### PR TITLE
Fix for iree-run-module with --input=not-a-path.bin

### DIFF
--- a/runtime/src/iree/io/stdio_stream.c
+++ b/runtime/src/iree/io/stdio_stream.c
@@ -180,7 +180,8 @@ IREE_API_EXPORT iree_status_t iree_io_stdio_stream_open(
   } else {
     if (stream) {
       iree_io_stream_release(stream);
-    } else {
+    }
+    if (handle) {
       fclose(handle);
     }
   }


### PR DESCRIPTION
This change means that you get the error

```
iree/runtime/src/iree/io/stdio_stream.c:170: UNKNOWN; unable to open file `not-a-path.bin` with mode 2; parsing input
```
instead of a segmentation fault. 
