### PR TITLE
[Flow] Enable softmax-like fusion under aggressive fusion.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
@@ -636,10 +636,12 @@ isFusableWithConsumer(OpOperand &fusedOperand,
   // Check if the iteration spaces of the producer and consumer are same.
   // TODO(#12664): This is unnecessary requirement, but we need a better config
   // to tile the consumer with a larger iteration space.
-  auto producerIterationSpace = producerFusionOp.getStaticLoopRanges();
-  auto consumerIterationSpace = consumerFusionOp.getStaticLoopRanges();
-  if (producerIterationSpace.size() < consumerIterationSpace.size()) {
-    return false;
+  if (!options.aggressiveFusion) {
+    auto producerIterationSpace = producerFusionOp.getStaticLoopRanges();
+    auto consumerIterationSpace = consumerFusionOp.getStaticLoopRanges();
+    if (producerIterationSpace.size() < consumerIterationSpace.size()) {
+      return false;
+    }
   }
 
   // Under aggressive fusion assume that the dispatches are vectorized. In which


### PR DESCRIPTION
Under aggressive fusion, drop the restriction of consumer iteration space being same dimensionality as the producer iteration space. Typically this can lead to large vectors if not handled properly. So this is guarded under
`--iree-flow-enable-aggressive-fusion` flag.

Fixes https://github.com/nod-ai/SHARK-Turbine/issues/749