### PR TITLE
 [CPU] Do not unroll outer dimensions for elementwise ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/TargetMLTransformInfo.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/TargetMLTransformInfo.cpp
@@ -14,7 +14,8 @@ namespace {
 
 struct RISCVTargetMLTransformInfo : TargetMLTransformInfo {
   RISCVTargetMLTransformInfo() {
-    defaultMaxUnrollFactor = 8;
+    defaultMaxReductionUnrollFactor = 8;
+    defaultMaxElementwiseUnrollFactor = 8;
     defaultMaxTransposeUnrollFactor = 1;
   }
 };

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/TargetMLTransformInfo.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/TargetMLTransformInfo.h
@@ -16,7 +16,8 @@ namespace mlir::iree_compiler {
 /// Holds target specific information to specialize ML transformations.
 // TODO(dcaballe): Move to a Concept-Model implementation when it's worth it.
 struct TargetMLTransformInfo {
-  unsigned defaultMaxUnrollFactor = 8;
+  unsigned defaultMaxReductionUnrollFactor = 8;
+  unsigned defaultMaxElementwiseUnrollFactor = 1;
   unsigned defaultMaxTransposeUnrollFactor =
       std::numeric_limits<unsigned>::max();
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
@@ -1309,7 +1309,7 @@ module {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64], [4, 8], [0, 0], [0, 0]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64], [2, 8], [0, 0], [0, 0]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: func.func @unpack_elem()
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -1648,7 +1648,7 @@ module {
     return
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 32, 32], [8, 8, 1], [0, 0, 0], [0, 0, 0]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 32, 32], [1, 8, 1], [0, 0, 0], [0, 0, 0]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: func.func @elementwise_output_transposed()
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/Utils/LinalgOpInfo.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/LinalgOpInfo.cpp
@@ -112,7 +112,7 @@ computeTransposeInfo(LinalgOp linalgOp,
 }
 
 static bool computeReductionInfo(LinalgOp linalgOp) {
-  return linalgOp.getNumReductionLoops() > 1;
+  return linalgOp.getNumReductionLoops() >= 1;
 }
 
 static bool computeDynamicInfo(LinalgOp linalgOp) {


### PR DESCRIPTION
The revision replace the default unrolling factor with `defaultMaxReductionUnrollFactor` and `defaultMaxElementwiseUnrollFactor`. It also fixes a bug in LinalgOpInfo. A linalg op with single reduction was not a reduction op. The change only happens on element-wise operations, but not reduction ops.