### PR TITLE
[CPU] Add scalable flags to configs for Conv

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1976,7 +1976,7 @@ static LogicalResult setConvRootConfig(mlir::FunctionOpInterface entryPointFn,
     // Level 2: Parallel
     SmallVector<bool> parallelScalableFlags(numTilingDims, false);
     // Make the channel dim scalable
-    parallelScalableFlags[3] = true;
+    parallelScalableFlags[dims->depth[0]] = true;
     scalableTileFlags.emplace_back(parallelScalableFlags);
     // Level 3: Reduction
     scalableTileFlags.emplace_back(numTilingDims, false);


### PR DESCRIPTION
Adds scalable flags to lowering_config for depthwise 2D convolution.

**NOTE** Requires https://github.com/openxla/iree/pull/17069. Please only review the top commit.