### PR TITLE
Run pytorch/models tests on AMDGPU with Vulkan.

### DIFF
--- a/.github/workflows/pkgci_regression_test_amdgpu_vulkan.yml
+++ b/.github/workflows/pkgci_regression_test_amdgpu_vulkan.yml
@@ -71,3 +71,57 @@ jobs:
               -n 4 -rpfE --timeout=30 --retries=2 --durations=20 \
               --config-files=build_tools/pkgci/external_test_suite/onnx_gpu_vulkan.json \
               --no-skip-tests-missing-files
+
+  # Note: this is a persistent runner with a local cache. Downloading all input
+  # files (50GB+) without a cache can take 20+ minutes.
+  linux_x86_64_models:
+    name: Linux (x86_64) Model Testing
+    runs-on: nodai-amdgpu-w7900-x86-64
+    env:
+      PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
+      IREERS_ARTIFACT_DIR: ${{ github.workspace }}/artifacts
+      VENV_DIR: ${{ github.workspace }}/venv
+      IREE_TEST_FILES: ~/iree_tests_cache
+    steps:
+      - name: Checking out IREE repository
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+        with:
+          submodules: false
+      - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1  # v4.7.0
+        with:
+          # Must match the subset of versions built in pkgci_build_packages.
+          python-version: '3.11'
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
+        with:
+          name: linux_x86_64_release_packages
+          path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
+      - name: Setup venv
+        run: |
+          ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
+            --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
+            --fetch-gh-workflow=${{ inputs.artifact_run_id }}
+
+      # Out of tree tests
+      - name: Check out external TestSuite repository
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+        with:
+          repository: nod-ai/SHARK-TestSuite
+          ref: d83c02dbecf7963320b5773ceb8ac3b3b7d90831
+          path: SHARK-TestSuite
+          submodules: false
+          lfs: true
+      - name: Install external TestSuite Python requirements
+        run: |
+          source ${VENV_DIR}/bin/activate
+          python -m pip install -r SHARK-TestSuite/iree_tests/requirements.txt
+      - name: Download remote files for real weight model tests
+        run: |
+          source ${VENV_DIR}/bin/activate
+          python SHARK-TestSuite/iree_tests/download_remote_files.py --root-dir pytorch/models
+      - name: Run external tests - Models with real weights
+        run: |
+          source ${VENV_DIR}/bin/activate
+          pytest SHARK-TestSuite/iree_tests/pytorch/models -k real_weights \
+               -rpfxE --timeout=600 --durations=0 \
+              --config-files=build_tools/pkgci/external_test_suite/pytorch_models_gpu_vulkan.json \
+              --no-skip-tests-missing-files

--- a/.github/workflows/pkgci_regression_test_cpu.yml
+++ b/.github/workflows/pkgci_regression_test_cpu.yml
@@ -72,9 +72,11 @@ jobs:
               -n auto -rpfE --timeout=30 --retries=2 --durations=20 \
               --config-files=build_tools/pkgci/external_test_suite/onnx_cpu_llvm_sync.json \
               --no-skip-tests-missing-files
-  # persistent runner with cache enabled for model testing
+
+  # Note: this is a persistent runner with a local cache. Downloading all input
+  # files (50GB+) without a cache can take 20+ minutes.
   linux_x86_64_models:
-    name: Linux (x86_64) Model Testing/Benchmark
+    name: Linux (x86_64) Model Testing
     runs-on: nodai-amdgpu-w7900-x86-64
     env:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages

--- a/build_tools/pkgci/external_test_suite/pytorch_models_gpu_vulkan.json
+++ b/build_tools/pkgci/external_test_suite/pytorch_models_gpu_vulkan.json
@@ -1,0 +1,18 @@
+{
+    "config_name": "gpu_vulkan",
+    "iree_compile_flags" : [
+      "--iree-hal-target-backends=vulkan-spirv"
+    ],
+    "iree_run_module_flags": [
+      "--device=vulkan"
+    ],
+    "skip_compile_tests": [],
+    "skip_run_tests": [],
+    "expected_compile_failures": [
+      "resnet50",
+      "sdxl-prompt-encoder-tank",
+      "sdxl-scheduled-unet-3-tank",
+      "sdxl-vae-decode-tank",
+    ],
+    "expected_run_failures": []
+}


### PR DESCRIPTION
Note that most of these tests fail to compile with default flags, so they are marked XFAIL. I also set the 'x' option in pytest logging to include the output for xfail tests.

I still want to refactor these jobs to use a matrix. Most of this is duplicated boilerplate.

ci-exactly: build_packages,regression_test_amdgpu_vulkan,regression_test_cpu