### PR TITLE
[runtime] Add semaphore test where 2 batches wait on a former batch amongst 2

### DIFF
--- a/runtime/src/iree/hal/cts/cts_test_base.h
+++ b/runtime/src/iree/hal/cts/cts_test_base.h
@@ -125,6 +125,30 @@ class CtsTestBase : public ::testing::TestWithParam<std::string> {
     return status;
   }
 
+  iree_hal_command_buffer_t* CreateEmptyCommandBuffer() {
+    iree_hal_command_buffer_t* command_buffer = NULL;
+    IREE_EXPECT_OK(iree_hal_command_buffer_create(
+        device_, IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT,
+        IREE_HAL_COMMAND_CATEGORY_DISPATCH, IREE_HAL_QUEUE_AFFINITY_ANY,
+        /*binding_capacity=*/0, &command_buffer));
+    IREE_EXPECT_OK(iree_hal_command_buffer_begin(command_buffer));
+    IREE_EXPECT_OK(iree_hal_command_buffer_end(command_buffer));
+    return command_buffer;
+  }
+
+  iree_hal_semaphore_t* CreateSemaphore() {
+    iree_hal_semaphore_t* semaphore = NULL;
+    IREE_EXPECT_OK(iree_hal_semaphore_create(device_, 0, &semaphore));
+    return semaphore;
+  }
+
+  void CheckSemaphoreValue(iree_hal_semaphore_t* semaphore,
+                           uint64_t expected_value) {
+    uint64_t value;
+    IREE_EXPECT_OK(iree_hal_semaphore_query(semaphore, &value));
+    EXPECT_EQ(expected_value, value);
+  }
+
   iree_hal_driver_t* driver_ = NULL;
   iree_hal_device_t* device_ = NULL;
   iree_hal_allocator_t* device_allocator_ = NULL;


### PR DESCRIPTION
With this this test I added some functions to make the test body shorter.
Unfortunately, we can't put gtest asserts in functions that have a non-void return. Because of that in the functions I am using `IREE_EXPECT*` instead of `IREE_ASSERT*`. This may cause tests other than the one that is failing to fail also, as the whole executable may crash if for example a command buffer fails to be created and then we get a segmentation fault when trying to use it.
I thought this is an acceptable sacrifice to avoid repetition and to have shorter and more readable tests.