### PR TITLE
Making FlattenFullFillToSplat more conservative.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/async_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/async_folding.mlir
@@ -179,12 +179,30 @@ util.func private @PropagateSplatsThroughSlices(%arg0: index) -> !stream.resourc
 
 // -----
 
+// Allow pattern because we can verify the target is safe to elide.
+
 // CHECK-LABEL: @FlattenFullFillToSplat
-util.func private @FlattenFullFillToSplat(%arg0: !stream.resource<*>, %arg1: index, %arg2: i32) -> !stream.resource<*> {
+util.func private @FlattenFullFillToSplat(%arg0: index, %arg1: i32) -> !stream.resource<*> {
   %c0 = arith.constant 0 : index
-  // CHECK: %[[T:.+]] = stream.async.splat %arg2 : i32 -> !stream.resource<*>{%arg1}
-  %0 = stream.async.fill %arg2, %arg0[%c0 to %arg1 for %arg1] : i32 -> %arg0 as !stream.resource<*>{%arg1}
+  %c123_i32 = arith.constant 123 : i32
+  %target = stream.async.splat %c123_i32 : i32 -> !stream.resource<*>{%arg0}
+  // CHECK: %[[T:.+]] = stream.async.splat %arg1 : i32 -> !stream.resource<*>{%arg0}
+  %0 = stream.async.fill %arg1, %target[%c0 to %arg0 for %arg0] : i32 -> %target as !stream.resource<*>{%arg0}
   // CHECK: util.return %[[T]]
+  util.return %0 : !stream.resource<*>
+}
+
+// -----
+
+// The target is tied and we cannot avoid the fill.
+
+// CHECK-LABEL: @FlattenFullFillToSplatUnsafe
+util.func private @FlattenFullFillToSplatUnsafe(%arg0: index, %arg1: i32, %arg2: !hal.buffer_view) -> !stream.resource<*> {
+  %c0 = arith.constant 0 : index
+  // CHECK: stream.tensor.import
+  %target = stream.tensor.import %arg2 : !hal.buffer_view -> tensor<8xi32> in !stream.resource<*>{%arg0}
+  // CHECK: stream.async.fill
+  %0 = stream.async.fill %arg1, %target[%c0 to %arg0 for %arg0] : i32 -> %target as !stream.resource<*>{%arg0}
   util.return %0 : !stream.resource<*>
 }
 


### PR DESCRIPTION
Full analysis is required to do this in all cases as we need to know that the target storage isn't required to be the same. The pattern now does a local check to see if it can be proven to be producing into a non-tied value it knows the providence of and bails otherwise.