### PR TITLE
Remove `dropUnitDims` from `OptimizeVectorTransferPass`

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
@@ -61,8 +61,7 @@ static void loopInvariantCodeMotion(mlir::FunctionOpInterface funcOp) {
 
 struct OptimizeVectorTransferPass
     : public OptimizeVectorTransferBase<OptimizeVectorTransferPass> {
-  OptimizeVectorTransferPass(bool flatten, bool dropUnitDims)
-      : flatten(flatten), dropUnitDims(dropUnitDims) {}
+  OptimizeVectorTransferPass(bool flatten) : flatten(flatten) {}
   void runOnOperation() override {
     auto funcOp = getOperation();
     LDBG("before optimize vector transfer\n" << funcOp);
@@ -106,19 +105,6 @@ struct OptimizeVectorTransferPass
 
     LDBG("after bubbling vector bitcasts\n" << funcOp);
 
-    // TODO(#14191): SPIR-V can't handle the vector.shape_cast created for
-    // dropping unit dims so this option is disabled in SPIR-V pipeline.
-    // This option should go away after all backend issues have been resolved.
-    if (dropUnitDims) {
-      RewritePatternSet patterns(&getContext());
-      mlir::vector::populateVectorTransferDropUnitDimsPatterns(patterns);
-      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
-        return signalPassFailure();
-      }
-
-      LDBG("after dropping vector transfer unit dims\n" << funcOp);
-    }
-
     // Second stage of patterns to flatten transfer ops.
     if (flatten) {
       RewritePatternSet patterns(&getContext());
@@ -149,14 +135,13 @@ struct OptimizeVectorTransferPass
 
 private:
   bool flatten;
-  bool dropUnitDims;
 };
 
 } // namespace
 
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createOptimizeVectorTransferPass(bool flatten, bool dropUnitDims) {
-  return std::make_unique<OptimizeVectorTransferPass>(flatten, dropUnitDims);
+createOptimizeVectorTransferPass(bool flatten) {
+  return std::make_unique<OptimizeVectorTransferPass>(flatten);
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.h
@@ -229,8 +229,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createMaterializeUserConfigsPass();
 
 /// Pass to optimize vector transfer_read and transfer_write.
 std::unique_ptr<InterfacePass<FunctionOpInterface>>
-createOptimizeVectorTransferPass(bool flatten = false,
-                                 bool dropUnitDims = true);
+createOptimizeVectorTransferPass(bool flatten = false);
 
 /// Pad dynamic alloc op to convert them into static one.
 std::unique_ptr<InterfacePass<FunctionOpInterface>> createPadDynamicAlloc();

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -406,8 +406,6 @@ def OptimizeVectorTransfer :
   let options = [
     Option<"optionFlatten", "flatten", "bool", "false",
            "Flatten the vector type of vector transfers where possible (contiguous row-major data).">,
-    Option<"optionDropUnitDims", "drop-unit-dims", "bool", /*default=*/"true",
-           "Drop unit dims in vector transfers where possible (might generate vector.shape_cast).">,
   ];
   let dependentDialects = [
       "memref::MemRefDialect"

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -212,20 +212,14 @@ static void addMemRefLoweringPasses(OpPassManager &modulePassManager) {
       .addPass(createForOpCanonicalizationPass)
       // Perform various vector-level cross-op optimizations like load-store
       // forwarding, shape casting and casting op cancelling.
-      .addPass([&]() {
-        return createOptimizeVectorTransferPass(
-            /*flatten=*/false, /*dropUnitDims=*/false);
-      })
+      .addPass([&]() { return createOptimizeVectorTransferPass(); })
       .addPass(createSPIRVBreakDownLargeVectorPass)
 
       // Perform optimizations that need to across the scf.for region boundary.
       .addPass(createForOpCanonicalizationPass)
       .addPass(createCanonicalizerPass)
       .addPass(createCSEPass)
-      .addPass([&]() {
-        return createOptimizeVectorTransferPass(
-            /*flatten=*/false, /*dropUnitDims=*/false);
-      });
+      .addPass([&]() { return createOptimizeVectorTransferPass(); });
 
   // Turn multi-dimension memref into one-dimension. This is needed for
   // SPIR-V because we don't use upstream memref descriptors.
@@ -340,8 +334,7 @@ void addSPIRVBaseVectorizePassPipeline(OpPassManager &funcPassManager) {
 
   // Perform various vector-level cross-op optimizations like load-store
   // forwarding, shape casting and casting op cancelling.
-  funcPassManager.addPass(createOptimizeVectorTransferPass(
-      /*flatten=*/false, /*dropUnitDims=*/false));
+  funcPassManager.addPass(createOptimizeVectorTransferPass());
 }
 
 void addSPIRVWinogradVectorizePassPipeline(OpPassManager &funcPassManager) {
@@ -383,8 +376,7 @@ void addSPIRVWinogradVectorizePassPipeline(OpPassManager &funcPassManager) {
 
   // Perform various vector-level cross-op optimizations like load-store
   // forwarding, shape casting and casting op cancelling.
-  funcPassManager.addPass(createOptimizeVectorTransferPass(
-      /*flatten=*/false, /*dropUnitDims=*/false));
+  funcPassManager.addPass(createOptimizeVectorTransferPass());
 }
 
 void addSPIRVCooperativeMatrixVectorizePassPipeline(
@@ -446,8 +438,7 @@ void addSPIRVCooperativeMatrixVectorizePassPipeline(
 
   // Perform various vector-level cross-op optimizations like load-store
   // forwarding, shape casting and casting op cancelling.
-  funcPassManager.addPass(createOptimizeVectorTransferPass(
-      /*flatten=*/false, /*dropUnitDims=*/false));
+  funcPassManager.addPass(createOptimizeVectorTransferPass());
 
   funcPassManager.addPass(createForOpCanonicalizationPass());
   funcPassManager.addPass(createCanonicalizerPass());
@@ -527,8 +518,7 @@ void addSPIRVMatmulPromoteVectorizePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createForOpCanonicalizationPass());
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
-  funcPassManager.addPass(createOptimizeVectorTransferPass(
-      /*flatten=*/false, /*dropUnitDims=*/false));
+  funcPassManager.addPass(createOptimizeVectorTransferPass());
 
   // Hoist loop invariant code to avoid pipelining it.
   funcPassManager.addPass(createLoopInvariantCodeMotionPass());
@@ -581,8 +571,7 @@ void addSPIRVSubgroupReducePassPipeline(OpPassManager &funcPassManager) {
 
   // Perform various vector-level cross-op optimizations like load-store
   // forwarding, shape casting and casting op cancelling.
-  funcPassManager.addPass(createOptimizeVectorTransferPass(
-      /*flatten=*/false, /*dropUnitDims=*/false));
+  funcPassManager.addPass(createOptimizeVectorTransferPass());
 
   // Simplify the IR for vector distribution.
   funcPassManager.addPass(memref::createFoldMemRefAliasOpsPass());


### PR DESCRIPTION
Remove `populateVectorTransferDropUnitDimsPatterns` from `OptimizeVectorTransferPass`

This is a cleanup of `OptimizeVectorTransferPass`. Places requiring dropping unit dims can use the standalone pass `LLVMCPUDropVectorUnitDimsPass`. 