### PR TITLE
Fixing global symbol replacement when referenced by non-load ops.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/BUILD.bazel
@@ -16,10 +16,12 @@ iree_compiler_cc_library(
     name = "Analysis",
     srcs = [
         "Explorer.cpp",
+        "GlobalTable.cpp",
         "Position.cpp",
     ],
     hdrs = [
         "Explorer.h",
+        "GlobalTable.h",
         "Position.h",
     ],
     deps = [

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/CMakeLists.txt
@@ -15,9 +15,11 @@ iree_cc_library(
     Analysis
   HDRS
     "Explorer.h"
+    "GlobalTable.h"
     "Position.h"
   SRCS
     "Explorer.cpp"
+    "GlobalTable.cpp"
     "Position.cpp"
   DEPS
     LLVMSupport

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/GlobalTable.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/GlobalTable.cpp
@@ -1,0 +1,122 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Util/Analysis/GlobalTable.h"
+
+namespace mlir::iree_compiler::IREE::Util {
+
+GlobalTable::GlobalTable(mlir::ModuleOp moduleOp) : moduleOp(moduleOp) {
+  rebuild();
+}
+
+void GlobalTable::rebuild() {
+  globalOrder.clear();
+  globalMap.clear();
+
+  for (auto globalOp : moduleOp.getOps<IREE::Util::GlobalOpInterface>()) {
+    auto globalName = globalOp.getGlobalName();
+    globalMap[globalName] = Global{globalOrder.size(), globalOp};
+    globalOrder.push_back(globalName);
+  }
+
+  for (auto callableOp : moduleOp.getOps<CallableOpInterface>()) {
+    if (auto uses = SymbolTable::getSymbolUses(callableOp)) {
+      for (auto use : *uses) {
+        auto leafRef = use.getSymbolRef().getLeafReference().getValue();
+        auto it = globalMap.find(leafRef);
+        if (it != globalMap.end()) {
+          auto &global = it->second;
+          auto *op = use.getUser();
+          if (auto addressOp =
+                  dyn_cast<IREE::Util::GlobalAddressOpInterface>(op)) {
+            global.isIndirect = true;
+          } else if (auto loadOp =
+                         dyn_cast<IREE::Util::GlobalLoadOpInterface>(op)) {
+            global.loadOps.push_back(loadOp);
+          } else if (auto storeOp =
+                         dyn_cast<IREE::Util::GlobalStoreOpInterface>(op)) {
+            global.storeOps.push_back(storeOp);
+          } else {
+            global.referencingOps.push_back(op);
+          }
+        }
+      }
+    }
+  }
+}
+
+Global &GlobalTable::lookup(StringRef globalName) {
+  return globalMap[globalName];
+}
+
+StringRef GlobalTable::lookupByOrdinal(size_t ordinal) const {
+  return globalOrder[ordinal];
+}
+
+bool GlobalTable::forEach(std::function<GlobalAction(Global &global)> fn) {
+  bool didChange = false;
+  for (size_t i = 0; i < size();) {
+    auto globalName = globalOrder[i];
+    auto action = fn(globalMap[globalName]);
+    switch (action) {
+    case GlobalAction::PRESERVE: {
+      ++i;
+      break;
+    }
+    case GlobalAction::UPDATE: {
+      didChange |= true;
+      ++i;
+      break;
+    }
+    case GlobalAction::DELETE: {
+      didChange |= true;
+      eraseGlobal(globalName);
+      break;
+    }
+    }
+  }
+  return didChange;
+}
+
+void GlobalTable::renameGlobalUses(Global &sourceGlobal, Global &targetGlobal) {
+  auto sourceAttr = FlatSymbolRefAttr::get(sourceGlobal.op.getGlobalName());
+  auto targetAttr = FlatSymbolRefAttr::get(targetGlobal.op.getGlobalName());
+
+  // Rename all global load ops.
+  for (auto loadOp : sourceGlobal.loadOps) {
+    loadOp.setGlobalAttr(targetAttr);
+    targetGlobal.loadOps.push_back(loadOp);
+  }
+  sourceGlobal.loadOps.clear();
+
+  // Rename all references via op attributes.
+  AttrTypeReplacer replacer;
+  replacer.addReplacement([&](Attribute originalAttr)
+                              -> AttrTypeReplacer::ReplaceFnResult<Attribute> {
+    if (originalAttr == sourceAttr) {
+      return std::make_pair(cast<Attribute>(targetAttr), WalkResult::advance());
+    }
+    return std::nullopt;
+  });
+  for (auto refOp : sourceGlobal.referencingOps) {
+    replacer.recursivelyReplaceElementsIn(refOp);
+    targetGlobal.referencingOps.push_back(refOp);
+  }
+  sourceGlobal.referencingOps.clear();
+}
+
+void GlobalTable::eraseGlobal(StringRef globalName) {
+  auto &global = globalMap[globalName];
+  assert(global.op.isGlobalPrivate() && "can't delete public globals");
+  assert(global.loadOps.empty() && "must not be used");
+  assert(global.referencingOps.empty() && "must not be referenced");
+  global.eraseStores();
+  globalMap.erase(globalName);
+  llvm::erase(globalOrder, globalName);
+  global.op.erase();
+}
+
+} // namespace mlir::iree_compiler::IREE::Util

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/GlobalTable.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/GlobalTable.h
@@ -1,0 +1,129 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_DIALECT_IREE_ANALYSIS_GLOBALTABLE_H_
+#define IREE_COMPILER_DIALECT_IREE_ANALYSIS_GLOBALTABLE_H_
+
+#include <functional>
+
+#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Support/LLVM.h"
+
+namespace mlir::iree_compiler::IREE::Util {
+
+// An entry in a GlobalTable representing a util.global (or related) op.
+struct Global {
+  // Ordinal of the global in the parent module.
+  size_t ordinal = 0;
+
+  // Global this information relates to.
+  IREE::Util::GlobalOpInterface op;
+
+  // True if the address of the global is ever taken.
+  // This disables most optimizations here; we could use some data flow analysis
+  // to track potential operations on globals via the addresses but we don't
+  // currently have any input programs that require doing so.
+  bool isIndirect = false;
+
+  // All util.global.load ops referencing the global.
+  SmallVector<IREE::Util::GlobalLoadOpInterface> loadOps;
+  // All util.global.store ops referencing the global.
+  SmallVector<IREE::Util::GlobalStoreOpInterface> storeOps;
+  // All other operations that reference the global via an attribute.
+  SmallVector<Operation *> referencingOps;
+
+  // Returns the symbol name of the global op.
+  StringRef getName() { return op.getGlobalName().getValue(); }
+
+  // Returns true if the global is a candidate for folding.
+  bool isCandidate() { return !isIndirect && op.isGlobalPrivate(); }
+
+  // TODO(benvanik): refine how we determine whether we can DCE things. Today we
+  // can be too aggressive with certain types that may be side-effecting though
+  // that shouldn't be the case: the IREE execution model should not require
+  // globals to be stored to be correct as anything using a reference type
+  // should be capturing it. Unfortunately today our DCE is not comprehensive
+  // enough to be safe.
+  //
+  // Returns true if the global can be DCEd if there are no loads.
+  // This is generally only the case for value types as reference types may be
+  // aliased or have side effects on creation.
+  bool canDCE() {
+    return isCandidate() &&
+           !isa<IREE::Util::ReferenceTypeInterface>(op.getGlobalType());
+  }
+
+  // Erases all stores to the global.
+  void eraseStores() {
+    for (auto storeOp : storeOps) {
+      storeOp.erase();
+    }
+    storeOps.clear();
+  }
+};
+
+// Action to perform on a global under enumeration.
+enum class GlobalAction {
+  // Preserve the global in the program as-is.
+  PRESERVE,
+  // Global has been updated and another iteration of the pass may be required.
+  UPDATE,
+  // Delete the global as it is unused.
+  DELETE,
+};
+
+// A constructed table of analyzed globals in a module with some utilities for
+// manipulating them. This is designed for simple uses and more advanced
+// analysis should be performed with an Explorer or DFX.
+struct GlobalTable {
+  GlobalTable() = delete;
+  explicit GlobalTable(mlir::ModuleOp moduleOp);
+
+  MLIRContext *getContext() { return moduleOp.getContext(); }
+
+  // Total number of globals in the module.
+  size_t size() const { return globalOrder.size(); }
+
+  // Returns the information for the given global.
+  Global &lookup(StringRef globalName);
+  Global &lookup(StringAttr globalName) {
+    return lookup(globalName.getValue());
+  }
+
+  // Returns the global with the given ordinal.
+  StringRef lookupByOrdinal(size_t ordinal) const;
+
+  // Enumerates all globals in the program and calls the given |fn|.
+  // The function should return an action as to what should be done with the
+  // global.
+  // Returns true if any changes were made.
+  bool forEach(std::function<GlobalAction(Global &global)> fn);
+
+  // Renames all uses of |sourceGlobal| into |targetGlobal|.
+  // The source global and stores to it are preserved.
+  void renameGlobalUses(Global &sourceGlobal, Global &targetGlobal);
+
+  // Erases the global with the given name.
+  // Must have no loads or references remaining.
+  void eraseGlobal(StringRef globalName);
+
+private:
+  void rebuild();
+
+  // Module under analysis.
+  mlir::ModuleOp moduleOp;
+  // All globals in the order they are declared by symbol name.
+  SmallVector<StringRef> globalOrder;
+  // A map of global symbol names to analysis results.
+  DenseMap<StringRef, Global> globalMap;
+};
+
+} // namespace mlir::iree_compiler::IREE::Util
+
+#endif // IREE_COMPILER_DIALECT_IREE_ANALYSIS_GLOBALTABLE_H_

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/GlobalTable.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/GlobalTable.h
@@ -56,7 +56,7 @@ struct Global {
   // aliased or have side effects on creation.
   bool canDCE() {
     return isCandidate() &&
-           !isa<IREE::Util::ReferenceTypeInterface>(op.getGlobalType());
+           cast<SymbolOpInterface>(op.getOperation()).canDiscardOnUseEmpty();
   }
 
   // Erases all stores to the global.

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
@@ -635,6 +635,8 @@ def Util_FuncOp : Util_Op<"func", [
     ArrayRef<Type> getArgumentTypes() { return getFunctionType().getInputs(); }
     ArrayRef<Type> getResultTypes() { return getFunctionType().getResults(); }
 
+    bool canDiscardOnUseEmpty();
+
     // Returns true if any operand is tied to a result.
     bool hasAnyTiedOperands();
 
@@ -827,6 +829,8 @@ def Util_GlobalOp : Util_Op<"global", [
   ];
 
   let extraClassDeclaration = [{
+    bool canDiscardOnUseEmpty();
+
     IREE::Util::GlobalLoadOpInterface createLoadOp(Location loc, OpBuilder &builder);
     IREE::Util::GlobalStoreOpInterface createStoreOp(Location loc, Value value, OpBuilder &builder);
   }];

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/FoldGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/FoldGlobals.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <iterator>
 
+#include "iree/compiler/Dialect/Util/Analysis/GlobalTable.h"
 #include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "iree/compiler/Dialect/Util/IR/UtilTraits.h"
@@ -35,91 +36,6 @@ static size_t count(R &&range) {
   return std::distance(range.begin(), range.end());
 }
 
-struct Global {
-  size_t ordinal = 0;
-  IREE::Util::GlobalOpInterface op;
-  bool isIndirect = false;
-  SmallVector<IREE::Util::GlobalLoadOpInterface> loadOps;
-  SmallVector<IREE::Util::GlobalStoreOpInterface> storeOps;
-
-  bool isCandidate() { return !isIndirect && op.isGlobalPrivate(); }
-};
-
-enum class GlobalAction {
-  PRESERVE,
-  UPDATE,
-  DELETE,
-};
-
-struct GlobalTable {
-  mlir::ModuleOp moduleOp;
-  SmallVector<StringRef> globalOrder;
-  DenseMap<StringRef, Global> globalMap;
-
-  size_t size() const { return globalOrder.size(); }
-
-  explicit GlobalTable(mlir::ModuleOp moduleOp) : moduleOp(moduleOp) {
-    rebuild();
-  }
-
-  void rebuild() {
-    globalOrder.clear();
-    globalMap.clear();
-    for (auto globalOp : moduleOp.getOps<IREE::Util::GlobalOpInterface>()) {
-      auto globalName = globalOp.getGlobalName();
-      globalMap[globalName] = Global{globalOrder.size(), globalOp};
-      globalOrder.push_back(globalName);
-    }
-    for (auto callableOp : moduleOp.getOps<CallableOpInterface>()) {
-      callableOp.walk([&](Operation *op) {
-        if (auto addressOp =
-                dyn_cast<IREE::Util::GlobalAddressOpInterface>(op)) {
-          globalMap[addressOp.getGlobalName()].isIndirect = true;
-        } else if (auto loadOp =
-                       dyn_cast<IREE::Util::GlobalLoadOpInterface>(op)) {
-          globalMap[loadOp.getGlobalName()].loadOps.push_back(loadOp);
-        } else if (auto storeOp =
-                       dyn_cast<IREE::Util::GlobalStoreOpInterface>(op)) {
-          globalMap[storeOp.getGlobalName()].storeOps.push_back(storeOp);
-        }
-      });
-    }
-  }
-
-  bool forEach(std::function<GlobalAction(Global &global)> fn) {
-    bool didChange = false;
-    for (size_t i = 0; i < size();) {
-      auto globalName = globalOrder[i];
-      auto action = fn(globalMap[globalName]);
-      switch (action) {
-      case GlobalAction::PRESERVE: {
-        ++i;
-        break;
-      }
-      case GlobalAction::UPDATE: {
-        didChange |= true;
-        ++i;
-        break;
-      }
-      case GlobalAction::DELETE: {
-        didChange |= true;
-        auto &global = globalMap[globalName];
-        assert(global.op.isGlobalPrivate() && "can't delete public globals");
-        assert(global.loadOps.empty() && "must not be used");
-        for (auto storeOp : global.storeOps) {
-          storeOp.erase();
-        }
-        global.op.erase();
-        globalMap.erase(globalName);
-        globalOrder.erase(globalOrder.begin() + i);
-        break;
-      }
-      }
-    }
-    return didChange;
-  }
-};
-
 // Inlines constant stores into global initializers if always stored to the
 // same value.
 //
@@ -137,8 +53,9 @@ struct GlobalTable {
 //  util.global @a = 5 : i32
 static bool inlineConstantGlobalStores(GlobalTable &globalTable) {
   return globalTable.forEach([&](Global &global) {
-    if (global.isIndirect)
+    if (global.isIndirect) {
       return GlobalAction::PRESERVE;
+    }
 
     // Find the constant value used in all stores.
     // All stores must match the initial value of the global _or_ the global
@@ -162,18 +79,16 @@ static bool inlineConstantGlobalStores(GlobalTable &globalTable) {
         break;
       }
     }
-    if (!constantValue)
+    if (!constantValue || constantValue == global.op.getGlobalInitialValue()) {
       return GlobalAction::PRESERVE;
+    }
 
     // Propagate constant into the initial value. Note that there may have been
     // a previous initial value that is being replaced.
     global.op.setGlobalInitialValue(constantValue);
 
     // Remove all of the stores.
-    for (auto storeOp : global.storeOps) {
-      storeOp.erase();
-    }
-    global.storeOps.clear();
+    global.eraseStores();
 
     return GlobalAction::UPDATE;
   });
@@ -191,8 +106,9 @@ static bool inlineConstantGlobalStores(GlobalTable &globalTable) {
 //  util.global.mutable @chained0 : i32
 static bool renameChainedGlobals(GlobalTable &globalTable) {
   return globalTable.forEach([&](Global &global) {
-    if (!global.isCandidate())
+    if (!global.isCandidate()) {
       return GlobalAction::PRESERVE;
+    }
 
     // Find the other symbol this global is chained with by looking for uniform
     // stores. Note that we don't care about initializers.
@@ -213,22 +129,16 @@ static bool renameChainedGlobals(GlobalTable &globalTable) {
         break;
       }
     }
-    if (!aliasName)
+    if (!aliasName) {
       return GlobalAction::PRESERVE;
+    }
 
     // Replace all loads from the global with the aliased global.
-    auto &aliasGlobal = globalTable.globalMap[aliasName.getValue()];
-    for (auto loadOp : global.loadOps) {
-      loadOp.setGlobalAttr(aliasName);
-      aliasGlobal.loadOps.push_back(loadOp);
-    }
-    global.loadOps.clear();
+    auto &aliasGlobal = globalTable.lookup(aliasName.getValue());
+    globalTable.renameGlobalUses(global, aliasGlobal);
 
     // Erase all stores to the global.
-    for (auto storeOp : global.storeOps) {
-      storeOp.erase();
-    }
-    global.storeOps.clear();
+    global.eraseStores();
 
     return GlobalAction::DELETE;
   });
@@ -246,10 +156,11 @@ static bool renameChainedGlobals(GlobalTable &globalTable) {
 //  util.global @a = 5 : i32
 static bool updateGlobalImmutability(GlobalTable &globalTable) {
   return globalTable.forEach([&](Global &global) {
-    if (!global.isCandidate())
+    if (!global.isCandidate()) {
       return GlobalAction::PRESERVE;
-    if (!global.storeOps.empty())
+    } else if (!global.storeOps.empty()) {
       return GlobalAction::PRESERVE;
+    }
     bool didChangeAny = global.op.isGlobalMutable() != false;
     global.op.setGlobalMutable(false);
     for (auto loadOp : global.loadOps) {
@@ -279,22 +190,24 @@ static Value tryMaterializeConstant(Location loc, Type type, Attribute attr,
   }
   // Fallback that asks a dialect to materialize things. This may fail!
   auto *op = attr.getDialect().materializeConstant(builder, attr, type, loc);
-  if (!op)
+  if (!op) {
     return nullptr;
+  }
   return op->getResult(0);
 }
 
 // Inlines constant global values that are known to not change.
 static bool inlineConstantGlobalLoads(GlobalTable &globalTable) {
   return globalTable.forEach([&](Global &global) {
-    if (global.isIndirect)
+    if (global.isIndirect) {
       return GlobalAction::PRESERVE;
-    if (!global.storeOps.empty())
+    } else if (!global.storeOps.empty()) {
       return GlobalAction::PRESERVE;
-    if (global.op.isGlobalMutable())
+    } else if (global.op.isGlobalMutable()) {
       return GlobalAction::PRESERVE;
-    if (!global.op.getGlobalInitialValue())
+    } else if (!global.op.getGlobalInitialValue()) {
       return GlobalAction::PRESERVE;
+    }
 
     if (llvm::isa<IREE::Util::ReferenceTypeInterface>(
             global.op.getGlobalType())) {
@@ -329,8 +242,9 @@ static bool inlineConstantGlobalLoads(GlobalTable &globalTable) {
     }
 
     // If not all loads could be removed we need to preserve the global.
-    if (!global.loadOps.empty())
+    if (!global.loadOps.empty() || !global.referencingOps.empty()) {
       return GlobalAction::PRESERVE;
+    }
 
     // Only delete if private.
     return global.op.isGlobalPrivate() ? GlobalAction::DELETE
@@ -343,9 +257,10 @@ static bool inlineConstantGlobalLoads(GlobalTable &globalTable) {
 // are discarded.
 static bool eraseUnusedGlobals(GlobalTable &globalTable) {
   return globalTable.forEach([&](Global &global) {
-    if (!global.isCandidate())
+    if (!global.canDCE()) {
       return GlobalAction::PRESERVE;
-    if (global.loadOps.empty()) {
+    }
+    if (global.loadOps.empty() && global.referencingOps.empty()) {
       // No loads; remove entirely.
       return GlobalAction::DELETE;
     }
@@ -356,22 +271,20 @@ static bool eraseUnusedGlobals(GlobalTable &globalTable) {
 // Deduplicates immutable globals with constant initial values.
 // This is a simplified and safer version of the global fusion pass.
 static bool deduplicateConstantGlobals(GlobalTable &globalTable) {
-  auto *context = globalTable.moduleOp.getContext();
+  auto *context = globalTable.getContext();
 
   // Build sets of all equivalent globals.
   llvm::EquivalenceClasses<StringRef> ec;
   DenseMap<Attribute, StringRef> leaderMap;
-  for (auto globalIt : globalTable.globalMap) {
-    auto &global = globalIt.getSecond();
-    if (!global.isCandidate())
-      continue;
-    if (!global.storeOps.empty()) {
+  globalTable.forEach([&](Global &global) {
+    if (!global.isCandidate()) {
+      return GlobalAction::PRESERVE;
+    } else if (!global.storeOps.empty()) {
       // Stores - not eligible for deduplication.
-      continue;
-    }
-    if (!global.op.getGlobalInitialValue()) {
+      return GlobalAction::PRESERVE;
+    } else if (!global.op.getGlobalInitialValue()) {
       // No initial value, not constant.
-      continue;
+      return GlobalAction::PRESERVE;
     }
     auto it = leaderMap.insert({
         ArrayAttr::get(
@@ -381,62 +294,63 @@ static bool deduplicateConstantGlobals(GlobalTable &globalTable) {
                 DictionaryAttr::get(
                     context, llvm::to_vector(global.op->getDialectAttrs())),
             }),
-        global.op.getGlobalName(),
+        global.getName(),
     });
     if (it.second) {
       // Inserted new.
-      ec.insert(global.op.getGlobalName());
+      ec.insert(global.getName());
     } else {
       // Existing global with the same value.
-      ec.unionSets(global.op.getGlobalName(), it.first->second);
+      ec.unionSets(global.getName(), it.first->second);
     }
-  }
+    return GlobalAction::PRESERVE;
+  });
 
-  bool didChange = false;
+  SmallVector<StringRef> deadGlobalNames;
   for (auto it = ec.begin(), end = ec.end(); it != end; ++it) {
-    if (!it->isLeader())
-      continue; // Ignore non-leader sets.
-    if (++ec.member_begin(it) == ec.member_end())
+    if (!it->isLeader()) {
+      // Ignore non-leader sets.
       continue;
-    IREE::Util::GlobalOpInterface baseGlobalOp =
-        globalTable.globalMap[it->getData()].op;
+    } else if (++ec.member_begin(it) == ec.member_end()) {
+      continue;
+    }
+    auto *baseGlobal = &globalTable.lookup(it->getData());
 
     // Build fused location from all of the globals.
     SmallVector<Location> locs;
     for (auto mi = ec.member_begin(it); mi != ec.member_end(); ++mi) {
-      Global &global = globalTable.globalMap[*mi];
+      Global &global = globalTable.lookup(*mi);
       locs.push_back(global.op.getLoc());
-      if (global.op->isBeforeInBlock(baseGlobalOp)) {
-        baseGlobalOp = global.op;
+      if (global.ordinal < baseGlobal->ordinal) {
+        baseGlobal = &global;
       }
     }
-    auto fusedLoc = FusedLoc::get(baseGlobalOp.getContext(), locs);
+    auto fusedLoc = FusedLoc::get(context, locs);
 
     // Update base global location.
+    IREE::Util::GlobalOpInterface baseGlobalOp = baseGlobal->op;
     baseGlobalOp->setLoc(fusedLoc);
 
     // Replace all other globals to point at the new one.
-    auto baseGlobalNameAttr = FlatSymbolRefAttr::get(
-        baseGlobalOp.getContext(), baseGlobalOp.getGlobalName());
+    auto baseGlobalNameAttr =
+        FlatSymbolRefAttr::get(context, baseGlobalOp.getGlobalName());
     for (auto mi = ec.member_begin(it); mi != ec.member_end(); ++mi) {
-      Global &global = globalTable.globalMap[*mi];
-      if (global.op == baseGlobalOp)
+      Global &global = globalTable.lookup(*mi);
+      if (global.op == baseGlobalOp) {
         continue;
-      for (auto loadOp : global.loadOps) {
-        loadOp.setGlobalAttr(baseGlobalNameAttr);
       }
-      global.op.erase();
+      globalTable.renameGlobalUses(global, *baseGlobal);
+      deadGlobalNames.push_back(global.getName());
     }
-
-    didChange |= true;
+  }
+  if (deadGlobalNames.empty()) {
+    return false; // no change
   }
 
-  if (didChange) {
-    // We could keep the table up to date to avoid the rebuilds by merging all
-    // loads into the base global.
-    globalTable.rebuild();
+  for (auto globalName : deadGlobalNames) {
+    globalTable.eraseGlobal(globalName);
   }
-  return didChange;
+  return true; // did change
 }
 
 class FoldGlobalsPass : public FoldGlobalsBase<FoldGlobalsPass> {
@@ -511,8 +425,9 @@ public:
         didChange = true;
       }
 
-      if (!didChange)
+      if (!didChange) {
         break;
+      }
     }
 
     afterFoldingGlobals =

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/FoldGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/FoldGlobals.cpp
@@ -332,8 +332,6 @@ static bool deduplicateConstantGlobals(GlobalTable &globalTable) {
     baseGlobalOp->setLoc(fusedLoc);
 
     // Replace all other globals to point at the new one.
-    auto baseGlobalNameAttr =
-        FlatSymbolRefAttr::get(context, baseGlobalOp.getGlobalName());
     for (auto mi = ec.member_begin(it); mi != ec.member_end(); ++mi) {
       Global &global = globalTable.lookup(*mi);
       if (global.op == baseGlobalOp) {

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/FuseGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/FuseGlobals.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <iterator>
 
+#include "iree/compiler/Dialect/Util/Analysis/GlobalTable.h"
 #include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "iree/compiler/Dialect/Util/IR/UtilTraits.h"
@@ -27,52 +28,6 @@
 
 namespace mlir::iree_compiler::IREE::Util {
 namespace {
-
-struct Global {
-  size_t ordinal = 0;
-  IREE::Util::GlobalOpInterface op;
-  bool isIndirect = false;
-  SmallVector<IREE::Util::GlobalLoadOpInterface> loadOps;
-  SmallVector<IREE::Util::GlobalStoreOpInterface> storeOps;
-
-  bool isCandidate() { return !isIndirect && op.isGlobalPrivate(); }
-};
-
-struct GlobalTable {
-  mlir::ModuleOp moduleOp;
-  SmallVector<StringRef> globalOrder;
-  DenseMap<StringRef, Global> globalMap;
-
-  size_t size() const { return globalOrder.size(); }
-
-  explicit GlobalTable(mlir::ModuleOp moduleOp) : moduleOp(moduleOp) {
-    rebuild();
-  }
-
-  void rebuild() {
-    globalOrder.clear();
-    globalMap.clear();
-    for (auto globalOp : moduleOp.getOps<IREE::Util::GlobalOpInterface>()) {
-      auto globalName = globalOp.getGlobalName();
-      globalMap[globalName] = Global{globalOrder.size(), globalOp};
-      globalOrder.push_back(globalName);
-    }
-    for (auto callableOp : moduleOp.getOps<CallableOpInterface>()) {
-      callableOp.walk([&](Operation *op) {
-        if (auto addressOp =
-                dyn_cast<IREE::Util::GlobalAddressOpInterface>(op)) {
-          globalMap[addressOp.getGlobalName()].isIndirect = true;
-        } else if (auto loadOp =
-                       dyn_cast<IREE::Util::GlobalLoadOpInterface>(op)) {
-          globalMap[loadOp.getGlobalName()].loadOps.push_back(loadOp);
-        } else if (auto storeOp =
-                       dyn_cast<IREE::Util::GlobalStoreOpInterface>(op)) {
-          globalMap[storeOp.getGlobalName()].storeOps.push_back(storeOp);
-        }
-      });
-    }
-  }
-};
 
 static llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
                                      llvm::BitVector &bits) {
@@ -131,7 +86,7 @@ public:
             valueStores;
         for (auto storeOp :
              block.getOps<IREE::Util::GlobalStoreOpInterface>()) {
-          auto &global = globalTable.globalMap[storeOp.getGlobalName()];
+          auto &global = globalTable.lookup(storeOp.getGlobalName());
           LLVM_DEBUG({
             llvm::dbgs() << " - store #" << global.ordinal << ": ";
             storeOp.print(llvm::dbgs(), *asmState);
@@ -152,7 +107,7 @@ public:
           });
           tempBits.reset();
           for (auto storeOp : valueStore.second) {
-            auto &global = globalTable.globalMap[storeOp.getGlobalName()];
+            auto &global = globalTable.lookup(storeOp.getGlobalName());
             tempBits.set(global.ordinal);
           }
           for (auto storeOp : valueStore.second) {
@@ -175,12 +130,13 @@ public:
     for (auto it : correlationMap) {
       auto globalName = it.first;
       auto &correlationBits = it.second;
-      auto &global = globalTable.globalMap[globalName];
+      auto &global = globalTable.lookup(globalName);
       llvm::BitVector tempBits = correlationBits;
       for (auto ordinal : correlationBits.set_bits()) {
-        auto &otherGlobalName = globalTable.globalOrder[ordinal];
-        if (otherGlobalName == globalName)
+        auto &otherGlobalName = globalTable.lookupByOrdinal(ordinal);
+        if (otherGlobalName == globalName) {
           continue;
+        }
         auto &otherBits = correlationMap[otherGlobalName];
         if (!otherBits.test(global.ordinal)) {
           LLVM_DEBUG(llvm::dbgs() << "Fixup: " << globalName
@@ -199,12 +155,12 @@ public:
       for (auto it : correlationMap) {
         auto globalName = it.first;
         auto &correlationBits = it.second;
-        auto &global = globalTable.globalMap[globalName];
-        llvm::dbgs() << "= #" << global.ordinal << " "
-                     << global.op.getGlobalName() << " = " << correlationBits
-                     << ":\n";
+        auto &global = globalTable.lookup(globalName);
+        llvm::dbgs() << "= #" << global.ordinal << " " << global.getName()
+                     << " = " << correlationBits << ":\n";
         for (auto ordinal : correlationBits.set_bits()) {
-          llvm::dbgs() << "  => " << globalTable.globalOrder[ordinal] << "\n";
+          llvm::dbgs() << "  => " << globalTable.lookupByOrdinal(ordinal)
+                       << "\n";
         }
       }
     });
@@ -215,10 +171,9 @@ public:
     for (auto it : correlationMap) {
       auto globalName = it.first;
       auto &correlationBits = it.second;
-      auto &global = globalTable.globalMap[globalName];
+      auto &global = globalTable.lookup(globalName);
       for (auto ordinal : correlationBits.set_bits()) {
-        ec.unionSets(global.op.getGlobalName(),
-                     globalTable.globalOrder[ordinal]);
+        ec.unionSets(global.getName(), globalTable.lookupByOrdinal(ordinal));
       }
     }
 
@@ -228,13 +183,15 @@ public:
     // differ.
     SmallVector<SmallVector<Global *>> fusableSets;
     for (auto it = ec.begin(), end = ec.end(); it != end; ++it) {
-      if (!it->isLeader())
+      if (!it->isLeader()) {
         continue; // Ignore non-leader sets.
-      if (++ec.member_begin(it) == ec.member_end())
+      }
+      if (++ec.member_begin(it) == ec.member_end()) {
         continue; // size 1
+      }
       DenseMap<Attribute, SmallVector<Global *>> initialValueMap;
       for (auto mi = ec.member_begin(it); mi != ec.member_end(); ++mi) {
-        Global &global = globalTable.globalMap[*mi];
+        Global &global = globalTable.lookup(*mi);
         initialValueMap[global.op.getGlobalInitialValue()].push_back(&global);
       }
       for (auto it : initialValueMap) {
@@ -245,42 +202,38 @@ public:
     // For each foldable set combine into a single global and update all uses.
     SymbolTable symbolTable(moduleOp);
     for (auto &fusableSet : fusableSets) {
-      IREE::Util::GlobalOpInterface baseGlobalOp = fusableSet.front()->op;
+      auto *baseGlobal = fusableSet.front();
       LLVM_DEBUG(llvm::dbgs()
                  << "Fusing " << fusableSet.size() << " globals into "
-                 << baseGlobalOp.getGlobalName() << "\n");
+                 << baseGlobal->getName() << "\n");
 
       // Build fused location from all of the globals.
       SmallVector<Location> locs;
       for (auto *global : fusableSet) {
         locs.push_back(global->op.getLoc());
-        if (global->op->isBeforeInBlock(baseGlobalOp)) {
-          baseGlobalOp = global->op;
+        if (global->ordinal < baseGlobal->ordinal) {
+          baseGlobal = global;
         }
       }
-      auto fusedLoc = FusedLoc::get(baseGlobalOp.getContext(), locs);
+      auto fusedLoc = FusedLoc::get(moduleOp.getContext(), locs);
 
       // Update base global location.
+      IREE::Util::GlobalOpInterface baseGlobalOp = baseGlobal->op;
       baseGlobalOp->setLoc(fusedLoc);
 
       // Replace all globals to point at the new one.
       auto baseGlobalNameAttr = FlatSymbolRefAttr::get(
           baseGlobalOp.getContext(), baseGlobalOp.getGlobalName());
       for (auto *global : fusableSet) {
-        if (global->op == baseGlobalOp)
+        if (global->op == baseGlobalOp) {
           continue;
+        }
 
         // Redirect all loads to the new fused global.
-        for (auto loadOp : global->loadOps) {
-          loadOp.setGlobalAttr(baseGlobalNameAttr);
-        }
+        globalTable.renameGlobalUses(*global, *baseGlobal);
 
-        // Remove all stores to all variables but the base.
-        for (auto storeOp : global->storeOps) {
-          storeOp.erase();
-        }
-
-        global->op.erase();
+        // Remove all stores to and the definition of the dead global op.
+        globalTable.eraseGlobal(global->getName());
       }
     }
   }

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/fold_globals.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/fold_globals.mlir
@@ -134,6 +134,24 @@ util.initializer {
 
 // -----
 
+builtin.module attributes {
+  some.attr = @only_ref_on_module
+} {
+  // CHECK: @only_ref_on_module
+  util.global private @only_ref_on_module : index
+}
+
+// -----
+
+builtin.module @named_module attributes {
+  some.attr = @named_module::@only_ref_on_module
+} {
+  // CHECK: @only_ref_on_module
+  util.global private @only_ref_on_module : index
+}
+
+// -----
+
 // CHECK: util.global private @dupeCst0 {inlining_policy = #util.inline.never} = 5 : index
 util.global private @dupeCst0 {inlining_policy = #util.inline.never} = 5 : index
 // CHECK-NOT: util.global private @dupeCst1

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/fold_globals.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/fold_globals.mlir
@@ -102,7 +102,11 @@ util.func @foo(%arg0: index) -> (index, index, index) {
 util.global private mutable @used0 = 5 : index
 // CHECK: util.global private mutable @used1 : index
 util.global private mutable @used1 : index
-util.func @foo(%arg0: index, %arg1: index) -> (index, index) {
+// CHECK: util.global private @referenced : index
+util.global private @referenced : index
+util.func @foo(%arg0: index, %arg1: index) -> (index, index) attributes {
+  some.attr = @referenced
+} {
   // CHECK: %[[VALUE0:.+]] = util.global.load @used0 : index
   %0 = util.global.load @used0 : index
   // CHECK: %[[VALUE1:.+]] = util.global.load @used1 : index
@@ -134,11 +138,16 @@ util.initializer {
 util.global private @dupeCst0 {inlining_policy = #util.inline.never} = 5 : index
 // CHECK-NOT: util.global private @dupeCst1
 util.global private @dupeCst1 {inlining_policy = #util.inline.never} = 5 : index
-util.func @foo() -> (index, index) {
+util.func @foo() -> (index, index) attributes {
+  some.attr = @dupeCst1
+} {
   // CHECK-DAG: %[[VALUE0:.+]] = util.global.load immutable @dupeCst0
   %0 = util.global.load @dupeCst0 : index
   // CHECK-DAG: %[[VALUE1:.+]] = util.global.load immutable @dupeCst0
   %1 = util.global.load @dupeCst1 : index
+  // CHECK-DAG: util.optimization_barrier
+  // CHECK-SAME: op.attr = @dupeCst0
+  util.optimization_barrier {op.attr = @dupeCst1} %1 : index
   // CHECK: return %[[VALUE0]], %[[VALUE1]]
   util.return %0, %1 : index, index
 }

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/fuse_globals.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/fuse_globals.mlir
@@ -12,6 +12,9 @@ util.func @foo(%arg0: index) -> (index, index) {
   %0 = util.global.load @fusable0 : index
   // CHECK: %[[VALUE1:.+]] = util.global.load @fusable0 : index
   %1 = util.global.load @fusable1 : index
+  // CHECK: util.optimization_barrier
+  // CHECK-SAME: op.attr = @fusable0
+  util.optimization_barrier {op.attr = @fusable1} %1 : index
   // CHECK: util.return %[[VALUE0]], %[[VALUE1]]
   util.return %0, %1 : index, index
 }


### PR DESCRIPTION
This cleans up the code used in FoldGlobalsPass/FuseGlobalsPass and extends it to support ops that reference globals as if they are loads.

Fixes #17825.