### PR TITLE
Fix runtime trace console provider dependency

### DIFF
--- a/runtime/src/iree/base/CMakeLists.txt
+++ b/runtime/src/iree/base/CMakeLists.txt
@@ -35,7 +35,6 @@ iree_cc_library(
     "wait_source.h"
   DEPS
     ::core_headers
-    iree::base::tracing::provider
   PUBLIC
 )
 

--- a/runtime/src/iree/base/tracing/CMakeLists.txt
+++ b/runtime/src/iree/base/tracing/CMakeLists.txt
@@ -18,6 +18,7 @@ if(${IREE_TRACING_PROVIDER} STREQUAL "console")
     SRCS
       "console.c"
     DEPS
+      iree::base::base
       iree::base::core_headers
     DEFINES
       "IREE_TRACING_PROVIDER_H=\"iree/base/tracing/console.h\""


### PR DESCRIPTION
This PR fix the undefined reference to `iree_time_now`  in https://github.com/iree-org/iree/pull/16454.

The console tracy provider should depend on `iree::base::base` library.