### PR TITLE
[LLVMGPU] allow multiple m and n dims in contraction distribution

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
@@ -97,8 +97,10 @@ struct DistributeContract final : OpDistributionPattern<vector::ContractionOp> {
     LLVM_DEBUG(llvm::dbgs() << "init tile: " << finalTile << "\n");
 
     // Offsets into the LHS/RHS batches.
-    SmallVector<int64_t, 2> lhsBatchOffsets(rank, 0);
-    SmallVector<int64_t, 2> rhsBatchOffsets(rank, 0);
+    SmallVector<int64_t, 2> lhsBatchOffsets(
+        lhsLayout.getBatchesPerSubgroup().size(), 0);
+    SmallVector<int64_t, 2> rhsBatchOffsets(
+        rhsLayout.getBatchesPerSubgroup().size(), 0);
 
     // Offsets into the result batches.
     ArrayRef<int64_t> resultBatches = resultLayout.getBatchesPerSubgroup();
@@ -183,7 +185,7 @@ struct DistributeContract final : OpDistributionPattern<vector::ContractionOp> {
   std::optional<int64_t> getKBatchSize(const VectorContractOpInfo &opDetail,
                                        NestedLayoutAttr lhsLayout,
                                        NestedLayoutAttr rhsLayout) const {
-    auto [lhsK, rhsK] = *opDetail.getOperandKIndex();
+    auto [lhsK, rhsK] = opDetail.getOperandFullKIndex();
     int64_t lhsKBatch = lhsLayout.getBatchesPerSubgroup()[lhsK];
     int64_t rhsKBatch = rhsLayout.getBatchesPerSubgroup()[rhsK];
 
@@ -201,15 +203,21 @@ struct DistributeContract final : OpDistributionPattern<vector::ContractionOp> {
                                SmallVector<int64_t, 2> &rhsOffsets,
                                NestedLayoutAttr lhsLayout,
                                NestedLayoutAttr rhsLayout) const {
-    auto [lhsM, rhsN] = *opDetail.getOperandMNIndex();
-    auto [lhsK, rhsK] = *opDetail.getOperandKIndex();
-    auto [resultM, resultN] = *opDetail.getResultMNIndex();
+
     // resultOffsets contains batch indices into the C/D vector. It is a 2-D
     // index for both M and N. We need to split out for M and N, and add index
     // for K.
-    lhsOffsets[lhsM] = resultOffsets[resultM];
+    for (auto [lhsM, resultM] :
+         llvm::zip_equal(opDetail.lhsMDims, opDetail.outMDims)) {
+      lhsOffsets[lhsM] = resultOffsets[resultM];
+    }
+    for (auto [rhsN, resultN] :
+         llvm::zip_equal(opDetail.rhsNDims, opDetail.outNDims)) {
+      rhsOffsets[rhsN] = resultOffsets[resultN];
+    }
+
+    auto [lhsK, rhsK] = opDetail.getOperandFullKIndex();
     lhsOffsets[lhsK] = kOffset;
-    rhsOffsets[rhsN] = resultOffsets[resultN];
     rhsOffsets[rhsK] = kOffset;
 
     // Now apply permutation on LHS/RHS according to their batch order.

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
@@ -183,7 +183,7 @@ struct DistributeContract final : OpDistributionPattern<vector::ContractionOp> {
   std::optional<int64_t> getKBatchSize(const VectorContractOpInfo &opDetail,
                                        NestedLayoutAttr lhsLayout,
                                        NestedLayoutAttr rhsLayout) const {
-    auto [lhsK, rhsK] = opDetail.getOperandFullKIndex();
+    auto [lhsK, rhsK] = opDetail.getOperandKIndex();
     int64_t lhsKBatch = lhsLayout.getBatchesPerSubgroup()[lhsK];
     int64_t rhsKBatch = rhsLayout.getBatchesPerSubgroup()[rhsK];
 
@@ -214,7 +214,7 @@ struct DistributeContract final : OpDistributionPattern<vector::ContractionOp> {
       rhsOffsets[rhsN] = resultOffsets[resultN];
     }
 
-    auto [lhsK, rhsK] = opDetail.getOperandFullKIndex();
+    auto [lhsK, rhsK] = opDetail.getOperandKIndex();
     lhsOffsets[lhsK] = kOffset;
     rhsOffsets[rhsK] = kOffset;
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
@@ -97,10 +97,8 @@ struct DistributeContract final : OpDistributionPattern<vector::ContractionOp> {
     LLVM_DEBUG(llvm::dbgs() << "init tile: " << finalTile << "\n");
 
     // Offsets into the LHS/RHS batches.
-    SmallVector<int64_t, 2> lhsBatchOffsets(
-        lhsLayout.getBatchesPerSubgroup().size(), 0);
-    SmallVector<int64_t, 2> rhsBatchOffsets(
-        rhsLayout.getBatchesPerSubgroup().size(), 0);
+    SmallVector<int64_t, 2> lhsBatchOffsets(lhsLayout.getRank(), 0);
+    SmallVector<int64_t, 2> rhsBatchOffsets(rhsLayout.getRank(), 0);
 
     // Offsets into the result batches.
     ArrayRef<int64_t> resultBatches = resultLayout.getBatchesPerSubgroup();

--- a/compiler/src/iree/compiler/Codegen/Common/test/vector_layout_analysis.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/vector_layout_analysis.mlir
@@ -243,13 +243,13 @@ builtin.module attributes { transform.with_named_sequence } {
     %c0 = arith.constant 0 : index
     %cst_0 = arith.constant 0.0 : f16
     %cst0_1 = arith.constant dense<0.0> : vector<16xf16>
-    // expected-remark @above {{subgroup_basis = [1, 1], subgroup_active_ids= [false, true], thread_basis = [4, 16], thread_active_ids= [false, true]}}
+    // expected-remark @above {{subgroup_basis = [1, 1], subgroup_active_ids = [false, true], thread_basis = [4, 16], thread_active_ids = [false, true]}}
     %root = vector.transfer_read %arr[%c0, %c0], %cst_0 {in_bounds = [true, true], "__vector_layout_test_anchor_result_0" = #layout} : memref<16x16xf16>, vector<16x16xf16>
     // expected-remark @above {{thread_basis = [4, 16]}}
     %root_red = vector.multi_reduction<add>, %root, %cst0_1 [0]  : vector<16x16xf16> to vector<16xf16>
-    // expected-remark @above {{subgroup_basis = [1, 1], subgroup_active_ids= [false, true], thread_basis = [4, 16], thread_active_ids= [false, true]}}
+    // expected-remark @above {{subgroup_basis = [1, 1], subgroup_active_ids = [false, true], thread_basis = [4, 16], thread_active_ids = [false, true]}}
     %c = arith.mulf %root_red, %a : vector<16xf16>
-    // expected-remark @above {{subgroup_basis = [1, 1], subgroup_active_ids= [false, true], thread_basis = [4, 16], thread_active_ids= [false, true]}}
+    // expected-remark @above {{subgroup_basis = [1, 1], subgroup_active_ids = [false, true], thread_basis = [4, 16], thread_active_ids = [false, true]}}
     func.return %c : vector<16xf16>
   }
 
@@ -281,13 +281,13 @@ builtin.module attributes { transform.with_named_sequence } {
     %c0 = arith.constant 0 : index
     %cst_0 = arith.constant 0.0 : f16
     %cst0_1 = arith.constant dense<0.0> : vector<16xf16>
-    // expected-remark @above {{subgroup_basis = [1, 1], subgroup_active_ids= [true, false], thread_basis = [4, 16], thread_active_ids= [true, false]}}
+    // expected-remark @above {{subgroup_basis = [1, 1], subgroup_active_ids = [true, false], thread_basis = [4, 16], thread_active_ids = [true, false]}}
     %root = vector.transfer_read %arr[%c0, %c0], %cst_0 {in_bounds = [true, true], "__vector_layout_test_anchor_result_0" = #layout} : memref<16x16xf16>, vector<16x16xf16>
     // expected-remark @above {{thread_basis = [4, 16]}}
     %root_red = vector.multi_reduction<add>, %root, %cst0_1 [1]  : vector<16x16xf16> to vector<16xf16>
-    // expected-remark @above {{subgroup_basis = [1, 1], subgroup_active_ids= [true, false], thread_basis = [4, 16], thread_active_ids= [true, false]}}
+    // expected-remark @above {{subgroup_basis = [1, 1], subgroup_active_ids = [true, false], thread_basis = [4, 16], thread_active_ids = [true, false]}}
     %c = arith.mulf %root_red, %a : vector<16xf16>
-    // expected-remark @above {{subgroup_basis = [1, 1], subgroup_active_ids= [true, false], thread_basis = [4, 16], thread_active_ids= [true, false]}}
+    // expected-remark @above {{subgroup_basis = [1, 1], subgroup_active_ids = [true, false], thread_basis = [4, 16], thread_active_ids = [true, false]}}
     func.return %c : vector<16xf16>
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUCastTypeToFitMMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUCastTypeToFitMMA.cpp
@@ -45,7 +45,6 @@ struct UpcastContractOutput : OpRewritePattern<vector::ContractionOp> {
 
     auto [dstAElemType, dstBElemType, dstCElemType] =
         intrinsic.getABCElementTypes();
-    auto [dstM, dstN, dstK] = intrinsic.getMNKShape();
 
     auto srcCElemFType = dyn_cast<FloatType>(srcCType.getElementType());
     auto dstCElemFType = dyn_cast<FloatType>(dstCElemType);
@@ -58,16 +57,6 @@ struct UpcastContractOutput : OpRewritePattern<vector::ContractionOp> {
     if (srcAType.getElementType() != dstAElemType ||
         srcBType.getElementType() != dstBElemType) {
       return rewriter.notifyMatchFailure(contractOp, "a/b type mismatch");
-    }
-
-    auto [srcCMIndex, srcCNIndex] = *opInfo.getResultMNIndex();
-    auto [srcAKIndex, srcBKIndex] = *opInfo.getOperandKIndex();
-    int64_t srcM = srcCType.getShape()[srcCMIndex];
-    int64_t srcN = srcCType.getShape()[srcCNIndex];
-    int64_t srcK = srcAType.getShape()[srcAKIndex];
-
-    if (srcM % dstM != 0 || srcN % dstN != 0 || srcK % dstK != 0) {
-      return rewriter.notifyMatchFailure(contractOp, "shape cannot divide");
     }
 
     Location loc = contractOp.getLoc();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/cast_type_to_fit_mma.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/cast_type_to_fit_mma.mlir
@@ -45,26 +45,6 @@ func.func @mfma_matmul_96x64x16_mmt(%lhs: vector<96x16xf16>, %rhs: vector<64x16x
 
 // -----
 
-func.func @mfma_matmul_96x64x16_mm_cannot_divide(%lhs: vector<95x16xf16>, %rhs: vector<16x64xf16>, %init: vector<95x64xf16>) -> vector<95x64xf16> attributes {
-    mma_schedule = #iree_gpu.mma_schedule<
-      intrinsic = #iree_gpu.mma_layout<MFMA_F16_32x32x8_F32>,
-      subgroup_m_count = 1, subgroup_n_count = 1, subgroup_m_tile_count = 3, subgroup_n_tile_count = 2, subgroup_k_tile_count = 2>,
-    workgroup_size = [64, 1, 1]} {
-    %0 = vector.contract {
-      indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>],
-      iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>}
-      %lhs, %rhs, %init : vector<95x16xf16>, vector<16x64xf16> into vector<95x64xf16>
-  return %0 : vector<95x64xf16>
-}
-
-// CHECK-LABEL: func.func @mfma_matmul_96x64x16_mm_cannot_divide
-//   CHECK-NOT:   arith.extf
-//       CHECK:   vector.contract
-//  CHECK-SAME:     %{{.+}}, %{{.+}}, %{{.+}} : vector<95x16xf16>, vector<16x64xf16> into vector<95x64xf16>
-//   CHECK-NOT:   arith.truncf
-
-// -----
-
 func.func @mfma_matmul_96x64x16_mm_cannot_downcast(%lhs: vector<96x16xf16>, %rhs: vector<16x64xf16>, %init: vector<96x64xf64>) -> vector<96x64xf64> attributes {
     mma_schedule = #iree_gpu.mma_schedule<
       intrinsic = #iree_gpu.mma_layout<MFMA_F16_32x32x8_F32>,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_distribute_layout.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_distribute_layout.mlir
@@ -15,15 +15,15 @@ func.func @mfma_matmul_96x64x16_mm(%lhs: vector<96x16xf16>, %rhs: vector<16x64xf
 //      CHECK: contract A vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [3, 2], outers_per_batch = [1, 1], threads_per_outer = [32, 2], elements_per_thread = [1, 4],
 // CHECK-SAME:   thread_order = [1, 0]
-// CHECK-SAME:   subgroup_basis = [1, 1], thread_basis = [2, 32]>
+// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, false, true], thread_basis = [2, 32]>
 //      CHECK: contract B vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [2, 2], outers_per_batch = [1, 1], threads_per_outer = [2, 32], elements_per_thread = [4, 1],
 // CHECK-SAME:   element_order = [1, 0],
-// CHECK-SAME:   subgroup_basis = [1, 1], thread_basis = [2, 32]>
+// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [false, true, true], thread_basis = [2, 32]>
 //      CHECK: contract C vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [3, 2], outers_per_batch = [4, 1], threads_per_outer = [2, 32], elements_per_thread = [4, 1],
 // CHECK-SAME:   element_order = [1, 0],
-// CHECK-SAME:   subgroup_basis = [1, 1], thread_basis = [2, 32]>
+// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, true, false], thread_basis = [2, 32]>
 
 // -----
 
@@ -42,15 +42,15 @@ func.func @mfma_matmul_96x64x16_mmt(%lhs: vector<96x16xf16>, %rhs: vector<64x16x
 //      CHECK: contract A vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [3, 2], outers_per_batch = [1, 1], threads_per_outer = [32, 2], elements_per_thread = [1, 4],
 // CHECK-SAME:   thread_order = [1, 0]
-// CHECK-SAME:   subgroup_basis = [1, 1], thread_basis = [2, 32]>
+// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, false, true], thread_basis = [2, 32]>
 //      CHECK: contract B vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [2, 2], outers_per_batch = [1, 1], threads_per_outer = [32, 2], elements_per_thread = [1, 4],
-// CHECK-SAME:   subgroup_order = [1, 0], batch_order = [1, 0], outer_order = [1, 0], thread_order = [1, 0]
-// CHECK-SAME:   subgroup_basis = [1, 1], thread_basis = [2, 32]>
+// CHECK-SAME:   outer_order = [1, 0], thread_order = [1, 0]
+// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [false, true, true], thread_basis = [2, 32]>
 //      CHECK: contract C vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [3, 2], outers_per_batch = [4, 1], threads_per_outer = [2, 32], elements_per_thread = [4, 1],
-// CHECK-SAME:   element_order = [1, 0],
-// CHECK-SAME:   subgroup_basis = [1, 1], thread_basis = [2, 32]>
+// CHECK-SAME:   element_order = [1, 0]
+// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, true, false], thread_basis = [2, 32]>
 
 // -----
 
@@ -117,15 +117,15 @@ func.func @matmul_16x16x256_read(%lhs: memref<16x256xf16, strided<[256, 1], offs
 //      CHECK: contract A vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [1, 2], outers_per_batch = [1, 1], threads_per_outer = [16, 4], elements_per_thread = [1, 4],
 // CHECK-SAME:   thread_order = [1, 0]
-// CHECK-SAME:   subgroup_basis = [1, 1], thread_basis = [4, 16]>
+// CHECK-SAME:   subgroup_active_ids = [true, false, true], thread_basis = [4, 16]>
 //      CHECK: contract B vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [2, 1], outers_per_batch = [1, 1], threads_per_outer = [4, 16], elements_per_thread = [4, 1],
-// CHECK-SAME:   element_order = [1, 0],
-// CHECK-SAME:   subgroup_basis = [1, 1], thread_basis = [4, 16]>
+// CHECK-SAME:   subgroup_order = [1, 0], element_order = [1, 0],
+// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [false, true, true], thread_basis = [4, 16]>
 //      CHECK: contract C vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [1, 1], outers_per_batch = [1, 1], threads_per_outer = [4, 16], elements_per_thread = [4, 1],
 // CHECK-SAME:   element_order = [1, 0],
-// CHECK-SAME:   subgroup_basis = [1, 1], thread_basis = [4, 16]>
+// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, true, false], thread_basis = [4, 16]>
 
 // -----
 
@@ -178,15 +178,15 @@ func.func @matmul_16x16x256_read_permute(%lhs: memref<16x256xf16, strided<[256, 
 //      CHECK: contract A vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [1, 2], outers_per_batch = [1, 1], threads_per_outer = [16, 4], elements_per_thread = [1, 4],
 // CHECK-SAME:   thread_order = [1, 0]
-// CHECK-SAME:   subgroup_basis = [1, 1], thread_basis = [4, 16]>
+// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, false, true], thread_basis = [4, 16]>
 //      CHECK: contract B vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [2, 1], outers_per_batch = [1, 1], threads_per_outer = [4, 16], elements_per_thread = [4, 1],
 // CHECK-SAME:   element_order = [1, 0],
-// CHECK-SAME:   subgroup_basis = [1, 1], thread_basis = [4, 16]>
+// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [false, true, true], thread_basis = [4, 16]>
 //      CHECK: contract C vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [1, 1], outers_per_batch = [1, 1], threads_per_outer = [4, 16], elements_per_thread = [4, 1],
 // CHECK-SAME:   element_order = [1, 0],
-// CHECK-SAME:   subgroup_basis = [1, 1], thread_basis = [4, 16]>
+// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, true, false], thread_basis = [4, 16]>
 
 // -----
 
@@ -243,15 +243,15 @@ func.func @wmma_matmul_48x32x32_mm(%lhs: vector<48x32xf16>, %rhs: vector<32x32xf
 //      CHECK: contract A vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [3, 2], outers_per_batch = [1, 1], threads_per_outer = [16, 1], elements_per_thread = [1, 16],
 // CHECK-SAME:   thread_order = [1, 0]
-// CHECK-SAME:   subgroup_basis = [1, 1], thread_basis = [1, 32]>
+// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, false, true], thread_basis = [1, 32]>
 //      CHECK: contract B vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [2, 2], outers_per_batch = [1, 1], threads_per_outer = [1, 16], elements_per_thread = [16, 1],
 // CHECK-SAME:   element_order = [1, 0],
-// CHECK-SAME:   subgroup_basis = [1, 1], thread_basis = [1, 32]>
+// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [false, true, true], thread_basis = [1, 32]>
 //      CHECK: contract C vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [3, 2], outers_per_batch = [8, 1], threads_per_outer = [2, 16], elements_per_thread = [1, 1],
 // CHECK-SAME:   element_order = [1, 0],
-// CHECK-SAME:   subgroup_basis = [1, 1], thread_basis = [2, 16]>
+// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, true, false], thread_basis = [2, 16]>
 
 // -----
 
@@ -270,12 +270,113 @@ func.func @wmma_matmul_48x32x32_mmt(%lhs: vector<48x32xf16>, %rhs: vector<32x32x
 //      CHECK: contract A vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [3, 2], outers_per_batch = [1, 1], threads_per_outer = [16, 1], elements_per_thread = [1, 16],
 // CHECK-SAME:   thread_order = [1, 0]
-// CHECK-SAME:   subgroup_basis = [1, 1], thread_basis = [1, 32]>
+// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, false, true], thread_basis = [1, 32]>
 //      CHECK: contract B vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [2, 2], outers_per_batch = [1, 1], threads_per_outer = [16, 1], elements_per_thread = [1, 16],
-// CHECK-SAME:   subgroup_order = [1, 0], batch_order = [1, 0], outer_order = [1, 0], thread_order = [1, 0],
-// CHECK-SAME:   subgroup_basis = [1, 1], thread_basis = [1, 32]>
+// CHECK-SAME:   outer_order = [1, 0], thread_order = [1, 0],
+// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [false, true, true], thread_basis = [1, 32]>
 //      CHECK: contract C vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [3, 2], outers_per_batch = [8, 1], threads_per_outer = [2, 16], elements_per_thread = [1, 1],
 // CHECK-SAME:   element_order = [1, 0],
-// CHECK-SAME:   subgroup_basis = [1, 1], thread_basis = [2, 16]>
+// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, true, false], thread_basis = [2, 16]>
+
+// -----
+
+func.func @matmul_192x64x16_mmt_multi_m(%lhs: vector<2x64x16xf16>, %rhs: vector<16x64xf16>, %init: vector<2x64x64xf32>) -> vector<2x64x64xf32> attributes {
+    mma_schedule = #iree_gpu.mma_schedule<
+      intrinsic = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>,
+      subgroup_m_count = 2, subgroup_n_count = 1, subgroup_m_tile_count = 4, subgroup_n_tile_count = 4, subgroup_k_tile_count = 1>,
+    workgroup_size = [64, 2, 1]} {
+    %0 = vector.contract {
+      indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>, affine_map<(d0, d1, d2, d3) -> (d3, d2)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>],
+      iterator_types = ["parallel", "parallel", "parallel", "reduction"], kind = #vector.kind<add>}
+      %lhs, %rhs, %init : vector<2x64x16xf16>, vector<16x64xf16> into vector<2x64x64xf32>
+  return %0 : vector<2x64x64xf32>
+}
+
+//      CHECK: contract A vector layout: #iree_vector_ext.nested_layout<
+// CHECK-SAME:   subgroups_per_workgroup = [2, 1, 1],
+// CHECK-SAME:   batches_per_subgroup = [1, 4, 1],
+// CHECK-SAME:   outers_per_batch = [1, 1, 1],
+// CHECK-SAME:   threads_per_outer = [1, 16, 4],
+// CHECK-SAME:   elements_per_thread = [1, 1, 4],
+// CHECK-SAME:   thread_order = [0, 2, 1],
+// CHECK-SAME:   subgroup_basis = [2, 1, 1, 1],
+// CHECK-SAME:   subgroup_active_ids = [true, true, false, true],
+// CHECK-SAME:   thread_basis = [1, 4, 16]>
+//      CHECK: contract B vector layout: #iree_vector_ext.nested_layout<
+// CHECK-SAME:   subgroups_per_workgroup = [1, 1],
+// CHECK-SAME:   batches_per_subgroup = [1, 4],
+// CHECK-SAME:   outers_per_batch = [1, 1],
+// CHECK-SAME:   threads_per_outer = [4, 16],
+// CHECK-SAME:   elements_per_thread = [4, 1],
+// CHECK-SAME:   subgroup_order = [1, 0],
+// CHECK-SAME:   element_order = [1, 0],
+// CHECK-SAME:   subgroup_basis = [2, 1, 1, 1],
+// CHECK-SAME:   subgroup_active_ids = [false, false, true, true],
+// CHECK-SAME:   thread_basis = [4, 16]>
+//      CHECK: contract C vector layout: #iree_vector_ext.nested_layout<
+// CHECK-SAME:   subgroups_per_workgroup = [2, 1, 1],
+// CHECK-SAME:   batches_per_subgroup = [1, 4, 4],
+// CHECK-SAME:   outers_per_batch = [1, 1, 1],
+// CHECK-SAME:   threads_per_outer = [1, 4, 16],
+// CHECK-SAME:   elements_per_thread = [1, 4, 1],
+// CHECK-SAME:   element_order = [0, 2, 1],
+// CHECK-SAME:   subgroup_basis = [2, 1, 1, 1],
+// CHECK-SAME:   subgroup_active_ids = [true, true, true, false],
+// CHECK-SAME:   thread_basis = [1, 4, 16]>
+
+// -----
+
+func.func @matmul_192x64x16_mmt_multi_split_m(%lhs: vector<2x64x16xf16>, %rhs: vector<16x64xf16>, %init: vector<2x64x64xf32>) -> vector<2x64x64xf32> attributes {
+    mma_schedule = #iree_gpu.mma_schedule<
+      intrinsic = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>,
+      subgroup_m_count = 4, subgroup_n_count = 1, subgroup_m_tile_count = 2, subgroup_n_tile_count = 4, subgroup_k_tile_count = 1>,
+    workgroup_size = [64, 2, 1]} {
+    %0 = vector.contract {
+      indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>, affine_map<(d0, d1, d2, d3) -> (d3, d2)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>],
+      iterator_types = ["parallel", "parallel", "parallel", "reduction"], kind = #vector.kind<add>}
+      %lhs, %rhs, %init : vector<2x64x16xf16>, vector<16x64xf16> into vector<2x64x64xf32>
+  return %0 : vector<2x64x64xf32>
+}
+
+//      CHECK: contract A vector layout: #iree_vector_ext.nested_layout<
+// CHECK-SAME:   subgroups_per_workgroup = [2, 2, 1],
+// CHECK-SAME:   batches_per_subgroup = [1, 2, 1],
+// CHECK-SAME:   subgroup_basis = [2, 2, 1, 1],
+// CHECK-SAME:   subgroup_active_ids = [true, true, false, true]
+//      CHECK: contract C vector layout: #iree_vector_ext.nested_layout<
+// CHECK-SAME:   subgroups_per_workgroup = [2, 2, 1],
+// CHECK-SAME:   batches_per_subgroup = [1, 2, 4],
+// CHECK-SAME:   subgroup_basis = [2, 2, 1, 1],
+// CHECK-SAME:   subgroup_active_ids = [true, true, true, false]
+
+// -----
+
+func.func @matmul_192x64x16_mmt_multi_m_and_n(%lhs: vector<4x64x16xf16>, %rhs: vector<2x16x64xf16>, %init: vector<4x2x64x64xf32>) -> vector<4x2x64x64xf32> attributes {
+    mma_schedule = #iree_gpu.mma_schedule<
+      intrinsic = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>,
+      subgroup_m_count = 2, subgroup_n_count = 2, subgroup_m_tile_count = 8, subgroup_n_tile_count = 4, subgroup_k_tile_count = 1>,
+    workgroup_size = [128, 2, 1]} {
+    %0 = vector.contract {
+      indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4)>, affine_map<(d0, d1, d2, d3, d4) -> (d1, d4, d3)>, affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>],
+      iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"], kind = #vector.kind<add>}
+      %lhs, %rhs, %init : vector<4x64x16xf16>, vector<2x16x64xf16> into vector<4x2x64x64xf32>
+  return %0 : vector<4x2x64x64xf32>
+}
+
+//      CHECK: contract A vector layout: #iree_vector_ext.nested_layout<
+// CHECK-SAME:   subgroups_per_workgroup = [2, 1, 1],
+// CHECK-SAME:   batches_per_subgroup = [2, 4, 1],
+// CHECK-SAME:   subgroup_basis = [2, 2, 1, 1, 1],
+// CHECK-SAME:   subgroup_active_ids = [true, false, true, false, true]
+//      CHECK: contract B vector layout: #iree_vector_ext.nested_layout<
+// CHECK-SAME:   subgroups_per_workgroup = [2, 1, 1],
+// CHECK-SAME:   batches_per_subgroup = [1, 1, 4],
+// CHECK-SAME:   subgroup_basis = [2, 2, 1, 1, 1],
+// CHECK-SAME:   subgroup_active_ids = [false, true, false, true, true]
+//      CHECK: contract C vector layout: #iree_vector_ext.nested_layout<
+// CHECK-SAME:   subgroups_per_workgroup = [2, 2, 1, 1],
+// CHECK-SAME:   batches_per_subgroup = [2, 1, 4, 4],
+// CHECK-SAME:   subgroup_basis = [2, 2, 1, 1, 1],
+// CHECK-SAME:   subgroup_active_ids = [true, true, true, true, false]

--- a/compiler/src/iree/compiler/Codegen/Utils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Utils/BUILD.bazel
@@ -78,6 +78,7 @@ iree_compiler_cc_library(
     deps = [
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LinalgDialect",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:VectorDialect",
     ],

--- a/compiler/src/iree/compiler/Codegen/Utils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Utils/CMakeLists.txt
@@ -72,6 +72,7 @@ iree_cc_library(
   DEPS
     LLVMSupport
     MLIRIR
+    MLIRLinalgDialect
     MLIRSupport
     MLIRVectorDialect
   PUBLIC

--- a/compiler/src/iree/compiler/Codegen/Utils/VectorOpUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/VectorOpUtils.cpp
@@ -12,57 +12,17 @@
 
 namespace mlir::iree_compiler {
 
-std::optional<std::pair<int, int>>
-VectorContractOpInfo::getOperandMNIndex() const {
-  switch (opKind) {
-  case OpKind::MK_KN_MN:
-    return std::make_pair(0, 1);
-  case OpKind::MK_NK_MN:
-    return std::make_pair(0, 0);
-  case OpKind::UNKNOWN:
-    break;
-  }
-  return std::nullopt;
-}
-
-std::pair<int, int> VectorContractOpInfo::getOperandFullMNIndex() const {
+std::pair<int, int> VectorContractOpInfo::getOperandMNIndex() const {
   return std::make_pair(lhsMDims.back(), rhsNDims.back());
 }
 
 // Returns the (LHS K, RHS K) dimension index pair.
-std::optional<std::pair<int, int>>
-VectorContractOpInfo::getOperandKIndex() const {
-  switch (opKind) {
-  case OpKind::MK_KN_MN:
-    return std::make_pair(1, 0);
-  case OpKind::MK_NK_MN:
-    return std::make_pair(1, 1);
-  case OpKind::UNKNOWN:
-    break;
-  }
-  return std::nullopt;
-}
-
-// Returns the (LHS K, RHS K) dimension index pair.
-std::pair<int, int> VectorContractOpInfo::getOperandFullKIndex() const {
+std::pair<int, int> VectorContractOpInfo::getOperandKIndex() const {
   return std::make_pair(lhsKDim, rhsKDim);
 }
 
 // Returns the result (M, N) dimension index pair.
-std::optional<std::pair<int, int>>
-VectorContractOpInfo::getResultMNIndex() const {
-  switch (opKind) {
-  case OpKind::MK_KN_MN:
-  case OpKind::MK_NK_MN:
-    return std::make_pair(0, 1);
-  default:
-    break;
-  }
-  return std::nullopt;
-}
-
-// Returns the result (M, N) dimension index pair.
-std::pair<int, int> VectorContractOpInfo::getResultFullMNIndex() const {
+std::pair<int, int> VectorContractOpInfo::getResultMNIndex() const {
   return std::make_pair(outMDims.back(), outNDims.back());
 }
 

--- a/compiler/src/iree/compiler/Codegen/Utils/VectorOpUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/VectorOpUtils.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/Utils/VectorOpUtils.h"
 
+#include "llvm/ADT/STLExtras.h"
 #include "mlir/IR/AffineExpr.h"
 #include "mlir/IR/AffineMap.h"
 
@@ -24,6 +25,10 @@ VectorContractOpInfo::getOperandMNIndex() const {
   return std::nullopt;
 }
 
+std::pair<int, int> VectorContractOpInfo::getOperandFullMNIndex() const {
+  return std::make_pair(lhsMDims.back(), rhsNDims.back());
+}
+
 // Returns the (LHS K, RHS K) dimension index pair.
 std::optional<std::pair<int, int>>
 VectorContractOpInfo::getOperandKIndex() const {
@@ -36,6 +41,11 @@ VectorContractOpInfo::getOperandKIndex() const {
     break;
   }
   return std::nullopt;
+}
+
+// Returns the (LHS K, RHS K) dimension index pair.
+std::pair<int, int> VectorContractOpInfo::getOperandFullKIndex() const {
+  return std::make_pair(lhsKDim, rhsKDim);
 }
 
 // Returns the result (M, N) dimension index pair.
@@ -51,17 +61,46 @@ VectorContractOpInfo::getResultMNIndex() const {
   return std::nullopt;
 }
 
+// Returns the result (M, N) dimension index pair.
+std::pair<int, int> VectorContractOpInfo::getResultFullMNIndex() const {
+  return std::make_pair(outMDims.back(), outNDims.back());
+}
+
 VectorContractOpInfo::OpKind
 VectorContractOpInfo::inferOpKind(MLIRContext *ctx,
-                                  SmallVector<AffineMap> maps) const {
-  using MapList = ArrayRef<ArrayRef<AffineExpr>>;
-  auto infer = [&](MapList m) { return AffineMap::inferFromExprList(m, ctx); };
-  AffineExpr m, n, k;
-  bindDims(ctx, m, n, k);
-  if (maps == infer({{m, k}, {k, n}, {m, n}}))
-    return OpKind::MK_KN_MN;
-  if (maps == infer({{m, k}, {n, k}, {m, n}}))
-    return OpKind::MK_NK_MN;
+                                  SmallVector<AffineMap> maps) {
+  if (contractionDims.k.size() != 1) {
+    return OpKind::UNKNOWN;
+  }
+
+  int64_t innerM = contractionDims.m.back();
+  int64_t innerN = contractionDims.n.back();
+  int64_t k = contractionDims.k.back();
+
+  int64_t lhsM = *maps[0].getResultPosition(getAffineDimExpr(innerM, ctx));
+  lhsKDim = *maps[0].getResultPosition(getAffineDimExpr(k, ctx));
+  int64_t rhsN = *maps[1].getResultPosition(getAffineDimExpr(innerN, ctx));
+  rhsKDim = *maps[1].getResultPosition(getAffineDimExpr(k, ctx));
+  int64_t outM = *maps[2].getResultPosition(getAffineDimExpr(innerM, ctx));
+  int64_t outN = *maps[2].getResultPosition(getAffineDimExpr(innerN, ctx));
+
+  for (auto m : contractionDims.m) {
+    lhsMDims.push_back(*maps[0].getResultPosition(getAffineDimExpr(m, ctx)));
+    outMDims.push_back(*maps[2].getResultPosition(getAffineDimExpr(m, ctx)));
+  }
+  for (auto n : contractionDims.n) {
+    rhsNDims.push_back(*maps[1].getResultPosition(getAffineDimExpr(n, ctx)));
+    outNDims.push_back(*maps[2].getResultPosition(getAffineDimExpr(n, ctx)));
+  }
+
+  if (outM < outN) {
+    if (lhsM < lhsKDim) {
+      if (rhsN < rhsKDim) {
+        return OpKind::MK_NK_MN;
+      }
+      return OpKind::MK_KN_MN;
+    }
+  }
   return OpKind::UNKNOWN;
 }
 

--- a/compiler/src/iree/compiler/Codegen/Utils/VectorOpUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/VectorOpUtils.h
@@ -4,7 +4,9 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/BuiltinTypes.h"
 
 namespace mlir::iree_compiler {
 
@@ -14,6 +16,7 @@ public:
   enum class OpKind { MK_KN_MN, MK_NK_MN, UNKNOWN };
 
   explicit VectorContractOpInfo(vector::ContractionOp op) {
+    contractionDims = *linalg::inferContractionDims(op.getIndexingMapsArray());
     opKind = inferOpKind(op.getContext(), op.getIndexingMapsArray());
   }
 
@@ -21,18 +24,44 @@ public:
 
   // Returns the (LHS M, RHS N) dimension index pair.
   std::optional<std::pair<int, int>> getOperandMNIndex() const;
+  std::pair<int, int> getOperandFullMNIndex() const;
 
   // Returns the (LHS K, RHS K) dimension index pair.
   std::optional<std::pair<int, int>> getOperandKIndex() const;
+  std::pair<int, int> getOperandFullKIndex() const;
 
   // Returns the result (M, N) dimension index pair.
   std::optional<std::pair<int, int>> getResultMNIndex() const;
+  std::pair<int, int> getResultFullMNIndex() const;
+
+  SmallVector<unsigned, 2> getMDims() const { return contractionDims.m; }
+
+  SmallVector<unsigned, 2> getNDims() const { return contractionDims.n; }
+
+  int64_t getARank() {
+    return contractionDims.m.size() + contractionDims.k.size();
+  }
+  int64_t getBRank() {
+    return contractionDims.k.size() + contractionDims.n.size();
+  }
+  int64_t getCRank() {
+    return contractionDims.m.size() + contractionDims.n.size();
+  }
+
+  SmallVector<int64_t> lhsMDims;
+  int64_t lhsKDim;
+  SmallVector<int64_t> rhsNDims;
+  int64_t rhsKDim;
+  SmallVector<int64_t> outMDims;
+  SmallVector<int64_t> outNDims;
 
 private:
   // Gets the kind of a contract op with the given indexing |maps|.
-  OpKind inferOpKind(MLIRContext *ctx, SmallVector<AffineMap> maps) const;
+  OpKind inferOpKind(MLIRContext *ctx, SmallVector<AffineMap> maps);
 
   OpKind opKind = OpKind::UNKNOWN;
+
+  linalg::ContractionDimensions contractionDims;
 };
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Utils/VectorOpUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/VectorOpUtils.h
@@ -23,16 +23,13 @@ public:
   OpKind getOpKind() const { return opKind; }
 
   // Returns the (LHS M, RHS N) dimension index pair.
-  std::optional<std::pair<int, int>> getOperandMNIndex() const;
-  std::pair<int, int> getOperandFullMNIndex() const;
+  std::pair<int, int> getOperandMNIndex() const;
 
   // Returns the (LHS K, RHS K) dimension index pair.
-  std::optional<std::pair<int, int>> getOperandKIndex() const;
-  std::pair<int, int> getOperandFullKIndex() const;
+  std::pair<int, int> getOperandKIndex() const;
 
   // Returns the result (M, N) dimension index pair.
-  std::optional<std::pair<int, int>> getResultMNIndex() const;
-  std::pair<int, int> getResultFullMNIndex() const;
+  std::pair<int, int> getResultMNIndex() const;
 
   SmallVector<unsigned, 2> getMDims() const { return contractionDims.m; }
 

--- a/llvm-external-projects/iree-dialects/lib/Dialect/VectorExt/IR/VectorExtAttrs.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/VectorExt/IR/VectorExtAttrs.cpp
@@ -740,7 +740,7 @@ static void printBasis(AsmPrinter &p, StringRef basisName, StringRef maskName,
   p << ']';
   if (llvm::any_of(mask, [](bool b) { return !b; })) {
     p << ',' << ' ';
-    p << maskName;
+    p << maskName << ' ';
     p << '=';
     p << ' ';
     p << '[';

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_vector_ext/roundtrip.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_vector_ext/roundtrip.mlir
@@ -110,29 +110,89 @@ func.func @specify_layout(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
 func.func @specify_nested(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
   %cst_0 = arith.constant 0.0 : f16
   %c0 = arith.constant 0 : index
-  %result = vector.transfer_read %lhs[%c0, %c0], %cst_0 {in_bounds = [true, true]} : memref<32x32xf16>, vector<32x32xf16>
-  %2 = iree_vector_ext.layout_conflict_resolution %result {
-    sourceLayout = #nested_1,
-    desiredLayout = #nested_2,
-    otherLayout0 = #nested_3,
-    otherLayout1 = #nested_4,
-    otherLayout2 = #nested_5
-  } : vector<32x32xf16> -> vector<32x32xf16>
-  return %2 : vector<32x32xf16>
+  %result = vector.transfer_read %lhs[%c0, %c0], %cst_0 {
+    in_bounds = [true, true],
+    layout0 = #nested_1,
+    layout1 = #nested_2,
+    layout2 = #nested_3,
+    layout3 = #nested_4,
+    layout4 = #nested_5
+  } : memref<32x32xf16>, vector<32x32xf16>
+  return %result : vector<32x32xf16>
 }
 
-// CHECK-DAG: #[[LAYOUT0:.+]] = #iree_vector_ext.nested_layout<subgroups_per_workgroup = [1, 1], batches_per_subgroup = [4, 2], outers_per_batch = [1, 4], threads_per_outer = [2, 4], elements_per_thread = [4, 1], subgroup_order = [1, 0], batch_order = [1, 0], thread_order = [1, 0], element_order = [1, 0], subgroup_basis = [1, 1], thread_basis = [2, 4]>
-// CHECK-DAG: #[[LAYOUT1:.+]] = #iree_vector_ext.nested_layout<subgroups_per_workgroup = [1, 1], batches_per_subgroup = [2, 4], outers_per_batch = [4, 1], threads_per_outer = [4, 2], elements_per_thread = [1, 4], outer_order = [1, 0], subgroup_basis = [1, 1], thread_basis = [4, 2]>
-// CHECK-DAG: #[[LAYOUT2:.+]] = #iree_vector_ext.nested_layout<subgroups_per_workgroup = [1, 1], batches_per_subgroup = [4, 2], outers_per_batch = [1, 4], threads_per_outer = [2, 4], elements_per_thread = [4, 1], subgroup_order = [1, 0], batch_order = [1, 0], thread_order = [1, 0], element_order = [1, 0], subgroup_basis = [2, 4, 8], subgroup_active_ids= [true, true, false], thread_basis = [2, 4]>
-// CHECK-DAG: #[[LAYOUT3:.+]] = #iree_vector_ext.nested_layout<subgroups_per_workgroup = [1, 1], batches_per_subgroup = [4, 2], outers_per_batch = [1, 4], threads_per_outer = [2, 4], elements_per_thread = [4, 1], subgroup_order = [1, 0], batch_order = [1, 0], thread_order = [1, 0], element_order = [1, 0], subgroup_basis = [2, 4, 8], subgroup_active_ids= [true, true, false], thread_basis = [2, 4, 2], thread_active_ids= [false, true, true]>
-// CHECK-DAG: #[[LAYOUT4:.+]] = #iree_vector_ext.nested_layout<subgroups_per_workgroup = [1, 1], batches_per_subgroup = [4, 2], outers_per_batch = [1, 4], threads_per_outer = [2, 4], elements_per_thread = [4, 1], subgroup_order = [1, 0], batch_order = [1, 0], thread_order = [1, 0], element_order = [1, 0], subgroup_basis = [2, 4], thread_basis = [4, 2]>
+// CHECK: #[[LAYOUT0:.+]] = #iree_vector_ext.nested_layout<
+// CHECK-SAME: subgroups_per_workgroup = [1, 1],
+// CHECK-SAME: batches_per_subgroup = [2, 4],
+// CHECK-SAME: outers_per_batch = [4, 1],
+// CHECK-SAME: threads_per_outer = [4, 2],
+// CHECK-SAME: elements_per_thread = [1, 4],
+// CHECK-SAME: outer_order = [1, 0],
+// CHECK-SAME: subgroup_basis = [1, 1],
+// CHECK-SAME: thread_basis = [4, 2]>
+
+// CHECK: #[[LAYOUT1:.+]] = #iree_vector_ext.nested_layout<
+// CHECK-SAME: subgroups_per_workgroup = [1, 1],
+// CHECK-SAME: batches_per_subgroup = [4, 2],
+// CHECK-SAME: outers_per_batch = [1, 4],
+// CHECK-SAME: threads_per_outer = [2, 4],
+// CHECK-SAME: elements_per_thread = [4, 1],
+// CHECK-SAME: subgroup_order = [1, 0],
+// CHECK-SAME: batch_order = [1, 0],
+// CHECK-SAME: thread_order = [1, 0],
+// CHECK-SAME: element_order = [1, 0],
+// CHECK-SAME: subgroup_basis = [1, 1],
+// CHECK-SAME: thread_basis = [2, 4]>
+
+// CHECK: #[[LAYOUT2:.+]] = #iree_vector_ext.nested_layout<
+// CHECK-SAME: subgroups_per_workgroup = [1, 1],
+// CHECK-SAME: batches_per_subgroup = [4, 2],
+// CHECK-SAME: outers_per_batch = [1, 4],
+// CHECK-SAME: threads_per_outer = [2, 4],
+// CHECK-SAME: elements_per_thread = [4, 1],
+// CHECK-SAME: subgroup_order = [1, 0],
+// CHECK-SAME: batch_order = [1, 0],
+// CHECK-SAME: thread_order = [1, 0],
+// CHECK-SAME: element_order = [1, 0],
+// CHECK-SAME: subgroup_basis = [2, 4, 8],
+// CHECK-SAME: subgroup_active_ids = [true, true, false],
+// CHECK-SAME: thread_basis = [2, 4]>
+
+// CHECK: #[[LAYOUT3:.+]] = #iree_vector_ext.nested_layout<
+// CHECK-SAME: subgroups_per_workgroup = [1, 1],
+// CHECK-SAME: batches_per_subgroup = [4, 2],
+// CHECK-SAME: outers_per_batch = [1, 4],
+// CHECK-SAME: threads_per_outer = [2, 4],
+// CHECK-SAME: elements_per_thread = [4, 1],
+// CHECK-SAME: subgroup_order = [1, 0],
+// CHECK-SAME: batch_order = [1, 0],
+// CHECK-SAME: thread_order = [1, 0],
+// CHECK-SAME: element_order = [1, 0],
+// CHECK-SAME: subgroup_basis = [2, 4, 8],
+// CHECK-SAME: subgroup_active_ids = [true, true, false],
+// CHECK-SAME: thread_basis = [2, 4, 2],
+// CHECK-SAME: thread_active_ids = [false, true, true]>
+
+// CHECK: #[[LAYOUT4:.+]] = #iree_vector_ext.nested_layout<
+// CHECK-SAME: subgroups_per_workgroup = [1, 1],
+// CHECK-SAME: batches_per_subgroup = [4, 2],
+// CHECK-SAME: outers_per_batch = [1, 4],
+// CHECK-SAME: threads_per_outer = [2, 4],
+// CHECK-SAME: elements_per_thread = [4, 1],
+// CHECK-SAME: subgroup_order = [1, 0],
+// CHECK-SAME: batch_order = [1, 0],
+// CHECK-SAME: thread_order = [1, 0],
+// CHECK-SAME: element_order = [1, 0],
+// CHECK-SAME: subgroup_basis = [2, 4],
+// CHECK-SAME: thread_basis = [4, 2]>
+
 // CHECK-LABEL: func.func @specify_nested
-// CHECK:      iree_vector_ext.layout_conflict_resolution
-// CHECK-SAME:         desiredLayout = #[[LAYOUT0]]
-// CHECK-SAME:         otherLayout0 = #[[LAYOUT2]]
-// CHECK-SAME:         otherLayout1 = #[[LAYOUT3]]
-// CHECK-SAME:         otherLayout2 = #[[LAYOUT4]]
-// CHECK-SAME:         sourceLayout = #[[LAYOUT1]]
+// CHECK:      vector.transfer_read
+// CHECK-SAME:         layout0 = #[[LAYOUT0]]
+// CHECK-SAME:         layout1 = #[[LAYOUT1]]
+// CHECK-SAME:         layout2 = #[[LAYOUT2]]
+// CHECK-SAME:         layout3 = #[[LAYOUT3]]
+// CHECK-SAME:         layout4 = #[[LAYOUT4]]
 
 // -----
 


### PR DESCRIPTION
This adjusts the layout generation logic to allow distribution of contractions with multiple m and n dimensions by greedily using the subgroup/tile_counts of the mma_schedule with the outer dims. The inner most m/n dimensions are still required to be divisible by the intrinsic shape. (and this only supports a single k dimension).

This also decouples the ordering logic of the batch/subgroup distribution from the lane distribution for the intrinsics. Currently it assumes intrinsics can only specify three important sizes, an M, N, and K size. To support distributed batches this would require adding a fourth dim type.

Depends on #17071