### PR TITLE
Refactor pkgci scripting and ctest to enable more flexible package testing.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
               --env IREE_CUDA_DISABLE \
               --env IREE_HIP_DISABLE \
               gcr.io/iree-oss/nvidia@sha256:433e072f075f90fdf07471673626b17091d8d8e2395626f1e6ac6c98803c8807 \
-              ./build_tools/pkgci/build_tests_using_package.sh ${INSTALL_DIR}
+              ./build_tools/pkgci/build_tests_using_package.sh ${INSTALL_DIR}/bin
       - name: "Running GPU tests"
         env:
           IREE_CTEST_LABEL_REGEX: ^requires-gpu|^driver=vulkan$|^driver=cuda$
@@ -192,7 +192,7 @@ jobs:
   #             --env IREE_CUDA_DISABLE \
   #             --env IREE_HIP_DISABLE \
   #             gcr.io/iree-oss/nvidia@sha256:433e072f075f90fdf07471673626b17091d8d8e2395626f1e6ac6c98803c8807 \
-  #             ./build_tools/pkgci/build_tests_using_package.sh ${INSTALL_DIR}
+  #             ./build_tools/pkgci/build_tests_using_package.sh ${INSTALL_DIR}/bin
   #     - name: "Running GPU tests"
   #       env:
   #         IREE_CTEST_LABEL_REGEX: ^requires-gpu-sm80|^requires-gpu|^driver=vulkan$|^driver=cuda$
@@ -242,7 +242,7 @@ jobs:
         run: tar -xf "${INSTALL_DIR_ARCHIVE}"
       - name: "Building tests"
         run: |
-          ./build_tools/pkgci/build_tests_using_package.sh ${INSTALL_DIR}
+          ./build_tools/pkgci/build_tests_using_package.sh ${INSTALL_DIR}/bin
       - name: "Running GPU tests"
         env:
           IREE_CTEST_LABEL_REGEX: ^requires-gpu|^driver=hip$
@@ -286,7 +286,7 @@ jobs:
         run: tar -xf "${INSTALL_DIR_ARCHIVE}"
       - name: "Building tests"
         run: |
-          ./build_tools/pkgci/build_tests_using_package.sh ${INSTALL_DIR}
+          ./build_tools/pkgci/build_tests_using_package.sh ${INSTALL_DIR}/bin
       - name: "Running GPU tests"
         env:
           IREE_CTEST_LABEL_REGEX: ^requires-gpu|^driver=hip$
@@ -325,7 +325,7 @@ jobs:
         run: tar -xf "${INSTALL_DIR_ARCHIVE}"
       - name: "Building tests"
         run: |
-          ./build_tools/pkgci/build_tests_using_package.sh ${INSTALL_DIR}
+          ./build_tools/pkgci/build_tests_using_package.sh ${INSTALL_DIR}/bin
       - name: "Running GPU tests"
         env:
           CTEST_PARALLEL_LEVEL: 1

--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -211,6 +211,7 @@ function(iree_check_test)
         "--module={{${_MODULE_FILE_NAME}}}"
         ${_RULE_RUNNER_ARGS}
       LABELS
+        "test-type=check-test"
         ${_RULE_LABELS}
       TIMEOUT
         ${_RULE_TIMEOUT}

--- a/build_tools/cmake/iree_lit_test.cmake
+++ b/build_tools/cmake/iree_lit_test.cmake
@@ -18,8 +18,8 @@ include(CMakeParseArguments)
 # TOOLS: Tools that should be included on the PATH
 # DATA: Additional data dependencies invoked by the test (e.g. binaries
 #   called in the RUN line)
-# LABELS: Additional labels to apply to the test. The package path is added
-#     automatically.
+# LABELS: Additional labels to apply to the test. Package path and
+#     "test-type=lit-test" labels are added automatically.
 function(iree_lit_test)
   if(NOT IREE_BUILD_TESTS)
     return()
@@ -75,6 +75,7 @@ function(iree_lit_test)
   )
 
   list(APPEND _RULE_LABELS "${_PACKAGE_PATH}")
+  list(APPEND _RULE_LABELS "test-type=lit-test")
   set_property(TEST ${_NAME_PATH} PROPERTY LABELS "${_RULE_LABELS}")
   set_property(TEST ${_NAME_PATH} PROPERTY REQUIRED_FILES "${_TEST_FILE_PATH}")
   set_property(TEST ${_NAME_PATH} PROPERTY ENVIRONMENT

--- a/build_tools/cmake/iree_run_module_test.cmake
+++ b/build_tools/cmake/iree_run_module_test.cmake
@@ -27,8 +27,9 @@ endfunction()
 #   EXPECTED_OUTPUT: A string representing the expected output from executing
 #       the module in the format accepted by `iree-run-module` or a file
 #       containing the same. Can also be an HTTPS URL to download large npy.
-#   LABELS: Additional labels to apply to the test. The package path and
-#       "driver=${DRIVER}" are added automatically.
+#   LABELS: Additional labels to apply to the test. The package path,
+#       "test-type=run-module-test", and "driver=${DRIVER}" labels are added
+#       automatically.
 #   XFAIL_PLATFORMS: List of platforms (see iree_get_platform) for which the
 #       test is expected to fail. The test pass/fail status is inverted.
 #   UNSUPPORTED_PLATFORMS: List of platforms (see iree_get_platform) for which

--- a/build_tools/pkgci/build_tests_using_package.sh
+++ b/build_tools/pkgci/build_tests_using_package.sh
@@ -27,7 +27,7 @@
 set -xeuo pipefail
 
 
-PACKAGE_DIR="$1"
+BINARY_DIR="$1"
 BUILD_DIR="${BUILD_DIR:-build-tests}"
 
 source build_tools/scripts/install_lit.sh
@@ -76,7 +76,7 @@ cmake_args=(
   "-DIREE_BUILD_PYTHON_BINDINGS=OFF"
   "-DIREE_BUILD_COMPILER=OFF"
   "-DIREE_BUILD_ALL_CHECK_TEST_MODULES=OFF"
-  "-DIREE_HOST_BIN_DIR=${PACKAGE_DIR?}/bin"
+  "-DIREE_HOST_BIN_DIR=${BINARY_DIR?}"
   "-DLLVM_EXTERNAL_LIT=${LLVM_EXTERNAL_LIT?}"
 )
 cmake_args+=(${cmake_config_options[@]})


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree/issues/16203.

## Context

I'm trying to move the `test_[gpu_vendor]_[model]` CI jobs (e.g. `test_amd_mi250`) in [`ci.yml`](https://github.com/iree-org/iree/blob/main/.github/workflows/ci.yml) over to [`pkgci.yml`](https://github.com/iree-org/iree/blob/main/.github/workflows/pkgci.yml). These jobs build the runtime portions of the project using CMake and currently use the "install directory" from the `build_all` job.

## Changes

* Pass binary directory to `build_tests_using_package.sh` for easier substitutions, instead of "package" (really "install") directory
  * This matches the `IREE_HOST_BIN_DIR` CMake variable
  * Some might recall that we used to have a `IREE_HOST_BINARY_ROOT` CMake variable (we still do, but it is deprecated) that inferred the `/bin` subdirectory
* Add "test-type=lit-test" and "test-type=check-test" labels
  * This allows test runs to exclude tests based on that label. Excluding by label may be used as a short term measure to ease in the migration. Longer term, any "package tests" should be using separate CMake projects or other test runners like pytest.