### PR TITLE
Disable failing Pixel6/Vulkan linalg_ext reverse test again.

### DIFF
--- a/tests/e2e/linalg_ext_ops/BUILD.bazel
+++ b/tests/e2e/linalg_ext_ops/BUILD.bazel
@@ -102,33 +102,46 @@ iree_check_single_backend_test_suite(
     target_backend = "rocm",
 )
 
-SPIRV_SRCS = enforce_glob(
-    # keep sorted
-    [
-        "reverse.mlir",
-        "scan.mlir",
-        "scatter.mlir",
-        "sort.mlir",
-        "winograd_input.mlir",
-        "winograd_output.mlir",
-    ],
-    include = ["*.mlir"],
-    exclude = [
-        "attention.mlir",
-        "top-k.mlir",
-    ],
-)
-
 iree_check_single_backend_test_suite(
     name = "check_metal-spirv_vulkan",
-    srcs = SPIRV_SRCS,
+    srcs = enforce_glob(
+        # keep sorted
+        [
+            "reverse.mlir",
+            "scan.mlir",
+            "scatter.mlir",
+            "sort.mlir",
+            "winograd_input.mlir",
+            "winograd_output.mlir",
+        ],
+        include = ["*.mlir"],
+        exclude = [
+            "attention.mlir",
+            "top-k.mlir",
+        ],
+    ),
     driver = "metal",
     target_backend = "metal-spirv",
 )
 
 iree_check_single_backend_test_suite(
     name = "check_vulkan-spirv_vulkan",
-    srcs = SPIRV_SRCS,
+    srcs = enforce_glob(
+        # keep sorted
+        [
+            "scan.mlir",
+            "scatter.mlir",
+            "sort.mlir",
+            "winograd_input.mlir",
+            "winograd_output.mlir",
+        ],
+        include = ["*.mlir"],
+        exclude = [
+            "attention.mlir",
+            "reverse.mlir",  #TODO(#12415): disabled due to miscompilation on Pixel 6.
+            "top-k.mlir",
+        ],
+    ),
     driver = "vulkan",
     target_backend = "vulkan-spirv",
 )

--- a/tests/e2e/linalg_ext_ops/CMakeLists.txt
+++ b/tests/e2e/linalg_ext_ops/CMakeLists.txt
@@ -107,7 +107,6 @@ iree_check_single_backend_test_suite(
   NAME
     check_vulkan-spirv_vulkan
   SRCS
-    "reverse.mlir"
     "scan.mlir"
     "scatter.mlir"
     "sort.mlir"


### PR DESCRIPTION
See https://github.com/iree-org/iree/pull/17856#discussion_r1673193963