### PR TITLE
[runtime][cts] Add test waiting on a semaphore for finite time and fix Vulkan driver

### DIFF
--- a/runtime/src/iree/hal/cts/semaphore_test.h
+++ b/runtime/src/iree/hal/cts/semaphore_test.h
@@ -296,7 +296,49 @@ TEST_P(semaphore_test, WaitOnTheSameValueMultipleTimes) {
   iree_hal_semaphore_release(semaphore);
 }
 
-// TODO: test waiting for a finite amount of time.
+// Waiting for a finite amount of time.
+TEST_P(semaphore_test, WaitForFiniteTime) {
+  auto generic_test_fn = [this](auto wait_fn) {
+    iree_hal_semaphore_t* semaphore = this->CreateSemaphore();
+
+    // Wait before signaling and make sure the semaphore value has not changed.
+    IREE_ASSERT_STATUS_IS(IREE_STATUS_DEADLINE_EXCEEDED, wait_fn(semaphore));
+    CheckSemaphoreValue(semaphore, 0);
+
+    std::thread signaling_thread(
+        [&]() { IREE_ASSERT_OK(iree_hal_semaphore_signal(semaphore, 1)); });
+
+    // The semaphore must advance at some point.
+    while (true) {
+      iree_status_t status = wait_fn(semaphore);
+      // The semaphore either timed out or has advanced.
+      IREE_ASSERT_TRUE(iree_status_is_ok(status) ||
+                       iree_status_is_deadline_exceeded(status));
+      if (iree_status_is_deadline_exceeded(status)) continue;
+      CheckSemaphoreValue(semaphore, 1);
+      break;
+    }
+
+    signaling_thread.join();
+    iree_hal_semaphore_release(semaphore);
+  };
+
+  // Immediate timeout.
+  generic_test_fn([](iree_hal_semaphore_t* semaphore) {
+    return iree_hal_semaphore_wait(semaphore, 1, iree_immediate_timeout());
+  });
+
+  // Absolute timeout.
+  generic_test_fn([](iree_hal_semaphore_t* semaphore) {
+    return iree_hal_semaphore_wait(semaphore, 1,
+                                   iree_make_deadline(iree_time_now() + 1));
+  });
+
+  // Relative timeout.
+  generic_test_fn([](iree_hal_semaphore_t* semaphore) {
+    return iree_hal_semaphore_wait(semaphore, 1, iree_make_timeout_ns(1));
+  });
+}
 
 }  // namespace cts
 }  // namespace hal

--- a/runtime/src/iree/hal/drivers/metal/cts/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/metal/cts/CMakeLists.txt
@@ -23,6 +23,7 @@ iree_hal_cts_test_suite(
     # Disabled until fixing semaphore tests.
     # https://github.com/iree-org/iree/pull/17080#discussion_r1569867998
     "semaphore_submission"
+    "semaphore_test"
   LABELS
     driver=metal
 )

--- a/runtime/src/iree/hal/drivers/metal/shared_event.m
+++ b/runtime/src/iree/hal/drivers/metal/shared_event.m
@@ -149,7 +149,10 @@ static iree_status_t iree_hal_metal_shared_event_wait(iree_hal_semaphore_t* base
     apple_timeout_ns = DISPATCH_TIME_NOW;
   } else {
     iree_time_t now_ns = iree_time_now();
-    timeout_ns = deadline_ns < now_ns ? 0 : (uint64_t)(deadline_ns - now_ns);
+    if (deadline_ns < now_ns) {
+      return iree_status_from_code(IREE_STATUS_DEADLINE_EXCEEDED);
+    }
+    timeout_ns = (uint64_t)(deadline_ns - now_ns);
     apple_timeout_ns = dispatch_time(DISPATCH_TIME_NOW, timeout_ns);
   }
 
@@ -216,7 +219,10 @@ iree_status_t iree_hal_metal_shared_event_multi_wait(
     apple_timeout_ns = DISPATCH_TIME_NOW;
   } else {
     iree_time_t now_ns = iree_time_now();
-    timeout_ns = deadline_ns < now_ns ? 0 : (uint64_t)(deadline_ns - now_ns);
+    if (deadline_ns < now_ns) {
+      return iree_status_from_code(IREE_STATUS_DEADLINE_EXCEEDED);
+    }
+    timeout_ns = (uint64_t)(deadline_ns - now_ns);
     apple_timeout_ns = dispatch_time(DISPATCH_TIME_NOW, timeout_ns);
   }
 

--- a/runtime/src/iree/hal/drivers/metal/shared_event.m
+++ b/runtime/src/iree/hal/drivers/metal/shared_event.m
@@ -149,10 +149,7 @@ static iree_status_t iree_hal_metal_shared_event_wait(iree_hal_semaphore_t* base
     apple_timeout_ns = DISPATCH_TIME_NOW;
   } else {
     iree_time_t now_ns = iree_time_now();
-    if (deadline_ns < now_ns) {
-      return iree_status_from_code(IREE_STATUS_DEADLINE_EXCEEDED);
-    }
-    timeout_ns = (uint64_t)(deadline_ns - now_ns);
+    timeout_ns = deadline_ns < now_ns ? 0 : (uint64_t)(deadline_ns - now_ns);
     apple_timeout_ns = dispatch_time(DISPATCH_TIME_NOW, timeout_ns);
   }
 
@@ -219,10 +216,7 @@ iree_status_t iree_hal_metal_shared_event_multi_wait(
     apple_timeout_ns = DISPATCH_TIME_NOW;
   } else {
     iree_time_t now_ns = iree_time_now();
-    if (deadline_ns < now_ns) {
-      return iree_status_from_code(IREE_STATUS_DEADLINE_EXCEEDED);
-    }
-    timeout_ns = (uint64_t)(deadline_ns - now_ns);
+    timeout_ns = deadline_ns < now_ns ? 0 : (uint64_t)(deadline_ns - now_ns);
     apple_timeout_ns = dispatch_time(DISPATCH_TIME_NOW, timeout_ns);
   }
 

--- a/runtime/src/iree/hal/drivers/vulkan/native_semaphore.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/native_semaphore.cc
@@ -216,10 +216,7 @@ iree_status_t iree_hal_vulkan_native_semaphore_multi_wait(
     timeout_ns = 0;
   } else {
     iree_time_t now_ns = iree_time_now();
-    if (deadline_ns < now_ns) {
-      return iree_status_from_code(IREE_STATUS_DEADLINE_EXCEEDED);
-    }
-    timeout_ns = (uint64_t)(deadline_ns - now_ns);
+    timeout_ns = deadline_ns < now_ns ? 0 : (uint64_t)(deadline_ns - now_ns);
   }
 
   IREE_TRACE_ZONE_BEGIN(z0);

--- a/runtime/src/iree/testing/status_matchers.h
+++ b/runtime/src/iree/testing/status_matchers.h
@@ -325,6 +325,9 @@ inline internal::IsOkMatcherGenerator IsOk() {
 #define IREE_EXPECT_STATUS_IS(expected_code, expr)     \
   EXPECT_THAT(expr, ::iree::testing::status::StatusIs( \
                         static_cast<::iree::StatusCode>(expected_code)))
+#define IREE_ASSERT_STATUS_IS(expected_code, expr)     \
+  ASSERT_THAT(expr, ::iree::testing::status::StatusIs( \
+                        static_cast<::iree::StatusCode>(expected_code)))
 
 // Executes an expression that returns an iree::StatusOr<T>, and assigns the
 // contained variable to lhs if the error code is OK.


### PR DESCRIPTION
Fix Vulkan semaphore wait timeout if the timeout has already
passed. Don't check for a timeout on the host side.
Let Vulkan handle the timeout.
If the timeout has passed and the semaphore value is big enough,
we want an OK status to be returned.

Disable semaphore_test for Metal.