### PR TITLE
[flow] Add check for `util.global` expansion for `util.load` to `flow`

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/Patterns.cpp
@@ -280,12 +280,13 @@ struct GlobalLoadOpExpansion
     if (!isExpandedType(loadOp.getType()))
       return failure();
 
-    auto expandedGlobalIt = this->expansionState->globalMap.find(adaptor.getGlobal());
+    auto expandedGlobalIt =
+        this->expansionState->globalMap.find(adaptor.getGlobal());
     if (expandedGlobalIt == this->expansionState->globalMap.end())
       return rewriter.notifyMatchFailure(loadOp, "expanded global not found");
 
     auto &expandedGlobal = expandedGlobalIt->getSecond();
-    
+
     // Insert a load/transfer to the unknown resource lifetime.
     auto unknownType = IREE::Stream::ResourceType::get(rewriter.getContext());
     auto resource =
@@ -317,8 +318,9 @@ struct GlobalStoreOpExpansion
     // Only apply to expanded types (tensors/etc).
     if (!isExpandedType(storeOp.getValue().getType()))
       return failure();
-    
-    auto expandedGlobalIt = this->expansionState->globalMap.find(adaptor.getGlobal());
+
+    auto expandedGlobalIt =
+        this->expansionState->globalMap.find(adaptor.getGlobal());
     if (expandedGlobalIt == this->expansionState->globalMap.end())
       return rewriter.notifyMatchFailure(storeOp, "expanded global not found");
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/Patterns.cpp
@@ -279,6 +279,10 @@ struct GlobalLoadOpExpansion
     // Only apply to expanded types (tensors/etc).
     if (!isExpandedType(loadOp.getType()))
       return failure();
+    
+    if (!this->expansionState->globalMap.contains(adaptor.getGlobal()))
+      return rewriter.notifyMatchFailure(loadOp, "expanded global not found");
+
     auto &expandedGlobal = this->expansionState->globalMap[adaptor.getGlobal()];
 
     // Insert a load/transfer to the unknown resource lifetime.
@@ -312,6 +316,10 @@ struct GlobalStoreOpExpansion
     // Only apply to expanded types (tensors/etc).
     if (!isExpandedType(storeOp.getValue().getType()))
       return failure();
+    
+    if (!this->expansionState->globalMap.contains(adaptor.getGlobal()))
+      return rewriter.notifyMatchFailure(storeOp, "expanded global not found");
+
     auto &expandedGlobal = expansionState->globalMap[adaptor.getGlobal()];
 
     // Insert a transfer/store to the global with unknown lifetime. Lifetime


### PR DESCRIPTION
We need to verify that the expansion has occurred before requesting the corresponding expansion. Previously if this failed the pass would fail with little explanation.