### PR TITLE
[Flow] Make sink reshapes changes less conservative.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/SinkReshapes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/SinkReshapes.cpp
@@ -88,7 +88,7 @@ static bool shouldSinkExpandShapeOp(OpOperand *opOperand) {
     return false;
   }
 
-  // Do not sink reshapes across dequantize operations since tey are
+  // Do not sink reshapes across dequantize operations since they are
   // cloned into their producers.
   if (isDequantizationLikeOp(consumer)) {
     return false;

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/SinkReshapes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/SinkReshapes.cpp
@@ -127,8 +127,14 @@ static bool shouldSinkExpandShapeOp(OpOperand *opOperand) {
     // There is already a tile-and-fusable producer to fuse with. Still prefer
     // fusing with the producer whose parallel iteration space rank matches
     // the consumer parallel iteration space rank to avoid loss of parallelism.
-    if (isa<linalg::LinalgOp>(reshapeProducer) &&
-        isa<linalg::LinalgOp>(currProducer)) {
+    if (auto currLinalgProducer = dyn_cast<linalg::LinalgOp>(currProducer)) {
+      auto reshapeLinalgProducer = dyn_cast<linalg::LinalgOp>(reshapeProducer);
+      if (!reshapeLinalgProducer) {
+        // For now we will prefer to fold with Linalg op. So if the reshape
+        // producer is not a Linalg op, bail.
+        return false;
+      }
+
       unsigned currConsumerNumParallelLoops =
           consumerGenericOp.getNumParallelLoops();
       unsigned currProducerNumParallelLoops =

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/sink_reshapes.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/sink_reshapes.mlir
@@ -194,7 +194,7 @@ func.func @reduce_broadcast(%arg0: tensor<4x768xf32>, %arg1: tensor<4xf32>,
       : tensor<4xf32> into tensor<1x4xf32>
   %1 = tensor.empty() : tensor<1x4x768xf32>
   %2 = linalg.generic {
-      indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, 
+      indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
                        affine_map<(d0, d1, d2) -> (d0, d1)>,
                        affine_map<(d0, d1, d2) -> (d0, d1, d2)>],
       iterator_types = ["parallel", "parallel", "parallel"]}


### PR DESCRIPTION
While deciding if a reshape needs "sinking", for a `tensor.expand_shape` -> `linalg.*`, first check was to check that the `linalg.*` operation could already fuse with one of its existing producers. That check was broadly aggressive. The fusion only kicks in when the iteration domains match. Eventually the actual dispatch formation logic needs to be commoned to a single place to do this better, but kicking that to a follow up.