### PR TITLE
Enable end-of-file-fixer and trailing-whitespace hooks.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,13 +18,11 @@ repos:
         #   resulting in errors like `expected a single document in the stream`
         exclude: "mkdocs.yml|.clang-format"
 
-    # TODO(scotttodd): enable once enough contributors are familiar with pre-commit
-    # -   id: end-of-file-fixer
-    #     exclude_types: ["image", "jupyter"]
+    -   id: end-of-file-fixer
+        exclude_types: ["image", "jupyter"]
 
-    # TODO(scotttodd): enable once enough contributors are familiar with pre-commit
-    # -   id: trailing-whitespace
-    #     exclude_types: ["image", "jupyter"]
+    -   id: trailing-whitespace
+        exclude_types: ["image", "jupyter"]
 
 -   repo: https://github.com/psf/black
     rev: 23.3.0

--- a/compiler/src/iree/compiler/Codegen/Common/test/optimize_tensor_insert_extract_slices.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/optimize_tensor_insert_extract_slices.mlir
@@ -19,7 +19,7 @@ func.func @fold_extract_slice_consumer_into_xfer_write(%arg0: vector<1x64x128xf1
 
 // -----
 
-// Test the case where we write out of bounds because large index 
+// Test the case where we write out of bounds because large index
 func.func @fold_extract_slice_consumer_into_xfer_write_2(%arg0: vector<1x64x128xf16>, %arg1: index) -> tensor<1x?x128xf16> {
   %c0 = arith.constant 0 : index
   %c127 = arith.constant 127 : index

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/distribute_multi_mma.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/distribute_multi_mma.mlir
@@ -47,4 +47,3 @@ module attributes { transform.with_named_sequence } {
 //       CHECK:       tensor.parallel_insert_slice %[[MMA]] into %[[ITER_ARG]][0, 0, %[[IDS]]#0, %[[IDS]]#1]
 //  CHECK-SAME:         [2, 2, 4, 1] [1, 1, 1, 1] : tensor<2x2x4x1xf32> into tensor<2x2x16x16xf32>
 //       CHECK:   mapping = [#iree_gpu.lane_id<0>]
-


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree/issues/17430. We've had pre-commit enabled as blocking on PRs for about a week now and setup is documented at https://iree.dev/developers/general/contributing/#coding-style-guidelines, so I'm comfortable enforcing these extra checks:

* `end-of-file-fixer` ensures that files end with a single `\n` character, trimming extra newlines and inserting missing newlines
* `trailing-whitespace` ensures that lines in files do not contain trailing whitespace

Together, both of these hooks enforce more consistency in file formatting, making large scale changes easier and cleaner.