### PR TITLE
[Winograd][LLVMCPU] Enable tileAndFuse for winograd ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1842,14 +1842,24 @@ setWinogradRootConfig(mlir::FunctionOpInterface entryPointFn,
   assert(!getLoweringConfig(winogradOp) &&
          "expected lowering_config is not set");
   auto iterationRank = winogradOp.getIterationDomainRank();
-  SmallVector<int64_t> vecSizeHints(iterationRank, 1);
   DistributionHeuristicConfig distConfig;
+  SmallVector<int64_t> maxTileSizes(iterationRank, clDefaultDistTileSize);
+  maxTileSizes[0] = maxTileSizes[1] = 0;
+  SmallVector<int64_t> minTileSizes(iterationRank, 1);
+  minTileSizes[0] = minTileSizes[1] = 0;
+  SmallVector<int64_t> vecSizeHints(iterationRank, 1);
+  vecSizeHints[0] = vecSizeHints[1] = winogradOp.getInputTileSize();
   distConfig.vectorSizeHints = vecSizeHints;
+  distConfig.minTileSizes = minTileSizes;
+  distConfig.maxTileSizes = maxTileSizes;
   SmallVector<int64_t> distTileSizes =
       getDefaultDistributedLevelTileSizes(winogradOp, distConfig);
   TileSizesListType tileSizes;
   tileSizes.push_back(distTileSizes);
+  assert(distTileSizes[0] == 0 && distTileSizes[1] == 0 &&
+         "expected outer 2 distTileSizes to be 0");
   SmallVector<int64_t> vecTileSizes(iterationRank, 1);
+  vecTileSizes[0] = vecTileSizes[1] = winogradOp.getInputTileSize();
   tileSizes.push_back(vecTileSizes);
   // Dummy tiling config for reduction level.
   SmallVector<int64_t> reductionTileSizes(iterationRank, 0);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -586,8 +586,8 @@ void addCPULinalgExtTileAndVectorizePipeline(
     OpPassManager &funcPassManager, TilingConfig &tilingConfig,
     LLVMCPUPipelineOptions &pipelineOpt) {
   addTileAndDistributePasses(funcPassManager);
-  funcPassManager.addPass(
-      createLLVMCPUTilePass(tilingConfig.getVectorCommonParallelLevel()));
+  funcPassManager.addPass(createLLVMCPUTileAndFusePass(
+      tilingConfig.getVectorCommonParallelLevel()));
   // TODO: Remove the pass once we have PartialReductionOpInterface implemented
   // for AttentionOp.
   funcPassManager.addPass(

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
@@ -1531,7 +1531,7 @@ module {
     return
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 6, 64], [1, 1, 1, 1], [0, 0, 0, 0]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 0, 1, 6, 64], [8, 8, 1, 1, 1, 1], [0, 0, 0, 0, 0, 0]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPULinalgExtTileAndVectorize>
 //      CHECK: func.func @winograd_output_transform()
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -1556,7 +1556,7 @@ module {
     return
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 6, 64], [1, 1, 1, 1], [0, 0, 0, 0]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 0, 1, 6, 64], [8, 8, 1, 1, 1, 1], [0, 0, 0, 0, 0, 0]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPULinalgExtTileAndVectorize>
 //      CHECK: func.func @winograd_input_transform()
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -1581,7 +1581,7 @@ module {
     return
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[8, 64], [1, 1], [0, 0]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 8, 64], [8, 8, 1, 1], [0, 0, 0, 0]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPULinalgExtTileAndVectorize>
 //      CHECK: func.func @winograd_filter_transform()
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -899,19 +899,24 @@ static LogicalResult setWinogradOpConfig(IREE::GPU::TargetAttr target,
   std::array<int64_t, 3> workgroupSize = {32, 4, 4};
   int64_t iterationRank = op.getIterationDomainRank();
   SmallVector<int64_t> workgroupTileSizes(iterationRank, 4);
+  // Do not tile the input tile dimensions
+  workgroupTileSizes[0] = 0;
+  workgroupTileSizes[1] = 0;
   // Set batch workgroup size
-  workgroupTileSizes.front() = 1;
+  workgroupTileSizes[2] = 1;
   // Set input channel workgroup size
   workgroupTileSizes.back() = 32;
   if (isa<IREE::LinalgExt::WinogradFilterTransformOp>(op)) {
     // Set input channel workgroup size
-    workgroupTileSizes.front() = 32;
+    workgroupTileSizes[2] = 32;
     // Set output channel workgroup size
     workgroupTileSizes.back() = 16;
     workgroupSize = {16, 32, 1};
   }
   tileSizes.push_back(workgroupTileSizes);
   SmallVector<int64_t> threadTileSizes(iterationRank, 1);
+  threadTileSizes[0] = 0;
+  threadTileSizes[1] = 0;
   tileSizes.push_back(threadTileSizes);
   return setOpConfigAndEntryPointFnTranslation(entryPoint, op, tileSizes,
                                                pipeline, workgroupSize);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_winograd.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_winograd.mlir
@@ -13,7 +13,7 @@ module {
   }
 }
 
-//   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[32, 16], [1, 1]{{\]}}>
+//   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 32, 16], [0, 0, 1, 1]{{\]}}>
 //   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUWinogradVectorize workgroup_size = [16, 32, 1]>
 //       CHECK: func.func @winograd_filter_transform()
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
@@ -35,7 +35,7 @@ module {
   }
 }
 
-//   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 4, 4, 32], [1, 1, 1, 1]{{\]}}>
+//   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 1, 4, 4, 32], [0, 0, 1, 1, 1, 1]{{\]}}>
 //   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUWinogradVectorize workgroup_size = [32, 4, 4]>
 //       CHECK: func.func @winograd_input_transform()
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
@@ -57,7 +57,7 @@ module {
   }
 }
 
-//   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 4, 4, 32], [1, 1, 1, 1]{{\]}}>
+//   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 1, 4, 4, 32], [0, 0, 1, 1, 1, 1]{{\]}}>
 //   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUWinogradVectorize workgroup_size = [32, 4, 4]>
 //       CHECK: func.func @winograd_output_transform()
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -1054,7 +1054,8 @@ static LogicalResult setWinogradOpConfig(spirv::ResourceLimitsAttr limits,
   // sizes found in the StableDiffusion model.
   auto pipeline = CodeGenPipeline::SPIRVWinogradVectorize;
   std::array<int64_t, 3> workgroupSize = {32, 4, 4};
-  TileSizesListType tileSizes = {{1, 0, 0, 32}, {1, 1, 1, 1}, {0, 0, 0, 0}};
+  TileSizesListType tileSizes = {
+      {0, 0, 1, 0, 0, 32}, {0, 0, 1, 1, 1, 1}, {0, 0, 0, 0, 0, 0}};
   return setOpConfigAndEntryPointFnTranslation(
       op->getParentOfType<mlir::FunctionOpInterface>(), op, tileSizes, pipeline,
       workgroupSize);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ext_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ext_ops.mlir
@@ -123,7 +123,7 @@ module {
   }
 }
 
-//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 0, 0, 32], [1, 1, 1, 1], [0, 0, 0, 0]]>
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 1, 0, 0, 32], [0, 0, 1, 1, 1, 1], [0, 0, 0, 0, 0, 0]]>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVWinogradVectorize workgroup_size = [32, 4, 4]>
 //       CHECK: func.func @winograd_input_transform()
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -145,7 +145,7 @@ module {
   }
 }
 
-//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 0, 0, 32], [1, 1, 1, 1], [0, 0, 0, 0]]>
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 1, 0, 0, 32], [0, 0, 1, 1, 1, 1], [0, 0, 0, 0, 0, 0]]>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVWinogradVectorize workgroup_size = [32, 4, 4]>
 //       CHECK: func.func @winograd_output_transform()
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -1223,7 +1223,8 @@ def IREELinalgExt_WinogradInputTransformOp : IREELinalgExt_Op<"winograd.input_tr
       ["getIterationDomain",
        "getLoopIteratorTypes",
        "getResultTilePosition",
-       "getTiledImplementation"]>]> {
+       "getTiledImplementation",
+       "generateResultTileValue"]>]> {
   let summary = "Winograd Input Transform operator";
   let description = [{
     This operator is part of the first step in converting a convolution to
@@ -1318,7 +1319,7 @@ def IREELinalgExt_WinogradInputTransformOp : IREELinalgExt_Op<"winograd.input_tr
       return isNhwc() ? 3 : 1;
     }
     int64_t getIterationDomainRank() {
-      return getOutputRank() - getImageDimensions().size();
+      return getOutputRank();
     }
     // Method to implement for specifying output range for
     // DestinationStyleOpInterface
@@ -1334,7 +1335,8 @@ def IREELinalgExt_WinogradFilterTransformOp : IREELinalgExt_Op<"winograd.filter_
       ["getIterationDomain",
        "getLoopIteratorTypes",
        "getResultTilePosition",
-       "getTiledImplementation"]>]> {
+       "getTiledImplementation",
+       "generateResultTileValue"]>]> {
   let summary = "Winograd Filter Transform operator";
   let description = [{
     This operator is part of the first step in converting a convolution to
@@ -1434,7 +1436,7 @@ def IREELinalgExt_WinogradFilterTransformOp : IREELinalgExt_Op<"winograd.filter_
       return isHwcf() ? 3 : 0;
     }
     int64_t getIterationDomainRank() {
-      return getInputRank() - getKernelDimensions().size();
+      return getOutputRank();
     }
     // Method to implement for specifying output range for
     // DestinationStyleOpInterface
@@ -1546,7 +1548,7 @@ def IREELinalgExt_WinogradOutputTransformOp : IREELinalgExt_Op<"winograd.output_
       return getOutputType().getRank();
     }
     int64_t getIterationDomainRank() {
-      return getInputRank() - getImageDimensions().size();
+      return getInputRank();
     }
     int64_t getInputTileSize() {
       return getOutputTileSize() + getKernelSize() - 1;

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TilingInterfaceImpl.cpp
@@ -1337,15 +1337,11 @@ WinogradInputTransformOp::getIterationDomain(OpBuilder &builder) {
   Location loc = getLoc();
   Value zero = builder.create<arith::ConstantIndexOp>(loc, 0);
   Value one = builder.create<arith::ConstantIndexOp>(loc, 1);
-  Value dest = getOutput();
   SmallVector<Range> loopBounds(getIterationDomainRank());
-  int count = 0;
-  for (auto dim :
-       llvm::seq<int64_t>(getImageDimensions().size(), getOutputRank())) {
-    loopBounds[count].offset = zero;
-    loopBounds[count].size = getDimValue(builder, loc, dest, dim);
-    loopBounds[count].stride = one;
-    count++;
+  for (int dim = 0; dim < getOutputRank(); ++dim) {
+    loopBounds[dim].offset = zero;
+    loopBounds[dim].size = getDimValue(builder, loc, getOutput(), dim);
+    loopBounds[dim].stride = one;
   }
   return loopBounds;
 }
@@ -1362,44 +1358,32 @@ WinogradInputTransformOp::getTiledImplementation(OpBuilder &builder,
                                                  ArrayRef<OpFoldResult> offsets,
                                                  ArrayRef<OpFoldResult> sizes) {
   Location loc = getLoc();
-  auto one = builder.getIndexAttr(1);
   auto zero = builder.getIndexAttr(0);
   const int cDim = getChannelDim();
 
-  assert(offsets.size() == 4);
+  assert(offsets.size() == 6);
   SmallVector<OpFoldResult> inputOffsets(getInputRank(), zero);
-  SmallVector<OpFoldResult> outputOffsets(getOutputRank(), zero);
   const auto hDim = getImageDimensions()[0];
   const auto wDim = getImageDimensions()[1];
-  outputOffsets[2] = inputOffsets[0] = offsets[0];
-  outputOffsets[3] = offsets[1];
-  outputOffsets[4] = offsets[2];
-  outputOffsets[5] = inputOffsets[cDim] = offsets[3];
+  inputOffsets[0] = offsets[2];
+  inputOffsets[cDim] = offsets[5];
 
-  SmallVector<OpFoldResult> inputStrides(getInputRank(), one);
-  SmallVector<OpFoldResult> outputStrides(getOutputRank(), one);
-  ReifiedRankedShapedTypeDims reifiedResultShapes, reifiedInputShapes;
-  if (failed(reifyResultShapes(builder, reifiedResultShapes))) {
-    return failure();
-  }
-  SmallVector<OpFoldResult> outputSizes = reifiedResultShapes[0];
+  ReifiedRankedShapedTypeDims reifiedInputShapes;
   if (failed(getStaticOrReifiedInputDims(builder, loc, getInput(),
                                          reifiedInputShapes))) {
     return failure();
   }
   SmallVector<OpFoldResult> inputSizes = reifiedInputShapes[0];
 
-  assert(sizes.size() == 4);
-  outputSizes[2] = inputSizes[0] = sizes[0];
-  outputSizes[3] = sizes[1];
-  outputSizes[4] = sizes[2];
-  outputSizes[5] = inputSizes[cDim] = sizes[3];
+  assert(sizes.size() == 6);
+  inputSizes[0] = sizes[2];
+  inputSizes[cDim] = sizes[5];
 
   auto hSizeAndOffset = getScaledSizeAndOffset(
-      builder, loc, sizes[1], offsets[1], inputSizes[hDim], getOutputTileSize(),
+      builder, loc, sizes[3], offsets[3], inputSizes[hDim], getOutputTileSize(),
       getInputTileSize());
   auto wSizeAndOffset = getScaledSizeAndOffset(
-      builder, loc, sizes[2], offsets[2], inputSizes[wDim], getOutputTileSize(),
+      builder, loc, sizes[4], offsets[4], inputSizes[wDim], getOutputTileSize(),
       getInputTileSize());
 
   inputSizes[hDim] = hSizeAndOffset.first;
@@ -1408,10 +1392,13 @@ WinogradInputTransformOp::getTiledImplementation(OpBuilder &builder,
   inputOffsets[wDim] = wSizeAndOffset.second;
 
   SmallVector<Value> tiledOperands;
+  auto one = builder.getIndexAttr(1);
+  SmallVector<OpFoldResult> inputStrides(getInputRank(), one);
   tiledOperands.emplace_back(getSlice(builder, loc, getInput(), inputOffsets,
                                       inputSizes, inputStrides));
-  tiledOperands.emplace_back(getSlice(builder, loc, getOutput(), outputOffsets,
-                                      outputSizes, outputStrides));
+  SmallVector<OpFoldResult> outputStrides(getOutputRank(), one);
+  tiledOperands.emplace_back(
+      getSlice(builder, loc, getOutput(), offsets, sizes, outputStrides));
 
   SmallVector<Type, 4> resultTypes;
   if (hasPureTensorSemantics()) {
@@ -1429,21 +1416,19 @@ LogicalResult WinogradInputTransformOp::getResultTilePosition(
     ArrayRef<OpFoldResult> sizes, SmallVector<OpFoldResult> &resultOffsets,
     SmallVector<OpFoldResult> &resultSizes) {
   if (resultNumber == 0) {
-    auto resultShape = cast<ShapedType>(getOutput().getType()).getShape();
-    resultSizes = getAsOpFoldResult(builder.getIndexArrayAttr(resultShape));
-    resultOffsets =
-        SmallVector<OpFoldResult>(getOutputRank(), builder.getIndexAttr(0));
-    resultOffsets[2] = offsets[0];
-    resultOffsets[3] = offsets[1];
-    resultOffsets[4] = offsets[2];
-    resultOffsets[5] = offsets[3];
-    resultSizes[2] = sizes[0];
-    resultSizes[3] = sizes[1];
-    resultSizes[4] = sizes[2];
-    resultSizes[5] = sizes[3];
+    resultSizes = SmallVector<OpFoldResult>(sizes);
+    resultOffsets = SmallVector<OpFoldResult>(offsets);
     return success();
   }
   return failure();
+}
+
+FailureOr<TilingResult> WinogradInputTransformOp::generateResultTileValue(
+    OpBuilder &b, unsigned resultNumber, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes) {
+  int64_t numLoops = getIterationDomainRank();
+  return getTiledImplementation(b, offsets.take_front(numLoops),
+                                sizes.take_front(numLoops));
 }
 
 //===----------------------------------------------------------------------===//
@@ -1455,15 +1440,11 @@ WinogradFilterTransformOp::getIterationDomain(OpBuilder &builder) {
   Location loc = getLoc();
   OpFoldResult zero = builder.getIndexAttr(0);
   OpFoldResult one = builder.getIndexAttr(1);
-  Value source = getOutput();
-  int64_t numKernelDims = getKernelDimensions().size();
-  auto outRank = getOutputRank();
-  SmallVector<Range> loopBounds(outRank - numKernelDims);
-  for (auto dim : llvm::seq<int64_t>(numKernelDims, outRank)) {
-    int64_t loopDim = dim - numKernelDims;
-    loopBounds[loopDim].offset = zero;
-    loopBounds[loopDim].size = getDimValue(builder, loc, source, dim);
-    loopBounds[loopDim].stride = one;
+  SmallVector<Range> loopBounds(getOutputRank());
+  for (int dim = 0; dim < getOutputRank(); ++dim) {
+    loopBounds[dim].offset = zero;
+    loopBounds[dim].size = getDimValue(builder, loc, getOutput(), dim);
+    loopBounds[dim].stride = one;
   }
   return loopBounds;
 }
@@ -1484,30 +1465,25 @@ FailureOr<TilingResult> WinogradFilterTransformOp::getTiledImplementation(
   const int cDim = getChannelDim();
   const int fDim = getFilterDim();
 
-  assert(offsets.size() == 2);
+  assert(offsets.size() == 4);
   SmallVector<OpFoldResult> inputOffsets(getInputRank(), zero);
-  SmallVector<OpFoldResult> outputOffsets(getOutputRank(), zero);
-  outputOffsets[2] = inputOffsets[cDim] = offsets[0];
-  outputOffsets[3] = inputOffsets[fDim] = offsets[1];
+  inputOffsets[cDim] = offsets[2];
+  inputOffsets[fDim] = offsets[3];
 
-  SmallVector<OpFoldResult> inputStrides(getInputRank(), one);
-  SmallVector<OpFoldResult> outputStrides(getOutputRank(), one);
-
-  assert(sizes.size() == 2);
+  assert(sizes.size() == 4);
   ArrayRef<int64_t> inputShape = getInputType().getShape();
-  ArrayRef<int64_t> outputShape = getOutputType().getShape();
   SmallVector<OpFoldResult> inputSizes =
       getAsOpFoldResult(builder.getIndexArrayAttr(inputShape));
-  SmallVector<OpFoldResult> outputSizes =
-      getAsOpFoldResult(builder.getIndexArrayAttr(outputShape));
-  outputSizes[2] = inputSizes[cDim] = sizes[0];
-  outputSizes[3] = inputSizes[fDim] = sizes[1];
+  inputSizes[cDim] = sizes[2];
+  inputSizes[fDim] = sizes[3];
 
   SmallVector<Value> tiledOperands;
+  SmallVector<OpFoldResult> inputStrides(getInputRank(), one);
   tiledOperands.emplace_back(getSlice(builder, loc, getInput(), inputOffsets,
                                       inputSizes, inputStrides));
-  tiledOperands.emplace_back(getSlice(builder, loc, getOutput(), outputOffsets,
-                                      outputSizes, outputStrides));
+  SmallVector<OpFoldResult> outputStrides(getOutputRank(), one);
+  tiledOperands.emplace_back(
+      getSlice(builder, loc, getOutput(), offsets, sizes, outputStrides));
 
   SmallVector<Type> resultTypes;
   if (hasPureTensorSemantics()) {
@@ -1527,15 +1503,17 @@ LogicalResult WinogradFilterTransformOp::getResultTilePosition(
   if (resultNumber != 0) {
     return failure();
   }
-  ArrayRef<int64_t> resultShape = getOutputType().getShape();
-  resultSizes = getAsOpFoldResult(builder.getIndexArrayAttr(resultShape));
-  resultOffsets =
-      SmallVector<OpFoldResult>(getOutputRank(), builder.getIndexAttr(0));
-  resultOffsets[2] = offsets[0];
-  resultOffsets[3] = offsets[1];
-  resultSizes[2] = sizes[0];
-  resultSizes[3] = sizes[1];
+  resultSizes = SmallVector<OpFoldResult>(sizes);
+  resultOffsets = SmallVector<OpFoldResult>(offsets);
   return success();
+}
+
+FailureOr<TilingResult> WinogradFilterTransformOp::generateResultTileValue(
+    OpBuilder &b, unsigned resultNumber, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes) {
+  int64_t numLoops = getIterationDomainRank();
+  return getTiledImplementation(b, offsets.take_front(numLoops),
+                                sizes.take_front(numLoops));
 }
 
 //===----------------------------------------------------------------------===//
@@ -1547,15 +1525,11 @@ WinogradOutputTransformOp::getIterationDomain(OpBuilder &builder) {
   Location loc = getLoc();
   Value zero = builder.create<arith::ConstantIndexOp>(loc, 0);
   Value one = builder.create<arith::ConstantIndexOp>(loc, 1);
-  Value source = getInput();
   SmallVector<Range> loopBounds(getIterationDomainRank());
-  int count = 0;
-  for (auto dim :
-       llvm::seq<int64_t>(getImageDimensions().size(), getInputRank())) {
-    loopBounds[count].offset = zero;
-    loopBounds[count].size = getDimValue(builder, loc, source, dim);
-    loopBounds[count].stride = one;
-    count++;
+  for (int dim = 0; dim < getInputRank(); ++dim) {
+    loopBounds[dim].offset = zero;
+    loopBounds[dim].size = getDimValue(builder, loc, getInput(), dim);
+    loopBounds[dim].stride = one;
   }
   return loopBounds;
 }
@@ -1575,45 +1549,29 @@ FailureOr<TilingResult> WinogradOutputTransformOp::getTiledImplementation(
   auto zero = builder.getIndexAttr(0);
   const int cDim = getChannelDim();
 
-  assert(offsets.size() == 4);
+  assert(offsets.size() == 6);
   const auto hDim = getImageDimensions()[0];
   const auto wDim = getImageDimensions()[1];
-  SmallVector<OpFoldResult> inputOffsets(getInputRank(), zero);
   SmallVector<OpFoldResult> outputOffsets(getOutputRank(), zero);
 
-  inputOffsets[2] = outputOffsets[0] = offsets[0];
-  inputOffsets[3] = offsets[1];
-  inputOffsets[4] = offsets[2];
-  inputOffsets[5] = outputOffsets[cDim] = offsets[3];
+  outputOffsets[0] = offsets[2];
+  outputOffsets[cDim] = offsets[5];
 
-  SmallVector<OpFoldResult> inputStrides(getInputRank(), one);
-  SmallVector<OpFoldResult> outputStrides(getOutputRank(), one);
-
-  ReifiedRankedShapedTypeDims reifiedResultShapes, reifiedInputShapes;
+  ReifiedRankedShapedTypeDims reifiedResultShapes;
   if (failed(reifyResultShapes(builder, reifiedResultShapes))) {
     return failure();
   }
   SmallVector<OpFoldResult> outputSizes = reifiedResultShapes[0];
-  if (failed(getStaticOrReifiedInputDims(builder, loc, getInput(),
-                                         reifiedInputShapes))) {
-    return failure();
-  }
-  SmallVector<OpFoldResult> inputSizes = reifiedInputShapes[0];
 
-  inputSizes[2] = outputSizes[0] = sizes[0];
-  inputSizes[5] = outputSizes[cDim] = sizes[3];
-
-  assert(sizes.size() == 4);
-  inputSizes[2] = outputSizes[0] = sizes[0];
-  inputSizes[3] = sizes[1];
-  inputSizes[4] = sizes[2];
-  inputSizes[5] = outputSizes[cDim] = sizes[3];
+  assert(sizes.size() == 6);
+  outputSizes[0] = sizes[2];
+  outputSizes[cDim] = sizes[5];
 
   auto hSizeAndOffset = getScaledSizeAndOffset(
-      builder, loc, sizes[1], offsets[1], outputSizes[hDim],
+      builder, loc, sizes[3], offsets[3], outputSizes[hDim],
       getOutputTileSize(), getOutputTileSize());
   auto wSizeAndOffset = getScaledSizeAndOffset(
-      builder, loc, sizes[2], offsets[2], outputSizes[wDim],
+      builder, loc, sizes[4], offsets[4], outputSizes[wDim],
       getOutputTileSize(), getOutputTileSize());
 
   outputSizes[hDim] = hSizeAndOffset.first;
@@ -1621,6 +1579,7 @@ FailureOr<TilingResult> WinogradOutputTransformOp::getTiledImplementation(
   outputOffsets[hDim] = hSizeAndOffset.second;
   outputOffsets[wDim] = wSizeAndOffset.second;
 
+  SmallVector<OpFoldResult> outputStrides(getOutputRank(), one);
   Value outputSlice = getSlice(builder, loc, getOutput(), outputOffsets,
                                outputSizes, outputStrides);
   // The image dims of the winograd.output_transform result will always be a
@@ -1628,11 +1587,11 @@ FailureOr<TilingResult> WinogradOutputTransformOp::getTiledImplementation(
   // maintain more static information in the IR.
   auto outSliceType = cast<ShapedType>(outputSlice.getType());
   SmallVector<int64_t> staticOutShape(outSliceType.getShape());
-  auto constSizeH = getConstantIntValue(sizes[1]);
+  auto constSizeH = getConstantIntValue(sizes[3]);
   if (constSizeH.has_value()) {
     staticOutShape[hDim] = constSizeH.value() * getOutputTileSize();
   }
-  auto constSizeW = getConstantIntValue(sizes[2]);
+  auto constSizeW = getConstantIntValue(sizes[4]);
   if (constSizeW.has_value()) {
     staticOutShape[wDim] = constSizeW.value() * getOutputTileSize();
   }
@@ -1640,8 +1599,9 @@ FailureOr<TilingResult> WinogradOutputTransformOp::getTiledImplementation(
       castValue(builder, loc, outputSlice, outSliceType.clone(staticOutShape));
 
   SmallVector<Value> tiledOperands;
-  tiledOperands.emplace_back(getSlice(builder, loc, getInput(), inputOffsets,
-                                      inputSizes, inputStrides));
+  SmallVector<OpFoldResult> inputStrides(getInputRank(), one);
+  tiledOperands.emplace_back(
+      getSlice(builder, loc, getInput(), offsets, sizes, inputStrides));
   tiledOperands.emplace_back(staticOutputSlice);
 
   SmallVector<Type, 4> resultTypes;
@@ -1672,19 +1632,19 @@ LogicalResult WinogradOutputTransformOp::getResultTilePosition(
     const auto hDim = getImageDimensions()[0];
     const auto wDim = getImageDimensions()[1];
     auto loc = getLoc();
-    resultOffsets[0] = offsets[0];
-    resultOffsets[cDim] = offsets[3];
-    resultSizes[0] = sizes[0];
-    resultSizes[cDim] = sizes[3];
+    resultOffsets[0] = offsets[2];
+    resultOffsets[cDim] = offsets[5];
+    resultSizes[0] = sizes[2];
+    resultSizes[cDim] = sizes[5];
     SmallVector<SmallVector<OpFoldResult>> reifiedResultShapes;
     if (failed(reifyResultShapes(builder, reifiedResultShapes))) {
       return failure();
     }
     auto hSizeAndOffset = getScaledSizeAndOffset(
-        builder, loc, sizes[1], offsets[1], reifiedResultShapes[0][hDim],
+        builder, loc, sizes[3], offsets[3], reifiedResultShapes[0][hDim],
         getOutputTileSize(), getOutputTileSize());
     auto wSizeAndOffset = getScaledSizeAndOffset(
-        builder, loc, sizes[2], offsets[2], reifiedResultShapes[0][wDim],
+        builder, loc, sizes[4], offsets[4], reifiedResultShapes[0][wDim],
         getOutputTileSize(), getOutputTileSize());
 
     resultSizes[hDim] = hSizeAndOffset.first;

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
@@ -1020,7 +1020,7 @@ func.func @winograd_filter_transform(%arg0: tensor<3x3x64x128xf32>) -> tensor<8x
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["iree_linalg_ext.winograd.filter_transform"]} in %module_op : (!transform.any_op) -> !transform.any_op
-    %1, %loops:2 = transform.structured.tile_using_for %0 tile_sizes [1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+    %1, %loops:2 = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
     transform.yield
   }
 }
@@ -1064,7 +1064,7 @@ func.func @winograd_filter_transform_memref(%arg0: memref<3x3x64x128xf32>, %arg1
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["iree_linalg_ext.winograd.filter_transform"]} in %module_op : (!transform.any_op) -> !transform.any_op
-    %1, %loops:2 = transform.structured.tile_using_for %0 tile_sizes [1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+    %1, %loops:2 = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
     transform.yield
   }
 }
@@ -1101,7 +1101,7 @@ func.func @winograd_filter_transform_dynamic(%arg0: tensor<3x3x?x?xf32>, %s0: in
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["iree_linalg_ext.winograd.filter_transform"]} in %module_op : (!transform.any_op) -> !transform.any_op
-    %1, %loops:2 = transform.structured.tile_using_for %0 tile_sizes [1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+    %1, %loops:2 = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
     transform.yield
   }
 }
@@ -1145,7 +1145,7 @@ func.func @winograd_filter_transform_fchw(%arg0: tensor<128x64x3x3xf32>) -> tens
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["iree_linalg_ext.winograd.filter_transform"]} in %module_op : (!transform.any_op) -> !transform.any_op
-    %1, %loops:2 = transform.structured.tile_using_for %0 tile_sizes [1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+    %1, %loops:2 = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
     transform.yield
   }
 }
@@ -1190,7 +1190,7 @@ func.func @winograd_input_transform(%arg0: tensor<1x10x10x1280xf32>) -> tensor<8
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["iree_linalg_ext.winograd.input_transform"]} in %module_op : (!transform.any_op) -> !transform.any_op
-    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
     transform.yield
   }
 }
@@ -1244,7 +1244,7 @@ func.func @winograd_input_transform_memref(%arg0: memref<1x10x10x1280xf32>, %arg
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["iree_linalg_ext.winograd.input_transform"]} in %module_op : (!transform.any_op) -> !transform.any_op
-    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
     transform.yield
   }
 }
@@ -1294,7 +1294,7 @@ func.func @winograd_input_transform_dynamic(%arg0: tensor<2x34x34x128xf32>, %i0:
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["iree_linalg_ext.winograd.input_transform"]} in %module_op : (!transform.any_op) -> !transform.any_op
-    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
     transform.yield
   }
 }
@@ -1363,7 +1363,7 @@ func.func @winograd_input_transform_nchw(%arg0: tensor<1x1280x10x10xf32>) -> ten
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["iree_linalg_ext.winograd.input_transform"]} in %module_op : (!transform.any_op) -> !transform.any_op
-    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
     transform.yield
   }
 }
@@ -1418,7 +1418,7 @@ func.func @winograd_output_transform(%arg0: tensor<8x8x1x2x2x32xf32>) -> tensor<
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["iree_linalg_ext.winograd.output_transform"]} in %module_op : (!transform.any_op) -> !transform.any_op
-    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
     transform.yield
   }
 }
@@ -1469,7 +1469,7 @@ func.func @winograd_output_transform_memref(%arg0: memref<8x8x1x2x2x32xf32>, %ar
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["iree_linalg_ext.winograd.output_transform"]} in %module_op : (!transform.any_op) -> !transform.any_op
-    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
     transform.yield
   }
 }
@@ -1513,7 +1513,7 @@ func.func @winograd_output_transform_dynamic(%arg0: tensor<8x8x?x?x?x?xf32>, %i0
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["iree_linalg_ext.winograd.output_transform"]} in %module_op : (!transform.any_op) -> !transform.any_op
-    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
     transform.yield
   }
 }
@@ -1578,7 +1578,7 @@ func.func @winograd_output_transform_nchw(%arg0: tensor<8x8x1x2x2x32xf32>) -> te
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["iree_linalg_ext.winograd.output_transform"]} in %module_op : (!transform.any_op) -> !transform.any_op
-    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
     transform.yield
   }
 }


### PR DESCRIPTION
This PR implements `generateResultTileValue` for the winograd input transform and filter transform ops. The PR also updates the tiling semantics for all winograd ops to include the input_tile dimensions in the iteration space. The input_tile dimensions are not intended to be tiled, but are included to match tile sizes for tileAndFuse.