### PR TITLE
[python] Expose python bindings for amdgpu in iree.compiler.dialects

### DIFF
--- a/compiler/bindings/python/CMakeLists.txt
+++ b/compiler/bindings/python/CMakeLists.txt
@@ -177,6 +177,7 @@ set(_SOURCE_COMPONENTS
   MLIRPythonSources.Core
 
   # Core dialects (constrained to IREE input dialects).
+  MLIRPythonSources.Dialects.amdgpu
   MLIRPythonSources.Dialects.arith
   MLIRPythonSources.Dialects.builtin
   MLIRPythonSources.Dialects.cf


### PR DESCRIPTION
This exposes the amdgpu python bindings as part of the iree.compiler.dialect package, allowing:
```
from iree.compiler.dialects import amdgpu
```
