### PR TITLE
[Flow] Fix dominance error in `FormScalarDispatches`

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/form_scalar_dispatches.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/form_scalar_dispatches.mlir
@@ -161,7 +161,7 @@ util.func public @interleaving(
 // -----
 
 #map = affine_map<() -> ()>
-util.func public @nonRootInChain(%arg0: i32, %arg1: i1, %arg2: tensor<i32>, %arg7: i32) -> (tensor<i32>, tensor<i32>) {
+util.func public @clonable_op_in_chain(%arg0: i32, %arg1: i1, %arg2: tensor<i32>, %arg7: i32) -> (tensor<i32>, tensor<i32>) {
   %0 = linalg.generic {indexing_maps = [#map], iterator_types = []} outs(%arg2 : tensor<i32>) {
   ^bb0(%out: i32):
     %2 = arith.select %arg1, %arg7, %arg0 : i32
@@ -176,6 +176,51 @@ util.func public @nonRootInChain(%arg0: i32, %arg1: i1, %arg2: tensor<i32>, %arg
   util.return %0, %1 : tensor<i32>, tensor<i32>
 }
 
-// CHECK-LABEL: util.func public @nonRootInChain(
+// CHECK-LABEL: util.func public @clonable_op_in_chain(
+//       CHECK:   %[[DISPATCH0:.+]] = flow.dispatch.region
+//       CHECK:   %[[DISPATCH1:.+]] = flow.dispatch.region
+
+// -----
+
+#map = affine_map<() -> ()>
+util.func public @clonable_op_used_after(%arg0: i32, %arg1: i1, %arg2: tensor<i32>, %arg7: i32) -> (tensor<i32>, tensor<i32>, i32) {
+  %0 = linalg.generic {indexing_maps = [#map], iterator_types = []} outs(%arg2 : tensor<i32>) {
+  ^bb0(%out: i32):
+    %2 = arith.select %arg1, %arg7, %arg0 : i32
+    linalg.yield %2 : i32
+  } -> tensor<i32>
+  %extracted = tensor.extract %0[] : tensor<i32>
+  %1 = linalg.generic {indexing_maps = [#map], iterator_types = []} outs(%arg2 : tensor<i32>) {
+  ^bb0(%out: i32):
+    %2 = arith.select %arg1, %arg7, %extracted : i32
+    linalg.yield %2 : i32
+  } -> tensor<i32>
+  util.return %0, %1, %extracted : tensor<i32>, tensor<i32>, i32
+}
+
+// CHECK-LABEL: util.func public @clonable_op_used_after
+//       CHECK:   %[[DISPATCH0:.+]] = flow.dispatch.region
+//       CHECK:   %[[DISPATCH1:.+]] = flow.dispatch.region
+
+// -----
+
+#map = affine_map<() -> ()>
+util.func public @clonable_op_only_used_after(%arg0: i32, %arg1: i1, %arg2: tensor<i32>, %arg7: i32) -> (tensor<i32>, tensor<i32>, i32) {
+  %0 = linalg.generic {indexing_maps = [#map], iterator_types = []} outs(%arg2 : tensor<i32>) {
+  ^bb0(%out: i32):
+    %2 = arith.select %arg1, %arg7, %arg0 : i32
+    linalg.yield %2 : i32
+  } -> tensor<i32>
+  %extracted = tensor.extract %0[] : tensor<i32>
+  %1 = linalg.generic {indexing_maps = [#map], iterator_types = []} outs(%arg2 : tensor<i32>) {
+  ^bb0(%out: i32):
+    %extracted2 = tensor.extract %arg2[] : tensor<i32>
+    %2 = arith.select %arg1, %arg7, %extracted2 : i32
+    linalg.yield %2 : i32
+  } -> tensor<i32>
+  util.return %0, %1, %extracted : tensor<i32>, tensor<i32>, i32
+}
+
+// CHECK-LABEL: util.func public @clonable_op_only_used_after
 //       CHECK:   %[[DISPATCH0:.+]] = flow.dispatch.region
 //       CHECK:   %[[DISPATCH1:.+]] = flow.dispatch.region


### PR DESCRIPTION
Issue here https://github.com/iree-org/iree/issues/17759

When preforming horizontal fusion, ops that were clonable (but not used by the fusion group) were ignored. If these ops were dependent on values produced by 'root ops', then the root op would get moved into the region. The logic here probably needs to get refactored because there is probably missed horizontal fusion opportunities. This probably need a more in depth analysis, however. 