### PR TITLE
Converting arith.constant to flow.tensor.constant.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Patterns.cpp
@@ -20,6 +20,29 @@ namespace mlir::iree_compiler::IREE::Flow {
 
 namespace {
 
+/// Converts linalg.fill ops into flow.tensor.splat ops.
+///
+/// This is expected to improve performance because we can use DMA
+/// functionalities for the fill, instead of dispatching kernels.
+struct ConvertLinalgFillPattern final
+    : public OpRewritePattern<linalg::FillOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::FillOp fillOp,
+                                PatternRewriter &rewriter) const override {
+    if (fillOp->getParentOfType<IREE::Flow::DispatchWorkgroupsOp>()) {
+      // Don't convert linalg.fill ops that were fused together with other ops.
+      return failure();
+    }
+
+    SmallVector<Value> dynamicDims = tensor::createDynamicDimValues(
+        rewriter, fillOp.getLoc(), fillOp.output());
+    rewriter.replaceOpWithNewOp<IREE::Flow::TensorSplatOp>(
+        fillOp, fillOp.output().getType(), fillOp.value(), dynamicDims);
+    return success();
+  }
+};
+
 /// Convert tensor.insert_slice ops into flow.tensor.update ops where possible.
 struct ConvertTensorInsertSlicePattern
     : public OpRewritePattern<tensor::InsertSliceOp> {
@@ -35,7 +58,7 @@ struct ConvertTensorInsertPattern : public OpRewritePattern<tensor::InsertOp> {
   using OpRewritePattern<tensor::InsertOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(tensor::InsertOp insertOp,
                                 PatternRewriter &rewriter) const override {
-    if (insertOp->getParentOfType<Flow::DispatchWorkgroupsOp>()) {
+    if (insertOp->getParentOfType<IREE::Flow::DispatchWorkgroupsOp>()) {
       return failure();
     }
     rewriter.replaceOpWithNewOp<IREE::Flow::TensorStoreOp>(
@@ -61,7 +84,7 @@ struct ConvertTensorExtractPattern
 
   LogicalResult matchAndRewrite(tensor::ExtractOp op,
                                 PatternRewriter &rewriter) const override {
-    if (op->getParentOfType<Flow::DispatchWorkgroupsOp>()) {
+    if (op->getParentOfType<IREE::Flow::DispatchWorkgroupsOp>()) {
       return failure();
     }
     rewriter.replaceOpWithNewOp<IREE::Flow::TensorLoadOp>(
@@ -75,7 +98,7 @@ struct ConvertTensorBitcastPattern
   using OpRewritePattern<tensor::BitcastOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(tensor::BitcastOp op,
                                 PatternRewriter &rewriter) const override {
-    if (op->getParentOfType<Flow::DispatchWorkgroupsOp>()) {
+    if (op->getParentOfType<IREE::Flow::DispatchWorkgroupsOp>()) {
       return failure();
     }
     auto dynamicDims = IREE::Util::buildDynamicDimsForValue(
@@ -91,7 +114,7 @@ struct ConvertTensorCastPattern : public OpRewritePattern<tensor::CastOp> {
   using OpRewritePattern<tensor::CastOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(tensor::CastOp op,
                                 PatternRewriter &rewriter) const override {
-    if (op->getParentOfType<Flow::DispatchWorkgroupsOp>()) {
+    if (op->getParentOfType<IREE::Flow::DispatchWorkgroupsOp>()) {
       return failure();
     }
 
@@ -159,7 +182,7 @@ struct ConvertTensorFromElementsPattern
     // TODO: This pattern was mainly added to iron out some kinks specific to
     // detensoring (see: https://github.com/iree-org/iree/issues/1159). Do we
     // need to expand this check for other uses?
-    if (op->getParentOfType<Flow::DispatchWorkgroupsOp>()) {
+    if (op->getParentOfType<IREE::Flow::DispatchWorkgroupsOp>()) {
       return failure();
     }
     auto tensorType = op.getType();
@@ -200,7 +223,7 @@ struct ConvertTensorDialectReshapeOpPattern
   using OpRewritePattern<tensor::ReshapeOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(tensor::ReshapeOp op,
                                 PatternRewriter &rewriter) const override {
-    if (op->getParentOfType<Flow::DispatchWorkgroupsOp>()) {
+    if (op->getParentOfType<IREE::Flow::DispatchWorkgroupsOp>()) {
       return failure();
     }
     auto loc = op.getLoc();
@@ -242,7 +265,8 @@ struct ConvertTensorReshapePattern : public OpRewritePattern<TensorReshapeOp> {
 
   LogicalResult matchAndRewrite(TensorReshapeOp reshapeOp,
                                 PatternRewriter &rewriter) const override {
-    if (reshapeOp->template getParentOfType<Flow::DispatchWorkgroupsOp>()) {
+    if (reshapeOp
+            ->template getParentOfType<IREE::Flow::DispatchWorkgroupsOp>()) {
       return failure();
     }
     SmallVector<SmallVector<OpFoldResult>> outputShape;
@@ -263,29 +287,6 @@ struct ConvertTensorReshapePattern : public OpRewritePattern<TensorReshapeOp> {
     rewriter.replaceOpWithNewOp<IREE::Flow::TensorReshapeOp>(
         reshapeOp, reshapeOp.getResultType(), reshapeOp.getSrc(),
         outputDynamicShapes);
-    return success();
-  }
-};
-
-/// Converts linalg.fill ops into flow.tensor.splat ops.
-///
-/// This is expected to improve performance because we can use DMA
-/// functionalities for the fill, instead of dispatching kernels.
-struct ConvertLinalgFillPattern final
-    : public OpRewritePattern<linalg::FillOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(linalg::FillOp fillOp,
-                                PatternRewriter &rewriter) const override {
-    if (fillOp->getParentOfType<IREE::Flow::DispatchWorkgroupsOp>()) {
-      // Don't convert linalg.fill ops that were fused together with other ops.
-      return failure();
-    }
-
-    SmallVector<Value> dynamicDims = tensor::createDynamicDimValues(
-        rewriter, fillOp.getLoc(), fillOp.output());
-    rewriter.replaceOpWithNewOp<TensorSplatOp>(
-        fillOp, fillOp.output().getType(), fillOp.value(), dynamicDims);
     return success();
   }
 };

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/BUILD.bazel
@@ -18,6 +18,7 @@ iree_lit_test_suite(
         [
             "bitcast.mlir",
             "cast.mlir",
+            "constant.mlir",
             "extract.mlir",
             "extract_slice.mlir",
             "fill.mlir",

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_lit_test_suite(
   SRCS
     "bitcast.mlir"
     "cast.mlir"
+    "constant.mlir"
     "extract.mlir"
     "extract_slice.mlir"
     "fill.mlir"

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/bitcast.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/bitcast.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt --allow-unregistered-dialect --split-input-file --iree-flow-convert-to-flow %s | FileCheck %s
 
- util.func public @static_tensor_bitcast(%arg0: tensor<4x4xf32>) -> tensor<4x4xi32> {
+util.func public @static_tensor_bitcast(%arg0: tensor<4x4xf32>) -> tensor<4x4xi32> {
   // CHECK-DAG: %[[RESULT:.*]] = flow.tensor.bitcast %arg0 : tensor<4x4xf32> -> tensor<4x4xi32>
   // CHECK: util.return %[[RESULT]]
   %0 = tensor.bitcast %arg0 : tensor<4x4xf32> to tensor<4x4xi32>
@@ -9,7 +9,7 @@
 
 // -----
 
- util.func public @dynamic_tensor_bitcast(%arg0: tensor<?x?xf32>) -> tensor<?x?xi32> {
+util.func public @dynamic_tensor_bitcast(%arg0: tensor<?x?xf32>) -> tensor<?x?xi32> {
   // CHECK: %[[DIM0:.+]] = tensor.dim %arg0, %c0 : tensor<?x?xf32>
   // CHECK: %[[DIM1:.+]] = tensor.dim %arg0, %c1 : tensor<?x?xf32>
   // CHECK: %[[RESULT:.+]] = flow.tensor.bitcast %arg0 : tensor<?x?xf32>{%[[DIM0]], %[[DIM1]]} -> tensor<?x?xi32>{%[[DIM0]], %[[DIM1]]}

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/cast.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/cast.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt --allow-unregistered-dialect --split-input-file --iree-flow-convert-to-flow %s | FileCheck %s
 
- util.func public @static_tensor_cast_to_dynamic(%arg0: tensor<4x4xf32>) -> tensor<?x?xf32> {
+util.func public @static_tensor_cast_to_dynamic(%arg0: tensor<4x4xf32>) -> tensor<?x?xf32> {
   // CHECK-DAG: %[[C4:.*]] = arith.constant 4 : index
   // CHECK-DAG: %[[RESULT:.*]] = flow.tensor.reshape %arg0 : tensor<4x4xf32> -> tensor<?x?xf32>{%[[C4]], %[[C4]]}
   // CHECK: util.return %[[RESULT]]
@@ -10,7 +10,7 @@
 
 // -----
 
- util.func public @dynamic_tensor_cast_to_static(%arg0: tensor<?xf32>) -> tensor<4xf32> {
+util.func public @dynamic_tensor_cast_to_static(%arg0: tensor<?xf32>) -> tensor<4xf32> {
   // CHECK: %[[C4:.*]] = arith.constant 4 : index
   // CHECK: %[[RESULT:.*]] = flow.tensor.reshape %arg0 : tensor<?xf32>{%[[C4]]} -> tensor<4xf32>
   // CHECK: util.return %[[RESULT]]
@@ -20,7 +20,7 @@
 
 // -----
 
- util.func public @dynamic_tensor_cast_to_dynamic(%arg0: tensor<?x?xf32>) -> tensor<?x3xf32> {
+util.func public @dynamic_tensor_cast_to_dynamic(%arg0: tensor<?x?xf32>) -> tensor<?x3xf32> {
   // CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
   // CHECK-DAG: %[[D0:.*]] = tensor.dim %arg0, %[[C0]] : tensor<?x?xf32>
   // CHECK-DAG: %[[C3:.*]] = arith.constant 3 : index
@@ -32,7 +32,7 @@
 
 // -----
 
- util.func public @tensor_cast_within_dispatch_workgroups_not_converted() -> tensor<f32> {
+util.func public @tensor_cast_within_dispatch_workgroups_not_converted() -> tensor<f32> {
   %x = arith.constant 100 : index
   %0 = flow.dispatch.workgroups[%x]() : () -> (tensor<f32>) = () {
     // CHECK: = tensor.cast %[[source:.+]] : tensor<4x4xf32> to tensor<?x?xf32>

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/constant.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/constant.mlir
@@ -1,0 +1,16 @@
+// RUN: iree-opt --allow-unregistered-dialect --split-input-file --iree-flow-convert-to-flow %s | FileCheck %s
+
+util.func public @non_tensor_constant() -> i32 {
+  // CHECK: arith.constant 4
+  %0 = arith.constant 4 : i32
+  util.return %0 : i32
+}
+
+// -----
+
+util.func public @tensor_constant() -> tensor<4xi32> {
+  // CHECK: %[[RESULT:.+]] = flow.tensor.constant dense<[0, 1, 2, 3]> : tensor<4xi32>
+  // CHECK: util.return %[[RESULT]]
+  %0 = arith.constant dense<[0, 1, 2, 3]> : tensor<4xi32>
+  util.return %0 : tensor<4xi32>
+}

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/extract.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/extract.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt --split-input-file --iree-flow-convert-to-flow %s | FileCheck %s
 
- util.func public @tensor_extract(%arg0 : tensor<1xi32>, %arg1 : index) -> i32 {
+util.func public @tensor_extract(%arg0 : tensor<1xi32>, %arg1 : index) -> i32 {
   // CHECK: %[[RESULT:.*]] = flow.tensor.load %arg0[%arg1] : tensor<1xi32>
   // CHECK: util.return %[[RESULT]]
   %extract = tensor.extract %arg0[%arg1] : tensor<1xi32>
@@ -9,7 +9,7 @@
 
 // -----
 
- util.func public @tensor_extract_i1(%arg0 : tensor<1xi1>, %arg1 : index) -> i1 {
+util.func public @tensor_extract_i1(%arg0 : tensor<1xi1>, %arg1 : index) -> i1 {
   // CHECK: %[[RESULT:.*]] = flow.tensor.load %arg0[%arg1] : tensor<1xi1>
   // CHECK: util.return %[[RESULT]]
   %extract = tensor.extract %arg0[%arg1] : tensor<1xi1>

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/extract_slice.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/extract_slice.mlir
@@ -1,11 +1,11 @@
 // RUN: iree-opt --allow-unregistered-dialect --split-input-file --iree-flow-convert-to-flow %s | FileCheck %s
 
- util.func public @extract_slice1(%arg0 : tensor<5x24x48xf32>) -> tensor<4xf32> {
+util.func public @extract_slice1(%arg0 : tensor<5x24x48xf32>) -> tensor<4xf32> {
   %0 = tensor.extract_slice %arg0[2, 3, 4] [1, 1, 4] [1, 1, 1]
       : tensor<5x24x48xf32> to tensor<4xf32>
   util.return %0 : tensor<4xf32>
 }
-// CHECK-LABEL:  util.func public @extract_slice1(
+// CHECK-LABEL: util.func public @extract_slice1(
 //  CHECK-SAME:   %[[ARG0:.+]]: tensor<5x24x48xf32>)
 //   CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : index
 //   CHECK-DAG:   %[[C3:.+]] = arith.constant 3 : index
@@ -17,12 +17,12 @@
 
 // -----
 
- util.func public @extract_slice2(%arg0 : tensor<5x24x48xf32>) -> tensor<2x48xf32> {
+util.func public @extract_slice2(%arg0 : tensor<5x24x48xf32>) -> tensor<2x48xf32> {
   %0 = tensor.extract_slice %arg0[2, 3, 0] [1, 2, 48] [1, 1, 1]
       : tensor<5x24x48xf32> to tensor<2x48xf32>
   util.return %0 : tensor<2x48xf32>
 }
-// CHECK-LABEL:  util.func public @extract_slice2
+// CHECK-LABEL: util.func public @extract_slice2
 //  CHECK-SAME:   %[[ARG0:.+]]: tensor<5x24x48xf32>)
 //   CHECK-DAG:   %[[C3:.+]] = arith.constant 3 : index
 //   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
@@ -35,32 +35,32 @@
 
 // -----
 
- util.func public @extract_slice3(%arg0 : tensor<5x24x48xf32>) -> tensor<2x24xf32> {
+util.func public @extract_slice3(%arg0 : tensor<5x24x48xf32>) -> tensor<2x24xf32> {
   %0 = tensor.extract_slice %arg0[2, 3, 0] [1, 2, 24] [1, 1, 1]
       : tensor<5x24x48xf32> to tensor<2x24xf32>
   util.return %0 : tensor<2x24xf32>
 }
-// CHECK-LABEL:  util.func public @extract_slice3
+// CHECK-LABEL: util.func public @extract_slice3
 //       CHECK:   tensor.extract_slice
 
 // -----
 
- util.func public @extract_slice4(%arg0 : tensor<5x24x48xf32>, %arg1 : index) -> tensor<2x24xf32> {
+util.func public @extract_slice4(%arg0 : tensor<5x24x48xf32>, %arg1 : index) -> tensor<2x24xf32> {
   %0 = tensor.extract_slice %arg0[2, 3, 0] [1, 2, 24] [1, %arg1, 1]
       : tensor<5x24x48xf32> to tensor<2x24xf32>
   util.return %0 : tensor<2x24xf32>
 }
-// CHECK-LABEL:  util.func public @extract_slice4
+// CHECK-LABEL: util.func public @extract_slice4
 //       CHECK:   tensor.extract_slice
 
 // -----
 
- util.func public @extract_slice5(%arg0 : tensor<5x24x48xf32>, %arg1 : index) -> tensor<2x48xf32> {
+util.func public @extract_slice5(%arg0 : tensor<5x24x48xf32>, %arg1 : index) -> tensor<2x48xf32> {
   %0 = tensor.extract_slice %arg0[2, %arg1, 0] [1, 2, 48] [1, 1, 1]
       : tensor<5x24x48xf32> to tensor<2x48xf32>
   util.return %0 : tensor<2x48xf32>
 }
-// CHECK-LABEL:  util.func public @extract_slice5(
+// CHECK-LABEL: util.func public @extract_slice5(
 //  CHECK-SAME:   %[[ARG0:.+]]: tensor<5x24x48xf32>
 //  CHECK-SAME:   %[[ARG1:.+]]: index)
 //   CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : index
@@ -73,12 +73,12 @@
 
 // -----
 
- util.func public @extract_slice6(%arg0 : tensor<5x24x48xf32>, %arg1 : index) -> tensor<?x48xf32> {
+util.func public @extract_slice6(%arg0 : tensor<5x24x48xf32>, %arg1 : index) -> tensor<?x48xf32> {
   %0 = tensor.extract_slice %arg0[2, 3, 0] [1, %arg1, 48] [1, 1, 1]
       : tensor<5x24x48xf32> to tensor<?x48xf32>
   util.return %0 : tensor<?x48xf32>
 }
-// CHECK-LABEL:  util.func public @extract_slice6(
+// CHECK-LABEL: util.func public @extract_slice6(
 //  CHECK-SAME:   %[[ARG0:.+]]: tensor<5x24x48xf32>
 //  CHECK-SAME:   %[[ARG1:.+]]: index)
 //   CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : index
@@ -92,12 +92,12 @@
 
 // -----
 
- util.func public @extract_slice7(%arg0 : tensor<5x?x48xf32>, %arg1 : index) -> tensor<2x48xf32> {
+util.func public @extract_slice7(%arg0 : tensor<5x?x48xf32>, %arg1 : index) -> tensor<2x48xf32> {
   %0 = tensor.extract_slice %arg0[2, 3, 0] [1, 2, 48] [1, 1, 1]
       : tensor<5x?x48xf32> to tensor<2x48xf32>
   util.return %0 : tensor<2x48xf32>
 }
-// CHECK-LABEL:  util.func public @extract_slice7(
+// CHECK-LABEL: util.func public @extract_slice7(
 //  CHECK-SAME:   %[[ARG0:.+]]: tensor<5x?x48xf32>
 //  CHECK-SAME:   %[[ARG1:.+]]: index)
 //   CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : index
@@ -112,11 +112,11 @@
 
 // -----
 
- util.func public @rank_reducing_extract_slice(%arg0: tensor<?x513xi32>) -> tensor<513xi32> {
+util.func public @rank_reducing_extract_slice(%arg0: tensor<?x513xi32>) -> tensor<513xi32> {
   %0 = tensor.extract_slice %arg0[4, 0] [1, 513] [1, 1] : tensor<?x513xi32> to tensor<513xi32>
   util.return %0 : tensor<513xi32>
 }
-// CHECK-LABEL:  util.func public @rank_reducing_extract_slice
+// CHECK-LABEL: util.func public @rank_reducing_extract_slice
 //  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]
 //   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
@@ -131,12 +131,12 @@
 
 // -----
 
- util.func public @rank_reducing_extract_slice_trailing_unit_dims
+util.func public @rank_reducing_extract_slice_trailing_unit_dims
    (%arg0 : tensor<1x50x20x1xf32>) -> tensor<49x20xf32> {
   %0 = tensor.extract_slice %arg0[0, 1, 0, 0] [1, 49, 20, 1] [1, 1, 1, 1] : tensor<1x50x20x1xf32> to tensor<49x20xf32>
   util.return %0 : tensor<49x20xf32>
 }
-// CHECK-LABEL:  util.func public @rank_reducing_extract_slice_trailing_unit_dims
+// CHECK-LABEL: util.func public @rank_reducing_extract_slice_trailing_unit_dims
 //   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
 //   CHECK-DAG:   %[[C49:.+]] = arith.constant 49 : index
@@ -146,7 +146,7 @@
 
 // -----
 
- util.func public @extract_slice_within_dispatch_workgroups_not_converted() -> tensor<f32> {
+util.func public @extract_slice_within_dispatch_workgroups_not_converted() -> tensor<f32> {
   %x = arith.constant 100 : index
   %0 = flow.dispatch.workgroups[%x]() : () -> (tensor<f32>) = () {
     // CHECK: = tensor.extract_slice %[[source:.+]][2, 3, 4] [1, 1, 4] [1, 1, 1] : tensor<5x24x48xf32> to tensor<4xf32>

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/fill.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/fill.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt --iree-flow-convert-to-flow --split-input-file %s | FileCheck %s
 
- util.func public @tensor_reshape(%arg0 : tensor<?x4x?x5x?x6xf32>, %arg1 : tensor<20x?x40xf32>)
+util.func public @tensor_reshape(%arg0 : tensor<?x4x?x5x?x6xf32>, %arg1 : tensor<20x?x40xf32>)
     -> (tensor<?x5x?xf32>, tensor<5x4x?x4x2x4x5xf32>)
 {
   %0 = tensor.collapse_shape %arg0 [[0, 1, 2], [3], [4, 5]]
@@ -9,7 +9,7 @@
       : tensor<20x?x40xf32> into tensor<5x4x?x4x2x4x5xf32>
   util.return %0, %1 : tensor<?x5x?xf32>, tensor<5x4x?x4x2x4x5xf32>
 }
-// CHECK-LABEL:  util.func public @tensor_reshape
+// CHECK-LABEL: util.func public @tensor_reshape
 //  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<?x4x?x5x?x6xf32>
 //  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<20x?x40xf32>
 //   CHECK-DAG:   %[[R0:.+]] = flow.tensor.reshape %[[ARG0]]

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/from_elements.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/from_elements.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt --allow-unregistered-dialect --split-input-file --iree-flow-convert-to-flow %s | FileCheck %s
 
-// CHECK:  util.func public @tensor.from_elements__to__flow.tensor.splat(%[[arg0:.*]]: i8)
- util.func public @tensor.from_elements__to__flow.tensor.splat(%arg0: i8) -> (i8) {
+// CHECK: util.func public @tensor.from_elements__to__flow.tensor.splat(%[[arg0:.*]]: i8)
+util.func public @tensor.from_elements__to__flow.tensor.splat(%arg0: i8) -> (i8) {
   // CHECK: %[[splat_res:.*]] = flow.tensor.splat %[[arg0]] : tensor<1xi8>
   %0 = tensor.from_elements %arg0 : tensor<1xi8>
   // CHECK: flow.tensor.load %[[splat_res]]
@@ -10,8 +10,8 @@
 }
 
 // -----
-// CHECK:  util.func public @tensor.from_elements__not_convertible(%[[arg0:.*]]: i8)
- util.func public @tensor.from_elements__not_convertible(%arg0: i8) -> (i8) {
+// CHECK: util.func public @tensor.from_elements__not_convertible(%[[arg0:.*]]: i8)
+util.func public @tensor.from_elements__not_convertible(%arg0: i8) -> (i8) {
   // CHECK: %[[c0:.*]] = arith.constant 0
   %c0 = arith.constant 0 : index
   // CHECK: %[[res:.*]] = tensor.from_elements %[[arg0]], %[[arg0]] : tensor<2xi8>
@@ -22,7 +22,7 @@
 }
 
 // -----
- util.func public @tensor.from_elements__within_dispatch_workgroups_not_converted() -> tensor<f32> {
+util.func public @tensor.from_elements__within_dispatch_workgroups_not_converted() -> tensor<f32> {
   %x = arith.constant 100 : index
   %0 = flow.dispatch.workgroups[%x]() : () -> (tensor<f32>) = () {
     // CHECK: = tensor.from_elements %[[source:.+]] : tensor<1xi8>
@@ -36,11 +36,11 @@
 
 // -----
 
- util.func public @tensor.from_elements_0D(%arg0 : f32) -> tensor<f32> {
+util.func public @tensor.from_elements_0D(%arg0 : f32) -> tensor<f32> {
   %0 = tensor.from_elements %arg0 : tensor<f32>
   util.return %0 : tensor<f32>
 }
-//      CHECK:  util.func public @tensor.from_elements_0D
+//      CHECK: util.func public @tensor.from_elements_0D
 // CHECK-SAME:     %[[ARG0:.+]]: f32
 //      CHECK:   %[[SPLAT:.+]] = flow.tensor.splat %[[ARG0]] : tensor<f32>
 //      CHECK:   util.return %[[SPLAT]]

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/insert.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/insert.mlir
@@ -1,26 +1,26 @@
 // RUN: iree-opt --allow-unregistered-dialect --split-input-file --iree-flow-convert-to-flow %s | FileCheck %s
 
- util.func public @insert_convert_zero_ranked_tensor
+util.func public @insert_convert_zero_ranked_tensor
     (%arg0 : tensor<i64>) -> tensor<i64> {
   %c0_i64 = arith.constant 0 : i64
   %0 = tensor.insert %c0_i64 into %arg0[] : tensor<i64>
   util.return %0 : tensor<i64>
 }
-// CHECK-LABEL:  util.func public @insert_convert_zero_ranked_tensor
+// CHECK-LABEL: util.func public @insert_convert_zero_ranked_tensor
 //  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]
 //   CHECK-DAG:   %[[C0_I64:.+]] = arith.constant 0 : i64
 //       CHECK:   %[[UPDATE:.+]] = flow.tensor.store %[[C0_I64]], %[[ARG0]] : tensor<i64>
 
 // -----
 
- util.func public @insert_convert
+util.func public @insert_convert
     (%arg0 : tensor<2x3xi64>) -> tensor<2x3xi64> {
   %c0 = arith.constant 0 : index
   %c0_i64 = arith.constant 0 : i64
   %0 = tensor.insert %c0_i64 into %arg0[%c0, %c0] : tensor<2x3xi64>
   util.return %0 : tensor<2x3xi64>
 }
-// CHECK-LABEL:  util.func public @insert_convert
+// CHECK-LABEL: util.func public @insert_convert
 //  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]
 //   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //   CHECK-DAG:   %[[C0_I64:.+]] = arith.constant 0 : i64
@@ -28,14 +28,14 @@
 
 // -----
 
- util.func public @insert_convert_dynamic_dims
+util.func public @insert_convert_dynamic_dims
     (%arg0 : tensor<?x3xi64>) -> tensor<?x3xi64> {
   %c0 = arith.constant 0 : index
   %c0_i64 = arith.constant 0 : i64
   %0 = tensor.insert %c0_i64 into %arg0[%c0, %c0] : tensor<?x3xi64>
   util.return %0 : tensor<?x3xi64>
 }
-// CHECK-LABEL:  util.func public @insert_convert_dynamic_dims
+// CHECK-LABEL: util.func public @insert_convert_dynamic_dims
 //  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]
 //   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //   CHECK-DAG:   %[[C0_I64:.+]] = arith.constant 0 : i64
@@ -44,7 +44,7 @@
 
 // -----
 
- util.func public @insert_within_dispatch_workgroups_not_converted() -> tensor<f32> {
+util.func public @insert_within_dispatch_workgroups_not_converted() -> tensor<f32> {
   %x = arith.constant 100 : index
   %0 = flow.dispatch.workgroups[%x]() : () -> (tensor<f32>) = () {
     %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/insert_slice.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/insert_slice.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt --allow-unregistered-dialect --split-input-file --iree-flow-convert-to-flow %s | FileCheck %s
 
- util.func public @insert_slice_convert
+util.func public @insert_slice_convert
     (%arg0 : tensor<?x24x48xf32>, %arg1 : tensor<1x4x48xf32>) ->
     tensor<?x24x48xf32> {
   %c0 = arith.constant 0 : index
@@ -8,7 +8,7 @@
       tensor<1x4x48xf32> into tensor<?x24x48xf32>
   util.return %0 : tensor<?x24x48xf32>
 }
-// CHECK-LABEL:  util.func public @insert_slice_convert
+// CHECK-LABEL: util.func public @insert_slice_convert
 //  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]
 //  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]
 //   CHECK-DAG:   %[[C0:.+]] = arith.constant 0
@@ -20,7 +20,7 @@
 
 // -----
 
- util.func public @insert_slice_convert_rank_reducing
+util.func public @insert_slice_convert_rank_reducing
     (%arg0 : tensor<?x24x48xf32>, %arg1 : tensor<4x48xf32>) ->
     tensor<?x24x48xf32> {
   %c0 = arith.constant 0 : index
@@ -28,7 +28,7 @@
       tensor<4x48xf32> into tensor<?x24x48xf32>
   util.return %0 : tensor<?x24x48xf32>
 }
-// CHECK-LABEL:  util.func public @insert_slice_convert_rank_reducing
+// CHECK-LABEL: util.func public @insert_slice_convert_rank_reducing
 //  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]
 //  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]
 //   CHECK-DAG:   %[[C0:.+]] = arith.constant 0
@@ -41,12 +41,12 @@
 
 // -----
 
- util.func public @rank_reducing_insert_slice_trailing_unit_dims
+util.func public @rank_reducing_insert_slice_trailing_unit_dims
    (%arg0 : tensor<49x20xf32>, %arg1 : tensor<1x50x20x1xf32>) -> tensor<1x50x20x1xf32> {
   %0 = tensor.insert_slice %arg0 into %arg1[0, 1, 0, 0] [1, 49, 20, 1] [1, 1, 1, 1] : tensor<49x20xf32> into tensor<1x50x20x1xf32>
   util.return %0 : tensor<1x50x20x1xf32>
 }
-// CHECK-LABEL:  util.func public @rank_reducing_insert_slice_trailing_unit_dims
+// CHECK-LABEL: util.func public @rank_reducing_insert_slice_trailing_unit_dims
 //   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
 //       CHECK:   %[[RESHAPE:.+]] = flow.tensor.reshape %{{.+}} : tensor<49x20xf32> -> tensor<1x49x20x1xf32>
@@ -55,8 +55,8 @@
 
 // -----
 
-// CHECK-LABEL:  util.func public @insert_slice_within_dispatch_workgroups_not_converted
- util.func public @insert_slice_within_dispatch_workgroups_not_converted() -> tensor<f32> {
+// CHECK-LABEL: util.func public @insert_slice_within_dispatch_workgroups_not_converted
+util.func public @insert_slice_within_dispatch_workgroups_not_converted() -> tensor<f32> {
   %x = arith.constant 100 : index
   %0 = flow.dispatch.workgroups[%x]() : () -> (tensor<f32>) = () {
     // CHECK: = tensor.insert_slice %[[source2:.+]] into %[[source1:.+]][4, 2, 0] [1, 4, 48] [1, 1, 1] : tensor<1x4x48xf32> into tensor<?x24x48xf32>
@@ -72,14 +72,14 @@
 
 // -----
 
- util.func public @insert_slice_convert_dynamic_offset_and_size
+util.func public @insert_slice_convert_dynamic_offset_and_size
     (%target: tensor<?x24x48xf32>, %slice: tensor<1x?x48xf32>, %offset: index, %size: index) ->
     tensor<?x24x48xf32> {
   %0 = tensor.insert_slice %slice into %target[%offset, 2, 0] [1, %size, 48] [1, 1, 1] :
       tensor<1x?x48xf32> into tensor<?x24x48xf32>
   util.return %0 : tensor<?x24x48xf32>
 }
-// CHECK-LABEL:  util.func public @insert_slice_convert_dynamic_offset_and_size
+// CHECK-LABEL: util.func public @insert_slice_convert_dynamic_offset_and_size
 //  CHECK-SAME:   %[[TARGET:[a-zA-Z0-9_]+]]
 //  CHECK-SAME:   %[[SLICE:[a-zA-Z0-9_]+]]
 //  CHECK-SAME:   %[[OFFSET:[a-zA-Z0-9_]+]]
@@ -92,8 +92,8 @@
 
 // -----
 
-// CHECK-LABEL:  util.func public @insert_slice_dynamic_tensor_result_not_converted
- util.func public @insert_slice_dynamic_tensor_result_not_converted
+// CHECK-LABEL: util.func public @insert_slice_dynamic_tensor_result_not_converted
+util.func public @insert_slice_dynamic_tensor_result_not_converted
     (%arg0: tensor<?x24x48xf32>, %arg1: tensor<1x4x48xf32>, %offset: index) ->
     tensor<?x24x48xf32> {
   %x = arith.constant 100 : index

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/reshape.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/reshape.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt --iree-flow-convert-to-flow --split-input-file %s | FileCheck %s
 
- util.func public @turn_fill_into_splat(%arg0: tensor<?x?xf32>, %arg1: tensor<f32>, %arg2: index, %arg3: index, %arg4: index, %arg5: index) -> tensor<?x?xf32> {
+util.func public @turn_fill_into_splat(%arg0: tensor<?x?xf32>, %arg1: tensor<f32>, %arg2: index, %arg3: index, %arg4: index, %arg5: index) -> tensor<?x?xf32> {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %0 = tensor.extract %arg1[] : tensor<f32>
@@ -15,7 +15,7 @@
 }
 
 //       CHECK: #[[MAP:.+]] = affine_map<(d0)[s0, s1] -> (d0 + s0 + s1)>
-//       CHECK:  util.func public @turn_fill_into_splat
+//       CHECK: util.func public @turn_fill_into_splat
 //  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
 //  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9]+]]: tensor<f32>
 //  CHECK-SAME:   %[[ARG2:[a-zA-Z0-9]+]]: index
@@ -34,7 +34,7 @@
 
 // -----
 
- util.func public @static_tensor_reshape(%arg0: tensor<2x4xf32>, %arg1: tensor<2xindex>) -> tensor<1x8xf32> {
+util.func public @static_tensor_reshape(%arg0: tensor<2x4xf32>, %arg1: tensor<2xindex>) -> tensor<1x8xf32> {
   // CHECK-DAG: %[[RESULT:.*]] = flow.tensor.reshape %arg0 : tensor<2x4xf32> -> tensor<1x8xf32>
   // CHECK: util.return %[[RESULT]]
   %0 = tensor.reshape %arg0(%arg1)
@@ -43,8 +43,8 @@
 
 // -----
 
-   util.func public @dynamic_tensor_reshape(%arg0: tensor<2x4xf32>, %arg1: tensor<2xindex>) -> tensor<?x?xf32> {
-  //      CHECK:  util.func public @dynamic_tensor_reshape
+  util.func public @dynamic_tensor_reshape(%arg0: tensor<2x4xf32>, %arg1: tensor<2xindex>) -> tensor<?x?xf32> {
+  //      CHECK: util.func public @dynamic_tensor_reshape
   // CHECK-SAME:     %[[ARG0:.+]]: tensor<2x4xf32>
   // CHECK-SAME:     %[[ARG1:.+]]: tensor<2xindex>
   // CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
@@ -59,8 +59,8 @@
 
   // -----
 
-   util.func public @mix_dynamic_and_static_tensor_reshape(%arg0: tensor<2x4xf32>, %arg1: tensor<2xindex>) -> tensor<1x?xf32> {
-  //      CHECK:  util.func public @mix_dynamic_and_static_tensor_reshape
+  util.func public @mix_dynamic_and_static_tensor_reshape(%arg0: tensor<2x4xf32>, %arg1: tensor<2xindex>) -> tensor<1x?xf32> {
+  //      CHECK: util.func public @mix_dynamic_and_static_tensor_reshape
   // CHECK-SAME:     %[[ARG0:.+]]: tensor<2x4xf32>
   // CHECK-SAME:     %[[ARG1:.+]]: tensor<2xindex>
   // CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
@@ -73,8 +73,8 @@
 
   // -----
 
-   util.func public @dynamic_input_and_output_tensor_reshape(%arg0: tensor<?x4xf32>, %arg1: tensor<2xindex>) -> tensor<1x?xf32> {
-  //      CHECK:  util.func public @dynamic_input_and_output_tensor_reshape
+  util.func public @dynamic_input_and_output_tensor_reshape(%arg0: tensor<?x4xf32>, %arg1: tensor<2xindex>) -> tensor<1x?xf32> {
+  //      CHECK: util.func public @dynamic_input_and_output_tensor_reshape
   // CHECK-SAME:     %[[ARG0:.+]]: tensor<?x4xf32>
   // CHECK-SAME:     %[[ARG1:.+]]: tensor<2xindex>
   // CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
@@ -88,7 +88,7 @@
   util.return %0 : tensor<1x?xf32> }
 
   // -----
-   util.func public @from_elements_test_reshape(%arg0: tensor<?x4xf32>, %arg1: index, %arg2: index) -> tensor<?x1xf32> {
+  util.func public @from_elements_test_reshape(%arg0: tensor<?x4xf32>, %arg1: index, %arg2: index) -> tensor<?x1xf32> {
   // CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
   // CHECK-DAG: %[[D1:.*]] = tensor.dim %arg0, %[[C0:.*]] : tensor<?x4xf32>
   // CHECK-DAG: %[[RESULT:.*]] = flow.tensor.reshape %arg0 : tensor<?x4xf32>{%[[D1]]} -> tensor<?x1xf32>{%arg1}

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowDialect.cpp
@@ -74,11 +74,11 @@ FlowDialect::FlowDialect(MLIRContext *context)
 
 Operation *FlowDialect::materializeConstant(OpBuilder &builder, Attribute value,
                                             Type type, Location loc) {
-  if (arith::ConstantOp::isBuildableWith(value, type)) {
-    return builder.create<arith::ConstantOp>(loc, type, cast<TypedAttr>(value));
-  } else if (IREE::Flow::TensorConstantOp::isBuildableWith(value, type)) {
+  if (IREE::Flow::TensorConstantOp::isBuildableWith(value, type)) {
     return builder.create<IREE::Flow::TensorConstantOp>(loc, type,
                                                         cast<TypedAttr>(value));
+  } else if (arith::ConstantOp::isBuildableWith(value, type)) {
+    return builder.create<arith::ConstantOp>(loc, type, cast<TypedAttr>(value));
   }
   return nullptr;
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -1118,9 +1118,7 @@ bool DispatchWorkgroupsOp::canClosureContainOp(Operation *op) {
   // to requirements around tensor access checking.
   if (auto constantOp = dyn_cast<arith::ConstantOp>(op)) {
     auto constantType = constantOp.getType();
-    if (constantType.isIntOrIndexOrFloat()) {
-      return true;
-    }
+    return constantType.isIntOrIndexOrFloat();
   }
   return false;
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
@@ -233,7 +233,7 @@ util.func public @reshapeEmpty(%dim: index) -> tensor<?xi32> {
 
 // CHECK-LABEL: @loadConst
 util.func public @loadConst() -> i32 {
-  %0 = arith.constant dense<[[0, 1], [2, 3]]> : tensor<2x2xi32>
+  %0 = flow.tensor.constant dense<[[0, 1], [2, 3]]> : tensor<2x2xi32>
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   // CHECK-NEXT: %[[C2:.+]] = arith.constant 2 : i32
@@ -246,7 +246,7 @@ util.func public @loadConst() -> i32 {
 
 // CHECK-LABEL: @loadConstScalar
 util.func public @loadConstScalar() -> i32 {
-  %0 = arith.constant dense<4> : tensor<i32>
+  %0 = flow.tensor.constant dense<4> : tensor<i32>
   // CHECK-NEXT: %[[C4:.+]] = arith.constant 4 : i32
   %1 = flow.tensor.load %0 : tensor<i32>
   // CHECK-NEXT: util.return %[[C4]]
@@ -257,11 +257,11 @@ util.func public @loadConstScalar() -> i32 {
 
 // CHECK-LABEL: @storeConst
 util.func public @storeConst() -> tensor<2x2xi32> {
-  %0 = arith.constant dense<[[0, 1], [2, 3]]> : tensor<2x2xi32>
+  %0 = flow.tensor.constant dense<[[0, 1], [2, 3]]> : tensor<2x2xi32>
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c4 = arith.constant 4 : i32
-  // CHECK-NEXT: %[[C:.+]] = arith.constant dense<[
+  // CHECK-NEXT: %[[C:.+]] = flow.tensor.constant dense<[
   // CHECK-SAME:     [0, 1], [4, 3]
   // CHECK-SAME: ]> : tensor<2x2xi32>
   %1 = flow.tensor.store %c4, %0[%c1, %c0] : tensor<2x2xi32>
@@ -273,9 +273,9 @@ util.func public @storeConst() -> tensor<2x2xi32> {
 
 // CHECK-LABEL: @storeConstScalar
 util.func public @storeConstScalar() -> tensor<i32> {
-  %0 = arith.constant dense<0> : tensor<i32>
+  %0 = flow.tensor.constant dense<0> : tensor<i32>
   %1 = arith.constant 4 : i32
-  // CHECK-NEXT: %[[C:.+]] = arith.constant dense<4> : tensor<i32>
+  // CHECK-NEXT: %[[C:.+]] = flow.tensor.constant dense<4> : tensor<i32>
   %2 = flow.tensor.store %1, %0 : tensor<i32>
   // CHECK-NEXT: util.return %[[C]]
   util.return %2 : tensor<i32>
@@ -353,8 +353,8 @@ util.func public @splatDynamicZeroElements(%value: f32, %dim: index) -> tensor<0
 
 // CHECK-LABEL: @cloneConst
 util.func public @cloneConst() -> tensor<4xi32> {
-  // CHECK-NEXT: %[[C:.+]] = arith.constant dense<[0, 1, 2, 3]> : tensor<4xi32>
-  %0 = arith.constant dense<[0, 1, 2, 3]> : tensor<4xi32>
+  // CHECK-NEXT: %[[C:.+]] = flow.tensor.constant dense<[0, 1, 2, 3]> : tensor<4xi32>
+  %0 = flow.tensor.constant dense<[0, 1, 2, 3]> : tensor<4xi32>
   %1 = flow.tensor.clone %0 : tensor<4xi32>
   // CHECK-NEXT: util.return %[[C]]
   util.return %1 : tensor<4xi32>
@@ -364,8 +364,8 @@ util.func public @cloneConst() -> tensor<4xi32> {
 
 // CHECK-LABEL: @cloneConstZeroElements
 util.func public @cloneConstZeroElements() -> tensor<0x2xi32> {
-  // CHECK-NEXT: %[[C:.+]] = arith.constant dense<> : tensor<0x2xi32>
-  %0 = arith.constant dense<> : tensor<0x2xi32>
+  // CHECK-NEXT: %[[C:.+]] = flow.tensor.constant dense<> : tensor<0x2xi32>
+  %0 = flow.tensor.constant dense<> : tensor<0x2xi32>
   // CHECK-NOT: flow.tensor.clone
   %1 = flow.tensor.clone %0 : tensor<0x2xi32>
   // CHECK-NEXT: util.return %[[C]]
@@ -399,8 +399,8 @@ util.func public @cloneDynamicZeroElements(%arg0: tensor<0x?xf32>, %dim: index) 
 
 // CHECK-LABEL: @sliceConst0D
 util.func public @sliceConst0D() -> tensor<i32> {
-  %0 = arith.constant dense<0> : tensor<i32>
-  // CHECK-NEXT: %[[C:.+]] = arith.constant dense<0> : tensor<i32>
+  %0 = flow.tensor.constant dense<0> : tensor<i32>
+  // CHECK-NEXT: %[[C:.+]] = flow.tensor.constant dense<0> : tensor<i32>
   %1 = flow.tensor.slice %0[for] : tensor<i32> -> tensor<i32>
   // CHECK-NEXT: util.return %[[C]]
   util.return %1 : tensor<i32>
@@ -410,10 +410,10 @@ util.func public @sliceConst0D() -> tensor<i32> {
 
 // CHECK-LABEL: @sliceConst1D
 util.func public @sliceConst1D() -> tensor<1xi32> {
-  %0 = arith.constant dense<0> : tensor<1xi32>
+  %0 = flow.tensor.constant dense<0> : tensor<1xi32>
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
-  // CHECK-NEXT: %[[C:.+]] = arith.constant dense<0> : tensor<1xi32>
+  // CHECK-NEXT: %[[C:.+]] = flow.tensor.constant dense<0> : tensor<1xi32>
   %1 = flow.tensor.slice %0[%c0 for %c1] : tensor<1xi32> -> tensor<1xi32>
   // CHECK-NEXT: util.return %[[C]]
   util.return %1 : tensor<1xi32>
@@ -423,9 +423,9 @@ util.func public @sliceConst1D() -> tensor<1xi32> {
 
 // CHECK-LABEL: @sliceConst1DZeroLength
 util.func public @sliceConst1DZeroLength() -> tensor<0xi32> {
-  %0 = arith.constant dense<0> : tensor<1xi32>
+  %0 = flow.tensor.constant dense<0> : tensor<1xi32>
   %c0 = arith.constant 0 : index
-  // CHECK-NEXT: %[[C:.+]] = arith.constant dense<> : tensor<0xi32>
+  // CHECK-NEXT: %[[C:.+]] = flow.tensor.constant dense<> : tensor<0xi32>
   %1 = flow.tensor.slice %0[%c0 for %c0] : tensor<1xi32> -> tensor<0xi32>
   // CHECK-NEXT: util.return %[[C]]
   util.return %1 : tensor<0xi32>
@@ -435,11 +435,11 @@ util.func public @sliceConst1DZeroLength() -> tensor<0xi32> {
 
 // CHECK-LABEL: @sliceConst2D
 util.func public @sliceConst2D() -> tensor<1x2xi32> {
-  %0 = arith.constant dense<[[0, 1, 2], [3, 4, 5]]> : tensor<2x3xi32>
+  %0 = flow.tensor.constant dense<[[0, 1, 2], [3, 4, 5]]> : tensor<2x3xi32>
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index
-  // CHECK-NEXT: %[[C:.+]] = arith.constant dense<[
+  // CHECK-NEXT: %[[C:.+]] = flow.tensor.constant dense<[
   // CHECK-SAME:     [1, 2]
   // CHECK-SAME: ]> : tensor<1x2xi32>
   %1 = flow.tensor.slice %0[%c0, %c1 for %c1, %c2] : tensor<2x3xi32> -> tensor<1x2xi32>
@@ -451,10 +451,10 @@ util.func public @sliceConst2D() -> tensor<1x2xi32> {
 
 // CHECK-LABEL: @sliceConst2DZeroLength1
 util.func public @sliceConst2DZeroLength1() -> tensor<1x0xi32> {
-  %0 = arith.constant dense<[[0, 1, 2], [3, 4, 5]]> : tensor<2x3xi32>
+  %0 = flow.tensor.constant dense<[[0, 1, 2], [3, 4, 5]]> : tensor<2x3xi32>
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
-  // CHECK-NEXT: %[[C:.+]] = arith.constant dense<> : tensor<1x0xi32>
+  // CHECK-NEXT: %[[C:.+]] = flow.tensor.constant dense<> : tensor<1x0xi32>
   %1 = flow.tensor.slice %0[%c0, %c0 for %c1, %c0] : tensor<2x3xi32> -> tensor<1x0xi32>
   // CHECK-NEXT: util.return %[[C]]
   util.return %1 : tensor<1x0xi32>
@@ -464,9 +464,9 @@ util.func public @sliceConst2DZeroLength1() -> tensor<1x0xi32> {
 
 // CHECK-LABEL: @sliceConst2DZeroLength01
 util.func public @sliceConst2DZeroLength01() -> tensor<0x0xi32> {
-  %0 = arith.constant dense<[[0, 1, 2], [3, 4, 5]]> : tensor<2x3xi32>
+  %0 = flow.tensor.constant dense<[[0, 1, 2], [3, 4, 5]]> : tensor<2x3xi32>
   %c0 = arith.constant 0 : index
-  // CHECK-NEXT: %[[C:.+]] = arith.constant dense<> : tensor<0x0xi32>
+  // CHECK-NEXT: %[[C:.+]] = flow.tensor.constant dense<> : tensor<0x0xi32>
   %1 = flow.tensor.slice %0[%c0, %c0 for %c0, %c0] : tensor<2x3xi32> -> tensor<0x0xi32>
   // CHECK-NEXT: util.return %[[C]]
   util.return %1 : tensor<0x0xi32>
@@ -500,12 +500,12 @@ util.func public @sliceZeroElements(%arg0: tensor<?xi32>, %dim: index) -> tensor
 
 // CHECK-LABEL: @sliceConst3D
 util.func public @sliceConst3D() -> tensor<1x2x3xi32> {
-  %0 = arith.constant dense<[[[0, 1, 2], [3, 4, 5], [6, 7, 8]], [[9, 10, 11], [12, 13, 14], [15, 16, 17]]]> : tensor<2x3x3xi32>
+  %0 = flow.tensor.constant dense<[[[0, 1, 2], [3, 4, 5], [6, 7, 8]], [[9, 10, 11], [12, 13, 14], [15, 16, 17]]]> : tensor<2x3x3xi32>
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index
   %c3 = arith.constant 3 : index
-  // CHECK-NEXT: %[[C:.+]] = arith.constant dense<[
+  // CHECK-NEXT: %[[C:.+]] = flow.tensor.constant dense<[
   // CHECK-SAME:                             [
   // CHECK-SAME:                              [3, 4, 5], [6, 7, 8]]]> : tensor<1x2x3xi32>
   %1 = flow.tensor.slice %0[%c0, %c1, %c0 for %c1, %c2, %c3] : tensor<2x3x3xi32> -> tensor<1x2x3xi32>
@@ -517,9 +517,9 @@ util.func public @sliceConst3D() -> tensor<1x2x3xi32> {
 
 // CHECK-LABEL: @updateConst0D
 util.func public @updateConst0D() -> tensor<i32> {
-  %0 = arith.constant dense<0> : tensor<i32>
-  %1 = arith.constant dense<1> : tensor<i32>
-  // CHECK-NEXT: %[[C:.+]] = arith.constant dense<0> : tensor<i32>
+  %0 = flow.tensor.constant dense<0> : tensor<i32>
+  %1 = flow.tensor.constant dense<1> : tensor<i32>
+  // CHECK-NEXT: %[[C:.+]] = flow.tensor.constant dense<0> : tensor<i32>
   %2 = flow.tensor.update %0, %1[] : tensor<i32> -> tensor<i32>
   // CHECK-NEXT: util.return %[[C]]
   util.return %2 : tensor<i32>
@@ -529,10 +529,10 @@ util.func public @updateConst0D() -> tensor<i32> {
 
 // CHECK-LABEL: @updateConst1D
 util.func public @updateConst1D() -> tensor<1xi32> {
-  %0 = arith.constant dense<0> : tensor<1xi32>
-  %1 = arith.constant dense<1> : tensor<1xi32>
+  %0 = flow.tensor.constant dense<0> : tensor<1xi32>
+  %1 = flow.tensor.constant dense<1> : tensor<1xi32>
   %c0 = arith.constant 0 : index
-  // CHECK-NEXT: %[[C:.+]] = arith.constant dense<0> : tensor<1xi32>
+  // CHECK-NEXT: %[[C:.+]] = flow.tensor.constant dense<0> : tensor<1xi32>
   %2 = flow.tensor.update %0, %1[%c0] : tensor<1xi32> -> tensor<1xi32>
   // CHECK-NEXT: util.return %[[C]]
   util.return %2 : tensor<1xi32>
@@ -542,10 +542,10 @@ util.func public @updateConst1D() -> tensor<1xi32> {
 
 // CHECK-LABEL: @updateConst1DUpdateZeroSize
 util.func public @updateConst1DUpdateZeroSize() -> tensor<1xi32> {
-  %0 = arith.constant dense<> : tensor<0xi32>
-  %1 = arith.constant dense<1> : tensor<1xi32>
+  %0 = flow.tensor.constant dense<> : tensor<0xi32>
+  %1 = flow.tensor.constant dense<1> : tensor<1xi32>
   %c0 = arith.constant 0 : index
-  // CHECK-NEXT: %[[C:.+]] = arith.constant dense<1> : tensor<1xi32>
+  // CHECK-NEXT: %[[C:.+]] = flow.tensor.constant dense<1> : tensor<1xi32>
   %2 = flow.tensor.update %0, %1[%c0] : tensor<0xi32> -> tensor<1xi32>
   // CHECK-NEXT: util.return %[[C]]
   util.return %2 : tensor<1xi32>
@@ -555,11 +555,11 @@ util.func public @updateConst1DUpdateZeroSize() -> tensor<1xi32> {
 
 // CHECK-LABEL: @updateConst2DUpdate1x1
 util.func public @updateConst2DUpdate1x1() -> tensor<3x4xi32> {
-  %0 = arith.constant dense<[[12]]> : tensor<1x1xi32>
-  %1 = arith.constant dense<[[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]> : tensor<3x4xi32>
+  %0 = flow.tensor.constant dense<[[12]]> : tensor<1x1xi32>
+  %1 = flow.tensor.constant dense<[[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]> : tensor<3x4xi32>
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
-  // CHECK-NEXT: %[[C:.+]] = arith.constant dense<[
+  // CHECK-NEXT: %[[C:.+]] = flow.tensor.constant dense<[
   // CHECK-SAME: [0, 12, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]> : tensor<3x4xi32>
   %2 = flow.tensor.update %0, %1[%c0, %c1] : tensor<1x1xi32> -> tensor<3x4xi32>
   // CHECK-NEXT: util.return %[[C]]
@@ -570,11 +570,11 @@ util.func public @updateConst2DUpdate1x1() -> tensor<3x4xi32> {
 
 // CHECK-LABEL: @updateConst2DUpdate2x2
 util.func public @updateConst2DUpdate2x2() -> tensor<3x4xi32> {
-  %0 = arith.constant dense<[[12, 13], [14, 15]]> : tensor<2x2xi32>
-  %1 = arith.constant dense<[[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]> : tensor<3x4xi32>
+  %0 = flow.tensor.constant dense<[[12, 13], [14, 15]]> : tensor<2x2xi32>
+  %1 = flow.tensor.constant dense<[[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]> : tensor<3x4xi32>
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
-  // CHECK-NEXT: %[[C:.+]] = arith.constant dense<[
+  // CHECK-NEXT: %[[C:.+]] = flow.tensor.constant dense<[
   // CHECK-SAME: [0, 12, 13, 3], [4, 14, 15, 7], [8, 9, 10, 11]]> : tensor<3x4xi32>
   %2 = flow.tensor.update %0, %1[%c0, %c1] : tensor<2x2xi32> -> tensor<3x4xi32>
   // CHECK-NEXT: util.return %[[C]]
@@ -585,11 +585,11 @@ util.func public @updateConst2DUpdate2x2() -> tensor<3x4xi32> {
 
 // CHECK-LABEL: @updateConst3DUpdate1x2x3
 util.func public @updateConst3DUpdate1x2x3() -> tensor<2x3x3xi32> {
-  %0 = arith.constant dense<[[[18, 19, 20], [21, 22, 23]]]> : tensor<1x2x3xi32>
-  %1 = arith.constant dense<[[[0, 1, 2], [3, 4, 5], [6, 7, 8]], [[9, 10, 11], [12, 13, 14], [15, 16, 17]]]> : tensor<2x3x3xi32>
+  %0 = flow.tensor.constant dense<[[[18, 19, 20], [21, 22, 23]]]> : tensor<1x2x3xi32>
+  %1 = flow.tensor.constant dense<[[[0, 1, 2], [3, 4, 5], [6, 7, 8]], [[9, 10, 11], [12, 13, 14], [15, 16, 17]]]> : tensor<2x3x3xi32>
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
-  // CHECK-NEXT: %[[C:.+]] = arith.constant dense<[
+  // CHECK-NEXT: %[[C:.+]] = flow.tensor.constant dense<[
   // CHECK-SAME:                             [
   // CHECK-SAME:                              [0, 1, 2], [18, 19, 20], [21, 22, 23]], [
   // CHECK-SAME: [9, 10, 11], [12, 13, 14], [15, 16, 17]]]> : tensor<2x3x3xi32>
@@ -602,11 +602,11 @@ util.func public @updateConst3DUpdate1x2x3() -> tensor<2x3x3xi32> {
 
 // CHECK-LABEL: @updateConst3DUpdate2x3x2
 util.func public @updateConst3DUpdate2x3x2() -> tensor<2x3x3xi32> {
-  %0 = arith.constant dense<[[[18, 19], [20, 21], [22, 23]], [[24, 25], [26, 27], [28, 29]]]> : tensor<2x3x2xi32>
-  %1 = arith.constant dense<[[[0, 1, 2], [3, 4, 5], [6, 7, 8]], [[9, 10, 11], [12, 13, 14], [15, 16, 17]]]> : tensor<2x3x3xi32>
+  %0 = flow.tensor.constant dense<[[[18, 19], [20, 21], [22, 23]], [[24, 25], [26, 27], [28, 29]]]> : tensor<2x3x2xi32>
+  %1 = flow.tensor.constant dense<[[[0, 1, 2], [3, 4, 5], [6, 7, 8]], [[9, 10, 11], [12, 13, 14], [15, 16, 17]]]> : tensor<2x3x3xi32>
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 0 : index
-  // CHECK-NEXT: %[[C:.+]] = arith.constant dense<[
+  // CHECK-NEXT: %[[C:.+]] = flow.tensor.constant dense<[
   // CHECK-SAME:                             [
   // CHECK-SAME:                              [18, 19, 2], [20, 21, 5], [22, 23, 8]], [
   // CHECK-SAME: [24, 25, 11], [26, 27, 14], [28, 29, 17]]]> : tensor<2x3x3xi32>

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -601,7 +601,8 @@ bool isClonableIntoDispatchOp(Operation *op) {
   if (isDequantizationLikeOp(op)) {
     return true;
   }
-  if (isa<arith::ConstantOp>(op) || isa<complex::ConstantOp>(op)) {
+  if (isa<arith::ConstantOp>(op) || isa<complex::ConstantOp>(op) ||
+      isa<IREE::Flow::TensorConstantOp>(op)) {
     if (clInlineConstantByteLength == 0)
       return false;
     Attribute constantValueAttr;


### PR DESCRIPTION
This allow us to consistently have our own op instead of mixing in the arith op at various times (any time a folder returns a constant value, partial conversion, etc).