### PR TITLE
Switch TensorFlow test requirement off of tf-nightly.

### DIFF
--- a/integrations/tensorflow/test/requirements.txt
+++ b/integrations/tensorflow/test/requirements.txt
@@ -1,15 +1,4 @@
 # Requirements for running TF tests
-tf-nightly==2.17.0.dev20240507
+tensorflow>=2.16.1
 keras>=2.7.0
 Pillow>=9.2.0
-
-# NOTE: 2022-05-27: protobuf 4.21.0, released on May 25, 2022 is incompatible
-# with prior releases. Specifically implicated are the above versions of
-# tensorflow, which seem to include it without a version pin and therefore
-# break out of the box. The next time the above versions are upgraded,
-# try removing this line and then, within the docker image, run:
-#   python3 -c "import tensorflow"
-# If that fails with a stack trace, put this line back.
-# On behalf of Google, we are sorry for the live at head philosophy
-# and shoddy version management leaking into everything. We're victims too.
-protobuf>=3.20.3, <4


### PR DESCRIPTION
Fixes https://github.com/iree-org/iree/issues/17372 - the nightly releases from pypi have been changing sha256 hashes...? We can also try purging the pip cache (https://stackoverflow.com/a/68809728).

Follow-up to the recent bump to latest nightly on https://github.com/iree-org/iree/pull/17306 (and using stable was also suggested [here on Discord](https://discord.com/channels/689900678990135345/1166024193599615006/1237791196948988008))

Separately we can update documentation (https://iree.dev/guides/ml-frameworks/tensorflow/#prerequisites) and samples (Colab notebooks) to use stable instead of nightly.

ci-exactly: build_packages, test_tensorflow_cpu