### PR TITLE
Ensure IREE GPU dialect is registered for all GPU targets (fixes #17736)

### DIFF
--- a/compiler/plugins/target/CUDA/CUDATarget.cpp
+++ b/compiler/plugins/target/CUDA/CUDATarget.cpp
@@ -450,7 +450,7 @@ public:
     // `LLVMGPULowerExecutableTargetPass`.
     registry.insert<gpu::GPUDialect, nvgpu::NVGPUDialect,
                     IREE::Codegen::IREECodegenDialect,
-                    transform::TransformDialect>();
+                    transform::TransformDialect, IREE::GPU::IREEGPUDialect>();
     mlir::registerBuiltinDialectTranslation(registry);
     mlir::registerLLVMDialectTranslation(registry);
     mlir::registerNVVMDialectTranslation(registry);

--- a/compiler/plugins/target/MetalSPIRV/MetalSPIRVTarget.cpp
+++ b/compiler/plugins/target/MetalSPIRV/MetalSPIRVTarget.cpp
@@ -112,7 +112,8 @@ public:
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<gpu::GPUDialect, IREE::Codegen::IREECodegenDialect,
-                    IREE::Flow::FlowDialect, spirv::SPIRVDialect>();
+                    IREE::Flow::FlowDialect, spirv::SPIRVDialect,
+                    IREE::GPU::IREEGPUDialect>();
   }
 
   void

--- a/compiler/plugins/target/VulkanSPIRV/VulkanSPIRVTarget.cpp
+++ b/compiler/plugins/target/VulkanSPIRV/VulkanSPIRVTarget.cpp
@@ -126,7 +126,7 @@ public:
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<IREE::Codegen::IREECodegenDialect, spirv::SPIRVDialect,
-                    gpu::GPUDialect>();
+                    gpu::GPUDialect, IREE::GPU::IREEGPUDialect>();
   }
 
   void

--- a/compiler/plugins/target/WebGPUSPIRV/WebGPUSPIRVTarget.cpp
+++ b/compiler/plugins/target/WebGPUSPIRV/WebGPUSPIRVTarget.cpp
@@ -106,7 +106,8 @@ public:
   //     pipeline created by buildTranslationPassPipeline)
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<IREE::Codegen::IREECodegenDialect, IREE::Flow::FlowDialect,
-                    spirv::SPIRVDialect, gpu::GPUDialect>();
+                    spirv::SPIRVDialect, gpu::GPUDialect,
+                    IREE::GPU::IREEGPUDialect>();
   }
 
   void


### PR DESCRIPTION
Before this commit, it was only registered for ROCm, so the compiler would sometimes crash during compilation (including for some things compiled as part of the IREE build process) when trying to use IREE GPU dialect attributes if the ROCm target wasn't enabled.