### PR TITLE
[CPU] Enable mmt4d ukernels when iree-llvmcpu-enable-ukernels is not set

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -104,7 +104,6 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
   pipelineOpts.enableVectorMasking =
       isX86(target) || isRISCV(target) ||
       (isAArch64(target) && hasAnySVEFeature(target));
-  pipelineOpts.enableUkernels = hasUkernel(target);
   pipelineOpts.enableAArch64SSVE =
       isAArch64(target) && hasAnySVEFeature(target) && hasSMEFeature(target);
   pipelineOpts.enableAArch64I8mm = isAArch64(target) && hasI8mmFeature(target);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -501,11 +501,11 @@ void addMmt4dTilingExpertPassPipeline(OpPassManager &funcPassManager,
 
   funcPassManager.addPass(createLLVMCPUTileAndFusePass(
       static_cast<int64_t>(tilingConfig.getVectorCommonParallelLevel())));
-  if (pipelineOpt.enableUkernels) {
-    funcPassManager.addPass(createCPUPrepareUkernelsPass());
-    funcPassManager.addPass(
-        createCPULowerToUKernelsPass(clSkipIntermediateRoundings));
-  }
+  // The below two passes are nop if the "mmt4d" is explicitly excluded in the
+  // ukernels attribute.
+  funcPassManager.addPass(createCPUPrepareUkernelsPass());
+  funcPassManager.addPass(
+      createCPULowerToUKernelsPass(clSkipIntermediateRoundings));
   funcPassManager.addPass(createLLVMCPUTilePass(
       static_cast<int64_t>(tilingConfig.getVectorReductionLevel())));
 
@@ -545,11 +545,11 @@ void addCPUDataTilingPipeline(OpPassManager &funcPassManager,
                               LLVMCPUPipelineOptions &pipelineOpt) {
   addTileAndDistributePasses(funcPassManager);
 
-  if (pipelineOpt.enableUkernels) {
-    funcPassManager.addPass(createCPUPrepareUkernelsPass());
-    funcPassManager.addPass(
-        createCPULowerToUKernelsPass(clSkipIntermediateRoundings));
-  }
+  // The below two passes are nop if pack/unpack is not specified in ukernels
+  // attribute. By default, they are disabled.
+  funcPassManager.addPass(createCPUPrepareUkernelsPass());
+  funcPassManager.addPass(
+      createCPULowerToUKernelsPass(clSkipIntermediateRoundings));
 
   funcPassManager.addPass(
       createLLVMCPUTilePass(tilingConfig.getVectorCommonParallelLevel()));

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.h
@@ -149,7 +149,6 @@ struct LLVMCPUPipelineOptions {
   bool enableVectorMasking = false;
   bool enableAArch64SSVE = false;
   bool enableAArch64I8mm = false;
-  bool enableUkernels = false;
   bool lowerToAVX2 = false;
 };
 

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -152,10 +152,12 @@ getDefaultEnabledUkernels(IREE::HAL::ExecutableTargetAttr targetAttr) {
 bool hasUkernel(IREE::HAL::ExecutableTargetAttr targetAttr,
                 StringRef ukernelName) {
   auto enabledUkernels = getConfigStringAttr(targetAttr, "ukernels");
-  if (!enabledUkernels) {
-    return false;
+  StringRef enabledUkernelsStr;
+  if (enabledUkernels) {
+    enabledUkernelsStr = enabledUkernels->getValue();
+  } else {
+    enabledUkernelsStr = "default";
   }
-  StringRef enabledUkernelsStr = enabledUkernels->getValue();
   // Resolve `default`.
   if (enabledUkernelsStr == "default") {
     enabledUkernelsStr = getDefaultEnabledUkernels(targetAttr);


### PR DESCRIPTION
This is a follow-up for
https://github.com/iree-org/iree/commit/3b5d269c7fec61743cc41f4394b33a31625ef2ae. The previous revision enables mmt4d ukernels only when `--iree-llvmcpu-enable-ukernels` is passed to IREE tools. If the `ukernels` attribute is not present in hal.executable.target, it is not enabled.

The revisions removes the constraint, so users don't need to pass `--iree-llvmcpu-enable-ukernels=default` to enable the mmt4d ukernels.