### PR TITLE
Fix conversion of pathlib.Path to str

### DIFF
--- a/compiler/bindings/python/iree/compiler/tools/import_onnx/__main__.py
+++ b/compiler/bindings/python/iree/compiler/tools/import_onnx/__main__.py
@@ -69,7 +69,7 @@ def load_onnx_model(args: argparse.Namespace) -> onnx.ModelProto:
         raw_model = onnx.load(args.input_file)
     else:
         raw_model = onnx.load(args.input_file, load_external_data=False)
-        onnx.load_external_data_for_model(raw_model, args.data_dir)
+        onnx.load_external_data_for_model(raw_model, str(args.data_dir))
 
     # Do shape inference two ways.  First, attempt in-memory to avoid redundant
     # loading and the need for writing a temporary file somewhere.  If that
@@ -104,7 +104,7 @@ def load_onnx_model(args: argparse.Namespace) -> onnx.ModelProto:
         # Load the temp file and the external data.
         inferred_model = onnx.load(temp_inferred_file, load_external_data=False)
         data_dir = Path(input_dir if args.data_dir is None else args.data_dir)
-        onnx.load_external_data_for_model(inferred_model, data_dir)
+        onnx.load_external_data_for_model(inferred_model, str(data_dir))
 
         return inferred_model
 


### PR DESCRIPTION
This fixes the error shown in [0] that I see when trying to import a big model.


[0] 

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/code/iree/build/compiler/bindings/python/iree/compiler/tools/import_onnx/__main__.py", line 144, in <module>
    _cli_main()
  File "/code/iree/build/compiler/bindings/python/iree/compiler/tools/import_onnx/__main__.py", line 140, in _cli_main
    sys.exit(main(parse_arguments()))
  File "/code/iree/build/compiler/bindings/python/iree/compiler/tools/import_onnx/__main__.py", line 44, in main
    model_proto = load_onnx_model(args)
  File "/code/iree/build/compiler/bindings/python/iree/compiler/tools/import_onnx/__main__.py", line 107, in load_onnx_model
    onnx.load_external_data_for_model(inferred_model, data_dir)
  File "/code/iree/.venv/lib/python3.10/site-packages/onnx/external_data_helper.py", line 65, in load_external_data_for_model
    load_external_data_for_tensor(tensor, base_dir)
  File "/code/iree/.venv/lib/python3.10/site-packages/onnx/external_data_helper.py", line 43, in load_external_data_for_tensor
    external_data_file_path = c_checker._resolve_external_data_location(  # type: ignore[attr-defined]
TypeError: _resolve_external_data_location(): incompatible function arguments. The following argument types are supported:
    1. (arg0: str, arg1: str, arg2: str) -> str
```