### PR TITLE
Deflake ScopeTest.WaitIdleFailure by increasing sleep time.

### DIFF
--- a/runtime/src/iree/task/scope_test.cc
+++ b/runtime/src/iree/task/scope_test.cc
@@ -182,6 +182,8 @@ TEST(ScopeTest, WaitIdleSuccess) {
 
   // Spin up a thread to wait on the scope.
   std::thread wait_thread([&]() {
+    // Note: if the thread takes longer to start than the sleep below, this
+    // will fail with a flake :(
     EXPECT_FALSE(iree_task_scope_is_idle(&scope));
     EXPECT_TRUE(iree_status_is_ok(
         iree_task_scope_wait_idle(&scope, IREE_TIME_INFINITE_FUTURE)));
@@ -190,7 +192,7 @@ TEST(ScopeTest, WaitIdleSuccess) {
 
   // Wait a moment for the thread to spin up.
   // NOTE: this may flake. Need to see if there's a better way to do this.
-  std::this_thread::sleep_for(std::chrono::milliseconds(150));
+  std::this_thread::sleep_for(std::chrono::milliseconds(250));
 
   // Complete the task.
   iree_task_submission_t pending_submission;
@@ -222,6 +224,8 @@ TEST(ScopeTest, WaitIdleFailure) {
 
   // Spin up a thread to wait on the scope.
   std::thread wait_thread([&]() {
+    // Note: if the thread takes longer to start than the sleep below, this
+    // will fail with a flake :(
     EXPECT_FALSE(iree_task_scope_is_idle(&scope));
     EXPECT_TRUE(iree_status_is_ok(
         iree_task_scope_wait_idle(&scope, IREE_TIME_INFINITE_FUTURE)));
@@ -230,7 +234,7 @@ TEST(ScopeTest, WaitIdleFailure) {
 
   // Wait a moment for the thread to spin up.
   // NOTE: this may flake. Need to see if there's a better way to do this.
-  std::this_thread::sleep_for(std::chrono::milliseconds(150));
+  std::this_thread::sleep_for(std::chrono::milliseconds(250));
 
   // Set the failure state.
   iree_task_scope_fail(


### PR DESCRIPTION
This test has flaked a few times:

* https://github.com/iree-org/iree/actions/runs/9653016869/job/26624436852#step:5:1882
* https://github.com/iree-org/iree/actions/runs/9716312176/job/26819673196#step:4:18786

```
[ RUN      ] ScopeTest.WaitIdleFailure
/work/runtime/src/iree/task/scope_test.cc:225: Failure
Value of: iree_task_scope_is_idle(&scope)
  Actual: true
Expected: false

[  FAILED  ] ScopeTest.WaitIdleFailure (175 ms)
[----------] 9 tests from ScopeTest (326 ms total)

[----------] Global test environment tear-down
[==========] 9 tests from 1 test suite ran. (326 ms total)
[  PASSED  ] 8 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] ScopeTest.WaitIdleFailure

 1 FAILED TEST
```

We could instead drop the `EXPECT_FALSE(iree_task_scope_is_idle(&scope));` check entirely. Increasing the sleep time will increase test time regardless of OS scheduler behavior (unlike https://github.com/iree-org/iree/pull/17857 which increased a _timeout_ duration).