### PR TITLE
Integrate LLVM at llvm/llvm-project@286bd42a7a799e3d9035c09bf0d64cb1a1eef682

### DIFF
--- a/compiler/plugins/input/StableHLO/Conversion/LegalizeCHLO.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/LegalizeCHLO.cpp
@@ -702,7 +702,7 @@ materializePolynomialApproximation(ConversionPatternRewriter &rewriter,
 static Value materializeErfcApproximationF64ForMagnituteGeOne(
     ConversionPatternRewriter &rewriter, Location loc, ValueRange args) {
   Value x = args.front();
-  assert(x.getType().cast<ShapedType>().getElementType().isF64() &&
+  assert(cast<ShapedType>(x.getType()).getElementType().isF64() &&
          "expect f64 element type");
   const double kMaxlog = 7.09782712893383996843E2;
   const double kErfcPCoefficients[] = {
@@ -841,7 +841,7 @@ static Value
 materializeErfcApproximationF64(ConversionPatternRewriter &rewriter,
                                 Location loc, ValueRange args) {
   Value x = args.front();
-  assert(x.getType().cast<ShapedType>().getElementType().isF64() &&
+  assert(cast<ShapedType>(x.getType()).getElementType().isF64() &&
          "expect f64 element type");
 
   // Rely on erfc approximation for |x| >= 1
@@ -873,7 +873,7 @@ materializeErfcApproximationF64(ConversionPatternRewriter &rewriter,
 static Value materializeErfcApproximationF32ForMagnitudeGeOne(
     ConversionPatternRewriter &rewriter, Location loc, ValueRange args) {
   Value x = args.front();
-  assert(x.getType().cast<ShapedType>().getElementType().isF32() &&
+  assert(cast<ShapedType>(x.getType()).getElementType().isF32() &&
          "expect f32 element type");
   const double kMaxlog = 88.72283905206835;
   const float kErfcPCoefficients[] = {
@@ -939,7 +939,7 @@ static Value materializeErfcApproximationF32ForMagnitudeGeOne(
 static Value materializeErfApproximationF32ForMagnitudeLeOne(
     ConversionPatternRewriter &rewriter, Location loc, ValueRange args) {
   Value x = args.front();
-  assert(x.getType().cast<ShapedType>().getElementType().isF32() &&
+  assert(cast<ShapedType>(x.getType()).getElementType().isF32() &&
          "expect f32 element type");
   const float kErfTCoefficients[] = {
       +7.853861353153693E-5f, -8.010193625184903E-4f, +5.188327685732524E-3f,
@@ -959,7 +959,7 @@ static Value materializeErfApproximationF32ForMagnitudeLeOne(
 static Value materializeErfApproximationF32(ConversionPatternRewriter &rewriter,
                                             Location loc, ValueRange args) {
   Value x = args.front();
-  assert(x.getType().cast<ShapedType>().getElementType().isF32() &&
+  assert(cast<ShapedType>(x.getType()).getElementType().isF32() &&
          "expect f32 element type");
   const float kAlpha[] = {
       -2.72614225801306e-10f, 2.77068142495902e-08f,  -2.10102402082508e-06f,
@@ -997,7 +997,7 @@ static Value
 materializeErfcApproximationF32(ConversionPatternRewriter &rewriter,
                                 Location loc, ValueRange args) {
   Value x = args.front();
-  assert(x.getType().cast<ShapedType>().getElementType().isF32() &&
+  assert(cast<ShapedType>(x.getType()).getElementType().isF32() &&
          "expect f32 element type");
 
   // Rely on erfc approximation for |x| >= 1
@@ -1583,7 +1583,7 @@ static Value materializeDigamma(ConversionPatternRewriter &rewriter,
 
 static Value getConstantLikeSmallestFiniteValue(OpBuilder &b, Location loc,
                                                 Value val) {
-  auto ty = getElementTypeOrSelf(val.getType()).cast<FloatType>();
+  auto ty = cast<FloatType>(getElementTypeOrSelf(val.getType()));
   return getConstantLike(
       b, loc, llvm::APFloat::getSmallest(ty.getFloatSemantics()), val);
 }
@@ -1997,7 +1997,7 @@ struct ConvertSinhOp final : OpConversionPattern<mlir::chlo::SinhOp> {
   matchAndRewrite(mlir::chlo::SinhOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Value x = adaptor.getOperand();
-    if (cast<ShapedType>(x.getType()).getElementType().isa<ComplexType>()) {
+    if (isa<ComplexType>(cast<ShapedType>(x.getType()).getElementType())) {
       rewriter.replaceOp(op, materializeSinhApproximationForLargeX(
                                  rewriter, op.getLoc(), adaptor.getOperands()));
       return success();

--- a/compiler/plugins/input/StableHLO/Conversion/MapStableHLOToScalarOp.h
+++ b/compiler/plugins/input/StableHLO/Conversion/MapStableHLOToScalarOp.h
@@ -225,13 +225,13 @@ struct MapStableHloOpToScalarOpImpl<SupportedType, void, Args...> {
 };
 
 struct IsAnyIntegerType {
-  bool operator()(Type t) { return t.isa<IntegerType>(); }
+  bool operator()(Type t) { return isa<IntegerType>(t); }
 };
 
 struct IsSignedIntegerType {
   bool operator()(Type t) {
     // Pretend that signless is signed. This will change eventually.
-    return t.isa<IntegerType>() && !t.isUnsignedInteger() &&
+    return isa<IntegerType>(t) && !t.isUnsignedInteger() &&
            !t.isSignlessInteger(1);
   }
 };
@@ -243,11 +243,11 @@ struct IsUnsignedIntegerType {
 };
 
 struct IsFloatType {
-  bool operator()(Type t) { return t.isa<FloatType>(); }
+  bool operator()(Type t) { return isa<FloatType>(t); }
 };
 
 struct IsComplexType {
-  bool operator()(Type t) { return t.isa<ComplexType>(); }
+  bool operator()(Type t) { return isa<ComplexType>(t); }
 };
 
 template <template <typename T> class MapTy, typename OpTy,
@@ -282,11 +282,11 @@ inline Value mapStableHloOpToStdScalarOp<stablehlo::AbsOp>(
     Location loc, ArrayRef<Type> resultTypes, ArrayRef<Type> argTypes,
     stablehlo::AbsOp::Adaptor adaptor, OpBuilder *b) {
   Type elementType = getElementTypeOrSelf(argTypes.front());
-  if (elementType.isa<FloatType>()) {
+  if (isa<FloatType>(elementType)) {
     return MapStableHloOpToScalarOpImpl<IsFloatType, ::mlir::math::AbsFOp>{}(
         loc, resultTypes, argTypes, adaptor.getOperands(), b);
   }
-  if (elementType.isa<ComplexType>()) {
+  if (isa<ComplexType>(elementType)) {
     return MapStableHloOpToScalarOpImpl<IsComplexType,
                                         ::mlir::complex::AbsOp>{}(
         loc, resultTypes, argTypes, adaptor.getOperands(), b);
@@ -308,7 +308,7 @@ inline Value mapStableHloOpToStdScalarOp<stablehlo::AbsOp>(
 // Return a constant for v of type t, splat if t is a vector type.
 inline Value getConstantOrSplat(OpBuilder *b, Location loc, Type t,
                                 Attribute v) {
-  if (VectorType vecType = t.dyn_cast<VectorType>()) {
+  if (VectorType vecType = dyn_cast<VectorType>(t)) {
     v = SplatElementsAttr::get(vecType, v);
   }
   return b->create<arith::ConstantOp>(loc, t, cast<TypedAttr>(v));
@@ -358,8 +358,8 @@ getCmpPredicate<arith::CmpIPredicate>(
 inline Value cmpComplex(Location loc, Value lhs, Value rhs,
                         stablehlo::ComparisonDirection comparisonDirection,
                         OpBuilder *b) {
-  auto complexType = lhs.getType().cast<ComplexType>();
-  if (complexType.getElementType().isa<FloatType>()) {
+  auto complexType = cast<ComplexType>(lhs.getType());
+  if (isa<FloatType>(complexType.getElementType())) {
     if (comparisonDirection == stablehlo::ComparisonDirection::EQ) {
       return b->create<complex::EqualOp>(loc, lhs, rhs);
     }
@@ -404,7 +404,7 @@ inline Value mapStableHloOpToStdScalarOp<stablehlo::CompareOp>(
   const auto &lhs = adaptor.getLhs();
   const auto &rhs = adaptor.getRhs();
   Type elementType = getElementTypeOrSelf(argTypes.front());
-  if (elementType.isa<IntegerType>()) {
+  if (isa<IntegerType>(elementType)) {
     bool isUnsigned = IsUnsignedIntegerType{}(elementType);
     std::optional<arith::CmpIPredicate> predicate =
         getCmpPredicate<arith::CmpIPredicate>(comparisonDirection, !isUnsigned);
@@ -412,7 +412,7 @@ inline Value mapStableHloOpToStdScalarOp<stablehlo::CompareOp>(
     return b->create<ScalarIOp<stablehlo::CompareOp>>(loc, predicate.value(),
                                                       lhs, rhs);
   }
-  if (auto floatType = elementType.dyn_cast<FloatType>()) {
+  if (auto floatType = dyn_cast<FloatType>(elementType)) {
     if (adaptor.getCompareType() &&
         *adaptor.getCompareType() == stablehlo::ComparisonType::TOTALORDER) {
       // The semantics of totalorder fp compare are
@@ -456,7 +456,7 @@ inline Value mapStableHloOpToStdScalarOp<stablehlo::CompareOp>(
     return b->create<ScalarFOp<stablehlo::CompareOp>>(loc, predicate.value(),
                                                       lhs, rhs);
   }
-  if (auto complexType = elementType.dyn_cast<ComplexType>())
+  if (auto complexType = dyn_cast<ComplexType>(elementType))
     return cmpComplex(loc, lhs, rhs, comparisonDirection, b);
   return nullptr;
 }
@@ -470,7 +470,7 @@ inline Value mapStableHloOpToStdScalarOp<stablehlo::ReducePrecisionOp>(
 
   // Integer and float types for casting and constant generation.
   auto floatType =
-      argTypes.front().cast<TensorType>().getElementType().cast<FloatType>();
+      cast<FloatType>(cast<TensorType>(argTypes.front()).getElementType());
   int64_t nbits = floatType.getWidth();
   auto intType = mlir::IntegerType::get(loc.getContext(), floatType.getWidth());
 
@@ -601,7 +601,7 @@ inline Value mapStableHloOpToStdScalarOp<stablehlo::MaxOp>(
   Value lhs = operands.front();
   Type complexTy = lhs.getType();
 
-  if (!complexTy.isa<ComplexType>())
+  if (!isa<ComplexType>(complexTy))
     return MapStableHloOpToScalarOpImpl<
         IsFloatType, arith::MaximumFOp, IsSignedIntegerType, arith::MaxSIOp,
         IsUnsignedIntegerType, arith::MaxUIOp>{}(loc, resultTypes, argTypes,
@@ -625,7 +625,7 @@ inline Value mapStableHloOpToStdScalarOp<stablehlo::MinOp>(
   Value lhs = operands.front();
   Type complexTy = lhs.getType();
 
-  if (!complexTy.isa<ComplexType>())
+  if (!isa<ComplexType>(complexTy))
     return MapStableHloOpToScalarOpImpl<
         IsFloatType, arith::MinimumFOp, IsSignedIntegerType, arith::MinSIOp,
         IsUnsignedIntegerType, arith::MinUIOp>{}(loc, resultTypes, argTypes,
@@ -645,7 +645,7 @@ template <>
 inline Value mapStableHloOpToStdScalarOp<stablehlo::RealOp>(
     Location loc, ArrayRef<Type> resultTypes, ArrayRef<Type> argTypes,
     stablehlo::RealOp::Adaptor adaptor, OpBuilder *b) {
-  if (!adaptor.getOperand().getType().isa<ComplexType>())
+  if (!isa<ComplexType>(adaptor.getOperand().getType()))
     return adaptor.getOperand();
   return MapStableHloOpToScalarOpImpl<complex::ReOp>{}(
       loc, resultTypes, argTypes, adaptor.getOperands(), b);
@@ -655,7 +655,7 @@ template <>
 inline Value mapStableHloOpToStdScalarOp<stablehlo::ImagOp>(
     Location loc, ArrayRef<Type> resultTypes, ArrayRef<Type> argTypes,
     stablehlo::ImagOp::Adaptor adaptor, OpBuilder *b) {
-  if (!adaptor.getOperand().getType().isa<ComplexType>())
+  if (!isa<ComplexType>(adaptor.getOperand().getType()))
     return b->create<arith::ConstantOp>(
         loc, b->getZeroAttr(adaptor.getOperand().getType()));
   return MapStableHloOpToScalarOpImpl<complex::ImOp>{}(
@@ -689,9 +689,9 @@ inline Value mapConvertOpToStdScalarOp(Location loc, ArrayRef<Type> targetTypes,
     return b->create<mlir::arith::SIToFPOp>(loc, resultTypes, args,
                                             std::nullopt);
   }
-  if (sourceType.isa<FloatType>() && targetType.isa<FloatType>()) {
-    auto src = sourceType.cast<FloatType>();
-    auto res = targetType.cast<FloatType>();
+  if (isa<FloatType>(sourceType) && isa<FloatType>(targetType)) {
+    auto src = cast<FloatType>(sourceType);
+    auto res = cast<FloatType>(targetType);
     if (src.getWidth() > res.getWidth()) {
       return b->create<mlir::arith::TruncFOp>(loc, resultTypes, args,
                                               std::nullopt);
@@ -719,16 +719,16 @@ inline Value mapConvertOpToStdScalarOp(Location loc, ArrayRef<Type> targetTypes,
       return b->create<mlir::arith::CmpIOp>(loc, arith::CmpIPredicate::ne,
                                             args.front(), zeroIntval);
     }
-    if (sourceType.isa<FloatType>()) {
+    if (isa<FloatType>(sourceType)) {
       Value zero = b->create<arith::ConstantOp>(
           loc, b->getZeroAttr(args.front().getType()));
       return b->create<mlir::arith::CmpFOp>(loc, arith::CmpFPredicate::UNE,
                                             args.front(), zero);
     }
   }
-  if (sourceType.isa<IntegerType>() && targetType.isa<IntegerType>()) {
-    auto src = sourceType.cast<IntegerType>();
-    auto res = targetType.cast<IntegerType>();
+  if (isa<IntegerType>(sourceType) && isa<IntegerType>(targetType)) {
+    auto src = cast<IntegerType>(sourceType);
+    auto res = cast<IntegerType>(targetType);
     if (src.getWidth() > res.getWidth()) {
       return b->create<mlir::arith::TruncIOp>(loc, resultTypes, args,
                                               std::nullopt);
@@ -756,17 +756,17 @@ inline Value mapConvertOpToStdScalarOp(Location loc, ArrayRef<Type> targetTypes,
     return b->create<mlir::arith::FPToSIOp>(loc, resultTypes, args,
                                             std::nullopt);
   }
-  if (targetType.isa<ComplexType>()) {
-    Type targetElementType = targetType.cast<ComplexType>().getElementType();
-    assert(!targetElementType.isa<ComplexType>() &&
+  if (isa<ComplexType>(targetType)) {
+    Type targetElementType = cast<ComplexType>(targetType).getElementType();
+    assert(!isa<ComplexType>(targetElementType) &&
            "elements of complex numbers should not be complex");
     Value targetReal;
     Value targetImag;
-    if (sourceType.isa<ComplexType>()) {
+    if (isa<ComplexType>(sourceType)) {
       // We are converting from complex type: convert real and imaginary parts
       // separately.
-      Type sourceElementType = sourceType.cast<ComplexType>().getElementType();
-      assert(!sourceElementType.isa<ComplexType>() &&
+      Type sourceElementType = cast<ComplexType>(sourceType).getElementType();
+      assert(!isa<ComplexType>(sourceElementType) &&
              "elements of complex numbers should not be complex");
       Value sourceReal =
           b->create<mlir::complex::ReOp>(loc, sourceElementType, args.front());
@@ -789,7 +789,7 @@ inline Value mapConvertOpToStdScalarOp(Location loc, ArrayRef<Type> targetTypes,
     return b->create<mlir::complex::CreateOp>(loc, targetType, targetReal,
                                               targetImag);
   }
-  if (auto sourceComplexType = sourceType.dyn_cast<ComplexType>()) {
+  if (auto sourceComplexType = dyn_cast<ComplexType>(sourceType)) {
     auto sourceElementType = sourceComplexType.getElementType();
     // When converting from complex to a non-complex type, we take just the real
     // part of the complex number.
@@ -835,14 +835,14 @@ inline Value mapStableHloOpToStdScalarOp<stablehlo::DotOp>(
   const auto &rhs = adaptor.getOperands()[1];
   const auto &result = adaptor.getOperands()[2];
   Type elementType = lhs.getType();
-  if (elementType.isa<FloatType>()) {
+  if (isa<FloatType>(elementType)) {
     Value floatMul =
         MapStableHloOpToScalarOpImpl<IsFloatType, ::mlir::arith::MulFOp>{}(
             loc, resultTypes, argTypes, {lhs, rhs}, b);
     return MapStableHloOpToScalarOpImpl<IsFloatType, ::mlir::arith::AddFOp>{}(
         loc, resultTypes, argTypes, {floatMul, result}, b);
   }
-  if (elementType.isa<IntegerType>()) {
+  if (isa<IntegerType>(elementType)) {
     Value intMul =
         MapStableHloOpToScalarOpImpl<IsAnyIntegerType, ::mlir::arith::MulIOp>{}(
             loc, resultTypes, argTypes, {lhs, rhs}, b);
@@ -857,9 +857,9 @@ template <>
 inline Value mapStableHloOpToStdScalarOp<stablehlo::IsFiniteOp>(
     Location loc, ArrayRef<Type> /*ResultTypes*/, ArrayRef<Type> /*argTypes*/,
     stablehlo::IsFiniteOp::Adaptor adaptor, OpBuilder *b) {
-  if (adaptor.getX().getType().isa<FloatType>()) {
+  if (isa<FloatType>(adaptor.getX().getType())) {
     auto posInf = APFloat::getInf(
-        adaptor.getX().getType().cast<FloatType>().getFloatSemantics());
+        cast<FloatType>(adaptor.getX().getType()).getFloatSemantics());
     auto constPosInf = b->create<arith::ConstantOp>(
         loc, b->getFloatAttr(adaptor.getX().getType(), posInf));
     Value absX = b->create<::mlir::math::AbsFOp>(loc, adaptor.getX());
@@ -892,7 +892,7 @@ struct CompareSelectOpToStdScalarOp<SupportedType, StdCompareOp, Predicate,
                    ArrayRef<Type> resultTypes, ArrayRef<Type> argTypes,
                    ValueRange args, OpBuilder *b) {
     Type elementType = getElementTypeOrSelf(argTypes.front());
-    if (elementType.isa<SupportedType>()) {
+    if (isa<SupportedType>(elementType)) {
       auto predicate = getCmpPredicate<Predicate>(
           comparisonDirection, !elementType.isUnsignedInteger());
       assert(predicate.has_value() && "expected valid comparison direction");
@@ -921,7 +921,7 @@ inline Value makeSafeIntDiv(ImplicitLocOpBuilder &lb, Type originalType,
                             Value lhs, Value rhs, Value returnedOnZero,
                             Value returnedOnSignedOverflow) {
   Type type = lhs.getType();
-  auto elementType = getElementTypeOrSelf(type).cast<IntegerType>();
+  auto elementType = cast<IntegerType>(getElementTypeOrSelf(type));
   Value zero = lb.create<arith::ConstantOp>(lb.getZeroAttr(type));
   auto makeConstant = [&](const APInt &i) {
     return getConstantOrSplat(&lb, lb.getLoc(), type,
@@ -959,7 +959,7 @@ inline Value mapStableHloOpToStdScalarOp<stablehlo::DivOp>(
     Location loc, ArrayRef<Type> resultTypes, ArrayRef<Type> argTypes,
     stablehlo::DivOp::Adaptor adaptor, OpBuilder *b) {
   Type originalType = getElementTypeOrSelf(argTypes.front());
-  if (originalType.isa<ComplexType, FloatType>()) {
+  if (isa<ComplexType, FloatType>(originalType)) {
     return MapStableHloOpToScalarOpImpl<IsFloatType, arith::DivFOp,
                                         IsComplexType, complex::DivOp>{}(
         loc, resultTypes, argTypes, adaptor.getOperands(), b);
@@ -971,7 +971,7 @@ inline Value mapStableHloOpToStdScalarOp<stablehlo::DivOp>(
   // INT_SMIN /s -1 = INT_SMIN
   ImplicitLocOpBuilder lb(loc, *b);
   Type type = adaptor.getLhs().getType();
-  auto elementType = getElementTypeOrSelf(type).cast<IntegerType>();
+  auto elementType = cast<IntegerType>(getElementTypeOrSelf(type));
   auto makeConstant = [&](const APInt &i) {
     return getConstantOrSplat(&lb, lb.getLoc(), type,
                               lb.getIntegerAttr(elementType, i));
@@ -989,7 +989,7 @@ inline Value mapStableHloOpToStdScalarOp<stablehlo::RemOp>(
     Location loc, ArrayRef<Type> resultTypes, ArrayRef<Type> argTypes,
     stablehlo::RemOp::Adaptor adaptor, OpBuilder *b) {
   Type originalType = getElementTypeOrSelf(argTypes.front());
-  if (originalType.isa<ComplexType, FloatType>()) {
+  if (isa<ComplexType, FloatType>(originalType)) {
     return MapStableHloOpToScalarOpImpl<IsFloatType, arith::RemFOp>{}(
         loc, resultTypes, argTypes, adaptor.getOperands(), b);
   }
@@ -1012,13 +1012,13 @@ inline Value mapStableHloOpToStdScalarOp<stablehlo::NegOp>(
     Location loc, ArrayRef<Type> resultTypes, ArrayRef<Type> argTypes,
     stablehlo::NegOp::Adaptor adaptor, OpBuilder *b) {
   Type elementType = getElementTypeOrSelf(adaptor.getOperand().getType());
-  if (elementType.isa<ComplexType, FloatType>()) {
+  if (isa<ComplexType, FloatType>(elementType)) {
     return MapStableHloOpToScalarOpImpl<IsFloatType, ::mlir::arith::NegFOp,
                                         IsComplexType,
                                         ::mlir::complex::NegOp>{}(
         loc, resultTypes, argTypes, adaptor.getOperands(), b);
   }
-  if (elementType.isa<IntegerType>()) {
+  if (isa<IntegerType>(elementType)) {
     // lmhlo.neg(x, result) -> result = sub(0, x)
     Value lhs = adaptor.getOperand();
     Value zeroIntval =
@@ -1033,7 +1033,7 @@ inline Value mapStableHloOpToStdScalarOp<stablehlo::NotOp>(
     Location loc, ArrayRef<Type> /*ResultTypes*/, ArrayRef<Type> /*argTypes*/,
     stablehlo::NotOp::Adaptor adaptor, OpBuilder *b) {
   Type elementType = getElementTypeOrSelf(adaptor.getOperand().getType());
-  if (auto integerType = elementType.dyn_cast<IntegerType>()) {
+  if (auto integerType = dyn_cast<IntegerType>(elementType)) {
     // lmhlo.not(x) -> x ^ -1
     Value allOnes = getConstantOrSplat(
         b, loc, adaptor.getOperand().getType(),
@@ -1070,7 +1070,7 @@ inline Value mapStableHloOpToStdScalarOp<stablehlo::PowOp>(
   auto lb = ImplicitLocOpBuilder(loc, *b);
   // Floating point can use std::powf
   auto resultType = resultTypes.front();
-  if (resultType.isa<ComplexType, FloatType>()) {
+  if (isa<ComplexType, FloatType>(resultType)) {
     return MapStableHloOpToScalarOpImpl<IsFloatType, math::PowFOp,
                                         IsComplexType, complex::PowOp>{}(
         loc, resultTypes, argTypes, adaptor.getOperands(), b);
@@ -1156,7 +1156,7 @@ inline Value mapStableHloOpToStdScalarOp<stablehlo::SignOp>(
     stablehlo::SignOp::Adaptor adaptor, OpBuilder *b) {
   Value operand = adaptor.getOperand();
   Type elementType = getElementTypeOrSelf(operand.getType());
-  if (auto floatType = elementType.dyn_cast<FloatType>()) {
+  if (auto floatType = dyn_cast<FloatType>(elementType)) {
     Value zero =
         b->create<arith::ConstantOp>(loc, b->getZeroAttr(operand.getType()));
     Value ne0I1 = b->create<::mlir::arith::CmpFOp>(
@@ -1169,7 +1169,7 @@ inline Value mapStableHloOpToStdScalarOp<stablehlo::SignOp>(
         loc, arith::CmpFPredicate::UNO, operand, operand);
     return b->create<::mlir::arith::SelectOp>(loc, isNan, operand, copySign);
   }
-  if (auto integerType = elementType.dyn_cast<IntegerType>()) {
+  if (auto integerType = dyn_cast<IntegerType>(elementType)) {
     // sign(x) = x == 0 ? 0 : ((x s>> 31) | 1)
     Value zero =
         b->create<arith::ConstantOp>(loc, b->getZeroAttr(operand.getType()));
@@ -1185,7 +1185,7 @@ inline Value mapStableHloOpToStdScalarOp<stablehlo::SignOp>(
     Value orOp = b->create<::mlir::arith::OrIOp>(loc, ashr, one);
     return b->create<::mlir::arith::SelectOp>(loc, cmp, zero, orOp);
   }
-  if (elementType.isa<ComplexType>()) {
+  if (isa<ComplexType>(elementType)) {
     return b->create<::mlir::complex::SignOp>(loc, elementType, operand);
   }
   return nullptr;

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/DotGeneralToDot.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/DotGeneralToDot.cpp
@@ -382,9 +382,9 @@ struct DotVectorOptimization final : OpRewritePattern<mlir::stablehlo::DotOp> {
     Value lhs = op.getLhs();
     Value rhs = op.getRhs();
 
-    ShapedType lhsTy = lhs.getType().cast<ShapedType>();
-    ShapedType rhsTy = rhs.getType().cast<ShapedType>();
-    ShapedType resultTy = op.getType().cast<ShapedType>();
+    ShapedType lhsTy = cast<ShapedType>(lhs.getType());
+    ShapedType rhsTy = cast<ShapedType>(rhs.getType());
+    ShapedType resultTy = cast<ShapedType>(op.getType());
 
     llvm::SmallVector<int64_t> dotShape;
     if (lhsTy.getRank() == 2 && lhsTy.getDimSize(0) == 1) {

--- a/compiler/plugins/input/StableHLO/Conversion/StableHLOToLinalgExt.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/StableHLOToLinalgExt.cpp
@@ -484,9 +484,9 @@ struct ScanOpConversion final
     }
 
     auto input0 = inputs.front();
-    auto input0Ty = input0.getType().cast<ShapedType>();
+    auto input0Ty = cast<ShapedType>(input0.getType());
     auto init0 = op.getInitValues().front();
-    auto init0Ty = init0.getType().cast<ShapedType>();
+    auto init0Ty = cast<ShapedType>(init0.getType());
 
     auto window = llvm::to_vector(op.getWindowDimensions());
     llvm::SmallVector<int64_t, 4> reduceAxes;

--- a/compiler/plugins/input/StableHLO/Conversion/StableHLOToLinalgRandom.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/StableHLOToLinalgRandom.cpp
@@ -586,7 +586,7 @@ LogicalResult generateLinalgPhilox32(OpBuilder &builder, Location loc,
   Value dest3 = builder.create<tensor::EmptyOp>(loc, ArrayRef<int64_t>({count}),
                                                 resultETy);
 
-  ShapedType destTy = dest0.getType().cast<ShapedType>();
+  ShapedType destTy = cast<ShapedType>(dest0.getType());
 
   SmallVector<AffineMap> indexingMaps(4, builder.getMultiDimIdentityMap(1));
   SmallVector<utils::IteratorType> iterators(1, utils::IteratorType::parallel);
@@ -683,7 +683,7 @@ LogicalResult generateLinalgPhilox64(OpBuilder &builder, Location loc,
                                                 resultETy);
   Value dest1 = builder.create<tensor::EmptyOp>(loc, ArrayRef<int64_t>({count}),
                                                 resultETy);
-  ShapedType destTy = dest0.getType().cast<ShapedType>();
+  ShapedType destTy = cast<ShapedType>(dest0.getType());
 
   SmallVector<AffineMap> indexingMaps(2, builder.getMultiDimIdentityMap(1));
   SmallVector<utils::IteratorType> iterators(1, utils::IteratorType::parallel);

--- a/compiler/plugins/input/TOSA/InputConversion/Converti48Toi64.cpp
+++ b/compiler/plugins/input/TOSA/InputConversion/Converti48Toi64.cpp
@@ -61,7 +61,7 @@ public:
 
     // Extract the typed attributes for conversion.
     for (auto [index, attr] : llvm::enumerate(op->getAttrs())) {
-      if (auto typedAttr = attr.getValue().dyn_cast<TypedAttr>()) {
+      if (auto typedAttr = dyn_cast<TypedAttr>(attr.getValue())) {
         oldAttrTypes.push_back(typedAttr.getType());
         typedIndices.push_back(index);
       }
@@ -89,7 +89,7 @@ public:
       // For shaped types, map the values to the new types.
       if (auto shapedType = dyn_cast<ShapedType>(newAttrType)) {
         if (auto denseAttr = dyn_cast<DenseIntElementsAttr>(attrValue)) {
-          auto eType = shapedType.getElementType().dyn_cast<IntegerType>();
+          auto eType = dyn_cast<IntegerType>(shapedType.getElementType());
           auto cast = [&](APInt value) {
             return APInt(eType.getWidth(), value.getZExtValue());
           };
@@ -152,7 +152,7 @@ void Converti48Toi64Pass::runOnOperation() {
         return false;
     }
     for (auto attr : op->getAttrs()) {
-      if (auto typedAttr = attr.getValue().dyn_cast<TypedAttr>()) {
+      if (auto typedAttr = dyn_cast<TypedAttr>(attr.getValue())) {
         if (isIllegalType(typedAttr.getType())) {
           return false;
         }

--- a/compiler/plugins/input/Torch/InputConversion/BitCastQuantTensor.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/BitCastQuantTensor.cpp
@@ -48,7 +48,7 @@ public:
     if (failed(getConstantIntegerFromDefiningOp(bitWidth, unpackedBitWidth)))
       return failure();
 
-    auto rhsType = rhs.getType().dyn_cast<torch::Torch::ValueTensorType>();
+    auto rhsType = dyn_cast<torch::Torch::ValueTensorType>(rhs.getType());
     if (!rhsType)
       return failure();
 

--- a/compiler/plugins/input/Torch/InputConversion/CMakeLists.txt
+++ b/compiler/plugins/input/Torch/InputConversion/CMakeLists.txt
@@ -54,6 +54,8 @@ iree_cc_library(
     iree::compiler::plugins::input::Torch::torch-mlir::TorchDialectPasses
     iree::compiler::plugins::input::Torch::torch-mlir-dialects::TMTensorDialectIR
     iree::compiler::Dialect::Flow::IR
+    iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::LinalgExt::IR
+    iree::compiler::Dialect::Stream::IR
   PUBLIC
 )

--- a/compiler/plugins/input/Torch/InputConversion/ConvertTMTensorToLinalgExt.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/ConvertTMTensorToLinalgExt.cpp
@@ -73,11 +73,11 @@ struct ScatterOpConversion
 
 static Value collapseBatches(PatternRewriter &rewriter, Location loc,
                              Value val) {
-  auto valSizes = val.getType().cast<RankedTensorType>().getShape();
+  auto valSizes = cast<RankedTensorType>(val.getType()).getShape();
   int64_t newBatch =
       std::accumulate(valSizes.begin(), valSizes.end() - 2, 1,
                       [](int64_t x, int64_t y) { return x * y; });
-  Type elementType = val.getType().cast<RankedTensorType>().getElementType();
+  Type elementType = cast<RankedTensorType>(val.getType()).getElementType();
   SmallVector<int64_t> newSizes{newBatch};
   newSizes.append(valSizes.end() - 2, valSizes.end());
   Type newType = RankedTensorType::get(newSizes, elementType);
@@ -98,8 +98,8 @@ static Value collapseBatches(PatternRewriter &rewriter, Location loc,
 }
 static Value expandBatches(PatternRewriter &rewriter, Location loc,
                            SmallVector<int64_t> batchSizes, Value val) {
-  auto valSizes = val.getType().cast<RankedTensorType>().getShape();
-  Type elementType = val.getType().cast<RankedTensorType>().getElementType();
+  auto valSizes = cast<RankedTensorType>(val.getType()).getShape();
+  Type elementType = cast<RankedTensorType>(val.getType()).getElementType();
   SmallVector<int64_t> newSizes(batchSizes);
   newSizes.append(valSizes.end() - 2, valSizes.end());
   auto rank = newSizes.size();
@@ -124,7 +124,7 @@ struct AttentionOpConversion
     Value query = op.getQuery();
     Value key = op.getKey();
     Value value = op.getValue();
-    auto sizes = query.getType().cast<RankedTensorType>().getShape();
+    auto sizes = cast<RankedTensorType>(query.getType()).getShape();
     SmallVector<int64_t> batchSizes(sizes.begin(), sizes.end() - 2);
 
     if (sizes.size() > 3) {
@@ -134,14 +134,13 @@ struct AttentionOpConversion
     }
 
     SmallVector<int64_t> resultShape(
-        op->getResultTypes()[0].cast<RankedTensorType>().getShape());
+        cast<RankedTensorType>(op->getResultTypes()[0]).getShape());
     SmallVector<int64_t> collapsedResultShape;
     collapsedResultShape.push_back(
         std::accumulate(resultShape.begin(), resultShape.end() - 2, 1,
                         [](int64_t x, int64_t y) { return x * y; }));
     collapsedResultShape.append(resultShape.end() - 2, resultShape.end());
-    Type elementType =
-        query.getType().cast<RankedTensorType>().getElementType();
+    Type elementType = cast<RankedTensorType>(query.getType()).getElementType();
     auto collapsedResultType =
         RankedTensorType::get(collapsedResultShape, elementType);
     Value collapsedResult = rewriter.create<tensor::EmptyOp>(

--- a/compiler/plugins/input/Torch/torch-mlir/CMakeLists.txt
+++ b/compiler/plugins/input/Torch/torch-mlir/CMakeLists.txt
@@ -116,10 +116,15 @@ iree_cc_library(
   DEPS
     ::defs
     ::TorchConversionDialectGen
+    ::TorchDialectTransformsGen
     ::TorchDialectIR
     MLIRIR
+    MLIRFuncTransforms
+    MLIRGPUDialect
+    MLIRLinalgTransforms
     MLIRSupport
     MLIRSideEffectInterfaces
+    MLIRVectorTransforms
 )
 
 iree_tablegen_library(

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPULowerToUKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPULowerToUKernels.cpp
@@ -45,8 +45,8 @@ getCastOpOfElementWiseCast(linalg::GenericOp genericOp) {
     return std::nullopt;
   }
   Value castIn = castOp->getOperand(0);
-  if (castIn.isa<BlockArgument>() &&
-      castIn.cast<BlockArgument>().getArgNumber() != 0) {
+  if (isa<BlockArgument>(castIn) &&
+      cast<BlockArgument>(castIn).getArgNumber() != 0) {
     return std::nullopt;
   }
   return castOp;
@@ -483,9 +483,9 @@ getFlagForUserAndOperandTypes(IREE::LinalgExt::EncodingAttr encoding,
     return IREE_UK_FLAG_QUERY_TILE_SIZES_OPERATION_NONE;
   }
 
-  Type lhs = operandTypes[0].cast<TypeAttr>().getValue();
-  Type rhs = operandTypes[1].cast<TypeAttr>().getValue();
-  Type out = operandTypes[2].cast<TypeAttr>().getValue();
+  Type lhs = cast<TypeAttr>(operandTypes[0]).getValue();
+  Type rhs = cast<TypeAttr>(operandTypes[1]).getValue();
+  Type out = cast<TypeAttr>(operandTypes[2]).getValue();
 
   if (lhs.isF32() && rhs.isF32() && out.isF32()) {
     return IREE_UK_FLAG_QUERY_TILE_SIZES_OPERATION_MATMUL_F32F32F32;
@@ -526,7 +526,7 @@ matchDAGForUKernel(RewriterBase &rewriter, IREE::Codegen::QueryTileSizesOp op,
   if (!hasUkernel(targetAttr, ukernelName)) {
     return failure();
   }
-  auto tensorType = op.getTensorType().dyn_cast<RankedTensorType>();
+  auto tensorType = dyn_cast<RankedTensorType>(op.getTensorType());
   if (!tensorType) {
     return rewriter.notifyMatchFailure(op,
                                        "need a ranked tensor type attribute");

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPUMaterializeEncodingPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPUMaterializeEncodingPass.cpp
@@ -475,7 +475,7 @@ materializeEncodingForTarget(RankedTensorType tensorType,
   // Enumerate available tile shapes for the given encoding and target.
   auto elementTypes = llvm::to_vector(
       llvm::map_range(encoding.getElementTypes().getValue(), [](Attribute a) {
-        return a.cast<TypeAttr>().getValue();
+        return cast<TypeAttr>(a).getValue();
       }));
   SmallVector<TileMxNxK> enumeratedTileMxNxK =
       enumerateMatmulTileMxNxK(cDims.value(), elementTypes, targetAttr);

--- a/compiler/src/iree/compiler/Codegen/Common/ConcretizePadResultShape.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConcretizePadResultShape.cpp
@@ -29,7 +29,7 @@ namespace mlir::iree_compiler {
 static Value getAsIndexValue(OpFoldResult attrOrValue, OpBuilder &builder,
                              Location loc) {
   IntegerAttr attr;
-  if (Value val = attrOrValue.dyn_cast<Value>()) {
+  if (Value val = dyn_cast<Value>(attrOrValue)) {
     if (val.getType().isIndex())
       return val;
     matchPattern(val, m_Constant(&attr));

--- a/compiler/src/iree/compiler/Codegen/Common/DecomposeBatchMmt4DOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DecomposeBatchMmt4DOps.cpp
@@ -78,7 +78,7 @@ struct ConvertBatchMmt4DtoMmt4DPattern
     auto rhs = op.getDpsInputOperand(1)->get();
     auto out = op.getDpsInitOperand(0)->get();
 
-    auto outType = out.getType().cast<RankedTensorType>();
+    auto outType = cast<RankedTensorType>(out.getType());
     // Batch dim needs to be tiled to 1 first.
     if (outType.getShape()[0] != 1) {
       return rewriter.notifyMatchFailure(op, "batch dim needs to be 1");
@@ -111,7 +111,7 @@ struct ConvertBatchMmt4DtoMmt4DPattern
       initTensor = out;
     }
 
-    auto lhsType = lhs.getType().cast<RankedTensorType>();
+    auto lhsType = cast<RankedTensorType>(lhs.getType());
     RankedTensorType reducedLhsType =
         RankedTensorType::Builder(lhsType).dropDim(0);
     auto reducedLhs = tensor::createCanonicalRankReducingExtractSliceOp(
@@ -121,7 +121,7 @@ struct ConvertBatchMmt4DtoMmt4DPattern
           lhs.getLoc(), "lhs producer should be reduced, but reduction failed");
     }
 
-    auto rhsType = rhs.getType().cast<RankedTensorType>();
+    auto rhsType = cast<RankedTensorType>(rhs.getType());
     RankedTensorType reducedRhsType =
         RankedTensorType::Builder(rhsType).dropDim(0);
     auto reducedRhs = tensor::createCanonicalRankReducingExtractSliceOp(
@@ -169,7 +169,7 @@ void DecomposeBatchMmt4DOpsPass::runOnOperation() {
   WalkResult result =
       funcOp.walk([&](linalg::BatchMmt4DOp batchMmt4DOp) -> WalkResult {
         auto out = batchMmt4DOp.getDpsInitOperand(0)->get();
-        auto outType = out.getType().cast<RankedTensorType>();
+        auto outType = cast<RankedTensorType>(out.getType());
         // Tile only non unit batch dimensions with tile size equals to 1.
         if (outType.getShape()[0] <= 1) {
           return WalkResult::advance();

--- a/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
@@ -38,13 +38,13 @@ struct ConvertHalInterfaceBindingSubspan final
   LogicalResult
   matchAndRewrite(IREE::HAL::InterfaceBindingSubspanOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto currentType = op.getType().dyn_cast<MemRefType>();
+    auto currentType = dyn_cast<MemRefType>(op.getType());
     if (!currentType) {
       return rewriter.notifyMatchFailure(op->getLoc(),
                                          "unhandled non-memref types");
     }
     auto newResultType =
-        getTypeConverter()->convertType(currentType).dyn_cast<MemRefType>();
+        dyn_cast<MemRefType>(getTypeConverter()->convertType(currentType));
     if (!newResultType) {
       return rewriter.notifyMatchFailure(
           op->getLoc(),

--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
@@ -28,13 +28,12 @@ getMaterializedType(RankedTensorType tensorType,
   if (failed(materializeEncodingInfo)) {
     return dropEncoding(tensorType);
   }
-  return tensor::PackOp::inferPackedType(
-             getOriginalTypeWithEncoding(tensorType)
-                 .clone(tensorType.getElementType()),
-             materializeEncodingInfo->innerTileSizes,
-             materializeEncodingInfo->innerDimsPos,
-             materializeEncodingInfo->outerDimsPerm)
-      .cast<RankedTensorType>();
+  return cast<RankedTensorType>(
+      tensor::PackOp::inferPackedType(getOriginalTypeWithEncoding(tensorType)
+                                          .clone(tensorType.getElementType()),
+                                      materializeEncodingInfo->innerTileSizes,
+                                      materializeEncodingInfo->innerDimsPos,
+                                      materializeEncodingInfo->outerDimsPerm));
 }
 
 MaterializeEncodingTypeConverter::MaterializeEncodingTypeConverter(
@@ -57,7 +56,7 @@ MaterializeEncodingConversionTarget::MaterializeEncodingConversionTarget(
   // illegal.
   markUnknownOpDynamicallyLegal([](Operation *op) {
     auto typeHasEncoding = [](Type t) -> bool {
-      auto tensorType = t.dyn_cast<RankedTensorType>();
+      auto tensorType = dyn_cast<RankedTensorType>(t);
       return tensorType && tensorType.getEncoding();
     };
     auto valueHasEncoding = [=](Value v) -> bool {
@@ -77,7 +76,7 @@ RankedTensorType getOriginalTypeWithEncoding(RankedTensorType type) {
   }
   RankedTensorType originalType = type;
   if (auto originalTypeAttr = encoding.getOriginalType()) {
-    originalType = originalTypeAttr.getValue().cast<RankedTensorType>();
+    originalType = cast<RankedTensorType>(originalTypeAttr.getValue());
   }
   return RankedTensorType::get(originalType.getShape(),
                                originalType.getElementType(), encoding);

--- a/compiler/src/iree/compiler/Codegen/Common/ExtractAddressComputation.h
+++ b/compiler/src/iree/compiler/Codegen/Common/ExtractAddressComputation.h
@@ -38,7 +38,7 @@ struct StoreLoadLikeOpRewriter : public OpRewritePattern<StoreLoadLikeOp> {
   LogicalResult matchAndRewrite(StoreLoadLikeOp storeLoadLikeOp,
                                 PatternRewriter &rewriter) const override {
     Value srcMemRef = getSrcMemRef(storeLoadLikeOp);
-    auto ldTy = srcMemRef.getType().cast<MemRefType>();
+    auto ldTy = cast<MemRefType>(srcMemRef.getType());
     unsigned storeLoadRank = ldTy.getRank();
     // Don't waste compile time if there is nothing to rewrite.
     if (storeLoadRank == 0)

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCreateFastSlowPath.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCreateFastSlowPath.cpp
@@ -79,7 +79,7 @@ static void applyFastSlowPathConversion(mlir::FunctionOpInterface funcOp) {
   Value cstZero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
   SmallVector<Value> eqZeroCmpVals;
   for (OpFoldResult pad : llvm::concat<OpFoldResult>(lowPads, highPads)) {
-    if (auto padValue = pad.dyn_cast<Value>()) {
+    if (auto padValue = dyn_cast<Value>(pad)) {
       getBackwardSlice(padValue, &padSizeOps, options);
       padSizeOps.insert(padValue.getDefiningOp());
     }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeSharedMemoryCopy.cpp
@@ -192,9 +192,9 @@ SmallVector<linalg::ProcInfo> getIds(OpBuilder &b, Location loc,
   AffineExpr d0 = b.getAffineDimExpr(0);
   for (Range r : llvm::reverse(parallelLoopRanges)) {
     linalg::ProcInfo info;
-    auto offset = r.offset.dyn_cast<Attribute>();
-    auto stride = r.stride.dyn_cast<Attribute>();
-    auto size = r.size.dyn_cast<Attribute>();
+    auto offset = dyn_cast<Attribute>(r.offset);
+    auto stride = dyn_cast<Attribute>(r.stride);
+    auto size = dyn_cast<Attribute>(r.size);
     assert(offset && stride && size);
     int64_t numThreadsDim = (llvm::cast<IntegerAttr>(size).getInt() -
                              llvm::cast<IntegerAttr>(offset).getInt()) /

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
@@ -395,7 +395,7 @@ struct DistributeReductions final
           loc, packed, i, subgroupSize, gpu::ShuffleMode::XOR);
       Value unpacked =
           unpackToVector(loc, rewriter, shuffleOp.getShuffleResult(),
-                         result.getType().cast<VectorType>());
+                         cast<VectorType>(result.getType()));
       result = makeArithReduction(rewriter, loc, combiningKind, unpacked,
                                   result, nullptr, mask);
     }

--- a/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
@@ -640,7 +640,7 @@ static void enforceLayoutToBroadcastOp(
   auto inputType = broadcast.getSourceType();
   assert(isa<VectorType>(inputType) &&
          "Scalar broadcast not supported for now.");
-  auto inputShape = inputType.cast<VectorType>().getShape();
+  auto inputShape = cast<VectorType>(inputType).getShape();
 
   SmallVector<bool> reductionMask(resultShape.size(), false);
   // Set the trailing dimensions to be reduced.

--- a/compiler/src/iree/compiler/Codegen/Common/VectorizePad.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorizePad.cpp
@@ -31,7 +31,7 @@ namespace mlir::iree_compiler {
 static Value getAsIndexValue(OpFoldResult attrOrValue, OpBuilder &builder,
                              Location loc) {
   IntegerAttr attr;
-  if (Value val = attrOrValue.dyn_cast<Value>()) {
+  if (Value val = dyn_cast<Value>(attrOrValue)) {
     if (val.getType().isIndex())
       return val;
     matchPattern(val, m_Constant(&attr));

--- a/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
@@ -242,8 +242,8 @@ struct DispatchTensorStoreOpInterface
       // Writing to a part of the tensor.
       auto subviewMemRefType =
           llvm::cast<MemRefType>(memref::SubViewOp::inferRankReducedResultType(
-              storeOp.getValue().getType().cast<ShapedType>().getShape(),
-              target.getType().cast<MemRefType>(), storeOp.getMixedOffsets(),
+              cast<ShapedType>(storeOp.getValue().getType()).getShape(),
+              cast<MemRefType>(target.getType()), storeOp.getMixedOffsets(),
               storeOp.getMixedSizes(), storeOp.getMixedStrides()));
 
       target = rewriter.create<memref::SubViewOp>(

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -756,7 +756,7 @@ struct RewriteCallOpABI : public OpRewritePattern<LLVM::CallOp> {
 
   LogicalResult matchAndRewrite(LLVM::CallOp callOp,
                                 PatternRewriter &rewriter) const override {
-    auto symbol = callOp.getCallableForCallee().dyn_cast<SymbolRefAttr>();
+    auto symbol = dyn_cast<SymbolRefAttr>(callOp.getCallableForCallee());
     auto flatSymbol = llvm::dyn_cast_if_present<FlatSymbolRefAttr>(symbol);
     if (!flatSymbol)
       return failure();
@@ -804,7 +804,7 @@ struct RewriteExternCallOpToDynamicImportCallOp
   LogicalResult matchAndRewrite(LLVM::CallOp callOp,
                                 PatternRewriter &rewriter) const override {
     // Ignore indirect calls (they're probably already converted imports).
-    auto symbol = callOp.getCallableForCallee().dyn_cast<SymbolRefAttr>();
+    auto symbol = dyn_cast<SymbolRefAttr>(callOp.getCallableForCallee());
     auto flatSymbol = llvm::dyn_cast_if_present<FlatSymbolRefAttr>(symbol);
     if (!flatSymbol)
       return failure();

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/VectorContractCustomKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/VectorContractCustomKernels.cpp
@@ -168,7 +168,7 @@ static Value getUnpromotedInput(Type unpromotedType, Type promotedType,
 // Helper to create a 1D, contiguous slice of a 1D vector.
 static Value extract1DSlice(PatternRewriter &rewriter, Location loc,
                             VectorType dstVecType, Value input, int position) {
-  assert(input.getType().cast<VectorType>().getRank() == 1);
+  assert(cast<VectorType>(input.getType()).getRank() == 1);
   assert(dstVecType.getRank() == 1);
   std::array<int64_t, 1> offsets{position};
   std::array<int64_t, 1> strides{1};
@@ -742,7 +742,7 @@ private:
                        VectorType expectedType) {
       assert(vals.size() == expectedSize);
       for (const auto &val : vals) {
-        assert(val.getType().dyn_cast<VectorType>() == expectedType);
+        assert(dyn_cast<VectorType>(val.getType()) == expectedType);
         (void)val;
       }
       (void)expectedSize;

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUCastAddressSpaceFunction.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUCastAddressSpaceFunction.cpp
@@ -62,7 +62,7 @@ struct LLVMGPUCastAddressSpaceFunctionPass
     };
 
     moduleOp->walk([&](mlir::CallOpInterface callOp) {
-      auto callee = callOp.getCallableForCallee().dyn_cast<SymbolRefAttr>();
+      auto callee = dyn_cast<SymbolRefAttr>(callOp.getCallableForCallee());
       SmallVector<Value> newOperands;
       OpBuilder::InsertionGuard g(rewriter);
       rewriter.setInsertionPoint(callOp);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Verifiers.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Verifiers.cpp
@@ -117,8 +117,8 @@ verifyGPUMatmulPipeline(Operation *op,
   // Get Operand/Result types.
   mlir::Type lhsType = op->getOperand(0).getType();
   mlir::Type rhsType = op->getOperand(1).getType();
-  assert(lhsType.cast<ShapedType>().getElementType() ==
-             rhsType.cast<ShapedType>().getElementType() &&
+  assert(cast<ShapedType>(lhsType).getElementType() ==
+             cast<ShapedType>(rhsType).getElementType() &&
          "expected lhs and rhs to have same type. Mixed input types are not "
          "supported yet in IREE Codegen.");
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
@@ -985,7 +985,7 @@ struct ReifyExtractOfCreateMask final
   LogicalResult matchAndRewrite(vector::ExtractOp extractOp,
                                 PatternRewriter &rewriter) const override {
     // Restrict to the degenerate case where we are extracting a single element.
-    if (extractOp.getResult().getType().isa<VectorType>()) {
+    if (isa<VectorType>(extractOp.getResult().getType())) {
       return failure();
     }
     auto maskOp = extractOp.getVector().getDefiningOp<vector::CreateMaskOp>();
@@ -1001,7 +1001,7 @@ struct ReifyExtractOfCreateMask final
       Value idxVal;
       if (idx.is<Attribute>()) {
         idxVal = rewriter.create<arith::ConstantIndexOp>(
-            loc, idx.get<Attribute>().cast<IntegerAttr>().getInt());
+            loc, cast<IntegerAttr>(idx.get<Attribute>()).getInt());
       } else {
         idxVal = idx.get<Value>();
       }

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -344,7 +344,7 @@ LogicalResult lowerWorkgroupCountFromSliceOp(
   options.inclusive = true;
   llvm::SetVector<Operation *> slice;
   for (auto ofr : workgroupCount) {
-    if (auto val = ofr.dyn_cast<Value>()) {
+    if (auto val = dyn_cast<Value>(ofr)) {
       mlir::getBackwardSlice(val, &slice, options);
     }
   }
@@ -393,7 +393,7 @@ LogicalResult lowerWorkgroupCountFromSliceOp(
   // Since the workgroup count at HAL level is in x, y, z form, process the
   // workload in reverse.
   for (auto ofr : llvm::reverse(workgroupCount)) {
-    if (auto val = ofr.dyn_cast<Value>()) {
+    if (auto val = dyn_cast<Value>(ofr)) {
       results.push_back(getAsOpFoldResult(map.lookup(val)));
     } else {
       results.push_back(ofr);

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -322,7 +322,7 @@ static Value promoteElementToVector(Location loc, OpBuilder &builder,
 Value packVectorToSupportedWidth(Location loc, OpBuilder &builder,
                                  Value input) {
   LLVM_DEBUG({
-    auto vecType = input.getType().cast<VectorType>();
+    auto vecType = cast<VectorType>(input.getType());
     Type elementType = vecType.getElementType();
     assert(vecType.getDimSize(0) * elementType.getIntOrFloatBitWidth() ==
                kShuffleBitWidth &&

--- a/compiler/src/iree/compiler/Codegen/Utils/MarkerUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/MarkerUtils.cpp
@@ -83,8 +83,8 @@ bool LinalgTransformationFilter::hasReplacementFilter(Operation *op) const {
   if (!replacement) {
     return false;
   }
-  auto attr = op->getAttr(LinalgTransforms::kLinalgTransformMarker)
-                  .dyn_cast<StringAttr>();
+  auto attr = dyn_cast<StringAttr>(
+      op->getAttr(LinalgTransforms::kLinalgTransformMarker));
   return attr && attr == *replacement;
 }
 

--- a/compiler/src/iree/compiler/ConstEval/JitGlobals.cpp
+++ b/compiler/src/iree/compiler/ConstEval/JitGlobals.cpp
@@ -482,8 +482,8 @@ private:
 
     // And loose tensor constants.
     for (auto constantOp : funcOp.getOps<arith::ConstantOp>()) {
-      auto tensorType = constantOp.getResult().getType().dyn_cast<TensorType>();
-      auto elementsAttr = constantOp.getValue().dyn_cast<ElementsAttr>();
+      auto tensorType = dyn_cast<TensorType>(constantOp.getResult().getType());
+      auto elementsAttr = dyn_cast<ElementsAttr>(constantOp.getValue());
       if (!tensorType || !elementsAttr)
         continue;
       if (!supportedFeatures.isSupportedAbiType(tensorType)) {

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/MeshToFlow/MeshToFlow.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/MeshToFlow/MeshToFlow.cpp
@@ -256,14 +256,14 @@ static Value buildCachedChannelLoading(
 static TypedValue<RankedTensorType>
 buildTranspose(Value v, ArrayRef<int64_t> transposeVector,
                ImplicitLocOpBuilder &builder) {
-  RankedTensorType type = v.getType().cast<RankedTensorType>();
+  RankedTensorType type = cast<RankedTensorType>(v.getType());
   SmallVector<int64_t> transposedShape =
       permute(type.getShape(), transposeVector);
   Value target =
       builder.create<tensor::EmptyOp>(transposedShape, type.getElementType());
-  return builder.create<linalg::TransposeOp>(v, target, transposeVector)
-      ->getResult(0)
-      .cast<TypedValue<RankedTensorType>>();
+  return cast<TypedValue<RankedTensorType>>(
+      builder.create<linalg::TransposeOp>(v, target, transposeVector)
+          ->getResult(0));
 }
 
 static SmallVector<int64_t> transpose(ArrayRef<int64_t> shape, int64_t axisA,
@@ -282,7 +282,7 @@ static RankedTensorType transpose(RankedTensorType type, int64_t axisA,
 static TypedValue<RankedTensorType>
 buildTranspose(Value v, int64_t axisA, int64_t axisB,
                ImplicitLocOpBuilder &builder) {
-  int64_t rank = v.getType().cast<RankedTensorType>().getRank();
+  int64_t rank = cast<RankedTensorType>(v.getType()).getRank();
   SmallVector<int64_t> transposeVector(rank);
   std::iota(transposeVector.begin(), transposeVector.end(), 0);
   std::swap(transposeVector[axisA], transposeVector[axisB]);
@@ -428,7 +428,7 @@ struct MeshAllGatherToFlow
   LogicalResult matchAndRewrite(mesh::AllGatherOp op,
                                 PatternRewriter &rewriter) const override {
     if (ShapedType::isDynamicShape(
-            op.getOperand().getType().cast<RankedTensorType>().getShape()) ||
+            cast<RankedTensorType>(op.getOperand().getType()).getShape()) ||
         ShapedType::isDynamicShape(op.getResult().getType().getShape())) {
       // TODO: add dynamic support.
       return rewriter.notifyMatchFailure(op->getLoc(),
@@ -448,7 +448,7 @@ struct MeshAllGatherToFlow
         buildTranspose(op.getOperand(), 0, gatherAxis, builder);
 
     RankedTensorType flowAllGatherResultType = transpose(
-        op.getResult().getType().cast<RankedTensorType>(), 0, gatherAxis);
+        cast<RankedTensorType>(op.getResult().getType()), 0, gatherAxis);
     Value target = builder.create<tensor::EmptyOp>(
         flowAllGatherResultType.getShape(),
         op.getResult().getType().getElementType());
@@ -472,7 +472,7 @@ struct MeshAllToAllToFlow
   LogicalResult matchAndRewrite(mesh::AllToAllOp op,
                                 PatternRewriter &rewriter) const override {
     if (ShapedType::isDynamicShape(
-            op.getOperand().getType().cast<RankedTensorType>().getShape()) ||
+            cast<RankedTensorType>(op.getOperand().getType()).getShape()) ||
         ShapedType::isDynamicShape(op.getResult().getType().getShape())) {
       // TODO: add dynamic support.
       return rewriter.notifyMatchFailure(op->getLoc(),
@@ -548,7 +548,7 @@ struct MeshReduceScatterToFlow
   LogicalResult matchAndRewrite(mesh::ReduceScatterOp op,
                                 PatternRewriter &rewriter) const override {
     if (ShapedType::isDynamicShape(
-            op.getOperand().getType().cast<RankedTensorType>().getShape()) ||
+            cast<RankedTensorType>(op.getOperand().getType()).getShape()) ||
         ShapedType::isDynamicShape(op.getResult().getType().getShape())) {
       // TODO: add dynamic support.
       return rewriter.notifyMatchFailure(op->getLoc(),
@@ -567,7 +567,7 @@ struct MeshReduceScatterToFlow
     Value flowReduceScatterOperand =
         buildTranspose(op.getOperand(), 0, scatterAxis, builder);
     RankedTensorType flowReduceScatterResultType = transpose(
-        op.getResult().getType().cast<RankedTensorType>(), 0, scatterAxis);
+        cast<RankedTensorType>(op.getResult().getType()), 0, scatterAxis);
 
     Value target = builder.create<tensor::EmptyOp>(
         flowReduceScatterResultType.getShape(),

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Utils.cpp
@@ -19,7 +19,7 @@ static SmallVector<Value>
 getDynamicValues(ArrayRef<OpFoldResult> valueOrAttrList) {
   SmallVector<Value> dynamicDims;
   for (auto valueOrAttr : valueOrAttrList) {
-    if (auto value = valueOrAttr.dyn_cast<Value>()) {
+    if (auto value = dyn_cast<Value>(valueOrAttr)) {
       dynamicDims.push_back(value);
     }
   }
@@ -31,7 +31,7 @@ static SmallVector<int64_t>
 getShapeFromSizes(ArrayRef<OpFoldResult> valueOrAttrList) {
   return llvm::map_to_vector(
       valueOrAttrList, [&](OpFoldResult valueOrAttr) -> int64_t {
-        if (auto attr = valueOrAttr.dyn_cast<Attribute>()) {
+        if (auto attr = dyn_cast<Attribute>(valueOrAttr)) {
           return llvm::cast<IntegerAttr>(attr).getInt();
         }
         return ShapedType::kDynamic;
@@ -74,7 +74,7 @@ bool isOffsetSizeAndStrideMappableToFlow(ArrayRef<OpFoldResult> offsets,
     return false;
   }
   auto getVal = [](OpFoldResult valueOrAttr, int64_t dynamicVal) -> int64_t {
-    auto attr = valueOrAttr.dyn_cast<Attribute>();
+    auto attr = dyn_cast<Attribute>(valueOrAttr);
     return attr ? llvm::cast<IntegerAttr>(attr).getInt() : dynamicVal;
   };
   /// To ensure contiguity, start from the least significant dimension. As long

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowBase.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowBase.td
@@ -96,22 +96,22 @@ def FLOW_GlobalPtr : Util_AnyPtrOf<[FLOW_Tensor, FLOW_PrimitiveType]>;
 //===----------------------------------------------------------------------===//
 
 def FLOW_TensorAccessCanReadPred : CPred<[{
-  $_self.cast<IREE::Flow::DispatchTensorType>().getAccess() ==
+  cast<IREE::Flow::DispatchTensorType>($_self).getAccess() ==
       IREE::Flow::TensorAccess::ReadOnly ||
-  $_self.cast<IREE::Flow::DispatchTensorType>().getAccess() ==
+  cast<IREE::Flow::DispatchTensorType>($_self).getAccess() ==
       IREE::Flow::TensorAccess::ReadWrite
 }]>;
 
 def FLOW_TensorAccessCanWritePred : CPred<[{
-  $_self.cast<IREE::Flow::DispatchTensorType>().getAccess() ==
+  cast<IREE::Flow::DispatchTensorType>($_self).getAccess() ==
       IREE::Flow::TensorAccess::WriteOnly ||
-  $_self.cast<IREE::Flow::DispatchTensorType>().getAccess() ==
+  cast<IREE::Flow::DispatchTensorType>($_self).getAccess() ==
       IREE::Flow::TensorAccess::ReadWrite
 }]>;
 
 def FLOW_DispatchTensor : DialectType<
     Flow_Dialect,
-    CPred<"$_self.isa<IREE::Flow::DispatchTensorType>()">,
+    CPred<"isa<IREE::Flow::DispatchTensorType>($_self)">,
     "dispatch.tensor"> {
   let description = [{
     A placeholder for a dispatch region input/output operand. This can be used
@@ -123,7 +123,7 @@ def FLOW_DispatchTensor : DialectType<
 def FLOW_ReadableDispatchTensor : DialectType<
     Flow_Dialect,
     And<[
-      CPred<"$_self.isa<IREE::Flow::DispatchTensorType>()">,
+      CPred<"isa<IREE::Flow::DispatchTensorType>($_self)">,
       FLOW_TensorAccessCanReadPred,
     ]>,
     "dispatch.tensor"> {
@@ -137,7 +137,7 @@ def FLOW_ReadableDispatchTensor : DialectType<
 def FLOW_WritableDispatchTensor : DialectType<
     Flow_Dialect,
     And<[
-      CPred<"$_self.isa<IREE::Flow::DispatchTensorType>()">,
+      CPred<"isa<IREE::Flow::DispatchTensorType>($_self)">,
       FLOW_TensorAccessCanWritePred,
     ]>,
     "dispatch.tensor"> {

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -699,12 +699,12 @@ static void processMixedOperands(ArrayRef<OpFoldResult> valueOrAttrs,
                                  SmallVectorImpl<int64_t> &staticValues,
                                  int64_t dynamicIndexValue) {
   for (OpFoldResult valueOrAttr : valueOrAttrs) {
-    if (auto value = valueOrAttr.dyn_cast<Value>()) {
+    if (auto value = dyn_cast<Value>(valueOrAttr)) {
       dynamicValues.push_back(value);
       staticValues.push_back(dynamicIndexValue);
     } else {
       auto operandValue =
-          llvm::cast<IntegerAttr>(valueOrAttr.dyn_cast<Attribute>()).getInt();
+          llvm::cast<IntegerAttr>(dyn_cast<Attribute>(valueOrAttr)).getInt();
       staticValues.push_back(operandValue);
     }
   }
@@ -742,7 +742,7 @@ DispatchTensorLoadOp::inferResultType(IREE::Flow::DispatchTensorType sourceType,
                                       ArrayRef<OpFoldResult> mixedSizes) {
   auto shape =
       llvm::map_to_vector(mixedSizes, [&](OpFoldResult valueOrAttr) -> int64_t {
-        if (auto attr = valueOrAttr.dyn_cast<Attribute>()) {
+        if (auto attr = dyn_cast<Attribute>(valueOrAttr)) {
           return llvm::cast<IntegerAttr>(attr).getInt();
         }
         return ShapedType::kDynamic;
@@ -1118,7 +1118,9 @@ bool DispatchWorkgroupsOp::canClosureContainOp(Operation *op) {
   // to requirements around tensor access checking.
   if (auto constantOp = dyn_cast<arith::ConstantOp>(op)) {
     auto constantType = constantOp.getType();
-    return constantType.isIntOrIndexOrFloat();
+    if (constantType.isIntOrIndexOrFloat()) {
+      return true;
+    }
   }
   return false;
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -459,7 +459,7 @@ def FLOW_DispatchTensorLoadOp : FLOW_PureOp<"dispatch.tensor.load", [
     /// and `static_strides` attributes.
     std::array<unsigned, 3> getArrayAttrMaxRanks() {
       unsigned sourceRank =
-          getSource().getType().cast<DispatchTensorType>().asRankedTensorType().getRank();
+          cast<DispatchTensorType>(getSource().getType()).asRankedTensorType().getRank();
       return {sourceRank, sourceRank, sourceRank};
     }
 
@@ -484,12 +484,12 @@ def FLOW_DispatchTensorLoadOp : FLOW_PureOp<"dispatch.tensor.load", [
 
     /// Return the result type as a `RankedTensorType`.
     RankedTensorType getType() {
-      return getResult().getType().cast<RankedTensorType>();
+      return cast<RankedTensorType>(getResult().getType());
     }
 
     /// Return the type of the source as `IREE::Flow::DispatchTensorType`.
     IREE::Flow::DispatchTensorType getSourceType() {
-      return getSource().getType().cast<IREE::Flow::DispatchTensorType>();
+      return cast<IREE::Flow::DispatchTensorType>(getSource().getType());
     }
 
     ValueRange getOperandDynamicDims(unsigned idx) { return getSourceDims(); }
@@ -568,16 +568,16 @@ def FLOW_DispatchTensorStoreOp : FLOW_Op<"dispatch.tensor.store", [
     /// and `static_strides` attributes.
     std::array<unsigned, 3> getArrayAttrMaxRanks() {
       unsigned resultRank =
-           getTarget().getType().cast<DispatchTensorType>().asRankedTensorType().getRank();
+           cast<DispatchTensorType>(getTarget().getType()).asRankedTensorType().getRank();
       return {resultRank, resultRank, resultRank};
     }
 
     /// Return the type of the value type as a RankedTensorType.
-    RankedTensorType getValueType() { return getValue().getType().cast<RankedTensorType>(); }
+    RankedTensorType getValueType() { return cast<RankedTensorType>(getValue().getType()); }
 
     /// Return the type of the target.
     IREE::Flow::DispatchTensorType getTargetType() {
-      return getTarget().getType().cast<IREE::Flow::DispatchTensorType>();
+      return cast<IREE::Flow::DispatchTensorType>(getTarget().getType());
     }
 
     /// Return the number of leading operands before the `offsets`, `sizes` and
@@ -1248,7 +1248,7 @@ def FLOW_TensorBitCastOp : FLOW_PureOp<"tensor.bitcast", [
 def FLOW_TensorLoadOp : FLOW_PureOp<"tensor.load", [
   TypesMatchWith<"value type matches element type of target operand",
                   "source", "result",
-                  "$_self.cast<ShapedType>().getElementType()">,
+                  "cast<ShapedType>($_self).getElementType()">,
   AttrSizedOperandSegments,
   Util_ShapeAwareOp,
 ]> {
@@ -1299,7 +1299,7 @@ def FLOW_TensorStoreOp : FLOW_PureOp<"tensor.store", [
   AllTypesMatch<["target", "result"]>,
   TypesMatchWith<"value type matches element type of target operand",
                   "target", "value",
-                  "$_self.cast<ShapedType>().getElementType()">,
+                  "cast<ShapedType>($_self).getElementType()">,
   AttrSizedOperandSegments,
   Util_ShapeAwareOp,
 ]> {
@@ -1418,7 +1418,7 @@ def FLOW_TensorEmptyOp : FLOW_PureOp<"tensor.empty", [
 def FLOW_TensorSplatOp : FLOW_PureOp<"tensor.splat", [
   TypesMatchWith<"value type matches element type of result",
                   "result", "value",
-                  "$_self.cast<ShapedType>().getElementType()">,
+                  "cast<ShapedType>($_self).getElementType()">,
   DeclareOpInterfaceMethods<Util_HoistableOpInterface>,
   Util_ShapeAwareOp,
 ]> {

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowTypes.cpp
@@ -222,7 +222,7 @@ void FlowDialect::printType(Type type, DialectAsmPrinter &p) const {
 
 std::optional<IREE::Flow::CollectiveElementType>
 convertToFlowCollectiveElementType(Type type) {
-  if (type.isa<FloatType>()) {
+  if (isa<FloatType>(type)) {
     if (type.isF16()) {
       return IREE::Flow::CollectiveElementType::Float16;
     }
@@ -235,7 +235,7 @@ convertToFlowCollectiveElementType(Type type) {
     if (type.isF64()) {
       return IREE::Flow::CollectiveElementType::Float64;
     }
-  } else if (type.isa<IntegerType>()) {
+  } else if (isa<IntegerType>(type)) {
     if (type.isInteger(8)) {
       if (type.isSignedInteger()) {
         return IREE::Flow::CollectiveElementType::Sint8;

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowTypes.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowTypes.h
@@ -130,7 +130,7 @@ public:
     if (boundType.isIntOrIndexOrFloat()) {
       return RankedTensorType::get({}, boundType);
     }
-    return boundType.cast<RankedTensorType>();
+    return llvm::cast<RankedTensorType>(boundType);
   }
 };
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertRegionToWorkgroups.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertRegionToWorkgroups.cpp
@@ -103,7 +103,7 @@ rewriteFlowDispatchRegionToFlowDispatchWorkgroups(
   mlir::getUsedValuesDefinedAbove(region, argumentsSet);
   // Unranked tensors are not supported.
   assert(!llvm::any_of(argumentsSet, [](Value v) {
-    return v.getType().isa<UnrankedTensorType>();
+    return isa<UnrankedTensorType>(v.getType());
   }) && "unranked tensors are not supported");
 
   // Compute dimensions of tensor args.
@@ -237,7 +237,7 @@ rewriteFlowDispatchRegionToFlowDispatchWorkgroups(
                                                  arguments, argumentDims);
       }
 #ifndef NDEBUG
-      auto tensorType = it.value().getType().cast<RankedTensorType>();
+      auto tensorType = cast<RankedTensorType>(it.value().getType());
       assert(dims.size() == tensorType.getNumDynamicDims() &&
              "mismatching number of dynamic dims");
 #endif // NDEBUG

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormScalarDispatches.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormScalarDispatches.cpp
@@ -37,7 +37,7 @@ static bool isScalarOrTensorOfLinearSizeN(int n, Type type) {
   if (type.isIntOrIndexOrFloat()) {
     return true;
   }
-  if (auto tensorType = type.dyn_cast<RankedTensorType>()) {
+  if (auto tensorType = dyn_cast<RankedTensorType>(type)) {
     if (!tensorType.hasStaticShape()) {
       return false;
     }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -339,7 +339,7 @@ FailureOr<IREE::Flow::DispatchRegionOp> appendDispatchRegionResults(
 
   for (auto [index, result] : llvm::enumerate(results)) {
 #ifndef NDEBUG
-    auto tensorType = result.getType().cast<RankedTensorType>();
+    auto tensorType = cast<RankedTensorType>(result.getType());
     assert(tensorType.getNumDynamicDims() == dynamicDims[index].size() &&
            "incorrect number of dynamicDims provided");
 #endif // NDEBUG

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
@@ -55,9 +55,9 @@ struct ContextResolveOpPattern
         IREE::HAL::DeviceType::resolveAny(resolveOp.getLoc(), rewriter);
 
     SmallVector<Value> results;
-    if (resultTypes[0].isa<IREE::HAL::DeviceType>()) {
+    if (isa<IREE::HAL::DeviceType>(resultTypes[0])) {
       results.push_back(device);
-    } else if (resultTypes[0].isa<IREE::HAL::AllocatorType>()) {
+    } else if (isa<IREE::HAL::AllocatorType>(resultTypes[0])) {
       results.push_back(rewriter.create<IREE::HAL::DeviceAllocatorOp>(
           resolveOp.getLoc(), device));
     } else {
@@ -65,7 +65,7 @@ struct ContextResolveOpPattern
           resolveOp, "unrecognized context resolve types for a HAL target");
     }
     if (resultTypes.size() > 1) {
-      if (resultTypes[1].isa<IntegerType>()) {
+      if (isa<IntegerType>(resultTypes[1])) {
         results.push_back(buildQueueAffinityMask(
             resolveOp.getLoc(), resolveOp.getAffinityAttr(), device, rewriter));
       } else {

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALBase.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALBase.td
@@ -20,7 +20,7 @@ include "mlir/IR/EnumAttr.td"
 
 def HAL_Allocator : DialectType<
     HAL_Dialect,
-    CPred<"$_self.isa<IREE::HAL::AllocatorType>()">,
+    CPred<"isa<IREE::HAL::AllocatorType>($_self)">,
     "allocator"> {
   let description = [{
     Allocates buffers for a particular device memory space.
@@ -30,7 +30,7 @@ def HAL_Allocator : DialectType<
 
 def HAL_Buffer : DialectType<
     HAL_Dialect,
-    CPred<"$_self.isa<IREE::HAL::BufferType>()">,
+    CPred<"isa<IREE::HAL::BufferType>($_self)">,
     "buffer"> {
   let description = [{
     A memory buffer with a specific memory_type that is used to describe the
@@ -44,7 +44,7 @@ def HAL_Buffer : DialectType<
 
 def HAL_BufferView : DialectType<
     HAL_Dialect,
-    CPred<"$_self.isa<IREE::HAL::BufferViewType>()">,
+    CPred<"isa<IREE::HAL::BufferViewType>($_self)">,
     "buffer_view"> {
   let description = [{
     A shaped and typed buffer reference. This just wraps an existing hal.buffer
@@ -57,7 +57,7 @@ def HAL_BufferView : DialectType<
 
 def HAL_Channel : DialectType<
     HAL_Dialect,
-    CPred<"$_self.isa<IREE::HAL::ChannelType>()">,
+    CPred<"isa<IREE::HAL::ChannelType>($_self)">,
     "collective.channel"> {
   let description = [{
     Channel identifier used to allow for participation in multiple collective
@@ -68,7 +68,7 @@ def HAL_Channel : DialectType<
 
 def HAL_CommandBuffer : DialectType<
     HAL_Dialect,
-    CPred<"$_self.isa<IREE::HAL::CommandBufferType>()">,
+    CPred<"isa<IREE::HAL::CommandBufferType>($_self)">,
     "command_buffer"> {
   let description = [{
     Asynchronous command buffer recording interface. Commands are recorded by
@@ -79,7 +79,7 @@ def HAL_CommandBuffer : DialectType<
 
 def HAL_DescriptorSetLayout : DialectType<
     HAL_Dialect,
-    CPred<"$_self.isa<IREE::HAL::DescriptorSetLayoutType>()">,
+    CPred<"isa<IREE::HAL::DescriptorSetLayoutType>($_self)">,
     "descriptor_set_layout"> {
   let description = [{
     Descriptor set layout.
@@ -89,7 +89,7 @@ def HAL_DescriptorSetLayout : DialectType<
 
 def HAL_Device : DialectType<
     HAL_Dialect,
-    CPred<"$_self.isa<IREE::HAL::DeviceType>()">,
+    CPred<"isa<IREE::HAL::DeviceType>($_self)">,
     "device"> {
   let description = [{
     Logical device instance.
@@ -99,7 +99,7 @@ def HAL_Device : DialectType<
 
 def HAL_Event : DialectType<
     HAL_Dialect,
-    CPred<"$_self.isa<IREE::HAL::EventType>()">,
+    CPred<"isa<IREE::HAL::EventType>($_self)">,
     "event"> {
   let description = [{
     Events are used for defining synchronization scopes within CommandBuffers.
@@ -110,7 +110,7 @@ def HAL_Event : DialectType<
 
 def HAL_Executable : DialectType<
     HAL_Dialect,
-    CPred<"$_self.isa<IREE::HAL::ExecutableType>()">,
+    CPred<"isa<IREE::HAL::ExecutableType>($_self)">,
     "executable"> {
   let description = [{
     A prepared and ready-to-dispatch executable.
@@ -120,7 +120,7 @@ def HAL_Executable : DialectType<
 
 def HAL_Fence : DialectType<
     HAL_Dialect,
-    CPred<"$_self.isa<IREE::HAL::FenceType>()">,
+    CPred<"isa<IREE::HAL::FenceType>($_self)">,
     "fence"> {
   let description = [{
     A set of semaphore timepoints defining a common point in time across
@@ -131,7 +131,7 @@ def HAL_Fence : DialectType<
 
 def HAL_File : DialectType<
     HAL_Dialect,
-    CPred<"$_self.isa<IREE::HAL::FileType>()">,
+    CPred<"isa<IREE::HAL::FileType>($_self)">,
     "buffer"> {
   let description = [{
     A stateless file handle that can be read/written using queue-ordered
@@ -142,7 +142,7 @@ def HAL_File : DialectType<
 
 def HAL_PipelineLayout : DialectType<
     HAL_Dialect,
-    CPred<"$_self.isa<IREE::HAL::PipelineLayoutType>()">,
+    CPred<"isa<IREE::HAL::PipelineLayoutType>($_self)">,
     "pipeline_layout"> {
   let description = [{
     A pipeline layout describing the descriptor sets and push constants used.

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -384,7 +384,7 @@ void TensorImportOp::build(OpBuilder &builder, OperationState &result,
                            TypeAttr targetEncoding, Value waitFence,
                            StringAttr name) {
   auto shapedType = llvm::cast<ShapedType>(resultType);
-  assert((source.getType().isa<IREE::HAL::BufferViewType>() ||
+  assert((isa<IREE::HAL::BufferViewType>(source.getType()) ||
           shapedType.hasStaticShape()) &&
          "can only use this constructor for buffer views when shape "
          "information is required");
@@ -601,7 +601,7 @@ verifyWorkgroupCountRegion(Operation *op, ValueRange workload, Region &region) {
   // Verify the workload operands match the expected capture args.
   auto regionArguments =
       llvm::make_filter_range(region.getArgumentTypes(), [](Type type) {
-        return !type.isa<IREE::HAL::DeviceType>();
+        return !isa<IREE::HAL::DeviceType>(type);
       });
   if (workload.size() != llvm::range_size(regionArguments)) {
     return op->emitOpError()

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/ElideRedundantCommands.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/ElideRedundantCommands.cpp
@@ -227,7 +227,7 @@ struct ElideRedundantCommandsPass
         auto resetCommandBufferBarrierBit = [&](Operation *op) {
           assert(op->getNumOperands() > 0 && "must be a command buffer op");
           auto commandBuffer = op->getOperand(0);
-          assert(commandBuffer.getType().isa<IREE::HAL::CommandBufferType>() &&
+          assert(isa<IREE::HAL::CommandBufferType>(commandBuffer.getType()) &&
                  "operand 0 must be a command buffer");
           stateMap[commandBuffer].previousFullBarrier = {};
         };

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
@@ -370,9 +370,8 @@ declareEntryPointOps(IREE::Stream::ExecutableOp sourceExecutableOp,
       // Check if workgroup size is set externally.
       ArrayAttr workgroupSize;
       for (auto attr : exportOp->getAttrs()) {
-        if (attr.getValue().isa<IREE::Codegen::ExportConfigAttr>()) {
-          workgroupSize = attr.getValue()
-                              .cast<IREE::Codegen::ExportConfigAttr>()
+        if (isa<IREE::Codegen::ExportConfigAttr>(attr.getValue())) {
+          workgroupSize = cast<IREE::Codegen::ExportConfigAttr>(attr.getValue())
                               .getWorkgroupSizeIndexArray();
           if (workgroupSize.size() < 3) {
             SmallVector<Attribute> workgroupSizeVals =

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtInterfaces.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtInterfaces.cpp
@@ -46,10 +46,10 @@ LogicalResult LinalgExtOp::reifyResultShapes(
   for (auto output : cast<DestinationStyleOpInterface>(op).getDpsInits()) {
     SmallVector<OpFoldResult> dims;
     Type outputType = output.getType();
-    if (auto rankedTensorType = outputType.dyn_cast<RankedTensorType>()) {
+    if (auto rankedTensorType = dyn_cast<RankedTensorType>(outputType)) {
       getDimValues<RankedTensorType, tensor::DimOp>(b, op->getLoc(), output,
                                                     rankedTensorType, dims);
-    } else if (auto memrefType = outputType.dyn_cast<MemRefType>()) {
+    } else if (auto memrefType = dyn_cast<MemRefType>(outputType)) {
       getDimValues<MemRefType, memref::DimOp>(b, op->getLoc(), output,
                                               memrefType, dims);
     } else if (!outputType.isIntOrIndexOrFloat()) {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtInterfaces.td
@@ -28,8 +28,8 @@ def LinalgExtInterface : OpInterface<"LinalgExtOp"> {
 
     private:
     void setOperandSegmentAt(unsigned idx, unsigned val) {
-      auto attr = (*this)->getAttr("operand_segment_sizes")
-        .cast<DenseIntElementsAttr>();
+      auto attr = cast<DenseIntElementsAttr>(
+        (*this)->getAttr("operand_segment_sizes"));
       unsigned i = 0;
       auto newAttr = attr.mapValues(IntegerType::get(getContext(), 32),
         [&](const APInt &v) { return (i++ == idx) ? APInt(32, val) : v; });

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -499,7 +499,7 @@ LogicalResult SortOp::verify() {
   if (yieldOp.getNumOperands() != 1) {
     return op->emitOpError("should yield exactly one operand");
   }
-  auto ty = yieldOp.getOperand(0).getType().dyn_cast<IntegerType>();
+  auto ty = dyn_cast<IntegerType>(yieldOp.getOperand(0).getType());
   if (!ty || ty.getWidth() != 1) {
     return op->emitOpError("should yield i1 type");
   }
@@ -903,7 +903,7 @@ LogicalResult ScanOp::verify() {
   if (getNumDpsInits() != 2) {
     return op->emitOpError("expected two output operands");
   }
-  if (!input().getType().isa<ShapedType>()) {
+  if (!isa<ShapedType>(input().getType())) {
     return op->emitOpError("expected first input element type to be shaped");
   }
   auto accumulatorType = cast<ShapedType>(accumulator().getType());
@@ -1743,7 +1743,7 @@ void PackOp::build(OpBuilder &builder, OperationState &state, Value source,
   dispatchIndexOpFoldResults(innerTiles, dynamicTileSizes, staticTileSizes);
   SmallVector<Type> resultType;
   auto outputType = output.getType();
-  if (outputType.isa<RankedTensorType>()) {
+  if (isa<RankedTensorType>(outputType)) {
     resultType.push_back(outputType);
   }
   build(builder, state, resultType, source, output,
@@ -2037,7 +2037,7 @@ void UnPackOp::build(OpBuilder &builder, OperationState &state, Value source,
   dispatchIndexOpFoldResults(innerTiles, dynamicTileSizes, staticTileSizes);
   SmallVector<Type> resultType;
   auto outputType = output.getType();
-  if (outputType.isa<RankedTensorType>()) {
+  if (isa<RankedTensorType>(outputType)) {
     resultType.push_back(outputType);
   }
   build(builder, state, resultType, source, output,
@@ -3049,7 +3049,7 @@ ArrayRef<int64_t> EncodingAttr::getRoundDimsToArray() {
   if (!roundDimsTo) {
     return {};
   }
-  return roundDimsTo.cast<DenseI64ArrayAttr>().asArrayRef();
+  return llvm::cast<DenseI64ArrayAttr>(roundDimsTo).asArrayRef();
 }
 
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -140,10 +140,7 @@ def IREELinalgExt_ScatterOp : IREELinalgExt_Op<"scatter",
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
 
     int64_t getIndexDepth() {
-      return getDpsInputOperand(1)
-          ->get()
-          .getType()
-          .cast<ShapedType>()
+      return cast<ShapedType>(getDpsInputOperand(1)->get().getType())
           .getShape()
           .back();
     }
@@ -153,7 +150,7 @@ def IREELinalgExt_ScatterOp : IREELinalgExt_Op<"scatter",
     }
 
     ShapedType getUpdateType() {
-      return updates().getType().cast<ShapedType>();
+      return cast<ShapedType>(updates().getType());
     }
 
     Value indices() {
@@ -161,7 +158,7 @@ def IREELinalgExt_ScatterOp : IREELinalgExt_Op<"scatter",
     }
 
     ShapedType getIndicesType() {
-      return indices().getType().cast<ShapedType>();
+      return cast<ShapedType>(indices().getType());
     }
 
     Value original() {
@@ -169,11 +166,11 @@ def IREELinalgExt_ScatterOp : IREELinalgExt_Op<"scatter",
     }
 
     ShapedType getOriginalType() {
-      return original().getType().cast<ShapedType>();
+      return cast<ShapedType>(original().getType());
     }
 
     int64_t getUpdateSliceRank() {
-      return updates().getType().cast<ShapedType>().getRank() - 1;
+      return cast<ShapedType>(updates().getType()).getRank() - 1;
     }
 
     bool isScalarUpdate() {
@@ -222,7 +219,7 @@ def IREELinalgExt_SortOp : IREELinalgExt_Op<"sort",
       return getOutputs()[index];
     }
     ShapedType getOperandType(int index) {
-      return operand(index).getType().cast<ShapedType>();
+      return cast<ShapedType>(operand(index).getType());
     }
     int64_t getOperandRank() {
       return getOperandType(0).getRank();
@@ -289,7 +286,7 @@ def IREELinalgExt_FftOp : IREELinalgExt_Op<"fft", [
       return getInputs()[2];
     }
     ShapedType getOperandType() {
-      return getReal().getType().cast<ShapedType>();
+      return cast<ShapedType>(getReal().getType());
     }
     int64_t getOperandRank() {
       return getOperandType().getRank();
@@ -356,7 +353,7 @@ def IREELinalgExt_ScanOp : IREELinalgExt_Op<"scan",
       return getDpsInitOperand(0)->get();
     }
     ShapedType getOperandType() {
-      return input().getType().cast<ShapedType>();
+      return cast<ShapedType>(input().getType());
     }
     int64_t getOperandRank() {
       return getOperandType().getRank();
@@ -406,7 +403,7 @@ def IREELinalgExt_ReverseOp : IREELinalgExt_Op<"reverse", [
       return getDpsInitOperand(0)->get();
     }
     ShapedType getOperandType() {
-      return input().getType().cast<ShapedType>();
+      return cast<ShapedType>(input().getType());
     }
     int64_t getOperandRank() {
       return getOperandType().getRank();
@@ -493,7 +490,7 @@ def IREELinalgExt_TopkOp : IREELinalgExt_Op<"topk",[
       return getDpsInitOperand(1)->get();
     }
     ShapedType getInputType() {
-      return values().getType().cast<ShapedType>();
+      return cast<ShapedType>(values().getType());
     }
     int64_t getInputRank() {
       return getInputType().getRank();
@@ -593,29 +590,29 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_Op<"attention",
       return getDpsInitOperand(2)->get();
     }
     ShapedType getQueryType() {
-      return getQuery().getType().cast<ShapedType>();
+      return cast<ShapedType>(getQuery().getType());
     }
     ShapedType getKeyType() {
-      return getKey().getType().cast<ShapedType>();
+      return cast<ShapedType>(getKey().getType());
     }
     ShapedType getValueType() {
-      return getValue().getType().cast<ShapedType>();
+      return cast<ShapedType>(getValue().getType());
     }
     FloatType getScaleType() {
-      return getScale().getType().cast<FloatType>();
+      return cast<FloatType>(cast<ShapedType>(getScale().getType()));
     }
     ShapedType getOutputType() {
-      return getOutput().getType().cast<ShapedType>();
+      return cast<ShapedType>(getOutput().getType());
     }
     std::optional<ShapedType> getMaxType() {
       std::optional<Value> maxVal = getMax();
       if (!maxVal) return std::nullopt;
-      return maxVal->getType().cast<ShapedType>();
+      return cast<ShapedType>(maxVal->getType());
     }
     std::optional<ShapedType> getSumType() {
       std::optional<Value> sumVal = getSum();
       if (!sumVal) return std::nullopt;
-      return sumVal->getType().cast<ShapedType>();
+      return cast<ShapedType>(sumVal->getType());
     }
     int64_t getQueryRank() {
       return getQueryType().getRank();
@@ -769,12 +766,12 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack", [
 
     // Return the output type.
     ShapedType getOutputType() {
-      return getOutput().getType().cast<ShapedType>();
+      return cast<ShapedType>(getOutput().getType());
     }
 
     // Return the input type.
     ShapedType getInputType() {
-      return getInput().getType().cast<ShapedType>();
+      return cast<ShapedType>(getInput().getType());
     }
 
     // Return the output shape.
@@ -912,12 +909,12 @@ def IREELinalgExt_UnPackOp : IREELinalgExt_Op<"unpack", [
 
     // Return the output type.
     ShapedType getOutputType() {
-      return getOutput().getType().cast<ShapedType>();
+      return cast<ShapedType>(getOutput().getType());
     }
 
     // Return the input type.
     ShapedType getInputType() {
-      return getInput().getType().cast<ShapedType>();
+      return cast<ShapedType>(getInput().getType());
     }
 
     // Return the output shape.
@@ -972,10 +969,10 @@ def IREELinalgExt_SetEncodingOp : IREELinalgExt_PureOp<"set_encoding",[
 
   let extraClassDeclaration = [{
     RankedTensorType getSourceType() {
-      return getSource().getType().cast<RankedTensorType>();
+      return cast<RankedTensorType>(getSource().getType());
     }
     RankedTensorType getResultType() {
-      return getResult().getType().cast<RankedTensorType>();
+      return cast<RankedTensorType>(getResult().getType());
     }
   }];
 }
@@ -1019,10 +1016,10 @@ def IREELinalgExt_UnsetEncodingOp : IREELinalgExt_PureOp<"unset_encoding", [
 
   let extraClassDeclaration = [{
     RankedTensorType getSourceType() {
-      return getSource().getType().cast<RankedTensorType>();
+      return cast<RankedTensorType>(getSource().getType());
     }
     RankedTensorType getResultType() {
-      return getResult().getType().cast<RankedTensorType>();
+      return cast<RankedTensorType>(getResult().getType());
     }
   }];
 }
@@ -1106,10 +1103,10 @@ def IREELinalgExt_WinogradInputTransformOp : IREELinalgExt_Op<"winograd.input_tr
       return getOutputType();
     }
     ShapedType getInputType() {
-      return input().getType().cast<ShapedType>();
+      return cast<ShapedType>(input().getType());
     }
     ShapedType getOutputType() {
-      return output().getType().cast<ShapedType>();
+      return cast<ShapedType>(output().getType());
     }
     int64_t getInputRank() {
       return getInputType().getRank();
@@ -1206,10 +1203,10 @@ def IREELinalgExt_WinogradFilterTransformOp : IREELinalgExt_Op<"winograd.filter_
       return getDpsInitOperand(0)->get();
     }
     ShapedType getInputType() {
-      return input().getType().cast<ShapedType>();
+      return cast<ShapedType>(input().getType());
     }
     ShapedType getOutputType() {
-      return output().getType().cast<ShapedType>();
+      return cast<ShapedType>(output().getType());
     }
     Value getOriginalOperand() {
       return input();
@@ -1327,10 +1324,10 @@ def IREELinalgExt_WinogradOutputTransformOp : IREELinalgExt_Op<"winograd.output_
       return getDpsInitOperand(0)->get();
     }
     ShapedType getInputType() {
-      return input().getType().cast<ShapedType>();
+      return cast<ShapedType>(input().getType());
     }
     ShapedType getOutputType() {
-      return output().getType().cast<ShapedType>();
+      return cast<ShapedType>(output().getType());
     }
     Value getOriginalOperand() {
       return output();

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConv2DToWinograd.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConv2DToWinograd.cpp
@@ -145,7 +145,7 @@ public:
 
     // Check that kernel size = 3x3
     Value kernel = convOp.getInputs()[1];
-    auto kernelType = kernel.getType().cast<ShapedType>();
+    auto kernelType = cast<ShapedType>(kernel.getType());
     if (!kernelType) {
       return failure();
     }
@@ -167,8 +167,8 @@ public:
     }
 
     Operation *constOp = kernel.getDefiningOp();
-    ShapedType type = constOp->getResult(0).getType().cast<ShapedType>();
-    auto elemType = type.getElementType().cast<FloatType>();
+    ShapedType type = cast<ShapedType>(constOp->getResult(0).getType());
+    auto elemType = cast<FloatType>(type.getElementType());
     ArrayRef<int64_t> shape = type.getShape();
     DenseElementsAttr::iterator_range<APFloat> nonSplatValues =
         kernelAttr.getValues<APFloat>();
@@ -199,7 +199,7 @@ static Value
 createCollapse(Value tensor, Location loc, PatternRewriter &rewriter,
                SmallVectorImpl<int64_t> &outputShape,
                SmallVectorImpl<ReassociationIndices> &reassociations) {
-  auto tensorType = tensor.getType().cast<ShapedType>();
+  auto tensorType = cast<ShapedType>(tensor.getType());
   auto elementTy = tensorType.getElementType();
   auto resultType = RankedTensorType::get(outputShape, elementTy);
   return rewriter.create<tensor::CollapseShapeOp>(loc, resultType, tensor,
@@ -210,7 +210,7 @@ static Value
 createExpand(Value tensor, Location loc, PatternRewriter &rewriter,
              SmallVectorImpl<int64_t> &outputShape,
              SmallVectorImpl<ReassociationIndices> &reassociations) {
-  auto tensorType = tensor.getType().cast<ShapedType>();
+  auto tensorType = cast<ShapedType>(tensor.getType());
   auto elementTy = tensorType.getElementType();
   auto resultType = RankedTensorType::get(outputShape, elementTy);
   return rewriter.create<tensor::ExpandShapeOp>(loc, resultType, tensor,
@@ -298,7 +298,7 @@ public:
 
     // Check that kernel has been constant folded (by validating rank = 3)
     Value kernel = convOp.getInputs()[1];
-    auto kernelType = kernel.getType().cast<ShapedType>();
+    auto kernelType = cast<ShapedType>(kernel.getType());
     if (!kernelType) {
       return failure();
     }
@@ -316,7 +316,7 @@ public:
     Value zero = rewriter.create<arith::ConstantOp>(
         loc, rewriter.getZeroAttr(elementType));
     Value input = convOp.getInputs()[0];
-    auto inputType = input.getType().cast<ShapedType>();
+    auto inputType = cast<ShapedType>(input.getType());
     if (!inputType) {
       return failure();
     }
@@ -366,7 +366,7 @@ public:
     // Add BatchMatmulOp
     SmallVector<int64_t> bmmShape(collapsedShape.begin(), collapsedShape.end());
     Value output = convOp.getOutputs()[0];
-    auto outputType = output.getType().cast<RankedTensorType>();
+    auto outputType = cast<RankedTensorType>(output.getType());
     SmallVector<int64_t> outputShape(outputType.getShape());
     if (isNchw) {
       permute<IREE::LinalgExt::Permutation::NCHW_TO_NHWC>(outputShape);

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertToLoops.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertToLoops.cpp
@@ -82,7 +82,7 @@ struct TilingInterfaceLowerToLoopsPattern : public RewritePattern {
       return rewriter.notifyMatchFailure(op, "ignoring LinalgOps");
     }
     if (llvm::any_of(tilableOp->getResults(),
-                     [&](Value v) { return v.getType().isa<ShapedType>(); })) {
+                     [&](Value v) { return isa<ShapedType>(v.getType()); })) {
       return rewriter.notifyMatchFailure(
           tilableOp, "lower to loops needs to have tensor semantics");
     }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/PadContractionToBlockSize.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/PadContractionToBlockSize.cpp
@@ -33,7 +33,7 @@ static Operation *sliceTensor(Location loc, Value expanded, Value original,
 static bool padTensor(Location loc, OpOperand *operand,
                       ArrayRef<int64_t> alignments, OpBuilder &builder) {
   Value original = operand->get();
-  auto type = original.getType().cast<RankedTensorType>();
+  auto type = cast<RankedTensorType>(original.getType());
   ArrayRef<int64_t> shape = type.getShape();
   assert(shape.size() == alignments.size() &&
          "expected shape and alignments to match");

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/SplitReduction.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/SplitReduction.cpp
@@ -102,10 +102,10 @@ computeParallelTopk(Location loc, RewriterBase &rewriter,
                     int64_t splitReductionRatio, int64_t splitDimParallel,
                     int64_t kDimParallel, int64_t kSize) {
   Value valuesOrig = topkOp.values();
-  auto valuesOriginalType = valuesOrig.getType().cast<ShapedType>();
+  auto valuesOriginalType = cast<ShapedType>(valuesOrig.getType());
   Type valueElementType = valuesOriginalType.getElementType();
   Type indicesElementType =
-      topkOp.getResultTypes()[1].cast<ShapedType>().getElementType();
+      cast<ShapedType>(topkOp.getResultTypes()[1]).getElementType();
 
   SmallVector<int64_t> expandedShape = getExpandedShape(
       valuesOriginalType.getShape(), splitReductionRatio, splitDimParallel);
@@ -119,7 +119,7 @@ computeParallelTopk(Location loc, RewriterBase &rewriter,
   // Expand input indices shape for parallel processing if they exist
   std::optional<Value> indicesExpanded;
   if (std::optional<Value> inputIndices = topkOp.indices()) {
-    // Type inputElementType = inputIndices->getType().cast<ShapedType>();
+    // Type inputElementType = cast<ShapedType>(inputIndices->getType());
     Type indicesExpandedType =
         RankedTensorType::get(expandedShape, indicesElementType);
     indicesExpanded = rewriter.create<tensor::ExpandShapeOp>(
@@ -150,12 +150,12 @@ computeParallelTopk(Location loc, RewriterBase &rewriter,
   // Initialize indices to positive infinity and values to negative infinity
   // for a top (maxk) comparison.
   TypedAttr negInfAttr;
-  if (auto intType = valueElementType.dyn_cast<IntegerType>()) {
+  if (auto intType = dyn_cast<IntegerType>(valueElementType)) {
     negInfAttr = rewriter.getIntegerAttr(
         intType, APInt::getSignedMinValue(intType.getWidth()));
   } else {
     auto negApFloat =
-        APFloat::getInf(valueElementType.cast<FloatType>().getFloatSemantics(),
+        APFloat::getInf(cast<FloatType>(valueElementType).getFloatSemantics(),
                         /*Negative=*/true);
     negInfAttr = rewriter.getFloatAttr(valueElementType, negApFloat);
   }
@@ -200,7 +200,7 @@ computeParallelTopk(Location loc, RewriterBase &rewriter,
 Value offsetParallelIndices(Location loc, RewriterBase &rewriter,
                             Value parallelIndices, int64_t kDimParallelSize,
                             int64_t splitDimParallel) {
-  auto parallelIndicesType = parallelIndices.getType().cast<ShapedType>();
+  auto parallelIndicesType = cast<ShapedType>(parallelIndices.getType());
   size_t parallelIndicesRank = parallelIndicesType.getRank();
   AffineMap mapIdentity = rewriter.getMultiDimIdentityMap(parallelIndicesRank);
   SmallVector<AffineMap> indexingMaps = {mapIdentity};
@@ -235,10 +235,10 @@ TopkOp computeReductionTopk(Location loc, RewriterBase &rewriter, TopkOp topkOp,
                             int64_t splitReductionRatio, int64_t kDimOrig,
                             int64_t kSize) {
   Value valuesOrig = topkOp.values();
-  auto valuesOriginalType = valuesOrig.getType().cast<ShapedType>();
+  auto valuesOriginalType = cast<ShapedType>(valuesOrig.getType());
   Type valueElementType = valuesOriginalType.getElementType();
   Type indicesElementType =
-      topkOp.getResultTypes()[1].cast<ShapedType>().getElementType();
+      cast<ShapedType>(topkOp.getResultTypes()[1]).getElementType();
 
   // Define the collapsed input shapes
   SmallVector<int64_t> collapsedShape = getCollapsedShape(
@@ -348,7 +348,7 @@ splitReduction(RewriterBase &rewriter, LinalgExt::TopkOp topkOp,
   // For parallel topk: the dimension that we reduce
   int64_t kDimParallel = kDimOrig + 1;
   int64_t kSize =
-      topkOp.getResult(0).getType().cast<ShapedType>().getDimSize(kDimOrig);
+      cast<ShapedType>(topkOp.getResult(0).getType()).getDimSize(kDimOrig);
   int64_t splitReductionDepth = getSplitReductionDepth(topkOp);
   int64_t splitReductionRatio = splitReductionFn(splitReductionDepth);
   SmallVector<ReassociationIndices> reassociationIndices =
@@ -372,9 +372,9 @@ splitReduction(RewriterBase &rewriter, LinalgExt::TopkOp topkOp,
   Value updatedParallelIndices = parallelTopkOp.getResult(1);
   if (!topkOp.indices()) {
     Value parallelIndices = parallelTopkOp.getResult(1);
-    SmallVector<int64_t> expandedShape = getExpandedShape(
-        topkOp.values().getType().cast<ShapedType>().getShape(),
-        splitReductionRatio, splitDimParallel);
+    SmallVector<int64_t> expandedShape =
+        getExpandedShape(cast<ShapedType>(topkOp.values().getType()).getShape(),
+                         splitReductionRatio, splitDimParallel);
     int64_t kDimParallelSize = expandedShape[kDimParallel];
     updatedParallelIndices = offsetParallelIndices(
         loc, rewriter, parallelIndices, kDimParallelSize, splitDimParallel);

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TileAndDecomposeAttention.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TileAndDecomposeAttention.cpp
@@ -315,7 +315,7 @@ static Value extractOrInsertOutputSlice(Value src, Value dst,
   Value slice;
   if (!dst) {
     SmallVector<int64_t> accShape{queryShape[1], queryShape[2]};
-    Type elementType = src.getType().cast<ShapedType>().getElementType();
+    Type elementType = cast<ShapedType>(src.getType()).getElementType();
     auto tensorType = RankedTensorType::get(accShape, elementType);
     slice = builder.create<tensor::ExtractSliceOp>(loc, tensorType, src,
                                                    offsets, sizes, strides);

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -15,7 +15,7 @@
 namespace mlir::iree_compiler::IREE::LinalgExt {
 
 Value getDimValue(OpBuilder &builder, Location loc, Value v, int64_t dim) {
-  ShapedType type = v.getType().cast<ShapedType>();
+  ShapedType type = cast<ShapedType>(v.getType());
   if (!type.isDynamicDim(dim)) {
     return builder.create<arith::ConstantIndexOp>(loc, type.getDimSize(dim));
   }
@@ -29,7 +29,7 @@ Value getDimValue(OpBuilder &builder, Location loc, Value v, int64_t dim) {
 }
 
 OpFoldResult getDim(OpBuilder &builder, Location loc, Value v, int64_t dim) {
-  auto t = v.getType().cast<ShapedType>();
+  auto t = cast<ShapedType>(v.getType());
   if (t.isDynamicDim(dim)) {
     return getDimValue(builder, loc, v, dim);
   }
@@ -39,8 +39,8 @@ OpFoldResult getDim(OpBuilder &builder, Location loc, Value v, int64_t dim) {
 SmallVector<OpFoldResult> getDims(OpBuilder &builder, Location loc,
                                   Value shapedTypeValue) {
   return llvm::map_to_vector(
-      llvm::seq<int64_t>(
-          0, shapedTypeValue.getType().cast<ShapedType>().getRank()),
+      llvm::seq<int64_t>(0,
+                         cast<ShapedType>(shapedTypeValue.getType()).getRank()),
       [&](int64_t dim) { return getDim(builder, loc, shapedTypeValue, dim); });
 }
 
@@ -83,7 +83,7 @@ SmallVector<int64_t> asShapeWithAnyValueAsDynamic(ArrayRef<OpFoldResult> ofrs) {
   SmallVector<int64_t> result;
   for (auto o : ofrs) {
     // Have to do this first, as getConstantIntValue special-cases constants.
-    if (o.dyn_cast<Value>()) {
+    if (dyn_cast<Value>(o)) {
       result.push_back(ShapedType::kDynamic);
     } else {
       result.push_back(getConstantIntValue(o).value_or(ShapedType::kDynamic));

--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/Partitioning/ReferencePartitioning.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/Partitioning/ReferencePartitioning.cpp
@@ -388,7 +388,7 @@ partitionRegionConcurrencyReference(IREE::Stream::PartitioningConfigAttr config,
     // For each resource operand of this op we scan back through previously
     // created waves to see if there are any partitioned ops that have a hazard.
     for (auto operand : op.getOperands()) {
-      if (!operand.getType().isa<IREE::Stream::ResourceType>())
+      if (!isa<IREE::Stream::ResourceType>(operand.getType()))
         continue;
       for (auto user : operand.getUsers()) {
         if (user == &op || user->getBlock() != block ||

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/Patterns.cpp
@@ -238,7 +238,7 @@ struct GlobalOpExpansion
       auto *entryBlock = rewriter.createBlock(&initializerOp.getBody());
       rewriter.setInsertionPointToStart(entryBlock);
       Value initialValue, initialValueSize;
-      if (initialValueAttr.isa<IREE::Util::UninitializedAttr>()) {
+      if (isa<IREE::Util::UninitializedAttr>(initialValueAttr)) {
         initialValueSize = rewriter.create<IREE::Stream::TensorSizeOfOp>(
             globalOp.getLoc(), TypeAttr::get(globalOp.getType()),
             /*result_encoding_dims=*/ValueRange{}, affinityAttr);

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamBase.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamBase.td
@@ -474,7 +474,7 @@ def Stream_LifetimeAttr :
 }
 
 def Stream_AnyResource : Type<
-    CPred<"$_self.isa<IREE::Stream::ResourceType>()">,
+    CPred<"mlir::isa<IREE::Stream::ResourceType>($_self)">,
     "any stream-compatible type">;
 
 // TODO(benvanik): support other types; the interface may be enough.
@@ -550,32 +550,32 @@ def Stream_Resource : TypeDef<Stream_Dialect, "Resource", [
 }
 
 def Stream_ResourceLifetimeUnknown : CPred<[{
-  $_self.cast<IREE::Stream::ResourceType>().getLifetime() ==
+  mlir::cast<IREE::Stream::ResourceType>($_self).getLifetime() ==
       IREE::Stream::Lifetime::Unknown
 }]>;
 def Stream_ResourceLifetimeExternal : CPred<[{
-  $_self.cast<IREE::Stream::ResourceType>().getLifetime() ==
+  mlir::cast<IREE::Stream::ResourceType>($_self).getLifetime() ==
       IREE::Stream::Lifetime::External
 }]>;
 def Stream_ResourceLifetimeStaging : CPred<[{
-  $_self.cast<IREE::Stream::ResourceType>().getLifetime() ==
+  mlir::cast<IREE::Stream::ResourceType>($_self).getLifetime() ==
       IREE::Stream::Lifetime::Staging
 }]>;
 def Stream_ResourceLifetimeTransient : CPred<[{
-  $_self.cast<IREE::Stream::ResourceType>().getLifetime() ==
+  mlir::cast<IREE::Stream::ResourceType>($_self).getLifetime() ==
       IREE::Stream::Lifetime::Transient
 }]>;
 def Stream_ResourceLifetimeVariable : CPred<[{
-  $_self.cast<IREE::Stream::ResourceType>().getLifetime() ==
+  mlir::cast<IREE::Stream::ResourceType>($_self).getLifetime() ==
       IREE::Stream::Lifetime::Variable
 }]>;
 def Stream_ResourceLifetimeConstant : CPred<[{
-  $_self.cast<IREE::Stream::ResourceType>().getLifetime() ==
+  mlir::cast<IREE::Stream::ResourceType>($_self).getLifetime() ==
       IREE::Stream::Lifetime::Constant
 }]>;
 
 def Stream_UnknownResource : DialectType<Stream_Dialect, And<[
-  CPred<"$_self.isa<IREE::Stream::ResourceType>()">,
+  CPred<"mlir::isa<IREE::Stream::ResourceType>($_self)">,
   Stream_ResourceLifetimeUnknown,
 ]>, "resource"> {
   let description = [{
@@ -584,7 +584,7 @@ def Stream_UnknownResource : DialectType<Stream_Dialect, And<[
 }
 
 def Stream_ExternalResource : DialectType<Stream_Dialect, And<[
-  CPred<"$_self.isa<IREE::Stream::ResourceType>()">,
+  CPred<"mlir::isa<IREE::Stream::ResourceType>($_self)">,
   Stream_ResourceLifetimeExternal,
 ]>, "external resource"> {
   let description = [{
@@ -601,7 +601,7 @@ def Stream_ExternalResource : DialectType<Stream_Dialect, And<[
 }
 
 def Stream_StagingResource : DialectType<Stream_Dialect, And<[
-  CPred<"$_self.isa<IREE::Stream::ResourceType>()">,
+  CPred<"mlir::isa<IREE::Stream::ResourceType>($_self)">,
   Stream_ResourceLifetimeStaging,
 ]>, "staging resource"> {
   let description = [{
@@ -613,7 +613,7 @@ def Stream_StagingResource : DialectType<Stream_Dialect, And<[
 }
 
 def Stream_TransientResource : DialectType<Stream_Dialect, And<[
-  CPred<"$_self.isa<IREE::Stream::ResourceType>()">,
+  CPred<"mlir::isa<IREE::Stream::ResourceType>($_self)">,
   Stream_ResourceLifetimeTransient,
 ]>, "transient resource"> {
   let description = [{
@@ -629,7 +629,7 @@ def Stream_TransientResource : DialectType<Stream_Dialect, And<[
 }
 
 def Stream_VariableResource : DialectType<Stream_Dialect, And<[
-  CPred<"$_self.isa<IREE::Stream::ResourceType>()">,
+  CPred<"mlir::isa<IREE::Stream::ResourceType>($_self)">,
   Stream_ResourceLifetimeVariable,
 ]>, "variable resource"> {
   let description = [{
@@ -645,7 +645,7 @@ def Stream_VariableResource : DialectType<Stream_Dialect, And<[
 }
 
 def Stream_ConstantResource : DialectType<Stream_Dialect, And<[
-  CPred<"$_self.isa<IREE::Stream::ResourceType>()">,
+  CPred<"mlir::isa<IREE::Stream::ResourceType>($_self)">,
   Stream_ResourceLifetimeConstant,
 ]>, "constant resource"> {
   let description = [{

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
@@ -124,9 +124,9 @@ static TypedAttr tryNarrowPatternBits(TypedAttr patternAttr) {
   // Get the old pattern bitcast to an APInt. Splats are bitwise operations
   // and we don't care what the value originally was.
   APInt oldPattern;
-  if (auto floatAttr = patternAttr.dyn_cast<FloatAttr>()) {
+  if (auto floatAttr = dyn_cast<FloatAttr>(patternAttr)) {
     oldPattern = floatAttr.getValue().bitcastToAPInt();
-  } else if (auto intAttr = patternAttr.dyn_cast<IntegerAttr>()) {
+  } else if (auto intAttr = dyn_cast<IntegerAttr>(patternAttr)) {
     oldPattern = intAttr.getValue();
   } else {
     // Can't handle today.

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -1689,7 +1689,7 @@ ValueRange TensorTraceOp::getOperandDynamicDims(unsigned idx) {
   auto resourceEncodings = getResourceEncodings().getValue();
   auto resourceEncodingDims = getResourceEncodingDims();
   for (unsigned i = 0; i <= idx; ++i) {
-    auto resourceEncoding = resourceEncodings[i].cast<TypeAttr>().getValue();
+    auto resourceEncoding = cast<TypeAttr>(resourceEncodings[i]).getValue();
     int64_t dynamicDimCount =
         cast<ShapedType>(resourceEncoding).getNumDynamicDims();
     if (i == idx) {

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamTypes.cpp
@@ -297,7 +297,7 @@ int64_t NamedParameterAttr::getStorageSize() const {
       return lengthAttr.getInt();
     }
   }
-  if (auto shapedType = getType().dyn_cast<ShapedType>()) {
+  if (auto shapedType = llvm::dyn_cast<ShapedType>(getType())) {
     return IREE::Util::getRoundedPhysicalStorageSize(shapedType);
   } else {
     return IREE::Util::getTypePhysicalStorageBitWidth(getType());

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/DumpStatistics.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/DumpStatistics.cpp
@@ -143,7 +143,7 @@ struct Statistics {
     }
     for (auto constantOp : usageInfo.bufferConstantOps) {
       if (auto storageAttr =
-              constantOp.getValue().dyn_cast<IREE::Util::SizedStorageAttr>()) {
+              dyn_cast<IREE::Util::SizedStorageAttr>(constantOp.getValue())) {
         constantSize += storageAttr.getStorageSize();
       }
     }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/EmplaceAllocations.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/EmplaceAllocations.cpp
@@ -34,8 +34,8 @@ namespace {
 //===----------------------------------------------------------------------===//
 
 static void replaceUsesAndTransfer(Value oldValue, Value newValue) {
-  assert(oldValue.getType().isa<IREE::Stream::ResourceType>());
-  assert(newValue.getType().isa<IREE::Stream::ResourceType>());
+  assert(isa<IREE::Stream::ResourceType>(oldValue.getType()));
+  assert(isa<IREE::Stream::ResourceType>(newValue.getType()));
   if (oldValue.getType() == newValue.getType()) {
     oldValue.replaceAllUsesWith(newValue);
     return;

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
@@ -1144,14 +1144,12 @@ static std::optional<ConstantAllocation>
 extractConstantsWithLifetime(IREE::Stream::AsyncExecuteOp executeOp,
                              IREE::Stream::Lifetime lifetime,
                              OpBuilder &externalBuilder) {
-  auto constantOps = llvm::to_vector(
-      llvm::make_filter_range(executeOp.getOps<IREE::Stream::AsyncConstantOp>(),
-                              [&](IREE::Stream::AsyncConstantOp op) {
-                                return op.getResult()
-                                           .getType()
-                                           .cast<IREE::Stream::ResourceType>()
-                                           .getLifetime() == lifetime;
-                              }));
+  auto constantOps = llvm::to_vector(llvm::make_filter_range(
+      executeOp.getOps<IREE::Stream::AsyncConstantOp>(),
+      [&](IREE::Stream::AsyncConstantOp op) {
+        return cast<IREE::Stream::ResourceType>(op.getResult().getType())
+                   .getLifetime() == lifetime;
+      }));
   if (constantOps.empty())
     return {};
 

--- a/compiler/src/iree/compiler/Dialect/Util/Conversion/ConversionPatterns.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Conversion/ConversionPatterns.h
@@ -55,7 +55,7 @@ protected:
   LogicalResult convertTypeAttributes(ArrayRef<NamedAttribute> attrs,
                                       SmallVector<NamedAttribute> &res) const {
     for (NamedAttribute attr : attrs) {
-      TypeAttr oldType = attr.getValue().dyn_cast<TypeAttr>();
+      TypeAttr oldType = dyn_cast<TypeAttr>(attr.getValue());
       if (!oldType) {
         res.push_back(attr);
         continue;

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.cpp
@@ -492,7 +492,7 @@ static LogicalResult serializeGenericResourceElementData(
 //===----------------------------------------------------------------------===//
 
 int64_t BytePatternAttr::getStorageSize() const {
-  if (auto shapedType = getType().dyn_cast<ShapedType>()) {
+  if (auto shapedType = llvm::dyn_cast<ShapedType>(getType())) {
     return IREE::Util::getRoundedPhysicalStorageSize(shapedType);
   } else {
     return IREE::Util::getTypePhysicalStorageBitWidth(getType());
@@ -716,7 +716,7 @@ LogicalResult CompositeAttr::serializeToStream(Location loc,
 //===----------------------------------------------------------------------===//
 
 int64_t UninitializedAttr::getStorageSize() const {
-  if (auto shapedType = getType().dyn_cast<ShapedType>()) {
+  if (auto shapedType = llvm::dyn_cast<ShapedType>(getType())) {
     return IREE::Util::getRoundedPhysicalStorageSize(shapedType);
   } else {
     return IREE::Util::getTypePhysicalStorageBitWidth(getType());

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilBase.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilBase.td
@@ -51,8 +51,8 @@ class Util_IndexAttrBase<string descr> :
     TypedAttrBase<
       Index, "IntegerAttr",
       And<[
-        CPred<"$_self.isa<IntegerAttr>()">,
-        CPred<"$_self.cast<IntegerAttr>().getType().isIndex()">,
+        CPred<"isa<IntegerAttr>($_self)">,
+        CPred<"cast<IntegerAttr>($_self).getType().isIndex()">,
       ]>,
       descr> {
   let returnType = [{ APInt }];
@@ -67,9 +67,9 @@ def Util_TiedOpStorageAttr :
 defvar Util_GlobalRefAttr = FlatSymbolRefAttr;
 
 def Util_AnySerializableAttr : Attr<Or<[
-  CPred<"$_self.isa<mlir::DenseElementsAttr>()">,
-  CPred<"$_self.isa<mlir::DenseResourceElementsAttr>()">,
-  CPred<"$_self.isa<IREE::Util::SerializableAttrInterface>()">,
+  CPred<"isa<mlir::DenseElementsAttr>($_self)">,
+  CPred<"isa<mlir::DenseResourceElementsAttr>($_self)">,
+  CPred<"isa<IREE::Util::SerializableAttrInterface>($_self)">,
 ]>, "buffer-like constant attribute values"> {
   let storageType = [{ ::mlir::Attribute }];
   let returnType = [{ ::mlir::Attribute }];
@@ -81,7 +81,7 @@ def Util_AnySerializableArrayAttr :
                      "array attribute of serializable attributes"
   >;
 
-class Util_AliasedSymbolRefAttr : Attr<CPred<"$_self.isa<FlatSymbolRefAttr>()">,
+class Util_AliasedSymbolRefAttr : Attr<CPred<"isa<FlatSymbolRefAttr>($_self)">,
                                        "symbol reference attribute"> {
   let storageType = [{ FlatSymbolRefAttr }];
   let returnType = [{ StringRef }];

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilInterfaces.td
@@ -797,7 +797,7 @@ def Util_TiedOpInterface : OpInterface<"TiedOpInterface"> {
       /*args=*/(ins "Value":$result),
       /*methodBody=*/[{}],
       /*defaultImplementation=*/[{
-        auto resultIndex = result.cast<mlir::OpResult>().getResultNumber();
+        auto resultIndex = cast<mlir::OpResult>(result).getResultNumber();
         auto operandIndex = cast<TiedOpInterface>($_op.getOperation())
             .getTiedResultOperandIndex(resultIndex);
         return operandIndex.has_value() ?
@@ -975,7 +975,7 @@ def Util_ShapeAwareOp : OpInterface<"ShapeAwareOpInterface"> {
       /*methodBody=*/[{
         auto shapeAwareOp = dyn_cast<IREE::Util::ShapeAwareOpInterface>(result.getDefiningOp());
         return shapeAwareOp.buildResultShape(
-            result.cast<mlir::OpResult>().getResultNumber(), builder);
+            cast<mlir::OpResult>(result).getResultNumber(), builder);
       }]
     >,
   ];
@@ -1115,7 +1115,7 @@ def Util_GlobalType : TypeInterface<"GlobalTypeInterface"> {
       /*defaultImplementation=*/[{
         // If one is a shaped type, then they both must be and have compatible
         // shapes.
-        if ($_type.template isa<ShapedType>() || accessType.isa<ShapedType>()) {
+        if ($_type.template isa<ShapedType>() || isa<ShapedType>(accessType)) {
           return succeeded(mlir::verifyCompatibleShape($_type, accessType));
         }
         // Otherwise, the types must be the same.

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
@@ -190,7 +190,7 @@ def Util_NumericOptionalNarrowOp : Util_PureOp<"numeric.optional_narrow", [
 
   let extraClassDeclaration = [{
     bool isSigned() {
-      if (auto integerType = getType().dyn_cast<IntegerType>()) {
+      if (auto integerType = dyn_cast<IntegerType>(getType())) {
         return !integerType.isUnsigned();
       }
       return true;

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.h
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.h
@@ -218,10 +218,10 @@ static inline uint64_t align(uint64_t value, const APInt &alignment) {
 // Returns the bit-width of the scalar type. If the type is complex, it returns
 // the type of individual elements * 2 (1 for real and 1 for complex).
 static inline unsigned getTypeBitWidth(Type type) {
-  if (auto complexType = type.dyn_cast<ComplexType>()) {
+  if (auto complexType = dyn_cast<ComplexType>(type)) {
     return 2 * complexType.getElementType().getIntOrFloatBitWidth();
   }
-  if (auto vectorType = type.dyn_cast<VectorType>()) {
+  if (auto vectorType = dyn_cast<VectorType>(type)) {
     return vectorType.getNumElements() *
            getTypeBitWidth(vectorType.getElementType());
   }
@@ -251,12 +251,12 @@ static inline unsigned getTypePhysicalStorageBitWidth(Type type) {
 //   getRoundedElementByteWidth(i33) = 8
 //   getRoundedElementByteWidth(complex<f32>) = 8
 static inline int32_t getRoundedElementByteWidth(Type type) {
-  if (auto complexType = type.dyn_cast<ComplexType>()) {
+  if (auto complexType = dyn_cast<ComplexType>(type)) {
     return 2 * getRoundedElementByteWidth(complexType.getElementType());
   }
   // TODO(ravishankarm): evaluate if this vector packing works with sub-byte
   // element types.
-  if (auto vectorType = type.dyn_cast<VectorType>()) {
+  if (auto vectorType = dyn_cast<VectorType>(type)) {
     return vectorType.getNumElements() *
            getRoundedElementByteWidth(vectorType.getElementType());
   }

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.td
@@ -83,9 +83,9 @@ def Util_AnyListType : TypeAlias<Util_ListType>;
 
 class Util_ListOf<Type type> :
     Type<And<[
-      CPred<"$_self.isa<IREE::Util::ListType>()">,
+      CPred<"isa<IREE::Util::ListType>($_self)">,
       SubstLeaves<"$_self",
-                  "$_self.cast<IREE::Util::ListType>().getElementType()",
+                  "cast<IREE::Util::ListType>($_self).getElementType()",
                   type.predicate>
     ]>, "list<" # type.summary # ">"> {
   string builderCall = !if(!empty(type.builderCall),
@@ -131,8 +131,8 @@ def Util_AnyPtrType : TypeAlias<Util_PtrType>;
 
 class Util_PtrOf<Type type> :
     Type<And<[
-      CPred<"$_self.isa<IREE::Util::PtrType>()">,
-      SubstLeaves<"$_self", "$_self.cast<IREE::Util::PtrType>().getTargetType()",
+      CPred<"isa<IREE::Util::PtrType>($_self)">,
+      SubstLeaves<"$_self", "cast<IREE::Util::PtrType>($_self).getTargetType()",
                   type.predicate>
     ]>, "ptr<" # type.summary # ">"> {
   string builderCall = !if(!empty(type.builderCall),
@@ -141,11 +141,11 @@ class Util_PtrOf<Type type> :
 
 class Util_AnyPtrOf<list<Type> types> :
     Type<And<[
-      CPred<"$_self.isa<IREE::Util::PtrType>()">,
+      CPred<"isa<IREE::Util::PtrType>($_self)">,
       Or<!foreach(type, types,
           SubstLeaves<
               "$_self",
-              "$_self.cast<IREE::Util::PtrType>().getTargetType()",
+              "cast<IREE::Util::PtrType>($_self).getTargetType()",
               type.predicate>)>,
     ]>, !interleave(!foreach(type, types, type.summary), " or ")> {
   string builderCall = "";

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/ImportUtils.h
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/ImportUtils.h
@@ -126,7 +126,7 @@ rewriteToCall(T op, Adaptor adaptor, IREE::VM::ImportOp importOp,
     state.addAttribute("segment_types",
                        rewriter.getArrayAttr(llvm::map_to_vector(
                            importType.getInputs(), [&](Type type) {
-                             return TypeAttr::get(type).cast<Attribute>();
+                             return cast<Attribute>(TypeAttr::get(type));
                            })));
   }
 

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -175,7 +175,7 @@ LogicalResult
 removeBlockArguments(IREE::VM::ModuleOp moduleOp,
                      SmallVector<BlockArgument> &blockArgsToRemove) {
   for (auto &blockArg : blockArgsToRemove) {
-    assert(blockArg.getType().isa<IREE::VM::RefType>());
+    assert(isa<IREE::VM::RefType>(blockArg.getType()));
     assert(blockArg.use_empty());
     Block *block = blockArg.getOwner();
 
@@ -2400,7 +2400,7 @@ private:
     for (size_t i = 0; i < inputTypes.size(); i++) {
       BlockArgument arg = funcOp.getArgument(i + inputOffset);
       Type argType = arg.getType();
-      assert(!argType.isa<IREE::VM::RefType>());
+      assert(!isa<IREE::VM::RefType>(argType));
 
       if (argType == emitc::PointerType::get(
                          emitc::OpaqueType::get(ctx, "iree_vm_ref_t"))) {
@@ -2421,7 +2421,7 @@ private:
             /*templateArgs=*/ArrayAttr{},
             /*operands=*/ArrayRef<Value>{arg, refPtr});
       } else {
-        assert(!argType.isa<emitc::PointerType>());
+        assert(!isa<emitc::PointerType>(argType));
         Value size =
             emitc_builders::sizeOf(builder, loc, TypeAttr::get(argType));
 
@@ -2475,7 +2475,7 @@ private:
     for (size_t i = 0; i < resultTypes.size(); i++) {
       BlockArgument arg = funcOp.getArgument(i + resultOffset);
       Type argType = arg.getType();
-      assert(!argType.isa<IREE::VM::RefType>());
+      assert(!isa<IREE::VM::RefType>(argType));
 
       if (argType == emitc::PointerType::get(
                          emitc::OpaqueType::get(ctx, "iree_vm_ref_t"))) {
@@ -3110,8 +3110,8 @@ class BranchOpConversion : public EmitCConversionPattern<IREE::VM::BranchOp> {
           continue;
         }
 
-        assert(operand.getType().isa<IREE::VM::RefType>());
-        assert(blockArg.getType().isa<IREE::VM::RefType>());
+        assert(isa<IREE::VM::RefType>(operand.getType()));
+        assert(isa<IREE::VM::RefType>(blockArg.getType()));
 
         Value operandRef = getModuleAnalysis().lookupRef(operand);
         Value blockArgRef = getModuleAnalysis().lookupRef(blockArg);
@@ -3732,7 +3732,7 @@ private:
         Type originalType =
             op.getOperation()->getOperand(operand.index()).getType();
 
-        assert(originalType.isa<IREE::VM::RefType>() && "expected ref type");
+        assert(isa<IREE::VM::RefType>(originalType) && "expected ref type");
 
         Type objectType =
             llvm::cast<IREE::VM::RefType>(originalType).getObjectType();

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCBuilders.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCBuilders.cpp
@@ -78,7 +78,7 @@ Value contentsOf(OpBuilder builder, Location location, Value operand) {
   auto ctx = builder.getContext();
 
   Type type = operand.getType();
-  assert(type.isa<emitc::PointerType>());
+  assert(isa<emitc::PointerType>(type));
 
   return builder
       .create<emitc::ApplyOp>(

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.cpp
@@ -37,7 +37,7 @@ EmitCTypeConverter::EmitCTypeConverter(ModuleOp module)
   addSourceMaterialization([this](OpBuilder &builder, IREE::VM::RefType type,
                                   ValueRange inputs, Location loc) -> Value {
     assert(inputs.size() == 1);
-    assert(inputs[0].getType().isa<emitc::PointerType>());
+    assert(isa<emitc::PointerType>(inputs[0].getType()));
 
     Type objectType = IREE::VM::OpaqueType::get(builder.getContext());
     Type refType = IREE::VM::RefType::get(objectType);

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMBase.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMBase.td
@@ -246,7 +246,7 @@ def VM_AnyRefObject : DialectType<
 
 def VM_AnyRef : DialectType<
     Util_Dialect,
-    CPred<"$_self.isa<IREE::VM::RefType>()">,
+    CPred<"isa<IREE::VM::RefType>($_self)">,
     "ref"> {
   let description = [{
     An iree_vm_ref_t/iree::vm::ref<T> of some type.
@@ -255,8 +255,8 @@ def VM_AnyRef : DialectType<
 
 class VM_RefOf<Type type> :
     Type<And<[
-      CPred<"$_self.isa<IREE::VM::RefType>()">,
-      SubstLeaves<"$_self", "$_self.cast<IREE::VM::RefType>().getObjectType()",
+      CPred<"isa<IREE::VM::RefType>($_self)">,
+      SubstLeaves<"$_self", "cast<IREE::VM::RefType>($_self).getObjectType()",
                   type.predicate>
     ]>, "ref<" # type.summary # ">"> {
   // Set the builder call if the base type has a builder call.
@@ -270,7 +270,7 @@ class VM_RefOf<Type type> :
 
 def VM_BufferType : DialectType<
     Util_Dialect,
-    CPred<"$_self.isa<IREE::VM::BufferType>()">,
+    CPred<"isa<IREE::VM::BufferType>($_self)">,
     "buffer"> {
   let description = [{
     A byte buffer.
@@ -285,8 +285,8 @@ def VM_BufferType : DialectType<
 def VM_AnyList : DialectType<
     Util_Dialect,
     And<[
-      CPred<"$_self.isa<IREE::VM::RefType>()">,
-      CPred<"$_self.cast<IREE::VM::RefType>().getObjectType().isa<IREE::VM::ListType>()">,
+      CPred<"isa<IREE::VM::RefType>($_self)">,
+      CPred<"isa<IREE::VM::ListType>(cast<IREE::VM::RefType>($_self).getObjectType())">,
     ]>,
     "list"> {
   let description = [{
@@ -296,11 +296,11 @@ def VM_AnyList : DialectType<
 
 class VM_ListOf<Type type> :
     Type<And<[
-      CPred<"$_self.cast<IREE::VM::RefType>().getObjectType().isa<IREE::VM::ListType>()">,
+      CPred<"isa<IREE::VM::ListType>(cast<IREE::VM::RefType>($_self).getObjectType())">,
       Or<[
-        CPred<"$_self.cast<IREE::VM::RefType>().getObjectType().cast<IREE::VM::ListType>().getElementType().isa<IREE::VM::OpaqueType>()">,
+        CPred<"isa<IREE::VM::OpaqueType>(cast<IREE::VM::ListType>(cast<IREE::VM::RefType>($_self).getObjectType()).getElementType())">,
         SubstLeaves<"$_self",
-                    "$_self.cast<IREE::VM::RefType>().getObjectType().cast<IREE::VM::ListType>().getElementType()",
+                    "cast<IREE::VM::ListType>(cast<IREE::VM::RefType>($_self).getObjectType()).getElementType()",
                     type.predicate>
       ]>,
     ]>, "list<" # type.summary # ">"> {

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
@@ -3050,7 +3050,7 @@ struct SwapInvertedCondBranchOpTargets : public OpRewritePattern<CondBranchOp> {
     // if (auto xorOp = dyn_cast_or_null<XorI32Op>(condValue.getDefiningOp())) {
     //   Attribute rhs;
     //   if (matchPattern(xorOp.getRhs(), m_Constant(&rhs)) &&
-    //       rhs.cast<IntegerAttr>().getInt() == 1) {
+    //       cast<IntegerAttr>(rhs).getInt() == 1) {
     //     rewriter.replaceOpWithNewOp<CondBranchOp>(
     //         op, xorOp.getLhs(), op.getFalseDest(), op.getFalseOperands(),
     //         op.getTrueDest(), op.getTrueOperands());

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
@@ -897,7 +897,7 @@ void RodataTableInlineOp::build(OpBuilder &builder, OperationState &result,
 LogicalResult ListGetRefOp::verify() {
   Operation *op = getOperation();
   auto listType = llvm::cast<IREE::VM::ListType>(
-      getList().getType().cast<IREE::VM::RefType>().getObjectType());
+      cast<IREE::VM::RefType>(getList().getType()).getObjectType());
   auto elementType = listType.getElementType();
   auto resultType = getResult().getType();
   if (!llvm::isa<IREE::VM::OpaqueType>(elementType)) {
@@ -922,7 +922,7 @@ LogicalResult ListGetRefOp::verify() {
 LogicalResult ListSetRefOp::verify() {
   Operation *op = getOperation();
   auto listType = llvm::cast<IREE::VM::ListType>(
-      getList().getType().cast<IREE::VM::RefType>().getObjectType());
+      cast<IREE::VM::RefType>(getList().getType()).getObjectType());
   auto elementType = listType.getElementType();
   auto valueType = getValue().getType();
   if (!llvm::isa<IREE::VM::OpaqueType>(elementType)) {

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -416,8 +416,8 @@ class VM_PrimitiveGlobalOp<string mnemonic, Attr attr_type, list<Trait> traits =
         $_state.addAttribute("is_mutable", $_builder.getUnitAttr());
       }
       if (initialValue.has_value() &&
-                 (initialValue.value().isa<IntegerAttr>() ||
-                  initialValue.value().isa<FloatAttr>())) {
+                 (isa<IntegerAttr>(initialValue.value()) ||
+                  isa<FloatAttr>(initialValue.value()))) {
         $_state.addAttribute("initial_value", initialValue.value());
       }
       $_state.addAttribute("type", TypeAttr::get(type));
@@ -1682,7 +1682,7 @@ def VM_ListAllocOp :
 
   let encoding = [
     VM_EncOpcode<VM_OPC_ListAlloc>,
-    VM_EncType<"getResult().getType().cast<IREE::VM::RefType>().getObjectType().cast<IREE::VM::ListType>().getElementType()">,
+    VM_EncType<"cast<IREE::VM::ListType>(cast<IREE::VM::RefType>(getResult().getType()).getObjectType()).getElementType()">,
     VM_EncOperand<"initial_capacity", 0>,
     VM_EncResult<"result">,
   ];
@@ -4283,7 +4283,7 @@ def VM_CallVariadicOp : VM_CallBaseOp<"call.variadic"> {
               segmentSizes));
       $_state.addAttribute("segment_types", $_builder.getArrayAttr(
           llvm::map_to_vector(segmentTypes, [&](Type type) {
-              return TypeAttr::get(type).cast<Attribute>();
+              return cast<Attribute>(TypeAttr::get(type));
           })));
       $_state.addOperands(operands);
       $_state.addTypes(resultTypes);

--- a/compiler/src/iree/compiler/Dialect/VMVX/Conversion/HALToVMVX/ConvertHALToVMVX.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Conversion/HALToVMVX/ConvertHALToVMVX.cpp
@@ -214,7 +214,7 @@ struct ConvertGetRawInterfaceBindingBufferOp
     auto bindingsArg =
         op->getParentOfType<mlir::FunctionOpInterface>().getArgument(
             kEntryArgBindings);
-    assert(bindingsArg && bindingsArg.getType().isa<IREE::Util::ListType>() &&
+    assert(bindingsArg && isa<IREE::Util::ListType>(bindingsArg.getType()) &&
            "entry point not conforming to requirements");
 
     // TODO(benvanik): compact the indices - the bindings we have on the ABI
@@ -247,7 +247,7 @@ struct ConvertHALInterfaceBindingSubspanOp
     auto bindingsArg =
         op->getParentOfType<mlir::FunctionOpInterface>().getArgument(
             kEntryArgBindings);
-    assert(bindingsArg && bindingsArg.getType().isa<IREE::Util::ListType>() &&
+    assert(bindingsArg && isa<IREE::Util::ListType>(bindingsArg.getType()) &&
            "entry point not conforming to requirements");
 
     // TODO(benvanik): compact the indices - the bindings we have on the ABI

--- a/compiler/src/iree/compiler/Dialect/Vulkan/IR/VulkanBase.td
+++ b/compiler/src/iree/compiler/Dialect/Vulkan/IR/VulkanBase.td
@@ -42,10 +42,10 @@ def VK_Dialect : Dialect {
 // enum class with `name`.
 class VK_IsKnownBitEnumCaseFor<string name> :
     CPred<"::mlir::iree_compiler::IREE::Vulkan::symbolize" # name # "("
-          "$_self.cast<IntegerAttr>().getValue().getZExtValue()).hasValue()">;
+          "cast<IntegerAttr>($_self).getValue().getZExtValue()).hasValue()">;
 class VK_IsKnownIntEnumCaseFor<string name> :
     CPred<"::mlir::iree_compiler::IREE::Vulkan::symbolize" # name # "("
-          "$_self.cast<IntegerAttr>().getValue().getZExtValue()).hasValue()">;
+          "cast<IntegerAttr>($_self).getValue().getZExtValue()).hasValue()">;
 
 // Wrapper over base I32BitEnumAttr to set common fields.
 class VK_BitEnumAttr<string name, string description,

--- a/compiler/src/iree/compiler/GlobalOptimization/FuseDequantizationMatmul.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/FuseDequantizationMatmul.cpp
@@ -312,9 +312,9 @@ LogicalResult QuantizedMatmulRewriter::precondition() {
   }
   Value scales = ins[2]->get();
   Value zps = ins[3]->get();
-  if (!unquantizedInputType.getElementType().isa<FloatType>() ||
-      !getElementTypeOrSelf(scales).isa<FloatType>() ||
-      !getElementTypeOrSelf(zps).isa<FloatType>()) {
+  if (!isa<FloatType>(unquantizedInputType.getElementType()) ||
+      !isa<FloatType>(getElementTypeOrSelf(scales)) ||
+      !isa<FloatType>(getElementTypeOrSelf(zps))) {
     return rewriter.notifyMatchFailure(matmul, "expected float type");
   }
   OpOperand *matmulDequantizedOperand = ins[4];
@@ -381,7 +381,7 @@ QuantizedMatmulRewriter::getGroupReductionMapsAndIterators(
 // Helper to create an init Value for reductions along the group dimension.
 Value QuantizedMatmulRewriter::getGroupReductionInit(Value input) {
   RankedTensorType inputType = llvm::cast<RankedTensorType>(input.getType());
-  assert(inputType.getElementType().isa<FloatType>() && "expected float type");
+  assert(isa<FloatType>(inputType.getElementType()) && "expected float type");
   Value zero = rewriter.create<arith::ConstantOp>(
       loc, rewriter.getFloatAttr(inputType.getElementType(), 0.0));
   SmallVector<int64_t> inputShape(inputType.getShape());
@@ -418,7 +418,7 @@ Value QuantizedMatmulRewriter::generateGroupMaxGeneric() {
 // returns the result.
 Value QuantizedMatmulRewriter::generateScalesGeneric(Value groupMax) {
   auto groupMaxType = llvm::cast<RankedTensorType>(groupMax.getType());
-  assert(groupMaxType.getElementType().isa<FloatType>() &&
+  assert(isa<FloatType>(groupMaxType.getElementType()) &&
          "expected float type");
   Value cst = rewriter.create<arith::ConstantOp>(
       loc, rewriter.getFloatAttr(groupMaxType.getElementType(),

--- a/compiler/src/iree/compiler/GlobalOptimization/RaiseSpecialOps.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/RaiseSpecialOps.cpp
@@ -65,7 +65,7 @@ static bool matchInner2DTranspose(linalg::LinalgOp genericOp, unsigned rank) {
     return false;
   }
   auto yieldOp = cast<linalg::YieldOp>(body->getTerminator());
-  auto blockArg = yieldOp.getOperand(0).dyn_cast<BlockArgument>();
+  auto blockArg = dyn_cast<BlockArgument>(yieldOp.getOperand(0));
   if (!blockArg || blockArg.getOwner() != body ||
       blockArg.getArgNumber() != 0) {
     return false;
@@ -470,7 +470,7 @@ matchCatNegateAndSlice(tensor::InsertSliceOp insertOp) {
     return std::nullopt;
   }
 
-  auto sourceType = source.getType().dyn_cast<RankedTensorType>();
+  auto sourceType = dyn_cast<RankedTensorType>(source.getType());
   if (!sourceType || sourceType.getRank() == 0) {
     return std::nullopt;
   }

--- a/compiler/src/iree/compiler/GlobalOptimization/SetEncoding.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/SetEncoding.cpp
@@ -52,7 +52,7 @@ using IREE::LinalgExt::EncodingRole;
 /// materialization of `encodingAttr`.
 static Value pad(OpBuilder &builder, Location loc, Value source,
                  EncodingAttr encodingAttr) {
-  RankedTensorType sourceType = source.getType().cast<RankedTensorType>();
+  RankedTensorType sourceType = cast<RankedTensorType>(source.getType());
   Type elemType = sourceType.getElementType();
   size_t rank = sourceType.getRank();
   RankedTensorType tensorTypeWithEncoding =
@@ -84,7 +84,7 @@ static Value pad(OpBuilder &builder, Location loc, Value source,
 
 Value setEncoding(OpBuilder &builder, Location loc, Value source,
                   EncodingAttr encodingAttr) {
-  auto sourceType = source.getType().cast<RankedTensorType>();
+  auto sourceType = cast<RankedTensorType>(source.getType());
   auto resultType = RankedTensorType::get(
       sourceType.getShape(), sourceType.getElementType(), encodingAttr);
   return builder.create<IREE::LinalgExt::SetEncodingOp>(loc, resultType,
@@ -161,7 +161,7 @@ static Value padAndSetEncoding(OpBuilder &builder, Location loc, Value source,
 static Value unsetEncodingAndExtractSlice(OpBuilder &builder, Location loc,
                                           Value source,
                                           SmallVector<OpFoldResult> sizes) {
-  auto sourceType = source.getType().cast<RankedTensorType>();
+  auto sourceType = cast<RankedTensorType>(source.getType());
   auto unsetEncodingReturnType =
       RankedTensorType::get(sourceType.getShape(), sourceType.getElementType());
   auto unsetEncoding = builder
@@ -320,7 +320,7 @@ public:
     SmallVector<Type> elemTypes = {lhsElemType, rhsElemType, outElemType};
 
     MatmulNarrowSizes narrowSizes =
-        getMatmulNarrowSizes(out.getType().cast<ShapedType>(), linalgOp);
+        getMatmulNarrowSizes(cast<ShapedType>(out.getType()), linalgOp);
 
     Location loc = linalgOp.getLoc();
     SmallVector<AffineMap> maps = linalgOp.getIndexingMapsArray();

--- a/compiler/src/iree/compiler/GlobalOptimization/Utils.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Utils.cpp
@@ -49,8 +49,8 @@ std::optional<CastOpInterface> getDefiningNonI1ExtendingCastOp(Value input) {
     return std::nullopt;
   }
   Value castIn = castOp->getOperand(0);
-  if (castIn.isa<BlockArgument>() &&
-      castIn.cast<BlockArgument>().getArgNumber() != 0) {
+  if (isa<BlockArgument>(castIn) &&
+      cast<BlockArgument>(castIn).getArgNumber() != 0) {
     return std::nullopt;
   }
   if (!isI1Src(castOp) && isExtending(castOp)) {

--- a/compiler/src/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
@@ -57,7 +57,7 @@ template <typename To, typename From, typename Converter>
 static ArrayAttr convertArrayAttribute(ArrayAttr src, Converter fn) {
   SmallVector<Attribute> result;
   for (auto attr : src) {
-    if (auto arr = attr.dyn_cast<ArrayAttr>()) {
+    if (auto arr = dyn_cast<ArrayAttr>(attr)) {
       result.push_back(convertArrayAttribute<To, From, Converter>(arr, fn));
     } else {
       result.push_back(fn(attr.template cast<From>()));

--- a/compiler/src/iree/compiler/Modules/Check/Conversion/ConversionPatterns.cpp
+++ b/compiler/src/iree/compiler/Modules/Check/Conversion/ConversionPatterns.cpp
@@ -79,7 +79,7 @@ static LogicalResult applyDefaultCheckBufferRewrite(
     // during development.
     assert(
         (!HALTypeConverter::shouldConvertToBufferView(srcOperand.getType()) ||
-         dstOperand.getType().isa<IREE::HAL::BufferViewType>()) &&
+         isa<IREE::HAL::BufferViewType>(dstOperand.getType())) &&
         "expect that tensors have been mapped to buffer views");
     state.addOperands({dstOperand});
   }

--- a/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvToChannelsLast.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvToChannelsLast.cpp
@@ -190,7 +190,7 @@ createTransposeAsTensorPack(
     return std::make_tuple(input, std::nullopt, inputMap);
   }
 
-  RankedTensorType inType = input.getType().cast<RankedTensorType>();
+  RankedTensorType inType = cast<RankedTensorType>(input.getType());
   auto elementType = inType.getElementType();
   auto inputShape(inType.getShape());
 
@@ -259,7 +259,7 @@ static Value createTransposeAsTensorUnPack(PatternRewriter &rewriter,
                                            int tilingFactor) {
   Value packedOutput = output;
   if (tilingFactor <= 0) {
-    RankedTensorType outType = output.getType().cast<RankedTensorType>();
+    RankedTensorType outType = cast<RankedTensorType>(output.getType());
     auto elementType = outType.getElementType();
     auto outputShape(outType.getShape());
     int64_t rank = outType.getRank();
@@ -531,7 +531,7 @@ public:
       return failure();
 
     RankedTensorType destType =
-        packOp.getDest().getType().cast<RankedTensorType>();
+        cast<RankedTensorType>(packOp.getDest().getType());
     ArrayRef<int64_t> destShape = destType.getShape();
     ArrayRef<int64_t> innerDimsPos = packOp.getInnerDimsPos();
 
@@ -603,7 +603,7 @@ public:
       return failure();
 
     RankedTensorType srcType =
-        unpackOp.getSource().getType().cast<RankedTensorType>();
+        cast<RankedTensorType>(unpackOp.getSource().getType());
     ArrayRef<int64_t> srcShape = srcType.getShape();
 
     ArrayRef<int64_t> innerDimsPos = unpackOp.getInnerDimsPos();
@@ -621,7 +621,7 @@ public:
     }
 
     RankedTensorType destType =
-        unpackOp.getDest().getType().cast<RankedTensorType>();
+        cast<RankedTensorType>(unpackOp.getDest().getType());
     SmallVector<int64_t> perm;
     for (int i = 0, e = destType.getRank(); i < e; i++) {
       if (!innerDims.count(i)) {

--- a/compiler/src/iree/compiler/Preprocessing/Common/MakeSingleDispatchForFunction.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/MakeSingleDispatchForFunction.cpp
@@ -44,7 +44,7 @@ void MakeSingleDispatchForFunctionPass::runOnOperation() {
   // a function.
   auto resultTypes = funcOp.getResultTypes();
   if (llvm::any_of(resultTypes, [&](Type t) {
-        auto shapedType = t.dyn_cast<ShapedType>();
+        auto shapedType = dyn_cast<ShapedType>(t);
         return shapedType && !shapedType.hasStaticShape();
       })) {
     return;

--- a/compiler/src/iree/compiler/Reducer/Strategies/ReduceFlowDispatchResultBySplat.cpp
+++ b/compiler/src/iree/compiler/Reducer/Strategies/ReduceFlowDispatchResultBySplat.cpp
@@ -66,7 +66,7 @@ void mlir::iree_compiler::Reducer::reduceFlowDispatchResultBySplatDelta(
          ++index) {
       auto result = dispatch.getResults()[index];
       auto dynamicDims = dispatch.getResultDynamicDims(index);
-      auto tensorType = result.getType().cast<RankedTensorType>();
+      auto tensorType = cast<RankedTensorType>(result.getType());
       auto elType = tensorType.getElementType();
       auto zeroAttr = builder.getZeroAttr(elType);
       auto zero = builder.create<arith::ConstantOp>(result.getLoc(), zeroAttr);

--- a/compiler/src/iree/compiler/Utils/ConversionUtils.cpp
+++ b/compiler/src/iree/compiler/Utils/ConversionUtils.cpp
@@ -113,7 +113,7 @@ Attribute convertAttribute(Location loc, Attribute oldAttr,
   } else if (auto denseAttr =
                  llvm::dyn_cast<DenseFPElementsAttr>(typedOldAttr)) {
     auto newElementType =
-        llvm::cast<FloatType>(newType.cast<ShapedType>().getElementType());
+        llvm::cast<FloatType>(cast<ShapedType>(newType).getElementType());
     const auto &newFloatSemantics = newElementType.getFloatSemantics();
     return denseAttr.mapValues(newElementType, [&](APFloat src) {
       bool losesInfo = false;

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputBase.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputBase.td
@@ -44,7 +44,7 @@ class IREEInput_Type<string name> : TypeDef<IREEInput_Dialect, name>;
 // Predicates
 //===----------------------------------------------------------------------===//
 
-class IREEInput_AliasedSymbolRefAttr : Attr<CPred<"$_self.isa<FlatSymbolRefAttr>()">,
+class IREEInput_AliasedSymbolRefAttr : Attr<CPred<"isa<FlatSymbolRefAttr>($_self)">,
                                                   "symbol reference attribute"> {
   let storageType = [{ FlatSymbolRefAttr }];
   let returnType = [{ StringRef }];
@@ -53,11 +53,11 @@ class IREEInput_AliasedSymbolRefAttr : Attr<CPred<"$_self.isa<FlatSymbolRefAttr>
 }
 class IREEInput_AnyPtrOf<list<Type> types> :
     Type<And<[
-      CPred<"$_self.isa<::mlir::iree_compiler::IREE::Input::PtrType>()">,
+      CPred<"isa<::mlir::iree_compiler::IREE::Input::PtrType>($_self)">,
       Or<!foreach(type, types,
           SubstLeaves<
               "$_self",
-              "$_self.cast<::mlir::iree_compiler::IREE::Input::PtrType>().getTargetType()",
+              "cast<::mlir::iree_compiler::IREE::Input::PtrType>($_self).getTargetType()",
               type.predicate>)>,
     ]>, !interleave(!foreach(type, types, type.summary), " or ")> {
   string builderCall = "";
@@ -68,7 +68,7 @@ def IREEInput_Tensor : TypeAlias<AnyRankedTensor>;
 
 def IREEInput_AnyList : DialectType<
     IREEInput_Dialect,
-    CPred<"$_self.isa<::mlir::iree_compiler::IREE::Input::ListType>()">,
+    CPred<"isa<::mlir::iree_compiler::IREE::Input::ListType>($_self)">,
       "list"> {
   let description = [{
     A mutable, resizable list of some type.
@@ -77,9 +77,9 @@ def IREEInput_AnyList : DialectType<
 
 class IREEInput_ListOf<Type type> :
     Type<And<[
-      CPred<"$_self.isa<::mlir::iree_compiler::IREE::Input::ListType>()">,
+      CPred<"isa<::mlir::iree_compiler::IREE::Input::ListType>($_self)">,
       SubstLeaves<"$_self",
-                  "$_self.cast<::mlir::iree_compiler::IREE::Input::ListType>().getElementType()",
+                  "cast<::mlir::iree_compiler::IREE::Input::ListType>($_self).getElementType()",
                   type.predicate>
     ]>, "list<" # type.summary # ">"> {
   // Set the builder call if the base type has a builder call.
@@ -99,8 +99,8 @@ class IREEInput_IndexAttrBase<string descr> :
     TypedAttrBase<
       Index, "IntegerAttr",
       And<[
-        CPred<"$_self.isa<IntegerAttr>()">,
-        CPred<"$_self.cast<IntegerAttr>().getType().isIndex()">,
+        CPred<"isa<IntegerAttr>($_self)">,
+        CPred<"cast<IntegerAttr>($_self).getType().isIndex()">,
       ]>,
       descr> {
   let returnType = [{ APInt }];

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputInterfaces.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputInterfaces.td
@@ -106,7 +106,7 @@ def IREEInput_TiedOpInterface : OpInterface<"TiedOpInterface"> {
       /*args=*/(ins "Value":$result),
       /*methodBody=*/[{}],
       /*defaultImplementation=*/[{
-        auto resultIndex = result.cast<mlir::OpResult>().getResultNumber();
+        auto resultIndex = cast<mlir::OpResult>(result).getResultNumber();
         auto operandIndex = cast<TiedOpInterface>($_op.getOperation())
             .getTiedResultOperandIndex(resultIndex);
         return operandIndex.has_value() ?

--- a/llvm-external-projects/iree-dialects/lib/CAPI/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/lib/CAPI/CMakeLists.txt
@@ -2,6 +2,7 @@ add_mlir_public_c_api_library(IREEDialectsCAPI
   Dialects.cpp
   LINK_LIBS PUBLIC
   MLIRIR
+  MLIRLinalgTransformOps
   MLIRTransformDialect
   IREEInputDialect
   IREELinalgTransformDialect

--- a/llvm-external-projects/iree-dialects/lib/Dialect/Input/InputOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/Input/InputOps.cpp
@@ -602,15 +602,15 @@ void GlobalOp::build(OpBuilder &builder, OperationState &result, StringRef name,
 static bool isGlobalTypeCompatible(Type globalType, Type accessType) {
   // If one is a shaped type, then they both must be and have compatible
   // shapes.
-  if (globalType.isa<ShapedType>() && accessType.isa<ShapedType>()) {
+  if (isa<ShapedType>(globalType) && isa<ShapedType>(accessType)) {
     return succeeded(mlir::verifyCompatibleShape(globalType, accessType)) &&
-           globalType.cast<ShapedType>().getElementType() ==
-               accessType.cast<ShapedType>().getElementType();
+           cast<ShapedType>(globalType).getElementType() ==
+               cast<ShapedType>(accessType).getElementType();
   }
 
   // Permissively allow any other types to be marked compatible as long as
   // neither are shaped type.
-  return !globalType.isa<ShapedType>() && !accessType.isa<ShapedType>();
+  return !isa<ShapedType>(globalType) && !isa<ShapedType>(accessType);
 }
 
 LogicalResult
@@ -630,7 +630,7 @@ GlobalLoadOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 }
 
 LogicalResult GlobalLoadIndirectOp::verify() {
-  auto globalType = getGlobal().getType().cast<PtrType>().getTargetType();
+  auto globalType = cast<PtrType>(getGlobal().getType()).getTargetType();
   auto loadType = getResult().getType();
   if (!isGlobalTypeCompatible(globalType, loadType)) {
     return emitOpError() << "global type mismatch; global pointer is "
@@ -656,7 +656,7 @@ GlobalStoreOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 }
 
 LogicalResult GlobalStoreIndirectOp::verify() {
-  auto globalType = getGlobal().getType().cast<PtrType>().getTargetType();
+  auto globalType = cast<PtrType>(getGlobal().getType()).getTargetType();
   auto storeType = getValue().getType();
   if (!isGlobalTypeCompatible(globalType, storeType)) {
     return emitOpError() << "global type mismatch; global pointer is "

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/IR/StructuredTransformOpsExt.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/IR/StructuredTransformOpsExt.cpp
@@ -65,7 +65,7 @@ static LogicalResult nestedInFunc(PatternRewriter &rewriter,
   auto func = operation->getParentOfType<mlir::FunctionOpInterface>();
   if (!func)
     return rewriter.notifyMatchFailure(operation, "not nested in a function");
-  auto functionSymbol = attr.dyn_cast<SymbolRefAttr>();
+  auto functionSymbol = dyn_cast<SymbolRefAttr>(attr);
   if (!functionSymbol)
     return rewriter.notifyMatchFailure(operation, "not a function identifier");
   return success(functionSymbol.getLeafReference() == func.getName());
@@ -174,7 +174,7 @@ static LogicalResult isEquivalentToOp(PatternRewriter &rewriter,
   Operation *operation = pdlValues[0].cast<Operation *>();
   Attribute attribute = pdlValues[1].cast<Attribute>();
 
-  auto modelOpNameAttr = attribute.dyn_cast<StringAttr>();
+  auto modelOpNameAttr = dyn_cast<StringAttr>(attribute);
   if (!modelOpNameAttr)
     return failure(); // TODO: notifyMatchFailure needs an Operation* handle.
   auto modelOpName = modelOpNameAttr.strref();
@@ -215,7 +215,7 @@ static LogicalResult isDimMultipleOf(PatternRewriter &rewriter,
   ValueRange operands = pdlValues[0].cast<ValueRange>();
   Attribute attribute = pdlValues[1].cast<Attribute>();
 
-  auto dict = attribute.dyn_cast<DictionaryAttr>();
+  auto dict = dyn_cast<DictionaryAttr>(attribute);
   if (!dict)
     return failure(); // TODO: notifyMatchFailure needs an Operation* handle.
 
@@ -239,7 +239,7 @@ static LogicalResult isDimMultipleOf(PatternRewriter &rewriter,
 
   ShapedType shapedType;
   if (static_cast<int64_t>(operands.size()) > operandNumber)
-    shapedType = operands[operandNumber].getType().dyn_cast<ShapedType>();
+    shapedType = dyn_cast<ShapedType>(operands[operandNumber].getType());
   if (!shapedType || shapedType.getRank() <= dim)
     return failure();
   return success(divisor == 0 || (shapedType.getShape()[dim] > 0 &&
@@ -259,7 +259,7 @@ static LogicalResult isDimStatic(PatternRewriter &rewriter,
   ValueRange operands = pdlValues[0].cast<ValueRange>();
   Attribute attribute = pdlValues[1].cast<Attribute>();
 
-  auto dict = attribute.dyn_cast<DictionaryAttr>();
+  auto dict = dyn_cast<DictionaryAttr>(attribute);
   if (!dict)
     return failure(); // TODO: notifyMatchFailure needs an Operation* handle.
 
@@ -277,7 +277,7 @@ static LogicalResult isDimStatic(PatternRewriter &rewriter,
 
   ShapedType shapedType;
   if (static_cast<int64_t>(operands.size()) > operandNumber)
-    shapedType = operands[operandNumber].getType().dyn_cast<ShapedType>();
+    shapedType = dyn_cast<ShapedType>(operands[operandNumber].getType());
   return success(shapedType && !shapedType.isDynamicDim(dim));
 }
 
@@ -294,7 +294,7 @@ static LogicalResult isDimDynamic(PatternRewriter &rewriter,
   ValueRange operands = pdlValues[0].cast<ValueRange>();
   Attribute attribute = pdlValues[1].cast<Attribute>();
 
-  auto dict = attribute.dyn_cast<DictionaryAttr>();
+  auto dict = dyn_cast<DictionaryAttr>(attribute);
   if (!dict)
     return failure(); // TODO: notifyMatchFailure needs an Operation* handle.
 
@@ -312,7 +312,7 @@ static LogicalResult isDimDynamic(PatternRewriter &rewriter,
 
   ShapedType shapedType;
   if (static_cast<int64_t>(operands.size()) > operandNumber)
-    shapedType = operands[operandNumber].getType().dyn_cast<ShapedType>();
+    shapedType = dyn_cast<ShapedType>(operands[operandNumber].getType());
   return success(shapedType && shapedType.isDynamicDim(dim));
 }
 
@@ -904,7 +904,7 @@ transform_ext::TakeFirstOp::apply(mlir::transform::TransformRewriter &rewriter,
     if (payloads.empty())
       continue;
     if (!found) {
-      results.set(getFirst().cast<OpResult>(), payloads);
+      results.set(cast<OpResult>(getFirst()), payloads);
       found = true;
     } else {
       llvm::append_range(concatenated, payloads);
@@ -912,8 +912,8 @@ transform_ext::TakeFirstOp::apply(mlir::transform::TransformRewriter &rewriter,
   }
 
   if (!found)
-    results.set(getFirst().cast<OpResult>(), {});
-  results.set(getRest().cast<OpResult>(), concatenated);
+    results.set(cast<OpResult>(getFirst()), {});
+  results.set(cast<OpResult>(getRest()), concatenated);
   return DiagnosedSilenceableFailure::success();
 }
 

--- a/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
@@ -296,12 +296,12 @@ struct DebugPrintValueWrapper {
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
                               const DebugPrintValueWrapper &wrapper) {
-  if (auto opResult = wrapper.value.dyn_cast<OpResult>()) {
+  if (auto opResult = dyn_cast<OpResult>(wrapper.value)) {
     return os << "op result #" << opResult.getResultNumber() << " in "
               << wrapper.value;
   }
 
-  auto blockArg = wrapper.value.cast<BlockArgument>();
+  auto blockArg = cast<BlockArgument>(wrapper.value);
   os << "block argument #" << blockArg.getArgNumber();
   Block *parentBlock = blockArg.getParentBlock();
   Region *parentRegion = parentBlock->getParent();
@@ -358,7 +358,7 @@ transform_ext::ShapedValueMatcher::ShapedValueMatcher()
     : CapturingValueMatcher() {
   addPredicate([](Value value) {
     LLVM_DEBUG(DBGS() << "value is of shaped type");
-    return value && value.getType().isa<ShapedType>();
+    return value && isa<ShapedType>(value.getType());
   });
 }
 
@@ -366,7 +366,7 @@ transform_ext::ShapedValueMatcher &
 transform_ext::ShapedValueMatcher::rank(transform_ext::CaptureRank capture) {
   addPredicate([=](Value value) {
     LLVM_DEBUG(DBGS() << "capturing shaped value rank");
-    capture.value = value.getType().cast<ShapedType>().getRank();
+    capture.value = cast<ShapedType>(value.getType()).getRank();
     return true;
   });
   return *this;
@@ -376,7 +376,7 @@ transform_ext::ShapedValueMatcher &
 transform_ext::ShapedValueMatcher::dim(int64_t dimension, CaptureDim capture) {
   addPredicate([=](Value value) {
     LLVM_DEBUG(DBGS() << "capturing shaped value dimension " << dimension);
-    capture.value = value.getType().cast<ShapedType>().getDimSize(dimension);
+    capture.value = cast<ShapedType>(value.getType()).getDimSize(dimension);
     return true;
   });
   return *this;
@@ -387,7 +387,7 @@ transform_ext::ShapedValueMatcher::dim(AllDims tag, CaptureDims captures) {
   (void)tag;
   addPredicate([=](Value value) {
     LLVM_DEBUG(DBGS() << "capturing all shaped value dimensions");
-    ArrayRef<int64_t> shape = value.getType().cast<ShapedType>().getShape();
+    ArrayRef<int64_t> shape = cast<ShapedType>(value.getType()).getShape();
     captures.value.assign(shape.begin(), shape.end());
     return true;
   });
@@ -398,7 +398,7 @@ transform_ext::ShapedValueMatcher &
 transform_ext::ShapedValueMatcher::elementType(CaptureElementType captures) {
   addPredicate([=](Value value) {
     LLVM_DEBUG(DBGS() << "capturing elementType");
-    captures.value = value.getType().cast<ShapedType>().getElementType();
+    captures.value = cast<ShapedType>(value.getType()).getElementType();
     return true;
   });
   return *this;
@@ -811,10 +811,8 @@ transform_ext::StructuredOpMatcher::input(int64_t position,
     int64_t updatedPosition = position;
     if (!makeValidPositiveIndex(updatedPosition, linalgOp.getNumDpsInputs()))
       return false;
-    auto shapedType = linalgOp.getDpsInputOperand(updatedPosition)
-                          ->get()
-                          .getType()
-                          .dyn_cast<ShapedType>();
+    auto shapedType = dyn_cast<ShapedType>(
+        linalgOp.getDpsInputOperand(updatedPosition)->get().getType());
     return shapedType && shapedType.getElementType().isIntOrFloat() &&
            shapedType.getElementType().getIntOrFloatBitWidth() == width.value;
   });
@@ -828,10 +826,8 @@ transform_ext::StructuredOpMatcher::input(int64_t position,
     int64_t updatedPosition = position;
     if (!makeValidPositiveIndex(updatedPosition, linalgOp.getNumDpsInputs()))
       return false;
-    auto shapedType = linalgOp.getDpsInputOperand(updatedPosition)
-                          ->get()
-                          .getType()
-                          .dyn_cast<ShapedType>();
+    auto shapedType = dyn_cast<ShapedType>(
+        linalgOp.getDpsInputOperand(updatedPosition)->get().getType());
     if (!shapedType || !shapedType.getElementType().isIntOrFloat())
       return false;
     width.value = shapedType.getElementType().getIntOrFloatBitWidth();
@@ -848,10 +844,8 @@ transform_ext::StructuredOpMatcher::input(int64_t position,
     int64_t updatedPosition = position;
     if (!makeValidPositiveIndex(updatedPosition, linalgOp.getNumDpsInputs()))
       return false;
-    auto shapedType = linalgOp.getDpsInputOperand(updatedPosition)
-                          ->get()
-                          .getType()
-                          .dyn_cast<ShapedType>();
+    auto shapedType = dyn_cast<ShapedType>(
+        linalgOp.getDpsInputOperand(updatedPosition)->get().getType());
     if (!shapedType) {
       LLVM_DEBUG(DBGSNL() << "  not a shaped type");
       return false;
@@ -993,10 +987,8 @@ transform_ext::StructuredOpMatcher::output(int64_t position,
     int64_t updatedPosition = position;
     if (!makeValidPositiveIndex(updatedPosition, linalgOp.getNumDpsInits()))
       return false;
-    auto shapedType = linalgOp.getDpsInitOperand(updatedPosition)
-                          ->get()
-                          .getType()
-                          .dyn_cast<ShapedType>();
+    auto shapedType = dyn_cast<ShapedType>(
+        linalgOp.getDpsInitOperand(updatedPosition)->get().getType());
     return shapedType && shapedType.getElementType().isIntOrFloat() &&
            shapedType.getElementType().getIntOrFloatBitWidth() == width.value;
   });
@@ -1010,10 +1002,8 @@ transform_ext::StructuredOpMatcher::output(int64_t position,
     int64_t updatedPosition = position;
     if (!makeValidPositiveIndex(updatedPosition, linalgOp.getNumDpsInits()))
       return false;
-    auto shapedType = linalgOp.getDpsInitOperand(updatedPosition)
-                          ->get()
-                          .getType()
-                          .dyn_cast<ShapedType>();
+    auto shapedType = dyn_cast<ShapedType>(
+        linalgOp.getDpsInitOperand(updatedPosition)->get().getType());
     if (!shapedType || !shapedType.getElementType().isIntOrFloat()) {
       LLVM_DEBUG(DBGSNL() << "  could not infer element type");
       return false;
@@ -1032,10 +1022,8 @@ transform_ext::StructuredOpMatcher::output(int64_t position,
     int64_t updatedPosition = position;
     if (!makeValidPositiveIndex(updatedPosition, linalgOp.getNumDpsInits()))
       return false;
-    auto shapedType = linalgOp.getDpsInitOperand(updatedPosition)
-                          ->get()
-                          .getType()
-                          .dyn_cast<ShapedType>();
+    auto shapedType = dyn_cast<ShapedType>(
+        linalgOp.getDpsInitOperand(updatedPosition)->get().getType());
     if (!shapedType) {
       LLVM_DEBUG(DBGSNL() << "  not a shaped type");
       return false;


### PR DESCRIPTION
Integrate with more recent llvm commit get in following change for downstream iree-amd-aie project: https://github.com/llvm/llvm-project/commit/286bd42a7a799e3d9035c09bf0d64cb1a1eef682.

API breaking changes:
- Deprecate mlir::Value::isa/dyn_cast/cast/ member functions: https://github.com/llvm/llvm-project/pull/89238. See also: https://discourse.llvm.org/t/preferred-casting-style-going-forward/68443

Additionally, the gcc CI build broke on a missing `iree::compiler::Dialect::Stream::IR` dependency in the Torch/InputConversion plugin. Therefore, I ran the dependencies check and fixed all the ones that came up:
- `Torch/InputConversion` depends on `HAL::IR` and `Stream::IR`
- `Torch/torch-mlir` depends on `TorchDialectTransformsGen`, `MLIRFuncTransforms`, `MLIRGPUDialect`, `MLIRLinalgTransforms` and `MLIRVectorTransforms`
- `llvm-external-projects/CAPI` depends on `MLIRLinalgTransformOps`