### PR TITLE
Change calculation of reassociation indicies in ConvertConvToChannelsLast.cpp

### DIFF
--- a/compiler/src/iree/compiler/Preprocessing/Common/test/conv_to_channels_last.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/conv_to_channels_last.mlir
@@ -154,3 +154,5 @@ util.func @test_unit_dims_pack(%arg0: tensor<10x20x5xf32>) -> tensor<1x1x5x20x10
 // CHECK-SAME:    outs(%[[DST:.+]] : tensor<5x20x10xf32>) permutation = [2, 1, 0]
 // CHECK:       %[[EXPANDED:.+]] = tensor.expand_shape
 // CHECK-SAME:    [0, 1, 2], [3], [4]
+// CHECK-SAME:    tensor<5x20x10xf32> into tensor<1x1x5x20x10xf32>
+// CHECK:       util.return %[[EXPANDED]] : tensor<1x1x5x20x10xf32>


### PR DESCRIPTION
- Added `GreedyRewriteConfig` set to `kNoLimit` since the patterns were failing to converge within the 10 iterations
- Changed the way re-association indices are calculated for `GeneralizeOuterUnitDimsPackOps`. (There might be a helper function somewhere for this but i couldn't find one)




#### Before (verification error)
```mlir
%30042 = "tensor.expand_shape"(%30041) 
	<{reassociation = [[0, 1], [2, 3], [4], [5]], 
		static_output_shape = array<i64: 1, 1, 3, 3, 320, 4>}> 
	: (tensor<3x3x320x4xi8>) -> tensor<1x1x3x3x320x4xi8>
```

#### After
```mlir
%30042 = "tensor.expand_shape"(%30041) 
	<{reassociation = [[0, 1, 2], [3], [4], [5]], 
		static_output_shape = array<i64: 1, 1, 3, 3, 320, 4>}> 
	: (tensor<3x3x320x4xi8>) -> tensor<1x1x3x3x320x4xi8>
```



https://github.com/iree-org/iree/issues/17643