### PR TITLE
Document testing policy and external test suite.

### DIFF
--- a/docs/website/docs/developers/general/contributing.md
+++ b/docs/website/docs/developers/general/contributing.md
@@ -72,6 +72,14 @@ information on using pull requests.
   working for a certain situation, please ask as we bias towards pragmatism for
   cases that require it.
 
+### :material-test-tube: Testing policy
+
+With few exceptions, features should be accompanied by automated tests.
+
+We use a mix of in-tree and out-of-tree unit and integration tests. For more
+information about the types of tests used across the project, refer to the
+[testing guide](./testing-guide.md).
+
 ### :material-check-all: GitHub Actions workflows
 
 We use [GitHub Actions](https://docs.github.com/en/actions) to automatically


### PR DESCRIPTION
Having a documented "test policy" is one of the checkboxes for https://www.bestpractices.dev/en :

> The project MUST have a general policy (formal or not) that as major new functionality is added to the software produced by the project, tests of that functionality should be added to an automated test suite.
As long as a policy is in place, even by word of mouth, that says developers should add tests to the automated test suite for major new functionality, select "Met."

We've had an informal policy, but this makes it more explicit.

---

While touching testing docs, I also added a section for https://github.com/nod-ai/SHARK-TestSuite/ and how that is integrated into this repo.