### PR TITLE
Deprecate `--iree-preprocessing-transpose-matmul`

### DIFF
--- a/compiler/src/iree/compiler/Pipelines/Options.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Options.cpp
@@ -246,6 +246,8 @@ void PreprocessingOptions::bindOptions(OptionsBinder &binder) {
           "File name of a transform dialect spec to use for preprocessing"),
       llvm::cl::cat(category));
 
+  // @andwar02 - deprecated, use `--iree-preprocessing-pass-pipeline` instead
+  // TODO: Remove once all users have switched
   binder.opt<TransposeMatmulInput>(
       "iree-preprocessing-transpose-matmul", preprocessingTransposeMatmulInput,
       llvm::cl::desc("Convert Linalg matmul ops to transposed variants."),

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/transpose_matmul.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/transpose_matmul.mlir
@@ -1,9 +1,6 @@
-// RUN: iree-compile --iree-preprocessing-pass-pipeline="builtin.module(util.func(iree-preprocessing-transpose-matmul-pass{input=lhs}))" \
-// RUN:   --iree-hal-target-backends=llvm-cpu --compile-to=preprocessing %s  | FileCheck %s --check-prefixes=CHECK,LHS
-// RUN: iree-compile --iree-preprocessing-pass-pipeline="builtin.module(util.func(iree-preprocessing-transpose-matmul-pass{input=rhs}))" \
-// RUN:   --iree-hal-target-backends=llvm-cpu --compile-to=preprocessing %s  | FileCheck %s --check-prefixes=CHECK,RHS
-// RUN: iree-compile --iree-preprocessing-pass-pipeline="builtin.module(util.func(iree-preprocessing-transpose-matmul-pass))" \
-// RUN:   --iree-hal-target-backends=llvm-cpu --compile-to=preprocessing %s  | FileCheck %s --check-prefixes=CHECK,DISABLED
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-preprocessing-transpose-matmul-pass{input=lhs}))" %s | FileCheck %s --check-prefixes=CHECK,LHS
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-preprocessing-transpose-matmul-pass{input=rhs}))" %s | FileCheck %s --check-prefixes=CHECK,RHS
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-preprocessing-transpose-matmul-pass))" %s | FileCheck %s --check-prefixes=CHECK,DISABLED
 
 // CHECK-LABEL: @matmul
 // LHS: linalg.matmul_transpose_a

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/transpose_matmul.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/transpose_matmul.mlir
@@ -1,6 +1,9 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-preprocessing-transpose-matmul-pass{input=lhs}))" %s | FileCheck %s --check-prefixes=CHECK,LHS
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-preprocessing-transpose-matmul-pass{input=rhs}))" %s | FileCheck %s --check-prefixes=CHECK,RHS
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-preprocessing-transpose-matmul-pass))" %s | FileCheck %s --check-prefixes=CHECK,DISABLED
+// RUN: iree-compile --iree-preprocessing-pass-pipeline="builtin.module(util.func(iree-preprocessing-transpose-matmul-pass{input=lhs}))" \
+// RUN:   --iree-hal-target-backends=llvm-cpu --compile-to=preprocessing %s  | FileCheck %s --check-prefixes=CHECK,LHS
+// RUN: iree-compile --iree-preprocessing-pass-pipeline="builtin.module(util.func(iree-preprocessing-transpose-matmul-pass{input=rhs}))" \
+// RUN:   --iree-hal-target-backends=llvm-cpu --compile-to=preprocessing %s  | FileCheck %s --check-prefixes=CHECK,RHS
+// RUN: iree-compile --iree-preprocessing-pass-pipeline="builtin.module(util.func(iree-preprocessing-transpose-matmul-pass))" \
+// RUN:   --iree-hal-target-backends=llvm-cpu --compile-to=preprocessing %s  | FileCheck %s --check-prefixes=CHECK,DISABLED
 
 // CHECK-LABEL: @matmul
 // LHS: linalg.matmul_transpose_a


### PR DESCRIPTION
This is a follow-up for #17157. As per post-commit PR comment, we are
,removing `--iree-preprocessing-transpose-matmul`. Instead, you can use:
  * ` --iree-preprocessing-pass-pipeline="builtin.module(util.func(iree-preprocessing-transpose-matmul-pass{input=lhs}))"`

The removal will be done in two stages to facilitate CI update:
  1. Deprecate the flag and update tests to use
     `--iree-preprocessing-pass-pipeline` instead,
  2. Remove the flag.

This PR is step 1.
