### PR TITLE
Re-enable ROCm ONNX tests, running one test at a time.

### DIFF
--- a/.github/workflows/pkgci_regression_test_amdgpu_rocm.yml
+++ b/.github/workflows/pkgci_regression_test_amdgpu_rocm.yml
@@ -53,24 +53,24 @@ jobs:
             -rA -s -m "plat_rdna3_rocm and presubmit" \
             experimental/regression_suite
 
-      # Disabled while flaky / unreliable (runners crashing?)
-
-      # # Out of tree tests
-      # - name: Checking out external TestSuite repository
-      #   uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
-      #   with:
-      #     repository: nod-ai/SHARK-TestSuite
-      #     ref: e67779cee2a3878c2ba9ede50f2121cf21c1e99c
-      #     path: SHARK-TestSuite
-      #     submodules: false
-      # - name: Installing external TestSuite Python requirements
-      #   run: |
-      #     source ${VENV_DIR}/bin/activate
-      #     python -m pip install -r SHARK-TestSuite/iree_tests/requirements.txt
-      # - name: Run external tests - ONNX test suite
-      #   run: |
-      #     source ${VENV_DIR}/bin/activate
-      #     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/rocm/lib:/opt/rocm/hip/lib
-      #     pytest SHARK-TestSuite/iree_tests/onnx/ \
-      #         -n 4 -rpfE --timeout=30 --retries=2 --durations=20 \
-      #         --config-files=build_tools/pkgci/external_test_suite/onnx_gpu_rocm_rdna3.json
+      # Out of tree tests
+      # TODO(scotttodd): Increase parallelism when supported by the HIP HAL
+      #   driver and/or test runner machine.
+      - name: Checking out external TestSuite repository
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+        with:
+          repository: nod-ai/SHARK-TestSuite
+          ref: e67779cee2a3878c2ba9ede50f2121cf21c1e99c
+          path: SHARK-TestSuite
+          submodules: false
+      - name: Installing external TestSuite Python requirements
+        run: |
+          source ${VENV_DIR}/bin/activate
+          python -m pip install -r SHARK-TestSuite/iree_tests/requirements.txt
+      - name: Run external tests - ONNX test suite
+        run: |
+          source ${VENV_DIR}/bin/activate
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/rocm/lib:/opt/rocm/hip/lib
+          pytest SHARK-TestSuite/iree_tests/onnx/ \
+              -rpfE --timeout=30 --retries=2 --durations=20 \
+              --config-files=build_tools/pkgci/external_test_suite/onnx_gpu_rocm_rdna3.json

--- a/build_tools/pkgci/external_test_suite/onnx_gpu_rocm_rdna3.json
+++ b/build_tools/pkgci/external_test_suite/onnx_gpu_rocm_rdna3.json
@@ -5,7 +5,7 @@
     "--iree-rocm-target-chip=gfx1100"
   ],
   "iree_run_module_flags": [
-    "--device=rocm"
+    "--device=hip"
   ],
   "skip_compile_tests": [
     // TODO(#16666): Fix these tests hanging at runtime (miscompiles?)


### PR DESCRIPTION
We're observing GPU driver issues when running multiple tests in parallel. Until those are resolved, this will hopefully continue providing test coverage with relatively stable CI runs. This should still be fast enough for presubmit (~5 minutes), at least until more tests are enabled in the test suite.

This also switches to using `--device=hip`, since the "rocm" HAL driver is experimental and planned for deletion in favor of the newer HIP "hip" driver.