### PR TITLE
[Codegen] NFC: Cleanup common transform dialect ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -73,7 +73,7 @@ void mlir::iree_compiler::registerTransformDialectCommonExtension(
 }
 
 //===---------------------------------------------------------------------===//
-// ApplyIreeLinalgElementwiseGreedyFusionPatternsOp
+// ApplyIREELinalgElementwiseGreedyFusionPatternsOp
 //===---------------------------------------------------------------------===//
 
 static void addOperands(Operation *op, SetVector<Value> &operandSet) {
@@ -104,7 +104,7 @@ static bool setFusedOpOperandLimit(OpOperand *fusedOperand) {
   return fusedOpOperands.size() <= limit;
 }
 
-void transform_dialect::ApplyIreeLinalgElementwiseGreedyFusionPatternsOp::
+void transform_dialect::ApplyIREELinalgElementwiseGreedyFusionPatternsOp::
     populatePatterns(RewritePatternSet &patterns) {
   linalg::populateElementwiseOpsFusionPatterns(patterns,
                                                setFusedOpOperandLimit<3>);
@@ -249,141 +249,6 @@ void transform_dialect::ApplyPrepareVectorToMMAPatternsOp::populatePatterns(
 }
 
 //===---------------------------------------------------------------------===//
-// ApplyLoopIndependentCodeMotionOp
-//===---------------------------------------------------------------------===//
-
-DiagnosedSilenceableFailure
-transform_dialect::ApplyLoopIndependentCodeMotionOp::applyToOne(
-    transform::TransformRewriter &rewriter, Operation *target,
-    transform::ApplyToEachResultList &results,
-    transform::TransformState &state) {
-  ErrorCheckingTrackingListener listener(state, *this);
-  target->walk([&](mlir::FunctionOpInterface funcOp) {
-    // This assumes LICM never removes operations so we don't need tracking.
-    // TODO: confirm / revisit this assumption and plumb a rewriter through
-    // upstream moveLoopInvariantCode if necessary.
-    funcOp->walk([](LoopLikeOpInterface loopLike) {
-      // Do not hoist from scf.forall ops. These capture isolated computations
-      // that will be mapped to a certain level in the GPU hierarchy (e.g.,
-      // GPU blocks), so hoisting is not desired.
-      if (!isa<scf::ForallOp>(loopLike.getOperation()))
-        moveLoopInvariantCode(loopLike);
-    });
-    // For now, put single loop promotion as part of licm. Underlying
-    // implementations perform splice operations which shouldn't need
-    // tracking.
-    // TODO: confirm / revisit this assumption and plumb a rewriter through
-    // upstream moveLoopInvariantCode if necessary.
-    funcOp->walk([&](Operation *op) {
-      (void)llvm::TypeSwitch<Operation *, LogicalResult>(op)
-          .Case<affine::AffineForOp, scf::ForOp>([&](auto loop) {
-            return loop.promoteIfSingleIteration(rewriter);
-          })
-          .Default([](Operation *) { return success(); });
-    });
-  });
-
-  return listener.checkAndResetError();
-}
-
-void transform_dialect::ApplyLoopIndependentCodeMotionOp::getEffects(
-    SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
-  transform::onlyReadsHandle(getTarget(), effects);
-  transform::modifiesPayload(effects);
-}
-
-//===----------------------------------------------------------------------===//
-// HoistStaticAllocOp
-//===----------------------------------------------------------------------===//
-
-DiagnosedSilenceableFailure transform_dialect::HoistStaticAllocOp::applyToOne(
-    transform::TransformRewriter &rewriter, mlir::FunctionOpInterface target,
-    transform::ApplyToEachResultList &results,
-    transform::TransformState &state) {
-  mlir::iree_compiler::hoistStaticallyBoundAllocationsInFunc<memref::AllocOp>(
-      rewriter, target);
-  return DiagnosedSilenceableFailure::success();
-}
-
-void transform_dialect::HoistStaticAllocOp::getEffects(
-    SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
-  transform::onlyReadsHandle(getTarget(), effects);
-  transform::modifiesPayload(effects);
-}
-
-//===----------------------------------------------------------------------===//
-// ShareForallOperandsOp
-//===----------------------------------------------------------------------===//
-
-DiagnosedSilenceableFailure
-transform_dialect::ShareForallOperandsOp::applyToOne(
-    transform::TransformRewriter &rewriter, scf::ForallOp forallOp,
-    transform::ApplyToEachResultList &results,
-    transform::TransformState &state) {
-  SmallVector<int64_t> shareOperands(getShareOperands());
-  // Empty case: consider all operands need to be shared.
-  if (shareOperands.empty()) {
-    shareOperands =
-        llvm::to_vector(llvm::seq<int64_t>(0, forallOp.getOutputs().size()));
-  }
-  for (int64_t outputIdx : getShareOperands()) {
-    if (outputIdx < 0 || outputIdx >= forallOp.getOutputs().size())
-      return mlir::emitDefiniteFailure(forallOp, "operand idx overflow");
-    Value toShare = forallOp.getOutputs()[outputIdx];
-    if (std::distance(toShare.getUses().begin(), toShare.getUses().end()) !=
-        2) {
-      /*return mlir::emitSilenceableFailure(
-          forallOp,
-          "operand to share must have exactly 2 uses, the forall op "
-          "and an extract_slice op.");*/
-      continue;
-    }
-    tensor::ExtractSliceOp extractSliceOp;
-    for (Operation *user : toShare.getUsers()) {
-      extractSliceOp = dyn_cast<tensor::ExtractSliceOp>(user);
-      if (extractSliceOp)
-        break;
-    }
-    if (!extractSliceOp) {
-      /*return mlir::emitSilenceableFailure(
-        forallOp,
-        "shared operands use must be extractSliceOp.");*/
-      continue;
-    }
-    // Get the corresponding bbArg.
-    BlockArgument bbArg = forallOp.getRegionIterArgs()[outputIdx];
-
-    // Check if the extract_slice has a matching parallel_insert_slice
-    // (i.e., same source/target, offsets, sizes and strides).
-    auto isMatchingParallelInsertSlice = [&](Operation &op) {
-      auto insertSlice = dyn_cast<tensor::ParallelInsertSliceOp>(&op);
-      if (!insertSlice)
-        return false;
-      if (insertSlice.getDest() != bbArg)
-        return false;
-      return llvm::equal(insertSlice.getMixedOffsets(),
-                         extractSliceOp.getMixedOffsets()) &&
-             llvm::equal(insertSlice.getMixedSizes(),
-                         extractSliceOp.getMixedSizes()) &&
-             llvm::equal(insertSlice.getMixedStrides(),
-                         extractSliceOp.getMixedStrides());
-    };
-    if (llvm::none_of(forallOp.getTerminator().getYieldingOps(),
-                      isMatchingParallelInsertSlice)) {
-      continue;
-    }
-
-    // Promote extract_slice source to bbArg.
-    rewriter.modifyOpInPlace(extractSliceOp, [&]() {
-      extractSliceOp.getSourceMutable().assign(bbArg);
-    });
-  }
-
-  results.push_back(forallOp);
-  return DiagnosedSilenceableFailure::success();
-}
-
-//===---------------------------------------------------------------------===//
 // ForallToWorkgroupOp
 //===---------------------------------------------------------------------===//
 
@@ -482,10 +347,6 @@ LogicalResult rewriteForallToWorkgroup(RewriterBase &rewriter,
   return success();
 }
 
-//===---------------------------------------------------------------------===//
-// IREE-specific transformations defined outside of iree_linalg_transform.
-//===---------------------------------------------------------------------===//
-
 DiagnosedSilenceableFailure transform_dialect::ForallToWorkgroupOp::applyToOne(
     transform::TransformRewriter &rewriter, mlir::FunctionOpInterface target,
     transform::ApplyToEachResultList &results,
@@ -519,18 +380,91 @@ void transform_dialect::ForallToWorkgroupOp::getEffects(
   transform::modifiesPayload(effects);
 }
 
+//===----------------------------------------------------------------------===//
+// GpuDistributeSharedMemoryCopyOp
+//===----------------------------------------------------------------------===//
+
+DiagnosedSilenceableFailure
+transform_dialect::GpuDistributeSharedMemoryCopyOp::applyToOne(
+    transform::TransformRewriter &rewriter, mlir::FunctionOpInterface target,
+    transform::ApplyToEachResultList &results,
+    transform::TransformState &state) {
+
+  // Look for ops that move to workgroup memory and mark as copies for
+  // distribution.
+  target.walk([&](linalg::GenericOp copyOp) {
+    if (copyOp.getNumDpsInputs() != 1 || copyOp.getNumDpsInits() != 1)
+      return;
+    auto dest =
+        dyn_cast<TypedValue<MemRefType>>(copyOp.getDpsInitOperand(0)->get());
+    if (!dest)
+      return;
+
+    MemRefType destType = dest.getType();
+
+    // Check if the only operation in the possible copy op region is a
+    // terminator.
+    Block &body = copyOp.getRegion().front();
+    if (!std::begin(body)->hasTrait<OpTrait::IsTerminator>())
+      return;
+
+    auto destSpace =
+        dyn_cast_or_null<gpu::AddressSpaceAttr>(destType.getMemorySpace());
+    if (!destSpace)
+      return;
+
+    // The destination space must be shared memory.
+    if (destSpace.getValue() != gpu::GPUDialect::getWorkgroupAddressSpace())
+      return;
+
+    // Mark this copy operation as a copy to workgroup memory.
+    setMarker(copyOp, getCopyToWorkgroupMemoryMarker());
+  });
+
+  if (failed(mlir::iree_compiler::gpuDistributeSharedMemoryCopy(target))) {
+    return mlir::emitDefiniteFailure(state.getTopLevel(),
+                                     "Pattern failed to apply");
+  }
+  return DiagnosedSilenceableFailure::success();
+}
+
+void transform_dialect::GpuDistributeSharedMemoryCopyOp::getEffects(
+    SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
+  transform::onlyReadsHandle(getTarget(), effects);
+  transform::modifiesPayload(effects);
+}
+
+//===----------------------------------------------------------------------===//
+// HoistStaticAllocOp
+//===----------------------------------------------------------------------===//
+
+DiagnosedSilenceableFailure transform_dialect::HoistStaticAllocOp::applyToOne(
+    transform::TransformRewriter &rewriter, mlir::FunctionOpInterface target,
+    transform::ApplyToEachResultList &results,
+    transform::TransformState &state) {
+  mlir::iree_compiler::hoistStaticallyBoundAllocationsInFunc<memref::AllocOp>(
+      rewriter, target);
+  return DiagnosedSilenceableFailure::success();
+}
+
+void transform_dialect::HoistStaticAllocOp::getEffects(
+    SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
+  transform::onlyReadsHandle(getTarget(), effects);
+  transform::modifiesPayload(effects);
+}
+
 //===---------------------------------------------------------------------===//
-// IREEPopulateWorkgroupCountRegionUsingNumThreadsSliceOp
+// PopulateWorkgroupCountRegionUsingNumThreadsSliceOp
 //===---------------------------------------------------------------------===//
 
-void transform_dialect::IREEPopulateWorkgroupCountRegionUsingNumThreadsSliceOp::
+void transform_dialect::PopulateWorkgroupCountRegionUsingNumThreadsSliceOp::
     getEffects(SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
   transform::onlyReadsHandle(getForAllOp(), effects);
   transform::modifiesPayload(effects);
 }
 
 DiagnosedSilenceableFailure
-transform_dialect::IREEPopulateWorkgroupCountRegionUsingNumThreadsSliceOp::
+transform_dialect::PopulateWorkgroupCountRegionUsingNumThreadsSliceOp::
     applyToOne(transform::TransformRewriter &rewriter, Operation *target,
                transform::ApplyToEachResultList &results,
                transform::TransformState &state) {
@@ -576,6 +510,50 @@ transform_dialect::IREEPopulateWorkgroupCountRegionUsingNumThreadsSliceOp::
                                      "failed to lower workgroup count region");
   }
   return DiagnosedSilenceableFailure::success();
+}
+
+//===---------------------------------------------------------------------===//
+// IREEApplyLoopIndependentCodeMotionOp
+//===---------------------------------------------------------------------===//
+
+DiagnosedSilenceableFailure
+transform_dialect::IREEApplyLoopIndependentCodeMotionOp::applyToOne(
+    transform::TransformRewriter &rewriter, Operation *target,
+    transform::ApplyToEachResultList &results,
+    transform::TransformState &state) {
+  ErrorCheckingTrackingListener listener(state, *this);
+  target->walk([&](mlir::FunctionOpInterface funcOp) {
+    // This assumes LICM never removes operations so we don't need tracking.
+    // TODO: confirm / revisit this assumption and plumb a rewriter through
+    // upstream moveLoopInvariantCode if necessary.
+    funcOp->walk([](LoopLikeOpInterface loopLike) {
+      // Do not hoist from scf.forall ops. These capture isolated computations
+      // that will be mapped to a certain level in the GPU hierarchy (e.g.,
+      // GPU blocks), so hoisting is not desired.
+      if (!isa<scf::ForallOp>(loopLike.getOperation()))
+        moveLoopInvariantCode(loopLike);
+    });
+    // For now, put single loop promotion as part of licm. Underlying
+    // implementations perform splice operations which shouldn't need
+    // tracking.
+    // TODO: confirm / revisit this assumption and plumb a rewriter through
+    // upstream moveLoopInvariantCode if necessary.
+    funcOp->walk([&](Operation *op) {
+      (void)llvm::TypeSwitch<Operation *, LogicalResult>(op)
+          .Case<affine::AffineForOp, scf::ForOp>([&](auto loop) {
+            return loop.promoteIfSingleIteration(rewriter);
+          })
+          .Default([](Operation *) { return success(); });
+    });
+  });
+
+  return listener.checkAndResetError();
+}
+
+void transform_dialect::IREEApplyLoopIndependentCodeMotionOp::getEffects(
+    SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
+  transform::onlyReadsHandle(getTarget(), effects);
+  transform::modifiesPayload(effects);
 }
 
 //===---------------------------------------------------------------------===//
@@ -828,25 +806,7 @@ void transform_dialect::IREEEliminateEmptyTensorsOp::getEffects(
 }
 
 //===----------------------------------------------------------------------===//
-// WorkgroupSwizzleOp
-//===----------------------------------------------------------------------===//
-
-DiagnosedSilenceableFailure transform_dialect::WorkgroupSwizzleOp::applyToOne(
-    transform::TransformRewriter &rewriter, mlir::FunctionOpInterface target,
-    transform::ApplyToEachResultList &results,
-    transform::TransformState &state) {
-  (void)swizzleWorkgroupsInFunc(target, getLogTile());
-  return DiagnosedSilenceableFailure::success();
-}
-
-void transform_dialect::WorkgroupSwizzleOp::getEffects(
-    SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
-  transform::onlyReadsHandle(getTarget(), effects);
-  transform::modifiesPayload(effects);
-}
-
-//===----------------------------------------------------------------------===//
-// ReduceSharedMemoryBankConclitsOp
+// ReduceSharedMemoryBankConflictsOp
 //===----------------------------------------------------------------------===//
 
 DiagnosedSilenceableFailure
@@ -862,6 +822,128 @@ transform_dialect::ReduceSharedMemoryBankConflictsOp::applyToOne(
 }
 
 void transform_dialect::ReduceSharedMemoryBankConflictsOp::getEffects(
+    SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
+  transform::onlyReadsHandle(getTarget(), effects);
+  transform::modifiesPayload(effects);
+}
+
+//===----------------------------------------------------------------------===//
+// ShareForallOperandsOp
+//===----------------------------------------------------------------------===//
+
+DiagnosedSilenceableFailure
+transform_dialect::ShareForallOperandsOp::applyToOne(
+    transform::TransformRewriter &rewriter, scf::ForallOp forallOp,
+    transform::ApplyToEachResultList &results,
+    transform::TransformState &state) {
+  SmallVector<int64_t> shareOperands(getShareOperands());
+  // Empty case: consider all operands need to be shared.
+  if (shareOperands.empty()) {
+    shareOperands =
+        llvm::to_vector(llvm::seq<int64_t>(0, forallOp.getOutputs().size()));
+  }
+  for (int64_t outputIdx : getShareOperands()) {
+    if (outputIdx < 0 || outputIdx >= forallOp.getOutputs().size())
+      return mlir::emitDefiniteFailure(forallOp, "operand idx overflow");
+    Value toShare = forallOp.getOutputs()[outputIdx];
+    if (std::distance(toShare.getUses().begin(), toShare.getUses().end()) !=
+        2) {
+      /*return mlir::emitSilenceableFailure(
+          forallOp,
+          "operand to share must have exactly 2 uses, the forall op "
+          "and an extract_slice op.");*/
+      continue;
+    }
+    tensor::ExtractSliceOp extractSliceOp;
+    for (Operation *user : toShare.getUsers()) {
+      extractSliceOp = dyn_cast<tensor::ExtractSliceOp>(user);
+      if (extractSliceOp)
+        break;
+    }
+    if (!extractSliceOp) {
+      /*return mlir::emitSilenceableFailure(
+        forallOp,
+        "shared operands use must be extractSliceOp.");*/
+      continue;
+    }
+    // Get the corresponding bbArg.
+    BlockArgument bbArg = forallOp.getRegionIterArgs()[outputIdx];
+
+    // Check if the extract_slice has a matching parallel_insert_slice
+    // (i.e., same source/target, offsets, sizes and strides).
+    auto isMatchingParallelInsertSlice = [&](Operation &op) {
+      auto insertSlice = dyn_cast<tensor::ParallelInsertSliceOp>(&op);
+      if (!insertSlice)
+        return false;
+      if (insertSlice.getDest() != bbArg)
+        return false;
+      return llvm::equal(insertSlice.getMixedOffsets(),
+                         extractSliceOp.getMixedOffsets()) &&
+             llvm::equal(insertSlice.getMixedSizes(),
+                         extractSliceOp.getMixedSizes()) &&
+             llvm::equal(insertSlice.getMixedStrides(),
+                         extractSliceOp.getMixedStrides());
+    };
+    if (llvm::none_of(forallOp.getTerminator().getYieldingOps(),
+                      isMatchingParallelInsertSlice)) {
+      continue;
+    }
+
+    // Promote extract_slice source to bbArg.
+    rewriter.modifyOpInPlace(extractSliceOp, [&]() {
+      extractSliceOp.getSourceMutable().assign(bbArg);
+    });
+  }
+
+  results.push_back(forallOp);
+  return DiagnosedSilenceableFailure::success();
+}
+
+//===----------------------------------------------------------------------===//
+// TestGpuVectorDistribution
+//===----------------------------------------------------------------------===//
+
+class TestVectorLayoutOptions : public VectorLayoutOptions {
+public:
+  TestVectorLayoutOptions(Operation *root)
+      : VectorLayoutOptions(root, /*fullConversion=*/false) {}
+
+  LogicalResult setAnchorOps(VectorLayoutAnalysis &analysis) override {
+    return setAnchorOpsFromAttributes(analysis, root);
+  }
+};
+
+DiagnosedSilenceableFailure
+transform_dialect::TestGpuVectorDistribution::applyToOne(
+    transform::TransformRewriter &rewriter, mlir::FunctionOpInterface target,
+    transform::ApplyToEachResultList &results,
+    transform::TransformState &state) {
+  TestVectorLayoutOptions options(target);
+  RewritePatternSet patterns(target.getContext());
+
+  rewriter.setInsertionPointToStart(&target.getFunctionBody().front());
+  // This is a test op so we unsafely use thread_id x as the lane ID. In
+  // general this should linearize the thread IDs based on the workgroup size
+  // and divide by the subgroup size. i.e.
+  //
+  // lane_id = (tid_x + tid_y * dim_x + tid_z * dim_y * dim_x) / subgroup_size;
+  Value laneId =
+      rewriter.create<gpu::ThreadIdOp>(target.getLoc(), gpu::Dimension::x);
+
+  populateGPUDistributionPatterns(patterns);
+  populateGPUDistributionLayoutAttrPatterns(laneId, patterns);
+  populateGPUReductionDistributionPatterns(patterns);
+  populateGPUDistributeNestedLayoutAttrPatterns(laneId, patterns);
+  populateGPUDistributeNestedLayoutContractAMDGPUPatterns(patterns);
+  if (getExperimental())
+    populateGPULayoutResolutionDistributionPatterns(patterns);
+  if (failed(distributeVectorOps(target, patterns, options))) {
+    return emitDefaultDefiniteFailure(target);
+  }
+  return DiagnosedSilenceableFailure::success();
+}
+
+void transform_dialect::TestGpuVectorDistribution::getEffects(
     SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
   transform::onlyReadsHandle(getTarget(), effects);
   transform::modifiesPayload(effects);
@@ -917,104 +999,18 @@ void transform_dialect::TestVectorLayoutAnalysisOp::getEffects(
 }
 
 //===----------------------------------------------------------------------===//
-// TestGpuVectorDistribution
+// WorkgroupSwizzleOp
 //===----------------------------------------------------------------------===//
 
-class TestVectorLayoutOptions : public VectorLayoutOptions {
-public:
-  TestVectorLayoutOptions(Operation *root)
-      : VectorLayoutOptions(root, /*fullConversion=*/false) {}
-
-  LogicalResult setAnchorOps(VectorLayoutAnalysis &analysis) override {
-    return setAnchorOpsFromAttributes(analysis, root);
-  }
-};
-
-DiagnosedSilenceableFailure
-transform_dialect::TestGpuVectorDistribution::applyToOne(
+DiagnosedSilenceableFailure transform_dialect::WorkgroupSwizzleOp::applyToOne(
     transform::TransformRewriter &rewriter, mlir::FunctionOpInterface target,
     transform::ApplyToEachResultList &results,
     transform::TransformState &state) {
-  TestVectorLayoutOptions options(target);
-  RewritePatternSet patterns(target.getContext());
-
-  rewriter.setInsertionPointToStart(&target.getFunctionBody().front());
-  // This is a test op so we unsafely use thread_id x as the lane ID. In
-  // general this should linearize the thread IDs based on the workgroup size
-  // and divide by the subgroup size. i.e.
-  //
-  // lane_id = (tid_x + tid_y * dim_x + tid_z * dim_y * dim_x) / subgroup_size;
-  Value laneId =
-      rewriter.create<gpu::ThreadIdOp>(target.getLoc(), gpu::Dimension::x);
-
-  populateGPUDistributionPatterns(patterns);
-  populateGPUDistributionLayoutAttrPatterns(laneId, patterns);
-  populateGPUReductionDistributionPatterns(patterns);
-  populateGPUDistributeNestedLayoutAttrPatterns(laneId, patterns);
-  populateGPUDistributeNestedLayoutContractAMDGPUPatterns(patterns);
-  if (getExperimental())
-    populateGPULayoutResolutionDistributionPatterns(patterns);
-  if (failed(distributeVectorOps(target, patterns, options))) {
-    return emitDefaultDefiniteFailure(target);
-  }
+  (void)swizzleWorkgroupsInFunc(target, getLogTile());
   return DiagnosedSilenceableFailure::success();
 }
 
-void transform_dialect::TestGpuVectorDistribution::getEffects(
-    SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
-  transform::onlyReadsHandle(getTarget(), effects);
-  transform::modifiesPayload(effects);
-}
-
-//===----------------------------------------------------------------------===//
-// GpuDistributeSharedMemoryCopyOp
-//===----------------------------------------------------------------------===//
-
-DiagnosedSilenceableFailure
-transform_dialect::GpuDistributeSharedMemoryCopyOp::applyToOne(
-    transform::TransformRewriter &rewriter, mlir::FunctionOpInterface target,
-    transform::ApplyToEachResultList &results,
-    transform::TransformState &state) {
-
-  // Look for ops that move to workgroup memory and mark as copies for
-  // distribution.
-  target.walk([&](linalg::GenericOp copyOp) {
-    if (copyOp.getNumDpsInputs() != 1 || copyOp.getNumDpsInits() != 1)
-      return;
-    auto dest =
-        dyn_cast<TypedValue<MemRefType>>(copyOp.getDpsInitOperand(0)->get());
-    if (!dest)
-      return;
-
-    MemRefType destType = dest.getType();
-
-    // Check if the only operation in the possible copy op region is a
-    // terminator.
-    Block &body = copyOp.getRegion().front();
-    if (!std::begin(body)->hasTrait<OpTrait::IsTerminator>())
-      return;
-
-    auto destSpace =
-        dyn_cast_or_null<gpu::AddressSpaceAttr>(destType.getMemorySpace());
-    if (!destSpace)
-      return;
-
-    // The destination space must be shared memory.
-    if (destSpace.getValue() != gpu::GPUDialect::getWorkgroupAddressSpace())
-      return;
-
-    // Mark this copy operation as a copy to workgroup memory.
-    setMarker(copyOp, getCopyToWorkgroupMemoryMarker());
-  });
-
-  if (failed(mlir::iree_compiler::gpuDistributeSharedMemoryCopy(target))) {
-    return mlir::emitDefiniteFailure(state.getTopLevel(),
-                                     "Pattern failed to apply");
-  }
-  return DiagnosedSilenceableFailure::success();
-}
-
-void transform_dialect::GpuDistributeSharedMemoryCopyOp::getEffects(
+void transform_dialect::WorkgroupSwizzleOp::getEffects(
     SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
   transform::onlyReadsHandle(getTarget(), effects);
   transform::modifiesPayload(effects);

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -98,7 +98,7 @@ def ApplyFoldTensorSliceIntoTransferPatternsOp : Op<Transform_Dialect,
   let assemblyFormat = "attr-dict";
 }
 
-def ApplyIreeLinalgElementwiseGreedyFusionPatternsOp : Op<Transform_Dialect,
+def ApplyIREELinalgElementwiseGreedyFusionPatternsOp : Op<Transform_Dialect,
     "apply_patterns.iree.linalg_elementwise_greedy_fusion",
     [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
      ReportTrackingListenerFailuresOpTrait]> {
@@ -154,29 +154,30 @@ def ApplyUnrollVectorsGpuWmmaSyncPatternsOp : Op<Transform_Dialect,
   let assemblyFormat = "attr-dict";
 }
 
-def ApplyLoopIndependentCodeMotionOp : Op<Transform_Dialect, "iree.apply_licm",
+def GpuDistributeSharedMemoryCopyOp :
+  Op<Transform_Dialect, "iree.gpu_distribute_shared_memory_copy",
     [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-     TransformEachOpTrait,
-     TransformOpInterface,
-     ReportTrackingListenerFailuresOpTrait]> {
+     TransformOpInterface, TransformEachOpTrait]> {
+  let summary = "Distribute shared memory copies";
   let description = [{
-    Apply loop-independent code motion and single iteration loop promotion.
-    This transform is applied to all FuncOps within the target.
+    Find copies to/from shared memory and distribute the copies based on the
+    workgroup size.
 
     #### Return modes
-
-    This operation does not consume the target handle and does not produce any
-    handle.
+    This operation applies to the entire function and does not consume the
+    target handle. It always return success.
   }];
 
   let arguments = (ins TransformHandleTypeInterface:$target);
-  let assemblyFormat = "$target attr-dict `:` type($target)";
+  let results = (outs);
+
+  let assemblyFormat = "$target attr-dict `:` functional-type(operands, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
         ::mlir::transform::TransformRewriter &rewriter,
-        ::mlir::Operation *target,
+        ::mlir::FunctionOpInterface target,
         ::mlir::transform::ApplyToEachResultList &results,
         ::mlir::transform::TransformState &state);
   }];
@@ -207,6 +208,93 @@ def HoistStaticAllocOp :  Op<Transform_Dialect, "iree.hoist_static_alloc",
     ::mlir::DiagnosedSilenceableFailure applyToOne(
         ::mlir::transform::TransformRewriter &rewriter,
         ::mlir::FunctionOpInterface funcOp,
+        ::mlir::transform::ApplyToEachResultList &results,
+        ::mlir::transform::TransformState &state);
+  }];
+}
+
+def ForallToWorkgroupOp : Op<Transform_Dialect,
+    "iree.forall_to_workgroup",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     TransformEachOpTrait,
+     TransformOpInterface,
+     ReportTrackingListenerFailuresOpTrait]> {
+  let description = [{
+    Target the whole hal.executable_variant op and rewrite the unique topLevel
+    scf.forall to distributed workgroup_id and workgroup_count.
+
+    The mapping of threads to workgroup_id is currently one-to-one and in order.
+    Only **bufferized** scf.forall are currently supported.
+    Only scf.forall distributed to **at most 3 dimensions** are currently
+    supported.
+
+    Return modes:
+    =============
+    This operation ignores non-Func ops and drops them in the return.
+
+    If no unique scf.forall topLevel operation is found, then the
+    transform definitely fails.
+    If the unique topLevel scf.forall has results (i.e. tensors), then
+    the transform definitely fails.
+
+    If the unique topLevel scf.forall maps to a dynamic number of
+    threads, then the transform definitely fails. This is a temporary
+    limitation until the backward slice computing scf.forall.num_threads
+    can be extracted into the hal::executable_export workgroup_count region.
+    This region may require arbitrary computations and cannot magically match
+    what the `stream.cmd.dispatch` has already imposed on us at a distance.
+    For now we must specify the number of values properly when applying the
+    topLevel tile_using_forall.
+
+    If the unique topLevel scf.forall operation contained within the
+    FuncOp referred to by the `target` transform handle lowers to workgroup
+    properly, the transform succeeds.
+
+    Otherwise the transform definitely fails.
+
+    This transform does not consume its input handle and produces no result.
+  }];
+
+  let arguments = (ins TransformHandleTypeInterface:$target);
+  let results = (outs);
+
+  let assemblyFormat = "$target attr-dict `:` functional-type($target, results)";
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::transform::TransformRewriter &rewriter,
+        ::mlir::FunctionOpInterface target,
+        ::mlir::transform::ApplyToEachResultList &results,
+        ::mlir::transform::TransformState &state);
+  }];
+}
+
+def IREEApplyLoopIndependentCodeMotionOp : Op<Transform_Dialect, "iree.apply_licm",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     TransformEachOpTrait,
+     TransformOpInterface,
+     ReportTrackingListenerFailuresOpTrait]> {
+  let description = [{
+    Apply loop-independent code motion and single iteration loop promotion.
+    This transform is applied to all FuncOps within the target. Distinguished
+    from the upstream `apply_licm` op that only applies to a single loop with
+    the `iree` prefix.
+
+    #### Return modes
+
+    This operation does not consume the target handle and does not produce any
+    handle.
+  }];
+
+  let arguments = (ins TransformHandleTypeInterface:$target);
+  let assemblyFormat = "$target attr-dict `:` type($target)";
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::transform::TransformRewriter &rewriter,
+        ::mlir::Operation *target,
         ::mlir::transform::ApplyToEachResultList &results,
         ::mlir::transform::TransformState &state);
   }];
@@ -291,58 +379,70 @@ def IREEEliminateEmptyTensorsOp : Op<
   }];
 }
 
-def ForallToWorkgroupOp : Op<Transform_Dialect,
-    "iree.forall_to_workgroup",
+def PopulateWorkgroupCountRegionUsingNumThreadsSliceOp :
+    Op<Transform_Dialect, "iree.populate_workgroup_count_region_using_num_threads_slice",
+      [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+       TransformEachOpTrait,
+       TransformOpInterface,
+       ReportTrackingListenerFailuresOpTrait]> {
+  let description = [{
+    Populate the workgroup_count region on the `hal.executable.export` op.
+
+    The default dispatch region formation expects that the workgroup count
+    be computed from within the dispatch by using a program slice. The utility
+    method `lowerWorkgroupCountFromSliceOp` handles populating the
+    workgroup count region given the values in the dispatch that represent the
+    number of workgroups. This transform op calls the underlying function using
+    the `num_threads` value from the `scf.for_all` op that distributes the work
+    to different workgroups.
+  }];
+
+  let arguments = (ins TransformHandleTypeInterface:$for_all_op);
+  let results = (outs);
+  let assemblyFormat = [{
+    attr-dict $for_all_op `:` functional-type($for_all_op, results)
+  }];
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+      ::mlir::transform::TransformRewriter &rewriter,
+      ::mlir::Operation *target,
+      ::mlir::transform::ApplyToEachResultList &results,
+      ::mlir::transform::TransformState &state);
+  }];
+}
+
+def ReduceSharedMemoryBankConflictsOp :  Op<Transform_Dialect, "iree.reduce_shared_memory_bank_conflicts",
     [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
      TransformEachOpTrait,
      TransformOpInterface,
      ReportTrackingListenerFailuresOpTrait]> {
+  let summary = "Add padding to 'memref.alloc' ops reduce shared memory bank conflicts";
   let description = [{
-    Target the whole hal.executable_variant op and rewrite the unique topLevel
-    scf.forall to distributed workgroup_id and workgroup_count.
+    The `paddingSizeBits` argument should be picked based on the target
+    architecture, striking balance between minimizing bank conflicts and keeping
+    the data aligned. Smaller values (close to the bank bitwidth) achieve the
+    former, while larger (~= widest load size) the latter. We want to **misalign**
+    the rows, but not too much. For gfx942, 64 is a good default.
 
-    The mapping of threads to workgroup_id is currently one-to-one and in order.
-    Only **bufferized** scf.forall are currently supported.
-    Only scf.forall distributed to **at most 3 dimensions** are currently
-    supported.
+    #### Return modes
 
-    Return modes:
-    =============
-    This operation ignores non-Func ops and drops them in the return.
-
-    If no unique scf.forall topLevel operation is found, then the
-    transform definitely fails.
-    If the unique topLevel scf.forall has results (i.e. tensors), then
-    the transform definitely fails.
-
-    If the unique topLevel scf.forall maps to a dynamic number of
-    threads, then the transform definitely fails. This is a temporary
-    limitation until the backward slice computing scf.forall.num_threads
-    can be extracted into the hal::executable_export workgroup_count region.
-    This region may require arbitrary computations and cannot magically match
-    what the `stream.cmd.dispatch` has already imposed on us at a distance.
-    For now we must specify the number of values properly when applying the
-    topLevel tile_using_forall.
-
-    If the unique topLevel scf.forall operation contained within the
-    FuncOp referred to by the `target` transform handle lowers to workgroup
-    properly, the transform succeeds.
-
-    Otherwise the transform definitely fails.
-
-    This transform does not consume its input handle and produces no result.
+    This transform does not consume the target handle and always return success.
   }];
 
-  let arguments = (ins TransformHandleTypeInterface:$target);
+  let arguments = (
+      ins TransformHandleTypeInterface:$target,
+          DefaultValuedOptionalAttr<I64Attr, "64">:$padding_size_bits
+  );
   let results = (outs);
 
-  let assemblyFormat = "$target attr-dict `:` functional-type($target, results)";
+  let assemblyFormat = "$target attr-dict `:` functional-type(operands, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
         ::mlir::transform::TransformRewriter &rewriter,
-        ::mlir::FunctionOpInterface target,
+        ::mlir::FunctionOpInterface funcOp,
         ::mlir::transform::ApplyToEachResultList &results,
         ::mlir::transform::TransformState &state);
   }];
@@ -421,37 +521,80 @@ def ShareForallOperandsOp : Op<
   }];
 }
 
-def IREEPopulateWorkgroupCountRegionUsingNumThreadsSliceOp :
-    Op<Transform_Dialect, "iree.populate_workgroup_count_region_using_num_threads_slice",
-      [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-       TransformEachOpTrait,
-       TransformOpInterface,
-       ReportTrackingListenerFailuresOpTrait]> {
+def TestGpuVectorDistribution :
+  Op<Transform_Dialect, "iree.test_gpu_vector_distribution",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     TransformEachOpTrait,
+     TransformOpInterface,
+     ReportTrackingListenerFailuresOpTrait]> {
   let description = [{
-    Populate the workgroup_count region on the `hal.executable.export` op.
+    Run GPUVectorDistribution on the target as the root.
 
-    The default dispatch region formation expects that the workgroup count
-    be computed from within the dispatch by using a program slice. The utility
-    method `lowerWorkgroupCountFromSliceOp` handles populating the
-    workgroup count region given the values in the dispatch that represent the
-    number of workgroups. This transform op calls the underlying function using
-    the `num_threads` value from the `scf.for_all` op that distributes the work
-    to different workgroups.
-  }];
+    The anchor points are set by using the attribute
+    "__vector_layout_test_anchor_operand_x" and
+    "__vector_layout_test_anchor_result_x", where "x" is the operand/result
+    number.
 
-  let arguments = (ins TransformHandleTypeInterface:$for_all_op);
-  let results = (outs);
-  let assemblyFormat = [{
-    attr-dict $for_all_op `:` functional-type($for_all_op, results)
-  }];
-  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
-  let extraClassDeclaration = [{
-    ::mlir::DiagnosedSilenceableFailure applyToOne(
-      ::mlir::transform::TransformRewriter &rewriter,
-      ::mlir::Operation *target,
-      ::mlir::transform::ApplyToEachResultList &results,
-      ::mlir::transform::TransformState &state);
-  }];
+    The distribution is done for a single warp using gpu.thread x as the lane
+    ID. The optional experimental attribute enabled experimental distribution
+    patterns.
+
+    #### Return modes
+
+    This transform does not consume the target handle and always return success.
+    }];
+
+    let arguments = (ins TransformHandleTypeInterface:$target,
+                         DefaultValuedOptionalAttr<BoolAttr, "false">:$experimental);
+    let results = (outs);
+
+    let assemblyFormat = [{ $target attr-dict `:` type($target)}];
+    let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+
+    let extraClassDeclaration = [{
+      ::mlir::DiagnosedSilenceableFailure applyToOne(
+          ::mlir::transform::TransformRewriter &rewriter,
+          ::mlir::FunctionOpInterface funcOp,
+          ::mlir::transform::ApplyToEachResultList &results,
+          ::mlir::transform::TransformState &state);
+    }];
+}
+
+def TestVectorLayoutAnalysisOp :
+  Op<Transform_Dialect, "iree.test_vector_layout_analysis",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     TransformEachOpTrait,
+     TransformOpInterface,
+     ReportTrackingListenerFailuresOpTrait]> {
+  let description = [{
+    Run VectorLayoutAnalysis on the target as the root.
+
+    The anchor points are set by using the attribute
+    "__vector_layout_test_anchor_operand_x" and
+    "__vector_layout_test_anchor_result_x", where "x" is the operand/result
+    number.
+
+    The analysis emits remarks for the layout for each SSA value infered
+    on it's owning operation.
+
+    #### Return modes
+
+    This transform does not consume the target handle and always return success.
+    }];
+
+    let arguments = (ins TransformHandleTypeInterface:$target);
+    let results = (outs);
+
+    let assemblyFormat = [{ $target attr-dict `:` type($target)}];
+    let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+
+    let extraClassDeclaration = [{
+      ::mlir::DiagnosedSilenceableFailure applyToOne(
+          ::mlir::transform::TransformRewriter &rewriter,
+          ::mlir::FunctionOpInterface funcOp,
+          ::mlir::transform::ApplyToEachResultList &results,
+          ::mlir::transform::TransformState &state);
+    }];
 }
 
 def WorkgroupSwizzleOp :  Op<Transform_Dialect, "iree.workgroup_swizzle",
@@ -492,147 +635,6 @@ def WorkgroupSwizzleOp :  Op<Transform_Dialect, "iree.workgroup_swizzle",
     ::mlir::DiagnosedSilenceableFailure applyToOne(
         ::mlir::transform::TransformRewriter &rewriter,
         ::mlir::FunctionOpInterface funcOp,
-        ::mlir::transform::ApplyToEachResultList &results,
-        ::mlir::transform::TransformState &state);
-  }];
-}
-
-def ReduceSharedMemoryBankConflictsOp :  Op<Transform_Dialect, "iree.reduce_shared_memory_bank_conflicts",
-    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-     TransformEachOpTrait,
-     TransformOpInterface,
-     ReportTrackingListenerFailuresOpTrait]> {
-  let summary = "Add padding to 'memref.alloc' ops reduce shared memory bank conflicts";
-  let description = [{
-    The `paddingSizeBits` argument should be picked based on the target
-    architecture, striking balance between minimizing bank conflicts and keeping
-    the data aligned. Smaller values (close to the bank bitwidth) achieve the
-    former, while larger (~= widest load size) the latter. We want to **misalign**
-    the rows, but not too much. For gfx942, 64 is a good default.
-
-    #### Return modes
-
-    This transform does not consume the target handle and always return success.
-  }];
-
-  let arguments = (
-      ins TransformHandleTypeInterface:$target,
-          DefaultValuedOptionalAttr<I64Attr, "64">:$padding_size_bits
-  );
-  let results = (outs);
-
-  let assemblyFormat = "$target attr-dict `:` functional-type(operands, results)";
-  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
-
-  let extraClassDeclaration = [{
-    ::mlir::DiagnosedSilenceableFailure applyToOne(
-        ::mlir::transform::TransformRewriter &rewriter,
-        ::mlir::FunctionOpInterface funcOp,
-        ::mlir::transform::ApplyToEachResultList &results,
-        ::mlir::transform::TransformState &state);
-  }];
-}
-
-def TestVectorLayoutAnalysisOp :
-  Op<Transform_Dialect, "iree.test_vector_layout_analysis",
-    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-     TransformEachOpTrait,
-     TransformOpInterface,
-     ReportTrackingListenerFailuresOpTrait]> {
-  let description = [{
-    Run VectorLayoutAnalysis on the target as the root.
-
-    The anchor points are set by using the attribute
-    "__vector_layout_test_anchor_operand_x" and
-    "__vector_layout_test_anchor_result_x", where "x" is the operand/result
-    number.
-
-    The analysis emits remarks for the layout for each SSA value infered
-    on it's owning operation.
-
-    #### Return modes
-
-    This transform does not consume the target handle and always return success.
-    }];
-
-    let arguments = (ins TransformHandleTypeInterface:$target);
-    let results = (outs);
-
-    let assemblyFormat = [{ $target attr-dict `:` type($target)}];
-    let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
-
-    let extraClassDeclaration = [{
-      ::mlir::DiagnosedSilenceableFailure applyToOne(
-          ::mlir::transform::TransformRewriter &rewriter,
-          ::mlir::FunctionOpInterface funcOp,
-          ::mlir::transform::ApplyToEachResultList &results,
-          ::mlir::transform::TransformState &state);
-    }];
-}
-
-def TestGpuVectorDistribution :
-  Op<Transform_Dialect, "iree.test_gpu_vector_distribution",
-    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-     TransformEachOpTrait,
-     TransformOpInterface,
-     ReportTrackingListenerFailuresOpTrait]> {
-  let description = [{
-    Run GPUVectorDistribution on the target as the root.
-
-    The anchor points are set by using the attribute
-    "__vector_layout_test_anchor_operand_x" and
-    "__vector_layout_test_anchor_result_x", where "x" is the operand/result
-    number.
-
-    The distribution is done for a single warp using gpu.thread x as the lane
-    ID. The optional experimental attribute enabled experimental distribution
-    patterns.
-
-    #### Return modes
-
-    This transform does not consume the target handle and always return success.
-    }];
-
-    let arguments = (ins TransformHandleTypeInterface:$target,
-                         DefaultValuedOptionalAttr<BoolAttr, "false">:$experimental);
-    let results = (outs);
-
-    let assemblyFormat = [{ $target attr-dict `:` type($target)}];
-    let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
-
-    let extraClassDeclaration = [{
-      ::mlir::DiagnosedSilenceableFailure applyToOne(
-          ::mlir::transform::TransformRewriter &rewriter,
-          ::mlir::FunctionOpInterface funcOp,
-          ::mlir::transform::ApplyToEachResultList &results,
-          ::mlir::transform::TransformState &state);
-    }];
-}
-
-def GpuDistributeSharedMemoryCopyOp :
-  Op<Transform_Dialect, "iree.gpu_distribute_shared_memory_copy",
-    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
-     TransformOpInterface, TransformEachOpTrait]> {
-  let summary = "Distribute shared memory copies";
-  let description = [{
-    Find copies to/from shared memory and distribute the copies based on the
-    workgroup size.
-
-    #### Return modes
-    This operation applies to the entire function and does not consume the
-    target handle. It always return success.
-  }];
-
-  let arguments = (ins TransformHandleTypeInterface:$target);
-  let results = (outs);
-
-  let assemblyFormat = "$target attr-dict `:` functional-type(operands, results)";
-  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
-
-  let extraClassDeclaration = [{
-    ::mlir::DiagnosedSilenceableFailure applyToOne(
-        ::mlir::transform::TransformRewriter &rewriter,
-        ::mlir::FunctionOpInterface target,
         ::mlir::transform::ApplyToEachResultList &results,
         ::mlir::transform::TransformState &state);
   }];

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/Common/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/Common/Common.cpp
@@ -34,7 +34,7 @@ using iree_compiler::IREE::transform_dialect::ForallToWorkgroupOp;
 using iree_compiler::IREE::transform_dialect::IREEBufferizeOp;
 using iree_compiler::IREE::transform_dialect::IREEEliminateEmptyTensorsOp;
 using iree_compiler::IREE::transform_dialect::
-    IREEPopulateWorkgroupCountRegionUsingNumThreadsSliceOp;
+    PopulateWorkgroupCountRegionUsingNumThreadsSliceOp;
 using transform::FuseIntoContainingOp;
 using transform::HoistLoopInvariantSubsetsOp;
 using transform::MatchOp;
@@ -151,7 +151,8 @@ void mlir::iree_compiler::buildCanonicalizationAndEnablingTransforms(
     if (populatePatternsFn)
       populatePatternsFn(b, loc);
   });
-  b.create<IREE::transform_dialect::ApplyLoopIndependentCodeMotionOp>(funcH);
+  b.create<IREE::transform_dialect::IREEApplyLoopIndependentCodeMotionOp>(
+      funcH);
   b.create<mlir::transform::ApplyCommonSubexpressionEliminationOp>(funcH);
 }
 
@@ -449,7 +450,7 @@ mlir::iree_compiler::buildReductionStrategyBlockDistribution(
           /*threadDimMapping=*/b.getArrayAttr(blockDimMapping));
 
   // Handle the workgroup count region.
-  b.create<IREEPopulateWorkgroupCountRegionUsingNumThreadsSliceOp>(
+  b.create<PopulateWorkgroupCountRegionUsingNumThreadsSliceOp>(
       tileResult.forallH);
 
   fillH =

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/Common.cpp
@@ -55,8 +55,6 @@ using iree_compiler::gpu::GPUModel;
 using iree_compiler::IREE::transform_dialect::EliminateGpuBarriersOp;
 using iree_compiler::IREE::transform_dialect::IREEBufferizeOp;
 using iree_compiler::IREE::transform_dialect::IREEEliminateEmptyTensorsOp;
-using iree_compiler::IREE::transform_dialect::
-    IREEPopulateWorkgroupCountRegionUsingNumThreadsSliceOp;
 using iree_compiler::IREE::transform_dialect::ShareForallOperandsOp;
 using iree_compiler::IREE::transform_dialect::SynchronizeLoopOp;
 using transform::FuseIntoContainingOp;
@@ -686,7 +684,8 @@ Value mlir::iree_compiler::gpu::buildBufferize(ImplicitLocOpBuilder &b,
   b.create<transform::ApplyPatternsOp>(funcH, [](OpBuilder &b, Location loc) {
     b.create<transform::ApplyCanonicalizationPatternsOp>(loc);
   });
-  b.create<IREE::transform_dialect::ApplyLoopIndependentCodeMotionOp>(funcH);
+  b.create<IREE::transform_dialect::IREEApplyLoopIndependentCodeMotionOp>(
+      funcH);
   b.create<mlir::transform::ApplyCommonSubexpressionEliminationOp>(funcH);
   b.create<IREEEliminateEmptyTensorsOp>(funcH);
   auto bufferizeOp = b.create<IREEBufferizeOp>(funcH, /*targetGpu=*/true);

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/ConvolutionImplicitGemmStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/ConvolutionImplicitGemmStrategy.cpp
@@ -53,7 +53,7 @@ using iree_compiler::IREE::transform_dialect::
     ApplyFoldReshapeIntoTensorHalInterfacePatternsOp;
 using iree_compiler::IREE::transform_dialect::EliminateGpuBarriersOp;
 using iree_compiler::IREE::transform_dialect::
-    IREEPopulateWorkgroupCountRegionUsingNumThreadsSliceOp;
+    PopulateWorkgroupCountRegionUsingNumThreadsSliceOp;
 using transform::ConvertConv2DToImg2ColOp;
 using transform::FuseIntoContainingOp;
 using transform::MatchOp;
@@ -238,7 +238,7 @@ buildConvolutionStrategyBlockDistribution(
           b.getArrayAttr(blockMapping.threadMapping));
 
   // Handle the workgroup count region.
-  b.create<IREEPopulateWorkgroupCountRegionUsingNumThreadsSliceOp>(
+  b.create<PopulateWorkgroupCountRegionUsingNumThreadsSliceOp>(
       tileResult.forallH);
 
   // Rematch the fill because earlier handle is invalidated.

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/MatmulTensorCoreStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/MatmulTensorCoreStrategy.cpp
@@ -51,7 +51,7 @@ using iree_compiler::gpu::MatmulStrategy;
 using iree_compiler::gpu::scaleUpByBitWidth;
 using iree_compiler::IREE::transform_dialect::EliminateGpuBarriersOp;
 using iree_compiler::IREE::transform_dialect::
-    IREEPopulateWorkgroupCountRegionUsingNumThreadsSliceOp;
+    PopulateWorkgroupCountRegionUsingNumThreadsSliceOp;
 using transform::MatchOp;
 using transform_ext::RegisterMatchCallbacksOp;
 
@@ -192,7 +192,7 @@ buildMatmulStrategyBlockDistribution(ImplicitLocOpBuilder &b, Value variantH,
           b.getArrayAttr(blockMapping.threadMapping));
 
   // Handle the workgroup count region.
-  b.create<IREEPopulateWorkgroupCountRegionUsingNumThreadsSliceOp>(
+  b.create<PopulateWorkgroupCountRegionUsingNumThreadsSliceOp>(
       tileResult.forallH);
 
   // TODO: handle trailing op.
@@ -330,7 +330,7 @@ buildBatchMatmulStrategyBlockDistribution(ImplicitLocOpBuilder &b,
           b.getArrayAttr(blockMapping.threadMapping));
 
   // Handle the workgroup count region.
-  b.create<IREEPopulateWorkgroupCountRegionUsingNumThreadsSliceOp>(
+  b.create<PopulateWorkgroupCountRegionUsingNumThreadsSliceOp>(
       tileResult.forallH);
   return std::make_tuple(tileResult.resultingFusedOpsHandles.front(),
                          tileResult.tiledOpH, tileResult.forallH);

--- a/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/PadStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformStrategies/GPU/PadStrategy.cpp
@@ -41,7 +41,7 @@ using iree_compiler::gpu::buildDistributeOnePadOrCopyWithNumThreads;
 using iree_compiler::gpu::buildDistributeOnePadOrCopyWithTileSizes;
 using iree_compiler::gpu::PadStrategy;
 using iree_compiler::IREE::transform_dialect::
-    IREEPopulateWorkgroupCountRegionUsingNumThreadsSliceOp;
+    PopulateWorkgroupCountRegionUsingNumThreadsSliceOp;
 using transform::MatchOp;
 using transform_ext::RegisterMatchCallbacksOp;
 
@@ -94,7 +94,7 @@ buildPadStrategyBlockDistribution(ImplicitLocOpBuilder &b, Value variantH,
       /*threadDimMapping=*/{blockY(ctx), blockX(ctx)}, /*foldIfBranch=*/true);
 
   // Step 3.Handle the workgroup count region.
-  b.create<IREEPopulateWorkgroupCountRegionUsingNumThreadsSliceOp>(forallH);
+  b.create<PopulateWorkgroupCountRegionUsingNumThreadsSliceOp>(forallH);
   return std::make_tuple(tiledPadH, forallH);
 }
 


### PR DESCRIPTION
Reorders the list of operations to be alphabetical and updates the naming of op classes with the IREE prefix to more accurately reflect when it is an iree specific variant of an upstream op.