### PR TITLE
[Codegen][GPU] Add derived thread config implementation for im2col op

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/BUILD.bazel
@@ -22,6 +22,7 @@ iree_compiler_cc_library(
     ],
     deps = [
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
+        "//compiler/src/iree/compiler/Dialect/LinalgExt/IR",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:FunctionInterfaces",
         "@llvm-project//mlir:IR",

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/CMakeLists.txt
@@ -24,6 +24,7 @@ iree_cc_library(
     MLIRLinalgDialect
     MLIRSupport
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
+    iree::compiler::Dialect::LinalgExt::IR
   PUBLIC
 )
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -8,6 +8,7 @@
 #include <numeric>
 
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "llvm/Support/Casting.h"
 #include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -18,18 +19,9 @@ namespace mlir::iree_compiler::IREE::GPU {
 
 static constexpr int64_t kPreferredCopyNumBits = 128;
 
-SmallVector<int64_t> deriveThreadTileSizes(Operation *op) {
-  auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
-  if (!linalgOp || !linalgOp.hasPureTensorSemantics()) {
-    return {};
-  }
-
-  // TODO: Support multi-result
-  if (linalgOp->getNumResults() != 1) {
-    return {};
-  }
-
-  SmallVector<int64_t> loopRanges = linalgOp.getStaticLoopRanges();
+SmallVector<int64_t>
+getThreadTileSizesFromLoopRanges(SmallVector<int64_t> loopRanges,
+                                 int64_t numThreads, int64_t vectorSize) {
   // TODO: We shouldn't need this check, however loop fusion currently requires
   // loop trip counts to be identical, meaning we need to use a num_threads
   // variant of tiling. Remove this and simply return the preferred vector size
@@ -39,24 +31,12 @@ SmallVector<int64_t> deriveThreadTileSizes(Operation *op) {
     return {};
   }
 
-  std::optional<SmallVector<int64_t>> workgroupSize =
-      getWorkgroupSize(op->getParentOfType<FunctionOpInterface>());
-  if (!workgroupSize) {
-    return {};
-  }
-
-  int64_t flatNumThreads =
-      std::accumulate(workgroupSize->begin(), workgroupSize->end(), 1,
-                      std::multiplies<int64_t>());
   int64_t flatNumTrips = std::accumulate(loopRanges.begin(), loopRanges.end(),
                                          1, std::multiplies<int64_t>());
-  if (flatNumTrips % flatNumThreads != 0) {
+  if (flatNumTrips % numThreads != 0) {
     return {};
   }
-  int64_t maxVectorSize = flatNumTrips / flatNumThreads;
-  int64_t vectorSize = kPreferredCopyNumBits /
-                       getElementTypeOrSelf(linalgOp->getResultTypes()[0])
-                           .getIntOrFloatBitWidth();
+  int64_t maxVectorSize = flatNumTrips / numThreads;
 
   while (maxVectorSize % vectorSize != 0) {
     vectorSize /= 2;
@@ -64,8 +44,7 @@ SmallVector<int64_t> deriveThreadTileSizes(Operation *op) {
 
   SmallVector<int64_t> tileSizes(loopRanges.size(), 0);
   tileSizes.back() = vectorSize;
-  int64_t residualNumThreads =
-      flatNumThreads / (loopRanges.back() / vectorSize);
+  int64_t residualNumThreads = numThreads / (loopRanges.back() / vectorSize);
   for (int i = tileSizes.size() - 2, e = 0; i >= e; --i) {
     if (loopRanges[i] >= residualNumThreads) {
       tileSizes[i] = loopRanges[i] / residualNumThreads;
@@ -76,6 +55,54 @@ SmallVector<int64_t> deriveThreadTileSizes(Operation *op) {
     residualNumThreads /= loopRanges[i];
   }
   return tileSizes;
+}
+
+SmallVector<int64_t> deriveLinalgOpThreadTileSizes(linalg::LinalgOp linalgOp,
+                                                   int64_t numThreads) {
+  if (!linalgOp.hasPureTensorSemantics()) {
+    return {};
+  }
+  // TODO: Support multi-result
+  if (linalgOp->getNumResults() != 1) {
+    return {};
+  }
+  SmallVector<int64_t> loopRanges = linalgOp.getStaticLoopRanges();
+  int64_t vectorSize = kPreferredCopyNumBits /
+                       getElementTypeOrSelf(linalgOp->getResultTypes()[0])
+                           .getIntOrFloatBitWidth();
+  return getThreadTileSizesFromLoopRanges(loopRanges, numThreads, vectorSize);
+}
+
+SmallVector<int64_t>
+deriveIm2colOpThreadTileSizes(IREE::LinalgExt::Im2colOp im2colOp,
+                              int64_t numThreads) {
+  if (!im2colOp.hasPureTensorSemantics()) {
+    return {};
+  }
+  SmallVector<int64_t> loopRanges(im2colOp.getOutputType().getShape());
+  int64_t vectorSize = kPreferredCopyNumBits /
+                       getElementTypeOrSelf(im2colOp->getResultTypes()[0])
+                           .getIntOrFloatBitWidth();
+  return getThreadTileSizesFromLoopRanges(loopRanges, numThreads, vectorSize);
+}
+
+SmallVector<int64_t> deriveThreadTileSizes(Operation *op) {
+  std::optional<SmallVector<int64_t>> workgroupSize =
+      getWorkgroupSize(op->getParentOfType<FunctionOpInterface>());
+  if (!workgroupSize) {
+    return {};
+  }
+  int64_t numThreads =
+      std::accumulate(workgroupSize->begin(), workgroupSize->end(), 1,
+                      std::multiplies<int64_t>());
+  return TypeSwitch<Operation *, SmallVector<int64_t>>(op)
+      .Case([&](linalg::LinalgOp linalgOp) -> SmallVector<int64_t> {
+        return deriveLinalgOpThreadTileSizes(linalgOp, numThreads);
+      })
+      .Case([&](IREE::LinalgExt::Im2colOp im2colOp) -> SmallVector<int64_t> {
+        return deriveIm2colOpThreadTileSizes(im2colOp, numThreads);
+      })
+      .Default([](Operation *op) -> SmallVector<int64_t> { return {}; });
 }
 
 } // namespace mlir::iree_compiler::IREE::GPU

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -79,6 +79,10 @@ deriveIm2colOpThreadTileSizes(IREE::LinalgExt::Im2colOp im2colOp,
   if (!im2colOp.hasPureTensorSemantics()) {
     return {};
   }
+  // TODO(Max191): Add `getStaticLoopRanges` to TilingInterface, and use it
+  // here instead of `im2colOp.getOutputType().getShape()`. Then we can also
+  // get rid of the specialization for Im2colOp vs LinalgOp and just use
+  // TilingInterface ops.
   SmallVector<int64_t> loopRanges(im2colOp.getOutputType().getShape());
   int64_t vectorSize = kPreferredCopyNumBits /
                        getElementTypeOrSelf(im2colOp->getResultTypes()[0])


### PR DESCRIPTION
This PR adds an `iree_gpu.derived_thread_config` implementation for the `iree_linalg_ext.im2col` op. The implementation follows the implementation of the derived thread config for linalg ops.