### PR TITLE
Avoid distributing loops that are statically known to be unit trip count

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_pad_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_pad_tests.mlir
@@ -39,24 +39,23 @@ hal.executable private @pad_only {
 //       CHECK:   %[[OUTPUT:.+]] = hal.interface.binding.subspan {{.+}} : memref<1x114x114x64xf32
 //       CHECK:   scf.for
 //       CHECK:     scf.for
-//       CHECK:       scf.for
-//       CHECK:         scf.if
-//       CHECK:           %[[OUTPUT_SUBVIEW_IF:.+]] = memref.subview %[[OUTPUT]]
-//       CHECK:           linalg.generic
-//  CHECK-SAME:               outs(%[[OUTPUT_SUBVIEW_IF]]
-//       CHECK:         else
-//       CHECK:           %[[INPUT_SUBVIEW:.+]] = memref.subview %[[INPUT]]
-//       CHECK:           %[[OUTPUT_SUBVIEW:.+]] = memref.subview %[[OUTPUT]]
+//       CHECK:       scf.if
+//       CHECK:         %[[OUTPUT_SUBVIEW_IF:.+]] = memref.subview %[[OUTPUT]]
+//       CHECK:         linalg.generic
+//  CHECK-SAME:             outs(%[[OUTPUT_SUBVIEW_IF]]
+//       CHECK:       else
+//       CHECK:         %[[INPUT_SUBVIEW:.+]] = memref.subview %[[INPUT]]
+//       CHECK:         %[[OUTPUT_SUBVIEW:.+]] = memref.subview %[[OUTPUT]]
+//       CHECK:         scf.for
 //       CHECK:           scf.for
 //       CHECK:             scf.for
-//       CHECK:               scf.for
-//       CHECK:                 %[[OUTPUT_SLICE:.+]] = memref.subview %[[OUTPUT_SUBVIEW]]
-//       CHECK:                 %[[RESULT_VEC:.+]] = scf.if %{{.+}} -> (vector<4xf32>) {
-//       CHECK:                   %[[VEC_LOAD:.+]] = vector.load %[[INPUT_SUBVIEW]]
-//       CHECK:                   scf.yield %[[VEC_LOAD]]
-//       CHECK:                 }
-//       CHECK:                 %[[DROP_UNIT_OUTPUT_SLICE:.+]] = memref.subview %[[OUTPUT_SLICE]]
-//       CHECK:                 vector.store %[[RESULT_VEC]], %[[DROP_UNIT_OUTPUT_SLICE]]
+//       CHECK:               %[[OUTPUT_SLICE:.+]] = memref.subview %[[OUTPUT_SUBVIEW]]
+//       CHECK:               %[[RESULT_VEC:.+]] = scf.if %{{.+}} -> (vector<4xf32>) {
+//       CHECK:                 %[[VEC_LOAD:.+]] = vector.load %[[INPUT_SUBVIEW]]
+//       CHECK:                 scf.yield %[[VEC_LOAD]]
+//       CHECK:               }
+//       CHECK:               %[[DROP_UNIT_OUTPUT_SLICE:.+]] = memref.subview %[[OUTPUT_SLICE]]
+//       CHECK:               vector.store %[[RESULT_VEC]], %[[DROP_UNIT_OUTPUT_SLICE]]
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute.mlir
@@ -135,15 +135,12 @@ hal.executable private @conv_1d {
 //       CHECK: %[[BDIMX:.+]] = gpu.block_dim x
 //       CHECK: %[[TIDY:.+]] = gpu.thread_id y
 //       CHECK: %[[BDIMY:.+]] = gpu.block_dim y
-//       CHECK: %[[TIDZ:.+]] = gpu.thread_id z
-//       CHECK: %[[BDIMZ:.+]] = gpu.block_dim z
-//       CHECK: scf.for %[[IV_Z:.+]] = %[[TIDZ]] to %{{.*}} step %[[BDIMZ]]
-//       CHECK:   scf.for %[[IV_Y:.+]] = %[[TIDY]] to %{{.*}} step %[[BDIMY]]
-//       CHECK:     scf.for %[[IV_X:.+]] = %[[TIDX]] to %{{.*}} step %[[BDIMX]]
-//       CHECK:       %[[ARG0SV2:.+]] = memref.subview %[[ARG0SV1]][%[[IV_Z]], %[[IV_Y]], 0] [1, 3, 1]
-//       CHECK:       %[[ARG1SV2:.+]] = memref.subview %[[ARG1SV1]][0, 0, %[[IV_X]]] [3, 1, 1]
-//       CHECK:       %[[RETSV2:.+]] = memref.subview %[[RETSV1]][%[[IV_Z]], %[[IV_Y]], %[[IV_X]]] [1, 1, 1]
-//       CHECK:       linalg.conv_1d_nwc_wcf
+//       CHECK: scf.for %[[IV_Y:.+]] = %[[TIDY]] to %{{.*}} step %[[BDIMY]]
+//       CHECK:   scf.for %[[IV_X:.+]] = %[[TIDX]] to %{{.*}} step %[[BDIMX]]
+//       CHECK:     %[[ARG0SV2:.+]] = memref.subview %[[ARG0SV1]][0, %[[IV_Y]], 0] [1, 3, 1]
+//       CHECK:     %[[ARG1SV2:.+]] = memref.subview %[[ARG1SV1]][0, 0, %[[IV_X]]] [3, 1, 1]
+//       CHECK:     %[[RETSV2:.+]] = memref.subview %[[RETSV1]][0, %[[IV_Y]], %[[IV_X]]] [1, 1, 1]
+//       CHECK:     linalg.conv_1d_nwc_wcf
 //  CHECK-SAME:         ins(%[[ARG0SV2]], %[[ARG1SV2]]
 //  CHECK-SAME:         outs(%[[RETSV2]]
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_sort.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_sort.mlir
@@ -38,11 +38,9 @@ hal.executable private @static_3d_sort  {
 //       CHECK: %[[WG_OUTPUT:.+]] = memref.subview %[[ARG0]]
 //       CHECK: %[[TID_X:.+]] = gpu.thread_id x
 //       CHECK: %[[DIM_X:.+]] = gpu.block_dim x
-//       CHECK: %[[TID_Y:.+]] = gpu.thread_id y
-//       CHECK: %[[DIM_Y:.+]] = gpu.block_dim y
-//       CHECK: scf.for %[[IV_Y:.+]] = %[[TID_Y]] to %{{.+}} step %[[DIM_Y]]
-//       CHECK:   scf.for %[[IV_X:.+]] = %[[TID_X]] to %{{.+}} step %[[DIM_X]]
-//       CHECK:     %[[DEST:.+]] = memref.subview %[[WG_OUTPUT]][%[[IV_Y]], 0, %[[IV_X]]]
-//       CHECK:     iree_linalg_ext.sort
+//       CHECK: scf.for %[[IV_X:.+]] = %[[TID_X]] to %{{.+}} step %[[DIM_X]]
+//       CHECK:   %[[DEST:.+]] = memref.subview %[[WG_OUTPUT]][0, 0, %[[IV_X]]]
+//       CHECK:   %[[CAST:.+]] = memref.cast %[[DEST]]
+//       CHECK:   iree_linalg_ext.sort
 //  CHECK-SAME:       dimension(1)
-//  CHECK-SAME:       outs(%[[DEST]]
+//  CHECK-SAME:       outs(%[[CAST]]


### PR DESCRIPTION
If a loop is known to be statically unit dimension, there is no reason to distribute it. Not doing so avoids creating unnecessary dynamic dimensions in the tiled code.

Also use `OpFoldResult` more aggressively to constant propagate values in first level tile and distribute.