### PR TITLE
[VectorDistribution] Remove iteration on non-distributed levels

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
@@ -219,10 +219,6 @@ struct DistributeContract final : OpDistributionPattern<vector::ContractionOp> {
 
     lhsOffsets[lhsK] = kOffset;
     rhsOffsets[rhsK] = kOffset;
-
-    // Now apply permutation on LHS/RHS according to their batch order.
-    lhsOffsets = applyPermutationMap(lhsMap, ArrayRef(lhsOffsets));
-    rhsOffsets = applyPermutationMap(rhsMap, ArrayRef(rhsOffsets));
   }
 
   struct AMDMMAParameters {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
@@ -616,17 +616,18 @@ struct DistributeScfFor final : OpDistributionPattern<scf::ForOp> {
   }
 };
 
-struct DistributeTranspose final : OpDistributionPattern<vector::TransposeOp> {
+struct DistributeTransposeLayoutAttr final
+    : OpDistributionPattern<vector::TransposeOp> {
   using OpDistributionPattern::OpDistributionPattern;
 
   LogicalResult matchAndRewrite(vector::TransposeOp transposeOp,
                                 DistributionSignature &signature,
                                 PatternRewriter &rewriter) const override {
     VectorValue value = transposeOp.getVector();
-    VectorLayoutInterface layout =
-        dyn_cast<VectorLayoutInterface>(signature[value]);
+    VectorLayoutInterface layout = dyn_cast<LayoutAttr>(signature[value]);
     if (!layout) {
-      return failure();
+      return rewriter.notifyMatchFailure(transposeOp,
+                                         "layout must be LayoutAttr");
     }
 
     /// Transpose only changes the notion of where the data carried by each
@@ -849,7 +850,7 @@ void populateGPUDistributionLayoutAttrPatterns(Value laneId,
   patterns
       .add<DistributeTransferReadLayoutAttr, DistributeTransferWriteLayoutAttr>(
           patterns.getContext(), laneId);
-  patterns.add<DistributeBroadcastLayoutAttr, DistributeTranspose>(
+  patterns.add<DistributeBroadcastLayoutAttr, DistributeTransposeLayoutAttr>(
       patterns.getContext());
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -81,9 +81,8 @@ static SmallVector<Value> getTransferIndicesFromNestedLayout(
   int64_t rank = vectorLayout.getRank();
   // Permute the batch and outer vector offsets to match the order of
   // the vector dimensions using the inverse of the batch/offset order.
-  ArrayRef<int64_t> batchOffsets = ArrayRef<int64_t>(offsets.begin(), rank);
-  ArrayRef<int64_t> outerVectorOffsets =
-      ArrayRef<int64_t>(offsets.begin() + rank, rank);
+  ArrayRef<int64_t> batchOffsets(offsets.begin(), rank);
+  ArrayRef<int64_t> outerVectorOffsets(offsets.begin() + rank, rank);
 
   SmallVector<Value> slicedIndices(indices.begin(), indices.end());
   for (const auto &[i, dim] : llvm::enumerate(permutationMap.getResults())) {
@@ -577,7 +576,7 @@ struct DistributeTranspose final : OpDistributionPattern<vector::TransposeOp> {
     /// So, for distributed dimensions (thread and subgroup) transpose is a
     /// no-op.
     ///
-    /// Example:
+    /// Example (indices [0-3] represent ids of the threads carrying the data):
     ///
     /// input: vector<2x4xf16>
     ///

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -468,14 +468,13 @@ struct DistributeMultiReduction final
 
     // Do thread local reduce.
 
+    // The distributed reduction mask is simply the same permutation appended
+    // thrice.
     SmallVector<bool> distributedReductionMask;
     distributedReductionMask.reserve(3 * rank);
-    distributedReductionMask.append(
-        applyPermutation(reducedDims, srcLayout.getBatchOrder()));
-    distributedReductionMask.append(
-        applyPermutation(reducedDims, srcLayout.getOuterOrder()));
-    distributedReductionMask.append(
-        applyPermutation(reducedDims, srcLayout.getElementOrder()));
+    for (int i = 0; i < 3; ++i) {
+      distributedReductionMask.append(reducedDims.begin(), reducedDims.end());
+    }
 
     auto localReduction = rewriter.create<vector::MultiDimReductionOp>(
         loc, disSrc, disAcc, distributedReductionMask, multiReduceOp.getKind());

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -468,7 +468,7 @@ struct DistributeMultiReduction final
 
     // Do thread local reduce.
 
-    // The distributed reduction mask is simply the same permutation appended
+    // The distributed reduction mask is simply the same mask appended
     // thrice.
     SmallVector<bool> distributedReductionMask;
     distributedReductionMask.reserve(3 * rank);

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
@@ -919,8 +919,6 @@ builtin.module attributes { transform.with_named_sequence } {
   elements_per_thread = [1, 4],
 
   subgroup_order = [1, 0],
-  batch_order = [1, 0],
-  outer_order = [1, 0],
   thread_order = [1, 0],
 
   subgroup_basis = [1, 1],
@@ -950,7 +948,7 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK-DAG: %[[DARG0:.*]] = iree_vector_ext.to_simt %{{.*}} : vector<32x32xf32> -> vector<2x2x1x1x1x4xf32>
 // CHECK-DAG: %[[DARG1:.*]] = iree_vector_ext.to_simt %{{.*}} : vector<32xf32> -> vector<2x1x1xf32>
 // Local reduction
-// CHECK: vector.multi_reduction <maximumf>, %[[DARG0]], %[[DARG1]] [0, 2, 5] : vector<2x2x1x1x1x4xf32> to vector<2x1x1xf32>
+// CHECK: vector.multi_reduction <maximumf>, %[[DARG0]], %[[DARG1]] [1, 3, 5] : vector<2x2x1x1x1x4xf32> to vector<2x1x1xf32>
 // Global reduction
 // CHECK: gpu.shuffle  xor %{{.*}}, %[[C16]], %[[C64]] : f32
 // CHECK: gpu.shuffle  xor %{{.*}}, %[[C32]], %[[C64]] : f32

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_distribution.mlir
@@ -45,10 +45,7 @@ func.func @distribute_elementwise_i32(%a: vector<16x16xi32>, %b: vector<16x16xi3
   elements_per_thread     = [1, 8, 2],
 
   subgroup_order          = [0, 1, 2],
-  batch_order             = [0, 1, 2],
-  outer_order             = [0, 1, 2],
   thread_order            = [0, 1, 2],
-  element_order           = [0, 2, 1],
 
   subgroup_basis          = [2, 1, 1],
   thread_basis            = [8, 2, 4]
@@ -58,15 +55,15 @@ func.func @distribute_elementwise_i32(%a: vector<16x16xi32>, %b: vector<16x16xi3
 func.func @distribute_elementwise_nested_layout_f16(%a: vector<128x128x128xf16>, %b: vector<128x128x128xf16>) -> vector<128x128x128xf16> {
   %c0 = arith.constant 0 : index
   %cst_0 = arith.constant 0.0 : f16
-  // CHECK: %[[ROOT:.*]] = arith.constant dense<0.000000e+00> : vector<8x2x4x1x4x4x1x2x8xf16>
+  // CHECK: %[[ROOT:.*]] = arith.constant dense<0.000000e+00> : vector<8x2x4x1x4x4x1x8x2xf16>
   %root = arith.constant {"__vector_layout_test_anchor_result_0" = #nested} dense<0.0> : vector<128x128x128xf16>
-  // CHECK-DAG: %[[B:.*]] = iree_vector_ext.to_simt %{{.*}} : vector<128x128x128xf16> -> vector<8x2x4x1x4x4x1x2x8xf16>
-  // CHECK-DAG: %[[C:.*]] = arith.mulf %[[B]], %[[ROOT]] : vector<8x2x4x1x4x4x1x2x8xf16>
+  // CHECK-DAG: %[[B:.*]] = iree_vector_ext.to_simt %{{.*}} : vector<128x128x128xf16> -> vector<8x2x4x1x4x4x1x8x2xf16>
+  // CHECK-DAG: %[[C:.*]] = arith.mulf %[[B]], %[[ROOT]] : vector<8x2x4x1x4x4x1x8x2xf16>
   %c = arith.mulf %root, %b : vector<128x128x128xf16>
-  // CHECK-DAG: %[[A:.*]] = iree_vector_ext.to_simt %{{.*}} : vector<128x128x128xf16> -> vector<8x2x4x1x4x4x1x2x8xf16>
-  // CHECK-DAG: %[[D:.*]] = arith.addf %[[C]], %[[A]] fastmath<reassoc,nnan> : vector<8x2x4x1x4x4x1x2x8xf16>
+  // CHECK-DAG: %[[A:.*]] = iree_vector_ext.to_simt %{{.*}} : vector<128x128x128xf16> -> vector<8x2x4x1x4x4x1x8x2xf16>
+  // CHECK-DAG: %[[D:.*]] = arith.addf %[[C]], %[[A]] fastmath<reassoc,nnan> : vector<8x2x4x1x4x4x1x8x2xf16>
   %d = arith.addf %c, %a fastmath<reassoc,nnan> : vector<128x128x128xf16>
-  // CHECK: iree_vector_ext.to_simd %[[D]] : vector<8x2x4x1x4x4x1x2x8xf16> -> vector<128x128x128xf16>
+  // CHECK: iree_vector_ext.to_simd %[[D]] : vector<8x2x4x1x4x4x1x8x2xf16> -> vector<128x128x128xf16>
   return %d : vector<128x128x128xf16>
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -624,7 +624,7 @@ NestedLayoutAttr permuteAndCreateNestedLayout(
     llvm::interleaveComma(orders.thread, llvm::errs());
     llvm::errs() << "\n    counts.element: ";
     llvm::interleaveComma(counts.element, llvm::errs());
-    llvm::errs() << "\n    orders.element: ";
+    llvm::errs() << "\n    subgroupBasis: ";
     llvm::interleaveComma(subgroupBasis, llvm::errs());
     llvm::errs() << "\n    subgroupActiveIds: ";
     llvm::interleaveComma(subgroupActiveIds, llvm::errs());
@@ -657,13 +657,13 @@ NestedLayoutAttr permuteAndCreateNestedLayout(
     llvm::interleaveComma(batchCount, llvm::errs());
     llvm::errs() << "\n    outerCount: ";
     llvm::interleaveComma(outerCount, llvm::errs());
-    llvm::errs() << "\n    outerOrder: ";
+    llvm::errs() << "\n    threadCount: ";
     llvm::interleaveComma(threadCount, llvm::errs());
     llvm::errs() << "\n    threadOrder: ";
     llvm::interleaveComma(threadOrder, llvm::errs());
     llvm::errs() << "\n    elementCount: ";
     llvm::interleaveComma(elementCount, llvm::errs());
-    llvm::errs() << "\n    elementOrder: ";
+    llvm::errs() << "\n    subgroupBasis: ";
     llvm::interleaveComma(subgroupBasis, llvm::errs());
     llvm::errs() << "\n    subgroupActiveIds: ";
     llvm::interleaveComma(subgroupActiveIds, llvm::errs());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorDistribute.cpp
@@ -326,8 +326,8 @@ private:
     SmallVector<int64_t> threadBasis = threadCounts;
 
     auto layout = IREE::VectorExt::NestedLayoutAttr::get(
-        context, subgroupCounts, order, batchSizes, order, outerSizes, order,
-        threadCounts, order, elementSizes, order, subgroupBasis,
+        context, subgroupCounts, order, batchSizes, outerSizes, threadCounts,
+        order, elementSizes, subgroupBasis,
         SmallVector<bool>(subgroupBasis.size(), true), threadBasis,
         SmallVector<bool>(threadBasis.size(), true));
     if (analysis.setAnchor(transfer.getResult(), layout).failed()) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute.mlir
@@ -49,11 +49,11 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb", {
 
 //    CHECK-LABEL: func.func @matmul_256x256x256_f16_f32()
 //     CHECK-SAME:    translation_info = #[[$TRANSLATION]]
-//          CHECK:   scf.for {{.*}} = %c0 to %c256 step %c128 iter_args({{.*}}) -> (vector<2x2x1x1x1x4xf32>)
+//          CHECK:   scf.for {{.*}} = %c0 to %c256 step %c128 iter_args({{.*}}) -> (vector<2x2x1x1x4x1xf32>)
 // Each subgroup handles 2 * 2 tiles, and for each tile we accumulate 8 times
 // along the K dimension. So in total 32 mfma ops.
 // CHECK-COUNT-32:     amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
-//          CHECK:     scf.yield %{{.+}} : vector<2x2x1x1x1x4xf32>
+//          CHECK:     scf.yield %{{.+}} : vector<2x2x1x1x4x1xf32>
 //  CHECK-COUNT-4:   vector.transfer_write {{.+}} {in_bounds = [true, true]} : vector<4x1xf32>, memref<256x256xf32, #hal.descriptor_type<storage_buffer>>
 
 // -----
@@ -100,11 +100,11 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb", {
 
 //    CHECK-LABEL: func.func @matmul_256x256x256_f16_f16()
 //     CHECK-SAME:     translation_info = #[[$TRANSLATION]]
-//          CHECK:   scf.for {{.*}} = %c0 to %c256 step %c128 iter_args(%[[ARG:.+]] = {{.*}}) -> (vector<2x2x1x1x1x4xf16>)
-//          CHECK:     arith.extf %[[ARG]] : vector<2x2x1x1x1x4xf16> to vector<2x2x1x1x1x4xf32>
+//          CHECK:   scf.for {{.*}} = %c0 to %c256 step %c128 iter_args(%[[ARG:.+]] = {{.*}}) -> (vector<2x2x1x1x4x1xf16>)
+//          CHECK:     arith.extf %[[ARG]] : vector<2x2x1x1x4x1xf16> to vector<2x2x1x1x4x1xf32>
 // CHECK-COUNT-32:     amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
-//          CHECK:     %[[TRUNC:.+]] = arith.truncf %{{.*}} : vector<2x2x1x1x1x4xf32> to vector<2x2x1x1x1x4xf16>
-//          CHECK:     scf.yield %[[TRUNC]] : vector<2x2x1x1x1x4xf16>
+//          CHECK:     %[[TRUNC:.+]] = arith.truncf %{{.*}} : vector<2x2x1x1x4x1xf32> to vector<2x2x1x1x4x1xf16>
+//          CHECK:     scf.yield %[[TRUNC]] : vector<2x2x1x1x4x1xf16>
 //  CHECK-COUNT-4:   vector.transfer_write {{.+}} {in_bounds = [true, true]} : vector<4x1xf16>, memref<256x256xf16, #hal.descriptor_type<storage_buffer>>
 
 // -----
@@ -170,11 +170,11 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb", {
 //     CHECK-SAME:     translation_info = #[[TRANSLATION]]
 // This has more than 2 iteartions. So we have prefetching enabled for this case. Due to
 // prefetching, we have one iteration peeled of so upper bound is 2048 - 128 = 1920.
-//          CHECK:   scf.for {{.*}} = %c0 to %c1920 step %c128 iter_args(%[[ARG:.+]] = {{.*}}) -> (vector<4x1x1x1x1x4xf16>)
-//          CHECK:     arith.extf %[[ARG]] : vector<4x1x1x1x1x4xf16> to vector<4x1x1x1x1x4xf32>
+//          CHECK:   scf.for {{.*}} = %c0 to %c1920 step %c128 iter_args(%[[ARG:.+]] = {{.*}}) -> (vector<4x1x1x1x4x1xf16>)
+//          CHECK:     arith.extf %[[ARG]] : vector<4x1x1x1x4x1xf16> to vector<4x1x1x1x4x1xf32>
 // CHECK-COUNT-32:     amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
-//          CHECK:     %[[TRUNC:.+]] = arith.truncf %{{.*}} : vector<4x1x1x1x1x4xf32> to vector<4x1x1x1x1x4xf16>
-//          CHECK:     scf.yield %[[TRUNC]] : vector<4x1x1x1x1x4xf16>
+//          CHECK:     %[[TRUNC:.+]] = arith.truncf %{{.*}} : vector<4x1x1x1x4x1xf32> to vector<4x1x1x1x4x1xf16>
+//          CHECK:     scf.yield %[[TRUNC]] : vector<4x1x1x1x4x1xf16>
 // CHECK-COUNT-32:   amdgpu.mfma
 //  CHECK-COUNT-4:   vector.transfer_write {{.+}} {in_bounds = [true, true]} : vector<4x1xf16>, memref<2x10x64x64xf16, #hal.descriptor_type<storage_buffer>>
 
@@ -221,7 +221,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb", {
 //          CHECK:     scf.for {{.*}} = %c0 to %c3
 // This has more than 2 iteartions. So we have prefetching enabled for this case. Due to
 // prefetching, we have one iteration peeled of so upper bound is 768 - 32 = 736.
-//          CHECK:       scf.for {{.*}} = %c0 to %c736 step %c32 iter_args(%[[ARG:.+]] = {{.*}}) -> (vector<2x4x1x1x1x4xf32>)
+//          CHECK:       scf.for {{.*}} = %c0 to %c736 step %c32 iter_args(%[[ARG:.+]] = {{.*}}) -> (vector<2x4x1x1x4x1xf32>)
 // CHECK-COUNT-16:         amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
 //          CHECK:         scf.yield
 // CHECK-COUNT-16:       amdgpu.mfma
@@ -300,11 +300,11 @@ hal.executable public @main_dispatch_expanded_matmul {
 //    CHECK-LABEL: func.func @generic_2x1024x20x64x1280_f16
 // This has more than 2 iteartions. So we have prefetching enabled for this case. Due to
 // prefetching, we have one iteration peeled of so upper bound is 1280 - 128 = 1152.
-//          CHECK:   scf.for {{.*}} = %c0 to %c1152 step %c128 iter_args({{.*}}) -> (vector<2x2x1x1x1x4xf16>)
+//          CHECK:   scf.for {{.*}} = %c0 to %c1152 step %c128 iter_args({{.*}}) -> (vector<2x2x1x1x4x1xf16>)
 // Each subgroup handles 2 * 2 tiles, and for each tile we accumulate 8 times
 // along the K dimension. So in total 32 mfma ops.
 // CHECK-COUNT-32:     amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
-//          CHECK:     scf.yield %{{.+}} : vector<2x2x1x1x1x4xf16>
+//          CHECK:     scf.yield %{{.+}} : vector<2x2x1x1x4x1xf16>
 // CHECK-COUNT-32:   amdgpu.mfma
 //  CHECK-COUNT-4:   vector.transfer_write {{.+}} : vector<4x1xf16>
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_distribute_conversion.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_distribute_conversion.mlir
@@ -38,10 +38,10 @@ func.func @mfma_matmul_256x256x256(%lhs: memref<16x256xf16, strided<[256, 1], of
 }
 
 // CHECK-LABEL: func.func @mfma_matmul_256x256x256
-//       CHECK:   %[[INIT:.+]] = arith.constant dense<0.000000e+00> : vector<1x1x1x1x1x4xf32>
+//       CHECK:   %[[INIT:.+]] = arith.constant dense<0.000000e+00> : vector<1x1x1x1x4x1xf32>
 //       CHECK:   %[[RHS_ALLOC:.+]] = memref.alloc() : memref<32x16xf16, #gpu.address_space<workgroup>>
 //       CHECK:   %[[LHS_ALLOC:.+]] = memref.alloc() : memref<16x32xf16, #gpu.address_space<workgroup>>
-//       CHECK:   scf.for {{.*}} = %c0 to %c256 step %c32 iter_args({{.*}} = %[[INIT]]) -> (vector<1x1x1x1x1x4xf32>)
+//       CHECK:   scf.for {{.*}} = %c0 to %c256 step %c32 iter_args({{.*}} = %[[INIT]])
 //       CHECK:     %[[LLOAD:.+]] = vector.transfer_read {{.*}} : memref<16x256xf16, {{.*}}>, vector<1x8xf16>
 //       CHECK:     %[[RLOAD:.+]] = vector.transfer_read {{.*}} : memref<256x16xf16, {{.*}}>, vector<1x8xf16>
 //       CHECK:     vector.transfer_write %[[LLOAD]], %[[LHS_ALLOC]]{{.*}} : vector<1x8xf16>, memref<16x32xf16, #gpu.address_space<workgroup>>
@@ -50,8 +50,8 @@ func.func @mfma_matmul_256x256x256(%lhs: memref<16x256xf16, strided<[256, 1], of
 // CHECK-COUNT-2:   vector.transfer_read %[[LHS_ALLOC]][{{.+}}], %{{.+}} {in_bounds = [true, true]} : memref<16x32xf16, #gpu.address_space<workgroup>>, vector<1x4xf16>
 // CHECK-COUNT-2:   vector.transfer_read %[[RHS_ALLOC]][{{.+}}], %{{.+}} {in_bounds = [true, true]} : memref<32x16xf16, #gpu.address_space<workgroup>>, vector<4x1xf16>
 // CHECK-COUNT-2:   amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
-//       CHECK:     %[[BCAST:.+]] = vector.broadcast {{.*}} : vector<1x1x1x4xf32> to vector<1x1x1x1x1x4xf32>
-//       CHECK:     scf.yield %[[BCAST]] : vector<1x1x1x1x1x4xf32>
+//       CHECK:     %[[BCAST:.+]] = vector.broadcast {{.*}} : vector<1x1x4x1xf32> to vector<1x1x1x1x4x1xf32>
+//       CHECK:     scf.yield %[[BCAST]]
 //       CHECK:  vector.transfer_write {{.+}} {in_bounds = [true, true]} : vector<4x1xf32>, memref<16x16xf32{{.*}}>
 
 // -----
@@ -107,9 +107,8 @@ func.func @mfma_matmul_256x256x256(%lhs: memref<16x256xf16, strided<[256, 1], of
 //       CHECK:   %[[LHS_ALLOC:.+]] = memref.alloc() : memref<16x32xf16, #gpu.address_space<workgroup>>
 //       CHECK:   affine.delinearize_index %[[LIN_ID]]
 //       CHECK:   %[[INIT_READ:.+]] = vector.transfer_read %{{.*}} memref<16x16xf32, {{.*}}>, vector<4x1xf32>
-//       CHECK:   %[[INIT_TRANSP:.+]] = vector.transpose %[[INIT_READ]], [1, 0]
-//       CHECK:   %[[INIT:.+]] = vector.insert_strided_slice %[[INIT_TRANSP]]
-//       CHECK:   scf.for {{.*}} = %c0 to %c256 step %c32 iter_args({{.*}} = %[[INIT]]) -> (vector<1x1x1x1x1x4xf32>)
+//       CHECK:   %[[INIT:.+]] = vector.insert_strided_slice %[[INIT_READ]]
+//       CHECK:   scf.for {{.*}} = %c0 to %c256 step %c32 iter_args({{.*}} = %[[INIT]]) -> (vector<1x1x1x1x4x1xf32>)
 //       CHECK:     %[[LLOAD:.+]] = vector.transfer_read {{.*}} : memref<16x256xf16, {{.*}}>, vector<1x8xf16>
 //       CHECK:     %[[RLOAD:.+]] = vector.transfer_read {{.*}} permutation_map = #[[$MAP1]]} : memref<16x256xf16, {{.*}}>, vector<8x1xf16>
 //       CHECK:     vector.transfer_write %[[LLOAD]], %[[LHS_ALLOC]]{{.*}} : vector<1x8xf16>, memref<16x32xf16, #gpu.address_space<workgroup>>
@@ -118,8 +117,8 @@ func.func @mfma_matmul_256x256x256(%lhs: memref<16x256xf16, strided<[256, 1], of
 // CHECK-COUNT-2:   vector.transfer_read %[[LHS_ALLOC]][{{.+}}], %{{.+}} {in_bounds = [true, true]} : memref<16x32xf16, #gpu.address_space<workgroup>>, vector<1x4xf16>
 // CHECK-COUNT-2:   vector.transfer_read %[[RHS_ALLOC]][{{.+}}], %{{.+}} {in_bounds = [true, true]} : memref<32x16xf16, #gpu.address_space<workgroup>>, vector<4x1xf16>
 // CHECK-COUNT-2:   amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
-//       CHECK:     %[[BCAST:.+]] = vector.broadcast {{.*}} : vector<1x1x1x4xf32> to vector<1x1x1x1x1x4xf32>
-//       CHECK:     scf.yield %[[BCAST]] : vector<1x1x1x1x1x4xf32>
+//       CHECK:     %[[BCAST:.+]] = vector.broadcast {{.*}} : vector<1x1x4x1xf32> to vector<1x1x1x1x4x1xf32>
+//       CHECK:     scf.yield %[[BCAST]]
 //       CHECK:  vector.transfer_write {{.+}} {in_bounds = [true, true]} : vector<4x1xf32>, memref<16x16xf32{{.*}}>
 
 // -----
@@ -237,29 +236,21 @@ func.func @wmma_matmul_256x256x256(%lhs: memref<16x256xf16, strided<[256, 1], of
 //       CHECK:   %[[LHS_ALLOC:.+]] = memref.alloc() : memref<16x32xf16, #gpu.address_space<workgroup>>
 //       CHECK:   affine.delinearize_index %[[LIN_ID]]
 //       CHECK:   %[[INIT_READ0:.+]] = vector.transfer_read %{{.*}} memref<16x16xf32, {{.*}}>, vector<1x1xf32>
-//       CHECK:   %[[INIT_TRANSP0:.+]] = vector.transpose %[[INIT_READ0]], [1, 0]
-//       CHECK:   %[[INIT0:.+]] = vector.insert_strided_slice %[[INIT_TRANSP0]]
+//       CHECK:   %[[INIT0:.+]] = vector.insert_strided_slice %[[INIT_READ0]]
 //       CHECK:   %[[INIT_READ1:.+]] = vector.transfer_read %{{.*}} memref<16x16xf32, {{.*}}>, vector<1x1xf32>
-//       CHECK:   %[[INIT_TRANSP1:.+]] = vector.transpose %[[INIT_READ1]], [1, 0]
-//       CHECK:   %[[INIT1:.+]] = vector.insert_strided_slice %[[INIT_TRANSP1]]
+//       CHECK:   %[[INIT1:.+]] = vector.insert_strided_slice %[[INIT_READ1]]
 //       CHECK:   %[[INIT_READ2:.+]] = vector.transfer_read %{{.*}} memref<16x16xf32, {{.*}}>, vector<1x1xf32>
-//       CHECK:   %[[INIT_TRANSP2:.+]] = vector.transpose %[[INIT_READ2]], [1, 0]
-//       CHECK:   %[[INIT2:.+]] = vector.insert_strided_slice %[[INIT_TRANSP2]]
+//       CHECK:   %[[INIT2:.+]] = vector.insert_strided_slice %[[INIT_READ2]]
 //       CHECK:   %[[INIT_READ3:.+]] = vector.transfer_read %{{.*}} memref<16x16xf32, {{.*}}>, vector<1x1xf32>
-//       CHECK:   %[[INIT_TRANSP3:.+]] = vector.transpose %[[INIT_READ3]], [1, 0]
-//       CHECK:   %[[INIT3:.+]] = vector.insert_strided_slice %[[INIT_TRANSP3]]
+//       CHECK:   %[[INIT3:.+]] = vector.insert_strided_slice %[[INIT_READ3]]
 //       CHECK:   %[[INIT_READ4:.+]] = vector.transfer_read %{{.*}} memref<16x16xf32, {{.*}}>, vector<1x1xf32>
-//       CHECK:   %[[INIT_TRANSP4:.+]] = vector.transpose %[[INIT_READ4]], [1, 0]
-//       CHECK:   %[[INIT4:.+]] = vector.insert_strided_slice %[[INIT_TRANSP4]]
+//       CHECK:   %[[INIT4:.+]] = vector.insert_strided_slice %[[INIT_READ4]]
 //       CHECK:   %[[INIT_READ5:.+]] = vector.transfer_read %{{.*}} memref<16x16xf32, {{.*}}>, vector<1x1xf32>
-//       CHECK:   %[[INIT_TRANSP5:.+]] = vector.transpose %[[INIT_READ5]], [1, 0]
-//       CHECK:   %[[INIT5:.+]] = vector.insert_strided_slice %[[INIT_TRANSP5]]
+//       CHECK:   %[[INIT5:.+]] = vector.insert_strided_slice %[[INIT_READ5]]
 //       CHECK:   %[[INIT_READ6:.+]] = vector.transfer_read %{{.*}} memref<16x16xf32, {{.*}}>, vector<1x1xf32>
-//       CHECK:   %[[INIT_TRANSP6:.+]] = vector.transpose %[[INIT_READ6]], [1, 0]
-//       CHECK:   %[[INIT6:.+]] = vector.insert_strided_slice %[[INIT_TRANSP6]]
+//       CHECK:   %[[INIT6:.+]] = vector.insert_strided_slice %[[INIT_READ6]]
 //       CHECK:   %[[INIT_READ7:.+]] = vector.transfer_read %{{.*}} memref<16x16xf32, {{.*}}>, vector<1x1xf32>
-//       CHECK:   %[[INIT_TRANSP7:.+]] = vector.transpose %[[INIT_READ7]], [1, 0]
-//       CHECK:   %[[INIT7:.+]] = vector.insert_strided_slice %[[INIT_TRANSP7]]
+//       CHECK:   %[[INIT7:.+]] = vector.insert_strided_slice %[[INIT_READ7]]
 //       CHECK:   scf.for {{.*}} = %c0 to %c256 step %c32 iter_args({{.*}} = %[[INIT7]]) -> (vector<1x1x8x1x1x1xf32>)
 //       CHECK:     %[[LLOAD0:.+]] = vector.transfer_read {{.*}} : memref<16x256xf16, {{.*}}>, vector<1x8xf16>
 //       CHECK:     %[[LLOAD1:.+]] = vector.transfer_read {{.*}} : memref<16x256xf16, {{.*}}>, vector<1x8xf16>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_distribute_layout.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_distribute_layout.mlir
@@ -23,7 +23,6 @@ func.func @mfma_matmul_96x64x16_mm(%lhs: vector<96x16xf16>, %rhs: vector<16x64xf
 //      CHECK: contract C vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [3, 2], outers_per_batch = [4, 1], threads_per_outer = [2, 32], elements_per_thread = [4, 1],
 // CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, true, false], thread_basis = [2, 32]>
->>>>>>> 91dd5a41ff (more test fixes)
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_distribute_layout.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_distribute_layout.mlir
@@ -19,12 +19,11 @@ func.func @mfma_matmul_96x64x16_mm(%lhs: vector<96x16xf16>, %rhs: vector<16x64xf
 // CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, false, true], thread_basis = [2, 32]>
 //      CHECK: contract B vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [2, 2], outers_per_batch = [1, 1], threads_per_outer = [2, 32], elements_per_thread = [4, 1],
-// CHECK-SAME:   element_order = [1, 0],
 // CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [false, true, true], thread_basis = [2, 32]>
 //      CHECK: contract C vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [3, 2], outers_per_batch = [4, 1], threads_per_outer = [2, 32], elements_per_thread = [4, 1],
-// CHECK-SAME:   element_order = [1, 0],
 // CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, true, false], thread_basis = [2, 32]>
+>>>>>>> 91dd5a41ff (more test fixes)
 
 // -----
 
@@ -47,11 +46,10 @@ func.func @mfma_matmul_96x64x16_mmt(%lhs: vector<96x16xf16>, %rhs: vector<64x16x
 // CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, false, true], thread_basis = [2, 32]>
 //      CHECK: contract B vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [2, 2], outers_per_batch = [1, 1], threads_per_outer = [32, 2], elements_per_thread = [1, 4],
-// CHECK-SAME:   outer_order = [1, 0], thread_order = [1, 0]
+// CHECK-SAME:   thread_order = [1, 0]
 // CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [false, true, true], thread_basis = [2, 32]>
 //      CHECK: contract C vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [3, 2], outers_per_batch = [4, 1], threads_per_outer = [2, 32], elements_per_thread = [4, 1],
-// CHECK-SAME:   element_order = [1, 0]
 // CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, true, false], thread_basis = [2, 32]>
 
 // -----
@@ -125,11 +123,10 @@ func.func @matmul_16x16x256_read(%lhs: memref<16x256xf16, strided<[256, 1], offs
 // CHECK-SAME:   subgroup_active_ids = [true, false, true], thread_basis = [4, 16]>
 //      CHECK: contract B vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [2, 1], outers_per_batch = [1, 1], threads_per_outer = [4, 16], elements_per_thread = [4, 1],
-// CHECK-SAME:   subgroup_order = [1, 0], element_order = [1, 0],
+// CHECK-SAME:   subgroup_order = [1, 0]
 // CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [false, true, true], thread_basis = [4, 16]>
 //      CHECK: contract C vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [1, 1], outers_per_batch = [1, 1], threads_per_outer = [4, 16], elements_per_thread = [4, 1],
-// CHECK-SAME:   element_order = [1, 0],
 // CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, true, false], thread_basis = [4, 16]>
 
 // -----
@@ -180,7 +177,7 @@ func.func @matmul_16x16x256_read_permute(%lhs: memref<16x256xf16, strided<[256, 
 // CHECK-SAME:   subgroup_basis = [1, 1], thread_basis = [16, 4]>
 //      CHECK: transfer '{{.+}} memref<16x256xf16{{.+}}storage_buffer>>, vector<32x16xf16>' vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [1, 1], outers_per_batch = [1, 1], threads_per_outer = [4, 16], elements_per_thread = [8, 1],
-// CHECK-SAME:   subgroup_order = [1, 0], batch_order = [1, 0], outer_order = [1, 0], thread_order = [1, 0], element_order = [1, 0],
+// CHECK-SAME:   subgroup_order = [1, 0], thread_order = [1, 0],
 // CHECK-SAME:   subgroup_basis = [1, 1], thread_basis = [4, 16]>
 
 //      CHECK: contract A vector layout: #iree_vector_ext.nested_layout<
@@ -189,11 +186,9 @@ func.func @matmul_16x16x256_read_permute(%lhs: memref<16x256xf16, strided<[256, 
 // CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, false, true], thread_basis = [4, 16]>
 //      CHECK: contract B vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [2, 1], outers_per_batch = [1, 1], threads_per_outer = [4, 16], elements_per_thread = [4, 1],
-// CHECK-SAME:   element_order = [1, 0],
 // CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [false, true, true], thread_basis = [4, 16]>
 //      CHECK: contract C vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [1, 1], outers_per_batch = [1, 1], threads_per_outer = [4, 16], elements_per_thread = [4, 1],
-// CHECK-SAME:   element_order = [1, 0],
 // CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, true, false], thread_basis = [4, 16]>
 
 // -----
@@ -257,11 +252,9 @@ func.func @wmma_matmul_48x32x32_mm(%lhs: vector<48x32xf16>, %rhs: vector<32x32xf
 // CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, false, true], thread_basis = [1, 32]>
 //      CHECK: contract B vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [2, 2], outers_per_batch = [1, 1], threads_per_outer = [1, 16], elements_per_thread = [16, 1],
-// CHECK-SAME:   element_order = [1, 0],
 // CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [false, true, true], thread_basis = [1, 32]>
 //      CHECK: contract C vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [3, 2], outers_per_batch = [8, 1], threads_per_outer = [2, 16], elements_per_thread = [1, 1],
-// CHECK-SAME:   element_order = [1, 0],
 // CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, true, false], thread_basis = [2, 16]>
 
 // -----
@@ -285,11 +278,10 @@ func.func @wmma_matmul_48x32x32_mmt(%lhs: vector<48x32xf16>, %rhs: vector<32x32x
 // CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, false, true], thread_basis = [1, 32]>
 //      CHECK: contract B vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [2, 2], outers_per_batch = [1, 1], threads_per_outer = [16, 1], elements_per_thread = [1, 16],
-// CHECK-SAME:   outer_order = [1, 0], thread_order = [1, 0],
+// CHECK-SAME:   thread_order = [1, 0],
 // CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [false, true, true], thread_basis = [1, 32]>
 //      CHECK: contract C vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [3, 2], outers_per_batch = [8, 1], threads_per_outer = [2, 16], elements_per_thread = [1, 1],
-// CHECK-SAME:   element_order = [1, 0],
 // CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, true, false], thread_basis = [2, 16]>
 
 // -----
@@ -325,7 +317,6 @@ func.func @matmul_192x64x16_mmt_multi_m(%lhs: vector<2x64x16xf16>, %rhs: vector<
 // CHECK-SAME:   threads_per_outer = [4, 16],
 // CHECK-SAME:   elements_per_thread = [4, 1],
 // CHECK-SAME:   subgroup_order = [1, 0],
-// CHECK-SAME:   element_order = [1, 0],
 // CHECK-SAME:   subgroup_basis = [2, 1, 1, 1],
 // CHECK-SAME:   subgroup_active_ids = [false, false, true, true],
 // CHECK-SAME:   thread_basis = [4, 16]>
@@ -335,7 +326,6 @@ func.func @matmul_192x64x16_mmt_multi_m(%lhs: vector<2x64x16xf16>, %rhs: vector<
 // CHECK-SAME:   outers_per_batch = [1, 1, 1],
 // CHECK-SAME:   threads_per_outer = [1, 4, 16],
 // CHECK-SAME:   elements_per_thread = [1, 4, 1],
-// CHECK-SAME:   element_order = [0, 2, 1],
 // CHECK-SAME:   subgroup_basis = [2, 1, 1, 1],
 // CHECK-SAME:   subgroup_active_ids = [true, true, true, false],
 // CHECK-SAME:   thread_basis = [1, 4, 16]>

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/VectorExt/IR/VectorExtAttrs.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/VectorExt/IR/VectorExtAttrs.td
@@ -130,8 +130,7 @@ def NestedLayoutAttr : IREEVectorExt_Attr<"NestedLayout",
     would have 2-D tile sizes per compute hierarchy level.
 
     We now describe each level of tiling. Each level of tiling represents a
-    count of tiles over the next level (rather than a list of tile sizes) and
-    an ordering over the tiles:
+    count of tiles over the next level (rather than a list of tile sizes).
 
     1. Subgroups per Workgroup
 
@@ -178,9 +177,7 @@ def NestedLayoutAttr : IREEVectorExt_Attr<"NestedLayout",
       for b_1 in range(batch_1):
         ...
 
-    Batches are represented using two attributes:
-      - batches_per_subgroup: Ranges of each loop
-      - batch_order: Ordering of each loop, from outermost to innermost
+    `batches_per_subgroup` represents the range of each loop.
 
     The second level, outers, is a way to represent thread layout duplication
     required by a particular intrinsic. For example, some AMDGPU matrix
@@ -193,9 +190,7 @@ def NestedLayoutAttr : IREEVectorExt_Attr<"NestedLayout",
     0 1 2 3 4     outers_per_batch=[2, 1]
     5 6 7 8 9     threads_per_outer=[2, 5]
 
-    Outers is represented using two attributes:
-      - outers_per_batch: Number of outers in a batch
-      - outer_order: Ordering of outers, from outermost to innermost
+    `outers_per_batch` represents the number of outers in a batch.
 
     Finally, threads are distributed in a single outer. The thread
     distribution is represented by:
@@ -210,8 +205,6 @@ def NestedLayoutAttr : IREEVectorExt_Attr<"NestedLayout",
       outers_per_batch = [2, 2]
       threads_per_outer = [2, 2]
 
-      batch_order = [0, 1]
-      outer_order = [0, 1]
       thread_order = [1, 0]
     }
 
@@ -259,10 +252,7 @@ def NestedLayoutAttr : IREEVectorExt_Attr<"NestedLayout",
     The final level of tiling, representing the minimum shape of vector that
     is treated as an atom.
 
-    The elements are placed contigiously with their shape and ordering
-    determined by:
-      - `elements_per_thread`: Sizes of this level of tiling
-      - `element_order`: Ordering of dimensions, from outermost to innermost
+    `elements_per_thread` represents the native size of the vector.
   }];
 
   let parameters = (ins

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/VectorExt/IR/VectorExtAttrs.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/VectorExt/IR/VectorExtAttrs.td
@@ -270,16 +270,13 @@ def NestedLayoutAttr : IREEVectorExt_Attr<"NestedLayout",
     ArrayRefParameter<"int64_t", "subgroup_order">:$subgroupOrder,
 
     ArrayRefParameter<"int64_t", "batches_per_subgroup">:$batchesPerSubgroup,
-    ArrayRefParameter<"int64_t", "batch_order">:$batchOrder,
 
     ArrayRefParameter<"int64_t", "outers_per_batch">:$outersPerBatch,
-    ArrayRefParameter<"int64_t", "outer_order">:$outerOrder,
 
     ArrayRefParameter<"int64_t", "threads_per_outer">:$threadsPerOuter,
     ArrayRefParameter<"int64_t", "thread_order">:$threadOrder,
 
     ArrayRefParameter<"int64_t", "elements_per_thread">:$elementsPerThread,
-    ArrayRefParameter<"int64_t", "element_order">:$elementOrder,
 
     ArrayRefParameter<"int64_t", "subgroup_basis">:$subgroupBasis,
     ArrayRefParameter<"bool", "subgroup_active_ids">:$subgroupActiveIds,
@@ -298,10 +295,7 @@ def NestedLayoutAttr : IREEVectorExt_Attr<"NestedLayout",
         `elements_per_thread`     `=` `[` $elementsPerThread `]` `,`
 
         custom<Permutation>("\"subgroup_order\"", ref($subgroupsPerWorkgroup), "true", $subgroupOrder) ``
-        custom<Permutation>("\"batch_order\"", ref($batchesPerSubgroup), "true", $batchOrder) ``
-        custom<Permutation>("\"outer_order\"", ref($outersPerBatch), "true", $outerOrder) ``
         custom<Permutation>("\"thread_order\"", ref($threadsPerOuter), "true", $threadOrder) ``
-        custom<Permutation>("\"element_order\"", ref($elementsPerThread), "true", $elementOrder) ``
 
         custom<Basis>("\"subgroup_basis\"", "\"subgroup_active_ids\"", "true", $subgroupBasis, $subgroupActiveIds) ``
         custom<Basis>("\"thread_basis\"", "\"thread_active_ids\"", "false", $threadBasis, $threadActiveIds) ``

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_vector_ext/roundtrip.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_vector_ext/roundtrip.mlir
@@ -29,10 +29,7 @@ func.func @specify_layout(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
   elements_per_thread = [1, 4],
 
   subgroup_order = [0, 1],
-  batch_order = [0, 1],
-  outer_order = [1, 0],
   thread_order = [0, 1],
-  element_order = [0, 1],
 
   subgroup_basis = [1, 1],
   thread_basis   = [4, 2]
@@ -46,9 +43,7 @@ func.func @specify_layout(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
   elements_per_thread = [4, 1],
 
   subgroup_order = [1, 0],
-  batch_order = [1, 0],
   thread_order = [1, 0],
-  element_order = [1, 0],
 
   subgroup_basis = [1, 1],
   thread_basis   = [2, 4]
@@ -62,9 +57,7 @@ func.func @specify_layout(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
   elements_per_thread = [4, 1],
 
   subgroup_order = [1, 0],
-  batch_order = [1, 0],
   thread_order = [1, 0],
-  element_order = [1, 0],
 
   subgroup_basis = [2, 4, 8],
   subgroup_active_ids = [true, true, false],
@@ -79,9 +72,7 @@ func.func @specify_layout(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
   elements_per_thread = [4, 1],
 
   subgroup_order = [1, 0],
-  batch_order = [1, 0],
   thread_order = [1, 0],
-  element_order = [1, 0],
 
   subgroup_basis = [2, 4, 8],
   subgroup_active_ids = [true, true, false],
@@ -97,9 +88,7 @@ func.func @specify_layout(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
   elements_per_thread = [4, 1],
 
   subgroup_order = [1, 0],
-  batch_order = [1, 0],
   thread_order = [1, 0],
-  element_order = [1, 0],
 
   subgroup_basis = [2, 4],
   subgroup_active_ids = [true, true],
@@ -127,7 +116,6 @@ func.func @specify_nested(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
 // CHECK-SAME: outers_per_batch = [4, 1],
 // CHECK-SAME: threads_per_outer = [4, 2],
 // CHECK-SAME: elements_per_thread = [1, 4],
-// CHECK-SAME: outer_order = [1, 0],
 // CHECK-SAME: subgroup_basis = [1, 1],
 // CHECK-SAME: thread_basis = [4, 2]>
 
@@ -138,9 +126,7 @@ func.func @specify_nested(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
 // CHECK-SAME: threads_per_outer = [2, 4],
 // CHECK-SAME: elements_per_thread = [4, 1],
 // CHECK-SAME: subgroup_order = [1, 0],
-// CHECK-SAME: batch_order = [1, 0],
 // CHECK-SAME: thread_order = [1, 0],
-// CHECK-SAME: element_order = [1, 0],
 // CHECK-SAME: subgroup_basis = [1, 1],
 // CHECK-SAME: thread_basis = [2, 4]>
 
@@ -151,9 +137,7 @@ func.func @specify_nested(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
 // CHECK-SAME: threads_per_outer = [2, 4],
 // CHECK-SAME: elements_per_thread = [4, 1],
 // CHECK-SAME: subgroup_order = [1, 0],
-// CHECK-SAME: batch_order = [1, 0],
 // CHECK-SAME: thread_order = [1, 0],
-// CHECK-SAME: element_order = [1, 0],
 // CHECK-SAME: subgroup_basis = [2, 4, 8],
 // CHECK-SAME: subgroup_active_ids = [true, true, false],
 // CHECK-SAME: thread_basis = [2, 4]>
@@ -165,9 +149,7 @@ func.func @specify_nested(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
 // CHECK-SAME: threads_per_outer = [2, 4],
 // CHECK-SAME: elements_per_thread = [4, 1],
 // CHECK-SAME: subgroup_order = [1, 0],
-// CHECK-SAME: batch_order = [1, 0],
 // CHECK-SAME: thread_order = [1, 0],
-// CHECK-SAME: element_order = [1, 0],
 // CHECK-SAME: subgroup_basis = [2, 4, 8],
 // CHECK-SAME: subgroup_active_ids = [true, true, false],
 // CHECK-SAME: thread_basis = [2, 4, 2],
@@ -180,9 +162,7 @@ func.func @specify_nested(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
 // CHECK-SAME: threads_per_outer = [2, 4],
 // CHECK-SAME: elements_per_thread = [4, 1],
 // CHECK-SAME: subgroup_order = [1, 0],
-// CHECK-SAME: batch_order = [1, 0],
 // CHECK-SAME: thread_order = [1, 0],
-// CHECK-SAME: element_order = [1, 0],
 // CHECK-SAME: subgroup_basis = [2, 4],
 // CHECK-SAME: thread_basis = [4, 2]>
 


### PR DESCRIPTION
This patch removes iteration order in the layout for non-distributed levels. The layout now only represents how the register is tiled, and does not define an iteration order over it. The patterns themselves define an iteration order over the tiled layout.