### PR TITLE
[GlobalOpt][DT] Add a flag to disable early materialization.

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
@@ -36,8 +36,8 @@ static llvm::cl::opt<bool> clEnableTransposePropagation(
     llvm::cl::init(false));
 
 // TODO(hanchung): Remove the flag. We don't want to do early materialization by
-// default. Because it won't work for heterogeneous computing. This is the right
-// layer for handling such information.
+// default. Because it won't work for heterogeneous computing. This is not the
+// right layer for handling such information.
 static llvm::cl::opt<bool> clEnableEarlyMaterialization(
     "iree-global-opt-enable-early-materialization",
     llvm::cl::desc(

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
@@ -35,6 +35,16 @@ static llvm::cl::opt<bool> clEnableTransposePropagation(
         "Enables propagation of transpose ops to improve fusion chances."),
     llvm::cl::init(false));
 
+// TODO(hanchung): Remove the flag. We don't want to do early materialization by
+// default. Because it won't work for heterogeneous computing. This is the right
+// layer for handling such information.
+static llvm::cl::opt<bool> clEnableEarlyMaterialization(
+    "iree-global-opt-enable-early-materialization",
+    llvm::cl::desc(
+        "Enables early materialization on encodings. Note, this flag should be "
+        "false eventually. This does not work for heterogeneous computing."),
+    llvm::cl::init(true));
+
 static llvm::cl::opt<bool> clEnableDemoteContractionInputsToBF16(
     "iree-global-opt-enable-demote-contraction-inputs-to-bf16",
     llvm::cl::desc(
@@ -138,8 +148,12 @@ void buildGlobalOptimizationPassPipeline(
 
   // Enable data tiling after they are in a canonical form.
   if (transformOptions.options.dataTiling) {
+    // TODO(hanchung): Make data-tiling passes be FunctionOpInterface pass, so
+    // we can use `FunctionLikNest` here.
     mainPassManager.addPass(createSetEncodingPass());
-    mainPassManager.addPass(createMaterializeHomogeneousEncodingsPass());
+    if (clEnableEarlyMaterialization) {
+      mainPassManager.addPass(createMaterializeHomogeneousEncodingsPass());
+    }
     mainPassManager.addPass(createCanonicalizerPass());
     mainPassManager.addPass(createCSEPass());
     mainPassManager.addPass(createSimplifyPackUnpackPass());


### PR DESCRIPTION
This revision adds a flag to disable early materialization. It unblocks the data-tiling prototype of next evolution. Because it provides a path to defer materialization to later stages, e.g., Flow, Stream, etc.