### PR TITLE
[GPU] Overhaul reduce shared memory bank conflicts pass for gfx9

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUReduceBankConflicts.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUReduceBankConflicts.cpp
@@ -17,7 +17,7 @@ namespace mlir::iree_compiler {
 /// Pad out the inner dimension of the `memref.alloc` op in order reduce the
 /// chances to have bank conflicts when reading 2D shapes within shared memory.
 static void padAlloc(MLIRContext *context, memref::AllocOp allocOp,
-                     int64_t paddingSizeBits) {
+                     unsigned paddingSizeBits) {
   auto allocOpShape = allocOp.getType().getShape();
   if (allocOpShape.empty())
     return;
@@ -89,7 +89,7 @@ struct GPUReduceBankConflictsPass final
   }
 
 private:
-  int64_t paddingSizeBits;
+  unsigned paddingSizeBits;
 };
 
 } // namespace

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
@@ -116,7 +116,7 @@ createGPUPipeliningPass(bool epiloguePeeling = true, unsigned depth = 1,
 /// Apply transformation to reduce the number of bank conflicts when accessing
 /// shared memory by padding fastest moving dimension with the specified size.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createGPUReduceSharedMemoryBankConflicts(int64_t paddingSizeBits = 64);
+createGPUReduceSharedMemoryBankConflicts(int64_t paddingSizeBits = 128);
 
 // Creates a pass to create allocations for some tensor values to use GPU
 // shared memory.

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
@@ -56,6 +56,15 @@ LogicalResult tileReductionToSerialLoops(mlir::FunctionOpInterface funcOp,
 LogicalResult swizzleWorkgroupsInFunc(mlir::FunctionOpInterface funcOp,
                                       unsigned swizzleLogTile);
 
+/// Adds padding to `memref.alloc` ops to reduce shared memory bank conflicts.
+/// The `paddingSizeBits` argument should be picked based on the target
+/// architecture, striking balance between minimizing bank conflicts and keeping
+/// the data aligned. Smaller values (close to the bank bitwidth) achieve the
+/// former, while larger (~= widest load size) the latter. We want to
+/// **misalign** the rows, but not too much.
+LogicalResult reduceSharedMemoryBankConflicts(mlir::FunctionOpInterface funcOp,
+                                              unsigned paddingSizeBits);
+
 // Lowers workgroup memory copies to distributed transfer_read/transfer_write
 // ops. Expects the memory copy to be marked with copy_to_workgroup_memory
 // marker.
@@ -107,7 +116,7 @@ createGPUPipeliningPass(bool epiloguePeeling = true, unsigned depth = 1,
 /// Apply transformation to reduce the number of bank conflicts when accessing
 /// shared memory by padding fastest moving dimension with the specified size.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createGPUReduceSharedMemoryBankConflicts(int64_t paddingSizeBits = 128);
+createGPUReduceSharedMemoryBankConflicts(int64_t paddingSizeBits = 64);
 
 // Creates a pass to create allocations for some tensor values to use GPU
 // shared memory.

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -82,6 +82,11 @@ def GPUReduceBankConflicts :
     InterfacePass<"iree-codegen-gpu-reduce-bank-conflicts", "mlir::FunctionOpInterface"> {
   let summary = "Pass to try to reduce the number of bank conflicts by padding memref.alloc ops.";
   let constructor = "mlir::iree_compiler::createGPUReduceSharedMemoryBankConflicts()";
+  let options = [
+    Option<"paddingBits", "padding-bits", "unsigned",
+            /*default=*/"128",
+            "Padding size (in bits) to introduce between rows.">
+  ];
 }
 
 def GPUTensorAlloc :

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -80,7 +80,7 @@ def GPUPipelining : InterfacePass<"iree-codegen-gpu-pipelining", "mlir::Function
 
 def GPUReduceBankConflicts :
     InterfacePass<"iree-codegen-gpu-reduce-bank-conflicts", "mlir::FunctionOpInterface"> {
-  let summary = "Pass to try to reduce the number of bank conflicts.";
+  let summary = "Pass to try to reduce the number of bank conflicts by padding memref.alloc ops.";
   let constructor = "mlir::iree_compiler::createGPUReduceSharedMemoryBankConflicts()";
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
@@ -36,6 +36,7 @@ iree_lit_test_suite(
             "gpu_vector_distribution.mlir",
             "reduce_bank_conflicts.mlir",
             "transform_gpu_distribute_shared_memory.mlir",
+            "transform_gpu_reduce_bank_conflicts.mlir",
             "transform_gpu_workgroup_swizzle.mlir",
             "vector_reduction_to_gpu.mlir",
         ],

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
@@ -32,6 +32,7 @@ iree_lit_test_suite(
     "gpu_vector_distribution.mlir"
     "reduce_bank_conflicts.mlir"
     "transform_gpu_distribute_shared_memory.mlir"
+    "transform_gpu_reduce_bank_conflicts.mlir"
     "transform_gpu_workgroup_swizzle.mlir"
     "vector_reduction_to_gpu.mlir"
   TOOLS

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/reduce_bank_conflicts.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/reduce_bank_conflicts.mlir
@@ -3,18 +3,21 @@
 #map = affine_map<(d0, d1, d2) -> (d0 * 2048 + d1 * 64 + d2)>
 
 // CHECK-LABEL: func.func @pad_alloc
+// CHECK:         %[[A:.*]] = memref.alloc() : memref<4x32x66xf32, #gpu.address_space<workgroup>>
+// CHECK:         %[[S1:.*]] = memref.subview %[[A]][0, 0, 0] [4, 32, 64] [1, 1, 1] :
+// CHECK-SAME:      memref<4x32x66xf32, #gpu.address_space<workgroup>> to memref<4x32x64xf32, strided<[2112, 66, 1]>, #gpu.address_space<workgroup>>
+// CHECK:         %[[S2:.*]] = memref.subview %[[S1]][0, 0, 0] [1, 32, 64] [1, 1, 1] :
+// CHECK-SAME:      memref<4x32x64xf32, strided<[2112, 66, 1]>, #gpu.address_space<workgroup>> to memref<1x32x64xf32, strided<[2112, 66, 1]>, #gpu.address_space<workgroup>>
+// CHECK:           vector.transfer_write %{{.*}}, %[[S2]][%{{.*}}, %{{.*}}, %{{.*}}] {in_bounds = [true]} :
+// CHECK-SAME:      vector<4xf32>, memref<1x32x64xf32, strided<[2112, 66, 1]>, #gpu.address_space<workgroup>
 func.func @pad_alloc(%a: memref<1024x1024xf32>) {
-// CHECK: %[[A:.*]] = memref.alloc() : memref<4x32x66xf32, #gpu.address_space<workgroup>>
   %0 = memref.alloc() : memref<4x32x64xf32, #gpu.address_space<workgroup>>
-// CHECK: %[[S1:.*]] = memref.subview %[[A]][0, 0, 0] [4, 32, 64] [1, 1, 1] : memref<4x32x66xf32, #gpu.address_space<workgroup>> to memref<4x32x64xf32, strided<[2112, 66, 1]>, #gpu.address_space<workgroup>>
-// CHECK: %[[S2:.*]] = memref.subview %[[S1]][0, 0, 0] [1, 32, 64] [1, 1, 1] : memref<4x32x64xf32, strided<[2112, 66, 1]>, #gpu.address_space<workgroup>> to memref<1x32x64xf32, strided<[2112, 66, 1]>, #gpu.address_space<workgroup>>
   %1 = memref.subview %0[0, 0, 0] [1, 32, 64] [1, 1, 1] :
     memref<4x32x64xf32, #gpu.address_space<workgroup>> to memref<1x32x64xf32, #map, #gpu.address_space<workgroup>>
   %c0 = arith.constant 0 : index
   %cst_0 = arith.constant 0.000000e+00 : f32
   %2 = vector.transfer_read %a[%c0, %c0], %cst_0 {in_bounds = [true]} :
     memref<1024x1024xf32>, vector<4xf32>
-// CHECK: vector.transfer_write %{{.*}}, %[[S2]][%{{.*}}, %{{.*}}, %{{.*}}] {in_bounds = [true]} : vector<4xf32>, memref<1x32x64xf32, strided<[2112, 66, 1]>, #gpu.address_space<workgroup>
   vector.transfer_write %2, %1[%c0, %c0, %c0] {in_bounds = [true]} :
     vector<4xf32>, memref<1x32x64xf32, #map, #gpu.address_space<workgroup>>
   return
@@ -23,9 +26,9 @@ func.func @pad_alloc(%a: memref<1024x1024xf32>) {
 // -----
 
 // CHECK-LABEL: func.func @pad_alloc_negative
+// CHECK:         memref.alloc(%{{.*}}) : memref<?x32x64xf32, #gpu.address_space<workgroup>
 func.func @pad_alloc_negative(%a: memref<1024x1024xf32>, %i: index, %v: vector<4xf32>) {
   %c0 = arith.constant 0 : index
-// CHECK: memref.alloc(%{{.*}}) : memref<?x32x64xf32, #gpu.address_space<workgroup>
   %0 = memref.alloc(%i) : memref<?x32x64xf32, #gpu.address_space<workgroup>>
   vector.transfer_write %v, %0[%c0, %c0, %c0] {in_bounds = [true]} :
     vector<4xf32>, memref<?x32x64xf32, #gpu.address_space<workgroup>>
@@ -35,9 +38,9 @@ func.func @pad_alloc_negative(%a: memref<1024x1024xf32>, %i: index, %v: vector<4
 // -----
 
 // CHECK-LABEL: func.func @pad_alloc_rank_zero
+// CHECK:         memref.alloc() : memref<f32, #gpu.address_space<workgroup>
 func.func @pad_alloc_rank_zero() {
   %cst = arith.constant dense<-3.40282347E+38> : vector<f32>
-// CHECK: memref.alloc() : memref<f32, #gpu.address_space<workgroup>
   %0 = memref.alloc() : memref<f32, #gpu.address_space<workgroup>>
   vector.transfer_write %cst, %0[] : vector<f32>, memref<f32, #gpu.address_space<workgroup>>
   return

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/reduce_bank_conflicts.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/reduce_bank_conflicts.mlir
@@ -4,17 +4,17 @@
 
 // CHECK-LABEL: func.func @pad_alloc
 func.func @pad_alloc(%a: memref<1024x1024xf32>) {
-// CHECK: %[[A:.*]] = memref.alloc() : memref<4x32x68xf32, #gpu.address_space<workgroup>>
+// CHECK: %[[A:.*]] = memref.alloc() : memref<4x32x66xf32, #gpu.address_space<workgroup>>
   %0 = memref.alloc() : memref<4x32x64xf32, #gpu.address_space<workgroup>>
-// CHECK: %[[S1:.*]] = memref.subview %[[A]][0, 0, 0] [4, 32, 64] [1, 1, 1] : memref<4x32x68xf32, #gpu.address_space<workgroup>> to memref<4x32x64xf32, strided<[2176, 68, 1]>, #gpu.address_space<workgroup>>
-// CHECK: %[[S2:.*]] = memref.subview %[[S1]][0, 0, 0] [1, 32, 64] [1, 1, 1] : memref<4x32x64xf32, strided<[2176, 68, 1]>, #gpu.address_space<workgroup>> to memref<1x32x64xf32, strided<[2176, 68, 1]>, #gpu.address_space<workgroup>>
+// CHECK: %[[S1:.*]] = memref.subview %[[A]][0, 0, 0] [4, 32, 64] [1, 1, 1] : memref<4x32x66xf32, #gpu.address_space<workgroup>> to memref<4x32x64xf32, strided<[2112, 66, 1]>, #gpu.address_space<workgroup>>
+// CHECK: %[[S2:.*]] = memref.subview %[[S1]][0, 0, 0] [1, 32, 64] [1, 1, 1] : memref<4x32x64xf32, strided<[2112, 66, 1]>, #gpu.address_space<workgroup>> to memref<1x32x64xf32, strided<[2112, 66, 1]>, #gpu.address_space<workgroup>>
   %1 = memref.subview %0[0, 0, 0] [1, 32, 64] [1, 1, 1] :
     memref<4x32x64xf32, #gpu.address_space<workgroup>> to memref<1x32x64xf32, #map, #gpu.address_space<workgroup>>
   %c0 = arith.constant 0 : index
   %cst_0 = arith.constant 0.000000e+00 : f32
   %2 = vector.transfer_read %a[%c0, %c0], %cst_0 {in_bounds = [true]} :
     memref<1024x1024xf32>, vector<4xf32>
-// CHECK: vector.transfer_write %{{.*}}, %[[S2]][%{{.*}}, %{{.*}}, %{{.*}}] {in_bounds = [true]} : vector<4xf32>, memref<1x32x64xf32, strided<[2176, 68, 1]>, #gpu.address_space<workgroup>
+// CHECK: vector.transfer_write %{{.*}}, %[[S2]][%{{.*}}, %{{.*}}, %{{.*}}] {in_bounds = [true]} : vector<4xf32>, memref<1x32x64xf32, strided<[2112, 66, 1]>, #gpu.address_space<workgroup>
   vector.transfer_write %2, %1[%c0, %c0, %c0] {in_bounds = [true]} :
     vector<4xf32>, memref<1x32x64xf32, #map, #gpu.address_space<workgroup>>
   return

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/reduce_bank_conflicts.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/reduce_bank_conflicts.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt %s --split-input-file --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-reduce-bank-conflicts))" | FileCheck %s
+// RUN: iree-opt %s --split-input-file --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-reduce-bank-conflicts{padding-bits=64}))" | FileCheck %s
 
 #map = affine_map<(d0, d1, d2) -> (d0 * 2048 + d1 * 64 + d2)>
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/transform_gpu_reduce_bank_conflicts.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/transform_gpu_reduce_bank_conflicts.mlir
@@ -1,17 +1,20 @@
 // RUN: iree-opt %s --iree-transform-dialect-interpreter --transform-dialect-drop-schedule | FileCheck %s
 
 // CHECK-LABEL: func.func @pad_alloc
+// CHECK:         %[[A:.*]] = memref.alloc() : memref<64x68xf16, #gpu.address_space<workgroup>>
+// CHECK:         %[[S1:.*]] = memref.subview %[[A]][0, 0] [64, 64] [1, 1] :
+// CHECK-SAME:    memref<64x68xf16, #gpu.address_space<workgroup>> to memref<64x64xf16, strided<[68, 1]>, #gpu.address_space<workgroup>>
+// CHECK:         vector.transfer_read %[[S1]][%{{.*}}, %{{.*}}], %{{.*}} :
+// CHECK-SAME:      memref<64x64xf16, strided<[68, 1]>, #gpu.address_space<workgroup>>, vector<8xf16>
+// CHECK:         vector.transfer_write %{{.*}}, %[[S1]][%{{.*}}, %{{.*}}] :
+// CHECK-SAME:      vector<1x8xf16>, memref<64x64xf16, strided<[68, 1]>, #gpu.address_space<workgroup>>
 func.func @pad_alloc() {
-// CHECK: %[[A:.*]] = memref.alloc() : memref<64x68xf16, #gpu.address_space<workgroup>>
   %alloc = memref.alloc() : memref<64x64xf16, #gpu.address_space<workgroup>>
-// CHECK: %[[S1:.*]] = memref.subview %[[A]][0, 0] [64, 64] [1, 1] : memref<64x68xf16, #gpu.address_space<workgroup>> to memref<64x64xf16, strided<[68, 1]>, #gpu.address_space<workgroup>>
   %c0 = arith.constant 0 : index
   %cst_0 = arith.constant 0.000000e+00 : f16
   %cst_1 = arith.constant dense<1.0> : vector<1x8xf16>
 
-// CHECK: vector.transfer_read %[[S1]][%{{.*}}, %{{.*}}], %{{.*}} : memref<64x64xf16, strided<[68, 1]>, #gpu.address_space<workgroup>>, vector<8xf16>
   %2 = vector.transfer_read %alloc[%c0, %c0], %cst_0 : memref<64x64xf16, #gpu.address_space<workgroup>>, vector<8xf16>
-// CHECK: vector.transfer_write %{{.*}}, %[[S1]][%{{.*}}, %{{.*}}] : vector<1x8xf16>, memref<64x64xf16, strided<[68, 1]>, #gpu.address_space<workgroup>>
   vector.transfer_write %cst_1, %alloc[%c0, %c0] :
     vector<1x8xf16>, memref<64x64xf16, #gpu.address_space<workgroup>>
   return

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/transform_gpu_reduce_bank_conflicts.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/transform_gpu_reduce_bank_conflicts.mlir
@@ -1,0 +1,27 @@
+// RUN: iree-opt %s --iree-transform-dialect-interpreter --transform-dialect-drop-schedule | FileCheck %s
+
+// CHECK-LABEL: func.func @pad_alloc
+func.func @pad_alloc() {
+// CHECK: %[[A:.*]] = memref.alloc() : memref<64x68xf16, #gpu.address_space<workgroup>>
+  %alloc = memref.alloc() : memref<64x64xf16, #gpu.address_space<workgroup>>
+// CHECK: %[[S1:.*]] = memref.subview %[[A]][0, 0] [64, 64] [1, 1] : memref<64x68xf16, #gpu.address_space<workgroup>> to memref<64x64xf16, strided<[68, 1]>, #gpu.address_space<workgroup>>
+  %c0 = arith.constant 0 : index
+  %cst_0 = arith.constant 0.000000e+00 : f16
+  %cst_1 = arith.constant dense<1.0> : vector<1x8xf16>
+
+// CHECK: vector.transfer_read %[[S1]][%{{.*}}, %{{.*}}], %{{.*}} : memref<64x64xf16, strided<[68, 1]>, #gpu.address_space<workgroup>>, vector<8xf16>
+  %2 = vector.transfer_read %alloc[%c0, %c0], %cst_0 : memref<64x64xf16, #gpu.address_space<workgroup>>, vector<8xf16>
+// CHECK: vector.transfer_write %{{.*}}, %[[S1]][%{{.*}}, %{{.*}}] : vector<1x8xf16>, memref<64x64xf16, strided<[68, 1]>, #gpu.address_space<workgroup>>
+  vector.transfer_write %cst_1, %alloc[%c0, %c0] :
+    vector<1x8xf16>, memref<64x64xf16, #gpu.address_space<workgroup>>
+  return
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(
+      %variant_op: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.reduce_shared_memory_bank_conflicts %0 { padding_size_bits = 64 } : (!transform.any_op) -> ()
+    transform.yield
+  }
+} // module

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -886,6 +886,28 @@ void transform_dialect::WorkgroupSwizzleOp::getEffects(
 }
 
 //===----------------------------------------------------------------------===//
+// ReduceSharedMemoryBankConclitsOp
+//===----------------------------------------------------------------------===//
+
+DiagnosedSilenceableFailure
+transform_dialect::ReduceSharedMemoryBankConflictsOp::applyToOne(
+    transform::TransformRewriter &rewriter, mlir::FunctionOpInterface target,
+    transform::ApplyToEachResultList &results,
+    transform::TransformState &state) {
+  if (failed(reduceSharedMemoryBankConflicts(target, getPaddingSizeBits()))) {
+    return emitDefaultDefiniteFailure(target)
+           << "failed to reduce shared memory bank conflicts";
+  }
+  return DiagnosedSilenceableFailure::success();
+}
+
+void transform_dialect::ReduceSharedMemoryBankConflictsOp::getEffects(
+    SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
+  transform::onlyReadsHandle(getTarget(), effects);
+  transform::modifiesPayload(effects);
+}
+
+//===----------------------------------------------------------------------===//
 // TestVectorLayoutAnalysisOp
 //===----------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -511,6 +511,42 @@ def WorkgroupSwizzleOp :  Op<Transform_Dialect, "iree.workgroup_swizzle",
   }];
 }
 
+def ReduceSharedMemoryBankConflictsOp :  Op<Transform_Dialect, "iree.reduce_shared_memory_bank_conflicts",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     TransformEachOpTrait,
+     TransformOpInterface,
+     ReportTrackingListenerFailuresOpTrait]> {
+  let summary = "Add padding to 'memref.alloc' ops reduce shared memory bank conflicts";
+  let description = [{
+    The `paddingSizeBits` argument should be picked based on the target
+    architecture, striking balance between minimizing bank conflicts and keeping
+    the data aligned. Smaller values (close to the bank bitwidth) achieve the
+    former, while larger (~= widest load size) the latter. We want to **misalign**
+    the rows, but not too much. For gfx942, 64 is a good default.
+
+    #### Return modes
+
+    This transform does not consume the target handle and always return success.
+  }];
+
+  let arguments = (
+      ins TransformHandleTypeInterface:$target,
+          DefaultValuedOptionalAttr<I64Attr, "64">:$padding_size_bits
+  );
+  let results = (outs);
+
+  let assemblyFormat = "$target attr-dict `:` functional-type(operands, results)";
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::transform::TransformRewriter &rewriter,
+        ::mlir::FunctionOpInterface funcOp,
+        ::mlir::transform::ApplyToEachResultList &results,
+        ::mlir::transform::TransformState &state);
+  }];
+}
+
 def TestVectorLayoutAnalysisOp :
   Op<Transform_Dialect, "iree.test_vector_layout_analysis",
     [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -614,7 +614,7 @@ void addGPUVectorDistributePassPipeline(OpPassManager &pm) {
   nestedModulePM.addPass(createCSEPass());
 
   nestedModulePM.addNestedPass<func::FuncOp>(
-      createGPUReduceSharedMemoryBankConflicts());
+      createGPUReduceSharedMemoryBankConflicts(/*paddingSizeBits=*/64));
 
   if (clLLVMGPUEnablePrefetch) {
     nestedModulePM.addNestedPass<func::FuncOp>(


### PR DESCRIPTION
The issue with 128 bits as the padding size is that it does not reduce bank conflicts on gfx9. The whole point of adding padding is to misalign the rows, therefore we need a smaller padding amount than the usual 128-bit-wide memory access size.

* Change the default padding size used by the vector distribution pass pipeline to something that reduces bank conflicts on AMDGPU.
* Improve pass documentation and explain how the padding size should be chosen.
* Add a transform op for this optimization.