### PR TITLE
[multi-device] Adding `flow.tensor.transfer` and preparing for frontend assignment.

### DIFF
--- a/compiler/plugins/target/CUDA/test/smoketest.mlir
+++ b/compiler/plugins/target/CUDA/test/smoketest.mlir
@@ -5,7 +5,9 @@
 
 module attributes {
   hal.device.targets = [
-    #hal.device.target<"cuda", [#hal.executable.target<"cuda", "cuda-nvptx-fb">]>
+    #hal.device.target<"cuda", [
+      #hal.executable.target<"cuda", "cuda-nvptx-fb">
+    ]> : !hal.device
   ]
 } {
 

--- a/compiler/plugins/target/LLVMCPU/test/smoketest_embedded.mlir
+++ b/compiler/plugins/target/LLVMCPU/test/smoketest_embedded.mlir
@@ -7,7 +7,7 @@ module attributes {
       #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
         native_vector_size = 16 : index
       }>
-    ]>
+    ]> : !hal.device
   ]
 } {
 

--- a/compiler/plugins/target/LLVMCPU/test/smoketest_system.mlir
+++ b/compiler/plugins/target/LLVMCPU/test/smoketest_system.mlir
@@ -9,7 +9,7 @@ module attributes {
       #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
         native_vector_size = 16 : index
       }>
-    ]>
+    ]> : !hal.device
   ]
 } {
 

--- a/compiler/plugins/target/MetalSPIRV/test/smoketest.mlir
+++ b/compiler/plugins/target/MetalSPIRV/test/smoketest.mlir
@@ -8,7 +8,7 @@ module attributes {
           compute = fp32|int32, storage = b32, subgroup = none, dot = none, mma = [], subgroup_size_choices = [32],
           max_workgroup_sizes = [128, 128, 64], max_thread_count_per_workgroup = 128, max_workgroup_memory_bytes = 16384>>
       }>
-    ]>
+    ]> : !hal.device
   ]
 } {
 

--- a/compiler/plugins/target/ROCM/test/smoketest.mlir
+++ b/compiler/plugins/target/ROCM/test/smoketest.mlir
@@ -2,7 +2,9 @@
 
 module attributes {
   hal.device.targets = [
-    #hal.device.target<"rocm", [#hal.executable.target<"rocm", "rocm-hsaco-fb">]>
+    #hal.device.target<"rocm", [
+      #hal.executable.target<"rocm", "rocm-hsaco-fb">
+    ]> : !hal.device
   ]
 } {
 
@@ -44,7 +46,9 @@ stream.executable public @add_dispatch_0 {
 #loc = loc(unknown)
 module attributes {
   hal.device.targets = [
-    #hal.device.target<"rocm", [#hal.executable.target<"rocm", "rocm-hsaco-fb">]>
+    #hal.device.target<"rocm", [
+      #hal.executable.target<"rocm", "rocm-hsaco-fb">
+    ]> : !hal.device
   ]
 } {
 

--- a/compiler/plugins/target/ROCM/test/target_device_features.mlir
+++ b/compiler/plugins/target/ROCM/test/target_device_features.mlir
@@ -1,7 +1,7 @@
-// RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetBackends=rocm},iree-hal-transformation-pipeline{serialize-executables=false})' --iree-rocm-target-chip=mi300x %s | FileCheck %s --check-prefix=GFX942
-// RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetBackends=rocm},iree-hal-transformation-pipeline{serialize-executables=false})' --iree-rocm-target-chip=gfx940 %s | FileCheck %s --check-prefix=GFX940
-// RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetBackends=rocm},iree-hal-transformation-pipeline{serialize-executables=false})' --iree-rocm-target-chip=rx7900xtx %s | FileCheck %s --check-prefix=GFX1100
-// RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetBackends=rocm},iree-hal-transformation-pipeline{serialize-executables=false})' --iree-rocm-target-chip=gfx941 --iree-rocm-target-features=+sramecc,-xnack %s | FileCheck %s --check-prefix=GFX941
+// RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=rocm},iree-hal-transformation-pipeline{serialize-executables=false})' --iree-rocm-target-chip=mi300x %s | FileCheck %s --check-prefix=GFX942
+// RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=rocm},iree-hal-transformation-pipeline{serialize-executables=false})' --iree-rocm-target-chip=gfx940 %s | FileCheck %s --check-prefix=GFX940
+// RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=rocm},iree-hal-transformation-pipeline{serialize-executables=false})' --iree-rocm-target-chip=rx7900xtx %s | FileCheck %s --check-prefix=GFX1100
+// RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=rocm},iree-hal-transformation-pipeline{serialize-executables=false})' --iree-rocm-target-chip=gfx941 --iree-rocm-target-features=+sramecc,-xnack %s | FileCheck %s --check-prefix=GFX941
 
 // GFX942: target = #iree_gpu.target<arch = "gfx942",
 // GFX942-SAME: wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8,
@@ -20,7 +20,6 @@
 
 // GFX941: target = #iree_gpu.target<arch = "gfx941",
 // GFX941-SAME:         features = "+sramecc,-xnack"
-
 
 stream.executable public @reduce_dispatch {
   stream.executable.export @reduce_dispatch workgroups(%arg0: index) -> (index, index, index) {

--- a/compiler/plugins/target/VMVX/test/smoketest.mlir
+++ b/compiler/plugins/target/VMVX/test/smoketest.mlir
@@ -4,7 +4,7 @@ module attributes {
   hal.device.targets = [
     #hal.device.target<"local", [
       #hal.executable.target<"vmvx", "vmvx-bytecode-fb">
-    ]>
+    ]> : !hal.device
   ]
 } {
 

--- a/compiler/plugins/target/VulkanSPIRV/test/smoketest.mlir
+++ b/compiler/plugins/target/VulkanSPIRV/test/smoketest.mlir
@@ -8,7 +8,7 @@ module attributes {
           compute = fp32|int32, storage = b32, subgroup = none, dot = none, mma = [], subgroup_size_choices = [32, 32],
           max_workgroup_sizes = [128, 128, 64], max_thread_count_per_workgroup = 128, max_workgroup_memory_bytes = 16384>>
       }>
-    ]>
+    ]> : !hal.device
   ]
 } {
 

--- a/compiler/plugins/target/WebGPUSPIRV/test/smoketest.mlir
+++ b/compiler/plugins/target/WebGPUSPIRV/test/smoketest.mlir
@@ -9,7 +9,7 @@ module attributes {
           compute = fp32|int32, storage = b32, subgroup = none, dot = none, mma = [], subgroup_size_choices = [32],
           max_workgroup_sizes = [128, 128, 64], max_thread_count_per_workgroup = 128, max_workgroup_memory_bytes = 16384>>
       }>
-    ]>
+    ]> : !hal.device
   ]
 } {
 

--- a/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
+++ b/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
@@ -934,10 +934,12 @@ bool Invocation::runPipeline(enum iree_compiler_pipeline_t pipeline) {
     if (!getCompilationPhase(compileFrom, compileTo)) {
       return false;
     }
+
+    // TODO: move to someplace centralized; erroring here is not great.
     // InlineStatic (currently) only supports the `vmvx-inline` backend.
     if (session.schedulingOptions.executionModel ==
         SchedulingOptions::ExecutionModel::InlineStatic) {
-      for (auto target : session.halTargetOptions.targets) {
+      for (auto target : session.halTargetOptions.legacyTargetBackends) {
         if (target != "vmvx-inline") {
           parsedModule->emitError() << "InlineStatic execution model is not "
                                        "compatible with hal target '"

--- a/compiler/src/iree/compiler/Bindings/TFLite/Transforms/WrapEntryPoints.cpp
+++ b/compiler/src/iree/compiler/Bindings/TFLite/Transforms/WrapEntryPoints.cpp
@@ -227,7 +227,8 @@ private:
       auto dynamicDims = inputDynamicDims.loadDynamicDims(recalculateBuilder);
       auto castOp = recalculateBuilder.create<IREE::HAL::TensorImportOp>(
           loc, inputValue.getType(), inputPlaceholder, inputValue.getType(),
-          dynamicDims, /*wait_fence=*/Value{}, /*name=*/nullptr);
+          dynamicDims, /*wait_fence=*/Value{}, /*name=*/nullptr,
+          /*affinity=*/nullptr);
       inputValue.replaceAllUsesWith(castOp.getTarget());
     }
     while (entryBlock.getNumArguments() > 0) {
@@ -525,7 +526,8 @@ private:
       callOperands.push_back(entryBuilder.create<IREE::HAL::TensorImportOp>(
           arg.getLoc(), inputDynamicDims.tensorType, arg,
           TypeAttr::get(inputDynamicDims.tensorType), dynamicDims,
-          /*wait_fence=*/Value{}, /*name=*/nullptr));
+          /*wait_fence=*/Value{}, /*name=*/nullptr,
+          /*affinity=*/nullptr));
     }
     auto callOp = entryBuilder.create<IREE::Util::CallOp>(
         entryFuncOp.getLoc(), entryFuncOp, callOperands);
@@ -541,7 +543,7 @@ private:
       }
       callResults.push_back(entryBuilder.create<IREE::HAL::TensorExportOp>(
           result.getLoc(), bufferType, result, outputDynamicDims.tensorType,
-          dynamicDims, /*name=*/nullptr));
+          dynamicDims, /*name=*/nullptr, /*affinity=*/nullptr));
       for (auto [dynamicDim, globalOp] :
            llvm::zip_equal(dynamicDims, outputDynamicDims.globalOps)) {
         globalOp.createStoreOp(result.getLoc(), dynamicDim, entryBuilder);

--- a/compiler/src/iree/compiler/ConstEval/JitGlobals.cpp
+++ b/compiler/src/iree/compiler/ConstEval/JitGlobals.cpp
@@ -619,7 +619,8 @@ struct JitGlobalsPass : public JitGlobalsBase<JitGlobalsPass> {
     requestedTargetDevice = resolveTargetDevice(*targetRegistry.value);
     hasRequestedTargetDevice =
         targetRegistry->getTargetDevice(requestedTargetDevice) != nullptr;
-    compileOptions->executableOptions.targets.push_back(requestedTargetDevice);
+    compileOptions->executableOptions.legacyTargetBackends.push_back(
+        requestedTargetDevice);
     compileOptions->targetOptions.f32Extension = true;
     compileOptions->targetOptions.f64Extension = true;
     compileOptions->targetOptions.truncateUnsupportedFloats = false;

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -288,7 +288,6 @@ struct ElideRedundantWorkloadValues
 struct ElideRedundantOperandsOfWorkgroupCountFromSliceOp
     : OpRewritePattern<DispatchWorkgroupsOp> {
   using OpRewritePattern::OpRewritePattern;
-
   LogicalResult matchAndRewrite(DispatchWorkgroupsOp op,
                                 PatternRewriter &rewriter) const override {
     Region &count = op.getWorkgroupCount();
@@ -369,7 +368,6 @@ void DispatchWorkgroupsOp::getCanonicalizationPatterns(
 // Bubble up the ordinal ops so that all uses go through this operation.
 struct BubbleUpOrdinalOp : public OpRewritePattern<DispatchWorkloadOrdinalOp> {
   using OpRewritePattern::OpRewritePattern;
-
   LogicalResult matchAndRewrite(DispatchWorkloadOrdinalOp ordinalOp,
                                 PatternRewriter &rewriter) const override {
     auto blockArg = llvm::dyn_cast<BlockArgument>(ordinalOp.getOperand());
@@ -894,7 +892,6 @@ namespace {
 template <typename CastOpTy>
 struct FlattenTensorCastLikeChain : public OpRewritePattern<CastOpTy> {
   using OpRewritePattern<CastOpTy>::OpRewritePattern;
-
   LogicalResult matchAndRewrite(CastOpTy reshapeOp,
                                 PatternRewriter &rewriter) const override {
     // We want the same result value/shape but to source from the ancestor. We
@@ -1294,7 +1291,6 @@ namespace {
 // to be updated to use the source of the cast as the target tensor.
 struct FoldTensorUpdateOpWithCasts : public OpRewritePattern<TensorUpdateOp> {
   using OpRewritePattern<TensorUpdateOp>::OpRewritePattern;
-
   LogicalResult matchAndRewrite(TensorUpdateOp updateOp,
                                 PatternRewriter &rewriter) const override {
     auto targetCastOp = updateOp.getTarget().getDefiningOp<tensor::CastOp>();

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -1786,6 +1786,20 @@ LogicalResult TensorCloneOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// flow.tensor.transfer
+//===----------------------------------------------------------------------===//
+
+LogicalResult TensorTransferOp::verify() {
+  if (failed(verifyOpDynamicDims(getOperation(), {getOperand()},
+                                 getArgumentDims())) ||
+      failed(verifyOpDynamicDims(getOperation(), {getResult()},
+                                 getArgumentDims()))) {
+    return failure();
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // flow.tensor.slice
 //===----------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -1500,6 +1500,57 @@ def FLOW_TensorCloneOp : FLOW_PureOp<"tensor.clone", [
   let hasFolder = 1;
 }
 
+def FLOW_TensorTransferOp : FLOW_PureOp<"tensor.transfer", [
+  AllTypesMatch<["operand", "result"]>,
+  DeclareOpInterfaceMethods<Util_HoistableOpInterface>,
+  Util_ShapeAwareOp,
+]> {
+  let summary = [{transfers a tensor to a target by copying if needed}];
+  let description = [{
+    Transfers the tensor from whichever context it may be in to the specified
+    target context. If the contexts are compatible and can access each others
+    memory the operation may be elided and otherwise will become one or more
+    copies to transfer the tensor in cases where staging through an intermediate
+    context is required.
+  }];
+
+  let arguments = (ins
+    FLOW_Tensor:$operand,
+    FLOW_ShapeDynamicDims:$argument_dims,
+    AnyAttr:$target
+  );
+  let results = (outs
+    FLOW_Tensor:$result
+  );
+
+  let assemblyFormat = [{
+    $operand `:` type($result) (`{` $argument_dims^ `}`)?
+    `to` $target
+    attr-dict-with-keyword
+  }];
+
+  let builders = [
+    OpBuilder<(ins "Value":$operand, "Attribute":$target),
+    [{
+      build($_builder, $_state,
+          operand.getType(),
+          operand,
+          IREE::Util::buildDynamicDimsForValue($_state.location, operand, $_builder),
+          target);
+    }]>,
+  ];
+
+  let extraClassDeclaration = [{
+    bool isHoistableLeafOp() { return false; }
+
+    ValueRange getOperandDynamicDims(unsigned idx) { return getArgumentDims(); }
+    ValueRange getResultDynamicDims(unsigned idx) { return getArgumentDims(); }
+  }];
+
+  let hasVerifier = 1;
+  let hasCanonicalizer = 1;
+}
+
 def FLOW_TensorSliceOp : FLOW_PureOp<"tensor.slice", [
   AllRanksMatch<["source", "result"]>,
   AllElementTypesMatch<["source", "result"]>,

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
@@ -351,8 +351,8 @@ util.func public @splatDynamicZeroElements(%value: f32, %dim: index) -> tensor<0
 
 // -----
 
-// CHECK-LABEL: @cloneConst
-util.func public @cloneConst() -> tensor<4xi32> {
+// CHECK-LABEL: @cloneConstant
+util.func public @cloneConstant() -> tensor<4xi32> {
   // CHECK-NEXT: %[[C:.+]] = arith.constant dense<[0, 1, 2, 3]> : tensor<4xi32>
   %0 = arith.constant dense<[0, 1, 2, 3]> : tensor<4xi32>
   %1 = flow.tensor.clone %0 : tensor<4xi32>
@@ -362,8 +362,8 @@ util.func public @cloneConst() -> tensor<4xi32> {
 
 // -----
 
-// CHECK-LABEL: @cloneConstZeroElements
-util.func public @cloneConstZeroElements() -> tensor<0x2xi32> {
+// CHECK-LABEL: @cloneConstantZeroElements
+util.func public @cloneConstantZeroElements() -> tensor<0x2xi32> {
   // CHECK-NEXT: %[[C:.+]] = arith.constant dense<> : tensor<0x2xi32>
   %0 = arith.constant dense<> : tensor<0x2xi32>
   // CHECK-NOT: flow.tensor.clone

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_ops.mlir
@@ -158,6 +158,15 @@ util.func public @tensorClone(%arg0 : tensor<4x4xf32>) -> tensor<4x4xf32> {
 
 // -----
 
+// CHECK-LABEL: @tensorTransfer
+util.func public @tensorTransfer(%arg0 : tensor<4x4xf32>) -> tensor<4x4xf32> {
+  // CHECK-NEXT: %0 = flow.tensor.transfer %arg0 : tensor<4x4xf32> to "dummy"
+  %0 = flow.tensor.transfer %arg0 : tensor<4x4xf32> to "dummy"
+  util.return %0 : tensor<4x4xf32>
+}
+
+// -----
+
 // CHECK-LABEL: @tensorCloneScalar
 util.func public @tensorCloneScalar(%arg0 : tensor<f32>) -> tensor<f32> {
   // CHECK-NEXT: %0 = flow.tensor.clone %arg0 : tensor<f32>

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_ops.mlir
@@ -7,12 +7,16 @@ util.func public @tensorReshape(%arg0 : tensor<4x4xf32>) -> tensor<16xf32> {
   util.return %0 : tensor<16xf32>
 }
 
+// -----
+
 // CHECK-LABEL: @tensorReshapeScalar
 util.func public @tensorReshapeScalar(%arg0 : tensor<f32>) -> tensor<f32> {
   // CHECK-NEXT: %0 = flow.tensor.reshape %arg0 : tensor<f32> -> tensor<f32>
   %0 = flow.tensor.reshape %arg0 : tensor<f32> -> tensor<f32>
   util.return %0 : tensor<f32>
 }
+
+// -----
 
 // CHECK-LABEL: @tensorReshapeDynamic
 util.func public @tensorReshapeDynamic(%arg0 : tensor<?x4xf32>) -> tensor<?x2xf32> {
@@ -22,6 +26,8 @@ util.func public @tensorReshapeDynamic(%arg0 : tensor<?x4xf32>) -> tensor<?x2xf3
   %0 = flow.tensor.reshape %arg0 : tensor<?x4xf32>{%c4} -> tensor<?x2xf32>{%c8}
   util.return %0 : tensor<?x2xf32>
 }
+
+// -----
 
 // CHECK-LABEL: @tensorReshapeComplex
 util.func public @tensorReshapeComplex(%arg0 : tensor<4x4xcomplex<f32>>) -> tensor<16xcomplex<f32>> {
@@ -48,12 +54,16 @@ util.func public @tensorLoad(%arg0 : tensor<4x4xf32>, %arg1 : index, %arg2 : ind
   util.return %0 : f32
 }
 
+// -----
+
 // CHECK-LABEL: @tensorLoadScalar
 util.func public @tensorLoadScalar(%arg0 : tensor<f32>) -> f32 {
   // CHECK-NEXT: %0 = flow.tensor.load %arg0 : tensor<f32>
   %0 = flow.tensor.load %arg0 : tensor<f32>
   util.return %0 : f32
 }
+
+// -----
 
 // CHECK-LABEL: @tensorLoadDynamic
 util.func public @tensorLoadDynamic(%arg0 : tensor<?x4xf32>, %arg1 : index, %arg2 : index) -> f32 {
@@ -72,12 +82,16 @@ util.func public @tensorStore(%arg0 : tensor<4x4xf32>, %arg1 : index, %arg2 : in
   util.return %0 : tensor<4x4xf32>
 }
 
+// -----
+
 // CHECK-LABEL: @tensorStoreScalar
 util.func public @tensorStoreScalar(%arg0 : f32, %arg1 : tensor<f32>) -> tensor<f32> {
   // CHECK-NEXT: %0 = flow.tensor.store %arg0, %arg1 : tensor<f32>
   %0 = flow.tensor.store %arg0, %arg1 : tensor<f32>
   util.return %0 : tensor<f32>
 }
+
+// -----
 
 // CHECK-LABEL: @tensorStoreDynamic
 util.func public @tensorStoreDynamic(%arg0 : tensor<?x4xf32>, %arg1 : index, %arg2 : index, %arg3 : f32) -> tensor<?x4xf32> {
@@ -114,12 +128,16 @@ util.func public @tensorSplat(%arg0 : f32) -> tensor<4x4xf32> {
   util.return %0 : tensor<4x4xf32>
 }
 
+// -----
+
 // CHECK-LABEL: @tensorSplatScalar
 util.func public @tensorSplatScalar(%arg0 : f32) -> tensor<f32> {
   // CHECK-NEXT: %0 = flow.tensor.splat %arg0 : tensor<f32>
   %0 = flow.tensor.splat %arg0 : tensor<f32>
   util.return %0 : tensor<f32>
 }
+
+// -----
 
 // CHECK-LABEL: @tensorSplatDynamic
 util.func public @tensorSplatDynamic(%arg0 : f32) -> tensor<?x4xf32> {
@@ -138,12 +156,16 @@ util.func public @tensorClone(%arg0 : tensor<4x4xf32>) -> tensor<4x4xf32> {
   util.return %0 : tensor<4x4xf32>
 }
 
+// -----
+
 // CHECK-LABEL: @tensorCloneScalar
 util.func public @tensorCloneScalar(%arg0 : tensor<f32>) -> tensor<f32> {
   // CHECK-NEXT: %0 = flow.tensor.clone %arg0 : tensor<f32>
   %0 = flow.tensor.clone %arg0 : tensor<f32>
   util.return %0 : tensor<f32>
 }
+
+// -----
 
 // CHECK-LABEL: @tensorCloneDynamic
 util.func public @tensorCloneDynamic(%arg0 : tensor<?x4xf32>) -> tensor<?x4xf32> {
@@ -162,6 +184,8 @@ util.func public @tensorSlice(%arg0 : tensor<4x4xf32>, %arg1 : index, %arg2 : in
   util.return %0 : tensor<2x2xf32>
 }
 
+// -----
+
 // CHECK-LABEL: @tensorSliceDynamic
 util.func public @tensorSliceDynamic(%arg0 : tensor<?x4xf32>, %arg1 : index, %arg2 : index) -> tensor<?x2xf32> {
   %c2 = arith.constant 2 : index
@@ -179,6 +203,8 @@ util.func public @tensorUpdate(%arg0 : tensor<2x2xf32>, %arg1 : tensor<4x4xf32>,
   %0 = flow.tensor.update %arg0, %arg1[%arg2, %arg3] : tensor<2x2xf32> -> %arg1 as tensor<4x4xf32>
   util.return %0 : tensor<4x4xf32>
 }
+
+// -----
 
 // CHECK-LABEL: @tensorUpdateDynamic
 util.func public @tensorUpdateDynamic(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x4xf32>, %arg2 : index, %arg3 : index) -> tensor<?x4xf32> {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ExportBenchmarkFuncs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ExportBenchmarkFuncs.cpp
@@ -81,7 +81,8 @@ createBufferLikeGlobalOp(std::string name, Location loc, Type globalType,
   // hal.tensor.export
   auto bufferExportOp = initializerBuilder.create<IREE::HAL::TensorExportOp>(
       loc, globalOp.getType(), splatOp.getResult(),
-      TypeAttr::get(splatOp.getType()), /*name=*/nullptr);
+      TypeAttr::get(splatOp.getType()), /*name=*/nullptr,
+      /*affinity=*/nullptr);
   // util.optimization_barrier (try to prevent optimizations across the export)
   auto barrierOp = initializerBuilder.create<IREE::Util::OptimizationBarrierOp>(
       loc, bufferExportOp.getTarget());

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/InsertDispatchDebugTargets.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/InsertDispatchDebugTargets.cpp
@@ -103,7 +103,8 @@ static LogicalResult replaceReturnWithOpResults(mlir::ModuleOp moduleOp,
     if (llvm::isa<TensorType>(retVal.getType())) {
       auto type = IREE::HAL::BufferViewType::get(context);
       auto exportOp = builder.create<IREE::HAL::TensorExportOp>(
-          loc, type, retVal, TypeAttr::get(retVal.getType()), /*name=*/nullptr);
+          loc, type, retVal, TypeAttr::get(retVal.getType()), /*name=*/nullptr,
+          /*affinity=*/nullptr);
       exports.push_back(exportOp.getResult());
       newTypes.push_back(type);
     } else {

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALAttrs.td
@@ -484,8 +484,10 @@ def HAL_DeviceTargetAttr : AttrDef<HAL_Dialect, "DeviceTarget", [
     several target executable formats specified with `#hal.executable.target`.
     An optional configuration dictionary allows for overriding backend defaults.
 
-    If used to initialize a device global returns the first device matching or
-    null if no devices match.
+    If used to initialize a device global returns the first device matching the
+    target requirements or null if no devices match. An optional `ordinal`
+    index may be provided that selects the N-th matching device and is used to
+    select between multiple homogeneous devices.
 
     Example:
     ```mlir

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALAttrs.td
@@ -469,65 +469,6 @@ def HAL_InterfaceBindingArrayAttr :
                        "HAL binding array attribute">;
 
 //===----------------------------------------------------------------------===//
-// #hal.device.target<*>
-//===----------------------------------------------------------------------===//
-
-def HAL_DeviceTargetAttr : AttrDef<HAL_Dialect, "DeviceTarget", [
-  DeclareAttrInterfaceMethods<HAL_DeviceInitializationAttrInterface>,
-]> {
-  let mnemonic = "device.target";
-  let summary = [{generic device target specification}];
-  let description = [{
-    Specifies the properties of a target runtime device.
-    Target devices are specified with a canonical identifier matching those used
-    by the runtime (such as `cpu`, `vulkan`, etc). Target devices may support
-    several target executable formats specified with `#hal.executable.target`.
-    An optional configuration dictionary allows for overriding backend defaults.
-
-    If used to initialize a device global returns the first device matching the
-    target requirements or null if no devices match. An optional `ordinal`
-    index may be provided that selects the N-th matching device and is used to
-    select between multiple homogeneous devices.
-
-    Example:
-    ```mlir
-    #hal.device.target<"llvm-cpu", {
-      device_configuration = ...
-    }, [
-      #hal.executable.target<"llvm-cpu", "embedded-elf-arm_32">,
-      #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64">,
-    ]>
-    ```
-  }];
-  let parameters = (ins
-    AttrParameter<"StringAttr", "">:$deviceID,
-    AttrParameter<"DictionaryAttr", "">:$configuration,
-    ArrayRefParameter<"ExecutableTargetAttr", "">:$executable_targets
-  );
-  let builders = [
-    AttrBuilder<(ins "StringRef":$deviceID)>,
-  ];
-
-  let extraClassDeclaration = [{
-    Type getType() { return IREE::HAL::DeviceType::get(getContext()); }
-
-    // Returns a symbol-compatible name that pseudo-uniquely identifies this
-    // target. Callers must perform deduplication when required.
-    std::string getSymbolNameFragment();
-
-    // Returns true if there's an attribute with the given name in the
-    // configuration dictionary.
-    bool hasConfigurationAttr(StringRef name);
-
-    // Returns zero or more executable targets that this device supports.
-    void getExecutableTargets(
-        SetVector<IREE::HAL::ExecutableTargetAttr> &resultAttrs);
-  }];
-
-  let hasCustomAssemblyFormat = 1;
-}
-
-//===----------------------------------------------------------------------===//
 // #hal.executable.target<*>
 //===----------------------------------------------------------------------===//
 
@@ -922,9 +863,6 @@ def HAL_DeviceSelectAttr : AttrDef<HAL_Dialect, "DeviceSelect", [
   );
 
   let builders = [
-    AttrBuilder<(ins
-      "IREE::HAL::DeviceTargetAttr":$device
-    )>,
     AttrBuilder<(ins
       "ArrayRef<Attribute>":$values
     )>,

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
@@ -96,8 +96,8 @@ struct DeduplicateTensorBarrierSources
     }
     if (orderedSources.size() == op.getSources().size())
       return failure();
-    auto newOp = rewriter.create<TensorBarrierOp>(op.getLoc(), orderedSources,
-                                                  op.getSignalFence());
+    auto newOp = rewriter.create<TensorBarrierOp>(
+        op.getLoc(), orderedSources, op.getSignalFence(), op.getAffinityAttr());
     SmallVector<Value> newResults;
     newResults.reserve(newOp.getNumResults());
     for (unsigned newIndex : resultMapping) {

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -431,15 +431,16 @@ LogicalResult ReturnOp::verify() {
 
 void TensorImportOp::build(OpBuilder &builder, OperationState &result,
                            Type resultType, Value source,
-                           TypeAttr targetEncoding, StringAttr name) {
+                           TypeAttr targetEncoding, StringAttr name,
+                           Attribute affinity) {
   build(builder, result, resultType, source, targetEncoding,
-        /*waitFence=*/Value{}, name);
+        /*waitFence=*/Value{}, name, affinity);
 }
 
 void TensorImportOp::build(OpBuilder &builder, OperationState &result,
                            Type resultType, Value source,
                            TypeAttr targetEncoding, Value waitFence,
-                           StringAttr name) {
+                           StringAttr name, Attribute affinity) {
   auto shapedType = llvm::cast<ShapedType>(resultType);
   assert((isa<IREE::HAL::BufferViewType>(source.getType()) ||
           shapedType.hasStaticShape()) &&
@@ -454,7 +455,7 @@ void TensorImportOp::build(OpBuilder &builder, OperationState &result,
         builder.getIndexAttr(i)));
   }
   build(builder, result, resultType, source, targetEncoding, dynamicDims,
-        waitFence, name);
+        waitFence, name, affinity);
 }
 
 Value TensorImportOp::getTiedResult(unsigned resultIndex) {
@@ -530,10 +531,12 @@ LogicalResult TensorImportOp::verify() {
 
 void TensorExportOp::build(OpBuilder &builder, OperationState &result,
                            Type resultType, Value source,
-                           TypeAttr sourceEncoding, StringAttr name) {
+                           TypeAttr sourceEncoding, StringAttr name,
+                           Attribute affinity) {
   auto dynamicDims =
       IREE::Util::buildDynamicDimsForValue(result.location, source, builder);
-  build(builder, result, resultType, source, sourceEncoding, dynamicDims, name);
+  build(builder, result, resultType, source, sourceEncoding, dynamicDims, name,
+        affinity);
 }
 
 Value TensorExportOp::getTiedResult(unsigned resultIndex) {
@@ -592,10 +595,11 @@ LogicalResult TensorAliasOp::verify() {
 //===----------------------------------------------------------------------===//
 
 void TensorBarrierOp::build(OpBuilder &builder, OperationState &result,
-                            ValueRange sources, Value signalFence) {
+                            ValueRange sources, Value signalFence,
+                            Attribute affinity) {
   auto resultTypes = llvm::map_to_vector(
       sources, [](Value source) { return source.getType(); });
-  build(builder, result, resultTypes, sources, signalFence);
+  build(builder, result, resultTypes, sources, signalFence, affinity);
 }
 
 Value TensorBarrierOp::getTiedResult(unsigned resultIndex) {

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -125,13 +125,15 @@ def HAL_TensorImportOp : HAL_PureOp<"tensor.import", [
     TypeAttr:$target_encoding,
     HAL_ShapeDynamicDims:$target_dims,
     Optional<HAL_Fence>:$wait_fence,
-    OptionalAttr<StrAttr>:$name
+    OptionalAttr<StrAttr>:$name,
+    OptionalAttr<AnyAttr>:$affinity
   );
   let results = (outs
     AnyTensor:$target
   );
 
   let assemblyFormat = [{
+    (`on` `(` $affinity^ `)`)?
     (`wait` `(` $wait_fence^ `)` `=` `` `>`)?
     $source
     ($name^)?
@@ -145,14 +147,16 @@ def HAL_TensorImportOp : HAL_PureOp<"tensor.import", [
       "Type":$resultType,
       "Value":$source,
       "TypeAttr":$targetEncoding,
-      "StringAttr":$name
+      "StringAttr":$name,
+      "Attribute":$affinity
     )>,
     OpBuilder<(ins
       "Type":$resultType,
       "Value":$source,
       "TypeAttr":$targetEncoding,
       "Value":$waitFence,
-      "StringAttr":$name
+      "StringAttr":$name,
+      "Attribute":$affinity
     )>,
   ];
 
@@ -190,13 +194,15 @@ def HAL_TensorExportOp : HAL_PureOp<"tensor.export", [
     AnyTensor:$source,
     TypeAttr:$source_encoding,
     HAL_ShapeDynamicDims:$source_dims,
-    OptionalAttr<StrAttr>:$name
+    OptionalAttr<StrAttr>:$name,
+    OptionalAttr<AnyAttr>:$affinity
   );
   let results = (outs
     AnyTypeOf<[HAL_Buffer, HAL_BufferView]>:$target
   );
 
   let assemblyFormat = [{
+    (`on` `(` $affinity^ `)`)?
     $source
     ($name^)?
     `:`
@@ -211,7 +217,8 @@ def HAL_TensorExportOp : HAL_PureOp<"tensor.export", [
       "Type":$resultType,
       "Value":$source,
       "TypeAttr":$sourceEncoding,
-      "StringAttr":$name
+      "StringAttr":$name,
+      "Attribute":$affinity
     )>,
   ];
 
@@ -273,13 +280,15 @@ def HAL_TensorAliasOp : HAL_PureOp<"tensor.alias", [
     AnyTensor:$source,
     HAL_ShapeDynamicDims:$source_dims,
     AnyTypeOf<[HAL_Buffer, HAL_BufferView]>:$storage,
-    Optional<HAL_Fence>:$wait_fence
+    Optional<HAL_Fence>:$wait_fence,
+    OptionalAttr<AnyAttr>:$affinity
   );
   let results = (outs
     AnyTensor:$result
   );
 
   let assemblyFormat = [{
+    (`on` `(` $affinity^ `)`)?
     (`wait` `(` $wait_fence^ `)` `=` `` `>`)?
     $source `:` type($source) (`{` $source_dims^ `}`)?
     `to`
@@ -311,13 +320,15 @@ def HAL_TensorBarrierOp : HAL_Op<"tensor.barrier", [
 
   let arguments = (ins
     Variadic<AnyTensor>:$sources,
-    HAL_Fence:$signal_fence
+    HAL_Fence:$signal_fence,
+    OptionalAttr<AnyAttr>:$affinity
   );
   let results = (outs
     Variadic<AnyTensor>:$results
   );
 
   let assemblyFormat = [{
+    (`on` `(` $affinity^ `)`)?
     `join` `` `(` $sources `:` type($sources) `)`
     `=` `` `>`
     $signal_fence `:` type($signal_fence)
@@ -327,7 +338,8 @@ def HAL_TensorBarrierOp : HAL_Op<"tensor.barrier", [
   let builders = [
     OpBuilder<(ins
       "ValueRange":$sources,
-      "Value":$signalFence
+      "Value":$signalFence,
+      "Attribute":$affinity
     )>,
   ];
 

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/attributes.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/attributes.mlir
@@ -61,6 +61,20 @@
 
 // -----
 
+// CHECK-LABEL: "device.aliases"
+"device.aliases"() {
+  // CHECK-SAME: alias_0 = #hal.device.alias<"a"> : !hal.device
+  alias_0 = #hal.device.alias<"a"> : !hal.device,
+  // CHECK-SAME: alias_1 = #hal.device.alias<"b", {}> : !hal.device
+  alias_1 = #hal.device.alias<"b", {}> : !hal.device,
+  // CHECK-SAME: alias_2 = #hal.device.alias<"c"[4]> : !hal.device
+  alias_2 = #hal.device.alias<"c"[4]> : !hal.device,
+  // CHECK-SAME: alias_3 = #hal.device.alias<"d", {config = 123 : index}>
+  alias_3 = #hal.device.alias<"d", {config = 123 : index}> : !hal.device
+} : () -> ()
+
+// -----
+
 // CHECK-LABEL: "device.targets"
 "device.targets"() {
   // CHECK-SAME: target_0 = #hal.device.target<"a"> : !hal.device

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetOptions.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetOptions.cpp
@@ -22,9 +22,20 @@ void TargetOptions::bindOptions(OptionsBinder &binder) {
   // initialized, so targetBackendsFlags needs to be here to be initialized
   // first.
   binder.list<std::string>(
-      "iree-hal-target-backends", targets,
+      "iree-hal-target-backends", legacyTargetBackends,
       llvm::cl::desc("Target backends for executable compilation."),
       llvm::cl::ZeroOrMore, llvm::cl::cat(halTargetOptionsCategory));
+
+  binder.list<std::string>("iree-hal-target-device", targetDevices,
+                           llvm::cl::desc("Target device specifications."),
+                           llvm::cl::ZeroOrMore,
+                           llvm::cl::cat(halTargetOptionsCategory));
+  binder.opt<std::string>(
+      "iree-hal-default-device", defaultDevice,
+      llvm::cl::desc("Which device is considered the default when no device "
+                     "affinity is specified. Either the device name when names "
+                     "are specified or the numeric ordinal of the device."),
+      llvm::cl::cat(halTargetOptionsCategory));
 
   binder.opt<int>(
       "iree-hal-executable-debug-level", debugLevel,

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetOptions.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetOptions.h
@@ -17,8 +17,35 @@ namespace mlir::iree_compiler::IREE::HAL {
 // TODO(benvanik): remove this and replace with the pass pipeline options.
 // Controls executable translation targets.
 struct TargetOptions {
-  // TODO(benvanik): multiple targets of the same type, etc.
-  std::vector<std::string> targets;
+  // TODO(benvanik): remove the legacy flag once users are switched to devices.
+  std::vector<std::string> legacyTargetBackends;
+
+  // Specifies target devices to assign to the program. May be omitted if the
+  // program already has devices assigned or no devices are required (host
+  // program not using the HAL).
+  //
+  // Two devices, one the local host device and the other a Vulkan device:
+  // `local`, `vulkan`
+  //
+  // One device selecting between Vulkan if available and otherwise use the
+  // local host device:
+  // `vulkan,local`
+  //
+  // Two CUDA devices selected by runtime ordinal; at runtime two --device=
+  // flags are required to configure both devices:
+  // `cuda[0]`, `cuda[1]`
+  //
+  // A fully-defined target specification:
+  // `#hal.device.target<"cuda", {...}, [#hal.executable.target<...>]>`
+  //
+  // Named device for defining a reference by #hal.device.promise<@some_name>:
+  // `some_name=vulkan`
+  std::vector<std::string> targetDevices;
+
+  // Which device is considered the default when no device affinity is specified
+  // on a particular operation. Accepts string names matching those specified
+  // in the target devices list or numeric ordinals if names were omitted.
+  std::string defaultDevice;
 
   // Coarse debug level for executable translation across all targets.
   // Each target backend can use this to control its own flags, with values

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/AssignLegacyTargetDevices.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/AssignLegacyTargetDevices.cpp
@@ -1,0 +1,117 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <memory>
+#include <utility>
+
+#include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "iree/compiler/Dialect/HAL/Target/TargetBackend.h"
+#include "iree/compiler/Dialect/HAL/Target/TargetRegistry.h"
+#include "iree/compiler/Dialect/HAL/Transforms/Passes.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/raw_ostream.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir::iree_compiler::IREE::HAL {
+
+#define GEN_PASS_DEF_ASSIGNLEGACYTARGETDEVICESPASS
+#include "iree/compiler/Dialect/HAL/Transforms/Passes.h.inc"
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// --iree-hal-assign-legacy-target-devices
+//===----------------------------------------------------------------------===//
+
+struct AssignLegacyTargetDevicesPass
+    : public IREE::HAL::impl::AssignLegacyTargetDevicesPassBase<
+          AssignLegacyTargetDevicesPass> {
+  using IREE::HAL::impl::AssignLegacyTargetDevicesPassBase<
+      AssignLegacyTargetDevicesPass>::AssignLegacyTargetDevicesPassBase;
+
+  void runOnOperation() override {
+    auto moduleOp = getOperation();
+
+    // If no targets are specified we can't do anything - another pass earlier
+    // in the pipeline will have had to add the targets.
+    if (targetBackends.empty()) {
+      return;
+    }
+
+    // Check to see if targets are already specified and if so then no-op the
+    // pass so that we don't mess with whatever the user intended.
+    auto existingTargetsAttr =
+        moduleOp->getAttrOfType<ArrayAttr>("hal.device.targets");
+    if (existingTargetsAttr) {
+      return;
+    }
+
+    // If there are any device globals declared then bail as it means the user
+    // has already materialized the devices they want.
+    for (auto globalOp : moduleOp.getOps<IREE::Util::GlobalOpInterface>()) {
+      if (isa<IREE::HAL::DeviceType>(globalOp.getGlobalType())) {
+        return;
+      }
+    }
+
+    llvm::SmallDenseSet<Attribute> targetAttrSet;
+    SmallVector<Attribute> targetAttrs;
+    for (const auto &targetBackendName : targetBackends) {
+      auto targetBackend = targetRegistry->getTargetBackend(targetBackendName);
+      if (!targetBackend) {
+        auto diagnostic = emitError(moduleOp.getLoc())
+                          << "target backend '" << targetBackendName
+                          << "' not registered; registered backends: [";
+        llvm::interleaveComma(targetRegistry->getRegisteredTargetBackends(),
+                              diagnostic);
+        diagnostic << "]";
+        return signalPassFailure();
+      }
+      auto targetDeviceName = targetBackend->getLegacyDefaultDeviceID();
+      auto targetDevice = targetRegistry->getTargetDevice(targetDeviceName);
+      if (!targetDevice) {
+        auto diagnostic = emitError(moduleOp.getLoc())
+                          << "target device '" << targetDeviceName
+                          << "' not registered; registered devices: [";
+        llvm::interleaveComma(targetRegistry->getRegisteredTargetDevices(),
+                              diagnostic);
+        diagnostic << "]";
+        return signalPassFailure();
+      }
+
+      // Ask the target backend for its default device specification attribute.
+      auto targetAttr = targetDevice->getDefaultDeviceTarget(
+          moduleOp.getContext(), *targetRegistry.value);
+      if (!targetAttr) {
+        emitError(moduleOp.getLoc()) << "no default device targets available";
+        return signalPassFailure();
+      }
+      if (!targetAttrSet.contains(targetAttr)) {
+        targetAttrSet.insert(targetAttr);
+        targetAttrs.push_back(targetAttr);
+      }
+    }
+
+    Attribute targetsAttr;
+    if (targetAttrs.size() == 1) {
+      targetsAttr = targetAttrs.front();
+    } else {
+      targetsAttr =
+          IREE::HAL::DeviceSelectAttr::get(moduleOp.getContext(), targetAttrs);
+    }
+    moduleOp->setAttr("hal.device.targets",
+                      ArrayAttr::get(moduleOp.getContext(), targetsAttr));
+  }
+};
+
+} // namespace
+
+} // namespace mlir::iree_compiler::IREE::HAL

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/AssignTargetDevices.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/AssignTargetDevices.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 The IREE Authors
+// Copyright 2024 The IREE Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -14,6 +14,7 @@
 #include "iree/compiler/Dialect/HAL/Transforms/Passes.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/raw_ostream.h"
+#include "mlir/AsmParser/AsmParser.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -30,6 +31,162 @@ namespace {
 //===----------------------------------------------------------------------===//
 // --iree-hal-assign-target-devices
 //===----------------------------------------------------------------------===//
+
+// Strips leading and trailing whitespace from |value|.
+static StringRef stripWhitespace(StringRef value) {
+  while (!value.empty() && llvm::isSpace(value.front())) {
+    value = value.substr(1);
+  }
+  while (!value.empty() && llvm::isSpace(value.back())) {
+    value = value.substr(0, value.size() - 1);
+  }
+  return value;
+}
+
+// Strips leading and trailing double quotes from |value| if both exist.
+static StringRef stripQuotes(StringRef value) {
+  value = stripWhitespace(value);
+  if (!value.empty() && value.front() == '"' && value.back() == '"') {
+    return stripWhitespace(value.substr(1, value.size() - 2));
+  }
+  return value;
+}
+
+// Consumes a leading `name=` literal.
+// Returns the `name` and leaves remaining characters after `=` in |value|.
+// Returns an empty string if no name literal is present.
+static StringRef consumeNameLiteral(StringRef &value) {
+  value = stripWhitespace(value);
+  const size_t splitIdx = value.find('=');
+  if (splitIdx == std::string::npos) {
+    return "";
+  }
+  for (size_t i = 0; i < splitIdx; ++i) {
+    const char c = value[i];
+    if (!llvm::isAlnum(c) && c != '_') {
+      return value;
+    }
+  }
+  const StringRef name = value.substr(0, splitIdx);
+  value = stripWhitespace(value.substr(splitIdx + 1));
+  return stripWhitespace(name);
+}
+
+// Consumes the first portion of |value| corresponding to a device alias.
+// Expects: `abc` or `abc[123]` (and allows `"abc"[123]`).
+// Only valid literals will be parsed (a-z0-9_).
+// Returns the device ID and optional ordinal. All other unconsumed characters
+// will remain in |value| upon return.
+static std::pair<StringRef, std::optional<int64_t>>
+consumeAliasLiteral(StringRef &value) {
+  value = stripWhitespace(value);
+  const size_t splitIdx = value.find(',');
+  StringRef part =
+      splitIdx == std::string::npos ? value : value.substr(0, splitIdx);
+
+  StringRef deviceID = part;
+  std::optional<int64_t> ordinal;
+
+  const size_t ordinalIdx = part.find('[');
+  if (ordinalIdx != std::string::npos) {
+    deviceID = part.substr(0, ordinalIdx);
+    StringRef ordinalStr = part.substr(ordinalIdx + 1);
+    if (ordinalStr.ends_with(']')) {
+      ordinalStr = ordinalStr.substr(0, ordinalStr.size() - 1);
+    }
+    int64_t ordinalI64 = 0;
+    if (!ordinalStr.getAsInteger(10, ordinalI64)) {
+      ordinal = ordinalI64;
+    }
+  }
+
+  value = stripWhitespace(value.substr(part.size()));
+  return std::make_pair(stripQuotes(deviceID), ordinal);
+}
+
+struct TargetSpec {
+  StringAttr name;
+  TypedAttr attr;
+};
+
+// Parses the user-provided string into a target spec.
+//
+// Supports attributes:
+//  #hal.device.alias<...>
+//  #hal.device.target<...>
+//  #hal.device.select<...>
+//  #hal.device.fallback<...>
+// Supports convenience shorthand:
+//  ...,... -> #hal.device.select<[...,...]>
+//  target -> #hal.device.alias<"target">
+//  target[0] -> #hal.device.alias<"target"[0]>
+//  "target"[0] -> #hal.device.alias<"target"[0]>
+// Supports name= prefixes:
+//  name=... -> ...
+static FailureOr<TargetSpec> parseTargetSpec(Location loc,
+                                             StringRef targetSpecStr) {
+  auto *context = loc.getContext();
+  targetSpecStr = stripQuotes(targetSpecStr);
+
+  // Check for a name prefix and strip it from the spec.
+  StringRef name = consumeNameLiteral(targetSpecStr);
+  StringAttr nameAttr =
+      name.empty() ? StringAttr{} : StringAttr::get(context, name);
+
+  // Parse the spec attributes.
+  SmallVector<Attribute> attrs;
+  while (!targetSpecStr.empty()) {
+    TypedAttr typedAttr;
+    if (targetSpecStr.starts_with('#')) {
+      // MLIR attribute.
+      size_t numRead = 0;
+      auto parsedAttr = mlir::parseAttribute(targetSpecStr, context,
+                                             /*type=*/nullptr, &numRead);
+      if (!parsedAttr) {
+        return mlir::emitError(loc) << "failed to parse target spec prefix `"
+                                    << targetSpecStr << "`";
+      }
+      typedAttr = dyn_cast<TypedAttr>(parsedAttr);
+      if (!typedAttr) {
+        return mlir::emitError(loc) << "unexpected target attribute type: "
+                                       "expected a `!hal.device` but got `"
+                                    << parsedAttr << "`";
+      }
+      targetSpecStr = stripWhitespace(targetSpecStr.substr(numRead));
+    } else {
+      // Alias string.
+      auto [deviceID, ordinal] = consumeAliasLiteral(targetSpecStr);
+      typedAttr = IREE::HAL::DeviceAliasAttr::get(
+          context, IREE::HAL::DeviceType::get(context),
+          StringAttr::get(context, deviceID), ordinal, DictionaryAttr{});
+    }
+
+    if (!typedAttr || !isa<IREE::HAL::DeviceType>(typedAttr.getType())) {
+      return mlir::emitError(loc) << "unexpected target attribute type: "
+                                     "expected a `!hal.device` but got `"
+                                  << typedAttr.getType() << "`";
+    }
+    attrs.push_back(typedAttr);
+
+    if (targetSpecStr.empty()) {
+      break; // done
+    } else if (!targetSpecStr.starts_with(',')) {
+      return mlir::emitError(loc)
+             << "unexpected additional characters after parsing an element: `"
+             << targetSpecStr << "`";
+    }
+    targetSpecStr = targetSpecStr.substr(1); // strip ,
+  }
+
+  if (attrs.empty()) {
+    return mlir::emitError(loc) << "expected one or more target attributes";
+  } else if (attrs.size() == 1) {
+    return TargetSpec{nameAttr, cast<TypedAttr>(attrs.front())};
+  } else {
+    return TargetSpec{nameAttr,
+                      IREE::HAL::DeviceSelectAttr::get(context, attrs)};
+  }
+}
 
 struct AssignTargetDevicesPass
     : public IREE::HAL::impl::AssignTargetDevicesPassBase<
@@ -55,50 +212,58 @@ struct AssignTargetDevicesPass
     // If there are any device globals declared then bail as it means the user
     // has already materialized the devices they want.
     for (auto globalOp : moduleOp.getOps<IREE::Util::GlobalOpInterface>()) {
-      if (isa<IREE::HAL::DeviceType>(globalOp.getGlobalType()))
+      if (isa<IREE::HAL::DeviceType>(globalOp.getGlobalType())) {
         return;
-    }
-
-    llvm::SmallDenseSet<Attribute> targetAttrSet;
-    SmallVector<Attribute> targetAttrs;
-    for (const auto &targetBackendName : targetBackends) {
-      auto targetBackend = targetRegistry->getTargetBackend(targetBackendName);
-      if (!targetBackend) {
-        auto diagnostic = emitError(moduleOp.getLoc())
-                          << "target backend '" << targetBackendName
-                          << "' not registered; registered backends: [";
-        llvm::interleaveComma(targetRegistry->getRegisteredTargetBackends(),
-                              diagnostic);
-        diagnostic << "]";
-        return signalPassFailure();
-      }
-      auto targetDeviceName = targetBackend->getLegacyDefaultDeviceID();
-      auto targetDevice = targetRegistry->getTargetDevice(targetDeviceName);
-      if (!targetDevice) {
-        auto diagnostic = emitError(moduleOp.getLoc())
-                          << "target device '" << targetDeviceName
-                          << "' not registered; registered devices: [";
-        llvm::interleaveComma(targetRegistry->getRegisteredTargetDevices(),
-                              diagnostic);
-        diagnostic << "]";
-        return signalPassFailure();
-      }
-
-      // Ask the target backend for its default device specification attribute.
-      auto targetAttr = targetDevice->getDefaultDeviceTarget(
-          moduleOp.getContext(), *targetRegistry.value);
-      if (!targetAttr) {
-        emitError(moduleOp.getLoc()) << "no default device targets available";
-        return signalPassFailure();
-      }
-      if (!targetAttrSet.contains(targetAttr)) {
-        targetAttrSet.insert(targetAttr);
-        targetAttrs.push_back(targetAttr);
       }
     }
 
-    moduleOp->setAttr("hal.device.targets",
-                      ArrayAttr::get(moduleOp.getContext(), targetAttrs));
+    // Parse each spec and validate correctness.
+    bool hasAnyNamed = false;
+    bool hasAnyUnnamed = false;
+    SmallVector<TargetSpec> targetSpecs;
+    for (auto &targetDevice : targetDevices) {
+      auto targetSpecOr = parseTargetSpec(moduleOp.getLoc(), targetDevice);
+      if (failed(targetSpecOr)) {
+        return signalPassFailure();
+      }
+      if (targetSpecOr->name) {
+        hasAnyNamed = true;
+      } else {
+        hasAnyUnnamed = true;
+      }
+      targetSpecs.push_back(*targetSpecOr);
+    }
+
+    // If any spec has a name assigned then all must have names assigned.
+    if (hasAnyNamed && hasAnyUnnamed) {
+      emitError(moduleOp.getLoc())
+          << "if any target device spec has a name then all must be named";
+      return signalPassFailure();
+    }
+
+    if (hasAnyNamed) {
+      // NOTE: we allow duplicate names to override assignment.
+      llvm::MapVector<StringAttr, Attribute> deviceAttrMap;
+      for (auto targetSpec : targetSpecs) {
+        assert(targetSpec.name && "all devices must be named");
+        deviceAttrMap[targetSpec.name] = targetSpec.attr;
+      }
+      SmallVector<NamedAttribute> deviceAttrs;
+      for (auto [name, value] : deviceAttrMap) {
+        deviceAttrs.push_back(NamedAttribute(name, value));
+      }
+      moduleOp->setAttr(
+          "hal.device.targets",
+          DictionaryAttr::get(moduleOp.getContext(), deviceAttrs));
+    } else {
+      SmallVector<Attribute> deviceAttrs;
+      for (auto [name, value] : targetSpecs) {
+        assert(!name && "no devices may have names");
+        deviceAttrs.push_back(value);
+      }
+      moduleOp->setAttr("hal.device.targets",
+                        ArrayAttr::get(moduleOp.getContext(), deviceAttrs));
+    }
   }
 };
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/BUILD.bazel
@@ -35,6 +35,7 @@ iree_compiler_cc_library(
         "PreprocessExecutables.cpp",
         "PruneExecutables.cpp",
         "RepeatDispatches.cpp",
+        "ResolveDeviceAliases.cpp",
         "ResolveDevicePromises.cpp",
         "ResolveExportOrdinals.cpp",
         "SerializeExecutables.cpp",

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/BUILD.bazel
@@ -15,6 +15,7 @@ package(
 iree_compiler_cc_library(
     name = "Transforms",
     srcs = [
+        "AssignLegacyTargetDevices.cpp",
         "AssignTargetDevices.cpp",
         "CaptureExecutableSources.cpp",
         "ConfigureExecutables.cpp",
@@ -75,6 +76,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:AffineToStandard",
         "@llvm-project//mlir:AffineTransforms",
         "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:AsmParser",
         "@llvm-project//mlir:BufferizationDialect",
         "@llvm-project//mlir:ControlFlowDialect",
         "@llvm-project//mlir:FuncDialect",

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
@@ -36,6 +36,7 @@ iree_cc_library(
     "PreprocessExecutables.cpp"
     "PruneExecutables.cpp"
     "RepeatDispatches.cpp"
+    "ResolveDeviceAliases.cpp"
     "ResolveDevicePromises.cpp"
     "ResolveExportOrdinals.cpp"
     "SerializeExecutables.cpp"

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_cc_library(
   HDRS
     "Passes.h"
   SRCS
+    "AssignLegacyTargetDevices.cpp"
     "AssignTargetDevices.cpp"
     "CaptureExecutableSources.cpp"
     "ConfigureExecutables.cpp"
@@ -50,6 +51,7 @@ iree_cc_library(
     MLIRAffineToStandard
     MLIRAffineTransforms
     MLIRArithDialect
+    MLIRAsmParser
     MLIRBufferizationDialect
     MLIRControlFlowDialect
     MLIRFuncDialect

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeTargetDevices.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeTargetDevices.cpp
@@ -166,8 +166,9 @@ static void assignDefaultDeviceAffinity(mlir::ModuleOp moduleOp,
     }
 
     if (auto affinityOp = dyn_cast<IREE::Stream::AffinityOpInterface>(op)) {
-      if (!affinityOp.getAffinity())
-        affinityOp.setAffinity(affinityAttr);
+      if (!affinityOp.getAffinityAttr()) {
+        affinityOp.setAffinityAttr(affinityAttr);
+      }
     } else {
       if (!op.hasAttr(affinityName)) {
         op.setAttr(affinityName, affinityAttr);

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
@@ -200,6 +200,8 @@ void buildHALDeviceAssignmentPassPipeline(OpPassManager &passManager,
   }
   passManager.addPass(IREE::HAL::createMaterializeTargetDevicesPass());
   passManager.addPass(IREE::HAL::createResolveDevicePromisesPass());
+  passManager.addPass(
+      IREE::HAL::createResolveDeviceAliasesPass({&targetRegistry}));
   passManager.addPass(IREE::HAL::createVerifyDevicesPass({&targetRegistry}));
 }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.h
@@ -46,12 +46,36 @@ struct PipelineHooks {
   std::function<void(PipelinePhase phase, OpPassManager &)> afterPhase;
 };
 
+struct AssignmentOptions : public PassPipelineOptions<AssignmentOptions> {
+  // TODO(benvanik): remove the legacy flag once users are switched to devices.
+  ListOption<std::string> legacyTargetBackends{
+      *this,
+      "legacy-target-backends",
+      llvm::cl::desc("DEPRECATED: Target backend names."),
+      llvm::cl::ZeroOrMore,
+  };
+  ListOption<std::string> targetDevices{
+      *this,
+      "target-devices",
+      llvm::cl::desc("Target device specifications."),
+      llvm::cl::ZeroOrMore,
+  };
+  Option<std::string> defaultDevice{
+      *this,
+      "default-device",
+      llvm::cl::desc("Which device is considered the default when no device "
+                     "affinity is specified. Either the device name when names "
+                     "are specified or the numeric ordinal of the device."),
+      llvm::cl::init(""),
+  };
+};
+
 // Assigns devices from flags and coarse module-level specification.
 // Frontends are encouraged to create and assign devices themselves in order to
 // support more complex configurations (multiple devices, fallbacks, etc).
-void buildHALDeviceAssignmentPassPipeline(OpPassManager &passManager,
-                                          const TargetRegistry &targetRegistry,
-                                          const TargetOptions &targetOptions);
+void buildHALDeviceAssignmentPassPipeline(
+    OpPassManager &passManager, const TargetRegistry &targetRegistry,
+    const AssignmentOptions &assignmentOptions);
 
 // Adds a set of passes to the given pass manager that run the head of the HAL
 // pipeline to materialize interfaces, import externally specified executables,

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.td
@@ -91,6 +91,25 @@ def ResolveDevicePromisesPass :
   ];
 }
 
+def ResolveDeviceAliasesPass :
+    Pass<"iree-hal-resolve-device-aliases", "mlir::ModuleOp"> {
+  let summary = "Resolves `#hal.device.alias` attributes to their expanded configurations.";
+  let description = [{
+    Resolves device aliases to the concrete targets using defaults, flags, and
+    registered device configurations.
+  }];
+  let options = [
+    Option<
+      "targetRegistry", "target-registry",
+      "llvm::cl::TargetRegistryRef", "",
+      "Target registry containing the list of available devices and backends."
+    >,
+  ];
+  let dependentDialects = [
+    "IREE::HAL::HALDialect",
+  ];
+}
+
 def VerifyDevicesPass :
     Pass<"iree-hal-verify-devices", "mlir::ModuleOp"> {
   let summary = "Verifies that all devices can be targeted with the available compiler plugins.";

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.td
@@ -42,8 +42,8 @@ def ConvertToHALPass :
 // Device management
 //===----------------------------------------------------------------------===//
 
-def AssignTargetDevicesPass :
-    Pass<"iree-hal-assign-target-devices", "mlir::ModuleOp"> {
+def AssignLegacyTargetDevicesPass :
+    Pass<"iree-hal-assign-legacy-target-devices", "mlir::ModuleOp"> {
   let summary = "Assigns the HAL devices the module will target to the given list of targets.";
   let description = [{
     Assigns target HAL devices to the module based on the given list.
@@ -65,14 +65,75 @@ def AssignTargetDevicesPass :
   ];
 }
 
+def AssignTargetDevicesPass :
+    Pass<"iree-hal-assign-target-devices", "mlir::ModuleOp"> {
+  let summary = "Assigns the HAL devices the module will target to the given list of target specifications.";
+  let description = [{
+    Assigns target HAL devices to the module based on the given list of target
+    specifications.
+
+    Targets can be specified in several ways depending on whether there are
+    multiple devices, named devices, or devices imported from external files.
+    Human-friendly device aliases can be used as shorthand for
+    `IREE::HAL::TargetDevice` implementations providing their own configuration.
+    The aliases are identical to those used by `#hal.device.alias<>`.
+
+    If multiple targets are specified they will be available as multiple
+    distinct devices. A single device may select from one or more targets such
+    that the first enumerated that matches at runtime will be selected. For
+    example a `gpu` device may select between CUDA, HIP, or Vulkan at runtime
+    based on what kind of device the user has and what HAL implementations were
+    compiled into the runtime.
+
+    Examples using the canonical flag:
+    ```mlir
+    // Two devices, one the local host device and the other a Vulkan device:
+    --iree-hal-target-device=local
+    --iree-hal-target-device=vulkan
+
+    // One device selecting between Vulkan if available and otherwise use the
+    // local host device:
+    --iree-hal-target-device=vulkan,local
+
+    // Two CUDA devices selected by runtime ordinal; at runtime two --device=
+    // flags are required to configure both devices:
+    --iree-hal-target-device=cuda[0]
+    --iree-hal-target-device=cuda[1]
+
+    // A fully-defined target specification:
+    --iree-hal-target-device=#hal.device.target<"cuda", {...}, [#hal.executable.target<...>]>
+
+    // Named device for defining a reference by #hal.device.promise<@some_name>:
+    --iree-hal-target-device=some_name=vulkan
+    ```
+  }];
+  let options = [
+    ListOption<
+      "targetDevices", "targetDevices",
+      "std::string",
+      "List of target device specifications."
+    >,
+  ];
+  let dependentDialects = [
+    "IREE::HAL::HALDialect",
+  ];
+}
+
 def MaterializeTargetDevicesPass :
     Pass<"iree-hal-materialize-target-devices", "mlir::ModuleOp"> {
   let summary = "Materializes global device handles based on a `hal.device.targets` spec.";
   let description = [{
-    Materializes a global `!hal.device` for the devices specified by the
-    `hal.device.targets` attribute on the module. It's preferred that frontends
-    provide IR with the globals assigned as this only supports a single device.
+    Materializes global `!hal.device` ops for the devices specified by the
+    `hal.device.targets` attribute on the module. An optional default device can
+    be specified to assign to ops that do not have a default device specified.
   }];
+  let options = [
+    Option<
+      "defaultDevice", "defaultDevice",
+      "std::string", "",
+      "Which device is considered the default when no device affinity is specified."
+    >,
+  ];
   let dependentDialects = [
     "IREE::HAL::HALDialect",
     "IREE::Util::UtilDialect",

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/ResolveDeviceAliases.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/ResolveDeviceAliases.cpp
@@ -1,0 +1,134 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <memory>
+#include <utility>
+
+#include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "iree/compiler/Dialect/HAL/Target/TargetRegistry.h"
+#include "iree/compiler/Dialect/HAL/Transforms/Passes.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir::iree_compiler::IREE::HAL {
+
+#define GEN_PASS_DEF_RESOLVEDEVICEALIASESPASS
+#include "iree/compiler/Dialect/HAL/Transforms/Passes.h.inc"
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// --iree-hal-resolve-device-aliases
+//===----------------------------------------------------------------------===//
+
+static FailureOr<Attribute>
+resolveAliasAttr(Operation *forOp, IREE::HAL::DeviceAliasAttr aliasAttr,
+                 const TargetRegistry &targetRegistry) {
+  // Lookup device in the registry.
+  auto targetDevice =
+      targetRegistry.getTargetDevice(aliasAttr.getDeviceID().getValue());
+  if (!targetDevice) {
+    auto diagnostic = forOp->emitError();
+    diagnostic << "unregistered device alias " << aliasAttr.getDeviceID()
+               << "; ensure it is linked into the compiler (available = [ ";
+    for (const auto &targetName : targetRegistry.getRegisteredTargetDevices()) {
+      diagnostic << "'" << targetName << "' ";
+    }
+    diagnostic << "])";
+    return diagnostic;
+  }
+
+  // Query the default device target.
+  auto defaultAttr =
+      targetDevice->getDefaultDeviceTarget(forOp->getContext(), targetRegistry);
+  assert(defaultAttr && "expected a default device target attr");
+
+  // Merge in any additional configuration from the alias attr.
+  if (aliasAttr.getOrdinal().has_value() ||
+      (aliasAttr.getConfiguration() && !aliasAttr.getConfiguration().empty())) {
+    NamedAttrList configAttrs;
+    if (auto defaultConfigAttr = defaultAttr.getConfiguration()) {
+      for (auto existingAttr : defaultConfigAttr) {
+        configAttrs.push_back(existingAttr);
+      }
+    }
+    if (auto overrideConfigAttr = aliasAttr.getConfiguration()) {
+      for (auto overrideAttr : overrideConfigAttr) {
+        configAttrs.set(overrideAttr.getName(), overrideAttr.getValue());
+      }
+    }
+    if (aliasAttr.getOrdinal().has_value()) {
+      configAttrs.set("ordinal",
+                      IntegerAttr::get(IndexType::get(forOp->getContext()),
+                                       aliasAttr.getOrdinal().value()));
+    }
+    defaultAttr = IREE::HAL::DeviceTargetAttr::get(
+        forOp->getContext(), defaultAttr.getDeviceID(),
+        DictionaryAttr::get(forOp->getContext(), configAttrs),
+        defaultAttr.getExecutableTargets());
+  }
+
+  return defaultAttr;
+}
+
+static FailureOr<Attribute>
+resolveNestedAliasAttrs(Operation *forOp, Attribute attr,
+                        const TargetRegistry &targetRegistry) {
+  if (auto aliasAttr = dyn_cast<IREE::HAL::DeviceAliasAttr>(attr)) {
+    return resolveAliasAttr(forOp, aliasAttr, targetRegistry);
+  } else if (auto selectAttr = dyn_cast<IREE::HAL::DeviceSelectAttr>(attr)) {
+    SmallVector<Attribute> resolvedAttrs;
+    bool didChange = false;
+    for (auto deviceAttr : selectAttr.getDevices()) {
+      auto resolvedAttr =
+          resolveNestedAliasAttrs(forOp, deviceAttr, targetRegistry);
+      if (failed(resolvedAttr)) {
+        return failure();
+      }
+      didChange = didChange || *resolvedAttr != deviceAttr;
+      resolvedAttrs.push_back(*resolvedAttr);
+    }
+    return didChange ? IREE::HAL::DeviceSelectAttr::get(attr.getContext(),
+                                                        resolvedAttrs)
+                     : attr;
+  } else {
+    return attr; // pass-through
+  }
+}
+
+struct ResolveDeviceAliasesPass
+    : public IREE::HAL::impl::ResolveDeviceAliasesPassBase<
+          ResolveDeviceAliasesPass> {
+  using IREE::HAL::impl::ResolveDeviceAliasesPassBase<
+      ResolveDeviceAliasesPass>::ResolveDeviceAliasesPassBase;
+  void runOnOperation() override {
+    // Walks all device globals and resolve any aliases found.
+    auto moduleOp = getOperation();
+    for (auto globalOp : moduleOp.getOps<IREE::Util::GlobalOpInterface>()) {
+      if (!isa<IREE::HAL::DeviceType>(globalOp.getGlobalType())) {
+        continue;
+      }
+      auto initialValue = globalOp.getGlobalInitialValue();
+      if (!initialValue) {
+        continue;
+      }
+      auto resolvedValue = resolveNestedAliasAttrs(globalOp, initialValue,
+                                                   *targetRegistry.value);
+      if (failed(resolvedValue)) {
+        return signalPassFailure();
+      }
+      globalOp.setGlobalInitialValue(*resolvedValue);
+    }
+  }
+};
+
+} // namespace
+
+} // namespace mlir::iree_compiler::IREE::HAL

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/VerifyDevices.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/VerifyDevices.cpp
@@ -50,7 +50,7 @@ verifyDeviceTargetAttr(Operation *deviceOp,
     auto diagnostic = deviceOp->emitError();
     diagnostic << "unregistered target device "
                << deviceTargetAttr.getDeviceID()
-               << "; ensure it is linked in to the compiler (available = [ ";
+               << "; ensure it is linked into the compiler (available = [ ";
     for (const auto &targetName : targetRegistry.getRegisteredTargetDevices()) {
       diagnostic << "'" << targetName << "' ";
     }
@@ -65,7 +65,7 @@ verifyDeviceTargetAttr(Operation *deviceOp,
       auto diagnostic = deviceOp->emitError();
       diagnostic << "unregistered target backend "
                  << executableTargetAttr.getBackend()
-                 << "; ensure it is linked in to the compiler (available = [ ";
+                 << "; ensure it is linked into the compiler (available = [ ";
       for (const auto &targetName :
            targetRegistry.getRegisteredTargetBackends()) {
         diagnostic << "'" << targetName << "' ";

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/BUILD.bazel
@@ -16,6 +16,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "assign_legacy_target_devices.mlir",
             "assign_target_devices.mlir",
             "capture_executable_sources.mlir",
             "convert_to_hal.mlir",

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/BUILD.bazel
@@ -32,6 +32,7 @@ iree_lit_test_suite(
             "preprocess_executables.mlir",
             "prune_executables.mlir",
             "repeat_dispatches.mlir",
+            "resolve_device_aliases.mlir",
             "resolve_device_promises.mlir",
             "resolve_export_ordinals.mlir",
             "strip_executable_contents.mlir",

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "assign_legacy_target_devices.mlir"
     "assign_target_devices.mlir"
     "capture_executable_sources.mlir"
     "convert_to_hal.mlir"

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/CMakeLists.txt
@@ -30,6 +30,7 @@ iree_lit_test_suite(
     "preprocess_executables.mlir"
     "prune_executables.mlir"
     "repeat_dispatches.mlir"
+    "resolve_device_aliases.mlir"
     "resolve_device_promises.mlir"
     "resolve_export_ordinals.mlir"
     "strip_executable_contents.mlir"

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/assign_legacy_target_devices.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/assign_legacy_target_devices.mlir
@@ -1,0 +1,42 @@
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-hal-assign-legacy-target-devices)' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-0
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-hal-assign-legacy-target-devices{targetBackends=vmvx})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-1
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-hal-assign-legacy-target-devices{targetBackends=vmvx,vmvx-inline})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-2
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-hal-assign-legacy-target-devices{targetBackends=vmvx,vmvx})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-EQ
+
+// TARGET-1: #device_target_local = #hal.device.target<"local"
+
+// TARGET-2: #device_target_local = #hal.device.target<"local"
+// TARGET-2: #device_target_vmvx_inline = #hal.device.target<"vmvx-inline"
+
+// TARGET-EQ: #device_target_local = #hal.device.target<"local"
+
+// CHECK: module
+// TARGET-0: @module {
+// TARGET-1: @module attributes {
+// TARGET-1-SAME: hal.device.targets = [#device_target_local]
+// TARGET-2: @module attributes {
+// TARGET-2-SAME: hal.device.targets = [#hal.device.select<[#device_target_local, #device_target_vmvx_inline]> : !hal.device]
+// TARGET-EQ: @module attributes {
+// TARGET-EQ-SAME: hal.device.targets = [#device_target_local]}
+module @module {}
+
+// -----
+
+// The pass is a no-op when targets are already specified.
+
+// CHECK: #device_target_foo = #hal.device.target<"foo"
+// CHECK: module @module attributes {hal.device.targets = [#device_target_foo]}
+module @module attributes {
+  hal.device.targets = [#hal.device.target<"foo">]
+} {}
+
+// -----
+
+// The pass does nothing when one or more devices has already been defined.
+
+// CHECK: module @module
+// CHECK-NOT: hal.device.targets
+module @module {
+  // CHECK: @existing_device
+  util.global private @existing_device : !hal.device
+}

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/assign_target_devices.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/assign_target_devices.mlir
@@ -1,33 +1,36 @@
-// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-hal-assign-target-devices)' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-0
-// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetBackends=vmvx})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-1
-// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetBackends=vmvx,vmvx-inline})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-2
-// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetBackends=vmvx,vmvx})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-EQ
-
-// TARGET-1: #device_target_local = #hal.device.target<"local"
-
-// TARGET-2: #device_target_local = #hal.device.target<"local"
-// TARGET-2: #device_target_vmvx_inline = #hal.device.target<"vmvx-inline"
-
-// TARGET-EQ: #device_target_local = #hal.device.target<"local"
+// RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline='builtin.module(iree-hal-assign-target-devices)' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-0
+// RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=device})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-1
+// RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=device_a,device_b})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-2
+// RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=device_a[0],device_a[1]})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-ORDINALS
+// RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=#hal.device.target<"local">})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-ATTR
+// RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=#hal.device.alias<"device_a">})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-ALIAS
+// RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices="device_a,#hal.device.alias<"device_b">"})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-SELECT
+// RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=device_a=#hal.device.alias<"device_a">,"device_bc=device_b,#hal.device.alias<"device_c">"})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-SELECT-MULTI
 
 // CHECK: module
-// TARGET-0: @module {
-// TARGET-1: @module attributes {
-// TARGET-1-SAME: hal.device.targets = [#device_target_local]
-// TARGET-2: @module attributes {
-// TARGET-2-SAME: hal.device.targets = [#device_target_local, #device_target_vmvx_inline]}
-// TARGET-EQ: @module attributes {
-// TARGET-EQ-SAME: hal.device.targets = [#device_target_local]}
-module @module {}
+// TARGET-0-NOT: hal.device.targets
+// TARGET-1: hal.device.targets = [#hal.device.alias<"device"> : !hal.device]
+// TARGET-2: hal.device.targets = [#hal.device.alias<"device_a"> : !hal.device, #hal.device.alias<"device_b"> : !hal.device]}
+// TARGET-ORDINALS: hal.device.targets = [#hal.device.alias<"device_a"[0]> : !hal.device, #hal.device.alias<"device_a"[1]> : !hal.device]}
+// TARGET-ATTR: hal.device.targets = [#hal.device.target<"local"> : !hal.device]
+// TARGET-ALIAS: hal.device.targets = [#hal.device.alias<"device_a"> : !hal.device]
+// TARGET-SELECT: hal.device.targets = [#hal.device.select<[#hal.device.alias<"device_a"> : !hal.device, #hal.device.alias<"device_b"> : !hal.device]> : !hal.device]
+// TARGET-SELECT-MULTI: hal.device.targets = {
+// TARGET-SELECT-MULTI-SAME: device_a = #hal.device.alias<"device_a"> : !hal.device,
+// TARGET-SELECT-MULTI-SAME: device_bc = #hal.device.select<[#hal.device.alias<"device_b"> : !hal.device, #hal.device.alias<"device_c"> : !hal.device]> : !hal.device
+// TARGET-SELECT-MULTI-SAME: }
+module @module {
+  util.global private @tensor_global : tensor<4xf32>
+}
 
 // -----
 
 // The pass is a no-op when targets are already specified.
 
-// CHECK: #device_target_foo = #hal.device.target<"foo"
-// CHECK: module @module attributes {hal.device.targets = [#device_target_foo]}
+// CHECK: module @module attributes {
+// CHECK-SAME: hal.device.targets = [#hal.device.target<"foo"> : !hal.device]
 module @module attributes {
-  hal.device.targets = [#hal.device.target<"foo">]
+  hal.device.targets = [#hal.device.target<"foo"> : !hal.device]
 } {}
 
 // -----

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/fixup_legacy_sync.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/fixup_legacy_sync.mlir
@@ -3,7 +3,7 @@
 // TODO(multi-device): remove once device globals are used. This is a fallback
 // path during the transition.
 module attributes {hal.device.targets = [
-  #hal.device.target<"vulkan", {legacy_sync}>
+  #hal.device.target<"vulkan", {legacy_sync}> : !hal.device
 ]} {
 // CHECK-LABEL: @default_device_targets
 // CHECK-SAME: (%[[DEVICE:.+]]: !hal.device)

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_dispatch_instrumentation.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_dispatch_instrumentation.mlir
@@ -4,7 +4,7 @@ module attributes {hal.device.targets = [
   #hal.device.target<"llvm-cpu", [
     #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64">,
     #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64">
-  ]>
+  ]> : !hal.device
 ]} {
 
   // Instrumentation storage buffer allocated at startup (defaults to 64MB + footer):

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_target_devices.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_target_devices.mlir
@@ -11,24 +11,36 @@ module @module attributes {
 
 // -----
 
-// Valid input with proper attributes.
+// Modules without anything that needs an environment are OK as-is.
 
-// CHECK: #device_target_llvm_cpu = #hal.device.target<"llvm-cpu">
-#device_target_llvm_cpu = #hal.device.target<"llvm-cpu">
-// CHECK: #device_target_vmvx = #hal.device.target<"vmvx">
-#device_target_vmvx = #hal.device.target<"vmvx">
+// CHECK: module @module
+module @module {
+  // CHECK-NEXT: hal.executable private @exe
+  hal.executable private @exe {
+    // CHECK-NEXT: hal.executable.variant public @embedded_elf_arm_64
+    hal.executable.variant public @embedded_elf_arm_64 target(#hal.executable.target<"backend", "format", {}>) {}
+  }
+}
+
+// -----
+
+// Valid input with proper attributes for a single device.
+
+// CHECK: #[[DEVICE_A:.+]] = #hal.device.target<"device_a"
+#device_a = #hal.device.target<"device_a", [#hal.executable.target<"backend_a", "format_a">]>
+// CHECK: #[[DEVICE_B:.+]] = #hal.device.target<"device_b"
+#device_b = #hal.device.target<"device_b", [#hal.executable.target<"backend_b", "format_b">]>
 
 // CHECK: module @module
 // CHECK-NOT: hal.device.targets
 module @module attributes {
   hal.device.targets = [
-    #device_target_llvm_cpu,
-    #device_target_vmvx
+    #hal.device.select<[#device_a, #device_b]> : !hal.device
   ]
 } {
-  //      CHECK: util.global private @__device.0 = #hal.device.select<[
-  // CHECK-SAME:   #device_target_llvm_cpu,
-  // CHECK-SAME:   #device_target_vmvx
+  //      CHECK: util.global private @__device_0 = #hal.device.select<[
+  // CHECK-SAME:   #[[DEVICE_A]],
+  // CHECK-SAME:   #[[DEVICE_B]]
   // CHECK-SAME: ]> : !hal.device
 
   // CHECK: util.global private @tensor_global
@@ -46,13 +58,80 @@ module @module attributes {
 
 // -----
 
-// Modules without anything that needs an environment are OK.
+// Multiple devices using device names.
+
+// CHECK: #[[DEVICE_A:.+]] = #hal.device.target<"device_a"
+#device_a = #hal.device.target<"device_a", [#hal.executable.target<"backend_a", "format_a">]>
+// CHECK: #[[DEVICE_B:.+]] = #hal.device.target<"device_b"
+#device_b = #hal.device.target<"device_b", [#hal.executable.target<"backend_b", "format_b">]>
+// CHECK: #[[DEVICE_C:.+]] = #hal.device.target<"device_c"
+#device_c = #hal.device.target<"device_c", [#hal.executable.target<"backend_c", "format_c">]>
 
 // CHECK: module @module
-module @module {
-  // CHECK-NEXT: hal.executable private @exe
-  hal.executable private @exe {
-    // CHECK-NEXT: hal.executable.variant public @embedded_elf_arm_64
-    hal.executable.variant public @embedded_elf_arm_64 target(#hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {}>) {}
+// CHECK-NOT: hal.device.targets
+module @module attributes {
+  hal.device.targets = {
+    device_a = #device_a,
+    device_bc = [#device_b, #device_c]
   }
+} {
+  // CHECK: util.global private @device_a = #[[DEVICE_A]]
+  // CHECK: util.global private @device_bc = #hal.device.select<[#[[DEVICE_B]], #[[DEVICE_C]]]>
+
+  // CHECK: util.global private @tensor_global
+  // CHECK-SAME: stream.affinity = #hal.device.affinity<@device_a>
+  util.global private @tensor_global : tensor<4xf32>
 }
+
+// -----
+
+// Default device selection by name.
+
+// CHECK: #[[DEVICE_A:.+]] = #hal.device.target<"device_a"
+#device_a = #hal.device.target<"device_a", [#hal.executable.target<"backend_a", "format_a">]>
+// CHECK: #[[DEVICE_B:.+]] = #hal.device.target<"device_b"
+#device_b = #hal.device.target<"device_b", [#hal.executable.target<"backend_b", "format_b">]>
+
+// CHECK: module @module
+// CHECK-NOT: hal.device.targets
+module @module attributes {
+  hal.device.targets = {
+    device_a = #device_a,
+    device_b = #device_b
+  },
+  hal.device.default = "device_b"
+} {
+  // CHECK: util.global private @device_a
+  // CHECK: util.global private @device_b
+
+  // CHECK: util.global private @tensor_global
+  // CHECK-SAME: stream.affinity = #hal.device.affinity<@device_b>
+  util.global private @tensor_global : tensor<4xf32>
+}
+
+// -----
+
+// Default device selection by ordinal.
+
+// CHECK: #[[DEVICE_A:.+]] = #hal.device.target<"device_a"
+#device_a = #hal.device.target<"device_a", [#hal.executable.target<"backend_a", "format_a">]>
+// CHECK: #[[DEVICE_B:.+]] = #hal.device.target<"device_b"
+#device_b = #hal.device.target<"device_b", [#hal.executable.target<"backend_b", "format_b">]>
+
+// CHECK: module @module
+// CHECK-NOT: hal.device.targets
+module @module attributes {
+  hal.device.targets = [
+    #device_a,
+    #device_b
+  ],
+  hal.device.default = 1 : index
+} {
+  // CHECK: util.global private @__device_0
+  // CHECK: util.global private @__device_1
+
+  // CHECK: util.global private @tensor_global
+  // CHECK-SAME: stream.affinity = #hal.device.affinity<@__device_1>
+  util.global private @tensor_global : tensor<4xf32>
+}
+

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/resolve_device_aliases.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/resolve_device_aliases.mlir
@@ -1,0 +1,41 @@
+// RUN: iree-opt --split-input-file --iree-hal-resolve-device-aliases %s --mlir-print-local-scope --verify-diagnostics | FileCheck %s
+
+// CHECK: util.global private @device
+// CHECK-SAME: #hal.device.target<"local"
+// CHECK-SAME: extra_config = 4 : index
+// CHECK-SAME: #hal.executable.target<"vmvx"
+util.global private @device = #hal.device.alias<"vmvx", {
+  extra_config = 4 : index
+}> : !hal.device
+
+// -----
+
+// CHECK: util.global private @device_ordinal
+// CHECK-SAME: #hal.device.target<"local"
+// CHECK-SAME: ordinal = 123 : index
+// CHECK-SAME: #hal.executable.target<"vmvx"
+util.global private @device_ordinal = #hal.device.alias<"vmvx"[123]> : !hal.device
+
+// -----
+
+// CHECK: util.global private @device_select
+// CHECK-SAME: #hal.device.select<[
+// CHECK-SAME:  #hal.device.target<"local", {ordinal = 0 : index}
+// CHECK-SAME:  #hal.device.target<"local", {ordinal = 1 : index}
+util.global private @device_select = #hal.device.select<[
+  #hal.device.alias<"vmvx"[0]> : !hal.device,
+  #hal.device.alias<"vmvx"[1]> : !hal.device
+]> : !hal.device
+
+// -----
+
+// expected-error@+1 {{unregistered device alias "__unregistered__"}}
+util.global private @device_unregistered = #hal.device.alias<"__unregistered__"> : !hal.device
+
+// -----
+
+// expected-error@+1 {{unregistered device alias "__unregistered__"}}
+util.global private @device_select_unregistered = #hal.device.select<[
+  #hal.device.alias<"vmvx"> : !hal.device,
+  #hal.device.alias<"__unregistered__"> : !hal.device
+]> : !hal.device

--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/Partitioning.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/Partitioning.cpp
@@ -58,9 +58,9 @@ LogicalResult Partition::verify(Location loc) {
   for (auto *op : ops) {
     if (auto affinityOp = dyn_cast<IREE::Stream::AffinityOpInterface>(op)) {
       if (!IREE::Stream::AffinityAttr::areCompatible(
-              affinity, affinityOp.getAffinity())) {
+              affinity, affinityOp.getAffinityAttr())) {
         return op->emitError("op affinity ")
-               << affinityOp.getAffinity()
+               << affinityOp.getAffinityAttr()
                << " is not compatible with the partition affinity " << affinity;
       }
     }

--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/Partitioning/ReferencePartitioning.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/Partitioning/ReferencePartitioning.cpp
@@ -54,8 +54,8 @@ partitionStreamableOpsReference(IREE::Stream::PartitioningConfigAttr config,
     DenseSet<Operation *> clonedOps;
     void insert(Operation *op) {
       if (auto affinityOp = dyn_cast<IREE::Stream::AffinityOpInterface>(op)) {
-        affinity = affinity ? affinity.joinAND(affinityOp.getAffinity())
-                            : affinityOp.getAffinity();
+        affinity = affinity ? affinity.joinAND(affinityOp.getAffinityAttr())
+                            : affinityOp.getAffinityAttr();
       }
       ops.insert(op);
     }
@@ -109,7 +109,7 @@ partitionStreamableOpsReference(IREE::Stream::PartitioningConfigAttr config,
 
     IREE::Stream::AffinityAttr affinityAttr;
     if (auto affinityOp = dyn_cast<IREE::Stream::AffinityOpInterface>(op)) {
-      affinityAttr = affinityOp.getAffinity();
+      affinityAttr = affinityOp.getAffinityAttr();
     }
 
     LLVM_DEBUG({

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
@@ -28,7 +28,7 @@ static Value buildResultSizeOf(Location loc, Value tensorValue,
                                ConversionPatternRewriter &rewriter) {
   // TODO(benvanik): see if we can stash this on the side to avoid expensive
   // materialization of a bunch of redundant IR.
-  return rewriter.createOrFold<IREE::Stream::TensorSizeOfOp>(
+  return rewriter.create<IREE::Stream::TensorSizeOfOp>(
       loc, rewriter.getIndexType(), TypeAttr::get(tensorValue.getType()),
       dynamicDims,
       IREE::Stream::AffinityAttr::lookup(tensorValue.getDefiningOp()));

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/tensor_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/tensor_ops.mlir
@@ -136,6 +136,19 @@ util.func public @tensorSplat(%value: i8, %dim0: index) -> tensor<?x128xi8> {
 
 // -----
 
+util.global private @device : !hal.device
+
+// CHECK-LABEL: @tensorTransfer
+//  CHECK-SAME: (%[[INPUT:.+]]: !stream.resource<*>, %[[INPUT_SIZE:.+]]: index, %[[DIM0:.+]]: index)
+util.func public @tensorTransfer(%input: tensor<?x128xi8>, %dim0: index) -> tensor<?x128xi8> {
+  // CHECK: %[[TRANSFER:.+]] = stream.async.transfer %[[INPUT]] : !stream.resource<*>{%[[INPUT_SIZE]]} -> to(#hal.device.affinity<@device>) !stream.resource<*>{%[[INPUT_SIZE]]}
+  %transfer = flow.tensor.transfer %input : tensor<?x128xi8>{%dim0} to #hal.device.affinity<@device>
+  // CHECK: util.return %[[TRANSFER]], %[[INPUT_SIZE]]
+  util.return %transfer : tensor<?x128xi8>
+}
+
+// -----
+
 // CHECK-LABEL: @tensorSlice
 //  CHECK-SAME: (%[[INPUT:.+]]: !stream.resource<*>, %[[INPUT_SIZE:.+]]: index)
 util.func public @tensorSlice(%input : tensor<5x24x48xf32>) -> tensor<3x24x48xf32> {

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/tensor_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/tensor_ops.mlir
@@ -179,45 +179,62 @@ util.func public @tensorUpdate(%update : tensor<1x1x10xf32>, %target : tensor<5x
 
 // -----
 
-util.global private @device : !hal.device
-
 // CHECK-LABEL: @tensorLoad
 //  CHECK-SAME: (%[[SOURCE:.+]]: !stream.resource<*>, %[[SOURCE_SIZE:.+]]: index)
 util.func public @tensorLoad(%source : tensor<2x3xi32>) -> i32 {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
-  // CHECK: %[[T0:.+]] = stream.async.transfer
-  // CHECK-SAME:           %[[SOURCE]] : !stream.resource<*>{%[[SOURCE_SIZE]]}
-  // CHECK-SAME:           from(#hal.device.affinity<@device>) -> !stream.resource<staging>{%[[SOURCE_SIZE]]}
-  // CHECK: %[[T1:.+]] = stream.tensor.load %[[T0]][%c0, %c1] : tensor<2x3xi32> in !stream.resource<staging>{%[[SOURCE_SIZE]]} -> i32
-  %0 = flow.tensor.load %source[%c0, %c1] : tensor<2x3xi32> attributes {
-    stream.affinity = #hal.device.affinity<@device>
-  }
-  // CHECK: util.return %[[T1]]
+  // CHECK: %[[SLICE_SIZE:.+]] = stream.tensor.sizeof tensor<1x1xi32>
+  // CHECK: %[[SLICE:.+]] = stream.tensor.slice %[[SOURCE]][%c0, %c1 for %c1, %c1] : tensor<2x3xi32> in !stream.resource<*>{%[[SOURCE_SIZE]]} -> tensor<1x1xi32> in !stream.resource<*>{%[[SLICE_SIZE]]}
+  // CHECK: %[[STAGING:.+]] = stream.async.transfer
+  // CHECK-SAME: %[[SLICE]] : !stream.resource<*>{%[[SLICE_SIZE]]}
+  // CHECK-SAME: !stream.resource<staging>{%[[SLICE_SIZE]]}
+  // CHECK: %[[VALUE:.+]] = stream.tensor.load %[[STAGING]][%c0, %c0] : tensor<1x1xi32> in !stream.resource<staging>{%[[SLICE_SIZE]]} -> i32
+  %0 = flow.tensor.load %source[%c0, %c1] : tensor<2x3xi32>
+  // CHECK: util.return %[[VALUE]]
   util.return %0 : i32
 }
 
 // -----
 
-util.global private @device : !hal.device
+// CHECK-LABEL: @tensorLoadScalar
+//  CHECK-SAME: (%[[SOURCE:.+]]: !stream.resource<*>, %[[SOURCE_SIZE:.+]]: index)
+util.func public @tensorLoadScalar(%source : tensor<i32>) -> i32 {
+  // CHECK: %[[STAGING:.+]] = stream.async.transfer
+  // CHECK-SAME: %[[SOURCE]] : !stream.resource<*>{%[[SOURCE_SIZE]]}
+  // CHECK-SAME: !stream.resource<staging>{%[[SOURCE_SIZE]]}
+  // CHECK: %[[VALUE:.+]] = stream.tensor.load %[[STAGING]] : tensor<i32> in !stream.resource<staging>{%[[SOURCE_SIZE]]} -> i32
+  %0 = flow.tensor.load %source : tensor<i32>
+  // CHECK: util.return %[[VALUE]]
+  util.return %0 : i32
+}
+
+// -----
 
 // CHECK-LABEL: @tensorStore
 //  CHECK-SAME: (%[[TARGET:.+]]: !stream.resource<*>, %[[TARGET_SIZE:.+]]: index)
 util.func public @tensorStore(%target : tensor<2x3xi32>) -> tensor<2x3xi32> {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
-  %c9 = arith.constant 9 : i32
-  // CHECK: %[[T0:.+]] = stream.async.transfer %[[TARGET]] : !stream.resource<*>{%[[TARGET_SIZE]]}
-  // CHECK-SAME:           from(#hal.device.affinity<@device>) -> !stream.resource<staging>{%[[TARGET_SIZE]]}
-  // CHECK: %[[T1:.+]] = stream.tensor.store %c9_i32, %[[T0]][%c0, %c1] :
-  // CHECK-SAME:           i32 -> tensor<2x3xi32> in %[[T0]] as !stream.resource<staging>{%[[TARGET_SIZE]]}
-  // CHECK: %[[T2:.+]] = stream.async.transfer %[[T1]] : !stream.resource<staging>{%[[TARGET_SIZE]]} ->
-  // CHECK-SAME:           to(#hal.device.affinity<@device>) !stream.resource<*>{%[[TARGET_SIZE]]}
-  %0 = flow.tensor.store %c9, %target[%c0, %c1] : tensor<2x3xi32> attributes {
-    stream.affinity = #hal.device.affinity<@device>
-  }
-  // CHECK: util.return %[[T2]]
+  // CHECK: %[[VALUE:.+]] = arith.constant 9
+  %value = arith.constant 9 : i32
+  // CHECK: %[[FILL:.+]] = stream.tensor.fill %[[VALUE]], %[[TARGET]][%c0, %c1 for %c1, %c1] : i32 -> tensor<2x3xi32> in %[[TARGET]] as !stream.resource<*>{%[[TARGET_SIZE]]}
+  %0 = flow.tensor.store %value, %target[%c0, %c1] : tensor<2x3xi32>
+  // CHECK: util.return %[[FILL]]
   util.return %0 : tensor<2x3xi32>
+}
+
+// -----
+
+// CHECK-LABEL: @tensorStoreScalar
+//  CHECK-SAME: (%[[TARGET:.+]]: !stream.resource<*>, %[[TARGET_SIZE:.+]]: index)
+util.func public @tensorStoreScalar(%target : tensor<i32>) -> tensor<i32> {
+  // CHECK: %[[VALUE:.+]] = arith.constant 9
+  %value = arith.constant 9 : i32
+  // CHECK: %[[SPLAT:.+]] = stream.tensor.splat %[[VALUE]] : i32 -> tensor<i32> in !stream.resource<*>{%[[TARGET_SIZE]]}
+  %0 = flow.tensor.store %value, %target : tensor<i32>
+  // CHECK: util.return %[[SPLAT]]
+  util.return %0 : tensor<i32>
 }
 
 // -----

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/Patterns.cpp
@@ -49,11 +49,7 @@ struct ConvertTensorImportOp
       }
     }
 
-    auto affinityAttr =
-        dyn_cast_if_present<IREE::Stream::AffinityAttr>(op.getAffinityAttr());
-    if (!affinityAttr) {
-      affinityAttr = IREE::Stream::AffinityAttr::lookup(op);
-    }
+    auto affinityAttr = IREE::Stream::AffinityAttr::lookup(op);
 
     // Import (buffer view to stream resource).
     auto resultType = rewriter.getType<IREE::Stream::ResourceType>(
@@ -138,11 +134,7 @@ struct ConvertTensorExportOp
       return rewriter.notifyMatchFailure(op, "unsupported HAL cast conversion");
     }
 
-    auto affinityAttr =
-        dyn_cast_if_present<IREE::Stream::AffinityAttr>(op.getAffinityAttr());
-    if (!affinityAttr) {
-      affinityAttr = IREE::Stream::AffinityAttr::lookup(op);
-    }
+    auto affinityAttr = IREE::Stream::AffinityAttr::lookup(op);
     auto source =
         consumeTensorOperand(op.getLoc(), adaptor.getSource(), rewriter);
 

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamInterfaces.td
@@ -145,9 +145,10 @@ def Stream_AffinityOp : OpInterface<"AffinityOpInterface"> {
         Returns the stream affinity for the op, indicating where it should run.
       }],
       /*retTy=*/"IREE::Stream::AffinityAttr",
-      /*methodName=*/"getAffinity",
+      /*methodName=*/"getAffinityAttr",
       /*args=*/(ins),
-      /*methodBody=*/[{
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
         return dyn_cast_or_null<IREE::Stream::AffinityAttr>($_self->getAttr("affinity"));
       }]
     >,
@@ -156,9 +157,10 @@ def Stream_AffinityOp : OpInterface<"AffinityOpInterface"> {
         Sets the stream affinity for the op, indicating where it should run.
       }],
       /*retTy=*/"void",
-      /*methodName=*/"setAffinity",
+      /*methodName=*/"setAffinityAttr",
       /*args=*/(ins "IREE::Stream::AffinityAttr":$value),
-      /*methodBody=*/[{
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
         if (value) $_self->setAttr("affinity", value);
         else $_self->removeAttr("affinity");
       }]

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
@@ -1183,7 +1183,7 @@ struct TensorConstantToEmpty : public OpRewritePattern<TensorConstantOp> {
       return failure();
 
     // Definitely empty if here.
-    auto resultSize = rewriter.createOrFold<IREE::Stream::TensorSizeOfOp>(
+    Value resultSize = rewriter.create<IREE::Stream::TensorSizeOfOp>(
         constantOp.getLoc(), rewriter.getIndexType(),
         TypeAttr::get(constantOp.getResultEncoding()),
         constantOp.getResultEncodingDims(), constantOp.getAffinityAttr());
@@ -1219,7 +1219,7 @@ struct TensorConstantToSplat : public OpRewritePattern<TensorConstantOp> {
     }
 
     auto resultType = IREE::Stream::ResourceType::get(constantOp.getContext());
-    auto resultSize = rewriter.createOrFold<IREE::Stream::TensorSizeOfOp>(
+    Value resultSize = rewriter.create<IREE::Stream::TensorSizeOfOp>(
         constantOp.getLoc(), rewriter.getIndexType(),
         TypeAttr::get(constantOp.getResultEncoding()),
         constantOp.getResultEncodingDims(), constantOp.getAffinityAttr());

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -2019,6 +2019,17 @@ LogicalResult AsyncTransferOp::verify() {
   return success();
 }
 
+IREE::Stream::AffinityAttr AsyncTransferOp::getAffinityAttr() {
+  return getResultAffinityAttr();
+}
+
+void AsyncTransferOp::setAffinityAttr(IREE::Stream::AffinityAttr value) {
+  if (value)
+    setResultAffinityAttr(value);
+  else
+    removeResultAffinityAttr();
+}
+
 void AsyncTransferOp::getAsyncAccessRanges(
     SmallVectorImpl<AsyncAccessRange> &ranges) {
   ranges.push_back({ResourceAccessBitfield::Read, getSource(), Value{},

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -86,10 +86,7 @@ def OpGroupResourceOps : OpDocGroup {
 let opDocGroup = OpGroupResourceOps in {
 
 def Stream_ResourceAllocOp : Stream_Op<"resource.alloc", [
-  DeclareOpInterfaceMethods<Stream_AffinityOp, [
-    "getAffinity",
-    "setAffinity",
-  ]>,
+  Stream_AffinityOp,
   Util_SizeAwareOp,
   AlwaysSpeculatable,
   MemoryEffects<[MemAlloc]>,
@@ -148,10 +145,7 @@ def Stream_ResourceAllocOp : Stream_Op<"resource.alloc", [
 }
 
 def Stream_ResourceAllocaOp : Stream_Op<"resource.alloca", [
-  DeclareOpInterfaceMethods<Stream_AffinityOp, [
-    "getAffinity",
-    "setAffinity",
-  ]>,
+  Stream_AffinityOp,
   Stream_TimelineOp,
   Util_SizeAwareOp,
   AlwaysSpeculatable,
@@ -209,10 +203,7 @@ def Stream_ResourceAllocaOp : Stream_Op<"resource.alloca", [
 }
 
 def Stream_ResourceDeallocaOp : Stream_Op<"resource.dealloca", [
-  DeclareOpInterfaceMethods<Stream_AffinityOp, [
-    "getAffinity",
-    "setAffinity",
-  ]>,
+  Stream_AffinityOp,
   Stream_TimelineOp,
   Util_SizeAwareOp,
   MemoryEffects<[MemFree]>,
@@ -645,10 +636,7 @@ let opDocGroup = OpGroupParameterOps in {
 def Stream_ParameterLoadOp : Stream_PureOp<"parameter.load", [
   AttrSizedOperandSegments,
   AllTypesMatch<["results"]>,
-  DeclareOpInterfaceMethods<Stream_AffinityOp, [
-    "getAffinity",
-    "setAffinity",
-  ]>,
+  Stream_AffinityOp,
   Stream_CmdPhaseOp,
   Stream_TimelineOp,
   Util_SizeAwareOp,
@@ -702,10 +690,7 @@ def Stream_ParameterLoadOp : Stream_PureOp<"parameter.load", [
 }
 
 def Stream_ParameterReadOp : Stream_Op<"parameter.read", [
-  DeclareOpInterfaceMethods<Stream_AffinityOp, [
-    "getAffinity",
-    "setAffinity",
-  ]>,
+  Stream_AffinityOp,
   Stream_CmdPhaseOp,
   Stream_TimelineOp,
   Util_SizeAwareOp,
@@ -757,10 +742,7 @@ def Stream_ParameterReadOp : Stream_Op<"parameter.read", [
 }
 
 def Stream_ParameterWriteOp : Stream_Op<"parameter.write", [
-  DeclareOpInterfaceMethods<Stream_AffinityOp, [
-    "getAffinity",
-    "setAffinity",
-  ]>,
+  Stream_AffinityOp,
   Stream_CmdPhaseOp,
   Stream_TimelineOp,
   Util_SizeAwareOp,
@@ -813,10 +795,7 @@ def Stream_ParameterWriteOp : Stream_Op<"parameter.write", [
 
 def Stream_ParameterGatherOp : Stream_Op<"parameter.gather", [
   AttrSizedOperandSegments,
-  DeclareOpInterfaceMethods<Stream_AffinityOp, [
-    "getAffinity",
-    "setAffinity",
-  ]>,
+  Stream_AffinityOp,
   Stream_CmdPhaseOp,
   Stream_TimelineOp,
   Util_SizeAwareOp,
@@ -872,10 +851,7 @@ def Stream_ParameterGatherOp : Stream_Op<"parameter.gather", [
 
 def Stream_ParameterScatterOp : Stream_Op<"parameter.scatter", [
   AttrSizedOperandSegments,
-  DeclareOpInterfaceMethods<Stream_AffinityOp, [
-    "getAffinity",
-    "setAffinity",
-  ]>,
+  Stream_AffinityOp,
   Stream_CmdPhaseOp,
   Stream_TimelineOp,
   Util_SizeAwareOp,
@@ -982,10 +958,7 @@ def Stream_FileConstantOp : Stream_PureOp<"file.constant", [
 }
 
 def Stream_FileReadOp : Stream_Op<"file.read", [
-  DeclareOpInterfaceMethods<Stream_AffinityOp, [
-    "getAffinity",
-    "setAffinity",
-  ]>,
+  Stream_AffinityOp,
   Stream_CmdPhaseOp,
   Stream_TimelineOp,
   Util_SizeAwareOp,
@@ -1040,10 +1013,7 @@ def Stream_FileReadOp : Stream_Op<"file.read", [
 }
 
 def Stream_FileWriteOp : Stream_Op<"file.write", [
-  DeclareOpInterfaceMethods<Stream_AffinityOp, [
-    "getAffinity",
-    "setAffinity",
-  ]>,
+  Stream_AffinityOp,
   Stream_CmdPhaseOp,
   Stream_TimelineOp,
   Util_SizeAwareOp,
@@ -1783,10 +1753,7 @@ def OpGroupAsyncOps : OpDocGroup {
 let opDocGroup = OpGroupAsyncOps in {
 
 def Stream_AsyncAllocaOp : Stream_Op<"async.alloca", [
-  DeclareOpInterfaceMethods<Stream_AffinityOp, [
-    "getAffinity",
-    "setAffinity",
-  ]>,
+  Stream_AffinityOp,
   Stream_AsyncPhaseOp,
   DeclareOpInterfaceMethods<Stream_StreamableOp, [
     "isMetadata",
@@ -2250,7 +2217,10 @@ def Stream_AsyncCollectiveOp : Stream_Op<"async.collective", [
 }
 
 def Stream_AsyncTransferOp : Stream_Op<"async.transfer", [
-  Stream_AffinityOp,
+  DeclareOpInterfaceMethods<Stream_AffinityOp, [
+    "getAffinityAttr",
+    "setAffinityAttr",
+  ]>,
   Stream_AsyncPhaseOp,
   Stream_StreamableOp,
   DeclareOpInterfaceMethods<Stream_AsyncAccessOp, [

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -3753,7 +3753,6 @@ def Stream_TimepointBarrierOp : Stream_PureOp<"timepoint.barrier", [
 
 def Stream_TimepointAwaitOp : Stream_PureOp<"timepoint.await", [
   AttrSizedOperandSegments,
-  Stream_AffinityOp,
   Stream_TimelineOp,
   Util_SizeAwareOp,
   DeclareOpInterfaceMethods<Util_TiedOpInterface, [
@@ -3777,8 +3776,7 @@ def Stream_TimepointAwaitOp : Stream_PureOp<"timepoint.await", [
       Stream_StagingResource,
     ]>>:$resource_operands,
     Variadic<Stream_Size>:$resource_operand_sizes,
-    Stream_Timepoint:$await_timepoint,
-    OptionalAttr<Stream_AffinityAttr>:$affinity
+    Stream_Timepoint:$await_timepoint
   );
   let results = (outs
     Variadic<AnyTypeOf<[
@@ -3788,7 +3786,6 @@ def Stream_TimepointAwaitOp : Stream_PureOp<"timepoint.await", [
   );
 
   let assemblyFormat = [{
-    (`on` `(` $affinity^ `)`)?
     $await_timepoint `=` `` `>`
     $resource_operands `:`
     custom<ShapedTypeList>(type($resource_operands),

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamTypes.cpp
@@ -274,7 +274,7 @@ ResourceConfigAttr ResourceConfigAttr::lookup(Operation *op) {
       return attr;
     // See if the affinity specified provides a resource configuration.
     if (auto affinityOp = llvm::dyn_cast<AffinityOpInterface>(op)) {
-      auto affinityAttr = affinityOp.getAffinity();
+      auto affinityAttr = affinityOp.getAffinityAttr();
       if (affinityAttr) {
         auto attr = affinityAttr.getResourceConfigAttr();
         if (attr)
@@ -339,7 +339,7 @@ AffinityAttr AffinityAttr::lookup(Operation *op) {
   auto attrId = StringAttr::get(op->getContext(), "stream.affinity");
   while (op) {
     if (auto affinityOp = llvm::dyn_cast<AffinityOpInterface>(op)) {
-      auto affinity = affinityOp.getAffinity();
+      auto affinity = affinityOp.getAffinityAttr();
       if (affinity)
         return affinity;
     }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ConvertToStream.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ConvertToStream.cpp
@@ -55,7 +55,7 @@ static Value buildTensorImportOp(Location loc, Value sourceTensor,
   // This may differ from the external encoding of the tensor as imports are
   // a transfer operation that may need to reformat the tensor.
   auto encodingAttr = TypeAttr::get(sourceTensor.getType());
-  auto resultSize = builder.createOrFold<IREE::Stream::TensorSizeOfOp>(
+  Value resultSize = builder.create<IREE::Stream::TensorSizeOfOp>(
       loc, builder.getIndexType(), encodingAttr, dynamicDims,
       /*affinity=*/nullptr);
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeCopyOnWrite.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeCopyOnWrite.cpp
@@ -103,7 +103,7 @@ static bool materializeTiedOpCOW(IREE::Util::TiedOpInterface tiedOp) {
   IREE::Stream::AffinityAttr affinity;
   if (auto affinityOp =
           dyn_cast<IREE::Stream::AffinityOpInterface>(tiedOp.getOperation())) {
-    affinity = affinityOp.getAffinity();
+    affinity = affinityOp.getAffinityAttr();
   }
 
   // Clones each operand that is tied to a result and it may be required.

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/RefineUsage.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/RefineUsage.cpp
@@ -65,7 +65,7 @@ static Lifetime convertUsageToLifetime(ResourceUsageBitfield usage) {
 // Returns either the affinity of |op| or nullptr.
 static IREE::Stream::AffinityAttr getOpAffinity(Operation *op) {
   if (auto affinityOp = dyn_cast<IREE::Stream::AffinityOpInterface>(op)) {
-    return affinityOp.getAffinity();
+    return affinityOp.getAffinityAttr();
   }
   return {};
 }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
@@ -152,8 +152,8 @@ struct ExecutePartitionBuilder {
     // want to preserve those as long as possible.
     if (auto affinityOp =
             dyn_cast<IREE::Stream::AffinityOpInterface>(clonedOp)) {
-      if (affinityOp.getAffinity() == partition->affinity) {
-        affinityOp.setAffinity(nullptr);
+      if (affinityOp.getAffinityAttr() == partition->affinity) {
+        affinityOp.setAffinityAttr(nullptr);
       }
     }
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
@@ -275,9 +275,6 @@ LogicalResult processRegion(Location loc, MLIRContext *context, Region &region,
         auto awaitOp = builder.create<IREE::Stream::TimepointAwaitOp>(
             executeOp.getLoc(), newResult, newResultSize,
             executeOp.getResultTimepoint());
-        if (executeOp.getAffinity().has_value()) {
-          awaitOp.setAffinityAttr(executeOp.getAffinityAttr());
-        }
 
         // Explicitly copy the Value since it is marked as const.
         Value toBeDeleted = oldResult;

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/schedule_execution.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/schedule_execution.mlir
@@ -75,7 +75,6 @@ util.func public @partitioningWithAffinities(%arg0: !stream.resource<external>) 
   // CHECK-NEXT: } => !stream.timepoint
 
   // CHECK-NEXT: %[[READY:.+]] = stream.timepoint.await
-  // CHECK-SAME:   on(#hal.device.affinity<@device_b>)
   // CHECK-SAME:   %[[TIMEPOINT1]] => %[[RESULT]] : !stream.resource<external>{%c20}
   // CHECK-NEXT: util.return %[[READY]]
   util.return %dispatch2 : !stream.resource<external>
@@ -133,7 +132,6 @@ util.func public @partitioningWithConcurrentAffinities(%arg0: !stream.resource<e
   // CHECK-NEXT: } => !stream.timepoint
 
   // CHECK-NEXT: %[[READY:.+]] = stream.timepoint.await
-  // CHECK-SAME:   on(#hal.device.affinity<@device_c>)
   // CHECK-SAME:   %[[TIMEPOINT2]] => %[[RESULT]] : !stream.resource<external>{%c20}
   // CHECK-NEXT: util.return %[[READY]]
   util.return %dispatch2 : !stream.resource<external>

--- a/compiler/src/iree/compiler/ExternalInterfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/ExternalInterfaces/BUILD.bazel
@@ -29,6 +29,7 @@ iree_compiler_cc_library(
     deps = [
         "//compiler/src/iree/compiler/Dialect/Encoding/IR",
         "//compiler/src/iree/compiler/Dialect/Flow/IR",
+        "//compiler/src/iree/compiler/Dialect/HAL/IR",
         "//compiler/src/iree/compiler/Dialect/LinalgExt/IR",
         "//compiler/src/iree/compiler/Dialect/Stream/IR",
         "//compiler/src/iree/compiler/Dialect/Util/IR",

--- a/compiler/src/iree/compiler/ExternalInterfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/ExternalInterfaces/CMakeLists.txt
@@ -34,6 +34,7 @@ iree_cc_library(
     MLIRValueBoundsOpInterface
     iree::compiler::Dialect::Encoding::IR
     iree::compiler::Dialect::Flow::IR
+    iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::LinalgExt::IR
     iree::compiler::Dialect::Stream::IR
     iree::compiler::Dialect::Util::IR

--- a/compiler/src/iree/compiler/ExternalInterfaces/StreamExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/StreamExternalModels.cpp
@@ -6,6 +6,10 @@
 
 #include "iree/compiler/ExternalInterfaces/StreamExternalModels.h"
 
+#include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "iree/compiler/Dialect/Stream/IR/StreamTypes.h"
 #include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
@@ -14,27 +18,47 @@ namespace mlir::iree_compiler {
 
 namespace {
 
-template <typename OpT>
-struct AffinityOpAttrExternalModel
+struct FlowTransferTargetAffinityAttrExternalModel
     : public IREE::Stream::AffinityOpInterface::ExternalModel<
-          AffinityOpAttrExternalModel<OpT>, OpT> {
+          FlowTransferTargetAffinityAttrExternalModel,
+          IREE::Flow::TensorTransferOp> {
   static void add(MLIRContext *context) {
-    OpT::template attachInterface<AffinityOpAttrExternalModel<OpT>>(*context);
+    IREE::Flow::TensorTransferOp::attachInterface<
+        FlowTransferTargetAffinityAttrExternalModel>(*context);
   }
 
-  // Most structural ops don't require affinities and after placement we don't
-  // use the affinities even if the ops still exist.
+  bool requiresAffinity(Operation *op) const { return true; }
+
+  IREE::Stream::AffinityAttr getAffinity(Operation *op) const {
+    return op->getAttrOfType<IREE::Stream::AffinityAttr>("target");
+  }
+
+  void setAffinity(Operation *op, IREE::Stream::AffinityAttr value) const {
+    op->setAttr("target", value);
+  }
+};
+
+template <typename OpT>
+struct HALTensorAffinityAttrExternalModel
+    : public IREE::Stream::AffinityOpInterface::ExternalModel<
+          HALTensorAffinityAttrExternalModel<OpT>, OpT> {
+  static void add(MLIRContext *context) {
+    OpT::template attachInterface<HALTensorAffinityAttrExternalModel<OpT>>(
+        *context);
+  }
+
   bool requiresAffinity(Operation *op) const { return false; }
 
   IREE::Stream::AffinityAttr getAffinity(Operation *op) const {
-    return op->getAttrOfType<IREE::Stream::AffinityAttr>("stream.affinity");
+    return op->getAttrOfType<IREE::Stream::AffinityAttr>("affinity");
   }
 
   void setAffinity(Operation *op, IREE::Stream::AffinityAttr value) const {
     if (value)
-      op->setAttr("stream.affinity", value);
-    else
-      op->removeAttr("stream.affinity");
+      op->setAttr("affinity", value);
+    } else {
+      op->removeAttr("affinity");
+    }
   }
 };
 
@@ -61,17 +85,58 @@ struct GlobalOpAffinityAttrExternalModel
   void setAffinity(Operation *op, IREE::Stream::AffinityAttr value) const {
     if (value)
       op->setAttr("stream.affinity", value);
-    else
+    } else {
       op->removeAttr("stream.affinity");
+    }
+  }
+};
+
+template <typename OpT>
+struct AffinityOpAttrExternalModel
+    : public IREE::Stream::AffinityOpInterface::ExternalModel<
+          AffinityOpAttrExternalModel<OpT, kRequiresAffinity>, OpT> {
+  static void add(MLIRContext *context) {
+    OpT::template attachInterface<
+        AffinityOpAttrExternalModel<OpT, kRequiresAffinity>>(*context);
+  }
+
+  // Most structural ops don't require affinities and after placement we don't
+  // use the affinities even if the ops still exist.
+  bool requiresAffinity(Operation *op) const { return false; }
+
+  IREE::Stream::AffinityAttr getAffinity(Operation *op) const {
+    return op->getAttrOfType<IREE::Stream::AffinityAttr>("stream.affinity");
+  }
+
+  void setAffinity(Operation *op, IREE::Stream::AffinityAttr value) const {
+    if (value)
+      op->setAttr("stream.affinity", value);
+    } else {
+      op->removeAttr("stream.affinity");
+    }
   }
 };
 
 } // namespace
 
 void registerStreamExternalModels(DialectRegistry &registry) {
-  // Must ensure that any dependent dialects are registered.
-  registry.insert<IREE::Util::UtilDialect>();
+  registry.insert<IREE::Flow::FlowDialect>();
+  registry.addExtension(
+      +[](MLIRContext *context, IREE::Flow::FlowDialect *dialect) {
+        FlowTransferTargetAffinityAttrExternalModel::add(context);
+      });
 
+  registry.insert<IREE::HAL::HALDialect>();
+  registry.addExtension(+[](MLIRContext *context,
+                            IREE::HAL::HALDialect *dialect) {
+    HALTensorAffinityAttrExternalModel<IREE::HAL::TensorImportOp>::add(context);
+    HALTensorAffinityAttrExternalModel<IREE::HAL::TensorExportOp>::add(context);
+    HALTensorAffinityAttrExternalModel<IREE::HAL::TensorAliasOp>::add(context);
+    HALTensorAffinityAttrExternalModel<IREE::HAL::TensorBarrierOp>::add(
+        context);
+  });
+
+  registry.insert<IREE::Util::UtilDialect>();
   registry.addExtension(
       +[](MLIRContext *context, IREE::Util::UtilDialect *dialect) {
         GlobalOpAffinityAttrExternalModel<IREE::Util::GlobalOp>::add(context);

--- a/compiler/src/iree/compiler/GlobalOptimization/test/materialize_homogeneous_encodings.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/materialize_homogeneous_encodings.mlir
@@ -5,7 +5,7 @@
 #map1 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map2 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map3 = affine_map<(d0, d1, d2) -> (d0, d1)>
-#device_target_llvm_cpu = #hal.device.target<"llvm-cpu", [#executable_target_embedded_elf_x86_64_]>
+#device_target_llvm_cpu = #hal.device.target<"llvm-cpu", [#executable_target_embedded_elf_x86_64_]> : !hal.device
 module attributes {hal.device.targets = [#device_target_llvm_cpu]} {
   util.func public @lhs_encoding(%arg0: tensor<?x?xf32>) -> tensor<?x?xf32> {
     %cst = arith.constant 0.000000e+00 : f32
@@ -36,7 +36,7 @@ module attributes {hal.device.targets = [#device_target_llvm_cpu]} {
 #map1 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map2 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map3 = affine_map<(d0, d1, d2) -> (d0, d1)>
-#device_target_vulkan = #hal.device.target<"vulkan", [#executable_target_vulkan_spirv_fb]>
+#device_target_vulkan = #hal.device.target<"vulkan", [#executable_target_vulkan_spirv_fb]> : !hal.device
 module attributes {hal.device.targets = [#device_target_vulkan]} {
   util.func public @lhs_encoding(%arg0: tensor<?x?xf32>) -> tensor<?x?xf32> {
     %cst = arith.constant 0.000000e+00 : f32
@@ -69,10 +69,10 @@ module attributes {hal.device.targets = [#device_target_vulkan]} {
 #map2 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map3 = affine_map<(d0, d1, d2) -> (d0, d1)>
 #executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {target_triple = "x86_64-none-elf", cpu_features = "+avx512f"}>
-#device_target_llvm_cpu = #hal.device.target<"llvm-cpu", [#executable_target_embedded_elf_x86_64_]>
+#device_target_llvm_cpu = #hal.device.target<"llvm-cpu", [#executable_target_embedded_elf_x86_64_]> : !hal.device
 #executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb">
-#device_target_vulkan = #hal.device.target<"vulkan", [#executable_target_vulkan_spirv_fb]>
-module attributes {hal.device.targets = [#device_target_vulkan, #device_target_llvm_cpu]} {
+#device_target_vulkan = #hal.device.target<"vulkan", [#executable_target_vulkan_spirv_fb]> : !hal.device
+module attributes {hal.device.targets = [#hal.device.select<[#device_target_vulkan, #device_target_llvm_cpu]> : !hal.device]} {
   util.func public @lhs_encoding(%arg0: tensor<?x?xf32>) -> tensor<?x?xf32> {
     %cst = arith.constant 0.000000e+00 : f32
     %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
@@ -209,13 +209,15 @@ class TensorImportPattern
       // the work.
       rewriter.replaceOpWithNewOp<IREE::HAL::TensorImportOp>(
           srcOp, resultType, adaptor.getSource(), TypeAttr::get(resultType),
-          /*name=*/nullptr);
+          /*name=*/nullptr,
+          /*affinity=*/nullptr);
     } else {
       // Dynamic dims explicitly provided (or wrong, in which case the verifier
       // will get it).
       rewriter.replaceOpWithNewOp<IREE::HAL::TensorImportOp>(
           srcOp, resultType, adaptor.getSource(), TypeAttr::get(resultType),
-          adaptor.getTargetDims(), /*wait_fence=*/Value{}, /*name=*/nullptr);
+          adaptor.getTargetDims(), /*wait_fence=*/Value{}, /*name=*/nullptr,
+          /*affinity=*/nullptr);
     }
     return success();
   }
@@ -237,14 +239,16 @@ class TensorExportPattern
       // the work.
       rewriter.replaceOpWithNewOp<IREE::HAL::TensorExportOp>(
           srcOp, resultType, adaptor.getSource(),
-          TypeAttr::get(adaptor.getSource().getType()), /*name=*/nullptr);
+          TypeAttr::get(adaptor.getSource().getType()), /*name=*/nullptr,
+          /*affinity=*/nullptr);
     } else {
       // Dynamic dims explicitly provided (or wrong, in which case the verifier
       // will get it).
       rewriter.replaceOpWithNewOp<IREE::HAL::TensorExportOp>(
           srcOp, resultType, adaptor.getSource(),
           TypeAttr::get(adaptor.getSource().getType()), adaptor.getSourceDims(),
-          /*name=*/nullptr);
+          /*name=*/nullptr,
+          /*affinity=*/nullptr);
     }
     return success();
   }

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Transforms/Passes.cpp
@@ -53,8 +53,12 @@ void buildHALInlineStaticTransformPassPipeline(
   // Device assignment and interface materialization
   //----------------------------------------------------------------------------
 
+  IREE::HAL::AssignmentOptions assignmentOptions;
+  assignmentOptions.legacyTargetBackends = targetOptions.legacyTargetBackends;
+  assignmentOptions.targetDevices = targetOptions.targetDevices;
+  assignmentOptions.defaultDevice = targetOptions.defaultDevice;
   IREE::HAL::buildHALDeviceAssignmentPassPipeline(passManager, targetRegistry,
-                                                  targetOptions);
+                                                  assignmentOptions);
   IREE::HAL::buildHALConfigurationPassPipeline(passManager, targetRegistry,
                                                targetOptions);
 

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/Transforms/Passes.cpp
@@ -53,8 +53,12 @@ void buildHALInlineDynamicTransformPassPipeline(
   // Device assignment and interface materialization
   //----------------------------------------------------------------------------
 
+  IREE::HAL::AssignmentOptions assignmentOptions;
+  assignmentOptions.legacyTargetBackends = targetOptions.legacyTargetBackends;
+  assignmentOptions.targetDevices = targetOptions.targetDevices;
+  assignmentOptions.defaultDevice = targetOptions.defaultDevice;
   IREE::HAL::buildHALDeviceAssignmentPassPipeline(passManager, targetRegistry,
-                                                  targetOptions);
+                                                  assignmentOptions);
   IREE::HAL::buildHALConfigurationPassPipeline(passManager, targetRegistry,
                                                targetOptions);
 

--- a/compiler/src/iree/compiler/Pipelines/Pipelines.h
+++ b/compiler/src/iree/compiler/Pipelines/Pipelines.h
@@ -102,7 +102,7 @@ void buildIREEPrecompileTransformPassPipeline(
     PreprocessingOptions preprocessingOptions,
     GlobalOptimizationOptions highLevelOptimizationOptions,
     SchedulingOptions schedulingOptions,
-    IREE::HAL::TargetOptions executableOptions, IREEVMPipelineHooks &hooks,
+    IREE::HAL::TargetOptions halTargetOptions, IREEVMPipelineHooks &hooks,
     OpPassManager &passManager,
     IREEVMPipelinePhase compileFrom = IREEVMPipelinePhase::Start,
     IREEVMPipelinePhase compileTo = IREEVMPipelinePhase::GlobalOptimization);
@@ -118,8 +118,8 @@ void buildIREEVMTransformPassPipeline(
     PreprocessingOptions preprocessingOptions,
     GlobalOptimizationOptions highLevelOptimizationOptions,
     SchedulingOptions schedulingOptions,
-    IREE::HAL::TargetOptions executableOptions,
-    IREE::VM::TargetOptions targetOptions, IREEVMPipelineHooks &hooks,
+    IREE::HAL::TargetOptions halTargetOptions,
+    IREE::VM::TargetOptions vmTargetOptions, IREEVMPipelineHooks &hooks,
     OpPassManager &passManager,
     IREEVMPipelinePhase compileFrom = IREEVMPipelinePhase::Start,
     IREEVMPipelinePhase compileTo = IREEVMPipelinePhase::End);

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/pad_to_intrinsics_wmma.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/pad_to_intrinsics_wmma.mlir
@@ -2,7 +2,6 @@
 // RUN: iree-opt --split-input-file %s --iree-gpu-test-target=gfx1100 --pass-pipeline="builtin.module(func.func(iree-preprocessing-pad-to-intrinsics{pad-target-type=conv},canonicalize))" | FileCheck %s -check-prefix=CONVOLUTION
 // RUN: iree-opt --split-input-file %s --iree-gpu-test-target=gfx1100 --pass-pipeline="builtin.module(func.func(iree-preprocessing-pad-to-intrinsics{pad-target-type=contraction},canonicalize))" | FileCheck %s -check-prefix=CONTRACT
 
-
 //       CHECK: func.func @matmul_static(
 //  CHECK-SAME:    %[[ARG0:.+]]: tensor<10x20xf16>,
 //  CHECK-SAME:    %[[ARG1:.+]]: tensor<20x30xf16>,

--- a/compiler/src/iree/compiler/Utils/IndexSet.h
+++ b/compiler/src/iree/compiler/Utils/IndexSet.h
@@ -40,6 +40,15 @@ public:
     }
   }
 
+  Value add(int64_t lhs, int64_t rhs) { return get(lhs + rhs); }
+  Value add(Value lhs, int64_t rhs) {
+    APInt lhsValue;
+    if (matchPattern(lhs, m_ConstantInt(&lhsValue))) {
+      return add(lhsValue.getSExtValue(), rhs);
+    }
+    return builder.create<arith::AddIOp>(loc, lhs, get(rhs));
+  }
+
 private:
   Location loc;
   OpBuilder builder;

--- a/docs/website/docs/community/blog/posts/microkernels.md
+++ b/docs/website/docs/community/blog/posts/microkernels.md
@@ -338,7 +338,7 @@ This then goes to the LLVM x86 backend, which produces x86 assembly.
 [...]
 // -----// IR Dump After Inliner (inline) //----- //
 #executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {cpu = "znver4", cpu_features = "+mmx,+popcnt,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+avx,+avx2,+sse4a,+fma,+avx512f,+bmi,+bmi2,+aes,+pclmul,+avx512vl,+avx512bw,+avx512dq,+avx512cd,+avx512vbmi,+avx512ifma,+avx512vpopcntdq,+avx512vbmi2,+gfni,+vpclmulqdq,+avx512vnni,+avx512bitalg,+avx512bf16,+adx,+clflushopt,+clwb,+clzero,+cx16,+cx8,+crc32,+f16c,+fsgsbase,+fxsr,+invpcid,+lzcnt,+movbe,+mwaitx,+pku,+prfchw,+rdpid,+rdpru,+rdrnd,+rdseed,+sahf,+sha,+shstk,+vaes,+wbnoinvd,+x87,+xsave,+xsavec,+xsaveopt,+xsaves,+evex512", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128", native_vector_size = 64 : index, target_triple = "x86_64-unknown-unknown-eabi-elf", ukernels = "all"}>
-#device_target_llvm_cpu = #hal.device.target<"llvm-cpu", {executable_targets = [#executable_target_embedded_elf_x86_64_]}>
+#device_target_llvm_cpu = #hal.device.target<"llvm-cpu", {executable_targets = [#executable_target_embedded_elf_x86_64_]}> : !hal.device
 module attributes {hal.device.targets = [#device_target_llvm_cpu]} {
   func.func @matmul_dynamic(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view, %arg2: !hal.buffer_view) -> !hal.buffer_view attributes {iree.abi.stub, iree.reflection = {iree.abi.declaration = "sync func @matmul_dynamic(%input0: tensor<?x?xf32>, %input1: tensor<?x?xf32>, %input2: tensor<?x?xf32>) -> (%output0: tensor<?x?xf32>)"}} {
     %0 = hal.buffer_view.dim<%arg0 : !hal.buffer_view>[0] : index
@@ -367,7 +367,7 @@ module attributes {hal.device.targets = [#device_target_llvm_cpu]} {
 // -----// IR Dump After CSE (cse) //----- //
 #executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {cpu = "znver4", cpu_features = "+mmx,+popcnt,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+avx,+avx2,+sse4a,+fma,+avx512f,+bmi,+bmi2,+aes,+pclmul,+avx512vl,+avx512bw,+avx512dq,+avx512cd,+avx512vbmi,+avx512ifma,+avx512vpopcntdq,+avx512vbmi2,+gfni,+vpclmulqdq,+avx512vnni,+avx512bitalg,+avx512bf16,+adx,+clflushopt,+clwb,+clzero,+cx16,+cx8,+crc32,+f16c,+fsgsbase,+fxsr,+invpcid,+lzcnt,+movbe,+mwaitx,+pku,+prfchw,+rdpid,+rdpru,+rdrnd,+rdseed,+sahf,+sha,+shstk,+vaes,+wbnoinvd,+x87,+xsave,+xsavec,+xsaveopt,+xsaves,+evex512", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128", native_vector_size = 64 : index, target_triple = "x86_64-unknown-unknown-eabi-elf", ukernels = "all"}>
 #map = affine_map<()[s0] -> (s0 ceildiv 16)>
-#device_target_llvm_cpu = #hal.device.target<"llvm-cpu", {executable_targets = [#executable_target_embedded_elf_x86_64_]}>
+#device_target_llvm_cpu = #hal.device.target<"llvm-cpu", {executable_targets = [#executable_target_embedded_elf_x86_64_]}> : !hal.device
 module attributes {hal.device.targets = [#device_target_llvm_cpu]} {
   func.func @matmul_dynamic(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view, %arg2: !hal.buffer_view) -> !hal.buffer_view attributes {iree.abi.stub, iree.reflection = {iree.abi.declaration = "sync func @matmul_dynamic(%input0: tensor<?x?xf32>, %input1: tensor<?x?xf32>, %input2: tensor<?x?xf32>) -> (%output0: tensor<?x?xf32>)"}} {
     %cst = arith.constant 0.000000e+00 : f32

--- a/runtime/src/iree/vm/bytecode/disassembler.c
+++ b/runtime/src/iree/vm/bytecode/disassembler.c
@@ -1326,6 +1326,7 @@ iree_status_t iree_vm_bytecode_disassemble_op(
       IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, " : "));
       EMIT_REF_REG_NAME(false_value_reg);
       EMIT_OPTIONAL_VALUE_REF(&regs->ref[false_value_reg]);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(b, " -> !"));
       EMIT_TYPE_NAME(type_def);
       break;
     }

--- a/samples/custom_dispatch/cpu/embedded/example_hal.mlir
+++ b/samples/custom_dispatch/cpu/embedded/example_hal.mlir
@@ -43,7 +43,7 @@
 // compiled binary (CPU + Vulkan, etc).
 #cpu_target = #hal.device.target<"llvm-cpu", [
   #x86_64_target
-]>
+]> : !hal.device
 
 module @example attributes {hal.device.targets = [#cpu_target]} {
 

--- a/samples/custom_dispatch/cpu/embedded/example_stream.mlir
+++ b/samples/custom_dispatch/cpu/embedded/example_stream.mlir
@@ -48,7 +48,7 @@
 #cpu_target = #hal.device.target<"llvm-cpu", [
   #arm_64_target,
   #x86_64_target
-]>
+]> : !hal.device
 
 module @example attributes {hal.device.targets = [#cpu_target]} {
 

--- a/samples/custom_dispatch/cpu/embedded/example_transform.mlir
+++ b/samples/custom_dispatch/cpu/embedded/example_transform.mlir
@@ -28,7 +28,7 @@
 // hence we only support llvm-cpu here.
 #cpu_target = #hal.device.target<"llvm-cpu", [
   #x86_64_target
-]>
+]> : !hal.device
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d0)>

--- a/samples/custom_dispatch/cpu/mlp_plugin/mlp.mlir
+++ b/samples/custom_dispatch/cpu/mlp_plugin/mlp.mlir
@@ -21,7 +21,7 @@
 // hence we only support llvm-cpu here.
 #cpu_target = #hal.device.target<"llvm-cpu", [
   #x86_64_target
-]>
+]> : !hal.device
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @example attributes {hal.device.targets = [#cpu_target]} {

--- a/samples/custom_dispatch/cpu/mlp_plugin/mlp_linalg.mlir
+++ b/samples/custom_dispatch/cpu/mlp_plugin/mlp_linalg.mlir
@@ -72,7 +72,7 @@
 // hence we only support llvm-cpu here.
 #cpu_target = #hal.device.target<"llvm-cpu", [
   #x86_64_target
-]>
+]> : !hal.device
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @example attributes {hal.device.targets = [#cpu_target]} {

--- a/samples/custom_dispatch/cpu/mlp_plugin/mlp_linalg_two_matmul.mlir
+++ b/samples/custom_dispatch/cpu/mlp_plugin/mlp_linalg_two_matmul.mlir
@@ -29,7 +29,7 @@
 // hence we only support llvm-cpu here.
 #cpu_target = #hal.device.target<"llvm-cpu", [
   #x86_64_target
-]>
+]> : !hal.device
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @example attributes {hal.device.targets = [#cpu_target]} {

--- a/samples/custom_dispatch/cpu/mlp_plugin/mlp_torch.mlir
+++ b/samples/custom_dispatch/cpu/mlp_plugin/mlp_torch.mlir
@@ -41,7 +41,7 @@
 // hence we only support llvm-cpu here.
 #cpu_target = #hal.device.target<"llvm-cpu", [
   #x86_64_target
-]>
+]> : !hal.device
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 module @example attributes {hal.device.targets = [#cpu_target]} {

--- a/samples/custom_dispatch/cpu/mlp_plugin/mlp_tosa.mlir
+++ b/samples/custom_dispatch/cpu/mlp_plugin/mlp_tosa.mlir
@@ -41,7 +41,7 @@
 // hence we only support llvm-cpu here.
 #cpu_target = #hal.device.target<"llvm-cpu", [
   #x86_64_target
-]>
+]> : !hal.device
 
 module @example attributes {hal.device.targets = [#cpu_target]} {
   func.func @mlp_invocation(%lhs: tensor<2x4xf32>, %rhs : tensor<4x8xf32>) -> tensor<2x8xf32> {

--- a/samples/custom_dispatch/cuda/kernels/example.mlir
+++ b/samples/custom_dispatch/cuda/kernels/example.mlir
@@ -27,7 +27,7 @@
 #cuda_target = #hal.device.target<"cuda", [
   #nvptx_sm_52_target,
   #nvptx_sm_80_target
-]>
+]> : !hal.device
 
 module @example attributes {hal.device.targets = [#cuda_target]} {
 

--- a/samples/custom_dispatch/hip/kernels/example.mlir
+++ b/samples/custom_dispatch/hip/kernels/example.mlir
@@ -23,7 +23,7 @@
 // compiled binary.
 #rocm_target = #hal.device.target<"rocm", [
   #rocm_gfx1100_target
-]>
+]> : !hal.device
 
 module @example attributes {hal.device.targets = [#rocm_target]} {
 

--- a/samples/custom_dispatch/vulkan/shaders/example.mlir
+++ b/samples/custom_dispatch/vulkan/shaders/example.mlir
@@ -29,7 +29,7 @@
 // compiled binary.
 #vulkan_target = #hal.device.target<"vulkan", [
   #spirv_target
-]>
+]> : !hal.device
 
 module @example attributes {hal.device.targets = [#vulkan_target]} {
 

--- a/samples/custom_dispatch/vulkan/shaders/example_inline.mlir
+++ b/samples/custom_dispatch/vulkan/shaders/example_inline.mlir
@@ -27,7 +27,7 @@
 // These can come from compiler flags and multiple targets can be supported
 // It's possible, for example, to support targeting multiple devices in the same
 // compiled binary.
-#vulkan_target = #hal.device.target<"vulkan", [#spirv_target]>
+#vulkan_target = #hal.device.target<"vulkan", [#spirv_target]> : !hal.device
 
 module @example attributes {hal.device.targets = [#vulkan_target]} {
 

--- a/samples/custom_dispatch/vulkan/shaders/example_transform.mlir
+++ b/samples/custom_dispatch/vulkan/shaders/example_transform.mlir
@@ -33,7 +33,7 @@
 // hence we only support vulkan here. It is possible to hand author a custom
 // kernel that supports multiple targets by specifying an object per-target, but
 // that requires authoring the kernel for multiple targets.
-#vulkan_target = #hal.device.target<"vulkan", [#spirv_target]>
+#vulkan_target = #hal.device.target<"vulkan", [#spirv_target]> : !hal.device
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d0)>

--- a/samples/multiple_modules/pipeline_async.mlir
+++ b/samples/multiple_modules/pipeline_async.mlir
@@ -1,7 +1,8 @@
 // RUN: (iree-compile --iree-execution-model=async-external --iree-hal-target-backends=vmvx %p/module_a.mlir -o=%t.module_a.vmfb && \
 // RUN:  iree-compile --iree-execution-model=async-external --iree-hal-target-backends=vmvx %p/module_b.mlir -o=%t.module_b.vmfb && \
 // RUN:  iree-compile --iree-execution-model=async-external --iree-hal-target-backends=vmvx %s | \
-// RUN:  iree-run-module --device=local-task \
+// RUN:  iree-run-module \
+// RUN:    --device=local-task \
 // RUN:    --module=%t.module_a.vmfb \
 // RUN:    --module=%t.module_b.vmfb \
 // RUN:    --module=- --function=run \

--- a/samples/multiple_modules/pipeline_sync.mlir
+++ b/samples/multiple_modules/pipeline_sync.mlir
@@ -1,7 +1,8 @@
 // RUN: (iree-compile --iree-hal-target-backends=vmvx %p/module_a.mlir -o=%t.module_a.vmfb && \
 // RUN:  iree-compile --iree-hal-target-backends=vmvx %p/module_b.mlir -o=%t.module_b.vmfb && \
 // RUN:  iree-compile --iree-hal-target-backends=vmvx %s | \
-// RUN:  iree-run-module --device=local-sync \
+// RUN:  iree-run-module \
+// RUN:    --device=local-sync \
 // RUN:    --module=%t.module_a.vmfb \
 // RUN:    --module=%t.module_b.vmfb \
 // RUN:    --module=- --function=run \

--- a/samples/transform_dialect/example_module.mlir
+++ b/samples/transform_dialect/example_module.mlir
@@ -35,7 +35,7 @@ module attributes {
       #hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb", {
         iree.gpu.target = #target
       }>
-    ]>
+    ]> : !hal.device
   ]
 } {
   hal.executable private @example_module_dispatch_0 {

--- a/tests/compiler_driver/precompile.mlir
+++ b/tests/compiler_driver/precompile.mlir
@@ -7,4 +7,6 @@ func.func @test(%arg0 : tensor<10x20xf32>, %arg1 : tensor<20x30xf32>, %arg2 : te
 }
 
 // Just check that we have the right target and executable targets.
-// CHECK: module attributes {hal.device.targets = [#hal.device.target<"local", [#hal.executable.target<"vmvx"
+//      CHECK: module
+// CHECK-SAME: stream.affinity.default = #hal.device.affinity<@[[DEVICE:.+]]>
+//      CHECK: util.global private @[[DEVICE]] = #hal.device.target<"local", [#hal.executable.target<"vmvx"

--- a/tests/compiler_driver/preprocessing_flags.mlir
+++ b/tests/compiler_driver/preprocessing_flags.mlir
@@ -13,7 +13,7 @@ func.func @test(%arg0 : tensor<10x20xf32>, %arg1 : tensor<20x30xf32>, %arg2 : te
 //       CHECK: ConvertConv2DToImg2ColPass (iree-preprocessing-convert-conv2d-to-img2col)
 //       CHECK: PadLinalgOpsPass (iree-preprocessing-pad-linalg-ops)
 // CHECK-LABEL: module
-//  CHECK-NEXT:   util.func public @test(
+//       CHECK:   util.func public @test(
 //   CHECK-DAG:     %[[ARG0:.+]] = hal.tensor.import %{{[a-zA-Z0-9]+}} "input0" : !hal.buffer_view -> tensor<10x20xf32>
 //   CHECK-DAG:     %[[ARG1:.+]] = hal.tensor.import %{{[a-zA-Z0-9]+}} "input1" : !hal.buffer_view -> tensor<20x30xf32>
 //   CHECK-DAG:     %[[ARG2:.+]] = hal.tensor.import %{{[a-zA-Z0-9]+}} "input2" : !hal.buffer_view -> tensor<10x30xf32>

--- a/tests/e2e/regression/libm_linking.mlir
+++ b/tests/e2e/regression/libm_linking.mlir
@@ -1,5 +1,5 @@
-// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetBackends=llvm-cpu},iree-transformation-pipeline)' %s | FileCheck %s
-// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetBackends=llvm-cpu},iree-transformation-pipeline)' --iree-llvmcpu-link-embedded=false %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=llvm-cpu},iree-transformation-pipeline)' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=llvm-cpu},iree-transformation-pipeline)' --iree-llvmcpu-link-embedded=false %s | FileCheck %s
 
 // When lowering to CPU code through LLVM, certain LLVM intrinsics require
 // linking against libm (the standard C library of math functions, `-lm`).


### PR DESCRIPTION
The new `flow.tensor.transfer` op is used to indicate that a tensor should be moved to a particular affinity by cloning it. This is lowered into a `stream.async.transfer` op and with analysis allows for hinting placement. More flow-level optimizations are likely to be required in larger programs but until we start to see those things are kept simple here.

Additional plumbing has been added to enable frontends to specify default/arg/result affinities on program boundaries via the new `iree.abi.affinity` attribute.

Since frontends may want to specify a device type without populating all of its information the `#hal.device.alias` attribute was added to allow for for less verbose "I don't care, pick something for me" attributes that are expanded into the full target devices and their executable configurations. Resolution happens early in the process so that any flags that may be influencing the resolved configurations are captured and no longer required by the pipeline.
```mlir
// This expands to a `#hal.device.target<"local"> with a VMVX executable target:
util.global private @device = #hal.device.alias<"vmvx", {
  extra_config = 4 : index
}> : !hal.device
```

(NOTE: this is a staging PR for review - it's not expected this will pass CI)