### PR TITLE
WIP: Add winograd filter transform op

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
@@ -640,6 +640,8 @@ void registerBufferizationInterfaces(DialectRegistry &registry) {
         LinalgExtOpInterface<IREE::LinalgExt::TopkOp>>(*ctx);
     IREE::LinalgExt::WinogradInputTransformOp::attachInterface<
         LinalgExtOpInterface<IREE::LinalgExt::WinogradInputTransformOp>>(*ctx);
+    IREE::LinalgExt::WinogradFilterTransformOp::attachInterface<
+        LinalgExtOpInterface<IREE::LinalgExt::WinogradFilterTransformOp>>(*ctx);
     IREE::LinalgExt::WinogradOutputTransformOp::attachInterface<
         LinalgExtOpInterface<IREE::LinalgExt::WinogradOutputTransformOp>>(*ctx);
     IREE::LinalgExt::AttentionOp::attachInterface<

--- a/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.cpp
@@ -248,6 +248,9 @@ void registerPartitionableLoopsInterfaceModels(DialectRegistry &registry) {
     IREE::LinalgExt::WinogradInputTransformOp::attachInterface<
         AllParallelAsPartitionableLoops<
             IREE::LinalgExt::WinogradInputTransformOp>>(*ctx);
+    IREE::LinalgExt::WinogradFilterTransformOp::attachInterface<
+        AllParallelAsPartitionableLoops<
+            IREE::LinalgExt::WinogradFilterTransformOp>>(*ctx);
     IREE::LinalgExt::WinogradOutputTransformOp::attachInterface<
         AllParallelAsPartitionableLoops<
             IREE::LinalgExt::WinogradOutputTransformOp>>(*ctx);

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -1142,6 +1142,104 @@ def IREELinalgExt_WinogradInputTransformOp : IREELinalgExt_Op<"winograd.input_tr
   }];
 }
 
+def IREELinalgExt_WinogradFilterTransformOp : IREELinalgExt_Op<"winograd.filter_transform",
+    [DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
+     DeclareOpInterfaceMethods<TilingInterface,
+      ["getIterationDomain",
+       "getLoopIteratorTypes",
+       "getResultTilePosition",
+       "getTiledImplementation"]>]> {
+  let summary = "Winograd Filter Transform operator";
+  let description = [{
+    Filter transform op.
+  }];
+
+  let arguments = (ins Variadic<AnyShaped>:$inputs,
+                       Variadic<AnyShaped>:$outputs,
+                       I64Attr:$output_tile_size,
+                       DenseI64ArrayAttr:$kernel_dimensions
+  );
+
+  let builders = [
+    OpBuilder<(ins "ValueRange":$inputs, "ValueRange":$outputs,
+      CArg<"int64_t", "8">:$output_tile_size,
+      CArg<"ArrayRef<int64_t>", "{0, 1}">:$kernel_dimensions)>
+  ];
+
+  let results = (outs Variadic<AnyRankedTensor>:$result);
+  let hasFolder = 1;
+  let assemblyFormat = [{
+    attr-dict
+    `output_tile_size` `(` $output_tile_size `)`
+    `kernel_dimensions` `(` $kernel_dimensions `)`
+    `ins` `(` $inputs `:` type($inputs) `)`
+    `outs` `(` $outputs `:` type($outputs) `)`
+    (`->` type($result)^)?
+  }];
+
+  let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
+    Value input() {
+      return getDpsInputOperand(0)->get();
+    }
+    Value output() {
+      return getDpsInitOperand(0)->get();
+    }
+    ShapedType getInputOperandType() {
+      return input().getType().cast<ShapedType>();
+    }
+    ShapedType getOutputOperandType() {
+      return output().getType().cast<ShapedType>();
+    }
+    int64_t getInputOperandRank() {
+      return getInputOperandType().getRank();
+    }
+    int64_t getOutputOperandRank() {
+      return getOutputOperandType().getRank();
+    }
+    SmallVector<int64_t> kernelDimensions() {
+      return llvm::to_vector(getKernelDimensions());
+    }
+    int64_t getKernelSize() {
+      ArrayRef<int64_t> shape = getInputOperandType().getShape();
+      return shape[kernelDimensions().front()];
+    }
+    int64_t getInputTileSize() {
+      return getOutputTileSize() + getKernelSize() - 1;
+    }
+    std::array<int64_t, 2> hwcfKernelDimensions() {
+      return {0, 1};
+    }
+    std::array<int64_t, 2> fchwKernelDimensions() {
+      return {2, 3};
+    }
+    bool isHwcf() {
+      std::array<int64_t, 2> hwcfKernelDims = hwcfKernelDimensions();
+      SmallVector<int64_t> kernelDims = kernelDimensions();
+      return kernelDims == ArrayRef<int64_t>(hwcfKernelDims);
+    }
+    bool isFchw() {
+      std::array<int64_t, 2> fchwKernelDims = fchwKernelDimensions();
+      SmallVector<int64_t> kernelDims = kernelDimensions();
+      return kernelDims == ArrayRef<int64_t>(fchwKernelDims);
+    }
+    int channelDim() {
+      return isHwcf() ? 2 : 1;
+    }
+    int filterDim() {
+      return isHwcf() ? 3 : 0;
+    }
+    int64_t getIterationDomainRank() {
+      SmallVector<int64_t> kernelDims = kernelDimensions();
+      return getInputOperandRank() - kernelDims.size();
+    }
+    // Method to implement for specifying output range for
+    // DestinationStyleOpInterface
+    MutableOperandRange getDpsInitsMutable() {
+      return getOutputsMutable();
+    }
+  }];
+}
+
 def IREELinalgExt_WinogradOutputTransformOp : IREELinalgExt_Op<"winograd.output_transform",
     [DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
      DeclareOpInterfaceMethods<TilingInterface,

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
@@ -65,6 +65,7 @@ enum class Permutation {
   NHWC_TO_NCHW,
   TTNHWC_TO_TTNCHW,
   TTNCHW_TO_TTNHWC,
+  TTFC_TO_TTCF,
 };
 
 // Permutes the elements of a SmallVector depending on the permutation specified
@@ -82,6 +83,9 @@ static void permute(SmallVectorImpl<T> &vector) {
     break;
   case Permutation::TTNHWC_TO_TTNCHW:
     std::rotate(vector.rbegin(), vector.rbegin() + 1, vector.rend() - 3);
+    break;
+  case Permutation::TTFC_TO_TTCF:
+    std::rotate(vector.rbegin(), vector.rbegin() + 1, vector.rend() - 2);
     break;
   default:
     break;

--- a/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
@@ -319,6 +319,9 @@ void registerUtilExternalModels(DialectRegistry &registry) {
         LinalgOpTiedOpInterface<LinalgExt::TopkOp>>(*context);
     LinalgExt::WinogradInputTransformOp::attachInterface<
         LinalgOpTiedOpInterface<LinalgExt::WinogradInputTransformOp>>(*context);
+    LinalgExt::WinogradFilterTransformOp::attachInterface<
+        LinalgOpTiedOpInterface<LinalgExt::WinogradFilterTransformOp>>(
+        *context);
     LinalgExt::WinogradOutputTransformOp::attachInterface<
         LinalgOpTiedOpInterface<LinalgExt::WinogradOutputTransformOp>>(
         *context);


### PR DESCRIPTION
This is a WIP branch for properly supporting the winograd filter transform op. So far I have added:
 - `iree_linalg_ext.winograd.filter_transform` op definition
 - The filter transform op verifier
 - A tiled implementation meant for TileAndDistribute (not yet tested)

Example op IR:
```mlir
!filter_type = tensor<2560x1280x3x3xf32>
!transformed_type = tensor<8x8x1280x2560xf32>
func.func @filter_transform(%arg0: !filter_type) -> !transformed_type {
  %0 = tensor.empty() : !transformed_type
  %filter_transform = iree_linalg_ext.winograd.filter_transform output_tile_size(6) kernel_dimensions([2, 3]) ins(%arg0 : !filter_type) outs(%0 : !transformed_type) -> !transformed_type
  return %filter_transform : !transformed_type
}
```

What is still needed:
 - Support for the filter transform op in `TileAndDecomposeWinogradTransform`. The tiling for this op is similar to the input transform, but it does not have tiling on the kernel `H` and `W` dimensions (this is different from the input transform, which has `H` and `W` tiling. The decomposition part of this is also similar to the input transform, and there are more details in a comment from the `ConvertConv2DToWinogradPass`:
 https://github.com/openxla/iree/blob/07a854cac43adf1e120d0e459497f8216568a747/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConv2DToWinograd.cpp#L47-L59
 - The transform op needs a KernelConfig for TileAndDistribute and setting the winograd transform pipelines. This should tile the input channel and filter channel dimensions.
 - Update the `ConvertConv2DToWinogradPass` to generate the new filter transform op instead of constant folding the filter transform. Then this should hit const-eval and get folded there instead. This should be a matter of updating some of the matchers, creating the new filter transform op, and removing the `FoldWinogradFilterTransform` pattern.

After this is working on LLVMCPU, there are some improvements to be made to the winograd path:
 - It would be better to do all tiling with the tiling interface for the 3 winograd transform ops. Right now the tiled implementations only work for TileAndDistribute, but this should be extended to work for the tiling done in `TileAndDecomposeWinogradTransform`.
 - There are some changes to the winograd path that need to be better tested and landed properly. The details for this were laid out here https://github.com/openxla/iree/issues/16886#issue-2203505555. Once there is some better testing in place, and most of the pieces are landed, then it would be a good idea to reevaluate the different backend pipelines to see if there are potential improvements to be made.

@harsh-nod This is the plan I have come up with so far, but you still probably have more context (even if it is a bit rusty) than I do on the filter transform. I spent some time trying to understand better what was going on with the op, so I have a better idea now, but it would be helpful if you could double check my plan of action and implementations so far.