### PR TITLE
[EmitC][NFC] Use builder with default arguments for opaque_call ops

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -249,12 +249,11 @@ createVmTypeDefPtr(ConversionPatternRewriter &rewriter, Location loc,
             .create<emitc::CallOpaqueOp>(
                 /*location=*/loc,
                 /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_type_def_t"),
-                /*callee=*/StringAttr::get(ctx, "iree_vm_make_value_type_def"),
+                /*callee=*/"iree_vm_make_value_type_def",
+                /*operands=*/ArrayRef<Value>{},
                 /*args=*/
                 ArrayAttr::get(
-                    ctx, {emitc::OpaqueAttr::get(ctx, ptr->second.first)}),
-                /*templateArgs=*/ArrayAttr{},
-                /*operands=*/ArrayRef<Value>{})
+                    ctx, {emitc::OpaqueAttr::get(ctx, ptr->second.first)}))
             .getResult(0);
   } else if (llvm::isa<IREE::VM::RefType>(elementType)) {
     Type objType = llvm::cast<IREE::VM::RefType>(elementType).getObjectType();
@@ -277,9 +276,7 @@ createVmTypeDefPtr(ConversionPatternRewriter &rewriter, Location loc,
             .create<emitc::CallOpaqueOp>(
                 /*location=*/loc,
                 /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_type_def_t"),
-                /*callee=*/StringAttr::get(ctx, "iree_vm_make_ref_type_def"),
-                /*args=*/ArrayAttr{},
-                /*templateArgs=*/ArrayAttr{},
+                /*callee=*/"iree_vm_make_ref_type_def",
                 /*operands=*/ArrayRef<Value>{refType})
             .getResult(0);
   } else if (llvm::isa<IREE::VM::OpaqueType>(elementType)) {
@@ -288,10 +285,7 @@ createVmTypeDefPtr(ConversionPatternRewriter &rewriter, Location loc,
             .create<emitc::CallOpaqueOp>(
                 /*location=*/loc,
                 /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_type_def_t"),
-                /*callee=*/
-                StringAttr::get(ctx, "iree_vm_make_undefined_type_def"),
-                /*args=*/ArrayAttr{},
-                /*templateArgs=*/ArrayAttr{},
+                /*callee=*/"iree_vm_make_undefined_type_def",
                 /*operands=*/ArrayRef<Value>{})
             .getResult(0);
   }
@@ -330,9 +324,7 @@ LogicalResult retainOrMoveRefs(OpBuilder &builder, Location location,
     builder.create<emitc::CallOpaqueOp>(
         /*location=*/location,
         /*type=*/TypeRange{},
-        /*callee=*/StringAttr::get(ctx, callee),
-        /*args=*/ArrayAttr{},
-        /*templateArgs=*/ArrayAttr{},
+        /*callee=*/callee,
         /*operands=*/ArrayRef<Value>{srcRef, tmpPtr});
 
     tmpMapping.map(srcRef, tmpPtr);
@@ -346,9 +338,7 @@ LogicalResult retainOrMoveRefs(OpBuilder &builder, Location location,
     builder.create<emitc::CallOpaqueOp>(
         /*location=*/location,
         /*type=*/TypeRange{},
-        /*callee=*/StringAttr::get(ctx, callee),
-        /*args=*/ArrayAttr{},
-        /*templateArgs=*/ArrayAttr{},
+        /*callee=*/callee,
         /*operands=*/ArrayRef<Value>{tmpRef, destRef});
   }
 
@@ -395,7 +385,7 @@ void releaseRefs(OpBuilder &builder, Location location,
 /// value, i.e. a truthy value branches to the continuation block when
 /// `negateCondition` is false.
 emitc::CallOpaqueOp failableCall(
-    OpBuilder &builder, Location location, Type type, StringAttr callee,
+    OpBuilder &builder, Location location, Type type, StringRef callee,
     ArrayAttr args, ArrayRef<Value> operands,
     const std::function<void(emitc::CallOpaqueOp &)> &failureBlockBuilder,
     bool negateCondition = false) {
@@ -403,9 +393,8 @@ emitc::CallOpaqueOp failableCall(
       /*location=*/location,
       /*type=*/type,
       /*callee=*/callee,
-      /*args=*/args,
-      /*templateArgs=*/ArrayAttr{},
-      /*operands=*/operands);
+      /*operands=*/operands,
+      /*args=*/args);
 
   Type boolType = builder.getIntegerType(1);
 
@@ -442,7 +431,7 @@ emitc::CallOpaqueOp failableCall(
 }
 
 emitc::CallOpaqueOp returnIfError(OpBuilder &builder, Location location,
-                                  StringAttr callee, ArrayAttr args,
+                                  StringRef callee, ArrayAttr args,
                                   ArrayRef<Value> operands,
                                   IREE::VM::ModuleAnalysis &moduleAnalysis) {
   auto blockBuilder = [&builder, &location,
@@ -464,7 +453,7 @@ emitc::CallOpaqueOp returnIfError(OpBuilder &builder, Location location,
 
 emitc::CallOpaqueOp
 failContainerNull(OpBuilder &builder, Location location, Type type,
-                  StringAttr callee, ArrayAttr args, ArrayRef<Value> operands,
+                  StringRef callee, ArrayAttr args, ArrayRef<Value> operands,
                   IREE::VM::ModuleAnalysis &moduleAnalysis) {
   auto blockBuilder = [&builder, &location,
                        &moduleAnalysis](emitc::CallOpaqueOp &callOp) {
@@ -479,12 +468,11 @@ failContainerNull(OpBuilder &builder, Location location, Type type,
     auto statusOp = builder.create<emitc::CallOpaqueOp>(
         /*location=*/location,
         /*type=*/emitc::OpaqueType::get(ctx, "iree_status_t"),
-        /*callee=*/StringAttr::get(ctx, "iree_make_status"),
+        /*callee=*/"iree_make_status",
+        /*operands=*/ArrayRef<Value>{},
         /*args=*/
-        ArrayAttr::get(
-            ctx, {emitc::OpaqueAttr::get(ctx, "IREE_STATUS_INVALID_ARGUMENT")}),
-        /*templateArgs=*/ArrayAttr{},
-        /*operands=*/ArrayRef<Value>{});
+        ArrayAttr::get(ctx, {emitc::OpaqueAttr::get(
+                                ctx, "IREE_STATUS_INVALID_ARGUMENT")}));
 
     builder.create<mlir::emitc::ReturnOp>(location, statusOp.getResult(0));
   };
@@ -610,9 +598,7 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
     builder.create<emitc::CallOpaqueOp>(
         /*location=*/loc,
         /*type=*/TypeRange{},
-        /*callee=*/StringAttr::get(ctx, "iree_allocator_free"),
-        /*args=*/ArrayAttr{},
-        /*templateArgs=*/ArrayAttr{},
+        /*callee=*/"iree_allocator_free",
         /*operands=*/ArrayRef<Value>{allocatorOp, castedModuleOp.getResult()});
 
     builder.create<mlir::emitc::ReturnOp>(loc, nullptr);
@@ -671,8 +657,8 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
             emitc::PointerType::get(emitc::OpaqueType::get(ctx, "void"))),
         /*operand=*/statePtr);
 
-    returnIfError(builder, loc, StringAttr::get(ctx, "iree_allocator_malloc"),
-                  {}, {allocatorArg, stateSize, voidPtr.getResult()},
+    returnIfError(builder, loc, "iree_allocator_malloc", {},
+                  {allocatorArg, stateSize, voidPtr.getResult()},
                   moduleAnalysis);
 
     emitc_builders::memset(builder, loc, state, 0, stateSize);
@@ -704,20 +690,14 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
       auto byteSpan = builder.create<emitc::CallOpaqueOp>(
           /*location=*/loc,
           /*type=*/emitc::OpaqueType::get(ctx, "iree_byte_span_t"),
-          /*callee=*/StringAttr::get(ctx, "iree_make_byte_span"),
-          /*args=*/ArrayAttr{},
-          /*templateArgs=*/ArrayAttr{},
-          /*operands=*/
-          ArrayRef<Value>{bufferVoid.getResult(), bufferSize});
+          /*callee=*/"iree_make_byte_span",
+          /*operands=*/ArrayRef<Value>{bufferVoid.getResult(), bufferSize});
 
       auto allocator = builder.create<emitc::CallOpaqueOp>(
           /*location=*/loc,
           /*type=*/emitc::OpaqueType::get(ctx, "iree_allocator_t"),
-          /*callee=*/StringAttr::get(ctx, "iree_allocator_null"),
-          /*args=*/ArrayAttr{},
-          /*templateArgs=*/ArrayAttr{},
-          /*operands=*/
-          ArrayRef<Value>{});
+          /*callee=*/"iree_allocator_null",
+          /*operands=*/ArrayRef<Value>{});
 
       auto buffers = emitc_builders::structPtrMember(
           builder, loc,
@@ -738,16 +718,15 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
       builder.create<emitc::CallOpaqueOp>(
           /*location=*/loc,
           /*type=*/TypeRange{},
-          /*callee=*/StringAttr::get(ctx, "iree_vm_buffer_initialize"),
+          /*callee=*/"iree_vm_buffer_initialize",
+          /*operands=*/
+          ArrayRef<Value>{byteSpan.getResult(0), allocator.getResult(0),
+                          buffer},
           /*args=*/
           ArrayAttr::get(ctx, {emitc::OpaqueAttr::get(
                                    ctx, "IREE_VM_BUFFER_ACCESS_ORIGIN_MODULE"),
                                builder.getIndexAttr(0), builder.getIndexAttr(1),
-                               builder.getIndexAttr(2)}),
-          /*templateArgs=*/ArrayAttr{},
-          /*operands=*/
-          ArrayRef<Value>{byteSpan.getResult(0), allocator.getResult(0),
-                          buffer});
+                               builder.getIndexAttr(2)}));
     }
 
     // Zero out refs from state struct.
@@ -792,11 +771,8 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
     builder.create<emitc::CallOpaqueOp>(
         /*location=*/loc,
         /*type=*/TypeRange{},
-        /*callee=*/StringAttr::get(ctx, "EMITC_DEREF_ASSIGN_VALUE"),
-        /*args=*/ArrayAttr{},
-        /*templateArgs=*/ArrayAttr{},
-        /*operands=*/
-        ArrayRef<Value>{moduleStateArg, baseStateOp.getResult()});
+        /*callee=*/"EMITC_DEREF_ASSIGN_VALUE",
+        /*operands=*/ArrayRef<Value>{moduleStateArg, baseStateOp.getResult()});
 
     auto status = emitc_builders::ireeOkStatus(builder, loc);
 
@@ -880,11 +856,8 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
     builder.create<emitc::CallOpaqueOp>(
         /*location=*/loc,
         /*type=*/TypeRange{},
-        /*callee=*/StringAttr::get(ctx, "iree_allocator_free"),
-        /*args=*/ArrayAttr{},
-        /*templateArgs=*/ArrayAttr{},
-        /*operands=*/
-        ArrayRef<Value>{allocatorOp, stateOp.getResult()});
+        /*callee=*/"iree_allocator_free",
+        /*operands=*/ArrayRef<Value>{allocatorOp, stateOp.getResult()});
 
     builder.create<mlir::emitc::ReturnOp>(loc, nullptr);
   }
@@ -961,11 +934,8 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
     builder.create<emitc::CallOpaqueOp>(
         /*location=*/loc,
         /*type=*/TypeRange{},
-        /*callee=*/StringAttr::get(ctx, "EMITC_DEREF_ASSIGN_PTR"),
-        /*args=*/ArrayAttr{},
-        /*templateArgs=*/ArrayAttr{},
-        /*operands=*/
-        ArrayRef<Value>{import, functionArg});
+        /*callee=*/"EMITC_DEREF_ASSIGN_PTR",
+        /*operands=*/ArrayRef<Value>{import, functionArg});
 
     auto status = emitc_builders::ireeOkStatus(builder, loc);
 
@@ -1033,8 +1003,8 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
             emitc::PointerType::get(emitc::OpaqueType::get(ctx, "void"))),
         /*operand=*/modulePtr);
 
-    returnIfError(builder, loc, StringAttr::get(ctx, "iree_allocator_malloc"),
-                  {}, {allocatorArg, moduleSize, voidPtr.getResult()},
+    returnIfError(builder, loc, "iree_allocator_malloc", {},
+                  {allocatorArg, moduleSize, voidPtr.getResult()},
                   moduleAnalysis);
 
     emitc_builders::memset(builder, loc, module, 0, moduleSize);
@@ -1081,22 +1051,16 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
     auto vmInitializeStatus = builder.create<emitc::CallOpaqueOp>(
         /*location=*/loc,
         /*type=*/emitc::OpaqueType::get(ctx, "iree_status_t"),
-        /*callee=*/StringAttr::get(ctx, "iree_vm_module_initialize"),
-        /*args=*/ArrayAttr{},
-        /*templateArgs=*/ArrayAttr{},
-        /*operands=*/
-        ArrayRef<Value>{vmModulePtr, module});
+        /*callee=*/"iree_vm_module_initialize",
+        /*operands=*/ArrayRef<Value>{vmModulePtr, module});
 
     Type boolType = builder.getIntegerType(1);
 
     auto vmInitializeIsOk = builder.create<emitc::CallOpaqueOp>(
         /*location=*/loc,
         /*type=*/boolType,
-        /*callee=*/StringAttr::get(ctx, "iree_status_is_ok"),
-        /*args=*/ArrayAttr{},
-        /*templateArgs=*/ArrayAttr{},
-        /*operands=*/
-        ArrayRef<Value>{vmInitializeStatus.getResult(0)});
+        /*callee=*/"iree_status_is_ok",
+        /*operands=*/ArrayRef<Value>{vmInitializeStatus.getResult(0)});
 
     // Start by splitting the block into two. The part before will contain the
     // condition, and the part after will contain the continuation point.
@@ -1114,11 +1078,8 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
       builder.create<emitc::CallOpaqueOp>(
           /*location=*/loc,
           /*type=*/TypeRange{},
-          /*callee=*/StringAttr::get(ctx, "iree_allocator_free"),
-          /*args=*/ArrayAttr{},
-          /*templateArgs=*/ArrayAttr{},
-          /*operands=*/
-          ArrayRef<Value>{allocatorArg, module});
+          /*callee=*/"iree_allocator_free",
+          /*operands=*/ArrayRef<Value>{allocatorArg, module});
 
       builder.create<mlir::emitc::ReturnOp>(loc,
                                             vmInitializeStatus.getResult(0));
@@ -1145,15 +1106,14 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
     auto status = builder.create<emitc::CallOpaqueOp>(
         /*location=*/loc,
         /*type=*/emitc::OpaqueType::get(ctx, "iree_status_t"),
-        /*callee=*/StringAttr::get(ctx, "iree_vm_native_module_create"),
+        /*callee=*/"iree_vm_native_module_create",
+        /*operands=*/
+        ArrayRef<Value>{vmModulePtr, instanceArg, allocatorArg, moduleArg},
         /*args=*/
         ArrayAttr::get(ctx, {builder.getIndexAttr(0),
                              emitc::OpaqueAttr::get(ctx, descriptorPtr),
                              builder.getIndexAttr(1), builder.getIndexAttr(2),
-                             builder.getIndexAttr(3)}),
-        /*templateArgs=*/ArrayAttr{},
-        /*operands=*/
-        ArrayRef<Value>{vmModulePtr, instanceArg, allocatorArg, moduleArg});
+                             builder.getIndexAttr(3)}));
 
     builder.create<mlir::emitc::ReturnOp>(loc, status.getResult(0));
   }
@@ -1548,30 +1508,30 @@ private:
                   ConversionPatternRewriter &rewriter) const override {
     auto ctx = op.getContext();
 
-    auto type = op.getOperation()->getResultTypes();
-    StringAttr callee = StringAttr::get(ctx, funcName);
-
     // Default to an empty args attribute, which results in the operands being
     // printed as the arguments to the function call.
-    ArrayAttr args;
-    ArrayAttr templateArgs;
+    SmallVector<Attribute> args_;
 
     // If the operation has attributes, we need to explicitely build the args
     // attribute of the emitc opaque_call op. This consists of index attributes
     // for the operands, followed by the source op attributes themselves.
     if (op->getAttrs().size() > 0) {
-      SmallVector<Attribute> args_ =
-          indexSequence(adaptor.getOperands().size(), op.getContext());
+      args_ = indexSequence(adaptor.getOperands().size(), op.getContext());
 
       for (NamedAttribute attr : op->getAttrs()) {
         args_.push_back(attr.getValue());
       }
-
-      args = rewriter.getArrayAttr(args_);
     }
 
+    ArrayAttr args =
+        args_.size() > 0 ? ArrayAttr::get(ctx, args_) : ArrayAttr{};
+
     rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-        op, type, callee, args, templateArgs, adaptor.getOperands());
+        /*op=*/op,
+        /*type=*/op.getOperation()->getResultTypes(),
+        /*callee=*/funcName,
+        /*operands=*/adaptor.getOperands(),
+        /*args=*/args);
 
     return success();
   }
@@ -1956,18 +1916,15 @@ class ExportOpConversion : public EmitCConversionPattern<IREE::VM::ExportOp> {
         auto memberPtr = rewriter.create<emitc::CallOpaqueOp>(
             /*location=*/loc,
             /*type=*/ptrType,
-            /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_PTR_MEMBER_ADDRESS"),
+            /*callee=*/"EMITC_STRUCT_PTR_MEMBER_ADDRESS",
+            /*operands=*/ArrayRef<Value>{value},
             /*args=*/
             ArrayAttr::get(ctx, {rewriter.getIndexAttr(0),
-                                 emitc::OpaqueAttr::get(ctx, memberName)}),
-            /*templateArgs=*/ArrayAttr{},
-            /*operands=*/ArrayRef<Value>{value});
+                                 emitc::OpaqueAttr::get(ctx, memberName)}));
         rewriter.create<emitc::CallOpaqueOp>(
             /*location=*/memberPtr.getLoc(),
             /*type=*/TypeRange{},
-            /*callee=*/StringAttr::get(ctx, "iree_vm_ref_retain_inplace"),
-            /*args=*/ArrayAttr{},
-            /*templateArgs=*/ArrayAttr{},
+            /*callee=*/"iree_vm_ref_retain_inplace",
             /*operands=*/ArrayRef<Value>{memberPtr.getResult(0)});
         argumentStruct.callArguments.push_back(memberPtr.getResult(0));
       } else {
@@ -2015,12 +1972,11 @@ class ExportOpConversion : public EmitCConversionPattern<IREE::VM::ExportOp> {
       auto memberPtr = rewriter.create<emitc::CallOpaqueOp>(
           /*location=*/loc,
           /*type=*/ptrType,
-          /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_PTR_MEMBER_ADDRESS"),
+          /*callee=*/"EMITC_STRUCT_PTR_MEMBER_ADDRESS",
+          /*operands=*/ArrayRef<Value>{value},
           /*args=*/
           ArrayAttr::get(ctx, {rewriter.getIndexAttr(0),
-                               emitc::OpaqueAttr::get(ctx, memberName)}),
-          /*templateArgs=*/ArrayAttr{},
-          /*operands=*/ArrayRef<Value>{value});
+                               emitc::OpaqueAttr::get(ctx, memberName)}));
       resultStruct.callArguments.push_back(memberPtr.getResult(0));
     }
 
@@ -2121,12 +2077,11 @@ private:
       auto statusOp = builder.create<emitc::CallOpaqueOp>(
           /*location=*/location,
           /*type=*/emitc::OpaqueType::get(ctx, "iree_status_t"),
-          /*callee=*/StringAttr::get(ctx, "iree_make_status"),
+          /*callee=*/"iree_make_status",
+          /*operands=*/ArrayRef<Value>{},
           /*args=*/
           ArrayAttr::get(
-              ctx, {emitc::OpaqueAttr::get(ctx, "IREE_STATUS_NOT_FOUND")}),
-          /*templateArgs=*/ArrayAttr{},
-          /*operands=*/ArrayRef<Value>{});
+              ctx, {emitc::OpaqueAttr::get(ctx, "IREE_STATUS_NOT_FOUND")}));
       builder.create<mlir::emitc::ReturnOp>(location, statusOp.getResult(0));
     }
 
@@ -2324,12 +2279,11 @@ private:
                 /*type=*/
                 emitc::PointerType::get(
                     emitc::OpaqueType::get(ctx, "iree_byte_span_t")),
-                /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_MEMBER_ADDRESS"),
+                /*callee=*/"EMITC_STRUCT_MEMBER_ADDRESS",
+                /*operands=*/ArrayRef<Value>{call},
                 /*args=*/
                 ArrayAttr::get(ctx, {builder.getIndexAttr(0),
-                                     emitc::OpaqueAttr::get(ctx, memberName)}),
-                /*templateArgs=*/ArrayAttr{},
-                /*operands=*/ArrayRef<Value>{call})
+                                     emitc::OpaqueAttr::get(ctx, memberName)}))
             .getResult(0);
 
     // void *byteSpan_data_void = iree_alloca(size);
@@ -2339,9 +2293,7 @@ private:
                 /*location=*/loc,
                 /*type=*/
                 emitc::PointerType::get(emitc::OpaqueType::get(ctx, "void")),
-                /*callee=*/StringAttr::get(ctx, "iree_alloca"),
-                /*args=*/ArrayAttr{},
-                /*templateArgs=*/ArrayAttr{},
+                /*callee=*/"iree_alloca",
                 /*operands=*/ArrayRef<Value>{size})
             .getResult(0);
 
@@ -2415,9 +2367,7 @@ private:
         builder.create<emitc::CallOpaqueOp>(
             /*location=*/loc,
             /*type=*/TypeRange{},
-            /*callee=*/StringAttr::get(ctx, "iree_vm_ref_assign"),
-            /*args=*/ArrayAttr{},
-            /*templateArgs=*/ArrayAttr{},
+            /*callee=*/"iree_vm_ref_assign",
             /*operands=*/ArrayRef<Value>{arg, refPtr});
       } else {
         assert(!isa<emitc::PointerType>(argType));
@@ -2490,9 +2440,7 @@ private:
         builder.create<emitc::CallOpaqueOp>(
             /*location=*/loc,
             /*type=*/TypeRange{},
-            /*callee=*/StringAttr::get(ctx, "iree_vm_ref_move"),
-            /*args=*/ArrayAttr{},
-            /*templateArgs=*/ArrayAttr{},
+            /*callee=*/"iree_vm_ref_move",
             /*operands=*/ArrayRef<Value>{refPtr, arg});
       } else {
         Type valueType = llvm::cast<emitc::PointerType>(argType).getPointee();
@@ -2535,7 +2483,7 @@ private:
     returnIfError(
         /*rewriter=*/builder,
         /*location=*/loc,
-        /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_PTR_MEMBER_CALL"),
+        /*callee=*/"EMITC_STRUCT_PTR_MEMBER_CALL",
         /*args=*/
         ArrayAttr::get(ctx,
                        {
@@ -2840,11 +2788,8 @@ class CallOpConversion : public EmitCConversionPattern<OpTy> {
     builder.create<emitc::CallOpaqueOp>(
         /*location=*/loc,
         /*type=*/TypeRange{},
-        /*callee=*/StringAttr::get(ctx, "iree_vm_ref_assign"),
-        /*args=*/ArrayAttr{},
-        /*templateArgs=*/ArrayAttr{},
-        /*operands=*/
-        ArrayRef<Value>{operandRef, refPtr});
+        /*callee=*/"iree_vm_ref_assign",
+        /*operands=*/ArrayRef<Value>{operandRef, refPtr});
 
     return refPtr;
   }
@@ -2890,9 +2835,7 @@ private:
     rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
         /*op=*/cmpOp,
         /*type=*/cmpOp.getType(),
-        /*callee=*/StringAttr::get(ctx, funcName),
-        /*args=*/ArrayAttr{},
-        /*templateArgs=*/ArrayAttr{},
+        /*callee=*/funcName,
         /*operands=*/ArrayRef<Value>{refLhs, refRhs});
 
     if (moveLhs) {
@@ -2919,7 +2862,6 @@ class CompareRefNotZeroOpConversion
   LogicalResult
   matchAndRewrite(IREE::VM::CmpNZRefOp cmpOp, Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto ctx = cmpOp.getContext();
     auto loc = cmpOp.getLoc();
 
     auto funcOp = cmpOp.getOperation()->getParentOfType<mlir::emitc::FuncOp>();
@@ -2933,9 +2875,7 @@ class CompareRefNotZeroOpConversion
     rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
         /*op=*/cmpOp,
         /*type=*/cmpOp.getType(),
-        /*callee=*/StringAttr::get(ctx, "vm_cmp_nz_ref"),
-        /*args=*/ArrayAttr{},
-        /*templateArgs=*/ArrayAttr{},
+        /*callee=*/"vm_cmp_nz_ref",
         /*operands=*/ArrayRef<Value>{ref});
 
     if (move) {
@@ -2975,8 +2915,7 @@ class SelectRefOpConversion
             .create<emitc::CallOpaqueOp>(
                 /*location=*/loc,
                 /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_ref_type_t"),
-                /*callee=*/StringAttr::get(ctx, "iree_vm_type_def_as_ref"),
-                /*args=*/ArrayAttr{}, /*templateArgs=*/ArrayAttr{},
+                /*callee=*/"iree_vm_type_def_as_ref",
                 /*operands=*/ArrayRef<Value>{resultTypePtr.value()})
             .getResult(0);
 
@@ -3009,13 +2948,12 @@ class SelectRefOpConversion
       returnIfError(
           /*rewriter=*/rewriter,
           /*location=*/loc,
-          /*callee=*/StringAttr::get(ctx, "iree_vm_ref_retain_or_move_checked"),
+          /*callee=*/"iree_vm_ref_retain_or_move_checked",
           /*args=*/
           ArrayAttr::get(
               ctx, {rewriter.getBoolAttr(moveTrue), rewriter.getIndexAttr(0),
                     rewriter.getIndexAttr(1), rewriter.getIndexAttr(2)}),
-          /*operands=*/
-          ArrayRef<Value>{refTrue, resultTypeAsRef, refResult},
+          /*operands=*/ArrayRef<Value>{refTrue, resultTypeAsRef, refResult},
           this->getModuleAnalysis());
       rewriter.create<IREE::VM::BranchOp>(loc, continueBlock);
     }
@@ -3027,13 +2965,12 @@ class SelectRefOpConversion
       returnIfError(
           /*rewriter=*/rewriter,
           /*location=*/loc,
-          /*callee=*/StringAttr::get(ctx, "iree_vm_ref_retain_or_move_checked"),
+          /*callee=*/"iree_vm_ref_retain_or_move_checked",
           /*args=*/
           ArrayAttr::get(
               ctx, {rewriter.getBoolAttr(moveFalse), rewriter.getIndexAttr(0),
                     rewriter.getIndexAttr(1), rewriter.getIndexAttr(2)}),
-          /*operands=*/
-          ArrayRef<Value>{refFalse, resultTypeAsRef, refResult},
+          /*operands=*/ArrayRef<Value>{refFalse, resultTypeAsRef, refResult},
           this->getModuleAnalysis());
       rewriter.create<IREE::VM::BranchOp>(loc, continueBlock);
     }
@@ -3144,9 +3081,7 @@ class ConstRefRodataOpConversion
     auto typeIdOp = rewriter.create<emitc::CallOpaqueOp>(
         /*location=*/loc,
         /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_ref_type_t"),
-        /*callee=*/StringAttr::get(ctx, "iree_vm_buffer_type"),
-        /*args=*/ArrayAttr{},
-        /*templateArgs=*/ArrayAttr{},
+        /*callee=*/"iree_vm_buffer_type",
         /*operands=*/ArrayRef<Value>{});
 
     Value ref = getModuleAnalysis().lookupRef(constRefRodataOp.getResult());
@@ -3154,7 +3089,7 @@ class ConstRefRodataOpConversion
     returnIfError(
         /*rewriter=*/rewriter,
         /*location=*/loc,
-        /*callee=*/StringAttr::get(ctx, "iree_vm_ref_wrap_retain"),
+        /*callee=*/"iree_vm_ref_wrap_retain",
         /*args=*/ArrayAttr{},
         /*operands=*/
         ArrayRef<Value>{byteBufferPtrOp, typeIdOp.getResult(0), ref},
@@ -3370,7 +3305,6 @@ class ReturnOpConversion : public EmitCConversionPattern<IREE::VM::ReturnOp> {
   LogicalResult
   matchAndRewrite(IREE::VM::ReturnOp op, Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto ctx = op.getContext();
     auto loc = op.getLoc();
 
     auto funcOp = op.getOperation()->getParentOfType<mlir::emitc::FuncOp>();
@@ -3390,7 +3324,7 @@ class ReturnOpConversion : public EmitCConversionPattern<IREE::VM::ReturnOp> {
       if (llvm::isa<IREE::VM::RefType>(operand.getType())) {
         assert(operand.getType() !=
                emitc::PointerType::get(
-                   emitc::OpaqueType::get(ctx, "iree_vm_ref_t")));
+                   emitc::OpaqueType::get(op.getContext(), "iree_vm_ref_t")));
 
         Value operandRef = getModuleAnalysis().lookupRef(operand);
 
@@ -3399,9 +3333,7 @@ class ReturnOpConversion : public EmitCConversionPattern<IREE::VM::ReturnOp> {
         rewriter.create<emitc::CallOpaqueOp>(
             /*location=*/loc,
             /*type=*/TypeRange{},
-            /*callee=*/StringAttr::get(ctx, "EMITC_DEREF_ASSIGN_VALUE"),
-            /*args=*/ArrayAttr{},
-            /*templateArgs=*/ArrayAttr{},
+            /*callee=*/"EMITC_DEREF_ASSIGN_VALUE",
             /*operands=*/ArrayRef<Value>{resultArgument, operand});
       }
     }
@@ -3553,7 +3485,9 @@ class FailOpConversion : public EmitCConversionPattern<IREE::VM::FailOp> {
       auto status = rewriter.create<emitc::CallOpaqueOp>(
           /*location=*/loc,
           /*type=*/emitc::OpaqueType::get(ctx, "iree_status_t"),
-          /*callee=*/StringAttr::get(ctx, "iree_status_allocate_f"),
+          /*callee=*/"iree_status_allocate_f",
+          /*operands=*/
+          ArrayRef<Value>{messageSizeIntOp.getResult(), messageDataOp},
           /*args=*/
           ArrayAttr::get(
               ctx,
@@ -3561,10 +3495,7 @@ class FailOpConversion : public EmitCConversionPattern<IREE::VM::FailOp> {
                emitc::OpaqueAttr::get(ctx, "\"<vm>\""),
                rewriter.getI32IntegerAttr(0),
                emitc::OpaqueAttr::get(ctx, "\"%.*s\""),
-               rewriter.getIndexAttr(0), rewriter.getIndexAttr(1)}),
-          /*templateArgs=*/ArrayAttr{},
-          /*operands=*/
-          ArrayRef<Value>{messageSizeIntOp.getResult(), messageDataOp});
+               rewriter.getIndexAttr(0), rewriter.getIndexAttr(1)}));
 
       rewriter.create<mlir::emitc::ReturnOp>(loc, status.getResult(0));
     }
@@ -3597,7 +3528,6 @@ private:
   LogicalResult
   matchAndRewrite(OpTy loadOp, Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto ctx = loadOp.getContext();
     auto loc = loadOp.getLoc();
 
     GlobalOpTy globalOp =
@@ -3621,14 +3551,13 @@ private:
     rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
         /*op=*/loadOp,
         /*type=*/loadOp.getOperation()->getResultTypes(),
-        /*callee=*/StringAttr::get(ctx, funcName),
+        /*callee=*/funcName,
+        /*operands=*/ArrayRef<Value>{rwDataPtr},
         /*args=*/
         rewriter.getArrayAttr(
             {rewriter.getIndexAttr(0),
              rewriter.getUI32IntegerAttr(static_cast<uint32_t>(
-                 globalOp.getOrdinal()->getZExtValue()))}),
-        /*templateArgs=*/ArrayAttr{},
-        /*operands=*/ArrayRef<Value>{rwDataPtr});
+                 globalOp.getOrdinal()->getZExtValue()))}));
 
     return success();
   }
@@ -3712,8 +3641,7 @@ class GlobalLoadStoreRefOpConversion : public EmitCConversionPattern<OpTy> {
             .create<emitc::CallOpaqueOp>(
                 /*location=*/loc,
                 /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_ref_type_t"),
-                /*callee=*/StringAttr::get(ctx, "iree_vm_type_def_as_ref"),
-                /*args=*/ArrayAttr{}, /*templateArgs=*/ArrayAttr{},
+                /*callee=*/"iree_vm_type_def_as_ref",
                 /*operands=*/ArrayRef<Value>{elementTypePtr.value()})
             .getResult(0);
 
@@ -3725,7 +3653,7 @@ class GlobalLoadStoreRefOpConversion : public EmitCConversionPattern<OpTy> {
     returnIfError(
         /*rewriter=*/rewriter,
         /*location=*/loc,
-        /*callee=*/StringAttr::get(ctx, "iree_vm_ref_retain_or_move_checked"),
+        /*callee=*/"iree_vm_ref_retain_or_move_checked",
         /*args=*/
         ArrayAttr::get(ctx,
                        {rewriter.getBoolAttr(move), rewriter.getIndexAttr(0),
@@ -3758,7 +3686,6 @@ private:
   LogicalResult
   matchAndRewrite(OpTy storeOp, Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto ctx = storeOp.getContext();
     auto loc = storeOp.getLoc();
 
     GlobalOpTy globalOp =
@@ -3782,16 +3709,14 @@ private:
     rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
         /*op=*/storeOp,
         /*type=*/storeOp.getOperation()->getResultTypes(),
-        /*callee=*/StringAttr::get(ctx, funcName),
+        /*callee=*/funcName,
+        /*operands=*/ArrayRef<Value>{rwDataPtr, storeOp.getValue()},
         /*args=*/
         rewriter.getArrayAttr(
             {rewriter.getIndexAttr(0),
              rewriter.getUI32IntegerAttr(
                  static_cast<uint32_t>(globalOp.getOrdinal()->getZExtValue())),
-             rewriter.getIndexAttr(1)}),
-        /*templateArgs=*/ArrayAttr{},
-        /*operands=*/
-        ArrayRef<Value>{rwDataPtr, storeOp.getValue()});
+             rewriter.getIndexAttr(1)}));
 
     return success();
   }
@@ -3860,7 +3785,7 @@ private:
             /*location=*/loc,
             /*type=*/
             emitc::PointerType::get(emitc::OpaqueType::get(ctx, vmType)),
-            /*callee=*/StringAttr::get(ctx, vmDerefCallee),
+            /*callee=*/vmDerefCallee,
             /*args=*/ArrayAttr{},
             /*operands=*/ArrayRef<Value>{refValue}, this->getModuleAnalysis());
         unwrappedOperands.push_back(derefOp.getResult(0));
@@ -3879,7 +3804,7 @@ private:
       returnIfError(
           /*rewriter=*/rewriter,
           /*location=*/loc,
-          /*callee=*/StringAttr::get(ctx, funcName),
+          /*callee=*/funcName,
           /*args=*/ArrayAttr{},
           /*operands=*/ArrayRef<Value>(unwrappedOperands),
           this->getModuleAnalysis());
@@ -3891,9 +3816,7 @@ private:
       rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
           /*op=*/op,
           /*type=*/op.getOperation()->getResultTypes(),
-          /*callee=*/StringAttr::get(ctx, funcName),
-          /*args=*/ArrayAttr{},
-          /*templateArgs=*/ArrayAttr{},
+          /*callee=*/funcName,
           /*operands=*/ArrayRef<Value>(unwrappedOperands));
     }
 
@@ -4003,7 +3926,7 @@ class ContainerAllocOpConversion : public EmitCConversionPattern<OpTy> {
     returnIfError(
         /*rewriter=*/rewriter,
         /*location=*/loc,
-        /*callee=*/StringAttr::get(ctx, cNames.value().constructor),
+        /*callee=*/cNames.value().constructor,
         /*args=*/ArrayAttr{},
         /*operands=*/ArrayRef<Value>{operands.value()},
         this->getModuleAnalysis());
@@ -4015,16 +3938,14 @@ class ContainerAllocOpConversion : public EmitCConversionPattern<OpTy> {
             .create<emitc::CallOpaqueOp>(
                 /*location=*/loc,
                 /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_ref_type_t"),
-                /*callee=*/StringAttr::get(ctx, cNames.value().typeId),
-                /*args=*/ArrayAttr{},
-                /*templateArgs=*/ArrayAttr{},
+                /*callee=*/cNames.value().typeId,
                 /*operands=*/ArrayRef<Value>{})
             .getResult(0);
 
     returnIfError(
         /*rewriter=*/rewriter,
         /*location=*/loc,
-        /*callee=*/StringAttr::get(ctx, "iree_vm_ref_wrap_assign"),
+        /*callee=*/"iree_vm_ref_wrap_assign",
         /*args=*/ArrayAttr{},
         /*operands=*/ArrayRef<Value>{container, refType, ref},
         this->getModuleAnalysis());
@@ -4135,7 +4056,7 @@ class ContainerAllocOpConversion : public EmitCConversionPattern<OpTy> {
             /*type=*/
             emitc::PointerType::get(
                 emitc::OpaqueType::get(ctx, "iree_vm_buffer_t")),
-            /*callee=*/StringAttr::get(ctx, "iree_vm_buffer_deref"),
+            /*callee=*/"iree_vm_buffer_deref",
             /*args=*/ArrayAttr{},
             /*operands=*/ArrayRef<Value>{refValue}, this->getModuleAnalysis())
             .getResult(0);
@@ -4197,14 +4118,14 @@ class ListGetOpConversion : public EmitCConversionPattern<OpTy> {
         /*location=*/loc,
         /*type=*/
         emitc::PointerType::get(emitc::OpaqueType::get(ctx, "iree_vm_list_t")),
-        /*callee=*/StringAttr::get(ctx, "iree_vm_list_deref"),
+        /*callee=*/"iree_vm_list_deref",
         /*args=*/ArrayAttr{},
         /*operands=*/ArrayRef<Value>{refValue}, this->getModuleAnalysis());
 
     returnIfError(
         /*rewriter=*/rewriter,
         /*location=*/loc,
-        /*callee=*/StringAttr::get(ctx, "iree_vm_list_get_value_as"),
+        /*callee=*/"iree_vm_list_get_value_as",
         /*args=*/
         ArrayAttr::get(ctx, {rewriter.getIndexAttr(0), rewriter.getIndexAttr(1),
                              emitc::OpaqueAttr::get(ctx, valueTypeEnum.value()),
@@ -4216,9 +4137,7 @@ class ListGetOpConversion : public EmitCConversionPattern<OpTy> {
     rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
         /*op=*/getOp,
         /*type=*/getOp.getType(),
-        /*callee=*/StringAttr::get(ctx, valueExtractor.value()),
-        /*args=*/ArrayAttr{},
-        /*templateArgs=*/ArrayAttr{},
+        /*callee=*/valueExtractor.value(),
         /*operands=*/ArrayRef<Value>{valuePtr});
 
     return success();
@@ -4244,7 +4163,7 @@ class ListGetRefOpConversion
         /*location=*/loc,
         /*type=*/
         emitc::PointerType::get(emitc::OpaqueType::get(ctx, "iree_vm_list_t")),
-        /*callee=*/StringAttr::get(ctx, "iree_vm_list_deref"),
+        /*callee=*/"iree_vm_list_deref",
         /*args=*/ArrayAttr{},
         /*operands=*/ArrayRef<Value>{listRefValue}, getModuleAnalysis());
 
@@ -4253,7 +4172,7 @@ class ListGetRefOpConversion
     returnIfError(
         /*rewriter=*/rewriter,
         /*location=*/loc,
-        /*callee=*/StringAttr::get(ctx, "iree_vm_list_get_ref_retain"),
+        /*callee=*/"iree_vm_list_get_ref_retain",
         /*args=*/ArrayAttr{},
         /*operands=*/
         ArrayRef<Value>{listDerefOp.getResult(0), getOp.getIndex(), ref},
@@ -4315,9 +4234,7 @@ class ListGetRefOpConversion
               .create<emitc::CallOpaqueOp>(
                   /*location=*/loc,
                   /*type=*/rewriter.getI1Type(),
-                  /*callee=*/StringAttr::get(ctx, "iree_vm_type_def_is_value"),
-                  /*args=*/ArrayAttr{},
-                  /*templateArgs=*/ArrayAttr{},
+                  /*callee=*/"iree_vm_type_def_is_value",
                   /*operands=*/ArrayRef<Value>{elementTypePtr.value()})
               .getResult(0);
 
@@ -4327,9 +4244,7 @@ class ListGetRefOpConversion
               .create<emitc::CallOpaqueOp>(
                   /*location=*/loc,
                   /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_ref_type_t"),
-                  /*callee=*/StringAttr::get(ctx, "iree_vm_type_def_as_ref"),
-                  /*args=*/ArrayAttr{},
-                  /*templateArgs=*/ArrayAttr{},
+                  /*callee=*/"iree_vm_type_def_as_ref",
                   /*operands=*/ArrayRef<Value>{elementTypePtr.value()})
               .getResult(0);
 
@@ -4415,9 +4330,7 @@ class ListSetOpConversion : public EmitCConversionPattern<OpTy> {
     auto valueOp = rewriter.create<emitc::CallOpaqueOp>(
         /*location=*/loc,
         /*type=*/emitc::OpaqueType::get(ctx, "iree_vm_value_t"),
-        /*callee=*/StringAttr::get(ctx, valueConstructor.value()),
-        /*args=*/ArrayAttr{},
-        /*templateArgs=*/ArrayAttr{},
+        /*callee=*/valueConstructor.value(),
         /*operands=*/ArrayRef<Value>{setOp.getValue()});
 
     Value valuePtr =
@@ -4431,14 +4344,14 @@ class ListSetOpConversion : public EmitCConversionPattern<OpTy> {
         /*location=*/loc,
         /*type=*/
         emitc::PointerType::get(emitc::OpaqueType::get(ctx, "iree_vm_list_t")),
-        /*callee=*/StringAttr::get(ctx, "iree_vm_list_deref"),
+        /*callee=*/"iree_vm_list_deref",
         /*args=*/ArrayAttr{},
         /*operands=*/ArrayRef<Value>{refValue}, this->getModuleAnalysis());
 
     returnIfError(
         /*rewriter=*/rewriter,
         /*location=*/loc,
-        /*callee=*/StringAttr::get(ctx, "iree_vm_list_set_value"),
+        /*callee=*/"iree_vm_list_set_value",
         /*args=*/ArrayAttr{},
         /*operands=*/
         ArrayRef<Value>{listDerefOp.getResult(0), setOp.getIndex(), valuePtr},
@@ -4469,7 +4382,7 @@ class ListSetRefOpConversion
         /*location=*/loc,
         /*type=*/
         emitc::PointerType::get(emitc::OpaqueType::get(ctx, "iree_vm_list_t")),
-        /*callee=*/StringAttr::get(ctx, "iree_vm_list_deref"),
+        /*callee=*/"iree_vm_list_deref",
         /*args=*/ArrayAttr{},
         /*operands=*/ArrayRef<Value>{refValue}, getModuleAnalysis());
 
@@ -4485,7 +4398,7 @@ class ListSetRefOpConversion
     returnIfError(
         /*rewriter=*/rewriter,
         /*location=*/loc,
-        /*callee=*/StringAttr::get(ctx, callee),
+        /*callee=*/callee,
         /*args=*/ArrayAttr{},
         /*operands=*/
         ArrayRef<Value>{listDerefOp.getResult(0), setOp.getIndex(),

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCBuilders.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCBuilders.cpp
@@ -95,9 +95,7 @@ Value sizeOf(OpBuilder builder, Location loc, Value value) {
       .create<emitc::CallOpaqueOp>(
           /*location=*/loc,
           /*type=*/emitc::OpaqueType::get(ctx, "iree_host_size_t"),
-          /*callee=*/StringAttr::get(ctx, "sizeof"),
-          /*args=*/ArrayAttr{},
-          /*templateArgs=*/ArrayAttr{},
+          /*callee=*/"sizeof",
           /*operands=*/ArrayRef<Value>{value})
       .getResult(0);
 }
@@ -108,22 +106,18 @@ Value sizeOf(OpBuilder builder, Location loc, Attribute attr) {
       .create<emitc::CallOpaqueOp>(
           /*location=*/loc,
           /*type=*/emitc::OpaqueType::get(ctx, "iree_host_size_t"),
-          /*callee=*/StringAttr::get(ctx, "sizeof"),
-          /*args=*/ArrayAttr::get(ctx, {attr}),
-          /*templateArgs=*/ArrayAttr{},
-          /*operands=*/ArrayRef<Value>{})
+          /*callee=*/"sizeof",
+          /*operands=*/ArrayRef<Value>{},
+          /*args=*/ArrayAttr::get(ctx, {attr}))
       .getResult(0);
 }
 
 void memcpy(OpBuilder builder, Location location, Value dest, Value src,
             Value count) {
-  auto ctx = builder.getContext();
   builder.create<emitc::CallOpaqueOp>(
       /*location=*/location,
       /*type=*/TypeRange{},
-      /*callee=*/StringAttr::get(ctx, "memcpy"),
-      /*args=*/ArrayAttr{},
-      /*templateArgs=*/ArrayAttr{},
+      /*callee=*/"memcpy",
       /*operands=*/ArrayRef<Value>{dest, src, count});
 }
 
@@ -133,14 +127,12 @@ void memset(OpBuilder builder, Location location, Value dest, int ch,
   builder.create<emitc::CallOpaqueOp>(
       /*location=*/location,
       /*type=*/TypeRange{},
-      /*callee=*/StringAttr::get(ctx, "memset"),
+      /*callee=*/"memset",
+      /*operands=*/ArrayRef<Value>{dest, count},
       /*args=*/
       ArrayAttr::get(ctx,
                      {builder.getIndexAttr(0), builder.getUI32IntegerAttr(ch),
-                      builder.getIndexAttr(1)}),
-      /*templateArgs=*/ArrayAttr{},
-      /*operands=*/
-      ArrayRef<Value>{dest, count});
+                      builder.getIndexAttr(1)}));
 }
 
 Value arrayElement(OpBuilder builder, Location location, Type type,
@@ -150,12 +142,11 @@ Value arrayElement(OpBuilder builder, Location location, Type type,
       .create<emitc::CallOpaqueOp>(
           /*location=*/location,
           /*type=*/type,
-          /*callee=*/StringAttr::get(ctx, "EMITC_ARRAY_ELEMENT"),
+          /*callee=*/"EMITC_ARRAY_ELEMENT",
+          /*operands=*/ArrayRef<Value>{operand},
           /*args=*/
           ArrayAttr::get(
-              ctx, {builder.getIndexAttr(0), builder.getI32IntegerAttr(index)}),
-          /*templateArgs=*/ArrayAttr{},
-          /*operands=*/ArrayRef<Value>{operand})
+              ctx, {builder.getIndexAttr(0), builder.getI32IntegerAttr(index)}))
       .getResult(0);
 }
 
@@ -166,11 +157,10 @@ Value arrayElementAddress(OpBuilder builder, Location location, Type type,
       .create<emitc::CallOpaqueOp>(
           /*location=*/location,
           /*type=*/type,
-          /*callee=*/StringAttr::get(ctx, "EMITC_ARRAY_ELEMENT_ADDRESS"),
+          /*callee=*/"EMITC_ARRAY_ELEMENT_ADDRESS",
+          /*operands=*/ArrayRef<Value>{operand},
           /*args=*/
-          ArrayAttr::get(ctx, {builder.getIndexAttr(0), index}),
-          /*templateArgs=*/ArrayAttr{},
-          /*operands=*/ArrayRef<Value>{operand})
+          ArrayAttr::get(ctx, {builder.getIndexAttr(0), index}))
       .getResult(0);
 }
 
@@ -181,12 +171,12 @@ Value arrayElementAddress(OpBuilder builder, Location location, Type type,
       .create<emitc::CallOpaqueOp>(
           /*location=*/location,
           /*type=*/type,
-          /*callee=*/StringAttr::get(ctx, "EMITC_ARRAY_ELEMENT_ADDRESS"),
+          /*callee=*/"EMITC_ARRAY_ELEMENT_ADDRESS",
+          /*operands=*/ArrayRef<Value>{operand, index},
           /*args=*/
           ArrayAttr::get(ctx,
                          {builder.getIndexAttr(0), builder.getIndexAttr(1)}),
-          /*templateArgs=*/ArrayAttr{},
-          /*operands=*/ArrayRef<Value>{operand, index})
+          /*templateArgs=*/ArrayAttr{})
       .getResult(0);
 }
 
@@ -196,13 +186,12 @@ void arrayElementAssign(OpBuilder builder, Location location, Value array,
   builder.create<emitc::CallOpaqueOp>(
       /*location=*/location,
       /*type=*/TypeRange{},
-      /*callee=*/StringAttr::get(ctx, "EMITC_ARRAY_ELEMENT_ASSIGN"),
+      /*callee=*/"EMITC_ARRAY_ELEMENT_ASSIGN",
+      /*operands=*/ArrayRef<Value>{array, value},
       /*args=*/
       ArrayAttr::get(ctx,
                      {builder.getIndexAttr(0), builder.getI32IntegerAttr(index),
-                      builder.getIndexAttr(1)}),
-      /*templateArgs=*/ArrayAttr{},
-      /*operands=*/ArrayRef<Value>{array, value});
+                      builder.getIndexAttr(1)}));
 }
 
 void structDefinition(OpBuilder builder, Location location,
@@ -227,12 +216,11 @@ Value structMember(OpBuilder builder, Location location, Type type,
       .create<emitc::CallOpaqueOp>(
           /*location=*/location,
           /*type=*/type,
-          /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_MEMBER"),
+          /*callee=*/"EMITC_STRUCT_MEMBER",
+          /*operands=*/ArrayRef<Value>{operand},
           /*args=*/
           ArrayAttr::get(ctx, {builder.getIndexAttr(0),
-                               emitc::OpaqueAttr::get(ctx, memberName)}),
-          /*templateArgs=*/ArrayAttr{},
-          /*operands=*/ArrayRef<Value>{operand})
+                               emitc::OpaqueAttr::get(ctx, memberName)}))
       .getResult(0);
 }
 
@@ -242,13 +230,12 @@ void structMemberAssign(OpBuilder builder, Location location,
   builder.create<emitc::CallOpaqueOp>(
       /*location=*/location,
       /*type=*/TypeRange{},
-      /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_MEMBER_ASSIGN"),
+      /*callee=*/"EMITC_STRUCT_MEMBER_ASSIGN",
+      /*operands=*/ArrayRef<Value>{operand, data},
       /*args=*/
       ArrayAttr::get(ctx, {builder.getIndexAttr(0),
                            emitc::OpaqueAttr::get(ctx, memberName),
-                           builder.getIndexAttr(1)}),
-      /*templateArgs=*/ArrayAttr{},
-      /*operands=*/ArrayRef<Value>{operand, data});
+                           builder.getIndexAttr(1)}));
 }
 
 void structMemberAssign(OpBuilder builder, Location location,
@@ -257,13 +244,12 @@ void structMemberAssign(OpBuilder builder, Location location,
   builder.create<emitc::CallOpaqueOp>(
       /*location=*/location,
       /*type=*/TypeRange{},
-      /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_MEMBER_ASSIGN"),
+      /*callee=*/"EMITC_STRUCT_MEMBER_ASSIGN",
+      /*operands=*/ArrayRef<Value>{operand},
       /*args=*/
       ArrayAttr::get(ctx, {builder.getIndexAttr(0),
                            emitc::OpaqueAttr::get(ctx, memberName),
-                           emitc::OpaqueAttr::get(ctx, data)}),
-      /*templateArgs=*/ArrayAttr{},
-      /*operands=*/ArrayRef<Value>{operand});
+                           emitc::OpaqueAttr::get(ctx, data)}));
 }
 
 Value structPtrMember(OpBuilder builder, Location location, Type type,
@@ -273,12 +259,11 @@ Value structPtrMember(OpBuilder builder, Location location, Type type,
       .create<emitc::CallOpaqueOp>(
           /*location=*/location,
           /*type=*/type,
-          /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_PTR_MEMBER"),
+          /*callee=*/"EMITC_STRUCT_PTR_MEMBER",
+          /*operands=*/ArrayRef<Value>{operand},
           /*args=*/
           ArrayAttr::get(ctx, {builder.getIndexAttr(0),
-                               emitc::OpaqueAttr::get(ctx, memberName)}),
-          /*templateArgs=*/ArrayAttr{},
-          /*operands=*/ArrayRef<Value>{operand})
+                               emitc::OpaqueAttr::get(ctx, memberName)}))
       .getResult(0);
 }
 
@@ -288,13 +273,12 @@ void structPtrMemberAssign(OpBuilder builder, Location location,
   builder.create<emitc::CallOpaqueOp>(
       /*location=*/location,
       /*type=*/TypeRange{},
-      /*callee=*/StringAttr::get(ctx, "EMITC_STRUCT_PTR_MEMBER_ASSIGN"),
+      /*callee=*/"EMITC_STRUCT_PTR_MEMBER_ASSIGN",
+      /*operands=*/ArrayRef<Value>{operand, data},
       /*args=*/
       ArrayAttr::get(ctx, {builder.getIndexAttr(0),
                            emitc::OpaqueAttr::get(ctx, memberName),
-                           builder.getIndexAttr(1)}),
-      /*templateArgs=*/ArrayAttr{},
-      /*operands=*/ArrayRef<Value>{operand, data});
+                           builder.getIndexAttr(1)}));
 }
 
 Value ireeMakeCstringView(OpBuilder builder, Location location,
@@ -309,11 +293,10 @@ Value ireeMakeCstringView(OpBuilder builder, Location location,
       .create<emitc::CallOpaqueOp>(
           /*location=*/location,
           /*type=*/emitc::OpaqueType::get(ctx, "iree_string_view_t"),
-          /*callee=*/StringAttr::get(ctx, "iree_make_cstring_view"),
+          /*callee=*/"iree_make_cstring_view",
+          /*operands=*/ArrayRef<Value>{},
           /*args=*/
-          ArrayAttr::get(ctx, {emitc::OpaqueAttr::get(ctx, quotedStr)}),
-          /*templateArgs=*/ArrayAttr{},
-          /*operands=*/ArrayRef<Value>{})
+          ArrayAttr::get(ctx, {emitc::OpaqueAttr::get(ctx, quotedStr)}))
       .getResult(0);
 }
 
@@ -323,9 +306,7 @@ Value ireeOkStatus(OpBuilder builder, Location location) {
       .create<emitc::CallOpaqueOp>(
           /*location=*/location,
           /*type=*/emitc::OpaqueType::get(ctx, "iree_status_t"),
-          /*callee=*/StringAttr::get(ctx, "iree_ok_status"),
-          /*args=*/ArrayAttr{},
-          /*templateArgs=*/ArrayAttr{},
+          /*callee=*/"iree_ok_status",
           /*operands=*/ArrayRef<Value>{})
       .getResult(0);
 }
@@ -338,21 +319,16 @@ Value ireeVmInstanceLookupType(OpBuilder builder, Location location,
       .create<emitc::CallOpaqueOp>(
           /*location=*/location,
           /*type=*/refType,
-          /*callee=*/StringAttr::get(ctx, "iree_vm_instance_lookup_type"),
-          /*args=*/ArrayAttr{},
-          /*templateArgs=*/ArrayAttr{},
+          /*callee=*/"iree_vm_instance_lookup_type",
           /*operands=*/ArrayRef<Value>{instance, stringView})
       .getResult(0);
 }
 
 void ireeVmRefRelease(OpBuilder builder, Location location, Value operand) {
-  auto ctx = builder.getContext();
   builder.create<emitc::CallOpaqueOp>(
       /*location=*/location,
       /*type=*/TypeRange{},
-      /*callee=*/StringAttr::get(ctx, "iree_vm_ref_release"),
-      /*args=*/ArrayAttr{},
-      /*templateArgs=*/ArrayAttr{},
+      /*callee=*/"iree_vm_ref_release",
       /*operands=*/ArrayRef<Value>{operand});
 }
 


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/80879 introduced custom build methods for the `emitc.call_opaque` op for common cases.