### PR TITLE
Converting some runtime benchmarks to use our C API.

### DIFF
--- a/runtime/src/iree/base/internal/BUILD.bazel
+++ b/runtime/src/iree/base/internal/BUILD.bazel
@@ -199,8 +199,8 @@ cc_binary_benchmark(
     deps = [
         ":fpu_state",
         "//runtime/src/iree/base",
+        "//runtime/src/iree/testing:benchmark",
         "//runtime/src/iree/testing:benchmark_main",
-        "@com_google_benchmark//:benchmark",
     ],
 )
 

--- a/runtime/src/iree/base/internal/CMakeLists.txt
+++ b/runtime/src/iree/base/internal/CMakeLists.txt
@@ -206,8 +206,8 @@ iree_cc_binary_benchmark(
     "fpu_state_benchmark.cc"
   DEPS
     ::fpu_state
-    benchmark
     iree::base
+    iree::testing::benchmark
     iree::testing::benchmark_main
   TESTONLY
 )

--- a/runtime/src/iree/builtins/device/tools/libdevice_benchmark.c
+++ b/runtime/src/iree/builtins/device/tools/libdevice_benchmark.c
@@ -18,8 +18,7 @@ static iree_status_t iree_h2f_ieee_benchmark(
   while (iree_benchmark_keep_running(benchmark_state,
                                      /*batch_count=*/FLAG_batch_count)) {
     for (int i = 0; i < FLAG_batch_count; ++i) {
-      // TODO(benvanik): iree_do_not_optimize barrier.
-      iree_h2f_ieee(0x3400 + i);
+      iree_optimization_barrier(iree_h2f_ieee(0x3400 + i));
     }
   }
   return iree_ok_status();
@@ -31,8 +30,7 @@ static iree_status_t iree_f2h_ieee_benchmark(
   while (iree_benchmark_keep_running(benchmark_state,
                                      /*batch_count=*/FLAG_batch_count)) {
     for (int i = 0; i < FLAG_batch_count; ++i) {
-      // TODO(benvanik): iree_do_not_optimize barrier.
-      iree_f2h_ieee(0.25f + i);
+      iree_optimization_barrier(iree_f2h_ieee(0.25f + i));
     }
   }
   return iree_ok_status();

--- a/runtime/src/iree/testing/BUILD.bazel
+++ b/runtime/src/iree/testing/BUILD.bazel
@@ -24,6 +24,7 @@ iree_runtime_cc_library(
     ],
     deps = [
         "//runtime/src/iree/base",
+        "//runtime/src/iree/base/internal",
         "@com_google_benchmark//:benchmark",
     ],
 )

--- a/runtime/src/iree/testing/benchmark_nop.c
+++ b/runtime/src/iree/testing/benchmark_nop.c
@@ -7,6 +7,8 @@
 #include "iree/base/api.h"
 #include "iree/testing/benchmark.h"
 
+void iree_benchmark_use_ptr(char const volatile* x) {}
+
 int64_t iree_benchmark_get_range(iree_benchmark_state_t* state,
                                  iree_host_size_t ordinal) {
   return 0;
@@ -32,8 +34,14 @@ void iree_benchmark_set_bytes_processed(iree_benchmark_state_t* state,
 void iree_benchmark_set_items_processed(iree_benchmark_state_t* state,
                                         int64_t items) {}
 
-void iree_benchmark_register(iree_string_view_t name,
-                             const iree_benchmark_def_t* benchmark_def) {}
+const iree_benchmark_def_t* iree_benchmark_register(
+    iree_string_view_t name, const iree_benchmark_def_t* benchmark_def) {
+  return benchmark_def;
+}
+
+iree_benchmark_def_t* iree_make_function_benchmark(iree_benchmark_fn_t fn) {
+  return NULL;
+}
 
 void iree_benchmark_initialize(int* argc, char** argv) {}
 

--- a/runtime/src/iree/vm/BUILD.bazel
+++ b/runtime/src/iree/vm/BUILD.bazel
@@ -138,8 +138,8 @@ cc_binary_benchmark(
         ":impl",
         ":native_module_test_hdrs",
         "//runtime/src/iree/base",
+        "//runtime/src/iree/testing:benchmark",
         "//runtime/src/iree/testing:benchmark_main",
-        "@com_google_benchmark//:benchmark",
     ],
 )
 

--- a/runtime/src/iree/vm/CMakeLists.txt
+++ b/runtime/src/iree/vm/CMakeLists.txt
@@ -129,8 +129,8 @@ iree_cc_binary_benchmark(
   DEPS
     ::impl
     ::native_module_test_hdrs
-    benchmark
     iree::base
+    iree::testing::benchmark
     iree::testing::benchmark_main
   TESTONLY
 )

--- a/runtime/src/iree/vm/bytecode/BUILD.bazel
+++ b/runtime/src/iree/vm/bytecode/BUILD.bazel
@@ -87,9 +87,9 @@ cc_binary_benchmark(
         ":module",
         ":module_benchmark_module_c",
         "//runtime/src/iree/base",
+        "//runtime/src/iree/testing:benchmark",
         "//runtime/src/iree/testing:benchmark_main",
         "//runtime/src/iree/vm",
-        "@com_google_benchmark//:benchmark",
     ],
 )
 

--- a/runtime/src/iree/vm/bytecode/CMakeLists.txt
+++ b/runtime/src/iree/vm/bytecode/CMakeLists.txt
@@ -76,8 +76,8 @@ iree_cc_binary_benchmark(
   DEPS
     ::module
     ::module_benchmark_module_c
-    benchmark
     iree::base
+    iree::testing::benchmark
     iree::testing::benchmark_main
     iree::vm
   TESTONLY

--- a/runtime/src/iree/vm/native_module_benchmark.cc
+++ b/runtime/src/iree/vm/native_module_benchmark.cc
@@ -4,8 +4,8 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "benchmark/benchmark.h"
 #include "iree/base/api.h"
+#include "iree/testing/benchmark.h"
 #include "iree/vm/module.h"
 #include "iree/vm/native_module.h"
 #include "iree/vm/native_module_test.h"

--- a/runtime/src/iree/vm/native_module_test.h
+++ b/runtime/src/iree/vm/native_module_test.h
@@ -96,8 +96,8 @@ static iree_status_t module_a_sub_1(iree_vm_stack_t* stack, module_a_t* module,
 }
 
 static const iree_vm_native_export_descriptor_t module_a_exports_[] = {
-    {iree_make_cstring_view("add_1"), iree_make_cstring_view("0i_i"), 0, NULL},
-    {iree_make_cstring_view("sub_1"), iree_make_cstring_view("0i_i"), 0, NULL},
+    {IREE_SV("add_1"), IREE_SV("0i_i"), 0, NULL},
+    {IREE_SV("sub_1"), IREE_SV("0i_i"), 0, NULL},
 };
 static const iree_vm_native_function_ptr_t module_a_funcs_[] = {
     {(iree_vm_native_function_shim_t)call_shim_i32_i32,
@@ -109,7 +109,7 @@ static_assert(IREE_ARRAYSIZE(module_a_funcs_) ==
                   IREE_ARRAYSIZE(module_a_exports_),
               "function pointer table must be 1:1 with exports");
 static const iree_vm_native_module_descriptor_t module_a_descriptor_ = {
-    /*name=*/iree_make_cstring_view("module_a"),
+    /*name=*/IREE_SV("module_a"),
     /*version=*/0,
     /*attr_count=*/0,
     /*attrs=*/NULL,
@@ -244,24 +244,24 @@ static const iree_vm_native_function_ptr_t module_b_funcs_[] = {
 };
 
 static const iree_vm_native_import_descriptor_t module_b_imports_[] = {
-    {IREE_VM_NATIVE_IMPORT_REQUIRED, iree_make_cstring_view("module_a.add_1")},
-    {IREE_VM_NATIVE_IMPORT_REQUIRED, iree_make_cstring_view("module_a.sub_1")},
+    {IREE_VM_NATIVE_IMPORT_REQUIRED, IREE_SV("module_a.add_1")},
+    {IREE_VM_NATIVE_IMPORT_REQUIRED, IREE_SV("module_a.sub_1")},
 };
-static_assert(IREE_ARRAYSIZE(module_b_state_t::imports) ==
+static_assert(IREE_ARRAYSIZE(((module_b_state_t*)NULL)->imports) ==
                   IREE_ARRAYSIZE(module_b_imports_),
               "import storage must be able to hold all imports");
 static const iree_string_pair_t module_b_entry_attrs_[] = {
-    {iree_make_cstring_view("key1"), iree_make_cstring_view("value1")},
+    {IREE_SV("key1"), IREE_SV("value1")},
 };
 static const iree_vm_native_export_descriptor_t module_b_exports_[] = {
-    {iree_make_cstring_view("entry"), iree_make_cstring_view("0i_i"),
-     IREE_ARRAYSIZE(module_b_entry_attrs_), module_b_entry_attrs_},
+    {IREE_SV("entry"), IREE_SV("0i_i"), IREE_ARRAYSIZE(module_b_entry_attrs_),
+     module_b_entry_attrs_},
 };
 static_assert(IREE_ARRAYSIZE(module_b_funcs_) ==
                   IREE_ARRAYSIZE(module_b_exports_),
               "function pointer table must be 1:1 with exports");
 static const iree_vm_native_module_descriptor_t module_b_descriptor_ = {
-    /*name=*/iree_make_cstring_view("module_b"),
+    /*name=*/IREE_SV("module_b"),
     /*version=*/0,
     /*attr_count=*/0,
     /*attrs=*/NULL,


### PR DESCRIPTION
The API is incomplete and only works from C++ today but allows us to hide the google benchmark dependency behind the iree::testing::benchmark library. Some bazel/cmake goo can be used to switch off the google benchmark library and no-op it (until we have an embedded-friendly impl) but that's left as future work.

This should make solving what #16110 was doing much easier.