### PR TITLE
Disable out of tree ROCm tests again.

### DIFF
--- a/.github/workflows/pkgci_regression_test_amdgpu_rocm.yml
+++ b/.github/workflows/pkgci_regression_test_amdgpu_rocm.yml
@@ -53,22 +53,24 @@ jobs:
             -rA -s -m "plat_rdna3_rocm and presubmit" \
             experimental/regression_suite
 
-      # Out of tree tests
-      - name: Checking out external TestSuite repository
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
-        with:
-          repository: nod-ai/SHARK-TestSuite
-          ref: e67779cee2a3878c2ba9ede50f2121cf21c1e99c
-          path: SHARK-TestSuite
-          submodules: false
-      - name: Installing external TestSuite Python requirements
-        run: |
-          source ${VENV_DIR}/bin/activate
-          python -m pip install -r SHARK-TestSuite/iree_tests/requirements.txt
-      - name: Run external tests - ONNX test suite
-        run: |
-          source ${VENV_DIR}/bin/activate
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/rocm/lib:/opt/rocm/hip/lib
-          pytest SHARK-TestSuite/iree_tests/onnx/ \
-              -n 4 -rpfE --timeout=30 --retries=2 --durations=20 \
-              --config-files=build_tools/pkgci/external_test_suite/onnx_gpu_rocm_rdna3.json
+      # Disabled while flaky / unreliable (runners crashing?)
+
+      # # Out of tree tests
+      # - name: Checking out external TestSuite repository
+      #   uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+      #   with:
+      #     repository: nod-ai/SHARK-TestSuite
+      #     ref: e67779cee2a3878c2ba9ede50f2121cf21c1e99c
+      #     path: SHARK-TestSuite
+      #     submodules: false
+      # - name: Installing external TestSuite Python requirements
+      #   run: |
+      #     source ${VENV_DIR}/bin/activate
+      #     python -m pip install -r SHARK-TestSuite/iree_tests/requirements.txt
+      # - name: Run external tests - ONNX test suite
+      #   run: |
+      #     source ${VENV_DIR}/bin/activate
+      #     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/rocm/lib:/opt/rocm/hip/lib
+      #     pytest SHARK-TestSuite/iree_tests/onnx/ \
+      #         -n 4 -rpfE --timeout=30 --retries=2 --durations=20 \
+      #         --config-files=build_tools/pkgci/external_test_suite/onnx_gpu_rocm_rdna3.json


### PR DESCRIPTION
Partial revert of https://github.com/openxla/iree/pull/16974

These tests are still unstable. Unclear where the source of instability is... I'm suspecting that they are crashing the runner.

skip-ci: not useful to run builds/tests on this