### PR TITLE
Transform dialect fix to allow multiple calls to same custom dispatch

### DIFF
--- a/compiler/src/iree/compiler/Preprocessing/Passes.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Passes.cpp
@@ -82,8 +82,6 @@ void buildPreprocessingPassPipeline(
         preprocessingOptions.preprocessingTransformSpecFilename;
     passManager.addPass(
         Preprocessing::createInterpreterPass(interpreterOptions));
-    // Custom dispatch formation creates util.func ops that need to be inlined.
-    passManager.addPass(mlir::createInlinerPass());
   }
 
   if (!preprocessingOptions.preprocessingPDLSpecFilename.empty()) {

--- a/compiler/src/iree/compiler/Preprocessing/Passes.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Passes.cpp
@@ -82,6 +82,8 @@ void buildPreprocessingPassPipeline(
         preprocessingOptions.preprocessingTransformSpecFilename;
     passManager.addPass(
         Preprocessing::createInterpreterPass(interpreterOptions));
+    // Custom dispatch formation creates util.func ops that need to be inlined.
+    passManager.addPass(mlir::createInlinerPass());
   }
 
   if (!preprocessingOptions.preprocessingPDLSpecFilename.empty()) {

--- a/samples/custom_dispatch/cpu/mlp_plugin/CMakeLists.txt
+++ b/samples/custom_dispatch/cpu/mlp_plugin/CMakeLists.txt
@@ -103,6 +103,7 @@ iree_lit_test_suite(
     iree_samples_custom_dispatch_cpu_mlp_plugin
   DATA
     "mlp_linalg_spec.pdl.mlir"
+    "mlp_spec_matmul.mlir"
   LABELS
     "driver=local-sync"
     "hostonly"

--- a/samples/custom_dispatch/cpu/mlp_plugin/mlp_linalg_two_matmul.mlir
+++ b/samples/custom_dispatch/cpu/mlp_plugin/mlp_linalg_two_matmul.mlir
@@ -7,6 +7,15 @@
 // RUN:     --input="8x8xf32=5" | \
 // RUN:   FileCheck %s
 
+// RUN: iree-compile --iree-preprocessing-transform-spec-filename=%p/mlp_spec_matmul.mlir %s | \
+// RUN:   iree-run-module --device=local-sync \
+// RUN:     --executable_plugin=$IREE_BINARY_DIR/samples/custom_dispatch/cpu/mlp_plugin/mlp_plugin$IREE_DYLIB_EXT \
+// RUN:     --module=- \
+// RUN:     --function=mlp_invocation \
+// RUN:     --input="8x8xf32=6" \
+// RUN:     --input="8x8xf32=5" | \
+// RUN:   FileCheck %s --check-prefix=TRANSFORM
+
 
 #x86_64_target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
   data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
@@ -61,3 +70,8 @@ module @example attributes {hal.device.targets = [#cpu_target]} {
   //       CHECK: [Plugin]: M = 8, N = 8, K = 8
   //       CHECK: [Plugin]: M = 8, N = 8, K = 8
   //       CHECK: 8x8xf32=[-9600 -9600 -9600 -9600 -9600 -9600 -9600 -9600][-9600 -9600 -9600 -9600 -9600 -9600 -9600 -9600][-9600 -9600 -9600 -9600 -9600 -9600 -9600 -9600][-9600 -9600 -9600 -9600 -9600 -9600 -9600 -9600][-9600 -9600 -9600 -9600 -9600 -9600 -9600 -9600][-9600 -9600 -9600 -9600 -9600 -9600 -9600 -9600][-9600 -9600 -9600 -9600 -9600 -9600 -9600 -9600][-9600 -9600 -9600 -9600 -9600 -9600 -9600 -9600]
+
+  // TRANSFORM-LABEL: EXEC @mlp_invocation
+  //       TRANSFORM: [Plugin]: M = 8, N = 8, K = 8
+  //       TRANSFORM: [Plugin]: M = 8, N = 8, K = 8
+  //       TRANSFORM: 8x8xf32=[-9600 -9600 -9600 -9600 -9600 -9600 -9600 -9600][-9600 -9600 -9600 -9600 -9600 -9600 -9600 -9600][-9600 -9600 -9600 -9600 -9600 -9600 -9600 -9600][-9600 -9600 -9600 -9600 -9600 -9600 -9600 -9600][-9600 -9600 -9600 -9600 -9600 -9600 -9600 -9600][-9600 -9600 -9600 -9600 -9600 -9600 -9600 -9600][-9600 -9600 -9600 -9600 -9600 -9600 -9600 -9600][-9600 -9600 -9600 -9600 -9600 -9600 -9600 -9600]

--- a/samples/custom_dispatch/cpu/mlp_plugin/mlp_spec_matmul.mlir
+++ b/samples/custom_dispatch/cpu/mlp_plugin/mlp_spec_matmul.mlir
@@ -1,0 +1,104 @@
+// Sample spec that matches an MLP example and forwards to
+// an implementation implemented by a system plugin.
+// Is used along with samples/custom_dispatch/cpu/plugin/mlp.mlir
+
+module attributes {transform.with_named_sequence} {
+
+  // Executable that stages call to the external functions.
+  stream.executable private @executable {
+    stream.executable.export public @mlp workgroups() -> (index, index, index) {
+      %c1 = arith.constant 1 : index
+      hal.return %c1, %c1, %c1 : index, index, index
+    }
+    builtin.module {
+      func.func private @mlp_external(%lhs : memref<f32>, %lhs_offset : index, %rhs : memref<f32>, %rhs_offset : index, %result : memref<f32>, %result_offset : index, %m : i32, %n : i32, %k : i32, %doRelu : i1) attributes {llvm.bareptr}
+      func.func @mlp(%arg0: !stream.binding, %arg1: !stream.binding, %arg2: !stream.binding, %arg3: i32, %arg4: i32, %arg5 : i32) {
+        %c0 = arith.constant 0 : index
+        %do_relu = arith.constant false
+        %m = arith.index_cast %arg3 : i32 to index
+        %n = arith.index_cast %arg4 : i32 to index
+        %k = arith.index_cast %arg5 : i32 to index
+        %lhs = stream.binding.subspan %arg0[%c0] : !stream.binding -> memref<?x?xf32, strided<[?, 1], offset: ?>>{%m, %k}
+        %rhs = stream.binding.subspan %arg1[%c0] : !stream.binding -> memref<?x?xf32, strided<[?, 1], offset: ?>>{%k, %n}
+        %result = stream.binding.subspan %arg2[%c0] : !stream.binding -> memref<?x?xf32, strided<[?, 1], offset: ?>>{%m, %n}
+        %p0, %o0, %s00, %s01, %t00, %t01 = iree_codegen.extract_strided_metadata %lhs : memref<?x?xf32, strided<[?, 1], offset: ?>> -> memref<f32>, index, index, index, index, index
+        %p1, %o1, %s10, %s11, %t10, %t11 = iree_codegen.extract_strided_metadata %rhs : memref<?x?xf32, strided<[?, 1], offset: ?>> -> memref<f32>, index, index, index, index, index
+        %p2, %o2, %s20, %s21, %t20, %t21 = iree_codegen.extract_strided_metadata %result : memref<?x?xf32, strided<[?, 1], offset: ?>> -> memref<f32>, index, index, index, index, index
+        func.call @mlp_external(%p0, %o0, %p1, %o1, %p2, %o2, %arg3, %arg4, %arg5, %do_relu) : (memref<f32>, index, memref<f32>, index, memref<f32>, index, i32, i32, i32, i1) -> ()
+        return
+      }
+    }
+  }
+
+  util.func private @call_mlp(%lhs : tensor<?x?xf32>, %rhs : tensor<?x?xf32>, %init1 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %m = tensor.dim %lhs, %c0 : tensor<?x?xf32>
+    %n = tensor.dim %rhs, %c1 : tensor<?x?xf32>
+    %k = tensor.dim %lhs, %c1 : tensor<?x?xf32>
+    %m_i32 = arith.index_cast %m : index to i32
+    %n_i32 = arith.index_cast %n : index to i32
+    %k_i32 = arith.index_cast %k : index to i32
+
+    %mlp_result = flow.dispatch @executable::@mlp(%lhs, %rhs, %m_i32, %n_i32, %k_i32)
+        : (tensor<?x?xf32>{%m, %k}, tensor<?x?xf32>{%k, %n}, i32, i32, i32) -> tensor<?x?xf32>{%m, %n}
+
+    util.return %mlp_result : tensor<?x?xf32>
+  }
+
+  transform.named_sequence @match_mlp(%root: !transform.any_op {transform.readonly}) -> (!transform.any_value, !transform.any_value) {
+    %ins, %outs = transform.iree.match.cast_compatible_dag_from_root %root {
+      ^bb0(%lhs: tensor<?x?xf32>, %rhs: tensor<?x?xf32>, %init1 : tensor<?x?xf32>):
+        %cst = arith.constant 0.0 : f32
+        %fill = linalg.fill ins(%cst : f32) outs(%init1 : tensor<?x?xf32>) -> tensor<?x?xf32>
+        %matmul = linalg.matmul
+            ins(%lhs, %rhs : tensor<?x?xf32>, tensor<?x?xf32>)
+                outs(%fill : tensor<?x?xf32>) -> tensor<?x?xf32>
+      } : (!transform.any_op) -> (!transform.any_value, !transform.any_value)
+    transform.yield %ins, %outs : !transform.any_value, !transform.any_value
+  }
+
+
+  // Rewrite callback for `transform.foreach_match`. The input signature for
+  // this sequence must match exactly with the outputs of the matcher. In this
+  // case the matcher returns the inputs and outputs to the matched dag directly
+  // so we just insert a call to the hand authored function above.
+  transform.named_sequence @cast_and_call_dag(%ins: !transform.any_value {transform.readonly},
+                                              %out: !transform.any_value {transform.readonly}) {
+    %root = transform.get_defining_op %out : (!transform.any_value) -> !transform.any_op
+    %module = transform.util.get_nearest_symbol_table %root : (!transform.any_op) -> !transform.any_op
+    %executable = transform.util.import_symbol @executable into %module if undefined : (!transform.any_op) -> !transform.any_op
+    %func = transform.util.import_symbol @call_mlp into %module if undefined : (!transform.any_op) -> !transform.any_op
+    transform.util.cast_and_call %func(%ins) -> %out after %root {
+      // This specifies how to resolve type mismatches between the arguments
+      // of the function and the inputs from the matcher. In this example,
+      // the only casts this will generate are same-rank tensor casts that
+      // drop static information.
+      transform.type_conversion.tensor.cast_shape_dynamic_dims
+    } : (!transform.any_op, !transform.any_value, !transform.any_value, !transform.any_op) -> !transform.any_op
+    transform.yield
+  }
+
+  // Entry point for the transform interpreter, nested on the full module. This
+  // is because the rewrites needed for importing the custom kernel needs to
+  // add a new symbol to the module's symbol table.
+  transform.named_sequence @__transform_main(%module: !transform.any_op) {
+    // Gather the set of functions within the module.
+    %funcs = transform.structured.match ops{["util.func"]} in %module : (!transform.any_op) -> !transform.any_op
+    // For each function in the module, run the matcher on all contained
+    // operations.
+    transform.foreach %funcs : !transform.any_op {
+      ^bb1(%func: !transform.any_op):
+        transform.foreach_match in %func
+          // <matcher name> -> <rewriter name>
+          // Multiple matcher-action pairs can be specified comma separated,
+          // here we are only doing a single kind of match and replace.
+          @match_mlp -> @cast_and_call_dag
+        : (!transform.any_op) -> (!transform.any_op)
+    }
+    // Cleanup leftover dead code; cast_and_call does not do replacement, only
+    // rewires uses.
+    transform.apply_dce to %module : !transform.any_op
+    transform.yield
+  }
+}

--- a/samples/custom_dispatch/cpu/mlp_plugin/mlp_spec_matmul.mlir
+++ b/samples/custom_dispatch/cpu/mlp_plugin/mlp_spec_matmul.mlir
@@ -99,6 +99,7 @@ module attributes {transform.with_named_sequence} {
     // Cleanup leftover dead code; cast_and_call does not do replacement, only
     // rewires uses.
     transform.apply_dce to %module : !transform.any_op
+    // Custom dispatch formation creates util.func ops that need to be inline
     transform.apply_registered_pass "inline" to %module : (!transform.any_op) -> !transform.any_op
     transform.yield
   }

--- a/samples/custom_dispatch/cpu/mlp_plugin/mlp_spec_matmul.mlir
+++ b/samples/custom_dispatch/cpu/mlp_plugin/mlp_spec_matmul.mlir
@@ -99,6 +99,7 @@ module attributes {transform.with_named_sequence} {
     // Cleanup leftover dead code; cast_and_call does not do replacement, only
     // rewires uses.
     transform.apply_dce to %module : !transform.any_op
+    transform.apply_registered_pass "inline" to %module : (!transform.any_op) -> !transform.any_op
     transform.yield
   }
 }


### PR DESCRIPTION
Adds an inliner pass that fixes https://github.com/iree-org/iree/issues/17327
Adds a mlp_spec transform dialect script that just matches matmuls and tests it on the existing two matmul linalg payload IR.
