### PR TITLE
Updated `linalg_ext.online_attention` for `fp8` support

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1275,25 +1275,15 @@ LogicalResult AttentionOp::verify() {
   }
   bool isTiled = numOutputs == 3;
 
-  SmallVector<AffineMap> indexingMaps = attnOp.getIndexingMapsArray();
-
-<<<<<<< HEAD
   // Check if indexing maps can represent attention.
+  SmallVector<AffineMap> indexingMaps = attnOp.getIndexingMapsArray();
   FailureOr<AttentionOpDetail> maybeOpInfo =
       AttentionOpDetail::get(indexingMaps);
-=======
-  ShapedType queryType = getQueryType();
-  ShapedType keyType = getKeyType();
-  ShapedType outputType = getOutputType();
-  Type queryElementType = queryType.getElementType();
-  Type keyElementType = keyType.getElementType();
-  Type outputElementType = outputType.getElementType();
 
   FloatType scaleElementType = dyn_cast<FloatType>(getScale().getType());
   if (!scaleElementType) {
     return op->emitOpError("expected scale to be of floating point type");
   }
->>>>>>> 6e37905473 (Add support for mixed types)
 
   // Check shape compatibility based on indexing maps.
   SmallVector<int64_t> shape(getIterationDomainRank());
@@ -1333,6 +1323,12 @@ LogicalResult AttentionOp::verify() {
     return failure();
   }
 
+<<<<<<< HEAD
+=======
+  if (queryElementType != keyElementType) {
+    return op->emitOpError("element types of (Q)uery and (K)ey should be same");
+  }
+>>>>>>> 3f0179b1bf (git-clang-format)
   if (isTiled) {
     // Tiled/Flash attention.
     Type maxElementType = getMaxType()->getElementType();

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1277,9 +1277,23 @@ LogicalResult AttentionOp::verify() {
 
   SmallVector<AffineMap> indexingMaps = attnOp.getIndexingMapsArray();
 
+<<<<<<< HEAD
   // Check if indexing maps can represent attention.
   FailureOr<AttentionOpDetail> maybeOpInfo =
       AttentionOpDetail::get(indexingMaps);
+=======
+  ShapedType queryType = getQueryType();
+  ShapedType keyType = getKeyType();
+  ShapedType outputType = getOutputType();
+  Type queryElementType = queryType.getElementType();
+  Type keyElementType = keyType.getElementType();
+  Type outputElementType = outputType.getElementType();
+
+  FloatType scaleElementType = dyn_cast<FloatType>(getScale().getType());
+  if (!scaleElementType) {
+    return op->emitOpError("expected scale to be of floating point type");
+  }
+>>>>>>> 6e37905473 (Add support for mixed types)
 
   // Check shape compatibility based on indexing maps.
   SmallVector<int64_t> shape(getIterationDomainRank());

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1282,7 +1282,7 @@ LogicalResult AttentionOp::verify() {
 
   FloatType scaleElementType = dyn_cast<FloatType>(getScale().getType());
   if (!scaleElementType) {
-    return op->emitOpError("expected scale to be of floating point type");
+    return attnOp->emitOpError("expected scale to be of floating point type");
   }
 
   // Check shape compatibility based on indexing maps.
@@ -1323,12 +1323,6 @@ LogicalResult AttentionOp::verify() {
     return failure();
   }
 
-<<<<<<< HEAD
-=======
-  if (queryElementType != keyElementType) {
-    return op->emitOpError("element types of (Q)uery and (K)ey should be same");
-  }
->>>>>>> 3f0179b1bf (git-clang-format)
   if (isTiled) {
     // Tiled/Flash attention.
     Type maxElementType = getMaxType()->getElementType();

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/AggregatedOpInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/AggregatedOpInterfaceImpl.cpp
@@ -90,6 +90,7 @@ static Value truncateFloat(OpBuilder &builder, Location loc, AffineMap inputMap,
             APFloat::getLargest(dstTy.getFloatSemantics(), /*Negative=*/false)
                 .convertToDouble();
 
+        // Truncate to the `fp8` range so avoid nan values.
         Value mn = builder.create<arith::ConstantOp>(
             loc, builder.getFloatAttr(srcTy, mnDbl));
         Value mx = builder.create<arith::ConstantOp>(

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/AggregatedOpInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/AggregatedOpInterfaceImpl.cpp
@@ -119,7 +119,6 @@ static Value reduce(OpBuilder &builder, Location loc, AffineMap inputMap,
 
 static Value reduceAbsMax(OpBuilder &builder, Location loc, AffineMap inputMap,
                           Value input, Value intermediate) {
-  ShapedType inputTy = cast<ShapedType>(input.getType());
   FloatType fpTy = cast<FloatType>(getElementTypeOrSelf(input.getType()));
 
   AffineMap outputMap = AffineMap::get(inputMap.getNumDims(), /*symbolCount=*/0,

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_online_attention.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_online_attention.mlir
@@ -26,6 +26,9 @@ func.func @attention_f16(%query: tensor<192x1024x64xf16>,
 
 // We just want to check if we are using the correct algorithm.
 // CHECK-LABEL: @attention_f16
+// Q = Q * scale
+// CHECK: linalg.generic
+// CHECK:   arith.mulf
 // S = Q @ K
 // CHECK: linalg.generic
 // CHECK:   arith.mulf
@@ -59,6 +62,84 @@ func.func @attention_f16(%query: tensor<192x1024x64xf16>,
 // CHECK:   linalg.yield
 // newAcc = P @ V + newAcc
 // CHECK: linalg.generic
+// CHECK:   arith.mulf
+// CHECK:   arith.addf
+// CHECK:   linalg.yield
+
+// -----
+
+#mapQ = affine_map<(batch, m, k1, k2, n) -> (batch, m, k1)>
+#mapK = affine_map<(batch, m, k1, k2, n) -> (batch, k2, k1)>
+#mapV = affine_map<(batch, m, k1, k2, n) -> (batch, k2, n)>
+#mapO = affine_map<(batch, m, k1, k2, n) -> (batch, m, n)>
+#mapR = affine_map<(batch, m, k1, k2, n) -> (batch, m)>
+
+func.func @attention_f8(%query: tensor<192x1024x64xf8E4M3FNUZ>,
+                         %key: tensor<192x1024x64xf8E4M3FNUZ>,
+                         %value: tensor<192x1024x64xf8E4M3FNUZ>,
+                         %output: tensor<192x1024x64xf32>,
+                         %max: tensor<192x1024xf32>,
+                         %sum: tensor<192x1024xf32>)
+                         -> (tensor<192x1024x64xf32>, tensor<192x1024xf32>) {
+  %scale = arith.constant 1.0 : f16
+
+  %out:3 = iree_linalg_ext.online_attention
+        { indexing_maps = [#mapQ, #mapK, #mapV, #mapO, #mapR, #mapR] }
+        ins(%query, %key, %value, %scale : tensor<192x1024x64xf8E4M3FNUZ>, tensor<192x1024x64xf8E4M3FNUZ>, tensor<192x1024x64xf8E4M3FNUZ>, f16)
+        outs(%output, %max, %sum : tensor<192x1024x64xf32>, tensor<192x1024xf32>, tensor<192x1024xf32>)
+        -> tensor<192x1024x64xf32>, tensor<192x1024xf32>, tensor<192x1024xf32>
+
+  return %out#0, %out#2 : tensor<192x1024x64xf32>, tensor<192x1024xf32>
+}
+
+// CHECK-LABEL: @attention_f8
+// S = Q @ K
+// CHECK: linalg.generic
+// CHECK:   arith.extf %[[A:.+]] : f8E4M3FNUZ to f32
+// CHECK:   arith.extf %[[A:.+]] : f8E4M3FNUZ to f32
+// CHECK:   arith.mulf
+// CHECK:   arith.addf
+// CHECK:   linalg.yield
+// S = S * scale
+// CHECK:   linalg.generic
+// CHECK:   arith.mulf
+// newMax = max(oldMax, rowMax(S))
+// CHECK: linalg.generic
+// CHECK:   arith.maximumf
+// CHECK:   linalg.yield
+// P = exp2(S - newMax)
+// CHECK: linalg.generic
+// CHECK:   arith.subf
+// CHECK:   math.exp2
+// CHECK:   linalg.yield
+// norm = exp2(oldMax - newMax)
+// CHECK: linalg.generic
+// CHECK:   arith.subf
+// CHECK:   math.exp2
+// CHECK:   linalg.yield
+// normSum = norm * oldSum
+// CHECK: linalg.generic
+// CHECK:   arith.mulf
+// CHECK:   linalg.yield
+// newSum = normSum + rowMax(P)
+// CHECK: linalg.generic
+// CHECK:   arith.addf
+// CHECK:   linalg.yield
+// clamp = clamp(norm)
+// CHECK: linalg.generic
+// CHECK:   arith.cmpf ogt
+// CHECK:   arith.cmpf olt
+// CHECK:   arith.select
+// CHECK:   arith.select
+// CHECK:   arith.truncf
+// newAcc = norm * oldAcc
+// CHECK: linalg.generic
+// CHECK:   arith.mulf
+// CHECK:   linalg.yield
+// newAcc = P @ V + newAcc
+// CHECK: linalg.generic
+// CHECK:   arith.extf [[A:.+]] f8E4M3FNUZ to f32
+// CHECK:   arith.extf [[A:.+]] f8E4M3FNUZ to f32
 // CHECK:   arith.mulf
 // CHECK:   arith.addf
 // CHECK:   linalg.yield


### PR DESCRIPTION
We add additional support for `fp8` support include scaling post Q @ K, exp(QK) normalization, and iterative normalization required for `fp8`s limited range. This has been numerically evaluated on `llvm-cpu`. The `rocm` path is currently numerically incorrect.