### PR TITLE
[VectorDistribution] Add better verifiers for anchors in layout analysis

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -917,7 +917,9 @@ transform_dialect::TestVectorLayoutAnalysisOp::applyToOne(
     transform::ApplyToEachResultList &results,
     transform::TransformState &state) {
   VectorLayoutAnalysis analysis(target);
-  setAnchorOpsFromAttributes(analysis, target);
+  if (setAnchorOpsFromAttributes(analysis, target).failed()) {
+    return emitDefaultSilenceableFailure(target);
+  }
   if (failed(analysis.run())) {
     target.emitError("layout analysis failed");
     return emitDefaultSilenceableFailure(target);
@@ -942,8 +944,7 @@ public:
       : VectorLayoutOptions(root, /*fullConversion=*/false) {}
 
   LogicalResult setAnchorOps(VectorLayoutAnalysis &analysis) override {
-    setAnchorOpsFromAttributes(analysis, root);
-    return success();
+    return setAnchorOpsFromAttributes(analysis, root);
   }
 };
 

--- a/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
@@ -100,20 +100,7 @@ private:
   /// should only be used when you know there will be no layout conflicts.
   /// Otherwise, the resolve-like functions should be used.
   void setInnerLayout(const VectorLayoutInterface &layout) {
-    if (layout && !layout.isValidLayout(getValue().getType().getShape())) {
-      Location loc = getValue().getLoc();
-      emitError(loc)
-          << "Attempting to assign an invalid or incompatible layout: "
-          << layout;
-      emitRemark(loc) << "To value: " << getValue();
-      std::string buf;
-      llvm::raw_string_ostream os(buf);
-      llvm::interleaveComma(getValue().getType().getShape(), os);
-      emitRemark(loc) << "Of shape: [" << os.str() << "]";
-      // TODO(https://github.com/openxla/iree/issues/16119): We shouldn't crash
-      // here.
-      llvm::report_fatal_error("Invalid layout assignment");
-    }
+    assert(layout && layout.isValidLayout(getValue()).succeeded());
     vectorLayout = layout;
   }
 
@@ -987,6 +974,20 @@ DistributionLayout *EnforceLayout::getLatticeElement(Value val) {
 ///        VectorLayoutAnalysis
 /// ==========================================================================
 
+LogicalResult VectorLayoutAnalysis::setAnchor(Value val, Attribute layout) {
+  VectorLayoutInterface layoutInterface =
+      dyn_cast<VectorLayoutInterface>(layout);
+  assert(layoutInterface &&
+         "expected layout to implement VectorLayoutInterface");
+  auto typedVal = dyn_cast<TypedValue<VectorType>>(val);
+  assert(typedVal && "expected value to be a vector type");
+  if (layoutInterface.isValidLayout(typedVal).failed()) {
+    return failure();
+  }
+  anchors[typedVal] = cast<VectorLayoutInterface>(layout);
+  return success();
+}
+
 LogicalResult VectorLayoutAnalysis::run() {
   // The order of loading matters here, because propagateLayout does anchoring
   // initialization which needs the lattice to know both enforcement and
@@ -1045,9 +1046,9 @@ void VectorLayoutAnalysis::dump() {
 
 namespace mlir::iree_compiler {
 
-void setAnchorOpsFromAttributes(VectorLayoutAnalysis &analysis,
-                                Operation *root) {
-  root->walk([&](Operation *op) {
+LogicalResult setAnchorOpsFromAttributes(VectorLayoutAnalysis &analysis,
+                                         Operation *root) {
+  WalkResult result = root->walk([&](Operation *op) {
     for (NamedAttribute attr : op->getAttrs()) {
       StringRef name = attr.getName().strref();
       if (name.contains("__vector_layout_test_anchor_operand_")) {
@@ -1056,17 +1057,29 @@ void setAnchorOpsFromAttributes(VectorLayoutAnalysis &analysis,
             .getAsInteger(/*Radix=*/10, operandNum);
         assert(operandNum < op->getNumOperands() &&
                "operand number out of range");
-        analysis.setAnchor(op->getOperand(operandNum), attr.getValue());
+        if (analysis.setAnchor(op->getOperand(operandNum), attr.getValue())
+                .failed()) {
+          return WalkResult::interrupt();
+        }
       }
       if (name.contains("__vector_layout_test_anchor_result_")) {
         int resultNum;
         name.substr(name.find_last_of("_") + 1)
             .getAsInteger(/*Radix=*/10, resultNum);
         assert(resultNum < op->getNumResults() && "result number out of range");
-        analysis.setAnchor(op->getResult(resultNum), attr.getValue());
+        if (analysis.setAnchor(op->getResult(resultNum), attr.getValue())
+                .failed()) {
+          return WalkResult::interrupt();
+        }
       }
     }
+    return WalkResult::advance();
   });
+
+  if (result.wasInterrupted()) {
+    return failure();
+  }
+  return success();
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.h
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.h
@@ -141,7 +141,7 @@ private:
 };
 
 LogicalResult setAnchorOpsFromAttributes(VectorLayoutAnalysis &analysis,
-                                Operation *root);
+                                         Operation *root);
 
 }; // namespace iree_compiler
 }; // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.h
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.h
@@ -98,10 +98,9 @@ class VectorLayoutAnalysis {
 public:
   VectorLayoutAnalysis(Operation *root) : root(root) {}
 
-  /// Fix the layout for a specific value. The layout must implement
-  /// VectorLayoutInterface. Returns failure if the layout set is invalid for
-  /// the value.
-  LogicalResult setAnchor(Value val, Attribute layout);
+  /// Fix the layout for a specific value. Returns failure if the layout set is
+  /// invalid for the value.
+  LogicalResult setAnchor(Value val, VectorLayoutInterface layout);
 
   /// Run the analysis. The analysis expects that the user has set some anchor
   /// points and is trying to infer the layout of other values.

--- a/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.h
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.h
@@ -99,15 +99,9 @@ public:
   VectorLayoutAnalysis(Operation *root) : root(root) {}
 
   /// Fix the layout for a specific value. The layout must implement
-  /// VectorLayoutInterface.
-  template <typename T>
-  void setAnchor(Value val, T layout) {
-    assert(isa<VectorLayoutInterface>(layout) &&
-           "expected layout to implement VectorLayoutInterface");
-    auto typedVal = dyn_cast<TypedValue<VectorType>>(val);
-    assert(typedVal && "expected value to be a vector type");
-    anchors[typedVal] = cast<VectorLayoutInterface>(layout);
-  }
+  /// VectorLayoutInterface. Returns failure if the layout set is invalid for
+  /// the value.
+  LogicalResult setAnchor(Value val, Attribute layout);
 
   /// Run the analysis. The analysis expects that the user has set some anchor
   /// points and is trying to infer the layout of other values.
@@ -146,7 +140,7 @@ private:
   DataFlowSolver solver;
 };
 
-void setAnchorOpsFromAttributes(VectorLayoutAnalysis &analysis,
+LogicalResult setAnchorOpsFromAttributes(VectorLayoutAnalysis &analysis,
                                 Operation *root);
 
 }; // namespace iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/test/vector_layout_analysis.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/vector_layout_analysis.mlir
@@ -336,3 +336,65 @@ builtin.module attributes { transform.with_named_sequence } {
     transform.yield
   }
 }
+
+// -----
+
+#layout = #iree_vector_ext.nested_layout<
+  subgroups_per_workgroup = [2, 1, 1],
+  batches_per_subgroup = [1, 2, 4],
+  outers_per_batch = [1, 1, 1],
+  threads_per_outer = [4, 8, 2],
+  elements_per_thread = [4, 1, 2],
+
+  subgroup_basis = [2, 1, 1],
+  thread_basis   = [4, 8, 2]
+>
+
+/// Invalid anchor tests
+
+// Rank mismatch anchor.
+builtin.module attributes { transform.with_named_sequence } {
+  // expected-note @below {{when applied to this op}}
+  func.func @invalid_rank_nested_layout_anchor(%a: vector<16x16xf16>, %b: vector<16x16xf16>) -> vector<16x16xf16> {
+    %c = arith.addf %a, %b : vector<16x16xf16>
+    // expected-error @above {{Rank of vector (2) does not match rank of layout (3)}}
+    func.return {"__vector_layout_test_anchor_operand_0" = #layout} %c : vector<16x16xf16>
+  }
+
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_vector_layout_analysis %top_level_func : !transform.any_op
+    // expected-error @above {{transform.iree.test_vector_layout_analysis failed to apply}}
+    transform.yield
+  }
+}
+
+// -----
+
+#layout2 = #iree_vector_ext.nested_layout<
+  subgroups_per_workgroup = [1, 1],
+  batches_per_subgroup = [2, 4],
+  outers_per_batch = [1, 1],
+  threads_per_outer = [8, 2],
+  elements_per_thread = [2, 2],
+
+  subgroup_basis = [1, 1],
+  thread_basis   = [8, 2]
+>
+
+// Size mismatch anchor.
+builtin.module attributes { transform.with_named_sequence } {
+  // expected-note @below {{when applied to this op}}
+  func.func @invalid_size_nested_layout_anchor(%a: vector<16x16xf16>, %b: vector<16x16xf16>) -> vector<16x16xf16> {
+    %c = arith.addf %a, %b : vector<16x16xf16>
+    // expected-error @above {{Vector shape: [16, 16] does not match the layout (nested_layout<subgroups_per_workgroup = [1, 1], batches_per_subgroup = [2, 4], outers_per_batch = [1, 1], threads_per_outer = [8, 2], elements_per_thread = [2, 2], subgroup_basis = [1, 1], thread_basis = [8, 2]>) at dim 0. Dimension expected by layout: 32 actual: 16}}
+    func.return {"__vector_layout_test_anchor_operand_0" = #layout2} %c : vector<16x16xf16>
+  }
+
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_vector_layout_analysis %top_level_func : !transform.any_op
+    // expected-error @above {{transform.iree.test_vector_layout_analysis failed to apply}}
+    transform.yield
+  }
+}

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorDistribute.cpp
@@ -74,8 +74,7 @@ public:
                 return setContractionAnchor(context, analysis, contract);
               })
               .Case([&](vector::TransferReadOp transfer) {
-                setTransferReadAnchor(context, analysis, transfer);
-                return success();
+                return setTransferReadAnchor(context, analysis, transfer);
               })
               .Default([](Operation *) { return success(); });
       return failed(setResult) ? WalkResult::interrupt()
@@ -104,10 +103,18 @@ private:
     }
 
     auto [aLayout, bLayout, cLayout] = *layouts;
-    analysis.setAnchor(contract.getLhs(), aLayout);
-    analysis.setAnchor(contract.getRhs(), bLayout);
-    analysis.setAnchor(contract.getAcc(), cLayout);
-    analysis.setAnchor(contract.getResult(), cLayout);
+    if (analysis.setAnchor(contract.getLhs(), aLayout).failed()) {
+      return failure();
+    }
+    if (analysis.setAnchor(contract.getRhs(), bLayout).failed()) {
+      return failure();
+    }
+    if (analysis.setAnchor(contract.getAcc(), cLayout).failed()) {
+      return failure();
+    }
+    if (analysis.setAnchor(contract.getResult(), cLayout).failed()) {
+      return failure();
+    }
     contract->setAttr("iree.amdgpu.mfma", schedule.getIntrinsic());
     if (printLayout) {
       llvm::outs() << "contract A vector layout: " << aLayout << "\n";
@@ -158,9 +165,9 @@ private:
   //    elements_per_thread =     [1, 8]
   //
   //    *_order = [0, 1]>
-  void setTransferReadAnchor(MLIRContext *context,
-                             VectorLayoutAnalysis &analysis,
-                             vector::TransferReadOp transfer) {
+  LogicalResult setTransferReadAnchor(MLIRContext *context,
+                                      VectorLayoutAnalysis &analysis,
+                                      vector::TransferReadOp transfer) {
 
     // Get the forward slice of the transfer to approximate whether it will take
     // the layout of a contraction instead. Transfer_read ops used directly by a
@@ -184,38 +191,38 @@ private:
     if (llvm::any_of(slice, [](Operation *op) {
           return llvm::isa<vector::ContractionOp>(op);
         })) {
-      return;
+      return success();
     }
 
     // TODO: Support masking.
     if (transfer.getMask()) {
-      return;
+      return success();
     }
     // Shared memory loads are expected to take the layout of the contraction.
     auto sourceMemRefType =
         dyn_cast<MemRefType>(transfer.getSource().getType());
     if (!sourceMemRefType || hasSharedMemoryAddressSpace(sourceMemRefType)) {
-      return;
+      return success();
     }
 
     int64_t bitWidth = IREE::Util::getTypeBitWidth(
         getElementTypeOrSelf(transfer.getVectorType()));
     if (!llvm::isPowerOf2_64(bitWidth) || bitWidth > 128) {
-      return;
+      return success();
     }
     int64_t numElementsPerThread = 128 / bitWidth;
     int64_t flatNumElements =
         ShapedType::getNumElements(transfer.getVectorType().getShape());
     int64_t flatNumThreads = ShapedType::getNumElements(workgroupSize);
     if (flatNumElements % flatNumThreads != 0) {
-      return;
+      return success();
     }
     numElementsPerThread =
         std::min(numElementsPerThread, flatNumElements / flatNumThreads);
 
     AffineMap transferMap = transfer.getPermutationMap();
     if (transferMap.getNumDims() == 0) {
-      return;
+      return success();
     }
 
     // Select the innermost dim of the memref as the contiguous dim to load
@@ -308,11 +315,14 @@ private:
         threadCounts, order, elementSizes, order, subgroupBasis,
         SmallVector<bool>(subgroupBasis.size(), true), threadBasis,
         SmallVector<bool>(threadBasis.size(), true));
-    analysis.setAnchor(transfer.getResult(), layout);
+    if (analysis.setAnchor(transfer.getResult(), layout).failed()) {
+      return failure();
+    }
     if (printLayout) {
       llvm::outs() << "transfer '" << transfer << "' vector layout: " << layout
                    << "\n";
     }
+    return success();
   }
 
   SmallVector<int64_t, 3> workgroupSize;

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -1526,8 +1526,7 @@ public:
       : VectorLayoutOptions(root, fullConversion) {}
 
   LogicalResult setAnchorOps(VectorLayoutAnalysis &analysis) override {
-    setAnchorOpsFromAttributes(analysis, root);
-    return success();
+    return setAnchorOpsFromAttributes(analysis, root);
   }
 };
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/VectorExt/IR/VectorExtInterfaces.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/VectorExt/IR/VectorExtInterfaces.td
@@ -18,10 +18,11 @@ def VectorLayoutInterface : AttrInterface<"VectorLayoutInterface"> {
 
   let methods = [
     InterfaceMethod<
-      /*description=*/"Check if this is a valid layout for the given shape.",
-      /*retTy=*/"bool",
+      /*description=*/"Check if this layout is valid for the given vector type."
+                       "On failure, emits diagnostics to explain the failure.",
+      /*retTy=*/"LogicalResult",
       /*methodName=*/"isValidLayout",
-      /*args=*/(ins "::llvm::ArrayRef<int64_t>":$shape)
+      /*args=*/(ins "::mlir::TypedValue<::mlir::VectorType>":$vector)
     >,
     InterfaceMethod<
       /*description=*/"Permutes the given layout.",

--- a/llvm-external-projects/iree-dialects/lib/Dialect/VectorExt/IR/VectorExtAttrs.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/VectorExt/IR/VectorExtAttrs.cpp
@@ -54,6 +54,12 @@ std::optional<int64_t> LayoutAttr::getShape(const LayoutDimension &dim) const {
 // specified, then return an empty vector.
 LogicalResult LayoutAttr::isValidLayout(VectorValue vector) const {
   ArrayRef<int64_t> shape = vector.getType().getShape();
+  if (shape.size() != getLayouts().size()) {
+    return emitError(vector.getLoc(),
+                     "Rank of vector (" + std::to_string(shape.size()) +
+                         ") does not match rank of layout (" +
+                         std::to_string(getLayouts().size()) + ").");
+  }
   for (auto [idx, layout] : llvm::enumerate(getLayouts())) {
     ArrayRef<int64_t> layoutShape = layout.getShapes();
     int64_t expectedShape =
@@ -380,6 +386,12 @@ SmallVector<int64_t> NestedLayoutAttr::getDistributedShape() const {
 
 LogicalResult NestedLayoutAttr::isValidLayout(VectorValue vector) const {
   ArrayRef<int64_t> shape = vector.getType().getShape();
+  if (shape.size() != getBatchOrder().size()) {
+    return emitError(vector.getLoc(),
+                     "Rank of vector (" + std::to_string(shape.size()) +
+                         ") does not match rank of layout (" +
+                         std::to_string(getBatchOrder().size()) + ").");
+  }
   // Multiply all shapes in the layout.
   for (int i = 0, e = shape.size(); i < e; ++i) {
     int64_t expectedShape = getSubgroupsPerWorkgroup()[i] *

--- a/llvm-external-projects/iree-dialects/lib/Dialect/VectorExt/IR/VectorExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/VectorExt/IR/VectorExtOps.cpp
@@ -19,8 +19,6 @@ using VectorValue = TypedValue<VectorType>;
 
 // Validate that the desired layout has the same shape as the input.
 LogicalResult LayoutConflictResolutionOp::verify() {
-  ArrayRef<int64_t> inputShape =
-      cast<VectorType>(getInput().getType()).getShape();
   if (getSourceLayout().isValidLayout(getInput()).failed()) {
     return failure();
   }

--- a/llvm-external-projects/iree-dialects/lib/Dialect/VectorExt/IR/VectorExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/VectorExt/IR/VectorExtOps.cpp
@@ -11,29 +11,24 @@
 using namespace mlir;
 using namespace mlir::iree_compiler::IREE::VectorExt;
 
+using VectorValue = TypedValue<VectorType>;
+
 //===----------------------------------------------------------------------===//
 // LayoutConflictResolutionOp
 //===----------------------------------------------------------------------===//
-
-LogicalResult validateLayout(Operation *op, StringRef label,
-                             VectorLayoutInterface layout,
-                             ArrayRef<int64_t> inputShape) {
-  if (!layout.isValidLayout(inputShape)) {
-    return op->emitError(
-        "The " + label +
-        " layout shape cannot be distributed over the given vector shape.");
-  }
-  return success();
-}
 
 // Validate that the desired layout has the same shape as the input.
 LogicalResult LayoutConflictResolutionOp::verify() {
   Operation *op = getOperation();
   ArrayRef<int64_t> inputShape =
       cast<VectorType>(getInput().getType()).getShape();
-  if (succeeded(validateLayout(op, "source", getSourceLayout(), inputShape)))
-    return validateLayout(op, "desired", getDesiredLayout(), inputShape);
-  return failure();
+  if (getSourceLayout().isValidLayout(getInput()).failed()) {
+    return failure();
+  }
+  if (getDesiredLayout().isValidLayout(getOutput()).failed()) {
+    return failure();
+  }
+  return success();
 }
 
 // to_simd -> to_simt

--- a/llvm-external-projects/iree-dialects/lib/Dialect/VectorExt/IR/VectorExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/VectorExt/IR/VectorExtOps.cpp
@@ -19,7 +19,6 @@ using VectorValue = TypedValue<VectorType>;
 
 // Validate that the desired layout has the same shape as the input.
 LogicalResult LayoutConflictResolutionOp::verify() {
-  Operation *op = getOperation();
   ArrayRef<int64_t> inputShape =
       cast<VectorType>(getInput().getType()).getShape();
   if (getSourceLayout().isValidLayout(getInput()).failed()) {

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_vector_ext/invalid.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_vector_ext/invalid.mlir
@@ -8,7 +8,7 @@ func.func @invalid_desired_layout(%lhs: memref<32x32xf16>, %rhs: memref<32x32xf1
   %cst_0 = arith.constant 0.0 : f16
   %c0 = arith.constant 0 : index
   %result = vector.transfer_read %lhs[%c0, %c0], %cst_0 {in_bounds = [true, true]} : memref<32x32xf16>, vector<32x32xf16>
-  // expected-error @+1 {{The desired layout shape cannot be distributed over the given vector shape}}
+  // expected-error @+1 {{Vector shape: [32, 32] does not match the layout (layout<<[ BATCHX,  LANEX,  VECTORY], [1, 1, 1]>, <[ BATCHY,  LANEY,  VECTORX], [4, 2, 4]>>) at dim 0. Dimension expected by layout: 1 actual: 32}}
   %2 = iree_vector_ext.layout_conflict_resolution %result {desiredLayout = #layout1, sourceLayout = #layout2} : vector<32x32xf16> -> vector<32x32xf16>
   return %2 : vector<32x32xf16>
 }
@@ -23,7 +23,7 @@ func.func @invalid_source_layout(%lhs: memref<32x32xf16>, %rhs: memref<32x32xf16
   %cst_0 = arith.constant 0.0 : f16
   %c0 = arith.constant 0 : index
   %result = vector.transfer_read %lhs[%c0, %c0], %cst_0 {in_bounds = [true, true]} : memref<32x32xf16>, vector<32x32xf16>
-  // expected-error @+1 {{The source layout shape cannot be distributed over the given vector shape}}
+  // expected-error @-1 {{Vector shape: [32, 32] does not match the layout (layout<<[ BATCHX,  LANEX,  VECTORY], [1, 1, 1]>, <[ BATCHY,  LANEY,  VECTORX], [4, 2, 4]>>) at dim 0. Dimension expected by layout: 1 actual: 32}}
   %2 = iree_vector_ext.layout_conflict_resolution %result {desiredLayout = #layout2, sourceLayout = #layout1} : vector<32x32xf16> -> vector<32x32xf16>
   return %2 : vector<32x32xf16>
 }


### PR DESCRIPTION
This patch moves the layout verification on anchoring for layout analysis. This allows for giving better error messages and graceful failure during vector distribution instead of crashing during the analysis.

Fixes #16119