### PR TITLE
[Flow] Add pass to bubble and hoist encoding ops out of dispatch regions

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingBase.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingBase.td
@@ -113,6 +113,9 @@ def EncodingAttr :
 
     /// Returns an integer array with values in `round_dims_to`.
     ArrayRef<int64_t> getRoundDimsToArray();
+
+    /// Clones an encoding with a new bcast_map
+    EncodingAttr clone(AffineMap bcastMap);
   }];
 
   let genVerifyDecl = 0;

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.cpp
@@ -153,6 +153,13 @@ ArrayRef<int64_t> EncodingAttr::getRoundDimsToArray() {
   return llvm::cast<DenseI64ArrayAttr>(roundDimsTo).asArrayRef();
 }
 
+EncodingAttr EncodingAttr::clone(AffineMap bcastMap) {
+  return get(bcastMap.getContext(), getOperandIndex(), getOpType(),
+             getElementTypes(), getOriginalType(), getMatmulNarrow_M(),
+             getMatmulNarrow_N(), getUserIndexingMaps(),
+             AffineMapAttr::get(bcastMap), getRoundDimsTo());
+}
+
 //===---------------------------------------------------------------------===//
 // Encoding Dialect Helpers
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD.bazel
@@ -55,6 +55,7 @@ iree_compiler_cc_library(
         "FuseMultiUseElementwiseProducer.cpp",
         "FusionPreprocessing.cpp",
         "FusionUtils.cpp",
+        "HoistEncodingOps.cpp",
         "InitializeEmptyTensors.cpp",
         "InjectDispatchTracing.cpp",
         "InjectTensorTracing.cpp",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -55,6 +55,7 @@ iree_cc_library(
     "FuseMultiUseElementwiseProducer.cpp"
     "FusionPreprocessing.cpp"
     "FusionUtils.cpp"
+    "HoistEncodingOps.cpp"
     "InitializeEmptyTensors.cpp"
     "InjectDispatchTracing.cpp"
     "InjectTensorTracing.cpp"

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/HoistEncodingOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/HoistEncodingOps.cpp
@@ -1,0 +1,242 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Encoding/IR/EncodingDialect.h"
+#include "iree/compiler/Dialect/Encoding/IR/EncodingOps.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
+#include "iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h"
+#include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/Debug.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Utils/Utils.h"
+#include "mlir/Dialect/MemRef/Transforms/Transforms.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/StructuredOpsUtils.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "iree-flow-hoist-encoding-ops"
+
+namespace mlir::iree_compiler::IREE::Flow {
+#define GEN_PASS_DEF_HOISTENCODINGOPSPASS
+#include "iree/compiler/Dialect/Flow/Transforms/Passes.h.inc"
+
+static AffineMap getBcastMapOrIdentity(RewriterBase &rewriter,
+                                       RankedTensorType encodedType) {
+  auto encoding = cast<IREE::Encoding::EncodingAttr>(encodedType.getEncoding());
+  AffineMapAttr bcastMapAttr = encoding.getBcastMap();
+  return bcastMapAttr ? bcastMapAttr.getAffineMap()
+                      : rewriter.getMultiDimIdentityMap(encodedType.getRank());
+}
+
+static LogicalResult
+bubbleUpSetEncodingThroughBroadcastOp(RewriterBase &rewriter,
+                                      IREE::Encoding::SetEncodingOp encodingOp,
+                                      linalg::BroadcastOp broadcastOp) {
+  if (!broadcastOp->hasOneUse()) {
+    return failure();
+  }
+  RankedTensorType encodedType = encodingOp.getResultType();
+
+  // Create new encoding and set encoding on broadcast input.
+  AffineMap bcastMap = getBcastMapOrIdentity(rewriter, encodedType);
+  bcastMap = bcastMap.dropResults(broadcastOp.getDimensions());
+  Value input = broadcastOp.getInput();
+  auto encoding = cast<IREE::Encoding::EncodingAttr>(encodedType.getEncoding());
+  auto newEncoding = encoding.clone(bcastMap);
+  auto inputType = cast<RankedTensorType>(input.getType());
+  auto resType = RankedTensorType::get(inputType.getShape(),
+                                       inputType.getElementType(), newEncoding);
+  Location loc = broadcastOp->getLoc();
+  IREE::Encoding::SetEncodingOp newSetEncoding =
+      rewriter.create<IREE::Encoding::SetEncodingOp>(loc, resType, input);
+
+  // Create encoded broadcast op.
+  SmallVector<OpFoldResult> mixedSizes =
+      tensor::getMixedSizes(rewriter, loc, encodingOp.getSource());
+  Value encodedBCastInit = rewriter.create<tensor::EmptyOp>(
+      loc, mixedSizes, encodedType.getElementType(), encoding);
+  SmallVector<Value> encodedBCastOperands = {newSetEncoding.getResult(),
+                                             encodedBCastInit};
+  auto encodedBroadcast = clone(
+      rewriter, broadcastOp, encodingOp.getResultType(), encodedBCastOperands);
+
+  rewriter.replaceOp(encodingOp, encodedBroadcast);
+  return success();
+}
+
+static LogicalResult
+bubbleUpSetEncodingThroughGenericOp(RewriterBase &rewriter,
+                                    IREE::Encoding::SetEncodingOp encodingOp,
+                                    linalg::GenericOp genericOp) {
+  if (!genericOp->hasOneUse()) {
+    return failure();
+  }
+  if (genericOp.getNumDpsInits() != 1) {
+    return failure();
+  }
+  if (genericOp.getNumReductionLoops() != 0) {
+    return failure();
+  }
+  AffineMap outputMap =
+      genericOp.getMatchingIndexingMap(genericOp.getDpsInitOperand(0));
+  if (!outputMap.isIdentity()) {
+    return rewriter.notifyMatchFailure(genericOp, "output map not identity");
+  }
+
+  RankedTensorType encodedType = encodingOp.getResultType();
+  AffineMap bcastMap = getBcastMapOrIdentity(rewriter, encodedType);
+  if (outputMap.getNumDims() != bcastMap.getNumDims()) {
+    return rewriter.notifyMatchFailure(
+        genericOp, "output map dims do not match bcast_map dims");
+  }
+
+  // Set encodings on each input
+  Location loc = genericOp->getLoc();
+  SmallVector<Value> encodedOperands;
+  auto encoding = cast<IREE::Encoding::EncodingAttr>(encodedType.getEncoding());
+  for (OpOperand *operand : genericOp.getDpsInputOperands()) {
+    // Compute the new bcastMap from the operand's indexing map.
+    AffineMap operandMap = genericOp.getMatchingIndexingMap(operand);
+    AffineMap newBcastMap = operandMap.compose(bcastMap);
+
+    // Create new encoding and set encoding on the operand.
+    auto newEncoding = encoding.clone(newBcastMap);
+    auto operandType = cast<RankedTensorType>(operand->get().getType());
+    auto resType = RankedTensorType::get(
+        operandType.getShape(), operandType.getElementType(), newEncoding);
+    Value encodedInput = rewriter.create<IREE::Encoding::SetEncodingOp>(
+        loc, resType, operand->get());
+    encodedOperands.push_back(encodedInput);
+  }
+
+  // Create encoded generic op.
+  SmallVector<OpFoldResult> mixedSizes =
+      tensor::getMixedSizes(rewriter, loc, encodingOp.getSource());
+  Value encodedInit = rewriter.create<tensor::EmptyOp>(
+      loc, mixedSizes, encodedType.getElementType(), encoding);
+  encodedOperands.push_back(encodedInit);
+  auto encodedGenericOp =
+      clone(rewriter, genericOp, encodingOp.getResultType(), encodedOperands);
+
+  rewriter.replaceOp(encodingOp, encodedGenericOp);
+  return success();
+}
+
+static LogicalResult bubbleUpSetEncoding(RewriterBase &rewriter,
+                                         OpOperand &operand) {
+  auto setEncoding = cast<Encoding::SetEncodingOp>(operand.getOwner());
+  Operation *producer = operand.get().getDefiningOp();
+  if (!producer) {
+    return failure();
+  }
+
+  // Only bubble through dequantization ops and broadcasting ops for now.
+  if (!LinalgExt::isBitExtendOp(producer) && !isBroadcastingOp(producer)) {
+    return failure();
+  }
+
+  return TypeSwitch<Operation *, LogicalResult>(producer)
+      .Case<linalg::GenericOp>([&](linalg::GenericOp genericOp) {
+        return bubbleUpSetEncodingThroughGenericOp(rewriter, setEncoding,
+                                                   genericOp);
+      })
+      .Case<linalg::BroadcastOp>([&](linalg::BroadcastOp broadcastOp) {
+        return bubbleUpSetEncodingThroughBroadcastOp(rewriter, setEncoding,
+                                                     broadcastOp);
+      })
+      .Default([](Operation *op) { return failure(); });
+}
+
+namespace {
+/// Pass declaration.
+struct HoistEncodingOpsPass
+    : public IREE::Flow::impl::HoistEncodingOpsPassBase<HoistEncodingOpsPass> {
+  using IREE::Flow::impl::HoistEncodingOpsPassBase<
+      HoistEncodingOpsPass>::HoistEncodingOpsPassBase;
+  void runOnOperation() override;
+};
+
+/// Pattern to bubble SetEncoding ops upwards through producers. This pattern
+/// runs until bubbling is not possible, or until the SetEncoding op is outside
+/// of a dispatch.
+struct HoistSetEncodingOp
+    : public OpRewritePattern<IREE::Encoding::SetEncodingOp> {
+  using OpRewritePattern<IREE::Encoding::SetEncodingOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(IREE::Encoding::SetEncodingOp encodingOp,
+                                PatternRewriter &rewriter) const override {
+    if (isNonNullAndOutsideDispatch(encodingOp)) {
+      return failure();
+    }
+    // Try to hoist the SetEncodingOp out of the dispatch region.
+    if (succeeded(hoistOutOfDispatch(rewriter, encodingOp))) {
+      return success();
+    }
+
+    // Otherwise, try to bubble the SetEncodingOp past its producer op.
+    return bubbleUpSetEncoding(rewriter, encodingOp->getOpOperand(0));
+  }
+};
+
+/// Pattern to bubble SetEncoding ops upwards through producers. This pattern
+/// runs until bubbling is not possible, or until the SetEncoding op is outside
+/// of a dispatch.
+struct HoistUnsetEncodingOp
+    : public OpRewritePattern<IREE::Encoding::UnsetEncodingOp> {
+  using OpRewritePattern<IREE::Encoding::UnsetEncodingOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(IREE::Encoding::UnsetEncodingOp encodingOp,
+                                PatternRewriter &rewriter) const override {
+    if (isNonNullAndOutsideDispatch(encodingOp)) {
+      return failure();
+    }
+    if (!encodingOp->hasOneUse()) {
+      return failure();
+    }
+    // First check for extract_slice op, and hoist the extract_slice.
+    SmallVector<Operation *> users(encodingOp->getUsers());
+    auto extractSliceOp = dyn_cast<tensor::ExtractSliceOp>(users.front());
+    if (!extractSliceOp) {
+      return hoistOutOfDispatch(rewriter, encodingOp);
+    }
+    if (!extractSliceOp->hasOneUse()) {
+      return failure();
+    }
+    if (failed(hoistOutOfDispatch(rewriter, extractSliceOp))) {
+      return failure();
+    }
+    return hoistOutOfDispatch(rewriter, encodingOp);
+  }
+};
+} // namespace
+
+/// Create dispatch.region Ops based on a fusion heuristic.
+void HoistEncodingOpsPass::runOnOperation() {
+  MLIRContext *ctx = &getContext();
+  IRRewriter rewriter(ctx);
+
+  RewritePatternSet patterns(ctx);
+  patterns.insert<HoistSetEncodingOp>(ctx);
+  //   patterns.insert<HoistUnsetEncodingOp>(ctx);
+  memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);
+  if (failed(
+          applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
+    return signalPassFailure();
+  }
+}
+} // namespace mlir::iree_compiler::IREE::Flow

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/HoistEncodingOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/HoistEncodingOps.cpp
@@ -207,9 +207,10 @@ void HoistEncodingOpsPass::runOnOperation() {
     }
   }
 
-  RewritePatternSet dimPatterns(ctx);
-  memref::populateResolveRankedShapedTypeResultDimsPatterns(dimPatterns);
-  if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(dimPatterns)))) {
+  RewritePatternSet cleanPatterns(ctx);
+  memref::populateResolveRankedShapedTypeResultDimsPatterns(cleanPatterns);
+  DispatchRegionOp::getCanonicalizationPatterns(cleanPatterns, ctx);
+  if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(cleanPatterns)))) {
     return signalPassFailure();
   }
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -285,6 +285,8 @@ static void addDispatchRegionCreationPasses(OpPassManager &passManager) {
                            return createSetEncodingPass(
                                SetEncodingPassOptions{clPadFactor});
                          })
+      .addPredicatedPass(clEnableDataTiling,
+                         IREE::Flow::createHoistEncodingOpsPass)
       // Collapse dimensions of linalg Ops.
       .addPass(IREE::Flow::createCollapseDimensionsPass)
       // Convert dispatch regions into dispatch workgroups by capturing values

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -279,14 +279,24 @@ static void addDispatchRegionCreationPasses(OpPassManager &passManager) {
       // afterwards that would need the full dispatch content but don't want to
       // handle explicit captures as materialized as dispatch workgroup operands
       // and block arguments.
-      .addPass(IREE::Flow::createCloneProducersIntoDispatchRegionsPass)
-      .addPredicatedPass(clEnableDataTiling,
-                         [&]() {
-                           return createSetEncodingPass(
-                               SetEncodingPassOptions{clPadFactor});
-                         })
-      .addPredicatedPass(clEnableDataTiling,
-                         IREE::Flow::createHoistEncodingOpsPass)
+      .addPass(IREE::Flow::createCloneProducersIntoDispatchRegionsPass);
+  // Experimental data tiling path. The intent of this path is to set encodings
+  // after fusion decisions have already been made, so encodings can be
+  // separated from compiler fusion decisions.
+  if (clEnableDataTiling) {
+    SetEncodingPassOptions options{clPadFactor};
+    FunctionLikeNest(passManager)
+        // Set encodings on all eligible ops. All ops should be in compiler
+        // formed dispatch regions, so encodings will be placed inside of the
+        // dispatch regions with the data-tiled op.
+        .addPass([&]() { return createSetEncodingPass(options); })
+        // SetEncodingOps should not be in the same dispatch as the data-tiled
+        // op, so hoist them out of their current dispatch regions. Also, bubble
+        // SetEncodingOps through special operations like bit-extending ops and
+        // broadcasting ops.
+        .addPass(IREE::Flow::createHoistEncodingOpsPass);
+  }
+  FunctionLikeNest(passManager)
       // Collapse dimensions of linalg Ops.
       .addPass(IREE::Flow::createCollapseDimensionsPass)
       // Convert dispatch regions into dispatch workgroups by capturing values

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -437,6 +437,16 @@ def ExportBenchmarkFuncsPass :
 }
 
 
+def HoistEncodingOpsPass :
+    InterfacePass<"iree-flow-hoist-encoding-ops", "mlir::FunctionOpInterface"> {
+  let summary = "Hoists tensor encoding ops out of flow dispatch regions.";
+  let dependentDialects = [
+    "mlir::linalg::LinalgDialect",
+    "IREE::Flow::FlowDialect",
+    "IREE::Encoding::IREEEncodingDialect",
+  ];
+}
+
 def InitializeEmptyTensorsPass :
     Pass<"iree-flow-initialize-empty-tensors", ""> {
   let summary = "Initialize empty tensors.";

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -528,6 +528,185 @@ wrapOpInDispatchRegion(RewriterBase &rewriter, Operation *op) {
   return newRegionOp;
 }
 
+FailureOr<Operation *> hoistOutOfDispatch(RewriterBase &rewriter,
+                                          Operation *op) {
+  assert(op && !isNonNullAndOutsideDispatch(op) &&
+         "op expected to be in a dispatch");
+  OpBuilder::InsertionGuard g(rewriter);
+  auto dispatchRegionOp = op->getParentOfType<DispatchRegionOp>();
+  // If all operands of the `op` come from outside the dispatch, then the op can
+  // be hoisted out before the dispatch region. Otherwise, the op can be hoisted
+  // out below the dispatch if the only users of the op are the dispatch return.
+  if (llvm::none_of(op->getOperands(), [&](Value operand) {
+        Operation *producer = operand.getDefiningOp();
+        return producer && producer->getParentOfType<DispatchRegionOp>();
+      })) {
+    rewriter.setInsertionPoint(dispatchRegionOp);
+  } else if (llvm::all_of(op->getUsers(), [&](Operation *user) {
+               return isa<IREE::Flow::ReturnOp>(user);
+             })) {
+    rewriter.setInsertionPointAfter(dispatchRegionOp);
+  } else {
+    return rewriter.notifyMatchFailure(
+        op, "op has both operands and users insided of its dispatch");
+  }
+  Operation *hoistedOp = rewriter.clone(*op);
+  rewriter.setInsertionPoint(dispatchRegionOp);
+
+  // Get the new dispatch region result types without the hoisted op results.
+  auto dispatchReturnOp = cast<IREE::Flow::ReturnOp>(
+      dispatchRegionOp.getBody().front().getTerminator());
+  SmallVector<Type> newResultTypes;
+  SmallVector<OpOperand *> newDispatchReturnOperands;
+  for (OpOperand &operand : dispatchReturnOp->getOpOperands()) {
+    if (operand.get().getDefiningOp() != op) {
+      newResultTypes.push_back(operand.get().getType());
+      newDispatchReturnOperands.push_back(&operand);
+    }
+  }
+
+  // Replace op uses inside and outside of the dispatch region with the hoisted
+  // results.
+  bool yieldsResults = false;
+  for (OpResult result : op->getResults()) {
+    Value hoistedResult = hoistedOp->getResult(result.getResultNumber());
+    // Replace all results yielded by the dispatch region with the hoisted
+    // op results.
+    for (OpOperand &use : result.getUses()) {
+      if (!isa<IREE::Flow::ReturnOp>(use.getOwner())) {
+        continue;
+      }
+      yieldsResults = true;
+      Value dispResult = dispatchRegionOp.getResults()[use.getOperandNumber()];
+      rewriter.replaceAllUsesWith(dispResult, hoistedResult);
+    }
+    // Replace uses inside the dispatch region.
+    rewriter.replaceAllUsesWith(result, hoistedResult);
+  }
+  // If no results were yielded from `op`, then nothing more to do.
+  if (!yieldsResults) {
+    return hoistedOp;
+  }
+
+  // Add the operands of the `op` to the new return values of the dispatch.
+  SmallVector<Value> newReturnedValues = llvm::map_to_vector(
+      newDispatchReturnOperands, [](OpOperand *val) { return val->get(); });
+  SetVector<Value> newReturnedValueSet(newReturnedValues.begin(),
+                                       newReturnedValues.end());
+  SmallVector<OpOperand *> yieldedOperands;
+  SmallVector<SmallVector<Value>> newResultsDynamicDims;
+  for (OpOperand &operand : op->getOpOperands()) {
+    // Only need to yield operands defined in the dispatch region.
+    if (operand.get().getParentRegion() != &dispatchRegionOp.getBody()) {
+      continue;
+    }
+    // Skip already yielded operands.
+    if (newReturnedValueSet.contains(operand.get())) {
+      continue;
+    }
+    // Save operand and dynamic dims to add to the dispatch region.
+    yieldedOperands.push_back(&operand);
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPointAfterValue(operand.get());
+    SmallVector<Value> &dims = newResultsDynamicDims.emplace_back();
+    if (failed(reifyDynamicResultDims(rewriter, operand.get(), dims))) {
+      return op->emitOpError(
+          "failed to reify dynamic dims of result to be yielded from "
+          "dispatch region");
+    }
+  }
+
+  // Get the new set of dynamic dims without the `op` result dims.
+  SetVector<Value> dynamicDims;
+  for (int64_t res = 0; res < dispatchRegionOp->getNumResults(); ++res) {
+    auto dims = dispatchRegionOp.getResultDynamicDims(res);
+    dynamicDims.insert(dims.begin(), dims.end());
+  }
+  // Create the new dispatch region op. The region does not yet yield the
+  // operands of the `op`.
+  auto newDispatchRegionOp = rewriter.create<IREE::Flow::DispatchRegionOp>(
+      dispatchRegionOp->getLoc(), newResultTypes, dynamicDims.takeVector(),
+      dispatchRegionOp.getWorkload());
+  rewriter.inlineRegionBefore(dispatchRegionOp.getBody(),
+                              newDispatchRegionOp.getBody(),
+                              newDispatchRegionOp.getBody().begin());
+  auto newDispatchReturnOp = cast<IREE::Flow::ReturnOp>(
+      newDispatchRegionOp.getBody().front().getTerminator());
+  {
+    OpBuilder::InsertionGuard returnGuard(rewriter);
+    rewriter.setInsertionPoint(newDispatchReturnOp);
+    rewriter.replaceOpWithNewOp<IREE::Flow::ReturnOp>(newDispatchReturnOp,
+                                                      newReturnedValues);
+  }
+
+  // Append newly yielded operands to the new dispatch results.
+  SmallVector<Value> newYieldedResults = llvm::map_to_vector(
+      yieldedOperands, [](OpOperand *operand) { return operand->get(); });
+  FailureOr<IREE::Flow::DispatchRegionOp> finalDispatchRegionOp =
+      appendDispatchRegionResults(rewriter, newDispatchRegionOp,
+                                  newYieldedResults, newResultsDynamicDims);
+  if (failed(finalDispatchRegionOp)) {
+    return failure();
+  }
+
+  // Replace operands of the `hoistedOp` with dispatch region results.
+  auto replaceHoistedOpOperand = [&](Value v, int operandIdx) {
+    rewriter.modifyOpInPlace(hoistedOp,
+                             [&]() { hoistedOp->setOperand(operandIdx, v); });
+  };
+  for (auto [resIdx, operand] : llvm::enumerate(yieldedOperands)) {
+    auto dispatchResIdx = resIdx + newReturnedValues.size();
+    Value dispatchResult = finalDispatchRegionOp->getResults()[dispatchResIdx];
+    replaceHoistedOpOperand(dispatchResult, operand->getOperandNumber());
+  }
+
+  // Replace the uses of the original dispatch region results with the final
+  // dispatch region results.
+  for (auto [idx, operand] : llvm::enumerate(newDispatchReturnOperands)) {
+    Value result = dispatchRegionOp.getResults()[operand->getOperandNumber()];
+    Value newResult = finalDispatchRegionOp->getResults()[idx];
+    rewriter.replaceAllUsesWith(result, newResult);
+  }
+
+  return hoistedOp;
+}
+
+bool isBroadcastingOp(Operation *op) {
+  if (isa<linalg::BroadcastOp>(op)) {
+    return true;
+  }
+  auto genericOp = dyn_cast<linalg::GenericOp>(op);
+  if (!genericOp) {
+    return false;
+  }
+
+  // Only allow a single input and init.
+  if (genericOp.getNumDpsInits() != 1 || genericOp.getNumDpsInputs() != 1) {
+    return false;
+  }
+
+  // Check that the all loops are parallel.
+  unsigned numLoops = genericOp.getNumLoops();
+  unsigned numParallelLoops = genericOp.getNumParallelLoops();
+  if (numLoops != numParallelLoops) {
+    return false;
+  }
+
+  // Check that indexing maps are broadcasting.
+  SmallVector<AffineMap> indexingMaps = genericOp.getIndexingMapsArray();
+  auto inMap =
+      genericOp.getMatchingIndexingMap(genericOp.getDpsInputOperand(0));
+  auto outMap =
+      genericOp.getMatchingIndexingMap(genericOp.getDpsInitOperand(0));
+  if (inMap.getNumResults() >= outMap.getNumResults()) {
+    return false;
+  }
+  if (!inMap.isProjectedPermutation() || outMap.isIdentity()) {
+    return false;
+  }
+  return true;
+}
+
 //===---------------------------------------------------------------------===//
 // Utilities to make a dispatch region isolated from above
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -671,42 +671,6 @@ FailureOr<Operation *> hoistOutOfDispatch(RewriterBase &rewriter,
   return hoistedOp;
 }
 
-bool isBroadcastingOp(Operation *op) {
-  if (isa<linalg::BroadcastOp>(op)) {
-    return true;
-  }
-  auto genericOp = dyn_cast<linalg::GenericOp>(op);
-  if (!genericOp) {
-    return false;
-  }
-
-  // Only allow a single input and init.
-  if (genericOp.getNumDpsInits() != 1 || genericOp.getNumDpsInputs() != 1) {
-    return false;
-  }
-
-  // Check that the all loops are parallel.
-  unsigned numLoops = genericOp.getNumLoops();
-  unsigned numParallelLoops = genericOp.getNumParallelLoops();
-  if (numLoops != numParallelLoops) {
-    return false;
-  }
-
-  // Check that indexing maps are broadcasting.
-  SmallVector<AffineMap> indexingMaps = genericOp.getIndexingMapsArray();
-  auto inMap =
-      genericOp.getMatchingIndexingMap(genericOp.getDpsInputOperand(0));
-  auto outMap =
-      genericOp.getMatchingIndexingMap(genericOp.getDpsInitOperand(0));
-  if (inMap.getNumResults() >= outMap.getNumResults()) {
-    return false;
-  }
-  if (!inMap.isProjectedPermutation() || outMap.isIdentity()) {
-    return false;
-  }
-  return true;
-}
-
 //===---------------------------------------------------------------------===//
 // Utilities to make a dispatch region isolated from above
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h
@@ -104,6 +104,28 @@ FailureOr<Flow::DispatchRegionOp> wrapOpInDispatchRegion(RewriterBase &rewriter,
 /// into a dispatch region.
 bool isClonableIntoDispatchOp(Operation *op);
 
+/// Hoists an operation out of a dispatch region, as long as it does not have
+/// producers inside of the dispatch region, or all of its uses are part of
+/// the dispatch region op return. If these criteria are not met, then return
+/// failure.
+///
+/// If all producers are defined outside of the dispatch region, then the op
+/// will be hoisted above the dispatch region op. Otherwise, the op will be
+/// hoisted below the dispatch region op, and the operands of the hoisted op
+/// will be added to the yielded values of the dispatch region op.
+FailureOr<Operation *> hoistOutOfDispatch(RewriterBase &rewriter,
+                                          Operation *op);
+
+/// Returns true if the operation is a BroadcastOp or a GenericOp performing
+/// a broadcast.
+/// This function checks that the genericOp:
+///     1. Has a single input and output.
+///     2. Has all parallel loops.
+///     3. Has an identity output map.
+///     4. Has a projected permutation input map.
+///     5. The input map has fewer results than the output map.
+bool isBroadcastingOp(Operation *op);
+
 /// Collect all ops that should be cloned into the given dispatch region op.
 SmallVector<Operation *> getCloneableOps(Flow::DispatchRegionOp regionOp);
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h
@@ -116,16 +116,6 @@ bool isClonableIntoDispatchOp(Operation *op);
 FailureOr<Operation *> hoistOutOfDispatch(RewriterBase &rewriter,
                                           Operation *op);
 
-/// Returns true if the operation is a BroadcastOp or a GenericOp performing
-/// a broadcast.
-/// This function checks that the genericOp:
-///     1. Has a single input and output.
-///     2. Has all parallel loops.
-///     3. Has an identity output map.
-///     4. Has a projected permutation input map.
-///     5. The input map has fewer results than the output map.
-bool isBroadcastingOp(Operation *op);
-
 /// Collect all ops that should be cloned into the given dispatch region op.
 SmallVector<Operation *> getCloneableOps(Flow::DispatchRegionOp regionOp);
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD.bazel
@@ -41,6 +41,7 @@ iree_lit_test_suite(
             "fuse_horizontal_contractions.mlir",
             "fuse_multiuse_elementwise_producer.mlir",
             "fusion_preprocessing.mlir",
+            "hoist_encoding_ops.mlir",
             "initialize_empty_tensors.mlir",
             "inject_dispatch_tracing.mlir",
             "inject_tensor_tracing.mlir",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
@@ -39,6 +39,7 @@ iree_lit_test_suite(
     "fuse_horizontal_contractions.mlir"
     "fuse_multiuse_elementwise_producer.mlir"
     "fusion_preprocessing.mlir"
+    "hoist_encoding_ops.mlir"
     "initialize_empty_tensors.mlir"
     "inject_dispatch_tracing.mlir"
     "inject_tensor_tracing.mlir"

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/hoist_encoding_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/hoist_encoding_ops.mlir
@@ -1,0 +1,88 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-flow-hoist-encoding-ops))" --split-input-file %s | FileCheck %s
+
+#map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+#map5 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+util.func public @quantized_matmul(
+    %arg0: tensor<2x11008x128xi8>, %arg1: tensor<2x128x64xi8>,
+    %arg2: tensor<2x11008xf32>, %arg3: tensor<2x11008xf32>,
+    %arg4: tensor<2x64xf32>, %arg5: tensor<2x64xf32>) -> tensor<2x11008x64xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %6 = flow.dispatch.region -> (tensor<2x11008x64xf32>) {
+    %8 = tensor.empty() : tensor<2x11008x128xf32>
+    %9 = tensor.empty() : tensor<2x128x64xf32>
+    %10 = linalg.generic
+        {indexing_maps = [#map, #map1, #map1, #map],
+        iterator_types = ["parallel", "parallel", "parallel"]}
+        ins(%arg1, %arg4, %arg5 : tensor<2x128x64xi8>, tensor<2x64xf32>, tensor<2x64xf32>)
+        outs(%9 : tensor<2x128x64xf32>) {
+    ^bb0(%in: i8, %in_0: f32, %in_1: f32, %out: f32):
+      %18 = arith.extui %in : i8 to i32
+      %19 = arith.uitofp %18 : i32 to f32
+      %20 = arith.subf %19, %in_1 : f32
+      %21 = arith.mulf %20, %in_0 : f32
+      linalg.yield %21 : f32
+    } -> tensor<2x128x64xf32>
+    %11 = linalg.generic
+        {indexing_maps = [#map, #map2, #map2, #map],
+        iterator_types = ["parallel", "parallel", "parallel"]}
+        ins(%arg0, %arg2, %arg3 : tensor<2x11008x128xi8>, tensor<2x11008xf32>, tensor<2x11008xf32>)
+        outs(%8 : tensor<2x11008x128xf32>) {
+    ^bb0(%in: i8, %in_0: f32, %in_1: f32, %out: f32):
+      %18 = arith.extui %in : i8 to i32
+      %19 = arith.uitofp %18 : i32 to f32
+      %20 = arith.subf %19, %in_1 : f32
+      %21 = arith.mulf %20, %in_0 : f32
+      linalg.yield %21 : f32
+    } -> tensor<2x11008x128xf32>
+    %12 = iree_encoding.set_encoding %10 : tensor<2x128x64xf32> -> tensor<2x128x64xf32, #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x128x64xf32>, user_indexing_maps = [#map3, #map4, #map5], round_dims_to = array<i64: 32, 32, 32>>>
+    %13 = iree_encoding.set_encoding %11 : tensor<2x11008x128xf32> -> tensor<2x11008x128xf32, #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x128xf32>, user_indexing_maps = [#map3, #map4, #map5], round_dims_to = array<i64: 32, 32, 32>>>
+    %14 = tensor.empty() : tensor<2x11008x64xf32, #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x64xf32>, user_indexing_maps = [#map3, #map4, #map5], round_dims_to = array<i64: 32, 32, 32>>>
+    %15 = linalg.fill ins(%cst : f32) outs(%14 : tensor<2x11008x64xf32, #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x64xf32>, user_indexing_maps = [#map3, #map4, #map5], round_dims_to = array<i64: 32, 32, 32>>>) -> tensor<2x11008x64xf32, #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x64xf32>, user_indexing_maps = [#map3, #map4, #map5], round_dims_to = array<i64: 32, 32, 32>>>
+    %16 = linalg.generic
+        {indexing_maps = [#map3, #map4, #map5],
+        iterator_types = ["parallel", "parallel", "parallel", "reduction"]}
+        ins(%12, %13 : tensor<2x128x64xf32, #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x128x64xf32>, user_indexing_maps = [#map3, #map4, #map5], round_dims_to = array<i64: 32, 32, 32>>>, tensor<2x11008x128xf32, #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x128xf32>, user_indexing_maps = [#map3, #map4, #map5], round_dims_to = array<i64: 32, 32, 32>>>)
+        outs(%15 : tensor<2x11008x64xf32, #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x64xf32>, user_indexing_maps = [#map3, #map4, #map5], round_dims_to = array<i64: 32, 32, 32>>>) {
+    ^bb0(%in: f32, %in_0: f32, %out: f32):
+      %18 = arith.mulf %in, %in_0 : f32
+      %19 = arith.addf %18, %out : f32
+      linalg.yield %19 : f32
+    } -> tensor<2x11008x64xf32, #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x64xf32>, user_indexing_maps = [#map3, #map4, #map5], round_dims_to = array<i64: 32, 32, 32>>>
+    %17 = iree_encoding.unset_encoding %16 : tensor<2x11008x64xf32, #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x64xf32>, user_indexing_maps = [#map3, #map4, #map5], round_dims_to = array<i64: 32, 32, 32>>> -> tensor<2x11008x64xf32>
+    flow.return %17 : tensor<2x11008x64xf32>
+  }
+  util.return %6 : tensor<2x11008x64xf32>
+}
+
+// CHECK-DAG:   #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
+// CHECK-DAG:   #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+// CHECK-DAG:   #[[$MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+// CHECK-DAG:   #[[$MAP3:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+// CHECK-DAG:   #[[$MAP4:.+]] = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+// CHECK-DAG:   #[[$MAP5:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
+// CHECK-LABEL: @quantized_matmul
+// CHECK-SAME:    %[[ARG0:.+]]: tensor<2x11008x128xi8>, %[[ARG1:.+]]: tensor<2x128x64xi8>,
+// CHECK-SAME:    %[[ARG2:.+]]: tensor<2x11008xf32>, %[[ARG3:.+]]: tensor<2x11008xf32>,
+// CHECK-SAME:    %[[ARG4:.+]]: tensor<2x64xf32>, %[[ARG5:.+]]: tensor<2x64xf32>
+// CHECK-DAG:   %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:   %[[ENCODING0:.+]] = iree_encoding.set_encoding %[[ARG0]] : tensor<2x11008x128xi8> -> tensor<2x11008x128xi8, #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x128xf32>, user_indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]]], bcast_map = #[[$MAP4]], round_dims_to = array<i64: 32, 32, 32>>>
+// CHECK-DAG:   %[[ENCODING1:.+]] = iree_encoding.set_encoding %[[ARG1]] : tensor<2x128x64xi8> -> tensor<2x128x64xi8, #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x128x64xf32>, user_indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]]], bcast_map = #[[$MAP4]], round_dims_to = array<i64: 32, 32, 32>>>
+// CHECK-DAG:   %[[ENCODING2:.+]] = iree_encoding.set_encoding %[[ARG2]] : tensor<2x11008xf32> -> tensor<2x11008xf32, #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x128xf32>, user_indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]]], bcast_map = #[[$MAP3]], round_dims_to = array<i64: 32, 32, 32>>>
+// CHECK-DAG:   %[[ENCODING3:.+]] = iree_encoding.set_encoding %[[ARG3]] : tensor<2x11008xf32> -> tensor<2x11008xf32, #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x128xf32>, user_indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]]], bcast_map = #[[$MAP3]], round_dims_to = array<i64: 32, 32, 32>>>
+// CHECK-DAG:   %[[ENCODING4:.+]] = iree_encoding.set_encoding %[[ARG4]] : tensor<2x64xf32> -> tensor<2x64xf32, #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x128x64xf32>, user_indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]]], bcast_map = #[[$MAP5]], round_dims_to = array<i64: 32, 32, 32>>>
+// CHECK-DAG:   %[[ENCODING5:.+]] = iree_encoding.set_encoding %[[ARG5]] : tensor<2x64xf32> -> tensor<2x64xf32, #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x128x64xf32>, user_indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]]], bcast_map = #[[$MAP5]], round_dims_to = array<i64: 32, 32, 32>>>
+// CHECK:       %[[DISPATCH:.+]] = flow.dispatch.region -> (tensor<2x11008x64xf32>) {
+// CHECK:         %[[INIT0:.+]] = tensor.empty() : tensor<2x128x64xf32, #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x128x64xf32>, user_indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]]], round_dims_to = array<i64: 32, 32, 32>>>
+// CHECK:         %[[DEQUANT0:.+]] = linalg.generic {{.*}} ins(%[[ENCODING1]], %[[ENCODING4]], %[[ENCODING5]] : {{.*}} outs(%[[INIT0]] :
+// CHECK:         %[[INIT1:.+]] = tensor.empty() : tensor<2x11008x128xf32, #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x128xf32>, user_indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]]], round_dims_to = array<i64: 32, 32, 32>>>
+// CHECK:         %[[DEQUANT1:.+]] = linalg.generic {{.*}} ins(%[[ENCODING0]], %[[ENCODING2]], %[[ENCODING3]] : {{.*}} outs(%[[INIT1]] :
+// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<2x11008x64xf32, #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x64xf32>, user_indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]]], round_dims_to = array<i64: 32, 32, 32>>>
+// CHECK:         %[[FILL:.+]] = linalg.fill ins(%[[ZERO]] : f32) outs(%[[EMPTY]] :
+// CHECK:         %[[MATMUL:.+]] = linalg.generic {{.*}} ins(%[[DEQUANT0]], %[[DEQUANT1]] : {{.*}} outs(%[[FILL]] :
+// CHECK:         %[[UNSET_ENCODING:.+]] = iree_encoding.unset_encoding %[[MATMUL]] {{.*}} -> tensor<2x11008x64xf32>
+// CHECK:       }
+// CHECK:       util.return %[[DISPATCH]] : tensor<2x11008x64xf32>

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/hoist_encoding_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/hoist_encoding_ops.mlir
@@ -1,35 +1,57 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-flow-hoist-encoding-ops))" --split-input-file %s | FileCheck %s
 
+#map1 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
+#map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+module {
+  util.func public @hoist_matmul_encodings(%arg0: tensor<2x128x64xf32>, %arg1: tensor<2x11008x128xf32>) -> tensor<2x11008x64xf32> {
+    %cst = arith.constant 0.000000e+00 : f32
+    %2 = flow.dispatch.region -> (tensor<2x11008x64xf32>) {
+      %3 = iree_encoding.set_encoding %arg0 : tensor<2x128x64xf32> -> tensor<2x128x64xf32, #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x128x64xf32>, user_indexing_maps = [#map1, #map2, #map3], round_dims_to = array<i64: 32, 32, 32>>>
+      %4 = iree_encoding.set_encoding %arg1 : tensor<2x11008x128xf32> -> tensor<2x11008x128xf32, #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x128xf32>, user_indexing_maps = [#map1, #map2, #map3], round_dims_to = array<i64: 32, 32, 32>>>
+      %5 = tensor.empty() : tensor<2x11008x64xf32, #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x64xf32>, user_indexing_maps = [#map1, #map2, #map3], round_dims_to = array<i64: 32, 32, 32>>>
+      %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<2x11008x64xf32, #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x64xf32>, user_indexing_maps = [#map1, #map2, #map3], round_dims_to = array<i64: 32, 32, 32>>>) -> tensor<2x11008x64xf32, #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x64xf32>, user_indexing_maps = [#map1, #map2, #map3], round_dims_to = array<i64: 32, 32, 32>>>
+      %7 = linalg.generic {
+          indexing_maps = [#map1, #map2, #map3],
+          iterator_types = ["parallel", "parallel", "parallel", "reduction"]}
+          ins(%3, %4 : tensor<2x128x64xf32, #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x128x64xf32>, user_indexing_maps = [#map1, #map2, #map3], round_dims_to = array<i64: 32, 32, 32>>>, tensor<2x11008x128xf32, #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x128xf32>, user_indexing_maps = [#map1, #map2, #map3], round_dims_to = array<i64: 32, 32, 32>>>)
+          outs(%6 : tensor<2x11008x64xf32, #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x64xf32>, user_indexing_maps = [#map1, #map2, #map3], round_dims_to = array<i64: 32, 32, 32>>>) {
+      ^bb0(%in: f32, %in_0: f32, %out: f32):
+        %9 = arith.mulf %in, %in_0 : f32
+        %10 = arith.addf %9, %out : f32
+        linalg.yield %10 : f32
+      } -> tensor<2x11008x64xf32, #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x64xf32>, user_indexing_maps = [#map1, #map2, #map3], round_dims_to = array<i64: 32, 32, 32>>>
+      %8 = iree_encoding.unset_encoding %7 : tensor<2x11008x64xf32, #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x64xf32>, user_indexing_maps = [#map1, #map2, #map3], round_dims_to = array<i64: 32, 32, 32>>> -> tensor<2x11008x64xf32>
+      flow.return %8 : tensor<2x11008x64xf32>
+    }
+    util.return %2 : tensor<2x11008x64xf32>
+  }
+}
+
+// CHECK-LABEL: @hoist_matmul_encodings
+// CHECK-SAME:    (%[[ARG0:.+]]: tensor<2x128x64xf32>, %[[ARG1:.+]]: tensor<2x11008x128xf32>)
+// CHECK-DAG:   %[[SET_ENCODING0:.+]] = iree_encoding.set_encoding %[[ARG0]] : tensor<2x128x64xf32> -> tensor<2x128x64xf32, #iree_encoding.encoding
+// CHECK-DAG:   %[[SET_ENCODING1:.+]] = iree_encoding.set_encoding %[[ARG1]] : tensor<2x11008x128xf32> -> tensor<2x11008x128xf32, #iree_encoding.encoding
+// CHECK:       %[[DISPATCH:.+]] = flow.dispatch.region -> (tensor<2x11008x64xf32>) {
+// CHECK:         %[[MATMUL:.+]] = linalg.generic {{.*}} ins(%[[SET_ENCODING0]], %[[SET_ENCODING1]]
+// CHECK:         %[[UNSET_ENCODING1:.+]] = iree_encoding.unset_encoding %[[MATMUL]] : tensor<2x11008x64xf32, #iree_encoding.encoding
+// CHECK:         flow.return %[[UNSET_ENCODING1]] : tensor<2x11008x64xf32>
+// CHECK:       }
+// CHECK:       util.return %[[DISPATCH]] : tensor<2x11008x64xf32>
+
+// -----
+
 #map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
-#map1 = affine_map<(d0, d1, d2) -> (d0, d2)>
-#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
-#map3 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
-#map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
-#map5 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
-util.func public @quantized_matmul(
-    %arg0: tensor<2x11008x128xi8>, %arg1: tensor<2x128x64xi8>,
-    %arg2: tensor<2x11008xf32>, %arg3: tensor<2x11008xf32>,
-    %arg4: tensor<2x64xf32>, %arg5: tensor<2x64xf32>) -> tensor<2x11008x64xf32> {
-  %cst = arith.constant 0.000000e+00 : f32
-  %6 = flow.dispatch.region -> (tensor<2x11008x64xf32>) {
+#map1 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#encoding = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x128xf32>, user_indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>], round_dims_to = array<i64: 32, 32, 32>>
+util.func public @bubble_through_dequant(
+    %arg0: tensor<2x11008x128xi8>, %arg1: tensor<2x11008xf32>, %arg2: tensor<2x11008xf32>) -> tensor<2x11008x128xf32, #encoding> {
+  %6 = flow.dispatch.region -> (tensor<2x11008x128xf32, #encoding>) {
     %8 = tensor.empty() : tensor<2x11008x128xf32>
-    %9 = tensor.empty() : tensor<2x128x64xf32>
-    %10 = linalg.generic
+    %11 = linalg.generic
         {indexing_maps = [#map, #map1, #map1, #map],
         iterator_types = ["parallel", "parallel", "parallel"]}
-        ins(%arg1, %arg4, %arg5 : tensor<2x128x64xi8>, tensor<2x64xf32>, tensor<2x64xf32>)
-        outs(%9 : tensor<2x128x64xf32>) {
-    ^bb0(%in: i8, %in_0: f32, %in_1: f32, %out: f32):
-      %18 = arith.extui %in : i8 to i32
-      %19 = arith.uitofp %18 : i32 to f32
-      %20 = arith.subf %19, %in_1 : f32
-      %21 = arith.mulf %20, %in_0 : f32
-      linalg.yield %21 : f32
-    } -> tensor<2x128x64xf32>
-    %11 = linalg.generic
-        {indexing_maps = [#map, #map2, #map2, #map],
-        iterator_types = ["parallel", "parallel", "parallel"]}
-        ins(%arg0, %arg2, %arg3 : tensor<2x11008x128xi8>, tensor<2x11008xf32>, tensor<2x11008xf32>)
+        ins(%arg0, %arg1, %arg2 : tensor<2x11008x128xi8>, tensor<2x11008xf32>, tensor<2x11008xf32>)
         outs(%8 : tensor<2x11008x128xf32>) {
     ^bb0(%in: i8, %in_0: f32, %in_1: f32, %out: f32):
       %18 = arith.extui %in : i8 to i32
@@ -38,24 +60,10 @@ util.func public @quantized_matmul(
       %21 = arith.mulf %20, %in_0 : f32
       linalg.yield %21 : f32
     } -> tensor<2x11008x128xf32>
-    %12 = iree_encoding.set_encoding %10 : tensor<2x128x64xf32> -> tensor<2x128x64xf32, #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x128x64xf32>, user_indexing_maps = [#map3, #map4, #map5], round_dims_to = array<i64: 32, 32, 32>>>
-    %13 = iree_encoding.set_encoding %11 : tensor<2x11008x128xf32> -> tensor<2x11008x128xf32, #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x128xf32>, user_indexing_maps = [#map3, #map4, #map5], round_dims_to = array<i64: 32, 32, 32>>>
-    %14 = tensor.empty() : tensor<2x11008x64xf32, #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x64xf32>, user_indexing_maps = [#map3, #map4, #map5], round_dims_to = array<i64: 32, 32, 32>>>
-    %15 = linalg.fill ins(%cst : f32) outs(%14 : tensor<2x11008x64xf32, #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x64xf32>, user_indexing_maps = [#map3, #map4, #map5], round_dims_to = array<i64: 32, 32, 32>>>) -> tensor<2x11008x64xf32, #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x64xf32>, user_indexing_maps = [#map3, #map4, #map5], round_dims_to = array<i64: 32, 32, 32>>>
-    %16 = linalg.generic
-        {indexing_maps = [#map3, #map4, #map5],
-        iterator_types = ["parallel", "parallel", "parallel", "reduction"]}
-        ins(%12, %13 : tensor<2x128x64xf32, #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x128x64xf32>, user_indexing_maps = [#map3, #map4, #map5], round_dims_to = array<i64: 32, 32, 32>>>, tensor<2x11008x128xf32, #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x128xf32>, user_indexing_maps = [#map3, #map4, #map5], round_dims_to = array<i64: 32, 32, 32>>>)
-        outs(%15 : tensor<2x11008x64xf32, #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x64xf32>, user_indexing_maps = [#map3, #map4, #map5], round_dims_to = array<i64: 32, 32, 32>>>) {
-    ^bb0(%in: f32, %in_0: f32, %out: f32):
-      %18 = arith.mulf %in, %in_0 : f32
-      %19 = arith.addf %18, %out : f32
-      linalg.yield %19 : f32
-    } -> tensor<2x11008x64xf32, #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x64xf32>, user_indexing_maps = [#map3, #map4, #map5], round_dims_to = array<i64: 32, 32, 32>>>
-    %17 = iree_encoding.unset_encoding %16 : tensor<2x11008x64xf32, #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x64xf32>, user_indexing_maps = [#map3, #map4, #map5], round_dims_to = array<i64: 32, 32, 32>>> -> tensor<2x11008x64xf32>
-    flow.return %17 : tensor<2x11008x64xf32>
+    %13 = iree_encoding.set_encoding %11 : tensor<2x11008x128xf32> -> tensor<2x11008x128xf32, #encoding>
+    flow.return %13 : tensor<2x11008x128xf32, #encoding>
   }
-  util.return %6 : tensor<2x11008x64xf32>
+  util.return %6 : tensor<2x11008x128xf32, #encoding>
 }
 
 // CHECK-DAG:   #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
@@ -63,26 +71,56 @@ util.func public @quantized_matmul(
 // CHECK-DAG:   #[[$MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 // CHECK-DAG:   #[[$MAP3:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
 // CHECK-DAG:   #[[$MAP4:.+]] = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
-// CHECK-DAG:   #[[$MAP5:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
-// CHECK-LABEL: @quantized_matmul
-// CHECK-SAME:    %[[ARG0:.+]]: tensor<2x11008x128xi8>, %[[ARG1:.+]]: tensor<2x128x64xi8>,
-// CHECK-SAME:    %[[ARG2:.+]]: tensor<2x11008xf32>, %[[ARG3:.+]]: tensor<2x11008xf32>,
-// CHECK-SAME:    %[[ARG4:.+]]: tensor<2x64xf32>, %[[ARG5:.+]]: tensor<2x64xf32>
-// CHECK-DAG:   %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
-// CHECK-DAG:   %[[ENCODING0:.+]] = iree_encoding.set_encoding %[[ARG0]] : tensor<2x11008x128xi8> -> tensor<2x11008x128xi8, #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x128xf32>, user_indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]]], bcast_map = #[[$MAP4]], round_dims_to = array<i64: 32, 32, 32>>>
-// CHECK-DAG:   %[[ENCODING1:.+]] = iree_encoding.set_encoding %[[ARG1]] : tensor<2x128x64xi8> -> tensor<2x128x64xi8, #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x128x64xf32>, user_indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]]], bcast_map = #[[$MAP4]], round_dims_to = array<i64: 32, 32, 32>>>
-// CHECK-DAG:   %[[ENCODING2:.+]] = iree_encoding.set_encoding %[[ARG2]] : tensor<2x11008xf32> -> tensor<2x11008xf32, #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x128xf32>, user_indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]]], bcast_map = #[[$MAP3]], round_dims_to = array<i64: 32, 32, 32>>>
-// CHECK-DAG:   %[[ENCODING3:.+]] = iree_encoding.set_encoding %[[ARG3]] : tensor<2x11008xf32> -> tensor<2x11008xf32, #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x128xf32>, user_indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]]], bcast_map = #[[$MAP3]], round_dims_to = array<i64: 32, 32, 32>>>
-// CHECK-DAG:   %[[ENCODING4:.+]] = iree_encoding.set_encoding %[[ARG4]] : tensor<2x64xf32> -> tensor<2x64xf32, #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x128x64xf32>, user_indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]]], bcast_map = #[[$MAP5]], round_dims_to = array<i64: 32, 32, 32>>>
-// CHECK-DAG:   %[[ENCODING5:.+]] = iree_encoding.set_encoding %[[ARG5]] : tensor<2x64xf32> -> tensor<2x64xf32, #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x128x64xf32>, user_indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]]], bcast_map = #[[$MAP5]], round_dims_to = array<i64: 32, 32, 32>>>
-// CHECK:       %[[DISPATCH:.+]] = flow.dispatch.region -> (tensor<2x11008x64xf32>) {
-// CHECK:         %[[INIT0:.+]] = tensor.empty() : tensor<2x128x64xf32, #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x128x64xf32>, user_indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]]], round_dims_to = array<i64: 32, 32, 32>>>
-// CHECK:         %[[DEQUANT0:.+]] = linalg.generic {{.*}} ins(%[[ENCODING1]], %[[ENCODING4]], %[[ENCODING5]] : {{.*}} outs(%[[INIT0]] :
-// CHECK:         %[[INIT1:.+]] = tensor.empty() : tensor<2x11008x128xf32, #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x128xf32>, user_indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]]], round_dims_to = array<i64: 32, 32, 32>>>
-// CHECK:         %[[DEQUANT1:.+]] = linalg.generic {{.*}} ins(%[[ENCODING0]], %[[ENCODING2]], %[[ENCODING3]] : {{.*}} outs(%[[INIT1]] :
-// CHECK:         %[[EMPTY:.+]] = tensor.empty() : tensor<2x11008x64xf32, #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f32, f32, f32], original_type = tensor<2x11008x64xf32>, user_indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]]], round_dims_to = array<i64: 32, 32, 32>>>
-// CHECK:         %[[FILL:.+]] = linalg.fill ins(%[[ZERO]] : f32) outs(%[[EMPTY]] :
-// CHECK:         %[[MATMUL:.+]] = linalg.generic {{.*}} ins(%[[DEQUANT0]], %[[DEQUANT1]] : {{.*}} outs(%[[FILL]] :
-// CHECK:         %[[UNSET_ENCODING:.+]] = iree_encoding.unset_encoding %[[MATMUL]] {{.*}} -> tensor<2x11008x64xf32>
+// CHECK-LABEL: @bubble_through_dequant
+// CHECK-SAME:    %[[ARG0:.+]]: tensor<2x11008x128xi8>,
+// CHECK-SAME:    %[[ARG1:.+]]: tensor<2x11008xf32>, %[[ARG2:.+]]: tensor<2x11008xf32>
+// CHECK-DAG:   %[[SET_ENCODING0:.+]] = iree_encoding.set_encoding %[[ARG0]] : {{.*}} bcast_map = #[[$MAP4]]
+// CHECK-DAG:   %[[SET_ENCODING1:.+]] = iree_encoding.set_encoding %[[ARG1]] : {{.*}} bcast_map = #[[$MAP3]]
+// CHECK-DAG:   %[[SET_ENCODING2:.+]] = iree_encoding.set_encoding %[[ARG2]] : {{.*}} bcast_map = #[[$MAP3]]
+// CHECK:       %[[DISPATCH:.+]] = flow.dispatch.region
+// CHECK:         %[[INIT:.+]] = tensor.empty() : tensor<2x11008x128xf32, #iree_encoding.encoding
+// CHECK:         %[[DEQUANT:.+]] = linalg.generic {{.*}} ins(%[[SET_ENCODING0]], %[[SET_ENCODING1]], %[[SET_ENCODING2]] : {{.*}} outs(%[[INIT]] :
+// CHECK:         flow.return %[[DEQUANT]]
 // CHECK:       }
-// CHECK:       util.return %[[DISPATCH]] : tensor<2x11008x64xf32>
+// CHECK:       util.return %[[DISPATCH]]
+
+// -----
+
+#map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d1, d2)>
+#encoding = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul,
+    element_types = [f32, f32, f32], original_type = tensor<2x11008x128xf32>,
+    user_indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>],
+    round_dims_to = array<i64: 32, 32, 32>>
+util.func public @bubble_through_broadcast(
+    %arg0: tensor<11008x128xf32>) -> tensor<2x11008x128xf32, #encoding> {
+  %6 = flow.dispatch.region -> (tensor<2x11008x128xf32, #encoding>) {
+    %8 = tensor.empty() : tensor<2x11008x128xf32>
+    %11 = linalg.generic
+        {indexing_maps = [#map1, #map],
+        iterator_types = ["parallel", "parallel", "parallel"]}
+        ins(%arg0 : tensor<11008x128xf32>)
+        outs(%8 : tensor<2x11008x128xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<2x11008x128xf32>
+    %13 = iree_encoding.set_encoding %11 : tensor<2x11008x128xf32> -> tensor<2x11008x128xf32, #encoding>
+    flow.return %13 : tensor<2x11008x128xf32, #encoding>
+  }
+  util.return %6 : tensor<2x11008x128xf32, #encoding>
+}
+
+// CHECK-DAG:   #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
+// CHECK-DAG:   #[[$MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+// CHECK-DAG:   #[[$MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+// CHECK-DAG:   #[[$MAP3:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
+// CHECK-DAG:   #[[$MAP4:.+]] = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+// CHECK-LABEL: @bubble_through_broadcast
+// CHECK-SAME:    %[[ARG0:.+]]: tensor<11008x128xf32>
+// CHECK-DAG:   %[[SET_ENCODING:.+]] = iree_encoding.set_encoding %[[ARG0]] : {{.*}} bcast_map = #[[$MAP3]]
+// CHECK:       %[[DISPATCH:.+]] = flow.dispatch.region
+// CHECK:         %[[INIT:.+]] = tensor.empty() : tensor<2x11008x128xf32, #iree_encoding.encoding
+// CHECK:         %[[BROADCAST:.+]] = linalg.generic {{.*}} ins(%[[SET_ENCODING]] : {{.*}} outs(%[[INIT]] :
+// CHECK:         flow.return %[[BROADCAST]]
+// CHECK:       }
+// CHECK:       util.return %[[DISPATCH]]

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -278,7 +278,7 @@ bool isBroadcastingOp(linalg::LinalgOp op) {
   if (inMap.getNumResults() >= outMap.getNumResults()) {
     return false;
   }
-  if (!inMap.isProjectedPermutation() || outMap.isIdentity()) {
+  if (!inMap.isProjectedPermutation() || !outMap.isIdentity()) {
     return false;
   }
   return llvm::hasSingleElement(op.getBlock()->getOperations());

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -244,4 +244,44 @@ bool isBitTruncateOp(Operation *op) {
   return isBitExtendOrTruncateOp(op) == BitWidthChangeInfo::kTruncate;
 }
 
+//===---------------------------------------------------------------------===//
+// Classification of other ops
+//===---------------------------------------------------------------------===//
+
+bool isBroadcastingOp(linalg::LinalgOp op) {
+  if (isa<linalg::BroadcastOp>(op)) {
+    return true;
+  }
+  auto genericOp = dyn_cast<linalg::GenericOp>(op.getOperation());
+  if (!genericOp) {
+    return false;
+  }
+
+  // Only allow a single input and init.
+  if (genericOp.getNumDpsInits() != 1 || genericOp.getNumDpsInputs() != 1) {
+    return false;
+  }
+
+  // Check that the all loops are parallel.
+  unsigned numLoops = genericOp.getNumLoops();
+  unsigned numParallelLoops = genericOp.getNumParallelLoops();
+  if (numLoops != numParallelLoops) {
+    return false;
+  }
+
+  // Check that indexing maps are broadcasting.
+  SmallVector<AffineMap> indexingMaps = genericOp.getIndexingMapsArray();
+  auto inMap =
+      genericOp.getMatchingIndexingMap(genericOp.getDpsInputOperand(0));
+  auto outMap =
+      genericOp.getMatchingIndexingMap(genericOp.getDpsInitOperand(0));
+  if (inMap.getNumResults() >= outMap.getNumResults()) {
+    return false;
+  }
+  if (!inMap.isProjectedPermutation() || outMap.isIdentity()) {
+    return false;
+  }
+  return llvm::hasSingleElement(op.getBlock()->getOperations());
+}
+
 } // namespace mlir::iree_compiler::IREE::LinalgExt

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
@@ -7,6 +7,7 @@
 #ifndef IREE_COMPILER_DIALECT_LINALGEXT_UTILS_UTILS_H_
 #define IREE_COMPILER_DIALECT_LINALGEXT_UTILS_UTILS_H_
 
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
@@ -126,6 +127,17 @@ bool isBitExtendOp(Operation *op);
 /// 3. Compared to the element type of the input with highest rank,
 ///    the output element type has a lower bitwidth.
 bool isBitTruncateOp(Operation *op);
+
+/// Returns true if the operation is a BroadcastOp or a GenericOp performing
+/// a broadcast.
+/// This function checks that the genericOp:
+///     1. Has a single input and output.
+///     2. Has all parallel loops.
+///     3. Has an identity output map.
+///     4. Has a projected permutation input map.
+///     5. The input map has fewer results than the output map.
+///     6. Has a body with only a linalg.yield op.
+bool isBroadcastingOp(linalg::LinalgOp op);
 
 } // namespace mlir::iree_compiler::IREE::LinalgExt
 #endif // IREE_COMPILER_DIALECT_LINALGEXT_UTILS_UTILS_H_


### PR DESCRIPTION
This PR adds a new pass in the Flow data tiling pipeline to hoist encoding ops out of their dispatch regions. After SetEncoding, the encoding ops are inserted directly inside of the dispatch regions that contain the data tiled ops. The set_encoding ops then need to be hoisted out of the dispatch region in order to fuse into the producer dispatch.

Sometimes there may be producer operations fused into the same dispatch as the data tiled op, in which case the set_encoding ops will have producers inside of the dispatch. In order to hoist the set_encoding op, it needs to be bubbled up through these producer operations until it has no producers inside of its dispatch. This pass supports bubbling of set_encoding ops through bit extending ops and broadcasting ops.

After this pass, all set_encoding ops should be outside of dispatch regions, and they need to be fused with their producers. Another pass will be added in the next PR to fuse set_encoding ops into their producer dispatch regions or wrap them in a new dispatch region.