### PR TITLE
Add lowering for iree_attention custom op

### DIFF
--- a/compiler/plugins/input/StableHLO/Conversion/test/stablehlo_custom_calls.mlir
+++ b/compiler/plugins/input/StableHLO/Conversion/test/stablehlo_custom_calls.mlir
@@ -10,3 +10,10 @@ func.func public @householder(%arg0: tensor<4x3xf32>, %arg1: tensor<2xf32>) -> (
   %0 = stablehlo.custom_call @ProductOfElementaryHouseholderReflectors(%arg0, %arg1) : (tensor<4x3xf32>, tensor<2xf32>) -> tensor<4x3xf32>
   return %0 : tensor<4x3xf32>
 }
+
+// CHECK-LABEL: @attention
+func.func public @attention(%query: tensor<1x3x4xf32>, %key: tensor<1x3x4xf32>, %value: tensor<1x3x4xf32>, %scale: tensor<f32>) -> (tensor<1x3x4xf32>) {
+  // CHECK: linalg_ext.attention
+  %0 = stablehlo.custom_call @iree_attention(%query, %key, %value, %scale) {api_version = 2 : i32, transpose_v = false} : (tensor<1x3x4xf32>, tensor<1x3x4xf32>, tensor<1x3x4xf32>, tensor<f32>) -> tensor<1x3x4xf32>
+  return %0 : tensor<1x3x4xf32>
+}


### PR DESCRIPTION
This PR is a follow-up for [this PR](https://github.com/iree-org/iree-jax/pull/81) in IREE-Jax in an effort to introduce a custom StableHLO attention op which lowers to the  linalg_ext version.