### PR TITLE
Redirect submodules from shark-infra to iree-org.

### DIFF
--- a/.github/workflows/bump_torch_mlir.yml
+++ b/.github/workflows/bump_torch_mlir.yml
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# Automatically bumps the torch-mlir submodule to match shark-infra/torch-mlir:main.
+# Automatically bumps the torch-mlir submodule to match iree-org/torch-mlir:main.
 # Manually triggered for now, but can be scheduled in the future.
 # This typically takes ~90s to run.
 # Will succeed without creating a PR if there is no newer version for torch-mlir.

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/google/googletest.git
 [submodule "third_party/llvm-project"]
 	path = third_party/llvm-project
-	url = https://github.com/shark-infra/llvm-project.git
+	url = https://github.com/iree-org/llvm-project.git
 [submodule "third_party/vulkan_headers"]
 	path = third_party/vulkan_headers
 	url = https://github.com/KhronosGroup/Vulkan-Headers.git
@@ -34,10 +34,10 @@
 	url = https://github.com/powderluv/musl.git
 [submodule "third_party/stablehlo"]
 	path = third_party/stablehlo
-	url = https://github.com/shark-infra/stablehlo.git
+	url = https://github.com/iree-org/stablehlo.git
 [submodule "third_party/torch-mlir"]
 	path = third_party/torch-mlir
-	url = https://github.com/shark-infra/torch-mlir.git
+	url = https://github.com/iree-org/torch-mlir.git
 [submodule "third_party/hip-build-deps"]
 	path = third_party/hip-build-deps
-	url = https://github.com/shark-infra/hip-build-deps.git
+	url = https://github.com/iree-org/hip-build-deps.git

--- a/docs/website/docs/developers/general/contributing.md
+++ b/docs/website/docs/developers/general/contributing.md
@@ -265,12 +265,6 @@ All access tiers first require joining the
 Once you are a member of the iree-org GitHub organization, you can request to
 join any of the teams on <https://github.com/orgs/iree-org/teams>.
 
-!!! note - "Note: other GitHub organizations"
-
-    Work on IREE sometimes spans other GitHub organizations like
-    [shark-infra](https://github.com/shark-infra/). Reach out to a project
-    member if you would also like access to repositories in those organizations.
-
 ### :octicons-git-branch-16: Branch naming
 
 Most work should be done on


### PR DESCRIPTION
We moved these out of https://github.com/iree-org to make it easier for project contributors to access them at a time when iree-org was defunct, creating repos there took navigating an extraordinary amount of red tape, and the main iree repo was in the https://github.com/openxla GitHub org. Now that the iree repo is back in iree-org and we've updated how we manage access, these repositories can move back too.

GitHub does some automatic redirecting but individual developers may want to run `git submodule sync` after the repository moves and this change. For developers working in the other repositories directly, run `git submodule set-url [remote name] [new url]`. For example: `git remote set-url origin https://github.com/iree-org/megabump.git`