### PR TITLE
[CPU][ArmSME] Enable transposes for f32 and f64

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -334,31 +334,6 @@ static bool x86TransposeLoweringPrecondition(linalg::GenericOp genericOp) {
            indexingMaps[1].isIdentity()));
 }
 
-/// Returns true if the `genericOp` implementing a transposition is supported by
-/// AArch64 SME, i.e. all of the following are true:
-///
-///   1. The op has 2 dimensions.
-///   2. The op has a single input and a single output.
-///   3. One of the `indexing_maps` is a permutation and the other an identity.
-static bool
-transposeLoweringPreconditionAArch64SME(linalg::GenericOp genericOp) {
-  // Check op has 2 dimensions.
-  if (genericOp.getNumLoops() != 2)
-    return false;
-
-  // Check op has single input and output.
-  if ((genericOp.getNumDpsInputs() != 1) || (genericOp.getNumDpsInits() != 1))
-    return false;
-
-  // Check all iterators are parallel.
-  if (genericOp.getNumParallelLoops() != genericOp.getNumLoops())
-    return false;
-
-  // Check that the two indexing maps are a permutation of each other.
-  SmallVector<AffineMap> indexingMaps = genericOp.getIndexingMapsArray();
-  return indexingMaps[0].isPermutation() && indexingMaps[1].isIdentity();
-}
-
 /// Returns minimum tiling sizes for each dimension. One dimension is possible
 /// to access at different element types. It determines the tiling sizes by
 /// looking into all the operands.

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -2007,8 +2007,8 @@ static void getTransposeX86VectorSizes(
   // Replace dims to be vectorized with the new tile sizes.
   sizes.assign(minTileSizes.begin(), minTileSizes.end());
   std::replace_if(
-      sizes.begin(), sizes.end(),
-      [](int64_t tileSize) { return tileSize > 1; }, targetVectorSize);
+      sizes.begin(), sizes.end(), [](int64_t tileSize) { return tileSize > 1; },
+      targetVectorSize);
 }
 
 /// Utility to return the transpose vector `sizes` for AArch64. Empty `sizes` on

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1974,7 +1974,7 @@ setTransformStrategyRootConfig(mlir::FunctionOpInterface entryPointFn,
 /// return indicates failure.
 static void getTransposeX86VectorSizes(
     linalg::GenericOp genericOp, IREE::HAL::ExecutableTargetAttr targetAttr,
-    SmallVectorImpl<int64_t> &minTileSizes, SmallVectorImpl<int64_t> &sizes) {
+    ArrayRef<int64_t> minTileSizes, SmallVectorImpl<int64_t> &sizes) {
   if (!hasAVX2Feature(targetAttr) ||
       !x86TransposeLoweringPrecondition(genericOp))
     return;
@@ -2005,11 +2005,10 @@ static void getTransposeX86VectorSizes(
   }
 
   // Replace dims to be vectorized with the new tile sizes.
+  sizes.assign(minTileSizes.begin(), minTileSizes.end());
   std::replace_if(
-      minTileSizes.begin(), minTileSizes.end(),
+      sizes.begin(), sizes.end(),
       [](int64_t tileSize) { return tileSize > 1; }, targetVectorSize);
-
-  sizes = minTileSizes;
 }
 
 /// Utility to return the transpose vector `sizes` for AArch64. Empty `sizes` on

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -2014,6 +2014,7 @@ static void getTransposeX86VectorSizes(
 
 /// Utility to return the transpose vector `sizes` for AArch64. Empty `sizes` on
 /// return indicates failure.
+/// NOTE: only SME is currently supported.
 static void getTransposeAArch64VectorSizes(
     linalg::GenericOp genericOp, IREE::HAL::ExecutableTargetAttr targetAttr,
     SmallVectorImpl<int64_t> &sizes, SmallVectorImpl<bool> &scalableFlags) {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -2063,6 +2063,8 @@ setTransposeLikeOpRootConfig(mlir::FunctionOpInterface entryPointFn,
       distConfig.minTileSizes = {2, 2};
     else
       return failure();
+  } else {
+    return failure();
   }
 
   auto vecPreProcStrategy = getVectorPreProcStrategy(genericOp);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPU2DScalableTo1DScalable.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPU2DScalableTo1DScalable.cpp
@@ -89,8 +89,7 @@ public:
 
 static bool opKnownToSupport2DScalableVectorizationWithArmSME(Operation *op) {
   if (auto genericOp = dyn_cast<linalg::GenericOp>(op))
-    return LinalgOpInfo(genericOp).isTranspose() &&
-           isLinalgGeneric2DTranspose(genericOp);
+    return isLinalgGeneric2DTranspose(genericOp);
   return isa<linalg::MatmulOp, linalg::MatmulTransposeAOp, linalg::FillOp>(op);
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPU2DScalableTo1DScalable.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPU2DScalableTo1DScalable.cpp
@@ -89,7 +89,8 @@ public:
 
 static bool opKnownToSupport2DScalableVectorizationWithArmSME(Operation *op) {
   if (auto genericOp = dyn_cast<linalg::GenericOp>(op))
-    return LinalgOpInfo(genericOp).isTranspose();
+    return LinalgOpInfo(genericOp).isTranspose() &&
+           transposeLoweringPreconditionAArch64SME(genericOp);
   return isa<linalg::MatmulOp, linalg::MatmulTransposeAOp, linalg::FillOp>(op);
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPU2DScalableTo1DScalable.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPU2DScalableTo1DScalable.cpp
@@ -9,6 +9,7 @@
 #include "iree/compiler/Codegen/LLVMCPU/PassDetail.h"
 #include "iree/compiler/Codegen/LLVMCPU/Passes.h"
 #include "iree/compiler/Codegen/LLVMCPU/Utils.h"
+#include "iree/compiler/Codegen/Utils/LinalgOpInfo.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "mlir/Dialect/SCF/Utils/Utils.h"
 #include "mlir/Pass/Pass.h"
@@ -87,6 +88,8 @@ public:
 };
 
 static bool opKnownToSupport2DScalableVectorizationWithArmSME(Operation *op) {
+  if (auto genericOp = dyn_cast<linalg::GenericOp>(op))
+    return LinalgOpInfo(genericOp).isTranspose();
   return isa<linalg::MatmulOp, linalg::MatmulTransposeAOp, linalg::FillOp>(op);
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPU2DScalableTo1DScalable.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPU2DScalableTo1DScalable.cpp
@@ -90,7 +90,7 @@ public:
 static bool opKnownToSupport2DScalableVectorizationWithArmSME(Operation *op) {
   if (auto genericOp = dyn_cast<linalg::GenericOp>(op))
     return LinalgOpInfo(genericOp).isTranspose() &&
-           transposeLoweringPreconditionAArch64SME(genericOp);
+           isLinalgGeneric2DTranspose(genericOp);
   return isa<linalg::MatmulOp, linalg::MatmulTransposeAOp, linalg::FillOp>(op);
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.cpp
@@ -85,7 +85,7 @@ bool isLinalgGeneric2DTranspose(linalg::GenericOp genericOp) {
 
   auto yieldOp = cast<linalg::YieldOp>(body.getTerminator());
 
-  // The yield op should return the block argument corresponds to the input.
+  // The yield op should return the block argument corresponding to the input.
   auto yieldArg = dyn_cast<BlockArgument>(yieldOp.getValues()[0]);
   if (!yieldArg || yieldArg.getArgNumber() != 0 || yieldArg.getOwner() != &body)
     return false;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.h
@@ -42,6 +42,16 @@ bool hasSMEFeature(IREE::HAL::ExecutableTargetAttr targetAttr);
 /// Returns true if the 'targetAttr' contains '+i8mm' in its cpu features.
 bool hasI8mmFeature(IREE::HAL::ExecutableTargetAttr targetAttr);
 
+/// Returns true if the `genericOp` implementing a transposition is supported by
+/// AArch64 SME, i.e. all of the following are true:
+///
+///   1. The op has 2 dimensions.
+///   2. The op has a single input and a single output.
+///   3. One of the `indexing_maps` is a permutation and the other an identity.
+///   4. The body of the generic has a single yield op returning the block
+///   argument corresponding to the input.
+bool transposeLoweringPreconditionAArch64SME(linalg::GenericOp genericOp);
+
 } // namespace mlir::iree_compiler
 
 #endif // IREE_COMPILER_CODEGEN_LLVMCPU_UTILS_H_

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.h
@@ -42,15 +42,14 @@ bool hasSMEFeature(IREE::HAL::ExecutableTargetAttr targetAttr);
 /// Returns true if the 'targetAttr' contains '+i8mm' in its cpu features.
 bool hasI8mmFeature(IREE::HAL::ExecutableTargetAttr targetAttr);
 
-/// Returns true if the `genericOp` implementing a transposition is supported by
-/// AArch64 SME, i.e. all of the following are true:
+/// Returns true if the `genericOp` is a simple 2D transpose, i.e.,
 ///
 ///   1. The op has 2 dimensions.
 ///   2. The op has a single input and a single output.
 ///   3. One of the `indexing_maps` is a permutation and the other an identity.
 ///   4. The body of the generic has a single yield op returning the block
 ///   argument corresponding to the input.
-bool transposeLoweringPreconditionAArch64SME(linalg::GenericOp genericOp);
+bool isLinalgGeneric2DTranspose(linalg::GenericOp genericOp);
 
 } // namespace mlir::iree_compiler
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD.bazel
@@ -48,6 +48,7 @@ iree_lit_test_suite(
             "pipeline_vectorize_nd_extract_tests.mlir",
             "scalable_tile_and_vectorize_matmul.mlir",
             "select_aarch64_lowering_strategy.mlir",
+            "select_aarch64_sme_lowering_strategy.mlir",
             "select_aarch64_sve_lowering_strategy.mlir",
             "select_aarch64_sve_lowering_strategy_peeling.mlir",
             "select_lowering_strategy_without_distribution.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
@@ -43,6 +43,7 @@ iree_lit_test_suite(
     "pipeline_vectorize_nd_extract_tests.mlir"
     "scalable_tile_and_vectorize_matmul.mlir"
     "select_aarch64_lowering_strategy.mlir"
+    "select_aarch64_sme_lowering_strategy.mlir"
     "select_aarch64_sve_lowering_strategy.mlir"
     "select_aarch64_sve_lowering_strategy_peeling.mlir"
     "select_lowering_strategy_without_distribution.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sme_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sme_lowering_strategy.mlir
@@ -1,0 +1,47 @@
+// RUN: iree-opt --pass-pipeline='builtin.module(iree-llvmcpu-select-lowering-strategy)' --iree-llvmcpu-enable-scalable-vectorization=true --split-input-file %s | FileCheck %s
+
+#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve,+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>
+func.func @transpose_f32() attributes {hal.executable.target = #executable_target_embedded_elf_arm_64_} {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<32x32xf32>>
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<32x32xf32>>
+  %2 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [32, 32], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<32x32xf32>> -> tensor<32x32xf32>
+  %3 = tensor.empty() : tensor<32x32xf32>
+  %4 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d1, d0)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%2 : tensor<32x32xf32>) outs(%3 : tensor<32x32xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    linalg.yield %in : f32
+  } -> tensor<32x32xf32>
+  flow.dispatch.tensor.store %4, %1, offsets = [0, 0], sizes = [32, 32], strides = [1, 1] : tensor<32x32xf32> -> !flow.dispatch.tensor<writeonly:tensor<32x32xf32>>
+  return
+}
+
+//   CHECK: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[16, 16], {{\[}}[4], [4]], [0, 0], [0, 0]]>
+//   CHECK: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
+//       CHECK: func.func @transpose_f32()
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//       CHECK: linalg.generic
+//  CHECK-SAME:     lowering_config = #[[CONFIG]]
+
+// -----
+
+#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve,+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>
+func.func @transpose_f64() attributes {hal.executable.target = #executable_target_embedded_elf_arm_64_} {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<32x32xf64>>
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<32x32xf64>>
+  %2 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [32, 32], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<32x32xf64>> -> tensor<32x32xf64>
+  %3 = tensor.empty() : tensor<32x32xf64>
+  %4 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d1, d0)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%2 : tensor<32x32xf64>) outs(%3 : tensor<32x32xf64>) {
+  ^bb0(%in: f64, %out: f64):
+    linalg.yield %in : f64
+  } -> tensor<32x32xf64>
+  flow.dispatch.tensor.store %4, %1, offsets = [0, 0], sizes = [32, 32], strides = [1, 1] : tensor<32x32xf64> -> !flow.dispatch.tensor<writeonly:tensor<32x32xf64>>
+  return
+}
+
+//   CHECK: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[16, 16], {{\[}}[2], [2]], [0, 0], [0, 0]]>
+//   CHECK: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
+//       CHECK: func.func @transpose_f64()
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//       CHECK: linalg.generic
+//  CHECK-SAME:     lowering_config = #[[CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sme_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sme_lowering_strategy.mlir
@@ -15,7 +15,7 @@ func.func @transpose_f32() attributes {hal.executable.target = #executable_targe
   return
 }
 
-//   CHECK: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[16, 16], {{\[}}[4], [4]], [0, 0], [0, 0]]>
+//   CHECK: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[4, 16], {{\[}}[4], [4]], [0, 0], [0, 0]]>
 //   CHECK: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //       CHECK: func.func @transpose_f32()
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -39,9 +39,33 @@ func.func @transpose_f64() attributes {hal.executable.target = #executable_targe
   return
 }
 
-//   CHECK: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[16, 16], {{\[}}[2], [2]], [0, 0], [0, 0]]>
+//   CHECK: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[4, 16], {{\[}}[2], [2]], [0, 0], [0, 0]]>
 //   CHECK: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //       CHECK: func.func @transpose_f64()
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//       CHECK: linalg.generic
+//  CHECK-SAME:     lowering_config = #[[CONFIG]]
+
+// -----
+
+#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve,+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>
+func.func @transpose_unsupported() attributes {hal.executable.target = #executable_target_embedded_elf_arm_64_} {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2x4x8xf32>>
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2x8x4xf32>>
+  %2 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [2, 4, 8], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<2x4x8xf32>> -> tensor<2x4x8xf32>
+  %3 = tensor.empty() : tensor<2x8x4xf32>
+  %4 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%2 : tensor<2x4x8xf32>) outs(%3 : tensor<2x8x4xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    linalg.yield %in : f32
+  } -> tensor<2x8x4xf32>
+  flow.dispatch.tensor.store %4, %1, offsets = [0, 0, 0], sizes = [2, 8, 4], strides = [1, 1, 1] : tensor<2x8x4xf32> -> !flow.dispatch.tensor<writeonly:tensor<2x8x4xf32>>
+  return
+}
+
+//   CHECK: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[2, 8, 4], [1, 4, 4], [0, 0, 0], [0, 0, 0]]>
+//   CHECK: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
+//       CHECK: func.func @transpose_unsupported
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK: linalg.generic
 //  CHECK-SAME:     lowering_config = #[[CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sme_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_aarch64_sme_lowering_strategy.mlir
@@ -49,7 +49,7 @@ func.func @transpose_f64() attributes {hal.executable.target = #executable_targe
 // -----
 
 #executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve,+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>
-func.func @transpose_unsupported() attributes {hal.executable.target = #executable_target_embedded_elf_arm_64_} {
+func.func @transpose_unsupported_not_rank_2() attributes {hal.executable.target = #executable_target_embedded_elf_arm_64_} {
   %c0 = arith.constant 0 : index
   %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2x4x8xf32>>
   %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2x8x4xf32>>
@@ -65,7 +65,31 @@ func.func @transpose_unsupported() attributes {hal.executable.target = #executab
 
 //   CHECK: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[2, 8, 4], [1, 4, 4], [0, 0, 0], [0, 0, 0]]>
 //   CHECK: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
-//       CHECK: func.func @transpose_unsupported
+//       CHECK: func.func @transpose_unsupported_not_rank_2
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//       CHECK: linalg.generic
+//  CHECK-SAME:     lowering_config = #[[CONFIG]]
+
+// -----
+
+#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {cpu_features = "+sve,+sme", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>
+func.func @transpose_unsupported_not_simple_transpose() attributes {hal.executable.target = #executable_target_embedded_elf_arm_64_} {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<32x32xf32>>
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<32x32xf32>>
+  %2 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [32, 32], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<32x32xf32>> -> tensor<32x32xf32>
+  %3 = tensor.empty() : tensor<32x32xf32>
+  %4 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d1, d0)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%2 : tensor<32x32xf32>) outs(%3 : tensor<32x32xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    linalg.yield %out : f32
+  } -> tensor<32x32xf32>
+  flow.dispatch.tensor.store %4, %1, offsets = [0, 0], sizes = [32, 32], strides = [1, 1] : tensor<32x32xf32> -> !flow.dispatch.tensor<writeonly:tensor<32x32xf32>>
+  return
+}
+
+//   CHECK: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[32, 32], {{\[}}4, 4], [0, 0], [0, 0]]>
+//   CHECK: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
+//       CHECK: func.func @transpose_unsupported_not_simple_transpose()
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK: linalg.generic
 //  CHECK-SAME:     lowering_config = #[[CONFIG]]


### PR DESCRIPTION
This patch enables transposes for ArmSME for f32 and f64 types now that they
may get eliminated by folding into defining `vector.transfer_read` since [1].
This is done by extending `setTransposeLikeOpRootConfig` which currently only
supports x86 (no changes there). The transpose is represented by a
`linalg.generic`, since `linalg.transpose` gets converted by
`GeneralizeLinalgNamedOps`.

[1] https://github.com/llvm/llvm-project/pull/92562

ci-extra: build_test_all_arm64