### PR TITLE
[runtime] Use IREE notifications as wait API when compiling with TSan

### DIFF
--- a/runtime/src/iree/base/internal/wait_handle.h
+++ b/runtime/src/iree/base/internal/wait_handle.h
@@ -164,7 +164,7 @@ iree_status_t iree_wait_all(iree_wait_set_t* set, iree_time_t deadline_ns);
 // A deadline of IREE_TIME_INFINITE_PAST will act as a poll and not block the
 // caller. IREE_TIME_INFINITE_FUTURE can be used to block until signaled.
 //
-// Returns success if all handles were signaled either prior to the call or
+// Returns success if any handles were signaled either prior to the call or
 // during the wait. A handle of one of the signaled handles will be returned in
 // the optional |out_wake_handle| argument; note however that one or more
 // handles may have signaled and which handle is returned is unspecified.

--- a/runtime/src/iree/base/internal/wait_handle_emscripten.c
+++ b/runtime/src/iree/base/internal/wait_handle_emscripten.c
@@ -135,5 +135,5 @@ void iree_event_reset(iree_event_t* event) {
   iree_wait_primitive_promise_reset(event->value.promise.handle);
 }
 
-#endif  // IREE_WAIT_API == IREE_WAIT_API_INPROC &&
+#endif  // IREE_WAIT_API == IREE_WAIT_API_PROMISE &&
         // defined(IREE_PLATFORM_EMSCRIPTEN)

--- a/runtime/src/iree/base/internal/wait_handle_impl.h
+++ b/runtime/src/iree/base/internal/wait_handle_impl.h
@@ -47,8 +47,13 @@
 // try to guess based on the target platform.
 #if !defined(IREE_WAIT_API)
 
+#if defined(IREE_SANITIZER_THREAD)
+// TSan does not support poll, ppoll, etc., which will cause it to report false
+// positives.
+// TODO: add TSan instrumentation for the other wait methods.
+#define IREE_WAIT_API IREE_WAIT_API_INPROC
 // NOTE: we could be tighter here, but we today only have win32 or not-win32.
-#if IREE_SYNCHRONIZATION_DISABLE_UNSAFE
+#elif IREE_SYNCHRONIZATION_DISABLE_UNSAFE
 #define IREE_WAIT_API IREE_WAIT_API_NULL
 #elif defined(IREE_PLATFORM_EMSCRIPTEN)
 #define IREE_WAIT_API IREE_WAIT_API_PROMISE

--- a/runtime/src/iree/base/internal/wait_handle_inproc.c
+++ b/runtime/src/iree/base/internal/wait_handle_inproc.c
@@ -285,7 +285,7 @@ iree_status_t iree_wait_all(iree_wait_set_t* set, iree_time_t deadline_ns) {
 iree_status_t iree_wait_any(iree_wait_set_t* set, iree_time_t deadline_ns,
                             iree_wait_handle_t* out_wake_handle) {
   IREE_TRACE_ZONE_BEGIN(z0);
-  memset(out_wake_handle, 0, sizeof(*out_wake_handle));
+  if (out_wake_handle) memset(out_wake_handle, 0, sizeof(*out_wake_handle));
   iree_status_t status = iree_wait_multi(set, deadline_ns, out_wake_handle);
   IREE_TRACE_ZONE_END(z0);
   return status;


### PR DESCRIPTION
This makes semaphore waiting/signaling more TSan friendly to avoid false positives.

There are some tests that hang with this wait API backend. For example some tests in hip_stream_semaphore_submission_test.