### PR TITLE
[Flow] Do not propagate reshape when it's blocking unpack+generic fusion

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
@@ -15,6 +15,7 @@
 #include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
 #include "iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h"
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -488,7 +489,8 @@ struct FusionOfTensorOpsPass
             if (!reshapeOp)
               return true;
 
-            return isa<linalg::LinalgOp, tensor::UnPackOp>(
+            return isa<linalg::LinalgOp, tensor::UnPackOp,
+                       LinalgExt::UnsetEncodingOp>(
                 reshapeOp.getSrc().getDefiningOp());
           };
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
@@ -488,8 +488,8 @@ struct FusionOfTensorOpsPass
             if (!reshapeOp)
               return true;
 
-            return reshapeOp.getSrc().getDefiningOp<linalg::LinalgOp>() !=
-                   nullptr;
+            return isa<linalg::LinalgOp, tensor::UnPackOp>(
+                reshapeOp.getSrc().getDefiningOp());
           };
 
       RewritePatternSet collapsingReshapePatterns(&getContext());


### PR DESCRIPTION
It saves up to 20% number of dispatches in the benchmark suite.

Fixes https://github.com/openxla/iree/issues/16835