### PR TITLE
FlattenMemRefSubspan: ignore strides on unit dims.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
@@ -353,6 +353,15 @@ static Value linearizeIndices(Value sourceValue, ValueRange indices,
   SmallVector<int64_t> strides;
   int64_t offset;
   if (succeeded(getStridesAndOffset(sourceType, strides, offset))) {
+    // For unit dimensions, strides don't matter since the index value can only
+    // be 0. Rewriting strides a 1 prevents unnecessarily failing the flattening
+    // when the stride has a dynamic value.
+    SmallVector<int64_t> shape(sourceType.getShape());
+    for (int i = 0; i < rank; ++i) {
+      if (shape[i] == 1) {
+        strides[i] = 1;
+      }
+    }
     // The memref itself might have an offset, but we should not account for it
     // when computing the linearization. The original memref might be
     // `memref<?x?xf32, strided<[?, ?], offset: ?>`


### PR DESCRIPTION
Memrefs such as `memref<1x?x1x4xf32, strided<[?, 4, 4, 1], offset: ?>` were failing to flatten because of the dynamic stride. But in fact, the stride doesn't matter because the dimension it refers to has unit size, so the index value that it get multiplied against is always 0.