### PR TITLE
Mark pytorch_aot_advanced Colab notebook passing again.

### DIFF
--- a/samples/colab/test_notebooks.py
+++ b/samples/colab/test_notebooks.py
@@ -22,9 +22,7 @@ NOTEBOOKS_TO_SKIP = [
 ]
 
 NOTEBOOKS_EXPECTED_TO_FAIL = [
-    # Bug in iree-turbine==2.3.0rc20240410
-    #   `assert issubclass(type(mdl), CompiledModule)` (fixed in 2190a8a)
-    "pytorch_aot_advanced.ipynb",
+    # None!
 ]
 
 


### PR DESCRIPTION
This notebook is working again now that iree-turbine released an update (https://pypi.org/project/iree-turbine/#history):
https://github.com/iree-org/iree/actions/runs/8873175630/job/24358603849
`UNEXPECTED SUCCESS: test_pytorch_aot_advanced.ipynb (__main__.ColabNotebookTests.test_pytorch_aot_advanced.ipynb)`

skip-ci: not covered by presubmit CI