### PR TITLE
[LLVMGPU] Landing VectorDistribution pipeline for attention

### DIFF
--- a/build_tools/pkgci/external_test_suite/models_gpu_rocm_gfx90a.json
+++ b/build_tools/pkgci/external_test_suite/models_gpu_rocm_gfx90a.json
@@ -23,6 +23,7 @@
     // TODO(#17874): error: a handle passed as operand #0 and consumed by this operation points to a payload entity more than once
     "sharktank/llama/open-llama-3b-v2-f16",
 
+    // TODO: Add I8 MFMA layout support for CDNA2. Currently only CDNA3 specific I8 layout is implemented.
     "sharktank/punet/int8"
   ],
   "expected_run_failures": []

--- a/build_tools/pkgci/external_test_suite/models_gpu_rocm_gfx90a.json
+++ b/build_tools/pkgci/external_test_suite/models_gpu_rocm_gfx90a.json
@@ -23,7 +23,6 @@
     // TODO(#17874): error: a handle passed as operand #0 and consumed by this operation points to a payload entity more than once
     "sharktank/llama/open-llama-3b-v2-f16",
 
-    "sharktank/punet/fp16",
     "sharktank/punet/int8"
   ],
   "expected_run_failures": []

--- a/build_tools/pkgci/external_test_suite/models_gpu_rocm_gfx942.json
+++ b/build_tools/pkgci/external_test_suite/models_gpu_rocm_gfx942.json
@@ -23,7 +23,6 @@
       // TODO(#17874): error: a handle passed as operand #0 and consumed by this operation points to a payload entity more than once
     "sharktank/llama/open-llama-3b-v2-f16",
 
-    "sharktank/punet/fp16",
     "sharktank/punet/int8"
   ],
   "expected_run_failures": []

--- a/build_tools/pkgci/external_test_suite/models_gpu_rocm_gfx942.json
+++ b/build_tools/pkgci/external_test_suite/models_gpu_rocm_gfx942.json
@@ -22,8 +22,6 @@
 
       // TODO(#17874): error: a handle passed as operand #0 and consumed by this operation points to a payload entity more than once
     "sharktank/llama/open-llama-3b-v2-f16",
-
-    "sharktank/punet/int8"
   ],
   "expected_run_failures": []
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
@@ -145,6 +145,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
         "//compiler/src/iree/compiler/Dialect/LinalgExt/IR",
         "//compiler/src/iree/compiler/Dialect/LinalgExt/Transforms",
+        "//compiler/src/iree/compiler/Dialect/LinalgExt/Utils",
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "//compiler/src/iree/compiler/Dialect/Util/Transforms",
         "//compiler/src/iree/compiler/Utils",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -187,6 +187,7 @@ iree_cc_library(
     iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::LinalgExt::IR
     iree::compiler::Dialect::LinalgExt::Transforms
+    iree::compiler::Dialect::LinalgExt::Utils
     iree::compiler::Dialect::Util::IR
     iree::compiler::Dialect::Util::Transforms
     iree::compiler::Utils

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -759,8 +759,6 @@ setAttentionVectorDistributionConfig(IREE::GPU::TargetAttr target,
 
   // Follow the LLVMGPU convention of keeping all of the tile sizes in one list.
   workgroupTileSizes[k2Dim] = schedule->kTileCount * schedule->kSize;
-  // workgroupTileSizes[opInfo.getMDims().back()] = 64;
-  // workgroupTileSizes[opInfo.getK2Dims().back()] = 32;
 
   TileSizesListType tileSizes;
   tileSizes.push_back(workgroupTileSizes);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -621,16 +621,7 @@ setAttentionVectorDistributionConfig(IREE::GPU::TargetAttr target,
 
   // Get iteration domain bounds.
   OpBuilder b(op);
-  SmallVector<Range> itDomain = op.getIterationDomain(b);
-  SmallVector<int64_t> bounds(itDomain.size());
-  for (auto [slice, bound] : llvm::zip_equal(itDomain, bounds)) {
-    OpFoldResult size = slice.size;
-    if (std::optional<int64_t> constSize = getConstantIntValue(size)) {
-      bound = constSize.value();
-    } else {
-      bound = ShapedType::kDynamic;
-    }
-  }
+  SmallVector<int64_t, 4> bounds = op.getStaticLoopRanges();
 
   auto opInfo =
       IREE::LinalgExt::AttentionOpDetail::get(op.getIndexingMapsArray())

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -643,7 +643,7 @@ setAttentionVectorDistributionConfig(IREE::GPU::TargetAttr target,
   // TODO: Do we need a matvec-like attention pipeline? Probably not,
   // considering M is generally the largest dimension.
 
-  Value v = op.getValue();
+  Value vMatrix = op.getValue();
 
   SmallVector<GPUMatmulShapeType> intrinsics;
   intrinsics.reserve(target.getWgp().getMma().size());
@@ -663,7 +663,7 @@ setAttentionVectorDistributionConfig(IREE::GPU::TargetAttr target,
   //
   // We assume that the second matmul uses the element type of V for input
   // and f32 as output. It is possible to use other element types also.
-  Type vElementType = getElementTypeOrSelf(v);
+  Type vElementType = getElementTypeOrSelf(vMatrix);
   Type f32Type = b.getF32Type();
   GPUMatmulShapeType problem{bounds[mDim],
                              bounds[nDim],

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -684,8 +684,8 @@ setAttentionVectorDistributionConfig(IREE::GPU::TargetAttr target,
   // TODO: Currently, we are forcing number of subgroups to be 1. This can be
   // fixed by teaching vector distribution chained matmul.
   GPUMMAHeuristicSeeds seeds = {/*bestSubgroupCountPerWorkgroup=*/1,
-                                /*bestMNTileCountPerSubgroup=*/16,
-                                /*bestKTileCountPerSubgroup=*/2};
+                                /*bestMNTileCountPerSubgroup=*/8,
+                                /*bestKTileCountPerSubgroup=*/4};
 
   LDBG("Attention Vector Distribution Config");
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -23,6 +23,7 @@
 #include "iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h"
 #include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "iree/compiler/Dialect/LinalgExt/Utils/IndexingUtils.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
@@ -610,6 +611,181 @@ setMatmulVectorDistributionConfig(IREE::GPU::TargetAttr target,
 }
 
 static LogicalResult
+setAttentionVectorDistributionConfig(IREE::GPU::TargetAttr target,
+                                     mlir::FunctionOpInterface entryPoint,
+                                     IREE::LinalgExt::AttentionOp op) {
+  if (target.getWgp().getMma().empty())
+    return failure();
+
+  const int64_t targetSubgroupSize = target.getPreferredSubgroupSize();
+
+  // Get iteration domain bounds.
+  OpBuilder b(op->getContext());
+  SmallVector<Range> itDomain = op.getIterationDomain(b);
+  SmallVector<int64_t> bounds(itDomain.size());
+  for (auto [slice, bound] : llvm::zip(itDomain, bounds)) {
+    OpFoldResult size = slice.size;
+    if (std::optional<int64_t> constSize = getConstantIntValue(size)) {
+      bound = constSize.value();
+    } else {
+      bound = ShapedType::kDynamic;
+    }
+  }
+
+  auto opInfo =
+      IREE::LinalgExt::AttentionOpDetail::get(op.getIndexingMapsArray())
+          .value();
+
+  int64_t mDim = opInfo.getMDims().back();
+  int64_t k1Dim = opInfo.getK1Dims().back();
+  int64_t k2Dim = opInfo.getK2Dims().back();
+  int64_t nDim = opInfo.getNDims().back();
+
+  // Dynamic dims are expected to be taken care of earlier in the pipeline.
+  if (ShapedType::isDynamic(bounds[mDim]) ||
+      ShapedType::isDynamic(bounds[k1Dim]) ||
+      ShapedType::isDynamic(bounds[k2Dim]) ||
+      ShapedType::isDynamic(bounds[nDim])) {
+    return failure();
+  }
+
+  // TODO: Do we need a matvec-like attention pipeline? Probably not,
+  // considering M is generally the largest dimension.
+
+  Value v = op.getValue();
+
+  SmallVector<GPUMatmulShapeType> intrinsics;
+  intrinsics.reserve(target.getWgp().getMma().size());
+  for (IREE::GPU::MMAAttr mma : target.getWgp().getMma()) {
+    auto [mSize, nSize, kSize] = mma.getMNKShape();
+    auto [aType, bType, cType] = mma.getABCElementTypes();
+    if (mma.getSubgroupSize() != targetSubgroupSize)
+      continue;
+    intrinsics.emplace_back(mSize, nSize, kSize, aType, bType, cType);
+  }
+  if (intrinsics.empty())
+    return failure();
+
+  // We select the tile sizes based on the second matmul. We can probably
+  // use a better heuristic, but all tile sizes can be determined from the
+  // second matmul.
+  //
+  // We assume that the second matmul uses the element type of V for input
+  // and f32 as output. It is possible to use other element types also.
+  Type vElementType = getElementTypeOrSelf(v);
+  Type f32Type = b.getF32Type();
+  GPUMatmulShapeType problem{bounds[mDim],
+                             bounds[nDim],
+                             bounds[k2Dim],
+                             /*lhsType=*/vElementType,
+                             /*rhsType=*/vElementType,
+                             /*accType=*/f32Type};
+
+  // TODO: Currently, we are forcing number of subgroups to be 1. This can be
+  // fixed by teaching vector distribution chained matmul.
+  GPUMMAHeuristicSeeds seeds = {/*bestSubgroupCountPerWorkgroup=*/1,
+                                /*bestMNTileCountPerSubgroup=*/8,
+                                /*bestKTileCountPerSubgroup=*/4};
+
+  LDBG("Attention Vector Distribution Config");
+
+  auto pipeline = CodeGenPipeline::LLVMGPUVectorDistribute;
+
+  // Infer if lhs or rhs is transposed to help generate better schedule.
+  AffineMap sMap = opInfo.getSMap();
+  AffineMap vMap = op.getValueMap();
+
+  bool transposedLhs =
+      (k2Dim !=
+       llvm::cast<AffineDimExpr>(sMap.getResults().back()).getPosition());
+  bool transposedRhs =
+      (nDim !=
+       llvm::cast<AffineDimExpr>(vMap.getResults().back()).getPosition());
+
+  int64_t maxSharedMemoryBytes = target.getWgp().getMaxWorkgroupMemoryBytes();
+
+  // First try to find a schedule with an exactly matching intrinsic.
+  std::optional<GPUMMASchedule> schedule = deduceMMASchedule(
+      problem, intrinsics, seeds, maxSharedMemoryBytes, targetSubgroupSize);
+  if (!schedule) {
+    // Then try again by allowing upcasting accumulator.
+    schedule =
+        deduceMMASchedule(problem, intrinsics, seeds, maxSharedMemoryBytes,
+                          targetSubgroupSize, transposedLhs, transposedRhs,
+                          /*canUpcastAcc=*/true);
+  }
+
+  if (!schedule) {
+    LDBG("Failed to deduce Attention schedule");
+    return failure();
+  }
+
+  LDBG("Target Subgroup size: " << targetSubgroupSize);
+  LDBG("Schedule: sizes [" << schedule->mSize << ", " << schedule->nSize << ", "
+                           << schedule->kSize << "]");
+  LDBG("Schedule: tile counts [" << schedule->mTileCount << ", "
+                                 << schedule->nTileCount << ", "
+                                 << schedule->kTileCount << "]");
+  LDBG("Schedule: warp counts [" << schedule->mWarpCount << ", "
+                                 << schedule->nWarpCount << "]");
+
+  std::array<int64_t, 3> workgroupSize{
+      schedule->nWarpCount * targetSubgroupSize, schedule->mWarpCount, 1};
+
+  SmallVector<int64_t> workgroupTileSizes(opInfo.getDomainRank(), 0);
+  // Tile all batch dimensions with unit size.
+  for (int64_t batch : opInfo.getBatchDims()) {
+    workgroupTileSizes[batch] = 1;
+  }
+
+  // Tile all m, n, and k2 dimensions to 1 except the innermost. Unit dims
+  // from this tiling are folded before vectorization. k1 dimension cannot be
+  // tiled, so we leave it.
+  for (int64_t m : llvm::drop_end(opInfo.getMDims())) {
+    workgroupTileSizes[m] = 1;
+  }
+  for (int64_t n : llvm::drop_end(opInfo.getNDims())) {
+    workgroupTileSizes[n] = 1;
+  }
+  for (int64_t k2 : llvm::drop_end(opInfo.getK2Dims())) {
+    workgroupTileSizes[k2] = 1;
+  }
+
+  // Compute the M/N dimension tile size by multiply subgroup information.
+  workgroupTileSizes[mDim] =
+      schedule->mWarpCount * schedule->mTileCount * schedule->mSize;
+  workgroupTileSizes[nDim] =
+      schedule->nWarpCount * schedule->nTileCount * schedule->nSize;
+
+  // Follow the LLVMGPU convention of keeping all of the tile sizes in one list.
+  workgroupTileSizes[k2Dim] = schedule->kTileCount * schedule->kSize;
+
+  workgroupTileSizes[opInfo.getMDims().back()] = 64;
+  workgroupTileSizes[opInfo.getK2Dims().back()] = 32;
+
+  TileSizesListType tileSizes;
+  tileSizes.push_back(workgroupTileSizes);
+
+  // Attach the MMA schedule as an attribute to the entry point export function
+  // for later access in the pipeline.
+  MLIRContext *context = op.getContext();
+  auto scheduleAttr = IREE::GPU::MMAScheduleAttr::get(
+      context, target.getWgp().getMma()[schedule->index], schedule->mWarpCount,
+      schedule->nWarpCount);
+  SmallVector<NamedAttribute, 1> attrs;
+  attrs.emplace_back(StringAttr::get(context, "mma_schedule"), scheduleAttr);
+  auto configDict = DictionaryAttr::get(context, attrs);
+
+  // TODO: We do not turn prefetching on even when requested by the prefetching
+  // flag because there is a shared memory allocation the two matmuls, which
+  // the prefetching pass cannot understand.
+
+  return setOpConfigAndEntryPointFnTranslation(entryPoint, op, tileSizes,
+                                               pipeline, workgroupSize,
+                                               targetSubgroupSize, configDict);
+}
+
+static LogicalResult
 setVectorDistributionConfig(IREE::GPU::TargetAttr target,
                             mlir::FunctionOpInterface entryPoint,
                             Operation *computeOp) {
@@ -635,6 +811,11 @@ setVectorDistributionConfig(IREE::GPU::TargetAttr target,
       return setConvolutionVectorDistributionConfig(target, entryPoint,
                                                     linalgOp);
     }
+  }
+
+  if (auto attnOp = dyn_cast<IREE::LinalgExt::AttentionOp>(computeOp)) {
+    LDBG("VectorDistribution: trying to find a suitable attention config");
+    return setAttentionVectorDistributionConfig(target, entryPoint, attnOp);
   }
 
   LDBG("VectorDistribution: failed to find a suitable config");

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -620,7 +620,7 @@ setAttentionVectorDistributionConfig(IREE::GPU::TargetAttr target,
   const int64_t targetSubgroupSize = target.getPreferredSubgroupSize();
 
   // Get iteration domain bounds.
-  OpBuilder b(op->getContext());
+  OpBuilder b(op);
   SmallVector<Range> itDomain = op.getIterationDomain(b);
   SmallVector<int64_t> bounds(itDomain.size());
   for (auto [slice, bound] : llvm::zip(itDomain, bounds)) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -623,7 +623,7 @@ setAttentionVectorDistributionConfig(IREE::GPU::TargetAttr target,
   OpBuilder b(op);
   SmallVector<Range> itDomain = op.getIterationDomain(b);
   SmallVector<int64_t> bounds(itDomain.size());
-  for (auto [slice, bound] : llvm::zip(itDomain, bounds)) {
+  for (auto [slice, bound] : llvm::zip_equal(itDomain, bounds)) {
     OpFoldResult size = slice.size;
     if (std::optional<int64_t> constSize = getConstantIntValue(size)) {
       bound = constSize.value();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -684,8 +684,8 @@ setAttentionVectorDistributionConfig(IREE::GPU::TargetAttr target,
   // TODO: Currently, we are forcing number of subgroups to be 1. This can be
   // fixed by teaching vector distribution chained matmul.
   GPUMMAHeuristicSeeds seeds = {/*bestSubgroupCountPerWorkgroup=*/1,
-                                /*bestMNTileCountPerSubgroup=*/8,
-                                /*bestKTileCountPerSubgroup=*/4};
+                                /*bestMNTileCountPerSubgroup=*/16,
+                                /*bestKTileCountPerSubgroup=*/2};
 
   LDBG("Attention Vector Distribution Config");
 
@@ -759,9 +759,8 @@ setAttentionVectorDistributionConfig(IREE::GPU::TargetAttr target,
 
   // Follow the LLVMGPU convention of keeping all of the tile sizes in one list.
   workgroupTileSizes[k2Dim] = schedule->kTileCount * schedule->kSize;
-
-  workgroupTileSizes[opInfo.getMDims().back()] = 64;
-  workgroupTileSizes[opInfo.getK2Dims().back()] = 32;
+  // workgroupTileSizes[opInfo.getMDims().back()] = 64;
+  // workgroupTileSizes[opInfo.getK2Dims().back()] = 32;
 
   TileSizesListType tileSizes;
   tileSizes.push_back(workgroupTileSizes);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -242,6 +242,7 @@ static void tileAndBufferize(OpPassManager &funcPassManager) {
 static void addGPUVectorizationPasses(OpPassManager &funcPassManager,
                                       bool earlySubsetTransferFolding = true) {
   funcPassManager.addPass(createDecomposeConvolutionToLowerDimOpsPass());
+  // Vectorize.
   GenericVectorizationPassOptions options;
   options.vectorizePadding = true;
   options.vectorizeGatherAccesses = true;
@@ -249,6 +250,9 @@ static void addGPUVectorizationPasses(OpPassManager &funcPassManager,
   options.foldCastIntoContract = true;
   options.earlySubsetTransferFolding = earlySubsetTransferFolding;
   funcPassManager.addPass(createGenericVectorizationPass(options));
+  funcPassManager.addPass(createCanonicalizerPass());
+  funcPassManager.addPass(createCSEPass());
+  // Run subset hoisting to convert iter_args to vectors.
   funcPassManager.addPass(createOptimizeTensorInsertExtractSlicesPass());
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
@@ -283,7 +287,6 @@ void addGPUVectorizationPassPipeline(OpPassManager &funcPassManager) {
   funcPassManager.addPass(memref::createFoldMemRefAliasOpsPass());
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
-  funcPassManager.addPass(createOptimizeVectorTransferPass());
   funcPassManager.addPass(createOptimizeTensorInsertExtractSlicesPass());
 }
 
@@ -726,6 +729,8 @@ void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createReorderWorkgroups(
       reorderStrategy, clReorderWorkgroupsLogSwizzleTile,
       canReorderWorkgroups));
+  funcPassManager.addPass(
+      IREE::LinalgExt::createConvertAttentionToOnlineAttentionPass());
 
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
@@ -747,6 +752,10 @@ void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager,
     LLVMGPUMatmulPadOption option = LLVMGPUMatmulPadOption::ReductionDims;
     funcPassManager.addPass(createLLVMGPUPromoteMatmulToFitMMAPass(option));
   }
+
+  funcPassManager.addPass(IREE::LinalgExt::createDecomposeAttentionPass());
+  funcPassManager.addPass(createCanonicalizerPass());
+  funcPassManager.addPass(createCSEPass());
 
   // Generalize all named ops so that we can fold away unit extent dims. By this
   // point, all tiling is finished so the tiling configurations on those ops can
@@ -777,8 +786,11 @@ void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createCSEPass());
   funcPassManager.addPass(createHoistStaticallyBoundAllocationsPass());
 
-  // Vector SIMD -> Vector SIMT
+  // Preprocessing for vector distribution.
   funcPassManager.addPass(createLLVMGPUCastTypeToFitMMAPass());
+  funcPassManager.addPass(createAMDGPUPrepareForChainedMatmulPass());
+
+  // Vector SIMD -> Vector SIMT
   funcPassManager.addPass(createLLVMGPUVectorDistribute());
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -287,6 +287,7 @@ void addGPUVectorizationPassPipeline(OpPassManager &funcPassManager) {
   funcPassManager.addPass(memref::createFoldMemRefAliasOpsPass());
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
+  funcPassManager.addPass(createOptimizeVectorTransferPass());
   funcPassManager.addPass(createOptimizeTensorInsertExtractSlicesPass());
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute.mlir
@@ -329,7 +329,11 @@ func.func @attention_20x4096x64x4096x64() {
   %5 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
   %6 = flow.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
   %7 = tensor.empty() : tensor<20x4096x64xf16>
-  %8 = iree_linalg_ext.attention ins(%4, %5, %6, %cst : tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16) outs(%7 : tensor<20x4096x64xf16>) -> tensor<20x4096x64xf16>
+  %8 = iree_linalg_ext.attention  {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>]}
+                     ins(%4, %5, %6, %cst : tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16) outs(%7 : tensor<20x4096x64xf16>) -> tensor<20x4096x64xf16>
   flow.dispatch.tensor.store %8, %3, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : tensor<20x4096x64xf16> -> !flow.dispatch.tensor<writeonly:tensor<20x4096x64xf16>>
   return
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute.mlir
@@ -308,3 +308,28 @@ module {
 }
 // Check that we have unhandled dynamic dimension.
 //       CHECK-NOT: iree_codegen.translation_info<LLVMGPUVectorDistribute
+
+// -----
+
+// CHECK:       #[[$TILE_SIZES:.+]] = #iree_codegen.lowering_config<tile_sizes =  {{\[}}[1, 64, 0, 32, 64]{{\]}}
+// CHECK:       #iree_codegen.translation_info<LLVMGPUVectorDistribute
+// CHECK-SAME:  subgroup_m_count = 1, subgroup_n_count = 1
+// CHECK-NOT:   prefetch_shared_memory
+
+// CHECK-LABEL: func.func @attention_20x4096x64x4096x64()
+
+func.func @attention_20x4096x64x4096x64() {
+  %cst = arith.constant 1.250000e-01 : f16
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
+  %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
+  %3 = hal.interface.binding.subspan set(0) binding(3) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<20x4096x64xf16>>
+  %4 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
+  %5 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
+  %6 = flow.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
+  %7 = tensor.empty() : tensor<20x4096x64xf16>
+  %8 = iree_linalg_ext.attention ins(%4, %5, %6, %cst : tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16) outs(%7 : tensor<20x4096x64xf16>) -> tensor<20x4096x64xf16>
+  flow.dispatch.tensor.store %8, %3, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : tensor<20x4096x64xf16> -> !flow.dispatch.tensor<writeonly:tensor<20x4096x64xf16>>
+  return
+}

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute.mlir
@@ -311,7 +311,7 @@ module {
 
 // -----
 
-// CHECK:       #[[$TILE_SIZES:.+]] = #iree_codegen.lowering_config<tile_sizes =  {{\[}}[1, 64, 0, 32, 64]{{\]}}
+// CHECK:       #[[$TILE_SIZES:.+]] = #iree_codegen.lowering_config<tile_sizes =  {{\[}}[1, 32, 0, 64, 64]{{\]}}
 // CHECK:       #iree_codegen.translation_info<LLVMGPUVectorDistribute
 // CHECK-SAME:  subgroup_m_count = 1, subgroup_n_count = 1
 // CHECK-NOT:   prefetch_shared_memory

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute.mlir
@@ -678,7 +678,7 @@ hal.executable private @attention_20x4096x64x4096x64 {
 // CHECK-LABEL: func.func @attention_20x4096x64x4096x64()
 // CHECK-SAME:    translation_info = #[[$TRANSLATION]]
 
-// CHECK: scf.for %{{.*}} = %c0 to %c4096 step %c32
-// CHECK-SAME: -> (vector<4x1x4xf32>, vector<4x4x1x1x4x1xf16>, vector<4x1x4xf32>)
-// CHECK-COUNT-64:  amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
+// CHECK: scf.for %{{.*}} = %c0 to %c4096 step %c64
+// CHECK-SAME: -> (vector<2x1x4xf32>, vector<2x4x1x1x4x1xf16>, vector<2x1x4xf32>)
+// CHECK-COUNT-32:  amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
 // CHECK: scf.yield

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute.mlir
@@ -636,3 +636,49 @@ hal.executable public @contract_schedule_considering_read_layout {
 // CHECK-COUNT-16:     amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
 // CHECK:     scf.yield
 // CHECK-COUNT-16:   amdgpu.mfma
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer, ReadOnly>, <3, storage_buffer>]>]>
+hal.executable private @attention_20x4096x64x4096x64 {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @attention_20x4096x64x4096x64 ordinal(0) layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_slice
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @attention_20x4096x64x4096x64() {
+        %cst = arith.constant 1.250000e-01 : f16
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
+        %3 = hal.interface.binding.subspan set(0) binding(3) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<20x4096x64xf16>>
+        %4 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
+        %5 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
+        %6 = flow.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
+        %7 = tensor.empty() : tensor<20x4096x64xf16>
+        %8 = iree_linalg_ext.attention ins(%4, %5, %6, %cst : tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16) outs(%7 : tensor<20x4096x64xf16>) -> tensor<20x4096x64xf16>
+        flow.dispatch.tensor.store %8, %3, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : tensor<20x4096x64xf16> -> !flow.dispatch.tensor<writeonly:tensor<20x4096x64xf16>>
+        return
+      }
+    }
+  }
+}
+
+// Basic test to make sure we can handle attention
+
+// CHECK:       #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
+// CHECK-SAME:    mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>,
+// CHECK-SAME:    subgroup_m_count = 1, subgroup_n_count = 1>
+// Prefetching is disabled for attention for now
+// CHECK-NOT:     prefetch_shared_memory
+
+// CHECK-LABEL: func.func @attention_20x4096x64x4096x64()
+// CHECK-SAME:    translation_info = #[[$TRANSLATION]]
+
+// CHECK: scf.for %{{.*}} = %c0 to %c4096 step %c32
+// CHECK-SAME: -> (vector<4x1x4xf32>, vector<4x4x1x1x4x1xf16>, vector<4x1x4xf32>)
+// CHECK-COUNT-64:  amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
+// CHECK: scf.yield

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute.mlir
@@ -659,7 +659,11 @@ hal.executable private @attention_20x4096x64x4096x64 {
         %5 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
         %6 = flow.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
         %7 = tensor.empty() : tensor<20x4096x64xf16>
-        %8 = iree_linalg_ext.attention ins(%4, %5, %6, %cst : tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16) outs(%7 : tensor<20x4096x64xf16>) -> tensor<20x4096x64xf16>
+        %8 = iree_linalg_ext.attention  {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>]}
+                     ins(%4, %5, %6, %cst : tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16) outs(%7 : tensor<20x4096x64xf16>) -> tensor<20x4096x64xf16>
         flow.dispatch.tensor.store %8, %3, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : tensor<20x4096x64xf16> -> !flow.dispatch.tensor<writeonly:tensor<20x4096x64xf16>>
         return
       }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -516,6 +516,8 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_PureOp<"attention",
 
     SmallVector<AffineMap> getIndexingMapsArray();
 
+    SmallVector<int64_t, 4> getStaticLoopRanges();
+
     AffineMap getQueryMap() {
       return cast<AffineMap>(getIndexingMapsArray()[0]);
     }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -17,8 +17,7 @@ namespace mlir::iree_compiler::IREE::LinalgExt {
 Value getDimValue(OpBuilder &builder, Location loc, Value v, int64_t dim) {
   ShapedType type = cast<ShapedType>(v.getType());
   if (!type.isDynamicDim(dim)) {
-    return builder.createOrFold<arith::ConstantIndexOp>(loc,
-                                                        type.getDimSize(dim));
+    return builder.create<arith::ConstantIndexOp>(loc, type.getDimSize(dim));
   }
   return TypeSwitch<Type, Value>(v.getType())
       .Case<RankedTensorType>([&](RankedTensorType t) -> Value {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -17,7 +17,8 @@ namespace mlir::iree_compiler::IREE::LinalgExt {
 Value getDimValue(OpBuilder &builder, Location loc, Value v, int64_t dim) {
   ShapedType type = cast<ShapedType>(v.getType());
   if (!type.isDynamicDim(dim)) {
-    return builder.createOrFold<arith::ConstantIndexOp>(loc, type.getDimSize(dim));
+    return builder.createOrFold<arith::ConstantIndexOp>(loc,
+                                                        type.getDimSize(dim));
   }
   return TypeSwitch<Type, Value>(v.getType())
       .Case<RankedTensorType>([&](RankedTensorType t) -> Value {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -17,8 +17,7 @@ namespace mlir::iree_compiler::IREE::LinalgExt {
 Value getDimValue(OpBuilder &builder, Location loc, Value v, int64_t dim) {
   ShapedType type = cast<ShapedType>(v.getType());
   if (!type.isDynamicDim(dim)) {
-    return builder.create<arith::ConstantIndexOp>(loc, type.getDimSize(dim))
-        .getResult();
+    return builder.createOrFold<arith::ConstantIndexOp>(loc, type.getDimSize(dim));
   }
   return TypeSwitch<Type, Value>(v.getType())
       .Case<RankedTensorType>([&](RankedTensorType t) -> Value {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -16,6 +16,7 @@ namespace mlir::iree_compiler::IREE::LinalgExt {
 
 Value getDimValue(OpBuilder &builder, Location loc, Value v, int64_t dim) {
   ShapedType type = cast<ShapedType>(v.getType());
+  assert(type.getRank() > dim && "Inquired dim needs to less than rank.");
   if (!type.isDynamicDim(dim)) {
     return builder.create<arith::ConstantIndexOp>(loc, type.getDimSize(dim));
   }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -16,9 +16,9 @@ namespace mlir::iree_compiler::IREE::LinalgExt {
 
 Value getDimValue(OpBuilder &builder, Location loc, Value v, int64_t dim) {
   ShapedType type = cast<ShapedType>(v.getType());
-  assert(type.getRank() > dim && "Inquired dim needs to less than rank.");
   if (!type.isDynamicDim(dim)) {
-    return builder.create<arith::ConstantIndexOp>(loc, type.getDimSize(dim));
+    return builder.create<arith::ConstantIndexOp>(loc, type.getDimSize(dim))
+        .getResult();
   }
   return TypeSwitch<Type, Value>(v.getType())
       .Case<RankedTensorType>([&](RankedTensorType t) -> Value {


### PR DESCRIPTION
This PR is to fix and land the original https://github.com/iree-org/iree/pull/17716.  Which adds support for lowering attention through VectorDistribution pipeline. 
Currently, it has the following limitations which will be fixed as followups:

Only 1 subgroup is used
There are 4 shared memory promotions. Based on the intrinsic, this can be reduced to 2 or 3.
