### PR TITLE
[Im2col] Add pass to convert conv_2d ops into GEMM with im2col op

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/BUILD.bazel
@@ -31,6 +31,7 @@ iree_compiler_cc_library(
     name = "Transforms",
     srcs = [
         "AggregatedOpInterfaceImpl.cpp",
+        "ConvertConv2DToIm2ColOp.cpp",
         "ConvertConv2DToWinograd.cpp",
         "ConvertToLoops.cpp",
         "DecomposeAttention.cpp",

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/CMakeLists.txt
@@ -27,6 +27,7 @@ iree_cc_library(
     "Passes.h.inc"
   SRCS
     "AggregatedOpInterfaceImpl.cpp"
+    "ConvertConv2DToIm2ColOp.cpp"
     "ConvertConv2DToWinograd.cpp"
     "ConvertToLoops.cpp"
     "DecomposeAttention.cpp"

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConv2DToIm2ColOp.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConv2DToIm2ColOp.cpp
@@ -1,0 +1,340 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "iree/compiler/Dialect/LinalgExt/Transforms/PassDetail.h"
+#include "iree/compiler/Dialect/LinalgExt/Transforms/Passes.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Tensor/Transforms/Transforms.h"
+#include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/Dialect/Utils/StructuredOpsUtils.h"
+#include "mlir/IR/AffineExpr.h"
+#include "mlir/IR/AffineMap.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::iree_compiler::IREE::LinalgExt {
+
+static bool hasAllOneValues(DenseIntElementsAttr attr) {
+  return llvm::all_of(
+      attr, [](APInt element) { return element.getSExtValue() == 1; });
+}
+
+static Value createAdd(Location loc, Value x, Value y, bool isInt,
+                       OpBuilder &builder) {
+  if (isInt)
+    return builder.create<arith::AddIOp>(loc, x, y);
+  return builder.create<arith::AddFOp>(loc, x, y);
+}
+
+static Value createMul(Location loc, Value x, Value y, bool isInt,
+                       OpBuilder &builder) {
+  if (isInt)
+    return builder.create<arith::MulIOp>(loc, x, y);
+  return builder.create<arith::MulFOp>(loc, x, y);
+}
+
+namespace {
+
+// Convert linalg.conv_2d_nhwc_hwcf into linalg.generic (for img2col packing)
+// and linalg.matmul.
+//
+// A convolution operaton can be written as a matrix-matrix multiplication by
+// unfolding the cross correlation between input and filter and explicitly copy
+// overlapped sliding window inputs.
+//
+// Consider 2D input X with single channel input and output and 2x2 filter W:
+// [x(0, 0)  , x(0, 1)  , ...,   x(0, n)  ]
+// [x(1, 0)  , x(1, 1)  , ...,   x(1, n)  ]
+// [.        ,  .       ,.   ,      .     ]            [w(0, 0), w(0, 1)]
+// [.        ,  .       , .  ,      .     ]    (conv)  [w(1, 0), w(1, 1)]
+// [.        ,  .       ,   .,      .     ]
+// [x(n-1, 0), x(n-1, 1), ..., x(n-1, n-1)]
+//
+// The packed input data (img2col) is a matrix with |rows| = output spatial
+// size, |columns| = filter spatial size. To compute the output Y(i, j) we need
+// to calculate the dot product between filter window at input X(x, y)) and the
+// filter which will look like the following where r.h.s is the img2col matrix
+// and l.h.s is the flattned filter:
+//
+// clang-format off
+// [x(0, 0), x(0, 1), x(1, 0), x(1, 1)]
+// [x(0, 1), x(1, 1), x(0, 2), x(1, 2)] (matmul) [w(0, 0), w(0, 1), w(1, 0), w(1, 1)]
+// [x(0, 1), x(1, 1), x(0, 2), x(1, 2)]
+// [   .   ,    .   ,    .   ,    .   ]
+// clang-format on
+//
+// In general for 2D case with (N, H, W, C) input and (Kh, Kw, C, D) filter
+// and output (N, Ho, Wo, D) the convolutin is the following matrix-matrix
+// multiplication (Ho x Wo, Kh x Kw x C) * (Kh x Kw x C, D) for each input in
+// the N input. For the case where N > 1 its a batched matrxi-matrix
+// multplication.
+class ConvertConv2DNhwcHwcf final
+    : public OpRewritePattern<linalg::Conv2DNhwcHwcfOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::Conv2DNhwcHwcfOp convOp,
+                                PatternRewriter &rewriter) const override {
+    auto inputType = llvm::cast<ShapedType>(convOp.getInputs()[0].getType());
+    auto filterType = llvm::cast<ShapedType>(convOp.getInputs()[1].getType());
+    auto outputType = llvm::cast<ShapedType>(convOp.getOutputs()[0].getType());
+
+    if (!filterType.hasStaticShape() || !inputType.hasStaticShape()) {
+      return rewriter.notifyMatchFailure(convOp, [](Diagnostic &diag) {
+        diag << "[unimplemented] "
+             << "expected 'filterType' and 'inputType' to have static shapes.";
+      });
+    }
+
+    // TODO: Support dilation.
+    if (!hasAllOneValues(convOp.getDilations())) {
+      return rewriter.notifyMatchFailure(convOp, [](Diagnostic &diag) {
+        diag << "[unimplemented] "
+             << "expected no dilations (expected dilations to all be one).";
+      });
+    }
+
+    Value input = convOp.getInputs()[0];
+    Value filter = convOp.getInputs()[1];
+    Value output = convOp.getOutputs()[0];
+
+    auto filterShape = filterType.getShape();
+    auto outputShape = outputType.getShape();
+
+    const int n = outputShape[0];
+    const int oh = outputShape[1];
+    const int ow = outputShape[2];
+    const int oc = outputShape[3];
+    const int fh = filterShape[0];
+    const int fw = filterShape[1];
+    const int ic = filterShape[2];
+
+    auto loc = convOp.getLoc();
+
+    SmallVector<int64_t> colTensorShape = {n, oh * ow, fh * fw * ic};
+
+    SmallVector<ReassociationIndices> outputReassocIndices = {{0}, {1, 2}, {3}};
+    auto reshapedOutputType =
+        RankedTensorType::get({n, oh * ow, oc}, outputType.getElementType());
+
+    Value colTensor = rewriter.create<tensor::EmptyOp>(
+        loc, colTensorShape, inputType.getElementType());
+    SmallVector<int64_t> strides(convOp.getStrides().getValues<int64_t>());
+    SmallVector<int64_t> dilations(convOp.getDilations().getValues<int64_t>());
+    SmallVector<OpFoldResult> kernelSize = {
+        getAsIndexOpFoldResult(convOp->getContext(), fh),
+        getAsIndexOpFoldResult(convOp->getContext(), fw)};
+    SmallVector<OpFoldResult> kOffset = {
+        getAsIndexOpFoldResult(convOp->getContext(), 0)};
+    SmallVector<OpFoldResult> mOffset = {
+        getAsIndexOpFoldResult(convOp->getContext(), 0)};
+    SmallVector<int64_t> batchPos = {0};
+    SmallVector<int64_t> mPos = {1, 2};
+    SmallVector<int64_t> kPos = {3};
+    Value img2ColTensor =
+        rewriter
+            .create<IREE::LinalgExt::Im2colOp>(
+                loc, input, /*output=*/colTensor, strides, dilations,
+                kernelSize, mOffset, kOffset, batchPos, mPos, kPos)
+            .getResult(0);
+
+    SmallVector<ReassociationIndices> filterReassocIndices = {{0, 1, 2}, {3}};
+    auto reshapedFilterType =
+        RankedTensorType::get({fh * fw * ic, oc}, inputType.getElementType());
+
+    Value reshapedFilter = rewriter.create<tensor::CollapseShapeOp>(
+        loc, reshapedFilterType, filter, filterReassocIndices);
+
+    Value reshapedOutput = rewriter.create<tensor::CollapseShapeOp>(
+        loc, reshapedOutputType, output, outputReassocIndices);
+
+    AffineExpr bDim, mDim, nDim, kDim;
+    bindDims(getContext(), bDim, mDim, nDim, kDim);
+    auto lhsMap = AffineMap::get(4, 0, {bDim, mDim, kDim}, getContext());
+    auto rhsMap = AffineMap::get(4, 0, {kDim, nDim}, getContext());
+    auto resultMap = AffineMap::get(4, 0, {bDim, mDim, nDim}, getContext());
+    auto parallel = utils::IteratorType::parallel;
+    auto reduction = utils::IteratorType::reduction;
+    SmallVector<utils::IteratorType> genericIterators = {parallel, parallel,
+                                                         parallel, reduction};
+    bool isInt = llvm::isa<IntegerType>(outputType.getElementType());
+    auto genericOp = rewriter.create<linalg::GenericOp>(
+        loc, reshapedOutputType,
+        /*inputs=*/ValueRange{img2ColTensor, reshapedFilter},
+        /*outputs=*/ValueRange{reshapedOutput},
+        ArrayRef<AffineMap>{lhsMap, rhsMap, resultMap}, genericIterators,
+        [&](OpBuilder &nestedBuilder, Location nestedLoc, ValueRange args) {
+          Value lhs = convertScalarToDtype(nestedBuilder, nestedLoc, args[0],
+                                           args[2].getType(),
+                                           /*isUnsignedCast=*/false);
+          Value rhs = convertScalarToDtype(nestedBuilder, nestedLoc, args[1],
+                                           args[2].getType(),
+                                           /*isUnsignedCast=*/false);
+          Value mul = createMul(nestedLoc, lhs, rhs, isInt, nestedBuilder);
+          Value add = createAdd(nestedLoc, mul, args[2], isInt, nestedBuilder);
+          nestedBuilder.create<linalg::YieldOp>(nestedLoc, add);
+        });
+    Value result = genericOp.getResults().front();
+
+    auto reshapedResult = rewriter.create<tensor::ExpandShapeOp>(
+        loc, outputType, result, outputReassocIndices);
+
+    rewriter.replaceOp(convOp, ArrayRef<Value>{reshapedResult});
+
+    return success();
+  }
+};
+
+// For nchw, because the channels are to the left of the image shape dimensions,
+// the position of the contraction dimension in the resulting matmul is
+// reversed. This swaps the LHS and RHS of the matmul when compared with nhwc
+// (i.e. (D, C x Kh x Kw) * (C x Kh x Kw, Ho x Wo))
+class ConvertConv2DNchwFchw final
+    : public OpRewritePattern<linalg::Conv2DNchwFchwOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::Conv2DNchwFchwOp convOp,
+                                PatternRewriter &rewriter) const override {
+    auto inputType = llvm::cast<ShapedType>(convOp.getInputs()[0].getType());
+    auto filterType = llvm::cast<ShapedType>(convOp.getInputs()[1].getType());
+    auto outputType = llvm::cast<ShapedType>(convOp.getOutputs()[0].getType());
+
+    if (!filterType.hasStaticShape() || !inputType.hasStaticShape()) {
+      return rewriter.notifyMatchFailure(convOp, [](Diagnostic &diag) {
+        diag << "[unimplemented] "
+             << "expected 'filterType' and 'inputType' to have static shapes.";
+      });
+    }
+
+    // TODO: Support dilation.
+    if (!hasAllOneValues(convOp.getDilations()))
+      return rewriter.notifyMatchFailure(convOp, [](Diagnostic &diag) {
+        diag << "[unimplemented] "
+             << "expected no dilations (expected dilations to all be one).";
+      });
+
+    Value input = convOp.getInputs()[0];
+    Value filter = convOp.getInputs()[1];
+    Value output = convOp.getOutputs()[0];
+
+    auto filterShape = filterType.getShape();
+    auto outputShape = outputType.getShape();
+
+    const int n = outputShape[0];
+    const int oc = outputShape[1];
+    const int oh = outputShape[2];
+    const int ow = outputShape[3];
+    const int ic = filterShape[1];
+    const int fh = filterShape[2];
+    const int fw = filterShape[3];
+
+    auto loc = convOp.getLoc();
+
+    SmallVector<int64_t> colTensorShape = {n, oh * ow, ic * fh * fw};
+
+    Value colTensor = rewriter.create<tensor::EmptyOp>(
+        loc, colTensorShape, inputType.getElementType());
+    SmallVector<int64_t> strides(convOp.getStrides().getValues<int64_t>());
+    SmallVector<int64_t> dilations(convOp.getDilations().getValues<int64_t>());
+    SmallVector<OpFoldResult> kernelSize = {
+        getAsIndexOpFoldResult(convOp->getContext(), fh),
+        getAsIndexOpFoldResult(convOp->getContext(), fw)};
+    SmallVector<OpFoldResult> kOffset = {
+        getAsIndexOpFoldResult(convOp->getContext(), 0)};
+    SmallVector<OpFoldResult> mOffset = {
+        getAsIndexOpFoldResult(convOp->getContext(), 0)};
+    SmallVector<int64_t> batchPos = {0};
+    SmallVector<int64_t> mPos = {2, 3};
+    SmallVector<int64_t> kPos = {1};
+    Value img2ColTensor =
+        rewriter
+            .create<IREE::LinalgExt::Im2colOp>(
+                loc, input, /*output=*/colTensor, strides, dilations,
+                kernelSize, mOffset, kOffset, batchPos, mPos, kPos)
+            .getResult(0);
+
+    SmallVector<ReassociationIndices> filterReassocIndices = {{0}, {1, 2, 3}};
+    auto reshapedFilterType =
+        RankedTensorType::get({oc, fh * fw * ic}, inputType.getElementType());
+    Value reshapedFilter = rewriter.create<tensor::CollapseShapeOp>(
+        loc, reshapedFilterType, filter, filterReassocIndices);
+
+    SmallVector<ReassociationIndices> outputReassocIndices = {{0}, {1}, {2, 3}};
+    RankedTensorType reshapedOutputType =
+        RankedTensorType::get({n, oc, oh * ow}, outputType.getElementType());
+
+    Value reshapedOutput = rewriter.create<tensor::CollapseShapeOp>(
+        loc, reshapedOutputType, output, outputReassocIndices);
+
+    AffineExpr bDim, mDim, nDim, kDim;
+    bindDims(getContext(), bDim, mDim, nDim, kDim);
+    auto lhsMap = AffineMap::get(4, 0, {mDim, kDim}, getContext());
+    auto rhsMap = AffineMap::get(4, 0, {bDim, nDim, kDim}, getContext());
+    auto resultMap = AffineMap::get(4, 0, {bDim, mDim, nDim}, getContext());
+    auto parallel = utils::IteratorType::parallel;
+    auto reduction = utils::IteratorType::reduction;
+    SmallVector<utils::IteratorType> genericIterators = {parallel, parallel,
+                                                         parallel, reduction};
+    bool isInt = llvm::isa<IntegerType>(outputType.getElementType());
+    auto genericOp = rewriter.create<linalg::GenericOp>(
+        loc, reshapedOutputType,
+        /*inputs=*/ValueRange{reshapedFilter, img2ColTensor},
+        /*outputs=*/ValueRange{reshapedOutput},
+        ArrayRef<AffineMap>{lhsMap, rhsMap, resultMap}, genericIterators,
+        [&](OpBuilder &nestedBuilder, Location nestedLoc, ValueRange args) {
+          Value lhs = convertScalarToDtype(nestedBuilder, nestedLoc, args[0],
+                                           args[2].getType(),
+                                           /*isUnsignedCast=*/false);
+          Value rhs = convertScalarToDtype(nestedBuilder, nestedLoc, args[1],
+                                           args[2].getType(),
+                                           /*isUnsignedCast=*/false);
+          Value mul = createMul(nestedLoc, lhs, rhs, isInt, nestedBuilder);
+          Value add = createAdd(nestedLoc, mul, args[2], isInt, nestedBuilder);
+          nestedBuilder.create<linalg::YieldOp>(nestedLoc, add);
+        });
+    Value result = genericOp.getResults().front();
+
+    auto reshapedResult = rewriter.create<tensor::ExpandShapeOp>(
+        loc, outputType, result, outputReassocIndices);
+
+    rewriter.replaceOp(convOp, ArrayRef<Value>{reshapedResult});
+
+    return success();
+  }
+};
+
+struct ConvertConv2DToIm2ColOpPass
+    : ConvertConv2DToIm2ColOpBase<ConvertConv2DToIm2ColOpPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry
+        .insert<linalg::LinalgDialect, IREE::LinalgExt::IREELinalgExtDialect>();
+  }
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(&getContext());
+    patterns.insert<ConvertConv2DNhwcHwcf, ConvertConv2DNchwFchw>(context);
+    linalg::FillOp::getCanonicalizationPatterns(patterns, context);
+    tensor::populateFoldTensorEmptyPatterns(patterns);
+    if (failed(applyPatternsAndFoldGreedily(getOperation(),
+                                            std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+
+} // namespace
+
+std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
+createConvertConv2DToIm2ColOpPass() {
+  return std::make_unique<ConvertConv2DToIm2ColOpPass>();
+}
+
+} // namespace mlir::iree_compiler::IREE::LinalgExt

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.h
@@ -44,6 +44,11 @@ createDecomposeIm2colPass();
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createDecomposeWinogradTransformPass();
 
+// Creates a pass to convert linalg convolution ops into a gemm with an im2col
+// op and reshapes on the inputs.
+std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
+createConvertConv2DToIm2ColOpPass();
+
 // Creates a pass to convert linalg convolution ops into a sequence of
 // linalg_ext.winograd.* ops and linalg.batch_matmul ops using the winograd
 // tranformation.

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.td
@@ -69,6 +69,12 @@ def DecomposeWinogradTransform :
                     "createDecomposeWinogradTransformPass()";
 }
 
+def ConvertConv2DToIm2ColOp :
+    InterfacePass<"iree-linalg-ext-convert-conv2d-to-im2col-op", "mlir::FunctionOpInterface"> {
+  let summary = "Convert linalg convolution ops to im2col gemm based implementation.";
+  let constructor = "mlir::iree_compiler::IREE::LinalgExt::createConvertConv2DToIm2ColOpPass()";
+}
+
 def ConvertConv2DToWinograd :
     InterfacePass<"iree-linalg-ext-convert-conv2d-to-winograd", "mlir::FunctionOpInterface"> {
   let summary = "Convert linalg convolution ops to winograd based implementation. By default, "

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/BUILD.bazel
@@ -16,6 +16,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "conv2d_to_im2col.mlir",
             "conv2d_to_winograd.mlir",
             "convert_to_loops.mlir",
             "decompose_attention.mlir",

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "conv2d_to_im2col.mlir"
     "conv2d_to_winograd.mlir"
     "convert_to_loops.mlir"
     "decompose_attention.mlir"

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv2d_to_im2col.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv2d_to_im2col.mlir
@@ -1,0 +1,147 @@
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(util.func(iree-linalg-ext-convert-conv2d-to-im2col-op))" %s | FileCheck %s
+
+util.func public @conv_2d_nhwc_hwcf(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<3x3x4x16xf32>, %arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32> {
+  %0 = linalg.conv_2d_nhwc_hwcf
+    {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64> }
+     ins(%arg0, %arg1: tensor<1x16x16x4xf32>, tensor<3x3x4x16xf32>)
+    outs(%arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32>
+  util.return %0 : tensor<1x14x14x16xf32>
+}
+// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d3, d2)>
+// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+// CHECK:      util.func public @conv_2d_nhwc_hwcf(
+// CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x16x16x4xf32>
+// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<3x3x4x16xf32>
+// CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<1x14x14x16xf32>
+// CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<1x196x36xf32>
+// CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
+// CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
+// CHECK-SAME:   m_offset = [0] k_offset = [0]
+// CHECK-SAME:   batch_pos = [0] m_pos = [1, 2] k_pos = [3]
+// CHECK-SAME:   ins(%[[ARG0]] : tensor<1x16x16x4xf32>)
+// CHECK-SAME:   outs(%[[EMPTY]] : tensor<1x196x36xf32>) -> tensor<1x196x36xf32>
+// CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0, 1, 2], [3]] : tensor<3x3x4x16xf32> into tensor<36x16xf32>
+// CHECK-DAG:  %[[COLLAPSED_0:.+]] = tensor.collapse_shape %[[ARG2]] {{\[}}[0], [1, 2], [3]] : tensor<1x14x14x16xf32> into tensor<1x196x16xf32>
+// CHECK:      %[[MATMUL:.+]] = linalg.generic
+// CHECK-SAME:   indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
+// CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "reduction"]
+// CHECK-SAME:   ins(%[[IM2COL]], %[[COLLAPSED]] : tensor<1x196x36xf32>, tensor<36x16xf32>)
+// CHECK-SAME:   outs(%[[COLLAPSED_0]] : tensor<1x196x16xf32>) {
+// CHECK:          arith.mulf
+// CHECK:          arith.addf
+// CHECK:      } -> tensor<1x196x16xf32>
+// CHECK:      %[[EXPANDED:.+]] = tensor.expand_shape %[[MATMUL]] {{\[}}[0], [1, 2], [3]] output_shape [1, 14, 14, 16] : tensor<1x196x16xf32> into tensor<1x14x14x16xf32>
+// CHECK:      util.return %[[EXPANDED]] : tensor<1x14x14x16xf32>
+
+// -----
+
+util.func public @conv_2d_nchw_fchw(%arg0: tensor<1x4x16x16xf32>, %arg1: tensor<16x4x3x3xf32>, %arg2: tensor<1x16x14x14xf32>) -> tensor<1x16x14x14xf32> {
+  %0 = linalg.conv_2d_nchw_fchw
+    {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64> }
+     ins(%arg0, %arg1: tensor<1x4x16x16xf32>, tensor<16x4x3x3xf32>)
+    outs(%arg2: tensor<1x16x14x14xf32>) -> tensor<1x16x14x14xf32>
+  util.return %0 : tensor<1x16x14x14xf32>
+}
+// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+// CHECK:      util.func public @conv_2d_nchw_fchw(
+// CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x4x16x16xf32>
+// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<16x4x3x3xf32>
+// CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<1x16x14x14xf32>
+// CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<1x196x36xf32>
+// CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
+// CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
+// CHECK-SAME:   m_offset = [0] k_offset = [0]
+// CHECK-SAME:   batch_pos = [0] m_pos = [2, 3] k_pos = [1]
+// CHECK-SAME:   ins(%[[ARG0]] : tensor<1x4x16x16xf32>)
+// CHECK-SAME:   outs(%[[EMPTY]] : tensor<1x196x36xf32>) -> tensor<1x196x36xf32>
+// CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0], [1, 2, 3]] : tensor<16x4x3x3xf32> into tensor<16x36xf32>
+// CHECK-DAG:  %[[COLLAPSED_0:.+]] = tensor.collapse_shape %[[ARG2]] {{\[}}[0], [1], [2, 3]] : tensor<1x16x14x14xf32> into tensor<1x16x196xf32>
+// CHECK:      %[[MATMUL:.+]] = linalg.generic
+// CHECK-SAME:   indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
+// CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "reduction"]
+// CHECK-SAME:   ins(%[[COLLAPSED]], %[[IM2COL]] : tensor<16x36xf32>, tensor<1x196x36xf32>)
+// CHECK-SAME:   outs(%[[COLLAPSED_0]] : tensor<1x16x196xf32>) {
+// CHECK:          arith.mulf
+// CHECK:          arith.addf
+// CHECK:      } -> tensor<1x16x196xf32>
+// CHECK:      %[[EXPANDED:.+]] = tensor.expand_shape %[[MATMUL]] {{\[}}[0], [1], [2, 3]] output_shape [1, 16, 14, 14] : tensor<1x16x196xf32> into tensor<1x16x14x14xf32>
+// CHECK:      util.return %[[EXPANDED]] : tensor<1x16x14x14xf32>
+
+// -----
+
+util.func public @conv_mixed_types(%arg0: tensor<1x16x16x4xf16>, %arg1: tensor<3x3x4x16xf16>, %arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32> {
+  %0 = linalg.conv_2d_nhwc_hwcf
+    {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64> }
+     ins(%arg0, %arg1: tensor<1x16x16x4xf16>, tensor<3x3x4x16xf16>)
+    outs(%arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32>
+  util.return %0 : tensor<1x14x14x16xf32>
+}
+// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d3, d2)>
+// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+// CHECK:      util.func public @conv_mixed_types(
+// CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x16x16x4xf16>
+// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<3x3x4x16xf16>
+// CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<1x14x14x16xf32>
+// CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<1x196x36xf16>
+// CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
+// CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
+// CHECK-SAME:   m_offset = [0] k_offset = [0]
+// CHECK-SAME:   batch_pos = [0] m_pos = [1, 2] k_pos = [3]
+// CHECK-SAME:   ins(%[[ARG0]] : tensor<1x16x16x4xf16>)
+// CHECK-SAME:   outs(%[[EMPTY]] : tensor<1x196x36xf16>) -> tensor<1x196x36xf16>
+// CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0, 1, 2], [3]] : tensor<3x3x4x16xf16> into tensor<36x16xf16>
+// CHECK-DAG:  %[[COLLAPSED_0:.+]] = tensor.collapse_shape %[[ARG2]] {{\[}}[0], [1, 2], [3]] : tensor<1x14x14x16xf32> into tensor<1x196x16xf32>
+// CHECK:      %[[MATMUL:.+]] = linalg.generic
+// CHECK-SAME:   indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
+// CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "reduction"]
+// CHECK-SAME:   ins(%[[IM2COL]], %[[COLLAPSED]] : tensor<1x196x36xf16>, tensor<36x16xf16>)
+// CHECK-SAME:   outs(%[[COLLAPSED_0]] : tensor<1x196x16xf32>) {
+// CHECK:          arith.extf
+// CHECK:          arith.extf
+// CHECK:          arith.mulf
+// CHECK:          arith.addf
+// CHECK:      } -> tensor<1x196x16xf32>
+// CHECK:      %[[EXPANDED:.+]] = tensor.expand_shape %[[MATMUL]] {{\[}}[0], [1, 2], [3]] output_shape [1, 14, 14, 16] : tensor<1x196x16xf32> into tensor<1x14x14x16xf32>
+// CHECK:      util.return %[[EXPANDED]] : tensor<1x14x14x16xf32>
+
+// -----
+
+util.func public @conv_strided(%arg0: tensor<1x16x16x4xf16>, %arg1: tensor<3x3x4x16xf16>, %arg2: tensor<1x7x7x16xf32>) -> tensor<1x7x7x16xf32> {
+  %0 = linalg.conv_2d_nhwc_hwcf
+    {dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64> }
+     ins(%arg0, %arg1: tensor<1x16x16x4xf16>, tensor<3x3x4x16xf16>)
+    outs(%arg2: tensor<1x7x7x16xf32>) -> tensor<1x7x7x16xf32>
+  util.return %0 : tensor<1x7x7x16xf32>
+}
+// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d3, d2)>
+// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+// CHECK:      util.func public @conv_strided(
+// CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x16x16x4xf16>
+// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<3x3x4x16xf16>
+// CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<1x7x7x16xf32>
+// CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<1x49x36xf16>
+// CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
+// CHECK-SAME:   strides = [2, 2] dilations = [1, 1] kernel_size = [3, 3]
+// CHECK-SAME:   m_offset = [0] k_offset = [0]
+// CHECK-SAME:   batch_pos = [0] m_pos = [1, 2] k_pos = [3]
+// CHECK-SAME:   ins(%[[ARG0]] : tensor<1x16x16x4xf16>)
+// CHECK-SAME:   outs(%[[EMPTY]] : tensor<1x49x36xf16>) -> tensor<1x49x36xf16>
+// CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0, 1, 2], [3]] : tensor<3x3x4x16xf16> into tensor<36x16xf16>
+// CHECK-DAG:  %[[COLLAPSED_0:.+]] = tensor.collapse_shape %[[ARG2]] {{\[}}[0], [1, 2], [3]] : tensor<1x7x7x16xf32> into tensor<1x49x16xf32>
+// CHECK:      %[[MATMUL:.+]] = linalg.generic
+// CHECK-SAME:   indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
+// CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "reduction"]
+// CHECK-SAME:   ins(%[[IM2COL]], %[[COLLAPSED]] : tensor<1x49x36xf16>, tensor<36x16xf16>)
+// CHECK-SAME:   outs(%[[COLLAPSED_0]] : tensor<1x49x16xf32>) {
+// CHECK:          arith.extf
+// CHECK:          arith.extf
+// CHECK:          arith.mulf
+// CHECK:          arith.addf
+// CHECK:      } -> tensor<1x49x16xf32>
+// CHECK:      %[[EXPANDED:.+]] = tensor.expand_shape %[[MATMUL]] {{\[}}[0], [1, 2], [3]] output_shape [1, 7, 7, 16] : tensor<1x49x16xf32> into tensor<1x7x7x16xf32>
+// CHECK:      util.return %[[EXPANDED]] : tensor<1x7x7x16xf32>


### PR DESCRIPTION
This PR adds a new pass to convert a conv_2d op with NHWC or NCHW layouts into a `iree_linalg_ext.im2col` op + GEMM. This pass mostly mirrors the `ConvertConv2DToImg2ColPass` in Preprocessing, but this generates the im2col op instead of a generic op.