### PR TITLE
[ROCMTarget] Add denormal flushing for fp32 math

### DIFF
--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -380,6 +380,8 @@ public:
         }
         if (targetArch.starts_with("gfx9"))
           addPreloadKernArgHint(llvmFunc);
+
+	llvmFunc->addFnAttr("denormal-fp-math-f32", "preserve-sign");
       }
 
       std::unique_ptr<llvm::TargetMachine> targetMachine;

--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -381,7 +381,7 @@ public:
         if (targetArch.starts_with("gfx9"))
           addPreloadKernArgHint(llvmFunc);
 
-	llvmFunc->addFnAttr("denormal-fp-math-f32", "preserve-sign");
+        llvmFunc->addFnAttr("denormal-fp-math-f32", "preserve-sign");
       }
 
       std::unique_ptr<llvm::TargetMachine> targetMachine;


### PR DESCRIPTION
This flag improves exp2 perf on amdgpu llvm backend for Flash Attention 2 kernels