### PR TITLE
[Preprocessing] Skip skinny matmuls during PadToIntrinsics.

### DIFF
--- a/compiler/src/iree/compiler/Preprocessing/Common/PadToIntrinsics.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/PadToIntrinsics.cpp
@@ -32,7 +32,7 @@ namespace mlir::iree_compiler::Preprocessing {
 namespace {
 
 // Threshold used to determine whether a matmul dimension is 'very skinny'.
-// Linked to LLVMGPU/KernelConfig.cpp
+// Based on the same variable in LLVMGPU/KernelConfig.cpp.
 constexpr int64_t kVerySkinnyDimThreshold = 4;
 
 static Value getPaddedValue(RewriterBase &rewriter, Location loc,

--- a/compiler/src/iree/compiler/Preprocessing/Common/PadToIntrinsics.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/PadToIntrinsics.cpp
@@ -31,6 +31,10 @@ namespace mlir::iree_compiler::Preprocessing {
 
 namespace {
 
+// Threshold used to determine whether a matmul dimension is 'very skinny'.
+// Linked to LLVMGPU/KernelConfig.cpp
+constexpr int64_t kVerySkinnyDimThreshold = 4;
+
 static Value getPaddedValue(RewriterBase &rewriter, Location loc,
                             Value padSource, ArrayRef<OpFoldResult> padding) {
   auto sourceType = cast<RankedTensorType>(padSource.getType());
@@ -321,8 +325,9 @@ static void padContractionLikeOp(RewriterBase &rewriter,
   int64_t nSize = bounds[nDim];
   int64_t kSize = bounds[kDim];
 
-  // Bail out on matvec-like cases.
-  if (mSize == 1 || nSize == 1) {
+  // Bail out on matvec-like/skinny matmul cases.
+  if ((!ShapedType::isDynamic(mSize) && mSize <= kVerySkinnyDimThreshold) ||
+      (!ShapedType::isDynamic(nSize) && nSize <= kVerySkinnyDimThreshold)) {
     return;
   }
 

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/pad_to_intrinsics.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/pad_to_intrinsics.mlir
@@ -296,15 +296,17 @@ func.func @dequant_gemm_dynamic_m(%arg0: tensor<4096x32x128xi4>, %arg1: tensor<4
 
 // -----
 
+// We want to skip padding skinny matmul cases, since warpReduction is more performant for it.
+
 #rocm_executable_target = #hal.executable.target<"rocm", "rocm-hsaco-fb",
                                     {mma_intrinsics = [#iree_gpu.mma_layout<WMMA_F16_16x16x16_F32>],
                                       target_arch = "gfx1100", ukernels = "none"}>
 
-//       CHECK: func.func @skinny_m_matmul(
+//       CHECK: func.func @skip_skinny_m_matmul(
 //  CHECK-SAME:    %[[ARG0:.+]]: tensor<2x20xf16>,
 //  CHECK-SAME:    %[[ARG1:.+]]: tensor<20x30xf16>,
 //  CHECK-SAME:    %[[ARG2:.+]]: tensor<2x30xf16>)
-func.func @skinny_m_matmul(%arg0 : tensor<2x20xf16>, %arg1 : tensor<20x30xf16>, %arg2 : tensor<2x30xf16>) -> tensor<2x30xf16>
+func.func @skip_skinny_m_matmul(%arg0 : tensor<2x20xf16>, %arg1 : tensor<20x30xf16>, %arg2 : tensor<2x30xf16>) -> tensor<2x30xf16>
     attributes {hal.device.targets = [#hal.device.target<"rocm", [#rocm_executable_target]>]} {
     %0 = linalg.matmul ins(%arg0, %arg1 : tensor<2x20xf16>, tensor<20x30xf16>)
         outs(%arg2 : tensor<2x30xf16>) -> tensor<2x30xf16>
@@ -315,15 +317,17 @@ func.func @skinny_m_matmul(%arg0 : tensor<2x20xf16>, %arg1 : tensor<20x30xf16>, 
 
 // -----
 
+// We want to skip padding skinny matmul cases, since warpReduction is more performant for it.
+
 #rocm_executable_target = #hal.executable.target<"rocm", "rocm-hsaco-fb",
                                     {mma_intrinsics = [#iree_gpu.mma_layout<WMMA_F16_16x16x16_F32>],
                                       target_arch = "gfx1100", ukernels = "none"}>
 
-//       CHECK: func.func @skinny_n_mmtb(
+//       CHECK: func.func @skip_skinny_n_mmtb(
 //  CHECK-SAME:    %[[ARG0:.+]]: tensor<10x20xf16>,
 //  CHECK-SAME:    %[[ARG1:.+]]: tensor<4x20xf16>,
 //  CHECK-SAME:    %[[ARG2:.+]]: tensor<10x4xf16>)
-func.func @skinny_n_mmtb(%arg0 : tensor<10x20xf16>, %arg1 : tensor<4x20xf16>, %arg2 : tensor<10x4xf16>) -> tensor<10x4xf16>
+func.func @skip_skinny_n_mmtb(%arg0 : tensor<10x20xf16>, %arg1 : tensor<4x20xf16>, %arg2 : tensor<10x4xf16>) -> tensor<10x4xf16>
     attributes {hal.device.targets = [#hal.device.target<"rocm", [#rocm_executable_target]>]} {
     %0 = linalg.matmul_transpose_b ins(%arg0, %arg1 : tensor<10x20xf16>, tensor<4x20xf16>)
         outs(%arg2 : tensor<10x4xf16>) -> tensor<10x4xf16>

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/pad_to_intrinsics.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/pad_to_intrinsics.mlir
@@ -293,3 +293,41 @@ func.func @dequant_gemm_dynamic_m(%arg0: tensor<4096x32x128xi4>, %arg1: tensor<4
 
 // CONTRACT:        tensor.pad {{.*}} low[0, 0, 0]
 // CONTRACT:        tensor.expand_shape {{.*}} {{\[}}[0, 1], [2], [3]] : tensor<?x32x128xf16> into tensor<?x16x32x128xf16>
+
+// -----
+
+#rocm_executable_target = #hal.executable.target<"rocm", "rocm-hsaco-fb",
+                                    {mma_intrinsics = [#iree_gpu.mma_layout<WMMA_F16_16x16x16_F32>],
+                                      target_arch = "gfx1100", ukernels = "none"}>
+
+//       CHECK: func.func @skinny_m_matmul(
+//  CHECK-SAME:    %[[ARG0:.+]]: tensor<2x20xf16>,
+//  CHECK-SAME:    %[[ARG1:.+]]: tensor<20x30xf16>,
+//  CHECK-SAME:    %[[ARG2:.+]]: tensor<2x30xf16>)
+func.func @skinny_m_matmul(%arg0 : tensor<2x20xf16>, %arg1 : tensor<20x30xf16>, %arg2 : tensor<2x30xf16>) -> tensor<2x30xf16>
+    attributes {hal.device.targets = [#hal.device.target<"rocm", [#rocm_executable_target]>]} {
+    %0 = linalg.matmul ins(%arg0, %arg1 : tensor<2x20xf16>, tensor<20x30xf16>)
+        outs(%arg2 : tensor<2x30xf16>) -> tensor<2x30xf16>
+    return %0 : tensor<2x30xf16>
+}
+
+// CHECK-NOT:  tensor.pad
+
+// -----
+
+#rocm_executable_target = #hal.executable.target<"rocm", "rocm-hsaco-fb",
+                                    {mma_intrinsics = [#iree_gpu.mma_layout<WMMA_F16_16x16x16_F32>],
+                                      target_arch = "gfx1100", ukernels = "none"}>
+
+//       CHECK: func.func @skinny_n_mmtb(
+//  CHECK-SAME:    %[[ARG0:.+]]: tensor<10x20xf16>,
+//  CHECK-SAME:    %[[ARG1:.+]]: tensor<4x20xf16>,
+//  CHECK-SAME:    %[[ARG2:.+]]: tensor<10x4xf16>)
+func.func @skinny_n_mmtb(%arg0 : tensor<10x20xf16>, %arg1 : tensor<4x20xf16>, %arg2 : tensor<10x4xf16>) -> tensor<10x4xf16>
+    attributes {hal.device.targets = [#hal.device.target<"rocm", [#rocm_executable_target]>]} {
+    %0 = linalg.matmul_transpose_b ins(%arg0, %arg1 : tensor<10x20xf16>, tensor<4x20xf16>)
+        outs(%arg2 : tensor<10x4xf16>) -> tensor<10x4xf16>
+    return %0 : tensor<10x4xf16>
+}
+
+// CHECK-NOT:  tensor.pad


### PR DESCRIPTION
Skinny matmuls are more performant when they go down the WarpReduction pipeline. This PR allows preprocessing to skip through such skinny matmuls, such that it would not intervene with the skinny matmul heuristics and compilation flow in LLVMGPU.