### PR TITLE
Clean up redundant VectorOp::Kind checks after generalization.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/AMDGPUDistributeContract.cpp
@@ -67,9 +67,6 @@ struct DistributeContract final : OpDistributionPattern<vector::ContractionOp> {
 
     // Infer the contract kind so that we know know to correlate M/N/K dims.
     VectorContractOpInfo opDetail(contractOp);
-    if (opDetail.getOpKind() == VectorContractOpInfo::OpKind::UNKNOWN) {
-      return rewriter.notifyMatchFailure(contractOp, "unknown contract kind");
-    }
 
     SmallVector<int64_t> distShape = resultLayout.getDistributedShape();
     LLVM_DEBUG({

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -832,10 +832,6 @@ MMAScheduleAttr::getContractionLayout(vector::ContractionOp contractOp) const {
     llvm::errs() << "Getting mma layouts for:\n" << contractOp << "\n";
     llvm::errs() << "For schedule: " << *this << "\n";
   });
-  if (opInfo.getOpKind() == VectorContractOpInfo::OpKind::UNKNOWN) {
-    LLVM_DEBUG({ llvm::errs() << "Unknown contraction kind\n"; });
-    return failure();
-  }
 
   auto mmaAttr = llvm::cast<MMAAttr>(getIntrinsic());
   MLIRContext *context = getContext();


### PR DESCRIPTION
After generalization (through usage of opDetail.getOperandKIndex, opDetail.lhsMDims, opDetail.getOperandMNIndex, etc) , we are now able to handle any type of contraction, so long as they are valid contractions with proper indexing maps without relying on types that are recorded within VectorContractOpInfo::OpKind.

However, some of these asserts still lives on unnecesarily, blocking vector distribution in cases such as A.T * B, as seen on https://github.com/iree-org/iree/issues/17585