### PR TITLE
Bump SHARK-TestSuite commit to include "keep going" change.

### DIFF
--- a/.github/workflows/pkgci_regression_test_amdgpu_rocm.yml
+++ b/.github/workflows/pkgci_regression_test_amdgpu_rocm.yml
@@ -60,7 +60,7 @@ jobs:
       #   uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       #   with:
       #     repository: nod-ai/SHARK-TestSuite
-      #     ref: 65cdac8e1dfab53892337009a9704162e1cf8bfb
+      #     ref: e67779cee2a3878c2ba9ede50f2121cf21c1e99c
       #     path: SHARK-TestSuite
       #     submodules: false
       # - name: Installing external TestSuite Python requirements

--- a/.github/workflows/pkgci_regression_test_amdgpu_vulkan.yml
+++ b/.github/workflows/pkgci_regression_test_amdgpu_vulkan.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:
           repository: nod-ai/SHARK-TestSuite
-          ref: 65cdac8e1dfab53892337009a9704162e1cf8bfb
+          ref: e67779cee2a3878c2ba9ede50f2121cf21c1e99c
           path: SHARK-TestSuite
           submodules: false
       - name: Installing external TestSuite Python requirements

--- a/.github/workflows/pkgci_regression_test_cpu.yml
+++ b/.github/workflows/pkgci_regression_test_cpu.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:
           repository: nod-ai/SHARK-TestSuite
-          ref: 65cdac8e1dfab53892337009a9704162e1cf8bfb
+          ref: e67779cee2a3878c2ba9ede50f2121cf21c1e99c
           path: SHARK-TestSuite
           submodules: false
           lfs: true


### PR DESCRIPTION
This bumps to https://github.com/nod-ai/SHARK-TestSuite/commit/e67779cee2a3878c2ba9ede50f2121cf21c1e99c.

* Previously, if compilation unexpectedly succeeded, a test case would immediately XPASS. The process would then be to remove the test from `expected_compile_failures`, run the test suite again, then possibly add the test case back to `expected_run_failures` if the run fails.
* Now, if compilation unexpectedly succeeds, the 'run' test phase will be attempted, so we can directly move the test from one XFAIL list to the other, or at least know more confidently that the test is now fully passing.

(Updating XFAIL lists could still be further automated, but this is an incremental step in the right direction)