### PR TITLE
[Flow] Do not fuse operations that truncate bitwidths with operations that extend it

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/BubbleUpExpandShapes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/BubbleUpExpandShapes.cpp
@@ -53,7 +53,7 @@ void BubbleUpExpandShapesPass::runOnOperation() {
         }
 
         // Do not fuse by expand if consumer is dequant.
-        if (isDequantizationLikeOp(consumer)) {
+        if (isBitExtendOp(consumer)) {
           return false;
         }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
@@ -226,7 +226,7 @@ static bool isRootOp(Operation *op) {
     return false;
   }
   // Dequantization-like ops get cloned into dispatches later.
-  if (isDequantizationLikeOp(op)) {
+  if (isBitExtendOp(op)) {
     return false;
   }
   // Any Linalg named op or generic op with reduction iterator types is a root
@@ -539,7 +539,7 @@ isFusableWithConsumer(OpOperand &fusedOperand,
 
   // If consumer is a dequant operation, dont fuse it. These get cloned
   // into their consumers.
-  if (isDequantizationLikeOp(consumer)) {
+  if (isBitExtendOp(consumer)) {
     return false;
   }
 
@@ -872,7 +872,7 @@ decideFusableLinalgOps(Region &region, DominanceInfo const &dominanceInfo,
       // materializing large tensors between dispatches.
       if (!isa<linalg::LinalgOp, tensor::PadOp, tensor::PackOp,
                IREE::Encoding::SetEncodingOp>(op) ||
-          isa<linalg::FillOp>(op) || isDequantizationLikeOp(&op)) {
+          isa<linalg::FillOp>(op) || isBitExtendOp(&op)) {
         continue;
       }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
@@ -156,7 +156,7 @@ static FailureOr<unsigned> fuseMultiUseProducers(Operation *funcOp,
 
         // Dequantization-like operations should be fused with consumers to keep
         // the smaller bit width on the dispatch boundary.
-        if (isDequantizationLikeOp(genericOp)) {
+        if (isBitExtendOp(genericOp)) {
           return;
         }
 
@@ -196,7 +196,7 @@ static FailureOr<unsigned> fuseMultiUseProducers(Operation *funcOp,
 
           // 7. Skip dequantization-like `producer` ops as we would rather fuse
           //    by cloning the producer instead of multi-use fusion.
-          if (isDequantizationLikeOp(producer)) {
+          if (isBitExtendOp(producer)) {
             return;
           }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionPreprocessing.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionPreprocessing.cpp
@@ -195,7 +195,7 @@ struct GatherFusionPattern : public OpRewritePattern<tensor::ExtractOp> {
 
     // Check if the producerOp is fusible
     if (producerOp.getNumDpsInputs() != 1 || producerOp.getNumResults() != 1 ||
-        !isElementwise(producerOp) || !isDequantizationLikeOp(producerOp)) {
+        !isElementwise(producerOp) || !isBitExtendOp(producerOp)) {
       return rewriter.notifyMatchFailure(producerOp,
                                          "producer op is not fusible");
     }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h
@@ -104,15 +104,41 @@ FailureOr<Flow::DispatchRegionOp> wrapOpInDispatchRegion(RewriterBase &rewriter,
 /// into a dispatch region.
 bool isClonableIntoDispatchOp(Operation *op);
 
-/// Returns true if the operation has dequantization-like properties.
+/// Returns true if the operation increases/decreases bitwidths of tensors.
 /// This function checks that the genericOp:
-///     1. Has only one output, and the output has an identity indexing map
-///     2. Has all parallel loops.
-///     3. Has exactly one input with an identity indexing map.
-///     4. All other inputs are projected permutations and not permutations.
-///     5. The input with an identity indexing map has a smaller element
-///        bitwidth than the output
-bool isDequantizationLikeOp(Operation *op);
+/// 1. Has only one output.
+/// 2. Has all parallel loops.
+/// 3. Compared to the element type of the input with highest rank,
+///    the output element type has either a higher or lower bitwidth.
+struct BitWidthChangeInfo {
+  // Return the operand the recognizer treats as the "input".
+  // Is guaranteed to be a `RankedTensorType`.
+  OpOperand *inputOperand;
+  // The output element type is int or float type.
+  Type outputElementType;
+
+  // Helper methods.
+  Type getInputElementType() const;
+  bool isExtensionOp() const {
+    return getInputElementType().getIntOrFloatBitWidth() <
+           outputElementType.getIntOrFloatBitWidth();
+  }
+  bool isTruncationOp() const {
+    return outputElementType.getIntOrFloatBitWidth() <
+           getInputElementType().getIntOrFloatBitWidth();
+  }
+};
+std::optional<BitWidthChangeInfo> isBitExtendOrTruncateOp(Operation *op);
+inline bool isBitExtendOp(Operation *op) {
+  std::optional<BitWidthChangeInfo> bitWidthChangeInfo =
+      isBitExtendOrTruncateOp(op);
+  return bitWidthChangeInfo && bitWidthChangeInfo->isExtensionOp();
+}
+inline bool isBitTruncateOp(Operation *op) {
+  std::optional<BitWidthChangeInfo> bitWidthChangeInfo =
+      isBitExtendOrTruncateOp(op);
+  return bitWidthChangeInfo && bitWidthChangeInfo->isTruncationOp();
+}
 
 /// Collect all ops that should be cloned into the given dispatch region op.
 SmallVector<Operation *> getCloneableOps(Flow::DispatchRegionOp regionOp);

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/SinkReshapes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/SinkReshapes.cpp
@@ -67,7 +67,7 @@ static bool shouldSinkExpandShapeOp(OpOperand *opOperand) {
 
   // Do not sink reshapes across dequantize operations since they are
   // cloned into their producers.
-  if (isDequantizationLikeOp(consumer)) {
+  if (isBitExtendOp(consumer)) {
     return false;
   }
 


### PR DESCRIPTION
In quantized/dequantized models the fusion should result in the least bit width operation being written out to memory. To do so need to prevent fusing operations that truncate the bitwidth with operations that extend it back.