### PR TITLE
Update internal time library to allow user defined now function

### DIFF
--- a/runtime/src/iree/base/internal/time.c
+++ b/runtime/src/iree/base/internal/time.c
@@ -8,6 +8,7 @@
 
 #include <time.h>
 
+#include "iree/base/config.h"
 #include "iree/base/target_platform.h"
 
 int64_t iree_platform_time_now(void) {


### PR DESCRIPTION
iree/base/config.h allows the user to define IREE_TIME_NOW_FN. Reinstate the configurability after https://github.com/iree-org/iree/pull/17493