### PR TITLE
Run w7900 tests in serial instead of parallel.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,6 +457,7 @@ jobs:
           ./build_tools/pkgci/build_tests_using_package.sh ${INSTALL_DIR}
       - name: "Running GPU tests"
         env:
+          CTEST_PARALLEL_LEVEL: 1
           IREE_CTEST_LABEL_REGEX: ^requires-gpu|^driver=vulkan$|^driver=hip$
           IREE_AMD_RDNA3_TESTS_DISABLE: 0
           IREE_NVIDIA_GPU_TESTS_DISABLE: 0


### PR DESCRIPTION
Follow-up to https://github.com/iree-org/iree/pull/17675, attempting a fix-forward for failed builds: https://github.com/iree-org/iree/actions/runs/9551239129/job/26327378915#step:7:280

These runners are unstable when running multiple GPU processes at once.

ci-exactly: build_all, test_amd_w7900