### PR TITLE
Switch ci.yml to use standard sized runners, disable build_test_all_windows.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
   #       env:
   #         IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
   #         IREE_CCACHE_GCP_TOKEN: ${{ steps.gcp-auth.outputs.access_token }}
-  #         CCACHE_NAMESPACE: github-windows-2022-64core
+  #         CCACHE_NAMESPACE: github-windows-2022
   #       run: ./build_tools/cmake/build_all.sh "${BUILD_DIR}"
   #     - name: "Testing IREE"
   #       run: ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,53 +100,55 @@ jobs:
             ./build_tools/cmake/ctest_all.sh \
             "${BUILD_DIR}"
 
-  build_test_all_windows:
-    needs: setup
-    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_test_all_windows')
-    # GitHub-hosted 64 core runners are too expensive and take too long to check out the repo
-    # TODO(scotttodd): disable GitHub-hosted if too slow
-    # TODO(saienduri): switch to self-hosted
-    runs-on: windows-2022
-    defaults:
-      run:
-        shell: bash
-    env:
-      BUILD_DIR: build-windows
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-        with:
-          submodules: true
-      - id: "gcp-auth"
-        name: "Authenticating to Google Cloud"
-        if: needs.setup.outputs.write-caches == 1
-        uses: "google-github-actions/auth@v1"
-        with:
-          token_format: "access_token"
-          credentials_json: "${{ secrets.IREE_OSS_GITHUB_RUNNER_BASIC_TRUST_SERVICE_ACCOUNT_KEY }}"
-          create_credentials_file: false
-      - name: "Setting up Python"
-        uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
-        with:
-          python-version: "3.10" # Needs pybind >= 2.10.1 for Python >= 3.11
-      - name: "Installing Python packages"
-        run: |
-          python3 -m venv .venv
-          .venv/Scripts/activate.bat
-          python3 -m pip install -r runtime/bindings/python/iree/runtime/build_requirements.txt
-      - name: "Installing requirements"
-        run: choco install ccache --yes
-      - name: "Configuring MSVC"
-        uses: ilammy/msvc-dev-cmd@7315a94840631165970262a99c72cfb48a65d25d # v1.12.0
-      # Finally: build and run tests.
-      - name: "Building IREE"
-        env:
-          IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
-          IREE_CCACHE_GCP_TOKEN: ${{ steps.gcp-auth.outputs.access_token }}
-          CCACHE_NAMESPACE: github-windows-2022-64core
-        run: ./build_tools/cmake/build_all.sh "${BUILD_DIR}"
-      - name: "Testing IREE"
-        run: ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
+  # Disabled since
+  #   * windows-2022 is too slow
+  #   * windows-2022-64core is too expensive (and takes ~8 minutes just to checkout the repo)
+  #   * we don't have self-hosted Windows runners with enough cores yet
+  # build_test_all_windows:
+  #   needs: setup
+  #   if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_test_all_windows')
+  #   # TODO(saienduri): switch to self-hosted
+  #   runs-on: windows-2022
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #   env:
+  #     BUILD_DIR: build-windows
+  #   steps:
+  #     - name: "Checking out repository"
+  #       uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+  #       with:
+  #         submodules: true
+  #     - id: "gcp-auth"
+  #       name: "Authenticating to Google Cloud"
+  #       if: needs.setup.outputs.write-caches == 1
+  #       uses: "google-github-actions/auth@v1"
+  #       with:
+  #         token_format: "access_token"
+  #         credentials_json: "${{ secrets.IREE_OSS_GITHUB_RUNNER_BASIC_TRUST_SERVICE_ACCOUNT_KEY }}"
+  #         create_credentials_file: false
+  #     - name: "Setting up Python"
+  #       uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
+  #       with:
+  #         python-version: "3.10" # Needs pybind >= 2.10.1 for Python >= 3.11
+  #     - name: "Installing Python packages"
+  #       run: |
+  #         python3 -m venv .venv
+  #         .venv/Scripts/activate.bat
+  #         python3 -m pip install -r runtime/bindings/python/iree/runtime/build_requirements.txt
+  #     - name: "Installing requirements"
+  #       run: choco install ccache --yes
+  #     - name: "Configuring MSVC"
+  #       uses: ilammy/msvc-dev-cmd@7315a94840631165970262a99c72cfb48a65d25d # v1.12.0
+  #     # Finally: build and run tests.
+  #     - name: "Building IREE"
+  #       env:
+  #         IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
+  #         IREE_CCACHE_GCP_TOKEN: ${{ steps.gcp-auth.outputs.access_token }}
+  #         CCACHE_NAMESPACE: github-windows-2022-64core
+  #       run: ./build_tools/cmake/build_all.sh "${BUILD_DIR}"
+  #     - name: "Testing IREE"
+  #       run: ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
 
   build_test_all_macos_arm64:
     needs: setup
@@ -1066,7 +1068,7 @@ jobs:
 
       # Platforms
       - build_test_all_arm64
-      - build_test_all_windows
+      # - build_test_all_windows
       - build_test_all_macos_arm64
       - build_test_all_macos_x86_64
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,28 +103,20 @@ jobs:
   build_test_all_windows:
     needs: setup
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_test_all_windows')
-    runs-on: windows-2022-64core
+    # GitHub-hosted 64 core runners are too expensive and take too long to check out the repo
+    # TODO(scotttodd): disable GitHub-hosted if too slow
+    # TODO(saienduri): switch to self-hosted
+    runs-on: windows-2022
     defaults:
       run:
         shell: bash
     env:
       BUILD_DIR: build-windows
     steps:
-      # actions/checkout is for some reason unusably slow on the large managed
-      # Windows GitHub runners so we roll our own. See
-      # https://github.com/actions/checkout/issues/1186
-      # TODO(gcmn): Factor this out into something reusable across jobs. Can't
-      # be a script because we haven't done the checkout yet :-)
       - name: "Checking out repository"
-        env:
-          REMOTE_URL: ${{ github.server_url }}/${{ github.repository }}
-        run: |
-          mkdir -p ${GITHUB_WORKSPACE}
-          cd ${GITHUB_WORKSPACE}
-          git init
-          git fetch --depth 1 "${REMOTE_URL}" "${GITHUB_SHA}"
-          git checkout "${GITHUB_SHA}"
-          git submodule update --init --jobs 8 --depth 1
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          submodules: true
       - id: "gcp-auth"
         name: "Authenticating to Google Cloud"
         if: needs.setup.outputs.write-caches == 1
@@ -160,7 +152,7 @@ jobs:
     needs: setup
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_test_all_macos_arm64')
     runs-on:
-      - ${{ github.repository == 'iree-org/iree' && 'self-hosted' || 'macos-11' }} # must come first
+      - ${{ github.repository == 'iree-org/iree' && 'self-hosted' || 'macos-12' }} # must come first
       - runner-group=postsubmit
       - os-family=macOS
     env:
@@ -401,7 +393,7 @@ jobs:
   build_test_runtime:
     needs: setup
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_test_runtime')
-    runs-on: ubuntu-20.04-64core
+    runs-on: ubuntu-20.04
     env:
       BUILD_DIR: build-runtime
     steps:
@@ -456,7 +448,7 @@ jobs:
   build_test_runtime_windows:
     needs: setup
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_test_runtime_windows')
-    runs-on: windows-2022-64core
+    runs-on: windows-2022
     defaults:
       run:
         shell: bash
@@ -607,7 +599,7 @@ jobs:
   small_runtime:
     needs: setup
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'small_runtime')
-    runs-on: ubuntu-20.04-64core
+    runs-on: ubuntu-20.04
     env:
       BUILD_DIR: build-runtime
     steps:

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -125,7 +125,7 @@ CONTROL_JOBS = frozenset(["setup", "summary"])
 DEFAULT_POSTSUBMIT_ONLY_JOBS = frozenset(
     [
         "build_test_all_arm64",
-        "build_test_all_windows",
+        # "build_test_all_windows",  # Currently disabled
         "build_test_all_macos_arm64",
         "build_test_all_macos_x86_64",
         # Due to the outstock of A100, only run this test in postsubmit.
@@ -138,10 +138,11 @@ DEFAULT_POSTSUBMIT_ONLY_JOBS = frozenset(
 # The file paths should be specified using Unix shell-style wildcards.
 PRESUBMIT_TOUCH_ONLY_JOBS = [
     ("build_test_all_macos_arm64", ["runtime/src/iree/hal/drivers/metal/*"]),
-    (
-        "build_test_all_windows",
-        ["*win32*", "*windows*", "*msvc*", "runtime/src/iree/builtins/ukernel/*"],
-    ),
+    # Currently disabled
+    # (
+    #     "build_test_all_windows",
+    #     ["*win32*", "*windows*", "*msvc*", "runtime/src/iree/builtins/ukernel/*"],
+    # ),
 ]
 
 # Default presets enabled in CI.

--- a/build_tools/github_actions/configure_ci_test.py
+++ b/build_tools/github_actions/configure_ci_test.py
@@ -308,6 +308,7 @@ class ConfigureCITest(unittest.TestCase):
         expected_jobs = {"job1", "build_test_all_macos_arm64"}
         self.assertCountEqual(jobs, expected_jobs)
 
+    @unittest.skip("skip while `build_test_all_windows` job is disabled")
     def test_get_enabled_jobs_windows(self):
         trailers = {}
         all_jobs = {"job1"}


### PR DESCRIPTION
__This also disables the `build_test_all_windows` job entirely__

---

* Small runners are free: [Standard GitHub-hosted runners for Public repositories](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)
* Large runners are expensive: [Per-minute rates for larger runners](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#per-minute-rates-for-larger-runners) ($0.50 per minute for Windows 64 core, 8 minutes per run just to check out the repo... you do the math :P)

Where we care about job latency we should use self hosted runners -- ideally with local caches for git objects, test resources, and other build cache files.

ci-extra: build_test_all_windows