### PR TITLE
Revert "[iree][global] Add conv2d op to demote to bf16 pass (#17410)"

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/test/demote_contraction_inputs_to_bf16.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/demote_contraction_inputs_to_bf16.mlir
@@ -219,36 +219,3 @@ util.func public @matmul_transpose_b_f32f32f32(%arg0 : tensor<100x250xf32>, %arg
 // CHECK: linalg.matmul_transpose_b
 // CHECK-SAME: ins(%[[DEMOTED0]], %[[DEMOTED1]] : tensor<100x250xbf16>, tensor<500x250xbf16>)
 // CHECK-SAME: outs(%[[ARG2]] : tensor<100x500xf32>)
-
-// -----
-
-util.func public @conv_2d_nchw_fchw_f32f32f32(%arg0 : tensor<1x16x130x130xf32>, %arg1 : tensor<512x16x3x3xf32>,
-    %arg2 : tensor<1x512x128x128xf32>) -> tensor<1x512x128x128xf32> {
-    %0 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} 
-         ins(%arg0, %arg1 : tensor<1x16x130x130xf32>, tensor<512x16x3x3xf32>) 
-         outs(%arg2 : tensor<1x512x128x128xf32>) -> tensor<1x512x128x128xf32>
-  util.return %0 : tensor<1x512x128x128xf32>
-}
-// CHECK: #[[$ATTR_0:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
-// CHECK-LABEL:   util.func public @conv_2d_nchw_fchw_f32f32f32(
-// CHECK-SAME:                                                  %[[VAL_0:.*]]: tensor<1x16x130x130xf32>,
-// CHECK-SAME:                                                  %[[VAL_1:.*]]: tensor<512x16x3x3xf32>,
-// CHECK-SAME:                                                  %[[VAL_2:.*]]: tensor<1x512x128x128xf32>) -> tensor<1x512x128x128xf32> {
-// CHECK:           %[[VAL_3:.*]] = tensor.empty() : tensor<1x16x130x130xbf16>
-// CHECK:           %[[DEMOT1:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]]], 
-// CHECK-SAME:          iterator_types = ["parallel", "parallel", "parallel", "parallel"]} 
-// CHECK-SAME:          ins(%[[VAL_0]] : tensor<1x16x130x130xf32>) outs(%[[VAL_3]] : tensor<1x16x130x130xbf16>) {
-// CHECK:           ^bb0(%[[VAL_5:.*]]: f32, %[[VAL_6:.*]]: bf16):
-// CHECK:             %[[VAL_7:.*]] = arith.truncf %[[VAL_5]] : f32 to bf16
-// CHECK:             linalg.yield %[[VAL_7]] : bf16
-// CHECK:           } -> tensor<1x16x130x130xbf16>
-// CHECK:           %[[VAL_8:.*]] = tensor.empty() : tensor<512x16x3x3xbf16>
-// CHECK:           %[[DEMOT2:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]]], 
-// CHECK-SAME:          iterator_types = ["parallel", "parallel", "parallel", "parallel"]} 
-// CHECK-SAME:          ins(%[[VAL_1]] : tensor<512x16x3x3xf32>) outs(%[[VAL_8]] : tensor<512x16x3x3xbf16>) {
-// CHECK:           ^bb0(%[[VAL_10:.*]]: f32, %[[VAL_11:.*]]: bf16):
-// CHECK:             %[[VAL_12:.*]] = arith.truncf %[[VAL_10]] : f32 to bf16
-// CHECK:             linalg.yield %[[VAL_12]] : bf16
-// CHECK:           } -> tensor<512x16x3x3xbf16>
-// CHECK:           %[[VAL_13:.*]] = linalg.conv_2d_nchw_fchw ins(%[[DEMOT1]], %[[DEMOT2]] : tensor<1x16x130x130xbf16>, tensor<512x16x3x3xbf16>) 
-// CHECK-SAME:      outs(%[[VAL_2]] : tensor<1x512x128x128xf32>) -> tensor<1x512x128x128xf32>


### PR DESCRIPTION
This reverts commit f2fcbbf1987807685dd3bbbed5a64200907fd36d.

This reversion is needed to reduce the run time of non-winograd convolutions.