### PR TITLE
[Codegen][GPU] Add unrolling pattern for iree_gpu.multi_mma

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
@@ -39,6 +39,7 @@ iree_td_library(
         "@llvm-project//mlir:OpBaseTdFiles",
         "@llvm-project//mlir:SCFTdFiles",
         "@llvm-project//mlir:SideEffectInterfacesTdFiles",
+        "@llvm-project//mlir:VectorInterfacesTdFiles",
     ],
 )
 
@@ -89,6 +90,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:VectorDialect",
+        "@llvm-project//mlir:VectorInterfaces",
     ],
 )
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/CMakeLists.txt
@@ -52,6 +52,7 @@ iree_cc_library(
     MLIRSupport
     MLIRTensorDialect
     MLIRVectorDialect
+    MLIRVectorInterfaces
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
     iree::compiler::Codegen::Utils::VectorOpUtils
   PUBLIC

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -182,6 +182,12 @@ void MultiMmaOp::getIterationBounds(SmallVectorImpl<int64_t> &iterationBounds) {
   }
 }
 
+std::optional<SmallVector<int64_t, 4>> MultiMmaOp::getShapeForUnroll() {
+  SmallVector<int64_t, 4> shape;
+  getIterationBounds(shape);
+  return shape;
+}
+
 //===----------------------------------------------------------------------===//
 // ShuffleTensorOp
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -13,6 +13,7 @@ include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/DestinationStyleOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/Interfaces/VectorInterfaces.td"
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/OpBase.td"
 
@@ -23,6 +24,7 @@ include "mlir/IR/OpBase.td"
 def IREEGPU_MultiMmaOp : Op<IREEGPU_Dialect, "multi_mma", [
     Pure,
     AllTypesMatch<["acc", "result"]>,
+    DeclareOpInterfaceMethods<VectorUnrollOpInterface, ["getShapeForUnroll"]>,
     ]> {
   let summary = "Models a contraction of multiple mma operations";
   let description = [{
@@ -184,6 +186,27 @@ def IREEGPU_MultiMmaOp : Op<IREEGPU_Dialect, "multi_mma", [
           getIteratorTypes()
               .template getAsValueRange<IteratorTypeAttr, utils::IteratorType>();
       return {range.begin(), range.end()};
+    }
+
+    ArrayRef<int64_t> getLhsInnerShape() {
+      ShapedType lhsType = getLhsType();
+      int64_t lhsInnerDimRank =
+        lhsType.getRank() - getIndexingMapsArray()[0].getNumResults();
+      return lhsType.getShape().take_back(lhsInnerDimRank);
+    }
+
+    ArrayRef<int64_t> getRhsInnerShape() {
+      ShapedType rhsType = getRhsType();
+      int64_t rhsInnerDimRank =
+        rhsType.getRank() - getIndexingMapsArray()[1].getNumResults();
+      return rhsType.getShape().take_back(rhsInnerDimRank);
+    }
+
+    ArrayRef<int64_t> getAccInnerShape() {
+      ShapedType accType = getAccType();
+      int64_t accInnerDimRank =
+        accType.getRank() - getIndexingMapsArray()[2].getNumResults();
+      return accType.getShape().take_back(accInnerDimRank);
     }
   }];
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/BUILD.bazel
@@ -65,5 +65,6 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:TransformDialect",
         "@llvm-project//mlir:TransformDialectInterfaces",
+        "@llvm-project//mlir:VectorTransforms",
     ],
 )

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/CMakeLists.txt
@@ -35,6 +35,7 @@ iree_cc_library(
     MLIRIR
     MLIRTransformDialect
     MLIRTransformDialectInterfaces
+    MLIRVectorTransforms
     iree::compiler::Codegen::Dialect::GPU::IR::IREEGPUDialect
     iree::compiler::Codegen::Dialect::GPU::Transforms::GPUTransforms
   PUBLIC

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/IREEGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/IREEGPUExtensions.cpp
@@ -6,9 +6,11 @@
 
 #include "iree/compiler/Codegen/Dialect/GPU/TransformExtensions/IREEGPUExtensions.h"
 
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
 #include "iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.h"
 #include "mlir/Dialect/Transform/IR/TransformTypes.h"
 #include "mlir/Dialect/Transform/Interfaces/TransformInterfaces.h"
+#include "mlir/Dialect/Vector/Transforms/VectorRewritePatterns.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/PatternMatch.h"
 
@@ -19,6 +21,70 @@ transform_dialect::IREEGPUExtensions::IREEGPUExtensions() {
 #define GET_OP_LIST
 #include "iree/compiler/Codegen/Dialect/GPU/TransformExtensions/IREEGPUExtensionsOps.cpp.inc"
       >();
+}
+
+//===---------------------------------------------------------------------===//
+// ApplyUnrollMultiMmaOp
+//===---------------------------------------------------------------------===//
+
+static bool isReductionIterator(Attribute attr) {
+  return cast<IREE::GPU::IteratorTypeAttr>(attr).getValue() ==
+         utils::IteratorType::reduction;
+}
+static bool isParallelIterator(Attribute attr) {
+  return cast<IREE::GPU::IteratorTypeAttr>(attr).getValue() ==
+         utils::IteratorType::parallel;
+}
+
+/// Pick an unrolling order that reuses the LHS register.
+static std::optional<SmallVector<int64_t>>
+gpuMultiMmaUnrollOrder(Operation *op) {
+  IREE::GPU::MultiMmaOp mmaOp = dyn_cast<IREE::GPU::MultiMmaOp>(op);
+  if (!mmaOp) {
+    return std::nullopt;
+  }
+  SmallVector<int64_t> order;
+  // First make reduction the outer dimensions.
+  for (auto [index, iter] : llvm::enumerate(mmaOp.getIteratorTypes())) {
+    if (isReductionIterator(iter)) {
+      order.push_back(index);
+    }
+  }
+
+  llvm::SmallDenseSet<int64_t> dims;
+  for (AffineExpr expr : mmaOp.getIndexingMapsArray()[0].getResults()) {
+    dims.insert(cast<AffineDimExpr>(expr).getPosition());
+  }
+  // Then parallel dimensions that are part of Lhs as we want to re-use Lhs.
+  for (auto [index, iter] : llvm::enumerate(mmaOp.getIteratorTypes())) {
+    if (isParallelIterator(iter) && dims.count(index)) {
+      order.push_back(index);
+    }
+  }
+  // Then the remaining parallel loops.
+  for (auto [index, iter] : llvm::enumerate(mmaOp.getIteratorTypes())) {
+    if (isParallelIterator(iter) && !dims.count(index)) {
+      order.push_back(index);
+    }
+  }
+  return order;
+}
+
+static std::optional<SmallVector<int64_t>> getMultiMmaUnitShape(Operation *op) {
+  IREE::GPU::MultiMmaOp mmaOp = dyn_cast<IREE::GPU::MultiMmaOp>(op);
+  if (!mmaOp) {
+    return std::nullopt;
+  }
+  SmallVector<int64_t> targetOuterShape(mmaOp.getIteratorTypes().size(), 1);
+  return targetOuterShape;
+}
+
+void transform_dialect::ApplyUnrollMultiMmaOp::populatePatterns(
+    RewritePatternSet &patterns) {
+  GPU::populateIREEGPUVectorUnrollPatterns(
+      patterns, vector::UnrollVectorOptions()
+                    .setNativeShapeFn(getMultiMmaUnitShape)
+                    .setUnrollTraversalOrderFn(gpuMultiMmaUnrollOrder));
 }
 
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/IREEGPUExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/IREEGPUExtensionsOps.td
@@ -14,6 +14,18 @@ include "mlir/Dialect/Transform/Interfaces/TransformInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/OpBase.td"
 
+def ApplyUnrollMultiMmaOp : Op<Transform_Dialect,
+    "apply_patterns.iree.unroll_multi_mma",
+    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+     ReportTrackingListenerFailuresOpTrait]> {
+  let description = [{
+    Populate patterns to unroll iree_gpu.multi_mma ops to a single intrinsic.
+  }];
+
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+  let assemblyFormat = "attr-dict";
+}
+
 def ApplyVectorizeMultiMmaOp : Op<Transform_Dialect,
     "apply_patterns.iree.vectorize_multi_mma",
     [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/BUILD.bazel
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     srcs = enforce_glob(
         [
             "vectorize_multi_mma.mlir",
+            "unroll_multi_mma.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "unroll_multi_mma.mlir"
     "vectorize_multi_mma.mlir"
   TOOLS
     FileCheck

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/unroll_multi_mma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/unroll_multi_mma.mlir
@@ -1,0 +1,95 @@
+// RUN: iree-opt %s -iree-transform-dialect-interpreter -transform-dialect-drop-schedule --split-input-file | FileCheck %s
+
+#contraction_accesses = [
+ affine_map<(i, j, k) -> (i, k)>,
+ affine_map<(i, j, k) -> (k, j)>,
+ affine_map<(i, j, k) -> (i, j)>
+]
+func.func @unroll_multi_mma_order(%lhs: vector<2x2x4xf16>, %rhs: vector<2x2x4xf16>, %acc: vector<2x2x4xf32>) -> vector<2x2x4xf32> {
+  %0 = iree_gpu.multi_mma %lhs, %rhs, %acc {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<reduction>],
+    kind = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>
+  } : vector<2x2x4xf16>, vector<2x2x4xf16> into vector<2x2x4xf32>
+  return %0 : vector<2x2x4xf32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.unroll_multi_mma
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @unroll_multi_mma_order
+//  CHECK-SAME:   %[[LHS:[A-Za-z0-9]+]]: vector<2x2x4xf16>
+//  CHECK-SAME:   %[[RHS:[A-Za-z0-9]+]]: vector<2x2x4xf16>
+//  CHECK-SAME:   %[[ACC:[A-Za-z0-9]+]]: vector<2x2x4xf32>
+
+//       CHECK:   %[[DEST:.+]] = arith.constant dense<0.000000e+00> : vector<2x2x4xf32>
+//       CHECK:   vector.extract_strided_slice %[[LHS]] {offsets = [0, 0]
+//       CHECK:   vector.extract_strided_slice %[[RHS]] {offsets = [0, 0]
+//       CHECK:   %[[ACC0:.+]] = vector.extract_strided_slice %[[ACC]] {offsets = [0, 0]
+//       CHECK:   %[[MMA0_K0:.+]] = iree_gpu.multi_mma %{{.*}}, %{{.*}}, %[[ACC0]]
+//       CHECK:   vector.extract_strided_slice %[[LHS]] {offsets = [0, 0]
+//       CHECK:   vector.extract_strided_slice %[[RHS]] {offsets = [0, 1]
+//       CHECK:   %[[ACC1:.+]] = vector.extract_strided_slice %[[ACC]] {offsets = [0, 1]
+//       CHECK:   %[[MMA1_K0:.+]] = iree_gpu.multi_mma %{{.*}}, %{{.*}}, %[[ACC1]]
+//       CHECK:   vector.extract_strided_slice %[[LHS]] {offsets = [1, 0]
+//       CHECK:   vector.extract_strided_slice %[[RHS]] {offsets = [0, 0]
+//       CHECK:   %[[ACC2:.+]] = vector.extract_strided_slice %[[ACC]] {offsets = [1, 0]
+//       CHECK:   %[[MMA2_K0:.+]] = iree_gpu.multi_mma %{{.*}}, %{{.*}}, %[[ACC2]]
+//       CHECK:   vector.extract_strided_slice %[[LHS]] {offsets = [1, 0]
+//       CHECK:   vector.extract_strided_slice %[[RHS]] {offsets = [0, 1]
+//       CHECK:   %[[ACC3:.+]] = vector.extract_strided_slice %[[ACC]] {offsets = [1, 1]
+//       CHECK:   %[[MMA3_K0:.+]] = iree_gpu.multi_mma %{{.*}}, %{{.*}}, %[[ACC3]]
+//       CHECK:   vector.extract_strided_slice %[[LHS]] {offsets = [0, 1]
+//       CHECK:   vector.extract_strided_slice %[[RHS]] {offsets = [1, 0]
+//       CHECK:   %[[MMA0:.+]] = iree_gpu.multi_mma %{{.*}}, %{{.*}}, %[[MMA0_K0]]
+//       CHECK:   vector.extract_strided_slice %[[LHS]] {offsets = [0, 1]
+//       CHECK:   vector.extract_strided_slice %[[RHS]] {offsets = [1, 1]
+//       CHECK:   %[[MMA1:.+]] = iree_gpu.multi_mma %{{.*}}, %{{.*}}, %[[MMA1_K0]]
+//       CHECK:   vector.extract_strided_slice %[[LHS]] {offsets = [1, 1]
+//       CHECK:   vector.extract_strided_slice %[[RHS]] {offsets = [1, 0]
+//       CHECK:   %[[MMA2:.+]] = iree_gpu.multi_mma %{{.*}}, %{{.*}}, %[[MMA2_K0]]
+//       CHECK:   vector.extract_strided_slice %[[LHS]] {offsets = [1, 1]
+//       CHECK:   vector.extract_strided_slice %[[RHS]] {offsets = [1, 1]
+//       CHECK:   %[[MMA3:.+]] = iree_gpu.multi_mma %{{.*}}, %{{.*}}, %[[MMA3_K0]]
+//       CHECK:   %[[IN0:.+]] = vector.insert_strided_slice %[[MMA0]], %[[DEST]] {offsets = [0, 0, 0], strides = [1, 1, 1]} : vector<1x1x4xf32> into vector<2x2x4xf32>
+//       CHECK:   %[[IN1:.+]] = vector.insert_strided_slice %[[MMA1]], %[[IN0]] {offsets = [0, 1, 0]
+//       CHECK:   %[[IN2:.+]] = vector.insert_strided_slice %[[MMA2]], %[[IN1]] {offsets = [1, 0, 0]
+//       CHECK:   %[[RES:.+]] = vector.insert_strided_slice %[[MMA3]], %[[IN2]] {offsets = [1, 1, 0]
+//       CHECK:   return %[[RES]]
+
+// -----
+
+#contraction_accesses = [
+ affine_map<(i, j, k) -> (i, k)>,
+ affine_map<(i, j, k) -> (k, j)>,
+ affine_map<(i, j, k) -> (i, j)>
+]
+func.func @unroll_multi_mma_count(%lhs: vector<2x3x4xf16>, %rhs: vector<3x5x4xf16>, %acc: vector<2x5x4xf32>) -> vector<2x5x4xf32> {
+  %0 = iree_gpu.multi_mma %lhs, %rhs, %acc {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<reduction>],
+    kind = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>
+  } : vector<2x3x4xf16>, vector<3x5x4xf16> into vector<2x5x4xf32>
+  return %0 : vector<2x5x4xf32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.unroll_multi_mma
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+//    CHECK-LABEL: func @unroll_multi_mma_count
+// CHECK-COUNT-30:   %[[MMA:.+]] = iree_gpu.multi_mma {{.*}} : vector<1x1x4xf16>, vector<1x1x4xf16> into vector<1x1x4xf32>
+// CHECK-COUNT-10:   vector.insert_strided_slice {{.*}} : vector<1x1x4xf32> into vector<2x5x4xf32>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BUILD.bazel
@@ -51,6 +51,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:TransformUtils",
         "@llvm-project//mlir:Transforms",
         "@llvm-project//mlir:VectorDialect",
+        "@llvm-project//mlir:VectorTransforms",
         "@llvm-project//mlir:VectorUtils",
     ],
 )

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/CMakeLists.txt
@@ -44,6 +44,7 @@ iree_cc_library(
     MLIRTransformUtils
     MLIRTransforms
     MLIRVectorDialect
+    MLIRVectorTransforms
     MLIRVectorUtils
     iree::compiler::Codegen::Dialect::GPU::IR::IREEGPUDialect
   PUBLIC

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.cpp
@@ -7,8 +7,10 @@
 #include "iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.h"
 
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
+#include "llvm/ADT/STLExtras.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/Dialect/Vector/Transforms/VectorRewritePatterns.h"
 #include "mlir/Dialect/Vector/Utils/VectorUtils.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/PatternMatch.h"
@@ -16,6 +18,181 @@
 #define DEBUG_TYPE "iree-codegen-gpu-transforms"
 
 namespace mlir::iree_compiler::IREE::GPU {
+
+//===----------------------------------------------------------------------===//
+// MultiMmaOp Unrolling
+//===----------------------------------------------------------------------===//
+
+static SmallVector<int64_t>
+getUnrollOrder(unsigned numLoops, Operation *op,
+               const vector::UnrollVectorOptions &options) {
+  SmallVector<int64_t> loopOrder =
+      llvm::to_vector(llvm::seq<int64_t>(0, static_cast<int64_t>(numLoops)));
+  if (options.traversalOrderCallback != nullptr) {
+    std::optional<SmallVector<int64_t>> order =
+        options.traversalOrderCallback(op);
+    if (order) {
+      loopOrder = std::move(*order);
+    }
+  }
+  return loopOrder;
+}
+
+namespace {
+
+/// Helper structure to track partially accumulated values while unrolling.
+struct OffsetMapInfo {
+  static SmallVector<int64_t> getEmptyKey() { return {int64_t(-1)}; }
+
+  static SmallVector<int64_t> getTombstoneKey() { return {int64_t(-2)}; }
+
+  static unsigned getHashValue(const SmallVector<int64_t> &v) {
+    return static_cast<unsigned>(llvm::hash_combine_range(v.begin(), v.end()));
+  }
+
+  static bool isEqual(const SmallVector<int64_t> &lhs,
+                      const SmallVector<int64_t> &rhs) {
+    return lhs == rhs;
+  }
+};
+
+struct UnrollMultiMmaPattern : public OpRewritePattern<GPU::MultiMmaOp> {
+  UnrollMultiMmaPattern(MLIRContext *context,
+                        const vector::UnrollVectorOptions &options,
+                        PatternBenefit benefit = 1)
+      : OpRewritePattern<GPU::MultiMmaOp>(context, benefit), options(options) {}
+
+  LogicalResult matchAndRewrite(GPU::MultiMmaOp mmaOp,
+                                PatternRewriter &rewriter) const override {
+    if (options.filterConstraint && failed(options.filterConstraint(mmaOp))) {
+      return rewriter.notifyMatchFailure(mmaOp, "unrolling filter");
+    }
+    assert(options.nativeShape &&
+           "vector unrolling expects the native shape or native shape call "
+           "back function to be set");
+    std::optional<SmallVector<int64_t, 4>> maybeUnrollShape =
+        mmaOp.getShapeForUnroll();
+    if (!maybeUnrollShape) {
+      return rewriter.notifyMatchFailure(
+          mmaOp, "unexpected failure to get unroll shape");
+    }
+
+    std::optional<SmallVector<int64_t>> targetShape =
+        options.nativeShape(mmaOp);
+    if (!targetShape) {
+      return rewriter.notifyMatchFailure(mmaOp,
+                                         "unspecified native unroll shape");
+    }
+
+    auto maybeShapeRatio = computeShapeRatio(*maybeUnrollShape, *targetShape);
+    if (!maybeShapeRatio) {
+      return rewriter.notifyMatchFailure(
+          mmaOp, "operation unroll shape not divisible by target shape");
+    }
+
+    // Early exit if unrolling has no effect.
+    if (llvm::all_of(*maybeShapeRatio, [](int64_t v) { return v == 1; })) {
+      return rewriter.notifyMatchFailure(
+          mmaOp, "operation already unrolled to native shape");
+    }
+
+    auto dstVecType = cast<VectorType>(mmaOp.getResultType());
+    SmallVector<int64_t, 4> originalSize = *maybeUnrollShape;
+
+    Location loc = mmaOp.getLoc();
+    llvm::MapVector<
+        SmallVector<int64_t>, Value,
+        llvm::DenseMap<SmallVector<int64_t>, unsigned, OffsetMapInfo>>
+        accCache;
+
+    SmallVector<int64_t> loopOrder =
+        getUnrollOrder(mmaOp.getIteratorTypes().size(), mmaOp, options);
+
+    AffineMap lhsPermutationMap = mmaOp.getIndexingMapsArray()[0];
+    AffineMap rhsPermutationMap = mmaOp.getIndexingMapsArray()[1];
+    AffineMap accPermutationMap = mmaOp.getIndexingMapsArray()[2];
+
+    ArrayRef<int64_t> innerAccShape = mmaOp.getAccInnerShape();
+
+    for (SmallVector<int64_t> offsets :
+         StaticTileOffsetRange(originalSize, *targetShape, loopOrder)) {
+      SmallVector<Value> slicesOperands(mmaOp.getNumOperands());
+
+      // Helper to compute the new shape of each operand and extract the slice.
+      auto extractOperand = [&](unsigned index, Value operand,
+                                AffineMap permutationMap,
+                                ArrayRef<int64_t> operandOffets) {
+        SmallVector<int64_t> operandShape = applyPermutationMap(
+            permutationMap, ArrayRef<int64_t>(*targetShape));
+        SmallVector<int64_t> operandStrides(operandOffets.size(), 1);
+        slicesOperands[index] = rewriter.create<vector::ExtractStridedSliceOp>(
+            loc, operand, operandOffets, operandShape, operandStrides);
+      };
+
+      // Extract the new lhs operand.
+      SmallVector<int64_t> lhsOffets =
+          applyPermutationMap(lhsPermutationMap, ArrayRef<int64_t>(offsets));
+      extractOperand(0, mmaOp.getLhs(), lhsPermutationMap, lhsOffets);
+
+      // Extract the new rhs operand.
+      SmallVector<int64_t> rhsOffets =
+          applyPermutationMap(rhsPermutationMap, ArrayRef<int64_t>(offsets));
+      extractOperand(1, mmaOp.getRhs(), rhsPermutationMap, rhsOffets);
+
+      SmallVector<int64_t> accOffets =
+          applyPermutationMap(accPermutationMap, ArrayRef<int64_t>(offsets));
+      // If a version of the accumulator has already been computed, use it
+      // otherwise extract the first version from the original operand.
+      auto *accIt = accCache.find(accOffets);
+      if (accIt != accCache.end()) {
+        slicesOperands[2] = accIt->second;
+      } else {
+        extractOperand(2, mmaOp.getAcc(), accPermutationMap, accOffets);
+      }
+
+      SmallVector<int64_t> dstShape = applyPermutationMap(
+          accPermutationMap, ArrayRef<int64_t>(*targetShape));
+      dstShape.append(innerAccShape.begin(), innerAccShape.end());
+      auto targetType = VectorType::get(dstShape, dstVecType.getElementType());
+
+      // Clone the mma op with the new operands and result type.
+      Operation *newOp =
+          rewriter.create(loc, mmaOp->getName().getIdentifier(), slicesOperands,
+                          targetType, mmaOp->getAttrs());
+
+      SmallVector<int64_t> dstOffets =
+          applyPermutationMap(accPermutationMap, ArrayRef<int64_t>(offsets));
+      // Save the accumulated value until all the loops are unrolled since
+      // reduction loop keep updating the accumulator.
+      accCache[dstOffets] = newOp->getResult(0);
+    }
+    // Assemble back the accumulator into a single vector.
+    Value result = rewriter.create<arith::ConstantOp>(
+        loc, dstVecType, rewriter.getZeroAttr(dstVecType));
+    for (const auto &[offsets, partialResult] : accCache) {
+      SmallVector<int64_t> dstStrides(offsets.size() + innerAccShape.size(), 1);
+      SmallVector<int64_t> fullOffsets(offsets.begin(), offsets.end());
+      fullOffsets.append(innerAccShape.size(), 0);
+      result = rewriter.create<vector::InsertStridedSliceOp>(
+          loc, partialResult, result, fullOffsets, dstStrides);
+    }
+    rewriter.replaceOp(mmaOp, result);
+    return success();
+  }
+
+private:
+  vector::UnrollVectorOptions options;
+};
+} // namespace
+
+void populateIREEGPUVectorUnrollPatterns(
+    RewritePatternSet &patterns, const vector::UnrollVectorOptions &options) {
+  patterns.add<UnrollMultiMmaPattern>(patterns.getContext(), options);
+}
+
+//===----------------------------------------------------------------------===//
+// MultiMmaOp Vectorization
+//===----------------------------------------------------------------------===//
 
 static LogicalResult vectorizeStaticMultiMmaOp(RewriterBase &rewriter,
                                                IREE::GPU::MultiMmaOp mmaOp) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.cpp
@@ -156,15 +156,14 @@ struct UnrollMultiMmaPattern : public OpRewritePattern<GPU::MultiMmaOp> {
       auto targetType = VectorType::get(dstShape, dstVecType.getElementType());
 
       // Clone the mma op with the new operands and result type.
-      Operation *newOp =
-          rewriter.create(loc, mmaOp->getName().getIdentifier(), slicesOperands,
-                          targetType, mmaOp->getAttrs());
+      IREE::GPU::MultiMmaOp newOp =
+          mlir::clone(rewriter, mmaOp, targetType, slicesOperands);
 
       SmallVector<int64_t> dstOffets =
           applyPermutationMap(accPermutationMap, ArrayRef<int64_t>(offsets));
       // Save the accumulated value until all the loops are unrolled since
       // reduction loop keep updating the accumulator.
-      accCache[dstOffets] = newOp->getResult(0);
+      accCache[dstOffets] = newOp.getResult();
     }
     // Assemble back the accumulator into a single vector.
     Value result = rewriter.create<arith::ConstantOp>(

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.h
@@ -14,10 +14,17 @@
 #define IREE_COMPILER_CODEGEN_DIALECT_GPU_TRANSFORMS_TRANSFORMS_H_
 
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
+#include "mlir/Dialect/Vector/Transforms/VectorRewritePatterns.h"
 #include "mlir/IR/PatternMatch.h"
+
+namespace mlir::vector {
+struct UnrollVectorOptions;
+}
 
 namespace mlir::iree_compiler::IREE::GPU {
 
+void populateIREEGPUVectorUnrollPatterns(
+    RewritePatternSet &patterns, const vector::UnrollVectorOptions &options);
 void populateIREEGPUVectorizationPatterns(RewritePatternSet &patterns);
 
 } // namespace mlir::iree_compiler::IREE::GPU


### PR DESCRIPTION
This enables unrolling all the way to the implicit shape of the intrinsic.
Unroll order is set to match a known good order for sm_80 in the past.