### PR TITLE
[cuda][hip] Fix a resource leak when using deferred command buffers.

### DIFF
--- a/runtime/src/iree/hal/drivers/cuda/pending_queue_actions.c
+++ b/runtime/src/iree/hal/drivers/cuda/pending_queue_actions.c
@@ -742,6 +742,10 @@ static iree_status_t iree_hal_cuda_pending_queue_actions_issue_execution(
           z0, iree_hal_deferred_command_buffer_apply(
                   command_buffer, stream_command_buffer,
                   iree_hal_buffer_binding_table_empty()));
+      // The stream_command_buffer is going to be retained by
+      // the action->resource_set and deleted after the action
+      // completes.
+      iree_hal_resource_release(stream_command_buffer);
     }
   }
   IREE_TRACE_ZONE_END(dispatch_command_buffers);

--- a/runtime/src/iree/hal/drivers/hip/pending_queue_actions.c
+++ b/runtime/src/iree/hal/drivers/hip/pending_queue_actions.c
@@ -747,6 +747,10 @@ static iree_status_t iree_hal_hip_pending_queue_actions_issue_execution(
           z0, iree_hal_deferred_command_buffer_apply(
                   command_buffer, stream_command_buffer,
                   iree_hal_buffer_binding_table_empty()));
+      // The stream_command_buffer is going to be retained by
+      // the action->resource_set and deleted after the action
+      // completes.
+      iree_hal_resource_release(stream_command_buffer);
     }
   }
   IREE_TRACE_ZONE_END(dispatch_command_buffers);


### PR DESCRIPTION
The stream_command_buffer that is created when applying deferred_commands is never properly freed, as we never release it after adding it to the resource set.