### PR TITLE
[Flow] Improve dispatch name categorization around broadcast/transpose

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/annotate_dispatches.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/annotate_dispatches.mlir
@@ -512,6 +512,8 @@ flow.executable private @ex {
 
 // -----
 
+// Test transposing elementwise operation.
+
 #map = affine_map<(d0, d1) -> (d0)>
 #map1 = affine_map<(d0, d1) -> (d1, d0)>
 #map2 = affine_map<(d0, d1) -> (d0, d1)>
@@ -540,6 +542,8 @@ flow.executable private @ex {
 }
 
 // -----
+
+// Same as the above, but with the transpose map represented on the output.
 
 #map = affine_map<(d0, d1) -> (d1)>
 #map1 = affine_map<(d0, d1) -> (d0, d1)>
@@ -570,6 +574,8 @@ flow.executable private @ex {
 
 // -----
 
+// Test marking a strictly broadcasting elementwise operation as a broadcast.
+
 #map = affine_map<(d0, d1) -> (d1)>
 #map1 = affine_map<(d0, d1) -> (d0, d1)>
 flow.executable private @ex {
@@ -597,6 +603,8 @@ flow.executable private @ex {
 }
 
 // -----
+
+// Test a pure elementwise operation with a broadcasted operand.
 
 #map = affine_map<(d0, d1) -> (d0)>
 #map1 = affine_map<(d0, d1) -> (d0, d1)>
@@ -628,6 +636,8 @@ flow.executable private @ex {
 }
 
 // -----
+
+// Test a multi-result elementwise operation where one result is transposed.
 
 #map = affine_map<(d0, d1) -> (d0)>
 #map1 = affine_map<(d0, d1) -> (d0, d1)>


### PR DESCRIPTION
The dispatch names are largely to tell us
1) What kind of computation it is and
2) What did fusion come up with

This patch changes the way that broadcast and transpose is labeled to reflect what we want to know about each dispatch. Essentially, it tries to categorize dispatches as follows:

Elementwise: Dispatches that are pure elementwise (identity) maps with potentially some minor transposed/broadcasted operands. This indicates that the core memory bound operands are pure elementwise.

Transpose: Same as elementwise except either the input or output maps are permuted. This indicates that there is data movement happening.

Broadcast: Cases where the input maps are all strict projections of the output maps. This should only ever appear if something in fusion went off the rails.