### PR TITLE
[LinalgExt][Flow] Add `LinalgFusionOpInterface` to attention op

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
@@ -743,6 +743,11 @@ isFusableWithProducer(OpOperand &operand,
     return true;
   }
 
+  // Don't fuse attention with it's producer
+  if (isa<LinalgExt::AttentionOp>(consumer)) {
+    return false;
+  }
+
   if (isPackLikeOp(consumer)) {
     return TypeSwitch<Operation *, bool>(producer)
         .Case<tensor::PadOp>([&](auto padOp) { return true; })

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_ext_fusion.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_ext_fusion.mlir
@@ -114,10 +114,12 @@ util.func public @attention_dispatch(%arg0: tensor<?x?x?xf16>, %arg1: tensor<?x?
 //       CHECK:       %[[DISPATCH1:.+]] = flow.dispatch.region
 //  CHECK-NEXT:         %[[GEN1:.+]] = linalg.generic
 //       CHECK:         flow.return %[[GEN1]]
+//       CHECK:       %[[DISPATCH2:.+]] = flow.dispatch.region
+//  CHECK-NEXT:         %[[GEN2:.+]] = linalg.generic
+//       CHECK:         flow.return %[[GEN2]]
 //       CHECK:       %[[RESULT:.+]] = flow.dispatch.region
-//       CHECK:         %[[GEN:.+]] = linalg.generic
 //       CHECK:         %[[ATTN:.+]] = iree_linalg_ext.attention
-//  CHECK-SAME:           ins(%[[GEN]], %[[DISPATCH0]], %[[DISPATCH1]]
+//  CHECK-SAME:           ins(%[[DISPATCH0]], %[[DISPATCH1]], %[[DISPATCH2]]
 //       CHECK:         %[[GEN2:.+]] = linalg.generic
 //  CHECK-SAME:           ins(%[[ATTN]]
 //       CHECK:         flow.return %[[GEN2]]

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.cpp
@@ -97,10 +97,7 @@ public:
     return (llvm::cast<ConcreteType>(op).getMatchingIndexingMap(operand));
   }
 
-  SmallVector<AffineMap> getIndexingMaps(mlir::Operation *op) const {
-    // Note: this is different from linalg's implementation
-    // of `getIndexingMaps`. Call interface methods to get
-    // the vector of indexing maps for operands and results.
+  SmallVector<AffineMap> getIndexingMapsArray(mlir::Operation *op) const {
     auto inputMaps = getIndexingMapsForOperands(op);
     llvm::append_range(inputMaps, getIndexingMapsForResults(op));
     return inputMaps;

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtInterfaces.td
@@ -73,7 +73,7 @@ def LinalgFusionInterface : OpInterface<"LinalgFusionOpInterface"> {
         operand or result does not have an indexing map representation.
       }],
       /*retTy=*/"SmallVector<AffineMap>",
-      /*methodName=*/"getIndexingMaps",
+      /*methodName=*/"getIndexingMapsArray",
       /*args=*/(ins),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1214,6 +1214,9 @@ LogicalResult AttentionOp::verify() {
   SmallVector<AffineMap> indexingMaps = attnOp.getIndexingMapsArray();
   FailureOr<AttentionOpDetail> maybeOpInfo =
       AttentionOpDetail::get(indexingMaps);
+  if (failed(maybeOpInfo)) {
+    return attnOp->emitOpError("failed to verify op's indexing maps");
+  }
 
   FloatType scaleElementType = dyn_cast<FloatType>(getScale().getType());
   if (!scaleElementType) {
@@ -1317,6 +1320,18 @@ SmallVector<int64_t, 4> AttentionOp::getStaticLoopRanges() {
   fillSizes(queryShape, queryDims);
   fillSizes(valueShape, valueDims);
   return bounds;
+}
+
+SmallVector<AffineMap> AttentionOp::getIndexingMapsForOperands() {
+  auto maps = getIndexingMapsArray();
+  return SmallVector<AffineMap>(maps.begin(),
+                                maps.end() + getNumDpsInputs() - 1);
+}
+
+SmallVector<AffineMap> AttentionOp::getIndexingMapsForResults() {
+  auto maps = getIndexingMapsArray();
+  return SmallVector<AffineMap>(maps.begin() + getNumDpsInputs() - 1,
+                                maps.end());
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -453,6 +453,8 @@ def IREELinalgExt_TopkOp : IREELinalgExt_Op<"topk",[
 def IREELinalgExt_AttentionOp : IREELinalgExt_PureOp<"attention",
     [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
      DestinationStyleOpInterface, LinalgExtInterface,
+     DeclareOpInterfaceMethods<LinalgFusionInterface,
+      ["getIndexingMapsForResults", "getIndexingMapsForOperands"]>,
      DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
      DeclareOpInterfaceMethods<TilingInterface,
       ["getIterationDomain",

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -746,3 +746,16 @@ func.func @illegal_attention_inputs(%query: tensor<192x1024x64xf32>, %key: tenso
                     ins(%query, %key, %value, %scale : tensor<192x1024x64xf32>, tensor<192x1024x64xf32>, f32, f32) outs(%0 : tensor<192x1024x64xf32>) -> tensor<192x1024x64xf32>
   return %1 : tensor<192x1024x64xf32>
 }
+
+// -----
+
+func.func @attention(%query: tensor<192x1024x64xf32>, %key: tensor<192x1024x64xf32>, %value: tensor<192x1024x64xf32>) -> tensor<192x1024x64xf32> {
+  %0 = tensor.empty() : tensor<192x1024x64xf32>
+  %scale = arith.constant 1.0 : f32
+  // expected-error @below {{'iree_linalg_ext.attention' op failed to verify op's indexing maps}}
+  %1 = iree_linalg_ext.attention {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>]}
+                     ins(%query, %key, %value, %scale : tensor<192x1024x64xf32>, tensor<192x1024x64xf32>, tensor<192x1024x64xf32>, f32) outs(%0 : tensor<192x1024x64xf32>) -> tensor<192x1024x64xf32>
+  return %1 : tensor<192x1024x64xf32>
+}


### PR DESCRIPTION
- Added interface to attention op so that producers/consumers can get fused into the same dispatch.
- Cleaned up interface method naming by changing `getIndexingMaps` to `getIndexingMapsArray` to better match linalg. `getIndexingMaps` also already conflicted with a method that attention already has.
- Added indexing check to attention verifier and corresponding test.