### PR TITLE
Use `iree-turbine` in PyTorch docs and samples.

### DIFF
--- a/docs/website/docs/guides/ml-frameworks/pytorch.md
+++ b/docs/website/docs/guides/ml-frameworks/pytorch.md
@@ -72,7 +72,6 @@ python -m pip install \
   --pre --index-url https://download.pytorch.org/whl/test/cpu torch==2.3.0
 ```
 
-
 Install iree-turbine:
 
 ``` shell

--- a/docs/website/docs/guides/ml-frameworks/pytorch.md
+++ b/docs/website/docs/guides/ml-frameworks/pytorch.md
@@ -5,11 +5,13 @@ tags:
   - Python
   - PyTorch
 icon: simple/pytorch
+status: new
 ---
 
 # PyTorch + IREE = :octicons-heart-16:
 
 !!! caution "Caution - under development"
+
     We are still validating and fixing specific models. Between bug fixes in
     flight and releases running behind, we don't expect that you will be able
     to do a lot of advanced things without using nightly releases or working
@@ -20,7 +22,8 @@ icon: simple/pytorch
 
 ## :octicons-book-16: Overview
 
-[SHARK-Turbine](https://github.com/nod-ai/SHARK-Turbine) offers a tight
+[iree-turbine](https://pypi.org/project/iree-turbine/) (rebrand pending from
+[SHARK-Turbine](https://github.com/nod-ai/SHARK-Turbine)) offers a tight
 integration between compatible versions of IREE,
 [torch-mlir](https://github.com/llvm/torch-mlir), and
 [PyTorch](https://pytorch.org/).
@@ -36,14 +39,14 @@ graph LR
   accTitle: PyTorch integration overview
   accDescr {
     PyTorch programs can be optimized within a Python session with
-    SHARK-Turbine's just-in-time tools.
+    iree-turbine's just-in-time tools.
     PyTorch programs can be exported out of Python to native binaries using
-    SHARK-Turbine's ahead-of-time export toolkit.
+    iree-turbine's ahead-of-time export toolkit.
   }
 
   subgraph Python
     pytorch(PyTorch)
-    subgraph turbine [SHARK-Turbine]
+    subgraph turbine [iree-turbine]
       jit("Eager execution (JIT)")
       aot("Export toolkit (AOT)")
     end
@@ -62,10 +65,18 @@ graph LR
 
 ## :octicons-download-16: Prerequisites
 
-Install Turbine and its requirements:
+Install a recent version of PyTorch (`2.3.0+`, prerelease as of April 2024):
 
 ``` shell
-python -m pip install shark-turbine
+python -m pip install \
+  --pre --index-url https://download.pytorch.org/whl/test/cpu torch==2.3.0
+```
+
+
+Install iree-turbine:
+
+``` shell
+python -m pip install iree-turbine
 ```
 
 ## :octicons-flame-16: Just-in-time (JIT) execution
@@ -91,7 +102,7 @@ graph TD
     subgraph compile ["torch.compile()"]
       direction LR
       dynamo{{TorchDynamo}}
-      turbine{{SHARK-Turbine}}
+      turbine{{iree-turbine}}
       iree{{IREE}}
       dynamo --> turbine --> iree
     end
@@ -101,12 +112,14 @@ graph TD
   end
 ```
 
-For deployment outside of Python, see the ahead-of-time sections below.
+For deployment outside of Python, see the
+[ahead-of-time sections below](#ahead-of-time-aot-export).
 
 ### :octicons-rocket-16: Quickstart
 
 Turbine integrates into PyTorch as a
-[custom backend](https://pytorch.org/docs/2.0/dynamo/custom-backends.html) for
+[custom backend](https://pytorch.org/docs/stable/torch.compiler_custom_backends.html)
+for
 [`torch.compile`](https://pytorch.org/docs/stable/generated/torch.compile.html).
 
 Behind the scenes, PyTorch captures the structure of the input model into a
@@ -143,7 +156,7 @@ turbine_output = opt_linear_module(args)
 | Code samples |  |
 | -- | -- |
 JIT compilation notebook | [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/openxla/iree/blob/main/samples/colab/pytorch_jit.ipynb)
-Simple MLP eager | [`examples/eager_mlp/mlp_eager_simple.py`](https://github.com/nod-ai/SHARK-Turbine/blob/main/examples/eager_mlp/mlp_eager_simple.py)
+Simple MLP eager | [`core/examples/eager_mlp/mlp_eager_simple.py`](https://github.com/nod-ai/SHARK-Turbine/blob/main/core/examples/eager_mlp/mlp_eager_simple.py)
 
 ## :octicons-package-dependents-16: Ahead-of-time (AOT) export
 
@@ -219,7 +232,7 @@ print(result.to_host())
 | Code samples |  |
 | -- | -- |
 Simple AOT export notebook | [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/openxla/iree/blob/main/samples/colab/pytorch_aot_simple.ipynb)
-Simple MLP export | [`examples/aot_mlp/mlp_export_simple.py`](https://github.com/nod-ai/SHARK-Turbine/blob/main/examples/aot_mlp/mlp_export_simple.py)
+Simple MLP export | [`core/examples/aot_mlp/mlp_export_simple.py`](https://github.com/nod-ai/SHARK-Turbine/blob/main/core/examples/aot_mlp/mlp_export_simple.py)
 
 ### :octicons-tools-16: Advanced API
 
@@ -251,7 +264,7 @@ graph LR
 ```
 
 Advanced export workflows can use the
-[`aot.CompiledModule`](https://github.com/nod-ai/SHARK-Turbine/blob/main/python/shark_turbine/aot/compiled_module.py)
+[`aot.CompiledModule`](https://github.com/nod-ai/SHARK-Turbine/blob/main/core/shark_turbine/aot/compiled_module.py)
 class to define and constrain the structure of a program prior to compiling it.
 
 <!-- TODO(scotttodd): API reference pages for aot.CompiledModule etc.?
@@ -349,8 +362,7 @@ their values independently at runtime.
 * Individual globals can be exported using `aot.export_global()`:
 
     ```python
-    state_example = torch.tensor(0, dtype=torch.int32)
-    update_example = torch.tensor(0, dtype=torch.int32)
+    state_example = torch.zeros([1], dtype=torch.int32)
 
     class SampleModule(aot.CompiledModule):
       value = aot.export_global(state_example, mutable=True)
@@ -358,7 +370,7 @@ their values independently at runtime.
       def get_value(self):
         return self.value
 
-      def update_value(self, new_value=aot.abstractify(update_example)):
+      def update_value(self, new_value=aot.abstractify(value)):
         self.value = new_value
     ```
 
@@ -400,24 +412,6 @@ their values independently at runtime.
 | -- | -- |
 Advanced AOT export notebook | [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/openxla/iree/blob/main/samples/colab/pytorch_aot_advanced.ipynb)
 PyTorch dynamic shapes notebook | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/openxla/iree/blob/main/samples/dynamic_shapes/pytorch_dynamic_shapes.ipynb)
-AOT unit tests | [`tests/aot/`](https://github.com/nod-ai/SHARK-Turbine/tree/main/tests/aot)
-Dynamic MLP export | [`examples/aot_mlp/mlp_export_dynamic.py`](https://github.com/nod-ai/SHARK-Turbine/blob/main/examples/aot_mlp/mlp_export_dynamic.py)
-stateless llama2 | [`python/turbine_models/custom_models/stateless_llama.py`](https://github.com/nod-ai/SHARK-Turbine/blob/main/python/turbine_models/custom_models/stateless_llama.py)
-
-## Alternate workflows
-
-!!! caution "Caution - These are due for migration to SHARK-Turbine."
-
-| Code samples |  |
-| -- | -- |
-(Deprecated) Inference on BERT | [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/iree-org/iree-torch/blob/main/examples/bert.ipynb)
-
-### Native / on-device training
-
-A small (~100-250KB), self-contained binary can be built for deploying to
-resource-constrained environments without a Python interpreter.
-
-| Example scripts |
-| -- |
-| [Basic Inference and Training Example](https://github.com/iree-org/iree-torch/blob/main/examples/regression.py) |
-| [Native On-device Training Example](https://github.com/iree-org/iree-torch/tree/main/examples/native_training) |
+AOT unit tests | [`core/tests/aot/`](https://github.com/nod-ai/SHARK-Turbine/tree/main/core/tests/aot)
+Dynamic MLP export | [`core/examples/aot_mlp/mlp_export_dynamic.py`](https://github.com/nod-ai/SHARK-Turbine/blob/main/core/examples/aot_mlp/mlp_export_dynamic.py)
+stateless llama2 | [`models/turbine_models/custom_models/stateless_llama.py`](https://github.com/nod-ai/SHARK-Turbine/blob/main/models/turbine_models/custom_models/stateless_llama.py)

--- a/samples/colab/pytorch_aot_advanced.ipynb
+++ b/samples/colab/pytorch_aot_advanced.ipynb
@@ -37,7 +37,7 @@
         "cellView": "form",
         "id": "FqsvmKpjBJO2"
       },
-      "execution_count": 1,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -73,88 +73,103 @@
         "!python -m pip uninstall -y fastai torchaudio torchdata torchtext torchvision"
       ],
       "metadata": {
-        "id": "KsPubQSvCbXd"
+        "id": "KsPubQSvCbXd",
+        "cellView": "form"
+      },
+      "execution_count": 1,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#@title Install Pytorch 2.3.0 (prerelease)\n",
+        "!python -m pip install --pre --index-url https://download.pytorch.org/whl/test/cpu --upgrade torch==2.3.0"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "oO1tirq2ggmO",
+        "outputId": "401ec66b-213b-4b56-de3f-f1130ca8a6a3"
       },
       "execution_count": 2,
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Looking in indexes: https://download.pytorch.org/whl/test/cpu\n",
+            "Collecting torch==2.3.0\n",
+            "  Downloading https://download.pytorch.org/whl/test/cpu/torch-2.3.0%2Bcpu-cp310-cp310-linux_x86_64.whl (190.4 MB)\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m190.4/190.4 MB\u001b[0m \u001b[31m2.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hRequirement already satisfied: filelock in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (3.13.4)\n",
+            "Requirement already satisfied: typing-extensions>=4.8.0 in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (4.11.0)\n",
+            "Requirement already satisfied: sympy in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (1.12)\n",
+            "Requirement already satisfied: networkx in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (3.3)\n",
+            "Requirement already satisfied: jinja2 in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (3.1.3)\n",
+            "Requirement already satisfied: fsspec in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (2023.6.0)\n",
+            "Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.10/dist-packages (from jinja2->torch==2.3.0) (2.1.5)\n",
+            "Requirement already satisfied: mpmath>=0.19 in /usr/local/lib/python3.10/dist-packages (from sympy->torch==2.3.0) (1.3.0)\n",
+            "Installing collected packages: torch\n",
+            "  Attempting uninstall: torch\n",
+            "    Found existing installation: torch 2.2.1+cu121\n",
+            "    Uninstalling torch-2.2.1+cu121:\n",
+            "      Successfully uninstalled torch-2.2.1+cu121\n",
+            "Successfully installed torch-2.3.0+cpu\n"
+          ]
+        }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 3,
       "metadata": {
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 300
+          "base_uri": "https://localhost:8080/"
         },
         "id": "4iJFDHbsAzo4",
-        "outputId": "642f4878-b5df-4499-c682-0cace5af016c"
+        "outputId": "0f6f81e8-deb6-4e35-cd30-563c335329d7"
       },
       "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<IPython.core.display.Javascript object>"
-            ],
-            "application/javascript": [
-              "google.colab.output.setIframeHeight(0, true, {maxHeight: 300})"
-            ]
-          },
-          "metadata": {}
-        },
         {
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "Collecting shark-turbine\n",
-            "  Downloading shark-turbine-0.9.1.dev3.tar.gz (60 kB)\n",
-            "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/60.2 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━\u001b[0m \u001b[32m51.2/60.2 kB\u001b[0m \u001b[31m1.3 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m60.2/60.2 kB\u001b[0m \u001b[31m1.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25h  Installing build dependencies ... \u001b[?25l\u001b[?25hdone\n",
-            "  Getting requirements to build wheel ... \u001b[?25l\u001b[?25hdone\n",
-            "  Preparing metadata (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
-            "Requirement already satisfied: numpy in /usr/local/lib/python3.10/dist-packages (from shark-turbine) (1.23.5)\n",
-            "Collecting iree-compiler>=20231004.665 (from shark-turbine)\n",
-            "  Downloading iree_compiler-20231004.665-cp310-cp310-manylinux_2_28_x86_64.whl (57.2 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m57.2/57.2 MB\u001b[0m \u001b[31m8.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting iree-runtime>=20231004.665 (from shark-turbine)\n",
-            "  Downloading iree_runtime-20231004.665-cp310-cp310-manylinux_2_28_x86_64.whl (7.8 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m7.8/7.8 MB\u001b[0m \u001b[31m91.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hRequirement already satisfied: torch>=2.1.0 in /usr/local/lib/python3.10/dist-packages (from shark-turbine) (2.1.0+cu118)\n",
-            "Requirement already satisfied: PyYAML in /usr/local/lib/python3.10/dist-packages (from iree-compiler>=20231004.665->shark-turbine) (6.0.1)\n",
-            "Requirement already satisfied: filelock in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->shark-turbine) (3.12.4)\n",
-            "Requirement already satisfied: typing-extensions in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->shark-turbine) (4.5.0)\n",
-            "Requirement already satisfied: sympy in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->shark-turbine) (1.12)\n",
-            "Requirement already satisfied: networkx in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->shark-turbine) (3.2)\n",
-            "Requirement already satisfied: jinja2 in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->shark-turbine) (3.1.2)\n",
-            "Requirement already satisfied: fsspec in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->shark-turbine) (2023.6.0)\n",
-            "Requirement already satisfied: triton==2.1.0 in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->shark-turbine) (2.1.0)\n",
-            "Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.10/dist-packages (from jinja2->torch>=2.1.0->shark-turbine) (2.1.3)\n",
-            "Requirement already satisfied: mpmath>=0.19 in /usr/local/lib/python3.10/dist-packages (from sympy->torch>=2.1.0->shark-turbine) (1.3.0)\n",
-            "Building wheels for collected packages: shark-turbine\n",
-            "  Building wheel for shark-turbine (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
-            "  Created wheel for shark-turbine: filename=shark_turbine-0.9.1.dev3-py3-none-any.whl size=70102 sha256=d4633a862e3a4815488be7a3b339b3aa927f1fd5637720b8e63a64ef31e1dd8f\n",
-            "  Stored in directory: /root/.cache/pip/wheels/e9/78/0f/88c9d8224ef1550fe00b18a014eab5121f26264e2261f31926\n",
-            "Successfully built shark-turbine\n",
-            "Installing collected packages: iree-runtime, iree-compiler, shark-turbine\n",
-            "Successfully installed iree-compiler-20231004.665 iree-runtime-20231004.665 shark-turbine-0.9.1.dev3\n"
+            "Collecting iree-turbine\n",
+            "  Downloading iree_turbine-2.3.0rc20240410-py3-none-any.whl (150 kB)\n",
+            "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/150.4 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m61.4/150.4 kB\u001b[0m \u001b[31m1.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m150.4/150.4 kB\u001b[0m \u001b[31m2.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hRequirement already satisfied: numpy in /usr/local/lib/python3.10/dist-packages (from iree-turbine) (1.25.2)\n",
+            "Collecting iree-compiler>=20240410.859 (from iree-turbine)\n",
+            "  Downloading iree_compiler-20240410.859-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (64.4 MB)\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m64.4/64.4 MB\u001b[0m \u001b[31m9.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hCollecting iree-runtime>=20240410.859 (from iree-turbine)\n",
+            "  Downloading iree_runtime-20240410.859-cp310-cp310-manylinux_2_28_x86_64.whl (7.4 MB)\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m7.4/7.4 MB\u001b[0m \u001b[31m57.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hRequirement already satisfied: torch>=2.1.0 in /usr/local/lib/python3.10/dist-packages (from iree-turbine) (2.3.0+cpu)\n",
+            "Requirement already satisfied: PyYAML in /usr/local/lib/python3.10/dist-packages (from iree-compiler>=20240410.859->iree-turbine) (6.0.1)\n",
+            "Requirement already satisfied: filelock in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->iree-turbine) (3.13.4)\n",
+            "Requirement already satisfied: typing-extensions>=4.8.0 in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->iree-turbine) (4.11.0)\n",
+            "Requirement already satisfied: sympy in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->iree-turbine) (1.12)\n",
+            "Requirement already satisfied: networkx in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->iree-turbine) (3.3)\n",
+            "Requirement already satisfied: jinja2 in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->iree-turbine) (3.1.3)\n",
+            "Requirement already satisfied: fsspec in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->iree-turbine) (2023.6.0)\n",
+            "Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.10/dist-packages (from jinja2->torch>=2.1.0->iree-turbine) (2.1.5)\n",
+            "Requirement already satisfied: mpmath>=0.19 in /usr/local/lib/python3.10/dist-packages (from sympy->torch>=2.1.0->iree-turbine) (1.3.0)\n",
+            "Installing collected packages: iree-runtime, iree-compiler, iree-turbine\n",
+            "Successfully installed iree-compiler-20240410.859 iree-runtime-20240410.859 iree-turbine-2.3.0rc20240410\n"
           ]
         }
       ],
       "source": [
-        "#@title Install SHARK-Turbine\n",
-        "\n",
-        "# Limit cell height.\n",
-        "from IPython.display import Javascript\n",
-        "display(Javascript('''google.colab.output.setIframeHeight(0, true, {maxHeight: 300})'''))\n",
-        "\n",
-        "!python -m pip install shark-turbine"
+        "#@title Install iree-turbine\n",
+        "!python -m pip install iree-turbine"
       ]
     },
     {
       "cell_type": "code",
       "source": [
         "#@title Report version information\n",
-        "!echo \"Installed SHARK-Turbine, $(python -m pip show shark_turbine | grep Version)\"\n",
+        "!echo \"Installed iree-turbine, $(python -m pip show iree_turbine | grep Version)\"\n",
         "\n",
         "!echo -e \"\\nInstalled IREE, compiler version information:\"\n",
         "!iree-compile --version\n",
@@ -167,23 +182,23 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "nkVLzRpcDnVL",
-        "outputId": "13d71d90-5f42-4e72-e85d-1d8137e1afda"
+        "outputId": "2c0a2229-0ab9-4eb3-e302-e75e15d08cce"
       },
-      "execution_count": 4,
+      "execution_count": 5,
       "outputs": [
         {
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "Installed SHARK-Turbine, Version: 0.9.1.dev3\n",
+            "Installed iree-turbine, Version: 2.3.0rc20240410\n",
             "\n",
             "Installed IREE, compiler version information:\n",
-            "IREE (https://openxla.github.io/iree):\n",
-            "  IREE compiler version 20231004.665 @ bb51f6f1a1b4ee619fb09a7396f449dadb211447\n",
-            "  LLVM version 18.0.0git\n",
+            "IREE (https://iree.dev):\n",
+            "  IREE compiler version 20240410.859 @ b4273a4bfc66ba6dd8f62f6483d74d42a7b936f1\n",
+            "  LLVM version 19.0.0git\n",
             "  Optimized build\n",
             "\n",
-            "Installed PyTorch, version: 2.1.0+cu118\n"
+            "Installed PyTorch, version: 2.3.0+cpu\n"
           ]
         }
       ]
@@ -230,7 +245,7 @@
       "metadata": {
         "id": "oPdjrmPZMNz6"
       },
-      "execution_count": 5,
+      "execution_count": 6,
       "outputs": []
     },
     {
@@ -265,21 +280,19 @@
       "metadata": {
         "id": "Ua3tNtUIozoa"
       },
-      "execution_count": 6,
+      "execution_count": 7,
       "outputs": []
     },
     {
       "cell_type": "code",
       "source": [
         "#@title 3. Export the program using `aot.export()`\n",
-        "\n",
-        "example_arg = torch.randn(4)\n",
-        "export_output = aot.export(CompiledLinearModule, example_arg)"
+        "export_output = aot.export(CompiledLinearModule)"
       ],
       "metadata": {
         "id": "eK2fWVfiSQ8f"
       },
-      "execution_count": 7,
+      "execution_count": 12,
       "outputs": []
     },
     {
@@ -311,15 +324,15 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "eMRNdFdos900",
-        "outputId": "465d47e1-45a5-4f88-bcf9-33ceb5d417e7"
+        "outputId": "29aaa0ad-a424-4856-d03f-b0bd0a839a29"
       },
-      "execution_count": 8,
+      "execution_count": 13,
       "outputs": [
         {
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "[ 1.4178504 -1.2343317 -7.4767947]\n"
+            "[ 1.4178505 -1.2343317 -7.4767942]\n"
           ]
         }
       ]
@@ -339,24 +352,24 @@
         "export_output.save_mlir(mlir_file_path)\n",
         "\n",
         "!iree-compile --iree-input-type=torch --iree-hal-target-backends=llvm-cpu {mlir_file_path} -o {vmfb_file_path}\n",
-        "!iree-run-module --module={vmfb_file_path} --device=local-task --input=\"4xf32=[1.0, 2.0, 3.0, 4.0]\""
+        "!iree-run-module --module={vmfb_file_path} --device=local-task --function=main --input=\"4xf32=[1.0, 2.0, 3.0, 4.0]\""
       ],
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "0AdkXY8VNL2-",
-        "outputId": "52995990-0d11-46f3-b538-98a0f1e94473"
+        "outputId": "c4faaf27-59b7-4ee1-88aa-b6c209e8a1cf"
       },
-      "execution_count": 9,
+      "execution_count": 15,
       "outputs": [
         {
           "output_type": "stream",
           "name": "stdout",
           "text": [
             "module @compiled_linear {\n",
-            "  util.global private mutable @_params.weight {inlining_policy = #util.inline.never} = dense<[[1.54099607, -0.293428898, -2.17878938], [0.568431258, -1.08452237, -1.39859545], [0.403346837, 0.838026344, -0.719257593], [-0.403343529, -0.596635341, 0.182036489]]> : tensor<4x3xf32>\n",
-            "  util.global private mutable @_params.bias {inlining_policy = #util.inline.never} = dense<[-0.856674611, 1.10060418, -1.07118738]> : tensor<3xf32>\n",
+            "  util.global private mutable @_params.weight = dense_resource<_params.weight> : tensor<4x3xf32>\n",
+            "  util.global private mutable @_params.bias = dense_resource<_params.bias> : tensor<3xf32>\n",
             "  func.func @main(%arg0: tensor<4xf32>) -> tensor<3xf32> attributes {torch.args_schema = \"[1, {\\22type\\22: \\22builtins.tuple\\22, \\22context\\22: \\22null\\22, \\22children_spec\\22: [{\\22type\\22: \\22builtins.list\\22, \\22context\\22: \\22null\\22, \\22children_spec\\22: [{\\22type\\22: null, \\22context\\22: null, \\22children_spec\\22: []}]}, {\\22type\\22: \\22builtins.dict\\22, \\22context\\22: \\22[]\\22, \\22children_spec\\22: []}]}]\", torch.return_schema = \"[1, {\\22type\\22: null, \\22context\\22: null, \\22children_spec\\22: []}]\"} {\n",
             "    %0 = torch_c.from_builtin_tensor %arg0 : tensor<4xf32> -> !torch.vtensor<[4],f32>\n",
             "    %1 = call @forward(%0) : (!torch.vtensor<[4],f32>) -> !torch.vtensor<[3],f32>\n",
@@ -393,7 +406,19 @@
             "    util.global.store %arg0, @_params.bias : tensor<3xf32>\n",
             "    return\n",
             "  }\n",
-            "}\n"
+            "}\n",
+            "\n",
+            "{-#\n",
+            "  dialect_resources: {\n",
+            "    builtin: {\n",
+            "      _params.weight: \"0x040000005C3FC53F503C96BE49710BC0B684113FA1D18ABF2D05B3BF7A83CE3EE588563F442138BF0B83CEBE18BD18BFC6673A3E\",\n",
+            "      _params.bias: \"0x04000000074F5BBF99E08C3FAB1C89BF\"\n",
+            "    }\n",
+            "  }\n",
+            "#-}\n",
+            "EXEC @main\n",
+            "result[0]: hal.buffer_view\n",
+            "3xf32=1.41785 -1.23433 -7.47679\n"
           ]
         }
       ]

--- a/samples/colab/pytorch_aot_simple.ipynb
+++ b/samples/colab/pytorch_aot_simple.ipynb
@@ -73,136 +73,104 @@
         "!python -m pip uninstall -y fastai torchaudio torchdata torchtext torchvision"
       ],
       "metadata": {
-        "id": "KsPubQSvCbXd"
+        "id": "KsPubQSvCbXd",
+        "cellView": "form"
       },
       "execution_count": 2,
       "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "source": [
+        "#@title Install Pytorch 2.3.0 (prerelease)\n",
+        "!python -m pip install --pre --index-url https://download.pytorch.org/whl/test/cpu --upgrade torch==2.3.0"
+      ],
       "metadata": {
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 300
+          "base_uri": "https://localhost:8080/"
         },
-        "id": "4iJFDHbsAzo4",
-        "outputId": "4484964e-9163-4694-c5fc-1c4054bfbb84"
+        "id": "3ebWazfjJ6en",
+        "outputId": "a04009ab-92d2-4796-a476-e7912fc84410"
       },
+      "execution_count": 3,
       "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<IPython.core.display.Javascript object>"
-            ],
-            "application/javascript": [
-              "google.colab.output.setIframeHeight(0, true, {maxHeight: 300})"
-            ]
-          },
-          "metadata": {}
-        },
         {
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "Collecting shark-turbine\n",
-            "  Downloading shark-turbine-0.9.1.dev3.tar.gz (60 kB)\n",
-            "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/60.2 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━\u001b[0m \u001b[32m51.2/60.2 kB\u001b[0m \u001b[31m1.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m60.2/60.2 kB\u001b[0m \u001b[31m1.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25h  Installing build dependencies ... \u001b[?25l\u001b[?25hdone\n",
-            "  Getting requirements to build wheel ... \u001b[?25l\u001b[?25hdone\n",
-            "  Preparing metadata (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
-            "Requirement already satisfied: numpy in /usr/local/lib/python3.10/dist-packages (from shark-turbine) (1.23.5)\n",
-            "Collecting iree-compiler>=20231004.665 (from shark-turbine)\n",
-            "  Downloading iree_compiler-20231004.665-cp310-cp310-manylinux_2_28_x86_64.whl (57.2 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m57.2/57.2 MB\u001b[0m \u001b[31m13.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting iree-runtime>=20231004.665 (from shark-turbine)\n",
-            "  Downloading iree_runtime-20231004.665-cp310-cp310-manylinux_2_28_x86_64.whl (7.8 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m7.8/7.8 MB\u001b[0m \u001b[31m95.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting torch>=2.1.0 (from shark-turbine)\n",
-            "  Downloading torch-2.1.0-cp310-cp310-manylinux1_x86_64.whl (670.2 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m670.2/670.2 MB\u001b[0m \u001b[31m1.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hRequirement already satisfied: PyYAML in /usr/local/lib/python3.10/dist-packages (from iree-compiler>=20231004.665->shark-turbine) (6.0.1)\n",
-            "Requirement already satisfied: filelock in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->shark-turbine) (3.12.4)\n",
-            "Requirement already satisfied: typing-extensions in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->shark-turbine) (4.5.0)\n",
-            "Requirement already satisfied: sympy in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->shark-turbine) (1.12)\n",
-            "Requirement already satisfied: networkx in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->shark-turbine) (3.1)\n",
-            "Requirement already satisfied: jinja2 in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->shark-turbine) (3.1.2)\n",
-            "Requirement already satisfied: fsspec in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->shark-turbine) (2023.6.0)\n",
-            "Collecting nvidia-cuda-nvrtc-cu12==12.1.105 (from torch>=2.1.0->shark-turbine)\n",
-            "  Downloading nvidia_cuda_nvrtc_cu12-12.1.105-py3-none-manylinux1_x86_64.whl (23.7 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m23.7/23.7 MB\u001b[0m \u001b[31m62.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting nvidia-cuda-runtime-cu12==12.1.105 (from torch>=2.1.0->shark-turbine)\n",
-            "  Downloading nvidia_cuda_runtime_cu12-12.1.105-py3-none-manylinux1_x86_64.whl (823 kB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m823.6/823.6 kB\u001b[0m \u001b[31m49.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting nvidia-cuda-cupti-cu12==12.1.105 (from torch>=2.1.0->shark-turbine)\n",
-            "  Downloading nvidia_cuda_cupti_cu12-12.1.105-py3-none-manylinux1_x86_64.whl (14.1 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m14.1/14.1 MB\u001b[0m \u001b[31m64.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting nvidia-cudnn-cu12==8.9.2.26 (from torch>=2.1.0->shark-turbine)\n",
-            "  Downloading nvidia_cudnn_cu12-8.9.2.26-py3-none-manylinux1_x86_64.whl (731.7 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m731.7/731.7 MB\u001b[0m \u001b[31m1.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting nvidia-cublas-cu12==12.1.3.1 (from torch>=2.1.0->shark-turbine)\n",
-            "  Downloading nvidia_cublas_cu12-12.1.3.1-py3-none-manylinux1_x86_64.whl (410.6 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m410.6/410.6 MB\u001b[0m \u001b[31m2.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting nvidia-cufft-cu12==11.0.2.54 (from torch>=2.1.0->shark-turbine)\n",
-            "  Downloading nvidia_cufft_cu12-11.0.2.54-py3-none-manylinux1_x86_64.whl (121.6 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m121.6/121.6 MB\u001b[0m \u001b[31m8.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting nvidia-curand-cu12==10.3.2.106 (from torch>=2.1.0->shark-turbine)\n",
-            "  Downloading nvidia_curand_cu12-10.3.2.106-py3-none-manylinux1_x86_64.whl (56.5 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m56.5/56.5 MB\u001b[0m \u001b[31m11.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting nvidia-cusolver-cu12==11.4.5.107 (from torch>=2.1.0->shark-turbine)\n",
-            "  Downloading nvidia_cusolver_cu12-11.4.5.107-py3-none-manylinux1_x86_64.whl (124.2 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m124.2/124.2 MB\u001b[0m \u001b[31m8.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting nvidia-cusparse-cu12==12.1.0.106 (from torch>=2.1.0->shark-turbine)\n",
-            "  Downloading nvidia_cusparse_cu12-12.1.0.106-py3-none-manylinux1_x86_64.whl (196.0 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m196.0/196.0 MB\u001b[0m \u001b[31m6.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting nvidia-nccl-cu12==2.18.1 (from torch>=2.1.0->shark-turbine)\n",
-            "  Downloading nvidia_nccl_cu12-2.18.1-py3-none-manylinux1_x86_64.whl (209.8 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m209.8/209.8 MB\u001b[0m \u001b[31m2.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting nvidia-nvtx-cu12==12.1.105 (from torch>=2.1.0->shark-turbine)\n",
-            "  Downloading nvidia_nvtx_cu12-12.1.105-py3-none-manylinux1_x86_64.whl (99 kB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m99.1/99.1 kB\u001b[0m \u001b[31m12.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting triton==2.1.0 (from torch>=2.1.0->shark-turbine)\n",
-            "  Downloading triton-2.1.0-0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl (89.2 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m89.2/89.2 MB\u001b[0m \u001b[31m8.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting nvidia-nvjitlink-cu12 (from nvidia-cusolver-cu12==11.4.5.107->torch>=2.1.0->shark-turbine)\n",
-            "  Downloading nvidia_nvjitlink_cu12-12.2.140-py3-none-manylinux1_x86_64.whl (20.2 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m20.2/20.2 MB\u001b[0m \u001b[31m77.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hRequirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.10/dist-packages (from jinja2->torch>=2.1.0->shark-turbine) (2.1.3)\n",
-            "Requirement already satisfied: mpmath>=0.19 in /usr/local/lib/python3.10/dist-packages (from sympy->torch>=2.1.0->shark-turbine) (1.3.0)\n",
-            "Building wheels for collected packages: shark-turbine\n",
-            "  Building wheel for shark-turbine (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
-            "  Created wheel for shark-turbine: filename=shark_turbine-0.9.1.dev3-py3-none-any.whl size=70102 sha256=c498fa5dd115d1b796c30744cde960da1f63a85ea783c567832c27e896dcd3ee\n",
-            "  Stored in directory: /root/.cache/pip/wheels/e9/78/0f/88c9d8224ef1550fe00b18a014eab5121f26264e2261f31926\n",
-            "Successfully built shark-turbine\n",
-            "Installing collected packages: triton, nvidia-nvtx-cu12, nvidia-nvjitlink-cu12, nvidia-nccl-cu12, nvidia-curand-cu12, nvidia-cufft-cu12, nvidia-cuda-runtime-cu12, nvidia-cuda-nvrtc-cu12, nvidia-cuda-cupti-cu12, nvidia-cublas-cu12, iree-runtime, iree-compiler, nvidia-cusparse-cu12, nvidia-cudnn-cu12, nvidia-cusolver-cu12, torch, shark-turbine\n",
-            "  Attempting uninstall: triton\n",
-            "    Found existing installation: triton 2.0.0\n",
-            "    Uninstalling triton-2.0.0:\n",
-            "      Successfully uninstalled triton-2.0.0\n",
+            "Looking in indexes: https://download.pytorch.org/whl/test/cpu\n",
+            "Collecting torch==2.3.0\n",
+            "  Downloading https://download.pytorch.org/whl/test/cpu/torch-2.3.0%2Bcpu-cp310-cp310-linux_x86_64.whl (190.4 MB)\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m190.4/190.4 MB\u001b[0m \u001b[31m3.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hRequirement already satisfied: filelock in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (3.13.4)\n",
+            "Requirement already satisfied: typing-extensions>=4.8.0 in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (4.11.0)\n",
+            "Requirement already satisfied: sympy in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (1.12)\n",
+            "Requirement already satisfied: networkx in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (3.3)\n",
+            "Requirement already satisfied: jinja2 in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (3.1.3)\n",
+            "Requirement already satisfied: fsspec in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (2023.6.0)\n",
+            "Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.10/dist-packages (from jinja2->torch==2.3.0) (2.1.5)\n",
+            "Requirement already satisfied: mpmath>=0.19 in /usr/local/lib/python3.10/dist-packages (from sympy->torch==2.3.0) (1.3.0)\n",
+            "Installing collected packages: torch\n",
             "  Attempting uninstall: torch\n",
-            "    Found existing installation: torch 2.0.1+cu118\n",
-            "    Uninstalling torch-2.0.1+cu118:\n",
-            "      Successfully uninstalled torch-2.0.1+cu118\n",
-            "Successfully installed iree-compiler-20231004.665 iree-runtime-20231004.665 nvidia-cublas-cu12-12.1.3.1 nvidia-cuda-cupti-cu12-12.1.105 nvidia-cuda-nvrtc-cu12-12.1.105 nvidia-cuda-runtime-cu12-12.1.105 nvidia-cudnn-cu12-8.9.2.26 nvidia-cufft-cu12-11.0.2.54 nvidia-curand-cu12-10.3.2.106 nvidia-cusolver-cu12-11.4.5.107 nvidia-cusparse-cu12-12.1.0.106 nvidia-nccl-cu12-2.18.1 nvidia-nvjitlink-cu12-12.2.140 nvidia-nvtx-cu12-12.1.105 shark-turbine-0.9.1.dev3 torch-2.1.0 triton-2.1.0\n"
+            "    Found existing installation: torch 2.2.1+cu121\n",
+            "    Uninstalling torch-2.2.1+cu121:\n",
+            "      Successfully uninstalled torch-2.2.1+cu121\n",
+            "Successfully installed torch-2.3.0+cpu\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "4iJFDHbsAzo4",
+        "outputId": "72f7e43a-fbec-4140-d15b-9df10691e984"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Collecting iree-turbine\n",
+            "  Downloading iree_turbine-2.3.0rc20240410-py3-none-any.whl (150 kB)\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m150.4/150.4 kB\u001b[0m \u001b[31m3.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hRequirement already satisfied: numpy in /usr/local/lib/python3.10/dist-packages (from iree-turbine) (1.25.2)\n",
+            "Collecting iree-compiler>=20240410.859 (from iree-turbine)\n",
+            "  Downloading iree_compiler-20240410.859-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (64.4 MB)\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m64.4/64.4 MB\u001b[0m \u001b[31m7.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hCollecting iree-runtime>=20240410.859 (from iree-turbine)\n",
+            "  Downloading iree_runtime-20240410.859-cp310-cp310-manylinux_2_28_x86_64.whl (7.4 MB)\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m7.4/7.4 MB\u001b[0m \u001b[31m23.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hRequirement already satisfied: torch>=2.1.0 in /usr/local/lib/python3.10/dist-packages (from iree-turbine) (2.3.0+cpu)\n",
+            "Requirement already satisfied: PyYAML in /usr/local/lib/python3.10/dist-packages (from iree-compiler>=20240410.859->iree-turbine) (6.0.1)\n",
+            "Requirement already satisfied: filelock in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->iree-turbine) (3.13.4)\n",
+            "Requirement already satisfied: typing-extensions>=4.8.0 in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->iree-turbine) (4.11.0)\n",
+            "Requirement already satisfied: sympy in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->iree-turbine) (1.12)\n",
+            "Requirement already satisfied: networkx in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->iree-turbine) (3.3)\n",
+            "Requirement already satisfied: jinja2 in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->iree-turbine) (3.1.3)\n",
+            "Requirement already satisfied: fsspec in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->iree-turbine) (2023.6.0)\n",
+            "Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.10/dist-packages (from jinja2->torch>=2.1.0->iree-turbine) (2.1.5)\n",
+            "Requirement already satisfied: mpmath>=0.19 in /usr/local/lib/python3.10/dist-packages (from sympy->torch>=2.1.0->iree-turbine) (1.3.0)\n",
+            "Installing collected packages: iree-runtime, iree-compiler, iree-turbine\n",
+            "Successfully installed iree-compiler-20240410.859 iree-runtime-20240410.859 iree-turbine-2.3.0rc20240410\n"
           ]
         }
       ],
       "source": [
-        "#@title Install SHARK-Turbine\n",
+        "#@title Install iree-turbine\n",
         "\n",
-        "# Limit cell height.\n",
-        "from IPython.display import Javascript\n",
-        "display(Javascript('''google.colab.output.setIframeHeight(0, true, {maxHeight: 300})'''))\n",
-        "\n",
-        "!python -m pip install shark-turbine"
+        "!python -m pip install iree-turbine"
       ]
     },
     {
       "cell_type": "code",
       "source": [
         "#@title Report version information\n",
-        "!echo \"Installed SHARK-Turbine, $(python -m pip show shark_turbine | grep Version)\"\n",
+        "!echo \"Installed iree-turbine, $(python -m pip show iree_turbine | grep Version)\"\n",
         "\n",
         "!echo -e \"\\nInstalled IREE, compiler version information:\"\n",
         "!iree-compile --version\n",
@@ -215,23 +183,23 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "nkVLzRpcDnVL",
-        "outputId": "46ec1bc5-3720-40fd-e2d6-3a617903b317"
+        "outputId": "c8687418-f2c4-42af-974f-2733a5797c1c"
       },
-      "execution_count": 4,
+      "execution_count": 5,
       "outputs": [
         {
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "Installed SHARK-Turbine, Version: 0.9.1.dev3\n",
+            "Installed iree-turbine, Version: 2.3.0rc20240410\n",
             "\n",
             "Installed IREE, compiler version information:\n",
             "IREE (https://iree.dev):\n",
-            "  IREE compiler version 20231004.665 @ bb51f6f1a1b4ee619fb09a7396f449dadb211447\n",
-            "  LLVM version 18.0.0git\n",
+            "  IREE compiler version 20240410.859 @ b4273a4bfc66ba6dd8f62f6483d74d42a7b936f1\n",
+            "  LLVM version 19.0.0git\n",
             "  Optimized build\n",
             "\n",
-            "Installed PyTorch, version: 2.1.0+cu121\n"
+            "Installed PyTorch, version: 2.3.0+cpu\n"
           ]
         }
       ]
@@ -276,7 +244,7 @@
       "metadata": {
         "id": "oPdjrmPZMNz6"
       },
-      "execution_count": 5,
+      "execution_count": 6,
       "outputs": []
     },
     {
@@ -291,7 +259,7 @@
       "metadata": {
         "id": "eK2fWVfiSQ8f"
       },
-      "execution_count": 6,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -319,19 +287,19 @@
         "print(result.to_host())"
       ],
       "metadata": {
+        "id": "eMRNdFdos900",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "eMRNdFdos900",
-        "outputId": "db4a575b-562c-40ab-dd8c-fba3bbe3a68f"
+        "outputId": "2b4db1b2-12d5-4b63-8f0e-9635dfe48277"
       },
-      "execution_count": 7,
+      "execution_count": 8,
       "outputs": [
         {
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "[ 1.4178504 -1.2343317 -7.4767947]\n"
+            "[ 1.4178505 -1.2343317 -7.4767942]\n"
           ]
         }
       ]
@@ -347,49 +315,52 @@
         "mlir_file_path = \"/tmp/linear_module_pytorch.mlirbc\"\n",
         "vmfb_file_path = \"/tmp/linear_module_pytorch_llvmcpu.vmfb\"\n",
         "\n",
+        "print(\"Exported .mlir:\")\n",
         "export_output.print_readable()\n",
         "export_output.save_mlir(mlir_file_path)\n",
         "\n",
+        "print(\"Compiling and running...\")\n",
         "!iree-compile --iree-input-type=torch --iree-hal-target-backends=llvm-cpu {mlir_file_path} -o {vmfb_file_path}\n",
         "!iree-run-module --module={vmfb_file_path} --device=local-task --input=\"4xf32=[1.0, 2.0, 3.0, 4.0]\""
       ],
       "metadata": {
+        "id": "0AdkXY8VNL2-",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "0AdkXY8VNL2-",
-        "outputId": "f521d749-a4b7-45a3-ba1a-4e67267ef244"
+        "outputId": "75ca37ad-0321-4a40-9f54-5c6613f01e9e"
       },
-      "execution_count": 8,
+      "execution_count": 9,
       "outputs": [
         {
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "module @LinearModule {\n",
-            "  util.global private @_params.weight {inlining_policy = #util.inline.never} = dense<[[1.54099607, -0.293428898, -2.17878938], [0.568431258, -1.08452237, -1.39859545], [0.403346837, 0.838026344, -0.719257593], [-0.403343529, -0.596635341, 0.182036489]]> : tensor<4x3xf32>\n",
-            "  util.global private @_params.bias {inlining_policy = #util.inline.never} = dense<[-0.856674611, 1.10060418, -1.07118738]> : tensor<3xf32>\n",
-            "  func.func @main(%arg0: tensor<4xf32>) -> tensor<3xf32> attributes {torch.args_schema = \"[1, {\\22type\\22: \\22builtins.tuple\\22, \\22context\\22: \\22null\\22, \\22children_spec\\22: [{\\22type\\22: \\22builtins.list\\22, \\22context\\22: \\22null\\22, \\22children_spec\\22: [{\\22type\\22: null, \\22context\\22: null, \\22children_spec\\22: []}]}, {\\22type\\22: \\22builtins.dict\\22, \\22context\\22: \\22[]\\22, \\22children_spec\\22: []}]}]\", torch.return_schema = \"[1, {\\22type\\22: null, \\22context\\22: null, \\22children_spec\\22: []}]\"} {\n",
-            "    %0 = torch_c.from_builtin_tensor %arg0 : tensor<4xf32> -> !torch.vtensor<[4],f32>\n",
-            "    %1 = call @forward(%0) : (!torch.vtensor<[4],f32>) -> !torch.vtensor<[3],f32>\n",
-            "    %2 = torch_c.to_builtin_tensor %1 : !torch.vtensor<[3],f32> -> tensor<3xf32>\n",
-            "    return %2 : tensor<3xf32>\n",
-            "  }\n",
-            "  func.func private @forward(%arg0: !torch.vtensor<[4],f32>) -> !torch.vtensor<[3],f32> {\n",
+            "Exported .mlir:\n",
+            "module @module {\n",
+            "  func.func @main(%arg0: !torch.vtensor<[4],f32>) -> !torch.vtensor<[3],f32> {\n",
             "    %int0 = torch.constant.int 0\n",
             "    %0 = torch.aten.unsqueeze %arg0, %int0 : !torch.vtensor<[4],f32>, !torch.int -> !torch.vtensor<[1,4],f32>\n",
-            "    %_params.weight = util.global.load @_params.weight : tensor<4x3xf32>\n",
-            "    %1 = torch_c.from_builtin_tensor %_params.weight : tensor<4x3xf32> -> !torch.vtensor<[4,3],f32>\n",
+            "    %1 = torch.vtensor.literal(dense_resource<torch_tensor_4_3_torch.float32> : tensor<4x3xf32>) : !torch.vtensor<[4,3],f32>\n",
             "    %2 = torch.aten.mm %0, %1 : !torch.vtensor<[1,4],f32>, !torch.vtensor<[4,3],f32> -> !torch.vtensor<[1,3],f32>\n",
             "    %int0_0 = torch.constant.int 0\n",
             "    %3 = torch.aten.squeeze.dim %2, %int0_0 : !torch.vtensor<[1,3],f32>, !torch.int -> !torch.vtensor<[3],f32>\n",
-            "    %_params.bias = util.global.load @_params.bias : tensor<3xf32>\n",
-            "    %4 = torch_c.from_builtin_tensor %_params.bias : tensor<3xf32> -> !torch.vtensor<[3],f32>\n",
+            "    %4 = torch.vtensor.literal(dense_resource<torch_tensor_3_torch.float32> : tensor<3xf32>) : !torch.vtensor<[3],f32>\n",
             "    %int1 = torch.constant.int 1\n",
             "    %5 = torch.aten.add.Tensor %3, %4, %int1 : !torch.vtensor<[3],f32>, !torch.vtensor<[3],f32>, !torch.int -> !torch.vtensor<[3],f32>\n",
             "    return %5 : !torch.vtensor<[3],f32>\n",
             "  }\n",
             "}\n",
+            "\n",
+            "{-#\n",
+            "  dialect_resources: {\n",
+            "    builtin: {\n",
+            "      torch_tensor_4_3_torch.float32: \"0x040000005C3FC53F503C96BE49710BC0B684113FA1D18ABF2D05B3BF7A83CE3EE588563F442138BF0B83CEBE18BD18BFC6673A3E\",\n",
+            "      torch_tensor_3_torch.float32: \"0x04000000074F5BBF99E08C3FAB1C89BF\"\n",
+            "    }\n",
+            "  }\n",
+            "#-}\n",
+            "Compiling and running...\n",
             "EXEC @main\n",
             "result[0]: hal.buffer_view\n",
             "3xf32=1.41785 -1.23433 -7.47679\n"

--- a/samples/colab/pytorch_jit.ipynb
+++ b/samples/colab/pytorch_jit.ipynb
@@ -69,136 +69,103 @@
         "!python -m pip uninstall -y fastai torchaudio torchdata torchtext torchvision"
       ],
       "metadata": {
-        "id": "KsPubQSvCbXd"
+        "id": "KsPubQSvCbXd",
+        "cellView": "form"
       },
       "execution_count": 2,
       "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "source": [
+        "#@title Install Pytorch 2.3.0 (prerelease)\n",
+        "!python -m pip install --pre --index-url https://download.pytorch.org/whl/test/cpu --upgrade torch==2.3.0"
+      ],
       "metadata": {
+        "id": "KHbDmehBWuDW",
+        "outputId": "c2af25cd-58c9-4757-bdda-1124f9f2aa88",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 300
-        },
-        "id": "4iJFDHbsAzo4",
-        "outputId": "6ed6f706-f701-47a6-f8b9-2d0141579f8d"
+          "base_uri": "https://localhost:8080/"
+        }
       },
+      "execution_count": 3,
       "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<IPython.core.display.Javascript object>"
-            ],
-            "application/javascript": [
-              "google.colab.output.setIframeHeight(0, true, {maxHeight: 300})"
-            ]
-          },
-          "metadata": {}
-        },
         {
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "Collecting shark-turbine\n",
-            "  Downloading shark-turbine-0.9.1.dev3.tar.gz (60 kB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m60.2/60.2 kB\u001b[0m \u001b[31m786.0 kB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25h  Installing build dependencies ... \u001b[?25l\u001b[?25hdone\n",
-            "  Getting requirements to build wheel ... \u001b[?25l\u001b[?25hdone\n",
-            "  Preparing metadata (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
-            "Requirement already satisfied: numpy in /usr/local/lib/python3.10/dist-packages (from shark-turbine) (1.23.5)\n",
-            "Collecting iree-compiler>=20231004.665 (from shark-turbine)\n",
-            "  Downloading iree_compiler-20231004.665-cp310-cp310-manylinux_2_28_x86_64.whl (57.2 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m57.2/57.2 MB\u001b[0m \u001b[31m14.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting iree-runtime>=20231004.665 (from shark-turbine)\n",
-            "  Downloading iree_runtime-20231004.665-cp310-cp310-manylinux_2_28_x86_64.whl (7.8 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m7.8/7.8 MB\u001b[0m \u001b[31m60.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting torch>=2.1.0 (from shark-turbine)\n",
-            "  Downloading torch-2.1.0-cp310-cp310-manylinux1_x86_64.whl (670.2 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m670.2/670.2 MB\u001b[0m \u001b[31m1.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hRequirement already satisfied: PyYAML in /usr/local/lib/python3.10/dist-packages (from iree-compiler>=20231004.665->shark-turbine) (6.0.1)\n",
-            "Requirement already satisfied: filelock in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->shark-turbine) (3.12.4)\n",
-            "Requirement already satisfied: typing-extensions in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->shark-turbine) (4.5.0)\n",
-            "Requirement already satisfied: sympy in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->shark-turbine) (1.12)\n",
-            "Requirement already satisfied: networkx in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->shark-turbine) (3.1)\n",
-            "Requirement already satisfied: jinja2 in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->shark-turbine) (3.1.2)\n",
-            "Requirement already satisfied: fsspec in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->shark-turbine) (2023.6.0)\n",
-            "Collecting nvidia-cuda-nvrtc-cu12==12.1.105 (from torch>=2.1.0->shark-turbine)\n",
-            "  Downloading nvidia_cuda_nvrtc_cu12-12.1.105-py3-none-manylinux1_x86_64.whl (23.7 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m23.7/23.7 MB\u001b[0m \u001b[31m56.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting nvidia-cuda-runtime-cu12==12.1.105 (from torch>=2.1.0->shark-turbine)\n",
-            "  Downloading nvidia_cuda_runtime_cu12-12.1.105-py3-none-manylinux1_x86_64.whl (823 kB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m823.6/823.6 kB\u001b[0m \u001b[31m54.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting nvidia-cuda-cupti-cu12==12.1.105 (from torch>=2.1.0->shark-turbine)\n",
-            "  Downloading nvidia_cuda_cupti_cu12-12.1.105-py3-none-manylinux1_x86_64.whl (14.1 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m14.1/14.1 MB\u001b[0m \u001b[31m72.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting nvidia-cudnn-cu12==8.9.2.26 (from torch>=2.1.0->shark-turbine)\n",
-            "  Downloading nvidia_cudnn_cu12-8.9.2.26-py3-none-manylinux1_x86_64.whl (731.7 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m731.7/731.7 MB\u001b[0m \u001b[31m2.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting nvidia-cublas-cu12==12.1.3.1 (from torch>=2.1.0->shark-turbine)\n",
-            "  Downloading nvidia_cublas_cu12-12.1.3.1-py3-none-manylinux1_x86_64.whl (410.6 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m410.6/410.6 MB\u001b[0m \u001b[31m2.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting nvidia-cufft-cu12==11.0.2.54 (from torch>=2.1.0->shark-turbine)\n",
-            "  Downloading nvidia_cufft_cu12-11.0.2.54-py3-none-manylinux1_x86_64.whl (121.6 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m121.6/121.6 MB\u001b[0m \u001b[31m8.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting nvidia-curand-cu12==10.3.2.106 (from torch>=2.1.0->shark-turbine)\n",
-            "  Downloading nvidia_curand_cu12-10.3.2.106-py3-none-manylinux1_x86_64.whl (56.5 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m56.5/56.5 MB\u001b[0m \u001b[31m11.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting nvidia-cusolver-cu12==11.4.5.107 (from torch>=2.1.0->shark-turbine)\n",
-            "  Downloading nvidia_cusolver_cu12-11.4.5.107-py3-none-manylinux1_x86_64.whl (124.2 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m124.2/124.2 MB\u001b[0m \u001b[31m8.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting nvidia-cusparse-cu12==12.1.0.106 (from torch>=2.1.0->shark-turbine)\n",
-            "  Downloading nvidia_cusparse_cu12-12.1.0.106-py3-none-manylinux1_x86_64.whl (196.0 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m196.0/196.0 MB\u001b[0m \u001b[31m3.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting nvidia-nccl-cu12==2.18.1 (from torch>=2.1.0->shark-turbine)\n",
-            "  Downloading nvidia_nccl_cu12-2.18.1-py3-none-manylinux1_x86_64.whl (209.8 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m209.8/209.8 MB\u001b[0m \u001b[31m6.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting nvidia-nvtx-cu12==12.1.105 (from torch>=2.1.0->shark-turbine)\n",
-            "  Downloading nvidia_nvtx_cu12-12.1.105-py3-none-manylinux1_x86_64.whl (99 kB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m99.1/99.1 kB\u001b[0m \u001b[31m10.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting triton==2.1.0 (from torch>=2.1.0->shark-turbine)\n",
-            "  Downloading triton-2.1.0-0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl (89.2 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m89.2/89.2 MB\u001b[0m \u001b[31m7.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting nvidia-nvjitlink-cu12 (from nvidia-cusolver-cu12==11.4.5.107->torch>=2.1.0->shark-turbine)\n",
-            "  Downloading nvidia_nvjitlink_cu12-12.2.140-py3-none-manylinux1_x86_64.whl (20.2 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m20.2/20.2 MB\u001b[0m \u001b[31m74.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hRequirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.10/dist-packages (from jinja2->torch>=2.1.0->shark-turbine) (2.1.3)\n",
-            "Requirement already satisfied: mpmath>=0.19 in /usr/local/lib/python3.10/dist-packages (from sympy->torch>=2.1.0->shark-turbine) (1.3.0)\n",
-            "Building wheels for collected packages: shark-turbine\n",
-            "  Building wheel for shark-turbine (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
-            "  Created wheel for shark-turbine: filename=shark_turbine-0.9.1.dev3-py3-none-any.whl size=70102 sha256=73e3b15d1dfbe2c9d718b6d9f08ba3ec8dc149061c13935ed97214fb6aa77ac7\n",
-            "  Stored in directory: /root/.cache/pip/wheels/e9/78/0f/88c9d8224ef1550fe00b18a014eab5121f26264e2261f31926\n",
-            "Successfully built shark-turbine\n",
-            "Installing collected packages: triton, nvidia-nvtx-cu12, nvidia-nvjitlink-cu12, nvidia-nccl-cu12, nvidia-curand-cu12, nvidia-cufft-cu12, nvidia-cuda-runtime-cu12, nvidia-cuda-nvrtc-cu12, nvidia-cuda-cupti-cu12, nvidia-cublas-cu12, iree-runtime, iree-compiler, nvidia-cusparse-cu12, nvidia-cudnn-cu12, nvidia-cusolver-cu12, torch, shark-turbine\n",
-            "  Attempting uninstall: triton\n",
-            "    Found existing installation: triton 2.0.0\n",
-            "    Uninstalling triton-2.0.0:\n",
-            "      Successfully uninstalled triton-2.0.0\n",
+            "Looking in indexes: https://download.pytorch.org/whl/test/cpu\n",
+            "Collecting torch==2.3.0\n",
+            "  Downloading https://download.pytorch.org/whl/test/cpu/torch-2.3.0%2Bcpu-cp310-cp310-linux_x86_64.whl (190.4 MB)\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m190.4/190.4 MB\u001b[0m \u001b[31m2.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hRequirement already satisfied: filelock in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (3.13.4)\n",
+            "Requirement already satisfied: typing-extensions>=4.8.0 in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (4.11.0)\n",
+            "Requirement already satisfied: sympy in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (1.12)\n",
+            "Requirement already satisfied: networkx in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (3.3)\n",
+            "Requirement already satisfied: jinja2 in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (3.1.3)\n",
+            "Requirement already satisfied: fsspec in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (2023.6.0)\n",
+            "Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.10/dist-packages (from jinja2->torch==2.3.0) (2.1.5)\n",
+            "Requirement already satisfied: mpmath>=0.19 in /usr/local/lib/python3.10/dist-packages (from sympy->torch==2.3.0) (1.3.0)\n",
+            "Installing collected packages: torch\n",
             "  Attempting uninstall: torch\n",
-            "    Found existing installation: torch 2.0.1+cu118\n",
-            "    Uninstalling torch-2.0.1+cu118:\n",
-            "      Successfully uninstalled torch-2.0.1+cu118\n",
-            "Successfully installed iree-compiler-20231004.665 iree-runtime-20231004.665 nvidia-cublas-cu12-12.1.3.1 nvidia-cuda-cupti-cu12-12.1.105 nvidia-cuda-nvrtc-cu12-12.1.105 nvidia-cuda-runtime-cu12-12.1.105 nvidia-cudnn-cu12-8.9.2.26 nvidia-cufft-cu12-11.0.2.54 nvidia-curand-cu12-10.3.2.106 nvidia-cusolver-cu12-11.4.5.107 nvidia-cusparse-cu12-12.1.0.106 nvidia-nccl-cu12-2.18.1 nvidia-nvjitlink-cu12-12.2.140 nvidia-nvtx-cu12-12.1.105 shark-turbine-0.9.1.dev3 torch-2.1.0 triton-2.1.0\n"
+            "    Found existing installation: torch 2.2.1+cu121\n",
+            "    Uninstalling torch-2.2.1+cu121:\n",
+            "      Successfully uninstalled torch-2.2.1+cu121\n",
+            "Successfully installed torch-2.3.0+cpu\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "4iJFDHbsAzo4",
+        "outputId": "13397b7e-42cd-4f14-d6e8-a21fa2d1f524"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Collecting iree-turbine\n",
+            "  Downloading iree_turbine-2.3.0rc20240410-py3-none-any.whl (150 kB)\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m150.4/150.4 kB\u001b[0m \u001b[31m1.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hRequirement already satisfied: numpy in /usr/local/lib/python3.10/dist-packages (from iree-turbine) (1.25.2)\n",
+            "Collecting iree-compiler>=20240410.859 (from iree-turbine)\n",
+            "  Downloading iree_compiler-20240410.859-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (64.4 MB)\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m64.4/64.4 MB\u001b[0m \u001b[31m9.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hCollecting iree-runtime>=20240410.859 (from iree-turbine)\n",
+            "  Downloading iree_runtime-20240410.859-cp310-cp310-manylinux_2_28_x86_64.whl (7.4 MB)\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m7.4/7.4 MB\u001b[0m \u001b[31m31.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hRequirement already satisfied: torch>=2.1.0 in /usr/local/lib/python3.10/dist-packages (from iree-turbine) (2.3.0+cpu)\n",
+            "Requirement already satisfied: PyYAML in /usr/local/lib/python3.10/dist-packages (from iree-compiler>=20240410.859->iree-turbine) (6.0.1)\n",
+            "Requirement already satisfied: filelock in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->iree-turbine) (3.13.4)\n",
+            "Requirement already satisfied: typing-extensions>=4.8.0 in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->iree-turbine) (4.11.0)\n",
+            "Requirement already satisfied: sympy in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->iree-turbine) (1.12)\n",
+            "Requirement already satisfied: networkx in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->iree-turbine) (3.3)\n",
+            "Requirement already satisfied: jinja2 in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->iree-turbine) (3.1.3)\n",
+            "Requirement already satisfied: fsspec in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->iree-turbine) (2023.6.0)\n",
+            "Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.10/dist-packages (from jinja2->torch>=2.1.0->iree-turbine) (2.1.5)\n",
+            "Requirement already satisfied: mpmath>=0.19 in /usr/local/lib/python3.10/dist-packages (from sympy->torch>=2.1.0->iree-turbine) (1.3.0)\n",
+            "Installing collected packages: iree-runtime, iree-compiler, iree-turbine\n",
+            "Successfully installed iree-compiler-20240410.859 iree-runtime-20240410.859 iree-turbine-2.3.0rc20240410\n"
           ]
         }
       ],
       "source": [
-        "#@title Install SHARK-Turbine\n",
-        "\n",
-        "# Limit cell height.\n",
-        "from IPython.display import Javascript\n",
-        "display(Javascript('''google.colab.output.setIframeHeight(0, true, {maxHeight: 300})'''))\n",
-        "\n",
-        "!python -m pip install shark-turbine"
+        "#@title Install iree-turbine\n",
+        "!python -m pip install iree-turbine"
       ]
     },
     {
       "cell_type": "code",
       "source": [
         "#@title Report version information\n",
-        "!echo \"Installed SHARK-Turbine, $(python -m pip show shark_turbine | grep Version)\"\n",
+        "!echo \"Installed iree-turbine, $(python -m pip show iree_turbine | grep Version)\"\n",
         "\n",
         "!echo -e \"\\nInstalled IREE, compiler version information:\"\n",
         "!iree-compile --version\n",
@@ -211,23 +178,23 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "nkVLzRpcDnVL",
-        "outputId": "1fa62bc3-6cba-4d7b-9ccf-d8ad024df53b"
+        "outputId": "230b113c-6800-45e2-ec93-eddefa439803"
       },
-      "execution_count": 4,
+      "execution_count": 5,
       "outputs": [
         {
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "Installed SHARK-Turbine, Version: 0.9.1.dev3\n",
+            "Installed iree-turbine, Version: 2.3.0rc20240410\n",
             "\n",
             "Installed IREE, compiler version information:\n",
             "IREE (https://iree.dev):\n",
-            "  IREE compiler version 20231004.665 @ bb51f6f1a1b4ee619fb09a7396f449dadb211447\n",
-            "  LLVM version 18.0.0git\n",
+            "  IREE compiler version 20240410.859 @ b4273a4bfc66ba6dd8f62f6483d74d42a7b936f1\n",
+            "  LLVM version 19.0.0git\n",
             "  Optimized build\n",
             "\n",
-            "Installed PyTorch, version: 2.1.0+cu121\n"
+            "Installed PyTorch, version: 2.3.0+cpu\n"
           ]
         }
       ]
@@ -269,7 +236,7 @@
       "metadata": {
         "id": "oPdjrmPZMNz6"
       },
-      "execution_count": 5,
+      "execution_count": 6,
       "outputs": []
     },
     {
@@ -283,9 +250,9 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "eK2fWVfiSQ8f",
-        "outputId": "7696a60a-46d1-4d4b-a38b-901aa36530b5"
+        "outputId": "337f5077-22e3-4ff0-cde1-38b08ff5bea5"
       },
-      "execution_count": 6,
+      "execution_count": 7,
       "outputs": [
         {
           "output_type": "stream",
@@ -312,9 +279,9 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "0AdkXY8VNL2-",
-        "outputId": "c965bf26-5d23-4776-8cda-80ce8a307d28"
+        "outputId": "0f19bdd4-15ff-43ce-b9a7-6fa1113d124c"
       },
-      "execution_count": 7,
+      "execution_count": 8,
       "outputs": [
         {
           "output_type": "stream",
@@ -335,20 +302,36 @@
             "\n",
             "#map = affine_map<(d0) -> (d0)>\n",
             "module {\n",
-            "  func.func @main(%arg0: tensor<4x3xf32>, %arg1: tensor<3xf32>, %arg2: tensor<4xf32>) -> (tensor<3xf32>, tensor<1x4xf32>) {\n",
+            "  util.func public @main$async(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view, %arg2: !hal.buffer_view, %arg3: !hal.fence, %arg4: !hal.fence) -> (!hal.buffer_view, !hal.buffer_view) attributes {inlining_policy = #util.inline.never, iree.abi.model = \"coarse-fences\", iree.abi.stub} {\n",
             "    %cst = arith.constant 0.000000e+00 : f32\n",
-            "    %expanded = tensor.expand_shape %arg2 [[0, 1]] : tensor<4xf32> into tensor<1x4xf32>\n",
-            "    %0 = tensor.empty() : tensor<1x3xf32>\n",
-            "    %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<1x3xf32>) -> tensor<1x3xf32>\n",
-            "    %2 = linalg.matmul ins(%expanded, %arg0 : tensor<1x4xf32>, tensor<4x3xf32>) outs(%1 : tensor<1x3xf32>) -> tensor<1x3xf32>\n",
-            "    %collapsed = tensor.collapse_shape %2 [[0, 1]] : tensor<1x3xf32> into tensor<3xf32>\n",
-            "    %3 = tensor.empty() : tensor<3xf32>\n",
-            "    %4 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = [\"parallel\"]} ins(%collapsed, %arg1 : tensor<3xf32>, tensor<3xf32>) outs(%3 : tensor<3xf32>) {\n",
+            "    %0 = hal.tensor.import wait(%arg3) => %arg0 : !hal.buffer_view -> tensor<4x3xf32>\n",
+            "    %1 = hal.tensor.import wait(%arg3) => %arg1 : !hal.buffer_view -> tensor<3xf32>\n",
+            "    %2 = hal.tensor.import wait(%arg3) => %arg2 : !hal.buffer_view -> tensor<4xf32>\n",
+            "    %expanded = tensor.expand_shape %2 [[0, 1]] : tensor<4xf32> into tensor<1x4xf32>\n",
+            "    %3 = tensor.empty() : tensor<1x3xf32>\n",
+            "    %4 = linalg.fill ins(%cst : f32) outs(%3 : tensor<1x3xf32>) -> tensor<1x3xf32>\n",
+            "    %5 = linalg.matmul ins(%expanded, %0 : tensor<1x4xf32>, tensor<4x3xf32>) outs(%4 : tensor<1x3xf32>) -> tensor<1x3xf32>\n",
+            "    %collapsed = tensor.collapse_shape %5 [[0, 1]] : tensor<1x3xf32> into tensor<3xf32>\n",
+            "    %6 = tensor.empty() : tensor<3xf32>\n",
+            "    %7 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = [\"parallel\"]} ins(%collapsed, %1 : tensor<3xf32>, tensor<3xf32>) outs(%6 : tensor<3xf32>) {\n",
             "    ^bb0(%in: f32, %in_0: f32, %out: f32):\n",
-            "      %5 = arith.addf %in, %in_0 : f32\n",
-            "      linalg.yield %5 : f32\n",
+            "      %11 = arith.addf %in, %in_0 : f32\n",
+            "      linalg.yield %11 : f32\n",
             "    } -> tensor<3xf32>\n",
-            "    return %4, %expanded : tensor<3xf32>, tensor<1x4xf32>\n",
+            "    %8:2 = hal.tensor.barrier join(%7, %expanded : tensor<3xf32>, tensor<1x4xf32>) => %arg4 : !hal.fence\n",
+            "    %9 = hal.tensor.export %8#0 : tensor<3xf32> -> !hal.buffer_view\n",
+            "    %10 = hal.tensor.export %8#1 : tensor<1x4xf32> -> !hal.buffer_view\n",
+            "    util.return %9, %10 : !hal.buffer_view, !hal.buffer_view\n",
+            "  }\n",
+            "  util.func public @main(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view, %arg2: !hal.buffer_view) -> (!hal.buffer_view, !hal.buffer_view) attributes {iree.abi.stub} {\n",
+            "    %c-1_i32 = arith.constant -1 : i32\n",
+            "    %c0 = arith.constant 0 : index\n",
+            "    %device_0 = hal.devices.get %c0 : !hal.device\n",
+            "    %0 = util.null : !hal.fence\n",
+            "    %fence = hal.fence.create device(%device_0 : !hal.device) flags(\"None\") : !hal.fence\n",
+            "    %1:2 = util.call @main$async(%arg0, %arg1, %arg2, %0, %fence) : (!hal.buffer_view, !hal.buffer_view, !hal.buffer_view, !hal.fence, !hal.fence) -> (!hal.buffer_view, !hal.buffer_view)\n",
+            "    %status = hal.fence.await until([%fence]) timeout_millis(%c-1_i32) : i32\n",
+            "    util.return %1#0, %1#1 : !hal.buffer_view, !hal.buffer_view\n",
             "  }\n",
             "}\n",
             "\n"
@@ -367,14 +350,6 @@
             "tensor([-0.8567,  1.1006, -1.0712], requires_grad=True)\n",
             "Args: tensor([ 0.1227, -0.5663,  0.3731, -0.8920])\n",
             "Output: tensor([-0.4792,  2.5237, -0.9772], grad_fn=<CompiledFunctionBackward>)\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.10/dist-packages/torch/_functorch/aot_autograd.py:1510: UserWarning: Your compiler for AOTAutograd is returning a function that doesn't take boxed arguments. Please wrap it with functorch.compile.make_boxed_func or handle the boxed arguments yourself. See https://github.com/pytorch/pytorch/pull/83137#issuecomment-1211320670 for rationale.\n",
-            "  warnings.warn(\n"
           ]
         }
       ]


### PR DESCRIPTION
This is fairly minimal at the moment. Future changes should explore more of the API surface and reference the newer `iree-turbine` branding / namespace in all locations once that settles.

Changes:

* Fixed broken links to source files in https://github.com/nod-ai/SHARK-Turbine and PyTorch reference pages
* Ran the sample code on the website and verified that it still works
* Updated sample Colab notebooks to...
  * Download PyTorch 2.3.0 (prerelease)
  * Install `iree-turbine` instead of `shark-turbine`
  * Adapt to small API changes