### PR TITLE
[Winograd] Use output_tile_size for more static output transform tiling

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TilingInterfaceImpl.cpp
@@ -8,7 +8,6 @@
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
 #include "llvm/ADT/TypeSwitch.h"
-#include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/Utils.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
@@ -17,7 +16,6 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
-#include "mlir/IR/BuiltinTypes.h"
 
 namespace mlir::iree_compiler::IREE::LinalgExt {
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
@@ -24,6 +24,15 @@ Value getDimValue(OpBuilder &builder, Location loc, Value v, int64_t dim);
 OpFoldResult getDim(OpBuilder &builder, Location loc, Value v, int64_t dim);
 SmallVector<OpFoldResult> getDims(OpBuilder &builder, Location loc, Value v);
 
+/// Returns a `memref.subview` or a `tensor.extract_slice` based on the type of
+/// `src`.
+Value getSlice(OpBuilder &b, Location loc, Value src,
+               ArrayRef<OpFoldResult> offsets, ArrayRef<OpFoldResult> sizes,
+               ArrayRef<OpFoldResult> strides);
+
+/// Returns a `memref.cast` or `tensor.cast` based on the type of `src`.
+Value castValue(OpBuilder &builder, Location loc, Value src, ShapedType type);
+
 /// Returns a vector that interchanges `elements` starting at offset `offset`
 /// based on the indexes in `interchangeVector`.
 template <typename T>


### PR DESCRIPTION
In the winograd output transform, the output tiles will always write in bounds, and will always have the same static shape. This PR uses this in the tiledImplementation of the output transform to maintain more static information.

This also gets rid of an unnecessary alloc that comes from a dynamically sized `tensor.empty` op after decomposition.