### PR TITLE
Allow flags to be set with greater flexibility

### DIFF
--- a/runtime/bindings/python/hal.h
+++ b/runtime/bindings/python/hal.h
@@ -145,7 +145,7 @@ class HalDriver : public ApiRefCounted<HalDriver, iree_hal_driver_t> {
  public:
   static std::vector<std::string> Query();
   static py::object Create(const std::string& device_uri,
-                           py::dict& driver_cache);
+                           py::dict& driver_cache, std::optional<bool> clean);
 
   py::list QueryAvailableDevices();
   HalDevice CreateDefaultDevice(std::optional<py::list> allocators);

--- a/runtime/bindings/python/hal.h
+++ b/runtime/bindings/python/hal.h
@@ -12,6 +12,7 @@
 #include "./binding.h"
 #include "./status_utils.h"
 #include "./vm.h"
+#include "iree/base/string_view.h"
 #include "iree/hal/api.h"
 
 namespace iree {
@@ -142,10 +143,29 @@ class HalDevice : public ApiRefCounted<HalDevice, iree_hal_device_t> {
 };
 
 class HalDriver : public ApiRefCounted<HalDriver, iree_hal_driver_t> {
+  // Object that holds the components of a device URI string.
+  struct DeviceUri {
+    iree_string_view_t driver_name;
+    iree_string_view_t device_path;
+    iree_string_view_t params_str;
+
+    DeviceUri(const std::string& device_uri);
+  };
+
+  // Create a stand-alone driver (not residing in a cache) given the name,
+  // path, and params components of a device URI.
+  static py::object Create(const DeviceUri& device_uri);
+
  public:
   static std::vector<std::string> Query();
+
+  // Create a stand-alone driver (not residing in a cache) given a device URI.
+  static py::object Create(const std::string& device_uri);
+
+  // Returns a driver from the given cache, creating it and placing it in
+  // the cache if not already found there.
   static py::object Create(const std::string& device_uri,
-                           py::dict& driver_cache, std::optional<bool> clean);
+                           py::dict& driver_cache);
 
   py::list QueryAvailableDevices();
   HalDevice CreateDefaultDevice(std::optional<py::list> allocators);

--- a/runtime/bindings/python/initialize_module.cc
+++ b/runtime/bindings/python/initialize_module.cc
@@ -16,6 +16,13 @@
 #include "iree/base/internal/flags.h"
 #include "iree/hal/drivers/init.h"
 
+namespace {
+// Stable storage for flag processing.  Flag handling uses string views,
+// expecting the caller to keep the original strings around for as long
+// as the flags are in use.
+std::vector<std::string> alloced_flags;
+}  // namespace
+
 namespace iree {
 namespace python {
 
@@ -35,7 +42,7 @@ NB_MODULE(_runtime, m) {
   SetupVmBindings(m);
 
   m.def("parse_flags", [](py::args py_flags) {
-    std::vector<std::string> alloced_flags;
+    alloced_flags.clear();
     alloced_flags.push_back("python");
     for (py::handle py_flag : py_flags) {
       alloced_flags.push_back(py::cast<std::string>(py_flag));

--- a/runtime/bindings/python/initialize_module.cc
+++ b/runtime/bindings/python/initialize_module.cc
@@ -4,6 +4,8 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <memory>
+
 #include "./binding.h"
 #include "./hal.h"
 #include "./invoke.h"
@@ -21,7 +23,7 @@ namespace {
 // expecting the caller to keep the original strings around for as long
 // as the flags are in use.  This object holds one set of flag strings
 // for each invocation of parse_flags.
-std::vector<std::vector<std::string>> alloced_flag_cache;
+std::vector<std::unique_ptr<std::vector<std::string>>> alloced_flag_cache;
 }  // namespace
 
 namespace iree {
@@ -47,8 +49,9 @@ NB_MODULE(_runtime, m) {
   // drivers already created.
   m.def("parse_flags", [](py::args py_flags) {
     // Make a new set of strings at the back of the cache
-    alloced_flag_cache.emplace_back(std::vector<std::string>());
-    std::vector<std::string> &alloced_flags = alloced_flag_cache.back();
+    alloced_flag_cache.emplace_back(
+        std::make_unique<std::vector<std::string>>(std::vector<std::string>()));
+    auto &alloced_flags = *alloced_flag_cache.back();
 
     // Add the given python strings to the std::string set.
     alloced_flags.push_back("python");

--- a/runtime/bindings/python/iree/runtime/system_setup.py
+++ b/runtime/bindings/python/iree/runtime/system_setup.py
@@ -25,16 +25,14 @@ def query_available_drivers() -> Collection[str]:
     return HalDriver.query()
 
 
-def get_driver(device_uri: str, clean: bool = False) -> HalDriver:
+def get_driver(device_uri: str) -> HalDriver:
     """Returns a HAL driver by device_uri (or driver name).
 
     Args:
       device_uri: The URI of the device, either just a driver name for the
         default or a fully qualified "driver://path?params".
-      clean: Whether to clean out any cached driver and make a new one
-        (default False).
     """
-    return get_cached_hal_driver(device_uri, clean)
+    return get_cached_hal_driver(device_uri)
 
 
 def get_device(device_uri: str, cache: bool = True) -> HalDevice:

--- a/runtime/bindings/python/iree/runtime/system_setup.py
+++ b/runtime/bindings/python/iree/runtime/system_setup.py
@@ -25,9 +25,16 @@ def query_available_drivers() -> Collection[str]:
     return HalDriver.query()
 
 
-def get_driver(device_uri: str) -> HalDriver:
-    """Returns a HAL driver by device_uri (or driver name)."""
-    return get_cached_hal_driver(device_uri)
+def get_driver(device_uri: str, clean: bool = False) -> HalDriver:
+    """Returns a HAL driver by device_uri (or driver name).
+
+    Args:
+      device_uri: The URI of the device, either just a driver name for the
+        default or a fully qualified "driver://path?params".
+      clean: Whether to clean out any cached driver and make a new one
+        (default False).
+    """
+    return get_cached_hal_driver(device_uri, clean)
 
 
 def get_device(device_uri: str, cache: bool = True) -> HalDevice:


### PR DESCRIPTION
Changes to the python binding to allow iree.runtime.flags.parse_flags to take effect at times other than before the first time a driver is created. Also includes fixes for bugs exposed during the development of this feature.

-    Added "internal" API functions `create_hal_driver()` and `clear_hal_driver_cache()` to create a driver object independent of the cache, and to clear the cache, respectively
- Added `HalDriver` class implementation functions for the above new API functions.  Refactored class to share as much common code as possible.
- Factored out driver URI processing into its own nested class for easier handling of URI components
-    Fixed dangling pointer bug. In the C layer flags are being kept by reference as string views, requiring the caller to keep the original flag strings (argc, argv) around for as long as the flags are being used. However, the python binding was using a local variable for those strings, letting them go out of scope and causing garbage values later on. The fix is to move the strings to a file scope variable. Flag handling does not appear to be getting used in a multi-threaded environment, as other aspects of flag handling use static variables with no mutex guarding that I could find.
-    Fixed runtime assert in Windows debug build for the improper use of std::vector<>::front() on an empty vector. The code never used the value of front(), as it was guarded by a check for the vector's size, but the assert prevents the debug build from running.

