### PR TITLE
[GlobalOptimization] Add a pass to do horizontal fusion of contraction operations with a common operand.

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
+++ b/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
@@ -54,6 +54,7 @@ iree_compiler_cc_library(
         "EraseUnusedLinalgOperands.cpp",
         "ExpandTensorShapes.cpp",
         "FuseDequantizationMatmul.cpp",
+        "FuseHorizontalContractions.cpp",
         "FuseSiluHorizontalMatmul.cpp",
         "GeneralizeLinalgNamedOps.cpp",
         "GlobalLoopInvariantCodeMotion.cpp",

--- a/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
+++ b/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
@@ -50,6 +50,7 @@ iree_cc_library(
     "EraseUnusedLinalgOperands.cpp"
     "ExpandTensorShapes.cpp"
     "FuseDequantizationMatmul.cpp"
+    "FuseHorizontalContractions.cpp"
     "FuseSiluHorizontalMatmul.cpp"
     "GeneralizeLinalgNamedOps.cpp"
     "GlobalLoopInvariantCodeMotion.cpp"

--- a/compiler/src/iree/compiler/GlobalOptimization/FuseHorizontalContractions.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/FuseHorizontalContractions.cpp
@@ -1,0 +1,475 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h"
+#include "iree/compiler/GlobalOptimization/PassDetail.h"
+#include "iree/compiler/GlobalOptimization/Passes.h"
+#include "iree/compiler/GlobalOptimization/Utils.h"
+#include "mlir/IR/Dominance.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Tensor/Transforms/Transforms.h"
+#include "mlir/Dialect/Tensor/Utils/Utils.h"
+#include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
+#include "mlir/Dialect/Utils/StructuredOpsUtils.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "iree-global-opt-fuse-horizontal-contraction"
+
+namespace mlir::iree_compiler::GlobalOptimization {
+
+namespace {
+
+struct FuseHorizontalContractionsPass
+    : public FuseHorizontalContractionsBase<FuseHorizontalContractionsPass> {
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<arith::ArithDialect, tensor::TensorDialect>();
+  }
+  FuseHorizontalContractionsPass() {}
+  FuseHorizontalContractionsPass(const FuseHorizontalContractionsPass &pass)
+      : FuseHorizontalContractionsPass() {}
+
+  void runOnOperation() override;
+};
+
+} // namespace
+
+/// Structs that captures the ops that are to be fused
+struct HorizontalFusionGroup {
+  // Contractions op that are to be fused.
+  SmallVector<linalg::LinalgOp> contractionOps;
+  // Optional truncate operations that could be following the contraction op.
+  std::optional<SmallVector<linalg::GenericOp>> truncateOps;
+  // Operation that dominates all the ops of the group.
+  Operation *dominatedByAll;
+};
+
+/// Get user of operation that is a truncate operation.
+static std::optional<linalg::GenericOp> getTruncFUser(Operation *op) {
+  if (op->getNumResults() != 1) {
+    return std::nullopt;
+  }
+  Value result = op->getResult(0);
+  if (!result.hasOneUse()) {
+    return std::nullopt;
+  }
+  Operation *user = *result.user_begin();
+  auto genericOp = dyn_cast<linalg::GenericOp>(user);
+  if (!genericOp) {
+    return std::nullopt;
+  }
+  if (genericOp.getNumDpsInputs() != 1 || genericOp.getNumDpsInits() != 1) {
+    return std::nullopt;
+  }
+  if (llvm::any_of(genericOp.getIndexingMapsArray(),
+                   [](AffineMap map) { return !map.isIdentity(); })) {
+    return std::nullopt;
+  }
+  if (genericOp.getNumParallelLoops() != genericOp.getNumLoops()) {
+    return std::nullopt;
+  }
+  auto yieldOp = cast<linalg::YieldOp>(genericOp.getBody()->getTerminator());
+  auto yieldDefOp = yieldOp->getOperand(0).getDefiningOp<arith::TruncFOp>();
+  if (!yieldDefOp) {
+    return std::nullopt;
+  }
+  auto arg = dyn_cast<BlockArgument>(yieldDefOp->getOperand(0));
+  if (!arg || arg.getParentBlock() != genericOp.getBody() ||
+      arg.getArgNumber() != 0) {
+    return std::nullopt;
+  }
+  return genericOp;
+}
+
+/// Find the operation that is dominated by all other operation.
+std::optional<Operation *>
+findDominatedByAllOps(const SetVector<Operation *> &ops,
+                      const DominanceInfo &dominanceInfo) {
+  for (auto opA : ops) {
+    bool opAIsDominatedByAll = true;
+    for (auto opB : ops) {
+      if (opA == opB) {
+        continue;
+      }
+      if (!dominanceInfo.properlyDominates(opB, opA)) {
+        opAIsDominatedByAll = false;
+        break;
+      }
+    }
+    if (opAIsDominatedByAll) {
+      return opA;
+    }
+  }
+  return std::nullopt;
+}
+
+/// Find all candidates that can be used for horizontal fusion. For example
+/// ```
+/// %0 = linalg.matmul ins(%arg0, %arg1)
+/// %1 = linalg.matmul ins(%arg0, %arg2)
+/// %2 = linalg.matmul ins(%arg0, %arg3)
+/// ```
+///
+/// where all matmul share an operand can be combined into
+///
+/// ```
+/// %4 = linalg.matmul ins(%arg0, concat(%arg1, %arg2, %arg3))
+/// ```
+///
+/// This method recognizes such patterns. It also accounts for the quantized
+/// case where individual operations might be have lower-precision operands and
+/// accumulate in higher precision, followed by a `linalg.generic` that performs
+/// the `truncf` on the result.
+static std::optional<HorizontalFusionGroup> getHorizontalFusionGroupMembers(
+    linalg::LinalgOp seedOp,
+    const llvm::SmallDenseSet<linalg::LinalgOp> &groupedOperations,
+    const DominanceInfo &dominanceInfo) {
+  Value lhs = seedOp->getOperand(0);
+  auto lhsType = cast<RankedTensorType>(lhs.getType());
+  Value rhs = seedOp->getOperand(1);
+  auto rhsType = cast<RankedTensorType>(rhs.getType());
+  Value out = seedOp->getOperand(2);
+  auto outType = cast<RankedTensorType>(out.getType());
+
+  if (!lhsType.hasStaticShape() || !rhsType.hasStaticShape() ||
+      !outType.hasStaticShape()) {
+    return std::nullopt;
+  }
+
+  SetVector<Operation *> allOps;
+  SmallVector<linalg::LinalgOp> contractionOps = {seedOp};
+  std::optional<linalg::GenericOp> truncOp = getTruncFUser(seedOp);
+  std::optional<SmallVector<linalg::GenericOp>> truncateOps;
+  if (truncOp) {
+    truncateOps = {truncOp.value()};
+  }
+  allOps.insert(seedOp);
+  if (truncOp) {
+    allOps.insert(truncOp.value());
+  }
+
+  auto canBeGrouped = [&](linalg::LinalgOp linalgOp) -> bool {
+    if (linalgOp->getParentOp() != seedOp->getParentOp()) {
+      return false;
+    }
+    if (!linalg::isaContractionOpInterface(linalgOp)) {
+      return false;
+    }
+    if (groupedOperations.contains(linalgOp) || allOps.contains(linalgOp)) {
+      return false;
+    }
+    if (linalgOp->getOperand(0).getType() != lhsType ||
+        linalgOp->getOperand(1).getType() != rhsType ||
+        linalgOp->getOperand(2).getType() != outType) {
+      return false;
+    }
+    // Either this has to dominate the seed or seed has to dominate this.
+    if (!dominanceInfo.properlyDominates(linalgOp, seedOp) &&
+        !dominanceInfo.properlyDominates(seedOp, linalgOp)) {
+      return false;
+    }
+    return true;
+  };
+
+  // Iterating over the users as is bad cause the users have no ordering
+  // gaurantees. So look for only ops within the same block as the seed op and
+  // sort them.
+  SmallVector<Operation *> lhsUsers;
+  for (Operation *lhsUser : lhs.getUsers()) {
+    if (lhsUser->getBlock() == seedOp->getBlock()) {
+      lhsUsers.push_back(lhsUser);
+    }
+  }
+  llvm::sort(lhsUsers, [&](Operation *lhs, Operation *rhs) {
+    return dominanceInfo.properlyDominates(lhs, rhs);
+  });
+
+  // Collect all contraction op users of lhs.
+  for (Operation *lhsUser : lhsUsers) {
+    if (lhsUser == seedOp.getOperation()) {
+      continue;
+    }
+
+    auto linalgUser = dyn_cast<linalg::LinalgOp>(lhsUser);
+    if (!linalgUser || !canBeGrouped(linalgUser)) {
+      continue;
+    }
+
+    std::optional<linalg::GenericOp> userTruncOp = getTruncFUser(linalgUser);
+    if (truncateOps && !userTruncOp) {
+      continue;
+    }
+
+    contractionOps.push_back(linalgUser);
+    allOps.insert(linalgUser);
+    if (truncateOps) {
+      truncateOps.value().push_back(userTruncOp.value());
+      allOps.insert(userTruncOp.value());
+    }
+  }
+
+  if (contractionOps.size() == 1) {
+    return std::nullopt;
+  }
+
+  // Check that all uses are "self-contained", i.e. one of the ops dominates
+  // all the ops (for both the contraction and the truncation ops)
+  // and that this op dominates all the other uses of all the ops.
+  std::optional<Operation *> dominatedByAllOps =
+      findDominatedByAllOps(allOps, dominanceInfo);
+  if (!dominatedByAllOps) {
+    return std::nullopt;
+  }
+
+  // Check that this operation dominates all other uses of allOps.
+  for (auto op : allOps) {
+    if (op == dominatedByAllOps.value()) {
+      continue;
+    }
+    for (Operation *user : op->getUsers()) {
+      if (allOps.contains(user)) {
+        continue;
+      }
+      if (!dominanceInfo.properlyDominates(dominatedByAllOps.value(), user)) {
+        return std::nullopt;
+      }
+    }
+  }
+  return HorizontalFusionGroup{contractionOps, truncateOps,
+                               dominatedByAllOps.value()};
+}
+
+/// On finding this pattern
+/// ```
+/// %0 = linalg.matmul ins(%arg0, %arg1)
+/// %1 = linalg.matmul ins(%arg0, %arg2)
+/// %2 = linalg.matmul ins(%arg0, %arg3)
+/// ```
+///
+/// where all matmul share an operand can be combined into
+/// rewrite to
+///
+/// ```
+/// %arg1_r = tensor.expand_shape %arg1 [[0, 1], ...] : tensor<?x?xf32> to
+/// tensor<1x?x?xf32> %arg2_r = tensor.expand_shape %arg2 [[0, 1], ...] :
+/// tensor<?x?xf32> to tensor<1x?x?xf32> %arg3_r = tensor.expand_shape %arg3
+/// [[0, 1], ...] : tensor<?x?xf32> to tensor<1x?x?xf32> %rhs = tensor.concat
+/// (%arg1_r, %arg2_r, %arg3_r) %fused = linalg.generic {
+///     indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d1, d3)>,
+///                      affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>,
+///                      affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>}],
+///     iterator_types = ["parallel", "parallel", "parallel", "reduction"]}
+///   ins(%arg0, %rhs) ... { ... }
+/// %0 = tensor.extract_slice %fused [0, 0, 0] ... : tensor<1x?x?xf32> to
+/// tensor<?x?xf32> %1 = tensor.extract_slice %fused [1, 0, 0] ... :
+/// tensor<1x?x?xf32> to tensor<?x?xf32> %2 = tensor.extract_slice %fused [2, 0,
+/// 0] ... : tensor<1x?x?xf32> to tensor<?x?xf32>
+/// ```
+///
+/// Also accounts for quantized cases where inputs are at lower precision and
+/// accumulate is in higher-precision with truncate getting back to the
+/// quantized sizes.
+static LogicalResult fuseGroup(RewriterBase &rewriter,
+                               HorizontalFusionGroup &fusionGroup) {
+  rewriter.setInsertionPointAfter(fusionGroup.dominatedByAll);
+
+  linalg::LinalgOp base = fusionGroup.contractionOps.front();
+  Location loc = base.getLoc();
+  auto rhsType = cast<RankedTensorType>(base->getOperand(1).getType());
+  auto outType = cast<RankedTensorType>(base->getResult(0).getType());
+  std::optional<linalg::GenericOp> baseTruncOp;
+  if (fusionGroup.truncateOps) {
+    baseTruncOp = fusionGroup.truncateOps->front();
+  }
+
+  SmallVector<ReassociationIndices> reassoc;
+  reassoc.push_back({0, 1});
+  for (int i = 0, e = rhsType.getRank() - 1; i < e; ++i) {
+    reassoc.push_back({i + 2});
+  }
+
+  SmallVector<int64_t> rhsNewShape(rhsType.getShape());
+  rhsNewShape.insert(rhsNewShape.begin(), 1);
+  auto concatRhsType =
+      RankedTensorType::get(rhsNewShape, rhsType.getElementType());
+
+  SmallVector<Value> rhsVals;
+  for (auto op : fusionGroup.contractionOps) {
+    Value thisRhs = op.getDpsInputOperand(1)->get();
+    Value expanded = rewriter.create<tensor::ExpandShapeOp>(loc, concatRhsType,
+                                                            thisRhs, reassoc);
+    rhsVals.push_back(expanded);
+  }
+
+  Value newRhs = rewriter.create<tensor::ConcatOp>(loc, /*dim=*/0, rhsVals);
+
+  SmallVector<int64_t> newShape(outType.getShape());
+  newShape.insert(newShape.begin(), rhsVals.size());
+  auto concatOutType =
+      RankedTensorType::get(newShape, outType.getElementType());
+
+  Value baseOut = base.getDpsInitOperand(0)->get();
+  auto origFill = baseOut.getDefiningOp<linalg::FillOp>();
+  if (!origFill) {
+    // TODO: This should be avoidable if we just concatenate the fill operands
+    // and add a folder for `fill -> concat`.
+    return base.emitOpError("expected outs operand to be a fill op");
+  }
+  auto origEmpty =
+      origFill.getDpsInitOperand(0)->get().getDefiningOp<tensor::EmptyOp>();
+  if (!origEmpty) {
+    return base.emitOpError("expected fill outs operand to be a tensor.empty");
+  }
+
+  auto newEmpty = rewriter.create<tensor::EmptyOp>(loc, concatOutType,
+                                                   origEmpty.getDynamicSizes());
+  auto newFill = rewriter.create<linalg::FillOp>(
+      loc, concatOutType, origFill.getDpsInputOperand(0)->get(),
+      newEmpty.getResult());
+
+  Value lhs = base->getOperand(0);
+
+  SmallVector<AffineMap> indexingMaps = base.getIndexingMapsArray();
+  SmallVector<utils::IteratorType> iteratorTypes = base.getIteratorTypesArray();
+  iteratorTypes.insert(iteratorTypes.begin(), utils::IteratorType::parallel);
+
+  indexingMaps[0] = indexingMaps[0].shiftDims(1);
+  indexingMaps[1] = indexingMaps[1].shiftDims(1).insertResult(
+      rewriter.getAffineDimExpr(0), 0);
+  indexingMaps[2] = indexingMaps[2].shiftDims(1).insertResult(
+      rewriter.getAffineDimExpr(0), 0);
+
+  linalg::GenericOp newGenericOp = rewriter.create<linalg::GenericOp>(
+      loc, concatOutType, ValueRange{lhs, newRhs}, newFill.getResult(0),
+      indexingMaps, iteratorTypes);
+  rewriter.cloneRegionBefore(base->getRegion(0), newGenericOp.getRegion(),
+                             newGenericOp.getRegion().begin());
+
+  Value fusedResult = newGenericOp.getResult(0);
+  if (fusionGroup.truncateOps) {
+    // Insert truncate operator.
+    auto truncType =
+        cast<RankedTensorType>(baseTruncOp.value()->getResult(0).getType());
+    auto concatTruncType =
+        RankedTensorType::get(newShape, truncType.getElementType());
+    size_t concatTruncRank = concatTruncType.getRank();
+    Value truncOuts = rewriter.create<tensor::EmptyOp>(
+        loc, concatTruncType, origEmpty.getDynamicSizes());
+    SmallVector<AffineMap> truncIndexingMaps(
+        2, rewriter.getMultiDimIdentityMap(concatTruncRank));
+    SmallVector<utils::IteratorType> truncIteratorTypes(
+        concatTruncRank, utils::IteratorType::parallel);
+    auto truncateOpBody = [&](OpBuilder &b, Location loc, ValueRange args) {
+      Value truncOp = b.create<arith::TruncFOp>(
+          loc, concatTruncType.getElementType(), args[0]);
+      rewriter.create<linalg::YieldOp>(loc, truncOp);
+    };
+    auto truncateOp = rewriter.create<linalg::GenericOp>(
+        loc, concatTruncType, newGenericOp->getResults(), truncOuts,
+        truncIndexingMaps, truncIteratorTypes, truncateOpBody);
+
+    fusedResult = truncateOp.getResult(0);
+  }
+
+  SmallVector<Value> newOuts;
+
+  auto fusedResultType = cast<RankedTensorType>(fusedResult.getType());
+  SmallVector<int64_t> shape = llvm::to_vector(fusedResultType.getShape());
+
+  SmallVector<OpFoldResult> sizes = newEmpty.getMixedSizes();
+  sizes[0] = rewriter.getIndexAttr(1);
+
+  SmallVector<OpFoldResult> offsets(fusedResultType.getRank(),
+                                    rewriter.getIndexAttr(0));
+  SmallVector<OpFoldResult> strides(fusedResultType.getRank(),
+                                    rewriter.getIndexAttr(1));
+  auto resultOutType = RankedTensorType::get(outType.getShape(),
+                                             fusedResultType.getElementType());
+  for (auto i : llvm::seq<int>(0, rhsVals.size())) {
+    offsets[0] = rewriter.getIndexAttr(i);
+    newOuts.push_back(rewriter.create<tensor::ExtractSliceOp>(
+        loc, resultOutType, fusedResult, offsets, sizes, strides));
+  }
+
+  for (auto [index, op, replacement] :
+       llvm::enumerate(fusionGroup.contractionOps, newOuts)) {
+    Operation *replacedOp = op;
+    if (fusionGroup.truncateOps) {
+      replacedOp = fusionGroup.truncateOps.value()[index];
+    }
+    rewriter.replaceOp(replacedOp, replacement);
+  }
+  return success();
+}
+
+void FuseHorizontalContractionsPass::runOnOperation() {
+  MLIRContext *context = &getContext();
+  DominanceInfo dominanceInfo(getOperation());
+
+  SmallVector<HorizontalFusionGroup> horizontalFusionGroups;
+  llvm::SmallDenseSet<linalg::LinalgOp> groupedOperations;
+
+  getOperation()->walk([&](linalg::LinalgOp linalgOp) {
+    if (!linalg::isaContractionOpInterface(linalgOp)) {
+      return;
+    }
+    // Avoid already grouped operations;
+    if (groupedOperations.contains(linalgOp)) {
+      return;
+    }
+
+    std::optional<HorizontalFusionGroup> fusionGroup =
+        getHorizontalFusionGroupMembers(linalgOp, groupedOperations,
+                                        dominanceInfo);
+
+    if (!fusionGroup) {
+      return;
+    }
+    groupedOperations.insert(fusionGroup->contractionOps.begin(),
+                             fusionGroup->contractionOps.end());
+    horizontalFusionGroups.emplace_back(std::move(fusionGroup.value()));
+  });
+
+  if (horizontalFusionGroups.empty()) {
+    return;
+  }
+
+  IRRewriter rewriter(context);
+  for (auto &fusionGroup : horizontalFusionGroups) {
+    if (failed(fuseGroup(rewriter, fusionGroup))) {
+      return signalPassFailure();
+    }
+  }
+
+  // Note: Currently these patterns are required due to early lowering of
+  // tensor.concat. When we choose  to move the lowering of tensor.concat later,
+  // these patterns should be dropped.
+  RewritePatternSet patterns(context);
+  tensor::populateDecomposeTensorConcatPatterns(patterns);
+  if (failed(
+          applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
+    return signalPassFailure();
+  }
+}
+
+std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
+createFuseHorizontalContractionsPass() {
+  return std::make_unique<FuseHorizontalContractionsPass>();
+}
+
+} // namespace mlir::iree_compiler::GlobalOptimization

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.h
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.h
@@ -70,6 +70,10 @@ std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createFuseDequantizationMatmulPass(
     bool enableQuantizedMatmulReassociation = false);
 
+/// Horizontally fuses multiple contraction ops.
+std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
+createFuseHorizontalContractionsPass();
+
 /// Fuses two matmul ops and a linalg.generic Silu op
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createFuseSiluHorizontalMatmulPass();

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.td
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.td
@@ -65,6 +65,12 @@ def FuseDequantizationMatmul:
   ];
 }
 
+def FuseHorizontalContractions:
+    InterfacePass<"iree-global-opt-fuse-horizontal-contractions", "mlir::FunctionOpInterface"> {
+  let summary = "Fuses horizontal contraction ops without fusions";
+  let constructor = "mlir::iree_compiler::GlobalOptimization::createFuseHorizontalContractionsPass()";
+}
+
 def FuseSiluHorizontalMatmul:
     InterfacePass<"iree-global-opt-fuse-silu-horizontal-matmul", "mlir::FunctionOpInterface"> {
   let summary = "Fuses matmul ops and silu linalg.generic op";

--- a/compiler/src/iree/compiler/GlobalOptimization/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/BUILD.bazel
@@ -24,6 +24,7 @@ iree_lit_test_suite(
             "expand_tensor_shapes.mlir",
             "flow_hoist_into_globals.mlir",
             "fuse_dequantization_matmul.mlir",
+            "fuse_horizontal_contractions.mlir",
             "fuse_silu_horizontal_matmul.mlir",
             "generalize_named_ops.mlir",
             "global_loop_invariant_code_motion.mlir",

--- a/compiler/src/iree/compiler/GlobalOptimization/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/CMakeLists.txt
@@ -22,6 +22,7 @@ iree_lit_test_suite(
     "expand_tensor_shapes.mlir"
     "flow_hoist_into_globals.mlir"
     "fuse_dequantization_matmul.mlir"
+    "fuse_horizontal_contractions.mlir"
     "fuse_silu_horizontal_matmul.mlir"
     "generalize_named_ops.mlir"
     "global_loop_invariant_code_motion.mlir"

--- a/compiler/src/iree/compiler/GlobalOptimization/test/fuse_horizontal_contractions.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/fuse_horizontal_contractions.mlir
@@ -1,0 +1,119 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-global-opt-fuse-horizontal-contractions))" --split-input-file %s | FileCheck %s
+
+#map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4)>
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d1, d3, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+util.func public @test_horizontal_fuse(%arg0 : tensor<2x4096x640xf16>, %arg1: tensor<10x64x640xf16>, %arg2: tensor<10x64x640xf16>, %arg3: tensor<10x64x640xf16>) -> (tensor<2x10x4096x64xf16>, tensor<2x10x4096x64xf16>, tensor<2x10x4096x64xf16>) {
+  %cst = arith.constant 0.000000e+00 : f32
+  %2 = tensor.empty() : tensor<2x10x4096x64xf32>
+  %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<2x10x4096x64xf32>) -> tensor<2x10x4096x64xf32>
+  %4 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<2x4096x640xf16>, tensor<10x64x640xf16>) outs(%3 : tensor<2x10x4096x64xf32>) {
+  ^bb0(%in: f16, %in_5: f16, %out: f32):
+    %11 = arith.extf %in : f16 to f32
+    %12 = arith.extf %in_5 : f16 to f32
+    %13 = arith.mulf %11, %12 : f32
+    %14 = arith.addf %out, %13 : f32
+    linalg.yield %14 : f32
+  } -> tensor<2x10x4096x64xf32>
+  %5 = tensor.empty() : tensor<2x10x4096x64xf16>
+  %6 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%4 : tensor<2x10x4096x64xf32>) outs(%5 : tensor<2x10x4096x64xf16>) {
+  ^bb0(%in: f32, %out: f16):
+    %11 = arith.truncf %in : f32 to f16
+    linalg.yield %11 : f16
+  } -> tensor<2x10x4096x64xf16>
+  %7 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]} ins(%arg0, %arg2 : tensor<2x4096x640xf16>, tensor<10x64x640xf16>) outs(%3 : tensor<2x10x4096x64xf32>) {
+  ^bb0(%in: f16, %in_5: f16, %out: f32):
+    %11 = arith.extf %in : f16 to f32
+    %12 = arith.extf %in_5 : f16 to f32
+    %13 = arith.mulf %11, %12 : f32
+    %14 = arith.addf %out, %13 : f32
+    linalg.yield %14 : f32
+  } -> tensor<2x10x4096x64xf32>
+  %8 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%7 : tensor<2x10x4096x64xf32>) outs(%5 : tensor<2x10x4096x64xf16>) {
+  ^bb0(%in: f32, %out: f16):
+    %11 = arith.truncf %in : f32 to f16
+    linalg.yield %11 : f16
+  } -> tensor<2x10x4096x64xf16>
+  %9 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]} ins(%arg0, %arg3 : tensor<2x4096x640xf16>, tensor<10x64x640xf16>) outs(%3 : tensor<2x10x4096x64xf32>) {
+  ^bb0(%in: f16, %in_5: f16, %out: f32):
+    %11 = arith.extf %in : f16 to f32
+    %12 = arith.extf %in_5 : f16 to f32
+    %13 = arith.mulf %11, %12 : f32
+    %14 = arith.addf %out, %13 : f32
+    linalg.yield %14 : f32
+  } -> tensor<2x10x4096x64xf32>
+  %10 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%9 : tensor<2x10x4096x64xf32>) outs(%5 : tensor<2x10x4096x64xf16>) {
+  ^bb0(%in: f32, %out: f16):
+    %11 = arith.truncf %in : f32 to f16
+    linalg.yield %11 : f16
+  } -> tensor<2x10x4096x64xf16>
+  util.return %6, %8, %10 : tensor<2x10x4096x64xf16>, tensor<2x10x4096x64xf16>, tensor<2x10x4096x64xf16>
+}
+
+//  CHECK-DAG: #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d3, d5)>
+//  CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d4, d5)>
+//  CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d4)>
+//  CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>
+//      CHECK: util.func public @test_horizontal_fuse
+// CHECK-SAME:     %[[ARG0:.+]]: tensor<2x4096x640xf16>
+// CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<10x64x640xf16>
+// CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<10x64x640xf16>
+// CHECK-SAME:     %[[ARG3:[a-zA-Z0-9]+]]: tensor<10x64x640xf16>
+//  CHECK-DAG:    %[[CST:.+]] = arith.constant 0.0
+//  CHECK-DAG:    %[[EXP:.+]] = tensor.expand_shape %[[ARG1]] {{\[}}[0, 1], [2], [3]] : tensor<10x64x640xf16> into tensor<1x10x64x640xf16>
+//  CHECK-DAG:    %[[EXP1:.+]] = tensor.expand_shape %[[ARG2]] {{\[}}[0, 1], [2], [3]] : tensor<10x64x640xf16> into tensor<1x10x64x640xf16>
+//  CHECK-DAG:    %[[EXP2:.+]] = tensor.expand_shape %[[ARG3]] {{\[}}[0, 1], [2], [3]] : tensor<10x64x640xf16> into tensor<1x10x64x640xf16>
+//      CHECK:    %[[INP:.+]] = tensor.empty() : tensor<3x10x64x640xf16>
+//      CHECK:    %[[SLC:.+]] = tensor.insert_slice %[[EXP]] into %[[INP]][0, 0, 0, 0] [1, 10, 64, 640] [1, 1, 1, 1] : tensor<1x10x64x640xf16> into tensor<3x10x64x640xf16>
+//      CHECK:    %[[SLC1:.+]] = tensor.insert_slice %[[EXP1]] into %[[SLC]][1, 0, 0, 0] [1, 10, 64, 640] [1, 1, 1, 1] : tensor<1x10x64x640xf16> into tensor<3x10x64x640xf16>
+//      CHECK:    %[[SLC2:.+]] = tensor.insert_slice %[[EXP2]] into %[[SLC1]][2, 0, 0, 0] [1, 10, 64, 640] [1, 1, 1, 1] : tensor<1x10x64x640xf16> into tensor<3x10x64x640xf16>
+//      CHECK:    %[[OUT:.+]] = tensor.empty() : tensor<3x2x10x4096x64xf32>
+//      CHECK:    %[[FILL:.+]] = linalg.fill
+// CHECK-SAME:        ins(%[[CST]]
+// CHECK-SAME:        outs(%[[OUT]]
+//      CHECK:    %[[GEN1:.+]] = linalg.generic {indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "reduction"]} ins(%[[ARG0]], %[[SLC2]] : tensor<2x4096x640xf16>, tensor<3x10x64x640xf16>) outs(%[[FILL]] : tensor<3x2x10x4096x64xf32>)
+//      CHECK:    %[[EMPTY:.+]] = tensor.empty() : tensor<3x2x10x4096x64xf16>
+//      CHECK:    %[[GEN2:.+]] = linalg.generic {indexing_maps = [#[[MAP3]], #[[MAP3]]], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]} ins(%[[GEN1]] : tensor<3x2x10x4096x64xf32>) outs(%[[EMPTY]] : tensor<3x2x10x4096x64xf16>) {
+//      CHECK:    %[[R1:.+]] = tensor.extract_slice %[[GEN2]][0, 0, 0, 0, 0] [1, 2, 10, 4096, 64] [1, 1, 1, 1, 1] : tensor<3x2x10x4096x64xf16> to tensor<2x10x4096x64xf16>
+//      CHECK:    %[[R2:.+]] = tensor.extract_slice %[[GEN2]][1, 0, 0, 0, 0] [1, 2, 10, 4096, 64] [1, 1, 1, 1, 1] : tensor<3x2x10x4096x64xf16> to tensor<2x10x4096x64xf16>
+//      CHECK:    %[[R3:.+]] = tensor.extract_slice %[[GEN2]][2, 0, 0, 0, 0] [1, 2, 10, 4096, 64] [1, 1, 1, 1, 1] : tensor<3x2x10x4096x64xf16> to tensor<2x10x4096x64xf16>
+//      CHECK:    util.return %[[R1]], %[[R2]], %[[R3]]
+
+// -----
+
+util.func public @test_horizontal_fuse(%arg0 : tensor<4096x640xf32>, %arg1: tensor<640x640xf32>, %arg2: tensor<640x640xf32>, %arg3: tensor<640x640xf32>) -> (tensor<4096x640xf32>, tensor<4096x640xf32>, tensor<4096x640xf32>) {
+  %cst = arith.constant 0.000000e+00 : f32
+  %2 = tensor.empty() : tensor<4096x640xf32>
+  %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<4096x640xf32>) -> tensor<4096x640xf32>
+  %4 = linalg.matmul ins(%arg0, %arg1 : tensor<4096x640xf32>, tensor<640x640xf32>) outs(%3 : tensor<4096x640xf32>) -> tensor<4096x640xf32>
+  %7 = linalg.matmul ins(%arg0, %arg2 : tensor<4096x640xf32>, tensor<640x640xf32>) outs(%3 : tensor<4096x640xf32>) -> tensor<4096x640xf32>
+  %9 = linalg.matmul ins(%arg0, %arg3 : tensor<4096x640xf32>, tensor<640x640xf32>) outs(%3 : tensor<4096x640xf32>) -> tensor<4096x640xf32>
+  util.return %4, %7, %9 : tensor<4096x640xf32>, tensor<4096x640xf32>, tensor<4096x640xf32>
+}
+
+// CHECK-DAG: #[[MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
+// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
+// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+//     CHECK: util.func public @test_horizontal_fuse
+// CHECK-SAME:     %[[ARG0:.+]]: tensor<4096x640xf32>
+// CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<640x640xf32>
+// CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<640x640xf32>
+// CHECK-SAME:     %[[ARG3:[a-zA-Z0-9]+]]: tensor<640x640xf32>
+// CHECK-DAG:    %[[CST:.+]] = arith.constant 0.0
+// CHECK-DAG:    %[[EXP:.+]] = tensor.expand_shape %[[ARG1]] {{\[}}[0, 1], [2]] : tensor<640x640xf32> into tensor<1x640x640xf32>
+// CHECK-DAG:    %[[EXP1:.+]] = tensor.expand_shape %[[ARG2]] {{\[}}[0, 1], [2]] : tensor<640x640xf32> into tensor<1x640x640xf32>
+// CHECK-DAG:    %[[EXP2:.+]] = tensor.expand_shape %[[ARG3]] {{\[}}[0, 1], [2]] : tensor<640x640xf32> into tensor<1x640x640xf32>
+//     CHECK:    %[[INP:.+]] = tensor.empty() : tensor<3x640x640xf32>
+//     CHECK:    %[[SLC:.+]] = tensor.insert_slice %[[EXP]] into %[[INP]][0, 0, 0] [1, 640, 640] [1, 1, 1] : tensor<1x640x640xf32> into tensor<3x640x640xf32>
+//     CHECK:    %[[SLC1:.+]] = tensor.insert_slice %[[EXP1]] into %[[SLC]][1, 0, 0] [1, 640, 640] [1, 1, 1] : tensor<1x640x640xf32> into tensor<3x640x640xf32>
+//     CHECK:    %[[SLC2:.+]] = tensor.insert_slice %[[EXP2]] into %[[SLC1]][2, 0, 0] [1, 640, 640] [1, 1, 1] : tensor<1x640x640xf32> into tensor<3x640x640xf32>
+//     CHECK:    %[[OUT:.+]] = tensor.empty() : tensor<3x4096x640xf32>
+//     CHECK:    %[[FILL:.+]] = linalg.fill
+// CHECK-SAME:       ins(%[[CST]] :
+// CHECK-SAME:       outs(%[[OUT]] :
+//     CHECK:    %[[GEN1:.+]] = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "reduction"]} ins(%[[ARG0]], %[[SLC2]] : tensor<4096x640xf32>, tensor<3x640x640xf32>) outs(%[[FILL]] : tensor<3x4096x640xf32>)
+//     CHECK:    %[[R1:.+]] = tensor.extract_slice %[[GEN1]][0, 0, 0] [1, 4096, 640] [1, 1, 1] : tensor<3x4096x640xf32> to tensor<4096x640xf32>
+//     CHECK:    %[[R2:.+]] = tensor.extract_slice %[[GEN1]][1, 0, 0] [1, 4096, 640] [1, 1, 1] : tensor<3x4096x640xf32> to tensor<4096x640xf32>
+//     CHECK:    %[[R3:.+]] = tensor.extract_slice %[[GEN1]][2, 0, 0] [1, 4096, 640] [1, 1, 1] : tensor<3x4096x640xf32> to tensor<4096x640xf32>
+//     CHECK:    util.return %[[R1]], %[[R2]], %[[R3]]


### PR DESCRIPTION
This pass does a one-off horizontal fusion of contraction operations
with one common operand. It handles the case where the contraction
might be followed by a truncate operation (when the contraction is
done at higher precision, but final result is in lower precision
typical of quantized models).

The pass is off by default and can be enabled by
`--iree-global-opt-fuse-horizontal-contractions`.

Note this pass might be better off being in Preprocessing.

Co-authored-by: Quinn Dawkins <quinn.dawkins@gmail.com>
Co-authored-by: MaheshRavishankar <mahesh@nod-labs.com>