### PR TITLE
Drop references to CLA check and Google security policy.

### DIFF
--- a/build_tools/github_actions/runner/README.md
+++ b/build_tools/github_actions/runner/README.md
@@ -110,8 +110,7 @@ code authorship and review.
 The runners for iree-org can be viewed in the
 [GitHub UI](https://github.com/organizations/iree-org/settings/actions/runners).
 Unfortunately, only organization admins have access to this page. Organization
-admin gives very broad privileges, so this set is necessarily kept very small by
-Google security policy.
+admin gives very broad privileges, so this set is necessarily kept small.
 
  ## Updating the Runners
 

--- a/docs/website/docs/developers/general/contributing.md
+++ b/docs/website/docs/developers/general/contributing.md
@@ -302,9 +302,11 @@ primary CI is configured in the
 In addition to the default runners GitHub provides, IREE uses
 [self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners)
 to run many of its workflow jobs. These enable access to additional compute and
-custom configurations such as accelerators. Configuration scripting is checked
-in to this repository (see the
-[README for that directory](https://github.com/iree-org/iree/blob/main/build_tools/github_actions/runner/README.md)).
+custom configurations such as accelerators.
+
+* Configuration for GCP runners is stored at
+[`build_tools/github_actions/runner/`](https://github.com/iree-org/iree/blob/main/build_tools/github_actions/runner/)
+* Configuration for other runners is done manually as needed
 
 #### CI behavior manipulation
 

--- a/docs/website/docs/developers/general/contributing.md
+++ b/docs/website/docs/developers/general/contributing.md
@@ -127,21 +127,6 @@ Signed-off-by: Random J Developer <random@developer.example.org>
 * See `.git/hooks/prepare-commit-msg.sample` for how to automatically
   add this using a [git hook](https://git-scm.com/docs/githooks)
 
-### :octicons-law-16: Contributor License Agreement
-
-!!! info - "CLA is being replaced with DCO. Both are enabled while we migrate."
-
-Contributions to this project must be accompanied by a Contributor License
-Agreement (CLA). Head over to <https://cla.developers.google.com/> to see
-your current agreements on file or to sign a new one.
-
-* You (or your employer) retain the copyright to your contribution; this simply
-  gives us permission to use and redistribute your contributions as part of the
-  project.
-* You generally only need to submit a CLA once, so if you've already submitted
-  one (even if it was for a different project), you probably don't need to do it
-  again.
-
 ### :octicons-people-16: AUTHORS, CODEOWNERS, and MAINTAINERS
 
 The [`AUTHORS` file](https://github.com/iree-org/iree/blob/main/AUTHORS) keeps


### PR DESCRIPTION
We have moved out of the Alphabet enterprise GitHub organization and are no longer required to use these.