### PR TITLE
[LLVMGPU] Fit mma schedules inside shared memory limits

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -48,16 +48,16 @@ fitScheduleInSharedMemory(ArrayRef<GPUMatmulShapeType> intrinsics,
       llvm::errs() << "nWarpCount: " << schedule.nWarpCount << "\n";
     });
     // Attempt to shrink the schedule along one of the dimensions.
-    if (schedule.mTileCount > 1) {
-      schedule.mTileCount--;
+    if (schedule.mTileCount % 2 == 0) {
+      schedule.mTileCount /= 2;
       continue;
     }
-    if (schedule.nTileCount > 1) {
-      schedule.nTileCount--;
+    if (schedule.nTileCount % 2 == 0) {
+      schedule.nTileCount /= 2;
       continue;
     }
-    if (schedule.kTileCount > 1) {
-      schedule.kTileCount--;
+    if (schedule.kTileCount % 2 == 0) {
+      schedule.kTileCount /= 2;
       continue;
     }
     if (schedule.mWarpCount % 2 == 0) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -48,16 +48,16 @@ fitScheduleInSharedMemory(ArrayRef<GPUMatmulShapeType> intrinsics,
       llvm::errs() << "nWarpCount: " << schedule.nWarpCount << "\n";
     });
     // Attempt to shrink the schedule along one of the dimensions.
-    if (schedule.mTileCount % 2 == 0) {
-      schedule.mTileCount /= 2;
+    if (schedule.mTileCount > 1) {
+      schedule.mTileCount--;
       continue;
     }
-    if (schedule.nTileCount % 2 == 0) {
-      schedule.nTileCount /= 2;
+    if (schedule.nTileCount > 1) {
+      schedule.nTileCount--;
       continue;
     }
-    if (schedule.kTileCount % 2 == 0) {
-      schedule.kTileCount /= 2;
+    if (schedule.kTileCount > 1) {
+      schedule.kTileCount--;
       continue;
     }
     if (schedule.mWarpCount % 2 == 0) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -96,13 +96,14 @@ FailureOr<GPUMMASchedule> fitScheduleInSharedMemory(
   return schedule;
 }
 
-FailureOr<GPUMMASchedule> deduceMMASchedule(
-    const GPUMatmulShapeType &problem, ArrayRef<GPUMatmulShapeType> intrinsics,
-    const GPUMMAHeuristicSeeds &seeds, int64_t sharedMemLimitInBytes,
-    bool canUpcastAcc) {
+FailureOr<GPUMMASchedule>
+deduceMMASchedule(const GPUMatmulShapeType &problem,
+                  ArrayRef<GPUMatmulShapeType> intrinsics,
+                  const GPUMMAHeuristicSeeds &seeds,
+                  int64_t sharedMemLimitInBytes, bool canUpcastAcc) {
   for (auto [index, intrinsic] : llvm::enumerate(intrinsics)) {
     if (problem.aType != intrinsic.aType || problem.bType != intrinsic.bType) {
-      continue;  // Cannot use this intrinsic for mismatched types
+      continue; // Cannot use this intrinsic for mismatched types
     }
     if (problem.cType != intrinsic.cType) {
       auto isFpCase =
@@ -110,14 +111,14 @@ FailureOr<GPUMMASchedule> deduceMMASchedule(
       auto isUpcast = problem.cType.getIntOrFloatBitWidth() <
                       intrinsic.cType.getIntOrFloatBitWidth();
       if (!(canUpcastAcc && isFpCase && isUpcast)) {
-        continue;  // Cannot use this intrinsic if not upcasting
+        continue; // Cannot use this intrinsic if not upcasting
       }
     }
 
     if (problem.mSize % intrinsic.mSize != 0 ||
         problem.nSize % intrinsic.nSize != 0 ||
         problem.kSize % intrinsic.kSize != 0) {
-      continue;  // Cannot use this intrinsic for misaligned cases
+      continue; // Cannot use this intrinsic for misaligned cases
     }
 
     int64_t mTotalTileCount = problem.mSize / intrinsic.mSize;
@@ -201,4 +202,4 @@ FailureOr<GPUMMASchedule> deduceMMASchedule(
   return failure();
 }
 
-}  // namespace mlir::iree_compiler
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -74,19 +74,19 @@ FailureOr<GPUMMASchedule> fitScheduleInSharedMemory(
     // TODO: A better solution should probably factor problem.mSize /
     // (mWarpCount * mTileCount * mSize) and then pop off the smallest factors
     // one at a time, preferably trying to keep the tile "generally square."
-    if (decrementIfPossible(schedule.mTileCount).succeeded()) {
+    if (succeeded(decrementIfPossible(schedule.mTileCount))) {
       continue;
     }
-    if (decrementIfPossible(schedule.nTileCount).succeeded()) {
+    if (succeeded(decrementIfPossible(schedule.nTileCount))) {
       continue;
     }
-    if (decrementIfPossible(schedule.kTileCount).succeeded()) {
+    if (succeeded(decrementIfPossible(schedule.kTileCount))) {
       continue;
     }
-    if (decrementIfPossible(schedule.mWarpCount).succeeded()) {
+    if (succeeded(decrementIfPossible(schedule.mWarpCount))) {
       continue;
     }
-    if (decrementIfPossible(schedule.nWarpCount).succeeded()) {
+    if (succeeded(decrementIfPossible(schedule.nWarpCount))) {
       continue;
     }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -31,11 +31,11 @@ static int64_t calculateSharedMemoryUsedInBytes(const GPUMMASchedule &schedule,
 
 bool isValidSchedule(const GPUMatmulShapeType &problem,
                      const GPUMMASchedule &schedule) {
-  bool isValidM = problem.mSize %
-                  (schedule.mSize * schedule.mTileCount * schedule.mWarpCount);
-  bool isValidN = problem.nSize %
-                  (schedule.nSize * schedule.nTileCount * schedule.nWarpCount);
-  bool isValidK = problem.kSize % (schedule.kSize * schedule.kTileCount) == 0;
+  bool isValidM = (problem.mSize % (schedule.mSize * schedule.mTileCount *
+                                    schedule.mWarpCount)) == 0;
+  bool isValidN = (problem.nSize % (schedule.nSize * schedule.nTileCount *
+                                    schedule.nWarpCount)) == 0;
+  bool isValidK = (problem.kSize % (schedule.kSize * schedule.kTileCount)) == 0;
   return isValidN && isValidM && isValidK;
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
@@ -46,7 +46,7 @@ struct GPUMMASchedule {
 
 /// Returns a schedule for using one of the given MMA |intrinsics| to target the
 /// input |problem|. Returns std::nullopt if we cannot find such a schedule.
-std::optional<GPUMMASchedule>
+FailureOr<GPUMMASchedule>
 deduceMMASchedule(const GPUMatmulShapeType &problem,
                   ArrayRef<GPUMatmulShapeType> intrinsics,
                   const GPUMMAHeuristicSeeds &seeds, int64_t sharedMemLimit,

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
@@ -49,7 +49,7 @@ struct GPUMMASchedule {
 FailureOr<GPUMMASchedule>
 deduceMMASchedule(const GPUMatmulShapeType &problem,
                   ArrayRef<GPUMatmulShapeType> intrinsics,
-                  const GPUMMAHeuristicSeeds &seeds, int64_t sharedMemLimit,
-                  bool canUpcastAcc = false);
+                  const GPUMMAHeuristicSeeds &seeds,
+                  int64_t sharedMemLimitInBytes, bool canUpcastAcc = false);
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
@@ -49,6 +49,7 @@ struct GPUMMASchedule {
 std::optional<GPUMMASchedule>
 deduceMMASchedule(const GPUMatmulShapeType &problem,
                   ArrayRef<GPUMatmulShapeType> intrinsics,
-                  const GPUMMAHeuristicSeeds &seeds, bool canUpcastAcc = false);
+                  const GPUMMAHeuristicSeeds &seeds, int64_t sharedMemLimit,
+                  bool canUpcastAcc = false);
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -46,16 +46,16 @@ llvm::cl::opt<bool> clGPUEnableTransformDialectJit(
     llvm::cl::init(true));
 
 /// Flag to force using WMMA tensorcore operations.
-llvm::cl::opt<bool> clGPUUseWMMA(
-    "iree-codegen-llvmgpu-use-wmma",
-    llvm::cl::desc("force use of wmma operations for tensorcore"),
-    llvm::cl::init(false));
+llvm::cl::opt<bool>
+    clGPUUseWMMA("iree-codegen-llvmgpu-use-wmma",
+                 llvm::cl::desc("force use of wmma operations for tensorcore"),
+                 llvm::cl::init(false));
 
 /// Flag used to toggle using mma.sync vs wmma when targetting tensorcore.
-llvm::cl::opt<bool> clGPUUseMMASync(
-    "iree-codegen-llvmgpu-use-mma-sync",
-    llvm::cl::desc("force use mma sync instead of wmma ops"),
-    llvm::cl::init(false));
+llvm::cl::opt<bool>
+    clGPUUseMMASync("iree-codegen-llvmgpu-use-mma-sync",
+                    llvm::cl::desc("force use mma sync instead of wmma ops"),
+                    llvm::cl::init(false));
 
 llvm::cl::opt<int> clGPUMatmulCThreshold(
     "iree-codegen-llvmgpu-matmul-c-matrix-threshold",
@@ -93,7 +93,7 @@ struct TileWorkgroupSizePair {
 // Simt codegen does not do software pipelining.
 constexpr unsigned softwarePipelineDepthSimt = 0;
 
-}  // namespace
+} // namespace
 
 //====---------------------------------------------------------------------===//
 // Matmul Configuration Helpers
@@ -128,9 +128,9 @@ getMatmulConfig(const TargetInfo &targetInfo) {
 
 /// Return the best combination of tile size and wg size when using tensorcore
 /// operations.
-static void getTensorCoreConfig(
-    SmallVectorImpl<TileWorkgroupSizePair> &tileSizes, Type elementType,
-    int64_t M, int64_t N, int64_t K) {
+static void
+getTensorCoreConfig(SmallVectorImpl<TileWorkgroupSizePair> &tileSizes,
+                    Type elementType, int64_t M, int64_t N, int64_t K) {
   // Based on early analysis we found that 128x256x32_3 gives acceptable
   // performance across many of the large matrix sizes for f16 and fp32. This
   // needs to be refined into a better startegy based on empircal data but this
@@ -200,7 +200,8 @@ static TargetInfo getCudaTargetInfo(mlir::FunctionOpInterface entryPoint) {
   info.sharedMemoryLimit = 163 * 1024;
   StringRef targetName = getTargetArch(entryPoint);
   // If no target name is set assume all the features are off.
-  if (targetName == "") return info;
+  if (targetName == "")
+    return info;
   if (!StringRef(targetName).starts_with("sm_")) {
     entryPoint.emitError("unknown target name ") << targetName;
     return info;
@@ -224,7 +225,8 @@ static TargetInfo getRocmTargetInfo(mlir::FunctionOpInterface entryPoint) {
   StringRef targetName = getTargetArch(entryPoint);
   info.sharedMemoryLimit = 65536;
   // If no target name is set assume all the features are off.
-  if (targetName.empty()) return info;
+  if (targetName.empty())
+    return info;
 
   if (!targetName.starts_with("gfx")) {
     entryPoint.emitError("unknown target name ") << targetName;
@@ -246,8 +248,10 @@ static TargetInfo getRocmTargetInfo(mlir::FunctionOpInterface entryPoint) {
 
 static TargetInfo getTargetInfo(mlir::FunctionOpInterface entryPoint) {
   // TODO: fill out target info for other vendors.
-  if (isCudaTarget(entryPoint)) return getCudaTargetInfo(entryPoint);
-  if (isRocmTarget(entryPoint)) return getRocmTargetInfo(entryPoint);
+  if (isCudaTarget(entryPoint))
+    return getCudaTargetInfo(entryPoint);
+  if (isRocmTarget(entryPoint))
+    return getRocmTargetInfo(entryPoint);
   return {};
 }
 
@@ -256,7 +260,8 @@ static bool supportsTensorCore(mlir::FunctionOpInterface entryPoint,
                                const TargetInfo &targetInfo) {
   // Limit tensor core pipeline to matmul as not all combinations of transpose
   // are supported upstream.
-  if (!targetInfo.hasTF32TensorCore) return false;
+  if (!targetInfo.hasTF32TensorCore)
+    return false;
   if (!(isa<linalg::MatmulOp>(op) || isa<linalg::BatchMatmulOp>(op))) {
     assert(linalg::isaContractionOpInterface(op));
     // If this is not a named op matmul check some properties to make sure that
@@ -265,22 +270,27 @@ static bool supportsTensorCore(mlir::FunctionOpInterface entryPoint,
     // should be a reduce.
     Region &body = op->getRegion(0);
     Region::OpIterator it = body.op_begin();
-    if (it == body.op_end() || !isa<arith::MulFOp>(*(it++))) return false;
-    if (it == body.op_end() || !isa<arith::AddFOp>(*(it++))) return false;
-    if (it == body.op_end() || !isa<linalg::YieldOp>(*(it++))) return false;
+    if (it == body.op_end() || !isa<arith::MulFOp>(*(it++)))
+      return false;
+    if (it == body.op_end() || !isa<arith::AddFOp>(*(it++)))
+      return false;
+    if (it == body.op_end() || !isa<linalg::YieldOp>(*(it++)))
+      return false;
     AffineMap outputMap = op.getMatchingIndexingMap(op.getDpsInitOperand(0));
-    if (outputMap.getNumResults() != outputMap.getNumDims() - 1) return false;
+    if (outputMap.getNumResults() != outputMap.getNumDims() - 1)
+      return false;
     OpBuilder b(op);
     for (unsigned i = 0, e = outputMap.getNumResults(); i < e - 1; i++) {
-      if (outputMap.getResult(i) != b.getAffineDimExpr(i)) return false;
+      if (outputMap.getResult(i) != b.getAffineDimExpr(i))
+        return false;
     }
   }
   return true;
 }
 
 /// Decides which tensorcore operations to use.
-static IREE::Codegen::DispatchLoweringPassPipeline getTensorCorePipeline(
-    Type elementType) {
+static IREE::Codegen::DispatchLoweringPassPipeline
+getTensorCorePipeline(Type elementType) {
   // Currently mma.sync is on by default for fp16 only.
   IREE::Codegen::DispatchLoweringPassPipeline codegenPipeline =
       IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUMatmulTensorCore;
@@ -308,9 +318,10 @@ static IREE::Codegen::DispatchLoweringPassPipeline getTensorCorePipeline(
 // Vector Distribution Contraction/Convolution Pipeline Configuration
 //====---------------------------------------------------------------------===//
 
-static LogicalResult setConvolutionVectorDistributionConfig(
-    mlir::FunctionOpInterface entryPoint, linalg::LinalgOp op,
-    const TargetInfo &targetInfo) {
+static LogicalResult
+setConvolutionVectorDistributionConfig(mlir::FunctionOpInterface entryPoint,
+                                       linalg::LinalgOp op,
+                                       const TargetInfo &targetInfo) {
   FailureOr<ArrayAttr> mmaKinds = getSupportedMmaTypes(entryPoint);
   if (failed(mmaKinds)) {
     return failure();
@@ -469,9 +480,10 @@ static LogicalResult setConvolutionVectorDistributionConfig(
       workgroupSize, targetSubgroupSize, configDict);
 }
 
-static LogicalResult setMatmulVectorDistributionConfig(
-    mlir::FunctionOpInterface entryPoint, linalg::LinalgOp op,
-    const TargetInfo &targetInfo) {
+static LogicalResult
+setMatmulVectorDistributionConfig(mlir::FunctionOpInterface entryPoint,
+                                  linalg::LinalgOp op,
+                                  const TargetInfo &targetInfo) {
   FailureOr<ArrayAttr> mmaKinds = getSupportedMmaTypes(entryPoint);
   if (failed(mmaKinds)) {
     return failure();
@@ -616,9 +628,10 @@ static LogicalResult setMatmulVectorDistributionConfig(
       workgroupSize, targetSubgroupSize, configDict);
 }
 
-static LogicalResult setVectorDistributionConfig(
-    mlir::FunctionOpInterface entryPoint, linalg::LinalgOp linalgOp,
-    const TargetInfo &targetInfo) {
+static LogicalResult
+setVectorDistributionConfig(mlir::FunctionOpInterface entryPoint,
+                            linalg::LinalgOp linalgOp,
+                            const TargetInfo &targetInfo) {
   if (linalg::isaContractionOpInterface(linalgOp)) {
     return setMatmulVectorDistributionConfig(entryPoint, linalgOp, targetInfo);
   }
@@ -656,7 +669,8 @@ static LogicalResult setContractConfig(mlir::FunctionOpInterface entryPoint,
     staticNonUnitParallelDimCount +=
         bounds[nDim] != 1 && !ShapedType::isDynamic(bounds[nDim]);
   }
-  if (staticNonUnitParallelDimCount <= 1) return failure();
+  if (staticNonUnitParallelDimCount <= 1)
+    return failure();
 
   // Don't consider operations that don't have a broadcast, those should go
   // through reductions.
@@ -714,9 +728,10 @@ static LogicalResult setContractConfig(mlir::FunctionOpInterface entryPoint,
         }
 
         tileSizes.emplace_back(
-            std::move(workgroupTileSizes));  // Workgroup level.
+            std::move(workgroupTileSizes)); // Workgroup level.
         std::optional<int64_t> subgroupSize = std::nullopt;
-        if (!subgroupSizes.empty()) subgroupSize = subgroupSizes.front();
+        if (!subgroupSizes.empty())
+          subgroupSize = subgroupSizes.front();
 
         return setOpConfigAndEntryPointFnTranslation(
             entryPoint, op, tileSizes, pipeline, workgroupSize, subgroupSize,
@@ -823,7 +838,8 @@ static LogicalResult setContractConfig(mlir::FunctionOpInterface entryPoint,
   int64_t tileK = config.tileSize[2];
   // Since specialization doesn't work for K loop and peeling is not enabled yet
   // we pick a tileK size that is aligned on the K size.
-  if (ShapedType::isDynamic(sizeK)) tileK = 1;
+  if (ShapedType::isDynamic(sizeK))
+    tileK = 1;
   while (sizeK % tileK != 0) {
     tileK >>= 1;
   }
@@ -911,7 +927,7 @@ static LogicalResult setSortConfig(mlir::FunctionOpInterface entryPoint,
       break;
     }
   }
-  tileSizes.emplace_back(std::move(workgroupTileSizes));  // Workgroup level
+  tileSizes.emplace_back(std::move(workgroupTileSizes)); // Workgroup level
   return setOpConfigAndEntryPointFnTranslation(
       entryPoint, op, tileSizes,
       IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUDistribute,
@@ -922,8 +938,9 @@ static LogicalResult setSortConfig(mlir::FunctionOpInterface entryPoint,
 // Pack/Unpack Pipeline Configuration
 //====---------------------------------------------------------------------===//
 
-static SmallVector<int64_t> getDefaultWorkgroupTileSizesForPackUnPack(
-    TilingInterface op, int64_t defaultSize) {
+static SmallVector<int64_t>
+getDefaultWorkgroupTileSizesForPackUnPack(TilingInterface op,
+                                          int64_t defaultSize) {
   unsigned numLoops = op.getLoopIteratorTypes().size();
   auto partitionedLoops = cast<PartitionableLoopsInterface>(op.getOperation())
                               .getPartitionableLoops(kNumMaxParallelDims);
@@ -952,7 +969,8 @@ static LogicalResult setPackConfig(mlir::FunctionOpInterface entryPoint,
   SmallVector<int64_t> innerTiles = packOp.getStaticTiles();
   ArrayRef<int64_t> dimPos = packOp.getInnerDimsPos();
   for (auto [pos, size] : llvm::zip_equal(dimPos, innerTiles)) {
-    if (tileSizes[pos] == 0 || ShapedType::isDynamic(size)) continue;
+    if (tileSizes[pos] == 0 || ShapedType::isDynamic(size))
+      continue;
     tileSizes[pos] = tileSizes[pos] / size;
     tileSizes[pos] = std::max<int64_t>(tileSizes[pos], 1);
   }
@@ -1020,7 +1038,7 @@ static LogicalResult setRootDefaultConfig(mlir::FunctionOpInterface entryPoint,
              shape.back() % (workgroupSize[0] * vectorSize) != 0) {
         vectorSize /= 2;
       }
-      if (vectorSize == 1)  // assume there is fastpath + slowpath
+      if (vectorSize == 1) // assume there is fastpath + slowpath
         vectorSize = 4;
       int64_t problemSize = std::accumulate(
           shape.begin(), shape.end(), 1,
@@ -1038,7 +1056,8 @@ static LogicalResult setRootDefaultConfig(mlir::FunctionOpInterface entryPoint,
         int64_t id = 0;
         for (int64_t dim : llvm::reverse(shape)) {
           // Unit loops are already skipped.
-          if (dim == 1) continue;
+          if (dim == 1)
+            continue;
           if (dim < flatWG) {
             skipInnerTiling++;
             workgroupSize[id] = dim;
@@ -1048,7 +1067,8 @@ static LogicalResult setRootDefaultConfig(mlir::FunctionOpInterface entryPoint,
           }
           flatWG = flatWG / dim;
           id++;
-          if (flatWG <= 1 || id >= workgroupSize.size()) break;
+          if (flatWG <= 1 || id >= workgroupSize.size())
+            break;
         }
         break;
       }
@@ -1080,7 +1100,8 @@ static LogicalResult setRootDefaultConfig(mlir::FunctionOpInterface entryPoint,
         workgroupTileSizes[depth - 1] = 0;
         skipInnerTiling--;
         id++;
-        if (id >= workgroupSize.size()) break;
+        if (id >= workgroupSize.size())
+          break;
         continue;
       }
       workgroupTileSizes[depth - 1] = workgroupSize[id] * vectorSize;
@@ -1093,7 +1114,7 @@ static LogicalResult setRootDefaultConfig(mlir::FunctionOpInterface entryPoint,
     // is the most inner dimension.
     workgroupTileSizes.append(linalgOp.getNumReductionLoops(), 4);
   }
-  tileSizes.emplace_back(std::move(workgroupTileSizes));  // Workgroup level
+  tileSizes.emplace_back(std::move(workgroupTileSizes)); // Workgroup level
   return setOpConfigAndEntryPointFnTranslation(
       entryPoint, op, tileSizes, passPipeline, workgroupSize,
       targetInfo.supportedSubgroupSizes.front());
@@ -1104,9 +1125,9 @@ static LogicalResult setRootDefaultConfig(mlir::FunctionOpInterface entryPoint,
 //====---------------------------------------------------------------------===//
 
 /// Set configuration for transform dialect based strategies.
-static LogicalResult setTransformDialectConfig(
-    mlir::FunctionOpInterface entryPoint, Operation *op,
-    const TargetInfo &targetInfo) {
+static LogicalResult
+setTransformDialectConfig(mlir::FunctionOpInterface entryPoint, Operation *op,
+                          const TargetInfo &targetInfo) {
   if (!clGPUEnableTransformDialectJit) {
     return failure();
   }
@@ -1152,26 +1173,32 @@ static LogicalResult setTransformDialectConfig(
 }
 
 static bool isMatvecLike(linalg::LinalgOp linalgOp) {
-  if (linalgOp.getNumParallelLoops() != 2) return false;
+  if (linalgOp.getNumParallelLoops() != 2)
+    return false;
 
-  if (linalgOp.getNumReductionLoops() != 1) return false;
+  if (linalgOp.getNumReductionLoops() != 1)
+    return false;
 
   // TODO: Allow for matvec with fused dequantization.
   FailureOr<linalg::ContractionDimensions> dims =
       linalg::inferContractionDims(linalgOp);
-  if (failed(dims)) return false;
+  if (failed(dims))
+    return false;
 
   // TODO: Support batch matvec.
-  if (!dims->batch.empty()) return false;
+  if (!dims->batch.empty())
+    return false;
 
   for (ArrayRef indices : {dims->m, dims->n, dims->k}) {
-    if (!llvm::hasSingleElement(indices)) return false;
+    if (!llvm::hasSingleElement(indices))
+      return false;
   }
 
   // Check if the first parallel dimension has bound 1, indicating we found a
   // vector shape.
   SmallVector<int64_t, 4> bounds = linalgOp.getStaticLoopRanges();
-  if (bounds[dims->m.front()] != 1) return false;
+  if (bounds[dims->m.front()] != 1)
+    return false;
 
   return true;
 }
@@ -1181,10 +1208,11 @@ static bool isMatvecLike(linalg::LinalgOp linalgOp) {
 //====---------------------------------------------------------------------===//
 
 /// Set the configuration for reductions that can be mapped to warp reductions.
-static LogicalResult setWarpReductionConfig(
-    mlir::FunctionOpInterface entryPoint, linalg::LinalgOp op,
-    const TargetInfo &targetInfo) {
-  if (!targetInfo.hasWarpShuffle) return failure();
+static LogicalResult
+setWarpReductionConfig(mlir::FunctionOpInterface entryPoint,
+                       linalg::LinalgOp op, const TargetInfo &targetInfo) {
+  if (!targetInfo.hasWarpShuffle)
+    return failure();
 
   SmallVector<unsigned> parallelDims;
   SmallVector<unsigned> reductionDims;
@@ -1194,7 +1222,8 @@ static LogicalResult setWarpReductionConfig(
   SmallVector<int64_t, 4> bounds = op.getStaticLoopRanges();
   int64_t numParallelDims = op.getNumParallelLoops();
 
-  if (reductionDims.empty()) return failure();
+  if (reductionDims.empty())
+    return failure();
 
   // Make sure reduction dimensions are static and innermost ones.
   int64_t numDynamicReductionDims = 0;
@@ -1212,7 +1241,8 @@ static LogicalResult setWarpReductionConfig(
     return failure();
   }
 
-  if (op.getRegionOutputArgs().size() != 1) return failure();
+  if (op.getRegionOutputArgs().size() != 1)
+    return failure();
 
   // Only support projected permutation, this could be extended to projected
   // permutated with broadcast.
@@ -1227,14 +1257,16 @@ static LogicalResult setWarpReductionConfig(
     SmallVector<Operation *> combinerOps;
     if (matchReduction(op.getRegionOutputArgs(), index, combinerOps) &&
         combinerOps.size() == 1) {
-      if (foundSingleReductionOutput) return failure();
+      if (foundSingleReductionOutput)
+        return failure();
       foundSingleReductionOutput = true;
       continue;
     }
     if (!op.getMatchingIndexingMap(&initOpOperand).isIdentity())
       return failure();
   }
-  if (!foundSingleReductionOutput) return failure();
+  if (!foundSingleReductionOutput)
+    return failure();
 
   // Tile all the parallel dimension to 1.
   SmallVector<unsigned> partitionedLoops =
@@ -1250,8 +1282,8 @@ static LogicalResult setWarpReductionConfig(
     int64_t preferredSubgroupSize = targetInfo.supportedSubgroupSizes.front();
     reductionTileSizes[reductionDims[0]] = preferredSubgroupSize;
     TileSizesListType tileSizes;
-    tileSizes.emplace_back(std::move(workgroupTileSizes));  // Workgroup level
-    tileSizes.emplace_back(std::move(reductionTileSizes));  // Reduction level
+    tileSizes.emplace_back(std::move(workgroupTileSizes)); // Workgroup level
+    tileSizes.emplace_back(std::move(reductionTileSizes)); // Reduction level
     std::array<int64_t, 3> workgroupSize = {preferredSubgroupSize, 1, 1};
     if (failed(setOpConfigAndEntryPointFnTranslation(
             entryPoint, op, tileSizes,
@@ -1263,7 +1295,8 @@ static LogicalResult setWarpReductionConfig(
   }
 
   int64_t reductionSize = 1;
-  for (int64_t dim : reductionDims) reductionSize *= bounds[dim];
+  for (int64_t dim : reductionDims)
+    reductionSize *= bounds[dim];
 
   auto selectedSubgroupSizeIt = llvm::find_if(
       targetInfo.supportedSubgroupSizes, [reductionSize](int64_t subgroupSize) {
@@ -1276,14 +1309,17 @@ static LogicalResult setWarpReductionConfig(
   const Type elementType =
       llvm::cast<ShapedType>(op.getDpsInitOperand(0)->get().getType())
           .getElementType();
-  if (!elementType.isIntOrFloat()) return failure();
+  if (!elementType.isIntOrFloat())
+    return failure();
   unsigned bitWidth = elementType.getIntOrFloatBitWidth();
   // Reduction distribution only supports 8/16/32 bit types now.
-  if (bitWidth != 32 && bitWidth != 16 && bitWidth != 8) return failure();
+  if (bitWidth != 32 && bitWidth != 16 && bitWidth != 8)
+    return failure();
 
   const unsigned largestLoadSizeInBits = 128;
   unsigned vectorSize = largestLoadSizeInBits / bitWidth;
-  while ((reductionSize / vectorSize) % subgroupSize != 0) vectorSize /= 2;
+  while ((reductionSize / vectorSize) % subgroupSize != 0)
+    vectorSize /= 2;
 
   // Deduce the workgroup size we should use for reduction. Currently a
   // workgroup processes all elements in reduction dimensions. Need to make sure
@@ -1331,7 +1367,8 @@ static LogicalResult setWarpReductionConfig(
   // First, do warp reductions along multiple subgroups.
   // Second, reduce results from multiple subgroups using single warp reduce.
   // The final warp reduce requires subgroup count <= subgroup size to work.
-  if ((groupSize / subgroupSize) > subgroupSize) return failure();
+  if ((groupSize / subgroupSize) > subgroupSize)
+    return failure();
 
   // With just one subgroup per workgroup, make each subgroup do more work and
   // process a few reductions (rows) along the last parallel dimension.
@@ -1359,16 +1396,18 @@ static LogicalResult setWarpReductionConfig(
   for (int i = reductionDims.size() - 1; i >= 0; --i) {
     int64_t dim = reductionDims[i];
     int64_t bound = bounds[dim];
-    if (i == reductionDims.size() - 1) bound /= vectorSize;
+    if (i == reductionDims.size() - 1)
+      bound /= vectorSize;
     APInt size = llvm::APIntOps::GreatestCommonDivisor(
         {64, uint64_t(remainingGroupSize)}, {64, uint64_t(bound)});
     reductionTileSizes[dim] = size.getSExtValue();
-    if (i == reductionDims.size() - 1) reductionTileSizes[dim] *= vectorSize;
+    if (i == reductionDims.size() - 1)
+      reductionTileSizes[dim] *= vectorSize;
     remainingGroupSize /= size.getSExtValue();
   }
   TileSizesListType tileSizes;
-  tileSizes.emplace_back(std::move(workgroupTileSizes));  // Workgroup level
-  tileSizes.emplace_back(std::move(reductionTileSizes));  // Reduction level
+  tileSizes.emplace_back(std::move(workgroupTileSizes)); // Workgroup level
+  tileSizes.emplace_back(std::move(reductionTileSizes)); // Reduction level
   return setOpConfigAndEntryPointFnTranslation(
       entryPoint, op, tileSizes,
       IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUWarpReduction,
@@ -1447,9 +1486,9 @@ static LogicalResult setTransposeConfig(mlir::FunctionOpInterface entryPoint,
 /// Set the configuration for argmax that can be mapped to argmax uKernel.
 /// Distribute all parallel dim across different workgroups, and only use single
 /// subgroup per workgroup.
-static LogicalResult setArgmaxUkernelConfig(
-    mlir::FunctionOpInterface entryPoint, linalg::GenericOp op,
-    const TargetInfo &targetInfo) {
+static LogicalResult
+setArgmaxUkernelConfig(mlir::FunctionOpInterface entryPoint,
+                       linalg::GenericOp op, const TargetInfo &targetInfo) {
   // Checks if UKernels are enabled.
   if (auto variantOp =
           entryPoint->getParentOfType<IREE::HAL::ExecutableVariantOp>()) {
@@ -1461,16 +1500,19 @@ static LogicalResult setArgmaxUkernelConfig(
     }
   }
 
-  if (!targetInfo.hasWarpShuffle) return failure();
+  if (!targetInfo.hasWarpShuffle)
+    return failure();
 
-  if (failed(isArgmaxOp(op))) return failure();
+  if (failed(isArgmaxOp(op)))
+    return failure();
   SmallVector<unsigned> parallelDims;
   SmallVector<unsigned> reductionDims;
   op.getParallelDims(parallelDims);
   op.getReductionDims(reductionDims);
 
   // Currently Argmax UKernel only support 1 reduction dim.
-  if (reductionDims.size() != 1) return failure();
+  if (reductionDims.size() != 1)
+    return failure();
 
   // Make sure reduction dimensions are static and innermost ones.
   SmallVector<int64_t, 4> bounds = op.getStaticLoopRanges();
@@ -1505,8 +1547,8 @@ static LogicalResult setArgmaxUkernelConfig(
   int64_t preferredSubgroupSize = targetInfo.supportedSubgroupSizes.front();
   reductionTileSizes[reductionDims[0]] = preferredSubgroupSize;
   TileSizesListType tileSizes;
-  tileSizes.emplace_back(std::move(workgroupTileSizes));  // Workgroup level
-  tileSizes.emplace_back(std::move(reductionTileSizes));  // Reduction level
+  tileSizes.emplace_back(std::move(workgroupTileSizes)); // Workgroup level
+  tileSizes.emplace_back(std::move(reductionTileSizes)); // Reduction level
   std::array<int64_t, 3> workgroupSize = {preferredSubgroupSize, 1, 1};
   if (failed(setOpConfigAndEntryPointFnTranslation(
           entryPoint, op, tileSizes,
@@ -1518,9 +1560,9 @@ static LogicalResult setArgmaxUkernelConfig(
 }
 
 /// Make UKernels take the LLVMGPUDefault lowering pipeline.
-static LogicalResult setUKernelConfig(
-    mlir::FunctionOpInterface entryPoint,
-    IREE::Codegen::UKernelOpInterface ukernelOp) {
+static LogicalResult
+setUKernelConfig(mlir::FunctionOpInterface entryPoint,
+                 IREE::Codegen::UKernelOpInterface ukernelOp) {
   auto translationInfo = IREE::Codegen::TranslationInfoAttr::get(
       entryPoint->getContext(),
       IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUDefault);
@@ -1548,7 +1590,8 @@ static bool distributeToOneDim(const int64_t inputDim,
       // Handle 4 elements per thread for the innermost dimension. We need
       // this for vectorized load.
       chosenTileSize = 4;
-      if (inputDim % (dim * chosenTileSize) != 0) continue;
+      if (inputDim % (dim * chosenTileSize) != 0)
+        continue;
     } else {
       for (int64_t t = residualTilingFactor; t >= 1; t >>= 1)
         if (inputDim % (dim * t) == 0) {
@@ -1630,7 +1673,7 @@ static LogicalResult setConvolutionConfig(linalg::LinalgOp linalgOp,
   int64_t residualThreads = subgroupSize;
   int64_t residualTilingFactor = bestTilingFactor;
 
-  SmallVector<int64_t, 3> workgroupSize(3, 1);  // (X, Y, Z)
+  SmallVector<int64_t, 3> workgroupSize(3, 1); // (X, Y, Z)
   SmallVector<int64_t> workgroupTileSizes(4, 1);
 
   if (isNCHW) {
@@ -1757,7 +1800,8 @@ static void propagateLoweringConfig(Operation *rootOperation,
   if (IREE::Codegen::LoweringConfigAttr config =
           getLoweringConfig(rootOperation)) {
     for (auto op : computeOps) {
-      if (op == rootOperation) continue;
+      if (op == rootOperation)
+        continue;
       setLoweringConfig(op, config);
     }
   }
@@ -1777,7 +1821,8 @@ LogicalResult initGPULaunchConfig(ModuleOp moduleOp) {
 
   for (auto funcOp : moduleOp.getOps<mlir::FunctionOpInterface>()) {
     auto exportOp = exportOps.lookup(funcOp.getName());
-    if (!exportOp) continue;
+    if (!exportOp)
+      continue;
 
     if (!getTranslationInfo(funcOp)) {
       // If no translation info set, first check whether we already have
@@ -1853,11 +1898,12 @@ LogicalResult initGPULaunchConfig(ModuleOp moduleOp) {
       continue;
     }
 
-    if (failed(setRootConfig(funcOp, rootOperation))) continue;
+    if (failed(setRootConfig(funcOp, rootOperation)))
+      continue;
 
     propagateLoweringConfig(rootOperation, computeOps);
   }
   return success();
 }
 
-}  // namespace mlir::iree_compiler
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -80,7 +80,7 @@ struct TargetInfo {
   bool hasMmaSync = false;
   // These are listed in the order of preference, not necessarily monotonically.
   SmallVector<int64_t, 2> supportedSubgroupSizes = {32};
-  int64_t sharedMemoryLimit = 65536;
+  int64_t sharedMemoryLimitInBytes = 65536;
 };
 
 struct TileWorkgroupSizePair {
@@ -197,7 +197,7 @@ static TargetInfo getCudaTargetInfo(mlir::FunctionOpInterface entryPoint) {
   // All the cuda target are assumed to have warp support.
   info.hasWarpShuffle = true;
   info.supportedSubgroupSizes = {32};
-  info.sharedMemoryLimit = 163 * 1024;
+  info.sharedMemoryLimitInBytes = 163 * 1024;
   StringRef targetName = getTargetArch(entryPoint);
   // If no target name is set assume all the features are off.
   if (targetName == "")
@@ -223,7 +223,7 @@ static TargetInfo getCudaTargetInfo(mlir::FunctionOpInterface entryPoint) {
 static TargetInfo getRocmTargetInfo(mlir::FunctionOpInterface entryPoint) {
   TargetInfo info;
   StringRef targetName = getTargetArch(entryPoint);
-  info.sharedMemoryLimit = 65536;
+  info.sharedMemoryLimitInBytes = 65536;
   // If no target name is set assume all the features are off.
   if (targetName.empty())
     return info;
@@ -412,15 +412,16 @@ setConvolutionVectorDistributionConfig(mlir::FunctionOpInterface entryPoint,
                              /*bestMNTileCountPerSubgroup=*/8,
                              /*bestKTileCountPerSubgroup=*/2};
 
-  int64_t sharedMemoryLimit = targetInfo.sharedMemoryLimit;
+  int64_t sharedMemoryLimitInBytes = targetInfo.sharedMemoryLimitInBytes;
 
   // First try to find a schedule with an exactly matching intrinsic.
   FailureOr<GPUMMASchedule> schedule =
-      deduceMMASchedule(problem, intrinsics, seeds, sharedMemoryLimit);
+      deduceMMASchedule(problem, intrinsics, seeds, sharedMemoryLimitInBytes);
   if (failed(schedule)) {
     // Then try again by allowing upcasting accumulator.
-    schedule = deduceMMASchedule(problem, intrinsics, seeds, sharedMemoryLimit,
-                                 /*canUpcastAcc=*/true);
+    schedule =
+        deduceMMASchedule(problem, intrinsics, seeds, sharedMemoryLimitInBytes,
+                          /*canUpcastAcc=*/true);
   }
   if (failed(schedule)) {
     return failure();
@@ -562,15 +563,16 @@ setMatmulVectorDistributionConfig(mlir::FunctionOpInterface entryPoint,
              /*bestKTileCountPerSubgroup=*/4};
   }
 
-  int64_t sharedMemoryLimit = targetInfo.sharedMemoryLimit;
+  int64_t sharedMemoryLimitInBytes = targetInfo.sharedMemoryLimitInBytes;
 
   // First try to find a schedule with an exactly matching intrinsic.
   std::optional<GPUMMASchedule> schedule =
-      deduceMMASchedule(problem, intrinsics, seeds, sharedMemoryLimit);
+      deduceMMASchedule(problem, intrinsics, seeds, sharedMemoryLimitInBytes);
   if (!schedule) {
     // Then try again by allowing upcasting accumulator.
-    schedule = deduceMMASchedule(problem, intrinsics, seeds, sharedMemoryLimit,
-                                 /*canUpcastAcc=*/true);
+    schedule =
+        deduceMMASchedule(problem, intrinsics, seeds, sharedMemoryLimitInBytes,
+                          /*canUpcastAcc=*/true);
   }
   if (!schedule) {
     return failure();
@@ -1807,8 +1809,8 @@ static void propagateLoweringConfig(Operation *rootOperation,
   }
 }
 
-int64_t getTargetSharedMemoryLimit(FunctionOpInterface entryPoint) {
-  return getTargetInfo(entryPoint).sharedMemoryLimit;
+int64_t getTargetSharedMemoryLimitInBytes(FunctionOpInterface entryPoint) {
+  return getTargetInfo(entryPoint).sharedMemoryLimitInBytes;
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.h
@@ -8,10 +8,13 @@
 #define IREE_COMPILER_CODEGEN_LLVMGPU_KERNELCONFIG_H_
 
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
 
 namespace mlir::iree_compiler {
 
+int64_t getTargetSharedMemoryLimit(FunctionOpInterface entryPoint);
+
 LogicalResult initGPULaunchConfig(ModuleOp moduleOp);
 
-} // namespace mlir::iree_compiler
-#endif // IREE_COMPILER_CODEGEN_LLVMGPU_KERNELCONFIG_H_
+}  // namespace mlir::iree_compiler
+#endif  // IREE_COMPILER_CODEGEN_LLVMGPU_KERNELCONFIG_H_

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.h
@@ -16,5 +16,5 @@ int64_t getTargetSharedMemoryLimit(FunctionOpInterface entryPoint);
 
 LogicalResult initGPULaunchConfig(ModuleOp moduleOp);
 
-}  // namespace mlir::iree_compiler
-#endif  // IREE_COMPILER_CODEGEN_LLVMGPU_KERNELCONFIG_H_
+} // namespace mlir::iree_compiler
+#endif // IREE_COMPILER_CODEGEN_LLVMGPU_KERNELCONFIG_H_

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.h
@@ -12,9 +12,11 @@
 
 namespace mlir::iree_compiler {
 
+// TODO: Ideally, we should be setting the resource limits as an attribute in
+// the lowering configuration.
 int64_t getTargetSharedMemoryLimit(FunctionOpInterface entryPoint);
 
 LogicalResult initGPULaunchConfig(ModuleOp moduleOp);
 
-} // namespace mlir::iree_compiler
-#endif // IREE_COMPILER_CODEGEN_LLVMGPU_KERNELCONFIG_H_
+}  // namespace mlir::iree_compiler
+#endif  // IREE_COMPILER_CODEGEN_LLVMGPU_KERNELCONFIG_H_

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.h
@@ -14,7 +14,7 @@ namespace mlir::iree_compiler {
 
 // TODO: Ideally, we should be setting the resource limits as an attribute in
 // the lowering configuration.
-int64_t getTargetSharedMemoryLimit(FunctionOpInterface entryPoint);
+int64_t getTargetSharedMemoryLimitInBytes(FunctionOpInterface entryPoint);
 
 LogicalResult initGPULaunchConfig(ModuleOp moduleOp);
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.h
@@ -18,5 +18,5 @@ int64_t getTargetSharedMemoryLimit(FunctionOpInterface entryPoint);
 
 LogicalResult initGPULaunchConfig(ModuleOp moduleOp);
 
-}  // namespace mlir::iree_compiler
-#endif  // IREE_COMPILER_CODEGEN_LLVMGPU_KERNELCONFIG_H_
+} // namespace mlir::iree_compiler
+#endif // IREE_COMPILER_CODEGEN_LLVMGPU_KERNELCONFIG_H_

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -824,13 +824,13 @@ static void addLowerToLLVMGPUPasses(OpPassManager &pm, bool forROCDL) {
   addLowerAndOptimizeAddressComputationPasses(pm);
 
   // Run checks on shared memory usage.
-  auto getSharedMemoryLimit = [](mlir::FunctionOpInterface entryPoint) {
-    return getTargetSharedMemoryLimit(entryPoint);
+  auto getSharedMemoryLimitInBytes = [](mlir::FunctionOpInterface entryPoint) {
+    return getTargetSharedMemoryLimitInBytes(entryPoint);
   };
   // TODO: query this from the target.
   auto getIndexBitwidth = [](mlir::FunctionOpInterface) { return 64; };
-  pm.addPass(
-      createGPUCheckResourceUsagePass(getSharedMemoryLimit, getIndexBitwidth));
+  pm.addPass(createGPUCheckResourceUsagePass(getSharedMemoryLimitInBytes,
+                                             getIndexBitwidth));
 
   // SCF -> CF
   pm.addNestedPass<func::FuncOp>(createConvertSCFToCFPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -12,6 +12,7 @@
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/LLVMGPU/KernelConfig.h"
 #include "iree/compiler/Codegen/LLVMGPU/Passes.h"
 #include "iree/compiler/Codegen/LLVMGPU/ROCDLPasses.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
@@ -49,6 +50,7 @@ namespace mlir::iree_compiler {
 
 constexpr int64_t kDefaultSubgroupSize = 32;
 
+<<<<<<< HEAD
 static llvm::cl::opt<ReorderWorkgrupsStrategy> clReorderWorkgroupsStrategy(
     "iree-codegen-reorder-workgroups-strategy",
     llvm::cl::desc("Reorder workgroup IDs using the selected strategy"),
@@ -59,6 +61,11 @@ static llvm::cl::opt<ReorderWorkgrupsStrategy> clReorderWorkgroupsStrategy(
                      clEnumValN(ReorderWorkgrupsStrategy::Transpose,
                                 "transpose", "Transpose")),
     llvm::cl::init(ReorderWorkgrupsStrategy::None));
+=======
+static llvm::cl::opt<unsigned>
+    logSwizzleTile("iree-codegen-log-swizzle-tile",
+                   llvm::cl::desc("log swizzle tile value"), llvm::cl::init(0));
+>>>>>>> f0ce3eea5f (address comments and add shared memory limit)
 
 static llvm::cl::opt<unsigned> clReorderWorkgroupsLogSwizzleTile(
     "iree-codegen-reorder-workgroups-log-swizzle-tile",
@@ -824,9 +831,8 @@ static void addLowerToLLVMGPUPasses(OpPassManager &pm, bool forROCDL) {
 
   // Run checks on shared memory usage.
   // TODO: query this from the target.
-  int64_t limit = clLLVMGPUSharedMemoryLimit;
-  auto getSharedMemoryLimit = [limit](mlir::FunctionOpInterface) {
-    return limit;
+  auto getSharedMemoryLimit = [](mlir::FunctionOpInterface entryPoint) {
+    return getTargetSharedMemoryLimit(entryPoint);
   };
   auto getIndexBitwidth = [](mlir::FunctionOpInterface) { return 64; };
   pm.addPass(

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -824,10 +824,10 @@ static void addLowerToLLVMGPUPasses(OpPassManager &pm, bool forROCDL) {
   addLowerAndOptimizeAddressComputationPasses(pm);
 
   // Run checks on shared memory usage.
-  // TODO: query this from the target.
   auto getSharedMemoryLimit = [](mlir::FunctionOpInterface entryPoint) {
     return getTargetSharedMemoryLimit(entryPoint);
   };
+  // TODO: query this from the target.
   auto getIndexBitwidth = [](mlir::FunctionOpInterface) { return 64; };
   pm.addPass(
       createGPUCheckResourceUsagePass(getSharedMemoryLimit, getIndexBitwidth));

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -50,7 +50,6 @@ namespace mlir::iree_compiler {
 
 constexpr int64_t kDefaultSubgroupSize = 32;
 
-<<<<<<< HEAD
 static llvm::cl::opt<ReorderWorkgrupsStrategy> clReorderWorkgroupsStrategy(
     "iree-codegen-reorder-workgroups-strategy",
     llvm::cl::desc("Reorder workgroup IDs using the selected strategy"),
@@ -61,11 +60,6 @@ static llvm::cl::opt<ReorderWorkgrupsStrategy> clReorderWorkgroupsStrategy(
                      clEnumValN(ReorderWorkgrupsStrategy::Transpose,
                                 "transpose", "Transpose")),
     llvm::cl::init(ReorderWorkgrupsStrategy::None));
-=======
-static llvm::cl::opt<unsigned>
-    logSwizzleTile("iree-codegen-log-swizzle-tile",
-                   llvm::cl::desc("log swizzle tile value"), llvm::cl::init(0));
->>>>>>> f0ce3eea5f (address comments and add shared memory limit)
 
 static llvm::cl::opt<unsigned> clReorderWorkgroupsLogSwizzleTile(
     "iree-codegen-reorder-workgroups-log-swizzle-tile",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
@@ -71,6 +71,7 @@ iree_lit_test_suite(
             "ukernel_pipeline_transform.mlir",
             "vector_distribute_conversion.mlir",
             "vector_distribute_layout.mlir",
+            "vector_distribution_pipeline_test.mlir",
             "vector_lowering.mlir",
             "vector_to_gpu.mlir",
             "workgroup_specialization_pipeline_test.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -67,6 +67,7 @@ iree_lit_test_suite(
     "ukernel_pipeline_transform.mlir"
     "vector_distribute_conversion.mlir"
     "vector_distribute_layout.mlir"
+    "vector_distribution_pipeline_test.mlir"
     "vector_lowering.mlir"
     "vector_to_gpu.mlir"
     "workgroup_specialization_pipeline_test.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_distribution_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_distribution_pipeline_test.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-opt --split-input-file \ 
-// RUN: --iree-codegen-llvmgpu-use-vector-distribution '--pass-pipeline=builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-select-lowering-strategy, iree-llvmgpu-lower-executable-target, canonicalize)))'
+// RUN: --iree-codegen-llvmgpu-use-vector-distribution '--pass-pipeline=builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-select-lowering-strategy, iree-llvmgpu-lower-executable-target, canonicalize)))' %s | FileCheck %s
 
 hal.executable @fit_shared_memory_schedule {
 hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb", {mma_intrinsics = [#iree_gpu.mfma_layout<F16_16x16x16_F32>, #iree_gpu.mfma_layout<F16_32x32x8_F32>], target_arch = "gfx942", ukernels = "none"}>) {
@@ -27,3 +27,5 @@ hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb", {m
     }
   }
 }}
+
+// CHECK-LABEL: .executable.export public @fit_shared_memory_schedule

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_distribution_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_distribution_pipeline_test.mlir
@@ -1,11 +1,14 @@
-// RUN: iree-opt --split-input-file \ 
-// RUN: --iree-codegen-llvmgpu-use-vector-distribution '--pass-pipeline=builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-select-lowering-strategy, iree-llvmgpu-lower-executable-target, canonicalize)))' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-codegen-llvmgpu-use-vector-distribution \
+// RUN:   --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-select-lowering-strategy, iree-llvmgpu-lower-executable-target, canonicalize)))' \
+// RUN:   %s | FileCheck %s
 
 hal.executable @fit_shared_memory_schedule {
-hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb", {mma_intrinsics = [#iree_gpu.mfma_layout<F16_16x16x16_F32>, #iree_gpu.mfma_layout<F16_32x32x8_F32>], target_arch = "gfx942", ukernels = "none"}>) {
+hal.executable.variant public @rocm_hsaco_fb
+  target(<"rocm", "rocm-hsaco-fb", {mma_intrinsics = [#iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>, #iree_gpu.mma_layout<MFMA_F16_32x32x8_F32>],
+                                    target_arch = "gfx942", ukernels = "none"}>) {
   hal.executable.export public @fit_shared_memory_schedule ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) attributes {hal.interface.bindings = [#hal.interface.binding<0, 0>, #hal.interface.binding<0, 1>, #hal.interface.binding<0, 2>]} {
   ^bb0(%arg0: !hal.device):
-    %x, %y, %z = flow.dispatch.workgroup_count_from_slice 
+    %x, %y, %z = flow.dispatch.workgroup_count_from_slice
     hal.return %x, %y, %z : index, index, index
   }
   builtin.module {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_distribution_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_distribution_pipeline_test.mlir
@@ -1,0 +1,29 @@
+// RUN: iree-opt --split-input-file \ 
+// RUN: --iree-codegen-llvmgpu-use-vector-distribution '--pass-pipeline=builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-select-lowering-strategy, iree-llvmgpu-lower-executable-target, canonicalize)))'
+
+hal.executable @fit_shared_memory_schedule {
+hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb", {mma_intrinsics = [#iree_gpu.mfma_layout<F16_16x16x16_F32>, #iree_gpu.mfma_layout<F16_32x32x8_F32>], target_arch = "gfx942", ukernels = "none"}>) {
+  hal.executable.export public @fit_shared_memory_schedule ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) attributes {hal.interface.bindings = [#hal.interface.binding<0, 0>, #hal.interface.binding<0, 1>, #hal.interface.binding<0, 2>]} {
+  ^bb0(%arg0: !hal.device):
+    %x, %y, %z = flow.dispatch.workgroup_count_from_slice 
+    hal.return %x, %y, %z : index, index, index
+  }
+  builtin.module {
+    func.func @fit_shared_memory_schedule() {
+      %cst = arith.constant 0.000000e+00 : f32
+      %c129181184 = arith.constant 129181184 : index
+      %c18112 = arith.constant 18112 : index
+      %c100980224 = arith.constant 100980224 : index
+      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c129181184) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<64x80x1280xf16>>
+      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c18112) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<64x1280x1280xf16>>
+      %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c100980224) : !flow.dispatch.tensor<writeonly:tensor<64x80x1280xf32>>
+      %3 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [64, 80, 1280], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<64x80x1280xf16>> -> tensor<64x80x1280xf16>
+      %4 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [64, 1280, 1280], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<64x1280x1280xf16>> -> tensor<64x1280x1280xf16>
+      %5 = tensor.empty() : tensor<64x80x1280xf32>
+      %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<64x80x1280xf32>) -> tensor<64x80x1280xf32>
+      %7 = linalg.batch_matmul ins(%3, %4 : tensor<64x80x1280xf16>, tensor<64x1280x1280xf16>) outs(%6 : tensor<64x80x1280xf32>) -> tensor<64x80x1280xf32>
+      flow.dispatch.tensor.store %7, %2, offsets = [0, 0, 0], sizes = [64, 80, 1280], strides = [1, 1, 1] : tensor<64x80x1280xf32> -> !flow.dispatch.tensor<writeonly:tensor<64x80x1280xf32>>
+      return
+    }
+  }
+}}

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -909,8 +909,11 @@ LogicalResult setCooperativeMatrixConfig(
   GPUMMAHeuristicSeeds seeds{numSubgroupsPerWorkgroup, numMNTilesPerSubgroup,
                              numKTilesPerSubgroup};
 
+  int64_t sharedMemoryLimit =
+      targetEnv.getResourceLimits().getMaxComputeSharedMemorySize();
+
   std::optional<GPUMMASchedule> schedule =
-      deduceMMASchedule(problem, intrinsics, seeds);
+      deduceMMASchedule(problem, intrinsics, seeds, sharedMemoryLimit);
   if (!schedule)
     return failure();
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -909,11 +909,11 @@ LogicalResult setCooperativeMatrixConfig(
   GPUMMAHeuristicSeeds seeds{numSubgroupsPerWorkgroup, numMNTilesPerSubgroup,
                              numKTilesPerSubgroup};
 
-  int64_t sharedMemoryLimit =
+  int64_t sharedMemoryLimitInBytes =
       targetEnv.getResourceLimits().getMaxComputeSharedMemorySize();
 
   FailureOr<GPUMMASchedule> schedule =
-      deduceMMASchedule(problem, intrinsics, seeds, sharedMemoryLimit);
+      deduceMMASchedule(problem, intrinsics, seeds, sharedMemoryLimitInBytes);
   if (failed(schedule))
     return failure();
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -60,8 +60,7 @@ using CodeGenPipeline = IREE::Codegen::DispatchLoweringPassPipeline;
 // Check if the given linalg op is fused with another op that may result
 // in too much shared memory usage.
 static bool fusedOpMayUseExtraSharedMemory(linalg::LinalgOp matmul) {
-  if (matmul->getNumResults() != 1)
-    return true;
+  if (matmul->getNumResults() != 1) return true;
 
   auto entryPoint = matmul->getParentOfType<mlir::FunctionOpInterface>();
 
@@ -111,8 +110,7 @@ static bool tileConvOneDim(const int64_t inputDim, const bool isInnerMostDim,
       // Handle `vectorSize` elements per thread for the innermost dimension.
       // We need this for the best utilization of memory.
       chosenTileSize = vectorSize;
-      if (inputDim % (dim * chosenTileSize) != 0)
-        continue;
+      if (inputDim % (dim * chosenTileSize) != 0) continue;
     } else {
       for (int64_t t = residualTilingFactor; t >= 1; t >>= 1)
         if (inputDim % (dim * t) == 0) {
@@ -174,12 +172,10 @@ LogicalResult setConvOpConfig(linalg::LinalgOp linalgOp,
   // Restrict to pure 4-D input/output shapes for now. This excludes convolution
   // ops with 1- or 3-D window sizes. It also excludes 2-D-window convolution
   // ops like `linalg.depthwise_conv_2d_nhwc_hwcm`.
-  if (inputShape.size() != 4 || outputShape.size() != 4)
-    return failure();
+  if (inputShape.size() != 4 || outputShape.size() != 4) return failure();
 
   auto convDimsOrFailure = linalg::inferConvolutionDims(linalgOp);
-  if (failed(convDimsOrFailure))
-    return failure();
+  if (failed(convDimsOrFailure)) return failure();
   const mlir::linalg::ConvolutionDimensions &convDims = *convDimsOrFailure;
   LLVM_DEBUG({
     llvm::dbgs() << "conv: " << linalgOp;
@@ -241,8 +237,7 @@ LogicalResult setConvOpConfig(linalg::LinalgOp linalgOp,
 
   // We use `vectorSize` as the tile size along IC dimension. If smaller than
   // 4, it will be unrolled into size 1.
-  if (ic && !(*ic % vectorSize == 0 || *ic < 4))
-    return failure();
+  if (ic && !(*ic % vectorSize == 0 || *ic < 4)) return failure();
 
   // The core idea is to distribute the convolution dimensions to the workgroup
   // Z/Y/X dimensions, with each thread in a workgroup handling multiple vector
@@ -252,7 +247,7 @@ LogicalResult setConvOpConfig(linalg::LinalgOp linalgOp,
   int64_t residualThreads = subgroupSize;
   int64_t residualTilingFactor = bestTilingFactor;
 
-  SmallVector<int64_t, 3> workgroupSize(3, 1); // (X, Y, Z)
+  SmallVector<int64_t, 3> workgroupSize(3, 1);  // (X, Y, Z)
   SmallVector<int64_t> workgroupTileSizes(4, 0);
 
   const bool isNCHW = ocIndex < ohIndex;
@@ -299,7 +294,7 @@ LogicalResult setConvOpConfig(linalg::LinalgOp linalgOp,
   }
 
   SmallVector<int64_t> threadTileSizes(4, 0);
-  threadTileSizes[0] = 1; // Tile along the N dimension with size 1
+  threadTileSizes[0] = 1;  // Tile along the N dimension with size 1
   for (int i = 1; i <= 3; ++i) {
     threadTileSizes[i] = workgroupTileSizes[i] / workgroupSize[3 - i];
   }
@@ -332,7 +327,7 @@ LogicalResult setConvOpConfig(linalg::LinalgOp linalgOp,
                                                pipeline, workgroupSize);
 }
 
-} // namespace detail
+}  // namespace detail
 
 //===----------------------------------------------------------------------===//
 // Matmul Default Configuration
@@ -348,14 +343,12 @@ std::tuple<int, int, int, int> getMatmulBMNKIndex(linalg::LinalgOp op,
   auto lhsShape = llvm::cast<ShapedType>(lhs->get().getType()).getShape();
   auto rhsShape = llvm::cast<ShapedType>(rhs->get().getType()).getShape();
 
-  auto lhsLoopIndices =
-      llvm::map_to_vector(llvm::seq<int>(0, lhsShape.size()), [&](int i) {
-        return op.getMatchingIndexingMap(lhs).getDimPosition(i);
-      });
-  auto rhsLoopIndices =
-      llvm::map_to_vector(llvm::seq<int>(0, rhsShape.size()), [&](int i) {
-        return op.getMatchingIndexingMap(rhs).getDimPosition(i);
-      });
+  auto lhsLoopIndices = llvm::map_to_vector(
+      llvm::seq<int>(0, lhsShape.size()),
+      [&](int i) { return op.getMatchingIndexingMap(lhs).getDimPosition(i); });
+  auto rhsLoopIndices = llvm::map_to_vector(
+      llvm::seq<int>(0, rhsShape.size()),
+      [&](int i) { return op.getMatchingIndexingMap(rhs).getDimPosition(i); });
 
   // Figure out what dimension each loop corresponds to.
   int bIndex = -1, mIndex = -1, nIndex = -1, kIndex = -1;
@@ -372,18 +365,15 @@ std::tuple<int, int, int, int> getMatmulBMNKIndex(linalg::LinalgOp op,
     } else if (inLHS) {
       // For cases where we have two parallel dimensions only accessed by
       // the LHS, treat the outer one of them as the batch dimension.
-      if (mIndex >= 0 && bIndex < 0)
-        bIndex = mIndex;
+      if (mIndex >= 0 && bIndex < 0) bIndex = mIndex;
       mIndex = i;
     } else if (inRHS) {
       // For cases where we have two parallel dimensions only accessed by
       // the RHS, treat the outer one of them as the batch dimension.
-      if (nIndex >= 0 && bIndex < 0)
-        bIndex = nIndex;
+      if (nIndex >= 0 && bIndex < 0) bIndex = nIndex;
       nIndex = i;
     }
-    if (lastParallelDim)
-      *lastParallelDim = i;
+    if (lastParallelDim) *lastParallelDim = i;
   }
 
   LLVM_DEBUG({
@@ -469,15 +459,13 @@ int64_t getTileBytes(int64_t mTileSize, int64_t nTileSize, int64_t kTileSize,
                      int64_t elementBits, bool promoteC) {
   int64_t paddingBits = detail::bankConflictReductionPaddingBits / elementBits;
   int64_t count = (mTileSize + nTileSize) * (kTileSize + paddingBits);
-  if (promoteC)
-    count += mTileSize * (nTileSize + paddingBits);
+  if (promoteC) count += mTileSize * (nTileSize + paddingBits);
   return (elementBits / 8) * count;
 }
 
 int64_t getMultiBufferMemoryUsage(int64_t singleBufferBytes, unsigned depth,
                                   unsigned storeStage) {
-  if (depth == 0)
-    return singleBufferBytes;
+  if (depth == 0) return singleBufferBytes;
   return singleBufferBytes * (storeStage == 1 ? depth : depth + 1);
 };
 
@@ -489,8 +477,7 @@ static bool adjustToVectorLoad(ArrayRef<int64_t> dimMNKSize, int64_t &mTileSize,
                                const int64_t subgroupSize, int64_t vectorSize) {
   const int64_t totalThreads = wgSize[0] * wgSize[1] * wgSize[2];
   LLVM_DEBUG(llvm::dbgs() << "initial total thread = " << totalThreads << "\n");
-  if (totalThreads <= subgroupSize)
-    return false;
+  if (totalThreads <= subgroupSize) return false;
 
   const bool canVectorLoadLHS = canPerformVectorAccessUsingAllThreads(
       {mTileSize, kTileSize}, totalThreads, vectorSize);
@@ -500,8 +487,7 @@ static bool adjustToVectorLoad(ArrayRef<int64_t> dimMNKSize, int64_t &mTileSize,
   LLVM_DEBUG(llvm::dbgs() << "RHS vector load: " << canVectorLoadRHS << "\n");
 
   // If we can perform vector load of neither, just don't use shared memory.
-  if (!canVectorLoadLHS && !canVectorLoadRHS)
-    return false;
+  if (!canVectorLoadLHS && !canVectorLoadRHS) return false;
 
   // If we can only perform vector load of one operands, adjust the tiling
   // scheme to see if we can make both work. Increase K to load more data for
@@ -509,15 +495,12 @@ static bool adjustToVectorLoad(ArrayRef<int64_t> dimMNKSize, int64_t &mTileSize,
   if (canVectorLoadLHS && !canVectorLoadRHS) {
     for (const int scale : {2, 4}) {
       const int64_t newKTileSize = kTileSize * scale;
-      if (dimMNKSize[2] % newKTileSize != 0)
-        continue;
+      if (dimMNKSize[2] % newKTileSize != 0) continue;
       const int64_t newMTileSize = mTileSize / scale;
       const int64_t newWgMDim = wgSize[1] / scale;
-      if (newMTileSize == 0 || newWgMDim == 0)
-        continue;
+      if (newMTileSize == 0 || newWgMDim == 0) continue;
       const int64_t newCount = wgSize[0] * newWgMDim * wgSize[2];
-      if (newCount <= subgroupSize)
-        continue;
+      if (newCount <= subgroupSize) continue;
       if (!canPerformVectorAccessUsingAllThreads({newMTileSize, newKTileSize},
                                                  newCount, vectorSize) ||
           !canPerformVectorAccessUsingAllThreads({newKTileSize, nTileSize},
@@ -619,23 +602,19 @@ LogicalResult setMatmulOpConfig(spirv::ResourceLimitsAttr limits,
   auto rhsType = llvm::cast<ShapedType>(rhs->get().getType());
   auto elementBits =
       static_cast<int>(IREE::Util::getTypeBitWidth(lhsType.getElementType()));
-  if (!llvm::is_contained({8, 16, 32}, elementBits))
-    return failure();
+  if (!llvm::is_contained({8, 16, 32}, elementBits)) return failure();
 
   ArrayRef<int64_t> lhsShape = lhsType.getShape();
   ArrayRef<int64_t> rhsShape = rhsType.getShape();
-  if (llvm::any_of(lhsShape, ShapedType::isDynamic))
-    return failure();
-  if (llvm::any_of(rhsShape, ShapedType::isDynamic))
-    return failure();
+  if (llvm::any_of(lhsShape, ShapedType::isDynamic)) return failure();
+  if (llvm::any_of(rhsShape, ShapedType::isDynamic)) return failure();
 
   assert(llvm::is_contained({2u, 3u}, op.getNumParallelLoops()));
 
   int lastParallelDim = -1;
   const auto [bIndex, mIndex, nIndex, kIndex] =
       getMatmulBMNKIndex(op, &lastParallelDim);
-  if (mIndex < 0 || nIndex < 0 || kIndex < 0)
-    return failure();
+  if (mIndex < 0 || nIndex < 0 || kIndex < 0) return failure();
   const bool isBM = bIndex >= 0;
 
   SmallVector<int64_t> loopRanges = op.getStaticLoopRanges();
@@ -675,12 +654,11 @@ LogicalResult setMatmulOpConfig(spirv::ResourceLimitsAttr limits,
   int64_t residualThreads = bestX * bestY;
   int64_t residualTilingFactor = (bestThreadM + bestThreadK) * bestThreadN;
 
-  SmallVector<int64_t, 3> workgroupSize(3, 1); // (X, Y, Z)
+  SmallVector<int64_t, 3> workgroupSize(3, 1);  // (X, Y, Z)
   SmallVector<int64_t> workgroupTileSizes(numLoops, 0);
   SmallVector<int64_t> reductionTileSizes(numLoops, 0);
 
-  if (isBM)
-    workgroupTileSizes[bIndex] = 1;
+  if (isBM) workgroupTileSizes[bIndex] = 1;
 
   if (!tileMatmulNToWorkgroupX(dimN, bestThreadN, residualThreads, bestX,
                                residualTilingFactor, workgroupSize[0],
@@ -777,15 +755,14 @@ LogicalResult setMatmulOpConfig(spirv::ResourceLimitsAttr limits,
       CodeGenPipeline::SPIRVBaseVectorize, workgroupSize);
 }
 
-} // namespace detail
+}  // namespace detail
 
 //===----------------------------------------------------------------------===//
 // Cooperative Matrix Default Configuration
 //===----------------------------------------------------------------------===//
 
 bool isCooperativeMatrixFusable(linalg::GenericOp genericOp) {
-  if (genericOp.getNumLoops() != genericOp.getNumParallelLoops())
-    return false;
+  if (genericOp.getNumLoops() != genericOp.getNumParallelLoops()) return false;
 
   // Look at fused elementwise ops to make sure they are allowed by the
   // cooperative matrix spec.
@@ -808,8 +785,7 @@ bool isCooperativeMatrixFusable(linalg::GenericOp genericOp) {
   // classes.
   for (Value input : genericOp.getInputs()) {
     if (llvm::isa<TensorType>(input.getType())) {
-      if (matchPattern(input, m_Constant()))
-        return false;
+      if (matchPattern(input, m_Constant())) return false;
       continue;
     }
 
@@ -819,8 +795,7 @@ bool isCooperativeMatrixFusable(linalg::GenericOp genericOp) {
       input = subviewOp.getViewSource();
     }
     if (auto toMemrefOp = input.getDefiningOp<bufferization::ToMemrefOp>()) {
-      if (matchPattern(toMemrefOp.getTensor(), m_Constant()))
-        return false;
+      if (matchPattern(toMemrefOp.getTensor(), m_Constant())) return false;
     }
   }
 
@@ -830,15 +805,13 @@ bool isCooperativeMatrixFusable(linalg::GenericOp genericOp) {
 bool needToPrmoteCForCooperativeMatrix(linalg::LinalgOp matmulOp) {
   assert(matmulOp.hasPureTensorSemantics());
   Value result = matmulOp.getOperation()->getResult(0);
-  if (!result.hasOneUse())
-    return true; // Be conservative.
+  if (!result.hasOneUse()) return true;  // Be conservative.
   Operation *user = *result.getUsers().begin();
-  if (isa<IREE::Flow::DispatchTensorStoreOp>(user))
-    return false;
+  if (isa<IREE::Flow::DispatchTensorStoreOp>(user)) return false;
   if (auto genericOp = dyn_cast<linalg::GenericOp>(user)) {
     return !isCooperativeMatrixFusable(genericOp);
   }
-  return true; // Be conservative.
+  return true;  // Be conservative.
 }
 
 namespace detail {
@@ -855,8 +828,7 @@ LogicalResult setCooperativeMatrixConfig(
     return failure();
   }
 
-  if (op.hasDynamicShape())
-    return failure();
+  if (op.hasDynamicShape()) return failure();
 
   Value lhs = op.getDpsInputOperand(0)->get();
   Value rhs = op.getDpsInputOperand(1)->get();
@@ -865,8 +837,7 @@ LogicalResult setCooperativeMatrixConfig(
   int lastParallelDim = -1;
   const auto [bIndex, mIndex, nIndex, kIndex] =
       getMatmulBMNKIndex(op, &lastParallelDim);
-  if (mIndex < 0 || nIndex < 0 || kIndex < 0)
-    return failure();
+  if (mIndex < 0 || nIndex < 0 || kIndex < 0) return failure();
   const bool isBM = bIndex >= 0;
 
   SmallVector<int64_t> loopRanges = op.getStaticLoopRanges();
@@ -912,10 +883,9 @@ LogicalResult setCooperativeMatrixConfig(
   int64_t sharedMemoryLimit =
       targetEnv.getResourceLimits().getMaxComputeSharedMemorySize();
 
-  std::optional<GPUMMASchedule> schedule =
+  FailureOr<GPUMMASchedule> schedule =
       deduceMMASchedule(problem, intrinsics, seeds, sharedMemoryLimit);
-  if (!schedule)
-    return failure();
+  if (failed(schedule)) return failure();
 
   auto pipeline = CodeGenPipeline::SPIRVCooperativeMatrixVectorize;
 
@@ -931,21 +901,18 @@ LogicalResult setCooperativeMatrixConfig(
                                        schedule->mWarpCount, 1};
 
   SmallVector<int64_t> vectorSizes(kIndex + 1, 0);
-  if (isBM)
-    vectorSizes[bIndex] = 1;
+  if (isBM) vectorSizes[bIndex] = 1;
   vectorSizes[mIndex] = schedule->mSize;
   vectorSizes[nIndex] = schedule->nSize;
   vectorSizes[kIndex] = schedule->kSize;
 
   SmallVector<int64_t> subgroupTileSizes(lastParallelDim + 1, 0);
-  if (isBM)
-    subgroupTileSizes[bIndex] = 1;
+  if (isBM) subgroupTileSizes[bIndex] = 1;
   subgroupTileSizes[mIndex] = schedule->mTileCount * vectorSizes[mIndex];
   subgroupTileSizes[nIndex] = schedule->nTileCount * vectorSizes[nIndex];
 
   SmallVector<int64_t> workgroupTileSizes(lastParallelDim + 1, 0);
-  if (isBM)
-    workgroupTileSizes[bIndex] = 1;
+  if (isBM) workgroupTileSizes[bIndex] = 1;
   workgroupTileSizes[mIndex] = schedule->mWarpCount * subgroupTileSizes[mIndex];
   workgroupTileSizes[nIndex] = schedule->nWarpCount * subgroupTileSizes[nIndex];
 
@@ -990,7 +957,7 @@ LogicalResult setCooperativeMatrixConfig(
                                     storeStage));
 }
 
-} // namespace detail
+}  // namespace detail
 
 //===----------------------------------------------------------------------===//
 // FFT Default Configuration
@@ -1072,8 +1039,7 @@ static LogicalResult setReductionConfig(const spirv::TargetEnv &targetEnv,
   int64_t numParallelDims = op.getNumParallelLoops();
 
   // We should have reduction dimensions.
-  if (reductionDims.empty())
-    return failure();
+  if (reductionDims.empty()) return failure();
 
   // Make sure reduction dimensions are static and innermost ones.
   int64_t numDynamicReductionDims = 0;
@@ -1092,8 +1058,7 @@ static LogicalResult setReductionConfig(const spirv::TargetEnv &targetEnv,
     return failure();
   }
 
-  if (op.getRegionOutputArgs().size() != 1)
-    return failure();
+  if (op.getRegionOutputArgs().size() != 1) return failure();
 
   // Only support projected permutation for now. This could be extended to
   // projected permutated with broadcast.
@@ -1109,8 +1074,7 @@ static LogicalResult setReductionConfig(const spirv::TargetEnv &targetEnv,
     SmallVector<Operation *> combinerOps;
     if (matchReduction(op.getRegionOutputArgs(), i, combinerOps) &&
         combinerOps.size() == 1) {
-      if (foundSingleReductionOutput)
-        return failure();
+      if (foundSingleReductionOutput) return failure();
       foundSingleReductionOutput = true;
       continue;
     }
@@ -1118,8 +1082,7 @@ static LogicalResult setReductionConfig(const spirv::TargetEnv &targetEnv,
       return failure();
     }
   }
-  if (!foundSingleReductionOutput)
-    return failure();
+  if (!foundSingleReductionOutput) return failure();
 
   const int subgroupSize = targetEnv.getResourceLimits().getSubgroupSize();
 
@@ -1138,8 +1101,8 @@ static LogicalResult setReductionConfig(const spirv::TargetEnv &targetEnv,
     SmallVector<int64_t> reductionTileSizes(op.getNumLoops(), 0);
     reductionTileSizes[reductionDims[0]] = subgroupSize;
     TileSizesListType tileSizes;
-    tileSizes.emplace_back(std::move(workgroupTileSizes)); // Workgroup level
-    tileSizes.emplace_back(std::move(reductionTileSizes)); // Reduction level
+    tileSizes.emplace_back(std::move(workgroupTileSizes));  // Workgroup level
+    tileSizes.emplace_back(std::move(reductionTileSizes));  // Reduction level
     std::array<int64_t, 3> workgroupSize = {subgroupSize, 1, 1};
     if (failed(setOpConfigAndEntryPointFnTranslation(
             op->getParentOfType<mlir::FunctionOpInterface>(), op, tileSizes,
@@ -1157,24 +1120,19 @@ static LogicalResult setReductionConfig(const spirv::TargetEnv &targetEnv,
   }
 
   int64_t reductionSize = 1;
-  for (int64_t dim : reductionDims)
-    reductionSize *= bounds[dim];
-  if (reductionSize % subgroupSize != 0)
-    return failure();
+  for (int64_t dim : reductionDims) reductionSize *= bounds[dim];
+  if (reductionSize % subgroupSize != 0) return failure();
 
   const Type elementType =
       llvm::cast<ShapedType>(op.getDpsInits()[0].getType()).getElementType();
-  if (!elementType.isIntOrFloat())
-    return failure();
+  if (!elementType.isIntOrFloat()) return failure();
   unsigned bitWidth = IREE::Util::getTypeBitWidth(elementType);
   // Reduction distribution only supports 8/16/32 bit types now.
-  if (bitWidth != 32 && bitWidth != 16 && bitWidth != 8)
-    return failure();
+  if (bitWidth != 32 && bitWidth != 16 && bitWidth != 8) return failure();
 
   // Let each thread handle `vectorSize` elements.
   unsigned vectorSize = kMaxVectorNumBits / bitWidth;
-  while ((reductionSize / vectorSize) % subgroupSize != 0)
-    vectorSize /= 2;
+  while ((reductionSize / vectorSize) % subgroupSize != 0) vectorSize /= 2;
 
   // Deduce the workgroup size we should use for reduction. Currently a
   // workgroup processes all elements in reduction dimensions. Need to make sure
@@ -1199,8 +1157,7 @@ static LogicalResult setReductionConfig(const spirv::TargetEnv &targetEnv,
 
   int64_t parallelSize = 1;
   for (int64_t dim : parallelDims) {
-    if (!ShapedType::isDynamic(bounds[dim]))
-      parallelSize *= bounds[dim];
+    if (!ShapedType::isDynamic(bounds[dim])) parallelSize *= bounds[dim];
   }
   // Total parallel size that can fill the GPU with enough workgorups.
   // TODO: query from the target device; roughly 2x hardware compute unit.
@@ -1220,8 +1177,7 @@ static LogicalResult setReductionConfig(const spirv::TargetEnv &targetEnv,
   // First, do warp reductions along multiple subgroups.
   // Second, reduce results from multiple subgroups using single warp reduce.
   // The final warp reduce requires subgroup count <= subgroup size to work.
-  if ((groupSize / subgroupSize) > subgroupSize)
-    return failure();
+  if ((groupSize / subgroupSize) > subgroupSize) return failure();
 
   std::array<int64_t, 3> workgroupSize = {groupSize, 1, 1};
 
@@ -1230,19 +1186,17 @@ static LogicalResult setReductionConfig(const spirv::TargetEnv &targetEnv,
   for (int i = reductionDims.size() - 1; i >= 0; --i) {
     int64_t dim = reductionDims[i];
     int64_t bound = bounds[dim];
-    if (i == reductionDims.size() - 1)
-      bound /= vectorSize;
+    if (i == reductionDims.size() - 1) bound /= vectorSize;
     APInt size = GreatestCommonDivisor(APInt(64, uint64_t(remaingGroupSize)),
                                        APInt(64, uint64_t(bound)));
     reductionTileSizes[dim] = size.getSExtValue();
-    if (i == reductionDims.size() - 1)
-      reductionTileSizes[dim] *= vectorSize;
+    if (i == reductionDims.size() - 1) reductionTileSizes[dim] *= vectorSize;
     remaingGroupSize /= size.getSExtValue();
   }
 
   TileSizesListType tileSizes;
-  tileSizes.emplace_back(std::move(workgroupTileSizes)); // Workgroup level
-  tileSizes.emplace_back(std::move(reductionTileSizes)); // reduction level
+  tileSizes.emplace_back(std::move(workgroupTileSizes));  // Workgroup level
+  tileSizes.emplace_back(std::move(reductionTileSizes));  // reduction level
   if (failed(setOpConfigAndEntryPointFnTranslation(
           op->getParentOfType<mlir::FunctionOpInterface>(), op, tileSizes,
           CodeGenPipeline::SPIRVSubgroupReduce, workgroupSize))) {
@@ -1265,8 +1219,7 @@ static LogicalResult setReductionConfig(const spirv::TargetEnv &targetEnv,
 /// Returns a small tiling factor for the given reduction `dimSize`.
 /// Returns 0 to avoid tiling.
 static int getReductionTilingFactor(int64_t dimSize) {
-  if (dimSize % 4 == 0)
-    return 4;
+  if (dimSize % 4 == 0) return 4;
 
   // Try to find the smallest prime factor as the tiling factor. As a trade off
   // between generated code size and compilation time, only look at prime
@@ -1274,11 +1227,10 @@ static int getReductionTilingFactor(int64_t dimSize) {
   static constexpr std::array<int, 15> primeNumbers = {
       2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47};
   for (int n : primeNumbers) {
-    if (dimSize % n == 0)
-      return n;
+    if (dimSize % n == 0) return n;
   }
 
-  return 1; // Otherwise just tile with size 1.
+  return 1;  // Otherwise just tile with size 1.
 }
 
 /// Returns the minimal element bitwidth used in the operands and results of the
@@ -1394,10 +1346,8 @@ static LogicalResult setDefaultOpConfig(spirv::ResourceLimitsAttr limits,
     // dimensions to 1 for extra dimensions.
     if (isa<linalg::GenericOp>(linalgOp.getOperation())) {
       for (int64_t i = 0, e = workgroupTileSizes.size(); i < e; i++) {
-        if (workgroupTileSizes[i] != 0)
-          break;
-        if (loopBounds[i] != 1)
-          workgroupTileSizes[i] = 1;
+        if (workgroupTileSizes[i] != 0) break;
+        if (loopBounds[i] != 1) workgroupTileSizes[i] = 1;
       }
     }
     // Scan from the innermost shape dimension and try to deduce the
@@ -1406,8 +1356,7 @@ static LogicalResult setDefaultOpConfig(spirv::ResourceLimitsAttr limits,
     for (auto shapeDim : llvm::reverse(partitionedLoops)) {
       int64_t loopBound = loopBounds[shapeDim];
       // Skip dynamic dimensions.
-      if (ShapedType::isDynamic(loopBound))
-        continue;
+      if (ShapedType::isDynamic(loopBound)) continue;
 
       // Try to find some power of two that can devide the current shape dim
       // size. This vector keeps the candidate tile sizes.
@@ -1431,12 +1380,10 @@ static LogicalResult setDefaultOpConfig(spirv::ResourceLimitsAttr limits,
       for (int64_t candidate : candidates) {
         int64_t scaledTileSize = candidate * scaleToByte;
         if (loopBound % scaledTileSize != 0) {
-          if (!lossFactor)
-            continue;
+          if (!lossFactor) continue;
           // Skip this candidate if it causes many threads to be idle.
           int64_t idleThreads = candidate - (loopBound % scaledTileSize);
-          if (idleThreads > candidate / *lossFactor)
-            continue;
+          if (idleThreads > candidate / *lossFactor) continue;
         }
         // If the workload is too small and we cannot distribute to more than 2
         // workgroups, try a smaller tile size to increase parallelism.
@@ -1462,8 +1409,7 @@ static LogicalResult setDefaultOpConfig(spirv::ResourceLimitsAttr limits,
           assert(numThreads % (candidate / vectorSize) == 0);
           numThreads /= candidate / vectorSize;
         } else {
-          if (wgDim == 0)
-            vectorizable = false;
+          if (wgDim == 0) vectorizable = false;
           threadTileSizes[shapeDim] = scaleToByte;
           workgroupSize[wgDim] = candidate;
           assert(numThreads % candidate == 0);
@@ -1474,8 +1420,7 @@ static LogicalResult setDefaultOpConfig(spirv::ResourceLimitsAttr limits,
       }
 
       // Stop if we have distributed all threads.
-      if (numThreads == 1)
-        break;
+      if (numThreads == 1) break;
       wgDim++;
     }
     return numThreads;
@@ -1491,8 +1436,7 @@ static LogicalResult setDefaultOpConfig(spirv::ResourceLimitsAttr limits,
     int64_t lossFactor = 32;
 
     for (; lossFactor >= 1; lossFactor >>= 1) {
-      if (distributeToThreads(numThreads, lossFactor) == 1)
-        break;
+      if (distributeToThreads(numThreads, lossFactor) == 1) break;
     }
   }
 
@@ -1529,9 +1473,9 @@ static LogicalResult setDefaultOpConfig(spirv::ResourceLimitsAttr limits,
 // Transform Dialect Specialized Configurations
 //===----------------------------------------------------------------------===//
 
-static LogicalResult
-setTransformDialectConfig(mlir::FunctionOpInterface entryPoint, Operation *op,
-                          const spirv::TargetEnv &targetEnv) {
+static LogicalResult setTransformDialectConfig(
+    mlir::FunctionOpInterface entryPoint, Operation *op,
+    const spirv::TargetEnv &targetEnv) {
   if (!clSPIRVEnableTransformDialectJit) {
     return failure();
   }
@@ -1559,8 +1503,7 @@ setTransformDialectConfig(mlir::FunctionOpInterface entryPoint, Operation *op,
       limits.getCooperativeMatrixPropertiesKhr()
           .getAsRange<spirv::CooperativeMatrixPropertiesKHRAttr>();
   for (auto property : properties) {
-    if (property.getScope().getValue() != spirv::Scope::Subgroup)
-      continue;
+    if (property.getScope().getValue() != spirv::Scope::Subgroup) continue;
     gpuModel.supportedWMMAConfigs.emplace_back(iree_compiler::gpu::MMAConfig{
         property.getMSize(), property.getNSize(), property.getKSize(),
         property.getAType(), property.getBType(), property.getCType()});
@@ -1589,28 +1532,28 @@ static LogicalResult setSPIRVOpConfig(const spirv::TargetEnv &targetEnv,
   // First try to find a proper CodeGen configuration to tile and vectorize for
   // the current target architecture.
   switch (targetEnv.getVendorID()) {
-  case spirv::Vendor::AMD:
-    if (succeeded(detail::setAMDCodeGenConfig(targetEnv, rootOp)))
-      return success();
-    break;
-  case spirv::Vendor::Apple:
-    if (succeeded(detail::setAppleCodeGenConfig(targetEnv, rootOp)))
-      return success();
-    break;
-  case spirv::Vendor::ARM:
-    if (succeeded(detail::setMaliCodeGenConfig(targetEnv, rootOp)))
-      return success();
-    break;
-  case spirv::Vendor::NVIDIA:
-    if (succeeded(detail::setNVIDIACodeGenConfig(targetEnv, rootOp)))
-      return success();
-    break;
-  case spirv::Vendor::Qualcomm:
-    if (succeeded(detail::setAdrenoCodeGenConfig(targetEnv, rootOp)))
-      return success();
-    break;
-  default:
-    break;
+    case spirv::Vendor::AMD:
+      if (succeeded(detail::setAMDCodeGenConfig(targetEnv, rootOp)))
+        return success();
+      break;
+    case spirv::Vendor::Apple:
+      if (succeeded(detail::setAppleCodeGenConfig(targetEnv, rootOp)))
+        return success();
+      break;
+    case spirv::Vendor::ARM:
+      if (succeeded(detail::setMaliCodeGenConfig(targetEnv, rootOp)))
+        return success();
+      break;
+    case spirv::Vendor::NVIDIA:
+      if (succeeded(detail::setNVIDIACodeGenConfig(targetEnv, rootOp)))
+        return success();
+      break;
+    case spirv::Vendor::Qualcomm:
+      if (succeeded(detail::setAdrenoCodeGenConfig(targetEnv, rootOp)))
+        return success();
+      break;
+    default:
+      break;
   }
 
   // Otherwise fallback to use a default configuration that tiles and
@@ -1630,13 +1573,11 @@ static LogicalResult setSPIRVOpConfig(const spirv::TargetEnv &targetEnv,
         }
         auto result =
             detail::setMatmulOpConfig(limits, op, workgroupXY, threadMNK);
-        if (succeeded(result))
-          return success();
+        if (succeeded(result)) return success();
 
         LLVM_DEBUG(llvm::dbgs()
                    << "failed to set matmul op config, trying reduction\n");
-        if (succeeded(setReductionConfig(targetEnv, op)))
-          return success();
+        if (succeeded(setReductionConfig(targetEnv, op))) return success();
 
         // If unsuccessful, try to tile and distribute.
         return setDefaultOpConfig(limits, op);
@@ -1651,8 +1592,7 @@ static LogicalResult setSPIRVOpConfig(const spirv::TargetEnv &targetEnv,
           const int subgroupSize = 32;
           auto result = detail::setConvOpConfig(cast<linalg::LinalgOp>(*op),
                                                 subgroupSize, bestTilingFactor);
-          if (succeeded(result))
-            return success();
+          if (succeeded(result)) return success();
         }
 
         // If unsuccessful, try to tile and distribute/vectorize.
@@ -1660,8 +1600,7 @@ static LogicalResult setSPIRVOpConfig(const spirv::TargetEnv &targetEnv,
       })
       .Case<linalg::GenericOp>([&](linalg::GenericOp op) {
         LLVM_DEBUG(llvm::dbgs() << "figuring configuration for generic op\n");
-        if (succeeded(setReductionConfig(targetEnv, op)))
-          return success();
+        if (succeeded(setReductionConfig(targetEnv, op))) return success();
 
         // If a generic op has reduction iterator types, it can be treated as a
         // root op for configuration as well. Use the default configuration,
@@ -1718,10 +1657,8 @@ static LogicalResult setConfigForKernel(const spirv::TargetEnv &targetEnv,
   ArrayRef roots(computeOps);
   while (roots.size() > 1) {
     auto linalgOp = dyn_cast<linalg::LinalgOp>(roots.front());
-    if (!linalgOp)
-      break;
-    if (linalgOp.getNumParallelLoops() != linalgOp.getNumLoops())
-      break;
+    if (!linalgOp) break;
+    if (linalgOp.getNumParallelLoops() != linalgOp.getNumLoops()) break;
     roots = roots.drop_front();
   }
 
@@ -1733,8 +1670,7 @@ static LogicalResult setConfigForKernel(const spirv::TargetEnv &targetEnv,
   Operation *computeOp = roots.back();
   spirv::ResourceLimitsAttr limits = targetEnv.getResourceLimits();
   // If there are still no root op, check for any linalg.generic op.
-  if (succeeded(setDefaultOpConfig(limits, computeOp)))
-    return success();
+  if (succeeded(setDefaultOpConfig(limits, computeOp))) return success();
 
   // Check if the op configuration was set.
   return computeOp->emitOpError(
@@ -1755,10 +1691,8 @@ LogicalResult initSPIRVLaunchConfig(ModuleOp module) {
 
   for (auto funcOp : module.getOps<mlir::FunctionOpInterface>()) {
     auto exportOp = exportOps.lookup(funcOp.getName());
-    if (!exportOp)
-      continue;
-    if (getTranslationInfo(exportOp))
-      continue;
+    if (!exportOp) continue;
+    if (getTranslationInfo(exportOp)) continue;
 
     if (failed(setConfigForKernel(targetEnv, exportOp, funcOp))) {
       return failure();
@@ -1768,4 +1702,4 @@ LogicalResult initSPIRVLaunchConfig(ModuleOp module) {
   return success();
 }
 
-} // namespace mlir::iree_compiler
+}  // namespace mlir::iree_compiler


### PR DESCRIPTION
This patch adds support to check if a matmul schedule would cause promotion to create allocations which do not fit shared memory size, and shrink the MMA schedule if so. The patch also updates the check-resource-usage pass in LLVMGPU pass pipeline to query shared memory limit from the target.