### PR TITLE
Disable a100 benchmarks until the runner has gcloud.

### DIFF
--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -154,6 +154,8 @@ DEFAULT_BENCHMARK_PRESET_GROUP = [
     for preset in benchmark_presets.DEFAULT_PRESETS
     # RISC-V benchmarks haven't been supported in CI workflow.
     if preset not in [benchmark_presets.RISCV]
+    # CUDA benchmarks on CI depend on unreliable a100 runners.
+    and preset not in [benchmark_presets.CUDA]
 ] + ["comp-stats"]
 DEFAULT_BENCHMARK_PRESET = "default"
 LARGE_BENCHMARK_PRESET_GROUP = benchmark_presets.LARGE_PRESETS


### PR DESCRIPTION
https://github.com/iree-org/iree/actions/runs/9370478419/job/25798437507#step:5:18
```
Run gcloud storage cp "${BENCHMARK_TOOLS_GCS_ARTIFACT}" "${BENCHMARK_TOOLS_ARCHIVE}"
/runner-root/actions-runner/_work/_temp/1dbef82c-d53f-40bb-8879-38f4ffd53cf4.sh: line 1: gcloud: command not found
```

skip-ci: no use testing on presubmit