### PR TITLE
Update onnx package version minimum to 1.16.0.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -621,7 +621,7 @@ jobs:
           pip install --upgrade pip
           # Pre-fetch optional deps that iree-compiler needs (but we constrain that
           # to not consult a package index).
-          pip install onnx>=1.15.0
+          pip install onnx>=1.16.0
           pip install --no-index -f $PWD -v iree-compiler[onnx]
           echo "Testing default compiler:"
           python -m iree.compiler._package_test

--- a/compiler/setup.py
+++ b/compiler/setup.py
@@ -467,7 +467,7 @@ setup(
     ],
     extras_require={
         "onnx": [
-            "onnx>=1.15.0",
+            "onnx>=1.16.0",
         ],
     },
 )


### PR DESCRIPTION
As discovered on https://github.com/iree-org/iree/pull/17476#discussion_r1617673191, this is needed to avoid an error running `iree-import-onnx` on certain test files:

> onnx.onnx_cpp2py_export.checker.ValidationError: Your model ir_version 10 is higher than the checker's (9).

If we care about supporting older onnx package versions, we could add some fallback code to `iree-import-onnx`.

We may also want to update the version used in torch-mlir? https://github.com/llvm/torch-mlir/blob/e0a5adb1db38b0072c44b87570bc530eb3b324ad/setup.py#L264