### PR TITLE
ConvertToLLVM depends on AffineDialect

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -921,7 +921,8 @@ public:
   }
   ConvertToLLVMPass(const ConvertToLLVMPass &pass) {}
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<LLVM::LLVMDialect, arm_neon::ArmNeonDialect>();
+    registry.insert<LLVM::LLVMDialect, arm_neon::ArmNeonDialect,
+                    affine::AffineDialect>();
   }
 
   void runOnOperation() override;


### PR DESCRIPTION
The undeclared dependency comes from VectorToSCF patterns creating `affine.apply` ops.

This PR fixes the following testcase (not worth adding as a test):

```
tools/iree-opt --iree-convert-to-llvm test.mlir
```

Where `test.mlir` is:

```mlir
module {
  func.func @test_logsoftmax_axis_1_expanded$async_dispatch_2_generic_3x5x4_f32() attributes {translation_info = #iree_codegen.translation_info<None workgroup_size = [1, 64, 1] subgroup_size = 32>} {
    %cst_12 = arith.constant dense<1.44269502> : vector<4x1xf32>
    %cst_14 = arith.constant dense<5.000000e-01> : vector<4x1xf32>
    %c0 = arith.constant 0 : index
    %c0f32 = arith.constant 0.0 : f32

    %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : memref<4x1xf32>
    memref.assume_alignment %1, 64 : memref<4x1xf32>
    
    %33 = vector.transfer_read %1[%c0, %c0], %c0f32 {in_bounds = [true, true]} :
      memref<4x1xf32>, vector<4x1xf32>
    %34 = math.fma %33, %cst_12, %cst_14 : vector<4x1xf32>

    vector.transfer_write %34, %1 [%c0, %c0] {in_bounds = [true, true]} :
      vector<4x1xf32>, memref<4x1xf32>

    return
  }
}
```