### PR TITLE
[Codegen][GPU] Add semi-generic tile + fuse pass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
@@ -50,6 +50,7 @@ iree_compiler_cc_library(
     name = "CommonGPUPasses",
     srcs = [
         "AMDGPUDistributeContract.cpp",
+        "GPUApplyTilingLevel.cpp",
         "GPUCheckResourceUsage.cpp",
         "GPUCreateFastSlowPath.cpp",
         "GPUDistribute.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
@@ -127,6 +127,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TensorTransforms",
+        "@llvm-project//mlir:TilingInterface",
         "@llvm-project//mlir:TransformUtils",
         "@llvm-project//mlir:Transforms",
         "@llvm-project//mlir:VectorDialect",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
@@ -109,6 +109,7 @@ iree_cc_library(
     MLIRSupport
     MLIRTensorDialect
     MLIRTensorTransforms
+    MLIRTilingInterface
     MLIRTransformUtils
     MLIRTransforms
     MLIRVectorDialect

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
@@ -48,6 +48,7 @@ iree_cc_library(
     "Passes.h"
   SRCS
     "AMDGPUDistributeContract.cpp"
+    "GPUApplyTilingLevel.cpp"
     "GPUCheckResourceUsage.cpp"
     "GPUCreateFastSlowPath.cpp"
     "GPUDistribute.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyTilingLevel.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyTilingLevel.cpp
@@ -19,7 +19,7 @@
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Interfaces/TilingInterface.h"
 
-#define DEBUG_TYPE "iree-codegen-gpu-tensor-tile"
+#define DEBUG_TYPE "iree-codegen-gpu-apply-tiling-level"
 
 namespace mlir::iree_compiler {
 
@@ -34,6 +34,10 @@ struct GPUApplyTilingLevelPass final
 };
 } // namespace
 
+/// This collects the set of operations to tile + fuse starting from the given
+/// root |op| and walking up to its producers. Stops at operations given by
+/// |exclude| which are expected to receive their own independent tiling for the
+/// given level.
 static llvm::SmallDenseSet<Operation *>
 collectTiledAndFusedOps(Operation *op,
                         llvm::SmallDenseSet<TilingInterface> exclude) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyTilingLevel.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyTilingLevel.cpp
@@ -1,0 +1,202 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/GPU/Passes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
+#include "llvm/ADT/DenseSet.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/SCF/Transforms/TileUsingInterface.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Interfaces/TilingInterface.h"
+
+#define DEBUG_TYPE "iree-codegen-gpu-tensor-tile"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_GPUAPPLYTILINGLEVELPASS
+#include "iree/compiler/Codegen/Common/GPU/Passes.h.inc"
+
+namespace {
+struct GPUApplyTilingLevelPass final
+    : impl::GPUApplyTilingLevelPassBase<GPUApplyTilingLevelPass> {
+  using GPUApplyTilingLevelPassBase::GPUApplyTilingLevelPassBase;
+  void runOnOperation() override;
+};
+} // namespace
+
+static llvm::SmallDenseSet<Operation *>
+collectTiledAndFusedOps(Operation *op,
+                        llvm::SmallDenseSet<TilingInterface> exclude) {
+  SmallVector<Operation *> worklist;
+  llvm::SmallDenseSet<Operation *> producers;
+  worklist.push_back(op);
+  producers.insert(op);
+  while (!worklist.empty()) {
+    Operation *current = worklist.pop_back_val();
+    for (OpOperand &operand : current->getOpOperands()) {
+      auto producer = operand.get().getDefiningOp<TilingInterface>();
+      if (!producer || producers.contains(producer) ||
+          exclude.contains(producer))
+        continue;
+      worklist.push_back(producer);
+      producers.insert(producer);
+    }
+  }
+  return producers;
+}
+
+/// Apply a tile and fuse transformation to all payload ops and store both the
+/// tiled operation as well as the created tile loops.
+static LogicalResult
+applyTileAndFuseToEachRoot(RewriterBase &rewriter,
+                           llvm::SmallDenseSet<TilingInterface> &payloadOps,
+                           bool threadTiling) {
+  MLIRContext *context = rewriter.getContext();
+  unsigned tilingLevel =
+      threadTiling ? static_cast<unsigned>(IREE::GPU::TilingLevel::Thread)
+                   : static_cast<unsigned>(IREE::GPU::TilingLevel::Reduction);
+  for (TilingInterface tilingInterfaceOp : payloadOps) {
+    mlir::DominanceInfo dominanceInfo(tilingInterfaceOp);
+
+    llvm::SmallDenseSet<Operation *> tiledAndFusedOps =
+        collectTiledAndFusedOps(tilingInterfaceOp, payloadOps);
+    llvm::DenseSet<Operation *> yieldReplacementsFor;
+    for (auto op : tiledAndFusedOps) {
+      if (llvm::any_of(op->getUsers(), [&](Operation *user) {
+            return dominanceInfo.properlyDominates(tilingInterfaceOp, user);
+          })) {
+        yieldReplacementsFor.insert(op);
+      }
+    }
+
+    rewriter.setInsertionPoint(tilingInterfaceOp);
+    SmallVector<OpFoldResult> tileSizes =
+        getLoweringConfig(tilingInterfaceOp)
+            .getTilingLevelSizes(rewriter, tilingLevel, tilingInterfaceOp);
+
+    // Pad the tile sizes with zero.
+    auto zero = rewriter.getIndexAttr(0);
+    int64_t numLoops = tilingInterfaceOp.getLoopIteratorTypes().size();
+    if (tileSizes.size() > numLoops) {
+      return failure();
+    }
+    while (tileSizes.size() < numLoops) {
+      tileSizes.push_back(zero);
+    }
+
+    scf::SCFTilingOptions tilingOptions;
+    tilingOptions.setTileSizes(tileSizes);
+    if (threadTiling) {
+      tilingOptions.setLoopType(scf::SCFTilingOptions::LoopType::ForallOp);
+
+      // TODO: Add some helpers to construct this based on the enum type rather
+      // than doing it here.
+      SmallVector<DeviceMappingAttrInterface> mapping;
+      for (auto [idx, size] : llvm::enumerate(tileSizes)) {
+        if (!isConstantIntValue(size, 0)) {
+          unsigned mappingId =
+              static_cast<unsigned>(gpu::MappingId::LinearDim0) + idx;
+          mapping.push_back(gpu::GPUThreadMappingAttr::get(
+              context, static_cast<gpu::MappingId>(mappingId)));
+        }
+      }
+      tilingOptions.setMapping(mapping);
+    }
+
+    scf::SCFTileAndFuseOptions tileAndFuseOptions;
+    tileAndFuseOptions.setTilingOptions(tilingOptions);
+
+    scf::SCFTileAndFuseOptions::ControlFnTy controlFn =
+        [&](tensor::ExtractSliceOp candidateSliceOp, OpResult originalProducer,
+            bool isDestinationOperand) {
+          Operation *owner = originalProducer.getOwner();
+          bool yieldProducerReplacement = yieldReplacementsFor.contains(owner);
+          bool shouldFuse = false;
+          if (auto tilingOwner = dyn_cast<TilingInterface>(owner)) {
+            shouldFuse = !payloadOps.contains(tilingOwner);
+          }
+          // Do not fuse destination operands.
+          shouldFuse &= !isDestinationOperand;
+          return std::make_tuple(shouldFuse, yieldProducerReplacement);
+        };
+    tileAndFuseOptions.setFusionControlFn(controlFn);
+
+    FailureOr<scf::SCFTileAndFuseResult> tiledResults =
+        scf::tileConsumerAndFuseProducersUsingSCF(rewriter, tilingInterfaceOp,
+                                                  tileAndFuseOptions);
+    if (failed(tiledResults))
+      return failure();
+
+    // Perform the replacement of tiled and fused values.
+    SmallVector<Operation *> opsToReplace{tilingInterfaceOp};
+    llvm::append_range(opsToReplace, tiledResults->fusedProducers);
+    for (Operation *toReplace : opsToReplace) {
+      for (OpResult res : toReplace->getResults())
+        if (auto replacement = tiledResults->replacements.lookup(res)) {
+          Operation *replacementOp = replacement.getDefiningOp();
+          rewriter.replaceUsesWithIf(res, replacement, [&](OpOperand &use) {
+            Operation *user = use.getOwner();
+            return dominanceInfo.properlyDominates(replacementOp, user) &&
+                   user->getParentOp() == replacementOp->getParentOp();
+          });
+        }
+
+      if (toReplace->use_empty()) {
+        rewriter.eraseOp(toReplace);
+      }
+    }
+  }
+  return success();
+}
+
+static llvm::SmallDenseSet<TilingInterface>
+getTiledOps(Operation *funcOp, IREE::GPU::TilingLevel tilingLevel) {
+  llvm::SmallDenseSet<TilingInterface> targets;
+  unsigned opaqueLevel = static_cast<unsigned>(tilingLevel);
+  funcOp->walk([&](TilingInterface target) {
+    // TODO: This would probably be easier with a lowering config interface
+    // method that checks whether a particular level is tiled.
+    if (IREE::Codegen::LoweringConfigAttrInterface loweringConfig =
+            getLoweringConfig(target)) {
+      if (!loweringConfig.getStaticTilingLevelSizes(opaqueLevel, target)
+               .empty()) {
+        targets.insert(target);
+      }
+    }
+  });
+  return targets;
+}
+
+void GPUApplyTilingLevelPass::runOnOperation() {
+  FunctionOpInterface funcOp = getOperation();
+
+  if (tilingLevel != IREE::GPU::TilingLevel::Reduction &&
+      tilingLevel != IREE::GPU::TilingLevel::Thread) {
+    funcOp.emitError() << "unsupported tiling level: "
+                       << IREE::GPU::stringifyEnum(tilingLevel) << "\n";
+    return signalPassFailure();
+  }
+
+  llvm::SmallDenseSet<TilingInterface> targetOps =
+      getTiledOps(funcOp, tilingLevel);
+  bool useThread = tilingLevel == IREE::GPU::TilingLevel::Thread;
+
+  IRRewriter rewriter(funcOp);
+  if (failed(applyTileAndFuseToEachRoot(rewriter, targetOps, useThread))) {
+    funcOp.emitError() << "tiling of level "
+                       << IREE::GPU::stringifyEnum(tilingLevel) << " failed\n";
+    return signalPassFailure();
+  }
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyTilingLevel.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyTilingLevel.cpp
@@ -134,8 +134,9 @@ applyTileAndFuseToEachRoot(RewriterBase &rewriter,
     FailureOr<scf::SCFTileAndFuseResult> tiledResults =
         scf::tileConsumerAndFuseProducersUsingSCF(rewriter, tilingInterfaceOp,
                                                   tileAndFuseOptions);
-    if (failed(tiledResults))
+    if (failed(tiledResults)) {
       return failure();
+    }
 
     // Perform the replacement of tiled and fused values.
     SmallVector<Operation *> opsToReplace{tilingInterfaceOp};

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
@@ -9,6 +9,7 @@
 #define IREE_COMPILER_CODEGEN_COMMON_GPU_PASSES_H_
 
 #include <cstdint>
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Pass/Pass.h"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -127,6 +127,25 @@ def GPUTensorTilePass :
   ];
 }
 
+def GPUApplyTilingLevelPass :
+    InterfacePass<"iree-codegen-gpu-apply-tiling-level", "mlir::FunctionOpInterface"> {
+  let summary = "Pass to tile tensor ops based on tiling configs";
+  let dependentDialects = [
+    "::mlir::affine::AffineDialect", "::mlir::gpu::GPUDialect", "::mlir::scf::SCFDialect"
+  ];
+  let options = [
+    Option<"tilingLevel", "tiling-level", "IREE::GPU::TilingLevel",
+           /*default=*/"IREE::GPU::TilingLevel::Reduction",
+           "Tiling level to tile. Supported levels are 'reduction' and 'thread'",
+           [{llvm::cl::values(
+              clEnumValN(IREE::GPU::TilingLevel::Reduction, "reduction",
+                         "Tile and fuse all annotated ops to serial loops"),
+              clEnumValN(IREE::GPU::TilingLevel::Thread, "thread",
+                         "Tile and fuse all annotated ops to threads")
+           )}]>,
+  ];
+}
+
 def GPUTensorTileToSerialLoopsPass :
     InterfacePass<"iree-codegen-gpu-tensor-tile-to-serial-loops", "mlir::FunctionOpInterface"> {
   let summary = "Pass to tile reduction dimensions for certain GPU ops";

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "gpu_apply_tiling_level.mlir",
             "gpu_check_resource_usage.mlir",
             "gpu_create_fast_slow_path.mlir",
             "gpu_distribute.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "gpu_apply_tiling_level.mlir"
     "gpu_check_resource_usage.mlir"
     "gpu_create_fast_slow_path.mlir"
     "gpu_distribute.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_tiling_level.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_tiling_level.mlir
@@ -1,0 +1,108 @@
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-apply-tiling-level, canonicalize, cse))" %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-apply-tiling-level{tiling-level=thread}, canonicalize, cse))" %s | FileCheck %s --check-prefix=THREAD
+
+#config = #iree_gpu.lowering_config<{thread = [2, 16]}>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+module {
+  func.func @add_tensor() {
+    %c0 = arith.constant 0 : index
+    %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<64x256xf32>>
+    %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<64x256xf32>>
+    %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<64x256xf32>>
+    %3 = flow.dispatch.tensor.load %0, offsets = [%c0, %c0], sizes = [64, 256], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<64x256xf32>> -> tensor<64x256xf32>
+    %4 = flow.dispatch.tensor.load %1, offsets = [%c0, %c0], sizes = [64, 256], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<64x256xf32>> -> tensor<64x256xf32>
+    %5 = flow.dispatch.tensor.load %2, offsets = [%c0, %c0], sizes = [64, 256], strides = [1, 1] : !flow.dispatch.tensor<writeonly:tensor<64x256xf32>> -> tensor<64x256xf32>
+    %6 = linalg.generic {
+      indexing_maps = [#map, #map, #map],
+      iterator_types = ["parallel", "parallel"]
+      } ins(%3, %4 : tensor<64x256xf32>, tensor<64x256xf32>) outs(%5 : tensor<64x256xf32>) attrs =  {lowering_config = #config} {
+    ^bb0(%in: f32, %in_0: f32, %out: f32):
+      %7 = arith.addf %in, %in_0 : f32
+      linalg.yield %7 : f32
+    } -> tensor<64x256xf32>
+    flow.dispatch.tensor.store %6, %2, offsets = [%c0, %c0], sizes = [64, 256], strides = [1, 1] : tensor<64x256xf32> -> !flow.dispatch.tensor<writeonly:tensor<64x256xf32>>
+    return
+  }
+}
+
+// Verify that no loops are generated without a reduction configuration.
+// CHECK-LABEL: func.func @add_tensor
+//   CHECK-NOT:   scf.for
+
+// THREAD-LABEL: func.func @add_tensor
+//       THREAD:   scf.forall ({{.*}}) = (0, 0) to (64, 256) step (2, 16)
+//       THREAD:     linalg.generic {{.*}} ins(%{{.*}}: tensor<2x16xf32>, tensor<2x16xf32>)
+//       THREAD:     scf.forall.in_parallel
+//       THREAD:   mapping = [#gpu.thread<linear_dim_0>, #gpu.thread<linear_dim_1>]
+
+// -----
+
+#config = #iree_gpu.lowering_config<{reduction = [0, 8]}>
+#map = affine_map<()[s0] -> (s0 * 64)>
+#map1 = affine_map<(d0, d1) -> (d0, d1)>
+#map2 = affine_map<(d0, d1) -> (d0)>
+module {
+  func.func @reduction() {
+    %c0 = arith.constant 0 : index
+    %cst = arith.constant 0.000000e+00 : f32
+    %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<128x384xf32>>
+    %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<128xf32>>
+    %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [128, 384], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<128x384xf32>> -> tensor<128x384xf32>
+    %empty = tensor.empty() : tensor<128xf32>
+    %4 = linalg.fill ins(%cst : f32) outs(%empty : tensor<128xf32>) -> tensor<128xf32>
+    %5 = linalg.generic {
+      indexing_maps = [#map1, #map2],
+      iterator_types = ["parallel", "reduction"]
+      } ins(%3 : tensor<128x384xf32>) outs(%4 : tensor<128xf32>) attrs =  {lowering_config = #config} {
+    ^bb0(%in: f32, %out: f32):
+      %7 = arith.addf %in, %out : f32
+      linalg.yield %7 : f32
+    } -> tensor<128xf32>
+    flow.dispatch.tensor.store %5, %1, offsets = [%c0], sizes = [128], strides = [1] : tensor<128xf32> -> !flow.dispatch.tensor<writeonly:tensor<128xf32>>
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @reduction
+//       CHECK:   %[[FILL:.+]] = linalg.fill {{.*}} tensor<128xf32>
+//       CHECK:   scf.for %{{.*}} = %c0 to %c384 step %c8 iter_args(%{{.*}} = %[[FILL]])
+//       CHECK:     linalg.generic {{.*}} ins(%{{.*}} : tensor<128x8xf32>)
+//       CHECK:     scf.yield
+
+// Verify that no tiling happens in the thread case.
+// THREAD-LABEL: func.func @reduction
+//   THREAD-NOT:   scf.forall
+
+// -----
+
+#config = #iree_gpu.lowering_config<{reduction = [0, 0, 8]}>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+module {
+  func.func @matmul_fuse() {
+    %c0 = arith.constant 0 : index
+    %cst = arith.constant 1.0 : f32
+    %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<64x64xf32>>
+    %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<64x64xf32>>
+    %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<64x64xf32>>
+    %3 = flow.dispatch.tensor.load %0, offsets = [%c0, %c0], sizes = [64, 64], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<64x64xf32>> -> tensor<64x64xf32>
+    %4 = flow.dispatch.tensor.load %1, offsets = [%c0, %c0], sizes = [64, 64], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<64x64xf32>> -> tensor<64x64xf32>
+    %5 = flow.dispatch.tensor.load %2, offsets = [%c0, %c0], sizes = [64, 64], strides = [1, 1] : !flow.dispatch.tensor<writeonly:tensor<64x64xf32>> -> tensor<64x64xf32>
+    %empty = tensor.empty() : tensor<64x64xf32>
+    %6 = linalg.generic {
+      indexing_maps = [#map, #map],
+      iterator_types = ["parallel", "parallel"]
+      } ins(%3 : tensor<64x64xf32>) outs(%empty : tensor<64x64xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %8 = arith.addf %in, %cst : f32
+      linalg.yield %8 : f32
+    } -> tensor<64x64xf32>
+    %7 = linalg.matmul {lowering_config = #config} ins(%6, %4 : tensor<64x64xf32>, tensor<64x64xf32>) outs(%5 : tensor<64x64xf32>) -> tensor<64x64xf32>
+    flow.dispatch.tensor.store %7, %2, offsets = [%c0, %c0], sizes = [64, 64], strides = [1, 1] : tensor<64x64xf32> -> !flow.dispatch.tensor<writeonly:tensor<64x64xf32>>
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @matmul_fuse
+//       CHECK:   scf.for %{{.*}} = %c0 to %c64 step %c8
+//       CHECK:     %[[ELEMWISE:.+]] = linalg.generic {{.*}} ins(%{{.*}} : tensor<64x8xf32>)
+//       CHECK:     %[[MM:.+]] = linalg.matmul {{.*}} ins(%[[ELEMWISE]], {{.*}} : tensor<64x8xf32>, tensor<8x64xf32>)


### PR DESCRIPTION
This performs greedy tile + fuse based on lowering configs interpreted
using iree_gpu tiling levels. This assumes configs are NOT propagated,
instead collecting the set of operations that are tiled for the
specified level and performing greedy tile + fuse on each one
individually.

Depends on #17463