### PR TITLE
Drop `--retries=2` from pytest to fix `--timeout` behavior.

### DIFF
--- a/.github/workflows/pkgci_regression_test_amdgpu_rocm.yml
+++ b/.github/workflows/pkgci_regression_test_amdgpu_rocm.yml
@@ -74,7 +74,7 @@ jobs:
   #         source ${VENV_DIR}/bin/activate
   #         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/rocm/lib:/opt/rocm/hip/lib
   #         pytest SHARK-TestSuite/iree_tests/onnx/ \
-  #             -rpfE --timeout=30 --retries=2 --durations=20 \
+  #             -rpfE --timeout=30 --durations=20 \
   #             --config-files=build_tools/pkgci/external_test_suite/onnx_gpu_rocm_rdna3.json \
   #             --no-skip-tests-missing-files \
   #             --report-log=/tmp/iree_tests_onnx_gpu_rocm_rdna3_logs.json

--- a/.github/workflows/pkgci_regression_test_amdgpu_vulkan.yml
+++ b/.github/workflows/pkgci_regression_test_amdgpu_vulkan.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           source ${VENV_DIR}/bin/activate
           pytest SHARK-TestSuite/iree_tests/onnx/ \
-              -n 4 -rpfE --timeout=30 --retries=2 --durations=20 \
+              -n 4 -rpfE --timeout=30 --durations=20 \
               --config-files=build_tools/pkgci/external_test_suite/onnx_gpu_vulkan.json \
               --no-skip-tests-missing-files
 

--- a/.github/workflows/pkgci_regression_test_cpu.yml
+++ b/.github/workflows/pkgci_regression_test_cpu.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           source ${VENV_DIR}/bin/activate
           pytest SHARK-TestSuite/iree_tests/onnx/ \
-              -n auto -rpfE --timeout=30 --retries=2 --durations=20 \
+              -n auto -rpfE --timeout=30 --durations=20 \
               --config-files=build_tools/pkgci/external_test_suite/onnx_cpu_llvm_sync.json \
               --no-skip-tests-missing-files \
               --report-log=/tmp/iree_tests_onnx_cpu_llvm_sync_logs.json

--- a/.github/workflows/pkgci_regression_test_nvidiagpu_cuda.yml
+++ b/.github/workflows/pkgci_regression_test_nvidiagpu_cuda.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           source ${VENV_DIR}/bin/activate
           pytest SHARK-TestSuite/iree_tests/onnx/ \
-              -n 4 -rpfE --timeout=30 --retries=2 --durations=20 \
+              -n 4 -rpfE --timeout=30 --durations=20 \
               --config-files=build_tools/pkgci/external_test_suite/onnx_gpu_cuda.json \
               --no-skip-tests-missing-files \
               --report-log=/tmp/iree_tests_onnx_gpu_cuda_logs.json

--- a/.github/workflows/pkgci_regression_test_nvidiagpu_vulkan.yml
+++ b/.github/workflows/pkgci_regression_test_nvidiagpu_vulkan.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           source ${VENV_DIR}/bin/activate
           pytest SHARK-TestSuite/iree_tests/onnx/ \
-              -n 4 -rpfE --timeout=30 --retries=2 --durations=20 \
+              -n 4 -rpfE --timeout=30 --durations=20 \
               --config-files=build_tools/pkgci/external_test_suite/onnx_gpu_vulkan.json \
               --no-skip-tests-missing-files \
               --report-log=/tmp/iree_tests_onnx_gpu_vulkan_logs.json

--- a/build_tools/pkgci/external_test_suite/onnx_cpu_llvm_sync.json
+++ b/build_tools/pkgci/external_test_suite/onnx_cpu_llvm_sync.json
@@ -6,7 +6,9 @@
   "iree_run_module_flags": [
     "--device=local-sync"
   ],
-  "skip_compile_tests": [],
+  "skip_compile_tests": [
+    "test_dequantizelinear"
+  ],
   "skip_run_tests": [],
   "expected_compile_failures": [
     "test_acosh",

--- a/build_tools/pkgci/external_test_suite/onnx_cpu_llvm_sync.json
+++ b/build_tools/pkgci/external_test_suite/onnx_cpu_llvm_sync.json
@@ -6,10 +6,7 @@
   "iree_run_module_flags": [
     "--device=local-sync"
   ],
-  "skip_compile_tests": [
-    "test_dequantizelinear",
-    "test_slice_default_axes"
-  ],
+  "skip_compile_tests": [],
   "skip_run_tests": [],
   "expected_compile_failures": [
     "test_acosh",

--- a/build_tools/pkgci/external_test_suite/onnx_gpu_cuda.json
+++ b/build_tools/pkgci/external_test_suite/onnx_gpu_cuda.json
@@ -6,7 +6,9 @@
   "iree_run_module_flags": [
     "--device=cuda"
   ],
-  "skip_compile_tests": [],
+  "skip_compile_tests": [
+    "test_dequantizelinear"
+  ],
   "skip_run_tests": [
     "test_gather_elements_negative_indices",
     "test_gridsample_zeros_padding",

--- a/build_tools/pkgci/external_test_suite/onnx_gpu_cuda.json
+++ b/build_tools/pkgci/external_test_suite/onnx_gpu_cuda.json
@@ -6,10 +6,7 @@
   "iree_run_module_flags": [
     "--device=cuda"
   ],
-  "skip_compile_tests": [
-    "test_dequantizelinear",
-    "test_slice_default_axes"
-  ],
+  "skip_compile_tests": [],
   "skip_run_tests": [
     "test_gather_elements_negative_indices",
     "test_gridsample_zeros_padding",

--- a/build_tools/pkgci/external_test_suite/onnx_gpu_rocm_rdna3.json
+++ b/build_tools/pkgci/external_test_suite/onnx_gpu_rocm_rdna3.json
@@ -7,10 +7,7 @@
   "iree_run_module_flags": [
     "--device=hip"
   ],
-  "skip_compile_tests": [
-    "test_dequantizelinear",
-    "test_slice_default_axes"
-  ],
+  "skip_compile_tests": [],
   "skip_run_tests": [],
   "expected_compile_failures": [
     "test_acosh",

--- a/build_tools/pkgci/external_test_suite/onnx_gpu_rocm_rdna3.json
+++ b/build_tools/pkgci/external_test_suite/onnx_gpu_rocm_rdna3.json
@@ -7,7 +7,9 @@
   "iree_run_module_flags": [
     "--device=hip"
   ],
-  "skip_compile_tests": [],
+  "skip_compile_tests": [
+    "test_dequantizelinear"
+  ],
   "skip_run_tests": [],
   "expected_compile_failures": [
     "test_acosh",

--- a/build_tools/pkgci/external_test_suite/onnx_gpu_vulkan.json
+++ b/build_tools/pkgci/external_test_suite/onnx_gpu_vulkan.json
@@ -6,7 +6,9 @@
   "iree_run_module_flags": [
     "--device=vulkan"
   ],
-  "skip_compile_tests": [],
+  "skip_compile_tests": [
+    "test_dequantizelinear"
+  ],
   "skip_run_tests": [],
   "expected_compile_failures": [
     "test_acosh",

--- a/build_tools/pkgci/external_test_suite/onnx_gpu_vulkan.json
+++ b/build_tools/pkgci/external_test_suite/onnx_gpu_vulkan.json
@@ -6,10 +6,7 @@
   "iree_run_module_flags": [
     "--device=vulkan"
   ],
-  "skip_compile_tests": [
-    "test_dequantizelinear",
-    "test_slice_default_axes"
-  ],
+  "skip_compile_tests": [],
   "skip_run_tests": [],
   "expected_compile_failures": [
     "test_acosh",


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree/issues/16666.

The [pytest-retry](https://pypi.org/project/pytest-retry/) and [pytest-timeout](https://pypi.org/project/pytest-timeout/) plugins initially appeared to be compatible. However, we've been observing tests hanging without ever tripping the timeout. Hangs under [pytest-xdist](https://pypi.org/project/pytest-xdist/) don't log information about individual tests until after the full suite finishes, making such failures impossible to debug directly ([sample logs](https://github.com/iree-org/iree/actions/runs/9038964717/job/24841208573#step:9:43)). Conversely, test failure flakes that would benefit from a retry show which test failed and can be attempted again from the GitHub UI.

Tests that hang still need to be added to `skip_run_tests` instead of `expected_run_failures`, since our conftest.py logic is only looking for failures in `iree-compile` or `iree-run-module`, not timeout signals from the test runner. See [these sample logs](https://github.com/iree-org/iree/actions/runs/9069578568/job/24919962287#step:16:4699) for what a timeout failure now looks like.

ci-exactly: build_packages,regression_test_amdgpu_rocm,regression_test_cpu,regression_test_nvidiagpu_cuda,regression_test_nvidiagpu_vulkan,test_tensorflow_cpu