### PR TITLE
Re-enable test_amd_w7900 CI job.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,45 +429,44 @@ jobs:
         run: |
           ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}
 
-  # TODO(saienduri): re-enable when iree/hal/drivers/hip/dynamic_symbols_test is fixed
-  # test_amd_w7900:
-  #   needs: [setup, build_all]
-  #   if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_amd_w7900')
-  #   env:
-  #     BUILD_DIR: build-tests
-  #     INSTALL_DIR: ${{ needs.build_all.outputs.install-dir }}
-  #     INSTALL_DIR_ARCHIVE: ${{ needs.build_all.outputs.install-dir-archive }}
-  #     INSTALL_DIR_GCS_URL: ${{ needs.build_all.outputs.install-dir-gcs-url }}
-  #     IREE_CPU_DISABLE: 1
-  #     IREE_VULKAN_DISABLE: 0
-  #     IREE_CUDA_DISABLE: 1
-  #     IREE_HIP_DISABLE: 0
-  #     IREE_HIP_TEST_TARGET_CHIP: "gfx1100"
-  #   runs-on: nodai-amdgpu-w7900-x86-64
-  #   steps:
-  #     - name: "Checking out repository"
-  #       uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-  #     - name: "Checking out runtime submodules"
-  #       run: ./build_tools/scripts/git/update_runtime_submodules.sh
-  #     - name: "Downloading install dir archive"
-  #       run: wget "${INSTALL_DIR_GCS_URL}" -O "${INSTALL_DIR_ARCHIVE}"
-  #     - name: "Extracting install directory"
-  #       run: tar -xf "${INSTALL_DIR_ARCHIVE}"
-  #     - name: "Building tests"
-  #       run: |
-  #         ./build_tools/pkgci/build_tests_using_package.sh ${INSTALL_DIR}
-  #     - name: "Running GPU tests"
-  #       env:
-  #         IREE_CTEST_LABEL_REGEX: ^requires-gpu|^driver=vulkan$|^driver=hip$
-  #         IREE_AMD_RDNA3_TESTS_DISABLE: 0
-  #         IREE_NVIDIA_GPU_TESTS_DISABLE: 0
-  #         IREE_NVIDIA_SM80_TESTS_DISABLE: 1
-  #         IREE_MULTI_DEVICE_TESTS_DISABLE: 0
-  #         IREE_CUDA_DISABLE: 1
-  #         IREE_CPU_DISABLE: 1
-  #         IREE_HIP_DISABLE: 0
-  #       run: |
-  #         ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}
+  test_amd_w7900:
+    needs: [setup, build_all]
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_amd_w7900')
+    env:
+      BUILD_DIR: build-tests
+      INSTALL_DIR: ${{ needs.build_all.outputs.install-dir }}
+      INSTALL_DIR_ARCHIVE: ${{ needs.build_all.outputs.install-dir-archive }}
+      INSTALL_DIR_GCS_URL: ${{ needs.build_all.outputs.install-dir-gcs-url }}
+      IREE_CPU_DISABLE: 1
+      IREE_VULKAN_DISABLE: 0
+      IREE_CUDA_DISABLE: 1
+      IREE_HIP_DISABLE: 0
+      IREE_HIP_TEST_TARGET_CHIP: "gfx1100"
+    runs-on: nodai-amdgpu-w7900-x86-64
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: "Checking out runtime submodules"
+        run: ./build_tools/scripts/git/update_runtime_submodules.sh
+      - name: "Downloading install dir archive"
+        run: wget "${INSTALL_DIR_GCS_URL}" -O "${INSTALL_DIR_ARCHIVE}"
+      - name: "Extracting install directory"
+        run: tar -xf "${INSTALL_DIR_ARCHIVE}"
+      - name: "Building tests"
+        run: |
+          ./build_tools/pkgci/build_tests_using_package.sh ${INSTALL_DIR}
+      - name: "Running GPU tests"
+        env:
+          IREE_CTEST_LABEL_REGEX: ^requires-gpu|^driver=vulkan$|^driver=hip$
+          IREE_AMD_RDNA3_TESTS_DISABLE: 0
+          IREE_NVIDIA_GPU_TESTS_DISABLE: 0
+          IREE_NVIDIA_SM80_TESTS_DISABLE: 1
+          IREE_MULTI_DEVICE_TESTS_DISABLE: 0
+          IREE_CUDA_DISABLE: 1
+          IREE_CPU_DISABLE: 1
+          IREE_HIP_DISABLE: 0
+        run: |
+          ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}
 
   ############################### Configurations ###############################
   # Jobs that build IREE in some non-default configuration
@@ -921,7 +920,7 @@ jobs:
       - test_nvidia_gpu
       - test_nvidia_a100
       - test_amd_mi250
-      # - test_amd_w7900
+      - test_amd_w7900
 
       # Configurations
       - build_test_runtime

--- a/runtime/src/iree/hal/drivers/hip/dynamic_symbols_test.cc
+++ b/runtime/src/iree/hal/drivers/hip/dynamic_symbols_test.cc
@@ -87,9 +87,11 @@ TEST(NCCLDynamicSymbolsTest, CreateFromSystemLoader) {
     GTEST_SKIP() << "HIP RCCL symbols cannot be loaded, skipping test.";
   }
 
+  // Check that the loaded version is at least the version we compiled for.
   int nccl_version = 0;
   NCCL_CHECK_ERRORS(nccl_symbols.ncclGetVersion(&nccl_version));
-  ASSERT_EQ(NCCL_VERSION_CODE, nccl_version);
+  ASSERT_GE(nccl_version, NCCL_VERSION_CODE);
+
   iree_hal_hip_nccl_dynamic_symbols_deinitialize(&nccl_symbols);
   iree_hal_hip_dynamic_symbols_deinitialize(&hip_symbols);
 }


### PR DESCRIPTION
This job was disabled due to runner issues and then test failures. The runners have been more stable and the tests have (hopefully) been fixed.

~~Depends on https://github.com/iree-org/iree/pull/17674~~
Fixes https://github.com/iree-org/iree/issues/17370

ci-exactly: build_all, test_amd_w7900