### PR TITLE
Add extra info to error message in transfer_read operation with element and thread count info

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorDistribute.cpp
@@ -225,9 +225,11 @@ private:
         ShapedType::getNumElements(transfer.getVectorType().getShape());
     int64_t flatNumThreads = ShapedType::getNumElements(workgroupSize);
     if (flatNumElements % flatNumThreads != 0) {
-      transfer->emitOpError() << "Anchoring on transfer_read with unsupported number of elements (not divisible by workgroup size)"
-                              << ", number of elements: " << flatNumElements
-                              << ", workgroup size: " << flatNumThreads;
+      transfer->emitOpError()
+          << "Anchoring on transfer_read with unsupported number of elements "
+             "(not divisible by workgroup size)"
+          << ", number of elements: " << flatNumElements
+          << ", workgroup size: " << flatNumThreads;
       return failure();
     }
     numElementsPerThread =

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorDistribute.cpp
@@ -225,9 +225,9 @@ private:
         ShapedType::getNumElements(transfer.getVectorType().getShape());
     int64_t flatNumThreads = ShapedType::getNumElements(workgroupSize);
     if (flatNumElements % flatNumThreads != 0) {
-      transfer->emitOpError(
-          "Anchoring on transfer_read with unsupported number of elements (not "
-          "divisible by workgroup size)");
+      transfer->emitOpError() << "Anchoring on transfer_read with unsupported number of elements (not divisible by workgroup size)"
+                              << ", number of elements: " << flatNumElements
+                              << ", workgroup size: " << flatNumThreads;
       return failure();
     }
     numElementsPerThread =


### PR DESCRIPTION
Added values of "number of elements" and "workgroup size" to `Anchoring on transfer_read with unsupported number of elements (not divisible by workgroup size)`