### PR TITLE
Add dependent dialects for custom dispatch to transform dialect interpreter pass

### DIFF
--- a/compiler/src/iree/compiler/Preprocessing/Common/InterpreterPass.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/InterpreterPass.cpp
@@ -6,6 +6,10 @@
 
 #include "iree/compiler/Preprocessing/Common/Passes.h"
 #include "mlir/Dialect/Transform/Transforms/TransformInterpreterUtils.h"
+#include "iree/compiler/Dialect/Stream/IR/StreamOps.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 
 using namespace mlir;
 

--- a/compiler/src/iree/compiler/Preprocessing/Common/Passes.td
+++ b/compiler/src/iree/compiler/Preprocessing/Common/Passes.td
@@ -61,7 +61,11 @@ def InterpreterPass : Pass<"iree-preprocessing-transform-interpreter"> {
     separate loading of the module and thus isn't suited for single-use
     transform scripts.
   }];
-  let dependentDialects = ["::mlir::transform::TransformDialect"];
+  let dependentDialects = ["::mlir::transform::TransformDialect",
+                           "iree_compiler::IREE::Stream::StreamDialect",
+                           "iree_compiler::IREE::Codegen::IREECodegenDialect",
+                           "iree_compiler::IREE::Flow::FlowDialect",
+  ];
   let options = [
     Option<"disableExpensiveChecks", "disable-expensive-checks", "bool",
            "false",


### PR DESCRIPTION
With this custom dispatch should be able to be demonstarted with just iree-opt command but in my experiment no matching happened?