### PR TITLE
Update instructions for getting write-access in iree-org.

### DIFF
--- a/docs/website/docs/developers/general/contributing.md
+++ b/docs/website/docs/developers/general/contributing.md
@@ -117,27 +117,26 @@ yet).
 
 ### :octicons-git-merge-16: Obtaining commit access
 
-Access to affiliated repositories is divided into three tiers:
+Access to affiliated repositories is divided into tiers:
 
 | Tier | Description | Team link |
 | ---- | ----------- | --------- |
-Triage | **New project members should typically start here**<br>:material-check: Can be [assigned issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)<br>:material-check: Can apply labels to issues / PRs<br>:material-check: Can run workflows [without approval](https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks) | [iree-triage](https://github.com/orgs/openxla/teams/iree-triage)
-Write | **Established project contributors should request this access**<br>:material-check: Can [merge approved pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/merging-a-pull-request)<br>:material-check: Can create branches | [iree-write](https://github.com/orgs/openxla/teams/iree-write)
-Maintain | :material-check: Can [edit repository settings](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features)<br>:material-check: Can push to [protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches) | [iree-maintain](https://github.com/orgs/openxla/teams/iree-maintain)
+Triage | **New project members should typically start here**<br>:material-check: Can be [assigned issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)<br>:material-check: Can apply labels to issues / PRs<br>:material-check: Can run workflows [without approval](https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks) | [iree-triage](https://github.com/orgs/iree-org/teams/iree-triage)
+Write | **Established project contributors should request this access**<br>:material-check: Can [merge approved pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/merging-a-pull-request)<br>:material-check: Can create branches | [iree-write](https://github.com/orgs/iree-org/teams/iree-write)
+Maintain/Admin | :material-check: Can [edit repository settings](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features)<br>:material-check: Can push to [protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches) | Added case-by-case
 
 All access tiers first require joining the
-[OpenXLA GitHub organization](https://github.com/openxla/).
+[iree-org GitHub organization](https://github.com/iree-org/).
 
 <!-- markdownlint-disable-next-line -->
 [Fill out this form to request access :fontawesome-solid-paper-plane:](https://docs.google.com/forms/d/e/1FAIpQLSfEwANtMvLJWq-ED4lub_xsMch0MgNY02VxgtXE61FqNvNVUg/viewform){ .md-button .md-button--primary }
 
-Once you are a member of the OpenXLA GitHub organization, you can request to
-join any of the teams on <https://github.com/orgs/openxla/teams>.
+Once you are a member of the iree-org GitHub organization, you can request to
+join any of the teams on <https://github.com/orgs/iree-org/teams>.
 
 !!! note - "Note: other GitHub organizations"
 
     Work on IREE sometimes spans other GitHub organizations like
-    [iree-org](https://github.com/iree-org) and
     [shark-infra](https://github.com/shark-infra/). Reach out to a project
     member if you would also like access to repositories in those organizations.
 


### PR DESCRIPTION
As part of [moving IREE out of OpenXLA](https://groups.google.com/g/iree-discuss/c/kdFr4CQwEyY/m/PWJIpZlRBQAJ), we moved the repository from the [openxla GitHub organization](https://github.com/openxla) to the [iree-org GitHub organzation](https://github.com/iree-org).

This updates the "obtaining commit access" instructions to reference new GitHub teams locations in `iree-org`. We also no longer have a `iree-maintain` team (it wasn't used).

The existing form link is still valid - the contents were changed to be IREE-specific.