### PR TITLE
[ConstEval] Add flag to adjust tensor size limit for hoisting

### DIFF
--- a/compiler/src/iree/compiler/Pipelines/Options.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Options.cpp
@@ -124,6 +124,12 @@ void GlobalOptimizationOptions::bindOptions(OptionsBinder &binder) {
           "Hoists the results of latent constant expressions into immutable "
           "global initializers for evaluation at program load."),
       llvm::cl::cat(category));
+  binder.opt<int64_t>(
+      "iree-opt-const-expr-max-size-increase-threshold",
+      constExprMaxSizeIncreaseThreshold,
+      llvm::cl::desc("Maximum byte size increase allowed for constant expr "
+                     "hoisting policy to allow hoisting."),
+      llvm::cl::cat(category));
   binder.opt<bool>(
       "iree-opt-numeric-precision-reduction", numericPrecisionReduction,
       llvm::cl::desc(


### PR DESCRIPTION
Add a flag for the `maxSizeIncreaseThreshold` option in `HoistIntoGlobals`.