### PR TITLE
allow quant/dequant to form own dispatches

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
@@ -874,7 +874,7 @@ decideFusableLinalgOps(Region &region, DominanceInfo const &dominanceInfo,
       // materializing large tensors between dispatches.
       if (!isa<linalg::LinalgOp, tensor::PadOp, tensor::PackOp,
                IREE::Encoding::SetEncodingOp>(op) ||
-          isa<linalg::FillOp>(op) || isBitExtendOp(&op)) {
+          isa<linalg::FillOp>(op)) {
         continue;
       }
 


### PR DESCRIPTION
- Need this to compile quantised models with fail with `large vector sizes`
- This is only proposed as an alternative (may not be a viable one) until we figure out how to fuse dequant with pool_sum
 