### PR TITLE
[Codegen][LLVMGPU] Add pass pipeline for greedy tile + fuse

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -141,6 +141,7 @@ iree_compiler_cc_library(
         "TileSizeSelection.cpp",
         "TypePropagationPass.cpp",
         "UserConfig.cpp",
+        "VectorizeMemrefCopy.cpp",
         "VectorizePad.cpp",
     ],
     hdrs = [

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -132,6 +132,7 @@ iree_cc_library(
     "TileSizeSelection.cpp"
     "TypePropagationPass.cpp"
     "UserConfig.cpp"
+    "VectorizeMemrefCopy.cpp"
     "VectorizePad.cpp"
   DEPS
     ::PassHeaders

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
@@ -63,6 +63,7 @@ iree_compiler_cc_library(
         "GPUNestedLayoutDistributionPatterns.cpp",
         "GPUPatterns.cpp",
         "GPUPipelining.cpp",
+        "GPUPromoteMatmulOperands.cpp",
         "GPUReduceBankConflicts.cpp",
         "GPUTensorAlloc.cpp",
         "GPUTensorTile.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
@@ -61,6 +61,7 @@ iree_cc_library(
     "GPUNestedLayoutDistributionPatterns.cpp"
     "GPUPatterns.cpp"
     "GPUPipelining.cpp"
+    "GPUPromoteMatmulOperands.cpp"
     "GPUReduceBankConflicts.cpp"
     "GPUTensorAlloc.cpp"
     "GPUTensorTile.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyTilingLevel.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyTilingLevel.cpp
@@ -210,6 +210,7 @@ void GPUApplyTilingLevelPass::runOnOperation() {
     RewritePatternSet patterns(context);
     // Merge consecutive insert/extract slice ops to simplify later loop
     // hoisting patterns.
+    tensor::populateFoldTensorEmptyPatterns(patterns);
     tensor::populateMergeConsecutiveInsertExtractSlicePatterns(patterns);
     tensor::InsertSliceOp::getCanonicalizationPatterns(patterns, context);
     tensor::ExtractSliceOp::getCanonicalizationPatterns(patterns, context);

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromoteMatmulOperands.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromoteMatmulOperands.cpp
@@ -1,0 +1,70 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/GPU/Passes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
+#include "iree/compiler/Codegen/Utils/LinalgOpInfo.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Transforms/Passes.h"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_GPUPROMOTEMATMULOPERANDSPASS
+#include "iree/compiler/Codegen/Common/GPU/Passes.h.inc"
+
+namespace {
+
+void promoteOperand(OpBuilder &builder, Operation *op, unsigned index) {
+  Value operand = op->getOperand(index);
+
+  if (auto producer = operand.getDefiningOp<TilingInterface>()) {
+    setLoweringConfig(producer, IREE::GPU::DerivedThreadConfigAttr::get(
+                                    builder.getContext()));
+    return;
+  }
+
+  auto tensorType = dyn_cast<RankedTensorType>(operand.getType());
+  if (!tensorType) {
+    return;
+  }
+
+  SmallVector<OpFoldResult> mixedSizes =
+      tensor::getMixedSizes(builder, op->getLoc(), operand);
+  Value empty = builder.create<tensor::EmptyOp>(op->getLoc(), mixedSizes,
+                                                tensorType.getElementType());
+  auto copy = builder.create<linalg::CopyOp>(op->getLoc(), operand, empty);
+  setLoweringConfig(
+      copy, IREE::GPU::DerivedThreadConfigAttr::get(builder.getContext()));
+  op->setOperand(index, copy.getResult(0));
+}
+
+struct GPUPromoteMatmulOperandsPass final
+    : impl::GPUPromoteMatmulOperandsPassBase<GPUPromoteMatmulOperandsPass> {
+  void runOnOperation() override {
+    FunctionOpInterface funcOp = getOperation();
+
+    OpBuilder builder(funcOp);
+    funcOp.walk([&](linalg::LinalgOp linalgOp) {
+      if (!isMatmulOrBatchMatmul(linalgOp)) {
+        return;
+      }
+      builder.setInsertionPoint(linalgOp);
+      promoteOperand(builder, linalgOp, 0);
+      promoteOperand(builder, linalgOp, 1);
+    });
+  }
+};
+
+} // namespace
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromoteMatmulOperands.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromoteMatmulOperands.cpp
@@ -25,6 +25,21 @@ namespace mlir::iree_compiler {
 
 namespace {
 
+/// Inserts a `linalg.copy` directly before the given operation on the
+/// specified operand, for example with operand index = 1:
+///
+///   linalg.matmul ins(%0, %1)
+///
+/// becomes
+///
+///   %empty = tensor.empty()
+///   %copy = linalg.copy %1 to %empty {
+///     lowering_config = #iree_gpu.derived_thread_config}
+///   linalg.matmul ins(%0, %copy)
+///
+/// If the producer is already a tilable op, the producer is just annotated with
+/// #iree_gpu.derived_thread_config to indicate that it should be distributed
+/// to threads independently of the matmul.
 void promoteOperand(OpBuilder &builder, Operation *op, unsigned index) {
   Value operand = op->getOperand(index);
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -96,6 +96,17 @@ def GPUPipeliningPass :
   ];
 }
 
+def GPUPromoteMatmulOperandsPass :
+    InterfacePass<"iree-codegen-gpu-promote-matmul-operands",
+                  "mlir::FunctionOpInterface"> {
+  let summary = "Pass to insert copies with a different thread configuration "
+                "on matmul operands";
+  let dependentDialects = [
+    "::mlir::linalg::LinalgDialect",
+    "::mlir::iree_compiler::IREE::GPU::IREEGPUDialect"
+  ];
+}
+
 def GPUReduceBankConflictsPass :
     InterfacePass<"iree-codegen-gpu-reduce-bank-conflicts", "mlir::FunctionOpInterface"> {
   let summary = "Pass to try to reduce the number of bank conflicts by padding memref.alloc ops.";

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
@@ -29,6 +29,7 @@ iree_lit_test_suite(
             "gpu_nested_layout_contract_amdgpu.mlir",
             "gpu_nested_layout_vector_distribution.mlir",
             "gpu_pipeline.mlir",
+            "gpu_promote_matmul_operands.mlir",
             "gpu_reorder_workgroups_static.mlir",
             "gpu_reorder_workgroups.mlir",
             "gpu_tensor_alloc.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_lit_test_suite(
     "gpu_nested_layout_contract_amdgpu.mlir"
     "gpu_nested_layout_vector_distribution.mlir"
     "gpu_pipeline.mlir"
+    "gpu_promote_matmul_operands.mlir"
     "gpu_reorder_workgroups.mlir"
     "gpu_reorder_workgroups_static.mlir"
     "gpu_tensor_alloc.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_tiling_level.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_tiling_level.mlir
@@ -191,3 +191,40 @@ module {
 //   THREAD-DAG:       %[[LHS:.+]] = tensor.extract_slice %[[A]]
 //   THREAD-DAG:       %[[RHS:.+]] = tensor.extract_slice %[[B]]
 //       THREAD:       %[[MM:.+]] = linalg.matmul {{.*}} ins(%[[LHS]], %[[RHS]] : tensor<8x8xf32>, tensor<8x8xf32>)
+
+// -----
+
+#config = #iree_gpu.derived_thread_config
+#map = affine_map<(d0, d1) -> (d0, d1)>
+module {
+  func.func @inferred_add_tensor()
+      attributes {translation_info = #iree_codegen.translation_info<LLVMGPUVectorize workgroup_size = [16, 32, 1] subgroup_size = 64, {}>} {
+    %c0 = arith.constant 0 : index
+    %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<64x256xf32>>
+    %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<64x256xf32>>
+    %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<64x256xf32>>
+    %3 = flow.dispatch.tensor.load %0, offsets = [%c0, %c0], sizes = [64, 256], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<64x256xf32>> -> tensor<64x256xf32>
+    %4 = flow.dispatch.tensor.load %1, offsets = [%c0, %c0], sizes = [64, 256], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<64x256xf32>> -> tensor<64x256xf32>
+    %5 = flow.dispatch.tensor.load %2, offsets = [%c0, %c0], sizes = [64, 256], strides = [1, 1] : !flow.dispatch.tensor<writeonly:tensor<64x256xf32>> -> tensor<64x256xf32>
+    %6 = linalg.generic {
+      indexing_maps = [#map, #map, #map],
+      iterator_types = ["parallel", "parallel"]
+      } ins(%3, %4 : tensor<64x256xf32>, tensor<64x256xf32>) outs(%5 : tensor<64x256xf32>) attrs =  {lowering_config = #config} {
+    ^bb0(%in: f32, %in_0: f32, %out: f32):
+      %7 = arith.addf %in, %in_0 : f32
+      linalg.yield %7 : f32
+    } -> tensor<64x256xf32>
+    flow.dispatch.tensor.store %6, %2, offsets = [%c0, %c0], sizes = [64, 256], strides = [1, 1] : tensor<64x256xf32> -> !flow.dispatch.tensor<writeonly:tensor<64x256xf32>>
+    return
+  }
+}
+
+// Verify that no loops are generated without a reduction configuration.
+// CHECK-LABEL: func.func @inferred_add_tensor
+//   CHECK-NOT:   scf.for
+
+// THREAD-LABEL: func.func @inferred_add_tensor
+//       THREAD:   scf.forall ({{.*}}) = (0, 0) to (64, 256) step (8, 4)
+//       THREAD:     linalg.generic {{.*}} ins(%{{.*}}: tensor<8x4xf32>, tensor<8x4xf32>)
+//       THREAD:     scf.forall.in_parallel
+//       THREAD:   mapping = [#gpu.thread<linear_dim_0>, #gpu.thread<linear_dim_1>]

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_promote_matmul_operands.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_promote_matmul_operands.mlir
@@ -1,0 +1,31 @@
+// RUN: iree-opt %s --split-input-file --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-promote-matmul-operands))" | FileCheck %s
+
+func.func @matmul(%a: tensor<32x1024xf32>, %b: tensor<1024x128xf32>) -> tensor<32x128xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %empty = tensor.empty() : tensor<32x128xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<32x128xf32>) -> tensor<32x128xf32>
+  %mm = linalg.matmul ins(%a, %b : tensor<32x1024xf32>, tensor<1024x128xf32>) outs(%fill : tensor<32x128xf32>) -> tensor<32x128xf32>
+  return %mm : tensor<32x128xf32>
+}
+
+// CHECK-LABEL: func.func @matmul
+//  CHECK-SAME:   %[[A:[A-Za-z0-9]+]]: tensor<32x1024xf32>
+//  CHECK-SAME:   %[[B:[A-Za-z0-9]+]]: tensor<1024x128xf32>
+//   CHECK-DAG:   %[[PA:.+]] = linalg.copy {{.*}} ins(%[[A]] : tensor<32x1024xf32>)
+//   CHECK-DAG:   %[[PB:.+]] = linalg.copy {{.*}} ins(%[[B]] : tensor<1024x128xf32>)
+//       CHECK:   linalg.matmul ins(%[[PA]], %[[PB]] : tensor<32x1024xf32>, tensor<1024x128xf32>)
+
+// -----
+
+func.func @matvec(%a: tensor<1x1024xf32>, %b: tensor<1024x128xf32>) -> tensor<1x128xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %empty = tensor.empty() : tensor<1x128xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<1x128xf32>) -> tensor<1x128xf32>
+  %mm = linalg.matmul ins(%a, %b : tensor<1x1024xf32>, tensor<1024x128xf32>) outs(%fill : tensor<1x128xf32>) -> tensor<1x128xf32>
+  return %mm : tensor<1x128xf32>
+}
+
+// Verify that no copies are generated for matvec operations.
+// CHECK-LABEL: func.func @matvec
+//   CHECK-NOT:   linalg.copy
+//       CHECK: return

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.h
@@ -288,6 +288,9 @@ createTransformDialectInterpreterPass(StringRef transformSequenceName = "");
 /// Pass to propagate type to avoid generating load/stores of illegal types.
 std::unique_ptr<InterfacePass<FunctionOpInterface>> createTypePropagationPass();
 
+/// Pass to vectorize memref.copy ops.
+std::unique_ptr<OperationPass<void>> createVectorizeMemrefCopyPass();
+
 /// Creates a pass to vectorize a very specific form of tensor.pad ops with
 /// control flows.
 std::unique_ptr<InterfacePass<FunctionOpInterface>> createVectorizePadPass();

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -524,4 +524,10 @@ def TypePropagation :
   let constructor = "mlir::iree_compiler::createTypePropagationPass()";
 }
 
+def VectorizeMemrefCopyPass :
+    Pass<"iree-codegen-vectorize-memref-copy", ""> {
+  let summary = "Vectorizes memref copy operations.";
+  let constructor = "mlir::iree_compiler::createVectorizeMemrefCopyPass()";
+}
+
 #endif // IREE_CODEGEN_COMMON_PASSES

--- a/compiler/src/iree/compiler/Codegen/Common/VectorizeMemrefCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorizeMemrefCopy.cpp
@@ -1,0 +1,39 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/PassDetail.h"
+#include "iree/compiler/Codegen/Common/Passes.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::iree_compiler {
+
+namespace {
+
+struct VectorizeMemrefCopyPass
+    : public VectorizeMemrefCopyPassBase<VectorizeMemrefCopyPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<arith::ArithDialect, vector::VectorDialect>();
+  }
+  void runOnOperation() override {
+    MLIRContext *ctx = &getContext();
+    auto funcOp = getOperation();
+
+    RewritePatternSet patterns(ctx);
+    patterns.add<linalg::CopyVectorizationPattern>(&getContext());
+    (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
+  }
+};
+
+} // namespace
+
+std::unique_ptr<OperationPass<void>> createVectorizeMemrefCopyPass() {
+  return std::make_unique<VectorizeMemrefCopyPass>();
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -74,6 +74,7 @@ iree_lit_test_suite(
             "transpose_canonicalization.mlir",
             "type_propagation.mlir",
             "type_propagation_packing.mlir",
+            "vectorize_memref_copy.mlir",
             "vectorize_tensor_pad.mlir",
             "vector_layout_analysis.mlir",
             "workgroup_specialization.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -71,6 +71,7 @@ iree_lit_test_suite(
     "type_propagation.mlir"
     "type_propagation_packing.mlir"
     "vector_layout_analysis.mlir"
+    "vectorize_memref_copy.mlir"
     "vectorize_tensor_pad.mlir"
     "workgroup_specialization.mlir"
   TOOLS

--- a/compiler/src/iree/compiler/Codegen/Common/test/vectorize_memref_copy.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/vectorize_memref_copy.mlir
@@ -1,0 +1,12 @@
+// RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline="builtin.module(func.func(iree-codegen-vectorize-memref-copy))" %s | FileCheck %s
+
+func.func @memref_copy(%source: memref<2x2xf32>, %dest: memref<2x2xf32>) {
+  memref.copy %source, %dest : memref<2x2xf32> to memref<2x2xf32>
+  return
+}
+
+// CHECK-LABEL: func.func @memref_copy
+//  CHECK-SAME:   %[[SOURCE:[A-Za-z0-9]+]]: memref<2x2xf32>
+//  CHECK-SAME:   %[[DEST:[A-Za-z0-9]+]]: memref<2x2xf32>
+//       CHECK:   %[[RD:.+]] = vector.transfer_read %[[SOURCE]]
+//       CHECK:   vector.transfer_write %[[RD]], %[[DEST]]

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -53,6 +53,8 @@ def LLVMGPU_PadAndVectorDistribute
     : I32EnumAttrCase<"LLVMGPUPadAndVectorDistribute", 111>;
 def LLVMGPU_WinogradVectorize
     : I32EnumAttrCase<"LLVMGPUWinogradVectorize", 112>;
+def LLVMGPU_TileAndFuse
+    : I32EnumAttrCase<"LLVMGPUTileAndFuse", 113>;
 
 def SPIRV_BaseLowering
     : I32EnumAttrCase<"SPIRVBaseLowering", 200>;
@@ -95,6 +97,7 @@ def DispatchLoweringPassPipelineEnum : I32EnumAttr<
     LLVMGPU_TransposeSharedMem, LLVMGPU_WarpReduction, LLVMGPU_PackUnPack,
     LLVMGPU_MatmulTensorCoreMmaSync, LLVMGPU_VectorDistribute,
     LLVMGPU_PadAndVectorDistribute, LLVMGPU_WinogradVectorize,
+    LLVMGPU_TileAndFuse,
 
     // SPIR-V CodeGen pipelines
     SPIRV_BaseLowering, SPIRV_BaseDistribute, SPIRV_BaseVectorize,

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/BUILD.bazel
@@ -77,6 +77,7 @@ iree_compiler_cc_library(
         ":IREEGPUInterfaces",
         ":IREEGPUOpsGen",
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
+        "//compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils:ConfigUtils",
         "//compiler/src/iree/compiler/Codegen/Utils:VectorOpUtils",
         "//llvm-external-projects/iree-dialects:IREEVectorExtDialect",
         "@llvm-project//llvm:Support",

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/CMakeLists.txt
@@ -57,6 +57,7 @@ iree_cc_library(
     MLIRVectorDialect
     MLIRVectorInterfaces
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
+    iree::compiler::Codegen::Dialect::GPU::TargetUtils::ConfigUtils
     iree::compiler::Codegen::Utils::VectorOpUtils
   PUBLIC
 )

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -29,7 +29,7 @@ def IREEGPU_IteratorTypeArrayAttr
                          "Iterator type should be an enum.">;
 
 //===----------------------------------------------------------------------===//
-// GPU Specific Lowering Config Attribute
+// GPU Specific Lowering Config Attributes
 //===----------------------------------------------------------------------===//
 
 def IREEGPU_LoweringConfigAttr :
@@ -57,6 +57,28 @@ def IREEGPU_LoweringConfigAttr :
   let extraClassDeclaration = [{
     SmallVector<int64_t> getThreadTileSizes() const;
   }];
+}
+
+def IREEGPU_DerivedThreadConfig :
+    AttrDef<IREEGPU_Dialect, "DerivedThreadConfig", [
+      DeclareAttrInterfaceMethods<IREECodegen_LoweringConfigAttrInterface, [
+        "getStaticTilingLevelSizes",
+        "getTilingLevelSizes",
+      ]>
+    ]> {
+  let mnemonic = "derived_thread_config";
+  let summary = [{
+    drive lowering of an operation by deriving thread distribution when needed.
+  }];
+  let description = [{
+    Lowering config for a single thread tiling level that is inferred after
+    previous (often reduction) levels of tile + fuse. This is intended for
+    fused operations where it is much easier to compute the tile sizes to use
+    after previous levels of tile + fuse, rather than trying to pre-propagate
+    tiling configs.
+  }];
+  let assemblyFormat = "";
+  let parameters = (ins);
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/BUILD.bazel
@@ -13,6 +13,24 @@ package(
 )
 
 iree_compiler_cc_library(
+    name = "ConfigUtils",
+    srcs = [
+        "ConfigUtils.cpp",
+    ],
+    hdrs = [
+        "ConfigUtils.h",
+    ],
+    deps = [
+        "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:FunctionInterfaces",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LinalgDialect",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
+iree_compiler_cc_library(
     name = "KnownTargets",
     srcs = [
         "KnownTargets.cpp",

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/CMakeLists.txt
@@ -12,6 +12,23 @@ iree_add_all_subdirs()
 
 iree_cc_library(
   NAME
+    ConfigUtils
+  HDRS
+    "ConfigUtils.h"
+  SRCS
+    "ConfigUtils.cpp"
+  DEPS
+    LLVMSupport
+    MLIRFunctionInterfaces
+    MLIRIR
+    MLIRLinalgDialect
+    MLIRSupport
+    iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
     KnownTargets
   HDRS
     "KnownTargets.h"

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -1,0 +1,81 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h"
+#include <numeric>
+
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "llvm/Support/Casting.h"
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/TypeUtilities.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+
+namespace mlir::iree_compiler::IREE::GPU {
+
+static constexpr int64_t kPreferredCopyNumBits = 128;
+
+SmallVector<int64_t> deriveThreadTileSizes(Operation *op) {
+  auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
+  if (!linalgOp || !linalgOp.hasPureTensorSemantics()) {
+    return {};
+  }
+
+  // TODO: Support multi-result
+  if (linalgOp->getNumResults() != 1) {
+    return {};
+  }
+
+  SmallVector<int64_t> loopRanges = linalgOp.getStaticLoopRanges();
+  // TODO: We shouldn't need this check, however loop fusion currently requires
+  // loop trip counts to be identical, meaning we need to use a num_threads
+  // variant of tiling. Remove this and simply return the preferred vector size
+  // once loop fusion can resolve the forall properly.
+  if (llvm::any_of(loopRanges,
+                   [](int64_t s) { return ShapedType::isDynamic(s); })) {
+    return {};
+  }
+
+  std::optional<SmallVector<int64_t>> workgroupSize =
+      getWorkgroupSize(op->getParentOfType<FunctionOpInterface>());
+  if (!workgroupSize) {
+    return {};
+  }
+
+  int64_t flatNumThreads =
+      std::accumulate(workgroupSize->begin(), workgroupSize->end(), 1,
+                      std::multiplies<int64_t>());
+  int64_t flatNumTrips = std::accumulate(loopRanges.begin(), loopRanges.end(),
+                                         1, std::multiplies<int64_t>());
+  if (flatNumTrips % flatNumThreads != 0) {
+    return {};
+  }
+  int64_t maxVectorSize = flatNumTrips / flatNumThreads;
+  int64_t vectorSize = kPreferredCopyNumBits /
+                       getElementTypeOrSelf(linalgOp->getResultTypes()[0])
+                           .getIntOrFloatBitWidth();
+
+  while (maxVectorSize % vectorSize != 0) {
+    vectorSize /= 2;
+  }
+
+  SmallVector<int64_t> tileSizes(loopRanges.size(), 0);
+  tileSizes.back() = vectorSize;
+  int64_t residualNumThreads =
+      flatNumThreads / (loopRanges.back() / vectorSize);
+  for (int i = tileSizes.size() - 2, e = 0; i >= e; --i) {
+    if (loopRanges[i] >= residualNumThreads) {
+      tileSizes[i] = loopRanges[i] / residualNumThreads;
+      residualNumThreads = 1;
+      break;
+    }
+    tileSizes[i] = 1;
+    residualNumThreads /= loopRanges[i];
+  }
+  return tileSizes;
+}
+
+} // namespace mlir::iree_compiler::IREE::GPU

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h
@@ -1,0 +1,18 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_DIALECT_GPU_TARGETUTILS_CONFIGUTILS_H_
+#define IREE_COMPILER_CODEGEN_DIALECT_GPU_TARGETUTILS_CONFIGUTILS_H_
+
+#include "mlir/IR/Operation.h"
+
+namespace mlir::iree_compiler::IREE::GPU {
+
+SmallVector<int64_t> deriveThreadTileSizes(Operation *op);
+
+} // namespace mlir::iree_compiler::IREE::GPU
+
+#endif // IREE_COMPILER_CODEGEN_DIALECT_GPU_TARGETUTILS_CONFIGUTILS_H_

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BUILD.bazel
@@ -52,8 +52,10 @@ iree_compiler_cc_library(
     name = "GPUTransforms",
     srcs = [
         "FuseAndHoistParallelLoops.cpp",
+        "LowerIREEGPUOps.cpp",
         "Passes.cpp",
         "Transforms.cpp",
+        "VectorizeIREEGPUOps.cpp",
     ],
     hdrs = [
         "Passes.h",

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/CMakeLists.txt
@@ -46,8 +46,10 @@ iree_cc_library(
     "Transforms.h"
   SRCS
     "FuseAndHoistParallelLoops.cpp"
+    "LowerIREEGPUOps.cpp"
     "Passes.cpp"
     "Transforms.cpp"
+    "VectorizeIREEGPUOps.cpp"
   DEPS
     ::PassesIncGen
     LLVMSupport

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/FuseAndHoistParallelLoops.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/FuseAndHoistParallelLoops.cpp
@@ -121,6 +121,7 @@ void FuseAndHoistParallelLoopsPass::runOnOperation() {
   // potentially nested loops, hoisting from said loops, and continued fusion.
   patterns.add<FuseForalls>(context);
   patterns.add<FuseTileableDestinationProducers>(context);
+  tensor::populateFoldTensorEmptyPatterns(patterns);
   populateForallLoopHoistingPattern(patterns);
   if (failed(
           applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/LowerIREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/LowerIREEGPUOps.cpp
@@ -1,0 +1,37 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
+#include "iree/compiler/Codegen/Dialect/GPU/Transforms/Passes.h"
+#include "iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::iree_compiler::IREE::GPU {
+
+#define GEN_PASS_DEF_LOWERIREEGPUOPSPASS
+#include "iree/compiler/Codegen/Dialect/GPU/Transforms/Passes.h.inc"
+
+namespace {
+struct LowerIREEGPUOpsPass final
+    : impl::LowerIREEGPUOpsPassBase<LowerIREEGPUOpsPass> {
+  void runOnOperation() override;
+};
+} // namespace
+
+void LowerIREEGPUOpsPass::runOnOperation() {
+  MLIRContext *context = &getContext();
+  RewritePatternSet patterns(context);
+  populateIREEGPULowerValueBarrierPatterns(patterns);
+  populateIREEGPULowerMultiMmaPatterns(patterns);
+  if (failed(
+          applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
+    return signalPassFailure();
+  }
+}
+
+} // namespace mlir::iree_compiler::IREE::GPU

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Passes.td
@@ -11,10 +11,28 @@ include "mlir/Pass/PassBase.td"
 
 def FuseAndHoistParallelLoopsPass :
     InterfacePass<"iree-gpu-fuse-and-hoist-parallel-loops", "mlir::FunctionOpInterface"> {
-  let summary = "Checks GPU specific resource usage constraints like shared memory limits";
+  let summary = "Greedily fuses and hoists parallel loops.";
   let dependentDialects = [
     "::mlir::affine::AffineDialect",
     "::mlir::iree_compiler::IREE::GPU::IREEGPUDialect"
+  ];
+}
+
+def VectorizeIREEGPUOpsPass :
+    InterfacePass<"iree-gpu-vectorize-ops", "mlir::FunctionOpInterface"> {
+  let summary = "Vectorizes then lowers a few iree_gpu ops before vectorization.";
+  let dependentDialects = [
+    "::mlir::vector::VectorDialect",
+    "::mlir::arith::ArithDialect",
+    "::mlir::iree_compiler::IREE::GPU::IREEGPUDialect"
+  ];
+}
+
+def LowerIREEGPUOpsPass :
+    InterfacePass<"iree-gpu-lower-ops", "mlir::FunctionOpInterface"> {
+  let summary = "Post bufferization lowerings of iree_gpu ops before late lowerings";
+  let dependentDialects = [
+    "::mlir::gpu::GPUDialect",
   ];
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/VectorizeIREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/VectorizeIREEGPUOps.cpp
@@ -1,0 +1,38 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
+#include "iree/compiler/Codegen/Dialect/GPU/Transforms/Passes.h"
+#include "iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::iree_compiler::IREE::GPU {
+
+#define GEN_PASS_DEF_VECTORIZEIREEGPUOPSPASS
+#include "iree/compiler/Codegen/Dialect/GPU/Transforms/Passes.h.inc"
+
+namespace {
+struct VectorizeIREEGPUOpsPass final
+    : impl::VectorizeIREEGPUOpsPassBase<VectorizeIREEGPUOpsPass> {
+  void runOnOperation() override;
+};
+} // namespace
+
+void VectorizeIREEGPUOpsPass::runOnOperation() {
+  MLIRContext *context = &getContext();
+  RewritePatternSet patterns(context);
+  populateIREEGPUVectorizationPatterns(patterns);
+  populateIREEGPULowerShuffleTensorPatterns(patterns);
+  if (failed(
+          applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
+    return signalPassFailure();
+  }
+}
+
+} // namespace mlir::iree_compiler::IREE::GPU

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
@@ -131,6 +131,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Common/GPU:GPUHeuristics",
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/IR:IREEGPUDialect",
+        "//compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms:GPUTransforms",
         "//compiler/src/iree/compiler/Codegen/Interfaces:PartitionableLoopsInterface",
         "//compiler/src/iree/compiler/Codegen/Interfaces:UKernelOpInterface",
         "//compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions:LLVMGPUExtensions",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -173,6 +173,7 @@ iree_cc_library(
     iree::compiler::Codegen::Common::VectorLayoutAnalysis
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
     iree::compiler::Codegen::Dialect::GPU::IR::IREEGPUDialect
+    iree::compiler::Codegen::Dialect::GPU::Transforms::GPUTransforms
     iree::compiler::Codegen::Interfaces::PartitionableLoopsInterface
     iree::compiler::Codegen::Interfaces::UKernelOpInterface
     iree::compiler::Codegen::LLVMGPU::TransformExtensions::LLVMGPUExtensions

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
@@ -8,6 +8,7 @@
 #include "iree/compiler/Codegen/Common/PassUtils.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
 #include "iree/compiler/Codegen/LLVMGPU/KernelConfig.h"
 #include "iree/compiler/Codegen/LLVMGPU/PassDetail.h"
 #include "iree/compiler/Codegen/LLVMGPU/Passes.h"
@@ -53,6 +54,7 @@ public:
     // clang-format off
     registry
         .insert<IREE::HAL::HALDialect,
+                IREE::GPU::IREEGPUDialect,
                 IREE::LinalgExt::IREELinalgExtDialect,
                 IREE::VectorExt::IREEVectorExtDialect,
                 linalg::LinalgDialect,
@@ -177,6 +179,9 @@ void LLVMGPULowerExecutableTargetPass::runOnOperation() {
     break;
   case IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUPackUnPack:
     addGPUPackUnPackPasses(pipeline);
+    break;
+  case IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUTileAndFuse:
+    addGPUTileAndFusePassPipeline(pipeline);
     break;
   // no pipeline specified, nothing to do.
   case IREE::Codegen::DispatchLoweringPassPipeline::None:

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -12,6 +12,8 @@
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
+#include "iree/compiler/Codegen/Dialect/GPU/Transforms/Passes.h"
 #include "iree/compiler/Codegen/LLVMGPU/Passes.h"
 #include "iree/compiler/Codegen/LLVMGPU/ROCDLPasses.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
@@ -77,7 +79,8 @@ static llvm::cl::opt<bool> clLLVMGPUEnablePrefetch(
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
                               const LLVMGPUPipelineOptions &options) {
-  return os << "{" << "enableReduceSharedMemoryBankConflicts = "
+  return os << "{"
+            << "enableReduceSharedMemoryBankConflicts = "
             << options.enableReduceSharedMemoryBankConflicts
             << ", enableReorderWorkgroups = " << options.enableReorderWorkgroups
             << ", enableUkernels = " << options.enableUkernels << "}";
@@ -120,6 +123,20 @@ static FailureOr<Value> gpuAllocationFn(OpBuilder &builder, Location loc,
     addressSpace = gpu::AddressSpaceAttr::get(
         builder.getContext(), gpu::GPUDialect::getWorkgroupAddressSpace());
   }
+  MemRefType allocType =
+      MemRefType::get(memRefType.getShape(), memRefType.getElementType(),
+                      AffineMap(), addressSpace);
+  return builder.create<memref::AllocOp>(loc, allocType, dynamicSizes)
+      .getResult();
+}
+
+static FailureOr<Value> gpuWorkgroupAllocationFn(OpBuilder &builder,
+                                                 Location loc,
+                                                 MemRefType memRefType,
+                                                 ValueRange dynamicSizes,
+                                                 unsigned alignment) {
+  gpu::AddressSpaceAttr addressSpace = gpu::AddressSpaceAttr::get(
+      builder.getContext(), gpu::GPUDialect::getWorkgroupAddressSpace());
   MemRefType allocType =
       MemRefType::get(memRefType.getShape(), memRefType.getElementType(),
                       AffineMap(), addressSpace);
@@ -174,8 +191,10 @@ static LogicalResult canReorderWorkgroups(FunctionOpInterface funcOp) {
 // Common Pass Recipes
 //===----------------------------------------------------------------------===//
 
-static void addBufferizePasses(OpPassManager &funcPassManager) {
-  BufferizationOptions::AllocationFn allocationFn = gpuAllocationFn;
+static void addBufferizePasses(OpPassManager &funcPassManager,
+                               bool allowPrivateAllocations = true) {
+  BufferizationOptions::AllocationFn allocationFn =
+      allowPrivateAllocations ? gpuAllocationFn : gpuWorkgroupAllocationFn;
   BufferizationOptions::MemCpyFn memcpyFn = gpuCopyFn;
   addIREEComprehensiveBufferizePasses(funcPassManager, allocationFn, memcpyFn);
   funcPassManager.addPass(createCanonicalizerPass());
@@ -248,6 +267,78 @@ void addGPUVectorizationPassPipeline(OpPassManager &funcPassManager) {
   funcPassManager.addPass(createCSEPass());
   funcPassManager.addPass(createOptimizeVectorTransferPass());
   funcPassManager.addPass(createOptimizeTensorInsertExtractSlicesPass());
+}
+
+//===---------------------------------------------------------------------===//
+// Tile and Fuse
+//===---------------------------------------------------------------------===//
+
+void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager) {
+  tileAndDistributeToWorkgroup(funcPassManager);
+  funcPassManager.addPass(createCanonicalizerPass());
+  funcPassManager.addPass(createCSEPass());
+
+  funcPassManager.addPass(createGPUPromoteMatmulOperandsPass());
+
+  // Step 1. Tile and fuse tileable ops to reduction loops.
+  {
+    GPUApplyTilingLevelPassOptions options;
+    options.tilingLevel = IREE::GPU::TilingLevel::Reduction;
+    funcPassManager.addPass(createGPUApplyTilingLevelPass(options));
+    funcPassManager.addPass(createCanonicalizerPass());
+    funcPassManager.addPass(createCSEPass());
+  }
+
+  // Step 2. Tile and fuse tileable ops to threads.
+  {
+    GPUApplyTilingLevelPassOptions options;
+    options.tilingLevel = IREE::GPU::TilingLevel::Thread;
+    funcPassManager.addPass(createGPUApplyTilingLevelPass(options));
+    funcPassManager.addPass(createCanonicalizerPass());
+    funcPassManager.addPass(createCSEPass());
+  }
+
+  // Normalize loop bounds for later lowerings.
+  funcPassManager.addPass(iree_compiler::createNormalizeLoopBoundsPass(
+      /*normalizeFor=*/false, /*normalizeForall=*/true));
+  funcPassManager.addPass(createCanonicalizerPass());
+  funcPassManager.addPass(createCSEPass());
+  funcPassManager.addPass(createLoopInvariantCodeMotionPass());
+
+  // Step 3. Greedily fuse parallel loops and hoist from serial loops.
+  // TODO: Tileable consumer fusion needs to happen here as well.
+  funcPassManager.addPass(IREE::GPU::createFuseAndHoistParallelLoopsPass());
+  funcPassManager.addPass(createCanonicalizerPass());
+  funcPassManager.addPass(createCSEPass());
+  funcPassManager.addPass(createLoopInvariantCodeMotionPass());
+
+  // Step 4. Lower special ops and vectorize.
+  funcPassManager.addPass(IREE::GPU::createVectorizeIREEGPUOpsPass());
+  addGPUVectorizationPasses(funcPassManager);
+
+  // Step 5. Bufferize.
+  // TODO: This is a workaround for a bug in the lowering of
+  // `iree_gpu.shuffle_tensor` which does not properly represent the concurrent
+  // nature of the write to the intermediate tensor.
+  addBufferizePasses(funcPassManager, /*allowPrivateAllocations=*/false);
+
+  // Step 6. Resolve remaining parallel loops.
+  funcPassManager.addPass(createGPUDistributePass());
+
+  // Vectorize copies that came out of vectorization.
+  funcPassManager.addPass(createVectorizeMemrefCopyPass());
+
+  // Step 7. Remaining post-bufferization optimizations/lowerings.
+  funcPassManager.addPass(IREE::GPU::createLowerIREEGPUOpsPass());
+  funcPassManager.addPass(createLoopInvariantCodeMotionPass());
+  funcPassManager.addPass(memref::createFoldMemRefAliasOpsPass());
+  funcPassManager.addPass(createCanonicalizerPass());
+  funcPassManager.addPass(createCSEPass());
+  funcPassManager.addPass(createOptimizeVectorTransferPass());
+  funcPassManager.addPass(createOptimizeTensorInsertExtractSlicesPass());
+  funcPassManager.addPass(createHoistStaticallyBoundAllocationsPass());
+  funcPassManager.addPass(createCanonicalizerPass());
+  funcPassManager.addPass(createCSEPass());
 }
 
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -79,8 +79,7 @@ static llvm::cl::opt<bool> clLLVMGPUEnablePrefetch(
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
                               const LLVMGPUPipelineOptions &options) {
-  return os << "{"
-            << "enableReduceSharedMemoryBankConflicts = "
+  return os << "{" << "enableReduceSharedMemoryBankConflicts = "
             << options.enableReduceSharedMemoryBankConflicts
             << ", enableReorderWorkgroups = " << options.enableReorderWorkgroups
             << ", enableUkernels = " << options.enableUkernels << "}";

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
@@ -64,6 +64,10 @@ void addGPUPackUnPackPasses(OpPassManager &funcPassManager);
 /// module-level pass manager.
 void addGPUSimpleDistributePassPipeline(OpPassManager &funcPassManager);
 
+/// Lowering config driven pipeline that uses greedy tile + fuse to distribute
+/// to threads.
+void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager);
+
 /// Transform dialect-based path.
 void addGPUTransformDialectPasses(OpPassManager &funcPassManager,
                                   StringRef entryPoint);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLLowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLLowerExecutableTarget.cpp
@@ -5,12 +5,14 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Codegen/Common/PassUtils.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
 #include "iree/compiler/Codegen/LLVMGPU/Passes.h"
 #include "iree/compiler/Codegen/LLVMGPU/ROCDLPassDetail.h"
 #include "iree/compiler/Codegen/LLVMGPU/ROCDLPasses.h"
 #include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
@@ -33,6 +35,7 @@ public:
   void getDependentDialects(DialectRegistry &registry) const override {
     registry
         .insert<IREE::HAL::HALDialect, IREE::LinalgExt::IREELinalgExtDialect,
+                IREE::GPU::IREEGPUDialect, bufferization::BufferizationDialect,
                 gpu::GPUDialect, linalg::LinalgDialect, scf::SCFDialect,
                 tensor::TensorDialect, vector::VectorDialect>();
   }
@@ -61,6 +64,9 @@ public:
       break;
     case CodeGenPipeline::LLVMGPUWarpReduction:
       addGPUWarpReductionPassPipeline(pipeline);
+      break;
+    case CodeGenPipeline::LLVMGPUTileAndFuse:
+      addGPUTileAndFusePassPipeline(pipeline);
       break;
     // If no pipeline specified, then nothing to do.
     case IREE::Codegen::DispatchLoweringPassPipeline::None:

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/BUILD.bazel
@@ -21,6 +21,7 @@ iree_lit_test_suite(
             "config_vector_distribute.mlir",
             "config_user_vector_distribute.mlir",
             "lowering_scalar_dispatch.mlir",
+            "pipeline_tile_and_fuse.mlir",
             "pipeline_vector_distribute.mlir",
             "pipeline_warp_reduction.mlir",
         ],

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
@@ -17,6 +17,7 @@ iree_lit_test_suite(
     "config_user_vector_distribute.mlir"
     "config_vector_distribute.mlir"
     "lowering_scalar_dispatch.mlir"
+    "pipeline_tile_and_fuse.mlir"
     "pipeline_vector_distribute.mlir"
     "pipeline_warp_reduction.mlir"
   TOOLS

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
@@ -1,0 +1,64 @@
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx940 \
+// RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-llvmgpu-lower-executable-target)))))" %s | FileCheck %s
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>
+  ]>
+]>
+#config = #iree_gpu.lowering_config<{workgroup = [64, 64, 0], reduction = [0, 0, 4], thread = [8, 4]}>
+hal.executable public @main {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @matmul_transpose_b ordinal(0) layout(#pipeline_layout)
+    attributes {hal.interface.bindings = [#hal.interface.binding<0, 0>, #hal.interface.binding<0, 1>, #hal.interface.binding<0, 2>]} {
+    ^bb0(%arg0: !hal.device):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_slice
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matmul_transpose_b()
+        attributes {translation_info = #iree_codegen.translation_info<LLVMGPUTileAndFuse workgroup_size = [128, 1, 1] subgroup_size = 64>} {
+        %cst = arith.constant 0.000000e+00 : f16
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2048x1280xf16>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<10240x1280xf16>>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2048x10240xf32>>
+        %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2048, 1280], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<2048x1280xf16>> -> tensor<2048x1280xf16>
+        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [10240, 1280], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<10240x1280xf16>> -> tensor<10240x1280xf16>
+        %5 = tensor.empty() : tensor<2048x10240xf32>
+        %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<2048x10240xf32>) -> tensor<2048x10240xf32>
+        %7 = linalg.matmul_transpose_b {lowering_config = #config}
+          ins(%3, %4 : tensor<2048x1280xf16>, tensor<10240x1280xf16>)
+          outs(%6 : tensor<2048x10240xf32>) -> tensor<2048x10240xf32>
+        flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [2048, 10240], strides = [1, 1] : tensor<2048x10240xf32> -> !flow.dispatch.tensor<writeonly:tensor<2048x10240xf32>>
+        return
+      }
+    }
+  }
+}
+
+// Note that current barrier placement logic is observedly poor. Some cleanup
+// analysis should be able to simplify the below to just two barriers.
+
+// CHECK-LABEL: func @matmul_transpose_b
+//   CHECK-DAG:   %[[B0:.+]] = hal.interface.binding.subspan set(0) binding(0)
+//   CHECK-DAG:   %[[B1:.+]] = hal.interface.binding.subspan set(0) binding(1)
+//   CHECK-DAG:   %[[B2:.+]] = hal.interface.binding.subspan set(0) binding(2)
+//   CHECK-DAG:   memref.alloc() : memref<64x4xf16, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   memref.alloc() : memref<64x4xf16, #gpu.address_space<workgroup>>
+//       CHECK:   %[[LOOP:.+]] = scf.for %[[IV:.+]] = %c0 to %c1280 step %c4 {{.*}} -> (vector<8x4xf32>)
+//       CHECK:     gpu.barrier
+//       CHECK:     %[[LHS_RD:.+]] = vector.transfer_read %[[B0]]{{.*}} vector<2xf16>
+//       CHECK:     vector.transfer_write %[[LHS_RD]], %[[LHS_ALLOC:[A-Za-z0-9]+]]
+//       CHECK:     gpu.barrier
+//       CHECK:     %[[LHS_MM:.+]] = vector.transfer_read %[[LHS_ALLOC]]{{.*}} vector<8x4xf16>
+//       CHECK:     gpu.barrier
+//       CHECK:     %[[RHS_RD:.+]] = vector.transfer_read %[[B1]]{{.*}} vector<2xf16>
+//       CHECK:     vector.transfer_write %[[RHS_RD]], %[[RHS_ALLOC:[A-Za-z0-9]+]]
+//       CHECK:     gpu.barrier
+//       CHECK:     %[[RHS_MM:.+]] = vector.transfer_read %[[RHS_ALLOC]]{{.*}} vector<4x4xf16>
+//       CHECK:     gpu.barrier
+//       CHECK:     %[[MM:.+]] = vector.contract {{.*}} %[[LHS_MM]], %[[RHS_MM]]
+//       CHECK:     scf.yield %[[MM]]
+//       CHECK:   vector.transfer_write %[[LOOP]], %[[B2]]


### PR DESCRIPTION
This adds a pass pipeline based around recently added patterns to fuse and hoist scf.forall loops. The core idea of this pipeline is aimed at the requirements for matmul and convolution where they are tiled to a serial loop and then the tiles of the operands are copied first to a shared memory allocation, then loaded in the layout needed for the GEMM. This requires shared tiling for the reduction loop (tile + fuse), however tiling the input copies (or potential fused producers) requires different thread tiling for the matmul and the input operands. This pass pipeline addresses this issue by doing such tiling independently and then fusing the resulting loops together.

The remaining TODOs for this pipeline are:
1. Distribution/fusion of consumers with the thread tiled matmul forall.
2. Adding a kernel config logic for the pipeline (matmul and conv).
3. Passes for packing matmuls to MMA intrinsic shapes and then tiling
   + distributing to intrinsics. This may require a tiling interface implementation for `iree_gpu.multi_mma`.
4. Fix an issue related to `iree_gpu.shuffle_tensor` and bufferization that currently is relying on the bufferization allocation function to pick the correct memory space.
5. Add img2col to this pass to allow doing convolutions with implicit gemm. 5a. Generalize the upstream img2col pass to enable more conv-like generics.
6. Add multibuffering/pipelining passes and make them configurable (ideally coming from attributes on lowering configs added to loops when tiling).