### PR TITLE
[Codegen] NFC: Move the lowering config to an attribute interface

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/DecomposeBatchMmt4DOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DecomposeBatchMmt4DOps.cpp
@@ -99,8 +99,8 @@ struct ConvertBatchMmt4DtoMmt4DPattern
                                       ValueRange{newInit})
               .result();
 
-      IREE::Codegen::LoweringConfigAttr loweringConfig =
-          getLoweringConfig(oldFillOp);
+      auto loweringConfig =
+          getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(oldFillOp);
       if (loweringConfig) {
         auto config = dropBatchTileSize(loweringConfig);
         setLoweringConfig(reducedOut.getDefiningOp(), config);
@@ -135,7 +135,8 @@ struct ConvertBatchMmt4DtoMmt4DPattern
         loc, reducedOut.getType(), ValueRange{reducedLhs, reducedRhs},
         ValueRange{reducedOut});
 
-    IREE::Codegen::LoweringConfigAttr loweringConfig = getLoweringConfig(op);
+    auto loweringConfig =
+        getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(op);
     if (loweringConfig) {
       auto config = dropBatchTileSize(loweringConfig);
       setLoweringConfig(mmt4DOp, config);

--- a/compiler/src/iree/compiler/Codegen/Common/DecomposeConvolutionToLowerDimOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DecomposeConvolutionToLowerDimOps.cpp
@@ -75,8 +75,8 @@ computeDecomposedLoweringConfig(ArrayRef<Operation *> computeOps,
     return failure();
 
   // 2. Get the current lowering config attached to the Conv Op.
-  FailureOr<IREE::Codegen::LoweringConfigAttr> loweringConfigAttr =
-      getLoweringConfig(computeOps);
+  auto loweringConfigAttr =
+      getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(computeOps);
   if (failed(loweringConfigAttr))
     return failure();
 

--- a/compiler/src/iree/compiler/Codegen/Common/DecomposeConvolutionToLowerDimOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DecomposeConvolutionToLowerDimOps.cpp
@@ -75,8 +75,8 @@ computeDecomposedLoweringConfig(ArrayRef<Operation *> computeOps,
     return failure();
 
   // 2. Get the current lowering config attached to the Conv Op.
-  auto loweringConfigAttr =
-      getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(computeOps);
+  FailureOr<IREE::Codegen::LoweringConfigAttr> loweringConfigAttr =
+      getFirstLoweringConfig<IREE::Codegen::LoweringConfigAttr>(computeOps);
   if (failed(loweringConfigAttr))
     return failure();
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUGeneralizeNamedOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUGeneralizeNamedOps.cpp
@@ -31,7 +31,8 @@ generalizeCandidates(MLIRContext *context,
   for (auto linalgOp : namedOpCandidates) {
     // Pass down lowering configuration. It can exist due to user set
     // configuration from the input.
-    auto config = getLoweringConfig(linalgOp);
+    IREE::Codegen::LoweringConfigAttrInterface config =
+        getLoweringConfig(linalgOp);
     rewriter.setInsertionPoint(linalgOp);
     FailureOr<linalg::GenericOp> generalizedOp =
         linalg::generalizeNamedOp(rewriter, linalgOp);

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTile.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTile.cpp
@@ -65,7 +65,8 @@ collectComputeOps(mlir::FunctionOpInterface funcOp,
   if (ifOps.empty()) {
     computeOps = getComputeOps(funcOp);
     for (Operation *op : computeOps) {
-      if (auto config = getLoweringConfig(op))
+      if (auto config =
+              getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(op))
         configs.push_back(config);
     }
     if (computeOps.size() > 1) {
@@ -80,7 +81,8 @@ collectComputeOps(mlir::FunctionOpInterface funcOp,
 
     ifOps.front()->walk([&configs](Operation *op) {
       if (isa<linalg::LinalgOp, TilingInterface>(op)) {
-        if (auto config = getLoweringConfig(op))
+        if (auto config =
+                getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(op))
           configs.push_back(config);
       }
     });

--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -232,7 +232,8 @@ static std::optional<VectorizationTileSizes> inferSizesFromIR(Value val) {
 static std::optional<SizesAndScalableFlags>
 getVectorSizes(Operation *op, bool useConfiguredVectorSizes) {
   // Get vector sizes from the lowering config, if available in the op itself.
-  IREE::Codegen::LoweringConfigAttr loweringConfig = getLoweringConfig(op);
+  auto loweringConfig =
+      getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(op);
   if (useConfiguredVectorSizes && loweringConfig) {
     TilingConfig tilingConfig(loweringConfig);
     auto [vectorSizes, scalableFlags] = tilingConfig.getVectorTileSizes();

--- a/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
@@ -91,14 +91,15 @@ getTileAndDistributeConfig(ArrayRef<Operation *> computeOps,
 
   partitionableLoops =
       partitionableLoopInterface.getPartitionableLoops(std::nullopt);
-  IREE::Codegen::LoweringConfigAttr rootOpConfig = getLoweringConfig(rootOp);
+  IREE::Codegen::LoweringConfigAttrInterface rootOpConfig =
+      getLoweringConfig(rootOp);
   if (!rootOpConfig) {
     return rootOp->emitOpError(
         "unable to find configuration of root op to define workgroup count "
         "region");
   }
-  tileSizes.assign(rootOpConfig.getTileSizeVals(0));
-  interchange.assign(rootOpConfig.getTileInterchangeVals(0));
+  tileSizes.assign(rootOpConfig.getWorkgroupTileSizes());
+  interchange.assign(rootOpConfig.getWorkgroupInterchange());
 
   // Set tile sizes of non-partitioned loops to 0.
   llvm::SmallDenseSet<unsigned> partitionableLoopsSet;

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/BUILD.bazel
@@ -16,6 +16,7 @@ package(
 exports_files([
     "IREECodegenAttrs.td",
     "IREECodegenDialect.td",
+    "IREECodegenInterfaces.td",
     "IREECodegenOps.td",
     "UKernelOps.td",
 ])
@@ -26,6 +27,7 @@ iree_td_library(
         [
             "IREECodegenAttrs.td",
             "IREECodegenDialect.td",
+            "IREECodegenInterfaces.td",
             "IREECodegenOps.td",
             "UKernelOps.td",
         ],
@@ -46,6 +48,7 @@ iree_compiler_cc_library(
     srcs = [
         "IREECodegenAttrs.cpp",
         "IREECodegenDialect.cpp",
+        "IREECodegenInterfaces.cpp",
         "IREECodegenLibraryManager.cpp",
         "IREECodegenOps.cpp",
         "UKernelOps.cpp",
@@ -53,16 +56,19 @@ iree_compiler_cc_library(
     hdrs = [
         "IREECodegenAttrs.h",
         "IREECodegenDialect.h",
+        "IREECodegenInterfaces.h",
         "IREECodegenOps.h",
         "UKernelOps.h",
     ],
     textual_hdrs = [
-        "IREECodegenDialect.cpp.inc",
-        "IREECodegenDialect.h.inc",
-        "IREECodegenOps.cpp.inc",
-        "IREECodegenOps.h.inc",
         "IREECodegenAttrs.cpp.inc",
         "IREECodegenAttrs.h.inc",
+        "IREECodegenDialect.cpp.inc",
+        "IREECodegenDialect.h.inc",
+        "IREECodegenInterfaces.cpp.inc",
+        "IREECodegenInterfaces.h.inc",
+        "IREECodegenOps.cpp.inc",
+        "IREECodegenOps.h.inc",
         "LoweringConfigEnums.cpp.inc",
         "LoweringConfigEnums.h.inc",
         "UKernelOps.cpp.inc",
@@ -72,11 +78,13 @@ iree_compiler_cc_library(
         ":IREECodegenDialectGen",
         ":IREECodegenOpsGen",
         ":LoweringConfigGen",
+        ":LoweringConfigInterfaceGen",
         ":UKernelOpsGen",
         "//compiler/src/iree/compiler/Codegen/Interfaces:UKernelOpInterface",
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:ArithUtils",
         "@llvm-project//mlir:BufferizationDialect",
         "@llvm-project//mlir:DestinationStyleOpInterface",
         "@llvm-project//mlir:DialectUtils",
@@ -128,6 +136,23 @@ iree_gentbl_cc_library(
         ":td_files",
         "//compiler/src/iree/compiler/Codegen/Interfaces:td_files",
     ],
+)
+
+iree_gentbl_cc_library(
+    name = "LoweringConfigInterfaceGen",
+    tbl_outs = [
+        (
+            ["--gen-attr-interface-decls"],
+            "IREECodegenInterfaces.h.inc",
+        ),
+        (
+            ["--gen-attr-interface-defs"],
+            "IREECodegenInterfaces.cpp.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "IREECodegenInterfaces.td",
+    deps = [":td_files"],
 )
 
 iree_gentbl_cc_library(

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_cc_library(
   HDRS
     "IREECodegenAttrs.h"
     "IREECodegenDialect.h"
+    "IREECodegenInterfaces.h"
     "IREECodegenOps.h"
     "UKernelOps.h"
   TEXTUAL_HDRS
@@ -23,6 +24,8 @@ iree_cc_library(
     "IREECodegenAttrs.h.inc"
     "IREECodegenDialect.cpp.inc"
     "IREECodegenDialect.h.inc"
+    "IREECodegenInterfaces.cpp.inc"
+    "IREECodegenInterfaces.h.inc"
     "IREECodegenOps.cpp.inc"
     "IREECodegenOps.h.inc"
     "LoweringConfigEnums.cpp.inc"
@@ -32,6 +35,7 @@ iree_cc_library(
   SRCS
     "IREECodegenAttrs.cpp"
     "IREECodegenDialect.cpp"
+    "IREECodegenInterfaces.cpp"
     "IREECodegenLibraryManager.cpp"
     "IREECodegenOps.cpp"
     "UKernelOps.cpp"
@@ -39,9 +43,11 @@ iree_cc_library(
     ::IREECodegenDialectGen
     ::IREECodegenOpsGen
     ::LoweringConfigGen
+    ::LoweringConfigInterfaceGen
     ::UKernelOpsGen
     LLVMSupport
     MLIRArithDialect
+    MLIRArithUtils
     MLIRBufferizationDialect
     MLIRDestinationStyleOpInterface
     MLIRFuncDialect
@@ -77,6 +83,16 @@ iree_tablegen_library(
   OUTS
     --gen-op-decls IREECodegenOps.h.inc
     --gen-op-defs IREECodegenOps.cpp.inc
+)
+
+iree_tablegen_library(
+  NAME
+    LoweringConfigInterfaceGen
+  TD_FILE
+    "IREECodegenInterfaces.td"
+  OUTS
+    --gen-attr-interface-decls IREECodegenInterfaces.h.inc
+    --gen-attr-interface-defs IREECodegenInterfaces.cpp.inc
 )
 
 iree_tablegen_library(

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h
@@ -91,12 +91,12 @@ getLoweringConfigCarryingOp(ArrayRef<Operation *> computeOps) {
 }
 
 /// Returns the lowering configuration from the list of operations; returns
-/// nullptr if unable to find.
+/// failure if no operations is carrying a lowering config.
 ///
 /// This scans ops in top-down order and the first one carrying the attribute
 /// will be returned.
 template <typename ConfigTy = IREE::Codegen::LoweringConfigAttrInterface>
-FailureOr<ConfigTy> getLoweringConfig(ArrayRef<Operation *> computeOps) {
+FailureOr<ConfigTy> getFirstLoweringConfig(ArrayRef<Operation *> computeOps) {
   FailureOr<Operation *> op = getLoweringConfigCarryingOp<ConfigTy>(computeOps);
   if (failed(op))
     return failure();

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h
@@ -10,6 +10,7 @@
 #ifndef IREE_COMPILER_CODEGEN_DIALECT_LOWERINGCONFIG_H_
 #define IREE_COMPILER_CODEGEN_DIALECT_LOWERINGCONFIG_H_
 
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -64,38 +65,51 @@ void eraseTranslationInfo(mlir::FunctionOpInterface funcOp);
 // operations.
 //===----------------------------------------------------------------------===//
 
+static const char kConfigAttrName[] = "lowering_config";
+
+/// Returns the lowering configuration set for an operation. Returns `nullptr`
+/// if no value is set.  It expects that the attribute is stored using the
+/// identifier `lowering_config`.
+template <typename ConfigTy = IREE::Codegen::LoweringConfigAttrInterface>
+ConfigTy getLoweringConfig(Operation *op) {
+  return op->getAttrOfType<ConfigTy>(kConfigAttrName);
+}
+
 /// Returns the op that carries the `lowering_config` attribute; returns nullptr
 /// if none is carrying the attribute.
 ///
 /// This scans ops in top-down order and the first one carrying the attribute
 /// will be returned.
+template <typename ConfigTy = IREE::Codegen::LoweringConfigAttrInterface>
 FailureOr<Operation *>
-getLoweringConfigCarryingOp(ArrayRef<Operation *> computeOps);
-
-/// Returns the lowering configuration set for an operation. Returns `nullptr`
-/// if no value is set.  It expects that the attribute is stored using the
-/// identifier `lowering_config`.
-IREE::Codegen::LoweringConfigAttr getLoweringConfig(Operation *op);
+getLoweringConfigCarryingOp(ArrayRef<Operation *> computeOps) {
+  for (Operation *op : computeOps) {
+    if (getLoweringConfig<ConfigTy>(op))
+      return op;
+  }
+  return failure();
+}
 
 /// Returns the lowering configuration from the list of operations; returns
 /// nullptr if unable to find.
 ///
 /// This scans ops in top-down order and the first one carrying the attribute
 /// will be returned.
-FailureOr<IREE::Codegen::LoweringConfigAttr>
-getLoweringConfig(ArrayRef<Operation *> computeOps);
+template <typename ConfigTy = IREE::Codegen::LoweringConfigAttrInterface>
+FailureOr<ConfigTy> getLoweringConfig(ArrayRef<Operation *> computeOps) {
+  FailureOr<Operation *> op = getLoweringConfigCarryingOp<ConfigTy>(computeOps);
+  if (failed(op))
+    return failure();
+  return getLoweringConfig<ConfigTy>(*op);
+}
 
 /// Returns the tile sizes for a particular operation if the
 /// `iree_codegen.lowering_config` attribute is set on it.
 SmallVector<int64_t> getTileSizes(Operation *op, unsigned level);
 SmallVector<Value> getTileSizes(OpBuilder &b, Operation *op, unsigned level);
 
-/// Returns the number of tiling levels defined in the
-/// `iree_codegen.lowering_config` of this operation.
-unsigned getNumTileLevels(Operation *op);
-
 /// Sets the lowering configuration, overwriting existing attribute values.
-void setLoweringConfig(Operation *op, IREE::Codegen::LoweringConfigAttr config);
+void setLoweringConfig(Operation *op, Attribute config);
 
 /// Convenience function that sets the lowering configuration on the operation
 /// and translation info on the entry point op for the common case of specifying

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -8,6 +8,7 @@
 #define IREE_COMPILER_CODEGEN_DIALECT_IREECODEGENATTRS
 
 include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.td"
+include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td"
 include "mlir/IR/EnumAttr.td"
 
 // List of pre-existing pipelines for translating executables.
@@ -201,14 +202,20 @@ def IREECodegen_LoweringConfigTilingLevelsAttr :
 }
 
 def IREECodegen_LoweringConfigAttr :
-    AttrDef<IREECodegen_Dialect, "LoweringConfig", []> {
+    AttrDef<IREECodegen_Dialect, "LoweringConfig", [
+      DeclareAttrInterfaceMethods<IREECodegen_LoweringConfigAttrInterface, [
+        "getWorkgroupTileSizes",
+        "getWorkgroupInterchange",
+        "getStaticTilingLevelSizes",
+        "getTilingLevelSizes",
+      ]>
+    ]> {
   let mnemonic = "lowering_config";
   let summary = [{drive lowering of an operation within dispatch region}];
   let description = [{
-    Specifies the information that is used by backend compiler to
-    translate an operation to scalar code. The way the information is
-    used is specific to each backend (indeed specific to the pass
-    pipeline used) to compile that operation.
+    Default implementation of a lowering configuration attribute. It includes
+    only tiling and optionally vectorization information. The interpretation of
+    the tiles sizes are backend dependent.
 
     TODO: Currently there is no verification that the configuration
     specifies everything needed for a pass-pipeline. The values to set
@@ -240,10 +247,10 @@ def IREECodegen_LoweringConfigAttr :
   ];
   let extraClassDeclaration = [{
     // Returns the tile sizes for all levels set for the op.
-    TileSizesListType getTileSizeVals();
+    TileSizesListType getTileSizeVals() const;
 
     // Returns the tile sizes for a level set for the op.
-    SmallVector<int64_t> getTileSizeVals(unsigned level);
+    SmallVector<int64_t> getTileSizeVals(unsigned level) const;
 
     // Returns the scalable tile flags for all levels set for the op.
     ScalableTileFlagsListType getScalableTileFlagVals();
@@ -252,7 +259,7 @@ def IREECodegen_LoweringConfigAttr :
     SmallVector<bool> getScalableTileFlagVals(unsigned level);
 
     // Returns the tile interchange for a level set for the op.
-    SmallVector<int64_t> getTileInterchangeVals(unsigned level);
+    SmallVector<int64_t> getTileInterchangeVals(unsigned level) const;
 
     // Returns true if there are no tile interchange values (this means that
     // interchange can be ignored).

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.cpp
@@ -1,0 +1,12 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
+
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
+#include "mlir/IR/DialectImplementation.h"
+
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.cpp.inc"

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h
@@ -1,0 +1,19 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_DIALECT_CODEGEN_IREECODEGENINTERFACES_H_
+#define IREE_COMPILER_CODEGEN_DIALECT_CODEGEN_IREECODEGENINTERFACES_H_
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+
+// clang-format off
+#define GET_ATTRDEF_CLASSES
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h.inc"
+// clang-format on
+
+#endif // IREE_COMPILER_CODEGEN_DIALECT_CODEGEN_IREECODEGENINTERFACES_H_

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
@@ -1,0 +1,93 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_DIALECT_CODEGEN_IREECODEGENINTERFACES
+#define IREE_COMPILER_CODEGEN_DIALECT_CODEGEN_IREECODEGENINTERFACES
+
+include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.td"
+
+def IREECodegen_LoweringConfigAttrInterface :
+  AttrInterface<"LoweringConfigAttrInterface"> {
+  let cppNamespace = "::mlir::iree_compiler::IREE::Codegen";
+  let description = [{
+    Attribute interface for specifying information used by the compiler to
+    translate a specific operation. The way this information is used is backend
+    and/or pipeline specific, so this interface only exposes information needed
+    for shared use cases.
+  }];
+
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns the tile sizes to use for workgroup distribution.
+
+        TODO: This should be queried/constructed from device information and
+        used to compute workgroup size.
+      }],
+      /*retTy=*/"::llvm::SmallVector<int64_t>",
+      /*methodName=*/"getWorkgroupTileSizes",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return ::llvm::SmallVector<int64_t>();
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns the loop interchange to use for workgroup distribution.
+      }],
+      /*retTy=*/"::llvm::SmallVector<int64_t>",
+      /*methodName=*/"getWorkgroupInterchange",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return ::llvm::SmallVector<int64_t>();
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns the tile sizes for the specified tiling level. The
+        interpretation of |level| is attribute and backend dependent. The
+        |target| is the operation this lowering configuration annotates.
+
+        returns an empty list if sizes are not specified for this level. dynamic
+        sizes are specified with `shapedtype::kdynamicsize`.
+      }],
+      /*retTy=*/"::llvm::SmallVector<int64_t>",
+      /*methodName=*/"getStaticTilingLevelSizes",
+      /*args=*/(ins
+        "unsigned":$level,
+        "::mlir::Operation *":$target
+      ),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return ::llvm::SmallVector<int64_t>();
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Constructs the tile sizes for the specified level. The
+        interpretation of |level| is attribute and backend dependent. The
+        |target| is the operation this lowering configuration annotates.
+
+        Returns an empty list if sizes are not specified for this level.
+      }],
+      /*retTy=*/"::llvm::SmallVector<::mlir::OpFoldResult>",
+      /*methodName=*/"getTilingLevelSizes",
+      /*args=*/(ins
+        "::mlir::OpBuilder &":$builder,
+        "unsigned":$level,
+        "::mlir::Operation *":$target
+      ),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return ::llvm::SmallVector<OpFoldResult>();
+      }]
+    >
+  ];
+}
+
+#endif // IREE_COMPILER_CODEGEN_DIALECT_CODEGEN_IREECODEGENINTERFACES

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Codegen/LLVMCPU/KernelDispatch.h"
 
 #include "iree/compiler/Codegen/Common/TileSizeSelection.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.h"
 #include "iree/compiler/Codegen/LLVMCPU/TargetMLTransformInfo.h"
 #include "iree/compiler/Codegen/LLVMCPU/Utils.h"
@@ -2454,7 +2455,8 @@ adjustTileSizesForUnPackOp(mlir::FunctionOpInterface entryPointFn,
   if (!linalgOp)
     return success();
 
-  auto loweringConfig = getLoweringConfig(linalgOp);
+  auto loweringConfig =
+      getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(linalgOp);
   TileSizesListType tileSizesList = loweringConfig.getTileSizeVals();
 
   bool foundUnPackOp = false;
@@ -2625,7 +2627,8 @@ setLoweringConfigForComputeOps(mlir::FunctionOpInterface entryPointFn,
   }
 
   auto ctx = entryPointFn.getContext();
-  auto rootLoweringConfig = getLoweringConfig(rootOperation);
+  auto rootLoweringConfig =
+      getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(rootOperation);
   TilingConfig tilingConfig(rootLoweringConfig);
   SmallVector<int64_t> distTileSizes, parallelVecTileSizes;
   SmallVector<bool> distScalableTileSizes, parallelVecScalableTileSizes;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPU2DScalableTo1DScalable.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPU2DScalableTo1DScalable.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Codegen/Common/TileSizeSelection.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/LLVMCPU/PassDetail.h"
 #include "iree/compiler/Codegen/LLVMCPU/Passes.h"
 #include "iree/compiler/Codegen/LLVMCPU/Utils.h"
@@ -111,7 +112,8 @@ dropScalabilityFromUnsupportedOperations(mlir::FunctionOpInterface funcOp,
   });
 
   for (TilingInterface tilingOp : computeOps) {
-    auto loweringConfigAttr = getLoweringConfig(tilingOp);
+    auto loweringConfigAttr =
+        getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(tilingOp);
     if (!loweringConfigAttr)
       continue;
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -70,7 +70,9 @@ getRootLoweringConfig(FunctionOpInterface funcOp) {
   SmallVector<Operation *> computeOps = getComputeOps(funcOp);
   // Check for self first.
   FailureOr<Operation *> rootOp = getRootOperation(computeOps);
-  auto rootLoweringConfig = iree_compiler::getLoweringConfig(rootOp.value());
+  auto rootLoweringConfig =
+      iree_compiler::getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(
+          rootOp.value());
   if (rootLoweringConfig) {
     return rootLoweringConfig;
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSelectLoweringStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSelectLoweringStrategy.cpp
@@ -68,7 +68,8 @@ verifyLoweringConfiguration(FunctionOpInterface funcOp,
                             IREE::Codegen::TranslationInfoAttr translationInfo,
                             F verificationFn) {
   auto walkResult = funcOp.walk([&](Operation *op) -> WalkResult {
-    IREE::Codegen::LoweringConfigAttr loweringConfig = getLoweringConfig(op);
+    auto loweringConfig =
+        getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(op);
     if (!loweringConfig)
       return WalkResult::advance();
     TilingConfig tilingConfig(loweringConfig);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSplitReduction.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSplitReduction.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Codegen/Common/TileSizeSelection.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/LLVMCPU/PassDetail.h"
 #include "iree/compiler/Codegen/LLVMCPU/Passes.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -188,14 +189,14 @@ void LLVMCPUSplitReductionPass::runOnOperation() {
       continue;
     }
 
-    FailureOr<IREE::Codegen::LoweringConfigAttr> maybeLoweringConfig =
-        getLoweringConfig(genericOp);
-    if (failed(maybeLoweringConfig)) {
+    auto maybeLoweringConfig =
+        getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(genericOp);
+    if (!maybeLoweringConfig) {
       LLVM_DEBUG(llvm::dbgs()
                  << "can't find lowering_config, skip SplitReduction");
       continue;
     }
-    TilingConfig tilingConfig(maybeLoweringConfig.value());
+    TilingConfig tilingConfig(maybeLoweringConfig);
     auto [reductionSizes, scalableDims] =
         tilingConfig.getVectorReductionSizes();
     if (scalableDims.back()) {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTile.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTile.cpp
@@ -4,6 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/LLVMCPU/PassDetail.h"
 #include "iree/compiler/Codegen/LLVMCPU/Passes.h"
 #include "iree/compiler/Codegen/LLVMCPU/Utils.h"
@@ -52,8 +53,8 @@ void LLVMCPUTilePass::runOnOperation() {
   auto funcOp = getOperation();
 
   SmallVector<Operation *> computeOps = getComputeOps(funcOp);
-  FailureOr<IREE::Codegen::LoweringConfigAttr> rootLoweringConfig =
-      getLoweringConfig(computeOps);
+  auto rootLoweringConfig =
+      getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(computeOps);
   if (failed(rootLoweringConfig)) {
     LLVM_DEBUG(llvm::dbgs() << "can't find lowering_config, skip tiling\n");
     return;
@@ -74,7 +75,8 @@ void LLVMCPUTilePass::runOnOperation() {
     LLVM_DEBUG(llvm::dbgs() << "candidate: " << op << "\n");
     SmallVector<int64_t> tileSizes;
     SmallVector<bool> tileScalableFlags;
-    if (auto loweringConfig = getLoweringConfig(op)) {
+    if (auto loweringConfig =
+            getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(op)) {
       tileSizes = loweringConfig.getTileSizeVals(tilingLevel);
       tileScalableFlags = loweringConfig.getScalableTileFlagVals(tilingLevel);
     } else {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTile.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTile.cpp
@@ -53,8 +53,8 @@ void LLVMCPUTilePass::runOnOperation() {
   auto funcOp = getOperation();
 
   SmallVector<Operation *> computeOps = getComputeOps(funcOp);
-  auto rootLoweringConfig =
-      getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(computeOps);
+  FailureOr<IREE::Codegen::LoweringConfigAttr> rootLoweringConfig =
+      getFirstLoweringConfig<IREE::Codegen::LoweringConfigAttr>(computeOps);
   if (failed(rootLoweringConfig)) {
     LLVM_DEBUG(llvm::dbgs() << "can't find lowering_config, skip tiling\n");
     return;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileAndFuse.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileAndFuse.cpp
@@ -4,6 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/UKernelOps.h"
 #include "iree/compiler/Codegen/LLVMCPU/PassDetail.h"
 #include "iree/compiler/Codegen/LLVMCPU/Passes.h"
@@ -244,12 +245,14 @@ void LLVMCPUTileAndFusePass::runOnOperation() {
   // fallback to find a lowering_config from other operations.
   SmallVector<int64_t> tileSizes;
   SmallVector<bool> tileScalableFlags;
-  if (auto loweringConfig = getLoweringConfig(consumerOp)) {
+  if (auto loweringConfig =
+          getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(consumerOp)) {
     tileSizes = loweringConfig.getTileSizeVals(tilingLevel);
     tileScalableFlags = loweringConfig.getScalableTileFlagVals(tilingLevel);
   } else {
-    FailureOr<IREE::Codegen::LoweringConfigAttr> maybeLoweringConfig =
-        getLoweringConfig(getComputeOps(funcOp));
+    auto maybeLoweringConfig =
+        getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(
+            getComputeOps(funcOp));
     if (failed(maybeLoweringConfig)) {
       LLVM_DEBUG(llvm::dbgs()
                  << "can't find lowering_config, skip TileAndFuse");

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileAndFuse.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileAndFuse.cpp
@@ -250,8 +250,8 @@ void LLVMCPUTileAndFusePass::runOnOperation() {
     tileSizes = loweringConfig.getTileSizeVals(tilingLevel);
     tileScalableFlags = loweringConfig.getScalableTileFlagVals(tilingLevel);
   } else {
-    auto maybeLoweringConfig =
-        getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(
+    FailureOr<IREE::Codegen::LoweringConfigAttr> maybeLoweringConfig =
+        getFirstLoweringConfig<IREE::Codegen::LoweringConfigAttr>(
             getComputeOps(funcOp));
     if (failed(maybeLoweringConfig)) {
       LLVM_DEBUG(llvm::dbgs()

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -1927,7 +1927,7 @@ static LogicalResult setRootConfig(mlir::FunctionOpInterface entryPointFn,
 // determined based on the op.
 static void propagateLoweringConfig(Operation *rootOperation,
                                     SmallVector<Operation *> computeOps) {
-  if (IREE::Codegen::LoweringConfigAttr config =
+  if (IREE::Codegen::LoweringConfigAttrInterface config =
           getLoweringConfig(rootOperation)) {
     for (auto op : computeOps) {
       if (op == rootOperation)

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUSelectLoweringStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUSelectLoweringStrategy.cpp
@@ -71,7 +71,8 @@ verifyLoweringConfiguration(FunctionOpInterface funcOp,
                             IREE::Codegen::TranslationInfoAttr translationInfo,
                             ArrayRef<int64_t> workgroupSize, F verificationFn) {
   auto walkResult = funcOp.walk([&](Operation *op) -> WalkResult {
-    IREE::Codegen::LoweringConfigAttr loweringConfig = getLoweringConfig(op);
+    auto loweringConfig =
+        getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(op);
     if (!loweringConfig)
       return WalkResult::advance();
     return verificationFn(op, loweringConfig, translationInfo, workgroupSize);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLKernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLKernelConfig.cpp
@@ -324,7 +324,8 @@ static LogicalResult setRootConfig(mlir::FunctionOpInterface entryPointFn,
 // Propagates the configuration to the other ops.
 static void propagateLoweringConfig(Operation *rootOp,
                                     ArrayRef<Operation *> computeOps) {
-  if (IREE::Codegen::LoweringConfigAttr config = getLoweringConfig(rootOp)) {
+  if (IREE::Codegen::LoweringConfigAttrInterface config =
+          getLoweringConfig(rootOp)) {
     for (auto op : computeOps) {
       if (op != rootOp)
         setLoweringConfig(op, config);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVSelectLoweringStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVSelectLoweringStrategy.cpp
@@ -62,7 +62,8 @@ verifyLoweringConfiguration(FunctionOpInterface funcOp,
                             IREE::Codegen::TranslationInfoAttr translationInfo,
                             ArrayRef<int64_t> workgroupSize, F verificationFn) {
   auto walkResult = funcOp.walk([&](Operation *op) -> WalkResult {
-    IREE::Codegen::LoweringConfigAttr loweringConfig = getLoweringConfig(op);
+    auto loweringConfig =
+        getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(op);
     if (!loweringConfig)
       return WalkResult::advance();
     return verificationFn(op, loweringConfig, translationInfo, workgroupSize);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Utils.cpp
@@ -71,8 +71,8 @@ std::optional<int> getSPIRVSubgroupSize(mlir::FunctionOpInterface funcOp) {
 FailureOr<SmallVector<int64_t>>
 getSPIRVTileSize(mlir::FunctionOpInterface funcOp, int tilingLevel) {
   SmallVector<Operation *> computeOps = getComputeOps(funcOp);
-  auto config =
-      getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(computeOps);
+  FailureOr<IREE::Codegen::LoweringConfigAttr> config =
+      getFirstLoweringConfig<IREE::Codegen::LoweringConfigAttr>(computeOps);
   if (failed(config)) {
     return funcOp.emitOpError("failed to get lowering configuration");
   }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Utils.cpp
@@ -71,7 +71,8 @@ std::optional<int> getSPIRVSubgroupSize(mlir::FunctionOpInterface funcOp) {
 FailureOr<SmallVector<int64_t>>
 getSPIRVTileSize(mlir::FunctionOpInterface funcOp, int tilingLevel) {
   SmallVector<Operation *> computeOps = getComputeOps(funcOp);
-  auto config = getLoweringConfig(computeOps);
+  auto config =
+      getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(computeOps);
   if (failed(config)) {
     return funcOp.emitOpError("failed to get lowering configuration");
   }

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -161,8 +161,8 @@ const char *getGPUDistributeAttrName() { return "iree.gpu.distribute_dim"; }
 FailureOr<SmallVector<int64_t>> getGPUTileSize(mlir::FunctionOpInterface funcOp,
                                                int tilingLevel) {
   SmallVector<Operation *> computeOps = getComputeOps(funcOp);
-  auto config =
-      getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(computeOps);
+  FailureOr<IREE::Codegen::LoweringConfigAttr> config =
+      getFirstLoweringConfig<IREE::Codegen::LoweringConfigAttr>(computeOps);
   if (failed(config)) {
     return funcOp.emitOpError("failed to get lowering configuration");
   }

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -161,7 +161,8 @@ const char *getGPUDistributeAttrName() { return "iree.gpu.distribute_dim"; }
 FailureOr<SmallVector<int64_t>> getGPUTileSize(mlir::FunctionOpInterface funcOp,
                                                int tilingLevel) {
   SmallVector<Operation *> computeOps = getComputeOps(funcOp);
-  auto config = getLoweringConfig(computeOps);
+  auto config =
+      getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(computeOps);
   if (failed(config)) {
     return funcOp.emitOpError("failed to get lowering configuration");
   }


### PR DESCRIPTION
This makes it easier to add more varied lowering configurations across backends without having to add to a shared attribute implementation.

This patch opts against changing the `iree_codegen.compilation_info` attribute to use the interface because that would introduce a parsing change to that attribute and keeps this PR as close to NFC as possible.

Closes #17438