### PR TITLE
[NestedLayout] Make layout use strides instead of basis

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_contract_amdgpu.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_contract_amdgpu.mlir
@@ -14,10 +14,8 @@
   threads_per_outer       = [32, 2],
   elements_per_thread     = [1, 4],
 
-  thread_order            = [1, 0],
-
-  subgroup_basis          = [1, 1],
-  thread_basis            = [32, 2]
+  subgroup_strides        = [1, 1],
+  thread_strides          = [1, 32]
 >
 
 // B: shape = 8x32, layout = layoutB
@@ -28,8 +26,8 @@
   threads_per_outer       = [2, 32],
   elements_per_thread     = [4, 1],
 
-  subgroup_basis          = [1, 1],
-  thread_basis            = [2, 32]
+  subgroup_strides        = [1, 1],
+  thread_strides          = [32, 1]
 >
 
 // C: shape = 32x32, layout = layoutC
@@ -40,8 +38,8 @@
   threads_per_outer       = [2, 32],
   elements_per_thread     = [4, 1],
 
-  subgroup_basis          = [1, 1],
-  thread_basis            = [2, 32]
+  subgroup_strides        = [1, 1],
+  thread_strides          = [32, 1]
 >
 
 func.func @contract_to_mfma_32x32x8_mm(%a : vector<32x8xf16>, %b : vector<8x32xf16>, %c : vector<32x32xf32>) -> vector<32x32xf32> {
@@ -101,10 +99,8 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [16, 4],
   elements_per_thread     = [1, 4],
 
-  thread_order            = [1, 0],
-
-  subgroup_basis          = [1, 1],
-  thread_basis            = [16, 4]
+  subgroup_strides        = [1, 1],
+  thread_strides          = [1, 16]
 >
 
 // B: shape = 16x16, layout = layoutB
@@ -115,8 +111,8 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [4, 16],
   elements_per_thread     = [4, 1],
 
-  subgroup_basis          = [1, 1],
-  thread_basis            = [4, 16]
+  subgroup_strides        = [1, 1],
+  thread_strides          = [16, 1]
 >
 
 // C: shape = 16x16, layout = layoutB
@@ -179,10 +175,8 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [32, 2],
   elements_per_thread     = [1, 4],
 
-  thread_order            = [1, 0],
-
-  subgroup_basis          = [1, 1],
-  thread_basis            = [32, 2]
+  subgroup_strides        = [1, 1],
+  thread_strides          = [1, 32]
 >
 
 // B: shape = 8x32, layout = layoutB
@@ -193,8 +187,8 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [2, 32],
   elements_per_thread     = [4, 1],
 
-  subgroup_basis          = [1, 1],
-  thread_basis            = [2, 32]
+  subgroup_strides        = [1, 1],
+  thread_strides          = [32, 1]
 >
 
 // C: shape = 64x32, layout = layoutC
@@ -205,8 +199,8 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [2, 32],
   elements_per_thread     = [4, 1],
 
-  subgroup_basis          = [1, 1],
-  thread_basis            = [2, 32]
+  subgroup_strides        = [1, 1],
+  thread_strides          = [32, 1]
 >
 
 func.func @contract_to_mfma_32x32x8_mm_mnbatch(%a : vector<64x8xf16>, %b : vector<8x32xf16>, %c : vector<64x32xf32>) -> vector<64x32xf32> {
@@ -268,10 +262,8 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [32, 2],
   elements_per_thread     = [1, 4],
 
-  thread_order            = [1, 0],
-
-  subgroup_basis          = [1, 1],
-  thread_basis            = [32, 2]
+  subgroup_strides        = [1, 1],
+  thread_strides          = [1, 32]
 >
 
 // B: shape = 16x32, layout = layoutB
@@ -282,8 +274,8 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [2, 32],
   elements_per_thread     = [4, 1],
 
-  subgroup_basis          = [1, 1],
-  thread_basis            = [2, 32]
+  subgroup_strides         = [1, 1],
+  thread_strides          = [32, 1]
 >
 
 // C: shape = 32x32, layout = layoutC
@@ -294,8 +286,8 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [2, 32],
   elements_per_thread     = [4, 1],
 
-  subgroup_basis          = [1, 1],
-  thread_basis            = [2, 32]
+  subgroup_strides         = [1, 1],
+  thread_strides          = [32, 1]
 >
 
 func.func @contract_to_mfma_32x32x8_mm_kbatch(%a : vector<32x16xf16>, %b : vector<16x32xf16>, %c : vector<32x32xf32>) -> vector<32x32xf32> {
@@ -351,10 +343,8 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [32, 2],
   elements_per_thread     = [1, 4],
 
-  thread_order            = [1, 0],
-
-  subgroup_basis          = [1, 1],
-  thread_basis            = [32, 2]
+  subgroup_strides        = [1, 1],
+  thread_strides          = [1, 32]
 >
 
 // B: shape = 8x96, layout = layoutB
@@ -365,8 +355,8 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [2, 32],
   elements_per_thread     = [4, 1],
 
-  subgroup_basis          = [1, 1],
-  thread_basis            = [2, 32]
+  subgroup_strides        = [1, 1],
+  thread_strides          = [32, 1]
 >
 
 // C: shape = 64x96, layout = layoutC
@@ -377,8 +367,8 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [2, 32],
   elements_per_thread     = [4, 1],
 
-  subgroup_basis          = [1, 1],
-  thread_basis            = [2, 32]
+  subgroup_strides        = [1, 1],
+  thread_strides          = [32, 1]
 >
 
 func.func @contract_to_mfma_32x32x8_mm_mnbatch_order(%a : vector<64x8xf16>, %b : vector<8x96xf16>, %c : vector<64x96xf32>) -> vector<64x96xf32> {
@@ -442,10 +432,8 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [32, 2],
   elements_per_thread     = [1, 4],
 
-  thread_order            = [1, 0],
-
-  subgroup_basis          = [1, 1],
-  thread_basis            = [32, 2]
+  subgroup_strides        = [1, 1],
+  thread_strides          = [1, 32]
 >
 
 // B: shape = 64x8, layout = layoutB
@@ -456,10 +444,8 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [32, 2],
   elements_per_thread     = [1, 4],
 
-  thread_order            = [1, 0],
-
-  subgroup_basis          = [1, 1],
-  thread_basis            = [32, 2]
+  subgroup_strides        = [1, 1],
+  thread_strides          = [32, 1]
 >
 
 // C: shape = 32x64, layout = layoutC
@@ -470,8 +456,8 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [2, 32],
   elements_per_thread     = [4, 1],
 
-  subgroup_basis          = [1, 1],
-  thread_basis            = [2, 32]
+  subgroup_strides        = [1, 1],
+  thread_strides          = [32, 1]
 >
 
 func.func @contract_to_mfma_32x32x8_mmt(%a : vector<32x8xf16>, %b : vector<64x8xf16>, %c : vector<32x64xf32>) -> vector<32x64xf32> {
@@ -523,10 +509,8 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [16, 1],
   elements_per_thread     = [1, 16],
 
-  thread_order            = [1, 0],
-
-  subgroup_basis          = [1, 1],
-  thread_basis            = [1, 32]
+  subgroup_strides        = [1, 1],
+  thread_strides          = [1, 16]
 >
 
 // B: shape = 16x16, layout = layoutB
@@ -537,8 +521,8 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [1, 16],
   elements_per_thread     = [16, 1],
 
-  subgroup_basis          = [1, 1],
-  thread_basis            = [1, 32]
+  subgroup_strides        = [1, 1],
+  thread_strides          = [16, 1]
 >
 
 // C: shape = 16x16, layout = layoutC
@@ -549,8 +533,8 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [2, 16],
   elements_per_thread     = [1, 1],
 
-  subgroup_basis          = [1, 1],
-  thread_basis            = [2, 16]
+  subgroup_strides        = [1, 1],
+  thread_strides          = [16, 1]
 >
 
 func.func @contract_to_wmma_16x16x16_mm(%a : vector<16x16xf16>, %b : vector<16x16xf16>, %c : vector<16x16xf32>) -> vector<16x16xf32> {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
@@ -7,13 +7,13 @@
   threads_per_outer       = [4, 8],
   elements_per_thread     = [4, 1],
 
-  subgroup_basis          = [1, 1],
-  thread_basis            = [4, 8]
+  subgroup_strides        = [1, 1],
+  thread_strides          = [8, 1]
 >
 
-// CHECK-DAG: #[[$MAP:.+]] = affine_map<()[s0] -> (s0 * 4)>
-// CHECK-DAG: #[[$MAP1:.+]] = affine_map<()[s0] -> (s0 + 8)>
-
+// CHECK: #[[$MAP:.+]] = affine_map<()[s0] -> ((s0 floordiv 8) * 4 - ((s0 floordiv 8) floordiv 4) * 16)>
+// CHECK: #[[$MAP1:.+]] = affine_map<()[s0] -> (s0 mod 8)>
+// CHECK: #[[$MAP2:.+]] = affine_map<()[s0] -> (s0 mod 8 + 8)>
 // CHECK-LABEL: @distribute_transfer_read_col_major
 func.func @distribute_transfer_read_col_major(%arg0: memref<32x32xf16>) -> vector<16x16xf16> {
   %c0 = arith.constant 0 : index
@@ -33,12 +33,13 @@ builtin.module attributes { transform.with_named_sequence } {
   }
 }
 
-// CHECK: %[[IDS:.+]]:4 = affine.delinearize_index %{{.*}} into (%c1, %c1, %c4, %c8) : index, index, index, index
-// CHECK: %[[LANEY:.+]] = affine.apply #[[$MAP]]()[%[[IDS]]#2]
-// CHECK: %[[RD00:.+]] = vector.transfer_read %arg0[%[[LANEY:.+]], %[[IDS]]#3], {{.*}} : memref<32x32xf16>, vector<4x1xf16>
+// CHECK: %[[IDX:.+]] = gpu.thread_id  x
+// CHECK: %[[X:.+]] = affine.apply #[[$MAP]]()[%[[IDX]]]
+// CHECK: %[[Y:.+]] = affine.apply #[[$MAP1]]()[%[[IDX]]]
+// CHECK: %[[RD00:.+]] = vector.transfer_read %arg0[%[[X]], %[[Y]]], {{.*}} : memref<32x32xf16>, vector<4x1xf16>
 // CHECK: vector.insert_strided_slice %[[RD00]], %{{.*}} {offsets = [0, 0, 0, 0, 0, 0], strides = [1, 1]} : vector<4x1xf16> into vector<1x2x1x1x4x1xf16>
-// CHECK: %[[LANEX_PLUS_BATCH:.+]] = affine.apply #[[$MAP1]]()[%[[IDS]]#3]
-// CHECK: vector.transfer_read %arg0[%[[LANEY]], %[[LANEX_PLUS_BATCH]]], %{{.*}} {in_bounds = [true, true]} : memref<32x32xf16>, vector<4x1xf16>
+// CHECK: %[[X_PLUS_BATCH:.+]] = affine.apply #[[$MAP2]]()[%[[IDX]]]
+// CHECK: vector.transfer_read %arg0[%[[X]], %[[X_PLUS_BATCH]]], %{{.*}} {in_bounds = [true, true]} : memref<32x32xf16>, vector<4x1xf16>
 // CHECK: vector.insert_strided_slice {{.*}} {offsets = [0, 1, 0, 0, 0, 0]
 // CHECK: iree_vector_ext.to_simd %{{.*}} : vector<1x2x1x1x4x1xf16> -> vector<16x16xf16>
 
@@ -51,13 +52,13 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [8, 1],
   elements_per_thread     = [1, 8],
 
-  subgroup_basis          = [1, 1],
-  thread_basis            = [8, 1]
+  subgroup_strides        = [1, 1],
+  thread_strides          = [1, 1]
 >
 
-// CHECK-DAG: #[[$MAP:.+]] = affine_map<()[s0, s1] -> (s0 + s1)>
+// CHECK-DAG: #[[$MAP:.+]] = affine_map<()[s0, s1] -> (s0 + s1 - (s1 floordiv 8) * 8)>
 // CHECK-DAG: #[[$MAP1:.+]] = affine_map<()[s0] -> (s0 + 8)>
-// CHECK-DAG: #[[$MAP2:.+]] = affine_map<()[s0, s1] -> (s0 + s1 + 8)>
+// CHECK-DAG: #[[$MAP2:.+]] = affine_map<()[s0, s1] -> (s0 + s1 - (s1 floordiv 8) * 8 + 8)>
 
 func.func @distribute_transfer_read_row_major_with_nontrivial_index(%a: index, %b: index, %arg0: memref<32x32x32x32xf16>) -> vector<16x16xf16> {
   %c0 = arith.constant 0 : index
@@ -80,12 +81,12 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK-LABEL: @distribute_transfer_read_row_major_with_nontrivial_index
 // CHECK-SAME:    %[[I0:.+]]: index, %[[I1:.+]]: index
 
-// CHECK: %[[IDS:.+]]:4 = affine.delinearize_index %{{.*}} into (%c1, %c1, %c8, %c1) : index, index, index, index
-// CHECK: %[[OFF0:.+]] = affine.apply #[[$MAP]]()[%[[IDS]]#2, %[[I0]]]
+// CHECK: %[[IDX:.+]] = gpu.thread_id  x
+// CHECK: %[[OFF0:.+]] = affine.apply #[[$MAP]]()[%[[I0]], %[[IDX]]]
 // CHECK: vector.transfer_read %{{.*}}[%c0, %c0, %[[OFF0]], %[[I1]]]
 // CHECK: %[[OFF1:.+]] = affine.apply #[[$MAP1]]()[%[[I1]]]
 // CHECK: vector.transfer_read %{{.*}}[%c0, %c0, %[[OFF0]], %[[OFF1]]]
-// CHECK: %[[OFF2:.+]] = affine.apply #[[$MAP2]]()[%[[IDS]]#2, %[[I0]]]
+// CHECK: %[[OFF2:.+]] = affine.apply #[[$MAP2]]()[%[[I0]], %[[IDX]]]
 // CHECK: vector.transfer_read %{{.*}}[%c0, %c0, %[[OFF2]], %[[I1]]]
 // CHECK: vector.transfer_read %{{.*}}[%c0, %c0, %[[OFF2]], %[[OFF1]]]
 
@@ -98,8 +99,8 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [4, 8],
   elements_per_thread     = [4, 1],
 
-  subgroup_basis          = [1, 1],
-  thread_basis            = [4, 8]
+  subgroup_strides        = [1, 1],
+  thread_strides          = [8, 1]
 >
 
 func.func @distribute_transfer_read_col_major_with_broadcast(%a: index, %b: index, %arg0: memref<32x32x32x32xf16>) -> vector<16x16xf16> {
@@ -139,14 +140,14 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [8, 1],
   elements_per_thread     = [1, 8],
 
-  subgroup_basis          = [1, 1],
-  thread_basis            = [8, 1]
+  subgroup_strides        = [1, 1],
+  thread_strides          = [1, 1]
 >
 
-// CHECK-DAG: #[[$MAP0:.+]] = affine_map<()[s0, s1] -> (s0 + s1)>
-// CHECK-DAG: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d3, d2)>
-// CHECK-DAG: #[[$MAP2:.+]] = affine_map<()[s0] -> (s0 + 8)>
-// CHECK-DAG: #[[$MAP3:.+]] = affine_map<()[s0, s1] -> (s0 + s1 + 8)>
+// CHECK-DAG: #[[$MAP:.+]] = affine_map<()[s0, s1] -> (s0 + s1 - (s1 floordiv 8) * 8)>
+// CHECK-DAG: #[[$MAP1:.+]] = affine_map<()[s0] -> (s0 + 8)>
+// CHECK-DAG: #[[$MAP2:.+]] = affine_map<()[s0, s1] -> (s0 + s1 - (s1 floordiv 8) * 8 + 8)>
+// CHECK-DAG: #[[$PERM:.+]] = affine_map<(d0, d1, d2, d3) -> (d3, d2)>
 
 func.func @distribute_transfer_read_row_major_transpose(%a: index, %b: index, %arg0: memref<32x32x32x32xf16>) -> vector<16x16xf16> {
   %c0 = arith.constant 0 : index
@@ -170,14 +171,14 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK-LABEL: @distribute_transfer_read_row_major_transpose
 // CHECK-SAME:    %[[I0:.+]]: index, %[[I1:.+]]: index
 
-// CHECK: %[[IDS:.+]]:4 = affine.delinearize_index %{{.*}} into (%c1, %c1, %c8, %c1) : index, index, index, index
-// CHECK: %[[LIN_ID0:.+]] = affine.apply #[[$MAP:.+]]()[%[[IDS]]#2, %[[I1]]]
-// CHECK: vector.transfer_read %{{.*}}[%c0, %c0, %[[I0]], %[[LIN_ID0]]], {{.*}} permutation_map = #[[$MAP1]]
-// CHECK: %[[I0_PLUS_8:.+]] = affine.apply #[[$MAP2]]()[%[[I0]]]
-// CHECK: vector.transfer_read %{{.*}}[%c0, %c0, %[[I0_PLUS_8]], %[[LIN_ID0]]], {{.*}} permutation_map = #[[$MAP1]]
-// CHECK: %[[LIN_ID1:.+]] = affine.apply #[[$MAP3]]()[%[[IDS]]#2, %[[I1]]]
-// CHECK: vector.transfer_read %{{.*}}[%c0, %c0, %[[I0]], %[[LIN_ID1]]], {{.*}} permutation_map = #[[$MAP1]]
-// CHECK: vector.transfer_read %{{.*}}[%c0, %c0, %[[I0_PLUS_8]], %[[LIN_ID1]]], %cst_0 {in_bounds = [true, true], permutation_map = #map1} : memref<32x32x32x32xf16>, vector<1x8xf16>
+// CHECK: %[[IDX:.+]] = gpu.thread_id  x
+// CHECK: %[[LIN_ID0:.+]] = affine.apply #[[$MAP:.+]]()[%[[I1]], %[[IDX]]]
+// CHECK: vector.transfer_read %{{.*}}[%c0, %c0, %[[I0]], %[[LIN_ID0]]], {{.*}} permutation_map = #[[$PERM]]
+// CHECK: %[[I0_PLUS_8:.+]] = affine.apply #[[$MAP1]]()[%[[I0]]]
+// CHECK: vector.transfer_read %{{.*}}[%c0, %c0, %[[I0_PLUS_8]], %[[LIN_ID0]]], {{.*}} permutation_map = #[[$PERM]]
+// CHECK: %[[LIN_ID1:.+]] = affine.apply #[[$MAP2]]()[%[[I1]], %[[IDX]]]
+// CHECK: vector.transfer_read %{{.*}}[%c0, %c0, %[[I0]], %[[LIN_ID1]]], {{.*}} permutation_map = #[[$PERM]]
+// CHECK: vector.transfer_read %{{.*}}[%c0, %c0, %[[I0_PLUS_8]], %[[LIN_ID1]]], %cst_0 {in_bounds = [true, true], permutation_map = #[[$PERM]]} : memref<32x32x32x32xf16>, vector<1x8xf16>
 
 // -----
 
@@ -188,8 +189,8 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [4, 8],
   elements_per_thread     = [4, 1],
 
-  subgroup_basis          = [1, 1],
-  thread_basis            = [4, 8]
+  subgroup_strides        = [1, 1],
+  thread_strides          = [8, 1]
 >
 
 // CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d3, d2)>
@@ -226,11 +227,8 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [1, 1, 2, 2],
   elements_per_thread     = [1, 1, 1, 2],
 
-  subgroup_order          = [1, 0, 2, 3],
-  thread_order            = [0, 1, 3, 2],
-
-  subgroup_basis          = [7, 3, 1, 1],
-  thread_basis            = [1, 1, 2, 2]
+  subgroup_strides        = [3, 1, 1, 1],
+  thread_strides          = [1, 1, 1, 2]
 >
 
 func.func @distribute_transfer_read_row_major_with_permutations(%a: index, %b: index, %arg0: memref<32x32x32x32xf16>) -> vector<21x15x8x16xf16> {
@@ -267,12 +265,11 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [4],
   elements_per_thread     = [4],
 
-  subgroup_basis          = [1],
-  thread_basis            = [4, 16],
-  thread_active_ids       = [true, false]
+  subgroup_strides        = [1],
+  thread_strides          = [16]
 >
 
-// CHECK-DAG: #[[$MAP:.+]] = affine_map<()[s0] -> (s0 * 4)>
+// CHECK-DAG: #[[$MAP:.+]] = affine_map<()[s0] -> ((s0 floordiv 16) * 4 - ((s0 floordiv 16) floordiv 4) * 16)>
 
 // CHECK-LABEL: @distribute_transfer_read_broadcast
 func.func @distribute_transfer_read_broadcast(%arg0: memref<32x32xf16>) -> vector<16xf16> {
@@ -293,8 +290,8 @@ builtin.module attributes { transform.with_named_sequence } {
   }
 }
 
-// CHECK: %[[IDS:.+]]:3 = affine.delinearize_index %{{.*}} into (%c1, %c4, %c16) : index, index, index
-// CHECK: %[[LANEY:.+]] = affine.apply #[[$MAP]]()[%[[IDS]]#1]
+// CHECK: %[[IDX:.+]] = gpu.thread_id  x
+// CHECK: %[[LANEY:.+]] = affine.apply #[[$MAP]]()[%[[IDX]]]
 // CHECK: %[[RD:.+]] = vector.transfer_read %{{.*}}[%c0, %[[LANEY:.+]]], {{.*}} : memref<32x32xf16>, vector<4xf16>
 
 // -----
@@ -306,16 +303,14 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [16],
   elements_per_thread     = [4],
 
-  subgroup_basis          = [2, 2],
-  subgroup_active_ids     = [false, true],
-  thread_basis            = [4, 16],
-  thread_active_ids       = [false, true]
+  subgroup_strides        = [1],
+  thread_strides          = [1]
 >
 
-// CHECK-DAG: #[[$MAP:.+]] = affine_map<()[s0, s1] -> (s0 * 64 + s1 * 4)>
+// CHECK-DAG: #[[$MAP:.+]] = affine_map<()[s0] -> (s0 * 4 + (s0 floordiv 64) * 64 - ((s0 floordiv 64) floordiv 2) * 128 - (s0 floordiv 16) * 64)>
 
-// CHECK-LABEL: @distribute_transfer_read_broadcast
-func.func @distribute_transfer_read_broadcast(%arg0: memref<32x128xf16>) -> vector<128xf16> {
+// CHECK-LABEL: @distribute_transfer_read_broadcast2
+func.func @distribute_transfer_read_broadcast2(%arg0: memref<32x128xf16>) -> vector<128xf16> {
   %c0 = arith.constant 0 : index
   %cst = arith.constant 0.0 : f16
   %root = vector.transfer_read %arg0[%c0, %c0], %cst
@@ -333,8 +328,8 @@ builtin.module attributes { transform.with_named_sequence } {
   }
 }
 
-// CHECK: %[[IDS:.+]]:4 = affine.delinearize_index %{{.*}} into (%c2, %c2, %c4, %c16) : index, index, index, index
-// CHECK: %[[LANEY:.+]] = affine.apply #[[$MAP]]()[%[[IDS]]#1, %[[IDS]]#3]
+// CHECK: %[[IDX:.+]] = gpu.thread_id  x
+// CHECK: %[[LANEY:.+]] = affine.apply #[[$MAP]]()[%[[IDX]]]
 // CHECK: %[[RD:.+]] = vector.transfer_read %{{.*}}[%c0, %[[LANEY:.+]]], {{.*}} : memref<32x128xf16>, vector<4xf16>
 
 // -----
@@ -346,11 +341,12 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [8, 1],
   elements_per_thread     = [1, 8],
 
-  subgroup_basis          = [1, 1],
-  thread_basis            = [8, 1]
+  subgroup_strides        = [1, 1],
+  thread_strides          = [1, 1]
 >
 
-// CHECK: #[[$MAP:.+]] = affine_map<()[s0] -> (s0 + 8)>
+// CHECK: #[[$MAP:.+]]  = affine_map<()[s0] -> (s0 mod 8)>
+// CHECK: #[[$MAP1:.+]] = affine_map<()[s0] -> (s0 mod 8 + 8)>
 
 // CHECK-LABEL: @distribute_transfer_write_row_major
 func.func @distribute_transfer_write_row_major(%root: vector<16x16xf16>, %alloc: memref<64x64xf16>) {
@@ -370,12 +366,13 @@ builtin.module attributes { transform.with_named_sequence } {
   }
 }
 
-// CHECK: %[[IDS:.+]]:4 = affine.delinearize_index %{{.*}} into (%c1, %c1, %c8, %c1) : index, index, index, index
+// CHECK: %[[IDX:.+]] = gpu.thread_id  x
+// CHECK: %[[LANEX:.+]] = affine.apply #[[$MAP]]()[%[[IDX]]]
 // CHECK: %[[SLICE:.+]] = vector.extract %{{.*}}[0, 0, 0, 0] : vector<1x8xf16> from vector<2x2x1x1x1x8xf16>
-// CHECK: vector.transfer_write %[[SLICE]], %{{.*}}[%[[IDS]]#2, %c0] {in_bounds = [true, true]} : vector<1x8xf16>, memref<64x64xf16>
+// CHECK: vector.transfer_write %[[SLICE]], %{{.*}}[%[[LANEX]], %c0] {in_bounds = [true, true]} : vector<1x8xf16>, memref<64x64xf16>
 // CHECK: vector.extract %{{.*}}[0, 1, 0, 0]
-// CHECK: vector.transfer_write %{{.*}}, %{{.*}}[%[[IDS]]#2, %c8]
-// CHECK: %[[LANEX_PLUS_VECDIMX:.+]] = affine.apply #[[$MAP]]()[%[[IDS]]#2]
+// CHECK: vector.transfer_write %{{.*}}, %{{.*}}[%[[LANEX]], %c8]
+// CHECK: %[[LANEX_PLUS_VECDIMX:.+]] = affine.apply #[[$MAP1]]()[%[[IDX]]]
 // CHECK: vector.extract %{{.*}}[1, 0, 0, 0]
 // CHECK: vector.transfer_write %{{.*}}[%[[LANEX_PLUS_VECDIMX]], %c0]
 // CHECK: vector.extract %{{.*}}[1, 1, 0, 0]
@@ -390,12 +387,13 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [4, 8],
   elements_per_thread     = [4, 1],
 
-  subgroup_basis          = [1, 1],
-  thread_basis            = [4, 8]
+  subgroup_strides        = [1, 1],
+  thread_strides          = [8, 1]
 >
 
-// CHECK-DAG: #[[$MAP:.+]] = affine_map<()[s0] -> (s0 * 4)>
-// CHECK-DAG: #[[$MAP1:.+]] = affine_map<()[s0] -> (s0 + 8)>
+// CHECK-DAG: #[[$MAP:.+]] = affine_map<()[s0] -> ((s0 floordiv 8) * 4 - ((s0 floordiv 8) floordiv 4) * 16)>
+// CHECK-DAG: #[[$MAP1:.+]] = affine_map<()[s0] -> (s0 mod 8)>
+// CHECK-DAG: #[[$MAP2:.+]] = affine_map<()[s0] -> (s0 mod 8 + 8)>
 
 // CHECK-LABEL: @distribute_transfer_write_col_major
 func.func @distribute_transfer_write_col_major(%root: vector<16x16xf16>, %alloc: memref<64x64xf16>) {
@@ -415,12 +413,12 @@ builtin.module attributes { transform.with_named_sequence } {
   }
 }
 
-// CHECK: %[[TIDX:.+]] = gpu.thread_id  x
-// CHECK: %[[IDS:.+]]:4 = affine.delinearize_index %[[TIDX]] into (%c1, %c1, %c4, %c8) : index, index, index, index
-// CHECK: %[[LANEY:.+]] = affine.apply #map()[%[[IDS]]#2]
+// CHECK: %[[IDX:.+]] = gpu.thread_id  x
+// CHECK: %[[LANEY:.+]] = affine.apply #[[$MAP]]()[%[[IDX]]]
+// CHECK: %[[LANEY2:.+]] = affine.apply #[[$MAP1]]()[%[[IDX]]]
 // CHECK: vector.extract %{{.*}}[0, 0, 0, 0]
-// CHECK: vector.transfer_write %{{.*}}[%[[LANEY]], %[[IDS]]#3]
-// CHECK: %[[LANEX:.+]] = affine.apply #[[$MAP1]]()[%[[IDS]]#3]
+// CHECK: vector.transfer_write %{{.*}}[%[[LANEY]], %[[LANEY2]]]
+// CHECK: %[[LANEX:.+]] = affine.apply #[[$MAP2]]()[%[[IDX]]]
 // CHECK: vector.extract %{{.*}}[0, 1, 0, 0]
 // CHECK: vector.transfer_write {{.*}}[%[[LANEY]], %[[LANEX]]]
 
@@ -433,14 +431,14 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [8, 1],
   elements_per_thread     = [1, 8],
 
-  subgroup_basis          = [1, 1],
-  thread_basis            = [8, 1]
+  subgroup_strides        = [1, 1],
+  thread_strides          = [1, 1]
 >
 
-// CHECK-DAG: #[[$MAP:.+]] = affine_map<()[s0, s1] -> (s0 + s1)>
+// CHECK-DAG: #[[$MAP:.+]] = affine_map<()[s0, s1] -> (s0 + s1 - (s1 floordiv 8) * 8)>
 // CHECK-DAG: #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d3, d2)>
 // CHECK-DAG: #[[$MAP2:.+]] = affine_map<()[s0] -> (s0 + 8)>
-// CHECK-DAG: #[[$MAP3:.+]] = affine_map<()[s0, s1] -> (s0 + s1 + 8)>
+// CHECK-DAG: #[[$MAP3:.+]] = affine_map<()[s0, s1] -> (s0 + s1 - (s1 floordiv 8) * 8 + 8)>
 
 func.func @distribute_transfer_write_row_major_with_nontrivial_index(%root: vector<16x16xf16>, %a: index, %b: index, %alloc: memref<32x32x32x32xf16>) {
   %c0 = arith.constant 0 : index
@@ -463,14 +461,14 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK-LABEL: @distribute_transfer_write_row_major_with_nontrivial_index
 // CHECK-SAME:    vector<16x16xf16>, %[[I0:.+]]: index, %[[I1:.+]]: index
 
-// CHECK: %[[IDS:.+]]:4 = affine.delinearize_index %{{.*}} into (%c1, %c1, %c8, %c1) : index, index, index, index
-// CHECK: %[[LIN_ID0:.+]] = affine.apply #[[$MAP]]()[%[[IDS]]#2, %[[I1]]]
+// CHECK: %[[IDX:.+]] = gpu.thread_id  x
+// CHECK: %[[LIN_ID0:.+]] = affine.apply #[[$MAP]]()[%[[I1]], %[[IDX]]]
 // CHECK: vector.extract %{{.*}}[0, 0, 0, 0]
 // CHECK: vector.transfer_write %{{.*}}[%c0, %c0, %[[I0]], %[[LIN_ID0]]] {{.*}} permutation_map = #[[$MAP1]]
 // CHECK: %[[LIN_ID1:.+]] = affine.apply #[[$MAP2]]()[%[[I0]]]
 // CHECK: vector.extract %{{.*}}[0, 1, 0, 0]
 // CHECK: vector.transfer_write %{{.*}}[%c0, %c0, %[[LIN_ID1]], %[[LIN_ID0]]] {{.*}} permutation_map = #[[$MAP1]]
-// CHECK: %[[LIN_ID2:.+]] = affine.apply #[[$MAP3]]()[%[[IDS]]#2, %[[I1]]]
+// CHECK: %[[LIN_ID2:.+]] = affine.apply #[[$MAP3]]()[%[[I1]], %[[IDX]]]
 // CHECK: vector.extract %{{.*}}[1, 0, 0, 0]
 // CHECK: vector.transfer_write %{{.*}}[%c0, %c0, %[[I0]], %[[LIN_ID2]]] {{.*}} permutation_map = #[[$MAP1]]
 // CHECK: vector.extract %{{.*}}[1, 1, 0, 0]
@@ -485,8 +483,8 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [8, 1],
   elements_per_thread     = [1, 8],
 
-  subgroup_basis          = [1, 1],
-  thread_basis            = [8, 1]
+  subgroup_strides        = [1, 1],
+  thread_strides          = [1, 1]
 >
 
 func.func @distribute_transfer_read_write(%a: index, %b: index,
@@ -534,10 +532,8 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [32, 2],
   elements_per_thread     = [1, 4],
 
-  thread_order            = [1, 0],
-
-  subgroup_basis          = [4, 2],
-  thread_basis            = [2, 32]
+  subgroup_strides        = [2, 1],
+  thread_strides          = [1, 32]
 >
 
 // B: shape = 8x64, layout = layoutB
@@ -548,8 +544,8 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [2, 32],
   elements_per_thread     = [4, 1],
 
-  subgroup_basis          = [4, 2],
-  thread_basis            = [2, 32]
+  subgroup_strides        = [1, 1],
+  thread_strides          = [32, 1]
 >
 
 // C: shape = 128x64, layout = layoutC
@@ -560,16 +556,17 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [2, 32],
   elements_per_thread     = [4, 1],
 
-  subgroup_basis          = [4, 2],
-  thread_basis            = [2, 32]
+  subgroup_strides        = [2, 1],
+  thread_strides          = [32, 1]
 >
 
-// CHECK-DAG: #[[$MAP:.+]] = affine_map<()[s0, s1] -> (s0 * 32 + s1)>
-// CHECK-DAG: #[[$MAP1:.+]] = affine_map<()[s0] -> (s0 * 4)>
-// CHECK-DAG: #[[$MAP2:.+]] = affine_map<()[s0, s1] -> (s0 * 32 + s1 * 4)>
-// CHECK-DAG: #[[$MAP3:.+]] = affine_map<()[s0, s1] -> (s0 * 32 + s1 * 4 + 8)>
-// CHECK-DAG: #[[$MAP4:.+]] = affine_map<()[s0, s1] -> (s0 * 32 + s1 * 4 + 16)>
-// CHECK-DAG: #[[$MAP5:.+]] = affine_map<()[s0, s1] -> (s0 * 32 + s1 * 4 + 24)>
+// CHECK-DAG: #[[$MAP:.+]] = affine_map<()[s0] -> (s0 + (s0 floordiv 128) * 32 - ((s0 floordiv 128) floordiv 4) * 128 - (s0 floordiv 32) * 32)>
+// CHECK-DAG: #[[$MAP1:.+]] = affine_map<()[s0] -> ((s0 floordiv 32) * 4 - ((s0 floordiv 32) floordiv 2) * 8)>
+// CHECK-DAG: #[[$MAP2:.+]] = affine_map<()[s0] -> (s0 + (s0 floordiv 64) * 32 - ((s0 floordiv 64) floordiv 2) * 64 - (s0 floordiv 32) * 32)>
+// CHECK-DAG: #[[$MAP3:.+]] = affine_map<()[s0] -> ((s0 floordiv 128) * 32 - ((s0 floordiv 128) floordiv 4) * 128 + (s0 floordiv 32) * 4 - ((s0 floordiv 32) floordiv 2) * 8)>
+// CHECK-DAG: #[[$MAP4:.+]] = affine_map<()[s0] -> ((s0 floordiv 128) * 32 - ((s0 floordiv 128) floordiv 4) * 128 + (s0 floordiv 32) * 4 - ((s0 floordiv 32) floordiv 2) * 8 + 8)>
+// CHECK-DAG: #[[$MAP5:.+]] = affine_map<()[s0] -> ((s0 floordiv 128) * 32 - ((s0 floordiv 128) floordiv 4) * 128 + (s0 floordiv 32) * 4 - ((s0 floordiv 32) floordiv 2) * 8 + 16)>
+// CHECK-DAG: #[[$MAP6:.+]] = affine_map<()[s0] -> ((s0 floordiv 128) * 32 - ((s0 floordiv 128) floordiv 4) * 128 + (s0 floordiv 32) * 4 - ((s0 floordiv 32) floordiv 2) * 8 + 24)>
 // CHECK-LABEL: @mfma_64x128x8_read
 func.func @mfma_64x128x8_read(%mem: memref<128x8xf16>,
                               %mem1: memref<8x64xf16>,
@@ -580,27 +577,28 @@ func.func @mfma_64x128x8_read(%mem: memref<128x8xf16>,
   %cst = arith.constant 0.0 : f16
 
   // CHECK: %[[IDX:.+]] = gpu.thread_id  x
-  // CHECK: %[[IDS:.+]]:4 = affine.delinearize_index %[[IDX]] into (%c4, %c2, %c2, %c32) : index, index, index, index
 
-  // CHECK-DAG: %[[M:.+]] = affine.apply #[[$MAP]]()[%[[IDS]]#0, %[[IDS]]#3]
-  // CHECK-DAG: %[[N:.+]] = affine.apply #[[$MAP]]()[%[[IDS]]#1, %[[IDS]]#3]
-  // CHECK-DAG: %[[K:.+]] = affine.apply #[[$MAP1]]()[%[[IDS]]#2]
+  // CHECK-DAG: %[[LHSM:.+]] = affine.apply #[[$MAP]]()[%[[IDX]]]
+  // LHSK = RHSK
+  // CHECK-DAG: %[[LHSK:.+]] = affine.apply #[[$MAP1]]()[%[[IDX]]]
+  // ACCN = RHSN
+  // CHECK-DAG: %[[RHSN:.+]] = affine.apply #[[$MAP2]]()[%[[IDX]]]
 
   // M is unrolled 4 times.
-  // CHECK-DAG: %[[M0:.+]] = affine.apply #[[$MAP2]]()[%[[IDS]]#0, %[[IDS]]#2]
-  // CHECK-DAG: %[[M1:.+]] = affine.apply #[[$MAP3]]()[%[[IDS]]#0, %[[IDS]]#2]
-  // CHECK-DAG: %[[M2:.+]] = affine.apply #[[$MAP4]]()[%[[IDS]]#0, %[[IDS]]#2]
-  // CHECK-DAG: %[[M3:.+]] = affine.apply #[[$MAP5]]()[%[[IDS]]#0, %[[IDS]]#2]
+  // CHECK-DAG: %[[ACCM0:.+]] = affine.apply #[[$MAP3]]()[%[[IDX]]]
+  // CHECK-DAG: %[[ACCM1:.+]] = affine.apply #[[$MAP4]]()[%[[IDX]]]
+  // CHECK-DAG: %[[ACCM2:.+]] = affine.apply #[[$MAP5]]()[%[[IDX]]]
+  // CHECK-DAG: %[[ACCM3:.+]] = affine.apply #[[$MAP6]]()[%[[IDX]]]
 
   // M, K
-  // CHECK-DAG: transfer_read %{{.*}}[%[[M]], %[[K]]]
+  // CHECK-DAG: transfer_read %{{.*}}[%[[LHSM]], %[[LHSK]]]
   // K, N
-  // CHECK-DAG: transfer_read %{{.*}}[%[[K]], %[[N]]]
+  // CHECK-DAG: transfer_read %{{.*}}[%[[LHSK]], %[[RHSN]]]
   // M, N
-  // CHECK-DAG: transfer_read %{{.*}}[%[[M0]], %[[N]]]
-  // CHECK-DAG: transfer_read %{{.*}}[%[[M1]], %[[N]]]
-  // CHECK-DAG: transfer_read %{{.*}}[%[[M2]], %[[N]]]
-  // CHECK-DAG: transfer_read %{{.*}}[%[[M3]], %[[N]]
+  // CHECK-DAG: transfer_read %{{.*}}[%[[ACCM0]], %[[RHSN]]]
+  // CHECK-DAG: transfer_read %{{.*}}[%[[ACCM1]], %[[RHSN]]]
+  // CHECK-DAG: transfer_read %{{.*}}[%[[ACCM2]], %[[RHSN]]]
+  // CHECK-DAG: transfer_read %{{.*}}[%[[ACCM3]], %[[RHSN]]
 
   %a = vector.transfer_read %mem[%c0, %c0], %cst
           {in_bounds = [true, true],
@@ -635,11 +633,8 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [32, 2],
   elements_per_thread     = [1, 4],
 
-  subgroup_order          = [1, 0],
-  thread_order            = [1, 0],
-
-  subgroup_basis          = [4, 2],
-  thread_basis            = [2, 32]
+  subgroup_strides        = [2, 1],
+  thread_strides          = [1, 32]
 >
 
 func.func @transposed_read_64x8(%mem: memref<8x64xf16>)
@@ -664,17 +659,14 @@ builtin.module attributes { transform.with_named_sequence } {
   }
 }
 
-// CHECK-DAG: #[[$MAP:.+]] = affine_map<()[s0, s1] -> (s0 * 32 + s1)>
-// CHECK-DAG: #[[$MAP1:.+]] = affine_map<()[s0] -> (s0 * 4)>
+// CHECK-DAG: #[[$MAP:.+]] = affine_map<()[s0] -> (s0 + (s0 floordiv 128) * 32 - ((s0 floordiv 128) floordiv 2) * 64 - (s0 floordiv 32) * 32)>
+// CHECK-DAG: #[[$MAP1:.+]] = affine_map<()[s0] -> ((s0 floordiv 32) * 4 - ((s0 floordiv 32) floordiv 2) * 8)>
 
 // CHECK-LABEL: @transposed_read_64x8
 
 // CHECK: %[[IDX:.+]] = gpu.thread_id  x
-// Delinearization basis comes directly from the
-// CHECK: %[[IDS:.+]]:4 = affine.delinearize_index %[[IDX]] into (%c4, %c2, %c2, %c32) : index, index, index, index
-
-// CHECK-DAG: %[[M:.+]] = affine.apply #[[$MAP]]()[%[[IDS]]#1, %[[IDS]]#3]
-// CHECK-DAG: %[[N:.+]] = affine.apply #[[$MAP1]]()[%[[IDS]]#2]
+// CHECK-DAG: %[[M:.+]] = affine.apply #[[$MAP]]()[%[[IDX]]]
+// CHECK-DAG: %[[N:.+]] = affine.apply #[[$MAP1]]()[%[[IDX]]]
 // CHECK: transfer_read %{{.*}}[%[[N]], %[[M]]
 
 // -----
@@ -685,8 +677,8 @@ builtin.module attributes { transform.with_named_sequence } {
   outers_per_batch = [1, 1],
   threads_per_outer = [4, 16],
   elements_per_thread = [4, 1],
-  subgroup_basis = [2, 2],
-  thread_basis = [4, 16]
+  subgroup_strides = [2, 1],
+  thread_strides   = [16, 1]
 >
 
 func.func @broadcast(%src: vector<128xf16>) -> (vector<64x128xf16>) {
@@ -728,8 +720,8 @@ builtin.module attributes { transform.with_named_sequence } {
   outers_per_batch = [2, 1, 1],
   threads_per_outer = [4, 16, 8],
   elements_per_thread = [1, 4, 4],
-  subgroup_basis = [2, 2, 2],
-  thread_basis = [4, 16, 8]
+  subgroup_strides = [4, 2, 1],
+  thread_strides   = [128, 8, 1]
 >
 
 func.func @broadcast(%src: vector<64xf16>) -> (vector<32x256x64xf16>) {
@@ -765,8 +757,8 @@ builtin.module attributes { transform.with_named_sequence } {
   outers_per_batch = [2, 1, 1],
   threads_per_outer = [4, 16, 8],
   elements_per_thread = [1, 4, 4],
-  subgroup_basis = [2, 2, 2],
-  thread_basis = [4, 16, 8]
+  subgroup_strides = [4, 2, 1],
+  thread_strides = [128, 8, 1]
 >
 
 func.func @scalar_broadcast(%src: f16) -> (vector<32x256x64xf16>) {
@@ -796,8 +788,8 @@ builtin.module attributes { transform.with_named_sequence } {
   outers_per_batch = [2, 1],
   threads_per_outer = [4, 16],
   elements_per_thread = [2, 2],
-  subgroup_basis = [2, 2],
-  thread_basis = [4, 16]
+  subgroup_strides = [2, 1],
+  thread_strides = [16, 1]
 >
 
 func.func @transpose(%src: vector<256x64xf16>) -> (vector<64x256xf16>) {
@@ -829,8 +821,8 @@ builtin.module attributes { transform.with_named_sequence } {
   outers_per_batch = [2, 1],
   threads_per_outer = [4, 16],
   elements_per_thread = [2, 2],
-  subgroup_basis = [2, 2],
-  thread_basis = [4, 16]
+  subgroup_strides = [2, 1],
+  thread_strides = [16, 1]
 >
 
 func.func @transpose(%src: vector<64x256xf16>) -> (vector<256x64xf16>) {
@@ -854,10 +846,8 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK-SAME:   outers_per_batch = [1, 2]
 // CHECK-SAME:   threads_per_outer = [16, 4]
 // CHECK-SAME:   elements_per_thread = [2, 2]
-// CHECK-SAME:   subgroup_order = [1, 0]
-// CHECK-SAME:   thread_order = [1, 0]
-// CHECK-SAME:   subgroup_basis = [2, 2]
-// CHECK-SAME:   thread_basis = [4, 16]
+// CHECK-SAME:   subgroup_strides = [1, 2],
+// CHECK-SAME:   thread_strides = [1, 16]
 
 // CHECK-LABEL: func @transpose
 // CHECK: iree_vector_ext.to_simt %{{.*}} : vector<64x256xf16> -> vector<2x4x2x1x2x2xf16>
@@ -875,8 +865,8 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer = [4, 8, 2],
   elements_per_thread = [4, 1, 2],
 
-  subgroup_basis = [2, 1, 1],
-  thread_basis   = [4, 8, 2]
+  subgroup_strides = [1, 1, 1],
+  thread_strides = [16, 2, 1]
 >
 
 func.func @transpose_3d(%arr: memref<32x32x32xf16>) -> () {
@@ -900,41 +890,43 @@ builtin.module attributes { transform.with_named_sequence } {
   }
 }
 
-// CHECK: #[[$MAP:.+]] = affine_map<()[s0, s1] -> (s0 * 16 + s1 * 4)>
-// CHECK: #[[$MAP1:.+]] = affine_map<()[s0] -> (s0 * 2)>
-// CHECK: #[[$MAP2:.+]] = affine_map<()[s0] -> (s0 * 2 + 4)>
-// CHECK: #[[$MAP3:.+]] = affine_map<()[s0] -> (s0 * 2 + 8)>
-// CHECK: #[[$MAP4:.+]] = affine_map<()[s0] -> (s0 * 2 + 12)>
-// CHECK: #[[$MAP5:.+]] = affine_map<()[s0] -> (s0 + 8)>
+// CHECK-DAG: #[[$MAP:.+]] = affine_map<()[s0] -> ((s0 floordiv 64) * 16 - ((s0 floordiv 64) floordiv 2) * 32 + (s0 floordiv 16) * 4 - ((s0 floordiv 16) floordiv 4) * 16)>
+// CHECK-DAG: #[[$MAP1:.+]] = affine_map<()[s0] -> ((s0 floordiv 2) mod 8)>
+// CHECK-DAG: #[[$MAP2:.+]] = affine_map<()[s0] -> (s0 * 2 - (s0 floordiv 2) * 4)>
+// CHECK-DAG: #[[$MAP3:.+]] = affine_map<()[s0] -> (s0 * 2 - (s0 floordiv 2) * 4 + 4)>
+// CHECK-DAG: #[[$MAP4:.+]] = affine_map<()[s0] -> (s0 * 2 - (s0 floordiv 2) * 4 + 8)>
+// CHECK-DAG: #[[$MAP5:.+]] = affine_map<()[s0] -> (s0 * 2 - (s0 floordiv 2) * 4 + 12)>
+// CHECK-DAG: #[[$MAP6:.+]] = affine_map<()[s0] -> ((s0 floordiv 2) mod 8 + 8)>
 
 // CHECK-LABEL: func @transpose_3d
-// CHECK:         %[[IDS:.+]]:6 = affine.delinearize_index %{{.*}} into (%c2, %c1, %c1, %c4, %c8, %c2)
+// CHECK-DAG:         %[[IDX:.+]] = gpu.thread_id  x
 
-// CHECK-DAG:         %[[DIM0_ID:.+]] = affine.apply #[[$MAP]]()[%[[IDS]]#0, %[[IDS]]#3]
-// CHECK-DAG:         %[[DIM2_ID0:.+]] = affine.apply #[[$MAP1]]()[%[[IDS]]#5]
-// CHECK-DAG:         %[[RD0:.+]] = vector.transfer_read %arg0[%[[DIM0_ID]], %[[IDS]]#4, %[[DIM2_ID0]]], {{.*}} : memref<32x32x32xf16>, vector<4x1x2xf16>
-// CHECK-DAG:         %[[DIM2_ID1:.+]] = affine.apply #[[$MAP2]]()[%[[IDS]]#5]
-// CHECK-DAG:         %[[RD1:.+]] = vector.transfer_read %arg0[%[[DIM0_ID]], %[[IDS]]#4, %[[DIM2_ID1]]]
-// CHECK-DAG:         %[[DIM2_ID2:.+]] = affine.apply #[[$MAP3]]()[%[[IDS]]#5]
-// CHECK-DAG:         %[[RD2:.+]] = vector.transfer_read %arg0[%[[DIM0_ID]], %[[IDS]]#4, %[[DIM2_ID2]]]
-// CHECK-DAG:         %[[DIM2_ID3:.+]] = affine.apply #[[$MAP4]]()[%[[IDS]]#5]
-// CHECK-DAG:         %[[RD3:.+]] = vector.transfer_read %arg0[%[[DIM0_ID]], %[[IDS]]#4, %[[DIM2_ID3]]]
-// CHECK-DAG:         %[[DIM2_ID4:.+]] = affine.apply #[[$MAP5]]()[%[[IDS]]#4]
-// CHECK-DAG:         %[[RD4:.+]] = vector.transfer_read %arg0[%[[DIM0_ID]], %[[DIM2_ID4]], %[[DIM2_ID0]]]
-// CHECK-DAG:         %[[RD5:.+]] = vector.transfer_read %arg0[%[[DIM0_ID]], %[[DIM2_ID4]], %[[DIM2_ID1]]]
-// CHECK-DAG:         %[[RD6:.+]] = vector.transfer_read %arg0[%[[DIM0_ID]], %[[DIM2_ID4]], %[[DIM2_ID2]]]
-// CHECK-DAG:         %[[RD7:.+]] = vector.transfer_read %arg0[%[[DIM0_ID]], %[[DIM2_ID4]], %[[DIM2_ID3]]]
+// CHECK-DAG:         %[[DIM:.+]]  = affine.apply #[[$MAP]]()[%[[IDX]]]
+// CHECK-DAG:         %[[DIM1:.+]] = affine.apply #[[$MAP1]]()[%[[IDX]]]
+// CHECK-DAG:         %[[DIM2:.+]] = affine.apply #[[$MAP2]]()[%[[IDX]]]
+// CHECK-DAG:         %[[DIM3:.+]] = affine.apply #[[$MAP3]]()[%[[IDX]]]
+// CHECK-DAG:         %[[DIM4:.+]] = affine.apply #[[$MAP4]]()[%[[IDX]]]
+// CHECK-DAG:         %[[DIM5:.+]] = affine.apply #[[$MAP5]]()[%[[IDX]]]
+// CHECK-DAG:         %[[DIM6:.+]] = affine.apply #[[$MAP6]]()[%[[IDX]]]
+// CHECK-DAG:         %[[RD0:.+]] = vector.transfer_read %arg0[%[[DIM]], %[[DIM1]], %[[DIM2]]], {{.*}} : memref<32x32x32xf16>, vector<4x1x2xf16>
+// CHECK-DAG:         %[[RD1:.+]] = vector.transfer_read %arg0[%[[DIM]], %[[DIM1]], %[[DIM3]]]
+// CHECK-DAG:         %[[RD2:.+]] = vector.transfer_read %arg0[%[[DIM]], %[[DIM1]], %[[DIM4]]]
+// CHECK-DAG:         %[[RD3:.+]] = vector.transfer_read %arg0[%[[DIM]], %[[DIM1]], %[[DIM5]]]
+// CHECK-DAG:         %[[RD4:.+]] = vector.transfer_read %arg0[%[[DIM]], %[[DIM6]], %[[DIM2]]]
+// CHECK-DAG:         %[[RD5:.+]] = vector.transfer_read %arg0[%[[DIM]], %[[DIM6]], %[[DIM3]]]
+// CHECK-DAG:         %[[RD6:.+]] = vector.transfer_read %arg0[%[[DIM]], %[[DIM6]], %[[DIM4]]]
+// CHECK-DAG:         %[[RD7:.+]] = vector.transfer_read %arg0[%[[DIM]], %[[DIM6]], %[[DIM5]]]
 
 // CHECK:         vector.transpose %{{.*}}, [1, 2, 0, 4, 5, 3, 7, 8, 6] : vector<1x2x4x1x1x1x4x1x2xf16> to vector<2x4x1x1x1x1x1x2x4xf16>
 
-// CHECK-DAG:         vector.transfer_write %{{.*}}, %arg0[%[[IDS]]#4, %[[DIM2_ID0]], %[[DIM0_ID]]] {{.*}} : vector<1x2x4xf16>, memref<32x32x32xf16>
-// CHECK-DAG:         vector.transfer_write %{{.*}}, %arg0[%[[DIM2_ID4]], %[[DIM2_ID0]], %[[DIM0_ID]]]
-// CHECK-DAG:         vector.transfer_write %{{.*}}, %arg0[%[[IDS]]#4, %[[DIM2_ID1]], %[[DIM0_ID]]]
-// CHECK-DAG:         vector.transfer_write %{{.*}}, %arg0[%[[DIM2_ID4]], %[[DIM2_ID1]], %[[DIM0_ID]]]
-// CHECK-DAG:         vector.transfer_write %{{.*}}, %arg0[%[[IDS]]#4, %[[DIM2_ID2]], %[[DIM0_ID]]]
-// CHECK-DAG:         vector.transfer_write %{{.*}}, %arg0[%[[DIM2_ID4]], %[[DIM2_ID2]], %[[DIM0_ID]]]
-// CHECK-DAG:         vector.transfer_write %{{.*}}, %arg0[%[[IDS]]#4, %[[DIM2_ID3]], %[[DIM0_ID]]]
-// CHECK-DAG:         vector.transfer_write %{{.*}}, %arg0[%[[DIM2_ID4]], %[[DIM2_ID3]], %[[DIM0_ID]]]
+// CHECK-DAG:         vector.transfer_write %{{.*}}, %arg0[%[[DIM1]], %[[DIM2]], %[[DIM]]] {{.*}} : vector<1x2x4xf16>, memref<32x32x32xf16>
+// CHECK-DAG:         vector.transfer_write %{{.*}}, %arg0[%[[DIM1]], %[[DIM3]], %[[DIM]]]
+// CHECK-DAG:         vector.transfer_write %{{.*}}, %arg0[%[[DIM1]], %[[DIM4]], %[[DIM]]]
+// CHECK-DAG:         vector.transfer_write %{{.*}}, %arg0[%[[DIM1]], %[[DIM5]], %[[DIM]]]
+// CHECK-DAG:         vector.transfer_write %{{.*}}, %arg0[%[[DIM6]], %[[DIM2]], %[[DIM]]]
+// CHECK-DAG:         vector.transfer_write %{{.*}}, %arg0[%[[DIM6]], %[[DIM3]], %[[DIM]]]
+// CHECK-DAG:         vector.transfer_write %{{.*}}, %arg0[%[[DIM6]], %[[DIM4]], %[[DIM]]]
+// CHECK-DAG:         vector.transfer_write %{{.*}}, %arg0[%[[DIM6]], %[[DIM5]], %[[DIM]]]
 
 // -----
 
@@ -949,11 +941,8 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer = [16, 4],
   elements_per_thread = [1, 4],
 
-  subgroup_order = [1, 0],
-  thread_order = [1, 0],
-
-  subgroup_basis = [1, 1],
-  thread_basis = [4, 16]
+  subgroup_strides = [1, 1],
+  thread_strides = [1, 16]
 >
 
 func.func @mfma_16x16x16_out_reduced_dim1(%arg0: vector<32x32xf32>, %arg1: vector<32xf32>) -> vector<32xf32> {
@@ -1000,10 +989,8 @@ builtin.module attributes { transform.with_named_sequence } {
   threads_per_outer       = [32, 2],
   elements_per_thread     = [1, 4],
 
-  thread_order            = [1, 0],
-
-  subgroup_basis          = [1, 1],
-  thread_basis            = [2, 32]
+  subgroup_strides        = [1, 1],
+  thread_strides          = [1, 32]
 >
 
 func.func @mfma_32x32x8_out_reduced_dim1(%arg0: vector<32x32xf32>, %arg1: vector<32xf32>) -> vector<32xf32> {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_distribution.mlir
@@ -46,11 +46,8 @@ func.func @distribute_elementwise_i32(%a: vector<16x16xi32>, %b: vector<16x16xi3
   threads_per_outer       = [8, 2, 4],
   elements_per_thread     = [1, 8, 2],
 
-  subgroup_order          = [0, 1, 2],
-  thread_order            = [0, 1, 2],
-
-  subgroup_basis          = [2, 1, 1],
-  thread_basis            = [8, 2, 4]
+  subgroup_strides        = [1, 1, 1],
+  thread_strides          = [1, 8, 16]
 >
 
 // CHECK-LABEL: @distribute_elementwise_nested_layout_f16

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -541,7 +541,7 @@ static LogicalResult populateCanonicalOffsetsSizesAndStrides(
   // vtid = (tid floordiv stride_i) mod size_i.
   SmallVector<OpFoldResult> vtids;
   for (auto [dimSize, dimStride] :
-       llvm::zip(subgroupLayout.thread, subgroupLayout.tstrides)) {
+       llvm::zip_equal(subgroupLayout.thread, subgroupLayout.tstrides)) {
     if (dimSize == 1) {
       vtids.push_back(zero);
     }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -420,120 +420,58 @@ int64_t MMAAttr::getSubgroupSize() const {
   return 0;
 }
 
-SmallVector<int64_t> MMAAttr::getADataDuplicate() const {
-  switch (getIntrinsic().getValue()) {
-  case MMAIntrinsic::MFMA_F16_16x16x16_F32:
-  case MMAIntrinsic::MFMA_F16_32x32x8_F32: {
-    break;
-  }
-  case MMAIntrinsic::WMMA_F16_16x16x16_F32:
-  case MMAIntrinsic::WMMA_F16_16x16x16_F16: {
-    return {2, 1};
-  }
-  }
-  // Defaults to no data duplication.
-  return {1, 1};
-}
-
-SmallVector<int64_t> MMAAttr::getBDataDuplicate() const {
-  switch (getIntrinsic().getValue()) {
-  case MMAIntrinsic::MFMA_F16_16x16x16_F32:
-  case MMAIntrinsic::MFMA_F16_32x32x8_F32: {
-    break;
-  }
-  case MMAIntrinsic::WMMA_F16_16x16x16_F32:
-  case MMAIntrinsic::WMMA_F16_16x16x16_F16: {
-    return {1, 2};
-  }
-  }
-  // Defaults to no data duplication.
-  return {1, 1};
-}
-
-SmallVector<int64_t> MMAAttr::getCDataDuplicate() const {
-  // Currently no C-layout need data duplication yet.
-  return {1, 1};
-}
-
-MMAAttr::SingleSubgroupLayout MMAAttr::getASingleSubgroupLayoutCount() const {
+MMAAttr::SingleSubgroupLayout MMAAttr::getASingleSubgroupLayout() const {
   switch (getIntrinsic().getValue()) {
   case MMAIntrinsic::MFMA_F16_16x16x16_F32: {
-    return {/*outer=*/{1, 1}, /*thread=*/{16, 4}, /*element=*/{1, 4}};
+    return {/*outer=*/{1, 1}, /*thread=*/{16, 4}, /*strides=*/{1, 16},
+            /*element=*/{1, 4}};
   }
   case MMAIntrinsic::MFMA_F16_32x32x8_F32: {
-    return {/*outer=*/{1, 1}, /*thread=*/{32, 2}, /*element=*/{1, 4}};
+    return {/*outer=*/{1, 1}, /*thread=*/{32, 2}, /*strides=*/{1, 32},
+            /*element=*/{1, 4}};
   }
   case MMAIntrinsic::WMMA_F16_16x16x16_F32:
   case MMAIntrinsic::WMMA_F16_16x16x16_F16: {
-    return {/*outer=*/{1, 1}, /*thread=*/{16, 1}, /*element=*/{1, 16}};
+    return {/*outer=*/{1, 1}, /*thread=*/{16, 1}, /*strides=*/{1, 16},
+            /*element=*/{1, 16}};
   }
   }
   return {};
 }
 
-MMAAttr::SingleSubgroupLayout MMAAttr::getBSingleSubgroupLayoutCount() const {
+MMAAttr::SingleSubgroupLayout MMAAttr::getBSingleSubgroupLayout() const {
   switch (getIntrinsic().getValue()) {
   case MMAIntrinsic::MFMA_F16_16x16x16_F32: {
-    return {/*outer=*/{1, 1}, /*thread=*/{4, 16}, /*element=*/{4, 1}};
+    return {/*outer=*/{1, 1}, /*thread=*/{4, 16}, /*strides=*/{16, 1},
+            /*element=*/{4, 1}};
   }
   case MMAIntrinsic::MFMA_F16_32x32x8_F32: {
-    return {/*outer=*/{1, 1}, /*thread=*/{2, 32}, /*element=*/{4, 1}};
+    return {/*outer=*/{1, 1}, /*thread=*/{2, 32}, /*strides=*/{32, 1},
+            /*element=*/{4, 1}};
   }
   case MMAIntrinsic::WMMA_F16_16x16x16_F32:
   case MMAIntrinsic::WMMA_F16_16x16x16_F16: {
-    return {/*outer=*/{1, 1}, /*thread=*/{1, 16}, /*element=*/{16, 1}};
+    return {/*outer=*/{1, 1}, /*thread=*/{1, 16}, /*strides=*/{16, 1},
+            /*element=*/{16, 1}};
   }
   }
   return {};
 }
 
-MMAAttr::SingleSubgroupLayout MMAAttr::getCSingleSubgroupLayoutCount() const {
+MMAAttr::SingleSubgroupLayout MMAAttr::getCSingleSubgroupLayout() const {
   switch (getIntrinsic().getValue()) {
   case MMAIntrinsic::MFMA_F16_16x16x16_F32: {
-    return {/*outer=*/{1, 1}, /*thread=*/{4, 16}, /*element=*/{4, 1}};
+    return {/*outer=*/{1, 1}, /*thread=*/{4, 16}, /*strides=*/{16, 1},
+            /*element=*/{4, 1}};
   }
   case MMAIntrinsic::MFMA_F16_32x32x8_F32: {
-    return {/*outer=*/{4, 1}, /*thread=*/{2, 32}, /*element=*/{4, 1}};
+    return {/*outer=*/{4, 1}, /*thread=*/{2, 32}, /*strides=*/{32, 1},
+            /*element=*/{4, 1}};
   }
   case MMAIntrinsic::WMMA_F16_16x16x16_F32:
   case MMAIntrinsic::WMMA_F16_16x16x16_F16: {
-    return {/*outer=*/{8, 1}, /*thread=*/{2, 16}, /*element=*/{1, 1}};
-  }
-  }
-  return {};
-}
-
-MMAAttr::SingleSubgroupLayout MMAAttr::getASingleSubgroupLayoutOrder() const {
-  switch (getIntrinsic().getValue()) {
-  case MMAIntrinsic::MFMA_F16_16x16x16_F32:
-  case MMAIntrinsic::MFMA_F16_32x32x8_F32:
-  case MMAIntrinsic::WMMA_F16_16x16x16_F32:
-  case MMAIntrinsic::WMMA_F16_16x16x16_F16: {
-    return {/*outer=*/{0, 1}, /*thread=*/{1, 0}, /*element=*/{0, 1}};
-  }
-  }
-  return {};
-}
-
-MMAAttr::SingleSubgroupLayout MMAAttr::getBSingleSubgroupLayoutOrder() const {
-  switch (getIntrinsic().getValue()) {
-  case MMAIntrinsic::MFMA_F16_16x16x16_F32:
-  case MMAIntrinsic::MFMA_F16_32x32x8_F32:
-  case MMAIntrinsic::WMMA_F16_16x16x16_F32:
-  case MMAIntrinsic::WMMA_F16_16x16x16_F16: {
-    return {/*outer=*/{0, 1}, /*thread=*/{0, 1}, /*element=*/{1, 0}};
-  }
-  }
-  return {};
-}
-
-MMAAttr::SingleSubgroupLayout MMAAttr::getCSingleSubgroupLayoutOrder() const {
-  switch (getIntrinsic().getValue()) {
-  case MMAIntrinsic::MFMA_F16_16x16x16_F32:
-  case MMAIntrinsic::MFMA_F16_32x32x8_F32:
-  case MMAIntrinsic::WMMA_F16_16x16x16_F32:
-  case MMAIntrinsic::WMMA_F16_16x16x16_F16: {
-    return {/*outer=*/{0, 1}, /*thread=*/{0, 1}, /*element=*/{1, 0}};
+    return {/*outer=*/{8, 1}, /*thread=*/{2, 16}, /*strides=*/{16, 1},
+            /*element=*/{1, 1}};
   }
   }
   return {};
@@ -572,33 +510,20 @@ FailureOr<Value> MMAAttr::buildMmaOperation(OpBuilder &builder, Location loc,
   return failure();
 }
 
-static SmallVector<int64_t>
-getRankReducedSingleSubgroupShape(const MMAAttr::SingleSubgroupLayout &counts) {
-  SmallVector<int64_t> rankReducedShape;
-  for (auto [outer, thread, element] :
-       llvm::zip_equal(counts.outer, counts.thread, counts.element)) {
-    if (outer != 1) {
-      rankReducedShape.push_back(outer);
-    }
-    rankReducedShape.push_back(thread * element);
-  }
-  return rankReducedShape;
-}
-
-// Generates amdgpu.mfma/wmma operation on the given inputs for this attribute
-// type.
 static LogicalResult populateCanonicalOffsetsSizesAndStrides(
     OpBuilder &builder, Location loc, Value laneId,
-    ArrayRef<int64_t> permutation, MMAAttr::SingleSubgroupLayout counts,
-    MMAAttr::SingleSubgroupLayout orders,
+    ArrayRef<int64_t> permutation, MMAAttr::SingleSubgroupLayout subgroupLayout,
     SmallVector<OpFoldResult> &canonicalOffsets,
     SmallVector<OpFoldResult> &canonicalSizes,
     SmallVector<OpFoldResult> &canonicalStrides) {
   SmallVector<int64_t> rankReducedShape;
   for (auto [outer, thread, element] :
-       llvm::zip_equal(counts.outer, counts.thread, counts.element)) {
+       llvm::zip_equal(subgroupLayout.outer, subgroupLayout.thread,
+                       subgroupLayout.element)) {
     if (outer != 1) {
-      rankReducedShape.push_back(outer);
+      // TODO: Support this case. Might need a reshape since this makes the
+      // slice non-contigious.
+      return failure();
     }
     rankReducedShape.push_back(thread * element);
   }
@@ -611,26 +536,29 @@ static LogicalResult populateCanonicalOffsetsSizesAndStrides(
   OpFoldResult one = builder.getIndexAttr(1);
   canonicalStrides.append(rankReducedShape.size(), one);
 
-  SmallVector<int64_t> threadDimSizes =
-      applyPermutation(counts.thread, orders.thread);
-  SmallVector<Value> basis;
-  for (int64_t dimSize : threadDimSizes) {
-    basis.push_back(builder.create<arith::ConstantIndexOp>(loc, dimSize));
+  // vtid: virtual thread id
+  // tid: lane id
+  // vtid = (tid floordiv stride_i) mod size_i.
+  SmallVector<OpFoldResult> vtids;
+  for (auto [dimSize, dimStride] :
+       llvm::zip(subgroupLayout.thread, subgroupLayout.tstrides)) {
+    if (dimSize == 1) {
+      vtids.push_back(zero);
+    }
+
+    // (tid floordiv stride) mod size
+    AffineExpr tidExpr = builder.getAffineDimExpr(0);
+    AffineMap vtidMap = AffineMap::get(
+        /*dims=*/1, /*syms=*/0, tidExpr.floorDiv(dimStride) % dimSize);
+    Value vtid = builder.create<affine::AffineApplyOp>(loc, vtidMap, laneId);
+    vtids.push_back(vtid);
   }
-  SmallVector<Value> threadIds =
-      builder.create<affine::AffineDelinearizeIndexOp>(loc, laneId, basis)
-          .getResults();
-  applyPermutationToVector(threadIds, orders.thread);
 
   int64_t idx = 0;
-  for (auto [outer, thread, element] :
-       llvm::zip_equal(counts.outer, counts.thread, counts.element)) {
-    if (outer != 1) {
-      canonicalSizes.push_back(builder.getIndexAttr(outer));
-      canonicalOffsets.push_back(zero);
-    }
+  for (auto [thread, element] :
+       llvm::zip_equal(subgroupLayout.thread, subgroupLayout.element)) {
     canonicalSizes.push_back(builder.getIndexAttr(element));
-    canonicalOffsets.push_back(threadIds[idx++]);
+    canonicalOffsets.push_back(vtids[idx++]);
   }
   applyPermutationToVector(canonicalOffsets, permutation);
   applyPermutationToVector(canonicalSizes, permutation);
@@ -646,22 +574,18 @@ LogicalResult MMAAttr::populateOperandOffsetsSizesStrides(
     return failure();
   }
 
-  MMAAttr::SingleSubgroupLayout counts;
-  MMAAttr::SingleSubgroupLayout orders;
+  MMAAttr::SingleSubgroupLayout subgroupLayout;
   switch (fragment) {
   case IREE::GPU::MMAFragment::Lhs: {
-    counts = getASingleSubgroupLayoutCount();
-    orders = getASingleSubgroupLayoutOrder();
+    subgroupLayout = getASingleSubgroupLayout();
     break;
   }
   case IREE::GPU::MMAFragment::Rhs: {
-    counts = getBSingleSubgroupLayoutCount();
-    orders = getBSingleSubgroupLayoutOrder();
+    subgroupLayout = getBSingleSubgroupLayout();
     break;
   }
   case IREE::GPU::MMAFragment::Acc: {
-    counts = getCSingleSubgroupLayoutCount();
-    orders = getCSingleSubgroupLayoutOrder();
+    subgroupLayout = getCSingleSubgroupLayout();
     break;
   }
   }
@@ -669,7 +593,7 @@ LogicalResult MMAAttr::populateOperandOffsetsSizesStrides(
   SmallVector<OpFoldResult> canonicalOffsets;
   SmallVector<OpFoldResult> canonicalSizes;
   if (failed(populateCanonicalOffsetsSizesAndStrides(
-          builder, loc, laneId, permutation, counts, orders, canonicalOffsets,
+          builder, loc, laneId, permutation, subgroupLayout, canonicalOffsets,
           canonicalSizes, strides))) {
     return failure();
   }
@@ -759,83 +683,46 @@ SmallVector<int64_t> getIdentityPermWithSwap(int64_t rank,
 /// And here inner most is referential to the iteration order, not the order
 /// they appear per fragment (because there is no relationship between the
 /// dimension order of M in A and in C, for example).
-NestedLayoutAttr permuteAndCreateNestedLayout(
-    MLIRContext *context, int64_t rank, int64_t outerDim, int64_t innerDim,
-    SmallVector<int64_t> subgroupCount, SmallVector<int64_t> subgroupOrder,
-    SmallVector<int64_t> batchCount, MMAAttr::SingleSubgroupLayout counts,
-    MMAAttr::SingleSubgroupLayout orders, ArrayRef<int64_t> dataDuplicate,
-    ArrayRef<int64_t> subgroupBasis, ArrayRef<bool> subgroupActiveIds) {
+NestedLayoutAttr createNestedLayout(MLIRContext *context, int64_t rank,
+                                    int64_t outerDim, int64_t innerDim,
+                                    SmallVector<int64_t> subgroupSizes,
+                                    SmallVector<int64_t> subgroupStrides,
+                                    SmallVector<int64_t> batchCount,
+                                    MMAAttr::SingleSubgroupLayout counts) {
 
   LLVM_DEBUG({
-    llvm::errs() << "Given:";
+    llvm::errs() << "Creating Nested Layout for::";
     llvm::errs() << "\n    outerDim = " << outerDim;
     llvm::errs() << "\n    innerDim = " << innerDim;
-    llvm::errs() << "\n    subgroupCount: ";
-    llvm::interleaveComma(subgroupCount, llvm::errs());
-    llvm::errs() << "\n    subgroupOrder: ";
-    llvm::interleaveComma(subgroupOrder, llvm::errs());
+    llvm::errs() << "\n    subgroupSizes: ";
+    llvm::interleaveComma(subgroupSizes, llvm::errs());
+    llvm::errs() << "\n    subgroupStrides: ";
+    llvm::interleaveComma(subgroupStrides, llvm::errs());
     llvm::errs() << "\n    batchCount: ";
     llvm::interleaveComma(batchCount, llvm::errs());
     llvm::errs() << "\n    counts.outer: ";
     llvm::interleaveComma(counts.outer, llvm::errs());
     llvm::errs() << "\n    counts.thread: ";
     llvm::interleaveComma(counts.thread, llvm::errs());
-    llvm::errs() << "\n    orders.thread: ";
-    llvm::interleaveComma(orders.thread, llvm::errs());
     llvm::errs() << "\n    counts.element: ";
     llvm::interleaveComma(counts.element, llvm::errs());
-    llvm::errs() << "\n    subgroupBasis: ";
-    llvm::interleaveComma(subgroupBasis, llvm::errs());
-    llvm::errs() << "\n    subgroupActiveIds: ";
-    llvm::interleaveComma(subgroupActiveIds, llvm::errs());
+    llvm::errs() << "\n    counts.tstrides: ";
+    llvm::interleaveComma(counts.tstrides, llvm::errs());
     llvm::errs() << "\n";
   });
-
-  SmallVector<int64_t> threadOrder =
-      getIdentityPermWithSwap(rank, orders.thread, outerDim, innerDim);
-
-  SmallVector<int64_t> threadBasis =
-      getUnitOfRankWithDims(rank, counts.thread, outerDim, innerDim);
-  threadBasis[outerDim] *= dataDuplicate[0];
-  threadBasis[innerDim] *= dataDuplicate[1];
-  applyPermutationToVector(threadBasis, threadOrder);
 
   SmallVector<int64_t> outerCount =
       getUnitOfRankWithDims(rank, counts.outer, outerDim, innerDim);
   SmallVector<int64_t> threadCount =
       getUnitOfRankWithDims(rank, counts.thread, outerDim, innerDim);
+  SmallVector<int64_t> threadStrides =
+      getUnitOfRankWithDims(rank, counts.tstrides, outerDim, innerDim);
   SmallVector<int64_t> elementCount =
       getUnitOfRankWithDims(rank, counts.element, outerDim, innerDim);
 
-  LLVM_DEBUG({
-    llvm::errs() << "\nNew layout attr:";
-    llvm::errs() << "\n    subgroupCount: ";
-    llvm::interleaveComma(subgroupCount, llvm::errs());
-    llvm::errs() << "\n    subgroupOrder: ";
-    llvm::interleaveComma(subgroupOrder, llvm::errs());
-    llvm::errs() << "\n    batchCount: ";
-    llvm::interleaveComma(batchCount, llvm::errs());
-    llvm::errs() << "\n    outerCount: ";
-    llvm::interleaveComma(outerCount, llvm::errs());
-    llvm::errs() << "\n    threadCount: ";
-    llvm::interleaveComma(threadCount, llvm::errs());
-    llvm::errs() << "\n    threadOrder: ";
-    llvm::interleaveComma(threadOrder, llvm::errs());
-    llvm::errs() << "\n    elementCount: ";
-    llvm::interleaveComma(elementCount, llvm::errs());
-    llvm::errs() << "\n    subgroupBasis: ";
-    llvm::interleaveComma(subgroupBasis, llvm::errs());
-    llvm::errs() << "\n    subgroupActiveIds: ";
-    llvm::interleaveComma(subgroupActiveIds, llvm::errs());
-    llvm::errs() << "\n    threadBasis: ";
-    llvm::interleaveComma(threadBasis, llvm::errs());
-    llvm::errs() << "\n";
-  });
-
-  auto layoutAttr = NestedLayoutAttr::get(
-      context, subgroupCount, subgroupOrder, batchCount, outerCount,
-      threadCount, threadOrder, elementCount, subgroupBasis, subgroupActiveIds,
-      threadBasis, SmallVector<bool>(threadBasis.size(), true));
+  auto layoutAttr = NestedLayoutAttr::get(context, subgroupSizes, batchCount,
+                                          outerCount, threadCount, elementCount,
+                                          subgroupStrides, threadStrides);
   return layoutAttr;
 }
 
@@ -852,6 +739,7 @@ MMAScheduleAttr::getContractionLayout(vector::ContractionOp contractOp) const {
     return contractOp->emitError("Unimplemented: > 1 k dims");
   }
 
+  int64_t rank = contractOp.getIteratorTypesArray().size();
   auto mmaAttr = llvm::cast<MMAAttr>(getIntrinsic());
   MLIRContext *context = getContext();
 
@@ -870,13 +758,13 @@ MMAScheduleAttr::getContractionLayout(vector::ContractionOp contractOp) const {
   // So here we need to permute/transpose the canonical layout to match with
   // the concrete contract op.
 
-  // Note that no matter how we permute/transpose the input contraction problem,
-  // the way we view the hardware warps remain the same--that is, from the
-  // hardware's perspective, a single warp has the same warp ID no matter what
-  // part of the contraction it works on. Similarly here, we are delinearizing
-  // the linearized GPU hardware lane ID into a n-D concatenated logical
-  // warp+thread using the subgroup/thread basis, so the subgroup basis should
-  // remain the same for all A/B/C matrix.
+  // Note that no matter how we permute/transpose the input contraction
+  // problem, the way we view the hardware warps remain the same--that is,
+  // from the hardware's perspective, a single warp has the same warp ID no
+  // matter what part of the contraction it works on. Similarly here, we are
+  // delinearizing the linearized GPU hardware lane ID into a n-D concatenated
+  // logical warp+thread using the subgroup/thread basis, so the subgroup
+  // basis should remain the same for all A/B/C matrix.
 
   auto [intrinsicM, intrinsicN, intrinsicK] = mmaAttr.getMNKShape();
 
@@ -894,11 +782,11 @@ MMAScheduleAttr::getContractionLayout(vector::ContractionOp contractOp) const {
   };
 
   // Greedily break up the M subgroup and batch counts along the "M" iteration
-  // bounds. We distribute as many residual subgroups as possible per M dim, and
-  // then divide the remaining along batch dims. The inner most M dim is always
-  // the one used for the intrinsic, meaning for a valid schedule, the computed
-  // batch counts and subgroup basis will satisfy
-  // totalMSize / intrinsicM = product(batchMSizes) * product(subgroupMBasis)
+  // bounds. We distribute as many residual subgroups as possible per M dim,
+  // and then divide the remaining along batch dims. The inner most M dim is
+  // always the one used for the intrinsic, meaning for a valid schedule, the
+  // computed batch counts and subgroup basis will satisfy totalMSize /
+  // intrinsicM = product(batchMSizes) * product(subgroupMBasis)
   for (auto dim : opInfo.getMDims()) {
     // Get the number of subgroups and batches used for this dimension based
     // on the intrinsic size and the bound size.
@@ -938,73 +826,39 @@ MMAScheduleAttr::getContractionLayout(vector::ContractionOp contractOp) const {
     currNCount /= subgroupsUsed;
   }
 
-  SmallVector<int64_t> subgroupBasis;
-  if (batchCount == 1) {
-    subgroupBasis.push_back(1);
-  }
+  SmallVector<int64_t> subgroupMStrides(subgroupMBasis.size());
+  SmallVector<int64_t> subgroupNStrides(subgroupNBasis.size());
+
   auto mDimVec = opInfo.getMDims();
   llvm::SmallDenseSet<int64_t> mDims(mDimVec.begin(), mDimVec.end());
   auto nDimVec = opInfo.getNDims();
   llvm::SmallDenseSet<int64_t> nDims(nDimVec.begin(), nDimVec.end());
-
-  int64_t currM = 0;
-  int64_t currN = 0;
-  // Because we currently require all batch dimensions to be unit, the subgroup
-  // basis can be constructed from the M and N bases. To keep things simple,
-  // the current heuristic is to distribute all M dims followed by all N dims.
-  for (auto dim : llvm::seq(static_cast<int64_t>(0), opInfo.getCRank())) {
+  // Because we currently require all batch dimensions to be unit, the
+  // subgroup basis can be constructed from the M and N bases. To keep things
+  // simple, the current heuristic is to distribute the loop dimensions from
+  // outer to inner.
+  int64_t currStride = 1;
+  int64_t currM = subgroupMStrides.size() - 1;
+  int64_t currN = subgroupNStrides.size() - 1;
+  for (int64_t dim : llvm::reverse(llvm::seq<int64_t>(rank))) {
     if (mDims.contains(dim)) {
-      subgroupBasis.push_back(subgroupMBasis[currM]);
-      // Construct mDimVec such that it contains the order in which the M dims
-      // appear in the C matrix.
-      mDimVec[currM] = dim;
-      currM++;
+      subgroupMStrides[currM] = currStride;
+      currStride *= subgroupMBasis[currM];
+      currM--;
+      continue;
     }
+
     if (nDims.contains(dim)) {
-      subgroupBasis.push_back(subgroupNBasis[currN]);
-      // Construct nDimVec such that it contains the order in which the N dims
-      // appear in the C matrix.
-      nDimVec[currN] = dim;
-      currN++;
+      subgroupNStrides[currN] = currStride;
+      currStride *= subgroupNBasis[currN];
+      currN--;
+      continue;
     }
   }
 
-  // For threads though, we also need to make sure the basis is consistent
-  // across A, B, and C matrix. Though here we need to additionally think it
-  // from the matching of how the MMA intrinsics expect the treads organize and
-  // how we distribute the large input contraction problem to the threads.
-  // The intrinsics expect a certain 2-D (x, y) thread layout, where it's not
-  // guaranteed that y is always the fastest moving dimension. But when we
-  // distribute the large input contraction problem, we always associate the
-  // fastest moving dimension to the innermost thread ID dimension. Therefore,
-  // we need to "adjust" the intrinsic thread shape to from the slowest moving
-  // dimension to the fastest one. That is, to apply the corresponding order
-  // permutation vector. Because how the intrinsics are designed, the end result
-  // is actually we are basically guaranteed to see the same thread basis for A,
-  // B, and C matrix. But still..
-
   // C matrix layout
-  MMAAttr::SingleSubgroupLayout cCounts =
-      mmaAttr.getCSingleSubgroupLayoutCount();
-  MMAAttr::SingleSubgroupLayout cOrders =
-      mmaAttr.getCSingleSubgroupLayoutOrder();
-
   auto [m, n] = opInfo.getResultMNIndex();
   int64_t cRank = opInfo.getCRank();
-  LLVM_DEBUG({
-    llvm::errs() << "Subgroup M Basis: ";
-    llvm::interleaveComma(subgroupMBasis, llvm::errs());
-    llvm::errs() << "\n";
-    llvm::errs() << "Subgroup N Basis: ";
-    llvm::interleaveComma(subgroupNBasis, llvm::errs());
-    llvm::errs() << "\n";
-    llvm::errs() << "Batch M Sizes: ";
-    llvm::interleaveComma(batchMSizes, llvm::errs());
-    llvm::errs() << "\n";
-    llvm::errs() << "Batch N Sizes: ";
-    llvm::interleaveComma(batchNSizes, llvm::errs());
-    llvm::errs() << "\n";
-  });
 
   // Get the M and N dims w.r.t. the dimensions of the C matrix. cMDims and
   // cNDims are the M and N dimensions of the C matrix in the order they are
@@ -1013,39 +867,26 @@ MMAScheduleAttr::getContractionLayout(vector::ContractionOp contractOp) const {
   SmallVector<int64_t> cNDims = opInfo.outNDims;
   SmallVector<int64_t> cBatchSizes(cRank, 1);
   SmallVector<int64_t> cSubgroupSizes(cRank, 1);
-  SmallVector<int64_t> cOverallOrder = getIdentityPerm(cRank);
+  SmallVector<int64_t> cSubgroupStrides(cRank, 0);
   for (auto [i, dim] : llvm::enumerate(cMDims)) {
     cBatchSizes[dim] = batchMSizes[i];
     cSubgroupSizes[dim] = subgroupMBasis[i];
-    cOverallOrder[dim] = mDimVec[i];
+    cSubgroupStrides[dim] = subgroupMStrides[i];
   }
   for (auto [i, dim] : llvm::enumerate(cNDims)) {
     cBatchSizes[dim] = batchNSizes[i];
     cSubgroupSizes[dim] = subgroupNBasis[i];
-    cOverallOrder[dim] = nDimVec[i];
+    cSubgroupStrides[dim] = subgroupNStrides[i];
   }
 
-  // Dummy 1 for the k dimension.
-  subgroupBasis.push_back(1);
-
-  SmallVector<bool> cActiveSubgroups(cRank + 1, true);
-  cActiveSubgroups.back() = false;
-
-  auto cLayout = permuteAndCreateNestedLayout(
-      context, cRank, m, n,
-      /*subgroupCount=*/cSubgroupSizes,
-      /*subgroupOrder=*/cOverallOrder,
-      /*batchCount=*/cBatchSizes, cCounts, cOrders,
-      /*dataDuplicate=*/mmaAttr.getCDataDuplicate(), subgroupBasis,
-      cActiveSubgroups);
+  auto cLayout = createNestedLayout(context, cRank, m, n,
+                                    /*subgroupCount=*/cSubgroupSizes,
+                                    /*subgroupStrides=*/cSubgroupStrides,
+                                    /*batchCount=*/cBatchSizes,
+                                    mmaAttr.getCSingleSubgroupLayout());
   LLVM_DEBUG({ llvm::errs() << "C layout: " << cLayout << "\n"; });
 
   // A matrix layout
-  MMAAttr::SingleSubgroupLayout aCounts =
-      mmaAttr.getASingleSubgroupLayoutCount();
-  MMAAttr::SingleSubgroupLayout aOrders =
-      mmaAttr.getASingleSubgroupLayoutOrder();
-
   auto [afm, bfn] = opInfo.getOperandMNIndex();
   auto [afk, bfk] = opInfo.getOperandKIndex();
 
@@ -1054,75 +895,39 @@ MMAScheduleAttr::getContractionLayout(vector::ContractionOp contractOp) const {
   SmallVector<int64_t> aMDims = opInfo.lhsMDims;
   SmallVector<int64_t> aBatchSizes(aRank, 1);
   SmallVector<int64_t> aSubgroupSizes(aRank, 1);
-  SmallVector<int64_t> aSubgroupOrder = getIdentityPerm(aRank);
-  SmallVector<int64_t> aBatchOrder = getIdentityPerm(aRank);
+  SmallVector<int64_t> aSubgroupStrides(aRank, 0);
   for (auto [i, dim] : llvm::enumerate(aMDims)) {
     aBatchSizes[dim] = batchMSizes[i];
     aSubgroupSizes[dim] = subgroupMBasis[i];
-    int64_t j = i + batchCount;
-    aSubgroupOrder[dim] = j;
-    aBatchOrder[dim] = j >= afk ? j + 1 : j;
+    aSubgroupStrides[dim] = subgroupMStrides[i];
   }
-  aSubgroupOrder[afk] = aRank - 1;
   aBatchSizes[afk] = bounds[opInfo.getKDims().back()] / intrinsicK;
 
-  SmallVector<bool> aActiveSubgroups(subgroupBasis.size(), false);
-  for (auto mDim : mDims) {
-    aActiveSubgroups[mDim] = true;
-  }
-  aActiveSubgroups.back() = true;
-  if (batchCount == 1) {
-    aActiveSubgroups[0] = true;
-  }
-
-  auto aLayout = permuteAndCreateNestedLayout(
-      context, aRank, afm, afk,
-      /*subgroupCount=*/aSubgroupSizes,
-      /*subgroupOrder=*/aSubgroupOrder,
-      /*batchCount=*/aBatchSizes, aCounts, aOrders,
-      /*dataDuplicate=*/mmaAttr.getADataDuplicate(), subgroupBasis,
-      aActiveSubgroups);
+  auto aLayout = createNestedLayout(context, aRank, afm, afk,
+                                    /*subgroupCount=*/aSubgroupSizes,
+                                    /*subgroupStrides=*/aSubgroupStrides,
+                                    /*batchCount=*/aBatchSizes,
+                                    mmaAttr.getASingleSubgroupLayout());
   LLVM_DEBUG({ llvm::errs() << "A layout: " << aLayout << "\n"; });
-
-  // B matrix layout
-  MMAAttr::SingleSubgroupLayout bCounts =
-      mmaAttr.getBSingleSubgroupLayoutCount();
-  MMAAttr::SingleSubgroupLayout bOrders =
-      mmaAttr.getBSingleSubgroupLayoutOrder();
 
   int64_t bRank = opInfo.getBRank();
 
   SmallVector<int64_t> bNDims = opInfo.rhsNDims;
   SmallVector<int64_t> bBatchSizes(bRank, 1);
   SmallVector<int64_t> bSubgroupSizes(bRank, 1);
-  SmallVector<int64_t> bSubgroupOrder = getIdentityPerm(bRank);
-  SmallVector<int64_t> bBatchOrder = getIdentityPerm(bRank);
+  SmallVector<int64_t> bSubgroupStrides(bRank, 0);
   for (auto [i, dim] : llvm::enumerate(bNDims)) {
     bBatchSizes[dim] = batchNSizes[i];
     bSubgroupSizes[dim] = subgroupNBasis[i];
-    int64_t j = i + batchCount;
-    bSubgroupOrder[dim] = j;
-    bBatchOrder[dim] = j >= bfk ? j + 1 : j;
+    bSubgroupStrides[dim] = subgroupNStrides[i];
   }
-  bSubgroupOrder[bfk] = bRank - 1;
   bBatchSizes[bfk] = bounds[opInfo.getKDims().back()] / intrinsicK;
 
-  SmallVector<bool> bActiveSubgroups(subgroupBasis.size(), false);
-  for (auto nDim : nDims) {
-    bActiveSubgroups[nDim] = true;
-  }
-  if (batchCount == 1) {
-    bActiveSubgroups[0] = true;
-  }
-  bActiveSubgroups.back() = true;
-
-  auto bLayout = permuteAndCreateNestedLayout(
-      context, bRank, bfk, bfn,
-      /*subgroupCount=*/bSubgroupSizes,
-      /*subgroupOrder=*/bSubgroupOrder,
-      /*batchCount=*/bBatchSizes, bCounts, bOrders,
-      /*dataDuplicate=*/mmaAttr.getBDataDuplicate(), subgroupBasis,
-      bActiveSubgroups);
+  auto bLayout = createNestedLayout(context, bRank, bfk, bfn,
+                                    /*subgroupCount=*/bSubgroupSizes,
+                                    /*subgroupStrides=*/bSubgroupStrides,
+                                    /*batchCount=*/bBatchSizes,
+                                    mmaAttr.getBSingleSubgroupLayout());
   LLVM_DEBUG({ llvm::errs() << "B layout: " << bLayout << "\n"; });
 
   std::tuple<VectorLayoutInterface, VectorLayoutInterface,

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -202,18 +202,13 @@ def IREEGPU_MMAAttr : IREEGPU_MmaVectorLayoutAttr<"MMA", "MMAIntrinsicAttr"> {
 
   let extraClassDeclaration = [{
     int64_t getBlockSize() const;
-    SmallVector<int64_t> getADataDuplicate() const;
-    SmallVector<int64_t> getBDataDuplicate() const;
-    SmallVector<int64_t> getCDataDuplicate() const;
 
     // Partial nested layout for an MMA intrinsic's matrix input/output inside
     // a single subgroup.
-    //
-    // Note that this is just a container used by the following methods; it can
-    // contain both the shape and the order.
     struct SingleSubgroupLayout {
       SmallVector<int64_t, 2> outer;
       SmallVector<int64_t, 2> thread;
+      SmallVector<int64_t, 2> tstrides;
       SmallVector<int64_t, 2> element;
     };
 
@@ -221,17 +216,9 @@ def IREEGPU_MMAAttr : IREEGPU_MmaVectorLayoutAttr<"MMA", "MMAIntrinsicAttr"> {
     // subgroup. Shape at each outer/thread/element level is a 2-D value,
     // following canonical matmul order--(M, K) for A, (K, N) for B, and
     // (M, N) for C.
-    SingleSubgroupLayout getASingleSubgroupLayoutCount() const;
-    SingleSubgroupLayout getBSingleSubgroupLayoutCount() const;
-    SingleSubgroupLayout getCSingleSubgroupLayoutCount() const;
-
-    // Returns the A/B/C matrix's partial nested layout order inside a single
-    // subgroup. Order at each outer/thread/element level is a 2-value
-    // permuation vector, following canonical matmul order--(M, K) for A,
-    // (K, N) for B, and (M, N) for C.
-    SingleSubgroupLayout getASingleSubgroupLayoutOrder() const;
-    SingleSubgroupLayout getBSingleSubgroupLayoutOrder() const;
-    SingleSubgroupLayout getCSingleSubgroupLayoutOrder() const;
+    SingleSubgroupLayout getASingleSubgroupLayout() const;
+    SingleSubgroupLayout getBSingleSubgroupLayout() const;
+    SingleSubgroupLayout getCSingleSubgroupLayout() const;
   }];
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/distribute_multi_mma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/distribute_multi_mma.mlir
@@ -28,22 +28,24 @@ module attributes { transform.with_named_sequence } {
   }
 }
 
+// CHECK-DAG:   #[[$MAP:.+]]  = affine_map<(d0) -> (d0 mod 16)>
+// CHECK-DAG:   #[[$MAP1:.+]] = affine_map<(d0) -> ((d0 floordiv 16) mod 4)>
 // CHECK-LABEL: func @distribute_multi_mma_16x16x16
 //  CHECK-SAME:   %[[LHS:[A-Za-z0-9]+]]: tensor<2x2x16x16xf16>
 //  CHECK-SAME:   %[[RHS:[A-Za-z0-9]+]]: tensor<2x2x16x16xf16>
 //  CHECK-SAME:   %[[ACC:[A-Za-z0-9]+]]: tensor<2x2x16x16xf32>
-
 //       CHECK:   scf.forall (%[[LANE_ID:.+]]) in (64) shared_outs(%[[ITER_ARG:.+]] = %[[ACC]]) -> (tensor<2x2x16x16xf32>)
-//       CHECK:     %[[IDS:.+]]:2 = affine.delinearize_index %[[LANE_ID]] into (%c4, %c16) : index, index
-//       CHECK:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]][0, 0, %[[IDS]]#1, %[[IDS]]#0]
+//       CHECK:     %[[ID:.+]]  = affine.apply #[[$MAP]](%[[LANE_ID]])
+//       CHECK:     %[[ID1:.+]] = affine.apply #[[$MAP1]](%[[LANE_ID]])
+//       CHECK:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]][0, 0, %[[ID]], %[[ID1]]]
 //  CHECK-SAME:       [2, 2, 1, 4] [1, 1, 1, 1] : tensor<2x2x16x16xf16> to tensor<2x2x1x4xf16>
-//       CHECK:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]][0, 0, %[[IDS]]#0, %[[IDS]]#1]
+//       CHECK:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]][0, 0, %[[ID1]], %[[ID]]]
 //  CHECK-SAME:       [2, 2, 4, 1] [1, 1, 1, 1] : tensor<2x2x16x16xf16> to tensor<2x2x4x1xf16>
-//       CHECK:     %[[ACC_SLICE:.+]] = tensor.extract_slice %[[ITER_ARG]][0, 0, %[[IDS]]#0, %[[IDS]]#1]
+//       CHECK:     %[[ACC_SLICE:.+]] = tensor.extract_slice %[[ITER_ARG]][0, 0, %[[ID1]], %[[ID]]]
 //  CHECK-SAME:       [2, 2, 4, 1] [1, 1, 1, 1] : tensor<2x2x16x16xf32> to tensor<2x2x4x1xf32>
 //       CHECK:     %[[MMA:.+]] = iree_gpu.multi_mma %[[LHS_SLICE]], %[[RHS_SLICE]], %[[ACC_SLICE]]
 //  CHECK-SAME:       : tensor<2x2x1x4xf16>, tensor<2x2x4x1xf16> into tensor<2x2x4x1xf32>
 //       CHECK:     scf.forall.in_parallel
-//       CHECK:       tensor.parallel_insert_slice %[[MMA]] into %[[ITER_ARG]][0, 0, %[[IDS]]#0, %[[IDS]]#1]
+//       CHECK:       tensor.parallel_insert_slice %[[MMA]] into %[[ITER_ARG]][0, 0, %[[ID1]], %[[ID]]]
 //  CHECK-SAME:         [2, 2, 4, 1] [1, 1, 1, 1] : tensor<2x2x4x1xf32> into tensor<2x2x16x16xf32>
 //       CHECK:   mapping = [#iree_gpu.lane_id<0>]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_distribute_conversion.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_distribute_conversion.mlir
@@ -95,17 +95,12 @@ func.func @mfma_matmul_256x256x256(%lhs: memref<16x256xf16, strided<[256, 1], of
   return
 }
 
-// CHECK: #[[$MAP:.+]] = affine_map<()[s0, s1, s2] -> (s0 + s1 * 64 + s2 * 64)>
 // CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1) -> (d1, d0)>
 
 // CHECK-LABEL: func.func @mfma_matmul_256x256x256
 //       CHECK:   %[[TIDX:.+]] = gpu.thread_id  x
-//       CHECK:   %[[TIDY:.+]] = gpu.thread_id  y
-//       CHECK:   %[[TIDZ:.+]] = gpu.thread_id  z
-//       CHECK:   %[[LIN_ID:.+]] = affine.apply #[[$MAP]]()[%[[TIDX]], %[[TIDY]], %[[TIDZ]]]
 //       CHECK:   %[[RHS_ALLOC:.+]] = memref.alloc() : memref<32x16xf16, #gpu.address_space<workgroup>>
 //       CHECK:   %[[LHS_ALLOC:.+]] = memref.alloc() : memref<16x32xf16, #gpu.address_space<workgroup>>
-//       CHECK:   affine.delinearize_index %[[LIN_ID]]
 //       CHECK:   %[[INIT_READ:.+]] = vector.transfer_read %{{.*}} memref<16x16xf32, {{.*}}>, vector<4x1xf32>
 //       CHECK:   %[[INIT:.+]] = vector.insert_strided_slice %[[INIT_READ]]
 //       CHECK:   scf.for {{.*}} = %c0 to %c256 step %c32 iter_args({{.*}} = %[[INIT]]) -> (vector<1x1x1x1x4x1xf32>)
@@ -224,17 +219,12 @@ func.func @wmma_matmul_256x256x256(%lhs: memref<16x256xf16, strided<[256, 1], of
 // TODO: Currently have many inits because of the strided/interleaved layout of the C/D matrix.
 //       Need to add some canonicalization pattern to improve this.
 
-// CHECK: #[[$MAP:.+]] = affine_map<()[s0, s1, s2] -> (s0 + s1 * 32 + s2 * 32)>
 // CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1) -> (d1, d0)>
 
 // CHECK-LABEL: func.func @wmma_matmul_256x256x256
 //       CHECK:   %[[TIDX:.+]] = gpu.thread_id  x
-//       CHECK:   %[[TIDY:.+]] = gpu.thread_id  y
-//       CHECK:   %[[TIDZ:.+]] = gpu.thread_id  z
-//       CHECK:   %[[LIN_ID:.+]] = affine.apply #[[$MAP]]()[%[[TIDX]], %[[TIDY]], %[[TIDZ]]]
 //       CHECK:   %[[RHS_ALLOC:.+]] = memref.alloc() : memref<32x16xf16, #gpu.address_space<workgroup>>
 //       CHECK:   %[[LHS_ALLOC:.+]] = memref.alloc() : memref<16x32xf16, #gpu.address_space<workgroup>>
-//       CHECK:   affine.delinearize_index %[[LIN_ID]]
 //       CHECK:   %[[INIT_READ0:.+]] = vector.transfer_read %{{.*}} memref<16x16xf32, {{.*}}>, vector<1x1xf32>
 //       CHECK:   %[[INIT0:.+]] = vector.insert_strided_slice %[[INIT_READ0]]
 //       CHECK:   %[[INIT_READ1:.+]] = vector.transfer_read %{{.*}} memref<16x16xf32, {{.*}}>, vector<1x1xf32>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_distribute_layout.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_distribute_layout.mlir
@@ -15,14 +15,13 @@ func.func @mfma_matmul_96x64x16_mm(%lhs: vector<96x16xf16>, %rhs: vector<16x64xf
 
 //      CHECK: contract A vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [3, 2], outers_per_batch = [1, 1], threads_per_outer = [32, 2], elements_per_thread = [1, 4],
-// CHECK-SAME:   thread_order = [1, 0]
-// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, false, true], thread_basis = [2, 32]>
+// CHECK-SAME:   subgroup_strides = [0, 0], thread_strides = [1, 32]>
 //      CHECK: contract B vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [2, 2], outers_per_batch = [1, 1], threads_per_outer = [2, 32], elements_per_thread = [4, 1],
-// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [false, true, true], thread_basis = [2, 32]>
+// CHECK-SAME:   subgroup_strides = [0, 0], thread_strides = [32, 1]>
 //      CHECK: contract C vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [3, 2], outers_per_batch = [4, 1], threads_per_outer = [2, 32], elements_per_thread = [4, 1],
-// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, true, false], thread_basis = [2, 32]>
+// CHECK-SAME:   subgroup_strides = [0, 0], thread_strides = [32, 1]>
 
 // -----
 
@@ -41,15 +40,13 @@ func.func @mfma_matmul_96x64x16_mmt(%lhs: vector<96x16xf16>, %rhs: vector<64x16x
 
 //      CHECK: contract A vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [3, 2], outers_per_batch = [1, 1], threads_per_outer = [32, 2], elements_per_thread = [1, 4],
-// CHECK-SAME:   thread_order = [1, 0]
-// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, false, true], thread_basis = [2, 32]>
+// CHECK-SAME:   subgroup_strides = [0, 0], thread_strides = [1, 32]>
 //      CHECK: contract B vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [2, 2], outers_per_batch = [1, 1], threads_per_outer = [32, 2], elements_per_thread = [1, 4],
-// CHECK-SAME:   thread_order = [1, 0]
-// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [false, true, true], thread_basis = [2, 32]>
+// CHECK-SAME:   subgroup_strides = [0, 0], thread_strides = [1, 32]>
 //      CHECK: contract C vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [3, 2], outers_per_batch = [4, 1], threads_per_outer = [2, 32], elements_per_thread = [4, 1],
-// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, true, false], thread_basis = [2, 32]>
+// CHECK-SAME:   subgroup_strides = [0, 0], thread_strides = [32, 1]>
 
 // -----
 
@@ -68,16 +65,13 @@ func.func @mfma_matmul_96x64x16_mmtt(%lhs: vector<96x16xf16>, %rhs: vector<64x16
 
 //      CHECK: contract A vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME: subgroups_per_workgroup = [1, 1], batches_per_subgroup = [3, 2], outers_per_batch = [1, 1], threads_per_outer = [32, 2], elements_per_thread = [1, 4],
-// CHECK-SAME: thread_order = [1, 0],
-// CHECK-SAME: subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, false, true], thread_basis = [2, 32]>
+// CHECK-SAME: subgroup_strides = [0, 0], thread_strides = [1, 32]
 //      CHECK: contract B vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME: subgroups_per_workgroup = [1, 1], batches_per_subgroup = [2, 2], outers_per_batch = [1, 1], threads_per_outer = [32, 2], elements_per_thread = [1, 4],
-// CHECK-SAME: thread_order = [1, 0],
-// CHECK-SAME: subgroup_basis = [1, 1, 1], subgroup_active_ids = [false, true, true], thread_basis = [2, 32]>
+// CHECK-SAME: subgroup_strides = [0, 0], thread_strides = [1, 32]
 //      CHECK: contract C vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME: subgroups_per_workgroup = [1, 1], batches_per_subgroup = [2, 3], outers_per_batch = [1, 4], threads_per_outer = [32, 2], elements_per_thread = [1, 4],
-// CHECK-SAME: subgroup_order = [1, 0], thread_order = [1, 0],
-// CHECK-SAME: subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, true, false], thread_basis = [2, 32]>
+// CHECK-SAME: subgroup_strides = [0, 0], thread_strides = [1, 32]
 
 // -----
 
@@ -139,22 +133,20 @@ func.func @matmul_16x16x256_read(%lhs: memref<16x256xf16, strided<[256, 1], offs
 
 //      CHECK: transfer '{{.+}} memref<16x256xf16{{.+}}<storage_buffer>>, vector<16x32xf16>' vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [1, 1], outers_per_batch = [1, 1], threads_per_outer = [16, 4], elements_per_thread = [1, 8],
-// CHECK-SAME:   subgroup_basis = [1, 1], thread_basis = [16, 4]>
+// CHECK-SAME:   subgroup_strides = [0, 0], thread_strides = [4, 1]>
 //      CHECK: transfer '{{.+}} memref<256x16xf16{{.+}}<storage_buffer>>, vector<32x16xf16>' vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [1, 1], outers_per_batch = [1, 1], threads_per_outer = [32, 2], elements_per_thread = [1, 8],
-// CHECK-SAME:   subgroup_basis = [1, 1], thread_basis = [32, 2]>
+// CHECK-SAME:   subgroup_strides = [0, 0], thread_strides = [2, 1]>
 
 //      CHECK: contract A vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [1, 2], outers_per_batch = [1, 1], threads_per_outer = [16, 4], elements_per_thread = [1, 4],
-// CHECK-SAME:   thread_order = [1, 0]
-// CHECK-SAME:   subgroup_active_ids = [true, false, true], thread_basis = [4, 16]>
+// CHECK-SAME:   subgroup_strides = [0, 0], thread_strides = [1, 16]>
 //      CHECK: contract B vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [2, 1], outers_per_batch = [1, 1], threads_per_outer = [4, 16], elements_per_thread = [4, 1],
-// CHECK-SAME:   subgroup_order = [1, 0]
-// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [false, true, true], thread_basis = [4, 16]>
+// CHECK-SAME:   subgroup_strides = [0, 0], thread_strides = [16, 1]>
 //      CHECK: contract C vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [1, 1], outers_per_batch = [1, 1], threads_per_outer = [4, 16], elements_per_thread = [4, 1],
-// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, true, false], thread_basis = [4, 16]>
+// CHECK-SAME:   subgroup_strides = [0, 0], thread_strides = [16, 1]>
 
 // -----
 
@@ -201,22 +193,20 @@ func.func @matmul_16x16x256_read_permute(%lhs: memref<16x256xf16, strided<[256, 
 //  CHECK-NOT: transfer '{{.+}} memref<16x16xf16{{.+}}<storage_buffer>>, vector<16x16xf16>' vector layout
 //      CHECK: transfer '{{.+}} memref<16x256xf16{{.+}}<storage_buffer>>, vector<16x32xf16>' vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [1, 1], outers_per_batch = [1, 1], threads_per_outer = [16, 4], elements_per_thread = [1, 8],
-// CHECK-SAME:   subgroup_basis = [1, 1], thread_basis = [16, 4]>
+// CHECK-SAME:   subgroup_strides = [0, 0], thread_strides = [4, 1]>
 //      CHECK: transfer '{{.+}} memref<16x256xf16{{.+}}storage_buffer>>, vector<32x16xf16>' vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [1, 1], outers_per_batch = [1, 1], threads_per_outer = [4, 16], elements_per_thread = [8, 1],
-// CHECK-SAME:   subgroup_order = [1, 0], thread_order = [1, 0],
-// CHECK-SAME:   subgroup_basis = [1, 1], thread_basis = [4, 16]>
+// CHECK-SAME:   subgroup_strides = [0, 0], thread_strides = [1, 4]>
 
 //      CHECK: contract A vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [1, 2], outers_per_batch = [1, 1], threads_per_outer = [16, 4], elements_per_thread = [1, 4],
-// CHECK-SAME:   thread_order = [1, 0]
-// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, false, true], thread_basis = [4, 16]>
+// CHECK-SAME:   subgroup_strides = [0, 0], thread_strides = [1, 16]>
 //      CHECK: contract B vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [2, 1], outers_per_batch = [1, 1], threads_per_outer = [4, 16], elements_per_thread = [4, 1],
-// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [false, true, true], thread_basis = [4, 16]>
+// CHECK-SAME:   subgroup_strides = [0, 0], thread_strides = [16, 1]>
 //      CHECK: contract C vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [1, 1], outers_per_batch = [1, 1], threads_per_outer = [4, 16], elements_per_thread = [4, 1],
-// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, true, false], thread_basis = [4, 16]>
+// CHECK-SAME:   subgroup_strides = [0, 0], thread_strides = [16, 1]>
 
 // -----
 
@@ -275,14 +265,13 @@ func.func @wmma_matmul_48x32x32_mm(%lhs: vector<48x32xf16>, %rhs: vector<32x32xf
 
 //      CHECK: contract A vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [3, 2], outers_per_batch = [1, 1], threads_per_outer = [16, 1], elements_per_thread = [1, 16],
-// CHECK-SAME:   thread_order = [1, 0]
-// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, false, true], thread_basis = [1, 32]>
+// CHECK-SAME:   subgroup_strides = [0, 0], thread_strides = [1, 0]>
 //      CHECK: contract B vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [2, 2], outers_per_batch = [1, 1], threads_per_outer = [1, 16], elements_per_thread = [16, 1],
-// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [false, true, true], thread_basis = [1, 32]>
+// CHECK-SAME:   subgroup_strides = [0, 0], thread_strides = [0, 1]>
 //      CHECK: contract C vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [3, 2], outers_per_batch = [8, 1], threads_per_outer = [2, 16], elements_per_thread = [1, 1],
-// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, true, false], thread_basis = [2, 16]>
+// CHECK-SAME:   subgroup_strides = [0, 0], thread_strides = [16, 1]>
 
 // -----
 
@@ -301,15 +290,13 @@ func.func @wmma_matmul_48x32x32_mmt(%lhs: vector<48x32xf16>, %rhs: vector<32x32x
 
 //      CHECK: contract A vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [3, 2], outers_per_batch = [1, 1], threads_per_outer = [16, 1], elements_per_thread = [1, 16],
-// CHECK-SAME:   thread_order = [1, 0]
-// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, false, true], thread_basis = [1, 32]>
+// CHECK-SAME:   subgroup_strides = [0, 0], thread_strides = [1, 0]>
 //      CHECK: contract B vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [2, 2], outers_per_batch = [1, 1], threads_per_outer = [16, 1], elements_per_thread = [1, 16],
-// CHECK-SAME:   thread_order = [1, 0],
-// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [false, true, true], thread_basis = [1, 32]>
+// CHECK-SAME:   subgroup_strides = [0, 0], thread_strides = [1, 0]>
 //      CHECK: contract C vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [3, 2], outers_per_batch = [8, 1], threads_per_outer = [2, 16], elements_per_thread = [1, 1],
-// CHECK-SAME:   subgroup_basis = [1, 1, 1], subgroup_active_ids = [true, true, false], thread_basis = [2, 16]>
+// CHECK-SAME:   subgroup_strides = [0, 0], thread_strides = [16, 1]>
 
 // -----
 
@@ -333,29 +320,24 @@ func.func @matmul_192x64x16_mmt_multi_m(%lhs: vector<2x64x16xf16>, %rhs: vector<
 // CHECK-SAME:   outers_per_batch = [1, 1, 1],
 // CHECK-SAME:   threads_per_outer = [1, 16, 4],
 // CHECK-SAME:   elements_per_thread = [1, 1, 4],
-// CHECK-SAME:   thread_order = [0, 2, 1],
-// CHECK-SAME:   subgroup_basis = [2, 1, 1, 1],
-// CHECK-SAME:   subgroup_active_ids = [true, true, false, true],
-// CHECK-SAME:   thread_basis = [1, 4, 16]>
+// CHECK-SAME:   subgroup_strides = [1, 0, 0],
+// CHECK-SAME:   thread_strides = [0, 1, 16]>
 //      CHECK: contract B vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1],
 // CHECK-SAME:   batches_per_subgroup = [1, 4],
 // CHECK-SAME:   outers_per_batch = [1, 1],
 // CHECK-SAME:   threads_per_outer = [4, 16],
 // CHECK-SAME:   elements_per_thread = [4, 1],
-// CHECK-SAME:   subgroup_order = [1, 0],
-// CHECK-SAME:   subgroup_basis = [2, 1, 1, 1],
-// CHECK-SAME:   subgroup_active_ids = [false, false, true, true],
-// CHECK-SAME:   thread_basis = [4, 16]>
+// CHECK-SAME:   subgroup_strides = [0, 0],
+// CHECK-SAME:   thread_strides = [16, 1]>
 //      CHECK: contract C vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [2, 1, 1],
 // CHECK-SAME:   batches_per_subgroup = [1, 4, 4],
 // CHECK-SAME:   outers_per_batch = [1, 1, 1],
 // CHECK-SAME:   threads_per_outer = [1, 4, 16],
 // CHECK-SAME:   elements_per_thread = [1, 4, 1],
-// CHECK-SAME:   subgroup_basis = [2, 1, 1, 1],
-// CHECK-SAME:   subgroup_active_ids = [true, true, true, false],
-// CHECK-SAME:   thread_basis = [1, 4, 16]>
+// CHECK-SAME:   subgroup_strides = [1, 0, 0],
+// CHECK-SAME:   thread_strides = [0, 16, 1]>
 
 // -----
 
@@ -375,13 +357,11 @@ func.func @matmul_192x64x16_mmt_multi_split_m(%lhs: vector<2x64x16xf16>, %rhs: v
 //      CHECK: contract A vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [2, 2, 1],
 // CHECK-SAME:   batches_per_subgroup = [1, 2, 1],
-// CHECK-SAME:   subgroup_basis = [2, 2, 1, 1],
-// CHECK-SAME:   subgroup_active_ids = [true, true, false, true]
+// CHECK-SAME:   subgroup_strides = [2, 1, 0],
 //      CHECK: contract C vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [2, 2, 1],
 // CHECK-SAME:   batches_per_subgroup = [1, 2, 4],
-// CHECK-SAME:   subgroup_basis = [2, 2, 1, 1],
-// CHECK-SAME:   subgroup_active_ids = [true, true, true, false]
+// CHECK-SAME:   subgroup_strides = [2, 1, 0],
 
 // -----
 
@@ -401,18 +381,15 @@ func.func @matmul_192x64x16_mmt_multi_m_and_n(%lhs: vector<4x64x16xf16>, %rhs: v
 //      CHECK: contract A vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [2, 1, 1],
 // CHECK-SAME:   batches_per_subgroup = [2, 4, 1],
-// CHECK-SAME:   subgroup_basis = [2, 2, 1, 1, 1],
-// CHECK-SAME:   subgroup_active_ids = [true, false, true, false, true]
+// CHECK-SAME:   subgroup_strides = [2, 0, 0],
 //      CHECK: contract B vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [2, 1, 1],
 // CHECK-SAME:   batches_per_subgroup = [1, 1, 4],
-// CHECK-SAME:   subgroup_basis = [2, 2, 1, 1, 1],
-// CHECK-SAME:   subgroup_active_ids = [false, true, false, true, true]
+// CHECK-SAME:   subgroup_strides = [1, 0, 0],
 //      CHECK: contract C vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [2, 2, 1, 1],
 // CHECK-SAME:   batches_per_subgroup = [2, 1, 4, 4],
-// CHECK-SAME:   subgroup_basis = [2, 2, 1, 1, 1],
-// CHECK-SAME:   subgroup_active_ids = [true, true, true, true, false]
+// CHECK-SAME:   subgroup_strides = [2, 1, 0, 0],
 
 // -----
 
@@ -447,7 +424,7 @@ func.func @dequant_anchors_on_quant_only(%quant: memref<128x128xi4, strided<[409
   return
 }
 //      CHECK: transfer '{{.+}} memref<128x128xi4{{.+}}<storage_buffer>>, vector<128x128xi4>' vector layout: #iree_vector_ext.nested_layout<
-// CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [4, 1], outers_per_batch = [1, 1], threads_per_outer = [32, 4], elements_per_thread = [1, 32], subgroup_basis = [1, 1], thread_basis = [32, 4]>
+// CHECK-SAME:   subgroups_per_workgroup = [1, 1], batches_per_subgroup = [4, 1], outers_per_batch = [1, 1], threads_per_outer = [32, 4], elements_per_thread = [1, 32], subgroup_strides = [0, 0], thread_strides = [4, 1]>
 //  CHECK-NOT: transfer '{{.+}} memref<128xf16{{.+}}<storage_buffer>>, vector<128xf16>' vector layout
 
 // -----
@@ -473,26 +450,21 @@ func.func @batch_matmul_unit_batch(%arg0: vector<1x64x64xf16>, %arg1: vector<1x6
 // CHECK-SAME:   outers_per_batch = [1, 1, 1]
 // CHECK-SAME:   threads_per_outer = [1, 16, 4]
 // CHECK-SAME:   elements_per_thread = [1, 1, 4]
-// CHECK-SAME:   thread_order = [0, 2, 1]
-// CHECK-SAME:   subgroup_basis = [1, 2, 2, 1]
-// CHECK-SAME:   subgroup_active_ids = [true, true, false, true]
-// CHECK-SAME:   thread_basis = [1, 4, 16]
+// CHECK-SAME:   subgroup_strides = [0, 2, 0],
+// CHECK-SAME:   thread_strides = [0, 1, 16]>
 //      CHECK: contract B vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 1, 2]
 // CHECK-SAME:   batches_per_subgroup = [1, 4, 4]
 // CHECK-SAME:   outers_per_batch = [1, 1, 1]
 // CHECK-SAME:   threads_per_outer = [1, 4, 16]
 // CHECK-SAME:   elements_per_thread = [1, 4, 1]
-// CHECK-SAME:   subgroup_order = [0, 2, 1]
-// CHECK-SAME:   subgroup_basis = [1, 2, 2, 1]
-// CHECK-SAME:   subgroup_active_ids = [true, false, true, true]
-// CHECK-SAME:   thread_basis = [1, 4, 16]
+// CHECK-SAME:   subgroup_strides = [0, 0, 1],
+// CHECK-SAME:   thread_strides = [0, 16, 1]>
 //      CHECK: contract C vector layout: #iree_vector_ext.nested_layout<
 // CHECK-SAME:   subgroups_per_workgroup = [1, 2, 2]
 // CHECK-SAME:   batches_per_subgroup = [1, 2, 4]
 // CHECK-SAME:   outers_per_batch = [1, 1, 1]
 // CHECK-SAME:   threads_per_outer = [1, 4, 16]
 // CHECK-SAME:   elements_per_thread = [1, 4, 1]
-// CHECK-SAME:   subgroup_basis = [1, 2, 2, 1]
-// CHECK-SAME:   subgroup_active_ids = [true, true, true, false]
-// CHECK-SAME:   thread_basis = [1, 4, 16]
+// CHECK-SAME:   subgroup_strides = [0, 2, 1],
+// CHECK-SAME:   thread_strides = [0, 16, 1]>

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/VectorExt/IR/VectorExtAttrs.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/VectorExt/IR/VectorExtAttrs.td
@@ -257,26 +257,15 @@ def NestedLayoutAttr : IREEVectorExt_Attr<"NestedLayout",
 
   let parameters = (ins
     ArrayRefParameter<"int64_t", "subgroups_per_workgroup">:$subgroupsPerWorkgroup,
-    ArrayRefParameter<"int64_t", "subgroup_order">:$subgroupOrder,
-
     ArrayRefParameter<"int64_t", "batches_per_subgroup">:$batchesPerSubgroup,
-
     ArrayRefParameter<"int64_t", "outers_per_batch">:$outersPerBatch,
-
     ArrayRefParameter<"int64_t", "threads_per_outer">:$threadsPerOuter,
-    ArrayRefParameter<"int64_t", "thread_order">:$threadOrder,
-
     ArrayRefParameter<"int64_t", "elements_per_thread">:$elementsPerThread,
 
-    ArrayRefParameter<"int64_t", "subgroup_basis">:$subgroupBasis,
-    ArrayRefParameter<"bool", "subgroup_active_ids">:$subgroupActiveIds,
-
-    ArrayRefParameter<"int64_t", "thread_basis">:$threadBasis,
-    ArrayRefParameter<"bool", "thread_active_ids">:$threadActiveIds
+    ArrayRefParameter<"int64_t", "subgroup_strides">:$subgroupStrides,
+    ArrayRefParameter<"int64_t", "thread_strides">:$threadStrides
   );
 
-  // By default, identity orderings are elided when parsing/printing.
-  // TODO: Improve custom parsing/printing for sizes/basis elements.
   let assemblyFormat = [{
     `<` `subgroups_per_workgroup` `=` `[` $subgroupsPerWorkgroup `]` `,`
         `batches_per_subgroup`    `=` `[` $batchesPerSubgroup `]` `,`
@@ -284,18 +273,26 @@ def NestedLayoutAttr : IREEVectorExt_Attr<"NestedLayout",
         `threads_per_outer`       `=` `[` $threadsPerOuter `]` `,`
         `elements_per_thread`     `=` `[` $elementsPerThread `]` `,`
 
-        custom<Permutation>("\"subgroup_order\"", ref($subgroupsPerWorkgroup), "true", $subgroupOrder) ``
-        custom<Permutation>("\"thread_order\"", ref($threadsPerOuter), "true", $threadOrder) ``
-
-        custom<Basis>("\"subgroup_basis\"", "\"subgroup_active_ids\"", "true", $subgroupBasis, $subgroupActiveIds) ``
-        custom<Basis>("\"thread_basis\"", "\"thread_active_ids\"", "false", $threadBasis, $threadActiveIds) ``
+        `subgroup_strides`        `=` `[` $subgroupStrides `]` `,`
+        `thread_strides`          `=` `[` $threadStrides `]`
     `>`
   }];
+
+  let skipDefaultBuilders = 1;
+  let builders = [
+    AttrBuilder<(ins "ArrayRef<int64_t>":$subgroupsPerWorkgroup,
+                     "ArrayRef<int64_t>":$batchesPerSubgroup,
+                     "ArrayRef<int64_t>":$outersPerBatch,
+                     "ArrayRef<int64_t>":$threadsPerOuter,
+                     "ArrayRef<int64_t>":$elementsPerThread,
+                     "ArrayRef<int64_t>":$subgroupStrides,
+                     "ArrayRef<int64_t>":$threadStrides)>
+  ];
 
   let extraClassDeclaration = [{
     // Returns the subgroup/lane ids delinearized from a single linearized
     // thread ID.
-    SmallVector<Value> computeThreadIds(Value threadId, RewriterBase &rewriter) const;
+    SmallVector<Value> computeThreadIds(Value threadId, int64_t subgroupSize, RewriterBase &rewriter) const;
   }];
 
   let genVerifyDecl = 1;

--- a/llvm-external-projects/iree-dialects/lib/Dialect/VectorExt/IR/VectorExtAttrs.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/VectorExt/IR/VectorExtAttrs.cpp
@@ -255,6 +255,8 @@ NestedLayoutAttr::project(ArrayRef<bool> droppedDims) const {
   SmallVector<int64_t> outerCount;
   SmallVector<int64_t> threadCount;
   SmallVector<int64_t> elementCount;
+  SmallVector<int64_t> subgroupStrides;
+  SmallVector<int64_t> threadStrides;
   int64_t count = 0;
   // Map to track pre-projection -> post-projection indices. Used to update
   // the dimension orders.
@@ -266,108 +268,39 @@ NestedLayoutAttr::project(ArrayRef<bool> droppedDims) const {
       outerCount.push_back(getOutersPerBatch()[idx]);
       threadCount.push_back(getThreadsPerOuter()[idx]);
       elementCount.push_back(getElementsPerThread()[idx]);
+      subgroupStrides.push_back(getSubgroupStrides()[idx]);
+      threadStrides.push_back(getThreadStrides()[idx]);
       indexToRankReducedIndexMap[idx] = count++;
     }
   }
   // This layout is invalid for rank-0 vectors.
   assert(count >= 0 && "unimplemented rank-0 vector");
 
-  auto getRankReducedPermutation =
-      [&](ArrayRef<int64_t> perm) -> SmallVector<int64_t> {
-    SmallVector<int64_t> newPerm;
-    for (auto i : perm) {
-      if (indexToRankReducedIndexMap.contains(i)) {
-        newPerm.push_back(indexToRankReducedIndexMap[i]);
-      }
-    }
-    return newPerm;
-  };
-
-  SmallVector<int64_t> subgroupOrder =
-      getRankReducedPermutation(getSubgroupOrder());
-  SmallVector<int64_t> threadOrder =
-      getRankReducedPermutation(getThreadOrder());
-
-  // Compose the projected dims with the basis mask to get the new active
-  // ids. Active ids indicates that we should use the ids marked as true, and
-  // projected dims drop the dims marked as true. So to get the new mask, we
-  // turn off all of the currently `true` ids marked as projected. For example:
-  //
-  // subgroup_active_ids = [true,  true,  false, true]
-  // projected_dims =      [false, true,         false]
-  //
-  // new_active_ids =      [true,  false, false, true]
-  auto composeMasks = [&](SmallVector<bool> &newMask, ArrayRef<bool> mask) {
-    int64_t rankReducedIdx = 0;
-    for (auto [i, active] : llvm::enumerate(newMask)) {
-      if (active) {
-        newMask[i] = !mask[rankReducedIdx];
-        rankReducedIdx++;
-      }
-    }
-  };
-  SmallVector<bool> subgroupMask(getSubgroupActiveIds());
-  SmallVector<bool> threadMask(getThreadActiveIds());
-
-  SmallVector<bool> invertedDroppedThreadMask =
-      applyPermutation(droppedDims, invertPermutationVector(getThreadOrder()));
-  composeMasks(subgroupMask, invertedDroppedThreadMask);
-
-  SmallVector<bool> invertedDroppedSubgroupMask =
-      applyPermutation(droppedDims, invertPermutationVector(getThreadOrder()));
-  composeMasks(threadMask, invertedDroppedSubgroupMask);
-
-  return NestedLayoutAttr::get(getContext(), subgroupCount, subgroupOrder,
-                               batchCount, outerCount, threadCount, threadOrder,
-                               elementCount, getSubgroupBasis(), subgroupMask,
-                               getThreadBasis(), threadMask);
+  return NestedLayoutAttr::get(getContext(), subgroupCount, batchCount,
+                               outerCount, threadCount, elementCount,
+                               subgroupStrides, threadStrides);
 }
 
 VectorLayoutInterface
 NestedLayoutAttr::permute(ArrayRef<int64_t> permutation) const {
-  // The order fields are permuted by the inverse permutation to map the
-  // permuted sizes back to their original positions.
-  //
-  // Shape = S
-  // Distributed Shape = DS
-  // Ordering = P
-  //
-  // S(A) * P(A) = DS(A)
-  //
-  // AT = transpose(A)
-  //
-  // Given:
-  // DS(A) = DS(AT) -- 1
-  // S(AT) = S(A) * perm -- 2
-  //
-  // :=
-  //
-  // Using 1
-  // S(A) * P(A) = S(AT) * P(AT)
-  // Using 2
-  // S(A) * P(A) =  S(A) * perm * P(AT)
-  // P(A) = perm * P(AT)
-  // P(AT) = perm^-1 * P(A)
   SmallVector<int64_t> invPerm = invertPermutationVector(permutation);
   SmallVector<int64_t> subgroupCount =
       applyPermutation(getSubgroupsPerWorkgroup(), permutation);
-  SmallVector<int64_t> subgroupOrder =
-      applyPermutation(invPerm, getSubgroupOrder());
   SmallVector<int64_t> batchCount =
       applyPermutation(getBatchesPerSubgroup(), permutation);
   SmallVector<int64_t> outerCount =
       applyPermutation(getOutersPerBatch(), permutation);
   SmallVector<int64_t> threadCount =
       applyPermutation(getThreadsPerOuter(), permutation);
-  SmallVector<int64_t> threadOrder =
-      applyPermutation(invPerm, getThreadOrder());
   SmallVector<int64_t> elementCount =
       applyPermutation(getElementsPerThread(), permutation);
-
-  return NestedLayoutAttr::get(
-      getContext(), subgroupCount, subgroupOrder, batchCount, outerCount,
-      threadCount, threadOrder, elementCount, getSubgroupBasis(),
-      getSubgroupActiveIds(), getThreadBasis(), getThreadActiveIds());
+  SmallVector<int64_t> subgroupStrides =
+      applyPermutation(getSubgroupStrides(), permutation);
+  SmallVector<int64_t> threadStrides =
+      applyPermutation(getThreadStrides(), permutation);
+  return NestedLayoutAttr::get(getContext(), subgroupCount, batchCount,
+                               outerCount, threadCount, elementCount,
+                               subgroupStrides, threadStrides);
 }
 
 /// We distribute to:
@@ -421,34 +354,66 @@ LogicalResult NestedLayoutAttr::isValidLayout(VectorValue vector) const {
   }
   return success();
 }
+NestedLayoutAttr NestedLayoutAttr::getChecked(
+    ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
+    ::mlir::MLIRContext *context, ArrayRef<int64_t> subgroupsPerWorkgroup,
+    ArrayRef<int64_t> batchesPerSubgroup, ArrayRef<int64_t> outersPerBatch,
+    ArrayRef<int64_t> threadsPerOuter, ArrayRef<int64_t> elementsPerThread,
+    ArrayRef<int64_t> subgroupStrides, ArrayRef<int64_t> threadStrides) {
+  if (failed(NestedLayoutAttr::verify(emitError, subgroupsPerWorkgroup,
+                                      batchesPerSubgroup, outersPerBatch,
+                                      threadsPerOuter, elementsPerThread,
+                                      subgroupStrides, threadStrides))) {
+    return NestedLayoutAttr();
+  }
 
-// TODO: These things should ideally go into the parser when we have a custom
-// parser.
+  return NestedLayoutAttr::get(
+      context, subgroupsPerWorkgroup, batchesPerSubgroup, outersPerBatch,
+      threadsPerOuter, elementsPerThread, subgroupStrides, threadStrides);
+}
+
+NestedLayoutAttr NestedLayoutAttr::get(
+    MLIRContext *context, ArrayRef<int64_t> subgroupsPerWorkgroup,
+    ArrayRef<int64_t> batchesPerSubgroup, ArrayRef<int64_t> outersPerBatch,
+    ArrayRef<int64_t> threadsPerOuter, ArrayRef<int64_t> elementsPerThread,
+    ArrayRef<int64_t> subgroupStrides, ArrayRef<int64_t> threadStrides) {
+
+  SmallVector<int64_t> normalizedSubgroupStrides(subgroupStrides);
+  SmallVector<int64_t> normalizedThreadStrides(threadStrides);
+
+  // Dimension of size 1 only have one element to distribute, so stride can be
+  // anything. We normalize the stride to be 0, to have consistency.
+
+  for (auto [stride, size] :
+       llvm::zip_equal(normalizedSubgroupStrides, subgroupsPerWorkgroup)) {
+    if (size == 1) {
+      stride = 0;
+    }
+  }
+
+  for (auto [stride, size] :
+       llvm::zip_equal(normalizedThreadStrides, threadsPerOuter)) {
+    if (size == 1) {
+      stride = 0;
+    }
+  }
+
+  return Base::get(context, subgroupsPerWorkgroup, batchesPerSubgroup,
+                   outersPerBatch, threadsPerOuter, elementsPerThread,
+                   normalizedSubgroupStrides, normalizedThreadStrides);
+}
+
 LogicalResult NestedLayoutAttr::verify(
     llvm::function_ref<InFlightDiagnostic()> emitError,
-    ArrayRef<int64_t> subgroupsPerWorkgroup, ArrayRef<int64_t> subgroupOrder,
+    ArrayRef<int64_t> subgroupsPerWorkgroup,
     ArrayRef<int64_t> batchesPerSubgroup, ArrayRef<int64_t> outersPerBatch,
-    ArrayRef<int64_t> threadsPerOuter, ArrayRef<int64_t> threadOrder,
-    ArrayRef<int64_t> elementsPerThread, ArrayRef<int64_t> subgroupBasis,
-    ArrayRef<bool> subgroupActiveIds, ArrayRef<int64_t> threadBasis,
-    ArrayRef<bool> threadActiveIds) {
+    ArrayRef<int64_t> threadsPerOuter, ArrayRef<int64_t> elementsPerThread,
+    ArrayRef<int64_t> subgroupStrides, ArrayRef<int64_t> threadStrides) {
 
   size_t rank = subgroupsPerWorkgroup.size();
   auto checkTile = [&](ArrayRef<int64_t> tileShape) {
     if (tileShape.size() != rank) {
-      emitError() << "all tiles must have the same rank as the layout";
-      return failure();
-    }
-    return success();
-  };
-
-  auto checkOrder = [&](ArrayRef<int64_t> order) {
-    if (order.size() != rank) {
-      emitError() << "all orders must have the same rank as the layout";
-      return failure();
-    }
-    if (!mlir::isPermutationVector(order)) {
-      emitError() << "all orderings must be permutation vectors";
+      emitError() << "all fields must have the same rank as the layout";
       return failure();
     }
     return success();
@@ -457,27 +422,8 @@ LogicalResult NestedLayoutAttr::verify(
   if (failed(checkTile(subgroupsPerWorkgroup)) ||
       failed(checkTile(batchesPerSubgroup)) ||
       failed(checkTile(outersPerBatch)) || failed(checkTile(threadsPerOuter)) ||
-      failed(checkTile(elementsPerThread))) {
-    return failure();
-  }
-
-  if (failed(checkOrder(subgroupOrder)) || failed(checkOrder(threadOrder))) {
-    return failure();
-  }
-
-  auto checkBasis = [&](ArrayRef<int64_t> basis, ArrayRef<bool> mask) {
-    if (basis.size() != mask.size()) {
-      emitError() << "basis and active id mask must be the same length";
-      return failure();
-    }
-    if (llvm::count(mask, true) != rank) {
-      emitError()
-          << "number of active basis ids must be equal to the layout rank";
-    }
-    return success();
-  };
-  if (failed(checkBasis(subgroupBasis, subgroupActiveIds)) ||
-      failed(checkBasis(threadBasis, threadActiveIds))) {
+      failed(checkTile(elementsPerThread)) ||
+      failed(checkTile(subgroupStrides)) || failed(checkTile(threadStrides))) {
     return failure();
   }
 
@@ -491,271 +437,59 @@ LogicalResult NestedLayoutAttr::verify(
 /// threads -> elements). There is no requirement that a subgroup id only
 /// spans subgroups.
 SmallVector<Value>
-NestedLayoutAttr::computeThreadIds(Value threadId,
+NestedLayoutAttr::computeThreadIds(Value threadId, int64_t subgroupSize,
                                    RewriterBase &rewriter) const {
-  // The subgroup/thread bases tell us the ranges of the corresponding id from
-  // slowest varying to fastest varying. Thus to get the correct basis ids, we
-  // simply concatenate the sizes and delinearize the single thread id to those
-  // sizes. For example:
-  //
-  // subgroup_basis = [3, 5]
-  // thread_basis = [7, 9]
-  //
-  // subgroup_id(Y, X), thread_id(Y, X) = affine.delinearize_index(3, 5, 7, 9)
-  auto basisSizes =
-      llvm::concat<const int64_t>(getSubgroupBasis(), getThreadBasis());
+  SmallVector<Value> vtids;
 
-  SmallVector<OpFoldResult> basisIndexAttr;
-  for (int64_t basisIndex : basisSizes) {
-    basisIndexAttr.push_back(rewriter.getIndexAttr(basisIndex));
-  }
+  Location loc = threadId.getLoc();
 
-  SmallVector<Value> delinearized =
-      rewriter
-          .create<mlir::affine::AffineDelinearizeIndexOp>(
-              threadId.getLoc(), threadId, basisIndexAttr)
-          .getResults();
+  AffineExpr tidExpr, size, stride;
+  bindDims(rewriter.getContext(), tidExpr);
+  bindSymbols(rewriter.getContext(), size, stride);
 
-  // The subgroups_per_workgroup and threads_per_outer fields represent the
-  // number of subgroups/threads along each vector dimension. To get the sizes
-  // in the order of slowest varying to fastest varying (to match with the ids
-  // delinearized based on the basis), we need to apply the subgroup/thread
-  // permutation orders.
-  auto tileSizes = llvm::concat<const int64_t>(
-      applyPermutation(getSubgroupsPerWorkgroup(), getSubgroupOrder()),
-      applyPermutation(getThreadsPerOuter(), getThreadOrder()));
-  auto tileSizesIterator = tileSizes.begin();
+  // (tid floordiv stride) mod size
+  AffineMap threadTidMap =
+      AffineMap::get(/*dims=*/1, /*syms=*/2, tidExpr.floorDiv(stride) % size);
 
-  auto activeIdFilter =
-      llvm::concat<const bool>(getSubgroupActiveIds(), getThreadActiveIds());
+  // (tid floordiv (stride * subgroup_size)) mod size
+  AffineMap subgroupTidMap = AffineMap::get(
+      /*dims=*/1, /*syms=*/2, tidExpr.floorDiv(stride * subgroupSize) % size);
 
-  // Modulo the active delinearized subgroup/thread ids by the number of unique
-  // elements distributed to those ids. The only difference between subgroup
-  // and thread dimensions is the order in which they are "divided out" of the
-  // underlying vector (i.e. vector_shape /= subgroups -> batches -> outers ->
-  // threads -> elements). There is no requirement that a subgroup id only
-  // spans subgroups.
-  //
-  // thread_basis = [8, 4, 2]
-  // active_thread_ids = [true, false, true]
-  // threads_per_outer = [4, 2]
-  //
-  // To obtain the thread ids, we just delinearize based on the basis.
-  //
-  // i0, i1, i2 = affine.delinearize_inds %threadId (8, 4, 2)
-  //
-  // And then to get the thread id for the layout, we only consider the active
-  // ids:
-  //
-  // layout_id0 = i0 % 4
-  // layout_id1 = i2 % 2
-  //
-  // The typical way this is used it to implicitly broadcast data across
-  // threads. For example, take a simpler case of the following:
-  //
-  // vector_shape = vector<2>
-  // thread_basis = [2, 2]
-  // active_thread_ids = [true, false]
-  // threads_per_outer = [2]
-  //
-  // If we give the two elements in the vector labels, say s0 and s1, we can
-  // see what this layout assigns as ids when doing a read of those two values
-  // across 4 threads.
-  //
-  // %id = gpu.flat_thread_id   // In range [0, 4)
-  // i0, i1 = affine.delinearize_index %id (2, 2)
-  // %id = 0, 1, 2, 3
-  // ----------------
-  // i0  = 0, 0, 1, 1
-  // i1  = 0, 1, 0, 1
-  //
-  // %0 = vector.load mem[i0]
-  //
-  // %id = 0, 1, 2, 3
-  // ----------------
-  // %0  = s0 s0 s1 s1
-  //
-  // If we instead had this layout:
-  //
-  // thread_basis = [4]
-  // active_thread_ids = [true]
-  // threads_per_outer = [2]
-  //
-  // With the modulus, we would get:
-  //
-  // %id = gpu.flat_thread_id   // In range [0, 4)
-  // i0 = %id = affine.delinearize_index %id (4)
-  // layout_i0 = i0 % 2
-  //
-  // %id        = 0, 1, 2, 3
-  // ----------------
-  // layout_i0  = 0, 1, 0, 1
-  //
-  // %0 = vector.load mem[layout_i0]
-  //
-  // %id = 0, 1, 2, 3
-  // ----------------
-  // %0  = s0 s1 s0 s1
-  for (auto [delinearized, basis, isActive] :
-       llvm::zip_equal(delinearized, basisSizes, activeIdFilter)) {
-    if (!isActive) {
-      continue;
-    }
-    int64_t tile = *tileSizesIterator;
-    tileSizesIterator++;
-    if (basis == tile) {
+  for (auto [dimSize, dimStride] :
+       llvm::zip(getSubgroupsPerWorkgroup(), getSubgroupStrides())) {
+    // Dimension is not distributed.
+    if (dimStride == 0) {
+      vtids.push_back(rewriter.create<arith::ConstantOp>(
+          loc, rewriter.getIndexAttr(dimStride)));
       continue;
     }
 
-    AffineMap modMap =
-        AffineMap::get(1, 0, rewriter.getAffineDimExpr(0) % tile);
-    delinearized = rewriter.create<affine::AffineApplyOp>(threadId.getLoc(),
-                                                          modMap, delinearized);
+    auto sizeVal =
+        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(dimSize));
+    auto strideVal = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getIndexAttr(dimStride));
+    vtids.push_back(rewriter.create<affine::AffineApplyOp>(
+        loc, subgroupTidMap, ValueRange{threadId, sizeVal, strideVal}));
   }
 
-  return delinearized;
-}
-
-//===----------------------------------------------------------------------===//
-// Custom Parsers/Printers
-//===----------------------------------------------------------------------===//
-
-// Custom parser/printer to construct the permutation based on the rank of the
-// sizes corresponding to this order.
-static ParseResult parsePermutation(AsmParser &parser, StringRef baseName,
-                                    ArrayRef<int64_t> sizes, bool parseComma,
-                                    SmallVector<int64_t> &permutation) {
-  if (failed(parser.parseOptionalKeyword(baseName))) {
-    permutation = llvm::to_vector(llvm::seq<int64_t>(0, sizes.size()));
-    return success();
-  }
-  if (failed(parser.parseEqual())) {
-    return failure();
-  }
-  if (parser.parseLSquare()) {
-    return failure();
-  }
-  auto arrayParser = FieldParser<SmallVector<int64_t>>::parse(parser);
-  if (failed(arrayParser)) {
-    parser.emitError(parser.getCurrentLocation(),
-                     "failed to parse permutation parameter '")
-        << baseName << "' which is to be a `::llvm::ArrayRef<int64_t>`";
-  }
-  if (parser.parseRSquare()) {
-    return failure();
-  }
-  if (parseComma) {
-    if (parser.parseComma()) {
-      return failure();
+  for (auto [dimSize, dimStride] :
+       llvm::zip(getThreadsPerOuter(), getThreadStrides())) {
+    // Dimension is not distributed.
+    if (dimStride == 0) {
+      vtids.push_back(rewriter.create<arith::ConstantOp>(
+          loc, rewriter.getIndexAttr(dimStride)));
+      continue;
     }
-  }
-  permutation = *arrayParser;
-  return success();
-}
 
-static void printPermutation(AsmPrinter &p, StringRef baseName,
-                             ArrayRef<int64_t> sizes, bool printComma,
-                             ArrayRef<int64_t> permutation) {
-  if (isIdentityPermutation(permutation)) {
-    return;
-  }
-  p << baseName;
-  // This is called without whitespace inserted by default for optionality.
-  // Insert it explicitly instead.
-  p << ' ';
-  p << '=';
-  p << ' ';
-  p << '[';
-  llvm::interleaveComma(permutation, p);
-  p << ']';
-  if (printComma) {
-    p << ',' << ' ';
-  }
-}
-
-// Custom parser/printer for a basis (array of i64 values) and a mask (array
-// of boolean values).
-static ParseResult parseBasis(AsmParser &parser, StringRef basisName,
-                              StringRef maskName, bool parseComma,
-                              SmallVector<int64_t> &basis,
-                              SmallVector<bool> &mask) {
-  if (failed(parser.parseKeyword(basisName)) || failed(parser.parseEqual()) ||
-      failed(parser.parseLSquare())) {
-    return failure();
-  }
-  auto arrayParser = FieldParser<SmallVector<int64_t>>::parse(parser);
-  if (failed(arrayParser)) {
-    parser.emitError(parser.getCurrentLocation(),
-                     "failed to parse basis parameter '")
-        << basisName << "' which is to be a `::llvm::ArrayRef<int64_t>`";
-  }
-  basis = *arrayParser;
-  if (parser.parseRSquare()) {
-    return failure();
-  }
-  // Optionally parse a comma between the basis and mask.
-  if (parser.parseOptionalComma()) {
-    // If we were supposed to find a comma, fail parsing.
-    if (parseComma) {
-      return failure();
-    }
-    // If it was fine not to find a comma, set the mask. If the comma was
-    // missing this will fail to parse the closing angle bracket.
-    mask = SmallVector<bool>(basis.size(), true);
-    return success();
-  }
-  // There is a comma, meaning we either must find the mask, or we shouldn't
-  // have expected a comma.
-  if (failed(parser.parseOptionalKeyword(maskName))) {
-    if (!parseComma) {
-      return failure();
-    }
-    mask = SmallVector<bool>(basis.size(), true);
-    return success();
+    auto sizeVal =
+        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(dimSize));
+    auto strideVal = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getIndexAttr(dimStride));
+    vtids.push_back(rewriter.create<affine::AffineApplyOp>(
+        loc, threadTidMap, ValueRange{threadId, sizeVal, strideVal}));
   }
 
-  if (failed(parser.parseEqual()) || failed(parser.parseLSquare())) {
-    return failure();
-  }
-  auto maskParser = FieldParser<SmallVector<bool>>::parse(parser);
-  if (failed(maskParser)) {
-    parser.emitError(parser.getCurrentLocation(),
-                     "failed to parse mask parameter '")
-        << maskName << "' which is to be a `::llvm::ArrayRef<bool>`";
-  }
-  if (failed(parser.parseRSquare()) ||
-      (parseComma && failed(parser.parseComma()))) {
-    return failure();
-  }
-  mask = *maskParser;
-
-  return success();
-}
-
-static void printBasis(AsmPrinter &p, StringRef basisName, StringRef maskName,
-                       bool printComma, ArrayRef<int64_t> basis,
-                       ArrayRef<bool> mask) {
-  p << basisName;
-  // This is called without whitespace inserted by default for optionality.
-  // Insert it explicitly instead.
-  p << ' ';
-  p << '=';
-  p << ' ';
-  p << '[';
-  llvm::interleaveComma(basis, p);
-  p << ']';
-  if (llvm::any_of(mask, [](bool b) { return !b; })) {
-    p << ',' << ' ';
-    p << maskName << ' ';
-    p << '=';
-    p << ' ';
-    p << '[';
-    llvm::interleaveComma(mask, p);
-    p << ']';
-  }
-  if (printComma) {
-    p << ',' << ' ';
-  }
+  return vtids;
 }
 
 } // namespace mlir::iree_compiler::IREE::VectorExt

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_vector_ext/invalid.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_vector_ext/invalid.mlir
@@ -46,7 +46,7 @@ func.func @invalid_to_simt_vector_element_type(%simt : vector<64xf32>) -> vector
 
 // -----
 
-// expected-error @+1 {{number of active basis ids must be equal to the layout rank}}
+// expected-error @+1 {{all fields must have the same rank as the layout}}
 #layout = #iree_vector_ext.nested_layout<
   subgroups_per_workgroup = [1],
   batches_per_subgroup = [1],
@@ -54,7 +54,6 @@ func.func @invalid_to_simt_vector_element_type(%simt : vector<64xf32>) -> vector
   threads_per_outer = [1],
   elements_per_thread = [1],
 
-  subgroup_basis = [2],
-  subgroup_active_ids = [false],
-  thread_basis   = [2]
+  subgroup_strides = [0, 0],
+  thread_strides = [0]
 >

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_vector_ext/roundtrip.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_vector_ext/roundtrip.mlir
@@ -21,79 +21,26 @@ func.func @specify_layout(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
 
 // -----
 
-#nested_1 = #iree_vector_ext.nested_layout<
+#nested_0 = #iree_vector_ext.nested_layout<
   subgroups_per_workgroup = [1, 1],
   batches_per_subgroup = [2, 4],
   outers_per_batch = [4, 1],
   threads_per_outer = [4, 2],
   elements_per_thread = [1, 4],
 
-  subgroup_order = [0, 1],
-  thread_order = [0, 1],
-
-  subgroup_basis = [1, 1],
-  thread_basis   = [4, 2]
+  subgroup_strides = [0, 0],
+  thread_strides   = [1, 4]
 >
 
-#nested_2 = #iree_vector_ext.nested_layout<
+#nested_1 = #iree_vector_ext.nested_layout<
   subgroups_per_workgroup = [1, 1],
   batches_per_subgroup = [4, 2],
   outers_per_batch = [1, 4],
   threads_per_outer = [2, 4],
   elements_per_thread = [4, 1],
 
-  subgroup_order = [1, 0],
-  thread_order = [1, 0],
-
-  subgroup_basis = [1, 1],
-  thread_basis   = [2, 4]
->
-
-#nested_3 = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup = [4, 2],
-  outers_per_batch = [1, 4],
-  threads_per_outer = [2, 4],
-  elements_per_thread = [4, 1],
-
-  subgroup_order = [1, 0],
-  thread_order = [1, 0],
-
-  subgroup_basis = [2, 4, 8],
-  subgroup_active_ids = [true, true, false],
-  thread_basis   = [2, 4]
->
-
-#nested_4 = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup = [4, 2],
-  outers_per_batch = [1, 4],
-  threads_per_outer = [2, 4],
-  elements_per_thread = [4, 1],
-
-  subgroup_order = [1, 0],
-  thread_order = [1, 0],
-
-  subgroup_basis = [2, 4, 8],
-  subgroup_active_ids = [true, true, false],
-  thread_basis   = [2, 4, 2],
-  thread_active_ids = [false, true, true]
->
-
-#nested_5 = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup = [4, 2],
-  outers_per_batch = [1, 4],
-  threads_per_outer = [2, 4],
-  elements_per_thread = [4, 1],
-
-  subgroup_order = [1, 0],
-  thread_order = [1, 0],
-
-  subgroup_basis = [2, 4],
-  subgroup_active_ids = [true, true],
-  thread_basis   = [4, 2],
-  thread_active_ids = [true, true]
+  subgroup_strides = [0, 0],
+  thread_strides = [8, 2]
 >
 
 func.func @specify_nested(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
@@ -101,11 +48,8 @@ func.func @specify_nested(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
   %c0 = arith.constant 0 : index
   %result = vector.transfer_read %lhs[%c0, %c0], %cst_0 {
     in_bounds = [true, true],
-    layout0 = #nested_1,
-    layout1 = #nested_2,
-    layout2 = #nested_3,
-    layout3 = #nested_4,
-    layout4 = #nested_5
+    layout0 = #nested_0,
+    layout1 = #nested_1
   } : memref<32x32xf16>, vector<32x32xf16>
   return %result : vector<32x32xf16>
 }
@@ -116,8 +60,8 @@ func.func @specify_nested(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
 // CHECK-SAME: outers_per_batch = [4, 1],
 // CHECK-SAME: threads_per_outer = [4, 2],
 // CHECK-SAME: elements_per_thread = [1, 4],
-// CHECK-SAME: subgroup_basis = [1, 1],
-// CHECK-SAME: thread_basis = [4, 2]>
+// CHECK-SAME: subgroup_strides = [0, 0],
+// CHECK-SAME: thread_strides = [1, 4]>
 
 // CHECK: #[[LAYOUT1:.+]] = #iree_vector_ext.nested_layout<
 // CHECK-SAME: subgroups_per_workgroup = [1, 1],
@@ -125,54 +69,13 @@ func.func @specify_nested(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
 // CHECK-SAME: outers_per_batch = [1, 4],
 // CHECK-SAME: threads_per_outer = [2, 4],
 // CHECK-SAME: elements_per_thread = [4, 1],
-// CHECK-SAME: subgroup_order = [1, 0],
-// CHECK-SAME: thread_order = [1, 0],
-// CHECK-SAME: subgroup_basis = [1, 1],
-// CHECK-SAME: thread_basis = [2, 4]>
-
-// CHECK: #[[LAYOUT2:.+]] = #iree_vector_ext.nested_layout<
-// CHECK-SAME: subgroups_per_workgroup = [1, 1],
-// CHECK-SAME: batches_per_subgroup = [4, 2],
-// CHECK-SAME: outers_per_batch = [1, 4],
-// CHECK-SAME: threads_per_outer = [2, 4],
-// CHECK-SAME: elements_per_thread = [4, 1],
-// CHECK-SAME: subgroup_order = [1, 0],
-// CHECK-SAME: thread_order = [1, 0],
-// CHECK-SAME: subgroup_basis = [2, 4, 8],
-// CHECK-SAME: subgroup_active_ids = [true, true, false],
-// CHECK-SAME: thread_basis = [2, 4]>
-
-// CHECK: #[[LAYOUT3:.+]] = #iree_vector_ext.nested_layout<
-// CHECK-SAME: subgroups_per_workgroup = [1, 1],
-// CHECK-SAME: batches_per_subgroup = [4, 2],
-// CHECK-SAME: outers_per_batch = [1, 4],
-// CHECK-SAME: threads_per_outer = [2, 4],
-// CHECK-SAME: elements_per_thread = [4, 1],
-// CHECK-SAME: subgroup_order = [1, 0],
-// CHECK-SAME: thread_order = [1, 0],
-// CHECK-SAME: subgroup_basis = [2, 4, 8],
-// CHECK-SAME: subgroup_active_ids = [true, true, false],
-// CHECK-SAME: thread_basis = [2, 4, 2],
-// CHECK-SAME: thread_active_ids = [false, true, true]>
-
-// CHECK: #[[LAYOUT4:.+]] = #iree_vector_ext.nested_layout<
-// CHECK-SAME: subgroups_per_workgroup = [1, 1],
-// CHECK-SAME: batches_per_subgroup = [4, 2],
-// CHECK-SAME: outers_per_batch = [1, 4],
-// CHECK-SAME: threads_per_outer = [2, 4],
-// CHECK-SAME: elements_per_thread = [4, 1],
-// CHECK-SAME: subgroup_order = [1, 0],
-// CHECK-SAME: thread_order = [1, 0],
-// CHECK-SAME: subgroup_basis = [2, 4],
-// CHECK-SAME: thread_basis = [4, 2]>
+// CHECK-SAME: subgroup_strides = [0, 0],
+// CHECK-SAME: thread_strides = [8, 2]>
 
 // CHECK-LABEL: func.func @specify_nested
 // CHECK:      vector.transfer_read
 // CHECK-SAME:         layout0 = #[[LAYOUT0]]
 // CHECK-SAME:         layout1 = #[[LAYOUT1]]
-// CHECK-SAME:         layout2 = #[[LAYOUT2]]
-// CHECK-SAME:         layout3 = #[[LAYOUT3]]
-// CHECK-SAME:         layout4 = #[[LAYOUT4]]
 
 // -----
 


### PR DESCRIPTION
This patch makes the layout store how threads and subgroups are distributed as "strides" instead of basis.

Strides are just a mapping from `virtual tid --> tid` (where tid is thread id). The mapping is a dot product between `virtual tid` and `strides`:

```
tid = vtid * stride
```

If we put some restrictions on `strides` and make the mapping can be made invertible with the inverse mapping:

```
vtid_i = tid floordiv stride_i mod size_i
```

The advantage with strides is that strides are only dependent on the dimension they are working on, while basis actually depend on the order of dimension because to get the distribution for dimension `i`, you need to know the distribution for dimensions `i-1`. (If you think about it, this is just skewing to remove dependency of`i` on `i-1`).

With strides, dimensions are essentially independent, and we do not need any orders in the layout, which hugely simplifies the layout. This is much closer to what CuTe layouts do (somewhat).

Along with this change, distribution now actually uses 2 new ops to query the `tid -> virtual tid` map, which makes distribution independent of these changes.

The reason for implementing this was that with strides, the layouts actually have a canonical form, unlike with basis, because different active ids, order, basis permutations can represent the same layout. Having a canonical form helps a lot when try to match two different matmul anchors.