### PR TITLE
[LLVMGPU] Add translation_info config knobs to disable passes

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUReduceBankConflicts.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUReduceBankConflicts.cpp
@@ -10,6 +10,7 @@
 #include "mlir/Dialect/GPU/Transforms/Passes.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Support/LogicalResult.h"
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUReduceBankConflicts.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUReduceBankConflicts.cpp
@@ -10,7 +10,6 @@
 #include "mlir/Dialect/GPU/Transforms/Passes.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
-#include "mlir/Support/LogicalResult.h"
 
 namespace mlir::iree_compiler {
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -145,9 +145,19 @@ static LogicalResult gpuCopyFn(OpBuilder &builder, Location loc, Value from,
   return success();
 }
 
-// Returns success when workgroup reordering is supported for `funcOp`.
-// On ROCm, we require workgroup counts to be static.
+// Returns success when workgroup reordering is supported / enabled for
+// `funcOp`. On ROCm, we require workgroup counts to be static.
 static LogicalResult canReorderWorkgroups(FunctionOpInterface funcOp) {
+  if (IREE::Codegen::TranslationInfoAttr translationInfo =
+          getTranslationInfo(funcOp)) {
+    if (DictionaryAttr config = translationInfo.getConfiguration()) {
+      // Escape hatch to disable workgroup reordering.
+      if (config.contains(LLVMGPUAttrNames::kNoReorderWorkgroups)) {
+        return failure();
+      }
+    }
+  }
+
   auto target = IREE::HAL::ExecutableTargetAttr::lookup(funcOp);
   if (!target) {
     return failure();
@@ -164,6 +174,24 @@ static LogicalResult canReorderWorkgroups(FunctionOpInterface funcOp) {
   // This is further restricted to 2D+ grids as we reorder along the X and Y
   // workgroup IDs.
   return success(workgroupCounts.size() >= 2);
+}
+
+// Returns success when shared memory bank conflict reduction is supported /
+// enabled for `funcOp`.
+static LogicalResult
+canReduceSharedMemoryBankConflicts(FunctionOpInterface funcOp) {
+  if (IREE::Codegen::TranslationInfoAttr translationInfo =
+          getTranslationInfo(funcOp)) {
+    if (DictionaryAttr config = translationInfo.getConfiguration()) {
+      // Escape hatch to disable shared memory padding.
+      if (config.contains(
+              LLVMGPUAttrNames::kNoReduceSharedMemoryBankConflicts)) {
+        return failure();
+      }
+    }
+  }
+
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -18,8 +18,6 @@
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Codegen/Utils/MarkerUtils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
-#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
-#include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
 #include "iree/compiler/Dialect/Util/Transforms/Passes.h"
 #include "iree/compiler/Utils/PassUtils.h"
 #include "llvm/ADT/STLForwardCompat.h"
@@ -31,9 +29,7 @@
 #include "mlir/Dialect/Affine/Passes.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Arith/Transforms/Passes.h"
-#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
-#include "mlir/Dialect/GPU/Transforms/Passes.h"
 #include "mlir/Dialect/Linalg/Passes.h"
 #include "mlir/Dialect/MemRef/Transforms/Passes.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -78,6 +74,15 @@ static llvm::cl::opt<bool> clLLVMGPUEnablePrefetch(
     "iree-llvmgpu-enable-prefetch",
     llvm::cl::desc("Enable prefetch in the vector distribute pipeline"),
     llvm::cl::init(false));
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                              const LLVMGPUPipelineOptions &options) {
+  return os << "{"
+            << "enableReduceSharedMemoryBankConflicts = "
+            << options.enableReduceSharedMemoryBankConflicts
+            << ", enableReorderWorkgroups = " << options.enableReorderWorkgroups
+            << ", enableUkernels = " << options.enableUkernels << "}";
+}
 
 //===----------------------------------------------------------------------===//
 // Bufferization Configuration
@@ -148,16 +153,6 @@ static LogicalResult gpuCopyFn(OpBuilder &builder, Location loc, Value from,
 // Returns success when workgroup reordering is supported / enabled for
 // `funcOp`. On ROCm, we require workgroup counts to be static.
 static LogicalResult canReorderWorkgroups(FunctionOpInterface funcOp) {
-  if (IREE::Codegen::TranslationInfoAttr translationInfo =
-          getTranslationInfo(funcOp)) {
-    if (DictionaryAttr config = translationInfo.getConfiguration()) {
-      // Escape hatch to disable workgroup reordering.
-      if (config.contains(LLVMGPUAttrNames::kNoReorderWorkgroups)) {
-        return failure();
-      }
-    }
-  }
-
   auto target = IREE::HAL::ExecutableTargetAttr::lookup(funcOp);
   if (!target) {
     return failure();
@@ -174,24 +169,6 @@ static LogicalResult canReorderWorkgroups(FunctionOpInterface funcOp) {
   // This is further restricted to 2D+ grids as we reorder along the X and Y
   // workgroup IDs.
   return success(workgroupCounts.size() >= 2);
-}
-
-// Returns success when shared memory bank conflict reduction is supported /
-// enabled for `funcOp`.
-static LogicalResult
-canReduceSharedMemoryBankConflicts(FunctionOpInterface funcOp) {
-  if (IREE::Codegen::TranslationInfoAttr translationInfo =
-          getTranslationInfo(funcOp)) {
-    if (DictionaryAttr config = translationInfo.getConfiguration()) {
-      // Escape hatch to disable shared memory padding.
-      if (config.contains(
-              LLVMGPUAttrNames::kNoReduceSharedMemoryBankConflicts)) {
-        return failure();
-      }
-    }
-  }
-
-  return success();
 }
 
 //===----------------------------------------------------------------------===//
@@ -278,7 +255,8 @@ void addGPUVectorizationPassPipeline(OpPassManager &funcPassManager) {
 // MatmulSIMT
 //===---------------------------------------------------------------------===//
 
-void addGPUMatmulSimtPassPipeline(OpPassManager &funcPassManager) {
+void addGPUMatmulSimtPassPipeline(OpPassManager &funcPassManager,
+                                  const LLVMGPUPipelineOptions &options) {
   tileAndDistributeToWorkgroup(funcPassManager);
 
   funcPassManager.addPass(createCanonicalizerPass());
@@ -304,10 +282,15 @@ void addGPUMatmulSimtPassPipeline(OpPassManager &funcPassManager) {
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
 
-  funcPassManager.addPass(createGPUReduceBankConflictsPass());
-  funcPassManager.addPass(createReorderWorkgroups(
-      clReorderWorkgroupsStrategy, clReorderWorkgroupsLogSwizzleTile,
-      canReorderWorkgroups));
+  if (options.enableReduceSharedMemoryBankConflicts) {
+    funcPassManager.addPass(createGPUReduceBankConflictsPass());
+  }
+
+  if (options.enableReorderWorkgroups) {
+    funcPassManager.addPass(createReorderWorkgroups(
+        clReorderWorkgroupsStrategy, clReorderWorkgroupsLogSwizzleTile,
+        canReorderWorkgroups));
+  }
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
 
@@ -334,6 +317,7 @@ void addGPUMatmulSimtPassPipeline(OpPassManager &funcPassManager) {
 //===---------------------------------------------------------------------===//
 
 void addGPUMatmulTensorCorePassPipeline(OpPassManager &funcPassManager,
+                                        const LLVMGPUPipelineOptions &options,
                                         unsigned pipelineDepth) {
   tileAndBufferize(funcPassManager);
 
@@ -349,9 +333,11 @@ void addGPUMatmulTensorCorePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createCSEPass());
 
   funcPassManager.addPass(createRemoveSingleIterationLoopPass());
-  funcPassManager.addPass(createReorderWorkgroups(
-      clReorderWorkgroupsStrategy, clReorderWorkgroupsLogSwizzleTile,
-      canReorderWorkgroups));
+  if (options.enableReorderWorkgroups) {
+    funcPassManager.addPass(createReorderWorkgroups(
+        clReorderWorkgroupsStrategy, clReorderWorkgroupsLogSwizzleTile,
+        canReorderWorkgroups));
+  }
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
 
@@ -367,7 +353,9 @@ void addGPUMatmulTensorCorePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createGPUDistributeSharedMemoryCopyPass());
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
-  funcPassManager.addPass(createGPUReduceBankConflictsPass());
+  if (options.enableReduceSharedMemoryBankConflicts) {
+    funcPassManager.addPass(createGPUReduceBankConflictsPass());
+  }
 
   // Vector -> MMA ops
   funcPassManager.addPass(memref::createFoldMemRefAliasOpsPass());
@@ -394,8 +382,9 @@ void addGPUMatmulTensorCorePassPipeline(OpPassManager &funcPassManager,
 // Matmul MMA.Sync
 //===---------------------------------------------------------------------===//
 
-void addGPUMatmulTensorCoreMmaSyncPassPipeline(OpPassManager &funcPassManager,
-                                               unsigned pipelineDepth) {
+void addGPUMatmulTensorCoreMmaSyncPassPipeline(
+    OpPassManager &funcPassManager, const LLVMGPUPipelineOptions &options,
+    unsigned pipelineDepth) {
   tileAndBufferize(funcPassManager);
 
   // Distribute linalg onto warps within the workgroup.
@@ -410,9 +399,11 @@ void addGPUMatmulTensorCoreMmaSyncPassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createCSEPass());
 
   funcPassManager.addPass(createRemoveSingleIterationLoopPass());
-  funcPassManager.addPass(createReorderWorkgroups(
-      clReorderWorkgroupsStrategy, clReorderWorkgroupsLogSwizzleTile,
-      canReorderWorkgroups));
+  if (options.enableReorderWorkgroups) {
+    funcPassManager.addPass(createReorderWorkgroups(
+        clReorderWorkgroupsStrategy, clReorderWorkgroupsLogSwizzleTile,
+        canReorderWorkgroups));
+  }
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
 
@@ -456,7 +447,8 @@ void addGPUMatmulTensorCoreMmaSyncPassPipeline(OpPassManager &funcPassManager,
 // Transpose
 //===---------------------------------------------------------------------===//
 
-void addGPUTransposePassPipeline(OpPassManager &funcPassManager) {
+void addGPUTransposePassPipeline(OpPassManager &funcPassManager,
+                                 const LLVMGPUPipelineOptions &options) {
   tileAndDistributeToWorkgroup(funcPassManager);
 
   funcPassManager.addPass(createCanonicalizerPass());
@@ -484,8 +476,8 @@ void addGPUTransposePassPipeline(OpPassManager &funcPassManager) {
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
 
-  // May or may not need to reduce shared mememory conflicts
-  {
+  if (options.enableReduceSharedMemoryBankConflicts) {
+    // May or may not need to reduce shared mememory conflicts.
     GPUReduceBankConflictsPassOptions options = {};
     options.paddingBits = 32;
     funcPassManager.addPass(createGPUReduceBankConflictsPass(options));
@@ -561,11 +553,14 @@ static void addVectorBufferizePasses(OpPassManager &funcPassManager) {
 }
 
 void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager,
+                                        const LLVMGPUPipelineOptions &options,
                                         bool usePadToModelSharedMemcpy) {
   tileAndDistributeToWorkgroup(funcPassManager);
-  funcPassManager.addPass(createReorderWorkgroups(
-      clReorderWorkgroupsStrategy, clReorderWorkgroupsLogSwizzleTile,
-      canReorderWorkgroups));
+  if (options.enableReorderWorkgroups) {
+    funcPassManager.addPass(createReorderWorkgroups(
+        clReorderWorkgroupsStrategy, clReorderWorkgroupsLogSwizzleTile,
+        canReorderWorkgroups));
+  }
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
 
@@ -616,7 +611,7 @@ void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
 
-  {
+  if (options.enableReduceSharedMemoryBankConflicts) {
     GPUReduceBankConflictsPassOptions options = {};
     options.paddingBits = 64;
     funcPassManager.addPass(createGPUReduceBankConflictsPass(options));
@@ -717,10 +712,10 @@ void addGPUSimpleDistributePassPipeline(OpPassManager &funcPassManager) {
 }
 
 void addGPUDefaultPassPipeline(OpPassManager &funcPassManager,
-                               bool enableMicrokernels) {
+                               const LLVMGPUPipelineOptions &options) {
   tileAndDistributeToWorkgroup(funcPassManager,
                                /*useWARForCooperativeMatrixCodegen=*/true);
-  if (enableMicrokernels) {
+  if (options.enableUkernels) {
     funcPassManager.addPass(createGPULowerToUKernelsPass());
   }
   funcPassManager.addPass(createCanonicalizerPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
@@ -18,6 +18,19 @@
 namespace mlir::iree_compiler {
 
 //===----------------------------------------------------------------------===//
+// Constants
+//===----------------------------------------------------------------------===//
+
+/// Named attributes used in the `translation_info`'s config dictionary
+/// attribute. These are used to override default pass heuristics at the
+/// function granularity.
+namespace LLVMGPUAttrNames {
+inline constexpr StringLiteral kNoReorderWorkgroups = "no_reorder_workgroups";
+inline constexpr StringLiteral kNoReduceSharedMemoryBankConflicts =
+    "no_reduce_shared_memory_bank_conflicts";
+} //  namespace LLVMGPUAttrNames
+
+//===----------------------------------------------------------------------===//
 // Passes
 //===----------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
@@ -18,7 +18,7 @@
 namespace mlir::iree_compiler {
 
 //===----------------------------------------------------------------------===//
-// Constants
+// Pass Pipeline Options
 //===----------------------------------------------------------------------===//
 
 /// Named attributes used in the `translation_info`'s config dictionary
@@ -30,19 +30,31 @@ inline constexpr StringLiteral kNoReduceSharedMemoryBankConflicts =
     "no_reduce_shared_memory_bank_conflicts";
 } //  namespace LLVMGPUAttrNames
 
+struct LLVMGPUPipelineOptions {
+  bool enableReduceSharedMemoryBankConflicts = true;
+  bool enableReorderWorkgroups = true;
+  bool enableUkernels = false;
+};
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                              const LLVMGPUPipelineOptions &options);
+
 //===----------------------------------------------------------------------===//
 // Passes
 //===----------------------------------------------------------------------===//
 
 /// Lowering using SIMT CUDA core operations.
-void addGPUMatmulSimtPassPipeline(OpPassManager &funcPassManager);
+void addGPUMatmulSimtPassPipeline(OpPassManager &funcPassManager,
+                                  const LLVMGPUPipelineOptions &options);
 
 /// Lowering using mma.sync Tensor Core operations.
-void addGPUMatmulTensorCoreMmaSyncPassPipeline(OpPassManager &funcPassManager,
-                                               unsigned pipelineDepth);
+void addGPUMatmulTensorCoreMmaSyncPassPipeline(
+    OpPassManager &funcPassManager, const LLVMGPUPipelineOptions &options,
+    unsigned pipelineDepth);
 
 /// Lowering using wmma Tensor Core operations.
 void addGPUMatmulTensorCorePassPipeline(OpPassManager &funcPassManager,
+                                        const LLVMGPUPipelineOptions &options,
                                         unsigned pipelineDepth);
 
 void addGPUPackUnPackPasses(OpPassManager &funcPassManager);
@@ -57,7 +69,8 @@ void addGPUTransformDialectPasses(OpPassManager &funcPassManager,
                                   StringRef entryPoint);
 
 /// Lowering transpose using shared memory.
-void addGPUTransposePassPipeline(OpPassManager &funcPassManager);
+void addGPUTransposePassPipeline(OpPassManager &funcPassManager,
+                                 const LLVMGPUPipelineOptions &options);
 
 /// Lowering calling vectorization patterns. Expects pass manager to be a
 /// module-level pass manager.
@@ -65,6 +78,7 @@ void addGPUVectorizationPassPipeline(OpPassManager &funcPassManager);
 
 /// Lowering based on vector distribution patterns.
 void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager,
+                                        const LLVMGPUPipelineOptions &options,
                                         bool usePadToModelSharedMemcpy);
 
 /// Lowering reductions to warp reductions.
@@ -72,7 +86,7 @@ void addGPUWarpReductionPassPipeline(OpPassManager &funcPassManager);
 
 /// Default pass pipeline on GPU, currently used only for the ukernel path.
 void addGPUDefaultPassPipeline(OpPassManager &funcPassManager,
-                               bool enableMicrokernels);
+                               const LLVMGPUPipelineOptions &options);
 
 /// Pass pipeline to lower IREE HAL executables without tiling and distribution.
 void addGPUBaseLoweringPassPipeline(OpPassManager &pm);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/BUILD.bazel
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     srcs = enforce_glob(
         [
             "config_vector_distribute.mlir",
+            "config_user_vector_distribute.mlir",
             "lowering_scalar_dispatch.mlir",
             "pipeline_vector_distribute.mlir",
             "pipeline_warp_reduction.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
@@ -14,8 +14,8 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "config_vector_distribute.mlir"
     "config_user_vector_distribute.mlir"
+    "config_vector_distribute.mlir"
     "lowering_scalar_dispatch.mlir"
     "pipeline_vector_distribute.mlir"
     "pipeline_warp_reduction.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "config_vector_distribute.mlir"
+    "config_user_vector_distribute.mlir"
     "lowering_scalar_dispatch.mlir"
     "pipeline_vector_distribute.mlir"
     "pipeline_warp_reduction.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_user_vector_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_user_vector_distribute.mlir
@@ -1,0 +1,130 @@
+// RUN: iree-opt --split-input-file --iree-codegen-llvmgpu-use-vector-distribution \
+// RUN:   --iree-codegen-reorder-workgroups-strategy=transpose \
+// RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-llvmgpu-select-lowering-strategy, func.func(iree-llvmgpu-lower-executable-target)))))" %s | FileCheck %s
+
+// Check that applying the `no_reduce_shared_memory_bank_conflicts` unit attribute disables shared memory padding.
+
+// CHECK:       #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64
+// CHECK-SAME:    mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>,
+// CHECK-SAME:    no_reduce_shared_memory_bank_conflicts
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>
+  ]>
+]>
+hal.executable public @main_0_dispatch_0 {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb", {
+        mma_intrinsics = [#iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>, #iree_gpu.mma_layout<MFMA_F16_32x32x8_F32>],
+        target_arch = "gfx942",
+        ukernels = "none"
+      }>) {
+    hal.executable.export public @main_0_dispatch_0_matmul_transpose_b_2048x10240x1280_f16xf16xf32 ordinal(0) layout(#pipeline_layout)
+    attributes {hal.interface.bindings = [#hal.interface.binding<0, 0>, #hal.interface.binding<0, 1>, #hal.interface.binding<0, 2>]} {
+    ^bb0(%arg0: !hal.device):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_slice
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      // CHECK-LABEL: func.func @main_0_dispatch_0_matmul_transpose_b
+      // CHECK:         memref.alloc() : memref<128x32xf16, #gpu.address_space<workgroup>>
+      // CHECK:         memref.alloc() : memref<128x32xf16, #gpu.address_space<workgroup>>
+
+      func.func @main_0_dispatch_0_matmul_transpose_b_2048x10240x1280_f16xf16xf32()
+        attributes {translation_info = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64, {
+          mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>, subgroup_m_count = 2, subgroup_n_count = 2>,
+          no_reduce_shared_memory_bank_conflicts  // Disable the 'reduceSharedMemoryBankConflicts' pass.
+        }>} {
+        %cst = arith.constant 0.000000e+00 : f16
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2048x1280xf16>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<10240x1280xf16>>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2048x10240xf32>>
+        %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2048, 1280], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<2048x1280xf16>> -> tensor<2048x1280xf16>
+        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [10240, 1280], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<10240x1280xf16>> -> tensor<10240x1280xf16>
+        %5 = tensor.empty() : tensor<2048x10240xf32>
+        %6 = linalg.fill {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[128, 128, 32]]>} ins(%cst : f16) outs(%5 : tensor<2048x10240xf32>) -> tensor<2048x10240xf32>
+        %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
+                                              affine_map<(d0, d1, d2) -> (d1, d2)>,
+                                              affine_map<(d0, d1, d2) -> (d0, d1)>],
+                             iterator_types = ["parallel", "parallel", "reduction"]}
+          ins(%3, %4 : tensor<2048x1280xf16>, tensor<10240x1280xf16>)
+          outs(%6 : tensor<2048x10240xf32>) {
+        ^bb0(%in: f16, %in_0: f16, %out: f32):
+          %8 = arith.extf %in : f16 to f32
+          %9 = arith.extf %in_0 : f16 to f32
+          %10 = arith.mulf %8, %9 : f32
+          %11 = arith.addf %out, %10 : f32
+          linalg.yield %11 : f32
+        } -> tensor<2048x10240xf32>
+        flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [2048, 10240], strides = [1, 1] : tensor<2048x10240xf32> -> !flow.dispatch.tensor<writeonly:tensor<2048x10240xf32>>
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+// Check that applying the `no_reorder_workgroups` unit attribute disables workgroup reordering.
+
+// CHECK:       #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64
+// CHECK-SAME:    mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>,
+// CHECK-SAME:    no_reorder_workgroups
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>
+  ]>
+]>
+hal.executable public @main_0_dispatch_0 {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb", {
+        mma_intrinsics = [#iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>, #iree_gpu.mma_layout<MFMA_F16_32x32x8_F32>],
+        target_arch = "gfx942",
+        ukernels = "none"
+      }>) {
+    hal.executable.export public @main_0_dispatch_0_matmul_transpose_b_2048x10240x1280_f16xf16xf32 ordinal(0) layout(#pipeline_layout)
+    attributes {hal.interface.bindings = [#hal.interface.binding<0, 0>, #hal.interface.binding<0, 1>, #hal.interface.binding<0, 2>]} {
+    ^bb0(%arg0: !hal.device):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_slice
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      // CHECK-LABEL: func.func @main_0_dispatch_0_matmul_transpose_b
+      // CHECK-DAG:     hal.interface.workgroup.id[1] : index
+      // CHECK-DAG:     hal.interface.workgroup.id[0] : index
+      // CHECK-NEXT:    scf.for
+
+      func.func @main_0_dispatch_0_matmul_transpose_b_2048x10240x1280_f16xf16xf32()
+        attributes {translation_info = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64, {
+          mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>, subgroup_m_count = 2, subgroup_n_count = 2>,
+          no_reorder_workgroups  // Disable the 'reorderWorkgroups' pass.
+        }>} {
+        %cst = arith.constant 0.000000e+00 : f16
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2048x1280xf16>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<10240x1280xf16>>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2048x10240xf32>>
+        %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2048, 1280], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<2048x1280xf16>> -> tensor<2048x1280xf16>
+        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [10240, 1280], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<10240x1280xf16>> -> tensor<10240x1280xf16>
+        %5 = tensor.empty() : tensor<2048x10240xf32>
+        %6 = linalg.fill {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[128, 128, 32]]>} ins(%cst : f16) outs(%5 : tensor<2048x10240xf32>) -> tensor<2048x10240xf32>
+        %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
+                                              affine_map<(d0, d1, d2) -> (d1, d2)>,
+                                              affine_map<(d0, d1, d2) -> (d0, d1)>],
+                             iterator_types = ["parallel", "parallel", "reduction"]}
+          ins(%3, %4 : tensor<2048x1280xf16>, tensor<10240x1280xf16>)
+          outs(%6 : tensor<2048x10240xf32>) {
+        ^bb0(%in: f16, %in_0: f16, %out: f32):
+          %8 = arith.extf %in : f16 to f32
+          %9 = arith.extf %in_0 : f16 to f32
+          %10 = arith.mulf %8, %9 : f32
+          %11 = arith.addf %out, %10 : f32
+          linalg.yield %11 : f32
+        } -> tensor<2048x10240xf32>
+        flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [2048, 10240], strides = [1, 1] : tensor<2048x10240xf32> -> !flow.dispatch.tensor<writeonly:tensor<2048x10240xf32>>
+        return
+      }
+    }
+  }
+}

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_user_vector_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_user_vector_distribute.mlir
@@ -29,6 +29,11 @@ hal.executable public @main_0_dispatch_0 {
       // CHECK-LABEL: func.func @main_0_dispatch_0_matmul_transpose_b
       // CHECK:         memref.alloc() : memref<128x32xf16, #gpu.address_space<workgroup>>
       // CHECK:         memref.alloc() : memref<128x32xf16, #gpu.address_space<workgroup>>
+      // CHECK-DAG:     %[[WG_Y:.+]] = hal.interface.workgroup.id[1] : index
+      // CHECK-DAG:     %[[WG_X:.+]] = hal.interface.workgroup.id[0] : index
+      // CHECK-DAG:     arith.muli %[[WG_Y]], %{{.+}} : index
+      // CHECK-DAG:     arith.addi %{{.+}}, %[[WG_X]] : index
+      // CHECK:         scf.for
 
       func.func @main_0_dispatch_0_matmul_transpose_b_2048x10240x1280_f16xf16xf32()
         attributes {translation_info = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64, {
@@ -91,6 +96,8 @@ hal.executable public @main_0_dispatch_0 {
     }
     builtin.module {
       // CHECK-LABEL: func.func @main_0_dispatch_0_matmul_transpose_b
+      // CHECK:         memref.alloc() : memref<128x36xf16, #gpu.address_space<workgroup>>
+      // CHECK:         memref.alloc() : memref<128x36xf16, #gpu.address_space<workgroup>>
       // CHECK-DAG:     hal.interface.workgroup.id[1] : index
       // CHECK-DAG:     hal.interface.workgroup.id[0] : index
       // CHECK-NEXT:    scf.for

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute.mlir
@@ -275,7 +275,7 @@ module {
     return
   }
 }
-// Check taht we don't support LLVMGPUPadAndVectorDistribute for narrow N/M atm.
+// Check that we don't support LLVMGPUPadAndVectorDistribute for narrow N/M atm.
 // CHECK-NOT:      #iree_codegen.translation_info<LLVMGPUPadAndVectorDistribute
 // CHECK-LABEL: func.func @narrow_n_batch_matmul_64x968x4x320_f16()
 


### PR DESCRIPTION
Support disabling workgroup reordering and shared memory optimization passes based on translation info config entries. Because these are just named unit attributes, they do not require custom attributes defined in tablegen.

These are intended for tuning.

Issue: https://github.com/iree-org/iree/issues/16952