### PR TITLE
[runtime][hip][cuda] Fix semaphore multi-wait, action GPU events and cleanup

### DIFF
--- a/runtime/src/iree/hal/cts/cts_test_base.h
+++ b/runtime/src/iree/hal/cts/cts_test_base.h
@@ -36,7 +36,12 @@ iree_const_byte_span_t get_test_executable_data(iree_string_view_t file_name);
 class CtsTestBase : public ::testing::TestWithParam<std::string> {
  protected:
   static void SetUpTestSuite() {
-    IREE_CHECK_OK(register_test_driver(iree_hal_driver_registry_default()));
+    iree_status_t status =
+        register_test_driver(iree_hal_driver_registry_default());
+    if (iree_status_is_already_exists(status)) {
+      return;
+    }
+    IREE_CHECK_OK(status);
   }
 
   virtual void SetUp() {

--- a/runtime/src/iree/hal/drivers/cuda/event_semaphore.c
+++ b/runtime/src/iree/hal/drivers/cuda/event_semaphore.c
@@ -256,9 +256,13 @@ bool iree_hal_cuda_semaphore_acquire_event_host_wait(
   return *out_event != NULL;
 }
 
-static iree_status_t iree_hal_cuda_semaphore_wait(
+// Checks if the semaphore has to wait to reach `value`.
+// If it has to wait, then acquires a wait timepoint and returns it.
+// If we don't need to wait, then *out_timepoint is set to NULL.
+static iree_status_t iree_hal_cuda_semaphore_try_wait_or_acquire_wait_timepoint(
     iree_hal_semaphore_t* base_semaphore, uint64_t value,
-    iree_timeout_t timeout) {
+    iree_timeout_t timeout, iree_hal_cuda_timepoint_t** out_timepoint) {
+  *out_timepoint = NULL;
   iree_hal_cuda_semaphore_t* semaphore =
       iree_hal_cuda_semaphore_cast(base_semaphore);
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -286,21 +290,39 @@ static iree_status_t iree_hal_cuda_semaphore_wait(
   // Slow path: acquire a timepoint. This should happen inside of the lock too.
   // If not locked the semaphore may be signal before acquiring a timepoint.
   // Then we would miss the signal.
-  iree_hal_cuda_timepoint_t* timepoint = NULL;
   iree_status_t status = iree_hal_cuda_semaphore_acquire_timepoint_host_wait(
-      semaphore, value, timeout, &timepoint);
-  if (IREE_UNLIKELY(!iree_status_is_ok(status))) {
-    iree_slim_mutex_unlock(&semaphore->mutex);
-    IREE_TRACE_ZONE_END(z0);
-    return status;
-  }
+      semaphore, value, timeout, out_timepoint);
 
   iree_slim_mutex_unlock(&semaphore->mutex);
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+static iree_status_t iree_hal_cuda_semaphore_wait(
+    iree_hal_semaphore_t* base_semaphore, uint64_t value,
+    iree_timeout_t timeout) {
+  iree_hal_cuda_semaphore_t* semaphore =
+      iree_hal_cuda_semaphore_cast(base_semaphore);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_hal_cuda_timepoint_t* timepoint;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_hal_cuda_semaphore_try_wait_or_acquire_wait_timepoint(
+              base_semaphore, value, timeout, &timepoint));
+  if (!timepoint) {
+    // We don't need to wait on a timepoint.
+    // The wait condition is satisfied.
+    IREE_TRACE_ZONE_END(z0);
+    return iree_ok_status();
+  }
 
   // Wait until the timepoint resolves.
   // If satisfied the timepoint is automatically cleaned up and we are done. If
   // the deadline is reached before satisfied then we have to clean it up.
   iree_time_t deadline_ns = iree_timeout_as_deadline_ns(timeout);
+  iree_status_t status =
+      iree_wait_one(&timepoint->timepoint.host_wait, deadline_ns);
   status = iree_wait_one(&timepoint->timepoint.host_wait, deadline_ns);
   if (!iree_status_is_ok(status)) {
     iree_hal_semaphore_cancel_timepoint(&semaphore->base, &timepoint->base);
@@ -345,35 +367,24 @@ iree_status_t iree_hal_cuda_semaphore_multi_wait(
   if (iree_status_is_ok(status)) {
     memset(timepoints, 0, total_timepoint_size);
     for (iree_host_size_t i = 0; i < semaphore_list.count && needs_wait; ++i) {
-      uint64_t current_value = 0;
-      status = iree_hal_cuda_semaphore_query(semaphore_list.semaphores[i],
-                                             &current_value);
+      iree_hal_cuda_timepoint_t* timepoint;
+      status = iree_hal_cuda_semaphore_try_wait_or_acquire_wait_timepoint(
+          semaphore_list.semaphores[i], semaphore_list.payload_values[i],
+          timeout, &timepoint);
       if (!iree_status_is_ok(status)) break;
-
-      if (current_value >= semaphore_list.payload_values[i]) {
-        // Fast path: already satisfied.
-        // If in ANY wait mode, this is sufficient and we don't actually need
-        // to wait. This also skips acquiring timepoints for any remaining
-        // semaphores. We still exit normally otherwise so as to cleanup
-        // any timepoints already acquired.
-        if (wait_mode == IREE_HAL_WAIT_MODE_ANY) needs_wait = false;
-      } else {
-        iree_hal_cuda_semaphore_t* semaphore =
-            iree_hal_cuda_semaphore_cast(semaphore_list.semaphores[i]);
-
-        // Slow path: get a native host wait handle for the timepoint. This
-        // should happen outside of the lock given that acquiring has its own
-        // internal locks.
-        iree_hal_cuda_timepoint_t* timepoint = NULL;
-        status = iree_hal_cuda_semaphore_acquire_timepoint_host_wait(
-            semaphore, semaphore_list.payload_values[i], timeout, &timepoint);
-        if (iree_status_is_ok(status)) {
-          timepoints[timepoint_count++] = timepoint;
-          status =
-              iree_wait_set_insert(wait_set, timepoint->timepoint.host_wait);
+      if (!timepoint) {
+        // We don't need to wait on a timepoint.
+        // The wait condition is satisfied.
+        if (wait_mode == IREE_HAL_WAIT_MODE_ANY) {
+          needs_wait = false;
+          break;
         }
-        if (!iree_status_is_ok(status)) break;
+        continue;
       }
+
+      timepoints[timepoint_count++] = timepoint;
+      status = iree_wait_set_insert(wait_set, timepoint->timepoint.host_wait);
+      if (!iree_status_is_ok(status)) break;
     }
   }
 

--- a/runtime/src/iree/hal/drivers/cuda/pending_queue_actions.c
+++ b/runtime/src/iree/hal/drivers/cuda/pending_queue_actions.c
@@ -40,9 +40,9 @@ typedef enum iree_hal_cuda_queue_action_kind_e {
 
 typedef enum iree_hal_cuda_queue_action_state_e {
   // The current action is active as waiting for or under execution.
-  IREE_HAL_cuda_QUEUE_ACTION_STATE_ALIVE,
+  IREE_HAL_CUDA_QUEUE_ACTION_STATE_ALIVE,
   // The current action is done execution and waiting for destruction.
-  IREE_HAL_cuda_QUEUE_ACTION_STATE_ZOMBIE,
+  IREE_HAL_CUDA_QUEUE_ACTION_STATE_ZOMBIE,
 } iree_hal_cuda_queue_action_state_t;
 
 // A pending queue action.
@@ -102,6 +102,17 @@ typedef struct iree_hal_cuda_queue_action_t {
   bool is_pending;
 } iree_hal_cuda_queue_action_t;
 
+static void iree_hal_cuda_queue_action_clear_events(
+    iree_hal_cuda_queue_action_t* action) {
+  for (iree_host_size_t i = 0; i < action->event_count; ++i) {
+    iree_hal_cuda_event_release(action->events[i]);
+  }
+  action->event_count = 0;
+}
+
+static void iree_hal_cuda_queue_action_destroy(
+    iree_hal_cuda_queue_action_t* action);
+
 //===----------------------------------------------------------------------===//
 // Queue action list
 //===----------------------------------------------------------------------===//
@@ -117,38 +128,36 @@ static inline bool iree_hal_cuda_queue_action_list_is_empty(
   return list->head == NULL;
 }
 
+static iree_hal_cuda_queue_action_t* iree_hal_cuda_queue_action_list_pop_front(
+    iree_hal_cuda_queue_action_list_t* list) {
+  IREE_ASSERT(list->head && list->tail);
+
+  iree_hal_cuda_queue_action_t* action = list->head;
+  IREE_ASSERT(!action->prev);
+  list->head = action->next;
+  if (action->next) {
+    action->next->prev = NULL;
+    action->next = NULL;
+  }
+  if (list->tail == action) {
+    list->tail = NULL;
+  }
+
+  return action;
+}
+
 // Pushes |action| on to the end of the given action |list|.
 static void iree_hal_cuda_queue_action_list_push_back(
     iree_hal_cuda_queue_action_list_t* list,
     iree_hal_cuda_queue_action_t* action) {
+  IREE_ASSERT(!action->next && !action->prev);
   if (list->tail) {
     list->tail->next = action;
   } else {
     list->head = action;
   }
-  action->next = NULL;
   action->prev = list->tail;
   list->tail = action;
-}
-
-// Erases |action| from |list|.
-static void iree_hal_cuda_queue_action_list_erase(
-    iree_hal_cuda_queue_action_list_t* list,
-    iree_hal_cuda_queue_action_t* action) {
-  iree_hal_cuda_queue_action_t* next = action->next;
-  iree_hal_cuda_queue_action_t* prev = action->prev;
-  if (prev) {
-    prev->next = next;
-    action->prev = NULL;
-  } else {
-    list->head = next;
-  }
-  if (next) {
-    next->prev = prev;
-    action->next = NULL;
-  } else {
-    list->tail = prev;
-  }
 }
 
 // Takes all actions from |available_list| and moves them into |ready_list|.
@@ -162,13 +171,12 @@ static void iree_hal_cuda_queue_action_list_take_all(
   available_list->tail = NULL;
 }
 
-// Frees all actions in the given |list|.
-static void iree_hal_cuda_queue_action_list_free_actions(
-    iree_allocator_t host_allocator, iree_hal_cuda_queue_action_list_t* list) {
-  for (iree_hal_cuda_queue_action_t* action = list->head; action != NULL;) {
-    iree_hal_cuda_queue_action_t* next_action = action->next;
-    iree_allocator_free(host_allocator, action);
-    action = next_action;
+static void iree_hal_cuda_queue_action_list_destroy(
+    iree_hal_cuda_queue_action_t* head_action) {
+  while (head_action) {
+    iree_hal_cuda_queue_action_t* next_action = head_action->next;
+    iree_hal_cuda_queue_action_destroy(head_action);
+    head_action = next_action;
   }
 }
 
@@ -187,6 +195,33 @@ IREE_TYPED_ATOMIC_SLIST_WRAPPER(iree_hal_cuda_ready_action,
                                 iree_hal_cuda_atomic_slist_entry_t,
                                 offsetof(iree_hal_cuda_atomic_slist_entry_t,
                                          slist_next));
+
+static void iree_hal_cuda_ready_action_slist_destroy(
+    iree_hal_cuda_ready_action_slist_t* list, iree_allocator_t host_allocator) {
+  while (true) {
+    iree_hal_cuda_atomic_slist_entry_t* entry =
+        iree_hal_cuda_ready_action_slist_pop(list);
+    if (!entry) break;
+    iree_hal_cuda_queue_action_list_destroy(entry->ready_list_head);
+    iree_allocator_free(host_allocator, entry);
+  }
+  iree_hal_cuda_ready_action_slist_deinitialize(list);
+}
+
+static iree_hal_cuda_queue_action_t* iree_hal_cuda_atomic_slist_entry_pop_front(
+    iree_hal_cuda_atomic_slist_entry_t* list) {
+  IREE_ASSERT(list->ready_list_head);
+
+  iree_hal_cuda_queue_action_t* action = list->ready_list_head;
+  IREE_ASSERT(!action->prev);
+  list->ready_list_head = action->next;
+  if (action->next) {
+    action->next->prev = NULL;
+    action->next = NULL;
+  }
+
+  return action;
+}
 
 // The ready-list processing worker's working/exiting state.
 //
@@ -211,20 +246,30 @@ typedef enum iree_hal_cuda_worker_state_e {
 // The parent thread should push a list of ready actions to ready_worklist,
 // update worker_state, and give state_notification accordingly.
 // The worker thread waits on the state_notification and checks worker_state,
-// and pops from the ready_worklist to process. The worker thread also monintors
+// and pops from the ready_worklist to process. The worker thread also monitors
 // worker_state and stops processing if requested by the parent thread.
 typedef struct iree_hal_cuda_working_area_t {
   // Notification from the parent thread to request worker state changes.
   iree_notification_t state_notification;
   // Notification to the parent thread to indicate the worker committed exiting.
+  // TODO: maybe remove this. We can just wait on the worker thread to exit.
   iree_notification_t exit_notification;
   iree_hal_cuda_ready_action_slist_t ready_worklist;  // atomic
   iree_atomic_int32_t worker_state;                   // atomic
-  iree_atomic_intptr_t error_code;                    // atomic
-  // The number of actions that have been issued to the GPU but not yet fully
-  // completed both execution and cleanup. We don't need this field to be atomic
-  // given it is modified only from the worker thread.
-  int32_t pending_action_count;
+  // TODO: use status to provide more context for the error.
+  iree_atomic_intptr_t error_code;  // atomic
+
+  // The number of asynchronous work items that are scheduled and not
+  // complete.
+  // These are
+  // * the number of callbacks that are scheduled on the host stream.
+  // * the number of pending action cleanup.
+  // We need to wait for them to finish before destroying the context.
+  iree_slim_mutex_t pending_work_items_count_mutex;
+  iree_notification_t pending_work_items_count_notification;
+  int32_t pending_work_items_count
+      IREE_GUARDED_BY(pending_work_items_count_mutex);
+
   iree_allocator_t host_allocator;  // const
 } iree_hal_cuda_working_area_t;
 
@@ -239,15 +284,22 @@ static void iree_hal_cuda_working_area_initialize(
                           iree_memory_order_release);
   iree_atomic_store_int32(&working_area->error_code, IREE_STATUS_OK,
                           iree_memory_order_release);
-  working_area->pending_action_count = 0;
+  iree_slim_mutex_initialize(&working_area->pending_work_items_count_mutex);
+  iree_notification_initialize(
+      &working_area->pending_work_items_count_notification);
+  working_area->pending_work_items_count = 0;
   working_area->host_allocator = host_allocator;
 }
 
 static void iree_hal_cuda_working_area_deinitialize(
     iree_hal_cuda_working_area_t* working_area) {
-  iree_hal_cuda_ready_action_slist_deinitialize(&working_area->ready_worklist);
+  iree_hal_cuda_ready_action_slist_destroy(&working_area->ready_worklist,
+                                           working_area->host_allocator);
   iree_notification_deinitialize(&working_area->exit_notification);
   iree_notification_deinitialize(&working_area->state_notification);
+  iree_slim_mutex_deinitialize(&working_area->pending_work_items_count_mutex);
+  iree_notification_deinitialize(
+      &working_area->pending_work_items_count_notification);
 }
 
 // The main function for the ready-list processing worker thread.
@@ -368,8 +420,7 @@ void iree_hal_cuda_pending_queue_actions_destroy(
   iree_hal_cuda_working_area_deinitialize(working_area);
 
   iree_slim_mutex_deinitialize(&actions->action_mutex);
-  iree_hal_cuda_queue_action_list_free_actions(host_allocator,
-                                               &actions->action_list);
+  iree_hal_cuda_queue_action_list_destroy(actions->action_list.head);
   iree_allocator_free(host_allocator, actions);
 
   IREE_TRACE_ZONE_END(z0);
@@ -432,6 +483,46 @@ static void iree_hal_cuda_free_semaphore_list(
   iree_allocator_free(host_allocator, semaphore_list->payload_values);
 }
 
+static void iree_hal_cuda_queue_action_destroy(
+    iree_hal_cuda_queue_action_t* action) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_hal_cuda_pending_queue_actions_t* actions = action->owning_actions;
+  iree_allocator_t host_allocator = actions->host_allocator;
+
+  // Call user provided callback before releasing any resource.
+  if (action->cleanup_callback) {
+    action->cleanup_callback(action->callback_user_data);
+  }
+
+  // Only release resources after callbacks have been issued.
+  iree_hal_resource_set_free(action->resource_set);
+  iree_hal_cuda_free_semaphore_list(host_allocator,
+                                    &action->wait_semaphore_list);
+  iree_hal_cuda_free_semaphore_list(host_allocator,
+                                    &action->signal_semaphore_list);
+
+  iree_hal_cuda_queue_action_clear_events(action);
+
+  iree_hal_resource_release(actions);
+
+  iree_allocator_free(host_allocator, action);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+static void decrement_work_items_count(
+    iree_hal_cuda_working_area_t* working_area) {
+  iree_slim_mutex_lock(&working_area->pending_work_items_count_mutex);
+  --working_area->pending_work_items_count;
+  if (working_area->pending_work_items_count == 0) {
+    // Notify inside the lock to make sure that we are done touching anything
+    // since the context may get destroyed in the meantime.
+    iree_notification_post(&working_area->pending_work_items_count_notification,
+                           IREE_ALL_WAITERS);
+  }
+  iree_slim_mutex_unlock(&working_area->pending_work_items_count_mutex);
+}
+
 iree_status_t iree_hal_cuda_pending_queue_actions_enqueue_execution(
     iree_hal_device_t* device, CUstream dispatch_stream,
     CUstream callback_stream, iree_hal_cuda_pending_queue_actions_t* actions,
@@ -451,7 +542,7 @@ iree_status_t iree_hal_cuda_pending_queue_actions_enqueue_execution(
                                 (void**)&action));
 
   action->owning_actions = actions;
-  action->state = IREE_HAL_cuda_QUEUE_ACTION_STATE_ALIVE;
+  action->state = IREE_HAL_CUDA_QUEUE_ACTION_STATE_ALIVE;
   action->cleanup_callback = cleanup_callback;
   action->callback_user_data = callback_user_data;
   action->kind = IREE_HAL_CUDA_QUEUE_ACTION_TYPE_EXECUTION;
@@ -532,13 +623,19 @@ iree_status_t iree_hal_cuda_pending_queue_actions_enqueue_execution(
 
 static void iree_hal_cuda_post_error_to_worker_state(
     iree_hal_cuda_working_area_t* working_area, iree_status_code_t code) {
-  iree_atomic_store_int32(&working_area->error_code, code,
-                          iree_memory_order_release);
+  // Write error code, but don't overwrite existing error codes.
+  intptr_t prev_error_code = IREE_STATUS_OK;
+  iree_atomic_compare_exchange_strong_int32(
+      &working_area->error_code, /*expected=*/&prev_error_code,
+      /*desired=*/code,
+      /*order_succ=*/iree_memory_order_acq_rel,
+      /*order_fail=*/iree_memory_order_acquire);
+
   // This state has the highest priority so just overwrite.
   iree_atomic_store_int32(&working_area->worker_state,
                           IREE_HAL_CUDA_WORKER_STATE_EXIT_ERROR,
                           iree_memory_order_release);
-  iree_notification_post(&working_area->exit_notification, IREE_ALL_WAITERS);
+  iree_notification_post(&working_area->state_notification, IREE_ALL_WAITERS);
 }
 
 // Releases resources after action completion on the GPU and advances timeline
@@ -553,35 +650,41 @@ static void iree_hal_cuda_execution_device_signal_host_callback(
   iree_hal_cuda_queue_action_t* action =
       (iree_hal_cuda_queue_action_t*)user_data;
   IREE_ASSERT_EQ(action->kind, IREE_HAL_CUDA_QUEUE_ACTION_TYPE_EXECUTION);
-  IREE_ASSERT_EQ(action->state, IREE_HAL_cuda_QUEUE_ACTION_STATE_ALIVE);
+  IREE_ASSERT_EQ(action->state, IREE_HAL_CUDA_QUEUE_ACTION_STATE_ALIVE);
   iree_hal_cuda_pending_queue_actions_t* actions = action->owning_actions;
+
+  iree_status_t status;
+
+  // Need to signal the list before zombifying the action, because in the mean
+  // time someone else may issue the pending queue actions.
+  // If we push first to the pending actions list, the cleanup of this action
+  // may run while we are still using the semaphore list, causing a crash.
+  status = iree_hal_semaphore_list_signal(action->signal_semaphore_list);
+  if (IREE_UNLIKELY(!iree_status_is_ok(status))) {
+    IREE_ASSERT(false && "cannot signal semaphores in host callback");
+    iree_hal_cuda_post_error_to_worker_state(&actions->working_area,
+                                             iree_status_code(status));
+  }
 
   // Flip the action state to zombie and enqueue it again so that we can let
   // the worker thread clean it up. Note that this is necessary because cleanup
   // may involve GPU API calls like buffer releasing or unregistering, so we can
   // not inline it here.
-  action->state = IREE_HAL_cuda_QUEUE_ACTION_STATE_ZOMBIE;
+  action->state = IREE_HAL_CUDA_QUEUE_ACTION_STATE_ZOMBIE;
   iree_slim_mutex_lock(&actions->action_mutex);
   iree_hal_cuda_queue_action_list_push_back(&actions->action_list, action);
   iree_slim_mutex_unlock(&actions->action_mutex);
 
-  iree_status_t status;
-  if (action->signal_semaphore_list.count) {
-    // Advance semaphore timelines by calling into the host signaling function.
-    // This will internally try to release more workload to the GPU.
-    status = iree_hal_semaphore_list_signal(action->signal_semaphore_list);
-  } else {
-    // If there is no semaphores to signal we still need to trigger execution
-    // of the recently zombified action so it can be cleaned up.
-    status = iree_hal_cuda_pending_queue_actions_issue(actions);
-  }
-
+  // We need to trigger execution of this action again, so it gets cleaned up.
+  status = iree_hal_cuda_pending_queue_actions_issue(actions);
   if (IREE_UNLIKELY(!iree_status_is_ok(status))) {
-    IREE_ASSERT(false &&
-                "can't signal semaphores and/or issue pending actions");
+    IREE_ASSERT(false && "cannot issue action for cleanup in host callback");
     iree_hal_cuda_post_error_to_worker_state(&actions->working_area,
                                              iree_status_code(status));
   }
+
+  // The callback (work item) is complete.
+  decrement_work_items_count(&actions->working_area);
 
   IREE_TRACE_ZONE_END(z0);
 }
@@ -664,12 +767,16 @@ static iree_status_t iree_hal_cuda_pending_queue_actions_issue_execution(
         "cuStreamWaitEvent");
   }
 
-  // Increase the pending action counter. We decrease it once it fully
-  // completes and gets cleaned up.
-  ++action->owning_actions->working_area.pending_action_count;
-
+  iree_slim_mutex_lock(
+      &action->owning_actions->working_area.pending_work_items_count_mutex);
+  // One work item is the host stream callback.
+  // The other is the cleanup of the action.
+  action->owning_actions->working_area.pending_work_items_count += 2;
+  iree_slim_mutex_unlock(
+      &action->owning_actions->working_area.pending_work_items_count_mutex);
   // Now launch a host function on the callback stream to advance the semaphore
   // timeline.
+
   IREE_CUDA_RETURN_AND_END_ZONE_IF_ERROR(
       z0, symbols,
       cuLaunchHostFunc(action->callback_cu_stream,
@@ -681,46 +788,19 @@ static iree_status_t iree_hal_cuda_pending_queue_actions_issue_execution(
   return iree_ok_status();
 }
 
-static void iree_hal_cuda_queue_action_clear_events(
-    iree_hal_cuda_queue_action_t* action) {
-  for (iree_host_size_t i = 0; i < action->event_count; ++i) {
-    iree_hal_cuda_event_release(action->events[i]);
-  }
-  action->event_count = 0;
-}
-
 // Performs the given cleanup |action| on the CPU.
-static iree_status_t iree_hal_cuda_pending_queue_actions_issue_cleanup(
+static void iree_hal_cuda_pending_queue_actions_issue_cleanup(
     iree_hal_cuda_queue_action_t* action) {
   iree_hal_cuda_pending_queue_actions_t* actions = action->owning_actions;
-  iree_allocator_t host_allocator = actions->host_allocator;
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  // Call user provided callback before releasing any resource.
-  if (action->cleanup_callback) {
-    action->cleanup_callback(action->callback_user_data);
-  }
+  iree_hal_cuda_queue_action_destroy(action);
 
-  // Only release resources after callbacks have been issued.
-  iree_hal_resource_set_free(action->resource_set);
-  iree_hal_cuda_free_semaphore_list(host_allocator,
-                                    &action->wait_semaphore_list);
-  iree_hal_cuda_free_semaphore_list(host_allocator,
-                                    &action->signal_semaphore_list);
-
-  iree_hal_cuda_queue_action_clear_events(action);
-
-  iree_allocator_free(host_allocator, action);
-
-  // Now we fully executed and cleaned up this action. Decrease the pending
-  // action counter.
-  --actions->working_area.pending_action_count;
-
-  // Drop reference to the pending action queue given now we are done.
-  iree_hal_resource_release(actions);
+  // Now we fully executed and cleaned up this action. Decrease the work items
+  // counter.
+  decrement_work_items_count(&actions->working_area);
 
   IREE_TRACE_ZONE_END(z0);
-  return iree_ok_status();
 }
 
 iree_status_t iree_hal_cuda_pending_queue_actions_issue(
@@ -740,21 +820,19 @@ iree_status_t iree_hal_cuda_pending_queue_actions_issue(
 
   // Scan through the list and categorize actions into pending and ready lists.
   iree_status_t status = iree_ok_status();
-  iree_hal_cuda_queue_action_t* action = actions->action_list.head;
-  while (action) {
-    iree_hal_cuda_queue_action_t* next_action = action->next;
-    action->next = NULL;
+  while (!iree_hal_cuda_queue_action_list_is_empty(&actions->action_list)) {
+    iree_hal_cuda_queue_action_t* action =
+        iree_hal_cuda_queue_action_list_pop_front(&actions->action_list);
 
     iree_hal_semaphore_t** semaphores = action->wait_semaphore_list.semaphores;
     uint64_t* values = action->wait_semaphore_list.payload_values;
 
-    action->event_count = 0;
     action->is_pending = false;
 
     // Cleanup actions are immediately ready to release. Otherwise, look at all
     // wait semaphores to make sure that they are either already ready or we can
     // wait on a device event.
-    if (action->state == IREE_HAL_cuda_QUEUE_ACTION_STATE_ALIVE) {
+    if (action->state == IREE_HAL_CUDA_QUEUE_ACTION_STATE_ALIVE) {
       for (iree_host_size_t i = 0; i < action->wait_semaphore_list.count; ++i) {
         // If this semaphore has already signaled past the desired value, we can
         // just ignore it.
@@ -781,8 +859,6 @@ iree_status_t iree_hal_cuda_pending_queue_actions_issue(
         iree_hal_cuda_event_t* wait_event = NULL;
         if (!iree_hal_cuda_semaphore_acquire_event_host_wait(
                 semaphores[i], values[i], &wait_event)) {
-          // Clear the scratch fields.
-          action->event_count = 0;
           action->is_pending = true;
           break;
         }
@@ -803,23 +879,19 @@ iree_status_t iree_hal_cuda_pending_queue_actions_issue(
       }
     }
 
-    if (IREE_UNLIKELY(!iree_status_is_ok(status))) break;
+    if (IREE_UNLIKELY(!iree_status_is_ok(status))) {
+      // Some error happened during processing the current action.
+      // Put it back to the pending list so we don't leak.
+      action->is_pending = true;
+      iree_hal_cuda_queue_action_list_push_back(&pending_list, action);
+      break;
+    }
 
     if (action->is_pending) {
       iree_hal_cuda_queue_action_list_push_back(&pending_list, action);
     } else {
       iree_hal_cuda_queue_action_list_push_back(&ready_list, action);
     }
-
-    action = next_action;
-  }
-
-  if (IREE_UNLIKELY(!iree_status_is_ok(status))) {
-    // Some error happened during processing the current action. Clear the
-    // scratch fields and put it back to the pending list so we don't leak.
-    action->event_count = 0;
-    action->is_pending = true;
-    iree_hal_cuda_queue_action_list_push_back(&pending_list, action);
   }
 
   // Preserve pending timepoints.
@@ -842,8 +914,7 @@ iree_status_t iree_hal_cuda_pending_queue_actions_issue(
 
   if (IREE_UNLIKELY(!iree_status_is_ok(status))) {
     // Release all actions in the ready list to avoid leaking.
-    iree_hal_cuda_queue_action_list_free_actions(actions->host_allocator,
-                                                 &ready_list);
+    iree_hal_cuda_queue_action_list_destroy(ready_list.head);
     iree_allocator_free(actions->host_allocator, entry);
     IREE_TRACE_ZONE_END(z0);
     return status;
@@ -883,14 +954,13 @@ iree_status_t iree_hal_cuda_pending_queue_actions_issue(
 // Worker routines
 //===----------------------------------------------------------------------===//
 
-static bool iree_hal_cuda_worker_has_incoming_request(
+static bool iree_hal_cuda_worker_has_incoming_request_or_error(
     iree_hal_cuda_working_area_t* working_area) {
   iree_hal_cuda_worker_state_t value = iree_atomic_load_int32(
       &working_area->worker_state, iree_memory_order_acquire);
-  // These are the only two possible states that set from the main thread to
-  // the worker thread.
   return value == IREE_HAL_CUDA_WORKER_STATE_WORKLOAD_PENDING ||
-         value == IREE_HAL_CUDA_WORKER_STATE_EXIT_REQUESTED;
+         value == IREE_HAL_CUDA_WORKER_STATE_EXIT_REQUESTED ||
+         value == IREE_HAL_CUDA_WORKER_STATE_EXIT_ERROR;
 }
 
 static bool iree_hal_cuda_worker_committed_exiting(
@@ -907,36 +977,64 @@ static iree_status_t iree_hal_cuda_worker_process_ready_list(
   IREE_TRACE_ZONE_BEGIN(z0);
 
   iree_status_t status = iree_ok_status();
-  do {
+  while (true) {
     iree_hal_cuda_atomic_slist_entry_t* entry =
         iree_hal_cuda_ready_action_slist_pop(worklist);
     if (!entry) break;
 
     // Process the current batch of ready actions.
-    iree_hal_cuda_queue_action_t* action = entry->ready_list_head;
-    while (action) {
-      iree_hal_cuda_queue_action_t* next_action = action->next;
-      action->next = NULL;
+    while (entry->ready_list_head) {
+      iree_hal_cuda_queue_action_t* action =
+          iree_hal_cuda_atomic_slist_entry_pop_front(entry);
 
       switch (action->state) {
-        case IREE_HAL_cuda_QUEUE_ACTION_STATE_ALIVE:
+        case IREE_HAL_CUDA_QUEUE_ACTION_STATE_ALIVE:
           status = iree_hal_cuda_pending_queue_actions_issue_execution(action);
-          if (iree_status_is_ok(status)) action->event_count = 0;
+          if (IREE_UNLIKELY(!iree_status_is_ok(status))) {
+            iree_hal_cuda_queue_action_destroy(action);
+          }
           break;
-        case IREE_HAL_cuda_QUEUE_ACTION_STATE_ZOMBIE:
-          status = iree_hal_cuda_pending_queue_actions_issue_cleanup(action);
+        case IREE_HAL_CUDA_QUEUE_ACTION_STATE_ZOMBIE:
+          iree_hal_cuda_pending_queue_actions_issue_cleanup(action);
           break;
       }
-      if (!iree_status_is_ok(status)) break;
+      if (IREE_UNLIKELY(!iree_status_is_ok(status))) break;
+    }
 
-      action = next_action;
+    if (IREE_UNLIKELY(!iree_status_is_ok(status))) {
+      // Let common destruction path take care of destroying the worklist.
+      // When we know all host stream callbacks are done and not touching
+      // anything.
+      iree_hal_cuda_ready_action_slist_push(worklist, entry);
+      break;
     }
 
     iree_allocator_free(host_allocator, entry);
-  } while (iree_status_is_ok(status));
+  }
 
   IREE_TRACE_ZONE_END(z0);
   return status;
+}
+
+static bool iree_hal_cuda_worker_has_no_pending_work_items(
+    iree_hal_cuda_working_area_t* working_area) {
+  iree_slim_mutex_lock(&working_area->pending_work_items_count_mutex);
+  bool result = (working_area->pending_work_items_count == 0);
+  iree_slim_mutex_unlock(&working_area->pending_work_items_count_mutex);
+  return result;
+}
+
+// Wait for all work items to finish.
+static void iree_hal_cuda_worker_wait_pending_work_items(
+    iree_hal_cuda_working_area_t* working_area) {
+  iree_notification_await(
+      &working_area->pending_work_items_count_notification,
+      (iree_condition_fn_t)iree_hal_cuda_worker_has_no_pending_work_items,
+      working_area, iree_infinite_timeout());
+  // Lock then unlock to make sure that all callbacks are really done.
+  // Not even touching the notification.
+  iree_slim_mutex_lock(&working_area->pending_work_items_count_mutex);
+  iree_slim_mutex_unlock(&working_area->pending_work_items_count_mutex);
 }
 
 // The main function for the ready-list processing worker thread.
@@ -946,9 +1044,15 @@ static int iree_hal_cuda_worker_execute(
 
   while (true) {
     // Block waiting for incoming requests.
+    //
+    // TODO: When exit is requested with
+    // IREE_HAL_CUDA_WORKER_STATE_EXIT_REQUESTED
+    // we will return immediately causing a busy wait and hogging the CPU.
+    // We need to properly wait for action cleanups to be scheduled from the
+    // host stream callbacks.
     iree_notification_await(
         &working_area->state_notification,
-        (iree_condition_fn_t)iree_hal_cuda_worker_has_incoming_request,
+        (iree_condition_fn_t)iree_hal_cuda_worker_has_incoming_request_or_error,
         working_area, iree_infinite_timeout());
 
     // Immediately flip the state to idle waiting if and only if the previous
@@ -969,6 +1073,7 @@ static int iree_hal_cuda_worker_execute(
                                                   iree_memory_order_acquire);
     // Exit if CUDA callbacks have posted any errors.
     if (IREE_UNLIKELY(worker_state == IREE_HAL_CUDA_WORKER_STATE_EXIT_ERROR)) {
+      iree_hal_cuda_worker_wait_pending_work_items(working_area);
       return -1;
     }
     // Check if we received request to stop processing and exit this thread.
@@ -979,13 +1084,16 @@ static int iree_hal_cuda_worker_execute(
     iree_status_t status = iree_hal_cuda_worker_process_ready_list(
         working_area->host_allocator, worklist);
     if (IREE_UNLIKELY(!iree_status_is_ok(status))) {
-      IREE_ASSERT(false && "error when processing ready list");
+      iree_hal_cuda_worker_wait_pending_work_items(working_area);
       iree_hal_cuda_post_error_to_worker_state(working_area,
                                                iree_status_code(status));
       return -1;
     }
 
-    if (IREE_UNLIKELY(should_exit && working_area->pending_action_count == 0)) {
+    if (IREE_UNLIKELY(
+            should_exit &&
+            iree_hal_cuda_worker_has_no_pending_work_items(working_area))) {
+      iree_hal_cuda_worker_wait_pending_work_items(working_area);
       // Signal that this thread is committed to exit.
       // This state has a priority that is only lower than error exit.
       // A CUDA callback may have posted an error, make sure we don't


### PR DESCRIPTION
* Fix a bug where we may miss a signal when waiting on multiple semaphores. Improve code reusability by increasing code sharing in multi-wait and single-wait.

* Fix destruction in error path to not leak actions.

* Fix acquisition of action GPU events from semaphore timepoints. The switch to using iree_hal_*_event_t instead of HIP/CUDA events directly, introduced by 459fab66b0c59389b88c7bb8a8bfe81492581d9b, caused mishandling of timepoint events.
This may cause erroneous removal of action wait events and leaking them.

* Add a mutex-protected counter in the work area that keeps track of all pending host stream callbacks.
We need to make sure that all work is done before exiting the worker and then tear down the execution context.