### PR TITLE
[python] Read default flags from the IREE_PY_RUNTIME_FLAGS env var.

### DIFF
--- a/runtime/bindings/python/iree/runtime/flags.py
+++ b/runtime/bindings/python/iree/runtime/flags.py
@@ -4,9 +4,40 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+"""Global runtime flags.
+
+Obligatory disclaimer: there are APIs for managing most of this in a library
+friendly way, and those are almost always better. However, flags as are
+typically passed to `iree-run-module` can be set *process wide* by using
+the `parse_flags` API below.
+
+In addition, the `IREE_PY_RUNTIME_FLAGS` environment variable, if present,
+will cause the included flags to be parsed at import time.
+"""
+
 from ._binding import parse_flags
 
 # When enabled, performs additional function input validation checks. In the
 # event of errors, this will yield nicer error messages but comes with a
 # runtime cost.
 FUNCTION_INPUT_VALIDATION = True
+
+
+def _load_default_flags_from_env():
+    import os
+    import shlex
+
+    flags_env_str = os.getenv("IREE_PY_RUNTIME_FLAGS")
+    if not flags_env_str:
+        return
+    flags_env_list = shlex.split(flags_env_str)
+    try:
+        parse_flags(*flags_env_list)
+    except ValueError as e:
+        raise RuntimeError(
+            f"Bad flag value in environment variable IREE_PY_RUNTIME_FLAGS="
+            f"'{flags_env_str}': {e}"
+        ) from e
+
+
+_load_default_flags_from_env()

--- a/runtime/bindings/python/tests/flags_test.py
+++ b/runtime/bindings/python/tests/flags_test.py
@@ -5,11 +5,15 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from iree import runtime as rt
+import os
 import numpy as np
 import unittest
 
 
 class FlagsTest(unittest.TestCase):
+    def setUp(self):
+        os.environ["IREE_PY_RUNTIME_FLAGS"] = ""
+
     def testParse(self):
         # --help is always available if flags are.
         rt.flags.parse_flags("--help")
@@ -17,6 +21,15 @@ class FlagsTest(unittest.TestCase):
     def testParseError(self):
         with self.assertRaisesRegex(ValueError, "flag 'barbar' not recognized"):
             rt.flags.parse_flags("--barbar")
+
+    def testEnvParse(self):
+        os.environ["IREE_PY_RUNTIME_FLAGS"] = "--help"
+        rt.flags._load_default_flags_from_env()
+
+    def testEnvParseError(self):
+        os.environ["IREE_PY_RUNTIME_FLAGS"] = "--barbar"
+        with self.assertRaisesRegex(RuntimeError, "IREE_PY_RUNTIME_FLAGS.*barbar"):
+            rt.flags._load_default_flags_from_env()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
If present, the IREE_PY_RUNTIME_FLAGS env var will be parsed with shlex and contained flags will be set globally. On error, a descriptive error noting the environment variable is raised.