### PR TITLE
[GlobalOpt] Add pattern to raise insert_slice(%x, constant) to tensor.pad

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/test/raise_special_ops.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/raise_special_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --iree-global-opt-raise-special-ops -canonicalize --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-global-opt-raise-special-ops -canonicalize --split-input-file --mlir-print-local-scope %s | FileCheck %s
 
 // CHECK-LABEL: @softmax
 //  CHECK-SAME: %[[ARG:.+]]: tensor<?x?x?xf32>
@@ -687,3 +687,35 @@ util.func public @unsigned_matmul_extsi(%arg0 : tensor<10x20xi32>,
 //       CHECK:   %[[GEN:.+]] = linalg.generic
 //       CHECK:   %[[RESULT:.+]] = linalg.matmul_unsigned ins(%[[ARG0]], %[[GEN]]
 //       CHECK:   util.return %[[RESULT]]
+
+// -----
+
+util.func public @constant_pad_i8(%arg0: tensor<10x20xi8>) -> tensor<13x23xi8> {
+  %cst = arith.constant dense<1> : tensor<13x23xi8>
+  %1 = tensor.insert_slice %arg0 into %cst[1, 2] [10, 20] [1, 1] : tensor<10x20xi8> into tensor<13x23xi8>
+  util.return %1 : tensor<13x23xi8>
+}
+// CHECK-LABEL: util.func public @constant_pad_i8
+//  CHECK-SAME:     %[[ARG0:.+]]: tensor<10x20xi8>
+//       CHECK:   %[[C1:.+]] = arith.constant 1 : i8
+//       CHECK:   %[[PAD:.+]] = tensor.pad %[[ARG0]] low[1, 2] high[2, 1]
+//       CHECK:     tensor.yield %[[C1]]
+//       CHECK:   util.return %[[PAD]]
+
+// -----
+
+util.func public @constant_pad_f32(%arg0: tensor<?x?xf32>, %x: index, %y: index) -> tensor<13x23xf32> {
+  %cst = arith.constant dense<1.0> : tensor<13x23xf32>
+  %1 = tensor.insert_slice %arg0 into %cst[1, 2] [%x, %y] [1, 1] : tensor<?x?xf32> into tensor<13x23xf32>
+  util.return %1 : tensor<13x23xf32>
+}
+// CHECK-LABEL: util.func public @constant_pad_f32
+//  CHECK-SAME:     %[[ARG0:[A-Za-z0-9]+]]: tensor<?x?xf32>
+//  CHECK-SAME:     %[[X:[A-Za-z0-9]+]]: index
+//  CHECK-SAME:     %[[Y:[A-Za-z0-9]+]]: index
+//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1.000000e+00 : f32
+//   CHECK-DAG:   %[[H0:.+]] = affine.apply affine_map<()[s0] -> (-s0 + 12)>()[%[[X]]]
+//   CHECK-DAG:   %[[H1:.+]] = affine.apply affine_map<()[s0] -> (-s0 + 21)>()[%[[Y]]]
+//       CHECK:   %[[PAD:.+]] = tensor.pad %[[ARG0]] low[1, 2] high[%[[H0]], %[[H1]]]
+//       CHECK:     tensor.yield %[[C1]]
+//       CHECK:   util.return %[[PAD]]


### PR DESCRIPTION
Pad has improved analyzability earlier on in the compilation flow due to
omitting the destination. This adds a raising pattern to convert
insert_slice ops that are just constant pads to tensor.pad.

This allows us to propagate NCHW -> NHWC transposes through convolution padding.