### PR TITLE
[LLVMGPU] Preserve config dictionary during MapNestedForallToGpuThreadsOp application

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -107,8 +107,10 @@ transform_dialect::MapNestedForallToGpuThreadsOp::applyToOne(
   // be set to None here.
   if (translationInfo) {
     updatedTranslationInfo = IREE::Codegen::TranslationInfoAttr::get(
-        rewriter.getContext(), translationInfo.getPassPipeline(),
-        translationInfo.getCodegenSpec(), getWorkgroupDims(), getSubgroupSize(),
+        rewriter.getContext(), updatedTranslationInfo.getPassPipeline(),
+        updatedTranslationInfo.getCodegenSpec(),
+        updatedTranslationInfo.getWorkgroupSize(),
+        updatedTranslationInfo.getSubgroupSize(),
         translationInfo.getConfiguration());
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -87,17 +87,32 @@ transform_dialect::MapNestedForallToGpuThreadsOp::applyToOne(
   auto transformOp = cast<transform::TransformOpInterface>(getOperation());
 
   rewriter.setInsertionPointToStart(&target.getFunctionBody().front());
+  IREE::Codegen::TranslationInfoAttr translationInfo =
+      getTranslationInfo(target);
   DiagnosedSilenceableFailure diag =
       mlir::transform::gpu::mapNestedForallToThreadsImpl(
           rewriter, transformOp, target, getWorkgroupDims(), getSubgroupSize(),
           getSyncAfterDistribution());
   if (!diag.succeeded())
     return diag;
-  if (failed(setTranslationInfo(
-          target, IREE::Codegen::TranslationInfoAttr::get(
-                      rewriter.getContext(),
-                      IREE::Codegen::DispatchLoweringPassPipeline::None,
-                      getWorkgroupDims(), getSubgroupSize())))) {
+
+  IREE::Codegen::TranslationInfoAttr updatedTranslationInfo =
+      IREE::Codegen::TranslationInfoAttr::get(
+          rewriter.getContext(),
+          IREE::Codegen::DispatchLoweringPassPipeline::None, getWorkgroupDims(),
+          getSubgroupSize());
+
+  // Set config dictionary.
+  // TODO: Transform Dialect pipeline requires translation_info pass pipeline to
+  // be set to None here.
+  if (translationInfo) {
+    updatedTranslationInfo = IREE::Codegen::TranslationInfoAttr::get(
+        rewriter.getContext(), translationInfo.getPassPipeline(),
+        translationInfo.getCodegenSpec(), getWorkgroupDims(), getSubgroupSize(),
+        translationInfo.getConfiguration());
+  }
+
+  if (failed(setTranslationInfo(target, updatedTranslationInfo))) {
     target->emitOpError("failed to update translation info");
     return emitDefaultDefiniteFailure(target);
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -103,7 +103,7 @@ transform_dialect::MapNestedForallToGpuThreadsOp::applyToOne(
           getSubgroupSize());
 
   // Set config dictionary.
-  // TODO: Transform Dialect pipeline requires translation_info pass pipeline to
+  // Transform Dialect pipeline requires translation_info pass pipeline to
   // be set to None here.
   if (translationInfo) {
     updatedTranslationInfo = IREE::Codegen::TranslationInfoAttr::get(

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_distribute_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_distribute_forall.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt %s --pass-pipeline="builtin.module(iree-codegen-lower-executable-using-transform-dialect)" | FileCheck %s
 
 #executable_target_cuda_nvptx_fb = #hal.executable.target<"cuda", "cuda-nvptx-fb", {target_arch = "sm_60"}>
-#translation = #iree_codegen.translation_info<TransformDialectCodegen>
+#translation = #iree_codegen.translation_info<TransformDialectCodegen, { config_test = "config_test" }>
 module {
   func.func @distribute() attributes {hal.executable.target = #executable_target_cuda_nvptx_fb, translation_info = #translation} {
     %cst = arith.constant dense<0.000000e+00> : vector<1xf16>
@@ -41,7 +41,7 @@ module {
 }
 
 // CHECK-DAG: #[[DIV32:.*]] = affine_map<()[s0] -> (s0 floordiv 32)>
-// CHECK-DAG: #[[TRANSLATION_INFO:.*]] = #iree_codegen.translation_info<None workgroup_size = [256, 1, 1] subgroup_size = 32>
+// CHECK-DAG: #[[TRANSLATION_INFO:.*]] = #iree_codegen.translation_info<None workgroup_size = [256, 1, 1] subgroup_size = 32, {config_test = "config_test"}>
 // CHECK: func.func @distribute()
 // CHECK-SAME: translation_info = #[[TRANSLATION_INFO]]
 // CHECK: %[[TX:.+]] = gpu.thread_id  x


### PR DESCRIPTION
This op currently removes all translation_info information from the dispatch and adds it's own, destroying the config dictionary in the process. This patch makes it preserves the config dictionary.

Ideally, the pipeline would also be preserved. That is being tracked here https://github.com/iree-org/iree/issues/17379