### PR TITLE
Add support for batch_matmul vector distribution with batch_size=1.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
@@ -212,6 +212,12 @@ struct DistributeContract final : OpDistributionPattern<vector::ContractionOp> {
          llvm::zip_equal(opDetail.lhsMDims, opDetail.outMDims)) {
       lhsOffsets[lhsM] = resultOffsets[resultM];
     }
+
+    if (opDetail.getBatchCount() == 1) {
+      rhsOffsets[0] = resultOffsets[0];
+      lhsOffsets[0] = resultOffsets[0];
+    }
+
     for (auto [rhsN, resultN] :
          llvm::zip_equal(opDetail.rhsNDims, opDetail.outNDims)) {
       rhsOffsets[rhsN] = resultOffsets[resultN];

--- a/compiler/src/iree/compiler/Codegen/Utils/VectorOpUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/VectorOpUtils.cpp
@@ -32,6 +32,16 @@ VectorContractOpInfo::inferOpKind(MLIRContext *ctx,
   if (contractionDims.k.size() != 1) {
     return OpKind::UNKNOWN;
   }
+  if (!contractionDims.batch.empty()) {
+    if (contractionDims.batch.size() > 1 || contractionDims.batch[0] != 0) {
+      return OpKind::UNKNOWN;
+    }
+    if (*maps[0].getResultPosition(getAffineDimExpr(0, ctx)) != 0 ||
+        *maps[1].getResultPosition(getAffineDimExpr(0, ctx)) != 0 ||
+        *maps[2].getResultPosition(getAffineDimExpr(0, ctx)) != 0) {
+      return OpKind::UNKNOWN;
+    }
+  }
 
   int64_t innerM = contractionDims.m.back();
   int64_t innerN = contractionDims.n.back();

--- a/compiler/src/iree/compiler/Codegen/Utils/VectorOpUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/VectorOpUtils.h
@@ -35,15 +35,20 @@ public:
   SmallVector<unsigned, 2> getNDims() const { return contractionDims.n; }
   SmallVector<unsigned, 2> getKDims() const { return contractionDims.k; }
 
-  int64_t getARank() {
-    return contractionDims.m.size() + contractionDims.k.size();
+  int64_t getARank() const {
+    return contractionDims.batch.size() + contractionDims.m.size() +
+           contractionDims.k.size();
   }
-  int64_t getBRank() {
-    return contractionDims.k.size() + contractionDims.n.size();
+  int64_t getBRank() const {
+    return contractionDims.batch.size() + contractionDims.k.size() +
+           contractionDims.n.size();
   }
-  int64_t getCRank() {
-    return contractionDims.m.size() + contractionDims.n.size();
+  int64_t getCRank() const {
+    return contractionDims.batch.size() + contractionDims.m.size() +
+           contractionDims.n.size();
   }
+
+  int64_t getBatchCount() const { return contractionDims.batch.size(); }
 
   SmallVector<int64_t> lhsMDims;
   int64_t lhsKDim;


### PR DESCRIPTION
The revision adds the support to distribute batch_matmul when the batch size is 1.

Co-authored-by: Quinn Dawkins <quinn.dawkins@gmail.com>