### PR TITLE
[runtime][hip] Add tracing in graph execution mode

### DIFF
--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.c
@@ -543,9 +543,10 @@ static iree_status_t iree_hal_cuda_device_create_command_buffer(
   switch (device->params.command_buffer_mode) {
     case IREE_HAL_CUDA_COMMAND_BUFFER_MODE_GRAPH:
       return iree_hal_cuda_graph_command_buffer_create(
-          base_device, device->cuda_symbols, device->cu_context, mode,
-          command_categories, queue_affinity, binding_capacity,
-          &device->block_pool, device->host_allocator, out_command_buffer);
+          base_device, device->cuda_symbols, device->tracing_context,
+          device->cu_context, mode, command_categories, queue_affinity,
+          binding_capacity, &device->block_pool, device->host_allocator,
+          out_command_buffer);
     case IREE_HAL_CUDA_COMMAND_BUFFER_MODE_STREAM:
       return iree_hal_deferred_command_buffer_create(
           base_device, mode, command_categories, binding_capacity,

--- a/runtime/src/iree/hal/drivers/cuda/cuda_dynamic_symbol_table.h
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_dynamic_symbol_table.h
@@ -30,6 +30,8 @@ IREE_CU_PFN_DECL(cuEventSynchronize, CUevent)
 IREE_CU_PFN_DECL(cuGetProcAddress, const char*, void**, int, cuuint64_t)
 IREE_CU_PFN_DECL(cuGraphAddEmptyNode, CUgraphNode*, CUgraph, const CUgraphNode*,
                  size_t)
+IREE_CU_PFN_DECL(cuGraphAddEventRecordNode, CUgraphNode*, CUgraph,
+                 const CUgraphNode*, size_t, CUevent)
 IREE_CU_PFN_DECL(cuGraphAddMemcpyNode, CUgraphNode*, CUgraph,
                  const CUgraphNode*, size_t, const CUDA_MEMCPY3D*, CUcontext)
 IREE_CU_PFN_DECL(cuGraphAddMemsetNode, CUgraphNode*, CUgraph,

--- a/runtime/src/iree/hal/drivers/cuda/graph_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/cuda/graph_command_buffer.c
@@ -15,6 +15,7 @@
 #include "iree/hal/drivers/cuda/cuda_status_util.h"
 #include "iree/hal/drivers/cuda/native_executable.h"
 #include "iree/hal/drivers/cuda/pipeline_layout.h"
+#include "iree/hal/drivers/cuda/tracing.h"
 #include "iree/hal/utils/collective_batch.h"
 #include "iree/hal/utils/resource_set.h"
 
@@ -29,6 +30,9 @@ typedef struct iree_hal_cuda_graph_command_buffer_t {
   iree_hal_command_buffer_t base;
   iree_allocator_t host_allocator;
   const iree_hal_cuda_dynamic_symbols_t* symbols;
+
+  // Per-stream CUDA tracing context.
+  iree_hal_cuda_tracing_context_t* tracing_context;
 
   // A resource set to maintain references to all resources used within the
   // command buffer.
@@ -65,15 +69,95 @@ typedef struct iree_hal_cuda_graph_command_buffer_t {
 static const iree_hal_command_buffer_vtable_t
     iree_hal_cuda_graph_command_buffer_vtable;
 
+static iree_status_t
+iree_hal_cuda_graph_command_buffer_execution_barrier_internal(
+    iree_hal_cuda_graph_command_buffer_t* command_buffer);
+
 static iree_hal_cuda_graph_command_buffer_t*
 iree_hal_cuda_graph_command_buffer_cast(iree_hal_command_buffer_t* base_value) {
   IREE_HAL_ASSERT_TYPE(base_value, &iree_hal_cuda_graph_command_buffer_vtable);
   return (iree_hal_cuda_graph_command_buffer_t*)base_value;
 }
 
+#if IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION_DEVICE
+
+static void iree_cuda_graph_command_buffer_trace_zone_begin_external(
+    iree_hal_cuda_graph_command_buffer_t* command_buffer, const char* file_name,
+    size_t file_name_length, uint32_t line, const char* function_name,
+    size_t function_name_length, const char* name, size_t name_length) {
+  // Make sure there are no new nodes after the last barrier.
+  // Work should start after the event.
+  if (IREE_UNLIKELY(command_buffer->graph_node_count != 0)) {
+    iree_hal_cuda_graph_command_buffer_execution_barrier_internal(
+        command_buffer);
+  }
+
+  CUgraphNode* tracing_event_node =
+      &command_buffer->cu_graph_nodes[command_buffer->graph_node_count++];
+  size_t dependency_count = command_buffer->cu_barrier_node ? 1 : 0;
+  IREE_CUDA_GRAPH_TRACE_ZONE_BEGIN_EXTERNAL(
+      command_buffer->tracing_context, tracing_event_node,
+      command_buffer->cu_graph, &command_buffer->cu_barrier_node,
+      dependency_count, file_name, file_name_length, line, function_name,
+      function_name_length, name, name_length);
+
+  // Move the barrier forward to make sure that the tracing event is recorded
+  // before work starts.
+  // Downstream operations will wait on the tracing node.
+  command_buffer->cu_barrier_node = *tracing_event_node;
+}
+
+static void iree_cuda_graph_command_buffer_trace_zone_end(
+    iree_hal_cuda_graph_command_buffer_t* command_buffer) {
+  // Make sure there are no new nodes after the last barrier.
+  // Prior work should end before the tracing event is recorded.
+  if (IREE_UNLIKELY(command_buffer->graph_node_count != 0)) {
+    iree_hal_cuda_graph_command_buffer_execution_barrier_internal(
+        command_buffer);
+  }
+
+  CUgraphNode* tracing_event_node =
+      &command_buffer->cu_graph_nodes[command_buffer->graph_node_count++];
+  size_t dependency_count = command_buffer->cu_barrier_node ? 1 : 0;
+  IREE_ASSERT_GT(dependency_count, 0,
+                 "ending a zone should at least depend on the beginning");
+  IREE_CUDA_GRAPH_TRACE_ZONE_END(command_buffer->tracing_context,
+                                 tracing_event_node, command_buffer->cu_graph,
+                                 &command_buffer->cu_barrier_node,
+                                 dependency_count);
+
+  // We need to wait on the tracing end before other work starts.
+  // GPU tracing zones are first-in, last-out.
+  command_buffer->cu_barrier_node = *tracing_event_node;
+}
+
+#define IREE_CUDA_GRAPH_COMMAND_BUFFER_TRACE_ZONE_BEGIN_EXTERNAL(       \
+    command_buffer, file_name, file_name_length, line, function_name,   \
+    function_name_length, name, name_length)                            \
+  iree_cuda_graph_command_buffer_trace_zone_begin_external(             \
+      command_buffer, file_name, file_name_length, line, function_name, \
+      function_name_length, name, name_length)
+#define IREE_CUDA_GRAPH_COMMAND_BUFFER_TRACE_ZONE_BEGIN(command_buffer) \
+  IREE_CUDA_GRAPH_COMMAND_BUFFER_TRACE_ZONE_BEGIN_EXTERNAL(             \
+      command_buffer, /*file_name=*/NULL, 0, /*line=*/0, __FUNCTION__,  \
+      strlen(__FUNCTION__), /*name=*/NULL, 0)
+#define IREE_CUDA_GRAPH_COMMAND_BUFFER_TRACE_ZONE_END(command_buffer) \
+  iree_cuda_graph_command_buffer_trace_zone_end(command_buffer)
+
+#else  // IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION_DEVICE
+
+#define IREE_CUDA_GRAPH_COMMAND_BUFFER_TRACE_ZONE_BEGIN_EXTERNAL(     \
+    command_buffer, file_name, file_name_length, line, function_name, \
+    function_name_length, name, name_length)
+#define IREE_CUDA_GRAPH_COMMAND_BUFFER_TRACE_ZONE_BEGIN(command_buffer)
+#define IREE_CUDA_GRAPH_COMMAND_BUFFER_TRACE_ZONE_END(command_buffer)
+
+#endif  // IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION_DEVICE
+
 iree_status_t iree_hal_cuda_graph_command_buffer_create(
     iree_hal_device_t* device,
-    const iree_hal_cuda_dynamic_symbols_t* cuda_symbols, CUcontext context,
+    const iree_hal_cuda_dynamic_symbols_t* cuda_symbols,
+    iree_hal_cuda_tracing_context_t* tracing_context, CUcontext context,
     iree_hal_command_buffer_mode_t mode,
     iree_hal_command_category_t command_categories,
     iree_hal_queue_affinity_t queue_affinity, iree_host_size_t binding_capacity,
@@ -101,6 +185,7 @@ iree_status_t iree_hal_cuda_graph_command_buffer_create(
       &iree_hal_cuda_graph_command_buffer_vtable, &command_buffer->base);
   command_buffer->host_allocator = host_allocator;
   command_buffer->symbols = cuda_symbols;
+  command_buffer->tracing_context = tracing_context;
   iree_arena_initialize(block_pool, &command_buffer->arena);
   command_buffer->cu_context = context;
   command_buffer->cu_graph = NULL;
@@ -227,6 +312,8 @@ static iree_status_t iree_hal_cuda_graph_command_buffer_begin(
       command_buffer->symbols,
       cuGraphCreate(&command_buffer->cu_graph, /*flags=*/0), "cuGraphCreate");
 
+  IREE_CUDA_GRAPH_COMMAND_BUFFER_TRACE_ZONE_BEGIN(command_buffer);
+
   return iree_ok_status();
 }
 
@@ -238,6 +325,8 @@ static iree_status_t iree_hal_cuda_graph_command_buffer_end(
   // Flush any pending collective batches.
   IREE_RETURN_IF_ERROR(
       iree_hal_cuda_graph_command_buffer_flush_collectives(command_buffer));
+
+  IREE_CUDA_GRAPH_COMMAND_BUFFER_TRACE_ZONE_END(command_buffer);
 
   // Reset state used during recording.
   command_buffer->cu_barrier_node = NULL;
@@ -267,12 +356,50 @@ static void iree_hal_cuda_graph_command_buffer_begin_debug_group(
     iree_hal_command_buffer_t* base_command_buffer, iree_string_view_t label,
     iree_hal_label_color_t label_color,
     const iree_hal_label_location_t* location) {
-  // TODO(benvanik): tracy event stack.
+  iree_hal_cuda_graph_command_buffer_t* command_buffer =
+      iree_hal_cuda_graph_command_buffer_cast(base_command_buffer);
+
+  (void)command_buffer;
+  IREE_CUDA_GRAPH_COMMAND_BUFFER_TRACE_ZONE_BEGIN_EXTERNAL(
+      command_buffer, location ? location->file.data : NULL,
+      location ? location->file.size : 0, location ? location->line : 0,
+      /*func_name=*/NULL, 0, label.data, label.size);
 }
 
 static void iree_hal_cuda_graph_command_buffer_end_debug_group(
     iree_hal_command_buffer_t* base_command_buffer) {
-  // TODO(benvanik): tracy event stack.
+  iree_hal_cuda_graph_command_buffer_t* command_buffer =
+      iree_hal_cuda_graph_command_buffer_cast(base_command_buffer);
+  (void)command_buffer;
+  IREE_CUDA_GRAPH_COMMAND_BUFFER_TRACE_ZONE_END(command_buffer);
+}
+
+static iree_status_t
+iree_hal_cuda_graph_command_buffer_execution_barrier_internal(
+    iree_hal_cuda_graph_command_buffer_t* command_buffer) {
+  IREE_RETURN_IF_ERROR(
+      iree_hal_cuda_graph_command_buffer_flush_collectives(command_buffer));
+
+  IREE_ASSERT_GT(command_buffer->graph_node_count, 0,
+                 "expected at least one node before a barrier");
+
+  // Use the last node as a barrier to avoid creating redundant empty nodes.
+  if (IREE_LIKELY(command_buffer->graph_node_count == 1)) {
+    command_buffer->cu_barrier_node = command_buffer->cu_graph_nodes[0];
+    command_buffer->graph_node_count = 0;
+    return iree_ok_status();
+  }
+
+  IREE_CUDA_RETURN_IF_ERROR(
+      command_buffer->symbols,
+      cuGraphAddEmptyNode(
+          &command_buffer->cu_barrier_node, command_buffer->cu_graph,
+          command_buffer->cu_graph_nodes, command_buffer->graph_node_count),
+      "cuGraphAddEmptyNode");
+
+  command_buffer->graph_node_count = 0;
+
+  return iree_ok_status();
 }
 
 static iree_status_t iree_hal_cuda_graph_command_buffer_execution_barrier(
@@ -288,31 +415,12 @@ static iree_status_t iree_hal_cuda_graph_command_buffer_execution_barrier(
       iree_hal_cuda_graph_command_buffer_cast(base_command_buffer);
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  IREE_RETURN_IF_ERROR(
-      iree_hal_cuda_graph_command_buffer_flush_collectives(command_buffer));
-
-  IREE_ASSERT_GT(command_buffer->graph_node_count, 0,
-                 "expected at least one node before a barrier");
-
-  // Use the last node as a barrier to avoid creating redundant empty nodes.
-  if (IREE_LIKELY(command_buffer->graph_node_count == 1)) {
-    command_buffer->cu_barrier_node = command_buffer->cu_graph_nodes[0];
-    command_buffer->graph_node_count = 0;
-    IREE_TRACE_ZONE_END(z0);
-    return iree_ok_status();
-  }
-
-  IREE_CUDA_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, command_buffer->symbols,
-      cuGraphAddEmptyNode(
-          &command_buffer->cu_barrier_node, command_buffer->cu_graph,
-          command_buffer->cu_graph_nodes, command_buffer->graph_node_count),
-      "cuGraphAddEmptyNode");
-
-  command_buffer->graph_node_count = 0;
+  iree_status_t status =
+      iree_hal_cuda_graph_command_buffer_execution_barrier_internal(
+          command_buffer);
 
   IREE_TRACE_ZONE_END(z0);
-  return iree_ok_status();
+  return status;
 }
 
 static iree_status_t iree_hal_cuda_graph_command_buffer_signal_event(
@@ -376,6 +484,7 @@ static iree_status_t iree_hal_cuda_graph_command_buffer_fill_buffer(
   iree_hal_cuda_graph_command_buffer_t* command_buffer =
       iree_hal_cuda_graph_command_buffer_cast(base_command_buffer);
   IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_CUDA_GRAPH_COMMAND_BUFFER_TRACE_ZONE_BEGIN(command_buffer);
 
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_hal_cuda_graph_command_buffer_flush_collectives(command_buffer));
@@ -412,6 +521,7 @@ static iree_status_t iree_hal_cuda_graph_command_buffer_fill_buffer(
           dependency_count, &params, command_buffer->cu_context),
       "cuGraphAddMemsetNode");
 
+  IREE_CUDA_GRAPH_COMMAND_BUFFER_TRACE_ZONE_END(command_buffer);
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
 }
@@ -423,6 +533,7 @@ static iree_status_t iree_hal_cuda_graph_command_buffer_update_buffer(
   iree_hal_cuda_graph_command_buffer_t* command_buffer =
       iree_hal_cuda_graph_command_buffer_cast(base_command_buffer);
   IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_CUDA_GRAPH_COMMAND_BUFFER_TRACE_ZONE_BEGIN(command_buffer);
 
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_hal_cuda_graph_command_buffer_flush_collectives(command_buffer));
@@ -471,6 +582,7 @@ static iree_status_t iree_hal_cuda_graph_command_buffer_update_buffer(
           dependency_count, &params, command_buffer->cu_context),
       "cuGraphAddMemcpyNode");
 
+  IREE_CUDA_GRAPH_COMMAND_BUFFER_TRACE_ZONE_END(command_buffer);
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
 }
@@ -483,6 +595,7 @@ static iree_status_t iree_hal_cuda_graph_command_buffer_copy_buffer(
   iree_hal_cuda_graph_command_buffer_t* command_buffer =
       iree_hal_cuda_graph_command_buffer_cast(base_command_buffer);
   IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_CUDA_GRAPH_COMMAND_BUFFER_TRACE_ZONE_BEGIN(command_buffer);
 
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_hal_cuda_graph_command_buffer_flush_collectives(command_buffer));
@@ -526,6 +639,7 @@ static iree_status_t iree_hal_cuda_graph_command_buffer_copy_buffer(
           dependency_count, &params, command_buffer->cu_context),
       "cuGraphAddMemcpyNode");
 
+  IREE_CUDA_GRAPH_COMMAND_BUFFER_TRACE_ZONE_END(command_buffer);
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
 }
@@ -611,6 +725,12 @@ static iree_status_t iree_hal_cuda_graph_command_buffer_dispatch(
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_hal_cuda_native_executable_entry_point_kernel_info(
               executable, entry_point, &kernel_info));
+
+  IREE_CUDA_GRAPH_COMMAND_BUFFER_TRACE_ZONE_BEGIN_EXTERNAL(
+      command_buffer, kernel_info.source_filename.data,
+      kernel_info.source_filename.size, kernel_info.source_line,
+      kernel_info.function_name.data, kernel_info.function_name.size,
+      /*name=*/NULL, 0);
 
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_hal_resource_set_insert(command_buffer->resource_set, 1,
@@ -709,6 +829,7 @@ static iree_status_t iree_hal_cuda_graph_command_buffer_dispatch(
           dependency_count, &params),
       "cuGraphAddKernelNode");
 
+  IREE_CUDA_GRAPH_COMMAND_BUFFER_TRACE_ZONE_END(command_buffer);
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
 }

--- a/runtime/src/iree/hal/drivers/cuda/graph_command_buffer.h
+++ b/runtime/src/iree/hal/drivers/cuda/graph_command_buffer.h
@@ -17,6 +17,7 @@ extern "C" {
 #endif  // __cplusplus
 
 typedef struct iree_arena_block_pool_t iree_arena_block_pool_t;
+typedef struct iree_hal_cuda_tracing_context_t iree_hal_cuda_tracing_context_t;
 
 // Creates a command buffer that records into a CUDA graph.
 //
@@ -25,7 +26,8 @@ typedef struct iree_arena_block_pool_t iree_arena_block_pool_t;
 // buffers that use it.
 iree_status_t iree_hal_cuda_graph_command_buffer_create(
     iree_hal_device_t* device,
-    const iree_hal_cuda_dynamic_symbols_t* cuda_symbols, CUcontext context,
+    const iree_hal_cuda_dynamic_symbols_t* cuda_symbols,
+    iree_hal_cuda_tracing_context_t* tracing_context, CUcontext context,
     iree_hal_command_buffer_mode_t mode,
     iree_hal_command_category_t command_categories,
     iree_hal_queue_affinity_t queue_affinity, iree_host_size_t binding_capacity,

--- a/runtime/src/iree/hal/drivers/cuda/nccl_channel.c
+++ b/runtime/src/iree/hal/drivers/cuda/nccl_channel.c
@@ -557,7 +557,7 @@ iree_status_t iree_hal_cuda_nccl_submit_batch(
     iree_hal_collective_batch_entry_t* entry = &batch->entries[i];
     iree_string_view_t collective_str =
         iree_hal_collective_op_format(&entry->op, &string_temp);
-    IREE_CUDA_TRACE_ZONE_BEGIN_EXTERNAL(
+    IREE_CUDA_STREAM_TRACE_ZONE_BEGIN_EXTERNAL(
         tracing_context, stream, __FILE__, strlen(__FILE__), (uint32_t)__LINE__,
         __FUNCTION__, strlen(__FUNCTION__), collective_str.data,
         collective_str.size);
@@ -577,7 +577,7 @@ iree_status_t iree_hal_cuda_nccl_submit_batch(
   // order doesn't matter so long as we end the right number of zones.
   IREE_TRACE({
     for (iree_host_size_t i = 0; i < batch->count; ++i) {
-      IREE_CUDA_TRACE_ZONE_END(tracing_context, stream);
+      IREE_CUDA_STREAM_TRACE_ZONE_END(tracing_context, stream);
     }
   });
 

--- a/runtime/src/iree/hal/drivers/cuda/pending_queue_actions.c
+++ b/runtime/src/iree/hal/drivers/cuda/pending_queue_actions.c
@@ -594,6 +594,10 @@ static iree_status_t iree_hal_cuda_pending_queue_actions_issue_execution(
   }
 
   // Then launch all command buffers to the dispatch stream.
+  IREE_TRACE_ZONE_BEGIN(dispatch_command_buffers);
+  IREE_TRACE_ZONE_APPEND_TEXT(dispatch_command_buffers,
+                              " dispatch_command_buffers",
+                              strlen(" dispatch_command_buffers"));
   for (iree_host_size_t i = 0; i < action->payload.command_buffers.count; ++i) {
     iree_hal_command_buffer_t* command_buffer =
         action->payload.command_buffers.ptr[i];
@@ -622,6 +626,7 @@ static iree_status_t iree_hal_cuda_pending_queue_actions_issue_execution(
                   iree_hal_buffer_binding_table_empty()));
     }
   }
+  IREE_TRACE_ZONE_END(dispatch_command_buffers);
 
   // Last record CUevent signals in the dispatch stream.
   for (iree_host_size_t i = 0; i < action->signal_semaphore_list.count; ++i) {

--- a/runtime/src/iree/hal/drivers/cuda/stream_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/cuda/stream_command_buffer.c
@@ -159,7 +159,7 @@ static iree_status_t iree_hal_cuda_stream_command_buffer_begin(
       iree_hal_cuda_stream_command_buffer_cast(base_command_buffer);
   (void)command_buffer;
 
-  IREE_CUDA_TRACE_ZONE_BEGIN_EXTERNAL(
+  IREE_CUDA_STREAM_TRACE_ZONE_BEGIN_EXTERNAL(
       command_buffer->tracing_context, command_buffer->cu_stream,
       /*file_name=*/NULL, 0, /*line=*/0, "iree_hal_cuda_stream_command_buffer",
       strlen("iree_hal_cuda_stream_command_buffer"), /*name=*/NULL, 0);
@@ -195,8 +195,8 @@ static iree_status_t iree_hal_cuda_stream_command_buffer_end(
                                        command_buffer->resource_set,
                                        &command_buffer->collective_batch);
 
-  IREE_CUDA_TRACE_ZONE_END(command_buffer->tracing_context,
-                           command_buffer->cu_stream);
+  IREE_CUDA_STREAM_TRACE_ZONE_END(command_buffer->tracing_context,
+                                  command_buffer->cu_stream);
 
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
@@ -210,7 +210,7 @@ static void iree_hal_cuda_stream_command_buffer_begin_debug_group(
       iree_hal_cuda_stream_command_buffer_cast(base_command_buffer);
   (void)command_buffer;
 
-  IREE_CUDA_TRACE_ZONE_BEGIN_EXTERNAL(
+  IREE_CUDA_STREAM_TRACE_ZONE_BEGIN_EXTERNAL(
       command_buffer->tracing_context, command_buffer->cu_stream,
       location ? location->file.data : NULL, location ? location->file.size : 0,
       location ? location->line : 0, /*func_name=*/NULL, 0, label.data,
@@ -227,8 +227,8 @@ static void iree_hal_cuda_stream_command_buffer_end_debug_group(
 
   // TODO: pass along to CUPTI if available.
 
-  IREE_CUDA_TRACE_ZONE_END(command_buffer->tracing_context,
-                           command_buffer->cu_stream);
+  IREE_CUDA_STREAM_TRACE_ZONE_END(command_buffer->tracing_context,
+                                  command_buffer->cu_stream);
 }
 
 static iree_status_t iree_hal_cuda_stream_command_buffer_execution_barrier(
@@ -516,7 +516,7 @@ static iree_status_t iree_hal_cuda_stream_command_buffer_dispatch(
       z0, iree_hal_cuda_native_executable_entry_point_kernel_info(
               executable, entry_point, &kernel_info));
 
-  IREE_CUDA_TRACE_ZONE_BEGIN_EXTERNAL(
+  IREE_CUDA_STREAM_TRACE_ZONE_BEGIN_EXTERNAL(
       command_buffer->tracing_context, command_buffer->cu_stream,
       kernel_info.source_filename.data, kernel_info.source_filename.size,
       kernel_info.source_line, kernel_info.function_name.data,
@@ -602,8 +602,8 @@ static iree_status_t iree_hal_cuda_stream_command_buffer_dispatch(
                      params_ptr, NULL),
       "cuLaunchKernel");
 
-  IREE_CUDA_TRACE_ZONE_END(command_buffer->tracing_context,
-                           command_buffer->cu_stream);
+  IREE_CUDA_STREAM_TRACE_ZONE_END(command_buffer->tracing_context,
+                                  command_buffer->cu_stream);
 
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();

--- a/runtime/src/iree/hal/drivers/cuda/tracing.c
+++ b/runtime/src/iree/hal/drivers/cuda/tracing.c
@@ -218,7 +218,7 @@ void iree_hal_cuda_tracing_context_collect(
   IREE_TRACE_ZONE_END(z0);
 }
 
-static uint16_t iree_hal_cuda_tracing_context_insert_query(
+static uint16_t iree_hal_cuda_stream_tracing_context_insert_query(
     iree_hal_cuda_tracing_context_t* context, CUstream stream) {
   // Allocate an event from the pool for use by the query.
   uint32_t query_id = context->query_head;
@@ -238,38 +238,88 @@ static uint16_t iree_hal_cuda_tracing_context_insert_query(
   return query_id;
 }
 
+static uint16_t iree_hal_cuda_graph_tracing_context_insert_query(
+    iree_hal_cuda_tracing_context_t* context, CUgraphNode* out_node,
+    CUgraph graph, CUgraphNode* dependency_nodes,
+    size_t dependency_nodes_count) {
+  // Allocate an event from the pool for use by the query.
+  uint32_t query_id = context->query_head;
+  context->query_head = (context->query_head + 1) % context->query_capacity;
+
+  // TODO: check to see if the read and write heads of the ringbuffer have
+  // overlapped. If they have we could try to collect but it's not guaranteed
+  // that collection will complete (e.g. we may be reserving events for use in
+  // graphs that haven't yet been launched).
+  //
+  // For now we just allow the overlap and tracing results will be inconsistent.
+  IREE_ASSERT_NE(context->query_head, context->query_tail);
+
+  CUevent event = context->event_pool[query_id];
+  iree_status_t status = IREE_CURESULT_TO_STATUS(
+      context->symbols,
+      cuGraphAddEventRecordNode(out_node, graph, dependency_nodes,
+                                dependency_nodes_count, event));
+  IREE_ASSERT(iree_status_is_ok(status));
+
+  return query_id;
+}
+
 // TODO: optimize this implementation to reduce the number of events required:
 // today we insert 2 events per zone (one for begin and one for end) but in
 // many cases we could reduce this by inserting events only between zones and
 // using the differences between them.
 
-void iree_hal_cuda_tracing_zone_begin_impl(
+void iree_hal_cuda_stream_tracing_zone_begin_impl(
     iree_hal_cuda_tracing_context_t* context, CUstream stream,
     const iree_tracing_location_t* src_loc) {
-  if (!context) return;
+  IREE_ASSERT_ARGUMENT(context);
   uint16_t query_id =
-      iree_hal_cuda_tracing_context_insert_query(context, stream);
+      iree_hal_cuda_stream_tracing_context_insert_query(context, stream);
   iree_tracing_gpu_zone_begin(context->id, query_id, src_loc);
 }
 
-void iree_hal_cuda_tracing_zone_begin_external_impl(
+void iree_hal_cuda_stream_tracing_zone_begin_external_impl(
     iree_hal_cuda_tracing_context_t* context, CUstream stream,
     const char* file_name, size_t file_name_length, uint32_t line,
     const char* function_name, size_t function_name_length, const char* name,
     size_t name_length) {
-  if (!context) return;
+  IREE_ASSERT_ARGUMENT(context);
   uint16_t query_id =
-      iree_hal_cuda_tracing_context_insert_query(context, stream);
+      iree_hal_cuda_stream_tracing_context_insert_query(context, stream);
   iree_tracing_gpu_zone_begin_external(context->id, query_id, file_name,
                                        file_name_length, line, function_name,
                                        function_name_length, name, name_length);
 }
 
-void iree_hal_cuda_tracing_zone_end_impl(
+void iree_hal_cuda_graph_tracing_zone_begin_external_impl(
+    iree_hal_cuda_tracing_context_t* context, CUgraphNode* out_node,
+    CUgraph graph, CUgraphNode* dependency_nodes, size_t dependency_nodes_count,
+    const char* file_name, size_t file_name_length, uint32_t line,
+    const char* function_name, size_t function_name_length, const char* name,
+    size_t name_length) {
+  if (!context) return;
+  uint16_t query_id = iree_hal_cuda_graph_tracing_context_insert_query(
+      context, out_node, graph, dependency_nodes, dependency_nodes_count);
+  iree_tracing_gpu_zone_begin_external(context->id, query_id, file_name,
+                                       file_name_length, line, function_name,
+                                       function_name_length, name, name_length);
+}
+
+void iree_hal_cuda_stream_tracing_zone_end_impl(
     iree_hal_cuda_tracing_context_t* context, CUstream stream) {
   if (!context) return;
   uint16_t query_id =
-      iree_hal_cuda_tracing_context_insert_query(context, stream);
+      iree_hal_cuda_stream_tracing_context_insert_query(context, stream);
+  iree_tracing_gpu_zone_end(context->id, query_id);
+}
+
+void iree_hal_cuda_graph_tracing_zone_end_impl(
+    iree_hal_cuda_tracing_context_t* context, CUgraphNode* out_node,
+    CUgraph graph, CUgraphNode* dependency_nodes,
+    size_t dependency_nodes_count) {
+  if (!context) return;
+  uint16_t query_id = iree_hal_cuda_graph_tracing_context_insert_query(
+      context, out_node, graph, dependency_nodes, dependency_nodes_count);
   iree_tracing_gpu_zone_end(context->id, query_id);
 }
 

--- a/runtime/src/iree/hal/drivers/cuda/tracing.h
+++ b/runtime/src/iree/hal/drivers/cuda/tracing.h
@@ -26,9 +26,9 @@ extern "C" {
 // each stream gets an ID allocated once and passed to all tracing macros.
 //
 // Usage:
-//   IREE_CUDA_TRACE_ZONE_BEGIN(queue->tracing_context, stream);
+//   IREE_CUDA_STREAM_TRACE_ZONE_BEGIN(queue->tracing_context, stream);
 //   cuLaunchKernel(..., stream);
-//   IREE_CUDA_TRACE_ZONE_END(queue->tracing_context, stream);
+//   IREE_CUDA_STREAM_TRACE_ZONE_END(queue->tracing_context, stream);
 //   ...
 //   iree_hal_cuda_tracing_context_collect(queue->tracing_context);
 //
@@ -37,8 +37,7 @@ extern "C" {
 //
 // TODO(benvanik): expose CUevent reservation separate from recording. For
 // graphs we will need to insert the events but in order to reuse the graphs
-// we'll need to reserve and patch new events each graph launch. For now we
-// don't instrument graphs.
+// we'll need to reserve and patch new events each graph launch.
 //
 // Thread-compatible: external synchronization is required if using from
 // multiple threads (same as with CUstream itself).
@@ -67,50 +66,76 @@ void iree_hal_cuda_tracing_context_collect(
 
 // Begins a normal zone derived on the calling |src_loc|.
 // Must be perfectly nested and paired with a corresponding zone end.
-void iree_hal_cuda_tracing_zone_begin_impl(
+void iree_hal_cuda_stream_tracing_zone_begin_impl(
     iree_hal_cuda_tracing_context_t* context, CUstream stream,
     const iree_tracing_location_t* src_loc);
 
 // Begins an external zone using the given source information.
 // The provided strings will be copied into the tracy buffer.
-void iree_hal_cuda_tracing_zone_begin_external_impl(
+void iree_hal_cuda_stream_tracing_zone_begin_external_impl(
     iree_hal_cuda_tracing_context_t* context, CUstream stream,
     const char* file_name, size_t file_name_length, uint32_t line,
     const char* function_name, size_t function_name_length, const char* name,
     size_t name_length);
 
-void iree_hal_cuda_tracing_zone_end_impl(
+void iree_hal_cuda_graph_tracing_zone_begin_external_impl(
+    iree_hal_cuda_tracing_context_t* context, CUgraphNode* out_node,
+    CUgraph graph, CUgraphNode* dependency_nodes, size_t dependency_nodes_count,
+    const char* file_name, size_t file_name_length, uint32_t line,
+    const char* function_name, size_t function_name_length, const char* name,
+    size_t name_length);
+
+void iree_hal_cuda_stream_tracing_zone_end_impl(
     iree_hal_cuda_tracing_context_t* context, CUstream stream);
+void iree_hal_cuda_graph_tracing_zone_end_impl(
+    iree_hal_cuda_tracing_context_t* context, CUgraphNode* out_node,
+    CUgraph graph, CUgraphNode* dependency_nodes,
+    size_t dependency_nodes_count);
 
 // Begins a new zone with the parent function name.
-#define IREE_CUDA_TRACE_ZONE_BEGIN(context, stream)                       \
+#define IREE_CUDA_STREAM_TRACE_ZONE_BEGIN(context, stream)                \
   static const iree_tracing_location_t TracyConcat(                       \
       __tracy_source_location, __LINE__) = {NULL, __FUNCTION__, __FILE__, \
                                             (uint32_t)__LINE__, 0};       \
-  iree_hal_cuda_tracing_zone_begin_impl(                                  \
+  iree_hal_cuda_stream_tracing_zone_begin_impl(                           \
       context, stream, &TracyConcat(__tracy_source_location, __LINE__));
 
 // Begins an externally defined zone with a dynamic source location.
 // The |file_name|, |function_name|, and optional |name| strings will be copied
 // into the trace buffer and do not need to persist.
-#define IREE_CUDA_TRACE_ZONE_BEGIN_EXTERNAL(                             \
+#define IREE_CUDA_STREAM_TRACE_ZONE_BEGIN_EXTERNAL(                      \
     context, stream, file_name, file_name_length, line, function_name,   \
     function_name_length, name, name_length)                             \
-  iree_hal_cuda_tracing_zone_begin_external_impl(                        \
+  iree_hal_cuda_stream_tracing_zone_begin_external_impl(                 \
       context, stream, file_name, file_name_length, line, function_name, \
       function_name_length, name, name_length)
+#define IREE_CUDA_GRAPH_TRACE_ZONE_BEGIN_EXTERNAL(                            \
+    context, out_node, graph, dpendency_nodes, dpendency_nodes_count,         \
+    file_name, file_name_length, line, function_name, function_name_length,   \
+    name, name_length)                                                        \
+  iree_hal_cuda_graph_tracing_zone_begin_external_impl(                       \
+      context, out_node, graph, dpendency_nodes, dpendency_nodes_count,       \
+      file_name, file_name_length, line, function_name, function_name_length, \
+      name, name_length)
 
-// Ends the current zone. Must be passed the |zone_id| from the _BEGIN.
-#define IREE_CUDA_TRACE_ZONE_END(context, stream) \
-  iree_hal_cuda_tracing_zone_end_impl(context, stream)
+#define IREE_CUDA_STREAM_TRACE_ZONE_END(context, stream) \
+  iree_hal_cuda_stream_tracing_zone_end_impl(context, stream)
+#define IREE_CUDA_GRAPH_TRACE_ZONE_END(                                 \
+    context, out_node, graph, dependency_nodes, dependency_nodes_count) \
+  iree_hal_cuda_graph_tracing_zone_end_impl(                            \
+      context, out_node, graph, dependency_nodes, dependency_nodes_count)
 
 #else
 
-#define IREE_CUDA_TRACE_ZONE_BEGIN(context, stream)
-#define IREE_CUDA_TRACE_ZONE_BEGIN_EXTERNAL(                           \
+#define IREE_CUDA_STREAM_TRACE_ZONE_BEGIN(context, stream)
+#define IREE_CUDA_STREAM_TRACE_ZONE_BEGIN_EXTERNAL(                    \
     context, stream, file_name, file_name_length, line, function_name, \
     function_name_length, name, name_length)
-#define IREE_CUDA_TRACE_ZONE_END(context, stream)
+#define IREE_CUDA_GRAPH_TRACE_ZONE_BEGIN_EXTERNAL(                          \
+    context, out_node, graph, dpendency_nodes, dpendency_nodes_count,       \
+    file_name, file_name_length, line, function_name, function_name_length, \
+    name, name_length)
+#define IREE_CUDA_STREAM_TRACE_ZONE_END(context, stream)
 
 #endif  // IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION
 

--- a/runtime/src/iree/hal/drivers/hip/dynamic_symbol_tables.h
+++ b/runtime/src/iree/hal/drivers/hip/dynamic_symbol_tables.h
@@ -42,6 +42,9 @@ IREE_HAL_HIP_REQUIRED_PFN_STR_DECL(hipGetErrorName, hipError_t)
 IREE_HAL_HIP_REQUIRED_PFN_STR_DECL(hipGetErrorString, hipError_t)
 IREE_HAL_HIP_REQUIRED_PFN_DECL(hipGraphAddEmptyNode, hipGraphNode_t *,
                                hipGraph_t, const hipGraphNode_t *, size_t)
+IREE_HAL_HIP_REQUIRED_PFN_DECL(hipGraphAddEventRecordNode, hipGraphNode_t *,
+                               hipGraph_t, const hipGraphNode_t *, size_t,
+                               hipEvent_t)
 IREE_HAL_HIP_REQUIRED_PFN_DECL(hipGraphAddKernelNode, hipGraphNode_t *,
                                hipGraph_t, const hipGraphNode_t *, size_t,
                                const hipKernelNodeParams *)

--- a/runtime/src/iree/hal/drivers/hip/graph_command_buffer.h
+++ b/runtime/src/iree/hal/drivers/hip/graph_command_buffer.h
@@ -21,6 +21,7 @@ extern "C" {
 // changes and may have outstanding issues.
 
 typedef struct iree_arena_block_pool_t iree_arena_block_pool_t;
+typedef struct iree_hal_hip_tracing_context_t iree_hal_hip_tracing_context_t;
 
 // Creates a command buffer that records into a HIP graph.
 //
@@ -28,7 +29,8 @@ typedef struct iree_arena_block_pool_t iree_arena_block_pool_t;
 // buffers that use it.
 iree_status_t iree_hal_hip_graph_command_buffer_create(
     iree_hal_device_t* device,
-    const iree_hal_hip_dynamic_symbols_t* hip_symbols, hipCtx_t context,
+    const iree_hal_hip_dynamic_symbols_t* hip_symbols,
+    iree_hal_hip_tracing_context_t* tracing_context, hipCtx_t context,
     iree_hal_command_buffer_mode_t mode,
     iree_hal_command_category_t command_categories,
     iree_hal_queue_affinity_t queue_affinity, iree_host_size_t binding_capacity,

--- a/runtime/src/iree/hal/drivers/hip/hip_device.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_device.c
@@ -456,9 +456,10 @@ static iree_status_t iree_hal_hip_device_create_command_buffer(
   switch (device->params.command_buffer_mode) {
     case IREE_HAL_HIP_COMMAND_BUFFER_MODE_GRAPH:
       return iree_hal_hip_graph_command_buffer_create(
-          base_device, device->hip_symbols, device->hip_context, mode,
-          command_categories, queue_affinity, binding_capacity,
-          &device->block_pool, device->host_allocator, out_command_buffer);
+          base_device, device->hip_symbols, device->tracing_context,
+          device->hip_context, mode, command_categories, queue_affinity,
+          binding_capacity, &device->block_pool, device->host_allocator,
+          out_command_buffer);
     case IREE_HAL_HIP_COMMAND_BUFFER_MODE_STREAM:
       return iree_hal_deferred_command_buffer_create(
           base_device, mode, command_categories, binding_capacity,

--- a/runtime/src/iree/hal/drivers/hip/pending_queue_actions.c
+++ b/runtime/src/iree/hal/drivers/hip/pending_queue_actions.c
@@ -594,6 +594,10 @@ static iree_status_t iree_hal_hip_pending_queue_actions_issue_execution(
   }
 
   // Then launch all command buffers to the dispatch stream.
+  IREE_TRACE_ZONE_BEGIN(dispatch_command_buffers);
+  IREE_TRACE_ZONE_APPEND_TEXT(dispatch_command_buffers,
+                              " dispatch_command_buffers",
+                              strlen(" dispatch_command_buffers"));
   for (iree_host_size_t i = 0; i < action->payload.command_buffers.count; ++i) {
     iree_hal_command_buffer_t* command_buffer =
         action->payload.command_buffers.ptr[i];
@@ -627,6 +631,7 @@ static iree_status_t iree_hal_hip_pending_queue_actions_issue_execution(
                   iree_hal_buffer_binding_table_empty()));
     }
   }
+  IREE_TRACE_ZONE_END(dispatch_command_buffers);
 
   // Last record hipEvent_t signals in the dispatch stream.
   for (iree_host_size_t i = 0; i < action->signal_semaphore_list.count; ++i) {

--- a/runtime/src/iree/hal/drivers/hip/stream_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/hip/stream_command_buffer.c
@@ -122,7 +122,7 @@ static iree_status_t iree_hal_hip_stream_command_buffer_begin(
       iree_hal_hip_stream_command_buffer_cast(base_command_buffer);
   (void)command_buffer;
 
-  IREE_HIP_TRACE_ZONE_BEGIN_EXTERNAL(
+  IREE_HIP_STREAM_TRACE_ZONE_BEGIN_EXTERNAL(
       command_buffer->tracing_context, command_buffer->hip_stream,
       /*file_name=*/NULL, 0, /*line=*/0, "iree_hal_hip_stream_command_buffer",
       strlen("iree_hal_hip_stream_command_buffer"),
@@ -149,8 +149,8 @@ static iree_status_t iree_hal_hip_stream_command_buffer_end(
       z0, iree_hal_resource_set_allocate(command_buffer->arena.block_pool,
                                          &command_buffer->resource_set));
 
-  IREE_HIP_TRACE_ZONE_END(command_buffer->tracing_context,
-                          command_buffer->hip_stream);
+  IREE_HIP_STREAM_TRACE_ZONE_END(command_buffer->tracing_context,
+                                 command_buffer->hip_stream);
 
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
@@ -164,7 +164,7 @@ static void iree_hal_hip_stream_command_buffer_begin_debug_group(
       iree_hal_hip_stream_command_buffer_cast(base_command_buffer);
   (void)command_buffer;
 
-  IREE_HIP_TRACE_ZONE_BEGIN_EXTERNAL(
+  IREE_HIP_STREAM_TRACE_ZONE_BEGIN_EXTERNAL(
       command_buffer->tracing_context, command_buffer->hip_stream,
       location ? location->file.data : NULL, location ? location->file.size : 0,
       location ? location->line : 0, /*func_name=*/NULL, 0, label.data,
@@ -177,8 +177,8 @@ static void iree_hal_hip_stream_command_buffer_end_debug_group(
       iree_hal_hip_stream_command_buffer_cast(base_command_buffer);
   (void)command_buffer;
 
-  IREE_HIP_TRACE_ZONE_END(command_buffer->tracing_context,
-                          command_buffer->hip_stream);
+  IREE_HIP_STREAM_TRACE_ZONE_END(command_buffer->tracing_context,
+                                 command_buffer->hip_stream);
 }
 
 static iree_status_t iree_hal_hip_stream_command_buffer_execution_barrier(
@@ -439,7 +439,7 @@ static iree_status_t iree_hal_hip_stream_command_buffer_dispatch(
       z0, iree_hal_hip_native_executable_entry_point_kernel_info(
               executable, entry_point, &kernel_info));
 
-  IREE_HIP_TRACE_ZONE_BEGIN_EXTERNAL(
+  IREE_HIP_STREAM_TRACE_ZONE_BEGIN_EXTERNAL(
       command_buffer->tracing_context, command_buffer->hip_stream,
       kernel_info.source_filename.data, kernel_info.source_filename.size,
       kernel_info.source_line, kernel_info.function_name.data,
@@ -514,8 +514,8 @@ static iree_status_t iree_hal_hip_stream_command_buffer_dispatch(
           command_buffer->hip_stream, params_ptr, NULL),
       "hipModuleLaunchKernel");
 
-  IREE_HIP_TRACE_ZONE_END(command_buffer->tracing_context,
-                          command_buffer->hip_stream);
+  IREE_HIP_STREAM_TRACE_ZONE_END(command_buffer->tracing_context,
+                                 command_buffer->hip_stream);
 
   IREE_TRACE_ZONE_END(z0);
   return status;

--- a/runtime/src/iree/hal/drivers/hip/tracing.h
+++ b/runtime/src/iree/hal/drivers/hip/tracing.h
@@ -26,9 +26,9 @@ extern "C" {
 // each stream gets an ID allocated once and passed to all tracing macros.
 //
 // Usage:
-//   IREE_HIP_TRACE_ZONE_BEGIN(queue->tracing_context, stream);
+//   IREE_HIP_STREAM_TRACE_ZONE_BEGIN(queue->tracing_context, stream);
 //   hipModuleLaunchKernel(..., stream);
-//   IREE_HIP_TRACE_ZONE_END(queue->tracing_context, stream);
+//   IREE_HIP_STREAM_TRACE_ZONE_END(queue->tracing_context, stream);
 //   ...
 //   iree_hal_hip_tracing_context_collect(queue->tracing_context);
 //
@@ -37,8 +37,7 @@ extern "C" {
 //
 // TODO(benvanik): expose hipEvent_t reservation separate from recording. For
 // graphs we will need to insert the events but in order to reuse the graphs
-// we'll need to reserve and patch new events each graph launch. For now we
-// don't instrument graphs.
+// we'll need to reserve and patch new events each graph launch.
 //
 // Thread-compatible: external synchronization is required if using from
 // multiple threads (same as with hipStream_t itself).
@@ -66,50 +65,75 @@ void iree_hal_hip_tracing_context_collect(
 
 // Begins a normal zone derived on the calling |src_loc|.
 // Must be perfectly nested and paired with a corresponding zone end.
-void iree_hal_hip_tracing_zone_begin_impl(
+void iree_hal_hip_stream_tracing_zone_begin_impl(
     iree_hal_hip_tracing_context_t* context, hipStream_t stream,
     const iree_tracing_location_t* src_loc);
 
 // Begins an external zone using the given source information.
 // The provided strings will be copied into the tracy buffer.
-void iree_hal_hip_tracing_zone_begin_external_impl(
+void iree_hal_hip_stream_tracing_zone_begin_external_impl(
     iree_hal_hip_tracing_context_t* context, hipStream_t stream,
     const char* file_name, size_t file_name_length, uint32_t line,
     const char* function_name, size_t function_name_length, const char* name,
     size_t name_length);
+void iree_hal_hip_graph_tracing_zone_begin_external_impl(
+    iree_hal_hip_tracing_context_t* context, hipGraphNode_t* out_node,
+    hipGraph_t graph, hipGraphNode_t* dependency_nodes,
+    size_t dependency_nodes_count, const char* file_name,
+    size_t file_name_length, uint32_t line, const char* function_name,
+    size_t function_name_length, const char* name, size_t name_length);
 
-void iree_hal_hip_tracing_zone_end_impl(iree_hal_hip_tracing_context_t* context,
-                                        hipStream_t stream);
+void iree_hal_hip_stream_tracing_zone_end_impl(
+    iree_hal_hip_tracing_context_t* context, hipStream_t stream);
+void iree_hal_hip_graph_tracing_zone_end_impl(
+    iree_hal_hip_tracing_context_t* context, hipGraphNode_t* out_node,
+    hipGraph_t graph, hipGraphNode_t* dependency_nodes,
+    size_t dependency_nodes_count);
 
 // Begins a new zone with the parent function name.
-#define IREE_HIP_TRACE_ZONE_BEGIN(context, stream)                        \
+#define IREE_HIP_STREAM_TRACE_ZONE_BEGIN(context, stream)                 \
   static const iree_tracing_location_t TracyConcat(                       \
       __tracy_source_location, __LINE__) = {NULL, __FUNCTION__, __FILE__, \
                                             (uint32_t)__LINE__, 0};       \
-  iree_hal_hip_tracing_zone_begin_impl(                                   \
+  iree_hal_hip_stream_tracing_zone_begin_impl(                            \
       context, stream, &TracyConcat(__tracy_source_location, __LINE__));
 
 // Begins an externally defined zone with a dynamic source location.
 // The |file_name|, |function_name|, and optional |name| strings will be copied
 // into the trace buffer and do not need to persist.
-#define IREE_HIP_TRACE_ZONE_BEGIN_EXTERNAL(                              \
+#define IREE_HIP_STREAM_TRACE_ZONE_BEGIN_EXTERNAL(                       \
     context, stream, file_name, file_name_length, line, function_name,   \
     function_name_length, name, name_length)                             \
-  iree_hal_hip_tracing_zone_begin_external_impl(                         \
+  iree_hal_hip_stream_tracing_zone_begin_external_impl(                  \
       context, stream, file_name, file_name_length, line, function_name, \
       function_name_length, name, name_length)
+#define IREE_HIP_GRAPH_TRACE_ZONE_BEGIN_EXTERNAL(                             \
+    context, out_node, graph, dpendency_nodes, dpendency_nodes_count,         \
+    file_name, file_name_length, line, function_name, function_name_length,   \
+    name, name_length)                                                        \
+  iree_hal_hip_graph_tracing_zone_begin_external_impl(                        \
+      context, out_node, graph, dpendency_nodes, dpendency_nodes_count,       \
+      file_name, file_name_length, line, function_name, function_name_length, \
+      name, name_length)
 
-// Ends the current zone. Must be passed the |zone_id| from the _BEGIN.
-#define IREE_HIP_TRACE_ZONE_END(context, stream) \
-  iree_hal_hip_tracing_zone_end_impl(context, stream)
+#define IREE_HIP_STREAM_TRACE_ZONE_END(context, stream) \
+  iree_hal_hip_stream_tracing_zone_end_impl(context, stream)
+#define IREE_HIP_GRAPH_TRACE_ZONE_END(                                  \
+    context, out_node, graph, dependency_nodes, dependency_nodes_count) \
+  iree_hal_hip_graph_tracing_zone_end_impl(                             \
+      context, out_node, graph, dependency_nodes, dependency_nodes_count)
 
 #else
 
-#define IREE_HIP_TRACE_ZONE_BEGIN(context, stream)
-#define IREE_HIP_TRACE_ZONE_BEGIN_EXTERNAL(                            \
+#define IREE_HIP_STREAM_TRACE_ZONE_BEGIN(context, stream)
+#define IREE_HIP_STREAM_TRACE_ZONE_BEGIN_EXTERNAL(                     \
     context, stream, file_name, file_name_length, line, function_name, \
     function_name_length, name, name_length)
-#define IREE_HIP_TRACE_ZONE_END(context, stream)
+#define IREE_HIP_GRAPH_TRACE_ZONE_BEGIN_EXTERNAL(                           \
+    context, out_node, graph, dpendency_nodes, dpendency_nodes_count,       \
+    file_name, file_name_length, line, function_name, function_name_length, \
+    name, name_length)
+#define IREE_HIP_STREAM_TRACE_ZONE_END(context, stream)
 
 #endif  // IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION_DEVICE
 


### PR DESCRIPTION
There are some outstanding concurrency issues where some events don't get recorded during collection.
If we collect only when the device gets destroyed with a 1s delay, the concurrency issues seem to not manifest.