### PR TITLE
[Preprocessing] Remove `input=none` option from TransposeMatmulPass 

### DIFF
--- a/compiler/src/iree/compiler/Preprocessing/Common/Passes.h
+++ b/compiler/src/iree/compiler/Preprocessing/Common/Passes.h
@@ -26,12 +26,10 @@ enum class PadTargetType {
 };
 
 enum class TransposeMatmulInput {
-  /// Transpose LHS input matrix.
+  // Transpose LHS input matrix.
   Lhs,
-  /// Transpose RHS input matrix.
-  Rhs,
-  /// Transpose neither input (disable).
-  None
+  // Transpose RHS input matrix.
+  Rhs
 };
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Preprocessing/Common/Passes.td
+++ b/compiler/src/iree/compiler/Preprocessing/Common/Passes.td
@@ -117,16 +117,14 @@ def TransposeMatmulPass : Pass<"iree-preprocessing-transpose-matmul-pass"> {
   let summary = "Convert Linalg matmul ops to transposed variants";
   let options = [
     Option<"input", "input", "Preprocessing::TransposeMatmulInput",
-           /*default=*/"Preprocessing::TransposeMatmulInput::None",
-           "Input to transpose, one of: 'none' (default), 'lhs', 'rhs'",
+           /*default=*/"Preprocessing::TransposeMatmulInput::Lhs",
+           "Input to transpose, one of: 'lhs' (default), 'rhs'",
            [{llvm::cl::values(
               clEnumValN(Preprocessing::TransposeMatmulInput::Lhs, "lhs",
                          "Transpose LHS input matrix."),
               clEnumValN(Preprocessing::TransposeMatmulInput::Rhs, "rhs",
-                         "Transpose RHS input matrix."),
-              clEnumValN(Preprocessing::TransposeMatmulInput::None, "none",
-                         "Transpose neither input (disable)."))
-           }]>
+                         "Transpose RHS input matrix.")
+           )}]>
   ];
   let dependentDialects = [
     "mlir::linalg::LinalgDialect",

--- a/compiler/src/iree/compiler/Preprocessing/Common/TransposeMatmul.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/TransposeMatmul.cpp
@@ -21,9 +21,6 @@ struct TransposeMatmulPass
       TransposeMatmulPass>::TransposeMatmulPassBase;
 
   void runOnOperation() override {
-    if (input == Preprocessing::TransposeMatmulInput::None)
-      return;
-
     bool transposeLHS = input == Preprocessing::TransposeMatmulInput::Lhs;
 
     RewritePatternSet patterns(&getContext());

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/transpose_matmul.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/transpose_matmul.mlir
@@ -1,13 +1,9 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-preprocessing-transpose-matmul-pass{input=lhs}))" %s | FileCheck %s --check-prefixes=CHECK,LHS
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-preprocessing-transpose-matmul-pass{input=rhs}))" %s | FileCheck %s --check-prefixes=CHECK,RHS
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-preprocessing-transpose-matmul-pass))" %s | FileCheck %s --check-prefixes=CHECK,DISABLED
 
 // CHECK-LABEL: @matmul
 // LHS: linalg.matmul_transpose_a
 // RHS: linalg.matmul_transpose_b
-// DISABLED-NOT: transpose
-// DISABLED: matmul
-// DISABLED-NOT: transpose
 func.func @matmul(%A: tensor<16x8xf32>, %B: tensor<8x16xf32>) -> (tensor<16x16xf32>) {
   %cst = arith.constant 0.0 : f32
   %init = tensor.empty() : tensor<16x16xf32>


### PR DESCRIPTION
Follow up to #17300. There's no point having a 'none' option if you can simply omit the pass from the pipeline.