### PR TITLE
[Winograd] Decompose with tensor.pad instead of fill + insert slice

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeWinogradPass.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeWinogradPass.cpp
@@ -18,6 +18,7 @@
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/SCF/Transforms/Transforms.h"
 #include "mlir/Dialect/Tensor/Utils/Utils.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -197,23 +198,15 @@ struct DecomposeWinogradInputTransform
 
   LogicalResult matchAndRewrite(WinogradInputTransformOp transformOp,
                                 PatternRewriter &rewriter) const override {
-    Location loc = transformOp.getLoc();
-    Value dynamicSlice = transformOp.input();
-    Value outputSlice = transformOp.output();
     if (transformOp.getInputRank() != 2 || transformOp.getOutputRank() != 2) {
       return rewriter.notifyMatchFailure(transformOp, "Winograd op not tiled");
     }
-    const int64_t inputTileSize = transformOp.getInputTileSize();
-    ArrayRef<int64_t> imageDims = transformOp.getImageDimensions();
-    llvm::SmallSetVector<int64_t, 2> imageDimsSet(imageDims.begin(),
-                                                  imageDims.end());
-    SmallVector<int64_t> inputTileSquare(imageDims.size(), inputTileSize);
-    Type elementType = transformOp.getOutputType().getElementType();
-    Value zero = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getZeroAttr(elementType));
+
     /// The two values below are the transpose(B) [BT]
     /// and B [B] constant matrices that convert the input
     /// tile from the original domain to the Winograd domain.
+    Location loc = transformOp.getLoc();
+    const int64_t inputTileSize = transformOp.getInputTileSize();
     Value BT = IREE::LinalgExt::createValueFrom2DConstant(
         IREE::LinalgExt::Winograd::BT_6x6_3x3, inputTileSize, inputTileSize,
         loc, rewriter);
@@ -221,40 +214,23 @@ struct DecomposeWinogradInputTransform
         IREE::LinalgExt::Winograd::B_6x6_3x3, inputTileSize, inputTileSize, loc,
         rewriter);
 
-    auto inputExtractSliceOp =
-        dynamicSlice.getDefiningOp<tensor::ExtractSliceOp>();
-    // Harcoding input rank as 4 here - since we'd be getting a tiled version
-    // with rank 2. We are always expected to either have a rank 4 version of
-    // this op, or rank 2 (tiled). And at this point in the flow, it is
-    // guaranteed to be a rank 2 version of the op as ensured by the assertion
-    // above. Pad the input slice.
-
-    SmallVector<OpFoldResult> mixedSizes = inputExtractSliceOp.getMixedSizes();
-    SmallVector<OpFoldResult> dynamicSliceSizes;
-    for (auto idx : transformOp.getImageDimensions()) {
-      dynamicSliceSizes.push_back(mixedSizes[idx]);
-    }
-    SmallVector<OpFoldResult> padLow(inputTileSquare.size(),
-                                     rewriter.getIndexAttr(0));
-    SmallVector<OpFoldResult> padHigh;
-    for (auto [idx, size] : llvm::enumerate(dynamicSliceSizes)) {
-      AffineExpr d0;
-      bindDims(rewriter.getContext(), d0);
-      auto ub = rewriter.getAffineConstantExpr(inputTileSquare[idx]);
-      padHigh.push_back(affine::makeComposedFoldedAffineApply(rewriter, loc,
-                                                              {ub - d0}, size));
-    }
-    auto inputSliceType = transformOp.getInputType().clone(inputTileSquare);
-    Value inputSlice = rewriter.create<tensor::PadOp>(
-        loc, inputSliceType, dynamicSlice, padLow, padHigh, zero);
+    // Pad the input slice.
+    Value dynamicSlice = transformOp.input();
+    Type elementType = transformOp.getOutputType().getElementType();
+    Value zero = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getZeroAttr(elementType));
+    SmallVector<int64_t> inputTileSquare(
+        transformOp.getImageDimensions().size(), inputTileSize);
+    auto inputSliceType = RankedTensorType::get(inputTileSquare, elementType);
+    Value inputSlice = tensor::createPadHighOp(
+        inputSliceType, dynamicSlice, zero, /*nofold=*/false, loc, rewriter);
 
     // Create computation
     Value result, AMatrix, BMatrix;
     linalg::MatmulOp matmulOp;
-    Type tensorType = outputSlice.getType();
     for (int i = 0; i < 2; i++) {
-      linalg::FillOp fillOp = rewriter.create<linalg::FillOp>(
-          loc, ValueRange{zero}, ValueRange{outputSlice});
+      auto fillOp = rewriter.create<linalg::FillOp>(
+          loc, ValueRange{zero}, ValueRange{transformOp.output()});
       if (i == 0) {
         AMatrix = inputSlice;
         BMatrix = B;
@@ -263,7 +239,8 @@ struct DecomposeWinogradInputTransform
         BMatrix = result;
       }
       matmulOp = rewriter.create<linalg::MatmulOp>(
-          loc, tensorType, ValueRange{AMatrix, BMatrix}, fillOp.result());
+          loc, transformOp.getOutputType(), ValueRange{AMatrix, BMatrix},
+          fillOp.result());
       result = matmulOp.getResult(0);
     }
     rewriter.replaceOp(transformOp, result);

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_winograd.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_winograd.mlir
@@ -69,6 +69,7 @@ module {
     return %inserted_slice : tensor<8x8x2x22x22x64xf16>
   }
 }
+// CHECK-DAG:  #[[MAP:.+]] = affine_map<()[s0] -> (-s0 + 8)>
 // CHECK:      func.func @winograd_input_transform(
 // CHECK-SAME:   %[[ARG0:.+]]: tensor<2x130x130x64xf16>
 // CHECK-SAME:   %[[ARG1:.+]]: tensor<8x8x2x22x22x64xf16>
@@ -77,19 +78,21 @@ module {
 // CHECK-DAG:    %[[ZERO:.+]] = arith.constant 0.000000e+00 : f16
 // CHECK-DAG:    %[[BT:.+]] = arith.constant dense<{{\[\[}}1.000000e+00, 0.000000e+00, 0.000000e+00,{{.*}} : tensor<8x8xf32>
 // CHECK-DAG:    %[[B:.+]] = arith.constant dense<{{\[\[}}1.000000e+00, 0.000000e+00, -5.250000e+00,{{.*}} : tensor<8x8xf32>
-// CHECK-DAG:    %[[EMPTY:.+]] = tensor.empty() : tensor<8x8xf16>
 // CHECK-DAG:    %[[INPUT_TILE:.+]] = tensor.extract_slice %[[ARG0]]
 // CHECK-DAG:    %[[OUTPUT_TILE:.+]] = tensor.extract_slice %[[ARG1]]
-// CHECK:        %[[FILL_0:.+]] = linalg.fill ins(%[[ZERO]] : f16) outs(%[[EMPTY]] : tensor<8x8xf16>) -> tensor<8x8xf16>
-// CHECK:        %[[INSERTED_SLICE_0:.+]] = tensor.insert_slice %[[INPUT_TILE]] into %[[FILL_0]][0, 0]
-// CHECK-SAME:                 [%[[S0]], %[[S1]]] [1, 1] : tensor<?x?xf16> into tensor<8x8xf16>
+// CHECK-DAG:    %[[PAD_HIGH0:.+]] = affine.apply #[[MAP]](){{\[}}%[[S0]]]
+// CHECK-DAG:    %[[PAD_HIGH1:.+]] = affine.apply #[[MAP]](){{\[}}%[[S1]]]
+// CHECK:        %[[PAD:.+]] = tensor.pad %[[INPUT_TILE]] low[0, 0] high{{\[}}%[[PAD_HIGH0]], %[[PAD_HIGH1]]]
+// CHECK-NEXT:     ^bb0(
+// CHECK-NEXT:       tensor.yield %[[ZERO]] : f16
+// CHECK-NEXT:    } : tensor<?x?xf16> to tensor<8x8xf16>
 // CHECK:        %[[FILL_1:.+]] = linalg.fill ins(%[[ZERO]] : f16) outs(%[[OUTPUT_TILE]] : tensor<8x8xf16>) -> tensor<8x8xf16>
-// CHECK:        %[[MATMUL_0:.+]] = linalg.matmul ins(%[[INSERTED_SLICE_0]], %[[BT]]
+// CHECK:        %[[MATMUL_0:.+]] = linalg.matmul ins(%[[PAD]], %[[BT]]
 // CHECK-SAME:     outs(%[[FILL_1]]
 // CHECK:        %[[MATMUL_1:.+]] = linalg.matmul ins(%[[B]], %[[MATMUL_0]]
 // CHECK-SAME:     outs(%[[FILL_1]]
-// CHECK:        %[[INSERTED_SLICE_1:.+]] = tensor.insert_slice %[[MATMUL_1]] into %[[ARG1]]
-// CHECK:        return %[[INSERTED_SLICE_1]] : tensor<8x8x2x22x22x64xf16>
+// CHECK:        %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[MATMUL_1]] into %[[ARG1]]
+// CHECK:        return %[[INSERTED_SLICE]] : tensor<8x8x2x22x22x64xf16>
 
 // -----
 
@@ -104,6 +107,7 @@ module {
     return %inserted_slice : tensor<8x8x2x22x22x64xf16>
   }
 }
+// CHECK-DAG:  #[[MAP:.+]] = affine_map<()[s0] -> (-s0 + 8)>
 // CHECK:      func.func @winograd_input_transform_nchw(
 // CHECK-SAME:   %[[ARG0:.+]]: tensor<2x64x130x130xf16>
 // CHECK-SAME:   %[[ARG1:.+]]: tensor<8x8x2x22x22x64xf16>
@@ -112,19 +116,21 @@ module {
 // CHECK-DAG:    %[[ZERO:.+]] = arith.constant 0.000000e+00 : f16
 // CHECK-DAG:    %[[BT:.+]] = arith.constant dense<{{\[\[}}1.000000e+00, 0.000000e+00, 0.000000e+00,{{.*}} : tensor<8x8xf32>
 // CHECK-DAG:    %[[B:.+]] = arith.constant dense<{{\[\[}}1.000000e+00, 0.000000e+00, -5.250000e+00,{{.*}} : tensor<8x8xf32>
-// CHECK-DAG:    %[[EMPTY:.+]] = tensor.empty() : tensor<8x8xf16>
 // CHECK-DAG:    %[[INPUT_TILE:.+]] = tensor.extract_slice %[[ARG0]]
 // CHECK-DAG:    %[[OUTPUT_TILE:.+]] = tensor.extract_slice %[[ARG1]]
-// CHECK:        %[[FILL_0:.+]] = linalg.fill ins(%[[ZERO]] : f16) outs(%[[EMPTY]] : tensor<8x8xf16>) -> tensor<8x8xf16>
-// CHECK:        %[[INSERTED_SLICE_0:.+]] = tensor.insert_slice %[[INPUT_TILE]] into %[[FILL_0]][0, 0]
-// CHECK-SAME:                 [%[[S0]], %[[S1]]] [1, 1] : tensor<?x?xf16> into tensor<8x8xf16>
-// CHECK:        %[[FILL_1:.+]] = linalg.fill ins(%[[ZERO]] : f16) outs(%[[OUTPUT_TILE]] : tensor<8x8xf16>) -> tensor<8x8xf16>
-// CHECK:        %[[MATMUL_0:.+]] = linalg.matmul ins(%[[INSERTED_SLICE_0]], %[[BT]]
-// CHECK-SAME:     outs(%[[FILL_1]]
+// CHECK-DAG:    %[[PAD_HIGH0:.+]] = affine.apply #[[MAP]](){{\[}}%[[S0]]]
+// CHECK-DAG:    %[[PAD_HIGH1:.+]] = affine.apply #[[MAP]](){{\[}}%[[S1]]]
+// CHECK:        %[[PAD:.+]] = tensor.pad %[[INPUT_TILE]] low[0, 0] high{{\[}}%[[PAD_HIGH0]], %[[PAD_HIGH1]]]
+// CHECK-NEXT:     ^bb0(
+// CHECK-NEXT:       tensor.yield %[[ZERO]] : f16
+// CHECK-NEXT:    } : tensor<?x?xf16> to tensor<8x8xf16>
+// CHECK:        %[[FILL:.+]] = linalg.fill ins(%[[ZERO]] : f16) outs(%[[OUTPUT_TILE]] : tensor<8x8xf16>) -> tensor<8x8xf16>
+// CHECK:        %[[MATMUL_0:.+]] = linalg.matmul ins(%[[PAD]], %[[BT]]
+// CHECK-SAME:     outs(%[[FILL]]
 // CHECK:        %[[MATMUL_1:.+]] = linalg.matmul ins(%[[B]], %[[MATMUL_0]]
-// CHECK-SAME:     outs(%[[FILL_1]]
-// CHECK:        %[[INSERTED_SLICE_1:.+]] = tensor.insert_slice %[[MATMUL_1]] into %[[ARG1]]
-// CHECK:        return %[[INSERTED_SLICE_1]] : tensor<8x8x2x22x22x64xf16>
+// CHECK-SAME:     outs(%[[FILL]]
+// CHECK:        %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[MATMUL_1]] into %[[ARG1]]
+// CHECK:        return %[[INSERTED_SLICE]] : tensor<8x8x2x22x22x64xf16>
 
 // -----
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_winograd.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_winograd.mlir
@@ -73,15 +73,17 @@ module {
 // CHECK:      func.func @winograd_input_transform(
 // CHECK-SAME:   %[[ARG0:.+]]: tensor<2x130x130x64xf16>
 // CHECK-SAME:   %[[ARG1:.+]]: tensor<8x8x2x22x22x64xf16>
-// CHECK-SAME:   %[[S0:[a-zA-Z0-9_]+]]: index
-// CHECK-SAME:   %[[S1:[a-zA-Z0-9_]+]]: index
 // CHECK-DAG:    %[[ZERO:.+]] = arith.constant 0.000000e+00 : f16
+// CHECK-DAG:    %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:    %[[C1:.+]] = arith.constant 1 : index
 // CHECK-DAG:    %[[BT:.+]] = arith.constant dense<{{\[\[}}1.000000e+00, 0.000000e+00, 0.000000e+00,{{.*}} : tensor<8x8xf32>
 // CHECK-DAG:    %[[B:.+]] = arith.constant dense<{{\[\[}}1.000000e+00, 0.000000e+00, -5.250000e+00,{{.*}} : tensor<8x8xf32>
 // CHECK-DAG:    %[[INPUT_TILE:.+]] = tensor.extract_slice %[[ARG0]]
 // CHECK-DAG:    %[[OUTPUT_TILE:.+]] = tensor.extract_slice %[[ARG1]]
-// CHECK-DAG:    %[[PAD_HIGH0:.+]] = affine.apply #[[MAP]](){{\[}}%[[S0]]]
-// CHECK-DAG:    %[[PAD_HIGH1:.+]] = affine.apply #[[MAP]](){{\[}}%[[S1]]]
+// CHECK-DAG:    %[[DIM0:.+]] = tensor.dim %[[INPUT_TILE]], %[[C0]] : tensor<?x?xf16>
+// CHECK-DAG:    %[[PAD_HIGH0:.+]] = affine.apply #[[MAP]](){{\[}}%[[DIM0]]]
+// CHECK-DAG:    %[[DIM1:.+]] = tensor.dim %[[INPUT_TILE]], %[[C1]] : tensor<?x?xf16>
+// CHECK-DAG:    %[[PAD_HIGH1:.+]] = affine.apply #[[MAP]](){{\[}}%[[DIM1]]]
 // CHECK:        %[[PAD:.+]] = tensor.pad %[[INPUT_TILE]] low[0, 0] high{{\[}}%[[PAD_HIGH0]], %[[PAD_HIGH1]]]
 // CHECK-NEXT:     ^bb0(
 // CHECK-NEXT:       tensor.yield %[[ZERO]] : f16
@@ -114,12 +116,16 @@ module {
 // CHECK-SAME:   %[[S0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[S1:[a-zA-Z0-9_]+]]: index
 // CHECK-DAG:    %[[ZERO:.+]] = arith.constant 0.000000e+00 : f16
+// CHECK-DAG:    %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:    %[[C1:.+]] = arith.constant 1 : index
 // CHECK-DAG:    %[[BT:.+]] = arith.constant dense<{{\[\[}}1.000000e+00, 0.000000e+00, 0.000000e+00,{{.*}} : tensor<8x8xf32>
 // CHECK-DAG:    %[[B:.+]] = arith.constant dense<{{\[\[}}1.000000e+00, 0.000000e+00, -5.250000e+00,{{.*}} : tensor<8x8xf32>
 // CHECK-DAG:    %[[INPUT_TILE:.+]] = tensor.extract_slice %[[ARG0]]
 // CHECK-DAG:    %[[OUTPUT_TILE:.+]] = tensor.extract_slice %[[ARG1]]
-// CHECK-DAG:    %[[PAD_HIGH0:.+]] = affine.apply #[[MAP]](){{\[}}%[[S0]]]
-// CHECK-DAG:    %[[PAD_HIGH1:.+]] = affine.apply #[[MAP]](){{\[}}%[[S1]]]
+// CHECK-DAG:    %[[DIM0:.+]] = tensor.dim %[[INPUT_TILE]], %[[C0]] : tensor<?x?xf16>
+// CHECK-DAG:    %[[PAD_HIGH0:.+]] = affine.apply #[[MAP]](){{\[}}%[[DIM0]]]
+// CHECK-DAG:    %[[DIM1:.+]] = tensor.dim %[[INPUT_TILE]], %[[C1]] : tensor<?x?xf16>
+// CHECK-DAG:    %[[PAD_HIGH1:.+]] = affine.apply #[[MAP]](){{\[}}%[[DIM1]]]
 // CHECK:        %[[PAD:.+]] = tensor.pad %[[INPUT_TILE]] low[0, 0] high{{\[}}%[[PAD_HIGH0]], %[[PAD_HIGH1]]]
 // CHECK-NEXT:     ^bb0(
 // CHECK-NEXT:       tensor.yield %[[ZERO]] : f16


### PR DESCRIPTION
The current winograd input transformation decomposition uses a fill + insert slice to do padding. This can cause some scalar loads, and it is more canonical to use `tensor.pad`. This PR changes the decomposition to use `tensor.pad`.