### PR TITLE
[Codegen] Add pattern for hoisting scf.forall from scf.for

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/BUILD.bazel
@@ -97,6 +97,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:SCFTransforms",
         "@llvm-project//mlir:SCFUtils",
+        "@llvm-project//mlir:SubsetOpInterface",
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TensorTransformOps",
         "@llvm-project//mlir:TensorTransforms",

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CMakeLists.txt
@@ -55,6 +55,7 @@ iree_cc_library(
     MLIRSCFDialect
     MLIRSCFTransforms
     MLIRSCFUtils
+    MLIRSubsetOpInterface
     MLIRTensorDialect
     MLIRTensorTransformOps
     MLIRTensorTransforms

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -26,6 +26,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Casting.h"
+#include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Conversion/VectorToGPU/VectorToGPU.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/LoopUtils.h"
@@ -58,6 +59,7 @@
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Value.h"
+#include "mlir/Interfaces/SubsetOpInterface.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/CSE.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -172,6 +174,225 @@ struct FoldFillIntoPad : public OpRewritePattern<tensor::PadOp> {
 void transform_dialect::ApplyFoldFillIntoPadPatternsOp::populatePatterns(
     RewritePatternSet &patterns) {
   patterns.insert<FoldFillIntoPad>(patterns.getContext());
+}
+
+//===---------------------------------------------------------------------===//
+// ApplyHoistForallFromForPatternsOp
+//===---------------------------------------------------------------------===//
+
+namespace {
+struct HoistForallFromFor : public OpRewritePattern<scf::ForOp> {
+  using OpRewritePattern<scf::ForOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(scf::ForOp loop,
+                                PatternRewriter &rewriter) const final {
+    if (loop.getBody()->getOperations().size() != 2) {
+      return rewriter.notifyMatchFailure(
+          loop, "Body of the loop contains more than one op");
+    }
+
+    auto forallOp =
+        dyn_cast<scf::ForallOp>(loop.getBody()->without_terminator().begin());
+    if (!forallOp) {
+      return rewriter.notifyMatchFailure(
+          loop, "Loop single contained op is not scf.forall op");
+    }
+
+    if (forallOp.getNumResults() != 1 || loop.getNumResults() != 1) {
+      return rewriter.notifyMatchFailure(
+          loop, "unimplemented: multi-result hoisting");
+    }
+
+    if (loop.getBody()->getTerminator()->getOperand(0).getDefiningOp() !=
+        forallOp) {
+      return rewriter.notifyMatchFailure(
+          loop, "Single for loop return is not forall result");
+    }
+
+    // Step 1. Collect the set of tensor.parallel_insert_slice ops in the
+    // terminator and their paired extract_slice ops from the for loop iter arg.
+    SmallVector<Operation *> sliceOperandProducers;
+
+    BackwardSliceOptions backwardOptions;
+    backwardOptions.inclusive = true;
+    backwardOptions.filter = [&](Operation *op) -> bool {
+      return forallOp->isProperAncestor(op);
+    };
+    SetVector<Operation *> slice;
+
+    scf::InParallelOp parallelTerminator = forallOp.getTerminator();
+    SmallVector<tensor::ParallelInsertSliceOp> terminators(
+        forallOp.getNumResults());
+    SmallVector<tensor::ExtractSliceOp> pairedSlices(forallOp.getNumResults());
+    int64_t numInductionVars = forallOp.getInductionVars().size();
+    for (auto &yieldingOp : parallelTerminator.getYieldingOps()) {
+      auto parallelInsert = cast<tensor::ParallelInsertSliceOp>(&yieldingOp);
+      BlockArgument destBbArg =
+          llvm::cast<BlockArgument>(parallelInsert.getDest());
+      tensor::ExtractSliceOp destSlice;
+      for (auto user : destBbArg.getUsers()) {
+        if (user == parallelInsert)
+          continue;
+        auto maybeSlice = dyn_cast<tensor::ExtractSliceOp>(user);
+        // Fail if the destination has more users than a direct insert and
+        // extract slice.
+        if (!maybeSlice) {
+          return failure();
+        }
+        // Require a single extract per destination.
+        if (destSlice) {
+          return failure();
+        }
+        destSlice = maybeSlice;
+      }
+      // Verify they operate on equivalent subsets, ensuring the slices are
+      // hoistable. It is still possible to hoist the loop if this is not true,
+      // however in such cases we likely formed the loops in the wrong order.
+      if (!cast<SubsetOpInterface>(*destSlice)
+               .operatesOnEquivalentSubset(
+                   cast<SubsetOpInterface>(*parallelInsert),
+                   [](Value v1, Value v2) { return v1 == v2; })) {
+        return failure();
+      }
+      terminators[destBbArg.getArgNumber() - numInductionVars] = parallelInsert;
+      pairedSlices[destBbArg.getArgNumber() - numInductionVars] = destSlice;
+
+      // Collect all of the offset/size/stride operands for both slices and
+      // compute a backwards slice of the program from them. Fail if any of
+      // them depend on the serial loop iterator.
+      llvm::SmallDenseSet<Value> sliceOperands;
+      sliceOperands.insert(
+          parallelInsert.getOperands().begin() +
+              parallelInsert.getOffsetSizeAndStrideStartOperandIndex(),
+          parallelInsert.getOperands().end());
+      sliceOperands.insert(
+          destSlice.getOperands().begin() +
+              destSlice.getOffsetSizeAndStrideStartOperandIndex(),
+          destSlice.getOperands().end());
+      for (Value operand : sliceOperands) {
+        if (auto bbArg = dyn_cast<BlockArgument>(operand)) {
+          if (bbArg.getOwner()->getParentOp() == loop) {
+            return rewriter.notifyMatchFailure(
+                loop, "Slice operand producers depend on loop");
+          }
+        }
+        SetVector<Operation *> tmpBackwardSlice;
+        getBackwardSlice(operand, &tmpBackwardSlice, backwardOptions);
+        slice.set_union(tmpBackwardSlice);
+      }
+    }
+
+    // An operation is safe to hoist if it is speculatable and none of its
+    // operands depend on the serial loop.
+    auto isSafeToHoist = [&](Operation *op) {
+      return op->getBlock() == forallOp.getBody() && isMemoryEffectFree(op) &&
+             isSpeculatable(op) &&
+             llvm::none_of(op->getOperands(), [&](Value operand) {
+               if (auto blockArg = dyn_cast<BlockArgument>(operand)) {
+                 return blockArg.getOwner() == loop.getBody();
+               }
+               return false;
+             });
+    };
+
+    if (!llvm::all_of(slice, isSafeToHoist)) {
+      return rewriter.notifyMatchFailure(
+          loop, "Slice operand producers not safe to hoist out of loop");
+    }
+
+    // Sort the backwards slice of the producers for the insertion/extraction
+    // indices by the block order in the scf.forall body. This ensures that we
+    // hoist operations in the same order they started. Any topological ordering
+    // would work too because the operations are speculatable.
+    SmallVector<Operation *> sliceVec(slice.getArrayRef());
+    std::sort(sliceVec.begin(), sliceVec.end(),
+              [](Operation *l, Operation *r) { return l->isBeforeInBlock(r); });
+
+    // Step 2. Create the ForallOp.
+    Location loc = forallOp.getLoc();
+    scf::ForallOp newForallOp = rewriter.create<scf::ForallOp>(
+        loc, forallOp.getMixedLowerBound(), forallOp.getMixedUpperBound(),
+        forallOp.getMixedStep(), loop.getInitArgs(), forallOp.getMappingAttr());
+
+    {
+      // RAII guard, inserting within forallOp, before terminator.
+      OpBuilder::InsertionGuard g(rewriter);
+      rewriter.setInsertionPoint(newForallOp.getTerminator());
+      SmallVector<Value> newInits;
+      for (auto slice : pairedSlices) {
+        newInits.push_back(slice.getResult());
+      }
+      // Step 3. Create a new for loop with new inits for the result of the
+      // extracted slices.
+      auto newLoop = rewriter.create<scf::ForOp>(
+          loop.getLoc(), loop.getLowerBound(), loop.getUpperBound(),
+          loop.getStep(), newInits,
+          [](OpBuilder &, Location, Value, ValueRange) {});
+
+      {
+        // Step 4. Inline the body of the original forall into the new for loop.
+        OpBuilder::InsertionGuard g2(rewriter);
+        SmallVector<Value> argReplacements(newForallOp.getInductionVars());
+        argReplacements.append(newForallOp.getRegionIterArgs().begin(),
+                               newForallOp.getRegionIterArgs().end());
+        rewriter.mergeBlocks(forallOp.getBody(), newLoop.getBody(),
+                             argReplacements);
+        rewriter.replaceAllUsesWith(loop.getInductionVar(),
+                                    newLoop.getInductionVar());
+        // Replace the users of the to-be-hoisted slices with the loop iter
+        // args.
+        for (auto [hoistedSlice, iterArg] :
+             llvm::zip_equal(pairedSlices, newLoop.getRegionIterArgs())) {
+          rewriter.replaceAllUsesExcept(hoistedSlice, iterArg, newLoop);
+        }
+
+        // Create the terminator for the new loop using the sources of the
+        // parallel inserts.
+        SmallVector<Value> newYields;
+        for (auto parallelSlice : terminators) {
+          newYields.push_back(parallelSlice.getSource());
+        }
+        rewriter.setInsertionPointToEnd(newLoop.getBody());
+        rewriter.create<scf::YieldOp>(loop.getLoc(), newYields);
+      }
+
+      // Move all producers for the indices of the slices outside of the body
+      // of the loop (and the extract_slice ops themselves).
+      for (auto sliceOperandProducer : sliceVec) {
+        rewriter.moveOpBefore(sliceOperandProducer, newLoop);
+      }
+      for (auto slice : pairedSlices) {
+        rewriter.moveOpBefore(slice, newLoop);
+      }
+
+      // Create the new terminator for the hoisted forall loop using the results
+      // of the new for loop.
+      rewriter.setInsertionPointToEnd(newForallOp.getTerminator().getBody());
+      for (auto [parallelSlice, source, dest] :
+           llvm::zip_equal(terminators, newLoop.getResults(),
+                           newForallOp.getRegionIterArgs())) {
+        rewriter.create<tensor::ParallelInsertSliceOp>(
+            parallelSlice.getLoc(), source, dest, parallelSlice.getOffsets(),
+            parallelSlice.getSizes(), parallelSlice.getStrides(),
+            parallelSlice.getStaticOffsets(), parallelSlice.getStaticSizes(),
+            parallelSlice.getStaticStrides());
+      }
+    }
+
+    // Step 5. Erase the original terminator and replace the loop with
+    // the hoisted loop.
+    for (auto parallelSlice : terminators) {
+      rewriter.eraseOp(parallelSlice);
+    }
+    rewriter.eraseOp(parallelTerminator);
+    rewriter.replaceOp(loop, newForallOp);
+    return success();
+  }
+};
+} // namespace
+
+void transform_dialect::ApplyHoistForallFromForPatternsOp::populatePatterns(
+    RewritePatternSet &patterns) {
+  patterns.insert<HoistForallFromFor>(patterns.getContext());
 }
 
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -190,6 +190,9 @@ struct HoistForallFromFor : public OpRewritePattern<scf::ForOp> {
           loop, "Body of the loop contains more than one op");
     }
 
+    // TODO(qedawkins): It should be fine to hoist as long as there is a single
+    // forall op such that any operation within the block of the parent scf.for
+    // is independent of the destination of the forall.
     auto forallOp =
         dyn_cast<scf::ForallOp>(loop.getBody()->without_terminator().begin());
     if (!forallOp) {

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -98,6 +98,24 @@ def ApplyFoldTensorSliceIntoTransferPatternsOp : Op<Transform_Dialect,
   let assemblyFormat = "attr-dict";
 }
 
+def ApplyHoistForallFromForPatternsOp : Op<Transform_Dialect,
+    "apply_patterns.iree.hoist_forall_from_for",
+    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>]> {
+  let description = [{
+    Hoists perfectly nested `scf.forall` ops from parent `scf.for` ops if
+    the slice the forall loop operates on is loop invariant w.r.t. the for loop.
+
+    This pattern only applies to forall ops that yield tensors. For bufferized
+    loops the parallel loop is always trivially hoistable with a barrier and
+    happens automatically when lowering the `scf.forall`.
+
+    Currently only supports a single result tensor.
+  }];
+
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+  let assemblyFormat = "attr-dict";
+}
+
 def ApplyIREELinalgElementwiseGreedyFusionPatternsOp : Op<Transform_Dialect,
     "apply_patterns.iree.linalg_elementwise_greedy_fusion",
     [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -67,6 +67,7 @@ iree_lit_test_suite(
             "transform_buffer_opt.mlir",
             "transform_copy_operand.mlir",
             "transform_fuse_forall.mlir",
+            "transform_hoist_forall.mlir",
             "transform_lower_shuffle.mlir",
             "transform_match_partial_reduction.mlir",
             "transform_ops_invalid.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -63,6 +63,7 @@ iree_lit_test_suite(
     "transform_buffer_opt.mlir"
     "transform_copy_operand.mlir"
     "transform_fuse_forall.mlir"
+    "transform_hoist_forall.mlir"
     "transform_lower_shuffle.mlir"
     "transform_match_partial_reduction.mlir"
     "transform_ops_invalid.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/transform_hoist_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/transform_hoist_forall.mlir
@@ -1,0 +1,90 @@
+// RUN: iree-opt %s -iree-transform-dialect-interpreter -transform-dialect-drop-schedule --split-input-file | FileCheck %s
+
+#map = affine_map<(d0) -> (d0 * 2)>
+module {
+  func.func @hoist_forall(%arg0: tensor<128x128xf32>) -> tensor<128x128xf32> {
+    %0 = tensor.empty() : tensor<128x128xf32>
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %4 = scf.for %arg1 = %c0 to %c2 step %c1 iter_args(%arg2 = %0) -> (tensor<128x128xf32>) {
+      %3 = scf.forall (%arg5, %arg6) in (64, 1) shared_outs(%arg7 = %arg2) -> (tensor<128x128xf32>) {
+        %4 = affine.apply #map(%arg5)
+        %extracted_slice = tensor.extract_slice %arg0[%4, %arg6] [2, 128] [1, 1] : tensor<128x128xf32> to tensor<2x128xf32>
+        %extracted_slice_0 = tensor.extract_slice %arg7[%4, %arg6] [2, 128] [1, 1] : tensor<128x128xf32> to tensor<2x128xf32>
+        %5 = linalg.copy ins(%extracted_slice : tensor<2x128xf32>) outs(%extracted_slice_0 : tensor<2x128xf32>) -> tensor<2x128xf32>
+        scf.forall.in_parallel {
+          tensor.parallel_insert_slice %5 into %arg7[%4, %arg6] [2, 128] [1, 1] : tensor<2x128xf32> into tensor<128x128xf32>
+        }
+      } {mapping = [#gpu.thread<y>, #gpu.thread<x>]}
+      scf.yield %3 : tensor<128x128xf32>
+    }
+    return %4 : tensor<128x128xf32>
+  }
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.hoist_forall_from_for
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK: #[[$MAP:.+]] = affine_map<(d0) -> (d0 * 2)>
+// CHECK-LABEL: func @hoist_forall
+
+//       CHECK:   %[[INIT:.+]] = tensor.empty() : tensor<128x128xf32>
+//       CHECK:   %[[FORALL:.+]] = scf.forall (%[[ID0:.+]], %[[ID1:.+]]) in (64, 1) shared_outs(%[[OUTS:.+]] = %[[INIT]]) -> (tensor<128x128xf32>)
+//  CHECK-NEXT:     %[[SLICE_ID:.+]] = affine.apply #[[$MAP]](%[[ID0]])
+//  CHECK-NEXT:     %[[SLICE:.+]] = tensor.extract_slice %[[OUTS]][%[[SLICE_ID]], %[[ID1]]] [2, 128] [1, 1] : tensor<128x128xf32> to tensor<2x128xf32>
+//  CHECK-NEXT:     %[[FOR:.+]] = scf.for {{.*}} iter_args(%[[FOR_INIT:.+]] = %[[SLICE]]) -> (tensor<2x128xf32>)
+//       CHECK:       %[[COPY:.+]] = linalg.copy {{.*}} outs(%[[FOR_INIT]] : tensor<2x128xf32>)
+//       CHECK:       scf.yield %[[COPY]]
+//       CHECK:     scf.forall.in_parallel
+//  CHECK-NEXT:       tensor.parallel_insert_slice %[[FOR]] into %[[OUTS]][%[[SLICE_ID]], %[[ID1]]] [2, 128] [1, 1] : tensor<2x128xf32> into tensor<128x128xf32>
+//       CHECK:   return %[[FORALL]]
+
+// -----
+
+#map = affine_map<(d0) -> (d0 * 2)>
+module {
+  func.func @no_hoist_loop_dependent(%arg0: tensor<128x128xf32>) -> tensor<128x128xf32> {
+    %0 = tensor.empty() : tensor<128x128xf32>
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %4 = scf.for %arg1 = %c0 to %c2 step %c1 iter_args(%arg2 = %0) -> (tensor<128x128xf32>) {
+      %3 = scf.forall (%arg5, %arg6) in (64, 1) shared_outs(%arg7 = %arg2) -> (tensor<128x128xf32>) {
+        %4 = affine.apply #map(%arg1)
+        %extracted_slice = tensor.extract_slice %arg0[%4, %arg6] [2, 128] [1, 1] : tensor<128x128xf32> to tensor<2x128xf32>
+        %extracted_slice_0 = tensor.extract_slice %arg7[%4, %arg6] [2, 128] [1, 1] : tensor<128x128xf32> to tensor<2x128xf32>
+        %5 = linalg.copy ins(%extracted_slice : tensor<2x128xf32>) outs(%extracted_slice_0 : tensor<2x128xf32>) -> tensor<2x128xf32>
+        scf.forall.in_parallel {
+          tensor.parallel_insert_slice %5 into %arg7[%4, %arg6] [2, 128] [1, 1] : tensor<2x128xf32> into tensor<128x128xf32>
+        }
+      } {mapping = [#gpu.thread<y>, #gpu.thread<x>]}
+      scf.yield %3 : tensor<128x128xf32>
+    }
+    return %4 : tensor<128x128xf32>
+  }
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.hoist_forall_from_for
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// Verify we don't hoist when the slices are dependent on the loop.
+// CHECK-LABEL: func @no_hoist_loop_dependent
+
+//       CHECK:   %[[FOR:.+]] = scf.for
+//       CHECK:     scf.forall
+//       CHECK:   return %[[FOR]]


### PR DESCRIPTION
This pattern does what is effectively subset hoisting on an scf.forall perfectly nested inside of an scf.for op, updating the iter arg of the for loop to use the slice read by and written by the parallel loop.