### PR TITLE
[VectorDistribution] Use to_layout operation to set anchors instead of attributes

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_contract_amdgpu.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_contract_amdgpu.mlir
@@ -43,17 +43,19 @@
 >
 
 func.func @contract_to_mfma_32x32x8_mm(%a : vector<32x8xf16>, %b : vector<8x32xf16>, %c : vector<32x32xf32>) -> vector<32x32xf32> {
+  %A = iree_vector_ext.to_layout %a to #layout_a : vector<32x8xf16>
+  %B = iree_vector_ext.to_layout %b to #layout_b : vector<8x32xf16>
+  %C = iree_vector_ext.to_layout %c to #layout_c : vector<32x32xf32>
+
   %output = vector.contract {
     indexing_maps = [#map1, #map2, #map3],
     iterator_types = ["parallel", "parallel", "reduction"],
     kind = #vector.kind<add>,
-    iree.amdgpu.mma = #iree_gpu.mma_layout<MFMA_F16_32x32x8_F32>,
-    "__vector_layout_test_anchor_operand_0" = #layout_a,
-    "__vector_layout_test_anchor_operand_1" = #layout_b,
-    "__vector_layout_test_anchor_operand_2" = #layout_c,
-    "__vector_layout_test_anchor_result_0" = #layout_c
-  } %a, %b, %c : vector<32x8xf16>, vector<8x32xf16> into vector<32x32xf32>
-  return %output : vector<32x32xf32>
+    iree.amdgpu.mma = #iree_gpu.mma_layout<MFMA_F16_32x32x8_F32>
+  } %A, %B, %C : vector<32x8xf16>, vector<8x32xf16> into vector<32x32xf32>
+
+  %O = iree_vector_ext.to_layout %output to #layout_c : vector<32x32xf32>
+  return %O : vector<32x32xf32>
 }
 
 builtin.module attributes { transform.with_named_sequence } {
@@ -118,17 +120,19 @@ builtin.module attributes { transform.with_named_sequence } {
 // C: shape = 16x16, layout = layoutB
 
 func.func @contract_to_mfma_16x16x16_mm(%a : vector<16x16xf16>, %b : vector<16x16xf16>, %c : vector<16x16xf32>) -> vector<16x16xf32> {
+  %A = iree_vector_ext.to_layout %a to #layout_a : vector<16x16xf16>
+  %B = iree_vector_ext.to_layout %b to #layout_b : vector<16x16xf16>
+  %C = iree_vector_ext.to_layout %c to #layout_b : vector<16x16xf32>
+
   %output = vector.contract {
     indexing_maps = [#map1, #map2, #map3],
     iterator_types = ["parallel", "parallel", "reduction"],
     kind = #vector.kind<add>,
-    iree.amdgpu.mma = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>,
-    "__vector_layout_test_anchor_operand_0" = #layout_a,
-    "__vector_layout_test_anchor_operand_1" = #layout_b,
-    "__vector_layout_test_anchor_operand_2" = #layout_b,
-    "__vector_layout_test_anchor_result_0" = #layout_b
-  } %a, %b, %c : vector<16x16xf16>, vector<16x16xf16> into vector<16x16xf32>
-  return %output : vector<16x16xf32>
+    iree.amdgpu.mma = #iree_gpu.mma_layout<MFMA_F16_16x16x16_F32>
+  } %A, %B, %C : vector<16x16xf16>, vector<16x16xf16> into vector<16x16xf32>
+
+  %O = iree_vector_ext.to_layout %output to #layout_b : vector<16x16xf32>
+  return %O : vector<16x16xf32>
 }
 
 builtin.module attributes { transform.with_named_sequence } {
@@ -204,17 +208,19 @@ builtin.module attributes { transform.with_named_sequence } {
 >
 
 func.func @contract_to_mfma_32x32x8_mm_mnbatch(%a : vector<64x8xf16>, %b : vector<8x32xf16>, %c : vector<64x32xf32>) -> vector<64x32xf32> {
+  %A = iree_vector_ext.to_layout %a to #layout_a : vector<64x8xf16>
+  %B = iree_vector_ext.to_layout %b to #layout_b : vector<8x32xf16>
+  %C = iree_vector_ext.to_layout %c to #layout_c : vector<64x32xf32>
+
   %output = vector.contract {
     indexing_maps = [#map1, #map2, #map3],
     iterator_types = ["parallel", "parallel", "reduction"],
     kind = #vector.kind<add>,
-    iree.amdgpu.mma = #iree_gpu.mma_layout<MFMA_F16_32x32x8_F32>,
-    "__vector_layout_test_anchor_operand_0" = #layout_a,
-    "__vector_layout_test_anchor_operand_1" = #layout_b,
-    "__vector_layout_test_anchor_operand_2" = #layout_c,
-    "__vector_layout_test_anchor_result_0" = #layout_c
-  } %a, %b, %c : vector<64x8xf16>, vector<8x32xf16> into vector<64x32xf32>
-  return %output : vector<64x32xf32>
+    iree.amdgpu.mma = #iree_gpu.mma_layout<MFMA_F16_32x32x8_F32>
+  } %A, %B, %C : vector<64x8xf16>, vector<8x32xf16> into vector<64x32xf32>
+
+  %O = iree_vector_ext.to_layout %output to #layout_c : vector<64x32xf32>
+  return %O : vector<64x32xf32>
 }
 
 builtin.module attributes { transform.with_named_sequence } {
@@ -291,17 +297,19 @@ builtin.module attributes { transform.with_named_sequence } {
 >
 
 func.func @contract_to_mfma_32x32x8_mm_kbatch(%a : vector<32x16xf16>, %b : vector<16x32xf16>, %c : vector<32x32xf32>) -> vector<32x32xf32> {
+  %A = iree_vector_ext.to_layout %a to #layout_a : vector<32x16xf16>
+  %B = iree_vector_ext.to_layout %b to #layout_b : vector<16x32xf16>
+  %C = iree_vector_ext.to_layout %c to #layout_c : vector<32x32xf32>
+
   %output = vector.contract {
     indexing_maps = [#map1, #map2, #map3],
     iterator_types = ["parallel", "parallel", "reduction"],
     kind = #vector.kind<add>,
-    iree.amdgpu.mma = #iree_gpu.mma_layout<MFMA_F16_32x32x8_F32>,
-    "__vector_layout_test_anchor_operand_0" = #layout_a,
-    "__vector_layout_test_anchor_operand_1" = #layout_b,
-    "__vector_layout_test_anchor_operand_2" = #layout_c,
-    "__vector_layout_test_anchor_result_0" = #layout_c
-  } %a, %b, %c : vector<32x16xf16>, vector<16x32xf16> into vector<32x32xf32>
-  return %output : vector<32x32xf32>
+    iree.amdgpu.mma = #iree_gpu.mma_layout<MFMA_F16_32x32x8_F32>
+  } %A, %B, %C : vector<32x16xf16>, vector<16x32xf16> into vector<32x32xf32>
+
+  %O = iree_vector_ext.to_layout %output to #layout_c : vector<32x32xf32>
+  return %O : vector<32x32xf32>
 }
 
 builtin.module attributes { transform.with_named_sequence } {
@@ -372,17 +380,19 @@ builtin.module attributes { transform.with_named_sequence } {
 >
 
 func.func @contract_to_mfma_32x32x8_mm_mnbatch_order(%a : vector<64x8xf16>, %b : vector<8x96xf16>, %c : vector<64x96xf32>) -> vector<64x96xf32> {
+  %A = iree_vector_ext.to_layout %a to #layout_a : vector<64x8xf16>
+  %B = iree_vector_ext.to_layout %b to #layout_b : vector<8x96xf16>
+  %C = iree_vector_ext.to_layout %c to #layout_c : vector<64x96xf32>
+
   %output = vector.contract {
     indexing_maps = [#map1, #map2, #map3],
     iterator_types = ["parallel", "parallel", "reduction"],
     kind = #vector.kind<add>,
-    iree.amdgpu.mma = #iree_gpu.mma_layout<MFMA_F16_32x32x8_F32>,
-    "__vector_layout_test_anchor_operand_0" = #layout_a,
-    "__vector_layout_test_anchor_operand_1" = #layout_b,
-    "__vector_layout_test_anchor_operand_2" = #layout_c,
-    "__vector_layout_test_anchor_result_0" = #layout_c
-  } %a, %b, %c : vector<64x8xf16>, vector<8x96xf16> into vector<64x96xf32>
-  return %output : vector<64x96xf32>
+    iree.amdgpu.mma = #iree_gpu.mma_layout<MFMA_F16_32x32x8_F32>
+  } %A, %B, %C : vector<64x8xf16>, vector<8x96xf16> into vector<64x96xf32>
+
+  %O = iree_vector_ext.to_layout %output to #layout_c : vector<64x96xf32>
+  return %O : vector<64x96xf32>
 }
 
 builtin.module attributes { transform.with_named_sequence } {
@@ -461,17 +471,19 @@ builtin.module attributes { transform.with_named_sequence } {
 >
 
 func.func @contract_to_mfma_32x32x8_mmt(%a : vector<32x8xf16>, %b : vector<64x8xf16>, %c : vector<32x64xf32>) -> vector<32x64xf32> {
+  %A = iree_vector_ext.to_layout %a to #layout_a : vector<32x8xf16>
+  %B = iree_vector_ext.to_layout %b to #layout_b : vector<64x8xf16>
+  %C = iree_vector_ext.to_layout %c to #layout_c : vector<32x64xf32>
+
   %output = vector.contract {
     indexing_maps = [#map1, #map2, #map3],
     iterator_types = ["parallel", "parallel", "reduction"],
     kind = #vector.kind<add>,
-    iree.amdgpu.mma = #iree_gpu.mma_layout<MFMA_F16_32x32x8_F32>,
-    "__vector_layout_test_anchor_operand_0" = #layout_a,
-    "__vector_layout_test_anchor_operand_1" = #layout_b,
-    "__vector_layout_test_anchor_operand_2" = #layout_c,
-    "__vector_layout_test_anchor_result_0" = #layout_c
-  } %a, %b, %c : vector<32x8xf16>, vector<64x8xf16> into vector<32x64xf32>
-  return %output : vector<32x64xf32>
+    iree.amdgpu.mma = #iree_gpu.mma_layout<MFMA_F16_32x32x8_F32>
+  } %A, %B, %C : vector<32x8xf16>, vector<64x8xf16> into vector<32x64xf32>
+
+  %O = iree_vector_ext.to_layout %output to #layout_c : vector<32x64xf32>
+  return %O : vector<32x64xf32>
 }
 
 builtin.module attributes { transform.with_named_sequence } {
@@ -538,17 +550,19 @@ builtin.module attributes { transform.with_named_sequence } {
 >
 
 func.func @contract_to_wmma_16x16x16_mm(%a : vector<16x16xf16>, %b : vector<16x16xf16>, %c : vector<16x16xf32>) -> vector<16x16xf32> {
+  %A = iree_vector_ext.to_layout %a to #layout_a : vector<16x16xf16>
+  %B = iree_vector_ext.to_layout %b to #layout_b : vector<16x16xf16>
+  %C = iree_vector_ext.to_layout %c to #layout_c : vector<16x16xf32>
+
   %output = vector.contract {
     indexing_maps = [#map1, #map2, #map3],
     iterator_types = ["parallel", "parallel", "reduction"],
     kind = #vector.kind<add>,
-    iree.amdgpu.mma = #iree_gpu.mma_layout<WMMA_F16_16x16x16_F32>,
-    "__vector_layout_test_anchor_operand_0" = #layout_a,
-    "__vector_layout_test_anchor_operand_1" = #layout_b,
-    "__vector_layout_test_anchor_operand_2" = #layout_c,
-    "__vector_layout_test_anchor_result_0" = #layout_c
-  } %a, %b, %c : vector<16x16xf16>, vector<16x16xf16> into vector<16x16xf32>
-  return %output : vector<16x16xf32>
+    iree.amdgpu.mma = #iree_gpu.mma_layout<WMMA_F16_16x16x16_F32>
+  } %A, %B, %C : vector<16x16xf16>, vector<16x16xf16> into vector<16x16xf32>
+
+  %O = iree_vector_ext.to_layout %output to #layout_c : vector<16x16xf32>
+  return %O : vector<16x16xf32>
 }
 
 builtin.module attributes { transform.with_named_sequence } {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
@@ -18,11 +18,10 @@
 func.func @distribute_transfer_read_col_major(%arg0: memref<32x32xf16>) -> vector<16x16xf16> {
   %c0 = arith.constant 0 : index
   %cst = arith.constant 0.0 : f16
-  %root = vector.transfer_read %arg0[%c0, %c0], %cst
-          {in_bounds = [true, true],
-           "__vector_layout_test_anchor_result_0" = #layout_col_major}
+  %root = vector.transfer_read %arg0[%c0, %c0], %cst {in_bounds = [true, true]}
                   : memref<32x32xf16>, vector<16x16xf16>
-  func.return %root : vector<16x16xf16>
+  %rootl = iree_vector_ext.to_layout %root to #layout_col_major : vector<16x16xf16>
+  func.return %rootl : vector<16x16xf16>
 }
 
 builtin.module attributes { transform.with_named_sequence } {
@@ -65,10 +64,10 @@ func.func @distribute_transfer_read_row_major_with_nontrivial_index(%a: index, %
   %cst = arith.constant 0.0 : f16
   %root = vector.transfer_read %arg0[%c0, %c0, %a, %b], %cst
           {in_bounds = [true, true],
-           permutation_map = affine_map<(d0, d1, d2, d3) -> (d2, d3)>,
-           "__vector_layout_test_anchor_result_0" = #layout_row_major}
+           permutation_map = affine_map<(d0, d1, d2, d3) -> (d2, d3)>}
                   : memref<32x32x32x32xf16>, vector<16x16xf16>
-  func.return %root : vector<16x16xf16>
+  %rootl = iree_vector_ext.to_layout %root to #layout_row_major : vector<16x16xf16>
+  func.return %rootl : vector<16x16xf16>
 }
 
 builtin.module attributes { transform.with_named_sequence } {
@@ -108,10 +107,10 @@ func.func @distribute_transfer_read_col_major_with_broadcast(%a: index, %b: inde
   %cst = arith.constant 0.0 : f16
   %root = vector.transfer_read %arg0[%c0, %c0, %a, %b], %cst
           {in_bounds = [true, true],
-           permutation_map = affine_map<(d0, d1, d2, d3) -> (0, 0)>,
-           "__vector_layout_test_anchor_result_0" = #layout_col_major}
+           permutation_map = affine_map<(d0, d1, d2, d3) -> (0, 0)>}
                   : memref<32x32x32x32xf16>, vector<16x16xf16>
-  func.return %root : vector<16x16xf16>
+  %rootl = iree_vector_ext.to_layout %root to #layout_col_major : vector<16x16xf16>
+  func.return %rootl : vector<16x16xf16>
 }
 
 builtin.module attributes { transform.with_named_sequence } {
@@ -154,10 +153,10 @@ func.func @distribute_transfer_read_row_major_transpose(%a: index, %b: index, %a
   %cst = arith.constant 0.0 : f16
   %root = vector.transfer_read %arg0[%c0, %c0, %a, %b], %cst
           {in_bounds = [true, true],
-           permutation_map = affine_map<(d0, d1, d2, d3) -> (d3, d2)>,
-           "__vector_layout_test_anchor_result_0" = #layout_row_major}
+           permutation_map = affine_map<(d0, d1, d2, d3) -> (d3, d2)>}
                   : memref<32x32x32x32xf16>, vector<16x16xf16>
-  func.return %root : vector<16x16xf16>
+  %rootl = iree_vector_ext.to_layout %root to #layout_row_major : vector<16x16xf16>
+  func.return %rootl : vector<16x16xf16>
 }
 
 builtin.module attributes { transform.with_named_sequence } {
@@ -201,10 +200,10 @@ func.func @distribute_transfer_read_col_major_transpose(%a: index, %b: index, %a
   %cst = arith.constant 0.0 : f16
   %root = vector.transfer_read %arg0[%c0, %c0, %a, %b], %cst
           {in_bounds = [true, true],
-           permutation_map = affine_map<(d0, d1, d2, d3) -> (d3, d2)>,
-           "__vector_layout_test_anchor_result_0" = #layout_col_major}
+           permutation_map = affine_map<(d0, d1, d2, d3) -> (d3, d2)>}
                   : memref<32x32x32x32xf16>, vector<16x16xf16>
-  func.return %root : vector<16x16xf16>
+  %rootl = iree_vector_ext.to_layout %root to #layout_col_major : vector<16x16xf16>
+  func.return %rootl : vector<16x16xf16>
 }
 
 builtin.module attributes { transform.with_named_sequence } {
@@ -236,10 +235,10 @@ func.func @distribute_transfer_read_row_major_with_permutations(%a: index, %b: i
   %cst = arith.constant 0.0 : f16
   %root = vector.transfer_read %arg0[%c0, %c0, %a, %b], %cst
           {in_bounds = [true, true, true, true],
-           permutation_map = affine_map<(d0, d1, d2, d3) -> (d0, d3, 0, d1)>,
-           "__vector_layout_test_anchor_result_0" = #layout}
+           permutation_map = affine_map<(d0, d1, d2, d3) -> (d0, d3, 0, d1)>}
                   : memref<32x32x32x32xf16>, vector<21x15x8x16xf16>
-  func.return %root : vector<21x15x8x16xf16>
+  %rootl = iree_vector_ext.to_layout %root to #layout : vector<21x15x8x16xf16>
+  func.return %rootl : vector<21x15x8x16xf16>
 }
 
 builtin.module attributes { transform.with_named_sequence } {
@@ -276,10 +275,9 @@ func.func @distribute_transfer_read_broadcast(%arg0: memref<32x32xf16>) -> vecto
   %c0 = arith.constant 0 : index
   %cst = arith.constant 0.0 : f16
   %root = vector.transfer_read %arg0[%c0, %c0], %cst
-          {in_bounds = [true],
-           "__vector_layout_test_anchor_result_0" = #layout}
-                  : memref<32x32xf16>, vector<16xf16>
-  func.return %root : vector<16xf16>
+          {in_bounds = [true]} : memref<32x32xf16>, vector<16xf16>
+  %rootl = iree_vector_ext.to_layout %root to #layout : vector<16xf16>
+  func.return %rootl : vector<16xf16>
 }
 
 builtin.module attributes { transform.with_named_sequence } {
@@ -314,10 +312,9 @@ func.func @distribute_transfer_read_broadcast2(%arg0: memref<32x128xf16>) -> vec
   %c0 = arith.constant 0 : index
   %cst = arith.constant 0.0 : f16
   %root = vector.transfer_read %arg0[%c0, %c0], %cst
-          {in_bounds = [true],
-           "__vector_layout_test_anchor_result_0" = #layout}
-                  : memref<32x128xf16>, vector<128xf16>
-  func.return %root : vector<128xf16>
+          {in_bounds = [true]} : memref<32x128xf16>, vector<128xf16>
+  %rootl = iree_vector_ext.to_layout %root to #layout : vector<128xf16>
+  func.return %rootl : vector<128xf16>
 }
 
 builtin.module attributes { transform.with_named_sequence } {
@@ -351,9 +348,9 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK-LABEL: @distribute_transfer_write_row_major
 func.func @distribute_transfer_write_row_major(%root: vector<16x16xf16>, %alloc: memref<64x64xf16>) {
   %c0 = arith.constant 0 : index
-  vector.transfer_write %root, %alloc[%c0, %c0]
-          {in_bounds = [true, true],
-           "__vector_layout_test_anchor_operand_0" = #layout_row_major}
+  %rootl = iree_vector_ext.to_layout %root to #layout_row_major : vector<16x16xf16>
+  vector.transfer_write %rootl, %alloc[%c0, %c0]
+          {in_bounds = [true, true]}
                   : vector<16x16xf16>, memref<64x64xf16>
   func.return
 }
@@ -398,9 +395,9 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK-LABEL: @distribute_transfer_write_col_major
 func.func @distribute_transfer_write_col_major(%root: vector<16x16xf16>, %alloc: memref<64x64xf16>) {
   %c0 = arith.constant 0 : index
-  vector.transfer_write %root, %alloc[%c0, %c0]
-          {in_bounds = [true, true],
-           "__vector_layout_test_anchor_operand_0" = #layout_col_major}
+  %rootl = iree_vector_ext.to_layout %root to #layout_col_major : vector<16x16xf16>
+  vector.transfer_write %rootl, %alloc[%c0, %c0]
+          {in_bounds = [true, true]}
                   : vector<16x16xf16>, memref<64x64xf16>
   func.return
 }
@@ -442,10 +439,10 @@ builtin.module attributes { transform.with_named_sequence } {
 
 func.func @distribute_transfer_write_row_major_with_nontrivial_index(%root: vector<16x16xf16>, %a: index, %b: index, %alloc: memref<32x32x32x32xf16>) {
   %c0 = arith.constant 0 : index
-  vector.transfer_write %root, %alloc[%c0, %c0, %a, %b]
+  %rootl = iree_vector_ext.to_layout %root to #layout_row_major : vector<16x16xf16>
+  vector.transfer_write %rootl, %alloc[%c0, %c0, %a, %b]
           {in_bounds = [true, true],
-           permutation_map = affine_map<(d0, d1, d2, d3) -> (d3, d2)>,
-           "__vector_layout_test_anchor_operand_0" = #layout_row_major}
+           permutation_map = affine_map<(d0, d1, d2, d3) -> (d3, d2)>}
                   : vector<16x16xf16>, memref<32x32x32x32xf16>
   func.return
 }
@@ -494,13 +491,14 @@ func.func @distribute_transfer_read_write(%a: index, %b: index,
   %cst = arith.constant 0.0 : f16
   %root = vector.transfer_read %arg0[%c0, %c0, %a, %b], %cst
           {in_bounds = [true, true],
-           permutation_map = affine_map<(d0, d1, d2, d3) -> (d2, d3)>,
-           "__vector_layout_test_anchor_result_0" = #layout_row_major}
+           permutation_map = affine_map<(d0, d1, d2, d3) -> (d2, d3)>}
                   : memref<32x32x32x32xf16>, vector<16x16xf16>
-  vector.transfer_write %root, %arg1[%c0, %c0, %a, %b]
+
+  %rootl = iree_vector_ext.to_layout %root to #layout_row_major : vector<16x16xf16>
+
+  vector.transfer_write %rootl, %arg1[%c0, %c0, %a, %b]
           {in_bounds = [true, true],
-           permutation_map = affine_map<(d0, d1, d2, d3) -> (d2, d3)>,
-           "__vector_layout_test_anchor_operand_0" = #layout_row_major}
+           permutation_map = affine_map<(d0, d1, d2, d3) -> (d2, d3)>}
                   : vector<16x16xf16>, memref<32x32x32x32xf16>
   return
 }
@@ -601,19 +599,20 @@ func.func @mfma_64x128x8_read(%mem: memref<128x8xf16>,
   // CHECK-DAG: transfer_read %{{.*}}[%[[ACCM3]], %[[RHSN]]
 
   %a = vector.transfer_read %mem[%c0, %c0], %cst
-          {in_bounds = [true, true],
-           "__vector_layout_test_anchor_result_0" = #layout_a}
+          {in_bounds = [true, true]}
   : memref<128x8xf16>, vector<128x8xf16>
   %b = vector.transfer_read %mem1[%c0, %c0], %cst
-          {in_bounds = [true, true],
-           "__vector_layout_test_anchor_result_0" = #layout_b}
+          {in_bounds = [true, true]}
   : memref<8x64xf16>, vector<8x64xf16>
   %c = vector.transfer_read %mem2[%c0, %c0], %cst
-          {in_bounds = [true, true],
-           "__vector_layout_test_anchor_result_0" = #layout_c}
+          {in_bounds = [true, true]}
   : memref<128x64xf16>, vector<128x64xf16>
 
-  return %a, %b, %c : vector<128x8xf16>, vector<8x64xf16>, vector<128x64xf16>
+  %A = iree_vector_ext.to_layout %a to #layout_a : vector<128x8xf16>
+  %B = iree_vector_ext.to_layout %b to #layout_b : vector<8x64xf16>
+  %C = iree_vector_ext.to_layout %c to #layout_c : vector<128x64xf16>
+
+  return %A, %B, %C : vector<128x8xf16>, vector<8x64xf16>, vector<128x64xf16>
 }
 
 builtin.module attributes { transform.with_named_sequence } {
@@ -644,11 +643,11 @@ func.func @transposed_read_64x8(%mem: memref<8x64xf16>)
   %cst = arith.constant 0.0 : f16
 
   %read = vector.transfer_read %mem[%c0, %c0], %cst
-          {in_bounds = [true, true], permutation_map = affine_map<(d0, d1) -> (d1, d0)>,
-           "__vector_layout_test_anchor_result_0" = #layout}
+          {in_bounds = [true, true], permutation_map = affine_map<(d0, d1) -> (d1, d0)>}
   : memref<8x64xf16>, vector<64x8xf16>
+  %readl = iree_vector_ext.to_layout %read to #layout : vector<64x8xf16>
 
-  return %read : vector<64x8xf16>
+  return %readl : vector<64x8xf16>
 }
 
 builtin.module attributes { transform.with_named_sequence } {
@@ -682,9 +681,10 @@ builtin.module attributes { transform.with_named_sequence } {
 >
 
 func.func @broadcast(%src: vector<128xf16>) -> (vector<64x128xf16>) {
-  %bcast = vector.broadcast %src {"__vector_layout_test_anchor_result_0" = #layout}
+  %bcast = vector.broadcast %src
     : vector<128xf16> to vector<64x128xf16>
-  return %bcast : vector<64x128xf16>
+  %bcastl = iree_vector_ext.to_layout %bcast to #layout : vector<64x128xf16>
+  return %bcastl : vector<64x128xf16>
 }
 
 builtin.module attributes { transform.with_named_sequence } {
@@ -725,9 +725,10 @@ builtin.module attributes { transform.with_named_sequence } {
 >
 
 func.func @broadcast(%src: vector<64xf16>) -> (vector<32x256x64xf16>) {
-  %bcast = vector.broadcast %src {"__vector_layout_test_anchor_result_0" = #layout}
+  %bcast = vector.broadcast %src
     : vector<64xf16> to vector<32x256x64xf16>
-  return %bcast : vector<32x256x64xf16>
+  %bcastl = iree_vector_ext.to_layout %bcast to #layout : vector<32x256x64xf16>
+  return %bcastl : vector<32x256x64xf16>
 }
 
 builtin.module attributes { transform.with_named_sequence } {
@@ -762,9 +763,9 @@ builtin.module attributes { transform.with_named_sequence } {
 >
 
 func.func @scalar_broadcast(%src: f16) -> (vector<32x256x64xf16>) {
-  %bcast = vector.broadcast %src {"__vector_layout_test_anchor_result_0" = #layout}
-    : f16 to vector<32x256x64xf16>
-  return %bcast : vector<32x256x64xf16>
+  %bcast = vector.broadcast %src : f16 to vector<32x256x64xf16>
+  %bcastl = iree_vector_ext.to_layout %bcast to #layout : vector<32x256x64xf16>
+  return %bcastl : vector<32x256x64xf16>
 }
 
 builtin.module attributes { transform.with_named_sequence } {
@@ -793,9 +794,10 @@ builtin.module attributes { transform.with_named_sequence } {
 >
 
 func.func @transpose(%src: vector<256x64xf16>) -> (vector<64x256xf16>) {
-  %transp = vector.transpose %src, [1, 0] {"__vector_layout_test_anchor_result_0" = #layout}
+  %transp = vector.transpose %src, [1, 0]
     : vector<256x64xf16> to vector<64x256xf16>
-  %sqrt = math.sqrt %transp : vector<64x256xf16>
+  %transpl = iree_vector_ext.to_layout %transp to #layout : vector<64x256xf16>
+  %sqrt = math.sqrt %transpl : vector<64x256xf16>
   return %sqrt : vector<64x256xf16>
 }
 
@@ -826,7 +828,8 @@ builtin.module attributes { transform.with_named_sequence } {
 >
 
 func.func @transpose(%src: vector<64x256xf16>) -> (vector<256x64xf16>) {
-  %transp = vector.transpose %src, [1, 0] {"__vector_layout_test_anchor_operand_0" = #layout}
+  %srcl = iree_vector_ext.to_layout %src to #layout : vector<64x256xf16>
+  %transp = vector.transpose %srcl, [1, 0]
     : vector<64x256xf16> to vector<256x64xf16>
   %sqrt = math.sqrt %transp : vector<256x64xf16>
   return %sqrt : vector<256x64xf16>
@@ -874,10 +877,10 @@ func.func @transpose_3d(%arr: memref<32x32x32xf16>) -> () {
   %cst_0 = arith.constant 0.0 : f16
   %cst0_1 = arith.constant dense<0.0> : vector<16xf16>
   %root = vector.transfer_read %arr[%c0, %c0, %c0], %cst_0 {
-    in_bounds = [true, true, true],
-    "__vector_layout_test_anchor_result_0" = #layout
+    in_bounds = [true, true, true]
   } : memref<32x32x32xf16>, vector<32x16x16xf16>
-  %t = vector.transpose %root, [1, 2, 0] : vector<32x16x16xf16> to vector<16x16x32xf16>
+  %rootl = iree_vector_ext.to_layout %root to #layout : vector<32x16x16xf16>
+  %t = vector.transpose %rootl, [1, 2, 0] : vector<32x16x16xf16> to vector<16x16x32xf16>
   vector.transfer_write %t, %arr[%c0, %c0, %c0] {in_bounds = [true, true, true]} : vector<16x16x32xf16>, memref<32x32x32xf16>
   func.return
 }
@@ -946,10 +949,8 @@ builtin.module attributes { transform.with_named_sequence } {
 >
 
 func.func @mfma_16x16x16_out_reduced_dim1(%arg0: vector<32x32xf32>, %arg1: vector<32xf32>) -> vector<32xf32> {
-  %0 = vector.multi_reduction <maximumf>, %arg0, %arg1
-  {
-    __vector_layout_test_anchor_operand_0 = #nested
-  } [1] : vector<32x32xf32> to vector<32xf32>
+  %arg0l = iree_vector_ext.to_layout %arg0 to #nested : vector<32x32xf32>
+  %0 = vector.multi_reduction <maximumf>, %arg0l, %arg1 [1] : vector<32x32xf32> to vector<32xf32>
   return %0 : vector<32xf32>
 }
 
@@ -997,10 +998,8 @@ builtin.module attributes { transform.with_named_sequence } {
 >
 
 func.func @mfma_32x32x8_out_reduced_dim1(%arg0: vector<32x32xf32>, %arg1: vector<32xf32>) -> vector<32xf32> {
-  %0 = vector.multi_reduction <maximumf>, %arg0, %arg1
-  {
-    __vector_layout_test_anchor_operand_0 = #nested
-  } [1] : vector<32x32xf32> to vector<32xf32>
+  %arg0l = iree_vector_ext.to_layout %arg0 to #nested : vector<32x32xf32>
+  %0 = vector.multi_reduction <maximumf>, %arg0l, %arg1 [1] : vector<32x32xf32> to vector<32xf32>
   return %0 : vector<32xf32>
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -1102,7 +1102,7 @@ public:
       : VectorLayoutOptions(root, /*fullConversion=*/false) {}
 
   LogicalResult setAnchorOps(VectorLayoutAnalysis &analysis) override {
-    return setAnchorOpsFromAttributes(analysis, root);
+    return success();
   }
 };
 
@@ -1176,9 +1176,6 @@ transform_dialect::TestVectorLayoutAnalysisOp::applyToOne(
     transform::ApplyToEachResultList &results,
     transform::TransformState &state) {
   VectorLayoutAnalysis analysis(target);
-  if (setAnchorOpsFromAttributes(analysis, target).failed()) {
-    return emitDefaultSilenceableFailure(target);
-  }
   if (failed(analysis.run())) {
     target.emitError("layout analysis failed");
     return emitDefaultSilenceableFailure(target);

--- a/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
@@ -50,8 +50,8 @@ public:
   ChangeResult resolveWithPossibleConflict(const VectorLayoutInterface &rhs,
                                            OpOperand &operand);
 
-  ChangeResult resolve(const DistributionLayout *rhs);
-  ChangeResult resolve(const VectorLayoutInterface &rhs);
+  ChangeResult resolve(const DistributionLayout *rhs, bool force = false);
+  ChangeResult resolve(const VectorLayoutInterface &rhs, bool force = false);
 
   VectorLayoutInterface getLayout() const { return vectorLayout; }
 
@@ -248,7 +248,15 @@ DistributionLayout::resolveWithPossibleConflict(const DistributionLayout *rhs,
   return resolveWithPossibleConflict(rhs->vectorLayout, opOperand);
 }
 
-ChangeResult DistributionLayout::resolve(const VectorLayoutInterface &rhs) {
+ChangeResult DistributionLayout::resolve(const VectorLayoutInterface &rhs,
+                                         bool force) {
+  // If forced, set the layout regardless of a possible conflict.
+  if (force) {
+    bool changed = (vectorLayout != rhs);
+    setInnerLayout(rhs);
+    return changed ? ChangeResult::Change : ChangeResult::NoChange;
+  }
+
   ResolutionResult result = doResolution(rhs);
 
   switch (result) {
@@ -269,9 +277,10 @@ ChangeResult DistributionLayout::resolve(const VectorLayoutInterface &rhs) {
   return ChangeResult::NoChange;
 }
 
-ChangeResult DistributionLayout::resolve(const DistributionLayout *rhs) {
+ChangeResult DistributionLayout::resolve(const DistributionLayout *rhs,
+                                         bool force) {
   assert(rhs && "layout to resolve with should not be null");
-  return resolve(rhs->vectorLayout);
+  return resolve(rhs->vectorLayout, force);
 }
 
 void DistributionLayout::print(raw_ostream &os) const {
@@ -389,6 +398,19 @@ static void enforceSameLayoutForOperands(
 /// ==========================================================================
 ///        PROPAGATION TRANSFER FUNCTIONS
 /// ==========================================================================
+
+static void propagateLayoutToLayoutOp(
+    ToLayoutOp toLayout, ArrayRef<const DistributionLayout *> operandLattices,
+    ArrayRef<DistributionLayout *> resultLattices,
+    std::function<void(DistributionLayout *, ChangeResult)> update) {
+  DistributionLayout *result = resultLattices[0];
+
+  // ToLayout operation propagates layout even if the result already has a
+  // layout.
+
+  ChangeResult changed = result->resolve(toLayout.getLayout(), /*force=*/true);
+  update(result, changed);
+}
 
 static void propagateLayoutToElementwiseOp(
     Operation *op, ArrayRef<const DistributionLayout *> operandLattices,
@@ -510,6 +532,12 @@ void propagationTransferFunction(
     ArrayRef<DistributionLayout *> resultLattices,
     std::function<void(DistributionLayout *, ChangeResult)> update) {
 
+  if (auto toLayout = dyn_cast<ToLayoutOp>(op)) {
+    propagateLayoutToLayoutOp(toLayout, operandLattices, resultLattices,
+                              update);
+    return;
+  }
+
   // Propagate layout to elementwise operations.
   if (OpTrait::hasElementwiseMappableTraits(op)) {
     propagateLayoutToElementwiseOp(op, operandLattices, resultLattices, update);
@@ -540,6 +568,24 @@ void propagationTransferFunction(
 /// ==========================================================================
 ///        ENFORCEMENT TRANSFER FUNCTIONS
 /// ==========================================================================
+
+static void enforceLayoutToLayoutOp(
+    ToLayoutOp toLayout, ArrayRef<DistributionLayout *> operandLattices,
+    ArrayRef<const DistributionLayout *> resultLattices,
+    std::function<void(DistributionLayout *, ChangeResult)> update) {
+
+  DistributionLayout *input = operandLattices[0];
+
+  // If the operand already has a layout, we don't do anything. The result
+  // will already have the layout desired by this operation.
+  if (input->hasLayout()) {
+    return;
+  }
+
+  // Enforce the result layout on init.
+  ChangeResult changed = input->resolve(toLayout.getLayout());
+  update(input, changed);
+}
 
 static void enforceLayoutToElementwiseOp(
     Operation *op, ArrayRef<DistributionLayout *> operandLattices,
@@ -681,6 +727,10 @@ void enforcementTransferFunction(
     Operation *op, ArrayRef<DistributionLayout *> operandLattices,
     ArrayRef<const DistributionLayout *> resultLattices,
     std::function<void(DistributionLayout *, ChangeResult)> update) {
+
+  if (auto toLayout = dyn_cast<ToLayoutOp>(op)) {
+    enforceLayoutToLayoutOp(toLayout, operandLattices, resultLattices, update);
+  }
 
   // Propagate layout to elementwise operations.
   if (OpTrait::hasElementwiseMappableTraits(op)) {
@@ -1039,54 +1089,3 @@ void VectorLayoutAnalysis::dump() {
   print(llvm::dbgs());
   llvm::dbgs() << "\n";
 }
-
-namespace mlir::iree_compiler {
-
-LogicalResult setAnchorOpsFromAttributes(VectorLayoutAnalysis &analysis,
-                                         Operation *root) {
-  WalkResult result = root->walk([&](Operation *op) {
-    for (NamedAttribute attr : op->getAttrs()) {
-      StringRef name = attr.getName().strref();
-      if (name.contains("__vector_layout_test_anchor_operand_")) {
-        int operandNum;
-        name.substr(name.find_last_of("_") + 1)
-            .getAsInteger(/*Radix=*/10, operandNum);
-        if (operandNum >= op->getNumOperands()) {
-          op->emitError("Operand number for anchor is out of range");
-          return WalkResult::interrupt();
-        }
-        auto layout = dyn_cast<VectorLayoutInterface>(attr.getValue());
-        if (!layout) {
-          op->emitError("Anchor should implement VectorLayoutInteface");
-        }
-        if (analysis.setAnchor(op->getOperand(operandNum), layout).failed()) {
-          return WalkResult::interrupt();
-        }
-      }
-      if (name.contains("__vector_layout_test_anchor_result_")) {
-        int resultNum;
-        name.substr(name.find_last_of("_") + 1)
-            .getAsInteger(/*Radix=*/10, resultNum);
-        if (resultNum >= op->getNumResults()) {
-          op->emitError("Result number for anchor is out of range");
-          return WalkResult::interrupt();
-        }
-        auto layout = dyn_cast<VectorLayoutInterface>(attr.getValue());
-        if (!layout) {
-          op->emitError("Anchor should implement VectorLayoutInteface");
-        }
-        if (analysis.setAnchor(op->getResult(resultNum), layout).failed()) {
-          return WalkResult::interrupt();
-        }
-      }
-    }
-    return WalkResult::advance();
-  });
-
-  if (result.wasInterrupted()) {
-    return failure();
-  }
-  return success();
-}
-
-} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.h
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.h
@@ -139,9 +139,6 @@ private:
   DataFlowSolver solver;
 };
 
-LogicalResult setAnchorOpsFromAttributes(VectorLayoutAnalysis &analysis,
-                                         Operation *root);
-
 }; // namespace iree_compiler
 }; // namespace mlir
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -1476,7 +1476,7 @@ public:
       : VectorLayoutOptions(root, fullConversion) {}
 
   LogicalResult setAnchorOps(VectorLayoutAnalysis &analysis) override {
-    return setAnchorOpsFromAttributes(analysis, root);
+    return success();
   }
 };
 
@@ -1647,17 +1647,16 @@ transform_dialect::SetContractionLayoutAttributes::apply(
              << "invalid opaque mma layout for annotation " << mmaType;
     }
 
-    contract->setAttr("iree.amdgpu.mma", mmaType);
+    Location loc = contract.getLoc();
     auto [aLayout, bLayout, cLayout] = *maybeLayouts;
-    contract->setAttr("__vector_layout_test_anchor_operand_0", aLayout);
-    contract->setAttr("__vector_layout_test_anchor_operand_1", bLayout);
-    contract->setAttr("__vector_layout_test_anchor_operand_2", cLayout);
+
+    // Set packed read layout for specified indices.
     ArrayRef<int64_t> operandIndices = getReadLayoutIndices();
     if (!operandIndices.empty()) {
       SmallVector<Value> operands;
       SmallVector<VectorExt::VectorLayoutInterface> layouts;
       for (int64_t index : operandIndices) {
-        operands.push_back(index == 0 ? contract.getLhs() : contract.getRhs());
+        operands.push_back(contract.getOperand(index));
         layouts.push_back(index == 0 ? aLayout : bLayout);
       }
       rewriter.setInsertionPoint(contract);
@@ -1675,12 +1674,26 @@ transform_dialect::SetContractionLayoutAttributes::apply(
         Operation *parentOp = operand.getDefiningOp();
         if (!parentOp || (parentOp->getNumResults() != 1))
           continue;
-        parentOp->setAttr("__vector_layout_test_anchor_result_0", readLayout);
         Value resolvedOperand = rewriter.create<VectorExt::ToLayoutOp>(
-            contract.getLoc(), operand.getType(), operand, layout);
+            loc, operand.getType(), operand, readLayout);
         contract.setOperand(operandIndices[i], resolvedOperand);
       }
     }
+
+    // Set layout anchors.
+    rewriter.setInsertionPoint(contract);
+    Value newLhs = rewriter.create<VectorExt::ToLayoutOp>(
+        loc, contract.getLhsType(), contract.getLhs(), aLayout);
+    Value newRhs = rewriter.create<VectorExt::ToLayoutOp>(
+        loc, contract.getRhsType(), contract.getRhs(), bLayout);
+    Value newAcc = rewriter.create<VectorExt::ToLayoutOp>(
+        loc, contract.getAccType(), contract.getAcc(), cLayout);
+    contract.setOperand(0, newLhs);
+    contract.setOperand(1, newRhs);
+    contract.setOperand(2, newAcc);
+
+    // Set intrinsic type.
+    contract->setAttr("iree.amdgpu.mma", mmaType);
   }
 
   return DiagnosedSilenceableFailure::success();


### PR DESCRIPTION
This patch enables using the new to_layout operation to set anchors instead of discardable attributes on operations. This patch is mostly NFC, which only changes how anchors are set in tests.

Changes in .mlir files simply replace the attribute setting the anchor with an operation setting the anchor.