### PR TITLE
Bump mkdocs-material version to include mkdocs 1.6.0.

### DIFF
--- a/docs/website/docs/developers/design-docs/design-roadmap.md
+++ b/docs/website/docs/developers/design-docs/design-roadmap.md
@@ -44,8 +44,7 @@ the allocation you don't make_ ;)
 ### Avoiding Readbacks with `flow.stream`
 
 A majority of the readbacks we have today (manifested as `flow.tensor.load.*`
-ops) will be removed when we have an
-[HLO tensor->primitive conversion](#xla-hlo-tensor-to-primitive-conversion).
+ops) will be removed when we have an HLO tensor->primitive conversion.
 There will still be cases when readbacks are required for correctness but they
 usually fall into a small set of usage patterns. For those that don't this is
 one place where IREE will warn about performance issues, allowing programs that

--- a/docs/website/docs/developers/design-docs/metal-hal-driver.md
+++ b/docs/website/docs/developers/design-docs/metal-hal-driver.md
@@ -188,7 +188,7 @@ caching allocator.
 ### Buffer
 
 IREE [`iree_hal_buffer_t`][hal-buffer] maps Metal `MTLBuffer`. See
-[Memory Management](#memory-management) for more details.
+[Object Lifetime Management](#object-lifetime-management) for more details.
 
 ### Executable
 
@@ -261,7 +261,7 @@ different places: the former is given when invoking
 dispatched SPIR-V code. This split does not match the Metal model, where we
 specify both in the API with `dispatchThreads:threadsPerThreadgroup:`.
 
-As said in [shader/kernel compilation](#shader-kernel-compilation), MSL kernels
+As said in [shader/kernel compilation](#shaderkernel-compilation), MSL kernels
 are cross compiled from SPIR-V code and then embeded in the module FlatBuffer.
 The module FlatBuffer provides us a way to convey the threadgroup/workgroup size
 information extracted from the SPIR-V code. We encode an additional 3-D vector

--- a/docs/website/docs/developers/general/developer-overview.md
+++ b/docs/website/docs/developers/general/developer-overview.md
@@ -192,7 +192,7 @@ MLIR type | Description | Input example
 The `iree-check-module` program takes an already translated IREE module as input
 and executes it as a series of
 [googletest](https://github.com/google/googletest) tests. This is the test
-runner for the IREE [check framework](./testing-guide.md#end-to-end-tests).
+runner for the IREE [check framework](./testing-guide.md#iree-core-end-to-end-e2e-tests).
 
 ```shell
 $ ../iree-build/tools/iree-compile \

--- a/docs/website/requirements.txt
+++ b/docs/website/requirements.txt
@@ -1,2 +1,2 @@
-mkdocs-material==9.5.18
+mkdocs-material==9.5.19
 mkdocs-redirects==1.2.1


### PR DESCRIPTION
Hoping this will fix https://github.com/iree-org/iree/actions/runs/8834861688/job/24257619493#step:10:20
`ERROR   -  Deployment terminated: Previous deployment was made with MkDocs version 1.6.0; you are attempting to deploy with an older version (1.5.3). Use --ignore-version to deploy anyway.`

Also fixed some broken links:
```
INFO    -  Doc file 'developers/design-docs/design-roadmap.md' contains a link
           '#xla-hlo-tensor-to-primitive-conversion', but there is no such anchor on this page.
INFO    -  Doc file 'developers/design-docs/metal-hal-driver.md' contains a link
           '#memory-management', but there is no such anchor on this page.
INFO    -  Doc file 'developers/design-docs/metal-hal-driver.md' contains a link
           '#shader-kernel-compilation', but there is no such anchor on this page.
INFO    -  Doc file 'developers/general/developer-overview.md' contains a link
           './testing-guide.md#end-to-end-tests', but the doc 'developers/general/testing-guide.md'
           does not contain an anchor '#end-to-end-tests'.
```