### PR TITLE
Switch macOS package builds to use github-hosted runners.

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -72,17 +72,16 @@ jobs:
             experimental: false
 
           # MacOS packages.
-          - runs-on:
-              - ${{ github.repository == 'iree-org/iree' && 'self-hosted' || 'macos-11' }}
-              - os-family=macOS
-              - runner-group=postsubmit
+          # TODO(scotttodd): build on larger runner when available (self-hosted or GitHub)
+          # - runs-on:
+          #     - ${{ github.repository == 'iree-org/iree' && 'self-hosted' || 'macos-14' }}
+          #     - os-family=macOS
+          #     - runner-group=postsubmit
+          - runs-on: macos-14
             build-family: macos
             build-package: py-compiler-pkg
             experimental: true
-          - runs-on:
-              - ${{ github.repository == 'iree-org/iree' && 'self-hosted' || 'macos-11' }}
-              - os-family=macOS
-              - runner-group=postsubmit
+          - runs-on: macos-14
             build-family: macos
             build-package: py-runtime-pkg
             experimental: true


### PR DESCRIPTION
Our nightly release builds have been queued waiting for a runner that is offline: https://github.com/iree-org/iree/actions/workflows/build_package.yml, so this switches to use github-hosted runners. This may be temporary while our self-hosted runner is offline.

GitHub docs:
* https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
* https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/about-larger-runners#about-macos-larger-runners

skip-ci: untested on presubmit, ~~can't~~ shouldn't make the releases worse (but might fail with out of disk space or other errors)