### PR TITLE
Adding `once` attribute to `stream.cmd.execute`.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -3537,6 +3537,7 @@ CmdExecuteOp::cloneReplacementExcludingOperandsAndResults(
   auto newOp = rewriter.create<CmdExecuteOp>(getLoc(), getAwaitTimepoint(),
                                              newOperandsValues, newOperandSizes,
                                              getOperation()->getAttrs());
+  newOp.setOnce(getOnce());
   auto &newBody = newOp.getClosureBodyRegion();
   newBody.takeBody(getClosureBodyRegion());
   auto &block = newBody.front();

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -3328,6 +3328,7 @@ def Stream_CmdExecuteOp : Stream_Op<"cmd.execute", [
       Stream_StagingResource,
     ]>>:$resource_operands,
     Variadic<Stream_Size>:$resource_operand_sizes,
+    UnitAttr:$once,
     Optional<Stream_Timepoint>:$await_timepoint,
     OptionalAttr<Stream_AffinityAttr>:$affinity
   );
@@ -3338,6 +3339,7 @@ def Stream_CmdExecuteOp : Stream_Op<"cmd.execute", [
   let regions = (region AnyRegion:$body);
 
   let assemblyFormat = [{
+    (`once` $once^)?
     (`on` `(` $affinity^ `)`)?
     (`await` `(` $await_timepoint^ `)` `=` `` `>`)?
     `with` ``


### PR DESCRIPTION
For now we set this flag only if the op is used in the entry block of an initializer. A must-be-executed analysis (and others) could be run to set it instead for cases where we call functions from initializers but we don't tend to do that today.

Progress on #17875.