### PR TITLE
Remove broken 'if' condition from `linux_arm64_clang` job.

### DIFF
--- a/.github/workflows/ci_linux_arm64_clang.yml
+++ b/.github/workflows/ci_linux_arm64_clang.yml
@@ -28,7 +28,6 @@ jobs:
   # TODO: Switch runs-on labels to use different (non-GCP) self-hosted runners?
   linux_arm64_clang:
     needs: setup
-    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_test_all_arm64')
     runs-on:
       - self-hosted # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}


### PR DESCRIPTION
Hooray for testing in prod.

This should fix the job being skipped: https://github.com/iree-org/iree/actions/runs/10049726682

skip-ci: more testing in prod