### PR TITLE
Add workgroup chipletgroup strategy to workgroup reordering pass

### DIFF
--- a/build_tools/pkgci/external_test_suite/attention_and_matmul_spec.mlir
+++ b/build_tools/pkgci/external_test_suite/attention_and_matmul_spec.mlir
@@ -541,7 +541,7 @@ module attributes { transform.with_named_sequence } {
         {mma_schedule = #iree_gpu.mma_schedule<
            intrinsic = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>,
            subgroup_m_count = 2, subgroup_n_count = 1>
-         , workgroup_reorder = #iree_gpu.workgroup_reorder<reorder_option = "transpose", log_tile_size = 4>,
+         , workgroup_reorder = #iree_gpu.workgroup_reorder<reorder_option = "transpose">,
          llvm_func_attrs = {"amdgpu-waves-per-eu" = "1"}}>
       > -> !transform.any_param
     transform.yield %matmul, %config : !transform.any_op, !transform.any_param
@@ -560,7 +560,7 @@ module attributes { transform.with_named_sequence } {
         {mma_schedule = #iree_gpu.mma_schedule<
            intrinsic = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>,
            subgroup_m_count = 2, subgroup_n_count = 1>
-         , workgroup_reorder = #iree_gpu.workgroup_reorder<reorder_option = "transpose", log_tile_size = 4>,
+         , workgroup_reorder = #iree_gpu.workgroup_reorder<reorder_option = "transpose">,
          llvm_func_attrs = {"amdgpu-waves-per-eu" = "1"}}>
       > -> !transform.any_param
     transform.yield %matmul, %config : !transform.any_op, !transform.any_param

--- a/build_tools/pkgci/external_test_suite/attention_and_matmul_spec.mlir
+++ b/build_tools/pkgci/external_test_suite/attention_and_matmul_spec.mlir
@@ -637,7 +637,7 @@ module attributes { transform.with_named_sequence } {
           {mma_schedule = #iree_gpu.mma_schedule<
               intrinsic = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>,
               subgroup_m_count = 1, subgroup_n_count = 5>
-           , reorder_workgroups = "transpose"}>
+           ,  workgroup_reorder = #iree_gpu.workgroup_reorder<reorder_option = "transpose">}>
       > -> !transform.any_param
     transform.yield %conv, %config : !transform.any_op, !transform.any_param
   }
@@ -657,7 +657,7 @@ module attributes { transform.with_named_sequence } {
           {mma_schedule = #iree_gpu.mma_schedule<
               intrinsic = #iree_gpu.mma_layout<MFMA_F16_32x32x8_F32>,
               subgroup_m_count = 1, subgroup_n_count = 4>
-           , reorder_workgroups = "transpose", llvm_func_attrs = {"amdgpu-waves-per-eu" = "1"}}>
+           ,  workgroup_reorder = #iree_gpu.workgroup_reorder<reorder_option = "transpose">}>
       > -> !transform.any_param
     transform.yield %conv, %config : !transform.any_op, !transform.any_param
   }
@@ -677,7 +677,7 @@ module attributes { transform.with_named_sequence } {
           {mma_schedule = #iree_gpu.mma_schedule<
               intrinsic = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>,
               subgroup_m_count = 1, subgroup_n_count = 5>
-           , reorder_workgroups = "transpose"}>
+           ,  workgroup_reorder = #iree_gpu.workgroup_reorder<reorder_option = "transpose">}>
       > -> !transform.any_param
     transform.yield %conv, %config : !transform.any_op, !transform.any_param
   }
@@ -697,7 +697,7 @@ module attributes { transform.with_named_sequence } {
           {mma_schedule = #iree_gpu.mma_schedule<
               intrinsic = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>,
               subgroup_m_count = 1, subgroup_n_count = 5>
-           , reorder_workgroups = "transpose"}>
+           ,  workgroup_reorder = #iree_gpu.workgroup_reorder<reorder_option = "transpose">}>
       > -> !transform.any_param
     transform.yield %conv, %config : !transform.any_op, !transform.any_param
   }
@@ -717,7 +717,7 @@ module attributes { transform.with_named_sequence } {
           {mma_schedule = #iree_gpu.mma_schedule<
               intrinsic = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>,
               subgroup_m_count = 4, subgroup_n_count = 2>
-           , reorder_workgroups = "transpose", llvm_func_attrs = {"amdgpu-waves-per-eu" = "1"}}>
+           ,  workgroup_reorder = #iree_gpu.workgroup_reorder<reorder_option = "transpose">}>
       > -> !transform.any_param
     transform.yield %conv, %config : !transform.any_op, !transform.any_param
   }
@@ -737,7 +737,7 @@ module attributes { transform.with_named_sequence } {
           {mma_schedule = #iree_gpu.mma_schedule<
               intrinsic = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>,
               subgroup_m_count = 1, subgroup_n_count = 5>
-           , reorder_workgroups = "transpose"}>
+           ,  workgroup_reorder = #iree_gpu.workgroup_reorder<reorder_option = "transpose">}>
       > -> !transform.any_param
     transform.yield %conv, %config : !transform.any_op, !transform.any_param
   }

--- a/build_tools/pkgci/external_test_suite/attention_and_matmul_spec.mlir
+++ b/build_tools/pkgci/external_test_suite/attention_and_matmul_spec.mlir
@@ -541,7 +541,8 @@ module attributes { transform.with_named_sequence } {
         {mma_schedule = #iree_gpu.mma_schedule<
            intrinsic = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>,
            subgroup_m_count = 2, subgroup_n_count = 1>
-         , llvm_func_attrs = {"amdgpu-waves-per-eu" = "1"}}>
+         , workgroup_reorder = #iree_gpu.workgroup_reorder<reorder_option = "transpose", log_tile_size = 4>,
+         llvm_func_attrs = {"amdgpu-waves-per-eu" = "1"}}>
       > -> !transform.any_param
     transform.yield %matmul, %config : !transform.any_op, !transform.any_param
   }
@@ -559,7 +560,8 @@ module attributes { transform.with_named_sequence } {
         {mma_schedule = #iree_gpu.mma_schedule<
            intrinsic = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>,
            subgroup_m_count = 2, subgroup_n_count = 1>
-         , llvm_func_attrs = {"amdgpu-waves-per-eu" = "1"}}>
+         , workgroup_reorder = #iree_gpu.workgroup_reorder<reorder_option = "transpose", log_tile_size = 4>,
+         llvm_func_attrs = {"amdgpu-waves-per-eu" = "1"}}>
       > -> !transform.any_param
     transform.yield %matmul, %config : !transform.any_op, !transform.any_param
   }

--- a/compiler/plugins/target/ROCM/test/target_device_features.mlir
+++ b/compiler/plugins/target/ROCM/test/target_device_features.mlir
@@ -9,7 +9,7 @@
 // GFX942-SAME:         mma = [<MFMA_F16_16x16x16_F32>, <MFMA_F16_32x32x8_F32>],
 // GFX942-SAME:         subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024],
 // GFX942-SAME:         max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536>,
-// GFX942-SAME: chip = <wgp_count = 304>>
+// GFX942-SAME: chip = <wgp_count = 304, chiplet_count = 8>>
 
 // GFX940: target = #iree_gpu.target<arch = "gfx940",
 // GFX940-SAME:         mma = [<MFMA_F16_16x16x16_F32>, <MFMA_F16_32x32x8_F32>]

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
@@ -109,7 +109,7 @@ createConvertVectorReductionToGPUPass(
     bool expandSubgroupReduction = true,
     std::function<int(mlir::FunctionOpInterface)> getWarpSize = nullptr);
 
-enum class ReorderWorkgroupsStrategy { None, Swizzle, Transpose };
+enum class ReorderWorkgroupsStrategy { None, ChipletGroup, Swizzle, Transpose };
 
 /// Reorders workgroup IDs.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -202,7 +202,8 @@ def ReorderWorkgroupsPass :
            "Workgroup reordering strategy, one of: '' (none),  'transpose', 'swizzle', 'chipletgroup'">,
     Option<"logTile", "logTile", "unsigned",
             /*default=*/"0",
-           "The log2 of the tile size used for swizzling. (0: disabled, non-0: swizzling enabled)">,
+           "The log2 of the tile size used for swizzling and chipletgroup. "
+           "(0: disabled, non-0: swizzling/chipletgroup enabled)">,
   ];
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -199,7 +199,7 @@ def ReorderWorkgroupsPass :
   let dependentDialects = ["::mlir::affine::AffineDialect"];
   let options = [
     Option<"strategy", "strategy", "std::string", /*default=*/"",
-           "Workgroup reordering strategy, one of: '' (none),  'transpose', 'swizzle'">,
+           "Workgroup reordering strategy, one of: '' (none),  'transpose', 'swizzle', 'chipletgroup'">,
     Option<"logTile", "logTile", "unsigned",
             /*default=*/"0",
            "The log2 of the tile size used for swizzling. (0: disabled, non-0: swizzling enabled)">,

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -200,11 +200,11 @@ def ReorderWorkgroupsPass :
   let options = [
     Option<"strategy", "strategy", "std::string", /*default=*/"",
            "Workgroup reordering strategy, one of: '' (none),  'transpose', 'swizzle', 'chipletgroup'">,
-    Option<"logSwTile", "logSwTile", "unsigned",
+    Option<"logSwizzleTile", "logSwizzleTile", "unsigned",
             /*default=*/"0",
            "The log2 of the tile size used for swizzling. "
            "(0: swizzling disabled, non-0: swizzling enabled)">,
-    Option<"logCgTile", "logCgTile", "unsigned",
+    Option<"logChipletgroupTile", "logChipletgroupTile", "unsigned",
             /*default=*/"0",
            "The log2 of the tile size used for chipletgroup. "
            "(0: chipletgroup disabled, non-0: chipletgroup enabled)">,

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -200,10 +200,14 @@ def ReorderWorkgroupsPass :
   let options = [
     Option<"strategy", "strategy", "std::string", /*default=*/"",
            "Workgroup reordering strategy, one of: '' (none),  'transpose', 'swizzle', 'chipletgroup'">,
-    Option<"logTile", "logTile", "unsigned",
+    Option<"logSwTile", "logSwTile", "unsigned",
             /*default=*/"0",
-           "The log2 of the tile size used for swizzling and chipletgroup. "
-           "(0: disabled, non-0: swizzling/chipletgroup enabled)">,
+           "The log2 of the tile size used for swizzling. "
+           "(0: swizzling disabled, non-0: swizzling enabled)">,
+    Option<"logCgTile", "logCgTile", "unsigned",
+            /*default=*/"0",
+           "The log2 of the tile size used for chipletgroup. "
+           "(0: chipletgroup disabled, non-0: chipletgroup enabled)">,
   ];
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/WorkgroupReordering.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/WorkgroupReordering.cpp
@@ -283,6 +283,8 @@ static LogicalResult reorderWorkgroupsInFunc(FunctionOpInterface funcOp,
         makeSwizzledIds(funcOp.getLoc(), builder, workgroupIdX, workgroupIdY,
                         workgroupCntX, workgroupCntY, reorderWgTileSize);
   } else if (strategy == ReorderWorkgroupsStrategy::ChipletGroup) {
+    if (numXCDs <= 1)
+      return failure();
     std::tie(newWorkgroupIdX, newWorkgroupIdY) = makeChipletGroupedIds(
         funcOp.getLoc(), builder, workgroupIdX, workgroupIdY, workgroupCntX,
         workgroupCntY, reorderWgTileSize, numXCDs);

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/WorkgroupReordering.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/WorkgroupReordering.cpp
@@ -135,7 +135,7 @@ makeChipletGroupedIds(Location loc, OpBuilder b, Value workgroupIdX,
                       Value workgroupIdY, Value workgroupCountX,
                       Value workgroupCountY, unsigned chipletGroupTile,
                       unsigned numXCDs) {
-  // Create one dimension ID for workgroup
+  // Create one dimension ID for workgroup.
   Value linearized =
       b.create<arith::MulIOp>(loc, workgroupIdY, workgroupCountX);
   linearized = b.create<arith::AddIOp>(loc, linearized, workgroupIdX);
@@ -152,12 +152,14 @@ makeChipletGroupedIds(Location loc, OpBuilder b, Value workgroupIdX,
   // Detailed explaination about the idea behind the below implementation:
   // the L2 Cache Optimizations subsection in
   // https://triton-lang.org/main/getting-started/tutorials/03-matrix-multiplication.html#
-  // Emphircally, found rowGroupSize=16 for mi300x achieves good performance
   unsigned rowGroupSize = chipletGroupTile;
   Value rowGroupSizeVal =
       b.createOrFold<arith::ConstantIndexOp>(loc, rowGroupSize);
-  // group every 16 workgroups along Y dimension
-  // Number of workgroups in the group
+
+  // Emphircally, found rowGroupSize=16 for mi300x achieves good performance
+  // group every 16 workgroups along Y dimension.
+
+  // Number of workgroups in the group.
   Value numWorkGroupsPerRowBlock =
       b.create<arith::MulIOp>(loc, rowGroupSizeVal, workgroupCountX);
 
@@ -327,10 +329,10 @@ struct ReorderWorkgroupsPass final
     reorderingStrategy = *selectedStrategy;
     if (reorderingStrategy == ReorderWorkgroupsStrategy::Swizzle &&
         reorderWgLogTileSize == 0)
-      reorderWgLogTileSize = logSwTile;
+      reorderWgLogTileSize = logSwizzleTile;
     else if (reorderingStrategy == ReorderWorkgroupsStrategy::ChipletGroup &&
              reorderWgLogTileSize == 0)
-      reorderWgLogTileSize = logCgTile;
+      reorderWgLogTileSize = logChipletgroupTile;
 
     return success();
   }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/WorkgroupReordering.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/WorkgroupReordering.cpp
@@ -144,7 +144,7 @@ makeChipletGroupedIds(Location loc, OpBuilder b, Value workgroupIdX,
   // Map chiplets to perform a spatially local tile operation.
   // Reorder the linearized ID such that every consecutive group of chiplets
   // is the slowest-changing dimension in the grid.
-  // Emphirically found that two chiplets as a group has better locality
+  // Empirically found that two chiplets as a group has better locality
   // throughout.
   linearized = chipletAwareWorkgroupReordering(
       loc, b, linearized, workgroupCountX, workgroupCountY, numXCDs / 2);
@@ -156,7 +156,7 @@ makeChipletGroupedIds(Location loc, OpBuilder b, Value workgroupIdX,
   Value rowGroupSizeVal =
       b.createOrFold<arith::ConstantIndexOp>(loc, rowGroupSize);
 
-  // Emphirically, found rowGroupSize=16 for MI300X achieves good performance
+  // Empirically, found rowGroupSize=16 for MI300X achieves good performance
   // group every 16 workgroups along Y dimension.
 
   // Number of workgroups in the group.

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_reorder_workgroups.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_reorder_workgroups.mlir
@@ -6,8 +6,12 @@
 
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-reorder-workgroups{strategy=chipletgroup logCgTile=3}))" \
 // RUN:   --split-input-file %s | FileCheck --check-prefix=CHIPLETGROUP %s
-
-func.func @matmul() {
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb",
+{iree.gpu.target = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8,
+storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, mma = [<MFMA_F16_16x16x16_F32>, <MFMA_F16_32x32x8_F32>],
+subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536>,
+chip = <wgp_count = 304, chiplet_count = 8>>, ukernels = "none"}>
+func.func @matmul() attributes {hal.executable.target = #executable_target_rocm_hsaco_fb} {
   %c0 = arith.constant 0 : index
   %c128 = arith.constant 128 : index
   %c96 = arith.constant 96 : index

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_reorder_workgroups.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_reorder_workgroups.mlir
@@ -1,10 +1,10 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-reorder-workgroups{strategy=swizzle logSwTile=3}))" \
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-reorder-workgroups{strategy=swizzle logSwizzleTile=3}))" \
 // RUN:   --split-input-file %s | FileCheck --check-prefix=SWIZZLE %s
 
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-reorder-workgroups{strategy=transpose}))" \
 // RUN:   --split-input-file %s | FileCheck --check-prefix=TRANSPOSE %s
 
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-reorder-workgroups{strategy=chipletgroup logCgTile=3}))" \
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-reorder-workgroups{strategy=chipletgroup logChipletgroupTile=3}))" \
 // RUN:   --split-input-file %s | FileCheck --check-prefix=CHIPLETGROUP %s
 #executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb",
 {iree.gpu.target = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8,

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_reorder_workgroups.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_reorder_workgroups.mlir
@@ -1,10 +1,10 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-reorder-workgroups{strategy=swizzle logTile=3}))" \
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-reorder-workgroups{strategy=swizzle logSwTile=3}))" \
 // RUN:   --split-input-file %s | FileCheck --check-prefix=SWIZZLE %s
 
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-reorder-workgroups{strategy=transpose}))" \
 // RUN:   --split-input-file %s | FileCheck --check-prefix=TRANSPOSE %s
 
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-reorder-workgroups{strategy=chipletgroup logTile=3}))" \
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-reorder-workgroups{strategy=chipletgroup logCgTile=3}))" \
 // RUN:   --split-input-file %s | FileCheck --check-prefix=CHIPLETGROUP %s
 
 func.func @matmul() {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_reorder_workgroups_static.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_reorder_workgroups_static.mlir
@@ -1,10 +1,10 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-codegen-reorder-workgroups{strategy=swizzle logTile=3})))))" \
+// RUN: iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-codegen-reorder-workgroups{strategy=swizzle logSwTile=3})))))" \
 // RUN:   %s | FileCheck --check-prefix=SWIZZLE %s
 
 // RUN: iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-codegen-reorder-workgroups{strategy=transpose})))))" \
 // RUN:   %s | FileCheck --check-prefix=TRANSPOSE %s
 
-// RUN: iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-codegen-reorder-workgroups{strategy=chipletgroup logTile=3})))))" \
+// RUN: iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-codegen-reorder-workgroups{strategy=chipletgroup logCgTile=3})))))" \
 // RUN:   %s | FileCheck --check-prefix=CHIPLETGROUP %s
 
 // Make sure we use static workgroup counts instead of introducting

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_reorder_workgroups_static.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_reorder_workgroups_static.mlir
@@ -4,6 +4,9 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-codegen-reorder-workgroups{strategy=transpose})))))" \
 // RUN:   %s | FileCheck --check-prefix=TRANSPOSE %s
 
+// RUN: iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-codegen-reorder-workgroups{strategy=chipletgroup logTile=3})))))" \
+// RUN:   %s | FileCheck --check-prefix=CHIPLETGROUP %s
+
 // Make sure we use static workgroup counts instead of introducting
 // `hal.interface.workgroup.count` ops. These are currently not supported on ROCm.
 
@@ -17,6 +20,25 @@
 // SWIZZLE-DAG:               affine.apply #{{.+}}()[%[[SEL_X]]]
 // SWIZZLE-DAG:               affine.apply #{{.+}}()[%[[SEL_Y]]]
 // SWIZZLE:                   return
+
+// CHIPLETGROUP-LABEL: hal.executable private @main_dispatch_0 {
+// CHIPLETGROUP-LABEL: func.func @main_dispatch_0_matmul_transpose_b_32000x32000x4096_f16
+// CHIPLETGROUP-DAG:               %[[WG_X:.+]] = hal.interface.workgroup.id[0] : index
+// CHIPLETGROUP-DAG:               %[[WG_Y:.+]] = hal.interface.workgroup.id[1] : index
+// CHIPLETGROUP-NOT:               hal.interface.workgroup.count
+// CHIPLETGROUP-DAG:               %[[C250:.+]] = arith.constant 250 : index
+// CHIPLETGROUP-DAG:               %[[C500:.+]] = arith.constant 500 : index
+// CHIPLETGROUP:                   %[[MUL:.+]] = arith.muli %[[WG_Y]], %[[C250]] : index
+// CHIPLETGROUP:                   %[[ADD:.+]] = arith.addi %[[MUL]], %[[WG_X]] : index
+// CHIPLETGROUP:                   %[[CMP:.+]] = arith.cmpi ugt, %[[ADD]], %{{.+}} : index
+// CHIPLETGROUP:                   %[[SELECT:.+]] = arith.select %[[CMP]], %[[ADD]], %{{.+}} : index
+// CHIPLETGROUP:                   %[[REM:.+]] = arith.remui %[[SELECT]], %{{.+}} : index
+// CHIPLETGROUP:                   %[[ADDI:.+]] = arith.addi %{{.+}}, %[[REM]] : index
+// CHIPLETGROUP:                   %[[REMI:.+]] = arith.remui %[[SELECT]], %{{.+}} : index
+// CHIPLETGROUP:                   %[[DIV:.+]] = arith.divui %[[REMI]], %{{.+}} : index
+// CHIPLETGROUP-DAG:               affine.apply #{{.+}}()[%[[ADDI]]]
+// CHIPLETGROUP-DAG:               affine.apply #{{.+}}()[%[[DIV]]]
+// CHIPLETGROUP:                   return
 
 // TRANSPOSE-LABEL: hal.executable private @main_dispatch_0 {
 // TRANSPOSE-LABEL: func.func @main_dispatch_0_matmul_transpose_b_32000x32000x4096_f16

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_reorder_workgroups_static.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_reorder_workgroups_static.mlir
@@ -55,8 +55,13 @@
 // TRANSPOSE-DAG:               affine.apply #{{.+}}()[%[[REM]]]
 // TRANSPOSE:                   return
 
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb",
+{iree.gpu.target = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8,
+storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, mma = [<MFMA_F16_16x16x16_F32>, <MFMA_F16_32x32x8_F32>],
+subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536>,
+chip = <wgp_count = 304, chiplet_count = 8>>, ukernels = "none"}>
 hal.executable private @main_dispatch_0 {
-hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
   hal.executable.export public @main_dispatch_0_matmul_transpose_b_32000x32000x4096_f16 ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer>]>]>) attributes {hal.interface.bindings = [#hal.interface.binding<0, 0>, #hal.interface.binding<0, 1>], subgroup_size = 64 : index, translation_info = #iree_codegen.translation_info<LLVMGPUMatmulSimt, {pipeline_depth = 0 : i64, store_stage = 1 : i64}>, workgroup_size = [64 : index, 16 : index, 1 : index]} {
   ^bb0(%arg0: !hal.device):
     %c250 = arith.constant 250 : index

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_reorder_workgroups_static.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_reorder_workgroups_static.mlir
@@ -1,10 +1,10 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-codegen-reorder-workgroups{strategy=swizzle logSwTile=3})))))" \
+// RUN: iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-codegen-reorder-workgroups{strategy=swizzle logSwizzleTile=3})))))" \
 // RUN:   %s | FileCheck --check-prefix=SWIZZLE %s
 
 // RUN: iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-codegen-reorder-workgroups{strategy=transpose})))))" \
 // RUN:   %s | FileCheck --check-prefix=TRANSPOSE %s
 
-// RUN: iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-codegen-reorder-workgroups{strategy=chipletgroup logCgTile=3})))))" \
+// RUN: iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-codegen-reorder-workgroups{strategy=chipletgroup logChipletgroupTile=3})))))" \
 // RUN:   %s | FileCheck --check-prefix=CHIPLETGROUP %s
 
 // Make sure we use static workgroup counts instead of introducting

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -270,6 +270,27 @@ def IREEGPU_MmaScheduleAttr : AttrDef<IREEGPU_Dialect, "MMASchedule"> {
 }
 
 //===----------------------------------------------------------------------===//
+// Workgroup Reordering Attr
+
+def IREEGPU_WorkGroupReorderAttr: AttrDef<IREEGPU_Dialect, "WorkgroupReorderOptions">{
+  let mnemonic = "reorder_workgroups";
+  let cppNamespace = "::mlir::iree_compiler::IREE::GPU";
+
+  string description = [{
+    options for workgroup reordering strategies to improve L2 cache hit rate
+    and thus provide performance improvement.
+  }];
+
+  let parameters = (ins
+    "::mlir::iree_compiler::IREE::GPU::ReorderWorkgroupEnum":$reorder_option,
+    OptionalParameter<"std::optional<int64_t>", "the tile size to use">:$tileSize
+  );
+
+  let assemblyFormat = "`<` struct(params) `>`";
+}
+
+
+//===----------------------------------------------------------------------===//
 // Workgroup processor level description
 
 def IREEGPU_TargetWgpAttr : AttrDef<IREEGPU_Dialect, "TargetWgp"> {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -282,7 +282,7 @@ def IREEGPU_WorkGroupReorderAttr: AttrDef<IREEGPU_Dialect, "WorkgroupReorderOpti
 
   let parameters = (ins
     OptionalParameter<"::mlir::iree_compiler::IREE::GPU::ReorderWorkgroupEnum">:$reorder_option,
-    OptionalParameter<"std::optional<int64_t>", "the tile size to use">:$tileSize
+    OptionalParameter<"std::optional<int64_t>", "the tile size to use in log2">:$log_tile_size
   );
 
   let assemblyFormat = "`<` struct(params) `>`";

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -282,7 +282,7 @@ def IREEGPU_WorkGroupReorderAttr: AttrDef<IREEGPU_Dialect, "WorkgroupReorderOpti
   }];
 
   let parameters = (ins
-    "::mlir::iree_compiler::IREE::GPU::ReorderWorkgroupEnum":$reorder_option,
+    OptionalParameter<"::mlir::iree_compiler::IREE::GPU::ReorderWorkgroupEnum">:$reorder_option,
     OptionalParameter<"std::optional<int64_t>", "the tile size to use">:$tileSize
   );
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -356,7 +356,7 @@ def IREEGPU_TargetChipAttr : AttrDef<IREEGPU_Dialect, "TargetChip"> {
 
   let parameters = (ins
     "uint32_t":$wgp_count,
-
+    "uint32_t":$chiplet_count,
     // An optional extra dict
     // This field allows to inject more features/limits not supported in the
     // above list for better flexibility.

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -277,7 +277,7 @@ def IREEGPU_WorkGroupReorderAttr: AttrDef<IREEGPU_Dialect, "WorkgroupReorderOpti
   let cppNamespace = "::mlir::iree_compiler::IREE::GPU";
 
   string description = [{
-    options for workgroup reordering strategies to improve L2 cache hit rate
+    Options for workgroup reordering strategies to improve L2 cache hit rate
     and thus provide performance improvement.
   }];
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -277,8 +277,7 @@ def IREEGPU_WorkGroupReorderAttr: AttrDef<IREEGPU_Dialect, "WorkgroupReorderOpti
   let cppNamespace = "::mlir::iree_compiler::IREE::GPU";
 
   string description = [{
-    Options for workgroup reordering strategies to improve L2 cache hit rate
-    and thus provide performance improvement.
+    Options for workgroup reordering strategies to improve L2 cache hit rate.
   }];
 
   let parameters = (ins

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -272,8 +272,8 @@ def IREEGPU_MmaScheduleAttr : AttrDef<IREEGPU_Dialect, "MMASchedule"> {
 //===----------------------------------------------------------------------===//
 // Workgroup Reordering Attr
 
-def IREEGPU_WorkGroupReorderAttr: AttrDef<IREEGPU_Dialect, "WorkgroupReorderOptions">{
-  let mnemonic = "reorder_workgroups";
+def IREEGPU_WorkgroupReorderAttr: AttrDef<IREEGPU_Dialect, "WorkgroupReorderOptions">{
+  let mnemonic = "workgroup_reorder";
   let cppNamespace = "::mlir::iree_compiler::IREE::GPU";
 
   string description = [{

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td
@@ -148,4 +148,20 @@ def IREEGPU_TilingLevel : IREEGPU_I32MmaEnumAttr<"TilingLevel",
       Lane
     ]>;
 
+//===----------------------------------------------------------------------===//
+// Workgroup reordering strategies
+
+def None : I32EnumAttrCase<"none", 0>;
+def Transpose :I32EnumAttrCase<"transpose", 1>;
+def Swizzle : I32EnumAttrCase<"swizzle", 2>;
+def Chipletgroup : I32EnumAttrCase<"chipletgroup", 3>;
+
+def IREEGPU_ReorderWorkgroupEnum : IREEGPU_I32MmaEnumAttr<"ReorderWorkgroupEnum",
+    "Descriptor for strategies of reordering workgroups on GPUs", [
+      None,
+      Transpose,
+      Swizzle,
+      Chipletgroup
+    ]>;
+
 #endif // IREE_COMPILER_CODEGEN_DIALECT_GPU_IREEGPUENUMS

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/target_attrs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/target_attrs.mlir
@@ -44,9 +44,10 @@ func.func @test_target_wgp_none() attributes {
 // CHECK-LABEL: func.func @test_target_chip()
 func.func @test_target_chip() attributes {
   // CHECK: #iree_gpu.target_chip<
-  // CHECK-SAME: wgp_count = 304>
+  // CHECK-SAME: wgp_count = 304, chiplet_count = 8>
   chip = #iree_gpu.target_chip<
-    wgp_count = 304
+    wgp_count = 304,
+    chiplet_count = 8
   >
 } { return }
 
@@ -68,6 +69,6 @@ func.func @test_target() attributes {
       max_workgroup_sizes = [1024, 1024, 1024],
       max_thread_count_per_workgroup = 1024,
       max_workgroup_memory_bytes = 65536>,
-    chip = <wgp_count = 304>
+    chip = <wgp_count = 304, chiplet_count = 8>
   >
 } { return }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
@@ -50,6 +50,7 @@ struct WgpDetails {
 // Chip level feature/limit details
 struct ChipDetails {
   uint32_t wgpCount;
+  uint32_t chipletCount;
 };
 
 // Full target details
@@ -111,7 +112,8 @@ TargetAttr createTargetAttr(const TargetDetails &details, StringRef arch,
   TargetChipAttr targetChip;
   if (details.chip)
     targetChip =
-        TargetChipAttr::get(context, details.chip->wgpCount, DictionaryAttr{});
+        TargetChipAttr::get(context, details.chip->wgpCount,
+                            details.chip->chipletCount, DictionaryAttr{});
 
   return TargetAttr::get(context, arch, features, targetWgp, targetChip);
 }
@@ -198,32 +200,31 @@ std::optional<TargetDetails> getAMDGPUTargetDetails(StringRef target) {
 
   // "AMD Instinct MI300 Series Product Offerings" in Page 23 of
   // https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/white-papers/amd-cdna-3-white-paper.pdf
-  static const ChipDetails mi300xChip = {304};
-  static const ChipDetails mi300aChip = {228};
+  static const ChipDetails mi300xChip = {304, 8};
+  static const ChipDetails mi300aChip = {228, 6};
 
   // "AMD Instinct MI200 Series Accelerator Product Offerings" in Page 14 of
   // https://www.amd.com/content/dam/amd/en/documents/instinct-business-docs/white-papers/amd-cdna2-white-paper.pdf
-  static const ChipDetails mi250xChip = {220};
-  static const ChipDetails mi250Chip = {208};
-  static const ChipDetails mi210Chip = {104};
+  static const ChipDetails mi250xChip = {220, 2};
+  static const ChipDetails mi250Chip = {208, 2};
+  static const ChipDetails mi210Chip = {104, 1};
 
   // "AMD CDNA Architecture Compute Units" in Page 5 of
   // https://www.amd.com/content/dam/amd/en/documents/instinct-business-docs/white-papers/amd-cdna-white-paper.pdf
-  static const ChipDetails mi100Chip = {120};
+  static const ChipDetails mi100Chip = {120, 1};
 
-  static const ChipDetails rx7900xtxChip = {96};
-  static const ChipDetails rx7900xtChip = {84};
-  static const ChipDetails rx7800xtChip = {60};
-  static const ChipDetails rx7700xtChip = {54};
+  static const ChipDetails rx7900xtxChip = {96, 1};
+  static const ChipDetails rx7900xtChip = {84, 1};
+  static const ChipDetails rx7800xtChip = {60, 1};
+  static const ChipDetails rx7700xtChip = {54, 1};
 
   // See https://llvm.org/docs/AMDGPUUsage.html#processors for gfxN to
   // cdnaN/rdnaN mapping.
 
   return llvm::StringSwitch<std::optional<TargetDetails>>(target.lower())
-      .Case("mi300x", TargetDetails{cdna3Wgp, &mi300xChip})
+      .Cases("mi300x", "gfx942", TargetDetails{cdna3Wgp, &mi300xChip})
       .Case("mi300a", TargetDetails{cdna3Wgp, &mi300aChip})
-      .Cases("cdna3", "gfx940", "gfx941", "gfx942",
-             TargetDetails{cdna3Wgp, nullptr})
+      .Cases("cdna3", "gfx940", "gfx941", TargetDetails{cdna3Wgp, nullptr})
       .Case("mi250x", TargetDetails{cdna2Wgp, &mi250xChip})
       .Case("mi250", TargetDetails{cdna2Wgp, &mi250Chip})
       .Case("mi210", TargetDetails{cdna2Wgp, &mi210Chip})

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
@@ -92,8 +92,7 @@ getPipelineOptions(FunctionOpInterface funcOp,
       // Get the workgroups reorder config and enable the workgroup reordering.
       Attribute reorderWorkgroupOption =
           config.get(LLVMGPUAttrNames::kReorderWorkgroups);
-      if (llvm::isa<IREE::GPU::WorkgroupReorderOptionsAttr>(
-              reorderWorkgroupOption)) {
+      if (isa<IREE::GPU::WorkgroupReorderOptionsAttr>(reorderWorkgroupOption)) {
         IREE::GPU::WorkgroupReorderOptionsAttr ReorderOption =
             llvm::dyn_cast<IREE::GPU::WorkgroupReorderOptionsAttr>(
                 reorderWorkgroupOption);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
@@ -100,6 +100,9 @@ getPipelineOptions(FunctionOpInterface funcOp,
         pipelineOptions.reorderStrategy = ReorderWorkgroupsStrategy::Transpose;
       } else if (reorderStr == "swizzle") {
         pipelineOptions.reorderStrategy = ReorderWorkgroupsStrategy::Swizzle;
+      } else if (reorderStr == "chipletgroup") {
+        pipelineOptions.reorderStrategy =
+            ReorderWorkgroupsStrategy::ChipletGroup;
       } else {
         if (reorderStr != "none")
           funcOp.emitOpError()

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
@@ -96,7 +96,7 @@ getPipelineOptions(FunctionOpInterface funcOp,
         IREE::GPU::WorkgroupReorderOptionsAttr ReorderOption =
             llvm::dyn_cast<IREE::GPU::WorkgroupReorderOptionsAttr>(
                 reorderWorkgroupOption);
-        pipelineOptions.reorderWgLogTileSize = ReorderOption.getTileSize();
+        pipelineOptions.reorderWgLogTileSize = ReorderOption.getLogTileSize();
         switch (ReorderOption.getReorderOption()) {
         case IREE::GPU::ReorderWorkgroupEnum::none:
           pipelineOptions.reorderStrategy = ReorderWorkgroupsStrategy::None;

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -101,8 +101,7 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
   return os << "{" << "enableReduceSharedMemoryBankConflicts = "
             << options.enableReduceSharedMemoryBankConflicts
             << ", reorderWorkgroupsStrategy = " << reorderStr
-            << ", reorderWorkgroupsTileSize (log2) = "
-            << options.reorderWgLogTileSize
+            << ", reorderWorkgroupsTileSize = " << options.reorderWgLogTileSize
             << ", enableUkernels = " << options.enableUkernels << "}";
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -57,6 +57,8 @@ static llvm::cl::opt<ReorderWorkgroupsStrategy> clReorderWorkgroupsStrategy(
                                 "No workgroup reordering"),
                      clEnumValN(ReorderWorkgroupsStrategy::Swizzle, "swizzle",
                                 "Swizzle"),
+                     clEnumValN(ReorderWorkgroupsStrategy::ChipletGroup,
+                                "chipletgroup", "ChipletGroup"),
                      clEnumValN(ReorderWorkgroupsStrategy::Transpose,
                                 "transpose", "Transpose")),
     llvm::cl::init(ReorderWorkgroupsStrategy::None));
@@ -85,6 +87,9 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
       reorderStr = "transpose";
     } else if (options.reorderStrategy == ReorderWorkgroupsStrategy::Swizzle) {
       reorderStr = "swizzle";
+    } else if (options.reorderStrategy ==
+               ReorderWorkgroupsStrategy::ChipletGroup) {
+      reorderStr = "chilpletgroup";
     } else {
       assert(options.reorderStrategy == ReorderWorkgroupsStrategy::None &&
              "Unhandled reorder option");
@@ -92,7 +97,8 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
     }
   }
 
-  return os << "{" << "enableReduceSharedMemoryBankConflicts = "
+  return os << "{"
+            << "enableReduceSharedMemoryBankConflicts = "
             << options.enableReduceSharedMemoryBankConflicts
             << ", reorderWorkgroupsStrategy = " << reorderStr
             << ", enableUkernels = " << options.enableUkernels << "}";

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -219,9 +219,10 @@ static ReorderWorkgroupsStrategy getReorderWorkgroupsStrategy(
 
 // Reconciles log2 of the workgroup reordering tile size based on the pipeline
 // `option` and the CLI flag.
-static unsigned
-getReorderWorkgroupsLogTileSize(const std::optional<int64_t> &option) {
-  return (unsigned)option.value_or(clReorderWorkgroupsLogTile);
+static unsigned getReorderWorkgroupsLogTileSize(std::optional<int64_t> option) {
+  int64_t logTile = option.value_or(clReorderWorkgroupsLogTile);
+  assert(logTile >= 0);
+  return static_cast<unsigned>(logTile);
 }
 //===----------------------------------------------------------------------===//
 // Common Pass Recipes

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -98,14 +98,11 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
     }
   }
 
-  StringRef tilesizeStr = "<not set>";
-  if (options.reorderWgLogTileSize)
-    tilesizeStr = StringRef(
-        std::to_string((unsigned long)options.reorderWgLogTileSize.value()));
   return os << "{" << "enableReduceSharedMemoryBankConflicts = "
             << options.enableReduceSharedMemoryBankConflicts
             << ", reorderWorkgroupsStrategy = " << reorderStr
-            << ", reorderWorkgroupsTileSize (log2) = " << tilesizeStr
+            << ", reorderWorkgroupsTileSize (log2) = "
+            << options.reorderWgLogTileSize
             << ", enableUkernels = " << options.enableUkernels << "}";
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
@@ -35,6 +35,7 @@ struct LLVMGPUPipelineOptions {
   bool enableReduceSharedMemoryBankConflicts = true;
   bool enableUkernels = false;
   std::optional<ReorderWorkgroupsStrategy> reorderStrategy;
+  std::optional<int64_t> reorderWgLogTileSize;
 };
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
@@ -26,7 +26,7 @@ namespace mlir::iree_compiler {
 /// attribute. These are used to override default pass heuristics at the
 /// function granularity.
 namespace LLVMGPUAttrNames {
-inline constexpr StringLiteral kReorderWorkgroups = "reorder_workgroups";
+inline constexpr StringLiteral kReorderWorkgroups = "workgroup_reorder";
 inline constexpr StringLiteral kNoReduceSharedMemoryBankConflicts =
     "no_reduce_shared_memory_bank_conflicts";
 } //  namespace LLVMGPUAttrNames

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_user_vector_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_user_vector_distribute.mlir
@@ -2,7 +2,7 @@
 // RUN:   --iree-codegen-reorder-workgroups-strategy=transpose \
 // RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-llvmgpu-select-lowering-strategy, func.func(iree-llvmgpu-lower-executable-target)))))" %s | FileCheck %s --check-prefix=OPT-OUT
 
-// Check that applying `reorder_workgroups` enables or disables workgroup reordering.
+// Check that applying `workgroup_reorder` enables or disables workgroup reordering.
 
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 --iree-codegen-llvmgpu-use-vector-distribution \
 // RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-llvmgpu-select-lowering-strategy, func.func(iree-llvmgpu-lower-executable-target)))))" %s | FileCheck %s --check-prefix=OPT-IN
@@ -88,15 +88,15 @@ hal.executable public @main_0_dispatch_0 {
 
 // -----
 
-// Check that applying the `reorder_workgroups = transpose` unit attribute enables workgroup reordering.
+// Check that applying the `workgroup_reorder = transpose` unit attribute enables workgroup reordering.
 
 // OPT-OUT:       #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64
 // OPT-OUT-SAME:    mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>,
-// OPT-OUT-SAME:    reorder_workgroups = #iree_gpu.reorder_workgroups<reorder_option = transpose>
+// OPT-OUT-SAME:    workgroup_reorder = #iree_gpu.workgroup_reorder<reorder_option = transpose>
 
 // OPT-IN:       #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64
 // OPT-IN-SAME:    mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>,
-// OPT-IN-SAME:    reorder_workgroups = #iree_gpu.reorder_workgroups<reorder_option = transpose>
+// OPT-IN-SAME:    workgroup_reorder = #iree_gpu.workgroup_reorder<reorder_option = transpose>
 
 #executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb",
 {iree.gpu.target = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8,
@@ -138,7 +138,7 @@ hal.executable public @main_0_dispatch_0 {
       func.func @main_0_dispatch_0_matmul_transpose_b_2048x10240x1280_f16xf16xf32()
         attributes {translation_info = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64, {
           mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>, subgroup_m_count = 2, subgroup_n_count = 2>,
-          reorder_workgroups = #iree_gpu.reorder_workgroups<reorder_option = "transpose">  // enable the 'reorderWorkgroups' pass.
+          workgroup_reorder = #iree_gpu.workgroup_reorder<reorder_option = "transpose">  // enable the 'reorderWorkgroups' pass.
         }>} {
         %cst = arith.constant 0.000000e+00 : f16
         %c0 = arith.constant 0 : index
@@ -170,11 +170,11 @@ hal.executable public @main_0_dispatch_0 {
 }
 
 // -----
-// Check that applying the `reorder_workgroups = none` unit attribute disables workgroup reordering.
+// Check that applying the `workgroup_reorder = none` unit attribute disables workgroup reordering.
 
 // OPT-OUT:       #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64
 // OPT-OUT-SAME:    mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>,
-// OPT-OUT-SAME:    reorder_workgroups = #iree_gpu.reorder_workgroups<>
+// OPT-OUT-SAME:    workgroup_reorder = #iree_gpu.workgroup_reorder<>
 #executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb",
 {iree.gpu.target = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8,
 storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, mma = [<MFMA_F16_16x16x16_F32>, <MFMA_F16_32x32x8_F32>],
@@ -204,7 +204,7 @@ hal.executable public @main_0_dispatch_0 {
       func.func @main_0_dispatch_0_matmul_transpose_b_2048x10240x1280_f16xf16xf32()
         attributes {translation_info = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64, {
           mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>, subgroup_m_count = 2, subgroup_n_count = 2>,
-          reorder_workgroups = #iree_gpu.reorder_workgroups<reorder_option="none">  // Disable the 'reorderWorkgroups' pass.
+          workgroup_reorder = #iree_gpu.workgroup_reorder<reorder_option="none">  // Disable the 'reorderWorkgroups' pass.
         }>} {
         %cst = arith.constant 0.000000e+00 : f16
         %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_user_vector_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_user_vector_distribute.mlir
@@ -87,11 +87,11 @@ hal.executable public @main_0_dispatch_0 {
 
 // OPT-OUT:       #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64
 // OPT-OUT-SAME:    mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>,
-// OPT-OUT-SAME:    reorder_workgroups = "transpose"
+// OPT-OUT-SAME:    reorder_workgroups = #iree_gpu.reorder_workgroups<reorder_option = transpose>
 
 // OPT-IN:       #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64
 // OPT-IN-SAME:    mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>,
-// OPT-IN-SAME:    reorder_workgroups = "transpose"
+// OPT-IN-SAME:    reorder_workgroups = #iree_gpu.reorder_workgroups<reorder_option = transpose>
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -127,7 +127,7 @@ hal.executable public @main_0_dispatch_0 {
       func.func @main_0_dispatch_0_matmul_transpose_b_2048x10240x1280_f16xf16xf32()
         attributes {translation_info = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64, {
           mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>, subgroup_m_count = 2, subgroup_n_count = 2>,
-          reorder_workgroups = "transpose"  // enable the 'reorderWorkgroups' pass.
+          reorder_workgroups = #iree_gpu.reorder_workgroups<reorder_option = "transpose">  // enable the 'reorderWorkgroups' pass.
         }>} {
         %cst = arith.constant 0.000000e+00 : f16
         %c0 = arith.constant 0 : index
@@ -163,7 +163,7 @@ hal.executable public @main_0_dispatch_0 {
 
 // OPT-OUT:       #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64
 // OPT-OUT-SAME:    mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>,
-// OPT-OUT-SAME:    reorder_workgroups = "none"
+// OPT-OUT-SAME:    reorder_workgroups = #iree_gpu.reorder_workgroups<reorder_option = none>
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -188,7 +188,7 @@ hal.executable public @main_0_dispatch_0 {
       func.func @main_0_dispatch_0_matmul_transpose_b_2048x10240x1280_f16xf16xf32()
         attributes {translation_info = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64, {
           mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>, subgroup_m_count = 2, subgroup_n_count = 2>,
-          reorder_workgroups = "none"  // Disable the 'reorderWorkgroups' pass.
+          reorder_workgroups = #iree_gpu.reorder_workgroups<reorder_option="none">  // Disable the 'reorderWorkgroups' pass.
         }>} {
         %cst = arith.constant 0.000000e+00 : f16
         %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_user_vector_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_user_vector_distribute.mlir
@@ -16,6 +16,11 @@
 // OPT-IN:       #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64
 // OPT-IN-SAME:    mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>,
 // OPT-IN-SAME:    no_reduce_shared_memory_bank_conflicts
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb",
+{iree.gpu.target = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8,
+storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, mma = [<MFMA_F16_16x16x16_F32>, <MFMA_F16_32x32x8_F32>],
+subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536>,
+chip = <wgp_count = 304, chiplet_count = 8>>, ukernels = "none"}>
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -23,7 +28,7 @@
   ]>
 ]>
 hal.executable public @main_0_dispatch_0 {
-  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+  hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
     hal.executable.export public @main_0_dispatch_0_matmul_transpose_b_2048x10240x1280_f16xf16xf32 ordinal(0) layout(#pipeline_layout)
     attributes {hal.interface.bindings = [#hal.interface.binding<0, 0>, #hal.interface.binding<0, 1>, #hal.interface.binding<0, 2>]} {
     ^bb0(%arg0: !hal.device):
@@ -92,6 +97,11 @@ hal.executable public @main_0_dispatch_0 {
 // OPT-IN:       #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64
 // OPT-IN-SAME:    mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>,
 // OPT-IN-SAME:    reorder_workgroups = #iree_gpu.reorder_workgroups<reorder_option = transpose>
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb",
+{iree.gpu.target = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8,
+storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, mma = [<MFMA_F16_16x16x16_F32>, <MFMA_F16_32x32x8_F32>],
+subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536>,
+chip = <wgp_count = 304, chiplet_count = 8>>, ukernels = "none"}>
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -99,7 +109,7 @@ hal.executable public @main_0_dispatch_0 {
   ]>
 ]>
 hal.executable public @main_0_dispatch_0 {
-  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+  hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
     hal.executable.export public @main_0_dispatch_0_matmul_transpose_b_2048x10240x1280_f16xf16xf32 ordinal(0) layout(#pipeline_layout)
     attributes {hal.interface.bindings = [#hal.interface.binding<0, 0>, #hal.interface.binding<0, 1>, #hal.interface.binding<0, 2>]} {
     ^bb0(%arg0: !hal.device):
@@ -163,7 +173,12 @@ hal.executable public @main_0_dispatch_0 {
 
 // OPT-OUT:       #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64
 // OPT-OUT-SAME:    mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>,
-// OPT-OUT-SAME:    reorder_workgroups = #iree_gpu.reorder_workgroups<reorder_option = none>
+// OPT-OUT-SAME:    reorder_workgroups = #iree_gpu.reorder_workgroups<>
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb",
+{iree.gpu.target = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8,
+storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, mma = [<MFMA_F16_16x16x16_F32>, <MFMA_F16_32x32x8_F32>],
+subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536>,
+chip = <wgp_count = 304, chiplet_count = 8>>, ukernels = "none"}>
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -171,7 +186,7 @@ hal.executable public @main_0_dispatch_0 {
   ]>
 ]>
 hal.executable public @main_0_dispatch_0 {
-  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+  hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
     hal.executable.export public @main_0_dispatch_0_matmul_transpose_b_2048x10240x1280_f16xf16xf32 ordinal(0) layout(#pipeline_layout)
     attributes {hal.interface.bindings = [#hal.interface.binding<0, 0>, #hal.interface.binding<0, 1>, #hal.interface.binding<0, 2>]} {
     ^bb0(%arg0: !hal.device):

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_user_vector_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_user_vector_distribute.mlir
@@ -97,6 +97,7 @@ hal.executable public @main_0_dispatch_0 {
 // OPT-IN:       #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64
 // OPT-IN-SAME:    mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>,
 // OPT-IN-SAME:    reorder_workgroups = #iree_gpu.reorder_workgroups<reorder_option = transpose>
+
 #executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb",
 {iree.gpu.target = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8,
 storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, mma = [<MFMA_F16_16x16x16_F32>, <MFMA_F16_32x32x8_F32>],


### PR DESCRIPTION
A new option, "chipletgroup," has been added to the existing options {none, swizzle, transpose}, making it {none, swizzle, transpose, chipletgroup}.

The new attribute #iree_gpu.reorder_workgroups has been introduced. You can refer to the IR test file (e.g., config_user_vector_distribute.mlir) to learn how to enable workgroup reordering in the configuration entries.