### PR TITLE
[Riscv] Implement a empty cpu initialize function for generic-riscv_64

### DIFF
--- a/runtime/src/iree/base/internal/cpu.c
+++ b/runtime/src/iree/base/internal/cpu.c
@@ -326,6 +326,12 @@ static void iree_cpu_initialize_from_platform_riscv_64(uint64_t* out_fields) {
                  IREE_HWCAP_ISA_V);
 }
 
+#else
+
+static void iree_cpu_initialize_from_platform_riscv_64(uint64_t* out_fields) {
+  // No implementation available. CPU data will be all zeros.
+}
+
 #endif  // IREE_PLATFORM_*
 #endif  // defined(IREE_ARCH_ARM_64)
 


### PR DESCRIPTION
Fix error: call to undeclared function
'iree_cpu_initialize_from_platform_riscv_64' on generic-riscv_64.