### PR TITLE
[VMVX] Add support for arith.maxnumf and arith.minnumf lowering.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/ArithToVM/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/ArithToVM/Patterns.cpp
@@ -728,7 +728,11 @@ void populateArithToVMPatterns(MLIRContext *context,
                                    IREE::VM::SubF64Op>,
       BinaryArithmeticOpConversion<arith::MinimumFOp, IREE::VM::MinF32Op,
                                    IREE::VM::MinF64Op>,
+      BinaryArithmeticOpConversion<arith::MinNumFOp, IREE::VM::MinF32Op,
+                                   IREE::VM::MinF64Op>,
       BinaryArithmeticOpConversion<arith::MaximumFOp, IREE::VM::MaxF32Op,
+                                   IREE::VM::MaxF64Op>,
+      BinaryArithmeticOpConversion<arith::MaxNumFOp, IREE::VM::MaxF32Op,
                                    IREE::VM::MaxF64Op>>(typeConverter, context);
 
   // Floating-point conversion ops.

--- a/runtime/src/iree/vm/ops.h
+++ b/runtime/src/iree/vm/ops.h
@@ -569,10 +569,18 @@ static inline float vm_round_f32_even(float operand) {
 #endif  // C23
 }
 static inline float vm_min_f32(float lhs, float rhs) {
-  return rhs < lhs ? rhs : lhs;
+  // If `lhs` is NaN, returns `rhs`.
+  if (lhs != lhs) return rhs;
+  // If `rhs` is NaN, returns `lhs`.
+  if (rhs != rhs) return lhs;
+  return lhs < rhs ? lhs : rhs;
 }
 static inline float vm_max_f32(float lhs, float rhs) {
-  return lhs < rhs ? rhs : lhs;
+  // If `lhs` is NaN, returns `rhs`.
+  if (lhs != lhs) return rhs;
+  // If `rhs` is NaN, returns `lhs`.
+  if (rhs != rhs) return lhs;
+  return lhs > rhs ? lhs : rhs;
 }
 
 static inline float vm_atan_f32(float operand) { return atanf(operand); }
@@ -753,10 +761,18 @@ static inline double vm_round_f64_even(double operand) {
 #endif  // C23
 }
 static inline double vm_min_f64(double lhs, double rhs) {
-  return rhs < lhs ? rhs : lhs;
+  // If `lhs` is NaN, returns `rhs`.
+  if (lhs != lhs) return rhs;
+  // If `rhs` is NaN, returns `lhs`.
+  if (rhs != rhs) return lhs;
+  return lhs < rhs ? lhs : rhs;
 }
 static inline double vm_max_f64(double lhs, double rhs) {
-  return lhs < rhs ? rhs : lhs;
+  // If `lhs` is NaN, returns `rhs`.
+  if (lhs != lhs) return rhs;
+  // If `rhs` is NaN, returns `lhs`.
+  if (rhs != rhs) return lhs;
+  return lhs > rhs ? lhs : rhs;
 }
 
 static inline double vm_atan_f64(double operand) { return atan(operand); }


### PR DESCRIPTION
The revision implements MinNum/MaxNum for vm_min/max ops. Previously it handled them as minimum/maximum ops. The maxnum/minnum semantics can be found at https://llvm.org/docs/LangRef.html#llvm-minnum-intrinsic

It drops the revert of https://github.com/llvm/llvm-project/commit/fa0666876cdf11162af341911b99311a56be2274. The rest of reverted LLVM commits are:

- https://github.com/llvm/llvm-project/commit/2c06fb899966b49ff0fe4adf55fceb7d1941fbca
- https://github.com/llvm/llvm-project/commit/137a7451f458cf7d8e1d88df93dbd8da6888886d

Fixes https://github.com/iree-org/iree/issues/17779