### PR TITLE
Disable test_amd_w7900 job in ci.yml while runner is unstable.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,44 +429,45 @@ jobs:
         run: |
           ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}
 
-  test_amd_w7900:
-    needs: [setup, build_all]
-    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_amd_w7900')
-    env:
-      BUILD_DIR: build-tests
-      INSTALL_DIR: ${{ needs.build_all.outputs.install-dir }}
-      INSTALL_DIR_ARCHIVE: ${{ needs.build_all.outputs.install-dir-archive }}
-      INSTALL_DIR_GCS_URL: ${{ needs.build_all.outputs.install-dir-gcs-url }}
-      IREE_CPU_DISABLE: 1
-      IREE_VULKAN_DISABLE: 0
-      IREE_CUDA_DISABLE: 1
-      IREE_HIP_DISABLE: 0
-      IREE_HIP_TEST_TARGET_CHIP: "gfx1100"
-    runs-on: nodai-amdgpu-w7900-x86-64
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-      - name: "Checking out runtime submodules"
-        run: ./build_tools/scripts/git/update_runtime_submodules.sh
-      - name: "Downloading install dir archive"
-        run: wget "${INSTALL_DIR_GCS_URL}" -O "${INSTALL_DIR_ARCHIVE}"
-      - name: "Extracting install directory"
-        run: tar -xf "${INSTALL_DIR_ARCHIVE}"
-      - name: "Building tests"
-        run: |
-          ./build_tools/pkgci/build_tests_using_package.sh ${INSTALL_DIR}
-      - name: "Running GPU tests"
-        env:
-          IREE_CTEST_LABEL_REGEX: ^requires-gpu|^driver=vulkan$|^driver=hip$
-          IREE_AMD_RDNA3_TESTS_DISABLE: 0
-          IREE_NVIDIA_GPU_TESTS_DISABLE: 0
-          IREE_NVIDIA_SM80_TESTS_DISABLE: 1
-          IREE_MULTI_DEVICE_TESTS_DISABLE: 0
-          IREE_CUDA_DISABLE: 1
-          IREE_CPU_DISABLE: 1
-          IREE_HIP_DISABLE: 0
-        run: |
-          ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}
+  # Disabled while the 'nodai-amdgpu-w7900-x86-64' runner is unstable.
+  # test_amd_w7900:
+  #   needs: [setup, build_all]
+  #   if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_amd_w7900')
+  #   env:
+  #     BUILD_DIR: build-tests
+  #     INSTALL_DIR: ${{ needs.build_all.outputs.install-dir }}
+  #     INSTALL_DIR_ARCHIVE: ${{ needs.build_all.outputs.install-dir-archive }}
+  #     INSTALL_DIR_GCS_URL: ${{ needs.build_all.outputs.install-dir-gcs-url }}
+  #     IREE_CPU_DISABLE: 1
+  #     IREE_VULKAN_DISABLE: 0
+  #     IREE_CUDA_DISABLE: 1
+  #     IREE_HIP_DISABLE: 0
+  #     IREE_HIP_TEST_TARGET_CHIP: "gfx1100"
+  #   runs-on: nodai-amdgpu-w7900-x86-64
+  #   steps:
+  #     - name: "Checking out repository"
+  #       uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+  #     - name: "Checking out runtime submodules"
+  #       run: ./build_tools/scripts/git/update_runtime_submodules.sh
+  #     - name: "Downloading install dir archive"
+  #       run: wget "${INSTALL_DIR_GCS_URL}" -O "${INSTALL_DIR_ARCHIVE}"
+  #     - name: "Extracting install directory"
+  #       run: tar -xf "${INSTALL_DIR_ARCHIVE}"
+  #     - name: "Building tests"
+  #       run: |
+  #         ./build_tools/pkgci/build_tests_using_package.sh ${INSTALL_DIR}
+  #     - name: "Running GPU tests"
+  #       env:
+  #         IREE_CTEST_LABEL_REGEX: ^requires-gpu|^driver=vulkan$|^driver=hip$
+  #         IREE_AMD_RDNA3_TESTS_DISABLE: 0
+  #         IREE_NVIDIA_GPU_TESTS_DISABLE: 0
+  #         IREE_NVIDIA_SM80_TESTS_DISABLE: 1
+  #         IREE_MULTI_DEVICE_TESTS_DISABLE: 0
+  #         IREE_CUDA_DISABLE: 1
+  #         IREE_CPU_DISABLE: 1
+  #         IREE_HIP_DISABLE: 0
+  #       run: |
+  #         ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}
 
   ################################## Subsets ###################################
   # Jobs that build some subset of IREE
@@ -1155,7 +1156,7 @@ jobs:
       - test_nvidia_gpu
       - test_nvidia_a100
       - test_amd_mi250
-      - test_amd_w7900
+      # - test_amd_w7900
 
       # Subsets
       - build_test_runtime


### PR DESCRIPTION
Context:
* New job added in https://github.com/iree-org/iree/pull/17298
* Recent stall: https://github.com/iree-org/iree/actions/runs/9054348031/job/24874255455#step:7:92

skip-ci: no need to run CI on removing a job