### PR TITLE
use tile 16

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -1751,7 +1751,7 @@ static LogicalResult setConvolutionConfig(IREE::GPU::TargetAttr target,
   if (isNCHW)
     workgroupTileSizes.append({4, 1, 1});
   else if (isNHWC)
-    workgroupTileSizes.append({1, 1, 4});
+    workgroupTileSizes.append({1, 1, 16});
   tileSizes.push_back(workgroupTileSizes);
 
   // Tile along OH by size 1 to enable downsizing 2-D convolution to 1-D.


### PR DESCRIPTION
It works for two convolution kernels with a stride of -2 (conv_2d_nhwc_hwcf_2x32x32x640x3x3x640 and conv_2d_nhwc_hwcf_2x64x64x320x3x3x320), which pass through the LLVM GPU Vectorize pipeline.