### PR TITLE
[LLVMGPU] Send skinny matmuls to the gpu reduction pipeline

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -647,8 +647,13 @@ static LogicalResult setContractConfig(mlir::FunctionOpInterface entryPoint,
   if (llvm::all_equal({contractionDims->m.size(), contractionDims->n.size(),
                        contractionDims->k.size(), size_t{1}}) &&
       contractionDims->batch.empty()) {
-    if (bounds[contractionDims->m.front()] <= 4 ||
-        bounds[contractionDims->n.front()] <= 4) {
+    int64_t mSize = bounds[contractionDims->m.front()];
+    int64_t nSize = bounds[contractionDims->n.front()];
+    int64_t preferredSubgroupSize = targetInfo.supportedSubgroupSizes.front();
+    if ((mSize <= 4 &&
+         (nSize > preferredSubgroupSize || ShapedType::isDynamic(nSize))) ||
+        (nSize <= 4 &&
+         (mSize > preferredSubgroupSize || ShapedType::isDynamic(mSize)))) {
       return failure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -69,6 +69,9 @@ namespace {
 constexpr StringLiteral kCudaTarget = "cuda";
 constexpr StringLiteral kRocmTarget = "rocm";
 
+// Threshold used to determine whether a matmul dimension is 'very skinny'.
+constexpr int64_t kVerySkinnyDimThreshold = 4;
+
 /// Structure to represent target features.
 struct TargetInfo {
   // TODO: add finer grain control for other tensorcore types.
@@ -650,9 +653,9 @@ static LogicalResult setContractConfig(mlir::FunctionOpInterface entryPoint,
     int64_t mSize = bounds[contractionDims->m.front()];
     int64_t nSize = bounds[contractionDims->n.front()];
     int64_t preferredSubgroupSize = targetInfo.supportedSubgroupSizes.front();
-    if ((mSize <= 4 &&
+    if ((mSize <= kVerySkinnyDimThreshold &&
          (nSize > preferredSubgroupSize || ShapedType::isDynamic(nSize))) ||
-        (nSize <= 4 &&
+        (nSize <= kVerySkinnyDimThreshold &&
          (mSize > preferredSubgroupSize || ShapedType::isDynamic(mSize)))) {
       return failure();
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matvec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matvec.mlir
@@ -246,7 +246,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb", {target_arch = "gf
 //  CHECK-SAME:   translation_info = #[[$TRANSLATION]]
 //  CHECK-SAME:   workgroup_size = [64 : index, 1 : index, 1 : index]
 //       CHECK: func.func @skinny_mmt()
-//       CHECK:   linalg.generic
+//       CHECK:   linalg.matmul_transpose_b
 //  CHECK-SAME:     lowering_config = #[[$CONFIG]]
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
@@ -1,5 +1,6 @@
 // RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-codegen-llvmgpu-configuration-pipeline)))" \
-// RUN: --iree-codegen-llvmgpu-enable-transform-dialect-jit=false %s | FileCheck %s
+// RUN:   --iree-codegen-llvmgpu-enable-transform-dialect-jit=false %s | FileCheck %s
+
 // Transform dialect attributes are tested separately.
 
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy_matmul.mlir
@@ -1,4 +1,5 @@
-// RUN: iree-opt %s --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-select-lowering-strategy)))" --iree-codegen-llvmgpu-enable-transform-dialect-aligned-matmul | FileCheck %s
+// RUN: iree-opt %s --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-select-lowering-strategy)))" \
+// RUN:   --iree-codegen-llvmgpu-enable-transform-dialect-aligned-matmul | FileCheck %s
 
 // Check that setting the command line options affect the transform
 // strategy as expected.
@@ -36,8 +37,8 @@
 // RUN: -td-matmul-strategy-pipeline-depth=3 \
 // RUN: | FileCheck --check-prefix=WITH_OPTIONS_3 %s
 
-// RUN: iree-opt %s --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-select-lowering-strategy)))" --iree-codegen-llvmgpu-enable-transform-dialect-small-matmul \
-// RUN: | FileCheck --check-prefix=SMALL %s
+// RUN: iree-opt %s --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-select-lowering-strategy)))" \
+// RUN:   --iree-codegen-llvmgpu-enable-transform-dialect-small-matmul | FileCheck --check-prefix=SMALL %s
 
 hal.executable @matmul_1 {
 hal.executable.variant public @cuda_nvptx_fb target(<"cuda", "cuda-nvptx-fb", {target_arch = "sm_80"}>) {
@@ -462,11 +463,11 @@ hal.executable.variant public @cuda_nvptx_fb target(<"cuda", "cuda-nvptx-fb", {t
 }
 }
 
-// CHECK:       iree_codegen.translation_info<LLVMGPUMatmulSimt, {pipeline_depth = 0 : i64, store_stage = 1 : i64}>
+// CHECK:       iree_codegen.translation_info<LLVMGPUVectorize>
 // CHECK-LABEL: func @matmul_5_small
 
 // This matmul is considered "too small"/"degenerate" for a tensor core strategy,
-// just fallback to the simt strategy.
+// just fallback to the vectorized strategy.
 
 // WITH_OPTIONS_2-LABEL: func @matmul_5_small
 


### PR DESCRIPTION
This applies to matmul with the M or N dimension of 2-4. Even though the subgroup reduction codegen is suboptimal, we saw that this is much faster on the 2xNxK matmul from SDXL than the MatmulSIMT fallback pipeline.

Corresponding SDXL PR: https://github.com/openxla/iree/pull/16818