### PR TITLE
Add more unit tests for TileSizeSelection

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileSizeSelection.cpp
@@ -23,9 +23,10 @@ TilingConfig::TilingConfig(IREE::Codegen::LoweringConfigAttr lc)
   // scenarios:
   //   1. [[distribution]]
   //   2. [[distribution], [vector-common-parallel]]
-  //   3. [[distribution], [vector-common-parallel], [vector-reduction],
+  //   3. [[distribution], [vector-common-parallel], [vector-reduction]]
+  //   4. [[distribution], [vector-common-parallel], [vector-reduction],
   //       [vector-inner-parallel]]
-  //   4. [[distribution], [cache-parallel], [cache-reduction],
+  //   5. [[distribution], [cache-parallel], [cache-reduction],
   //       [vector-common-parallel], [vector-reduction],
   //       [vector-inner-parallel]]
   int numTileLevels = loweringConfig.getTilingLevels().size();


### PR DESCRIPTION
Adds unit tests for hooks that retrieve the actual level for the given
tiling level, e.g. `getDistributionLevel()`.

To improve code re-use, initialize of `LoweringConfig` is moved to a
dedicated hook, `initLoweringConfig`.

One death test is added to verify that an assertion is hit when
"out-of-bounds" tiling level is request.
