### PR TITLE
Switch build_test_android from pixel 6 to pixel 8.

### DIFF
--- a/.github/workflows/build_and_test_android.yml
+++ b/.github/workflows/build_and_test_android.yml
@@ -109,7 +109,7 @@ jobs:
 
   test:
     # These physical devices are not scalable. Only run on postsubmit for now.
-    if: (! inputs.is-pr)
+    # if: (! inputs.is-pr)
     needs: cross_compile
     strategy:
       matrix:

--- a/.github/workflows/build_and_test_android.yml
+++ b/.github/workflows/build_and_test_android.yml
@@ -114,7 +114,7 @@ jobs:
     strategy:
       matrix:
         target:
-          - device-name: pixel-6-pro
+          - device-name: pixel-8-pro
             label-exclude: "^requires-gpu"
           - device-name: moto-edge-x30
             # Moto Edge X30 supports VK_KHR_16bit_storage for only storage


### PR DESCRIPTION
The pixel 6 is around three years old and has outdated Vulkan drivers. We could keep testing on it as a min-spec device, but we should also be testing on the latest device with recent drivers.

ci-exactly: build_all, build_and_test_android