### PR TITLE
[NFC] Fixing stray space and unneeded modules in some lit tests.

### DIFF
--- a/compiler/plugins/input/Torch/InputConversion/test/assume_strict_symbols.mlir
+++ b/compiler/plugins/input/Torch/InputConversion/test/assume_strict_symbols.mlir
@@ -1,14 +1,12 @@
 // RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(torch-iree-set-strict-symbolic-shapes))" %s | FileCheck %s
 
-module {
-  // CHECK: func @forward() {{.*}} attributes {torch.assume_strict_symbolic_shapes}
-  func.func @forward() -> !torch.int {
-    %int0 = torch.constant.int 0
-    return %int0 : !torch.int
-  }
-  // CHECK: func @other_forward() {{.*}} attributes {torch.assume_strict_symbolic_shapes}
-  func.func @other_forward() -> !torch.int {
-    %int1 = torch.constant.int 1
-    return %int1 : !torch.int
-  }
+// CHECK: func @forward() {{.*}} attributes {torch.assume_strict_symbolic_shapes}
+func.func @forward() -> !torch.int {
+  %int0 = torch.constant.int 0
+  return %int0 : !torch.int
+}
+// CHECK: func @other_forward() {{.*}} attributes {torch.assume_strict_symbolic_shapes}
+func.func @other_forward() -> !torch.int {
+  %int1 = torch.constant.int 1
+  return %int1 : !torch.int
 }

--- a/compiler/plugins/input/Torch/InputConversion/test/torch_to_iree.mlir
+++ b/compiler/plugins/input/Torch/InputConversion/test/torch_to_iree.mlir
@@ -6,50 +6,46 @@
 // properly.
 // CHECK-LABEL: util.func public @forward$async(%arg0: !hal.buffer_view, %arg1: !hal.fence, %arg2: !hal.fence) -> !hal.buffer_view
 // CHECK: linalg.matmul
-module {
-  func.func @forward(%arg0: !torch.vtensor<[128,20],f32>) -> !torch.vtensor<[128,30],f32> {
-    %_params.classifier.weight = util.global.load @_params.classifier.weight : tensor<30x20xf32>
-    %0 = torch_c.from_builtin_tensor %_params.classifier.weight : tensor<30x20xf32> -> !torch.vtensor<[30,20],f32>
-    %int0 = torch.constant.int 0
-    %int1 = torch.constant.int 1
-    %1 = torch.aten.transpose.int %0, %int0, %int1 : !torch.vtensor<[30,20],f32>, !torch.int, !torch.int -> !torch.vtensor<[20,30],f32>
-    %2 = torch.aten.mm %arg0, %1 : !torch.vtensor<[128,20],f32>, !torch.vtensor<[20,30],f32> -> !torch.vtensor<[128,30],f32>
-    %int1_0 = torch.constant.int 1
-    %3 = torch.aten.mul.Scalar %2, %int1_0 : !torch.vtensor<[128,30],f32>, !torch.int -> !torch.vtensor<[128,30],f32>
-    %_params.classifier.bias = util.global.load @_params.classifier.bias : tensor<30xf32>
-    %4 = torch_c.from_builtin_tensor %_params.classifier.bias : tensor<30xf32> -> !torch.vtensor<[30],f32>
-    %int1_1 = torch.constant.int 1
-    %5 = torch.aten.mul.Scalar %4, %int1_1 : !torch.vtensor<[30],f32>, !torch.int -> !torch.vtensor<[30],f32>
-    %int1_2 = torch.constant.int 1
-    %6 = torch.aten.add.Tensor %3, %5, %int1_2 : !torch.vtensor<[128,30],f32>, !torch.vtensor<[30],f32>, !torch.int -> !torch.vtensor<[128,30],f32>
-    return %6 : !torch.vtensor<[128,30],f32>
-  }
-  util.global private @_params.classifier.weight {inlining_policy = #util.inline.never} : tensor<30x20xf32>
-  util.global private @_params.classifier.bias {inlining_policy = #util.inline.never} : tensor<30xf32>
+func.func @forward(%arg0: !torch.vtensor<[128,20],f32>) -> !torch.vtensor<[128,30],f32> {
+  %_params.classifier.weight = util.global.load @_params.classifier.weight : tensor<30x20xf32>
+  %0 = torch_c.from_builtin_tensor %_params.classifier.weight : tensor<30x20xf32> -> !torch.vtensor<[30,20],f32>
+  %int0 = torch.constant.int 0
+  %int1 = torch.constant.int 1
+  %1 = torch.aten.transpose.int %0, %int0, %int1 : !torch.vtensor<[30,20],f32>, !torch.int, !torch.int -> !torch.vtensor<[20,30],f32>
+  %2 = torch.aten.mm %arg0, %1 : !torch.vtensor<[128,20],f32>, !torch.vtensor<[20,30],f32> -> !torch.vtensor<[128,30],f32>
+  %int1_0 = torch.constant.int 1
+  %3 = torch.aten.mul.Scalar %2, %int1_0 : !torch.vtensor<[128,30],f32>, !torch.int -> !torch.vtensor<[128,30],f32>
+  %_params.classifier.bias = util.global.load @_params.classifier.bias : tensor<30xf32>
+  %4 = torch_c.from_builtin_tensor %_params.classifier.bias : tensor<30xf32> -> !torch.vtensor<[30],f32>
+  %int1_1 = torch.constant.int 1
+  %5 = torch.aten.mul.Scalar %4, %int1_1 : !torch.vtensor<[30],f32>, !torch.int -> !torch.vtensor<[30],f32>
+  %int1_2 = torch.constant.int 1
+  %6 = torch.aten.add.Tensor %3, %5, %int1_2 : !torch.vtensor<[128,30],f32>, !torch.vtensor<[30],f32>, !torch.int -> !torch.vtensor<[128,30],f32>
+  return %6 : !torch.vtensor<[128,30],f32>
 }
+util.global private @_params.classifier.weight {inlining_policy = #util.inline.never} : tensor<30x20xf32>
+util.global private @_params.classifier.bias {inlining_policy = #util.inline.never} : tensor<30xf32>
 
 // -----
 
 // Verify we can decompose complex ops
 // CHECK-LABEL: util.func public @main$async(%arg0: !hal.buffer_view, %arg1: !hal.fence, %arg2: !hal.fence) -> (!hal.buffer_view, !hal.buffer_view)
 // CHECK: tensor.empty
-module {
-  func.func @main(%arg0: !torch.vtensor<[2,3,4],f32>) -> (!torch.vtensor<[2,3,4],f32>, !torch.vtensor<[2,3,4],f32>) {
-    %int2 = torch.constant.int 2
-    %int3 = torch.constant.int 3
-    %int4 = torch.constant.int 4
-    %0 = torch.prim.ListConstruct %int2, %int3, %int4 : (!torch.int, !torch.int, !torch.int) -> !torch.list<int>
-    %int12 = torch.constant.int 12
-    %int4_0 = torch.constant.int 4
-    %int1 = torch.constant.int 1
-    %1 = torch.prim.ListConstruct %int12, %int4_0, %int1 : (!torch.int, !torch.int, !torch.int) -> !torch.list<int>
-    %none = torch.constant.none
-    %none_1 = torch.constant.none    
-    %cpu = torch.constant.device "cpu"
-    %false = torch.constant.bool false
-    %2 = torch.aten.empty_strided %0, %1, %none, %none_1, %cpu, %false : !torch.list<int>, !torch.list<int>, !torch.none, !torch.none, !torch.Device, !torch.bool -> !torch.vtensor<[2,3,4],f32>
-    %false_2 = torch.constant.bool false
-    %3 = torch.aten.copy %arg0, %2, %false_2 : !torch.vtensor<[2,3,4],f32>, !torch.vtensor<[2,3,4],f32>, !torch.bool -> !torch.vtensor<[2,3,4],f32>
-    return %3, %3 : !torch.vtensor<[2,3,4],f32>, !torch.vtensor<[2,3,4],f32>
-  }
+func.func @main(%arg0: !torch.vtensor<[2,3,4],f32>) -> (!torch.vtensor<[2,3,4],f32>, !torch.vtensor<[2,3,4],f32>) {
+  %int2 = torch.constant.int 2
+  %int3 = torch.constant.int 3
+  %int4 = torch.constant.int 4
+  %0 = torch.prim.ListConstruct %int2, %int3, %int4 : (!torch.int, !torch.int, !torch.int) -> !torch.list<int>
+  %int12 = torch.constant.int 12
+  %int4_0 = torch.constant.int 4
+  %int1 = torch.constant.int 1
+  %1 = torch.prim.ListConstruct %int12, %int4_0, %int1 : (!torch.int, !torch.int, !torch.int) -> !torch.list<int>
+  %none = torch.constant.none
+  %none_1 = torch.constant.none
+  %cpu = torch.constant.device "cpu"
+  %false = torch.constant.bool false
+  %2 = torch.aten.empty_strided %0, %1, %none, %none_1, %cpu, %false : !torch.list<int>, !torch.list<int>, !torch.none, !torch.none, !torch.Device, !torch.bool -> !torch.vtensor<[2,3,4],f32>
+  %false_2 = torch.constant.bool false
+  %3 = torch.aten.copy %arg0, %2, %false_2 : !torch.vtensor<[2,3,4],f32>, !torch.vtensor<[2,3,4],f32>, !torch.bool -> !torch.vtensor<[2,3,4],f32>
+  return %3, %3 : !torch.vtensor<[2,3,4],f32>, !torch.vtensor<[2,3,4],f32>
 }

--- a/compiler/src/iree/compiler/Codegen/VMVX/test/pipeline.mlir
+++ b/compiler/src/iree/compiler/Codegen/VMVX/test/pipeline.mlir
@@ -5,31 +5,29 @@
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
 #map3 = affine_map<()[s0] -> (16 ceildiv s0)>
-module {
-  func.func @mmt4d_i8() attributes {hal.executable.target = #executable_target_vmvx_bytecode_fb} {
-    %c0 = arith.constant 0 : index
-    %c256 = arith.constant 256 : index
-    %c512 = arith.constant 512 : index
-    %c16 = arith.constant 16 : index
-    %0:2 = iree_codegen.query_tile_sizes tensor<16x16xi8, #iree_encoding.encoding<role =  LHS, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2]>> -> index, index
-    %1 = affine.apply #map3()[%0#0]
-    %2 = affine.apply #map3()[%0#1]
-    %3 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<?x?x?x?xi8>>{%1, %2, %0#0, %0#1}
-    %4:2 = iree_codegen.query_tile_sizes tensor<16x16xi8, #iree_encoding.encoding<role =  RHS, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2]>> -> index, index
-    %5 = affine.apply #map3()[%4#0]
-    %6 = affine.apply #map3()[%4#1]
-    %7 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c256) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<?x?x?x?xi8>>{%5, %6, %4#0, %4#1}
-    %8:2 = iree_codegen.query_tile_sizes tensor<16x16xi32, #iree_encoding.encoding<role =  RESULT, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2]>> -> index, index
-    %9 = affine.apply #map3()[%8#0]
-    %10 = affine.apply #map3()[%8#1]
-    %11 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c512) : !flow.dispatch.tensor<readwrite:tensor<?x?x?x?xi32>>{%9, %10, %8#0, %8#1}
-    %12 = flow.dispatch.tensor.load %3, offsets = [0, 0, 0, 0], sizes = [%1, %2, %0#0, %0#1], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<?x?x?x?xi8>>{%1, %2, %0#0, %0#1} -> tensor<?x?x?x?xi8>
-    %13 = flow.dispatch.tensor.load %7, offsets = [0, 0, 0, 0], sizes = [%5, %6, %4#0, %4#1], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<?x?x?x?xi8>>{%5, %6, %4#0, %4#1} -> tensor<?x?x?x?xi8>
-    %14 = flow.dispatch.tensor.load %11, offsets = [0, 0, 0, 0], sizes = [%9, %10, %8#0, %8#1], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readwrite:tensor<?x?x?x?xi32>>{%9, %10, %8#0, %8#1} -> tensor<?x?x?x?xi32>
-    %15 = linalg.mmt4d ins(%12, %13 : tensor<?x?x?x?xi8>, tensor<?x?x?x?xi8>) outs(%14 : tensor<?x?x?x?xi32>) -> tensor<?x?x?x?xi32>
-    flow.dispatch.tensor.store %15, %11, offsets = [0, 0, 0, 0], sizes = [%9, %10, %8#0, %8#1], strides = [1, 1, 1, 1] : tensor<?x?x?x?xi32> -> !flow.dispatch.tensor<readwrite:tensor<?x?x?x?xi32>>{%9, %10, %8#0, %8#1}
-    return
-  }
+func.func @mmt4d_i8() attributes {hal.executable.target = #executable_target_vmvx_bytecode_fb} {
+  %c0 = arith.constant 0 : index
+  %c256 = arith.constant 256 : index
+  %c512 = arith.constant 512 : index
+  %c16 = arith.constant 16 : index
+  %0:2 = iree_codegen.query_tile_sizes tensor<16x16xi8, #iree_encoding.encoding<role =  LHS, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2]>> -> index, index
+  %1 = affine.apply #map3()[%0#0]
+  %2 = affine.apply #map3()[%0#1]
+  %3 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<?x?x?x?xi8>>{%1, %2, %0#0, %0#1}
+  %4:2 = iree_codegen.query_tile_sizes tensor<16x16xi8, #iree_encoding.encoding<role =  RHS, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2]>> -> index, index
+  %5 = affine.apply #map3()[%4#0]
+  %6 = affine.apply #map3()[%4#1]
+  %7 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c256) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<?x?x?x?xi8>>{%5, %6, %4#0, %4#1}
+  %8:2 = iree_codegen.query_tile_sizes tensor<16x16xi32, #iree_encoding.encoding<role =  RESULT, element_types = [i8, i8, i32], user_indexing_maps = [#map, #map1, #map2]>> -> index, index
+  %9 = affine.apply #map3()[%8#0]
+  %10 = affine.apply #map3()[%8#1]
+  %11 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c512) : !flow.dispatch.tensor<readwrite:tensor<?x?x?x?xi32>>{%9, %10, %8#0, %8#1}
+  %12 = flow.dispatch.tensor.load %3, offsets = [0, 0, 0, 0], sizes = [%1, %2, %0#0, %0#1], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<?x?x?x?xi8>>{%1, %2, %0#0, %0#1} -> tensor<?x?x?x?xi8>
+  %13 = flow.dispatch.tensor.load %7, offsets = [0, 0, 0, 0], sizes = [%5, %6, %4#0, %4#1], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<?x?x?x?xi8>>{%5, %6, %4#0, %4#1} -> tensor<?x?x?x?xi8>
+  %14 = flow.dispatch.tensor.load %11, offsets = [0, 0, 0, 0], sizes = [%9, %10, %8#0, %8#1], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readwrite:tensor<?x?x?x?xi32>>{%9, %10, %8#0, %8#1} -> tensor<?x?x?x?xi32>
+  %15 = linalg.mmt4d ins(%12, %13 : tensor<?x?x?x?xi8>, tensor<?x?x?x?xi8>) outs(%14 : tensor<?x?x?x?xi32>) -> tensor<?x?x?x?xi32>
+  flow.dispatch.tensor.store %15, %11, offsets = [0, 0, 0, 0], sizes = [%9, %10, %8#0, %8#1], strides = [1, 1, 1, 1] : tensor<?x?x?x?xi32> -> !flow.dispatch.tensor<readwrite:tensor<?x?x?x?xi32>>{%9, %10, %8#0, %8#1}
+  return
 }
 // CHECK: func @mmt4d_i8()
 // CHECK:   iree_codegen.ukernel.generic "vmvx.mmt4d"

--- a/compiler/src/iree/compiler/Codegen/VMVX/test/select_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/VMVX/test/select_lowering_strategy.mlir
@@ -1,20 +1,18 @@
 // RUN: iree-opt -pass-pipeline='builtin.module(iree-vmvx-select-lowering-strategy)' -split-input-file %s | FileCheck %s
 
 #executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb">
-module {
-  func.func @matmul_static() attributes {hal.executable.target = #executable_target_vmvx_bytecode_fb} {
-    %cst = arith.constant 0.000000e+00 : f32
-    %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<384x512xf32>>
-    %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<512x128xf32>>
-    %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : !flow.dispatch.tensor<writeonly:tensor<384x128xf32>>
-    %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [384, 512], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<384x512xf32>> -> tensor<384x512xf32>
-    %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [512, 128], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<512x128xf32>> -> tensor<512x128xf32>
-    %5 = tensor.empty() : tensor<384x128xf32>
-    %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<384x128xf32>) -> tensor<384x128xf32>
-    %7 = linalg.matmul ins(%3, %4 : tensor<384x512xf32>, tensor<512x128xf32>) outs(%6 : tensor<384x128xf32>) -> tensor<384x128xf32>
-    flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [384, 128], strides = [1, 1] : tensor<384x128xf32> -> !flow.dispatch.tensor<writeonly:tensor<384x128xf32>>
-    return
-  }
+func.func @matmul_static() attributes {hal.executable.target = #executable_target_vmvx_bytecode_fb} {
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<384x512xf32>>
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<512x128xf32>>
+  %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : !flow.dispatch.tensor<writeonly:tensor<384x128xf32>>
+  %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [384, 512], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<384x512xf32>> -> tensor<384x512xf32>
+  %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [512, 128], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<512x128xf32>> -> tensor<512x128xf32>
+  %5 = tensor.empty() : tensor<384x128xf32>
+  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<384x128xf32>) -> tensor<384x128xf32>
+  %7 = linalg.matmul ins(%3, %4 : tensor<384x512xf32>, tensor<512x128xf32>) outs(%6 : tensor<384x128xf32>) -> tensor<384x128xf32>
+  flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [384, 128], strides = [1, 1] : tensor<384x128xf32> -> !flow.dispatch.tensor<writeonly:tensor<384x128xf32>>
+  return
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] =  #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64, 0]]>
@@ -28,23 +26,21 @@ module {
 
 #executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb">
 #map = affine_map<(d0, d1) -> (d0, d1)>
-module {
-  func.func @copy_op_dynamic() attributes {hal.executable.target = #executable_target_vmvx_bytecode_fb} {
-    %0 = hal.interface.constant.load[0] : index
-    %1 = hal.interface.constant.load[1] : index
-    %2 = hal.interface.constant.load[2] : index
-    %3 = hal.interface.constant.load[3] : index
-    %4 = hal.interface.constant.load[4] : index
-    %5 = hal.interface.constant.load[5] : index
-    %6 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<?x?xi32>{%0, %1}
-    %7 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<?x?xi32>{%2, %3}
-    %subview = memref.subview %7[%4, %5] [%0, %1] [1, 1] : memref<?x?xi32> to memref<?x?xi32, strided<[?, 1], offset: ?>>
-    linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%6 : memref<?x?xi32>) outs(%subview : memref<?x?xi32, strided<[?, 1], offset: ?>>) {
-    ^bb0(%in: i32, %out: i32):
-      linalg.yield %in : i32
-    }
-    return
+func.func @copy_op_dynamic() attributes {hal.executable.target = #executable_target_vmvx_bytecode_fb} {
+  %0 = hal.interface.constant.load[0] : index
+  %1 = hal.interface.constant.load[1] : index
+  %2 = hal.interface.constant.load[2] : index
+  %3 = hal.interface.constant.load[3] : index
+  %4 = hal.interface.constant.load[4] : index
+  %5 = hal.interface.constant.load[5] : index
+  %6 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<?x?xi32>{%0, %1}
+  %7 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<?x?xi32>{%2, %3}
+  %subview = memref.subview %7[%4, %5] [%0, %1] [1, 1] : memref<?x?xi32> to memref<?x?xi32, strided<[?, 1], offset: ?>>
+  linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%6 : memref<?x?xi32>) outs(%subview : memref<?x?xi32, strided<[?, 1], offset: ?>>) {
+  ^bb0(%in: i32, %out: i32):
+    linalg.yield %in : i32
   }
+  return
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64]]>
@@ -57,23 +53,20 @@ module {
 // -----
 
 #executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb">
-module {
-  func.func @static_1d_fft_stage2() attributes {hal.executable.target = #executable_target_vmvx_bytecode_fb} {
-    %c0 = arith.constant 0 : index
-    %c2 = arith.constant 2 : index
-    %cst = arith.constant dense<[1.000000e+00, 6.12323426E-17]> : tensor<2xf32>
-    %cst_0 = arith.constant dense<[-0.000000e+00, -1.000000e+00]> : tensor<2xf32>
-    %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readwrite:tensor<32xf32>>
-    %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<readwrite:tensor<32xf32>>
-    %2 = flow.dispatch.tensor.load %0, offsets = [0], sizes = [32], strides = [1] : !flow.dispatch.tensor<readwrite:tensor<32xf32>> -> tensor<32xf32>
-    %3 = flow.dispatch.tensor.load %1, offsets = [0], sizes = [32], strides = [1] : !flow.dispatch.tensor<readwrite:tensor<32xf32>> -> tensor<32xf32>
-    %4:2 = iree_linalg_ext.fft ins(%c2, %cst, %cst_0 : index, tensor<2xf32>, tensor<2xf32>) outs(%2, %3 : tensor<32xf32>, tensor<32xf32>) : tensor<32xf32>, tensor<32xf32>
-    flow.dispatch.tensor.store %4#0, %0, offsets = [0], sizes = [32], strides = [1] : tensor<32xf32> -> !flow.dispatch.tensor<readwrite:tensor<32xf32>>
-    flow.dispatch.tensor.store %4#1, %1, offsets = [0], sizes = [32], strides = [1] : tensor<32xf32> -> !flow.dispatch.tensor<readwrite:tensor<32xf32>>
-    return
-  }
+func.func @static_1d_fft_stage2() attributes {hal.executable.target = #executable_target_vmvx_bytecode_fb} {
+  %c0 = arith.constant 0 : index
+  %c2 = arith.constant 2 : index
+  %cst = arith.constant dense<[1.000000e+00, 6.12323426E-17]> : tensor<2xf32>
+  %cst_0 = arith.constant dense<[-0.000000e+00, -1.000000e+00]> : tensor<2xf32>
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readwrite:tensor<32xf32>>
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<readwrite:tensor<32xf32>>
+  %2 = flow.dispatch.tensor.load %0, offsets = [0], sizes = [32], strides = [1] : !flow.dispatch.tensor<readwrite:tensor<32xf32>> -> tensor<32xf32>
+  %3 = flow.dispatch.tensor.load %1, offsets = [0], sizes = [32], strides = [1] : !flow.dispatch.tensor<readwrite:tensor<32xf32>> -> tensor<32xf32>
+  %4:2 = iree_linalg_ext.fft ins(%c2, %cst, %cst_0 : index, tensor<2xf32>, tensor<2xf32>) outs(%2, %3 : tensor<32xf32>, tensor<32xf32>) : tensor<32xf32>, tensor<32xf32>
+  flow.dispatch.tensor.store %4#0, %0, offsets = [0], sizes = [32], strides = [1] : tensor<32xf32> -> !flow.dispatch.tensor<readwrite:tensor<32xf32>>
+  flow.dispatch.tensor.store %4#1, %1, offsets = [0], sizes = [32], strides = [1] : tensor<32xf32> -> !flow.dispatch.tensor<readwrite:tensor<32xf32>>
+  return
 }
-
 
 //   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64]{{\]}}>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<VMVXDefault>
@@ -87,47 +80,45 @@ module {
 #executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb">
 #map = affine_map<(d0, d1) -> (d1)>
 #map1 = affine_map<(d0, d1) -> (d0, d1)>
-module {
-  func.func @fusion_quant_matmul_generic() attributes {hal.executable.target = #executable_target_vmvx_bytecode_fb} {
-    %c0_i32 = arith.constant 0 : i32
-    %c-128_i32 = arith.constant -128 : i32
-    %c1101627623_i32 = arith.constant 1101627623 : i32
-    %c36_i8 = arith.constant 36 : i8
-    %c127_i32 = arith.constant 127 : i32
-    %c107520 = arith.constant 107520 : index
-    %c0 = arith.constant 0 : index
-    %0 = hal.interface.constant.load[0] : i32
-    %1 = arith.index_castui %0 : i32 to index
-    %2 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<3360x32xi8>>
-    %3 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<32xi32>>
-    %4 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c107520) : !flow.dispatch.tensor<readonly:tensor<32xi32>>
-    %5 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<?x3360xi8>>{%1}
-    %6 = hal.interface.binding.subspan set(0) binding(3) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<?x32xi8>>{%1}
-    %7 = flow.dispatch.tensor.load %5, offsets = [0, 0], sizes = [%1, 3360], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<?x3360xi8>>{%1} -> tensor<?x3360xi8>
-    %8 = flow.dispatch.tensor.load %2, offsets = [0, 0], sizes = [3360, 32], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<3360x32xi8>> -> tensor<3360x32xi8>
-    %9 = flow.dispatch.tensor.load %3, offsets = [0], sizes = [32], strides = [1] : !flow.dispatch.tensor<readonly:tensor<32xi32>> -> tensor<32xi32>
-    %10 = flow.dispatch.tensor.load %4, offsets = [0], sizes = [32], strides = [1] : !flow.dispatch.tensor<readonly:tensor<32xi32>> -> tensor<32xi32>
-    %11 = tensor.empty(%1) : tensor<?x32xi8>
-    %12 = tensor.empty(%1) : tensor<?x32xi32>
-    %13 = linalg.fill ins(%c0_i32 : i32) outs(%12 : tensor<?x32xi32>) -> tensor<?x32xi32>
-    %14 = linalg.matmul ins(%7, %8 : tensor<?x3360xi8>, tensor<3360x32xi8>) outs(%13 : tensor<?x32xi32>) -> tensor<?x32xi32>
-    %15 = linalg.generic {indexing_maps = [#map, #map1, #map, #map1], iterator_types = ["parallel", "parallel"]} ins(%9, %14, %10 : tensor<32xi32>, tensor<?x32xi32>, tensor<32xi32>) outs(%11 : tensor<?x32xi8>) {
-    ^bb0(%in: i32, %in_0: i32, %in_1: i32, %out: i8):
-      %16 = arith.muli %in_1, %c-128_i32 : i32
-      %17 = arith.subi %in_0, %16 : i32
-      %18 = arith.addi %in, %17 : i32
-      %19 = tosa.apply_scale %18, %c1101627623_i32, %c36_i8 {double_round = true} : (i32, i32, i8) -> i32
-      %20 = arith.addi %19, %c-128_i32 : i32
-      %21 = arith.cmpi slt, %20, %c-128_i32 : i32
-      %22 = arith.select %21, %c-128_i32, %20 : i32
-      %23 = arith.cmpi sgt, %20, %c127_i32 : i32
-      %24 = arith.select %23, %c127_i32, %22 : i32
-      %25 = arith.trunci %24 : i32 to i8
-      linalg.yield %25 : i8
-    } -> tensor<?x32xi8>
-    flow.dispatch.tensor.store %15, %6, offsets = [0, 0], sizes = [%1, 32], strides = [1, 1] : tensor<?x32xi8> -> !flow.dispatch.tensor<writeonly:tensor<?x32xi8>>{%1}
-    return
-  }
+func.func @fusion_quant_matmul_generic() attributes {hal.executable.target = #executable_target_vmvx_bytecode_fb} {
+  %c0_i32 = arith.constant 0 : i32
+  %c-128_i32 = arith.constant -128 : i32
+  %c1101627623_i32 = arith.constant 1101627623 : i32
+  %c36_i8 = arith.constant 36 : i8
+  %c127_i32 = arith.constant 127 : i32
+  %c107520 = arith.constant 107520 : index
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.constant.load[0] : i32
+  %1 = arith.index_castui %0 : i32 to index
+  %2 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<3360x32xi8>>
+  %3 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<32xi32>>
+  %4 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c107520) : !flow.dispatch.tensor<readonly:tensor<32xi32>>
+  %5 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<?x3360xi8>>{%1}
+  %6 = hal.interface.binding.subspan set(0) binding(3) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<?x32xi8>>{%1}
+  %7 = flow.dispatch.tensor.load %5, offsets = [0, 0], sizes = [%1, 3360], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<?x3360xi8>>{%1} -> tensor<?x3360xi8>
+  %8 = flow.dispatch.tensor.load %2, offsets = [0, 0], sizes = [3360, 32], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<3360x32xi8>> -> tensor<3360x32xi8>
+  %9 = flow.dispatch.tensor.load %3, offsets = [0], sizes = [32], strides = [1] : !flow.dispatch.tensor<readonly:tensor<32xi32>> -> tensor<32xi32>
+  %10 = flow.dispatch.tensor.load %4, offsets = [0], sizes = [32], strides = [1] : !flow.dispatch.tensor<readonly:tensor<32xi32>> -> tensor<32xi32>
+  %11 = tensor.empty(%1) : tensor<?x32xi8>
+  %12 = tensor.empty(%1) : tensor<?x32xi32>
+  %13 = linalg.fill ins(%c0_i32 : i32) outs(%12 : tensor<?x32xi32>) -> tensor<?x32xi32>
+  %14 = linalg.matmul ins(%7, %8 : tensor<?x3360xi8>, tensor<3360x32xi8>) outs(%13 : tensor<?x32xi32>) -> tensor<?x32xi32>
+  %15 = linalg.generic {indexing_maps = [#map, #map1, #map, #map1], iterator_types = ["parallel", "parallel"]} ins(%9, %14, %10 : tensor<32xi32>, tensor<?x32xi32>, tensor<32xi32>) outs(%11 : tensor<?x32xi8>) {
+  ^bb0(%in: i32, %in_0: i32, %in_1: i32, %out: i8):
+    %16 = arith.muli %in_1, %c-128_i32 : i32
+    %17 = arith.subi %in_0, %16 : i32
+    %18 = arith.addi %in, %17 : i32
+    %19 = tosa.apply_scale %18, %c1101627623_i32, %c36_i8 {double_round = true} : (i32, i32, i8) -> i32
+    %20 = arith.addi %19, %c-128_i32 : i32
+    %21 = arith.cmpi slt, %20, %c-128_i32 : i32
+    %22 = arith.select %21, %c-128_i32, %20 : i32
+    %23 = arith.cmpi sgt, %20, %c127_i32 : i32
+    %24 = arith.select %23, %c127_i32, %22 : i32
+    %25 = arith.trunci %24 : i32 to i8
+    linalg.yield %25 : i8
+  } -> tensor<?x32xi8>
+  flow.dispatch.tensor.store %15, %6, offsets = [0, 0], sizes = [%1, 32], strides = [1, 1] : tensor<?x32xi8> -> !flow.dispatch.tensor<writeonly:tensor<?x32xi8>>{%1}
+  return
 }
 
 //   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64, 0]]>
@@ -140,26 +131,24 @@ module {
 // -----
 
 #executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb">
-module {
-  func.func @unpack_outer_dynamic() attributes {hal.executable.target = #executable_target_vmvx_bytecode_fb} {
-    %c131072 = arith.constant 131072 : index
-    %c0 = arith.constant 0 : index
-    %0 = hal.interface.constant.load[0] : i32
-    %1 = hal.interface.constant.load[1] : i32
-    %2 = hal.interface.constant.load[2] : i32
-    %3 = hal.interface.constant.load[3] : i32
-    %4 = arith.index_castui %0 : i32 to index
-    %5 = arith.index_castui %1 : i32 to index
-    %6 = arith.index_castui %2 : i32 to index
-    %7 = arith.index_castui %3 : i32 to index
-    %8 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<?x?x32x16xi32>>{%4, %5}
-    %9 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c131072) : !flow.dispatch.tensor<writeonly:tensor<?x?xi32>>{%6, %7}
-    %10 = flow.dispatch.tensor.load %8, offsets = [0, 0, 0, 0], sizes = [%4, %5, 32, 16], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<?x?x32x16xi32>>{%4, %5} -> tensor<?x?x32x16xi32>
-    %11 = tensor.empty(%6, %7) : tensor<?x?xi32>
-    %unpack = tensor.unpack %10 inner_dims_pos = [0, 1] inner_tiles = [32, 16] into %11 : tensor<?x?x32x16xi32> -> tensor<?x?xi32>
-    flow.dispatch.tensor.store %unpack, %9, offsets = [0, 0], sizes = [%6, %7], strides = [1, 1] : tensor<?x?xi32> -> !flow.dispatch.tensor<writeonly:tensor<?x?xi32>>{%6, %7}
-    return
-  }
+func.func @unpack_outer_dynamic() attributes {hal.executable.target = #executable_target_vmvx_bytecode_fb} {
+  %c131072 = arith.constant 131072 : index
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.constant.load[0] : i32
+  %1 = hal.interface.constant.load[1] : i32
+  %2 = hal.interface.constant.load[2] : i32
+  %3 = hal.interface.constant.load[3] : i32
+  %4 = arith.index_castui %0 : i32 to index
+  %5 = arith.index_castui %1 : i32 to index
+  %6 = arith.index_castui %2 : i32 to index
+  %7 = arith.index_castui %3 : i32 to index
+  %8 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<?x?x32x16xi32>>{%4, %5}
+  %9 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c131072) : !flow.dispatch.tensor<writeonly:tensor<?x?xi32>>{%6, %7}
+  %10 = flow.dispatch.tensor.load %8, offsets = [0, 0, 0, 0], sizes = [%4, %5, 32, 16], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<?x?x32x16xi32>>{%4, %5} -> tensor<?x?x32x16xi32>
+  %11 = tensor.empty(%6, %7) : tensor<?x?xi32>
+  %unpack = tensor.unpack %10 inner_dims_pos = [0, 1] inner_tiles = [32, 16] into %11 : tensor<?x?x32x16xi32> -> tensor<?x?xi32>
+  flow.dispatch.tensor.store %unpack, %9, offsets = [0, 0], sizes = [%6, %7], strides = [1, 1] : tensor<?x?xi32> -> !flow.dispatch.tensor<writeonly:tensor<?x?xi32>>{%6, %7}
+  return
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64]]>
@@ -175,33 +164,31 @@ module {
 #map = affine_map<()[s0] -> (1024 ceildiv s0)>
 #map1 = affine_map<()[s0] -> (2048 ceildiv s0)>
 #map2 = affine_map<(d0, d1) -> (d0, d1)>
-module {
-  func.func @elem_pack_ukernels() attributes {hal.executable.target = #executable_target_vmvx_bytecode_fb} {
-    %cst = arith.constant 0.000000e+00 : f32
-    %c0 = arith.constant 0 : index
-    %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<1024x2048xf32>>
-    %1:2 = iree_codegen.query_tile_sizes tensor<1024x2048xf32, #iree_encoding.encoding<role =  LHS, element_types = [f32, f32, f32], original_type = tensor<1024x2048xf32>>> -> index, index
-    %2 = affine.apply #map()[%1#0]
-    %3 = affine.apply #map1()[%1#1]
-    %4 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<?x?x?x?xf32>>{%2, %3, %1#0, %1#1}
-    %5 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1024, 2048], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<1024x2048xf32>> -> tensor<1024x2048xf32>
-    %6 = tensor.empty() : tensor<1024x2048xf32>
-    %7 = linalg.generic {indexing_maps = [#map2, #map2], iterator_types = ["parallel", "parallel"]} ins(%5 : tensor<1024x2048xf32>) outs(%6 : tensor<1024x2048xf32>) {
-    ^bb0(%in: f32, %out: f32):
-      %15 = arith.addf %in, %in : f32
-      linalg.yield %15 : f32
-    } -> tensor<1024x2048xf32>
-    %8:2 = iree_codegen.query_tile_sizes tensor<?x?xf32, #iree_encoding.encoding<role =  LHS, element_types = [f32, f32, f32], original_type = tensor<1024x2048xf32>>> -> index, index
-    %9 = affine.apply #map()[%8#0]
-    %10 = affine.apply #map1()[%8#1]
-    %11 = tensor.empty(%9, %10, %8#0, %8#1) : tensor<?x?x?x?xf32>
-    %pack = tensor.pack %7 padding_value(%cst : f32) inner_dims_pos = [0, 1] inner_tiles = [%8#0, %8#1] into %11 : tensor<1024x2048xf32> -> tensor<?x?x?x?xf32>
-    %12:2 = iree_codegen.query_tile_sizes tensor<1024x2048xf32, #iree_encoding.encoding<role =  LHS, element_types = [f32, f32, f32], original_type = tensor<1024x2048xf32>>> -> index, index
-    %13 = affine.apply #map()[%12#0]
-    %14 = affine.apply #map1()[%12#1]
-    flow.dispatch.tensor.store %pack, %4, offsets = [0, 0, 0, 0], sizes = [%13, %14, %12#0, %12#1], strides = [1, 1, 1, 1] : tensor<?x?x?x?xf32> -> !flow.dispatch.tensor<writeonly:tensor<?x?x?x?xf32>>{%13, %14, %12#0, %12#1}
-    return
-  }
+func.func @elem_pack_ukernels() attributes {hal.executable.target = #executable_target_vmvx_bytecode_fb} {
+  %cst = arith.constant 0.000000e+00 : f32
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<1024x2048xf32>>
+  %1:2 = iree_codegen.query_tile_sizes tensor<1024x2048xf32, #iree_encoding.encoding<role =  LHS, element_types = [f32, f32, f32], original_type = tensor<1024x2048xf32>>> -> index, index
+  %2 = affine.apply #map()[%1#0]
+  %3 = affine.apply #map1()[%1#1]
+  %4 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<?x?x?x?xf32>>{%2, %3, %1#0, %1#1}
+  %5 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1024, 2048], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<1024x2048xf32>> -> tensor<1024x2048xf32>
+  %6 = tensor.empty() : tensor<1024x2048xf32>
+  %7 = linalg.generic {indexing_maps = [#map2, #map2], iterator_types = ["parallel", "parallel"]} ins(%5 : tensor<1024x2048xf32>) outs(%6 : tensor<1024x2048xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %15 = arith.addf %in, %in : f32
+    linalg.yield %15 : f32
+  } -> tensor<1024x2048xf32>
+  %8:2 = iree_codegen.query_tile_sizes tensor<?x?xf32, #iree_encoding.encoding<role =  LHS, element_types = [f32, f32, f32], original_type = tensor<1024x2048xf32>>> -> index, index
+  %9 = affine.apply #map()[%8#0]
+  %10 = affine.apply #map1()[%8#1]
+  %11 = tensor.empty(%9, %10, %8#0, %8#1) : tensor<?x?x?x?xf32>
+  %pack = tensor.pack %7 padding_value(%cst : f32) inner_dims_pos = [0, 1] inner_tiles = [%8#0, %8#1] into %11 : tensor<1024x2048xf32> -> tensor<?x?x?x?xf32>
+  %12:2 = iree_codegen.query_tile_sizes tensor<1024x2048xf32, #iree_encoding.encoding<role =  LHS, element_types = [f32, f32, f32], original_type = tensor<1024x2048xf32>>> -> index, index
+  %13 = affine.apply #map()[%12#0]
+  %14 = affine.apply #map1()[%12#1]
+  flow.dispatch.tensor.store %pack, %4, offsets = [0, 0, 0, 0], sizes = [%13, %14, %12#0, %12#1], strides = [1, 1, 1, 1] : tensor<?x?x?x?xf32> -> !flow.dispatch.tensor<writeonly:tensor<?x?x?x?xf32>>{%13, %14, %12#0, %12#1}
+  return
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64]]>
@@ -214,21 +201,19 @@ module {
 // -----
 
 #executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {ukernels = "none"}>
-module {
-  func.func @copy_cst() attributes {hal.executable.target = #executable_target_vmvx_bytecode_fb} {
-    %cst = arith.constant dense<4.200000e-01> : tensor<5x19x8x4xf32>
-    %c32_i64 = arith.constant 32 : i64
-    %0 = hal.interface.constant.load[0] : i32
-    %1 = hal.interface.constant.load[1] : i32
-    %2 = arith.extui %0 : i32 to i64
-    %3 = arith.extui %1 : i32 to i64
-    %4 = arith.shli %3, %c32_i64 : i64
-    %5 = arith.ori %2, %4 : i64
-    %6 = arith.index_castui %5 : i64 to index
-    %7 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%6) : !flow.dispatch.tensor<writeonly:tensor<5x19x8x4xf32>>
-    flow.dispatch.tensor.store %cst, %7, offsets = [0, 0, 0, 0], sizes = [5, 19, 8, 4], strides = [1, 1, 1, 1] : tensor<5x19x8x4xf32> -> !flow.dispatch.tensor<writeonly:tensor<5x19x8x4xf32>>
-    return
-  }
+func.func @copy_cst() attributes {hal.executable.target = #executable_target_vmvx_bytecode_fb} {
+  %cst = arith.constant dense<4.200000e-01> : tensor<5x19x8x4xf32>
+  %c32_i64 = arith.constant 32 : i64
+  %0 = hal.interface.constant.load[0] : i32
+  %1 = hal.interface.constant.load[1] : i32
+  %2 = arith.extui %0 : i32 to i64
+  %3 = arith.extui %1 : i32 to i64
+  %4 = arith.shli %3, %c32_i64 : i64
+  %5 = arith.ori %2, %4 : i64
+  %6 = arith.index_castui %5 : i64 to index
+  %7 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%6) : !flow.dispatch.tensor<writeonly:tensor<5x19x8x4xf32>>
+  flow.dispatch.tensor.store %cst, %7, offsets = [0, 0, 0, 0], sizes = [5, 19, 8, 4], strides = [1, 1, 1, 1] : tensor<5x19x8x4xf32> -> !flow.dispatch.tensor<writeonly:tensor<5x19x8x4xf32>>
+  return
 }
 
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<VMVXDefault>

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/clone_producers_into_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/clone_producers_into_dispatch_regions.mlir
@@ -186,33 +186,31 @@ util.func public @clone_dequantization(%arg0: tensor<4096x32x128xi8>, %arg1: ten
 // -----
 
 #map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>
-module {
-  util.func public @clone_dequantization_like(%arg0: tensor<32x1x16x1x8xi16>, %arg1: tensor<32x344x16x32x8xi4>) -> tensor<32x1x344x1x32xi32> {
-    %c0_i32 = arith.constant 0 : i32
-    %0 = tensor.empty() : tensor<32x1x16x1x8xi32>
-    %1 = linalg.generic {indexing_maps = [#map, #map],
-                         iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]}
-                         ins(%arg0 : tensor<32x1x16x1x8xi16>) outs(%0 : tensor<32x1x16x1x8xi32>) {
-    ^bb0(%in: i16, %out: i32):
-      %7 = arith.extsi %in : i16 to i32
-      linalg.yield %7 : i32
-    } -> tensor<32x1x16x1x8xi32>
-    %2 = tensor.empty() : tensor<32x344x16x32x8xi32>
-    %3 = linalg.generic {indexing_maps = [#map, #map],
-                         iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]}
-                         ins(%arg1 : tensor<32x344x16x32x8xi4>) outs(%2 : tensor<32x344x16x32x8xi32>) {
-    ^bb0(%in: i4, %out: i32):
-      %7 = arith.extui %in : i4 to i32
-      linalg.yield %7 : i32
-    } -> tensor<32x344x16x32x8xi32>
-    %4 = tensor.empty() : tensor<32x1x344x1x32xi32>
-    %5 = linalg.fill ins(%c0_i32 : i32) outs(%4 : tensor<32x1x344x1x32xi32>) -> tensor<32x1x344x1x32xi32>
-    %6 = flow.dispatch.region -> (tensor<32x1x344x1x32xi32>) {
-      %7 = linalg.batch_mmt4d ins(%1, %3 : tensor<32x1x16x1x8xi32>, tensor<32x344x16x32x8xi32>) outs(%5 : tensor<32x1x344x1x32xi32>) -> tensor<32x1x344x1x32xi32>
-      flow.return %7 : tensor<32x1x344x1x32xi32>
-    }
-    util.return %6 : tensor<32x1x344x1x32xi32>
+util.func public @clone_dequantization_like(%arg0: tensor<32x1x16x1x8xi16>, %arg1: tensor<32x344x16x32x8xi4>) -> tensor<32x1x344x1x32xi32> {
+  %c0_i32 = arith.constant 0 : i32
+  %0 = tensor.empty() : tensor<32x1x16x1x8xi32>
+  %1 = linalg.generic {indexing_maps = [#map, #map],
+                        iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]}
+                        ins(%arg0 : tensor<32x1x16x1x8xi16>) outs(%0 : tensor<32x1x16x1x8xi32>) {
+  ^bb0(%in: i16, %out: i32):
+    %7 = arith.extsi %in : i16 to i32
+    linalg.yield %7 : i32
+  } -> tensor<32x1x16x1x8xi32>
+  %2 = tensor.empty() : tensor<32x344x16x32x8xi32>
+  %3 = linalg.generic {indexing_maps = [#map, #map],
+                        iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]}
+                        ins(%arg1 : tensor<32x344x16x32x8xi4>) outs(%2 : tensor<32x344x16x32x8xi32>) {
+  ^bb0(%in: i4, %out: i32):
+    %7 = arith.extui %in : i4 to i32
+    linalg.yield %7 : i32
+  } -> tensor<32x344x16x32x8xi32>
+  %4 = tensor.empty() : tensor<32x1x344x1x32xi32>
+  %5 = linalg.fill ins(%c0_i32 : i32) outs(%4 : tensor<32x1x344x1x32xi32>) -> tensor<32x1x344x1x32xi32>
+  %6 = flow.dispatch.region -> (tensor<32x1x344x1x32xi32>) {
+    %7 = linalg.batch_mmt4d ins(%1, %3 : tensor<32x1x16x1x8xi32>, tensor<32x344x16x32x8xi32>) outs(%5 : tensor<32x1x344x1x32xi32>) -> tensor<32x1x344x1x32xi32>
+    flow.return %7 : tensor<32x1x344x1x32xi32>
   }
+  util.return %6 : tensor<32x1x344x1x32xi32>
 }
 //       CHECK: util.func public @clone_dequantization
 //  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<32x1x16x1x8xi16>
@@ -273,14 +271,14 @@ util.func public @dequant_like_extf_reduction(%arg0: tensor<11008x32x128xf16>) -
 
 #map1 = affine_map<(d0) -> (d0)>
 util.func public @clone_elementwise_op_empty() -> tensor<1280xf32> {
-   %0 = flow.tensor.constant #flow.parameter.named<"model"::"unet.time_embedding.linear_2.bias"> : tensor<1280xf16>
-   %1 = tensor.empty() : tensor<1280xf32>
-   %2 = linalg.generic {indexing_maps = [#map1, #map1], iterator_types = ["parallel"]} ins(%0 : tensor<1280xf16>) outs(%1 : tensor<1280xf32>) {
-   ^bb0(%in: f16, %out: f32):
-     %3 = arith.extf %in : f16 to f32
-     linalg.yield %3 : f32
-   } -> tensor<1280xf32>
-   util.return %2 : tensor<1280xf32>
+  %0 = flow.tensor.constant #flow.parameter.named<"model"::"unet.time_embedding.linear_2.bias"> : tensor<1280xf16>
+  %1 = tensor.empty() : tensor<1280xf32>
+  %2 = linalg.generic {indexing_maps = [#map1, #map1], iterator_types = ["parallel"]} ins(%0 : tensor<1280xf16>) outs(%1 : tensor<1280xf32>) {
+  ^bb0(%in: f16, %out: f32):
+    %3 = arith.extf %in : f16 to f32
+    linalg.yield %3 : f32
+  } -> tensor<1280xf32>
+  util.return %2 : tensor<1280xf32>
 }
 //      CHECK: util.func public @clone_elementwise_op_empty()
 //      CHECK:   %[[RETURN:.+]] = flow.dispatch.region

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
@@ -1764,35 +1764,33 @@ util.func public @reduction_broadcast_elementwise_dynamic(%a: tensor<12x16x?xf32
 
 #map0 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d0, d1)>
-module {
-  util.func public @softmax(%arg0: tensor<12x128x128xf32>) -> tensor<12x128x128xf32> {
-    %cst = arith.constant 1.000000e+00 : f32
-    %cst_0 = arith.constant 0.000000e+00 : f32
-    %cst_1 = arith.constant -3.40282347E+38 : f32
-    %0 = tensor.empty() : tensor<12x128xf32>
-    %1 = linalg.fill ins(%cst_1 : f32) outs(%0 : tensor<12x128xf32>) -> tensor<12x128xf32>
-    %2 = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0 : tensor<12x128x128xf32>) outs(%1 : tensor<12x128xf32>) {
-    ^bb0(%arg1: f32, %arg2: f32):
-      %7 = arith.maximumf %arg1, %arg2 : f32
-      linalg.yield %7 : f32
-    } -> tensor<12x128xf32>
-    %3 = tensor.empty() : tensor<12x128x128xf32>
-    %4 = linalg.fill ins(%cst_0 : f32) outs(%0 : tensor<12x128xf32>) -> tensor<12x128xf32>
-    %5:2 = linalg.generic {indexing_maps = [#map0, #map1, #map0, #map1], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0, %2 : tensor<12x128x128xf32>, tensor<12x128xf32>) outs(%3, %4 : tensor<12x128x128xf32>, tensor<12x128xf32>) {
-    ^bb0(%arg1: f32, %arg2: f32, %arg3: f32, %arg4: f32):
-      %7 = arith.subf %arg1, %arg2 : f32
-      %8 = math.exp %7 : f32
-      %9 = arith.addf %8, %arg4 : f32
-      linalg.yield %8, %9 : f32, f32
-    } -> (tensor<12x128x128xf32>, tensor<12x128xf32>)
-    %6 = linalg.generic {indexing_maps = [#map0, #map1, #map0], iterator_types = ["parallel", "parallel", "parallel"]} ins(%5#0, %5#1 : tensor<12x128x128xf32>, tensor<12x128xf32>) outs(%3 : tensor<12x128x128xf32>) {
-    ^bb0(%arg1: f32, %arg2: f32, %arg3: f32):
-      %7 = arith.divf %cst, %arg2 : f32
-      %8 = arith.mulf %arg1, %7 : f32
-      linalg.yield %8 : f32
-    } -> tensor<12x128x128xf32>
-    util.return %6 : tensor<12x128x128xf32>
-  }
+util.func public @softmax(%arg0: tensor<12x128x128xf32>) -> tensor<12x128x128xf32> {
+  %cst = arith.constant 1.000000e+00 : f32
+  %cst_0 = arith.constant 0.000000e+00 : f32
+  %cst_1 = arith.constant -3.40282347E+38 : f32
+  %0 = tensor.empty() : tensor<12x128xf32>
+  %1 = linalg.fill ins(%cst_1 : f32) outs(%0 : tensor<12x128xf32>) -> tensor<12x128xf32>
+  %2 = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0 : tensor<12x128x128xf32>) outs(%1 : tensor<12x128xf32>) {
+  ^bb0(%arg1: f32, %arg2: f32):
+    %7 = arith.maximumf %arg1, %arg2 : f32
+    linalg.yield %7 : f32
+  } -> tensor<12x128xf32>
+  %3 = tensor.empty() : tensor<12x128x128xf32>
+  %4 = linalg.fill ins(%cst_0 : f32) outs(%0 : tensor<12x128xf32>) -> tensor<12x128xf32>
+  %5:2 = linalg.generic {indexing_maps = [#map0, #map1, #map0, #map1], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0, %2 : tensor<12x128x128xf32>, tensor<12x128xf32>) outs(%3, %4 : tensor<12x128x128xf32>, tensor<12x128xf32>) {
+  ^bb0(%arg1: f32, %arg2: f32, %arg3: f32, %arg4: f32):
+    %7 = arith.subf %arg1, %arg2 : f32
+    %8 = math.exp %7 : f32
+    %9 = arith.addf %8, %arg4 : f32
+    linalg.yield %8, %9 : f32, f32
+  } -> (tensor<12x128x128xf32>, tensor<12x128xf32>)
+  %6 = linalg.generic {indexing_maps = [#map0, #map1, #map0], iterator_types = ["parallel", "parallel", "parallel"]} ins(%5#0, %5#1 : tensor<12x128x128xf32>, tensor<12x128xf32>) outs(%3 : tensor<12x128x128xf32>) {
+  ^bb0(%arg1: f32, %arg2: f32, %arg3: f32):
+    %7 = arith.divf %cst, %arg2 : f32
+    %8 = arith.mulf %arg1, %7 : f32
+    linalg.yield %8 : f32
+  } -> tensor<12x128x128xf32>
+  util.return %6 : tensor<12x128x128xf32>
 }
 // CHECK-LABEL: util.func public @softmax(
 //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<12x128x128xf32>
@@ -1823,33 +1821,31 @@ module {
 #map0 = affine_map<(d0, d1, d2, d3, d4) -> (d1, d2, d3, d4, d0)>
 #map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0)>
 #map2 = affine_map<(d0) -> (d0)>
-module {
-  util.func public @batchnorm_training(%arg0: tensor<12xf32>, %arg1: tensor<12x12x12x12x12xf32>, %arg2: tensor<12xf32>) -> (tensor<12xf32>, tensor<12xf32>, tensor<12xf32>) {
-    %cst = arith.constant 1.420000e+00 : f32
-    %cst_0 = arith.constant 1.450000e+00 : f32
-    %cst_1 = arith.constant 1.300000e+00 : f32
-    %cst_2 = arith.constant 0.000000e+00 : f32
-    %0 = tensor.empty() : tensor<12xf32>
-    %1 = linalg.fill ins(%cst_2 : f32) outs(%0 : tensor<12xf32>) -> tensor<12xf32>
-    %2 = linalg.generic {indexing_maps = [#map0, #map1, #map1], iterator_types = ["parallel", "reduction", "reduction", "reduction", "reduction"]} ins(%arg1, %arg2 : tensor<12x12x12x12x12xf32>, tensor<12xf32>) outs(%1 : tensor<12xf32>) {
-    ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):
-      %4 = arith.subf %arg3, %arg4 : f32
-      %5 = arith.mulf %4, %4 : f32
-      %6 = arith.addf %arg5, %5 : f32
-      linalg.yield %6 : f32
-    } -> tensor<12xf32>
-    %3:3 = linalg.generic {indexing_maps = [#map2, #map2, #map2, #map2, #map2], iterator_types = ["parallel"]} ins(%arg0, %2 : tensor<12xf32>, tensor<12xf32>) outs(%0, %0, %0 : tensor<12xf32>, tensor<12xf32>, tensor<12xf32>) {
-    ^bb0(%arg3: f32, %arg4: f32, %arg5: f32, %arg6: f32, %arg7: f32):
-      %4 = arith.divf %arg4, %cst_0 : f32
-      %5 = arith.addf %4, %cst_1 : f32
-      %6 = math.sqrt %5 : f32
-      %7 = arith.subf %arg3, %6 : f32
-      %8 = arith.mulf %7, %cst : f32
-      %9 = arith.subf %arg3, %8 : f32
-      linalg.yield %5, %6, %9 : f32, f32, f32
-    } -> (tensor<12xf32>, tensor<12xf32>, tensor<12xf32>)
-    util.return %3#0, %3#1, %3#2 : tensor<12xf32>, tensor<12xf32>, tensor<12xf32>
-  }
+util.func public @batchnorm_training(%arg0: tensor<12xf32>, %arg1: tensor<12x12x12x12x12xf32>, %arg2: tensor<12xf32>) -> (tensor<12xf32>, tensor<12xf32>, tensor<12xf32>) {
+  %cst = arith.constant 1.420000e+00 : f32
+  %cst_0 = arith.constant 1.450000e+00 : f32
+  %cst_1 = arith.constant 1.300000e+00 : f32
+  %cst_2 = arith.constant 0.000000e+00 : f32
+  %0 = tensor.empty() : tensor<12xf32>
+  %1 = linalg.fill ins(%cst_2 : f32) outs(%0 : tensor<12xf32>) -> tensor<12xf32>
+  %2 = linalg.generic {indexing_maps = [#map0, #map1, #map1], iterator_types = ["parallel", "reduction", "reduction", "reduction", "reduction"]} ins(%arg1, %arg2 : tensor<12x12x12x12x12xf32>, tensor<12xf32>) outs(%1 : tensor<12xf32>) {
+  ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):
+    %4 = arith.subf %arg3, %arg4 : f32
+    %5 = arith.mulf %4, %4 : f32
+    %6 = arith.addf %arg5, %5 : f32
+    linalg.yield %6 : f32
+  } -> tensor<12xf32>
+  %3:3 = linalg.generic {indexing_maps = [#map2, #map2, #map2, #map2, #map2], iterator_types = ["parallel"]} ins(%arg0, %2 : tensor<12xf32>, tensor<12xf32>) outs(%0, %0, %0 : tensor<12xf32>, tensor<12xf32>, tensor<12xf32>) {
+  ^bb0(%arg3: f32, %arg4: f32, %arg5: f32, %arg6: f32, %arg7: f32):
+    %4 = arith.divf %arg4, %cst_0 : f32
+    %5 = arith.addf %4, %cst_1 : f32
+    %6 = math.sqrt %5 : f32
+    %7 = arith.subf %arg3, %6 : f32
+    %8 = arith.mulf %7, %cst : f32
+    %9 = arith.subf %arg3, %8 : f32
+    linalg.yield %5, %6, %9 : f32, f32, f32
+  } -> (tensor<12xf32>, tensor<12xf32>, tensor<12xf32>)
+  util.return %3#0, %3#1, %3#2 : tensor<12xf32>, tensor<12xf32>, tensor<12xf32>
 }
 // CHECK-LABEL: util.func public @batchnorm_training(
 //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<12xf32>
@@ -2041,26 +2037,24 @@ util.func public @unset_encoding_and_slice(
 
 #map = affine_map<(d0, d1) -> (d1)>
 #map1 = affine_map<(d0, d1) -> (d0, d1)>
-module {
-  util.func public @root_on_unset_encoding(
-      %arg0: tensor<784x96xf32, #iree_encoding.encoding<role = LHS, element_types = [f32, f32, f32]>>,
-      %arg1: tensor<96xf32>) -> tensor<784x96xf32> {
-    %0 = iree_encoding.unset_encoding %arg0 : tensor<784x96xf32, #iree_encoding.encoding<role = LHS, element_types = [f32, f32, f32]>> -> tensor<784x96xf32>
-    %1 = tensor.empty() : tensor<784x96xf32>
-    %cst = arith.constant 0.000000e+00 : f32
-    %2 = linalg.fill ins(%cst : f32) outs(%1 : tensor<784x96xf32>) -> tensor<784x96xf32>
-    %3 = linalg.generic {indexing_maps = [#map, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%arg1, %0 : tensor<96xf32>, tensor<784x96xf32>) outs(%1 : tensor<784x96xf32>) {
-    ^bb0(%in: f32, %in_0: f32, %out: f32):
-      %5 = arith.addf %in, %in_0 : f32
-      linalg.yield %5 : f32
-    } -> tensor<784x96xf32>
-    %4 = linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%3, %3 : tensor<784x96xf32>, tensor<784x96xf32>) outs(%1 : tensor<784x96xf32>) {
-    ^bb0(%in: f32, %in_0: f32, %out: f32):
-      %5 = arith.addf %in, %in_0 : f32
-      linalg.yield %5 : f32
-    } -> tensor<784x96xf32>
-    util.return %4 : tensor<784x96xf32>
-  }
+util.func public @root_on_unset_encoding(
+    %arg0: tensor<784x96xf32, #iree_encoding.encoding<role = LHS, element_types = [f32, f32, f32]>>,
+    %arg1: tensor<96xf32>) -> tensor<784x96xf32> {
+  %0 = iree_encoding.unset_encoding %arg0 : tensor<784x96xf32, #iree_encoding.encoding<role = LHS, element_types = [f32, f32, f32]>> -> tensor<784x96xf32>
+  %1 = tensor.empty() : tensor<784x96xf32>
+  %cst = arith.constant 0.000000e+00 : f32
+  %2 = linalg.fill ins(%cst : f32) outs(%1 : tensor<784x96xf32>) -> tensor<784x96xf32>
+  %3 = linalg.generic {indexing_maps = [#map, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%arg1, %0 : tensor<96xf32>, tensor<784x96xf32>) outs(%1 : tensor<784x96xf32>) {
+  ^bb0(%in: f32, %in_0: f32, %out: f32):
+    %5 = arith.addf %in, %in_0 : f32
+    linalg.yield %5 : f32
+  } -> tensor<784x96xf32>
+  %4 = linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%3, %3 : tensor<784x96xf32>, tensor<784x96xf32>) outs(%1 : tensor<784x96xf32>) {
+  ^bb0(%in: f32, %in_0: f32, %out: f32):
+    %5 = arith.addf %in, %in_0 : f32
+    linalg.yield %5 : f32
+  } -> tensor<784x96xf32>
+  util.return %4 : tensor<784x96xf32>
 }
 //      CHECL: #[[MAP0:.+]] = affine_map<(d0, d1) -> (d1)>
 //      CHECK: #[[MAP1:.+]] = affine_map<(d0, d1) -> (d0, d1)>

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/form_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/form_dispatch_regions.mlir
@@ -105,24 +105,22 @@ util.func public @pack_fusion(%arg0 : tensor<?x?xf32>,
 #map1 = affine_map<(d0, d1) -> (d1, d0)>
 #map2 = affine_map<()[s0] -> (s0 ceildiv 8)>
 #map3 = affine_map<()[s0] -> (s0 ceildiv 32)>
-module {
-  util.func public @tranpose_pack_fusion(%arg0: tensor<?x?xf32>) -> tensor<?x?x8x32xf32> {
-    %cst = arith.constant 0.000000e+00 : f32
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %dim = tensor.dim %arg0, %c0 : tensor<?x?xf32>
-    %dim_0 = tensor.dim %arg0, %c1 : tensor<?x?xf32>
-    %0 = tensor.empty(%dim, %dim_0) : tensor<?x?xf32>
-    %1 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel"]} ins(%arg0 : tensor<?x?xf32>) outs(%0 : tensor<?x?xf32>) {
-    ^bb0(%in: f32, %out: f32):
-      linalg.yield %in : f32
-    } -> tensor<?x?xf32>
-    %2 = affine.apply #map2()[%dim]
-    %3 = affine.apply #map3()[%dim_0]
-    %4 = tensor.empty(%2, %3) : tensor<?x?x8x32xf32>
-    %pack = tensor.pack %1 padding_value(%cst : f32) inner_dims_pos = [0, 1] inner_tiles = [8, 32] into %4 : tensor<?x?xf32> -> tensor<?x?x8x32xf32>
-    util.return %pack : tensor<?x?x8x32xf32>
-  }
+util.func public @tranpose_pack_fusion(%arg0: tensor<?x?xf32>) -> tensor<?x?x8x32xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %dim = tensor.dim %arg0, %c0 : tensor<?x?xf32>
+  %dim_0 = tensor.dim %arg0, %c1 : tensor<?x?xf32>
+  %0 = tensor.empty(%dim, %dim_0) : tensor<?x?xf32>
+  %1 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel"]} ins(%arg0 : tensor<?x?xf32>) outs(%0 : tensor<?x?xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    linalg.yield %in : f32
+  } -> tensor<?x?xf32>
+  %2 = affine.apply #map2()[%dim]
+  %3 = affine.apply #map3()[%dim_0]
+  %4 = tensor.empty(%2, %3) : tensor<?x?x8x32xf32>
+  %pack = tensor.pack %1 padding_value(%cst : f32) inner_dims_pos = [0, 1] inner_tiles = [8, 32] into %4 : tensor<?x?xf32> -> tensor<?x?x8x32xf32>
+  util.return %pack : tensor<?x?x8x32xf32>
 }
 // No fusion as the CPU backend currently can't handle fusion with transpose
 // between ops.
@@ -561,30 +559,28 @@ util.func public @no_dequantization_fusion(%arg0: tensor<4096x32x128xi8>, %arg1:
 // -----
 
 #map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>
-module {
-  util.func public @no_dequantization_like_fusion(%arg0: tensor<32x1x16x1x8xi16>, %arg1: tensor<32x344x16x32x8xi4>) -> tensor<32x1x344x1x32xi32> {
-    %c0_i32 = arith.constant 0 : i32
-    %0 = tensor.empty() : tensor<32x1x16x1x8xi32>
-    %1 = linalg.generic {indexing_maps = [#map, #map],
-                         iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]}
-                         ins(%arg0 : tensor<32x1x16x1x8xi16>) outs(%0 : tensor<32x1x16x1x8xi32>) {
-    ^bb0(%in: i16, %out: i32):
-      %7 = arith.extsi %in : i16 to i32
-      linalg.yield %7 : i32
-    } -> tensor<32x1x16x1x8xi32>
-    %2 = tensor.empty() : tensor<32x344x16x32x8xi32>
-    %3 = linalg.generic {indexing_maps = [#map, #map],
-                         iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]}
-                         ins(%arg1 : tensor<32x344x16x32x8xi4>) outs(%2 : tensor<32x344x16x32x8xi32>) {
-    ^bb0(%in: i4, %out: i32):
-      %7 = arith.extui %in : i4 to i32
-      linalg.yield %7 : i32
-    } -> tensor<32x344x16x32x8xi32>
-    %4 = tensor.empty() : tensor<32x1x344x1x32xi32>
-    %5 = linalg.fill ins(%c0_i32 : i32) outs(%4 : tensor<32x1x344x1x32xi32>) -> tensor<32x1x344x1x32xi32>
-    %7 = linalg.batch_mmt4d ins(%1, %3 : tensor<32x1x16x1x8xi32>, tensor<32x344x16x32x8xi32>) outs(%5 : tensor<32x1x344x1x32xi32>) -> tensor<32x1x344x1x32xi32>
-    util.return %7 : tensor<32x1x344x1x32xi32>
-  }
+util.func public @no_dequantization_like_fusion(%arg0: tensor<32x1x16x1x8xi16>, %arg1: tensor<32x344x16x32x8xi4>) -> tensor<32x1x344x1x32xi32> {
+  %c0_i32 = arith.constant 0 : i32
+  %0 = tensor.empty() : tensor<32x1x16x1x8xi32>
+  %1 = linalg.generic {indexing_maps = [#map, #map],
+                        iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]}
+                        ins(%arg0 : tensor<32x1x16x1x8xi16>) outs(%0 : tensor<32x1x16x1x8xi32>) {
+  ^bb0(%in: i16, %out: i32):
+    %7 = arith.extsi %in : i16 to i32
+    linalg.yield %7 : i32
+  } -> tensor<32x1x16x1x8xi32>
+  %2 = tensor.empty() : tensor<32x344x16x32x8xi32>
+  %3 = linalg.generic {indexing_maps = [#map, #map],
+                        iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]}
+                        ins(%arg1 : tensor<32x344x16x32x8xi4>) outs(%2 : tensor<32x344x16x32x8xi32>) {
+  ^bb0(%in: i4, %out: i32):
+    %7 = arith.extui %in : i4 to i32
+    linalg.yield %7 : i32
+  } -> tensor<32x344x16x32x8xi32>
+  %4 = tensor.empty() : tensor<32x1x344x1x32xi32>
+  %5 = linalg.fill ins(%c0_i32 : i32) outs(%4 : tensor<32x1x344x1x32xi32>) -> tensor<32x1x344x1x32xi32>
+  %7 = linalg.batch_mmt4d ins(%1, %3 : tensor<32x1x16x1x8xi32>, tensor<32x344x16x32x8xi32>) outs(%5 : tensor<32x1x344x1x32xi32>) -> tensor<32x1x344x1x32xi32>
+  util.return %7 : tensor<32x1x344x1x32xi32>
 }
 //       CHECK: util.func public @no_dequantization_like_fusion
 //  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<32x1x16x1x8xi16>

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/fusion_of_tensor_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/fusion_of_tensor_ops.mlir
@@ -67,8 +67,7 @@ util.func public @softmax(%arg0 : tensor<12x128x128xf32>) -> tensor<12x128x128xf
 
 // -----
 
-util.func public @batchnorm_training(%10 : tensor<12xf32>, %11 : tensor<12x12x12x12x12xf32>, %12 : tensor<12xf32>) -> (tensor<12xf32>, tensor<12xf32>, tensor<12xf32>)
-{
+util.func public @batchnorm_training(%10 : tensor<12xf32>, %11 : tensor<12x12x12x12x12xf32>, %12 : tensor<12xf32>) -> (tensor<12xf32>, tensor<12xf32>, tensor<12xf32>) {
   %cst = arith.constant 1.42 : f32
   %cst_1 = arith.constant 1.45 : f32
   %cst_0 = arith.constant 1.3 : f32
@@ -131,37 +130,35 @@ util.func public @batchnorm_training(%10 : tensor<12xf32>, %11 : tensor<12x12x12
 // -----
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
-module {
-  util.func public @fuse_only_with_same_marker(%arg0: tensor<5x5xf32>, %arg1: tensor<5x5xf32>) -> (tensor<5x5xf32>, tensor<5x5xf32>, tensor<5x5xf32>, tensor<5x5xf32>) {
-    %cst = arith.constant 1.000000e+00 : f32
-    %cst_0 = arith.constant 2.000000e+00 : f32
-    %cst_1 = arith.constant 3.000000e+00 : f32
-    %0 = tensor.empty() : tensor<5x5xf32>
-    %1 = tensor.empty() : tensor<5x5xf32>
-    %2 = tensor.empty() : tensor<5x5xf32>
-    %3 = tensor.empty() : tensor<5x5xf32>
-    %4 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg0 : tensor<5x5xf32>) outs(%0 : tensor<5x5xf32>) {
-    ^bb0(%arg2: f32, %arg3: f32):
-      %8 = arith.addf %arg2, %cst : f32
-      linalg.yield %8 : f32
-    } -> tensor<5x5xf32>
-    %5 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg1 : tensor<5x5xf32>) outs(%1 : tensor<5x5xf32>) {
-    ^bb0(%arg2: f32, %arg3: f32):
-      %8 = arith.subf %arg2, %cst_0 : f32
-      linalg.yield %8 : f32
-    } -> tensor<5x5xf32>
-    %6 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%4 : tensor<5x5xf32>) outs(%2 : tensor<5x5xf32>) {
-    ^bb0(%arg2: f32, %arg3: f32):
-      %8 = arith.addf %arg2, %cst_1 : f32
-      linalg.yield %8 : f32
-    } -> tensor<5x5xf32>
-    %7 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%4, %5 : tensor<5x5xf32>, tensor<5x5xf32>) outs(%3 : tensor<5x5xf32>) {
-    ^bb0(%arg2: f32, %arg3: f32, %arg4: f32):
-      %8 = arith.subf %arg2, %arg3 : f32
-      linalg.yield %8 : f32
-    } -> tensor<5x5xf32>
-    util.return %4, %5, %6, %7 : tensor<5x5xf32>, tensor<5x5xf32>, tensor<5x5xf32>, tensor<5x5xf32>
-  }
+util.func public @fuse_only_with_same_marker(%arg0: tensor<5x5xf32>, %arg1: tensor<5x5xf32>) -> (tensor<5x5xf32>, tensor<5x5xf32>, tensor<5x5xf32>, tensor<5x5xf32>) {
+  %cst = arith.constant 1.000000e+00 : f32
+  %cst_0 = arith.constant 2.000000e+00 : f32
+  %cst_1 = arith.constant 3.000000e+00 : f32
+  %0 = tensor.empty() : tensor<5x5xf32>
+  %1 = tensor.empty() : tensor<5x5xf32>
+  %2 = tensor.empty() : tensor<5x5xf32>
+  %3 = tensor.empty() : tensor<5x5xf32>
+  %4 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg0 : tensor<5x5xf32>) outs(%0 : tensor<5x5xf32>) {
+  ^bb0(%arg2: f32, %arg3: f32):
+    %8 = arith.addf %arg2, %cst : f32
+    linalg.yield %8 : f32
+  } -> tensor<5x5xf32>
+  %5 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg1 : tensor<5x5xf32>) outs(%1 : tensor<5x5xf32>) {
+  ^bb0(%arg2: f32, %arg3: f32):
+    %8 = arith.subf %arg2, %cst_0 : f32
+    linalg.yield %8 : f32
+  } -> tensor<5x5xf32>
+  %6 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%4 : tensor<5x5xf32>) outs(%2 : tensor<5x5xf32>) {
+  ^bb0(%arg2: f32, %arg3: f32):
+    %8 = arith.addf %arg2, %cst_1 : f32
+    linalg.yield %8 : f32
+  } -> tensor<5x5xf32>
+  %7 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%4, %5 : tensor<5x5xf32>, tensor<5x5xf32>) outs(%3 : tensor<5x5xf32>) {
+  ^bb0(%arg2: f32, %arg3: f32, %arg4: f32):
+    %8 = arith.subf %arg2, %arg3 : f32
+    linalg.yield %8 : f32
+  } -> tensor<5x5xf32>
+  util.return %4, %5, %6, %7 : tensor<5x5xf32>, tensor<5x5xf32>, tensor<5x5xf32>, tensor<5x5xf32>
 }
 // CHECK-LABEL: util.func public @fuse_only_with_same_marke
 // CHECK:         linalg.generic
@@ -174,34 +171,32 @@ module {
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d1 + d4, d2 + d5)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d3, d4, d5)>
 #map3 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>
-module {
-  util.func public @fuse_only_projected_perm(%arg0: tensor<16x1082x1922xi8>, %arg1: tensor<32x16x3x3xf32>, %arg2: tensor<32x1080x1920xi32>) -> tensor<32x1080x1920xi32> {
-    %0 = tensor.empty() : tensor<32x16x3x3xi8>
-    %eltwise = linalg.generic {
-             indexing_maps = [#map0, #map0],
-             iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
-             ins(%arg1 : tensor<32x16x3x3xf32>)
-             outs(%0 : tensor<32x16x3x3xi8>) {
-    ^bb0(%in: f32, %out: i8):
-      %1 = arith.fptosi %in : f32 to i8
-      linalg.yield %1 : i8
-    } -> tensor<32x16x3x3xi8>
+util.func public @fuse_only_projected_perm(%arg0: tensor<16x1082x1922xi8>, %arg1: tensor<32x16x3x3xf32>, %arg2: tensor<32x1080x1920xi32>) -> tensor<32x1080x1920xi32> {
+  %0 = tensor.empty() : tensor<32x16x3x3xi8>
+  %eltwise = linalg.generic {
+            indexing_maps = [#map0, #map0],
+            iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+            ins(%arg1 : tensor<32x16x3x3xf32>)
+            outs(%0 : tensor<32x16x3x3xi8>) {
+  ^bb0(%in: f32, %out: i8):
+    %1 = arith.fptosi %in : f32 to i8
+    linalg.yield %1 : i8
+  } -> tensor<32x16x3x3xi8>
 
-    %conv = linalg.generic {
-          indexing_maps = [#map1, #map2, #map3],
-          iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction", "reduction"] }
-          ins(%arg0, %eltwise : tensor<16x1082x1922xi8>, tensor<32x16x3x3xi8>)
-          outs(%arg2 : tensor<32x1080x1920xi32>) {
-    ^bb0(%in: i8, %in_108: i8, %out: i32):
-      %232 = arith.extui %in : i8 to i32
-      %233 = arith.extsi %in_108 : i8 to i32
-      %234 = arith.muli %232, %233 : i32
-      %235 = arith.addi %234, %out : i32
-      linalg.yield %235 : i32
-    } -> tensor<32x1080x1920xi32>
+  %conv = linalg.generic {
+        indexing_maps = [#map1, #map2, #map3],
+        iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction", "reduction"] }
+        ins(%arg0, %eltwise : tensor<16x1082x1922xi8>, tensor<32x16x3x3xi8>)
+        outs(%arg2 : tensor<32x1080x1920xi32>) {
+  ^bb0(%in: i8, %in_108: i8, %out: i32):
+    %232 = arith.extui %in : i8 to i32
+    %233 = arith.extsi %in_108 : i8 to i32
+    %234 = arith.muli %232, %233 : i32
+    %235 = arith.addi %234, %out : i32
+    linalg.yield %235 : i32
+  } -> tensor<32x1080x1920xi32>
 
-    util.return %conv : tensor<32x1080x1920xi32>
-  }
+  util.return %conv : tensor<32x1080x1920xi32>
 }
 // CHECK-LABEL: util.func public @fuse_only_projected_perm
 // CHECK:         linalg.generic
@@ -213,47 +208,45 @@ module {
 #map1 = affine_map<(d0, d1, d2, d3) -> (d1, d3, d0)>
 #map2 = affine_map<(d0, d1, d2, d3) -> (d2, d3, d0)>
 #map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
-module {
-  util.func public @nofuse_broadcast_compute(%arg0: tensor<702x702x128xf32>, %arg1: tensor<702x702x128xf32>,
-      %arg2: tensor<702x702x128xf32>, %arg3: tensor<702x702x128xf32>) -> tensor<128x702x702xf32> {
-    %cst = arith.constant dense<1.000000e+00> : tensor<702x702x128xf32>
-    %cst_0 = arith.constant 0.000000e+00 : f32
-    %0 = tensor.empty() : tensor<702x702x128xf32>
-    %1 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg3 : tensor<702x702x128xf32>) outs(%0 : tensor<702x702x128xf32>) {
-    ^bb0(%in: f32, %out: f32):
-      %9 = math.exp %in : f32
-      linalg.yield %9 : f32
-    } -> tensor<702x702x128xf32>
-    %2 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%1, %cst : tensor<702x702x128xf32>, tensor<702x702x128xf32>) outs(%0 : tensor<702x702x128xf32>) {
-    ^bb0(%in: f32, %in_1: f32, %out: f32):
-      %9 = arith.addf %in, %in_1 : f32
-      linalg.yield %9 : f32
-    } -> tensor<702x702x128xf32>
-    %3 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%cst, %2 : tensor<702x702x128xf32>, tensor<702x702x128xf32>) outs(%0 : tensor<702x702x128xf32>) {
-    ^bb0(%in: f32, %in_1: f32, %out: f32):
-      %9 = arith.divf %in, %in_1 : f32
-      linalg.yield %9 : f32
-    } -> tensor<702x702x128xf32>
-    %4 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg0, %arg2 : tensor<702x702x128xf32>, tensor<702x702x128xf32>) outs(%0 : tensor<702x702x128xf32>) {
-    ^bb0(%in: f32, %in_1: f32, %out: f32):
-      %9 = arith.mulf %in, %in_1 : f32
-      linalg.yield %9 : f32
-    } -> tensor<702x702x128xf32>
-    %5 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg1, %3 : tensor<702x702x128xf32>, tensor<702x702x128xf32>) outs(%0 : tensor<702x702x128xf32>) {
-    ^bb0(%in: f32, %in_1: f32, %out: f32):
-      %9 = arith.mulf %in, %in_1 : f32
-      linalg.yield %9 : f32
-    } -> tensor<702x702x128xf32>
-    %6 = tensor.empty() : tensor<128x702x702xf32>
-    %7 = linalg.fill ins(%cst_0 : f32) outs(%6 : tensor<128x702x702xf32>) -> tensor<128x702x702xf32>
-    %8 = linalg.generic {indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "parallel", "reduction"]} ins(%5, %4 : tensor<702x702x128xf32>, tensor<702x702x128xf32>) outs(%7 : tensor<128x702x702xf32>) {
-    ^bb0(%in: f32, %in_1: f32, %out: f32):
-      %9 = arith.mulf %in, %in_1 : f32
-      %10 = arith.addf %out, %9 : f32
-      linalg.yield %10 : f32
-    } -> tensor<128x702x702xf32>
-    util.return %8 : tensor<128x702x702xf32>
-  }
+util.func public @nofuse_broadcast_compute(%arg0: tensor<702x702x128xf32>, %arg1: tensor<702x702x128xf32>,
+    %arg2: tensor<702x702x128xf32>, %arg3: tensor<702x702x128xf32>) -> tensor<128x702x702xf32> {
+  %cst = arith.constant dense<1.000000e+00> : tensor<702x702x128xf32>
+  %cst_0 = arith.constant 0.000000e+00 : f32
+  %0 = tensor.empty() : tensor<702x702x128xf32>
+  %1 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg3 : tensor<702x702x128xf32>) outs(%0 : tensor<702x702x128xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %9 = math.exp %in : f32
+    linalg.yield %9 : f32
+  } -> tensor<702x702x128xf32>
+  %2 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%1, %cst : tensor<702x702x128xf32>, tensor<702x702x128xf32>) outs(%0 : tensor<702x702x128xf32>) {
+  ^bb0(%in: f32, %in_1: f32, %out: f32):
+    %9 = arith.addf %in, %in_1 : f32
+    linalg.yield %9 : f32
+  } -> tensor<702x702x128xf32>
+  %3 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%cst, %2 : tensor<702x702x128xf32>, tensor<702x702x128xf32>) outs(%0 : tensor<702x702x128xf32>) {
+  ^bb0(%in: f32, %in_1: f32, %out: f32):
+    %9 = arith.divf %in, %in_1 : f32
+    linalg.yield %9 : f32
+  } -> tensor<702x702x128xf32>
+  %4 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg0, %arg2 : tensor<702x702x128xf32>, tensor<702x702x128xf32>) outs(%0 : tensor<702x702x128xf32>) {
+  ^bb0(%in: f32, %in_1: f32, %out: f32):
+    %9 = arith.mulf %in, %in_1 : f32
+    linalg.yield %9 : f32
+  } -> tensor<702x702x128xf32>
+  %5 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg1, %3 : tensor<702x702x128xf32>, tensor<702x702x128xf32>) outs(%0 : tensor<702x702x128xf32>) {
+  ^bb0(%in: f32, %in_1: f32, %out: f32):
+    %9 = arith.mulf %in, %in_1 : f32
+    linalg.yield %9 : f32
+  } -> tensor<702x702x128xf32>
+  %6 = tensor.empty() : tensor<128x702x702xf32>
+  %7 = linalg.fill ins(%cst_0 : f32) outs(%6 : tensor<128x702x702xf32>) -> tensor<128x702x702xf32>
+  %8 = linalg.generic {indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "parallel", "reduction"]} ins(%5, %4 : tensor<702x702x128xf32>, tensor<702x702x128xf32>) outs(%7 : tensor<128x702x702xf32>) {
+  ^bb0(%in: f32, %in_1: f32, %out: f32):
+    %9 = arith.mulf %in, %in_1 : f32
+    %10 = arith.addf %out, %9 : f32
+    linalg.yield %10 : f32
+  } -> tensor<128x702x702xf32>
+  util.return %8 : tensor<128x702x702xf32>
 }
 // CHECK-LABEL: util.func public @nofuse_broadcast_compute(
 //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<702x702x128xf32>

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/pipeline_tests.mlir
@@ -5,41 +5,39 @@
 #map1 = affine_map<(d0, d1) -> (d1)>
 #map2 = affine_map<(d0, d1) -> (d0, d1)>
 #map3 = affine_map<(d0, d1) -> ()>
-module {
-  util.func public @main(%arg0: tensor<833xi32>, %arg1: tensor<833x833xf32>, %arg2: tensor<f32>) -> tensor<f32> {
-    %cst = arith.constant 5.66893432E-4 : f32
-    %0 = tensor.empty() : tensor<833x833xf32>
-    %1 = linalg.generic {
-        indexing_maps = [#map2, #map3, #map2], iterator_types = ["parallel", "parallel"]}
-        ins(%arg1, %arg2 : tensor<833x833xf32>, tensor<f32>)
-        outs(%0 : tensor<833x833xf32>) {
-      ^bb0(%b0 : f32, %b1 : f32, %b2 : f32):
-        %2 = arith.divf %b0, %b1 : f32
-        linalg.yield %2 : f32
-      } -> tensor<833x833xf32>
-    %4 = linalg.generic {
-        indexing_maps = [#map, #map1, #map2, #map2], iterator_types = ["parallel", "parallel"]}
-        ins(%arg0, %arg0, %1 : tensor<833xi32>, tensor<833xi32>, tensor<833x833xf32>)
-        outs(%0 : tensor<833x833xf32>) {
-      ^bb0(%b0 : i32, %b1 : i32, %b2 : f32, %b3 : f32):
-        %5 = arith.cmpi eq, %b0, %b1 : i32
-        %6 = arith.select %5, %b2, %cst : f32
-        linalg.yield %6 : f32
-      } -> tensor<833x833xf32>
-    %7 = tensor.empty() : tensor<f32>
-    %8 = linalg.fill ins(%cst : f32) outs(%7 : tensor<f32>) -> tensor<f32>
-    %9 = linalg.generic {
-        indexing_maps = [#map2, #map3], iterator_types = ["reduction", "reduction"]}
-        ins(%4 : tensor<833x833xf32>) outs(%7 : tensor<f32>) {
-      ^bb0(%b0 : f32, %b1 : f32):
-        %10 = arith.addf %b1, %b0 : f32
-        linalg.yield %10 : f32
-      } -> tensor<f32>
-    util.return %9 : tensor<f32>
-  }
+util.func public @main(%arg0: tensor<833xi32>, %arg1: tensor<833x833xf32>, %arg2: tensor<f32>) -> tensor<f32> {
+  %cst = arith.constant 5.66893432E-4 : f32
+  %0 = tensor.empty() : tensor<833x833xf32>
+  %1 = linalg.generic {
+      indexing_maps = [#map2, #map3, #map2], iterator_types = ["parallel", "parallel"]}
+      ins(%arg1, %arg2 : tensor<833x833xf32>, tensor<f32>)
+      outs(%0 : tensor<833x833xf32>) {
+    ^bb0(%b0 : f32, %b1 : f32, %b2 : f32):
+      %2 = arith.divf %b0, %b1 : f32
+      linalg.yield %2 : f32
+    } -> tensor<833x833xf32>
+  %4 = linalg.generic {
+      indexing_maps = [#map, #map1, #map2, #map2], iterator_types = ["parallel", "parallel"]}
+      ins(%arg0, %arg0, %1 : tensor<833xi32>, tensor<833xi32>, tensor<833x833xf32>)
+      outs(%0 : tensor<833x833xf32>) {
+    ^bb0(%b0 : i32, %b1 : i32, %b2 : f32, %b3 : f32):
+      %5 = arith.cmpi eq, %b0, %b1 : i32
+      %6 = arith.select %5, %b2, %cst : f32
+      linalg.yield %6 : f32
+    } -> tensor<833x833xf32>
+  %7 = tensor.empty() : tensor<f32>
+  %8 = linalg.fill ins(%cst : f32) outs(%7 : tensor<f32>) -> tensor<f32>
+  %9 = linalg.generic {
+      indexing_maps = [#map2, #map3], iterator_types = ["reduction", "reduction"]}
+      ins(%4 : tensor<833x833xf32>) outs(%7 : tensor<f32>) {
+    ^bb0(%b0 : f32, %b1 : f32):
+      %10 = arith.addf %b1, %b0 : f32
+      linalg.yield %10 : f32
+    } -> tensor<f32>
+  util.return %9 : tensor<f32>
 }
-// Check that the linalg op with two reduction loops get folded into a single reduction
-// which then prevents the parallel ops to be folded into it.
+// Check that the linalg op with two reduction loops get folded into a single
+// reduction which then prevents the parallel ops to be folded into it.
 // See https://github.com/iree-org/iree/issues/13285
 //       CHECK:   flow.executable private @[[EXECUTABLE0:[a-zA-Z0-9_]+]]
 //       CHECK:     func.func @[[FUNC0:[a-zA-Z0-9_x]+]]
@@ -57,30 +55,28 @@ module {
 #map2 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d3, d4)>
 #map3 = affine_map<(d0, d1, d2, d3, d4) -> (d2, d3, d4)>
 #map4 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
-module {
-  util.func public @grouped_quantized_matmul(%arg0: tensor<4096x32x128xi4>, %arg1: tensor<1x1x32x128xf32>, %arg2: tensor<4096x32x1xf32>, %arg3: tensor<4096x32x1xf32>) -> tensor<1x1x4096xf32> {
-    %cst = arith.constant 0.000000e+00 : f32
-    %0 = tensor.empty() : tensor<1x1x4096xf32>
-    %1 = tensor.empty() : tensor<4096x32x128xf32>
-    %2 = linalg.fill ins(%cst : f32) outs(%0 : tensor<1x1x4096xf32>) -> tensor<1x1x4096xf32>
-    %3 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg0, %arg2, %arg3 : tensor<4096x32x128xi4>, tensor<4096x32x1xf32>, tensor<4096x32x1xf32>) outs(%1 : tensor<4096x32x128xf32>) {
-    ^bb0(%in: i4, %in_0: f32, %in_1: f32, %out: f32):
-      %5 = arith.extui %in : i4 to i32
-      %6 = arith.uitofp %5 : i32 to f32
-      %7 = arith.subf %6, %in_1 : f32
-      %8 = arith.mulf %7, %in_0 : f32
-      linalg.yield %8 : f32
-    } -> tensor<4096x32x128xf32>
-    %4 = linalg.generic {indexing_maps = [#map2, #map3, #map4], iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction"]} ins(%arg1, %3 : tensor<1x1x32x128xf32>, tensor<4096x32x128xf32>) outs(%2 : tensor<1x1x4096xf32>) {
-    ^bb0(%in: f32, %in_0: f32, %out: f32):
-      %5 = arith.mulf %in, %in_0 : f32
-      %6 = arith.addf %5, %out : f32
-      linalg.yield %6 : f32
-    } -> tensor<1x1x4096xf32>
-    util.return %4 : tensor<1x1x4096xf32>
-  }
+util.func public @grouped_quantized_matmul(%arg0: tensor<4096x32x128xi4>, %arg1: tensor<1x1x32x128xf32>, %arg2: tensor<4096x32x1xf32>, %arg3: tensor<4096x32x1xf32>) -> tensor<1x1x4096xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = tensor.empty() : tensor<1x1x4096xf32>
+  %1 = tensor.empty() : tensor<4096x32x128xf32>
+  %2 = linalg.fill ins(%cst : f32) outs(%0 : tensor<1x1x4096xf32>) -> tensor<1x1x4096xf32>
+  %3 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg0, %arg2, %arg3 : tensor<4096x32x128xi4>, tensor<4096x32x1xf32>, tensor<4096x32x1xf32>) outs(%1 : tensor<4096x32x128xf32>) {
+  ^bb0(%in: i4, %in_0: f32, %in_1: f32, %out: f32):
+    %5 = arith.extui %in : i4 to i32
+    %6 = arith.uitofp %5 : i32 to f32
+    %7 = arith.subf %6, %in_1 : f32
+    %8 = arith.mulf %7, %in_0 : f32
+    linalg.yield %8 : f32
+  } -> tensor<4096x32x128xf32>
+  %4 = linalg.generic {indexing_maps = [#map2, #map3, #map4], iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction"]} ins(%arg1, %3 : tensor<1x1x32x128xf32>, tensor<4096x32x128xf32>) outs(%2 : tensor<1x1x4096xf32>) {
+  ^bb0(%in: f32, %in_0: f32, %out: f32):
+    %5 = arith.mulf %in, %in_0 : f32
+    %6 = arith.addf %5, %out : f32
+    linalg.yield %6 : f32
+  } -> tensor<1x1x4096xf32>
+  util.return %4 : tensor<1x1x4096xf32>
 }
-// Check that the two linalg.generic ops are fused into the same dispatch
+// Check that the two linalg.generic ops are fused into the same dispatch.
 //       CHECK:   flow.executable private @[[EXECUTABLE0:[a-zA-Z0-9_]+]]
 //       CHECK:   func.func @[[FUNC0:[a-zA-Z0-9_x]+]]
 //       CHECK:   %[[GEN0:.+]] = linalg.generic

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/emplace_allocations.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/emplace_allocations.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module( util.func(iree-stream-emplace-allocations))' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(util.func(iree-stream-emplace-allocations))' %s | FileCheck %s
 
 // Tests that a dispatch result is placed into the target of an update.
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/layout_slices.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/layout_slices.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module( util.func(iree-stream-layout-slices, cse))' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(util.func(iree-stream-layout-slices, cse))' %s | FileCheck %s
 
 #layoutStaticConfig = #stream.resource_config<{
   max_allocation_size = 1073741824,

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/materialize_copy_on_write.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/materialize_copy_on_write.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module( util.func(iree-stream-materialize-copy-on-write))' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(util.func(iree-stream-materialize-copy-on-write))' %s | FileCheck %s
 
 // Tests that block arguments (including function arguments) are always cloned.
 // Until a whole-program analysis runs we don't know their semantics.

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/pack_constants.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/pack_constants.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module( util.func(iree-stream-pack-constants))' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(util.func(iree-stream-pack-constants))' %s | FileCheck %s
 
 // This is a high level test of the structure emitted by the pass.
 // Subsequent tests focus on individual components.

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/schedule_concurrency.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/schedule_concurrency.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module( util.func(iree-stream-schedule-concurrency))" %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(util.func(iree-stream-schedule-concurrency))" %s | FileCheck %s
 
 // Tests that when favor=min-peak-memory we assume ops are in an order that
 // reduces live memory ranges and only optimistically put them in concurrency

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/schedule_execution.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/schedule_execution.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module( util.func(iree-stream-schedule-execution))" %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(util.func(iree-stream-schedule-execution))" %s | FileCheck %s
 
 // Tests basic partitioning of multiple ops.
 


### PR DESCRIPTION
Note that there's always a top-level module and the only time one is required in a lit test is if an expected-error at the module scope needs a line to anchor on. Otherwise they should be omitted.