### PR TITLE
Remove enableFastMath plumbing from SPIRV/WebGPU.

### DIFF
--- a/compiler/plugins/target/MetalSPIRV/MetalSPIRVTarget.cpp
+++ b/compiler/plugins/target/MetalSPIRV/MetalSPIRVTarget.cpp
@@ -187,7 +187,7 @@ public:
     if (variantOp.isExternal())
       return;
 
-    buildSPIRVCodegenPassPipeline(passManager, /*enableFastMath=*/false);
+    buildSPIRVCodegenPassPipeline(passManager);
   }
 
   LogicalResult serializeExecutable(const SerializationOptions &serOptions,

--- a/compiler/plugins/target/VulkanSPIRV/VulkanSPIRVTarget.cpp
+++ b/compiler/plugins/target/VulkanSPIRV/VulkanSPIRVTarget.cpp
@@ -179,7 +179,7 @@ public:
     if (variantOp.isExternal())
       return;
 
-    buildSPIRVCodegenPassPipeline(passManager, /*enableFastMath=*/false);
+    buildSPIRVCodegenPassPipeline(passManager);
   }
 
   void buildLinkingPassPipeline(OpPassManager &passManager) override {

--- a/compiler/plugins/target/WebGPUSPIRV/WebGPUSPIRVTarget.cpp
+++ b/compiler/plugins/target/WebGPUSPIRV/WebGPUSPIRVTarget.cpp
@@ -145,22 +145,15 @@ public:
     passManager.nest<ModuleOp>().nest<func::FuncOp>().addPass(
         createWGSLReplacePushConstantsPass());
 
-    // From WGSL spec, "Floating Point Evaluation"
-    // (https://www.w3.org/TR/WGSL/#floating-point-evaluation):
-    // - Implementations may assume that NaNs and infinities are not present at
-    //   runtime.
-    //   - In such an implementation, when an evaluation would produce an
-    //     infinity or a NaN, an undefined value of the target type is produced
-    //     instead.
-    // So WebGPU effectively assumes fast math mode. We also don't have reliable
-    // ways to check whether a floating point number is NaN or infinity.
-    // Therefore, just let the SPIR-V CodeGen to avoid generating guards w.r.t.
-    // NaN and infinity.
-    buildSPIRVCodegenPassPipeline(passManager, /*enableFastMath=*/true);
+    buildSPIRVCodegenPassPipeline(passManager);
 
-    // WGSL does not support extended multiplication:
-    // https://github.com/gpuweb/gpuweb/issues/1565. Make sure to lower it to
-    // regular multiplication before we convert SPIR-V to WGSL.
+    // Prepare SPIR-V for WebGPU by expanding or removing unsupported ops.
+    // For example,
+    //   * WGSL does not support extended multiplication:
+    //     https://github.com/gpuweb/gpuweb/issues/1565, so we lower to
+    //     regular multiplication
+    //   * WGSL does not support NaN or infinities:
+    //     https://www.w3.org/TR/WGSL/#floating-point-evaluation
     passManager.nest<ModuleOp>().nest<spirv::ModuleOp>().addPass(
         spirv::createSPIRVWebGPUPreparePass());
   }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
@@ -483,16 +483,13 @@ public:
     registry.insert<spirv::SPIRVDialect>();
   }
 
-  explicit ConvertToSPIRVPass(bool enableFastMath, unsigned indexBits)
-      : enableFastMath(enableFastMath), indexBits(indexBits) {}
+  explicit ConvertToSPIRVPass(unsigned indexBits) : indexBits(indexBits) {}
 
   LogicalResult initializeOptions(
       StringRef options,
       function_ref<LogicalResult(const Twine &)> errorHandler) override {
     if (failed(Pass::initializeOptions(options, errorHandler)))
       return failure();
-    // Use pass option if present.
-    enableFastMath |= enableFastMathOption;
     indexBits = indexBitsOption;
     return success();
   }
@@ -500,9 +497,6 @@ public:
   void runOnOperation() override;
 
 private:
-  // Enable fast math when doing type conversion by assuming no NaN or infinite
-  // values.
-  bool enableFastMath;
   // Use 64 bits for index widths.
   unsigned indexBits;
 };
@@ -747,8 +741,8 @@ void ConvertToSPIRVPass::runOnOperation() {
 //===----------------------------------------------------------------------===//
 
 std::unique_ptr<OperationPass<ModuleOp>>
-createConvertToSPIRVPass(bool enableFastMath, unsigned indexBits) {
-  return std::make_unique<ConvertToSPIRVPass>(enableFastMath, indexBits);
+createConvertToSPIRVPass(unsigned indexBits) {
+  return std::make_unique<ConvertToSPIRVPass>(indexBits);
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -228,7 +228,7 @@ static void addMemRefLoweringPasses(OpPassManager &pm) {
 }
 
 /// Adds passes to perform the final SPIR-V conversion.
-static void addSPIRVLoweringPasses(OpPassManager &pm, bool enableFastMath) {
+static void addSPIRVLoweringPasses(OpPassManager &pm) {
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
@@ -248,7 +248,7 @@ static void addSPIRVLoweringPasses(OpPassManager &pm, bool enableFastMath) {
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 
-  pm.addPass(createConvertToSPIRVPass(enableFastMath, clSPIRVIndexingBits));
+  pm.addPass(createConvertToSPIRVPass(clSPIRVIndexingBits));
 
   auto getTargetEnv = [](spirv::ModuleOp moduleOp) {
     return getSPIRVTargetEnvAttr(moduleOp);
@@ -668,11 +668,11 @@ void buildSPIRVCodegenConfigurationPassPipeline(OpPassManager &pm) {
   pm.addPass(createSPIRVSelectLoweringStrategyPass());
 }
 
-void buildSPIRVCodegenPassPipeline(OpPassManager &pm, bool enableFastMath) {
+void buildSPIRVCodegenPassPipeline(OpPassManager &pm) {
   pm.addPass(createSPIRVLowerExecutableTargetPass());
 
   addMemRefLoweringPasses(pm.nest<ModuleOp>());
-  addSPIRVLoweringPasses(pm.nest<ModuleOp>(), enableFastMath);
+  addSPIRVLoweringPasses(pm.nest<ModuleOp>());
 
   LLVM_DEBUG({
     llvm::dbgs() << "Using SPIR-V pass pipeline:\n";
@@ -726,7 +726,7 @@ void registerCodegenSPIRVPasses() {
       "iree-codegen-linalg-to-spirv-pipeline",
       "Runs the progressive lowering pipeline from linalg to SPIR-V",
       [](OpPassManager &passManager) {
-        buildSPIRVCodegenPassPipeline(passManager, /*enableFastMath=*/false);
+        buildSPIRVCodegenPassPipeline(passManager);
       });
 }
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.h
@@ -61,7 +61,7 @@ void buildSPIRVCodegenConfigurationPassPipeline(OpPassManager &pm);
 /// Populates passes needed to lower linalg/arith/math ops to SPIR-V ops via
 /// the structured ops path. The pass manager `pm` here operate on the module
 /// within the IREE::HAL::ExecutableOp.
-void buildSPIRVCodegenPassPipeline(OpPassManager &pm, bool enableFastMath);
+void buildSPIRVCodegenPassPipeline(OpPassManager &pm);
 
 /// Populates passes needed to link HAL executables across SPIRV targets.
 void buildSPIRVLinkingPassPipeline(OpPassManager &passManager);
@@ -76,7 +76,7 @@ void buildSPIRVLinkingPassPipeline(OpPassManager &passManager);
 /// GPU processor ID ops into SPIR-V global variables, loop/standard ops into
 /// corresponding SPIR-V ops.
 std::unique_ptr<OperationPass<ModuleOp>>
-createConvertToSPIRVPass(bool enableFastMath = false, unsigned indexWidth = 32);
+createConvertToSPIRVPass(unsigned indexWidth = 32);
 
 /// Annotates the innermost Winograd loops with the spirv distribute attribute.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.td
@@ -17,8 +17,6 @@ def ConvertToSPIRV : Pass<"iree-convert-to-spirv", "ModuleOp"> {
   let summary = "Perform the final conversion to SPIR-V dialect";
   let constructor = "mlir::iree_compiler::createConvertToSPIRVPass()";
   let options = [
-    Option<"enableFastMathOption", "enable-fast-math", "bool", /*default=*/"false",
-          "Enable fast math mode during type conversion (i.e. assume no NaN/infinity)">,
     Option<"indexBitsOption", "index-bits", "unsigned", /*default=*/"32",
           "Specify the bit widths for SPIR-V indices">,
   ];


### PR DESCRIPTION
This flag is no longer used (`createSPIRVWebGPUPreparePass()` does more on its own), so we can drop the plumbing.