### PR TITLE
Exclude CUDA from benchmark preset while a100 runner is offline.

### DIFF
--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -154,6 +154,8 @@ DEFAULT_BENCHMARK_PRESET_GROUP = [
     for preset in benchmark_presets.DEFAULT_PRESETS
     # RISC-V benchmarks haven't been supported in CI workflow.
     if preset not in [benchmark_presets.RISCV]
+    # CUDA benchmarks on CI depend on unreliable a100 runners.
+    and preset not in [benchmark_presets.CUDA]
 ] + ["comp-stats"]
 DEFAULT_BENCHMARK_PRESET = "default"
 LARGE_BENCHMARK_PRESET_GROUP = benchmark_presets.LARGE_PRESETS


### PR DESCRIPTION
We have two persistent a100 runners: one for presubmit and one for postsubmit. The postsubmit runner has been offline for almost a week, resulting in stalled postsubmit benchmarks and presubmit benchmarks failing to find comparison commits. The postsubmit runner was online briefly yesterday (see [this Discord discussion](https://discord.com/channels/689900678990135345/689957613152239638/1245087596648861757)) but it went offline again after running one job.

Testing this with the `llvm-integrate` label since I believe the `benchmarks:cuda` label will still opt-in to CUDA benchmarks.