### PR TITLE
[LinalgExt] Implement masked_attention and it's tiling and decomposition

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1269,9 +1269,9 @@ LogicalResult AttentionOp::verify() {
   int numInputs = getNumDpsInputs();
   int numOutputs = getNumDpsInits();
 
-  if (numInputs != 4) {
+  if (numInputs < 4 || numInputs > 5) {
     return op->emitOpError(
-        "expected 4 input operands: Query, Key, Value and Scale");
+        "expected 4 or 5 input operands: Query, Key, Value, Scale, and Mask");
   }
 
   if (numOutputs != 1 && numOutputs != 3) {
@@ -1280,8 +1280,9 @@ LogicalResult AttentionOp::verify() {
   }
 
   bool isTiled = numOutputs == 3;
-
-  if (!llvm::all_of(llvm::drop_end(getDpsInputs()), [](Value input) {
+  SmallVector<Value> dpsInputs = getDpsInputs();
+  ArrayRef<Value> qkvValues(dpsInputs.begin(), dpsInputs.begin() + 3);
+  if (!llvm::all_of(qkvValues, [](Value input) {
         return isa<ShapedType>(input.getType());
       })) {
     return op->emitOpError(
@@ -1336,6 +1337,15 @@ LogicalResult AttentionOp::verify() {
       failed(checkShape("Key", getKeyType().getShape(), getKeyMap())) ||
       failed(checkShape("Value", getValueType().getShape(), getValueMap()))) {
     return failure();
+  }
+
+  if (getMask().has_value()) {
+    if (failed(checkShape("Mask", getMaskType()->getShape(), *getMaskMap()))) {
+      return failure();
+    }
+    if (!getMaskType()->getElementType().isInteger()) {
+      return op->emitOpError("Expects attention_mask to be of integer type.");
+    }
   }
 
   if (queryElementType != keyElementType ||
@@ -1402,10 +1412,17 @@ SmallVector<AffineMap> AttentionOp::getIndexingMapsArray() {
         AffineMap::get(/*dimCount=*/5, /*symbolCount=*/0, {batch, k2, n}, ctx);
   }
 
+  SmallVector<AffineMap> results = {qMap, kMap, vMap};
+
+  if (getMask()) {
+    AffineMap maskMap =
+        AffineMap::get(/*dimCount=*/5, /*symbolCount=*/0, {batch, m, k2}, ctx);
+    results.push_back(maskMap);
+  }
+
   AffineMap resMap =
       AffineMap::get(/*dimCount=*/5, /*symbolCount=*/0, {batch, m, n}, ctx);
-
-  SmallVector<AffineMap> results = {qMap, kMap, vMap, resMap};
+  results.push_back(resMap);
 
   if (getMax()) {
     AffineMap maxMap =

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -522,10 +522,14 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_Op<"attention",
   let description = [{
     Computes the scaled dot product attention function:
 
-    attention(Q, K, V, scale) = softmax(Q @ K.T * scale) @ V
+    attention(Q, K, V, scale, mask) = softmax(mask(Q @ K.T * scale)) @ V
 
     Here Q, K, V are given tensors and scale is a scalar value specifying
     the scale to use.
+
+    `mask` is an optional boolean tensor that specifies which relations
+    in attn_weight that should be ignored. This is useful for
+    causal attention, padded attention, and some special SD use cases.
 
     For self-attention, all inputs and the result have the same shape BxNxd
     where B is the batch dimension, N is the sequence length and d is head
@@ -539,10 +543,10 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_Op<"attention",
     FlashAttention 2 and optionally results in the current `max` and `sum`
     statistics while processing the current tile.
 
-    If transpose_v is speciifed, the V tensor passed as input is assumed to
+    If transpose_v is specifed, the V tensor passed as input is assumed to
     be transposed:
 
-    attention(Q, K, V, scale) = softmax(Q @ K.T * scale) @ V.T
+    attention(Q, K, V, scale, mask) = softmax(mask(Q @ K.T * scale)) @ V.T
 
     TODO: We should be moving to using a indexing map like approach so we
     can generalize which tensor is transposed and which is not.
@@ -579,6 +583,11 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_Op<"attention",
     Value getScale() {
       return getDpsInputOperand(3)->get();
     }
+    std::optional<Value> getMask() {
+      if (getNumDpsInputs() < 5)
+        return std::nullopt;
+      return getDpsInputOperand(4)->get();
+    }
     Value getOutput() {
       return getDpsInitOperand(0)->get();
     }
@@ -604,6 +613,11 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_Op<"attention",
     }
     FloatType getScaleType() {
       return cast<FloatType>(cast<ShapedType>(getScale().getType()));
+    }
+    std::optional<ShapedType> getMaskType() {
+      std::optional<Value> maskVal = getMask();
+      if (!maskVal) return std::nullopt;
+      return cast<ShapedType>(maskVal->getType());
     }
     ShapedType getOutputType() {
       return cast<ShapedType>(getOutput().getType());
@@ -659,18 +673,26 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_Op<"attention",
     AffineMap getValueMap() {
       return cast<AffineMap>(getIndexingMapsArray()[2]);
     }
-    AffineMap getOutputMap() {
+    std::optional<AffineMap> getMaskMap() {
+      if (getNumDpsInputs() < 5)
+        return std::nullopt;
       return cast<AffineMap>(getIndexingMapsArray()[3]);
+    }
+    AffineMap getOutputMap() {
+      int64_t outputIndex = getNumDpsInputs() - 1;
+      return cast<AffineMap>(getIndexingMapsArray()[outputIndex]);
     }
     std::optional<AffineMap> getMaxMap() {
       if (getNumResults() < 2)
         return std::nullopt;
-      return cast<AffineMap>(getIndexingMapsArray()[4]);
+      int64_t maxIndex = getNumDpsInputs();
+      return cast<AffineMap>(getIndexingMapsArray()[maxIndex]);
     }
     std::optional<AffineMap> getSumMap() {
       if (getNumResults() < 3)
         return std::nullopt;
-      return cast<AffineMap>(getIndexingMapsArray()[5]);
+      int64_t sumIndex = getNumDpsInputs() + 1;
+      return cast<AffineMap>(getIndexingMapsArray()[sumIndex]);
     }
 
     int64_t getIterationDomainRank() {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/IndexingUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/IndexingUtils.cpp
@@ -31,7 +31,6 @@ void AttentionOpDetail::inferFromIndexingMaps(
   AffineMap qMap = indexingMaps[0];
   AffineMap kMap = indexingMaps[1];
   AffineMap vMap = indexingMaps[2];
-  AffineMap resMap = indexingMaps[3];
 
   // Q   = B x M x K1
   // K   = B x K2 x K1
@@ -40,7 +39,6 @@ void AttentionOpDetail::inferFromIndexingMaps(
   llvm::SmallDenseSet<int64_t> qSet = findPermutationsIndexingOperand(qMap);
   llvm::SmallDenseSet<int64_t> vSet = findPermutationsIndexingOperand(vMap);
   llvm::SmallDenseSet<int64_t> kSet = findPermutationsIndexingOperand(kMap);
-  llvm::SmallDenseSet<int64_t> resSet = findPermutationsIndexingOperand(resMap);
 
   // B = Q & K & V
   llvm::SmallDenseSet<int64_t> bSet = qSet;
@@ -76,7 +74,7 @@ void AttentionOpDetail::inferFromIndexingMaps(
 
 FailureOr<AttentionOpDetail>
 AttentionOpDetail::get(ArrayRef<AffineMap> indexingMaps) {
-  if (indexingMaps.size() != 4 && indexingMaps.size() != 6) {
+  if (indexingMaps.size() < 4 || indexingMaps.size() > 7) {
     return failure();
   }
 


### PR DESCRIPTION
attn_weight or masking is often used to determine which part of the attention we need to attend to and which part we should mask out/ignore. This is often done by having a bitmask, where 1 implies to attend, and 0 to ignore, and entries is ignored by adding a very large negative number to the entry. This commit introduces masking as an optional argument and mechanisms to tile and decompose said mask / attn_weight.