### PR TITLE
Disable cross compilation tests for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -857,42 +857,43 @@ jobs:
   # Jobs that cross-compile IREE for other platforms
   ##############################################################################
 
-  cross_compile_and_test:
-    needs: [setup, build_all]
-    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'cross_compile_and_test')
-    runs-on:
-      - self-hosted # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.runner-env }}
-      - cpu
-      - os-family=Linux
-    strategy:
-      matrix:
-        target:
-          - platform: linux
-            arch: riscv_64
-            abi: lp64d
-            docker_image: "gcr.io/iree-oss/riscv@sha256:62e87bad3405d691ddba6f9be0ef44eeb60461a467c8d86f0842c81a1f97da79"
-            build_script: "./build_tools/cmake/build_riscv.sh"
-            test_script: "./build_tools/cmake/test_riscv.sh"
-          - platform: linux
-            arch: riscv_32
-            abi: ilp32d
-            docker_image: "gcr.io/iree-oss/riscv@sha256:62e87bad3405d691ddba6f9be0ef44eeb60461a467c8d86f0842c81a1f97da79"
-            build_script: "./build_tools/cmake/build_riscv.sh"
-            test_script: "./build_tools/cmake/test_riscv.sh"
-          - platform: generic
-            arch: riscv_32
-            abi: ilp32
-            docker_image: "gcr.io/iree-oss/riscv@sha256:62e87bad3405d691ddba6f9be0ef44eeb60461a467c8d86f0842c81a1f97da79"
-            build_script: "./build_tools/cmake/build_riscv.sh"
-            test_script: "./tests/riscv32/smoke.sh"
-          - platform: emscripten
-            arch: wasm32
-            abi: wasm32
-            docker_image: "gcr.io/iree-oss/emscripten@sha256:2dd4c52f1bb499ab365aad0111fe5538b685d88af38636b409b0cf6a576ab214"
-            build_script: "./build_tools/cmake/build_runtime_emscripten.sh"
-            # No test script
+  # Disabled to reduce self-hosted runners needed. See #17957
+  # cross_compile_and_test:
+  #  needs: [setup, build_all]
+  #  if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'cross_compile_and_test')
+  #  runs-on:
+  #    - self-hosted # must come first
+  #    - runner-group=${{ needs.setup.outputs.runner-group }}
+  #    - environment=${{ needs.setup.outputs.runner-env }}
+  #    - cpu
+  #    - os-family=Linux
+  #  strategy:
+  #    matrix:
+  #      target:
+  #        - platform: linux
+  #          arch: riscv_64
+  #          abi: lp64d
+  #          docker_image: "gcr.io/iree-oss/riscv@sha256:62e87bad3405d691ddba6f9be0ef44eeb60461a467c8d86f0842c81a1f97da79"
+  #          build_script: "./build_tools/cmake/build_riscv.sh"
+  #          test_script: "./build_tools/cmake/test_riscv.sh"
+  #        - platform: linux
+  #          arch: riscv_32
+  #          abi: ilp32d
+  #          docker_image: "gcr.io/iree-oss/riscv@sha256:62e87bad3405d691ddba6f9be0ef44eeb60461a467c8d86f0842c81a1f97da79"
+  #          build_script: "./build_tools/cmake/build_riscv.sh"
+  #          test_script: "./build_tools/cmake/test_riscv.sh"
+  #        - platform: generic
+  #          arch: riscv_32
+  #          abi: ilp32
+  #          docker_image: "gcr.io/iree-oss/riscv@sha256:62e87bad3405d691ddba6f9be0ef44eeb60461a467c8d86f0842c81a1f97da79"
+  #          build_script: "./build_tools/cmake/build_riscv.sh"
+  #          test_script: "./tests/riscv32/smoke.sh"
+  #        - platform: emscripten
+  #          arch: wasm32
+  #          abi: wasm32
+  #          docker_image: "gcr.io/iree-oss/emscripten@sha256:2dd4c52f1bb499ab365aad0111fe5538b685d88af38636b409b0cf6a576ab214"
+  #          build_script: "./build_tools/cmake/build_runtime_emscripten.sh"
+  #          # No test script
 
     env:
       PLATFORM: ${{ matrix.target.platform }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -859,87 +859,86 @@ jobs:
 
   # Disabled to reduce self-hosted runners needed. See #17957
   # cross_compile_and_test:
-  #  needs: [setup, build_all]
-  #  if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'cross_compile_and_test')
-  #  runs-on:
-  #    - self-hosted # must come first
-  #    - runner-group=${{ needs.setup.outputs.runner-group }}
-  #    - environment=${{ needs.setup.outputs.runner-env }}
-  #    - cpu
-  #    - os-family=Linux
-  #  strategy:
-  #    matrix:
-  #      target:
-  #        - platform: linux
-  #          arch: riscv_64
-  #          abi: lp64d
-  #          docker_image: "gcr.io/iree-oss/riscv@sha256:62e87bad3405d691ddba6f9be0ef44eeb60461a467c8d86f0842c81a1f97da79"
-  #          build_script: "./build_tools/cmake/build_riscv.sh"
-  #          test_script: "./build_tools/cmake/test_riscv.sh"
-  #        - platform: linux
-  #          arch: riscv_32
-  #          abi: ilp32d
-  #          docker_image: "gcr.io/iree-oss/riscv@sha256:62e87bad3405d691ddba6f9be0ef44eeb60461a467c8d86f0842c81a1f97da79"
-  #          build_script: "./build_tools/cmake/build_riscv.sh"
-  #          test_script: "./build_tools/cmake/test_riscv.sh"
-  #        - platform: generic
-  #          arch: riscv_32
-  #          abi: ilp32
-  #          docker_image: "gcr.io/iree-oss/riscv@sha256:62e87bad3405d691ddba6f9be0ef44eeb60461a467c8d86f0842c81a1f97da79"
-  #          build_script: "./build_tools/cmake/build_riscv.sh"
-  #          test_script: "./tests/riscv32/smoke.sh"
-  #        - platform: emscripten
-  #          arch: wasm32
-  #          abi: wasm32
-  #          docker_image: "gcr.io/iree-oss/emscripten@sha256:2dd4c52f1bb499ab365aad0111fe5538b685d88af38636b409b0cf6a576ab214"
-  #          build_script: "./build_tools/cmake/build_runtime_emscripten.sh"
-  #          # No test script
-
-    env:
-      PLATFORM: ${{ matrix.target.platform }}
-      ARCH: ${{ matrix.target.arch }}
-      ABI: ${{ matrix.target.abi }}
-      DOCKER_IMAGE: ${{ matrix.target.docker_image }}
-      BUILD_SCRIPT: ${{ matrix.target.build_script }}
-      TEST_SCRIPT: ${{ matrix.target.test_script }}
-      INSTALL_DIR: ${{ needs.build_all.outputs.install-dir }}
-      INSTALL_DIR_ARCHIVE: ${{ needs.build_all.outputs.install-dir-archive }}
-      INSTALL_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.install-dir-gcs-artifact }}
-      TARGET_BUILD_DIR: build-${{ matrix.target.platform }}-${{ matrix.target.arch }}
-      IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@v4.1.7
-      - name: "Checking out runtime submodules"
-        run: ./build_tools/scripts/git/update_runtime_submodules.sh
-      - name: "Downloading install dir archive"
-        run: gcloud storage cp "${INSTALL_DIR_GCS_ARTIFACT}" "${INSTALL_DIR_ARCHIVE}"
-      - name: "Extracting install directory"
-        run: tar -xf "${INSTALL_DIR_ARCHIVE}"
-      - name: "Build cross-compiling target"
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-            --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
-            --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
-            --env "CCACHE_NAMESPACE=${DOCKER_IMAGE}" \
-            --env "IREE_TARGET_PLATFORM=${PLATFORM}" \
-            --env "IREE_TARGET_ARCH=${ARCH}" \
-            --env "IREE_TARGET_ABI=${ABI}" \
-            --env "IREE_TARGET_BUILD_DIR=${TARGET_BUILD_DIR}" \
-            --env "BUILD_PRESET=test" \
-            --env "IREE_HOST_BIN_DIR=${INSTALL_DIR}/bin" \
-            "${DOCKER_IMAGE}" \
-            "${BUILD_SCRIPT}"
-      - name: "Test cross-compiling target"
-        if: matrix.target.test_script
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-            --env "IREE_TARGET_PLATFORM=${PLATFORM}" \
-            --env "IREE_TARGET_ARCH=${ARCH}" \
-            --env "IREE_TARGET_BUILD_DIR=${TARGET_BUILD_DIR}" \
-            --env "BUILD_PRESET=test" \
-            "${DOCKER_IMAGE}" \
-            "${TEST_SCRIPT}"
+  #   needs: [setup, build_all]
+  #   if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'cross_compile_and_test')
+  #   runs-on:
+  #     - self-hosted # must come first
+  #     - runner-group=${{ needs.setup.outputs.runner-group }}
+  #     - environment=${{ needs.setup.outputs.runner-env }}
+  #     - cpu
+  #     - os-family=Linux
+  #   strategy:
+  #     matrix:
+  #       target:
+  #         - platform: linux
+  #           arch: riscv_64
+  #           abi: lp64d
+  #           docker_image: "gcr.io/iree-oss/riscv@sha256:62e87bad3405d691ddba6f9be0ef44eeb60461a467c8d86f0842c81a1f97da79"
+  #           build_script: "./build_tools/cmake/build_riscv.sh"
+  #           test_script: "./build_tools/cmake/test_riscv.sh"
+  #         - platform: linux
+  #           arch: riscv_32
+  #           abi: ilp32d
+  #           docker_image: "gcr.io/iree-oss/riscv@sha256:62e87bad3405d691ddba6f9be0ef44eeb60461a467c8d86f0842c81a1f97da79"
+  #           build_script: "./build_tools/cmake/build_riscv.sh"
+  #           test_script: "./build_tools/cmake/test_riscv.sh"
+  #         - platform: generic
+  #           arch: riscv_32
+  #           abi: ilp32
+  #           docker_image: "gcr.io/iree-oss/riscv@sha256:62e87bad3405d691ddba6f9be0ef44eeb60461a467c8d86f0842c81a1f97da79"
+  #           build_script: "./build_tools/cmake/build_riscv.sh"
+  #           test_script: "./tests/riscv32/smoke.sh"
+  #         - platform: emscripten
+  #           arch: wasm32
+  #           abi: wasm32
+  #           docker_image: "gcr.io/iree-oss/emscripten@sha256:2dd4c52f1bb499ab365aad0111fe5538b685d88af38636b409b0cf6a576ab214"
+  #           build_script: "./build_tools/cmake/build_runtime_emscripten.sh"
+  #           # No test script
+  #   env:
+  #     PLATFORM: ${{ matrix.target.platform }}
+  #     ARCH: ${{ matrix.target.arch }}
+  #     ABI: ${{ matrix.target.abi }}
+  #     DOCKER_IMAGE: ${{ matrix.target.docker_image }}
+  #     BUILD_SCRIPT: ${{ matrix.target.build_script }}
+  #     TEST_SCRIPT: ${{ matrix.target.test_script }}
+  #     INSTALL_DIR: ${{ needs.build_all.outputs.install-dir }}
+  #     INSTALL_DIR_ARCHIVE: ${{ needs.build_all.outputs.install-dir-archive }}
+  #     INSTALL_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.install-dir-gcs-artifact }}
+  #     TARGET_BUILD_DIR: build-${{ matrix.target.platform }}-${{ matrix.target.arch }}
+  #     IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
+  #   steps:
+  #     - name: "Checking out repository"
+  #       uses: actions/checkout@v4.1.7
+  #     - name: "Checking out runtime submodules"
+  #       run: ./build_tools/scripts/git/update_runtime_submodules.sh
+  #     - name: "Downloading install dir archive"
+  #       run: gcloud storage cp "${INSTALL_DIR_GCS_ARTIFACT}" "${INSTALL_DIR_ARCHIVE}"
+  #     - name: "Extracting install directory"
+  #       run: tar -xf "${INSTALL_DIR_ARCHIVE}"
+  #     - name: "Build cross-compiling target"
+  #       run: |
+  #         ./build_tools/github_actions/docker_run.sh \
+  #           --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
+  #           --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
+  #           --env "CCACHE_NAMESPACE=${DOCKER_IMAGE}" \
+  #           --env "IREE_TARGET_PLATFORM=${PLATFORM}" \
+  #           --env "IREE_TARGET_ARCH=${ARCH}" \
+  #           --env "IREE_TARGET_ABI=${ABI}" \
+  #           --env "IREE_TARGET_BUILD_DIR=${TARGET_BUILD_DIR}" \
+  #           --env "BUILD_PRESET=test" \
+  #           --env "IREE_HOST_BIN_DIR=${INSTALL_DIR}/bin" \
+  #           "${DOCKER_IMAGE}" \
+  #           "${BUILD_SCRIPT}"
+  #     - name: "Test cross-compiling target"
+  #       if: matrix.target.test_script
+  #       run: |
+  #         ./build_tools/github_actions/docker_run.sh \
+  #           --env "IREE_TARGET_PLATFORM=${PLATFORM}" \
+  #           --env "IREE_TARGET_ARCH=${ARCH}" \
+  #           --env "IREE_TARGET_BUILD_DIR=${TARGET_BUILD_DIR}" \
+  #           --env "BUILD_PRESET=test" \
+  #           "${DOCKER_IMAGE}" \
+  #           "${TEST_SCRIPT}"
 
   # Android cross-compilation and test is separated from cross_compile_and_test
   # because some tests need to run on physical devices instead of emulators. And
@@ -1001,7 +1000,7 @@ jobs:
       - byo_llvm
 
       # Crosscompilation
-      - cross_compile_and_test
+      # - cross_compile_and_test
       - build_and_test_android
     steps:
       - name: "Checking out repository"


### PR DESCRIPTION
To decrease resource pressure on presubmits, disable the cross compile tests for now.

#17957