### PR TITLE
Integrate LLVM at 9708d0900311503aa4685d6810d8caf0412e15d7

### DIFF
--- a/build_tools/pkgci/external_test_suite/onnx_gpu_cuda.json
+++ b/build_tools/pkgci/external_test_suite/onnx_gpu_cuda.json
@@ -809,7 +809,6 @@
     "test_qlinearmatmul_3D_uint8_float32",
     "test_quantizelinear",
     "test_range_int32_type_negative_delta",
-    "test_scatter_elements_with_negative_indices",
     "test_selu_default",
     "test_shape",
     "test_shape_clip_end",


### PR DESCRIPTION
Removing `test_scatter_elements_with_negative_indices` from the expected-fail test list in `onnx-cuda-gpu`.