### PR TITLE
Skip tests failing on latest GitHub Actions runner image.

### DIFF
--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -123,6 +123,21 @@ if [[ "${OSTYPE}" =~ ^msys ]]; then
     "iree/tests/e2e/tensor_ops/check_vmvx_ukernel_local-task_unpack.mlir"
     # TODO(#11070): Fix argument/result signature mismatch
     "iree/tests/e2e/tosa_ops/check_vmvx_local-sync_microkernels_fully_connected.mlir"
+
+    # These are failing on GitHub's windows-2022 standard runners, version
+    # 20240603.1.0 see https://github.com/actions/runner-images/issues/10004.
+    "iree/base/internal/fpu_state_benchmark_test"
+    "iree/base/internal/synchronization_benchmark_test"
+    "iree/builtins/device/tools/libdevice_benchmark_test"
+    "iree/builtins/ukernel/tools/mmt4d_benchmark_test"
+    "iree/builtins/ukernel/tools/pack_benchmark_test"
+    "iree/builtins/ukernel/tools/unpack_benchmark_test"
+    "iree/builtins/ukernel/tools/e2e_matmul_benchmark_test"
+    "iree/hal/local/executable_library_benchmark_test"
+    "iree/hal/utils/libmpi_test"
+    "iree/hal/utils/resource_set_benchmark_test"
+    "iree/modules/check/check_test"
+    "iree/vm/native_module_benchmark_test"
   )
 elif [[ "${OSTYPE}" =~ ^darwin ]]; then
   excluded_tests+=(


### PR DESCRIPTION
Workaround for https://github.com/actions/runner-images/issues/10004

Sample logs: https://github.com/iree-org/iree/actions/runs/9405933668/job/25908232614 . Segfaults for various tests:
```
103/504 Test  #137: iree/vm/native_module_benchmark_test ........***Exception: SegFault  0.02 sec
```

ci-exactly: build_test_runtime