### PR TITLE
[Codegen][GPU] Allow iree_gpu.tensor_barrier to take vectors

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -237,12 +237,4 @@ LogicalResult ShuffleTensorOp::verifyRegions() {
   return success();
 }
 
-//===----------------------------------------------------------------------===//
-// TensorBarrierOp
-//===----------------------------------------------------------------------===//
-
-MutableOperandRange TensorBarrierOp::getDpsInitsMutable() {
-  return getInputMutable();
-}
-
 } // namespace mlir::iree_compiler::IREE::GPU

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -352,36 +352,39 @@ def IREEGPU_ShuffleTensorOp : Op<IREEGPU_Dialect, "shuffle_tensor", [
 }
 
 //===----------------------------------------------------------------------===//
-// TensorBarrierOp
+// ValueBarrierOp
 //===----------------------------------------------------------------------===//
 
-def IREEGPU_TensorBarrierOp : Op<IREEGPU_Dialect, "tensor_barrier", [
+def IREEGPU_ValueBarrierOp : Op<IREEGPU_Dialect, "value_barrier", [
     Pure,
-    DeclareOpInterfaceMethods<DestinationStyleOpInterface>,
     AllTypesMatch<["input", "result"]>,
     ]> {
   let summary = "Shuffles a private tensor across a shared allocation";
   let description = [{
-    This operation acts as a barrier on a tensor value. It takes a single
-    tensor operand and produces an equivalent tensor. This does not have copy
-    and/or data movement semantics and simply represents a barrier on all writes
-    to the input tensor.
+    This operation acts as a barrier on a value semantic SSA value (tensor or
+    vector). It takes a single operand and produces a value equivalent to the
+    input. This does not have copy and/or data movement semantics and simply
+    represents a barrier on all writes in the tensor case, and a barrier until
+    all threads acquire the input vector in the vector case.
 
     This operation is a no-op when not present in a parallel context. This
     operation is pure as it only requires synchronization for the value it
     produces.
   }];
 
-  let arguments = (ins AnyRankedTensor:$input);
-  let results = (outs AnyRankedTensor:$result);
+  let arguments = (ins AnyRankedTensorOrVector:$input);
+  let results = (outs AnyRankedTensorOrVector:$result);
 
   let assemblyFormat = [{
     $input attr-dict `:` type($result)
   }];
 
   let extraClassDeclaration = [{
-    RankedTensorType getInputType() {
-      return getInput().getType();
+    bool hasTensorSemantics() {
+      return isa<::mlir::RankedTensorType>(getInput().getType());
+    }
+    ::mlir::ShapedType getInputType() {
+      return ::llvm::cast<::mlir::ShapedType>(getInput().getType());
     }
   }];
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
@@ -134,10 +134,21 @@ func.func @single_multi_mma(%lhs: vector<4xf16>, %rhs: vector<4xf16>, %acc: vect
 // -----
 
 func.func @tensor_barrier(%input: tensor<?xf16>) -> tensor<?xf16> {
-  %out = iree_gpu.tensor_barrier %input : tensor<?xf16>
+  %out = iree_gpu.value_barrier %input : tensor<?xf16>
   return %out : tensor<?xf16>
 }
 
 // CHECK-LABEL: func @tensor_barrier
 //  CHECK-SAME:   %[[INPUT:[A-Za-z0-9]+]]: tensor<?xf16>
-//       CHECK:   iree_gpu.tensor_barrier %[[INPUT]] : tensor<?xf16>
+//       CHECK:   iree_gpu.value_barrier %[[INPUT]] : tensor<?xf16>
+
+// -----
+
+func.func @vector_barrier(%input: vector<8xf16>) -> vector<8xf16> {
+  %out = iree_gpu.value_barrier %input : vector<8xf16>
+  return %out : vector<8xf16>
+}
+
+// CHECK-LABEL: func @vector_barrier
+//  CHECK-SAME:   %[[INPUT:[A-Za-z0-9]+]]: vector<8xf16>
+//       CHECK:   iree_gpu.value_barrier %[[INPUT]] : vector<8xf16>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/IREEGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/IREEGPUExtensions.cpp
@@ -26,6 +26,15 @@ transform_dialect::IREEGPUExtensions::IREEGPUExtensions() {
 }
 
 //===---------------------------------------------------------------------===//
+// ApplyLowerValueBarrierOp
+//===---------------------------------------------------------------------===//
+
+void transform_dialect::ApplyLowerValueBarrierOp::populatePatterns(
+    RewritePatternSet &patterns) {
+  IREE::GPU::populateIREEGPULowerValueBarrierPatterns(patterns);
+}
+
+//===---------------------------------------------------------------------===//
 // ApplyUnrollMultiMmaOp
 //===---------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/IREEGPUExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/IREEGPUExtensionsOps.td
@@ -14,6 +14,19 @@ include "mlir/Dialect/Transform/Interfaces/TransformInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/OpBase.td"
 
+def ApplyLowerValueBarrierOp : Op<Transform_Dialect,
+    "apply_patterns.iree.lower_value_barrier",
+    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,
+     ReportTrackingListenerFailuresOpTrait]> {
+  let description = [{
+    Populate patterns to convert value barriers on vectors into gpu.barrier ops.
+    Barriers on tensors are ignored.
+  }];
+
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+  let assemblyFormat = "attr-dict";
+}
+
 def ApplyUnrollMultiMmaOp : Op<Transform_Dialect,
     "apply_patterns.iree.unroll_multi_mma",
     [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>,

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/BUILD.bazel
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "lower_vector_barrier.mlir",
             "transform_fuse_forall.mlir",
             "vectorize_multi_mma.mlir",
             "unroll_multi_mma.mlir",

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "lower_vector_barrier.mlir"
     "transform_fuse_forall.mlir"
     "unroll_multi_mma.mlir"
     "vectorize_multi_mma.mlir"

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/lower_vector_barrier.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/lower_vector_barrier.mlir
@@ -1,0 +1,21 @@
+// RUN: iree-opt %s -iree-transform-dialect-interpreter -transform-dialect-drop-schedule --split-input-file | FileCheck %s
+
+func.func @lower_value_barrier(%input: vector<4xf32>) -> vector<4xf32> {
+  %0 = iree_gpu.value_barrier %input : vector<4xf32>
+  return %0 : vector<4xf32>
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %root : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %func {
+      transform.apply_patterns.iree.lower_value_barrier
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @lower_value_barrier
+//  CHECK-SAME:   %[[INPUT:[A-Za-z0-9]+]]: vector<4xf32>
+//  CHECK-NEXT:   gpu.barrier
+//  CHECK-NEXT:   return %[[INPUT]]

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.h
@@ -39,6 +39,8 @@ void populateIREEGPUVectorUnrollPatterns(
 
 void populateIREEGPUVectorizationPatterns(RewritePatternSet &patterns);
 
+void populateIREEGPULowerValueBarrierPatterns(RewritePatternSet &patterns);
+
 } // namespace mlir::iree_compiler::IREE::GPU
 
 #endif // IREE_COMPILER_CODEGEN_DIALECT_GPU_TRANSFORMS_TRANSFORMS_H_


### PR DESCRIPTION
This allows synchronizing on vectors as well as tensors with similar
semantics.  In a typical lowering flow, this will represent the
read equivalent to a tensor barrier, in that a tensor barrier represents
a wait until all writes to a shared allocation has finished, while this
represents a wait until all threads have read the value they need from
that shared allocation.

Renames the operation to `iree_gpu.value_barrier` for clarity.