### PR TITLE
Remove unnecessary cpu flag for model testing 

### DIFF
--- a/build_tools/pkgci/external_test_suite/pytorch_models_cpu_llvm_task.json
+++ b/build_tools/pkgci/external_test_suite/pytorch_models_cpu_llvm_task.json
@@ -2,8 +2,7 @@
   "config_name": "cpu_llvm_task",
   "iree_compile_flags" : [
     "--iree-hal-target-backends=llvm-cpu",
-    "--iree-llvmcpu-target-cpu-features=host",
-    "--iree-llvmcpu-distribution-size=32"
+    "--iree-llvmcpu-target-cpu-features=host"
   ],
   "iree_run_module_flags": [
     "--device=local-task"

--- a/build_tools/pkgci/external_test_suite/sdxl_scheduled_unet_cpu_llvm_task.json
+++ b/build_tools/pkgci/external_test_suite/sdxl_scheduled_unet_cpu_llvm_task.json
@@ -2,8 +2,7 @@
     "config_name": "cpu_llvm_task",
     "iree_compile_flags" : [
       "--iree-hal-target-backends=llvm-cpu",
-      "--iree-llvmcpu-target-cpu-features=host",
-      "--iree-llvmcpu-distribution-size=32"
+      "--iree-llvmcpu-target-cpu-features=host"
     ],
     "iree_run_module_flags": [
       "--device=local-task",


### PR DESCRIPTION
ci-exactly: build_packages, regression_test_cpu