### PR TITLE
Reflow C API docs to prefer the low level API.

### DIFF
--- a/docs/website/docs/reference/bindings/c-api.md
+++ b/docs/website/docs/reference/bindings/c-api.md
@@ -213,6 +213,65 @@ with LTO style optimizations.
 The low level library components can be used directly or through a higher level
 API.
 
+!!! caution
+
+    Prefer using the low level API directly when writing custom bindings or
+    integrating into larger projects. The high level API is mainly useful as
+    a reference and when building samples.
+
+=== "Low level API"
+
+    Each runtime component has its own low level API. The low level APIs are
+    typically verbose as they expose the full flexibility of each underlying
+    system.
+
+    ```mermaid
+    graph TD
+      accTitle: IREE runtime low level API diagram
+      accDescr {
+        The IREE runtime includes 'base', 'HAL', and 'VM' components, each with
+        their own types and API methods.
+        Applications can interface directly with the IREE runtime via the low
+        level component APIs.
+      }
+
+      subgraph iree_runtime[IREE Runtime]
+        subgraph base
+          base_types("Types
+
+          • allocator
+          • status
+          • etc.")
+        end
+
+        subgraph hal[HAL]
+          hal_types("Types
+
+          • buffer
+          • device
+          • etc.")
+
+          hal_drivers("Drivers
+
+          • local-*
+          • vulkan
+          • etc.")
+        end
+
+        subgraph vm[VM]
+          vm_types("Types
+
+          • context
+          • invocation
+          • etc.")
+        end
+      end
+
+      application(Your application)
+
+      base_types & hal_types & hal_drivers & vm_types --> application
+    ```
+
 === "High level API"
 
     The high level 'runtime' API sits on top of the low level components. It is
@@ -275,65 +334,98 @@ API.
       runtime_api --> application
     ```
 
-=== "Low level API"
-
-    Each runtime component has its own low level API. The low level APIs are
-    typically verbose as they expose the full flexibility of each underlying
-    system.
-
-    ```mermaid
-    graph TD
-      accTitle: IREE runtime low level API diagram
-      accDescr {
-        The IREE runtime includes 'base', 'HAL', and 'VM' components, each with
-        their own types and API methods.
-        Applications can interface directly with the IREE runtime via the low
-        level component APIs.
-      }
-
-      subgraph iree_runtime[IREE Runtime]
-        subgraph base
-          base_types("Types
-
-          • allocator
-          • status
-          • etc.")
-        end
-        subgraph hal[HAL]
-          hal_types("Types
-
-          • buffer
-          • device
-          • etc.")
-
-          hal_drivers("Drivers
-
-          • local-*
-          • vulkan
-          • etc.")
-        end
-        subgraph vm[VM]
-          vm_types("Types
-
-          • context
-          • invocation
-          • etc.")
-        end
-      end
-
-      application(Your application)
-
-      base_types & hal_types & hal_drivers & vm_types --> application
-    ```
-
 Runtime API header files are organized by component:
 
 | Component header file | Overview |
 | --------------------- | -------- |
-[`iree/runtime/api.h`](https://github.com/iree-org/iree/blob/main/runtime/src/iree/runtime/api.h) | High level runtime API
-[`iree/base/api.h`](https://github.com/iree-org/iree/blob/main/runtime/src/iree/base/api.h) | Core API, type definitions, ownership policies, utilities
+[`iree/base/api.h`](https://github.com/iree-org/iree/blob/main/runtime/src/iree/base/api.h) | Base API: type definitions, cross-platform primitives, utilities
 [`iree/vm/api.h`](https://github.com/iree-org/iree/blob/main/runtime/src/iree/vm/api.h) | VM APIs: loading modules, I/O, calling functions
 [`iree/hal/api.h`](https://github.com/iree-org/iree/blob/main/runtime/src/iree/hal/api.h) | HAL APIs: device management, synchronization, accessing hardware features
+[`iree/runtime/api.h`](https://github.com/iree-org/iree/blob/main/runtime/src/iree/runtime/api.h) | High level runtime API
+
+### Low level concepts
+
+#### Base
+
+The 'base' component includes general runtime utilities such as:
+
+* Memory allocators
+* Status and error handling
+* String manipulation
+* File input and output
+* Event pools and loops
+* Synchronization and threading primitives
+* Tracing and other debugging
+
+As IREE is designed to support a variety of deployment targets, many of these
+utilities are written to be cross-platform or be optional.
+
+#### VM
+
+IREE uses its own Virtual Machine (VM) at runtime to interpret program
+instructions on the host system.
+
+??? tip "Tip - EmitC alternate lowering path"
+    VM instructions may be further lowered to C source code for static or
+    resource constrained deployment.
+
+    See the `--output-format=vm-c` compiler option and the samples in
+    [`samples/emitc_modules/`](https://github.com/iree-org/iree/tree/main/samples/emitc_modules)
+    for more information.
+
+The VM supports generic operations like loads, stores, arithmetic, function
+calls, and control flow. The VM builds streams of more complex program logic and
+dense math into HAL command buffers that are dispatched to hardware backends.
+
+* VM _instances_ can serve multiple isolated execution _contexts_.
+* VM _contexts_ are effectively sandboxes for loading modules and running
+  programs.
+* VM _modules_ provide all functionality to execution _contexts_, including
+  access to hardware accelerators through the HAL. Compiled user programs are
+  also modules.
+
+    ```mermaid
+    stateDiagram-v2
+      accTitle: Sample VM Modules
+      accDescr {
+        Bytecode modules contain program state, program functions, and debug
+        information.
+        HAL modules contain devices, executables, HAL functions, and HAL types.
+        Custom modules may contain external functions and custom types.
+      }
+
+      state "Bytecode module" as bytecode {
+        bytecode_contents: Module state<br>Program funcs<br>Debug info
+      }
+
+      state "HAL module" as HAL {
+        hal_contents: Devices<br>Executables<br>HAL funcs<br>HAL types
+      }
+
+      state "Parameters module" as Params {
+        parameters_contents: Providers
+      }
+
+      state "Custom module" as custom {
+        custom_contents: External funcs<br>Custom types
+      }
+    ```
+
+#### HAL
+
+<!-- TODO(scotttodd): command buffer construction -> dispatch diagram -->
+<!-- TODO(scotttodd): input buffers -> output buffers diagram -->
+<!-- TODO(scotttodd): HAL interface diagram -->
+
+IREE uses a Hardware Abstraction Layer (HAL) to model and interact with
+hardware devices like CPUs, GPUs and other accelerators.
+
+* HAL _drivers_ are used to enumerate and create HAL _devices_.
+* HAL _devices_ interface with hardware, such as by allocating device memory,
+  preparing executables, recording and dispatching command buffers, and
+  synchronizing with the host.
+* HAL _buffers_ represent data storage and _buffer views_ represent views into
+  that storage with associated shapes and types (similar to "tensors").
 
 ### High level concepts
 
@@ -387,80 +479,22 @@ A _call_ (`iree_runtime_call_t`) is a stateful VM function call builder.
 * _Calls_ can be reused to avoid having to construct input lists for each
   invocation.
 
-### Low level concepts
-
-#### Base
-
-!!! todo - "Under construction, more coming soon"
-
-#### VM
-
-IREE uses its own Virtual Machine (VM) at runtime to interpret program
-instructions on the host system.
-
-??? tip "Tip - EmitC alternate lowering path"
-    VM instructions may be further lowered to C source code for static or
-    resource constrained deployment.
-
-    See the `--output-format=vm-c` compiler option and the samples in
-    [`samples/emitc_modules/`](https://github.com/iree-org/iree/tree/main/samples/emitc_modules)
-    for more information.
-
-The VM supports generic operations like loads, stores, arithmetic, function
-calls, and control flow. The VM builds streams of more complex program logic and
-dense math into HAL command buffers that are dispatched to hardware backends.
-
-* VM _instances_ can serve multiple isolated execution _contexts_.
-* VM _contexts_ are effectively sandboxes for loading modules and running
-  programs.
-* VM _modules_ provide all functionality to execution _contexts_, including
-  access to hardware accelerators through the HAL. Compiled user programs are
-  also modules.
-
-    ```mermaid
-    stateDiagram-v2
-      accTitle: Sample VM Modules
-      accDescr {
-        Bytecode modules contain program state, program functions, and debug
-        information.
-        HAL modules contain devices, executables, HAL functions, and HAL types.
-        Custom modules may contain external functions and custom types.
-      }
-
-      state "Bytecode module" as bytecode {
-        bytecode_contents: Module state<br>Program functions<br>Debug information
-      }
-
-      state "HAL module" as HAL {
-        hal_contents: Devices<br>Executables<br>HAL functions<br>HAL types
-      }
-
-      state "Custom module" as custom {
-        custom_contents: External functions<br>Custom types
-      }
-    ```
-
-#### HAL
-
-<!-- TODO(scotttodd): command buffer construction -> dispatch diagram -->
-<!-- TODO(scotttodd): input buffers -> output buffers diagram -->
-<!-- TODO(scotttodd): HAL interface diagram -->
-
-IREE uses a Hardware Abstraction Layer (HAL) to model and interact with
-hardware devices like CPUs, GPUs and other accelerators.
-
-* HAL _drivers_ are used to enumerate and create HAL _devices_.
-* HAL _devices_ interface with hardware, such as by allocating device memory,
-  preparing executables, recording and dispatching command buffers, and
-  synchronizing with the host.
-* HAL _buffers_ represent data storage and _buffer views_ represent views into
-  that storage with associated shapes and types (similar to "tensors").
-
 ### Usage
 
-!!! info ""
+#### Samples
 
-    For other examples, see the [samples below](#samples_1).
+| Project | Source | Description |
+| ------- |------- | ----------- |
+[iree-org/iree-template-runtime-cmake](https://github.com/iree-org/iree-template-runtime-cmake/) | [`hello_world.c`](https://github.com/iree-org/iree-template-runtime-cmake/blob/main/hello_world.c) | Runtime application template
+[iree-org/iree](https://github.com/iree-org/iree/) | [`runtime/demo/`](https://github.com/iree-org/iree/blob/main/runtime/src/iree/runtime/demo/) | In-tree demos of the high level runtime API
+[iree-org/iree](https://github.com/iree-org/iree/) | [`samples/`](https://github.com/iree-org/iree/tree/main/samples) | In-tree sample applications
+[iree-org/iree-experimental](https://github.com/iree-org/iree-experimental/) | [`runtime-library/`](https://github.com/iree-org/iree-experimental/tree/main/runtime-library) | Shared runtime library builder<br>Builds `libireert.so` to aid development
+[iml130/iree-template-cpp](https://github.com/iml130/iree-template-cpp) | [`simple_embedding.c`](https://github.com/iml130/iree-template-cpp/blob/main/iree_simple_embedding/simple_embedding.c) | Demo integration into a project
+
+#### High level "hello world"
+
+Below are two samples showing how to use the high level runtime API - one
+"terse" sample and one "explained" sample with more detailed comments:
 
 === "hello_world_terse.c"
 
@@ -477,16 +511,6 @@ hardware devices like CPUs, GPUs and other accelerators.
     ```c++ title="runtime/src/iree/runtime/demo/hello_world_explained.c" linenums="1"
     --8<-- "runtime/src/iree/runtime/demo/hello_world_explained.c:7"
     ```
-
-#### Samples
-
-| Project | Source | Description |
-| ------- |------- | ----------- |
-[iree-org/iree-template-runtime-cmake](https://github.com/iree-org/iree-template-runtime-cmake/) | [`hello_world.c`](https://github.com/iree-org/iree-template-runtime-cmake/blob/main/hello_world.c) | Runtime application template
-[iree-org/iree](https://github.com/iree-org/iree/) | [`runtime/demo/`](https://github.com/iree-org/iree/blob/main/runtime/src/iree/runtime/demo/) | In-tree demos of the high level runtime API
-[iree-org/iree](https://github.com/iree-org/iree/) | [`samples/`](https://github.com/iree-org/iree/tree/main/samples) | In-tree sample applications
-[iree-org/iree-experimental](https://github.com/iree-org/iree-experimental/) | [`runtime-library/`](https://github.com/iree-org/iree-experimental/tree/main/runtime-library) | Shared runtime library builder<br>Builds `libireert.so` to aid development
-[iml130/iree-template-cpp](https://github.com/iml130/iree-template-cpp) | [`simple_embedding.c`](https://github.com/iml130/iree-template-cpp/blob/main/iree_simple_embedding/simple_embedding.c) | Demo integration into a project
 
 ## Compiler + Runtime = JIT
 


### PR DESCRIPTION
The "high level runtime API" has some sharp edges and limitations when used by higher level bindings or in complex applications, as seen in [this recent Discord discussion](https://discord.com/channels/689900678990135345/689900680009482386/1245180220152217610). We may rework the high level API or move it to samples/, so this at least features the low level API more prominently in our documentation.

| | |
| -- | -- |
Current page | https://iree.dev/reference/bindings/c-api/
This PR | https://scotttodd.github.io/iree/reference/bindings/c-api/

Changes:

* Add warning to prefer the low level API when writing custom bindings or integrating into larger projects
* Show "Low level API" diagram by default, requiring a click into the "High level API" tab to show that diagram
* Move `iree/runtime/api.h` from top to bottom of header file table
* Move "Low level concepts" above "High level concepts"
* Move "Usage samples" links above `runtime/demo/hello_world` inlined sample
* Add text to low level "Base" section listing some of the components there