### PR TITLE
[Codegen][GPU] Move PackToIntrinsics after workgroup tiling

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -289,12 +289,11 @@ void addGPUVectorizationPassPipeline(OpPassManager &funcPassManager) {
 //===---------------------------------------------------------------------===//
 
 void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager) {
+  tileAndDistributeToWorkgroup(funcPassManager);
 
   // Step 1. Promote matmul operands and pack to intrinsic shapes.
   funcPassManager.addPass(createGPUPromoteMatmulOperandsPass());
   funcPassManager.addPass(IREE::GPU::createPackToIntrinsicsPass());
-
-  tileAndDistributeToWorkgroup(funcPassManager);
 
   // Step 2. Tile and fuse tileable ops to reduction loops.
   {


### PR DESCRIPTION
Doing `PackToIntrinsics` before workgroup tiling is putting lower level lowering details too early in the pipeline, especially given that padding needs to happen at the workgroup level, not before that.

There is nothing to test for here, the generated IR remains the same.