### PR TITLE
[CodeGen] Refactor transform dialect patterns to Transforms/Patterns.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Transforms/BUILD.bazel
@@ -17,9 +17,11 @@ iree_compiler_cc_library(
     srcs = [
         "AffineMinDistributedSCFCanonicalization.cpp",
         "RemoveSingleIterationLoop.cpp",
+        "Patterns.cpp",
         "Transforms.cpp",
     ],
     hdrs = [
+        "Patterns.h",
         "Transforms.h",
     ],
     deps = [
@@ -42,6 +44,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:SCFTransforms",
         "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TransformUtils",
         "@llvm-project//mlir:Transforms",
         "@llvm-project//mlir:ValueBoundsOpInterface",

--- a/compiler/src/iree/compiler/Codegen/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Transforms/CMakeLists.txt
@@ -14,9 +14,11 @@ iree_cc_library(
   NAME
     Transforms
   HDRS
+    "Patterns.h"
     "Transforms.h"
   SRCS
     "AffineMinDistributedSCFCanonicalization.cpp"
+    "Patterns.cpp"
     "RemoveSingleIterationLoop.cpp"
     "Transforms.cpp"
   DEPS
@@ -35,6 +37,7 @@ iree_cc_library(
     MLIRPass
     MLIRSCFTransforms
     MLIRSupport
+    MLIRTensorDialect
     MLIRTransformUtils
     MLIRTransforms
     MLIRValueBoundsOpInterface

--- a/compiler/src/iree/compiler/Codegen/Transforms/Patterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Patterns.cpp
@@ -1,0 +1,58 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Transforms/Patterns.h"
+
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+
+#define DEBUG_TYPE "iree-codegen-patterns"
+
+namespace mlir::iree_compiler {
+
+LogicalResult
+FoldFillIntoPad::matchAndRewrite(tensor::PadOp padOp,
+                                 PatternRewriter &rewriter) const {
+
+  Operation *currentOp = padOp.getSource().getDefiningOp();
+  auto maybeExtractSlice = dyn_cast_or_null<tensor::ExtractSliceOp>(currentOp);
+  while (currentOp && maybeExtractSlice) {
+    currentOp = maybeExtractSlice.getSource().getDefiningOp();
+    maybeExtractSlice = dyn_cast_or_null<tensor::ExtractSliceOp>(currentOp);
+  }
+  auto fillOp = dyn_cast_or_null<linalg::FillOp>(currentOp);
+  if (!fillOp) {
+    return rewriter.notifyMatchFailure(
+        padOp, "not coming from a linalg.fill op via tensor.extract_slice*");
+  }
+
+  Value padValue = padOp.getConstantPaddingValue();
+  RankedTensorType resultType = padOp.getResultType();
+  if (!padValue || getAsOpFoldResult(padValue) !=
+                       getAsOpFoldResult(fillOp.getDpsInputOperand(0)->get())) {
+    return rewriter.notifyMatchFailure(
+        padOp, "not a constant value matching the fill value");
+  }
+
+  Location loc = padOp.getLoc();
+  auto emptyOp = rewriter.create<tensor::EmptyOp>(
+      loc, tensor::getMixedSizes(rewriter, loc, padOp),
+      resultType.getElementType());
+  rewriter.replaceOpWithNewOp<linalg::FillOp>(padOp, padValue,
+                                              emptyOp.getResult());
+
+  return success();
+}
+
+LogicalResult
+EmptyTensorLoweringPattern::matchAndRewrite(tensor::EmptyOp op,
+                                            PatternRewriter &rewriter) const {
+  rewriter.replaceOpWithNewOp<bufferization::AllocTensorOp>(
+      op, op.getType(), op.getDynamicSizes());
+  return success();
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Transforms/Patterns.h
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Patterns.h
@@ -1,0 +1,38 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_TRANSFORMS_PATTERNS_H_
+#define IREE_COMPILER_CODEGEN_TRANSFORMS_PATTERNS_H_
+
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/PatternMatch.h"
+
+namespace mlir::iree_compiler {
+
+/// Fold `tensor.pad(cst, tensor.extract*(linalg.fill(cst)))` into
+/// `linalg.fill(cst, empty)` when the padding constant and the fill constant
+/// are the same.
+/// This seems generally desirable as a folding but may be too intrusive, so we
+/// only apply it selectively for now.
+// TODO: atm hardcoded on linalg.fill but we could take any result of any
+// generic that yields a constant in that result.
+struct FoldFillIntoPad : public OpRewritePattern<tensor::PadOp> {
+  using OpRewritePattern<tensor::PadOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(tensor::PadOp padOp,
+                                PatternRewriter &rewriter) const;
+};
+
+/// Pattern to rewrite tensor.empty to tensor.alloc.
+struct EmptyTensorLoweringPattern : public OpRewritePattern<tensor::EmptyOp> {
+  using OpRewritePattern<tensor::EmptyOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tensor::EmptyOp op,
+                                PatternRewriter &rewriter) const;
+};
+
+} // namespace mlir::iree_compiler
+
+#endif // IREE_COMPILER_CODEGEN_TRANSFORMS_PATTERNS_H_


### PR DESCRIPTION
The patterns can be reused by any other passes. It makes the gaps between default codegen transform scripts smaller. We also found FoldFillIntoPad pattern useful in sdxl branch.