### PR TITLE
Fix pkgci regression test config file uploading.

### DIFF
--- a/.github/workflows/pkgci_regression_test.yml
+++ b/.github/workflows/pkgci_regression_test.yml
@@ -122,8 +122,8 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: "${{ matrix.config-file }}"
-          path: "${CONFIG_FILE_PATH}"
+          name: ${{ matrix.config-file }}
+          path: ${{ env.CONFIG_FILE_PATH }}
 
   test_models:
     name: "test_models :: ${{ matrix.name }}"


### PR DESCRIPTION
This fixes `Warning: No files were found with the provided path: ${CONFIG_FILE_PATH}. No artifacts will be uploaded.`:
https://github.com/iree-org/iree/actions/runs/9355995890/job/25752745889?pr=17554#step:10:22