### PR TITLE
[Codegen][GPU] Move MFMA/WMMA constructors to interface method

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
@@ -68,6 +68,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Utils:VectorOpUtils",
         "//llvm-external-projects/iree-dialects:IREEVectorExtDialect",
         "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:AMDGPUDialect",
         "@llvm-project//mlir:DialectUtils",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LinalgDialect",

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/CMakeLists.txt
@@ -39,6 +39,7 @@ iree_cc_library(
     ::IREEGPUOpsGen
     IREEVectorExtDialect
     LLVMSupport
+    MLIRAMDGPUDialect
     MLIRIR
     MLIRLinalgDialect
     MLIRParser

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -15,6 +15,7 @@
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
 #include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
@@ -329,6 +330,14 @@ MMAAttr MMAAttr::get(MLIRContext *context, MMAIntrinsic type) {
                    layout.cType);
 }
 
+std::tuple<Type, Type, Type> MMAAttr::getABCElementTypes() const {
+  return std::make_tuple(getAType(), getBType(), getCType());
+}
+
+std::tuple<int64_t, int64_t, int64_t> MMAAttr::getMNKShape() const {
+  return std::make_tuple(getMSize(), getNSize(), getKSize());
+}
+
 // NOTE: For layout specifications of the WMMA intrinsics
 //       below we are assuming subgroupsize of 32.
 std::tuple<VectorType, VectorType, VectorType>
@@ -393,20 +402,6 @@ int64_t MMAAttr::getSubgroupSize() const {
   }
   // This should not happen but just to make GCC happy.
   return 0;
-}
-
-MMAComputeType MMAAttr::getComputeType() const {
-  switch (getIntrinsic().getValue()) {
-  case MMAIntrinsic::MFMA_F16_16x16x16_F32:
-  case MMAIntrinsic::MFMA_F16_32x32x8_F32: {
-    return MMAComputeType::MFMA;
-  }
-  case MMAIntrinsic::WMMA_F16_16x16x16_F32: {
-    return MMAComputeType::WMMA;
-  }
-  }
-  // This should not happen but just to make GCC happy.
-  return MMAComputeType::INVALID;
 }
 
 SmallVector<int64_t> MMAAttr::getADataDuplicate() const {
@@ -518,6 +513,37 @@ MMAAttr::SingleSubgroupLayout MMAAttr::getCSingleSubgroupLayoutOrder() const {
   }
   }
   return {};
+}
+
+// Generates amdgpu.mfma/wmma operation on the given inputs for this attribute
+// type.
+FailureOr<Value> MMAAttr::buildMmaOperation(OpBuilder &builder, Location loc,
+                                            Type resultType, Value lhs,
+                                            Value rhs, Value acc) const {
+  auto [aType, bType, cType] = getABCVectorTypes();
+  if (aType != lhs.getType() || bType != rhs.getType() ||
+      cType != acc.getType()) {
+    return failure();
+  }
+  if (cType != resultType) {
+    return failure();
+  }
+  Value mmaOp;
+  switch (getIntrinsic().getValue()) {
+  case MMAIntrinsic::MFMA_F16_16x16x16_F32:
+  case MMAIntrinsic::MFMA_F16_32x32x8_F32: {
+    auto [m, n, k] = getMNKShape();
+    mmaOp = builder.create<amdgpu::MFMAOp>(loc, resultType, m, n, k,
+                                           getBlockSize(), lhs, rhs, acc);
+    break;
+  }
+  case MMAIntrinsic::WMMA_F16_16x16x16_F32: {
+    mmaOp = builder.create<amdgpu::WMMAOp>(loc, resultType, lhs, rhs, acc);
+    break;
+  }
+  }
+  assert(mmaOp && mmaOp.getType() == resultType && "Invalid mma op generated");
+  return mmaOp;
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -25,6 +25,7 @@ class IREEGPU_MmaVectorLayoutAttr<string attrname, string mmaintrinsic> :
     "getContractionLayout",
     "getMNKShape",
     "getSubgroupSize",
+    "buildMmaOperation",
   ]>
 ]> {
   let cppNamespace = "::mlir::iree_compiler::IREE::GPU";
@@ -61,16 +62,6 @@ class IREEGPU_MmaVectorLayoutAttr<string attrname, string mmaintrinsic> :
     "::mlir::Type":$bType,
     "::mlir::Type":$cType
   );
-
-  string baseExtraClassDeclaration = [{
-    ::std::tuple<Type, Type, Type> getABCElementTypes() {
-      return ::std::make_tuple(getAType(), getBType(), getCType());
-    }
-
-    ::std::tuple<int64_t, int64_t, int64_t> getMNKShape() {
-      return ::std::make_tuple(getMSize(), getNSize(), getKSize());
-    }
-  }];
 }
 
 class IREEGPU_I32MmaEnumAttr<string name, string summary, list<I32EnumAttrCase> cases>
@@ -95,16 +86,6 @@ def IREEGPU_MMAIntrinsic : IREEGPU_I32MmaEnumAttr<"MMAIntrinsic",
       MFMA_F16_16x16x16_F32,
       MFMA_F16_32x32x8_F32,
       WMMA_F16_16x16x16_F32
-    ]>;
-
-def INVALID_COMPUTE_TYPE : I32EnumAttrCase<"INVALID", 0>;
-def MFMA_COMPUTE_TYPE : I32EnumAttrCase<"MFMA", 1>;
-def WMMA_COMPUTE_TYPE : I32EnumAttrCase<"WMMA", 2>;
-def IREEGPU_MMAComputeType : IREEGPU_I32MmaEnumAttr<"MMAComputeType",
-    "Descriptor for different types of MMA operations", [
-      INVALID_COMPUTE_TYPE,
-      MFMA_COMPUTE_TYPE,
-      WMMA_COMPUTE_TYPE
     ]>;
 
 def IREEGPU_MMAIntrinsicAttr
@@ -132,9 +113,8 @@ def IREEGPU_MMAAttr : IREEGPU_MmaVectorLayoutAttr<"MMA", "MMAIntrinsicAttr"> {
     AttrBuilder<(ins "MMAIntrinsic":$intrinsic)>
   ];
 
-  let extraClassDeclaration = !strconcat(baseExtraClassDeclaration, [{
+  let extraClassDeclaration = [{
     int64_t getBlockSize() const;
-    MMAComputeType getComputeType() const;
     SmallVector<int64_t> getADataDuplicate() const;
     SmallVector<int64_t> getBDataDuplicate() const;
     SmallVector<int64_t> getCDataDuplicate() const;
@@ -165,7 +145,7 @@ def IREEGPU_MMAAttr : IREEGPU_MmaVectorLayoutAttr<"MMA", "MMAIntrinsicAttr"> {
     SingleSubgroupLayout getASingleSubgroupLayoutOrder() const;
     SingleSubgroupLayout getBSingleSubgroupLayoutOrder() const;
     SingleSubgroupLayout getCSingleSubgroupLayoutOrder() const;
-  }]);
+  }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.td
@@ -85,6 +85,25 @@ def IREEGPU_MmaInterfaceAttr : AttrInterface<"MmaInterfaceAttr"> {
       /*methodName=*/"getSubgroupSize",
       /*args=*/(ins)
     >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Constructs a concrete instance of the associated mma operation.
+      }],
+      /*retTy=*/"::mlir::FailureOr<::mlir::Value>",
+      /*methodName=*/"buildMmaOperation",
+      /*args=*/(ins
+        "::mlir::OpBuilder&":$builder,
+        "::mlir::Location":$loc,
+        "::mlir::Type":$result_type,
+        "::mlir::Value":$lhs,
+        "::mlir::Value":$rhs,
+        "::mlir::Value":$acc
+      ),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return failure();
+      }]
+    >,
   ];
 }
 


### PR DESCRIPTION
This moves the builder for mfma/wmma ops to a method on the MMAIntrinsic interface. This removes the dependency on the AMDGPU dialect from the contraction lowering and instead makes it a detail of the mma attribute. This makes it easier to add more mma variants without having to update the distribution pattern each time, and in theory will allow external users to define their own attribute implementing the interface and generate code for it.