### PR TITLE
Enable the `mmt4d` ukernel by default on `x86_64` and on `arm_64` (outside of SVE/SME).

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -134,6 +134,21 @@ bool isROCMBackend(IREE::HAL::ExecutableTargetAttr targetAttr) {
   return targetAttr && targetAttr.getBackend().getValue().starts_with("rocm");
 }
 
+static const char *
+getDefaultEnabledUkernels(IREE::HAL::ExecutableTargetAttr targetAttr) {
+  if (isX86_64(targetAttr)) {
+    return "mmt4d";
+  }
+  if (isAArch64(targetAttr)) {
+    if (hasFeature(targetAttr, "+sve") || hasFeature(targetAttr, "+sve2") ||
+        hasFeature(targetAttr, "+sme")) {
+      return "none";
+    }
+    return "mmt4d";
+  }
+  return "none";
+}
+
 bool hasUkernel(IREE::HAL::ExecutableTargetAttr targetAttr,
                 StringRef ukernelName) {
   auto enabledUkernels = getConfigStringAttr(targetAttr, "ukernels");
@@ -143,8 +158,7 @@ bool hasUkernel(IREE::HAL::ExecutableTargetAttr targetAttr,
   StringRef enabledUkernelsStr = enabledUkernels->getValue();
   // Resolve `default`.
   if (enabledUkernelsStr == "default") {
-    // Current defaults implemented here. Could depend on targetAttr.
-    enabledUkernelsStr = "none";
+    enabledUkernelsStr = getDefaultEnabledUkernels(targetAttr);
   }
   // Resolve `none`.
   if (enabledUkernelsStr == "none") {


### PR DESCRIPTION
Benchmark analysis: https://docs.google.com/spreadsheets/d/1CuS0hV-vHwBc2N95K50oiRTl5J1L72yCzzd_l-jz98o/edit?usp=sharing

Summary across e2e model benchmarks:
* No significant regression (within 3% noise).
* Geomean speedup: 1.53x
* Percentiles:

Percentile | Speedup
--- | ---
10% | 1.0x
20% | 1.07x
50% (median) | 1.26x
80% | 2.23x
90% | 3.46x

benchmark-extra: x86_64-dt-only,android-cpu-dt-only