### PR TITLE
[VectorDistribution] Add iree_vector_ext.subgroup/thread_ids to make distribution opaque

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
@@ -53,6 +53,7 @@ iree_compiler_cc_library(
         "AMDGPUDistributeContract.cpp",
         "GPUCheckResourceUsage.cpp",
         "GPUCreateFastSlowPath.cpp",
+        "GPUDecomposeVectorExtOps.cpp",
         "GPUDistribute.cpp",
         "GPUDistributeScfFor.cpp",
         "GPUDistributeSharedMemoryCopy.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
@@ -51,6 +51,7 @@ iree_cc_library(
     "AMDGPUDistributeContract.cpp"
     "GPUCheckResourceUsage.cpp"
     "GPUCreateFastSlowPath.cpp"
+    "GPUDecomposeVectorExtOps.cpp"
     "GPUDistribute.cpp"
     "GPUDistributeScfFor.cpp"
     "GPUDistributeSharedMemoryCopy.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDecomposeVectorExtOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDecomposeVectorExtOps.cpp
@@ -1,0 +1,127 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree-dialects/Dialect/VectorExt/IR/VectorExtOps.h"
+#include "iree/compiler/Codegen/Common/GPU/PassDetail.h"
+#include "iree/compiler/Codegen/Common/GPU/Passes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::iree_compiler {
+
+using namespace IREE::VectorExt;
+
+namespace {
+
+struct DecomposeThreadIds : public OpRewritePattern<ThreadIdsOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ThreadIdsOp threadIdsOp,
+                                PatternRewriter &rewriter) const override {
+    Location loc = threadIdsOp.getLoc();
+    Value tid = threadIdsOp.getTid();
+    NestedLayoutAttr layout =
+        dyn_cast<NestedLayoutAttr>(threadIdsOp.getLayout());
+    if (!layout) {
+      return rewriter.notifyMatchFailure(threadIdsOp,
+                                         "NestedLayoutAttr expected.");
+    }
+
+    SmallVector<Value> virtualTids;
+    for (auto [size, stride] :
+         llvm::zip(layout.getThreadsPerOuter(), layout.getThreadStrides())) {
+      if (size == 1) {
+        virtualTids.push_back(rewriter.create<arith::ConstantIndexOp>(loc, 0));
+        continue;
+      }
+
+      // (tid floordiv stride) mod size
+      AffineExpr tidExpr = rewriter.getAffineDimExpr(0);
+      AffineMap virtualTidMap = AffineMap::get(/*dims=*/1, /*syms=*/0,
+                                               tidExpr.floorDiv(stride) % size);
+      Value virtualTid =
+          rewriter.create<affine::AffineApplyOp>(loc, virtualTidMap, tid);
+      virtualTids.push_back(virtualTid);
+    }
+
+    rewriter.replaceOp(threadIdsOp, virtualTids);
+    return success();
+  }
+};
+
+struct DecomposeSubgroupIds : public OpRewritePattern<SubgroupIdsOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  DecomposeSubgroupIds(MLIRContext *ctx, int64_t subgroupSize,
+                       PatternBenefit benefit = 1)
+      : OpRewritePattern(ctx, benefit), subgroupSize(subgroupSize) {}
+
+  LogicalResult matchAndRewrite(SubgroupIdsOp subgroupIdsOp,
+                                PatternRewriter &rewriter) const override {
+    Location loc = subgroupIdsOp.getLoc();
+    Value tid = subgroupIdsOp.getTid();
+    NestedLayoutAttr layout =
+        dyn_cast<NestedLayoutAttr>(subgroupIdsOp.getLayout());
+    if (!layout) {
+      return rewriter.notifyMatchFailure(subgroupIdsOp,
+                                         "NestedLayoutAttr expected.");
+    }
+
+    SmallVector<Value> virtualTids;
+    for (auto [size, stride] : llvm::zip(layout.getSubgroupsPerWorkgroup(),
+                                         layout.getSubgroupStrides())) {
+      if (size == 1) {
+        virtualTids.push_back(rewriter.create<arith::ConstantIndexOp>(loc, 0));
+        continue;
+      }
+
+      // (tid floordiv (stride * subgroupSize)) mod size
+      AffineExpr tidExpr = rewriter.getAffineDimExpr(0);
+      AffineMap virtualTidMap =
+          AffineMap::get(/*dims=*/1, /*syms=*/0,
+                         tidExpr.floorDiv(stride * subgroupSize) % size);
+      Value virtualTid =
+          rewriter.create<affine::AffineApplyOp>(loc, virtualTidMap, tid);
+      virtualTids.push_back(virtualTid);
+    }
+
+    rewriter.replaceOp(subgroupIdsOp, virtualTids);
+    return success();
+  }
+
+  int64_t subgroupSize;
+};
+
+struct GPUDecomposeVectorExtOps
+    : public GPUDecomposeVectorExtOpsBase<GPUDecomposeVectorExtOps> {
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    FunctionOpInterface funcOp = getOperation();
+
+    std::optional<int64_t> maybeSubgroupSize = getSubgroupSize(funcOp);
+    if (!maybeSubgroupSize) {
+      funcOp->emitOpError("Unable to query subgroup size");
+      return signalPassFailure();
+    }
+
+    RewritePatternSet patterns(context);
+    patterns.add<DecomposeThreadIds>(patterns.getContext());
+    patterns.add<DecomposeSubgroupIds>(patterns.getContext(),
+                                       maybeSubgroupSize.value());
+    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+
+} // namespace
+
+std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
+createGPUDecomposeVectorExtOps() {
+  return std::make_unique<GPUDecomposeVectorExtOps>();
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
@@ -96,6 +96,10 @@ createGPUCheckResourceUsagePass(
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createGPUCreateFastSlowPathPass();
 
+/// Creates a pass to decompose vector_ext ops.
+std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
+createGPUDecomposeVectorExtOps();
+
 /// Creates a pass to distribute scf.forall ops to GPU processors.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>> createGPUDistribute();
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -25,6 +25,12 @@ def GPUCreateFastSlowPath :
   let constructor = "mlir::iree_compiler::createGPUCreateFastSlowPathPass()";
 }
 
+def GPUDecomposeVectorExtOps :
+    InterfacePass<"iree-codegen-gpu-decompose-vector-ext-ops", "mlir::FunctionOpInterface"> {
+  let summary = "Pass to decompose vector_ext ops";
+  let constructor = "mlir::iree_compiler::createGPUDecomposeVectorExtOps()";
+}
+
 def GPUDistribute :
     InterfacePass<"iree-codegen-gpu-distribute", "mlir::FunctionOpInterface"> {
   let summary = "Pass to distribute scf.forall ops.";

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -567,6 +567,7 @@ void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager) {
   if (clLLVMGPUEnablePrefetch) {
     funcPassManager.addPass(createLLVMGPUPrefetchSharedMemoryPass());
   }
+  funcPassManager.addPass(createGPUDecomposeVectorExtOps());
   funcPassManager.addPass(memref::createFoldMemRefAliasOpsPass());
   funcPassManager.addPass(createCSEPass());
   funcPassManager.addPass(createCanonicalizerPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_distribute_conversion.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_distribute_conversion.mlir
@@ -105,7 +105,7 @@ func.func @mfma_matmul_256x256x256(%lhs: memref<16x256xf16, strided<[256, 1], of
 //       CHECK:   %[[LIN_ID:.+]] = affine.apply #[[$MAP]]()[%[[TIDX]], %[[TIDY]], %[[TIDZ]]]
 //       CHECK:   %[[RHS_ALLOC:.+]] = memref.alloc() : memref<32x16xf16, #gpu.address_space<workgroup>>
 //       CHECK:   %[[LHS_ALLOC:.+]] = memref.alloc() : memref<16x32xf16, #gpu.address_space<workgroup>>
-//       CHECK:   affine.delinearize_index %[[LIN_ID]]
+//       CHECK:   iree_vector_ext.thread_ids %[[LIN_ID]]
 //       CHECK:   %[[INIT_READ:.+]] = vector.transfer_read %{{.*}} memref<16x16xf32, {{.*}}>, vector<4x1xf32>
 //       CHECK:   %[[INIT:.+]] = vector.insert_strided_slice %[[INIT_READ]]
 //       CHECK:   scf.for {{.*}} = %c0 to %c256 step %c32 iter_args({{.*}} = %[[INIT]]) -> (vector<1x1x1x1x4x1xf32>)
@@ -234,7 +234,7 @@ func.func @wmma_matmul_256x256x256(%lhs: memref<16x256xf16, strided<[256, 1], of
 //       CHECK:   %[[LIN_ID:.+]] = affine.apply #[[$MAP]]()[%[[TIDX]], %[[TIDY]], %[[TIDZ]]]
 //       CHECK:   %[[RHS_ALLOC:.+]] = memref.alloc() : memref<32x16xf16, #gpu.address_space<workgroup>>
 //       CHECK:   %[[LHS_ALLOC:.+]] = memref.alloc() : memref<16x32xf16, #gpu.address_space<workgroup>>
-//       CHECK:   affine.delinearize_index %[[LIN_ID]]
+//       CHECK:   iree_vector_ext.thread_ids %[[LIN_ID]]
 //       CHECK:   %[[INIT_READ0:.+]] = vector.transfer_read %{{.*}} memref<16x16xf32, {{.*}}>, vector<1x1xf32>
 //       CHECK:   %[[INIT0:.+]] = vector.insert_strided_slice %[[INIT_READ0]]
 //       CHECK:   %[[INIT_READ1:.+]] = vector.transfer_read %{{.*}} memref<16x16xf32, {{.*}}>, vector<1x1xf32>

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/VectorExt/IR/VectorExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/VectorExt/IR/VectorExtOps.td
@@ -82,5 +82,33 @@ def IREEVectorExt_ToSIMTOp : IREEVectorExt_PureOp<"to_simt",
   let hasFolder = 1;
 }
 
+def IREEVectorExt_SubgroupIdsOp : IREEVectorExt_PureOp<"subgroup_ids", [Pure]> {
+  let summary = "Compute subgroup ids from a layout";
+  let description = [{}];
+  let arguments = (ins
+    Index:$tid,
+    VectorLayoutInterface:$layout
+  );
+  let results = (outs
+    Variadic<Index>:$virtualTids
+  );
+  let extraClassDeclaration = [{}];
+  let assemblyFormat = "$tid attr-dict `:` type($virtualTids)";
+}
+
+def IREEVectorExt_ThreadIdsOp : IREEVectorExt_PureOp<"thread_ids", [Pure]> {
+  let summary = "Compute thread ids from a layout";
+  let description = [{}];
+  let arguments = (ins
+    Index:$tid,
+    VectorLayoutInterface:$layout
+  );
+  let results = (outs
+    Variadic<Index>:$virtualTids
+  );
+  let extraClassDeclaration = [{}];
+  let assemblyFormat = "$tid attr-dict `:` type($virtualTids)";
+}
+
 #endif  // IREE_DIALECT_VECTOREXT_OPS
 


### PR DESCRIPTION
This patch adds two new operations: `iree_vector_ext.subgroup_ids` and `iree_vector_ext.thread_ids`. These operations simply decouple vector distribution from the actual thread indexing and hide them behind another operation.

This makes distribution patterns independent of the distribution indexing and makes them much more easier to debug. The distribution patterns only need to be debugged for tile sizes and the distribution indexing can be debugged separately on these operations.