### PR TITLE
Disable `demoteF64ToF32` for JitGlobals

### DIFF
--- a/compiler/src/iree/compiler/ConstEval/JitGlobals.cpp
+++ b/compiler/src/iree/compiler/ConstEval/JitGlobals.cpp
@@ -624,6 +624,7 @@ struct JitGlobalsPass : public JitGlobalsBase<JitGlobalsPass> {
     compileOptions->targetOptions.f32Extension = true;
     compileOptions->targetOptions.f64Extension = true;
     compileOptions->targetOptions.truncateUnsupportedFloats = false;
+    compileOptions->inputOptions.demoteF64ToF32 = false;
     if (requestedTargetDevice == "vmvx" || !hasRequestedTargetDevice) {
       targetDevice = targetRegistry->getTargetDevice("vmvx");
     } else {


### PR DESCRIPTION
If an `f64` exists up until the point of jitting globals that means `f64` is enabled at runtime and these should be preserved so we can safely allow `f64` types during the jitting process.