### PR TITLE
[GPU] Support specifying LLVMGPU backend target features

### DIFF
--- a/compiler/plugins/target/CUDA/CUDATarget.cpp
+++ b/compiler/plugins/target/CUDA/CUDATarget.cpp
@@ -103,6 +103,14 @@ struct CUDAOptions {
         llvm::cl::cat(category),
         llvm::cl::desc("Passes the given additional parameters to ptxas."));
   }
+
+  LogicalResult verify(mlir::Builder &builder) const {
+    if (GPU::normalizeCUDATarget(clTargetChip).empty()) {
+      return emitError(builder.getUnknownLoc(), "Unknown CUDA target '")
+             << clTargetChip << "'";
+    }
+    return success();
+  }
 };
 } // namespace
 
@@ -425,6 +433,9 @@ public:
       configItems.emplace_back(b.getStringAttr(name), value);
     };
 
+    if (failed(options.verify(b)))
+      return nullptr;
+
     if (auto target = GPU::getCUDATargetDetails(
             options.clTargetChip, options.clTargetFeature, context))
       addConfig("iree.gpu.target", target);
@@ -461,8 +472,11 @@ public:
                                     OpBuilder &executableBuilder) override {
     auto targetAttr = variantOp.getTargetAttr();
     StringRef targetArch = options.clTargetChip;
-    if (auto attr = getGPUTargetAttr(targetAttr))
+    StringRef targetFeatures = options.clTargetFeature;
+    if (auto attr = getGPUTargetAttr(targetAttr)) {
       targetArch = attr.getArch();
+      targetFeatures = attr.getFeatures();
+    }
 
     // Perform the translation in a separate context to avoid any
     // multi-threading issues.
@@ -585,7 +599,6 @@ public:
       std::unique_ptr<llvm::TargetMachine> targetMachine;
       {
         llvm::Triple triple("nvptx64-nvidia-cuda");
-        std::string features = options.clTargetFeature;
         std::string error;
         const llvm::Target *target =
             llvm::TargetRegistry::lookupTarget("", triple, error);
@@ -593,7 +606,7 @@ public:
           return variantOp.emitError() << "cannot initialize target triple";
         }
         targetMachine.reset(target->createTargetMachine(
-            triple.str(), targetArch, features, {}, {}));
+            triple.str(), targetArch, targetFeatures, {}, {}));
         if (targetMachine == nullptr) {
           return variantOp.emitError() << "cannot initialize target machine";
         }

--- a/compiler/plugins/target/CUDA/CUDATarget.cpp
+++ b/compiler/plugins/target/CUDA/CUDATarget.cpp
@@ -425,7 +425,8 @@ public:
       configItems.emplace_back(b.getStringAttr(name), value);
     };
 
-    if (auto target = GPU::getCUDATargetDetails(options.clTargetChip, context))
+    if (auto target = GPU::getCUDATargetDetails(
+            options.clTargetChip, options.clTargetFeature, context))
       addConfig("iree.gpu.target", target);
 
     return b.getAttr<IREE::HAL::ExecutableTargetAttr>(

--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -298,8 +298,11 @@ public:
     ModuleOp innerModuleOp = variantOp.getInnerModule();
     auto targetAttr = variantOp.getTargetAttr();
     StringRef targetArch = options.targetChip;
-    if (auto attr = getGPUTargetAttr(targetAttr))
+    StringRef targetFeatures = options.targetFeatures;
+    if (auto attr = getGPUTargetAttr(targetAttr)) {
       targetArch = attr.getArch();
+      targetFeatures = attr.getFeatures();
+    }
 
     // We name our files after the executable name so that they are easy to
     // track both during compilation (logs/artifacts/etc), as outputs (final
@@ -445,6 +448,9 @@ public:
             features = "+wavefrontsize32";
           if (subgroupSize == 64)
             features = "+wavefrontsize64";
+        }
+        if (!targetFeatures.empty()) {
+          features += (features.empty() ? "" : ",") + targetFeatures.str();
         }
 
         targetMachine.reset(target->createTargetMachine(

--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -89,8 +89,7 @@ struct ROCmOptions {
     SmallVector<StringRef> features;
     llvm::SplitString(targetFeatures, features, ",");
     for (StringRef f : features) {
-      if (f.ends_with("+") || f.ends_with("-") ||
-          !(f.starts_with("+") || f.starts_with("-"))) {
+      if (!(f.starts_with("+") || f.starts_with("-"))) {
         return emitError(builder.getUnknownLoc(),
                          "ROCm target feature must be prefixed with '+' or "
                          "'-'; but seen '")

--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -23,6 +23,7 @@
 #include "iree/compiler/Utils/ModuleUtils.h"
 #include "iree/compiler/Utils/ToolUtils.h"
 #include "iree/schemas/rocm_executable_def_builder.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/Bitcode/BitcodeWriter.h"
@@ -54,6 +55,7 @@ namespace {
 
 struct ROCmOptions {
   std::string targetChip = "gfx908";
+  std::string targetFeatures = "";
   std::string bitcodeDirectory = getDefaultBitcodeDirectory();
   int wavesPerEu = 0;
   std::string enableROCMUkernels = "none";
@@ -63,6 +65,9 @@ struct ROCmOptions {
     static cl::OptionCategory category("ROCm HAL Target");
     binder.opt<std::string>("iree-rocm-target-chip", targetChip,
                             cl::cat(category), cl::desc("ROCm target chip."));
+    binder.opt<std::string>(
+        "iree-rocm-target-features", targetFeatures, cl::cat(category),
+        cl::desc("ROCm target features; e.g., '+sramecc,+xnack'."));
     binder.opt<std::string>("iree-rocm-bc-dir", bitcodeDirectory,
                             cl::cat(category),
                             cl::desc("Directory of ROCm Bitcode."));
@@ -74,6 +79,34 @@ struct ROCmOptions {
         cl::desc("Enables microkernels in the rocm compiler backend. May be "
                  "`default`, `none`, `all`, or a comma-separated list of "
                  "specific unprefixed microkernels to enable, e.g. `mmt4d`."));
+  }
+
+  LogicalResult verify(mlir::Builder &builder) const {
+    if (GPU::normalizeHIPTarget(targetChip).empty()) {
+      return emitError(builder.getUnknownLoc(), "Unknown ROCm target '")
+             << targetChip << "'";
+    }
+    SmallVector<StringRef> features;
+    llvm::SplitString(targetFeatures, features, ",");
+    for (StringRef f : features) {
+      if (f.ends_with("+") || f.ends_with("-") ||
+          !(f.starts_with("+") || f.starts_with("-"))) {
+        return emitError(builder.getUnknownLoc(),
+                         "ROCm target feature must be prefixed with '+' or "
+                         "'-'; but seen '")
+               << f << "'";
+      }
+      StringRef feature = f.substr(1);
+      if (feature != "sramecc" && feature != "xnack") {
+        // We only support these two features to be set explicitly. Features
+        // like wavefrontsize is controlled and tuned by the compiler.
+        return emitError(builder.getUnknownLoc(),
+                         "ROCm target feature can only be 'sramecc' or "
+                         "'xnack'; but seen '")
+               << feature << "'";
+      }
+    }
+    return success();
   }
 
 private:
@@ -173,7 +206,8 @@ public:
       MLIRContext *context, StringRef deviceID, DictionaryAttr deviceConfigAttr,
       SmallVectorImpl<IREE::HAL::ExecutableTargetAttr> &executableTargetAttrs)
       const override {
-    executableTargetAttrs.push_back(getExecutableTarget(context));
+    if (auto target = getExecutableTarget(context))
+      executableTargetAttrs.push_back(target);
   }
 
   IREE::HAL::ExecutableTargetAttr
@@ -184,7 +218,11 @@ public:
       configItems.emplace_back(b.getStringAttr(name), value);
     };
 
-    if (auto target = GPU::getHIPTargetDetails(options.targetChip, context))
+    if (failed(options.verify(b)))
+      return nullptr;
+
+    if (auto target = GPU::getHIPTargetDetails(options.targetChip,
+                                               options.targetFeatures, context))
       addConfig("iree.gpu.target", target);
 
     addConfig("ukernels", b.getStringAttr(options.enableROCMUkernels));
@@ -401,10 +439,8 @@ public:
         opt.NoInfsFPMath = false;
         opt.NoNaNsFPMath = true;
         std::string features;
-        if (targetArch.starts_with("gfx9")) {
-          features = "+sramecc,-xnack";
-        } else {
-          // GFX 10 or 11.
+        if (targetArch.starts_with("gfx10") ||
+            targetArch.starts_with("gfx11")) {
           if (subgroupSize == 32)
             features = "+wavefrontsize32";
           if (subgroupSize == 64)

--- a/compiler/plugins/target/ROCM/test/target_device_features.mlir
+++ b/compiler/plugins/target/ROCM/test/target_device_features.mlir
@@ -1,6 +1,7 @@
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetBackends=rocm},iree-hal-transformation-pipeline{serialize-executables=false})' --iree-rocm-target-chip=mi300x %s | FileCheck %s --check-prefix=GFX942
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetBackends=rocm},iree-hal-transformation-pipeline{serialize-executables=false})' --iree-rocm-target-chip=gfx940 %s | FileCheck %s --check-prefix=GFX940
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetBackends=rocm},iree-hal-transformation-pipeline{serialize-executables=false})' --iree-rocm-target-chip=rx7900xtx %s | FileCheck %s --check-prefix=GFX1100
+// RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetBackends=rocm},iree-hal-transformation-pipeline{serialize-executables=false})' --iree-rocm-target-chip=gfx941 --iree-rocm-target-features=+sramecc,-xnack %s | FileCheck %s --check-prefix=GFX941
 
 // GFX942: target = #iree_gpu.target<arch = "gfx942",
 // GFX942-SAME: wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8,
@@ -16,6 +17,9 @@
 // GFX1100: target = #iree_gpu.target<arch = "gfx1100",
 // GFX1100-SAME:        mma = [<WMMA_F16_16x16x16_F32>]
 // GFX1100-SAME:        subgroup_size_choices = [32, 64]
+
+// GFX941: target = #iree_gpu.target<arch = "gfx941",
+// GFX941-SAME:         features = "+sramecc,-xnack"
 
 
 stream.executable public @reduce_dispatch {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -308,6 +308,7 @@ def IREEGPU_TargetAttr : AttrDef<IREEGPU_Dialect, "Target"> {
 
   let parameters = (ins
     StringRefParameter<"target architecture">:$arch,
+    StringRefParameter<"target features">:$features,
     "TargetWgpAttr":$wgp,
     OptionalParameter<"TargetChipAttr">:$chip
   );

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/target_attrs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/target_attrs.mlir
@@ -53,10 +53,13 @@ func.func @test_target_chip() attributes {
 // CHECK-LABEL: func.func @test_target()
 func.func @test_target() attributes {
   // CHECK: #iree_gpu.target<
+  // CHECK-SAME: arch = "gfx942"
+  // CHECK-SAME: features = "+sramecc,+xnack"
   // CHECK-SAME: wgp = <
   // CHECK-SAME: chip = <
   target = #iree_gpu.target<
     arch="gfx942",
+    features="+sramecc,+xnack",
     wgp = <
       compute = fp16|fp32|int8, storage = b16|b32,
       subgroup = shuffle|arithmetic, dot = dp4xi8toi32,

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.h
@@ -14,9 +14,11 @@ namespace mlir::iree_compiler::IREE::GPU {
 
 // Returns a TargetAttr to describe the details of the given |target|, which can
 // be a product name like "rx7900xtx", an microarchitecture name like "rdna3",
-// or a compiler target like "gfx1100". Returns a null TargetAttr if the given
-// |target| is not recognized.
-TargetAttr getHIPTargetDetails(llvm::StringRef target, MLIRContext *context);
+// or a compiler target like "gfx1100". |features| is a list of comma-separated
+// target features. Returns a null TargetAttr if the given |target| is not
+// recognized.
+TargetAttr getHIPTargetDetails(llvm::StringRef target, llvm::StringRef features,
+                               MLIRContext *context);
 
 // Normalizes the given HIP |target| to the gfx target commonly used for
 // compiling towards HIP. For example, "gfx90a" for "cnda2", "gfx1100" for
@@ -25,19 +27,20 @@ StringRef normalizeHIPTarget(StringRef target);
 
 // Returns a TargetAttr to describe the details of the given |target|, which can
 // be a product name like "rtx3090", an microarchitecture name like "ampere", or
-// a compute capability like "sm_80". Returns a null TargetAttr if the given
-// |target| is not recognized.
-TargetAttr getCUDATargetDetails(llvm::StringRef target, MLIRContext *context);
+// a compute capability like "sm_80". |features| is a list of comma-separated
+// target features. TargetAttr if the given |target| is not recognized.
+TargetAttr getCUDATargetDetails(llvm::StringRef target,
+                                llvm::StringRef features, MLIRContext *context);
 
 // Normalizes the given CUDA |target| to the gfx target commonly used for
 // compiling towards CUDA. For example, "sm_80" for "a100", "sm_89" for "ada".
 // if the given |target| is not recognized.
 StringRef normalizeCUDATarget(StringRef target);
 
-// Returns the full target of the given |aliasTarget|. Returns null target if
-// unknown.
+// Returns the full target of the given |aliasTarget| with a list of
+// comma-separated target|features|. Returns null target if unknown.
 TargetAttr getFullTarget(StringRef targetAPI, StringRef aliasTarget,
-                         MLIRContext *context);
+                         llvm::StringRef features, MLIRContext *context);
 
 } // namespace mlir::iree_compiler::IREE::GPU
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.h
@@ -14,8 +14,8 @@ namespace mlir::iree_compiler::IREE::GPU {
 
 // Returns a TargetAttr to describe the details of the given |target|, which can
 // be a product name like "rx7900xtx", an microarchitecture name like "rdna3",
-// or a compiler target like "gfx1100". |features| is a list of comma-separated
-// target features. Returns a null TargetAttr if the given |target| is not
+// or a compiler target like "gfx1100", with a list of comma-separated
+// target |features|. Returns a null TargetAttr if the given |target| is not
 // recognized.
 TargetAttr getHIPTargetDetails(llvm::StringRef target, llvm::StringRef features,
                                MLIRContext *context);
@@ -27,8 +27,8 @@ StringRef normalizeHIPTarget(StringRef target);
 
 // Returns a TargetAttr to describe the details of the given |target|, which can
 // be a product name like "rtx3090", an microarchitecture name like "ampere", or
-// a compute capability like "sm_80". |features| is a list of comma-separated
-// target features. TargetAttr if the given |target| is not recognized.
+// a compute capability like "sm_80", with a list of comma-separated target
+// |features|. TargetAttr if the given |target| is not recognized.
 TargetAttr getCUDATargetDetails(llvm::StringRef target,
                                 llvm::StringRef features, MLIRContext *context);
 
@@ -38,7 +38,7 @@ TargetAttr getCUDATargetDetails(llvm::StringRef target,
 StringRef normalizeCUDATarget(StringRef target);
 
 // Returns the full target of the given |aliasTarget| with a list of
-// comma-separated target|features|. Returns null target if unknown.
+// comma-separated target |features|. Returns null target if unknown.
 TargetAttr getFullTarget(StringRef targetAPI, StringRef aliasTarget,
                          llvm::StringRef features, MLIRContext *context);
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute.mlir
@@ -71,7 +71,7 @@ module {
 
 // -----
 
-#target = #iree_gpu.target<arch = "gfx940", wgp = <
+#target = #iree_gpu.target<arch = "gfx940", features = "", wgp = <
   compute = fp64|fp32|fp16|int64|int32|int16|int8, storage = b64|b32|b16|b8,
   subgroup = shuffle|arithmetic, dot = dp4xi8toi32,
   mma = [],

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -961,8 +961,9 @@ IREE::GPU::TargetAttr getGPUTargetAttr(IREE::HAL::ExecutableTargetAttr target) {
       return attr;
   }
   if (!clTestTarget.empty()) {
+    auto [arch, features] = StringRef(clTestTarget).split(':');
     // Use the target specified in the command line for testing purposes.
-    return IREE::GPU::getFullTarget(target.getBackend(), clTestTarget,
+    return IREE::GPU::getFullTarget(target.getBackend(), arch, features,
                                     target.getContext());
   }
 
@@ -984,8 +985,9 @@ IREE::GPU::TargetAttr getGPUTargetAttr(Operation *op) {
       backend = "cuda";
     else if (StringRef(clTestTarget).starts_with("gfx"))
       backend = "rocm";
+    auto [arch, features] = StringRef(clTestTarget).split(':');
     // Use the target specified in the command line for testing purposes.
-    return IREE::GPU::getFullTarget(backend, clTestTarget, op->getContext());
+    return IREE::GPU::getFullTarget(backend, arch, features, op->getContext());
   }
   return nullptr;
 }

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/pad_to_intrinsics_mfma.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/pad_to_intrinsics_mfma.mlir
@@ -64,7 +64,7 @@ func.func @main1(%arg0: tensor<2x130x130x320xf16>, %arg1: tensor<3x3x320x4xf16>,
 // -----
 
 // Use an explicit target here given we are swapping the preferred order of MFMA intrinsics.
-#target = #iree_gpu.target<arch = "gfx942",
+#target = #iree_gpu.target<arch = "gfx942", features = "",
   wgp = <compute = fp64|fp32|fp16|int64|int32|int16|int8, storage = b64|b32|b16|b8,
   subgroup = shuffle|arithmetic, dot = dp4xi8toi32,
   mma = [<MFMA_F16_32x32x8_F32>],


### PR DESCRIPTION
This commit adds a new `features` field to the `#iree_gpu.target` to allow specifying additional LLVMGPU backend target features, e.g., "+sramecc,+xnack" for HIP `gfx942`. The new features can be specified via the `--iree-rocm-target-features` command-line option.

Along the way, dropped the hardcoded "+sramecc,-xnack" feature set for all `gfx9*` targets--for both of them, from the AMDGPU doc (https://llvm.org/docs/AMDGPUUsage.html), we have

> If not specified for code object V4 or above, generate code
> that can be loaded and executed in a process with either
> setting of SRAMECC (XNACK replay).

So that means it should be fine to be missing by default.

Fixes https://github.com/iree-org/iree/issues/17402
Progress towards https://github.com/iree-org/iree/issues/16341