### PR TITLE
Switch pkgci_regression_test_cpu.yml to use a self-hosted runner.

### DIFF
--- a/.github/workflows/pkgci_regression_test_cpu.yml
+++ b/.github/workflows/pkgci_regression_test_cpu.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   linux_x86_64:
     name: Linux (x86_64)
-    runs-on: ubuntu-20.04-64core
+    runs-on: nodai-amdgpu-w7900-x86-64
     env:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
       IREERS_ARTIFACT_DIR: ${{ github.workspace }}/artifacts


### PR DESCRIPTION
This improves consistency across jobs in the workflow file. Ideally this would be a self-hosted _CPU_ runner, but this _GPU_ runner already has a nice local cache and is being used for CPU model tests.

We also have self-hosted runners on GCP but on https://github.com/iree-org/iree/pull/16910 I found that they didn't have `git-lfs` installed and the install commands I wanted to use didn't work:
```yml
    runs-on:
      - self-hosted # must come first
      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
      - environment=prod
      - cpu
      - os-family=Linux
```
```
sudo apt-get install git-lfs
  git lfs install
E: Unable to locate package git-lfs
```

Standard sized GitHub-hosted runners should also work for small CPU tests (that don't need cached model weights or lots of RAM). We have a job upstream in the test suite repo using `ubuntu-latest`: https://github.com/nod-ai/SHARK-TestSuite/blob/main/.github/workflows/test_iree.yml.

ci-exactly: build_packages,regression_test_cpu