### PR TITLE
[CPU RISCV] Avoid using pre-configured tile sizes as input vector sizes

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -130,7 +130,7 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
   ModuleOp moduleOp = variantOp.getInnerModule();
   LLVMCPUPipelineOptions pipelineOpts;
   auto target = variantOp.getTarget();
-  if (isX86(target)) {
+  if (isX86(target) || isRISCV(target)) {
     pipelineOpts.useConfiguredVectorSizes = false;
   }
   pipelineOpts.lowerToAVX2 = hasAVX2Feature(target);


### PR DESCRIPTION
ISSUE: https://github.com/openxla/iree/issues/16990

This PR avoids RICS-V using lowering_config to determine vector sizes.
Similar to PR #16692.