### PR TITLE
Merge 3 mi300 test/benchmark jobs into 1.

### DIFF
--- a/.github/workflows/pkgci_regression_test.yml
+++ b/.github/workflows/pkgci_regression_test.yml
@@ -145,9 +145,6 @@ jobs:
           - name: amdgpu_rocm_mi250_gfx90a
             models-config-file: models_gpu_rocm_gfx90a.json
             runs-on: nodai-amdgpu-mi250-x86-64
-          - name: amdgpu_rocm_mi300_gfx942
-            models-config-file: models_gpu_rocm_gfx942.json
-            runs-on: nodai-amdgpu-mi300-x86-64
           - name: amdgpu_vulkan
             models-config-file: models_gpu_vulkan.json
             runs-on: nodai-amdgpu-w7900-x86-64
@@ -169,12 +166,6 @@ jobs:
       VENV_DIR: ${{ github.workspace }}/venv
       LD_LIBRARY_PATH: /home/esaimana/Python-3.11.9
     steps:
-      # TODO(saienduri): Find alternative to this temporary step that manipulates permission of github actions
-      # directory to be able to clean after every PR
-      - name: Pre Checkout MI300 Step
-        if: contains(matrix.name, 'gfx942')
-        run: |
-          sudo chmod -R 777 ~/actions-runner/_work
       - name: Checking out IREE repository
         uses: actions/checkout@v4.1.7
         with:
@@ -250,10 +241,6 @@ jobs:
             rocm-chip: gfx90a
             backend: rocm
             runs-on: nodai-amdgpu-mi250-x86-64
-          - name: amdgpu_rocm_mi300_gfx942
-            rocm-chip: gfx942
-            backend: rocm
-            runs-on: nodai-amdgpu-mi300-x86-64
     env:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
       IREERS_ARTIFACT_DIR: ${{ github.workspace }}/artifacts
@@ -262,12 +249,6 @@ jobs:
       VENV_DIR: ${{ github.workspace }}/venv
       LD_LIBRARY_PATH: /home/esaimana/Python-3.11.9
     steps:
-      # TODO(saienduri): Find alternative to this temporary step that manipulates permission of github actions
-      # directory to be able to clean after every PR
-      - name: Pre Checkout MI300 Step
-        if: contains(matrix.name, 'gfx942')
-        run: |
-          sudo chmod -R 777 ~/actions-runner/_work
       - name: Checking out IREE repository
         uses: actions/checkout@v4.1.7
         with:
@@ -347,24 +328,3 @@ jobs:
             --retries 7
           echo "$(<job_summary.md )" >> $GITHUB_STEP_SUMMARY
           rm job_summary.md
-
-      - name: "Running SDXL rocm pipeline benchmark (mi300)"
-        if: contains(matrix.name, 'rocm_mi300_gfx942')
-        run: |
-          source ${VENV_DIR}/bin/activate
-          pytest ./experimental/benchmarks/sdxl/benchmark_sdxl_rocm.py \
-            --goldentime-rocm-e2e-ms 325.0 \
-            --goldentime-rocm-unet-ms 77.0 \
-            --goldentime-rocm-clip-ms 15.5 \
-            --goldentime-rocm-vae-ms 74.0 \
-            --goldendispatch-rocm-unet 1714 \
-            --goldendispatch-rocm-clip 1569 \
-            --goldendispatch-rocm-vae 248 \
-            --goldensize-rocm-unet-bytes 2270000 \
-            --goldensize-rocm-clip-bytes 860000  \
-            --goldensize-rocm-vae-bytes 840000 \
-            --gpu-number 0 \
-            --rocm-chip gfx942 \
-            --log-cli-level=info \
-            --retries 7
-          echo "$(<job_summary.md )" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -42,7 +42,6 @@ jobs:
       #                  manipulates permission of github actions
       #                  directory to be able to clean after every PR
       - name: "Pre Checkout MI300 Step"
-        if: contains(matrix.name, 'gfx942')
         run: |
           sudo chmod -R 777 ~/actions-runner/_work
       - name: "Checking out repository"
@@ -122,7 +121,7 @@ jobs:
         run: |
           source ${VENV_DIR}/bin/activate
           pytest ./experimental/regression_suite/shark-test-suite-models/sdxl \
-            -k ${{ matrix.backend }} \
+            -k rocm \
             -rpfE \
             --capture=no \
             --log-cli-level=info \
@@ -133,7 +132,7 @@ jobs:
         run: |
           source ${VENV_DIR}/bin/activate
           pytest ./experimental/regression_suite/shark-test-suite-models/sd3 \
-            -k ${{ matrix.backend }} \
+            -k rocm \
             -rpfE \
             --capture=no \
             --log-cli-level=info \

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -21,21 +21,31 @@ jobs:
   test:
     runs-on: nodai-amdgpu-mi300-x86-64
     env:
+      # General environment variables.
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
-      BUILD_DIR: build-tests
       VENV_DIR: ${{ github.workspace }}/.venv
+      LD_LIBRARY_PATH: /home/esaimana/Python-3.11.9
+      # Environment variables for CMake/CTest.
+      BUILD_DIR: build-tests
       IREE_CPU_DISABLE: 1
       IREE_VULKAN_DISABLE: 1
       IREE_CUDA_DISABLE: 1
       IREE_HIP_DISABLE: 0
       IREE_HIP_TEST_TARGET_CHIP: "gfx942"
-      LD_LIBRARY_PATH: /home/esaimana/Python-3.11.9
+      # Environment variables for pytest.
+      IREE_TEST_FILES: ~/iree_tests_cache
+      IREE_TEST_PATH_EXTENSION: ${{ github.workspace }}/build_tools/pkgci/external_test_suite
+      ROCM_CHIP: "gfx942"
     steps:
-      - name: Pre Checkout MI300 Step
+      # Setup.
+      # TODO(saienduri): Find alternative to this temporary step that
+      #                  manipulates permission of github actions
+      #                  directory to be able to clean after every PR
+      - name: "Pre Checkout MI300 Step"
         if: contains(matrix.name, 'gfx942')
         run: |
           sudo chmod -R 777 ~/actions-runner/_work
-      - name: Checking out repository
+      - name: "Checking out repository"
         uses: actions/checkout@v4.1.7
         with:
           submodules: false
@@ -49,14 +59,30 @@ jobs:
         with:
           name: linux_x86_64_release_packages
           path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
-      - name: Setup base venv
+      - name: "Setting up base venv"
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
             --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
             --fetch-gh-workflow=${{ inputs.artifact_run_id }}
-      - name: "Building tests"
+      - name: "Checking out external TestSuite repository"
+        uses: actions/checkout@v4.1.7
+        with:
+          repository: nod-ai/SHARK-TestSuite
+          ref: 1da89a12a8b00dc77506d702f61300803b6240b7
+          path: SHARK-TestSuite
+          submodules: false
+          lfs: true
+      - name: "Installing external TestSuite Python requirements"
+        id: setupEnd
+        run: |
+          source ${VENV_DIR}/bin/activate
+          python -m pip install -r SHARK-TestSuite/iree_tests/requirements.txt
+          pip install --no-compile --pre --upgrade -e SHARK-TestSuite/common_tools
+
+      # Build the runtime and run CTest.
+      - name: "Building CMake tests"
         run: ./build_tools/pkgci/build_tests_using_package.sh ${VENV_DIR}/bin
-      - name: "Running GPU tests"
+      - name: "Running CMake GPU tests"
         env:
           CTEST_PARALLEL_LEVEL: 2
           IREE_CTEST_LABEL_REGEX: ^requires-gpu|^driver=hip$
@@ -65,3 +91,71 @@ jobs:
           IREE_NVIDIA_SM80_TESTS_DISABLE: 1
           IREE_MULTI_DEVICE_TESTS_DISABLE: 0
         run: ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}
+
+      # Run external test suite model tests.
+      - name: "Downloading remote files for real weight model tests"
+        id: externalTestsDownload
+        if: "!cancelled() && steps.setupEnd.outcome == 'success'"
+        run: |
+          source ${VENV_DIR}/bin/activate
+          python SHARK-TestSuite/iree_tests/download_remote_files.py --root-dir iree_tests/pytorch/models
+          python SHARK-TestSuite/iree_tests/download_remote_files.py --root-dir iree_tests/sharktank
+      - name: "Running external tests - models with real weights"
+        if: "!cancelled() && steps.externalTestsDownload.outcome == 'success'"
+        run: |
+          source ${VENV_DIR}/bin/activate
+          pytest \
+            SHARK-TestSuite/iree_tests/pytorch/models \
+            SHARK-TestSuite/iree_tests/sharktank \
+            -rA \
+            -k real_weights \
+            --no-skip-tests-missing-files \
+            --capture=no \
+            --log-cli-level=info \
+            --timeout=1200 \
+            --durations=0 \
+            --config-files=build_tools/pkgci/external_test_suite/models_gpu_rocm_gfx942.json
+
+      # Run special model tests and benchmarks
+      - name: "Running SDXL special model tests"
+        if: "!cancelled() && steps.setupEnd.outcome == 'success'"
+        run: |
+          source ${VENV_DIR}/bin/activate
+          pytest ./experimental/regression_suite/shark-test-suite-models/sdxl \
+            -k ${{ matrix.backend }} \
+            -rpfE \
+            --capture=no \
+            --log-cli-level=info \
+            --timeout=1200 \
+            --durations=0
+      - name: "Running SD3 special model tests"
+        if: "!cancelled() && steps.setupEnd.outcome == 'success'"
+        run: |
+          source ${VENV_DIR}/bin/activate
+          pytest ./experimental/regression_suite/shark-test-suite-models/sd3 \
+            -k ${{ matrix.backend }} \
+            -rpfE \
+            --capture=no \
+            --log-cli-level=info \
+            --timeout=1200 \
+            --durations=0
+      - name: "Running SDXL rocm pipeline benchmark"
+        if: "!cancelled() && steps.setupEnd.outcome == 'success'"
+        run: |
+          source ${VENV_DIR}/bin/activate
+          pytest ./experimental/benchmarks/sdxl/benchmark_sdxl_rocm.py \
+            --goldentime-rocm-e2e-ms 325.0 \
+            --goldentime-rocm-unet-ms 77.0 \
+            --goldentime-rocm-clip-ms 15.5 \
+            --goldentime-rocm-vae-ms 74.0 \
+            --goldendispatch-rocm-unet 1714 \
+            --goldendispatch-rocm-clip 1569 \
+            --goldendispatch-rocm-vae 248 \
+            --goldensize-rocm-unet-bytes 2270000 \
+            --goldensize-rocm-clip-bytes 860000  \
+            --goldensize-rocm-vae-bytes 840000 \
+            --gpu-number 0 \
+            --rocm-chip gfx942 \
+            --log-cli-level=info \
+            --retries 7
+          echo "$(<job_summary.md )" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This merges these three jobs into 1:
* `Regression Test / test_models :: amdgpu_rocm_mi300_gfx942`
* `Regression Test / test_regression_suite :: amdgpu_rocm_mi300_gfx942`
* `Test AMD MI300 / test`

Our mi300 actions runner has been taking 5-10 minutes to download 70MB of artifacts when other runners take less than 5 seconds for the exact same file download. Merging these jobs will share the download across each set of steps and hopefully cut queue times down significantly while we figure out how to stabilize the runner.

I generally also like the idea of splitting the matrices in `.github/workflows/pkgci_regression_test.yml` back into individual jobs for each runner / accelerator, since that will allow for finer-grained filtering. However, the unit tests and benchmarks should still be kept separate.

ci-exactly: build_packages, test_amd_mi300