### PR TITLE
[Codegen][GPU] Change iree_gpu.shuffle_tensor to take a region for the read

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -408,35 +408,30 @@ struct LowerShuffleTensor
                                 PatternRewriter &rewriter) const final {
     Location loc = shuffleOp.getLoc();
 
-    MemRefType allocType = shuffleOp.getSharedAllocType();
-    auto tensorType =
-        RankedTensorType::get(allocType.getShape(), allocType.getElementType());
-    Value tensorAlloc = rewriter.create<bufferization::ToTensorOp>(
-        loc, tensorType, shuffleOp.getSharedAlloc(), /*restrict=*/true,
-        /*writeable=*/true);
-
     // Step 1. Insert the source slice into the intermediate tensor.
-    SmallVector<OpFoldResult, 4> sourceOffsets =
-        shuffleOp.getMixedSourceOffsets();
-    SmallVector<OpFoldResult, 4> sourceSizes = shuffleOp.getMixedSourceSizes();
-    SmallVector<OpFoldResult, 4> sourceStrides =
-        shuffleOp.getMixedSourceStrides();
+    SmallVector<OpFoldResult, 4> sourceOffsets = shuffleOp.getMixedOffsets();
+    SmallVector<OpFoldResult, 4> sourceSizes = shuffleOp.getMixedSizes();
+    SmallVector<OpFoldResult, 4> sourceStrides = shuffleOp.getMixedStrides();
     Value insertedSlice = rewriter.create<tensor::InsertSliceOp>(
-        loc, shuffleOp.getSource(), tensorAlloc, sourceOffsets, sourceSizes,
-        sourceStrides);
+        loc, shuffleOp.getSource(), shuffleOp.getDest(), sourceOffsets,
+        sourceSizes, sourceStrides);
 
     // Step 2. Synchronize the workers.
     rewriter.create<gpu::BarrierOp>(loc);
 
-    // Step 3. Extract the result slice.
-    SmallVector<OpFoldResult, 4> resultOffsets =
-        shuffleOp.getMixedResultOffsets();
-    SmallVector<OpFoldResult, 4> resultSizes = shuffleOp.getMixedResultSizes();
-    SmallVector<OpFoldResult, 4> resultStrides =
-        shuffleOp.getMixedResultStrides();
-    rewriter.replaceOpWithNewOp<tensor::ExtractSliceOp>(
-        shuffleOp, shuffleOp.getType(), insertedSlice, resultOffsets,
-        resultSizes, resultStrides);
+    auto terminator = shuffleOp.getBody()->getTerminator();
+    Value replacement = terminator->getOperand(0);
+    rewriter.inlineBlockBefore(shuffleOp.getBody(), shuffleOp, {insertedSlice});
+    rewriter.replaceAllUsesWith(shuffleOp.getResult(), replacement);
+    rewriter.setInsertionPointAfterValue(replacement);
+
+    // Step 2. Synchronize the workers again after reading the shuffled values.
+    // TODO: This barrier is an approximation for what we expect bufferization +
+    // vectorization to produce. There is no guarantee that this barrier is
+    // adhered to, but the way that bufferization and vectorization works
+    // is unfriendly towards barrier-like constructs.
+    rewriter.create<gpu::BarrierOp>(loc);
+    rewriter.eraseOp(terminator);
     return success();
   }
 };
@@ -877,35 +872,27 @@ LogicalResult compareWorkerCountsAndTypes(scf::ForallOp producer,
   return success();
 }
 
-Value getReplacementSlice(RewriterBase &rewriter, Location loc,
-                          tensor::ParallelInsertSliceOp parallelInsert,
-                          tensor::ExtractSliceOp extractSlice,
-                          std::optional<Attribute> addressSpace) {
-  RankedTensorType destTensorType = parallelInsert.getDestType();
-  MemRefType allocType =
-      addressSpace ? MemRefType::get(destTensorType.getShape(),
-                                     destTensorType.getElementType(),
-                                     MemRefLayoutAttrInterface{}, *addressSpace)
-                   : MemRefType::get(destTensorType.getShape(),
-                                     destTensorType.getElementType());
-  Value dest = Value();
-  if (auto empty = parallelInsert.getDest().getDefiningOp<tensor::EmptyOp>()) {
-    OpBuilder::InsertionGuard g(rewriter);
-    rewriter.setInsertionPoint(empty);
-    dest = rewriter.create<memref::AllocOp>(loc, allocType,
-                                            empty.getDynamicSizes());
-  } else {
-    dest = rewriter.create<bufferization::ToMemrefOp>(loc, allocType,
-                                                      parallelInsert.getDest());
-  }
-  return rewriter.create<IREE::GPU::ShuffleTensorOp>(
+void replaceExtractSlice(RewriterBase &rewriter, Location loc,
+                         tensor::ParallelInsertSliceOp parallelInsert,
+                         tensor::ExtractSliceOp extractSlice) {
+  OpBuilder::InsertionGuard g(rewriter);
+  auto shuffleOp = rewriter.create<IREE::GPU::ShuffleTensorOp>(
       loc, extractSlice.getType(), parallelInsert.getSource(),
       parallelInsert.getOffsets(), parallelInsert.getSizes(),
       parallelInsert.getStrides(), parallelInsert.getStaticOffsets(),
-      parallelInsert.getStaticSizes(), parallelInsert.getStaticStrides(), dest,
-      extractSlice.getOffsets(), extractSlice.getSizes(),
-      extractSlice.getStrides(), extractSlice.getStaticOffsets(),
-      extractSlice.getStaticSizes(), extractSlice.getStaticStrides());
+      parallelInsert.getStaticSizes(), parallelInsert.getStaticStrides(),
+      parallelInsert.getDest());
+  Region *region = &shuffleOp.getRegion();
+  rewriter.createBlock(region, region->end(),
+                       ArrayRef<Type>{parallelInsert.getDestType()},
+                       ArrayRef<Location>{loc});
+  rewriter.setInsertionPointToStart(shuffleOp.getBody());
+  auto terminator =
+      rewriter.create<IREE::GPU::YieldOp>(loc, extractSlice.getResult());
+  rewriter.moveOpBefore(extractSlice, terminator);
+  extractSlice.getSourceMutable().assign(shuffleOp.getBody()->getArgument(0));
+  rewriter.replaceAllUsesExcept(extractSlice.getResult(), shuffleOp,
+                                terminator);
 }
 
 LogicalResult fuseForallIntoSlice(RewriterBase &rewriter,
@@ -975,12 +962,9 @@ LogicalResult fuseForallIntoSlice(RewriterBase &rewriter,
   auto parallelInsert =
       cast<tensor::ParallelInsertSliceOp>(*terminator.getYieldingOps().begin());
 
-  Value replacementSlice =
-      getReplacementSlice(rewriter, loc, parallelInsert, slice, addressSpace);
-  rewriter.replaceAllUsesWith(slice, replacementSlice);
+  replaceExtractSlice(rewriter, loc, parallelInsert, slice);
 
   rewriter.eraseOp(parallelInsert);
-  rewriter.eraseOp(slice);
   rewriter.eraseOp(terminator);
   rewriter.eraseOp(producer);
   return success();

--- a/compiler/src/iree/compiler/Codegen/Common/test/transform_lower_shuffle.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/transform_lower_shuffle.mlir
@@ -1,7 +1,11 @@
 // RUN: iree-opt %s -iree-transform-dialect-interpreter -transform-dialect-drop-schedule --split-input-file | FileCheck %s
 
-func.func @shuffle_tensor(%init: memref<6x6xf32>, %arg0: tensor<2x3xf32>, %x: index) -> tensor<3x2xf32> {
-  %0 = iree_gpu.shuffle_tensor %arg0[%x, 0] [2, 3] [1, 1] to %init[0, %x] [3, 2] [1, 1] : tensor<2x3xf32> -> memref<6x6xf32> -> tensor<3x2xf32>
+func.func @shuffle_tensor(%init: tensor<6x6xf32>, %source: tensor<2x3xf32>, %x: index) -> tensor<3x2xf32> {
+  %0 = iree_gpu.shuffle_tensor %source[%x, 0] [2, 3] [1, 1] to %init {
+  ^bb0(%intermediate: tensor<6x6xf32>):
+    %slice = tensor.extract_slice %intermediate[0, %x] [3, 2] [1, 1] : tensor<6x6xf32> to tensor<3x2xf32>
+    iree_gpu.yield %slice : tensor<3x2xf32>
+  } : tensor<2x3xf32> -> tensor<6x6xf32> -> tensor<3x2xf32>
   return %0 : tensor<3x2xf32>
 }
 
@@ -16,22 +20,24 @@ module attributes { transform.with_named_sequence } {
 }
 
 // CHECK-LABEL: func @shuffle_tensor
-//  CHECK-SAME:   %[[INIT:[A-Za-z0-9]+]]: memref<6x6xf32>
+//  CHECK-SAME:   %[[INIT:[A-Za-z0-9]+]]: tensor<6x6xf32>
 //  CHECK-SAME:   %[[ARG1:[A-Za-z0-9]+]]: tensor<2x3xf32>
 //  CHECK-SAME:   %[[X:[A-Za-z0-9]+]]: index
 
-//       CHECK:   %[[TENSOR:.+]] = bufferization.to_tensor %[[INIT]]
-//  CHECK-SAME:     restrict
-//  CHECK-SAME:     writable
-//       CHECK:   %[[IN:.+]] = tensor.insert_slice %[[ARG1]] into %[[TENSOR]][%[[X]], 0] [2, 3] [1, 1] : tensor<2x3xf32> into tensor<6x6xf32>
+//       CHECK:   %[[IN:.+]] = tensor.insert_slice %[[ARG1]] into %[[INIT]][%[[X]], 0] [2, 3] [1, 1] : tensor<2x3xf32> into tensor<6x6xf32>
 //       CHECK:   gpu.barrier
 //       CHECK:   %[[OUT:.+]] = tensor.extract_slice %[[IN]][0, %[[X]]] [3, 2] [1, 1] : tensor<6x6xf32> to tensor<3x2xf32>
+//       CHECK:   gpu.barrier
 //       CHECK:   return %[[OUT]] : tensor<3x2xf32>
 
 // -----
 
-func.func @rank_reducing_shuffle_tensor(%init: memref<1x6x6xf32>, %arg0: tensor<2x3xf32>, %x: index, %y: index) -> tensor<3x2xf32> {
-  %0 = iree_gpu.shuffle_tensor %arg0[0, %x, %y] [1, 2, 3] [1, 1, 1] to %init[0, %y, %x] [1, 3, 2] [1, 1, 1] : tensor<2x3xf32> -> memref<1x6x6xf32> -> tensor<3x2xf32>
+func.func @rank_reducing_shuffle_tensor(%init: tensor<1x6x6xf32>, %source: tensor<2x3xf32>, %x: index, %y: index) -> tensor<3x2xf32> {
+  %0 = iree_gpu.shuffle_tensor %source[0, %x, %y] [1, 2, 3] [1, 1, 1] to %init {
+  ^bb0(%intermediate: tensor<1x6x6xf32>):
+    %slice = tensor.extract_slice %intermediate[0, %y, %x] [1, 3, 2] [1, 1, 1] : tensor<1x6x6xf32> to tensor<3x2xf32>
+    iree_gpu.yield %slice : tensor<3x2xf32>
+  } : tensor<2x3xf32> -> tensor<1x6x6xf32> -> tensor<3x2xf32>
   return %0 : tensor<3x2xf32>
 }
 
@@ -46,14 +52,45 @@ module attributes { transform.with_named_sequence } {
 }
 
 // CHECK-LABEL: func @rank_reducing_shuffle_tensor
-//  CHECK-SAME:   %[[INIT:[A-Za-z0-9]+]]: memref<1x6x6xf32>
+//  CHECK-SAME:   %[[INIT:[A-Za-z0-9]+]]: tensor<1x6x6xf32>
 //  CHECK-SAME:   %[[ARG1:[A-Za-z0-9]+]]: tensor<2x3xf32>
 //  CHECK-SAME:   %[[X:[A-Za-z0-9]+]]: index
 //  CHECK-SAME:   %[[Y:[A-Za-z0-9]+]]: index
 
-//       CHECK:   %[[TENSOR:.+]] = bufferization.to_tensor %[[INIT]]
-//  CHECK-SAME:     restrict
-//  CHECK-SAME:     writable
-//       CHECK:   %[[IN:.+]] = tensor.insert_slice %[[ARG1]] into %[[TENSOR]][0, %[[X]], %[[Y]]] [1, 2, 3] [1, 1, 1] : tensor<2x3xf32> into tensor<1x6x6xf32>
+//       CHECK:   %[[IN:.+]] = tensor.insert_slice %[[ARG1]] into %[[INIT]][0, %[[X]], %[[Y]]] [1, 2, 3] [1, 1, 1] : tensor<2x3xf32> into tensor<1x6x6xf32>
 //       CHECK:   gpu.barrier
-//       CHECK:   tensor.extract_slice %[[IN]][0, %[[Y]], %[[X]]] [1, 3, 2] [1, 1, 1] : tensor<1x6x6xf32> to tensor<3x2xf32>
+//       CHECK:   %[[OUT:.+]] = tensor.extract_slice %[[IN]][0, %[[Y]], %[[X]]] [1, 3, 2] [1, 1, 1] : tensor<1x6x6xf32> to tensor<3x2xf32>
+//       CHECK:   gpu.barrier
+//       CHECK:   return %[[OUT]]
+
+// -----
+
+func.func @reshape_shuffle_tensor(%init: tensor<12x12xf32>, %source: tensor<2x3xf32>) -> tensor<2x1x3x2xf32> {
+  %0 = iree_gpu.shuffle_tensor %source[0, 0] [2, 3] [1, 1] to %init {
+  ^bb0(%intermediate: tensor<12x12xf32>):
+    %expand = tensor.expand_shape %intermediate [[0, 1], [2, 3]] output_shape [4, 3, 3, 4] : tensor<12x12xf32> into tensor<4x3x3x4xf32>
+    %slice = tensor.extract_slice %expand[0, 0, 0, 0] [2, 1, 3, 2] [1, 1, 1, 1] : tensor<4x3x3x4xf32> to tensor<2x1x3x2xf32>
+    iree_gpu.yield %slice : tensor<2x1x3x2xf32>
+  } : tensor<2x3xf32> -> tensor<12x12xf32> -> tensor<2x1x3x2xf32>
+  return %0 : tensor<2x1x3x2xf32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.lower_shuffle_tensor
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @reshape_shuffle_tensor
+//  CHECK-SAME:   %[[INIT:[A-Za-z0-9]+]]: tensor<12x12xf32>
+//  CHECK-SAME:   %[[ARG1:[A-Za-z0-9]+]]: tensor<2x3xf32>
+
+//       CHECK:   %[[IN:.+]] = tensor.insert_slice %[[ARG1]] into %[[INIT]][0, 0] [2, 3] [1, 1] : tensor<2x3xf32> into tensor<12x12xf32>
+//       CHECK:   gpu.barrier
+//       CHECK:   %[[EXPAND:.+]] = tensor.expand_shape %[[IN]] {{\[}}[0, 1], [2, 3]{{\]}} output_shape [4, 3, 3, 4] : tensor<12x12xf32> into tensor<4x3x3x4xf32>
+//       CHECK:   tensor.extract_slice %[[EXPAND]][0, 0, 0, 0] [2, 1, 3, 2] [1, 1, 1, 1] : tensor<4x3x3x4xf32> to tensor<2x1x3x2xf32>
+//       CHECK:   gpu.barrier

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
@@ -31,6 +31,7 @@ iree_td_library(
         include = ["*.td"],
     ),
     deps = [
+        "@llvm-project//mlir:ControlFlowInterfacesTdFiles",
         "@llvm-project//mlir:OpBaseTdFiles",
         "@llvm-project//mlir:SideEffectInterfacesTdFiles",
     ],
@@ -69,6 +70,7 @@ iree_compiler_cc_library(
         "//llvm-external-projects/iree-dialects:IREEVectorExtDialect",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AMDGPUDialect",
+        "@llvm-project//mlir:ControlFlowInterfaces",
         "@llvm-project//mlir:DialectUtils",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LinalgDialect",

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/CMakeLists.txt
@@ -40,6 +40,7 @@ iree_cc_library(
     IREEVectorExtDialect
     LLVMSupport
     MLIRAMDGPUDialect
+    MLIRControlFlowInterfaces
     MLIRIR
     MLIRLinalgDialect
     MLIRParser

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -25,38 +25,46 @@ namespace mlir::iree_compiler::IREE::GPU {
 
 LogicalResult ShuffleTensorOp::verify() {
   // Get the equivalent tensor type for the alloc to verify against.
-  MemRefType allocType = getSharedAllocType();
-  Type allocElementType = allocType.getElementType();
+  RankedTensorType destType = getDestType();
+  Type allocElementType = destType.getElementType();
   RankedTensorType allocTensorType =
-      RankedTensorType::get(allocType.getShape(), allocElementType);
+      RankedTensorType::get(destType.getShape(), allocElementType);
 
   // Verify source type against inferred type. Slice insertion and extraction
   // use the same verification logic.
   RankedTensorType expectedType = tensor::ExtractSliceOp::inferResultType(
-      allocTensorType, getMixedSourceOffsets(), getMixedSourceSizes(),
-      getMixedSourceStrides());
+      allocTensorType, getMixedOffsets(), getMixedSizes(), getMixedStrides());
   SliceVerificationResult result =
       isRankReducedType(expectedType, getSourceType());
   if (result != SliceVerificationResult::Success) {
     return emitError("Invalid source slice type");
   }
 
-  // Do the same for the resulting tensor type
-  expectedType = tensor::ExtractSliceOp::inferResultType(
-      allocTensorType, getMixedResultOffsets(), getMixedResultSizes(),
-      getMixedResultStrides());
-  result = isRankReducedType(expectedType, getType());
-  if (result != SliceVerificationResult::Success) {
-    return emitError("Invalid result slice type");
-  }
-
   if (allocElementType != getSourceType().getElementType() ||
       allocElementType != getType().getElementType()) {
-    return emitError(
-        "Element type mismatch between source, allocation, and result");
+    return emitError("Element type mismatch between source and destination");
+  }
+  return success();
+}
+
+LogicalResult ShuffleTensorOp::verifyRegions() {
+  auto &region = getRegion();
+  Block &block = region.front();
+  if (block.getNumArguments() != 1) {
+    return emitError("expected the block to have a single argument");
   }
 
-  // TODO: Verification of the allocation size in the static case.
+  if (block.getArgumentTypes()[0] != getDestType()) {
+    return emitError("expected block to have single argument type of")
+           << getDestType();
+  }
+
+  // Ensure that the region yields an element of the right type.
+  auto yieldOp = llvm::cast<GPU::YieldOp>(block.getTerminator());
+  if (yieldOp.getValue().getType() != getResult().getType()) {
+    return emitOpError("expected yield type to match result type");
+  }
+
   return success();
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h
@@ -13,6 +13,7 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/Operation.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
 // clang-format off

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -8,6 +8,7 @@
 #define IREE_CODEGEN_DIALECT_IREEGPUOPS
 
 include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.td"
+include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/OpBase.td"
@@ -18,7 +19,8 @@ include "mlir/IR/OpBase.td"
 
 def IREEGPU_ShuffleTensorOp : Op<IREEGPU_Dialect, "shuffle_tensor", [
     Pure,
-    AttrSizedOperandSegments
+    AttrSizedOperandSegments,
+    SingleBlockImplicitTerminator<"mlir::iree_compiler::IREE::GPU::YieldOp">
     ]> {
   let summary = "Shuffles a private tensor across a shared allocation";
   let description = [{
@@ -51,32 +53,36 @@ def IREEGPU_ShuffleTensorOp : Op<IREEGPU_Dialect, "shuffle_tensor", [
     boundary of the loops currently is.
 
     ```mlir
-      %alloc = bufferization.to_memref %empty
       %0 = scf.forall (%idy, %idx) in (8, 8) -> (tensor<4x128xf32>) {
         %ids = affine.delinearize_index %idy * 8 + %idx to (2, 32) : index
         %in = ...
         %2 = affine.apply #affine_map<(d0) -> (d0 * 2)> (%ids#0)
         %3 = affine.apply #affine_map<(d0) -> (d0 * 4)> (%ids#1)
         %4 = affine.apply #affine_map<(d0) -> (d0 * 16)> (%idx)
-        %slice = iree_gpu.shuffle_tensor %in[%2, %3] [2, 4] [1, 1] to %alloc[0, %4] [4, 16] [1, 1]
-          : tensor<2x4xf32> -> memref<4x128xf32> -> tensor<4x16xf32>
+        %slice = iree_gpu.shuffle_tensor %in[%2, %3] [2, 4] [1, 1] to %empty {
+        ^bb0(%intermediate: tensor<4x128xf32>):
+          %slice = tensor.extract_slice %intermediate[0, %4] [4, 16] [1, 1] : tensor<4x128xf32> to tensor<4x16xf32>
+          iree_gpu.yield %slice : tensor<4x16xf32>
+        } : tensor<2x4xf32> -> tensor<4x128xf32> -> tensor<4x16xf32>
         ...
       } {mapping = [#gpu.thread<y>, #gpu.thread<x>]}
     ```
 
     A shuffle can be lowered to a shared allocation with a write of the source
-    slice, a barrier, and a read of the result slice. Note that to avoid both
-    conflicting writes, and to execute the barrier, this renders any lowerings
-    of the enclosing `scf.forall` to serial loops invalid. In other words, the
-    lowerings/hardware must provide the number of workers requested by the loop.
+    slice, a barrier, inlining the body of the shuffle op (the read), and then
+    a barrier to synchronize all workers on the result of the read. Note that
+    it is undefined behavior if there are any conflicting writes to the
+    intermediate. Also to execute the barrier, any lowerings of the enclosing
+    `scf.forall` to serial loops is invalid. In other words, the lowerings must
+    provide the number of workers requested by the loop.
 
     This op takes an input |source| tensor to represent the slice held by this
-    worker before the shuffle, an intermediate memref |shared_alloc| that all
-    workers insert into, and yields a |result| slice of the intermediate memref
-    read by this worker after the shuffle is done.
+    worker before the shuffle, an intermediate tensor |dest| that all workers
+    insert into, and performs a synchronized read from that intermediate
+    tensor.
 
-    It is undefined behavior if the source or result tensor slices are out of
-    bounds of the intermediate allocation.
+    It is undefined behavior if the source tensor is out of bounds of the
+    intermediate allocation.
 
     Movtivation and Intended Use Cases:
 
@@ -94,34 +100,24 @@ def IREEGPU_ShuffleTensorOp : Op<IREEGPU_Dialect, "shuffle_tensor", [
 
   let arguments = (ins
     AnyRankedTensor:$source,
-    Variadic<Index>:$source_offsets,
-    Variadic<Index>:$source_sizes,
-    Variadic<Index>:$source_strides,
-    DenseI64ArrayAttr:$static_source_offsets,
-    DenseI64ArrayAttr:$static_source_sizes,
-    DenseI64ArrayAttr:$static_source_strides,
-    AnyMemRef:$shared_alloc,
-    Variadic<Index>:$result_offsets,
-    Variadic<Index>:$result_sizes,
-    Variadic<Index>:$result_strides,
-    DenseI64ArrayAttr:$static_result_offsets,
-    DenseI64ArrayAttr:$static_result_sizes,
-    DenseI64ArrayAttr:$static_result_strides
+    Variadic<Index>:$offsets,
+    Variadic<Index>:$sizes,
+    Variadic<Index>:$strides,
+    DenseI64ArrayAttr:$static_offsets,
+    DenseI64ArrayAttr:$static_sizes,
+    DenseI64ArrayAttr:$static_strides,
+    AnyRankedTensor:$dest
   );
-  let results = (outs
-    AnyRankedTensor:$result
-  );
+  let regions = (region SizedRegion<1>:$region);
+  let results = (outs AnyRankedTensor:$result);
 
   let assemblyFormat = [{
     $source ``
-    custom<DynamicIndexList>($source_offsets, $static_source_offsets)
-    custom<DynamicIndexList>($source_sizes, $static_source_sizes)
-    custom<DynamicIndexList>($source_strides, $static_source_strides)
-    `to` $shared_alloc
-    custom<DynamicIndexList>($result_offsets, $static_result_offsets)
-    custom<DynamicIndexList>($result_sizes, $static_result_sizes)
-    custom<DynamicIndexList>($result_strides, $static_result_strides)
-    attr-dict `:` type($source) `->` type($shared_alloc) `->` type($result)
+    custom<DynamicIndexList>($offsets, $static_offsets)
+    custom<DynamicIndexList>($sizes, $static_sizes)
+    custom<DynamicIndexList>($strides, $static_strides)
+    `to` $dest $region attr-dict
+    `:` type($source) `->` type($dest) `->` type($result)
   }];
 
   let extraClassDeclaration = [{
@@ -129,49 +125,47 @@ def IREEGPU_ShuffleTensorOp : Op<IREEGPU_Dialect, "shuffle_tensor", [
       return getSource().getType();
     }
 
-    MemRefType getSharedAllocType() {
-      return getSharedAlloc().getType();
+    RankedTensorType getDestType() {
+      return getDest().getType();
     }
-
-    // Because we have two sets of offsets/sizes/strides, we cannot use
-    // interface boilerplate and instead redefine it.
 
     // Source slice view-like getters.
-    ::llvm::SmallVector<::mlir::OpFoldResult, 4> getMixedSourceOffsets() {
+    ::llvm::SmallVector<::mlir::OpFoldResult, 4> getMixedOffsets() {
       Builder b(getContext());
-      return ::mlir::getMixedValues(getStaticSourceOffsets(),
-                                    getSourceOffsets(), b);
+      return ::mlir::getMixedValues(getStaticOffsets(),
+                                    getOffsets(), b);
     }
-    ::llvm::SmallVector<::mlir::OpFoldResult, 4> getMixedSourceSizes() {
+    ::llvm::SmallVector<::mlir::OpFoldResult, 4> getMixedSizes() {
       Builder b(getContext());
-      return ::mlir::getMixedValues(getStaticSourceSizes(),
-                                    getSourceSizes(), b);
+      return ::mlir::getMixedValues(getStaticSizes(),
+                                    getSizes(), b);
     }
-    ::llvm::SmallVector<::mlir::OpFoldResult, 4> getMixedSourceStrides() {
+    ::llvm::SmallVector<::mlir::OpFoldResult, 4> getMixedStrides() {
       Builder b(getContext());
-      return ::mlir::getMixedValues(getStaticSourceStrides(),
-                                    getSourceStrides(), b);
-    }
-
-    // Result slice view-like getters.
-    ::llvm::SmallVector<::mlir::OpFoldResult, 4> getMixedResultOffsets() {
-      Builder b(getContext());
-      return ::mlir::getMixedValues(getStaticResultOffsets(),
-                                    getResultOffsets(), b);
-    }
-    ::llvm::SmallVector<::mlir::OpFoldResult, 4> getMixedResultSizes() {
-      Builder b(getContext());
-      return ::mlir::getMixedValues(getStaticResultSizes(),
-                                    getResultSizes(), b);
-    }
-    ::llvm::SmallVector<::mlir::OpFoldResult, 4> getMixedResultStrides() {
-      Builder b(getContext());
-      return ::mlir::getMixedValues(getStaticResultStrides(),
-                                    getResultStrides(), b);
+      return ::mlir::getMixedValues(getStaticStrides(),
+                                    getStrides(), b);
     }
   }];
 
   let hasVerifier = 1;
+  let hasRegionVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// YieldOp
+//===----------------------------------------------------------------------===//
+
+def IREEGPU_YieldOp : Op<IREEGPU_Dialect, "yield", [
+    Pure, ReturnLike, Terminator,
+    HasParent<"::mlir::iree_compiler::IREE::GPU::ShuffleTensorOp">]> {
+  let summary = "Yield a value from a region";
+  let description = [{
+     This operation is used to yield a single value from a within a region.
+  }];
+
+  let arguments = (ins AnyType:$value);
+  let assemblyFormat = "$value attr-dict `:` type($value)";
+  let builders = [OpBuilder<(ins), [{ /* nothing to do */ }]>];
 }
 
 #endif // IREE_CODEGEN_DIALECT_IREEGPUOPS

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
@@ -1,32 +1,53 @@
 // RUN: iree-opt %s --split-input-file | FileCheck %s
 
-func.func @shuffle_tensor(%init: memref<6x6xf32>, %arg0: tensor<2x3xf32>) -> tensor<3x2xf32> {
-  %0 = iree_gpu.shuffle_tensor %arg0[0, 0] [2, 3] [1, 1] to %init[0, 0] [3, 2] [1, 1] : tensor<2x3xf32> -> memref<6x6xf32> -> tensor<3x2xf32>
+func.func @shuffle_tensor(%init: tensor<6x6xf32>, %source: tensor<2x3xf32>) -> tensor<3x2xf32> {
+  %0 = iree_gpu.shuffle_tensor %source[0, 0] [2, 3] [1, 1] to %init {
+  ^bb0(%intermediate: tensor<6x6xf32>):
+    %slice = tensor.extract_slice %intermediate[0, 0] [3, 2] [1, 1] : tensor<6x6xf32> to tensor<3x2xf32>
+    iree_gpu.yield %slice : tensor<3x2xf32>
+  } : tensor<2x3xf32> -> tensor<6x6xf32> -> tensor<3x2xf32>
   return %0 : tensor<3x2xf32>
 }
 
 // CHECK-LABEL: func @shuffle_tensor
-//       CHECK:   iree_gpu.shuffle_tensor %arg1[0, 0] [2, 3] [1, 1] to
-//  CHECK-SAME:     %arg0 [0, 0] [3, 2] [1, 1] : tensor<2x3xf32> -> memref<6x6xf32> -> tensor<3x2xf32>
+//       CHECK:   iree_gpu.shuffle_tensor %arg1[0, 0] [2, 3] [1, 1] to %arg0 {
+//       CHECK:     ^bb0(%[[INTERMEDIATE:.+]]: tensor<6x6xf32>):
+//       CHECK:       %[[SLICE:.+]] = tensor.extract_slice %[[INTERMEDIATE]][0, 0] [3, 2] [1, 1] : tensor<6x6xf32> to tensor<3x2xf32>
+//       CHECK:       iree_gpu.yield %[[SLICE]] : tensor<3x2xf32>
+//       CHECK:   } : tensor<2x3xf32> -> tensor<6x6xf32> -> tensor<3x2xf32>
 
 // -----
 
-func.func @rank_reducing_shuffle_tensor(%init: memref<1x6x6xf32>, %arg0: tensor<2x3xf32>) -> tensor<3x2xf32> {
-  %0 = iree_gpu.shuffle_tensor %arg0[0, 0, 0] [1, 2, 3] [1, 1, 1] to %init[0, 0, 0] [1, 3, 2] [1, 1, 1] : tensor<2x3xf32> -> memref<1x6x6xf32> -> tensor<3x2xf32>
+func.func @rank_reducing_shuffle_tensor(%init: tensor<1x6x6xf32>, %source: tensor<2x3xf32>) -> tensor<3x2xf32> {
+  %0 = iree_gpu.shuffle_tensor %source[0, 0, 0] [1, 2, 3] [1, 1, 1] to %init {
+  ^bb0(%intermediate: tensor<1x6x6xf32>):
+    %slice = tensor.extract_slice %intermediate[0, 0, 0] [1, 3, 2] [1, 1, 1] : tensor<1x6x6xf32> to tensor<3x2xf32>
+    iree_gpu.yield %slice : tensor<3x2xf32>
+  } : tensor<2x3xf32> -> tensor<1x6x6xf32> -> tensor<3x2xf32>
   return %0 : tensor<3x2xf32>
 }
 
 // CHECK-LABEL: func @rank_reducing_shuffle_tensor
-//       CHECK:   iree_gpu.shuffle_tensor %arg1[0, 0, 0] [1, 2, 3] [1, 1, 1] to
-//  CHECK-SAME:     %arg0 [0, 0, 0] [1, 3, 2] [1, 1, 1] : tensor<2x3xf32> -> memref<1x6x6xf32> -> tensor<3x2xf32>
+//       CHECK:   iree_gpu.shuffle_tensor %arg1[0, 0, 0] [1, 2, 3] [1, 1, 1] to %arg0 {
+//       CHECK:     ^bb0(%[[INTERMEDIATE:.+]]: tensor<1x6x6xf32>):
+//       CHECK:       %[[SLICE:.+]] = tensor.extract_slice %[[INTERMEDIATE]][0, 0, 0] [1, 3, 2] [1, 1, 1] : tensor<1x6x6xf32> to tensor<3x2xf32>
+//       CHECK:       iree_gpu.yield %[[SLICE]] : tensor<3x2xf32>
+//       CHECK:   } : tensor<2x3xf32> -> tensor<1x6x6xf32> -> tensor<3x2xf32>
 
 // -----
 
-func.func @dynamic_alloc_shuffle_tensor(%init: memref<?x?xf32>, %arg0: tensor<2x3xf32>) -> tensor<3x2xf32> {
-  %0 = iree_gpu.shuffle_tensor %arg0[0, 0] [2, 3] [1, 1] to %init[0, 0] [3, 2] [1, 1] : tensor<2x3xf32> -> memref<?x?xf32> -> tensor<3x2xf32>
-  return %0 : tensor<3x2xf32>
+func.func @reshape_shuffle_tensor(%init: tensor<12x12xf32>, %source: tensor<2x3xf32>) -> tensor<2x1x3x2xf32> {
+  %0 = iree_gpu.shuffle_tensor %source[0, 0] [2, 3] [1, 1] to %init {
+  ^bb0(%intermediate: tensor<12x12xf32>):
+    %expand = tensor.expand_shape %intermediate [[0, 1], [2, 3]] output_shape [4, 3, 3, 4] : tensor<12x12xf32> into tensor<4x3x3x4xf32>
+    %slice = tensor.extract_slice %expand[0, 0, 0, 0] [2, 1, 3, 2] [1, 1, 1, 1] : tensor<4x3x3x4xf32> to tensor<2x1x3x2xf32>
+    iree_gpu.yield %slice : tensor<2x1x3x2xf32>
+  } : tensor<2x3xf32> -> tensor<12x12xf32> -> tensor<2x1x3x2xf32>
+  return %0 : tensor<2x1x3x2xf32>
 }
 
-// CHECK-LABEL: func @dynamic_alloc_shuffle_tensor
-//       CHECK:   iree_gpu.shuffle_tensor %arg1[0, 0] [2, 3] [1, 1] to
-//  CHECK-SAME:     %arg0 [0, 0] [3, 2] [1, 1] : tensor<2x3xf32> -> memref<?x?xf32> -> tensor<3x2xf32>
+// CHECK-LABEL: func @reshape_shuffle_tensor
+//       CHECK:   iree_gpu.shuffle_tensor
+//       CHECK:       tensor.expand_shape
+//       CHECK:       tensor.extract_slice
+//       CHECK:   } : tensor<2x3xf32> -> tensor<12x12xf32> -> tensor<2x1x3x2xf32>


### PR DESCRIPTION
This simplifies the number of fields required for the ops and enables including reshaping of the intermediate allocation without needing to add fields to the op ad infinitum.

This change has another motivation due to an issue arising from alloc reuse that naturally arises from hoisting static allocations out of loops. In short, such hoisting (and bufferization) requires a synchronization not only on the write to the allocation, but also after all reads have completed due to reusing the same allocation for each iteration of the loop. This dependency is not modeled with SSA before or after bufferization, meaning the fact that this operation represents both the write and the reads is saving us with some spooky action at a distance. This missing dependency needs more investigation in the future, but it is unclear to me at the moment how to navigate bufferization and vectorization currently. I suspect we will end up wanting a vectorization pattern for this operation, but I'm leaving that as TODO for now.

This also makes the intermediate type a tensor again because we were just using `bufferization.to_memref` before to get back to a tensor and the generated IR was unnatural. Perhaps worth another look in the future as well.