### PR TITLE
[LLVMGPU] Add debug prints for vector distribution config

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -701,14 +701,12 @@ setVectorDistributionConfig(mlir::FunctionOpInterface entryPoint,
 
   if (auto linalgOp = dyn_cast<linalg::LinalgOp>(computeOp)) {
     if (linalg::isaContractionOpInterface(linalgOp)) {
-      LDBG(
-          "VectorDistribution: trying to find a suitable contraction config");
+      LDBG("VectorDistribution: trying to find a suitable contraction config");
       return setMatmulVectorDistributionConfig(entryPoint, linalgOp,
                                                targetInfo);
     }
     if (linalg::isaConvolutionOpInterface(linalgOp)) {
-      LDBG(
-          "VectorDistribution: trying to find a suitable convolution config");
+      LDBG("VectorDistribution: trying to find a suitable convolution config");
       return setConvolutionVectorDistributionConfig(entryPoint, linalgOp,
                                                     targetInfo);
     }


### PR DESCRIPTION
These include the deduced MMA schedule, contraction dims, and workgroup tile sizes. Example:
```
[iree-llvmgpu-kernel-config]: VectorDistribution: finding a suitable config...
[iree-llvmgpu-kernel-config]: VectorDistribution: trying to find a suitable contraction config
[iree-llvmgpu-kernel-config]: Matmul Vector Distribution Config
[iree-llvmgpu-kernel-config]: Target Subgroup size: 64
[iree-llvmgpu-kernel-config]: Schedule: sizes [16, 16, 16]
[iree-llvmgpu-kernel-config]: Schedule: tile counts [2, 2, 8]
[iree-llvmgpu-kernel-config]: Schedule: warp counts [2, 2]
[iree-llvmgpu-kernel-config]: Contraction dims: [m, n, k]
[iree-llvmgpu-kernel-config]: Workgroup tile sizes: [64, 64, 128]
```