### PR TITLE
Add support for serializing the textual representation of LLVM IR.

### DIFF
--- a/compiler/plugins/target/LLVMCPU/LLVMCPUTarget.cpp
+++ b/compiler/plugins/target/LLVMCPU/LLVMCPUTarget.cpp
@@ -53,14 +53,26 @@ namespace mlir::iree_compiler::IREE::HAL {
 static constexpr char kQueryFunctionName[] =
     "iree_hal_executable_library_query";
 
-static void dumpBitcodeToPath(StringRef path, StringRef baseName,
-                              StringRef suffix, StringRef extension,
-                              llvm::Module &module) {
-  llvm::SmallVector<char, 0> data;
-  llvm::raw_svector_ostream ostream(data);
-  llvm::WriteBitcodeToFile(module, ostream);
-  dumpDataToPath(path, baseName, suffix, extension,
-                 StringRef(data.data(), data.size()));
+static void dumpLLVMModuleToPath(StringRef path, StringRef baseName,
+                                 StringRef suffix, StringRef extPrefix,
+                                 llvm::Module &module) {
+  // Dump disassembly to path.
+  llvm::SmallVector<char> textData;
+  llvm::raw_svector_ostream textOstream(textData);
+
+  module.print(textOstream, nullptr);
+  std::string textExtension = extPrefix.str() + ".ll";
+  dumpDataToPath(path, baseName, suffix, textExtension,
+                 StringRef(textData.data(), textData.size()));
+
+  // Dump bitcode to path.
+  llvm::SmallVector<char> binaryData;
+  llvm::raw_svector_ostream binaryOstream(binaryData);
+  // Write the specified module to the specified output stream.
+  llvm::WriteBitcodeToFile(module, binaryOstream);
+  std::string binaryExtension = extPrefix.str() + ".bc";
+  dumpDataToPath(path, baseName, suffix, binaryExtension,
+                 StringRef(binaryData.data(), binaryData.size()));
 }
 
 static void fixupVisibility(llvm::Module &module,
@@ -467,8 +479,8 @@ public:
 
     // Dump just the codegen bitcode before linking and optimization.
     if (!options.dumpIntermediatesPath.empty()) {
-      dumpBitcodeToPath(options.dumpIntermediatesPath, options.dumpBaseName,
-                        variantOp.getName(), ".codegen.bc", *llvmModule);
+      dumpLLVMModuleToPath(options.dumpIntermediatesPath, options.dumpBaseName,
+                           variantOp.getName(), ".codegen", *llvmModule);
     }
 
     // Statically link libraries into our module prior to LLVM optimizations.
@@ -555,8 +567,8 @@ public:
 
     // Dump all linked bitcode prior to optimization.
     if (!options.dumpIntermediatesPath.empty()) {
-      dumpBitcodeToPath(options.dumpIntermediatesPath, options.dumpBaseName,
-                        variantOp.getName(), ".linked.bc", *llvmModule);
+      dumpLLVMModuleToPath(options.dumpIntermediatesPath, options.dumpBaseName,
+                           variantOp.getName(), ".linked", *llvmModule);
     }
 
     // LLVM opt passes that perform code generation optimizations/transformation
@@ -580,8 +592,8 @@ public:
 
     // Dump bitcode post-linking and optimization.
     if (!options.dumpIntermediatesPath.empty()) {
-      dumpBitcodeToPath(options.dumpIntermediatesPath, options.dumpBaseName,
-                        variantOp.getName(), ".optimized.bc", *llvmModule);
+      dumpLLVMModuleToPath(options.dumpIntermediatesPath, options.dumpBaseName,
+                           variantOp.getName(), ".optimized", *llvmModule);
     }
 
     SmallVector<Artifact> objectFiles;

--- a/docs/website/docs/developers/general/developer-tips.md
+++ b/docs/website/docs/developers/general/developer-tips.md
@@ -166,8 +166,11 @@ Flag | Files dumped
 
     module_abs_dispatch_0.mlir
     module_abs_dispatch_0_system_elf_x86_64_benchmark.mlir
+    module_abs_dispatch_0_system_elf_x86_64.codegen.ll
     module_abs_dispatch_0_system_elf_x86_64.codegen.bc
+    module_abs_dispatch_0_system_elf_x86_64.linked.ll
     module_abs_dispatch_0_system_elf_x86_64.linked.bc
+    module_abs_dispatch_0_system_elf_x86_64.optimized.ll
     module_abs_dispatch_0_system_elf_x86_64.optimized.bc
     module_abs_dispatch_0_system_elf_x86_64.o
     module_abs_dispatch_0_system_elf_x86_64.s
@@ -185,6 +188,7 @@ Flag | Files dumped
 
     ??? tip "Tip - Disassembling `.bc` files with `llvm-dis`"
 
+        This section can be skipped if the .ll files are already in the directory you choose.
         The `.bc` intermediate files use the
         [LLVM BitCode](https://llvm.org/docs/BitCodeFormat.html) format, which
         can be disassembled using
@@ -323,8 +327,11 @@ Flag | Files dumped
     $ ls /tmp/iree/simple_abs
 
     module_abs_dispatch_0_cuda_nvptx_fb_benchmark.mlir
+    module_abs_dispatch_0_cuda_nvptx_fb.codegen.ll
     module_abs_dispatch_0_cuda_nvptx_fb.codegen.bc
+    module_abs_dispatch_0_cuda_nvptx_fb.linked.ll
     module_abs_dispatch_0_cuda_nvptx_fb.linked.bc
+    module_abs_dispatch_0_cuda_nvptx_fb.optimized.ll
     module_abs_dispatch_0_cuda_nvptx_fb.optimized.bc
     module_abs_dispatch_0_cuda_nvptx_fb.ptx
     module_abs_dispatch_0.mlir
@@ -333,6 +340,7 @@ Flag | Files dumped
 
     ??? tip "Tip - Disassembling `.bc` files with `llvm-dis`"
 
+        This section can be skipped if the .ll files are already in the directory you choose.
         The `.bc` intermediate files use the
         [LLVM BitCode](https://llvm.org/docs/BitCodeFormat.html) format, which
         can be disassembled using


### PR DESCRIPTION
This PR adds support for direct serialization of LLVM IR textual representation from the module, eliminating the need for developers to use the llvm-dis tool to convert bitcode into human-readable IR format. This enhancement simplifies debugging and optimization processes, providing developers with a more streamlined workflow.