### PR TITLE
Disable test_nvidia_a100 while runner has no storage.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,69 +326,70 @@ jobs:
                 ./build_tools/scripts/check_vulkan.sh
                 ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}"
 
-  test_nvidia_a100:
-    needs: [setup, build_all]
-    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_nvidia_a100')
-    env:
-      BUILD_DIR: build-tests
-      INSTALL_DIR: ${{ needs.build_all.outputs.install-dir }}
-      INSTALL_DIR_ARCHIVE: ${{ needs.build_all.outputs.install-dir-archive }}
-      INSTALL_DIR_GCS_URL: ${{ needs.build_all.outputs.install-dir-gcs-url }}
-      IREE_CPU_DISABLE: 1
-      IREE_VULKAN_DISABLE: 0
-      IREE_CUDA_DISABLE: 0
-      IREE_HIP_DISABLE: 1
-    runs-on:
-      - self-hosted # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.runner-env }}
-      - a100
-      - os-family=Linux
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-      - name: "Checking out runtime submodules"
-        run: ./build_tools/scripts/git/update_runtime_submodules.sh
-      - name: Querying GPU information
-        run: |
-          ./build_tools/scripts/check_cuda.sh
-          ./build_tools/scripts/check_vulkan.sh
-      - name: "Downloading install dir archive"
-        run: wget "${INSTALL_DIR_GCS_URL}" -O "${INSTALL_DIR_ARCHIVE}"
-      - name: "Extracting install directory"
-        run: tar -xf "${INSTALL_DIR_ARCHIVE}"
-      - name: "Building tests"
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-              --env IREE_CPU_DISABLE \
-              --env IREE_VULKAN_DISABLE \
-              --env IREE_CUDA_DISABLE \
-              --env IREE_HIP_DISABLE \
-              gcr.io/iree-oss/nvidia@sha256:433e072f075f90fdf07471673626b17091d8d8e2395626f1e6ac6c98803c8807 \
-              ./build_tools/pkgci/build_tests_using_package.sh ${INSTALL_DIR}
-      - name: "Running GPU tests"
-        env:
-          IREE_CTEST_LABEL_REGEX: ^requires-gpu-sm80|^requires-gpu|^driver=vulkan$|^driver=cuda$
-          IREE_NVIDIA_SM80_TESTS_DISABLE: 0
-          IREE_MULTI_DEVICE_TESTS_DISABLE: 1
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-              --env IREE_VULKAN_DISABLE \
-              --env IREE_CUDA_DISABLE \
-              --env IREE_HIP_DISABLE \
-              --env IREE_CTEST_LABEL_REGEX \
-              --env IREE_NVIDIA_SM80_TESTS_DISABLE \
-              --env IREE_MULTI_DEVICE_TESTS_DISABLE \
-              --env IREE_VULKAN_F16_DISABLE=0 \
-              --env IREE_NVIDIA_GPU_TESTS_DISABLE=0 \
-              --env CTEST_PARALLEL_LEVEL=4 \
-              --env NVIDIA_DRIVER_CAPABILITIES=all \
-              --gpus all \
-              gcr.io/iree-oss/nvidia@sha256:433e072f075f90fdf07471673626b17091d8d8e2395626f1e6ac6c98803c8807 \
-              bash -euo pipefail -c \
-                "./build_tools/scripts/check_cuda.sh
-                ./build_tools/scripts/check_vulkan.sh
-                ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}"
+  # TODO(#17677): Re-enable when the postsubmit runner has enough disk space
+  # test_nvidia_a100:
+  #   needs: [setup, build_all]
+  #   if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_nvidia_a100')
+  #   env:
+  #     BUILD_DIR: build-tests
+  #     INSTALL_DIR: ${{ needs.build_all.outputs.install-dir }}
+  #     INSTALL_DIR_ARCHIVE: ${{ needs.build_all.outputs.install-dir-archive }}
+  #     INSTALL_DIR_GCS_URL: ${{ needs.build_all.outputs.install-dir-gcs-url }}
+  #     IREE_CPU_DISABLE: 1
+  #     IREE_VULKAN_DISABLE: 0
+  #     IREE_CUDA_DISABLE: 0
+  #     IREE_HIP_DISABLE: 1
+  #   runs-on:
+  #     - self-hosted # must come first
+  #     - runner-group=${{ needs.setup.outputs.runner-group }}
+  #     - environment=${{ needs.setup.outputs.runner-env }}
+  #     - a100
+  #     - os-family=Linux
+  #   steps:
+  #     - name: "Checking out repository"
+  #       uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+  #     - name: "Checking out runtime submodules"
+  #       run: ./build_tools/scripts/git/update_runtime_submodules.sh
+  #     - name: Querying GPU information
+  #       run: |
+  #         ./build_tools/scripts/check_cuda.sh
+  #         ./build_tools/scripts/check_vulkan.sh
+  #     - name: "Downloading install dir archive"
+  #       run: wget "${INSTALL_DIR_GCS_URL}" -O "${INSTALL_DIR_ARCHIVE}"
+  #     - name: "Extracting install directory"
+  #       run: tar -xf "${INSTALL_DIR_ARCHIVE}"
+  #     - name: "Building tests"
+  #       run: |
+  #         ./build_tools/github_actions/docker_run.sh \
+  #             --env IREE_CPU_DISABLE \
+  #             --env IREE_VULKAN_DISABLE \
+  #             --env IREE_CUDA_DISABLE \
+  #             --env IREE_HIP_DISABLE \
+  #             gcr.io/iree-oss/nvidia@sha256:433e072f075f90fdf07471673626b17091d8d8e2395626f1e6ac6c98803c8807 \
+  #             ./build_tools/pkgci/build_tests_using_package.sh ${INSTALL_DIR}
+  #     - name: "Running GPU tests"
+  #       env:
+  #         IREE_CTEST_LABEL_REGEX: ^requires-gpu-sm80|^requires-gpu|^driver=vulkan$|^driver=cuda$
+  #         IREE_NVIDIA_SM80_TESTS_DISABLE: 0
+  #         IREE_MULTI_DEVICE_TESTS_DISABLE: 1
+  #       run: |
+  #         ./build_tools/github_actions/docker_run.sh \
+  #             --env IREE_VULKAN_DISABLE \
+  #             --env IREE_CUDA_DISABLE \
+  #             --env IREE_HIP_DISABLE \
+  #             --env IREE_CTEST_LABEL_REGEX \
+  #             --env IREE_NVIDIA_SM80_TESTS_DISABLE \
+  #             --env IREE_MULTI_DEVICE_TESTS_DISABLE \
+  #             --env IREE_VULKAN_F16_DISABLE=0 \
+  #             --env IREE_NVIDIA_GPU_TESTS_DISABLE=0 \
+  #             --env CTEST_PARALLEL_LEVEL=4 \
+  #             --env NVIDIA_DRIVER_CAPABILITIES=all \
+  #             --gpus all \
+  #             gcr.io/iree-oss/nvidia@sha256:433e072f075f90fdf07471673626b17091d8d8e2395626f1e6ac6c98803c8807 \
+  #             bash -euo pipefail -c \
+  #               "./build_tools/scripts/check_cuda.sh
+  #               ./build_tools/scripts/check_vulkan.sh
+  #               ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}"
 
   test_amd_mi250:
     needs: [setup, build_all]
@@ -919,7 +920,7 @@ jobs:
 
       # Accelerators
       - test_nvidia_gpu
-      - test_nvidia_a100
+      # - test_nvidia_a100
       - test_amd_mi250
       # - test_amd_w7900
 


### PR DESCRIPTION
See https://github.com/iree-org/iree/issues/17677. This job has been failing on postsubmit due to insufficient storage space. The _presubmit_ runner (opt-in) does have enough space, but the _postsubmit_ runner does not.

skip-ci: no impact on other builds