### PR TITLE
Integrate LLVM at e0e615efac522365591119165a7691ce869de512

### DIFF
--- a/compiler/plugins/input/TOSA/InputConversion/test/apply_pdl_patterns_tosa.mlir
+++ b/compiler/plugins/input/TOSA/InputConversion/test/apply_pdl_patterns_tosa.mlir
@@ -39,14 +39,14 @@
 //       CHECK:       tosa.negate %[[RESULT]]
 
 func.func @mlp_invocation(%lhs: tensor<2x4xf32>, %rhs : tensor<4x8xf32>) -> tensor<2x8xf32> {
-  %lhs_3D = tosa.reshape %lhs {new_shape = array<i64 : 1, 2, 2>} : (tensor<2x4xf32>) -> tensor<1x2x4xf32>
-  %rhs_3D = tosa.reshape %rhs {new_shape = array<i64 : 1, 2, 2>} : (tensor<4x8xf32>) -> tensor<1x4x8xf32>
+  %lhs_3D = tosa.reshape %lhs {new_shape = array<i64 : 1, 2, 4>} : (tensor<2x4xf32>) -> tensor<1x2x4xf32>
+  %rhs_3D = tosa.reshape %rhs {new_shape = array<i64 : 1, 4, 8>} : (tensor<4x8xf32>) -> tensor<1x4x8xf32>
   %0 = tosa.matmul %lhs_3D, %rhs_3D : (tensor<1x2x4xf32>, tensor<1x4x8xf32>) -> tensor<1x2x8xf32>
   %1 = tosa.clamp %0 {
       min_int = 0 : i64, max_int = 9223372036854775807 : i64,
       min_fp = 0.0 : f32, max_fp = 3.4028235e+38 : f32}
       : (tensor<1x2x8xf32>) -> tensor<1x2x8xf32>
   %2 = tosa.negate %1 : (tensor<1x2x8xf32>) -> tensor<1x2x8xf32>
-  %3 = tosa.reshape %2 {new_shape = array<i64 : 2, 2>}  : (tensor<1x2x8xf32>) -> tensor<2x8xf32>
+  %3 = tosa.reshape %2 {new_shape = array<i64 : 2, 8>}  : (tensor<1x2x8xf32>) -> tensor<2x8xf32>
   return %3 : tensor<2x8xf32>
 }


### PR DESCRIPTION
IREE-side, just had to fix a faulty test, same issue as in integrate #16944.  Just some incoherent shapes in `tosa.reshape`.