### PR TITLE
Add collectives tests to CI

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -93,6 +93,7 @@ jobs:
         if: inputs.run-tests
         run: |
           ./build_tools/github_actions/docker_run.sh \
+            --env "IREE_PYTHON_VENV_DIR=${BUILD_DIR}/.venv" \
             gcr.io/iree-oss/base@sha256:dc314b4fe30fc1315742512891357bffed4d1b62ffcb46258b1e0761c737b446 \
             ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
       - name: "Testing iree-dialects"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
         run: |
           ./build_tools/github_actions/docker_run.sh \
             --env "IREE_ARM_SME_QEMU_AARCH64_BIN=/usr/bin/qemu-aarch64" \
+            --env "IREE_PYTHON_VENV_DIR=${BUILD_DIR}/.venv" \
             gcr.io/iree-oss/base-arm64@sha256:9daa1cdbbf12da8527319ece76a64d06219e04ecb99a4cff6e6364235ddf6c59 \
             ./build_tools/cmake/ctest_all.sh \
             "${BUILD_DIR}"
@@ -270,6 +271,8 @@ jobs:
       INSTALL_DIR: ${{ needs.build_all.outputs.install-dir }}
       INSTALL_DIR_ARCHIVE: ${{ needs.build_all.outputs.install-dir-archive }}
       INSTALL_DIR_GCS_URL: ${{ needs.build_all.outputs.install-dir-gcs-url }}
+      IREE_BUILD_SETUP_PYTHON_VENV: "${BUILD_DIR}/.venv"
+      PYTHONPATH: "${INSTALL_DIR}/python_packages"
       IREE_CPU_DISABLE: 1
       IREE_VULKAN_DISABLE: 0
       IREE_CUDA_DISABLE: 0
@@ -296,6 +299,8 @@ jobs:
       - name: "Building tests"
         run: |
           ./build_tools/github_actions/docker_run.sh \
+              --env IREE_BUILD_SETUP_PYTHON_VENV \
+              --env PYTHONPATH \
               --env IREE_CPU_DISABLE \
               --env IREE_VULKAN_DISABLE \
               --env IREE_CUDA_DISABLE \
@@ -309,6 +314,7 @@ jobs:
           IREE_MULTI_DEVICE_TESTS_DISABLE: 1
         run: |
           ./build_tools/github_actions/docker_run.sh \
+              --env IREE_PYTHON_VENV_DIR="${IREE_BUILD_SETUP_PYTHON_VENV}" \
               --env IREE_VULKAN_DISABLE \
               --env IREE_CUDA_DISABLE \
               --env IREE_HIP_DISABLE \
@@ -334,6 +340,8 @@ jobs:
       INSTALL_DIR: ${{ needs.build_all.outputs.install-dir }}
       INSTALL_DIR_ARCHIVE: ${{ needs.build_all.outputs.install-dir-archive }}
       INSTALL_DIR_GCS_URL: ${{ needs.build_all.outputs.install-dir-gcs-url }}
+      IREE_BUILD_SETUP_PYTHON_VENV: "${BUILD_DIR}/.venv"
+      PYTHONPATH: "${INSTALL_DIR}/python_packages"
       IREE_CPU_DISABLE: 1
       IREE_VULKAN_DISABLE: 0
       IREE_CUDA_DISABLE: 0
@@ -360,6 +368,8 @@ jobs:
       - name: "Building tests"
         run: |
           ./build_tools/github_actions/docker_run.sh \
+              --env IREE_BUILD_SETUP_PYTHON_VENV \
+              --env PYTHONPATH \
               --env IREE_CPU_DISABLE \
               --env IREE_VULKAN_DISABLE \
               --env IREE_CUDA_DISABLE \
@@ -373,6 +383,7 @@ jobs:
           IREE_MULTI_DEVICE_TESTS_DISABLE: 1
         run: |
           ./build_tools/github_actions/docker_run.sh \
+              --env IREE_PYTHON_VENV_DIR="${IREE_BUILD_SETUP_PYTHON_VENV}" \
               --env IREE_VULKAN_DISABLE \
               --env IREE_CUDA_DISABLE \
               --env IREE_HIP_DISABLE \
@@ -398,6 +409,8 @@ jobs:
       INSTALL_DIR: ${{ needs.build_all.outputs.install-dir }}
       INSTALL_DIR_ARCHIVE: ${{ needs.build_all.outputs.install-dir-archive }}
       INSTALL_DIR_GCS_URL: ${{ needs.build_all.outputs.install-dir-gcs-url }}
+      IREE_BUILD_SETUP_PYTHON_VENV: "${BUILD_DIR}/.venv"
+      PYTHONPATH: "${INSTALL_DIR}/python_packages"
       IREE_CPU_DISABLE: 1
       IREE_VULKAN_DISABLE: 1
       IREE_CUDA_DISABLE: 1
@@ -415,6 +428,15 @@ jobs:
         run: tar -xf "${INSTALL_DIR_ARCHIVE}"
       - name: "Building tests"
         run: |
+          ./build_tools/github_actions/docker_run.sh \
+            --env IREE_BUILD_SETUP_PYTHON_VENV \
+            --env PYTHONPATH \
+            --env IREE_CPU_DISABLE \
+            --env IREE_VULKAN_DISABLE \
+            --env IREE_CUDA_DISABLE \
+            --env IREE_HIP_DISABLE \
+            --env IREE_HIP_TEST_TARGET_CHIP \
+          ghcr.io/nod-ai/amdgpu_ubuntu_jammy_x86_64@sha256:c623e1c62a59c9eb756211fe7f4498c6cd909db7943670764ab11b7fd3929671 \
           ./build_tools/pkgci/build_tests_using_package.sh ${INSTALL_DIR}
       - name: "Running GPU tests"
         env:
@@ -427,6 +449,19 @@ jobs:
           IREE_CPU_DISABLE: 1
           IREE_HIP_DISABLE: 0
         run: |
+          ./build_tools/github_actions/docker_run.sh \
+            --device=/dev/kfd --device=/dev/dri \
+            --security-opt seccomp=unconfined \
+            --env "IREE_PYTHON_VENV_DIR=${IREE_BUILD_SETUP_PYTHON_VENV}" \
+            --env IREE_CTEST_LABEL_REGEX \
+            --env IREE_NVIDIA_SM80_TESTS_DISABLE \
+            --env IREE_MULTI_DEVICE_TESTS_DISABLE \
+            --env IREE_AMD_RDNA3_TESTS_DISABLE \
+            --env IREE_NVIDIA_GPU_TESTS_DISABLE \
+            --env IREE_CUDA_DISABLE \
+            --env IREE_CPU_DISABLE \
+            --env IREE_HIP_DISABLE \
+          ghcr.io/nod-ai/amdgpu_ubuntu_jammy_x86_64@sha256:c623e1c62a59c9eb756211fe7f4498c6cd909db7943670764ab11b7fd3929671 \
           ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}
 
   # TODO(saienduri): re-enable when iree/hal/drivers/hip/dynamic_symbols_test is fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,8 +113,6 @@ if(IREE_BUILD_E2E_TEST_ARTIFACTS AND NOT "${IREE_E2E_TEST_ARTIFACTS_DIR}" STREQU
   )
 endif()
 
-option(IREE_ENABLE_COLLECTIVE_RUNTIME_TESTS "Enable runtime tests for collective operations." OFF)
-
 # For development, builds LLVM (and in the future) the whole compiler as
 # individual shared libraries similar to if passing -DBUILD_SHARED_LIBS=ON
 # to a standalone LLVM build. This can dramatically reduce linking time and
@@ -856,7 +854,9 @@ else()
   endif()
 
   # Ensure that LLVM-based dependencies needed for testing are included.
-  add_dependencies(iree-test-deps FileCheck)
+  if(FileCheck)
+    add_dependencies(iree-test-deps FileCheck)
+  endif()
   if(IREE_LLD_TARGET)
     add_dependencies(iree-test-deps ${IREE_LLD_TARGET})
   endif()

--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -51,6 +51,8 @@ export IREE_CTEST_TESTS_REGEX="${IREE_CTEST_TESTS_REGEX:-}"
 # Respect the user setting, default to no --label-regex
 export IREE_CTEST_LABEL_REGEX="${IREE_CTEST_LABEL_REGEX:-}"
 
+source build_tools/cmake/setup_test_run_dependencies.sh
+
 # Tests to exclude by label. In addition to any custom labels (which are carried
 # over from Bazel tags), every test should be labeled with its directory.
 declare -a label_exclude_args=(

--- a/build_tools/cmake/iree_macros.cmake
+++ b/build_tools/cmake/iree_macros.cmake
@@ -341,6 +341,27 @@ function(iree_package_name PACKAGE_NAME)
   set(${PACKAGE_NAME} ${_PACKAGE_NAME} PARENT_SCOPE)
 endfunction()
 
+# Get the CMake target name from an IREE target name.
+# Accepts IREE-root relative target names.
+# Example:
+# iree_target_cmake_name(NAME my_target RESULT MY_CMAKE_TARGET)
+# when called form tests/python/CMakeLists.txt
+# the result is iree_tests_python_my_target
+function(iree_target_cmake_name)
+  cmake_parse_arguments(
+    _ARG
+    ""
+    "NAME;RESULT"
+    ""
+    ${ARGN}
+  )
+  iree_package_ns(_PACKAGE_NS)
+  set(_RESULT "${_ARG_NAME}")
+  string(REGEX REPLACE "^::" "${_PACKAGE_NS}::" _RESULT "${_ARG_NAME}")
+  string(REPLACE "::" "_" _RESULT "${_RESULT}")
+  set(${_ARG_RESULT} ${_RESULT} PARENT_SCOPE)
+endfunction()
+
 # Sets ${PACKAGE_PATH} to the IREE-root relative package path.
 #
 # Example when called from iree/base/CMakeLists.txt:

--- a/build_tools/cmake/iree_python.cmake
+++ b/build_tools/cmake/iree_python.cmake
@@ -114,7 +114,7 @@ function(iree_local_py_test)
   set_property(TEST ${_NAME_PATH} PROPERTY LABELS "${_RULE_LABELS}")
   set_property(TEST ${_NAME_PATH} PROPERTY TIMEOUT ${_RULE_ARGS})
 
-  # Extend the PYTHONPATH environment variable with _RULE_PACKAGE_DIRS.
+  # Extend _RULE_PACKAGE_DIRS with the PYTHONPATH environment variable.
   list(APPEND _RULE_PACKAGE_DIRS "$ENV{PYTHONPATH}")
   if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
     # Windows uses semi-colon delimiters, but so does CMake, so escape them.
@@ -156,9 +156,17 @@ function(iree_py_test)
     "ARGS;LABELS;TIMEOUT"
     ${ARGN}
   )
-  if(NOT IREE_BUILD_PYTHON_BINDINGS)
-    return()
+  unset(_PACKAGE_DIRS)
+  # If we are not building the bindings then the Python environment must
+  # provide required IREE modules.
+  if(IREE_BUILD_PYTHON_BINDINGS)
+    list(APPEND _PACKAGE_DIRS
+      "${IREE_BINARY_DIR}/compiler/bindings/python"
+      "${IREE_BINARY_DIR}/runtime/bindings/python"
+    )
   endif()
+
+  list(APPEND _PACKAGE_DIRS "${IREE_BINARY_DIR}/tests/python")
 
   iree_local_py_test(
     NAME
@@ -170,8 +178,7 @@ function(iree_py_test)
     LABELS
       ${_RULE_LABELS}
     PACKAGE_DIRS
-      "${IREE_BINARY_DIR}/compiler/bindings/python"
-      "${IREE_BINARY_DIR}/runtime/bindings/python"
+      ${_PACKAGE_DIRS}
     GENERATED_IN_BINARY_DIR
       "${_RULE_GENERATED_IN_BINARY_DIR}"
     TIMEOUT

--- a/build_tools/cmake/setup_test_run_dependencies.sh
+++ b/build_tools/cmake/setup_test_run_dependencies.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Setup run requirements for tests.
+
+set -euo pipefail
+
+if [[ $OSTYPE =~ ^linux ]]; then
+  source /etc/lsb-release
+  if [[ $DISTRIB_ID == "Ubuntu" ]]; then
+    if command -v sudo &> /dev/null; then
+      SUDO=sudo
+    else
+      # No sudo, probably running inside docker as root
+      SUDO=""
+    fi
+    $SUDO apt update
+    $SUDO apt -y install libopenmpi-dev
+  fi
+fi
+if [[ $OSTYPE =~ ^darwin ]]; then
+  brew install open-mpi
+fi
+
+if [[ -v IREE_PYTHON_VENV_DIR ]]; then
+  source "$IREE_PYTHON_VENV_DIR/bin/activate"
+fi
+pip install -r tests/run_requirements.txt

--- a/build_tools/pkgci/build_tests_using_package.sh
+++ b/build_tools/pkgci/build_tests_using_package.sh
@@ -30,7 +30,11 @@ set -xeuo pipefail
 PACKAGE_DIR="$1"
 BUILD_DIR="${BUILD_DIR:-build-tests}"
 
+echo "::group::Install dependencies"
 source build_tools/scripts/install_lit.sh
+source build_tools/cmake/setup_build.sh
+echo "::endgroup::"
+
 
 # CPU drivers and tests are enabled by default.
 export IREE_CPU_DISABLE="${IREE_CPU_DISABLE:-0}"

--- a/runtime/bindings/python/CMakeLists.txt
+++ b/runtime/bindings/python/CMakeLists.txt
@@ -133,6 +133,7 @@ iree_py_library(
     "iree/runtime/_binding.pyi"
     "iree/runtime/array_interop.py"
     "iree/runtime/benchmark.py"
+    "iree/runtime/exception.py"
     "iree/runtime/flags.py"
     "iree/runtime/function.py"
     "iree/runtime/io.py"

--- a/runtime/bindings/python/iree/runtime/__init__.py
+++ b/runtime/bindings/python/iree/runtime/__init__.py
@@ -65,6 +65,7 @@ from .system_setup import (
     get_driver,
     query_available_drivers,
 )
+from .exception import *
 from .function import *
 from .io import *
 

--- a/runtime/bindings/python/iree/runtime/exception.py
+++ b/runtime/bindings/python/iree/runtime/exception.py
@@ -1,0 +1,15 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+
+class ErrorUnavailable(RuntimeError):
+    """
+    The system used to perform the operation is currently (and transiently)
+    unavailable. Callers can retry with backoff.
+    """
+
+    def __init__(self, message):
+        super().__init__(self, message)

--- a/runtime/bindings/python/status_utils.cc
+++ b/runtime/bindings/python/status_utils.cc
@@ -6,10 +6,22 @@
 
 #include "./status_utils.h"
 
+#include <nanobind/nanobind.h>
+
+#include "iree/base/status.h"
+
 namespace iree {
 namespace python {
 
 namespace {
+
+static PyObject* GetErrorUnavailableClass() {
+  nanobind::module_ iree_runtime_ex =
+      nanobind::module_::import_("iree.runtime.exception");
+  nanobind::object error_unavailable = iree_runtime_ex.attr("ErrorUnavailable");
+  error_unavailable.inc_ref();
+  return error_unavailable.ptr();
+}
 
 PyObject* ApiStatusToPyExcClass(iree_status_t status) {
   switch (iree_status_code(status)) {
@@ -19,6 +31,8 @@ PyObject* ApiStatusToPyExcClass(iree_status_t status) {
       return PyExc_ValueError;
     case IREE_STATUS_OUT_OF_RANGE:
       return PyExc_IndexError;
+    case IREE_STATUS_UNAVAILABLE:
+      return GetErrorUnavailableClass();
     case IREE_STATUS_UNIMPLEMENTED:
       return PyExc_NotImplementedError;
     default:

--- a/runtime/src/iree/hal/drivers/cuda/dynamic_symbols_test.cc
+++ b/runtime/src/iree/hal/drivers/cuda/dynamic_symbols_test.cc
@@ -70,7 +70,8 @@ TEST(NCCLDynamicSymbolsTest, CreateFromSystemLoader) {
 
   int nccl_version = 0;
   NCCL_CHECK_ERRORS(nccl_symbols.ncclGetVersion(&nccl_version));
-  ASSERT_EQ(NCCL_VERSION_CODE, nccl_version);
+  ASSERT_GE(nccl_version, NCCL_VERSION(NCCL_MAJOR, NCCL_MINOR, 0));
+  ASSERT_LT(nccl_version, NCCL_VERSION(NCCL_MAJOR + 1, 0, 0));
   iree_hal_cuda_nccl_dynamic_symbols_deinitialize(&nccl_symbols);
   iree_hal_cuda_dynamic_symbols_deinitialize(&cuda_symbols);
 }

--- a/runtime/src/iree/hal/drivers/hip/dynamic_symbols_test.cc
+++ b/runtime/src/iree/hal/drivers/hip/dynamic_symbols_test.cc
@@ -89,7 +89,8 @@ TEST(NCCLDynamicSymbolsTest, CreateFromSystemLoader) {
 
   int nccl_version = 0;
   NCCL_CHECK_ERRORS(nccl_symbols.ncclGetVersion(&nccl_version));
-  ASSERT_EQ(NCCL_VERSION_CODE, nccl_version);
+  ASSERT_GE(nccl_version, NCCL_VERSION(NCCL_MAJOR, NCCL_MINOR, 0));
+  ASSERT_LT(nccl_version, NCCL_VERSION(NCCL_MAJOR + 1, 0, 0));
   iree_hal_hip_nccl_dynamic_symbols_deinitialize(&nccl_symbols);
   iree_hal_hip_dynamic_symbols_deinitialize(&hip_symbols);
 }

--- a/tests/e2e/collectives/CMakeLists.txt
+++ b/tests/e2e/collectives/CMakeLists.txt
@@ -6,72 +6,73 @@
 
 # These tests perform linking via the Compiler API, which is only supported
 # in bundled-LLVM builds at the moment (#14086).
-if(NOT IREE_BUILD_BUNDLED_LLVM OR NOT IREE_ENABLE_COLLECTIVE_RUNTIME_TESTS)
+if(NOT IREE_BUILD_BUNDLED_LLVM)
   return()
 endif()
 
-if(IREE_TARGET_BACKEND_CUDA AND IREE_HAL_DRIVER_CUDA)
 
-  set(COMMON_ARGS
-    "--target_backend=cuda"
-    "--driver=cuda"
-    "--iree_compiler_args=--iree-hal-cuda-llvm-target-arch=sm_53"
-  )
+set(CUDA_COMMON_ARGS
+  "--target_backend=cuda"
+  "--driver=cuda"
+  "--iree_compiler_args=--iree-hal-cuda-llvm-target-arch=sm_53"
+)
 
-  set(COMMON_LABELS
-    "requires-gpu-nvidia"
-    "driver=cuda"
-  )
+set(CUDA_COMMON_LABELS
+  "requires-gpu-nvidia"
+  "driver=cuda"
+)
 
-  iree_py_test(
-    NAME
-      collectives_test_cuda_1_gpu
-    SRCS
-      "collectives_test.py"
-    ARGS
-      "-k" "SingleRank"
-      ${COMMON_ARGS}
-    LABELS
-      ${COMMON_LABELS}
-  )
+iree_py_test(
+  NAME
+    collectives_test_cuda_1_gpu
+  SRCS
+    "collectives_test.py"
+  ARGS
+    "-k" "SingleRank"
+    ${CUDA_COMMON_ARGS}
+  LABELS
+    ${CUDA_COMMON_LABELS}
+)
 
-  iree_py_test(
-    NAME
-      collectives_test_cuda_2_gpus
-    SRCS
-      "collectives_test.py"
-    ARGS
-      "-k" "TwoRanks"
-      ${COMMON_ARGS}
-    LABELS
-      ${COMMON_LABELS}
-      # The NCCL collectives backend requires 1 GPU per rank.
-      # To properly test for 2 ranks we need 2 GPUs.
-      "requires-multiple-devices"
-  )
+iree_py_test(
+  NAME
+    collectives_test_cuda_2_gpus
+  SRCS
+    "collectives_test.py"
+  ARGS
+    "-k" "TwoRanks"
+    ${CUDA_COMMON_ARGS}
+  LABELS
+    ${CUDA_COMMON_LABELS}
+    # The NCCL collectives backend requires 1 GPU per rank.
+    # To properly test for 2 ranks we need 2 GPUs.
+    "requires-multiple-devices"
+    "requires-2-devices"
+)
 
-  iree_py_test(
-    NAME
-      collectives_test_cuda_4_gpus
-    SRCS
-      "collectives_test.py"
-    ARGS
-      "-k" "FourRanks"
-      ${COMMON_ARGS}
-    LABELS
-      ${COMMON_LABELS}
-      "requires-multiple-devices"
-  )
-endif()
+iree_py_test(
+  NAME
+    collectives_test_cuda_4_gpus
+  SRCS
+    "collectives_test.py"
+  ARGS
+    "-k" "FourRanks"
+    ${CUDA_COMMON_ARGS}
+  LABELS
+    ${CUDA_COMMON_LABELS}
+    "requires-multiple-devices"
+    "requires-4-devices"
+)
 
-if(IREE_TARGET_BACKEND_ROCM AND IREE_HAL_DRIVER_HIP AND IREE_HIP_TEST_TARGET_CHIP)
-  set(COMMON_ARGS
+
+if(IREE_HIP_TEST_TARGET_CHIP)
+  set(HIP_COMMON_ARGS
     "--target_backend=rocm"
     "--driver=hip"
     "--iree_compiler_args=--iree-rocm-target-chip=${IREE_HIP_TEST_TARGET_CHIP}"
   )
 
-  set(COMMON_LABELS
+  set(HIP_COMMON_LABELS
     "requires-gpu-amd"
     "driver=hip"
   )
@@ -83,9 +84,9 @@ if(IREE_TARGET_BACKEND_ROCM AND IREE_HAL_DRIVER_HIP AND IREE_HIP_TEST_TARGET_CHI
       "collectives_test.py"
     ARGS
       "-k" "SingleRank"
-      ${COMMON_ARGS}
+      ${HIP_COMMON_ARGS}
     LABELS
-      ${COMMON_LABELS}
+      ${HIP_COMMON_LABELS}
   )
 
   iree_py_test(
@@ -95,12 +96,13 @@ if(IREE_TARGET_BACKEND_ROCM AND IREE_HAL_DRIVER_HIP AND IREE_HIP_TEST_TARGET_CHI
       "collectives_test.py"
     ARGS
       "-k" "TwoRanks"
-      ${COMMON_ARGS}
+      ${HIP_COMMON_ARGS}
     LABELS
-      ${COMMON_LABELS}
-      # The NCCL collectives backend requires 1 GPU per rank.
+      ${HIP_COMMON_LABELS}
+      # The RCCL collectives backend requires 1 GPU per rank.
       # To properly test for 2 ranks we need 2 GPUs.
       "requires-multiple-devices"
+      "requires-2-devices"
   )
 
   iree_py_test(
@@ -110,9 +112,10 @@ if(IREE_TARGET_BACKEND_ROCM AND IREE_HAL_DRIVER_HIP AND IREE_HIP_TEST_TARGET_CHI
       "collectives_test.py"
     ARGS
       "-k" "FourRanks"
-      ${COMMON_ARGS}
+      ${HIP_COMMON_ARGS}
     LABELS
-      ${COMMON_LABELS}
+      ${HIP_COMMON_LABELS}
       "requires-multiple-devices"
+      "requires-4-devices"
   )
 endif()

--- a/tests/e2e/collectives/run_rank.py
+++ b/tests/e2e/collectives/run_rank.py
@@ -56,7 +56,7 @@ def run_module(
     config = iree.runtime.Config(device=device)
     with open(module_filepath, "rb") as f:
         vm_flatbuffer = f.read()
-    vm_module = iree.runtime.VmModule.from_flatbuffer(config.vm_instance, vm_flatbuffer)
+    vm_module = iree.runtime.VmModule.copy_buffer(config.vm_instance, vm_flatbuffer)
     bound_module = iree.runtime.load_vm_module(vm_module, config)
     input_args = test_utils.read_numpy_arrays_from_file(input_filepath)
     results = getattr(bound_module, function)(*input_args)

--- a/tests/e2e/stablehlo_models/mnist_train_test/CMakeLists.txt
+++ b/tests/e2e/stablehlo_models/mnist_train_test/CMakeLists.txt
@@ -10,45 +10,39 @@ if(NOT IREE_BUILD_BUNDLED_LLVM)
   return()
 endif()
 
-if(IREE_TARGET_BACKEND_LLVM_CPU AND IREE_HAL_DRIVER_LOCAL_TASK)
-  iree_py_test(
-    NAME
-      mnist_train_test_cpu
-    SRCS
-      "mnist_train_test.py"
-    ARGS
-      "--target_backend=llvm-cpu"
-      "--driver=local-task"
-    LABELS
-      "driver=local-task"
-  )
-endif()
+iree_py_test(
+  NAME
+    mnist_train_test_cpu
+  SRCS
+    "mnist_train_test.py"
+  ARGS
+    "--target_backend=llvm-cpu"
+    "--driver=local-task"
+  LABELS
+    "driver=local-task"
+)
 
-if(IREE_TARGET_BACKEND_CUDA AND IREE_HAL_DRIVER_CUDA)
-  iree_py_test(
-    NAME
-      mnist_train_test_cuda
-    SRCS
-      "mnist_train_test.py"
-    ARGS
-      "--target_backend=cuda"
-      "--driver=cuda"
-    LABELS
-      "requires-gpu-nvidia"
-      "driver=cuda"
-  )
-endif()
+iree_py_test(
+  NAME
+    mnist_train_test_cuda
+  SRCS
+    "mnist_train_test.py"
+  ARGS
+    "--target_backend=cuda"
+    "--driver=cuda"
+  LABELS
+    "requires-gpu-nvidia"
+    "driver=cuda"
+)
 
-if(IREE_TARGET_BACKEND_VULKAN_SPIRV AND IREE_HAL_DRIVER_VULKAN)
-  iree_py_test(
-    NAME
-      mnist_train_test_vulkan
-    SRCS
-      "mnist_train_test.py"
-    ARGS
-      "--target_backend=vulkan-spirv"
-      "--driver=vulkan"
-    LABELS
-      "driver=vulkan"
-  )
-endif()
+iree_py_test(
+  NAME
+    mnist_train_test_vulkan
+  SRCS
+    "mnist_train_test.py"
+  ARGS
+    "--target_backend=vulkan-spirv"
+    "--driver=vulkan"
+  LABELS
+    "driver=vulkan"
+)

--- a/tests/e2e/stablehlo_models/mnist_train_test/mnist_train_test.py
+++ b/tests/e2e/stablehlo_models/mnist_train_test/mnist_train_test.py
@@ -13,11 +13,12 @@ import tempfile
 import unittest
 from typing import List, TypeVar
 from urllib.request import urlretrieve
-
 import numpy as np
+import iree.testing
 
-from iree.compiler.tools import InputType, compile_file
-from iree.runtime import load_vm_flatbuffer_file
+if iree.testing.has_requirements(compiler=True, runtime=True):
+    from iree.compiler.tools import InputType, compile_file
+    from iree.runtime import load_vm_flatbuffer_file
 
 MODEL_ARTIFACTS_URL = "https://storage.googleapis.com/iree-model-artifacts/mnist_train.2bec0cb356ae7c059e04624a627eb3b15b0a556cbd781bbed9f8d32e80a4311d.tar"
 
@@ -114,6 +115,20 @@ def extract_test_data(archive_path: str, out_dir: str):
 
 
 class MnistTrainTest(unittest.TestCase):
+    def setUp(self):
+        if not iree.testing.has_requirements(
+            compiler=True,
+            runtime=True,
+            compiler_target_backends=[args.target_backend],
+            device_count={args.driver: 1},
+        ):
+            raise unittest.SkipTest(
+                (
+                    f'Skipping tests for driver "{args.driver}". '
+                    "Requirements not satisfied."
+                )
+            )
+
     def test_mnist_training(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             archive_path = os.path.join(tmp_dir, "mnist_train.tar")

--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+iree_py_library(
+  NAME
+    testing
+  SRCS
+    "iree/testing/__init__.py"
+    "iree/testing/requirements.py"
+)
+
+iree_target_cmake_name(NAME ::testing RESULT TESTING_CMAKE_TARGET)
+add_dependencies(iree-test-deps ${TESTING_CMAKE_TARGET})

--- a/tests/python/iree/testing/__init__.py
+++ b/tests/python/iree/testing/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from .requirements import (
+    has_compiler_module,
+    has_runtime_module,
+    has_compiler_module,
+    has_runtime_module,
+    get_device_count,
+    has_compiler_requirement,
+    has_runtime_requirement,
+    has_device_count_requirement,
+    has_requirements,
+)

--- a/tests/python/iree/testing/requirements.py
+++ b/tests/python/iree/testing/requirements.py
@@ -1,0 +1,136 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import importlib.util
+import multiprocessing
+from typing import Dict, List
+import sys
+import logging
+
+logger = logging.getLogger("iree.testing")
+
+
+def has_compiler_module() -> bool:
+    spec = importlib.util.find_spec("iree.compiler")
+    return spec is not None
+
+
+def has_runtime_module() -> bool:
+    spec = importlib.util.find_spec("iree.compiler")
+    return spec is not None
+
+
+if has_compiler_module():
+    import iree.compiler
+
+if has_runtime_module():
+    import iree.runtime
+
+
+def get_device_count_inplace(driver: str, queue: multiprocessing.Queue) -> None:
+    device_count = get_device_count(driver)
+    queue.put(device_count)
+
+
+def get_device_count(driver: str, use_subprocess: bool = False) -> int:
+    """
+    Parameters
+    ----------
+    use_subprocess:
+    Run in a subprocess to avoid initializing the driver context in this
+    process as it may interfere when other subprocesses need it.
+    """
+    if use_subprocess:
+        queue = multiprocessing.Queue()
+        process = multiprocessing.Process(
+            target=get_device_count_inplace, args=[driver, queue]
+        )
+        process.start()
+        process.join()
+        assert process.exitcode == 0
+        return queue.get()
+
+    available_driver_names = iree.runtime.query_available_drivers()
+    if driver not in available_driver_names:
+        return 0
+    try:
+        hal_driver = iree.runtime.get_driver(driver)
+    except iree.runtime.ErrorUnavailable:
+        # If the driver is unavailable we do not consider it a hard error.
+        # It means there are no devices associated with that driver.
+        return 0
+    except:
+        raise
+
+    device_infos = hal_driver.query_available_devices()
+    return len(device_infos)
+
+
+def has_compiler_requirement() -> bool:
+    res = has_compiler_module()
+    if not res:
+        logger.info("Python module iree.compiler is missing.")
+    return res
+
+
+def has_compiler_target_backends_requirement(target_backends: List[str] = []) -> bool:
+    res = True
+    available_backends = iree.compiler.query_available_targets()
+    for required_backend in target_backends:
+        has_backend = required_backend in available_backends
+        if not has_backend:
+            logger.info(
+                f"Compiler has missing required target backend {required_backend}."
+            )
+        res &= has_backend
+    return res
+
+
+def has_runtime_requirement() -> bool:
+    res = has_compiler_module()
+    if not res:
+        logger.info("Python module iree.runtime is missing.")
+    return res
+
+
+def has_device_count_requirement(driver: str, count: int) -> bool:
+    device_count = get_device_count(driver=driver, use_subprocess=True)
+    res = device_count >= count
+    if not res:
+        logger.info(
+            f"Found only {device_count} devices for driver {driver}, but {count} were required."
+        )
+    return res
+
+
+def has_requirements(
+    compiler: bool = False,
+    runtime: bool = False,
+    compiler_target_backends: List[str] = [],
+    device_count: Dict[str, int] = {},
+) -> bool:
+    """
+    Check if has the IREE requirements.
+
+    Parameters
+    ----------
+    device_count: Map of (driver name -> device count).
+    """
+    if len(device_count) > 0:
+        runtime = True
+    if len(compiler_target_backends) > 0:
+        compiler = True
+    res = True
+    if compiler:
+        res &= has_compiler_requirement()
+    if runtime:
+        res &= has_runtime_requirement()
+    if has_runtime_module():
+        for driver, count in device_count.items():
+            res &= has_device_count_requirement(driver=driver, count=count)
+    if has_compiler_module():
+        res &= has_compiler_target_backends_requirement(compiler_target_backends)
+    return res

--- a/tests/run_requirements.txt
+++ b/tests/run_requirements.txt
@@ -4,5 +4,4 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-mpi4py>=3.1.4
-numpy>=1.13
+-r e2e/collectives/run_requirements.txt


### PR DESCRIPTION
* Skip the end-to-end collectives test if the required driver or number of devices are not available.
* Add ErrorUnavailable to Python bindings.