### PR TITLE
Allow flags to be set with greater flexibility, plus flags bug fixes

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1834,14 +1834,24 @@ setWinogradRootConfig(mlir::FunctionOpInterface entryPointFn,
   assert(!getLoweringConfig(winogradOp) &&
          "expected lowering_config is not set");
   auto iterationRank = winogradOp.getIterationDomainRank();
-  SmallVector<int64_t> vecSizeHints(iterationRank, 1);
   DistributionHeuristicConfig distConfig;
+  SmallVector<int64_t> maxTileSizes(iterationRank, clDefaultDistTileSize);
+  maxTileSizes[0] = maxTileSizes[1] = 0;
+  SmallVector<int64_t> minTileSizes(iterationRank, 1);
+  minTileSizes[0] = minTileSizes[1] = 0;
+  SmallVector<int64_t> vecSizeHints(iterationRank, 1);
+  vecSizeHints[0] = vecSizeHints[1] = winogradOp.getInputTileSize();
   distConfig.vectorSizeHints = vecSizeHints;
+  distConfig.minTileSizes = minTileSizes;
+  distConfig.maxTileSizes = maxTileSizes;
   SmallVector<int64_t> distTileSizes =
       getDefaultDistributedLevelTileSizes(winogradOp, distConfig);
   TileSizesListType tileSizes;
   tileSizes.push_back(distTileSizes);
+  assert(distTileSizes[0] == 0 && distTileSizes[1] == 0 &&
+         "expected outer 2 distTileSizes to be 0");
   SmallVector<int64_t> vecTileSizes(iterationRank, 1);
+  vecTileSizes[0] = vecTileSizes[1] = winogradOp.getInputTileSize();
   tileSizes.push_back(vecTileSizes);
   return setOpConfigAndEntryPointFnTranslation(
       entryPointFn, winogradOp, tileSizes,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1847,7 +1847,7 @@ setWinogradRootConfig(mlir::FunctionOpInterface entryPointFn,
   perm.append(winogradOp.getNonInputTileDims());
   perm = invertPermutationVector(perm);
   DistributionHeuristicConfig distConfig;
-  SmallVector<int64_t> maxTileSizes(iterationRank, clDefaultDistTileSize / 4);
+  SmallVector<int64_t> maxTileSizes(iterationRank, clDefaultDistTileSize / 6);
   maxTileSizes[0] = maxTileSizes[1] = 0;
   SmallVector<int64_t> minTileSizes(iterationRank, 1);
   minTileSizes[0] = minTileSizes[1] = 0;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1833,7 +1833,11 @@ setWinogradRootConfig(mlir::FunctionOpInterface entryPointFn,
       "op expected to be a winograd op");
   assert(!getLoweringConfig(winogradOp) &&
          "expected lowering_config is not set");
+  SmallVector<int64_t> inputTileDims(winogradOp.getInputTileDimensions());
   auto iterationRank = winogradOp.getIterationDomainRank();
+  SmallVector<int64_t> perm(inputTileDims);
+  perm.append(winogradOp.getNonInputTileDims());
+  perm = invertPermutationVector(perm);
   DistributionHeuristicConfig distConfig;
   SmallVector<int64_t> maxTileSizes(iterationRank, clDefaultDistTileSize);
   maxTileSizes[0] = maxTileSizes[1] = 0;
@@ -1841,17 +1845,19 @@ setWinogradRootConfig(mlir::FunctionOpInterface entryPointFn,
   minTileSizes[0] = minTileSizes[1] = 0;
   SmallVector<int64_t> vecSizeHints(iterationRank, 1);
   vecSizeHints[0] = vecSizeHints[1] = winogradOp.getInputTileSize();
-  distConfig.vectorSizeHints = vecSizeHints;
-  distConfig.minTileSizes = minTileSizes;
-  distConfig.maxTileSizes = maxTileSizes;
+  distConfig.vectorSizeHints = applyPermutation(vecSizeHints, perm);
+  distConfig.minTileSizes = applyPermutation(minTileSizes, perm);
+  distConfig.maxTileSizes = applyPermutation(maxTileSizes, perm);
   SmallVector<int64_t> distTileSizes =
       getDefaultDistributedLevelTileSizes(winogradOp, distConfig);
   TileSizesListType tileSizes;
   tileSizes.push_back(distTileSizes);
-  assert(distTileSizes[0] == 0 && distTileSizes[1] == 0 &&
-         "expected outer 2 distTileSizes to be 0");
+  assert(distTileSizes[inputTileDims[0]] == 0 &&
+         distTileSizes[inputTileDims[1]] == 0 &&
+         "expected distTileSizes to be 0 for input tile");
   SmallVector<int64_t> vecTileSizes(iterationRank, 1);
-  vecTileSizes[0] = vecTileSizes[1] = winogradOp.getInputTileSize();
+  vecTileSizes[inputTileDims[0]] = vecTileSizes[inputTileDims[1]] =
+      winogradOp.getInputTileSize();
   tileSizes.push_back(vecTileSizes);
   return setOpConfigAndEntryPointFnTranslation(
       entryPointFn, winogradOp, tileSizes,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1839,7 +1839,7 @@ setWinogradRootConfig(mlir::FunctionOpInterface entryPointFn,
   perm.append(winogradOp.getNonInputTileDims());
   perm = invertPermutationVector(perm);
   DistributionHeuristicConfig distConfig;
-  SmallVector<int64_t> maxTileSizes(iterationRank, clDefaultDistTileSize);
+  SmallVector<int64_t> maxTileSizes(iterationRank, clDefaultDistTileSize / 4);
   maxTileSizes[0] = maxTileSizes[1] = 0;
   SmallVector<int64_t> minTileSizes(iterationRank, 1);
   minTileSizes[0] = minTileSizes[1] = 0;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1695,6 +1695,7 @@ static LogicalResult setRootConfig(mlir::FunctionOpInterface entryPointFn,
   // Fixup for making distTileSizes be multiple of inner_tile_sizes.
   SmallVector<int64_t> innerTiles = op.getStaticTiles();
   ArrayRef<int64_t> dimPos = op.getInnerDimsPos();
+  ArrayRef<int64_t> outerDimsPerm = op.getOuterDimsPerm();
   for (auto [pos, size] : llvm::zip_equal(dimPos, innerTiles)) {
     if (distTileSizes[pos] == 0 || ShapedType::isDynamic(size))
       continue;
@@ -1704,6 +1705,11 @@ static LogicalResult setRootConfig(mlir::FunctionOpInterface entryPointFn,
   SmallVector<int64_t> tileSizes(op.getDestRank(), 1);
   for (auto [pos, size] : llvm::zip_equal(dimPos, innerTiles)) {
     tileSizes[pos] = ShapedType::isDynamic(size) ? 1 : size;
+  }
+
+  // Adjust tile sizes for the outer dimensions permutation.
+  for (const auto &[index, pos] : llvm::enumerate(outerDimsPerm)) {
+    tileSizes[index] = std::max(tileSizes[pos], tileSizes[index]);
   }
 
   TileSizesListType tileSizesList = {distTileSizes, tileSizes};

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -595,6 +595,9 @@ void addCPULinalgExtTileAndVectorizePipeline(
   addTileAndDistributePasses(funcPassManager);
   funcPassManager.addPass(createLLVMCPUTileAndFusePass(
       tilingConfig.getVectorCommonParallelLevel()));
+  funcPassManager.addPass(createCanonicalizerPass());
+  funcPassManager.addPass(createCSEPass());
+  funcPassManager.addPass(createFuseTensorPadWithConsumerPass());
   // TODO: Remove the pass once we have PartialReductionOpInterface implemented
   // for AttentionOp.
   funcPassManager.addPass(IREE::LinalgExt::createTileAttentionPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -606,6 +606,7 @@ void addCPULinalgExtTileAndVectorizePipeline(
     GenericVectorizationPassOptions options;
     options.useConfiguredVectorSizes = pipelineOpt.useConfiguredVectorSizes;
     options.enableVectorMasking = pipelineOpt.enableVectorMasking;
+    options.vectorizePadding = true;
     funcPassManager.addPass(createGenericVectorizationPass(options));
     funcPassManager.addPass(createOptimizeTensorInsertExtractSlicesPass());
     funcPassManager.addPass(createCanonicalizerPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -593,8 +593,8 @@ void addCPULinalgExtTileAndVectorizePipeline(
     OpPassManager &funcPassManager, TilingConfig &tilingConfig,
     LLVMCPUPipelineOptions &pipelineOpt) {
   addTileAndDistributePasses(funcPassManager);
-  funcPassManager.addPass(
-      createLLVMCPUTilePass(tilingConfig.getVectorCommonParallelLevel()));
+  funcPassManager.addPass(createLLVMCPUTileAndFusePass(
+      tilingConfig.getVectorCommonParallelLevel()));
   // TODO: Remove the pass once we have PartialReductionOpInterface implemented
   // for AttentionOp.
   funcPassManager.addPass(IREE::LinalgExt::createTileAttentionPass());

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
@@ -588,6 +588,13 @@ isFusableWithConsumer(OpOperand &fusedOperand,
         .Default([](Operation *) { return false; });
   }
 
+  if (auto winogradOp =
+          dyn_cast<IREE::LinalgExt::WinogradInputTransformOp>(consumer)) {
+    return TypeSwitch<Operation *, bool>(producer)
+        .Case<tensor::PadOp>([&](auto padOp) { return true; })
+        .Default([](Operation *) { return false; });
+  }
+
   // By default, padding should be fused with producers. It is hard to square
   // this with fusion of pad with consumer. So for now split the difference.
   // Either fuse pad with producer or with consumer.
@@ -762,6 +769,13 @@ isFusableWithProducer(OpOperand &operand,
               cast<TilingInterface>(linalgOp.getOperation()),
               producerIndexingMap, rootOuterParallelLoops);
         })
+        .Default([](Operation *) { return false; });
+  }
+
+  if (auto winogradOp =
+          dyn_cast<IREE::LinalgExt::WinogradInputTransformOp>(consumer)) {
+    return TypeSwitch<Operation *, bool>(producer)
+        .Case<tensor::PadOp>([&](auto padOp) { return true; })
         .Default([](Operation *) { return false; });
   }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
@@ -545,7 +545,9 @@ isFusableWithConsumer(OpOperand &fusedOperand,
 
   // Fuse unset_encoding operations with `tensor.extract_slice` and elementwise
   // generic ops.
-  if (isUnpackLikeOpViaExtractSliceOps(producer)) {
+  if (isUnpackLikeOpViaExtractSliceOps(producer) ||
+      isa<IREE::LinalgExt::WinogradInputTransformOp,
+          IREE::LinalgExt::WinogradFilterTransformOp>(producer)) {
     // Fuse `unset_encoding` -> `extract_slice` op since they get folded into
     // `unpack` on materialization.
     if (isa<tensor::ExtractSliceOp>(consumer)) {
@@ -764,7 +766,9 @@ isFusableWithProducer(OpOperand &operand,
   }
 
   if (!isa<LinalgExt::LinalgFusionOpInterface>(consumer) ||
-      !isa<LinalgExt::LinalgFusionOpInterface>(producer)) {
+      !isa<LinalgExt::LinalgFusionOpInterface>(producer) ||
+      !isa<IREE::LinalgExt::WinogradInputTransformOp,
+           IREE::LinalgExt::WinogradFilterTransformOp>(producer)) {
     return false;
   }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/TensorPadToTensorInsertSlice.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/TensorPadToTensorInsertSlice.cpp
@@ -12,6 +12,7 @@
 
 #include "iree/compiler/Dialect/Encoding/IR/EncodingOps.h"
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -62,6 +63,9 @@ struct TensorPadOpConversion : public OpRewritePattern<tensor::PadOp> {
         if (isa<linalg::LinalgOp>(use) &&
             !isa<linalg::Conv2DNhwcHwcfQOp, linalg::DepthwiseConv2DNhwcHwcQOp,
                  linalg::DepthwiseConv2DNhwcHwcmQOp>(use)) {
+          return failure();
+        }
+        if (isa<LinalgExt::WinogradInputTransformOp>(use)) {
           return failure();
         }
       }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -1017,13 +1017,15 @@ def IREELinalgExt_WinogradInputTransformOp : IREELinalgExt_Op<"winograd.input_tr
                        Variadic<AnyShaped>:$outputs,
                        I64Attr:$output_tile_size,
                        I64Attr:$kernel_size,
-                       DenseI64ArrayAttr:$image_dimensions
+                       DenseI64ArrayAttr:$image_dimensions,
+                       DenseI64ArrayAttr:$input_tile_dimensions
   );
 
   let builders = [
     OpBuilder<(ins "ValueRange":$inputs, "ValueRange":$outputs,
       CArg<"int64_t", "8">:$output_tile_size, CArg<"int64_t", "3">:$kernel_size,
-      CArg<"ArrayRef<int64_t>", "{1, 2}">:$image_dimensions)>
+      CArg<"ArrayRef<int64_t>", "{1, 2}">:$image_dimensions,
+      CArg<"ArrayRef<int64_t>", "{0, 1}">:$input_tile_dimensions)>
   ];
 
   let results = (outs Variadic<AnyRankedTensor>:$result);
@@ -1033,6 +1035,7 @@ def IREELinalgExt_WinogradInputTransformOp : IREELinalgExt_Op<"winograd.input_tr
     `output_tile_size` `(` $output_tile_size `)`
     `kernel_size` `(` $kernel_size `)`
     `image_dimensions` `(` $image_dimensions `)`
+    `input_tile_dimensions` `(` $input_tile_dimensions `)`
     `ins` `(` $inputs `:` type($inputs) `)`
     `outs` `(` $outputs `:` type($outputs) `)`
     (`->` type($result)^)?
@@ -1092,6 +1095,8 @@ def IREELinalgExt_WinogradInputTransformOp : IREELinalgExt_Op<"winograd.input_tr
     int getChannelDim() {
       return isNhwc() ? 3 : 1;
     }
+    // Utility for mapping non input tile dims to the actual result dims
+    SmallVector<int64_t> getNonInputTileDims();
     int64_t getIterationDomainRank() {
       return getOutputRank();
     }
@@ -1129,13 +1134,15 @@ def IREELinalgExt_WinogradFilterTransformOp : IREELinalgExt_Op<"winograd.filter_
                        Variadic<AnyShaped>:$outputs,
                        I64Attr:$output_tile_size,
                        I64Attr:$kernel_size,
-                       DenseI64ArrayAttr:$kernel_dimensions
+                       DenseI64ArrayAttr:$kernel_dimensions,
+                       DenseI64ArrayAttr:$input_tile_dimensions
   );
 
   let builders = [
     OpBuilder<(ins "ValueRange":$inputs, "ValueRange":$outputs,
       CArg<"int64_t", "8">:$output_tile_size, CArg<"int64_t", "3">:$kernel_size,
-      CArg<"ArrayRef<int64_t>", "{0, 1}">:$kernel_dimensions)>
+      CArg<"ArrayRef<int64_t>", "{0, 1}">:$kernel_dimensions,
+      CArg<"ArrayRef<int64_t>", "{0, 1}">:$input_tile_dimensions)>
   ];
 
   let results = (outs Variadic<AnyRankedTensor>:$result);
@@ -1145,6 +1152,7 @@ def IREELinalgExt_WinogradFilterTransformOp : IREELinalgExt_Op<"winograd.filter_
     `output_tile_size` `(` $output_tile_size `)`
     `kernel_size` `(` $kernel_size `)`
     `kernel_dimensions` `(` $kernel_dimensions `)`
+    `input_tile_dimensions` `(` $input_tile_dimensions `)`
     `ins` `(` $inputs `:` type($inputs) `)`
     `outs` `(` $outputs `:` type($outputs) `)`
     (`->` type($result)^)?
@@ -1209,6 +1217,8 @@ def IREELinalgExt_WinogradFilterTransformOp : IREELinalgExt_Op<"winograd.filter_
     int getFilterDim() {
       return isHwcf() ? 3 : 0;
     }
+    // Utility for mapping non input tile dims to the actual result dims
+    SmallVector<int64_t> getNonInputTileDims();
     int64_t getIterationDomainRank() {
       return getOutputRank();
     }
@@ -1249,13 +1259,15 @@ def IREELinalgExt_WinogradOutputTransformOp : IREELinalgExt_Op<"winograd.output_
                        Variadic<AnyShaped>:$outputs,
                        I64Attr:$output_tile_size,
                        I64Attr:$kernel_size,
-                       DenseI64ArrayAttr:$image_dimensions
+                       DenseI64ArrayAttr:$image_dimensions,
+                       DenseI64ArrayAttr:$input_tile_dimensions
   );
 
   let builders = [
     OpBuilder<(ins "ValueRange":$inputs, "ValueRange":$outputs,
       CArg<"int64_t", "8">:$output_tile_size, CArg<"int64_t", "3">:$kernel_size,
-      CArg<"ArrayRef<int64_t>", "{1, 2}">:$image_dimensions)>
+      CArg<"ArrayRef<int64_t>", "{1, 2}">:$image_dimensions,
+      CArg<"ArrayRef<int64_t>", "{0, 1}">:$input_tile_dimensions)>
   ];
 
   let results = (outs Variadic<AnyRankedTensor>:$result);
@@ -1265,6 +1277,7 @@ def IREELinalgExt_WinogradOutputTransformOp : IREELinalgExt_Op<"winograd.output_
     `output_tile_size` `(` $output_tile_size `)`
     `kernel_size` `(` $kernel_size `)`
     `image_dimensions` `(` $image_dimensions `)`
+    `input_tile_dimensions` `(` $input_tile_dimensions `)`
     `ins` `(` $inputs `:` type($inputs) `)`
     `outs` `(` $outputs `:` type($outputs) `)`
     (`->` type($result)^)?
@@ -1321,6 +1334,8 @@ def IREELinalgExt_WinogradOutputTransformOp : IREELinalgExt_Op<"winograd.output_
     int64_t getOutputRank() {
       return getOutputType().getRank();
     }
+    // Utility for mapping non input tile dims to the actual result dims
+    SmallVector<int64_t> getNonInputTileDims();
     int64_t getIterationDomainRank() {
       return getInputRank();
     }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -1072,6 +1072,11 @@ def IREELinalgExt_WinogradInputTransformOp : IREELinalgExt_Op<"winograd.input_tr
     int64_t getOutputRank() {
       return getOutputType().getRank();
     }
+    bool hasBatch() {
+      int batchRank = getImageDimensions().size() +
+                      getInputTileDimensions().size() + 2;
+      return getOutputRank() == batchRank;
+    }
     int64_t getInputTileSize() {
       return getOutputTileSize() + getKernelSize() - 1;
     }
@@ -1079,10 +1084,14 @@ def IREELinalgExt_WinogradInputTransformOp : IREELinalgExt_Op<"winograd.input_tr
       return getImageDimensions();
     }
     std::array<int64_t, 2> nhwcImageDimensions() {
-      return {1, 2};
+      std::array<int64_t, 2> batched = {1, 2};
+      std::array<int64_t, 2> unbatched = {0, 1};
+      return hasBatch() ? batched : unbatched;
     }
     std::array<int64_t, 2> nchwImageDimensions() {
-      return {2, 3};
+      std::array<int64_t, 2> batched = {2, 3};
+      std::array<int64_t, 2> unbatched = {1, 2};
+      return hasBatch() ? batched : unbatched;
     }
     bool isNhwc() {
       std::array<int64_t, 2> nhwcImageDims = nhwcImageDimensions();
@@ -1093,7 +1102,10 @@ def IREELinalgExt_WinogradInputTransformOp : IREELinalgExt_Op<"winograd.input_tr
       return getImageDimensions() == ArrayRef<int64_t>(nchwImageDims);
     }
     int getChannelDim() {
-      return isNhwc() ? 3 : 1;
+      int cDim = isNhwc() ? 3 : 1;
+      if (!hasBatch())
+        cDim--;
+      return cDim;
     }
     // Utility for mapping non input tile dims to the actual result dims
     SmallVector<int64_t> getNonInputTileDims();
@@ -1296,6 +1308,17 @@ def IREELinalgExt_WinogradOutputTransformOp : IREELinalgExt_Op<"winograd.output_
     ShapedType getOutputType() {
       return cast<ShapedType>(getOutput().getType());
     }
+    int64_t getInputRank() {
+      return getInputType().getRank();
+    }
+    int64_t getOutputRank() {
+      return getOutputType().getRank();
+    }
+    bool hasBatch() {
+      int batchRank = getImageDimensions().size() +
+                      getInputTileDimensions().size() + 2;
+      return getInputRank() == batchRank;
+    }
     Value getOriginalOperand() {
       return getOutput();
     }
@@ -1312,10 +1335,14 @@ def IREELinalgExt_WinogradOutputTransformOp : IREELinalgExt_Op<"winograd.output_
       return getImageDimensions();
     }
     std::array<int64_t, 2> nhwcImageDimensions() {
-      return {1, 2};
+      std::array<int64_t, 2> batched = {1, 2};
+      std::array<int64_t, 2> unbatched = {0, 1};
+      return hasBatch() ? batched : unbatched;
     }
     std::array<int64_t, 2> nchwImageDimensions() {
-      return {2, 3};
+      std::array<int64_t, 2> batched = {2, 3};
+      std::array<int64_t, 2> unbatched = {1, 2};
+      return hasBatch() ? batched : unbatched;
     }
     bool isNhwc() {
       std::array<int64_t, 2> nhwcImageDims = nhwcImageDimensions();
@@ -1326,13 +1353,10 @@ def IREELinalgExt_WinogradOutputTransformOp : IREELinalgExt_Op<"winograd.output_
       return getImageDimensions() == ArrayRef<int64_t>(nchwImageDims);
     }
     int getChannelDim() {
-      return isNhwc() ? 3 : 1;
-    }
-    int64_t getInputRank() {
-      return getInputType().getRank();
-    }
-    int64_t getOutputRank() {
-      return getOutputType().getRank();
+      int cDim = isNhwc() ? 3 : 1;
+      if (!hasBatch())
+        cDim--;
+      return cDim;
     }
     // Utility for mapping non input tile dims to the actual result dims
     SmallVector<int64_t> getNonInputTileDims();

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -997,7 +997,8 @@ def IREELinalgExt_WinogradInputTransformOp : IREELinalgExt_Op<"winograd.input_tr
       ["getIterationDomain",
        "getLoopIteratorTypes",
        "getResultTilePosition",
-       "getTiledImplementation"]>]> {
+       "getTiledImplementation",
+       "generateResultTileValue"]>]> {
   let summary = "Winograd Input Transform operator";
   let description = [{
     This operator is part of the first step in converting a convolution to
@@ -1092,7 +1093,7 @@ def IREELinalgExt_WinogradInputTransformOp : IREELinalgExt_Op<"winograd.input_tr
       return isNhwc() ? 3 : 1;
     }
     int64_t getIterationDomainRank() {
-      return getOutputRank() - getImageDimensions().size();
+      return getOutputRank();
     }
     // Method to implement for specifying output range for
     // DestinationStyleOpInterface
@@ -1108,7 +1109,8 @@ def IREELinalgExt_WinogradFilterTransformOp : IREELinalgExt_Op<"winograd.filter_
       ["getIterationDomain",
        "getLoopIteratorTypes",
        "getResultTilePosition",
-       "getTiledImplementation"]>]> {
+       "getTiledImplementation",
+       "generateResultTileValue"]>]> {
   let summary = "Winograd Filter Transform operator";
   let description = [{
     This operator is part of the first step in converting a convolution to
@@ -1208,7 +1210,7 @@ def IREELinalgExt_WinogradFilterTransformOp : IREELinalgExt_Op<"winograd.filter_
       return isHwcf() ? 3 : 0;
     }
     int64_t getIterationDomainRank() {
-      return getInputRank() - getKernelDimensions().size();
+      return getOutputRank();
     }
     // Method to implement for specifying output range for
     // DestinationStyleOpInterface
@@ -1320,7 +1322,7 @@ def IREELinalgExt_WinogradOutputTransformOp : IREELinalgExt_Op<"winograd.output_
       return getOutputType().getRank();
     }
     int64_t getIterationDomainRank() {
-      return getInputRank() - getImageDimensions().size();
+      return getInputRank();
     }
     int64_t getInputTileSize() {
       return getOutputTileSize() + getKernelSize() - 1;

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeWinogradPass.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeWinogradPass.cpp
@@ -58,8 +58,9 @@ struct FoldWinogradOpUnitDims : public OpRewritePattern<TransformOp> {
     SmallVector<int64_t> newOriginalShape = llvm::map_to_vector(
         hwDims, [&](int64_t dim) { return originalShape[dim]; });
     auto newOriginalType = originalType.clone(newOriginalShape);
-    SmallVector<int64_t> newTransformedShape(transformedShape.begin(),
-                                             transformedShape.begin() + 2);
+    SmallVector<int64_t> newTransformedShape =
+        llvm::map_to_vector(transformOp.getInputTileDimensions(),
+                            [&](int64_t dim) { return transformedShape[dim]; });
     auto newTransformedType = transformedType.clone(newTransformedShape);
     RankedTensorType newInputType = newOriginalType;
     RankedTensorType newOutputType = newTransformedType;

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeWinogradPass.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeWinogradPass.cpp
@@ -357,6 +357,7 @@ void DecomposeWinogradTransformPass::runOnOperation() {
   patterns.add<DecomposeWinogradFilterTransform>(context);
   patterns.add<DecomposeWinogradInputTransform>(context);
   patterns.add<DecomposeWinogradOutputTransform>(context);
+  memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);
   if (failed(
           applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
     return signalPassFailure();

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TilingInterfaceImpl.cpp
@@ -18,6 +18,7 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"
+#include "mlir/IR/OpDefinition.h"
 
 namespace mlir::iree_compiler::IREE::LinalgExt {
 
@@ -1252,9 +1253,7 @@ WinogradInputTransformOp::getIterationDomain(OpBuilder &builder) {
     loopBounds[dim].size = getDimValue(builder, loc, getOutput(), dim);
     loopBounds[dim].stride = one;
   }
-  SmallVector<int64_t> perm(getInputTileDimensions());
-  perm.append(getNonInputTileDims());
-  return applyPermutation(loopBounds, perm);
+  return loopBounds;
 }
 
 SmallVector<utils::IteratorType>
@@ -1273,11 +1272,15 @@ WinogradInputTransformOp::getTiledImplementation(OpBuilder &builder,
   const int cDim = getChannelDim();
 
   assert(offsets.size() == 6);
+  SmallVector<int64_t> perm(getInputTileDimensions());
+  perm.append(getNonInputTileDims());
+  SmallVector<OpFoldResult> offsetsPermuted = applyPermutation(offsets, perm);
+  SmallVector<OpFoldResult> sizesPermuted = applyPermutation(sizes, perm);
   SmallVector<OpFoldResult> inputOffsets(getInputRank(), zero);
   const auto hDim = getImageDimensions()[0];
   const auto wDim = getImageDimensions()[1];
-  inputOffsets[0] = offsets[2];
-  inputOffsets[cDim] = offsets[5];
+  inputOffsets[0] = offsetsPermuted[2];
+  inputOffsets[cDim] = offsetsPermuted[5];
 
   ReifiedRankedShapedTypeDims reifiedInputShapes;
   if (failed(getStaticOrReifiedInputDims(builder, loc, getInput(),
@@ -1287,15 +1290,15 @@ WinogradInputTransformOp::getTiledImplementation(OpBuilder &builder,
   SmallVector<OpFoldResult> inputSizes = reifiedInputShapes[0];
 
   assert(sizes.size() == 6);
-  inputSizes[0] = sizes[2];
-  inputSizes[cDim] = sizes[5];
+  inputSizes[0] = sizesPermuted[2];
+  inputSizes[cDim] = sizesPermuted[5];
 
   auto hSizeAndOffset = getScaledSizeAndOffset(
-      builder, loc, sizes[3], offsets[3], inputSizes[hDim], getOutputTileSize(),
-      getInputTileSize());
+      builder, loc, sizesPermuted[3], offsetsPermuted[3], inputSizes[hDim],
+      getOutputTileSize(), getInputTileSize());
   auto wSizeAndOffset = getScaledSizeAndOffset(
-      builder, loc, sizes[4], offsets[4], inputSizes[wDim], getOutputTileSize(),
-      getInputTileSize());
+      builder, loc, sizesPermuted[4], offsetsPermuted[4], inputSizes[wDim],
+      getOutputTileSize(), getInputTileSize());
 
   inputSizes[hDim] = hSizeAndOffset.first;
   inputSizes[wDim] = wSizeAndOffset.first;
@@ -1308,13 +1311,8 @@ WinogradInputTransformOp::getTiledImplementation(OpBuilder &builder,
   tiledOperands.emplace_back(getSlice(builder, loc, getInput(), inputOffsets,
                                       inputSizes, inputStrides));
   SmallVector<OpFoldResult> outputStrides(getOutputRank(), one);
-  SmallVector<int64_t> perm(getInputTileDimensions());
-  perm.append(getNonInputTileDims());
-  perm = invertPermutationVector(perm);
-  SmallVector<OpFoldResult> outputSizes = applyPermutation(sizes, perm);
-  SmallVector<OpFoldResult> outputOffsets = applyPermutation(offsets, perm);
-  tiledOperands.emplace_back(getSlice(builder, loc, getOutput(), outputOffsets,
-                                      outputSizes, outputStrides));
+  tiledOperands.emplace_back(
+      getSlice(builder, loc, getOutput(), offsets, sizes, outputStrides));
 
   SmallVector<Type, 4> resultTypes;
   if (hasPureTensorSemantics()) {
@@ -1332,11 +1330,8 @@ LogicalResult WinogradInputTransformOp::getResultTilePosition(
     ArrayRef<OpFoldResult> sizes, SmallVector<OpFoldResult> &resultOffsets,
     SmallVector<OpFoldResult> &resultSizes) {
   if (resultNumber == 0) {
-    SmallVector<int64_t> perm(getInputTileDimensions());
-    perm.append(getNonInputTileDims());
-    perm = invertPermutationVector(perm);
-    resultSizes = applyPermutation(sizes, perm);
-    resultOffsets = applyPermutation(offsets, perm);
+    resultSizes = SmallVector<OpFoldResult>(sizes);
+    resultOffsets = SmallVector<OpFoldResult>(offsets);
     return success();
   }
   return failure();
@@ -1346,11 +1341,8 @@ FailureOr<TilingResult> WinogradInputTransformOp::generateResultTileValue(
     OpBuilder &b, unsigned resultNumber, ArrayRef<OpFoldResult> offsets,
     ArrayRef<OpFoldResult> sizes) {
   int64_t numLoops = getIterationDomainRank();
-  SmallVector<int64_t> perm(getInputTileDimensions());
-  perm.append(getNonInputTileDims());
-  auto tileOffsets = applyPermutation(offsets.take_front(numLoops), perm);
-  auto tileSizes = applyPermutation(sizes.take_front(numLoops), perm);
-  return getTiledImplementation(b, tileOffsets, tileSizes);
+  return getTiledImplementation(b, offsets.take_front(numLoops),
+                                sizes.take_front(numLoops));
 }
 
 //===----------------------------------------------------------------------===//
@@ -1368,9 +1360,7 @@ WinogradFilterTransformOp::getIterationDomain(OpBuilder &builder) {
     loopBounds[dim].size = getDimValue(builder, loc, getOutput(), dim);
     loopBounds[dim].stride = one;
   }
-  SmallVector<int64_t> perm(getInputTileDimensions());
-  perm.append(getNonInputTileDims());
-  return applyPermutation(loopBounds, perm);
+  return loopBounds;
 }
 
 SmallVector<utils::IteratorType>
@@ -1390,29 +1380,28 @@ FailureOr<TilingResult> WinogradFilterTransformOp::getTiledImplementation(
   const int fDim = getFilterDim();
 
   assert(offsets.size() == 4);
+  SmallVector<int64_t> perm(getInputTileDimensions());
+  perm.append(getNonInputTileDims());
+  SmallVector<OpFoldResult> offsetsPermuted = applyPermutation(offsets, perm);
+  SmallVector<OpFoldResult> sizesPermuted = applyPermutation(sizes, perm);
   SmallVector<OpFoldResult> inputOffsets(getInputRank(), zero);
-  inputOffsets[cDim] = offsets[2];
-  inputOffsets[fDim] = offsets[3];
+  inputOffsets[cDim] = offsetsPermuted[2];
+  inputOffsets[fDim] = offsetsPermuted[3];
 
   assert(sizes.size() == 4);
   ArrayRef<int64_t> inputShape = getInputType().getShape();
   SmallVector<OpFoldResult> inputSizes =
       getAsOpFoldResult(builder.getIndexArrayAttr(inputShape));
-  inputSizes[cDim] = sizes[2];
-  inputSizes[fDim] = sizes[3];
+  inputSizes[cDim] = sizesPermuted[2];
+  inputSizes[fDim] = sizesPermuted[3];
 
   SmallVector<Value> tiledOperands;
   SmallVector<OpFoldResult> inputStrides(getInputRank(), one);
   tiledOperands.emplace_back(getSlice(builder, loc, getInput(), inputOffsets,
                                       inputSizes, inputStrides));
   SmallVector<OpFoldResult> outputStrides(getOutputRank(), one);
-  SmallVector<int64_t> perm(getInputTileDimensions());
-  perm.append(getNonInputTileDims());
-  perm = invertPermutationVector(perm);
-  SmallVector<OpFoldResult> outputSizes = applyPermutation(sizes, perm);
-  SmallVector<OpFoldResult> outputOffsets = applyPermutation(offsets, perm);
-  tiledOperands.emplace_back(getSlice(builder, loc, getOutput(), outputOffsets,
-                                      outputSizes, outputStrides));
+  tiledOperands.emplace_back(
+      getSlice(builder, loc, getOutput(), offsets, sizes, outputStrides));
 
   SmallVector<Type> resultTypes;
   if (hasPureTensorSemantics()) {
@@ -1432,11 +1421,8 @@ LogicalResult WinogradFilterTransformOp::getResultTilePosition(
   if (resultNumber != 0) {
     return failure();
   }
-  SmallVector<int64_t> perm(getInputTileDimensions());
-  perm.append(getNonInputTileDims());
-  perm = invertPermutationVector(perm);
-  resultSizes = applyPermutation(sizes, perm);
-  resultOffsets = applyPermutation(offsets, perm);
+  resultSizes = SmallVector<OpFoldResult>(sizes);
+  resultOffsets = SmallVector<OpFoldResult>(offsets);
   return success();
 }
 
@@ -1444,11 +1430,8 @@ FailureOr<TilingResult> WinogradFilterTransformOp::generateResultTileValue(
     OpBuilder &b, unsigned resultNumber, ArrayRef<OpFoldResult> offsets,
     ArrayRef<OpFoldResult> sizes) {
   int64_t numLoops = getIterationDomainRank();
-  SmallVector<int64_t> perm(getInputTileDimensions());
-  perm.append(getNonInputTileDims());
-  auto tileOffsets = applyPermutation(offsets.take_front(numLoops), perm);
-  auto tileSizes = applyPermutation(sizes.take_front(numLoops), perm);
-  return getTiledImplementation(b, tileOffsets, tileSizes);
+  return getTiledImplementation(b, offsets.take_front(numLoops),
+                                sizes.take_front(numLoops));
 }
 
 //===----------------------------------------------------------------------===//
@@ -1466,9 +1449,7 @@ WinogradOutputTransformOp::getIterationDomain(OpBuilder &builder) {
     loopBounds[dim].size = getDimValue(builder, loc, getInput(), dim);
     loopBounds[dim].stride = one;
   }
-  SmallVector<int64_t> perm(getInputTileDimensions());
-  perm.append(getNonInputTileDims());
-  return applyPermutation(loopBounds, perm);
+  return loopBounds;
 }
 
 SmallVector<utils::IteratorType>
@@ -1487,12 +1468,16 @@ FailureOr<TilingResult> WinogradOutputTransformOp::getTiledImplementation(
   const int cDim = getChannelDim();
 
   assert(offsets.size() == 6);
+  SmallVector<int64_t> perm(getInputTileDimensions());
+  perm.append(getNonInputTileDims());
+  SmallVector<OpFoldResult> sizesPermuted = applyPermutation(sizes, perm);
+  SmallVector<OpFoldResult> offsetsPermuted = applyPermutation(offsets, perm);
   const auto hDim = getImageDimensions()[0];
   const auto wDim = getImageDimensions()[1];
   SmallVector<OpFoldResult> outputOffsets(getOutputRank(), zero);
 
-  outputOffsets[0] = offsets[2];
-  outputOffsets[cDim] = offsets[5];
+  outputOffsets[0] = offsetsPermuted[2];
+  outputOffsets[cDim] = offsetsPermuted[5];
 
   ReifiedRankedShapedTypeDims reifiedResultShapes;
   if (failed(reifyResultShapes(builder, reifiedResultShapes))) {
@@ -1501,14 +1486,14 @@ FailureOr<TilingResult> WinogradOutputTransformOp::getTiledImplementation(
   SmallVector<OpFoldResult> outputSizes = reifiedResultShapes[0];
 
   assert(sizes.size() == 6);
-  outputSizes[0] = sizes[2];
-  outputSizes[cDim] = sizes[5];
+  outputSizes[0] = sizesPermuted[2];
+  outputSizes[cDim] = sizesPermuted[5];
 
   auto hSizeAndOffset = getScaledSizeAndOffset(
-      builder, loc, sizes[3], offsets[3], outputSizes[hDim],
+      builder, loc, sizesPermuted[3], offsetsPermuted[3], outputSizes[hDim],
       getOutputTileSize(), getOutputTileSize());
   auto wSizeAndOffset = getScaledSizeAndOffset(
-      builder, loc, sizes[4], offsets[4], outputSizes[wDim],
+      builder, loc, sizesPermuted[4], offsetsPermuted[4], outputSizes[wDim],
       getOutputTileSize(), getOutputTileSize());
 
   outputSizes[hDim] = hSizeAndOffset.first;
@@ -1524,11 +1509,11 @@ FailureOr<TilingResult> WinogradOutputTransformOp::getTiledImplementation(
   // maintain more static information in the IR.
   auto outSliceType = cast<ShapedType>(outputSlice.getType());
   SmallVector<int64_t> staticOutShape(outSliceType.getShape());
-  auto constSizeH = getConstantIntValue(sizes[3]);
+  auto constSizeH = getConstantIntValue(sizesPermuted[3]);
   if (constSizeH.has_value()) {
     staticOutShape[hDim] = constSizeH.value() * getOutputTileSize();
   }
-  auto constSizeW = getConstantIntValue(sizes[4]);
+  auto constSizeW = getConstantIntValue(sizesPermuted[4]);
   if (constSizeW.has_value()) {
     staticOutShape[wDim] = constSizeW.value() * getOutputTileSize();
   }
@@ -1537,13 +1522,8 @@ FailureOr<TilingResult> WinogradOutputTransformOp::getTiledImplementation(
 
   SmallVector<Value> tiledOperands;
   SmallVector<OpFoldResult> inputStrides(getInputRank(), one);
-  SmallVector<int64_t> perm(getInputTileDimensions());
-  perm.append(getNonInputTileDims());
-  perm = invertPermutationVector(perm);
-  SmallVector<OpFoldResult> inputSizes = applyPermutation(sizes, perm);
-  SmallVector<OpFoldResult> inputOffsets = applyPermutation(offsets, perm);
-  tiledOperands.emplace_back(getSlice(builder, loc, getInput(), inputOffsets,
-                                      inputSizes, inputStrides));
+  tiledOperands.emplace_back(
+      getSlice(builder, loc, getInput(), offsets, sizes, inputStrides));
   tiledOperands.emplace_back(staticOutputSlice);
 
   SmallVector<Type, 4> resultTypes;
@@ -1573,21 +1553,25 @@ LogicalResult WinogradOutputTransformOp::getResultTilePosition(
     const int cDim = getChannelDim();
     const auto hDim = getImageDimensions()[0];
     const auto wDim = getImageDimensions()[1];
+    SmallVector<int64_t> perm(getInputTileDimensions());
+    perm.append(getNonInputTileDims());
+    SmallVector<OpFoldResult> sizesPermuted = applyPermutation(sizes, perm);
+    SmallVector<OpFoldResult> offsetsPermuted = applyPermutation(offsets, perm);
     auto loc = getLoc();
-    resultOffsets[0] = offsets[2];
-    resultOffsets[cDim] = offsets[5];
-    resultSizes[0] = sizes[2];
-    resultSizes[cDim] = sizes[5];
+    resultOffsets[0] = offsetsPermuted[2];
+    resultOffsets[cDim] = offsetsPermuted[5];
+    resultSizes[0] = sizesPermuted[2];
+    resultSizes[cDim] = sizesPermuted[5];
     SmallVector<SmallVector<OpFoldResult>> reifiedResultShapes;
     if (failed(reifyResultShapes(builder, reifiedResultShapes))) {
       return failure();
     }
     auto hSizeAndOffset = getScaledSizeAndOffset(
-        builder, loc, sizes[3], offsets[3], reifiedResultShapes[0][hDim],
-        getOutputTileSize(), getOutputTileSize());
+        builder, loc, sizesPermuted[3], offsetsPermuted[3],
+        reifiedResultShapes[0][hDim], getOutputTileSize(), getOutputTileSize());
     auto wSizeAndOffset = getScaledSizeAndOffset(
-        builder, loc, sizes[4], offsets[4], reifiedResultShapes[0][wDim],
-        getOutputTileSize(), getOutputTileSize());
+        builder, loc, sizesPermuted[4], offsetsPermuted[4],
+        reifiedResultShapes[0][wDim], getOutputTileSize(), getOutputTileSize());
 
     resultSizes[hDim] = hSizeAndOffset.first;
     resultSizes[wDim] = wSizeAndOffset.first;

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TilingInterfaceImpl.cpp
@@ -1245,15 +1245,11 @@ WinogradInputTransformOp::getIterationDomain(OpBuilder &builder) {
   Location loc = getLoc();
   Value zero = builder.create<arith::ConstantIndexOp>(loc, 0);
   Value one = builder.create<arith::ConstantIndexOp>(loc, 1);
-  Value dest = getOutput();
   SmallVector<Range> loopBounds(getIterationDomainRank());
-  int count = 0;
-  for (auto dim :
-       llvm::seq<int64_t>(getImageDimensions().size(), getOutputRank())) {
-    loopBounds[count].offset = zero;
-    loopBounds[count].size = getDimValue(builder, loc, dest, dim);
-    loopBounds[count].stride = one;
-    count++;
+  for (int dim = 0; dim < getOutputRank(); ++dim) {
+    loopBounds[dim].offset = zero;
+    loopBounds[dim].size = getDimValue(builder, loc, getOutput(), dim);
+    loopBounds[dim].stride = one;
   }
   return loopBounds;
 }
@@ -1270,44 +1266,32 @@ WinogradInputTransformOp::getTiledImplementation(OpBuilder &builder,
                                                  ArrayRef<OpFoldResult> offsets,
                                                  ArrayRef<OpFoldResult> sizes) {
   Location loc = getLoc();
-  auto one = builder.getIndexAttr(1);
   auto zero = builder.getIndexAttr(0);
   const int cDim = getChannelDim();
 
-  assert(offsets.size() == 4);
+  assert(offsets.size() == 6);
   SmallVector<OpFoldResult> inputOffsets(getInputRank(), zero);
-  SmallVector<OpFoldResult> outputOffsets(getOutputRank(), zero);
   const auto hDim = getImageDimensions()[0];
   const auto wDim = getImageDimensions()[1];
-  outputOffsets[2] = inputOffsets[0] = offsets[0];
-  outputOffsets[3] = offsets[1];
-  outputOffsets[4] = offsets[2];
-  outputOffsets[5] = inputOffsets[cDim] = offsets[3];
+  inputOffsets[0] = offsets[2];
+  inputOffsets[cDim] = offsets[5];
 
-  SmallVector<OpFoldResult> inputStrides(getInputRank(), one);
-  SmallVector<OpFoldResult> outputStrides(getOutputRank(), one);
-  ReifiedRankedShapedTypeDims reifiedResultShapes, reifiedInputShapes;
-  if (failed(reifyResultShapes(builder, reifiedResultShapes))) {
-    return failure();
-  }
-  SmallVector<OpFoldResult> outputSizes = reifiedResultShapes[0];
+  ReifiedRankedShapedTypeDims reifiedInputShapes;
   if (failed(getStaticOrReifiedInputDims(builder, loc, getInput(),
                                          reifiedInputShapes))) {
     return failure();
   }
   SmallVector<OpFoldResult> inputSizes = reifiedInputShapes[0];
 
-  assert(sizes.size() == 4);
-  outputSizes[2] = inputSizes[0] = sizes[0];
-  outputSizes[3] = sizes[1];
-  outputSizes[4] = sizes[2];
-  outputSizes[5] = inputSizes[cDim] = sizes[3];
+  assert(sizes.size() == 6);
+  inputSizes[0] = sizes[2];
+  inputSizes[cDim] = sizes[5];
 
   auto hSizeAndOffset = getScaledSizeAndOffset(
-      builder, loc, sizes[1], offsets[1], inputSizes[hDim], getOutputTileSize(),
+      builder, loc, sizes[3], offsets[3], inputSizes[hDim], getOutputTileSize(),
       getInputTileSize());
   auto wSizeAndOffset = getScaledSizeAndOffset(
-      builder, loc, sizes[2], offsets[2], inputSizes[wDim], getOutputTileSize(),
+      builder, loc, sizes[4], offsets[4], inputSizes[wDim], getOutputTileSize(),
       getInputTileSize());
 
   inputSizes[hDim] = hSizeAndOffset.first;
@@ -1316,10 +1300,13 @@ WinogradInputTransformOp::getTiledImplementation(OpBuilder &builder,
   inputOffsets[wDim] = wSizeAndOffset.second;
 
   SmallVector<Value> tiledOperands;
+  auto one = builder.getIndexAttr(1);
+  SmallVector<OpFoldResult> inputStrides(getInputRank(), one);
   tiledOperands.emplace_back(getSlice(builder, loc, getInput(), inputOffsets,
                                       inputSizes, inputStrides));
-  tiledOperands.emplace_back(getSlice(builder, loc, getOutput(), outputOffsets,
-                                      outputSizes, outputStrides));
+  SmallVector<OpFoldResult> outputStrides(getOutputRank(), one);
+  tiledOperands.emplace_back(
+      getSlice(builder, loc, getOutput(), offsets, sizes, outputStrides));
 
   SmallVector<Type, 4> resultTypes;
   if (hasPureTensorSemantics()) {
@@ -1337,21 +1324,19 @@ LogicalResult WinogradInputTransformOp::getResultTilePosition(
     ArrayRef<OpFoldResult> sizes, SmallVector<OpFoldResult> &resultOffsets,
     SmallVector<OpFoldResult> &resultSizes) {
   if (resultNumber == 0) {
-    auto resultShape = cast<ShapedType>(getOutput().getType()).getShape();
-    resultSizes = getAsOpFoldResult(builder.getIndexArrayAttr(resultShape));
-    resultOffsets =
-        SmallVector<OpFoldResult>(getOutputRank(), builder.getIndexAttr(0));
-    resultOffsets[2] = offsets[0];
-    resultOffsets[3] = offsets[1];
-    resultOffsets[4] = offsets[2];
-    resultOffsets[5] = offsets[3];
-    resultSizes[2] = sizes[0];
-    resultSizes[3] = sizes[1];
-    resultSizes[4] = sizes[2];
-    resultSizes[5] = sizes[3];
+    resultSizes = SmallVector<OpFoldResult>(sizes);
+    resultOffsets = SmallVector<OpFoldResult>(offsets);
     return success();
   }
   return failure();
+}
+
+FailureOr<TilingResult> WinogradInputTransformOp::generateResultTileValue(
+    OpBuilder &b, unsigned resultNumber, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes) {
+  int64_t numLoops = getIterationDomainRank();
+  return getTiledImplementation(b, offsets.take_front(numLoops),
+                                sizes.take_front(numLoops));
 }
 
 //===----------------------------------------------------------------------===//
@@ -1363,15 +1348,11 @@ WinogradFilterTransformOp::getIterationDomain(OpBuilder &builder) {
   Location loc = getLoc();
   OpFoldResult zero = builder.getIndexAttr(0);
   OpFoldResult one = builder.getIndexAttr(1);
-  Value source = getOutput();
-  int64_t numKernelDims = getKernelDimensions().size();
-  auto outRank = getOutputRank();
-  SmallVector<Range> loopBounds(outRank - numKernelDims);
-  for (auto dim : llvm::seq<int64_t>(numKernelDims, outRank)) {
-    int64_t loopDim = dim - numKernelDims;
-    loopBounds[loopDim].offset = zero;
-    loopBounds[loopDim].size = getDimValue(builder, loc, source, dim);
-    loopBounds[loopDim].stride = one;
+  SmallVector<Range> loopBounds(getOutputRank());
+  for (int dim = 0; dim < getOutputRank(); ++dim) {
+    loopBounds[dim].offset = zero;
+    loopBounds[dim].size = getDimValue(builder, loc, getOutput(), dim);
+    loopBounds[dim].stride = one;
   }
   return loopBounds;
 }
@@ -1392,30 +1373,25 @@ FailureOr<TilingResult> WinogradFilterTransformOp::getTiledImplementation(
   const int cDim = getChannelDim();
   const int fDim = getFilterDim();
 
-  assert(offsets.size() == 2);
+  assert(offsets.size() == 4);
   SmallVector<OpFoldResult> inputOffsets(getInputRank(), zero);
-  SmallVector<OpFoldResult> outputOffsets(getOutputRank(), zero);
-  outputOffsets[2] = inputOffsets[cDim] = offsets[0];
-  outputOffsets[3] = inputOffsets[fDim] = offsets[1];
+  inputOffsets[cDim] = offsets[2];
+  inputOffsets[fDim] = offsets[3];
 
-  SmallVector<OpFoldResult> inputStrides(getInputRank(), one);
-  SmallVector<OpFoldResult> outputStrides(getOutputRank(), one);
-
-  assert(sizes.size() == 2);
+  assert(sizes.size() == 4);
   ArrayRef<int64_t> inputShape = getInputType().getShape();
-  ArrayRef<int64_t> outputShape = getOutputType().getShape();
   SmallVector<OpFoldResult> inputSizes =
       getAsOpFoldResult(builder.getIndexArrayAttr(inputShape));
-  SmallVector<OpFoldResult> outputSizes =
-      getAsOpFoldResult(builder.getIndexArrayAttr(outputShape));
-  outputSizes[2] = inputSizes[cDim] = sizes[0];
-  outputSizes[3] = inputSizes[fDim] = sizes[1];
+  inputSizes[cDim] = sizes[2];
+  inputSizes[fDim] = sizes[3];
 
   SmallVector<Value> tiledOperands;
+  SmallVector<OpFoldResult> inputStrides(getInputRank(), one);
   tiledOperands.emplace_back(getSlice(builder, loc, getInput(), inputOffsets,
                                       inputSizes, inputStrides));
-  tiledOperands.emplace_back(getSlice(builder, loc, getOutput(), outputOffsets,
-                                      outputSizes, outputStrides));
+  SmallVector<OpFoldResult> outputStrides(getOutputRank(), one);
+  tiledOperands.emplace_back(
+      getSlice(builder, loc, getOutput(), offsets, sizes, outputStrides));
 
   SmallVector<Type> resultTypes;
   if (hasPureTensorSemantics()) {
@@ -1435,15 +1411,17 @@ LogicalResult WinogradFilterTransformOp::getResultTilePosition(
   if (resultNumber != 0) {
     return failure();
   }
-  ArrayRef<int64_t> resultShape = getOutputType().getShape();
-  resultSizes = getAsOpFoldResult(builder.getIndexArrayAttr(resultShape));
-  resultOffsets =
-      SmallVector<OpFoldResult>(getOutputRank(), builder.getIndexAttr(0));
-  resultOffsets[2] = offsets[0];
-  resultOffsets[3] = offsets[1];
-  resultSizes[2] = sizes[0];
-  resultSizes[3] = sizes[1];
+  resultSizes = SmallVector<OpFoldResult>(sizes);
+  resultOffsets = SmallVector<OpFoldResult>(offsets);
   return success();
+}
+
+FailureOr<TilingResult> WinogradFilterTransformOp::generateResultTileValue(
+    OpBuilder &b, unsigned resultNumber, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes) {
+  int64_t numLoops = getIterationDomainRank();
+  return getTiledImplementation(b, offsets.take_front(numLoops),
+                                sizes.take_front(numLoops));
 }
 
 //===----------------------------------------------------------------------===//
@@ -1455,15 +1433,11 @@ WinogradOutputTransformOp::getIterationDomain(OpBuilder &builder) {
   Location loc = getLoc();
   Value zero = builder.create<arith::ConstantIndexOp>(loc, 0);
   Value one = builder.create<arith::ConstantIndexOp>(loc, 1);
-  Value source = getInput();
   SmallVector<Range> loopBounds(getIterationDomainRank());
-  int count = 0;
-  for (auto dim :
-       llvm::seq<int64_t>(getImageDimensions().size(), getInputRank())) {
-    loopBounds[count].offset = zero;
-    loopBounds[count].size = getDimValue(builder, loc, source, dim);
-    loopBounds[count].stride = one;
-    count++;
+  for (int dim = 0; dim < getInputRank(); ++dim) {
+    loopBounds[dim].offset = zero;
+    loopBounds[dim].size = getDimValue(builder, loc, getInput(), dim);
+    loopBounds[dim].stride = one;
   }
   return loopBounds;
 }
@@ -1483,45 +1457,29 @@ FailureOr<TilingResult> WinogradOutputTransformOp::getTiledImplementation(
   auto zero = builder.getIndexAttr(0);
   const int cDim = getChannelDim();
 
-  assert(offsets.size() == 4);
+  assert(offsets.size() == 6);
   const auto hDim = getImageDimensions()[0];
   const auto wDim = getImageDimensions()[1];
-  SmallVector<OpFoldResult> inputOffsets(getInputRank(), zero);
   SmallVector<OpFoldResult> outputOffsets(getOutputRank(), zero);
 
-  inputOffsets[2] = outputOffsets[0] = offsets[0];
-  inputOffsets[3] = offsets[1];
-  inputOffsets[4] = offsets[2];
-  inputOffsets[5] = outputOffsets[cDim] = offsets[3];
+  outputOffsets[0] = offsets[2];
+  outputOffsets[cDim] = offsets[5];
 
-  SmallVector<OpFoldResult> inputStrides(getInputRank(), one);
-  SmallVector<OpFoldResult> outputStrides(getOutputRank(), one);
-
-  ReifiedRankedShapedTypeDims reifiedResultShapes, reifiedInputShapes;
+  ReifiedRankedShapedTypeDims reifiedResultShapes;
   if (failed(reifyResultShapes(builder, reifiedResultShapes))) {
     return failure();
   }
   SmallVector<OpFoldResult> outputSizes = reifiedResultShapes[0];
-  if (failed(getStaticOrReifiedInputDims(builder, loc, getInput(),
-                                         reifiedInputShapes))) {
-    return failure();
-  }
-  SmallVector<OpFoldResult> inputSizes = reifiedInputShapes[0];
 
-  inputSizes[2] = outputSizes[0] = sizes[0];
-  inputSizes[5] = outputSizes[cDim] = sizes[3];
-
-  assert(sizes.size() == 4);
-  inputSizes[2] = outputSizes[0] = sizes[0];
-  inputSizes[3] = sizes[1];
-  inputSizes[4] = sizes[2];
-  inputSizes[5] = outputSizes[cDim] = sizes[3];
+  assert(sizes.size() == 6);
+  outputSizes[0] = sizes[2];
+  outputSizes[cDim] = sizes[5];
 
   auto hSizeAndOffset = getScaledSizeAndOffset(
-      builder, loc, sizes[1], offsets[1], outputSizes[hDim],
+      builder, loc, sizes[3], offsets[3], outputSizes[hDim],
       getOutputTileSize(), getOutputTileSize());
   auto wSizeAndOffset = getScaledSizeAndOffset(
-      builder, loc, sizes[2], offsets[2], outputSizes[wDim],
+      builder, loc, sizes[4], offsets[4], outputSizes[wDim],
       getOutputTileSize(), getOutputTileSize());
 
   outputSizes[hDim] = hSizeAndOffset.first;
@@ -1529,6 +1487,7 @@ FailureOr<TilingResult> WinogradOutputTransformOp::getTiledImplementation(
   outputOffsets[hDim] = hSizeAndOffset.second;
   outputOffsets[wDim] = wSizeAndOffset.second;
 
+  SmallVector<OpFoldResult> outputStrides(getOutputRank(), one);
   Value outputSlice = getSlice(builder, loc, getOutput(), outputOffsets,
                                outputSizes, outputStrides);
   // The image dims of the winograd.output_transform result will always be a
@@ -1536,11 +1495,11 @@ FailureOr<TilingResult> WinogradOutputTransformOp::getTiledImplementation(
   // maintain more static information in the IR.
   auto outSliceType = cast<ShapedType>(outputSlice.getType());
   SmallVector<int64_t> staticOutShape(outSliceType.getShape());
-  auto constSizeH = getConstantIntValue(sizes[1]);
+  auto constSizeH = getConstantIntValue(sizes[3]);
   if (constSizeH.has_value()) {
     staticOutShape[hDim] = constSizeH.value() * getOutputTileSize();
   }
-  auto constSizeW = getConstantIntValue(sizes[2]);
+  auto constSizeW = getConstantIntValue(sizes[4]);
   if (constSizeW.has_value()) {
     staticOutShape[wDim] = constSizeW.value() * getOutputTileSize();
   }
@@ -1548,8 +1507,9 @@ FailureOr<TilingResult> WinogradOutputTransformOp::getTiledImplementation(
       castValue(builder, loc, outputSlice, outSliceType.clone(staticOutShape));
 
   SmallVector<Value> tiledOperands;
-  tiledOperands.emplace_back(getSlice(builder, loc, getInput(), inputOffsets,
-                                      inputSizes, inputStrides));
+  SmallVector<OpFoldResult> inputStrides(getInputRank(), one);
+  tiledOperands.emplace_back(
+      getSlice(builder, loc, getInput(), offsets, sizes, inputStrides));
   tiledOperands.emplace_back(staticOutputSlice);
 
   SmallVector<Type, 4> resultTypes;
@@ -1580,19 +1540,19 @@ LogicalResult WinogradOutputTransformOp::getResultTilePosition(
     const auto hDim = getImageDimensions()[0];
     const auto wDim = getImageDimensions()[1];
     auto loc = getLoc();
-    resultOffsets[0] = offsets[0];
-    resultOffsets[cDim] = offsets[3];
-    resultSizes[0] = sizes[0];
-    resultSizes[cDim] = sizes[3];
+    resultOffsets[0] = offsets[2];
+    resultOffsets[cDim] = offsets[5];
+    resultSizes[0] = sizes[2];
+    resultSizes[cDim] = sizes[5];
     SmallVector<SmallVector<OpFoldResult>> reifiedResultShapes;
     if (failed(reifyResultShapes(builder, reifiedResultShapes))) {
       return failure();
     }
     auto hSizeAndOffset = getScaledSizeAndOffset(
-        builder, loc, sizes[1], offsets[1], reifiedResultShapes[0][hDim],
+        builder, loc, sizes[3], offsets[3], reifiedResultShapes[0][hDim],
         getOutputTileSize(), getOutputTileSize());
     auto wSizeAndOffset = getScaledSizeAndOffset(
-        builder, loc, sizes[2], offsets[2], reifiedResultShapes[0][wDim],
+        builder, loc, sizes[4], offsets[4], reifiedResultShapes[0][wDim],
         getOutputTileSize(), getOutputTileSize());
 
     resultSizes[hDim] = hSizeAndOffset.first;

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TilingInterfaceImpl.cpp
@@ -1520,23 +1520,24 @@ FailureOr<TilingResult> WinogradOutputTransformOp::getTiledImplementation(
   // multiple of the static output_tile_size, so insert a tensor.cast op to
   // maintain more static information in the IR.
   auto outSliceType = cast<ShapedType>(outputSlice.getType());
-  SmallVector<int64_t> staticOutShape(outSliceType.getShape());
-  auto constSizeH = getConstantIntValue(sizesPermuted[sizesHDim]);
-  if (constSizeH.has_value()) {
-    staticOutShape[hDim] = constSizeH.value() * getOutputTileSize();
-  }
-  auto constSizeW = getConstantIntValue(sizesPermuted[sizesWDim]);
-  if (constSizeW.has_value()) {
-    staticOutShape[wDim] = constSizeW.value() * getOutputTileSize();
-  }
-  Value staticOutputSlice =
-      castValue(builder, loc, outputSlice, outSliceType.clone(staticOutShape));
+  // SmallVector<int64_t> staticOutShape(outSliceType.getShape());
+  // auto constSizeH = getConstantIntValue(sizesPermuted[sizesHDim]);
+  // if (constSizeH.has_value()) {
+  //   staticOutShape[hDim] = constSizeH.value() * getOutputTileSize();
+  // }
+  // auto constSizeW = getConstantIntValue(sizesPermuted[sizesWDim]);
+  // if (constSizeW.has_value()) {
+  //   staticOutShape[wDim] = constSizeW.value() * getOutputTileSize();
+  // }
+  // Value staticOutputSlice =
+  //     castValue(builder, loc, outputSlice,
+  //     outSliceType.clone(staticOutShape));
 
   SmallVector<Value> tiledOperands;
   SmallVector<OpFoldResult> inputStrides(getInputRank(), one);
   tiledOperands.emplace_back(
       getSlice(builder, loc, getInput(), offsets, sizes, inputStrides));
-  tiledOperands.emplace_back(staticOutputSlice);
+  tiledOperands.emplace_back(outputSlice);
 
   SmallVector<Type, 4> resultTypes;
   if (hasPureTensorSemantics()) {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
@@ -70,11 +70,9 @@ Value createValueFrom2DConstant(const float *val, int64_t rows, int64_t cols,
 SmallVector<int64_t> asShapeWithAnyValueAsDynamic(ArrayRef<OpFoldResult> ofrs);
 
 enum class Permutation {
-  NCHW_TO_NHWC,
-  NHWC_TO_NCHW,
   FCHW_TO_HWCF,
-  TTNHWC_TO_TTNCHW,
-  TTNCHW_TO_TTNHWC,
+  HWC_TO_CHW,
+  CHW_TO_HWC,
   TTFC_TO_TTCF,
 };
 
@@ -82,21 +80,15 @@ enum class Permutation {
 template <Permutation P, typename T>
 static void permute(SmallVectorImpl<T> &vector) {
   switch (P) {
-  case Permutation::NCHW_TO_NHWC:
-    std::rotate(vector.begin() + 1, vector.begin() + 2, vector.end());
-    break;
-  case Permutation::NHWC_TO_NCHW:
-    std::rotate(vector.rbegin(), vector.rbegin() + 1, vector.rend() - 1);
-    break;
   case Permutation::FCHW_TO_HWCF:
     std::rotate(vector.begin(), vector.begin() + 2, vector.end()); // to HWFC
     std::rotate(vector.rbegin(), vector.rbegin() + 1, vector.rend() - 2);
     break;
-  case Permutation::TTNCHW_TO_TTNHWC:
-    std::rotate(vector.begin() + 3, vector.begin() + 4, vector.end());
+  case Permutation::CHW_TO_HWC:
+    std::rotate(vector.rbegin(), vector.rbegin() + 2, vector.rbegin() + 3);
     break;
-  case Permutation::TTNHWC_TO_TTNCHW:
-    std::rotate(vector.rbegin(), vector.rbegin() + 1, vector.rend() - 3);
+  case Permutation::HWC_TO_CHW:
+    std::rotate(vector.rbegin(), vector.rbegin() + 1, vector.rbegin() + 3);
     break;
   case Permutation::TTFC_TO_TTCF:
     std::rotate(vector.rbegin(), vector.rbegin() + 1, vector.rend() - 2);

--- a/runtime/bindings/python/hal.h
+++ b/runtime/bindings/python/hal.h
@@ -145,7 +145,7 @@ class HalDriver : public ApiRefCounted<HalDriver, iree_hal_driver_t> {
  public:
   static std::vector<std::string> Query();
   static py::object Create(const std::string& device_uri,
-                           py::dict& driver_cache);
+                           py::dict& driver_cache, std::optional<bool> clean);
 
   py::list QueryAvailableDevices();
   HalDevice CreateDefaultDevice(std::optional<py::list> allocators);

--- a/runtime/bindings/python/initialize_module.cc
+++ b/runtime/bindings/python/initialize_module.cc
@@ -16,6 +16,13 @@
 #include "iree/base/internal/flags.h"
 #include "iree/hal/drivers/init.h"
 
+namespace {
+// Stable storage for flag processing.  Flag handling uses string views,
+// expecting the caller to keep the original strings around for as long
+// as the flags are in use.
+std::vector<std::string> alloced_flags;
+}  // namespace
+
 namespace iree {
 namespace python {
 
@@ -35,7 +42,7 @@ NB_MODULE(_runtime, m) {
   SetupVmBindings(m);
 
   m.def("parse_flags", [](py::args py_flags) {
-    std::vector<std::string> alloced_flags;
+    alloced_flags.clear();
     alloced_flags.push_back("python");
     for (py::handle py_flag : py_flags) {
       alloced_flags.push_back(py::cast<std::string>(py_flag));

--- a/runtime/bindings/python/iree/runtime/system_setup.py
+++ b/runtime/bindings/python/iree/runtime/system_setup.py
@@ -25,9 +25,16 @@ def query_available_drivers() -> Collection[str]:
     return HalDriver.query()
 
 
-def get_driver(device_uri: str) -> HalDriver:
-    """Returns a HAL driver by device_uri (or driver name)."""
-    return get_cached_hal_driver(device_uri)
+def get_driver(device_uri: str, clean: bool = False) -> HalDriver:
+    """Returns a HAL driver by device_uri (or driver name).
+
+    Args:
+      device_uri: The URI of the device, either just a driver name for the
+        default or a fully qualified "driver://path?params".
+      clean: Whether to clean out any cached driver and make a new one
+        (default False).
+    """
+    return get_cached_hal_driver(device_uri, clean)
 
 
 def get_device(device_uri: str, cache: bool = True) -> HalDevice:

--- a/tests/e2e/linalg/BUILD.bazel
+++ b/tests/e2e/linalg/BUILD.bazel
@@ -97,15 +97,17 @@ iree_check_single_backend_test_suite(
     target_backend = "llvm-cpu",
 )
 
-iree_check_single_backend_test_suite(
-    name = "check_winograd_vulkan-spirv_vulkan",
-    srcs = WINOGRAD_CONV_SRCS,
-    compiler_flags = [
-        "--iree-preprocessing-pass-pipeline=builtin.module\\(func.func\\(iree-linalg-ext-convert-conv2d-to-winograd\\)\\)",
-    ],
-    driver = "vulkan",
-    target_backend = "vulkan-spirv",
-)
+# XXX(Max191): Winograd transform ops are updated, while the code on SPIR-V are
+# not updated yet. Comment out for now.
+# iree_check_single_backend_test_suite(
+#     name = "check_winograd_vulkan-spirv_vulkan",
+#     srcs = WINOGRAD_CONV_SRCS,
+#     compiler_flags = [
+#         "--iree-preprocessing-pass-pipeline=builtin.module\\(func.func\\(iree-linalg-ext-convert-conv2d-to-winograd\\)\\)",
+#     ],
+#     driver = "vulkan",
+#     target_backend = "vulkan-spirv",
+# )
 
 CUDA_SRCS = enforce_glob(
     # keep sorted

--- a/tests/e2e/linalg/CMakeLists.txt
+++ b/tests/e2e/linalg/CMakeLists.txt
@@ -66,19 +66,6 @@ iree_check_single_backend_test_suite(
 
 iree_check_single_backend_test_suite(
   NAME
-    check_winograd_vulkan-spirv_vulkan
-  SRCS
-    "conv2d.mlir"
-  TARGET_BACKEND
-    "vulkan-spirv"
-  DRIVER
-    "vulkan"
-  COMPILER_FLAGS
-    "--iree-preprocessing-pass-pipeline=builtin.module\(func.func\(iree-linalg-ext-convert-conv2d-to-winograd\)\)"
-)
-
-iree_check_single_backend_test_suite(
-  NAME
     check_large_linalg_matmul_cuda
   SRCS
     "conv2d.mlir"

--- a/tests/e2e/linalg_ext_ops/BUILD.bazel
+++ b/tests/e2e/linalg_ext_ops/BUILD.bazel
@@ -145,8 +145,6 @@ iree_check_single_backend_test_suite(
             # Top-k test disabled due to miscompile on vulkan.
             #    "top-k.mlir",
             "sort.mlir",
-            "winograd_input.mlir",
-            "winograd_output.mlir",
         ],
         include = ["*.mlir"],
         exclude = [
@@ -156,6 +154,10 @@ iree_check_single_backend_test_suite(
             # Re-enable this once we have new devices with up-to-date drivers.
             "top-k.mlir",
             "scan.mlir",
+            # XXX(Max191): Winograd transform ops are updated, while the code on
+            # SPIR-V are not updated yet. Comment out for now.
+            "winograd_input.mlir",
+            "winograd_output.mlir",
         ],
     ),
     driver = "vulkan",

--- a/tests/e2e/linalg_ext_ops/CMakeLists.txt
+++ b/tests/e2e/linalg_ext_ops/CMakeLists.txt
@@ -113,8 +113,6 @@ iree_check_single_backend_test_suite(
   SRCS
     "scatter.mlir"
     "sort.mlir"
-    "winograd_input.mlir"
-    "winograd_output.mlir"
   TARGET_BACKEND
     "vulkan-spirv"
   DRIVER


### PR DESCRIPTION
Same as #17659 on the main branch.

Changes to the python binding to allow iree.runtime.flags.parse_flags to take effect at times other than before the first time a driver is created. Also includes fixes for bugs exposed during the development of this feature.

-    Added "internal" API functions create_hal_driver() and clear_hal_driver_cache() to create a driver object independent of the cache, and to clear the cache, respectively
-    Added HalDriver class implementation functions for the above new API functions. Refactored class to share as much common code as possible.
-    Factored out driver URI processing into its own nested class for easier handling of URI components
-    Fixed dangling pointer bug. In the C layer flags are being kept by reference as string views, requiring the caller to keep the original flag strings (argc, argv) around for as long as the flags are being used. However, the python binding was using a local variable for those strings, letting them go out of scope and causing garbage values later on. The fix is to move the strings to a file scope variable. Flag handling does not appear to be getting used in a multi-threaded environment, as other aspects of flag handling use static variables with no mutex guarding that I could find.
-    Fixed runtime assert in Windows debug build for the improper use of std::vector<>::front() on an empty vector. The code never used the value of front(), as it was guarded by a check for the vector's size, but the assert prevents the debug build from running.

