### PR TITLE
Disable Android tests and benchmarks while devices are offline.

### DIFF
--- a/.github/workflows/build_and_test_android.yml
+++ b/.github/workflows/build_and_test_android.yml
@@ -109,7 +109,8 @@ jobs:
 
   test:
     # These physical devices are not scalable. Only run on postsubmit for now.
-    if: (! inputs.is-pr)
+    # Disabled while Android devices are offline.
+    if: (! inputs.is-pr && 0)
     needs: cross_compile
     strategy:
       matrix:

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -154,6 +154,13 @@ DEFAULT_BENCHMARK_PRESET_GROUP = [
     for preset in benchmark_presets.DEFAULT_PRESETS
     # RISC-V benchmarks haven't been supported in CI workflow.
     if preset not in [benchmark_presets.RISCV]
+    # Disabled while lab Android devices are offline.
+    and preset
+    not in [
+        benchmark_presets.ANDROID_CPU,
+        benchmark_presets.ANDROID_CPU_DT_ONLY,
+        benchmark_presets.ANDROID_GPU,
+    ]
 ] + ["comp-stats"]
 DEFAULT_BENCHMARK_PRESET = "default"
 LARGE_BENCHMARK_PRESET_GROUP = benchmark_presets.LARGE_PRESETS


### PR DESCRIPTION
Devices are offline, see sample logs:
* https://github.com/iree-org/iree/actions/runs/9748314039/job/26911326157
* https://github.com/iree-org/iree/actions/runs/9748314041/job/26903976192

benchmark-extra: default