### PR TITLE
[Flow] Do not sink tensor.expand_shape past ops that can already fuse with a producer.

### DIFF
--- a/build_tools/pkgci/external_test_suite/pytorch_models_gpu_vulkan.json
+++ b/build_tools/pkgci/external_test_suite/pytorch_models_gpu_vulkan.json
@@ -9,7 +9,6 @@
     "skip_compile_tests": [],
     "skip_run_tests": [],
     "expected_compile_failures": [
-      "resnet50",
       "sdxl-prompt-encoder-tank",
       "sdxl-scheduled-unet-3-tank",
       "sdxl-vae-decode-tank",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD.bazel
@@ -60,6 +60,7 @@ iree_compiler_cc_library(
         "OutlineDispatchRegions.cpp",
         "Passes.cpp",
         "RegionOpUtils.cpp",
+        "SinkReshapes.cpp",
         "SplitReduction.cpp",
         "TensorPadToTensorInsertSlice.cpp",
         "TopLevelSCFToCFG.cpp",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -60,6 +60,7 @@ iree_cc_library(
     "OutlineDispatchRegions.cpp"
     "Passes.cpp"
     "RegionOpUtils.cpp"
+    "SinkReshapes.cpp"
     "SplitReduction.cpp"
     "TensorPadToTensorInsertSlice.cpp"
     "TopLevelSCFToCFG.cpp"

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -149,6 +149,12 @@ void addDispatchRegionCreationPreprocessingPasses(OpPassManager &passManager) {
             clEnableElementWiseFuseMultiReduction});
       })
       .addPass(mlir::createCanonicalizerPass)
+      .addPass(mlir::createCSEPass)
+
+      // 4. After elementwise operation fusion sink reshapes that block
+      //    producer-consumer fusion.
+      .addPass(createSinkReshapesPass)
+      .addPass(mlir::createCanonicalizerPass)
       .addPass(mlir::createCSEPass);
 }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -368,6 +368,15 @@ def OutlineDispatchRegionsPass :
   ];
 }
 
+def SinkReshapesPass :
+    Pass<"iree-flow-sink-reshapes", ""> {
+  let summary = "Sink reshapes to allow for compute op -> consumer fusion";
+  let dependentDialects = [
+    "arith::ArithDialect",
+    "affine::AffineDialect",
+  ];
+}
+
 def SplitReductionPass :
     Pass<"iree-flow-split-reduction-ops", ""> {
   let summary = "Split reduction dimension to increase parallelism.";

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/SinkReshapes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/SinkReshapes.cpp
@@ -1,0 +1,85 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===--- SinkReshapes.cpp --- Pass to sink reshapes -----------------------===//
+//
+// This pass sinks reshapes (tensor.expand_shape/tensor.collapse_shape) that
+// block producer-consumer fusion. These reshapes are generally produced by
+// the `BubbleExpandShapes.cpp` pass that propagates reshapes towards the
+// arguments, but get blocked on named op.
+//
+//===----------------------------------------------------------------------===//
+
+#include "iree/compiler/Dialect/Flow/Transforms/FusionUtils.h"
+#include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
+#include "iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h"
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "llvm/Support/Debug.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/Tensor/Transforms/Transforms.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "iree-flow-sink-reshapes"
+
+namespace mlir::iree_compiler::IREE::Flow {
+
+#define GEN_PASS_DEF_SINKRESHAPESPASS
+#include "iree/compiler/Dialect/Flow/Transforms/Passes.h.inc"
+
+namespace {
+
+class SinkReshapesPass : public impl::SinkReshapesPassBase<SinkReshapesPass> {
+public:
+  using Base::Base;
+
+  void runOnOperation() override;
+};
+
+/// Control function to check if an `tensor.expand_shape` (which is producer of
+/// `opOperand`) should be pushed past the `genericOp` (which is the consumer of
+/// `opOperand`).
+static bool shouldSinkExpandShapeOp(OpOperand *opOperand) {
+  auto reshapeOp =
+      dyn_cast<tensor::ExpandShapeOp>(opOperand->get().getDefiningOp());
+  if (!reshapeOp) {
+    return false;
+  }
+  Operation *consumer = opOperand->getOwner();
+  if (!isNonNullAndOutsideDispatch({reshapeOp, consumer})) {
+    return false;
+  }
+
+  // Do not sink if consumer is a contraction/matmul like op.
+  if (auto linalgConsumerOp = dyn_cast<linalg::LinalgOp>(consumer)) {
+    if (linalg::isaContractionOpInterface(linalgConsumerOp))
+      return false;
+  }
+
+  return llvm::isa_and_nonnull<linalg::LinalgOp, tensor::UnPackOp,
+                               LinalgExt::UnsetEncodingOp>(
+      reshapeOp.getSrc().getDefiningOp());
+}
+
+void SinkReshapesPass::runOnOperation() {
+  MLIRContext *context = &getContext();
+
+  RewritePatternSet sinkReshapePatterns(context);
+  linalg::populateFoldReshapeOpsByCollapsingPatterns(sinkReshapePatterns,
+                                                     shouldSinkExpandShapeOp);
+  // Add patterns to fold `tensor.empty` and reshape ops.
+  tensor::populateFoldTensorEmptyPatterns(sinkReshapePatterns);
+  if (failed(applyPatternsAndFoldGreedily(getOperation(),
+                                          std::move(sinkReshapePatterns)))) {
+    getOperation()->emitOpError("failed to sink reshape ops");
+    return signalPassFailure();
+  }
+}
+
+} // namespace
+
+} // namespace mlir::iree_compiler::IREE::Flow

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD.bazel
@@ -47,6 +47,7 @@ iree_lit_test_suite(
             "pad_fusion_with_consumer.mlir",
             "pad_fusion_with_producer.mlir",
             "pipeline_tests.mlir",
+            "sink_reshapes.mlir",
             "split_reduction.mlir",
             "tensor_pad_to_tensor_insert_slice.mlir",
             "top_level_scf_to_cfg.mlir",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
@@ -45,6 +45,7 @@ iree_lit_test_suite(
     "pad_fusion_with_consumer.mlir"
     "pad_fusion_with_producer.mlir"
     "pipeline_tests.mlir"
+    "sink_reshapes.mlir"
     "split_reduction.mlir"
     "tensor_pad_to_tensor_insert_slice.mlir"
     "top_level_scf_to_cfg.mlir"

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/sink_reshapes.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/sink_reshapes.mlir
@@ -1,0 +1,129 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-flow-sink-reshapes))" --split-input-file %s | FileCheck %s
+
+/// If for a `tensor.expand_shape` -> consumer pair if the consumer
+/// can already be fused with an op by tile and fuse, do nothing. In
+/// this example that would limit the sinking of `tensor.expand_shape`
+/// operation by just one step
+
+func.func @do_not_sink_across_already_fusable_ops(
+    %arg0 : tensor<?x?xf16>, %arg1 : tensor<?x?xf16>, 
+    %arg2 : tensor<?xf16>, %arg3 : tensor<2x?x?xf32>) -> tensor<2x?x?xf16> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %m = tensor.dim %arg0, %c0 : tensor<?x?xf16>
+  %n = tensor.dim %arg1, %c1 : tensor<?x?xf16>
+  %cst = arith.constant 0.0: f32
+  %0 = tensor.empty(%m, %n) : tensor<?x?xf32>
+  %m_by_2 = arith.divsi %m, %c2 : index
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<?x?xf32>) -> tensor<?x?xf32>
+  %2 = linalg.matmul_transpose_b ins(%arg0, %arg1 : tensor<?x?xf16>, tensor<?x?xf16>)
+      outs(%1 : tensor<?x?xf32>) -> tensor<?x?xf32>
+  %3 = tensor.expand_shape %2 [[0, 1], [2]] : tensor<?x?xf32> into tensor<2x?x?xf32>
+  %4 = tensor.empty(%m_by_2, %n) : tensor<2x?x?xf16>
+  %5 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
+                       affine_map<(d0, d1, d2) -> (d2)>,
+                       affine_map<(d0, d1, d2) -> (d0, d1, d2)>],
+      iterator_types = ["parallel", "parallel", "parallel"]}
+      ins(%3, %arg2 : tensor<2x?x?xf32>, tensor<?xf16>)
+      outs(%4 : tensor<2x?x?xf16>) {
+    ^bb0(%b0 : f32, %b1 : f16, %b2 : f16):
+      %6 = arith.truncf %b0 : f32 to f16
+      %7 = arith.addf %6, %b1 : f16
+      linalg.yield %7 : f16
+  } -> tensor<2x?x?xf16>
+  %6 = tensor.empty(%m_by_2) : tensor<2x?xf32>
+  %7 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
+                       affine_map<(d0, d1, d2) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel", "reduction"]}
+      ins(%arg3 : tensor<2x?x?xf32>)
+      outs(%6 : tensor<2x?xf32>) {
+    ^bb0(%b0 : f32, %b1 : f32):
+      %8 = arith.addf %b0, %b1 : f32
+      linalg.yield %8 : f32
+  } -> tensor<2x?xf32>
+  %8 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1)>,
+                       affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
+                       affine_map<(d0, d1, d2) -> (d0, d1, d2)>],
+      iterator_types = ["parallel", "parallel", "parallel"]}
+      ins(%7, %5 : tensor<2x?xf32>, tensor<2x?x?xf16>)
+      outs(%4 : tensor<2x?x?xf16>) {
+    ^bb0(%b0 : f32, %b1 : f16, %b2 : f16) :
+      %9 = arith.truncf %b0 : f32 to f16
+      %10 = arith.addf %9, %b1 : f16
+      linalg.yield %10 : f16
+  } -> tensor<2x?x?xf16>
+  func.return %8 : tensor<2x?x?xf16>
+}
+
+// CHECK-LABEL: func @do_not_sink_across_already_fusable_ops
+//       CHECK:   %[[GEMM:.+]] = linalg.matmul_transpose_b
+//       CHECK:   %[[GENERIC1:.+]] = linalg.generic
+//  CHECK-SAME:       ins(%[[GEMM]],
+//       CHECK:   %[[EXPAND:.+]] = tensor.expand_shape %[[GENERIC1]]
+//       CHECK:   %[[REDUCE:.+]] = linalg.generic
+//  CHECK-SAME:       iterator_types = ["parallel", "parallel", "reduction"]
+//       CHECK:   %[[RETURN:.+]] = linalg.generic
+//  CHECK-SAME:       ins(%[[REDUCE]], %[[EXPAND]] :
+//       CHECK:   return %[[RETURN]]
+
+// -----
+
+/// Do not sink the operations past dequantization-like operations.
+/// The dequantize operations must be cloned into all consumers, which
+/// will be prevented by the reshape being pushed down.
+
+func.func @do_not_sink_across_dequantize_ops(%arg0: tensor<?x?xf32>) -> tensor<2x?xf32> {
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %cst = arith.constant 0.0 : f32
+  %m = tensor.dim %arg0, %c1 : tensor<?x?xf32>
+  %n = tensor.dim %arg0, %c2 : tensor<?x?xf32>
+  %empty = tensor.empty(%m) : tensor<?xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<?xf32>) -> tensor<?xf32>
+  %reduce =  linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                       affine_map<(d0, d1) -> (d0)>],
+                  iterator_types = ["parallel", "reduction"]}
+      ins(%arg0 : tensor<?x?xf32>) outs(%fill : tensor<?xf32>) {
+    ^bb0(%b0: f32, %b1 : f32):
+      %0 = arith.addf %b0, %b1 : f32
+      linalg.yield %0 : f32
+  } -> tensor<?xf32>
+  %m_by_2 = arith.divsi %m, %c2 : index
+  %expand = tensor.expand_shape %reduce [[0, 1]] : tensor<?xf32> into tensor<2x?xf32>
+  %empty1 = tensor.empty(%m_by_2) : tensor<2x?xf16>
+  %generic = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                       affine_map<(d0, d1) -> (d0, d1)>],
+                  iterator_types = ["parallel", "parallel"]}
+      ins(%expand : tensor<2x?xf32>) outs(%empty1 : tensor<2x?xf16>) {
+    ^bb0(%b0 : f32, %b1 : f16):
+      %0 = arith.truncf %b0 : f32 to f16
+      linalg.yield %0 : f16
+  } -> tensor<2x?xf16>
+  %empty2 = tensor.empty(%m_by_2) : tensor<2x?xf32>
+  %dequant = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                       affine_map<(d0, d1) -> (d0, d1)>],
+                  iterator_types = ["parallel", "parallel"]}
+      ins(%generic : tensor<2x?xf16>) outs(%empty2 : tensor<2x?xf32>) {
+    ^bb0(%b0 : f16, %b1 : f32):
+      %0 = arith.extf %b0 : f16 to f32
+      linalg.yield %0 : f32
+  } -> tensor<2x?xf32>
+  func.return %dequant : tensor<2x?xf32>
+}
+// CHECK-LABEL: func @do_not_sink_across_dequantize_ops
+//  CHECK-SAME:     %[[ARG0:.+]]: tensor<?x?xf32>
+//       CHECK:   %[[REDUCE:.+]] = linalg.generic
+//  CHECK-SAME:       ins(%[[ARG0]] :
+//       CHECK:   %[[QUANT:.+]] = linalg.generic
+//  CHECK-SAME:       ins(%[[REDUCE]] :
+//       CHECK:   %[[EXPAND:.+]] = tensor.expand_shape %[[QUANT]]
+//       CHECK:   %[[DEQUANT:.+]] = linalg.generic
+//  CHECK-SAME:       ins(%[[EXPAND]] :
+//       CHECK:   return %[[DEQUANT]]


### PR DESCRIPTION
After elementwise fusion and bubble up `tensor.expand_shape` pass
these operations need to be "sink" past some operations to facilitate
fusion of linalg operations that have reduction iterator types and
their elementwise consumers. Yet, if an elementwise operation is
already fusable with its producers (with reduction iterator type)
doing this sink hampers that fusion.

To facilitate maintanence of this pass it is split out of
`FusionOfTensorOps` and made a separate pass.