### PR TITLE
[Preprocessing] Remove global transpose matmul option

### DIFF
--- a/compiler/src/iree/compiler/Pipelines/Options.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Options.cpp
@@ -91,18 +91,6 @@ void PreprocessingOptions::bindOptions(OptionsBinder &binder) {
       llvm::cl::desc(
           "File name of a transform dialect spec to use for preprocessing."),
       llvm::cl::cat(category));
-
-  // DEPRECATED: do not add explicit options for specific passes.
-  binder.opt<TransposeMatmulInput>(
-      "iree-preprocessing-transpose-matmul", preprocessingTransposeMatmulInput,
-      llvm::cl::desc("Convert Linalg matmul ops to transposed variants."),
-      llvm::cl::cat(category),
-      llvm::cl::values(clEnumValN(TransposeMatmulInput::Lhs, "lhs",
-                                  "Transpose LHS input matrix."),
-                       clEnumValN(TransposeMatmulInput::Rhs, "rhs",
-                                  "Transpose RHS input matrix."),
-                       clEnumValN(TransposeMatmulInput::None, "none",
-                                  "Transpose neither input (disable).")));
 }
 
 void GlobalOptimizationOptions::bindOptions(OptionsBinder &binder) {

--- a/compiler/src/iree/compiler/Pipelines/Options.h
+++ b/compiler/src/iree/compiler/Pipelines/Options.h
@@ -68,19 +68,6 @@ struct PreprocessingOptions {
   std::string preprocessingTransformSpecFilename;
   std::string preprocessingPDLSpecFilename;
 
-  // DEPRECATED: do not put pass-specific options here and instead use the
-  // pass pipeline.
-  enum class TransposeMatmulInput {
-    /// Transpose LHS input matrix.
-    Lhs,
-    /// Transpose RHS input matrix.
-    Rhs,
-    /// Transpose neither input (disable).
-    None
-  };
-  TransposeMatmulInput preprocessingTransposeMatmulInput =
-      TransposeMatmulInput::None;
-
   void bindOptions(OptionsBinder &binder);
   using FromFlags = OptionsFromFlags<PreprocessingOptions>;
 };

--- a/compiler/src/iree/compiler/Preprocessing/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Preprocessing/Common/BUILD.bazel
@@ -55,7 +55,6 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
         "//compiler/src/iree/compiler/Dialect/Stream/IR",
         "//compiler/src/iree/compiler/Dialect/Util/IR",
-        "//compiler/src/iree/compiler/Pipelines:Options",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:ArithDialect",

--- a/compiler/src/iree/compiler/Preprocessing/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Preprocessing/Common/CMakeLists.txt
@@ -66,7 +66,6 @@ iree_cc_library(
     iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::Stream::IR
     iree::compiler::Dialect::Util::IR
-    iree::compiler::Pipelines::Options
   PUBLIC
 )
 

--- a/compiler/src/iree/compiler/Preprocessing/Common/Passes.h
+++ b/compiler/src/iree/compiler/Preprocessing/Common/Passes.h
@@ -9,7 +9,6 @@
 
 #include <functional>
 
-#include "iree/compiler/Pipelines/Options.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
@@ -24,6 +23,15 @@ enum class PadTargetType {
   ContractionOp = 1,
   // All ops (both convolution and contraction ops).
   All = 2,
+};
+
+enum class TransposeMatmulInput {
+  /// Transpose LHS input matrix.
+  Lhs,
+  /// Transpose RHS input matrix.
+  Rhs,
+  /// Transpose neither input (disable).
+  None
 };
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Preprocessing/Common/Passes.td
+++ b/compiler/src/iree/compiler/Preprocessing/Common/Passes.td
@@ -116,15 +116,15 @@ def PadLinalgOpsPass :
 def TransposeMatmulPass : Pass<"iree-preprocessing-transpose-matmul-pass"> {
   let summary = "Convert Linalg matmul ops to transposed variants";
   let options = [
-    Option<"input", "input", "PreprocessingOptions::TransposeMatmulInput",
-           /*default=*/"PreprocessingOptions::TransposeMatmulInput::None",
+    Option<"input", "input", "Preprocessing::TransposeMatmulInput",
+           /*default=*/"Preprocessing::TransposeMatmulInput::None",
            "Input to transpose, one of: 'none' (default), 'lhs', 'rhs'",
            [{llvm::cl::values(
-              clEnumValN(PreprocessingOptions::TransposeMatmulInput::Lhs, "lhs",
+              clEnumValN(Preprocessing::TransposeMatmulInput::Lhs, "lhs",
                          "Transpose LHS input matrix."),
-              clEnumValN(PreprocessingOptions::TransposeMatmulInput::Rhs, "rhs",
+              clEnumValN(Preprocessing::TransposeMatmulInput::Rhs, "rhs",
                          "Transpose RHS input matrix."),
-              clEnumValN(PreprocessingOptions::TransposeMatmulInput::None, "none",
+              clEnumValN(Preprocessing::TransposeMatmulInput::None, "none",
                          "Transpose neither input (disable)."))
            }]>
   ];

--- a/compiler/src/iree/compiler/Preprocessing/Common/TransposeMatmul.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/TransposeMatmul.cpp
@@ -4,7 +4,6 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "iree/compiler/Pipelines/Options.h"
 #include "iree/compiler/Preprocessing/Common/Passes.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
@@ -22,11 +21,10 @@ struct TransposeMatmulPass
       TransposeMatmulPass>::TransposeMatmulPassBase;
 
   void runOnOperation() override {
-    if (input == PreprocessingOptions::TransposeMatmulInput::None)
+    if (input == Preprocessing::TransposeMatmulInput::None)
       return;
 
-    bool transposeLHS =
-        input == PreprocessingOptions::TransposeMatmulInput::Lhs;
+    bool transposeLHS = input == Preprocessing::TransposeMatmulInput::Lhs;
 
     RewritePatternSet patterns(&getContext());
     linalg::populateTransposeMatmulPatterns(patterns, transposeLHS);

--- a/compiler/src/iree/compiler/Preprocessing/Passes.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Passes.cpp
@@ -93,16 +93,6 @@ void buildPreprocessingPassPipeline(
     passManager.addPass(createCanonicalizerPass());
     passManager.addPass(createCSEPass());
   }
-
-  // DEPRECATED: do not add explicit options for specific passes.
-  if (preprocessingOptions.preprocessingTransposeMatmulInput !=
-      PreprocessingOptions::TransposeMatmulInput::None) {
-    Preprocessing::TransposeMatmulPassOptions transposeMatmulOptions;
-    transposeMatmulOptions.input =
-        preprocessingOptions.preprocessingTransposeMatmulInput;
-    passManager.addPass(
-        Preprocessing::createTransposeMatmulPass(transposeMatmulOptions));
-  }
 }
 
 static void


### PR DESCRIPTION
The IREE `--iree-preprocessing-pass-pipeline` supports being passed an arbitrary preprocessing pass pipeline via an option, so there is no need to add custom global options for each preprocessing pass. To use the transpose matmul pass with `iree-opt` you can do:

```
--iree-preprocessing-pass-pipeline=builtin.module(func.func(iree-preprocessing-transpose-matmul{input=lhs}))
```