### PR TITLE
Adding a hoistable attr interface to allow attaching attrs to hoists.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALAttrs.td
@@ -10,6 +10,7 @@
 include "iree/compiler/Dialect/HAL/IR/HALBase.td"
 include "iree/compiler/Dialect/HAL/IR/HALInterfaces.td"
 include "iree/compiler/Dialect/Stream/IR/StreamInterfaces.td"
+include "iree/compiler/Dialect/Util/IR/UtilInterfaces.td"
 include "iree/compiler/Dialect/Util/IR/UtilTypes.td"
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/BuiltinAttributeInterfaces.td"
@@ -741,6 +742,7 @@ def HAL_AffinityQueueAttr : AttrDef<HAL_Dialect, "AffinityQueue", [
     "joinOR",
     "joinAND",
   ]>,
+  Util_HoistableAttrInterface,
 ]> {
   let mnemonic = "affinity.queue";
   let summary = [{specifies a set of allowed queues for an operation}];

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilInterfaces.td
@@ -1129,6 +1129,36 @@ def Util_GlobalType : TypeInterface<"GlobalTypeInterface"> {
 // IREE::Util::Hoistable*Interface
 //===----------------------------------------------------------------------===//
 
+def Util_HoistableAttrInterface : AttrInterface<"HoistableAttrInterface"> {
+  let cppNamespace = "::mlir::iree_compiler::IREE::Util";
+
+  let description = [{
+    Interface used to control hoisting of dialect attributes associated with
+    ops that are hoisted. Attributes implementing this interface can opt into
+    being replicated onto the global and initializer produced during hoisting.
+
+    Hoisting will walk up ancestors of hoisted ops to see if any contain
+    attributes with this interface to allow context-scoped behavior such as
+    target execution environment for a function.
+  }];
+
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns true if dialect attributes of this type are replicated to the
+        global and initializer created during hoisting.
+      }],
+      /*retTy=*/"bool",
+      /*methodName=*/"shouldAttachToHoistedOps",
+      /*args=*/(ins),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        return true;
+      }]
+    >,
+  ];
+}
+
 def Util_HoistableOpInterface : OpInterface<"HoistableOpInterface"> {
   let cppNamespace = "::mlir::iree_compiler::IREE::Util";
 

--- a/compiler/src/iree/compiler/GlobalOptimization/test/hoist_into_globals.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/hoist_into_globals.mlir
@@ -134,3 +134,23 @@ module @hoist_inline_parameters {
     util.return %0 : tensor<i32>
   }
 }
+
+// -----
+
+// Tests that hoistable attributes like the device affinity get cloned onto the
+// global and initializer.
+
+// CHECK-LABEL: @hoist_dialect_attrs
+module @hoist_dialect_attrs {
+  //      CHECK: util.global private @[[HOISTED:[a-z0-9]+]]
+  // CHECK-SAME:   hal.affinity = #hal.affinity.queue<[0, 1]>
+  //      CHECK: util.initializer
+  // CHECK-SAME:   hal.affinity = #hal.affinity.queue<[0, 1]>
+  util.func public @main() -> tensor<i32> attributes {
+    hal.affinity = #hal.affinity.queue<[0, 1]>
+  } {
+    %0 = arith.constant dense<3> : tensor<i32>
+    %1 = "iree_unregistered.const_expr"(%0) : (tensor<i32>) -> tensor<i32>
+    util.return %1 : tensor<i32>
+  }
+}

--- a/compiler/src/iree/compiler/InputConversion/Common/ImportMLProgram.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/ImportMLProgram.cpp
@@ -109,6 +109,7 @@ public:
     auto globalOp = rewriter.replaceOpWithNewOp<IREE::Util::GlobalOp>(
         srcOp, srcOp.getName(), isMutable | isExtern, newType, srcOpTypedAttr);
     globalOp.setVisibility(SymbolTable::Visibility::Private);
+    globalOp->setDialectAttrs(srcOp->getDialectAttrs());
 
     if (isExtern)
       externGlobals.emplace_back(srcOp.getName(), newType);


### PR DESCRIPTION
This could use a bit of refinement but allows for scoped attributes like device affinity to be associated with the globals and initializers created by hoisting. In the future when we perform device placement later on we'll not require this but we'll always want to allow a user to indicate a particular value should live on a particular device. We may want loosen the behavior by only hoisting the attribute to the global and letting placement decide on which device it should be initialized.