### PR TITLE
[Codegen][GPU] Add pattern to distribute multi_mma ops to lanes

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
@@ -71,6 +71,8 @@ iree_compiler_cc_library(
         "//llvm-external-projects/iree-dialects:IREEVectorExtDialect",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AMDGPUDialect",
+        "@llvm-project//mlir:AffineDialect",
+        "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:DialectUtils",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LinalgDialect",

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/CMakeLists.txt
@@ -40,6 +40,8 @@ iree_cc_library(
     IREEVectorExtDialect
     LLVMSupport
     MLIRAMDGPUDialect
+    MLIRAffineDialect
+    MLIRArithDialect
     MLIRIR
     MLIRLinalgDialect
     MLIRParser

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -16,6 +16,8 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
@@ -545,6 +547,140 @@ FailureOr<Value> MMAAttr::buildMmaOperation(OpBuilder &builder, Location loc,
   }
   }
   return failure();
+}
+
+static SmallVector<int64_t>
+getRankReducedSingleSubgroupShape(const MMAAttr::SingleSubgroupLayout &counts) {
+  SmallVector<int64_t> rankReducedShape;
+  for (auto [outer, thread, element] :
+       llvm::zip_equal(counts.outer, counts.thread, counts.element)) {
+    if (outer != 1) {
+      rankReducedShape.push_back(outer);
+    }
+    rankReducedShape.push_back(thread * element);
+  }
+  return rankReducedShape;
+}
+
+// Generates amdgpu.mfma/wmma operation on the given inputs for this attribute
+// type.
+static LogicalResult populateCanonicalOffsetsSizesAndStrides(
+    OpBuilder &builder, Location loc, Value laneId,
+    ArrayRef<int64_t> permutation, MMAAttr::SingleSubgroupLayout counts,
+    MMAAttr::SingleSubgroupLayout orders,
+    SmallVector<OpFoldResult> &canonicalOffsets,
+    SmallVector<OpFoldResult> &canonicalSizes,
+    SmallVector<OpFoldResult> &canonicalStrides) {
+  SmallVector<int64_t> rankReducedShape;
+  for (auto [outer, thread, element] :
+       llvm::zip_equal(counts.outer, counts.thread, counts.element)) {
+    if (outer != 1) {
+      rankReducedShape.push_back(outer);
+    }
+    rankReducedShape.push_back(thread * element);
+  }
+
+  if (permutation.size() != rankReducedShape.size()) {
+    return failure();
+  }
+
+  OpFoldResult zero = builder.getIndexAttr(0);
+  OpFoldResult one = builder.getIndexAttr(1);
+  canonicalStrides.append(rankReducedShape.size(), one);
+
+  SmallVector<int64_t> threadDimSizes =
+      applyPermutation(counts.thread, orders.thread);
+  SmallVector<Value> basis;
+  for (auto dimSize : threadDimSizes) {
+    basis.push_back(builder.create<arith::ConstantIndexOp>(loc, dimSize));
+  }
+  SmallVector<Value> threadIds =
+      builder.create<affine::AffineDelinearizeIndexOp>(loc, laneId, basis)
+          .getResults();
+  applyPermutationToVector(threadIds, orders.thread);
+
+  int64_t idx = 0;
+  for (auto [outer, thread, element] :
+       llvm::zip_equal(counts.outer, counts.thread, counts.element)) {
+    if (outer != 1) {
+      canonicalSizes.push_back(builder.getIndexAttr(outer));
+      canonicalOffsets.push_back(zero);
+    }
+    canonicalSizes.push_back(builder.getIndexAttr(element));
+    canonicalOffsets.push_back(threadIds[idx++]);
+  }
+  applyPermutationToVector(canonicalOffsets, permutation);
+  applyPermutationToVector(canonicalSizes, permutation);
+  return success();
+}
+
+LogicalResult MMAAttr::populateLhsOffsetsSizesStrides(
+    OpBuilder &builder, Location loc, Value laneId,
+    ArrayRef<int64_t> permutation, SmallVector<OpFoldResult> &offsets,
+    SmallVector<OpFoldResult> &sizes,
+    SmallVector<OpFoldResult> &strides) const {
+  if (getIntrinsic().getValue() != MMAIntrinsic::MFMA_F16_16x16x16_F32) {
+    return failure();
+  }
+
+  SmallVector<OpFoldResult> canonicalOffsets;
+  SmallVector<OpFoldResult> canonicalSizes;
+  if (failed(populateCanonicalOffsetsSizesAndStrides(
+          builder, loc, laneId, permutation, getASingleSubgroupLayoutCount(),
+          getASingleSubgroupLayoutOrder(), canonicalOffsets, canonicalSizes,
+          strides))) {
+    return failure();
+  }
+  offsets.append(canonicalOffsets);
+  sizes.append(canonicalSizes);
+
+  return success();
+}
+
+LogicalResult MMAAttr::populateRhsOffsetsSizesStrides(
+    OpBuilder &builder, Location loc, Value laneId,
+    ArrayRef<int64_t> permutation, SmallVector<OpFoldResult> &offsets,
+    SmallVector<OpFoldResult> &sizes,
+    SmallVector<OpFoldResult> &strides) const {
+  if (getIntrinsic().getValue() != MMAIntrinsic::MFMA_F16_16x16x16_F32) {
+    return failure();
+  }
+
+  SmallVector<OpFoldResult> canonicalOffsets;
+  SmallVector<OpFoldResult> canonicalSizes;
+  if (failed(populateCanonicalOffsetsSizesAndStrides(
+          builder, loc, laneId, permutation, getBSingleSubgroupLayoutCount(),
+          getBSingleSubgroupLayoutOrder(), canonicalOffsets, canonicalSizes,
+          strides))) {
+    return failure();
+  }
+  offsets.append(canonicalOffsets);
+  sizes.append(canonicalSizes);
+
+  return success();
+}
+
+LogicalResult MMAAttr::populateAccOffsetsSizesStrides(
+    OpBuilder &builder, Location loc, Value laneId,
+    ArrayRef<int64_t> permutation, SmallVector<OpFoldResult> &offsets,
+    SmallVector<OpFoldResult> &sizes,
+    SmallVector<OpFoldResult> &strides) const {
+  if (getIntrinsic().getValue() != MMAIntrinsic::MFMA_F16_16x16x16_F32) {
+    return failure();
+  }
+
+  SmallVector<OpFoldResult> canonicalOffsets;
+  SmallVector<OpFoldResult> canonicalSizes;
+  if (failed(populateCanonicalOffsetsSizesAndStrides(
+          builder, loc, laneId, permutation, getCSingleSubgroupLayoutCount(),
+          getCSingleSubgroupLayoutOrder(), canonicalOffsets, canonicalSizes,
+          strides))) {
+    return failure();
+  }
+  offsets.append(canonicalOffsets);
+  sizes.append(canonicalSizes);
+
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -45,6 +45,9 @@ class IREEGPU_MmaVectorLayoutAttr<string attrname, string mmaintrinsic> :
     "getMNKShape",
     "getSubgroupSize",
     "buildMmaOperation",
+    "populateLhsOffsetsSizesStrides",
+    "populateRhsOffsetsSizesStrides",
+    "populateAccOffsetsSizesStrides",
   ]>
 ]> {
   let cppNamespace = "::mlir::iree_compiler::IREE::GPU";

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.td
@@ -104,6 +104,69 @@ def IREEGPU_MmaInterfaceAttr : AttrInterface<"MmaInterfaceAttr"> {
         return failure();
       }]
     >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Constructs the offsets/sizes/strides for extracting the per-thread
+        slice of the LHS.
+      }],
+      /*retTy=*/"::mlir::LogicalResult",
+      /*methodName=*/"populateLhsOffsetsSizesStrides",
+      /*args=*/(ins
+        "::mlir::OpBuilder&":$builder,
+        "::mlir::Location":$loc,
+        "::mlir::Value":$lane_id,
+        "::llvm::ArrayRef<int64_t>":$permutation,
+        "::llvm::SmallVector<::mlir::OpFoldResult>&":$offsets,
+        "::llvm::SmallVector<::mlir::OpFoldResult>&":$sizes,
+        "::llvm::SmallVector<::mlir::OpFoldResult>&":$strides
+      ),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return failure();
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Constructs the offsets/sizes/strides for extracting the per-thread
+        slice of the RHS.
+      }],
+      /*retTy=*/"::mlir::LogicalResult",
+      /*methodName=*/"populateRhsOffsetsSizesStrides",
+      /*args=*/(ins
+        "::mlir::OpBuilder&":$builder,
+        "::mlir::Location":$loc,
+        "::mlir::Value":$lane_id,
+        "::llvm::ArrayRef<int64_t>":$permutation,
+        "::llvm::SmallVector<::mlir::OpFoldResult>&":$offsets,
+        "::llvm::SmallVector<::mlir::OpFoldResult>&":$sizes,
+        "::llvm::SmallVector<::mlir::OpFoldResult>&":$strides
+      ),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return failure();
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Constructs the offsets/sizes/strides for extracting the per-thread
+        slice of the accumulator/result.
+      }],
+      /*retTy=*/"::mlir::LogicalResult",
+      /*methodName=*/"populateAccOffsetsSizesStrides",
+      /*args=*/(ins
+        "::mlir::OpBuilder&":$builder,
+        "::mlir::Location":$loc,
+        "::mlir::Value":$lane_id,
+        "::llvm::ArrayRef<int64_t>":$permutation,
+        "::llvm::SmallVector<::mlir::OpFoldResult>&":$offsets,
+        "::llvm::SmallVector<::mlir::OpFoldResult>&":$sizes,
+        "::llvm::SmallVector<::mlir::OpFoldResult>&":$strides
+      ),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return failure();
+      }]
+    >,
   ];
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/IREEGPUExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/IREEGPUExtensionsOps.td
@@ -100,4 +100,34 @@ def ConvertToMultiMmaOp : Op<Transform_Dialect, "iree.convert_to_multi_mma",
   }];
 }
 
+def DistributeMultiMmaOp : Op<Transform_Dialect, "iree.distribute_multi_mma",
+    [TransformEachOpTrait,
+     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     TransformOpInterface,
+     ReportTrackingListenerFailuresOpTrait]> {
+  let description = [{
+    Distributes the target multi_mma op to lanes.
+
+    #### Return modes
+    Emits a definite failure if the target is not an iree_gpu.multi_mma op or
+    if it fails to distribute.
+  }];
+
+  let arguments = (ins TransformHandleTypeInterface:$target);
+  let results = (outs TransformHandleTypeInterface:$result);
+
+  let assemblyFormat = [{
+    $target attr-dict `:` functional-type(operands, results)
+  }];
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::transform::TransformRewriter &rewriter,
+        ::mlir::Operation *target,
+        ::mlir::transform::ApplyToEachResultList &results,
+        ::mlir::transform::TransformState &state);
+  }];
+}
+
 #endif // IREE_COMPILER_CODEGEN_DIALECT_GPU_TRANSFORMEXTENSIONS_IREEGPUEXTENSIONS

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/BUILD.bazel
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     srcs = enforce_glob(
         [
             "convert_to_multi_mma.mlir",
+            "distribute_multi_mma.mlir",
             "drop_multi_mma_unit_dims.mlir",
             "lower_multi_mma.mlir",
             "vectorize_multi_mma.mlir",

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "convert_to_multi_mma.mlir"
+    "distribute_multi_mma.mlir"
     "drop_multi_mma_unit_dims.mlir"
     "lower_multi_mma.mlir"
     "unroll_multi_mma.mlir"

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/distribute_multi_mma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/distribute_multi_mma.mlir
@@ -1,0 +1,50 @@
+// RUN: iree-opt %s -iree-transform-dialect-interpreter -transform-dialect-drop-schedule --split-input-file | FileCheck %s
+
+#contraction_accesses = [
+ affine_map<(i, j, k) -> (i, k)>,
+ affine_map<(i, j, k) -> (k, j)>,
+ affine_map<(i, j, k) -> (i, j)>
+]
+func.func @distribute_multi_mma_16x16x16(%lhs: tensor<2x2x16x16xf16>, %rhs: tensor<2x2x16x16xf16>, %acc: tensor<2x2x16x16xf32>) -> tensor<2x2x16x16xf32> {
+  %0 = iree_gpu.multi_mma %lhs, %rhs, %acc {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<reduction>],
+    kind = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>
+  } : tensor<2x2x16x16xf16>, tensor<2x2x16x16xf16> into tensor<2x2x16x16xf32>
+  return %0 : tensor<2x2x16x16xf32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %multi_mma = transform.structured.match ops{["iree_gpu.multi_mma"]} in %root : (!transform.any_op) -> !transform.any_op
+    transform.iree.distribute_multi_mma %multi_mma : (!transform.any_op) -> !transform.any_op
+    %func = transform.structured.match ops{["func.func"]} in %root : (!transform.any_op) -> !transform.any_op
+     transform.apply_patterns to %func {
+      transform.apply_patterns.canonicalization
+    } : !transform.any_op
+    transform.apply_cse to %func : !transform.any_op
+
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @distribute_multi_mma_16x16x16
+//  CHECK-SAME:   %[[LHS:[A-Za-z0-9]+]]: tensor<2x2x16x16xf16>
+//  CHECK-SAME:   %[[RHS:[A-Za-z0-9]+]]: tensor<2x2x16x16xf16>
+//  CHECK-SAME:   %[[ACC:[A-Za-z0-9]+]]: tensor<2x2x16x16xf32>
+
+//       CHECK:   scf.forall (%[[LANE_ID:.+]]) in (64) shared_outs(%[[ITER_ARG:.+]] = %[[ACC]]) -> (tensor<2x2x16x16xf32>)
+//       CHECK:     %[[IDS:.+]]:2 = affine.delinearize_index %[[LANE_ID]] into (%c4, %c16) : index, index
+//       CHECK:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]][0, 0, %[[IDS]]#1, %[[IDS]]#0]
+//  CHECK-SAME:       [2, 2, 1, 4] [1, 1, 1, 1] : tensor<2x2x16x16xf16> to tensor<2x2x4xf16>
+//       CHECK:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]][0, 0, %[[IDS]]#0, %[[IDS]]#1]
+//  CHECK-SAME:       [2, 2, 4, 1] [1, 1, 1, 1] : tensor<2x2x16x16xf16> to tensor<2x2x4xf16>
+//       CHECK:     %[[ACC_SLICE:.+]] = tensor.extract_slice %[[ITER_ARG]][0, 0, %[[IDS]]#0, %[[IDS]]#1]
+//  CHECK-SAME:       [2, 2, 4, 1] [1, 1, 1, 1] : tensor<2x2x16x16xf32> to tensor<2x2x4xf32>
+//       CHECK:     %[[MMA:.+]] = iree_gpu.multi_mma %[[LHS_SLICE]], %[[RHS_SLICE]], %[[ACC_SLICE]]
+//  CHECK-SAME:       : tensor<2x2x4xf16>, tensor<2x2x4xf16> into tensor<2x2x4xf32>
+//       CHECK:     scf.forall.in_parallel
+//       CHECK:       tensor.parallel_insert_slice %[[MMA]] into %[[ITER_ARG]][0, 0, %[[IDS]]#0, %[[IDS]]#1]
+//  CHECK-SAME:         [2, 2, 4, 1] [1, 1, 1, 1] : tensor<2x2x4xf32> into tensor<2x2x16x16xf32>
+//       CHECK:   mapping = [#iree_gpu.lane_id<0>]
+

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BUILD.bazel
@@ -28,6 +28,8 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LinalgDialect",
+        "@llvm-project//mlir:SCFDialect",
+        "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TransformUtils",
         "@llvm-project//mlir:Transforms",
         "@llvm-project//mlir:VectorDialect",

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/CMakeLists.txt
@@ -23,6 +23,8 @@ iree_cc_library(
     MLIRFuncDialect
     MLIRIR
     MLIRLinalgDialect
+    MLIRSCFDialect
+    MLIRTensorDialect
     MLIRTransformUtils
     MLIRTransforms
     MLIRVectorDialect

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.h
@@ -21,6 +21,10 @@ namespace mlir::linalg {
 class LinalgOp;
 }
 
+namespace mlir::scf {
+class ForallOp;
+}
+
 namespace mlir::vector {
 struct UnrollVectorOptions;
 }
@@ -35,6 +39,10 @@ LogicalResult vectorizeStaticMultiMmaOp(RewriterBase &rewriter,
 FailureOr<IREE::GPU::MultiMmaOp>
 convertContractionToMultiMma(RewriterBase &rewriter, linalg::LinalgOp linalgOp,
                              IREE::GPU::MmaInterfaceAttr mmaKind);
+
+// Helper to distribute a multi_mma op to lanes.
+FailureOr<Operation *> distributeMultiMmaOp(RewriterBase &rewriter,
+                                            IREE::GPU::MultiMmaOp mmaOp);
 
 void populateIREEGPUVectorizationPatterns(RewritePatternSet &patterns);
 


### PR DESCRIPTION
Distribution of an `iree_gpu.multi_mma` op does a one-shot rewrite from warp semantics to thread semantics, inserting a lane mapped scf.forall that extracts the appropriate slices from each operand according to the intrinsic kind.