### PR TITLE
[python] Flesh out more of the python parameters API.

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -73,6 +73,7 @@ jobs:
             --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
             --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
             --env "CCACHE_NAMESPACE=gcr.io/iree-oss/base@sha256:dc314b4fe30fc1315742512891357bffed4d1b62ffcb46258b1e0761c737b446" \
+            --env "IREE_BUILD_SETUP_PYTHON_VENV=${BUILD_DIR}/.venv" \
             gcr.io/iree-oss/base@sha256:dc314b4fe30fc1315742512891357bffed4d1b62ffcb46258b1e0761c737b446 \
             ./build_tools/cmake/build_all.sh "${BUILD_DIR}"
       # TODO(scotttodd): trim build/tests to exclude integration tests (tests/ folder, check tests)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -655,6 +655,7 @@ jobs:
             --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
             --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
             --env "CCACHE_NAMESPACE=gcr.io/iree-oss/base@sha256:dc314b4fe30fc1315742512891357bffed4d1b62ffcb46258b1e0761c737b446" \
+            --env "IREE_BUILD_SETUP_PYTHON_VENV=${BUILD_DIR}/.venv" \
             gcr.io/iree-oss/base@sha256:dc314b4fe30fc1315742512891357bffed4d1b62ffcb46258b1e0761c737b446 \
             ./build_tools/cmake/build_all.sh \
             "${BUILD_DIR}"
@@ -713,6 +714,7 @@ jobs:
             --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
             --env "CMAKE_BUILD_TYPE=Debug" \
             --env "CCACHE_NAMESPACE=gcr.io/iree-oss/base@sha256:dc314b4fe30fc1315742512891357bffed4d1b62ffcb46258b1e0761c737b446" \
+            --env "IREE_BUILD_SETUP_PYTHON_VENV=${BUILD_DIR}/.venv" \
             gcr.io/iree-oss/base@sha256:dc314b4fe30fc1315742512891357bffed4d1b62ffcb46258b1e0761c737b446 \
             ./build_tools/cmake/build_all.sh \
             "${BUILD_DIR}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -741,7 +741,6 @@ jobs:
             --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
             --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
             --env "CCACHE_NAMESPACE=gcr.io/iree-oss/base@sha256:dc314b4fe30fc1315742512891357bffed4d1b62ffcb46258b1e0761c737b446" \
-            --env "IREE_BUILD_SETUP_PYTHON_VENV=${BUILD_DIR}/.venv" \
             gcr.io/iree-oss/base@sha256:dc314b4fe30fc1315742512891357bffed4d1b62ffcb46258b1e0761c737b446 \
             ./build_tools/cmake/build_and_test_byo_llvm.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -741,6 +741,7 @@ jobs:
             --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
             --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
             --env "CCACHE_NAMESPACE=gcr.io/iree-oss/base@sha256:dc314b4fe30fc1315742512891357bffed4d1b62ffcb46258b1e0761c737b446" \
+            --env "IREE_BUILD_SETUP_PYTHON_VENV=${BUILD_DIR}/.venv" \
             gcr.io/iree-oss/base@sha256:dc314b4fe30fc1315742512891357bffed4d1b62ffcb46258b1e0761c737b446 \
             ./build_tools/cmake/build_and_test_byo_llvm.sh
 

--- a/build_tools/cmake/build_and_test_byo_llvm.sh
+++ b/build_tools/cmake/build_and_test_byo_llvm.sh
@@ -18,15 +18,12 @@ export IREE_BYOLLVM_INSTALL_DIR="${IREE_BYOLLVM_BUILD_DIR}/install"
 
 python3 --version
 
-# Honor the venv setup instructions like we do in setup_build.sh, but we can't
-# just use that because this is independent/uses different env vars/etc.
-if [[ ! -z "${IREE_BUILD_SETUP_PYTHON_VENV:-}" ]]; then
-  # We've been instructed to set up a venv.
-  echo "Setting up venv at $IREE_BUILD_SETUP_PYTHON_VENV"
-  python3 -m venv "$IREE_BUILD_SETUP_PYTHON_VENV"
-  source "$IREE_BUILD_SETUP_PYTHON_VENV/bin/activate"
-  python -m pip install -r runtime/bindings/python/iree/runtime/build_requirements.txt
-fi
+# We've been instructed to set up a venv.
+VENV_DIR="$IREE_BYOLLVM_BUILD_DIR/.venv"
+echo "Setting up venv at $VENV_DIR"
+python3 -m venv "$VENV_DIR"
+source "$VENV_DIR/bin/activate"
+python -m pip install -r runtime/bindings/python/iree/runtime/build_requirements.txt
 
 # Note: by using the `build_llvm` action here, we are exercising byo_llvm.sh's
 # ability to build LLVM... from our own third_party/llvm-project. That's not

--- a/build_tools/cmake/build_and_test_byo_llvm.sh
+++ b/build_tools/cmake/build_and_test_byo_llvm.sh
@@ -16,6 +16,18 @@ source build_tools/cmake/setup_ccache.sh
 export IREE_BYOLLVM_BUILD_DIR="${1:-build-byo-llvm}"
 export IREE_BYOLLVM_INSTALL_DIR="${IREE_BYOLLVM_BUILD_DIR}/install"
 
+python3 --version
+
+# Honor the venv setup instructions like we do in setup_build.sh, but we can't
+# just use that because this is independent/uses different env vars/etc.
+if [[ ! -z "${IREE_BUILD_SETUP_PYTHON_VENV:-}" ]]; then
+  # We've been instructed to set up a venv.
+  echo "Setting up venv at $IREE_BUILD_SETUP_PYTHON_VENV"
+  python3 -m venv "$IREE_BUILD_SETUP_PYTHON_VENV"
+  source "$IREE_BUILD_SETUP_PYTHON_VENV/bin/activate"
+  python -m pip install -r runtime/bindings/python/iree/runtime/build_requirements.txt
+fi
+
 # Note: by using the `build_llvm` action here, we are exercising byo_llvm.sh's
 # ability to build LLVM... from our own third_party/llvm-project. That's not
 # the most intuitive interpretation of "bring your own LLVM", since as far as

--- a/build_tools/cmake/setup_build.sh
+++ b/build_tools/cmake/setup_build.sh
@@ -16,7 +16,7 @@ CMAKE_BIN="${CMAKE_BIN:-$(which cmake)}"
 ninja --version
 python3 --version
 
-if [[ ! -z "$IREE_BUILD_SETUP_PYTHON_VENV" ]]; then
+if [[ ! -z "${IREE_BUILD_SETUP_PYTHON_VENV:-}" ]]; then
   # We've been instructed to set up a venv.
   echo "Setting up venv at $IREE_BUILD_SETUP_PYTHON_VENV"
   python3 -m venv "$IREE_BUILD_SETUP_PYTHON_VENV"

--- a/build_tools/cmake/setup_build.sh
+++ b/build_tools/cmake/setup_build.sh
@@ -16,7 +16,19 @@ CMAKE_BIN="${CMAKE_BIN:-$(which cmake)}"
 ninja --version
 python3 --version
 
-IREE_PYTHON3_EXECUTABLE="${IREE_PYTHON3_EXECUTABLE:-$(which python3)}"
+if [[ ! -z "$IREE_BUILD_SETUP_PYTHON_VENV" ]]; then
+  # We've been instructed to set up a venv.
+  echo "Setting up venv at $IREE_BUILD_SETUP_PYTHON_VENV"
+  python3 -m venv "$IREE_BUILD_SETUP_PYTHON_VENV"
+  source "$IREE_BUILD_SETUP_PYTHON_VENV/bin/activate"
+  IREE_PYTHON3_EXECUTABLE="$IREE_BUILD_SETUP_PYTHON_VENV/bin/python"
+  python -m pip install -r runtime/bindings/python/iree/runtime/build_requirements.txt
+else
+  # Just use the host python and yolo with what may be installed.
+  # In practice, certain callers take care of this themselves, and we trust
+  # them to do it right.
+  IREE_PYTHON3_EXECUTABLE="${IREE_PYTHON3_EXECUTABLE:-$(which python3)}"
+fi
 
 if [[ -d "${BUILD_DIR}" ]]; then
   echo "'${BUILD_DIR}' directory already exists. Will use cached results there."

--- a/runtime/bindings/python/CMakeLists.txt
+++ b/runtime/bindings/python/CMakeLists.txt
@@ -244,6 +244,13 @@ iree_py_test(
 
 iree_py_test(
   NAME
+    io_test
+  SRCS
+    "tests/io_test.py"
+)
+
+iree_py_test(
+  NAME
     system_setup_test
   SRCS
     "tests/system_setup_test.py"
@@ -261,9 +268,9 @@ if(IREE_BUILD_BUNDLED_LLVM)
 
   iree_py_test(
     NAME
-      io_test
+      io_runtime_test
     SRCS
-      "tests/io_test.py"
+      "tests/io_runtime_test.py"
   )
 
   iree_py_test(

--- a/runtime/bindings/python/io.h
+++ b/runtime/bindings/python/io.h
@@ -46,7 +46,10 @@ struct ApiPtrAdapter<iree_io_parameter_index_t> {
   }
 };
 
-class FileHandle : public ApiRefCounted<FileHandle, iree_io_file_handle_t> {};
+class FileHandle : public ApiRefCounted<FileHandle, iree_io_file_handle_t> {
+ public:
+  int HandleBufferProtocol(Py_buffer *view, int flags);
+};
 
 class ParameterProvider
     : public ApiRefCounted<ParameterProvider, iree_io_parameter_provider_t> {};

--- a/runtime/bindings/python/iree/runtime/_binding.pyi
+++ b/runtime/bindings/python/iree/runtime/_binding.pyi
@@ -56,6 +56,14 @@ class FileHandle:
     def wrap_memory(
         host_buffer: Any, readable: bool = True, writable: bool = False
     ) -> FileHandle: ...
+    def host_allocation(self) -> memoryview:
+        """Access the raw view of the allocated host memory.
+
+        Requires is_host_allocation.
+        """
+        ...
+    @property
+    def is_host_allocation(self) -> bool: ...
 
 class HalAllocator:
     def allocate_buffer(
@@ -308,9 +316,40 @@ class MemoryType(int):
     def __and__(self, other: MemoryType) -> int: ...
     def __or__(self, other: MemoryType) -> int: ...
 
+class ParameterIndexEntry:
+    @property
+    def key(self) -> str: ...
+    @property
+    def length(self) -> int: ...
+    @property
+    def metadata(self) -> bytes: ...
+    @property
+    def is_file(self) -> bool: ...
+    @property
+    def is_splat(self) -> bool: ...
+    @property
+    def file_storage(self) -> Tuple[FileHandle, int]:
+        """Accesses the underlying storage (if is_file).
+
+        Only valid if is_file. Returns the backing FileHandle and offset.
+        """
+        ...
+    @property
+    def file_view(self) -> memoryview:
+        """Accesses a memoryview of the file contents.
+
+        Only valid if is_file and the file has host accessible storage.
+        """
+        ...
+    @property
+    def splat_pattern(self) -> bytes:
+        """Accesses the splat pattern (if is_splat)."""
+        ...
+
 class ParameterIndex:
     def __init__() -> None: ...
     def __len__(self) -> int: ...
+    def __getitem__(self, i) -> ParameterIndexEntry: ...
     def reserve(self, new_capacity: int) -> None: ...
     def add_splat(
         self,
@@ -357,6 +396,13 @@ class ParameterIndex:
     def create_provider(
         self, *, scope: str = "", max_concurrent_operations: Optional[int] = None
     ) -> ParameterProvider: ...
+    def items(self) -> List[Tuple[str, ParameterIndexEntry]]:
+        """Accesses the items as a tuple(str, entry).
+
+        Note that the index may contain duplicates, so loading into a dict
+        is up to the user, as only they can know if this is legal.
+        """
+        ...
 
 class ParameterProvider: ...
 

--- a/runtime/bindings/python/tests/io_runtime_test.py
+++ b/runtime/bindings/python/tests/io_runtime_test.py
@@ -1,0 +1,208 @@
+# Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import array
+import logging
+import numpy as np
+from pathlib import Path
+import tempfile
+import unittest
+
+import iree.compiler
+import iree.runtime as rt
+
+
+MM_TEST_COMPILED = None
+MM_TEST_ASM = r"""
+  #map = affine_map<(d0, d1) -> (d0, d1)>
+  #map1 = affine_map<(d0, d1) -> (d1, d0)>
+  #map2 = affine_map<(d0, d1) -> (d1)>
+  module @main {
+    util.global private @_params.classifier.weight {inlining_policy = #util.inline.never} = #stream.parameter.named<"params"::"weight"> : tensor<30x20xf32>
+    util.global private @_params.classifier.bias {inlining_policy = #util.inline.never} = #stream.parameter.named<"params"::"bias"> : tensor<30xf32>
+  func.func @run(%arg0: tensor<128x20xf32>) -> tensor<128x30xf32> {
+    %0 = call @forward(%arg0) : (tensor<128x20xf32>) -> tensor<128x30xf32>
+    return %0 : tensor<128x30xf32>
+  }
+  func.func private @forward(%arg0: tensor<128x20xf32>) -> tensor<128x30xf32> attributes {torch.assume_strict_symbolic_shapes} {
+    %cst = arith.constant 0.000000e+00 : f32
+    %_params.classifier.weight = util.global.load @_params.classifier.weight : tensor<30x20xf32>
+    %0 = tensor.empty() : tensor<20x30xf32>
+    %1 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel"]} ins(%_params.classifier.weight : tensor<30x20xf32>) outs(%0 : tensor<20x30xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<20x30xf32>
+    %2 = tensor.empty() : tensor<128x30xf32>
+    %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<128x30xf32>) -> tensor<128x30xf32>
+    %4 = linalg.matmul ins(%arg0, %1 : tensor<128x20xf32>, tensor<20x30xf32>) outs(%3 : tensor<128x30xf32>) -> tensor<128x30xf32>
+    %_params.classifier.bias = util.global.load @_params.classifier.bias : tensor<30xf32>
+    %5 = linalg.generic {indexing_maps = [#map, #map2, #map], iterator_types = ["parallel", "parallel"]} ins(%4, %_params.classifier.bias : tensor<128x30xf32>, tensor<30xf32>) outs(%2 : tensor<128x30xf32>) {
+    ^bb0(%in: f32, %in_0: f32, %out: f32):
+      %6 = arith.addf %in, %in_0 : f32
+      linalg.yield %6 : f32
+    } -> tensor<128x30xf32>
+    return %5 : tensor<128x30xf32>
+  }
+}
+"""
+
+
+def compile_mm_test():
+    global MM_TEST_COMPILED
+    if not MM_TEST_COMPILED:
+        MM_TEST_COMPILED = iree.compiler.compile_str(
+            MM_TEST_ASM,
+            target_backends=iree.compiler.core.DEFAULT_TESTING_BACKENDS,
+            # TODO(#16098): re-enable const eval once parameters are supported.
+            extra_args=["--iree-opt-const-eval=false"],
+        )
+    return MM_TEST_COMPILED
+
+
+def create_mm_test_module(instance):
+    binary = compile_mm_test()
+    return rt.VmModule.copy_buffer(instance, binary)
+
+
+def _float_constant(val: float) -> array.array:
+    return array.array("f", [val])
+
+
+class ParameterTest(unittest.TestCase):
+    def setUp(self):
+        self.instance = rt.VmInstance()
+        self.device = rt.get_device(iree.compiler.core.DEFAULT_TESTING_DRIVER)
+        self.config = rt.Config(device=self.device)
+
+    def testParameterIndex(self):
+        index = rt.ParameterIndex()
+        self.assertEqual(len(index), 0)
+        index.reserve(25)
+        self.assertEqual(len(index), 0)
+        provider = index.create_provider()
+        rt.create_io_parameters_module(self.instance, provider)
+
+    def testSplats(self):
+        splat_index = rt.ParameterIndex()
+        splat_index.add_splat("weight", _float_constant(2.0), 30 * 20 * 4)
+        splat_index.add_splat("bias", _float_constant(1.0), 30 * 4)
+        modules = rt.load_vm_modules(
+            rt.create_io_parameters_module(
+                self.instance, splat_index.create_provider(scope="params")
+            ),
+            rt.create_hal_module(self.instance, self.device),
+            create_mm_test_module(self.instance),
+            config=self.config,
+        )
+        main = modules[-1]
+        input = np.zeros([128, 20], dtype=np.float32) + 2.0
+        result = main.run(input)
+        print(result.to_host())
+        # TODO: Fix splat in the parameter code so it is not all zeros.
+        # expected_result = np.zeros([128, 30], dtype=np.float32) + 81.0
+        # np.testing.assert_array_almost_equal(result, expected_result)
+
+    def testSplatsFromBuiltIrpaFile(self):
+        with tempfile.TemporaryDirectory() as td:
+            file_path = Path(td) / "archive.irpa"
+            rt.save_archive_file(
+                {
+                    "weight": rt.SplatValue(np.float32(2.0), 30 * 20),
+                    "bias": rt.SplatValue(np.float32(1.0), 30),
+                },
+                file_path,
+            )
+
+            index = rt.ParameterIndex()
+            index.load(str(file_path))
+        modules = rt.load_vm_modules(
+            rt.create_io_parameters_module(
+                self.instance, index.create_provider(scope="params")
+            ),
+            rt.create_hal_module(self.instance, self.device),
+            create_mm_test_module(self.instance),
+            config=self.config,
+        )
+        main = modules[-1]
+        input = np.zeros([128, 20], dtype=np.float32) + 2.0
+        result = main.run(input)
+        print(result.to_host())
+        expected_result = np.zeros([128, 30], dtype=np.float32) + 81.0
+        np.testing.assert_array_almost_equal(result, expected_result)
+
+    def testBuffers(self):
+        index = rt.ParameterIndex()
+        weight = np.zeros([30, 20], dtype=np.float32) + 2.0
+        bias = np.zeros([30], dtype=np.float32) + 1.0
+        index.add_buffer("weight", weight)
+        index.add_buffer("bias", bias)
+        modules = rt.load_vm_modules(
+            rt.create_io_parameters_module(
+                self.instance, index.create_provider(scope="params")
+            ),
+            rt.create_hal_module(self.instance, self.device),
+            create_mm_test_module(self.instance),
+            config=self.config,
+        )
+        main = modules[-1]
+        input = np.zeros([128, 20], dtype=np.float32) + 2.0
+        result = main.run(input)
+        print(result.to_host())
+        expected_result = np.zeros([128, 30], dtype=np.float32) + 81.0
+        np.testing.assert_array_almost_equal(result, expected_result)
+
+    def testGguf(self):
+        index = rt.ParameterIndex()
+        index.load(
+            str(
+                Path(__file__).resolve().parent
+                / "testdata"
+                / "parameter_weight_bias_1.gguf"
+            )
+        )
+        modules = rt.load_vm_modules(
+            rt.create_io_parameters_module(
+                self.instance, index.create_provider(scope="params")
+            ),
+            rt.create_hal_module(self.instance, self.device),
+            create_mm_test_module(self.instance),
+            config=self.config,
+        )
+        main = modules[-1]
+        input = np.zeros([128, 20], dtype=np.float32) + 2.0
+        result = main.run(input)
+        print(result.to_host())
+        expected_result = np.zeros([128, 30], dtype=np.float32) + 81.0
+        np.testing.assert_array_almost_equal(result, expected_result)
+
+    def testSafetensors(self):
+        index = rt.ParameterIndex()
+        index.load(
+            str(
+                Path(__file__).resolve().parent
+                / "testdata"
+                / "parameter_weight_bias_1.safetensors"
+            )
+        )
+        modules = rt.load_vm_modules(
+            rt.create_io_parameters_module(
+                self.instance, index.create_provider(scope="params")
+            ),
+            rt.create_hal_module(self.instance, self.device),
+            create_mm_test_module(self.instance),
+            config=self.config,
+        )
+        main = modules[-1]
+        input = np.zeros([128, 20], dtype=np.float32) + 2.0
+        result = main.run(input)
+        print(result.to_host())
+        expected_result = np.zeros([128, 30], dtype=np.float32) + 81.0
+        np.testing.assert_array_almost_equal(result, expected_result)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()

--- a/runtime/bindings/python/tests/io_test.py
+++ b/runtime/bindings/python/tests/io_test.py
@@ -11,67 +11,14 @@ from pathlib import Path
 import tempfile
 import unittest
 
-import iree.compiler
 import iree.runtime as rt
-
-
-MM_TEST_COMPILED = None
-MM_TEST_ASM = r"""
-  #map = affine_map<(d0, d1) -> (d0, d1)>
-  #map1 = affine_map<(d0, d1) -> (d1, d0)>
-  #map2 = affine_map<(d0, d1) -> (d1)>
-  module @main {
-    util.global private @_params.classifier.weight {inlining_policy = #util.inline.never} = #stream.parameter.named<"params"::"weight"> : tensor<30x20xf32>
-    util.global private @_params.classifier.bias {inlining_policy = #util.inline.never} = #stream.parameter.named<"params"::"bias"> : tensor<30xf32>
-  func.func @run(%arg0: tensor<128x20xf32>) -> tensor<128x30xf32> {
-    %0 = call @forward(%arg0) : (tensor<128x20xf32>) -> tensor<128x30xf32>
-    return %0 : tensor<128x30xf32>
-  }
-  func.func private @forward(%arg0: tensor<128x20xf32>) -> tensor<128x30xf32> attributes {torch.assume_strict_symbolic_shapes} {
-    %cst = arith.constant 0.000000e+00 : f32
-    %_params.classifier.weight = util.global.load @_params.classifier.weight : tensor<30x20xf32>
-    %0 = tensor.empty() : tensor<20x30xf32>
-    %1 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel"]} ins(%_params.classifier.weight : tensor<30x20xf32>) outs(%0 : tensor<20x30xf32>) {
-    ^bb0(%in: f32, %out: f32):
-      linalg.yield %in : f32
-    } -> tensor<20x30xf32>
-    %2 = tensor.empty() : tensor<128x30xf32>
-    %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<128x30xf32>) -> tensor<128x30xf32>
-    %4 = linalg.matmul ins(%arg0, %1 : tensor<128x20xf32>, tensor<20x30xf32>) outs(%3 : tensor<128x30xf32>) -> tensor<128x30xf32>
-    %_params.classifier.bias = util.global.load @_params.classifier.bias : tensor<30xf32>
-    %5 = linalg.generic {indexing_maps = [#map, #map2, #map], iterator_types = ["parallel", "parallel"]} ins(%4, %_params.classifier.bias : tensor<128x30xf32>, tensor<30xf32>) outs(%2 : tensor<128x30xf32>) {
-    ^bb0(%in: f32, %in_0: f32, %out: f32):
-      %6 = arith.addf %in, %in_0 : f32
-      linalg.yield %6 : f32
-    } -> tensor<128x30xf32>
-    return %5 : tensor<128x30xf32>
-  }
-}
-"""
-
-
-def compile_mm_test():
-    global MM_TEST_COMPILED
-    if not MM_TEST_COMPILED:
-        MM_TEST_COMPILED = iree.compiler.compile_str(
-            MM_TEST_ASM,
-            target_backends=iree.compiler.core.DEFAULT_TESTING_BACKENDS,
-            # TODO(#16098): re-enable const eval once parameters are supported.
-            extra_args=["--iree-opt-const-eval=false"],
-        )
-    return MM_TEST_COMPILED
-
-
-def create_mm_test_module(instance):
-    binary = compile_mm_test()
-    return rt.VmModule.copy_buffer(instance, binary)
 
 
 def _float_constant(val: float) -> array.array:
     return array.array("f", [val])
 
 
-class ParameterArchiveTest(unittest.TestCase):
+class ParameterApiTest(unittest.TestCase):
     def testCreateArchiveFile(self):
         splat_index = rt.ParameterIndex()
         splat_index.add_splat("weight", _float_constant(2.0), 30 * 20 * 4)
@@ -84,161 +31,68 @@ class ParameterArchiveTest(unittest.TestCase):
             self.assertTrue(file_path.exists())
             self.assertGreater(file_path.stat().st_size, 0)
 
-    def testSaveArchiveFile(self):
-        index = rt.ParameterIndex()
+    def testArchiveFileRoundtrip(self):
         with tempfile.TemporaryDirectory() as td:
             file_path = Path(td) / "archive.irpa"
+            orig_array = np.asarray([[1], [2], [3]], dtype=np.int64)
             rt.save_archive_file(
                 {
-                    "weight": rt.SplatValue(np.float32(2.0), [30, 20]),
-                    "bias": rt.SplatValue(array.array("f", [1.0]), 30),
-                    "array": np.asarray([1, 2, 3]),
+                    "weight": rt.SplatValue(np.int8(2), [30, 20]),
+                    "bias": rt.SplatValue(array.array("b", [32]), 30),
+                    "array": orig_array,
                 },
                 file_path,
             )
             self.assertTrue(file_path.exists())
             self.assertGreater(file_path.stat().st_size, 0)
 
+            # Load and verify.
+            index = rt.ParameterIndex()
+            index.load(str(file_path))
+            self.assertEqual(len(index), 3)
 
-class ParameterTest(unittest.TestCase):
-    def setUp(self):
-        self.instance = rt.VmInstance()
-        self.device = rt.get_device(iree.compiler.core.DEFAULT_TESTING_DRIVER)
-        self.config = rt.Config(device=self.device)
+            # Note that the happy path of most properties are verified via
+            # the repr (as they are called internal to that).
+            entries = dict(index.items())
+            self.assertEqual(
+                repr(entries["weight"]),
+                "<ParameterIndexEntry 'weight' splat b'\\x02':600>",
+            )
+            self.assertEqual(
+                repr(entries["bias"]),
+                "<ParameterIndexEntry 'bias' splat b' ':30>",
+            )
+            self.assertRegex(
+                repr(entries["array"]),
+                r"<ParameterIndexEntry 'array' FileHandle<host_allocation\(.*\)>:384:24",
+            )
 
-    def testParameterIndex(self):
-        index = rt.ParameterIndex()
-        self.assertEqual(len(index), 0)
-        index.reserve(25)
-        self.assertEqual(len(index), 0)
-        provider = index.create_provider()
-        rt.create_io_parameters_module(self.instance, provider)
+            # Verify some non-happy paths.
+            with self.assertRaisesRegex(ValueError, "Entry is not file storage based"):
+                entries["weight"].file_storage
+            with self.assertRaisesRegex(ValueError, "Entry is not splat"):
+                entries["array"].splat_pattern
+
+            # Verify that the repr of the index itself is sensical.
+            index_repr = repr(index)
+            self.assertIn("Parameter scope <global> (3 entries", index_repr)
+
+            # Get the array contents and verify against original.
+            array_view = entries["array"].file_view
+            self.assertEqual(len(array_view), 24)
+            array_back = np.asarray(array_view).view(np.int64).reshape(orig_array.shape)
+            np.testing.assert_array_equal(array_back, orig_array)
 
     def testFileHandleWrap(self):
         fh = rt.FileHandle.wrap_memory(b"foobar")
+        view = fh.host_allocation
         del fh
+        self.assertEqual(bytes(view), b"foobar")
 
     def testParameterIndexAddFromFile(self):
         splat_index = rt.ParameterIndex()
         fh = rt.FileHandle.wrap_memory(b"foobar")
         splat_index.add_from_file_handle("data", fh, length=3, offset=3)
-
-    def testSplats(self):
-        splat_index = rt.ParameterIndex()
-        splat_index.add_splat("weight", _float_constant(2.0), 30 * 20 * 4)
-        splat_index.add_splat("bias", _float_constant(1.0), 30 * 4)
-        modules = rt.load_vm_modules(
-            rt.create_io_parameters_module(
-                self.instance, splat_index.create_provider(scope="params")
-            ),
-            rt.create_hal_module(self.instance, self.device),
-            create_mm_test_module(self.instance),
-            config=self.config,
-        )
-        main = modules[-1]
-        input = np.zeros([128, 20], dtype=np.float32) + 2.0
-        result = main.run(input)
-        print(result.to_host())
-        # TODO: Fix splat in the parameter code so it is not all zeros.
-        # expected_result = np.zeros([128, 30], dtype=np.float32) + 81.0
-        # np.testing.assert_array_almost_equal(result, expected_result)
-
-    def testSplatsFromBuiltIrpaFile(self):
-        with tempfile.TemporaryDirectory() as td:
-            file_path = Path(td) / "archive.irpa"
-            rt.save_archive_file(
-                {
-                    "weight": rt.SplatValue(np.float32(2.0), 30 * 20),
-                    "bias": rt.SplatValue(np.float32(1.0), 30),
-                },
-                file_path,
-            )
-
-            index = rt.ParameterIndex()
-            index.load(str(file_path))
-        modules = rt.load_vm_modules(
-            rt.create_io_parameters_module(
-                self.instance, index.create_provider(scope="params")
-            ),
-            rt.create_hal_module(self.instance, self.device),
-            create_mm_test_module(self.instance),
-            config=self.config,
-        )
-        main = modules[-1]
-        input = np.zeros([128, 20], dtype=np.float32) + 2.0
-        result = main.run(input)
-        print(result.to_host())
-        expected_result = np.zeros([128, 30], dtype=np.float32) + 81.0
-        np.testing.assert_array_almost_equal(result, expected_result)
-
-    def testBuffers(self):
-        index = rt.ParameterIndex()
-        weight = np.zeros([30, 20], dtype=np.float32) + 2.0
-        bias = np.zeros([30], dtype=np.float32) + 1.0
-        index.add_buffer("weight", weight)
-        index.add_buffer("bias", bias)
-        modules = rt.load_vm_modules(
-            rt.create_io_parameters_module(
-                self.instance, index.create_provider(scope="params")
-            ),
-            rt.create_hal_module(self.instance, self.device),
-            create_mm_test_module(self.instance),
-            config=self.config,
-        )
-        main = modules[-1]
-        input = np.zeros([128, 20], dtype=np.float32) + 2.0
-        result = main.run(input)
-        print(result.to_host())
-        expected_result = np.zeros([128, 30], dtype=np.float32) + 81.0
-        np.testing.assert_array_almost_equal(result, expected_result)
-
-    def testGguf(self):
-        index = rt.ParameterIndex()
-        index.load(
-            str(
-                Path(__file__).resolve().parent
-                / "testdata"
-                / "parameter_weight_bias_1.gguf"
-            )
-        )
-        modules = rt.load_vm_modules(
-            rt.create_io_parameters_module(
-                self.instance, index.create_provider(scope="params")
-            ),
-            rt.create_hal_module(self.instance, self.device),
-            create_mm_test_module(self.instance),
-            config=self.config,
-        )
-        main = modules[-1]
-        input = np.zeros([128, 20], dtype=np.float32) + 2.0
-        result = main.run(input)
-        print(result.to_host())
-        expected_result = np.zeros([128, 30], dtype=np.float32) + 81.0
-        np.testing.assert_array_almost_equal(result, expected_result)
-
-    def testSafetensors(self):
-        index = rt.ParameterIndex()
-        index.load(
-            str(
-                Path(__file__).resolve().parent
-                / "testdata"
-                / "parameter_weight_bias_1.safetensors"
-            )
-        )
-        modules = rt.load_vm_modules(
-            rt.create_io_parameters_module(
-                self.instance, index.create_provider(scope="params")
-            ),
-            rt.create_hal_module(self.instance, self.device),
-            create_mm_test_module(self.instance),
-            config=self.config,
-        )
-        main = modules[-1]
-        input = np.zeros([128, 20], dtype=np.float32) + 2.0
-        result = main.run(input)
-        print(result.to_host())
-        expected_result = np.zeros([128, 30], dtype=np.float32) + 81.0
-        np.testing.assert_array_almost_equal(result, expected_result)
 
     def testSplatTooBig(self):
         splat_index = rt.ParameterIndex()

--- a/runtime/bindings/python/vm.h
+++ b/runtime/bindings/python/vm.h
@@ -76,7 +76,10 @@ struct ApiPtrAdapter<iree_vm_ref_t> {
 // VmBuffer
 //------------------------------------------------------------------------------
 
-class VmBuffer : public ApiRefCounted<VmBuffer, iree_vm_buffer_t> {};
+class VmBuffer : public ApiRefCounted<VmBuffer, iree_vm_buffer_t> {
+ public:
+  int HandleBufferProtocol(Py_buffer* view, int flags);
+};
 
 //------------------------------------------------------------------------------
 // VmVariantList

--- a/runtime/pyproject.toml
+++ b/runtime/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools>=42",
     "wheel",
     "cmake",
-    "nanobind>=1.4.0",
+    "nanobind>=1.9.2",
     "ninja",
     "numpy>=2.0.0b1",
     "packaging",


### PR DESCRIPTION
The existing Python parameters API was sufficient to construct parameter indexes/archives but did not fully support introspecting them from Python.

New APIs:

* `FileHandle`:
  * Implements buffer protocol for accessing host allocations.
  * `is_host_allocation -> bool` property
  * `host_allocation -> memoryview`
  * `__repr__`
* `ParameterIndexEntry`:
  * Class added.
  * Properties: `key`, `length`, `metadata`, `is_file`, `is_splat`, `file_storage`, `file_view`, `splat_pattern`, `__repr__`
* `ParameterIndex`:
  * `__getitem__` for index based iteration
  * `items()` for `dict`-like access to a list of key/value tuples
  * `__repr__`

Includes a version upgrade of nanobind to 1.9.2 as some new features were needed (just bumped to current vs finding the exact version). This requires a patch to the Linux CI to make it set up a venv and install versions of build requirements like all of the others do (vs leaving this to whatever was packaged in the base docker).