### PR TITLE
Enable magiclink extension for mkdocs, linkifying bare URLs.

### DIFF
--- a/docs/website/docs/developers/performance/benchmark-suites.md
+++ b/docs/website/docs/developers/performance/benchmark-suites.md
@@ -93,9 +93,6 @@ cmake --build "${IREE_BUILD_DIR?}" --target \
 export E2E_TEST_ARTIFACTS_DIR="${IREE_BUILD_DIR?}/e2e_test_artifacts"
 ```
 
-> TODO(#13683): Each preset should have its own target to further reduce
-> unnecessary builds
-
 ### Run benchmarks
 
 Export the execution benchmark config:

--- a/docs/website/mkdocs.yml
+++ b/docs/website/mkdocs.yml
@@ -92,7 +92,10 @@ markdown_extensions:
           - overrides/.icons
   # Support for bare URLs, see https://github.com/mkdocs/mkdocs/issues/1711.
   # https://facelessuser.github.io/pymdown-extensions/extensions/magiclink/
-  - pymdownx.magiclink
+  - pymdownx.magiclink:
+      user: iree-org
+      repo: iree
+      repo_url_shorthand: true
   # Support for embedding external files (e.g. source code samples) via snippets
   # https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#embedding-external-files
   - pymdownx.snippets:

--- a/docs/website/mkdocs.yml
+++ b/docs/website/mkdocs.yml
@@ -90,6 +90,9 @@ markdown_extensions:
       options:
         custom_icons:
           - overrides/.icons
+  # Support for bare URLs, see https://github.com/mkdocs/mkdocs/issues/1711.
+  # https://facelessuser.github.io/pymdown-extensions/extensions/magiclink/
+  - pymdownx.magiclink
   # Support for embedding external files (e.g. source code samples) via snippets
   # https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#embedding-external-files
   - pymdownx.snippets:


### PR DESCRIPTION
We have some bare URLs in places like https://iree.dev/reference/mlir-dialects/HAL/#haldevicequery-haldevicequeryop . For those to be turned into hyperlinks, we can either wrap them in `<>` in the tablegen source or use an extension like this.

Before:
![image](https://github.com/iree-org/iree/assets/4010439/e412ec2b-3998-426c-b167-bba10ca72f42)
After: 
![image](https://github.com/iree-org/iree/assets/4010439/4fcfe765-2c9c-4640-ad40-409fc3450dc7)

Pages with markdown sources (and not pages generated from tablegen like those) are already using markdownlint's "no-bare-urls" rule: https://github.com/DavidAnson/markdownlint/blob/main/doc/md034.md