### PR TITLE
Use unauthenticated wget to download install archive in test jobs.

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -42,6 +42,7 @@ env:
   # last ran in. It therefore can't be passed in via inputs because the env
   # context isn't available there.
   GCS_DIR: gs://iree-github-actions-${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}-artifacts/${{ github.run_id }}/${{ github.run_attempt }}
+  GCS_URL: https://storage.googleapis.com/iree-github-actions-${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}-artifacts/${{ github.run_id }}/${{ github.run_attempt }}
 
 jobs:
   build_all:
@@ -63,6 +64,7 @@ jobs:
       #   an intermediate step towards a fully package-based CI setup.
       install-dir-archive: ${{ steps.install-archive.outputs.install-dir-archive }}
       install-dir-gcs-artifact: ${{ steps.install-upload.outputs.install-dir-gcs-artifact }}
+      install-dir-gcs-url: ${{ steps.install-upload.outputs.install-dir-gcs-url }}
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
@@ -107,6 +109,8 @@ jobs:
         env:
           INSTALL_DIR_ARCHIVE: ${{ steps.install-archive.outputs.install-dir-archive }}
           INSTALL_DIR_GCS_ARTIFACT: ${{ env.GCS_DIR }}/${{ steps.install-archive.outputs.install-dir-archive }}
+          INSTALL_DIR_GCS_URL: ${{ env.GCS_URL }}/${{ steps.install-archive.outputs.install-dir-archive }}
         run: |
           gcloud storage cp "${INSTALL_DIR_ARCHIVE}" "${INSTALL_DIR_GCS_ARTIFACT}"
           echo "install-dir-gcs-artifact=${INSTALL_DIR_GCS_ARTIFACT}" >> "${GITHUB_OUTPUT}"
+          echo "install-dir-gcs-url=${INSTALL_DIR_GCS_URL}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -31,6 +31,9 @@ on:
       install-dir-gcs-artifact:
         description: GCS path to the uploaded install archive.
         value: ${{ jobs.build_all.outputs.install-dir-gcs-artifact }}
+      install-dir-gcs-url:
+        description: GCS URL of the uploaded install archive.
+        value: ${{ jobs.build_all.outputs.install-dir-gcs-url }}
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,7 +290,7 @@ jobs:
           ./build_tools/scripts/check_cuda.sh
           ./build_tools/scripts/check_vulkan.sh
       - name: "Downloading install dir archive"
-        run: wget "${INSTALL_DIR_GCS_URL}" "${INSTALL_DIR_ARCHIVE}"
+        run: wget "${INSTALL_DIR_GCS_URL}" -O "${INSTALL_DIR_ARCHIVE}"
       - name: "Extracting install directory"
         run: tar -xf "${INSTALL_DIR_ARCHIVE}"
       - name: "Building tests"
@@ -354,7 +354,7 @@ jobs:
           ./build_tools/scripts/check_cuda.sh
           ./build_tools/scripts/check_vulkan.sh
       - name: "Downloading install dir archive"
-        run: wget "${INSTALL_DIR_GCS_URL}" "${INSTALL_DIR_ARCHIVE}"
+        run: wget "${INSTALL_DIR_GCS_URL}" -O "${INSTALL_DIR_ARCHIVE}"
       - name: "Extracting install directory"
         run: tar -xf "${INSTALL_DIR_ARCHIVE}"
       - name: "Building tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ env:
   # the run attempt and we want that to be the current attempt, not whatever
   # attempt the setup step last ran in.
   GCS_DIR: gs://iree-github-actions-${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}-artifacts/${{ github.run_id }}/${{ github.run_attempt }}
+  GCS_URL: https://storage.googleapis.com/iree-github-actions-${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}-artifacts/${{ github.run_id }}/${{ github.run_attempt }}
 
 # Jobs are organized into groups and topologically sorted by dependencies
 jobs:
@@ -268,7 +269,7 @@ jobs:
       BUILD_DIR: build-tests
       INSTALL_DIR: ${{ needs.build_all.outputs.install-dir }}
       INSTALL_DIR_ARCHIVE: ${{ needs.build_all.outputs.install-dir-archive }}
-      INSTALL_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.install-dir-gcs-artifact }}
+      INSTALL_DIR_GCS_URL: ${{ needs.build_all.outputs.install-dir-gcs-url }}
       IREE_CPU_DISABLE: 1
       IREE_VULKAN_DISABLE: 0
       IREE_CUDA_DISABLE: 0
@@ -289,7 +290,7 @@ jobs:
           ./build_tools/scripts/check_cuda.sh
           ./build_tools/scripts/check_vulkan.sh
       - name: "Downloading install dir archive"
-        run: gcloud storage cp "${INSTALL_DIR_GCS_ARTIFACT}" "${INSTALL_DIR_ARCHIVE}"
+        run: wget "${INSTALL_DIR_GCS_URL}" "${INSTALL_DIR_ARCHIVE}"
       - name: "Extracting install directory"
         run: tar -xf "${INSTALL_DIR_ARCHIVE}"
       - name: "Building tests"
@@ -332,7 +333,7 @@ jobs:
       BUILD_DIR: build-tests
       INSTALL_DIR: ${{ needs.build_all.outputs.install-dir }}
       INSTALL_DIR_ARCHIVE: ${{ needs.build_all.outputs.install-dir-archive }}
-      INSTALL_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.install-dir-gcs-artifact }}
+      INSTALL_DIR_GCS_URL: ${{ needs.build_all.outputs.install-dir-gcs-url }}
       IREE_CPU_DISABLE: 1
       IREE_VULKAN_DISABLE: 0
       IREE_CUDA_DISABLE: 0
@@ -353,7 +354,7 @@ jobs:
           ./build_tools/scripts/check_cuda.sh
           ./build_tools/scripts/check_vulkan.sh
       - name: "Downloading install dir archive"
-        run: gcloud storage cp "${INSTALL_DIR_GCS_ARTIFACT}" "${INSTALL_DIR_ARCHIVE}"
+        run: wget "${INSTALL_DIR_GCS_URL}" "${INSTALL_DIR_ARCHIVE}"
       - name: "Extracting install directory"
         run: tar -xf "${INSTALL_DIR_ARCHIVE}"
       - name: "Building tests"


### PR DESCRIPTION
As we add more test jobs (specifically for AMDGPU on self-hosted mi250 and w7900 runners), relying on the `gcloud` CLI to interface with workflow artifacts will require extra setup (install and auth). As these files are public and the jobs only need to read and not write, plain `wget` should be enough.

Progress on https://github.com/iree-org/iree/issues/17159 and https://github.com/iree-org/iree/issues/16203

ci-exactly: build_all, test_nvidia_gpu