### PR TITLE
Skip samples/custom_dispatch/cuda/kernels/ on MSVC.

### DIFF
--- a/samples/custom_dispatch/cuda/kernels/CMakeLists.txt
+++ b/samples/custom_dispatch/cuda/kernels/CMakeLists.txt
@@ -8,6 +8,12 @@ if(NOT IREE_TARGET_BACKEND_CUDA OR NOT IREE_HAL_DRIVER_CUDA)
   return()
 endif()
 
+# TODO(#17933): fix cuda_ukernel_unkernel.cu.bc compilation on MSVC (use compiler-rt?)
+if(MSVC)
+  message(STATUS "IREE custom_dispatch/cuda/kernels example ignored -- #17933 required to make MSVC work")
+  return()
+endif()
+
 # NOTE: this is not how one should actually build their PTX files. Do not use
 # this as an authoritative source for compilation settings or CMake goo. If you
 # choose to go the route of custom CUDA kernels you must bring your own build


### PR DESCRIPTION
See https://github.com/iree-org/iree/issues/17933. This sample started failing to build on my Windows machine with errors like

```
[build] [6785/7145  94% :: 1152.192] Compiling ukernel.cu to cuda_ukernel_ukernel.cu.bc
[build] FAILED: samples/custom_dispatch/cuda/kernels/cuda_ukernel_ukernel.cu.bc D:/dev/projects/iree-build/samples/custom_dispatch/cuda/kernels/cuda_ukernel_ukernel.cu.bc 
[build] cmd.exe /C "cd /D D:\dev\projects\iree-build\samples\custom_dispatch\cuda\kernels && D:\dev\projects\iree-build\llvm-project\bin\clang.exe -x cuda --cuda-gpu-arch=sm_60 "--cuda-path=C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.2" -Wno-unknown-cuda-version -nocudalib --cuda-device-only -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH -O3 -c -emit-llvm D:/dev/projects/iree/samples/custom_dispatch/cuda/kernels/ukernel.cu -o cuda_ukernel_ukernel.cu.bc"
[build] In file included from <built-in>:1:
[build] In file included from D:\dev\projects\iree-build\llvm-project\lib\clang\19\include\__clang_cuda_runtime_wrapper.h:472:
[build] In file included from D:\dev\projects\iree-build\llvm-project\lib\clang\19\include\__clang_cuda_cmath.h:16:
[build] In file included from C:\Program Files (x86)\Microsoft Visual Studio\2022\Preview\VC\Tools\MSVC\14.31.31103\include\limits:13:
[build] In file included from C:\Program Files (x86)\Microsoft Visual Studio\2022\Preview\VC\Tools\MSVC\14.31.31103\include\cwchar:12:
[build] In file included from C:\Program Files (x86)\Microsoft Visual Studio\2022\Preview\VC\Tools\MSVC\14.31.31103\include\cstdio:12:
[build] In file included from C:\Program Files (x86)\Windows Kits\10\include\10.0.22621.0\ucrt\stdio.h:13:
[build] C:\Program Files (x86)\Windows Kits\10\include\10.0.22621.0\ucrt\corecrt_wstdio.h:486:24: error: non-const lvalue reference to type '__builtin_va_list' cannot bind to a value of unrelated type 'va_list' (aka 'char *')
[build]   486 |         __crt_va_start(_ArgList, _Locale);
[build]       |                        ^~~~~~~~
[build] D:\dev\projects\iree-build\llvm-project\lib\clang\19\include\vadefs.h:39:54: note: expanded from macro '__crt_va_start'
[build]    39 | #define __crt_va_start(ap, param) __builtin_va_start(ap, param)
[build]       |                                                      ^~
```

We have some ideas for how to fix it, but disabling the sample keeps local builds working.

The message text is similar to another sample, resulting in CMake configure logs like this:
```
[build] -- Configuring IREE runtime plugins
[build] -- Enabling runtime tracing using the tracy provider
[build] -- Tracing mode set at 2
[build] -- IREE custom_dispatch/cpu/plugin standalone example ignored -- #12801 required to make MSVC work
[build] -- IREE custom_dispatch/cuda/kernels example ignored -- #17933 required to make MSVC work
[build] CMake Warning at samples/custom_module/dynamic/CMakeLists.txt:12 (message):
[build]   IREE_ENABLE_RUNTIME_TRACING enabled but it currently has issues with
[build]   dynamic libraries
[build] 
[build] 
[build] -- Configuring done (48.9s)
```