### PR TITLE
Integrate LLVM at `1650f1b3` (clean)

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -668,7 +668,6 @@ static void addLowerToLLVMPasses(OpPassManager &modulePassManager,
         .addPass(createCSEPass)
         .addPass(mlir::createArithToArmSMEConversionPass)
         .addPass(mlir::createConvertVectorToArmSMEPass)
-        .addPass(mlir::arm_sme::createTileAllocationPass)
         .addPass([]() {
           return mlir::arm_sme::createEnableArmStreamingPass(
               mlir::arm_sme::ArmStreamingMode::StreamingLocally,
@@ -703,7 +702,9 @@ static void addLowerToLLVMPasses(OpPassManager &modulePassManager,
                          createInstrumentMemoryAccessesPass);
 
   if (enableAArch64SME) {
-    modulePassManager.addPass(createConvertArmSMEToLLVMPass());
+    FunctionLikeNest(modulePassManager).addPass([&] {
+      return createConvertArmSMEToLLVMPass();
+    });
   }
   modulePassManager.addPass(
       createConvertToLLVMPass(clEnableReassociateFpReductions));


### PR DESCRIPTION
Integrate LLVM at llvm/llvm-project@1650f1b3 without local changes. One upstream change broke the construction of an ARM-related part of a pipeline but a patch had already circulated on Discord and is part of this PR.

The next MLIR-related commit breaks with an ASan failure. I think there is already a patch upstream but I prefer to wrap this up and tackle the next commits separately.