### PR TITLE
[CPU] Restrict how scalable flags are propagated

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPU2DScalableTo1DScalable.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPU2DScalableTo1DScalable.cpp
@@ -147,11 +147,11 @@ dropScalabilityFromUnsupportedOperations(mlir::FunctionOpInterface funcOp,
     // TODO: Remove once `vector.transpose` is supported
     bool nonIdentity = false;
     if (auto genericOp = dyn_cast<linalg::GenericOp>(&tilingOp)) {
-      for (auto map : ArrayRef<AffineMap>(genericOp->getIndexingMapsArray())
-                          .take_back(tilingOp->getResults().size())) {
-        if (!map.isIdentity())
-          nonIdentity = true;
-      }
+      auto indexingMaps = genericOp->getIndexingMapsArray();
+      nonIdentity =
+          llvm::any_of(ArrayRef<AffineMap>(indexingMaps)
+                           .take_back(tilingOp->getResults().size()),
+                       [](AffineMap map) { return !map.isIdentity(); });
     }
     if (nonIdentity) {
       newScalableFlags = SmallVector<bool>(newScalableFlags.size(), false);


### PR DESCRIPTION
Updates `LLVMCPU2DScalableTo1DScalablePass` to remove the scalable flags
when the affine map for the output tensor is a non-identity. Such maps
could represent a vector transposition - that's currently not
supported for SVE and leads to compilation failures.

This has become a problem once more Op fusion has been enabled during
dispatch formation:
  * https://github.com/iree-org/iree/pull/17663

(note - more Op fusion is a very desirable thing).

We may want to split `LLVMCPU2DScalableTo1DScalablePass` into e.g. 2
passes - the logic added here is a bit tangential to merely reducing the
number of scalable flags from 2 to 1.

Also, we ought to investigate how to properly handle transpositions like this
one:
```
  vector.transpose %47, [1, 0] : vector<4x[8]xf32> to vector<[8]x4xf32>
```

See the attached test case for an example that without this change would
lead to a transposition like the one above.
