### PR TITLE
Register ShapeDialect in StableHLO plugin.

### DIFF
--- a/compiler/plugins/input/StableHLO/BUILD.bazel
+++ b/compiler/plugins/input/StableHLO/BUILD.bazel
@@ -28,6 +28,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:ConversionPasses",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:ShapeDialect",
         "@llvm-project//mlir:Transforms",
         "@stablehlo//:chlo_ops",
         "@stablehlo//:stablehlo_ops",

--- a/compiler/plugins/input/StableHLO/CMakeLists.txt
+++ b/compiler/plugins/input/StableHLO/CMakeLists.txt
@@ -30,6 +30,7 @@ iree_cc_library(
     ChloOps
     MLIRIR
     MLIRPass
+    MLIRShapeDialect
     MLIRTransforms
     StablehloOps
     VhloOps

--- a/compiler/plugins/input/StableHLO/PluginRegistration.cpp
+++ b/compiler/plugins/input/StableHLO/PluginRegistration.cpp
@@ -7,6 +7,7 @@
 #include "compiler/plugins/input/StableHLO/Conversion/Passes.h"
 #include "iree/compiler/PluginAPI/Client.h"
 #include "mlir/Conversion/Passes.h"
+#include "mlir/Dialect/Shape/IR/Shape.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/PassManager.h"
 #include "stablehlo/dialect/ChloOps.h"
@@ -63,6 +64,7 @@ struct StableHLOSession
   }
 
   void onRegisterDialects(DialectRegistry &registry) override {
+    registry.insert<mlir::shape::ShapeDialect>();
     registry.insert<mlir::chlo::ChloDialect>();
     registry.insert<mlir::stablehlo::StablehloDialect>();
     registry.insert<mlir::vhlo::VhloDialect>();


### PR DESCRIPTION
Fixes https://github.com/iree-org/iree/issues/16345

This fixes ``LLVM ERROR: Building op `shape.shape_of` but it isn't known in this MLIRContext: the dialect may not be loaded or this operation hasn't been added by the dialect`` errors. Something about how the pass pipelines are constructed (dynamically?) made it so local registration wasn't enough.

A few other dialects (tensor, arith, scf) appear to also be missing. Might need to add those too.