### PR TITLE
Bump nanobind version in more requirement files.

### DIFF
--- a/compiler/pyproject.toml
+++ b/compiler/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
     # Note that the compiler wheel does not presently need nanobind, but
     # it's build is enabled by the same flag which enables the runtime
     # configuration, which does.
-    "nanobind>=1.4.0",
+    "nanobind>=1.9.2",
     "ninja",
     # MLIR build depends.
     "numpy",

--- a/runtime/bindings/python/iree/runtime/build_requirements.txt
+++ b/runtime/bindings/python/iree/runtime/build_requirements.txt
@@ -5,7 +5,7 @@
 
 pip>=21.3
 setuptools>=62.4.0
-nanobind>=1.4.0
+nanobind>=1.9.2
 numpy>=2.0.0b1
 requests>=2.28.0
 wheel>=0.36.2


### PR DESCRIPTION
The nanobind version in `runtime/pyproject.toml` was updated in https://github.com/openxla/iree/pull/16957. When I tried to update my local version with pip, I needed to additionally pass `--upgrade`. I think we should also update the minimums in these other files.

```
python -m pip install -r runtime/bindings/python/iree/runtime/build_requirements.txt
...
Requirement already satisfied: nanobind>=1.4.0 in d:\dev\projects\iree\.venv\lib\site-packages (from -r runtime/bindings/python/iree/runtime/build_requirements.txt (line 8)) (1.8.0)
```