### PR TITLE
Switch Linux x86 package builds to use standard runners.

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         include:
           # Ubuntu packages.
-          - runs-on: [managed-releaser, os-family=Linux, runner-group=releaser]
+          - runs-on: ubuntu-20.04
             build-family: linux-x86_64
             build-package: main-dist-linux
             experimental: false
@@ -48,7 +48,7 @@ jobs:
             build-family: linux-aarch64
             build-package: main-dist-linux
             experimental: true
-          - runs-on: [managed-releaser, os-family=Linux, runner-group=releaser]
+          - runs-on: ubuntu-20.04
             build-family: linux-x86_64
             build-package: py-compiler-pkg
             experimental: false
@@ -57,7 +57,7 @@ jobs:
             build-family: linux-aarch64
             build-package: py-compiler-pkg
             experimental: true
-          - runs-on: [managed-releaser, os-family=Linux, runner-group=releaser]
+          - runs-on: ubuntu-20.04
             build-family: linux-x86_64
             build-package: py-runtime-pkg
             experimental: false
@@ -66,7 +66,7 @@ jobs:
             build-family: linux-aarch64
             build-package: py-runtime-pkg
             experimental: true
-          - runs-on: [managed-releaser, os-family=Linux, runner-group=releaser]
+          - runs-on: ubuntu-20.04
             build-family: linux-x86_64
             build-package: py-tf-compiler-tools-pkg
             experimental: false


### PR DESCRIPTION
For some reason the runners tagged `managed-releaser, os-family=Linux, runner-group=releaser` aren't picking up jobs on https://github.com/iree-org/iree/actions/workflows/build_package.yml (discussion [here on Discord](https://discord.com/channels/689900678990135345/1259913154620686581/1259916287069523969)). Rather than troubleshoot those runners, we can just switch to standard GitHub-hosted runners and accept longer build times for these daily builds.

Tested here: https://github.com/iree-org/iree/actions/runs/9844299015 (3h30m runs, about the same as macOS and Windows).

skip-ci: not tested by presubmit