### PR TITLE
Switch Windows release package to use standard windows-2022 runner.

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -85,8 +85,10 @@ jobs:
             experimental: true
 
           # Windows packages.
-          - runs-on:
-              - ${{ github.repository == 'iree-org/iree' && 'windows-2022-64core' || 'windows-2022'}}
+          # TODO(scotttodd): build on larger runner when available (self-hosted or GitHub)
+          # - runs-on:
+          #     - ${{ github.repository == 'iree-org/iree' && 'windows-2022-64core' || 'windows-2022'}}
+          - runs-on: windows-2022
             build-family: windows
             build-package: py-compiler-pkg
             experimental: true


### PR DESCRIPTION
We disabled the [large GitHub-hosted runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners) a few days ago as part of reining in infrastructure costs. This workflow was still trying to use `windows-2022-64core`, so the jobs have been stuck waiting for runners: https://github.com/iree-org/iree/actions/workflows/build_package.yml.

Not sure if this will finish in under 6 hours without running out of disk space. See also https://github.com/iree-org/iree/pull/17145 (which disabled the large Windows runners in ci.yml for postsubmit testing)

skip-ci: not tested