### PR TITLE
[Codegen] Add op for flattening warp and thread ids of forall ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -37,6 +37,7 @@
 #include "mlir/Dialect/Bufferization/Transforms/Transforms.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
 #include "mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -562,6 +563,138 @@ DiagnosedSilenceableFailure transform_dialect::CopyTensorOperandOp::applyToOne(
 }
 
 void transform_dialect::CopyTensorOperandOp::getEffects(
+    SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
+  transform::onlyReadsHandle(getTarget(), effects);
+  transform::producesHandle(getResult(), effects);
+  transform::modifiesPayload(effects);
+}
+
+//===---------------------------------------------------------------------===//
+// FlattenForallOp
+//===---------------------------------------------------------------------===//
+
+template <typename MappingTy>
+bool isAscendingRelativeMapping(ArrayRef<Attribute> mapping) {
+  auto start = cast<MappingTy>(*mapping.begin());
+  if (start.getMappingId() !=
+      static_cast<int64_t>(gpu::MappingId::LinearDim0)) {
+    return false;
+  }
+  int64_t prev = start.getMappingId();
+  for (auto id : llvm::drop_begin(mapping)) {
+    int64_t nextId = cast<MappingTy>(id).getMappingId();
+    if (nextId != prev + 1) {
+      return false;
+    }
+    prev = nextId;
+  }
+  return true;
+}
+
+FailureOr<scf::ForallOp> flattenForallOp(RewriterBase &rewriter,
+                                         scf::ForallOp forallOp) {
+  if (!forallOp.getMapping().has_value())
+    return forallOp->emitError("mapping must be present");
+  SmallVector<Attribute> mapping =
+      llvm::to_vector(forallOp.getMapping()->getValue());
+  if (!(llvm::all_of(mapping, llvm::IsaPred<gpu::GPUThreadMappingAttr>) ||
+        llvm::all_of(mapping, llvm::IsaPred<gpu::GPUWarpMappingAttr>))) {
+    return forallOp->emitError("mapping must be #gpu.thread or #gpu.warp");
+  }
+
+  if (forallOp.getRank() == 1) {
+    return forallOp;
+  }
+
+  bool isThreadMapping = isa<gpu::GPUThreadMappingAttr>(*mapping.begin());
+
+  if (isThreadMapping) {
+    if (!isAscendingRelativeMapping<gpu::GPUThreadMappingAttr>(mapping)) {
+      return forallOp->emitError(
+          "mapping must be descending linear thread ids");
+    }
+  } else if (!isAscendingRelativeMapping<gpu::GPUWarpMappingAttr>(mapping)) {
+    return forallOp->emitError("mapping must be descending linear warp ids");
+  }
+
+  auto isAll = [](ArrayRef<int64_t> array, int64_t cmp) {
+    return llvm::all_of(array, [cmp](int64_t x) { return x == cmp; });
+  };
+
+  if (!isAll(forallOp.getStaticStep(), 1) ||
+      !isAll(forallOp.getStaticLowerBound(), 0)) {
+    return failure();
+    return forallOp->emitError("");
+  }
+
+  MLIRContext *context = rewriter.getContext();
+  Location loc = forallOp.getLoc();
+
+  // Step 1. Construct the new mapping attribute as a single linear dim of the
+  // original type.
+  Attribute flatMapping;
+  if (isThreadMapping) {
+    flatMapping =
+        gpu::GPUThreadMappingAttr::get(context, gpu::MappingId::LinearDim0);
+  } else {
+    flatMapping =
+        gpu::GPUWarpMappingAttr::get(context, gpu::MappingId::LinearDim0);
+  }
+
+  // Step 2. Compute the flat lower bound/upper bound/step.
+  AffineExpr d0, d1;
+  bindDims(context, d0, d1);
+  AffineExpr mulExpr = d0 * d1;
+  SmallVector<OpFoldResult> upperBounds = forallOp.getMixedUpperBound();
+  OpFoldResult newUpperBound = upperBounds.front();
+  for (OpFoldResult ub : llvm::drop_begin(upperBounds)) {
+    newUpperBound = affine::makeComposedFoldedAffineApply(
+        rewriter, loc, mulExpr, {newUpperBound, ub});
+  }
+
+  OpFoldResult zero = rewriter.getIndexAttr(0);
+  OpFoldResult one = rewriter.getIndexAttr(1);
+
+  // Step 3. Create a new parallel loop with a single mapping id.
+  auto newForallOp = rewriter.create<scf::ForallOp>(
+      loc, ArrayRef<OpFoldResult>{zero}, ArrayRef<OpFoldResult>{newUpperBound},
+      ArrayRef<OpFoldResult>{one}, forallOp.getOutputs(),
+      rewriter.getArrayAttr({flatMapping}));
+
+  rewriter.setInsertionPointToStart(newForallOp.getBody());
+  Value linearId = newForallOp.getInductionVar(0);
+
+  // Step 4. Delinearize the flat ID to the original basis.
+  auto ids = rewriter.create<affine::AffineDelinearizeIndexOp>(
+      loc, linearId, forallOp.getMixedUpperBound());
+
+  // Step 5. Inline the region of the original forall op.
+  SmallVector<Value> newArgs(ids.getResults());
+  newArgs.append(newForallOp.getRegionIterArgs().begin(),
+                 newForallOp.getRegionIterArgs().end());
+  rewriter.eraseOp(newForallOp.getTerminator());
+  rewriter.mergeBlocks(forallOp.getBody(), newForallOp.getBody(), newArgs);
+  rewriter.replaceOp(forallOp, newForallOp);
+  return newForallOp;
+}
+
+DiagnosedSilenceableFailure
+transform_dialect::FlattenForallMappingOp::applyToOne(
+    transform::TransformRewriter &rewriter, mlir::scf::ForallOp target,
+    transform::ApplyToEachResultList &results,
+    transform::TransformState &state) {
+
+  rewriter.setInsertionPoint(target);
+  auto newForallOp = flattenForallOp(rewriter, target);
+  if (failed(newForallOp)) {
+    return mlir::emitDefiniteFailure(target, "flattenForallOp failed");
+  }
+
+  results.push_back(*newForallOp);
+  return DiagnosedSilenceableFailure::success();
+}
+
+void transform_dialect::FlattenForallMappingOp::getEffects(
     SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
   transform::onlyReadsHandle(getTarget(), effects);
   transform::producesHandle(getResult(), effects);

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -573,7 +573,7 @@ void transform_dialect::CopyTensorOperandOp::getEffects(
 //===---------------------------------------------------------------------===//
 
 template <typename MappingTy>
-bool isAscendingRelativeMapping(ArrayRef<Attribute> mapping) {
+static bool isAscendingRelativeMapping(ArrayRef<Attribute> mapping) {
   auto start = cast<MappingTy>(*mapping.begin());
   if (start.getMappingId() !=
       static_cast<int64_t>(gpu::MappingId::LinearDim0)) {
@@ -590,8 +590,8 @@ bool isAscendingRelativeMapping(ArrayRef<Attribute> mapping) {
   return true;
 }
 
-FailureOr<scf::ForallOp> flattenForallOp(RewriterBase &rewriter,
-                                         scf::ForallOp forallOp) {
+static FailureOr<scf::ForallOp> flattenForallOp(RewriterBase &rewriter,
+                                                scf::ForallOp forallOp) {
   if (!forallOp.getMapping().has_value())
     return forallOp->emitError("mapping must be present");
   SmallVector<Attribute> mapping =

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -281,6 +281,37 @@ def HoistStaticAllocOp :  Op<Transform_Dialect, "iree.hoist_static_alloc",
   }];
 }
 
+def FlattenForallMappingOp : Op<Transform_Dialect, "iree.flatten_forall_mapping",
+    [TransformEachOpTrait,
+     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     TransformOpInterface,
+     ReportTrackingListenerFailuresOpTrait]> {
+  let description = [{
+    Flattens the thread mapping of an `scf.forall` op.
+
+    #### Return modes
+    Emits a definite failure if the target is not an scf.forall op or if
+    the mapping type is not `gpu.thread` or `gpu.warp` with linear dims in
+    descending order.
+  }];
+
+  let arguments = (ins TransformHandleTypeInterface:$target);
+  let results = (outs TransformHandleTypeInterface:$result);
+
+  let assemblyFormat = [{
+    $target attr-dict `:` functional-type(operands, results)
+  }];
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::transform::TransformRewriter &rewriter,
+        ::mlir::scf::ForallOp target,
+        ::mlir::transform::ApplyToEachResultList &results,
+        ::mlir::transform::TransformState &state);
+  }];
+}
+
 def ForallToWorkgroupOp : Op<Transform_Dialect,
     "iree.forall_to_workgroup",
     [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -67,6 +67,7 @@ iree_lit_test_suite(
             "transform_buffer_opt.mlir",
             "transform_copy_operand.mlir",
             "transform_fuse_forall.mlir",
+            "transform_flatten_forall.mlir",
             "transform_hoist_forall.mlir",
             "transform_lower_shuffle.mlir",
             "transform_match_partial_reduction.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -62,6 +62,7 @@ iree_lit_test_suite(
     "tile_and_distribute_to_workgroups.mlir"
     "transform_buffer_opt.mlir"
     "transform_copy_operand.mlir"
+    "transform_flatten_forall.mlir"
     "transform_fuse_forall.mlir"
     "transform_hoist_forall.mlir"
     "transform_lower_shuffle.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/transform_flatten_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/transform_flatten_forall.mlir
@@ -1,0 +1,81 @@
+// RUN: iree-opt %s -iree-transform-dialect-interpreter -transform-dialect-drop-schedule --split-input-file | FileCheck %s
+
+#map = affine_map<(d0) -> (d0 * 32)>
+#map1 = affine_map<(d0) -> (d0 * 16)>
+module {
+  func.func @flatten_forall_thread_mapping(%arg0: tensor<128x128xf32>) -> tensor<128x128xf32> {
+    %0 = tensor.empty() : tensor<128x128xf32>
+    %2 = scf.forall (%arg5, %arg6) in (4, 16) shared_outs(%arg7 = %0) -> (tensor<128x128xf32>) {
+      %3 = affine.apply #map(%arg5)
+      %4 = affine.apply #map1(%arg6)
+      %extracted_slice = tensor.extract_slice %arg0[%3, %4] [32, 8] [1, 1] : tensor<128x128xf32> to tensor<32x8xf32>
+      %extracted_slice_0 = tensor.extract_slice %arg7[%3, %4] [32, 8] [1, 1] : tensor<128x128xf32> to tensor<32x8xf32>
+      %5 = linalg.copy ins(%extracted_slice : tensor<32x8xf32>) outs(%extracted_slice_0 : tensor<32x8xf32>) -> tensor<32x8xf32>
+      scf.forall.in_parallel {
+        tensor.parallel_insert_slice %5 into %arg7[%3, %4] [32, 8] [1, 1] : tensor<32x8xf32> into tensor<128x128xf32>
+      }
+    } {mapping = [#gpu.thread<linear_dim_0>, #gpu.thread<linear_dim_1>]}
+    return %2 : tensor<128x128xf32>
+  }
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %loop = transform.structured.match ops{["scf.forall"]} in %root : (!transform.any_op) -> !transform.any_op
+    %new_loop = transform.iree.flatten_forall_mapping %loop : (!transform.any_op) -> !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK: #[[$MAP:.+]] = affine_map<(d0) -> (d0 * 32)>
+// CHECK: #[[$MAP1:.+]] = affine_map<(d0) -> (d0 * 16)>
+
+// CHECK-LABEL: func @flatten_forall_thread_mapping
+//       CHECK:   scf.forall (%[[FLAT_ID:.+]]) in (64)
+//       CHECK:     %[[IDS:.+]]:2 = affine.delinearize_index %[[FLAT_ID]] into (%c4, %c16) : index, index
+//   CHECK-DAG:     %[[IDX:.+]] = affine.apply #[[$MAP]](%[[IDS]]#0)
+//   CHECK-DAG:     %[[IDY:.+]] = affine.apply #[[$MAP1]](%[[IDS]]#1)
+//       CHECK:   } {mapping = [#gpu.thread<linear_dim_0>]}
+
+// -----
+
+#map = affine_map<(d0) -> (d0 * 32)>
+#map1 = affine_map<(d0) -> (d0 * 16)>
+module {
+  func.func @flatten_forall_warp_mapping(%arg0: tensor<128x128xf32>, %dimx: index, %dimy: index) -> tensor<128x128xf32> {
+    %0 = tensor.empty() : tensor<128x128xf32>
+    %2 = scf.forall (%arg5, %arg6) in (%dimx, %dimy) shared_outs(%arg7 = %0) -> (tensor<128x128xf32>) {
+      %3 = affine.apply #map(%arg5)
+      %4 = affine.apply #map1(%arg6)
+      %extracted_slice = tensor.extract_slice %arg0[%3, %4] [32, 8] [1, 1] : tensor<128x128xf32> to tensor<32x8xf32>
+      %extracted_slice_0 = tensor.extract_slice %arg7[%3, %4] [32, 8] [1, 1] : tensor<128x128xf32> to tensor<32x8xf32>
+      %5 = linalg.copy ins(%extracted_slice : tensor<32x8xf32>) outs(%extracted_slice_0 : tensor<32x8xf32>) -> tensor<32x8xf32>
+      scf.forall.in_parallel {
+        tensor.parallel_insert_slice %5 into %arg7[%3, %4] [32, 8] [1, 1] : tensor<32x8xf32> into tensor<128x128xf32>
+      }
+    } {mapping = [#gpu.warp<linear_dim_0>, #gpu.warp<linear_dim_1>]}
+    return %2 : tensor<128x128xf32>
+  }
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %loop = transform.structured.match ops{["scf.forall"]} in %root : (!transform.any_op) -> !transform.any_op
+    %new_loop = transform.iree.flatten_forall_mapping %loop : (!transform.any_op) -> !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0) -> (d0 * 32)>
+// CHECK-DAG: #[[$MAP1:.+]] = affine_map<(d0) -> (d0 * 16)>
+// CHECK-DAG: #[[$MAP2:.+]] = affine_map<()[s0, s1] -> (s0 * s1)>
+
+// CHECK-LABEL: func @flatten_forall_warp_mapping
+//  CHECK-SAME:   %[[DIMX:[A-Za-z0-9]+]]: index
+//  CHECK-SAME:   %[[DIMY:[A-Za-z0-9]+]]: index
+//       CHECK:   %[[FLAT_UB:.+]] = affine.apply #[[$MAP2]]()[%[[DIMX]], %[[DIMY]]]
+//       CHECK:   scf.forall (%[[FLAT_ID:.+]]) in (%[[FLAT_UB]])
+//       CHECK:     %[[IDS:.+]]:2 = affine.delinearize_index %[[FLAT_ID]] into (%[[DIMX]], %[[DIMY]]) : index, index
+//   CHECK-DAG:     %[[IDX:.+]] = affine.apply #[[$MAP]](%[[IDS]]#0)
+//   CHECK-DAG:     %[[IDY:.+]] = affine.apply #[[$MAP1]](%[[IDS]]#1)
+//       CHECK:   } {mapping = [#gpu.warp<linear_dim_0>]}


### PR DESCRIPTION
Normalizing the thread/warp ids of an scf.forall op eases later transformations between loops by decoupling the delinearization of indices from the (common) flat id. Currently this only supports cases with lower bound zero and unit stride with a "descending" mapping.