### PR TITLE
[VectorDistribution] Use to_layout to set anchors for LLVMGPUVectorDistribute pass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.cpp
@@ -285,8 +285,6 @@ LogicalResult distributeVectorOps(Operation *root,
   // Run the analysis and determine the layouts.
   LLVM_DEBUG(llvm::dbgs() << "Running Layout Analysis\n");
   VectorLayoutAnalysis analysis(root);
-  if (failed(options.setAnchorOps(analysis)))
-    return failure();
   if (failed(analysis.run()))
     return failure();
   LLVM_DEBUG(llvm::dbgs() << "Layout Analysis Succeded\n");

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.h
@@ -106,9 +106,6 @@ public:
 
   virtual ~VectorLayoutOptions() = default;
 
-  /// Set the anchor ops in the analysis rooted on the root operation.
-  virtual LogicalResult setAnchorOps(VectorLayoutAnalysis &analysis) = 0;
-
   bool verifyConversion() const { return fullConversion; }
 
 protected:

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -1100,10 +1100,6 @@ class TestVectorLayoutOptions : public VectorLayoutOptions {
 public:
   TestVectorLayoutOptions(Operation *root)
       : VectorLayoutOptions(root, /*fullConversion=*/false) {}
-
-  LogicalResult setAnchorOps(VectorLayoutAnalysis &analysis) override {
-    return success();
-  }
 };
 
 DiagnosedSilenceableFailure

--- a/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
@@ -1023,17 +1023,6 @@ DistributionLayout *EnforceLayout::getLatticeElement(Value val) {
 ///        VectorLayoutAnalysis
 /// ==========================================================================
 
-LogicalResult VectorLayoutAnalysis::setAnchor(Value val,
-                                              VectorLayoutInterface layout) {
-  auto typedVal = dyn_cast<TypedValue<VectorType>>(val);
-  assert(typedVal && "expected value to be a vector type");
-  if (layout.isValidLayout(typedVal).failed()) {
-    return failure();
-  }
-  anchors[typedVal] = cast<VectorLayoutInterface>(layout);
-  return success();
-}
-
 LogicalResult VectorLayoutAnalysis::run() {
   // The order of loading matters here, because propagateLayout does anchoring
   // initialization which needs the lattice to know both enforcement and

--- a/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.h
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.h
@@ -98,10 +98,6 @@ class VectorLayoutAnalysis {
 public:
   VectorLayoutAnalysis(Operation *root) : root(root) {}
 
-  /// Fix the layout for a specific value. Returns failure if the layout set is
-  /// invalid for the value.
-  LogicalResult setAnchor(Value val, VectorLayoutInterface layout);
-
   /// Run the analysis. The analysis expects that the user has set some anchor
   /// points and is trying to infer the layout of other values.
   LogicalResult run();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -1474,10 +1474,6 @@ class TransformVectorLayoutOptions : public VectorLayoutOptions {
 public:
   TransformVectorLayoutOptions(Operation *root, bool fullConversion)
       : VectorLayoutOptions(root, fullConversion) {}
-
-  LogicalResult setAnchorOps(VectorLayoutAnalysis &analysis) override {
-    return success();
-  }
 };
 
 DiagnosedSilenceableFailure


### PR DESCRIPTION
This patch makes LLVMGPUVectorDistribute pass use to_layout operations to set layout anchors instead of directly setting them on the analysis. This allows for better readability of what anchors are being set.

This patch allows the layout anchoring and the distribution to be split up, which will be done in future patches.