### PR TITLE
[LinalgExt] Generalize attention tiling interface implementation

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1754,6 +1754,11 @@ static LogicalResult setRootConfig(mlir::FunctionOpInterface entryPointFn,
   DistributionHeuristicConfig config;
   SmallVector<int64_t> distTileSizes = getDefaultDistributedLevelTileSizes(
       attnOp, DistributionHeuristicConfig{});
+  // TODO (Groverkss): Due to a bug in TileAndDecomposeAttention, N dimension
+  // cannot be tiled. Remove this once fixed.
+  for (int64_t i : opInfo.getNDims()) {
+    distTileSizes[i] = 0;
+  }
   tileSizes.push_back(distTileSizes);
 
   // Batch, M and N (parallel dimensions) are distributed on workgroups.
@@ -1773,6 +1778,11 @@ static LogicalResult setRootConfig(mlir::FunctionOpInterface entryPointFn,
     // TODO: Use native tile size here once bufferization is fixed for scf.
     vecTileSizes[i] = getMaxVectorTileSize(
         /*numElem=*/tileSize, vectorSize, vectorSize);
+  }
+  // TODO (Groverkss): Due to a bug in TileAndDecomposeAttention, N dimension
+  // cannot be tiled. Remove this once fixed.
+  for (int64_t i : opInfo.getNDims()) {
+    vecTileSizes[i] = 0;
   }
   tileSizes.push_back(vecTileSizes);
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
@@ -1613,7 +1613,7 @@ module {
     return
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[20, 64], [1, 32]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[20, 64, 0, 0, 64], [20, 32, 0, 0, 32]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPULinalgExtTileAndVectorize>
 //      CHECK: func.func @attention()
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
@@ -1613,7 +1613,7 @@ module {
     return
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[20, 64, 0, 0, 64], [20, 32, 0, 0, 32]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[20, 64, 0, 0, 0], [20, 32, 0, 0, 0]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPULinalgExtTileAndVectorize>
 //      CHECK: func.func @attention()
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1235,19 +1235,6 @@ LogicalResult WinogradOutputTransformOp::reifyResultShapes(
 // AttentionOp
 //===----------------------------------------------------------------------===//
 
-/// Utility function to check whether a given ShapedType has the expected rank.
-static LogicalResult checkShapeRank(Operation *op, StringRef operandName,
-                                    ShapedType shapedType,
-                                    int64_t rankToCompareWith) {
-  int64_t opRank = shapedType.getRank();
-  if (opRank != rankToCompareWith) {
-    return op->emitOpError("expected ")
-           << operandName << " to have rank " << rankToCompareWith
-           << " but found " << opRank;
-  }
-  return success();
-}
-
 LogicalResult AttentionOp::verify() {
   Operation *op = getOperation();
 
@@ -1265,13 +1252,6 @@ LogicalResult AttentionOp::verify() {
   }
 
   bool isTiled = numOutputs == 3;
-
-  int64_t rankToCompareWith;
-  if (isTiled) {
-    rankToCompareWith = 2;
-  } else {
-    rankToCompareWith = 3;
-  }
 
   if (!llvm::all_of(llvm::drop_end(getDpsInputs()), [](Value input) {
         return isa<ShapedType>(input.getType());
@@ -1294,33 +1274,35 @@ LogicalResult AttentionOp::verify() {
     return op->emitOpError("expected scale to be of floating point type");
   }
 
-  if (failed(checkShapeRank(op, "query", queryType, rankToCompareWith))) {
+  // Check shape compatibility based on indexing maps.
+  SmallVector<int64_t> shape(getIterationDomainRank(), -1);
+  auto checkShape = [&shape, &op](StringRef operandName,
+                                  ArrayRef<int64_t> valShape,
+                                  AffineMap indexingMap) -> LogicalResult {
+    for (auto [i, dimExpr] : llvm::enumerate(indexingMap.getResults())) {
+      AffineDimExpr dim = cast<AffineDimExpr>(dimExpr);
+      int64_t pos = dim.getPosition();
+      if (valShape[i] == ShapedType::kDynamic) {
+        continue;
+      }
+      if (shape[pos] == -1) {
+        shape[pos] = valShape[i];
+      }
+      if (shape[pos] != valShape[i]) {
+        return op->emitError("Shape Mismatch for ")
+               << operandName << ". Expected: " << shape[pos]
+               << " Got: " << valShape[i];
+      }
+    }
+    return success();
+  };
+
+  if (failed(checkShape("Query", getQueryType().getShape(), getQueryMap())) ||
+      failed(checkShape("Key", getKeyType().getShape(), getKeyMap())) ||
+      failed(checkShape("Value", getValueType().getShape(), getValueMap()))) {
     return failure();
   }
-  if (failed(checkShapeRank(op, "key", keyType, rankToCompareWith))) {
-    return failure();
-  }
-  if (failed(checkShapeRank(op, "value", valueType, rankToCompareWith))) {
-    return failure();
-  }
-  if (failed(checkShapeRank(op, "output", outputType, rankToCompareWith))) {
-    return failure();
-  }
-  ArrayRef<int64_t> queryShape = queryType.getShape();
-  ArrayRef<int64_t> keyShape = keyType.getShape();
-  ArrayRef<int64_t> outputShape = outputType.getShape();
-  SmallVector<int64_t> valueShape(valueType.getShape());
-  bool transposeV = getTransposeV();
-  if (transposeV) {
-    size_t lastIdx = valueShape.size() - 1;
-    std::swap(valueShape[lastIdx - 1], valueShape[lastIdx]);
-  }
-  if (failed(verifyCompatibleShape(keyShape, valueShape))) {
-    return op->emitOpError("incompatible value shape");
-  }
-  if (failed(verifyCompatibleShape(queryShape, outputShape))) {
-    return op->emitOpError("incompatible output shape");
-  }
+
   if (queryElementType != keyElementType ||
       queryElementType != valueElementType ||
       queryElementType != scaleElementType) {
@@ -1335,34 +1317,20 @@ LogicalResult AttentionOp::verify() {
              << queryElementType << "but found " << outputElementType
              << " instead";
     }
-    if (keyShape[2] != queryShape[2]) {
-      return op->emitOpError("query and key head dimension mismatch");
-    }
   }
   if (isTiled) {
     // Tiled/Flash attention.
-    ShapedType maxType = *getMaxType();
-    ShapedType sumType = *getSumType();
-    if (failed(checkShapeRank(op, "max", maxType, 1))) {
-      return failure();
-    }
-    if (failed(checkShapeRank(op, "sum", sumType, 1))) {
-      return failure();
-    }
-    Type maxElementType = maxType.getElementType();
-    Type sumElementType = sumType.getElementType();
-    ArrayRef<int64_t> maxShape = maxType.getShape();
-    ArrayRef<int64_t> sumShape = sumType.getShape();
+    Type maxElementType = getMaxType()->getElementType();
+    Type sumElementType = getSumType()->getElementType();
     if (outputElementType != maxElementType ||
         maxElementType != sumElementType) {
       return op->emitOpError(
           "element types of tiled output, max and sum should be same");
     }
-    if (failed(verifyCompatibleShape(maxShape, sumShape))) {
-      return op->emitOpError("incompatible sum shape");
-    }
-    if (maxShape[0] != queryShape[0]) {
-      return op->emitOpError("Query and max dimension-0 mismatch");
+
+    if (failed(checkShape("Max", getMaxType()->getShape(), *getMaxMap())) ||
+        failed(checkShape("Sum", getSumType()->getShape(), *getSumMap()))) {
+      return failure();
     }
   }
 
@@ -1377,6 +1345,55 @@ LogicalResult AttentionOp::reifyResultShapes(
     OpBuilder &b, ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
   return cast<LinalgExtOp>(getOperation())
       .reifyResultShapes(b, reifiedReturnShapes);
+}
+
+SmallVector<AffineMap> AttentionOp::getIndexingMapsArray() {
+  MLIRContext *ctx = getContext();
+
+  AffineExpr batch, m, k1, k2, n;
+  bindDims(ctx, batch, m, k1, k2, n);
+
+  AffineMap qMap =
+      AffineMap::get(/*dimCount=*/5, /*symbolCount=*/0, {batch, m, k1}, ctx);
+  AffineMap kMap =
+      AffineMap::get(/*dimCount=*/5, /*symbolCount=*/0, {batch, k2, k1}, ctx);
+
+  AffineMap vMap;
+  if (getTransposeV()) {
+    vMap =
+        AffineMap::get(/*dimCount=*/5, /*symbolCount=*/0, {batch, n, k2}, ctx);
+  } else {
+    vMap =
+        AffineMap::get(/*dimCount=*/5, /*symbolCount=*/0, {batch, k2, n}, ctx);
+  }
+
+  AffineMap resMap =
+      AffineMap::get(/*dimCount=*/5, /*symbolCount=*/0, {batch, m, n}, ctx);
+
+  SmallVector<AffineMap> results = {qMap, kMap, vMap, resMap};
+
+  if (getMax()) {
+    AffineMap maxMap =
+        AffineMap::get(/*dimCount=*/5, /*symbolCount=*/0, {batch, m}, ctx);
+    results.push_back(maxMap);
+  }
+
+  if (getSum()) {
+    AffineMap sumMap =
+        AffineMap::get(/*dimCount=*/5, /*symbolCount=*/0, {batch, m}, ctx);
+    results.push_back(sumMap);
+  }
+
+  // Remove batch dim for tiled operands.
+  // TODO: This is a weird expectation from TileAndDecomposeAttention.
+  bool isTiled = getNumResults() == 3;
+  if (isTiled) {
+    for (AffineMap &map : results) {
+      map.dropResult(0);
+    }
+  }
+
+  return results;
 }
 
 #define DEFINE_OP_GET_EFFECTS(OP_NAME)                                         \

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1279,6 +1279,11 @@ LogicalResult AttentionOp::verify() {
   auto checkShape = [&shape, &op](StringRef operandName,
                                   ArrayRef<int64_t> valShape,
                                   AffineMap indexingMap) -> LogicalResult {
+    if (indexingMap.getNumResults() != valShape.size()) {
+      return op->emitError("Rank Mismatch for ")
+             << operandName << ". Expected: " << indexingMap.getNumResults()
+             << " Got: " << valShape.size();
+    }
     for (auto [i, dimExpr] : llvm::enumerate(indexingMap.getResults())) {
       AffineDimExpr dim = cast<AffineDimExpr>(dimExpr);
       int64_t pos = dim.getPosition();
@@ -1389,7 +1394,7 @@ SmallVector<AffineMap> AttentionOp::getIndexingMapsArray() {
   bool isTiled = getNumResults() == 3;
   if (isTiled) {
     for (AffineMap &map : results) {
-      map.dropResult(0);
+      map = map.dropResult(0);
     }
   }
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -589,6 +589,7 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_Op<"attention",
         return std::nullopt;
       return getDpsInitOperand(2)->get();
     }
+
     ShapedType getQueryType() {
       return cast<ShapedType>(getQuery().getType());
     }
@@ -614,6 +615,7 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_Op<"attention",
       if (!sumVal) return std::nullopt;
       return cast<ShapedType>(sumVal->getType());
     }
+
     int64_t getQueryRank() {
       return getQueryType().getRank();
     }
@@ -636,13 +638,40 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_Op<"attention",
       if (!sumType) return std::nullopt;
       return sumType->getRank();
     }
-    int64_t getIterationDomainRank() {
-      return 2;
-    };
+
     // Method to implement for specifying output range for
     // DestinationStyleOpInterface
     MutableOperandRange getDpsInitsMutable() {
       return getOutputsMutable();
+    }
+
+    SmallVector<AffineMap> getIndexingMapsArray();
+
+    AffineMap getQueryMap() {
+      return cast<AffineMap>(getIndexingMapsArray()[0]);
+    }
+    AffineMap getKeyMap() {
+      return cast<AffineMap>(getIndexingMapsArray()[1]);
+    }
+    AffineMap getValueMap() {
+      return cast<AffineMap>(getIndexingMapsArray()[2]);
+    }
+    AffineMap getOutputMap() {
+      return cast<AffineMap>(getIndexingMapsArray()[3]);
+    }
+    std::optional<AffineMap> getMaxMap() {
+      if (getNumResults() < 2)
+        return std::nullopt;
+      return cast<AffineMap>(getIndexingMapsArray()[4]);
+    }
+    std::optional<AffineMap> getSumMap() {
+      if (getNumResults() < 3)
+        return std::nullopt;
+      return cast<AffineMap>(getIndexingMapsArray()[5]);
+    }
+
+    int64_t getIterationDomainRank() {
+      return getQueryMap().getNumDims();
     }
   }];
 }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -696,7 +696,7 @@ func.func @illegal_winograd_filter_kernel_dimensions(%arg0: tensor<3x3x64x128xf3
 func.func @illegal_attention_inputs(%query: tensor<6x12x20x8xf32>, %key: tensor<6x12x20x8xf32>, %value: tensor<6x12x20x8xf32>) {
   %0 = tensor.empty() : tensor<6x12x20x8xf32>
   %scale = arith.constant 1.0 : f32
-  // expected-error @+1 {{'iree_linalg_ext.attention' op expected query to have rank 3 but found 4}}
+  // expected-error @+1 {{Rank Mismatch for Query. Expected: 3 Got: 4}}
   %1 = iree_linalg_ext.attention ins(%query, %key, %value, %scale : tensor<6x12x20x8xf32>, tensor<6x12x20x8xf32>, tensor<6x12x20x8xf32>, f32) outs(%0 : tensor<6x12x20x8xf32>) -> tensor<6x12x20x8xf32>
   return %1 : tensor<6x12x20x8xf32>
 }
@@ -708,7 +708,7 @@ func.func @illegal_flash_attention_inputs(%query: tensor<20xf32>, %key: tensor<2
   %max = tensor.empty() : tensor<8xf32>
   %sum = tensor.empty() : tensor<8xf32>
   %scale = arith.constant 1.0 : f32
-  // expected-error @+1 {{'iree_linalg_ext.attention' op expected query to have rank 2 but found 1}}
+  // expected-error @+1 {{Rank Mismatch for Query. Expected: 2 Got: 1}}
   %1:3 = iree_linalg_ext.attention ins(%query, %key, %value, %scale : tensor<20xf32>, tensor<20x8xf32>, tensor<20x8xf32>, f32) outs(%result, %max, %sum : tensor<20x8xf32>, tensor<8xf32>, tensor<8xf32>) -> tensor<20x8xf32>, tensor<8xf32>, tensor<8xf32>
   return %1#0, %1#1, %1#2 : tensor<20x8xf32>, tensor<8xf32>, tensor<8xf32>
 }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TilingInterfaceImpl.cpp
@@ -1653,7 +1653,7 @@ SmallVector<utils::IteratorType> AttentionOp::getLoopIteratorTypes() {
   SmallVector<utils::IteratorType> iteratorTypes(getIterationDomainRank(),
                                                  utils::IteratorType::parallel);
 
-  for (int dim :
+  for (auto dim :
        llvm::concat<const int64_t>(opInfo.getK1Dims(), opInfo.getK2Dims())) {
     iteratorTypes[dim] = utils::IteratorType::reduction;
   }
@@ -1680,9 +1680,9 @@ AttentionOp::getTiledImplementation(OpBuilder &builder,
     SmallVector<OpFoldResult> outputSizes;
     SmallVector<OpFoldResult> outputStrides(indexingMap.getNumResults(), one);
     for (AffineExpr dimExpr : indexingMap.getResults()) {
-      auto dim = cast<AffineDimExpr>(dimExpr);
-      outputOffsets.push_back(offsets[dim.getPosition()]);
-      outputSizes.push_back(sizes[dim.getPosition()]);
+      int dim = cast<AffineDimExpr>(dimExpr).getPosition();
+      outputOffsets.push_back(offsets[dim]);
+      outputSizes.push_back(sizes[dim]);
     }
     return {outputOffsets, outputSizes, outputStrides};
   };
@@ -1764,10 +1764,9 @@ LogicalResult AttentionOp::getResultTilePosition(
   }
 
   for (AffineExpr dimExpr : resultIndexingMap.getResults()) {
-    AffineDimExpr dim = cast<AffineDimExpr>(dimExpr);
-    int64_t pos = dim.getPosition();
-    resultOffsets.push_back(offsets[pos]);
-    resultSizes.push_back(sizes[pos]);
+    int dim = cast<AffineDimExpr>(dimExpr).getPosition();
+    resultOffsets.push_back(offsets[dim]);
+    resultSizes.push_back(sizes[dim]);
   }
   return success();
 }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TilingInterfaceImpl.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "iree/compiler/Dialect/LinalgExt/Utils/IndexingUtils.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -1608,23 +1609,55 @@ LogicalResult WinogradOutputTransformOp::getResultTilePosition(
 //===----------------------------------------------------------------------===//
 
 SmallVector<Range> AttentionOp::getIterationDomain(OpBuilder &builder) {
-  int64_t iterationDomainRank = getIterationDomainRank();
-  SmallVector<Range> loopBounds(iterationDomainRank);
+  int64_t domainRank = getIterationDomainRank();
+
+  SmallVector<Range> loopBounds(domainRank);
   Location loc = getLoc();
   Value zero = builder.create<arith::ConstantIndexOp>(loc, 0);
   Value one = builder.create<arith::ConstantIndexOp>(loc, 1);
-  Value source = getQuery();
-  for (auto dim : llvm::seq<int64_t>(0, iterationDomainRank)) {
+
+  for (auto dim : llvm::seq<int64_t>(0, domainRank)) {
     loopBounds[dim].offset = zero;
-    loopBounds[dim].size = getDimValue(builder, loc, source, dim);
     loopBounds[dim].stride = one;
   }
+
+  SmallVector<bool> dimsFound(domainRank, false);
+  auto fillSizes = [&](Value val, AffineMap indexingMap) {
+    for (auto [idx, dimExpr] : llvm::enumerate(indexingMap.getResults())) {
+      assert(isa<AffineDimExpr>(dimExpr));
+      AffineDimExpr dim = cast<AffineDimExpr>(dimExpr);
+      int64_t pos = dim.getPosition();
+      if (dimsFound[pos]) {
+        continue;
+      }
+      dimsFound[pos] = true;
+      loopBounds[pos].size = getDimValue(builder, loc, val, idx);
+    }
+  };
+
+  // Sizes can be found from Q, K, V alone.
+  fillSizes(getQuery(), getQueryMap());
+  fillSizes(getKey(), getKeyMap());
+  fillSizes(getValue(), getValueMap());
+
   return loopBounds;
 }
 
 SmallVector<utils::IteratorType> AttentionOp::getLoopIteratorTypes() {
+  FailureOr<AttentionOpDetail> maybeOpInfo =
+      AttentionOpDetail::get(getIndexingMapsArray());
+  assert(succeeded(maybeOpInfo) && "Failed to infer attention op details");
+  AttentionOpDetail opInfo = maybeOpInfo.value();
+
+  // All dimensions other than k1 and k2 are parallel.
   SmallVector<utils::IteratorType> iteratorTypes(getIterationDomainRank(),
                                                  utils::IteratorType::parallel);
+
+  for (int dim :
+       llvm::concat<const int64_t>(opInfo.getK1Dims(), opInfo.getK2Dims())) {
+    iteratorTypes[dim] = utils::IteratorType::reduction;
+  }
+
   return iteratorTypes;
 }
 
@@ -1632,49 +1665,76 @@ FailureOr<TilingResult>
 AttentionOp::getTiledImplementation(OpBuilder &builder,
                                     ArrayRef<OpFoldResult> offsets,
                                     ArrayRef<OpFoldResult> sizes) {
-  assert(offsets.size() == getIterationDomainRank());
-  assert(sizes.size() == getIterationDomainRank());
+  int64_t domainRank = getIterationDomainRank();
+  assert(offsets.size() == domainRank);
+  assert(sizes.size() == domainRank);
 
   Location loc = getLoc();
   auto one = builder.getIndexAttr(1);
-  auto zero = builder.getIndexAttr(0);
 
-  SmallVector<OpFoldResult> queryOutputOffsets(getQueryRank(), zero);
-  SmallVector<OpFoldResult> queryOutputStrides(getQueryRank(), one);
-  ArrayRef<int64_t> queryShape = getQueryType().getShape();
-  SmallVector<OpFoldResult> queryOutputSizes =
-      getAsOpFoldResult(builder.getIndexArrayAttr(queryShape));
-  for (auto [idx, info] : llvm::enumerate(llvm::zip_equal(offsets, sizes))) {
-    queryOutputOffsets[idx] = std::get<0>(info);
-    queryOutputSizes[idx] = std::get<1>(info);
-  }
+  auto tileValue = [&](Value val, AffineMap indexingMap)
+      -> std::tuple<SmallVector<OpFoldResult>, SmallVector<OpFoldResult>,
+                    SmallVector<OpFoldResult>> {
+    assert(indexingMap.isProjectedPermutation() &&
+           "Indexing map should be a projected permutation");
+    SmallVector<OpFoldResult> outputOffsets;
+    SmallVector<OpFoldResult> outputSizes;
+    SmallVector<OpFoldResult> outputStrides(indexingMap.getNumResults(), one);
+    for (AffineExpr dimExpr : indexingMap.getResults()) {
+      auto dim = cast<AffineDimExpr>(dimExpr);
+      outputOffsets.push_back(offsets[dim.getPosition()]);
+      outputSizes.push_back(sizes[dim.getPosition()]);
+    }
+    return {outputOffsets, outputSizes, outputStrides};
+  };
 
-  SmallVector<OpFoldResult> keyValueOffsets(getKeyRank(), zero);
-  SmallVector<OpFoldResult> keyValueStrides(getKeyRank(), one);
-  ArrayRef<int64_t> keyShape = getKeyType().getShape();
-  SmallVector<OpFoldResult> keyValueSizes =
-      getAsOpFoldResult(builder.getIndexArrayAttr(keyShape));
-  keyValueSizes[0] = sizes[0];
-  keyValueOffsets[0] = offsets[0];
+  auto [queryOffsets, querySizes, queryStrides] =
+      tileValue(getQuery(), getQueryMap());
+  auto [keyOffsets, keySizes, keyStrides] = tileValue(getKey(), getKeyMap());
+  auto [valueOffsets, valueSizes, valueStrides] =
+      tileValue(getValue(), getValueMap());
+  auto [outputOffsets, outputSizes, outputStrides] =
+      tileValue(getOutput(), getOutputMap());
 
   Value scale = getScale();
 
   SmallVector<Value> tiledOperands;
-  tiledOperands.emplace_back(getSlice(builder, loc, getQuery(),
-                                      queryOutputOffsets, queryOutputSizes,
-                                      queryOutputStrides));
-  tiledOperands.emplace_back(getSlice(builder, loc, getKey(), keyValueOffsets,
-                                      keyValueSizes, keyValueStrides));
-  tiledOperands.emplace_back(getSlice(builder, loc, getValue(), keyValueOffsets,
-                                      keyValueSizes, keyValueStrides));
+  tiledOperands.emplace_back(getSlice(builder, loc, getQuery(), queryOffsets,
+                                      querySizes, queryStrides));
+  tiledOperands.emplace_back(
+      getSlice(builder, loc, getKey(), keyOffsets, keySizes, keyStrides));
+  tiledOperands.emplace_back(getSlice(builder, loc, getValue(), valueOffsets,
+                                      valueSizes, valueStrides));
   tiledOperands.emplace_back(scale);
-  tiledOperands.emplace_back(getSlice(builder, loc, getOutput(),
-                                      queryOutputOffsets, queryOutputSizes,
-                                      queryOutputStrides));
+  tiledOperands.emplace_back(getSlice(builder, loc, getOutput(), outputOffsets,
+                                      outputSizes, outputStrides));
+
+  std::optional<Value> max = getMax();
+  if (max) {
+    auto [maxOffsets, maxSizes, maxStrides] =
+        tileValue(max.value(), *getMaxMap());
+    tiledOperands.emplace_back(
+        getSlice(builder, loc, max.value(), maxOffsets, maxSizes, maxStrides));
+  }
+
+  std::optional<Value> sum = getMax();
+  if (sum) {
+    auto [sumOffsets, sumSizes, sumStrides] =
+        tileValue(sum.value(), *getSumMap());
+    tiledOperands.emplace_back(
+        getSlice(builder, loc, sum.value(), sumOffsets, sumSizes, sumStrides));
+  }
 
   SmallVector<Type> resultTypes;
-  if (hasPureTensorSemantics())
+  if (hasPureTensorSemantics()) {
     resultTypes.push_back(tiledOperands[4].getType());
+    if (max) {
+      resultTypes.push_back(tiledOperands[5].getType());
+    }
+    if (sum) {
+      resultTypes.push_back(tiledOperands[6].getType());
+    }
+  }
 
   Operation *tiledOp =
       mlir::clone(builder, getOperation(), resultTypes, tiledOperands);
@@ -1686,18 +1746,31 @@ LogicalResult AttentionOp::getResultTilePosition(
     OpBuilder &builder, unsigned resultNumber, ArrayRef<OpFoldResult> offsets,
     ArrayRef<OpFoldResult> sizes, SmallVector<OpFoldResult> &resultOffsets,
     SmallVector<OpFoldResult> &resultSizes) {
-  if (resultNumber == 0) {
-    ArrayRef<int64_t> resultShape = getOutputType().getShape();
-    resultSizes = getAsOpFoldResult(builder.getIndexArrayAttr(resultShape));
-    resultOffsets =
-        SmallVector<OpFoldResult>(getOutputRank(), builder.getIndexAttr(0));
-    for (auto [idx, info] : llvm::enumerate(llvm::zip_equal(offsets, sizes))) {
-      resultOffsets[idx] = std::get<0>(info);
-      resultSizes[idx] = std::get<1>(info);
-    }
-    return success();
+  resultOffsets.clear();
+  resultSizes.clear();
+
+  AffineMap resultIndexingMap;
+  switch (resultNumber) {
+  case 0:
+    resultIndexingMap = getOutputMap();
+    break;
+  case 1:
+    resultIndexingMap = *getMaxMap();
+    break;
+  case 2:
+    resultIndexingMap = *getSumMap();
+    break;
+  default:
+    return failure();
   }
-  return failure();
+
+  for (AffineExpr dimExpr : resultIndexingMap.getResults()) {
+    AffineDimExpr dim = cast<AffineDimExpr>(dimExpr);
+    int64_t pos = dim.getPosition();
+    resultOffsets.push_back(offsets[pos]);
+    resultSizes.push_back(sizes[pos]);
+  }
+  return success();
 }
 
 } // namespace mlir::iree_compiler::IREE::LinalgExt

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TilingInterfaceImpl.cpp
@@ -1665,9 +1665,8 @@ FailureOr<TilingResult>
 AttentionOp::getTiledImplementation(OpBuilder &builder,
                                     ArrayRef<OpFoldResult> offsets,
                                     ArrayRef<OpFoldResult> sizes) {
-  int64_t domainRank = getIterationDomainRank();
-  assert(offsets.size() == domainRank);
-  assert(sizes.size() == domainRank);
+  assert(offsets.size() == getIterationDomainRank());
+  assert(sizes.size() == getIterationDomainRank());
 
   Location loc = getLoc();
   auto one = builder.getIndexAttr(1);

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/BUILD.bazel
@@ -15,9 +15,11 @@ package(
 iree_compiler_cc_library(
     name = "Utils",
     srcs = [
+        "IndexingUtils.cpp",
         "Utils.cpp",
     ],
     hdrs = [
+        "IndexingUtils.h",
         "Utils.h",
         "WinogradConstants.h",
     ],

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/CMakeLists.txt
@@ -14,9 +14,11 @@ iree_cc_library(
   NAME
     Utils
   HDRS
+    "IndexingUtils.h"
     "Utils.h"
     "WinogradConstants.h"
   SRCS
+    "IndexingUtils.cpp"
     "Utils.cpp"
   DEPS
     LLVMSupport

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/IndexingUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/IndexingUtils.cpp
@@ -1,0 +1,88 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/LinalgExt/Utils/IndexingUtils.h"
+#include "llvm/ADT/SetOperations.h"
+
+namespace mlir::iree_compiler::IREE::LinalgExt {
+
+namespace {
+
+static llvm::SmallDenseSet<int64_t>
+findPermutationsIndexingOperand(AffineMap indexingMap) {
+  assert(indexingMap.isProjectedPermutation() &&
+         "indexing maps for attention must be permutations.");
+  llvm::SmallDenseSet<int64_t> res;
+  for (AffineExpr e : indexingMap.getResults()) {
+    auto d = cast<AffineDimExpr>(e);
+    res.insert(d.getPosition());
+  }
+  return res;
+}
+
+}; // namespace
+
+void AttentionOpDetail::inferFromIndexingMaps(
+    ArrayRef<AffineMap> indexingMaps) {
+  assert(indexingMaps.size() == 4);
+  AffineMap qMap = indexingMaps[0];
+  AffineMap kMap = indexingMaps[1];
+  AffineMap vMap = indexingMaps[2];
+  AffineMap resMap = indexingMaps[3];
+
+  // Q   = B x M x K1
+  // K   = B x K2 x K1
+  // V   = B x K2 x N
+  // res = B x M x N
+  llvm::SmallDenseSet<int64_t> qSet = findPermutationsIndexingOperand(qMap);
+  llvm::SmallDenseSet<int64_t> vSet = findPermutationsIndexingOperand(vMap);
+  llvm::SmallDenseSet<int64_t> kSet = findPermutationsIndexingOperand(kMap);
+  llvm::SmallDenseSet<int64_t> resSet = findPermutationsIndexingOperand(resMap);
+
+  // B = Q & K & V
+  llvm::SmallDenseSet<int64_t> bSet = qSet;
+  llvm::set_intersect(bSet, vSet);
+  llvm::set_intersect(bSet, kSet);
+
+  // K1 = Q & K - B
+  llvm::SmallDenseSet<int64_t> k1Set = qSet;
+  llvm::set_intersect(k1Set, kSet);
+  llvm::set_subtract(k1Set, bSet);
+
+  // K2 = K - B - K1
+  llvm::SmallDenseSet<int64_t> k2Set = kSet;
+  llvm::set_subtract(k2Set, bSet);
+  llvm::set_subtract(k2Set, k1Set);
+
+  // M = Q - B - K1
+  llvm::SmallDenseSet<int64_t> mSet = qSet;
+  llvm::set_subtract(mSet, bSet);
+  llvm::set_subtract(mSet, k1Set);
+
+  // N = V - B - K2
+  llvm::SmallDenseSet<int64_t> nSet = vSet;
+  llvm::set_subtract(nSet, bSet);
+  llvm::set_subtract(nSet, k2Set);
+
+  batch = SmallVector<int64_t>(bSet.begin(), bSet.end());
+  m = SmallVector<int64_t>(mSet.begin(), mSet.end());
+  k1 = SmallVector<int64_t>(k1Set.begin(), k1Set.end());
+  k2 = SmallVector<int64_t>(k2Set.begin(), k2Set.end());
+  n = SmallVector<int64_t>(nSet.begin(), nSet.end());
+}
+
+FailureOr<AttentionOpDetail>
+AttentionOpDetail::get(ArrayRef<AffineMap> indexingMaps) {
+  if (indexingMaps.size() != 4 && indexingMaps.size() != 6) {
+    return failure();
+  }
+
+  AttentionOpDetail opInfo;
+  opInfo.inferFromIndexingMaps(indexingMaps);
+  return opInfo;
+}
+
+}; // namespace mlir::iree_compiler::IREE::LinalgExt

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/IndexingUtils.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/IndexingUtils.h
@@ -7,7 +7,7 @@
 #ifndef IREE_COMPILER_DIALECT_LINALGEXT_UTILS_INDEXINGUTILS_H_
 #define IREE_COMPILER_DIALECT_LINALGEXT_UTILS_INDEXINGUTILS_H_
 
-#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "mlir/IR/AffineMap.h"
 
 namespace mlir::iree_compiler::IREE::LinalgExt {
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/IndexingUtils.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/IndexingUtils.h
@@ -1,0 +1,63 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_DIALECT_LINALGEXT_UTILS_INDEXINGUTILS_H_
+#define IREE_COMPILER_DIALECT_LINALGEXT_UTILS_INDEXINGUTILS_H_
+
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
+
+namespace mlir::iree_compiler::IREE::LinalgExt {
+
+/// Attention has the following shaped inputs:
+///
+/// Q  : B x M x K1
+/// K  : B x K2 x K1
+/// V  : B x K2 x N
+/// res: B x M x N
+///
+/// For the purposes of Tiling, Attention can be thought of:
+///
+/// QKT = Q @ K.T
+/// S = reduce QKT dim=2 keep_dims=True
+/// att = S @ V
+///
+/// By this defination, K1 and K2 can be seen as reduction dimensions and
+/// B, M, N can be seen as parallel dimensions.
+///
+/// Generally, K1 and N are really small (64/128), K2 and M are really large
+/// (16k, 64k, 128k), and B is batch size and depends on input batch size.
+///
+/// Tiling on parallel dimensions is trivial.
+///
+/// Tiling on reduction dimensions on the other hand is much harder.
+/// TileAndDecomposeAttention has an implementation to tile on K2 dimension
+/// based on an online softmax technique proposed by Flash Attention V2
+/// (https://arxiv.org/abs/2307.08691).
+///
+/// Tiling on K1 is generally not done because it's so small and is non-trivial.
+class AttentionOpDetail {
+public:
+  static FailureOr<AttentionOpDetail> get(ArrayRef<AffineMap> indexingMaps);
+
+  ArrayRef<int64_t> getBatchDims() const { return batch; }
+  ArrayRef<int64_t> getMDims() const { return m; }
+  ArrayRef<int64_t> getK1Dims() const { return k1; }
+  ArrayRef<int64_t> getK2Dims() const { return k2; }
+  ArrayRef<int64_t> getNDims() const { return n; }
+
+private:
+  void inferFromIndexingMaps(ArrayRef<AffineMap> indexingMaps);
+
+  SmallVector<int64_t> batch;
+  SmallVector<int64_t> m;
+  SmallVector<int64_t> k1;
+  SmallVector<int64_t> k2;
+  SmallVector<int64_t> n;
+};
+
+}; // namespace mlir::iree_compiler::IREE::LinalgExt
+
+#endif // IREE_COMPILER_DIALECT_LINALGEXT_UTILS_INDEXINGUTILS_H_


### PR DESCRIPTION
This patch generalizes tiling implementation for AttentionOp. Before, only the batch and M dimension of attention could be tiled. This patch instead, allows tiling of N dimension as well as allows transposition based on indexing maps (hardcoded for now).

Tiling on dimension N is disabled in CPU backend for now, because TileAndDecomposeAttention pass is hardecoded with dimensions. This will be fixed once we implement reduction tiling interface for it (after https://github.com/llvm/llvm-project/pull/92624)