### PR TITLE
Optimizing queries for optional VM functions.

### DIFF
--- a/runtime/bindings/python/py_module.cc
+++ b/runtime/bindings/python/py_module.cc
@@ -86,7 +86,8 @@ class PyModuleInterface {
       iree_vm_function_t* out_function, iree_string_view_t* out_name,
       iree_vm_function_signature_t* out_signature) {
     auto self = AsSelf(vself);
-    if (IREE_LIKELY(linkage == IREE_VM_FUNCTION_LINKAGE_EXPORT)) {
+    if (IREE_LIKELY(linkage == IREE_VM_FUNCTION_LINKAGE_EXPORT ||
+                    linkage == IREE_VM_FUNCTION_LINKAGE_EXPORT_OPTIONAL)) {
       if (IREE_LIKELY(ordinal < self->export_functions_.size())) {
         std::unique_ptr<PyFunction>& f = self->export_functions_[ordinal];
         if (IREE_LIKELY(out_function)) {
@@ -114,7 +115,8 @@ class PyModuleInterface {
       iree_vm_function_t* out_function) {
     auto self = AsSelf(vself);
     std::string_view name_cpp(name.data, name.size);
-    if (linkage == IREE_VM_FUNCTION_LINKAGE_EXPORT) {
+    if (linkage == IREE_VM_FUNCTION_LINKAGE_EXPORT ||
+        linkage == IREE_VM_FUNCTION_LINKAGE_EXPORT_OPTIONAL) {
       auto found_it = self->export_name_to_ordinals_.find(name_cpp);
       if (found_it != self->export_name_to_ordinals_.end()) {
         out_function->linkage = linkage;

--- a/runtime/bindings/python/vm.cc
+++ b/runtime/bindings/python/vm.cc
@@ -819,6 +819,7 @@ void SetupVmBindings(nanobind::module_ m) {
       .value("IMPORT", IREE_VM_FUNCTION_LINKAGE_IMPORT)
       .value("IMPORT_OPTIONAL", IREE_VM_FUNCTION_LINKAGE_IMPORT_OPTIONAL)
       .value("EXPORT", IREE_VM_FUNCTION_LINKAGE_EXPORT)
+      .value("EXPORT_OPTIONAL", IREE_VM_FUNCTION_LINKAGE_EXPORT_OPTIONAL)
       .export_values();
 
   auto vm_buffer = py::class_<VmBuffer>(m, "VmBuffer");

--- a/runtime/src/iree/tooling/instrument_util.c
+++ b/runtime/src/iree/tooling/instrument_util.c
@@ -94,7 +94,7 @@ iree_status_t iree_tooling_process_instrument_data(
       // Find the query function, if present.
       iree_vm_function_t query_func;
       iree_status_t lookup_status = iree_vm_module_lookup_function_by_name(
-          module, IREE_VM_FUNCTION_LINKAGE_EXPORT,
+          module, IREE_VM_FUNCTION_LINKAGE_EXPORT_OPTIONAL,
           IREE_SV("__query_instruments"), &query_func);
       if (!iree_status_is_ok(lookup_status)) {
         // Skip missing/invalid query function.

--- a/runtime/src/iree/vm/context.c
+++ b/runtime/src/iree/vm/context.c
@@ -75,7 +75,8 @@ static iree_status_t iree_vm_context_run_function(
   iree_vm_function_call_t call;
   memset(&call, 0, sizeof(call));
   iree_status_t status = iree_vm_module_lookup_function_by_name(
-      module, IREE_VM_FUNCTION_LINKAGE_EXPORT, function_name, &call.function);
+      module, IREE_VM_FUNCTION_LINKAGE_EXPORT_OPTIONAL, function_name,
+      &call.function);
   if (iree_status_is_not_found(status)) {
     // Function doesn't exist; that's ok as this was an optional call.
     iree_status_ignore(status);
@@ -618,7 +619,7 @@ static iree_status_t iree_vm_context_call_module_notify(
 
   // Try to find the function. Modules are not required to export it.
   iree_status_t status = iree_vm_module_lookup_function_by_name(
-      module, IREE_VM_FUNCTION_LINKAGE_EXPORT,
+      module, IREE_VM_FUNCTION_LINKAGE_EXPORT_OPTIONAL,
       iree_make_cstring_view("__notify"), &call.function);
   if (iree_status_is_not_found(status)) {
     // Function doesn't exist; that's ok as this was an optional call.

--- a/runtime/src/iree/vm/module.h
+++ b/runtime/src/iree/vm/module.h
@@ -36,7 +36,11 @@ typedef enum iree_vm_function_linkage_e {
   // Function is an export from the module.
   IREE_VM_FUNCTION_LINKAGE_EXPORT = 2,
   // Function is an import from another module that may be unavailable.
+  // This is a hint that failures should be lightweight/not reported.
   IREE_VM_FUNCTION_LINKAGE_IMPORT_OPTIONAL = 3,
+  // Function is an export from the module that may be unavailable.
+  // This is a hint that failures should be lightweight/not reported.
+  IREE_VM_FUNCTION_LINKAGE_EXPORT_OPTIONAL = 4,
 } iree_vm_function_linkage_t;
 
 // A function reference that can be used with the iree_vm_function_* methods.


### PR DESCRIPTION
Queries with IMPORT_OPTIONAL bypass reporting and full status creation as a way to avoid generating a bunch of stack traces for cases where the caller can gracefully handle the absence of an import. This change adds EXPORT_OPTIONAL to provide the same functionality to callers that know the export may not exist. This speeds up startup (when __init is omitted on a module), shutdown (when __deinit is omitted on a module), and event notification (__notify).