### PR TITLE
Try switching build_test_all_macos_arm64 to GitHub-hosted runner.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,10 +154,7 @@ jobs:
   build_test_all_macos_arm64:
     needs: setup
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_test_all_macos_arm64')
-    runs-on:
-      - ${{ github.repository == 'iree-org/iree' && 'self-hosted' || 'macos-12' }} # must come first
-      - runner-group=postsubmit
-      - os-family=macOS
+    runs-on: macos-14
     env:
       BUILD_DIR: build-macos
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,9 @@ jobs:
         uses: actions/checkout@v4.1.7
       - name: "Updating git submodules"
         run: git submodule update --init --jobs 8 --depth 1
+      - name: "Installing build dependencies"
+        run: |
+          brew install ninja
       - name: "Installing Python packages"
         run: |
           python3 -m venv .venv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,33 +160,44 @@ jobs:
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@v4.1.7
+      - id: "gcp-auth"
+        name: "Authenticating to Google Cloud"
+        if: needs.setup.outputs.write-caches == 1
+        uses: "google-github-actions/auth@v1"
+        with:
+          token_format: "access_token"
+          credentials_json: "${{ secrets.IREE_OSS_GITHUB_RUNNER_BASIC_TRUST_SERVICE_ACCOUNT_KEY }}"
+          create_credentials_file: false
       - name: "Updating git submodules"
         run: git submodule update --init --jobs 8 --depth 1
-      - name: "Installing build dependencies"
+      # There are multiple versions of Xcode and SDKs installed on the macOS runner.
+      # Select the latest Xcode app to enable using Metal offline toolchain.
+      - name: "Update Xcode command line tools path"
         run: |
-          brew install ninja
+          sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
+          xcrun metal --version
+          xcrun metallib --version
+      - name: "Setting up Python"
+        uses: actions/setup-python@v5.1.0
+        with:
+          python-version: "3.10"
+          cache: "pip"
       - name: "Installing Python packages"
-        run: |
-          python3 -m venv .venv
-          source .venv/bin/activate
-          python3 -m pip install -r runtime/bindings/python/iree/runtime/build_requirements.txt
+        run: pip install -r runtime/bindings/python/iree/runtime/build_requirements.txt
+      - name: "Installing requirements"
+        # We need coreutils for `realpath` used in scripts.
+        # We need bash because the default one on macOS is fairly old and lacks
+        # features we use in scripts.
+        run: brew install ninja ccache coreutils bash
+      # Finally: build and run tests.
       - name: "Building IREE"
         env:
-          IREE_READ_REMOTE_CCACHE: 0
-          IREE_WRITE_REMOTE_CCACHE: 0
-          IREE_READ_LOCAL_CCACHE: 1
-          IREE_WRITE_LOCAL_CCACHE: ${{ needs.setup.outputs.write-caches }}
-          # We'll remove the GITHUB_WORKSPACE directory after the job.
-          # Persist the cache by storing in the parent directory.
-          CCACHE_DIR: ${{ github.workspace }}/../.ccache
-          CCACHE_MAXSIZE: 30G
-        run: |
-          source .venv/bin/activate
-          bash ./build_tools/cmake/build_all.sh "${BUILD_DIR}"
+          IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
+          IREE_CCACHE_GCP_TOKEN: ${{ steps.gcp-auth.outputs.access_token }}
+          CCACHE_NAMESPACE: github-macos-13
+        run: bash ./build_tools/cmake/build_all.sh "${BUILD_DIR}"
       - name: "Testing IREE"
-        run: |
-          source .venv/bin/activate
-          IREE_METAL_DISABLE=0 bash ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
+        run: IREE_METAL_DISABLE=0 bash ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
 
   build_test_all_macos_x86_64:
     needs: setup


### PR DESCRIPTION
According to https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories , the macos-14 runners have 3 (M1) cores... which _might_ be enough to build the project, at least on postsubmit...?

ci-exactly: build_test_all_macos_arm64