### PR TITLE
[onnx] Enable `f64` backends for `onnx` test suite

### DIFF
--- a/build_tools/pkgci/external_test_suite/onnx_cpu_llvm_sync.json
+++ b/build_tools/pkgci/external_test_suite/onnx_cpu_llvm_sync.json
@@ -2,7 +2,7 @@
   "config_name": "cpu_llvm_sync",
   "iree_compile_flags": [
     "--iree-hal-target-backends=llvm-cpu",
-    "--iree-input-demote-f64-to-f32"
+    "--iree-input-demote-f64-to-f32=false"
   ],
   "iree_run_module_flags": [
     "--device=local-sync"

--- a/build_tools/pkgci/external_test_suite/onnx_gpu_cuda.json
+++ b/build_tools/pkgci/external_test_suite/onnx_gpu_cuda.json
@@ -2,7 +2,7 @@
   "config_name": "gpu_cuda_t4",
   "iree_compile_flags": [
     "--iree-hal-target-backends=cuda",
-    "--iree-input-demote-f64-to-f32"
+    "--iree-input-demote-f64-to-f32=false"
   ],
   "iree_run_module_flags": [
     "--device=cuda"

--- a/build_tools/pkgci/external_test_suite/onnx_gpu_rocm_rdna3.json
+++ b/build_tools/pkgci/external_test_suite/onnx_gpu_rocm_rdna3.json
@@ -3,7 +3,7 @@
   "iree_compile_flags": [
     "--iree-hal-target-backends=rocm",
     "--iree-rocm-target-chip=gfx1100",
-    "--iree-input-demote-f64-to-f32"
+    "--iree-input-demote-f64-to-f32=false"
   ],
   "iree_run_module_flags": [
     "--device=hip"


### PR DESCRIPTION
For `rocm` `cpu` and `cuda` we can support `f64` types for the onnx backend. It makes more sense to support testing using these types on backends where it is available.