### PR TITLE
[CPU] Add new attribute to control peeling

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -19,16 +19,14 @@ def CPU_DoubleTilingPeelingExpert
     : I32EnumAttrCase<"CPUDoubleTilingPeelingExpert", 2>;
 def CPU_ConvTileAndDecomposeExpert
     : I32EnumAttrCase<"CPUConvTileAndDecomposeExpert", 3>;
-def CPU_ConvTileAndDecomposeAndPeelExpert
-    : I32EnumAttrCase<"CPUConvTileAndDecomposeAndPeelExpert", 4>;
 def CPU_Mmt4dTilingExpert
-    : I32EnumAttrCase<"Mmt4dTilingExpert", 5>;
+    : I32EnumAttrCase<"Mmt4dTilingExpert", 4>;
 def CPU_BufferOpsTileAndVectorize
-    : I32EnumAttrCase<"CPUBufferOpsTileAndVectorize", 6>;
+    : I32EnumAttrCase<"CPUBufferOpsTileAndVectorize", 5>;
 def CPU_DataTiling
-    : I32EnumAttrCase<"CPUDataTiling", 7>;
+    : I32EnumAttrCase<"CPUDataTiling", 6>;
 def CPU_LinalgExtTileAndVectorize
-    : I32EnumAttrCase<"CPULinalgExtTileAndVectorize", 8>;
+    : I32EnumAttrCase<"CPULinalgExtTileAndVectorize", 7>;
 
 def LLVMGPU_Default
     : I32EnumAttrCase<"LLVMGPUDefault", 100>;
@@ -85,7 +83,6 @@ def DispatchLoweringPassPipelineEnum : I32EnumAttr<
     // CPU CodeGen pipelines
     CPU_Default, CPU_DoubleTilingExpert,
     CPU_DoubleTilingPeelingExpert, CPU_ConvTileAndDecomposeExpert,
-    CPU_ConvTileAndDecomposeAndPeelExpert,
     CPU_Mmt4dTilingExpert, CPU_BufferOpsTileAndVectorize,
     CPU_DataTiling, CPU_LinalgExtTileAndVectorize,
 
@@ -130,7 +127,7 @@ def IREECodegen_TranslationInfoAttr :
   let description = [{
     Specifies the information that is used to drive the translation of
     an entry point function using Linalg based structured-op
-    lowering.. During executable translation this is attached to the
+    lowering. During executable translation this is attached to the
     `hal.executable.export` operation.
 
     If this operation is already set on the root operation (as part of

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -19,14 +19,16 @@ def CPU_DoubleTilingPeelingExpert
     : I32EnumAttrCase<"CPUDoubleTilingPeelingExpert", 2>;
 def CPU_ConvTileAndDecomposeExpert
     : I32EnumAttrCase<"CPUConvTileAndDecomposeExpert", 3>;
+def CPU_ConvTileAndDecomposeAndPeelExpert
+    : I32EnumAttrCase<"CPUConvTileAndDecomposeAndPeelExpert", 4>;
 def CPU_Mmt4dTilingExpert
-    : I32EnumAttrCase<"Mmt4dTilingExpert", 4>;
+    : I32EnumAttrCase<"Mmt4dTilingExpert", 5>;
 def CPU_BufferOpsTileAndVectorize
-    : I32EnumAttrCase<"CPUBufferOpsTileAndVectorize", 5>;
+    : I32EnumAttrCase<"CPUBufferOpsTileAndVectorize", 6>;
 def CPU_DataTiling
-    : I32EnumAttrCase<"CPUDataTiling", 6>;
+    : I32EnumAttrCase<"CPUDataTiling", 7>;
 def CPU_LinalgExtTileAndVectorize
-    : I32EnumAttrCase<"CPULinalgExtTileAndVectorize", 7>;
+    : I32EnumAttrCase<"CPULinalgExtTileAndVectorize", 8>;
 
 def LLVMGPU_Default
     : I32EnumAttrCase<"LLVMGPUDefault", 100>;
@@ -83,6 +85,7 @@ def DispatchLoweringPassPipelineEnum : I32EnumAttr<
     // CPU CodeGen pipelines
     CPU_Default, CPU_DoubleTilingExpert,
     CPU_DoubleTilingPeelingExpert, CPU_ConvTileAndDecomposeExpert,
+    CPU_ConvTileAndDecomposeAndPeelExpert,
     CPU_Mmt4dTilingExpert, CPU_BufferOpsTileAndVectorize,
     CPU_DataTiling, CPU_LinalgExtTileAndVectorize,
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -2184,10 +2184,10 @@ setConvRootConfig(mlir::FunctionOpInterface entryPointFn,
     // This will later be extracted by LLVMCPULowerExecutableTargetPass.
     auto context = convOp.getContext();
     auto enableLoopPeelingAttrName = getEnableLoopPeelingAttrName(context);
-    auto trueValue = BoolAttr::get(context, true);
+    auto unitAttr = UnitAttr::get(context);
     pipelineConfig = DictionaryAttr::get(
         context,
-        ArrayRef<NamedAttribute>({enableLoopPeelingAttrName, trueValue}));
+        ArrayRef<NamedAttribute>({enableLoopPeelingAttrName, unitAttr}));
   }
 
   return setOpConfigAndEntryPointFnTranslation(

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -2184,9 +2184,9 @@ setConvRootConfig(mlir::FunctionOpInterface entryPointFn,
     // This will later be extracted by LLVMCPULowerExecutableTargetPass.
     auto ctx = convOp.getContext();
     SmallVector<NamedAttribute> attrs;
-    auto peelAttrName = StringAttr::get(ctx, "enable_peeling");
+    auto peelAttrName = getPeelAttrName(ctx);
     auto peelAttrVal = BoolAttr::get(ctx, true);
-    attrs.push_back({peelAttrName, peelAttrVal});
+    attrs.emplace_back(peelAttrName, peelAttrVal);
     pipelineConfig = DictionaryAttr::get(ctx, attrs);
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -211,7 +211,7 @@ getVectorPreProcStrategy(linalg::LinalgOp linalgOp) {
     return clPProcStrategy;
   }
 
-  // TODO: Implement heurystics for Convs
+  // TODO: Implement heuristics for Convs
   if (isa<linalg::ConvolutionOpInterface>(linalgOp.getOperation())) {
     return VectorPreProcStrategy::None;
   }
@@ -2182,18 +2182,18 @@ setConvRootConfig(mlir::FunctionOpInterface entryPointFn,
   if (vecPreProcStrategy == VectorPreProcStrategy::Peeling) {
     // Enable peeling. To this end, attach extra info to the pipeline config.
     // This will later be extracted by LLVMCPULowerExecutableTargetPass.
-    auto ctx = convOp.getContext();
-    SmallVector<NamedAttribute> attrs;
-    auto peelAttrName = getPeelAttrName(ctx);
-    auto peelAttrVal = BoolAttr::get(ctx, true);
-    attrs.emplace_back(peelAttrName, peelAttrVal);
-    pipelineConfig = DictionaryAttr::get(ctx, attrs);
+    auto context = convOp.getContext();
+    auto enableLoopPeelingAttrName = getEnableLoopPeelingAttrName(context);
+    auto trueValue = BoolAttr::get(context, true);
+    pipelineConfig = DictionaryAttr::get(
+        context,
+        ArrayRef<NamedAttribute>({enableLoopPeelingAttrName, trueValue}));
   }
 
   return setOpConfigAndEntryPointFnTranslation(
       entryPointFn, convOp, tileSizes, scalableTileFlags,
-      DispatchLoweringPassPipeline::CPUConvTileAndDecomposeExpert, {}, {},
-      pipelineConfig);
+      DispatchLoweringPassPipeline::CPUConvTileAndDecomposeExpert,
+      /*workgroupSize=*/{}, /*subgroupSize=*/{}, pipelineConfig);
 }
 
 /// Main utility to compute the vectorization/unrolling tile sizes.

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -140,7 +140,7 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
   case IREE::Codegen::DispatchLoweringPassPipeline::
       CPUConvTileAndDecomposeExpert: {
     TilingConfig tilingConfig = getTilingConfigForPipeline(funcOp);
-    pipelineOpts.enablePeeling = isLoopPeelingEnabled(&funcOp);
+    pipelineOpts.enablePeeling = isLoopPeelingEnabled(funcOp);
     addConvTileAndDecomposeExpertPassPipeline(pipeline, tilingConfig,
                                               pipelineOpts);
     break;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -140,14 +140,16 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
   case IREE::Codegen::DispatchLoweringPassPipeline::
       CPUConvTileAndDecomposeExpert: {
     TilingConfig tilingConfig = getTilingConfigForPipeline(funcOp);
-    addConvTileAndDecomposeExpertPassPipeline(pipeline, tilingConfig,
-                                              pipelineOpts);
-    break;
-  }
-  case IREE::Codegen::DispatchLoweringPassPipeline::
-      CPUConvTileAndDecomposeAndPeelExpert: {
-    TilingConfig tilingConfig = getTilingConfigForPipeline(funcOp);
-    pipelineOpts.enablePeeling = true;
+    auto peelAttrName = StringAttr::get(funcOp.getContext(), "enable_peeling");
+    auto trueAttr = BoolAttr::get(funcOp.getContext(), true);
+
+    DictionaryAttr config = translationInfo.getConfiguration();
+    if (config) {
+      auto peelAttr = translationInfo.getConfiguration().getNamed(peelAttrName);
+      if (peelAttr && peelAttr->getValue() == trueAttr) {
+        pipelineOpts.enablePeeling = true;
+      }
+    }
     addConvTileAndDecomposeExpertPassPipeline(pipeline, tilingConfig,
                                               pipelineOpts);
     break;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -140,16 +140,7 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
   case IREE::Codegen::DispatchLoweringPassPipeline::
       CPUConvTileAndDecomposeExpert: {
     TilingConfig tilingConfig = getTilingConfigForPipeline(funcOp);
-    auto peelAttrName = StringAttr::get(funcOp.getContext(), "enable_peeling");
-    auto trueAttr = BoolAttr::get(funcOp.getContext(), true);
-
-    DictionaryAttr config = translationInfo.getConfiguration();
-    if (config) {
-      auto peelAttr = translationInfo.getConfiguration().getNamed(peelAttrName);
-      if (peelAttr && peelAttr->getValue() == trueAttr) {
-        pipelineOpts.enablePeeling = true;
-      }
-    }
+    pipelineOpts.enablePeeling = isLoopPeelingEnabled(&funcOp);
     addConvTileAndDecomposeExpertPassPipeline(pipeline, tilingConfig,
                                               pipelineOpts);
     break;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -144,6 +144,14 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
                                               pipelineOpts);
     break;
   }
+  case IREE::Codegen::DispatchLoweringPassPipeline::
+      CPUConvTileAndDecomposeAndPeelExpert: {
+    TilingConfig tilingConfig = getTilingConfigForPipeline(funcOp);
+    pipelineOpts.enablePeeling = true;
+    addConvTileAndDecomposeExpertPassPipeline(pipeline, tilingConfig,
+                                              pipelineOpts);
+    break;
+  }
   case IREE::Codegen::DispatchLoweringPassPipeline::Mmt4dTilingExpert: {
     TilingConfig tilingConfig = getTilingConfigForPipeline(funcOp);
     addMmt4dTilingExpertPassPipeline(pipeline, tilingConfig, pipelineOpts);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -446,6 +446,10 @@ void addConvTileAndDecomposeExpertPassPipeline(
   funcPassManager.addPass(createFuseTensorPadWithConsumerPass());
   funcPassManager.addPass(createConcretizePadResultShapePass());
 
+  if (pipelineOpt.enablePeeling) {
+    funcPassManager.addPass(createLLVMCPUPeelPass());
+  }
+
   {
     funcPassManager.addPass(createVectorizePadPass());
     GenericVectorizationPassOptions options;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy_peeling.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy_peeling.mlir
@@ -80,6 +80,7 @@ module {
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
 
 // -----
+
 #executable_target_system_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "system-elf-arm_64", {data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-linux-android30"}>
 module {
   func.func @depthwise_conv() attributes {hal.executable.target = #executable_target_system_elf_arm_64_} {
@@ -99,7 +100,7 @@ module {
 }
 
 //   CHECK-DAG: #[[CONFIG:.+]] =  #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 0, 2, 0, 0], [1, 1, 1, 2, 0, 0], [0, 0, 0, 0, 1, 4], [0, 0, 0, 0, 0, 0]]>
-//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUConvTileAndDecomposeAndPeelExpert>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUConvTileAndDecomposeExpert, {{\{}}enable_peeling = true}>
 //      CHECK: func.func @depthwise_conv()
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.depthwise_conv_2d_nhwc_hwc

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy_peeling.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy_peeling.mlir
@@ -100,7 +100,7 @@ module {
 }
 
 //   CHECK-DAG: #[[CONFIG:.+]] =  #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 0, 2, 0, 0], [1, 1, 1, 2, 0, 0], [0, 0, 0, 0, 1, 4], [0, 0, 0, 0, 0, 0]]>
-//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUConvTileAndDecomposeExpert, {{\{}}enable_peeling = true}>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUConvTileAndDecomposeExpert, {{\{}}enable_loop_peeling = true}>
 //      CHECK: func.func @depthwise_conv()
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.depthwise_conv_2d_nhwc_hwc

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy_peeling.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy_peeling.mlir
@@ -100,7 +100,7 @@ module {
 }
 
 //   CHECK-DAG: #[[CONFIG:.+]] =  #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 0, 2, 0, 0], [1, 1, 1, 2, 0, 0], [0, 0, 0, 0, 1, 4], [0, 0, 0, 0, 0, 0]]>
-//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUConvTileAndDecomposeExpert, {{\{}}enable_loop_peeling = true}>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUConvTileAndDecomposeExpert, {{\{}}enable_loop_peeling}>
 //      CHECK: func.func @depthwise_conv()
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.depthwise_conv_2d_nhwc_hwc

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy_peeling.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sve_lowering_strategy_peeling.mlir
@@ -78,3 +78,29 @@ module {
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.matmul
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
+
+// -----
+#executable_target_system_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "system-elf-arm_64", {data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-linux-android30"}>
+module {
+  func.func @depthwise_conv() attributes {hal.executable.target = #executable_target_system_elf_arm_64_} {
+    %cst = arith.constant 0.000000e+00 : f32
+    %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<1x1x4x4xf32>>
+    %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<1x4x4xf32>>
+    %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : !flow.dispatch.tensor<writeonly:tensor<1x1x1x4xf32>>
+    %input = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [1, 1, 4, 4], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<1x1x4x4xf32>> -> tensor<1x1x4x4xf32>
+    %filter = flow.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [1, 4, 4], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<1x4x4xf32>> -> tensor<1x4x4xf32>
+    %5 = tensor.empty() : tensor<1x1x1x4xf32>
+    %output = linalg.fill ins(%cst : f32) outs(%5 : tensor<1x1x1x4xf32>) -> tensor<1x1x1x4xf32>
+    %7 = linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : tensor<2xi64>,
+            strides = dense<1> : tensor<2xi64>} ins(%input, %filter : tensor<1x1x4x4xf32>, tensor<1x4x4xf32>) outs(%output : tensor<1x1x1x4xf32>) -> tensor<1x1x1x4xf32>
+    flow.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [1, 1, 1, 4], strides = [1, 1, 1, 1] : tensor<1x1x1x4xf32> -> !flow.dispatch.tensor<writeonly:tensor<1x1x1x4xf32>>
+    return
+  }
+}
+
+//   CHECK-DAG: #[[CONFIG:.+]] =  #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 0, 2, 0, 0], [1, 1, 1, 2, 0, 0], [0, 0, 0, 0, 1, 4], [0, 0, 0, 0, 0, 0]]>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUConvTileAndDecomposeAndPeelExpert>
+//      CHECK: func.func @depthwise_conv()
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//      CHECK: linalg.depthwise_conv_2d_nhwc_hwc
+// CHECK-SAME:     lowering_config = #[[CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.cpp
@@ -71,23 +71,17 @@ StringAttr getEnableLoopPeelingAttrName(MLIRContext *ctx) {
 }
 
 bool isLoopPeelingEnabled(FunctionOpInterface funcOp) {
-  auto peelAttrName = getEnableLoopPeelingAttrName(funcOp->getContext());
-  auto trueAttr = BoolAttr::get(funcOp->getContext(), true);
+  auto context = funcOp->getContext();
 
-  IREE::Codegen::TranslationInfoAttr translationInfo =
-      getTranslationInfo(funcOp);
-  DictionaryAttr config = translationInfo.getConfiguration();
+  DictionaryAttr config = getTranslationInfo(funcOp).getConfiguration();
 
   if (!config) {
     return false;
   }
 
-  auto peelAttr = translationInfo.getConfiguration().getNamed(peelAttrName);
-  if (peelAttr && peelAttr->getValue() == trueAttr) {
-    return true;
-  }
-
-  return false;
+  auto enableLoopPeelingAttrName = getEnableLoopPeelingAttrName(context);
+  auto enableLoopPeelingAttr = config.getNamed(enableLoopPeelingAttrName);
+  return enableLoopPeelingAttr.has_value() ? true : false;
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.cpp
@@ -73,11 +73,7 @@ StringAttr getEnableLoopPeelingAttrName(MLIRContext *ctx) {
 bool isLoopPeelingEnabled(FunctionOpInterface funcOp) {
   DictionaryAttr config = getTranslationInfo(funcOp).getConfiguration();
 
-  if (!config) {
-    return false;
-  }
-
-  return config.contains(kLoopPeelingAttrName);
+  return config && config.contains(kLoopPeelingAttrName);
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.cpp
@@ -71,17 +71,13 @@ StringAttr getEnableLoopPeelingAttrName(MLIRContext *ctx) {
 }
 
 bool isLoopPeelingEnabled(FunctionOpInterface funcOp) {
-  auto context = funcOp->getContext();
-
   DictionaryAttr config = getTranslationInfo(funcOp).getConfiguration();
 
   if (!config) {
     return false;
   }
 
-  auto enableLoopPeelingAttrName = getEnableLoopPeelingAttrName(context);
-  auto enableLoopPeelingAttr = config.getNamed(enableLoopPeelingAttrName);
-  return enableLoopPeelingAttr.has_value() ? true : false;
+  return config.contains(kLoopPeelingAttrName);
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.h
@@ -19,6 +19,15 @@ namespace mlir::iree_compiler {
 /// to the end of the function is the root op.
 FailureOr<Operation *> getRootOperation(ArrayRef<Operation *> computeOps);
 
+/// Creates a string attribute containing the name of the attribute that is
+/// used to enable loop peeling.
+StringAttr getPeelAttrName(MLIRContext *ctx);
+
+/// Checks whether loop peeling has been enabled for the input function. This
+/// is infered from the config dictt. attribute that's part of to the
+/// translation info corresponding to this funciton.
+bool isLoopPeelingEnabled(FunctionOpInterface *funcOp);
+
 } // namespace mlir::iree_compiler
 
 #endif // IREE_COMPILER_CODEGEN_UTILS_CPUUTILS_H_

--- a/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.h
@@ -21,12 +21,12 @@ FailureOr<Operation *> getRootOperation(ArrayRef<Operation *> computeOps);
 
 /// Creates a string attribute containing the name of the attribute that is
 /// used to enable loop peeling.
-StringAttr getPeelAttrName(MLIRContext *ctx);
+StringAttr getEnableLoopPeelingAttrName(MLIRContext *ctx);
 
 /// Checks whether loop peeling has been enabled for the input function. This
 /// is infered from the config dictt. attribute that's part of to the
 /// translation info corresponding to this funciton.
-bool isLoopPeelingEnabled(FunctionOpInterface *funcOp);
+bool isLoopPeelingEnabled(FunctionOpInterface funcOp);
 
 } // namespace mlir::iree_compiler
 


### PR DESCRIPTION
Adds a new CPU lowering config attribute, `enable_loop_peeling`,
to control whether to run the loop peeling pass before vectorisation.

Peeling is highly beneficial when using "scalable" vectorisation - it
helps to get rid of masking:
  * https://discourse.llvm.org/t/psa-scalable-auto-vec-in-linalg-without-masking/

Similarly to other Ops (most notably `linalg.matmul`), peeling is
enabled through "pre-processing". It's "off" by default and can be
enabled with:
  * --iree-llvmcpu-vector-pproc-strategy=peel