### PR TITLE
[Stream] Teach allocation of encoding to take bcast map into account.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.cpp
@@ -126,7 +126,7 @@ AffineMap EncodingAttr::getMapForOperandIndex() {
     auto indexingMap =
         llvm::cast<AffineMapAttr>(getUserIndexingMaps()[index]).getAffineMap();
     if (auto bcastMap = getBcastMap()) {
-      indexingMap = bcastMap.getAffineMap();
+      indexingMap = bcastMap.getAffineMap().compose(indexingMap);
     }
     return indexingMap;
   }

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.cpp
@@ -122,9 +122,14 @@ AffineMap EncodingAttr::getMapForOperandIndex() {
   switch (index) {
   case MATMUL_LHS:
   case MATMUL_RHS:
-  case MATMUL_RESULT:
-    return llvm::cast<AffineMapAttr>(getUserIndexingMaps()[index])
-        .getAffineMap();
+  case MATMUL_RESULT: {
+    auto indexingMap =
+        llvm::cast<AffineMapAttr>(getUserIndexingMaps()[index]).getAffineMap();
+    if (auto bcastMap = getBcastMap()) {
+      indexingMap = bcastMap.getAffineMap();
+    }
+    return indexingMap;
+  }
   default:
     return AffineMap();
   }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/encode_host_tensors.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/encode_host_tensors.mlir
@@ -85,7 +85,7 @@ util.func public @sizeof_result_encoding_dynamic(%arg0: index, %arg1: index) -> 
 #map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
 #map1 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
 #map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
-#map3 = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
+#map3 = affine_map<(d0, d1, d2) -> (d1, d2)>
 util.func public @sizeof_lhs_encoding_with_bcast_across_batch_dim_dynamic(%arg0: index, %arg1: index) -> index {
   %0 = stream.tensor.sizeof tensor<?x?xf32, #iree_encoding.encoding<operand_index = 0, element_types = [f32, f32, f32], original_type = tensor<?x?xf32>, user_indexing_maps = [#map, #map1, #map2], bcast_map = #map3, round_dims_to = array<i64: 4, 8, 16>>>{%arg0, %arg1} : index
   util.return %0 : index
@@ -106,7 +106,7 @@ util.func public @sizeof_lhs_encoding_with_bcast_across_batch_dim_dynamic(%arg0:
 #map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
 #map1 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
 #map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
-#map3 = affine_map<(d0, d1, d2, d3) -> (d0, d3)>
+#map3 = affine_map<(d0, d1, d2) -> (d0, d2)>
 util.func public @sizeof_lhs_encoding_with_bcast_across_m_dim_dynamic(%arg0: index, %arg1: index) -> index {
   %0 = stream.tensor.sizeof tensor<?x?xf32, #iree_encoding.encoding<operand_index = 0, element_types = [f32, f32, f32], original_type = tensor<?x?xf32>, user_indexing_maps = [#map, #map1, #map2], bcast_map = #map3, round_dims_to = array<i64: 4, 8, 16>>>{%arg0, %arg1} : index
   util.return %0 : index

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/encode_host_tensors.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/encode_host_tensors.mlir
@@ -82,6 +82,49 @@ util.func public @sizeof_result_encoding_dynamic(%arg0: index, %arg1: index) -> 
 
 // -----
 
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
+util.func public @sizeof_lhs_encoding_with_bcast_across_batch_dim_dynamic(%arg0: index, %arg1: index) -> index {
+  %0 = stream.tensor.sizeof tensor<?x?xf32, #iree_encoding.encoding<operand_index = 0, element_types = [f32, f32, f32], original_type = tensor<?x?xf32>, user_indexing_maps = [#map, #map1, #map2], bcast_map = #map3, round_dims_to = array<i64: 4, 8, 16>>>{%arg0, %arg1} : index
+  util.return %0 : index
+}
+// CHECK-LABEL: @sizeof_lhs_encoding_with_bcast_across_batch_dim_dynamic
+// CHECK-DAG:     %[[C4:.+]] = arith.constant 4 : index
+// CHECK-DAG:     %[[C16:.+]] = arith.constant 16 : index
+// CHECK:         %[[CEIL_DIV_D0:.+]] = arith.ceildivui %arg0, %[[C4]]
+// CHECK:         %[[PAD_D0:.+]] = arith.muli %[[CEIL_DIV_D0]], %[[C4]]
+// CHECK:         %[[CEIL_DIV_D1:.+]] = arith.ceildivui %arg1, %[[C16]]
+// CHECK:         %[[PAD_D1:.+]] = arith.muli %[[CEIL_DIV_D1]], %[[C16]]
+// CHECK:         %[[T0:.+]] = arith.muli %[[PAD_D0]], %[[C4]]
+// CHECK:         %[[T1:.+]] = arith.muli %[[T0]], %[[PAD_D1]]
+// CHECK:         return %[[T1]]
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d0, d3)>
+util.func public @sizeof_lhs_encoding_with_bcast_across_m_dim_dynamic(%arg0: index, %arg1: index) -> index {
+  %0 = stream.tensor.sizeof tensor<?x?xf32, #iree_encoding.encoding<operand_index = 0, element_types = [f32, f32, f32], original_type = tensor<?x?xf32>, user_indexing_maps = [#map, #map1, #map2], bcast_map = #map3, round_dims_to = array<i64: 4, 8, 16>>>{%arg0, %arg1} : index
+  util.return %0 : index
+}
+// CHECK-LABEL: @sizeof_lhs_encoding_with_bcast_across_m_dim_dynamic
+// CHECK-DAG:     %[[C4:.+]] = arith.constant 4 : index
+// CHECK-DAG:     %[[C16:.+]] = arith.constant 16 : index
+// CHECK:         %[[CEIL_DIV_D1:.+]] = arith.ceildivui %arg1, %[[C16]]
+// CHECK:         %[[PAD_D1:.+]] = arith.muli %[[CEIL_DIV_D1]], %[[C16]]
+//
+// Multiplied by 4 because f32 has 4 bytes.
+//
+// CHECK:         %[[T0:.+]] = arith.muli %arg0, %[[C4]]
+// CHECK:         %[[T1:.+]] = arith.muli %[[T0]], %[[PAD_D1]]
+// CHECK:         return %[[T1]]
+
+// -----
+
 // CHECK-LABEL: @denseTensorEmpty
 util.func public @denseTensorEmpty(%arg0: index, %arg1: index) -> !stream.resource<*> {
   // CHECK: %[[RET:.+]] = stream.async.alloca : !stream.resource<*>{%arg1}


### PR DESCRIPTION
The bcast_map represents the iteration domain mapping from the source of dispatch to matmul. So it uses bcast_map in getMapForOperandIndex() when it is present.