### PR TITLE
[Flow] Extend CollapseDimensionsPass

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/collapse_dimensions.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/collapse_dimensions.mlir
@@ -27,6 +27,7 @@ util.func public @do_not_collapse_cst_in_place(%arg0: tensor<1x1x2304xf32>) {
 
 
 // -----
+
 #map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 #map1 = affine_map<(d0, d1, d2, d3) -> (d1)>
 #map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
@@ -57,3 +58,263 @@ util.func public @unpack_collapse(%arg0: tensor<2x320x128x128xf32>, %arg1: tenso
 // CHECK-LABEL:  util.func public @unpack_collapse
 //       CHECK:    %[[GEN:.+]] = linalg.generic
 //  CHECK-SAME:      tensor<2x320x16384xf32>, tensor<320xf32>, tensor<2x320xf32>, tensor<320xf32>
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d1)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+util.func public @unpack_elementwise_collapse(%arg0: tensor<2x320x128x128xf32>, %arg1: tensor<320xf32>, %arg2: tensor<320xf32>, %arg3: tensor<1x5x2x64xf32>) -> tensor<2x320x128x128xf16> {
+  %0 = flow.dispatch.region -> (tensor<2x320x128x128xf16>) {
+    %1 = tensor.empty() : tensor<2x320xf32>
+    %2 = tensor.empty() : tensor<2x320x128x128xf16>
+    %empty = tensor.empty() : tensor<2x320x128x128xf32>
+    %cst = arith.constant 3.14 : f32
+
+    %elementwise = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%arg0 : tensor<2x320x128x128xf32>) outs(%empty : tensor<2x320x128x128xf32>) {
+    ^bb0(%in : f32, %out : f32):
+      %22 = arith.mulf %cst, %in : f32
+      linalg.yield %22 : f32
+    } -> tensor<2x320x128x128xf32>
+
+    %unpack = tensor.unpack %arg3 outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [2, 64] into %1 : tensor<1x5x2x64xf32> -> tensor<2x320xf32>
+
+    %3 = linalg.generic {indexing_maps = [#map, #map1, #map2, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%elementwise, %arg1, %unpack, %arg2 : tensor<2x320x128x128xf32>, tensor<320xf32>, tensor<2x320xf32>, tensor<320xf32>) outs(%2 : tensor<2x320x128x128xf16>) {
+    ^bb0(%in: f32, %in_0: f32, %in_1: f32, %in_2: f32, %out: f16):
+      %4 = arith.addf %in_1, %in_2 : f32
+      %5 = arith.addf %in, %in_0 : f32
+      %6 = arith.truncf %4 : f32 to f16
+      %7 = arith.truncf %5 : f32 to f16
+      %8 = arith.addf %7, %6 : f16
+      linalg.yield %8 : f16
+    } -> tensor<2x320x128x128xf16>
+    flow.return %3 : tensor<2x320x128x128xf16>
+  }
+  util.return %0 : tensor<2x320x128x128xf16>
+}
+
+// CHECK-LABEL:  util.func public @unpack_elementwise_collapse
+//       CHECK:    %[[ELEMENTWISE:.+]] = linalg.generic
+//  CHECK-SAME:      tensor<2x320x16384xf32>
+//       CHECK:    %[[GEN:.+]] = linalg.generic
+//  CHECK-SAME:      tensor<2x320x16384xf32>, tensor<320xf32>, tensor<2x320xf32>, tensor<320xf32>
+
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d1)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1)>
+util.func public @prevent_collapse(%arg0: tensor<2x320x128x128xf32>, %arg1: tensor<320xf32>, %arg2: tensor<320xf32>, %arg3: tensor<1x5x2x64xf32>) -> tensor<2x320x128x128xf16> {
+  %0 = flow.dispatch.region -> (tensor<2x320x128x128xf16>) {
+    %1 = tensor.empty() : tensor<2x320xf32>
+    %2 = tensor.empty() : tensor<2x320x128x128xf16>
+    %empty = tensor.empty() : tensor<2x320x128x128xf32>
+    %cst = arith.constant 3.14 : f32
+
+    %elementwise = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%arg0 : tensor<2x320x128x128xf32>) outs(%empty : tensor<2x320x128x128xf32>) {
+    ^bb0(%in : f32, %out : f32):
+      %22 = arith.mulf %cst, %in : f32
+      linalg.yield %22 : f32
+    } -> tensor<2x320x128x128xf32>
+
+    %barrier = util.optimization_barrier %elementwise : tensor<2x320x128x128xf32>
+    %unpack = tensor.unpack %arg3 outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [2, 64] into %1 : tensor<1x5x2x64xf32> -> tensor<2x320xf32>
+
+    %3 = linalg.generic {indexing_maps = [#map, #map1, #map2, #map1, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%barrier, %arg1, %unpack, %arg2 : tensor<2x320x128x128xf32>, tensor<320xf32>, tensor<2x320xf32>, tensor<320xf32>) outs(%2 : tensor<2x320x128x128xf16>) {
+    ^bb0(%in: f32, %in_0: f32, %in_1: f32, %in_2: f32, %out: f16):
+      %4 = arith.addf %in_1, %in_2 : f32
+      %5 = arith.addf %in, %in_0 : f32
+      %6 = arith.truncf %4 : f32 to f16
+      %7 = arith.truncf %5 : f32 to f16
+      %8 = arith.addf %7, %6 : f16
+      linalg.yield %8 : f16
+    } -> tensor<2x320x128x128xf16>
+    flow.return %3 : tensor<2x320x128x128xf16>
+  }
+  util.return %0 : tensor<2x320x128x128xf16>
+}
+
+// CHECK-LABEL:  util.func public @prevent_collapse
+//       CHECK:    %[[ELEMENTWISE:.+]] = linalg.generic
+//  CHECK-SAME:      tensor<2x320x128x128xf32>
+//       CHECK:    %[[GEN:.+]] = linalg.generic
+//  CHECK-SAME:      tensor<2x320x128x128xf32>, tensor<320xf32>, tensor<2x320xf32>, tensor<320xf32>
+
+// -----
+
+#map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d3, d4)>
+#map3 = affine_map<(d0, d1, d2, d3, d4) -> (d2, d3, d4)>
+#map4 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
+util.func public @quantized_matmul(%arg0: tensor<4096x32x128xi8>, %arg1: tensor<1x1x32x128xf32>) -> tensor<1x1x4096xf32> {
+  %cst = arith.constant dense_resource<__elided__> : tensor<4096x32xf32>
+  %cst_0 = arith.constant dense_resource<__elided__> : tensor<4096x32xf32>
+  %0 = flow.dispatch.region -> (tensor<1x1x4096xf32>) {
+    %cst_1 = arith.constant 0.000000e+00 : f32
+    %1 = tensor.empty() : tensor<1x1x4096xf32>
+    %2 = tensor.empty() : tensor<4096x32x128xf32>
+    %3 = linalg.fill ins(%cst_1 : f32) outs(%1 : tensor<1x1x4096xf32>) -> tensor<1x1x4096xf32>
+    %4 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg0, %cst, %cst_0 : tensor<4096x32x128xi8>, tensor<4096x32xf32>, tensor<4096x32xf32>) outs(%2 : tensor<4096x32x128xf32>) {
+    ^bb0(%in: i8, %in_2: f32, %in_3: f32, %out: f32):
+      %6 = arith.extui %in : i8 to i32
+      %7 = arith.uitofp %6 : i32 to f32
+      %8 = arith.subf %7, %in_3 : f32
+      %9 = arith.mulf %8, %in_2 : f32
+      linalg.yield %9 : f32
+    } -> tensor<4096x32x128xf32>
+    %5 = linalg.generic {indexing_maps = [#map2, #map3, #map4], iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction"]} ins(%arg1, %4 : tensor<1x1x32x128xf32>, tensor<4096x32x128xf32>) outs(%3 : tensor<1x1x4096xf32>) {
+    ^bb0(%in: f32, %in_2: f32, %out: f32):
+      %6 = arith.mulf %in, %in_2 : f32
+      %7 = arith.addf %6, %out : f32
+      linalg.yield %7 : f32
+    } -> tensor<1x1x4096xf32>
+    flow.return %5 : tensor<1x1x4096xf32>
+  }
+  util.return %0 : tensor<1x1x4096xf32>
+}
+
+// CHECK-LABEL:  util.func public @quantized_matmul
+//       CHECK:    %[[DISPATCH:.+]] = flow.dispatch.region
+//       CHECK:      linalg.generic
+//  CHECK-SAME:          iterator_types = ["parallel", "parallel", "parallel"]
+//       CHECK:      linalg.generic
+//  CHECK-SAME:          iterator_types = ["parallel", "parallel", "reduction", "reduction"]
+//       CHECK:      flow.return
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+util.func public @elementwise_chain(%arg0: tensor<2x320x128x128xf32>) -> tensor<2x320x128x128xf32> {
+  %0 = flow.dispatch.region -> (tensor<2x320x128x128xf32>) {
+    %empty = tensor.empty() : tensor<2x320x128x128xf32>
+    %cst = arith.constant 3.14 : f32
+
+    %elementwise1 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%arg0 : tensor<2x320x128x128xf32>) outs(%empty : tensor<2x320x128x128xf32>) {
+    ^bb0(%in : f32, %out : f32):
+      %22 = arith.mulf %cst, %in : f32
+      linalg.yield %22 : f32
+    } -> tensor<2x320x128x128xf32>
+    %elementwise2 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%elementwise1 : tensor<2x320x128x128xf32>) outs(%empty : tensor<2x320x128x128xf32>) {
+    ^bb0(%in : f32, %out : f32):
+      %22 = arith.mulf %cst, %in : f32
+      linalg.yield %22 : f32
+    } -> tensor<2x320x128x128xf32>
+    %elementwise3 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%elementwise2 : tensor<2x320x128x128xf32>) outs(%empty : tensor<2x320x128x128xf32>) {
+    ^bb0(%in : f32, %out : f32):
+      %22 = arith.mulf %cst, %in : f32
+      linalg.yield %22 : f32
+    } -> tensor<2x320x128x128xf32>
+    %elementwise4 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%elementwise3 : tensor<2x320x128x128xf32>) outs(%empty : tensor<2x320x128x128xf32>) {
+    ^bb0(%in : f32, %out : f32):
+      %22 = arith.mulf %cst, %in : f32
+      linalg.yield %22 : f32
+    } -> tensor<2x320x128x128xf32>
+
+    flow.return %elementwise4 : tensor<2x320x128x128xf32>
+  }
+  util.return %0 : tensor<2x320x128x128xf32>
+}
+
+// CHECK-LABEL:  util.func public @elementwise_chain
+//       CHECK:    iterator_types = ["parallel"]
+//       CHECK:    iterator_types = ["parallel"]
+//       CHECK:    iterator_types = ["parallel"]
+//       CHECK:    iterator_types = ["parallel"]
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+util.func public @elementwise_dag(%arg0: tensor<2x320x128x128xf32>) -> tensor<2x320x128x128xf32> {
+  %0 = flow.dispatch.region -> (tensor<2x320x128x128xf32>) {
+    %empty = tensor.empty() : tensor<2x320x128x128xf32>
+    %cst = arith.constant 3.14 : f32
+
+    %elementwise1 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%arg0 : tensor<2x320x128x128xf32>) outs(%empty : tensor<2x320x128x128xf32>) {
+    ^bb0(%in : f32, %out : f32):
+      %22 = arith.mulf %cst, %in : f32
+      linalg.yield %22 : f32
+    } -> tensor<2x320x128x128xf32>
+    %elementwise2 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%elementwise1 : tensor<2x320x128x128xf32>) outs(%empty : tensor<2x320x128x128xf32>) {
+    ^bb0(%in : f32, %out : f32):
+      %22 = arith.mulf %cst, %in : f32
+      linalg.yield %22 : f32
+    } -> tensor<2x320x128x128xf32>
+    %elementwise3 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%elementwise1 : tensor<2x320x128x128xf32>) outs(%empty : tensor<2x320x128x128xf32>) {
+    ^bb0(%in : f32, %out : f32):
+      %22 = arith.mulf %cst, %in : f32
+      linalg.yield %22 : f32
+    } -> tensor<2x320x128x128xf32>
+    %elementwise4 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%elementwise3, %elementwise2 : tensor<2x320x128x128xf32>, tensor<2x320x128x128xf32>) outs(%empty : tensor<2x320x128x128xf32>) {
+    ^bb0(%in : f32, %in_1 : f32, %out : f32):
+      %22 = arith.mulf %in_1, %in : f32
+      linalg.yield %22 : f32
+    } -> tensor<2x320x128x128xf32>
+
+    flow.return %elementwise4 : tensor<2x320x128x128xf32>
+  }
+  util.return %0 : tensor<2x320x128x128xf32>
+}
+
+// CHECK-LABEL:  util.func public @elementwise_dag
+//       CHECK:    iterator_types = ["parallel"]
+//       CHECK:    iterator_types = ["parallel"]
+//       CHECK:    iterator_types = ["parallel"]
+//       CHECK:    iterator_types = ["parallel"]
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3, d2)>
+util.func public @elementwise_dag_transpose(%arg0: tensor<2x320x128x128xf32>) -> tensor<2x320x128x128xf32> {
+  %0 = flow.dispatch.region -> (tensor<2x320x128x128xf32>) {
+    %empty = tensor.empty() : tensor<2x320x128x128xf32>
+    %cst = arith.constant 3.14 : f32
+
+    // Check that reducing dims propagates more than 1 op away
+    %elementwise0 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%arg0 : tensor<2x320x128x128xf32>) outs(%empty : tensor<2x320x128x128xf32>) {
+    ^bb0(%in : f32, %out : f32):
+      %22 = arith.mulf %cst, %in : f32
+      linalg.yield %22 : f32
+    } -> tensor<2x320x128x128xf32>
+    %elementwise1 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%elementwise0: tensor<2x320x128x128xf32>) outs(%empty : tensor<2x320x128x128xf32>) {
+    ^bb0(%in : f32, %out : f32):
+      %22 = arith.mulf %cst, %in : f32
+      linalg.yield %22 : f32
+    } -> tensor<2x320x128x128xf32>
+    %elementwise2 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%elementwise1 : tensor<2x320x128x128xf32>) outs(%empty : tensor<2x320x128x128xf32>) {
+    ^bb0(%in : f32, %out : f32):
+      %22 = arith.mulf %cst, %in : f32
+      linalg.yield %22 : f32
+    } -> tensor<2x320x128x128xf32>
+    %elementwise3 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%elementwise1 : tensor<2x320x128x128xf32>) outs(%empty : tensor<2x320x128x128xf32>) {
+    ^bb0(%in : f32, %out : f32):
+      %22 = arith.mulf %cst, %in : f32
+      linalg.yield %22 : f32
+    } -> tensor<2x320x128x128xf32>
+    %elementwise4 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%elementwise3, %elementwise2 : tensor<2x320x128x128xf32>, tensor<2x320x128x128xf32>) outs(%empty : tensor<2x320x128x128xf32>) {
+    ^bb0(%in : f32, %in_1 : f32, %out : f32):
+      %22 = arith.mulf %in_1, %in : f32
+      linalg.yield %22 : f32
+    } -> tensor<2x320x128x128xf32>
+
+    // Check that reducing dims propagates more than 1 op away
+    %elementwise5 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%elementwise4 : tensor<2x320x128x128xf32>) outs(%empty : tensor<2x320x128x128xf32>) {
+    ^bb0(%in : f32, %out : f32):
+      %22 = arith.mulf %cst, %in : f32
+      linalg.yield %22 : f32
+    } -> tensor<2x320x128x128xf32>
+
+    flow.return %elementwise5 : tensor<2x320x128x128xf32>
+  }
+  util.return %0 : tensor<2x320x128x128xf32>
+}
+
+// CHECK-LABEL:  util.func public @elementwise_dag_transpose
+//       CHECK:    iterator_types = ["parallel", "parallel", "parallel"]
+//       CHECK:    iterator_types = ["parallel", "parallel", "parallel"]
+//       CHECK:    iterator_types = ["parallel", "parallel", "parallel"]
+//       CHECK:    iterator_types = ["parallel", "parallel", "parallel"]
+//       CHECK:    iterator_types = ["parallel", "parallel", "parallel"]
+//       CHECK:    iterator_types = ["parallel", "parallel", "parallel"]

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/collapse_linalg_generic_on_tensors.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/collapse_linalg_generic_on_tensors.mlir
@@ -507,51 +507,6 @@ util.func public @input_broadcast(%arg0: tensor<4x8xf32>, %arg1: tensor<4xf32>) 
 
 // -----
 
-// Do nothing if the dispatch is not a single elementwise op (with tensor.empty/linalg.fill producers)
-
-#map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
-#map1 = affine_map<(d0, d1, d2) -> (d0, d1)>
-#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d3, d4)>
-#map3 = affine_map<(d0, d1, d2, d3, d4) -> (d2, d3, d4)>
-#map4 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
-util.func public @quantized_matmul(%arg0: tensor<4096x32x128xi8>, %arg1: tensor<1x1x32x128xf32>) -> tensor<1x1x4096xf32> {
-  %cst = arith.constant dense_resource<__elided__> : tensor<4096x32xf32>
-  %cst_0 = arith.constant dense_resource<__elided__> : tensor<4096x32xf32>
-  %0 = flow.dispatch.region -> (tensor<1x1x4096xf32>) {
-    %cst_1 = arith.constant 0.000000e+00 : f32
-    %1 = tensor.empty() : tensor<1x1x4096xf32>
-    %2 = tensor.empty() : tensor<4096x32x128xf32>
-    %3 = linalg.fill ins(%cst_1 : f32) outs(%1 : tensor<1x1x4096xf32>) -> tensor<1x1x4096xf32>
-    %4 = linalg.generic {indexing_maps = [#map, #map1, #map1, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg0, %cst, %cst_0 : tensor<4096x32x128xi8>, tensor<4096x32xf32>, tensor<4096x32xf32>) outs(%2 : tensor<4096x32x128xf32>) {
-    ^bb0(%in: i8, %in_2: f32, %in_3: f32, %out: f32):
-      %6 = arith.extui %in : i8 to i32
-      %7 = arith.uitofp %6 : i32 to f32
-      %8 = arith.subf %7, %in_3 : f32
-      %9 = arith.mulf %8, %in_2 : f32
-      linalg.yield %9 : f32
-    } -> tensor<4096x32x128xf32>
-    %5 = linalg.generic {indexing_maps = [#map2, #map3, #map4], iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction"]} ins(%arg1, %4 : tensor<1x1x32x128xf32>, tensor<4096x32x128xf32>) outs(%3 : tensor<1x1x4096xf32>) {
-    ^bb0(%in: f32, %in_2: f32, %out: f32):
-      %6 = arith.mulf %in, %in_2 : f32
-      %7 = arith.addf %6, %out : f32
-      linalg.yield %7 : f32
-    } -> tensor<1x1x4096xf32>
-    flow.return %5 : tensor<1x1x4096xf32>
-  }
-  util.return %0 : tensor<1x1x4096xf32>
-}
-
-// CHECK-LABEL:  util.func public @quantized_matmul
-//       CHECK:    %[[DISPATCH:.+]] = flow.dispatch.region
-//       CHECK:      linalg.generic
-//  CHECK-SAME:          iterator_types = ["parallel", "parallel", "parallel"]
-//       CHECK:      linalg.generic
-//  CHECK-SAME:          iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction"]
-//       CHECK:      flow.return
-//       CHECK:    util.return %[[DISPATCH]]
-
-// -----
-
 util.func public @batchnorm_failure_repro(%arg0 : tensor<2x4xf32>, %arg1 : tensor<4xf32>) -> tensor<2x4xf32> {
   %0 = tensor.empty() : tensor<2x4xf32>
   %1 = linalg.generic {


### PR DESCRIPTION
iree-flow-collapse-dimensions is currently very limited. The pass doenst support propagating collapse of dimensions through multiple operations.  This adds support to collapsing dimensions through chains of operations.

Also, this will need to be disabled in the specific case of softmax fusion since there is a backend bug (https://github.com/iree-org/iree/issues/17948).