### PR TITLE
[Stream] Teach allocation of encoding to take bcast map into account

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
@@ -179,7 +179,7 @@ MaterializeEncodingInfo getEncodingInfoForMatmul(EncodingAttr encoding,
   MaterializeEncodingInfo encodingInfo;
   auto cDims = getEncodingContractionDims(encoding);
   // The following expects M, N, K, and Batch sizes of at most 1 for now
-  assert(cDims->m.size() <= 1 && cDims->n.size() <= 1 && cDims->k.size() <= 1 &&
+  assert(cDims->m.size() <= 1 && cDims->n.size() <= 1 && cDims->k.size() == 1 &&
          cDims->batch.size() <= 1 &&
          "Expected at most one M, N, K, and Batch dimension");
   std::optional<unsigned> batchDim =

--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
@@ -52,10 +52,12 @@ static RankedTensorType transposeIfNarrowNResult(RankedTensorType tensorType) {
     int m = cDims->m[0];
     int n = cDims->n[0];
     std::swap(permIndices[m], permIndices[n]);
-    int mDim = encoding.mapDimToOperandIndex(m);
-    int nDim = encoding.mapDimToOperandIndex(n);
-    std::swap(newShape[mDim], newShape[nDim]);
-    std::swap(newOriginalShape[mDim], newOriginalShape[nDim]);
+    std::optional<unsigned> mDim = encoding.mapDimToOperandIndex(m);
+    std::optional<unsigned> nDim = encoding.mapDimToOperandIndex(n);
+    if (mDim.has_value() && nDim.has_value()) {
+      std::swap(newShape[mDim.value()], newShape[nDim.value()]);
+      std::swap(newOriginalShape[mDim.value()], newOriginalShape[nDim.value()]);
+    }
   }
   // Vector case: there is no N dimension to swap the M dimension with. We
   // swap the maps themselves.
@@ -174,36 +176,38 @@ int64_t getIntOrZero(IntegerAttr a) {
 MaterializeEncodingInfo getEncodingInfoForMatmul(EncodingAttr encoding,
                                                  int64_t rank,
                                                  TileMxNxK tileMxNxK) {
-  auto index = encoding.getOperandIndex().getValue();
   MaterializeEncodingInfo encodingInfo;
   auto cDims = getEncodingContractionDims(encoding);
   // The following expects M, N, K, and Batch sizes of at most 1 for now
   assert(cDims->m.size() <= 1 && cDims->n.size() <= 1 && cDims->k.size() <= 1 &&
          cDims->batch.size() <= 1 &&
          "Expected at most one M, N, K, and Batch dimension");
-  if (!cDims->batch.empty()) {
-    encodingInfo.outerDimsPerm.push_back(
-        encoding.mapDimToOperandIndex(cDims->batch[0]));
+  std::optional<unsigned> batchDim =
+      cDims->batch.empty() ? std::nullopt
+                           : encoding.mapDimToOperandIndex(cDims->batch[0]);
+  std::optional<unsigned> mDim =
+      cDims->m.empty() ? std::nullopt
+                       : encoding.mapDimToOperandIndex(cDims->m[0]);
+  std::optional<unsigned> nDim =
+      cDims->n.empty() ? std::nullopt
+                       : encoding.mapDimToOperandIndex(cDims->n[0]);
+  std::optional<unsigned> kDim = encoding.mapDimToOperandIndex(cDims->k[0]);
+  if (batchDim.has_value()) {
+    encodingInfo.outerDimsPerm.push_back(batchDim.value());
   }
-  if (index != IREE::Encoding::MATMUL_RHS && !cDims->m.empty()) {
-    encodingInfo.outerDimsPerm.push_back(
-        encoding.mapDimToOperandIndex(cDims->m[0]));
-    encodingInfo.innerDimsPos.push_back(
-        encoding.mapDimToOperandIndex(cDims->m[0]));
+  if (mDim.has_value()) {
+    encodingInfo.outerDimsPerm.push_back(mDim.value());
+    encodingInfo.innerDimsPos.push_back(mDim.value());
     encodingInfo.innerTileSizes.push_back(tileMxNxK.M);
   }
-  if (index != IREE::Encoding::MATMUL_LHS && !cDims->n.empty()) {
-    encodingInfo.outerDimsPerm.push_back(
-        encoding.mapDimToOperandIndex(cDims->n[0]));
-    encodingInfo.innerDimsPos.push_back(
-        encoding.mapDimToOperandIndex(cDims->n[0]));
+  if (nDim.has_value()) {
+    encodingInfo.outerDimsPerm.push_back(nDim.value());
+    encodingInfo.innerDimsPos.push_back(nDim.value());
     encodingInfo.innerTileSizes.push_back(tileMxNxK.N);
   }
-  if (index != IREE::Encoding::MATMUL_RESULT) {
-    encodingInfo.outerDimsPerm.push_back(
-        encoding.mapDimToOperandIndex(cDims->k[0]));
-    encodingInfo.innerDimsPos.push_back(
-        encoding.mapDimToOperandIndex(cDims->k[0]));
+  if (kDim.has_value()) {
+    encodingInfo.outerDimsPerm.push_back(kDim.value());
+    encodingInfo.innerDimsPos.push_back(kDim.value());
     encodingInfo.innerTileSizes.push_back(tileMxNxK.K);
   }
   return encodingInfo;

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingBase.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingBase.td
@@ -100,12 +100,16 @@ def EncodingAttr :
   ];
 
   let extraClassDeclaration = [{
-    /// Returns the indexing map used by the operand index in the encoding.
+    /// Returns the bcast_map composed with the user_indexing_map for the
+    /// operand_index. The dimensions of the returned map are those of the
+    /// data-tiled op's iteration space, and the results of the map are in
+    /// the domain of the encoded tensor type.
     AffineMap getMapForOperandIndex();
 
     /// Given the dim position of the encoding `user_indexing_maps`, returns the
-    /// matching index of the given encoding's tensor.
-    unsigned mapDimToOperandIndex(int64_t dimPos);
+    /// matching index of the given encoding's tensor, using getMapForOperandIndex
+    /// bcast_map and user_indexing_map.
+    std::optional<unsigned> mapDimToOperandIndex(int64_t dimPos);
 
     /// Returns an integer array with values in `round_dims_to`.
     ArrayRef<int64_t> getRoundDimsToArray();

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.cpp
@@ -140,11 +140,9 @@ AffineMap EncodingAttr::getMapForOperandIndex() {
   }
 }
 
-unsigned EncodingAttr::mapDimToOperandIndex(int64_t dimPos) {
-  AffineMap map = getMapForOperandIndex();
-  auto idx = map.getResultPosition(getAffineDimExpr(dimPos, getContext()));
-  assert(idx.has_value());
-  return idx.value();
+std::optional<unsigned> EncodingAttr::mapDimToOperandIndex(int64_t dimPos) {
+  return getMapForOperandIndex().getResultPosition(
+      getAffineDimExpr(dimPos, getContext()));
 }
 
 ArrayRef<int64_t> EncodingAttr::getRoundDimsToArray() {

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.cpp
@@ -127,9 +127,14 @@ AffineMap EncodingAttr::getMapForOperandIndex() {
   switch (index) {
   case MATMUL_LHS:
   case MATMUL_RHS:
-  case MATMUL_RESULT:
-    return llvm::cast<AffineMapAttr>(getUserIndexingMaps()[index])
-        .getAffineMap();
+  case MATMUL_RESULT: {
+    auto indexingMap =
+        llvm::cast<AffineMapAttr>(getUserIndexingMaps()[index]).getAffineMap();
+    if (auto bcastMap = getBcastMap()) {
+      indexingMap = bcastMap.getAffineMap().compose(indexingMap);
+    }
+    return indexingMap;
+  }
   default:
     return AffineMap();
   }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/encode_host_tensors.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/encode_host_tensors.mlir
@@ -87,7 +87,7 @@ util.func public @sizeof_result_encoding_dynamic(%arg0: index, %arg1: index) -> 
 #map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 #map3 = affine_map<(d0, d1, d2) -> (d1, d2)>
 util.func public @sizeof_lhs_encoding_with_bcast_across_batch_dim_dynamic(%arg0: index, %arg1: index) -> index {
-  %0 = stream.tensor.sizeof tensor<?x?xf32, #iree_encoding.encoding<operand_index = 0, element_types = [f32, f32, f32], original_type = tensor<?x?xf32>, user_indexing_maps = [#map, #map1, #map2], bcast_map = #map3, round_dims_to = array<i64: 4, 8, 16>>>{%arg0, %arg1} : index
+  %0 = stream.tensor.sizeof tensor<?x?xf32, #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f32, f32, f32], original_type = tensor<?x?xf32>, user_indexing_maps = [#map, #map1, #map2], bcast_map = #map3, round_dims_to = array<i64: 4, 8, 16>>>{%arg0, %arg1} : index
   util.return %0 : index
 }
 // CHECK-LABEL: @sizeof_lhs_encoding_with_bcast_across_batch_dim_dynamic
@@ -108,7 +108,7 @@ util.func public @sizeof_lhs_encoding_with_bcast_across_batch_dim_dynamic(%arg0:
 #map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 #map3 = affine_map<(d0, d1, d2) -> (d0, d2)>
 util.func public @sizeof_lhs_encoding_with_bcast_across_m_dim_dynamic(%arg0: index, %arg1: index) -> index {
-  %0 = stream.tensor.sizeof tensor<?x?xf32, #iree_encoding.encoding<operand_index = 0, element_types = [f32, f32, f32], original_type = tensor<?x?xf32>, user_indexing_maps = [#map, #map1, #map2], bcast_map = #map3, round_dims_to = array<i64: 4, 8, 16>>>{%arg0, %arg1} : index
+  %0 = stream.tensor.sizeof tensor<?x?xf32, #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f32, f32, f32], original_type = tensor<?x?xf32>, user_indexing_maps = [#map, #map1, #map2], bcast_map = #map3, round_dims_to = array<i64: 4, 8, 16>>>{%arg0, %arg1} : index
   util.return %0 : index
 }
 // CHECK-LABEL: @sizeof_lhs_encoding_with_bcast_across_m_dim_dynamic

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/encode_host_tensors.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/encode_host_tensors.mlir
@@ -82,6 +82,49 @@ util.func public @sizeof_result_encoding_dynamic(%arg0: index, %arg1: index) -> 
 
 // -----
 
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+#map3 = affine_map<(d0, d1, d2) -> (d1, d2)>
+util.func public @sizeof_lhs_encoding_with_bcast_across_batch_dim_dynamic(%arg0: index, %arg1: index) -> index {
+  %0 = stream.tensor.sizeof tensor<?x?xf32, #iree_encoding.encoding<operand_index = 0, element_types = [f32, f32, f32], original_type = tensor<?x?xf32>, user_indexing_maps = [#map, #map1, #map2], bcast_map = #map3, round_dims_to = array<i64: 4, 8, 16>>>{%arg0, %arg1} : index
+  util.return %0 : index
+}
+// CHECK-LABEL: @sizeof_lhs_encoding_with_bcast_across_batch_dim_dynamic
+// CHECK-DAG:     %[[C4:.+]] = arith.constant 4 : index
+// CHECK-DAG:     %[[C16:.+]] = arith.constant 16 : index
+// CHECK:         %[[CEIL_DIV_D0:.+]] = arith.ceildivui %arg0, %[[C4]]
+// CHECK:         %[[PAD_D0:.+]] = arith.muli %[[CEIL_DIV_D0]], %[[C4]]
+// CHECK:         %[[CEIL_DIV_D1:.+]] = arith.ceildivui %arg1, %[[C16]]
+// CHECK:         %[[PAD_D1:.+]] = arith.muli %[[CEIL_DIV_D1]], %[[C16]]
+// CHECK:         %[[T0:.+]] = arith.muli %[[PAD_D0]], %[[C4]]
+// CHECK:         %[[T1:.+]] = arith.muli %[[T0]], %[[PAD_D1]]
+// CHECK:         return %[[T1]]
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+#map3 = affine_map<(d0, d1, d2) -> (d0, d2)>
+util.func public @sizeof_lhs_encoding_with_bcast_across_m_dim_dynamic(%arg0: index, %arg1: index) -> index {
+  %0 = stream.tensor.sizeof tensor<?x?xf32, #iree_encoding.encoding<operand_index = 0, element_types = [f32, f32, f32], original_type = tensor<?x?xf32>, user_indexing_maps = [#map, #map1, #map2], bcast_map = #map3, round_dims_to = array<i64: 4, 8, 16>>>{%arg0, %arg1} : index
+  util.return %0 : index
+}
+// CHECK-LABEL: @sizeof_lhs_encoding_with_bcast_across_m_dim_dynamic
+// CHECK-DAG:     %[[C4:.+]] = arith.constant 4 : index
+// CHECK-DAG:     %[[C16:.+]] = arith.constant 16 : index
+// CHECK:         %[[CEIL_DIV_D1:.+]] = arith.ceildivui %arg1, %[[C16]]
+// CHECK:         %[[PAD_D1:.+]] = arith.muli %[[CEIL_DIV_D1]], %[[C16]]
+//
+// Multiplied by 4 because f32 has 4 bytes.
+//
+// CHECK:         %[[T0:.+]] = arith.muli %arg0, %[[C4]]
+// CHECK:         %[[T1:.+]] = arith.muli %[[T0]], %[[PAD_D1]]
+// CHECK:         return %[[T1]]
+
+// -----
+
 // CHECK-LABEL: @denseTensorEmpty
 util.func public @denseTensorEmpty(%arg0: index, %arg1: index) -> !stream.resource<*> {
   // CHECK: %[[RET:.+]] = stream.async.alloca : !stream.resource<*>{%arg1}

--- a/compiler/src/iree/compiler/Utils/ElementPackingUtils.cpp
+++ b/compiler/src/iree/compiler/Utils/ElementPackingUtils.cpp
@@ -71,10 +71,9 @@ Value calculateStorageElementCountInBytes(Location loc,
     auto roundDimsTo = encoding.getRoundDimsToArray();
     FailureOr<linalg::ContractionDimensions> cDims =
         IREE::Encoding::getEncodingContractionDims(encoding);
-    auto indexingMap = encoding.getMapForOperandIndex();
     auto pad = [&](int dim, int value) {
       std::optional<unsigned> maybeMappedDim =
-          indexingMap.getResultPosition(builder.getAffineDimExpr(dim));
+          encoding.mapDimToOperandIndex(dim);
       if (!maybeMappedDim) {
         return;
       }


### PR DESCRIPTION
The bcast_map represents the iteration domain mapping from the source of dispatch to matmul. So it uses bcast_map in `getMapForOperandIndex()` when it is present. This PR also updates the `mapDimToOperandIndex()` method to return `std::optional<unsigned>`, because it now uses the composed bcast_map and user_indexing_map, and some contraction dims may not be present in a broadcasted indexing map's results.