### PR TITLE
[metal] Disable failing semaphore submission test until fixing

### DIFF
--- a/runtime/src/iree/hal/drivers/metal/cts/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/metal/cts/CMakeLists.txt
@@ -21,7 +21,7 @@ iree_hal_cts_test_suite(
     # HAL event is unimplemented for Metal right now.
     "event"
     # Disabled until fixing semaphore tests.
-    # https://github.com/openxla/iree/actions/runs/8730836551/job/23955300868#step:7:2999
+    # https://github.com/openxla/iree/pull/17080#discussion_r1569867998
     "semaphore_submission"
   LABELS
     driver=metal

--- a/runtime/src/iree/hal/drivers/metal/cts/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/metal/cts/CMakeLists.txt
@@ -20,6 +20,9 @@ iree_hal_cts_test_suite(
   EXCLUDED_TESTS
     # HAL event is unimplemented for Metal right now.
     "event"
+    # Disabled until fixing semaphore tests.
+    # https://github.com/openxla/iree/actions/runs/8730836551/job/23955300868#step:7:2999
+    "semaphore_submission"
   LABELS
     driver=metal
 )


### PR DESCRIPTION
We see failing metal tests after
https://github.com/openxla/iree/pull/17080.
Disable for now until fixing it.

ci-extra: build_test_all_macos_arm64