### PR TITLE
[GlobalOpt][DT] Simplify logics in SetEncoding pass.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtBase.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtBase.td
@@ -96,6 +96,14 @@ def EncodingAttr :
     OptionalParameter<"ArrayAttr", "Indexing maps of the operation using this tensor">:$user_indexing_maps
   );
 
+  let builders = [
+    AttrBuilder<(ins "EncodingRole":$role,
+        "ArrayRef<Type>":$elemTypes, "Type":$origType,
+        CArg<"std::optional<int64_t>", "{}">:$matmulNarrowM,
+        CArg<"std::optional<int64_t>", "{}">:$matmulNarrowN,
+        CArg<"ArrayRef<AffineMap>", "{}">:$maps)>
+  ];
+
   let genVerifyDecl = 0;
 }
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -2777,6 +2777,26 @@ LogicalResult UnsetEncodingOp::reifyResultShapes(
   return success();
 }
 
+//===----------------------------------------------------------------------===//
+// iree_linalg_ext.encoding
+//===----------------------------------------------------------------------===//
+
+EncodingAttr EncodingAttr::get(MLIRContext *ctx, EncodingRole role,
+                               ArrayRef<Type> elemTypes, Type origType,
+                               std::optional<int64_t> matmulNarrowM,
+                               std::optional<int64_t> matmulNarrowN,
+                               ArrayRef<AffineMap> maps) {
+  Builder b(ctx);
+  auto optionalToAttr = [&](std::optional<int64_t> x) {
+    return x ? b.getIndexAttr(*x) : IntegerAttr();
+  };
+  auto roleAttr = EncodingRoleAttr::get(ctx, role);
+  auto origTypeAttr = origType ? TypeAttr::get(origType) : TypeAttr();
+  return get(ctx, roleAttr, b.getTypeArrayAttr(elemTypes), origTypeAttr,
+             optionalToAttr(matmulNarrowM), optionalToAttr(matmulNarrowN),
+             b.getAffineMapArrayAttr(maps));
+}
+
 // clang-format off
 #define GET_OP_CLASSES
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp.inc" // IWYU pragma: keep


### PR DESCRIPTION
- It introduce a EncodingAttr builder, so we don't need to wrap attributes ourselves.
- It removes operandTypes during setting the encoding, because we only need the element types. We already have them, and we don't need to re-compute it.