### PR TITLE
[Flow] Implement ValueBoundsOpInterface for flow.dispatch.tensor.load op

### DIFF
--- a/compiler/src/iree/compiler/ExternalInterfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/ExternalInterfaces/BUILD.bazel
@@ -15,14 +15,17 @@ package(
 iree_compiler_cc_library(
     name = "ExternalModels",
     srcs = [
+        "FlowExternalModels.cpp",
         "Interfaces.cpp",
         "UtilExternalModels.cpp",
     ],
     hdrs = [
+        "FlowExternalModels.h",
         "Interfaces.h",
         "UtilExternalModels.h",
     ],
     deps = [
+        "//compiler/src/iree/compiler/Dialect/Flow/IR",
         "//compiler/src/iree/compiler/Dialect/LinalgExt/IR",
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "@llvm-project//mlir:ArithDialect",

--- a/compiler/src/iree/compiler/ExternalInterfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/ExternalInterfaces/BUILD.bazel
@@ -35,6 +35,6 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:LinalgStructuredOpsIncGen",
         "@llvm-project//mlir:MLProgramDialect",
         "@llvm-project//mlir:TensorDialect",
-        "@llvm-project//mlir:ValueBoundsOpInterface"
+        "@llvm-project//mlir:ValueBoundsOpInterface",
     ],
 )

--- a/compiler/src/iree/compiler/ExternalInterfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/ExternalInterfaces/BUILD.bazel
@@ -35,5 +35,6 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:LinalgStructuredOpsIncGen",
         "@llvm-project//mlir:MLProgramDialect",
         "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:ValueBoundsOpInterface"
     ],
 )

--- a/compiler/src/iree/compiler/ExternalInterfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/ExternalInterfaces/CMakeLists.txt
@@ -29,6 +29,7 @@ iree_cc_library(
     MLIRLinalgStructuredOpsIncGenLib
     MLIRMLProgramDialect
     MLIRTensorDialect
+    MLIRValueBoundsOpInterface
     iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::LinalgExt::IR
     iree::compiler::Dialect::Util::IR

--- a/compiler/src/iree/compiler/ExternalInterfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/ExternalInterfaces/CMakeLists.txt
@@ -14,9 +14,11 @@ iree_cc_library(
   NAME
     ExternalModels
   HDRS
+    "FlowExternalModels.h"
     "Interfaces.h"
     "UtilExternalModels.h"
   SRCS
+    "FlowExternalModels.cpp"
     "Interfaces.cpp"
     "UtilExternalModels.cpp"
   DEPS
@@ -27,6 +29,7 @@ iree_cc_library(
     MLIRLinalgStructuredOpsIncGenLib
     MLIRMLProgramDialect
     MLIRTensorDialect
+    iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::LinalgExt::IR
     iree::compiler::Dialect::Util::IR
   PUBLIC

--- a/compiler/src/iree/compiler/ExternalInterfaces/FlowExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/FlowExternalModels.cpp
@@ -1,0 +1,38 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/ExternalInterfaces/FlowExternalModels.h"
+
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "mlir/Interfaces/ValueBoundsOpInterface.h"
+
+using namespace mlir::iree_compiler::IREE;
+namespace mlir::iree_compiler {
+namespace {
+
+struct DispatchTensorLoadOpInterface
+    : public ValueBoundsOpInterface::ExternalModel<DispatchTensorLoadOpInterface,
+                                                   Flow::DispatchTensorLoadOp> {
+  void populateBoundsForShapedValueDim(Operation *op, Value value, int64_t dim,
+                                       ValueBoundsConstraintSet &cstr) const {
+    auto loadOp = cast<Flow::DispatchTensorLoadOp>(op);
+    assert(value == loadOp.getResult() && "invalid value");
+    cstr.bound(value)[dim] == loadOp.getMixedSizes()[dim];
+  }
+};
+
+} // namespace
+
+void registerFlowExternalModels(DialectRegistry &registry) {
+  registry.addExtension(+[](MLIRContext *ctx, Flow::FlowDialect *dialect) {
+    Flow::DispatchTensorLoadOp::attachInterface<DispatchTensorLoadOpInterface>(
+        *ctx);
+    // Note: ValueBoundsOpInterface implementation is not required for ops that
+    // implement `DestinationStyleOpInterface` (for querying shaped OpResults).
+  });
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/ExternalInterfaces/FlowExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/FlowExternalModels.cpp
@@ -14,8 +14,8 @@ namespace mlir::iree_compiler {
 namespace {
 
 struct DispatchTensorLoadOpInterface
-    : public ValueBoundsOpInterface::ExternalModel<DispatchTensorLoadOpInterface,
-                                                   Flow::DispatchTensorLoadOp> {
+    : public ValueBoundsOpInterface::ExternalModel<
+          DispatchTensorLoadOpInterface, Flow::DispatchTensorLoadOp> {
   void populateBoundsForShapedValueDim(Operation *op, Value value, int64_t dim,
                                        ValueBoundsConstraintSet &cstr) const {
     auto loadOp = cast<Flow::DispatchTensorLoadOp>(op);

--- a/compiler/src/iree/compiler/ExternalInterfaces/FlowExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/FlowExternalModels.cpp
@@ -9,16 +9,15 @@
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "mlir/Interfaces/ValueBoundsOpInterface.h"
 
-using namespace mlir::iree_compiler::IREE;
 namespace mlir::iree_compiler {
 namespace {
 
 struct DispatchTensorLoadOpInterface
     : public ValueBoundsOpInterface::ExternalModel<
-          DispatchTensorLoadOpInterface, Flow::DispatchTensorLoadOp> {
+          DispatchTensorLoadOpInterface, IREE::Flow::DispatchTensorLoadOp> {
   void populateBoundsForShapedValueDim(Operation *op, Value value, int64_t dim,
                                        ValueBoundsConstraintSet &cstr) const {
-    auto loadOp = cast<Flow::DispatchTensorLoadOp>(op);
+    auto loadOp = cast<IREE::Flow::DispatchTensorLoadOp>(op);
     assert(value == loadOp.getResult() && "invalid value");
     cstr.bound(value)[dim] == loadOp.getMixedSizes()[dim];
   }
@@ -27,12 +26,11 @@ struct DispatchTensorLoadOpInterface
 } // namespace
 
 void registerFlowExternalModels(DialectRegistry &registry) {
-  registry.addExtension(+[](MLIRContext *ctx, Flow::FlowDialect *dialect) {
-    Flow::DispatchTensorLoadOp::attachInterface<DispatchTensorLoadOpInterface>(
-        *ctx);
-    // Note: ValueBoundsOpInterface implementation is not required for ops that
-    // implement `DestinationStyleOpInterface` (for querying shaped OpResults).
-  });
+  registry.addExtension(
+      +[](MLIRContext *ctx, IREE::Flow::FlowDialect *dialect) {
+        IREE::Flow::DispatchTensorLoadOp::attachInterface<
+            DispatchTensorLoadOpInterface>(*ctx);
+      });
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/ExternalInterfaces/FlowExternalModels.h
+++ b/compiler/src/iree/compiler/ExternalInterfaces/FlowExternalModels.h
@@ -1,0 +1,20 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_EXTERNALINTERFACES_FLOWEXTERNALMODELS_H_
+#define IREE_COMPILER_EXTERNALINTERFACES_FLOWEXTERNALMODELS_H_
+
+namespace mlir {
+class DialectRegistry;
+} // namespace mlir
+
+namespace mlir::iree_compiler {
+
+void registerFlowExternalModels(DialectRegistry &registry);
+
+} // namespace mlir::iree_compiler
+
+#endif // IREE_COMPILER_EXTERNALINTERFACES_FLOWEXTERNALMODELS_H_

--- a/compiler/src/iree/compiler/ExternalInterfaces/Interfaces.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/Interfaces.cpp
@@ -5,11 +5,14 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/ExternalInterfaces/Interfaces.h"
+
+#include "iree/compiler/ExternalInterfaces/FlowExternalModels.h"
 #include "iree/compiler/ExternalInterfaces/UtilExternalModels.h"
 
 namespace mlir::iree_compiler {
 
 void registerExternalInterfaces(DialectRegistry &registry) {
+  registerFlowExternalModels(registry);
   registerUtilExternalModels(registry);
 }
 


### PR DESCRIPTION
The MLIR upstream defines a TestReifyValueBounds pass for testing. We do not have such pass in IREE, so we leverage the test to LLVMGPUTensorPad. It removes the workaround, and switch to use upstream method properly.

This is needed for all the codegen strategies with padding involved. It is a step towards landing sdxl patches.