### PR TITLE
[runtime][vulkan][cts] Disable flaky test WaitForFiniteTime on Android

### DIFF
--- a/runtime/src/iree/hal/drivers/vulkan/cts/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/vulkan/cts/CMakeLists.txt
@@ -4,6 +4,12 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+unset(ADDITIONAL_TEST_ARGS)
+if(ANDROID)
+  # Disable this test due to flaky failures on Google Pixel 6 Pro.
+  set(ADDITIONAL_TEST_ARGS "--gtest_filter=-*WaitForFiniteTime*")
+endif()
+
 iree_hal_cts_test_suite(
   DRIVER_NAME
     vulkan
@@ -21,4 +27,6 @@ iree_hal_cts_test_suite(
     "semaphore_submission"  # SubmitWithWait hangs (requires async)
   LABELS
     driver=vulkan
+  ARGS
+    ${ADDITIONAL_TEST_ARGS}
 )

--- a/runtime/src/iree/hal/drivers/vulkan/cts/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/vulkan/cts/CMakeLists.txt
@@ -6,7 +6,8 @@
 
 unset(ADDITIONAL_TEST_ARGS)
 if(ANDROID)
-  # Disable this test due to flaky failures on Google Pixel 6 Pro.
+  # Disable this test on Android due to flaky failures on Google Pixel 6 Pro
+  # and Moto Edge X30.
   set(ADDITIONAL_TEST_ARGS "--gtest_filter=-*WaitForFiniteTime*")
 endif()
 


### PR DESCRIPTION
This test is flaky on Google Pixel 6 Pro.
On other Vulkan backends it does not fail.
There is high likelihood that the Vulkan implementation on Pixel 6 Pro is broken.