### PR TITLE
[CPU] Fix FusionOfTensorOps nullptr

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
@@ -489,8 +489,8 @@ struct FusionOfTensorOpsPass
             if (!reshapeOp)
               return true;
 
-            return isa<linalg::LinalgOp, tensor::UnPackOp,
-                       LinalgExt::UnsetEncodingOp>(
+            return llvm::isa_and_nonnull<linalg::LinalgOp, tensor::UnPackOp,
+                                         LinalgExt::UnsetEncodingOp>(
                 reshapeOp.getSrc().getDefiningOp());
           };
 


### PR DESCRIPTION
This PR fixes a compilation crash of an internal models. I'm not familiar with the pass so happy to change the fix or incorporate a test if you can think of an example to exercise this fix.