### PR TITLE
[Flow] Changes to dispatch region formation based on SDXL branch.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
@@ -410,10 +410,10 @@ static bool hasCompatibleOuterParallelLoops(
 /// For all uses of an operation, finds the use that dominates all other uses.
 static std::optional<OpOperand *>
 getFusableUse(Operation *op, DominanceInfo const &dominanceInfo,
-              bool fuseMultiUse) {
-  if (!fuseMultiUse && llvm::count_if(op->getUses(), [](OpOperand &use) {
-                         return !isa<tensor::DimOp>(use.getOwner());
-                       }) != 1) {
+              bool aggressiveFusion) {
+  if (!aggressiveFusion && llvm::count_if(op->getUses(), [](OpOperand &use) {
+                             return !isa<tensor::DimOp>(use.getOwner());
+                           }) != 1) {
     return std::nullopt;
   }
 
@@ -502,6 +502,21 @@ static bool canUseInOperandAsInitOperand(OpOperand *inOperand,
   return true;
 }
 
+/// All operations in a dispatch should be vectorized, which isnt the case today
+/// This is an explicit list of operations that arent vectorized for now
+/// requiring special handling for now in dispatch region formation to avoid
+/// large stack allocations.
+static bool isVectorizedAlways(Operation *producer) {
+  // TODO(#17155) : This is a black list of operations that are not vectorized
+  // today (under the aggressive fusion flag). Remove this blacklist to return
+  // true always.
+  if (auto convOp = dyn_cast<linalg::Conv2DNhwcHwcfOp>(producer)) {
+    auto strides = convOp.getStrides();
+    return strides.isSplat() && strides.getSplatValue<int64_t>() == 1;
+  }
+  return true;
+}
+
 /// Returns true if this is a fusable use, while fusing a root with its
 /// consumer.
 static bool
@@ -510,6 +525,12 @@ isFusableWithConsumer(OpOperand &fusedOperand,
                       FormDispatchRegionsPassOptions const &options) {
   Operation *producer = fusedOperand.get().getDefiningOp();
   Operation *consumer = fusedOperand.getOwner();
+
+  // If consumer is a dequant operation, dont fuse it. These get cloned
+  // into their consumers.
+  if (isDequantizationLikeOp(consumer)) {
+    return false;
+  }
 
   // Fuse unset_encoding operations with `tensor.extract_slice` and elementwise
   // generic ops.
@@ -564,6 +585,20 @@ isFusableWithConsumer(OpOperand &fusedOperand,
     return false;
   }
 
+  // Insert slice ops should always be fused with their producers.
+  if (auto insertSliceOp = dyn_cast<tensor::InsertSliceOp>(consumer)) {
+    // TODO: Enable multi-use slice source fusion.
+    Value source = insertSliceOp.getSource();
+    if (!source.hasOneUse() || source.getDefiningOp() != producer) {
+      return false;
+    }
+    // Fuse in `insert_slice` consumer operations if destination is a fill.
+    // TODO: This can be generalized, but destination cannot be a
+    // `arith.constant` or other constant-like objects. `linalg.fill` captures a
+    // common case of pad generalization.
+    return insertSliceOp.getDest().getDefiningOp<linalg::FillOp>();
+  }
+
   // TODO(#16025): Enable mmt4d fusion. It is disabled because the backends
   // can not set multi lowering_config properly. See the issue for more details.
   if (isa<linalg::Mmt4DOp>(producer)) {
@@ -585,6 +620,23 @@ isFusableWithConsumer(OpOperand &fusedOperand,
     return false;
   }
 
+  // Check if the iteration spaces of the producer and consumer are same.
+  // TODO(#12664): This is unnecessary requirement, but we need a better config
+  // to tile the consumer with a larger iteration space.
+  auto producerIterationSpace = producerLinalgOp.getStaticLoopRanges();
+  auto consumerIterationSpace = consumerLinalgOp.getStaticLoopRanges();
+  if (producerIterationSpace.size() < consumerIterationSpace.size()) {
+    return false;
+  }
+
+  // Under aggressive fusion assume that the dispatches are vectorized. In which
+  // case we dont need to account for the subsequent stack allocation condition.
+  if (options.aggressiveFusion) {
+    if (isVectorizedAlways(producer)) {
+      return true;
+    }
+  }
+
   // While fusing with consumer, the result of the root might not be the final
   // result of the dispatch. To avoid a stack allocation we have to ensure that
   // all operations can bufferize without needing additional memory.
@@ -598,15 +650,6 @@ isFusableWithConsumer(OpOperand &fusedOperand,
             })) {
       return false;
     }
-  }
-
-  // Check if the iteration spaces of the producer and consumer are same.
-  // TODO(#12664): This is unnecessary requirement, but we need a better config
-  // to tile the consumer with a larger iteration space.
-  auto producerIterationSpace = producerLinalgOp.getStaticLoopRanges();
-  auto consumerIterationSpace = consumerLinalgOp.getStaticLoopRanges();
-  if (producerIterationSpace.size() < consumerIterationSpace.size()) {
-    return false;
   }
 
   return true;
@@ -637,8 +680,9 @@ fuseRootsWithConsumers(MLIRContext *context, ArrayRef<Operation *> roots,
         appendToFusionGroup(currRoot, rootNumber);
       };
 
-      std::optional<OpOperand *> fusableUse = getFusableUse(
-          currRoot, dominanceInfo, /*fuseMultiUse=*/options.fuseMultiUse);
+      std::optional<OpOperand *> fusableUse =
+          getFusableUse(currRoot, dominanceInfo,
+                        /*aggressiveFusion=*/options.aggressiveFusion);
       if (!fusableUse)
         continue;
 
@@ -704,9 +748,11 @@ isFusableWithProducer(OpOperand &operand,
     return false;
   }
 
-  auto consumerLinalgOp = cast<linalg::LinalgOp>(consumer);
-  if (!consumerLinalgOp.isDpsInit(&operand)) {
-    return false;
+  if (!options.aggressiveFusion) {
+    auto consumerLinalgOp = cast<linalg::LinalgOp>(consumer);
+    if (!consumerLinalgOp.isDpsInit(&operand)) {
+      return false;
+    }
   }
 
   return areOpsFusable(producer, consumer, rootOuterParallelLoops);
@@ -732,8 +778,9 @@ fuseRootsWithProducers(MLIRContext *context, Operation *root, unsigned groupNum,
         continue;
       }
 
-      std::optional<OpOperand *> fusableUse = getFusableUse(
-          producer, dominanceInfo, /*fuseMultiUse=*/options.fuseMultiUse);
+      std::optional<OpOperand *> fusableUse =
+          getFusableUse(producer, dominanceInfo,
+                        /*aggressiveFusion=*/options.aggressiveFusion);
       if (!fusableUse || fusableUse.value()->getOwner() != candidate)
         continue;
 
@@ -936,9 +983,9 @@ void FormDispatchRegionsPass::runOnOperation() {
   mlir::FunctionOpInterface funcOp = getOperation();
   DominanceInfo const &dominanceInfo = getAnalysis<DominanceInfo>();
   TensorDimTrackingRewriter rewriter(funcOp);
-  FormDispatchRegionsPassOptions options{fuseMultiUse, generateWorkloadRegion,
-                                         fusePadWithConsumers,
-                                         fusePadWithProducers};
+  FormDispatchRegionsPassOptions options{
+      aggressiveFusion, generateWorkloadRegion, fusePadWithConsumers,
+      fusePadWithProducers};
   if (failed(createFusionGroups(rewriter, funcOp, dominanceInfo, options))) {
     funcOp->emitOpError("failed to create fusion groups");
     return signalPassFailure();

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -88,6 +88,12 @@ static llvm::cl::opt<bool> clEnableElementWiseFuseMultiReduction(
     llvm::cl::desc("Enable element-wise fusion of multi-reduction loop ops."),
     llvm::cl::init(true));
 
+static llvm::cl::opt<bool> clEnableAggressiveFusion(
+    "iree-flow-enable-aggressive-fusion",
+    llvm::cl::desc("Aggressive fusion opportunities that are behind a flag "
+                   "since all backends dont support it yet"),
+    llvm::cl::init(false));
+
 static llvm::cl::opt<bool> clDispatchGenerateWorkloadRegion(
     "iree-flow-dispatch-generate-workload-region",
     llvm::cl::desc("Generate the workload region."), llvm::cl::init(true));
@@ -207,7 +213,7 @@ void addDispatchRegionCreationPasses(OpPassManager &passManager,
       // producers.
       .addPass([&]() {
         return createFormDispatchRegionsPass(FormDispatchRegionsPassOptions{
-            clEnableFuseMultiUse, clDispatchGenerateWorkloadRegion,
+            clEnableAggressiveFusion, clDispatchGenerateWorkloadRegion,
             clEnableFusePaddingIntoLinalgConsumerOps,
             clEnableFusePaddingIntoLinalgProducerOps});
       })

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -102,8 +102,8 @@ def FormDispatchRegionsPass :
     InterfacePass<"iree-flow-form-dispatch-regions", "mlir::FunctionOpInterface"> {
   let summary = "Form Dispatch Region Ops from Linalg operations on tensors to form dispatch.regions";
   let options = [
-    Option<"fuseMultiUse", "fuse-multi-use", "bool",
-           /*default=*/"false", "Fuse multi-use ops">,
+    Option<"aggressiveFusion", "aggressive-fusion", "bool",
+           /*default=*/"false", "Aggressive mode enabling fusions not ready for all backends">,
     Option<"generateWorkloadRegion", "genereate-workload-region", "bool",
            /*default=*/"true", "Generate workload regions of WorkgroupOps">,
     Option<"fusePadWithConsumers", "fuse-pad-with-consumers", "bool",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -580,6 +580,13 @@ bool isDequantizationLikeOp(Operation *op) {
       outputElementType.getIntOrFloatBitWidth()) {
     return false;
   }
+
+  // Check if there are any operations from math dialect.
+  for (Operation &op : *genericOp.getBody()) {
+    if (op.getDialect() == op.getContext()->getLoadedDialect("math")) {
+      return false;
+    }
+  }
   return true;
 }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/collapse_linalg_generic_on_tensors.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/collapse_linalg_generic_on_tensors.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(util.func(iree-flow-form-dispatch-regions{fuse-multi-use=true}, iree-flow-clone-producers-into-dispatch-regions, iree-flow-collapse-dimensions, cse))" %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(util.func(iree-flow-form-dispatch-regions{aggressive-fusion=true}, iree-flow-clone-producers-into-dispatch-regions, iree-flow-collapse-dimensions, cse))" %s | FileCheck %s
 !type = tensor<2x4x8x16x32x64xf32>
 util.global private @"__transpose_10_input" {inlining_policy = #util.inline.never} = dense<1.0> : !type
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors_default.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors_default.mlir
@@ -88,3 +88,36 @@ util.func public @fix_dominance_on_fusion(%arg0 : tensor<?x?xf32>, %arg1 : tenso
 //  CHECK-SAME:         ins(%[[GEMM]],
 //       CHECK:     flow.dispatch.tensor.store %[[GENERIC]]
 //       CHECK:   util.return %[[RESULT]]
+
+// -----
+
+util.func @mixed_conv(%arg0 : tensor<2x130x130x16xf16>, %arg1 : tensor<3x3x16x320xf16>) -> tensor<2x128x128x320xf16> {
+  %empty = tensor.empty() : tensor<2x128x128x320xf32>
+  %cst = arith.constant 0.0 : f32
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<2x128x128x320xf32>) -> tensor<2x128x128x320xf32>
+  %conv = linalg.conv_2d_nhwc_hwcf {
+      dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>}
+      ins(%arg0, %arg1 : tensor<2x130x130x16xf16>, tensor<3x3x16x320xf16>)
+      outs(%fill : tensor<2x128x128x320xf32>) -> tensor<2x128x128x320xf32>
+  %empty1 = tensor.empty() : tensor<2x128x128x320xf16>
+  %truncf = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>,
+                       affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
+      iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+      ins(%conv : tensor<2x128x128x320xf32>) outs(%empty1 : tensor<2x128x128x320xf16>) {
+    ^bb0(%b0 : f32, %b1 :f16):
+      %0 = arith.truncf %b0 : f32 to f16
+      linalg.yield %0 : f16
+  } -> tensor<2x128x128x320xf16>
+  util.return %truncf : tensor<2x128x128x320xf16>
+}
+// CHECK-LABEL: func public @mixed_conv(
+//       CHECK:   flow.dispatch.workgroups
+//       CHECK:     %[[FILL:.+]] = linalg.fill
+//       CHECK:     %[[CONV:.+]] = linalg.conv_2d_nhwc_hwcf
+//  CHECK-SAME:         outs(%[[FILL]] :
+//       CHECK:     flow.dispatch.tensor.store
+//       CHECK:   %[[DISPATCH1:.+]] = flow.dispatch.workgroups
+//       CHECK:     %[[GENERIC:.+]] = linalg.generic
+//       CHECK:     flow.dispatch.tensor.store %[[GENERIC]]
+//       CHECK:   util.return %[[DISPATCH1]]

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors_fusion_with_transpose.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors_fusion_with_transpose.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --verify-diagnostics --pass-pipeline="builtin.module(util.func(iree-flow-interchange-transpose-generic-ops,iree-flow-form-dispatch-regions{fuse-multi-use=true}, iree-flow-form-dispatch-workgroups, canonicalize, cse))" %s | FileCheck %s
+// RUN: iree-opt --split-input-file --verify-diagnostics --pass-pipeline="builtin.module(util.func(iree-flow-interchange-transpose-generic-ops,iree-flow-form-dispatch-regions{aggressive-fusion=true}, iree-flow-form-dispatch-workgroups, canonicalize, cse))" %s | FileCheck %s
 
 util.func public @fuse_batch_matmul_transpose(%a: tensor<4x384x384xf32>, %b: tensor<4x384x32xf32>) -> tensor<384x4x32xf32> {
   %cst = arith.constant 0.000000e+00 : f32


### PR DESCRIPTION
This PR merges changes to dispatch region formation that helped on reducing number of dispatches in the SDXL branch. It includes

1) Fuse `tensor.insert_slice` consumers in some cases. 2) Avoid fusing consumers that are dequantization operations (also
   tighten the definition of dequantization operations)
3) Add a mode to do aggressive fusion that assumes all operations
   within a dispatch are vectorized, avoiding some pessimizing fusion
   decisions which are made to avoid high stack allocations.