### PR TITLE
[LLVMGPU] Turn on the vector distribution pipeline by default

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -43,7 +43,7 @@ namespace mlir::iree_compiler {
 llvm::cl::opt<bool> clGPUEnableVectorDistribution(
     "iree-codegen-llvmgpu-use-vector-distribution",
     llvm::cl::desc("enable the usage of the vector distribution pipeline"),
-    llvm::cl::init(false));
+    llvm::cl::init(true));
 
 llvm::cl::opt<bool> clGPUEnableTransformDialectJit(
     "iree-codegen-llvmgpu-enable-transform-dialect-jit",


### PR DESCRIPTION
All known outstanding compilation failures with this pipeline have been resolved, so now is a good time to turn it on by default to start getting the predictable good performance for AMD gpu's w/ mma intrinsics like CDNA and RDNA cards.