### PR TITLE
[GPU] Add option for no gpu.block_dim in GPUDistributeScfFor

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeScfFor.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeScfFor.cpp
@@ -16,13 +16,9 @@
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
-#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinAttributes.h"
-#include "mlir/IR/MLIRContext.h"
-#include "mlir/IR/PatternMatch.h"
-#include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "iree-codegen-gpu-distribute-scf-for"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeScfFor.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeScfFor.cpp
@@ -13,6 +13,7 @@
 
 #include "iree/compiler/Codegen/Common/GPU/PassDetail.h"
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -42,16 +43,20 @@ public:
     if (!numDimAttr)
       return failure();
 
-    auto funcOp = forOp->getParentOfType<FunctionOpInterface>();
-    if (!funcOp) {
-      return failure();
+    // Get workgroup sizes if not using gpu.block_dim
+    SmallVector<int64_t> workgroupSize;
+    if (!useBlockDims) {
+      auto funcOp = forOp->getParentOfType<FunctionOpInterface>();
+      if (!funcOp) {
+        return failure();
+      }
+      std::optional<SmallVector<int64_t>> maybeWorkgroupSize =
+          getWorkgroupSize(funcOp);
+      if (!maybeWorkgroupSize) {
+        return failure();
+      }
+      workgroupSize = maybeWorkgroupSize.value();
     }
-    std::optional<SmallVector<int64_t>> maybeWorkgroupSize =
-        getWorkgroupSize(funcOp);
-    if (!maybeWorkgroupSize) {
-      return failure();
-    }
-    auto workgroupSize = maybeWorkgroupSize.value();
 
     Location loc = forOp.getLoc();
     auto indexType = rewriter.getIndexType();

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
@@ -106,7 +106,7 @@ createGPUDistributeSharedMemoryCopy();
 
 /// Pass to distribute tiled loop nests to invocations.
 std::unique_ptr<InterfacePass<FunctionOpInterface>>
-createGPUDistributeScfForPass();
+createGPUDistributeScfForPass(bool useBlockDims = true);
 
 /// Apply multi-buffering transformation.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -41,6 +41,11 @@ def GPUDistributeScfFor :
     InterfacePass<"iree-codegen-gpu-distribute-scf-for", "mlir::FunctionOpInterface"> {
   let summary = "Distribute tiled loop nests to invocations";
   let constructor = "mlir::iree_compiler::createGPUDistributeScfForPass()";
+  let options = [
+    Option<"useBlockDims", "use-block-dims", "bool",
+           /*default=*/"true",
+           "Use gpu.block_dim ops to query distribution sizes.">,
+  ];
 }
 
 def GPUGeneralizeNamedOps :

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_distribute_scf_for.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_distribute_scf_for.mlir
@@ -1,6 +1,9 @@
 // RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-distribute-scf-for))" --mlir-print-local-scope %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-distribute-scf-for{use-block-dims=false}))" --mlir-print-local-scope %s | FileCheck --check-prefix=NO-BLOCK-DIM %s
 
-func.func @distribute_to_x(%lb : index, %ub : index, %step: index, %output: memref<?xf32>) {
+#translation = #iree_codegen.translation_info<LLVMGPUVectorize workgroup_size = [64, 1, 1]>
+func.func @distribute_to_x(%lb : index, %ub : index, %step: index, %output: memref<?xf32>)
+  attributes {translation_info = #translation} {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index
@@ -16,16 +19,28 @@ func.func @distribute_to_x(%lb : index, %ub : index, %step: index, %output: memr
 
 // CHECK-LABEL: func.func @distribute_to_x
 //  CHECK-SAME: %[[LB:.+]]: index, %[[UB:.+]]: index, %[[STEP:.+]]: index
-//       CHECK:   %[[ID:.+]] = gpu.thread_id x
-//       CHECK:   %[[DIM:.+]] = gpu.block_dim x
+//   CHECK-DAG:   %[[ID:.+]] = gpu.thread_id x
+//   CHECK-DAG:   %[[DIM:.+]] = gpu.block_dim x
 //       CHECK:   %[[XLB:.+]] = affine.apply affine_map<()[s0, s1, s2] -> (s0 * s1 + s2)>()[%[[ID]], %[[STEP]], %[[LB]]]
 //       CHECK:   %[[XSTEP:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%[[DIM]], %[[STEP]]]
 //       CHECK:   scf.for %[[IV:.+]] = %[[XLB]] to %[[UB]] step %[[XSTEP]] {
 //       CHECK:     memref.store %{{.+}}, %{{.+}}[%[[IV]]] : memref<?xf32>
 
+// NO-BLOCK-DIM-LABEL: func.func @distribute_to_x
+//  NO-BLOCK-DIM-SAME: %[[LB:.+]]: index, %[[UB:.+]]: index, %[[STEP:.+]]: index
+//   NO-BLOCK-DIM-DAG:   %[[ID:.+]] = gpu.thread_id x
+//   NO-BLOCK-DIM-DAG:   %[[DIM:.+]] = arith.constant 64 : index
+//       NO-BLOCK-DIM:   %[[XLB:.+]] = affine.apply affine_map<()[s0, s1, s2] -> (s0 * s1 + s2)>()[%[[ID]], %[[STEP]], %[[LB]]]
+//       NO-BLOCK-DIM:   %[[XSTEP:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%[[DIM]], %[[STEP]]]
+//       NO-BLOCK-DIM:   scf.for %[[IV:.+]] = %[[XLB]] to %[[UB]] step %[[XSTEP]] {
+//       NO-BLOCK-DIM:     memref.store %{{.+}}, %{{.+}}[%[[IV]]] : memref<?xf32>
+
+
 // -----
 
-func.func @distribute_to_y(%lb : index, %ub : index, %step: index, %output: memref<?xf32>) {
+#translation = #iree_codegen.translation_info<LLVMGPUVectorize workgroup_size = [1, 64, 1]>
+func.func @distribute_to_y(%lb : index, %ub : index, %step: index, %output: memref<?xf32>)
+  attributes {translation_info = #translation} {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index
@@ -41,16 +56,28 @@ func.func @distribute_to_y(%lb : index, %ub : index, %step: index, %output: memr
 
 // CHECK-LABEL: func.func @distribute_to_y
 //  CHECK-SAME: %[[LB:.+]]: index, %[[UB:.+]]: index, %[[STEP:.+]]: index
-//       CHECK:   %[[ID:.+]] = gpu.thread_id y
-//       CHECK:   %[[DIM:.+]] = gpu.block_dim y
+//   CHECK-DAG:   %[[ID:.+]] = gpu.thread_id y
+//   CHECK-DAG:   %[[DIM:.+]] = gpu.block_dim y
 //       CHECK:   %[[YLB:.+]] = affine.apply affine_map<()[s0, s1, s2] -> (s0 * s1 + s2)>()[%[[ID]], %[[STEP]], %[[LB]]]
 //       CHECK:   %[[YSTEP:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%[[DIM]], %[[STEP]]]
 //       CHECK:   scf.for %[[IV:.+]] = %[[YLB]] to %[[UB]] step %[[YSTEP]] {
 //       CHECK:     memref.store %{{.+}}, %{{.+}}[%[[IV]]] : memref<?xf32>
 
+// NO-BLOCK-DIM-LABEL: func.func @distribute_to_y
+//  NO-BLOCK-DIM-SAME: %[[LB:.+]]: index, %[[UB:.+]]: index, %[[STEP:.+]]: index
+//   NO-BLOCK-DIM-DAG:   %[[ID:.+]] = gpu.thread_id y
+//   NO-BLOCK-DIM-DAG:   %[[DIM:.+]] = arith.constant 64 : index
+//       NO-BLOCK-DIM:   %[[YLB:.+]] = affine.apply affine_map<()[s0, s1, s2] -> (s0 * s1 + s2)>()[%[[ID]], %[[STEP]], %[[LB]]]
+//       NO-BLOCK-DIM:   %[[YSTEP:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%[[DIM]], %[[STEP]]]
+//       NO-BLOCK-DIM:   scf.for %[[IV:.+]] = %[[YLB]] to %[[UB]] step %[[YSTEP]] {
+//       NO-BLOCK-DIM:     memref.store %{{.+}}, %{{.+}}[%[[IV]]] : memref<?xf32>
+
+
 // -----
 
-func.func @distribute_to_z(%lb : index, %ub : index, %step: index, %output: memref<?xf32>) {
+#translation = #iree_codegen.translation_info<LLVMGPUVectorize workgroup_size = [1, 1, 64]>
+func.func @distribute_to_z(%lb : index, %ub : index, %step: index, %output: memref<?xf32>)
+  attributes {translation_info = #translation} {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index
@@ -66,12 +93,22 @@ func.func @distribute_to_z(%lb : index, %ub : index, %step: index, %output: memr
 
 // CHECK-LABEL: func.func @distribute_to_z
 //  CHECK-SAME: %[[LB:.+]]: index, %[[UB:.+]]: index, %[[STEP:.+]]: index
-//       CHECK:   %[[ID:.+]] = gpu.thread_id z
-//       CHECK:   %[[DIM:.+]] = gpu.block_dim z
+//   CHECK-DAG:   %[[ID:.+]] = gpu.thread_id z
+//   CHECK-DAG:   %[[DIM:.+]] = gpu.block_dim z
 //       CHECK:   %[[ZLB:.+]] = affine.apply affine_map<()[s0, s1, s2] -> (s0 * s1 + s2)>()[%[[ID]], %[[STEP]], %[[LB]]]
 //       CHECK:   %[[ZSTEP:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%[[DIM]], %[[STEP]]]
 //       CHECK:   scf.for %[[IV:.+]] = %[[ZLB]] to %[[UB]] step %[[ZSTEP]] {
 //       CHECK:     memref.store %{{.+}}, %{{.+}}[%[[IV]]] : memref<?xf32>
+
+// NO-BLOCK-DIM-LABEL: func.func @distribute_to_z
+//  NO-BLOCK-DIM-SAME: %[[LB:.+]]: index, %[[UB:.+]]: index, %[[STEP:.+]]: index
+//   NO-BLOCK-DIM-DAG:   %[[ID:.+]] = gpu.thread_id z
+//   NO-BLOCK-DIM-DAG:   %[[DIM:.+]] = arith.constant 64 : index
+//       NO-BLOCK-DIM:   %[[ZLB:.+]] = affine.apply affine_map<()[s0, s1, s2] -> (s0 * s1 + s2)>()[%[[ID]], %[[STEP]], %[[LB]]]
+//       NO-BLOCK-DIM:   %[[ZSTEP:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%[[DIM]], %[[STEP]]]
+//       NO-BLOCK-DIM:   scf.for %[[IV:.+]] = %[[ZLB]] to %[[UB]] step %[[ZSTEP]] {
+//       NO-BLOCK-DIM:     memref.store %{{.+}}, %{{.+}}[%[[IV]]] : memref<?xf32>
+
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_distribute_scf_for.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_distribute_scf_for.mlir
@@ -35,7 +35,6 @@ func.func @distribute_to_x(%lb : index, %ub : index, %step: index, %output: memr
 //       NO-BLOCK-DIM:   scf.for %[[IV:.+]] = %[[XLB]] to %[[UB]] step %[[XSTEP]] {
 //       NO-BLOCK-DIM:     memref.store %{{.+}}, %{{.+}}[%[[IV]]] : memref<?xf32>
 
-
 // -----
 
 #translation = #iree_codegen.translation_info<LLVMGPUVectorize workgroup_size = [1, 64, 1]>
@@ -63,16 +62,6 @@ func.func @distribute_to_y(%lb : index, %ub : index, %step: index, %output: memr
 //       CHECK:   scf.for %[[IV:.+]] = %[[YLB]] to %[[UB]] step %[[YSTEP]] {
 //       CHECK:     memref.store %{{.+}}, %{{.+}}[%[[IV]]] : memref<?xf32>
 
-// NO-BLOCK-DIM-LABEL: func.func @distribute_to_y
-//  NO-BLOCK-DIM-SAME: %[[LB:.+]]: index, %[[UB:.+]]: index, %[[STEP:.+]]: index
-//   NO-BLOCK-DIM-DAG:   %[[ID:.+]] = gpu.thread_id y
-//   NO-BLOCK-DIM-DAG:   %[[DIM:.+]] = arith.constant 64 : index
-//       NO-BLOCK-DIM:   %[[YLB:.+]] = affine.apply affine_map<()[s0, s1, s2] -> (s0 * s1 + s2)>()[%[[ID]], %[[STEP]], %[[LB]]]
-//       NO-BLOCK-DIM:   %[[YSTEP:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%[[DIM]], %[[STEP]]]
-//       NO-BLOCK-DIM:   scf.for %[[IV:.+]] = %[[YLB]] to %[[UB]] step %[[YSTEP]] {
-//       NO-BLOCK-DIM:     memref.store %{{.+}}, %{{.+}}[%[[IV]]] : memref<?xf32>
-
-
 // -----
 
 #translation = #iree_codegen.translation_info<LLVMGPUVectorize workgroup_size = [1, 1, 64]>
@@ -99,16 +88,6 @@ func.func @distribute_to_z(%lb : index, %ub : index, %step: index, %output: memr
 //       CHECK:   %[[ZSTEP:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%[[DIM]], %[[STEP]]]
 //       CHECK:   scf.for %[[IV:.+]] = %[[ZLB]] to %[[UB]] step %[[ZSTEP]] {
 //       CHECK:     memref.store %{{.+}}, %{{.+}}[%[[IV]]] : memref<?xf32>
-
-// NO-BLOCK-DIM-LABEL: func.func @distribute_to_z
-//  NO-BLOCK-DIM-SAME: %[[LB:.+]]: index, %[[UB:.+]]: index, %[[STEP:.+]]: index
-//   NO-BLOCK-DIM-DAG:   %[[ID:.+]] = gpu.thread_id z
-//   NO-BLOCK-DIM-DAG:   %[[DIM:.+]] = arith.constant 64 : index
-//       NO-BLOCK-DIM:   %[[ZLB:.+]] = affine.apply affine_map<()[s0, s1, s2] -> (s0 * s1 + s2)>()[%[[ID]], %[[STEP]], %[[LB]]]
-//       NO-BLOCK-DIM:   %[[ZSTEP:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%[[DIM]], %[[STEP]]]
-//       NO-BLOCK-DIM:   scf.for %[[IV:.+]] = %[[ZLB]] to %[[UB]] step %[[ZSTEP]] {
-//       NO-BLOCK-DIM:     memref.store %{{.+}}, %{{.+}}[%[[IV]]] : memref<?xf32>
-
 
 // -----
 


### PR DESCRIPTION
This PR adds an option to generate `arith.constant` ops with workgroup sizes in place of `gpu.block_dim` ops in `GPUDistributeScfFor`. The `gpu.block_dim` ops are not currently handled properly on ROCM backends, so this option is needed to support `GPUDistributeScfFor` on the LLVMGPU path.