### PR TITLE
[Debug] Test disk usage on a100 runners with Docker.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,6 +326,76 @@ jobs:
                 ./build_tools/scripts/check_vulkan.sh
                 ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}"
 
+  test_nvidia_a100_presubmit:
+    env:
+      IREE_CPU_DISABLE: 1
+      IREE_VULKAN_DISABLE: 0
+      IREE_CUDA_DISABLE: 0
+      IREE_HIP_DISABLE: 1
+    runs-on:
+      - self-hosted # must come first
+      - runner-group=presubmit
+      - environment=prod
+      - a100
+      - os-family=Linux
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: "Checking out runtime submodules"
+        run: ./build_tools/scripts/git/update_runtime_submodules.sh
+      - name: Querying GPU information
+        run: |
+          ./build_tools/scripts/check_cuda.sh
+          ./build_tools/scripts/check_vulkan.sh
+      - name: "Checking disk usage"
+        run: df -h
+      - name: "Running a test command under docker"
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+              --env IREE_CPU_DISABLE \
+              --env IREE_VULKAN_DISABLE \
+              --env IREE_CUDA_DISABLE \
+              --env IREE_HIP_DISABLE \
+              gcr.io/iree-oss/nvidia@sha256:433e072f075f90fdf07471673626b17091d8d8e2395626f1e6ac6c98803c8807 \
+              echo "hi"
+      - name: "Checking disk usage"
+        run: df -h
+
+  test_nvidia_a100_postsubmit:
+    env:
+      IREE_CPU_DISABLE: 1
+      IREE_VULKAN_DISABLE: 0
+      IREE_CUDA_DISABLE: 0
+      IREE_HIP_DISABLE: 1
+    runs-on:
+      - self-hosted # must come first
+      - runner-group=postsubmit
+      - environment=prod
+      - a100
+      - os-family=Linux
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: "Checking out runtime submodules"
+        run: ./build_tools/scripts/git/update_runtime_submodules.sh
+      - name: Querying GPU information
+        run: |
+          ./build_tools/scripts/check_cuda.sh
+          ./build_tools/scripts/check_vulkan.sh
+      - name: "Checking disk usage"
+        run: df -h
+      - name: "Running a test command under docker"
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+              --env IREE_CPU_DISABLE \
+              --env IREE_VULKAN_DISABLE \
+              --env IREE_CUDA_DISABLE \
+              --env IREE_HIP_DISABLE \
+              gcr.io/iree-oss/nvidia@sha256:433e072f075f90fdf07471673626b17091d8d8e2395626f1e6ac6c98803c8807 \
+              echo "hi"
+      - name: "Checking disk usage"
+        run: df -h
+
   test_nvidia_a100:
     needs: [setup, build_all]
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_nvidia_a100')


### PR DESCRIPTION
See https://github.com/iree-org/iree/pull/17661#issuecomment-2165987433 - the postsubmit `test_nvidia_a100` has been failing due to not enough disk space to fetch the docker image.

skip-ci: hacking at the workflow file, ignore all other jobs