### PR TITLE
Benchmark on any available runner (presubmit or postsubmit).

### DIFF
--- a/.github/workflows/benchmark_execution.yml
+++ b/.github/workflows/benchmark_execution.yml
@@ -119,7 +119,6 @@ jobs:
         benchmark: ${{ fromJSON(needs.generate_matrix.outputs.benchmark-matrix) }}
     runs-on:
       - self-hosted # must come first
-      - runner-group=${{ inputs.runner-group }}
       - environment=${{ inputs.runner-env }}
       - machine-type=${{ matrix.benchmark.device_name }}
     env:


### PR DESCRIPTION
We have two pixel-6-pro devices/runners, one labeled for `presubmit` one labeled for `postsubmit`. The presubmit runner has been offline for multiple days, causing benchmark runs on LLVM integrate PRs to time out waiting for a runner (and blocking other benchmark results from getting reported as PR comments).

Some options:
* (THIS PR) Switch presubmit benchmarks to also use postsubmit benchmark runners
* Switch only Android presubmit benchmarks to also use postsubmit benchmark runners
* Turn off Android benchmarks on presubmit (or just for LLVM integrate PRs)
* Switch benchmarks from pixel-6-pro to pixel-8-pro (we tried this before but pixel 6 was more stable than pixel 8... I'm not sure how much that level of stability is useful at this stage though, need to keep rolling forward with testing on recent hardware)
* Turn off Android benchmarks entirely

See also [this discussion on Discord](https://discord.com/channels/689900678990135345/1080178290188374049/1260359410035724402).

benchmark-extra: default