### PR TITLE
Add loop-invariant-subset-hoisting pass to iree-opt

### DIFF
--- a/compiler/src/iree/compiler/Tools/init_mlir_passes.h
+++ b/compiler/src/iree/compiler/Tools/init_mlir_passes.h
@@ -43,6 +43,7 @@ inline void registerMlirPasses() {
   registerLocationSnapshotPass();
   affine::registerLoopCoalescingPass();
   registerLoopInvariantCodeMotionPass();
+  registerLoopInvariantSubsetHoistingPass();
   affine::registerAffineScalarReplacementPass();
   registerPrintOpStatsPass();
   registerViewOpGraphPass();


### PR DESCRIPTION
This pass is similar to loop-invariant-code-motion but loops for loop invariant subsets instead. This pass is required for post-vectorization cleanups.