### PR TITLE
Revert "Disable Android tests and benchmarks while devices are offline."

### DIFF
--- a/.github/workflows/build_and_test_android.yml
+++ b/.github/workflows/build_and_test_android.yml
@@ -109,8 +109,7 @@ jobs:
 
   test:
     # These physical devices are not scalable. Only run on postsubmit for now.
-    # Disabled while Android devices are offline.
-    if: (! inputs.is-pr && 0)
+    if: (! inputs.is-pr)
     needs: cross_compile
     strategy:
       matrix:

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -155,13 +155,6 @@ DEFAULT_BENCHMARK_PRESET_GROUP = [
     for preset in benchmark_presets.DEFAULT_PRESETS
     # RISC-V benchmarks haven't been supported in CI workflow.
     if preset not in [benchmark_presets.RISCV]
-    # Disabled while lab Android devices are offline.
-    and preset
-    not in [
-        benchmark_presets.ANDROID_CPU,
-        benchmark_presets.ANDROID_CPU_DT_ONLY,
-        benchmark_presets.ANDROID_GPU,
-    ]
 ] + ["comp-stats"]
 DEFAULT_BENCHMARK_PRESET = "default"
 LARGE_BENCHMARK_PRESET_GROUP = benchmark_presets.LARGE_PRESETS


### PR DESCRIPTION
Reverts iree-org/iree#17784

The lab Android devices may be online again.