### PR TITLE
Test vmvx instead of vulkan-spirv for multiple target_backends test in `compiler_core_test.py`.

### DIFF
--- a/compiler/bindings/python/test/tools/compiler_core_test.py
+++ b/compiler/bindings/python/test/tools/compiler_core_test.py
@@ -60,7 +60,7 @@ class CompilerTest(unittest.TestCase):
     # See: https://github.com/iree-org/iree/issues/4436
     def testCompileMultipleBackends(self):
         binary = iree.compiler.tools.compile_str(
-            SIMPLE_MUL_ASM, target_backends=["llvm-cpu", "vulkan-spirv"]
+            SIMPLE_MUL_ASM, target_backends=["llvm-cpu", "vmvx"]
         )
         logging.info("Flatbuffer size = %d", len(binary))
         self.assertTrue(binary)


### PR DESCRIPTION
Thus, we could build iree without any gpu related targets.

e.g.
use cmake with:
```
  "-DIREE_TARGET_BACKEND_CUDA=OFF"
  "-DIREE_TARGET_BACKEND_METAL_SPIRV=OFF"
  "-DIREE_TARGET_BACKEND_ROCM=OFF"
  "-DIREE_TARGET_BACKEND_VULKAN_SPIRV=OFF"
  "-DIREE_TARGET_BACKEND_WEBGPU_SPIRV=OFF"
  "-DIREE_HAL_DRIVER_CUDA=OFF"
  "-DIREE_HAL_DRIVER_HIP=OFF"
  "-DIREE_HAL_DRIVER_METAL=OFF"
  "-DIREE_HAL_DRIVER_VULKAN=OFF"
```