### PR TITLE
[Winograd] Add TD specification option for winograd conv selection

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.h
@@ -43,7 +43,8 @@ createDecomposeWinogradTransformPass();
 // Creates a pass to convert linalg convolution ops into a sequence of
 // linalg_ext.winograd.* ops and linalg.batch_matmul ops using the winograd
 // tranformation.
-std::unique_ptr<Pass> createConvertConv2DToWinogradPass();
+std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
+createConvertConv2DToWinogradPass();
 
 // Transform dialect version of tile and decompose attention wrapper.
 // The optional tile size specifies the step for the innermost for loop.

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.td
@@ -62,9 +62,19 @@ def DecomposeWinogradTransform :
 }
 
 def ConvertConv2DToWinograd :
-    Pass<"iree-linalg-ext-convert-conv2d-to-winograd", ""> {
+    InterfacePass<"iree-linalg-ext-convert-conv2d-to-winograd", "mlir::FunctionOpInterface"> {
   let summary = "Convert linalg convolution ops to winograd based implementation";
   let constructor = "mlir::iree_compiler::IREE::LinalgExt::createConvertConv2DToWinogradPass()";
+  let options = [
+    Option<"tdLibraryPath", "td-library-path", "std::string",
+           /*default=*/"",
+           "File path to a module containing a library of transform dialect"
+           "strategies for annotating convs to be transformed.">,
+    Option<"ignoreAnnotations", "ignore-annotations", "bool",
+           /*default=*/"false",
+           "Choose to ignore `winograd_conv` annotations and transform all"
+           "compatible convolutions.">,
+  ];
 }
 
 def TileAndDecomposeAttention :

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv2d_to_winograd.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv2d_to_winograd.mlir
@@ -1,131 +1,162 @@
-// RUN: iree-opt --split-input-file -iree-linalg-ext-convert-conv2d-to-winograd -mlir-elide-elementsattrs-if-larger=4 %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(util.func(iree-linalg-ext-convert-conv2d-to-winograd{ignore-annotations}))" -mlir-elide-elementsattrs-if-larger=4 %s | FileCheck %s --check-prefixes=CHECK-ALL,CHECK-IGNORE
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(util.func(iree-linalg-ext-convert-conv2d-to-winograd))" -mlir-elide-elementsattrs-if-larger=4 %s | FileCheck %s --check-prefixes=CHECK-ALL,CHECK-ANNOTATED
 
-func.func @conv_16433136(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<3x3x4x16xf32>, %arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32> {
+util.func public @conv_16433136(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<3x3x4x16xf32>, %arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32> {
   %0 = linalg.conv_2d_nhwc_hwcf
     {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64> }
      ins(%arg0, %arg1: tensor<1x16x16x4xf32>, tensor<3x3x4x16xf32>)
     outs(%arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32>
-  return %0 : tensor<1x14x14x16xf32>
+  util.return %0 : tensor<1x14x14x16xf32>
 }
-// CHECK:      func.func @conv_16433136(
-// CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x16x16x4xf32>
-// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<3x3x4x16xf32>
-// CHECK-DAG:    %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
-// CHECK-DAG:    %[[EMPTY0:.+]] = tensor.empty() : tensor<8x8x4x16xf32>
-// CHECK:        %[[FILTER_TF:.+]] = iree_linalg_ext.winograd.filter_transform output_tile_size(6) kernel_size(3)
-// CHECK-SAME:     kernel_dimensions([0, 1]) ins(%[[ARG1]] : tensor<3x3x4x16xf32>) outs(%[[EMPTY0]] :
-// CHECK-SAME:     tensor<8x8x4x16xf32>) -> tensor<8x8x4x16xf32>
-// CHECK:        %[[COLLAPSED_FILTER:.+]] = tensor.collapse_shape %[[FILTER_TF]]
-// CHECK-SAME{LITERAL}:  [[0, 1], [2], [3]]
-// CHECK-SAME:           tensor<8x8x4x16xf32> into tensor<64x4x16xf32>
-// CHECK:        %[[EMPTY1:.+]] = tensor.empty() : tensor<8x8x1x3x3x4xf32>
-// CHECK:        %[[INPUT_TF:.+]] = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3)
-// CHECK-SAME:     image_dimensions([1, 2]) ins(%[[ARG0]] : tensor<1x16x16x4xf32>) outs(%[[EMPTY1]] :
-// CHECK-SAME:     tensor<8x8x1x3x3x4xf32>) -> tensor<8x8x1x3x3x4xf32>
-// CHECK:        %[[COLLAPSED_INPUT:.+]] = tensor.collapse_shape %[[INPUT_TF]]
-// CHECK-SAME{LITERAL}:  [[0, 1], [2, 3, 4], [5]]
-// CHECK-SAME:           tensor<8x8x1x3x3x4xf32> into tensor<64x9x4xf32>
-// CHECK:        %[[EMPTY2:.+]] = tensor.empty() : tensor<64x9x16xf32>
-// CHECK:        %[[FILL:.+]] = linalg.fill ins(%[[ZERO]] : f32) outs(%[[EMPTY2]] : tensor<64x9x16xf32>) ->
-// CHECK-SAME:     tensor<64x9x16xf32>
-// CHECK:        %[[BMM:.+]] = linalg.batch_matmul ins(%[[COLLAPSED_INPUT]], %[[COLLAPSED_FILTER]] : tensor<64x9x4xf32>,
-// CHECK-SAME:     tensor<64x4x16xf32>) outs(%[[FILL]] : tensor<64x9x16xf32>) -> tensor<64x9x16xf32>
-// CHECK:        %[[EXPANDED:.+]] = tensor.expand_shape %[[BMM]]
-// CHECK-SAME{LITERAL}: [[0, 1], [2, 3, 4], [5]]
-// CHECK-SAME:          tensor<64x9x16xf32> into tensor<8x8x1x3x3x16xf32>
-// CHECK:        %[[EMPTY3:.+]] = tensor.empty() : tensor<1x18x18x16xf32>
-// CHECK:        %[[OUTPUT_TF:.+]] = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3)
-// CHECK-SAME:     image_dimensions([1, 2]) ins(%[[EXPANDED]] : tensor<8x8x1x3x3x16xf32>) outs(%[[EMPTY3]] :
-// CHECK-SAME:     tensor<1x18x18x16xf32>) -> tensor<1x18x18x16xf32>
-// CHECK:        %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[OUTPUT_TF]][0, 0, 0, 0] [1, 14, 14, 16] [1, 1, 1, 1] :
-// CHECK-SAME:     tensor<1x18x18x16xf32> to tensor<1x14x14x16xf32>
-// CHECK:        return %[[EXTRACTED_SLICE]] : tensor<1x14x14x16xf32>
-// CHECK:      }
+// CHECK-ALL:         util.func public @conv_16433136(
+// CHECK-IGNORE-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x16x16x4xf32>
+// CHECK-IGNORE-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<3x3x4x16xf32>
+// CHECK-IGNORE-DAG:    %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-IGNORE-DAG:    %[[EMPTY0:.+]] = tensor.empty() : tensor<8x8x4x16xf32>
+// CHECK-IGNORE:        %[[FILTER_TF:.+]] = iree_linalg_ext.winograd.filter_transform output_tile_size(6) kernel_size(3)
+// CHECK-IGNORE-SAME:     kernel_dimensions([0, 1]) ins(%[[ARG1]] : tensor<3x3x4x16xf32>) outs(%[[EMPTY0]] :
+// CHECK-IGNORE-SAME:     tensor<8x8x4x16xf32>) -> tensor<8x8x4x16xf32>
+// CHECK-IGNORE:        %[[COLLAPSED_FILTER:.+]] = tensor.collapse_shape %[[FILTER_TF]]
+// CHECK-IGNORE-SAME{LITERAL}:  [[0, 1], [2], [3]]
+// CHECK-IGNORE-SAME:           tensor<8x8x4x16xf32> into tensor<64x4x16xf32>
+// CHECK-IGNORE:        %[[EMPTY1:.+]] = tensor.empty() : tensor<8x8x1x3x3x4xf32>
+// CHECK-IGNORE:        %[[INPUT_TF:.+]] = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3)
+// CHECK-IGNORE-SAME:     image_dimensions([1, 2]) ins(%[[ARG0]] : tensor<1x16x16x4xf32>) outs(%[[EMPTY1]] :
+// CHECK-IGNORE-SAME:     tensor<8x8x1x3x3x4xf32>) -> tensor<8x8x1x3x3x4xf32>
+// CHECK-IGNORE:        %[[COLLAPSED_INPUT:.+]] = tensor.collapse_shape %[[INPUT_TF]]
+// CHECK-IGNORE-SAME{LITERAL}:  [[0, 1], [2, 3, 4], [5]]
+// CHECK-IGNORE-SAME:           tensor<8x8x1x3x3x4xf32> into tensor<64x9x4xf32>
+// CHECK-IGNORE:        %[[EMPTY2:.+]] = tensor.empty() : tensor<64x9x16xf32>
+// CHECK-IGNORE:        %[[FILL:.+]] = linalg.fill ins(%[[ZERO]] : f32) outs(%[[EMPTY2]] : tensor<64x9x16xf32>) ->
+// CHECK-IGNORE-SAME:     tensor<64x9x16xf32>
+// CHECK-IGNORE:        %[[BMM:.+]] = linalg.batch_matmul ins(%[[COLLAPSED_INPUT]], %[[COLLAPSED_FILTER]] : tensor<64x9x4xf32>,
+// CHECK-IGNORE-SAME:     tensor<64x4x16xf32>) outs(%[[FILL]] : tensor<64x9x16xf32>) -> tensor<64x9x16xf32>
+// CHECK-IGNORE:        %[[EXPANDED:.+]] = tensor.expand_shape %[[BMM]]
+// CHECK-IGNORE-SAME{LITERAL}: [[0, 1], [2, 3, 4], [5]]
+// CHECK-IGNORE-SAME:          tensor<64x9x16xf32> into tensor<8x8x1x3x3x16xf32>
+// CHECK-IGNORE:        %[[EMPTY3:.+]] = tensor.empty() : tensor<1x18x18x16xf32>
+// CHECK-IGNORE:        %[[OUTPUT_TF:.+]] = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3)
+// CHECK-IGNORE-SAME:     image_dimensions([1, 2]) ins(%[[EXPANDED]] : tensor<8x8x1x3x3x16xf32>) outs(%[[EMPTY3]] :
+// CHECK-IGNORE-SAME:     tensor<1x18x18x16xf32>) -> tensor<1x18x18x16xf32>
+// CHECK-IGNORE:        %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[OUTPUT_TF]][0, 0, 0, 0] [1, 14, 14, 16] [1, 1, 1, 1] :
+// CHECK-IGNORE-SAME:     tensor<1x18x18x16xf32> to tensor<1x14x14x16xf32>
+// CHECK-IGNORE:        util.return %[[EXTRACTED_SLICE]] : tensor<1x14x14x16xf32>
+// CHECK-IGNORE:      }
 
 // -----
 
-func.func @conv_16433136_nchw_fchw(%arg0: tensor<1x4x16x16xf32>, %arg1: tensor<16x4x3x3xf32>, %arg2: tensor<1x16x14x14xf32>) -> tensor<1x16x14x14xf32> {
+util.func public @conv_16433136_nchw_fchw(%arg0: tensor<1x4x16x16xf32>, %arg1: tensor<16x4x3x3xf32>, %arg2: tensor<1x16x14x14xf32>) -> tensor<1x16x14x14xf32> {
   %0 = linalg.conv_2d_nchw_fchw
     {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64> }
      ins(%arg0, %arg1: tensor<1x4x16x16xf32>, tensor<16x4x3x3xf32>)
     outs(%arg2: tensor<1x16x14x14xf32>) -> tensor<1x16x14x14xf32>
-  return %0 : tensor<1x16x14x14xf32>
+  util.return %0 : tensor<1x16x14x14xf32>
 }
-// CHECK:      func.func @conv_16433136_nchw_fchw(
-// CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x4x16x16xf32>
-// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<16x4x3x3xf32>
-// CHECK-DAG:    %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
-// CHECK-DAG:    %[[EMPTY0:.+]] = tensor.empty() : tensor<8x8x4x16xf32>
-// CHECK:        %[[FILTER_TF:.+]] = iree_linalg_ext.winograd.filter_transform output_tile_size(6) kernel_size(3)
-// CHECK-SAME:     kernel_dimensions([2, 3]) ins(%[[ARG1]] : tensor<16x4x3x3xf32>) outs(%[[EMPTY0]] :
-// CHECK-SAME:     tensor<8x8x4x16xf32>) -> tensor<8x8x4x16xf32>
-// CHECK:        %[[COLLAPSED_FILTER:.+]] = tensor.collapse_shape %[[FILTER_TF]]
-// CHECK-SAME{LITERAL}:  [[0, 1], [2], [3]]
-// CHECK-SAME:           tensor<8x8x4x16xf32> into tensor<64x4x16xf32>
-// CHECK:        %[[EMPTY1:.+]] = tensor.empty() : tensor<8x8x1x3x3x4xf32>
-// CHECK:        %[[INPUT_TF:.+]] = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3)
-// CHECK-SAME:     image_dimensions([2, 3]) ins(%[[ARG0]] : tensor<1x4x16x16xf32>) outs(%[[EMPTY1]] :
-// CHECK-SAME:     tensor<8x8x1x3x3x4xf32>) -> tensor<8x8x1x3x3x4xf32>
-// CHECK:        %[[COLLAPSED_INPUT:.+]] = tensor.collapse_shape %[[INPUT_TF]]
-// CHECK-SAME{LITERAL}:  [[0, 1], [2, 3, 4], [5]]
-// CHECK-SAME:           tensor<8x8x1x3x3x4xf32> into tensor<64x9x4xf32>
-// CHECK:        %[[EMPTY2:.+]] = tensor.empty() : tensor<64x9x16xf32>
-// CHECK:        %[[FILL:.+]] = linalg.fill ins(%[[ZERO]] : f32) outs(%[[EMPTY2]] : tensor<64x9x16xf32>) ->
-// CHECK-SAME:     tensor<64x9x16xf32>
-// CHECK:        %[[BMM:.+]] = linalg.batch_matmul ins(%[[COLLAPSED_INPUT]], %[[COLLAPSED_FILTER]] : tensor<64x9x4xf32>,
-// CHECK-SAME:     tensor<64x4x16xf32>) outs(%[[FILL]] : tensor<64x9x16xf32>) -> tensor<64x9x16xf32>
-// CHECK:        %[[EXPANDED:.+]] = tensor.expand_shape %[[BMM]]
-// CHECK-SAME{LITERAL}: [[0, 1], [2, 3, 4], [5]]
-// CHECK-SAME:          tensor<64x9x16xf32> into tensor<8x8x1x3x3x16xf32>
-// CHECK:        %[[EMPTY3:.+]] = tensor.empty() : tensor<1x16x18x18xf32>
-// CHECK:        %[[OUTPUT_TF:.+]] = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3)
-// CHECK-SAME:     image_dimensions([2, 3]) ins(%[[EXPANDED]] : tensor<8x8x1x3x3x16xf32>) outs(%[[EMPTY3]] :
-// CHECK-SAME:     tensor<1x16x18x18xf32>) -> tensor<1x16x18x18xf32>
-// CHECK:        %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[OUTPUT_TF]][0, 0, 0, 0] [1, 16, 14, 14] [1, 1, 1, 1] :
-// CHECK-SAME:     tensor<1x16x18x18xf32> to tensor<1x16x14x14xf32>
-// CHECK:        return %[[EXTRACTED_SLICE]] : tensor<1x16x14x14xf32>
-// CHECK:      }
+// CHECK-ALL:         util.func public @conv_16433136_nchw_fchw(
+// CHECK-IGNORE-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x4x16x16xf32>
+// CHECK-IGNORE-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<16x4x3x3xf32>
+// CHECK-IGNORE-DAG:    %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-IGNORE-DAG:    %[[EMPTY0:.+]] = tensor.empty() : tensor<8x8x4x16xf32>
+// CHECK-IGNORE:        %[[FILTER_TF:.+]] = iree_linalg_ext.winograd.filter_transform output_tile_size(6) kernel_size(3)
+// CHECK-IGNORE-SAME:     kernel_dimensions([2, 3]) ins(%[[ARG1]] : tensor<16x4x3x3xf32>) outs(%[[EMPTY0]] :
+// CHECK-IGNORE-SAME:     tensor<8x8x4x16xf32>) -> tensor<8x8x4x16xf32>
+// CHECK-IGNORE:        %[[COLLAPSED_FILTER:.+]] = tensor.collapse_shape %[[FILTER_TF]]
+// CHECK-IGNORE-SAME{LITERAL}:  [[0, 1], [2], [3]]
+// CHECK-IGNORE-SAME:           tensor<8x8x4x16xf32> into tensor<64x4x16xf32>
+// CHECK-IGNORE:        %[[EMPTY1:.+]] = tensor.empty() : tensor<8x8x1x3x3x4xf32>
+// CHECK-IGNORE:        %[[INPUT_TF:.+]] = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3)
+// CHECK-IGNORE-SAME:     image_dimensions([2, 3]) ins(%[[ARG0]] : tensor<1x4x16x16xf32>) outs(%[[EMPTY1]] :
+// CHECK-IGNORE-SAME:     tensor<8x8x1x3x3x4xf32>) -> tensor<8x8x1x3x3x4xf32>
+// CHECK-IGNORE:        %[[COLLAPSED_INPUT:.+]] = tensor.collapse_shape %[[INPUT_TF]]
+// CHECK-IGNORE-SAME{LITERAL}:  [[0, 1], [2, 3, 4], [5]]
+// CHECK-IGNORE-SAME:           tensor<8x8x1x3x3x4xf32> into tensor<64x9x4xf32>
+// CHECK-IGNORE:        %[[EMPTY2:.+]] = tensor.empty() : tensor<64x9x16xf32>
+// CHECK-IGNORE:        %[[FILL:.+]] = linalg.fill ins(%[[ZERO]] : f32) outs(%[[EMPTY2]] : tensor<64x9x16xf32>) ->
+// CHECK-IGNORE-SAME:     tensor<64x9x16xf32>
+// CHECK-IGNORE:        %[[BMM:.+]] = linalg.batch_matmul ins(%[[COLLAPSED_INPUT]], %[[COLLAPSED_FILTER]] : tensor<64x9x4xf32>,
+// CHECK-IGNORE-SAME:     tensor<64x4x16xf32>) outs(%[[FILL]] : tensor<64x9x16xf32>) -> tensor<64x9x16xf32>
+// CHECK-IGNORE:        %[[EXPANDED:.+]] = tensor.expand_shape %[[BMM]]
+// CHECK-IGNORE-SAME{LITERAL}: [[0, 1], [2, 3, 4], [5]]
+// CHECK-IGNORE-SAME:          tensor<64x9x16xf32> into tensor<8x8x1x3x3x16xf32>
+// CHECK-IGNORE:        %[[EMPTY3:.+]] = tensor.empty() : tensor<1x16x18x18xf32>
+// CHECK-IGNORE:        %[[OUTPUT_TF:.+]] = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3)
+// CHECK-IGNORE-SAME:     image_dimensions([2, 3]) ins(%[[EXPANDED]] : tensor<8x8x1x3x3x16xf32>) outs(%[[EMPTY3]] :
+// CHECK-IGNORE-SAME:     tensor<1x16x18x18xf32>) -> tensor<1x16x18x18xf32>
+// CHECK-IGNORE:        %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[OUTPUT_TF]][0, 0, 0, 0] [1, 16, 14, 14] [1, 1, 1, 1] :
+// CHECK-IGNORE-SAME:     tensor<1x16x18x18xf32> to tensor<1x16x14x14xf32>
+// CHECK-IGNORE:        util.return %[[EXTRACTED_SLICE]] : tensor<1x16x14x14xf32>
+// CHECK-IGNORE:      }
 
 // -----
 
-func.func @conv_mixed_types(%arg0: tensor<1x16x16x4xf16>, %arg1: tensor<3x3x4x16xf16>, %arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32> {
+util.func public @conv_mixed_types(%arg0: tensor<1x16x16x4xf16>, %arg1: tensor<3x3x4x16xf16>, %arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32> {
   %0 = linalg.conv_2d_nhwc_hwcf
     {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64> }
      ins(%arg0, %arg1: tensor<1x16x16x4xf16>, tensor<3x3x4x16xf16>)
     outs(%arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32>
-  return %0 : tensor<1x14x14x16xf32>
+  util.return %0 : tensor<1x14x14x16xf32>
 }
-// CHECK:      func.func @conv_mixed_types(
-// CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x16x16x4xf16>
-// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<3x3x4x16xf16>
-// CHECK-DAG:    %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
-// CHECK-DAG:    %[[EMPTY0:.+]] = tensor.empty() : tensor<8x8x4x16xf16>
-// CHECK:        %[[FILTER_TF:.+]] = iree_linalg_ext.winograd.filter_transform output_tile_size(6) kernel_size(3)
-// CHECK-SAME:     kernel_dimensions([0, 1]) ins(%[[ARG1]] : tensor<3x3x4x16xf16>) outs(%[[EMPTY0]] :
-// CHECK-SAME:     tensor<8x8x4x16xf16>) -> tensor<8x8x4x16xf16>
-// CHECK:        %[[COLLAPSED_FILTER:.+]] = tensor.collapse_shape %[[FILTER_TF]]
-// CHECK-SAME{LITERAL}:  [[0, 1], [2], [3]]
-// CHECK-SAME:           tensor<8x8x4x16xf16> into tensor<64x4x16xf16>
-// CHECK:        %[[EMPTY1:.+]] = tensor.empty() : tensor<8x8x1x3x3x4xf16>
-// CHECK:        %[[INPUT_TF:.+]] = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3)
-// CHECK-SAME:     image_dimensions([1, 2]) ins(%[[ARG0]] : tensor<1x16x16x4xf16>) outs(%[[EMPTY1]] :
-// CHECK-SAME:     tensor<8x8x1x3x3x4xf16>) -> tensor<8x8x1x3x3x4xf16>
-// CHECK:        %[[COLLAPSED_INPUT:.+]] = tensor.collapse_shape %[[INPUT_TF]]
-// CHECK-SAME{LITERAL}:  [[0, 1], [2, 3, 4], [5]]
-// CHECK-SAME:           tensor<8x8x1x3x3x4xf16> into tensor<64x9x4xf16>
-// CHECK:        %[[EMPTY2:.+]] = tensor.empty() : tensor<64x9x16xf32>
-// CHECK:        %[[FILL:.+]] = linalg.fill ins(%[[ZERO]] : f32) outs(%[[EMPTY2]] : tensor<64x9x16xf32>) ->
-// CHECK-SAME:     tensor<64x9x16xf32>
-// CHECK:        %[[BMM:.+]] = linalg.batch_matmul ins(%[[COLLAPSED_INPUT]], %[[COLLAPSED_FILTER]] : tensor<64x9x4xf16>,
-// CHECK-SAME:     tensor<64x4x16xf16>) outs(%[[FILL]] : tensor<64x9x16xf32>) -> tensor<64x9x16xf32>
-// CHECK:        %[[EXPANDED:.+]] = tensor.expand_shape %[[BMM]]
-// CHECK-SAME{LITERAL}: [[0, 1], [2, 3, 4], [5]]
-// CHECK-SAME:          tensor<64x9x16xf32> into tensor<8x8x1x3x3x16xf32>
-// CHECK:        %[[EMPTY3:.+]] = tensor.empty() : tensor<1x18x18x16xf32>
-// CHECK:        %[[OUTPUT_TF:.+]] = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3)
-// CHECK-SAME:     image_dimensions([1, 2]) ins(%[[EXPANDED]] : tensor<8x8x1x3x3x16xf32>) outs(%[[EMPTY3]] :
-// CHECK-SAME:     tensor<1x18x18x16xf32>) -> tensor<1x18x18x16xf32>
-// CHECK:        %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[OUTPUT_TF]][0, 0, 0, 0] [1, 14, 14, 16] [1, 1, 1, 1] :
-// CHECK-SAME:     tensor<1x18x18x16xf32> to tensor<1x14x14x16xf32>
-// CHECK:        return %[[EXTRACTED_SLICE]] : tensor<1x14x14x16xf32>
-// CHECK:      }
+// CHECK-ALL:         util.func public @conv_mixed_types(
+// CHECK-IGNORE-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x16x16x4xf16>
+// CHECK-IGNORE-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<3x3x4x16xf16>
+// CHECK-IGNORE-DAG:    %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-IGNORE-DAG:    %[[EMPTY0:.+]] = tensor.empty() : tensor<8x8x4x16xf16>
+// CHECK-IGNORE:        %[[FILTER_TF:.+]] = iree_linalg_ext.winograd.filter_transform output_tile_size(6) kernel_size(3)
+// CHECK-IGNORE-SAME:     kernel_dimensions([0, 1]) ins(%[[ARG1]] : tensor<3x3x4x16xf16>) outs(%[[EMPTY0]] :
+// CHECK-IGNORE-SAME:     tensor<8x8x4x16xf16>) -> tensor<8x8x4x16xf16>
+// CHECK-IGNORE:        %[[COLLAPSED_FILTER:.+]] = tensor.collapse_shape %[[FILTER_TF]]
+// CHECK-IGNORE-SAME{LITERAL}:  [[0, 1], [2], [3]]
+// CHECK-IGNORE-SAME:           tensor<8x8x4x16xf16> into tensor<64x4x16xf16>
+// CHECK-IGNORE:        %[[EMPTY1:.+]] = tensor.empty() : tensor<8x8x1x3x3x4xf16>
+// CHECK-IGNORE:        %[[INPUT_TF:.+]] = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3)
+// CHECK-IGNORE-SAME:     image_dimensions([1, 2]) ins(%[[ARG0]] : tensor<1x16x16x4xf16>) outs(%[[EMPTY1]] :
+// CHECK-IGNORE-SAME:     tensor<8x8x1x3x3x4xf16>) -> tensor<8x8x1x3x3x4xf16>
+// CHECK-IGNORE:        %[[COLLAPSED_INPUT:.+]] = tensor.collapse_shape %[[INPUT_TF]]
+// CHECK-IGNORE-SAME{LITERAL}:  [[0, 1], [2, 3, 4], [5]]
+// CHECK-IGNORE-SAME:           tensor<8x8x1x3x3x4xf16> into tensor<64x9x4xf16>
+// CHECK-IGNORE:        %[[EMPTY2:.+]] = tensor.empty() : tensor<64x9x16xf32>
+// CHECK-IGNORE:        %[[FILL:.+]] = linalg.fill ins(%[[ZERO]] : f32) outs(%[[EMPTY2]] : tensor<64x9x16xf32>) ->
+// CHECK-IGNORE-SAME:     tensor<64x9x16xf32>
+// CHECK-IGNORE:        %[[BMM:.+]] = linalg.batch_matmul ins(%[[COLLAPSED_INPUT]], %[[COLLAPSED_FILTER]] : tensor<64x9x4xf16>,
+// CHECK-IGNORE-SAME:     tensor<64x4x16xf16>) outs(%[[FILL]] : tensor<64x9x16xf32>) -> tensor<64x9x16xf32>
+// CHECK-IGNORE:        %[[EXPANDED:.+]] = tensor.expand_shape %[[BMM]]
+// CHECK-IGNORE-SAME{LITERAL}: [[0, 1], [2, 3, 4], [5]]
+// CHECK-IGNORE-SAME:          tensor<64x9x16xf32> into tensor<8x8x1x3x3x16xf32>
+// CHECK-IGNORE:        %[[EMPTY3:.+]] = tensor.empty() : tensor<1x18x18x16xf32>
+// CHECK-IGNORE:        %[[OUTPUT_TF:.+]] = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3)
+// CHECK-IGNORE-SAME:     image_dimensions([1, 2]) ins(%[[EXPANDED]] : tensor<8x8x1x3x3x16xf32>) outs(%[[EMPTY3]] :
+// CHECK-IGNORE-SAME:     tensor<1x18x18x16xf32>) -> tensor<1x18x18x16xf32>
+// CHECK-IGNORE:        %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[OUTPUT_TF]][0, 0, 0, 0] [1, 14, 14, 16] [1, 1, 1, 1] :
+// CHECK-IGNORE-SAME:     tensor<1x18x18x16xf32> to tensor<1x14x14x16xf32>
+// CHECK-IGNORE:        util.return %[[EXTRACTED_SLICE]] : tensor<1x14x14x16xf32>
+// CHECK-IGNORE:      }
+
+// -----
+
+util.func public @conv_rewrite_annotated(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<3x3x4x16xf32>, %arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32> {
+  %0 = linalg.conv_2d_nhwc_hwcf
+    {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>, winograd_conv}
+     ins(%arg0, %arg1: tensor<1x16x16x4xf32>, tensor<3x3x4x16xf32>)
+    outs(%arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32>
+  util.return %0 : tensor<1x14x14x16xf32>
+}
+// CHECK-ALL:            util.func public @conv_rewrite_annotated(
+// CHECK-ANNOTATED:    iree_linalg_ext.winograd.filter_transform
+// CHECK-ANNOTATED:    iree_linalg_ext.winograd.input_transform
+// CHECK-ANNOTATED:    linalg.batch_matmul
+// CHECK-ANNOTATED:    iree_linalg_ext.winograd.output_transform
+
+// -----
+
+util.func public @conv_ignore_unannotated(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<3x3x4x16xf32>, %arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32> {
+  %0 = linalg.conv_2d_nhwc_hwcf
+    {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
+     ins(%arg0, %arg1: tensor<1x16x16x4xf32>, tensor<3x3x4x16xf32>)
+    outs(%arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32>
+  util.return %0 : tensor<1x14x14x16xf32>
+}
+// CHECK-ALL:            util.func public @conv_ignore_unannotated(
+// CHECK-ANNOTATED-NOT:    iree_linalg_ext.winograd.filter_transform
+// CHECK-ANNOTATED-NOT:    iree_linalg_ext.winograd.input_transform
+// CHECK-ANNOTATED-NOT:    linalg.batch_matmul
+// CHECK-ANNOTATED-NOT:    iree_linalg_ext.winograd.output_transform

--- a/compiler/src/iree/compiler/Utils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Utils/BUILD.bazel
@@ -27,6 +27,7 @@ iree_compiler_cc_library(
         "StringUtils.cpp",
         "ToolUtils.cpp",
         "TracingUtils.cpp",
+        "TransformDialectUtils.cpp",
     ],
     hdrs = [
         "ConversionUtils.h",
@@ -46,6 +47,7 @@ iree_compiler_cc_library(
         "StringUtils.h",
         "ToolUtils.h",
         "TracingUtils.h",
+        "TransformDialectUtils.h",
     ],
     deps = [
         "//compiler/src/iree/compiler/Dialect/Encoding/IR",

--- a/compiler/src/iree/compiler/Utils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Utils/CMakeLists.txt
@@ -31,6 +31,7 @@ iree_cc_library(
     "StringUtils.h"
     "ToolUtils.h"
     "TracingUtils.h"
+    "TransformDialectUtils.h"
   SRCS
     "ConversionUtils.cpp"
     "ElementPackingUtils.cpp"
@@ -42,7 +43,8 @@ iree_cc_library(
     "StringUtils.cpp"
     "ToolUtils.cpp"
     "TracingUtils.cpp"
-  DEPS
+    "TransformDialectUtils.cpp"
+    DEPS
     LLVMSupport
     MLIRArithDialect
     MLIRFuncDialect

--- a/compiler/src/iree/compiler/Utils/TransformDialectUtils.cpp
+++ b/compiler/src/iree/compiler/Utils/TransformDialectUtils.cpp
@@ -1,0 +1,67 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Utils/TransformDialectUtils.h"
+#include <string>
+#include "llvm/ADT/StringExtras.h"
+#include "mlir/Dialect/Transform/Transforms/TransformInterpreterUtils.h"
+#include "mlir/IR/BuiltinOps.h"
+
+namespace mlir::iree_compiler {
+
+StrategyRunResult
+runTransformConfigurationStrategy(Operation *payloadRoot,
+                                  StringRef entryPointName,
+                                  ModuleOp &transformLibrary) {
+  /// If we have a symbol, verify the existence of the symbol within the
+  /// transform library.
+  Operation *entryPoint = transform::detail::findTransformEntryPoint(
+      payloadRoot, transformLibrary, entryPointName);
+  if (!entryPoint) {
+    return StrategyRunResult::NotFound;
+  }
+
+  transform::TransformOptions options;
+  if (failed(transform::applyTransformNamedSequence(
+          payloadRoot, entryPoint, transformLibrary,
+          options.enableExpensiveChecks(true)))) {
+    return StrategyRunResult::Failed;
+  }
+  return StrategyRunResult::Success;
+}
+
+FailureOr<std::pair<std::optional<std::string>, std::optional<std::string>>>
+parseTransformLibraryFileNameAndEntrySequence(std::string input) {
+  SmallVector<StringRef, 2> parts;
+  llvm::SplitString(llvm::StringRef(input), parts, "@");
+  if (parts.size() > 2) {
+    //   funcOp.emitError()
+    //       << "Invalid transform library path and sequence name "
+    //       << input;
+    return failure();
+  }
+  bool hasTransformLibrary = !parts.empty();
+  std::optional<std::string> libraryFileName;
+  if (hasTransformLibrary) {
+    if (parts[0].empty()) {
+      // funcOp.emitError() << "Cannot specify an empty library path";
+      return failure();
+    }
+    libraryFileName = parts[0];
+  }
+  std::optional<std::string> entrySequenceName;
+  // Check if the user specified a custom entry point name.
+  if (parts.size() == 2) {
+    if (parts[1].empty()) {
+      //   funcOp.emitError() << "Cannot specify an empty sequence name";
+      return failure();
+    }
+    entrySequenceName = parts[1];
+  }
+  return std::make_pair(libraryFileName, entrySequenceName);
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Utils/TransformDialectUtils.h
+++ b/compiler/src/iree/compiler/Utils/TransformDialectUtils.h
@@ -1,0 +1,29 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_UTILS_TRANSFORMDIALECTUTILS_H_
+#define IREE_COMPILER_UTILS_TRANSFORMDIALECTUTILS_H_
+
+#include "mlir/IR/BuiltinOps.h"
+
+namespace mlir::iree_compiler {
+
+enum StrategyRunResult {
+  Success = 0,
+  NotFound = 1,
+  Failed = 2,
+};
+
+StrategyRunResult runTransformConfigurationStrategy(Operation *payloadRoot,
+                                                    StringRef entryPointName,
+                                                    ModuleOp &transformLibrary);
+
+FailureOr<std::pair<std::optional<std::string>, std::optional<std::string>>>
+parseTransformLibraryFileNameAndEntrySequence(std::string input);
+
+} // namespace mlir::iree_compiler
+
+#endif // IREE_COMPILER_UTILS_TRANSFORMDIALECTUTILS_H_


### PR DESCRIPTION
This PR adds an option to specify a transform dialect library path for winograd convolution selection. The specified transform script should annotate `linalg.conv_2d` ops with `winograd_conv`. Only annotated convs will be rewritten by default, but this PR also adds an option to ignore annotations and rewrite all compatible convolutions.

Since Winograd affects numerical results, and the performance benefit is different for different shapes, it is usually necessary to select specific shapes to use Winograd. This PR enables users to make this selection based on shapes or parameters of specific convolutions.

Some helpers from MaterializeUserConfigs are also moved to Utils/TransformDialectUtils.cpp to be reused in Conv2DToWinograd.