### PR TITLE
Exclude arm-sme tests by default on Bazel CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,7 +253,7 @@ jobs:
         uses: actions/checkout@v4.1.7
         with:
           submodules: true
-      - name: "Building with Bazel"
+      - name: "Building and testing with Bazel"
         env:
           IREE_WRITE_REMOTE_BAZEL_CACHE: ${{ needs.setup.outputs.write-caches }}
         run: |

--- a/build_tools/bazel/build_test_all.sh
+++ b/build_tools/bazel/build_test_all.sh
@@ -18,6 +18,7 @@
 #   * IREE_VULKAN_DISABLE
 #   * IREE_NVIDIA_GPU_TESTS_DISABLE
 #   * IREE_AMD_RDNA3_GPU_TESTS_DISABLE
+#   * IREE_ARM_SME_DISABLE
 #
 # Freeform filters can be appended using:
 #   * BUILD_TAG_FILTERS: Passed to bazel to filter targets to build:
@@ -55,6 +56,9 @@ if ! [[ -v IREE_NVIDIA_GPU_TESTS_DISABLE ]]; then
 fi
 if ! [[ -v IREE_AMD_RDNA3_GPU_TESTS_DISABLE ]]; then
   IREE_AMD_RDNA3_GPU_TESTS_DISABLE=1
+fi
+if ! [[ -v IREE_ARM_SME_DISABLE ]]; then
+  IREE_ARM_SME_DISABLE=1
 fi
 
 declare -a test_env_args=(
@@ -95,6 +99,9 @@ if (( IREE_NVIDIA_GPU_TESTS_DISABLE == 1 )); then
 fi
 if (( IREE_AMD_RDNA3_GPU_TESTS_DISABLE == 1 )); then
   default_test_tag_filters+=("-requires-gpu-rdna3")
+fi
+if (( IREE_ARM_SME_DISABLE == 1 )); then
+  default_test_tag_filters+=("-requires-arm-sme")
 fi
 
 # Use user-environment variables if set, otherwise use CI-friendly defaults.


### PR DESCRIPTION
These tests are a no-op if hardware support is missing, so they can be skipped entirely if a CI build knows that it uses different hardware: https://github.com/iree-org/iree/actions/runs/9699357725/job/26768139519#step:4:958

```
//tests/e2e/matmul:e2e_matmul_cpu_arm_sme_nondt_f32_large_llvm-cpu_local-task (cached) PASSED in 0.1s
//tests/e2e/matmul:e2e_matmul_cpu_arm_sme_nondt_f32_large_peel_llvm-cpu_local-task (cached) PASSED in 0.1s
//tests/e2e/matmul:e2e_matmul_cpu_arm_sme_nondt_f32_large_transpose_lhs_llvm-cpu_local-task (cached) PASSED in 0.6s
//tests/e2e/matmul:e2e_matmul_cpu_arm_sme_nondt_f32_large_transpose_lhs_peel_llvm-cpu_local-task (cached) PASSED in 0.5s
//tests/e2e/matmul:e2e_matmul_cpu_arm_sme_nondt_f32_small_llvm-cpu_local-task (cached) PASSED in 0.1s
//tests/e2e/matmul:e2e_matmul_cpu_arm_sme_nondt_f32_small_peel_llvm-cpu_local-task (cached) PASSED in 0.1s
//tests/e2e/matmul:e2e_matmul_cpu_arm_sme_nondt_f32_small_transpose_lhs_llvm-cpu_local-task (cached) PASSED in 0.1s
//tests/e2e/matmul:e2e_matmul_cpu_arm_sme_nondt_f32_small_transpose_lhs_peel_llvm-cpu_local-task (cached) PASSED in 0.1s
```

ci-exactly: build_test_all_bazel