### PR TITLE
[LLVMGPU] Generalize AMDGPUChainedMatmul pass to multiple dimensions

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/AMDGPUChainedMatmulPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/AMDGPUChainedMatmulPass.cpp
@@ -208,6 +208,9 @@ struct AMDGPUPrepareForChainedMatmulPass
       // For now, we only support transpose invariant matmuls. This is because
       // transposing the inputs may have a non-trivial cost which we need
       // to think about.
+      // TODO: We should probably enable it always. Currently, this is
+      // only useful in Flash Attention, where the first matmul is generally
+      // a transpose.
       if (!isOperandSwapInvariant(chainParent)) {
         continue;
       }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/AMDGPUChainedMatmulPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/AMDGPUChainedMatmulPass.cpp
@@ -168,7 +168,7 @@ struct AMDGPUPrepareForChainedMatmulPass
     auto [lhsM, rhsN] = opInfo.getOperandMNIndex();
     auto [lhsK, rhsK] = opInfo.getOperandKIndex();
     bool isLhsTransposed = lhsM > lhsK;
-    bool isRhsTransposed = rhsN > rhsK;
+    bool isRhsTransposed = rhsN < rhsK;
     return isLhsTransposed != isRhsTransposed;
   }
 
@@ -185,7 +185,9 @@ struct AMDGPUPrepareForChainedMatmulPass
   FailureOr<vector::ContractionOp>
   getTransitiveMatmulParent(vector::ContractionOp contractOp) const {
     SetVector<Operation *> backwardSlice;
-    getBackwardSlice(contractOp.getLhs(), &backwardSlice);
+    BackwardSliceOptions options;
+    options.inclusive = true;
+    getBackwardSlice(contractOp.getLhs(), &backwardSlice, options);
     vector::ContractionOp result;
     for (Operation *sliceOp : backwardSlice) {
       auto chainParent = dyn_cast<vector::ContractionOp>(sliceOp);


### PR DESCRIPTION
This patch generalizes the AMDGPUChainedMatmul pass to use VectorContractOpInfo to query and transpose dims, instead of hardcoding indexing maps.