### PR TITLE
Replace deprecated Python functions removed in 3.12

### DIFF
--- a/build_tools/python/e2e_test_framework/definitions/utils_test.py
+++ b/build_tools/python/e2e_test_framework/definitions/utils_test.py
@@ -24,7 +24,7 @@ class UtilsTest(unittest.TestCase):
             ],
         )
 
-        self.assertEquals(
+        self.assertEqual(
             flags, ["val_a val_b", "--key=val_a", "--no-value-key", "--filter=x=val_a"]
         )
 
@@ -36,7 +36,7 @@ class UtilsTest(unittest.TestCase):
 
         flags = utils.substitute_flag_vars(flags=raw_flags, HOLDER_A=1, HOLDER_B="b")
 
-        self.assertEquals(flags, ["1", "--key=b"])
+        self.assertEqual(flags, ["1", "--key=b"])
 
     def test_substitute_flag_vars_missing_variable(self):
         raw_flags = [

--- a/build_tools/python/e2e_test_framework/unique_ids_test.py
+++ b/build_tools/python/e2e_test_framework/unique_ids_test.py
@@ -14,7 +14,7 @@ class UniqueIdsTest(unittest.TestCase):
     def test_hash_composite_id(self):
         output = unique_ids.hash_composite_id(["abc", "123"])
 
-        self.assertEquals(
+        self.assertEqual(
             output, hashlib.sha256(f"0-abc:1-123".encode("utf-8")).hexdigest()
         )
 
@@ -38,14 +38,14 @@ class UniqueIdsTest(unittest.TestCase):
             ["abc", unique_ids.TRANSPARENT_ID, unique_ids.TRANSPARENT_ID]
         )
 
-        self.assertEquals(existing_id, new_id_a)
-        self.assertEquals(existing_id, new_id_b)
+        self.assertEqual(existing_id, new_id_a)
+        self.assertEqual(existing_id, new_id_b)
 
     def test_hash_composite_id_with_transparent_ids_in_diff_pos(self):
         id_a = unique_ids.hash_composite_id([unique_ids.TRANSPARENT_ID, "abc"])
         id_b = unique_ids.hash_composite_id(["abc", unique_ids.TRANSPARENT_ID])
 
-        self.assertNotEquals(id_a, id_b)
+        self.assertNotEqual(id_a, id_b)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adapt to the changes described in this table:
https://docs.python.org/3.12/whatsnew/3.12.html#id3