### PR TITLE
Update dotprod microbenchmark artifacts

### DIFF
--- a/build_tools/python/benchmark_suites/iree/armv8_a_benchmarks.py
+++ b/build_tools/python/benchmark_suites/iree/armv8_a_benchmarks.py
@@ -27,10 +27,10 @@ class Android_ARMv8_A_Benchmarks(object):
     ]
 
     MATMULS = [
-        # matmul.MATMUL_1x256x2048_I8xI4_MLIR,
+        matmul.MATMUL_1x256x2048_I8xI4_MLIR,
         matmul.MATMUL_256x256x2048_I8xI4_MLIR,
-        # matmul.MATMUL_1x256x2048_I8xI8_MLIR,
-        # matmul.MATMUL_256x256x2048_I8xI8_MLIR,
+        matmul.MATMUL_1x256x2048_I8xI8_MLIR,
+        matmul.MATMUL_256x256x2048_I8xI8_MLIR,
     ]
 
     ARMV8_A_CPU_TARGET = iree_definitions.CompileTarget(

--- a/build_tools/python/e2e_test_framework/models/matmul.py
+++ b/build_tools/python/e2e_test_framework/models/matmul.py
@@ -108,45 +108,42 @@ MATMUL_123x2561x2561_FP32_MLIR = common_definitions.Model(
     input_types=["123x2561xf32", "2561x2561xf32", "123x2561xf32"],
 )
 
-# TODO(#17344): regenerate .mlirbc files
-# MATMUL_1x256x2048_I8xI4_MLIR = common_definitions.Model(
-#     id=unique_ids.MICRO_MATMUL_1x256x2048_I8xI4_MLIR,
-#     name="matmul_1x256x2048_i8_i4_i32_tile_config_default",
-#     tags=["i8i4", "ubench", "matmul"],
-#     source_type=common_definitions.ModelSourceType.EXPORTED_LINALG_MLIR,
-#     source_url="https://storage.googleapis.com/iree-model-artifacts/linalg/jax_derived_0.4.25_1710887127/matmul_1x256x2048_i8_i4_i32_tile_config_default.mlirbc",
-#     entry_function="main",
-#     input_types=["1x256xi8"],
-# )
+MATMUL_1x256x2048_I8xI4_MLIR = common_definitions.Model(
+    id=unique_ids.MICRO_MATMUL_1x256x2048_I8xI4_MLIR,
+    name="matmul_1x256x2048_i8_i4_i32_tile_config_default",
+    tags=["i8i4", "ubench", "matmul"],
+    source_type=common_definitions.ModelSourceType.EXPORTED_LINALG_MLIR,
+    source_url="https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.30_1719457850/DOT_PRODUCT_JAX_1X256X2048XI8I4/linalg.mlirbc",
+    entry_function="main",
+    input_types=["1x256xi8"],
+)
 
 MATMUL_256x256x2048_I8xI4_MLIR = common_definitions.Model(
     id=unique_ids.MICRO_MATMUL_256x256x2048_I8xI4_MLIR,
     name="matmul_256x256x2048_i8_i4_i32_tile_config_default",
     tags=["i8i4", "ubench", "matmul"],
     source_type=common_definitions.ModelSourceType.EXPORTED_LINALG_MLIR,
-    source_url="https://storage.googleapis.com/iree-model-artifacts/linalg/jax_derived_0.4.25_1710887127/matmul_256x256x2048_i8_i4_i32_tile_config_default.mlirbc",
+    source_url="https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.30_1719457850/DOT_PRODUCT_JAX_256X256X2048XI8I4/linalg.mlirbc",
     entry_function="main",
     input_types=["256x256xi8"],
 )
 
-# TODO(#17344): regenerate .mlirbc files
-# MATMUL_1x256x2048_I8xI8_MLIR = common_definitions.Model(
-#     id=unique_ids.MICRO_MATMUL_1x256x2048_I8xI8_MLIR,
-#     name="matmul_1x256x2048_i8_i8_i32_tile_config_default",
-#     tags=["i8i8", "ubench", "matmul"],
-#     source_type=common_definitions.ModelSourceType.EXPORTED_LINALG_MLIR,
-#     source_url="https://storage.googleapis.com/iree-model-artifacts/linalg/jax_derived_0.4.25_1710887127/matmul_1x256x2048_i8_i8_i32_tile_config_default.mlirbc",
-#     entry_function="main",
-#     input_types=["1x256xi8"],
-# )
+MATMUL_1x256x2048_I8xI8_MLIR = common_definitions.Model(
+    id=unique_ids.MICRO_MATMUL_1x256x2048_I8xI8_MLIR,
+    name="matmul_1x256x2048_i8_i8_i32_tile_config_default",
+    tags=["i8i8", "ubench", "matmul"],
+    source_type=common_definitions.ModelSourceType.EXPORTED_LINALG_MLIR,
+    source_url="https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.30_1719457850/DOT_PRODUCT_JAX_1X256X2048XI8I8/linalg.mlirbc",
+    entry_function="main",
+    input_types=["1x256xi8"],
+)
 
-# TODO(#17344): regenerate .mlirbc files
-# MATMUL_256x256x2048_I8xI8_MLIR = common_definitions.Model(
-#     id=unique_ids.MICRO_MATMUL_256x256x2048_I8xI8_MLIR,
-#     name="matmul_256x256x2048_i8_i8_i32_tile_config_default",
-#     tags=["i8i8", "ubench", "matmul"],
-#     source_type=common_definitions.ModelSourceType.EXPORTED_LINALG_MLIR,
-#     source_url="https://storage.googleapis.com/iree-model-artifacts/linalg/jax_derived_0.4.25_1710887127/matmul_256x256x2048_i8_i8_i32_tile_config_default.mlirbc",
-#     entry_function="main",
-#     input_types=["256x256xi8"],
-# )
+MATMUL_256x256x2048_I8xI8_MLIR = common_definitions.Model(
+    id=unique_ids.MICRO_MATMUL_256x256x2048_I8xI8_MLIR,
+    name="matmul_256x256x2048_i8_i8_i32_tile_config_default",
+    tags=["i8i8", "ubench", "matmul"],
+    source_type=common_definitions.ModelSourceType.EXPORTED_LINALG_MLIR,
+    source_url="https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.30_1719457850/DOT_PRODUCT_JAX_256X256X2048XI8I8/linalg.mlirbc",
+    entry_function="main",
+    input_types=["256x256xi8"],
+)

--- a/build_tools/python/e2e_test_framework/models/model_groups.py
+++ b/build_tools/python/e2e_test_framework/models/model_groups.py
@@ -20,20 +20,18 @@ from e2e_test_framework.models import (
 # Note `0` represents sync execution.
 X86_64_BENCHMARK_CONFIG = [
     # Microbenchmarks.
-    # TODO(#17344): regenerate .mlirbc files
-    # common_definitions.CpuBenchmarkConfig(
-    #     model=matmul.MATMUL_1x256x2048_I8xI4_MLIR, threads=[0]
-    # ),
+    common_definitions.CpuBenchmarkConfig(
+        model=matmul.MATMUL_1x256x2048_I8xI4_MLIR, threads=[0]
+    ),
     common_definitions.CpuBenchmarkConfig(
         model=matmul.MATMUL_256x256x2048_I8xI4_MLIR, threads=[0]
     ),
-    # TODO(#17344): regenerate .mlirbc files
-    # common_definitions.CpuBenchmarkConfig(
-    #     model=matmul.MATMUL_1x256x2048_I8xI8_MLIR, threads=[0]
-    # ),
-    # common_definitions.CpuBenchmarkConfig(
-    #     model=matmul.MATMUL_256x256x2048_I8xI8_MLIR, threads=[0]
-    # ),
+    common_definitions.CpuBenchmarkConfig(
+        model=matmul.MATMUL_1x256x2048_I8xI8_MLIR, threads=[0]
+    ),
+    common_definitions.CpuBenchmarkConfig(
+        model=matmul.MATMUL_256x256x2048_I8xI8_MLIR, threads=[0]
+    ),
     # Tiny models.
     common_definitions.CpuBenchmarkConfig(
         model=tflite_models.PERSON_DETECT_INT8, threads=[0, 1]

--- a/tests/e2e/test_artifacts/generated_e2e_test_fetch_models.cmake
+++ b/tests/e2e/test_artifacts/generated_e2e_test_fetch_models.cmake
@@ -1,7 +1,28 @@
 iree_fetch_artifact(
+  NAME "model-matmul_1x256x2048_i8_i4_i32_tile_config_default"
+  SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.30_1719457850/DOT_PRODUCT_JAX_1X256X2048XI8I4/linalg.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_matmul_1x256x2048_i8_i4_i32_tile_config_default.mlirbc"
+  UNPACK
+)
+
+iree_fetch_artifact(
   NAME "model-matmul_256x256x2048_i8_i4_i32_tile_config_default"
-  SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/linalg/jax_derived_0.4.25_1710887127/matmul_256x256x2048_i8_i4_i32_tile_config_default.mlirbc"
+  SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.30_1719457850/DOT_PRODUCT_JAX_256X256X2048XI8I4/linalg.mlirbc"
   OUTPUT "${ROOT_ARTIFACTS_DIR}/model_matmul_256x256x2048_i8_i4_i32_tile_config_default.mlirbc"
+  UNPACK
+)
+
+iree_fetch_artifact(
+  NAME "model-matmul_1x256x2048_i8_i8_i32_tile_config_default"
+  SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.30_1719457850/DOT_PRODUCT_JAX_1X256X2048XI8I8/linalg.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_matmul_1x256x2048_i8_i8_i32_tile_config_default.mlirbc"
+  UNPACK
+)
+
+iree_fetch_artifact(
+  NAME "model-matmul_256x256x2048_i8_i8_i32_tile_config_default"
+  SOURCE_URL "https://storage.googleapis.com/iree-model-artifacts/jax/jax_models_0.4.30_1719457850/DOT_PRODUCT_JAX_256X256X2048XI8I8/linalg.mlirbc"
+  OUTPUT "${ROOT_ARTIFACTS_DIR}/model_matmul_256x256x2048_i8_i8_i32_tile_config_default.mlirbc"
   UNPACK
 )
 

--- a/tests/e2e/test_artifacts/generated_e2e_test_iree_artifacts.cmake
+++ b/tests/e2e/test_artifacts/generated_e2e_test_iree_artifacts.cmake
@@ -77,6 +77,20 @@ iree_import_tflite_model(
 )
 
 iree_bytecode_module(
+  NAME "iree-module-matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_1x256x2048_i8_i4_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvmcpu-target-cpu=cascadelake"
+    "--iree-opt-data-tiling=false"
+  FRIENDLY_NAME "matmul_1x256x2048_i8_i4_i32_tile_config_default(linalg) [x86_64-cascadelake-linux_gnu-llvm_cpu][experimental-flags,no-dt]"
+  PUBLIC
+)
+
+iree_bytecode_module(
   NAME "iree-module-matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_"
   SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_256x256x2048_i8_i4_i32_tile_config_default.mlirbc"
   MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_/module.vmfb"
@@ -87,6 +101,34 @@ iree_bytecode_module(
     "--iree-llvmcpu-target-cpu=cascadelake"
     "--iree-opt-data-tiling=false"
   FRIENDLY_NAME "matmul_256x256x2048_i8_i4_i32_tile_config_default(linalg) [x86_64-cascadelake-linux_gnu-llvm_cpu][experimental-flags,no-dt]"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME "iree-module-matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_1x256x2048_i8_i8_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvmcpu-target-cpu=cascadelake"
+    "--iree-opt-data-tiling=false"
+  FRIENDLY_NAME "matmul_1x256x2048_i8_i8_i32_tile_config_default(linalg) [x86_64-cascadelake-linux_gnu-llvm_cpu][experimental-flags,no-dt]"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME "iree-module-matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_256x256x2048_i8_i8_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvmcpu-target-cpu=cascadelake"
+    "--iree-opt-data-tiling=false"
+  FRIENDLY_NAME "matmul_256x256x2048_i8_i8_i32_tile_config_default(linalg) [x86_64-cascadelake-linux_gnu-llvm_cpu][experimental-flags,no-dt]"
   PUBLIC
 )
 
@@ -343,6 +385,21 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
+  NAME "iree-module-matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_1x256x2048_i8_i4_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvmcpu-target-cpu=cascadelake"
+    "--iree-opt-data-tiling=true"
+    "--iree-llvmcpu-enable-ukernels=none"
+  FRIENDLY_NAME "matmul_1x256x2048_i8_i4_i32_tile_config_default(linalg) [x86_64-cascadelake-linux_gnu-llvm_cpu][experimental-flags,dt-only]"
+  PUBLIC
+)
+
+iree_bytecode_module(
   NAME "iree-module-matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_"
   SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_256x256x2048_i8_i4_i32_tile_config_default.mlirbc"
   MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_/module.vmfb"
@@ -354,6 +411,36 @@ iree_bytecode_module(
     "--iree-opt-data-tiling=true"
     "--iree-llvmcpu-enable-ukernels=none"
   FRIENDLY_NAME "matmul_256x256x2048_i8_i4_i32_tile_config_default(linalg) [x86_64-cascadelake-linux_gnu-llvm_cpu][experimental-flags,dt-only]"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME "iree-module-matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_1x256x2048_i8_i8_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvmcpu-target-cpu=cascadelake"
+    "--iree-opt-data-tiling=true"
+    "--iree-llvmcpu-enable-ukernels=none"
+  FRIENDLY_NAME "matmul_1x256x2048_i8_i8_i32_tile_config_default(linalg) [x86_64-cascadelake-linux_gnu-llvm_cpu][experimental-flags,dt-only]"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME "iree-module-matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_256x256x2048_i8_i8_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvmcpu-target-cpu=cascadelake"
+    "--iree-opt-data-tiling=true"
+    "--iree-llvmcpu-enable-ukernels=none"
+  FRIENDLY_NAME "matmul_256x256x2048_i8_i8_i32_tile_config_default(linalg) [x86_64-cascadelake-linux_gnu-llvm_cpu][experimental-flags,dt-only]"
   PUBLIC
 )
 
@@ -628,6 +715,21 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
+  NAME "iree-module-matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_1x256x2048_i8_i4_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvmcpu-target-cpu=cascadelake"
+    "--iree-opt-data-tiling=true"
+    "--iree-llvmcpu-enable-ukernels=all"
+  FRIENDLY_NAME "matmul_1x256x2048_i8_i4_i32_tile_config_default(linalg) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,dt-uk]"
+  PUBLIC
+)
+
+iree_bytecode_module(
   NAME "iree-module-matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_"
   SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_256x256x2048_i8_i4_i32_tile_config_default.mlirbc"
   MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_/module.vmfb"
@@ -639,6 +741,36 @@ iree_bytecode_module(
     "--iree-opt-data-tiling=true"
     "--iree-llvmcpu-enable-ukernels=all"
   FRIENDLY_NAME "matmul_256x256x2048_i8_i4_i32_tile_config_default(linalg) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,dt-uk]"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME "iree-module-matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_1x256x2048_i8_i8_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvmcpu-target-cpu=cascadelake"
+    "--iree-opt-data-tiling=true"
+    "--iree-llvmcpu-enable-ukernels=all"
+  FRIENDLY_NAME "matmul_1x256x2048_i8_i8_i32_tile_config_default(linalg) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,dt-uk]"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME "iree-module-matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_256x256x2048_i8_i8_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvmcpu-target-cpu=cascadelake"
+    "--iree-opt-data-tiling=true"
+    "--iree-llvmcpu-enable-ukernels=all"
+  FRIENDLY_NAME "matmul_256x256x2048_i8_i8_i32_tile_config_default(linalg) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,dt-uk]"
   PUBLIC
 )
 
@@ -1686,6 +1818,20 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
+  NAME "iree-module-matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_1x256x2048_i8_i4_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=aarch64-none-linux-android29"
+    "--iree-opt-data-tiling=false"
+    "--iree-llvmcpu-target-cpu-features=+dotprod"
+  FRIENDLY_NAME "matmul_1x256x2048_i8_i4_i32_tile_config_default(linalg) [armv8.2-a-generic-linux_android29-llvm_cpu][experimental-flags,no-dt]"
+  PUBLIC
+)
+
+iree_bytecode_module(
   NAME "iree-module-matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_"
   SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_256x256x2048_i8_i4_i32_tile_config_default.mlirbc"
   MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_/module.vmfb"
@@ -1696,6 +1842,49 @@ iree_bytecode_module(
     "--iree-opt-data-tiling=false"
     "--iree-llvmcpu-target-cpu-features=+dotprod"
   FRIENDLY_NAME "matmul_256x256x2048_i8_i4_i32_tile_config_default(linalg) [armv8.2-a-generic-linux_android29-llvm_cpu][experimental-flags,no-dt]"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME "iree-module-matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_1x256x2048_i8_i8_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=aarch64-none-linux-android29"
+    "--iree-opt-data-tiling=false"
+    "--iree-llvmcpu-target-cpu-features=+dotprod"
+  FRIENDLY_NAME "matmul_1x256x2048_i8_i8_i32_tile_config_default(linalg) [armv8.2-a-generic-linux_android29-llvm_cpu][experimental-flags,no-dt]"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME "iree-module-matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_256x256x2048_i8_i8_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=aarch64-none-linux-android29"
+    "--iree-opt-data-tiling=false"
+    "--iree-llvmcpu-target-cpu-features=+dotprod"
+  FRIENDLY_NAME "matmul_256x256x2048_i8_i8_i32_tile_config_default(linalg) [armv8.2-a-generic-linux_android29-llvm_cpu][experimental-flags,no-dt]"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME "iree-module-matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_dt-uk_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_1x256x2048_i8_i4_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_dt-uk_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=aarch64-none-linux-android29"
+    "--iree-opt-data-tiling=true"
+    "--iree-llvmcpu-enable-ukernels=all"
+    "--iree-llvmcpu-target-cpu-features=+dotprod"
+  FRIENDLY_NAME "matmul_1x256x2048_i8_i4_i32_tile_config_default(linalg) [armv8.2-a-generic-linux_android29-llvm_cpu][default-flags,dt-uk]"
   PUBLIC
 )
 
@@ -1715,6 +1904,51 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
+  NAME "iree-module-matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_dt-uk_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_1x256x2048_i8_i8_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_dt-uk_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=aarch64-none-linux-android29"
+    "--iree-opt-data-tiling=true"
+    "--iree-llvmcpu-enable-ukernels=all"
+    "--iree-llvmcpu-target-cpu-features=+dotprod"
+  FRIENDLY_NAME "matmul_1x256x2048_i8_i8_i32_tile_config_default(linalg) [armv8.2-a-generic-linux_android29-llvm_cpu][default-flags,dt-uk]"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME "iree-module-matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_dt-uk_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_256x256x2048_i8_i8_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_dt-uk_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=aarch64-none-linux-android29"
+    "--iree-opt-data-tiling=true"
+    "--iree-llvmcpu-enable-ukernels=all"
+    "--iree-llvmcpu-target-cpu-features=+dotprod"
+  FRIENDLY_NAME "matmul_256x256x2048_i8_i8_i32_tile_config_default(linalg) [armv8.2-a-generic-linux_android29-llvm_cpu][default-flags,dt-uk]"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME "iree-module-matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_1x256x2048_i8_i4_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=aarch64-none-linux-android29"
+    "--iree-opt-data-tiling=true"
+    "--iree-llvmcpu-enable-ukernels=none"
+    "--iree-llvmcpu-target-cpu-features=+dotprod"
+  FRIENDLY_NAME "matmul_1x256x2048_i8_i4_i32_tile_config_default(linalg) [armv8.2-a-generic-linux_android29-llvm_cpu][experimental-flags,dt-only]"
+  PUBLIC
+)
+
+iree_bytecode_module(
   NAME "iree-module-matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_"
   SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_256x256x2048_i8_i4_i32_tile_config_default.mlirbc"
   MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_/module.vmfb"
@@ -1726,6 +1960,36 @@ iree_bytecode_module(
     "--iree-llvmcpu-enable-ukernels=none"
     "--iree-llvmcpu-target-cpu-features=+dotprod"
   FRIENDLY_NAME "matmul_256x256x2048_i8_i4_i32_tile_config_default(linalg) [armv8.2-a-generic-linux_android29-llvm_cpu][experimental-flags,dt-only]"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME "iree-module-matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_1x256x2048_i8_i8_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=aarch64-none-linux-android29"
+    "--iree-opt-data-tiling=true"
+    "--iree-llvmcpu-enable-ukernels=none"
+    "--iree-llvmcpu-target-cpu-features=+dotprod"
+  FRIENDLY_NAME "matmul_1x256x2048_i8_i8_i32_tile_config_default(linalg) [armv8.2-a-generic-linux_android29-llvm_cpu][experimental-flags,dt-only]"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME "iree-module-matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_256x256x2048_i8_i8_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=aarch64-none-linux-android29"
+    "--iree-opt-data-tiling=true"
+    "--iree-llvmcpu-enable-ukernels=none"
+    "--iree-llvmcpu-target-cpu-features=+dotprod"
+  FRIENDLY_NAME "matmul_256x256x2048_i8_i8_i32_tile_config_default(linalg) [armv8.2-a-generic-linux_android29-llvm_cpu][experimental-flags,dt-only]"
   PUBLIC
 )
 
@@ -1903,6 +2167,24 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
+  NAME "iree-module-matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_1x256x2048_i8_i4_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_compile-stats_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvmcpu-target-cpu=cascadelake"
+    "--iree-opt-data-tiling=false"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvmcpu-debug-symbols=false"
+    "--iree-scheduling-dump-statistics-format=json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_compile-stats_/scheduling_stats.json"
+  FRIENDLY_NAME "matmul_1x256x2048_i8_i4_i32_tile_config_default(linalg) [x86_64-cascadelake-linux_gnu-llvm_cpu][experimental-flags,no-dt,compile-stats]"
+  PUBLIC
+)
+
+iree_bytecode_module(
   NAME "iree-module-matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_compile-stats_"
   SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_256x256x2048_i8_i4_i32_tile_config_default.mlirbc"
   MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_compile-stats_/module.vmfb"
@@ -1917,6 +2199,42 @@ iree_bytecode_module(
     "--iree-scheduling-dump-statistics-format=json"
     "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "matmul_256x256x2048_i8_i4_i32_tile_config_default(linalg) [x86_64-cascadelake-linux_gnu-llvm_cpu][experimental-flags,no-dt,compile-stats]"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME "iree-module-matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_1x256x2048_i8_i8_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_compile-stats_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvmcpu-target-cpu=cascadelake"
+    "--iree-opt-data-tiling=false"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvmcpu-debug-symbols=false"
+    "--iree-scheduling-dump-statistics-format=json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_compile-stats_/scheduling_stats.json"
+  FRIENDLY_NAME "matmul_1x256x2048_i8_i8_i32_tile_config_default(linalg) [x86_64-cascadelake-linux_gnu-llvm_cpu][experimental-flags,no-dt,compile-stats]"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME "iree-module-matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_256x256x2048_i8_i8_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_compile-stats_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvmcpu-target-cpu=cascadelake"
+    "--iree-opt-data-tiling=false"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvmcpu-debug-symbols=false"
+    "--iree-scheduling-dump-statistics-format=json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_compile-stats_/scheduling_stats.json"
+  FRIENDLY_NAME "matmul_256x256x2048_i8_i8_i32_tile_config_default(linalg) [x86_64-cascadelake-linux_gnu-llvm_cpu][experimental-flags,no-dt,compile-stats]"
   PUBLIC
 )
 
@@ -2245,6 +2563,25 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
+  NAME "iree-module-matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_1x256x2048_i8_i4_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_compile-stats_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvmcpu-target-cpu=cascadelake"
+    "--iree-opt-data-tiling=true"
+    "--iree-llvmcpu-enable-ukernels=none"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvmcpu-debug-symbols=false"
+    "--iree-scheduling-dump-statistics-format=json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_compile-stats_/scheduling_stats.json"
+  FRIENDLY_NAME "matmul_1x256x2048_i8_i4_i32_tile_config_default(linalg) [x86_64-cascadelake-linux_gnu-llvm_cpu][experimental-flags,dt-only,compile-stats]"
+  PUBLIC
+)
+
+iree_bytecode_module(
   NAME "iree-module-matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_compile-stats_"
   SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_256x256x2048_i8_i4_i32_tile_config_default.mlirbc"
   MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_compile-stats_/module.vmfb"
@@ -2260,6 +2597,44 @@ iree_bytecode_module(
     "--iree-scheduling-dump-statistics-format=json"
     "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "matmul_256x256x2048_i8_i4_i32_tile_config_default(linalg) [x86_64-cascadelake-linux_gnu-llvm_cpu][experimental-flags,dt-only,compile-stats]"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME "iree-module-matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_1x256x2048_i8_i8_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_compile-stats_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvmcpu-target-cpu=cascadelake"
+    "--iree-opt-data-tiling=true"
+    "--iree-llvmcpu-enable-ukernels=none"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvmcpu-debug-symbols=false"
+    "--iree-scheduling-dump-statistics-format=json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_compile-stats_/scheduling_stats.json"
+  FRIENDLY_NAME "matmul_1x256x2048_i8_i8_i32_tile_config_default(linalg) [x86_64-cascadelake-linux_gnu-llvm_cpu][experimental-flags,dt-only,compile-stats]"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME "iree-module-matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_256x256x2048_i8_i8_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_compile-stats_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvmcpu-target-cpu=cascadelake"
+    "--iree-opt-data-tiling=true"
+    "--iree-llvmcpu-enable-ukernels=none"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvmcpu-debug-symbols=false"
+    "--iree-scheduling-dump-statistics-format=json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_compile-stats_/scheduling_stats.json"
+  FRIENDLY_NAME "matmul_256x256x2048_i8_i8_i32_tile_config_default(linalg) [x86_64-cascadelake-linux_gnu-llvm_cpu][experimental-flags,dt-only,compile-stats]"
   PUBLIC
 )
 
@@ -2606,6 +2981,25 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
+  NAME "iree-module-matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_1x256x2048_i8_i4_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_compile-stats_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvmcpu-target-cpu=cascadelake"
+    "--iree-opt-data-tiling=true"
+    "--iree-llvmcpu-enable-ukernels=all"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvmcpu-debug-symbols=false"
+    "--iree-scheduling-dump-statistics-format=json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_compile-stats_/scheduling_stats.json"
+  FRIENDLY_NAME "matmul_1x256x2048_i8_i4_i32_tile_config_default(linalg) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,dt-uk,compile-stats]"
+  PUBLIC
+)
+
+iree_bytecode_module(
   NAME "iree-module-matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_compile-stats_"
   SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_256x256x2048_i8_i4_i32_tile_config_default.mlirbc"
   MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_compile-stats_/module.vmfb"
@@ -2621,6 +3015,44 @@ iree_bytecode_module(
     "--iree-scheduling-dump-statistics-format=json"
     "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "matmul_256x256x2048_i8_i4_i32_tile_config_default(linalg) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,dt-uk,compile-stats]"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME "iree-module-matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_1x256x2048_i8_i8_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_compile-stats_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvmcpu-target-cpu=cascadelake"
+    "--iree-opt-data-tiling=true"
+    "--iree-llvmcpu-enable-ukernels=all"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvmcpu-debug-symbols=false"
+    "--iree-scheduling-dump-statistics-format=json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_compile-stats_/scheduling_stats.json"
+  FRIENDLY_NAME "matmul_1x256x2048_i8_i8_i32_tile_config_default(linalg) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,dt-uk,compile-stats]"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME "iree-module-matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_256x256x2048_i8_i8_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_compile-stats_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvmcpu-target-cpu=cascadelake"
+    "--iree-opt-data-tiling=true"
+    "--iree-llvmcpu-enable-ukernels=all"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvmcpu-debug-symbols=false"
+    "--iree-scheduling-dump-statistics-format=json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_compile-stats_/scheduling_stats.json"
+  FRIENDLY_NAME "matmul_256x256x2048_i8_i8_i32_tile_config_default(linalg) [x86_64-cascadelake-linux_gnu-llvm_cpu][default-flags,dt-uk,compile-stats]"
   PUBLIC
 )
 
@@ -3952,6 +4384,24 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
+  NAME "iree-module-matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_1x256x2048_i8_i4_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_compile-stats_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=aarch64-none-linux-android29"
+    "--iree-opt-data-tiling=false"
+    "--iree-llvmcpu-target-cpu-features=+dotprod"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvmcpu-debug-symbols=false"
+    "--iree-scheduling-dump-statistics-format=json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_compile-stats_/scheduling_stats.json"
+  FRIENDLY_NAME "matmul_1x256x2048_i8_i4_i32_tile_config_default(linalg) [armv8.2-a-generic-linux_android29-llvm_cpu][experimental-flags,no-dt,compile-stats]"
+  PUBLIC
+)
+
+iree_bytecode_module(
   NAME "iree-module-matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_compile-stats_"
   SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_256x256x2048_i8_i4_i32_tile_config_default.mlirbc"
   MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_compile-stats_/module.vmfb"
@@ -3966,6 +4416,61 @@ iree_bytecode_module(
     "--iree-scheduling-dump-statistics-format=json"
     "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "matmul_256x256x2048_i8_i4_i32_tile_config_default(linalg) [armv8.2-a-generic-linux_android29-llvm_cpu][experimental-flags,no-dt,compile-stats]"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME "iree-module-matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_1x256x2048_i8_i8_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_compile-stats_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=aarch64-none-linux-android29"
+    "--iree-opt-data-tiling=false"
+    "--iree-llvmcpu-target-cpu-features=+dotprod"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvmcpu-debug-symbols=false"
+    "--iree-scheduling-dump-statistics-format=json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_compile-stats_/scheduling_stats.json"
+  FRIENDLY_NAME "matmul_1x256x2048_i8_i8_i32_tile_config_default(linalg) [armv8.2-a-generic-linux_android29-llvm_cpu][experimental-flags,no-dt,compile-stats]"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME "iree-module-matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_256x256x2048_i8_i8_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_compile-stats_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=aarch64-none-linux-android29"
+    "--iree-opt-data-tiling=false"
+    "--iree-llvmcpu-target-cpu-features=+dotprod"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvmcpu-debug-symbols=false"
+    "--iree-scheduling-dump-statistics-format=json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_compile-stats_/scheduling_stats.json"
+  FRIENDLY_NAME "matmul_256x256x2048_i8_i8_i32_tile_config_default(linalg) [armv8.2-a-generic-linux_android29-llvm_cpu][experimental-flags,no-dt,compile-stats]"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME "iree-module-matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_dt-uk_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_1x256x2048_i8_i4_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_dt-uk_compile-stats_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=aarch64-none-linux-android29"
+    "--iree-opt-data-tiling=true"
+    "--iree-llvmcpu-enable-ukernels=all"
+    "--iree-llvmcpu-target-cpu-features=+dotprod"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvmcpu-debug-symbols=false"
+    "--iree-scheduling-dump-statistics-format=json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_dt-uk_compile-stats_/scheduling_stats.json"
+  FRIENDLY_NAME "matmul_1x256x2048_i8_i4_i32_tile_config_default(linalg) [armv8.2-a-generic-linux_android29-llvm_cpu][default-flags,dt-uk,compile-stats]"
   PUBLIC
 )
 
@@ -3989,6 +4494,63 @@ iree_bytecode_module(
 )
 
 iree_bytecode_module(
+  NAME "iree-module-matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_dt-uk_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_1x256x2048_i8_i8_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_dt-uk_compile-stats_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=aarch64-none-linux-android29"
+    "--iree-opt-data-tiling=true"
+    "--iree-llvmcpu-enable-ukernels=all"
+    "--iree-llvmcpu-target-cpu-features=+dotprod"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvmcpu-debug-symbols=false"
+    "--iree-scheduling-dump-statistics-format=json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_dt-uk_compile-stats_/scheduling_stats.json"
+  FRIENDLY_NAME "matmul_1x256x2048_i8_i8_i32_tile_config_default(linalg) [armv8.2-a-generic-linux_android29-llvm_cpu][default-flags,dt-uk,compile-stats]"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME "iree-module-matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_dt-uk_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_256x256x2048_i8_i8_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_dt-uk_compile-stats_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=aarch64-none-linux-android29"
+    "--iree-opt-data-tiling=true"
+    "--iree-llvmcpu-enable-ukernels=all"
+    "--iree-llvmcpu-target-cpu-features=+dotprod"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvmcpu-debug-symbols=false"
+    "--iree-scheduling-dump-statistics-format=json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_dt-uk_compile-stats_/scheduling_stats.json"
+  FRIENDLY_NAME "matmul_256x256x2048_i8_i8_i32_tile_config_default(linalg) [armv8.2-a-generic-linux_android29-llvm_cpu][default-flags,dt-uk,compile-stats]"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME "iree-module-matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_1x256x2048_i8_i4_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_compile-stats_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=aarch64-none-linux-android29"
+    "--iree-opt-data-tiling=true"
+    "--iree-llvmcpu-enable-ukernels=none"
+    "--iree-llvmcpu-target-cpu-features=+dotprod"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvmcpu-debug-symbols=false"
+    "--iree-scheduling-dump-statistics-format=json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_compile-stats_/scheduling_stats.json"
+  FRIENDLY_NAME "matmul_1x256x2048_i8_i4_i32_tile_config_default(linalg) [armv8.2-a-generic-linux_android29-llvm_cpu][experimental-flags,dt-only,compile-stats]"
+  PUBLIC
+)
+
+iree_bytecode_module(
   NAME "iree-module-matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_compile-stats_"
   SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_256x256x2048_i8_i4_i32_tile_config_default.mlirbc"
   MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_compile-stats_/module.vmfb"
@@ -4004,6 +4566,44 @@ iree_bytecode_module(
     "--iree-scheduling-dump-statistics-format=json"
     "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_compile-stats_/scheduling_stats.json"
   FRIENDLY_NAME "matmul_256x256x2048_i8_i4_i32_tile_config_default(linalg) [armv8.2-a-generic-linux_android29-llvm_cpu][experimental-flags,dt-only,compile-stats]"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME "iree-module-matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_1x256x2048_i8_i8_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_compile-stats_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=aarch64-none-linux-android29"
+    "--iree-opt-data-tiling=true"
+    "--iree-llvmcpu-enable-ukernels=none"
+    "--iree-llvmcpu-target-cpu-features=+dotprod"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvmcpu-debug-symbols=false"
+    "--iree-scheduling-dump-statistics-format=json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_compile-stats_/scheduling_stats.json"
+  FRIENDLY_NAME "matmul_1x256x2048_i8_i8_i32_tile_config_default(linalg) [armv8.2-a-generic-linux_android29-llvm_cpu][experimental-flags,dt-only,compile-stats]"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME "iree-module-matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_compile-stats_"
+  SRC "${ROOT_ARTIFACTS_DIR}/model_matmul_256x256x2048_i8_i8_i32_tile_config_default.mlirbc"
+  MODULE_FILE_NAME "${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_compile-stats_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=none"
+    "--iree-llvmcpu-target-triple=aarch64-none-linux-android29"
+    "--iree-opt-data-tiling=true"
+    "--iree-llvmcpu-enable-ukernels=none"
+    "--iree-llvmcpu-target-cpu-features=+dotprod"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvmcpu-debug-symbols=false"
+    "--iree-scheduling-dump-statistics-format=json"
+    "--iree-scheduling-dump-statistics-file=${ROOT_ARTIFACTS_DIR}/iree_module_matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_compile-stats_/scheduling_stats.json"
+  FRIENDLY_NAME "matmul_256x256x2048_i8_i8_i32_tile_config_default(linalg) [armv8.2-a-generic-linux_android29-llvm_cpu][experimental-flags,dt-only,compile-stats]"
   PUBLIC
 )
 
@@ -4255,12 +4855,15 @@ add_dependencies(iree-benchmark-import-models
   ${PACKAGE_NAME}_model-matmul_123x2561x2561_f32t_f32t_f32t_tile_config_default
   ${PACKAGE_NAME}_model-matmul_128x256x8192_f16t_tile_config_default
   ${PACKAGE_NAME}_model-matmul_128x256x8192_f32t_tile_config_default
+  ${PACKAGE_NAME}_model-matmul_1x256x2048_i8_i4_i32_tile_config_default
+  ${PACKAGE_NAME}_model-matmul_1x256x2048_i8_i8_i32_tile_config_default
   ${PACKAGE_NAME}_model-matmul_2560x2560x2560_f16t_tile_config_default
   ${PACKAGE_NAME}_model-matmul_2560x2560x2560_f32t_tile_config_default
   ${PACKAGE_NAME}_model-matmul_2562x2561x2561_f32t_f32t_f32t_tile_config_default
   ${PACKAGE_NAME}_model-matmul_2562x2564x2562_f32t_f32t_f32t_tile_config_default
   ${PACKAGE_NAME}_model-matmul_2564x2564x2564_f32t_f32t_f32t_tile_config_default
   ${PACKAGE_NAME}_model-matmul_256x256x2048_i8_i4_i32_tile_config_default
+  ${PACKAGE_NAME}_model-matmul_256x256x2048_i8_i8_i32_tile_config_default
   ${PACKAGE_NAME}_model-matmul_3456x1024x2048_f16t_tile_config_default
   ${PACKAGE_NAME}_model-matmul_3456x1024x2048_f32t_tile_config_default
 )
@@ -4290,8 +4893,14 @@ add_dependencies(iree-benchmark-suites-android-cpu
   ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_
   ${PACKAGE_NAME}_iree-module-Vit_int8_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_dt-uk_
   ${PACKAGE_NAME}_iree-module-Vit_int8_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_dt-uk_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_dt-uk_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_
   ${PACKAGE_NAME}_iree-module-matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_dt-uk_
   ${PACKAGE_NAME}_iree-module-matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_
+  ${PACKAGE_NAME}_iree-module-matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_dt-uk_
+  ${PACKAGE_NAME}_iree-module-matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_
 )
 
 add_dependencies(iree-benchmark-suites-android-cpu-dt-only
@@ -4301,7 +4910,10 @@ add_dependencies(iree-benchmark-suites-android-cpu-dt-only
   ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_
   ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_
   ${PACKAGE_NAME}_iree-module-Vit_int8_tflite___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_
   ${PACKAGE_NAME}_iree-module-matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_
+  ${PACKAGE_NAME}_iree-module-matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_
 )
 
 add_dependencies(iree-benchmark-suites-android-gpu
@@ -4423,6 +5035,18 @@ add_dependencies(iree-benchmark-suites-comp-stats
   ${PACKAGE_NAME}_iree-module-matmul_123x2561x2561_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_
   ${PACKAGE_NAME}_iree-module-matmul_128x256x8192_f16t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_splitk_compile-stats_
   ${PACKAGE_NAME}_iree-module-matmul_128x256x8192_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_splitk_compile-stats_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_dt-uk_compile-stats_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_compile-stats_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_compile-stats_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_compile-stats_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_compile-stats_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_compile-stats_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_dt-uk_compile-stats_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_compile-stats_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_compile-stats_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_compile-stats_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_compile-stats_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_compile-stats_
   ${PACKAGE_NAME}_iree-module-matmul_2560x2560x2560_f16t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_
   ${PACKAGE_NAME}_iree-module-matmul_2560x2560x2560_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_
   ${PACKAGE_NAME}_iree-module-matmul_2562x2561x2561_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_
@@ -4434,6 +5058,12 @@ add_dependencies(iree-benchmark-suites-comp-stats
   ${PACKAGE_NAME}_iree-module-matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_compile-stats_
   ${PACKAGE_NAME}_iree-module-matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_compile-stats_
   ${PACKAGE_NAME}_iree-module-matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_compile-stats_
+  ${PACKAGE_NAME}_iree-module-matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_dt-uk_compile-stats_
+  ${PACKAGE_NAME}_iree-module-matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_compile-stats_
+  ${PACKAGE_NAME}_iree-module-matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_compile-stats_
+  ${PACKAGE_NAME}_iree-module-matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_compile-stats_
+  ${PACKAGE_NAME}_iree-module-matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_compile-stats_
+  ${PACKAGE_NAME}_iree-module-matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_compile-stats_
   ${PACKAGE_NAME}_iree-module-matmul_3456x1024x2048_f16t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_
   ${PACKAGE_NAME}_iree-module-matmul_3456x1024x2048_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_compile-stats_
 )
@@ -4572,6 +5202,18 @@ add_dependencies(iree-benchmark-suites-default
   ${PACKAGE_NAME}_iree-module-matmul_123x2561x2561_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_
   ${PACKAGE_NAME}_iree-module-matmul_128x256x8192_f16t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_splitk_
   ${PACKAGE_NAME}_iree-module-matmul_128x256x8192_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_splitk_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_dt-uk_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_dt-uk_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_
   ${PACKAGE_NAME}_iree-module-matmul_2560x2560x2560_f16t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_
   ${PACKAGE_NAME}_iree-module-matmul_2560x2560x2560_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_
   ${PACKAGE_NAME}_iree-module-matmul_2562x2561x2561_f32t_f32t_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_
@@ -4583,6 +5225,12 @@ add_dependencies(iree-benchmark-suites-default
   ${PACKAGE_NAME}_iree-module-matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_
   ${PACKAGE_NAME}_iree-module-matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_
   ${PACKAGE_NAME}_iree-module-matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_
+  ${PACKAGE_NAME}_iree-module-matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__default-flags_dt-uk_
+  ${PACKAGE_NAME}_iree-module-matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_dt-only_
+  ${PACKAGE_NAME}_iree-module-matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___armv8.2-a-generic-linux_android29-llvm_cpu__experimental-flags_no-dt_
+  ${PACKAGE_NAME}_iree-module-matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_
+  ${PACKAGE_NAME}_iree-module-matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_
+  ${PACKAGE_NAME}_iree-module-matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_
   ${PACKAGE_NAME}_iree-module-matmul_3456x1024x2048_f16t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_
   ${PACKAGE_NAME}_iree-module-matmul_3456x1024x2048_f32t_tile_config_default_linalg___cuda-sm_80-linux_gnu-cuda__ukernel_matmul_
 )
@@ -4653,8 +5301,14 @@ add_dependencies(iree-benchmark-suites-x86_64
   ${PACKAGE_NAME}_iree-module-PersonDetect_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_
   ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_
   ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_
   ${PACKAGE_NAME}_iree-module-matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_
   ${PACKAGE_NAME}_iree-module-matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_
+  ${PACKAGE_NAME}_iree-module-matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__default-flags_dt-uk_
+  ${PACKAGE_NAME}_iree-module-matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_no-dt_
 )
 
 add_dependencies(iree-benchmark-suites-x86_64-dt-only
@@ -4676,7 +5330,10 @@ add_dependencies(iree-benchmark-suites-x86_64-dt-only
   ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_
   ${PACKAGE_NAME}_iree-module-PersonDetect_int8_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_
   ${PACKAGE_NAME}_iree-module-PoseNet_fp32_tflite___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_
+  ${PACKAGE_NAME}_iree-module-matmul_1x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_
   ${PACKAGE_NAME}_iree-module-matmul_256x256x2048_i8_i4_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_
+  ${PACKAGE_NAME}_iree-module-matmul_256x256x2048_i8_i8_i32_tile_config_default_linalg___x86_64-cascadelake-linux_gnu-llvm_cpu__experimental-flags_dt-only_
 )
 
 add_dependencies(iree-benchmark-suites-x86_64-large


### PR DESCRIPTION
To regenerate dotprod MLIR files, run the following:

```
git clone https://github.com/iree-org/iree-comparative-benchmark.git
cd iree-comparative-benchmark

AUTO_UPLOAD=1 ./common_benchmark_suite/openxla/benchmark/comparative_suite/jax/scripts/generate_model_artifacts.sh DOT_PRODUCT_JAX_.+
```

Once complete, the output will provide the URL that the artifacts have been uploaded to. Update the `source_url` fields in `matmul.py` similar to this PR.