### PR TITLE
Pin nanobind to 1.9.2 to defer 2.0.0 API changes.

### DIFF
--- a/compiler/pyproject.toml
+++ b/compiler/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
     # Note that the compiler wheel does not presently need nanobind, but
     # it's build is enabled by the same flag which enables the runtime
     # configuration, which does.
-    "nanobind>=1.9.2",
+    "nanobind==1.9.2",
     "ninja",
     # MLIR build depends.
     "numpy",

--- a/runtime/bindings/python/iree/runtime/build_requirements.txt
+++ b/runtime/bindings/python/iree/runtime/build_requirements.txt
@@ -5,7 +5,7 @@
 
 pip>=21.3
 setuptools>=62.4.0
-nanobind>=1.9.2
+nanobind==1.9.2
 numpy>=2.0.0b1
 requests>=2.28.0
 wheel>=0.36.2

--- a/runtime/pyproject.toml
+++ b/runtime/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools>=42",
     "wheel",
     "cmake",
-    "nanobind>=1.9.2",
+    "nanobind==1.9.2",
     "ninja",
     "numpy>=2.0.0b1",
     "packaging",


### PR DESCRIPTION
Version 2.0.0 just landed a few minutes ago: https://pypi.org/project/nanobind/#history, which broke some of our builds: https://github.com/iree-org/iree/actions/runs/9210086545/job/25336292024?pr=17478#step:4:14124

```
/work/runtime/bindings/python/hal.cc:1197:8: error: no member named 'def_static' in 'nanobind::enum_<iree_hal_element_types_t>'
      .def_static("map_to_dtype",
       ^
```