### PR TITLE
[LLVMGPU] Fix linear dim selection in GPUApplyTilingLevel

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyTilingLevel.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyTilingLevel.cpp
@@ -107,10 +107,11 @@ applyTileAndFuseToEachRoot(RewriterBase &rewriter,
       // TODO: Add some helpers to construct this based on the enum type rather
       // than doing it here.
       SmallVector<DeviceMappingAttrInterface> mapping;
-      for (auto [idx, size] : llvm::enumerate(tileSizes)) {
+      int idx = 0;
+      for (auto size : tileSizes) {
         if (!isConstantIntValue(size, 0)) {
           unsigned mappingId =
-              static_cast<unsigned>(gpu::MappingId::LinearDim0) + idx;
+              static_cast<unsigned>(gpu::MappingId::LinearDim0) + idx++;
           mapping.push_back(gpu::GPUThreadMappingAttr::get(
               context, static_cast<gpu::MappingId>(mappingId)));
         }


### PR DESCRIPTION
`GPUApplyTilingLevel` skips over dimensions with no tiling (tile size of zero), and the linear dim mapping in the forall loop also skips the indices of the dimensions. This PR fixes this so the linear dim mappings always increment by 1 starting from 0.