### PR TITLE
[python] Add missing public alias of symbol.

### DIFF
--- a/runtime/bindings/python/iree/runtime/__init__.py
+++ b/runtime/bindings/python/iree/runtime/__init__.py
@@ -17,6 +17,7 @@ from . import _binding
 from ._binding import (
     FileHandle,
     ParameterIndex,
+    ParameterIndexEntry,
     ParameterProvider,
     create_io_parameters_module,
 )


### PR DESCRIPTION
The prior patch forgot to export this as part of the public namespace despite advertising it as such. This type is mostly useful standalone for type annotations, which is why it was missed.