### PR TITLE
[Codegen][GPU] Add dictionary based lowering config attribute

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
@@ -33,6 +33,7 @@ iree_td_library(
         include = ["*.td"],
     ),
     deps = [
+        "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:td_files",
         "@llvm-project//mlir:ControlFlowInterfacesTdFiles",
         "@llvm-project//mlir:DialectUtilsTdFiles",
         "@llvm-project//mlir:OpBaseTdFiles",
@@ -73,6 +74,7 @@ iree_compiler_cc_library(
         ":IREEGPUEnums",
         ":IREEGPUInterfaces",
         ":IREEGPUOpsGen",
+        "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
         "//compiler/src/iree/compiler/Codegen/Utils:VectorOpUtils",
         "//llvm-external-projects/iree-dialects:IREEVectorExtDialect",
         "@llvm-project//llvm:Support",

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/CMakeLists.txt
@@ -52,6 +52,7 @@ iree_cc_library(
     MLIRSupport
     MLIRTensorDialect
     MLIRVectorDialect
+    iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
     iree::compiler::Codegen::Utils::VectorOpUtils
   PUBLIC
 )

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -8,6 +8,7 @@
 #include <numeric>
 
 #include "iree-dialects/Dialect/VectorExt/IR/VectorExtDialect.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
 #include "iree/compiler/Codegen/Utils/VectorOpUtils.h"
 #include "llvm/ADT/STLExtras.h"
@@ -19,8 +20,10 @@
 #include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/DialectImplementation.h"
+#include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/TypeUtilities.h"
 
 #define DEBUG_TYPE "iree-gpu-attrs"
@@ -1027,6 +1030,78 @@ bool TargetAttr::supportsSyncMMAOps() const {
   if (auto cc = getCUDAComputeCapability())
     return cc >= 80;
   return false;
+}
+
+//===----------------------------------------------------------------------===//
+// Lowering Config Attributes
+//===----------------------------------------------------------------------===//
+
+static constexpr char kWorkgroupLevelName[] = "workgroup";
+static constexpr char kPartialReductionLevelName[] = "partial_reduction";
+static constexpr char kReductionLevelName[] = "reduction";
+static constexpr char kThreadLevelName[] = "thread";
+static constexpr char kSubgroupLevelName[] = "subgroup";
+static constexpr char kLaneLevelName[] = "lane";
+
+static StringRef getTilingLevelName(GPU::TilingLevel level) {
+  switch (level) {
+  case GPU::TilingLevel::Workgroup:
+    return kWorkgroupLevelName;
+  case GPU::TilingLevel::PartialReduction:
+    return kPartialReductionLevelName;
+  case GPU::TilingLevel::Reduction:
+    return kReductionLevelName;
+  case GPU::TilingLevel::Thread:
+    return kThreadLevelName;
+  case GPU::TilingLevel::Subgroup:
+    return kSubgroupLevelName;
+  case GPU::TilingLevel::Lane:
+    return kLaneLevelName;
+  }
+  assert(false && "Unknown tiling level");
+  return StringAttr();
+}
+
+static SmallVector<int64_t> getTileSizes(DictionaryAttr config,
+                                         GPU::TilingLevel level) {
+  auto sizes = config.getAs<ArrayAttr>(getTilingLevelName(level));
+  if (!sizes) {
+    return {};
+  }
+  SmallVector<int64_t> sizeList;
+  for (auto maybeSize : sizes.getValue()) {
+    auto size = dyn_cast<IntegerAttr>(maybeSize);
+    if (!size) {
+      return {};
+    }
+    sizeList.push_back(size.getInt());
+  }
+  return sizeList;
+}
+
+SmallVector<int64_t> LoweringConfigAttr::getWorkgroupTileSizes() const {
+  return getTileSizes(getAttributes(), GPU::TilingLevel::Workgroup);
+}
+
+SmallVector<int64_t>
+LoweringConfigAttr::getStaticTilingLevelSizes(unsigned level,
+                                              Operation *op) const {
+  if (level > static_cast<unsigned>(GPU::TilingLevel::Lane)) {
+    return {};
+  }
+  return getTileSizes(getAttributes(), static_cast<GPU::TilingLevel>(level));
+}
+
+SmallVector<OpFoldResult>
+LoweringConfigAttr::getTilingLevelSizes(OpBuilder &b, unsigned level,
+                                        Operation *op) const {
+  if (level > static_cast<unsigned>(GPU::TilingLevel::Lane)) {
+    return {};
+  }
+  SmallVector<int64_t> sizes =
+      getTileSizes(getAttributes(), static_cast<GPU::TilingLevel>(level));
+  return llvm::map_to_vector(
+      sizes, [&](int64_t s) -> OpFoldResult { return b.getIndexAttr(s); });
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h
@@ -7,6 +7,7 @@
 #ifndef IREE_COMPILER_CODEGEN_DIALECT_GPU_IREEGPUATTRS_H_
 #define IREE_COMPILER_CODEGEN_DIALECT_GPU_IREEGPUATTRS_H_
 
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h"
 #include "mlir/Dialect/SCF/IR/DeviceMappingInterface.h"

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -41,14 +41,14 @@ def IREEGPU_LoweringConfigAttr :
       ]>
     ]> {
   let mnemonic = "lowering_config";
-  let summary = [{drive lowering of an operation for gpu compilation.}];
+  let summary = "drive lowering of an operation for gpu compilation.";
   let description = [{
     GPU specific implementation of a lowering config. This carries just a
     dictionary attribute to store any relevant fields. This is the simplest
     form of a lowering config, offering flexibility at the cost of structure.
   }];
 
-  let assemblyFormat = [{ `<` $attributes `>` }];
+  let assemblyFormat = "`<` $attributes `>`";
 
   let parameters = (ins
     AttrParameter<"DictionaryAttr",

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -7,6 +7,7 @@
 #ifndef IREE_COMPILER_CODEGEN_DIALECT_GPU_IREEGPUATTRS
 #define IREE_COMPILER_CODEGEN_DIALECT_GPU_IREEGPUATTRS
 
+include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td"
 include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.td"
 include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td"
 include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.td"
@@ -26,6 +27,37 @@ def IREEGPU_IteratorTypeEnum
 def IREEGPU_IteratorTypeArrayAttr
     : TypedArrayAttrBase<IREEGPU_IteratorTypeEnum,
                          "Iterator type should be an enum.">;
+
+//===----------------------------------------------------------------------===//
+// GPU Specific Lowering Config Attribute
+//===----------------------------------------------------------------------===//
+
+def IREEGPU_LoweringConfigAttr :
+    AttrDef<IREEGPU_Dialect, "LoweringConfig", [
+      DeclareAttrInterfaceMethods<IREECodegen_LoweringConfigAttrInterface, [
+        "getWorkgroupTileSizes",
+        "getStaticTilingLevelSizes",
+        "getTilingLevelSizes",
+      ]>
+    ]> {
+  let mnemonic = "lowering_config";
+  let summary = [{drive lowering of an operation for gpu compilation.}];
+  let description = [{
+    GPU specific implementation of a lowering config. This carries just a
+    dictionary attribute to store any relevant fields. This is the simplest
+    form of a lowering config, offering flexibility at the cost of structure.
+  }];
+
+  let assemblyFormat = [{ `<` $attributes `>` }];
+
+  let parameters = (ins
+    AttrParameter<"DictionaryAttr",
+        "The configured fields, including tiling levels">:$attributes
+  );
+  let extraClassDeclaration = [{
+    SmallVector<int64_t> getThreadTileSizes() const;
+  }];
+}
 
 //===----------------------------------------------------------------------===//
 // GPU Workgroup Processor (WGP) Level Feature/Limit Attributes
@@ -62,6 +94,7 @@ def IREEGPU_DotProductOpsAttr : EnumAttr<
 
 //===----------------------------------------------------------------------===//
 // Base MMA vector layout
+//===----------------------------------------------------------------------===//
 
 class IREEGPU_MmaVectorLayoutAttr<string attrname, string mmaintrinsic> :
     AttrDef<IREEGPU_Dialect, attrname, [

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td
@@ -109,4 +109,24 @@ def IREEGPU_MMAIntrinsic : IREEGPU_I32MmaEnumAttr<"MMAIntrinsic",
       WMMA_F16_16x16x16_F32
     ]>;
 
+//===----------------------------------------------------------------------===//
+// Tiling levels
+
+def Workgroup : I32EnumAttrCase<"Workgroup", 0>;
+def Reduction : I32EnumAttrCase<"Reduction", 1>;
+def PartialReduction : I32EnumAttrCase<"PartialReduction", 2>;
+def Thread : I32EnumAttrCase<"Thread", 3>;
+def Subgroup : I32EnumAttrCase<"Subgroup", 4>;
+def Lane : I32EnumAttrCase<"Lane", 5>;
+
+def IREEGPU_TilingLevel : IREEGPU_I32MmaEnumAttr<"TilingLevel",
+    "Descriptor for tiling levels for GPU lowering configs", [
+      Workgroup,
+      Reduction,
+      PartialReduction,
+      Thread,
+      Subgroup,
+      Lane
+    ]>;
+
 #endif // IREE_COMPILER_CODEGEN_DIALECT_GPU_IREEGPUENUMS

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td
@@ -119,6 +119,10 @@ def Thread : I32EnumAttrCase<"Thread", 3>;
 def Subgroup : I32EnumAttrCase<"Subgroup", 4>;
 def Lane : I32EnumAttrCase<"Lane", 5>;
 
+/// Enum descriptor for the set of tiling levels for GPU pass pipelines.
+/// Note that `Thread` tiling is mutually exclusive with `Subgroup` and
+/// `Lane` tiling, and `Lane` tiling is only legal if the same operation
+/// is also tiled or fused to subgroups.
 def IREEGPU_TilingLevel : IREEGPU_I32MmaEnumAttr<"TilingLevel",
     "Descriptor for tiling levels for GPU lowering configs", [
       Workgroup,

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/BUILD.bazel
@@ -18,8 +18,8 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "iree_gpu_attrs.mlir",
             "iree_gpu_ops.mlir",
-            "mma_attrs.mlir",
             "target_attrs.mlir",
         ],
         include = ["*.mlir"],

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/CMakeLists.txt
@@ -14,8 +14,8 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "iree_gpu_attrs.mlir"
     "iree_gpu_ops.mlir"
-    "mma_attrs.mlir"
     "target_attrs.mlir"
   TOOLS
     FileCheck

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
@@ -26,3 +26,12 @@ module {
 }
 // CHECK-LABEL: func @test_wmma_f16_16x16x16_f32
 //  CHECK-SAME:   mma_types = #iree_gpu.mma_layout<WMMA_F16_16x16x16_F32>
+
+module {
+  func.func @test_any_lowering_config() attributes {
+      lowering_config = #iree_gpu.lowering_config<{workgroup = [16, 16], thread = [0, 4]}>} {
+    return
+  }
+}
+// CHECK-LABEL: func @test_any_lowering_config
+//  CHECK-SAME:   lowering_config = #iree_gpu.lowering_config<{thread = [0, 4], workgroup = [16, 16]}>


### PR DESCRIPTION
This adds a lowering config attribute that is backed by a simple
dictionary attribute. This makes the attribute easier to interpret by
giving tiling levels labels, however at the cost of structure. This is
also the most flexible form of lowering attribute, being free to extend
as needed. We may opt for more structured configs in the future.