### PR TITLE
Switch code of conduct from OpenXLA to LF Projects.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,4 +17,4 @@ To get started with contributing, please take a look at the
 ## Community guidelines
 
 This project follows the
-[OpenXLA Code of Conduct](https://github.com/openxla/community/blob/main/CODE-OF-CONDUCT.md).
+[LF Projects code of conduct](https://lfprojects.org/policies/code-of-conduct/).

--- a/docs/website/docs/developers/general/contributing.md
+++ b/docs/website/docs/developers/general/contributing.md
@@ -19,7 +19,7 @@ We'd love to accept your patches and contributions to this project.
 ### :octicons-code-of-conduct-16: Code of conduct
 
 This project follows the
-[OpenXLA Code of Conduct](https://github.com/openxla/community/blob/main/CODE-OF-CONDUCT.md).
+[LF Projects code of conduct](https://lfprojects.org/policies/code-of-conduct/).
 
 ### :octicons-law-16: Developer Certificate of Origin
 

--- a/docs/website/docs/guides/ml-frameworks/onnx.md
+++ b/docs/website/docs/guides/ml-frameworks/onnx.md
@@ -71,7 +71,7 @@ graph LR
     === ":material-alert: Nightly releases"
 
         Nightly releases are published on
-        [GitHub releases](https://github.com/openxla/iree/releases).
+        [GitHub releases](https://github.com/iree-org/iree/releases).
 
         ``` shell
         python -m pip install \


### PR DESCRIPTION
We have been moving out of OpenXLA: https://groups.google.com/g/iree-discuss/c/kdFr4CQwEyY/m/PWJIpZlRBQAJ and into the Linux Foundation (LF AI & Data): https://lfaidata.foundation/blog/2024/05/23/announcing-iree-a-new-initiative-for-machine-learning-deployment/, so switching the code of conduct to https://lfprojects.org/policies/code-of-conduct/.