### PR TITLE
[LLVMGPU] Add im2col op decomposition before vectorization

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -240,6 +240,7 @@ static void tileAndBufferize(OpPassManager &funcPassManager) {
 
 static void addGPUVectorizationPasses(OpPassManager &funcPassManager) {
   funcPassManager.addPass(createDecomposeConvolutionToLowerDimOpsPass());
+  funcPassManager.addPass(IREE::LinalgExt::createDecomposeIm2colPass());
   GenericVectorizationPassOptions options;
   options.vectorizePadding = true;
   options.vectorizeGatherAccesses = true;


### PR DESCRIPTION
This PR adds the im2col op decomposition into the LLVMGPU pipeline. The pass is added before GenericVectorization, so the im2col op becomes nested loops of a `linalg.copy`, which gets vectorized in GenericVectorization.