### PR TITLE
Remove `reconcile-unrealize-casts` pattern from dialect conversion

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -1050,7 +1050,6 @@ void ConvertToLLVMPass::runOnOperation() {
   populateVectorToLLVMMatrixConversionPatterns(typeConverter, patterns);
   populateVectorToLLVMConversionPatterns(
       typeConverter, patterns, targetReassociateFpReductions.getValue());
-  populateReconcileUnrealizedCastsPatterns(patterns);
 
   if (isAArch64(targetAttr) &&
       (hasAnySVEFeature(targetAttr) || hasSMEFeature(targetAttr))) {


### PR DESCRIPTION
The pattern is not needed and may be removed from MLIR. For reference, see llvm/llvm-project#95700.

Signed-off-by: Matthias Springer <mspringer@nvidia.com>
