### PR TITLE
[Codegen] Do not consider parallel regions in bufferization analysis

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
@@ -206,6 +206,11 @@ void IREEComprehensiveBufferizePass::runOnOperation() {
   options.printConflicts = printConflicts;
   options.allocationFn = allocationFn;
   options.memCpyFn = memCpyFn;
+  // Turning off checkParallelRegions assumes that we are not relying too much
+  // on bufferization being conservative. If we are, then this could cause race
+  // conditions. Turning this option off could be a good step in diagnosing
+  // data races on GPU.
+  options.checkParallelRegions = false;
 
   if (failed(runIREEOneShotBufferize(funcOp, options))) {
     return signalPassFailure();


### PR DESCRIPTION
When there is a buffer used inside of an `scf.forall` op that is defined outside of the `scf.forall`, bufferization will unconditionally bufferize out of place by default in order to avoid race conditions. However, handling parallel accesses to a buffer should generally be the responsibility of the source program, and if there is a race condition, then it should be handled outside of bufferization. This PR disables the parallel region check in IREE to simplify the bufferization analysis and enable more buffer reuse.

It is possible that this PR could cause race conditions if data races are not handled properly, and we are relying too much on bufferization to be conservative. Turning this option off could be a good early step in diagnosing data races on GPU.