### PR TITLE
[DT] Retire UpperBoundTileSizeOp op and relevant passes.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/Passes.h
@@ -26,23 +26,6 @@ namespace mlir::iree_compiler {
 std::unique_ptr<Pass> createCPUMaterializeHostEncodingPass();
 std::unique_ptr<Pass> createCPUMaterializeDeviceEncodingPass();
 
-/// Like createLLVMCPUMaterializeEncodingPass, but specifically for
-/// encoding.upper_bound_tile_size, converting it to constants.
-///
-/// Unlike createLLVMCPUMaterializeEncodingPass, this does not require the
-/// op to have a specific HAL target attribute. Instead, this will iterate over
-/// all HAL target attributes, use the maximum of all padding sizes from each
-/// target. This is needed because in top-level functions outside of HAL
-/// executables, there are upper_bound_tile_size ops (created by SetEncoding,
-/// and computing buffer allocation sizes) and there isn't one specific HAL
-/// target.
-///
-/// In the VMVX case where padding sizes are not compile-time constants, this
-/// converts upper_bound_tile_size to some specific constant size (currently 16)
-/// that is the largest tile size that we can use in VMVX, and can be adjusted
-// as needed.
-std::unique_ptr<Pass> createCPUMaterializeUpperBoundTileSizePass();
-
 /// Adds CPU bufferization passes to the pipeline.
 void addCPUBufferizePasses(OpPassManager &funcPassManager);
 

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/Passes.td
@@ -25,12 +25,6 @@ def CPUMaterializeDeviceEncoding :
   let constructor = "mlir::iree_compiler::createCPUMaterializeDeviceEncodingPass()";
 }
 
-def CPUMaterializeUpperBoundTileSize :
-    Pass<"iree-codegen-cpu-materialize-upper-bound-tile-size", "mlir::ModuleOp"> {
-  let summary = "Materialize upper_bound_tile_size to constants.";
-  let constructor = "mlir::iree_compiler::createCPUMaterializeUpperBoundTileSizePass()";
-}
-
 def CPULowerToUKernels :
     Pass<"iree-codegen-cpu-lower-to-ukernels", ""> {
   let summary =

--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.h
@@ -96,9 +96,6 @@ void populateMaterializeEncodingIntoPackUnPackPatterns(
     MaterializeEncodingTypeConverter &typeConverter,
     MaterializeEncodingValueFn materializeEncodingValueFn);
 
-void populateMaterializeUpperBoundTileSizePatterns(
-    RewritePatternSet &patterns, MaterializeEncodingFn materializeEncodingFn);
-
 // Returns true if `encoding` represents a narrow-N matmul RESULT, e.g. the
 // result of a matvec.
 bool isNarrowNResult(IREE::Encoding::EncodingAttr encoding);

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoNop.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoNop.cpp
@@ -54,18 +54,6 @@ struct MaterializeEncodingIntoNopPass
       return signalPassFailure();
     }
 
-    {
-      RewritePatternSet patterns(context);
-      populateMaterializeUpperBoundTileSizePatterns(patterns,
-                                                    materializeEncodingFn);
-      if (failed(
-              applyPatternsAndFoldGreedily(operation, std::move(patterns)))) {
-        operation.emitOpError(
-            "encoding padding sizes materialization pattern failed");
-        return signalPassFailure();
-      }
-    }
-
     // Add patterns to resolve dims ops and cleanups.
     {
       RewritePatternSet patterns(context);

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.td
@@ -54,29 +54,6 @@ def IREEEncoding_SetEncodingOp : IREEEncoding_PureOp<"set_encoding",[
 }
 
 //===----------------------------------------------------------------------===//
-// upper_bound_tile_size op.
-//===----------------------------------------------------------------------===//
-
-def IREEEncoding_UpperBoundTileSizeOp : IREEEncoding_PureOp<"upper_bound_tile_size",
-    [Pure]> {
-  let summary = "returns an upper bound on tile sizes";
-  let description = [{
-    This returns the largest tile sizes that might result from materialization
-    of the given encoding. This can be used outside of target-specific code, so
-    there may be multiple targets, and this will return the maximum tile size
-    from iterating over all of them. The evaluation happens in the
-    MaterializeUpperBoundTileSize pass.
-  }];
-
-  let arguments = (ins TypeAttrOf<AnyRankedTensor>:$tensorType);
-  let results = (outs Variadic<Index>:$results);
-
-  let assemblyFormat = [{
-    attr-dict $tensorType `->` type($results)
-  }];
-}
-
-//===----------------------------------------------------------------------===//
 // unset_encoding op.
 //===----------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
@@ -8,7 +8,6 @@
 
 #include <memory>
 
-#include "iree/compiler/Codegen/Common/CPU/Passes.h"
 #include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "iree/compiler/Dialect/HAL/Target/Devices/LocalDevice.h"
@@ -312,12 +311,6 @@ void buildHALTransformPassPipeline(OpPassManager &passManager,
                                          assignmentOptions);
     buildHALConfigurationPassPipeline(passManager, targetRegistry,
                                       targetOptions, hooks);
-
-    // HACK: this should not be here and will be going away. It exists for
-    // lowering iree_linalg_ext.upper_bound_tile_size ops that exist on the
-    // host. We should be using stream ops for performing such calculations that
-    // we can attach affinities to and understand what devices are being used.
-    passManager.addPass(createCPUMaterializeUpperBoundTileSizePass());
 
     // Preprocess executables using an external tool. The tool may mutate one or
     // more variants and even insert or remove variants.

--- a/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
@@ -336,8 +336,7 @@ void registerUtilExternalModels(DialectRegistry &registry) {
   registry.addExtension(
       +[](MLIRContext *context, IREE::Encoding::IREEEncodingDialect *dialect) {
         UnhoistableOpInterfaceHelper<
-            IREE::Encoding::SetEncodingOp,
-            IREE::Encoding::UpperBoundTileSizeOp>::registerOpInterface(context);
+            IREE::Encoding::SetEncodingOp>::registerOpInterface(context);
       });
   // Register hoistable type interfaces for linalg ops.
   // We have a specific allow-list for Linalg ops because we want to consider

--- a/compiler/src/iree/compiler/GlobalOptimization/MaterializeHomogeneousEncodings.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/MaterializeHomogeneousEncodings.cpp
@@ -72,7 +72,6 @@ public:
     }
 
     OpPassManager passManager(moduleOp.getOperationName());
-    passManager.addPass(createCPUMaterializeUpperBoundTileSizePass());
     passManager.addPass(createCPUMaterializeHostEncodingPass());
     if (failed(runPipeline(passManager, moduleOp))) {
       return signalPassFailure();


### PR DESCRIPTION
This is a followup for https://github.com/iree-org/iree/commit/9aaae342bde3a469e5156214669866fd4ba57531, the op is no longer needed.