### PR TITLE
Integrate LLVM at 25efb746

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy_pad.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy_pad.mlir
@@ -75,7 +75,7 @@ module {
 //       CHECK:   transform.memref.erase_dead_alloc_and_stores {{.*}} : (!transform.any_op) -> ()
 //       CHECK:   {{.*}} = transform.structured.match ops{["func.func"]} in {{.*}} : (!transform.any_op) -> !transform.any_op
 //       CHECK:   transform.iree.forall_to_workgroup {{.*}} : (!transform.any_op) -> ()
-//       CHECK:   transform.iree.map_nested_forall_to_gpu_threads {{.*}} workgroup_dims = [16, 16, 1] subgroup_size = 32 sync_after_distribution = true : (!transform.any_op) -> ()
+//       CHECK:   transform.iree.map_nested_forall_to_gpu_threads {{.*}} workgroup_dims = [16, 16, 1] {{.*}}: (!transform.any_op) -> ()
 //       CHECK:     transform.apply_patterns.vector.lower_masks
 //       CHECK:     transform.apply_patterns.vector.materialize_masks
 //       CHECK:   apply_patterns to %{{.*}} {


### PR DESCRIPTION
Advance to https://github.com/llvm/llvm-project/commit/25efb746

Existing local patches carried over:
* Still carrying a revert of https://github.com/llvm/llvm-project/commit/f6431f0c
* Still carrying a revert of https://github.com/llvm/llvm-project/commit/fa066687
* Still carrying a revert of https://github.com/llvm/llvm-project/commit/bbd4af5d

