### PR TITLE
Optimize bazel_to_cmake and check_path_lengths pre-commit hooks.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,8 +98,8 @@ repos:
         name: Run check_path_lengths.py
         language: python
         entry: ./build_tools/scripts/check_path_lengths.py
-        always_run: true
         pass_filenames: false
+        files: '^compiler/(.*/)$'
 
     -   id: build_file_names
         name: Check Bazel file names

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,14 +92,14 @@ repos:
         # Keep the top level directories here in sync with .bazel_to_cmake.cfg.py.
         files: '^(compiler|runtime|samples|tests|tools)/(.*/)?(BUILD\.bazel|CMakeLists.txt)$'
 
-    # TODO(scotttodd): replace with an official pre-commit hook?
-    #   See https://github.com/pre-commit/pre-commit-hooks/issues/760
     -   id: check_path_lengths
-        name: Run check_path_lengths.py
-        language: python
-        entry: ./build_tools/scripts/check_path_lengths.py
-        pass_filenames: false
-        files: '^compiler/(.*/)$'
+        name: Check for excessively long path lengths
+        language: fail
+        entry: Path lengths relative to the root should be < 75 characters (run ./build_tools/scripts/check_path_lengths.py for detailed output)
+        # The regex includes/excludes here should roughly match the behavior of
+        # the check_path_lengths.py script.
+        files: '^compiler/.{66,}/\w+\.'
+        exclude: 'test/'
 
     -   id: build_file_names
         name: Check Bazel file names

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,10 +86,11 @@ repos:
     -   id: bazel_to_cmake
         name: Run bazel_to_cmake.py
         language: python
+        # Note: this passes file names to the tool. The tool can also be run
+        # manually with no arguments specified to walk directories on its own.
         entry: ./build_tools/bazel_to_cmake/bazel_to_cmake.py
-        # TODO(scotttodd): run on BUILD.bazel/CMakeLists.txt files individually
-        always_run: true
-        pass_filenames: false
+        # Keep the top level directories here in sync with .bazel_to_cmake.cfg.py.
+        files: '^(compiler|runtime|samples|tests|tools)/(.*/)?(BUILD\.bazel|CMakeLists.txt)$'
 
     # TODO(scotttodd): replace with an official pre-commit hook?
     #   See https://github.com/pre-commit/pre-commit-hooks/issues/760


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree/issues/17430. With these optimizations, the git hook is much faster to run, since unrelated file changes will no longer trigger directory walks for these hooks.

* Taught `bazel_to_cmake.py` to accept positional arguments (paths to `BUILD.bazel` and/or `CMakeLists.txt` files)
* Switched `bazel_to_cmake` pre-commit hook to use the new positional arguments on only changed files
* Replaced `build_tools/scripts/check_path_lengths.py` hook entry with a regex. The script will stick around since it provides a better debug experience.
  
  Output for this check looks like this after lowering the limit:

    ```
    λ pre-commit run --all-files check_path_lengths
    Check for excessively long path lengths..................................Failed
    - hook id: check_path_lengths
    - exit code: 1
    
    Path lengths relative to the root should be < 75 characters (run ./build_tools/scripts/check_path_lengths.py for detailed output)
    
    compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/StreamToHALInline/BUILD.bazel
    compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/StreamToHALInline/CMakeLists.txt
    compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/StreamToHALInline/Patterns.cpp
    compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/StreamToHALInline/Patterns.h
    compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/BUILD.bazel
    compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/CMakeLists.txt
    compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/Patterns.cpp
    compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/Patterns.h
    compiler/src/iree/compiler/Modules/IO/Parameters/Conversion/StreamToParams/BUILD.bazel
    compiler/src/iree/compiler/Modules/IO/Parameters/Conversion/StreamToParams/CMakeLists.txt
    compiler/src/iree/compiler/Modules/IO/Parameters/Conversion/StreamToParams/Patterns.cpp
    compiler/src/iree/compiler/Modules/IO/Parameters/Conversion/StreamToParams/Patterns.h
    ```

skip-ci: lint-only change