### PR TITLE
Fork `build_all.yml` to `ci_linux_x64_clang.yml`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
   ################################### Basic ####################################
   # Jobs that build all of IREE "normally"
   ##############################################################################
+  # TODO(scotttodd): drop this job in favor of ci_linux_x86_clang.yml once no jobs depend on it
   build_all:
     needs: setup
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_all')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
   ################################### Basic ####################################
   # Jobs that build all of IREE "normally"
   ##############################################################################
-  # TODO(scotttodd): drop this job in favor of ci_linux_x86_clang.yml once no jobs depend on it
+  # TODO(scotttodd): drop this job in favor of ci_linux_x64_clang.yml once no jobs depend on it
   build_all:
     needs: setup
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'build_all')

--- a/.github/workflows/ci_linux_x64_clang.yml
+++ b/.github/workflows/ci_linux_x64_clang.yml
@@ -4,14 +4,14 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-name: CI - Linux x86 clang
+name: CI - Linux x64 clang
 
 on:
   pull_request:
     branches:
       - main
     paths:
-      - ".github/workflows/ci_linux_x86_clang.yml"
+      - ".github/workflows/ci_linux_x64_clang.yml"
   schedule:
     # Weekday mornings at 09:15 UTC = 01:15 PST (UTC - 8).
     - cron: "15 9 * * 1-5"
@@ -29,7 +29,7 @@ jobs:
   setup:
     uses: ./.github/workflows/setup.yml
 
-  linux_x86_clang:
+  linux_x64_clang:
     needs: setup
     runs-on:
       - self-hosted # must come first

--- a/.github/workflows/ci_linux_x86_clang.yml
+++ b/.github/workflows/ci_linux_x86_clang.yml
@@ -1,0 +1,68 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+name: CI - Linux x86 clang
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/ci_linux_x86_clang.yml"
+  schedule:
+    # Weekday mornings at 09:15 UTC = 01:15 PST (UTC - 8).
+    - cron: "15 9 * * 1-5"
+  workflow_dispatch:
+
+concurrency:
+  # A PR number if a pull request and otherwise the commit hash. This cancels
+  # queued and in-progress runs for the same PR (presubmit) or commit
+  # (postsubmit). The workflow name is prepended to avoid conflicts between
+  # different workflows.
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  setup:
+    uses: ./.github/workflows/setup.yml
+
+  linux_x86_clang:
+    needs: setup
+    runs-on:
+      - self-hosted # must come first
+      - runner-group=${{ inputs.runner-group }}
+      - environment=${{ inputs.runner-env }}
+      - cpu
+      - os-family=Linux
+    env:
+      BUILD_DIR: build
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@v4.1.7
+        with:
+          submodules: true
+      - name: "Building IREE"
+        env:
+          IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
+            --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
+            --env "CCACHE_NAMESPACE=gcr.io/iree-oss/base@sha256:dc314b4fe30fc1315742512891357bffed4d1b62ffcb46258b1e0761c737b446" \
+            --env "IREE_BUILD_SETUP_PYTHON_VENV=${BUILD_DIR}/.venv" \
+            gcr.io/iree-oss/base@sha256:dc314b4fe30fc1315742512891357bffed4d1b62ffcb46258b1e0761c737b446 \
+            ./build_tools/cmake/build_all.sh \
+            "${BUILD_DIR}"
+      - name: "Testing IREE"
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            gcr.io/iree-oss/base@sha256:dc314b4fe30fc1315742512891357bffed4d1b62ffcb46258b1e0761c737b446 \
+            ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
+      - name: "Testing iree-dialects"
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            gcr.io/iree-oss/base@sha256:dc314b4fe30fc1315742512891357bffed4d1b62ffcb46258b1e0761c737b446 \
+            ./build_tools/cmake/test_iree_dialects.sh "${BUILD_DIR}"

--- a/.github/workflows/ci_linux_x86_clang.yml
+++ b/.github/workflows/ci_linux_x86_clang.yml
@@ -33,8 +33,8 @@ jobs:
     needs: setup
     runs-on:
       - self-hosted # must come first
-      - runner-group=${{ inputs.runner-group }}
-      - environment=${{ inputs.runner-env }}
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
       - cpu
       - os-family=Linux
     env:

--- a/.github/workflows/ci_linux_x86_clang.yml
+++ b/.github/workflows/ci_linux_x86_clang.yml
@@ -38,7 +38,7 @@ jobs:
       - cpu
       - os-family=Linux
     env:
-      BUILD_DIR: build
+      BUILD_DIR: full-build-dir
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@v4.1.7
@@ -54,8 +54,7 @@ jobs:
             --env "CCACHE_NAMESPACE=gcr.io/iree-oss/base@sha256:dc314b4fe30fc1315742512891357bffed4d1b62ffcb46258b1e0761c737b446" \
             --env "IREE_BUILD_SETUP_PYTHON_VENV=${BUILD_DIR}/.venv" \
             gcr.io/iree-oss/base@sha256:dc314b4fe30fc1315742512891357bffed4d1b62ffcb46258b1e0761c737b446 \
-            ./build_tools/cmake/build_all.sh \
-            "${BUILD_DIR}"
+            ./build_tools/cmake/build_all.sh "${BUILD_DIR}"
       - name: "Testing IREE"
         run: |
           ./build_tools/github_actions/docker_run.sh \

--- a/.github/workflows/ci_macos_x64_clang.yml
+++ b/.github/workflows/ci_macos_x64_clang.yml
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-name: CI - macOS x86 clang
+name: CI - macOS x64 clang
 
 on:
   schedule:
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  macos_x86_clang:
+  macos_x64_clang:
     runs-on: macos-13
     env:
       BUILD_DIR: build-macos

--- a/.github/workflows/ci_windows_x64_msvc.yml
+++ b/.github/workflows/ci_windows_x64_msvc.yml
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-name: CI - Windows x86 MSVC
+name: CI - Windows x64 MSVC
 
 on:
   schedule:
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  windows_x86_msvc:
+  windows_x64_msvc:
     runs-on: windows-2022
     defaults:
       run:


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree/issues/16203. Once all jobs in `ci.yml` are migrated to pkgci or their own workflow files this will be the primary "build the compiler and run the compiler tests" workflow/job.

For now I just forked the existing `build_all.yml` workflow, but future cleanup should change how Docker is used here and consider just inlining the `build_all.sh` and `ctest_all.sh` scripts.

skip-ci: adding a new workflow (with its own triggering)