### PR TITLE
[runtime][python] Add multi-device HAL module construction

### DIFF
--- a/runtime/bindings/python/hal.cc
+++ b/runtime/bindings/python/hal.cc
@@ -6,10 +6,9 @@
 
 #include "./hal.h"
 
+#include <nanobind/nanobind.h>
 #include <nanobind/stl/vector.h>
 
-#include <algorithm>
-#include <iterator>
 #include <optional>
 
 #include "./local_dlpack.h"
@@ -20,7 +19,6 @@
 #include "iree/hal/utils/allocators.h"
 #include "iree/modules/hal/module.h"
 #include "iree/tooling/device_util.h"
-#include "nanobind/nanobind.h"
 
 namespace iree {
 namespace python {
@@ -1092,11 +1090,10 @@ VmModule CreateHalModule(VmInstance* instance, std::optional<HalDevice*> device,
   } else {
     // Set device related arguments in the case of multiple devices.
     devices_vector.reserve(devices->size());
-    std::transform(devices->begin(), devices->end(),
-                   std::back_inserter(devices_vector), [](nanobind::handle h) {
-                     HalDevice* d = py::cast<HalDevice*>(h);
-                     return d->raw_ptr();
-                   });
+    for (auto devicesIt = devices->begin(); devicesIt != devices->end();
+         ++devicesIt) {
+      devices_vector.push_back(py::cast<HalDevice*>(*devicesIt)->raw_ptr());
+    }
     devices_ptr = devices_vector.data();
     device_count = devices_vector.size();
   }

--- a/runtime/bindings/python/iree/runtime/_binding.pyi
+++ b/runtime/bindings/python/iree/runtime/_binding.pyi
@@ -4,7 +4,11 @@ from typing import overload
 
 import asyncio
 
-def create_hal_module(instance: VmInstance, device: HalDevice) -> VmModule: ...
+def create_hal_module(
+    instance: VmInstance,
+    device: Optional[HalDevice] = None,
+    devices: Optional[List[HalDevice]] = None,
+) -> VmModule: ...
 def create_io_parameters_module(
     instance: VmInstance, *providers: ParameterProvider
 ) -> VmModule: ...

--- a/runtime/bindings/python/tests/vm_test.py
+++ b/runtime/bindings/python/tests/vm_test.py
@@ -219,6 +219,15 @@ class VmTest(unittest.TestCase):
         logging.info("result: %s", result)
         np.testing.assert_allclose(result, [4.0, 10.0, 18.0, 28.0])
 
+    def test_create_vm_module_with_multiple_devices(self):
+        """Sanity test that we can create a VM module with 2 devices."""
+        devices = [
+            iree.runtime.get_device("local-task"),
+            iree.runtime.get_device("local-sync"),
+        ]
+        module = iree.runtime.create_hal_module(self.instance, devices=devices)
+        assert isinstance(module, iree.runtime.VmModule)
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)


### PR DESCRIPTION
The underlying C HAL function supports creating the HAL with multiple devices. The Python API should support that as well.