### PR TITLE
[vulkan] Print VkResult as int32 value in errors

### DIFF
--- a/runtime/src/iree/hal/drivers/vulkan/status_util.c
+++ b/runtime/src/iree/hal/drivers/vulkan/status_util.c
@@ -255,6 +255,6 @@ iree_status_t iree_hal_vulkan_result_to_status(VkResult result,
           "VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT");
     default:
       return iree_make_status_with_location(file, line, IREE_STATUS_UNKNOWN,
-                                            "VkResult=%u", (uint32_t)result);
+                                            "VkResult=%d", (int32_t)result);
   }
 }


### PR DESCRIPTION
The VkResult enum is defined as int32:
https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkResult.html

This makes it easy to check which error we are seeing if not categorized in IREE.