### PR TITLE
[LLVMGPU] Switch GPU passes to tablegen definitions. NFC.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCreateFastSlowPath.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCreateFastSlowPath.cpp
@@ -13,7 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "iree/compiler/Codegen/Common/GPU/PassDetail.h"
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
@@ -26,12 +25,17 @@
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/PatternMatch.h"
-#include "mlir/Pass/Pass.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "iree-spirv-create-fast-slow-path"
 
 namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_GPUCREATEFASTSLOWPATHPASS
+#include "iree/compiler/Codegen/Common/GPU/Passes.h.inc"
+
+namespace {
 
 /// Returns true if the the given `attrOrValue` is a constant zero.
 static bool isZero(OpFoldResult attrOrValue) {
@@ -127,17 +131,11 @@ static void applyFastSlowPathConversion(mlir::FunctionOpInterface funcOp) {
     rewriter.eraseOp(op);
 }
 
-namespace {
-
 struct GPUCreateFastSlowPathPass final
-    : public GPUCreateFastSlowPathBase<GPUCreateFastSlowPathPass> {
-  void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<scf::SCFDialect>();
-  }
-
+    : impl::GPUCreateFastSlowPathPassBase<GPUCreateFastSlowPathPass> {
   void runOnOperation() override {
     MLIRContext *context = &getContext();
-    auto funcOp = getOperation();
+    FunctionOpInterface funcOp = getOperation();
 
     applyFastSlowPathConversion(funcOp);
 
@@ -153,10 +151,5 @@ struct GPUCreateFastSlowPathPass final
 };
 
 } // namespace
-
-std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createGPUCreateFastSlowPathPass() {
-  return std::make_unique<GPUCreateFastSlowPathPass>();
-}
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistribute.cpp
@@ -4,26 +4,23 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "iree/compiler/Codegen/Common/GPU/PassDetail.h"
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/GPU/TransformOps/GPUTransformOps.h"
 #include "mlir/Dialect/GPU/Transforms/Passes.h"
-#include "mlir/Support/MathExtras.h"
-
-#define DEBUG_TYPE "iree-codegen-gpu-distribute"
 
 namespace mlir::iree_compiler {
 
-static constexpr int64_t kCudaWarpSize = 32;
+#define GEN_PASS_DEF_GPUDISTRIBUTEPASS
+#include "iree/compiler/Codegen/Common/GPU/Passes.h.inc"
 
 namespace {
-struct GPUDistributePass : public GPUDistributeBase<GPUDistributePass> {
-  void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<affine::AffineDialect, gpu::GPUDialect>();
-  }
+static constexpr int64_t kCudaWarpSize = 32;
+
+struct GPUDistributePass final
+    : impl::GPUDistributePassBase<GPUDistributePass> {
   void runOnOperation() override {
     auto funcOp = getOperation();
 
@@ -49,10 +46,4 @@ struct GPUDistributePass : public GPUDistributeBase<GPUDistributePass> {
   }
 };
 } // namespace
-
-std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createGPUDistribute() {
-  return std::make_unique<GPUDistributePass>();
-}
-
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTensorTileToSerialLoops.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTensorTileToSerialLoops.cpp
@@ -4,7 +4,6 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "iree/compiler/Codegen/Common/GPU/PassDetail.h"
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -12,14 +11,12 @@
 
 namespace mlir::iree_compiler {
 
+#define GEN_PASS_DEF_GPUTENSORTILETOSERIALLOOPSPASS
+#include "iree/compiler/Codegen/Common/GPU/Passes.h.inc"
+
 namespace {
-struct GPUTensorTensorTileToSerialLoopsPass final
-    : public GPUTensorTileToSerialLoopsBase<
-          GPUTensorTensorTileToSerialLoopsPass> {
-public:
-  void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<scf::SCFDialect>();
-  }
+struct GPUTensorTileToSerialLoopsPass final
+    : impl::GPUTensorTileToSerialLoopsPassBase<GPUTensorTileToSerialLoopsPass> {
   void runOnOperation() override {
     // Tile reductions based on the annotated tiling configuration.
     if (failed(tileReductionToSerialLoops(getOperation(),
@@ -29,10 +26,4 @@ public:
   }
 };
 } // namespace
-
-std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createGPUTensorTileToSerialLoops() {
-  return std::make_unique<GPUTensorTensorTileToSerialLoopsPass>();
-}
-
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTile.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTile.cpp
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "iree/compiler/Codegen/Common/GPU/PassDetail.h"
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
@@ -29,12 +28,17 @@
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tensor/Transforms/Transforms.h"
 #include "mlir/IR/Matchers.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "iree-codegen-gpu-tile"
 
 namespace mlir::iree_compiler {
 
+#define GEN_PASS_DEF_GPUTILEPASS
+#include "iree/compiler/Codegen/Common/GPU/Passes.h.inc"
+
+namespace {
 //===----------------------------------------------------------------------===//
 // Tiling and fusion utilities
 //===----------------------------------------------------------------------===//
@@ -252,16 +256,10 @@ static LogicalResult tileAndUnrollConvWindow(mlir::FunctionOpInterface funcOp,
 // Main pass
 //===----------------------------------------------------------------------===//
 
-namespace {
-
-class GPUTilePass final : public GPUTileBase<GPUTilePass> {
-public:
-  GPUTilePass() = default;
-  GPUTilePass(const GPUTilePass &pass) = default;
-
+struct GPUTilePass final : impl::GPUTilePassBase<GPUTilePass> {
   void runOnOperation() override {
     MLIRContext *context = &getContext();
-    auto funcOp = getOperation();
+    FunctionOpInterface funcOp = getOperation();
 
     // Try to find computation ops which we will use as anchor to tile and fuse.
     SmallVector<Operation *> computeOps;
@@ -328,10 +326,6 @@ public:
     }
   }
 };
+
 } // namespace
-
-std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>> createGPUTilePass() {
-  return std::make_unique<GPUTilePass>();
-}
-
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/PassDetail.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/PassDetail.h
@@ -7,10 +7,17 @@
 #ifndef IREE_COMPILER_CODEGEN_COMMON_GPU_PASS_DETAIL_H_
 #define IREE_COMPILER_CODEGEN_COMMON_GPU_PASS_DETAIL_H_
 
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/NVGPU/IR/NVGPUDialect.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Pass/Pass.h"
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
@@ -8,6 +8,7 @@
 #ifndef IREE_COMPILER_CODEGEN_COMMON_GPU_PASSES_H_
 #define IREE_COMPILER_CODEGEN_COMMON_GPU_PASSES_H_
 
+#include <cstdint>
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Pass/Pass.h"
@@ -21,7 +22,7 @@ namespace mlir::iree_compiler {
 /// Pipeline shared memory copy by apply software pipelining scheduling where
 /// copy to shared memory is in stage 0 and the rest of the operations are in
 /// stage `depth - 1`.
-enum class PipeliningSchedulingStrategy {
+enum class PipeliningSchedulingStrategy : int64_t {
   // Schedule the load from global memory into stage 0 and the associated store
   // will be in stage depth - 1.
   loadGlobalStage0 = 0,
@@ -89,65 +90,11 @@ createGPUCheckResourceUsagePass(
     std::function<unsigned(mlir::FunctionOpInterface)> getIndexBitwidth =
         nullptr);
 
-// Uses `tensor.pad` ops as anchors to create separate fast and slow paths
-// inside the kernel. The fast path is for inner tiles where we don't need
-// padding, while the slow path is for boundary tiles where we do need
-// padding.
-std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createGPUCreateFastSlowPathPass();
-
-/// Creates a pass to distribute scf.forall ops to GPU processors.
-std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>> createGPUDistribute();
-
-/// Convert GPU shared memory copies to distributed
-/// transfer_read/transfer_write.
-std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createGPUDistributeSharedMemoryCopy();
-
-/// Pass to distribute tiled loop nests to invocations.
-std::unique_ptr<InterfacePass<FunctionOpInterface>>
-createGPUDistributeScfForPass(bool useBlockDims = true);
-
-/// Apply multi-buffering transformation.
-std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createGPUMultiBuffering(unsigned numBuffers = 5);
-
-/// Apply software pipelining.
-std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createGPUPipeliningPass(bool epiloguePeeling = true, unsigned depth = 1,
-                        PipeliningSchedulingStrategy schedule =
-                            PipeliningSchedulingStrategy::loadGlobalStage0);
-
-/// Apply transformation to reduce the number of bank conflicts when accessing
-/// shared memory by padding fastest moving dimension with the specified size.
-std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createGPUReduceSharedMemoryBankConflicts(int64_t paddingSizeBits = 128);
-
 // Creates a pass to create allocations for some tensor values to use GPU
 // shared memory.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createGPUTensorAlloc(GPUPromoteSharedMemPattern promoteSharedMemPattern =
                          GPUPromoteSharedMemPattern::ContractionOpPattern);
-
-// Creates a pass to tile tensor (linalg) ops within a GPU workgroup.
-std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createGPUTensorTile(bool distributeToWarp = false);
-
-// Creates a pass to tile tensor (linalg) ops along reduction dimensions.
-std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createGPUTensorTileToSerialLoops();
-
-/// Pass to tile Linalg ops with tensor semantics to invocations.
-std::unique_ptr<InterfacePass<FunctionOpInterface>> createGPUTilePass();
-
-/// Tile reductions and generate serial loops around reductions.
-std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createGPUTileReductionPass();
-
-// Creates a pass to create allocations for some vector values to use GPU
-// shared memory.
-std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createGPUVectorAlloc();
 
 // Distributes vector ops to all threads/warps in a GPU workgroup.
 // `getWarpSize` is for deciding the warp size to use; it takes the
@@ -160,10 +107,6 @@ createConvertVectorReductionToGPUPass(
     bool expandSubgroupReduction = true,
     std::function<int(mlir::FunctionOpInterface)> getWarpSize = nullptr);
 
-/// Pass to specialize workgroup distribution loops
-std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createWorkgroupSpecializationPass();
-
 enum class ReorderWorkgrupsStrategy { None, Swizzle, Transpose };
 
 /// Reorders workgroup IDs.
@@ -173,13 +116,8 @@ createReorderWorkgroups(
     unsigned swizzleLogTile = 0,
     std::function<LogicalResult(mlir::FunctionOpInterface)> filterFn = nullptr);
 
-// This pass generalizes named Linalg ops that are better off as generics.
-std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createGPUGeneralizeNamedOpsPass();
-
-/// Pass to lower a sequence of operations to a iree_codegen.ukernel.*
-/// operation.
-std::unique_ptr<OperationPass<>> createGPULowerToUKernelsPass();
+#define GEN_PASS_DECL
+#include "iree/compiler/Codegen/Common/GPU/Passes.h.inc" // IWYU pragma: keep
 
 /// Register Common GPU passes.
 void registerCodegenCommonGPUPasses();

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -13,34 +13,36 @@ include "mlir/Pass/PassBase.td"
 // Common Passes used for GPU-like backends (keep alphabetical)
 //===---------------------------------------------------------------------===//
 
-def GPUCheckResourceUsage :
+def GPUCheckResourceUsagePass :
     InterfacePass<"iree-codegen-gpu-check-resource-usage", "mlir::FunctionOpInterface"> {
   let summary = "Checks GPU specific resource usage constraints like shared memory limits";
   let constructor = "mlir::iree_compiler::createGPUCheckResourceUsagePass()";
 }
 
-def GPUCreateFastSlowPath :
+def GPUCreateFastSlowPathPass :
     InterfacePass<"iree-codegen-gpu-create-fast-slow-path", "mlir::FunctionOpInterface"> {
   let summary = "Create separate fast and slow paths to handle padding";
-  let constructor = "mlir::iree_compiler::createGPUCreateFastSlowPathPass()";
+  let dependentDialects = ["::mlir::scf::SCFDialect"];
 }
 
-def GPUDistribute :
+def GPUDistributePass :
     InterfacePass<"iree-codegen-gpu-distribute", "mlir::FunctionOpInterface"> {
   let summary = "Pass to distribute scf.forall ops.";
-  let constructor = "mlir::iree_compiler::createGPUDistribute()";
+  let dependentDialects = ["::mlir::affine::AffineDialect", "::mlir::gpu::GPUDialect"];
 }
 
-def GPUDistributeSharedMemoryCopy :
+def GPUDistributeSharedMemoryCopyPass :
     InterfacePass<"iree-codegen-gpu-distribute-shared-memory-copy", "mlir::FunctionOpInterface"> {
   let summary = "Pass to distribute shared memory copies to threads.";
-  let constructor = "mlir::iree_compiler::createGPUDistributeSharedMemoryCopy()";
+  let dependentDialects = [
+    "::mlir::gpu::GPUDialect", "::mlir::scf::SCFDialect", "::mlir::vector::VectorDialect"
+  ];
 }
 
-def GPUDistributeScfFor :
+def GPUDistributeScfForPass :
     InterfacePass<"iree-codegen-gpu-distribute-scf-for", "mlir::FunctionOpInterface"> {
   let summary = "Distribute tiled loop nests to invocations";
-  let constructor = "mlir::iree_compiler::createGPUDistributeScfForPass()";
+  let dependentDialects = ["::mlir::gpu::GPUDialect"];
   let options = [
     Option<"useBlockDims", "use-block-dims", "bool",
            /*default=*/"true",
@@ -48,29 +50,31 @@ def GPUDistributeScfFor :
   ];
 }
 
-def GPUGeneralizeNamedOps :
+def GPUGeneralizeNamedOpsPass :
     InterfacePass<"iree-codegen-gpu-generalize-named-ops", "mlir::FunctionOpInterface"> {
   let summary = "Convert named Linalg ops to linalg.generic ops";
-  let constructor = "mlir::iree_compiler::createGPUGeneralizeNamedOpsPass()";
 }
 
-def GPULowerToUKernels :
+def GPULowerToUKernelsPass :
     Pass<"iree-codegen-gpu-lower-to-ukernels", ""> {
-  let summary =
-      "Separate out parts of the IR that lower to a micro-kernel";
-  let constructor =
-      "mlir::iree_compiler::createGPULowerToUKernelsPass()";
+  let summary = "Separate out parts of the IR that lower to a micro-kernel";
+  let dependentDialects = ["::mlir::iree_compiler::IREE::Codegen::IREECodegenDialect"];
 }
 
-def GPUMultiBuffering :
+def GPUMultiBufferingPass :
     InterfacePass<"iree-codegen-gpu-multi-buffering", "mlir::FunctionOpInterface"> {
   let summary = "Pass to do multi buffering.";
-  let constructor = "mlir::iree_compiler::createGPUMultiBuffering()";
+  let dependentDialects = ["::mlir::affine::AffineDialect"];
+  let options = [
+    Option<"numBuffers", "num-buffers", "unsigned",
+            /*default=*/"5",
+            "Number of buffers to use.">,
+  ];
 }
 
-def GPUPipelining : InterfacePass<"iree-codegen-gpu-pipelining", "mlir::FunctionOpInterface"> {
+def GPUPipeliningPass :
+    InterfacePass<"iree-codegen-gpu-pipelining", "mlir::FunctionOpInterface"> {
   let summary = "Pass to do software pipelining.";
-  let constructor = "mlir::iree_compiler::createGPUPipeliningPass()";
   let options = [
     Option<"epiloguePeeling", "epilogue-peeling", "bool",
             /*default=*/"true",
@@ -89,10 +93,9 @@ def GPUPipelining : InterfacePass<"iree-codegen-gpu-pipelining", "mlir::Function
   ];
 }
 
-def GPUReduceBankConflicts :
+def GPUReduceBankConflictsPass :
     InterfacePass<"iree-codegen-gpu-reduce-bank-conflicts", "mlir::FunctionOpInterface"> {
   let summary = "Pass to try to reduce the number of bank conflicts by padding memref.alloc ops.";
-  let constructor = "mlir::iree_compiler::createGPUReduceSharedMemoryBankConflicts()";
   let options = [
     Option<"paddingBits", "padding-bits", "unsigned",
             /*default=*/"128",
@@ -100,65 +103,82 @@ def GPUReduceBankConflicts :
   ];
 }
 
-def GPUTensorAlloc :
+def GPUTensorAllocPass :
     InterfacePass<"iree-codegen-gpu-tensor-alloc", "mlir::FunctionOpInterface"> {
   let summary = "Pass to create allocations for some tensor values to use"
                 "GPU shared memory";
   let constructor = "mlir::iree_compiler::createGPUTensorAlloc()";
+  let dependentDialects = ["::mlir::bufferization::BufferizationDialect"];
 }
 
-def GPUTensorTile :
+def GPUTensorTilePass :
     InterfacePass<"iree-codegen-gpu-tensor-tile", "mlir::FunctionOpInterface"> {
   let summary = "Pass to tile tensor (linalg) ops within a GPU workgroup";
-  let constructor = "mlir::iree_compiler::createGPUTensorTile()";
+  let dependentDialects = [
+    "::mlir::affine::AffineDialect", "::mlir::gpu::GPUDialect", "::mlir::scf::SCFDialect"
+  ];
+  let options = [
+    Option<"distributeToSubgroup", "distribute-to-subgroup", "bool",
+           /*default=*/"false",
+           "Distribute the workloads to subgroup if true, otherwise distribute to threads.">,
+  ];
 }
 
-def GPUTensorTileToSerialLoops :
+def GPUTensorTileToSerialLoopsPass :
     InterfacePass<"iree-codegen-gpu-tensor-tile-to-serial-loops", "mlir::FunctionOpInterface"> {
   let summary = "Pass to tile reduction dimensions for certain GPU ops";
-  let constructor = "mlir::iree_compiler::createGPUTensorTileToSerialLoops()";
+  let dependentDialects = ["::mlir::scf::SCFDialect"];
 }
 
-def GPUTile : InterfacePass<"iree-codegen-gpu-tile", "mlir::FunctionOpInterface"> {
+def GPUTilePass : InterfacePass<"iree-codegen-gpu-tile", "mlir::FunctionOpInterface"> {
   let summary = "Tile Linalg ops with tensor semantics to invocations";
-  let constructor = "mlir::iree_compiler::createGPUTilePass()";
 }
 
-def GPUTileReduction :
+def GPUTileReductionPass :
     InterfacePass<"iree-codegen-gpu-tile-reduction", "mlir::FunctionOpInterface"> {
   let summary = "Pass to tile linalg reduction dimensions.";
-  let constructor = "mlir::iree_compiler::createGPUTileReductionPass()";
+  let dependentDialects = ["::mlir::scf::SCFDialect"];
 }
 
-def GPUVectorAlloc :
+def GPUVectorAllocPass :
     InterfacePass<"iree-codegen-gpu-vector-alloc", "mlir::FunctionOpInterface"> {
   let summary = "Pass to create allocations for contraction inputs to copy "
                 "to GPU shared memory";
-  let constructor = "mlir::iree_compiler::createGPUVectorAlloc()";
+  let dependentDialects = [
+    "::mlir::gpu::GPUDialect", "::mlir::bufferization::BufferizationDialect"
+  ];
 }
 
-def VectorReductionToGPU :
-    InterfacePass<"iree-codegen-vector-reduction-to-gpu", "mlir::FunctionOpInterface"> {
-  let summary = "Convert vector reduction to GPU ops.";
-  let constructor = "mlir::iree_compiler::createConvertVectorReductionToGPUPass()";
-}
-
-def WorkgroupSpecialization :
-    InterfacePass<"iree-codegen-workgroup-specialization", "mlir::FunctionOpInterface"> {
-  let summary = "Specialize workgroup distribution loops";
-  let constructor = "mlir::iree_compiler::createWorkgroupSpecializationPass()";
-}
-
-def ReorderWorkgroups :
+def ReorderWorkgroupsPass :
     InterfacePass<"iree-codegen-reorder-workgroups", "mlir::FunctionOpInterface"> {
   let summary = "Reorder workgroup ids for better cache reuse";
   let constructor = "mlir::iree_compiler::createReorderWorkgroups()";
+  let dependentDialects = ["::mlir::affine::AffineDialect"];
   let options = [
     Option<"strategy", "strategy", "std::string", /*default=*/"",
            "Workgroup reordering strategy, one of: '' (none),  'transpose', 'swizzle'">,
     Option<"logTile", "logTile", "unsigned",
             /*default=*/"0",
            "The log2 of the tile size used for swizzling. (0: disabled, non-0: swizzling enabled)">,
+  ];
+}
+
+def VectorReductionToGPUPass :
+    InterfacePass<"iree-codegen-vector-reduction-to-gpu", "mlir::FunctionOpInterface"> {
+  let summary = "Convert vector reduction to GPU ops.";
+  let constructor = "mlir::iree_compiler::createConvertVectorReductionToGPUPass()";
+  let dependentDialects = [
+    "::mlir::affine::AffineDialect", "::mlir::gpu::GPUDialect",
+    "::mlir::memref::MemRefDialect", "::mlir::scf::SCFDialect",
+  ];
+}
+
+def WorkgroupSpecializationPass :
+    InterfacePass<"iree-codegen-workgroup-specialization", "mlir::FunctionOpInterface"> {
+  let summary = "Specialize workgroup distribution loops";
+  let dependentDialects = [
+    "::mlir::affine::AffineDialect", "::mlir::linalg::LinalgDialect",
+    "::mlir::scf::SCFDialect", "::mlir::tensor::TensorDialect",
   ];
 }
 


### PR DESCRIPTION
Move constructor functions and dependent dialects to tablegen. More complicated constructors (e.g., using callback arguments) are kept as-is.