### PR TITLE
[Codegen][GPU] Add pattern to lower iree_gpu.multi_mma to intrinsics

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/IREEGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/IREEGPUExtensions.cpp
@@ -33,6 +33,15 @@ void transform_dialect::ApplyDropMultiMmaOpUnitDims::populatePatterns(
 }
 
 //===---------------------------------------------------------------------===//
+// ApplyLowerMultiMmaOp
+//===---------------------------------------------------------------------===//
+
+void transform_dialect::ApplyLowerMultiMmaOp::populatePatterns(
+    RewritePatternSet &patterns) {
+  IREE::GPU::populateIREEGPULowerMultiMmaPatterns(patterns);
+}
+
+//===---------------------------------------------------------------------===//
 // ApplyVectorizeMultiMmaOp
 //===---------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/IREEGPUExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/IREEGPUExtensionsOps.td
@@ -27,6 +27,19 @@ def ApplyDropMultiMmaOpUnitDims : Op<Transform_Dialect,
   let assemblyFormat = "attr-dict";
 }
 
+def ApplyLowerMultiMmaOp : Op<Transform_Dialect,
+    "apply_patterns.iree.lower_multi_mma",
+    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+     ReportTrackingListenerFailuresOpTrait]> {
+  let description = [{
+    Populate patterns to drop the unit dims from multi_mma ops with
+    only unit iteration bounds.
+  }];
+
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+  let assemblyFormat = "attr-dict";
+}
+
 def ApplyVectorizeMultiMmaOp : Op<Transform_Dialect,
     "apply_patterns.iree.vectorize_multi_mma",
     [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/BUILD.bazel
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     srcs = enforce_glob(
         [
             "drop_multi_mma_unit_dims.mlir",
+            "lower_multi_mma.mlir",
             "vectorize_multi_mma.mlir",
             "unroll_multi_mma.mlir",
         ],

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "drop_multi_mma_unit_dims.mlir"
+    "lower_multi_mma.mlir"
     "unroll_multi_mma.mlir"
     "vectorize_multi_mma.mlir"
   TOOLS

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/lower_multi_mma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/lower_multi_mma.mlir
@@ -1,0 +1,100 @@
+// RUN: iree-opt %s -iree-transform-dialect-interpreter -transform-dialect-drop-schedule --split-input-file | FileCheck %s
+
+#contraction_accesses = [
+ affine_map<() -> ()>,
+ affine_map<() -> ()>,
+ affine_map<() -> ()>
+]
+func.func @lower_multi_mma_mfma_16x16x16(%lhs: vector<4xf16>, %rhs: vector<4xf16>, %acc: vector<4xf32>) -> vector<4xf32> {
+  %0 = iree_gpu.multi_mma %lhs, %rhs, %acc {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [],
+    kind = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>
+  } : vector<4xf16>, vector<4xf16> into vector<4xf32>
+  return %0 : vector<4xf32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.lower_multi_mma
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @lower_multi_mma_mfma_16x16x16
+//  CHECK-SAME:   %[[LHS:[A-Za-z0-9]+]]: vector<4xf16>
+//  CHECK-SAME:   %[[RHS:[A-Za-z0-9]+]]: vector<4xf16>
+//  CHECK-SAME:   %[[ACC:[A-Za-z0-9]+]]: vector<4xf32>
+//       CHECK:   amdgpu.mfma %[[LHS]] * %[[RHS]] + %[[ACC]]
+//  CHECK-SAME:     blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32
+//  CHECK-SAME:     blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
+
+// -----
+
+#contraction_accesses = [
+ affine_map<() -> ()>,
+ affine_map<() -> ()>,
+ affine_map<() -> ()>
+]
+func.func @lower_multi_mma_mfma_32x32x8(%lhs: vector<4xf16>, %rhs: vector<4xf16>, %acc: vector<16xf32>) -> vector<16xf32> {
+  %0 = iree_gpu.multi_mma %lhs, %rhs, %acc {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [],
+    kind = #iree_gpu.mma_layout<MFMA_F16_32x32x8_F32>
+  } : vector<4xf16>, vector<4xf16> into vector<16xf32>
+  return %0 : vector<16xf32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.lower_multi_mma
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @lower_multi_mma_mfma_32x32x8
+//  CHECK-SAME:   %[[LHS:[A-Za-z0-9]+]]: vector<4xf16>
+//  CHECK-SAME:   %[[RHS:[A-Za-z0-9]+]]: vector<4xf16>
+//  CHECK-SAME:   %[[ACC:[A-Za-z0-9]+]]: vector<16xf32>
+//       CHECK:   amdgpu.mfma %[[LHS]] * %[[RHS]] + %[[ACC]]
+//  CHECK-SAME:     blocks = 1 : i32, k = 8 : i32, m = 32 : i32, n = 32 : i32
+//  CHECK-SAME:     blgp =  none : vector<4xf16>, vector<4xf16>, vector<16xf32>
+
+// -----
+
+#contraction_accesses = [
+ affine_map<() -> ()>,
+ affine_map<() -> ()>,
+ affine_map<() -> ()>
+]
+func.func @lower_multi_mma_wmma_16x16x16(%lhs: vector<16xf16>, %rhs: vector<16xf16>, %acc: vector<8xf32>) -> vector<8xf32> {
+  %0 = iree_gpu.multi_mma %lhs, %rhs, %acc {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [],
+    kind = #iree_gpu.mma_layout<WMMA_F16_16x16x16_F32>
+  } : vector<16xf16>, vector<16xf16> into vector<8xf32>
+  return %0 : vector<8xf32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.lower_multi_mma
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @lower_multi_mma_wmma_16x16x16
+//  CHECK-SAME:   %[[LHS:[A-Za-z0-9]+]]: vector<16xf16>
+//  CHECK-SAME:   %[[RHS:[A-Za-z0-9]+]]: vector<16xf16>
+//  CHECK-SAME:   %[[ACC:[A-Za-z0-9]+]]: vector<8xf32>
+//       CHECK:   amdgpu.wmma %[[LHS]] * %[[RHS]] + %[[ACC]]
+//  CHECK-SAME:     : vector<16xf16>, vector<16xf16>, vector<8xf32>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.h
@@ -33,6 +33,8 @@ void populateIREEGPUVectorUnrollPatterns(
 
 void populateIREEGPUDropUnitDimsPatterns(RewritePatternSet &patterns);
 
+void populateIREEGPULowerMultiMmaPatterns(RewritePatternSet &patterns);
+
 } // namespace mlir::iree_compiler::IREE::GPU
 
 #endif // IREE_COMPILER_CODEGEN_DIALECT_GPU_TRANSFORMS_TRANSFORMS_H_


### PR DESCRIPTION
This takes multi_mma ops that have already been unrolled to a single intrinsic and simply lowers them to the intrinsic using the interfaced attribute carried by the op.