### PR TITLE
Update integrate branch and title regexes for new naming.

### DIFF
--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -170,9 +170,9 @@ PR_DESCRIPTION_TEMPLATE = string.Template("${title}\n\n${body}")
 # intended to be merged and should exclude test/draft PRs as well as
 # PRs that include temporary patches to the submodule during review.
 # See also: https://github.com/iree-org/iree/issues/12268
-LLVM_INTEGRATE_TITLE_PATTERN = re.compile("^integrate.+llvm", re.IGNORECASE)
+LLVM_INTEGRATE_TITLE_PATTERN = re.compile("^integrate|bump.+llvm", re.IGNORECASE)
 LLVM_INTEGRATE_BRANCH_PATTERN = re.compile(
-    "bump-llvm|llvm-bump|integrate-llvm", re.IGNORECASE
+    "integrates/llvm|bump-llvm|llvm-bump|integrate-llvm", re.IGNORECASE
 )
 LLVM_INTEGRATE_LABEL = "llvm-integrate"
 


### PR DESCRIPTION
When a PR matches these patterns it runs all benchmarks and builds. The recent https://github.com/iree-org/iree/pull/17459 missed the checks due to the new [branch naming policy](https://iree.dev/developers/general/contributing/#branch-naming) (`integrates/llvm-`) and a slightly different PR title (`Bump LLVM` vs `Integrate LLVM`).

skip-ci: configuration change, no-op for builds/tests