### PR TITLE
[tilingInterface] Update the tile sizes to i64 attr type

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_sort.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_sort.mlir
@@ -40,7 +40,6 @@ hal.executable private @static_3d_sort  {
 //       CHECK: %[[DIM_X:.+]] = gpu.block_dim x
 //       CHECK: scf.for %[[IV_X:.+]] = %[[TID_X]] to %{{.+}} step %[[DIM_X]]
 //       CHECK:   %[[DEST:.+]] = memref.subview %[[WG_OUTPUT]][0, 0, %[[IV_X]]]
-//       CHECK:   %[[CAST:.+]] = memref.cast %[[DEST]]
 //       CHECK:   iree_linalg_ext.sort
 //  CHECK-SAME:       dimension(1)
-//  CHECK-SAME:       outs(%[[CAST]]
+//  CHECK-SAME:       outs(%[[DEST]]


### PR DESCRIPTION
Update the tile sizes to contain i64Attrs instead of arith.constant. Somehow it's giving dynamic shapes in tensor.extract_slice since the arith.constant op isn't folded or seen as a constant.

To fix Issue: https://github.com/iree-org/iree/issues/17441