### PR TITLE
[Codegen] Add op for copying tensor operands

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -154,6 +154,43 @@ def ApplyUnrollVectorsGpuWmmaSyncPatternsOp : Op<Transform_Dialect,
   let assemblyFormat = "attr-dict";
 }
 
+def CopyTensorOperandOp :  Op<Transform_Dialect, "iree.copy_tensor_operand",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     FunctionalStyleTransformOpTrait,
+     TransformEachOpTrait,
+     TransformOpInterface,
+     ReportTrackingListenerFailuresOpTrait]> {
+  let summary = "Hoist static allocations";
+  let description = [{
+    Inserts a copy of the specified operand of the target operation.
+
+    #### Return modes
+    Returns a handle to the new copy.
+
+    It does not consume the target handle and emits a definite failure if the
+    operand index is out of range or if the operand is not a tensor type.
+  }];
+
+  let arguments = (ins
+    TransformHandleTypeInterface:$target,
+    I64Attr:$operand_index);
+  let results = (outs TransformHandleTypeInterface:$result);
+
+  let assemblyFormat = [{
+    $target `[` $operand_index `]` attr-dict
+    `:` functional-type(operands, results)
+  }];
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::transform::TransformRewriter &rewriter,
+        ::mlir::Operation *target,
+        ::mlir::transform::ApplyToEachResultList &results,
+        ::mlir::transform::TransformState &state);
+  }];
+}
+
 def GpuDistributeSharedMemoryCopyOp :
   Op<Transform_Dialect, "iree.gpu_distribute_shared_memory_copy",
     [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -65,6 +65,7 @@ iree_lit_test_suite(
             "test_partitionable_loops_interface.mlir",
             "tile_and_distribute_to_workgroups.mlir",
             "transform_buffer_opt.mlir",
+            "transform_copy_operand.mlir",
             "transform_match_partial_reduction.mlir",
             "transform_ops_invalid.mlir",
             "transpose_canonicalization.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -61,6 +61,7 @@ iree_lit_test_suite(
     "test_partitionable_loops_interface.mlir"
     "tile_and_distribute_to_workgroups.mlir"
     "transform_buffer_opt.mlir"
+    "transform_copy_operand.mlir"
     "transform_match_partial_reduction.mlir"
     "transform_ops_invalid.mlir"
     "transpose_canonicalization.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/transform_copy_operand.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/transform_copy_operand.mlir
@@ -1,0 +1,22 @@
+// RUN: iree-opt %s -iree-transform-dialect-interpreter -transform-dialect-drop-schedule --split-input-file | FileCheck %s
+
+func.func @main(%arg0: tensor<?xf32>) -> tensor<?xf32> {
+  return %arg0 : tensor<?xf32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["func.return"]} in %root : (!transform.any_op) -> !transform.any_op
+    transform.iree.copy_tensor_operand %0 [0] : (!transform.any_op) -> (!transform.any_op)
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: @main
+//  CHECK-SAME:   (%[[ARG:.+]]: tensor<?xf32>)
+//       CHECK:   %[[DIM:.+]] = tensor.dim %[[ARG]], %c0 : tensor<?xf32>
+//       CHECK:   %[[EMPTY:.+]] = tensor.empty(%[[DIM]]) : tensor<?xf32>
+//       CHECK:   %[[COPY:.+]] = linalg.copy
+//  CHECK-SAME:     ins(%[[ARG]] : tensor<?xf32>)
+//  CHECK-SAME:     outs(%[[EMPTY]] : tensor<?xf32>)
+//       CHECK:   return %[[COPY]] : tensor<?xf32>


### PR DESCRIPTION
This is useful for providing an anchor to tile a copy of a particular tensor operand. The advantage of this over alternatives like pad and pack is that it does not require any fixup operations on the destination of a linalg op.