### PR TITLE
Bump goldentime values for mi250 sdxl benchmarks.

### DIFF
--- a/.github/workflows/pkgci_regression_test.yml
+++ b/.github/workflows/pkgci_regression_test.yml
@@ -314,8 +314,8 @@ jobs:
           pytest SHARK-TestSuite/iree_tests/benchmarks/sdxl/benchmark_sdxl_rocm.py \
             --goldentime-rocm-e2e-ms 1336.0 \
             --goldentime-rocm-unet-ms 340.0 \
-            --goldentime-rocm-clip-ms 17.0 \
-            --goldentime-rocm-vae-ms 291.0 \
+            --goldentime-rocm-clip-ms 17.5 \
+            --goldentime-rocm-vae-ms 300.0 \
             --goldendispatch-rocm-unet 1714 \
             --goldendispatch-rocm-clip 1569 \
             --goldendispatch-rocm-vae 248 \


### PR DESCRIPTION
Seeing some variance causing CI failures with unrelated changes:
* https://github.com/iree-org/iree/actions/runs/9879301822/job/27286342282#step:15:46
  * `VAE Decode Benchmark Time: 295.0 ms (golden time 291.0 ms)`
  * `Prompt Encoder Benchmark Time: 17.2 ms (golden time 17.0 ms)`
* https://github.com/iree-org/iree/actions/runs/9877397187/job/27279465007
  * `VAE Decode Benchmark Time: 295.0 ms (golden time 291.0 ms)`
  * `Prompt Encoder Benchmark Time: 17.1 ms (golden time 17.0 ms)`

Aside: we might want to move the benchmarks to a `pkgci_benchmarks.yml` workflow instead of chaining them on to the end of `pkgci_regression_test.yml`.

ci-exactly: build_packages,regression_test