### PR TITLE
[NFC] Switching to not use using-directives in UtilExternalModels.cpp

### DIFF
--- a/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
@@ -14,8 +14,6 @@
 #include "mlir/Dialect/MLProgram/IR/MLProgram.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 
-using namespace mlir::iree_compiler::IREE;
-
 namespace mlir::iree_compiler {
 
 namespace {
@@ -25,7 +23,7 @@ namespace {
 //===----------------------------------------------------------------------===//
 
 struct GlobalOpInterfaceExternalModel
-    : public Util::GlobalOpInterface::ExternalModel<
+    : public IREE::Util::GlobalOpInterface::ExternalModel<
           GlobalOpInterfaceExternalModel, ml_program::GlobalOp> {
   Attribute getGlobalInitialValue(Operation *op) const {
     return cast<ml_program::GlobalOp>(op).getValueAttr();
@@ -94,8 +92,8 @@ struct GlobalOpInterfaceExternalModel
 struct GenericNumericCastExternalModel {
   template <typename OpTy>
   struct ExternalModel
-      : public Util::NumericCastOpInterface::ExternalModel<ExternalModel<OpTy>,
-                                                           OpTy> {};
+      : public IREE::Util::NumericCastOpInterface::ExternalModel<
+            ExternalModel<OpTy>, OpTy> {};
 
   template <typename OpTy>
   static void add(MLIRContext *context) {
@@ -114,8 +112,8 @@ struct GenericNumericCastExternalModel {
 //===----------------------------------------------------------------------===//
 
 struct InsertSliceOpTiedOpInterface
-    : public Util::TiedOpInterface::ExternalModel<InsertSliceOpTiedOpInterface,
-                                                  tensor::InsertSliceOp> {
+    : public IREE::Util::TiedOpInterface::ExternalModel<
+          InsertSliceOpTiedOpInterface, tensor::InsertSliceOp> {
   Value getTiedResult(Operation *op, unsigned resultIndex) const {
     auto insertSliceOp = cast<tensor::InsertSliceOp>(op);
     return IREE::Util::TiedOpInterface::findTiedBaseValue(
@@ -134,8 +132,8 @@ struct InsertSliceOpTiedOpInterface
 
 template <typename OpTy>
 struct LinalgOpTiedOpInterface
-    : public Util::TiedOpInterface::ExternalModel<LinalgOpTiedOpInterface<OpTy>,
-                                                  OpTy> {
+    : public IREE::Util::TiedOpInterface::ExternalModel<
+          LinalgOpTiedOpInterface<OpTy>, OpTy> {
   Value getTiedResult(Operation *op, unsigned resultIndex) const {
     auto linalgOp = cast<OpTy>(op);
     return IREE::Util::TiedOpInterface::findTiedBaseValue(

--- a/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
@@ -302,26 +302,27 @@ void registerUtilExternalModels(DialectRegistry &registry) {
   // TODO(matthias-springer): Use a helper instead of listing all ops. This is
   // tricky because LinalgExtOps.td includes YieldOp.
   registry.addExtension(+[](MLIRContext *context,
-                            LinalgExt::IREELinalgExtDialect *dialect) {
-    LinalgExt::ScatterOp::attachInterface<
-        LinalgOpTiedOpInterface<LinalgExt::ScatterOp>>(*context);
-    LinalgExt::SortOp::attachInterface<
-        LinalgOpTiedOpInterface<LinalgExt::SortOp>>(*context);
-    LinalgExt::FftOp::attachInterface<
-        LinalgOpTiedOpInterface<LinalgExt::FftOp>>(*context);
-    LinalgExt::ScanOp::attachInterface<
-        LinalgOpTiedOpInterface<LinalgExt::ScanOp>>(*context);
-    LinalgExt::ReverseOp::attachInterface<
-        LinalgOpTiedOpInterface<LinalgExt::ReverseOp>>(*context);
-    LinalgExt::TopkOp::attachInterface<
-        LinalgOpTiedOpInterface<LinalgExt::TopkOp>>(*context);
-    LinalgExt::WinogradInputTransformOp::attachInterface<
-        LinalgOpTiedOpInterface<LinalgExt::WinogradInputTransformOp>>(*context);
-    LinalgExt::WinogradOutputTransformOp::attachInterface<
-        LinalgOpTiedOpInterface<LinalgExt::WinogradOutputTransformOp>>(
+                            IREE::LinalgExt::IREELinalgExtDialect *dialect) {
+    IREE::LinalgExt::ScatterOp::attachInterface<
+        LinalgOpTiedOpInterface<IREE::LinalgExt::ScatterOp>>(*context);
+    IREE::LinalgExt::SortOp::attachInterface<
+        LinalgOpTiedOpInterface<IREE::LinalgExt::SortOp>>(*context);
+    IREE::LinalgExt::FftOp::attachInterface<
+        LinalgOpTiedOpInterface<IREE::LinalgExt::FftOp>>(*context);
+    IREE::LinalgExt::ScanOp::attachInterface<
+        LinalgOpTiedOpInterface<IREE::LinalgExt::ScanOp>>(*context);
+    IREE::LinalgExt::ReverseOp::attachInterface<
+        LinalgOpTiedOpInterface<IREE::LinalgExt::ReverseOp>>(*context);
+    IREE::LinalgExt::TopkOp::attachInterface<
+        LinalgOpTiedOpInterface<IREE::LinalgExt::TopkOp>>(*context);
+    IREE::LinalgExt::WinogradInputTransformOp::attachInterface<
+        LinalgOpTiedOpInterface<IREE::LinalgExt::WinogradInputTransformOp>>(
         *context);
-    LinalgExt::AttentionOp::attachInterface<
-        LinalgOpTiedOpInterface<LinalgExt::AttentionOp>>(*context);
+    IREE::LinalgExt::WinogradOutputTransformOp::attachInterface<
+        LinalgOpTiedOpInterface<IREE::LinalgExt::WinogradOutputTransformOp>>(
+        *context);
+    IREE::LinalgExt::AttentionOp::attachInterface<
+        LinalgOpTiedOpInterface<IREE::LinalgExt::AttentionOp>>(*context);
   });
 
   // Hoistable Op Interface registration.


### PR DESCRIPTION
There are many reasons to avoid using-directives, see https://google.github.io/styleguide/cppguide.html#Namespaces for more details.