### PR TITLE
Tool to analyze singular values of matrices during execution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1034,6 +1034,11 @@ if(IREE_BUILD_EXPERIMENTAL_HAL_EXECUTABLE_LIBRARY_CALL_HOOKS)
   add_subdirectory(experimental/hal_executable_library_call_hooks)
 endif()
 
+find_package(Eigen3)
+if (EIGEN3_FOUND)
+  add_subdirectory(experimental/svd_analysis)
+endif()
+
 set(IREE_PUBLIC_INCLUDE_DIRS "${IREE_COMMON_INCLUDE_DIRS}"
     CACHE INTERNAL "IREE: Include Directories" FORCE)
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -68,14 +68,14 @@ static llvm::cl::opt<int> clNarrowMatmulTileBytes(
         "traverse their wide matrix operand once, there is no reuse here and "
         "this doesn't have to be sized to fit in some CPU cache. This is more "
         "about distributing work to threads."),
-    llvm::cl::init(64 * 1024));
+    llvm::cl::init(1024 * 1024 * 1024));
 
 static llvm::cl::opt<int> clGeneralMatmulTileBytes(
     "iree-llvmcpu-general-matmul-tile-bytes",
     llvm::cl::desc("target distribution tile size for matrix operands of "
                    "general matmuls, expressed in bytes. Currently only used "
                    "in data-tiled matmuls (mmt4d)."),
-    llvm::cl::init(64 * 1024));
+    llvm::cl::init(1024 * 1024 * 1024));
 
 static llvm::cl::opt<bool> clDisableVectorPeeling(
     "iree-llvmcpu-disable-vector-peeling",
@@ -1547,7 +1547,7 @@ static TileSizesListType getMmt4dTileSizes(linalg::LinalgOp op) {
                                               distTileSizes.end());
   SmallVector<int64_t> cacheReductionTileSizes(numLoops, 0);
 
-  SmallVector<int64_t> vecTileSizes(numLoops, 1);
+  SmallVector<int64_t> vecTileSizes(numLoops, 0);
   assert(vecTileSizes.size() == mmt4dDimBase + 6);
   vecTileSizes[mmt4dDimBase + 3] = M0;
   vecTileSizes[mmt4dDimBase + 4] = N0;

--- a/experimental/svd_analysis/CMakeLists.txt
+++ b/experimental/svd_analysis/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+iree_cc_library(
+  NAME
+    svd_analysis
+  SHARED
+  SRCS
+    svd_analysis.c
+    svd_analysis_impl.cc
+  DEPS
+    iree::base::core_headers
+    iree::builtins::ukernel::internal_headers
+  INCLUDES
+    "${EIGEN3_INCLUDE_DIR}"
+  COPTS
+    "-fno-fast-math"
+    "-march=native"
+    "-Wno-unused-variable"
+)

--- a/experimental/svd_analysis/svd_analysis.c
+++ b/experimental/svd_analysis/svd_analysis.c
@@ -1,0 +1,146 @@
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "experimental/svd_analysis/svd_analysis_impl.h"
+#include "iree/base/internal/math.h"
+#include "iree/builtins/ukernel/mmt4d.h"
+#include "iree/builtins/ukernel/mmt4d_internal.h"
+#include "iree/hal/local/executable_library.h"
+
+static float* allocate_and_convert_tiled_to_rowmajor_matrix_f32(
+    iree_uk_type_t elem_type, const char* src_buffer, int offset, int stride,
+    int rows1, int cols1, int rows0, int cols0) {
+  int elem_size = iree_uk_type_size(elem_type);
+  const char* src_data = src_buffer + elem_size * offset;
+  int64_t dst_f32_data_size = 4 * rows1 * cols1 * rows0 * cols0;
+  float* dst_f32_data = malloc(dst_f32_data_size);
+  for (int64_t r1 = 0; r1 < rows1; ++r1) {
+    for (int64_t c1 = 0; c1 < cols1; ++c1) {
+      for (int64_t r0 = 0; r0 < rows0; ++r0) {
+        for (int64_t c0 = 0; c0 < cols0; ++c0) {
+          int64_t src_index = c0 + cols0 * (r0 + rows0 * c1) + stride * r1;
+          float val = 0.f;
+          switch (elem_type) {
+            case IREE_UK_TYPE_FLOAT_32:
+              val = ((const float*)src_data)[src_index];
+              break;
+            case IREE_UK_TYPE_FLOAT_16:
+              val =
+                  iree_math_f16_to_f32(((const uint16_t*)src_data)[src_index]);
+              break;
+            case IREE_UK_TYPE_BFLOAT_16:
+              val =
+                  iree_math_bf16_to_f32(((const uint16_t*)src_data)[src_index]);
+              break;
+            case IREE_UK_TYPE_SINT_32:
+            case IREE_UK_TYPE_INT_32:
+              val = ((const int32_t*)src_data)[src_index];
+              break;
+            case IREE_UK_TYPE_UINT_32:
+              val = ((const uint32_t*)src_data)[src_index];
+              break;
+            case IREE_UK_TYPE_SINT_16:
+            case IREE_UK_TYPE_INT_16:
+              val = ((const int16_t*)src_data)[src_index];
+              break;
+            case IREE_UK_TYPE_UINT_16:
+              val = ((const uint16_t*)src_data)[src_index];
+              break;
+            case IREE_UK_TYPE_SINT_8:
+            case IREE_UK_TYPE_INT_8:
+              val = ((const int8_t*)src_data)[src_index];
+              break;
+            case IREE_UK_TYPE_UINT_8:
+              val = ((const uint8_t*)src_data)[src_index];
+              break;
+            case IREE_UK_TYPE_UINT_4:
+              val = (((const uint8_t*)src_data)[src_index / 2] >>
+                     ((src_index & 1) * 4)) &
+                    0xf;
+              break;
+            default:
+              assert(false && "unhandled element type");
+              break;
+          }
+          int64_t dst_row = r1 * rows0 + r0;
+          int64_t dst_col = c1 * cols0 + c0;
+          int64_t dst_index = dst_row * cols1 * cols0 + dst_col;
+          dst_f32_data[dst_index] = val;
+        }
+      }
+    }
+  }
+  return dst_f32_data;
+}
+
+const char* iree_uk_type_category_str(iree_uk_type_t t) {
+  switch (iree_uk_type_category(t)) {
+    case IREE_UK_TYPE_CATEGORY_FLOAT_IEEE:
+      return "f";
+    case IREE_UK_TYPE_CATEGORY_FLOAT_BRAIN:
+      return "bf";
+    case IREE_UK_TYPE_CATEGORY_INTEGER_SIGNLESS:
+      return "i";
+    case IREE_UK_TYPE_CATEGORY_INTEGER_SIGNED:
+      return "si";
+    case IREE_UK_TYPE_CATEGORY_INTEGER_UNSIGNED:
+      return "ui";
+    default:
+      assert(false && "unknown type");
+      return "?";
+  }
+}
+
+static void svd_analysis_for_tiled_matrix(FILE* file, const char* name,
+                                          iree_uk_type_t elem_type,
+                                          const char* src_buffer, int offset,
+                                          int stride, int rows1, int cols1,
+                                          int rows0, int cols0) {
+  float* f32_data = allocate_and_convert_tiled_to_rowmajor_matrix_f32(
+      elem_type, src_buffer, offset, stride, rows1, cols1, rows0, cols0);
+  fprintf(file, "      %s: %dx%dx%dx%dx%s%d\n", name, rows1, cols1, rows0,
+          cols0, iree_uk_type_category_str(elem_type),
+          iree_uk_type_bit_count(elem_type));
+  svd_analysis_for_matrix_f32(file, f32_data, rows1 * rows0, cols1 * cols0);
+  free(f32_data);
+}
+
+#ifdef __GNUC__
+#define IREE_HOOK_EXPORT __attribute__((visibility("default")))
+#else
+#define IREE_HOOK_EXPORT
+#endif
+
+const char* global_current_library_export_name = "";
+
+IREE_HOOK_EXPORT void iree_uk_mmt4d_svd_analysis(
+    const iree_uk_mmt4d_params_t* params) {
+  iree_uk_mmt4d_type_t mmt4d_type = iree_uk_mmt4d_type(params->flags);
+  iree_uk_type_t lhs_elem_type = iree_uk_mmt4d_lhs_type(mmt4d_type);
+  iree_uk_type_t rhs_elem_type = iree_uk_mmt4d_rhs_type(mmt4d_type);
+  printf("  CALL: %s\n", global_current_library_export_name);
+  printf("    OP: mmt4d\n");
+  svd_analysis_for_tiled_matrix(
+      stdout, "LHS", lhs_elem_type, params->lhs_buffer, params->lhs_offset,
+      params->lhs_stride0, params->M, params->K, params->M0, params->K0);
+  svd_analysis_for_tiled_matrix(
+      stdout, "RHS", rhs_elem_type, params->rhs_buffer, params->rhs_offset,
+      params->rhs_stride0, params->N, params->K, params->N0, params->K0);
+}
+
+#ifdef IREE_HAL_EXECUTABLE_LIBRARY_CALL_HOOK
+IREE_HOOK_EXPORT void iree_hal_executable_library_call_hook_begin(
+    iree_string_view_t executable_identifier,
+    const iree_hal_executable_library_v0_t* library, iree_host_size_t ordinal) {
+  global_current_library_export_name = library->exports.names[ordinal];
+}
+IREE_HOOK_EXPORT void iree_hal_executable_library_call_hook_end(
+    iree_string_view_t executable_identifier,
+    const iree_hal_executable_library_v0_t* library, iree_host_size_t ordinal) {
+  global_current_library_export_name = "";
+}
+#else
+#error Need `cmake -DCMAKE_C_FLAGS=-DIREE_HAL_EXECUTABLE_LIBRARY_CALL_HOOK .`
+#endif

--- a/experimental/svd_analysis/svd_analysis_impl.cc
+++ b/experimental/svd_analysis/svd_analysis_impl.cc
@@ -1,0 +1,51 @@
+#include "experimental/svd_analysis/svd_analysis_impl.h"
+
+#include <Eigen/Core>
+#include <Eigen/SVD>
+#include <cmath>
+
+extern "C" void svd_analysis_for_matrix_f32(FILE* file, const float* data,
+                                            int rows, int cols) {
+  using RowMajorMatrix =
+      Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+  Eigen::VectorXf singularValues = RowMajorMatrix::Map(data, rows, cols)
+                                       .bdcSvd()
+                                       .singularValues()
+                                       .cwiseMax(0.f);
+  int size = singularValues.size();
+  Eigen::VectorXf normalizedSingularValues;
+  if (singularValues.maxCoeff() == 0.f) {
+    normalizedSingularValues = Eigen::VectorXf::Zero(size);
+  } else {
+    normalizedSingularValues = singularValues / singularValues.maxCoeff();
+  }
+  std::vector<float> magnitude_boundaries = {1.f,   3e-1f, 1e-1f, 3e-2f, 1e-2f,
+                                             3e-3f, 1e-3f, 3e-4f, 1e-4f, 3e-5f,
+                                             1e-5f, 3e-6f, 1e-6f, 0.f};
+  for (int b = 0; b < magnitude_boundaries.size() - 1; ++b) {
+    int count = 0;
+    for (int i = 0; i < size; ++i) {
+      if (normalizedSingularValues[i] <= magnitude_boundaries[b] &&
+          normalizedSingularValues[i] > magnitude_boundaries[b + 1]) {
+        ++count;
+      }
+    }
+    if (count) {
+      fprintf(file,
+              "       %6.1f%% of normalized singular values are <= %6.2g and > "
+              "%6.2g\n",
+              100.f * count / size, magnitude_boundaries[b],
+              magnitude_boundaries[b + 1]);
+    }
+  }
+  int count = 0;
+  for (int i = 0; i < size; ++i) {
+    if (normalizedSingularValues[i] == 0.f) {
+      ++count;
+    }
+  }
+  if (count) {
+    fprintf(file, "       %6.1f%% of normalized singular values are == 0.\n",
+            100.f * count / size);
+  }
+}

--- a/experimental/svd_analysis/svd_analysis_impl.h
+++ b/experimental/svd_analysis/svd_analysis_impl.h
@@ -1,0 +1,17 @@
+#ifndef SVD_ANALYSIS_IMPL_H_
+#define SVD_ANALYSIS_IMPL_H_
+
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void svd_analysis_for_matrix_f32(FILE* file, const float* data, int rows,
+                                 int cols);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // SVD_ANALYSIS_IMPL_H_

--- a/runtime/src/iree/builtins/ukernel/mmt4d.c
+++ b/runtime/src/iree/builtins/ukernel/mmt4d.c
@@ -112,6 +112,8 @@ static bool iree_uk_mmt4d_early(const iree_uk_mmt4d_params_t* params) {
   return false;
 }
 
+extern void iree_uk_mmt4d_svd_analysis(const iree_uk_mmt4d_params_t* params);
+
 void iree_uk_mmt4d_p(const iree_uk_mmt4d_params_t* params) {
   iree_uk_mmt4d_validate(params);
 
@@ -119,6 +121,10 @@ void iree_uk_mmt4d_p(const iree_uk_mmt4d_params_t* params) {
   // Typical cases include trivial cases (e.g. when params->K == 0) and hardware
   // targets that want to handle the entire loop nest in target-specific code.
   if (iree_uk_mmt4d_early(params)) return;
+
+#ifdef IREE_DEVICE_STANDALONE
+  iree_uk_mmt4d_svd_analysis(params);
+#endif
 
   // Select a target-specific tile_func (inner loop on K, computing one M0xN0
   // tile) and use that with generic outer loops.


### PR DESCRIPTION
Super drafty and not intended for review.

1. Apply this PR.
2. Install Eigen3 in a way that cmake (standard FindEigen3.cmake) will find.
3. `cmake -DCMAKE_C_FLAGS=-DIREE_HAL_EXECUTABLE_LIBRARY_CALL_HOOK .`
    * Needed for a hook that records the name of the current dispatch function.
4. `ninja` (need to rebuild compiler, tools, and the experimental .so here).
5. Compile your MLIR program with your usual `iree-compile` command line plus this extra flag:
    * `--iree-llvmcpu-link-embedded=false`. This is needed so that unresolved symbols are not a linking error at that point, so your module can be linked with the SVD analysis hooks later at runtime.
6. Run your MLIR program as usual with these additional things:
    * Environment variable (assuming current working dir is IREE build dir):
        * `LD_PRELOAD=$PWD/experimental/svd_analysis/libiree_experimental_svd_analysis_svd_analysis.so`
    * Flags: force single-threaded execution, the tool is not ready for multi-threaded. Pass either `--task_topology_max_group_count=1`or `--device=local-sync`.

Example: to run on BERT-Large:

Get the artifacts (See https://github.com/iree-org/iree/discussions/16246).

Compile:
```
tools/iree-compile \
  --iree-hal-target-backends=llvm-cpu \
  --iree-llvmcpu-link-embedded=false \
  --iree-llvmcpu-target-cpu=znver4 \
  --iree-llvmcpu-enable-ukernels=mmt4d \
  ~/testing/bert_large_batch1.mlirbc -o /tmp/bert_large_batch1.vmfb
```

Run:
```
LD_PRELOAD=$PWD/experimental/svd_analysis/libiree_experimental_svd_analysis_svd_analysis.so \
tools/iree-run-module \
  --module=/tmp/bert_large_batch1.vmfb \
  --function=forward \
  "--input=1x384xi64=[[`seq 1 384`]]" \
  "--input=1x384xi64=[[`seq 11 394`]]" \
  --device=local-sync
```

Resulting log:
https://gist.github.com/bjacob/34fd85f2723233281826b9a2ccad8763

Example log entry for a dispatch:

```
  CALL: forward_dispatch_5_mmt4d_24x64x1024x16x16x1_f32
    OP: mmt4d
      LHS: 8x1024x16x1xf32
         25.8% of normalized singular values are <=      1 and >    0.3
          3.1% of normalized singular values are <=    0.3 and >    0.1
          1.6% of normalized singular values are <=    0.1 and >   0.03
          1.6% of normalized singular values are <=  0.003 and >  0.001
          0.8% of normalized singular values are <=  0.001 and > 0.0003
          0.8% of normalized singular values are <= 0.0003 and > 0.0001
          1.6% of normalized singular values are <=  1e-06 and >      0
         64.8% of normalized singular values are == 0.
      RHS: 32x1024x16x1xf32
         18.0% of normalized singular values are <=      1 and >    0.3
         60.2% of normalized singular values are <=    0.3 and >    0.1
         21.9% of normalized singular values are <=    0.1 and >   0.03
```

Note: here we call "normalized singular values" the singular values divided by the largest singular value. So, the largest normalized singular value is always 1 by construction, and the others decrease from there to zero. The question is how fast.

In this dispatch function `forward_dispatch_5_mmt4d_24x64x1024x16x16x1_f32`, we have a `mmt4d` op, and we can see that two thirds of its LHS's singular values are zero, meaning that this LHS matrix's rank is only about a third of the generic case of a matrix of this shape, which suggests that if the computation were expressed in a more favorable basis, this LHS matrix could become up to 3x smaller. On the other hand, the RHS matrix does not exhibit any such opportunity, with singular values that are not that small, it really is a full-rank matrix.