### PR TITLE
Improving global folding and IPO for immutable globals.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/export_benchmark_funcs.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/export_benchmark_funcs.mlir
@@ -1,9 +1,9 @@
-// RUN: iree-opt --split-input-file --iree-flow-transformation-pipeline --iree-flow-export-benchmark-funcs --verify-diagnostics %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-flow-export-benchmark-funcs-pass --verify-diagnostics %s | FileCheck %s
 
 // Basic usage from the `--iree-native-bindings-support` flag.
 
 // CHECK-LABEL: func private @simpleMul
-util.func public @simpleMul(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view) -> !hal.buffer_view attributes {iree.abi.stub, iree.module.export} {
+util.func public @simpleMul(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view) -> !hal.buffer_view {
   %0 = hal.tensor.import %arg0 : !hal.buffer_view -> tensor<4xf32>
   %1 = hal.tensor.import %arg1 : !hal.buffer_view -> tensor<4xf32>
   %2 = arith.mulf %0, %1 : tensor<4xf32>
@@ -41,8 +41,8 @@ util.func public @while(%start: i32, %bound: i32) -> i32 {
 //     CHECK: util.global private @[[GLOBAL_ARG1:.+]] {{{.+}}} = 0 : i32
 
 //     CHECK: util.func public @while_benchmark()
-// CHECK-DAG:   %[[ARG0:.+]] = util.global.load immutable @[[GLOBAL_ARG0]] : i32
-// CHECK-DAG:   %[[ARG1:.+]] = util.global.load immutable @[[GLOBAL_ARG1]] : i32
+// CHECK-DAG:   %[[ARG0:.+]] = util.global.load @[[GLOBAL_ARG0]] : i32
+// CHECK-DAG:   %[[ARG1:.+]] = util.global.load @[[GLOBAL_ARG1]] : i32
 //     CHECK:   %[[RET0:.+]] = util.call @while(%[[ARG0]], %[[ARG1]])
 //     CHECK:   util.optimization_barrier %[[RET0]] : i32
 //     CHECK:   util.return

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/FuseGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/FuseGlobals.cpp
@@ -59,6 +59,7 @@ public:
     auto moduleOp = getOperation();
 
     GlobalTable globalTable(moduleOp);
+    globalTable.rebuild();
 
     // Build a map of global symbol to a bitvector indicating which globals are
     // stored with the same values in all instances.

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/IPO.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/IPO.cpp
@@ -56,6 +56,7 @@ struct FuncAnalysis {
   // Which args are uniform from all call sites.
   BitVector callerUniformArgs;
   // Values for each arg if they are uniformly constant at all call sites.
+  // May be any constant attribute or an immutable global symbol ref.
   SmallVector<LocAttr> callerUniformArgValues;
   // Uniform call operand index -> deduplicated index.
   // Base/non-duplicated values will be identity.
@@ -69,6 +70,7 @@ struct FuncAnalysis {
   // Which results are uniform from all return sites in the function.
   BitVector calleeUniformResults;
   // Values for each result if they are uniformly constant at all return sites.
+  // May be any constant attribute or an immutable global symbol ref.
   SmallVector<LocAttr> calleeUniformResultValues;
   // Uniform callee return operand index -> deduplicated index.
   // Base/non-duplicated values will be identity.
@@ -94,9 +96,13 @@ struct FuncAnalysis {
         os << "dupe(%arg" << callerUniformArgDupeMap[i] << ") ";
       }
       os << argTypes[i] << " ";
-      if (callerUniformArgValues[i]) {
-        os << "constant = ";
-        callerUniformArgValues[i].attr.print(os);
+      if (auto constant = callerUniformArgValues[i]) {
+        if (isa<SymbolRefAttr>(constant.attr)) {
+          os << "immutable global = ";
+        } else {
+          os << "constant = ";
+        }
+        constant.attr.print(os);
       }
       os << "\n";
     }
@@ -113,9 +119,13 @@ struct FuncAnalysis {
         os << "pass(%arg" << passthroughResultArgs[i] << ") ";
       }
       os << resultTypes[i] << " ";
-      if (calleeUniformResultValues[i]) {
-        os << "constant = ";
-        calleeUniformResultValues[i].attr.print(os);
+      if (auto constant = calleeUniformResultValues[i]) {
+        if (isa<SymbolRefAttr>(constant.attr)) {
+          os << "immutable global = ";
+        } else {
+          os << "constant = ";
+        }
+        constant.attr.print(os);
       }
       os << "\n";
     }
@@ -127,6 +137,17 @@ struct FuncAnalysis {
     }
   }
 };
+
+// Returns a global symbol ref if the value is loaded from an immutable global.
+static SymbolRefAttr matchImmutableGlobalLoad(Value value) {
+  if (auto loadOp = dyn_cast_if_present<IREE::Util::GlobalLoadOpInterface>(
+          value.getDefiningOp())) {
+    if (loadOp.isGlobalImmutable()) {
+      return loadOp.getGlobalAttr();
+    }
+  }
+  return {};
+}
 
 // Note that the analysis results may be incomplete.
 static FuncAnalysis analyzeFuncOp(IREE::Util::FuncOp funcOp,
@@ -183,6 +204,12 @@ static FuncAnalysis analyzeFuncOp(IREE::Util::FuncOp funcOp,
             value.getLoc(),
             value.getType(),
             constantValue,
+        };
+      } else if (auto globalRef = matchImmutableGlobalLoad(value)) {
+        analysis.calleeUniformResultValues[i] = {
+            value.getLoc(),
+            value.getType(),
+            globalRef,
         };
       }
 
@@ -242,6 +269,20 @@ static FuncAnalysis analyzeFuncOp(IREE::Util::FuncOp funcOp,
               constantValue,
           };
         } else if (seenArgAttrs[i] != constantValue) {
+          // Value constant has changed from prior calls: mark non-uniform.
+          analysis.callerUniformArgs.reset(i);
+        }
+      } else if (auto globalRef = matchImmutableGlobalLoad(value)) {
+        if (!seenArgAttrs[i]) {
+          // First call site with a constant or immutable global: stash so we
+          // can inline it if it's uniform.
+          seenArgAttrs[i] = globalRef;
+          analysis.callerUniformArgValues[i] = {
+              value.getLoc(),
+              value.getType(),
+              globalRef,
+          };
+        } else if (seenArgAttrs[i] != globalRef) {
           // Value constant has changed from prior calls: mark non-uniform.
           analysis.callerUniformArgs.reset(i);
         }
@@ -366,6 +407,14 @@ static FuncAnalysis analyzeFuncOp(IREE::Util::FuncOp funcOp,
 static void replaceValueWithConstant(Value value, LocAttr constantValue,
                                      OpBuilder &builder) {
   Operation *op = nullptr;
+
+  // Immutable global loads are represented as constant symbol refs.
+  if (auto globalRef = dyn_cast<SymbolRefAttr>(constantValue.attr)) {
+    op = builder.create<IREE::Util::GlobalLoadOp>(
+        constantValue.loc.value(), constantValue.type,
+        globalRef.getLeafReference().getValue(),
+        /*is_immutable=*/true);
+  }
 
   // Handle special builtin types that for some reason can't materialize
   // themselves.

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/ipo.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/ipo.mlir
@@ -209,6 +209,61 @@ util.func public @uniform_result_caller(%arg0: i1) -> index {
 
 // -----
 
+// Tests that uniform args that come from immutable globals are inlined into
+// callees.
+
+util.global private @global : index
+
+// CHECK-LABEL: util.func private @immutable_global_arg_callee
+// CHECK-SAME: () -> index
+util.func private @immutable_global_arg_callee(%arg0: index) -> index {
+  // CHECK: %[[GLOBAL_VALUE:.+]] = util.global.load immutable @global
+  // CHECK: %[[ADD:.+]] = arith.addi %[[GLOBAL_VALUE]], %[[GLOBAL_VALUE]]
+  %add = arith.addi %arg0, %arg0 : index
+  // CHECK: util.return %[[ADD]]
+  util.return %add : index
+}
+
+// CHECK: util.func public @immutable_global_arg_caller
+util.func public @immutable_global_arg_caller() -> index {
+  %global_value = util.global.load immutable @global : index
+  // CHECK: %[[RET:.+]] = util.call @immutable_global_arg_callee() : () -> index
+  %ret = util.call @immutable_global_arg_callee(%global_value) : (index) -> index
+  // CHECK: util.return %[[RET]]
+  util.return %ret : index
+}
+
+// -----
+
+// Tests that uniformly results that are immutable global loads get inlined into
+// callers.
+
+util.global private @global : index
+
+// CHECK-LABEL: util.func private @immutable_global_result_callee
+// CHECK-SAME: (%[[ARG0:.+]]: i1)
+util.func private @immutable_global_result_callee(%arg0: i1) -> index {
+  %global_value = util.global.load immutable @global : index
+  cf.cond_br %arg0, ^bb1, ^bb2
+^bb1:
+  // CHECK: util.return
+  util.return %global_value : index
+^bb2:
+  // CHECK: util.return
+  util.return %global_value : index
+}
+
+// CHECK: util.func public @immutable_global_result_caller(%[[ARG0:.+]]: i1)
+util.func public @immutable_global_result_caller(%arg0: i1) -> index {
+  // CHECK: call @immutable_global_result_callee(%[[ARG0]]) : (i1) -> ()
+  %ret0 = util.call @immutable_global_result_callee(%arg0) : (i1) -> index
+  // CHECK: %[[GLOBAL_VALUE:.+]] = util.global.load immutable @global
+  // CHECK: util.return %[[GLOBAL_VALUE]]
+  util.return %ret0 : index
+}
+
+// -----
+
 // Tests that uniformly duplicate constant results get combined/inlined.
 
 // CHECK-LABEL: util.func private @dupe_constant_result_callee


### PR DESCRIPTION
Parameters and constants end up as globals that previously were not getting marked as immutable unless the globals were default initialized. Now the GlobalTable tracks whether a global is exclusively stored within initializers (or functions only called from initializers) in order to mark them as immutable. IPO was updated to support propagating uniform immutable global loads across call edges as if they were constants (as they effectively are just constants stored on the global scope).

Required for #17875 (to avoid treating constants/parameters as dynamic binding table values).