### PR TITLE
[Flow] Enable normalize input indexing maps by default, but restrict it to convolutions.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/InterchangeTransposeGenericOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/InterchangeTransposeGenericOps.cpp
@@ -39,8 +39,8 @@ struct TransposeGenericOpPattern : public OpRewritePattern<linalg::GenericOp> {
     std::optional<AffineMap> mapForInterchange;
 
     for (auto operand : genericOp.getDpsInputOperands()) {
-      auto producer = operand->get().getDefiningOp<linalg::LinalgOp>();
-      if (!producer)
+      auto producer = operand->get().getDefiningOp<linalg::Conv2DNhwcHwcfOp>();
+      if (!producer || !llvm::hasSingleElement(producer->getUsers()))
         continue;
 
       // check if the generic op has a non-identity map for the operand.

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -98,11 +98,6 @@ static llvm::cl::opt<bool> clDispatchGenerateWorkloadRegion(
     "iree-flow-dispatch-generate-workload-region",
     llvm::cl::desc("Generate the workload region."), llvm::cl::init(true));
 
-static llvm::cl::opt<bool> clNormalizeInputIndexingMap(
-    "iree-flow-normalize-input-indexing-map",
-    llvm::cl::desc("Enable normalizing input indexing map to identity."),
-    llvm::cl::init(false));
-
 static llvm::cl::opt<bool>
     clDumpDispatchGraph("iree-flow-dump-dispatch-graph",
                         llvm::cl::desc("Dump a dot graph for dispatches."),
@@ -193,8 +188,7 @@ void addDispatchRegionCreationPasses(OpPassManager &passManager,
       // Normalize the input indexing map to make the input indexing map
       // identity. This helps fusing named linalg op with a generic op with
       // transpose.
-      .addPredicatedPass(clNormalizeInputIndexingMap,
-                         createInterchangeTransposeGenericOpsPass)
+      .addPass(createInterchangeTransposeGenericOpsPass)
       ////////////////////////////////////////////////////////////////////////
       // Dispatch region formation.
       .addPredicatedPass(

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors_fusion_with_transpose.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors_fusion_with_transpose.mlir
@@ -1,59 +1,34 @@
-// RUN: iree-opt --split-input-file --verify-diagnostics --pass-pipeline="builtin.module(util.func(iree-flow-interchange-transpose-generic-ops,iree-flow-form-dispatch-regions{aggressive-fusion=true}, iree-flow-form-dispatch-workgroups, canonicalize, cse))" %s | FileCheck %s
+// RUN: iree-opt --split-input-file --verify-diagnostics --pass-pipeline="builtin.module(util.func(iree-flow-interchange-transpose-generic-ops,iree-flow-form-dispatch-regions{aggressive-fusion=true}, iree-flow-form-dispatch-workgroups, canonicalize, cse))" --mlir-print-local-scope %s | FileCheck %s
 
-util.func public @fuse_batch_matmul_transpose(%a: tensor<4x384x384xf32>, %b: tensor<4x384x32xf32>) -> tensor<384x4x32xf32> {
-  %cst = arith.constant 0.000000e+00 : f32
-  %init = tensor.empty() : tensor<4x384x32xf32>
-  %c = linalg.fill ins(%cst : f32) outs(%init : tensor<4x384x32xf32>) -> tensor<4x384x32xf32>
-  %matmul = linalg.batch_matmul ins(%a, %b : tensor<4x384x384xf32>, tensor<4x384x32xf32>) outs(%c : tensor<4x384x32xf32>) -> tensor<4x384x32xf32>
-  %result = tensor.empty() : tensor<384x4x32xf32>
-  %transpose = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d1, d0, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%matmul : tensor<4x384x32xf32>) outs(%result : tensor<384x4x32xf32>) {
-  ^bb0(%arg0: f32, %arg1: f32):
-    linalg.yield %arg0 : f32
-  } -> tensor<384x4x32xf32>
-  util.return %transpose : tensor<384x4x32xf32>
+util.func @fuse_conv(%arg0 : tensor<2x130x130x16xf32>, %arg1 : tensor<3x3x16x320xf32>) -> tensor<2x320x128x128xf32> {
+  %empty = tensor.empty() : tensor<2x128x128x320xf32>
+  %cst = arith.constant 0.0 : f32
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<2x128x128x320xf32>) -> tensor<2x128x128x320xf32>
+  %conv = linalg.conv_2d_nhwc_hwcf {
+      dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>}
+      ins(%arg0, %arg1 : tensor<2x130x130x16xf32>, tensor<3x3x16x320xf32>)
+      outs(%fill : tensor<2x128x128x320xf32>) -> tensor<2x128x128x320xf32>
+  %empty1 = tensor.empty() : tensor<2x320x128x128xf32>
+  %truncf = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d2, d3, d1)>,
+                       affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
+      iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+      ins(%conv : tensor<2x128x128x320xf32>) outs(%empty1 : tensor<2x320x128x128xf32>) {
+    ^bb0(%b0 : f32, %b1 :f32):
+      %0 = arith.addf %b0, %b0 : f32
+      linalg.yield %0 : f32
+  } -> tensor<2x320x128x128xf32>
+  util.return %truncf : tensor<2x320x128x128xf32>
 }
-
 // Check that
-// * linalg.batch_matmul is fused together with linalg.generic;
+// * linalg.conv is fused together with linalg.generic;
 // * linalg.generic's input and output indexing maps are exchanged.
 
-//      CHECK: #[[$MAP0:.+]] = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
-//      CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d0, d2)>
-// CHECK-LABEL: util.func public @fuse_batch_matmul_transpose
-//      CHECK: flow.dispatch.workgroups
-//      CHECK:   %[[MATMUL:.+]] = linalg.batch_matmul
-//      CHECK:   linalg.generic
-// CHECK-SAME:     indexing_maps = [#[[$MAP0]], #[[$MAP1]]]
-// CHECK-SAME:     ins(%[[MATMUL]] : tensor<4x384x32xf32>
-// CHECK-SAME:     outs(%[[OUT:.+]] : tensor<384x4x32xf32>)
-
-// -----
-
-util.func public @fuse_matmul_transpose(%a: tensor<128x384xf32>, %b: tensor<384x384xf32>) -> tensor<384x128xf32> {
-  %cst = arith.constant 0.000000e+00 : f32
-  %cst1 = arith.constant 1.000000e+00 : f32
-  %init = tensor.empty() : tensor<128x384xf32>
-  %c = linalg.fill ins(%cst : f32) outs(%init : tensor<128x384xf32>) -> tensor<128x384xf32>
-  %matmul = linalg.matmul ins(%a, %b : tensor<128x384xf32>, tensor<384x384xf32>) outs(%c : tensor<128x384xf32>) -> tensor<128x384xf32>
-  %result = tensor.empty() : tensor<384x128xf32>
-  %transpose = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d1, d0)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%matmul : tensor<128x384xf32>) outs(%result : tensor<384x128xf32>) {
-  ^bb0(%arg0: f32, %arg1: f32):
-    %add = arith.addf %arg0, %cst1 : f32
-    linalg.yield %add : f32
-  } -> tensor<384x128xf32>
-  util.return %transpose : tensor<384x128xf32>
-}
-
-// Check that
-// * linalg.matmul is fused together with linalg.generic;
-// * linalg.generic's input and output indexing maps are exchanged.
-
-//      CHECK: #[[$MAP0:.+]] = affine_map<(d0, d1) -> (d0, d1)>
-//      CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1) -> (d1, d0)>
-// CHECK-LABEL: util.func public @fuse_matmul_transpose
-//      CHECK: flow.dispatch.workgroups
-//      CHECK:   %[[MATMUL:.+]] = linalg.matmul
-//      CHECK:   linalg.generic
-// CHECK-SAME:     indexing_maps = [#[[$MAP0]], #[[$MAP1]]]
-// CHECK-SAME:     ins(%[[MATMUL]] : tensor<128x384xf32>
-// CHECK-SAME:     outs(%[[OUT:.+]] : tensor<384x128xf32>)
+// CHECK-LABEL: util.func public @fuse_conv
+//       CHECK: %[[DISPATCH:.+]] = flow.dispatch.workgroups
+//       CHECK:   %[[CONV:.+]] = linalg.conv_2d_nhwc_hwcf
+//       CHECK:   %[[GENERIC:.+]] = linalg.generic
+//  CHECK-SAME:     indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d3, d1, d2)>]
+//  CHECK-SAME:     ins(%[[CONV]] :
+//       CHECK:   flow.dispatch.tensor.store %[[GENERIC]]
+//       CHECK: return %[[DISPATCH]]

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/interchange_transpose_generic_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/interchange_transpose_generic_ops.mlir
@@ -1,52 +1,28 @@
-// RUN: iree-opt --split-input-file --verify-diagnostics --iree-flow-interchange-transpose-generic-ops --canonicalize -cse %s | FileCheck %s
+// RUN: iree-opt --split-input-file --verify-diagnostics --iree-flow-interchange-transpose-generic-ops --canonicalize -cse --mlir-print-local-scope %s | FileCheck %s
 
-util.func public @batch_matmul_transpose(%a: tensor<4x384x384xf32>, %b: tensor<4x384x32xf32>) -> tensor<384x4x32xf32> {
-  %cst = arith.constant 0.000000e+00 : f32
-  %init = tensor.empty() : tensor<4x384x32xf32>
-  %c = linalg.fill ins(%cst : f32) outs(%init : tensor<4x384x32xf32>) -> tensor<4x384x32xf32>
-  %matmul = linalg.batch_matmul ins(%a, %b : tensor<4x384x384xf32>, tensor<4x384x32xf32>) outs(%c : tensor<4x384x32xf32>) -> tensor<4x384x32xf32>
-  %result = tensor.empty() : tensor<384x4x32xf32>
-  %transpose = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d1, d0, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%matmul : tensor<4x384x32xf32>) outs(%result : tensor<384x4x32xf32>) {
-  ^bb0(%arg0: f32, %arg1: f32):
-    linalg.yield %arg0 : f32
-  } -> tensor<384x4x32xf32>
-  util.return %transpose : tensor<384x4x32xf32>
+util.func @supported_conv(%arg0 : tensor<2x130x130x16xf16>, %arg1 : tensor<3x3x16x320xf16>) -> tensor<2x320x128x128xf16> {
+  %empty = tensor.empty() : tensor<2x128x128x320xf32>
+  %cst = arith.constant 0.0 : f32
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<2x128x128x320xf32>) -> tensor<2x128x128x320xf32>
+  %conv = linalg.conv_2d_nhwc_hwcf {
+      dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>}
+      ins(%arg0, %arg1 : tensor<2x130x130x16xf16>, tensor<3x3x16x320xf16>)
+      outs(%fill : tensor<2x128x128x320xf32>) -> tensor<2x128x128x320xf32>
+  %empty1 = tensor.empty() : tensor<2x320x128x128xf16>
+  %truncf = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d2, d3, d1)>,
+                       affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
+      iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+      ins(%conv : tensor<2x128x128x320xf32>) outs(%empty1 : tensor<2x320x128x128xf16>) {
+    ^bb0(%b0 : f32, %b1 :f16):
+      %0 = arith.truncf %b0 : f32 to f16
+      linalg.yield %0 : f16
+  } -> tensor<2x320x128x128xf16>
+  util.return %truncf : tensor<2x320x128x128xf16>
 }
-
-// Check that linalg.generic's input and output indexing maps are exchanged.
-
-//      CHECK: #[[$MAP0:.+]] = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
-//      CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d0, d2)>
-// CHECK-LABEL: util.func public @batch_matmul_transpose
-//      CHECK:   %[[MATMUL:.+]] = linalg.batch_matmul
-//      CHECK:   linalg.generic
-// CHECK-SAME:     indexing_maps = [#[[$MAP0]], #[[$MAP1]]]
-// CHECK-SAME:     outs(%[[OUT:.+]] : tensor<384x4x32xf32>)
-
-// -----
-
-util.func public @matmul_transpose(%a: tensor<128x384xf32>, %b: tensor<384x384xf32>) -> tensor<384x128xf32> {
-  %cst = arith.constant 0.000000e+00 : f32
-  %cst1 = arith.constant 1.000000e+00 : f32
-  %init = tensor.empty() : tensor<128x384xf32>
-  %c = linalg.fill ins(%cst : f32) outs(%init : tensor<128x384xf32>) -> tensor<128x384xf32>
-  %matmul = linalg.matmul ins(%a, %b : tensor<128x384xf32>, tensor<384x384xf32>) outs(%c : tensor<128x384xf32>) -> tensor<128x384xf32>
-  %result = tensor.empty() : tensor<384x128xf32>
-  %transpose = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d1, d0)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%matmul : tensor<128x384xf32>) outs(%result : tensor<384x128xf32>) {
-  ^bb0(%arg0: f32, %arg1: f32):
-    %add = arith.addf %arg0, %cst1 : f32
-    linalg.yield %add : f32
-  } -> tensor<384x128xf32>
-  util.return %transpose : tensor<384x128xf32>
-}
-
-// Check that linalg.generic's input and output indexing maps are exchanged.
-
-//      CHECK: #[[$MAP0:.+]] = affine_map<(d0, d1) -> (d0, d1)>
-//      CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1) -> (d1, d0)>
-// CHECK-LABEL: util.func public @matmul_transpose
-//      CHECK:   %[[MATMUL:.+]] = linalg.matmul
-//      CHECK:   linalg.generic
-// CHECK-SAME:     indexing_maps = [#[[$MAP0]], #[[$MAP1]]]
-// CHECK-SAME:     ins(%[[MATMUL]] : tensor<128x384xf32>
-// CHECK-SAME:     outs(%[[OUT:.+]] : tensor<384x128xf32>)
+// CHECK-LABEL: func public @supported_conv
+//       CHECK:   %[[CONV:.+]] = linalg.conv_2d_nhwc_hwcf
+//       CHECK:   %[[GENERIC:.+]] = linalg.generic
+//  CHECK-SAME:       indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d3, d1, d2)>]
+//  CHECK-SAME:       ins(%[[CONV]] :
+//       CHECK:   return %[[GENERIC]]


### PR DESCRIPTION
The dispatch region formation logic when deciding fusability of
producer and consumer (currently) works best with the producer being
accessed using identity maps in the consumer. This pass was meant to
ensure this, but was not turned on by default. This PR turns it on by
default, but for now only for linalg.conv_2d_nhwc_hwcf as this was
found to be useful for SDXL. In time this could be made more
aggressive.