### PR TITLE
[TD][Preprocessing] Speed up `match.cast_compatible_dag_from_root`

### DIFF
--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensions.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensions.cpp
@@ -164,7 +164,7 @@ IREE::transform_dialect::MatchCastCompatibleDagFromRootOp::matchOperation(
     DiagnosedSilenceableFailure diag =
         compareCastCompatibleOperations(*this, targetOp, payloadOp);
     if (!diag.succeeded()) {
-      diag.attachNote() << "While processing operation " << *payloadOp;
+      diag.attachNote(payloadOp->getLoc()) << "While processing operation";
       return diag;
     }
 
@@ -218,8 +218,7 @@ IREE::transform_dialect::MatchCastCompatibleDagFromRootOp::matchOperation(
     DiagnosedSilenceableFailure diag =
         compareOperationRegions(*this, cache, *mapping, targetOp, payloadOp);
     if (!diag.succeeded()) {
-      diag.attachNote() << "While processing region of operation "
-                        << *payloadOp;
+      diag.attachNote(payloadOp->getLoc()) << "While processing region";
       return diag;
     }
     for (auto [targetOpResult, payloadOpResult] :


### PR DESCRIPTION
Do not attach the whole ops/regions to the diagnostics, as this causes extreme slowness on larger input files.

This change makes preprocessing with my TD spec a few orders of magnitude faster. I left expensive checks based on a whole-compilation profile that didn't show it to be a bottleneck.

Issue: https://github.com/openxla/iree/issues/16901