### PR TITLE
Implementing the f64 VM extension and flipping the flag by default.

### DIFF
--- a/compiler/plugins/target/VMVX/VMVXTarget.cpp
+++ b/compiler/plugins/target/VMVX/VMVXTarget.cpp
@@ -87,6 +87,7 @@ public:
     // TODO(benvanik): derive these from a vm target triple.
     auto vmOptions = IREE::VM::TargetOptions::FromFlags::get();
     vmOptions.f32Extension = true;
+    vmOptions.f64Extension = true;
     vmOptions.optimizeForStackSize = false;
     return vmOptions;
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/TargetOptions.h
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/TargetOptions.h
@@ -20,7 +20,7 @@ struct TargetOptions {
   // Whether the f32 extension is enabled in the target VM.
   bool f32Extension = true;
   // Whether the f64 extension is enabled in the target VM.
-  bool f64Extension = false;
+  bool f64Extension = true;
 
   // Whether to truncate f64 types to f32 when the f64 extension is not
   // enabled.

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOpcodesF64.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOpcodesF64.td
@@ -41,11 +41,11 @@ def VM_OPC_CeilF64               : VM_OPC<0x12, "CeilF64">;
 def VM_OPC_FloorF64              : VM_OPC<0x13, "FloorF64">;
 def VM_OPC_RoundF64              : VM_OPC<0x3C, "RoundF64">;
 def VM_OPC_RoundF64Even          : VM_OPC<0x3F, "RoundF64Even">;
-def VM_OPC_TruncF64F32           : VM_OPC<0x14, "TruncF64F32">;
-def VM_OPC_ExtF32F64             : VM_OPC<0x15, "ExtF32F64">;
 def VM_OPC_MinF64                : VM_OPC<0x3D, "MinF64">;
 def VM_OPC_MaxF64                : VM_OPC<0x3E, "MaxF64">;
 
+def VM_OPC_TruncF64F32           : VM_OPC<0x14, "TruncF64F32">;
+def VM_OPC_ExtF32F64             : VM_OPC<0x15, "ExtF32F64">;
 def VM_OPC_CastSI32F64           : VM_OPC<0x16, "CastSI32F64">;
 def VM_OPC_CastUI32F64           : VM_OPC<0x17, "CastUI32F64">;
 def VM_OPC_CastF64SI32           : VM_OPC<0x18, "CastF64SI32">;
@@ -84,7 +84,6 @@ def VM_OPC_CmpLTEF64O            : VM_OPC<0x36, "CmpLTEF64O">;
 def VM_OPC_CmpLTEF64U            : VM_OPC<0x37, "CmpLTEF64U">;
 def VM_OPC_CmpNaNF64             : VM_OPC<0x38, "CmpNaNF64">;
 
-// Buffer load/store:
 def VM_OPC_BufferLoadF64         : VM_OPC<0x39, "BufferLoadF64">;
 def VM_OPC_BufferStoreF64        : VM_OPC<0x3A, "BufferStoreF64">;
 def VM_OPC_BufferFillF64         : VM_OPC<0x3B, "BufferFillF64">;
@@ -121,6 +120,7 @@ def VM_ExtF64OpcodeAttr :
     VM_OPC_CeilF64,
     VM_OPC_FloorF64,
     VM_OPC_RoundF64,
+    VM_OPC_RoundF64Even,
     VM_OPC_MinF64,
     VM_OPC_MaxF64,
 

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -2659,7 +2659,7 @@ def VM_MaxF32Op :
 
 def VM_MaxF64Op :
     VM_TotalBinaryArithmeticOp<F64, "max.f64", VM_OPC_MaxF64,
-                               [VM_ExtF32, Commutative]> {
+                               [VM_ExtF64, Commutative]> {
   let summary = [{floating point maximum operation}];
   let hasFolder = 1;
 }
@@ -3161,6 +3161,20 @@ def VM_CastUI32F32Op :
   let hasFolder = 1;
 }
 
+def VM_CastSI64F64Op :
+    VM_ConversionOp<I64, F64, "cast.si64.f64", VM_OPC_CastSI64F64,
+                    [VM_ExtF64]> {
+  let summary = [{cast from a signed integer to a float-point value}];
+  let hasFolder = 1;
+}
+
+def VM_CastUI64F64Op :
+    VM_ConversionOp<I64, F64, "cast.ui64.f64", VM_OPC_CastUI64F64,
+                    [VM_ExtF64]> {
+  let summary = [{cast from an unsigned integer to a float-point value}];
+  let hasFolder = 1;
+}
+
 def VM_CastF32SI32Op :
     VM_ConversionOp<F32, I32, "cast.f32.si32", VM_OPC_CastF32SI32,
                     [VM_ExtF32]> {
@@ -3171,6 +3185,20 @@ def VM_CastF32SI32Op :
 def VM_CastF32UI32Op :
     VM_ConversionOp<F32, I32, "cast.f32.ui32", VM_OPC_CastF32UI32,
                     [VM_ExtF32]> {
+  let summary = [{cast from an float-point value to an unsigned integer}];
+  let hasFolder = 1;
+}
+
+def VM_CastF64SI64Op :
+    VM_ConversionOp<F64, I64, "cast.f64.si64", VM_OPC_CastF64SI64,
+                    [VM_ExtF64]> {
+  let summary = [{cast from a float-point value to a signed integer}];
+  let hasFolder = 1;
+}
+
+def VM_CastF64UI64Op :
+    VM_ConversionOp<F64, I64, "cast.f64.ui64", VM_OPC_CastF64UI64,
+                    [VM_ExtF64]> {
   let summary = [{cast from an float-point value to an unsigned integer}];
   let hasFolder = 1;
 }

--- a/runtime/src/iree/base/config.h
+++ b/runtime/src/iree/base/config.h
@@ -304,7 +304,7 @@ typedef IREE_DEVICE_SIZE_T iree_device_size_t;
 #if !defined(IREE_VM_EXT_F64_ENABLE)
 // Enables the 64-bit floating-point instruction extension.
 // Targeted from the compiler with `-iree-vm-target-extension-f64`.
-#define IREE_VM_EXT_F64_ENABLE 0
+#define IREE_VM_EXT_F64_ENABLE 1
 #endif  // !IREE_VM_EXT_F64_ENABLE
 
 #if !defined(IREE_VM_UBSAN_CHECKABLE_ENABLE)

--- a/runtime/src/iree/vm/bytecode/disassembler.c
+++ b/runtime/src/iree/vm/bytecode/disassembler.c
@@ -54,10 +54,10 @@
   iree_vm_map_type(module, OP_I32(0)); \
   pc += 4;
 #define VM_ParseTypeOf(name) VM_ParseType(name)
-#define VM_ParseIntAttr32(name) VM_ParseConstI32(name)
-#define VM_ParseIntAttr64(name) VM_ParseConstI64(name)
-#define VM_ParseFloatAttr32(name) VM_ParseConstF32(name)
-#define VM_ParseFloatAttr64(name) VM_ParseConstF64(name)
+#define VM_ParseAttrI32(name) VM_ParseConstI32(name)
+#define VM_ParseAttrI64(name) VM_ParseConstI64(name)
+#define VM_ParseAttrF32(name) VM_ParseConstF32(name)
+#define VM_ParseAttrF64(name) VM_ParseConstF64(name)
 #define VM_ParseStrAttr(name, out_str)                   \
   (out_str)->size = (iree_host_size_t)OP_I16(0);         \
   (out_str)->data = (const char*)&bytecode_data[pc + 2]; \
@@ -115,6 +115,7 @@
       b, "%%i%u:%u", ((reg) & IREE_I32_REGISTER_MASK),    \
       ((reg) & IREE_I32_REGISTER_MASK) + 1));
 #define EMIT_F32_REG_NAME(reg) EMIT_I32_REG_NAME(reg)
+#define EMIT_F64_REG_NAME(reg) EMIT_I64_REG_NAME(reg)
 #define EMIT_REF_REG_NAME(reg)                            \
   IREE_RETURN_IF_ERROR(iree_string_builder_append_format( \
       b, "%%r%u", ((reg) & IREE_REF_REGISTER_MASK)));
@@ -409,6 +410,54 @@ static iree_status_t iree_vm_bytecode_disassembler_emit_remap_list(
     break;                                                             \
   }
 
+#define DISASM_OP_EXT_F64_UNARY_F64(op_name, op_mnemonic)             \
+  DISASM_OP(EXT_F64, op_name) {                                       \
+    uint16_t operand_reg = VM_ParseOperandRegF64("operand");          \
+    uint16_t result_reg = VM_ParseResultRegF64("result");             \
+    EMIT_F64_REG_NAME(result_reg);                                    \
+    IREE_RETURN_IF_ERROR(                                             \
+        iree_string_builder_append_format(b, " = %s ", op_mnemonic)); \
+    EMIT_F64_REG_NAME(operand_reg);                                   \
+    EMIT_OPTIONAL_VALUE_F64(regs->i32[operand_reg]);                  \
+    break;                                                            \
+  }
+
+#define DISASM_OP_EXT_F64_BINARY_F64(op_name, op_mnemonic)             \
+  DISASM_OP(EXT_F64, op_name) {                                        \
+    uint16_t lhs_reg = VM_ParseOperandRegF64("lhs");                   \
+    uint16_t rhs_reg = VM_ParseOperandRegF64("rhs");                   \
+    uint16_t result_reg = VM_ParseResultRegF64("result");              \
+    EMIT_F64_REG_NAME(result_reg);                                     \
+    IREE_RETURN_IF_ERROR(                                              \
+        iree_string_builder_append_format(b, " = %s ", op_mnemonic));  \
+    EMIT_F64_REG_NAME(lhs_reg);                                        \
+    EMIT_OPTIONAL_VALUE_F64(regs->i32[lhs_reg]);                       \
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", ")); \
+    EMIT_F64_REG_NAME(rhs_reg);                                        \
+    EMIT_OPTIONAL_VALUE_F64(regs->i32[rhs_reg]);                       \
+    break;                                                             \
+  }
+
+#define DISASM_OP_EXT_F64_TERNARY_F64(op_name, op_mnemonic)            \
+  DISASM_OP(EXT_F64, op_name) {                                        \
+    uint16_t a_reg = VM_ParseOperandRegF64("a");                       \
+    uint16_t b_reg = VM_ParseOperandRegF64("b");                       \
+    uint16_t c_reg = VM_ParseOperandRegF64("c");                       \
+    uint16_t result_reg = VM_ParseResultRegF64("result");              \
+    EMIT_F64_REG_NAME(result_reg);                                     \
+    IREE_RETURN_IF_ERROR(                                              \
+        iree_string_builder_append_format(b, " = %s ", op_mnemonic));  \
+    EMIT_F64_REG_NAME(a_reg);                                          \
+    EMIT_OPTIONAL_VALUE_F64(regs->i32[a_reg]);                         \
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", ")); \
+    EMIT_F64_REG_NAME(b_reg);                                          \
+    EMIT_OPTIONAL_VALUE_F64(regs->i32[b_reg]);                         \
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", ")); \
+    EMIT_F64_REG_NAME(c_reg);                                          \
+    EMIT_OPTIONAL_VALUE_F64(regs->i32[c_reg]);                         \
+    break;                                                             \
+  }
+
 iree_status_t iree_vm_bytecode_disassemble_op(
     iree_vm_bytecode_module_t* module,
     iree_vm_bytecode_module_state_t* module_state, uint16_t function_ordinal,
@@ -593,7 +642,7 @@ iree_status_t iree_vm_bytecode_disassemble_op(
     //===------------------------------------------------------------------===//
 
     DISASM_OP(CORE, ConstI32) {
-      int32_t value = VM_ParseIntAttr32("value");
+      int32_t value = VM_ParseAttrI32("value");
       uint16_t result_reg = VM_ParseResultRegI32("result");
       EMIT_I32_REG_NAME(result_reg);
       IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
@@ -610,7 +659,7 @@ iree_status_t iree_vm_bytecode_disassemble_op(
     }
 
     DISASM_OP(CORE, ConstI64) {
-      int64_t value = VM_ParseIntAttr64("value");
+      int64_t value = VM_ParseAttrI64("value");
       uint16_t result_reg = VM_ParseResultRegI64("result");
       EMIT_I64_REG_NAME(result_reg);
       IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
@@ -1912,7 +1961,7 @@ iree_status_t iree_vm_bytecode_disassemble_op(
     //===----------------------------------------------------------------===//
 
     DISASM_OP(EXT_F32, ConstF32) {
-      float value = VM_ParseFloatAttr32("value");
+      float value = VM_ParseAttrF32("value");
       uint16_t result_reg = VM_ParseResultRegF32("result");
       EMIT_F32_REG_NAME(result_reg);
       IREE_RETURN_IF_ERROR(
@@ -2214,7 +2263,431 @@ iree_status_t iree_vm_bytecode_disassemble_op(
 #else
     UNHANDLED_DISASM_PREFIX(PrefixExtF32, EXT_F32)
 #endif  // IREE_VM_EXT_F32_ENABLE
+
+#if IREE_VM_EXT_F64_ENABLE
+    BEGIN_DISASM_PREFIX(PrefixExtF64, EXT_F64)
+
+    //===----------------------------------------------------------------===//
+    // ExtF64: Globals
+    //===----------------------------------------------------------------===//
+
+    DISASM_OP(EXT_F64, GlobalLoadF64) {
+      uint32_t byte_offset = VM_ParseGlobalAttr("global");
+      uint16_t value_reg = VM_ParseResultRegF64("value");
+      EMIT_F64_REG_NAME(value_reg);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+          b, " = vm.global.load.f64 .rwdata[%u]", byte_offset));
+      EMIT_OPTIONAL_VALUE_F64(module_state->rwdata_storage.data[byte_offset]);
+      break;
+    }
+
+    DISASM_OP(EXT_F64, GlobalStoreF64) {
+      uint32_t byte_offset = VM_ParseGlobalAttr("global");
+      uint16_t value_reg = VM_ParseOperandRegF64("value");
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_format(b, "vm.global.store.f64 "));
+      EMIT_F64_REG_NAME(value_reg);
+      EMIT_OPTIONAL_VALUE_F64(regs->i32[value_reg]);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_format(b, ", .rwdata[%u]", byte_offset));
+      break;
+    }
+
+    DISASM_OP(EXT_F64, GlobalLoadIndirectF64) {
+      uint16_t byte_offset_reg = VM_ParseOperandRegI32("global");
+      uint16_t value_reg = VM_ParseResultRegI32("value");
+      EMIT_F64_REG_NAME(value_reg);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(
+          b, " = vm.global.load.indirect.f64 .rwdata["));
+      EMIT_I32_REG_NAME(byte_offset_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[byte_offset_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, "]"));
+      EMIT_OPTIONAL_VALUE_F64(
+          module_state->rwdata_storage.data[regs->i32[byte_offset_reg]]);
+      break;
+    }
+
+    DISASM_OP(EXT_F64, GlobalStoreIndirectF64) {
+      uint16_t byte_offset_reg = VM_ParseOperandRegI32("global");
+      uint16_t value_reg = VM_ParseOperandRegF64("value");
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(
+          b, "vm.global.store.indirect.f64 "));
+      EMIT_F64_REG_NAME(value_reg);
+      EMIT_OPTIONAL_VALUE_F64(regs->i32[value_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", .rwdata["));
+      EMIT_I32_REG_NAME(byte_offset_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[byte_offset_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, "]"));
+      break;
+    }
+
+    //===----------------------------------------------------------------===//
+    // ExtF64: Constants
+    //===----------------------------------------------------------------===//
+
+    DISASM_OP(EXT_F64, ConstF64) {
+      double value = VM_ParseAttrF64("value");
+      uint16_t result_reg = VM_ParseResultRegF64("result");
+      EMIT_F64_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_format(b, " = vm.const.f64 %f", value));
+      break;
+    }
+
+    DISASM_OP(EXT_F64, ConstF64Zero) {
+      uint16_t result_reg = VM_ParseResultRegF64("result");
+      EMIT_F64_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.const.f64.zero"));
+      break;
+    }
+
+    //===----------------------------------------------------------------===//
+    // ExtF64: Lists
+    //===----------------------------------------------------------------===//
+
+    DISASM_OP(EXT_F64, ListGetF64) {
+      bool list_is_move;
+      uint16_t list_reg = VM_ParseOperandRegRef("list", &list_is_move);
+      uint16_t index_reg = VM_ParseOperandRegI32("index");
+      uint16_t result_reg = VM_ParseResultRegF64("result");
+      EMIT_F64_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.list.get.f64 "));
+      EMIT_REF_REG_NAME(list_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[list_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(index_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[index_reg]);
+      break;
+    }
+
+    DISASM_OP(EXT_F64, ListSetF64) {
+      bool list_is_move;
+      uint16_t list_reg = VM_ParseOperandRegRef("list", &list_is_move);
+      uint16_t index_reg = VM_ParseOperandRegI32("index");
+      uint16_t raw_value_reg = VM_ParseOperandRegF64("raw_value");
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, "vm.list.set.f64 "));
+      EMIT_REF_REG_NAME(list_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[list_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I32_REG_NAME(index_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[index_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_F64_REG_NAME(raw_value_reg);
+      EMIT_OPTIONAL_VALUE_F64(regs->i32[raw_value_reg]);
+      break;
+    }
+
+    //===----------------------------------------------------------------===//
+    // ExtF64: Conditional assignment
+    //===----------------------------------------------------------------===//
+
+    DISASM_OP(EXT_F64, SelectF64) {
+      uint16_t condition_reg = VM_ParseOperandRegI32("condition");
+      uint16_t true_value_reg = VM_ParseOperandRegF64("true_value");
+      uint16_t false_value_reg = VM_ParseOperandRegF64("false_value");
+      uint16_t result_reg = VM_ParseResultRegF64("result");
+      EMIT_F64_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.select.f64 "));
+      EMIT_I32_REG_NAME(condition_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[condition_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, " ? "));
+      EMIT_F64_REG_NAME(true_value_reg);
+      EMIT_OPTIONAL_VALUE_F64(regs->i32[true_value_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, " : "));
+      EMIT_F64_REG_NAME(false_value_reg);
+      EMIT_OPTIONAL_VALUE_F64(regs->i32[false_value_reg]);
+      break;
+    }
+
+    DISASM_OP(EXT_F64, SwitchF64) {
+      uint16_t index_reg = VM_ParseOperandRegI32("index");
+      double default_value = VM_ParseOperandRegF64("default_value");
+      const iree_vm_register_list_t* value_reg_list =
+          VM_ParseVariadicOperands("values");
+      uint16_t result_reg = VM_ParseResultRegF64("result");
+      EMIT_F64_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.switch.f64 "));
+      EMIT_I32_REG_NAME(index_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[index_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, "["));
+      EMIT_OPERAND_REG_LIST(value_reg_list);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_format(b, "] else %f", default_value));
+      break;
+    }
+
+    //===----------------------------------------------------------------===//
+    // ExtF64: Native floating-point arithmetic
+    //===----------------------------------------------------------------===//
+
+    DISASM_OP_EXT_F64_BINARY_F64(AddF64, "vm.add.f64");
+    DISASM_OP_EXT_F64_BINARY_F64(SubF64, "vm.sub.f64");
+    DISASM_OP_EXT_F64_BINARY_F64(MulF64, "vm.mul.f64");
+    DISASM_OP_EXT_F64_BINARY_F64(DivF64, "vm.div.f64");
+    DISASM_OP_EXT_F64_BINARY_F64(RemF64, "vm.rem.f64");
+    DISASM_OP_EXT_F64_TERNARY_F64(FMAF64, "vm.fma.f64");
+    DISASM_OP_EXT_F64_UNARY_F64(AbsF64, "vm.abs.f64");
+    DISASM_OP_EXT_F64_UNARY_F64(NegF64, "vm.neg.f64");
+    DISASM_OP_EXT_F64_UNARY_F64(CeilF64, "vm.ceil.f64");
+    DISASM_OP_EXT_F64_UNARY_F64(FloorF64, "vm.floor.f64");
+    DISASM_OP_EXT_F64_UNARY_F64(RoundF64, "vm.round.f64");
+    DISASM_OP_EXT_F64_UNARY_F64(RoundF64Even, "vm.round.f64.even");
+    DISASM_OP_EXT_F64_BINARY_F64(MinF64, "vm.min.f64");
+    DISASM_OP_EXT_F64_BINARY_F64(MaxF64, "vm.max.f64");
+
+    DISASM_OP_EXT_F64_UNARY_F64(AtanF64, "vm.atan.f64");
+    DISASM_OP_EXT_F64_BINARY_F64(Atan2F64, "vm.atan2.f64");
+    DISASM_OP_EXT_F64_UNARY_F64(CosF64, "vm.cos.f64");
+    DISASM_OP_EXT_F64_UNARY_F64(SinF64, "vm.sin.f64");
+    DISASM_OP_EXT_F64_UNARY_F64(ExpF64, "vm.exp.f64");
+    DISASM_OP_EXT_F64_UNARY_F64(Exp2F64, "vm.exp2.f64");
+    DISASM_OP_EXT_F64_UNARY_F64(ExpM1F64, "vm.expm1.f64");
+    DISASM_OP_EXT_F64_UNARY_F64(LogF64, "vm.log.f64");
+    DISASM_OP_EXT_F64_UNARY_F64(Log10F64, "vm.log10.f64");
+    DISASM_OP_EXT_F64_UNARY_F64(Log1pF64, "vm.log1p.f64");
+    DISASM_OP_EXT_F64_UNARY_F64(Log2F64, "vm.log2.f64");
+    DISASM_OP_EXT_F64_BINARY_F64(PowF64, "vm.pow.f64");
+    DISASM_OP_EXT_F64_UNARY_F64(RsqrtF64, "vm.rsqrt.f64");
+    DISASM_OP_EXT_F64_UNARY_F64(SqrtF64, "vm.sqrt.f64");
+    DISASM_OP_EXT_F64_UNARY_F64(TanhF64, "vm.tanh.f64");
+    DISASM_OP_EXT_F64_UNARY_F64(ErfF64, "vm.erf.f64");
+
+    //===----------------------------------------------------------------===//
+    // ExtF64: Casting and type conversion/emulation
+    //===----------------------------------------------------------------===//
+
+    DISASM_OP(EXT_F64, TruncF64F32) {
+      uint16_t operand_reg = VM_ParseOperandRegF64("operand");
+      uint16_t result_reg = VM_ParseResultRegF32("result");
+      EMIT_F32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.trunc.f64.f32 "));
+      EMIT_F64_REG_NAME(operand_reg);
+      EMIT_OPTIONAL_VALUE_F64(regs->i32[operand_reg]);
+      break;
+    }
+    DISASM_OP(EXT_F64, ExtF32F64) {
+      uint16_t operand_reg = VM_ParseOperandRegF32("operand");
+      uint16_t result_reg = VM_ParseResultRegF64("result");
+      EMIT_F64_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.ext.f32.f64 "));
+      EMIT_F32_REG_NAME(operand_reg);
+      EMIT_OPTIONAL_VALUE_F32(regs->i32[operand_reg]);
+      break;
+    }
+    DISASM_OP(EXT_F64, CastSI32F64) {
+      uint16_t operand_reg = VM_ParseOperandRegI32("operand");
+      uint16_t result_reg = VM_ParseResultRegF64("result");
+      EMIT_F64_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.cast.si32.f64 "));
+      EMIT_I32_REG_NAME(operand_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[operand_reg]);
+      break;
+    }
+    DISASM_OP(EXT_F64, CastUI32F64) {
+      uint16_t operand_reg = VM_ParseOperandRegI32("operand");
+      uint16_t result_reg = VM_ParseResultRegF64("result");
+      EMIT_F64_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.cast.ui32.f64 "));
+      EMIT_I32_REG_NAME(operand_reg);
+      EMIT_OPTIONAL_VALUE_I32(regs->i32[operand_reg]);
+      break;
+    }
+    DISASM_OP(EXT_F64, CastF64SI32) {
+      uint16_t operand_reg = VM_ParseOperandRegF64("operand");
+      uint16_t result_reg = VM_ParseResultRegI32("result");
+      EMIT_I32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.cast.f64.si32 "));
+      EMIT_F64_REG_NAME(operand_reg);
+      EMIT_OPTIONAL_VALUE_F64(regs->i32[operand_reg]);
+      break;
+    }
+    DISASM_OP(EXT_F64, CastF64UI32) {
+      uint16_t operand_reg = VM_ParseOperandRegF64("operand");
+      uint16_t result_reg = VM_ParseResultRegI32("result");
+      EMIT_I32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.cast.f64.ui32 "));
+      EMIT_F64_REG_NAME(operand_reg);
+      EMIT_OPTIONAL_VALUE_F64(regs->i32[operand_reg]);
+      break;
+    }
+    DISASM_OP(EXT_F64, CastSI64F64) {
+      uint16_t operand_reg = VM_ParseOperandRegI64("operand");
+      uint16_t result_reg = VM_ParseResultRegF64("result");
+      EMIT_F64_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.cast.si64.f64 "));
+      EMIT_I64_REG_NAME(operand_reg);
+      EMIT_OPTIONAL_VALUE_I64(regs->i32[operand_reg]);
+      break;
+    }
+    DISASM_OP(EXT_F64, CastUI64F64) {
+      uint16_t operand_reg = VM_ParseOperandRegI64("operand");
+      uint16_t result_reg = VM_ParseResultRegF64("result");
+      EMIT_F64_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.cast.ui64.f64 "));
+      EMIT_I64_REG_NAME(operand_reg);
+      EMIT_OPTIONAL_VALUE_I64(regs->i32[operand_reg]);
+      break;
+    }
+    DISASM_OP(EXT_F64, CastF64SI64) {
+      uint16_t operand_reg = VM_ParseOperandRegF64("operand");
+      uint16_t result_reg = VM_ParseResultRegI64("result");
+      EMIT_I64_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.cast.f64.si64 "));
+      EMIT_F64_REG_NAME(operand_reg);
+      EMIT_OPTIONAL_VALUE_F64(regs->i32[operand_reg]);
+      break;
+    }
+    DISASM_OP(EXT_F64, CastF64UI64) {
+      uint16_t operand_reg = VM_ParseOperandRegF64("operand");
+      uint16_t result_reg = VM_ParseResultRegI64("result");
+      EMIT_I64_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.cast.f64.ui64 "));
+      EMIT_F64_REG_NAME(operand_reg);
+      EMIT_OPTIONAL_VALUE_F64(regs->i32[operand_reg]);
+      break;
+    }
+    DISASM_OP(EXT_F64, BitcastI64F64) {
+      uint16_t operand_reg = VM_ParseOperandRegI64("operand");
+      uint16_t result_reg = VM_ParseResultRegF64("result");
+      EMIT_F64_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.bitcast.i64.f64 "));
+      EMIT_I32_REG_NAME(operand_reg);
+      EMIT_OPTIONAL_VALUE_I64(regs->i32[operand_reg]);
+      break;
+    }
+    DISASM_OP(EXT_F64, BitcastF64I64) {
+      uint16_t operand_reg = VM_ParseOperandRegF64("operand");
+      uint16_t result_reg = VM_ParseResultRegI64("result");
+      EMIT_I64_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.bitcast.f64.i64 "));
+      EMIT_F64_REG_NAME(operand_reg);
+      EMIT_OPTIONAL_VALUE_F64(regs->i32[operand_reg]);
+      break;
+    }
+
+    //===----------------------------------------------------------------===//
+    // ExtF64: Comparison ops
+    //===----------------------------------------------------------------===//
+
+#define DISASM_OP_EXT_F64_CMP_F64(op_name, op_mnemonic)                \
+  DISASM_OP(EXT_F64, op_name) {                                        \
+    uint16_t lhs_reg = VM_ParseOperandRegF64("lhs");                   \
+    uint16_t rhs_reg = VM_ParseOperandRegF64("rhs");                   \
+    uint16_t result_reg = VM_ParseResultRegI32("result");              \
+    EMIT_I32_REG_NAME(result_reg);                                     \
+    IREE_RETURN_IF_ERROR(                                              \
+        iree_string_builder_append_format(b, " = %s ", op_mnemonic));  \
+    EMIT_F64_REG_NAME(lhs_reg);                                        \
+    EMIT_OPTIONAL_VALUE_F64(regs->i32[lhs_reg]);                       \
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", ")); \
+    EMIT_F64_REG_NAME(rhs_reg);                                        \
+    EMIT_OPTIONAL_VALUE_F64(regs->i32[rhs_reg]);                       \
+    break;                                                             \
+  }
+
+    DISASM_OP_EXT_F64_CMP_F64(CmpEQF64O, "vm.cmp.eq.f64.o");
+    DISASM_OP_EXT_F64_CMP_F64(CmpEQF64U, "vm.cmp.eq.f64.u");
+    DISASM_OP_EXT_F64_CMP_F64(CmpNEF64O, "vm.cmp.ne.f64.o");
+    DISASM_OP_EXT_F64_CMP_F64(CmpNEF64U, "vm.cmp.ne.f64.u");
+    DISASM_OP_EXT_F64_CMP_F64(CmpLTF64O, "vm.cmp.lt.f64.o");
+    DISASM_OP_EXT_F64_CMP_F64(CmpLTF64U, "vm.cmp.lt.f64.u");
+    DISASM_OP_EXT_F64_CMP_F64(CmpLTEF64O, "vm.cmp.lte.f64.o");
+    DISASM_OP_EXT_F64_CMP_F64(CmpLTEF64U, "vm.cmp.lte.f64.u");
+    DISASM_OP(EXT_F64, CmpNaNF64) {
+      uint16_t operand_reg = VM_ParseOperandRegF64("operand");
+      uint16_t result_reg = VM_ParseResultRegI32("result");
+      EMIT_I32_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.cmp.nan.f64 "));
+      EMIT_F64_REG_NAME(operand_reg);
+      EMIT_OPTIONAL_VALUE_F64(regs->i32[operand_reg]);
+      break;
+    }
+
+    //===----------------------------------------------------------------===//
+    // ExtF64: Buffers
+    //===----------------------------------------------------------------===//
+
+    DISASM_OP(EXT_F64, BufferFillF64) {
+      bool buffer_is_move;
+      uint16_t buffer_reg =
+          VM_ParseOperandRegRef("target_buffer", &buffer_is_move);
+      uint16_t offset_reg = VM_ParseOperandRegI64("target_offset");
+      uint16_t length_reg = VM_ParseOperandRegI64("length");
+      uint16_t value_reg = VM_ParseOperandRegF64("value");
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, "vm.buffer.fill.f64 "));
+      EMIT_REF_REG_NAME(buffer_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[buffer_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I64_REG_NAME(offset_reg);
+      EMIT_OPTIONAL_VALUE_I64(regs->i32[offset_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I64_REG_NAME(length_reg);
+      EMIT_OPTIONAL_VALUE_I64(regs->i32[length_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_F64_REG_NAME(value_reg);
+      EMIT_OPTIONAL_VALUE_F64(regs->i32[value_reg]);
+      break;
+    }
+
+    DISASM_OP(EXT_F64, BufferLoadF64) {
+      bool buffer_is_move;
+      uint16_t buffer_reg =
+          VM_ParseOperandRegRef("source_buffer", &buffer_is_move);
+      uint16_t offset_reg = VM_ParseOperandRegI64("source_offset");
+      uint16_t result_reg = VM_ParseResultRegF64("result");
+      EMIT_F64_REG_NAME(result_reg);
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, " = vm.buffer.load.f64 "));
+      EMIT_REF_REG_NAME(buffer_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[buffer_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I64_REG_NAME(offset_reg);
+      EMIT_OPTIONAL_VALUE_I64(regs->i32[offset_reg]);
+      break;
+    }
+
+    DISASM_OP(EXT_F64, BufferStoreF64) {
+      bool buffer_is_move;
+      uint16_t buffer_reg =
+          VM_ParseOperandRegRef("target_buffer", &buffer_is_move);
+      uint16_t offset_reg = VM_ParseOperandRegI64("target_offset");
+      uint16_t value_reg = VM_ParseOperandRegF64("value");
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(b, "vm.buffer.store.f64 "));
+      EMIT_F64_REG_NAME(value_reg);
+      EMIT_OPTIONAL_VALUE_F64(regs->i32[value_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_REF_REG_NAME(buffer_reg);
+      EMIT_OPTIONAL_VALUE_REF(&regs->ref[buffer_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, ", "));
+      EMIT_I64_REG_NAME(offset_reg);
+      EMIT_OPTIONAL_VALUE_I64(regs->i32[offset_reg]);
+      break;
+    }
+
+    END_DISASM_PREFIX()
+#else
     UNHANDLED_DISASM_PREFIX(PrefixExtF64, EXT_F64)
+#endif  // IREE_VM_EXT_F64_ENABLE
 
     default:
       return iree_make_status(IREE_STATUS_UNIMPLEMENTED,

--- a/runtime/src/iree/vm/bytecode/dispatch_util.h
+++ b/runtime/src/iree/vm/bytecode/dispatch_util.h
@@ -157,10 +157,10 @@ static inline iree_vm_type_def_t iree_vm_map_type(
   iree_vm_map_type(module, OP_I32(0)); \
   pc += 4;
 #define VM_DecTypeOf(name) VM_DecType(name)
-#define VM_DecIntAttr32(name) VM_DecConstI32(name)
-#define VM_DecIntAttr64(name) VM_DecConstI64(name)
-#define VM_DecFloatAttr32(name) VM_DecConstF32(name)
-#define VM_DecFloatAttr64(name) VM_DecConstF64(name)
+#define VM_DecAttrI32(name) VM_DecConstI32(name)
+#define VM_DecAttrI64(name) VM_DecConstI64(name)
+#define VM_DecAttrF32(name) VM_DecConstF32(name)
+#define VM_DecAttrF64(name) VM_DecConstF64(name)
 #define VM_DecStrAttr(name, out_str)                     \
   (out_str)->size = (iree_host_size_t)OP_I16(0);         \
   (out_str)->data = (const char*)&bytecode_data[pc + 2]; \
@@ -284,7 +284,7 @@ static inline const iree_vm_register_list_t* VM_DecVariadicOperandsImpl(
   DEFINE_DISPATCH_TABLE_EXT_F64();
 
 #define DISPATCH_UNHANDLED_CORE()                                           \
-  _dispatch_unhandled : {                                                   \
+  _dispatch_unhandled /*verifier should prevent this*/ : {                  \
     IREE_ASSERT(0);                                                         \
     return iree_make_status(IREE_STATUS_UNIMPLEMENTED, "unhandled opcode"); \
   }

--- a/runtime/src/iree/vm/bytecode/verifier.c
+++ b/runtime/src/iree/vm/bytecode/verifier.c
@@ -598,10 +598,10 @@ iree_status_t iree_vm_bytecode_function_verify(
   (void)(name);                                                                \
   pc += 4;
 #define VM_VerifyTypeOf(name) VM_VerifyType(name)
-#define VM_VerifyIntAttr32(name) VM_VerifyConstI32(name)
-#define VM_VerifyIntAttr64(name) VM_VerifyConstI64(name)
-#define VM_VerifyFloatAttr32(name) VM_VerifyConstF32(name)
-#define VM_VerifyFloatAttr64(name) VM_VerifyConstF64(name)
+#define VM_VerifyAttrI32(name) VM_VerifyConstI32(name)
+#define VM_VerifyAttrI64(name) VM_VerifyConstI64(name)
+#define VM_VerifyAttrF32(name) VM_VerifyConstF32(name)
+#define VM_VerifyAttrF64(name) VM_VerifyConstF64(name)
 #define VM_VerifyStrAttr(name, out_str)                      \
   IREE_VM_VERIFY_PC_RANGE(pc + 2, max_pc);                   \
   (out_str)->size = (iree_host_size_t)OP_I16(0);             \
@@ -1000,12 +1000,13 @@ static iree_status_t iree_vm_bytecode_function_verify_call(
     IREE_VM_VERIFY_PC_RANGE(pc + 1, max_pc); \
     IREE_VM_VERIFY_REQUIREMENT(ext);         \
     switch (bytecode_data[pc++]) {
-#define END_VERIFY_PREFIX()                               \
-  default:                                                \
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, \
-                            "unhandled ext opcode");      \
-    }                                                     \
-    break;                                                \
+#define END_VERIFY_PREFIX(op_name, ext)                               \
+  default:                                                            \
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,             \
+                            "unhandled ext " #op_name " opcode %02X", \
+                            bytecode_data[pc - 1]);                   \
+    }                                                                 \
+    break;                                                            \
     }
 #define UNHANDLED_VERIFY_PREFIX(op_name, ext)                                 \
   case IREE_VM_OP_CORE_##op_name: {                                           \
@@ -1133,14 +1134,14 @@ static iree_status_t iree_vm_bytecode_function_verify_bytecode_op(
     //===------------------------------------------------------------------===//
 
     VERIFY_OP(CORE, ConstI32, {
-      VM_VerifyIntAttr32(value);
+      VM_VerifyAttrI32(value);
       VM_VerifyResultRegI32(result);
     });
 
     VERIFY_OP(CORE, ConstI32Zero, { VM_VerifyResultRegI32(result); });
 
     VERIFY_OP(CORE, ConstI64, {
-      VM_VerifyIntAttr64(value);
+      VM_VerifyAttrI64(value);
       VM_VerifyResultRegI64(result);
     });
 
@@ -1729,7 +1730,7 @@ static iree_status_t iree_vm_bytecode_function_verify_bytecode_op(
     //===----------------------------------------------------------------===//
 
     VERIFY_OP(EXT_F32, ConstF32, {
-      VM_VerifyFloatAttr32(value);
+      VM_VerifyAttrF32(value);
       VM_VerifyResultRegF32(result);
     });
 
@@ -1881,16 +1882,227 @@ static iree_status_t iree_vm_bytecode_function_verify_bytecode_op(
       VM_VerifyOperandRegF32(value);
     });
 
-    END_VERIFY_PREFIX();
+    END_VERIFY_PREFIX(PrefixExtF32, iree_vm_FeatureBits_EXT_F32);
 #else
     UNHANDLED_VERIFY_PREFIX(PrefixExtF32, iree_vm_FeatureBits_EXT_F32);
 #endif  // IREE_VM_EXT_F32_ENABLE
 
-    VERIFY_OP(CORE, PrefixExtF64, {
-      IREE_VM_VERIFY_REQUIREMENT(iree_vm_FeatureBits_EXT_F64);
-      return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
-                              "EXT_64 not yet implemented");
+#if IREE_VM_EXT_F64_ENABLE
+    BEGIN_VERIFY_PREFIX(PrefixExtF64, iree_vm_FeatureBits_EXT_F64)
+
+    //===----------------------------------------------------------------===//
+    // ExtF64: Globals
+    //===----------------------------------------------------------------===//
+
+    VERIFY_OP(EXT_F64, GlobalLoadF64, {
+      VM_VerifyGlobalAttr(byte_offset);
+      VM_VerifyRwdataOffset(byte_offset, 4);
+      VM_VerifyResultRegF64(value);
     });
+
+    VERIFY_OP(EXT_F64, GlobalStoreF64, {
+      VM_VerifyGlobalAttr(byte_offset);
+      VM_VerifyRwdataOffset(byte_offset, 4);
+      VM_VerifyOperandRegF64(value);
+    });
+
+    VERIFY_OP(EXT_F64, GlobalLoadIndirectF64, {
+      VM_VerifyOperandRegI32(byte_offset);
+      // NOTE: we have to verify the offset at runtime.
+      VM_VerifyResultRegF64(value);
+    });
+
+    VERIFY_OP(EXT_F64, GlobalStoreIndirectF64, {
+      VM_VerifyOperandRegI32(byte_offset);
+      // NOTE: we have to verify the offset at runtime.
+      VM_VerifyOperandRegF64(value);
+    });
+
+    //===----------------------------------------------------------------===//
+    // ExtF64: Constants
+    //===----------------------------------------------------------------===//
+
+    VERIFY_OP(EXT_F64, ConstF64, {
+      VM_VerifyAttrF64(value);
+      VM_VerifyResultRegF64(result);
+    });
+
+    VERIFY_OP(EXT_F64, ConstF64Zero, { VM_VerifyResultRegF64(result); });
+
+    //===----------------------------------------------------------------===//
+    // ExtF64: Lists
+    //===----------------------------------------------------------------===//
+
+    VERIFY_OP(EXT_F64, ListGetF64, {
+      VM_VerifyOperandRegRef(list);
+      VM_VerifyOperandRegI32(index);
+      VM_VerifyResultRegF64(result);
+    });
+
+    VERIFY_OP(EXT_F64, ListSetF64, {
+      VM_VerifyOperandRegRef(list);
+      VM_VerifyOperandRegI32(index);
+      VM_VerifyOperandRegF64(value);
+    });
+
+    //===----------------------------------------------------------------===//
+    // ExtF64: Conditional assignment
+    //===----------------------------------------------------------------===//
+
+    VERIFY_OP(EXT_F64, SelectF64, {
+      VM_VerifyOperandRegI32(condition);
+      VM_VerifyOperandRegF64(true_value);
+      VM_VerifyOperandRegF64(false_value);
+      VM_VerifyResultRegF64(result);
+    });
+
+    VERIFY_OP(EXT_F64, SwitchF64, {
+      VM_VerifyOperandRegI32(index);
+      VM_VerifyOperandRegF64(default_value);
+      VM_VerifyVariadicOperandsF64(values);
+      VM_VerifyResultRegF64(result);
+    });
+
+    //===----------------------------------------------------------------===//
+    // ExtF64: Native floating-point arithmetic
+    //===----------------------------------------------------------------===//
+
+    VERIFY_OP_EXT_F64_BINARY_F64(AddF64);
+    VERIFY_OP_EXT_F64_BINARY_F64(SubF64);
+    VERIFY_OP_EXT_F64_BINARY_F64(MulF64);
+    VERIFY_OP_EXT_F64_BINARY_F64(DivF64);
+    VERIFY_OP_EXT_F64_BINARY_F64(RemF64);
+    VERIFY_OP_EXT_F64_TERNARY_F64(FMAF64);
+    VERIFY_OP_EXT_F64_UNARY_F64(AbsF64);
+    VERIFY_OP_EXT_F64_UNARY_F64(NegF64);
+    VERIFY_OP_EXT_F64_UNARY_F64(CeilF64);
+    VERIFY_OP_EXT_F64_UNARY_F64(FloorF64);
+    VERIFY_OP_EXT_F64_UNARY_F64(RoundF64);
+    VERIFY_OP_EXT_F64_UNARY_F64(RoundF64Even);
+    VERIFY_OP_EXT_F64_BINARY_F64(MinF64);
+    VERIFY_OP_EXT_F64_BINARY_F64(MaxF64);
+
+    VERIFY_OP_EXT_F64_UNARY_F64(AtanF64);
+    VERIFY_OP_EXT_F64_BINARY_F64(Atan2F64);
+    VERIFY_OP_EXT_F64_UNARY_F64(CosF64);
+    VERIFY_OP_EXT_F64_UNARY_F64(SinF64);
+    VERIFY_OP_EXT_F64_UNARY_F64(ExpF64);
+    VERIFY_OP_EXT_F64_UNARY_F64(Exp2F64);
+    VERIFY_OP_EXT_F64_UNARY_F64(ExpM1F64);
+    VERIFY_OP_EXT_F64_UNARY_F64(LogF64);
+    VERIFY_OP_EXT_F64_UNARY_F64(Log10F64);
+    VERIFY_OP_EXT_F64_UNARY_F64(Log1pF64);
+    VERIFY_OP_EXT_F64_UNARY_F64(Log2F64);
+    VERIFY_OP_EXT_F64_BINARY_F64(PowF64);
+    VERIFY_OP_EXT_F64_UNARY_F64(RsqrtF64);
+    VERIFY_OP_EXT_F64_UNARY_F64(SqrtF64);
+    VERIFY_OP_EXT_F64_UNARY_F64(TanhF64);
+    VERIFY_OP_EXT_F64_UNARY_F64(ErfF64);
+
+    //===----------------------------------------------------------------===//
+    // ExtF64: Casting and type conversion/emulation
+    //===----------------------------------------------------------------===//
+
+    VERIFY_OP(EXT_F64, TruncF64F32, {
+      VM_VerifyOperandRegF64(operand);
+      VM_VerifyResultRegF32(result);
+    });
+    VERIFY_OP(EXT_F64, ExtF32F64, {
+      VM_VerifyOperandRegF32(operand);
+      VM_VerifyResultRegF64(result);
+    });
+    VERIFY_OP(EXT_F64, CastSI32F64, {
+      VM_VerifyOperandRegI32(operand);
+      VM_VerifyResultRegF64(result);
+    });
+    VERIFY_OP(EXT_F64, CastUI32F64, {
+      VM_VerifyOperandRegI32(operand);
+      VM_VerifyResultRegF64(result);
+    });
+    VERIFY_OP(EXT_F64, CastF64SI32, {
+      VM_VerifyOperandRegF64(operand);
+      VM_VerifyResultRegI32(result);
+    });
+    VERIFY_OP(EXT_F64, CastF64UI32, {
+      VM_VerifyOperandRegF64(operand);
+      VM_VerifyResultRegI32(result);
+    });
+    VERIFY_OP(EXT_F64, CastSI64F64, {
+      VM_VerifyOperandRegI64(operand);
+      VM_VerifyResultRegF64(result);
+    });
+    VERIFY_OP(EXT_F64, CastUI64F64, {
+      VM_VerifyOperandRegI64(operand);
+      VM_VerifyResultRegF64(result);
+    });
+    VERIFY_OP(EXT_F64, CastF64SI64, {
+      VM_VerifyOperandRegF64(operand);
+      VM_VerifyResultRegI64(result);
+    });
+    VERIFY_OP(EXT_F64, CastF64UI64, {
+      VM_VerifyOperandRegF64(operand);
+      VM_VerifyResultRegI64(result);
+    });
+    VERIFY_OP(EXT_F64, BitcastI64F64, {
+      VM_VerifyOperandRegI64(operand);
+      VM_VerifyResultRegF64(result);
+    });
+    VERIFY_OP(EXT_F64, BitcastF64I64, {
+      VM_VerifyOperandRegF64(operand);
+      VM_VerifyResultRegI64(result);
+    });
+
+    //===----------------------------------------------------------------===//
+    // ExtF64: Comparison ops
+    //===----------------------------------------------------------------===//
+
+#define VERIFY_OP_EXT_F64_CMP_F64(op_name) \
+  VERIFY_OP(EXT_F64, op_name, {            \
+    VM_VerifyOperandRegF64(lhs);           \
+    VM_VerifyOperandRegF64(rhs);           \
+    VM_VerifyResultRegI32(result);         \
+  });
+
+    VERIFY_OP_EXT_F64_CMP_F64(CmpEQF64O);
+    VERIFY_OP_EXT_F64_CMP_F64(CmpEQF64U);
+    VERIFY_OP_EXT_F64_CMP_F64(CmpNEF64O);
+    VERIFY_OP_EXT_F64_CMP_F64(CmpNEF64U);
+    VERIFY_OP_EXT_F64_CMP_F64(CmpLTF64O);
+    VERIFY_OP_EXT_F64_CMP_F64(CmpLTF64U);
+    VERIFY_OP_EXT_F64_CMP_F64(CmpLTEF64O);
+    VERIFY_OP_EXT_F64_CMP_F64(CmpLTEF64U);
+    VERIFY_OP(EXT_F64, CmpNaNF64, {
+      VM_VerifyOperandRegF64(operand);
+      VM_VerifyResultRegI32(result);
+    });
+
+    //===----------------------------------------------------------------===//
+    // ExtF64: Buffers
+    //===----------------------------------------------------------------===//
+
+    VERIFY_OP(EXT_F64, BufferFillF64, {
+      VM_VerifyOperandRegRef(target_buffer);
+      VM_VerifyOperandRegI64HostSize(target_offset);
+      VM_VerifyOperandRegI64HostSize(length);
+      VM_VerifyOperandRegF64(value);
+    });
+
+    VERIFY_OP(EXT_F64, BufferLoadF64, {
+      VM_VerifyOperandRegRef(source_buffer);
+      VM_VerifyOperandRegI64HostSize(source_offset);
+      VM_VerifyResultRegF64(result);
+    });
+
+    VERIFY_OP(EXT_F64, BufferStoreF64, {
+      VM_VerifyOperandRegRef(target_buffer);
+      VM_VerifyOperandRegI64HostSize(target_offset);
+      VM_VerifyOperandRegF64(value);
+    });
+
+    END_VERIFY_PREFIX(PrefixExtF64, iree_vm_FeatureBits_EXT_F64);
+#else
+    UNHANDLED_VERIFY_PREFIX(PrefixExtF64, iree_vm_FeatureBits_EXT_F64);
+#endif  // IREE_VM_EXT_F64_ENABLE
 
     default:
       return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,

--- a/runtime/src/iree/vm/test/BUILD.bazel
+++ b/runtime/src/iree/vm/test/BUILD.bazel
@@ -28,21 +28,26 @@ c_embed_data(
     srcs = [
         ":arithmetic_ops.vmfb",
         ":arithmetic_ops_f32.vmfb",
+        ":arithmetic_ops_f64.vmfb",
         ":arithmetic_ops_i64.vmfb",
         ":assignment_ops.vmfb",
         ":assignment_ops_f32.vmfb",
+        ":assignment_ops_f64.vmfb",
         ":assignment_ops_i64.vmfb",
         ":buffer_ops.vmfb",
         ":call_ops.vmfb",
         ":comparison_ops.vmfb",
         ":comparison_ops_f32.vmfb",
+        ":comparison_ops_f64.vmfb",
         ":comparison_ops_i64.vmfb",
         ":control_flow_ops.vmfb",
         ":conversion_ops.vmfb",
         ":conversion_ops_f32.vmfb",
+        ":conversion_ops_f64.vmfb",
         ":conversion_ops_i64.vmfb",
         ":global_ops.vmfb",
         ":global_ops_f32.vmfb",
+        ":global_ops_f64.vmfb",
         ":global_ops_i64.vmfb",
         ":list_ops.vmfb",
         ":list_ops_i64.vmfb",
@@ -69,6 +74,16 @@ iree_bytecode_module(
     src = "arithmetic_ops_f32.mlir",
     flags = [
         "--compile-mode=vm",
+        "--iree-vm-target-extension-f32=true",
+    ],
+)
+
+iree_bytecode_module(
+    name = "arithmetic_ops_f64",
+    src = "arithmetic_ops_f64.mlir",
+    flags = [
+        "--compile-mode=vm",
+        "--iree-vm-target-extension-f64=true",
     ],
 )
 
@@ -93,6 +108,16 @@ iree_bytecode_module(
     src = "assignment_ops_f32.mlir",
     flags = [
         "--compile-mode=vm",
+        "--iree-vm-target-extension-f32=true",
+    ],
+)
+
+iree_bytecode_module(
+    name = "assignment_ops_f64",
+    src = "assignment_ops_f64.mlir",
+    flags = [
+        "--compile-mode=vm",
+        "--iree-vm-target-extension-f64=true",
     ],
 )
 
@@ -133,6 +158,16 @@ iree_bytecode_module(
     src = "comparison_ops_f32.mlir",
     flags = [
         "--compile-mode=vm",
+        "--iree-vm-target-extension-f32=true",
+    ],
+)
+
+iree_bytecode_module(
+    name = "comparison_ops_f64",
+    src = "comparison_ops_f64.mlir",
+    flags = [
+        "--compile-mode=vm",
+        "--iree-vm-target-extension-f64=true",
     ],
 )
 
@@ -165,6 +200,16 @@ iree_bytecode_module(
     src = "conversion_ops_f32.mlir",
     flags = [
         "--compile-mode=vm",
+        "--iree-vm-target-extension-f32=true",
+    ],
+)
+
+iree_bytecode_module(
+    name = "conversion_ops_f64",
+    src = "conversion_ops_f64.mlir",
+    flags = [
+        "--compile-mode=vm",
+        "--iree-vm-target-extension-f64=true",
     ],
 )
 
@@ -189,6 +234,16 @@ iree_bytecode_module(
     src = "global_ops_f32.mlir",
     flags = [
         "--compile-mode=vm",
+        "--iree-vm-target-extension-f32=true",
+    ],
+)
+
+iree_bytecode_module(
+    name = "global_ops_f64",
+    src = "global_ops_f64.mlir",
+    flags = [
+        "--compile-mode=vm",
+        "--iree-vm-target-extension-f64=true",
     ],
 )
 

--- a/runtime/src/iree/vm/test/CMakeLists.txt
+++ b/runtime/src/iree/vm/test/CMakeLists.txt
@@ -20,21 +20,26 @@ iree_c_embed_data(
   SRCS
     "arithmetic_ops.vmfb"
     "arithmetic_ops_f32.vmfb"
+    "arithmetic_ops_f64.vmfb"
     "arithmetic_ops_i64.vmfb"
     "assignment_ops.vmfb"
     "assignment_ops_f32.vmfb"
+    "assignment_ops_f64.vmfb"
     "assignment_ops_i64.vmfb"
     "buffer_ops.vmfb"
     "call_ops.vmfb"
     "comparison_ops.vmfb"
     "comparison_ops_f32.vmfb"
+    "comparison_ops_f64.vmfb"
     "comparison_ops_i64.vmfb"
     "control_flow_ops.vmfb"
     "conversion_ops.vmfb"
     "conversion_ops_f32.vmfb"
+    "conversion_ops_f64.vmfb"
     "conversion_ops_i64.vmfb"
     "global_ops.vmfb"
     "global_ops_f32.vmfb"
+    "global_ops_f64.vmfb"
     "global_ops_i64.vmfb"
     "list_ops.vmfb"
     "list_ops_i64.vmfb"
@@ -67,6 +72,18 @@ iree_bytecode_module(
     "arithmetic_ops_f32.mlir"
   FLAGS
     "--compile-mode=vm"
+    "--iree-vm-target-extension-f32=true"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    arithmetic_ops_f64
+  SRC
+    "arithmetic_ops_f64.mlir"
+  FLAGS
+    "--compile-mode=vm"
+    "--iree-vm-target-extension-f64=true"
   PUBLIC
 )
 
@@ -97,6 +114,18 @@ iree_bytecode_module(
     "assignment_ops_f32.mlir"
   FLAGS
     "--compile-mode=vm"
+    "--iree-vm-target-extension-f32=true"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    assignment_ops_f64
+  SRC
+    "assignment_ops_f64.mlir"
+  FLAGS
+    "--compile-mode=vm"
+    "--iree-vm-target-extension-f64=true"
   PUBLIC
 )
 
@@ -147,6 +176,18 @@ iree_bytecode_module(
     "comparison_ops_f32.mlir"
   FLAGS
     "--compile-mode=vm"
+    "--iree-vm-target-extension-f32=true"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    comparison_ops_f64
+  SRC
+    "comparison_ops_f64.mlir"
+  FLAGS
+    "--compile-mode=vm"
+    "--iree-vm-target-extension-f64=true"
   PUBLIC
 )
 
@@ -187,6 +228,18 @@ iree_bytecode_module(
     "conversion_ops_f32.mlir"
   FLAGS
     "--compile-mode=vm"
+    "--iree-vm-target-extension-f32=true"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    conversion_ops_f64
+  SRC
+    "conversion_ops_f64.mlir"
+  FLAGS
+    "--compile-mode=vm"
+    "--iree-vm-target-extension-f64=true"
   PUBLIC
 )
 
@@ -217,6 +270,18 @@ iree_bytecode_module(
     "global_ops_f32.mlir"
   FLAGS
     "--compile-mode=vm"
+    "--iree-vm-target-extension-f32=true"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    global_ops_f64
+  SRC
+    "global_ops_f64.mlir"
+  FLAGS
+    "--compile-mode=vm"
+    "--iree-vm-target-extension-f64=true"
   PUBLIC
 )
 

--- a/runtime/src/iree/vm/test/arithmetic_ops_f64.mlir
+++ b/runtime/src/iree/vm/test/arithmetic_ops_f64.mlir
@@ -1,0 +1,323 @@
+vm.module @arithmetic_ops_f64 {
+
+  //===--------------------------------------------------------------------===//
+  // ExtF64: Native floating-point arithmetic
+  //===--------------------------------------------------------------------===//
+
+  vm.export @test_add_f64
+  vm.func @test_add_f64() {
+    %c1 = vm.const.f64 1.5
+    %c1dno = util.optimization_barrier %c1 : f64
+    %v = vm.add.f64 %c1dno, %c1dno : f64
+    %c2 = vm.const.f64 3.0
+    vm.check.eq %v, %c2, "1.5+1.5=3" : f64
+    vm.return
+  }
+
+  vm.export @test_sub_f64
+  vm.func @test_sub_f64() {
+    %c1 = vm.const.f64 3.0
+    %c1dno = util.optimization_barrier %c1 : f64
+    %c2 = vm.const.f64 2.5
+    %c2dno = util.optimization_barrier %c2 : f64
+    %v = vm.sub.f64 %c1dno, %c2dno : f64
+    %c3 = vm.const.f64 0.5
+    vm.check.eq %v, %c3, "3.0-2.5=0.5" : f64
+    vm.return
+  }
+
+  vm.export @test_mul_f64
+  vm.func @test_mul_f64() {
+    %c1 = vm.const.f64 2.5
+    %c1dno = util.optimization_barrier %c1 : f64
+    %v = vm.mul.f64 %c1dno, %c1dno : f64
+    %c2 = vm.const.f64 6.25
+    vm.check.eq %v, %c2, "2.5*2.5=6.25" : f64
+    vm.return
+  }
+
+  vm.export @test_div_f64
+  vm.func @test_div_f64() {
+    %c1 = vm.const.f64 4.0
+    %c1dno = util.optimization_barrier %c1 : f64
+    %c2 = vm.const.f64 -2.0
+    %c2dno = util.optimization_barrier %c2 : f64
+    %v = vm.div.f64 %c1dno, %c2dno : f64
+    %c3 = vm.const.f64 -2.0
+    vm.check.eq %v, %c3, "4.0/-2.0=-2.0" : f64
+    vm.return
+  }
+
+  vm.export @test_rem_f64
+  vm.func @test_rem_f64() {
+    %c1 = vm.const.f64 -3.0
+    %c1dno = util.optimization_barrier %c1 : f64
+    %c2 = vm.const.f64 -2.0
+    %c2dno = util.optimization_barrier %c2 : f64
+    %v = vm.rem.f64 %c1dno, %c2dno : f64
+    %c3 = vm.const.f64 1.0
+    vm.check.eq %v, %c3, "-3.0%-2.0=1.0" : f64
+    vm.return
+  }
+
+  vm.export @test_fma_f64
+  vm.func @test_fma_f64() {
+    %c2 = vm.const.f64 2.0
+    %c2dno = util.optimization_barrier %c2 : f64
+    %c3 = vm.const.f64 3.0
+    %c3dno = util.optimization_barrier %c3 : f64
+    %c5 = vm.const.f64 5.0
+    %c5dno = util.optimization_barrier %c5 : f64
+    %v = vm.fma.f64 %c2dno, %c3dno, %c5dno : f64
+    %c11 = vm.const.f64 11.0
+    vm.check.eq %v, %c11, "2.0*3.0+5.0=11.0" : f64
+    vm.return
+  }
+
+  vm.export @test_abs_f64
+  vm.func @test_abs_f64() {
+    %c1 = vm.const.f64 -1.0
+    %c1dno = util.optimization_barrier %c1 : f64
+    %v = vm.abs.f64 %c1dno : f64
+    %c2 = vm.const.f64 1.0
+    vm.check.eq %v, %c2, "abs(-1.0)=1.0" : f64
+    vm.return
+  }
+
+  vm.export @test_neg_f64
+  vm.func @test_neg_f64() {
+    %c1 = vm.const.f64 -1.0
+    %c1dno = util.optimization_barrier %c1 : f64
+    %v = vm.neg.f64 %c1dno : f64
+    %c2 = vm.const.f64 1.0
+    vm.check.eq %v, %c2, "neg(-1.0)=1.0" : f64
+    vm.return
+  }
+
+  vm.export @test_ceil_f64
+  vm.func @test_ceil_f64() {
+    %c1 = vm.const.f64 1.5
+    %c1dno = util.optimization_barrier %c1 : f64
+    %v = vm.ceil.f64 %c1dno : f64
+    %c2 = vm.const.f64 2.0
+    vm.check.eq %v, %c2, "ceil(1.5)=2.0" : f64
+    vm.return
+  }
+
+  vm.export @test_floor_f64
+  vm.func @test_floor_f64() {
+    %c15 = vm.const.f64 1.5
+    %c15dno = util.optimization_barrier %c15 : f64
+    %v = vm.floor.f64 %c15dno : f64
+    %c1 = vm.const.f64 1.0
+    vm.check.eq %v, %c1, "floor(1.5)=1.0" : f64
+    vm.return
+  }
+
+  vm.export @test_round_f64
+  vm.func @test_round_f64() {
+    %c15 = vm.const.f64 1.5
+    %c15dno = util.optimization_barrier %c15 : f64
+    %v = vm.round.f64 %c15dno : f64
+    %c2 = vm.const.f64 2.0
+    vm.check.eq %v, %c2, "round(1.5)=2.0" : f64
+    vm.return
+  }
+
+  vm.export @test_round_f64_even
+  vm.func @test_round_f64_even() {
+    %c15 = vm.const.f64 1.5
+    %c15dno = util.optimization_barrier %c15 : f64
+    %v = vm.round.f64.even %c15dno : f64
+    %c2 = vm.const.f64 2.0
+    vm.check.eq %v, %c2, "roundeven(1.5)=2.0" : f64
+    vm.return
+  }
+
+  vm.export @test_min_f64
+  vm.func @test_min_f64() {
+    %cn3 = vm.const.f64 -3.0
+    %cn3dno = util.optimization_barrier %cn3 : f64
+    %cn2 = vm.const.f64 -2.0
+    %cn2dno = util.optimization_barrier %cn2 : f64
+    %v = vm.min.f64 %cn3dno, %cn2dno : f64
+    vm.check.eq %v, %cn3, "min(-3.0,-2.0)=-3.0" : f64
+    vm.return
+  }
+
+  vm.export @test_max_f64
+  vm.func @test_max_f64() {
+    %cn3 = vm.const.f64 -3.0
+    %cn3dno = util.optimization_barrier %cn3 : f64
+    %cn2 = vm.const.f64 -2.0
+    %cn2dno = util.optimization_barrier %cn2 : f64
+    %v = vm.max.f64 %cn3dno, %cn2dno : f64
+    vm.check.eq %v, %cn2, "max(-3.0,-2.0)=-2.0" : f64
+    vm.return
+  }
+
+  vm.export @test_atan_f64
+  vm.func @test_atan_f64() {
+    %c1 = vm.const.f64 1.0
+    %c1dno = util.optimization_barrier %c1 : f64
+    %v = vm.atan.f64 %c1dno : f64
+    %c2 = vm.const.f64 0.7853981633974483
+    vm.check.eq %v, %c2, "atan(1.0)=0.7853981633974483" : f64
+    vm.return
+  }
+
+  vm.export @test_atan2_f64
+  vm.func @test_atan2_f64() {
+    %c1 = vm.const.f64 1.0
+    %c1dno = util.optimization_barrier %c1 : f64
+    %c2 = vm.const.f64 0.0
+    %c2dno = util.optimization_barrier %c2 : f64
+    %v = vm.atan2.f64 %c1dno, %c2dno : f64
+    %c3 = vm.const.f64 1.5707963267948966
+    vm.check.eq %v, %c3, "atan2(1.0,0.0)=1.5707963267948966" : f64
+    vm.return
+  }
+
+  vm.export @test_cos_f64
+  vm.func @test_cos_f64() {
+    %c1 = vm.const.f64 0.5
+    %c1dno = util.optimization_barrier %c1 : f64
+    %v = vm.cos.f64 %c1dno : f64
+    %c2 = vm.const.f64 0.8775825618903728
+    vm.check.eq %v, %c2, "cos(0.5)=0.8775825618903728" : f64
+    vm.return
+  }
+
+  vm.export @test_sin_f64
+  vm.func @test_sin_f64() {
+    %c1 = vm.const.f64 0.5
+    %c1dno = util.optimization_barrier %c1 : f64
+    %v = vm.sin.f64 %c1dno : f64
+    %c2 = vm.const.f64 0.479425538604203
+    vm.check.eq %v, %c2, "sin(0.5)=0.479425538604203" : f64
+    vm.return
+  }
+
+  vm.export @test_exp_f64
+  vm.func @test_exp_f64() {
+    %c1 = vm.const.f64 1.0
+    %c1dno = util.optimization_barrier %c1 : f64
+    %v = vm.exp.f64 %c1dno : f64
+    %c2 = vm.const.f64 2.718281828459045
+    vm.check.eq %v, %c2, "exp(1.0)=2.718281828459045" : f64
+    vm.return
+  }
+
+  vm.export @test_exp2_f64
+  vm.func @test_exp2_f64() {
+    %c1 = vm.const.f64 2.0
+    %c1dno = util.optimization_barrier %c1 : f64
+    %v = vm.exp2.f64 %c1dno : f64
+    %c2 = vm.const.f64 4.0
+    vm.check.eq %v, %c2, "exp(2.0)=4.0" : f64
+    vm.return
+  }
+
+  vm.export @test_expm1_f64
+  vm.func @test_expm1_f64() {
+    %c1 = vm.const.f64 2.0
+    %c1dno = util.optimization_barrier %c1 : f64
+    %v = vm.expm1.f64 %c1dno : f64
+    %c2 = vm.const.f64 6.38905609893065
+    vm.check.eq %v, %c2, "expm1(2.0)=6.38905609893065" : f64
+    vm.return
+  }
+
+  vm.export @test_log_f64
+  vm.func @test_log_f64() {
+    %c1 = vm.const.f64 10.0
+    %c1dno = util.optimization_barrier %c1 : f64
+    %v = vm.log.f64 %c1dno : f64
+    %c2 = vm.const.f64 2.302585092994046
+    vm.check.eq %v, %c2, "log(10.0)=2.302585092994046" : f64
+    vm.return
+  }
+
+  vm.export @test_log10_f64
+  vm.func @test_log10_f64() {
+    %c1 = vm.const.f64 10.0
+    %c1dno = util.optimization_barrier %c1 : f64
+    %v = vm.log10.f64 %c1dno : f64
+    %c2 = vm.const.f64 1.0
+    vm.check.eq %v, %c2, "log10(10.0)=1.0" : f64
+    vm.return
+  }
+
+  vm.export @test_log1p_f64
+  vm.func @test_log1p_f64() {
+    %c1 = vm.const.f64 10.0
+    %c1dno = util.optimization_barrier %c1 : f64
+    %v = vm.log1p.f64 %c1dno : f64
+    %c2 = vm.const.f64 2.3978952727983707
+    vm.check.eq %v, %c2, "log1p(10.0)=2.3978952727983707" : f64
+    vm.return
+  }
+
+  vm.export @test_log2_f64
+  vm.func @test_log2_f64() {
+    %c1 = vm.const.f64 10.0
+    %c1dno = util.optimization_barrier %c1 : f64
+    %v = vm.log2.f64 %c1dno : f64
+    %c2 = vm.const.f64 3.321928094887362
+    vm.check.eq %v, %c2, "log2(10.0)=3.321928094887362" : f64
+    vm.return
+  }
+
+  vm.export @test_pow_f64
+  vm.func @test_pow_f64() {
+    %c1 = vm.const.f64 3.0
+    %c1dno = util.optimization_barrier %c1 : f64
+    %c2 = vm.const.f64 2.0
+    %c2dno = util.optimization_barrier %c2 : f64
+    %v = vm.pow.f64 %c1dno, %c2dno : f64
+    %c3 = vm.const.f64 9.0
+    vm.check.eq %v, %c3, "pow(3.0,2.0)=9.0" : f64
+    vm.return
+  }
+
+  vm.export @test_rsqrt_f64
+  vm.func @test_rsqrt_f64() {
+    %c1 = vm.const.f64 4.0
+    %c1dno = util.optimization_barrier %c1 : f64
+    %v = vm.rsqrt.f64 %c1dno : f64
+    %c2 = vm.const.f64 0.5
+    vm.check.eq %v, %c2, "rsqrt(4.0)=0.5" : f64
+    vm.return
+  }
+
+  vm.export @test_sqrt_f64
+  vm.func @test_sqrt_f64() {
+    %c1 = vm.const.f64 4.0
+    %c1dno = util.optimization_barrier %c1 : f64
+    %v = vm.sqrt.f64 %c1dno : f64
+    %c2 = vm.const.f64 2.0
+    vm.check.eq %v, %c2, "sqrt(4.0)=2.0" : f64
+    vm.return
+  }
+
+  vm.export @test_tanh_f64
+  vm.func @test_tanh_f64() {
+    %c1 = vm.const.f64 0.5
+    %c1dno = util.optimization_barrier %c1 : f64
+    %v = vm.tanh.f64 %c1dno : f64
+    %c2 = vm.const.f64 0.46211715726000974
+    vm.check.eq %v, %c2, "tanh(0.5)=0.46211715726000974" : f64
+    vm.return
+  }
+
+  // TODO(#5854): vm.check.nearly_eq; this can differ across libm impls.
+  // vm.export @test_erf_f64
+  // vm.func @test_erf_f64() {
+  //   %c1 = vm.const.f64 0.5
+  //   %c1dno = util.optimization_barrier %c1 : f64
+  //   %v = vm.erf.f64 %c1dno : f64
+  //   %c2 = vm.const.f64 0.520499945
+  //   vm.check.eq %v, %c2, "erf(0.5)=0.520499945" : f64
+  //   vm.return
+  // }
+}

--- a/runtime/src/iree/vm/test/assignment_ops_f64.mlir
+++ b/runtime/src/iree/vm/test/assignment_ops_f64.mlir
@@ -1,0 +1,49 @@
+vm.module @assignment_ops_f64 {
+
+  //===--------------------------------------------------------------------===//
+  // ExtF64: Conditional assignment
+  //===--------------------------------------------------------------------===//
+
+  vm.export @test_select_f64
+  vm.func @test_select_f64() {
+    %c0 = vm.const.i32 0
+    %c0dno = util.optimization_barrier %c0 : i32
+    %c1 = vm.const.i32 1
+    %c1dno = util.optimization_barrier %c1 : i32
+    %c2 = vm.const.f64 0.0
+    %c3 = vm.const.f64 1.0
+    %v1 = vm.select.f64 %c0dno, %c2, %c3 : f64
+    vm.check.eq %v1, %c3, "0 ? 0.0 : 1.0 = 1.0" : f64
+    %v2 = vm.select.f64 %c1dno, %c2, %c3 : f64
+    vm.check.eq %v2, %c2, "1 ? 0.0 : 1.0 = 0.0" : f64
+    vm.return
+  }
+
+  //===--------------------------------------------------------------------===//
+  // ExtF64: Lookup table
+  //===--------------------------------------------------------------------===//
+
+  vm.export @test_switch_f64 attributes {emitc.exclude}
+  vm.func private @test_switch_f64() {
+    %c100 = vm.const.f64 100.0
+    %c200 = vm.const.f64 200.0
+    %c300 = vm.const.f64 300.0
+
+    %i0 = vm.const.i32 0
+    %i0_dno = util.optimization_barrier %i0 : i32
+    %v0 = vm.switch.f64 %i0_dno[%c100, %c200] else %c300 : f64
+    vm.check.eq %v0, %c100, "index 0 is 100" : f64
+
+    %i1 = vm.const.i32 1
+    %i1_dno = util.optimization_barrier %i1 : i32
+    %v1 = vm.switch.f64 %i1_dno[%c100, %c200] else %c300 : f64
+    vm.check.eq %v1, %c200, "index 1 is 200" : f64
+
+    %i2 = vm.const.i32 2
+    %i2_dno = util.optimization_barrier %i2 : i32
+    %v2 = vm.switch.f64 %i2_dno[%c100, %c200] else %c300 : f64
+    vm.check.eq %v2, %c300, "index 2 (out of bounds) is default 300" : f64
+
+    vm.return
+  }
+}

--- a/runtime/src/iree/vm/test/comparison_ops_f64.mlir
+++ b/runtime/src/iree/vm/test/comparison_ops_f64.mlir
@@ -1,0 +1,130 @@
+vm.module @comparison_ops_f64 {
+
+  //===--------------------------------------------------------------------===//
+  // vm.cmp.lt.f64
+  //===--------------------------------------------------------------------===//
+
+  vm.export @test_cmp_lt_0_f64
+  vm.func @test_cmp_lt_0_f64() {
+    %lhs = vm.const.f64 4.0
+    %lhs_dno = util.optimization_barrier %lhs : f64
+    %rhs = vm.const.f64 -4.0
+    %rhs_dno = util.optimization_barrier %rhs : f64
+    %actual = vm.cmp.lt.f64.o %lhs_dno, %rhs_dno : f64
+    %expected = vm.const.i32 0
+    vm.check.eq %actual, %expected, "4.0 < -4.0" : i32
+    vm.return
+  }
+
+  vm.export @test_cmp_lt_1_f64
+  vm.func @test_cmp_lt_1_f64() {
+    %lhs = vm.const.f64 -4.0
+    %lhs_dno = util.optimization_barrier %lhs : f64
+    %rhs = vm.const.f64 4.0
+    %rhs_dno = util.optimization_barrier %rhs : f64
+    %actual = vm.cmp.lt.f64.o %lhs_dno, %rhs_dno : f64
+    %expected = vm.const.i32 1
+    vm.check.eq %actual, %expected, "-4.0 < 4.0" : i32
+    vm.return
+  }
+
+  //===--------------------------------------------------------------------===//
+  // vm.cmp.*.f64 pseudo-ops
+  //===--------------------------------------------------------------------===//
+  // NOTE: all of these are turned in to some variants of vm.cmp.* and other
+  // ops by the compiler and are here as a way to test the runtime behavior of
+  // the pseudo-op expansions.
+
+  vm.export @test_cmp_eq_f64_near
+  vm.func @test_cmp_eq_f64_near() {
+    %true = vm.const.i32 1
+    %false = vm.const.i32 0
+
+    %cn2 = vm.const.f64 -2.0
+    %cn2_dno = util.optimization_barrier %cn2 : f64
+    %c2 = vm.const.f64 2.0
+    %c2_dno = util.optimization_barrier %c2 : f64
+
+    %cmp_0 = vm.cmp.eq.f64.near %cn2_dno, %c2_dno : f64
+    vm.check.eq %cmp_0, %false, "-2 !~ 2" : i32
+    %cmp_1 = vm.cmp.eq.f64.near %c2_dno, %cn2_dno : f64
+    vm.check.eq %cmp_1, %false, "2 !~ -2" : i32
+    %cmp_2 = vm.cmp.eq.f64.near %c2_dno, %c2_dno : f64
+    vm.check.eq %cmp_2, %true, "2 ~ 2" : i32
+    %cmp_3 = vm.cmp.eq.f64.near %cn2_dno, %cn2_dno : f64
+    vm.check.eq %cmp_3, %true, "-2 ~ -2" : i32
+
+    // off by 84 ULPs, arbitrary threshold sets these as "near enough"
+    %c1a = vm.const.f64 1.00002
+    %c1a_dno = util.optimization_barrier %c1a : f64
+    %c1b = vm.const.f64 1.00003
+    %c1b_dno = util.optimization_barrier %c1b : f64
+
+    %cmp_4 = vm.cmp.eq.f64.near %c1a_dno, %c1b_dno : f64
+    vm.check.eq %cmp_4, %true, "1.00002 ~ 1.00003" : i32
+    %cmp_5 = vm.cmp.eq.f64.near %c1a_dno, %c2_dno : f64
+    vm.check.eq %cmp_5, %false, "1.00002 !~ 2" : i32
+
+    vm.return
+  }
+
+  vm.export @test_cmp_lte_f64
+  vm.func @test_cmp_lte_f64() {
+    %true = vm.const.i32 1
+    %false = vm.const.i32 0
+
+    %cn2 = vm.const.f64 -2.0
+    %cn2_dno = util.optimization_barrier %cn2 : f64
+    %c2 = vm.const.f64 2.0
+    %c2_dno = util.optimization_barrier %c2 : f64
+
+    %cmp_0 = vm.cmp.lte.f64.o %cn2_dno, %c2_dno : f64
+    vm.check.eq %cmp_0, %true, "-2 <= 2" : i32
+    %cmp_1 = vm.cmp.lte.f64.o %c2_dno, %cn2_dno : f64
+    vm.check.eq %cmp_1, %false, "2 <= -2" : i32
+    %cmp_2 = vm.cmp.lte.f64.o %c2_dno, %c2_dno : f64
+    vm.check.eq %cmp_2, %true, "2 <= 2" : i32
+
+    vm.return
+  }
+
+  vm.export @test_cmp_gt_f64
+  vm.func @test_cmp_gt_f64() {
+    %true = vm.const.i32 1
+    %false = vm.const.i32 0
+
+    %cn2 = vm.const.f64 -2.0
+    %cn2_dno = util.optimization_barrier %cn2 : f64
+    %c2 = vm.const.f64 2.0
+    %c2_dno = util.optimization_barrier %c2 : f64
+
+    %cmp_0 = vm.cmp.gt.f64.o %cn2_dno, %c2_dno : f64
+    vm.check.eq %cmp_0, %false, "-2 > 2" : i32
+    %cmp_1 = vm.cmp.gt.f64.o %c2_dno, %cn2_dno : f64
+    vm.check.eq %cmp_1, %true, "2 > -2" : i32
+    %cmp_2 = vm.cmp.gt.f64.o %c2_dno, %c2_dno : f64
+    vm.check.eq %cmp_2, %false, "2 > 2" : i32
+
+    vm.return
+  }
+
+  vm.export @test_cmp_gte_f64
+  vm.func @test_cmp_gte_f64() {
+    %true = vm.const.i32 1
+    %false = vm.const.i32 0
+
+    %cn2 = vm.const.f64 -2.0
+    %cn2_dno = util.optimization_barrier %cn2 : f64
+    %c2 = vm.const.f64 2.0
+    %c2_dno = util.optimization_barrier %c2 : f64
+
+    %cmp_0 = vm.cmp.gte.f64.o %cn2_dno, %c2_dno : f64
+    vm.check.eq %cmp_0, %false, "-2 >= 2" : i32
+    %cmp_1 = vm.cmp.gte.f64.o %c2_dno, %cn2_dno : f64
+    vm.check.eq %cmp_1, %true, "2 >= -2" : i32
+    %cmp_2 = vm.cmp.gte.f64.o %c2_dno, %c2_dno : f64
+    vm.check.eq %cmp_2, %true, "2 >= 2" : i32
+
+    vm.return
+  }
+}

--- a/runtime/src/iree/vm/test/conversion_ops_f32.mlir
+++ b/runtime/src/iree/vm/test/conversion_ops_f32.mlir
@@ -4,10 +4,9 @@ vm.module @conversion_ops_f32 {
   // Casting and type conversion/emulation
   //===----------------------------------------------------------------------===//
 
-  // 5.5 f32 (0x40b00000 hex) -> 1085276160 int32
   vm.export @test_bitcast_i32_f32
   vm.func @test_bitcast_i32_f32() {
-    %c1 = vm.const.i32 1085276160
+    %c1 = vm.const.i32 0x40B00000
     %c1dno = util.optimization_barrier %c1 : i32
     %v = vm.bitcast.i32.f32 %c1dno : i32 -> f32
     %c2 = vm.const.f32 5.5
@@ -15,13 +14,12 @@ vm.module @conversion_ops_f32 {
     vm.return
   }
 
-  // 1085276160 int32 (0x40b00000 hex) -> 5.5 f32
   vm.export @test_bitcast_f32_i32
   vm.func @test_bitcast_f32_i32() {
     %c1 = vm.const.f32 5.5
     %c1dno = util.optimization_barrier %c1 : f32
     %v = vm.bitcast.f32.i32 %c1dno : f32 -> i32
-    %c2 = vm.const.i32 1085276160
+    %c2 = vm.const.i32 0x40B00000
     vm.check.eq %v, %c2, "bitcast f32 to i32" : i32
     vm.return
   }

--- a/runtime/src/iree/vm/test/conversion_ops_f64.mlir
+++ b/runtime/src/iree/vm/test/conversion_ops_f64.mlir
@@ -1,0 +1,97 @@
+vm.module @conversion_ops_f64 {
+
+  //===----------------------------------------------------------------------===//
+  // Casting and type conversion/emulation
+  //===----------------------------------------------------------------------===//
+
+  vm.export @test_bitcast_i64_f64
+  vm.func @test_bitcast_i64_f64() {
+    %c1 = vm.const.i64 0x4016000000000000
+    %c1dno = util.optimization_barrier %c1 : i64
+    %v = vm.bitcast.i64.f64 %c1dno : i64 -> f64
+    %c2 = vm.const.f64 5.5
+    vm.check.eq %v, %c2, "bitcast i64 to f64" : f64
+    vm.return
+  }
+
+  vm.export @test_bitcast_f64_i64
+  vm.func @test_bitcast_f64_i64() {
+    %c1 = vm.const.f64 5.5
+    %c1dno = util.optimization_barrier %c1 : f64
+    %v = vm.bitcast.f64.i64 %c1dno : f64 -> i64
+    %c2 = vm.const.i64 0x4016000000000000
+    vm.check.eq %v, %c2, "bitcast f64 to i64" : i64
+    vm.return
+  }
+
+  vm.export @test_cast_si64_f64_int_max
+  vm.func @test_cast_si64_f64_int_max() {
+    %c1 = vm.const.i64 2147483647
+    %c1dno = util.optimization_barrier %c1 : i64
+    %v = vm.cast.si64.f64 %c1dno : i64 -> f64
+    %c2 = vm.const.f64 2147483647.0
+    vm.check.eq %v, %c2, "cast signed integer to a floating-point value" : f64
+    vm.return
+  }
+
+  vm.export @test_cast_si64_f64_int_min
+  vm.func @test_cast_si64_f64_int_min() {
+    %c1 = vm.const.i64 -2147483648
+    %c1dno = util.optimization_barrier %c1 : i64
+    %v = vm.cast.si64.f64 %c1dno : i64 -> f64
+    %c2 = vm.const.f64 -2147483648.0
+    vm.check.eq %v, %c2, "cast signed integer to a floating-point value" : f64
+    vm.return
+  }
+
+  vm.export @test_cast_ui64_f64_int_max
+  vm.func @test_cast_ui64_f64_int_max() {
+    %c1 = vm.const.i64 4294967295
+    %c1dno = util.optimization_barrier %c1 : i64
+    %v = vm.cast.ui64.f64 %c1dno : i64 -> f64
+    %c2 = vm.const.f64 4294967295.0
+    vm.check.eq %v, %c2, "cast unsigned integer to a floating-point value" : f64
+    vm.return
+  }
+
+  vm.export @test_cast_f64_si64_int_min
+  vm.func @test_cast_f64_si64_int_min() {
+    %c1 = vm.const.f64 -2147483648.0
+    %c1dno = util.optimization_barrier %c1 : f64
+    %v = vm.cast.f64.si64 %c1dno : f64 -> i64
+    %c2 = vm.const.i64 -2147483648
+    vm.check.eq %v, %c2, "cast floating-point value to a signed integer" : i64
+    vm.return
+  }
+
+  vm.export @test_cast_f64_si64_away_from_zero_pos
+  vm.func @test_cast_f64_si64_away_from_zero_pos() {
+    %c1 = vm.const.f64 2.5
+    %c1dno = util.optimization_barrier %c1 : f64
+    %v = vm.cast.f64.si64 %c1dno : f64 -> i64
+    %c2 = vm.const.i64 3
+    vm.check.eq %v, %c2, "cast floating-point value to a signed integer" : i64
+    vm.return
+  }
+
+  vm.export @test_cast_f64_si64_away_from_zero_neg
+  vm.func @test_cast_f64_si64_away_from_zero_neg() {
+    %c1 = vm.const.f64 -2.5
+    %c1dno = util.optimization_barrier %c1 : f64
+    %v = vm.cast.f64.si64 %c1dno : f64 -> i64
+    %c2 = vm.const.i64 -3
+    vm.check.eq %v, %c2, "cast floating-point value to a signed integer" : i64
+    vm.return
+  }
+
+  vm.export @test_cast_f64_ui64_away_from_zero
+  vm.func @test_cast_f64_ui64_away_from_zero() {
+    %c1 = vm.const.f64 2.5
+    %c1dno = util.optimization_barrier %c1 : f64
+    %v = vm.cast.f64.ui64 %c1dno : f64 -> i64
+    %c2 = vm.const.i64 3
+    vm.check.eq %v, %c2, "cast floating-point value to a signed integer" : i64
+    vm.return
+  }
+
+}

--- a/runtime/src/iree/vm/test/global_ops_f64.mlir
+++ b/runtime/src/iree/vm/test/global_ops_f64.mlir
@@ -1,0 +1,27 @@
+vm.module @global_ops_f64 {
+
+  //===--------------------------------------------------------------------===//
+  // global.f64
+  //===--------------------------------------------------------------------===//
+
+  vm.global.f64 private @c42 = 42.5 : f64
+  vm.global.f64 private mutable @c107_mut = 107.5 : f64
+
+  vm.export @test_global_load_f64
+  vm.func @test_global_load_f64() {
+    %actual = vm.global.load.f64 @c42 : f64
+    %expected = vm.const.f64 42.5
+    vm.check.eq %actual, %expected, "@c42 != 42.5" : f64
+    vm.return
+  }
+
+  vm.export @test_global_store_f64
+  vm.func @test_global_store_f64() {
+    %c17 = vm.const.f64 17.5
+    vm.global.store.f64 %c17, @c107_mut : f64
+    %actual = vm.global.load.f64 @c107_mut : f64
+    vm.check.eq %actual, %c17, "@c107_mut != 17.5" : f64
+    vm.return
+  }
+
+}


### PR DESCRIPTION
This includes the f64 ops in the runtime outside of the size-optimized build setting. Users who want a smaller runtime can still disable it by setting `-DIREE_VM_EXT_F64_ENABLE=0` and can prevent the compiler from emitting the ops with `--iree-vm-target-extension-f64=false`.

This does not yet flip the demotion flag used by the StableHLO pipeline - that can be done separately for #8826, #10348 and #15830.

emitc support is not added here as the uses for emitc today don't need f64. Someone can add that as needed.

Fixes #8745.
Fixes #6991.