### PR TITLE
[Test] Tweak output_buffer_reference_test to repro ASan issue.

### DIFF
--- a/compiler/bindings/python/test/api/output_buffer_reference_test.py
+++ b/compiler/bindings/python/test/api/output_buffer_reference_test.py
@@ -21,6 +21,7 @@ from iree.runtime import (
     VmContext,
     VmInstance,
     VmModule,
+    load_vm_module,
 )
 
 
@@ -59,7 +60,7 @@ def run_mmap_free_before_context_test():
     output.write(vmfb_contents)
     mapped_memory = output.map_memory()
     module = VmModule.wrap_buffer(instance, mapped_memory)
-    context = VmContext(instance, modules=[module])
+    loaded_module = load_vm_module(module)
     # Shutdown in the most egregious way possible.
     # Note that during context destruction, the context needs some final
     # access to the mapped memory to run destructors. It is easy for the


### PR DESCRIPTION
Test case repro for https://github.com/iree-org/iree/issues/17635#issuecomment-2164009648. Not sure if any of our CI builds would catch this (Python + ASan consistently fails, Python without ASan may crash sometimes)

Related: https://github.com/iree-org/iree/pull/15975