### PR TITLE
Disable build_test_all_macos_arm64 while runner is offline.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,42 +151,43 @@ jobs:
   #     - name: "Testing IREE"
   #       run: ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
 
-  build_test_all_macos_arm64:
-    needs: setup
-    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_test_all_macos_arm64')
-    runs-on:
-      - ${{ github.repository == 'iree-org/iree' && 'self-hosted' || 'macos-12' }} # must come first
-      - runner-group=postsubmit
-      - os-family=macOS
-    env:
-      BUILD_DIR: build-macos
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@v4.1.7
-      - name: "Updating git submodules"
-        run: git submodule update --init --jobs 8 --depth 1
-      - name: "Installing Python packages"
-        run: |
-          python3 -m venv .venv
-          source .venv/bin/activate
-          python3 -m pip install -r runtime/bindings/python/iree/runtime/build_requirements.txt
-      - name: "Building IREE"
-        env:
-          IREE_READ_REMOTE_CCACHE: 0
-          IREE_WRITE_REMOTE_CCACHE: 0
-          IREE_READ_LOCAL_CCACHE: 1
-          IREE_WRITE_LOCAL_CCACHE: ${{ needs.setup.outputs.write-caches }}
-          # We'll remove the GITHUB_WORKSPACE directory after the job.
-          # Persist the cache by storing in the parent directory.
-          CCACHE_DIR: ${{ github.workspace }}/../.ccache
-          CCACHE_MAXSIZE: 30G
-        run: |
-          source .venv/bin/activate
-          bash ./build_tools/cmake/build_all.sh "${BUILD_DIR}"
-      - name: "Testing IREE"
-        run: |
-          source .venv/bin/activate
-          IREE_METAL_DISABLE=0 bash ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
+  # Disabled while runner is offline.
+  # build_test_all_macos_arm64:
+  #   needs: setup
+  #   if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_test_all_macos_arm64')
+  #   runs-on:
+  #     - ${{ github.repository == 'iree-org/iree' && 'self-hosted' || 'macos-12' }} # must come first
+  #     - runner-group=postsubmit
+  #     - os-family=macOS
+  #   env:
+  #     BUILD_DIR: build-macos
+  #   steps:
+  #     - name: "Checking out repository"
+  #       uses: actions/checkout@v4.1.7
+  #     - name: "Updating git submodules"
+  #       run: git submodule update --init --jobs 8 --depth 1
+  #     - name: "Installing Python packages"
+  #       run: |
+  #         python3 -m venv .venv
+  #         source .venv/bin/activate
+  #         python3 -m pip install -r runtime/bindings/python/iree/runtime/build_requirements.txt
+  #     - name: "Building IREE"
+  #       env:
+  #         IREE_READ_REMOTE_CCACHE: 0
+  #         IREE_WRITE_REMOTE_CCACHE: 0
+  #         IREE_READ_LOCAL_CCACHE: 1
+  #         IREE_WRITE_LOCAL_CCACHE: ${{ needs.setup.outputs.write-caches }}
+  #         # We'll remove the GITHUB_WORKSPACE directory after the job.
+  #         # Persist the cache by storing in the parent directory.
+  #         CCACHE_DIR: ${{ github.workspace }}/../.ccache
+  #         CCACHE_MAXSIZE: 30G
+  #       run: |
+  #         source .venv/bin/activate
+  #         bash ./build_tools/cmake/build_all.sh "${BUILD_DIR}"
+  #     - name: "Testing IREE"
+  #       run: |
+  #         source .venv/bin/activate
+  #         IREE_METAL_DISABLE=0 bash ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
 
   build_test_all_macos_x86_64:
     needs: setup
@@ -914,7 +915,7 @@ jobs:
       # Platforms
       - build_test_all_arm64
       # - build_test_all_windows
-      - build_test_all_macos_arm64
+      # - build_test_all_macos_arm64
       - build_test_all_macos_x86_64
 
       # Accelerators

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -126,7 +126,7 @@ DEFAULT_POSTSUBMIT_ONLY_JOBS = frozenset(
     [
         "build_test_all_arm64",
         # "build_test_all_windows",  # Currently disabled
-        "build_test_all_macos_arm64",
+        # "build_test_all_macos_arm64",  # Currently disabled
         "build_test_all_macos_x86_64",
         # Due to the outstock of A100, only run this test in postsubmit.
         "test_nvidia_a100",
@@ -140,7 +140,8 @@ DEFAULT_POSTSUBMIT_ONLY_JOBS = frozenset(
 # Each tuple consists of the CI job name and a list of file paths to match.
 # The file paths should be specified using Unix shell-style wildcards.
 PRESUBMIT_TOUCH_ONLY_JOBS = [
-    ("build_test_all_macos_arm64", ["runtime/src/iree/hal/drivers/metal/*"]),
+    # Currently disabled
+    # ("build_test_all_macos_arm64", ["runtime/src/iree/hal/drivers/metal/*"]),
     # Currently disabled
     # (
     #     "build_test_all_windows",

--- a/build_tools/github_actions/configure_ci_test.py
+++ b/build_tools/github_actions/configure_ci_test.py
@@ -292,6 +292,7 @@ class ConfigureCITest(unittest.TestCase):
         )
         self.assertCountEqual(jobs, {postsubmit_job})
 
+    @unittest.skip("skip while `build_test_all_macos_arm64` job is disabled")
     def test_get_enabled_jobs_metal(self):
         trailers = {}
         all_jobs = {"job1"}


### PR DESCRIPTION
We've had jobs queued for 24h+ waiting for a runner that is offline: 
![image](https://github.com/iree-org/iree/assets/4010439/e749dc1f-d2e3-48dd-b8c1-1f9e121c6ad2)
(https://github.com/iree-org/iree/actions/workflows/ci.yml?query=branch%3Amain)