### PR TITLE
[Codegen] Fix `TilingConfig::getTilingLevelForVectorDimPosition()` for <= 2 tiling levels

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
@@ -55,18 +55,16 @@ TilingConfig::TilingConfig(IREE::Codegen::LoweringConfigAttr lc)
 /// Returns the tiling level that contains the vector dim at `dimPos` (which is
 /// an index into the result of `getVectorTileSizes()`).
 std::optional<unsigned>
-TilingConfig::getTilingLevelForVectorDimPosition(unsigned dimPos) {
+TilingConfig::getTilingLevelForVectorDimPosition(unsigned dimPos) const {
   constexpr std::array vectorTilingLevels{VectorCommonParallelTiles,
                                           VectorReductionTiles,
                                           VectorInnerParallelTiles};
-  ArrayRef<TilingLevel> possibleLevels = vectorTilingLevels;
-  if (!hasVectorInnerParallelLevel())
-    possibleLevels = possibleLevels.drop_back();
   std::optional<unsigned> foundLevel;
   auto tilingLevels = loweringConfig.getTilingLevels();
-  for (TilingLevel level : possibleLevels) {
-    auto tilingLevelIndex = getActualLevel(level);
-    if (tilingLevels[tilingLevelIndex].getSizes()[dimPos] != 0) {
+  for (TilingLevel level : vectorTilingLevels) {
+    auto tilingLevelIndex = tilingLevelToActualLevelMap[level];
+    if (tilingLevelIndex != InvalidLevel &&
+        tilingLevels[tilingLevelIndex].getSizes()[dimPos] != 0) {
       assert(!foundLevel.has_value() &&
              "expected at most one tile size to be non-zero");
       foundLevel = tilingLevelIndex;
@@ -87,10 +85,6 @@ static std::pair<int64_t, bool> getTileSizeAtIndex(ArrayRef<int64_t> sizes,
 /// Returns the tile sizes of all the vector dimensions, including parallel
 /// and reduction dimensions.
 SizesAndScalableFlags TilingConfig::getVectorTileSizes() {
-  if (getNumTilingLevels() == 2) {
-    return getVectorCommonParallelSizes();
-  }
-
   unsigned numDims = getNumDimensions();
   SmallVector<int64_t> vectorSizes(numDims, 0);
   SmallVector<bool> scalableFlags(numDims, false);

--- a/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.h
@@ -110,11 +110,6 @@ public:
     return getVectorSizesForLevel(getVectorInnerParallelLevel());
   }
 
-  /// Returns the tiling level that contains the vector dim at `dimPos` (which
-  /// is an index into the result of `getVectorTileSizes()`).
-  std::optional<unsigned>
-  getTilingLevelForVectorDimPosition(unsigned dimPos) const;
-
   /// Returns the tile sizes of all the vector dimensions, including parallel
   /// and reduction dimensions.
   SizesAndScalableFlags getVectorTileSizes();
@@ -124,7 +119,7 @@ public:
   /// `scalableFlags`.
   IREE::Codegen::LoweringConfigAttr
   getLoweringConfigWithNewVectorSizes(ArrayRef<int64_t> sizes,
-                                      ArrayRef<bool> scalableFlags);
+                                      ArrayRef<bool> scalableFlags = {});
 
   /// Returns a list with the tiling levels that can be fused for this
   /// configuration.
@@ -147,6 +142,11 @@ private:
   SmallVector<int64_t> getTileSizesForLevel(unsigned level) {
     return loweringConfig.getTileSizeVals(level);
   }
+
+  /// Returns the tiling level that contains the vector dim at `dimPos` (which
+  /// is an index into the result of `getVectorTileSizes()`).
+  std::optional<unsigned>
+  getTilingLevelForVectorDimPosition(unsigned dimPos) const;
 
   /// Internal representation for all the supported tiling levels. All or just
   /// a subset of them may be available in a valid configuration.

--- a/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.h
@@ -112,7 +112,8 @@ public:
 
   /// Returns the tiling level that contains the vector dim at `dimPos` (which
   /// is an index into the result of `getVectorTileSizes()`).
-  std::optional<unsigned> getTilingLevelForVectorDimPosition(unsigned dimPos);
+  std::optional<unsigned>
+  getTilingLevelForVectorDimPosition(unsigned dimPos) const;
 
   /// Returns the tile sizes of all the vector dimensions, including parallel
   /// and reduction dimensions.


### PR DESCRIPTION
We can simply ignore vector tiling levels that don't exist rather than crashing. This change also removes a workaround in `TilingConfig::getVectorTileSizes()`.