### PR TITLE
[util] Add serialization support for `f64` resources

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.cpp
@@ -469,12 +469,13 @@ static LogicalResult serializeGenericResourceElementData(
              << " for type " << resourceElementsAttr.getType();
     }
   } else if (auto floatType = llvm::dyn_cast<FloatType>(elementType)) {
-    // TODO(saienduri): implement float64 support (not necessary now)
     unsigned bitWidth = floatType.getIntOrFloatBitWidth();
     switch (bitWidth) {
     case 16:
       return serializeResourceRawData(loc, resourceElementsAttr, os);
     case 32:
+      return serializeResourceRawData(loc, resourceElementsAttr, os);
+    case 64:
       return serializeResourceRawData(loc, resourceElementsAttr, os);
     default:
       return emitError(loc) << "unhandled float element bit width " << bitWidth

--- a/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/test/constant_encoding.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/test/constant_encoding.mlir
@@ -182,4 +182,32 @@ vm.module @constants {
   // CHECK-NEXT:   1
   // CHECK-NEXT: ]
   vm.rodata private @byte_pattern_i2 #util.byte_pattern<1> : tensor<9xi2>
+
+    //      CHECK: "embedded_data": [
+    // CHECK-NEXT:   0,
+    // CHECK-NEXT:   0,
+    // CHECK-NEXT:   0,
+    // CHECK-NEXT:   0,
+    // CHECK-NEXT:   0,
+    // CHECK-NEXT:   0,
+    // CHECK-NEXT:   240,
+    // CHECK-NEXT:   63,
+    // CHECK-NEXT:   0,
+    // CHECK-NEXT:   0,
+    // CHECK-NEXT:   0,
+    // CHECK-NEXT:   0,
+    // CHECK-NEXT:   0,
+    // CHECK-NEXT:   0,
+    // CHECK-NEXT:   0,
+    // CHECK-NEXT:   64,
+    // CHECK-NEXT:   0,
+    // CHECK-NEXT:   0,
+    // CHECK-NEXT:   0,
+    // CHECK-NEXT:   0,
+    // CHECK-NEXT:   0,
+    // CHECK-NEXT:   0,
+    // CHECK-NEXT:   8,
+    // CHECK-NEXT:   64
+    // CHECK-NEXT: ]
+    vm.rodata private @dense_f64 dense<[1.000000e+00, 2.000000e+00, 3.000000e+00]> : tensor<3xf64>
 }


### PR DESCRIPTION
Serializing `f64` resources was strangely omitted from the logic while `f32` and `f16` support is present. Running things with `f64` is certainly not a good idea in general but relatively well-supported in the LLVM backend. Our use-case is the bring-up of a custom compiler backend where `f64` happens to be the most trivial element type to support.