### PR TITLE
Fix failing transform dialect CUDA tests.

### DIFF
--- a/tests/transform_dialect/cuda/double_mma_layout_analysis.mlir
+++ b/tests/transform_dialect/cuda/double_mma_layout_analysis.mlir
@@ -1,5 +1,3 @@
-// XFAILED due to failure with https://github.com/openxla/iree/pull/16665 (Issues: https://github.com/openxla/iree/issues/17039)
-// XFAIL: * 
 func.func @double_matmul(%lhs : tensor<16x16xf16>, %rhs : tensor<16x16xf16>, %second : tensor<16x8xf16>) -> tensor<16x8xf16> {
   %c0 = arith.constant 0.0 : f16
   %0 = tensor.empty() : tensor<16x16xf16>

--- a/tests/transform_dialect/cuda/double_mma_layout_analysis_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/double_mma_layout_analysis_codegen_spec.mlir
@@ -64,10 +64,6 @@ module attributes { transform.with_named_sequence } {
     // ===========================================================================
     %func_11 = transform.iree.layout_analysis_and_distribution %memref_func : (!transform.any_op) -> (!transform.any_op)
 
-    // Annotate the exported function as already translated.
-    %none = transform.param.constant #iree_codegen.translation_info<None> -> !transform.any_param
-    transform.annotate %func_11 "translation_info" = %none : !transform.any_op, !transform.any_param
-
     transform.yield
   }
 } // module

--- a/tests/transform_dialect/cuda/mma_elemwise_layout_analysis.mlir
+++ b/tests/transform_dialect/cuda/mma_elemwise_layout_analysis.mlir
@@ -1,5 +1,3 @@
-// XFAILED due to failure with https://github.com/openxla/iree/pull/16665 (Issues: https://github.com/openxla/iree/issues/17039)
-// XFAIL: * 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 func.func @matmul(%lhs : tensor<16x16xf16>, %rhs : tensor<8x16xf16>, %bias : tensor<16x8xf16>) -> tensor<16x8xf16> {
   %c0 = arith.constant 0.0 : f16

--- a/tests/transform_dialect/cuda/mma_elemwise_layout_analysis_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/mma_elemwise_layout_analysis_codegen_spec.mlir
@@ -60,9 +60,6 @@ module attributes { transform.with_named_sequence } {
       // ===========================================================================
       %func_11 = transform.iree.layout_analysis_and_distribution %memref_func : (!transform.any_op) -> (!transform.any_op)
 
-      // Annotate the exported function as already translated.
-      %none = transform.param.constant #iree_codegen.translation_info<None> -> !transform.any_param
-      transform.annotate %func_11 "translation_info" = %none : !transform.any_op, !transform.any_param
       transform.yield
     }
 } // module

--- a/tests/transform_dialect/cuda/mma_reduction_layout_analysis.mlir
+++ b/tests/transform_dialect/cuda/mma_reduction_layout_analysis.mlir
@@ -1,5 +1,3 @@
-// XFAILED due to failure with https://github.com/openxla/iree/pull/16665 (Issues: https://github.com/openxla/iree/issues/17039)
-// XFAIL: * 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d0)>
 func.func @matmul_reduction(%lhs : tensor<16x16xf16>, %rhs : tensor<16x16xf16>) -> tensor<16x16xf16> {
@@ -11,8 +9,7 @@ func.func @matmul_reduction(%lhs : tensor<16x16xf16>, %rhs : tensor<16x16xf16>) 
   %1 = linalg.fill ins(%c0 : f16) outs(%0 : tensor<16x16xf16>) -> tensor<16x16xf16>
   %2 = linalg.matmul_transpose_b ins(%lhs, %rhs : tensor<16x16xf16>, tensor<16x16xf16>)
       outs(%1 : tensor<16x16xf16>) -> tensor<16x16xf16>
-  %6 = linalg.generic {indexing_maps// XFAILED due to failure with https://github.com/openxla/iree/pull/16665 (Issues: https://github.com/openxla/iree/issues/17039)
-// XFAIL: * 
+  %6 = linalg.generic {indexing_maps
  = [#map, #map1], iterator_types = ["parallel", "reduction"]}
         ins(%2 : tensor<16x16xf16>) outs(%init : tensor<16xf16>) {
         ^bb0(%in: f16, %out: f16):

--- a/tests/transform_dialect/cuda/mma_reduction_layout_analysis_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/mma_reduction_layout_analysis_codegen_spec.mlir
@@ -63,9 +63,6 @@ module attributes { transform.with_named_sequence } {
     // ===========================================================================
     %func_11 = transform.iree.layout_analysis_and_distribution %memref_func : (!transform.any_op) -> (!transform.any_op)
 
-    // Annotate the exported function as already translated.
-    %none = transform.param.constant #iree_codegen.translation_info<None> -> !transform.any_param
-    transform.annotate %func_11 "translation_info" = %none : !transform.any_op, !transform.any_param
     transform.yield
   }
 } // module

--- a/tests/transform_dialect/cuda/mma_using_layout_analysis.mlir
+++ b/tests/transform_dialect/cuda/mma_using_layout_analysis.mlir
@@ -1,5 +1,3 @@
-// XFAILED due to failure with https://github.com/openxla/iree/pull/16665 (Issues: https://github.com/openxla/iree/issues/17039)
-// XFAIL: * 
 func.func @matmul(%lhs : tensor<16x16xf16>, %rhs : tensor<16x8xf16>) -> tensor<16x8xf16> {
   %c0 = arith.constant 0.0 : f16
   %0 = tensor.empty() : tensor<16x8xf16>

--- a/tests/transform_dialect/cuda/mma_using_layout_analysis_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/mma_using_layout_analysis_codegen_spec.mlir
@@ -67,9 +67,6 @@ module attributes { transform.with_named_sequence } {
     // ===========================================================================
     %func_11 = transform.iree.layout_analysis_and_distribution %memref_func : (!transform.any_op) -> (!transform.any_op)
 
-    // Annotate the exported function as already translated.
-    %none = transform.param.constant #iree_codegen.translation_info<None> -> !transform.any_param
-    transform.annotate %func_11 "translation_info" = %none : !transform.any_op, !transform.any_param
     transform.yield
   }
 } // module


### PR DESCRIPTION
Fixes all of the failures in https://github.com/openxla/iree/issues/17039 except
`mma_reduction_layout_analysis.mlir`. Looking at the generated code,
the exact PTX is being generated, but the test fails on CI. So keeping
it as xfail for now.

Fixes #17039 

ci-extra:  test_nvidia_a100