### PR TITLE
Adding indirect command buffer emulation for Metal.

### DIFF
--- a/runtime/src/iree/hal/drivers/metal/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/metal/CMakeLists.txt
@@ -41,6 +41,7 @@ iree_cc_library(
     iree::base::internal::flatcc::parsing
     iree::hal
     iree::hal::drivers::metal::builtin
+    iree::hal::utils::deferred_command_buffer
     iree::hal::utils::file_transfer
     iree::hal::utils::memory_file
     iree::hal::utils::resource_set


### PR DESCRIPTION
Until we switch to using MTLIndirectCommandBuffer any reusable command buffers or ones with indirect bindings will need to be recorded into deferred command buffers and replayed upon submission.