### PR TITLE
Rename bump-torch-mlir-submodule branch to integrates/torch-mlir.

### DIFF
--- a/.github/workflows/bump_torch_mlir.yml
+++ b/.github/workflows/bump_torch_mlir.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           base: main
-          branch: bump-torch-mlir-submodule
+          branch: integrates/torch-mlir
           delete-branch: true # automatically supercedes the previous bump
           title: 'Bump torch-mlir submodule to ${{ steps.bump_submodule.outputs.TORCH_MLIR_COMMIT }}'
           body: |


### PR DESCRIPTION
This new branch name is in line with the policy being proposed at https://github.com/iree-org/iree/pull/17335

skip-ci: this doesn't affect CI