### PR TITLE
[python] Adds DLPack import and export support for BufferView.

### DIFF
--- a/runtime/bindings/python/CMakeLists.txt
+++ b/runtime/bindings/python/CMakeLists.txt
@@ -68,6 +68,7 @@ nanobind_add_module(iree_runtime_bindings_python_PyExtRt
   "io.cc"
   "hal.h"
   "hal.cc"
+  "local_dlpack.h"
   "loop.h"
   "loop.cc"
   "numpy_interop.h"

--- a/runtime/bindings/python/hal.h
+++ b/runtime/bindings/python/hal.h
@@ -111,6 +111,12 @@ struct ApiPtrAdapter<iree_hal_command_buffer_t> {
 class HalBuffer;
 class HalSemaphore;
 
+class HalBufferView
+    : public ApiRefCounted<HalBufferView, iree_hal_buffer_view_t> {
+ public:
+  py::str Repr();
+};
+
 class HalDevice : public ApiRefCounted<HalDevice, iree_hal_device_t> {
  public:
   iree_hal_allocator_t* allocator() {
@@ -130,6 +136,7 @@ class HalDevice : public ApiRefCounted<HalDevice, iree_hal_device_t> {
                     py::handle signal_semaphores);
   void QueueCopy(HalBuffer& src_buffer, HalBuffer& dst_buffer,
                  py::handle wait_semaphores, py::handle signal_semaphores);
+  HalBufferView FromDLPack(py::handle capsule);
 };
 
 class HalDriver : public ApiRefCounted<HalDriver, iree_hal_driver_t> {
@@ -164,12 +171,6 @@ struct HalShape {
   }
 
   std::vector<iree_hal_dim_t> s;
-};
-
-class HalBufferView
-    : public ApiRefCounted<HalBufferView, iree_hal_buffer_view_t> {
- public:
-  py::str Repr();
 };
 
 class HalBuffer : public ApiRefCounted<HalBuffer, iree_hal_buffer_t> {

--- a/runtime/bindings/python/hal.h
+++ b/runtime/bindings/python/hal.h
@@ -136,7 +136,9 @@ class HalDevice : public ApiRefCounted<HalDevice, iree_hal_device_t> {
                     py::handle signal_semaphores);
   void QueueCopy(HalBuffer& src_buffer, HalBuffer& dst_buffer,
                  py::handle wait_semaphores, py::handle signal_semaphores);
-  HalBufferView FromDLPack(py::handle capsule);
+  HalBufferView FromDLPackCapsule(py::object capsule);
+  py::object CreateDLPackCapsule(HalBufferView& bufferView,
+                                 int device_type_code, int device_id);
 };
 
 class HalDriver : public ApiRefCounted<HalDriver, iree_hal_driver_t> {

--- a/runtime/bindings/python/iree/runtime/_binding.pyi
+++ b/runtime/bindings/python/iree/runtime/_binding.pyi
@@ -187,6 +187,30 @@ class HalDevice:
     ) -> None: ...
     @property
     def allocator(self) -> HalAllocator: ...
+    def create_dlpack_capsule(self, buffer_view: HalBufferView, device_type_code: int, device_id: int) -> Any:
+        """Creates a DLPack capsule for the given buffer view with an explicit 
+        device type code and id.
+        
+        Note that IREE's HAL hierarchy does not match 1:1 with DLPack's view of
+        the world, which combines synchronization, memory access, and device
+        identity. As such, we presume that some higher level Python class will
+        represent "framework tensors" for interop in a way that interops
+        completely. Such an implementation would delegate to this facility
+        to create the low level capsule, having explicitly mapped the devices
+        and placed appropriate synchronization guards.
+        """
+        ...
+    def from_dlpack_capsule(self, capsule: Any) -> HalBufferView:
+        """Imports a DLPack tensor capsule and returns a corresponding buffer
+        view.
+        
+        As with create_dlpack_capsule, this is just a partial implementation
+        of concerns and presumes that the caller has chosen the correct
+        device and placed any synchronization barriers necessary for actually
+        using the result.
+        """
+        ...
+
 
 class HalDeviceLoopBridge:
     def __init__(self, device: HalDevice, loop: asyncio.BaseEventLoop): ...

--- a/runtime/bindings/python/iree/runtime/_binding.pyi
+++ b/runtime/bindings/python/iree/runtime/_binding.pyi
@@ -62,6 +62,7 @@ class FileHandle:
         Requires is_host_allocation.
         """
         ...
+
     @property
     def is_host_allocation(self) -> bool: ...
 
@@ -187,10 +188,12 @@ class HalDevice:
     ) -> None: ...
     @property
     def allocator(self) -> HalAllocator: ...
-    def create_dlpack_capsule(self, buffer_view: HalBufferView, device_type_code: int, device_id: int) -> Any:
-        """Creates a DLPack capsule for the given buffer view with an explicit 
+    def create_dlpack_capsule(
+        self, buffer_view: HalBufferView, device_type_code: int, device_id: int
+    ) -> Any:
+        """Creates a DLPack capsule for the given buffer view with an explicit
         device type code and id.
-        
+
         Note that IREE's HAL hierarchy does not match 1:1 with DLPack's view of
         the world, which combines synchronization, memory access, and device
         identity. As such, we presume that some higher level Python class will
@@ -200,17 +203,17 @@ class HalDevice:
         and placed appropriate synchronization guards.
         """
         ...
+
     def from_dlpack_capsule(self, capsule: Any) -> HalBufferView:
         """Imports a DLPack tensor capsule and returns a corresponding buffer
         view.
-        
+
         As with create_dlpack_capsule, this is just a partial implementation
         of concerns and presumes that the caller has chosen the correct
         device and placed any synchronization barriers necessary for actually
         using the result.
         """
         ...
-
 
 class HalDeviceLoopBridge:
     def __init__(self, device: HalDevice, loop: asyncio.BaseEventLoop): ...
@@ -358,6 +361,7 @@ class ParameterIndexEntry:
         Only valid if is_file. Returns the backing FileHandle and offset.
         """
         ...
+
     @property
     def file_view(self) -> memoryview:
         """Accesses a memoryview of the file contents.
@@ -365,6 +369,7 @@ class ParameterIndexEntry:
         Only valid if is_file and the file has host accessible storage.
         """
         ...
+
     @property
     def splat_pattern(self) -> bytes:
         """Accesses the splat pattern (if is_splat)."""

--- a/runtime/bindings/python/local_dlpack.h
+++ b/runtime/bindings/python/local_dlpack.h
@@ -1,0 +1,339 @@
+// Copied from https://github.com/dmlc/dlpack/tree/main/include/dlpack
+// at commit bbd2f4d32427e548797929af08cfe2a9cbb3cf12.
+// See Apache License: https://github.com/dmlc/dlpack/blob/main/LICENSE
+
+/*!
+ *  Copyright (c) 2017 by Contributors
+ * \file dlpack.h
+ * \brief The common header of DLPack.
+ */
+#ifndef DLPACK_DLPACK_H_
+#define DLPACK_DLPACK_H_
+
+/**
+ * \brief Compatibility with C++
+ */
+#ifdef __cplusplus
+#define DLPACK_EXTERN_C extern "C"
+#else
+#define DLPACK_EXTERN_C
+#endif
+
+/*! \brief The current major version of dlpack */
+#define DLPACK_MAJOR_VERSION 1
+
+/*! \brief The current minor version of dlpack */
+#define DLPACK_MINOR_VERSION 0
+
+/*! \brief DLPACK_DLL prefix for windows */
+#ifdef _WIN32
+#ifdef DLPACK_EXPORTS
+#define DLPACK_DLL __declspec(dllexport)
+#else
+#define DLPACK_DLL __declspec(dllimport)
+#endif
+#else
+#define DLPACK_DLL
+#endif
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * \brief The DLPack version.
+ *
+ * A change in major version indicates that we have changed the
+ * data layout of the ABI - DLManagedTensorVersioned.
+ *
+ * A change in minor version indicates that we have added new
+ * code, such as a new device type, but the ABI is kept the same.
+ *
+ * If an obtained DLPack tensor has a major version that disagrees
+ * with the version number specified in this header file
+ * (i.e. major != DLPACK_MAJOR_VERSION), the consumer must call the deleter
+ * (and it is safe to do so). It is not safe to access any other fields
+ * as the memory layout will have changed.
+ *
+ * In the case of a minor version mismatch, the tensor can be safely used as
+ * long as the consumer knows how to interpret all fields. Minor version
+ * updates indicate the addition of enumeration values.
+ */
+typedef struct {
+  /*! \brief DLPack major version. */
+  uint32_t major;
+  /*! \brief DLPack minor version. */
+  uint32_t minor;
+} DLPackVersion;
+
+/*!
+ * \brief The device type in DLDevice.
+ */
+#ifdef __cplusplus
+typedef enum : int32_t {
+#else
+typedef enum {
+#endif
+  /*! \brief CPU device */
+  kDLCPU = 1,
+  /*! \brief CUDA GPU device */
+  kDLCUDA = 2,
+  /*!
+   * \brief Pinned CUDA CPU memory by cudaMallocHost
+   */
+  kDLCUDAHost = 3,
+  /*! \brief OpenCL devices. */
+  kDLOpenCL = 4,
+  /*! \brief Vulkan buffer for next generation graphics. */
+  kDLVulkan = 7,
+  /*! \brief Metal for Apple GPU. */
+  kDLMetal = 8,
+  /*! \brief Verilog simulator buffer */
+  kDLVPI = 9,
+  /*! \brief ROCm GPUs for AMD GPUs */
+  kDLROCM = 10,
+  /*!
+   * \brief Pinned ROCm CPU memory allocated by hipMallocHost
+   */
+  kDLROCMHost = 11,
+  /*!
+   * \brief Reserved extension device type,
+   * used for quickly test extension device
+   * The semantics can differ depending on the implementation.
+   */
+  kDLExtDev = 12,
+  /*!
+   * \brief CUDA managed/unified memory allocated by cudaMallocManaged
+   */
+  kDLCUDAManaged = 13,
+  /*!
+   * \brief Unified shared memory allocated on a oneAPI non-partititioned
+   * device. Call to oneAPI runtime is required to determine the device
+   * type, the USM allocation type and the sycl context it is bound to.
+   *
+   */
+  kDLOneAPI = 14,
+  /*! \brief GPU support for next generation WebGPU standard. */
+  kDLWebGPU = 15,
+  /*! \brief Qualcomm Hexagon DSP */
+  kDLHexagon = 16,
+  /*! \brief Microsoft MAIA devices */
+  kDLMAIA = 17,
+} DLDeviceType;
+
+/*!
+ * \brief A Device for Tensor and operator.
+ */
+typedef struct {
+  /*! \brief The device type used in the device. */
+  DLDeviceType device_type;
+  /*!
+   * \brief The device index.
+   * For vanilla CPU memory, pinned memory, or managed memory, this is set to 0.
+   */
+  int32_t device_id;
+} DLDevice;
+
+/*!
+ * \brief The type code options DLDataType.
+ */
+typedef enum {
+  /*! \brief signed integer */
+  kDLInt = 0U,
+  /*! \brief unsigned integer */
+  kDLUInt = 1U,
+  /*! \brief IEEE floating point */
+  kDLFloat = 2U,
+  /*!
+   * \brief Opaque handle type, reserved for testing purposes.
+   * Frameworks need to agree on the handle data type for the exchange to be
+   * well-defined.
+   */
+  kDLOpaqueHandle = 3U,
+  /*! \brief bfloat16 */
+  kDLBfloat = 4U,
+  /*!
+   * \brief complex number
+   * (C/C++/Python layout: compact struct per complex number)
+   */
+  kDLComplex = 5U,
+  /*! \brief boolean */
+  kDLBool = 6U,
+} DLDataTypeCode;
+
+/*!
+ * \brief The data type the tensor can hold. The data type is assumed to follow
+ * the native endian-ness. An explicit error message should be raised when
+ * attempting to export an array with non-native endianness
+ *
+ *  Examples
+ *   - float: type_code = 2, bits = 32, lanes = 1
+ *   - float4(vectorized 4 float): type_code = 2, bits = 32, lanes = 4
+ *   - int8: type_code = 0, bits = 8, lanes = 1
+ *   - std::complex<float>: type_code = 5, bits = 64, lanes = 1
+ *   - bool: type_code = 6, bits = 8, lanes = 1 (as per common array library
+ * convention, the underlying storage size of bool is 8 bits)
+ */
+typedef struct {
+  /*!
+   * \brief Type code of base types.
+   * We keep it uint8_t instead of DLDataTypeCode for minimal memory
+   * footprint, but the value should be one of DLDataTypeCode enum values.
+   * */
+  uint8_t code;
+  /*!
+   * \brief Number of bits, common choices are 8, 16, 32.
+   */
+  uint8_t bits;
+  /*! \brief Number of lanes in the type, used for vector types. */
+  uint16_t lanes;
+} DLDataType;
+
+/*!
+ * \brief Plain C Tensor object, does not manage memory.
+ */
+typedef struct {
+  /*!
+   * \brief The data pointer points to the allocated data. This will be CUDA
+   * device pointer or cl_mem handle in OpenCL. It may be opaque on some device
+   * types. This pointer is always aligned to 256 bytes as in CUDA. The
+   * `byte_offset` field should be used to point to the beginning of the data.
+   *
+   * Note that as of Nov 2021, multiply libraries (CuPy, PyTorch, TensorFlow,
+   * TVM, perhaps others) do not adhere to this 256 byte aligment requirement
+   * on CPU/CUDA/ROCm, and always use `byte_offset=0`.  This must be fixed
+   * (after which this note will be updated); at the moment it is recommended
+   * to not rely on the data pointer being correctly aligned.
+   *
+   * For given DLTensor, the size of memory required to store the contents of
+   * data is calculated as follows:
+   *
+   * \code{.c}
+   * static inline size_t GetDataSize(const DLTensor* t) {
+   *   size_t size = 1;
+   *   for (tvm_index_t i = 0; i < t->ndim; ++i) {
+   *     size *= t->shape[i];
+   *   }
+   *   size *= (t->dtype.bits * t->dtype.lanes + 7) / 8;
+   *   return size;
+   * }
+   * \endcode
+   *
+   * Note that if the tensor is of size zero, then the data pointer should be
+   * set to `NULL`.
+   */
+  void* data;
+  /*! \brief The device of the tensor */
+  DLDevice device;
+  /*! \brief Number of dimensions */
+  int32_t ndim;
+  /*! \brief The data type of the pointer*/
+  DLDataType dtype;
+  /*! \brief The shape of the tensor */
+  int64_t* shape;
+  /*!
+   * \brief strides of the tensor (in number of elements, not bytes)
+   *  can be NULL, indicating tensor is compact and row-majored.
+   */
+  int64_t* strides;
+  /*! \brief The offset in bytes to the beginning pointer to data */
+  uint64_t byte_offset;
+} DLTensor;
+
+/*!
+ * \brief C Tensor object, manage memory of DLTensor. This data structure is
+ *  intended to facilitate the borrowing of DLTensor by another framework. It is
+ *  not meant to transfer the tensor. When the borrowing framework doesn't need
+ *  the tensor, it should call the deleter to notify the host that the resource
+ *  is no longer needed.
+ *
+ * \note This data structure is used as Legacy DLManagedTensor
+ *       in DLPack exchange and is deprecated after DLPack v0.8
+ *       Use DLManagedTensorVersioned instead.
+ *       This data structure may get renamed or deleted in future versions.
+ *
+ * \sa DLManagedTensorVersioned
+ */
+typedef struct DLManagedTensor {
+  /*! \brief DLTensor which is being memory managed */
+  DLTensor dl_tensor;
+  /*! \brief the context of the original host framework of DLManagedTensor in
+   *   which DLManagedTensor is used in the framework. It can also be NULL.
+   */
+  void* manager_ctx;
+  /*!
+   * \brief Destructor - this should be called
+   * to destruct the manager_ctx  which backs the DLManagedTensor. It can be
+   * NULL if there is no way for the caller to provide a reasonable destructor.
+   * The destructor deletes the argument self as well.
+   */
+  void (*deleter)(struct DLManagedTensor* self);
+} DLManagedTensor;
+
+// bit masks used in in the DLManagedTensorVersioned
+
+/*! \brief bit mask to indicate that the tensor is read only. */
+#define DLPACK_FLAG_BITMASK_READ_ONLY (1UL << 0UL)
+
+/*!
+ * \brief bit mask to indicate that the tensor is a copy made by the producer.
+ *
+ * If set, the tensor is considered solely owned throughout its lifetime by the
+ * consumer, until the producer-provided deleter is invoked.
+ */
+#define DLPACK_FLAG_BITMASK_IS_COPIED (1UL << 1UL)
+
+/*!
+ * \brief A versioned and managed C Tensor object, manage memory of DLTensor.
+ *
+ * This data structure is intended to facilitate the borrowing of DLTensor by
+ * another framework. It is not meant to transfer the tensor. When the borrowing
+ * framework doesn't need the tensor, it should call the deleter to notify the
+ * host that the resource is no longer needed.
+ *
+ * \note This is the current standard DLPack exchange data structure.
+ */
+struct DLManagedTensorVersioned {
+  /*!
+   * \brief The API and ABI version of the current managed Tensor
+   */
+  DLPackVersion version;
+  /*!
+   * \brief the context of the original host framework.
+   *
+   * Stores DLManagedTensorVersioned is used in the
+   * framework. It can also be NULL.
+   */
+  void* manager_ctx;
+  /*!
+   * \brief Destructor.
+   *
+   * This should be called to destruct manager_ctx which holds the
+   * DLManagedTensorVersioned. It can be NULL if there is no way for the caller
+   * to provide a reasonable destructor. The destructor deletes the argument
+   * self as well.
+   */
+  void (*deleter)(struct DLManagedTensorVersioned* self);
+  /*!
+   * \brief Additional bitmask flags information about the tensor.
+   *
+   * By default the flags should be set to 0.
+   *
+   * \note Future ABI changes should keep everything until this field
+   *       stable, to ensure that deleter can be correctly called.
+   *
+   * \sa DLPACK_FLAG_BITMASK_READ_ONLY
+   * \sa DLPACK_FLAG_BITMASK_IS_COPIED
+   */
+  uint64_t flags;
+  /*! \brief DLTensor which is being memory managed */
+  DLTensor dl_tensor;
+};
+
+#ifdef __cplusplus
+}  // DLPACK_EXTERN_C
+#endif
+#endif  // DLPACK_DLPACK_H_

--- a/runtime/bindings/python/tests/hal_test.py
+++ b/runtime/bindings/python/tests/hal_test.py
@@ -488,8 +488,8 @@ class DeviceHalTest(unittest.TestCase):
 
 class DeviceDLPackTest(unittest.TestCase):
     """Tests low level DLPack import/export against the CPU HAL backend.
-    
-    This test leverages the fact that numpy is a reasonable dlpack 
+
+    This test leverages the fact that numpy is a reasonable dlpack
     producer/consumer. It has the caveat that our low level support does not
     allow import of non page aligned data, so we have to take some extra
     steps to prep it. For pure CPU/Numpy import/export, we have better
@@ -497,6 +497,7 @@ class DeviceDLPackTest(unittest.TestCase):
     value, as it exercises code paths that are otherwise only accessible
     on devices.
     """
+
     def setUp(self):
         super().setUp()
         self.device = iree.runtime.get_device("local-task")

--- a/runtime/bindings/python/tests/hal_test.py
+++ b/runtime/bindings/python/tests/hal_test.py
@@ -486,5 +486,151 @@ class DeviceHalTest(unittest.TestCase):
         iree.runtime.HalFence.create_at(sem, 1).wait()
 
 
+class DeviceDLPackTest(unittest.TestCase):
+    """Tests low level DLPack import/export against the CPU HAL backend.
+    
+    This test leverages the fact that numpy is a reasonable dlpack 
+    producer/consumer. It has the caveat that our low level support does not
+    allow import of non page aligned data, so we have to take some extra
+    steps to prep it. For pure CPU/Numpy import/export, we have better
+    supported paths than this, but we leverage it here for its testing
+    value, as it exercises code paths that are otherwise only accessible
+    on devices.
+    """
+    def setUp(self):
+        super().setUp()
+        self.device = iree.runtime.get_device("local-task")
+        self.allocator = self.device.allocator
+        gc.collect()
+
+    def roundtrip(self, input_array, element_type):
+        # We have top copy the input array into our own buffer to ensure
+        # alignment (dlpack import/export require aligned data).
+        orig_bv = self.allocator.allocate_buffer_copy(
+            memory_type=iree.runtime.MemoryType.DEVICE_LOCAL,
+            allowed_usage=iree.runtime.BufferUsage.DEFAULT,
+            device=self.device,
+            buffer=input_array,
+            element_type=element_type,
+        )
+        aligned_input_array = orig_bv.map().asarray(
+            input_array.shape, input_array.dtype
+        )
+
+        # Export the __dlpack__ capsule from numpy, which should be a plain
+        # view over the buffer we originally allocated (therefore, aligned
+        # and importable).
+        input_capsule = aligned_input_array.__dlpack__()
+        aligned_input_array = None
+        gc.collect()
+        imported_bv = self.device.from_dlpack_capsule(input_capsule)
+
+        # Export a capsule from this imported buffer view and create a new
+        # array out of it.
+        class DummyProducer:
+            def __dlpack__(_, stream=None):
+                capsule = self.device.create_dlpack_capsule(imported_bv, 1, 0)
+                return capsule
+
+            def __dlpack_device__(self):
+                return (1, 0)  # CPU, id 0
+
+        reimported_array = np.from_dlpack(DummyProducer())
+        imported_bv = None
+        gc.collect()
+        np.testing.assert_array_equal(input_array, reimported_array)
+
+    def testImportExportF64(self):
+        self.roundtrip(np.random.rand(3, 4), iree.runtime.HalElementType.FLOAT_64)
+
+    def testImportExportF32(self):
+        self.roundtrip(
+            np.random.rand(3, 4, 16, 32, 1, 5, 2).astype(np.float32),
+            iree.runtime.HalElementType.FLOAT_32,
+        )
+
+    def testImportExportF16(self):
+        self.roundtrip(
+            np.random.rand(3, 4).astype(np.float16),
+            iree.runtime.HalElementType.FLOAT_16,
+        )
+
+    def testImportExportSI8(self):
+        self.roundtrip(
+            (np.random.rand(3, 4) * 255.0).astype(np.int8),
+            iree.runtime.HalElementType.SINT_8,
+        )
+
+    def testImportExportSI16(self):
+        self.roundtrip(
+            (np.random.rand(3, 4) * 255.0).astype(np.int16),
+            iree.runtime.HalElementType.SINT_16,
+        )
+
+    def testImportExportSI32(self):
+        self.roundtrip(
+            (np.random.rand(3, 4) * 255.0).astype(np.int32),
+            iree.runtime.HalElementType.SINT_32,
+        )
+
+    def testImportExportSI64(self):
+        self.roundtrip(
+            (np.random.rand(3, 4) * 255.0).astype(np.int64),
+            iree.runtime.HalElementType.SINT_64,
+        )
+
+    def testImportExportUI8(self):
+        self.roundtrip(
+            (np.random.rand(3, 4) * 255.0).astype(np.uint8),
+            iree.runtime.HalElementType.UINT_8,
+        )
+
+    def testImportExportUI16(self):
+        self.roundtrip(
+            (np.random.rand(3, 4) * 255.0).astype(np.uint16),
+            iree.runtime.HalElementType.UINT_16,
+        )
+
+    def testImportExportUI32(self):
+        self.roundtrip(
+            (np.random.rand(3, 4) * 255.0).astype(np.uint32),
+            iree.runtime.HalElementType.UINT_32,
+        )
+
+    def testImportExportUI64(self):
+        self.roundtrip(
+            (np.random.rand(3, 4) * 255.0).astype(np.uint64),
+            iree.runtime.HalElementType.UINT_64,
+        )
+
+    def testImportExportBool(self):
+        self.roundtrip(
+            (np.random.rand(3, 4) * 255.0).astype(np.bool_),
+            iree.runtime.HalElementType.BOOL_8,
+        )
+
+    def testImportExportUI64(self):
+        self.roundtrip(
+            (np.random.rand(3, 4) * 255.0).astype(np.uint64),
+            iree.runtime.HalElementType.UINT_64,
+        )
+
+    def testImportExportComplex64(self):
+        shape = (3, 1, 5, 6, 12, 2, 3)
+        self.roundtrip(
+            np.random.uniform(-1, 1, shape) + 1.0j * np.random.uniform(-1, 1, shape),
+            iree.runtime.HalElementType.COMPLEX_64,
+        )
+
+    def testImportExportComplex64(self):
+        shape = (3, 1, 5, 6, 12, 2, 3)
+        self.roundtrip(
+            (
+                np.random.uniform(-1, 1, shape) + 1.0j * np.random.uniform(-1, 1, shape)
+            ).astype(np.complex128),
+            iree.runtime.HalElementType.COMPLEX_64,
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/runtime/src/iree/hal/buffer.h
+++ b/runtime/src/iree/hal/buffer.h
@@ -144,6 +144,9 @@ enum iree_hal_memory_access_bits_t {
   // bypass the access verification.
   IREE_HAL_MEMORY_ACCESS_ANY = 1u << 5,
   // Memory may have any operation performed on it.
+  // Note that this explicitly includes 'DISCARD', which means that the
+  // mapped memory will have undefined contents. Do not use this access
+  // mode if you intend the existing contents to be accessible.
   IREE_HAL_MEMORY_ACCESS_ALL = IREE_HAL_MEMORY_ACCESS_READ |
                                IREE_HAL_MEMORY_ACCESS_WRITE |
                                IREE_HAL_MEMORY_ACCESS_DISCARD,

--- a/runtime/src/iree/hal/drivers/cuda/cuda_allocator.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_allocator.c
@@ -616,6 +616,7 @@ static iree_status_t iree_hal_cuda_allocator_export_buffer(
   switch (requested_type) {
     case IREE_HAL_EXTERNAL_BUFFER_TYPE_DEVICE_ALLOCATION:
       switch (buffer_type) {
+        case IREE_HAL_CUDA_BUFFER_TYPE_DEVICE:
         case IREE_HAL_CUDA_BUFFER_TYPE_EXTERNAL:
           out_external_buffer->flags = requested_flags;
           out_external_buffer->type = requested_type;

--- a/runtime/src/iree/hal/drivers/hip/hip_allocator.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_allocator.c
@@ -569,6 +569,7 @@ static iree_status_t iree_hal_hip_allocator_export_buffer(
   switch (requested_type) {
     case IREE_HAL_EXTERNAL_BUFFER_TYPE_DEVICE_ALLOCATION:
       switch (buffer_type) {
+        case IREE_HAL_HIP_BUFFER_TYPE_DEVICE:
         case IREE_HAL_HIP_BUFFER_TYPE_EXTERNAL:
           out_external_buffer->flags = requested_flags;
           out_external_buffer->type = requested_type;


### PR DESCRIPTION
* Currently only supports v0 of the protocol (which is what PyTorch implements).
* Requires contiguous tensors for the moment.
* Only supports device tensors.
* Implements the building blocks for the dlpack protocol, relying on more framework level classes to properly handle device mapping and synchronization, as IREE can't generically know this.

Also fixed `iree_hal_allocator_export_buffer` on HIP/CUDA to support export of DEVICE buffers, not just EXTERNAL. Fixes the CPU allocator_heap to be able to service IREE_HAL_EXTERNAL_BUFFER_TYPE_DEVICE_ALLOCATION requests. Also provides a better comment on a footgun with IREE_HAL_MEMORY_ACCESS_ALL that cost some time trying to figure out why on CPU my exported contents were being scribbled over (there is a debug feature that does this if DISCARD is set).

See corresponding PR to use this for PyTorch/IREE tensor interop for HIP and CUDA tensors.