### PR TITLE
Disable arm64 runtime build while runner availability is low.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -539,14 +539,15 @@ jobs:
           - name: macos-14
             runs-on: macos-14
             # No container, just install what we need directly.
-          - name: arm64
-            runs-on:
-              - self-hosted # must come first
-              - runner-group=${{ needs.setup.outputs.runner-group }}
-              - environment=${{ needs.setup.outputs.runner-env }}
-              - arm64
-              - os-family=Linux
-            container: gcr.io/iree-oss/base-arm64@sha256:9daa1cdbbf12da8527319ece76a64d06219e04ecb99a4cff6e6364235ddf6c59
+          # Disabled while we are short on arm64 runners. Could also make this opt-in, but the matrix complicates that.
+          # - name: arm64
+          #   runs-on:
+          #     - self-hosted # must come first
+          #     - runner-group=${{ needs.setup.outputs.runner-group }}
+          #     - environment=${{ needs.setup.outputs.runner-env }}
+          #     - arm64
+          #     - os-family=Linux
+          #   container: gcr.io/iree-oss/base-arm64@sha256:9daa1cdbbf12da8527319ece76a64d06219e04ecb99a4cff6e6364235ddf6c59
     env:
       BUILD_DIR: build-runtime
       BUILD_PRESET: test


### PR DESCRIPTION
We currently only have a single `t2a-standard-8` runner for arm64 presubmit jobs. The jobs we have are:

job name | when does it run?
-- | --
`build_test_runtime :: arm64` | all PRs
`build_test_all_arm64` | opt-in, always enabled on LLVM integrate PRs

While the runtime job is always fast (~4 minutes), the 'all' (compiler) job takes 15 minutes with a warm cache and 1h30m with a cold cache. Having only a single runner results in presubmit jobs getting starved for up to several times our presubmit target (20-30 minutes).

For now this just disables the runtime job entirely, trusting that changes affecting it will be infrequent. I also explored options for making it opt-in, but support for conditional jobs in matrices within GitHub Actions is a complete mess. We could split this back out into a non-matrix job is we want to go down that path.