### PR TITLE
[website] Bump mkdocs-material to latest and use new features.

### DIFF
--- a/docs/website/docs/community/blog/.authors.yml
+++ b/docs/website/docs/community/blog/.authors.yml
@@ -7,24 +7,29 @@ authors:
   ataei:
     name: Ahmed Taei
     description: Software Engineer
-    avatar: https://github.com/ataei.png
+    avatar: https://github.com/asaadaldien.png
+    url: https://github.com/asaadaldien
 
   bjacob:
     name: Benoit Jacob
     description: Software Engineer
     avatar: https://github.com/bjacob.png
+    url: https://github.com/bjacob
 
   jennik:
     name: Jenni Kilduff
     description: Software Engineer
     avatar: https://github.com/not-jenni.png
+    url: https://github.com/not-jenni
 
   rsuderman:
     name: Rob Suderman
     description: Software Engineer
     avatar: https://github.com/rsuderman.png
+    url: https://github.com/rsuderman
 
   thomasraoux:
     name: Thomas Raoux
     description: Software Engineer
     avatar: https://github.com/thomasraoux.png
+    url: https://github.com/thomasraoux

--- a/docs/website/docs/index.md
+++ b/docs/website/docs/index.md
@@ -15,7 +15,7 @@ considerations of mobile and edge deployments.
 
 <div class="grid cards" markdown>
 
--   :material-clock-fast: __Ahead-of-time compilation__
+- :material-clock-fast: **Ahead-of-time compilation**
 
     ---
 
@@ -23,7 +23,7 @@ considerations of mobile and edge deployments.
 
     [:octicons-arrow-right-24: Project architecture](#project-architecture)
 
--   :octicons-rocket-24: Support for advanced model features
+- :octicons-rocket-24: **Support for advanced model features**
 
     ---
 
@@ -31,7 +31,7 @@ considerations of mobile and edge deployments.
 
     [:octicons-arrow-right-24: Importing from ML frameworks](#importing-models-from-ml-frameworks)
 
--   :octicons-server-24: Designed for CPUs, GPUs, and other accelerators
+- :octicons-server-24: **Designed for CPUs, GPUs, and other accelerators**
 
     ---
 
@@ -39,7 +39,7 @@ considerations of mobile and edge deployments.
 
     [:octicons-arrow-right-24: Deployment configurations](#selecting-deployment-configurations)
 
--   :fontawesome-solid-chart-gantt: Low overhead, pipelined execution
+- :fontawesome-solid-chart-gantt: **Low overhead, pipelined execution**
 
     ---
 
@@ -47,13 +47,13 @@ considerations of mobile and edge deployments.
 
     [:octicons-arrow-right-24: Benchmarking](./developers/performance/benchmarking.md)
 
--   :fontawesome-regular-floppy-disk: Binary size as low as 30KB on embedded systems
+- :fontawesome-regular-floppy-disk: **Binary size as low as 30KB on embedded systems**
 
     ---
 
     [:octicons-arrow-right-24: Running on bare-metal](./guides/deployment-configurations/bare-metal.md)
 
--   :fontawesome-solid-magnifying-glass: Debugging and profiling support
+- :fontawesome-solid-magnifying-glass: **Debugging and profiling support**
 
     ---
 

--- a/docs/website/docs/index.md
+++ b/docs/website/docs/index.md
@@ -13,13 +13,53 @@ considerations of mobile and edge deployments.
 
 ## Key features
 
-- [x] Ahead-of-time compilation of scheduling and execution logic together
-- [x] Support for dynamic shapes, flow control, streaming, and other advanced
-      model features
-- [x] Optimized for many CPU and GPU architectures
-- [x] Low overhead, pipelined execution for efficient power and resource usage
-- [x] Binary size as low as 30KB on embedded systems
-- [x] Debugging and profiling support
+<div class="grid cards" markdown>
+
+-   :material-clock-fast: __Ahead-of-time compilation__
+
+    ---
+
+    Scheduling and execution logic are compiled together
+
+    [:octicons-arrow-right-24: Project architecture](#project-architecture)
+
+-   :octicons-rocket-24: Support for advanced model features
+
+    ---
+
+    Dynamic shapes, flow control, streaming, and more
+
+    [:octicons-arrow-right-24: Importing from ML frameworks](#importing-models-from-ml-frameworks)
+
+-   :octicons-server-24: Designed for CPUs, GPUs, and other accelerators
+
+    ---
+
+    First class support for many popular devices and APIs
+
+    [:octicons-arrow-right-24: Deployment configurations](#selecting-deployment-configurations)
+
+-   :fontawesome-solid-chart-gantt: Low overhead, pipelined execution
+
+    ---
+
+    Efficient power and resource usage on server and edge devices
+
+    [:octicons-arrow-right-24: Benchmarking](./developers/performance/benchmarking.md)
+
+-   :fontawesome-regular-floppy-disk: Binary size as low as 30KB on embedded systems
+
+    ---
+
+    [:octicons-arrow-right-24: Running on bare-metal](./guides/deployment-configurations/bare-metal.md)
+
+-   :fontawesome-solid-magnifying-glass: Debugging and profiling support
+
+    ---
+
+    [:octicons-arrow-right-24: Profiling with Tracy](./developers/performance/profiling-with-tracy.md)
+
+</div>
 
 ## Support matrix
 
@@ -28,8 +68,7 @@ IREE supports importing from a variety of ML frameworks:
 - [x] JAX
 - [x] ONNX
 - [x] PyTorch
-- [x] TensorFlow
-- [x] TensorFlow Lite
+- [x] TensorFlow and TensorFlow Lite
 
 The IREE compiler tools run on :fontawesome-brands-linux: Linux,
 :fontawesome-brands-windows: Windows, and :fontawesome-brands-apple: macOS
@@ -53,8 +92,8 @@ Support for hardware accelerators and APIs is also included:
 
 - [x] Vulkan
 - [x] CUDA
+- [x] ROCm
 - [x] Metal (for Apple silicon devices)
-- [ ] ROCm (experimental)
 - [ ] AMD AIE (experimental)
 - [ ] WebGPU (experimental)
 
@@ -98,9 +137,9 @@ Using IREE involves the following general steps:
 IREE supports importing models from a growing list of
 [ML frameworks](./guides/ml-frameworks/index.md) and model formats:
 
-* [:simple-pytorch: PyTorch](./guides/ml-frameworks/pytorch.md)
-* [:simple-onnx: ONNX](./guides/ml-frameworks/onnx.md)
 * [:simple-python: JAX](./guides/ml-frameworks/jax.md)
+* [:simple-onnx: ONNX](./guides/ml-frameworks/onnx.md)
+* [:simple-pytorch: PyTorch](./guides/ml-frameworks/pytorch.md)
 * [:simple-tensorflow: TensorFlow](./guides/ml-frameworks/tensorflow.md) and
   [:simple-tensorflow: TensorFlow Lite](./guides/ml-frameworks/tflite.md)
 

--- a/docs/website/mkdocs.yml
+++ b/docs/website/mkdocs.yml
@@ -84,8 +84,8 @@ markdown_extensions:
   - meta
   - pymdownx.details
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
       options:
         custom_icons:
           - overrides/.icons

--- a/docs/website/mkdocs.yml
+++ b/docs/website/mkdocs.yml
@@ -81,6 +81,7 @@ markdown_extensions:
   - admonition
   - attr_list
   - footnotes
+  - md_in_html
   - meta
   - pymdownx.details
   - pymdownx.emoji:

--- a/docs/website/requirements.txt
+++ b/docs/website/requirements.txt
@@ -1,2 +1,2 @@
-mkdocs-material==9.2.3
+mkdocs-material==9.5.18
 mkdocs-redirects==1.2.1


### PR DESCRIPTION
Preview: https://scotttodd.github.io/iree/

Changelog from previous version: https://squidfunk.github.io/mkdocs-material/changelog/#9.2.3

* Added fancy [grid cards](https://squidfunk.github.io/mkdocs-material/reference/grids/) to the homepage for "Key Features".
  Before: 
![image](https://github.com/iree-org/iree/assets/4010439/4617b6a5-ad02-4aeb-a542-bdc4e29e9a4a)
  After (one column instead of two on mobile):
![image](https://github.com/iree-org/iree/assets/4010439/bf87dc66-60a8-4a7b-9b4c-6b966d43382f)
* Added author URLs to blog entries, linking to GitHub profiles
* Dark mode color scheme now has a darker background (we can override this if we want)