### PR TITLE
[Encoding] Add an optional bcast_map attribute to EncodingAttr.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
@@ -85,11 +85,15 @@ static RankedTensorType transposeIfNarrowNResult(RankedTensorType tensorType) {
 
   auto opTypeAttr = IREE::Encoding::EncodingOpTypeAttr::get(
       context, IREE::Encoding::EncodingOpType::matmul);
+  // TODO(#17718): Handle the broadcast map for transpose cases. It is on the
+  // experimental path, so it is not clear what needs to be done here. For now
+  // just use the original map for the new encoding.
   auto newEncoding = IREE::Encoding::EncodingAttr::get(
       context, newIndex, opTypeAttr, encoding.getElementTypes(),
       TypeAttr::get(RankedTensorType::get(newOriginalShape, elemType)),
       encoding.getMatmulNarrow_N(), encoding.getMatmulNarrow_M(),
-      newIndexingMaps, DenseI64ArrayAttr::get(context, newRoundDimsTo));
+      newIndexingMaps, encoding.getBcastMap(),
+      DenseI64ArrayAttr::get(context, newRoundDimsTo));
   return RankedTensorType::get(newShape, elemType, newEncoding);
 }
 

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingBase.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingBase.td
@@ -83,6 +83,7 @@ def EncodingAttr :
     OptionalParameter<"IntegerAttr", "optional M narrow dimension size (only for contraction op user_indexing_maps)">:$matmul_narrow_M,
     OptionalParameter<"IntegerAttr", "optional N narrow dimension size (only for contraction op user_indexing_maps)">:$matmul_narrow_N,
     OptionalParameter<"ArrayAttr", "Indexing maps of the operation using this tensor">:$user_indexing_maps,
+    OptionalParameter<"AffineMapAttr", "Indexing map that represents the broadcasting dims in the producer">:$bcast_map,
     // TODO(hanchung): The round_dims_to parameter can be revisited. We explicitly map them to M,N,K dimension for now.
     OptionalParameter<"DenseArrayAttr", "Values for padding M,N,K dimensions">:$round_dims_to
   );
@@ -94,6 +95,7 @@ def EncodingAttr :
         CArg<"std::optional<int64_t>", "{}">:$matmulNarrowM,
         CArg<"std::optional<int64_t>", "{}">:$matmulNarrowN,
         CArg<"ArrayRef<AffineMap>", "{}">:$maps,
+        CArg<"std::optional<AffineMap>", "{}">:$bcastMap,
         CArg<"ArrayRef<int64_t>", "{}">:$roundDimsTo)>
   ];
 

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.cpp
@@ -102,6 +102,7 @@ EncodingAttr EncodingAttr::get(MLIRContext *ctx, int64_t operandIndex,
                                std::optional<int64_t> matmulNarrowM,
                                std::optional<int64_t> matmulNarrowN,
                                ArrayRef<AffineMap> maps,
+                               std::optional<AffineMap> bcastMap,
                                ArrayRef<int64_t> roundDimsTo) {
   Builder b(ctx);
   auto optionalToAttr = [&](std::optional<int64_t> x) {
@@ -112,10 +113,13 @@ EncodingAttr EncodingAttr::get(MLIRContext *ctx, int64_t operandIndex,
   auto roundDimsToAttr = roundDimsTo.empty()
                              ? DenseI64ArrayAttr()
                              : b.getDenseI64ArrayAttr(roundDimsTo);
+  auto bcastMapAttr = bcastMap.has_value()
+                          ? AffineMapAttr::get(bcastMap.value())
+                          : AffineMapAttr();
   return get(ctx, b.getIndexAttr(operandIndex), opTypeAttr,
              b.getTypeArrayAttr(elemTypes), origTypeAttr,
              optionalToAttr(matmulNarrowM), optionalToAttr(matmulNarrowN),
-             b.getAffineMapArrayAttr(maps), roundDimsToAttr);
+             b.getAffineMapArrayAttr(maps), bcastMapAttr, roundDimsToAttr);
 }
 
 AffineMap EncodingAttr::getMapForOperandIndex() {

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/test/roundtrip.mlir
@@ -82,3 +82,21 @@ func.func @encoding_tensors_with_ops(%arg0 : tensor<?x?xf32>,
 //  CHECK-SAME:       outs(%[[OUT]] :
 //       CHECK:   %[[RESULT:.+]] = iree_encoding.unset_encoding %[[GEMM]]
 //       CHECK:   return %[[RESULT]]
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+#map3 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+func.func @set_encoding_ops_with_indexing_maps(%arg0: tensor<?x?xf32>) -> tensor<?x?xf32, #iree_encoding.encoding<operand_index = 0 : i64, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], bcast_map = #map3>> {
+  %0 = iree_encoding.set_encoding %arg0 : tensor<?x?xf32> -> tensor<?x?xf32, #iree_encoding.encoding<operand_index = 0 : i64, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], bcast_map = #map3>>
+  return %0 : tensor<?x?xf32, #iree_encoding.encoding<operand_index = 0 : i64, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], bcast_map = #map3>>
+}
+// CHECK-DAG:   #[[MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+// CHECK-DAG:   #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+// CHECK-DAG:   #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+// CHECK-DAG:   #[[MAP3:.+]] = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+// CHECK:       func.func @set_encoding_ops_with_indexing_maps(
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]:
+// CHECK:         iree_encoding.set_encoding %[[ARG0]] : tensor<?x?xf32> -> tensor<?x?xf32, #iree_encoding.encoding<operand_index = 0 : i64, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]], bcast_map = #[[MAP3]]>>

--- a/compiler/src/iree/compiler/GlobalOptimization/SetEncoding.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/SetEncoding.cpp
@@ -277,9 +277,10 @@ public:
     auto opType = IREE::Encoding::EncodingOpType::matmul;
     auto setEncodingWrapper = [&](Value src, int64_t operandIndex) -> Value {
       SmallVector<int64_t> roundDimsTo(3, padFactor);
-      auto encoding = EncodingAttr::get(
-          linalgOp.getContext(), operandIndex, opType, elemTypes, src.getType(),
-          narrowSizes.M, narrowSizes.N, maps, roundDimsTo);
+      auto encoding = EncodingAttr::get(linalgOp.getContext(), operandIndex,
+                                        opType, elemTypes, src.getType(),
+                                        narrowSizes.M, narrowSizes.N, maps,
+                                        /*bcastMap=*/std::nullopt, roundDimsTo);
       return setEncoding(rewriter, loc, src, encoding);
     };
     Value encodedLhs = setEncodingWrapper(lhs, IREE::Encoding::MATMUL_LHS);


### PR DESCRIPTION
This adds a new optional field to encodings called `bcast_map`. When we set encodings, we want to set encodings on the inputs to broadcasting operations, since it is less data to pack. This `bcast_map` is a step towards being able to do this, since it is needed in order to know which dimensions of the tensor correspond to which dimensions of the packed layout.

The new field is an affine map that encodes which dimensions of the encoded tensor map to which dimensions in the corresponding operand of the data tiled op. For example, if the LHS of a matmul is broadcasted along the batch dimension, and we set encoding on the input to the broadcast:
```mlir
#map = affine_map<(d0, d1, d2) -> (d1, d2)>
#map1 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
%se = iree_encoding.set_encoding %lhs : tensor<4x16xf32> -> tensor<4x16xf32, ... bcast_map = #map
%bcast = linalg.broadcast ins(%lhs ... outs(%e : tensor<2x4x16xf32, ... bcast_map = #map1 ... dimensions = [0]
```
The result of the broadcast, which will be consumed by the matmul, has an identity broadcast map, and the input to the broadcast has a broadcasted affine map. The `#map` says that the dimensions of `%se` correspond to `d1` and `d2` in the LHS of the matmul that consumes `%bcast`.

In cases where we transpose narrow N matmuls, the `bcast_map` remains the same. Handling this properly is left as a TODO, to be fixed when more pieces land, and we can more properly test transposed narrow N matmuls. This is okay for now, since the `bcast_map` is not actually used anywhere yet.