### PR TITLE
Sync SDXL benchmark metrics with latest values.

### DIFF
--- a/.github/workflows/pkgci_regression_test.yml
+++ b/.github/workflows/pkgci_regression_test.yml
@@ -298,10 +298,10 @@ jobs:
         run: |
           source ${VENV_DIR}/bin/activate
           pytest SHARK-TestSuite/iree_tests/benchmarks/sdxl/benchmark_sdxl_rocm.py \
-            --goldentime-rocm-e2e-ms 1335.0 \
+            --goldentime-rocm-e2e-ms 1336.0 \
             --goldentime-rocm-unet-ms 340.0 \
             --goldentime-rocm-clip-ms 17.0 \
-            --goldentime-rocm-vae-ms 290.0 \
+            --goldentime-rocm-vae-ms 291.0 \
             --goldendispatch-rocm-unet 1714 \
             --goldendispatch-rocm-clip 1569 \
             --goldendispatch-rocm-vae 248 \

--- a/.github/workflows/pkgci_regression_test.yml
+++ b/.github/workflows/pkgci_regression_test.yml
@@ -298,16 +298,16 @@ jobs:
         run: |
           source ${VENV_DIR}/bin/activate
           pytest SHARK-TestSuite/iree_tests/benchmarks/sdxl/benchmark_sdxl_rocm.py \
-            --goldentime-rocm-e2e-ms 1661.5 \
-            --goldentime-rocm-unet-ms 450.5 \
-            --goldentime-rocm-clip-ms 19 \
+            --goldentime-rocm-e2e-ms 1335.0 \
+            --goldentime-rocm-unet-ms 340.0 \
+            --goldentime-rocm-clip-ms 17.0 \
             --goldentime-rocm-vae-ms 290.0 \
             --goldendispatch-rocm-unet 1714 \
             --goldendispatch-rocm-clip 1569 \
             --goldendispatch-rocm-vae 248 \
-            --goldensize-rocm-unet-bytes 2088217 \
-            --goldensize-rocm-clip-bytes 785493 \
-            --goldensize-rocm-vae-bytes 762067 \
+            --goldensize-rocm-unet-bytes 2062938 \
+            --goldensize-rocm-clip-bytes 780200 \
+            --goldensize-rocm-vae-bytes 757933 \
             --gpu-number 6 \
             --rocm-chip gfx90a \
             --log-cli-level=info \


### PR DESCRIPTION
Benchmark metrics improved (when using `--iree-llvmgpu-enable-prefetch=true`), so locking in the improvements. Context: https://github.com/iree-org/iree/pull/17744#issuecomment-2200424176

Presubmit results: https://github.com/iree-org/iree/actions/runs/9765047731/attempts/1#summary-26955236756