### PR TITLE
Clone `tensor.empty` operations on dispatches with only `linalg.generic` ops.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/CloneProducersIntoDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/CloneProducersIntoDispatchRegions.cpp
@@ -41,6 +41,13 @@ struct CloneProducersIntoDispatchRegionPass
         return signalPassFailure();
       }
     });
+
+    // Rerun the cloning again to move still clonable operations into
+    // dispatches.
+    funcOp->walk([&](DispatchRegionOp regionOp) {
+      if (failed(cloneProducersToRegion(rewriter, regionOp)))
+        return signalPassFailure();
+    });
   }
 };
 


### PR DESCRIPTION
Since some elementwise operations are formed as dispatches after cloning, more operations could be cloned into these dispatches. Run the cloning step again to make sure that happens.

Note : This ends up walking the program again that can be expensive. The cloning should happen "after" all dispatches are formed. That does not seem to be the case today. This needs to be refactored.

Fixes #17037