### PR TITLE
[Codegen][GPU] Add a contraction like operation for mma intrinsics

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
@@ -34,6 +34,7 @@ iree_td_library(
     ),
     deps = [
         "@llvm-project//mlir:ControlFlowInterfacesTdFiles",
+        "@llvm-project//mlir:DialectUtilsIncGen",
         "@llvm-project//mlir:OpBaseTdFiles",
         "@llvm-project//mlir:SideEffectInterfacesTdFiles",
     ],
@@ -135,10 +136,7 @@ iree_gentbl_cc_library(
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "IREEGPUAttrs.td",
-    deps = [
-        ":td_files",
-        "@llvm-project//mlir:DialectUtilsIncGen",
-    ],
+    deps = [":td_files"],
 )
 
 iree_gentbl_cc_library(

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
@@ -52,6 +52,8 @@ iree_compiler_cc_library(
         "IREEGPUOps.h",
     ],
     textual_hdrs = [
+        "IREEGPUEnums.cpp.inc",
+        "IREEGPUEnums.h.inc",
         "IREEGPUAttrs.cpp.inc",
         "IREEGPUAttrs.h.inc",
         "IREEGPUDialect.cpp.inc",
@@ -63,6 +65,7 @@ iree_compiler_cc_library(
     ],
     deps = [
         ":IREEGPUAttrs",
+        ":IREEGPUEnums",
         ":IREEGPUDialectGen",
         ":IREEGPUInterfaces",
         ":IREEGPUOpsGen",
@@ -100,7 +103,7 @@ iree_gentbl_cc_library(
 )
 
 iree_gentbl_cc_library(
-    name = "IREEGPUAttrs",
+    name = "IREEGPUEnums",
     tbl_outs = [
         (
             ["--gen-enum-decls"],
@@ -110,6 +113,15 @@ iree_gentbl_cc_library(
             ["--gen-enum-defs"],
             "IREEGPUEnums.cpp.inc",
         ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "IREEGPUEnums.td",
+    deps = [":td_files"],
+)
+
+iree_gentbl_cc_library(
+    name = "IREEGPUAttrs",
+    tbl_outs = [
         (
             ["--gen-attrdef-decls"],
             "IREEGPUAttrs.h.inc",
@@ -121,7 +133,10 @@ iree_gentbl_cc_library(
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "IREEGPUAttrs.td",
-    deps = [":td_files"],
+    deps = [
+        ":td_files",
+        "@llvm-project//mlir:DialectUtilsIncGen",
+    ],
 )
 
 iree_gentbl_cc_library(

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
@@ -16,6 +16,7 @@ package(
 exports_files([
     "IREEGPUAttrs.td",
     "IREEGPUDialect.td",
+    "IREEGPUEnums.td",
     "IREEGPUInterfaces.td",
 ])
 
@@ -25,6 +26,7 @@ iree_td_library(
         [
             "IREEGPUAttrs.td",
             "IREEGPUDialect.td",
+            "IREEGPUEnums.td",
             "IREEGPUInterfaces.td",
             "IREEGPUOps.td",
         ],

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
@@ -34,7 +34,7 @@ iree_td_library(
     ),
     deps = [
         "@llvm-project//mlir:ControlFlowInterfacesTdFiles",
-        "@llvm-project//mlir:DialectUtilsIncGen",
+        "@llvm-project//mlir:DialectUtilsTdFiles",
         "@llvm-project//mlir:OpBaseTdFiles",
         "@llvm-project//mlir:SideEffectInterfacesTdFiles",
     ],

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
@@ -65,8 +65,8 @@ iree_compiler_cc_library(
     ],
     deps = [
         ":IREEGPUAttrs",
-        ":IREEGPUEnums",
         ":IREEGPUDialectGen",
+        ":IREEGPUEnums",
         ":IREEGPUInterfaces",
         ":IREEGPUOpsGen",
         "//compiler/src/iree/compiler/Codegen/Utils:VectorOpUtils",

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/CMakeLists.txt
@@ -23,6 +23,8 @@ iree_cc_library(
     "IREEGPUAttrs.h.inc"
     "IREEGPUDialect.cpp.inc"
     "IREEGPUDialect.h.inc"
+    "IREEGPUEnums.cpp.inc"
+    "IREEGPUEnums.h.inc"
     "IREEGPUInterfaces.cpp.inc"
     "IREEGPUInterfaces.h.inc"
     "IREEGPUOps.cpp.inc"
@@ -35,6 +37,7 @@ iree_cc_library(
   DEPS
     ::IREEGPUAttrs
     ::IREEGPUDialectGen
+    ::IREEGPUEnums
     ::IREEGPUInterfaces
     ::IREEGPUOpsGen
     IREEVectorExtDialect
@@ -64,12 +67,20 @@ iree_tablegen_library(
 
 iree_tablegen_library(
   NAME
+    IREEGPUEnums
+  TD_FILE
+    "IREEGPUEnums.td"
+  OUTS
+    --gen-enum-decls IREEGPUEnums.h.inc
+    --gen-enum-defs IREEGPUEnums.cpp.inc
+)
+
+iree_tablegen_library(
+  NAME
     IREEGPUAttrs
   TD_FILE
     "IREEGPUAttrs.td"
   OUTS
-    --gen-enum-decls IREEGPUEnums.h.inc
-    --gen-enum-defs IREEGPUEnums.cpp.inc
     --gen-attrdef-decls IREEGPUAttrs.h.inc
     --gen-attrdef-defs IREEGPUAttrs.cpp.inc
 )

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h
@@ -9,6 +9,7 @@
 
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h"
+#include "mlir/Dialect/Utils/StructuredOpsUtils.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -18,6 +19,7 @@
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.h.inc"
 #define GET_ATTRDEF_CLASSES
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h.inc"
+#undef GET_ATTRDEF_CLASSES
 // clang-format on
 
 #endif // IREE_COMPILER_CODEGEN_DIALECT_GPU_IREEGPUATTRS_H_

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -8,24 +8,17 @@
 #define IREE_COMPILER_CODEGEN_DIALECT_GPU_IREEGPUATTRS
 
 include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.td"
+include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td"
 include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.td"
+include "mlir/Dialect/Utils/StructuredOpsUtils.td"
 include "mlir/IR/OpBase.td"
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/EnumAttr.td"
 
-/// TODO: Iterator types are duplicated across dialects upstream and here due
-/// to a lack of a shared attribute. This should be deduplicated upstream and
-/// then here as well.
-def IREEGPU_IteratorType : I32EnumAttr<"IteratorType", "Iterator type", [
-  I32EnumAttrCase<"parallel", 0>,
-  I32EnumAttrCase<"reduction", 1>
-]> {
-    let genSpecializedAttr = 0;
-    let cppNamespace = "::mlir::iree_compiler::IREE::GPU";
-}
-
+/// TODO: Iterator type arrays are duplicated across dialects upstream and here.
+/// These should be unified somewhere as a common iterator type array attr.
 def IREEGPU_IteratorTypeEnum
-    : EnumAttr<IREEGPU_Dialect, IREEGPU_IteratorType, "iterator_type"> {
+    : EnumAttr<IREEGPU_Dialect, IteratorType, "iterator_type"> {
     let assemblyFormat = "`<` $value `>`";
 }
 
@@ -84,29 +77,12 @@ class IREEGPU_MmaVectorLayoutAttr<string attrname, string mmaintrinsic> :
   );
 }
 
-class IREEGPU_I32MmaEnumAttr<string name, string summary, list<I32EnumAttrCase> cases>
-    : I32EnumAttr<name, summary, cases> {
-  let cppNamespace = "::mlir::iree_compiler::IREE::GPU";
-  let genSpecializedAttr = 0;
-}
-
-class IREEGPU_MmaEnumAttr<EnumAttrInfo enumInfo, string name = "">
-  : EnumAttr<IREEGPU_Dialect, enumInfo, name>;
-
 //===----------------------------------------------------------------------===//
 // MMA Attributes
 //===----------------------------------------------------------------------===//
 
-def MFMA_F16_16x16x16_F32 : I32EnumAttrCase<"MFMA_F16_16x16x16_F32", 0>;
-def MFMA_F16_32x32x8_F32 : I32EnumAttrCase<"MFMA_F16_32x32x8_F32", 1>;
-def WMMA_F16_16x16x16_F32 : I32EnumAttrCase<"WMMA_F16_16x16x16_F32", 2>;
-
-def IREEGPU_MMAIntrinsic : IREEGPU_I32MmaEnumAttr<"MMAIntrinsic",
-    "Descriptor for different MMA intrinsics", [
-      MFMA_F16_16x16x16_F32,
-      MFMA_F16_32x32x8_F32,
-      WMMA_F16_16x16x16_F32
-    ]>;
+class IREEGPU_MmaEnumAttr<EnumAttrInfo enumInfo, string name = "">
+  : EnumAttr<IREEGPU_Dialect, enumInfo, name>;
 
 def IREEGPU_MMAIntrinsicAttr
   : IREEGPU_MmaEnumAttr<IREEGPU_MMAIntrinsic, "mma_intrinsic">;
@@ -180,7 +156,6 @@ def IREEGPU_MmaScheduleAttr : AttrDef<IREEGPU_Dialect, "MMASchedule"> {
     A schedule of MMA intrinsic instruction and various levels of tile sizes
     to solve a specific contraction problem.
   }];
-
 
   let parameters = (ins
     "::mlir::iree_compiler::IREE::GPU::MmaInterfaceAttr":$intrinsic,

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -13,6 +13,26 @@ include "mlir/IR/OpBase.td"
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/EnumAttr.td"
 
+/// TODO: Iterator types are duplicated across dialects upstream and here due
+/// to a lack of a shared attribute. This should be deduplicated upstream and
+/// then here as well.
+def IREEGPU_IteratorType : I32EnumAttr<"IteratorType", "Iterator type", [
+  I32EnumAttrCase<"parallel", 0>,
+  I32EnumAttrCase<"reduction", 1>
+]> {
+    let genSpecializedAttr = 0;
+    let cppNamespace = "::mlir::iree_compiler::IREE::GPU";
+}
+
+def IREEGPU_IteratorTypeEnum
+    : EnumAttr<IREEGPU_Dialect, IREEGPU_IteratorType, "iterator_type"> {
+    let assemblyFormat = "`<` $value `>`";
+}
+
+def IREEGPU_IteratorTypeArrayAttr
+    : TypedArrayAttrBase<IREEGPU_IteratorTypeEnum,
+                         "Iterator type should be an enum.">;
+
 //===----------------------------------------------------------------------===//
 // Base MMA Vector Layout Attributes
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.td
@@ -8,6 +8,8 @@
 #define IREE_CODEGEN_DIALECT_GPU_IREEGPU_DIALECT
 
 include "mlir/IR/OpBase.td"
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/EnumAttr.td"
 
 //===----------------------------------------------------------------------===//
 // IREE GPU Dialect
@@ -32,5 +34,16 @@ def IREEGPU_Dialect : Dialect {
     void registerAttributes();
   }];
 }
+
+//===----------------------------------------------------------------------===//
+// Type definitions
+//===----------------------------------------------------------------------===//
+
+class RankedTensorOrVectorOf<list<Type> allowedTypes> :
+  ShapedContainerType<allowedTypes,
+      Or<[IsVectorTypePred, And<[IsTensorTypePred, HasRankPred]>]>,
+  "ranked tensor or vector", "::mlir::ShapedType">;
+
+def AnyRankedTensorOrVector : RankedTensorOrVectorOf<[AnyType]>;
 
 #endif // IREE_CODEGEN_DIALECT_GPU_IREEGPU_DIALECT

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td
@@ -1,0 +1,34 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_DIALECT_GPU_IREEGPUENUMS
+#define IREE_COMPILER_CODEGEN_DIALECT_GPU_IREEGPUENUMS
+
+include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.td"
+include "mlir/IR/EnumAttr.td"
+
+class IREEGPU_I32MmaEnumAttr<string name, string summary, list<I32EnumAttrCase> cases>
+    : I32EnumAttr<name, summary, cases> {
+  let cppNamespace = "::mlir::iree_compiler::IREE::GPU";
+  let genSpecializedAttr = 0;
+}
+
+//===----------------------------------------------------------------------===//
+// MMA Attribute Enums
+//===----------------------------------------------------------------------===//
+
+def MFMA_F16_16x16x16_F32 : I32EnumAttrCase<"MFMA_F16_16x16x16_F32", 0>;
+def MFMA_F16_32x32x8_F32 : I32EnumAttrCase<"MFMA_F16_32x32x8_F32", 1>;
+def WMMA_F16_16x16x16_F32 : I32EnumAttrCase<"WMMA_F16_16x16x16_F32", 2>;
+
+def IREEGPU_MMAIntrinsic : IREEGPU_I32MmaEnumAttr<"MMAIntrinsic",
+    "Descriptor for different MMA intrinsics", [
+      MFMA_F16_16x16x16_F32,
+      MFMA_F16_32x32x8_F32,
+      WMMA_F16_16x16x16_F32
+    ]>;
+
+#endif // IREE_COMPILER_CODEGEN_DIALECT_GPU_IREEGPUENUMS

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.td
@@ -107,4 +107,12 @@ def IREEGPU_MmaInterfaceAttr : AttrInterface<"MmaInterfaceAttr"> {
   ];
 }
 
+def IREEGPU_AnyMmaAttr : Attr<Or<[
+  CPred<"isa<IREE::GPU::MmaInterfaceAttr>($_self)">,
+]>, "buffer-like constant attribute values"> {
+  let storageType = [{ IREE::GPU::MmaInterfaceAttr }];
+  let returnType = [{ IREE::GPU::MmaInterfaceAttr }];
+  let convertFromStorage = "$_self";
+}
+
 #endif // IREE_COMPILER_CODEGEN_DIALECT_GPU_IREEGPUINTERFACES

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -6,8 +6,13 @@
 
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
 
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h"
+#include "llvm/ADT/iterator_range.h"
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/Support/LLVM.h"
@@ -18,6 +23,165 @@
 // clang-format on
 
 namespace mlir::iree_compiler::IREE::GPU {
+
+//===----------------------------------------------------------------------===//
+// MultiMmaOp
+//===----------------------------------------------------------------------===//
+
+void MultiMmaOp::build(OpBuilder &builder, OperationState &result, Value lhs,
+                       Value rhs, Value acc,
+                       ArrayRef<ArrayRef<AffineExpr>> indexingExprs,
+                       ArrayRef<GPU::IteratorType> iteratorTypes,
+                       MmaInterfaceAttr kind) {
+  result.addOperands({lhs, rhs, acc});
+  result.addTypes(acc.getType());
+  result.addAttribute(
+      getIndexingMapsAttrName(result.name),
+      builder.getAffineMapArrayAttr(
+          AffineMap::inferFromExprList(indexingExprs, builder.getContext())));
+  result.addAttribute(
+      getIteratorTypesAttrName(result.name),
+      builder.getArrayAttr(llvm::to_vector(llvm::map_range(
+          iteratorTypes, [&](IteratorType t) -> mlir::Attribute {
+            return IteratorTypeAttr::get(builder.getContext(), t);
+          }))));
+  result.addAttribute(getKindAttrName(result.name), kind);
+}
+
+void MultiMmaOp::build(OpBuilder &builder, OperationState &result, Value lhs,
+                       Value rhs, Value acc, ArrayAttr indexingMaps,
+                       ArrayAttr iteratorTypes, MmaInterfaceAttr kind) {
+  result.addOperands({lhs, rhs, acc});
+  result.addTypes(acc.getType());
+  result.addAttribute(getIndexingMapsAttrName(result.name), indexingMaps);
+  result.addAttribute(getIteratorTypesAttrName(result.name), iteratorTypes);
+  result.addAttribute(getKindAttrName(result.name), kind);
+}
+
+LogicalResult MultiMmaOp::verify() {
+  ShapedType lhsType = getLhsType();
+  ShapedType rhsType = getRhsType();
+  ShapedType accType = getAccType();
+
+  SmallVector<AffineMap, 4> indexingMaps = getIndexingMapsArray();
+
+  // Verify that an indexing map was specified for each operand.
+  if (indexingMaps.size() != 3)
+    return emitOpError("expected an indexing map for each operand");
+
+  // Verify that each index map has 'numIterators' inputs, no symbols, and
+  // that the number of map outputs equals the rank of its associated
+  // vector operand.
+  unsigned numIterators = getIteratorTypes().getValue().size();
+  for (const auto &it : llvm::enumerate(indexingMaps)) {
+    auto index = it.index();
+    auto map = it.value();
+    if (map.getNumSymbols() != 0)
+      return emitOpError("expected indexing map ")
+             << index << " to have no symbols";
+    auto shapedType = llvm::dyn_cast<ShapedType>(getOperand(index).getType());
+    unsigned rank = shapedType.getRank();
+    // Verify that the map has the right number of inputs, outputs, and indices.
+    // This also correctly accounts for (..) -> () for rank-0 results.
+    if (map.getNumDims() != numIterators)
+      return emitOpError("expected indexing map ")
+             << index << " to have " << numIterators << " number of inputs";
+    if (map.getNumResults() >= rank)
+      return emitOpError("expected indexing map ")
+             << index << " to have fewer than " << rank << " number of outputs";
+    if (!map.isProjectedPermutation())
+      return emitOpError("expected indexing map ")
+             << index << " to be a projected permutation of its inputs";
+
+    for (auto size :
+         shapedType.getShape().take_back(rank - map.getNumResults())) {
+      if (ShapedType::isDynamic(size)) {
+        return emitOpError("Unexpected dynamic inner dim for operand ")
+               << index << " of type " << shapedType;
+      }
+    }
+  }
+
+  if (failed(linalg::inferContractionDims(indexingMaps))) {
+    return emitOpError("failed to infer contraction dims");
+  }
+
+  SmallVector<int64_t> bounds;
+  getIterationBounds(bounds);
+  // The truncation functionality of llvm::zip is intentional here to ignore
+  // the inner dimensions.
+  auto verifyOperandShape = [&](ShapedType type, AffineMap map) {
+    for (auto [dim, size] : llvm::zip(map.getResults(), type.getShape())) {
+      int64_t dimIdx = cast<AffineDimExpr>(dim).getPosition();
+      if (size != bounds[dimIdx]) {
+        return failure();
+      }
+    }
+    return success();
+  };
+  if (failed(verifyOperandShape(lhsType, indexingMaps[0]))) {
+    return emitOpError("lhs shape does not match iteration bounds");
+  }
+  if (failed(verifyOperandShape(rhsType, indexingMaps[1]))) {
+    return emitOpError("rhs shape does not match iteration bounds");
+  }
+  if (failed(verifyOperandShape(accType, indexingMaps[2]))) {
+    return emitOpError("accumulator shape does not match iteration bounds");
+  }
+
+  // Verify supported combining kind.
+  auto [lType, rType, aType] = getKind().getABCElementTypes();
+  if (lType != lhsType.getElementType()) {
+    return emitOpError("lhs element type ")
+           << lhsType.getElementType()
+           << " does not match expected element type " << lType
+           << " for intrinsic";
+  }
+  if (rType != rhsType.getElementType()) {
+    return emitOpError("rhs element type ")
+           << rhsType.getElementType()
+           << " does not match expected element type " << rType
+           << " for intrinsic";
+  }
+  if (aType != accType.getElementType()) {
+    return emitOpError("accumulator element type ")
+           << accType.getElementType()
+           << " does not match expected element type " << aType
+           << " for intrinsic";
+  }
+
+  return success();
+}
+
+static int64_t getResultIndex(AffineMap map, AffineExpr targetExpr) {
+  for (int64_t i = 0, e = map.getNumResults(); i < e; ++i)
+    if (targetExpr == map.getResult(i))
+      return i;
+  return -1;
+}
+
+void MultiMmaOp::getIterationBounds(SmallVectorImpl<int64_t> &iterationBounds) {
+  auto lhsShape = getLhsType().getShape();
+  auto resType = getResultType();
+  SmallVector<AffineMap, 4> indexingMaps(getIndexingMapsArray());
+  SmallVector<int64_t, 2> iterationShape;
+  for (const auto &it : llvm::enumerate(getIteratorTypes())) {
+    // Search lhs/rhs map results for 'targetExpr'.
+    auto targetExpr = getAffineDimExpr(it.index(), getContext());
+    auto iteratorType = llvm::cast<IteratorTypeAttr>(it.value()).getValue();
+    if (iteratorType == IteratorType::reduction) {
+      // Get reduction dim size from lhs shape (same size in rhsShape).
+      int64_t lhsDimIndex = getResultIndex(indexingMaps[0], targetExpr);
+      assert(lhsDimIndex >= 0);
+      iterationBounds.push_back(lhsShape[lhsDimIndex]);
+      continue;
+    }
+    // Get parallel dimension size from result shape.
+    int64_t resDimIndex = getResultIndex(indexingMaps[2], targetExpr);
+    assert(resDimIndex >= 0);
+    iterationBounds.push_back(resType.getShape()[resDimIndex]);
+  }
+}
 
 //===----------------------------------------------------------------------===//
 // ShuffleTensorOp

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -9,9 +9,9 @@
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h"
-#include "llvm/ADT/iterator_range.h"
 #include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/StructuredOpsUtils.h"
 #include "mlir/IR/BuiltinTypeInterfaces.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OpImplementation.h"
@@ -31,7 +31,7 @@ namespace mlir::iree_compiler::IREE::GPU {
 void MultiMmaOp::build(OpBuilder &builder, OperationState &result, Value lhs,
                        Value rhs, Value acc,
                        ArrayRef<ArrayRef<AffineExpr>> indexingExprs,
-                       ArrayRef<GPU::IteratorType> iteratorTypes,
+                       ArrayRef<utils::IteratorType> iteratorTypes,
                        MmaInterfaceAttr kind) {
   result.addOperands({lhs, rhs, acc});
   result.addTypes(acc.getType());
@@ -42,7 +42,7 @@ void MultiMmaOp::build(OpBuilder &builder, OperationState &result, Value lhs,
   result.addAttribute(
       getIteratorTypesAttrName(result.name),
       builder.getArrayAttr(llvm::to_vector(llvm::map_range(
-          iteratorTypes, [&](IteratorType t) -> mlir::Attribute {
+          iteratorTypes, [&](utils::IteratorType t) -> mlir::Attribute {
             return IteratorTypeAttr::get(builder.getContext(), t);
           }))));
   result.addAttribute(getKindAttrName(result.name), kind);
@@ -169,7 +169,7 @@ void MultiMmaOp::getIterationBounds(SmallVectorImpl<int64_t> &iterationBounds) {
     // Search lhs/rhs map results for 'targetExpr'.
     auto targetExpr = getAffineDimExpr(it.index(), getContext());
     auto iteratorType = llvm::cast<IteratorTypeAttr>(it.value()).getValue();
-    if (iteratorType == IteratorType::reduction) {
+    if (iteratorType == utils::IteratorType::reduction) {
       // Get reduction dim size from lhs shape (same size in rhsShape).
       int64_t lhsDimIndex = getResultIndex(indexingMaps[0], targetExpr);
       assert(lhsDimIndex >= 0);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h
@@ -7,6 +7,8 @@
 #ifndef IREE_COMPILER_CODEGEN_DIALECT_IREEGPUOPS_H_
 #define IREE_COMPILER_CODEGEN_DIALECT_IREEGPUOPS_H_
 
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h"
 #include "mlir/Bytecode/BytecodeOpInterface.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/Builders.h"

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -8,10 +8,182 @@
 #define IREE_CODEGEN_DIALECT_IREEGPUOPS
 
 include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.td"
+include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.td"
+include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/OpBase.td"
+
+//===----------------------------------------------------------------------===//
+// MultiMmaOp
+//===----------------------------------------------------------------------===//
+
+def IREEGPU_MultiMmaOp : Op<IREEGPU_Dialect, "multi_mma", [
+    Pure,
+    AllTypesMatch<["acc", "result"]>,
+    ]> {
+  let summary = "Models a contraction of multiple mma operations";
+  let description = [{
+    Computes the sum of inner MMA operations along a set of outer dimensions.
+    Logically matches closely with a `vector.contraction` operation, however
+    the combiner type is a specific intrinsic rather than a generic combiner
+    type.
+
+    Similar to `vector.contraction`, an iterator type attribute list must be
+    specified, where each element of the list represents an iterator over one
+    of the outer dimensions. Iteration of inner dimensions is defined solely by
+    the intrinsic and may be opaque.
+
+    An indexing map attribute list must be specified with an entry for lhs, rhs
+    and acc arguments. An indexing map attribute specifies a mapping from each
+    outer loop iterator in the iterator type list, to each dimension of each
+    operand.
+
+    The combiner type is defined by the intrinsic.
+
+    Example:
+
+    ```mlir
+    #contraction_accesses = [
+     affine_map<(i, j, k) -> (i, k)>,
+     affine_map<(i, j, k) -> (k, j)>,
+     affine_map<(i, j, k) -> (i, j)>
+    ]
+    #contraction_trait = {
+      indexing_maps = #contraction_accesses,
+      iterator_types = ["parallel", "parallel", "reduction"],
+      kind = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>
+    }
+    %3 = iree_gpu.multi_mma %0, %1, %2 #contraction_trait
+      : vector<2x3x4xf16>, vector<3x5x4xf16> into vector<2x5x4xf32>
+
+    // Takes tensors as well, however the inner dimensions must always be
+    // static.
+    %7 = iree_gpu.multi_mma %4, %5, %6 #contraction_trait
+      : tensor<?x?x4xf16>, tensor<?x?x4xf16> into tensor<?x?x4xf32>
+    ```
+
+    The example above can be logically lowered directly to loops like this
+    (ignoring type conversions from tensor to vector needed for the mfma).
+    ```
+    %outer_m = tensor.dim %6, %c0 : index
+    %outer_n = tensor.dim %6, %c1 : index
+    %outer_k = tensor.dim %4, %c1 : index
+    %7 = scf.for %i = %c0 to %outer_m iter_args(%arg0 = %6) {
+      %8 = scf.for %j = %c0 to %outer_n iter_args(%arg1 = %arg0) {
+        %9 = scf.for %k = %c0 to %outer_k iter_args(%arg2 = %arg1) {
+          %lhs = tensor.extract_slice %4 [%i, %k, 0] [1, 1, 4] [1, 1, 1] : tensor<4xf16>
+          %rhs = tensor.extract_slice %5 [%k, %j, 0] [1, 1, 4] [1, 1, 1] : tensor<4xf16>
+          %acc = tensor.extract_slice %arg2 [%i, %j, 0] [1, 1, 4] [1, 1, 1] : tensor<4xf32>
+          %res = amdgpu.mfma %lhs, %rhs, %acc : tensor<4xf32>
+          %ret = tensor.insert_slice %acc into %arg2 [%i, %j, 0] [1, 1, 4] [1, 1, 1] : tensor<?x?x4xf32>
+          scf.yield %ret : tensor<?x?x4xf32>
+        }
+        scf.yield %9 : tensor<?x?x4xf32>
+      }
+      scf.yield %8 : tensor<?x?x4xf32>
+    }
+    ```
+
+    Or alternatively unrolled to a single intrinsic when operation on vectors.
+    ```mlir
+    #contraction_accesses = [
+     affine_map<() -> ()>,
+     affine_map<() -> ()>,
+     affine_map<() -> ()>
+    ]
+    #contraction_trait = {
+      indexing_maps = #contraction_accesses,
+      iterator_types = [],
+      kind = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>
+    }
+    %3 = iree_gpu.multi_mma %0, %1, %2 #contraction_trait
+      : vector<4xf16>, vector<4xf16> into vector<4xf32>
+    ```
+
+    ## Motivation, Design Choices, and Pitfalls
+
+    The idea behind this operation is to decouple the layout setting/tiling
+    required to target certain intrinsics from the lowering to them. Because
+    typically tiling of this sort happens on tensor operands, however the target
+    intrinsics operate on vectors, we use this operation to bridge the gap. The
+    choice for a shared operation is intended to ease the lowering process and
+    allow for different transformations at different stages of the pipeline
+    without needing to essentially clone this op.
+
+    The choice to let the inner dimensions required to compute the intrinsic be
+    implicit based on the indexing maps was made to make this operation easier
+    to generate and to skip the need for type conversion ops. However this comes
+    at the expense of ease of verification for the operation. It is also
+    implicitly linked to a lane-level parent `scf.forall` operation.
+  }];
+
+  let arguments = (ins
+    AnyRankedTensorOrVector:$lhs,
+    AnyRankedTensorOrVector:$rhs,
+    AnyRankedTensorOrVector:$acc,
+    ArrayAttr:$indexing_maps,
+    IREEGPU_IteratorTypeArrayAttr:$iterator_types,
+    IREEGPU_AnyMmaAttr:$kind
+  );
+  let results = (outs
+    AnyRankedTensorOrVector:$result
+  );
+
+  let assemblyFormat = [{
+    $lhs `,` $rhs `,` $acc attr-dict
+    `:` type($lhs) `,` type($rhs) `into` type($acc)
+  }];
+
+  let builders = [
+    OpBuilder<(ins "Value":$lhs, "Value":$rhs, "Value":$acc,
+      "ArrayAttr":$indexingMaps, "ArrayAttr":$iteratorTypes,
+      "MmaInterfaceAttr":$intrinsic)>,
+    OpBuilder<(ins "Value":$lhs, "Value":$rhs, "Value":$acc,
+      "ArrayRef<ArrayRef<AffineExpr>>":$indexingExprs,
+      "ArrayRef<IteratorType>":$iteratorTypes,
+      "MmaInterfaceAttr":$intrinsic)>
+  ];
+  let extraClassDeclaration = [{
+    ::mlir::ShapedType getLhsType() {
+      return ::llvm::cast<::mlir::ShapedType>(getLhs().getType());
+    }
+    ::mlir::ShapedType getRhsType() {
+      return ::llvm::cast<::mlir::ShapedType>(getRhs().getType());
+    }
+    ::mlir::ShapedType getAccType() {
+      return ::llvm::cast<::mlir::ShapedType>(getAcc().getType());
+    }
+    ::mlir::ShapedType getResultType() {
+      return ::llvm::cast<::mlir::ShapedType>(getResult().getType());
+    }
+
+    llvm::SmallVector<::mlir::AffineMap, 4> getIndexingMapsArray() {
+      return llvm::to_vector<4>(getIndexingMaps().getAsValueRange<::mlir::AffineMapAttr>());
+    }
+
+    // Returns the bounds of each dimension in the iteration space spanned
+    // by the iterator types of this operation.
+    void getIterationBounds(SmallVectorImpl<int64_t> &iterationBounds);
+
+    // Returns a list of index maps, where there is a list entry for each
+    // op indexing map attribute (i.e. one for each input and output, with
+    // the output listed last). Each index map, maps from this operations
+    // iteration space, to vector dimensions of the maps input/output.
+    void getIterationIndexMap(
+      std::vector<DenseMap<int64_t, int64_t>> &iterationIndexMap);
+
+    SmallVector<IteratorType> getIteratorTypesArray() {
+      auto range =
+          getIteratorTypes()
+              .template getAsValueRange<IteratorTypeAttr, IteratorType>();
+      return {range.begin(), range.end()};
+    }
+  }];
+
+  let hasVerifier = 1;
+}
 
 //===----------------------------------------------------------------------===//
 // ShuffleTensorOp

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -142,7 +142,7 @@ def IREEGPU_MultiMmaOp : Op<IREEGPU_Dialect, "multi_mma", [
       "MmaInterfaceAttr":$intrinsic)>,
     OpBuilder<(ins "Value":$lhs, "Value":$rhs, "Value":$acc,
       "ArrayRef<ArrayRef<AffineExpr>>":$indexingExprs,
-      "ArrayRef<IteratorType>":$iteratorTypes,
+      "ArrayRef<utils::IteratorType>":$iteratorTypes,
       "MmaInterfaceAttr":$intrinsic)>
   ];
   let extraClassDeclaration = [{
@@ -174,10 +174,10 @@ def IREEGPU_MultiMmaOp : Op<IREEGPU_Dialect, "multi_mma", [
     void getIterationIndexMap(
       std::vector<DenseMap<int64_t, int64_t>> &iterationIndexMap);
 
-    SmallVector<IteratorType> getIteratorTypesArray() {
+    SmallVector<utils::IteratorType> getIteratorTypesArray() {
       auto range =
           getIteratorTypes()
-              .template getAsValueRange<IteratorTypeAttr, IteratorType>();
+              .template getAsValueRange<IteratorTypeAttr, utils::IteratorType>();
       return {range.begin(), range.end()};
     }
   }];

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
@@ -68,6 +68,17 @@ func.func @vector_multi_mma(%lhs: vector<2x3x4xf16>, %rhs: vector<3x5x4xf16>, %a
   return %0 : vector<2x5x4xf32>
 }
 
+// CHECK: #[[$MAP:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
+// CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
+// CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+// CHECK-LABEL: func @vector_multi_mma
+//       CHECK:   iree_gpu.multi_mma %arg0, %arg1, %arg2
+//  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]]]
+//  CHECK-SAME:       iterator_types = [#iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<reduction>]
+//  CHECK-SAME:       kind = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>
+//  CHECK-SAME:     : vector<2x3x4xf16>, vector<3x5x4xf16> into vector<2x5x4xf32>
+
 // -----
 
 #contraction_accesses = [
@@ -84,6 +95,17 @@ func.func @tensor_multi_mma(%lhs: tensor<?x?x4xf16>, %rhs: tensor<?x?x4xf16>, %a
   return %0 : tensor<?x?x4xf32>
 }
 
+// CHECK: #[[$MAP:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
+// CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
+// CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+// CHECK-LABEL: func @tensor_multi_mma
+//       CHECK:   iree_gpu.multi_mma %arg0, %arg1, %arg2
+//  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]]]
+//  CHECK-SAME:       iterator_types = [#iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<reduction>]
+//  CHECK-SAME:       kind = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>
+//  CHECK-SAME:     : tensor<?x?x4xf16>, tensor<?x?x4xf16> into tensor<?x?x4xf32>
+
 // -----
 
 #contraction_accesses = [
@@ -99,3 +121,12 @@ func.func @single_multi_mma(%lhs: vector<4xf16>, %rhs: vector<4xf16>, %acc: vect
   } : vector<4xf16>, vector<4xf16> into vector<4xf32>
   return %0 : vector<4xf32>
 }
+
+// CHECK: #[[$MAP:.+]] = affine_map<() -> ()>
+
+// CHECK-LABEL: func @single_multi_mma
+//       CHECK:   iree_gpu.multi_mma %arg0, %arg1, %arg2
+//  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP]], #[[$MAP]]]
+//  CHECK-SAME:       iterator_types = []
+//  CHECK-SAME:       kind = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>
+//  CHECK-SAME:     : vector<4xf16>, vector<4xf16> into vector<4xf32>


### PR DESCRIPTION
This operation acts like a contraction but the inner most dimensions are implicitly used as a part of a specific MMA intrinsic. This helps to decouple the tiling/unrolling requirements of the target intrinsic from the initial lowering.