### PR TITLE
Add torch-fuse-quantized-ops pass to the torch-to-iree pipeline

### DIFF
--- a/compiler/plugins/input/Torch/InputConversion/Passes.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/Passes.cpp
@@ -50,6 +50,7 @@ void createTorchToIREEPipeline(
   pm.addNestedPass<func::FuncOp>(
       torch::Torch::createDecomposeComplexOpsPass(emptyArrayRef));
   pm.addNestedPass<func::FuncOp>(torch::Torch::createFuseQuantizedOpsPass());
+  pm.addNestedPass<func::FuncOp>(torch::Torch::createScalarizeShapesPass());
   pm.addNestedPass<func::FuncOp>(torch::createConvertTorchToTMTensorPass());
   pm.addNestedPass<func::FuncOp>(
       TorchInput::createConvertTMTensorToLinalgExtPass());

--- a/compiler/plugins/input/Torch/InputConversion/Passes.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/Passes.cpp
@@ -49,6 +49,7 @@ void createTorchToIREEPipeline(
       mlir::torch::TorchConversion::createConvertCustomQuantOpPass());
   pm.addNestedPass<func::FuncOp>(
       torch::Torch::createDecomposeComplexOpsPass(emptyArrayRef));
+  pm.addNestedPass<func::FuncOp>(torch::Torch::createFuseQuantizedOpsPass());
   pm.addNestedPass<func::FuncOp>(torch::createConvertTorchToTMTensorPass());
   pm.addNestedPass<func::FuncOp>(
       TorchInput::createConvertTMTensorToLinalgExtPass());


### PR DESCRIPTION
The torch to iree pipeline currently does not use `--torch-fuse-quantized-ops`, which is the cause of significant discrepancies between model testing with iree-compile from torch IR and model testing which first lowers to linalg with torch-mlir before compiling. Together with `--torch-fuse-quantized-ops`, a newer pass `--torch-scalarize-shapes` is added to the `torch-to-iree` pipeline to keep in line with the `--torch-backend-to-linalg-on-tensors-backend-pipeline`.