### PR TITLE
Fix crash in transform dialect script when using attention script with ToT IREE

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -1489,7 +1489,7 @@ transform_dialect::AMDGPUDistributeVectorsOp::applyToOne(
 
 void transform_dialect::AMDGPUDistributeVectorsOp::getEffects(
     SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
-  transform::onlyReadsHandle(getTarget(), effects);
+  transform::consumesHandle(getTarget(), effects);
   transform::modifiesPayload(effects);
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/attention_mfma_transform_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/attention_mfma_transform_spec.mlir
@@ -172,10 +172,11 @@ module attributes { transform.with_named_sequence } {
     %distribute_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
     transform.iree.amdgpu_distribute_vectors %distribute_func test_conversion : !transform.any_op
 
-    transform.apply_patterns to %distribute_func {
+    %distribute_func_2 = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %distribute_func_2 {
       transform.apply_patterns.canonicalization
     } : !transform.any_op
-    transform.apply_cse to %distribute_func : !transform.any_op
+    transform.apply_cse to %distribute_func_2 : !transform.any_op
 
     // Distribute shared memory copies
     // ==========================================


### PR DESCRIPTION
Fixes the crash when adopting the attention script here https://github.com/nod-ai/2024-q1-sdxl-sprint/blob/main/specs/attention_and_matmul_spec.mlir with ToT (PR https://github.com/nod-ai/2024-q1-sdxl-sprint/pull/30)