### PR TITLE
Deflake LoopTest.WaitOneBlocking by increasing timeout.

### DIFF
--- a/runtime/src/iree/base/loop_test.h
+++ b/runtime/src/iree/base/loop_test.h
@@ -606,7 +606,7 @@ TEST_F(LoopTest, WaitOneBlocking) {
     bool did_wait_callback = false;
   } user_data;
   IREE_ASSERT_OK(iree_loop_wait_one(
-      loop, wait_source, iree_make_timeout_ms(200),
+      loop, wait_source, iree_make_timeout_ms(2000),
       +[](void* user_data_ptr, iree_loop_t loop, iree_status_t status) {
         IREE_TRACE_SCOPE();
         IREE_EXPECT_OK(status);


### PR DESCRIPTION
This test case has failed a few times on macos_x86, and possibly on other platforms too. I suspect the OS isn't scheduling the test threads soon enough - there's only a 150 millisecond window between the event set on a worker thread and `iree_loop_wait_one`'s timeout on the main thread:

```
main thread                worker thread
-----------                -------------
test start
spin up thread   ------>   wait 50ms
wait 200ms                 ...
...              <------   set event
timeout if event not set
```

Sample logs:
* https://github.com/iree-org/iree/actions/runs/9214985535/job/25352380335#step:10:1578
* https://github.com/iree-org/iree/actions/runs/9882364677/job/27295096340?pr=17856#step:9:43

```
[ RUN      ] LoopTest.WaitOneBlocking
iree/runtime/src/iree/base/loop_test.h:612: Failure
Value of: status
Expected: error code OK
  Actual: 0x4, whose error code is DEADLINE_EXCEEDED: DEADLINE_EXCEEDED

[  FAILED  ] LoopTest.WaitOneBlocking (200 ms)
```

We could also use an infinite timeout.