### PR TITLE
Fix build_package.yml by giving uploads unique names.

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -288,6 +288,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4.3.3
         with:
+          name: wheels-${{ matrix.build-family }}-${{ matrix.build-package }}
           # We upload all wheels (which includes deps so that subsequent
           # steps can run without further fetching).
           path: ./bindist/*


### PR DESCRIPTION
https://github.com/iree-org/iree/pull/17705 updated this workflow to artifacts v4, which no longer allows multiple jobs to upload to the same artifact name. Last night the `build_package.yml` workflow failed with `Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run`. The fix here is taken from https://github.com/actions/upload-artifact?tab=readme-ov-file#not-uploading-to-the-same-artifact.

Previous success: https://github.com/iree-org/iree/actions/runs/9660426654
* Note: 1.02GB 'artifact' (combined with all .whl files in the same zip)
![image](https://github.com/iree-org/iree/assets/4010439/5fc400c2-51d7-47d5-b190-9f03bbea5081)

Latest failure: https://github.com/iree-org/iree/actions/runs/9677626043
* Note: 33KB 'artifact' from `linux-x86_64 :: Build py-tf-compiler-tools-pkg Package`

skip-ci: untested. Could try with https://github.com/iree-org/iree/actions/workflows/oneshot_candidate_release.yml but I'm leaning towards testing in prod for this. If this doesn't work we can revert back to artifacts v3.