### PR TITLE
Fixes to passes for custom dispatch to work with bf16 type

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
@@ -13,6 +13,7 @@
 
 #include "iree/compiler/Codegen/Common/PassDetail.h"
 #include "iree/compiler/Codegen/Common/Passes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
 #include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "iree/compiler/Utils/ConversionUtils.h"
@@ -268,7 +269,8 @@ struct ConvertBf16ToUInt16BuffersPass final
       target.addLegalOp<arith::TruncFOp, arith::ExtFOp, ModuleOp>();
       target.addDynamicallyLegalDialect<arith::ArithDialect, func::FuncDialect,
                                         IREE::HAL::HALDialect,
-                                        memref::MemRefDialect, scf::SCFDialect>(
+                                        memref::MemRefDialect, scf::SCFDialect,
+                                        IREE::Codegen::IREECodegenDialect>(
           [&typeConverter](Operation *op) {
             bool legal = typeConverter.isLegal(op);
             LLVM_DEBUG(if (!legal) llvm::dbgs()

--- a/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
@@ -14,6 +14,7 @@
 #include "iree/compiler/Codegen/Transforms/Transforms.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
@@ -243,7 +244,7 @@ struct IREEExpandStridedMetadataPass
     : public IREEExpandStridedMetadataBase<IREEExpandStridedMetadataPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<affine::AffineDialect, arith::ArithDialect,
-                    IREE::Codegen::IREECodegenDialect>();
+                    IREE::Codegen::IREECodegenDialect, memref::MemRefDialect>();
   }
 
   void runOnOperation() override;


### PR DESCRIPTION
Custom dispatch for bf16 type stopped working because of a couple of problems:

1. `--iree-codegen-expand-strided-metadata` doesn't work with `iree-opt` when given an `iree_codegen.extract_strided_metadata` op due to a lack of a dependency on the `memref` dialect.
2. `--iree-convert-bf16-to-uint16-buffers` doesn't convert types in an `iree_codegen.extract_strided_metadata` op due to a lack of a dependency on the `iree_codegen` dialect.  As a result, type casts are introduced between the `iree_codegen.extract_strided_metadata` and its `hal.interface.binding.subspan` predecessor, which confuses `--iree-codegen-expand-strided-metadata`, which fails to do its job of eliminating the `iree_codegen.extract_strided_metadata`.  This second problem was described in https://github.com/iree-org/iree/issues/17177.

The fix for both problems is to add the missing dialect dependencies.

fixes: https://github.com/iree-org/iree/issues/17177