### PR TITLE
[docs][website] Add subsection on profiling with perf and pprof

### DIFF
--- a/docs/website/docs/developers/debugging/compile-time-regressions.md
+++ b/docs/website/docs/developers/debugging/compile-time-regressions.md
@@ -196,6 +196,12 @@ time regressions, pay particular attention to the different compilation phases
 (Flow/Stream/HAL), how many times `TranslateExecutablesPass` runs, and if there
 are outlier passes that take significantly longer to run than others.
 
+!!! tip - "CMake Flags"
+
+    Currently, compiler tracing requires the runtime tracing to be enabled. Make
+    sure to set both `-DIREE_ENABLE_COMPILER_TRACING=ON` and
+    `-DIREE_ENABLE_RUNTIME_TRACING=ON`.
+
 Here are some previous analyses for inspiration:
 
 * <https://github.com/openxla/iree/issues/12033>
@@ -214,6 +220,47 @@ Example fast trace:
 Example sampling statistics showing 10s of minutes in LLVM codegen:
 
 ![slow LLVM codegen](https://user-images.githubusercontent.com/4010439/233441298-3c4f5afa-d1cc-43b3-8900-58652f295fe2.png)
+
+### Using `perf` and `pprof`
+
+These linux tools allow for fine-grained profiling. Below we present a list of
+steps to profile `iree-compile` and visualize the results as a flame graph.
+
+1. Compile IREE tools with debug information (line tables at minimum) and frame
+   pointers. You can do that by selecting the `RelWithDebInfo` build type and
+   adding `-fno-omit-frame-pointers` to your compiler flags:
+
+   ```shell
+   cmake <Your-CMAKE-Flags> \
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+      -DCMAKE_CXX_FLAGS="-fno-omit-frame-pointers" \
+      -DCMAKE_C_FLAGS="-fno-omit-frame-pointers"
+   ```
+
+2. Set perf event scope/access to the appropriate level with [`perf_event_paranoid`](https://www.kernel.org/doc/html/v5.7/admin-guide/perf-security.html#perf-events-perf-unprivileged-users).
+
+   ```shell
+   echo 0 | sudo tee /proc/sys/kernel/perf_event_paranoid
+   ```
+
+3. Run `iree-compile` under the `perf` profiler and collect profile data. This
+   requires `sudo`.
+
+   ```shell
+   sudo perf record -F 999 -g -- tools/iree-compile <Your-Compile-Arguments>
+   sudo chown "$USER:$USER" perf.data
+   ```
+
+4. Use `pprof` to process `perf.data` from the previous step and start a local
+   http server with the visualized profile. See the
+   [`pprof`'s README](https://github.com/google/pprof) for installation
+   instructions and make sure to build
+   [`perf_data_converter`](https://github.com/google/perf_data_converter) and
+   add it to your `PATH`.
+
+   ```shell
+   pprof -http ':' perf.data
+   ```
 
 ## Stepping through compiler IR
 

--- a/docs/website/docs/developers/debugging/compile-time-regressions.md
+++ b/docs/website/docs/developers/debugging/compile-time-regressions.md
@@ -233,11 +233,12 @@ steps to profile `iree-compile` and visualize the results as a flame graph.
    ```shell
    cmake <Your-CMAKE-Flags> \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-      -DCMAKE_CXX_FLAGS="-fno-omit-frame-pointers" \
-      -DCMAKE_C_FLAGS="-fno-omit-frame-pointers"
+      -DCMAKE_CXX_FLAGS="-fno-omit-frame-pointer" \
+      -DCMAKE_C_FLAGS="-fno-omit-frame-pointer"
    ```
 
-2. Set perf event scope/access to the appropriate level with [`perf_event_paranoid`](https://www.kernel.org/doc/html/v5.7/admin-guide/perf-security.html#perf-events-perf-unprivileged-users).
+2. Set perf event scope/access to the appropriate level with
+   [`perf_event_paranoid`](https://www.kernel.org/doc/html/v5.7/admin-guide/perf-security.html#perf-events-perf-unprivileged-users).
 
    ```shell
    echo 0 | sudo tee /proc/sys/kernel/perf_event_paranoid


### PR DESCRIPTION
Also add a tip for enabling compiler profiling with tracy.