### PR TITLE
[Winograd] Allow for specifying input tile dimensions as innermost

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1842,14 +1842,24 @@ setWinogradRootConfig(mlir::FunctionOpInterface entryPointFn,
   assert(!getLoweringConfig(winogradOp) &&
          "expected lowering_config is not set");
   auto iterationRank = winogradOp.getIterationDomainRank();
-  SmallVector<int64_t> vecSizeHints(iterationRank, 1);
   DistributionHeuristicConfig distConfig;
+  SmallVector<int64_t> maxTileSizes(iterationRank, clDefaultDistTileSize);
+  maxTileSizes[0] = maxTileSizes[1] = 0;
+  SmallVector<int64_t> minTileSizes(iterationRank, 1);
+  minTileSizes[0] = minTileSizes[1] = 0;
+  SmallVector<int64_t> vecSizeHints(iterationRank, 1);
+  vecSizeHints[0] = vecSizeHints[1] = winogradOp.getInputTileSize();
   distConfig.vectorSizeHints = vecSizeHints;
+  distConfig.minTileSizes = minTileSizes;
+  distConfig.maxTileSizes = maxTileSizes;
   SmallVector<int64_t> distTileSizes =
       getDefaultDistributedLevelTileSizes(winogradOp, distConfig);
   TileSizesListType tileSizes;
   tileSizes.push_back(distTileSizes);
+  assert(distTileSizes[0] == 0 && distTileSizes[1] == 0 &&
+         "expected outer 2 distTileSizes to be 0");
   SmallVector<int64_t> vecTileSizes(iterationRank, 1);
+  vecTileSizes[0] = vecTileSizes[1] = winogradOp.getInputTileSize();
   tileSizes.push_back(vecTileSizes);
   // Dummy tiling config for reduction level.
   SmallVector<int64_t> reductionTileSizes(iterationRank, 0);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -586,8 +586,8 @@ void addCPULinalgExtTileAndVectorizePipeline(
     OpPassManager &funcPassManager, TilingConfig &tilingConfig,
     LLVMCPUPipelineOptions &pipelineOpt) {
   addTileAndDistributePasses(funcPassManager);
-  funcPassManager.addPass(
-      createLLVMCPUTilePass(tilingConfig.getVectorCommonParallelLevel()));
+  funcPassManager.addPass(createLLVMCPUTileAndFusePass(
+      tilingConfig.getVectorCommonParallelLevel()));
   // TODO: Remove the pass once we have PartialReductionOpInterface implemented
   // for AttentionOp.
   funcPassManager.addPass(

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
@@ -340,7 +340,7 @@ module {
     %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<8x8x2x6x6x128xf16>>
     %2 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 34, 34, 128], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<2x34x34x128xf32>> -> tensor<2x34x34x128xf32>
     %3 = tensor.empty() : tensor<8x8x2x6x6x128xf32>
-    %4 = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) ins(%2 : tensor<2x34x34x128xf32>) outs(%3 : tensor<8x8x2x6x6x128xf32>) -> tensor<8x8x2x6x6x128xf32>
+    %4 = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) input_tile_dimensions([0, 1]) ins(%2 : tensor<2x34x34x128xf32>) outs(%3 : tensor<8x8x2x6x6x128xf32>) -> tensor<8x8x2x6x6x128xf32>
     %5 = tensor.empty() : tensor<8x8x2x6x6x128xf16>
     %truncf = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d4, d5)>,
                                                 affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d4, d5)>],

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
@@ -1531,7 +1531,7 @@ module {
     return
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 6, 64], [1, 1, 1, 1], [0, 0, 0, 0]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 0, 1, 6, 64], [8, 8, 1, 1, 1, 1], [0, 0, 0, 0, 0, 0]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPULinalgExtTileAndVectorize>
 //      CHECK: func.func @winograd_output_transform()
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -1556,7 +1556,7 @@ module {
     return
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 6, 64], [1, 1, 1, 1], [0, 0, 0, 0]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 0, 1, 6, 64], [8, 8, 1, 1, 1, 1], [0, 0, 0, 0, 0, 0]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPULinalgExtTileAndVectorize>
 //      CHECK: func.func @winograd_input_transform()
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -1581,7 +1581,7 @@ module {
     return
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[8, 64], [1, 1], [0, 0]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 8, 64], [8, 8, 1, 1], [0, 0, 0, 0]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPULinalgExtTileAndVectorize>
 //      CHECK: func.func @winograd_filter_transform()
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
@@ -1526,7 +1526,7 @@ module {
     %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2x36x36x128xf16>>
     %2 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0, 0, 0], sizes = [8, 8, 2, 6, 6, 128], strides = [1, 1, 1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<8x8x2x6x6x128xf16>> -> tensor<8x8x2x6x6x128xf16>
     %3 = tensor.empty() : tensor<2x36x36x128xf16>
-    %4 = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) ins(%2 : tensor<8x8x2x6x6x128xf16>) outs(%3 : tensor<2x36x36x128xf16>) -> tensor<2x36x36x128xf16>
+    %4 = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) input_tile_dimensions([0, 1]) ins(%2 : tensor<8x8x2x6x6x128xf16>) outs(%3 : tensor<2x36x36x128xf16>) -> tensor<2x36x36x128xf16>
     flow.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0], sizes = [2, 36, 36, 128], strides = [1, 1, 1, 1] : tensor<2x36x36x128xf16> -> !flow.dispatch.tensor<writeonly:tensor<2x36x36x128xf16>>
     return
   }
@@ -1545,13 +1545,38 @@ module {
       data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
       native_vector_size = 64 : index, target_triple = "x86_64-none-elf"}>
 module {
+    func.func @winograd_output_transform_inner_tile() attributes {hal.executable.target = #executable_target_embedded_elf_x86_64_} {
+    %c0 = arith.constant 0 : index
+    %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2x6x6x128x8x8xf16>>
+    %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2x36x36x128xf16>>
+    %2 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0, 0, 0], sizes = [2, 6, 6, 128, 8, 8], strides = [1, 1, 1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<2x6x6x128x8x8xf16>> -> tensor<2x6x6x128x8x8xf16>
+    %3 = tensor.empty() : tensor<2x36x36x128xf16>
+    %4 = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) input_tile_dimensions([4, 5]) ins(%2 : tensor<2x6x6x128x8x8xf16>) outs(%3 : tensor<2x36x36x128xf16>) -> tensor<2x36x36x128xf16>
+    flow.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0], sizes = [2, 36, 36, 128], strides = [1, 1, 1, 1] : tensor<2x36x36x128xf16> -> !flow.dispatch.tensor<writeonly:tensor<2x36x36x128xf16>>
+    return
+  }
+}
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 0, 16, 0, 0], [1, 1, 1, 1, 8, 8], [0, 0, 0, 0, 0, 0]]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPULinalgExtTileAndVectorize>
+//      CHECK: func.func @winograd_output_transform_inner_tile()
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//      CHECK:   iree_linalg_ext.winograd.output_transform
+// CHECK-SAME:     {lowering_config = #[[CONFIG]]}
+
+// -----
+
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
+      cpu = "generic", cpu_features = "",
+      data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+      native_vector_size = 64 : index, target_triple = "x86_64-none-elf"}>
+module {
     func.func @winograd_input_transform() attributes {hal.executable.target = #executable_target_embedded_elf_x86_64_} {
     %c0 = arith.constant 0 : index
     %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2x34x34x128xf16>>
     %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<8x8x2x6x6x128xf16>>
     %2 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 34, 34, 128], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<2x34x34x128xf16>> -> tensor<2x34x34x128xf16>
     %3 = tensor.empty() : tensor<8x8x2x6x6x128xf16>
-    %4 = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) ins(%2 : tensor<2x34x34x128xf16>) outs(%3 : tensor<8x8x2x6x6x128xf16>) -> tensor<8x8x2x6x6x128xf16>
+    %4 = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) input_tile_dimensions([0, 1]) ins(%2 : tensor<2x34x34x128xf16>) outs(%3 : tensor<8x8x2x6x6x128xf16>) -> tensor<8x8x2x6x6x128xf16>
     flow.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0, 0, 0], sizes = [8, 8, 2, 6, 6, 128], strides = [1, 1, 1, 1, 1, 1] : tensor<8x8x2x6x6x128xf16> -> !flow.dispatch.tensor<writeonly:tensor<8x8x2x6x6x128xf16>>
     return
   }
@@ -1570,13 +1595,38 @@ module {
       data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
       native_vector_size = 64 : index, target_triple = "x86_64-none-elf"}>
 module {
+    func.func @winograd_input_transform_inner_tile() attributes {hal.executable.target = #executable_target_embedded_elf_x86_64_} {
+    %c0 = arith.constant 0 : index
+    %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2x34x34x128xf16>>
+    %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2x6x6x128x8x8xf16>>
+    %2 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 34, 34, 128], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<2x34x34x128xf16>> -> tensor<2x34x34x128xf16>
+    %3 = tensor.empty() : tensor<2x6x6x128x8x8xf16>
+    %4 = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) input_tile_dimensions([4, 5]) ins(%2 : tensor<2x34x34x128xf16>) outs(%3 : tensor<2x6x6x128x8x8xf16>) -> tensor<2x6x6x128x8x8xf16>
+    flow.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0, 0, 0], sizes = [2, 6, 6, 128, 8, 8], strides = [1, 1, 1, 1, 1, 1] : tensor<2x6x6x128x8x8xf16> -> !flow.dispatch.tensor<writeonly:tensor<2x6x6x128x8x8xf16>>
+    return
+  }
+}
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 0, 16, 0, 0], [1, 1, 1, 1, 8, 8], [0, 0, 0, 0, 0, 0]]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPULinalgExtTileAndVectorize>
+//      CHECK: func.func @winograd_input_transform_inner_tile()
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//      CHECK:   iree_linalg_ext.winograd.input_transform
+// CHECK-SAME:     {lowering_config = #[[CONFIG]]}
+
+// -----
+
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
+      cpu = "generic", cpu_features = "",
+      data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+      native_vector_size = 64 : index, target_triple = "x86_64-none-elf"}>
+module {
     func.func @winograd_filter_transform() attributes {hal.executable.target = #executable_target_embedded_elf_x86_64_} {
     %c0 = arith.constant 0 : index
     %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<3x3x64x128xf32>>
     %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<8x8x64x128xf32>>
     %2 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [3, 3, 64, 128], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<3x3x64x128xf32>> -> tensor<3x3x64x128xf32>
     %3 = tensor.empty() : tensor<8x8x64x128xf32>
-    %4 = iree_linalg_ext.winograd.filter_transform output_tile_size(6) kernel_size(3) kernel_dimensions([0, 1]) ins(%2 : tensor<3x3x64x128xf32>) outs(%3 : tensor<8x8x64x128xf32>) -> tensor<8x8x64x128xf32>
+    %4 = iree_linalg_ext.winograd.filter_transform output_tile_size(6) kernel_size(3) kernel_dimensions([0, 1]) input_tile_dimensions([0, 1]) ins(%2 : tensor<3x3x64x128xf32>) outs(%3 : tensor<8x8x64x128xf32>) -> tensor<8x8x64x128xf32>
     flow.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0], sizes = [8, 8, 64, 128], strides = [1, 1, 1, 1] : tensor<8x8x64x128xf32> -> !flow.dispatch.tensor<writeonly:tensor<8x8x64x128xf32>>
     return
   }
@@ -1584,6 +1634,31 @@ module {
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 8, 64], [8, 8, 1, 1], [0, 0, 0, 0]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPULinalgExtTileAndVectorize>
 //      CHECK: func.func @winograd_filter_transform()
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//      CHECK:   iree_linalg_ext.winograd.filter_transform
+// CHECK-SAME:     {lowering_config = #[[CONFIG]]}
+
+// -----
+
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
+      cpu = "generic", cpu_features = "",
+      data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+      native_vector_size = 64 : index, target_triple = "x86_64-none-elf"}>
+module {
+    func.func @winograd_filter_transform_inner_tile() attributes {hal.executable.target = #executable_target_embedded_elf_x86_64_} {
+    %c0 = arith.constant 0 : index
+    %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<3x3x64x128xf32>>
+    %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<64x128x8x8xf32>>
+    %2 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [3, 3, 64, 128], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<3x3x64x128xf32>> -> tensor<3x3x64x128xf32>
+    %3 = tensor.empty() : tensor<64x128x8x8xf32>
+    %4 = iree_linalg_ext.winograd.filter_transform output_tile_size(6) kernel_size(3) kernel_dimensions([0, 1]) input_tile_dimensions([2, 3]) ins(%2 : tensor<3x3x64x128xf32>) outs(%3 : tensor<64x128x8x8xf32>) -> tensor<64x128x8x8xf32>
+    flow.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0], sizes = [64, 128, 8, 8], strides = [1, 1, 1, 1] : tensor<64x128x8x8xf32> -> !flow.dispatch.tensor<writeonly:tensor<64x128x8x8xf32>>
+    return
+  }
+}
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 16, 0, 0], [1, 1, 8, 8], [0, 0, 0, 0]]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPULinalgExtTileAndVectorize>
+//      CHECK: func.func @winograd_filter_transform_inner_tile()
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   iree_linalg_ext.winograd.filter_transform
 // CHECK-SAME:     {lowering_config = #[[CONFIG]]}

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -899,19 +899,24 @@ static LogicalResult setWinogradOpConfig(IREE::GPU::TargetAttr target,
   std::array<int64_t, 3> workgroupSize = {32, 4, 4};
   int64_t iterationRank = op.getIterationDomainRank();
   SmallVector<int64_t> workgroupTileSizes(iterationRank, 4);
+  // Do not tile the input tile dimensions
+  workgroupTileSizes[0] = 0;
+  workgroupTileSizes[1] = 0;
   // Set batch workgroup size
-  workgroupTileSizes.front() = 1;
+  workgroupTileSizes[2] = 1;
   // Set input channel workgroup size
   workgroupTileSizes.back() = 32;
   if (isa<IREE::LinalgExt::WinogradFilterTransformOp>(op)) {
     // Set input channel workgroup size
-    workgroupTileSizes.front() = 32;
+    workgroupTileSizes[2] = 32;
     // Set output channel workgroup size
     workgroupTileSizes.back() = 16;
     workgroupSize = {16, 32, 1};
   }
   tileSizes.push_back(workgroupTileSizes);
   SmallVector<int64_t> threadTileSizes(iterationRank, 1);
+  threadTileSizes[0] = 0;
+  threadTileSizes[1] = 0;
   tileSizes.push_back(threadTileSizes);
   return setOpConfigAndEntryPointFnTranslation(entryPoint, op, tileSizes,
                                                pipeline, workgroupSize);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -918,6 +918,13 @@ static LogicalResult setWinogradOpConfig(IREE::GPU::TargetAttr target,
   threadTileSizes[0] = 0;
   threadTileSizes[1] = 0;
   tileSizes.push_back(threadTileSizes);
+  SmallVector<int64_t> inputTileDims(op.getInputTileDimensions());
+  SmallVector<int64_t> perm(inputTileDims);
+  perm.append(op.getNonInputTileDims());
+  perm = invertPermutationVector(perm);
+  for (auto &tiles : tileSizes) {
+    applyPermutationToVector(tiles, perm);
+  }
   return setOpConfigAndEntryPointFnTranslation(entryPoint, op, tileSizes,
                                                pipeline, workgroupSize);
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_winograd.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_winograd.mlir
@@ -13,7 +13,7 @@ module {
   }
 }
 
-//   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[32, 16], [1, 1]{{\]}}>
+//   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 32, 16], [0, 0, 1, 1]{{\]}}>
 //   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUWinogradVectorize workgroup_size = [16, 32, 1]>
 //       CHECK: func.func @winograd_filter_transform()
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
@@ -35,7 +35,7 @@ module {
   }
 }
 
-//   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 4, 4, 32], [1, 1, 1, 1]{{\]}}>
+//   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 1, 4, 4, 32], [0, 0, 1, 1, 1, 1]{{\]}}>
 //   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUWinogradVectorize workgroup_size = [32, 4, 4]>
 //       CHECK: func.func @winograd_input_transform()
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
@@ -57,7 +57,7 @@ module {
   }
 }
 
-//   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 4, 4, 32], [1, 1, 1, 1]{{\]}}>
+//   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 1, 4, 4, 32], [0, 0, 1, 1, 1, 1]{{\]}}>
 //   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUWinogradVectorize workgroup_size = [32, 4, 4]>
 //       CHECK: func.func @winograd_output_transform()
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_winograd.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_winograd.mlir
@@ -7,7 +7,7 @@ module {
     %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<8x8x64x128xf32>>
     %2 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [3, 3, 64, 128], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<3x3x64x128xf32>> -> tensor<3x3x64x128xf32>
     %3 = tensor.empty() : tensor<8x8x64x128xf32>
-    %4 = iree_linalg_ext.winograd.filter_transform output_tile_size(6) kernel_size(3) kernel_dimensions([0, 1]) ins(%2 : tensor<3x3x64x128xf32>) outs(%3 : tensor<8x8x64x128xf32>) -> tensor<8x8x64x128xf32>
+    %4 = iree_linalg_ext.winograd.filter_transform output_tile_size(6) kernel_size(3) kernel_dimensions([0, 1]) input_tile_dimensions([0, 1]) ins(%2 : tensor<3x3x64x128xf32>) outs(%3 : tensor<8x8x64x128xf32>) -> tensor<8x8x64x128xf32>
     flow.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0], sizes = [8, 8, 64, 128], strides = [1, 1, 1, 1] : tensor<8x8x64x128xf32> -> !flow.dispatch.tensor<writeonly:tensor<8x8x64x128xf32>>
     return
   }
@@ -23,13 +23,35 @@ module {
 // -----
 
 module {
+  func.func @winograd_filter_transform_inner_tile() {
+    %c0 = arith.constant 0 : index
+    %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<3x3x64x128xf32>>
+    %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<64x128x8x8xf32>>
+    %2 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [3, 3, 64, 128], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<3x3x64x128xf32>> -> tensor<3x3x64x128xf32>
+    %3 = tensor.empty() : tensor<64x128x8x8xf32>
+    %4 = iree_linalg_ext.winograd.filter_transform output_tile_size(6) kernel_size(3) kernel_dimensions([0, 1]) input_tile_dimensions([2, 3]) ins(%2 : tensor<3x3x64x128xf32>) outs(%3 : tensor<64x128x8x8xf32>) -> tensor<64x128x8x8xf32>
+    flow.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0], sizes = [64, 128, 8, 8], strides = [1, 1, 1, 1] : tensor<64x128x8x8xf32> -> !flow.dispatch.tensor<writeonly:tensor<64x128x8x8xf32>>
+    return
+  }
+}
+
+//   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[32, 16, 0, 0], [1, 1, 0, 0]{{\]}}>
+//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUWinogradVectorize workgroup_size = [16, 32, 1]>
+//       CHECK: func.func @winograd_filter_transform_inner_tile()
+//  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
+//       CHECK:   iree_linalg_ext.winograd.filter_transform
+//  CHECK-SAME:       lowering_config = #[[$CONFIG]]
+
+// -----
+
+module {
   func.func @winograd_input_transform() {
     %c0 = arith.constant 0 : index
     %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2x34x34x128xf16>>
     %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<8x8x2x6x6x128xf16>>
     %2 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 34, 34, 128], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<2x34x34x128xf16>> -> tensor<2x34x34x128xf16>
     %3 = tensor.empty() : tensor<8x8x2x6x6x128xf16>
-    %4 = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) ins(%2 : tensor<2x34x34x128xf16>) outs(%3 : tensor<8x8x2x6x6x128xf16>) -> tensor<8x8x2x6x6x128xf16>
+    %4 = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) input_tile_dimensions([0, 1]) ins(%2 : tensor<2x34x34x128xf16>) outs(%3 : tensor<8x8x2x6x6x128xf16>) -> tensor<8x8x2x6x6x128xf16>
     flow.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0, 0, 0], sizes = [8, 8, 2, 6, 6, 128], strides = [1, 1, 1, 1, 1, 1] : tensor<8x8x2x6x6x128xf16> -> !flow.dispatch.tensor<writeonly:tensor<8x8x2x6x6x128xf16>>
     return
   }
@@ -45,13 +67,35 @@ module {
 // -----
 
 module {
+  func.func @winograd_input_transform_inner_tile() {
+    %c0 = arith.constant 0 : index
+    %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2x34x34x128xf16>>
+    %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2x6x6x128x8x8xf16>>
+    %2 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 34, 34, 128], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<2x34x34x128xf16>> -> tensor<2x34x34x128xf16>
+    %3 = tensor.empty() : tensor<2x6x6x128x8x8xf16>
+    %4 = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) input_tile_dimensions([4, 5]) ins(%2 : tensor<2x34x34x128xf16>) outs(%3 : tensor<2x6x6x128x8x8xf16>) -> tensor<2x6x6x128x8x8xf16>
+    flow.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0, 0, 0], sizes = [2, 6, 6, 128, 8, 8], strides = [1, 1, 1, 1, 1, 1] : tensor<2x6x6x128x8x8xf16> -> !flow.dispatch.tensor<writeonly:tensor<2x6x6x128x8x8xf16>>
+    return
+  }
+}
+
+//   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 4, 4, 32, 0, 0], [1, 1, 1, 1, 0, 0]{{\]}}>
+//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUWinogradVectorize workgroup_size = [32, 4, 4]>
+//       CHECK: func.func @winograd_input_transform_inner_tile()
+//  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
+//       CHECK:   iree_linalg_ext.winograd.input_transform
+//  CHECK-SAME:       lowering_config = #[[$CONFIG]]
+
+// -----
+
+module {
   func.func @winograd_output_transform() {
     %c0 = arith.constant 0 : index
     %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<8x8x2x6x6x128xf16>>
     %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2x36x36x128xf16>>
     %2 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0, 0, 0], sizes = [8, 8, 2, 6, 6, 128], strides = [1, 1, 1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<8x8x2x6x6x128xf16>> -> tensor<8x8x2x6x6x128xf16>
     %3 = tensor.empty() : tensor<2x36x36x128xf16>
-    %4 = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) ins(%2 : tensor<8x8x2x6x6x128xf16>) outs(%3 : tensor<2x36x36x128xf16>) -> tensor<2x36x36x128xf16>
+    %4 = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) input_tile_dimensions([0, 1]) ins(%2 : tensor<8x8x2x6x6x128xf16>) outs(%3 : tensor<2x36x36x128xf16>) -> tensor<2x36x36x128xf16>
     flow.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0], sizes = [2, 36, 36, 128], strides = [1, 1, 1, 1] : tensor<2x36x36x128xf16> -> !flow.dispatch.tensor<writeonly:tensor<2x36x36x128xf16>>
     return
   }
@@ -60,6 +104,28 @@ module {
 //   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 1, 4, 4, 32], [0, 0, 1, 1, 1, 1]{{\]}}>
 //   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUWinogradVectorize workgroup_size = [32, 4, 4]>
 //       CHECK: func.func @winograd_output_transform()
+//  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
+//       CHECK:   iree_linalg_ext.winograd.output_transform
+//  CHECK-SAME:       lowering_config = #[[$CONFIG]]
+
+// -----
+
+module {
+  func.func @winograd_output_transform_inner_tile() {
+    %c0 = arith.constant 0 : index
+    %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2x6x6x128x8x8xf16>>
+    %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2x36x36x128xf16>>
+    %2 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0, 0, 0], sizes = [2, 6, 6, 128, 8, 8], strides = [1, 1, 1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<2x6x6x128x8x8xf16>> -> tensor<2x6x6x128x8x8xf16>
+    %3 = tensor.empty() : tensor<2x36x36x128xf16>
+    %4 = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) input_tile_dimensions([4, 5]) ins(%2 : tensor<2x6x6x128x8x8xf16>) outs(%3 : tensor<2x36x36x128xf16>) -> tensor<2x36x36x128xf16>
+    flow.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0], sizes = [2, 36, 36, 128], strides = [1, 1, 1, 1] : tensor<2x36x36x128xf16> -> !flow.dispatch.tensor<writeonly:tensor<2x36x36x128xf16>>
+    return
+  }
+}
+
+//   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 4, 4, 32, 0, 0], [1, 1, 1, 1, 0, 0]{{\]}}>
+//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUWinogradVectorize workgroup_size = [32, 4, 4]>
+//       CHECK: func.func @winograd_output_transform_inner_tile()
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   iree_linalg_ext.winograd.output_transform
 //  CHECK-SAME:       lowering_config = #[[$CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/winograd_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/winograd_pipeline_test.mlir
@@ -7,7 +7,7 @@ module {
     %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<8x8x64x128xf32>>
     %2 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [3, 3, 64, 128], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<3x3x64x128xf32>> -> tensor<3x3x64x128xf32>
     %3 = tensor.empty() : tensor<8x8x64x128xf32>
-    %4 = iree_linalg_ext.winograd.filter_transform output_tile_size(6) kernel_size(3) kernel_dimensions([0, 1]) ins(%2 : tensor<3x3x64x128xf32>) outs(%3 : tensor<8x8x64x128xf32>) -> tensor<8x8x64x128xf32>
+    %4 = iree_linalg_ext.winograd.filter_transform output_tile_size(6) kernel_size(3) kernel_dimensions([0, 1]) input_tile_dimensions([0, 1]) ins(%2 : tensor<3x3x64x128xf32>) outs(%3 : tensor<8x8x64x128xf32>) -> tensor<8x8x64x128xf32>
     flow.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0], sizes = [8, 8, 64, 128], strides = [1, 1, 1, 1] : tensor<8x8x64x128xf32> -> !flow.dispatch.tensor<writeonly:tensor<8x8x64x128xf32>>
     return
   }
@@ -32,7 +32,7 @@ module {
     %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<8x8x2x6x6x128xf16>>
     %2 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 34, 34, 128], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<2x34x34x128xf16>> -> tensor<2x34x34x128xf16>
     %3 = tensor.empty() : tensor<8x8x2x6x6x128xf16>
-    %4 = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) ins(%2 : tensor<2x34x34x128xf16>) outs(%3 : tensor<8x8x2x6x6x128xf16>) -> tensor<8x8x2x6x6x128xf16>
+    %4 = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) input_tile_dimensions([0, 1]) ins(%2 : tensor<2x34x34x128xf16>) outs(%3 : tensor<8x8x2x6x6x128xf16>) -> tensor<8x8x2x6x6x128xf16>
     flow.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0, 0, 0], sizes = [8, 8, 2, 6, 6, 128], strides = [1, 1, 1, 1, 1, 1] : tensor<8x8x2x6x6x128xf16> -> !flow.dispatch.tensor<writeonly:tensor<8x8x2x6x6x128xf16>>
     return
   }
@@ -58,7 +58,7 @@ module {
     %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2x36x36x128xf16>>
     %2 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0, 0, 0], sizes = [8, 8, 2, 6, 6, 128], strides = [1, 1, 1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<8x8x2x6x6x128xf16>> -> tensor<8x8x2x6x6x128xf16>
     %3 = tensor.empty() : tensor<2x36x36x128xf16>
-    %4 = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) ins(%2 : tensor<8x8x2x6x6x128xf16>) outs(%3 : tensor<2x36x36x128xf16>) -> tensor<2x36x36x128xf16>
+    %4 = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) input_tile_dimensions([0, 1]) ins(%2 : tensor<8x8x2x6x6x128xf16>) outs(%3 : tensor<2x36x36x128xf16>) -> tensor<2x36x36x128xf16>
     flow.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0], sizes = [2, 36, 36, 128], strides = [1, 1, 1, 1] : tensor<2x36x36x128xf16> -> !flow.dispatch.tensor<writeonly:tensor<2x36x36x128xf16>>
     return
   }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -1054,7 +1054,8 @@ static LogicalResult setWinogradOpConfig(spirv::ResourceLimitsAttr limits,
   // sizes found in the StableDiffusion model.
   auto pipeline = CodeGenPipeline::SPIRVWinogradVectorize;
   std::array<int64_t, 3> workgroupSize = {32, 4, 4};
-  TileSizesListType tileSizes = {{1, 0, 0, 32}, {1, 1, 1, 1}, {0, 0, 0, 0}};
+  TileSizesListType tileSizes = {
+      {0, 0, 1, 0, 0, 32}, {0, 0, 1, 1, 1, 1}, {0, 0, 0, 0, 0, 0}};
   return setOpConfigAndEntryPointFnTranslation(
       op->getParentOfType<mlir::FunctionOpInterface>(), op, tileSizes, pipeline,
       workgroupSize);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ext_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ext_ops.mlir
@@ -123,7 +123,7 @@ module {
   }
 }
 
-//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 0, 0, 32], [1, 1, 1, 1], [0, 0, 0, 0]]>
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 1, 0, 0, 32], [0, 0, 1, 1, 1, 1], [0, 0, 0, 0, 0, 0]]>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVWinogradVectorize workgroup_size = [32, 4, 4]>
 //       CHECK: func.func @winograd_input_transform()
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -145,7 +145,7 @@ module {
   }
 }
 
-//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 0, 0, 32], [1, 1, 1, 1], [0, 0, 0, 0]]>
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 1, 0, 0, 32], [0, 0, 1, 1, 1, 1], [0, 0, 0, 0, 0, 0]]>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVWinogradVectorize workgroup_size = [32, 4, 4]>
 //       CHECK: func.func @winograd_output_transform()
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ext_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ext_ops.mlir
@@ -117,7 +117,7 @@ module {
     %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<8x8x2x6x6x128xf16>>
     %2 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 34, 34, 128], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<2x34x34x128xf16>> -> tensor<2x34x34x128xf16>
     %3 = tensor.empty() : tensor<8x8x2x6x6x128xf16>
-    %4 = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) ins(%2 : tensor<2x34x34x128xf16>) outs(%3 : tensor<8x8x2x6x6x128xf16>) -> tensor<8x8x2x6x6x128xf16>
+    %4 = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) input_tile_dimensions([0, 1]) ins(%2 : tensor<2x34x34x128xf16>) outs(%3 : tensor<8x8x2x6x6x128xf16>) -> tensor<8x8x2x6x6x128xf16>
     flow.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0, 0, 0], sizes = [8, 8, 2, 6, 6, 128], strides = [1, 1, 1, 1, 1, 1] : tensor<8x8x2x6x6x128xf16> -> !flow.dispatch.tensor<writeonly:tensor<8x8x2x6x6x128xf16>>
     return
   }
@@ -133,13 +133,35 @@ module {
 // -----
 #executable_target_vulkan_spirvfb = #hal.executable.target<"vulkan-spirv", "vulkan-spirvfb", {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Shader], []>, #spirv.resource_limits<max_compute_shared_memory_size = 32768, max_compute_workgroup_invocations = 512, max_compute_workgroup_size = [512, 512, 512], subgroup_size = 16>>}>
 module {
+    func.func @winograd_input_transform_inner_tile() attributes {hal.executable.target = #executable_target_vulkan_spirvfb} {
+    %c0 = arith.constant 0 : index
+    %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2x34x34x128xf16>>
+    %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2x6x6x128x8x8xf16>>
+    %2 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 34, 34, 128], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<2x34x34x128xf16>> -> tensor<2x34x34x128xf16>
+    %3 = tensor.empty() : tensor<2x6x6x128x8x8xf16>
+    %4 = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) input_tile_dimensions([4, 5]) ins(%2 : tensor<2x34x34x128xf16>) outs(%3 : tensor<2x6x6x128x8x8xf16>) -> tensor<2x6x6x128x8x8xf16>
+    flow.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0, 0, 0], sizes = [2, 6, 6, 128, 8, 8], strides = [1, 1, 1, 1, 1, 1] : tensor<2x6x6x128x8x8xf16> -> !flow.dispatch.tensor<writeonly:tensor<2x6x6x128x8x8xf16>>
+    return
+  }
+}
+
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 0, 0, 32, 0, 0], [1, 1, 1, 1, 0, 0], [0, 0, 0, 0, 0, 0]]>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVWinogradVectorize workgroup_size = [32, 4, 4]>
+//       CHECK: func.func @winograd_input_transform_inner_tile()
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//       CHECK:   iree_linalg_ext.winograd.input_transform
+//  CHECK-SAME:       lowering_config = #[[CONFIG]]
+
+// -----
+#executable_target_vulkan_spirvfb = #hal.executable.target<"vulkan-spirv", "vulkan-spirvfb", {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Shader], []>, #spirv.resource_limits<max_compute_shared_memory_size = 32768, max_compute_workgroup_invocations = 512, max_compute_workgroup_size = [512, 512, 512], subgroup_size = 16>>}>
+module {
     func.func @winograd_output_transform() attributes {hal.executable.target = #executable_target_vulkan_spirvfb} {
     %c0 = arith.constant 0 : index
     %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<8x8x2x6x6x128xf16>>
     %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2x36x36x128xf16>>
     %2 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0, 0, 0], sizes = [8, 8, 2, 6, 6, 128], strides = [1, 1, 1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<8x8x2x6x6x128xf16>> -> tensor<8x8x2x6x6x128xf16>
     %3 = tensor.empty() : tensor<2x36x36x128xf16>
-    %4 = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) ins(%2 : tensor<8x8x2x6x6x128xf16>) outs(%3 : tensor<2x36x36x128xf16>) -> tensor<2x36x36x128xf16>
+    %4 = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) input_tile_dimensions([0, 1]) ins(%2 : tensor<8x8x2x6x6x128xf16>) outs(%3 : tensor<2x36x36x128xf16>) -> tensor<2x36x36x128xf16>
     flow.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0], sizes = [2, 36, 36, 128], strides = [1, 1, 1, 1] : tensor<2x36x36x128xf16> -> !flow.dispatch.tensor<writeonly:tensor<2x36x36x128xf16>>
     return
   }
@@ -148,6 +170,28 @@ module {
 //   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 1, 0, 0, 32], [0, 0, 1, 1, 1, 1], [0, 0, 0, 0, 0, 0]]>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVWinogradVectorize workgroup_size = [32, 4, 4]>
 //       CHECK: func.func @winograd_output_transform()
+//  CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//       CHECK:   iree_linalg_ext.winograd.output_transform
+//  CHECK-SAME:       lowering_config = #[[CONFIG]]
+
+// -----
+#executable_target_vulkan_spirvfb = #hal.executable.target<"vulkan-spirv", "vulkan-spirvfb", {spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Shader], []>, #spirv.resource_limits<max_compute_shared_memory_size = 32768, max_compute_workgroup_invocations = 512, max_compute_workgroup_size = [512, 512, 512], subgroup_size = 16>>}>
+module {
+    func.func @winograd_output_transform_inner_tile() attributes {hal.executable.target = #executable_target_vulkan_spirvfb} {
+    %c0 = arith.constant 0 : index
+    %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2x6x6x128x8x8xf16>>
+    %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2x36x36x128xf16>>
+    %2 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0, 0, 0], sizes = [2, 6, 6, 128, 8, 8], strides = [1, 1, 1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<2x6x6x128x8x8xf16>> -> tensor<2x6x6x128x8x8xf16>
+    %3 = tensor.empty() : tensor<2x36x36x128xf16>
+    %4 = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) input_tile_dimensions([4, 5]) ins(%2 : tensor<2x6x6x128x8x8xf16>) outs(%3 : tensor<2x36x36x128xf16>) -> tensor<2x36x36x128xf16>
+    flow.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0], sizes = [2, 36, 36, 128], strides = [1, 1, 1, 1] : tensor<2x36x36x128xf16> -> !flow.dispatch.tensor<writeonly:tensor<2x36x36x128xf16>>
+    return
+  }
+}
+
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 0, 0, 32, 0, 0], [1, 1, 1, 1, 0, 0], [0, 0, 0, 0, 0, 0]]>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVWinogradVectorize workgroup_size = [32, 4, 4]>
+//       CHECK: func.func @winograd_output_transform_inner_tile()
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK:   iree_linalg_ext.winograd.output_transform
 //  CHECK-SAME:       lowering_config = #[[CONFIG]]

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -5,13 +5,17 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include <cstdint>
 
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtInterfaces.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/IndexingUtils.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/SmallVectorExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/MathExtras.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -20,6 +24,7 @@
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/Dialect/Utils/StructuredOpsUtils.h"
 #include "mlir/IR/AffineExpr.h"
@@ -977,8 +982,31 @@ LogicalResult UnPackOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// Winograd op utilities
+//===----------------------------------------------------------------------===//
+
+template <typename WinogradOp>
+static SmallVector<int64_t> getNonInputTileDims(WinogradOp op) {
+  static_assert(llvm::is_one_of<WinogradOp, WinogradInputTransformOp,
+                                WinogradFilterTransformOp,
+                                WinogradOutputTransformOp>::value,
+                "applies to only winograd transform operations");
+  SetVector<int64_t> inputTileDims(op.getInputTileDimensions().begin(),
+                                   op.getInputTileDimensions().end());
+  SmallVector<int64_t> dims = llvm::to_vector(
+      llvm::seq<int64_t>(op.getTransformedOperandType().getRank()));
+  SetVector<int64_t> dimSet(dims.begin(), dims.end());
+  dimSet.set_subtract(inputTileDims);
+  return dimSet.takeVector();
+}
+
+//===----------------------------------------------------------------------===//
 // WinogradInputTransformOp
 //===----------------------------------------------------------------------===//
+
+SmallVector<int64_t> WinogradInputTransformOp::getNonInputTileDims() {
+  return LinalgExt::getNonInputTileDims(*this);
+}
 
 LogicalResult WinogradInputTransformOp::verify() {
   Operation *op = getOperation();
@@ -1056,7 +1084,10 @@ LogicalResult WinogradInputTransformOp::verify() {
   if (isNchw()) {
     permute<Permutation::TTNCHW_TO_TTNHWC>(expectedOutputShape);
   }
-  ArrayRef<int64_t> outputShape = outputType.getShape();
+  SmallVector<int64_t> outputShape(outputType.getShape());
+  SmallVector<int64_t> perm(getInputTileDimensions());
+  perm.append(getNonInputTileDims());
+  applyPermutationToVector(outputShape, perm);
   if (failed(verifyCompatibleShape(expectedOutputShape, outputShape))) {
     return op->emitOpError("incompatible output shape");
   }
@@ -1077,6 +1108,10 @@ LogicalResult WinogradInputTransformOp::reifyResultShapes(
 //===----------------------------------------------------------------------===//
 // WinogradFilterTransformOp
 //===----------------------------------------------------------------------===//
+
+SmallVector<int64_t> WinogradFilterTransformOp::getNonInputTileDims() {
+  return LinalgExt::getNonInputTileDims(*this);
+}
 
 LogicalResult WinogradFilterTransformOp::verify() {
   Operation *op = getOperation();
@@ -1149,7 +1184,10 @@ LogicalResult WinogradFilterTransformOp::verify() {
   if (isFchw()) {
     permute<Permutation::TTFC_TO_TTCF>(expectedOutputShape);
   }
-  ArrayRef<int64_t> outputShape = outputType.getShape();
+  SmallVector<int64_t> outputShape(outputType.getShape());
+  SmallVector<int64_t> perm(getInputTileDimensions());
+  perm.append(getNonInputTileDims());
+  applyPermutationToVector(outputShape, perm);
   if (failed(verifyCompatibleShape(expectedOutputShape, outputShape))) {
     return op->emitOpError("incompatible output shape");
   }
@@ -1170,6 +1208,10 @@ LogicalResult WinogradFilterTransformOp::reifyResultShapes(
 //===----------------------------------------------------------------------===//
 // WinogradOutputTransformOp
 //===----------------------------------------------------------------------===//
+
+SmallVector<int64_t> WinogradOutputTransformOp::getNonInputTileDims() {
+  return LinalgExt::getNonInputTileDims(*this);
+}
 
 LogicalResult WinogradOutputTransformOp::verify() {
   Operation *op = getOperation();
@@ -1207,7 +1249,6 @@ LogicalResult WinogradOutputTransformOp::verify() {
     }
     return success();
   }
-  ArrayRef<int64_t> outputShape = outputType.getShape();
   if (outputType.getElementType() != inputType.getElementType()) {
     return op->emitOpError(
         "expected input/output element types to be identical");
@@ -1227,6 +1268,9 @@ LogicalResult WinogradOutputTransformOp::verify() {
         "expect image dimensions to be either [1, 2] or [2, 3]");
   }
   SmallVector<int64_t> inputShape(inputType.getShape());
+  SmallVector<int64_t> perm(getInputTileDimensions());
+  perm.append(getNonInputTileDims());
+  applyPermutationToVector(inputShape, perm);
   if (isNchw()) {
     permute<Permutation::TTNHWC_TO_TTNCHW>(inputShape);
   }
@@ -1244,7 +1288,8 @@ LogicalResult WinogradOutputTransformOp::verify() {
       expectedOutputShape[outputIndex] = getOutputTileSize() * inputShape[i];
     }
   }
-  if (failed(verifyCompatibleShape(expectedOutputShape, outputShape))) {
+  if (failed(
+          verifyCompatibleShape(expectedOutputShape, outputType.getShape()))) {
     return op->emitOpError("incompatible output shape");
   }
   return success();

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -1223,7 +1223,8 @@ def IREELinalgExt_WinogradInputTransformOp : IREELinalgExt_Op<"winograd.input_tr
       ["getIterationDomain",
        "getLoopIteratorTypes",
        "getResultTilePosition",
-       "getTiledImplementation"]>]> {
+       "getTiledImplementation",
+       "generateResultTileValue"]>]> {
   let summary = "Winograd Input Transform operator";
   let description = [{
     This operator is part of the first step in converting a convolution to
@@ -1318,7 +1319,7 @@ def IREELinalgExt_WinogradInputTransformOp : IREELinalgExt_Op<"winograd.input_tr
       return isNhwc() ? 3 : 1;
     }
     int64_t getIterationDomainRank() {
-      return getOutputRank() - getImageDimensions().size();
+      return getOutputRank();
     }
     // Method to implement for specifying output range for
     // DestinationStyleOpInterface
@@ -1334,7 +1335,8 @@ def IREELinalgExt_WinogradFilterTransformOp : IREELinalgExt_Op<"winograd.filter_
       ["getIterationDomain",
        "getLoopIteratorTypes",
        "getResultTilePosition",
-       "getTiledImplementation"]>]> {
+       "getTiledImplementation",
+       "generateResultTileValue"]>]> {
   let summary = "Winograd Filter Transform operator";
   let description = [{
     This operator is part of the first step in converting a convolution to
@@ -1434,7 +1436,7 @@ def IREELinalgExt_WinogradFilterTransformOp : IREELinalgExt_Op<"winograd.filter_
       return isHwcf() ? 3 : 0;
     }
     int64_t getIterationDomainRank() {
-      return getInputRank() - getKernelDimensions().size();
+      return getOutputRank();
     }
     // Method to implement for specifying output range for
     // DestinationStyleOpInterface
@@ -1546,7 +1548,7 @@ def IREELinalgExt_WinogradOutputTransformOp : IREELinalgExt_Op<"winograd.output_
       return getOutputType().getRank();
     }
     int64_t getIterationDomainRank() {
-      return getInputRank() - getImageDimensions().size();
+      return getInputRank();
     }
     int64_t getInputTileSize() {
       return getOutputTileSize() + getKernelSize() - 1;

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -1243,13 +1243,15 @@ def IREELinalgExt_WinogradInputTransformOp : IREELinalgExt_Op<"winograd.input_tr
                        Variadic<AnyShaped>:$outputs,
                        I64Attr:$output_tile_size,
                        I64Attr:$kernel_size,
-                       DenseI64ArrayAttr:$image_dimensions
+                       DenseI64ArrayAttr:$image_dimensions,
+                       DenseI64ArrayAttr:$input_tile_dimensions
   );
 
   let builders = [
     OpBuilder<(ins "ValueRange":$inputs, "ValueRange":$outputs,
       CArg<"int64_t", "8">:$output_tile_size, CArg<"int64_t", "3">:$kernel_size,
-      CArg<"ArrayRef<int64_t>", "{1, 2}">:$image_dimensions)>
+      CArg<"ArrayRef<int64_t>", "{1, 2}">:$image_dimensions,
+      CArg<"ArrayRef<int64_t>", "{0, 1}">:$input_tile_dimensions)>
   ];
 
   let results = (outs Variadic<AnyRankedTensor>:$result);
@@ -1259,6 +1261,7 @@ def IREELinalgExt_WinogradInputTransformOp : IREELinalgExt_Op<"winograd.input_tr
     `output_tile_size` `(` $output_tile_size `)`
     `kernel_size` `(` $kernel_size `)`
     `image_dimensions` `(` $image_dimensions `)`
+    `input_tile_dimensions` `(` $input_tile_dimensions `)`
     `ins` `(` $inputs `:` type($inputs) `)`
     `outs` `(` $outputs `:` type($outputs) `)`
     (`->` type($result)^)?
@@ -1318,6 +1321,8 @@ def IREELinalgExt_WinogradInputTransformOp : IREELinalgExt_Op<"winograd.input_tr
     int getChannelDim() {
       return isNhwc() ? 3 : 1;
     }
+    // Utility for mapping non input tile dims to the actual result dims
+    SmallVector<int64_t> getNonInputTileDims();
     int64_t getIterationDomainRank() {
       return getOutputRank();
     }
@@ -1355,13 +1360,15 @@ def IREELinalgExt_WinogradFilterTransformOp : IREELinalgExt_Op<"winograd.filter_
                        Variadic<AnyShaped>:$outputs,
                        I64Attr:$output_tile_size,
                        I64Attr:$kernel_size,
-                       DenseI64ArrayAttr:$kernel_dimensions
+                       DenseI64ArrayAttr:$kernel_dimensions,
+                       DenseI64ArrayAttr:$input_tile_dimensions
   );
 
   let builders = [
     OpBuilder<(ins "ValueRange":$inputs, "ValueRange":$outputs,
       CArg<"int64_t", "8">:$output_tile_size, CArg<"int64_t", "3">:$kernel_size,
-      CArg<"ArrayRef<int64_t>", "{0, 1}">:$kernel_dimensions)>
+      CArg<"ArrayRef<int64_t>", "{0, 1}">:$kernel_dimensions,
+      CArg<"ArrayRef<int64_t>", "{0, 1}">:$input_tile_dimensions)>
   ];
 
   let results = (outs Variadic<AnyRankedTensor>:$result);
@@ -1371,6 +1378,7 @@ def IREELinalgExt_WinogradFilterTransformOp : IREELinalgExt_Op<"winograd.filter_
     `output_tile_size` `(` $output_tile_size `)`
     `kernel_size` `(` $kernel_size `)`
     `kernel_dimensions` `(` $kernel_dimensions `)`
+    `input_tile_dimensions` `(` $input_tile_dimensions `)`
     `ins` `(` $inputs `:` type($inputs) `)`
     `outs` `(` $outputs `:` type($outputs) `)`
     (`->` type($result)^)?
@@ -1435,6 +1443,8 @@ def IREELinalgExt_WinogradFilterTransformOp : IREELinalgExt_Op<"winograd.filter_
     int getFilterDim() {
       return isHwcf() ? 3 : 0;
     }
+    // Utility for mapping non input tile dims to the actual result dims
+    SmallVector<int64_t> getNonInputTileDims();
     int64_t getIterationDomainRank() {
       return getOutputRank();
     }
@@ -1475,13 +1485,15 @@ def IREELinalgExt_WinogradOutputTransformOp : IREELinalgExt_Op<"winograd.output_
                        Variadic<AnyShaped>:$outputs,
                        I64Attr:$output_tile_size,
                        I64Attr:$kernel_size,
-                       DenseI64ArrayAttr:$image_dimensions
+                       DenseI64ArrayAttr:$image_dimensions,
+                       DenseI64ArrayAttr:$input_tile_dimensions
   );
 
   let builders = [
     OpBuilder<(ins "ValueRange":$inputs, "ValueRange":$outputs,
       CArg<"int64_t", "8">:$output_tile_size, CArg<"int64_t", "3">:$kernel_size,
-      CArg<"ArrayRef<int64_t>", "{1, 2}">:$image_dimensions)>
+      CArg<"ArrayRef<int64_t>", "{1, 2}">:$image_dimensions,
+      CArg<"ArrayRef<int64_t>", "{0, 1}">:$input_tile_dimensions)>
   ];
 
   let results = (outs Variadic<AnyRankedTensor>:$result);
@@ -1491,6 +1503,7 @@ def IREELinalgExt_WinogradOutputTransformOp : IREELinalgExt_Op<"winograd.output_
     `output_tile_size` `(` $output_tile_size `)`
     `kernel_size` `(` $kernel_size `)`
     `image_dimensions` `(` $image_dimensions `)`
+    `input_tile_dimensions` `(` $input_tile_dimensions `)`
     `ins` `(` $inputs `:` type($inputs) `)`
     `outs` `(` $outputs `:` type($outputs) `)`
     (`->` type($result)^)?
@@ -1547,6 +1560,8 @@ def IREELinalgExt_WinogradOutputTransformOp : IREELinalgExt_Op<"winograd.output_
     int64_t getOutputRank() {
       return getOutputType().getRank();
     }
+    // Utility for mapping non input tile dims to the actual result dims
+    SmallVector<int64_t> getNonInputTileDims();
     int64_t getIterationDomainRank() {
       return getInputRank();
     }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeWinogradPass.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeWinogradPass.cpp
@@ -58,8 +58,9 @@ struct FoldWinogradOpUnitDims : public OpRewritePattern<TransformOp> {
     SmallVector<int64_t> newOriginalShape = llvm::map_to_vector(
         hwDims, [&](int64_t dim) { return originalShape[dim]; });
     auto newOriginalType = originalType.clone(newOriginalShape);
-    SmallVector<int64_t> newTransformedShape(transformedShape.begin(),
-                                             transformedShape.begin() + 2);
+    SmallVector<int64_t> newTransformedShape =
+        llvm::map_to_vector(transformOp.getInputTileDimensions(),
+                            [&](int64_t dim) { return transformedShape[dim]; });
     auto newTransformedType = transformedType.clone(newTransformedShape);
     RankedTensorType newInputType = newOriginalType;
     RankedTensorType newOutputType = newTransformedType;

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.td
@@ -79,6 +79,9 @@ def ConvertConv2DToWinograd :
            /*default=*/"false",
            "Choose to ignore `__winograd_conv` annotations and transform all"
            "compatible convolutions.">,
+    Option<"innerInputTile", "inner-input-tile", "bool",
+           /*default=*/"false",
+           "Choose for the input tile dimensions to be innermost in the transformed shape.">,
   ];
 }
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TilingInterfaceImpl.cpp
@@ -1337,15 +1337,11 @@ WinogradInputTransformOp::getIterationDomain(OpBuilder &builder) {
   Location loc = getLoc();
   Value zero = builder.create<arith::ConstantIndexOp>(loc, 0);
   Value one = builder.create<arith::ConstantIndexOp>(loc, 1);
-  Value dest = getOutput();
   SmallVector<Range> loopBounds(getIterationDomainRank());
-  int count = 0;
-  for (auto dim :
-       llvm::seq<int64_t>(getImageDimensions().size(), getOutputRank())) {
-    loopBounds[count].offset = zero;
-    loopBounds[count].size = getDimValue(builder, loc, dest, dim);
-    loopBounds[count].stride = one;
-    count++;
+  for (int dim = 0; dim < getOutputRank(); ++dim) {
+    loopBounds[dim].offset = zero;
+    loopBounds[dim].size = getDimValue(builder, loc, getOutput(), dim);
+    loopBounds[dim].stride = one;
   }
   return loopBounds;
 }
@@ -1362,44 +1358,32 @@ WinogradInputTransformOp::getTiledImplementation(OpBuilder &builder,
                                                  ArrayRef<OpFoldResult> offsets,
                                                  ArrayRef<OpFoldResult> sizes) {
   Location loc = getLoc();
-  auto one = builder.getIndexAttr(1);
   auto zero = builder.getIndexAttr(0);
   const int cDim = getChannelDim();
 
-  assert(offsets.size() == 4);
+  assert(offsets.size() == 6);
   SmallVector<OpFoldResult> inputOffsets(getInputRank(), zero);
-  SmallVector<OpFoldResult> outputOffsets(getOutputRank(), zero);
   const auto hDim = getImageDimensions()[0];
   const auto wDim = getImageDimensions()[1];
-  outputOffsets[2] = inputOffsets[0] = offsets[0];
-  outputOffsets[3] = offsets[1];
-  outputOffsets[4] = offsets[2];
-  outputOffsets[5] = inputOffsets[cDim] = offsets[3];
+  inputOffsets[0] = offsets[2];
+  inputOffsets[cDim] = offsets[5];
 
-  SmallVector<OpFoldResult> inputStrides(getInputRank(), one);
-  SmallVector<OpFoldResult> outputStrides(getOutputRank(), one);
-  ReifiedRankedShapedTypeDims reifiedResultShapes, reifiedInputShapes;
-  if (failed(reifyResultShapes(builder, reifiedResultShapes))) {
-    return failure();
-  }
-  SmallVector<OpFoldResult> outputSizes = reifiedResultShapes[0];
+  ReifiedRankedShapedTypeDims reifiedInputShapes;
   if (failed(getStaticOrReifiedInputDims(builder, loc, getInput(),
                                          reifiedInputShapes))) {
     return failure();
   }
   SmallVector<OpFoldResult> inputSizes = reifiedInputShapes[0];
 
-  assert(sizes.size() == 4);
-  outputSizes[2] = inputSizes[0] = sizes[0];
-  outputSizes[3] = sizes[1];
-  outputSizes[4] = sizes[2];
-  outputSizes[5] = inputSizes[cDim] = sizes[3];
+  assert(sizes.size() == 6);
+  inputSizes[0] = sizes[2];
+  inputSizes[cDim] = sizes[5];
 
   auto hSizeAndOffset = getScaledSizeAndOffset(
-      builder, loc, sizes[1], offsets[1], inputSizes[hDim], getOutputTileSize(),
+      builder, loc, sizes[3], offsets[3], inputSizes[hDim], getOutputTileSize(),
       getInputTileSize());
   auto wSizeAndOffset = getScaledSizeAndOffset(
-      builder, loc, sizes[2], offsets[2], inputSizes[wDim], getOutputTileSize(),
+      builder, loc, sizes[4], offsets[4], inputSizes[wDim], getOutputTileSize(),
       getInputTileSize());
 
   inputSizes[hDim] = hSizeAndOffset.first;
@@ -1408,10 +1392,13 @@ WinogradInputTransformOp::getTiledImplementation(OpBuilder &builder,
   inputOffsets[wDim] = wSizeAndOffset.second;
 
   SmallVector<Value> tiledOperands;
+  auto one = builder.getIndexAttr(1);
+  SmallVector<OpFoldResult> inputStrides(getInputRank(), one);
   tiledOperands.emplace_back(getSlice(builder, loc, getInput(), inputOffsets,
                                       inputSizes, inputStrides));
-  tiledOperands.emplace_back(getSlice(builder, loc, getOutput(), outputOffsets,
-                                      outputSizes, outputStrides));
+  SmallVector<OpFoldResult> outputStrides(getOutputRank(), one);
+  tiledOperands.emplace_back(
+      getSlice(builder, loc, getOutput(), offsets, sizes, outputStrides));
 
   SmallVector<Type, 4> resultTypes;
   if (hasPureTensorSemantics()) {
@@ -1429,21 +1416,19 @@ LogicalResult WinogradInputTransformOp::getResultTilePosition(
     ArrayRef<OpFoldResult> sizes, SmallVector<OpFoldResult> &resultOffsets,
     SmallVector<OpFoldResult> &resultSizes) {
   if (resultNumber == 0) {
-    auto resultShape = cast<ShapedType>(getOutput().getType()).getShape();
-    resultSizes = getAsOpFoldResult(builder.getIndexArrayAttr(resultShape));
-    resultOffsets =
-        SmallVector<OpFoldResult>(getOutputRank(), builder.getIndexAttr(0));
-    resultOffsets[2] = offsets[0];
-    resultOffsets[3] = offsets[1];
-    resultOffsets[4] = offsets[2];
-    resultOffsets[5] = offsets[3];
-    resultSizes[2] = sizes[0];
-    resultSizes[3] = sizes[1];
-    resultSizes[4] = sizes[2];
-    resultSizes[5] = sizes[3];
+    resultSizes = SmallVector<OpFoldResult>(sizes);
+    resultOffsets = SmallVector<OpFoldResult>(offsets);
     return success();
   }
   return failure();
+}
+
+FailureOr<TilingResult> WinogradInputTransformOp::generateResultTileValue(
+    OpBuilder &b, unsigned resultNumber, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes) {
+  int64_t numLoops = getIterationDomainRank();
+  return getTiledImplementation(b, offsets.take_front(numLoops),
+                                sizes.take_front(numLoops));
 }
 
 //===----------------------------------------------------------------------===//
@@ -1455,15 +1440,11 @@ WinogradFilterTransformOp::getIterationDomain(OpBuilder &builder) {
   Location loc = getLoc();
   OpFoldResult zero = builder.getIndexAttr(0);
   OpFoldResult one = builder.getIndexAttr(1);
-  Value source = getOutput();
-  int64_t numKernelDims = getKernelDimensions().size();
-  auto outRank = getOutputRank();
-  SmallVector<Range> loopBounds(outRank - numKernelDims);
-  for (auto dim : llvm::seq<int64_t>(numKernelDims, outRank)) {
-    int64_t loopDim = dim - numKernelDims;
-    loopBounds[loopDim].offset = zero;
-    loopBounds[loopDim].size = getDimValue(builder, loc, source, dim);
-    loopBounds[loopDim].stride = one;
+  SmallVector<Range> loopBounds(getOutputRank());
+  for (int dim = 0; dim < getOutputRank(); ++dim) {
+    loopBounds[dim].offset = zero;
+    loopBounds[dim].size = getDimValue(builder, loc, getOutput(), dim);
+    loopBounds[dim].stride = one;
   }
   return loopBounds;
 }
@@ -1484,30 +1465,25 @@ FailureOr<TilingResult> WinogradFilterTransformOp::getTiledImplementation(
   const int cDim = getChannelDim();
   const int fDim = getFilterDim();
 
-  assert(offsets.size() == 2);
+  assert(offsets.size() == 4);
   SmallVector<OpFoldResult> inputOffsets(getInputRank(), zero);
-  SmallVector<OpFoldResult> outputOffsets(getOutputRank(), zero);
-  outputOffsets[2] = inputOffsets[cDim] = offsets[0];
-  outputOffsets[3] = inputOffsets[fDim] = offsets[1];
+  inputOffsets[cDim] = offsets[2];
+  inputOffsets[fDim] = offsets[3];
 
-  SmallVector<OpFoldResult> inputStrides(getInputRank(), one);
-  SmallVector<OpFoldResult> outputStrides(getOutputRank(), one);
-
-  assert(sizes.size() == 2);
+  assert(sizes.size() == 4);
   ArrayRef<int64_t> inputShape = getInputType().getShape();
-  ArrayRef<int64_t> outputShape = getOutputType().getShape();
   SmallVector<OpFoldResult> inputSizes =
       getAsOpFoldResult(builder.getIndexArrayAttr(inputShape));
-  SmallVector<OpFoldResult> outputSizes =
-      getAsOpFoldResult(builder.getIndexArrayAttr(outputShape));
-  outputSizes[2] = inputSizes[cDim] = sizes[0];
-  outputSizes[3] = inputSizes[fDim] = sizes[1];
+  inputSizes[cDim] = sizes[2];
+  inputSizes[fDim] = sizes[3];
 
   SmallVector<Value> tiledOperands;
+  SmallVector<OpFoldResult> inputStrides(getInputRank(), one);
   tiledOperands.emplace_back(getSlice(builder, loc, getInput(), inputOffsets,
                                       inputSizes, inputStrides));
-  tiledOperands.emplace_back(getSlice(builder, loc, getOutput(), outputOffsets,
-                                      outputSizes, outputStrides));
+  SmallVector<OpFoldResult> outputStrides(getOutputRank(), one);
+  tiledOperands.emplace_back(
+      getSlice(builder, loc, getOutput(), offsets, sizes, outputStrides));
 
   SmallVector<Type> resultTypes;
   if (hasPureTensorSemantics()) {
@@ -1527,15 +1503,17 @@ LogicalResult WinogradFilterTransformOp::getResultTilePosition(
   if (resultNumber != 0) {
     return failure();
   }
-  ArrayRef<int64_t> resultShape = getOutputType().getShape();
-  resultSizes = getAsOpFoldResult(builder.getIndexArrayAttr(resultShape));
-  resultOffsets =
-      SmallVector<OpFoldResult>(getOutputRank(), builder.getIndexAttr(0));
-  resultOffsets[2] = offsets[0];
-  resultOffsets[3] = offsets[1];
-  resultSizes[2] = sizes[0];
-  resultSizes[3] = sizes[1];
+  resultSizes = SmallVector<OpFoldResult>(sizes);
+  resultOffsets = SmallVector<OpFoldResult>(offsets);
   return success();
+}
+
+FailureOr<TilingResult> WinogradFilterTransformOp::generateResultTileValue(
+    OpBuilder &b, unsigned resultNumber, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes) {
+  int64_t numLoops = getIterationDomainRank();
+  return getTiledImplementation(b, offsets.take_front(numLoops),
+                                sizes.take_front(numLoops));
 }
 
 //===----------------------------------------------------------------------===//
@@ -1547,15 +1525,11 @@ WinogradOutputTransformOp::getIterationDomain(OpBuilder &builder) {
   Location loc = getLoc();
   Value zero = builder.create<arith::ConstantIndexOp>(loc, 0);
   Value one = builder.create<arith::ConstantIndexOp>(loc, 1);
-  Value source = getInput();
   SmallVector<Range> loopBounds(getIterationDomainRank());
-  int count = 0;
-  for (auto dim :
-       llvm::seq<int64_t>(getImageDimensions().size(), getInputRank())) {
-    loopBounds[count].offset = zero;
-    loopBounds[count].size = getDimValue(builder, loc, source, dim);
-    loopBounds[count].stride = one;
-    count++;
+  for (int dim = 0; dim < getInputRank(); ++dim) {
+    loopBounds[dim].offset = zero;
+    loopBounds[dim].size = getDimValue(builder, loc, getInput(), dim);
+    loopBounds[dim].stride = one;
   }
   return loopBounds;
 }
@@ -1575,45 +1549,29 @@ FailureOr<TilingResult> WinogradOutputTransformOp::getTiledImplementation(
   auto zero = builder.getIndexAttr(0);
   const int cDim = getChannelDim();
 
-  assert(offsets.size() == 4);
+  assert(offsets.size() == 6);
   const auto hDim = getImageDimensions()[0];
   const auto wDim = getImageDimensions()[1];
-  SmallVector<OpFoldResult> inputOffsets(getInputRank(), zero);
   SmallVector<OpFoldResult> outputOffsets(getOutputRank(), zero);
 
-  inputOffsets[2] = outputOffsets[0] = offsets[0];
-  inputOffsets[3] = offsets[1];
-  inputOffsets[4] = offsets[2];
-  inputOffsets[5] = outputOffsets[cDim] = offsets[3];
+  outputOffsets[0] = offsets[2];
+  outputOffsets[cDim] = offsets[5];
 
-  SmallVector<OpFoldResult> inputStrides(getInputRank(), one);
-  SmallVector<OpFoldResult> outputStrides(getOutputRank(), one);
-
-  ReifiedRankedShapedTypeDims reifiedResultShapes, reifiedInputShapes;
+  ReifiedRankedShapedTypeDims reifiedResultShapes;
   if (failed(reifyResultShapes(builder, reifiedResultShapes))) {
     return failure();
   }
   SmallVector<OpFoldResult> outputSizes = reifiedResultShapes[0];
-  if (failed(getStaticOrReifiedInputDims(builder, loc, getInput(),
-                                         reifiedInputShapes))) {
-    return failure();
-  }
-  SmallVector<OpFoldResult> inputSizes = reifiedInputShapes[0];
 
-  inputSizes[2] = outputSizes[0] = sizes[0];
-  inputSizes[5] = outputSizes[cDim] = sizes[3];
-
-  assert(sizes.size() == 4);
-  inputSizes[2] = outputSizes[0] = sizes[0];
-  inputSizes[3] = sizes[1];
-  inputSizes[4] = sizes[2];
-  inputSizes[5] = outputSizes[cDim] = sizes[3];
+  assert(sizes.size() == 6);
+  outputSizes[0] = sizes[2];
+  outputSizes[cDim] = sizes[5];
 
   auto hSizeAndOffset = getScaledSizeAndOffset(
-      builder, loc, sizes[1], offsets[1], outputSizes[hDim],
+      builder, loc, sizes[3], offsets[3], outputSizes[hDim],
       getOutputTileSize(), getOutputTileSize());
   auto wSizeAndOffset = getScaledSizeAndOffset(
-      builder, loc, sizes[2], offsets[2], outputSizes[wDim],
+      builder, loc, sizes[4], offsets[4], outputSizes[wDim],
       getOutputTileSize(), getOutputTileSize());
 
   outputSizes[hDim] = hSizeAndOffset.first;
@@ -1621,6 +1579,7 @@ FailureOr<TilingResult> WinogradOutputTransformOp::getTiledImplementation(
   outputOffsets[hDim] = hSizeAndOffset.second;
   outputOffsets[wDim] = wSizeAndOffset.second;
 
+  SmallVector<OpFoldResult> outputStrides(getOutputRank(), one);
   Value outputSlice = getSlice(builder, loc, getOutput(), outputOffsets,
                                outputSizes, outputStrides);
   // The image dims of the winograd.output_transform result will always be a
@@ -1628,11 +1587,11 @@ FailureOr<TilingResult> WinogradOutputTransformOp::getTiledImplementation(
   // maintain more static information in the IR.
   auto outSliceType = cast<ShapedType>(outputSlice.getType());
   SmallVector<int64_t> staticOutShape(outSliceType.getShape());
-  auto constSizeH = getConstantIntValue(sizes[1]);
+  auto constSizeH = getConstantIntValue(sizes[3]);
   if (constSizeH.has_value()) {
     staticOutShape[hDim] = constSizeH.value() * getOutputTileSize();
   }
-  auto constSizeW = getConstantIntValue(sizes[2]);
+  auto constSizeW = getConstantIntValue(sizes[4]);
   if (constSizeW.has_value()) {
     staticOutShape[wDim] = constSizeW.value() * getOutputTileSize();
   }
@@ -1640,8 +1599,9 @@ FailureOr<TilingResult> WinogradOutputTransformOp::getTiledImplementation(
       castValue(builder, loc, outputSlice, outSliceType.clone(staticOutShape));
 
   SmallVector<Value> tiledOperands;
-  tiledOperands.emplace_back(getSlice(builder, loc, getInput(), inputOffsets,
-                                      inputSizes, inputStrides));
+  SmallVector<OpFoldResult> inputStrides(getInputRank(), one);
+  tiledOperands.emplace_back(
+      getSlice(builder, loc, getInput(), offsets, sizes, inputStrides));
   tiledOperands.emplace_back(staticOutputSlice);
 
   SmallVector<Type, 4> resultTypes;
@@ -1672,19 +1632,19 @@ LogicalResult WinogradOutputTransformOp::getResultTilePosition(
     const auto hDim = getImageDimensions()[0];
     const auto wDim = getImageDimensions()[1];
     auto loc = getLoc();
-    resultOffsets[0] = offsets[0];
-    resultOffsets[cDim] = offsets[3];
-    resultSizes[0] = sizes[0];
-    resultSizes[cDim] = sizes[3];
+    resultOffsets[0] = offsets[2];
+    resultOffsets[cDim] = offsets[5];
+    resultSizes[0] = sizes[2];
+    resultSizes[cDim] = sizes[5];
     SmallVector<SmallVector<OpFoldResult>> reifiedResultShapes;
     if (failed(reifyResultShapes(builder, reifiedResultShapes))) {
       return failure();
     }
     auto hSizeAndOffset = getScaledSizeAndOffset(
-        builder, loc, sizes[1], offsets[1], reifiedResultShapes[0][hDim],
+        builder, loc, sizes[3], offsets[3], reifiedResultShapes[0][hDim],
         getOutputTileSize(), getOutputTileSize());
     auto wSizeAndOffset = getScaledSizeAndOffset(
-        builder, loc, sizes[2], offsets[2], reifiedResultShapes[0][wDim],
+        builder, loc, sizes[4], offsets[4], reifiedResultShapes[0][wDim],
         getOutputTileSize(), getOutputTileSize());
 
     resultSizes[hDim] = hSizeAndOffset.first;

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TilingInterfaceImpl.cpp
@@ -14,6 +14,8 @@
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/OpDefinition.h"
 
@@ -1362,11 +1364,15 @@ WinogradInputTransformOp::getTiledImplementation(OpBuilder &builder,
   const int cDim = getChannelDim();
 
   assert(offsets.size() == 6);
+  SmallVector<int64_t> perm(getInputTileDimensions());
+  perm.append(getNonInputTileDims());
+  SmallVector<OpFoldResult> offsetsPermuted = applyPermutation(offsets, perm);
+  SmallVector<OpFoldResult> sizesPermuted = applyPermutation(sizes, perm);
   SmallVector<OpFoldResult> inputOffsets(getInputRank(), zero);
   const auto hDim = getImageDimensions()[0];
   const auto wDim = getImageDimensions()[1];
-  inputOffsets[0] = offsets[2];
-  inputOffsets[cDim] = offsets[5];
+  inputOffsets[0] = offsetsPermuted[2];
+  inputOffsets[cDim] = offsetsPermuted[5];
 
   ReifiedRankedShapedTypeDims reifiedInputShapes;
   if (failed(getStaticOrReifiedInputDims(builder, loc, getInput(),
@@ -1376,15 +1382,15 @@ WinogradInputTransformOp::getTiledImplementation(OpBuilder &builder,
   SmallVector<OpFoldResult> inputSizes = reifiedInputShapes[0];
 
   assert(sizes.size() == 6);
-  inputSizes[0] = sizes[2];
-  inputSizes[cDim] = sizes[5];
+  inputSizes[0] = sizesPermuted[2];
+  inputSizes[cDim] = sizesPermuted[5];
 
   auto hSizeAndOffset = getScaledSizeAndOffset(
-      builder, loc, sizes[3], offsets[3], inputSizes[hDim], getOutputTileSize(),
-      getInputTileSize());
+      builder, loc, sizesPermuted[3], offsetsPermuted[3], inputSizes[hDim],
+      getOutputTileSize(), getInputTileSize());
   auto wSizeAndOffset = getScaledSizeAndOffset(
-      builder, loc, sizes[4], offsets[4], inputSizes[wDim], getOutputTileSize(),
-      getInputTileSize());
+      builder, loc, sizesPermuted[4], offsetsPermuted[4], inputSizes[wDim],
+      getOutputTileSize(), getInputTileSize());
 
   inputSizes[hDim] = hSizeAndOffset.first;
   inputSizes[wDim] = wSizeAndOffset.first;
@@ -1466,16 +1472,18 @@ FailureOr<TilingResult> WinogradFilterTransformOp::getTiledImplementation(
   const int fDim = getFilterDim();
 
   assert(offsets.size() == 4);
+  SmallVector<int64_t> perm(getInputTileDimensions());
+  perm.append(getNonInputTileDims());
+  SmallVector<OpFoldResult> offsetsPermuted = applyPermutation(offsets, perm);
+  SmallVector<OpFoldResult> sizesPermuted = applyPermutation(sizes, perm);
   SmallVector<OpFoldResult> inputOffsets(getInputRank(), zero);
-  inputOffsets[cDim] = offsets[2];
-  inputOffsets[fDim] = offsets[3];
+  inputOffsets[cDim] = offsetsPermuted[2];
+  inputOffsets[fDim] = offsetsPermuted[3];
 
   assert(sizes.size() == 4);
-  ArrayRef<int64_t> inputShape = getInputType().getShape();
-  SmallVector<OpFoldResult> inputSizes =
-      getAsOpFoldResult(builder.getIndexArrayAttr(inputShape));
-  inputSizes[cDim] = sizes[2];
-  inputSizes[fDim] = sizes[3];
+  SmallVector<OpFoldResult> inputSizes = getDims(builder, loc, getInput());
+  inputSizes[cDim] = sizesPermuted[2];
+  inputSizes[fDim] = sizesPermuted[3];
 
   SmallVector<Value> tiledOperands;
   SmallVector<OpFoldResult> inputStrides(getInputRank(), one);
@@ -1550,12 +1558,16 @@ FailureOr<TilingResult> WinogradOutputTransformOp::getTiledImplementation(
   const int cDim = getChannelDim();
 
   assert(offsets.size() == 6);
+  SmallVector<int64_t> perm(getInputTileDimensions());
+  perm.append(getNonInputTileDims());
+  SmallVector<OpFoldResult> sizesPermuted = applyPermutation(sizes, perm);
+  SmallVector<OpFoldResult> offsetsPermuted = applyPermutation(offsets, perm);
   const auto hDim = getImageDimensions()[0];
   const auto wDim = getImageDimensions()[1];
   SmallVector<OpFoldResult> outputOffsets(getOutputRank(), zero);
 
-  outputOffsets[0] = offsets[2];
-  outputOffsets[cDim] = offsets[5];
+  outputOffsets[0] = offsetsPermuted[2];
+  outputOffsets[cDim] = offsetsPermuted[5];
 
   ReifiedRankedShapedTypeDims reifiedResultShapes;
   if (failed(reifyResultShapes(builder, reifiedResultShapes))) {
@@ -1564,14 +1576,14 @@ FailureOr<TilingResult> WinogradOutputTransformOp::getTiledImplementation(
   SmallVector<OpFoldResult> outputSizes = reifiedResultShapes[0];
 
   assert(sizes.size() == 6);
-  outputSizes[0] = sizes[2];
-  outputSizes[cDim] = sizes[5];
+  outputSizes[0] = sizesPermuted[2];
+  outputSizes[cDim] = sizesPermuted[5];
 
   auto hSizeAndOffset = getScaledSizeAndOffset(
-      builder, loc, sizes[3], offsets[3], outputSizes[hDim],
+      builder, loc, sizesPermuted[3], offsetsPermuted[3], outputSizes[hDim],
       getOutputTileSize(), getOutputTileSize());
   auto wSizeAndOffset = getScaledSizeAndOffset(
-      builder, loc, sizes[4], offsets[4], outputSizes[wDim],
+      builder, loc, sizesPermuted[4], offsetsPermuted[4], outputSizes[wDim],
       getOutputTileSize(), getOutputTileSize());
 
   outputSizes[hDim] = hSizeAndOffset.first;
@@ -1587,11 +1599,11 @@ FailureOr<TilingResult> WinogradOutputTransformOp::getTiledImplementation(
   // maintain more static information in the IR.
   auto outSliceType = cast<ShapedType>(outputSlice.getType());
   SmallVector<int64_t> staticOutShape(outSliceType.getShape());
-  auto constSizeH = getConstantIntValue(sizes[3]);
+  auto constSizeH = getConstantIntValue(sizesPermuted[3]);
   if (constSizeH.has_value()) {
     staticOutShape[hDim] = constSizeH.value() * getOutputTileSize();
   }
-  auto constSizeW = getConstantIntValue(sizes[4]);
+  auto constSizeW = getConstantIntValue(sizesPermuted[4]);
   if (constSizeW.has_value()) {
     staticOutShape[wDim] = constSizeW.value() * getOutputTileSize();
   }
@@ -1631,21 +1643,25 @@ LogicalResult WinogradOutputTransformOp::getResultTilePosition(
     const int cDim = getChannelDim();
     const auto hDim = getImageDimensions()[0];
     const auto wDim = getImageDimensions()[1];
+    SmallVector<int64_t> perm(getInputTileDimensions());
+    perm.append(getNonInputTileDims());
+    SmallVector<OpFoldResult> sizesPermuted = applyPermutation(sizes, perm);
+    SmallVector<OpFoldResult> offsetsPermuted = applyPermutation(offsets, perm);
     auto loc = getLoc();
-    resultOffsets[0] = offsets[2];
-    resultOffsets[cDim] = offsets[5];
-    resultSizes[0] = sizes[2];
-    resultSizes[cDim] = sizes[5];
+    resultOffsets[0] = offsetsPermuted[2];
+    resultOffsets[cDim] = offsetsPermuted[5];
+    resultSizes[0] = sizesPermuted[2];
+    resultSizes[cDim] = sizesPermuted[5];
     SmallVector<SmallVector<OpFoldResult>> reifiedResultShapes;
     if (failed(reifyResultShapes(builder, reifiedResultShapes))) {
       return failure();
     }
     auto hSizeAndOffset = getScaledSizeAndOffset(
-        builder, loc, sizes[3], offsets[3], reifiedResultShapes[0][hDim],
-        getOutputTileSize(), getOutputTileSize());
+        builder, loc, sizesPermuted[3], offsetsPermuted[3],
+        reifiedResultShapes[0][hDim], getOutputTileSize(), getOutputTileSize());
     auto wSizeAndOffset = getScaledSizeAndOffset(
-        builder, loc, sizes[4], offsets[4], reifiedResultShapes[0][wDim],
-        getOutputTileSize(), getOutputTileSize());
+        builder, loc, sizesPermuted[4], offsetsPermuted[4],
+        reifiedResultShapes[0][wDim], getOutputTileSize(), getOutputTileSize());
 
     resultSizes[hDim] = hSizeAndOffset.first;
     resultSizes[wDim] = wSizeAndOffset.first;

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv2d_to_winograd.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv2d_to_winograd.mlir
@@ -1,5 +1,6 @@
-// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(util.func(iree-linalg-ext-convert-conv2d-to-winograd{replace-all-convs}))" -mlir-elide-elementsattrs-if-larger=4 %s | FileCheck %s --check-prefixes=CHECK-ALL,CHECK
-// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(util.func(iree-linalg-ext-convert-conv2d-to-winograd))" -mlir-elide-elementsattrs-if-larger=4 %s | FileCheck %s --check-prefixes=CHECK-ALL,CHECK-ANNOTATED
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(util.func(iree-linalg-ext-convert-conv2d-to-winograd{replace-all-convs}))" --mlir-print-local-scope %s | FileCheck %s --check-prefixes=CHECK-ALL,CHECK,CHECK-OUTER
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(util.func(iree-linalg-ext-convert-conv2d-to-winograd{replace-all-convs inner-input-tile}))" --mlir-print-local-scope %s | FileCheck %s --check-prefixes=CHECK-ALL,CHECK,CHECK-INNER
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(util.func(iree-linalg-ext-convert-conv2d-to-winograd))" --mlir-print-local-scope %s | FileCheck %s --check-prefixes=CHECK-ALL,CHECK-ANNOTATED
 
 util.func public @conv_16433136(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<3x3x4x16xf32>, %arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32> {
   %0 = linalg.conv_2d_nhwc_hwcf
@@ -8,40 +9,57 @@ util.func public @conv_16433136(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<3x3x
     outs(%arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32>
   util.return %0 : tensor<1x14x14x16xf32>
 }
-// CHECK-ALL:  util.func public @conv_16433136(
-// CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x16x16x4xf32>
-// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<3x3x4x16xf32>
-// CHECK-DAG:    %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
-// CHECK-DAG:    %[[EMPTY0:.+]] = tensor.empty() : tensor<8x8x4x16xf32>
-// CHECK:        %[[FILTER_TF:.+]] = iree_linalg_ext.winograd.filter_transform output_tile_size(6) kernel_size(3)
-// CHECK-SAME:     kernel_dimensions([0, 1]) ins(%[[ARG1]] : tensor<3x3x4x16xf32>) outs(%[[EMPTY0]] :
-// CHECK-SAME:     tensor<8x8x4x16xf32>) -> tensor<8x8x4x16xf32>
-// CHECK:        %[[COLLAPSED_FILTER:.+]] = tensor.collapse_shape %[[FILTER_TF]]
-// CHECK-SAME{LITERAL}:  [[0, 1], [2], [3]]
-// CHECK-SAME:           tensor<8x8x4x16xf32> into tensor<64x4x16xf32>
-// CHECK:        %[[EMPTY1:.+]] = tensor.empty() : tensor<8x8x1x3x3x4xf32>
-// CHECK:        %[[INPUT_TF:.+]] = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3)
-// CHECK-SAME:     image_dimensions([1, 2]) ins(%[[ARG0]] : tensor<1x16x16x4xf32>) outs(%[[EMPTY1]] :
-// CHECK-SAME:     tensor<8x8x1x3x3x4xf32>) -> tensor<8x8x1x3x3x4xf32>
-// CHECK:        %[[COLLAPSED_INPUT:.+]] = tensor.collapse_shape %[[INPUT_TF]]
-// CHECK-SAME{LITERAL}:  [[0, 1], [2, 3, 4], [5]]
-// CHECK-SAME:           tensor<8x8x1x3x3x4xf32> into tensor<64x9x4xf32>
-// CHECK:        %[[EMPTY2:.+]] = tensor.empty() : tensor<64x9x16xf32>
-// CHECK:        %[[FILL:.+]] = linalg.fill ins(%[[ZERO]] : f32) outs(%[[EMPTY2]] : tensor<64x9x16xf32>) ->
-// CHECK-SAME:     tensor<64x9x16xf32>
-// CHECK:        %[[BMM:.+]] = linalg.batch_matmul ins(%[[COLLAPSED_INPUT]], %[[COLLAPSED_FILTER]] : tensor<64x9x4xf32>,
-// CHECK-SAME:     tensor<64x4x16xf32>) outs(%[[FILL]] : tensor<64x9x16xf32>) -> tensor<64x9x16xf32>
-// CHECK:        %[[EXPANDED:.+]] = tensor.expand_shape %[[BMM]]
-// CHECK-SAME{LITERAL}: [[0, 1], [2, 3, 4], [5]]
-// CHECK-SAME:          tensor<64x9x16xf32> into tensor<8x8x1x3x3x16xf32>
-// CHECK:        %[[EMPTY3:.+]] = tensor.empty() : tensor<1x18x18x16xf32>
-// CHECK:        %[[OUTPUT_TF:.+]] = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3)
-// CHECK-SAME:     image_dimensions([1, 2]) ins(%[[EXPANDED]] : tensor<8x8x1x3x3x16xf32>) outs(%[[EMPTY3]] :
-// CHECK-SAME:     tensor<1x18x18x16xf32>) -> tensor<1x18x18x16xf32>
-// CHECK:        %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[OUTPUT_TF]][0, 0, 0, 0] [1, 14, 14, 16] [1, 1, 1, 1] :
-// CHECK-SAME:     tensor<1x18x18x16xf32> to tensor<1x14x14x16xf32>
-// CHECK:        util.return %[[EXTRACTED_SLICE]] : tensor<1x14x14x16xf32>
-// CHECK:      }
+// CHECK-ALL:        util.func public @conv_16433136(
+// CHECK-SAME:         %[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x16x16x4xf32>
+// CHECK-SAME:         %[[ARG1:[a-zA-Z0-9_]+]]: tensor<3x3x4x16xf32>
+// CHECK-DAG:          %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-OUTER-DAG:    %[[EMPTY0:.+]] = tensor.empty() : tensor<8x8x4x16xf32>
+// CHECK-INNER-DAG:    %[[EMPTY0:.+]] = tensor.empty() : tensor<4x16x8x8xf32>
+// CHECK:              %[[FILTER_TF:.+]] = iree_linalg_ext.winograd.filter_transform output_tile_size(6) kernel_size(3) kernel_dimensions([0, 1])
+// CHECK-OUTER-SAME:     input_tile_dimensions([0, 1]) ins(%[[ARG1]] : tensor<3x3x4x16xf32>) outs(%[[EMPTY0]] :
+// CHECK-INNER-SAME:     input_tile_dimensions([2, 3]) ins(%[[ARG1]] : tensor<3x3x4x16xf32>) outs(%[[EMPTY0]] :
+// CHECK-OUTER-SAME:     tensor<8x8x4x16xf32>) -> tensor<8x8x4x16xf32>
+// CHECK-INNER-SAME:     tensor<4x16x8x8xf32>) -> tensor<4x16x8x8xf32>
+// CHECK:              %[[COLLAPSED_FILTER:.+]] = tensor.collapse_shape %[[FILTER_TF]]
+// CHECK-OUTER-SAME{LITERAL}: [[0, 1], [2], [3]]
+// CHECK-INNER-SAME{LITERAL}: [[0], [1], [2, 3]]
+// CHECK-OUTER-SAME:           tensor<8x8x4x16xf32> into tensor<64x4x16xf32>
+// CHECK-INNER-SAME:           tensor<4x16x8x8xf32> into tensor<4x16x64xf32>
+// CHECK-OUTER:        %[[EMPTY1:.+]] = tensor.empty() : tensor<8x8x1x3x3x4xf32>
+// CHECK-INNER:        %[[EMPTY1:.+]] = tensor.empty() : tensor<1x3x3x4x8x8xf32>
+// CHECK:              %[[INPUT_TF:.+]] = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2])
+// CHECK-OUTER-SAME:     input_tile_dimensions([0, 1]) ins(%[[ARG0]] : tensor<1x16x16x4xf32>) outs(%[[EMPTY1]] :
+// CHECK-INNER-SAME:     input_tile_dimensions([4, 5]) ins(%[[ARG0]] : tensor<1x16x16x4xf32>) outs(%[[EMPTY1]] :
+// CHECK-OUTER-SAME:     tensor<8x8x1x3x3x4xf32>) -> tensor<8x8x1x3x3x4xf32>
+// CHECK-INNER-SAME:     tensor<1x3x3x4x8x8xf32>) -> tensor<1x3x3x4x8x8xf32>
+// CHECK:              %[[COLLAPSED_INPUT:.+]] = tensor.collapse_shape %[[INPUT_TF]]
+// CHECK-OUTER-SAME{LITERAL}:  [[0, 1], [2, 3, 4], [5]]
+// CHECK-INNER-SAME{LITERAL}:  [[0, 1, 2], [3], [4, 5]]
+// CHECK-OUTER-SAME:           tensor<8x8x1x3x3x4xf32> into tensor<64x9x4xf32>
+// CHECK-INNER-SAME:           tensor<1x3x3x4x8x8xf32> into tensor<9x4x64xf32>
+// CHECK-OUTER:        %[[EMPTY2:.+]] = tensor.empty() : tensor<64x9x16xf32>
+// CHECK-INNER:        %[[EMPTY2:.+]] = tensor.empty() : tensor<9x16x64xf32>
+// CHECK:              %[[FILL:.+]] = linalg.fill ins(%[[ZERO]] : f32) outs(%[[EMPTY2]]
+// CHECK:              %[[BMM:.+]] = linalg.generic
+// CHECK-OUTER-SAME:     indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>]
+// CHECK-INNER-SAME:     indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d1, d3, d0)>, affine_map<(d0, d1, d2, d3) -> (d3, d2, d0)>, affine_map<(d0, d1, d2, d3) -> (d1, d2, d0)>]
+// CHECK-SAME:           iterator_types = ["parallel", "parallel", "parallel", "reduction"]
+// CHECK-SAME:           ins(%[[COLLAPSED_INPUT]], %[[COLLAPSED_FILTER]]
+// CHECK-SAME:           outs(%[[FILL]]
+// CHECK:              %[[EXPANDED:.+]] = tensor.expand_shape %[[BMM]]
+// CHECK-OUTER-SAME{LITERAL}: [[0, 1], [2, 3, 4], [5]]
+// CHECK-INNER-SAME{LITERAL}: [[0, 1, 2], [3], [4, 5]]
+// CHECK-OUTER-SAME:          tensor<64x9x16xf32> into tensor<8x8x1x3x3x16xf32>
+// CHECK-INNER-SAME:          tensor<9x16x64xf32> into tensor<1x3x3x16x8x8xf32>
+// CHECK:              %[[EMPTY3:.+]] = tensor.empty() : tensor<1x18x18x16xf32>
+// CHECK:              %[[OUTPUT_TF:.+]] = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2])
+// CHECK-OUTER-SAME:     input_tile_dimensions([0, 1]) ins(%[[EXPANDED]] : tensor<8x8x1x3x3x16xf32>) outs(%[[EMPTY3]] :
+// CHECK-INNER-SAME:     input_tile_dimensions([4, 5]) ins(%[[EXPANDED]] : tensor<1x3x3x16x8x8xf32>) outs(%[[EMPTY3]] :
+// CHECK-SAME:           tensor<1x18x18x16xf32>) -> tensor<1x18x18x16xf32>
+// CHECK:              %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[OUTPUT_TF]][0, 0, 0, 0] [1, 14, 14, 16] [1, 1, 1, 1] :
+// CHECK-SAME:           tensor<1x18x18x16xf32> to tensor<1x14x14x16xf32>
+// CHECK:              util.return %[[EXTRACTED_SLICE]] : tensor<1x14x14x16xf32>
+// CHECK:            }
 
 // -----
 
@@ -52,40 +70,57 @@ util.func public @conv_16433136_nchw_fchw(%arg0: tensor<1x4x16x16xf32>, %arg1: t
     outs(%arg2: tensor<1x16x14x14xf32>) -> tensor<1x16x14x14xf32>
   util.return %0 : tensor<1x16x14x14xf32>
 }
-// CHECK-ALL:  util.func public @conv_16433136_nchw_fchw(
-// CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x4x16x16xf32>
-// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<16x4x3x3xf32>
-// CHECK-DAG:    %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
-// CHECK-DAG:    %[[EMPTY0:.+]] = tensor.empty() : tensor<8x8x4x16xf32>
-// CHECK:        %[[FILTER_TF:.+]] = iree_linalg_ext.winograd.filter_transform output_tile_size(6) kernel_size(3)
-// CHECK-SAME:     kernel_dimensions([2, 3]) ins(%[[ARG1]] : tensor<16x4x3x3xf32>) outs(%[[EMPTY0]] :
-// CHECK-SAME:     tensor<8x8x4x16xf32>) -> tensor<8x8x4x16xf32>
-// CHECK:        %[[COLLAPSED_FILTER:.+]] = tensor.collapse_shape %[[FILTER_TF]]
-// CHECK-SAME{LITERAL}:  [[0, 1], [2], [3]]
-// CHECK-SAME:           tensor<8x8x4x16xf32> into tensor<64x4x16xf32>
-// CHECK:        %[[EMPTY1:.+]] = tensor.empty() : tensor<8x8x1x3x3x4xf32>
-// CHECK:        %[[INPUT_TF:.+]] = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3)
-// CHECK-SAME:     image_dimensions([2, 3]) ins(%[[ARG0]] : tensor<1x4x16x16xf32>) outs(%[[EMPTY1]] :
-// CHECK-SAME:     tensor<8x8x1x3x3x4xf32>) -> tensor<8x8x1x3x3x4xf32>
-// CHECK:        %[[COLLAPSED_INPUT:.+]] = tensor.collapse_shape %[[INPUT_TF]]
-// CHECK-SAME{LITERAL}:  [[0, 1], [2, 3, 4], [5]]
-// CHECK-SAME:           tensor<8x8x1x3x3x4xf32> into tensor<64x9x4xf32>
-// CHECK:        %[[EMPTY2:.+]] = tensor.empty() : tensor<64x9x16xf32>
-// CHECK:        %[[FILL:.+]] = linalg.fill ins(%[[ZERO]] : f32) outs(%[[EMPTY2]] : tensor<64x9x16xf32>) ->
-// CHECK-SAME:     tensor<64x9x16xf32>
-// CHECK:        %[[BMM:.+]] = linalg.batch_matmul ins(%[[COLLAPSED_INPUT]], %[[COLLAPSED_FILTER]] : tensor<64x9x4xf32>,
-// CHECK-SAME:     tensor<64x4x16xf32>) outs(%[[FILL]] : tensor<64x9x16xf32>) -> tensor<64x9x16xf32>
-// CHECK:        %[[EXPANDED:.+]] = tensor.expand_shape %[[BMM]]
-// CHECK-SAME{LITERAL}: [[0, 1], [2, 3, 4], [5]]
-// CHECK-SAME:          tensor<64x9x16xf32> into tensor<8x8x1x3x3x16xf32>
-// CHECK:        %[[EMPTY3:.+]] = tensor.empty() : tensor<1x16x18x18xf32>
-// CHECK:        %[[OUTPUT_TF:.+]] = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3)
-// CHECK-SAME:     image_dimensions([2, 3]) ins(%[[EXPANDED]] : tensor<8x8x1x3x3x16xf32>) outs(%[[EMPTY3]] :
-// CHECK-SAME:     tensor<1x16x18x18xf32>) -> tensor<1x16x18x18xf32>
-// CHECK:        %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[OUTPUT_TF]][0, 0, 0, 0] [1, 16, 14, 14] [1, 1, 1, 1] :
-// CHECK-SAME:     tensor<1x16x18x18xf32> to tensor<1x16x14x14xf32>
-// CHECK:        util.return %[[EXTRACTED_SLICE]] : tensor<1x16x14x14xf32>
-// CHECK:      }
+// CHECK-ALL:        util.func public @conv_16433136_nchw_fchw(
+// CHECK-SAME:         %[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x4x16x16xf32>
+// CHECK-SAME:         %[[ARG1:[a-zA-Z0-9_]+]]: tensor<16x4x3x3xf32>
+// CHECK-DAG:          %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-OUTER-DAG:    %[[EMPTY0:.+]] = tensor.empty() : tensor<8x8x4x16xf32>
+// CHECK-INNER-DAG:    %[[EMPTY0:.+]] = tensor.empty() : tensor<4x16x8x8xf32>
+// CHECK:              %[[FILTER_TF:.+]] = iree_linalg_ext.winograd.filter_transform output_tile_size(6) kernel_size(3) kernel_dimensions([2, 3])
+// CHECK-OUTER-SAME:     input_tile_dimensions([0, 1]) ins(%[[ARG1]] : tensor<16x4x3x3xf32>) outs(%[[EMPTY0]] :
+// CHECK-INNER-SAME:     input_tile_dimensions([2, 3]) ins(%[[ARG1]] : tensor<16x4x3x3xf32>) outs(%[[EMPTY0]] :
+// CHECK-OUTER-SAME:     tensor<8x8x4x16xf32>) -> tensor<8x8x4x16xf32>
+// CHECK-INNER-SAME:     tensor<4x16x8x8xf32>) -> tensor<4x16x8x8xf32>
+// CHECK:              %[[COLLAPSED_FILTER:.+]] = tensor.collapse_shape %[[FILTER_TF]]
+// CHECK-OUTER-SAME{LITERAL}: [[0, 1], [2], [3]]
+// CHECK-INNER-SAME{LITERAL}: [[0], [1], [2, 3]]
+// CHECK-OUTER-SAME:           tensor<8x8x4x16xf32> into tensor<64x4x16xf32>
+// CHECK-INNER-SAME:           tensor<4x16x8x8xf32> into tensor<4x16x64xf32>
+// CHECK-OUTER:        %[[EMPTY1:.+]] = tensor.empty() : tensor<8x8x1x3x3x4xf32>
+// CHECK-INNER:        %[[EMPTY1:.+]] = tensor.empty() : tensor<1x3x3x4x8x8xf32>
+// CHECK:              %[[INPUT_TF:.+]] = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3) image_dimensions([2, 3])
+// CHECK-OUTER-SAME:     input_tile_dimensions([0, 1]) ins(%[[ARG0]] : tensor<1x4x16x16xf32>) outs(%[[EMPTY1]] :
+// CHECK-INNER-SAME:     input_tile_dimensions([4, 5]) ins(%[[ARG0]] : tensor<1x4x16x16xf32>) outs(%[[EMPTY1]] :
+// CHECK-OUTER-SAME:     tensor<8x8x1x3x3x4xf32>) -> tensor<8x8x1x3x3x4xf32>
+// CHECK-INNER-SAME:     tensor<1x3x3x4x8x8xf32>) -> tensor<1x3x3x4x8x8xf32>
+// CHECK:              %[[COLLAPSED_INPUT:.+]] = tensor.collapse_shape %[[INPUT_TF]]
+// CHECK-OUTER-SAME{LITERAL}: [[0, 1], [2, 3, 4], [5]]
+// CHECK-INNER-SAME{LITERAL}: [[0, 1, 2], [3], [4, 5]]
+// CHECK-OUTER-SAME:           tensor<8x8x1x3x3x4xf32> into tensor<64x9x4xf32>
+// CHECK-INNER-SAME:           tensor<1x3x3x4x8x8xf32> into tensor<9x4x64xf32>
+// CHECK-OUTER:        %[[EMPTY2:.+]] = tensor.empty() : tensor<64x9x16xf32>
+// CHECK-INNER:        %[[EMPTY2:.+]] = tensor.empty() : tensor<9x16x64xf32>
+// CHECK:              %[[FILL:.+]] = linalg.fill ins(%[[ZERO]] : f32) outs(%[[EMPTY2]]
+// CHECK:              %[[BMM:.+]] = linalg.generic
+// CHECK-OUTER-SAME:     indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>]
+// CHECK-INNER-SAME:     indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d1, d3, d0)>, affine_map<(d0, d1, d2, d3) -> (d3, d2, d0)>, affine_map<(d0, d1, d2, d3) -> (d1, d2, d0)>]
+// CHECK-SAME:           iterator_types = ["parallel", "parallel", "parallel", "reduction"]
+// CHECK-SAME:           ins(%[[COLLAPSED_INPUT]], %[[COLLAPSED_FILTER]]
+// CHECK-SAME:           outs(%[[FILL]]
+// CHECK:              %[[EXPANDED:.+]] = tensor.expand_shape %[[BMM]]
+// CHECK-OUTER-SAME{LITERAL}: [[0, 1], [2, 3, 4], [5]]
+// CHECK-INNER-SAME{LITERAL}: [[0, 1, 2], [3], [4, 5]]
+// CHECK-OUTER-SAME:          tensor<64x9x16xf32> into tensor<8x8x1x3x3x16xf32>
+// CHECK-INNER-SAME:          tensor<9x16x64xf32> into tensor<1x3x3x16x8x8xf32>
+// CHECK:              %[[EMPTY3:.+]] = tensor.empty() : tensor<1x16x18x18xf32>
+// CHECK:              %[[OUTPUT_TF:.+]] = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3) image_dimensions([2, 3])
+// CHECK-OUTER-SAME:     input_tile_dimensions([0, 1]) ins(%[[EXPANDED]] : tensor<8x8x1x3x3x16xf32>) outs(%[[EMPTY3]] :
+// CHECK-INNER-SAME:     input_tile_dimensions([4, 5]) ins(%[[EXPANDED]] : tensor<1x3x3x16x8x8xf32>) outs(%[[EMPTY3]] :
+// CHECK-SAME:           tensor<1x16x18x18xf32>) -> tensor<1x16x18x18xf32>
+// CHECK:              %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[OUTPUT_TF]][0, 0, 0, 0] [1, 16, 14, 14] [1, 1, 1, 1] :
+// CHECK-SAME:           tensor<1x16x18x18xf32> to tensor<1x16x14x14xf32>
+// CHECK:              util.return %[[EXTRACTED_SLICE]] : tensor<1x16x14x14xf32>
+// CHECK:            }
 
 // -----
 
@@ -96,40 +131,57 @@ util.func public @conv_mixed_types(%arg0: tensor<1x16x16x4xf16>, %arg1: tensor<3
     outs(%arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32>
   util.return %0 : tensor<1x14x14x16xf32>
 }
-// CHECK-ALL:  util.func public @conv_mixed_types(
-// CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x16x16x4xf16>
-// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<3x3x4x16xf16>
-// CHECK-DAG:    %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
-// CHECK-DAG:    %[[EMPTY0:.+]] = tensor.empty() : tensor<8x8x4x16xf16>
-// CHECK:        %[[FILTER_TF:.+]] = iree_linalg_ext.winograd.filter_transform output_tile_size(6) kernel_size(3)
-// CHECK-SAME:     kernel_dimensions([0, 1]) ins(%[[ARG1]] : tensor<3x3x4x16xf16>) outs(%[[EMPTY0]] :
-// CHECK-SAME:     tensor<8x8x4x16xf16>) -> tensor<8x8x4x16xf16>
-// CHECK:        %[[COLLAPSED_FILTER:.+]] = tensor.collapse_shape %[[FILTER_TF]]
-// CHECK-SAME{LITERAL}:  [[0, 1], [2], [3]]
-// CHECK-SAME:           tensor<8x8x4x16xf16> into tensor<64x4x16xf16>
-// CHECK:        %[[EMPTY1:.+]] = tensor.empty() : tensor<8x8x1x3x3x4xf16>
-// CHECK:        %[[INPUT_TF:.+]] = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3)
-// CHECK-SAME:     image_dimensions([1, 2]) ins(%[[ARG0]] : tensor<1x16x16x4xf16>) outs(%[[EMPTY1]] :
-// CHECK-SAME:     tensor<8x8x1x3x3x4xf16>) -> tensor<8x8x1x3x3x4xf16>
-// CHECK:        %[[COLLAPSED_INPUT:.+]] = tensor.collapse_shape %[[INPUT_TF]]
-// CHECK-SAME{LITERAL}:  [[0, 1], [2, 3, 4], [5]]
-// CHECK-SAME:           tensor<8x8x1x3x3x4xf16> into tensor<64x9x4xf16>
-// CHECK:        %[[EMPTY2:.+]] = tensor.empty() : tensor<64x9x16xf32>
-// CHECK:        %[[FILL:.+]] = linalg.fill ins(%[[ZERO]] : f32) outs(%[[EMPTY2]] : tensor<64x9x16xf32>) ->
-// CHECK-SAME:     tensor<64x9x16xf32>
-// CHECK:        %[[BMM:.+]] = linalg.batch_matmul ins(%[[COLLAPSED_INPUT]], %[[COLLAPSED_FILTER]] : tensor<64x9x4xf16>,
-// CHECK-SAME:     tensor<64x4x16xf16>) outs(%[[FILL]] : tensor<64x9x16xf32>) -> tensor<64x9x16xf32>
-// CHECK:        %[[EXPANDED:.+]] = tensor.expand_shape %[[BMM]]
-// CHECK-SAME{LITERAL}: [[0, 1], [2, 3, 4], [5]]
-// CHECK-SAME:          tensor<64x9x16xf32> into tensor<8x8x1x3x3x16xf32>
-// CHECK:        %[[EMPTY3:.+]] = tensor.empty() : tensor<1x18x18x16xf32>
-// CHECK:        %[[OUTPUT_TF:.+]] = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3)
-// CHECK-SAME:     image_dimensions([1, 2]) ins(%[[EXPANDED]] : tensor<8x8x1x3x3x16xf32>) outs(%[[EMPTY3]] :
-// CHECK-SAME:     tensor<1x18x18x16xf32>) -> tensor<1x18x18x16xf32>
-// CHECK:        %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[OUTPUT_TF]][0, 0, 0, 0] [1, 14, 14, 16] [1, 1, 1, 1] :
-// CHECK-SAME:     tensor<1x18x18x16xf32> to tensor<1x14x14x16xf32>
-// CHECK:        util.return %[[EXTRACTED_SLICE]] : tensor<1x14x14x16xf32>
-// CHECK:      }
+// CHECK-ALL:        util.func public @conv_mixed_types(
+// CHECK-SAME:         %[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x16x16x4xf16>
+// CHECK-SAME:         %[[ARG1:[a-zA-Z0-9_]+]]: tensor<3x3x4x16xf16>
+// CHECK-DAG:          %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-OUTER-DAG:    %[[EMPTY0:.+]] = tensor.empty() : tensor<8x8x4x16xf16>
+// CHECK-INNER-DAG:    %[[EMPTY0:.+]] = tensor.empty() : tensor<4x16x8x8xf16>
+// CHECK:              %[[FILTER_TF:.+]] = iree_linalg_ext.winograd.filter_transform output_tile_size(6) kernel_size(3) kernel_dimensions([0, 1])
+// CHECK-OUTER-SAME:     input_tile_dimensions([0, 1]) ins(%[[ARG1]] : tensor<3x3x4x16xf16>) outs(%[[EMPTY0]] :
+// CHECK-INNER-SAME:     input_tile_dimensions([2, 3]) ins(%[[ARG1]] : tensor<3x3x4x16xf16>) outs(%[[EMPTY0]] :
+// CHECK-OUTER-SAME:     tensor<8x8x4x16xf16>) -> tensor<8x8x4x16xf16>
+// CHECK-INNER-SAME:     tensor<4x16x8x8xf16>) -> tensor<4x16x8x8xf16>
+// CHECK:              %[[COLLAPSED_FILTER:.+]] = tensor.collapse_shape %[[FILTER_TF]]
+// CHECK-OUTER-SAME{LITERAL}:  [[0, 1], [2], [3]]
+// CHECK-INNER-SAME{LITERAL}:  [[0], [1], [2, 3]]
+// CHECK-OUTER-SAME:           tensor<8x8x4x16xf16> into tensor<64x4x16xf16>
+// CHECK-INNER-SAME:           tensor<4x16x8x8xf16> into tensor<4x16x64xf16>
+// CHECK-OUTER:        %[[EMPTY1:.+]] = tensor.empty() : tensor<8x8x1x3x3x4xf16>
+// CHECK-INNER:        %[[EMPTY1:.+]] = tensor.empty() : tensor<1x3x3x4x8x8xf16>
+// CHECK:              %[[INPUT_TF:.+]] = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2])
+// CHECK-OUTER-SAME:     input_tile_dimensions([0, 1]) ins(%[[ARG0]] : tensor<1x16x16x4xf16>) outs(%[[EMPTY1]] :
+// CHECK-INNER-SAME:     input_tile_dimensions([4, 5]) ins(%[[ARG0]] : tensor<1x16x16x4xf16>) outs(%[[EMPTY1]] :
+// CHECK-OUTER-SAME:     tensor<8x8x1x3x3x4xf16>) -> tensor<8x8x1x3x3x4xf16>
+// CHECK-INNER-SAME:     tensor<1x3x3x4x8x8xf16>) -> tensor<1x3x3x4x8x8xf16>
+// CHECK:              %[[COLLAPSED_INPUT:.+]] = tensor.collapse_shape %[[INPUT_TF]]
+// CHECK-OUTER-SAME{LITERAL}:  [[0, 1], [2, 3, 4], [5]]
+// CHECK-INNER-SAME{LITERAL}:  [[0, 1, 2], [3], [4, 5]]
+// CHECK-OUTER-SAME:           tensor<8x8x1x3x3x4xf16> into tensor<64x9x4xf16>
+// CHECK-INNER-SAME:           tensor<1x3x3x4x8x8xf16> into tensor<9x4x64xf16>
+// CHECK-OUTER:        %[[EMPTY2:.+]] = tensor.empty() : tensor<64x9x16xf32>
+// CHECK-INNER:        %[[EMPTY2:.+]] = tensor.empty() : tensor<9x16x64xf32>
+// CHECK:              %[[FILL:.+]] = linalg.fill ins(%[[ZERO]] : f32) outs(%[[EMPTY2]]
+// CHECK:              %[[BMM:.+]] = linalg.generic
+// CHECK-OUTER-SAME:     indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>]
+// CHECK-INNER-SAME:     indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d1, d3, d0)>, affine_map<(d0, d1, d2, d3) -> (d3, d2, d0)>, affine_map<(d0, d1, d2, d3) -> (d1, d2, d0)>]
+// CHECK-SAME:           iterator_types = ["parallel", "parallel", "parallel", "reduction"]
+// CHECK-SAME:           ins(%[[COLLAPSED_INPUT]], %[[COLLAPSED_FILTER]]
+// CHECK-SAME:           outs(%[[FILL]]
+// CHECK:              %[[EXPANDED:.+]] = tensor.expand_shape %[[BMM]]
+// CHECK-OUTER-SAME{LITERAL}: [[0, 1], [2, 3, 4], [5]]
+// CHECK-INNER-SAME{LITERAL}: [[0, 1, 2], [3], [4, 5]]
+// CHECK-OUTER-SAME:          tensor<64x9x16xf32> into tensor<8x8x1x3x3x16xf32>
+// CHECK-INNER-SAME:          tensor<9x16x64xf32> into tensor<1x3x3x16x8x8xf32>
+// CHECK:              %[[EMPTY3:.+]] = tensor.empty() : tensor<1x18x18x16xf32>
+// CHECK:              %[[OUTPUT_TF:.+]] = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2])
+// CHECK-OUTER-SAME:     input_tile_dimensions([0, 1]) ins(%[[EXPANDED]] : tensor<8x8x1x3x3x16xf32>) outs(%[[EMPTY3]] :
+// CHECK-INNER-SAME:     input_tile_dimensions([4, 5]) ins(%[[EXPANDED]] : tensor<1x3x3x16x8x8xf32>) outs(%[[EMPTY3]] :
+// CHECK-SAME:           tensor<1x18x18x16xf32>) -> tensor<1x18x18x16xf32>
+// CHECK:              %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[OUTPUT_TF]][0, 0, 0, 0] [1, 14, 14, 16] [1, 1, 1, 1] :
+// CHECK-SAME:           tensor<1x18x18x16xf32> to tensor<1x14x14x16xf32>
+// CHECK:              util.return %[[EXTRACTED_SLICE]] : tensor<1x14x14x16xf32>
+// CHECK:            }
 
 // -----
 
@@ -143,7 +195,7 @@ util.func public @conv_rewrite_annotated(%arg0: tensor<1x16x16x4xf32>, %arg1: te
 // CHECK-ALL:        util.func public @conv_rewrite_annotated(
 // CHECK-ANNOTATED:    iree_linalg_ext.winograd.filter_transform
 // CHECK-ANNOTATED:    iree_linalg_ext.winograd.input_transform
-// CHECK-ANNOTATED:    linalg.batch_matmul
+// CHECK-ANNOTATED:    linalg.generic
 // CHECK-ANNOTATED:    iree_linalg_ext.winograd.output_transform
 
 // -----
@@ -158,5 +210,5 @@ util.func public @conv_skip_unannotated(%arg0: tensor<1x16x16x4xf32>, %arg1: ten
 // CHECK-ALL:            util.func public @conv_skip_unannotated(
 // CHECK-ANNOTATED-NOT:    iree_linalg_ext.winograd.filter_transform
 // CHECK-ANNOTATED-NOT:    iree_linalg_ext.winograd.input_transform
-// CHECK-ANNOTATED-NOT:    linalg.batch_matmul
+// CHECK-ANNOTATED-NOT:    linalg.generic
 // CHECK-ANNOTATED-NOT:    iree_linalg_ext.winograd.output_transform

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_winograd.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_winograd.mlir
@@ -4,7 +4,7 @@ module {
   func.func @winograd_filter_transform(%arg0: tensor<3x3x64x128xf32>, %arg1: tensor<8x8x64x128xf32>) -> tensor<8x8x64x128xf32> {
     %extracted_slice = tensor.extract_slice %arg0[0, 0, 0, 0] [3, 3, 1, 1] [1, 1, 1, 1] : tensor<3x3x64x128xf32> to tensor<3x3x1x1xf32>
     %extracted_slice_0 = tensor.extract_slice %arg1[0, 0, 0, 0] [8, 8, 1, 1] [1, 1, 1, 1] : tensor<8x8x64x128xf32> to tensor<8x8x1x1xf32>
-    %14 = iree_linalg_ext.winograd.filter_transform output_tile_size(6) kernel_size(3) kernel_dimensions([0, 1]) ins(%extracted_slice : tensor<3x3x1x1xf32>) outs(%extracted_slice_0 : tensor<8x8x1x1xf32>) -> tensor<8x8x1x1xf32>
+    %14 = iree_linalg_ext.winograd.filter_transform output_tile_size(6) kernel_size(3) kernel_dimensions([0, 1]) input_tile_dimensions([0, 1]) ins(%extracted_slice : tensor<3x3x1x1xf32>) outs(%extracted_slice_0 : tensor<8x8x1x1xf32>) -> tensor<8x8x1x1xf32>
     %inserted_slice = tensor.insert_slice %14 into %arg1[0, 0, 0, 0] [8, 8, 1, 1] [1, 1, 1, 1] : tensor<8x8x1x1xf32> into tensor<8x8x64x128xf32>
     return %inserted_slice : tensor<8x8x64x128xf32>
   }
@@ -30,10 +30,39 @@ module {
 // -----
 
 module {
+  func.func @winograd_filter_transform_inner_tile(%arg0: tensor<3x3x64x128xf32>, %arg1: tensor<64x128x8x8xf32>) -> tensor<64x128x8x8xf32> {
+    %extracted_slice = tensor.extract_slice %arg0[0, 0, 0, 0] [3, 3, 1, 1] [1, 1, 1, 1] : tensor<3x3x64x128xf32> to tensor<3x3x1x1xf32>
+    %extracted_slice_0 = tensor.extract_slice %arg1[0, 0, 0, 0] [1, 1, 8, 8] [1, 1, 1, 1] : tensor<64x128x8x8xf32> to tensor<1x1x8x8xf32>
+    %14 = iree_linalg_ext.winograd.filter_transform output_tile_size(6) kernel_size(3) kernel_dimensions([0, 1]) input_tile_dimensions([2, 3]) ins(%extracted_slice : tensor<3x3x1x1xf32>) outs(%extracted_slice_0 : tensor<1x1x8x8xf32>) -> tensor<1x1x8x8xf32>
+    %inserted_slice = tensor.insert_slice %14 into %arg1[0, 0, 0, 0] [1, 1, 8, 8] [1, 1, 1, 1] : tensor<1x1x8x8xf32> into tensor<64x128x8x8xf32>
+    return %inserted_slice : tensor<64x128x8x8xf32>
+  }
+}
+// CHECK:      func.func @winograd_filter_transform_inner_tile(
+// CHECK-SAME:   %[[ARG0:.+]]: tensor<3x3x64x128xf32>
+// CHECK-SAME:   %[[ARG1:.+]]: tensor<64x128x8x8xf32>
+// CHECK-DAG:    %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:    %[[GT:.+]] = arith.constant dense<{{\[\[}}1.000000e+00, -0.222222224,{{.*}} : tensor<3x8xf32>
+// CHECK-DAG:    %[[G:.+]] = arith.constant dense<{{\[\[}}1.000000e+00, 0.000000e+00,{{.*}} : tensor<8x3xf32>
+// CHECK-DAG:    %[[EMPTY:.+]] = tensor.empty() : tensor<3x8xf32>
+// CHECK-DAG:    %[[INPUT_TILE:.+]] = tensor.extract_slice %[[ARG0]]
+// CHECK-DAG:    %[[OUTPUT_TILE:.+]] = tensor.extract_slice %[[ARG1]]
+// CHECK:        %[[FILL_0:.+]] = linalg.fill ins(%[[ZERO]] : f32) outs(%[[EMPTY]] : tensor<3x8xf32>) -> tensor<3x8xf32>
+// CHECK:        %[[MATMUL_0:.+]] = linalg.matmul ins(%[[INPUT_TILE]], %[[GT]]
+// CHECK-SAME:     outs(%[[FILL_0]]
+// CHECK:        %[[FILL_1:.+]] = linalg.fill ins(%[[ZERO]] : f32) outs(%[[OUTPUT_TILE]] : tensor<8x8xf32>) -> tensor<8x8xf32>
+// CHECK:        %[[MATMUL_1:.+]] = linalg.matmul ins(%[[G]], %[[MATMUL_0]]
+// CHECK-SAME:     outs(%[[FILL_1]]
+// CHECK:        %[[INSERTED_SLICE_1:.+]] = tensor.insert_slice %[[MATMUL_1]] into %[[ARG1]]
+// CHECK:        return %[[INSERTED_SLICE_1]] : tensor<64x128x8x8xf32>
+
+// -----
+
+module {
   func.func @winograd_filter_transform_fchw(%arg0: tensor<64x128x3x3xf32>, %arg1: tensor<8x8x64x128xf32>) -> tensor<8x8x64x128xf32> {
     %extracted_slice = tensor.extract_slice %arg0[0, 0, 0, 0] [1, 1, 3, 3] [1, 1, 1, 1] : tensor<64x128x3x3xf32> to tensor<1x1x3x3xf32>
     %extracted_slice_0 = tensor.extract_slice %arg1[0, 0, 0, 0] [8, 8, 1, 1] [1, 1, 1, 1] : tensor<8x8x64x128xf32> to tensor<8x8x1x1xf32>
-    %14 = iree_linalg_ext.winograd.filter_transform output_tile_size(6) kernel_size(3) kernel_dimensions([2, 3]) ins(%extracted_slice : tensor<1x1x3x3xf32>) outs(%extracted_slice_0 : tensor<8x8x1x1xf32>) -> tensor<8x8x1x1xf32>
+    %14 = iree_linalg_ext.winograd.filter_transform output_tile_size(6) kernel_size(3) kernel_dimensions([2, 3]) input_tile_dimensions([0, 1]) ins(%extracted_slice : tensor<1x1x3x3xf32>) outs(%extracted_slice_0 : tensor<8x8x1x1xf32>) -> tensor<8x8x1x1xf32>
     %inserted_slice = tensor.insert_slice %14 into %arg1[0, 0, 0, 0] [8, 8, 1, 1] [1, 1, 1, 1] : tensor<8x8x1x1xf32> into tensor<8x8x64x128xf32>
     return %inserted_slice : tensor<8x8x64x128xf32>
   }
@@ -64,7 +93,7 @@ module {
                                       %i0 : index, %i1 : index, %i2 : index, %i3 : index, %i4 : index, %i5 : index) -> tensor<8x8x2x22x22x64xf16> {
     %extracted_slice = tensor.extract_slice %arg0[%i0, %i2, %i3, %i1] [1, %s0, %s1, 1] [1, 1, 1, 1] : tensor<2x130x130x64xf16> to tensor<1x?x?x1xf16>
     %extracted_slice_0 = tensor.extract_slice %arg1[0, 0, %i0, %i4, %i5, %i1] [8, 8, 1, 1, 1, 1] [1, 1, 1, 1, 1, 1] : tensor<8x8x2x22x22x64xf16> to tensor<8x8x1x1x1x1xf16>
-    %14 = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) ins(%extracted_slice : tensor<1x?x?x1xf16>) outs(%extracted_slice_0 : tensor<8x8x1x1x1x1xf16>) -> tensor<8x8x1x1x1x1xf16>
+    %14 = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) input_tile_dimensions([0, 1]) ins(%extracted_slice : tensor<1x?x?x1xf16>) outs(%extracted_slice_0 : tensor<8x8x1x1x1x1xf16>) -> tensor<8x8x1x1x1x1xf16>
     %inserted_slice = tensor.insert_slice %14 into %arg1[0, 0, %i0, %i4, %i5, %i1] [8, 8, 1, 1, 1, 1] [1, 1, 1, 1, 1, 1] : tensor<8x8x1x1x1x1xf16> into tensor<8x8x2x22x22x64xf16>
     return %inserted_slice : tensor<8x8x2x22x22x64xf16>
   }
@@ -99,12 +128,52 @@ module {
 // -----
 
 module {
+  func.func @winograd_input_transform_inner_tile(%arg0: tensor<2x130x130x64xf16>, %arg1: tensor<2x22x22x64x8x8xf16>,
+                                      %s0 : index, %s1 : index,
+                                      %i0 : index, %i1 : index, %i2 : index, %i3 : index, %i4 : index, %i5 : index) -> tensor<2x22x22x64x8x8xf16> {
+    %extracted_slice = tensor.extract_slice %arg0[%i0, %i2, %i3, %i1] [1, %s0, %s1, 1] [1, 1, 1, 1] : tensor<2x130x130x64xf16> to tensor<1x?x?x1xf16>
+    %extracted_slice_0 = tensor.extract_slice %arg1[%i0, %i4, %i5, %i1, 0, 0] [1, 1, 1, 1, 8, 8] [1, 1, 1, 1, 1, 1] : tensor<2x22x22x64x8x8xf16> to tensor<1x1x1x1x8x8xf16>
+    %14 = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) input_tile_dimensions([4, 5]) ins(%extracted_slice : tensor<1x?x?x1xf16>) outs(%extracted_slice_0 : tensor<1x1x1x1x8x8xf16>) -> tensor<1x1x1x1x8x8xf16>
+    %inserted_slice = tensor.insert_slice %14 into %arg1[%i0, %i4, %i5, %i1, 0, 0] [1, 1, 1, 1, 8, 8] [1, 1, 1, 1, 1, 1] : tensor<1x1x1x1x8x8xf16> into tensor<2x22x22x64x8x8xf16>
+    return %inserted_slice : tensor<2x22x22x64x8x8xf16>
+  }
+}
+// CHECK-DAG:  #[[MAP:.+]] = affine_map<()[s0] -> (-s0 + 8)>
+// CHECK:      func.func @winograd_input_transform_inner_tile(
+// CHECK-SAME:   %[[ARG0:.+]]: tensor<2x130x130x64xf16>
+// CHECK-SAME:   %[[ARG1:.+]]: tensor<2x22x22x64x8x8xf16>
+// CHECK-DAG:    %[[ZERO:.+]] = arith.constant 0.000000e+00 : f16
+// CHECK-DAG:    %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:    %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:    %[[BT:.+]] = arith.constant dense<{{\[\[}}1.000000e+00, 0.000000e+00, 0.000000e+00,{{.*}} : tensor<8x8xf32>
+// CHECK-DAG:    %[[B:.+]] = arith.constant dense<{{\[\[}}1.000000e+00, 0.000000e+00, -5.250000e+00,{{.*}} : tensor<8x8xf32>
+// CHECK-DAG:    %[[INPUT_TILE:.+]] = tensor.extract_slice %[[ARG0]]
+// CHECK-DAG:    %[[OUTPUT_TILE:.+]] = tensor.extract_slice %[[ARG1]]
+// CHECK-DAG:    %[[DIM0:.+]] = tensor.dim %[[INPUT_TILE]], %[[C0]] : tensor<?x?xf16>
+// CHECK-DAG:    %[[PAD_HIGH0:.+]] = affine.apply #[[MAP]](){{\[}}%[[DIM0]]]
+// CHECK-DAG:    %[[DIM1:.+]] = tensor.dim %[[INPUT_TILE]], %[[C1]] : tensor<?x?xf16>
+// CHECK-DAG:    %[[PAD_HIGH1:.+]] = affine.apply #[[MAP]](){{\[}}%[[DIM1]]]
+// CHECK:        %[[PAD:.+]] = tensor.pad %[[INPUT_TILE]] low[0, 0] high{{\[}}%[[PAD_HIGH0]], %[[PAD_HIGH1]]]
+// CHECK-NEXT:     ^bb0(
+// CHECK-NEXT:       tensor.yield %[[ZERO]] : f16
+// CHECK-NEXT:    } : tensor<?x?xf16> to tensor<8x8xf16>
+// CHECK:        %[[FILL_1:.+]] = linalg.fill ins(%[[ZERO]] : f16) outs(%[[OUTPUT_TILE]] : tensor<8x8xf16>) -> tensor<8x8xf16>
+// CHECK:        %[[MATMUL_0:.+]] = linalg.matmul ins(%[[PAD]], %[[BT]]
+// CHECK-SAME:     outs(%[[FILL_1]]
+// CHECK:        %[[MATMUL_1:.+]] = linalg.matmul ins(%[[B]], %[[MATMUL_0]]
+// CHECK-SAME:     outs(%[[FILL_1]]
+// CHECK:        %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[MATMUL_1]] into %[[ARG1]]
+// CHECK:        return %[[INSERTED_SLICE]] : tensor<2x22x22x64x8x8xf16>
+
+// -----
+
+module {
   func.func @winograd_input_transform_nchw(%arg0: tensor<2x64x130x130xf16>, %arg1: tensor<8x8x2x22x22x64xf16>,
                                            %s0 : index, %s1 : index,
                                            %i0 : index, %i1 : index, %i2 : index, %i3 : index, %i4 : index, %i5 : index) -> tensor<8x8x2x22x22x64xf16> {
     %extracted_slice = tensor.extract_slice %arg0[%i0, %i1, %i2, %i3] [1, 1, %s0, %s1] [1, 1, 1, 1] : tensor<2x64x130x130xf16> to tensor<1x1x?x?xf16>
     %extracted_slice_0 = tensor.extract_slice %arg1[0, 0, %i0, %i4, %i5, %i1] [8, 8, 1, 1, 1, 1] [1, 1, 1, 1, 1, 1] : tensor<8x8x2x22x22x64xf16> to tensor<8x8x1x1x1x1xf16>
-    %14 = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3) image_dimensions([2, 3]) ins(%extracted_slice : tensor<1x1x?x?xf16>) outs(%extracted_slice_0 : tensor<8x8x1x1x1x1xf16>) -> tensor<8x8x1x1x1x1xf16>
+    %14 = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3) image_dimensions([2, 3]) input_tile_dimensions([0, 1]) ins(%extracted_slice : tensor<1x1x?x?xf16>) outs(%extracted_slice_0 : tensor<8x8x1x1x1x1xf16>) -> tensor<8x8x1x1x1x1xf16>
     %inserted_slice = tensor.insert_slice %14 into %arg1[0, 0, %i0, %i4, %i5, %i1] [8, 8, 1, 1, 1, 1] [1, 1, 1, 1, 1, 1] : tensor<8x8x1x1x1x1xf16> into tensor<8x8x2x22x22x64xf16>
     return %inserted_slice : tensor<8x8x2x22x22x64xf16>
   }
@@ -146,7 +215,7 @@ module {
                                        %i0 : index, %i1 : index, %i2 : index, %i3 : index, %i4 : index) -> tensor<1x36x36x32xf16> {
     %extracted_slice = tensor.extract_slice %arg0[0, 0, 0, %i0, %i1, %i2] [8, 8, 1, 1, 1, 1] [1, 1, 1, 1, 1, 1] : tensor<8x8x1x6x6x32xf16> to tensor<8x8x1x1x1x1xf16>
     %extracted_slice_0 = tensor.extract_slice %arg1[0, %i3, %i4, %i2] [1, %s0, %s1, 1] [1, 1, 1, 1] : tensor<1x36x36x32xf16> to tensor<1x?x?x1xf16>
-    %12 = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) ins(%extracted_slice : tensor<8x8x1x1x1x1xf16>) outs(%extracted_slice_0 : tensor<1x?x?x1xf16>) -> tensor<1x?x?x1xf16>
+    %12 = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) input_tile_dimensions([0, 1]) ins(%extracted_slice : tensor<8x8x1x1x1x1xf16>) outs(%extracted_slice_0 : tensor<1x?x?x1xf16>) -> tensor<1x?x?x1xf16>
     %inserted_slice = tensor.insert_slice %12 into %arg1[0, %i3, %i4, %i2] [1, %s0, %s1, 1] [1, 1, 1, 1] : tensor<1x?x?x1xf16> into tensor<1x36x36x32xf16>
     return %inserted_slice : tensor<1x36x36x32xf16>
   }
@@ -174,12 +243,45 @@ module {
 // -----
 
 module {
+  func.func @winograd_output_transform_inner_tile(%arg0: tensor<1x6x6x32x8x8xf16>, %arg1: tensor<1x36x36x32xf16>,
+                                       %s0 : index, %s1 : index,
+                                       %i0 : index, %i1 : index, %i2 : index, %i3 : index, %i4 : index) -> tensor<1x36x36x32xf16> {
+    %extracted_slice = tensor.extract_slice %arg0[0, %i0, %i1, %i2, 0, 0] [1, 1, 1, 1, 8, 8] [1, 1, 1, 1, 1, 1] : tensor<1x6x6x32x8x8xf16> to tensor<1x1x1x1x8x8xf16>
+    %extracted_slice_0 = tensor.extract_slice %arg1[0, %i3, %i4, %i2] [1, %s0, %s1, 1] [1, 1, 1, 1] : tensor<1x36x36x32xf16> to tensor<1x?x?x1xf16>
+    %12 = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3) image_dimensions([1, 2]) input_tile_dimensions([4, 5]) ins(%extracted_slice : tensor<1x1x1x1x8x8xf16>) outs(%extracted_slice_0 : tensor<1x?x?x1xf16>) -> tensor<1x?x?x1xf16>
+    %inserted_slice = tensor.insert_slice %12 into %arg1[0, %i3, %i4, %i2] [1, %s0, %s1, 1] [1, 1, 1, 1] : tensor<1x?x?x1xf16> into tensor<1x36x36x32xf16>
+    return %inserted_slice : tensor<1x36x36x32xf16>
+  }
+}
+// CHECK:      func.func @winograd_output_transform_inner_tile(
+// CHECK-SAME:   %[[ARG0:.+]]: tensor<1x6x6x32x8x8xf16>
+// CHECK-SAME:   %[[ARG1:.+]]: tensor<1x36x36x32xf16>
+// CHECK-DAG:    %[[ZERO:.+]] = arith.constant 0.000000e+00 : f16
+// CHECK-DAG:    %[[AT:.+]] = arith.constant dense<{{\[\[}}1.000000e+00, 1.000000e+00,{{.*}} : tensor<6x8xf32>
+// CHECK-DAG:    %[[A:.+]] = arith.constant dense<{{\[\[}}1.000000e+00, 0.000000e+00,{{.*}} : tensor<8x6xf32>
+// CHECK-DAG:    %[[EMPTY:.+]] = tensor.empty() : tensor<8x6xf16>
+// CHECK-DAG:    %[[INPUT_TILE:.+]] = tensor.extract_slice %[[ARG0]]
+// CHECK-DAG:    %[[OUTPUT_TILE:.+]] = tensor.extract_slice %[[ARG1]]{{.*}} : tensor<1x36x36x32xf16> to tensor<1x?x?x1xf16>
+// CHECK-DAG:    %[[OUTPUT_TILE_REDUCED:.+]] = tensor.extract_slice %[[ARG1]]{{.*}} : tensor<1x36x36x32xf16> to tensor<?x?xf16>
+// CHECK:        %[[FILL_0:.+]] = linalg.fill ins(%[[ZERO]] : f16) outs(%[[EMPTY]] : tensor<8x6xf16>) -> tensor<8x6xf16>
+// CHECK:        %[[MATMUL_0:.+]] = linalg.matmul ins(%[[INPUT_TILE]], %[[A]]
+// CHECK-SAME:     outs(%[[FILL_0]]
+// CHECK:        %[[FILL_1:.+]] = linalg.fill ins(%[[ZERO]] : f16) outs(%[[OUTPUT_TILE_REDUCED]] : tensor<?x?xf16>) -> tensor<?x?xf16>
+// CHECK:        %[[MATMUL_1:.+]] = linalg.matmul ins(%[[AT]], %[[MATMUL_0]]
+// CHECK-SAME:     outs(%[[FILL_1]]
+// CHECK:        %[[INSERTED_SLICE_0:.+]] = tensor.insert_slice %[[MATMUL_1]] into %[[OUTPUT_TILE]]
+// CHECK:        %[[INSERTED_SLICE_1:.+]] = tensor.insert_slice %[[INSERTED_SLICE_0]] into %[[ARG1]]
+// CHECK:        return %[[INSERTED_SLICE_1]] : tensor<1x36x36x32xf16>
+
+// -----
+
+module {
   func.func @winograd_output_transform_nchw(%arg0: tensor<8x8x1x6x6x32xf16>, %arg1: tensor<1x32x36x36xf16>,
                                             %s0 : index, %s1 : index,
                                             %i0 : index, %i1 : index, %i2 : index, %i3 : index, %i4 : index) -> tensor<1x32x36x36xf16> {
     %extracted_slice = tensor.extract_slice %arg0[0, 0, 0, %i0, %i1, %i2] [8, 8, 1, 1, 1, 1] [1, 1, 1, 1, 1, 1] : tensor<8x8x1x6x6x32xf16> to tensor<8x8x1x1x1x1xf16>
     %extracted_slice_0 = tensor.extract_slice %arg1[0, %i2, %i3, %i4] [1, 1, %s0, %s1] [1, 1, 1, 1] : tensor<1x32x36x36xf16> to tensor<1x1x?x?xf16>
-    %12 = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3) image_dimensions([2, 3]) ins(%extracted_slice : tensor<8x8x1x1x1x1xf16>) outs(%extracted_slice_0 : tensor<1x1x?x?xf16>) -> tensor<1x1x?x?xf16>
+    %12 = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3) image_dimensions([2, 3]) input_tile_dimensions([0, 1]) ins(%extracted_slice : tensor<8x8x1x1x1x1xf16>) outs(%extracted_slice_0 : tensor<1x1x?x?xf16>) -> tensor<1x1x?x?xf16>
     %inserted_slice = tensor.insert_slice %12 into %arg1[0, %i2, %i3, %i4] [1, 1, %s0, %s1] [1, 1, 1, 1] : tensor<1x1x?x?xf16> into tensor<1x32x36x36xf16>
     return %inserted_slice : tensor<1x32x36x36xf16>
   }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
@@ -1020,7 +1020,7 @@ func.func @winograd_filter_transform(%arg0: tensor<3x3x64x128xf32>) -> tensor<8x
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["iree_linalg_ext.winograd.filter_transform"]} in %module_op : (!transform.any_op) -> !transform.any_op
-    %1, %loops:2 = transform.structured.tile_using_for %0 tile_sizes [1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+    %1, %loops:2 = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
     transform.yield
   }
 }
@@ -1064,7 +1064,7 @@ func.func @winograd_filter_transform_memref(%arg0: memref<3x3x64x128xf32>, %arg1
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["iree_linalg_ext.winograd.filter_transform"]} in %module_op : (!transform.any_op) -> !transform.any_op
-    %1, %loops:2 = transform.structured.tile_using_for %0 tile_sizes [1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+    %1, %loops:2 = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
     transform.yield
   }
 }
@@ -1101,7 +1101,7 @@ func.func @winograd_filter_transform_dynamic(%arg0: tensor<3x3x?x?xf32>, %s0: in
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["iree_linalg_ext.winograd.filter_transform"]} in %module_op : (!transform.any_op) -> !transform.any_op
-    %1, %loops:2 = transform.structured.tile_using_for %0 tile_sizes [1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+    %1, %loops:2 = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
     transform.yield
   }
 }
@@ -1145,7 +1145,7 @@ func.func @winograd_filter_transform_fchw(%arg0: tensor<128x64x3x3xf32>) -> tens
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["iree_linalg_ext.winograd.filter_transform"]} in %module_op : (!transform.any_op) -> !transform.any_op
-    %1, %loops:2 = transform.structured.tile_using_for %0 tile_sizes [1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+    %1, %loops:2 = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
     transform.yield
   }
 }
@@ -1190,7 +1190,7 @@ func.func @winograd_input_transform(%arg0: tensor<1x10x10x1280xf32>) -> tensor<8
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["iree_linalg_ext.winograd.input_transform"]} in %module_op : (!transform.any_op) -> !transform.any_op
-    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
     transform.yield
   }
 }
@@ -1244,7 +1244,7 @@ func.func @winograd_input_transform_memref(%arg0: memref<1x10x10x1280xf32>, %arg
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["iree_linalg_ext.winograd.input_transform"]} in %module_op : (!transform.any_op) -> !transform.any_op
-    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
     transform.yield
   }
 }
@@ -1294,7 +1294,7 @@ func.func @winograd_input_transform_dynamic(%arg0: tensor<2x34x34x128xf32>, %i0:
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["iree_linalg_ext.winograd.input_transform"]} in %module_op : (!transform.any_op) -> !transform.any_op
-    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
     transform.yield
   }
 }
@@ -1363,7 +1363,7 @@ func.func @winograd_input_transform_nchw(%arg0: tensor<1x1280x10x10xf32>) -> ten
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["iree_linalg_ext.winograd.input_transform"]} in %module_op : (!transform.any_op) -> !transform.any_op
-    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
     transform.yield
   }
 }
@@ -1418,7 +1418,7 @@ func.func @winograd_output_transform(%arg0: tensor<8x8x1x2x2x32xf32>) -> tensor<
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["iree_linalg_ext.winograd.output_transform"]} in %module_op : (!transform.any_op) -> !transform.any_op
-    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
     transform.yield
   }
 }
@@ -1469,7 +1469,7 @@ func.func @winograd_output_transform_memref(%arg0: memref<8x8x1x2x2x32xf32>, %ar
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["iree_linalg_ext.winograd.output_transform"]} in %module_op : (!transform.any_op) -> !transform.any_op
-    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
     transform.yield
   }
 }
@@ -1513,7 +1513,7 @@ func.func @winograd_output_transform_dynamic(%arg0: tensor<8x8x?x?x?x?xf32>, %i0
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["iree_linalg_ext.winograd.output_transform"]} in %module_op : (!transform.any_op) -> !transform.any_op
-    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
     transform.yield
   }
 }
@@ -1578,7 +1578,7 @@ func.func @winograd_output_transform_nchw(%arg0: tensor<8x8x1x2x2x32xf32>) -> te
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
     %0 = transform.structured.match ops{["iree_linalg_ext.winograd.output_transform"]} in %module_op : (!transform.any_op) -> !transform.any_op
-    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+    %1, %loops:4 = transform.structured.tile_using_for %0 tile_sizes [0, 0, 1, 1, 1, 1] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
     transform.yield
   }
 }


### PR DESCRIPTION
This PR updates  the winograd op semantics to allow innermost inner_tile dimensions, and creates an option in the Conv2DToWinograd pass to generate this form. The new winograd semantics contain an additional field, `input_tile_dimensions`, which specifies the dimensions in the *transformed* (init for input_transform/filter_transform and input for output_transform) operand.

Having the inner_tile dimensions as innermost greatly improves the performance of the winograd transform ops themselves, but will create bad access patterns in the batch_matmul op consuming the transformed inputs. However, data tiling can get the result of the transformations back into a good layout for the matmul, and there is an overall performance benefit. Since different layouts may be better for different backends, this layout change is left as an option in the Conv2DToWinograd pass.