### PR TITLE
[hip][rocm] Switch to use old hipDeviceProp_t for queries

### DIFF
--- a/experimental/rocm/dynamic_symbol_tables.h
+++ b/experimental/rocm/dynamic_symbol_tables.h
@@ -10,7 +10,7 @@ IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipCtxDestroy, hipCtx_t)
 IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipDeviceGet, hipDevice_t *,
                                 int)  // No direct, need to modify
 IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipGetDeviceCount, int *)
-IREE_HAL_ROCM_OPTIONAL_PFN_DECL(hipGetDevicePropertiesR0600, hipDeviceProp_t *,
+IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipGetDeviceProperties, hipDeviceProp_tR0000 *,
                                 int)
 IREE_HAL_ROCM_REQUIRED_PFN_DECL(hipDeviceGetName, char *, int,
                                 hipDevice_t)  // No direct, need to modify

--- a/experimental/rocm/rocm_driver.c
+++ b/experimental/rocm/rocm_driver.c
@@ -191,18 +191,11 @@ static iree_status_t iree_hal_rocm_driver_dump_device_info(
     iree_hal_driver_t* base_driver, iree_hal_device_id_t device_id,
     iree_string_builder_t* builder) {
   iree_hal_rocm_driver_t* driver = iree_hal_rocm_driver_cast(base_driver);
-  if (!driver->syms.hipGetDevicePropertiesR0600) {
-    // ROCm 6.0 release changes the hipDeviceProp_t struct and would need to use
-    // the matching hipGetDevicePropertiesR0600() API to query it. This symbol
-    // is not available in earlier versions.
-    return iree_ok_status();
-  }
   hipDevice_t device = IREE_DEVICE_ID_TO_HIPDEVICE(device_id);
 
-  hipDeviceProp_t prop;
-  ROCM_RETURN_IF_ERROR(&driver->syms,
-                       hipGetDevicePropertiesR0600(&prop, device),
-                       "hipGetDevicePropertiesR0600");
+  hipDeviceProp_tR0000 prop;
+  ROCM_RETURN_IF_ERROR(&driver->syms, hipGetDeviceProperties(&prop, device),
+                       "hipGetDeviceProperties");
 
   // GPU capabilities and architecture.
   IREE_RETURN_IF_ERROR(iree_string_builder_append_format(

--- a/experimental/rocm/rocm_headers.h
+++ b/experimental/rocm/rocm_headers.h
@@ -12,6 +12,20 @@
 #endif  // defined(IREE_PTR_SIZE_32)
 
 #define __HIP_PLATFORM_AMD__
-#include "hip/hip_runtime.h"  // IWYU pragma: export
+
+// Order matters here--hip_deprecated.h depends on hip_runtime_api.h. So turn
+// off clang-format.
+//
+// We need to pull in this hip_deprecated.h for the old hipDeviceProp_t struct
+// definition, hipDeviceProp_tR0000. HIP 6.0 release changes the struct in the
+// middle. The hipDeviceProp_t struct would need to use the matching
+// hipGetDevicePropertiesR0600() API to query it. We want to also support HIP
+// 5.x versions so use the old hipGetDeviceProperties() API with its matching
+// struct.
+
+// clang-format off
+#include "hip/hip_runtime.h"     // IWYU pragma: export
+#include "hip/hip_deprecated.h"  // IWYU pragma: export
+// clang-format on
 
 #endif  // IREE_HAL_ROCM_ROCM_HEADERS_H_

--- a/runtime/src/iree/hal/drivers/hip/dynamic_symbol_tables.h
+++ b/runtime/src/iree/hal/drivers/hip/dynamic_symbol_tables.h
@@ -34,7 +34,7 @@ IREE_HAL_HIP_REQUIRED_PFN_DECL(hipFreeAsync, void *, hipStream_t)
 IREE_HAL_HIP_REQUIRED_PFN_DECL(hipFuncSetAttribute, const void *,
                                hipFuncAttribute, int)
 IREE_HAL_HIP_REQUIRED_PFN_DECL(hipGetDeviceCount, int *)
-IREE_HAL_HIP_OPTIONAL_PFN_DECL(hipGetDevicePropertiesR0600, hipDeviceProp_t *,
+IREE_HAL_HIP_OPTIONAL_PFN_DECL(hipGetDeviceProperties, hipDeviceProp_tR0000 *,
                                int)
 // hipGetErrorName(hipError_t) and hipGetErrorString(hipError_t) return
 // const char* instead of hipError_t so it uses a different macro.

--- a/runtime/src/iree/hal/drivers/hip/hip_driver.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_driver.c
@@ -15,7 +15,6 @@
 #include "iree/hal/drivers/hip/dynamic_symbols.h"
 #include "iree/hal/drivers/hip/hip_device.h"
 #include "iree/hal/drivers/hip/rccl_dynamic_symbols.h"
-#include "iree/hal/drivers/hip/rccl_status_util.h"
 #include "iree/hal/drivers/hip/status_util.h"
 
 // Maximum device name length supported by the HIP HAL driver.
@@ -260,20 +259,12 @@ static iree_status_t iree_hal_hip_driver_dump_device_info(
     IREE_RETURN_IF_ERROR(status);
   }
 
-  // Report driver properties.
-  if (!driver->hip_symbols.hipGetDevicePropertiesR0600) {
-    // ROCm 6.0 release changes the hipDeviceProp_t struct and would need to use
-    // the matching hipGetDevicePropertiesR0600() API to query it. This symbol
-    // is not available in earlier versions.
-    return iree_ok_status();
-  }
-
   hipDevice_t device = IREE_DEVICE_ID_TO_HIPDEVICE(device_id);
 
-  hipDeviceProp_t prop;
+  hipDeviceProp_tR0000 prop;
   IREE_HIP_RETURN_IF_ERROR(&driver->hip_symbols,
-                           hipGetDevicePropertiesR0600(&prop, device),
-                           "hipGetDevicePropertiesR0600");
+                           hipGetDeviceProperties(&prop, device),
+                           "hipGetDeviceProperties");
 
   // GPU capabilities and architecture.
   IREE_RETURN_IF_ERROR(iree_string_builder_append_format(

--- a/runtime/src/iree/hal/drivers/hip/hip_headers.h
+++ b/runtime/src/iree/hal/drivers/hip/hip_headers.h
@@ -12,6 +12,19 @@
 #endif  // defined(IREE_PTR_SIZE_32)
 
 #define __HIP_PLATFORM_AMD__
+// Order matters here--hip_deprecated.h depends on hip_runtime_api.h. So turn
+// off clang-format.
+//
+// We need to pull in this hip_deprecated.h for the old hipDeviceProp_t struct
+// definition, hipDeviceProp_tR0000. HIP 6.0 release changes the struct in the
+// middle. The hipDeviceProp_t struct would need to use the matching
+// hipGetDevicePropertiesR0600() API to query it. We want to also support HIP
+// 5.x versions so use the old hipGetDeviceProperties() API with its matching
+// struct.
+
+// clang-format off
 #include "hip/hip_runtime_api.h"  // IWYU pragma: export
+#include "hip/hip_deprecated.h"   // IWYU pragma: export
+// clang-format on
 
 #endif  // IREE_HAL_DRIVERS_HIP_HIP_HEADERS_H_


### PR DESCRIPTION
This allows us to cover HIP 5.x versions, which is what Windows have now.