### PR TITLE
[Preprocessing] Move TD interpreter pass before preprocessing passes

### DIFF
--- a/compiler/src/iree/compiler/Preprocessing/Passes.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Passes.cpp
@@ -67,6 +67,14 @@ void buildPreprocessingPassPipeline(
     OpPassManager &passManager,
     const PreprocessingOptions &preprocessingOptions,
     PipelineExtensions *pipelineExtensions) {
+  if (!preprocessingOptions.preprocessingTransformSpecFilename.empty()) {
+    Preprocessing::InterpreterPassOptions interpreterOptions;
+    interpreterOptions.transformSpecPath =
+        preprocessingOptions.preprocessingTransformSpecFilename;
+    passManager.addPass(
+        Preprocessing::createInterpreterPass(interpreterOptions));
+  }
+
   auto pipelineStr = preprocessingOptions.preprocessingPassPipeline;
   if (!pipelineStr.empty()) {
     extendWithTextPipeline(passManager, pipelineStr);
@@ -74,14 +82,6 @@ void buildPreprocessingPassPipeline(
 
   if (pipelineExtensions) {
     pipelineExtensions->extendPreprocessingPassPipeline(passManager);
-  }
-
-  if (!preprocessingOptions.preprocessingTransformSpecFilename.empty()) {
-    Preprocessing::InterpreterPassOptions interpreterOptions;
-    interpreterOptions.transformSpecPath =
-        preprocessingOptions.preprocessingTransformSpecFilename;
-    passManager.addPass(
-        Preprocessing::createInterpreterPass(interpreterOptions));
   }
 
   if (!preprocessingOptions.preprocessingPDLSpecFilename.empty()) {


### PR DESCRIPTION
This PR moves the transform dialect interpreter before the preprocessing-pass-pipeline, so transform scripts will be applied before any other preprocessing passes. The main purpose for this is to use the preprocessing TD interpreter to annotate convolutions for Winograd transformation rewrites, since the Conv2DToWinograd pass is usually called as preprocessing.