### PR TITLE
[Codegen][GPU] Fix result replacement given multiple tiled ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyTilingLevel.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyTilingLevel.cpp
@@ -151,8 +151,7 @@ applyTileAndFuseToEachRoot(RewriterBase &rewriter,
           Operation *replacementOp = replacement.getDefiningOp();
           rewriter.replaceUsesWithIf(res, replacement, [&](OpOperand &use) {
             Operation *user = use.getOwner();
-            return dominanceInfo.properlyDominates(replacementOp, user) &&
-                   user->getParentOp() == replacementOp->getParentOp();
+            return dominanceInfo.properlyDominates(replacementOp, user);
           });
         }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_tiling_level.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_tiling_level.mlir
@@ -37,6 +37,55 @@ module {
 
 // -----
 
+module {
+  func.func @matmul_transpose_b() attributes {translation_info = #iree_codegen.translation_info<LLVMGPUVectorize workgroup_size = [128, 2, 1] subgroup_size = 64>} {
+    %c4 = arith.constant 4 : index
+    %c1280 = arith.constant 1280 : index
+    %cst = arith.constant 0.000000e+00 : f16
+    %c0 = arith.constant 0 : index
+    %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2048x1280xf16>>
+    %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<10240x1280xf16>>
+    %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2048x10240xf32>>
+    %workgroup_id_y = hal.interface.workgroup.id[1] : index
+    %3 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_id_y]
+    %workgroup_id_x = hal.interface.workgroup.id[0] : index
+    %4 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_id_x]
+    %5 = flow.dispatch.tensor.load %2, offsets = [%3, %4], sizes = [64, 64], strides = [1, 1] : !flow.dispatch.tensor<writeonly:tensor<2048x10240xf32>> -> tensor<64x64xf32>
+    %6 = flow.dispatch.tensor.load %0, offsets = [%3, 0], sizes = [64, 1280], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<2048x1280xf16>> -> tensor<64x1280xf16>
+    %7 = flow.dispatch.tensor.load %1, offsets = [%4, 0], sizes = [64, 1280], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<10240x1280xf16>> -> tensor<64x1280xf16>
+    %8 = linalg.fill ins(%cst : f16) outs(%5 : tensor<64x64xf32>) -> tensor<64x64xf32>
+    %9 = tensor.empty() : tensor<64x1280xf16>
+    %10 = tensor.empty() : tensor<64x1280xf16>
+    %11 = scf.for %arg0 = %c0 to %c1280 step %c4 iter_args(%arg1 = %8) -> (tensor<64x64xf32>) {
+      %extracted_slice = tensor.extract_slice %6[0, %arg0] [64, 4] [1, 1] : tensor<64x1280xf16> to tensor<64x4xf16>
+      %extracted_slice_0 = tensor.extract_slice %9[0, %arg0] [64, 4] [1, 1] : tensor<64x1280xf16> to tensor<64x4xf16>
+      %12 = linalg.copy {lowering_config = #iree_gpu.lowering_config<{thread = [1, 1]}>} ins(%extracted_slice : tensor<64x4xf16>) outs(%extracted_slice_0 : tensor<64x4xf16>) -> tensor<64x4xf16>
+      %extracted_slice_1 = tensor.extract_slice %7[0, %arg0] [64, 4] [1, 1] : tensor<64x1280xf16> to tensor<64x4xf16>
+      %extracted_slice_2 = tensor.extract_slice %10[0, %arg0] [64, 4] [1, 1] : tensor<64x1280xf16> to tensor<64x4xf16>
+      %13 = linalg.copy {lowering_config = #iree_gpu.lowering_config<{thread = [1, 1]}>} ins(%extracted_slice_1 : tensor<64x4xf16>) outs(%extracted_slice_2 : tensor<64x4xf16>) -> tensor<64x4xf16>
+      %14 = linalg.matmul_transpose_b {lowering_config = #iree_gpu.lowering_config<{thread = [4, 4]}>} ins(%12, %13 : tensor<64x4xf16>, tensor<64x4xf16>) outs(%arg1 : tensor<64x64xf32>) -> tensor<64x64xf32>
+      scf.yield %14 : tensor<64x64xf32>
+    }
+    flow.dispatch.tensor.store %11, %2, offsets = [%3, %4], sizes = [64, 64], strides = [1, 1] : tensor<64x64xf32> -> !flow.dispatch.tensor<writeonly:tensor<2048x10240xf32>>
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @matmul_transpose_b
+
+// THREAD-LABEL: func.func @matmul_transpose_b
+//       THREAD:   scf.forall ({{.*}}) in (64, 4)
+//       THREAD:     linalg.copy
+//       THREAD:   mapping = [#gpu.thread<linear_dim_0>, #gpu.thread<linear_dim_1>]
+//       THREAD:   scf.forall ({{.*}}) in (64, 4)
+//       THREAD:     linalg.copy
+//       THREAD:   mapping = [#gpu.thread<linear_dim_0>, #gpu.thread<linear_dim_1>]
+//       THREAD:   scf.forall ({{.*}}) = (0, 0) to (64, 64) step (4, 4)
+//       THREAD:     linalg.matmul
+//       THREAD:   mapping = [#gpu.thread<linear_dim_0>, #gpu.thread<linear_dim_1>]
+
+// -----
+
 #config = #iree_gpu.lowering_config<{reduction = [0, 8]}>
 #map = affine_map<()[s0] -> (s0 * 64)>
 #map1 = affine_map<(d0, d1) -> (d0, d1)>


### PR DESCRIPTION
When applying tile + fuse with GPUApplyTilingLevelPass, result replacement was unnecessarily trying to make sure that the replaced user was contained within the same operation, resulting in tiling silently not occurring.