### PR TITLE
Integrate llvm-project @97c0dbe1ad6dacbcca84e63e9d726b85b65af4fe

### DIFF
--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/test/flatten_tuples_in_cfg.mlir
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/test/flatten_tuples_in_cfg.mlir
@@ -15,7 +15,7 @@ module @flatten_func {
 
   // CHECK: func.func private @callee(%arg0: i1, %arg1: tensor<f32>, %arg2: tensor<f32>, %arg3: tensor<f32>) -> (tensor<f32>, tensor<f32>)
   func.func private @callee(%arg0: i1, %arg1: tuple<tensor<f32>, tuple<tensor<f32>, tensor<f32>>>) -> tuple<tensor<f32>, tensor<f32>> {
-    // CHECK-NEXT: cf.cond_br %arg0, ^[[BB:.+]](%arg2, %arg3 : tensor<f32>, tensor<f32>), ^bb2(%arg1 : tensor<f32>)
+    // CHECK-NEXT: cf.cond_br %arg0, ^[[BB:.+]](%arg2, %arg3 : tensor<f32>, tensor<f32>), ^bb2
     // CHECK:      ^[[BB]](%[[V0:[^:]+]]: tensor<f32>, %[[V1:[^:]+]]: tensor<f32>)
     // CHECK-NEXT:   return %[[V0]], %[[V1]] : tensor<f32>, tensor<f32>
     %0 = stablehlo.get_tuple_element %arg1[0] : (tuple<tensor<f32>, tuple<tensor<f32>, tensor<f32>>>) -> tensor<f32>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.cpp
@@ -9,6 +9,7 @@
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/MathExtras.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/CaptureExecutableSources.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/CaptureExecutableSources.cpp
@@ -12,6 +12,7 @@
 #include "iree/compiler/Dialect/HAL/Transforms/Passes.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/LocationSnapshot.h"
+#include "mlir/IR/AsmState.h"
 
 namespace mlir::iree_compiler::IREE::HAL {
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/CaptureExecutableSources.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/CaptureExecutableSources.cpp
@@ -10,9 +10,9 @@
 #include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "iree/compiler/Dialect/HAL/Transforms/Passes.h"
+#include "mlir/IR/AsmState.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/LocationSnapshot.h"
-#include "mlir/IR/AsmState.h"
 
 namespace mlir::iree_compiler::IREE::HAL {
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/refine_usage.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/refine_usage.mlir
@@ -82,14 +82,14 @@ util.func private @propagateBlocks(%cond: i1, %size: index) -> (!stream.resource
   // CHECK: %[[SELECT:.+]] = arith.select %[[COND]], %[[SPLAT1]], %[[FILL1]] : !stream.resource<external>
   %bb1_1_new = arith.select %cond, %splat1, %fill1 : !stream.resource<*>
   // CHECK: cf.cond_br %[[COND]], ^bb1(%[[FILL0]], %[[SELECT]]
-  // CHECK-SAME:               ^bb2(%[[FILL0]], %[[SELECT]]
+  // CHECK-SAME:               ^bb2
   cf.cond_br %cond, ^bb1(%fill0, %bb1_1_new : !stream.resource<*>, !stream.resource<*>),
                  ^bb2(%fill0, %bb1_1_new : !stream.resource<*>, !stream.resource<*>)
-// CHECK: ^bb2(%[[BB2_ARG0:.+]]: !stream.resource<transient>, %[[BB2_ARG1:.+]]: !stream.resource<external>)
+// CHECK: ^bb2
 ^bb2(%bb2_0: !stream.resource<*>, %bb2_1: !stream.resource<*>):
   // CHECK-NOT: stream.async.transfer
   %external_transfer = stream.async.transfer %bb2_1 : !stream.resource<*>{%size} -> !stream.resource<external>{%size}
-  // CHECK: util.return %[[BB2_ARG0]], %[[BB2_ARG1]] : !stream.resource<transient>, !stream.resource<external>
+  // CHECK: util.return %[[FILL0]], %[[SELECT]] : !stream.resource<transient>, !stream.resource<external>
   util.return %bb2_0, %external_transfer : !stream.resource<*>, !stream.resource<external>
 }
 

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/ImportResources.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/ImportResources.cpp
@@ -10,6 +10,7 @@
 #include "iree/compiler/Dialect/Util/Transforms/Passes.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/Support/Debug.h"
+#include "mlir/IR/AsmState.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinDialect.h"
 #include "mlir/Pass/Pass.h"

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/VectorExt/IR/VectorExtOps.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/VectorExt/IR/VectorExtOps.h
@@ -17,6 +17,7 @@
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "llvm/ADT/MapVector.h"
 
 namespace mlir::iree_compiler::IREE::VectorExt {
 


### PR DESCRIPTION
Bumps llvm-project to: https://github.com/llvm/llvm-project/commit/15495b8cd4051d05c1b88c919e7c509a8ea4056a
- Updated `refine_usage.mlir` and `flatten_tuples_in_cfg.mlir` tests likely due to https://github.com/llvm/llvm-project/pull/97697

Still carrying revert: 97c0dbe1ad6dacbcca84e63e9d726b85b65af4fe

(TODO: bump torch-mlir and update
to bumped submodule)