### PR TITLE
Integrate llvm-project @9372a3b70cf3969dac2d1a14cf41358205944e60

### DIFF
--- a/compiler/plugins/input/StableHLO/Conversion/TypeConversion.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/TypeConversion.cpp
@@ -56,17 +56,18 @@ std::optional<Value> materializeCastToIllegal(OpBuilder &builder, Type type,
       ->getResult(0);
 }
 
-std::optional<Value> scalarToTensor(OpBuilder &builder, Type /*type*/,
+std::optional<Value> scalarToTensor(OpBuilder &builder, Type type,
                                     ValueRange inputs, Location loc) {
   assert(inputs.size() == 1);
   if (llvm::isa<ShapedType>(inputs.front().getType())) {
     return std::nullopt;
   }
-  return builder
-      .create<tensor::FromElementsOp>(
-          loc, RankedTensorType::get({}, inputs.front().getType()),
-          inputs.front())
-      .getResult();
+  auto x = builder
+               .create<tensor::FromElementsOp>(
+                   loc, RankedTensorType::get({}, inputs.front().getType()),
+                   inputs.front())
+               .getResult();
+  return builder.create<UnrealizedConversionCastOp>(loc, type, x).getResult(0);
 }
 
 } // namespace
@@ -77,7 +78,7 @@ RemoveSignTypeConverter::RemoveSignTypeConverter() {
   addConversion(convertInteger);
   addConversion(convertShapedType);
 
-  addArgumentMaterialization(materializeCastFromIllegal);
+  addArgumentMaterialization(materializeCastToIllegal);
   addSourceMaterialization(materializeCastToIllegal);
   addTargetMaterialization(materializeCastFromIllegal);
 }

--- a/compiler/plugins/input/StableHLO/Conversion/TypeConversion.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/TypeConversion.cpp
@@ -62,12 +62,14 @@ std::optional<Value> scalarToTensor(OpBuilder &builder, Type type,
   if (llvm::isa<ShapedType>(inputs.front().getType())) {
     return std::nullopt;
   }
-  auto x = builder
-               .create<tensor::FromElementsOp>(
-                   loc, RankedTensorType::get({}, inputs.front().getType()),
-                   inputs.front())
-               .getResult();
-  return builder.create<UnrealizedConversionCastOp>(loc, type, x).getResult(0);
+  auto tensor =
+      builder
+          .create<tensor::FromElementsOp>(
+              loc, RankedTensorType::get({}, inputs.front().getType()),
+              inputs.front())
+          .getResult();
+  return builder.create<UnrealizedConversionCastOp>(loc, type, tensor)
+      .getResult(0);
 }
 
 } // namespace

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
@@ -164,19 +164,22 @@ struct GenericTypeConversionPattern : public ConversionPattern {
     for (Region &r : op->getRegions()) {
       Region *newRegion = state.addRegion();
       rewriter.inlineRegionBefore(r, *newRegion, newRegion->begin());
-      TypeConverter::SignatureConversion result(newRegion->getNumArguments());
+    }
+    Operation *newOp = rewriter.create(state);
+
+    for (Region &newRegion : newOp->getRegions()) {
+      TypeConverter::SignatureConversion result(newRegion.getNumArguments());
 
       if (failed(getTypeConverter()->convertSignatureArgs(
-              newRegion->getArgumentTypes(), result))) {
+              newRegion.getArgumentTypes(), result))) {
         return rewriter.notifyMatchFailure(op,
                                            "argument type conversion failed");
       }
 
-      rewriter.applySignatureConversion(&newRegion->front(), result,
+      rewriter.applySignatureConversion(&newRegion.front(), result,
                                         typeConverter);
     }
 
-    Operation *newOp = rewriter.create(state);
     rewriter.replaceOp(op, newOp->getResults());
     return success();
   }

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
@@ -413,11 +413,11 @@ struct ConvertAllGatherOp
         consumeTensorOperand(op.getLoc(), adaptor.getSource(), rewriter);
 
     rewriter.replaceOpWithNewOp<IREE::Stream::AsyncCollectiveOp>(
-        op, collectiveAttr, adaptor.getTarget(),
+        op, collectiveAttr, newTargetCast.resource,
         /*target_size=*/newTargetCast.resourceSize,
         /*target_offset=*/zeroOffset,
         /*target_end=*/newTargetCast.resourceSize,
-        /*target_length=*/newTargetCast.resourceSize, adaptor.getSource(),
+        /*target_length=*/newTargetCast.resourceSize, newSourceCast.resource,
         /*source_size=*/newSourceCast.resourceSize,
         /*source_offset=*/zeroOffset, /*source_end=*/newSourceCast.resourceSize,
         /*source_length=*/newSourceCast.resourceSize, elementCount,
@@ -448,11 +448,11 @@ struct ConvertAllReduceOp
         consumeTensorOperand(op.getLoc(), adaptor.getSource(), rewriter);
 
     rewriter.replaceOpWithNewOp<IREE::Stream::AsyncCollectiveOp>(
-        op, collectiveAttr, adaptor.getTarget(),
+        op, collectiveAttr, newTargetCast.resource,
         /*target_size=*/newTargetCast.resourceSize,
         /*target_offset=*/zeroOffset,
         /*target_end=*/newTargetCast.resourceSize,
-        /*target_length=*/newTargetCast.resourceSize, adaptor.getSource(),
+        /*target_length=*/newTargetCast.resourceSize, newSourceCast.resource,
         /*source_size=*/newSourceCast.resourceSize,
         /*source_offset=*/zeroOffset, /*source_end=*/newSourceCast.resourceSize,
         /*source_length=*/newSourceCast.resourceSize, elementCount,
@@ -483,11 +483,11 @@ struct ConvertAllToAllOp
         consumeTensorOperand(op.getLoc(), adaptor.getSource(), rewriter);
 
     rewriter.replaceOpWithNewOp<IREE::Stream::AsyncCollectiveOp>(
-        op, collectiveAttr, adaptor.getTarget(),
+        op, collectiveAttr, newTargetCast.resource,
         /*target_size=*/newTargetCast.resourceSize,
         /*target_offset=*/zeroOffset,
         /*target_end=*/newTargetCast.resourceSize,
-        /*target_length=*/newTargetCast.resourceSize, adaptor.getSource(),
+        /*target_length=*/newTargetCast.resourceSize, newSourceCast.resource,
         /*source_size=*/newSourceCast.resourceSize,
         /*source_offset=*/zeroOffset, /*source_end=*/newSourceCast.resourceSize,
         /*source_length=*/newSourceCast.resourceSize, elementCount,
@@ -518,11 +518,11 @@ struct ConvertReduceScatterOp
         consumeTensorOperand(op.getLoc(), adaptor.getSource(), rewriter);
 
     rewriter.replaceOpWithNewOp<IREE::Stream::AsyncCollectiveOp>(
-        op, collectiveAttr, adaptor.getTarget(),
+        op, collectiveAttr, newTargetCast.resource,
         /*target_size=*/newTargetCast.resourceSize,
         /*target_offset=*/zeroOffset,
         /*target_end=*/newTargetCast.resourceSize,
-        /*target_length=*/newTargetCast.resourceSize, adaptor.getSource(),
+        /*target_length=*/newTargetCast.resourceSize, newSourceCast.resource,
         /*source_size=*/newSourceCast.resourceSize,
         /*source_offset=*/zeroOffset, /*source_end=*/newSourceCast.resourceSize,
         /*source_length=*/newSourceCast.resourceSize, elementCount,
@@ -567,11 +567,11 @@ struct ConvertCollectiveSendRecvOp
     auto param = rewriter.create<arith::OrIOp>(op.getLoc(), hi, lo);
 
     rewriter.replaceOpWithNewOp<IREE::Stream::AsyncCollectiveOp>(
-        op, collectiveAttr, adaptor.getTarget(),
+        op, collectiveAttr, newTargetCast.resource,
         /*target_size=*/newTargetCast.resourceSize,
         /*target_offset=*/zeroOffset,
         /*target_end=*/newTargetCast.resourceSize,
-        /*target_length=*/newTargetCast.resourceSize, adaptor.getSource(),
+        /*target_length=*/newTargetCast.resourceSize, newSourceCast.resource,
         /*source_size=*/newSourceCast.resourceSize,
         /*source_offset=*/zeroOffset, /*source_end=*/newSourceCast.resourceSize,
         /*source_length=*/newSourceCast.resourceSize, elementCount,

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/test/compiler_hints.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/test/compiler_hints.mlir
@@ -2,9 +2,9 @@
 
 // CHECK-LABEL: @optimizationBarrier
 util.func public @optimizationBarrier(%arg0: tensor<i32>) -> tensor<i32> {
-  // CHECK: stream.async.transfer
-  // CHECK: %[[RESOURCE:.*]] = util.optimization_barrier %0
-  // CHECK: %[[SIZE:.*]] = stream.resource.size %1 : !stream.resource<*>
+  // CHECK-SAME: %[[ARG0:.+]]: !stream.resource<*>
+  // CHECK: %[[RESOURCE:.*]] = util.optimization_barrier %[[ARG0]]
+  // CHECK: %[[SIZE:.*]] = stream.resource.size %[[RESOURCE]] : !stream.resource<*>
   // CHECK: util.return %[[RESOURCE]], %[[SIZE]] : !stream.resource<*>, index
   %0 = util.optimization_barrier %arg0 : tensor<i32>
   util.return %0 : tensor<i32>


### PR DESCRIPTION
Bumps llvm-project to https://github.com/llvm/llvm-project/commits/266a5a9cb9daa96c1eeaebc18e10f5a37d638734

Still carrying revert: https://github.com/iree-org/llvm-project/commit/9372a3b70cf3969dac2d1a14cf41358205944e60

https://github.com/llvm/llvm-project/pull/97903 Updated type conversion argument materialization, so this PR includes minor bug fixes in Codegen and Stream conversions after the change.