### PR TITLE
[GPU][VectDist] Refactor multiReducOp lowering to reduce acc at the end.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -480,7 +480,8 @@ struct DistributeMultiReduction final
       return failure();
     }
 
-    // Do reduction against accumulator.
+    // Do reduction against accumulator, which needs to be done after thread
+    // reduction.
     VectorValue unflattened = rewriter.create<vector::ShapeCastOp>(
         loc, shaped, threadReduced.value());
     Value accReduction = vector::makeArithReduction(

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -504,9 +504,8 @@ static TypedAttr getCombiningKindIdentity(OpBuilder &builder,
 }
 
 /// Emit identity variable.
-static Value getCombiningIdentityValue(Location loc, OpBuilder &builder,
-                                       vector::CombiningKind kind,
-                                       Type identityType) {
+Value getCombiningIdentityValue(Location loc, OpBuilder &builder,
+                                vector::CombiningKind kind, Type identityType) {
   auto vectorType = llvm::dyn_cast<VectorType>(identityType);
   Type elementType = identityType;
   if (vectorType) {

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -120,6 +120,9 @@ Value packVectorToSupportedWidth(Location loc, OpBuilder &builder, Value input);
 Value unpackToVector(Location loc, OpBuilder &builder, Value packedInput,
                      VectorType targetVecType);
 
+/// Emit identity constant based on combiningKind and type.
+Value getCombiningIdentityValue(Location loc, OpBuilder &builder,
+                                vector::CombiningKind kind, Type identityType);
 //===----------------------------------------------------------------------===//
 // GPU CodeGen op filter
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
The main motivation behind this commit is to fix the numerics issue we find in Attention GPU C++ pipeline. Where our output seems to be some scale off from reference (i.e out = k * ref). Through experiments we determine that the cause of the issue is the multiReducOp distribution, which is required for scaling/merge computation.

Through analyzing of IR and experimentation, reducing the srcVector and non constant accumulator at the same time with another multiDimReduction seems to output numerically wrong values.

This commit fixes numerical issue by refactoring the distribution of multireductionOp to 3 steps. First every thread locally reduce the srcVector it holds with combiningIdentity as localInit. Second, it does a subgroup/warp reduce amongs other threads. Finally, each thread does a local reduction of the intermediate reduced data it has with the accumulator it holds.