### PR TITLE
[LLVMGPU] Allow workgroup reordering on ROCm

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
@@ -70,7 +70,7 @@ iree_compiler_cc_library(
         "GPUVectorDistribution.cpp",
         "Passes.cpp",
         "VectorReductionToGPU.cpp",
-        "WorkGroupSwizzle.cpp",
+        "WorkgroupReordering.cpp",
         "WorkgroupSpecializationPass.cpp",
     ],
     hdrs = [

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
@@ -68,7 +68,7 @@ iree_cc_library(
     "GPUVectorDistribution.cpp"
     "Passes.cpp"
     "VectorReductionToGPU.cpp"
-    "WorkGroupSwizzle.cpp"
+    "WorkgroupReordering.cpp"
     "WorkgroupSpecializationPass.cpp"
   DEPS
     ::PassHeaders

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
@@ -52,7 +52,8 @@ LogicalResult tileReductionToSerialLoops(mlir::FunctionOpInterface funcOp,
                                          bool fuseInputProducer = false);
 
 LogicalResult swizzleWorkgroupsInFunc(mlir::FunctionOpInterface funcOp,
-                                      unsigned swizzleLogTile);
+                                      unsigned swizzleLogTile,
+                                      ArrayRef<int64_t> workgroupCount);
 
 // Lowers workgroup memory copies to distributed transfer_read/transfer_write
 // ops. Expects the memory copy to be marked with copy_to_workgroup_memory
@@ -143,9 +144,11 @@ createConvertVectorReductionToGPUPass(
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createWorkgroupSpecializationPass();
 
-/// Converts vector ops to gpu dialect.
+/// Reorders workgroup IDs.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createWorkGroupSwizzle(unsigned swizzleLogTile = 0);
+createReorderWorkgroups(
+    unsigned swizzleLogTile = 0,
+    std::function<LogicalResult(mlir::FunctionOpInterface)> filterFn = nullptr);
 
 // This pass generalizes named Linalg ops that are better off as generics.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
@@ -51,9 +51,10 @@ pipelineSharedMemoryCopy(RewriterBase &rewriter, scf::ForOp forOp,
 LogicalResult tileReductionToSerialLoops(mlir::FunctionOpInterface funcOp,
                                          bool fuseInputProducer = false);
 
+/// Swizzles the workgroup order in `funcOp` according to the `swizzleLogTile`
+/// size. `swizzleLogTile` of 0 disables any swizzling.
 LogicalResult swizzleWorkgroupsInFunc(mlir::FunctionOpInterface funcOp,
-                                      unsigned swizzleLogTile,
-                                      ArrayRef<int64_t> workgroupCount);
+                                      unsigned swizzleLogTile);
 
 // Lowers workgroup memory copies to distributed transfer_read/transfer_write
 // ops. Expects the memory copy to be marked with copy_to_workgroup_memory

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -128,10 +128,10 @@ def WorkgroupSpecialization :
   let constructor = "mlir::iree_compiler::createWorkgroupSpecializationPass()";
 }
 
-def WorkGroupSwizzle :
-    InterfacePass<"iree-workgroup-swizzle", "mlir::FunctionOpInterface"> {
-  let summary = "swizzle the workgroup ids for better cache reuse";
-  let constructor = "mlir::iree_compiler::createWorkGroupSwizzle()";
+def ReorderWorkgroups :
+    InterfacePass<"iree-codegen-reorder-workgroups", "mlir::FunctionOpInterface"> {
+  let summary = "Reorder workgroup ids for better cache reuse";
+  let constructor = "mlir::iree_compiler::createReorderWorkgroups()";
   let options = [
     Option<"logTile", "logTile", "unsigned",
             /*default=*/"0",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/WorkGroupSwizzle.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/WorkGroupSwizzle.cpp
@@ -4,10 +4,18 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "iree/compiler/Codegen/Common/GPU/PassDetail.h"
+#include <cassert>
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
+#include "iree/compiler/Codegen/Common/GPU/PassDetail.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+
+#define DEBUG_TYPE "iree-codegen-reorder-workgroups"
 
 namespace mlir::iree_compiler {
 
@@ -24,10 +32,14 @@ namespace mlir::iree_compiler {
 /// }
 // TODO: Make this a callback and the core functionality in the pass a utility
 // function.
-static void makeSwizzledId(Location loc, OpBuilder b, Value workgroupIdX,
-                           Value workgroupIdY, Value gridSizeX, Value gridSizeY,
-                           Value &SwizzledIdX, Value &SwizzledIdY,
-                           unsigned swizzleTile) {
+static std::pair<Value, Value> makeSwizzledId(Location loc, OpBuilder b,
+                                              Value workgroupIdX,
+                                              Value workgroupIdY,
+                                              ArrayRef<int64_t> workgroupCount,
+                                              unsigned swizzleTile) {
+  Value gridSizeX = b.create<arith::ConstantIndexOp>(loc, workgroupCount[0]);
+  Value gridSizeY = b.create<arith::ConstantIndexOp>(loc, workgroupCount[1]);
+
   Value zero = b.create<arith::ConstantIndexOp>(loc, 0);
   Value tile = b.create<arith::ConstantIndexOp>(loc, swizzleTile);
   Value yModTile = b.create<arith::RemUIOp>(loc, workgroupIdY, tile);
@@ -48,54 +60,78 @@ static void makeSwizzledId(Location loc, OpBuilder b, Value workgroupIdX,
   Value condition2 = b.create<arith::CmpIOp>(loc, arith::CmpIPredicate::ugt,
                                              gyAddTile, gridSizeY);
   Value condition3 = b.create<arith::AndIOp>(loc, condition1, condition2);
-  SwizzledIdX = b.create<arith::SelectOp>(loc, condition3, workgroupIdX,
-                                          unboundedSwizzledIdX);
-  SwizzledIdY = b.create<arith::SelectOp>(loc, condition3, workgroupIdY,
-                                          unboundedSwizzledIdY);
+  Value swizzledIdX = b.create<arith::SelectOp>(loc, condition3, workgroupIdX,
+                                                unboundedSwizzledIdX);
+  Value swizzledIdY = b.create<arith::SelectOp>(loc, condition3, workgroupIdY,
+                                                unboundedSwizzledIdY);
+  return {swizzledIdX, swizzledIdY};
+
+  /*
+  Value zero = b.create<arith::ConstantIndexOp>(loc, 0);
+  Value one = b.create<arith::ConstantIndexOp>(loc, 1);
+  Value two = b.create<arith::ConstantIndexOp>(loc, 2);
+  Value last = b.create<arith::SubIOp>(loc, gridSizeX, one);
+  Value reversedX = b.create<arith::SubIOp>(loc, last, workgroupIdX);
+  Value yMod2 = b.create<arith::RemSIOp>(loc, workgroupIdY, two);
+  Value isYEven = b.create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq, yMod2, zero);
+  Value newX = b.create<arith::SelectOp>(loc, isYEven, workgroupIdX, reversedX);
+  SwizzledIdX = newX;
+  SwizzledIdY = workgroupIdY; */
 }
 
 LogicalResult swizzleWorkgroupsInFunc(mlir::FunctionOpInterface funcOp,
-                                      unsigned swizzleLogTile) {
+                                      unsigned swizzleLogTile, ArrayRef<int64_t> workgroupCount) {
+  assert(workgroupCount.size() == 3 && "Expected a 3D grid");
   if (swizzleLogTile == 0)
     return success();
-  unsigned swizzleTile = pow(2, swizzleLogTile);
-  std::array<IREE::HAL::InterfaceWorkgroupIDOp, 2> oldWorkgroupIds;
-  bool xFound = false, yFound = false;
+
+  unsigned swizzleTile = 1u << swizzleLogTile;
+  IREE::HAL::InterfaceWorkgroupIDOp oldXId;
+  IREE::HAL::InterfaceWorkgroupIDOp oldYId;
+  unsigned numXIdOps = 0;
+  unsigned numYIdOps = 0;
   funcOp.walk([&](IREE::HAL::InterfaceWorkgroupIDOp idOp) {
     unsigned index = idOp.getDimension().getZExtValue();
     if (index == 0) {
-      oldWorkgroupIds[index] = idOp;
-      xFound = true;
+      oldXId = idOp;
+      ++numXIdOps;
     } else if (index == 1) {
-      oldWorkgroupIds[index] = idOp;
-      yFound = true;
+      oldYId = idOp;
+      ++numYIdOps;
     }
   });
-  if (xFound == false || yFound == false)
+
+  if (numXIdOps != 1 || numYIdOps != 1) {
+    LLVM_DEBUG(llvm::dbgs() << "Could not find X or Y\n");
     return failure();
+  }
+
   OpBuilder builder(funcOp);
-  builder.setInsertionPoint(&funcOp.front(), funcOp.front().begin());
+  builder.setInsertionPointToStart(&funcOp.front());
+  // We create two new workgroup ID ops at the very top of the function and use
+  // that to RAUW the old ones. This way we don't have to worry about the
+  // picking the exact insertion points that do not violate dominance between
+  // their defs and users.
   Value workgroupIdX =
       builder.create<IREE::HAL::InterfaceWorkgroupIDOp>(funcOp.getLoc(), 0);
   Value workgroupIdY =
       builder.create<IREE::HAL::InterfaceWorkgroupIDOp>(funcOp.getLoc(), 1);
-  Value gridSizeX =
-      builder.create<IREE::HAL::InterfaceWorkgroupCountOp>(funcOp.getLoc(), 0);
-  Value gridSizeY =
-      builder.create<IREE::HAL::InterfaceWorkgroupCountOp>(funcOp.getLoc(), 1);
-  Value SwizzledIdX, SwizzledIdY;
-  makeSwizzledId(funcOp.getLoc(), builder, workgroupIdX, workgroupIdY,
-                 gridSizeX, gridSizeY, SwizzledIdX, SwizzledIdY, swizzleTile);
-  oldWorkgroupIds[0].replaceAllUsesWith(SwizzledIdX);
-  oldWorkgroupIds[1].replaceAllUsesWith(SwizzledIdY);
+  auto [newX, newY] = makeSwizzledId(funcOp.getLoc(), builder, workgroupIdX,
+                                     workgroupIdY, workgroupCount, swizzleTile);
+  oldXId.replaceAllUsesWith(newX);
+  oldYId.replaceAllUsesWith(newY);
+  oldXId->erase();
+  oldYId->erase();
   return success();
 }
 
 namespace {
-struct WorkGroupSwizzlePass
-    : public WorkGroupSwizzleBase<WorkGroupSwizzlePass> {
-  WorkGroupSwizzlePass(unsigned swizzleLogTile)
-      : swizzleLogTile(swizzleLogTile) {}
+struct ReorderWorkgroupsPass final
+    : ReorderWorkgroupsBase<ReorderWorkgroupsPass> {
+  ReorderWorkgroupsPass(
+      unsigned swizzleLogTile,
+      std::function<LogicalResult(mlir::FunctionOpInterface)> filterFn)
+      : swizzleLogTile(swizzleLogTile), filterFn(std::move(filterFn)) {}
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<affine::AffineDialect>();
@@ -108,18 +144,52 @@ struct WorkGroupSwizzlePass
     return success();
   }
   void runOnOperation() override {
-    auto funcOp = getOperation();
-    (void)swizzleWorkgroupsInFunc(funcOp, swizzleLogTile);
+    if (swizzleLogTile == 0)
+      return;
+
+    FunctionOpInterface funcOp = getOperation();
+    if (filterFn && failed(filterFn(funcOp)))
+      return;
+
+    SmallVector<int64_t> workgroupCount = getStaticNumWorkgroups(funcOp);
+    if (workgroupCount.size() != 3) {
+      LLVM_DEBUG(llvm::dbgs() << "Reorder Workgroups: failed to find static "
+                                 "workgroup counts. Bailing out.");
+      return;
+    }
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "--- Before reorder workgroups with workgroup counts: [";
+      llvm::interleaveComma(workgroupCount, llvm::dbgs());
+      llvm::dbgs() << "] ---\n";
+      funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
+      llvm::dbgs() << "\n\n";
+    });
+
+    if (failed(
+            swizzleWorkgroupsInFunc(funcOp, swizzleLogTile, workgroupCount))) {
+      LLVM_DEBUG(llvm::dbgs() << "Failed to reorder workgroups\n");
+      return;
+    }
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "--- After reorder workgroups ---\n";
+      funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
+      llvm::dbgs() << "\n\n";
+    });
   }
 
 private:
   unsigned swizzleLogTile;
+  std::function<LogicalResult(mlir::FunctionOpInterface)> filterFn;
 };
 } // namespace
 
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createWorkGroupSwizzle(unsigned swizzleLogTile) {
-  return std::make_unique<WorkGroupSwizzlePass>(swizzleLogTile);
+createReorderWorkgroups(
+    unsigned swizzleLogTile,
+    std::function<LogicalResult(mlir::FunctionOpInterface)> filterFn) {
+  return std::make_unique<ReorderWorkgroupsPass>(swizzleLogTile, filterFn);
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/WorkgroupReordering.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/WorkgroupReordering.cpp
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <cassert>
-#include "iree/compiler/Codegen/Common/GPU/Passes.h"
 #include "iree/compiler/Codegen/Common/GPU/PassDetail.h"
+#include "iree/compiler/Codegen/Common/GPU/Passes.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "llvm/ADT/STLExtras.h"
@@ -34,12 +34,10 @@ namespace mlir::iree_compiler {
 /// }
 // TODO: Make this a callback and the core functionality in the pass a utility
 // function.
-static std::pair<Value, Value> makeSwizzledId(Location loc, OpBuilder b,
-                                              Value workgroupIdX,
-                                              Value workgroupIdY,
-                                              Value workgroupCountX,
-                                              Value workgroupCountY,
-                                              unsigned swizzleTile) {
+static std::pair<Value, Value>
+makeSwizzledId(Location loc, OpBuilder b, Value workgroupIdX,
+               Value workgroupIdY, Value workgroupCountX, Value workgroupCountY,
+               unsigned swizzleTile) {
   Value zero = b.create<arith::ConstantIndexOp>(loc, 0);
   Value tile = b.create<arith::ConstantIndexOp>(loc, swizzleTile);
   Value yModTile = b.create<arith::RemUIOp>(loc, workgroupIdY, tile);

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
@@ -30,6 +30,7 @@ iree_lit_test_suite(
             "gpu_tensor_alloc.mlir",
             "gpu_tensor_tile.mlir",
             "gpu_workgroup_swizzle.mlir",
+            "gpu_workgroup_swizzle_static.mlir",
             "gpu_tile_reduction.mlir",
             "gpu_vector_alloc.mlir",
             "gpu_vector_distribution.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
@@ -29,6 +29,7 @@ iree_lit_test_suite(
     "gpu_vector_alloc.mlir"
     "gpu_vector_distribution.mlir"
     "gpu_workgroup_swizzle.mlir"
+    "gpu_workgroup_swizzle_static.mlir"
     "reduce_bank_conflicts.mlir"
     "transform_gpu_distribute_shared_memory.mlir"
     "transform_gpu_workgroup_swizzle.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_workgroup_swizzle.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_workgroup_swizzle.mlir
@@ -1,4 +1,5 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-workgroup-swizzle{logTile=3}))" %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-reorder-workgroups{logTile=3}))" \
+// RUN:   --split-input-file %s | FileCheck %s
 
 func.func @matmul() {
   %c0 = arith.constant 0 : index
@@ -52,4 +53,36 @@ func.func @matmul() {
 //          CHECK: %[[S14:.*]] = arith.select %[[S12]], %[[WORKGROUPIDY]], %[[S7]] : index
 
 
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+
+hal.executable @mmt {
+hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb", {target_arch = "gfx940"}>) {
+    hal.executable.export @mmt layout(#pipeline_layout)
+    builtin.module {
+      func.func @mmt() {
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0.000000e+00 : f16
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<64x4096xf16>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<32000x4096xf16>>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<64x32000xf16>>
+        %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [64, 4096], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<64x4096xf16>> -> tensor<64x4096xf16>
+        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [32000, 4096], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<32000x4096xf16>> -> tensor<32000x4096xf16>
+        %5 = tensor.empty() : tensor<64x32000xf16>
+        %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<64x32000xf16>) -> tensor<64x32000xf16>
+        %7 = linalg.matmul_transpose_b ins(%3, %4 : tensor<64x4096xf16>, tensor<32000x4096xf16>)
+                                       outs(%6 : tensor<64x32000xf16>) -> tensor<64x32000xf16>
+        flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [64, 32000], strides = [1, 1] : tensor<64x32000xf16> -> !flow.dispatch.tensor<writeonly:tensor<64x32000xf16>>
+        return
+      }
+    }
+  }
+}
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_workgroup_swizzle_static.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_workgroup_swizzle_static.mlir
@@ -1,0 +1,59 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-codegen-reorder-workgroups{logTile=3})))))" \
+// RUN:   %s | FileCheck %s
+
+// Make sure we use static workgroup counts instead of introducting
+// `hal.interface.workgroup.count` ops. These are currently not supported on ROCm.
+
+// CHECK-LABEL: hal.executable private @main_dispatch_0 {
+// CHECK-LABEL: func.func @main_dispatch_0_matmul_transpose_b_32000x32000x4096_f16
+// CHECK-DAG:               %[[WG_X:.+]] = hal.interface.workgroup.id[0] : index
+// CHECK-DAG:               %[[WG_Y:.+]] = hal.interface.workgroup.id[1] : index
+// CHECK-NOT:               hal.interface.workgroup.count
+// CHECK-DAG:               %[[SEL_X:.+]] = arith.select %{{.+}}, %[[WG_X]]
+// CHECK-DAG:               %[[SEL_Y:.+]] = arith.select %{{.+}}, %[[WG_Y]]
+// CHECK-DAG:               affine.apply #{{.+}}()[%[[SEL_X]]]
+// CHECK-DAG:               affine.apply #{{.+}}()[%[[SEL_Y]]]
+// CHECK:                   return
+
+hal.executable private @main_dispatch_0 {
+hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb", {mma_intrinsics = [#iree_gpu.mfma_layout<F16_16x16x16_F32>, #iree_gpu.mfma_layout<F16_32x32x8_F32>], target_arch = "gfx940", ukernels = "none"}>) {
+  hal.executable.export public @main_dispatch_0_matmul_transpose_b_32000x32000x4096_f16 ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer>]>]>) attributes {hal.interface.bindings = [#hal.interface.binding<0, 0>, #hal.interface.binding<0, 1>], subgroup_size = 64 : index, translation_info = #iree_codegen.translation_info<LLVMGPUMatmulSimt, {pipeline_depth = 0 : i64, store_stage = 1 : i64}>, workgroup_size = [64 : index, 16 : index, 1 : index]} {
+  ^bb0(%arg0: !hal.device):
+    %c250 = arith.constant 250 : index
+    %c500 = arith.constant 500 : index
+    %c1 = arith.constant 1 : index
+    hal.return %c250, %c500, %c1 : index, index, index
+  }
+  builtin.module {
+    func.func @main_dispatch_0_matmul_transpose_b_32000x32000x4096_f16() {
+      %c128 = arith.constant 128 : index
+      %c64 = arith.constant 64 : index
+      %cst = arith.constant 0.000000e+00 : f16
+      %c0 = arith.constant 0 : index
+      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<32000x4096xf16>>
+      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<32000x32000xf16>>
+      %workgroup_id_x = hal.interface.workgroup.id[0] : index
+      %workgroup_id_y = hal.interface.workgroup.id[1] : index
+      %2 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_id_y]
+      %3 = flow.dispatch.tensor.load %0, offsets = [%2, 0], sizes = [%c64, 4096], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<32000x4096xf16>> -> tensor<?x4096xf16>
+      %4 = affine.apply affine_map<()[s0] -> (s0 * 128)>()[%workgroup_id_x]
+      %5 = flow.dispatch.tensor.load %0, offsets = [%4, 0], sizes = [%c128, 4096], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<32000x4096xf16>> -> tensor<?x4096xf16>
+      %6 = tensor.empty() : tensor<64x128xf16>
+      %7 = linalg.fill {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[64, 128, 64]]>} ins(%cst : f16) outs(%6 : tensor<64x128xf16>) -> tensor<64x128xf16>
+      %cast = tensor.cast %5 : tensor<?x4096xf16> to tensor<128x4096xf16>
+      %cast_0 = tensor.cast %3 : tensor<?x4096xf16> to tensor<64x4096xf16>
+      %8 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%cast_0, %cast : tensor<64x4096xf16>, tensor<128x4096xf16>) outs(%7 : tensor<64x128xf16>) attrs =  {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[64, 128, 64]]>} {
+      ^bb0(%in: f16, %in_2: f16, %out: f16):
+        %11 = arith.mulf %in, %in_2 : f16
+        %12 = arith.addf %out, %11 : f16
+        linalg.yield %12 : f16
+      } -> tensor<64x128xf16>
+      %cast_1 = tensor.cast %8 : tensor<64x128xf16> to tensor<?x?xf16>
+      %9 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_id_y]
+      %10 = affine.apply affine_map<()[s0] -> (s0 * 128)>()[%workgroup_id_x]
+      flow.dispatch.tensor.store %cast_1, %1, offsets = [%9, %10], sizes = [%c64, %c128], strides = [1, 1] : tensor<?x?xf16> -> !flow.dispatch.tensor<writeonly:tensor<32000x32000xf16>>
+      return
+    }
+  }
+}
+}

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -875,11 +875,7 @@ DiagnosedSilenceableFailure transform_dialect::WorkgroupSwizzleOp::applyToOne(
     transform::TransformRewriter &rewriter, mlir::FunctionOpInterface target,
     transform::ApplyToEachResultList &results,
     transform::TransformState &state) {
-  SmallVector<int64_t> workgroupCount = getStaticNumWorkgroups(target);
-  if (workgroupCount.size() != 3) {
-    return DiagnosedSilenceableFailure::success();
-  }
-  (void)swizzleWorkgroupsInFunc(target, getLogTile(), workgroupCount);
+  (void)swizzleWorkgroupsInFunc(target, getLogTile());
   return DiagnosedSilenceableFailure::success();
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -875,7 +875,11 @@ DiagnosedSilenceableFailure transform_dialect::WorkgroupSwizzleOp::applyToOne(
     transform::TransformRewriter &rewriter, mlir::FunctionOpInterface target,
     transform::ApplyToEachResultList &results,
     transform::TransformState &state) {
-  (void)swizzleWorkgroupsInFunc(target, getLogTile());
+  SmallVector<int64_t> workgroupCount = getStaticNumWorkgroups(target);
+  if (workgroupCount.size() != 3) {
+    return DiagnosedSilenceableFailure::success();
+  }
+  (void)swizzleWorkgroupsInFunc(target, getLogTile(), workgroupCount);
   return DiagnosedSilenceableFailure::success();
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -50,7 +50,7 @@ namespace mlir::iree_compiler {
 constexpr int64_t kDefaultSubgroupSize = 32;
 
 static llvm::cl::opt<unsigned> clReorderWorkgroupLogSwizzleTile(
-    "iree-codegen-reorder-workgrpu-log-swizzle-tile",
+    "iree-codegen-reorder-workgroups-log-swizzle-tile",
     llvm::cl::desc("Reorder workgroup using strategy: log swizzle tile value. "
                    "Setting this to a non-zero value enables swizzling."),
     llvm::cl::init(0));

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -14,7 +14,6 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/LLVMGPU/Passes.h"
 #include "iree/compiler/Codegen/LLVMGPU/ROCDLPasses.h"
-#include "iree/compiler/Codegen/SPIRV/Utils.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Codegen/Utils/MarkerUtils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"


### PR DESCRIPTION
This is a cleanup PR in preparation for adding more workgroup reordering strategies.

On ROCm we can't currently use dynamic workgroup counts, so we only apply swizzling when all the required counts are static. This is implemented with a filter function passed to the workgroup reordering pass.