### PR TITLE
[CPU] Add support for pack ukernel preparation. 

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPUPrepareUkernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPUPrepareUkernels.cpp
@@ -19,6 +19,64 @@ namespace {
 
 using IREE::Codegen::LoweringConfigAttr;
 
+static void tileBatchDimsForBatchMmt4dOp(RewriterBase &rewriter,
+                                         FunctionOpInterface funcOp) {
+  funcOp.walk([&](linalg::BatchMmt4DOp batchMmt4DOp) {
+    auto out = batchMmt4DOp.getDpsInitOperand(0)->get();
+    auto outType = cast<RankedTensorType>(out.getType());
+    // Tile only non unit batch dimensions with tile size equals to 1.
+    if (outType.getShape()[0] <= 1) {
+      return;
+    }
+    SmallVector<int64_t> tileSizes = {1};
+    auto tilingInterfaceOp = cast<TilingInterface>(batchMmt4DOp.getOperation());
+    auto options = scf::SCFTileAndFuseOptions().setTilingOptions(
+        scf::SCFTilingOptions().setTileSizes(
+            getAsIndexOpFoldResult(rewriter.getContext(), tileSizes)));
+    FailureOr<scf::SCFTileAndFuseResult> tileAndFuseResult =
+        scf::tileConsumerAndFuseProducersUsingSCF(rewriter, tilingInterfaceOp,
+                                                  options);
+    assert(succeeded(tileAndFuseResult));
+    rewriter.replaceOp(
+        batchMmt4DOp,
+        tileAndFuseResult->replacements[batchMmt4DOp.getResult(0)]);
+  });
+}
+
+static void tileNonPackedDimsFor3DPackOps(RewriterBase &rewriter,
+                                          FunctionOpInterface funcOp) {
+  funcOp.walk([&](tensor::PackOp packOp) {
+    if (packOp.getSourceRank() != 3 || packOp.getDestRank() != 5) {
+      return;
+    }
+
+    SmallVector<int64_t> tileSizes(packOp.getSourceRank(), 1);
+    for (auto dim : packOp.getInnerDimsPos()) {
+      tileSizes[dim] = 0;
+    }
+
+    // Skip the tiling if the size is already 1.
+    RankedTensorType srcType = packOp.getSourceType();
+    for (auto [idx, val] : llvm::enumerate(tileSizes)) {
+      if (val && srcType.getDimSize(idx) == 1)
+        return;
+    }
+
+    auto outerDimsPerm = packOp.getOuterDimsPerm();
+    if (!outerDimsPerm.empty()) {
+      applyPermutationToVector(tileSizes, outerDimsPerm);
+    }
+
+    auto tilingInterfaceOp = cast<TilingInterface>(packOp.getOperation());
+    auto options = scf::SCFTilingOptions().setTileSizes(
+        getAsIndexOpFoldResult(rewriter.getContext(), tileSizes));
+    FailureOr<scf::SCFTilingResult> tilingResult =
+        scf::tileUsingSCF(rewriter, tilingInterfaceOp, options);
+    assert(succeeded(tilingResult));
+    rewriter.replaceOp(packOp, tilingResult->replacements);
+  });
+}
+
 /// Returns true if:
 ///    1. `genericOp` is element-wise with all identity indexing maps
 ///    2. `genericOp` has only one input and one output with the same shape
@@ -150,6 +208,75 @@ struct ConvertBatchMmt4DtoMmt4DPattern
   }
 };
 
+struct Convert3DPackto2DPackPattern : public OpRewritePattern<tensor::PackOp> {
+  using OpRewritePattern<tensor::PackOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tensor::PackOp packOp,
+                                PatternRewriter &rewriter) const override {
+    if (packOp.getSourceRank() != 3 || packOp.getDestRank() != 5) {
+      return failure();
+    }
+
+    int64_t srcPos = 0;
+    llvm::SmallDenseSet<int64_t> s;
+    s.insert(packOp.getInnerDimsPos().begin(), packOp.getInnerDimsPos().end());
+    for (auto dim : llvm::seq<int64_t>(0, packOp.getSourceRank())) {
+      if (s.contains(dim))
+        continue;
+      srcPos = dim;
+      break;
+    }
+
+    int destPos = srcPos;
+    for (auto [idx, val] : llvm::enumerate(packOp.getOuterDimsPerm())) {
+      if (val == srcPos)
+        destPos = idx;
+    }
+
+    if (packOp.getSourceType().getDimSize(srcPos) != 1) {
+      return rewriter.notifyMatchFailure(packOp, "srcPos != 1");
+    }
+    if (packOp.getDestType().getDimSize(destPos) != 1) {
+      return rewriter.notifyMatchFailure(packOp, "destPos != 1");
+    }
+
+    SmallVector<int64_t> newInnerDimsPos(packOp.getInnerDimsPos());
+    for (auto &val : newInnerDimsPos) {
+      assert(val != srcPos);
+      if (val > srcPos)
+        val--;
+    }
+    SmallVector<int64_t> newOuterDimsPerm(packOp.getOuterDimsPerm());
+    if (!newOuterDimsPerm.empty()) {
+      newOuterDimsPerm.erase(newOuterDimsPerm.begin() + destPos);
+      for (auto &val : newOuterDimsPerm) {
+        if (val > srcPos)
+          val--;
+      }
+    }
+
+    Location loc = packOp.getLoc();
+    auto reducedSrcType =
+        RankedTensorType::Builder(packOp.getSourceType()).dropDim(srcPos);
+    auto reducedSrc = tensor::createCanonicalRankReducingExtractSliceOp(
+        rewriter, loc, packOp.getSource(), reducedSrcType);
+
+    auto reducedDestType =
+        RankedTensorType::Builder(packOp.getDestType()).dropDim(destPos);
+    auto reducedDest = tensor::createCanonicalRankReducingExtractSliceOp(
+        rewriter, loc, packOp.getDest(), reducedDestType);
+
+    auto newPackOp = rewriter.create<tensor::PackOp>(
+        loc, reducedSrc, reducedDest, newInnerDimsPos, packOp.getMixedTiles(),
+        packOp.getPaddingValue(), newOuterDimsPerm);
+
+    auto insertSliceOp = tensor::createCanonicalRankReducingInsertSliceOp(
+        rewriter, loc, newPackOp.getResult(), packOp.getDest());
+    rewriter.replaceOp(packOp, insertSliceOp);
+    return success();
+  }
+};
+
 struct CPUPrepareUkernelsPass
     : public CPUPrepareUkernelsBase<CPUPrepareUkernelsPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
@@ -165,48 +292,22 @@ struct CPUPrepareUkernelsPass
 void CPUPrepareUkernelsPass::runOnOperation() {
   MLIRContext *ctx = &getContext();
   auto funcOp = getOperation();
-  Operation *errorOp = nullptr;
   IRRewriter rewriter(ctx);
-
-  WalkResult result =
-      funcOp.walk([&](linalg::BatchMmt4DOp batchMmt4DOp) -> WalkResult {
-        auto out = batchMmt4DOp.getDpsInitOperand(0)->get();
-        auto outType = cast<RankedTensorType>(out.getType());
-        // Tile only non unit batch dimensions with tile size equals to 1.
-        if (outType.getShape()[0] <= 1) {
-          return WalkResult::advance();
-        }
-        SmallVector<int64_t> tileSizes = {1};
-        auto tilingInterfaceOp =
-            cast<TilingInterface>(batchMmt4DOp.getOperation());
-        auto options = scf::SCFTileAndFuseOptions().setTilingOptions(
-            scf::SCFTilingOptions().setTileSizes(
-                getAsIndexOpFoldResult(ctx, tileSizes)));
-        FailureOr<scf::SCFTileAndFuseResult> tileAndFuseResult =
-            scf::tileConsumerAndFuseProducersUsingSCF(
-                rewriter, tilingInterfaceOp, options);
-        if (failed(tileAndFuseResult)) {
-          errorOp = batchMmt4DOp;
-          return WalkResult::interrupt();
-        }
-        rewriter.replaceOp(
-            batchMmt4DOp,
-            tileAndFuseResult->replacements[batchMmt4DOp.getResult(0)]);
-        return WalkResult::advance();
-      });
-  if (result.wasInterrupted()) {
-    errorOp->emitOpError("failed to tile the batch dimension");
-    return signalPassFailure();
-  }
+  tileBatchDimsForBatchMmt4dOp(rewriter, funcOp);
+  tileNonPackedDimsFor3DPackOps(rewriter, funcOp);
 
   // Convert linalg.batch_mmt4d with batch dim = 1 into linalg.mmt4d.
   RewritePatternSet patterns(ctx);
-  patterns.add<ConvertBatchMmt4DtoMmt4DPattern>(ctx);
+  patterns.add<ConvertBatchMmt4DtoMmt4DPattern, Convert3DPackto2DPackPattern>(
+      ctx);
   // Canonicalize extract and insert slice ops created during the conversion.
   tensor::populateMergeConsecutiveInsertExtractSlicePatterns(patterns);
+  tensor::populateFoldTensorSubsetOpPatterns(patterns);
   tensor::InsertSliceOp::getCanonicalizationPatterns(patterns, ctx);
   tensor::ExtractSliceOp::getCanonicalizationPatterns(patterns, ctx);
   tensor::EmptyOp::getCanonicalizationPatterns(patterns, ctx);
+  tensor::PackOp::getCanonicalizationPatterns(patterns, ctx);
+  tensor::CastOp::getCanonicalizationPatterns(patterns, ctx);
   tensor::populateFoldTensorEmptyPatterns(patterns);
   if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
     return signalPassFailure();

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -565,6 +565,7 @@ void addCPUDataTilingPipeline(OpPassManager &funcPassManager,
   addTileAndDistributePasses(funcPassManager);
 
   if (pipelineOpt.enableUkernels) {
+    funcPassManager.addPass(createCPUPrepareUkernelsPass());
     funcPassManager.addPass(
         createCPULowerToUKernelsPass(clSkipIntermediateRoundings));
   }


### PR DESCRIPTION
The pack ukernel only works for 2D cases. Similar to what's happening in
batch_mmt4d, The revision adds the support to convert 3D pack into 2D
pack.