### PR TITLE
[CPU] Signal errors if there are large vectors.

### DIFF
--- a/build_tools/pkgci/external_test_suite/pytorch_models_cpu_llvm_task.json
+++ b/build_tools/pkgci/external_test_suite/pytorch_models_cpu_llvm_task.json
@@ -14,9 +14,10 @@
   "expected_compile_failures": [
     // TODO(#17344): need to regenerate .mlirbc
     "opt-125M",
-    "resnet50"
+    "resnet50",
+    // TODO(#17467): Remove the workaround once we have better support for attention op codegen.
+    "sdxl-vae-decode-tank"
   ],
   "expected_run_failures": [
-    "sdxl-vae-decode-tank"
   ]
 }

--- a/build_tools/pkgci/external_test_suite/sdxl_scheduled_unet_cpu_llvm_task.json
+++ b/build_tools/pkgci/external_test_suite/sdxl_scheduled_unet_cpu_llvm_task.json
@@ -3,7 +3,9 @@
   "iree_compile_flags": [
     "--iree-hal-target-backends=llvm-cpu",
     "--iree-llvmcpu-target-cpu-features=host",
-    "--iree-input-demote-f64-to-f32"
+    "--iree-input-demote-f64-to-f32",
+    // TODO(#17467): Remove the workaround once we have better support for attention op codegen.
+    "--iree-llvmcpu-fail-on-large-vector=false"
   ],
   "iree_run_module_flags": [
     "--device=local-task",
@@ -14,9 +16,7 @@
     "--input=2x1280xf16=@inference_input.2.bin",
     "--input=1xf16=@inference_input.3.bin",
     "--expected_output=1x4x128x128xf16=@inference_output.0.bin",
-    "--expected_f16_threshold=0.8f",
-    // TODO(#17467): Remove the workaround once we have better support for attention op codegen.
-    "iree-llvmcpu-fail-on-large-vector=false"
+    "--expected_f16_threshold=0.8f"
   ],
   "skip_compile_tests": [],
   "skip_run_tests": [],

--- a/build_tools/pkgci/external_test_suite/sdxl_scheduled_unet_cpu_llvm_task.json
+++ b/build_tools/pkgci/external_test_suite/sdxl_scheduled_unet_cpu_llvm_task.json
@@ -14,7 +14,9 @@
     "--input=2x1280xf16=@inference_input.2.bin",
     "--input=1xf16=@inference_input.3.bin",
     "--expected_output=1x4x128x128xf16=@inference_output.0.bin",
-    "--expected_f16_threshold=0.8f"
+    "--expected_f16_threshold=0.8f",
+    // TODO(#17467): Remove the workaround once we have better support for attention op codegen.
+    "iree-llvmcpu-fail-on-large-vector=false"
   ],
   "skip_compile_tests": [],
   "skip_run_tests": [],

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD.bazel
@@ -71,6 +71,7 @@ iree_compiler_cc_library(
         "LLVMCPUVectorShapeCastLowering.cpp",
         "LLVMCPUVectorTransferLowering.cpp",
         "LLVMCPUVectorTransposeLowering.cpp",
+        "LLVMCPUVerifyVectorSizeLegality.cpp",
         "LLVMCPUVirtualVectorLowering.cpp",
         "Passes.cpp",
         "TargetMLTransformInfo.cpp",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
@@ -72,6 +72,7 @@ iree_cc_library(
     "LLVMCPUVectorShapeCastLowering.cpp"
     "LLVMCPUVectorTransferLowering.cpp"
     "LLVMCPUVectorTransposeLowering.cpp"
+    "LLVMCPUVerifyVectorSizeLegality.cpp"
     "LLVMCPUVirtualVectorLowering.cpp"
     "Passes.cpp"
     "TargetMLTransformInfo.cpp"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVerifyVectorSizeLegality.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVerifyVectorSizeLegality.cpp
@@ -68,8 +68,7 @@ void LLVMCPUVerifyVectorSizeLegalityPass::runOnOperation() {
 
   auto checkFn = [&](Type t) {
     auto vectorType = dyn_cast<VectorType>(t);
-    // TODO: Add support for verifying scalable vectors.
-    if (!vectorType || vectorType.isScalable()) {
+    if (!vectorType) {
       return false;
     }
     int64_t size =
@@ -77,11 +76,6 @@ void LLVMCPUVerifyVectorSizeLegalityPass::runOnOperation() {
     return size >= maxVectorSizeInBytes;
   };
   auto isLargeVectorContract = [&](vector::ContractionOp op) {
-    // TODO: Add support for verifying scalable vectors.
-    if (op.getLhsType().isScalable() || op.getRhsType().isScalable()) {
-      return false;
-    }
-
     SmallVector<int64_t> iterationBounds;
     op.getIterationBounds(iterationBounds);
     int64_t size = getTotalSizeInBytes(getElementTypeOrSelf(op.getAccType()),

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVerifyVectorSizeLegality.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVerifyVectorSizeLegality.cpp
@@ -1,0 +1,123 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <climits>
+#include <numeric>
+
+#include "iree/compiler/Codegen/LLVMCPU/PassDetail.h"
+#include "iree/compiler/Codegen/LLVMCPU/Passes.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
+#include "llvm/Support/Alignment.h"
+#include "llvm/Support/MathExtras.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/TypeUtilities.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir::iree_compiler {
+
+namespace {
+struct LLVMCPUVerifyVectorSizeLegalityPass
+    : LLVMCPUVerifyVectorSizeLegalityBase<LLVMCPUVerifyVectorSizeLegalityPass> {
+  LLVMCPUVerifyVectorSizeLegalityPass(int64_t ratio) { this->ratio = ratio; }
+
+  void runOnOperation() override;
+};
+} // namespace
+
+static int64_t getTotalSizeInBytes(Type elemType, ArrayRef<int64_t> shape) {
+  // We can't query bitwidth for some types (e.g., index type). For those
+  // cases, we assume that they are 64 bits because most of modern systems are
+  // 64-bit.
+  int64_t elemBitWidth = 64;
+  if (elemType.isIntOrFloat()) {
+    elemBitWidth = elemType.getIntOrFloatBitWidth();
+  }
+  int64_t size = std::accumulate(shape.begin(), shape.end(), 1LL,
+                                 std::multiplies<int64_t>{});
+  size *= elemBitWidth;
+  size = llvm::divideCeil(size, 8);
+  return size;
+}
+
+void LLVMCPUVerifyVectorSizeLegalityPass::runOnOperation() {
+  FunctionOpInterface funcOp = getOperation();
+  // Use 64 bits as target hardware vector size if the native_vector_size is not
+  // present.
+  int64_t maxVectorSizeInBytes = 8;
+  auto targetAttr = IREE::HAL::ExecutableTargetAttr::lookup(funcOp);
+  if (targetAttr) {
+    auto nativeVectorSizeAttr =
+        getConfigIntegerAttr(targetAttr, "native_vector_size");
+    if (nativeVectorSizeAttr) {
+      maxVectorSizeInBytes = nativeVectorSizeAttr->getInt();
+    }
+  }
+  constexpr int64_t kInt64Max = std::numeric_limits<int64_t>::max();
+  if (maxVectorSizeInBytes <= kInt64Max / this->ratio) {
+    maxVectorSizeInBytes *= this->ratio;
+  } else {
+    maxVectorSizeInBytes = kInt64Max;
+  }
+
+  auto checkFn = [&](Type t) {
+    auto vectorType = dyn_cast<VectorType>(t);
+    // TODO: Add support for verifying scalable vectors.
+    if (!vectorType || vectorType.isScalable()) {
+      return false;
+    }
+    int64_t size =
+        getTotalSizeInBytes(vectorType.getElementType(), vectorType.getShape());
+    return size >= maxVectorSizeInBytes;
+  };
+  auto isLargeVectorContract = [&](vector::ContractionOp op) {
+    // TODO: Add support for verifying scalable vectors.
+    if (op.getLhsType().isScalable() || op.getRhsType().isScalable()) {
+      return false;
+    }
+
+    SmallVector<int64_t> iterationBounds;
+    op.getIterationBounds(iterationBounds);
+    int64_t size = getTotalSizeInBytes(getElementTypeOrSelf(op.getAccType()),
+                                       iterationBounds);
+    return size >= maxVectorSizeInBytes;
+  };
+
+  SmallVector<Operation *> invalidOps;
+  funcOp.walk([&](Operation *op) {
+    auto contractOp = dyn_cast<vector::ContractionOp>(op);
+    if (contractOp && isLargeVectorContract(contractOp)) {
+      invalidOps.push_back(op);
+      return;
+    }
+
+    SmallVector<Type> types(op->getOperandTypes());
+    llvm::append_range(types, op->getResultTypes());
+    if (llvm::any_of(types, checkFn)) {
+      invalidOps.push_back(op);
+    }
+  });
+  if (invalidOps.empty()) {
+    return;
+  }
+
+  // Error fall-through. Attach all reported issues as notes.
+  InFlightDiagnostic errorDiag =
+      emitError(funcOp.getLoc())
+      << "One or more operations with large vector sizes ("
+      << maxVectorSizeInBytes << " bytes) were found:\n";
+  for (Operation *op : invalidOps) {
+    errorDiag.attachNote(op->getLoc()) << "  " << *op << "\n";
+  }
+
+  signalPassFailure();
+}
+
+std::unique_ptr<InterfacePass<FunctionOpInterface>>
+createLLVMCPUVerifyVectorSizeLegalityPass(int64_t ratio) {
+  return std::make_unique<LLVMCPUVerifyVectorSizeLegalityPass>(ratio);
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -42,6 +42,11 @@ static llvm::cl::opt<bool> clFailOnOutOfBoundsStackAllocation(
                    "be solved"),
     llvm::cl::init(true));
 
+static llvm::cl::opt<bool> clFailOnLargeVector(
+    "iree-llvmcpu-fail-on-large-vector",
+    llvm::cl::desc("fail if there are operations with large vectors"),
+    llvm::cl::init(true));
+
 static llvm::cl::opt<bool> clCheckLinalgVectorization(
     "iree-llvmcpu-check-linalg-vectorization",
     llvm::cl::desc(
@@ -320,6 +325,9 @@ void addCPUBufferOpsTileAndVectorizePipeline(
     funcPassManager.addPass(createOptimizeTensorInsertExtractSlicesPass());
     funcPassManager.addPass(createCanonicalizerPass());
     funcPassManager.addPass(createCSEPass());
+    if (clFailOnLargeVector) {
+      funcPassManager.addPass(createLLVMCPUVerifyVectorSizeLegalityPass());
+    }
   }
 
   // Run IREE specific passes before vector lowering expert.
@@ -397,6 +405,9 @@ void addMultiTilingExpertPassPipeline(OpPassManager &funcPassManager,
     funcPassManager.addPass(createOptimizeTensorInsertExtractSlicesPass());
     funcPassManager.addPass(createCanonicalizerPass());
     funcPassManager.addPass(createCSEPass());
+    if (clFailOnLargeVector) {
+      funcPassManager.addPass(createLLVMCPUVerifyVectorSizeLegalityPass());
+    }
   }
 
   addCPUBufferizePasses(funcPassManager);
@@ -456,6 +467,9 @@ void addConvTileAndDecomposeExpertPassPipeline(
     funcPassManager.addPass(createOptimizeTensorInsertExtractSlicesPass());
     funcPassManager.addPass(createCanonicalizerPass());
     funcPassManager.addPass(createCSEPass());
+    if (clFailOnLargeVector) {
+      funcPassManager.addPass(createLLVMCPUVerifyVectorSizeLegalityPass());
+    }
   }
 
   // Eliminate redundant transfer_read/write to avoid stack allocations.
@@ -531,6 +545,9 @@ void addMmt4dTilingExpertPassPipeline(OpPassManager &funcPassManager,
     funcPassManager.addPass(createOptimizeTensorInsertExtractSlicesPass());
     funcPassManager.addPass(createCanonicalizerPass());
     funcPassManager.addPass(createCSEPass());
+    if (clFailOnLargeVector) {
+      funcPassManager.addPass(createLLVMCPUVerifyVectorSizeLegalityPass());
+    }
   }
 
   funcPassManager.addPass(createCanonicalizerPass());
@@ -576,6 +593,9 @@ void addCPUDataTilingPipeline(OpPassManager &funcPassManager,
     funcPassManager.addPass(createOptimizeTensorInsertExtractSlicesPass());
     funcPassManager.addPass(createCanonicalizerPass());
     funcPassManager.addPass(createCSEPass());
+    if (clFailOnLargeVector) {
+      funcPassManager.addPass(createLLVMCPUVerifyVectorSizeLegalityPass());
+    }
   }
 
   addCPUBufferizePasses(funcPassManager);
@@ -610,6 +630,9 @@ void addCPULinalgExtTileAndVectorizePipeline(
     funcPassManager.addPass(createOptimizeTensorInsertExtractSlicesPass());
     funcPassManager.addPass(createCanonicalizerPass());
     funcPassManager.addPass(createCSEPass());
+    if (clFailOnLargeVector) {
+      funcPassManager.addPass(createLLVMCPUVerifyVectorSizeLegalityPass());
+    }
   }
 
   addCPUBufferizePasses(funcPassManager);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
@@ -79,6 +79,9 @@ createLLVMCPUTilePass(int64_t tilingLevel = -1);
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createLLVMCPUUnfuseFMAOpsPass();
 
+std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
+createLLVMCPUVerifyVectorSizeLegalityPass(int64_t ratio = 512);
+
 //------------------------------------------------------------------------------
 // Passes to lower Vector ops before conversion to LLVM.
 //------------------------------------------------------------------------------

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
@@ -79,8 +79,10 @@ createLLVMCPUTilePass(int64_t tilingLevel = -1);
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createLLVMCPUUnfuseFMAOpsPass();
 
+/// Signals errors when there are large vectors in the IR.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createLLVMCPUVerifyVectorSizeLegalityPass(int64_t ratio = 512);
+createLLVMCPUVerifyVectorSizeLegalityPass(
+    int64_t maxAllowedNumberOfNativeVectors = 512);
 
 //------------------------------------------------------------------------------
 // Passes to lower Vector ops before conversion to LLVM.

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
@@ -142,6 +142,18 @@ def LLVMCPUTileAndFuse :
   ];
 }
 
+def LLVMCPUVerifyVectorSizeLegality :
+    InterfacePass<"iree-llvmcpu-verify-vector-size-legality", "mlir::FunctionOpInterface"> {
+  let summary =
+      "Signals errors when there are large vectors in the IR. I.e., one of"
+      "vector sizes is greater than ratio * native_vector_size";
+  let options = [
+    Option<"ratio", "ratio", "int64_t", /*default=*/"512",
+           "The ratio used in the computation of max vector size.">
+  ];
+  let constructor = "mlir::iree_compiler::createLLVMCPUVerifyVectorSizeLegalityPass()";
+}
+
 // Note: This pass is currently only required when targeting Arm SME (which is
 // the only target that currently has some concept of 2D scalability).
 def LLVMCPU2DScalableTo1DScalable :

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
@@ -146,9 +146,13 @@ def LLVMCPUVerifyVectorSizeLegality :
     InterfacePass<"iree-llvmcpu-verify-vector-size-legality", "mlir::FunctionOpInterface"> {
   let summary =
       "Signals errors when there are large vectors in the IR. I.e., one of"
-      "vector sizes is greater than ratio * native_vector_size";
+      "the vector sizes is greater than"
+      "maxAllowedNumberOfNativeVectors * native_vector_size. For scalable"
+      "vectors, it assumes that the vscale value is always 1. It may be an"
+      "underestimate if the runtime larger than 1, but it should still catch"
+      "unreasonable vector sizes.";
   let options = [
-    Option<"ratio", "ratio", "int64_t", /*default=*/"512",
+    Option<"maxAllowedNumberOfNativeVectors", "max-allowed-number-of-native-vectors", "int64_t", /*default=*/"512",
            "The ratio used in the computation of max vector size.">
   ];
   let constructor = "mlir::iree_compiler::createLLVMCPUVerifyVectorSizeLegalityPass()";

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD.bazel
@@ -66,6 +66,7 @@ iree_lit_test_suite(
             "vector_transpose_lowering.mlir",
             "vectorize_with_masking_and_hoist.mlir",
             "verify_linalg_transform_legality.mlir",
+            "verify_vector_size_legality.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
@@ -61,6 +61,7 @@ iree_lit_test_suite(
     "vector_transpose_lowering.mlir"
     "vectorize_with_masking_and_hoist.mlir"
     "verify_linalg_transform_legality.mlir"
+    "verify_vector_size_legality.mlir"
   TOOLS
     FileCheck
     iree-compile

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_peel_and_vectorize_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_peel_and_vectorize_tests.mlir
@@ -2,7 +2,7 @@
 
 #config = #iree_codegen.lowering_config<tile_sizes = [[64, 64, 0], [8, 32, 0], [0, 0, 16], [0, 0, 0]]>
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert, {enable_loop_peeling = true}>
-#executable_target_system_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "system-elf-x86_64">
+#executable_target_system_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "system-elf-x86_64", {native_vector_size = 64}>
 module {
   func.func @no_peel_static_matmul() attributes {hal.executable.target = #executable_target_system_elf_x86_64_, translation_info = #translation} {
     %cst = arith.constant 0.000000e+00 : f32
@@ -30,7 +30,7 @@ module {
 // -----
 #config = #iree_codegen.lowering_config<tile_sizes = [[65, 65, 0], [8, 32, 0], [0, 0, 16], [0, 0, 0]]>
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert, {enable_loop_peeling = true}>
-#executable_target_system_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "system-elf-x86_64">
+#executable_target_system_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "system-elf-x86_64", {native_vector_size = 64}>
 module {
   func.func @peel_static_matmul() attributes {hal.executable.target = #executable_target_system_elf_x86_64_, translation_info = #translation} {
     %cst = arith.constant 0.000000e+00 : f32
@@ -70,7 +70,7 @@ module {
 // -----
 #config = #iree_codegen.lowering_config<tile_sizes = [[64, 64, 0], [8, 32, 0], [0, 0, 16], [0, 0, 0]]>
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert, {enable_loop_peeling = true}>
-#executable_target_system_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "system-elf-x86_64">
+#executable_target_system_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "system-elf-x86_64", {native_vector_size = 64}>
 module {
   func.func @peel_dynamic_matmul() attributes {hal.executable.target = #executable_target_system_elf_x86_64_, translation_info = #translation} {
     %cst = arith.constant 0.000000e+00 : f32

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
@@ -92,7 +92,7 @@ module {
 //       CHECK:     arith.maximumf {{.*}} : vector<
 
 // -----
-#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {cpu_features = "", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "x86_64-none-elf"}>
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {cpu_features = "", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 64 : index, target_triple = "x86_64-none-elf"}>
 module {
   func.func @batch_matmul_dynamic() attributes {hal.executable.target = #executable_target_embedded_elf_x86_64_} {
     %cst = arith.constant 0.000000e+00 : f32
@@ -193,7 +193,7 @@ module {
 //       CHECK:    arith.cmpf olt, %{{.+}}, %{{.+}} : vector<4x4xf32>
 
 // -----
-#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {cpu = "generic", cpu_features = "", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "x86_64-none-elf"}>
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {cpu = "generic", cpu_features = "", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 64 : index, target_triple = "x86_64-none-elf"}>
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d1)>
 module {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/verify_vector_size_legality.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/verify_vector_size_legality.mlir
@@ -39,8 +39,39 @@ func.func @large_contract_with_native_vector_size(%lhs : vector<32x64xf32>, %rhs
 
 // -----
 
-// CHECK: func.func @scalable_vector
-func.func @scalable_vector(%arg0 : vector<[1]x64xf32>) -> vector<[1]x64xf32> {
-  %0 = math.exp %arg0 : vector<[1]x64xf32>
-  return %0 : vector<[1]x64xf32>
+// expected-error @+1 {{One or more operations with large vector sizes (4096 bytes) were found:}}
+func.func @large_scalable_vector_without_native_vector_size(%arg0 : vector<[16]x64xf32>) -> vector<[16]x64xf32> {
+  // expected-note-re @+1 {{math.exp}}
+  %0 = math.exp %arg0 : vector<[16]x64xf32>
+  // expected-note-re @+1 {{return}}
+  return %0 : vector<[16]x64xf32>
+}
+
+// -----
+
+// expected-error @+1 {{One or more operations with large vector sizes (8192 bytes) were found:}}
+func.func @large_scalable_vector_with_native_vector_size(%arg0 : vector<[16]x64x64xf32>) -> vector<[16]x64x64xf32> attributes {
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {native_vector_size = 16}>
+} {
+  // expected-note-re @+1 {{math.exp}}
+  %0 = math.exp %arg0 : vector<[16]x64x64xf32>
+  // expected-note-re @+1 {{return}}
+  return %0 : vector<[16]x64x64xf32>
+}
+
+// -----
+
+// expected-error @+1 {{One or more operations with large vector sizes (8192 bytes) were found:}}
+func.func @large_scalable_contract_with_native_vector_size(%lhs : vector<32x[64]xf32>, %rhs : vector<32x[64]xf32>, %acc : vector<32x32xf32>) -> vector<32x32xf32> attributes {
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {native_vector_size = 16}>
+} {
+  // expected-note-re @+1 {{vector.contract}}
+  %0 = vector.contract {
+      indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
+                       affine_map<(d0, d1, d2) -> (d1, d2)>,
+                       affine_map<(d0, d1, d2) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel", "reduction"],
+      kind = #vector.kind<add>}
+    %lhs, %rhs, %acc : vector<32x[64]xf32>, vector<32x[64]xf32> into vector<32x32xf32>
+  return %0 : vector<32x32xf32>
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/verify_vector_size_legality.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/verify_vector_size_legality.mlir
@@ -1,0 +1,46 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-llvmcpu-verify-vector-size-legality))" --split-input-file %s --verify-diagnostics
+
+// expected-error @+1 {{One or more operations with large vector sizes (4096 bytes) were found:}}
+func.func @large_vector_without_native_vector_size(%arg0 : vector<16x64xf32>) -> vector<16x64xf32> {
+  // expected-note-re @+1 {{math.exp}}
+  %0 = math.exp %arg0 : vector<16x64xf32>
+  // expected-note-re @+1 {{return}}
+  return %0 : vector<16x64xf32>
+}
+
+// -----
+
+// expected-error @+1 {{One or more operations with large vector sizes (32768 bytes) were found:}}
+func.func @large_vector_with_native_vector_size(%arg0 : vector<16x64x64xf32>) -> vector<16x64x64xf32> attributes {
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {native_vector_size = 64}>
+} {
+  // expected-note-re @+1 {{math.exp}}
+  %0 = math.exp %arg0 : vector<16x64x64xf32>
+  // expected-note-re @+1 {{return}}
+  return %0 : vector<16x64x64xf32>
+}
+
+// -----
+
+// expected-error @+1 {{One or more operations with large vector sizes (32768 bytes) were found:}}
+func.func @large_contract_with_native_vector_size(%lhs : vector<32x64xf32>, %rhs : vector<32x64xf32>, %acc : vector<32x32xf32>) -> vector<32x32xf32> attributes {
+  hal.executable.target = #hal.executable.target<"llvm-cpu", "xyz", {native_vector_size = 64}>
+} {
+  // expected-note-re @+1 {{vector.contract}}
+  %0 = vector.contract {
+      indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
+                       affine_map<(d0, d1, d2) -> (d1, d2)>,
+                       affine_map<(d0, d1, d2) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel", "reduction"],
+      kind = #vector.kind<add>}
+    %lhs, %rhs, %acc : vector<32x64xf32>, vector<32x64xf32> into vector<32x32xf32>
+  return %0 : vector<32x32xf32>
+}
+
+// -----
+
+// CHECK: func.func @scalable_vector
+func.func @scalable_vector(%arg0 : vector<[1]x64xf32>) -> vector<[1]x64xf32> {
+  %0 = math.exp %arg0 : vector<[1]x64xf32>
+  return %0 : vector<[1]x64xf32>
+}

--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -31,6 +31,7 @@ py_binary(
         "--iree-opt-data-tiling=false",
         "--iree-llvmcpu-enable-ukernels=none",
         "--iree-llvmcpu-enable-scalable-vectorization",
+        "--iree-llvmcpu-target-triple=aarch64-unknown-unknown",
     ],
     generator = ":generate_e2e_matmul_tests",
     generator_args = [
@@ -79,6 +80,7 @@ PREPROCESSING_PEEL = "--iree-llvmcpu-vector-pproc-strategy=peel"
     compiler_flags = [
                          "--iree-opt-data-tiling=false",
                          "--iree-llvmcpu-enable-scalable-vectorization",
+                         "--iree-llvmcpu-target-triple=aarch64-unknown-unknown",
                      ] + ([PREPROCESSING_TRANSPOSE_LHS] if transpose_lhs else []) +
                      ([PREPROCESSING_PEEL] if peel else []),
     generator = ":generate_e2e_matmul_tests",

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -30,6 +30,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     "--iree-opt-data-tiling=false"
     "--iree-llvmcpu-enable-scalable-vectorization"
+    "--iree-llvmcpu-target-triple=aarch64-unknown-unknown"
     "--iree-preprocessing-pass-pipeline=builtin.module\(util.func\(iree-preprocessing-transpose-matmul-pass{input=lhs}\)\)"
     "--iree-llvmcpu-vector-pproc-strategy=peel"
   LABELS
@@ -58,6 +59,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     "--iree-opt-data-tiling=false"
     "--iree-llvmcpu-enable-scalable-vectorization"
+    "--iree-llvmcpu-target-triple=aarch64-unknown-unknown"
     "--iree-preprocessing-pass-pipeline=builtin.module\(util.func\(iree-preprocessing-transpose-matmul-pass{input=lhs}\)\)"
   LABELS
     "requires-arm-sme"
@@ -85,6 +87,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     "--iree-opt-data-tiling=false"
     "--iree-llvmcpu-enable-scalable-vectorization"
+    "--iree-llvmcpu-target-triple=aarch64-unknown-unknown"
     "--iree-llvmcpu-vector-pproc-strategy=peel"
   LABELS
     "requires-arm-sme"
@@ -112,6 +115,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     "--iree-opt-data-tiling=false"
     "--iree-llvmcpu-enable-scalable-vectorization"
+    "--iree-llvmcpu-target-triple=aarch64-unknown-unknown"
   LABELS
     "requires-arm-sme"
   TARGET_CPU_FEATURES_VARIANTS
@@ -138,6 +142,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     "--iree-opt-data-tiling=false"
     "--iree-llvmcpu-enable-scalable-vectorization"
+    "--iree-llvmcpu-target-triple=aarch64-unknown-unknown"
     "--iree-preprocessing-pass-pipeline=builtin.module\(util.func\(iree-preprocessing-transpose-matmul-pass{input=lhs}\)\)"
     "--iree-llvmcpu-vector-pproc-strategy=peel"
   LABELS
@@ -166,6 +171,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     "--iree-opt-data-tiling=false"
     "--iree-llvmcpu-enable-scalable-vectorization"
+    "--iree-llvmcpu-target-triple=aarch64-unknown-unknown"
     "--iree-preprocessing-pass-pipeline=builtin.module\(util.func\(iree-preprocessing-transpose-matmul-pass{input=lhs}\)\)"
   LABELS
     "requires-arm-sme"
@@ -193,6 +199,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     "--iree-opt-data-tiling=false"
     "--iree-llvmcpu-enable-scalable-vectorization"
+    "--iree-llvmcpu-target-triple=aarch64-unknown-unknown"
     "--iree-llvmcpu-vector-pproc-strategy=peel"
   LABELS
     "requires-arm-sme"
@@ -220,6 +227,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     "--iree-opt-data-tiling=false"
     "--iree-llvmcpu-enable-scalable-vectorization"
+    "--iree-llvmcpu-target-triple=aarch64-unknown-unknown"
   LABELS
     "requires-arm-sme"
   TARGET_CPU_FEATURES_VARIANTS

--- a/tests/e2e/regression/lowering_config.mlir
+++ b/tests/e2e/regression/lowering_config.mlir
@@ -1,11 +1,11 @@
 #compilation0 = #iree_codegen.compilation_info<
-    lowering_config = <tile_sizes = [[32, 32], [8, 8, 0], [0, 0, 8], [0, 0, 0]]>,
+    lowering_config = <tile_sizes = [[32, 32], [1, 8, 0], [0, 0, 8], [0, 0, 0]]>,
     translation_info = <CPUDoubleTilingExpert>>
 #compilation1 = #iree_codegen.compilation_info<
-    lowering_config = <tile_sizes = [[64, 64], [4, 4, 0], [0, 0, 4], [0, 0, 0]]>,
+    lowering_config = <tile_sizes = [[64, 64], [1, 4, 0], [0, 0, 4], [0, 0, 0]]>,
     translation_info = <CPUDoubleTilingExpert>>
 #compilation2 = #iree_codegen.compilation_info<
-    lowering_config = <tile_sizes = [{sizes=[32, 64], interchange=[1,0]}, [8, 32, 0], [0, 0, 8], [0, 0, 0]]>,
+    lowering_config = <tile_sizes = [{sizes=[32, 64], interchange=[1, 0]}, [1, 1, 0], [0, 0, 8], [0, 0, 0]]>,
     translation_info = <CPUDoubleTilingExpert>>
 
 func.func @lowering_config_test() {
@@ -24,11 +24,11 @@ func.func @lowering_config_test() {
 // Conv dims: N, OH, OW, OC, KH, KW, (IC)
 // Remove H
 #conv_compilation0 = #iree_codegen.compilation_info<
-    lowering_config = <tile_sizes = [[0, 7, 7, 64, 0, 0, 0], [6, 1, 7, 32, 0, 0, 0], [0, 0, 0, 0, 1, 3, 4], [0, 0, 0, 0, 0, 0, 0]]>,
+    lowering_config = <tile_sizes = [[0, 7, 7, 64, 0, 0, 0], [1, 1, 7, 4, 0, 0, 0], [0, 0, 0, 0, 1, 3, 4], [0, 0, 0, 0, 0, 0, 0]]>,
     translation_info = <CPUConvTileAndDecomposeExpert>>
 // Remove W
 #conv_compilation1 = #iree_codegen.compilation_info<
-    lowering_config = <tile_sizes = [[0, 7, 7, 64, 0, 0, 0], [6, 7, 1, 32, 0, 0, 0], [0, 0, 0, 0, 3, 1, 4], [0, 0, 0, 0, 0, 0, 0]]>,
+    lowering_config = <tile_sizes = [[0, 7, 7, 64, 0, 0, 0], [1, 7, 1, 4, 0, 0, 0], [0, 0, 0, 0, 3, 1, 4], [0, 0, 0, 0, 0, 0, 0]]>,
     translation_info = <CPUConvTileAndDecomposeExpert>>
 func.func @conv() {
   %input = util.unfoldable_constant dense<1.0> : tensor<36x7x7x512xf32>


### PR DESCRIPTION
The default ratio is 512 because the codegen could generate ops with `vector<16x16x16xf32>` types in some tests. It should be revisited after we move codegen to a better state.

An additional `iree-llvmcpu-fail-on-large-vector` flag is added. It is on by default; it is a way to bypass the check for developers.

Additional changes:

- Update the preset tile sizes in `lowering_config.mlir`. It does not matter because it is just testing the e2e flow for preset compilation.
- Disable the check for `sdxl-scheduled-unet-3-tank` model. It should be removed after we fix the attention codegen issue.
- Disable the `sdxl-vae-decode-tank` model because of bad attention codegen. Different from the other one, it is generating ops with vector<512x32xf16> types, which should really just fail.

Fixes https://github.com/iree-org/iree/issues/17486