### PR TITLE
Enable build_test_all_windows on GitHub runners, opt-in.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,55 +101,51 @@ jobs:
             ./build_tools/cmake/ctest_all.sh \
             "${BUILD_DIR}"
 
-  # Disabled since
-  #   * windows-2022 is too slow
-  #   * windows-2022-64core is too expensive (and takes ~8 minutes just to checkout the repo)
-  #   * we don't have self-hosted Windows runners with enough cores yet
-  # build_test_all_windows:
-  #   needs: setup
-  #   if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_test_all_windows')
-  #   # TODO(saienduri): switch to self-hosted
-  #   runs-on: windows-2022
-  #   defaults:
-  #     run:
-  #       shell: bash
-  #   env:
-  #     BUILD_DIR: build-windows
-  #   steps:
-  #     - name: "Checking out repository"
-  #       uses: actions/checkout@v4.1.7
-  #       with:
-  #         submodules: true
-  #     - id: "gcp-auth"
-  #       name: "Authenticating to Google Cloud"
-  #       if: needs.setup.outputs.write-caches == 1
-  #       uses: "google-github-actions/auth@v1"
-  #       with:
-  #         token_format: "access_token"
-  #         credentials_json: "${{ secrets.IREE_OSS_GITHUB_RUNNER_BASIC_TRUST_SERVICE_ACCOUNT_KEY }}"
-  #         create_credentials_file: false
-  #     - name: "Setting up Python"
-  #       uses: actions/setup-python@v5.1.0
-  #       with:
-  #         python-version: "3.10" # Needs pybind >= 2.10.1 for Python >= 3.11
-  #     - name: "Installing Python packages"
-  #       run: |
-  #         python3 -m venv .venv
-  #         .venv/Scripts/activate.bat
-  #         python3 -m pip install -r runtime/bindings/python/iree/runtime/build_requirements.txt
-  #     - name: "Installing requirements"
-  #       run: choco install ccache --yes
-  #     - name: "Configuring MSVC"
-  #       uses: ilammy/msvc-dev-cmd@v1.13.0
-  #     # Finally: build and run tests.
-  #     - name: "Building IREE"
-  #       env:
-  #         IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
-  #         IREE_CCACHE_GCP_TOKEN: ${{ steps.gcp-auth.outputs.access_token }}
-  #         CCACHE_NAMESPACE: github-windows-2022
-  #       run: ./build_tools/cmake/build_all.sh "${BUILD_DIR}"
-  #     - name: "Testing IREE"
-  #       run: ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
+  build_test_all_windows:
+    needs: setup
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_test_all_windows')
+    # TODO(saienduri): switch to self-hosted
+    runs-on: windows-2022
+    defaults:
+      run:
+        shell: bash
+    env:
+      BUILD_DIR: build-windows
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@v4.1.7
+        with:
+          submodules: true
+      - id: "gcp-auth"
+        name: "Authenticating to Google Cloud"
+        if: needs.setup.outputs.write-caches == 1
+        uses: "google-github-actions/auth@v1"
+        with:
+          token_format: "access_token"
+          credentials_json: "${{ secrets.IREE_OSS_GITHUB_RUNNER_BASIC_TRUST_SERVICE_ACCOUNT_KEY }}"
+          create_credentials_file: false
+      - name: "Setting up Python"
+        uses: actions/setup-python@v5.1.0
+        with:
+          python-version: "3.10" # Needs pybind >= 2.10.1 for Python >= 3.11
+      - name: "Installing Python packages"
+        run: |
+          python3 -m venv .venv
+          .venv/Scripts/activate.bat
+          python3 -m pip install -r runtime/bindings/python/iree/runtime/build_requirements.txt
+      - name: "Installing requirements"
+        run: choco install ccache --yes
+      - name: "Configuring MSVC"
+        uses: ilammy/msvc-dev-cmd@v1.13.0
+      # Finally: build and run tests.
+      - name: "Building IREE"
+        env:
+          IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
+          IREE_CCACHE_GCP_TOKEN: ${{ steps.gcp-auth.outputs.access_token }}
+          CCACHE_NAMESPACE: github-windows-2022
+        run: ./build_tools/cmake/build_all.sh "${BUILD_DIR}"
+      - name: "Testing IREE"
+        run: ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
 
   # Disabled while runner is offline.
   # build_test_all_macos_arm64:
@@ -975,7 +971,7 @@ jobs:
 
       # Platforms
       - build_test_all_arm64
-      # - build_test_all_windows
+      - build_test_all_windows
       # - build_test_all_macos_arm64
       - build_test_all_macos_x86_64
 

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -125,7 +125,7 @@ CONTROL_JOBS = frozenset(["setup", "summary"])
 DEFAULT_POSTSUBMIT_ONLY_JOBS = frozenset(
     [
         "build_test_all_arm64",
-        # "build_test_all_windows",  # Currently disabled
+        "build_test_all_windows",
         # "build_test_all_macos_arm64",  # Currently disabled
         "build_test_all_macos_x86_64",
         "test_nvidia_gpu",
@@ -159,11 +159,6 @@ AMDGPU_PATHS = [
 PRESUBMIT_TOUCH_ONLY_JOBS = [
     # Currently disabled
     # ("build_test_all_macos_arm64", ["runtime/src/iree/hal/drivers/metal/*"]),
-    # Currently disabled
-    # (
-    #     "build_test_all_windows",
-    #     ["*win32*", "*windows*", "*msvc*", "runtime/src/iree/builtins/ukernel/*"],
-    # ),
     #
     # The runners with GPUs for these jobs can be unstable or in short supply,
     # so limit jobs to only code paths most likely to affect the tests.


### PR DESCRIPTION
This will be opt-in for presubmit (always enabled for LLVM integrates) and will always run on postsubmit. It uses GitHub-hosted runners, which are very slow to build the full compiler (3h+ builds). This is similar to `build_test_all_macos_x86_64` which also uses GitHub-hosted runners.

ci-exactly: build_test_all_windows