### PR TITLE
Disable TFL tests broken by tfhub/kaggle.

### DIFF
--- a/integrations/tensorflow/test/iree_tfl_tests/cartoon_gan.run
+++ b/integrations/tensorflow/test/iree_tfl_tests/cartoon_gan.run
@@ -1,1 +1,3 @@
+# REQUIRES: bugfix
+#           tfhub/kaggle broke their download endpoint, update URLs
 # RUN: %PYTHON -m iree_tfl_tests.cartoon_gan_test --artifacts_dir=%t

--- a/integrations/tensorflow/test/iree_tfl_tests/mnasnet.run
+++ b/integrations/tensorflow/test/iree_tfl_tests/mnasnet.run
@@ -1,1 +1,3 @@
+# REQUIRES: bugfix
+#           tfhub/kaggle broke their download endpoint, update URLs
 # RUN: %PYTHON -m iree_tfl_tests.mnasnet_test --artifacts_dir=%t

--- a/integrations/tensorflow/test/iree_tfl_tests/mobilenet_v3.run
+++ b/integrations/tensorflow/test/iree_tfl_tests/mobilenet_v3.run
@@ -1,1 +1,3 @@
+# REQUIRES: bugfix
+#           tfhub/kaggle broke their download endpoint, update URLs
 # RUN: %PYTHON -m iree_tfl_tests.mobilenet_v3_test --artifacts_dir=%t


### PR DESCRIPTION
Sample logs: https://github.com/iree-org/iree/actions/runs/9760105520/job/26938839345 (`urllib.error.HTTPError: HTTP Error 500: Internal Server Error`)

URLs like https://tfhub.dev/sayakpaul/lite-model/east-text-detector/dr/1?lite-format=tflite no longer work with direct downloading. "TensorFlow Hub has been integrated with Kaggle Models.", so those URLs are getting redirected to e.g. https://www.kaggle.com/models/spsayakpaul/east-text-detector/tfLite/dr/1?lite-format=tflite&tfhub-redirect=true, which hides the files behind some new download API. Until we can migrate to the new API (or use the cURL endpoint and extract from the .tar.gz archive), disable affected tests.