### PR TITLE
[Winograd] Fix element type bug for Conv2DToWinograd with mixed types

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConv2DToWinograd.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConv2DToWinograd.cpp
@@ -187,7 +187,10 @@ public:
                                          "Winograd only supports 3x3 filters");
     }
     assert(kernelShape.size() == 4);
-    Type elementType = kernelType.getElementType();
+    Type inElemType = kernelType.getElementType();
+    Value output = convOp.getOutputs()[0];
+    auto outputType = cast<RankedTensorType>(output.getType());
+    Type outElemType = outputType.getElementType();
 
     const int64_t kernelSize = 3;
     const int64_t inputTileSize = outputTileSize + kernelSize - 1;
@@ -199,7 +202,7 @@ public:
     filterResultShape[2] = isNchwFchw ? kernelShape[1] : kernelShape[2];
     filterResultShape[3] = isNchwFchw ? kernelShape[0] : kernelShape[3];
     Value kernelInit =
-        rewriter.create<tensor::EmptyOp>(loc, filterResultShape, elementType);
+        rewriter.create<tensor::EmptyOp>(loc, filterResultShape, inElemType);
     const std::array<int64_t, 2> kernelDims =
         isNchwFchw ? fchwKernelDims : hwcfKernelDims;
     Value winogradFilter =
@@ -220,8 +223,6 @@ public:
                        filterReassociations);
 
     // Create winograd input transform op.
-    Value zero = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getZeroAttr(elementType));
     Value input = convOp.getInputs()[0];
     auto inputType = cast<ShapedType>(input.getType());
     if (!inputType) {
@@ -253,7 +254,7 @@ public:
       }
     }
     Value emptyTensor =
-        rewriter.create<tensor::EmptyOp>(loc, resultShape, elementType);
+        rewriter.create<tensor::EmptyOp>(loc, resultShape, inElemType);
     const std::array<int64_t, 2> imageDims =
         isNchwFchw ? nchwImageDims : nhwcImageDims;
     Value winogradInput =
@@ -273,15 +274,15 @@ public:
 
     // Add BatchMatmulOp
     SmallVector<int64_t> bmmShape(collapsedShape.begin(), collapsedShape.end());
-    Value output = convOp.getOutputs()[0];
-    auto outputType = cast<RankedTensorType>(output.getType());
     SmallVector<int64_t> outputShape(outputType.getShape());
     if (isNchwFchw) {
       permute<IREE::LinalgExt::Permutation::NCHW_TO_NHWC>(outputShape);
     }
     bmmShape[2] = outputShape[3];
-    auto bmmOutputType = RankedTensorType::get(bmmShape, elementType);
-    emptyTensor = rewriter.create<tensor::EmptyOp>(loc, bmmShape, elementType);
+    auto bmmOutputType = RankedTensorType::get(bmmShape, outElemType);
+    emptyTensor = rewriter.create<tensor::EmptyOp>(loc, bmmShape, outElemType);
+    Value zero = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getZeroAttr(outElemType));
     auto fillOp = rewriter.create<linalg::FillOp>(loc, ValueRange{zero},
                                                   ValueRange{emptyTensor});
     auto bmmOp = rewriter.create<linalg::BatchMatmulOp>(
@@ -311,7 +312,7 @@ public:
       permute<IREE::LinalgExt::Permutation::NHWC_TO_NCHW>(paddedResultShape);
     }
     emptyTensor =
-        rewriter.create<tensor::EmptyOp>(loc, paddedResultShape, elementType);
+        rewriter.create<tensor::EmptyOp>(loc, paddedResultShape, outElemType);
     Value paddedOutput =
         rewriter
             .create<IREE::LinalgExt::WinogradOutputTransformOp>(

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv2d_to_winograd.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv2d_to_winograd.mlir
@@ -88,14 +88,14 @@ func.func @conv_16433136_nchw_fchw(%arg0: tensor<1x4x16x16xf32>, %arg1: tensor<1
 
 // -----
 
-func.func @conv_promoted(%arg0: tensor<1x16x16x4xf16>, %arg1: tensor<3x3x4x16xf16>, %arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32> {
+func.func @conv_mixed_types(%arg0: tensor<1x16x16x4xf16>, %arg1: tensor<3x3x4x16xf16>, %arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32> {
   %0 = linalg.conv_2d_nhwc_hwcf
     {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64> }
      ins(%arg0, %arg1: tensor<1x16x16x4xf16>, tensor<3x3x4x16xf16>)
     outs(%arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32>
   return %0 : tensor<1x14x14x16xf32>
 }
-// CHECK:      func.func @conv_promoted(
+// CHECK:      func.func @conv_mixed_types(
 // CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x16x16x4xf16>
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<3x3x4x16xf16>
 // CHECK-DAG:    %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv2d_to_winograd.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv2d_to_winograd.mlir
@@ -85,3 +85,47 @@ func.func @conv_16433136_nchw_fchw(%arg0: tensor<1x4x16x16xf32>, %arg1: tensor<1
 // CHECK-SAME:     tensor<1x16x18x18xf32> to tensor<1x16x14x14xf32>
 // CHECK:        return %[[EXTRACTED_SLICE]] : tensor<1x16x14x14xf32>
 // CHECK:      }
+
+// -----
+
+func.func @conv_promoted(%arg0: tensor<1x16x16x4xf16>, %arg1: tensor<3x3x4x16xf16>, %arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32> {
+  %0 = linalg.conv_2d_nhwc_hwcf
+    {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64> }
+     ins(%arg0, %arg1: tensor<1x16x16x4xf16>, tensor<3x3x4x16xf16>)
+    outs(%arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32>
+  return %0 : tensor<1x14x14x16xf32>
+}
+// CHECK:      func.func @conv_promoted(
+// CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x16x16x4xf16>
+// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<3x3x4x16xf16>
+// CHECK-DAG:    %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:    %[[EMPTY0:.+]] = tensor.empty() : tensor<8x8x4x16xf16>
+// CHECK:        %[[FILTER_TF:.+]] = iree_linalg_ext.winograd.filter_transform output_tile_size(6) kernel_size(3)
+// CHECK-SAME:     kernel_dimensions([0, 1]) ins(%[[ARG1]] : tensor<3x3x4x16xf16>) outs(%[[EMPTY0]] :
+// CHECK-SAME:     tensor<8x8x4x16xf16>) -> tensor<8x8x4x16xf16>
+// CHECK:        %[[COLLAPSED_FILTER:.+]] = tensor.collapse_shape %[[FILTER_TF]]
+// CHECK-SAME{LITERAL}:  [[0, 1], [2], [3]]
+// CHECK-SAME:           tensor<8x8x4x16xf16> into tensor<64x4x16xf16>
+// CHECK:        %[[EMPTY1:.+]] = tensor.empty() : tensor<8x8x1x3x3x4xf16>
+// CHECK:        %[[INPUT_TF:.+]] = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3)
+// CHECK-SAME:     image_dimensions([1, 2]) ins(%[[ARG0]] : tensor<1x16x16x4xf16>) outs(%[[EMPTY1]] :
+// CHECK-SAME:     tensor<8x8x1x3x3x4xf16>) -> tensor<8x8x1x3x3x4xf16>
+// CHECK:        %[[COLLAPSED_INPUT:.+]] = tensor.collapse_shape %[[INPUT_TF]]
+// CHECK-SAME{LITERAL}:  [[0, 1], [2, 3, 4], [5]]
+// CHECK-SAME:           tensor<8x8x1x3x3x4xf16> into tensor<64x9x4xf16>
+// CHECK:        %[[EMPTY2:.+]] = tensor.empty() : tensor<64x9x16xf32>
+// CHECK:        %[[FILL:.+]] = linalg.fill ins(%[[ZERO]] : f32) outs(%[[EMPTY2]] : tensor<64x9x16xf32>) ->
+// CHECK-SAME:     tensor<64x9x16xf32>
+// CHECK:        %[[BMM:.+]] = linalg.batch_matmul ins(%[[COLLAPSED_INPUT]], %[[COLLAPSED_FILTER]] : tensor<64x9x4xf16>,
+// CHECK-SAME:     tensor<64x4x16xf16>) outs(%[[FILL]] : tensor<64x9x16xf32>) -> tensor<64x9x16xf32>
+// CHECK:        %[[EXPANDED:.+]] = tensor.expand_shape %[[BMM]]
+// CHECK-SAME{LITERAL}: [[0, 1], [2, 3, 4], [5]]
+// CHECK-SAME:          tensor<64x9x16xf32> into tensor<8x8x1x3x3x16xf32>
+// CHECK:        %[[EMPTY3:.+]] = tensor.empty() : tensor<1x18x18x16xf32>
+// CHECK:        %[[OUTPUT_TF:.+]] = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3)
+// CHECK-SAME:     image_dimensions([1, 2]) ins(%[[EXPANDED]] : tensor<8x8x1x3x3x16xf32>) outs(%[[EMPTY3]] :
+// CHECK-SAME:     tensor<1x18x18x16xf32>) -> tensor<1x18x18x16xf32>
+// CHECK:        %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[OUTPUT_TF]][0, 0, 0, 0] [1, 14, 14, 16] [1, 1, 1, 1] :
+// CHECK-SAME:     tensor<1x18x18x16xf32> to tensor<1x14x14x16xf32>
+// CHECK:        return %[[EXTRACTED_SLICE]] : tensor<1x14x14x16xf32>
+// CHECK:      }


### PR DESCRIPTION
The Conv2DToWinograd transform does not account for promotion of element types. This PR fixes the bug by doing promotion in the resulting batch_matmul op.