### PR TITLE
Update IREE onnx import to be in sync with Torch-MLIR

### DIFF
--- a/compiler/bindings/python/iree/compiler/tools/import_onnx/__main__.py
+++ b/compiler/bindings/python/iree/compiler/tools/import_onnx/__main__.py
@@ -104,7 +104,7 @@ def load_onnx_model(args: argparse.Namespace) -> onnx.ModelProto:
 
         # Load the temp file and the external data.
         inferred_model = onnx.load(temp_inferred_file, load_external_data=False)
-        data_dir = Path(input_dir if args.temp_dir is None else args.data_dir)
+        data_dir = Path(input_dir if args.data_dir is None else args.data_dir)
         onnx.load_external_data_for_model(inferred_model, data_dir)
 
         return inferred_model
@@ -126,14 +126,6 @@ def parse_arguments(argv=None) -> argparse.Namespace:
         default=True,
         action=argparse.BooleanOptionalAction,
         help="Toggle data propogation for onnx shape inference",
-    )
-    parser.add_argument(
-        "--temp-dir",
-        help="Pre-existing directory in which to create temporary files."
-        ' For example, to place temporaries under the directory "foo/bar",'
-        ' specify --temp-dir=foo/bar.  "foo/bar" must already exist.'
-        " Defaults to the directory of the input file.",
-        type=Path,
     )
     parser.add_argument(
         "--data-dir",

--- a/compiler/bindings/python/iree/compiler/tools/import_onnx/__main__.py
+++ b/compiler/bindings/python/iree/compiler/tools/import_onnx/__main__.py
@@ -142,7 +142,7 @@ def load_onnx_model(args: argparse.Namespace) -> onnx.ModelProto:
 
 
 def parse_arguments(argv=None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Torch-mlir ONNX import tool")
+    parser = argparse.ArgumentParser(description="IREE ONNX import tool")
     parser.add_argument("input_file", help="ONNX protobuf input", type=Path)
     parser.add_argument(
         "-o", dest="output_file", help="Output path (or '-' for stdout)"

--- a/compiler/bindings/python/iree/compiler/tools/import_onnx/__main__.py
+++ b/compiler/bindings/python/iree/compiler/tools/import_onnx/__main__.py
@@ -15,7 +15,9 @@ Or from Python:
   python -m iree.compiler.tools.import_onnx ...
 """
 import argparse
+import os
 from pathlib import Path
+import shutil
 import sys
 
 try:
@@ -38,8 +40,8 @@ from ...ir import (
 )
 
 
-def main(args):
-    model_proto = load_onnx_model(args.input_file)
+def main(args: argparse.Namespace):
+    model_proto = load_onnx_model(args)
     context = Context()
     model_info = onnx_importer.ModelInfo(model_proto)
     m = model_info.create_module(context=context).operation
@@ -58,14 +60,89 @@ def main(args):
         print(m.get_asm(assume_verified=not args.no_verify))
 
 
-def load_onnx_model(file_path: Path) -> onnx.ModelProto:
-    raw_model = onnx.load(file_path)
-    inferred_model = onnx.shape_inference.infer_shapes(raw_model)
+def load_onnx_model(args: argparse.Namespace) -> onnx.ModelProto:
+    # Do shape inference two ways.  First, attempt in-memory to avoid redundant
+    # loading and the need for writing a temporary file somewhere.  If that
+    # fails, typically because of the 2 GB protobuf size limit, try again via
+    # files.  See
+    # https://github.com/onnx/onnx/blob/main/docs/PythonAPIOverview.md#shape-inference-a-large-onnx-model-2gb
+    # for details about the file-based technique.
+
+    # Make a temp dir for all the temp files we'll be generating as a side
+    # effect of infering shapes.  For now, the only file is a new .onnx holding
+    # the revised model with shapes.
+    #
+    # TODO: If the program temp_dir is None, we should be using an ephemeral
+    # temp directory instead of a hard-coded path in order to avoid data races
+    # by default.
+    input_dir = os.path.dirname(os.path.abspath(args.input_file))
+    temp_dir = (
+        Path(input_dir if args.temp_dir is None else args.temp_dir)
+        / "onnx-importer-temp"
+    )
+    shutil.rmtree(temp_dir, ignore_errors=True)
+    temp_dir.mkdir(exist_ok=True)
+
+    # Load the model, with possible external data coming from the default
+    # location, or the location specified on the conmand line.
+    if args.data_dir is None:
+        raw_model = onnx.load(args.input_file)
+    else:
+        raw_model = onnx.load(args.input_file, load_external_data=False)
+        onnx.load_external_data_for_model(raw_model, args.data_dir)
+
+    # Run the checker to test whether the file is above the threshold for
+    # in-memory shape inference.  If not, go ahead and do the shape inference.
+    try:
+        onnx.checker.check_model(raw_model)
+        inferred_model = onnx.shape_inference.infer_shapes(
+            raw_model, data_prop=args.data_prop
+        )
+        return inferred_model
+    except ValueError:
+        pass
+
+    # The following code was an attempt to work around the bug where models
+    # with external data produce invalid output shapes after infer_shapes_path.
+    # It works with small models but threw an error for llama seeming to
+    # indicate that the protobuf is corrupt.
+    #
+    # temp_raw_file = temp_dir / "raw.onnx"
+    # onnx.save(raw_model, temp_raw_file, save_as_external_data=False)
+    # onnx.shape_inference.infer_shapes_path(temp_raw_file, temp_inferred_file)
+    # inferred_model = onnx.load(temp_inferred_file)
+
+    # Model is too big for in-memory inference: do file-based shape inference
+    # to a temp file.
+    temp_inferred_file = temp_dir / "inferred.onnx"
+    onnx.shape_inference.infer_shapes_path(
+        args.input_file, temp_inferred_file, data_prop=args.data_prop
+    )
+
+    # Sanity check the shape-inferred model to be sure we have a good model
+    # for the importer.  This call uses the file-based method, as the
+    # in-memory method (passing the loaded model) fails due to the 2 GB limit.
+    #
+    # TODO: this call throws an exception because it can't find the external
+    # data files, and there doesn't appear to be a way to let the checker know
+    # where to find them.
+    #
+    # onnx.checker.check_model(temp_inferred_file)
+
+    # Load the temp file and the external data.
+    inferred_model = onnx.load(temp_inferred_file, load_external_data=False)
+    data_dir = Path(input_dir if args.temp_dir is None else args.data_dir)
+    onnx.load_external_data_for_model(inferred_model, data_dir)
+
+    # Remove the inferred shape file unless asked to keep it
+    if not args.keep_temps:
+        shutil.rmtree(temp_dir)
+
     return inferred_model
 
 
-def parse_arguments(argv=None):
-    parser = argparse.ArgumentParser(description="IREE ONNX import tool")
+def parse_arguments(argv=None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Torch-mlir ONNX import tool")
     parser.add_argument("input_file", help="ONNX protobuf input", type=Path)
     parser.add_argument(
         "-o", dest="output_file", help="Output path (or '-' for stdout)"
@@ -74,6 +151,34 @@ def parse_arguments(argv=None):
         "--no-verify",
         action="store_true",
         help="Disable verification prior to printing",
+    )
+    parser.add_argument(
+        "--data-prop",
+        dest="data_prop",
+        default=True,
+        action=argparse.BooleanOptionalAction,
+        help="Toggle data propogation for onnx shape inference",
+    )
+    parser.add_argument(
+        "--keep-temps", action="store_true", help="Keep intermediate files"
+    )
+    parser.add_argument(
+        "--temp-dir",
+        help="Pre-existing directory in which to create temporary files."
+        ' For example, to place temporaries under the directory "foo/bar",'
+        ' specify --temp-dir=foo/bar.  "foo/bar" must already exist.'
+        " Defaults to the directory of the input file.",
+        type=Path,
+    )
+    parser.add_argument(
+        "--data-dir",
+        help="Path between CWD and the base directory of the data,"
+        " excluding the directories given in the 'location' argument of "
+        " convert_model_to_external_data.  For example, if 'location' was"
+        ' "data/data.bin" and the relative path from CWD to that .bin file is'
+        ' a/b/data/data.bin, then set data-dir to "a/b".'
+        " Defaults to the directory of the input file.",
+        type=Path,
     )
     args = parser.parse_args(argv)
     return args

--- a/compiler/bindings/python/iree/compiler/tools/import_onnx/__main__.py
+++ b/compiler/bindings/python/iree/compiler/tools/import_onnx/__main__.py
@@ -78,7 +78,7 @@ def load_onnx_model(args: argparse.Namespace) -> onnx.ModelProto:
     # files.  See
     # https://onnx.ai/onnx/repo-docs/PythonAPIOverview.html#shape-inference-a-large-onnx-model-2gb
     # for details about the file-based technique.
-    
+
     # Run the checker to test whether the file is above the threshold for
     # in-memory shape inference.  If not, go ahead and do the shape inference.
     try:

--- a/compiler/bindings/python/iree/compiler/tools/import_onnx/__main__.py
+++ b/compiler/bindings/python/iree/compiler/tools/import_onnx/__main__.py
@@ -17,7 +17,6 @@ Or from Python:
 import argparse
 import os
 from pathlib import Path
-import shutil
 import sys
 import tempfile
 


### PR DESCRIPTION
This commit updates `iree-import-onnx` so that it behaves the same as torch-mlir's version (https://github.com/llvm/torch-mlir/blob/main/python/torch_mlir/tools/import_onnx/__main__.py).
Specifically, enabling the data propagation improves shape inference and is leading to more models passing.

Related to #17021 