### PR TITLE
Skip custom hip kernel sample if it would fail to build.

### DIFF
--- a/samples/custom_dispatch/hip/kernels/CMakeLists.txt
+++ b/samples/custom_dispatch/hip/kernels/CMakeLists.txt
@@ -10,7 +10,8 @@ if((NOT IREE_TARGET_BACKEND_ROCM) OR
 endif()
 
 if(NOT IREE_ROCM_PATH)
-  message(WARNING "IREE_ROCM_PATH not specified; cannot build sample")
+  message(WARNING "IREE_ROCM_PATH not specified; skipping custom_dispatch/hip/kernels sample")
+  return()
 endif()
 
 # NOTE: this is not how one should actually build their HSACO files. Do not use


### PR DESCRIPTION
Without this return, building `iree-test-deps` can fail when the clang command used in this file is passed an empty path to the rocm install.