### PR TITLE
Bump tf-nightly test pin to latest.

### DIFF
--- a/integrations/tensorflow/test/requirements.txt
+++ b/integrations/tensorflow/test/requirements.txt
@@ -1,7 +1,5 @@
 # Requirements for running TF tests
-# Temporarily pinning to nightly to make sure we have the newest feature
-# in the TFLite to TOSA importer.
-tf-nightly==2.16.0.dev20240207
+tf-nightly==2.17.0.dev20240508
 keras>=2.7.0
 Pillow>=9.2.0
 

--- a/integrations/tensorflow/test/requirements.txt
+++ b/integrations/tensorflow/test/requirements.txt
@@ -1,5 +1,5 @@
 # Requirements for running TF tests
-tf-nightly==2.17.0.dev20240508
+tf-nightly==2.17.0.dev20240507
 keras>=2.7.0
 Pillow>=9.2.0
 


### PR DESCRIPTION
The previous version we pinned to just dropped off of https://pypi.org/project/tf-nightly/#history (only the last 3 months of nightly releases are published)