### PR TITLE
Drop `python_release_packages` CI job in favor of pkgci.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -605,77 +605,6 @@ jobs:
             ./build_tools/cmake/ctest_all.sh \
             "${BUILD_DIR}"
 
-  python_release_packages:
-    needs: setup
-    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'python_release_packages')
-    runs-on:
-      - self-hosted # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.runner-env }}
-      - cpu
-      - os-family=Linux
-    steps:
-      - name: Prefetch Docker
-        run: |
-          docker pull ghcr.io/nod-ai/manylinux_x86_64:main &
-      - name: "Checking out repository"
-        uses: actions/checkout@v4.1.7
-        with:
-          submodules: true
-      - name: "Setting up Python"
-        uses: actions/setup-python@v5.1.0
-        with:
-          python-version: "3.9"
-      - name: Wait for docker pull
-        run: |
-          wait
-      - name: Build runtime wheels (Linux)
-        shell: bash
-        env:
-          packages: "iree-runtime"
-          output_dir: "${{ github.workspace }}/bindist"
-          # Note when upgrading: Build just one Python version synced to our
-          # minimum.
-          override_python_versions: cp39-cp39
-        run: |
-          output_dir="$PWD" ./build_tools/python_deploy/build_linux_packages.sh
-      - name: Validate runtime wheel (Linux)
-        shell: bash
-        run: |
-          pip install --upgrade pip
-          pip install --no-index -f $PWD -v iree-runtime
-          echo "Testing default runtime:"
-          python -m iree.runtime._package_test
-          echo "Testing tracy runtime:"
-          # GH runners don't expose the TSC but we want to make sure the basic packaging
-          # works, so override the check with TRACY_NO_INVARIANT_CHECK=1 (per instructions
-          # if this is left off).
-          TRACY_NO_INVARIANT_CHECK=1 IREE_PY_RUNTIME=tracy \
-            python -m iree.runtime._package_test
-      # Note that it is just a trade-off decision to have this serialized
-      # as a separate step vs parallelized as a separate job. The runtime
-      # build is fast, pays the clone/docker overhead and provides early
-      # signal (since it runs in just a couple of minutes).
-      - name: Build compiler wheels (Linux)
-        shell: bash
-        env:
-          packages: "iree-compiler"
-          # Note when upgrading: Build just one Python version synced to our
-          # minimum.
-          override_python_versions: cp39-cp39
-        run: |
-          output_dir="$PWD" ./build_tools/python_deploy/build_linux_packages.sh
-      - name: Validate compiler wheel (Linux)
-        shell: bash
-        run: |
-          pip install --upgrade pip
-          # Pre-fetch optional deps that iree-compiler needs (but we constrain that
-          # to not consult a package index).
-          pip install onnx>=1.16.0
-          pip install --no-index -f $PWD -v iree-compiler[onnx]
-          echo "Testing default compiler:"
-          python -m iree.compiler._package_test
-
   sanitizers:
     needs: setup
     name: "sanitizers :: ${{ matrix.name }}"
@@ -990,7 +919,6 @@ jobs:
 
       # Configurations
       - build_test_runtime
-      - python_release_packages
       - sanitizers
       - small_runtime
       - gcc

--- a/.github/workflows/pkgci.yml
+++ b/.github/workflows/pkgci.yml
@@ -37,6 +37,12 @@ jobs:
     with:
       package_version: 0.dev1
 
+  unit_test:
+    name: Unit Test
+    needs: [setup, build_packages]
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'unit_test')
+    uses: ./.github/workflows/pkgci_unit_test.yml
+
   regression_test:
     name: Regression Test
     needs: [setup, build_packages]

--- a/.github/workflows/pkgci_build_packages.yml
+++ b/.github/workflows/pkgci_build_packages.yml
@@ -72,8 +72,8 @@ jobs:
           sudo chown -R "$(whoami)" "${cache_dir}"
       - name: Validate runtime wheel
         run: |
-          pip install --upgrade pip
-          pip install --no-index -f $PWD -v iree-runtime
+          python -m pip install --upgrade pip
+          python -m pip install --no-index -f $PWD -v iree-runtime
           echo "Testing default runtime package:"
           python -m iree.runtime._package_test
           echo "Testing tracy runtime package:"
@@ -84,10 +84,10 @@ jobs:
             python -m iree.runtime._package_test
       - name: Validate compiler wheel
         run: |
-          pip install --upgrade pip
+          python -m pip install --upgrade pip
           # Pre-fetch optional deps (constrain to not consult a package index).
-          pip install onnx>=1.16.0
-          pip install --no-index -f $PWD -v iree-compiler[onnx]
+          python -m pip install onnx>=1.16.0
+          python -m pip install --no-index -f $PWD -v iree-compiler[onnx]
           echo "Testing compiler package:"
           python -m iree.compiler._package_test
       - name: Upload wheel artifacts

--- a/.github/workflows/pkgci_build_packages.yml
+++ b/.github/workflows/pkgci_build_packages.yml
@@ -70,29 +70,6 @@ jobs:
           # Some things put stuff in cache with weird, root read-only
           # permissions. Take them back.
           sudo chown -R "$(whoami)" "${cache_dir}"
-      - uses: actions/setup-python@v5.1.0
-        with:
-          python-version: "3.11"
-      - name: Validate runtime wheel
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install --no-index -f $PWD -v iree-runtime
-          echo "Testing default runtime package:"
-          python -m iree.runtime._package_test
-          echo "Testing tracy runtime package:"
-          # GH runners don't expose the TSC but we want to make sure the basic packaging
-          # works, so override the check with TRACY_NO_INVARIANT_CHECK=1 (per instructions
-          # if this is left off).
-          TRACY_NO_INVARIANT_CHECK=1 IREE_PY_RUNTIME=tracy \
-            python -m iree.runtime._package_test
-      - name: Validate compiler wheel
-        run: |
-          python -m pip install --upgrade pip
-          # Pre-fetch optional deps (constrain to not consult a package index).
-          python -m pip install onnx>=1.16.0
-          python -m pip install --no-index -f $PWD -v iree-compiler[onnx]
-          echo "Testing compiler package:"
-          python -m iree.compiler._package_test
       - name: Upload wheel artifacts
         uses: actions/upload-artifact@v4.3.3
         with:

--- a/.github/workflows/pkgci_build_packages.yml
+++ b/.github/workflows/pkgci_build_packages.yml
@@ -70,6 +70,9 @@ jobs:
           # Some things put stuff in cache with weird, root read-only
           # permissions. Take them back.
           sudo chown -R "$(whoami)" "${cache_dir}"
+      - uses: actions/setup-python@v5.1.0
+        with:
+          python-version: "3.11"
       - name: Validate runtime wheel
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/pkgci_build_packages.yml
+++ b/.github/workflows/pkgci_build_packages.yml
@@ -70,6 +70,26 @@ jobs:
           # Some things put stuff in cache with weird, root read-only
           # permissions. Take them back.
           sudo chown -R "$(whoami)" "${cache_dir}"
+      - name: Validate runtime wheel
+        run: |
+          pip install --upgrade pip
+          pip install --no-index -f $PWD -v iree-runtime
+          echo "Testing default runtime package:"
+          python -m iree.runtime._package_test
+          echo "Testing tracy runtime package:"
+          # GH runners don't expose the TSC but we want to make sure the basic packaging
+          # works, so override the check with TRACY_NO_INVARIANT_CHECK=1 (per instructions
+          # if this is left off).
+          TRACY_NO_INVARIANT_CHECK=1 IREE_PY_RUNTIME=tracy \
+            python -m iree.runtime._package_test
+      - name: Validate compiler wheel
+        run: |
+          pip install --upgrade pip
+          # Pre-fetch optional deps (constrain to not consult a package index).
+          pip install onnx>=1.16.0
+          pip install --no-index -f $PWD -v iree-compiler[onnx]
+          echo "Testing compiler package:"
+          python -m iree.compiler._package_test
       - name: Upload wheel artifacts
         uses: actions/upload-artifact@v4.3.3
         with:

--- a/.github/workflows/pkgci_unit_test.yml
+++ b/.github/workflows/pkgci_unit_test.yml
@@ -44,8 +44,6 @@ jobs:
             --fetch-gh-workflow=${{ inputs.artifact_run_id }}
       - name: Validate runtime wheel
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install --no-index -f $PWD -v iree-runtime
           echo "Testing default runtime package:"
           python -m iree.runtime._package_test
           echo "Testing tracy runtime package:"
@@ -56,9 +54,5 @@ jobs:
             python -m iree.runtime._package_test
       - name: Validate compiler wheel
         run: |
-          python -m pip install --upgrade pip
-          # Pre-fetch optional deps (constrain to not consult a package index).
-          python -m pip install onnx>=1.16.0
-          python -m pip install --no-index -f $PWD -v iree-compiler[onnx]
           echo "Testing compiler package:"
           python -m iree.compiler._package_test

--- a/.github/workflows/pkgci_unit_test.yml
+++ b/.github/workflows/pkgci_unit_test.yml
@@ -1,0 +1,64 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+name: PkgCI Unit Test
+on:
+  workflow_call:
+    inputs:
+      artifact_run_id:
+        type: string
+        default: ""
+  workflow_dispatch:
+    inputs:
+      artifact_run_id:
+        type: string
+        default: ""
+
+jobs:
+  linux_x86_64:
+    name: Linux (x86_64)
+    runs-on: ubuntu-20.04
+    env:
+      PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
+      VENV_DIR: ${{ github.workspace }}/.venv
+    steps:
+      - name: Checking out repository
+        uses: actions/checkout@v4.1.7
+        with:
+          submodules: false
+      - uses: actions/setup-python@v5.1.0
+        with:
+          # Must match the subset of versions built in pkgci_build_packages.
+          python-version: "3.11"
+      - uses: actions/download-artifact@v4.1.7
+        with:
+          name: linux_x86_64_release_packages
+          path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
+      - name: Setup base venv
+        run: |
+          ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
+            --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
+            --fetch-gh-workflow=${{ inputs.artifact_run_id }}
+      - name: Validate runtime wheel
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --no-index -f $PWD -v iree-runtime
+          echo "Testing default runtime package:"
+          python -m iree.runtime._package_test
+          echo "Testing tracy runtime package:"
+          # GH runners don't expose the TSC but we want to make sure the basic packaging
+          # works, so override the check with TRACY_NO_INVARIANT_CHECK=1 (per instructions
+          # if this is left off).
+          TRACY_NO_INVARIANT_CHECK=1 IREE_PY_RUNTIME=tracy \
+            python -m iree.runtime._package_test
+      - name: Validate compiler wheel
+        run: |
+          python -m pip install --upgrade pip
+          # Pre-fetch optional deps (constrain to not consult a package index).
+          python -m pip install onnx>=1.16.0
+          python -m pip install --no-index -f $PWD -v iree-compiler[onnx]
+          echo "Testing compiler package:"
+          python -m iree.compiler._package_test

--- a/.github/workflows/pkgci_unit_test.yml
+++ b/.github/workflows/pkgci_unit_test.yml
@@ -44,6 +44,7 @@ jobs:
             --fetch-gh-workflow=${{ inputs.artifact_run_id }}
       - name: Validate runtime wheel
         run: |
+          source ${VENV_DIR}/bin/activate
           echo "Testing default runtime package:"
           python -m iree.runtime._package_test
           echo "Testing tracy runtime package:"
@@ -54,5 +55,6 @@ jobs:
             python -m iree.runtime._package_test
       - name: Validate compiler wheel
         run: |
+          source ${VENV_DIR}/bin/activate
           echo "Testing compiler package:"
           python -m iree.compiler._package_test


### PR DESCRIPTION
Fixes https://github.com/iree-org/iree/issues/17955.

~~This puts the "validate wheels" step right in the build job, when it could be moved to a separate job. I figure that any following jobs should be able to trust that the wheels pass basic validation, though this does add 20 seconds to the front of the pipeline.~~
^ Nevermind, just added a new job. The way the wheels are built/uploaded/downloaded was a bit tricky to parse through and this keeps the flow compartmentalized.

ci-exactly: build_packages, unit_test