### PR TITLE
[Vecdist][GPU] Distribute LayoutConflict to roundtrip to shared memory.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
@@ -832,6 +832,173 @@ struct DistributeLayoutConflictResolutions final
   }
 };
 
+/// Pattern that allows us to write to shared memory
+/// and read back to register with correct layouts.
+/// especially used when we don't have an optimized way
+/// to resolve the conflict.
+struct DistributeLayoutConflictToSharedMemory final
+    : OpDistributionPattern<IREE::VectorExt::LayoutConflictResolutionOp> {
+  using OpDistributionPattern::OpDistributionPattern;
+
+  // Sets new layout/signature for op, and mark it for redistribution.
+  // When "vector layout storage" and "vector layout redistribution"
+  // is defined, VectorDistributionRewriter would add it to worklist
+  // of operations to be distributed.
+  void setSignatureForRedistribution(PatternRewriter &rewriter, Operation *op,
+                                     Attribute inputLayoutsAttr,
+                                     Attribute outputLayoutsAttr) const {
+    Attribute signature[] = {inputLayoutsAttr, outputLayoutsAttr};
+    auto unitAttr = UnitAttr::get(rewriter.getContext());
+    rewriter.modifyOpInPlace(op, [&]() {
+      op->setAttr(kVectorLayoutFetcherStorageAttrName,
+                  ArrayAttr::get(rewriter.getContext(), signature));
+      op->setAttr(kVectorLayoutRedistributeAttrName, unitAttr);
+    });
+  }
+
+  LogicalResult
+  matchAndRewrite(IREE::VectorExt::LayoutConflictResolutionOp resolutionOp,
+                  DistributionSignature &signature,
+                  PatternRewriter &rewriter) const override {
+    auto loc = resolutionOp.getLoc();
+    VectorValue vector = resolutionOp.getInput();
+    VectorValue result = resolutionOp.getOutput();
+    LayoutAttr currentLayout = dyn_cast<LayoutAttr>(signature[vector]);
+    if (!currentLayout)
+      return failure();
+    LayoutAttr targetLayout = dyn_cast<LayoutAttr>(signature[result]);
+    if (!targetLayout)
+      return failure();
+
+    SmallVector<int64_t> currentVecShape = currentLayout.getDistributedShape();
+    SmallVector<int64_t> targetVecShape = targetLayout.getDistributedShape();
+    if (currentVecShape.size() != targetVecShape.size())
+      return failure();
+
+    // If the conditions suffice, we can skip the trip to shared memory
+    // and just use the default/more efficient layout conflict resolution
+    // distribution.
+    auto numElements = [](ArrayRef<int64_t> vector) {
+      return std::accumulate(vector.begin(), vector.end(), 1,
+                             std::multiplies<int64_t>());
+    };
+    if (numElements(currentVecShape) == numElements(targetVecShape) &&
+        !currentLayout.hasLaneConflictWith(targetLayout))
+      return failure();
+
+    // Compute Subgroup and Workgroup related information and offsets.
+    auto funcOp = resolutionOp->getParentOfType<func::FuncOp>();
+    if (!funcOp)
+      return failure();
+    std::optional<SmallVector<int64_t>> workgroupSize =
+        getWorkgroupSize(funcOp);
+    std::optional<int64_t> subgroupSize = getSubgroupSize(funcOp);
+    if (!workgroupSize.has_value() || !subgroupSize.has_value()) {
+      return failure();
+    }
+    int64_t flatThreadSize = ShapedType::getNumElements(workgroupSize.value());
+    if (flatThreadSize % subgroupSize.value() != 0)
+      return failure();
+    int64_t numSubgroups = flatThreadSize / subgroupSize.value();
+
+    // Define shapes and types needed to be roundtripped to shared-memory.
+    // The allocated shared-memory will stack subgroup data
+    // on fastest dimension. Hence, shape will be:
+    // [dim0, dim1, ..., subgroupCount * dimN]
+
+    auto resolutionType =
+        llvm::dyn_cast_or_null<VectorType>(resolutionOp.getResult().getType());
+    if (!resolutionType)
+      return failure();
+    if (!resolutionType.hasStaticShape())
+      return failure();
+    auto paddedShape = SmallVector<int64_t>(resolutionType.getShape());
+    int64_t vectorRank = resolutionType.getRank();
+    paddedShape[vectorRank - 1] *= numSubgroups;
+
+    // Offset and indexing computation such that subgroups can
+    // write and read to shared memory correctly and without conflicts.
+    AffineExpr d0, d1, d2, s0;
+    bindDims(rewriter.getContext(), d0, d1, d2);
+    bindSymbols(rewriter.getContext(), s0);
+    auto indexType = rewriter.getIndexType();
+    Value threadX =
+        rewriter.create<gpu::ThreadIdOp>(loc, indexType, gpu::Dimension::x);
+    Value threadY =
+        rewriter.create<gpu::ThreadIdOp>(loc, indexType, gpu::Dimension::y);
+    Value threadZ =
+        rewriter.create<gpu::ThreadIdOp>(loc, indexType, gpu::Dimension::z);
+    Value flatThreadId = affine::makeComposedAffineApply(
+        rewriter, loc,
+        (d0 + workgroupSize.value()[0] * d1 +
+         (workgroupSize.value()[0] * workgroupSize.value()[1]) * d2),
+        {threadX, threadY, threadZ});
+    Value subgroupOffset = affine::makeComposedAffineApply(
+        rewriter, loc,
+        s0.floorDiv(subgroupSize.value()) *
+            resolutionType.getShape()[vectorRank - 1],
+        {flatThreadId});
+
+    // Create shared memory to store the intermediate from src layout.
+    auto workgroupMemoryAddressSpace = Attribute(gpu::AddressSpaceAttr::get(
+        rewriter.getContext(), gpu::AddressSpace::Workgroup));
+    MemRefType allocType =
+        MemRefType::get(paddedShape, resolutionType.getElementType(),
+                        AffineMap(), workgroupMemoryAddressSpace);
+    auto alloc = rewriter.create<memref::AllocOp>(loc, allocType);
+
+    SmallVector<OpFoldResult> offsets(vectorRank, rewriter.getIndexAttr(0));
+    SmallVector<OpFoldResult> strides(vectorRank, rewriter.getIndexAttr(1));
+    SmallVector<OpFoldResult> shapes = llvm::to_vector(
+        llvm::map_range(resolutionType.getShape(), [&](int64_t dim) {
+          return OpFoldResult(rewriter.getIndexAttr(dim));
+        }));
+    offsets[vectorRank - 1] = subgroupOffset;
+    auto subview = rewriter.create<memref::SubViewOp>(loc, alloc, offsets,
+                                                      shapes, strides);
+
+    // Creating write/trip to shared memory using src layout.
+    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    SmallVector<Value> indices(resolutionType.getRank(), c0);
+    SmallVector<bool> inBounds(vectorRank, true);
+    auto write = rewriter.create<vector::TransferWriteOp>(loc, vector, subview,
+                                                          indices, inBounds);
+    // Insert gpu.barrier
+    rewriter.create<gpu::BarrierOp>(write.getLoc());
+
+    // Creating read from shared memory using dst layout.
+    // Read with offset starting from the warpIdx * OG fastest dim.
+    indices[vectorRank - 1] = subgroupOffset;
+    auto read = rewriter.create<vector::TransferReadOp>(loc, resolutionType,
+                                                        alloc, indices);
+
+    // Set layouts signature for write.
+    // We need to set the layout on the srcVector/first operand.
+    auto unitAttr = UnitAttr::get(rewriter.getContext());
+    auto writeAttrs = SmallVector<Attribute>(write->getNumOperands(), unitAttr);
+    writeAttrs[0] =
+        currentLayout; // 1st operand is src which requires currentLayout.
+    ArrayAttr writeOperandsAttr =
+        ArrayAttr::get(rewriter.getContext(), writeAttrs);
+    ArrayAttr writeResultsAttr = ArrayAttr::get(rewriter.getContext(), {});
+    setSignatureForRedistribution(rewriter, write.getOperation(),
+                                  writeOperandsAttr, writeResultsAttr);
+
+    // Set layouts signature for read.
+    // We only need to set the layout on output.
+    ArrayAttr readOperandsAttr = ArrayAttr::get(
+        rewriter.getContext(),
+        SmallVector<Attribute>(read->getNumOperands(), unitAttr));
+    ArrayAttr readResultsAttr =
+        ArrayAttr::get(rewriter.getContext(), {targetLayout});
+    setSignatureForRedistribution(rewriter, read.getOperation(),
+                                  readOperandsAttr, readResultsAttr);
+
+    rewriter.replaceOp(resolutionOp, read.getResult());
+    return success();
+  }
+};
+
 } // namespace
 
 void populateGPUReductionDistributionPatterns(RewritePatternSet &patterns,
@@ -857,7 +1024,8 @@ void populateGPUDistributionLayoutAttrPatterns(Value laneId,
 // TODO: Need a new op/analysis to determine when this pattern is safe to use.
 void populateGPULayoutResolutionDistributionPatterns(
     RewritePatternSet &patterns) {
-  patterns.add<DistributeLayoutConflictResolutions>(patterns.getContext());
+  patterns.add<DistributeLayoutConflictResolutions,
+               DistributeLayoutConflictToSharedMemory>(patterns.getContext());
 }
 
 }; // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
@@ -840,22 +840,6 @@ struct DistributeLayoutConflictToSharedMemory final
     : OpDistributionPattern<IREE::VectorExt::LayoutConflictResolutionOp> {
   using OpDistributionPattern::OpDistributionPattern;
 
-  // Sets new layout/signature for op, and mark it for redistribution.
-  // When "vector layout storage" and "vector layout redistribution"
-  // is defined, VectorDistributionRewriter would add it to worklist
-  // of operations to be distributed.
-  void setSignatureForRedistribution(PatternRewriter &rewriter, Operation *op,
-                                     Attribute inputLayoutsAttr,
-                                     Attribute outputLayoutsAttr) const {
-    Attribute signature[] = {inputLayoutsAttr, outputLayoutsAttr};
-    auto unitAttr = UnitAttr::get(rewriter.getContext());
-    rewriter.modifyOpInPlace(op, [&]() {
-      op->setAttr(kVectorLayoutFetcherStorageAttrName,
-                  ArrayAttr::get(rewriter.getContext(), signature));
-      op->setAttr(kVectorLayoutRedistributeAttrName, unitAttr);
-    });
-  }
-
   LogicalResult
   matchAndRewrite(IREE::VectorExt::LayoutConflictResolutionOp resolutionOp,
                   DistributionSignature &signature,
@@ -996,6 +980,23 @@ struct DistributeLayoutConflictToSharedMemory final
 
     rewriter.replaceOp(resolutionOp, read.getResult());
     return success();
+  }
+
+private:
+  // Sets new layout/signature for op, and mark it for redistribution.
+  // When "vector layout storage" and "vector layout redistribution"
+  // is defined, VectorDistributionRewriter would add it to worklist
+  // of operations to be distributed.
+  void setSignatureForRedistribution(PatternRewriter &rewriter, Operation *op,
+                                     Attribute inputLayoutsAttr,
+                                     Attribute outputLayoutsAttr) const {
+    Attribute signature[] = {inputLayoutsAttr, outputLayoutsAttr};
+    auto unitAttr = UnitAttr::get(rewriter.getContext());
+    rewriter.modifyOpInPlace(op, [&]() {
+      op->setAttr(kVectorLayoutFetcherStorageAttrName,
+                  ArrayAttr::get(rewriter.getContext(), signature));
+      op->setAttr(kVectorLayoutRedistributeAttrName, unitAttr);
+    });
   }
 };
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.cpp
@@ -5,13 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.h"
-#include <numeric>
 #include "iree-dialects/Dialect/VectorExt/IR/VectorExtDialect.h"
 #include "iree-dialects/Dialect/VectorExt/IR/VectorExtOps.h"
 #include "iree/compiler/Codegen/Common/VectorLayoutAnalysis.h"
-#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
-#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Verifier.h"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.h
@@ -16,12 +16,6 @@
 
 namespace mlir::iree_compiler {
 
-constexpr StringLiteral kVectorLayoutFetcherStorageAttrName =
-    "__vector_layout_fetcher_storage";
-
-constexpr StringLiteral kVectorLayoutRedistributeAttrName =
-    "__vector_layout_redistribute";
-
 /// A signature describing the layout for each value of vector type which is
 /// an operand or result of this operation.
 ///
@@ -55,27 +49,6 @@ protected:
   void setSignatureForRedistribution(PatternRewriter &rewriter, Operation *op,
                                      Attribute inputLayoutsAttr,
                                      Attribute outputLayoutsAttr) const;
-};
-
-/// Custom listener to store emitted ops that needs to be distributed.
-struct VectorDistributionListener : public RewriterBase::Listener {
-  bool hasOpsToBeDistributed() { return !toBeDistributed.empty(); }
-
-  void clearOpsToBeDistributed() { return toBeDistributed.clear(); }
-
-  const std::deque<Operation *> &getOpsToBeDistributed() const {
-    return toBeDistributed;
-  }
-
-  void notifyOperationModified(Operation *op) override {
-    if (op->hasAttr(kVectorLayoutRedistributeAttrName) &&
-        op->hasAttrOfType<ArrayAttr>(kVectorLayoutFetcherStorageAttrName)) {
-      toBeDistributed.push_back(op);
-    }
-  }
-
-private:
-  std::deque<Operation *> toBeDistributed;
 };
 
 template <typename SourceOp>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.h
@@ -46,6 +46,15 @@ struct DistributionPattern : RewritePattern {
 
   /// Get the signature for the given operation.
   std::optional<DistributionSignature> getOpSignature(Operation *op) const;
+
+protected:
+  // Sets new layout/signature for op, and mark it for redistribution.
+  // When "vector layout storage" and "vector layout redistribution"
+  // is defined, VectorDistributionRewriter would add it to worklist
+  // of operations to be distributed.
+  void setSignatureForRedistribution(PatternRewriter &rewriter, Operation *op,
+                                     Attribute inputLayoutsAttr,
+                                     Attribute outputLayoutsAttr) const;
 };
 
 /// Custom listener to store emitted ops that needs to be distributed.


### PR DESCRIPTION
The motivation behind this PR is to enable chained-matmul and Flash attention on WMMA/RDNA3 layout. Since there is no easy way to resolve layout conflict from C-matrix of WMMA onto A-matrix or B-matrix of WMMA. One straightforward strategy is to write the data back onto shared memory and re-read it onto register. This PR introduces two features that is needed for such:

1. Pattern to distribute/decompose LayoutConflictResolutionOp into memref alloc of shared mem + transfer_write to said shared mem + transfer_read from shared mem to register with all the correct layouts and shape

2. This would also require us to teach our worklist to handle newly generated operations, this PR also modifies the VectorDistributionRewriter to have a listener function that adds new operations that needs to be distributed into it's "local" worklist. This "local" worklist would be then queried after every processing of a work item to see if we have any new operations/work items generated that we need to process/distribute.
