### PR TITLE
Fixing threading test reported by TSAN.

### DIFF
--- a/runtime/src/iree/base/internal/threading_test.cc
+++ b/runtime/src/iree/base/internal/threading_test.cc
@@ -111,8 +111,8 @@ TEST(ThreadTest, CreateSuspended) {
                                       iree_memory_order_relaxed) == (123 + 1);
       },
       &entry_data, iree_infinite_timeout());
-  iree_notification_deinitialize(&entry_data.barrier);
   iree_thread_release(thread);
+  iree_notification_deinitialize(&entry_data.barrier);
 }
 
 // NOTE: testing whether priority took effect is really hard given that on


### PR DESCRIPTION
Found here: https://github.com/iree-org/iree/actions/runs/8914840398/job/24483271590#step:4:14211
The thread must be joined prior to deinitializing the notification.