### PR TITLE
Fixes to enable out-of-tree plugin builds.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -68,9 +68,10 @@ def SPIRV_WinogradVectorize
 
 def VMVX_Default : I32EnumAttrCase<"VMVXDefault", 300>;
 
-
 def Linalg_TransformDialectCodegen
     : I32EnumAttrCase<"TransformDialectCodegen", 1000>;
+def Custom
+    : I32EnumAttrCase<"Custom", 1001>;
 
 def None : I32EnumAttrCase<"None", 0xffff>;
 
@@ -99,7 +100,13 @@ def DispatchLoweringPassPipelineEnum : I32EnumAttr<
     VMVX_Default,
 
     // Transform dialect based codegen
-    Linalg_TransformDialectCodegen, None
+    Linalg_TransformDialectCodegen,
+
+    // For out of tree pass-pipelines
+    Custom,
+
+    // None to specify no in-built pipelines to use.
+    None
   ]> {
   let cppNamespace = "::mlir::iree_compiler::IREE::Codegen";
   // Don't generate a C++ class! We want to use the AttrDef

--- a/compiler/src/iree/compiler/Codegen/Interfaces/Interfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/Interfaces.cpp
@@ -25,6 +25,7 @@
 #include "mlir/Dialect/Linalg/IR/ValueBoundsOpInterfaceImpl.h"
 #include "mlir/Dialect/Linalg/TransformOps/DialectExtension.h"
 #include "mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.h"
+#include "mlir/Dialect/Linalg/Transforms/SubsetInsertionOpInterfaceImpl.h"
 #include "mlir/Dialect/Linalg/Transforms/TilingInterfaceImpl.h"
 #include "mlir/Dialect/MemRef/IR/ValueBoundsOpInterfaceImpl.h"
 #include "mlir/Dialect/MemRef/TransformOps/MemRefTransformOps.h"
@@ -61,6 +62,7 @@ void registerCodegenInterfaces(DialectRegistry &registry) {
   gpu::registerTransformDialectExtension(registry);
   linalg::registerTransformDialectExtension(registry);
   linalg::registerValueBoundsOpInterfaceExternalModels(registry);
+  linalg::registerSubsetOpInterfaceExternalModels(registry);
   memref::registerTransformDialectExtension(registry);
   memref::registerValueBoundsOpInterfaceExternalModels(registry);
   scf::registerTransformDialectExtension(registry);


### PR DESCRIPTION
1) The new pass-pipeline setup uses `None` in load-bearing way. For
   out-of-tree plugins which have their own pipelines `Custom` can
   allow out-of-tree plugins to control which pipelines to use
   (instead of what they currently unintentionally ended up doing,
   which is use `None`)

2) Looks like in tree we dont use the SubsetOpInterface implementation
   of Linalg ops (which is interesting since it probably implies we
   today do not have Linalg ops surviving to bufferization). Adding
   this in IREE since this is an expected interface.