### PR TITLE
Add a pre-vm pattern to handle extf-truncf

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/patterns.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/patterns.mlir
@@ -297,3 +297,13 @@ util.func @mergeIndexSwitchesIntoEmptyDefault(%case: index) {
   }
   util.return
 }
+
+// -----
+
+// CHECK-LABEL: @extfTruncf
+util.func @extfTruncf(%arg0: f32) -> f32 {
+  %f64 = arith.extf %arg0 : f32 to f64
+  %f32 = arith.truncf %f64 : f64 to f32
+  // CHECK: util.return %arg0
+  util.return %f32 : f32
+}


### PR DESCRIPTION
Torch-mlir represents all scalar level values as int64 and f64. This can result in lower level failures when `f64` is not supported. In most of these cases the `f64` value can be completely ellided away.