### PR TITLE
[iree][global] Control the demotion of ops

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/PassDetail.h
+++ b/compiler/src/iree/compiler/GlobalOptimization/PassDetail.h
@@ -7,6 +7,7 @@
 #ifndef IREE_COMPILER_GLOBALOPTIMIZATION_PASSDETAIL_H_
 #define IREE_COMPILER_GLOBALOPTIMIZATION_PASSDETAIL_H_
 
+#include "iree/compiler/GlobalOptimization/Passes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Pass/Pass.h"

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.h
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.h
@@ -51,8 +51,13 @@ std::unique_ptr<Pass> createConvert1X1FilterConv2DToMatmulPass();
 std::unique_ptr<Pass>
 createDecomposeConcatPass(bool enableConcatTransposition = false);
 
+// Used by the demoteContractionInputsToBF16 pass to determine which op inputs
+// to demote.
+enum class DemotionOption { All, Conv, Matmul, None };
+
 /// Demotes inputs (LHS, RHS) of linalg matmul-like ops from f32 to bf16.
-std::unique_ptr<Pass> createDemoteContractionInputsToBF16Pass();
+std::unique_ptr<Pass> createDemoteContractionInputsToBF16Pass(
+    DemotionOption option = DemotionOption::None);
 
 /// Detaches elementwise ops from named Linalg ops.
 std::unique_ptr<Pass> createDetachElementwiseFromNamedOpsPass();

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.td
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.td
@@ -32,9 +32,33 @@ def DecomposeConcat :
   ];
 }
 
-def DemoteContractionInputsToBF16 : Pass<"iree-global-opt-demote-contraction-inputs-to-bf16", ""> {
-  let summary = "Demotes inputs (LHS, RHS) of linalg matmul-like ops from f32 to bf16.";
-  let constructor = "mlir::iree_compiler::GlobalOptimization::createDemoteContractionInputsToBF16Pass()";
+def DemoteContractionInputsToBF16
+    : Pass<"iree-global-opt-demote-contraction-inputs-to-bf16", ""> {
+  let summary =
+      "Demotes inputs (LHS, RHS) of linalg matmul-like ops from f32 to bf16.";
+  let constructor = "mlir::iree_compiler::GlobalOptimization::"
+                    "createDemoteContractionInputsToBF16Pass()";
+  let options =
+      [Option<"demoteOnly", "demote-only",
+              "mlir::iree_compiler::GlobalOptimization::DemotionOption",
+              /*default=*/
+              "mlir::iree_compiler::GlobalOptimization::DemotionOption::All",
+              "Select the type of contraction ops to demote.",
+              [{::llvm::cl::values(
+            clEnumValN(mlir::iree_compiler::GlobalOptimization::DemotionOption::All,
+                       "all",
+                      "demote all contraction ops."),
+            clEnumValN(mlir::iree_compiler::GlobalOptimization::DemotionOption::Conv,
+                       "conv",
+                       "Only demote convolution ops."),
+            clEnumValN(mlir::iree_compiler::GlobalOptimization::DemotionOption::Matmul,
+                       "matmul",
+                       "Only demote matmul ops."),
+            clEnumValN(mlir::iree_compiler::GlobalOptimization::DemotionOption::None,
+                       "none",
+                      "demote no contraction ops.")
+        )}]>,
+  ];
 }
 
 def DetachElementwiseFromNamedOps :

--- a/compiler/src/iree/compiler/GlobalOptimization/test/demote_contraction_inputs_to_bf16.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/demote_contraction_inputs_to_bf16.mlir
@@ -1,4 +1,5 @@
-// RUN: iree-opt --split-input-file -iree-global-opt-demote-contraction-inputs-to-bf16 %s | FileCheck %s
+// RUN: iree-opt --split-input-file -iree-global-opt-demote-contraction-inputs-to-bf16="demote-only=matmul" %s | FileCheck %s --check-prefix=MATMUL
+// RUN: iree-opt --split-input-file -iree-global-opt-demote-contraction-inputs-to-bf16="demote-only=conv" %s | FileCheck %s --check-prefix=CONV
 
 util.func public @matmul_f32f32f32(%arg0 : tensor<100x250xf32>, %arg1 : tensor<250x500xf32>,
     %arg2 : tensor<100x500xf32>) -> tensor<100x500xf32> {
@@ -7,19 +8,19 @@ util.func public @matmul_f32f32f32(%arg0 : tensor<100x250xf32>, %arg1 : tensor<2
   util.return %0 : tensor<100x500xf32>
 }
 
-// CHECK: @matmul_f32f32f32
-// CHECK-SAME: %[[ARG0:.+]]: tensor<100x250xf32>
-// CHECK-SAME: %[[ARG1:.+]]: tensor<250x500xf32>
-// CHECK-SAME: %[[ARG2:.+]]: tensor<100x500xf32>
-// CHECK: %[[DEMOTED0:.+]] = linalg.generic
-// CHECK-SAME: ins(%[[ARG0]] : tensor<100x250xf32>)
-// CHECK: arith.truncf {{.*}} : f32 to bf16
-// CHECK: %[[DEMOTED1:.+]] = linalg.generic
-// CHECK-SAME: ins(%[[ARG1]] : tensor<250x500xf32>)
-// CHECK: arith.truncf {{.*}} : f32 to bf16
-// CHECK: linalg.matmul
-// CHECK-SAME: ins(%[[DEMOTED0]], %[[DEMOTED1]] : tensor<100x250xbf16>, tensor<250x500xbf16>)
-// CHECK-SAME: outs(%[[ARG2]] : tensor<100x500xf32>)
+// MATMUL: @matmul_f32f32f32
+// MATMUL-SAME: %[[ARG0:.+]]: tensor<100x250xf32>
+// MATMUL-SAME: %[[ARG1:.+]]: tensor<250x500xf32>
+// MATMUL-SAME: %[[ARG2:.+]]: tensor<100x500xf32>
+// MATMUL: %[[DEMOTED0:.+]] = linalg.generic
+// MATMUL-SAME: ins(%[[ARG0]] : tensor<100x250xf32>)
+// MATMUL: arith.truncf {{.*}} : f32 to bf16
+// MATMUL: %[[DEMOTED1:.+]] = linalg.generic
+// MATMUL-SAME: ins(%[[ARG1]] : tensor<250x500xf32>)
+// MATMUL: arith.truncf {{.*}} : f32 to bf16
+// MATMUL: linalg.matmul
+// MATMUL-SAME: ins(%[[DEMOTED0]], %[[DEMOTED1]] : tensor<100x250xbf16>, tensor<250x500xbf16>)
+// MATMUL-SAME: outs(%[[ARG2]] : tensor<100x500xf32>)
 
 // -----
 
@@ -30,17 +31,17 @@ util.func public @dynamic_matmul_f32f32f32(%arg0 : tensor<?x?xf32>, %arg1 : tens
   util.return %0 : tensor<?x?xf32>
 }
 
-// CHECK: @dynamic_matmul_f32f32f32
-// CHECK-SAME: %[[ARG0:.+]]: tensor<?x?xf32>, %[[ARG1:.+]]: tensor<?x?xf32>, %[[ARG2:.+]]: tensor<?x?xf32>
-// CHECK: %[[DEMOTED0:.+]] = linalg.generic
-// CHECK-SAME: ins(%[[ARG0]] : tensor<?x?xf32>)
-// CHECK: arith.truncf {{.*}} : f32 to bf16
-// CHECK: %[[DEMOTED1:.+]] = linalg.generic
-// CHECK-SAME: ins(%[[ARG1]] : tensor<?x?xf32>)
-// CHECK: arith.truncf {{.*}} : f32 to bf16
-// CHECK: linalg.matmul
-// CHECK-SAME: ins(%[[DEMOTED0]], %[[DEMOTED1]] : tensor<?x?xbf16>, tensor<?x?xbf16>)
-// CHECK-SAME: outs(%[[ARG2]] : tensor<?x?xf32>)
+// MATMUL: @dynamic_matmul_f32f32f32
+// MATMUL-SAME: %[[ARG0:.+]]: tensor<?x?xf32>, %[[ARG1:.+]]: tensor<?x?xf32>, %[[ARG2:.+]]: tensor<?x?xf32>
+// MATMUL: %[[DEMOTED0:.+]] = linalg.generic
+// MATMUL-SAME: ins(%[[ARG0]] : tensor<?x?xf32>)
+// MATMUL: arith.truncf {{.*}} : f32 to bf16
+// MATMUL: %[[DEMOTED1:.+]] = linalg.generic
+// MATMUL-SAME: ins(%[[ARG1]] : tensor<?x?xf32>)
+// MATMUL: arith.truncf {{.*}} : f32 to bf16
+// MATMUL: linalg.matmul
+// MATMUL-SAME: ins(%[[DEMOTED0]], %[[DEMOTED1]] : tensor<?x?xbf16>, tensor<?x?xbf16>)
+// MATMUL-SAME: outs(%[[ARG2]] : tensor<?x?xf32>)
 
 // -----
 
@@ -51,19 +52,19 @@ util.func public @batch_matmul_f32f32f32(%arg0 : tensor<4x100x250xf32>, %arg1 : 
   util.return %0 : tensor<4x100x500xf32>
 }
 
-// CHECK: @batch_matmul_f32f32f32
-// CHECK-SAME: %[[ARG0:.+]]: tensor<4x100x250xf32>
-// CHECK-SAME: %[[ARG1:.+]]: tensor<4x250x500xf32>
-// CHECK-SAME: %[[ARG2:.+]]: tensor<4x100x500xf32>
-// CHECK: %[[DEMOTED0:.+]] = linalg.generic
-// CHECK-SAME: ins(%[[ARG0]] : tensor<4x100x250xf32>)
-// CHECK: arith.truncf {{.*}} : f32 to bf16
-// CHECK: %[[DEMOTED1:.+]] = linalg.generic
-// CHECK-SAME: ins(%[[ARG1]] : tensor<4x250x500xf32>)
-// CHECK: arith.truncf {{.*}} : f32 to bf16
-// CHECK: linalg.batch_matmul
-// CHECK-SAME: ins(%[[DEMOTED0]], %[[DEMOTED1]] : tensor<4x100x250xbf16>, tensor<4x250x500xbf16>)
-// CHECK-SAME: outs(%[[ARG2]] : tensor<4x100x500xf32>)
+// MATMUL: @batch_matmul_f32f32f32
+// MATMUL-SAME: %[[ARG0:.+]]: tensor<4x100x250xf32>
+// MATMUL-SAME: %[[ARG1:.+]]: tensor<4x250x500xf32>
+// MATMUL-SAME: %[[ARG2:.+]]: tensor<4x100x500xf32>
+// MATMUL: %[[DEMOTED0:.+]] = linalg.generic
+// MATMUL-SAME: ins(%[[ARG0]] : tensor<4x100x250xf32>)
+// MATMUL: arith.truncf {{.*}} : f32 to bf16
+// MATMUL: %[[DEMOTED1:.+]] = linalg.generic
+// MATMUL-SAME: ins(%[[ARG1]] : tensor<4x250x500xf32>)
+// MATMUL: arith.truncf {{.*}} : f32 to bf16
+// MATMUL: linalg.batch_matmul
+// MATMUL-SAME: ins(%[[DEMOTED0]], %[[DEMOTED1]] : tensor<4x100x250xbf16>, tensor<4x250x500xbf16>)
+// MATMUL-SAME: outs(%[[ARG2]] : tensor<4x100x500xf32>)
 
 // -----
 
@@ -74,19 +75,19 @@ util.func public @matvec_f32f32f32(%arg0 : tensor<100x250xf32>, %arg1 : tensor<2
   util.return %0 : tensor<100xf32>
 }
 
-// CHECK: @matvec_f32f32f32
-// CHECK-SAME: %[[ARG0:.+]]: tensor<100x250xf32>
-// CHECK-SAME: %[[ARG1:.+]]: tensor<250xf32>
-// CHECK-SAME: %[[ARG2:.+]]: tensor<100xf32>
-// CHECK: %[[DEMOTED0:.+]] = linalg.generic
-// CHECK-SAME: ins(%[[ARG0]] : tensor<100x250xf32>)
-// CHECK: arith.truncf {{.*}} : f32 to bf16
-// CHECK: %[[DEMOTED1:.+]] = linalg.generic
-// CHECK-SAME: ins(%[[ARG1]] : tensor<250xf32>)
-// CHECK: arith.truncf {{.*}} : f32 to bf16
-// CHECK: linalg.matvec
-// CHECK-SAME: ins(%[[DEMOTED0]], %[[DEMOTED1]] : tensor<100x250xbf16>, tensor<250xbf16>)
-// CHECK-SAME: outs(%[[ARG2]] : tensor<100xf32>)
+// MATMUL: @matvec_f32f32f32
+// MATMUL-SAME: %[[ARG0:.+]]: tensor<100x250xf32>
+// MATMUL-SAME: %[[ARG1:.+]]: tensor<250xf32>
+// MATMUL-SAME: %[[ARG2:.+]]: tensor<100xf32>
+// MATMUL: %[[DEMOTED0:.+]] = linalg.generic
+// MATMUL-SAME: ins(%[[ARG0]] : tensor<100x250xf32>)
+// MATMUL: arith.truncf {{.*}} : f32 to bf16
+// MATMUL: %[[DEMOTED1:.+]] = linalg.generic
+// MATMUL-SAME: ins(%[[ARG1]] : tensor<250xf32>)
+// MATMUL: arith.truncf {{.*}} : f32 to bf16
+// MATMUL: linalg.matvec
+// MATMUL-SAME: ins(%[[DEMOTED0]], %[[DEMOTED1]] : tensor<100x250xbf16>, tensor<250xbf16>)
+// MATMUL-SAME: outs(%[[ARG2]] : tensor<100xf32>)
 
 // -----
 
@@ -97,19 +98,19 @@ util.func public @batch_vecmat_f32f32f32(%arg0 : tensor<4x250xf32>, %arg1 : tens
   util.return %0 : tensor<4x500xf32>
 }
 
-// CHECK: @batch_vecmat_f32f32f32
-// CHECK-SAME: %[[ARG0:.+]]: tensor<4x250xf32>
-// CHECK-SAME: %[[ARG1:.+]]: tensor<4x250x500xf32>
-// CHECK-SAME: %[[ARG2:.+]]: tensor<4x500xf32>
-// CHECK: %[[DEMOTED0:.+]] = linalg.generic
-// CHECK-SAME: ins(%[[ARG0]] : tensor<4x250xf32>)
-// CHECK: arith.truncf {{.*}} : f32 to bf16
-// CHECK: %[[DEMOTED1:.+]] = linalg.generic
-// CHECK-SAME: ins(%[[ARG1]] : tensor<4x250x500xf32>)
-// CHECK: arith.truncf {{.*}} : f32 to bf16
-// CHECK: linalg.batch_vecmat
-// CHECK-SAME: ins(%[[DEMOTED0]], %[[DEMOTED1]] : tensor<4x250xbf16>, tensor<4x250x500xbf16>)
-// CHECK-SAME: outs(%[[ARG2]] : tensor<4x500xf32>)
+// MATMUL: @batch_vecmat_f32f32f32
+// MATMUL-SAME: %[[ARG0:.+]]: tensor<4x250xf32>
+// MATMUL-SAME: %[[ARG1:.+]]: tensor<4x250x500xf32>
+// MATMUL-SAME: %[[ARG2:.+]]: tensor<4x500xf32>
+// MATMUL: %[[DEMOTED0:.+]] = linalg.generic
+// MATMUL-SAME: ins(%[[ARG0]] : tensor<4x250xf32>)
+// MATMUL: arith.truncf {{.*}} : f32 to bf16
+// MATMUL: %[[DEMOTED1:.+]] = linalg.generic
+// MATMUL-SAME: ins(%[[ARG1]] : tensor<4x250x500xf32>)
+// MATMUL: arith.truncf {{.*}} : f32 to bf16
+// MATMUL: linalg.batch_vecmat
+// MATMUL-SAME: ins(%[[DEMOTED0]], %[[DEMOTED1]] : tensor<4x250xbf16>, tensor<4x250x500xbf16>)
+// MATMUL-SAME: outs(%[[ARG2]] : tensor<4x500xf32>)
 
 // -----
 
@@ -120,13 +121,13 @@ util.func public @nonmatch_matmul_f32f32f64(%arg0 : tensor<100x250xf32>, %arg1 :
   util.return %0 : tensor<100x500xf64>
 }
 
-// CHECK: @nonmatch_matmul_f32f32f64
-// CHECK-SAME: %[[ARG0:.+]]: tensor<100x250xf32>
-// CHECK-SAME: %[[ARG1:.+]]: tensor<250x500xf32>
-// CHECK-SAME: %[[ARG2:.+]]: tensor<100x500xf64>
-// CHECK: linalg.matmul
-// CHECK-SAME: ins(%[[ARG0]], %[[ARG1]] : tensor<100x250xf32>, tensor<250x500xf32>)
-// CHECK-SAME: outs(%[[ARG2]] : tensor<100x500xf64>)
+// MATMUL: @nonmatch_matmul_f32f32f64
+// MATMUL-SAME: %[[ARG0:.+]]: tensor<100x250xf32>
+// MATMUL-SAME: %[[ARG1:.+]]: tensor<250x500xf32>
+// MATMUL-SAME: %[[ARG2:.+]]: tensor<100x500xf64>
+// MATMUL: linalg.matmul
+// MATMUL-SAME: ins(%[[ARG0]], %[[ARG1]] : tensor<100x250xf32>, tensor<250x500xf32>)
+// MATMUL-SAME: outs(%[[ARG2]] : tensor<100x500xf64>)
 
 // -----
 
@@ -137,19 +138,19 @@ util.func public @batch_matmul_transpose_a_f32f32f32(%arg0 : tensor<4x250x100xf3
   util.return %0 : tensor<4x100x500xf32>
 }
 
-// CHECK: @batch_matmul_transpose_a_f32f32f32
-// CHECK-SAME: %[[ARG0:.+]]: tensor<4x250x100xf32>
-// CHECK-SAME: %[[ARG1:.+]]: tensor<4x250x500xf32>
-// CHECK-SAME: %[[ARG2:.+]]: tensor<4x100x500xf32>
-// CHECK: %[[DEMOTED0:.+]] = linalg.generic
-// CHECK-SAME: ins(%[[ARG0]] : tensor<4x250x100xf32>)
-// CHECK: arith.truncf {{.*}} : f32 to bf16
-// CHECK: %[[DEMOTED1:.+]] = linalg.generic
-// CHECK-SAME: ins(%[[ARG1]] : tensor<4x250x500xf32>)
-// CHECK: arith.truncf {{.*}} : f32 to bf16
-// CHECK: linalg.batch_matmul_transpose_a
-// CHECK-SAME: ins(%[[DEMOTED0]], %[[DEMOTED1]] : tensor<4x250x100xbf16>, tensor<4x250x500xbf16>)
-// CHECK-SAME: outs(%[[ARG2]] : tensor<4x100x500xf32>)
+// MATMUL: @batch_matmul_transpose_a_f32f32f32
+// MATMUL-SAME: %[[ARG0:.+]]: tensor<4x250x100xf32>
+// MATMUL-SAME: %[[ARG1:.+]]: tensor<4x250x500xf32>
+// MATMUL-SAME: %[[ARG2:.+]]: tensor<4x100x500xf32>
+// MATMUL: %[[DEMOTED0:.+]] = linalg.generic
+// MATMUL-SAME: ins(%[[ARG0]] : tensor<4x250x100xf32>)
+// MATMUL: arith.truncf {{.*}} : f32 to bf16
+// MATMUL: %[[DEMOTED1:.+]] = linalg.generic
+// MATMUL-SAME: ins(%[[ARG1]] : tensor<4x250x500xf32>)
+// MATMUL: arith.truncf {{.*}} : f32 to bf16
+// MATMUL: linalg.batch_matmul_transpose_a
+// MATMUL-SAME: ins(%[[DEMOTED0]], %[[DEMOTED1]] : tensor<4x250x100xbf16>, tensor<4x250x500xbf16>)
+// MATMUL-SAME: outs(%[[ARG2]] : tensor<4x100x500xf32>)
 
 // -----
 
@@ -160,19 +161,19 @@ util.func public @batch_matmul_transpose_b_f32f32f32(%arg0 : tensor<4x100x250xf3
   util.return %0 : tensor<4x100x500xf32>
 }
 
-// CHECK: @batch_matmul_transpose_b_f32f32f32
-// CHECK-SAME: %[[ARG0:.+]]: tensor<4x100x250xf32>
-// CHECK-SAME: %[[ARG1:.+]]: tensor<4x500x250xf32>
-// CHECK-SAME: %[[ARG2:.+]]: tensor<4x100x500xf32>
-// CHECK: %[[DEMOTED0:.+]] = linalg.generic
-// CHECK-SAME: ins(%[[ARG0]] : tensor<4x100x250xf32>)
-// CHECK: arith.truncf {{.*}} : f32 to bf16
-// CHECK: %[[DEMOTED1:.+]] = linalg.generic
-// CHECK-SAME: ins(%[[ARG1]] : tensor<4x500x250xf32>)
-// CHECK: arith.truncf {{.*}} : f32 to bf16
-// CHECK: linalg.batch_matmul_transpose_b
-// CHECK-SAME: ins(%[[DEMOTED0]], %[[DEMOTED1]] : tensor<4x100x250xbf16>, tensor<4x500x250xbf16>)
-// CHECK-SAME: outs(%[[ARG2]] : tensor<4x100x500xf32>)
+// MATMUL: @batch_matmul_transpose_b_f32f32f32
+// MATMUL-SAME: %[[ARG0:.+]]: tensor<4x100x250xf32>
+// MATMUL-SAME: %[[ARG1:.+]]: tensor<4x500x250xf32>
+// MATMUL-SAME: %[[ARG2:.+]]: tensor<4x100x500xf32>
+// MATMUL: %[[DEMOTED0:.+]] = linalg.generic
+// MATMUL-SAME: ins(%[[ARG0]] : tensor<4x100x250xf32>)
+// MATMUL: arith.truncf {{.*}} : f32 to bf16
+// MATMUL: %[[DEMOTED1:.+]] = linalg.generic
+// MATMUL-SAME: ins(%[[ARG1]] : tensor<4x500x250xf32>)
+// MATMUL: arith.truncf {{.*}} : f32 to bf16
+// MATMUL: linalg.batch_matmul_transpose_b
+// MATMUL-SAME: ins(%[[DEMOTED0]], %[[DEMOTED1]] : tensor<4x100x250xbf16>, tensor<4x500x250xbf16>)
+// MATMUL-SAME: outs(%[[ARG2]] : tensor<4x100x500xf32>)
 
 // -----
 
@@ -183,19 +184,19 @@ util.func public @matmul_transpose_a_f32f32f32(%arg0 : tensor<250x100xf32>, %arg
   util.return %0 : tensor<100x500xf32>
 }
 
-// CHECK: @matmul_transpose_a_f32f32f32
-// CHECK-SAME: %[[ARG0:.+]]: tensor<250x100xf32>
-// CHECK-SAME: %[[ARG1:.+]]: tensor<250x500xf32>
-// CHECK-SAME: %[[ARG2:.+]]: tensor<100x500xf32>
-// CHECK: %[[DEMOTED0:.+]] = linalg.generic
-// CHECK-SAME: ins(%[[ARG0]] : tensor<250x100xf32>)
-// CHECK: arith.truncf {{.*}} : f32 to bf16
-// CHECK: %[[DEMOTED1:.+]] = linalg.generic
-// CHECK-SAME: ins(%[[ARG1]] : tensor<250x500xf32>)
-// CHECK: arith.truncf {{.*}} : f32 to bf16
-// CHECK: linalg.matmul_transpose_a
-// CHECK-SAME: ins(%[[DEMOTED0]], %[[DEMOTED1]] : tensor<250x100xbf16>, tensor<250x500xbf16>)
-// CHECK-SAME: outs(%[[ARG2]] : tensor<100x500xf32>)
+// MATMUL: @matmul_transpose_a_f32f32f32
+// MATMUL-SAME: %[[ARG0:.+]]: tensor<250x100xf32>
+// MATMUL-SAME: %[[ARG1:.+]]: tensor<250x500xf32>
+// MATMUL-SAME: %[[ARG2:.+]]: tensor<100x500xf32>
+// MATMUL: %[[DEMOTED0:.+]] = linalg.generic
+// MATMUL-SAME: ins(%[[ARG0]] : tensor<250x100xf32>)
+// MATMUL: arith.truncf {{.*}} : f32 to bf16
+// MATMUL: %[[DEMOTED1:.+]] = linalg.generic
+// MATMUL-SAME: ins(%[[ARG1]] : tensor<250x500xf32>)
+// MATMUL: arith.truncf {{.*}} : f32 to bf16
+// MATMUL: linalg.matmul_transpose_a
+// MATMUL-SAME: ins(%[[DEMOTED0]], %[[DEMOTED1]] : tensor<250x100xbf16>, tensor<250x500xbf16>)
+// MATMUL-SAME: outs(%[[ARG2]] : tensor<100x500xf32>)
 
 // -----
 
@@ -206,19 +207,19 @@ util.func public @matmul_transpose_b_f32f32f32(%arg0 : tensor<100x250xf32>, %arg
   util.return %0 : tensor<100x500xf32>
 }
 
-// CHECK: @matmul_transpose_b_f32f32f32
-// CHECK-SAME: %[[ARG0:.+]]: tensor<100x250xf32>
-// CHECK-SAME: %[[ARG1:.+]]: tensor<500x250xf32>
-// CHECK-SAME: %[[ARG2:.+]]: tensor<100x500xf32>
-// CHECK: %[[DEMOTED0:.+]] = linalg.generic
-// CHECK-SAME: ins(%[[ARG0]] : tensor<100x250xf32>)
-// CHECK: arith.truncf {{.*}} : f32 to bf16
-// CHECK: %[[DEMOTED1:.+]] = linalg.generic
-// CHECK-SAME: ins(%[[ARG1]] : tensor<500x250xf32>)
-// CHECK: arith.truncf {{.*}} : f32 to bf16
-// CHECK: linalg.matmul_transpose_b
-// CHECK-SAME: ins(%[[DEMOTED0]], %[[DEMOTED1]] : tensor<100x250xbf16>, tensor<500x250xbf16>)
-// CHECK-SAME: outs(%[[ARG2]] : tensor<100x500xf32>)
+// MATMUL: @matmul_transpose_b_f32f32f32
+// MATMUL-SAME: %[[ARG0:.+]]: tensor<100x250xf32>
+// MATMUL-SAME: %[[ARG1:.+]]: tensor<500x250xf32>
+// MATMUL-SAME: %[[ARG2:.+]]: tensor<100x500xf32>
+// MATMUL: %[[DEMOTED0:.+]] = linalg.generic
+// MATMUL-SAME: ins(%[[ARG0]] : tensor<100x250xf32>)
+// MATMUL: arith.truncf {{.*}} : f32 to bf16
+// MATMUL: %[[DEMOTED1:.+]] = linalg.generic
+// MATMUL-SAME: ins(%[[ARG1]] : tensor<500x250xf32>)
+// MATMUL: arith.truncf {{.*}} : f32 to bf16
+// MATMUL: linalg.matmul_transpose_b
+// MATMUL-SAME: ins(%[[DEMOTED0]], %[[DEMOTED1]] : tensor<100x250xbf16>, tensor<500x250xbf16>)
+// MATMUL-SAME: outs(%[[ARG2]] : tensor<100x500xf32>)
 
 // -----
 
@@ -229,26 +230,26 @@ util.func public @conv_2d_nchw_fchw_f32f32f32(%arg0 : tensor<1x16x130x130xf32>, 
          outs(%arg2 : tensor<1x512x128x128xf32>) -> tensor<1x512x128x128xf32>
   util.return %0 : tensor<1x512x128x128xf32>
 }
-// CHECK: #[[$ATTR_0:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
-// CHECK-LABEL:   util.func public @conv_2d_nchw_fchw_f32f32f32(
-// CHECK-SAME:                                                  %[[VAL_0:.*]]: tensor<1x16x130x130xf32>,
-// CHECK-SAME:                                                  %[[VAL_1:.*]]: tensor<512x16x3x3xf32>,
-// CHECK-SAME:                                                  %[[VAL_2:.*]]: tensor<1x512x128x128xf32>) -> tensor<1x512x128x128xf32> {
-// CHECK:           %[[VAL_3:.*]] = tensor.empty() : tensor<1x16x130x130xbf16>
-// CHECK:           %[[DEMOT1:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]]],
-// CHECK-SAME:          iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
-// CHECK-SAME:          ins(%[[VAL_0]] : tensor<1x16x130x130xf32>) outs(%[[VAL_3]] : tensor<1x16x130x130xbf16>) {
-// CHECK:           ^bb0(%[[VAL_5:.*]]: f32, %[[VAL_6:.*]]: bf16):
-// CHECK:             %[[VAL_7:.*]] = arith.truncf %[[VAL_5]] : f32 to bf16
-// CHECK:             linalg.yield %[[VAL_7]] : bf16
-// CHECK:           } -> tensor<1x16x130x130xbf16>
-// CHECK:           %[[VAL_8:.*]] = tensor.empty() : tensor<512x16x3x3xbf16>
-// CHECK:           %[[DEMOT2:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]]],
-// CHECK-SAME:          iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
-// CHECK-SAME:          ins(%[[VAL_1]] : tensor<512x16x3x3xf32>) outs(%[[VAL_8]] : tensor<512x16x3x3xbf16>) {
-// CHECK:           ^bb0(%[[VAL_10:.*]]: f32, %[[VAL_11:.*]]: bf16):
-// CHECK:             %[[VAL_12:.*]] = arith.truncf %[[VAL_10]] : f32 to bf16
-// CHECK:             linalg.yield %[[VAL_12]] : bf16
-// CHECK:           } -> tensor<512x16x3x3xbf16>
-// CHECK:           %[[VAL_13:.*]] = linalg.conv_2d_nchw_fchw ins(%[[DEMOT1]], %[[DEMOT2]] : tensor<1x16x130x130xbf16>, tensor<512x16x3x3xbf16>)
-// CHECK-SAME:      outs(%[[VAL_2]] : tensor<1x512x128x128xf32>) -> tensor<1x512x128x128xf32>
+// CONV: #[[$ATTR_0:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+// CONV-LABEL:   util.func public @conv_2d_nchw_fchw_f32f32f32(
+// CONV-SAME:                                                  %[[VAL_0:.*]]: tensor<1x16x130x130xf32>,
+// CONV-SAME:                                                  %[[VAL_1:.*]]: tensor<512x16x3x3xf32>,
+// CONV-SAME:                                                  %[[VAL_2:.*]]: tensor<1x512x128x128xf32>) -> tensor<1x512x128x128xf32> {
+// CONV:           %[[VAL_3:.*]] = tensor.empty() : tensor<1x16x130x130xbf16>
+// CONV:           %[[DEMOT1:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]]],
+// CONV-SAME:          iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+// CONV-SAME:          ins(%[[VAL_0]] : tensor<1x16x130x130xf32>) outs(%[[VAL_3]] : tensor<1x16x130x130xbf16>) {
+// CONV:           ^bb0(%[[VAL_5:.*]]: f32, %[[VAL_6:.*]]: bf16):
+// CONV:             %[[VAL_7:.*]] = arith.truncf %[[VAL_5]] : f32 to bf16
+// CONV:             linalg.yield %[[VAL_7]] : bf16
+// CONV:           } -> tensor<1x16x130x130xbf16>
+// CONV:           %[[VAL_8:.*]] = tensor.empty() : tensor<512x16x3x3xbf16>
+// CONV:           %[[DEMOT2:.*]] = linalg.generic {indexing_maps = [#[[$ATTR_0]], #[[$ATTR_0]]],
+// CONV-SAME:          iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+// CONV-SAME:          ins(%[[VAL_1]] : tensor<512x16x3x3xf32>) outs(%[[VAL_8]] : tensor<512x16x3x3xbf16>) {
+// CONV:           ^bb0(%[[VAL_10:.*]]: f32, %[[VAL_11:.*]]: bf16):
+// CONV:             %[[VAL_12:.*]] = arith.truncf %[[VAL_10]] : f32 to bf16
+// CONV:             linalg.yield %[[VAL_12]] : bf16
+// CONV:           } -> tensor<512x16x3x3xbf16>
+// CONV:           %[[VAL_13:.*]] = linalg.conv_2d_nchw_fchw ins(%[[DEMOT1]], %[[DEMOT2]] : tensor<1x16x130x130xbf16>, tensor<512x16x3x3xbf16>)
+// CONV-SAME:      outs(%[[VAL_2]] : tensor<1x512x128x128xf32>) -> tensor<1x512x128x128xf32>


### PR DESCRIPTION
Introduces `demote-only` flag in `demote-contraction-inputs-to-bf16` to control the demotion of ops. For e.g., if `demote-only=conv` only conv ops will be demoted.