### PR TITLE
Increase pip install timeout for pkgci venv setup.

### DIFF
--- a/build_tools/pkgci/setup_venv.py
+++ b/build_tools/pkgci/setup_venv.py
@@ -169,14 +169,15 @@ def main(args):
         print(f"Running command: {' '.join([str(c) for c in cmd])}")
         subprocess.check_call(cmd)
 
-    # Now install the regression suite project, which will bring in any
-    # deps.
+    # Now install the regression suite project, which will bring in any deps.
     cmd = [
         str(python_exe),
         "-m",
         "pip",
         "install",
         "--force-reinstall",
+        "--timeout",
+        "60",
         "-e",
         str(rs_dir) + os.sep,
     ]


### PR DESCRIPTION
This seems to be hitting timeouts fairly consistently like https://github.com/openxla/iree/actions/runs/8620996079/job/23635284186#step:5:34 . Unclear if the download is just slow or if there are network issues (I'm suspecting network/configuration issues, but happy to be proven wrong...). The default timeout is 15 seconds.

```
Collecting numpy (from iree-regression-suite==0.1.dev1)
  Downloading numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (61 kB)
                                              0.0/61.0 kB ? eta -:--:--
ERROR: Exception:
Traceback (most recent call last):
  File "/_work/iree/iree/venv/lib/python3.11/site-packages/pip/_vendor/urllib3/response.py", line 4[38](https://github.com/openxla/iree/actions/runs/8620996079/job/23635284186#step:5:39), in _error_catcher
    yield
  File "/_work/iree/iree/venv/lib/python3.11/site-packages/pip/_vendor/urllib3/response.py", line 561, in read
    data = self._fp_read(amt) if not fp_closed else b""
           ^^^^^^^^^^^^^^^^^^
  File "/_work/iree/iree/venv/lib/python3.11/site-packages/pip/_vendor/urllib3/response.py", line 527, in _fp_read
    return self._fp.read(amt) if amt is not None else self._fp.read()
           ^^^^^^^^^^^^^^^^^^
  File "/_work/iree/iree/venv/lib/python3.11/site-packages/pip/_vendor/cachecontrol/filewrapper.py", line 98, in read
    data: bytes = self.__fp.read(amt)
                  ^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/http/client.py", line [47](https://github.com/openxla/iree/actions/runs/8620996079/job/23635284186#step:5:48)3, in read
    s = self.fp.read(amt)
        ^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/socket.py", line 706, in readinto
    return self._sock.recv_into(b)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/ssl.py", line 1314, in recv_into
    return self.read(nbytes, buffer)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/ssl.py", line 1166, in read
    return self._sslobj.read(len, buffer)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TimeoutError: The read operation timed out
```