### PR TITLE
[Codegen][GPU] Add pattern to drop lead unit dims of multi_mma ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -208,6 +208,18 @@ def IREEGPU_MultiMmaOp : Op<IREEGPU_Dialect, "multi_mma", [
         accType.getRank() - getIndexingMapsArray()[2].getNumResults();
       return accType.getShape().take_back(accInnerDimRank);
     }
+
+    int64_t getLhsOuterRank() {
+      return getIndexingMapsArray()[0].getNumResults();
+    }
+
+    int64_t getRhsOuterRank() {
+      return getIndexingMapsArray()[1].getNumResults();
+    }
+
+    int64_t getAccOuterRank() {
+      return getIndexingMapsArray()[2].getNumResults();
+    }
   }];
 
   let hasVerifier = 1;

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/IREEGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/IREEGPUExtensions.cpp
@@ -26,6 +26,15 @@ transform_dialect::IREEGPUExtensions::IREEGPUExtensions() {
 }
 
 //===---------------------------------------------------------------------===//
+// ApplyDropMultiMmaOpUnitDims
+//===---------------------------------------------------------------------===//
+
+void transform_dialect::ApplyDropMultiMmaOpUnitDims::populatePatterns(
+    RewritePatternSet &patterns) {
+  IREE::GPU::populateIREEGPUDropUnitDimsPatterns(patterns);
+}
+
+//===---------------------------------------------------------------------===//
 // ApplyLowerValueBarrierOp
 //===---------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/IREEGPUExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/IREEGPUExtensionsOps.td
@@ -14,6 +14,19 @@ include "mlir/Dialect/Transform/Interfaces/TransformInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/OpBase.td"
 
+def ApplyDropMultiMmaOpUnitDims : Op<Transform_Dialect,
+    "apply_patterns.iree.drop_multi_mma_unit_dims",
+    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+     ReportTrackingListenerFailuresOpTrait]> {
+  let description = [{
+    Populate patterns to drop the unit dims from multi_mma ops with
+    only unit iteration bounds.
+  }];
+
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+  let assemblyFormat = "attr-dict";
+}
+
 def ApplyLowerValueBarrierOp : Op<Transform_Dialect,
     "apply_patterns.iree.lower_value_barrier",
     [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/BUILD.bazel
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "drop_multi_mma_unit_dims.mlir",
             "lower_vector_barrier.mlir",
             "transform_fuse_forall.mlir",
             "vectorize_multi_mma.mlir",

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "drop_multi_mma_unit_dims.mlir"
     "lower_vector_barrier.mlir"
     "transform_fuse_forall.mlir"
     "unroll_multi_mma.mlir"

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/drop_multi_mma_unit_dims.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/drop_multi_mma_unit_dims.mlir
@@ -1,0 +1,78 @@
+// RUN: iree-opt %s -iree-transform-dialect-interpreter -transform-dialect-drop-schedule --split-input-file | FileCheck %s
+
+#contraction_accesses = [
+ affine_map<(i, j, k) -> (i, k)>,
+ affine_map<(i, j, k) -> (k, j)>,
+ affine_map<(i, j, k) -> (i, j)>
+]
+func.func @drop_multi_mma_unit_dims(%lhs: vector<1x1x4xf16>, %rhs: vector<1x1x4xf16>, %acc: vector<1x1x4xf32>) -> vector<1x1x4xf32> {
+  %0 = iree_gpu.multi_mma %lhs, %rhs, %acc {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<reduction>],
+    kind = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>
+  } : vector<1x1x4xf16>, vector<1x1x4xf16> into vector<1x1x4xf32>
+  return %0 : vector<1x1x4xf32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.drop_multi_mma_unit_dims
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK: #[[$MAP:.+]] =  affine_map<() -> ()>
+
+// CHECK-LABEL: func @drop_multi_mma_unit_dims
+//  CHECK-SAME:   %[[LHS:[A-Za-z0-9]+]]: vector<1x1x4xf16>
+//  CHECK-SAME:   %[[RHS:[A-Za-z0-9]+]]: vector<1x1x4xf16>
+//  CHECK-SAME:   %[[ACC:[A-Za-z0-9]+]]: vector<1x1x4xf32>
+//       CHECK:   %[[LHS_EXT:.+]] = vector.extract %[[LHS]][0, 0] : vector<4xf16> from vector<1x1x4xf16>
+//       CHECK:   %[[RHS_EXT:.+]] = vector.extract %[[RHS]][0, 0] : vector<4xf16> from vector<1x1x4xf16>
+//       CHECK:   %[[ACC_EXT:.+]] = vector.extract %[[ACC]][0, 0] : vector<4xf32> from vector<1x1x4xf32>
+//       CHECK:   %[[MMA:.+]] = iree_gpu.multi_mma %[[LHS_EXT]], %[[RHS_EXT]], %[[ACC_EXT]]
+//  CHECK-SAME:     indexing_maps = [#[[$MAP]], #[[$MAP]], #[[$MAP]]], iterator_types = []
+//  CHECK-SAME:     kind = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>} : vector<4xf16>, vector<4xf16> into vector<4xf32>
+//       CHECK:   vector.broadcast %[[MMA]] : vector<4xf32> to vector<1x1x4xf32>
+
+// -----
+
+#contraction_accesses = [
+ affine_map<(i) -> (i)>,
+ affine_map<(i) -> ()>,
+ affine_map<(i) -> (i)>
+]
+func.func @drop_multi_mma_unit_dims_no_kn(%lhs: vector<1x4xf16>, %rhs: vector<4xf16>, %acc: vector<1x4xf32>) -> vector<1x4xf32> {
+  %0 = iree_gpu.multi_mma %lhs, %rhs, %acc {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#iree_gpu.iterator_type<parallel>],
+    kind = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>
+  } : vector<1x4xf16>, vector<4xf16> into vector<1x4xf32>
+  return %0 : vector<1x4xf32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.drop_multi_mma_unit_dims
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK: #[[$MAP:.+]] =  affine_map<() -> ()>
+
+// CHECK-LABEL: func @drop_multi_mma_unit_dims_no_kn
+//  CHECK-SAME:   %[[LHS:[A-Za-z0-9]+]]: vector<1x4xf16>
+//  CHECK-SAME:   %[[RHS:[A-Za-z0-9]+]]: vector<4xf16>
+//  CHECK-SAME:   %[[ACC:[A-Za-z0-9]+]]: vector<1x4xf32>
+//       CHECK:   %[[LHS_EXT:.+]] = vector.extract %[[LHS]][0] : vector<4xf16> from vector<1x4xf16>
+//       CHECK:   %[[ACC_EXT:.+]] = vector.extract %[[ACC]][0] : vector<4xf32> from vector<1x4xf32>
+//       CHECK:   %[[MMA:.+]] = iree_gpu.multi_mma %[[LHS_EXT]], %[[RHS]], %[[ACC_EXT]]
+//  CHECK-SAME:     indexing_maps = [#[[$MAP]], #[[$MAP]], #[[$MAP]]], iterator_types = []
+//  CHECK-SAME:     kind = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>} : vector<4xf16>, vector<4xf16> into vector<4xf32>
+//       CHECK:   vector.broadcast %[[MMA]] : vector<4xf32> to vector<1x4xf32>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.h
@@ -34,12 +34,11 @@ LogicalResult fuseForallIntoSlice(RewriterBase &rewriter,
                                   scf::ForallOp consumer,
                                   tensor::ExtractSliceOp slice);
 
+void populateIREEGPUDropUnitDimsPatterns(RewritePatternSet &patterns);
+void populateIREEGPULowerValueBarrierPatterns(RewritePatternSet &patterns);
 void populateIREEGPUVectorUnrollPatterns(
     RewritePatternSet &patterns, const vector::UnrollVectorOptions &options);
-
 void populateIREEGPUVectorizationPatterns(RewritePatternSet &patterns);
-
-void populateIREEGPULowerValueBarrierPatterns(RewritePatternSet &patterns);
 
 } // namespace mlir::iree_compiler::IREE::GPU
 


### PR DESCRIPTION
Dropping leading unit dims is a useful step that simplifies the process
of lowering to intrinsics by removing the outer iteration space. The
typical lowering flow is to unroll the outer dims to 1 and then apply
this pattern to drop the unit outer dims.

Depends on #17454