### PR TITLE
Operands with periodically repeating rows/columns for faster testing

### DIFF
--- a/tools/testing/e2e/iree-e2e-matmul-test.cc
+++ b/tools/testing/e2e/iree-e2e-matmul-test.cc
@@ -820,7 +820,7 @@ class MatmulTestModuleState final {
     return std::move(result_view);
   }
 
-  Status CheckMatmulResults(
+  Status CheckCyclicalMatmulResults(
       const vm::ref<iree_hal_device_t> device, int64_t m, int64_t k, int64_t n,
       int64_t m_repeat_period, int64_t n_repeat_period, int32_t transpose_rhs,
       const vm::ref<iree_hal_buffer_view_t> lhs,
@@ -838,6 +838,21 @@ class MatmulTestModuleState final {
     return status;
   }
 
+  Status CheckMatmulResults(
+      const vm::ref<iree_hal_device_t> device, int64_t m, int64_t k, int64_t n,
+      int32_t transpose_rhs, const vm::ref<iree_hal_buffer_view_t> lhs,
+      const vm::ref<iree_hal_buffer_view_t> rhs,
+      const vm::ref<iree_hal_buffer_view_t> acc,
+      const vm::ref<iree_hal_buffer_view_t> actual_result,
+      const vm::ref<iree_hal_buffer_view_t> expected_result) {
+    // A repeat period of 0 denotes no repeat.
+    int64_t m_repeat_period = 0;
+    int64_t n_repeat_period = 0;
+    return CheckCyclicalMatmulResults(device, m, k, n, m_repeat_period,
+                                      n_repeat_period, transpose_rhs, lhs, rhs,
+                                      acc, actual_result);
+  }
+
  private:
   iree_allocator_t host_allocator_;
 };
@@ -849,6 +864,9 @@ static const vm::NativeFunction<MatmulTestModuleState>
         vm::MakeNativeFunction(
             "generate_random_cyclical_matrix",
             &MatmulTestModuleState::GenerateRandomCyclicalMatrix),
+        vm::MakeNativeFunction(
+            "check_cyclical_matmul_results",
+            &MatmulTestModuleState::CheckCyclicalMatmulResults),
         vm::MakeNativeFunction("check_matmul_results",
                                &MatmulTestModuleState::CheckMatmulResults),
 };


### PR DESCRIPTION
iree-amd-aie would like to run large matmul tests in CI. To make this feasible (not too slow), the calculation of the correct values on CPU needs to be significantly faster. I have tried improving the algorithm implemented in IREE (M-, N-, K- tiling) but the speedups are not significant enough. This PR takes a different approach: it makes the baseline calculation faster by forcing the matrices being multiplied to have a specific structure which can be taken advantage of. Specifically, LHS (RHS) has periodically repeating (rows) columns.

iree-amd-aie uses 
https://github.com/iree-org/iree/blob/main/tools/testing/e2e/iree-e2e-matmul-test.cc but does not use 
https://github.com/iree-org/iree/blame/main/tests/e2e/matmul/generate_e2e_matmul_tests.py -- it has it's own version of this file  
https://github.com/nod-ai/iree-amd-aie/blob/main/tests/matmul/generate_e2e_matmul_tests.py which is modified is this PR:
https://github.com/nod-ai/iree-amd-aie/pull/321

Currently this IREE PR does not have testing (I will add) but the corresponding iree-amd-aie PR above shows how this IREE PR works end-to-end. 