### PR TITLE
[hip] Use a thread to wait for events instead of hipLaunchHostFunc

### DIFF
--- a/runtime/src/iree/hal/drivers/hip/dynamic_symbol_tables.h
+++ b/runtime/src/iree/hal/drivers/hip/dynamic_symbol_tables.h
@@ -107,10 +107,10 @@ IREE_HAL_HIP_REQUIRED_PFN_DECL(hipModuleLoadData, hipModule_t *, const void *)
 IREE_HAL_HIP_REQUIRED_PFN_DECL(hipModuleLoadDataEx, hipModule_t *, const void *,
                                unsigned int, hipJitOption *, void **)
 IREE_HAL_HIP_REQUIRED_PFN_DECL(hipModuleUnload, hipModule_t)
+IREE_HAL_HIP_REQUIRED_PFN_DECL(hipSetDevice, unsigned int)
 IREE_HAL_HIP_REQUIRED_PFN_DECL(hipStreamCreateWithFlags, hipStream_t *,
                                unsigned int)
 IREE_HAL_HIP_REQUIRED_PFN_DECL(hipStreamDestroy, hipStream_t)
 IREE_HAL_HIP_REQUIRED_PFN_DECL(hipStreamSynchronize, hipStream_t)
 IREE_HAL_HIP_REQUIRED_PFN_DECL(hipStreamWaitEvent, hipStream_t, hipEvent_t,
                                unsigned int)
-IREE_HAL_HIP_REQUIRED_PFN_DECL(hipSetDevice, unsigned int)

--- a/runtime/src/iree/hal/drivers/hip/dynamic_symbol_tables.h
+++ b/runtime/src/iree/hal/drivers/hip/dynamic_symbol_tables.h
@@ -113,3 +113,4 @@ IREE_HAL_HIP_REQUIRED_PFN_DECL(hipStreamDestroy, hipStream_t)
 IREE_HAL_HIP_REQUIRED_PFN_DECL(hipStreamSynchronize, hipStream_t)
 IREE_HAL_HIP_REQUIRED_PFN_DECL(hipStreamWaitEvent, hipStream_t, hipEvent_t,
                                unsigned int)
+IREE_HAL_HIP_REQUIRED_PFN_DECL(hipSetDevice, unsigned int)

--- a/runtime/src/iree/hal/drivers/hip/hip_device.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_device.c
@@ -156,7 +156,7 @@ static iree_status_t iree_hal_hip_device_create_internal(
   device->host_allocator = host_allocator;
 
   iree_status_t status = iree_hal_hip_pending_queue_actions_create(
-      symbols, &device->block_pool, host_allocator,
+      symbols, hip_device, &device->block_pool, host_allocator,
       &device->pending_queue_actions);
 
   // Enable tracing for the (currently only) stream - no-op if disabled.
@@ -284,11 +284,6 @@ iree_status_t iree_hal_hip_device_create(
 hipCtx_t iree_hal_hip_device_context(iree_hal_device_t* base_device) {
   iree_hal_hip_device_t* device = iree_hal_hip_device_cast_unsafe(base_device);
   return device->hip_context;
-}
-
-hipDevice_t iree_hal_hip_device_get_device(iree_hal_device_t* base_device) {
-  iree_hal_hip_device_t* device = iree_hal_hip_device_cast_unsafe(base_device);
-  return device->hip_device;
 }
 
 const iree_hal_hip_dynamic_symbols_t* iree_hal_hip_device_dynamic_symbols(

--- a/runtime/src/iree/hal/drivers/hip/hip_device.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_device.c
@@ -63,8 +63,6 @@ typedef struct iree_hal_hip_device_t {
   // TODO: Support multiple device streams.
   // The hipStream_t used to issue device kernels and allocations.
   hipStream_t hip_dispatch_stream;
-  // The hipStream_t used to issue host callback functions.
-  hipStream_t hip_callback_stream;
 
   iree_hal_hip_tracing_context_t* tracing_context;
 
@@ -132,7 +130,7 @@ static iree_status_t iree_hal_hip_device_check_params(
 static iree_status_t iree_hal_hip_device_create_internal(
     iree_hal_driver_t* driver, iree_string_view_t identifier,
     const iree_hal_hip_device_params_t* params, hipDevice_t hip_device,
-    hipStream_t dispatch_stream, hipStream_t callback_stream, hipCtx_t context,
+    hipStream_t dispatch_stream, hipCtx_t context,
     const iree_hal_hip_dynamic_symbols_t* symbols,
     const iree_hal_hip_nccl_dynamic_symbols_t* nccl_symbols,
     iree_allocator_t host_allocator, iree_hal_device_t** out_device) {
@@ -155,7 +153,6 @@ static iree_status_t iree_hal_hip_device_create_internal(
   device->hip_context = context;
   device->hip_device = hip_device;
   device->hip_dispatch_stream = dispatch_stream;
-  device->hip_callback_stream = callback_stream;
   device->host_allocator = host_allocator;
 
   iree_status_t status = iree_hal_hip_pending_queue_actions_create(
@@ -234,20 +231,12 @@ iree_status_t iree_hal_hip_device_create(
         symbols,
         hipStreamCreateWithFlags(&dispatch_stream, hipStreamNonBlocking));
   }
-  // Create the default callback stream for the device.
-  hipStream_t callback_stream = NULL;
-  if (iree_status_is_ok(status)) {
-    status = IREE_HIP_RESULT_TO_STATUS(
-        symbols,
-        hipStreamCreateWithFlags(&callback_stream, hipStreamNonBlocking));
-  }
 
   if (iree_status_is_ok(status)) {
     status = iree_hal_hip_device_create_internal(
-        driver, identifier, params, device, dispatch_stream, callback_stream,
-        context, symbols, nccl_symbols, host_allocator, out_device);
+        driver, identifier, params, device, dispatch_stream, context, symbols,
+        nccl_symbols, host_allocator, out_device);
   } else {
-    if (callback_stream) symbols->hipStreamDestroy(callback_stream);
     if (dispatch_stream) symbols->hipStreamDestroy(dispatch_stream);
     // NOTE: This function return hipSuccess though doesn't release the
     // primaryCtx by design on HIP/HCC path.
@@ -297,6 +286,11 @@ hipCtx_t iree_hal_hip_device_context(iree_hal_device_t* base_device) {
   return device->hip_context;
 }
 
+hipDevice_t iree_hal_hip_device_get_device(iree_hal_device_t* base_device) {
+  iree_hal_hip_device_t* device = iree_hal_hip_device_cast_unsafe(base_device);
+  return device->hip_device;
+}
+
 const iree_hal_hip_dynamic_symbols_t* iree_hal_hip_device_dynamic_symbols(
     iree_hal_device_t* base_device) {
   iree_hal_hip_device_t* device = iree_hal_hip_device_cast_unsafe(base_device);
@@ -334,7 +328,6 @@ static void iree_hal_hip_device_destroy(iree_hal_device_t* base_device) {
   if (device->host_event_pool) iree_event_pool_free(device->host_event_pool);
 
   IREE_HIP_IGNORE_ERROR(symbols, hipStreamDestroy(device->hip_dispatch_stream));
-  IREE_HIP_IGNORE_ERROR(symbols, hipStreamDestroy(device->hip_callback_stream));
 
   // NOTE: This function return hipSuccess though doesn't release the
   // primaryCtx by design on HIP/HCC path.
@@ -780,8 +773,7 @@ static iree_status_t iree_hal_hip_device_queue_execute(
   IREE_TRACE_ZONE_BEGIN(z0);
 
   iree_status_t status = iree_hal_hip_pending_queue_actions_enqueue_execution(
-      base_device, device->hip_dispatch_stream, device->hip_callback_stream,
-      device->pending_queue_actions,
+      base_device, device->hip_dispatch_stream, device->pending_queue_actions,
       iree_hal_hip_device_collect_tracing_context, device->tracing_context,
       wait_semaphore_list, signal_semaphore_list, command_buffer_count,
       command_buffers, binding_tables);

--- a/runtime/src/iree/hal/drivers/hip/hip_device.h
+++ b/runtime/src/iree/hal/drivers/hip/hip_device.h
@@ -42,6 +42,9 @@ iree_status_t iree_hal_hip_device_create_stream_command_buffer(
 // contexts and the context may be in use on other threads.
 hipCtx_t iree_hal_hip_device_context(iree_hal_device_t* device);
 
+// Returns the hip device for the given iree_hal_device.
+hipDevice_t iree_hal_hip_device_get_device(iree_hal_device_t* device);
+
 // Returns the dynamic symbol table from the |device| if it is a HIP device
 // and otherwise returns NULL.
 //

--- a/runtime/src/iree/hal/drivers/hip/hip_device.h
+++ b/runtime/src/iree/hal/drivers/hip/hip_device.h
@@ -42,9 +42,6 @@ iree_status_t iree_hal_hip_device_create_stream_command_buffer(
 // contexts and the context may be in use on other threads.
 hipCtx_t iree_hal_hip_device_context(iree_hal_device_t* device);
 
-// Returns the hip device for the given iree_hal_device.
-hipDevice_t iree_hal_hip_device_get_device(iree_hal_device_t* device);
-
 // Returns the dynamic symbol table from the |device| if it is a HIP device
 // and otherwise returns NULL.
 //

--- a/runtime/src/iree/hal/drivers/hip/pending_queue_actions.c
+++ b/runtime/src/iree/hal/drivers/hip/pending_queue_actions.c
@@ -86,8 +86,6 @@ typedef struct iree_hal_hip_queue_action_t {
 
   // The stream to launch main GPU workload.
   hipStream_t dispatch_hip_stream;
-  // The stream to launch HIP host function callbacks.
-  hipStream_t callback_hip_stream;
 
   // Resource set to retain all associated resources by the payload.
   iree_hal_resource_set_t* resource_set;
@@ -198,6 +196,21 @@ IREE_TYPED_ATOMIC_SLIST_WRAPPER(iree_hal_hip_ready_action,
                                 offsetof(iree_hal_hip_atomic_slist_entry_t,
                                          slist_next));
 
+// Ready action atomic slist entry struct.
+typedef struct iree_hal_hip_atomic_slist_completion_t {
+  void (*callback)(void* user_data);
+  void* user_data;
+  hipEvent_t event;
+  bool created_event;
+  iree_atomic_slist_intrusive_ptr_t slist_next;
+} iree_hal_hip_atomic_slist_completion_t;
+
+// Ready action atomic slist.
+IREE_TYPED_ATOMIC_SLIST_WRAPPER(iree_hal_hip_completion,
+                                iree_hal_hip_atomic_slist_completion_t,
+                                offsetof(iree_hal_hip_atomic_slist_completion_t,
+                                         slist_next));
+
 static void iree_hal_hip_ready_action_slist_destroy(
     iree_hal_hip_ready_action_slist_t* list, iree_allocator_t host_allocator) {
   while (true) {
@@ -208,6 +221,22 @@ static void iree_hal_hip_ready_action_slist_destroy(
     iree_allocator_free(host_allocator, entry);
   }
   iree_hal_hip_ready_action_slist_deinitialize(list);
+}
+
+static void iree_hal_hip_completion_slist_destroy(
+    iree_hal_hip_completion_slist_t* list,
+    const iree_hal_hip_dynamic_symbols_t* symbols,
+    iree_allocator_t host_allocator) {
+  while (true) {
+    iree_hal_hip_atomic_slist_completion_t* entry =
+        iree_hal_hip_completion_slist_pop(list);
+    if (!entry) break;
+    if (entry->created_event) {
+      IREE_HIP_IGNORE_ERROR(symbols, hipEventDestroy(entry->event));
+    }
+    iree_allocator_free(host_allocator, entry);
+  }
+  iree_hal_hip_completion_slist_deinitialize(list);
 }
 
 static iree_hal_hip_queue_action_t* iree_hal_hip_atomic_slist_entry_pop_front(
@@ -275,6 +304,34 @@ typedef struct iree_hal_hip_working_area_t {
   iree_allocator_t host_allocator;  // const
 } iree_hal_hip_working_area_t;
 
+// This data structure is shared by the parent thread. It is responsible
+// for dispatching callbacks when work items complete.
+
+// This replaces the use of hipLaunchHostFunc, which causes the stream to block
+// and wait for the CPU work to complete. It also picks up completed
+// events with significantly less latency than hipLaunchHostFunc.
+
+typedef struct iree_hal_hip_completion_area_t {
+  // Notification from the parent thread to request completion state changes.
+  iree_notification_t state_notification;
+  // Notification to the parent thread to indicate the worker committed exiting.
+  iree_notification_t exit_notification;
+  iree_hal_hip_completion_slist_t completion_list;  // atomic
+  iree_atomic_int32_t worker_state;                 // atomic
+
+  iree_atomic_intptr_t error_code;  // atomic
+  const iree_hal_hip_dynamic_symbols_t* symbols;
+  // The number of asynchronous completions items that are scheduled and not
+  // yet waited on.
+  // We need to wait for them to finish before destroying the context.
+  iree_slim_mutex_t pending_completion_count_mutex;
+  iree_notification_t pending_completion_count_notification;
+  int32_t pending_completion_count
+      IREE_GUARDED_BY(pending_completion_count_mutex);
+
+  iree_allocator_t host_allocator;
+} iree_hal_hip_completion_area_t;
+
 static void iree_hal_hip_working_area_initialize(
     iree_allocator_t host_allocator,
     iree_hal_hip_working_area_t* working_area) {
@@ -304,9 +361,45 @@ static void iree_hal_hip_working_area_deinitialize(
       &working_area->pending_work_items_count_notification);
 }
 
+static void iree_hal_hip_completion_area_initialize(
+    iree_allocator_t host_allocator,
+    const iree_hal_hip_dynamic_symbols_t* symbols,
+    iree_hal_hip_completion_area_t* completion_area) {
+  iree_notification_initialize(&completion_area->state_notification);
+  iree_notification_initialize(&completion_area->exit_notification);
+  iree_hal_hip_completion_slist_initialize(&completion_area->completion_list);
+  iree_atomic_store_int32(&completion_area->worker_state,
+                          IREE_HAL_HIP_WORKER_STATE_IDLE_WAITING,
+                          iree_memory_order_release);
+  iree_atomic_store_int32(&completion_area->error_code, IREE_STATUS_OK,
+                          iree_memory_order_release);
+  iree_slim_mutex_initialize(&completion_area->pending_completion_count_mutex);
+  iree_notification_initialize(
+      &completion_area->pending_completion_count_notification);
+  completion_area->pending_completion_count = 0;
+  completion_area->host_allocator = host_allocator;
+  completion_area->symbols = symbols;
+}
+
+static void iree_hal_hip_completion_area_deinitialize(
+    iree_hal_hip_completion_area_t* completion_area) {
+  iree_hal_hip_completion_slist_destroy(&completion_area->completion_list,
+                                        completion_area->symbols,
+                                        completion_area->host_allocator);
+  iree_notification_deinitialize(&completion_area->exit_notification);
+  iree_notification_deinitialize(&completion_area->state_notification);
+  iree_slim_mutex_deinitialize(
+      &completion_area->pending_completion_count_mutex);
+  iree_notification_deinitialize(
+      &completion_area->pending_completion_count_notification);
+}
+
 // The main function for the ready-list processing worker thread.
 static int iree_hal_hip_worker_execute(
     iree_hal_hip_working_area_t* working_area);
+
+static int iree_hal_hip_completion_execute(
+    iree_hal_hip_completion_area_t* working_area);
 
 //===----------------------------------------------------------------------===//
 // Pending queue actions
@@ -334,8 +427,16 @@ struct iree_hal_hip_pending_queue_actions_t {
   // The worker thread that monitors incoming requests and issues ready actions
   // to the GPU.
   iree_thread_t* worker_thread;
+
+  // Worker thread to wait on completion events instead of running
+  // synchronous completion callbacks
+  iree_thread_t* completion_thread;
+
   // The worker's working area; data exchange place with the parent thread.
   iree_hal_hip_working_area_t working_area;
+
+  // Completion thread's working area.
+  iree_hal_hip_completion_area_t completion_area;
 };
 
 static const iree_hal_resource_vtable_t
@@ -366,6 +467,10 @@ iree_status_t iree_hal_hip_pending_queue_actions_create(
   iree_hal_hip_working_area_t* working_area = &actions->working_area;
   iree_hal_hip_working_area_initialize(host_allocator, working_area);
 
+  iree_hal_hip_completion_area_t* completion_area = &actions->completion_area;
+  iree_hal_hip_completion_area_initialize(host_allocator, symbols,
+                                          completion_area);
+
   // Create the ready-list processing worker itself.
   iree_thread_create_params_t params;
   memset(&params, 0, sizeof(params));
@@ -374,6 +479,14 @@ iree_status_t iree_hal_hip_pending_queue_actions_create(
   iree_status_t status = iree_thread_create(
       (iree_thread_entry_t)iree_hal_hip_worker_execute, working_area, params,
       actions->host_allocator, &actions->worker_thread);
+
+  params.name = IREE_SV("completion_worker");
+  params.create_suspended = false;
+  if (iree_status_is_ok(status)) {
+    status = iree_thread_create(
+        (iree_thread_entry_t)iree_hal_hip_completion_execute, completion_area,
+        params, actions->host_allocator, &actions->completion_thread);
+  }
 
   if (iree_status_is_ok(status)) {
     *out_actions = actions;
@@ -399,6 +512,7 @@ void iree_hal_hip_pending_queue_actions_destroy(
       iree_hal_hip_pending_queue_actions_cast(base_actions);
   iree_allocator_t host_allocator = actions->host_allocator;
   iree_hal_hip_working_area_t* working_area = &actions->working_area;
+  iree_hal_hip_completion_area_t* completion_area = &actions->completion_area;
   IREE_TRACE_ZONE_BEGIN(z0);
 
   // Request the worker to exit.
@@ -420,6 +534,25 @@ void iree_hal_hip_pending_queue_actions_destroy(
   // Now we can delete worker related resources.
   iree_thread_release(actions->worker_thread);
   iree_hal_hip_working_area_deinitialize(working_area);
+
+  // Request the completion thread to exit.
+  prev_state = (iree_hal_hip_worker_state_t)iree_atomic_exchange_int32(
+      &completion_area->worker_state, IREE_HAL_HIP_WORKER_STATE_EXIT_REQUESTED,
+      iree_memory_order_acq_rel);
+  iree_notification_post(&completion_area->state_notification,
+                         IREE_ALL_WAITERS);
+
+  // Check potential exit states from the completion thread.
+  if (prev_state != IREE_HAL_HIP_WORKER_STATE_EXIT_ERROR) {
+    // Wait until the worker acknowledged exiting.
+    iree_notification_await(
+        &completion_area->exit_notification,
+        (iree_condition_fn_t)iree_hal_hip_worker_committed_exiting,
+        completion_area, iree_infinite_timeout());
+  }
+
+  iree_thread_release(actions->completion_thread);
+  iree_hal_hip_completion_area_deinitialize(completion_area);
 
   iree_slim_mutex_deinitialize(&actions->action_mutex);
   iree_hal_hip_queue_action_list_destroy(actions->action_list.head);
@@ -469,9 +602,23 @@ static void iree_hal_hip_queue_decrement_work_items_count(
   iree_slim_mutex_unlock(&working_area->pending_work_items_count_mutex);
 }
 
+static void iree_hal_hip_queue_decrement_completion_count(
+    iree_hal_hip_completion_area_t* completion_area) {
+  iree_slim_mutex_lock(&completion_area->pending_completion_count_mutex);
+  --completion_area->pending_completion_count;
+  if (completion_area->pending_completion_count == 0) {
+    // Notify inside the lock to make sure that we are done touching anything
+    // since the context may get destroyed in the meantime.
+    iree_notification_post(
+        &completion_area->pending_completion_count_notification,
+        IREE_ALL_WAITERS);
+  }
+  iree_slim_mutex_unlock(&completion_area->pending_completion_count_mutex);
+}
+
 iree_status_t iree_hal_hip_pending_queue_actions_enqueue_execution(
     iree_hal_device_t* device, hipStream_t dispatch_stream,
-    hipStream_t callback_stream, iree_hal_hip_pending_queue_actions_t* actions,
+    iree_hal_hip_pending_queue_actions_t* actions,
     iree_hal_hip_pending_action_cleanup_callback_t cleanup_callback,
     void* callback_user_data,
     const iree_hal_semaphore_list_t wait_semaphore_list,
@@ -520,7 +667,6 @@ iree_status_t iree_hal_hip_pending_queue_actions_enqueue_execution(
   action->kind = IREE_HAL_HIP_QUEUE_ACTION_TYPE_EXECUTION;
   action->device = device;
   action->dispatch_hip_stream = dispatch_stream;
-  action->callback_hip_stream = callback_stream;
 
   // Initialize scratch fields.
   action->event_count = 0;
@@ -646,6 +792,24 @@ static void iree_hal_hip_post_error_to_worker_state(
   iree_notification_post(&working_area->state_notification, IREE_ALL_WAITERS);
 }
 
+static void iree_hal_hip_post_error_to_completion_state(
+    iree_hal_hip_completion_area_t* completion_area, iree_status_code_t code) {
+  // Write error code, but don't overwrite existing error codes.
+  intptr_t prev_error_code = IREE_STATUS_OK;
+  iree_atomic_compare_exchange_strong_int32(
+      &completion_area->error_code, /*expected=*/&prev_error_code,
+      /*desired=*/code,
+      /*order_succ=*/iree_memory_order_acq_rel,
+      /*order_fail=*/iree_memory_order_acquire);
+
+  // This state has the highest priority so just overwrite.
+  iree_atomic_store_int32(&completion_area->worker_state,
+                          IREE_HAL_HIP_WORKER_STATE_EXIT_ERROR,
+                          iree_memory_order_release);
+  iree_notification_post(&completion_area->state_notification,
+                         IREE_ALL_WAITERS);
+}
+
 // Releases resources after action completion on the GPU and advances timeline
 // and pending actions queue.
 //
@@ -704,6 +868,9 @@ static iree_status_t iree_hal_hip_pending_queue_actions_issue_execution(
   const iree_hal_hip_dynamic_symbols_t* symbols =
       action->owning_actions->symbols;
   IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_HIP_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, symbols, hipSetDevice(iree_hal_hip_device_get_device(action->device)),
+      "hipSetDevice");
 
   // No need to lock given that this action is already detched from the pending
   // actions list; so only this thread is seeing it now.
@@ -774,6 +941,7 @@ static iree_status_t iree_hal_hip_pending_queue_actions_issue_execution(
   }
   IREE_TRACE_ZONE_END(z_dispatch_command_buffers);
 
+  hipEvent_t completion_event = NULL;
   // Last record hipEvent_t signals in the dispatch stream.
   for (iree_host_size_t i = 0; i < action->signal_semaphore_list.count; ++i) {
     // Grab a hipEvent_t for this semaphore value signaling.
@@ -787,13 +955,22 @@ static iree_status_t iree_hal_hip_pending_queue_actions_issue_execution(
     IREE_HIP_RETURN_AND_END_ZONE_IF_ERROR(
         z0, symbols, hipEventRecord(event, action->dispatch_hip_stream),
         "hipEventRecord");
-    // Let the callback stream to wait on the hipEvent_t.
-    IREE_HIP_RETURN_AND_END_ZONE_IF_ERROR(
-        z0, symbols,
-        hipStreamWaitEvent(action->callback_hip_stream, event, /*flags=*/0),
-        "hipStreamWaitEvent");
+    completion_event = event;
   }
 
+  bool created_event = false;
+  if (IREE_UNLIKELY(!completion_event)) {
+    IREE_HIP_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, symbols,
+        hipEventCreateWithFlags(&completion_event, hipEventDisableTiming),
+        "hipEventCreateWithFlags");
+    created_event = true;
+  }
+
+  IREE_HIP_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, symbols,
+      hipEventRecord(completion_event, action->dispatch_hip_stream),
+      "hipEventRecord");
   iree_slim_mutex_lock(
       &action->owning_actions->working_area.pending_work_items_count_mutex);
   // One work item is the host stream callback.
@@ -802,14 +979,56 @@ static iree_status_t iree_hal_hip_pending_queue_actions_issue_execution(
   iree_slim_mutex_unlock(
       &action->owning_actions->working_area.pending_work_items_count_mutex);
 
-  // Now launch a host function on the callback stream to advance the semaphore
-  // timeline.
-  IREE_HIP_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, symbols,
-      hipLaunchHostFunc(action->callback_hip_stream,
-                        iree_hal_hip_execution_device_signal_host_callback,
-                        action),
-      "hipLaunchHostFunc");
+  iree_hal_hip_atomic_slist_completion_t* entry = NULL;
+  // TODO: avoid host allocator malloc; use some pool for the allocation.
+  iree_status_t status = iree_allocator_malloc(
+      action->owning_actions->host_allocator, sizeof(*entry), (void**)&entry);
+
+  if (IREE_UNLIKELY(!iree_status_is_ok(status))) {
+    // Release all actions in the ready list to avoid leaking.
+    IREE_TRACE_ZONE_END(z0);
+    return status;
+  }
+
+  // Now push the ready list to the worker and have it to issue the actions to
+  // the GPU.
+  entry->event = completion_event;
+  entry->created_event = created_event;
+  entry->callback = iree_hal_hip_execution_device_signal_host_callback;
+  entry->user_data = action;
+  iree_hal_hip_completion_slist_push(
+      &action->owning_actions->completion_area.completion_list, entry);
+
+  iree_slim_mutex_lock(
+      &action->owning_actions->completion_area.pending_completion_count_mutex);
+
+  action->owning_actions->completion_area.pending_completion_count += 1;
+
+  iree_slim_mutex_unlock(
+      &action->owning_actions->completion_area.pending_completion_count_mutex);
+
+  // We can only overwrite the worker state if the previous state is idle
+  // waiting; we cannot overwrite exit related states. so we need to perform
+  // atomic compare and exchange here.
+  iree_hal_hip_worker_state_t prev_state =
+      IREE_HAL_HIP_WORKER_STATE_IDLE_WAITING;
+  iree_atomic_compare_exchange_strong_int32(
+      &action->owning_actions->completion_area.worker_state,
+      /*expected=*/&prev_state,
+      /*desired=*/IREE_HAL_HIP_WORKER_STATE_WORKLOAD_PENDING,
+      /*order_succ=*/iree_memory_order_acq_rel,
+      /*order_fail=*/iree_memory_order_acquire);
+  iree_notification_post(
+      &action->owning_actions->completion_area.state_notification,
+      IREE_ALL_WAITERS);
+
+  // Handle potential error cases from the worker thread.
+  if (prev_state == IREE_HAL_HIP_WORKER_STATE_EXIT_ERROR) {
+    iree_status_code_t code = iree_atomic_load_int32(
+        &action->owning_actions->completion_area.error_code,
+        iree_memory_order_acquire);
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(z0, iree_status_from_code(code));
+  }
 
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
@@ -990,6 +1209,15 @@ static bool iree_hal_hip_worker_has_incoming_request_or_error(
          value == IREE_HAL_HIP_WORKER_STATE_EXIT_ERROR;
 }
 
+static bool iree_hal_hip_completion_has_incoming_request_or_error(
+    iree_hal_hip_completion_area_t* completion_area) {
+  iree_hal_hip_worker_state_t value = iree_atomic_load_int32(
+      &completion_area->worker_state, iree_memory_order_acquire);
+  return value == IREE_HAL_HIP_WORKER_STATE_WORKLOAD_PENDING ||
+         value == IREE_HAL_HIP_WORKER_STATE_EXIT_REQUESTED ||
+         value == IREE_HAL_HIP_WORKER_STATE_EXIT_ERROR;
+}
+
 static bool iree_hal_hip_worker_committed_exiting(
     iree_hal_hip_working_area_t* working_area) {
   return iree_atomic_load_int32(&working_area->worker_state,
@@ -1051,6 +1279,14 @@ static bool iree_hal_hip_worker_has_no_pending_work_items(
   return result;
 }
 
+static bool iree_hal_hip_completion_has_no_pending_completion_items(
+    iree_hal_hip_completion_area_t* completion_area) {
+  iree_slim_mutex_lock(&completion_area->pending_completion_count_mutex);
+  bool result = (completion_area->pending_completion_count == 0);
+  iree_slim_mutex_unlock(&completion_area->pending_completion_count_mutex);
+  return result;
+}
+
 // Wait for all work items to finish.
 static void iree_hal_hip_worker_wait_pending_work_items(
     iree_hal_hip_working_area_t* working_area) {
@@ -1062,6 +1298,122 @@ static void iree_hal_hip_worker_wait_pending_work_items(
   // Not even touching the notification.
   iree_slim_mutex_lock(&working_area->pending_work_items_count_mutex);
   iree_slim_mutex_unlock(&working_area->pending_work_items_count_mutex);
+}
+
+// Wait for all work items to finish.
+static void iree_hal_hip_completion_wait_pending_completion_items(
+    iree_hal_hip_completion_area_t* completion_area) {
+  iree_notification_await(
+      &completion_area->pending_completion_count_notification,
+      (iree_condition_fn_t)
+          iree_hal_hip_completion_has_no_pending_completion_items,
+      completion_area, iree_infinite_timeout());
+  // Lock then unlock to make sure that all callbacks are really done.
+  // Not even touching the notification.
+  iree_slim_mutex_lock(&completion_area->pending_completion_count_mutex);
+  iree_slim_mutex_unlock(&completion_area->pending_completion_count_mutex);
+}
+
+// The main function for the ready-list processing worker thread.
+static int iree_hal_hip_completion_execute(
+    iree_hal_hip_completion_area_t* completion_area) {
+  iree_hal_hip_completion_slist_t* worklist = &completion_area->completion_list;
+
+  while (true) {
+    iree_notification_await(
+        &completion_area->state_notification,
+        (iree_condition_fn_t)
+            iree_hal_hip_completion_has_incoming_request_or_error,
+        completion_area, iree_infinite_timeout());
+
+    IREE_TRACE_ZONE_BEGIN(z0);
+    // Immediately flip the state to idle waiting if and only if the previous
+    // state is workload pending. We do it before processing ready list to make
+    // sure that we don't accidentally ignore new workload pushed after done
+    // ready list processing but before overwriting the state from this worker
+    // thread. Also we don't want to overwrite other exit states. So we need to
+    // perform atomic compare and exchange here.
+    iree_hal_hip_worker_state_t prev_state =
+        IREE_HAL_HIP_WORKER_STATE_WORKLOAD_PENDING;
+    iree_atomic_compare_exchange_strong_int32(
+        &completion_area->worker_state, /*expected=*/&prev_state,
+        /*desired=*/IREE_HAL_HIP_WORKER_STATE_IDLE_WAITING,
+        /*order_succ=*/iree_memory_order_acq_rel,
+        /*order_fail=*/iree_memory_order_acquire);
+
+    int32_t worker_state = iree_atomic_load_int32(
+        &completion_area->worker_state, iree_memory_order_acquire);
+    // Exit if HIP callbacks have posted any errors.
+    if (IREE_UNLIKELY(worker_state == IREE_HAL_HIP_WORKER_STATE_EXIT_ERROR)) {
+      iree_hal_hip_completion_wait_pending_completion_items(completion_area);
+      IREE_TRACE_ZONE_END(z0);
+      return -1;
+    }
+    // Check if we received request to stop processing and exit this thread.
+    bool should_exit =
+        (worker_state == IREE_HAL_HIP_WORKER_STATE_EXIT_REQUESTED);
+
+    iree_status_t status = iree_ok_status();
+    while (true) {
+      iree_hal_hip_atomic_slist_completion_t* entry =
+          iree_hal_hip_completion_slist_pop(worklist);
+      if (!entry) break;
+
+      const iree_hal_hip_dynamic_symbols_t* symbols = completion_area->symbols;
+      IREE_TRACE_ZONE_BEGIN_NAMED(z1, "hipEventSynchronize");
+      hipError_t result = symbols->hipEventSynchronize(entry->event);
+      IREE_TRACE_ZONE_END(z1);
+      if (IREE_UNLIKELY(result != hipSuccess)) {
+        // Let common destruction path take care of destroying the worklist.
+        // When we know all host stream callbacks are done and not touching
+        // anything.
+        iree_hal_hip_completion_slist_push(worklist, entry);
+        break;
+      }
+      entry->callback(entry->user_data);
+
+      if (IREE_UNLIKELY(entry->created_event)) {
+        IREE_HIP_IGNORE_ERROR(symbols, hipEventDestroy(entry->event));
+      }
+      iree_allocator_free(completion_area->host_allocator, entry);
+
+      // Now we fully executed and cleaned up this entry. Decrease the work
+      // items counter.
+      iree_hal_hip_queue_decrement_completion_count(completion_area);
+    }
+
+    if (IREE_UNLIKELY(!iree_status_is_ok(status))) {
+      iree_hal_hip_completion_has_no_pending_completion_items(completion_area);
+      iree_hal_hip_post_error_to_completion_state(completion_area,
+                                                  iree_status_code(status));
+      IREE_TRACE_ZONE_END(z0);
+      return -1;
+    }
+
+    if (IREE_UNLIKELY(should_exit &&
+                      iree_hal_hip_completion_has_no_pending_completion_items(
+                          completion_area))) {
+      iree_hal_hip_completion_has_no_pending_completion_items(completion_area);
+      // Signal that this thread is committed to exit.
+      // This state has a priority that is only lower than error exit.
+      // A HIP callback may have posted an error, make sure we don't
+      // overwrite this error state.
+      iree_hal_hip_worker_state_t prev_state =
+          IREE_HAL_HIP_WORKER_STATE_EXIT_REQUESTED;
+      iree_atomic_compare_exchange_strong_int32(
+          &completion_area->worker_state, /*expected=*/&prev_state,
+          /*desired=*/IREE_HAL_HIP_WORKER_STATE_EXIT_COMMITTED,
+          /*order_succ=*/iree_memory_order_acq_rel,
+          /*order_fail=*/iree_memory_order_acquire);
+      iree_notification_post(&completion_area->exit_notification,
+                             IREE_ALL_WAITERS);
+      IREE_TRACE_ZONE_END(z0);
+      return 0;
+    }
+    IREE_TRACE_ZONE_END(z0);
+  }
+
+  return 0;
 }
 
 // The main function for the ready-list processing worker thread.

--- a/runtime/src/iree/hal/drivers/hip/pending_queue_actions.c
+++ b/runtime/src/iree/hal/drivers/hip/pending_queue_actions.c
@@ -974,9 +974,9 @@ static iree_status_t iree_hal_hip_pending_queue_actions_issue_execution(
   }
 
   bool created_event = false;
-  // In the case where a we issue an execution and there are signal semaphores
+  // In the case where we issue an execution and there are signal semaphores
   // we can re-use those as a wait event. However if there are no signals
-  // then we create one. In my testing this not a common case.
+  // then we create one. In my testing this is not a common case.
   if (IREE_UNLIKELY(!completion_event)) {
     IREE_HIP_RETURN_AND_END_ZONE_IF_ERROR(
         z0, symbols,
@@ -1332,7 +1332,7 @@ static void iree_hal_hip_completion_wait_pending_completion_items(
   iree_slim_mutex_unlock(&completion_area->pending_completion_count_mutex);
 }
 
-static iree_status_t iree_hal_hip_process_completion(
+static iree_status_t iree_hal_hip_worker_process_completion(
     iree_hal_hip_completion_slist_t* worklist,
     iree_hal_hip_completion_area_t* completion_area) {
   iree_status_t status = iree_ok_status();
@@ -1351,7 +1351,7 @@ static iree_status_t iree_hal_hip_process_completion(
       // anything.
       iree_hal_hip_completion_slist_push(worklist, entry);
       status =
-          iree_make_status(IREE_STATUS_ABORTED, "Could not wait on hip event.");
+          iree_make_status(IREE_STATUS_ABORTED, "could not wait on hip event");
       break;
     }
     status = entry->callback(entry->user_data);
@@ -1422,7 +1422,7 @@ static int iree_hal_hip_completion_execute(
         (worker_state == IREE_HAL_HIP_WORKER_STATE_EXIT_REQUESTED);
 
     iree_status_t status =
-        iree_hal_hip_process_completion(worklist, completion_area);
+        iree_hal_hip_worker_process_completion(worklist, completion_area);
 
     if (IREE_UNLIKELY(!iree_status_is_ok(status))) {
       iree_hal_hip_completion_wait_pending_completion_items(completion_area);

--- a/runtime/src/iree/hal/drivers/hip/pending_queue_actions.h
+++ b/runtime/src/iree/hal/drivers/hip/pending_queue_actions.h
@@ -38,7 +38,7 @@ typedef struct iree_hal_hip_pending_queue_actions_t
 
 // Creates a pending actions queue.
 iree_status_t iree_hal_hip_pending_queue_actions_create(
-    const iree_hal_hip_dynamic_symbols_t* symbols,
+    const iree_hal_hip_dynamic_symbols_t* symbols, hipDevice_t device,
     iree_arena_block_pool_t* block_pool, iree_allocator_t host_allocator,
     iree_hal_hip_pending_queue_actions_t** out_actions);
 

--- a/runtime/src/iree/hal/drivers/hip/pending_queue_actions.h
+++ b/runtime/src/iree/hal/drivers/hip/pending_queue_actions.h
@@ -59,7 +59,7 @@ typedef void(IREE_API_PTR* iree_hal_hip_pending_action_cleanup_callback_t)(
 // before releasing all retained resources.
 iree_status_t iree_hal_hip_pending_queue_actions_enqueue_execution(
     iree_hal_device_t* device, hipStream_t dispatch_stream,
-    hipStream_t callback_stream, iree_hal_hip_pending_queue_actions_t* actions,
+    iree_hal_hip_pending_queue_actions_t* actions,
     iree_hal_hip_pending_action_cleanup_callback_t cleanup_callback,
     void* callback_user_data,
     const iree_hal_semaphore_list_t wait_semaphore_list,


### PR DESCRIPTION
hipLaunchHostFunction has notably higher latency
than simply creating a thread and waiting for the events manually, and blocks the stream (although we were doing this on a secondary stream to avoid this issue).

This brings the total overhead of our hip implementation inline with our previous ROCm implementation.