### PR TITLE
Fix spelling of MLIR "GPUPasses" library.

### DIFF
--- a/compiler/setup.py
+++ b/compiler/setup.py
@@ -436,7 +436,7 @@ setup(
         # it also needs to be enabled on the build side.
         # CMakeExtension("iree.compiler._mlir_libs._mlirHlo"),
         CMakeExtension("iree.compiler._mlir_libs._mlirLinalgPasses"),
-        CMakeExtension("iree.compiler._mlir_libs._mlirGpuPasses"),
+        CMakeExtension("iree.compiler._mlir_libs._mlirGPUPasses"),
         CMakeExtension("iree.compiler._mlir_libs._site_initialize_0"),
     ],
     cmdclass={


### PR DESCRIPTION
Currently local build with `setup.py` (`pip install -e .`) fails at link step on the OSes that have cases sensitive file system. I.e. macOS works, Linux (Ubuntu on `ext4`, for example) fails. The correct spelling is `GPUPasses`, see it [here](https://github.com/llvm/llvm-project/blob/987c036f5413a94aab58bd5e27b653f740a5f7e2/mlir/python/CMakeLists.txt#L619) how it's defined in MLIR. 