### PR TITLE
Upgrade to nanobind 2.0.

### DIFF
--- a/compiler/pyproject.toml
+++ b/compiler/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
     # Note that the compiler wheel does not presently need nanobind, but
     # it's build is enabled by the same flag which enables the runtime
     # configuration, which does.
-    "nanobind==1.9.2",
+    "nanobind==2.0",
     "ninja",
     # MLIR build depends.
     "numpy",

--- a/runtime/bindings/python/hal.cc
+++ b/runtime/bindings/python/hal.cc
@@ -159,7 +159,7 @@ py::str HalAllocator::FormattedStatistics() {
 
 py::object HalAllocator::AllocateBufferCopy(
     int memory_type, int allowed_usage, HalDevice& device, py::object buffer,
-    std::optional<iree_hal_element_types_t> element_type) {
+    std::optional<uint64_t> raw_element_type) {
   IREE_TRACE_SCOPE_NAMED("HalAllocator::AllocateBufferCopy");
   // Request a view of the buffer (use the raw python C API to avoid
   // some allocation and copying at the pybind level).
@@ -196,13 +196,15 @@ py::object HalAllocator::AllocateBufferCopy(
   }
   CheckApiStatus(status, "Failed to allocate device visible buffer");
 
-  if (!element_type) {
+  if (!raw_element_type) {
     return py::cast(HalBuffer::StealFromRawPtr(hal_buffer),
                     py::rv_policy::move);
   }
 
   // Create the buffer_view. (note that numpy shape is ssize_t, so we need to
   // copy).
+  iree_hal_element_types_t element_type =
+      (iree_hal_element_types_t)*raw_element_type;
   iree_hal_encoding_type_t encoding_type =
       IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR;
   std::vector<iree_hal_dim_t> dims(py_view.ndim);
@@ -210,7 +212,7 @@ py::object HalAllocator::AllocateBufferCopy(
   iree_hal_buffer_view_t* hal_buffer_view;
   CheckApiStatus(
       iree_hal_buffer_view_create(
-          hal_buffer, dims.size(), dims.data(), *element_type, encoding_type,
+          hal_buffer, dims.size(), dims.data(), element_type, encoding_type,
           iree_hal_allocator_host_allocator(raw_ptr()), &hal_buffer_view),
       "Error allocating buffer_view");
   iree_hal_buffer_release(hal_buffer);
@@ -1082,12 +1084,12 @@ void SetupHalBindings(nanobind::module_ m) {
       .value("DEVICE_VISIBLE", IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE)
       .value("DEVICE_LOCAL", IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL)
       .export_values()
-      .def("__or__",
-           [](enum iree_hal_memory_type_bits_t self,
-              enum iree_hal_memory_type_bits_t other) { return self | other; })
+      .def("__or__", [](uint64_t self, uint64_t other) { return self | other; })
       .def("__and__",
-           [](enum iree_hal_memory_type_bits_t self,
-              enum iree_hal_memory_type_bits_t other) { return self & other; });
+           [](uint64_t self, uint64_t other) { return self & other; })
+      .def("__int__", [](enum iree_hal_memory_type_bits_t self) {
+        return (uint64_t)self;
+      });
 
   py::enum_<enum iree_hal_buffer_compatibility_bits_t>(m, "BufferCompatibility")
       .value("NONE", IREE_HAL_BUFFER_COMPATIBILITY_NONE)
@@ -1097,14 +1099,11 @@ void SetupHalBindings(nanobind::module_ m) {
       .value("QUEUE_TRANSFER", IREE_HAL_BUFFER_COMPATIBILITY_QUEUE_TRANSFER)
       .value("QUEUE_DISPATCH", IREE_HAL_BUFFER_COMPATIBILITY_QUEUE_DISPATCH)
       .export_values()
-      .def("__or__",
-           [](enum iree_hal_buffer_compatibility_bits_t self,
-              enum iree_hal_buffer_compatibility_bits_t other) {
-             return self | other;
-           })
-      .def("__and__", [](enum iree_hal_buffer_compatibility_bits_t self,
-                         enum iree_hal_buffer_compatibility_bits_t other) {
-        return self & other;
+      .def("__or__", [](uint64_t self, uint64_t other) { return self | other; })
+      .def("__and__",
+           [](uint64_t self, uint64_t other) { return self & other; })
+      .def("__int__", [](enum iree_hal_buffer_compatibility_bits_t self) {
+        return (uint64_t)self;
       });
 
   py::enum_<enum iree_hal_buffer_usage_bits_t>(m, "BufferUsage")
@@ -1138,14 +1137,12 @@ void SetupHalBindings(nanobind::module_ m) {
       .value("MAPPING", IREE_HAL_BUFFER_USAGE_MAPPING)
       .value("DEFAULT", IREE_HAL_BUFFER_USAGE_DEFAULT)
       .export_values()
-      .def("__or__",
-           [](enum iree_hal_buffer_usage_bits_t self,
-              enum iree_hal_buffer_usage_bits_t other) {
-             return (enum iree_hal_buffer_usage_bits_t)(self | other);
-           })
+      .def("__or__", [](enum iree_hal_buffer_usage_bits_t self,
+                        uint64_t other) { return self | other; })
       .def("__and__", [](enum iree_hal_buffer_usage_bits_t self,
-                         enum iree_hal_buffer_usage_bits_t other) {
-        return (enum iree_hal_buffer_usage_bits_t)(self & other);
+                         uint64_t other) { return self & other; })
+      .def("__int__", [](enum iree_hal_buffer_usage_bits_t self) {
+        return (uint64_t)self;
       });
 
   py::enum_<enum iree_hal_memory_access_bits_t>(m, "MemoryAccess")
@@ -1156,13 +1153,11 @@ void SetupHalBindings(nanobind::module_ m) {
       .value("DISCARD_WRITE", IREE_HAL_MEMORY_ACCESS_DISCARD_WRITE)
       .value("ALL", IREE_HAL_MEMORY_ACCESS_ALL)
       .export_values()
-      .def(
-          "__or__",
-          [](enum iree_hal_memory_access_bits_t self,
-             enum iree_hal_memory_access_bits_t other) { return self | other; })
-      .def("__and__", [](enum iree_hal_memory_access_bits_t self,
-                         enum iree_hal_memory_access_bits_t other) {
-        return self & other;
+      .def("__or__", [](uint64_t self, uint64_t other) { return self | other; })
+      .def("__and__",
+           [](uint64_t self, uint64_t other) { return self & other; })
+      .def("__int__", [](enum iree_hal_memory_access_bits_t self) {
+        return (uint64_t)self;
       });
 
   // Use compatibility type to enable def_static.
@@ -1210,7 +1205,9 @@ void SetupHalBindings(nanobind::module_ m) {
       .value("BFLOAT_16", IREE_HAL_ELEMENT_TYPE_BFLOAT_16)
       .value("COMPLEX_64", IREE_HAL_ELEMENT_TYPE_COMPLEX_FLOAT_64)
       .value("COMPLEX_128", IREE_HAL_ELEMENT_TYPE_COMPLEX_FLOAT_128)
-      .export_values();
+      .export_values()
+      .def("__int__",
+           [](enum iree_hal_element_types_t self) { return (uint64_t)self; });
 
   py::class_<HalDevice>(m, "HalDevice")
       .def_prop_ro(

--- a/runtime/bindings/python/hal.h
+++ b/runtime/bindings/python/hal.h
@@ -160,9 +160,9 @@ class HalAllocator : public ApiRefCounted<HalAllocator, iree_hal_allocator_t> {
   py::dict QueryStatistics();
   py::str FormattedStatistics();
 
-  py::object AllocateBufferCopy(
-      int memory_type, int allowed_usage, HalDevice& device, py::object buffer,
-      std::optional<iree_hal_element_types_t> element_type);
+  py::object AllocateBufferCopy(int memory_type, int allowed_usage,
+                                HalDevice& device, py::object buffer,
+                                std::optional<uint64_t> element_type);
   HalBuffer AllocateHostStagingBufferCopy(HalDevice& device, py::handle buffer);
 };
 

--- a/runtime/bindings/python/iree/runtime/build_requirements.txt
+++ b/runtime/bindings/python/iree/runtime/build_requirements.txt
@@ -5,7 +5,7 @@
 
 pip>=21.3
 setuptools>=62.4.0
-nanobind==1.9.2
+nanobind==2.0
 numpy>=2.0.0b1
 requests>=2.28.0
 wheel>=0.36.2

--- a/runtime/pyproject.toml
+++ b/runtime/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools>=42",
     "wheel",
     "cmake",
-    "nanobind==1.9.2",
+    "nanobind==2.0",
     "ninja",
     "numpy>=2.0.0b1",
     "packaging",


### PR DESCRIPTION
nanobind 2.0 dropped today and had a (presumed) inadvertent backwards compatibility issue: https://github.com/wjakob/nanobind/issues/597

Because we get built in multiple settings that make it difficult to ensure that the pinned version is the only version anyone ever needs to build at, I took the liberty to code the workaround in a way that works for pre and post 2.0. This way, we do not have a hard compatibility horizon and difficulty for engineers who may not be thinking about this.

This forced a rework of some things that have been accidentally working all the way back to pybind with respect to being able to __and__/__or__ to arbitrary bit patterns that don't actually exist as enum values. Typing wrappers still advertise the fully typed form but duck typing smooths it over in practice. At some point, we may want to do something other than treating these as enums so as to get some stronger typing/printing.

I also filed https://github.com/wjakob/nanobind/issues/596 to fix CMake version reporting so that a future required upgrade is handled more gracefully.

Fixes #17496