### PR TITLE
Log compile and run commands on successful model tests too.

### DIFF
--- a/.github/workflows/pkgci_regression_test_amdgpu_rocm.yml
+++ b/.github/workflows/pkgci_regression_test_amdgpu_rocm.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:
           repository: nod-ai/SHARK-TestSuite
-          ref: 337083616ae6f596c0206a9edd1c47e8afc0e400
+          ref: c9b3337e1f754c83d178568be1339aaef5f08045
           path: SHARK-TestSuite
           submodules: false
       - name: Installing external TestSuite Python requirements
@@ -125,7 +125,7 @@ jobs:
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:
           repository: nod-ai/SHARK-TestSuite
-          ref: 337083616ae6f596c0206a9edd1c47e8afc0e400
+          ref: c9b3337e1f754c83d178568be1339aaef5f08045
           path: SHARK-TestSuite
           submodules: false
           lfs: true
@@ -144,6 +144,7 @@ jobs:
             -rpfE \
             -k real_weights \
             --no-skip-tests-missing-files \
+            --log-cli-level=info \
             --capture=no \
             --timeout=1200 \
             --retries 2 \
@@ -158,6 +159,7 @@ jobs:
             -k real_weights \
             --no-skip-tests-missing-files \
             --capture=no \
+            --log-cli-level=info \
             --timeout=1200 \
             --retries 2 \
             --retry-delay 5 \
@@ -170,6 +172,7 @@ jobs:
             -rpfE \
             -k real_weights \
             --no-skip-tests-missing-files \
+            --log-cli-level=info \
             --capture=no \
             --timeout=1200 \
             --retries 2 \

--- a/.github/workflows/pkgci_regression_test_amdgpu_vulkan.yml
+++ b/.github/workflows/pkgci_regression_test_amdgpu_vulkan.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:
           repository: nod-ai/SHARK-TestSuite
-          ref: 337083616ae6f596c0206a9edd1c47e8afc0e400
+          ref: c9b3337e1f754c83d178568be1339aaef5f08045
           path: SHARK-TestSuite
           submodules: false
       - name: Installing external TestSuite Python requirements
@@ -107,7 +107,7 @@ jobs:
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:
           repository: nod-ai/SHARK-TestSuite
-          ref: 337083616ae6f596c0206a9edd1c47e8afc0e400
+          ref: c9b3337e1f754c83d178568be1339aaef5f08045
           path: SHARK-TestSuite
           submodules: false
           lfs: true
@@ -124,6 +124,7 @@ jobs:
           source ${VENV_DIR}/bin/activate
           pytest SHARK-TestSuite/iree_tests/pytorch/models -k real_weights \
                -rpfxE --timeout=600 --durations=0 \
+              --log-cli-level=info \
               --config-files=build_tools/pkgci/external_test_suite/pytorch_models_gpu_vulkan.json \
               --no-skip-tests-missing-files \
               --report-log=/tmp/iree_tests_pytorch_models_gpu_vulkan_logs.json

--- a/.github/workflows/pkgci_regression_test_cpu.yml
+++ b/.github/workflows/pkgci_regression_test_cpu.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:
           repository: nod-ai/SHARK-TestSuite
-          ref: 337083616ae6f596c0206a9edd1c47e8afc0e400
+          ref: c9b3337e1f754c83d178568be1339aaef5f08045
           path: SHARK-TestSuite
           submodules: false
           lfs: true
@@ -121,7 +121,7 @@ jobs:
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:
           repository: nod-ai/SHARK-TestSuite
-          ref: 337083616ae6f596c0206a9edd1c47e8afc0e400
+          ref: c9b3337e1f754c83d178568be1339aaef5f08045
           path: SHARK-TestSuite
           submodules: false
           lfs: true
@@ -137,11 +137,11 @@ jobs:
         run: |
           source ${VENV_DIR}/bin/activate
           pytest SHARK-TestSuite/iree_tests/pytorch/models \
-            -n 4 \
             -rpfE \
             -k real_weights \
             --no-skip-tests-missing-files \
             --capture=no \
+            --log-cli-level=info \
             --timeout=1200 \
             --retries 2 \
             --retry-delay 5 \
@@ -155,6 +155,7 @@ jobs:
             -k real_weights \
             --no-skip-tests-missing-files \
             --capture=no \
+            --log-cli-level=info \
             --timeout=1200 \
             --retries 2 \
             --retry-delay 5 \

--- a/.github/workflows/pkgci_regression_test_nvidiagpu_cuda.yml
+++ b/.github/workflows/pkgci_regression_test_nvidiagpu_cuda.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:
           repository: nod-ai/SHARK-TestSuite
-          ref: 337083616ae6f596c0206a9edd1c47e8afc0e400
+          ref: c9b3337e1f754c83d178568be1339aaef5f08045
           path: SHARK-TestSuite
           submodules: false
       - name: Installing external TestSuite Python requirements

--- a/.github/workflows/pkgci_regression_test_nvidiagpu_vulkan.yml
+++ b/.github/workflows/pkgci_regression_test_nvidiagpu_vulkan.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:
           repository: nod-ai/SHARK-TestSuite
-          ref: 337083616ae6f596c0206a9edd1c47e8afc0e400
+          ref: c9b3337e1f754c83d178568be1339aaef5f08045
           path: SHARK-TestSuite
           submodules: false
       - name: Installing external TestSuite Python requirements


### PR DESCRIPTION
This pulls in my change at https://github.com/nod-ai/SHARK-TestSuite/pull/227 to add more logging to these test jobs. Now when a test runs and `--log-cli-level=info` is set, it will log the compile and run commands as they are launched. Previously these were only logged on test failure.

Sample logs: https://github.com/iree-org/iree/actions/runs/8973823928/job/24645200447?pr=17290#step:11:40

```
============================= test session starts ==============================
platform linux -- Python 3.11.9, pytest-8.2.0, pluggy-1.5.0
rootdir: /mnt/share/amdsharks/actions-runner-iree/_work/iree/iree
plugins: xdist-3.6.1, timeout-2.3.1, retry-1.6.2, reportlog-0.4.0
timeout: 1200.0s
timeout method: signal
timeout func_only: False
collected 2 items / 1 deselected / 1 selected

SHARK-TestSuite/iree_tests/pytorch/models/sdxl-scheduled-unet-3-tank/model.mlirbc::gpu_rocm_real_weights 
-------------------------------- live log call ---------------------------------
INFO     root:conftest.py:393 Launching compile command:
cd /mnt/share/amdsharks/actions-runner-iree/_work/iree/iree/SHARK-TestSuite/iree_tests/pytorch/models/sdxl-scheduled-unet-3-tank && iree-compile model.mlirbc --iree-hal-target-backends=rocm --iree-rocm-target-chip=gfx90a --iree-opt-const-eval=false --iree-codegen-transform-dialect-library=/mnt/share/amdsharks/actions-runner-iree/_work/iree/iree/build_tools/pkgci/external_test_suite/attention_and_matmul_spec.mlir --iree-global-opt-propagate-transposes=true --iree-global-opt-enable-fuse-horizontal-contractions=true --iree-flow-enable-aggressive-fusion=true --iree-opt-aggressively-propagate-transposes=true --iree-opt-outer-dim-concat=true --iree-vm-target-truncate-unsupported-floats --iree-llvmgpu-enable-prefetch=true --iree-opt-data-tiling=false --iree-codegen-gpu-native-math-precision=true --iree-codegen-llvmgpu-use-vector-distribution "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline, util.func(iree-preprocessing-pad-to-intrinsics))" -o model_gpu_rocm_real_weights.vmfb
INFO     root:conftest.py:407 Launching run command:
cd /mnt/share/amdsharks/actions-runner-iree/_work/iree/iree/SHARK-TestSuite/iree_tests/pytorch/models/sdxl-scheduled-unet-3-tank && iree-run-module --module=model_gpu_rocm_real_weights.vmfb --device=hip --parameters=model=real_weights.irpa --module=sdxl_scheduled_unet_pipeline_fp16_rocm.vmfb --input=1x4x1[28](https://github.com/iree-org/iree/actions/runs/8973823928/job/24645200447?pr=17290#step:11:29)x128xf16=@inference_input.0.bin --input=2x64x2048xf16=@inference_input.1.bin --input=2x1280xf16=@inference_input.2.bin --input=1xf16=@inference_input.3.bin --expected_output=1x4x128x128xf16=@inference_output.0.bin --expected_f16_threshold=0.8f --flagfile=real_weights_data_flags.txt
PASSED

============================== slowest durations ===============================
[34](https://github.com/iree-org/iree/actions/runs/8973823928/job/24645200447?pr=17290#step:11:35).50s call     SHARK-TestSuite/iree_tests/pytorch/models/sdxl-scheduled-unet-3-tank/model.mlirbc::gpu_rocm_real_weights

(2 durations < 0.005s hidden.  Use -vv to show these durations.)
=========================== short test summary info ============================
PASSED SHARK-TestSuite/iree_tests/pytorch/models/sdxl-scheduled-unet-3-tank/model.mlirbc::gpu_rocm_real_weights
======================= 1 passed, 1 deselected in 34.54s =======================
```