### PR TITLE
Fix `ConvertToNVVM` and drop local revert in `third_party/llvm-project`

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
@@ -147,9 +147,22 @@ struct ConvertToNVVMPass : public ConvertToNVVMBase<ConvertToNVVMPass> {
       populateGpuToNVVMConversionPatterns(converter, llvmPatterns);
       populateNVGPUToNVVMConversionPatterns(converter, llvmPatterns);
       populateGpuWMMAToNVVMConversionPatterns(converter, llvmPatterns);
+
+      /// Target specification.
       LLVMConversionTarget target(getContext());
-      configureGpuToNVVMConversionLegality(target);
-      target.addLegalOp<LLVM::FMAOp>();
+      target.addIllegalOp<func::FuncOp>();
+      target.addLegalDialect<::mlir::LLVM::LLVMDialect>();
+      target.addLegalDialect<::mlir::NVVM::NVVMDialect>();
+      target.addIllegalDialect<gpu::GPUDialect>();
+      target.addIllegalOp<
+          LLVM::CopySignOp, LLVM::CosOp, LLVM::ExpOp, LLVM::Exp2Op,
+          LLVM::FAbsOp, LLVM::FCeilOp, LLVM::FFloorOp, LLVM::FRemOp,
+          LLVM::LogOp, LLVM::Log10Op, LLVM::Log2Op, LLVM::PowOp,
+          LLVM::RoundEvenOp, LLVM::RoundOp, LLVM::SinOp, LLVM::SqrtOp>();
+
+      // TODO: Remove once we support replacing non-root ops.
+      target.addLegalOp<gpu::YieldOp, gpu::GPUModuleOp, gpu::ModuleEndOp>();
+
       if (failed(applyPartialConversion(m, target, std::move(llvmPatterns)))) {
         signalPassFailure();
       }


### PR DESCRIPTION
After debugging why the same testcase succeeds with `iree-convert-to-llvm` but fails with `iree-convert-to-nvvm` unless a local revert of https://github.com/llvm/llvm-project/commit/f6431f0c is applied in `third_party/llvm-project`, comparing `-debug` logs, I found that the difference was that `VectorToSCF` patterns were part of `ConvertToLLVM` but not `ConvertToNVVM`.

Adding `VectorToSCF` to `ConvertToNVVM` fixes that and allows us to drop the revert.

This requires adding the `AffineDialect` dependency similar to https://github.com/iree-org/iree/pull/18062 because `VectorToSCF` creates `affine.apply` ops.