### PR TITLE
Generalize overriding llvm func attr flags in translation info

### DIFF
--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -373,14 +373,14 @@ public:
 
         // Override flags as given by target func attrs.
         if (auto funcAttrs =
-                func->getAttrOfType<DictionaryAttr>("target_func_attrs")) {
+                func->getAttrOfType<DictionaryAttr>("llvm_func_attrs")) {
           for (NamedAttribute funcAttr : funcAttrs) {
             auto value = dyn_cast<StringAttr>(funcAttr.getValue());
             if (!value) {
-              return variantOp->emitError(
-                  "target_func_attrs attribute must be a "
-                  "dictionary of strings. Attribute " +
-                  llvm::Twine(funcAttr.getName()) + " is not a StringAttr.");
+              return variantOp->emitError("llvm_func_attrs attribute must be "
+                                          "adictionary of strings. Attribute " +
+                                          llvm::Twine(funcAttr.getName()) +
+                                          " is not a StringAttr.");
             }
             llvmFunc->addFnAttr(funcAttr.getName(), value.getValue());
           }

--- a/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
@@ -69,7 +69,7 @@ getTargetFuncAttrs(IREE::Codegen::TranslationInfoAttr translationInfo) {
   if (!translationConfig) {
     return nullptr;
   }
-  auto attr = translationConfig.getAs<DictionaryAttr>("target_func_attrs");
+  auto attr = translationConfig.getAs<DictionaryAttr>("llvm_func_attrs");
   if (!attr) {
     return nullptr;
   }
@@ -102,7 +102,7 @@ void ReconcileTranslationInfoPass::runOnOperation() {
     // lowering configs and translation infos will be deleted.
     DictionaryAttr targetFuncAttrs = getTargetFuncAttrs(translationInfo);
     if (targetFuncAttrs) {
-      funcOp->setAttr("target_func_attrs", targetFuncAttrs);
+      funcOp->setAttr("llvm_func_attrs", targetFuncAttrs);
     }
   });
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info.mlir
@@ -132,15 +132,15 @@ hal.executable private @target_func_attrs {
   hal.executable.variant public @target_func_attrs target(#hal.executable.target<"", "", {}>) {
     hal.executable.export public @entry_point layout(#pipeline_layout)
     builtin.module {
-      func.func @fn1() attributes {translation_info = #iree_codegen.translation_info<None, {target_func_attrs = {"amdgpu-waves-per-eu" = 2}}>}  {
+      func.func @fn1() attributes {translation_info = #iree_codegen.translation_info<None, {target_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>}  {
         return
       }
-      func.func @fn2() attributes {translation_info = #iree_codegen.translation_info<None, {target_func_attrs = {"amdgpu-waves-per-eu" = 4}}>} {
+      func.func @fn2() attributes {translation_info = #iree_codegen.translation_info<None, {target_func_attrs = {"amdgpu-waves-per-eu" = "4"}}>} {
         return
       }
     }
   }
 }
 // CHECK-LABEL: hal.executable private @target_func_attrs
-//       CHECK:   func.func @fn1() attributes {target_func_attrs = {"amdgpu-waves-per-eu" = 2 : i64}}
-//       CHECK:   func.func @fn2() attributes {target_func_attrs = {"amdgpu-waves-per-eu" = 4 : i64}}
+//       CHECK:   func.func @fn1() attributes {target_func_attrs = {"amdgpu-waves-per-eu" = "2"}}
+//       CHECK:   func.func @fn2() attributes {target_func_attrs = {"amdgpu-waves-per-eu" = "4"}}

--- a/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info.mlir
@@ -128,19 +128,19 @@ hal.executable private @err_reconcile_subgroup_size {
 // -----
 
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [#hal.descriptor_set.layout<0, bindings = [#hal.descriptor_set.binding<0, storage_buffer>]>]>
-hal.executable private @target_func_attrs {
-  hal.executable.variant public @target_func_attrs target(#hal.executable.target<"", "", {}>) {
+hal.executable private @llvm_func_attrs {
+  hal.executable.variant public @llvm_func_attrs target(#hal.executable.target<"", "", {}>) {
     hal.executable.export public @entry_point layout(#pipeline_layout)
     builtin.module {
-      func.func @fn1() attributes {translation_info = #iree_codegen.translation_info<None, {target_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>}  {
+      func.func @fn1() attributes {translation_info = #iree_codegen.translation_info<None, {llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>}  {
         return
       }
-      func.func @fn2() attributes {translation_info = #iree_codegen.translation_info<None, {target_func_attrs = {"amdgpu-waves-per-eu" = "4"}}>} {
+      func.func @fn2() attributes {translation_info = #iree_codegen.translation_info<None, {llvm_func_attrs = {"amdgpu-waves-per-eu" = "4"}}>} {
         return
       }
     }
   }
 }
-// CHECK-LABEL: hal.executable private @target_func_attrs
-//       CHECK:   func.func @fn1() attributes {target_func_attrs = {"amdgpu-waves-per-eu" = "2"}}
-//       CHECK:   func.func @fn2() attributes {target_func_attrs = {"amdgpu-waves-per-eu" = "4"}}
+// CHECK-LABEL: hal.executable private @llvm_func_attrs
+//       CHECK:   func.func @fn1() attributes {llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}
+//       CHECK:   func.func @fn2() attributes {llvm_func_attrs = {"amdgpu-waves-per-eu" = "4"}}

--- a/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info.mlir
@@ -128,19 +128,19 @@ hal.executable private @err_reconcile_subgroup_size {
 // -----
 
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [#hal.descriptor_set.layout<0, bindings = [#hal.descriptor_set.binding<0, storage_buffer>]>]>
-hal.executable private @waves_per_eu {
-  hal.executable.variant public @waves_per_eu target(#hal.executable.target<"", "", {}>) {
+hal.executable private @target_func_attrs {
+  hal.executable.variant public @target_func_attrs target(#hal.executable.target<"", "", {}>) {
     hal.executable.export public @entry_point layout(#pipeline_layout)
     builtin.module {
-      func.func @fn1() attributes {translation_info = #iree_codegen.translation_info<None, {waves_per_eu = 2}>}  {
+      func.func @fn1() attributes {translation_info = #iree_codegen.translation_info<None, {target_func_attrs = {"amdgpu-waves-per-eu" = 2}}>}  {
         return
       }
-      func.func @fn2() attributes {translation_info = #iree_codegen.translation_info<None, {waves_per_eu = 4}>} {
+      func.func @fn2() attributes {translation_info = #iree_codegen.translation_info<None, {target_func_attrs = {"amdgpu-waves-per-eu" = 4}}>} {
         return
       }
     }
   }
 }
-// CHECK-LABEL: hal.executable private @waves_per_eu
-//       CHECK:   func.func @fn1() attributes {waves_per_eu = 2 : index}
-//       CHECK:   func.func @fn2() attributes {waves_per_eu = 4 : index}
+// CHECK-LABEL: hal.executable private @target_func_attrs
+//       CHECK:   func.func @fn1() attributes {target_func_attrs = {"amdgpu-waves-per-eu" = 2 : i64}}
+//       CHECK:   func.func @fn2() attributes {target_func_attrs = {"amdgpu-waves-per-eu" = 4 : i64}}


### PR DESCRIPTION
Previously, we were specifically querying for waves_per_eu attr in translation info in ROCMTarget. This patch makes this general by attaching a llvm function attribute override dictionary in the translation info instead which can be set.