### PR TITLE
Re-enable `test_amd_mi250` CI job.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,45 +391,44 @@ jobs:
   #               ./build_tools/scripts/check_vulkan.sh
   #               ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}"
 
-  # TODO: re-enable when mi250 runners are available again
-  # test_amd_mi250:
-  #   needs: [setup, build_all]
-  #   if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_amd_mi250')
-  #   env:
-  #     BUILD_DIR: build-tests
-  #     INSTALL_DIR: ${{ needs.build_all.outputs.install-dir }}
-  #     INSTALL_DIR_ARCHIVE: ${{ needs.build_all.outputs.install-dir-archive }}
-  #     INSTALL_DIR_GCS_URL: ${{ needs.build_all.outputs.install-dir-gcs-url }}
-  #     IREE_CPU_DISABLE: 1
-  #     IREE_VULKAN_DISABLE: 1
-  #     IREE_CUDA_DISABLE: 1
-  #     IREE_HIP_DISABLE: 0
-  #     IREE_HIP_TEST_TARGET_CHIP: "gfx90a"
-  #   runs-on: nodai-amdgpu-mi250-x86-64
-  #   steps:
-  #     - name: "Checking out repository"
-  #       uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-  #     - name: "Checking out runtime submodules"
-  #       run: ./build_tools/scripts/git/update_runtime_submodules.sh
-  #     - name: "Downloading install dir archive"
-  #       run: wget "${INSTALL_DIR_GCS_URL}" -O "${INSTALL_DIR_ARCHIVE}"
-  #     - name: "Extracting install directory"
-  #       run: tar -xf "${INSTALL_DIR_ARCHIVE}"
-  #     - name: "Building tests"
-  #       run: |
-  #         ./build_tools/pkgci/build_tests_using_package.sh ${INSTALL_DIR}
-  #     - name: "Running GPU tests"
-  #       env:
-  #         IREE_CTEST_LABEL_REGEX: ^requires-gpu|^driver=hip$
-  #         IREE_NVIDIA_SM80_TESTS_DISABLE: 1
-  #         IREE_MULTI_DEVICE_TESTS_DISABLE: 0
-  #         IREE_AMD_RDNA3_TESTS_DISABLE: 1
-  #         IREE_NVIDIA_GPU_TESTS_DISABLE: 0
-  #         IREE_CUDA_DISABLE: 1
-  #         IREE_CPU_DISABLE: 1
-  #         IREE_HIP_DISABLE: 0
-  #       run: |
-  #         ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}
+  test_amd_mi250:
+    needs: [setup, build_all]
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_amd_mi250')
+    env:
+      BUILD_DIR: build-tests
+      INSTALL_DIR: ${{ needs.build_all.outputs.install-dir }}
+      INSTALL_DIR_ARCHIVE: ${{ needs.build_all.outputs.install-dir-archive }}
+      INSTALL_DIR_GCS_URL: ${{ needs.build_all.outputs.install-dir-gcs-url }}
+      IREE_CPU_DISABLE: 1
+      IREE_VULKAN_DISABLE: 1
+      IREE_CUDA_DISABLE: 1
+      IREE_HIP_DISABLE: 0
+      IREE_HIP_TEST_TARGET_CHIP: "gfx90a"
+    runs-on: nodai-amdgpu-mi250-x86-64
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: "Checking out runtime submodules"
+        run: ./build_tools/scripts/git/update_runtime_submodules.sh
+      - name: "Downloading install dir archive"
+        run: wget "${INSTALL_DIR_GCS_URL}" -O "${INSTALL_DIR_ARCHIVE}"
+      - name: "Extracting install directory"
+        run: tar -xf "${INSTALL_DIR_ARCHIVE}"
+      - name: "Building tests"
+        run: |
+          ./build_tools/pkgci/build_tests_using_package.sh ${INSTALL_DIR}
+      - name: "Running GPU tests"
+        env:
+          IREE_CTEST_LABEL_REGEX: ^requires-gpu|^driver=hip$
+          IREE_NVIDIA_SM80_TESTS_DISABLE: 1
+          IREE_MULTI_DEVICE_TESTS_DISABLE: 0
+          IREE_AMD_RDNA3_TESTS_DISABLE: 1
+          IREE_NVIDIA_GPU_TESTS_DISABLE: 0
+          IREE_CUDA_DISABLE: 1
+          IREE_CPU_DISABLE: 1
+          IREE_HIP_DISABLE: 0
+        run: |
+          ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}
 
   # TODO(saienduri): re-enable when iree/hal/drivers/hip/dynamic_symbols_test is fixed
   # test_amd_w7900:
@@ -922,7 +921,7 @@ jobs:
       # Accelerators
       - test_nvidia_gpu
       # - test_nvidia_a100
-      # - test_amd_mi250
+      - test_amd_mi250
       # - test_amd_w7900
 
       # Configurations


### PR DESCRIPTION
This runner is back online.

ci-exactly: build_all, test_amd_mi250