### PR TITLE
[runtime][hal][hip] Implement collectives via RCCL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -919,6 +919,10 @@ if(IREE_HAL_DRIVER_CUDA)
   add_subdirectory(build_tools/third_party/nccl EXCLUDE_FROM_ALL)
 endif()
 
+if(IREE_HAL_DRIVER_HIP)
+  add_subdirectory(build_tools/third_party/rccl EXCLUDE_FROM_ALL)
+endif()
+
 if(IREE_HAL_DRIVER_VULKAN)
   add_subdirectory(third_party/vulkan_headers EXCLUDE_FROM_ALL)
   iree_install_targets(

--- a/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
@@ -96,6 +96,10 @@ class TargetConverter:
                 "@nccl//:headers": [
                     "nccl::headers",
                 ],
+                # RCCL
+                "@rccl//:headers": [
+                    "rccl::headers",
+                ],
                 # Tracy.
                 "@tracy_client//:runtime": ["tracy_client::runtime"],
                 # Vulkan

--- a/build_tools/third_party/rccl/BUILD.overlay
+++ b/build_tools/third_party/rccl/BUILD.overlay
@@ -1,0 +1,13 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "headers",
+    hdrs = ["rccl.h",],
+    include_prefix = "third_party/rccl",
+)

--- a/build_tools/third_party/rccl/CMakeLists.txt
+++ b/build_tools/third_party/rccl/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# We don't install any headers because their only use is in built code
+# (not public).
+set(IREE_HDRS_ROOT_PATH OFF)
+# Considered part of the runtime. See runtime/src/CMakeLists.txt.
+set(IREE_INSTALL_LIBRARY_TARGETS_DEFAULT_COMPONENT IREEDevLibraries)
+set(IREE_INSTALL_LIBRARY_TARGETS_DEFAULT_EXPORT_SET Runtime)
+
+set(RCCL_SOURCE_DIR
+  "${IREE_SOURCE_DIR}/third_party/rccl/"
+)
+
+external_cc_library(
+  PACKAGE
+    rccl
+  NAME
+    headers
+  ROOT
+    "${RCCL_SOURCE_DIR}"
+  INCLUDES
+    "${RCCL_SOURCE_DIR}"
+  PUBLIC
+)

--- a/experimental/rocm/dynamic_symbols_test.cc
+++ b/experimental/rocm/dynamic_symbols_test.cc
@@ -27,8 +27,7 @@ TEST(DynamicSymbolsTest, CreateFromSystemLoader) {
   iree_status_t status = iree_hal_rocm_dynamic_symbols_initialize(
       iree_allocator_system(), &symbols);
   if (!iree_status_is_ok(status)) {
-    std::cerr << "Symbols cannot be loaded, skipping test.";
-    GTEST_SKIP();
+    GTEST_SKIP() << "Symbols cannot be loaded, skipping test.";
   }
 
   int device_count = 0;

--- a/runtime/src/iree/hal/drivers/cuda/cuda_driver.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_driver.c
@@ -34,7 +34,7 @@ typedef struct iree_hal_cuda_driver_t {
   iree_string_view_t identifier;
   // CUDA driver API dynamic symbols to interact with the CUDA system.
   iree_hal_cuda_dynamic_symbols_t cuda_symbols;
-  // NCCL API dynamic symbols to interact with the CUDA system.
+  // NCCL API dynamic symbols to use collectives (multi-gpu/multi-node).
   iree_hal_cuda_nccl_dynamic_symbols_t nccl_symbols;
 
   // The default parameters for creating devices using this driver.

--- a/runtime/src/iree/hal/drivers/cuda/dynamic_symbols_test.cc
+++ b/runtime/src/iree/hal/drivers/cuda/dynamic_symbols_test.cc
@@ -29,8 +29,7 @@ TEST(DynamicSymbolsTest, CreateFromSystemLoader) {
   if (!iree_status_is_ok(status)) {
     iree_status_fprint(stderr, status);
     iree_status_ignore(status);
-    std::cerr << "Symbols cannot be loaded, skipping test.";
-    GTEST_SKIP();
+    GTEST_SKIP() << "Symbols cannot be loaded, skipping test.";
   }
 
   int device_count = 0;
@@ -57,8 +56,7 @@ TEST(NCCLDynamicSymbolsTest, CreateFromSystemLoader) {
   if (!iree_status_is_ok(status)) {
     iree_status_fprint(stderr, status);
     iree_status_ignore(status);
-    std::cerr << "CUDA symbols cannot be loaded, skipping test.";
-    GTEST_SKIP();
+    GTEST_SKIP() << "CUDA symbols cannot be loaded, skipping test.";
   }
 
   iree_hal_cuda_nccl_dynamic_symbols_t nccl_symbols;
@@ -67,8 +65,7 @@ TEST(NCCLDynamicSymbolsTest, CreateFromSystemLoader) {
   if (!iree_status_is_ok(status)) {
     iree_status_fprint(stderr, status);
     iree_status_ignore(status);
-    std::cerr << "CUDA NCCL symbols cannot be loaded, skipping test.";
-    GTEST_SKIP();
+    GTEST_SKIP() << "CUDA NCCL symbols cannot be loaded, skipping test.";
   }
 
   int nccl_version = 0;

--- a/runtime/src/iree/hal/drivers/hip/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/hip/CMakeLists.txt
@@ -44,6 +44,8 @@ iree_cc_library(
     "pending_queue_actions.h"
     "pipeline_layout.c"
     "pipeline_layout.h"
+    "rccl_channel.c"
+    "rccl_channel.h"
     "stream_command_buffer.c"
     "stream_command_buffer.h"
     "timepoint_pool.c"
@@ -82,18 +84,24 @@ iree_cc_library(
   HDRS
     "dynamic_symbols.h"
     "status_util.h"
+    "rccl_dynamic_symbols.h"
+    "rccl_status_util.h"
   TEXTUAL_HDRS
     "dynamic_symbol_tables.h"
   SRCS
     "dynamic_symbols.c"
     "hip_headers.h"
     "status_util.c"
+    "rccl_dynamic_symbols.c"
+    "rccl_headers.h"
+    "rccl_status_util.c"
   INCLUDES
     "${HIP_API_HEADERS_ROOT}"
   DEPS
     iree::base
     iree::base::core_headers
     iree::base::internal::dynamic_library
+    rccl::headers
   PUBLIC
 )
 

--- a/runtime/src/iree/hal/drivers/hip/api.h
+++ b/runtime/src/iree/hal/drivers/hip/api.h
@@ -28,6 +28,11 @@ typedef enum iree_hal_hip_command_buffer_mode_e {
   IREE_HAL_HIP_COMMAND_BUFFER_MODE_STREAM = 1,
 } iree_hal_hip_command_buffer_mode_t;
 
+// ncclUniqueId exposed without exporting the RCCL headers.
+typedef struct {
+  char data[128];
+} iree_hal_hip_nccl_id_t;
+
 // Parameters defining a hipMemPool_t.
 typedef struct iree_hal_hip_memory_pool_params_t {
   // Minimum number of bytes to keep in the pool when trimming with

--- a/runtime/src/iree/hal/drivers/hip/dynamic_symbols_test.cc
+++ b/runtime/src/iree/hal/drivers/hip/dynamic_symbols_test.cc
@@ -31,8 +31,7 @@ TEST(DynamicSymbolsTest, CreateFromSystemLoader) {
   if (!iree_status_is_ok(status)) {
     iree_status_fprint(stderr, status);
     iree_status_ignore(status);
-    std::cerr << "Symbols cannot be loaded, skipping test.";
-    GTEST_SKIP();
+    GTEST_SKIP() << "Symbols cannot be loaded, skipping test.";
   }
 
   int device_count = 0;
@@ -76,8 +75,7 @@ TEST(NCCLDynamicSymbolsTest, CreateFromSystemLoader) {
   if (!iree_status_is_ok(status)) {
     iree_status_fprint(stderr, status);
     iree_status_ignore(status);
-    std::cerr << "HIP symbols cannot be loaded, skipping test.";
-    GTEST_SKIP();
+    GTEST_SKIP() << "HIP symbols cannot be loaded, skipping test.";
   }
 
   iree_hal_hip_nccl_dynamic_symbols_t nccl_symbols;
@@ -86,8 +84,7 @@ TEST(NCCLDynamicSymbolsTest, CreateFromSystemLoader) {
   if (!iree_status_is_ok(status)) {
     iree_status_fprint(stderr, status);
     iree_status_ignore(status);
-    std::cerr << "HIP NCCL symbols cannot be loaded, skipping test.";
-    GTEST_SKIP();
+    GTEST_SKIP() << "HIP RCCL symbols cannot be loaded, skipping test.";
   }
 
   int nccl_version = 0;

--- a/runtime/src/iree/hal/drivers/hip/hip_device.h
+++ b/runtime/src/iree/hal/drivers/hip/hip_device.h
@@ -7,10 +7,13 @@
 #ifndef IREE_HAL_DRIVERS_HIP_DEVICE_H_
 #define IREE_HAL_DRIVERS_HIP_DEVICE_H_
 
+#include <stdint.h>
+
 #include "iree/base/api.h"
 #include "iree/hal/api.h"
 #include "iree/hal/drivers/hip/api.h"
 #include "iree/hal/drivers/hip/dynamic_symbols.h"
+#include "iree/hal/drivers/hip/rccl_dynamic_symbols.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -20,7 +23,8 @@ extern "C" {
 iree_status_t iree_hal_hip_device_create(
     iree_hal_driver_t* driver, iree_string_view_t identifier,
     const iree_hal_hip_device_params_t* params,
-    const iree_hal_hip_dynamic_symbols_t* symbols, hipDevice_t device,
+    const iree_hal_hip_dynamic_symbols_t* symbols,
+    const iree_hal_hip_nccl_dynamic_symbols_t* nccl_symbols, hipDevice_t device,
     iree_allocator_t host_allocator, iree_hal_device_t** out_device);
 
 // Creates a HIP stream-backed command buffer using resources from the
@@ -48,6 +52,19 @@ hipCtx_t iree_hal_hip_device_context(iree_hal_device_t* device);
 // the API.
 const iree_hal_hip_dynamic_symbols_t* iree_hal_hip_device_dynamic_symbols(
     iree_hal_device_t* device);
+
+// Hide the cast in a function as HIP deliberately added a type name for it.
+// HIP seem to not provide cast functions.
+// It will probably never going to change, but lets not pretend everywhere it
+// is void*.
+static inline iree_device_size_t iree_hal_hip_device_ptr_to_device_size(
+    hipDeviceptr_t p) {
+  return (uintptr_t)p;
+}
+static inline hipDeviceptr_t iree_hal_hip_device_size_to_hip_device_prt(
+    iree_device_size_t p) {
+  return (hipDeviceptr_t)p;
+}
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/hal/drivers/hip/hip_driver.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_driver.c
@@ -36,7 +36,7 @@ typedef struct iree_hal_hip_driver_t {
   iree_string_view_t identifier;
   // HIP driver API dynamic symbols to interact with the HIP system.
   iree_hal_hip_dynamic_symbols_t hip_symbols;
-  // NCCL API dynamic symbols to interact with the HIP system.
+  // NCCL API dynamic symbols to use collectives (multi-gpu/multi-node).
   iree_hal_hip_nccl_dynamic_symbols_t nccl_symbols;
 
   // The default parameters for creating devices using this driver.

--- a/runtime/src/iree/hal/drivers/hip/rccl_channel.c
+++ b/runtime/src/iree/hal/drivers/hip/rccl_channel.c
@@ -1,0 +1,625 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/hip/rccl_channel.h"
+
+#include <stddef.h>
+#include <stdlib.h>
+
+#include "iree/base/api.h"
+#include "iree/base/tracing.h"
+#include "iree/hal/drivers/hip/hip_buffer.h"
+#include "iree/hal/drivers/hip/hip_device.h"
+#include "iree/hal/drivers/hip/rccl_status_util.h"
+#include "iree/hal/drivers/hip/status_util.h"
+
+typedef struct iree_hal_hip_nccl_channel_t {
+  iree_hal_resource_t resource;
+
+  const iree_hal_hip_dynamic_symbols_t* hip_symbols;
+  const iree_hal_hip_nccl_dynamic_symbols_t* nccl_symbols;
+
+  iree_allocator_t host_allocator;
+
+  // Parent channel this was split from, if any.
+  // This is only used to keep the parent channel live for as long as there are
+  // any split channels live (including transitive splits).
+  iree_hal_channel_t* parent_channel;
+
+  // This participant's rank in the communicator.
+  // Equivalent to ncclCommUserRank.
+  int rank;
+  // Total number of participants in the communicator.
+  // Equivalent to ncclCommCount.
+  int count;
+
+  // Communicator handle.
+  ncclComm_t comm;
+
+  // Hash of the unique ID used to create the communicator.
+  // This is consistent with the hashes NCCL itself uses for logging but is not
+  // guaranteed to be unique - only use for informational purposes.
+  IREE_TRACE(uint64_t id_hash;)
+} iree_hal_hip_nccl_channel_t;
+
+static const iree_hal_channel_vtable_t iree_hal_hip_nccl_channel_vtable;
+
+static iree_hal_hip_nccl_channel_t* iree_hal_hip_nccl_channel_cast(
+    iree_hal_channel_t* base_value) {
+  IREE_HAL_ASSERT_TYPE(base_value, &iree_hal_hip_nccl_channel_vtable);
+  return (iree_hal_hip_nccl_channel_t*)base_value;
+}
+
+static const iree_hal_hip_nccl_channel_t* iree_hal_hip_nccl_channel_const_cast(
+    const iree_hal_channel_t* base_value) {
+  IREE_HAL_ASSERT_TYPE(base_value, &iree_hal_hip_nccl_channel_vtable);
+  return (const iree_hal_hip_nccl_channel_t*)base_value;
+}
+
+// Returns the same value as NCCL's init.cc hashUniqueId.
+// These magic constants were chosen by their implementation and unlikely to
+// be stable as it's not part of their public API. So they are only meant to be
+// used for correlating debug logging/traces. We keep it internal here too so
+// that we aren't tempted to use it in other places.
+static uint64_t iree_hal_hip_nccl_hash_id(const iree_hal_hip_nccl_id_t* id) {
+  uint64_t hash = 0xDEADBEEF;
+  for (iree_host_size_t i = 0; i < sizeof(*id); i++) {
+    hash ^= hash >> 32;
+    hash *= 0x8DB3DB47FA2994ADull;
+    hash += id->data[i];
+  }
+  return hash;
+}
+
+iree_status_t iree_hal_hip_nccl_get_unique_id(
+    const iree_hal_hip_nccl_dynamic_symbols_t* symbols,
+    iree_hal_hip_nccl_id_t* out_id) {
+  static_assert(sizeof(*out_id) == sizeof(ncclUniqueId),
+                "NCCL ID size mismatch");
+
+  IREE_ASSERT_ARGUMENT(symbols);
+  IREE_ASSERT_ARGUMENT(out_id);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  memset(out_id, 0, sizeof(*out_id));
+  iree_status_t status = IREE_NCCL_RESULT_TO_STATUS(
+      symbols, ncclGetUniqueId((ncclUniqueId*)out_id), "ncclGetUniqueId");
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+iree_status_t iree_hal_hip_nccl_channel_create(
+    const iree_hal_hip_dynamic_symbols_t* hip_symbols,
+    const iree_hal_hip_nccl_dynamic_symbols_t* nccl_symbols,
+    const iree_hal_hip_nccl_id_t* id, int rank, int count,
+    iree_allocator_t host_allocator, iree_hal_channel_t** out_channel) {
+  IREE_ASSERT_ARGUMENT(hip_symbols);
+  IREE_ASSERT_ARGUMENT(nccl_symbols);
+  IREE_ASSERT_ARGUMENT(id);
+  IREE_ASSERT_ARGUMENT(out_channel);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  *out_channel = NULL;
+  IREE_TRACE(const uint64_t id_hash = iree_hal_hip_nccl_hash_id(id));
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, id_hash);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, rank);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, count);
+
+  ncclComm_t comm = NULL;
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  // TODO: use async to check a timeout.
+  config.blocking = 1;
+  IREE_NCCL_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, nccl_symbols,
+      ncclCommInitRankConfig(&comm, count, *((const ncclUniqueId*)id), rank,
+                             &config),
+      "ncclCommInitRankConfig");
+
+  iree_hal_hip_nccl_channel_t* channel = NULL;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_allocator_malloc(host_allocator, sizeof(*channel),
+                                (void**)&channel));
+
+  iree_hal_resource_initialize(&iree_hal_hip_nccl_channel_vtable,
+                               &channel->resource);
+  channel->hip_symbols = hip_symbols;
+  channel->nccl_symbols = nccl_symbols;
+  channel->host_allocator = host_allocator;
+  channel->parent_channel = NULL;
+  channel->rank = rank;
+  channel->count = count;
+  channel->comm = comm;
+  IREE_TRACE(channel->id_hash = id_hash);
+  *out_channel = (iree_hal_channel_t*)channel;
+
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+static void iree_hal_hip_nccl_channel_destroy(
+    iree_hal_channel_t* base_channel) {
+  iree_hal_hip_nccl_channel_t* channel =
+      iree_hal_hip_nccl_channel_cast(base_channel);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, channel->id_hash);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, channel->rank);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, channel->count);
+
+  iree_allocator_t host_allocator = channel->host_allocator;
+
+  // TODO(#9580): support async tear down
+  // We could be smarter about starting finalization of all channels async and
+  // then waiting for them to complete but we aren't currently optimizing for
+  // lifetime performance. To do that we'd probably want to track each open
+  // channel on the device that created them and manage teardown there.
+  //
+  // Recommended:
+  //   ncclCommFinalize(channel->comm);  // non-blocking!
+  //   while (ncclCommGetAsyncError == ncclInProgress) sleep(1);
+  //   ncclCommDestroy(channel->comm)
+  // Should work the same (as we are doing a blocking teardown):
+  //   ncclCommDestroy(channel->comm)
+  IREE_NCCL_IGNORE_ERROR(channel->nccl_symbols,
+                         ncclCommFinalize(channel->comm));
+
+  IREE_NCCL_IGNORE_ERROR(channel->nccl_symbols, ncclCommDestroy(channel->comm));
+
+  iree_hal_channel_release(channel->parent_channel);
+  iree_allocator_free(host_allocator, channel);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+static iree_status_t iree_hal_hip_nccl_channel_split(
+    iree_hal_channel_t* base_channel, int32_t color, int32_t key,
+    iree_hal_channel_flags_t flags, iree_hal_channel_t** out_split_channel) {
+  iree_hal_hip_nccl_channel_t* channel =
+      iree_hal_hip_nccl_channel_cast(base_channel);
+
+  // TODO: see if we need to set the sharing config - we may always want to.
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  // TODO: use async to check a timeout.
+  config.blocking = 1;
+
+  // Split the communicator.
+  ncclComm_t split_comm = NULL;
+  IREE_NCCL_RETURN_IF_ERROR(
+      channel->nccl_symbols,
+      ncclCommSplit(channel->comm, color, key, &split_comm, &config),
+      "ncclCommSplit");
+
+  // Query the local rank/count from the split communicator.
+  int split_rank = 0;
+  int split_count = 0;
+  iree_status_t status = IREE_NCCL_RESULT_TO_STATUS(
+      channel->nccl_symbols, ncclCommUserRank(split_comm, &split_rank),
+      "ncclCommUserRank");
+  if (iree_status_is_ok(status)) {
+    status = IREE_NCCL_RESULT_TO_STATUS(channel->nccl_symbols,
+                                        ncclCommCount(split_comm, &split_count),
+                                        "ncclCommCount");
+  }
+
+  // Wrap the split communicator in a new channel.
+  iree_hal_hip_nccl_channel_t* split_channel = NULL;
+  if (iree_status_is_ok(status)) {
+    status =
+        iree_allocator_malloc(channel->host_allocator, sizeof(*split_channel),
+                              (void**)&split_channel);
+  }
+  if (iree_status_is_ok(status)) {
+    iree_hal_resource_initialize(&iree_hal_hip_nccl_channel_vtable,
+                                 &split_channel->resource);
+    split_channel->hip_symbols = channel->hip_symbols;
+    split_channel->nccl_symbols = channel->nccl_symbols;
+    split_channel->host_allocator = channel->host_allocator;
+    split_channel->parent_channel = base_channel;
+    iree_hal_channel_retain(base_channel);
+    split_channel->rank = split_rank;
+    split_channel->count = split_count;
+    split_channel->comm = split_comm;
+    *out_split_channel = (iree_hal_channel_t*)split_channel;
+  }
+
+  if (!iree_status_is_ok(status)) {
+    IREE_NCCL_IGNORE_ERROR(channel->nccl_symbols, ncclCommDestroy(split_comm));
+  }
+  return status;
+}
+
+static void iree_hal_hip_nccl_channel_query_rank_and_count(
+    const iree_hal_channel_t* base_channel, int32_t* out_rank,
+    int32_t* out_count) {
+  IREE_ASSERT_ARGUMENT(base_channel);
+  IREE_ASSERT_ARGUMENT(out_count);
+  const iree_hal_hip_nccl_channel_t* channel =
+      iree_hal_hip_nccl_channel_const_cast(base_channel);
+  // NOTE: since it's cheap we keep rank/count local - this lets us trace them
+  // out without needing to call into NCCL each time.
+  *out_rank = channel->rank;
+  *out_count = channel->count;
+}
+
+// Returns the NCCL communicator for the given |channel|, if available.
+static ncclComm_t iree_hal_hip_nccl_channel_comm(
+    iree_hal_channel_t* base_channel) {
+  IREE_ASSERT_ARGUMENT(base_channel);
+  iree_hal_hip_nccl_channel_t* channel =
+      iree_hal_hip_nccl_channel_cast(base_channel);
+  return channel->comm;
+}
+
+static iree_status_t iree_hal_hip_get_nccl_data_type(
+    iree_hal_collective_element_type_t in, ncclDataType_t* out) {
+  switch (in) {
+    case IREE_HAL_COLLECTIVE_ELEMENT_TYPE_SINT_8:
+      *out = ncclInt8;
+      break;
+    case IREE_HAL_COLLECTIVE_ELEMENT_TYPE_UINT_8:
+      *out = ncclUint8;
+      break;
+    case IREE_HAL_COLLECTIVE_ELEMENT_TYPE_SINT_16:
+      return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                              "SINT16 is not supported for collective op");
+    case IREE_HAL_COLLECTIVE_ELEMENT_TYPE_UINT_16:
+      return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                              "UINT16 is not supported for collective op");
+    case IREE_HAL_COLLECTIVE_ELEMENT_TYPE_SINT_32:
+      *out = ncclInt32;
+      break;
+    case IREE_HAL_COLLECTIVE_ELEMENT_TYPE_UINT_32:
+      *out = ncclUint32;
+      break;
+    case IREE_HAL_COLLECTIVE_ELEMENT_TYPE_SINT_64:
+      *out = ncclInt64;
+      break;
+    case IREE_HAL_COLLECTIVE_ELEMENT_TYPE_UINT_64:
+      *out = ncclUint64;
+      break;
+    case IREE_HAL_COLLECTIVE_ELEMENT_TYPE_FLOAT_16:
+      *out = ncclFloat16;
+      break;
+    case IREE_HAL_COLLECTIVE_ELEMENT_TYPE_FLOAT_32:
+      *out = ncclFloat32;
+      break;
+    case IREE_HAL_COLLECTIVE_ELEMENT_TYPE_FLOAT_64:
+      *out = ncclFloat64;
+      break;
+    case IREE_HAL_COLLECTIVE_ELEMENT_TYPE_BFLOAT_16:
+      *out = ncclFloat64;
+      break;
+    default:
+      return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                              "unhandled element type for collective op");
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_hip_get_nccl_reduction_type(
+    iree_hal_collective_reduction_t in, ncclRedOp_t* out) {
+  switch (in) {
+    case IREE_HAL_COLLECTIVE_REDUCTION_SUM:
+      *out = ncclSum;
+      break;
+    case IREE_HAL_COLLECTIVE_REDUCTION_PRODUCT:
+      *out = ncclProd;
+      break;
+    case IREE_HAL_COLLECTIVE_REDUCTION_MINIMUM:
+      *out = ncclMin;
+      break;
+    case IREE_HAL_COLLECTIVE_REDUCTION_MAXIMUM:
+      *out = ncclMax;
+      break;
+    case IREE_HAL_COLLECTIVE_REDUCTION_AVERAGE:
+      *out = ncclAvg;
+      break;
+    default:
+      return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                              "unhandled reduction type for collective op");
+  }
+
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_hip_nccl_submit_batch_entry(
+    const iree_hal_collective_batch_entry_t* entry, hipStream_t stream) {
+  IREE_ASSERT_ARGUMENT(entry);
+  IREE_ASSERT_ARGUMENT(stream);
+
+  iree_hal_hip_nccl_channel_t* channel =
+      iree_hal_hip_nccl_channel_cast(entry->channel);
+  const iree_hal_hip_nccl_dynamic_symbols_t* symbols = channel->nccl_symbols;
+  ncclComm_t comm = iree_hal_hip_nccl_channel_comm(entry->channel);
+
+  ncclDataType_t datatype;
+  IREE_RETURN_IF_ERROR(
+      iree_hal_hip_get_nccl_data_type(entry->op.element_type, &datatype));
+
+  switch (entry->op.kind) {
+    case IREE_HAL_COLLECTIVE_KIND_ALL_GATHER: {
+      iree_device_size_t sendbuff =
+          iree_hal_hip_device_ptr_to_device_size(
+              iree_hal_buffer_allocated_buffer(entry->send_binding.buffer)) +
+          iree_hal_buffer_byte_offset(entry->send_binding.buffer) +
+          entry->send_binding.offset;
+      iree_device_size_t recvbuff =
+          iree_hal_hip_device_ptr_to_device_size(
+              iree_hal_hip_buffer_device_pointer(
+                  iree_hal_buffer_allocated_buffer(
+                      entry->recv_binding.buffer))) +
+          iree_hal_buffer_byte_offset(entry->recv_binding.buffer) +
+          entry->recv_binding.offset;
+      IREE_NCCL_RETURN_IF_ERROR(
+          symbols,
+          ncclAllGather((const void*)sendbuff, (void*)recvbuff,
+                        entry->element_count, datatype, comm, stream),
+          "ncclAllGather");
+      break;
+    }
+    case IREE_HAL_COLLECTIVE_KIND_ALL_REDUCE: {
+      iree_device_size_t sendbuff =
+          iree_hal_hip_device_ptr_to_device_size(
+              iree_hal_hip_buffer_device_pointer(
+                  iree_hal_buffer_allocated_buffer(
+                      entry->send_binding.buffer))) +
+          iree_hal_buffer_byte_offset(entry->send_binding.buffer) +
+          entry->send_binding.offset;
+      iree_device_size_t recvbuff =
+          iree_hal_hip_device_ptr_to_device_size(
+              iree_hal_hip_buffer_device_pointer(
+                  iree_hal_buffer_allocated_buffer(
+                      entry->recv_binding.buffer))) +
+          iree_hal_buffer_byte_offset(entry->recv_binding.buffer) +
+          entry->recv_binding.offset;
+      ncclRedOp_t redop;
+      IREE_RETURN_IF_ERROR(
+          iree_hal_hip_get_nccl_reduction_type(entry->op.reduction, &redop));
+      IREE_NCCL_RETURN_IF_ERROR(
+          symbols,
+          ncclAllReduce((const void*)sendbuff, (void*)recvbuff,
+                        entry->element_count, datatype, redop, comm, stream),
+          "ncclAllReduce");
+      break;
+    }
+    case IREE_HAL_COLLECTIVE_KIND_ALL_TO_ALL: {
+      iree_device_size_t sendbuff =
+          iree_hal_hip_device_ptr_to_device_size(
+              iree_hal_hip_buffer_device_pointer(
+                  iree_hal_buffer_allocated_buffer(
+                      entry->send_binding.buffer))) +
+          iree_hal_buffer_byte_offset(entry->send_binding.buffer) +
+          entry->send_binding.offset;
+      iree_device_size_t recvbuff =
+          iree_hal_hip_device_ptr_to_device_size(
+              iree_hal_hip_buffer_device_pointer(
+                  iree_hal_buffer_allocated_buffer(
+                      entry->recv_binding.buffer))) +
+          iree_hal_buffer_byte_offset(entry->recv_binding.buffer) +
+          entry->recv_binding.offset;
+      iree_device_size_t send_count = entry->element_count / channel->count;
+      iree_device_size_t element_size_bytes =
+          iree_hal_collective_element_byte_count(entry->op.element_type);
+      iree_device_size_t rank_offset = send_count * element_size_bytes;
+      // These calls are already grouped by iree_hal_hip_nccl_submit_batch.
+      for (iree_host_size_t r = 0; r < channel->count; ++r) {
+        IREE_NCCL_RETURN_IF_ERROR(
+            symbols,
+            ncclSend((const void*)(sendbuff + r * rank_offset), send_count,
+                     datatype, r, comm, stream),
+            "ncclSend");
+        IREE_NCCL_RETURN_IF_ERROR(
+            symbols,
+            ncclRecv((void*)(recvbuff + r * rank_offset), send_count, datatype,
+                     r, comm, stream),
+            "ncclRecv");
+      }
+      break;
+    }
+    case IREE_HAL_COLLECTIVE_KIND_BROADCAST: {
+      iree_device_size_t sendbuff =
+          iree_hal_hip_device_ptr_to_device_size(
+              iree_hal_hip_buffer_device_pointer(
+                  iree_hal_buffer_allocated_buffer(
+                      entry->send_binding.buffer))) +
+          iree_hal_buffer_byte_offset(entry->send_binding.buffer) +
+          entry->send_binding.offset;
+      iree_device_size_t recvbuff =
+          iree_hal_hip_device_ptr_to_device_size(
+              iree_hal_hip_buffer_device_pointer(
+                  iree_hal_buffer_allocated_buffer(
+                      entry->recv_binding.buffer))) +
+          iree_hal_buffer_byte_offset(entry->recv_binding.buffer) +
+          entry->recv_binding.offset;
+      IREE_NCCL_RETURN_IF_ERROR(
+          symbols,
+          ncclBroadcast((const void*)sendbuff, (void*)recvbuff,
+                        entry->element_count, datatype, entry->param, comm,
+                        stream),
+          "ncclBroadcast");
+      break;
+    }
+    case IREE_HAL_COLLECTIVE_KIND_REDUCE: {
+      iree_device_size_t sendbuff =
+          iree_hal_hip_device_ptr_to_device_size(
+              iree_hal_hip_buffer_device_pointer(
+                  iree_hal_buffer_allocated_buffer(
+                      entry->send_binding.buffer))) +
+          iree_hal_buffer_byte_offset(entry->send_binding.buffer) +
+          entry->send_binding.offset;
+      iree_device_size_t recvbuff =
+          iree_hal_hip_device_ptr_to_device_size(
+              iree_hal_hip_buffer_device_pointer(
+                  iree_hal_buffer_allocated_buffer(
+                      entry->recv_binding.buffer))) +
+          iree_hal_buffer_byte_offset(entry->recv_binding.buffer) +
+          entry->recv_binding.offset;
+      ncclRedOp_t redop;
+      IREE_RETURN_IF_ERROR(
+          iree_hal_hip_get_nccl_reduction_type(entry->op.reduction, &redop));
+      IREE_NCCL_RETURN_IF_ERROR(
+          symbols,
+          ncclReduce((const void*)sendbuff, (void*)recvbuff,
+                     entry->element_count, datatype, redop, entry->param, comm,
+                     stream),
+          "ncclReduce");
+      break;
+    }
+    case IREE_HAL_COLLECTIVE_KIND_REDUCE_SCATTER: {
+      iree_device_size_t sendbuff =
+          iree_hal_hip_device_ptr_to_device_size(
+              iree_hal_hip_buffer_device_pointer(
+                  iree_hal_buffer_allocated_buffer(
+                      entry->send_binding.buffer))) +
+          iree_hal_buffer_byte_offset(entry->send_binding.buffer) +
+          entry->send_binding.offset;
+      iree_device_size_t recvbuff =
+          iree_hal_hip_device_ptr_to_device_size(
+              iree_hal_hip_buffer_device_pointer(
+                  iree_hal_buffer_allocated_buffer(
+                      entry->recv_binding.buffer))) +
+          iree_hal_buffer_byte_offset(entry->recv_binding.buffer) +
+          entry->recv_binding.offset;
+      ncclRedOp_t redop;
+      IREE_RETURN_IF_ERROR(
+          iree_hal_hip_get_nccl_reduction_type(entry->op.reduction, &redop));
+      IREE_NCCL_RETURN_IF_ERROR(
+          symbols,
+          ncclReduceScatter((const void*)sendbuff, (void*)recvbuff,
+                            entry->element_count, datatype, redop, comm,
+                            stream),
+          "ncclReduceScatter");
+      break;
+    }
+    case IREE_HAL_COLLECTIVE_KIND_SEND: {
+      iree_device_size_t sendbuff =
+          iree_hal_hip_device_ptr_to_device_size(
+              iree_hal_hip_buffer_device_pointer(
+                  iree_hal_buffer_allocated_buffer(
+                      entry->send_binding.buffer))) +
+          iree_hal_buffer_byte_offset(entry->send_binding.buffer) +
+          entry->send_binding.offset;
+      IREE_NCCL_RETURN_IF_ERROR(
+          symbols,
+          ncclSend((const void*)sendbuff, entry->element_count, datatype,
+                   entry->param, comm, stream),
+          "ncclSend");
+      break;
+    }
+    case IREE_HAL_COLLECTIVE_KIND_RECV: {
+      iree_device_size_t recvbuff =
+          iree_hal_hip_device_ptr_to_device_size(
+              iree_hal_hip_buffer_device_pointer(
+                  iree_hal_buffer_allocated_buffer(
+                      entry->recv_binding.buffer))) +
+          iree_hal_buffer_byte_offset(entry->recv_binding.buffer) +
+          entry->recv_binding.offset;
+      IREE_NCCL_RETURN_IF_ERROR(symbols,
+                                ncclRecv((void*)recvbuff, entry->element_count,
+                                         datatype, entry->param, comm, stream),
+                                "ncclRecv");
+      break;
+    }
+    case IREE_HAL_COLLECTIVE_KIND_SEND_RECV: {
+      iree_device_size_t sendbuff =
+          iree_hal_hip_device_ptr_to_device_size(
+              iree_hal_hip_buffer_device_pointer(
+                  iree_hal_buffer_allocated_buffer(
+                      entry->send_binding.buffer))) +
+          iree_hal_buffer_byte_offset(entry->send_binding.buffer) +
+          entry->send_binding.offset;
+      iree_device_size_t recvbuff =
+          iree_hal_hip_device_ptr_to_device_size(
+              iree_hal_hip_buffer_device_pointer(
+                  iree_hal_buffer_allocated_buffer(
+                      entry->recv_binding.buffer))) +
+          iree_hal_buffer_byte_offset(entry->recv_binding.buffer) +
+          entry->recv_binding.offset;
+      int16_t sendid;
+      int16_t recvid;
+      memcpy(&sendid, &entry->param, 2);
+      memcpy(&recvid, (char*)&entry->param + 2, 2);
+      if (sendid != -1) {
+        IREE_NCCL_RETURN_IF_ERROR(
+            symbols,
+            ncclSend((const void*)sendbuff, entry->element_count, datatype,
+                     sendid, comm, stream),
+            "ncclSend");
+      }
+      if (recvid != -1) {
+        IREE_NCCL_RETURN_IF_ERROR(
+            symbols,
+            ncclRecv((void*)recvbuff, entry->element_count, datatype, recvid,
+                     comm, stream),
+            "ncclRecv");
+      } else {
+        // Zero out recvbuff if this rank is not receiving any data.
+        iree_device_size_t num_bytes =
+            entry->element_count *
+            iree_hal_collective_element_byte_count(entry->op.element_type);
+        IREE_HIP_RETURN_IF_ERROR(
+            channel->hip_symbols,
+            hipMemsetD8Async(
+                iree_hal_hip_device_size_to_hip_device_prt(recvbuff), 0,
+                num_bytes, stream),
+            "hipMemsetD8Async");
+      }
+      break;
+    }
+  }  // switch
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_hip_nccl_submit_batch(
+    const iree_hal_hip_nccl_dynamic_symbols_t* symbols,
+    iree_hal_hip_tracing_context_t* tracing_context,
+    const iree_hal_collective_batch_t* batch, hipStream_t stream) {
+  IREE_ASSERT_ARGUMENT(symbols);
+  IREE_ASSERT_ARGUMENT(batch);
+  IREE_ASSERT_ARGUMENT(stream);
+
+#if IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION_DEVICE
+  // Begin one zone for each entry in the batch. Each entry will show stacked on
+  // top of each other and unfortunately use independent HIP events. We could
+  // optimize this by changing the tracing context to expose an API with event
+  // reservation and then zone commit using an existing event.
+  iree_bitfield_string_temp_t string_temp;
+  for (iree_host_size_t i = 0; i < batch->count; ++i) {
+    iree_hal_collective_batch_entry_t* entry = &batch->entries[i];
+    iree_string_view_t collective_str =
+        iree_hal_collective_op_format(&entry->op, &string_temp);
+    IREE_HIP_STREAM_TRACE_ZONE_BEGIN_EXTERNAL(
+        tracing_context, stream, __FILE__, strlen(__FILE__), (uint32_t)__LINE__,
+        __FUNCTION__, strlen(__FUNCTION__), collective_str.data,
+        collective_str.size);
+  }
+#endif  // IREE_TRACING_FEATURE_INSTRUMENTATION_DEVICE
+
+  // Issue all collective operations in the batch as part of a group.
+  // NCCL may be able to fuse or reduce overheads by issuing like this.
+  IREE_NCCL_RETURN_IF_ERROR(symbols, ncclGroupStart(), "ncclGroupStart");
+  for (iree_host_size_t i = 0; i < batch->count; ++i) {
+    IREE_RETURN_IF_ERROR(
+        iree_hal_hip_nccl_submit_batch_entry(&batch->entries[i], stream));
+  }
+  IREE_NCCL_RETURN_IF_ERROR(symbols, ncclGroupEnd(), "ncclGroupEnd");
+
+  // End all zones we began above - note that these are just simply nested so
+  // order doesn't matter so long as we end the right number of zones.
+  IREE_TRACE({
+    for (iree_host_size_t i = 0; i < batch->count; ++i) {
+      IREE_HIP_STREAM_TRACE_ZONE_END(tracing_context, stream);
+    }
+  });
+
+  return iree_ok_status();
+}
+
+static const iree_hal_channel_vtable_t iree_hal_hip_nccl_channel_vtable = {
+    .destroy = iree_hal_hip_nccl_channel_destroy,
+    .split = iree_hal_hip_nccl_channel_split,
+    .query_rank_and_count = iree_hal_hip_nccl_channel_query_rank_and_count,
+};

--- a/runtime/src/iree/hal/drivers/hip/rccl_channel.h
+++ b/runtime/src/iree/hal/drivers/hip/rccl_channel.h
@@ -1,0 +1,58 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_DRIVERS_HIP_NCCL_CHANNEL_H_
+#define IREE_HAL_DRIVERS_HIP_NCCL_CHANNEL_H_
+
+#include "iree/base/api.h"
+#include "iree/hal/api.h"
+#include "iree/hal/drivers/hip/api.h"
+#include "iree/hal/drivers/hip/dynamic_symbols.h"
+#include "iree/hal/drivers/hip/rccl_dynamic_symbols.h"
+#include "iree/hal/drivers/hip/tracing.h"
+#include "iree/hal/utils/collective_batch.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// Returns true if |id| is all zeros indicating an empty ID.
+static inline bool iree_hal_hip_nccl_id_is_empty(
+    const iree_hal_hip_nccl_id_t* id) {
+  for (iree_host_size_t i = 0; i < IREE_ARRAYSIZE(id->data); ++i) {
+    if (id->data[i] != 0) return false;
+  }
+  return true;
+}
+
+// Gets a unique ID to bootstrap a new communicator. It calls ncclGetUniqueId
+// under the hood.
+iree_status_t iree_hal_hip_nccl_get_unique_id(
+    const iree_hal_hip_nccl_dynamic_symbols_t* symbols,
+    iree_hal_hip_nccl_id_t* out_id);
+
+// Creates a IREE HAL channel using the given NCCL |id|, |rank|, and |count|.
+// It calls ncclCommInitRankConfig under the hood.
+iree_status_t iree_hal_hip_nccl_channel_create(
+    const iree_hal_hip_dynamic_symbols_t* hip_symbols,
+    const iree_hal_hip_nccl_dynamic_symbols_t* nccl_symbols,
+    const iree_hal_hip_nccl_id_t* id, int rank, int count,
+    iree_allocator_t host_allocator, iree_hal_channel_t** out_channel);
+
+// Performs a non-blocking submission of |batch| to |stream|.
+// The backing storage of |batch| is dropped immediately but all resources
+// referenced will be retained by the parent command buffer for its lifetime.
+// Note that operations in the batch may apply to different channels.
+iree_status_t iree_hal_hip_nccl_submit_batch(
+    const iree_hal_hip_nccl_dynamic_symbols_t* nccl_symbols,
+    iree_hal_hip_tracing_context_t* tracing_context,
+    const iree_hal_collective_batch_t* batch, hipStream_t stream);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_DRIVERS_HIP_NCCL_CHANNEL_H_

--- a/runtime/src/iree/hal/drivers/hip/rccl_channel.h
+++ b/runtime/src/iree/hal/drivers/hip/rccl_channel.h
@@ -4,8 +4,8 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef IREE_HAL_DRIVERS_HIP_NCCL_CHANNEL_H_
-#define IREE_HAL_DRIVERS_HIP_NCCL_CHANNEL_H_
+#ifndef IREE_HAL_DRIVERS_HIP_RCCL_CHANNEL_H_
+#define IREE_HAL_DRIVERS_HIP_RCCL_CHANNEL_H_
 
 #include "iree/base/api.h"
 #include "iree/hal/api.h"
@@ -55,4 +55,4 @@ iree_status_t iree_hal_hip_nccl_submit_batch(
 }  // extern "C"
 #endif  // __cplusplus
 
-#endif  // IREE_HAL_DRIVERS_HIP_NCCL_CHANNEL_H_
+#endif  // IREE_HAL_DRIVERS_HIP_RCCL_CHANNEL_H_

--- a/runtime/src/iree/hal/drivers/hip/rccl_dynamic_symbol_table.h
+++ b/runtime/src/iree/hal/drivers/hip/rccl_dynamic_symbol_table.h
@@ -1,0 +1,44 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+IREE_NCCL_PFN_DECL(ncclGetVersion, int*)
+IREE_NCCL_PFN_DECL(ncclGetUniqueId, ncclUniqueId*)
+IREE_NCCL_PFN_DECL(ncclCommInitRankConfig, ncclComm_t*, int, ncclUniqueId, int,
+                   ncclConfig_t*)
+IREE_NCCL_PFN_DECL(ncclCommInitRank, ncclComm_t*, int, ncclUniqueId, int)
+IREE_NCCL_PFN_DECL(ncclCommInitAll, ncclComm_t*, int, const int*)
+IREE_NCCL_PFN_DECL(ncclCommSplit, ncclComm_t, int, int, ncclComm_t*,
+                   ncclConfig_t*)
+IREE_NCCL_PFN_DECL(ncclCommFinalize, ncclComm_t)
+IREE_NCCL_PFN_DECL(ncclCommDestroy, ncclComm_t)
+IREE_NCCL_PFN_DECL(ncclCommAbort, ncclComm_t)
+IREE_NCCL_PFN_DECL_STR_RETURN(ncclGetErrorString, ncclResult_t)
+IREE_NCCL_PFN_DECL_STR_RETURN(ncclGetLastError, ncclComm_t)
+IREE_NCCL_PFN_DECL(ncclCommGetAsyncError, ncclComm_t, ncclResult_t*)
+IREE_NCCL_PFN_DECL(ncclCommCount, const ncclComm_t, int*)
+IREE_NCCL_PFN_DECL(ncclCommCuDevice, const ncclComm_t, int*)
+IREE_NCCL_PFN_DECL(ncclCommUserRank, const ncclComm_t, int*)
+IREE_NCCL_PFN_DECL(ncclRedOpCreatePreMulSum, ncclRedOp_t*, void*,
+                   ncclDataType_t, ncclScalarResidence_t, ncclComm_t)
+IREE_NCCL_PFN_DECL(ncclRedOpDestroy, ncclRedOp_t, ncclComm_t)
+IREE_NCCL_PFN_DECL(ncclReduce, const void*, void*, size_t, ncclDataType_t,
+                   ncclRedOp_t, int, ncclComm_t, hipStream_t)
+IREE_NCCL_PFN_DECL(ncclBcast, void*, size_t, ncclDataType_t, int, ncclComm_t,
+                   hipStream_t)
+IREE_NCCL_PFN_DECL(ncclBroadcast, const void*, void*, size_t, ncclDataType_t,
+                   int, ncclComm_t, hipStream_t)
+IREE_NCCL_PFN_DECL(ncclAllReduce, const void*, void*, size_t, ncclDataType_t,
+                   ncclRedOp_t, ncclComm_t, hipStream_t)
+IREE_NCCL_PFN_DECL(ncclReduceScatter, const void*, void*, size_t,
+                   ncclDataType_t, ncclRedOp_t, ncclComm_t, hipStream_t)
+IREE_NCCL_PFN_DECL(ncclAllGather, const void*, void*, size_t, ncclDataType_t,
+                   ncclComm_t, hipStream_t)
+IREE_NCCL_PFN_DECL(ncclSend, const void*, size_t, ncclDataType_t, int,
+                   ncclComm_t, hipStream_t)
+IREE_NCCL_PFN_DECL(ncclRecv, void*, size_t, ncclDataType_t, int, ncclComm_t,
+                   hipStream_t)
+IREE_NCCL_PFN_DECL(ncclGroupStart)
+IREE_NCCL_PFN_DECL(ncclGroupEnd)

--- a/runtime/src/iree/hal/drivers/hip/rccl_dynamic_symbols.c
+++ b/runtime/src/iree/hal/drivers/hip/rccl_dynamic_symbols.c
@@ -1,0 +1,144 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/hip/rccl_dynamic_symbols.h"
+
+#include <string.h>
+
+#include "iree/base/api.h"
+#include "iree/base/internal/dynamic_library.h"
+#include "iree/hal/drivers/hip/rccl_status_util.h"
+
+static const char* iree_hal_hip_nccl_dylib_names[] = {
+#if defined(IREE_PLATFORM_WINDOWS)
+    "rccl.dll",
+#else
+    "librccl.so",
+#endif  // IREE_PLATFORM_WINDOWS
+};
+
+// Resolves all NCCL dynamic symbols in `dynamic_symbol_tables.h`, prefer _v2
+// version if it exists.
+static iree_status_t iree_hal_hip_nccl_dynamic_symbols_resolve_all(
+    iree_hal_hip_nccl_dynamic_symbols_t* syms) {
+#define IREE_NCCL_PFN_DECL(nccl_symbol_name, ...)             \
+  {                                                           \
+    static const char* name = #nccl_symbol_name;              \
+    IREE_RETURN_IF_ERROR(iree_dynamic_library_lookup_symbol(  \
+        syms->dylib, name, (void**)&syms->nccl_symbol_name)); \
+  }
+#define IREE_NCCL_PFN_DECL_STR_RETURN(nccl_symbol_name, ...)  \
+  {                                                           \
+    static const char* name = #nccl_symbol_name;              \
+    IREE_RETURN_IF_ERROR(iree_dynamic_library_lookup_symbol(  \
+        syms->dylib, name, (void**)&syms->nccl_symbol_name)); \
+  }
+#include "iree/hal/drivers/hip/rccl_dynamic_symbol_table.h"  // IWYU pragma: keep
+#undef IREE_NCCL_PFN_DECL
+#undef IREE_NCCL_PFN_DECL_STR_RETURN
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_hip_nccl_check_version(
+    iree_dynamic_library_t* nccl_library) {
+  ncclResult_t (*ncclGetVersion)(int*) = NULL;
+
+  iree_status_t status = iree_dynamic_library_lookup_symbol(
+      nccl_library, "ncclGetVersion", (void**)&ncclGetVersion);
+  if (!iree_status_is_ok(status)) {
+    iree_status_ignore(status);
+    return iree_make_status(
+        IREE_STATUS_UNAVAILABLE,
+        "ncclGetVersion symbol not found in dynamic library");
+  }
+
+  // Check the NCCL version compatibility.
+  int nccl_version = 0;
+  ncclResult_t result = ncclGetVersion(&nccl_version);
+  if (result != ncclSuccess) {
+    return iree_make_status(IREE_STATUS_UNAVAILABLE,
+                            "ncclGetVersion() failed with error %d", result);
+  }
+
+  int major = 0;
+  int minor = 0;
+  int patch = 0;
+  if (nccl_version < 20000) {
+    major = nccl_version / 1000;
+    minor = (nccl_version % 1000) / 100;
+  } else {
+    major = nccl_version / 10000;
+    minor = (nccl_version % 10000) / 100;
+  }
+  patch = nccl_version % 100;
+  int required_minimum_version = NCCL_VERSION(NCCL_MAJOR, NCCL_MINOR, 0);
+  if (major != NCCL_MAJOR || nccl_version < required_minimum_version) {
+    return iree_make_status(
+        IREE_STATUS_UNAVAILABLE,
+        "NCCL version is %d.%d.%d, but >=%d.%d and <%d is required", major,
+        minor, patch, NCCL_MAJOR, NCCL_MINOR, NCCL_MAJOR + 1);
+  }
+
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_hip_nccl_dynamic_symbols_initialize(
+    iree_allocator_t host_allocator,
+    const iree_hal_hip_dynamic_symbols_t* hip_library,
+    iree_hal_hip_nccl_dynamic_symbols_t* out_syms) {
+  IREE_ASSERT_ARGUMENT(out_syms);
+  if (!hip_library->dylib) {
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "HIP dynamic symbols must be resolved prior to loading NCCL symbols");
+  }
+
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  memset(out_syms, 0, sizeof(*out_syms));
+  iree_status_t status = iree_dynamic_library_load_from_files(
+      IREE_ARRAYSIZE(iree_hal_hip_nccl_dylib_names),
+      iree_hal_hip_nccl_dylib_names, IREE_DYNAMIC_LIBRARY_FLAG_NONE,
+      host_allocator, &out_syms->dylib);
+  if (iree_status_is_not_found(status)) {
+    iree_status_ignore(status);
+    status = iree_make_status(
+        IREE_STATUS_UNAVAILABLE,
+        "RCCL runtime library version %d.%d and greater not available; "
+        "ensure installed and the shared library (rccl.dll/lirnccl.so) "
+        "is on your PATH/LD_LIBRARY_PATH.",
+        NCCL_MAJOR, NCCL_MINOR);
+  }
+
+  if (iree_status_is_ok(status)) {
+    // Check the version first before resolving all symbols. This makes sure
+    // that we have the right version and all symbols are available at the
+    // time of resolving.
+    status = iree_hal_hip_nccl_check_version(out_syms->dylib);
+  }
+
+  // Resolve all symbols; this will fail if any required symbols are missing.
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_hip_nccl_dynamic_symbols_resolve_all(out_syms);
+  }
+
+  if (!iree_status_is_ok(status)) {
+    iree_dynamic_library_release(out_syms->dylib);
+    out_syms->dylib = NULL;
+  }
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+void iree_hal_hip_nccl_dynamic_symbols_deinitialize(
+    iree_hal_hip_nccl_dynamic_symbols_t* syms) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_dynamic_library_release(syms->dylib);
+  memset(syms, 0, sizeof(*syms));
+
+  IREE_TRACE_ZONE_END(z0);
+}

--- a/runtime/src/iree/hal/drivers/hip/rccl_dynamic_symbols.h
+++ b/runtime/src/iree/hal/drivers/hip/rccl_dynamic_symbols.h
@@ -19,7 +19,7 @@ extern "C" {
 // iree_dynamic_library_t allows dynamically loading a subset of the NCCL API.
 // We load all the symbols in `nccl_dynamic_symbol_table.h` and fail if any of
 // the symbol is not available. The functions signatures are matching the
-// declarations in `nccl.h"`.
+// declarations in `nccl.h`.
 
 // NCCL API dynamic symbols.
 typedef struct iree_hal_hip_nccl_dynamic_symbols_t {

--- a/runtime/src/iree/hal/drivers/hip/rccl_dynamic_symbols.h
+++ b/runtime/src/iree/hal/drivers/hip/rccl_dynamic_symbols.h
@@ -1,0 +1,57 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_DRIVERS_HIP_NCCL_DYNAMIC_SYMBOLS_H_
+#define IREE_HAL_DRIVERS_HIP_NCCL_DYNAMIC_SYMBOLS_H_
+
+#include "iree/base/api.h"
+#include "iree/base/internal/dynamic_library.h"
+#include "iree/hal/drivers/hip/dynamic_symbols.h"
+#include "iree/hal/drivers/hip/rccl_headers.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// iree_dynamic_library_t allows dynamically loading a subset of the NCCL API.
+// We load all the symbols in `nccl_dynamic_symbol_table.h` and fail if any of
+// the symbol is not available. The functions signatures are matching the
+// declarations in `nccl.h"`.
+
+// NCCL API dynamic symbols.
+typedef struct iree_hal_hip_nccl_dynamic_symbols_t {
+  // The dynamic library handle.
+  iree_dynamic_library_t* dylib;
+
+  // Concrete NCCL symbols defined by including the `dynamic_symbol_tables.h`.
+#define IREE_NCCL_PFN_DECL(ncclSymbolName, ...) \
+  ncclResult_t (*ncclSymbolName)(__VA_ARGS__);
+#define IREE_NCCL_PFN_DECL_STR_RETURN(ncclSymbolName, ...) \
+  const char* (*ncclSymbolName)(__VA_ARGS__);
+#include "iree/hal/drivers/hip/rccl_dynamic_symbol_table.h"  // IWYU pragma: export
+#undef IREE_NCCL_PFN_DECL
+#undef IREE_NCCL_PFN_DECL_STR_RETURN
+} iree_hal_hip_nccl_dynamic_symbols_t;
+
+// Initializes |out_syms| in-place with dynamically loaded NCCL symbols.
+// iree_hal_hip_dynamic_symbols_deinitialize must be used to release the
+// library resources.
+iree_status_t iree_hal_hip_nccl_dynamic_symbols_initialize(
+    iree_allocator_t host_allocator,
+    const iree_hal_hip_dynamic_symbols_t* hip_library,
+    iree_hal_hip_nccl_dynamic_symbols_t* out_syms);
+
+// Deinitializes |syms| by unloading the backing library. All function pointers
+// will be invalidated. They _may_ still work if there are other reasons the
+// library remains loaded so be careful.
+void iree_hal_hip_nccl_dynamic_symbols_deinitialize(
+    iree_hal_hip_nccl_dynamic_symbols_t* syms);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_DRIVERS_HIP_NCCL_DYNAMIC_SYMBOLS_H_

--- a/runtime/src/iree/hal/drivers/hip/rccl_dynamic_symbols.h
+++ b/runtime/src/iree/hal/drivers/hip/rccl_dynamic_symbols.h
@@ -4,8 +4,8 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef IREE_HAL_DRIVERS_HIP_NCCL_DYNAMIC_SYMBOLS_H_
-#define IREE_HAL_DRIVERS_HIP_NCCL_DYNAMIC_SYMBOLS_H_
+#ifndef IREE_HAL_DRIVERS_HIP_RCCL_DYNAMIC_SYMBOLS_H_
+#define IREE_HAL_DRIVERS_HIP_RCCL_DYNAMIC_SYMBOLS_H_
 
 #include "iree/base/api.h"
 #include "iree/base/internal/dynamic_library.h"
@@ -54,4 +54,4 @@ void iree_hal_hip_nccl_dynamic_symbols_deinitialize(
 }  // extern "C"
 #endif  // __cplusplus
 
-#endif  // IREE_HAL_DRIVERS_HIP_NCCL_DYNAMIC_SYMBOLS_H_
+#endif  // IREE_HAL_DRIVERS_HIP_RCCL_DYNAMIC_SYMBOLS_H_

--- a/runtime/src/iree/hal/drivers/hip/rccl_headers.h
+++ b/runtime/src/iree/hal/drivers/hip/rccl_headers.h
@@ -4,9 +4,9 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef IREE_HAL_DRIVERS_HIP_NCCL_HEADERS_H_
-#define IREE_HAL_DRIVERS_HIP_NCCL_HEADERS_H_
+#ifndef IREE_HAL_DRIVERS_HIP_RCCL_HEADERS_H_
+#define IREE_HAL_DRIVERS_HIP_RCCL_HEADERS_H_
 
 #include "third_party/rccl/rccl.h"  // IWYU pragma: export
 
-#endif  // IREE_HAL_DRIVERS_HIP_NCCL_HEADERS_H_
+#endif  // IREE_HAL_DRIVERS_HIP_RCCL_HEADERS_H_

--- a/runtime/src/iree/hal/drivers/hip/rccl_headers.h
+++ b/runtime/src/iree/hal/drivers/hip/rccl_headers.h
@@ -1,0 +1,12 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_DRIVERS_HIP_NCCL_HEADERS_H_
+#define IREE_HAL_DRIVERS_HIP_NCCL_HEADERS_H_
+
+#include "third_party/rccl/rccl.h"  // IWYU pragma: export
+
+#endif  // IREE_HAL_DRIVERS_HIP_NCCL_HEADERS_H_

--- a/runtime/src/iree/hal/drivers/hip/rccl_status_util.c
+++ b/runtime/src/iree/hal/drivers/hip/rccl_status_util.c
@@ -1,0 +1,49 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/hip/rccl_status_util.h"
+
+#include <stddef.h>
+
+#include "iree/hal/drivers/hip/rccl_dynamic_symbols.h"
+
+iree_status_t iree_hal_hip_nccl_result_to_status(
+    const iree_hal_hip_nccl_dynamic_symbols_t* syms, ncclResult_t result,
+    const char* file, uint32_t line) {
+  iree_status_code_t code;
+
+  switch (result) {
+    case ncclSuccess:
+      return iree_ok_status();
+    case ncclUnhandledCudaError:
+      code = IREE_STATUS_FAILED_PRECONDITION;
+      break;
+    case ncclSystemError:
+      code = IREE_STATUS_INTERNAL;
+      break;
+    case ncclInternalError:
+      code = IREE_STATUS_INTERNAL;
+      break;
+    case ncclInvalidArgument:
+      code = IREE_STATUS_INVALID_ARGUMENT;
+      break;
+    case ncclInvalidUsage:
+      code = IREE_STATUS_FAILED_PRECONDITION;
+      break;
+    case ncclRemoteError:
+      code = IREE_STATUS_UNAVAILABLE;
+      break;
+    case ncclInProgress:
+      code = IREE_STATUS_DEFERRED;
+      break;
+    default:
+      code = IREE_STATUS_INTERNAL;
+      break;
+  }
+  return iree_make_status_with_location(file, line, code, "NCCL error %d: %s",
+                                        result,
+                                        syms->ncclGetErrorString(result));
+}

--- a/runtime/src/iree/hal/drivers/hip/rccl_status_util.h
+++ b/runtime/src/iree/hal/drivers/hip/rccl_status_util.h
@@ -1,0 +1,68 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_DRIVERS_HIP_NCCL_STATUS_UTIL_H_
+#define IREE_HAL_DRIVERS_HIP_NCCL_STATUS_UTIL_H_
+
+#include <stdint.h>
+
+#include "iree/base/api.h"
+#include "iree/hal/drivers/hip/rccl_dynamic_symbols.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// Converts a ncclResult_t to an iree_status_t.
+//
+// Usage:
+//   iree_status_t status = IREE_NCCL_RESULT_TO_STATUS(nccl_symbols,
+//                                                     ncclDoThing(...));
+#define IREE_NCCL_RESULT_TO_STATUS(syms, expr, ...) \
+  iree_hal_hip_nccl_result_to_status((syms), ((syms)->expr), __FILE__, __LINE__)
+
+// IREE_RETURN_IF_ERROR but implicitly converts the ncclResult_t return value to
+// an iree_status_t.
+//
+// Usage:
+//   IREE_NCCL_RETURN_IF_ERROR(nccl_symbols, ncclDoThing(...), "message");
+#define IREE_NCCL_RETURN_IF_ERROR(syms, expr, ...)                      \
+  IREE_RETURN_IF_ERROR(iree_hal_hip_nccl_result_to_status(              \
+                           (syms), ((syms)->expr), __FILE__, __LINE__), \
+                       __VA_ARGS__)
+
+// IREE_RETURN_IF_ERROR but ends the current zone and implicitly converts the
+// ncclResult_t return value to an iree_status_t.
+//
+// Usage:
+//   IREE_NCCL_RETURN_AND_END_ZONE_IF_ERROR(zone_id, hip_symbols,
+//                                          ncclDoThing(...), "message");
+#define IREE_NCCL_RETURN_AND_END_ZONE_IF_ERROR(zone_id, syms, expr, ...)   \
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(                                       \
+      zone_id,                                                             \
+      iree_hal_hip_nccl_result_to_status((syms), ((syms)->expr), __FILE__, \
+                                         __LINE__),                        \
+      __VA_ARGS__)
+
+// IREE_IGNORE_ERROR but implicitly converts the ncclResult_t return value to
+// an iree_status_t.
+//
+// Usage:
+//   IREE_NCCL_IGNORE_ERROR(nccl_symbols, ncclDoThing(...));
+#define IREE_NCCL_IGNORE_ERROR(syms, expr)                                     \
+  IREE_IGNORE_ERROR(iree_hal_hip_nccl_result_to_status((syms), ((syms)->expr), \
+                                                       __FILE__, __LINE__))
+
+// Converts a ncclResult_t to an iree_status_t object.
+iree_status_t iree_hal_hip_nccl_result_to_status(
+    const iree_hal_hip_nccl_dynamic_symbols_t* syms, ncclResult_t result,
+    const char* file, uint32_t line);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_DRIVERS_HIP_NCCL_STATUS_UTIL_H_

--- a/runtime/src/iree/hal/drivers/hip/rccl_status_util.h
+++ b/runtime/src/iree/hal/drivers/hip/rccl_status_util.h
@@ -4,8 +4,8 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef IREE_HAL_DRIVERS_HIP_NCCL_STATUS_UTIL_H_
-#define IREE_HAL_DRIVERS_HIP_NCCL_STATUS_UTIL_H_
+#ifndef IREE_HAL_DRIVERS_HIP_RCCL_STATUS_UTIL_H_
+#define IREE_HAL_DRIVERS_HIP_RCCL_STATUS_UTIL_H_
 
 #include <stdint.h>
 
@@ -65,4 +65,4 @@ iree_status_t iree_hal_hip_nccl_result_to_status(
 }  // extern "C"
 #endif  // __cplusplus
 
-#endif  // IREE_HAL_DRIVERS_HIP_NCCL_STATUS_UTIL_H_
+#endif  // IREE_HAL_DRIVERS_HIP_RCCL_STATUS_UTIL_H_

--- a/runtime/src/iree/hal/drivers/hip/stream_command_buffer.h
+++ b/runtime/src/iree/hal/drivers/hip/stream_command_buffer.h
@@ -11,6 +11,7 @@
 #include "iree/hal/api.h"
 #include "iree/hal/drivers/hip/dynamic_symbols.h"
 #include "iree/hal/drivers/hip/hip_headers.h"
+#include "iree/hal/drivers/hip/rccl_dynamic_symbols.h"
 #include "iree/hal/drivers/hip/tracing.h"
 
 #ifdef __cplusplus
@@ -31,6 +32,7 @@ extern "C" {
 iree_status_t iree_hal_hip_stream_command_buffer_create(
     iree_hal_device_t* device,
     const iree_hal_hip_dynamic_symbols_t* hip_symbols,
+    const iree_hal_hip_nccl_dynamic_symbols_t* nccl_symbols,
     iree_hal_hip_tracing_context_t* tracing_context,
     iree_hal_command_buffer_mode_t mode,
     iree_hal_command_category_t command_categories,

--- a/tests/e2e/collectives/CMakeLists.txt
+++ b/tests/e2e/collectives/CMakeLists.txt
@@ -19,8 +19,8 @@ if(IREE_TARGET_BACKEND_CUDA AND IREE_HAL_DRIVER_CUDA)
   )
 
   set(COMMON_LABELS
-    "requires-gpu-amd"
-    "driver=hip"
+    "requires-gpu-nvidia"
+    "driver=cuda"
   )
 
   iree_py_test(

--- a/tests/e2e/collectives/CMakeLists.txt
+++ b/tests/e2e/collectives/CMakeLists.txt
@@ -11,32 +11,40 @@ if(NOT IREE_BUILD_BUNDLED_LLVM OR NOT IREE_ENABLE_COLLECTIVE_RUNTIME_TESTS)
 endif()
 
 if(IREE_TARGET_BACKEND_CUDA AND IREE_HAL_DRIVER_CUDA)
-  iree_py_test(
-    NAME
-      collectives_test_1_gpu
-    SRCS
-      "collectives_test.py"
-    ARGS
-      "-k" "SingleRank"
-      "--target_backend=cuda"
-      "--driver=cuda"
-    LABELS
-      "requires-gpu-nvidia"
-      "driver=cuda"
+
+  set(COMMON_ARGS
+    "--target_backend=cuda"
+    "--driver=cuda"
+    "--iree_compiler_args=--iree-hal-cuda-llvm-target-arch=sm_53"
+  )
+
+  set(COMMON_LABELS
+    "requires-gpu-amd"
+    "driver=hip"
   )
 
   iree_py_test(
     NAME
-      collectives_test_2_gpus
+      collectives_test_cuda_1_gpu
+    SRCS
+      "collectives_test.py"
+    ARGS
+      "-k" "SingleRank"
+      ${COMMON_ARGS}
+    LABELS
+      ${COMMON_LABELS}
+  )
+
+  iree_py_test(
+    NAME
+      collectives_test_cuda_2_gpus
     SRCS
       "collectives_test.py"
     ARGS
       "-k" "TwoRanks"
-      "--target_backend=cuda"
-      "--driver=cuda"
+      ${COMMON_ARGS}
     LABELS
-      "requires-gpu-nvidia"
-      "driver=cuda"
+      ${COMMON_LABELS}
       # The NCCL collectives backend requires 1 GPU per rank.
       # To properly test for 2 ranks we need 2 GPUs.
       "requires-multiple-devices"
@@ -44,16 +52,67 @@ if(IREE_TARGET_BACKEND_CUDA AND IREE_HAL_DRIVER_CUDA)
 
   iree_py_test(
     NAME
-      collectives_test_4_gpus
+      collectives_test_cuda_4_gpus
     SRCS
       "collectives_test.py"
     ARGS
       "-k" "FourRanks"
-      "--target_backend=cuda"
-      "--driver=cuda"
+      ${COMMON_ARGS}
     LABELS
-      "requires-gpu-nvidia"
-      "driver=cuda"
+      ${COMMON_LABELS}
+      "requires-multiple-devices"
+  )
+endif()
+
+if(IREE_TARGET_BACKEND_ROCM AND IREE_HAL_DRIVER_HIP AND IREE_HIP_TEST_TARGET_CHIP)
+  set(COMMON_ARGS
+    "--target_backend=rocm"
+    "--driver=hip"
+    "--iree_compiler_args=--iree-rocm-target-chip=${IREE_HIP_TEST_TARGET_CHIP}"
+  )
+
+  set(COMMON_LABELS
+    "requires-gpu-amd"
+    "driver=hip"
+  )
+
+  iree_py_test(
+    NAME
+      collectives_test_hip_1_gpu
+    SRCS
+      "collectives_test.py"
+    ARGS
+      "-k" "SingleRank"
+      ${COMMON_ARGS}
+    LABELS
+      ${COMMON_LABELS}
+  )
+
+  iree_py_test(
+    NAME
+      collectives_test_hip_2_gpus
+    SRCS
+      "collectives_test.py"
+    ARGS
+      "-k" "TwoRanks"
+      ${COMMON_ARGS}
+    LABELS
+      ${COMMON_LABELS}
+      # The NCCL collectives backend requires 1 GPU per rank.
+      # To properly test for 2 ranks we need 2 GPUs.
+      "requires-multiple-devices"
+  )
+
+  iree_py_test(
+    NAME
+      collectives_test_hip_4_gpus
+    SRCS
+      "collectives_test.py"
+    ARGS
+      "-k" "FourRanks"
+      ${COMMON_ARGS}
+    LABELS
+      ${COMMON_LABELS}
       "requires-multiple-devices"
   )
 endif()

--- a/tests/e2e/collectives/collectives_test.py
+++ b/tests/e2e/collectives/collectives_test.py
@@ -24,6 +24,7 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--target_backend", type=str, default="llvm-cpu")
     parser.add_argument("--driver", type=str, default="local-task")
+    parser.add_argument("--iree_compiler_args", type=str, default="")
     return parser.parse_known_args()
 
 
@@ -104,7 +105,8 @@ def run_test(
             output_file=module_filepath,
             target_backends=[args.target_backend],
             input_type=mlir_input_type,
-            extra_args=["--iree-hal-cuda-llvm-target-arch", "sm_53"],
+            # TODO: do a proper split with " handling.
+            extra_args=args.iree_compiler_args.split(),
         )
 
         num_ranks = len(inputs)

--- a/third_party/rccl/LICENSE.txt
+++ b/third_party/rccl/LICENSE.txt
@@ -1,0 +1,45 @@
+
+Attributions
+
+Contains contributions from NVIDIA.
+
+Copyright (c) 2015-2020, NVIDIA CORPORATION. All rights reserved.
+Modifications Copyright (c) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
+Modifications Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  * Neither the name of NVIDIA CORPORATION, Lawrence Berkeley National
+    Laboratory, the U.S. Department of Energy, nor the names of their
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ The U.S. Department of Energy funded the development of this software
+ under subcontract 7078610 with Lawrence Berkeley National Laboratory.
+
+
+This code also includes files from the NVIDIA Tools Extension SDK project.
+
+See:
+
+   https://github.com/NVIDIA/NVTX
+
+for more information and license details.

--- a/third_party/rccl/README.md
+++ b/third_party/rccl/README.md
@@ -1,6 +1,6 @@
 # The declaration-only header for RCCL
 
-The header is copied from a build of RCCL 2.18.6 (Git tag `rocm-6.1.0`).
+The header is copied from a build of RCCL 2.18.3 (Git tag `rocm-6.0.2`).
 
 This declaration-only header is required to query the dynamically injected
 RCCL API at runtime. See the following for more information:

--- a/third_party/rccl/README.md
+++ b/third_party/rccl/README.md
@@ -1,0 +1,9 @@
+# The declaration-only header for RCCL
+
+The header is copied from a build of RCCL 2.18.6 (Git tag `rocm-6.1.0`).
+
+This declaration-only header is required to query the dynamically injected
+RCCL API at runtime. See the following for more information:
+
+* [RCCL Documentation](https://rocmdocs.amd.com/projects/rccl/en/latest/index.html)
+* [Repository](https://github.com/ROCm/rccl)

--- a/third_party/rccl/rccl.h
+++ b/third_party/rccl/rccl.h
@@ -14,10 +14,10 @@
 
 #define NCCL_MAJOR 2
 #define NCCL_MINOR 18
-#define NCCL_PATCH 6
+#define NCCL_PATCH 3
 #define NCCL_SUFFIX ""
 
-#define NCCL_VERSION_CODE 21806
+#define NCCL_VERSION_CODE 21803
 #define NCCL_VERSION(X,Y,Z) (((X) <= 2 && (Y) <= 8) ? (X) * 1000 + (Y) * 100 + (Z) : (X) * 10000 + (Y) * 100 + (Z))
 
 #define RCCL_BFLOAT16 1

--- a/third_party/rccl/rccl.h
+++ b/third_party/rccl/rccl.h
@@ -1,0 +1,802 @@
+/*************************************************************************
+ * Copyright (c) 2015-2021, NVIDIA CORPORATION. All rights reserved.
+ * Modifications Copyright (c) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Modifications Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#ifndef NCCL_H_
+#define NCCL_H_
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+#define NCCL_MAJOR 2
+#define NCCL_MINOR 18
+#define NCCL_PATCH 6
+#define NCCL_SUFFIX ""
+
+#define NCCL_VERSION_CODE 21806
+#define NCCL_VERSION(X,Y,Z) (((X) <= 2 && (Y) <= 8) ? (X) * 1000 + (Y) * 100 + (Z) : (X) * 10000 + (Y) * 100 + (Z))
+
+#define RCCL_BFLOAT16 1
+#define RCCL_GATHER_SCATTER 1
+#define RCCL_ALLTOALLV 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <limits.h>
+
+/*! @brief      Opaque handle to communicator
+    @details    A communicator contains information required to facilitate collective communications calls */
+typedef struct ncclComm* ncclComm_t;
+#define NCCL_COMM_NULL NULL
+
+#define NCCL_UNIQUE_ID_BYTES 128
+/*! @brief      Opaque unique id used to initialize communicators
+    @details    The ncclUniqueId must be passed to all participating ranks */
+typedef struct { char internal[NCCL_UNIQUE_ID_BYTES]; /*!< Opaque array>*/} ncclUniqueId;
+
+/*! @defgroup   rccl_result_code Result Codes
+    @details    The various result codes that RCCL API calls may return
+    @{ */
+
+/*! @brief      Result type
+    @details    Return codes aside from ncclSuccess indicate that a call has failed */
+  typedef enum {
+    ncclSuccess                 =  0, /*!< No error */
+    ncclUnhandledCudaError      =  1, /*!< Unhandled HIP error */
+    ncclSystemError             =  2, /*!< Unhandled system error */
+    ncclInternalError           =  3, /*!< Internal Error - Please report to RCCL developers */
+    ncclInvalidArgument         =  4, /*!< Invalid argument */
+    ncclInvalidUsage            =  5, /*!< Invalid usage */
+    ncclRemoteError             =  6, /*!< Remote process exited or there was a network error */
+    ncclInProgress              =  7, /*!< RCCL operation in progress */
+    ncclNumResults              =  8  /*!< Number of result types */
+  } ncclResult_t;
+/*! @} */
+
+#define NCCL_CONFIG_UNDEF_INT INT_MIN
+#define NCCL_CONFIG_UNDEF_PTR NULL
+#define NCCL_SPLIT_NOCOLOR -1
+
+/*! @defgroup   rccl_config_type Communicator Configuration
+    @details    Structure that allows for customizing Communicator behavior via ncclCommInitRankConfig
+    @{ */
+
+/*! @brief      Communicator configuration
+    @details    Users can assign value to attributes to specify the behavior of a communicator */
+typedef struct ncclConfig_v21700 {
+  /* attributes that users should never touch. */
+  size_t size;                 /*!< Should not be touched */
+  unsigned int magic;          /*!< Should not be touched */
+  unsigned int version;        /*!< Should not be touched */
+  /* attributes that users are able to customize. */
+  int blocking;                /*!< Whether or not calls should block or not */
+  int cgaClusterSize;          /*!< Cooperative group array cluster size */
+  int minCTAs;                 /*!< Minimum number of cooperative thread arrays (blocks) */
+  int maxCTAs;                 /*!< Maximum number of cooperative thread arrays (blocks) */
+  const char *netName;         /*!< Force NCCL to use a specfic network */
+  int splitShare;              /*!< Allow communicators to share resources */
+} ncclConfig_t;
+
+/* Config initializer must be assigned to initialize config structure when it is created.
+ * Not initialized config will result in an error. */
+#define NCCL_CONFIG_INITIALIZER {                                        \
+  sizeof(ncclConfig_t),                             /* size */           \
+  0xcafebeef,                                       /* magic */          \
+  NCCL_VERSION(NCCL_MAJOR, NCCL_MINOR, NCCL_PATCH), /* version */        \
+  NCCL_CONFIG_UNDEF_INT,                            /* blocking */       \
+  NCCL_CONFIG_UNDEF_INT,                            /* cgaClusterSize */ \
+  NCCL_CONFIG_UNDEF_INT,                            /* minCTAs */        \
+  NCCL_CONFIG_UNDEF_INT,                            /* maxCTAs */        \
+  NCCL_CONFIG_UNDEF_PTR,                            /* netName */        \
+  NCCL_CONFIG_UNDEF_INT                             /* splitShare */     \
+}
+/*! @} */
+
+/*! @defgroup   rccl_api_version Version Information
+    @details    API call that returns RCCL version
+    @{ */
+
+/*! @brief      Return the RCCL_VERSION_CODE of RCCL in the supplied integer.
+    @details    This integer is coded with the MAJOR, MINOR and PATCH level of RCCL.
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[out] version       Pointer to where version will be stored */
+ncclResult_t  ncclGetVersion(int *version);
+/*! @cond       include_hidden */
+ncclResult_t pncclGetVersion(int *version);
+/*! @endcond */
+/*! @} */
+
+/*! @defgroup   rccl_api_communicator Communicator Initialization/Destruction
+    @details    API calls that operate on communicators.
+                Communicators objects are used to launch collective communication
+                operations.  Unique ranks between 0 and N-1 must be assigned to
+                each HIP device participating in the same Communicator.
+                Using the same HIP device for multiple ranks of the same Communicator
+                is not supported at this time.
+    @{ */
+
+/*! @brief      Generates an ID for ncclCommInitRank.
+    @details    Generates an ID to be used in ncclCommInitRank.
+                ncclGetUniqueId should be called once by a single rank and the
+                ID should be distributed to all ranks in the communicator before
+                using it as a parameter for ncclCommInitRank.
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[out] uniqueId      Pointer to where uniqueId will be stored */
+ncclResult_t  ncclGetUniqueId(ncclUniqueId* uniqueId);
+/*! @cond       include_hidden */
+ncclResult_t pncclGetUniqueId(ncclUniqueId* uniqueId);
+/*! @endcond */
+
+/*! @brief      Create a new communicator with config.
+    @details    Create a new communicator (multi thread/process version) with a configuration
+                set by users. See @ref rccl_config_type for more details.
+                Each rank is associated to a CUDA device, which has to be set before calling
+                ncclCommInitRank.
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[out] comm          Pointer to created communicator
+    @param[in]  nranks        Total number of ranks participating in this communicator
+    @param[in]  commId        UniqueId required for initialization
+    @param[in]  rank          Current rank to create communicator for. [0 to nranks-1]
+    @param[in]  config        Pointer to communicator configuration */
+ncclResult_t  ncclCommInitRankConfig(ncclComm_t* comm, int nranks, ncclUniqueId commId, int rank, ncclConfig_t* config);
+/*! @cond       include_hidden */
+ncclResult_t pncclCommInitRankConfig(ncclComm_t* comm, int nranks, ncclUniqueId commId, int rank, ncclConfig_t* config);
+/*! @endcond */
+
+/*! @brief      Creates a new communicator (multi thread/process version).
+    @details    Rank must be between 0 and nranks-1 and unique within a communicator clique.
+                Each rank is associated to a CUDA device, which has to be set before calling
+                ncclCommInitRank.  ncclCommInitRank implicitly syncronizes with other ranks,
+                so it must be called by different threads/processes or use ncclGroupStart/ncclGroupEnd.
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[out] comm          Pointer to created communicator
+    @param[in]  nranks        Total number of ranks participating in this communicator
+    @param[in]  commId        UniqueId required for initialization
+    @param[in]  rank          Current rank to create communicator for */
+ncclResult_t  ncclCommInitRank(ncclComm_t* comm, int nranks, ncclUniqueId commId, int rank);
+/*! @cond       include_hidden */
+ncclResult_t pncclCommInitRank(ncclComm_t* comm, int nranks, ncclUniqueId commId, int rank);
+/*! @endcond */
+
+/*! @brief      Creates a clique of communicators (single process version).
+    @details    This is a convenience function to create a single-process communicator clique.
+                Returns an array of ndev newly initialized communicators in comm.
+                comm should be pre-allocated with size at least ndev*sizeof(ncclComm_t).
+                If devlist is NULL, the first ndev HIP devices are used.
+                Order of devlist defines user-order of processors within the communicator.
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[out] comm          Pointer to array of created communicators
+    @param[in]  ndev          Total number of ranks participating in this communicator
+    @param[in]  devlist       Array of GPU device indices to create for */
+ncclResult_t  ncclCommInitAll(ncclComm_t* comm, int ndev, const int* devlist);
+/*! @cond       include_hidden */
+ncclResult_t pncclCommInitAll(ncclComm_t* comm, int ndev, const int* devlist);
+/*! @endcond */
+
+/*! @brief      Finalize a communicator.
+    @details    ncclCommFinalize flushes all issued communications
+                and marks communicator state as ncclInProgress. The state will change to ncclSuccess
+                when the communicator is globally quiescent and related resources are freed; then,
+                calling ncclCommDestroy can locally free the rest of the resources (e.g. communicator
+                itself) without blocking.
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  comm          Communicator to finalize */
+ncclResult_t  ncclCommFinalize(ncclComm_t comm);
+/*! @cond       include_hidden */
+ncclResult_t pncclCommFinalize(ncclComm_t comm);
+/*! @endcond */
+
+/*! @brief      Frees local resources associated with communicator object.
+    @details    Destroy all local resources associated with the passed in communicator object
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  comm          Communicator to destroy */
+ncclResult_t  ncclCommDestroy(ncclComm_t comm);
+/*! @cond       include_hidden */
+ncclResult_t pncclCommDestroy(ncclComm_t comm);
+/*! @endcond */
+
+/*! @brief      Abort any in-progress calls and destroy the communicator object.
+    @details    Frees resources associated with communicator object and aborts any operations
+                that might still be running on the device.
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  comm          Communicator to abort and destroy */
+ncclResult_t  ncclCommAbort(ncclComm_t comm);
+/*! @cond       include_hidden */
+ncclResult_t pncclCommAbort(ncclComm_t comm);
+/*! @endcond */
+
+/*! @brief      Create one or more communicators from an existing one.
+    @details    Creates one or more communicators from an existing one.
+                Ranks with the same color will end up in the same communicator.
+                Within the new communicator, key will be used to order ranks.
+                NCCL_SPLIT_NOCOLOR as color will indicate the rank will not be part of any group
+                and will therefore return a NULL communicator.
+                If config is NULL, the new communicator will inherit the original communicator's configuration
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  comm          Original communicator object for this rank
+    @param[in]  color         Color to assign this rank
+    @param[in]  key           Key used to order ranks within the same new communicator
+    @param[out] newcomm       Pointer to new communicator
+    @param[in]  config        Config file for new communicator. May be NULL to inherit from comm */
+ncclResult_t  ncclCommSplit(ncclComm_t comm, int color, int key, ncclComm_t *newcomm, ncclConfig_t* config);
+/*! @cond       include_hidden */
+ncclResult_t pncclCommSplit(ncclComm_t comm, int color, int key, ncclComm_t *newcomm, ncclConfig_t* config);
+/*! @endcond */
+/*! @} */
+
+/*! @defgroup   rccl_api_errcheck Error Checking Calls
+    @details    API calls that check for errors
+    @{ */
+
+/*! @brief      Returns a string for each result code.
+    @details    Returns a human-readable string describing the given result code.
+    @return     String containing description of result code.
+
+    @param[in]  result        Result code to get description for */
+const char*  ncclGetErrorString(ncclResult_t result);
+/*! @cond       include_hidden */
+const char* pncclGetErrorString(ncclResult_t result);
+/*! @endcond */
+
+/*! @brief      Returns mesage on last result that occured.
+    @details    Returns a human-readable message of the last error that occurred.
+    @return     String containing the last result
+
+    @param[in]  comm is currently unused and can be set to NULL */
+const char*  ncclGetLastError(ncclComm_t comm);
+/*! @cond       include_hidden */
+const char* pncclGetLastError(ncclComm_t comm);
+/*! @endcond */
+
+/*! @brief      Checks whether the comm has encountered any asynchronous errors
+    @details    Query whether the provided communicator has encountered any asynchronous errors
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  comm          Communicator to query
+    @param[out] asyncError    Pointer to where result code will be stored */
+ncclResult_t  ncclCommGetAsyncError(ncclComm_t comm, ncclResult_t *asyncError);
+/*! @cond       include_hidden */
+ncclResult_t pncclCommGetAsyncError(ncclComm_t comm, ncclResult_t *asyncError);
+/*! @endcond */
+/*! @} */
+
+/*! @defgroup   rccl_api_comminfo Communicator Information
+    @details    API calls that query communicator information
+    @{ */
+
+/*! @brief      Gets the number of ranks in the communicator clique.
+    @details    Returns the number of ranks in the communicator clique (as set during initialization)
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  comm          Communicator to query
+    @param[out] count         Pointer to where number of ranks will be stored */
+ncclResult_t  ncclCommCount(const ncclComm_t comm, int* count);
+/*! @cond       include_hidden */
+ncclResult_t pncclCommCount(const ncclComm_t comm, int* count);
+/*~ @endcond */
+
+/*! @brief      Get the ROCm device index associated with a communicator
+    @details    Returns the ROCm device number associated with the provided communicator.
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  comm          Communicator to query
+    @param[out] device        Pointer to where the associated ROCm device index will be stored */
+ncclResult_t  ncclCommCuDevice(const ncclComm_t comm, int* device);
+/*! @cond       include_hidden */
+ncclResult_t pncclCommCuDevice(const ncclComm_t comm, int* device);
+/*! @endcond */
+
+/*! @brief      Get the rank associated with a communicator
+    @details    Returns the user-ordered "rank" associated with the provided communicator.
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  comm          Communicator to query
+    @param[out] rank          Pointer to where the associated rank will be stored */
+ncclResult_t  ncclCommUserRank(const ncclComm_t comm, int* rank);
+/*! @cond       include_hidden */
+ncclResult_t pncclCommUserRank(const ncclComm_t comm, int* rank);
+/*! @endcond */
+/*! @} */
+
+/*! @defgroup   rccl_api_enumerations API Enumerations
+    @details    Enumerations used by collective communication calls
+    @{ */
+
+/*! @brief      Dummy reduction enumeration
+    @details    Dummy reduction enumeration used to determine value for ncclMaxRedOp */
+typedef enum { ncclNumOps_dummy = 5 } ncclRedOp_dummy_t;
+
+/*! @brief      Reduction operation selector
+    @details    Enumeration used to specify the various reduction operations
+                ncclNumOps is the number of built-in ncclRedOp_t values and serves as
+                the least possible value for dynamic ncclRedOp_t values constructed by
+                ncclRedOpCreate functions.
+
+                ncclMaxRedOp is the largest valid value for ncclRedOp_t and is defined
+                to be the largest signed value (since compilers are permitted to use
+                signed enums) that won't grow sizeof(ncclRedOp_t) when compared to previous
+                RCCL versions to maintain ABI compatibility. */
+typedef enum { ncclSum        = 0, /*!< Sum */
+               ncclProd       = 1, /*!< Product */
+               ncclMax        = 2, /*!< Max */
+               ncclMin        = 3, /*!< Min */
+               ncclAvg        = 4, /*!< Average */
+               ncclNumOps     = 5, /*!< Number of built-in reduction ops */
+               ncclMaxRedOp   = 0x7fffffff>>(32-8*sizeof(ncclRedOp_dummy_t)) /*!< Largest value for ncclRedOp_t */
+             } ncclRedOp_t;
+
+/*! @brief      Data types
+    @details    Enumeration of the various supported datatype */
+typedef enum { ncclInt8       = 0, ncclChar       = 0,
+               ncclUint8      = 1,
+               ncclInt32      = 2, ncclInt        = 2,
+               ncclUint32     = 3,
+               ncclInt64      = 4,
+               ncclUint64     = 5,
+               ncclFloat16    = 6, ncclHalf       = 6,
+               ncclFloat32    = 7, ncclFloat      = 7,
+               ncclFloat64    = 8, ncclDouble     = 8,
+               ncclBfloat16   = 9,
+               ncclNumTypes   = 10 } ncclDataType_t;
+/*! @} */
+
+/*! @defgroup   rccl_api_custom_redop Custom Reduction Operator
+    @details    API calls relating to creation/destroying custom reduction operator
+                that pre-multiplies local source arrays prior to reduction
+    @{ */
+
+/*! @brief      Location and dereferencing logic for scalar arguments.
+    @details    Enumeration specifying memory location of the scalar argument.
+                Based on where the value is stored, the argument will be dereferenced either
+                while the collective is running (if in device memory), or before the ncclRedOpCreate()
+                function returns (if in host memory). */
+typedef enum {
+  ncclScalarDevice        = 0, /*!< Scalar is in device-visible memory */
+  ncclScalarHostImmediate = 1  /*!< Scalar is in host-visible memory */
+} ncclScalarResidence_t;
+
+/*! @brief      Create a custom pre-multiplier reduction operator
+    @details    Creates a new reduction operator which pre-multiplies input values by a given
+                scalar locally before reducing them with peer values via summation. For use
+                only with collectives launched against *comm* and *datatype*. The
+                *residence* argument indicates how/when the memory pointed to by *scalar*
+                will be dereferenced. Upon return, the newly created operator's handle
+                is stored in *op*.
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[out] op            Pointer to where newly created custom reduction operator is to be stored
+    @param[in]  scalar        Pointer to scalar value.
+    @param[in]  datatype      Scalar value datatype
+    @param[in]  residence     Memory type of the scalar value
+    @param[in]  comm          Communicator to associate with this custom reduction operator */
+ncclResult_t  ncclRedOpCreatePreMulSum(ncclRedOp_t *op, void *scalar, ncclDataType_t datatype, ncclScalarResidence_t residence, ncclComm_t comm);
+/*! @cond       include_hidden */
+ncclResult_t pncclRedOpCreatePreMulSum(ncclRedOp_t *op, void *scalar, ncclDataType_t datatype, ncclScalarResidence_t residence, ncclComm_t comm);
+/*! @endcond */
+
+/*! @brief      Destroy custom reduction operator
+    @details    Destroys the reduction operator *op*. The operator must have been created by
+                ncclRedOpCreatePreMul with the matching communicator *comm*. An operator may be
+                destroyed as soon as the last RCCL function which is given that operator returns.
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  op            Custom reduction operator is to be destroyed
+    @param[in]  comm          Communicator associated with this reduction operator */
+ncclResult_t ncclRedOpDestroy(ncclRedOp_t op, ncclComm_t comm);
+/*! @cond       include_hidden */
+ncclResult_t pncclRedOpDestroy(ncclRedOp_t op, ncclComm_t comm);
+/*! @endcond */
+/*! @} */
+
+/*! @defgroup   rccl_collective_api Collective Communication Operations
+    @details    Collective communication operations must be called separately for each
+                communicator in a communicator clique.
+
+                They return when operations have been enqueued on the HIP stream.
+                Since they may perform inter-CPU synchronization, each call has to be done
+                from a different thread or process, or need to use Group Semantics (see
+                below).
+    @{ */
+
+/*! @brief      Reduce
+    @details    Reduces data arrays of length *count* in *sendbuff* into *recvbuff* using *op*
+                operation.
+                *recvbuff* may be NULL on all calls except for root device.
+                *root* is the rank (not the HIP device) where data will reside after the
+                 operation is complete.
+                In-place operation will happen if sendbuff == recvbuff.
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  sendbuff      Local device data buffer to be reduced
+    @param[out] recvbuff      Data buffer where result is stored (only for *root* rank).  May be null for other ranks.
+    @param[in]  count         Number of elements in every send buffer
+    @param[in]  datatype      Data buffer element datatype
+    @param[in]  op            Reduction operator type
+    @param[in]  root          Rank where result data array will be stored
+    @param[in]  comm          Communicator group object to execute on
+    @param[in]  stream        HIP stream to execute collective on */
+ncclResult_t  ncclReduce(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
+    ncclRedOp_t op, int root, ncclComm_t comm, hipStream_t stream);
+/*! @cond       include_hidden */
+ncclResult_t pncclReduce(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
+    ncclRedOp_t op, int root, ncclComm_t comm, hipStream_t stream);
+/*! @endcond */
+
+/*! @brief      (Deprecated) Broadcast (in-place)
+    @details    Copies *count* values from *root* to all other devices.
+                root is the rank (not the CUDA device) where data resides before the
+                operation is started.
+                This operation is implicitly in-place.
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in,out]  buff      Input array on *root* to be copied to other ranks.  Output array for all ranks.
+    @param[in]  count         Number of elements in data buffer
+    @param[in]  datatype      Data buffer element datatype
+    @param[in]  root          Rank owning buffer to be copied to others
+    @param[in]  comm          Communicator group object to execute on
+    @param[in]  stream        HIP stream to execute collective on */
+ncclResult_t  ncclBcast(void* buff, size_t count, ncclDataType_t datatype, int root,
+    ncclComm_t comm, hipStream_t stream);
+/*! @cond       include_hidden */
+ncclResult_t pncclBcast(void* buff, size_t count, ncclDataType_t datatype, int root,
+    ncclComm_t comm, hipStream_t stream);
+/*! @endcond */
+
+/*! @brief      Broadcast
+    @details    Copies *count* values from *sendbuff* on *root* to *recvbuff* on all devices.
+                *root* is the rank (not the HIP device) where data resides before the operation is started.
+                *sendbuff* may be NULL on ranks other than *root*.
+                In-place operation will happen if *sendbuff* == *recvbuff*.
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  sendbuff      Data array to copy (if *root*).  May be NULL for other ranks
+    @param[in]  recvbuff      Data array to store received array
+    @param[in]  count         Number of elements in data buffer
+    @param[in]  datatype      Data buffer element datatype
+    @param[in]  root          Rank of broadcast root
+    @param[in]  comm          Communicator group object to execute on
+    @param[in]  stream        HIP stream to execute collective on */
+ncclResult_t  ncclBroadcast(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, int root,
+    ncclComm_t comm, hipStream_t stream);
+/*! @cond       include_hidden */
+ncclResult_t pncclBroadcast(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, int root,
+    ncclComm_t comm, hipStream_t stream);
+/*! @endcond */
+
+/*! @brief      All-Reduce
+    @details    Reduces data arrays of length *count* in *sendbuff* using *op* operation, and
+                leaves identical copies of result on each *recvbuff*.
+                In-place operation will happen if sendbuff == recvbuff.
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  sendbuff      Input data array to reduce
+    @param[out] recvbuff      Data array to store reduced result array
+    @param[in]  count         Number of elements in data buffer
+    @param[in]  datatype      Data buffer element datatype
+    @param[in]  op            Reduction operator
+    @param[in]  comm          Communicator group object to execute on
+    @param[in]  stream        HIP stream to execute collective on */
+ncclResult_t  ncclAllReduce(const void* sendbuff, void* recvbuff, size_t count,
+    ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, hipStream_t stream);
+/*! @cond       include_hidden */
+ncclResult_t pncclAllReduce(const void* sendbuff, void* recvbuff, size_t count,
+    ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm, hipStream_t stream);
+/*! @endcond */
+
+/*! @brief      Reduce-Scatter
+    @details    Reduces data in *sendbuff* using *op* operation and leaves reduced result
+                scattered over the devices so that *recvbuff* on rank i will contain the i-th
+                block of the result.
+                Assumes sendcount is equal to nranks*recvcount, which means that *sendbuff*
+                should have a size of at least nranks*recvcount elements.
+                In-place operations will happen if recvbuff == sendbuff + rank * recvcount.
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  sendbuff      Input data array to reduce
+    @param[out] recvbuff      Data array to store reduced result subarray
+    @param[in]  recvcount     Number of elements each rank receives
+    @param[in]  datatype      Data buffer element datatype
+    @param[in]  op            Reduction operator
+    @param[in]  comm          Communicator group object to execute on
+    @param[in]  stream        HIP stream to execute collective on */
+ncclResult_t  ncclReduceScatter(const void* sendbuff, void* recvbuff,
+    size_t recvcount, ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm,
+    hipStream_t stream);
+/*! @cond       include_hidden */
+ncclResult_t pncclReduceScatter(const void* sendbuff, void* recvbuff,
+    size_t recvcount, ncclDataType_t datatype, ncclRedOp_t op, ncclComm_t comm,
+    hipStream_t stream);
+/*! @endcond */
+
+/*! @brief      All-Gather
+    @details    Each device gathers *sendcount* values from other GPUs into *recvbuff*,
+                receiving data from rank i at offset i*sendcount.
+                Assumes recvcount is equal to nranks*sendcount, which means that recvbuff
+                should have a size of at least nranks*sendcount elements.
+                In-place operations will happen if sendbuff == recvbuff + rank * sendcount.
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  sendbuff      Input data array to send
+    @param[out] recvbuff      Data array to store the gathered result
+    @param[in]  sendcount     Number of elements each rank sends
+    @param[in]  datatype      Data buffer element datatype
+    @param[in]  comm          Communicator group object to execute on
+    @param[in]  stream        HIP stream to execute collective on */
+ncclResult_t  ncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcount,
+    ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream);
+/*! @cond       include_hidden */
+ncclResult_t pncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcount,
+    ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream);
+/*! @endcond */
+
+/*! @brief      Send
+    @details    Send data from *sendbuff* to rank *peer*.
+                Rank *peer* needs to call ncclRecv with the same *datatype* and the same *count*
+                as this rank.
+                This operation is blocking for the GPU. If multiple ncclSend and ncclRecv operations
+                need to progress concurrently to complete, they must be fused within a ncclGroupStart /
+                ncclGroupEnd section.
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  sendbuff      Data array to send
+    @param[in]  count         Number of elements to send
+    @param[in]  datatype      Data buffer element datatype
+    @param[in]  peer          Peer rank to send to
+    @param[in]  comm          Communicator group object to execute on
+    @param[in]  stream        HIP stream to execute collective on */
+ncclResult_t  ncclSend(const void* sendbuff, size_t count, ncclDataType_t datatype, int peer,
+    ncclComm_t comm, hipStream_t stream);
+/*! @cond       include_hidden */
+ncclResult_t pncclSend(const void* sendbuff, size_t count, ncclDataType_t datatype, int peer,
+    ncclComm_t comm, hipStream_t stream);
+/*! @endcond */
+
+/*! @brief      Receive
+    @details    Receive data from rank *peer* into *recvbuff*.
+                Rank *peer* needs to call ncclSend with the same datatype and the same count
+                as this rank.
+                This operation is blocking for the GPU. If multiple ncclSend and ncclRecv operations
+                need to progress concurrently to complete, they must be fused within a ncclGroupStart/
+                ncclGroupEnd section.
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[out] recvbuff      Data array to receive
+    @param[in]  count         Number of elements to receive
+    @param[in]  datatype      Data buffer element datatype
+    @param[in]  peer          Peer rank to send to
+    @param[in]  comm          Communicator group object to execute on
+    @param[in]  stream        HIP stream to execute collective on */
+ncclResult_t  ncclRecv(void* recvbuff, size_t count, ncclDataType_t datatype, int peer,
+    ncclComm_t comm, hipStream_t stream);
+/*! @cond       include_hidden */
+ncclResult_t pncclRecv(void* recvbuff, size_t count, ncclDataType_t datatype, int peer,
+    ncclComm_t comm, hipStream_t stream);
+/*! @endcond */
+
+/*! @brief      Gather
+    @details    Root device gathers *sendcount* values from other GPUs into *recvbuff*,
+                receiving data from rank i at offset i*sendcount.
+                Assumes recvcount is equal to nranks*sendcount, which means that *recvbuff*
+                should have a size of at least nranks*sendcount elements.
+                In-place operations will happen if sendbuff == recvbuff + rank * sendcount.
+                *recvbuff* may be NULL on ranks other than *root*.
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  sendbuff      Data array to send
+    @param[out] recvbuff      Data array to receive into on *root*.
+    @param[in]  sendcount     Number of elements to send per rank
+    @param[in]  datatype      Data buffer element datatype
+    @param[in]  root          Rank that receives data from all other ranks
+    @param[in]  comm          Communicator group object to execute on
+    @param[in]  stream        HIP stream to execute collective on */
+ncclResult_t  ncclGather(const void* sendbuff, void* recvbuff, size_t sendcount,
+    ncclDataType_t datatype, int root, ncclComm_t comm, hipStream_t stream);
+/*! @cond       include_hidden */
+ncclResult_t pncclGather(const void* sendbuff, void* recvbuff, size_t sendcount,
+    ncclDataType_t datatype, int root, ncclComm_t comm, hipStream_t stream);
+/*! @endcond */
+
+/*! @brief      Scatter
+    @details    Scattered over the devices so that recvbuff on rank i will contain the i-th
+                block of the data on root.
+                Assumes sendcount is equal to nranks*recvcount, which means that *sendbuff*
+                should have a size of at least nranks*recvcount elements.
+                In-place operations will happen if recvbuff == sendbuff + rank * recvcount.
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  sendbuff      Data array to send (on *root* rank).  May be NULL on other ranks.
+    @param[out] recvbuff      Data array to receive partial subarray into
+    @param[in]  recvcount     Number of elements to receive per rank
+    @param[in]  datatype      Data buffer element datatype
+    @param[in]  root          Rank that scatters data to all other ranks
+    @param[in]  comm          Communicator group object to execute on
+    @param[in]  stream        HIP stream to execute collective on */
+ncclResult_t  ncclScatter(const void* sendbuff, void* recvbuff,
+    size_t recvcount, ncclDataType_t datatype, int root, ncclComm_t comm,
+    hipStream_t stream);
+/*! @cond       include_hidden */
+ncclResult_t pncclScatter(const void* sendbuff, void* recvbuff,
+    size_t recvcount, ncclDataType_t datatype, int root, ncclComm_t comm,
+    hipStream_t stream);
+/*! @endcond */
+
+/*! @brief      All-To-All
+    @details    Device (i) send (j)th block of data to device (j) and be placed as (i)th
+                block. Each block for sending/receiving has *count* elements, which means
+                that *recvbuff* and *sendbuff* should have a size of nranks*count elements.
+                In-place operation is NOT supported. It is the user's responsibility
+                to ensure that sendbuff and recvbuff are distinct.
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  sendbuff      Data array to send (contains blocks for each other rank)
+    @param[out] recvbuff      Data array to receive (contains blocks from each other rank)
+    @param[in]  count         Number of elements to send between each pair of ranks
+    @param[in]  datatype      Data buffer element datatype
+    @param[in]  comm          Communicator group object to execute on
+    @param[in]  stream        HIP stream to execute collective on */
+ncclResult_t  ncclAllToAll(const void* sendbuff, void* recvbuff, size_t count,
+    ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream);
+/*! @cond       include_hidden */
+ncclResult_t pncclAllToAll(const void* sendbuff, void* recvbuff, size_t count,
+    ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream);
+/*! @endcond */
+
+/*! @brief      All-To-Allv
+    @details    Device (i) sends sendcounts[j] of data from offset sdispls[j]
+                to device (j). At the same time, device (i) receives recvcounts[j] of data
+                from device (j) to be placed at rdispls[j].
+                sendcounts, sdispls, recvcounts and rdispls are all measured in the units
+                of datatype, not bytes.
+                In-place operation will happen if sendbuff == recvbuff.
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  sendbuff      Data array to send (contains blocks for each other rank)
+    @param[in]  sendcounts    Array containing number of elements to send to each participating rank
+    @param[in]  sdispls       Array of offsets into *sendbuff* for each participating rank
+    @param[out] recvbuff      Data array to receive (contains blocks from each other rank)
+    @param[in]  recvcounts    Array containing number of elements to receive from each participating rank
+    @param[in]  rdispls       Array of offsets into *recvbuff* for each participating rank
+    @param[in]  datatype      Data buffer element datatype
+    @param[in]  comm          Communicator group object to execute on
+    @param[in]  stream        HIP stream to execute collective on */
+ncclResult_t  ncclAllToAllv(const void *sendbuff, const size_t sendcounts[],
+    const size_t sdispls[], void *recvbuff, const size_t recvcounts[],
+    const size_t rdispls[], ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream);
+/*! @cond       include_hidden */
+ncclResult_t pncclAllToAllv(const void *sendbuff, const size_t sendcounts[],
+    const size_t sdispls[], void *recvbuff, const size_t recvcounts[],
+    const size_t rdispls[], ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream);
+/*! @endcond */
+
+/*! @} */
+
+/*! @defgroup   msccl_api MSCCL Algorithm
+    @details    API calls relating to the optional MSCCL algorithm datapath
+    @{ */
+
+/*! @brief      Opaque handle to MSCCL algorithm */
+typedef int mscclAlgoHandle_t;
+
+/*! @brief      MSCCL Load Algorithm
+    @details    Load MSCCL algorithm file specified in mscclAlgoFilePath and return
+                its handle via mscclAlgoHandle. This API is expected to be called by MSCCL
+                scheduler instead of end users.
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  mscclAlgoFilePath  Path to MSCCL algorithm file
+    @param[out] mscclAlgoHandle    Returned handle to MSCCL algorithm
+    @param[in]  rank               Current rank */
+ncclResult_t  mscclLoadAlgo(const char *mscclAlgoFilePath, mscclAlgoHandle_t *mscclAlgoHandle, int rank);
+/*! @cond       include_hidden */
+ncclResult_t pmscclLoadAlgo(const char *mscclAlgoFilePath, mscclAlgoHandle_t *mscclAlgoHandle, int rank);
+/*! @endcond */
+
+/*! @brief      MSCCL Run Algorithm
+    @details    Run MSCCL algorithm specified by mscclAlgoHandle. The parameter
+                list merges all possible parameters required by different operations as this
+                is a general-purposed API. This API is expected to be called by MSCCL
+                scheduler instead of end users.
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  sendBuff         Data array to send
+    @param[in]  sendCounts       Array containing number of elements to send to each participating rank
+    @param[in]  sDisPls          Array of offsets into *sendbuff* for each participating rank
+    @param[out] recvBuff         Data array to receive
+    @param[in]  recvCounts       Array containing number of elements to receive from each participating rank
+    @param[in]  rDisPls          Array of offsets into *recvbuff* for each participating rank
+    @param[in]  count            Number of elements
+    @param[in]  dataType         Data buffer element datatype
+    @param[in]  root             Root rank index
+    @param[in]  peer             Peer rank index
+    @param[in]  op               Reduction operator
+    @param[in]  mscclAlgoHandle  Handle to MSCCL algorithm
+    @param[in]  comm             Communicator group object to execute on
+    @param[in]  stream           HIP stream to execute collective on */
+ncclResult_t  mscclRunAlgo(
+    const void* sendBuff, const size_t sendCounts[], const size_t sDisPls[],
+    void* recvBuff, const size_t recvCounts[], const size_t rDisPls[],
+    size_t count, ncclDataType_t dataType, int root, int peer, ncclRedOp_t op,
+    mscclAlgoHandle_t mscclAlgoHandle, ncclComm_t comm, hipStream_t stream);
+/*! @cond       include_hidden */
+ncclResult_t pmscclRunAlgo(
+    const void* sendBuff, const size_t sendCounts[], const size_t sDisPls[],
+    void* recvBuff, const size_t recvCounts[], const size_t rDisPls[],
+    size_t count, ncclDataType_t dataType, int root, int peer, ncclRedOp_t op,
+    mscclAlgoHandle_t mscclAlgoHandle, ncclComm_t comm, hipStream_t stream);
+/*! @endcond */
+
+/*! @brief      MSCCL Unload Algorithm
+    @details    Unload MSCCL algorithm previous loaded using its handle. This API
+                is expected to be called by MSCCL scheduler instead of end users.
+    @return     Result code. See @ref rccl_result_code for more details.
+
+    @param[in]  mscclAlgoHandle  Handle to MSCCL algorithm to unload
+*/
+ncclResult_t  mscclUnloadAlgo(mscclAlgoHandle_t mscclAlgoHandle);
+/*! @cond       include_hidden */
+ncclResult_t pmscclUnloadAlgo(mscclAlgoHandle_t mscclAlgoHandle);
+/*! @endcond */
+/*! @} */
+
+
+/*! @defgroup   rccl_group_api Group semantics
+    @details    When managing multiple GPUs from a single thread, and since RCCL collective
+                calls may perform inter-CPU synchronization, we need to "group" calls for
+                different ranks/devices into a single call.
+
+                Grouping RCCL calls as being part of the same collective operation is done
+                using ncclGroupStart and ncclGroupEnd. ncclGroupStart will enqueue all
+                collective calls until the ncclGroupEnd call, which will wait for all calls
+                to be complete. Note that for collective communication, ncclGroupEnd only
+                guarantees that the operations are enqueued on the streams, not that
+                the operation is effectively done.
+
+                Both collective communication and ncclCommInitRank can be used in conjunction
+                of ncclGroupStart/ncclGroupEnd, but not together.
+
+                Group semantics also allow to fuse multiple operations on the same device
+                to improve performance (for aggregated collective calls), or to permit
+                concurrent progress of multiple send/receive operations.
+    @{ */
+
+/*! @brief      Group Start
+    @details    Start a group call. All calls to RCCL until ncclGroupEnd will be fused into
+                a single RCCL operation. Nothing will be started on the HIP stream until
+                ncclGroupEnd.
+    @return     Result code. See @ref rccl_result_code for more details. */
+ncclResult_t  ncclGroupStart();
+/*! @cond       include_hidden */
+ncclResult_t pncclGroupStart();
+/*! @endcond */
+
+/*! @brief      Group End
+    @details    End a group call. Start a fused RCCL operation consisting of all calls since
+                ncclGroupStart. Operations on the HIP stream depending on the RCCL operations
+                need to be called after ncclGroupEnd.
+    @return     Result code. See @ref rccl_result_code for more details. */
+ncclResult_t  ncclGroupEnd();
+/*! @cond       include_hidden */
+ncclResult_t pncclGroupEnd();
+/*! @endcond */
+/*! @} */
+
+#ifdef __cplusplus
+} // end extern "C"
+#endif
+
+#endif // end include guard


### PR DESCRIPTION
RCCL is almost the same as NCCL.
The implementation is also almost the same as the one in the CUDA driver done via NCCL.

Differences are
* CUstream -> hipStream_t
* nccl -> rccl in file names. This follows the convention that RCCL's header is in rccl.h. This will allow for faster file navigation and avoid confusion which driver is being edited.
* In some places hipDevicePtr_t has to be handled differently from CUdeviceptr as they are pointer and integral types respectively.

In the source code all symbols that contain nccl are left as is since RCCL's API also uses nccl prefixes.

There was the option to unify much of the implementations for NCCL and RCCL with some macro trickery, but I decided against it, as it would make code navigation and debugging more difficult. We also don't know if RCCL and NCCL would diverge at some point in the future.