### PR TITLE
Switch pkgci CPU ONNX tests to use standard GitHub runner.

### DIFF
--- a/.github/workflows/pkgci.yml
+++ b/.github/workflows/pkgci.yml
@@ -37,12 +37,11 @@ jobs:
     with:
       package_version: 0.dev1
 
-  # TODO(#17370): re-enable when nodai-amdgpu-w7900-x86-64 runner is stable
-  # regression_test_cpu:
-  #   name: Regression Test CPU
-  #   needs: [setup, build_packages]
-  #   if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'regression_test_cpu')
-  #   uses: ./.github/workflows/pkgci_regression_test_cpu.yml
+  regression_test_cpu:
+    name: Regression Test CPU
+    needs: [setup, build_packages]
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'regression_test_cpu')
+    uses: ./.github/workflows/pkgci_regression_test_cpu.yml
 
   # TODO(#17370): re-enable when nodai-amdgpu-w7900-x86-64 runner is stable
   # regression_test_amdgpu_vulkan:

--- a/.github/workflows/pkgci_regression_test_cpu.yml
+++ b/.github/workflows/pkgci_regression_test_cpu.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   linux_x86_64:
     name: Linux (x86_64)
-    runs-on: nodai-amdgpu-w7900-x86-64
+    runs-on: ubuntu-20.04
     env:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
       IREERS_ARTIFACT_DIR: ${{ github.workspace }}/artifacts
@@ -43,17 +43,6 @@ jobs:
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
             --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
             --fetch-gh-workflow=${{ inputs.artifact_run_id }}
-
-      # TODO(#17344): regenerate .mlirbc files
-      # # In-tree tests
-      # - name: Run experimental/regression_suite tests
-      #   run: |
-      #     source ${VENV_DIR}/bin/activate
-      #     pytest \
-      #       -rA -s -m "plat_host_cpu and presubmit" \
-      #       experimental/regression_suite
-
-      # Out of tree tests
       - name: Check out external TestSuite repository
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:
@@ -89,76 +78,86 @@ jobs:
           name: "onnx_cpu_llvm_sync.json"
           path: "build_tools/pkgci/external_test_suite/onnx_cpu_llvm_sync.json"
 
-  # Note: this is a persistent runner with a local cache. Downloading all input
-  # files (50GB+) without a cache can take 20+ minutes.
-  linux_x86_64_models:
-    name: Linux (x86_64) Model Testing
-    runs-on: nodai-amdgpu-w7900-x86-64
-    env:
-      PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
-      IREERS_ARTIFACT_DIR: ${{ github.workspace }}/artifacts
-      VENV_DIR: ${{ github.workspace }}/venv
-      IREE_TEST_FILES: ~/iree_tests_cache
-    steps:
-      - name: Checking out IREE repository
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
-        with:
-          submodules: false
-      - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1  # v4.7.0
-        with:
-          # Must match the subset of versions built in pkgci_build_packages.
-          python-version: '3.11'
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
-        with:
-          name: linux_x86_64_release_packages
-          path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
-      - name: Setup venv
-        run: |
-          ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
-            --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
-            --fetch-gh-workflow=${{ inputs.artifact_run_id }}
+  # TODO(#17370): re-enable when nodai-amdgpu-w7900-x86-64 runner is stable
+  # # Note: this is a persistent runner with a local cache. Downloading all input
+  # # files (50GB+) without a cache can take 20+ minutes.
+  # linux_x86_64_models:
+  #   name: Linux (x86_64) Model Testing
+  #   runs-on: nodai-amdgpu-w7900-x86-64
+  #   env:
+  #     PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
+  #     IREERS_ARTIFACT_DIR: ${{ github.workspace }}/artifacts
+  #     VENV_DIR: ${{ github.workspace }}/venv
+  #     IREE_TEST_FILES: ~/iree_tests_cache
+  #   steps:
+  #     - name: Checking out IREE repository
+  #       uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+  #       with:
+  #         submodules: false
+  #     - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1  # v4.7.0
+  #       with:
+  #         # Must match the subset of versions built in pkgci_build_packages.
+  #         python-version: '3.11'
+  #     - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
+  #       with:
+  #         name: linux_x86_64_release_packages
+  #         path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
+  #     - name: Setup venv
+  #       run: |
+  #         ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
+  #           --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
+  #           --fetch-gh-workflow=${{ inputs.artifact_run_id }}
 
-      # Out of tree tests
-      - name: Check out external TestSuite repository
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
-        with:
-          repository: nod-ai/SHARK-TestSuite
-          ref: 337083616ae6f596c0206a9edd1c47e8afc0e400
-          path: SHARK-TestSuite
-          submodules: false
-          lfs: true
-      - name: Install external TestSuite Python requirements
-        run: |
-          source ${VENV_DIR}/bin/activate
-          python -m pip install -r SHARK-TestSuite/iree_tests/requirements.txt
-      - name: Download remote files for real weight model tests
-        run: |
-          source ${VENV_DIR}/bin/activate
-          python SHARK-TestSuite/iree_tests/download_remote_files.py --root-dir pytorch/models
-      - name: Run external tests - Models with real weights
-        run: |
-          source ${VENV_DIR}/bin/activate
-          pytest SHARK-TestSuite/iree_tests/pytorch/models \
-            -n 4 \
-            -rpfE \
-            -k real_weights \
-            --no-skip-tests-missing-files \
-            --capture=no \
-            --timeout=1200 \
-            --retries 2 \
-            --retry-delay 5 \
-            --durations=0 \
-            --config-files=build_tools/pkgci/external_test_suite/pytorch_models_cpu_llvm_task.json
-      - name: "Running real weight model tests scheduled unet cpu"
-        run: |
-          source ${VENV_DIR}/bin/activate
-          pytest SHARK-TestSuite/iree_tests/pytorch/models/sdxl-scheduled-unet-3-tank \
-            -rpfE \
-            -k real_weights \
-            --no-skip-tests-missing-files \
-            --capture=no \
-            --timeout=1200 \
-            --retries 2 \
-            --retry-delay 5 \
-            --durations=0 \
-            --config-files=build_tools/pkgci/external_test_suite/sdxl_scheduled_unet_cpu_llvm_task.json
+  #     # TODO(#17344): regenerate .mlirbc files
+  #     # # In-tree tests
+  #     # - name: Run experimental/regression_suite tests
+  #     #   run: |
+  #     #     source ${VENV_DIR}/bin/activate
+  #     #     pytest \
+  #     #       -rA -s -m "plat_host_cpu and presubmit" \
+  #     #       experimental/regression_suite
+
+  #     # Out of tree tests
+  #     - name: Check out external TestSuite repository
+  #       uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+  #       with:
+  #         repository: nod-ai/SHARK-TestSuite
+  #         ref: 337083616ae6f596c0206a9edd1c47e8afc0e400
+  #         path: SHARK-TestSuite
+  #         submodules: false
+  #         lfs: true
+  #     - name: Install external TestSuite Python requirements
+  #       run: |
+  #         source ${VENV_DIR}/bin/activate
+  #         python -m pip install -r SHARK-TestSuite/iree_tests/requirements.txt
+  #     - name: Download remote files for real weight model tests
+  #       run: |
+  #         source ${VENV_DIR}/bin/activate
+  #         python SHARK-TestSuite/iree_tests/download_remote_files.py --root-dir pytorch/models
+  #     - name: Run external tests - Models with real weights
+  #       run: |
+  #         source ${VENV_DIR}/bin/activate
+  #         pytest SHARK-TestSuite/iree_tests/pytorch/models \
+  #           -n 4 \
+  #           -rpfE \
+  #           -k real_weights \
+  #           --no-skip-tests-missing-files \
+  #           --capture=no \
+  #           --timeout=1200 \
+  #           --retries 2 \
+  #           --retry-delay 5 \
+  #           --durations=0 \
+  #           --config-files=build_tools/pkgci/external_test_suite/pytorch_models_cpu_llvm_task.json
+  #     - name: "Running real weight model tests scheduled unet cpu"
+  #       run: |
+  #         source ${VENV_DIR}/bin/activate
+  #         pytest SHARK-TestSuite/iree_tests/pytorch/models/sdxl-scheduled-unet-3-tank \
+  #           -rpfE \
+  #           -k real_weights \
+  #           --no-skip-tests-missing-files \
+  #           --capture=no \
+  #           --timeout=1200 \
+  #           --retries 2 \
+  #           --retry-delay 5 \
+  #           --durations=0 \
+  #           --config-files=build_tools/pkgci/external_test_suite/sdxl_scheduled_unet_cpu_llvm_task.json


### PR DESCRIPTION
Follow-up on https://github.com/iree-org/iree/pull/17371#discussion_r1598719094, progress on https://github.com/iree-org/iree/issues/17370.

CPU tests don't need to use a GPU machine so this moves the ONNX op tests to a standard GitHub-hosted runner. The model tests still use the (currently disabled) GPU machine since it has a cache of downloaded model files and enough CPU cores to compile and run the included tests quickly.

ci-exactly: build_packages, regression_test_cpu