### PR TITLE
Re-enable skipped tests that no longer hang.

### DIFF
--- a/build_tools/pkgci/external_test_suite/onnx_cpu_llvm_sync.json
+++ b/build_tools/pkgci/external_test_suite/onnx_cpu_llvm_sync.json
@@ -6,10 +6,7 @@
   "iree_run_module_flags": [
     "--device=local-sync"
   ],
-  "skip_compile_tests": [
-    "test_dequantizelinear",
-    "test_slice_default_axes"
-  ],
+  "skip_compile_tests": [],
   "skip_run_tests": [],
   "expected_compile_failures": [
     "test_acosh",

--- a/build_tools/pkgci/external_test_suite/onnx_gpu_cuda.json
+++ b/build_tools/pkgci/external_test_suite/onnx_gpu_cuda.json
@@ -6,15 +6,8 @@
   "iree_run_module_flags": [
     "--device=cuda"
   ],
-  "skip_compile_tests": [
-    "test_dequantizelinear",
-    "test_slice_default_axes"
-  ],
-  "skip_run_tests": [
-    "test_gather_elements_negative_indices",
-    "test_gridsample_zeros_padding",
-    "test_scatter_elements_with_negative_indices"
-  ],
+  "skip_compile_tests": [],
+  "skip_run_tests": [],
   "expected_compile_failures": [
     "test_acosh",
     "test_acosh_example",
@@ -615,6 +608,7 @@
     "test_einsum_transpose",
     "test_elu_default",
     "test_eyelike_with_dtype",
+    "test_gather_elements_negative_indices",
     "test_hardsigmoid",
     "test_hardsigmoid_default",
     "test_hardsigmoid_example",
@@ -657,6 +651,7 @@
     "test_reduce_sum_square_default_axes_keepdims_example_expanded",
     "test_reduce_sum_square_default_axes_keepdims_random",
     "test_reduce_sum_square_default_axes_keepdims_random_expanded",
+    "test_scatter_elements_with_negative_indices",
     "test_sce_mean_no_weight_ii",
     "test_sce_mean_no_weight_ii_log_prob",
     "test_shape_end_1",

--- a/build_tools/pkgci/external_test_suite/onnx_gpu_rocm_rdna3.json
+++ b/build_tools/pkgci/external_test_suite/onnx_gpu_rocm_rdna3.json
@@ -7,10 +7,7 @@
   "iree_run_module_flags": [
     "--device=hip"
   ],
-  "skip_compile_tests": [
-    "test_dequantizelinear",
-    "test_slice_default_axes"
-  ],
+  "skip_compile_tests": [],
   "skip_run_tests": [],
   "expected_compile_failures": [
     "test_acosh",

--- a/build_tools/pkgci/external_test_suite/onnx_gpu_vulkan.json
+++ b/build_tools/pkgci/external_test_suite/onnx_gpu_vulkan.json
@@ -6,10 +6,7 @@
   "iree_run_module_flags": [
     "--device=vulkan"
   ],
-  "skip_compile_tests": [
-    "test_dequantizelinear",
-    "test_slice_default_axes"
-  ],
+  "skip_compile_tests": [],
   "skip_run_tests": [],
   "expected_compile_failures": [
     "test_acosh",
@@ -154,6 +151,7 @@
     "test_cumsum_2d_negative_axis",
     "test_deform_conv_with_mask_bias",
     "test_deform_conv_with_multiple_offset_groups",
+    "test_dequantizelinear",
     "test_dequantizelinear_axis",
     "test_dequantizelinear_blocked",
     "test_dequantizelinear_e4m3fn",


### PR DESCRIPTION
Fixes https://github.com/iree-org/iree/issues/16666

These tests are no longer hanging when I run them locally.

ci-exactly: build_packages, regression_test_cpu, regression_test_amdgpu_vulkan, regression_test_amdgpu_rocm, regression_test_nvidiagpu_vulkan, regression_test_nvidiagpu_cuda