### PR TITLE
[MLIR][EmitC] Remove struct related macros from ops_emitc.h

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCBuilders.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCBuilders.cpp
@@ -211,74 +211,50 @@ void structDefinition(OpBuilder builder, Location location,
 
 Value structMember(OpBuilder builder, Location location, Type type,
                    StringRef memberName, Value operand) {
-  auto ctx = builder.getContext();
-  return builder
-      .create<emitc::CallOpaqueOp>(
-          /*location=*/location,
-          /*type=*/type,
-          /*callee=*/"EMITC_STRUCT_MEMBER",
-          /*operands=*/ArrayRef<Value>{operand},
-          /*args=*/
-          ArrayAttr::get(ctx, {builder.getIndexAttr(0),
-                               emitc::OpaqueAttr::get(ctx, memberName)}))
-      .getResult(0);
+  Value var = allocateVariable(builder, location, type);
+  Value member =
+      builder.create<emitc::MemberOp>(location, type, memberName, operand);
+  builder.create<emitc::AssignOp>(location, var, member);
+  return var;
+}
+
+Value structMemberAddress(OpBuilder builder, Location location,
+                          emitc::PointerType type, StringRef memberName,
+                          Value operand) {
+  Value member = builder.create<emitc::MemberOp>(location, type.getPointee(),
+                                                 memberName, operand);
+  return addressOf(builder, location, member);
 }
 
 void structMemberAssign(OpBuilder builder, Location location,
                         StringRef memberName, Value operand, Value data) {
-  auto ctx = builder.getContext();
-  builder.create<emitc::CallOpaqueOp>(
-      /*location=*/location,
-      /*type=*/TypeRange{},
-      /*callee=*/"EMITC_STRUCT_MEMBER_ASSIGN",
-      /*operands=*/ArrayRef<Value>{operand, data},
-      /*args=*/
-      ArrayAttr::get(ctx, {builder.getIndexAttr(0),
-                           emitc::OpaqueAttr::get(ctx, memberName),
-                           builder.getIndexAttr(1)}));
-}
-
-void structMemberAssign(OpBuilder builder, Location location,
-                        StringRef memberName, Value operand, StringRef data) {
-  auto ctx = builder.getContext();
-  builder.create<emitc::CallOpaqueOp>(
-      /*location=*/location,
-      /*type=*/TypeRange{},
-      /*callee=*/"EMITC_STRUCT_MEMBER_ASSIGN",
-      /*operands=*/ArrayRef<Value>{operand},
-      /*args=*/
-      ArrayAttr::get(ctx, {builder.getIndexAttr(0),
-                           emitc::OpaqueAttr::get(ctx, memberName),
-                           emitc::OpaqueAttr::get(ctx, data)}));
+  Value member = builder.create<emitc::MemberOp>(location, data.getType(),
+                                                 memberName, operand);
+  builder.create<emitc::AssignOp>(location, member, data);
 }
 
 Value structPtrMember(OpBuilder builder, Location location, Type type,
                       StringRef memberName, Value operand) {
-  auto ctx = builder.getContext();
-  return builder
-      .create<emitc::CallOpaqueOp>(
-          /*location=*/location,
-          /*type=*/type,
-          /*callee=*/"EMITC_STRUCT_PTR_MEMBER",
-          /*operands=*/ArrayRef<Value>{operand},
-          /*args=*/
-          ArrayAttr::get(ctx, {builder.getIndexAttr(0),
-                               emitc::OpaqueAttr::get(ctx, memberName)}))
-      .getResult(0);
+  Value var = allocateVariable(builder, location, type);
+  Value member =
+      builder.create<emitc::MemberOfPtrOp>(location, type, memberName, operand);
+  builder.create<emitc::AssignOp>(location, var, member);
+  return var;
+}
+
+Value structPtrMemberAddress(OpBuilder builder, Location location,
+                             emitc::PointerType type, StringRef memberName,
+                             Value operand) {
+  Value member = builder.create<emitc::MemberOfPtrOp>(
+      location, type.getPointee(), memberName, operand);
+  return addressOf(builder, location, member);
 }
 
 void structPtrMemberAssign(OpBuilder builder, Location location,
                            StringRef memberName, Value operand, Value data) {
-  auto ctx = builder.getContext();
-  builder.create<emitc::CallOpaqueOp>(
-      /*location=*/location,
-      /*type=*/TypeRange{},
-      /*callee=*/"EMITC_STRUCT_PTR_MEMBER_ASSIGN",
-      /*operands=*/ArrayRef<Value>{operand, data},
-      /*args=*/
-      ArrayAttr::get(ctx, {builder.getIndexAttr(0),
-                           emitc::OpaqueAttr::get(ctx, memberName),
-                           builder.getIndexAttr(1)}));
+  Value member = builder.create<emitc::MemberOfPtrOp>(location, data.getType(),
+                                                      memberName, operand);
+  builder.create<emitc::AssignOp>(location, member, data);
 }
 
 Value ireeMakeCstringView(OpBuilder builder, Location location,

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCBuilders.h
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCBuilders.h
@@ -119,6 +119,10 @@ void structDefinition(OpBuilder builder, Location location,
 Value structMember(OpBuilder builder, Location location, Type type,
                    StringRef memberName, Value operand);
 
+Value structMemberAddress(OpBuilder builder, Location location,
+                          emitc::PointerType type, StringRef memberName,
+                          Value operand);
+
 void structMemberAssign(OpBuilder builder, Location location,
                         StringRef memberName, Value operand, Value data);
 
@@ -127,6 +131,10 @@ void structMemberAssign(OpBuilder builder, Location location,
 
 Value structPtrMember(OpBuilder builder, Location location, Type type,
                       StringRef memberName, Value operand);
+
+Value structPtrMemberAddress(OpBuilder builder, Location location,
+                             emitc::PointerType type, StringRef memberName,
+                             Value operand);
 
 void structPtrMemberAssign(OpBuilder builder, Location location,
                            StringRef memberName, Value operand, Value data);

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.cpp
@@ -64,7 +64,7 @@ Type EmitCTypeConverter::convertTypeAsNonPointer(Type type) const {
   return convertedType;
 }
 
-Type EmitCTypeConverter::convertTypeAsPointer(Type type) const {
+emitc::PointerType EmitCTypeConverter::convertTypeAsPointer(Type type) const {
   return emitc::PointerType::get(convertTypeAsNonPointer(type));
 }
 

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.h
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCTypeConverter.h
@@ -22,7 +22,7 @@ public:
   // This is the same as convertType, but returns `iree_vm_ref_t` rather than a
   // pointer to it for `vm.ref` types.
   Type convertTypeAsNonPointer(Type type) const;
-  Type convertTypeAsPointer(Type type) const;
+  emitc::PointerType convertTypeAsPointer(Type type) const;
   emitc::OpaqueType convertTypeAsCType(Type type) const;
 
   SetVector<Operation *> sourceMaterializations;

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/buffer_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/buffer_ops.mlir
@@ -7,9 +7,11 @@ vm.module @my_module {
     // CHECK-DAG: %[[ALIGNMENT:.+]] = "emitc.constant"() <{value = 32 : i32}> : () -> i32
     // CHECK-DAG: %[[BUFFER:.+]] = "emitc.variable"() <{value = #emitc.opaque<"NULL">}> : () -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
     // CHECK-DAG: %[[BUFFER_PTR:.+]] = emitc.apply "&"(%[[BUFFER]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>) -> !emitc.ptr<!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>>
-    // CHECK-DAG: %[[ALLOCTOR:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"allocator">]} : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.opaque<"iree_allocator_t">
+    // CHECK-DAG: %[[ALLOCATOR_VAR:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.opaque<"iree_allocator_t">
+    // CHECK-DAG: %[[ALLOCATOR:.+]] = "emitc.member_of_ptr"(%arg2) <{member = "allocator"}> : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.opaque<"iree_allocator_t">
+    // CHECK-DAG: emitc.assign %[[ALLOCATOR]] : !emitc.opaque<"iree_allocator_t"> to %[[ALLOCATOR_VAR]] : !emitc.opaque<"iree_allocator_t">
     // CHECK-DAG: %[[BUFFER_ACCESS:.+]] = "emitc.constant"() <{value = #emitc.opaque<"IREE_VM_BUFFER_ACCESS_MUTABLE | IREE_VM_BUFFER_ACCESS_ORIGIN_GUEST">}> : () -> !emitc.opaque<"iree_vm_buffer_access_t">
-    // CHECK-NEXT: %[[STATUS:.+]] = emitc.call_opaque "iree_vm_buffer_create"(%[[BUFFER_ACCESS]], %[[SIZE]], %[[ALIGNMENT]], %[[ALLOCTOR]], %[[BUFFER_PTR]]) : (!emitc.opaque<"iree_vm_buffer_access_t">, i64, i32, !emitc.opaque<"iree_allocator_t">, !emitc.ptr<!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>>) -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %[[STATUS:.+]] = emitc.call_opaque "iree_vm_buffer_create"(%[[BUFFER_ACCESS]], %[[SIZE]], %[[ALIGNMENT]], %[[ALLOCATOR_VAR]], %[[BUFFER_PTR]]) : (!emitc.opaque<"iree_vm_buffer_access_t">, i64, i32, !emitc.opaque<"iree_allocator_t">, !emitc.ptr<!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>>) -> !emitc.opaque<"iree_status_t">
 
     // CHECK: %[[BUFFER_TYPE_ID:.+]] = emitc.call_opaque "iree_vm_buffer_type"() : () -> !emitc.opaque<"iree_vm_ref_type_t">
     // CHECK-NEXT: %[[STATUS2:.+]] = emitc.call_opaque "iree_vm_ref_wrap_assign"(%[[BUFFER]], %[[BUFFER_TYPE_ID]], %1) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, !emitc.opaque<"iree_vm_ref_type_t">, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
@@ -32,12 +34,13 @@ vm.module @my_module {
 
     // CHECK: %[[BUFFER:.+]] = "emitc.variable"() <{value = #emitc.opaque<"NULL">}> : () -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
     // CHECK-DAG: %[[BUFFER_PTR:.+]] = emitc.apply "&"(%[[BUFFER]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>) -> !emitc.ptr<!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>>
-    // CHECK-DAG: %[[ALLOCATOR:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"allocator">]} : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.opaque<"iree_allocator_t">
+    // CHECK-DAG: %[[ALLOCATOR_VAR:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.opaque<"iree_allocator_t">
+    // CHECK-DAG: %[[ALLOCATOR:.+]] = "emitc.member_of_ptr"(%arg2) <{member = "allocator"}> : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.opaque<"iree_allocator_t">
     // CHECK-DAG: %[[BUFFER_ACCESS:.+]] = "emitc.constant"() <{value = #emitc.opaque<"IREE_VM_BUFFER_ACCESS_MUTABLE | IREE_VM_BUFFER_ACCESS_ORIGIN_GUEST">}> : () -> !emitc.opaque<"iree_vm_buffer_access_t">
     // CHECK-DAG: %[[BUFFER_REF2:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
     // CHECK-DAG: %[[BUFFER_PTR2:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF2]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
-    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "iree_vm_buffer_clone"(%[[BUFFER_ACCESS]], %[[BUFFER_PTR2]], %[[C0]], %[[C32]], %[[ALIGNMENT]], %[[ALLOCATOR]], %[[BUFFER_PTR]]) : (!emitc.opaque<"iree_vm_buffer_access_t">, !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64, i32, !emitc.opaque<"iree_allocator_t">, !emitc.ptr<!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>>) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "iree_vm_buffer_clone"(%[[BUFFER_ACCESS]], %[[BUFFER_PTR2]], %[[C0]], %[[C32]], %[[ALIGNMENT]], %[[ALLOCATOR_VAR]], %[[BUFFER_PTR]]) : (!emitc.opaque<"iree_vm_buffer_access_t">, !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64, i32, !emitc.opaque<"iree_allocator_t">, !emitc.ptr<!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>>) -> !emitc.opaque<"iree_status_t">
     %c0 = vm.const.i64 0
     %c32 = vm.const.i64 32
     %alignment = vm.const.i32 64

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/control_flow_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/control_flow_ops.mlir
@@ -67,9 +67,10 @@ vm.module @my_module {
   vm.func @call_imported_fn(%arg0 : i32) -> i32 {
 
     // Lookup import from module struct.
-    // CHECK-NEXT: %[[IMPORTS:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"imports">]}
-    // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
-    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.call_opaque "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[IMPORTS]]) {args = [0 : index, 0 : ui32]}
+    // CHECK-NEXT: %[[IMPORTS_VAR:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[IMPORTS:.+]] = "emitc.member_of_ptr"(%arg2) <{member = "imports"}> : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: emitc.assign %[[IMPORTS]] : !emitc.ptr<!emitc.opaque<"iree_vm_function_t">> to %[[IMPORTS_VAR]] : !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.call_opaque "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[IMPORTS_VAR]]) {args = [0 : index, 0 : ui32]}
     // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
 
     // Create a variable for the function result.
@@ -93,9 +94,10 @@ vm.module @my_module {
   vm.func @call_imported_fn(%arg0 : i32) -> i32 {
 
     // Lookup import from module struct.
-    // CHECK-NEXT: %[[IMPORTS:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"imports">]}
-    // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
-    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.call_opaque "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[IMPORTS]]) {args = [0 : index, 0 : ui32]}
+    // CHECK-NEXT: %[[IMPORTS_VAR:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[IMPORTS:.+]] = "emitc.member_of_ptr"(%arg2) <{member = "imports"}> : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: emitc.assign %[[IMPORTS]] : !emitc.ptr<!emitc.opaque<"iree_vm_function_t">> to %[[IMPORTS_VAR]] : !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.call_opaque "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[IMPORTS_VAR]]) {args = [0 : index, 0 : ui32]}
     // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
 
     // Create a variable for the function result.
@@ -150,9 +152,10 @@ vm.module @my_module {
   vm.func @call_variadic(%arg0 : i32, %arg1 : i32) -> i32 {
 
     // Lookup import from module struct.
-    // CHECK-NEXT: %[[IMPORTS:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"imports">]}
-    // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
-    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.call_opaque "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[IMPORTS]]) {args = [0 : index, 0 : ui32]}
+    // CHECK-NEXT: %[[IMPORTS_VAR:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[IMPORTS:.+]] = "emitc.member_of_ptr"(%arg2) <{member = "imports"}> : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: emitc.assign %[[IMPORTS]] : !emitc.ptr<!emitc.opaque<"iree_vm_function_t">> to %[[IMPORTS_VAR]] : !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.call_opaque "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[IMPORTS_VAR]]) {args = [0 : index, 0 : ui32]}
     // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
 
     // This holds the number of variadic arguments.
@@ -183,9 +186,10 @@ vm.module @my_module {
   vm.func @call_variadic() -> i32 {
 
     // Lookup import from module struct.
-    // CHECK-NEXT: %[[IMPORTS:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"imports">]}
-    // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
-    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.call_opaque "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[IMPORTS]]) {args = [0 : index, 0 : ui32]}
+    // CHECK-NEXT: %[[IMPORTS_VAR:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[IMPORTS:.+]] = "emitc.member_of_ptr"(%arg2) <{member = "imports"}> : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: emitc.assign %[[IMPORTS]] : !emitc.ptr<!emitc.opaque<"iree_vm_function_t">> to %[[IMPORTS_VAR]] : !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.call_opaque "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[IMPORTS_VAR]]) {args = [0 : index, 0 : ui32]}
     // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
 
     // This holds the number of variadic arguments.
@@ -346,12 +350,14 @@ vm.module @my_module {
     // CHECK-NEXT: ^[[FAIL]]:
     // CHECK-NEXT: %[[MSG:.+]] = emitc.call_opaque "iree_make_cstring_view"() {args = [#emitc.opaque<"\22message\22">]}
     // CHECK-SAME:     : () -> !emitc.opaque<"iree_string_view_t">
-    // CHECK-NEXT: %[[MSGSIZE:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[MSG]]) {args = [0 : index, #emitc.opaque<"size">]}
-    // CHECK-SAME:     : (!emitc.opaque<"iree_string_view_t">) -> !emitc.opaque<"iree_host_size_t">
-    // CHECK-NEXT: %[[MSGSIZEINT:.+]] = emitc.cast %[[MSGSIZE]] : !emitc.opaque<"iree_host_size_t"> to !emitc.opaque<"int">
-    // CHECK-NEXT: %[[MSGDATA:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[MSG]]) {args = [0 : index, #emitc.opaque<"data">]}
-    // CHECK-SAME:     : (!emitc.opaque<"iree_string_view_t">) -> !emitc.ptr<!emitc.opaque<"const char">>
-    // CHECK-NEXT: %[[FAILSTATUS:.+]] = emitc.call_opaque "iree_status_allocate_f"(%[[MSGSIZEINT]], %[[MSGDATA]])
+    // CHECK-NEXT: %[[MSGSIZE_VAR:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.opaque<"iree_host_size_t">
+    // CHECK-NEXT: %[[MSGSIZE:.+]] = "emitc.member"(%[[MSG]]) <{member = "size"}> : (!emitc.opaque<"iree_string_view_t">) -> !emitc.opaque<"iree_host_size_t">
+    // CHECK-NEXT: emitc.assign %[[MSGSIZE]] : !emitc.opaque<"iree_host_size_t"> to %[[MSGSIZE_VAR]] : !emitc.opaque<"iree_host_size_t">
+    // CHECK-NEXT: %[[MSGSIZEINT:.+]] = emitc.cast %[[MSGSIZE_VAR]] : !emitc.opaque<"iree_host_size_t"> to !emitc.opaque<"int">
+    // CHECK-NEXT: %[[MSGDATA_VAR:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.ptr<!emitc.opaque<"const char">>
+    // CHECK-NEXT: %[[MSGDATA:.+]] = "emitc.member"(%[[MSG]]) <{member = "data"}> : (!emitc.opaque<"iree_string_view_t">) -> !emitc.ptr<!emitc.opaque<"const char">>
+    // CHECK-NEXT: emitc.assign %[[MSGDATA]] : !emitc.ptr<!emitc.opaque<"const char">> to %[[MSGDATA_VAR]] : !emitc.ptr<!emitc.opaque<"const char">>
+    // CHECK-NEXT: %[[FAILSTATUS:.+]] = emitc.call_opaque "iree_status_allocate_f"(%[[MSGSIZEINT]], %[[MSGDATA_VAR]])
     // CHECK-SAME:     {args = [#emitc.opaque<"IREE_STATUS_FAILED_PRECONDITION">, #emitc.opaque<"\22<vm>\22">, 0 : i32, #emitc.opaque<"\22%.*s\22">, 0 : index, 1 : index]}
     // CHECK-SAME:     : (!emitc.opaque<"int">, !emitc.ptr<!emitc.opaque<"const char">>) -> !emitc.opaque<"iree_status_t">
     // CHECK-NEXT: return %[[FAILSTATUS]] : !emitc.opaque<"iree_status_t">
@@ -376,39 +382,45 @@ vm.module @my_module {
   // Create a struct for the arguments and results.
   // CHECK: %[[ARGSTRUCT:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.opaque<"iree_vm_function_call_t">
   // CHECK-NEXT: %[[ARGSTRUCTFN:.+]] = emitc.apply "*"(%arg1) : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.opaque<"iree_vm_function_t">
-  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_MEMBER_ASSIGN"(%[[ARGSTRUCT]], %[[ARGSTRUCTFN]]) {args = [0 : index, #emitc.opaque<"function">, 1 : index]}
+  // CHECK-NEXT: %[[ARGSTRUCTFN_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "function"}> : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.opaque<"iree_vm_function_t">
+  // CHECK-NEXT: emitc.assign %[[ARGSTRUCTFN]] : !emitc.opaque<"iree_vm_function_t"> to %[[ARGSTRUCTFN_MEMBER]] : !emitc.opaque<"iree_vm_function_t">
 
   // Allocate space for the arguments.
-  // CHECK-NEXT: %[[ARGBYTESPAN:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER_ADDRESS"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"arguments">]}
-  // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.ptr<!emitc.opaque<"iree_byte_span_t">>
+  // CHECK-NEXT: %[[ARGBYTESPAN_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "arguments"}> : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.opaque<"iree_byte_span_t">
+  // CHECK-NEXT: %[[ARGBYTESPAN:.+]] = emitc.apply "&"(%[[ARGBYTESPAN_MEMBER]]) : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<!emitc.opaque<"iree_byte_span_t">>
   // CHECK-NEXT: %[[ARGBYTESPANDATAVOID:.+]] = emitc.call_opaque "iree_alloca"(%[[ARGSIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
   // CHECK-NEXT: %[[ARGBYTESPANDATA:.+]] = emitc.cast %[[ARGBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
-  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[ARGBYTESPAN]], %[[ARGSIZE]]) {args = [0 : index, #emitc.opaque<"data_length">, 1 : index]}
-  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[ARGBYTESPAN]], %[[ARGBYTESPANDATA]]) {args = [0 : index, #emitc.opaque<"data">, 1 : index]}
+  // CHECK-NEXT: %[[ARGSDATALENGTH:.+]] = "emitc.member_of_ptr"(%[[ARGBYTESPAN]]) <{member = "data_length"}> : (!emitc.ptr<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: emitc.assign %[[ARGSIZE]] : !emitc.opaque<"iree_host_size_t"> to %[[ARGSDATALENGTH]] : !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: %[[ARGSDATA:.+]] = "emitc.member_of_ptr"(%[[ARGBYTESPAN]]) <{member = "data"}> : (!emitc.ptr<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.ptr<ui8>
+  // CHECK-NEXT: emitc.assign %[[ARGBYTESPANDATA]] : !emitc.ptr<ui8> to %[[ARGSDATA]] : !emitc.ptr<ui8>
   // CHECK-NEXT: emitc.call_opaque "memset"(%[[ARGBYTESPANDATA]], %[[ARGSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
 
   // Allocate space for the result.
-  // CHECK-NEXT: %[[RESBYTESPAN:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER_ADDRESS"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"results">]}
-  // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.ptr<!emitc.opaque<"iree_byte_span_t">>
+  // CHECK-NEXT: %[[RESBYTESPAN_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "results"}> : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.opaque<"iree_byte_span_t">
+  // CHECK-NEXT: %[[RESBYTESPAN:.+]] = emitc.apply "&"(%[[RESBYTESPAN_MEMBER]]) : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<!emitc.opaque<"iree_byte_span_t">>
   // CHECK-NEXT: %[[RESBYTESPANDATAVOID:.+]] = emitc.call_opaque "iree_alloca"(%[[RESULTSIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
   // CHECK-NEXT: %[[RESBYTESPANDATA:.+]] = emitc.cast %[[RESBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
-  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[RESBYTESPAN]], %[[RESULTSIZE]]) {args = [0 : index, #emitc.opaque<"data_length">, 1 : index]}
-  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[RESBYTESPAN]], %[[RESBYTESPANDATA]]) {args = [0 : index, #emitc.opaque<"data">, 1 : index]}
+  // CHECK-NEXT: %[[RESSDATALENGTH:.+]] = "emitc.member_of_ptr"(%[[RESBYTESPAN]]) <{member = "data_length"}> : (!emitc.ptr<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: emitc.assign %[[RESULTSIZE]] : !emitc.opaque<"iree_host_size_t"> to %[[RESSDATALENGTH]] : !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: %[[RESSDATA:.+]] = "emitc.member_of_ptr"(%[[RESBYTESPAN]]) <{member = "data"}> : (!emitc.ptr<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.ptr<ui8>
+  // CHECK-NEXT: emitc.assign %[[RESBYTESPANDATA]] : !emitc.ptr<ui8> to %[[RESSDATA]] : !emitc.ptr<ui8>
   // CHECK-NEXT: emitc.call_opaque "memset"(%[[RESBYTESPANDATA]], %[[RESULTSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
 
   // Check that we don't pack anything into the argument struct.
-  // CHECK-NOT: emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"arguments">]}
-  // CHECK-NOT: %[[ARGSPTR:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%{{.+}}) {args = [0 : index, #emitc.opaque<"data">]}
+  // CHECK-NOT: "emitc.member"(%[[RESBYTESPAN]]) <{member = "arguments"}>
+  // CHECK-NOT: "emitc.member"(%{{.+}}) <{member = "data"}>
 
   // Create the call to the imported function.
-  // CHECK-NEXT: %[[IMPORTMOD:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg1) {args = [0 : index, #emitc.opaque<"module">]}
-  // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
-  // CHECK-NEXT: %{{.+}} = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_CALL"(%[[IMPORTMOD]], %arg0, %[[ARGSTRUCT]])
-  // CHECK-SAME:     {args = [0 : index, #emitc.opaque<"begin_call">, 0 : index, 1 : index, 2 : index]}
+  // CHECK-NEXT: %[[IMPORTMOD:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
+  // CHECK-NEXT: %[[MODULE_MEMBER:.+]] = "emitc.member_of_ptr"(%arg1) <{member = "module"}> : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
+  // CHECK-NEXT: emitc.assign %[[MODULE_MEMBER]] : !emitc.ptr<!emitc.opaque<"iree_vm_module_t">> to %[[IMPORTMOD]] : !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
+  // CHECK-NEXT: %[[BEGIN_CALL:.+]] = "emitc.member_of_ptr"(%[[IMPORTMOD]]) <{member = "begin_call"}> : (!emitc.ptr<!emitc.opaque<"iree_vm_module_t">>) -> !emitc.ptr<!emitc.opaque<"void">>
+  // CHECK-NEXT: %{{.+}} = emitc.call_opaque "EMITC_CALL_INDIRECT"(%[[BEGIN_CALL]], %[[IMPORTMOD]], %arg0, %[[ARGSTRUCT]])
 
   // Check that we don't unpack anything from the result struct.
-  // CHECK-NOT: emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"results">]}
-  // CHECK-NOT: emitc.call_opaque "EMITC_STRUCT_MEMBER"(%{{.+}}) {args = [0 : index, #emitc.opaque<"data">]}
+  // CHECK-NOT: "emitc.member"(%[[ARGSTRUCT]]) <{member = "results"}>
+  // CHECK-NOT: "emitc.member"(%{{.+}}) <{member = "data"}>
 
   // Return ok status.
   //      CHECK: %[[OK:.+]] = emitc.call_opaque "iree_ok_status"()
@@ -454,34 +466,39 @@ vm.module @my_module {
   // Create a struct for the arguments and results.
   // CHECK: %[[ARGSTRUCT:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.opaque<"iree_vm_function_call_t">
   // CHECK-NEXT: %[[ARGSTRUCTFN:.+]] = emitc.apply "*"(%arg1) : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.opaque<"iree_vm_function_t">
-  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_MEMBER_ASSIGN"(%[[ARGSTRUCT]], %[[ARGSTRUCTFN]]) {args = [0 : index, #emitc.opaque<"function">, 1 : index]}
+  // CHECK-NEXT: %[[ARGSTRUCTFN_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "function"}> : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.opaque<"iree_vm_function_t">
+  // CHECK-NEXT: emitc.assign %[[ARGSTRUCTFN]] : !emitc.opaque<"iree_vm_function_t"> to %[[ARGSTRUCTFN_MEMBER]] : !emitc.opaque<"iree_vm_function_t">
 
   // Allocate space for the arguments.
-  // CHECK-NEXT: %[[ARGBYTESPAN:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER_ADDRESS"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"arguments">]}
-  // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.ptr<!emitc.opaque<"iree_byte_span_t">>
-  // CHECK-NEXT: %[[ARGBYTESPANDATAVOID:.+]] = emitc.call_opaque "iree_alloca"(%[[ARGSIZE]])
-  // CHECK-SAME:     : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
+  // CHECK-NEXT: %[[ARGBYTESPAN_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "arguments"}> : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.opaque<"iree_byte_span_t">
+  // CHECK-NEXT: %[[ARGBYTESPAN:.+]] = emitc.apply "&"(%[[ARGBYTESPAN_MEMBER]]) : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<!emitc.opaque<"iree_byte_span_t">>
+  // CHECK-NEXT: %[[ARGBYTESPANDATAVOID:.+]] = emitc.call_opaque "iree_alloca"(%[[ARGSIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
   // CHECK-NEXT: %[[ARGBYTESPANDATA:.+]] = emitc.cast %[[ARGBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
-  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[ARGBYTESPAN]], %[[ARGSIZE]]) {args = [0 : index, #emitc.opaque<"data_length">, 1 : index]}
-  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[ARGBYTESPAN]], %[[ARGBYTESPANDATA]]) {args = [0 : index, #emitc.opaque<"data">, 1 : index]}
+  // CHECK-NEXT: %[[ARGSDATALENGTH:.+]] = "emitc.member_of_ptr"(%[[ARGBYTESPAN]]) <{member = "data_length"}> : (!emitc.ptr<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: emitc.assign %[[ARGSIZE]] : !emitc.opaque<"iree_host_size_t"> to %[[ARGSDATALENGTH]] : !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: %[[ARGSDATA:.+]] = "emitc.member_of_ptr"(%[[ARGBYTESPAN]]) <{member = "data"}> : (!emitc.ptr<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.ptr<ui8>
+  // CHECK-NEXT: emitc.assign %[[ARGBYTESPANDATA]] : !emitc.ptr<ui8> to %[[ARGSDATA]] : !emitc.ptr<ui8>
   // CHECK-NEXT: emitc.call_opaque "memset"(%[[ARGBYTESPANDATA]], %[[ARGSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
 
   // Allocate space for the result.
-  // CHECK-NEXT: %[[RESBYTESPAN:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER_ADDRESS"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"results">]}
-  // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.ptr<!emitc.opaque<"iree_byte_span_t">>
-  // CHECK-NEXT: %[[RESBYTESPANDATAVOID:.+]] = emitc.call_opaque "iree_alloca"(%[[RESULTSIZE]])
-  // CHECK-SAME:     : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
+  // CHECK-NEXT: %[[RESBYTESPAN_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "results"}> : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.opaque<"iree_byte_span_t">
+  // CHECK-NEXT: %[[RESBYTESPAN:.+]] = emitc.apply "&"(%[[RESBYTESPAN_MEMBER]]) : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<!emitc.opaque<"iree_byte_span_t">>
+  // CHECK-NEXT: %[[RESBYTESPANDATAVOID:.+]] = emitc.call_opaque "iree_alloca"(%[[RESULTSIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
   // CHECK-NEXT: %[[RESBYTESPANDATA:.+]] = emitc.cast %[[RESBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
-  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[RESBYTESPAN]], %[[RESULTSIZE]]) {args = [0 : index, #emitc.opaque<"data_length">, 1 : index]}
-  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[RESBYTESPAN]], %[[RESBYTESPANDATA]]) {args = [0 : index, #emitc.opaque<"data">, 1 : index]}
+  // CHECK-NEXT: %[[RESSDATALENGTH:.+]] = "emitc.member_of_ptr"(%[[RESBYTESPAN]]) <{member = "data_length"}> : (!emitc.ptr<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: emitc.assign %[[RESULTSIZE]] : !emitc.opaque<"iree_host_size_t"> to %[[RESSDATALENGTH]] : !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: %[[RESSDATA:.+]] = "emitc.member_of_ptr"(%[[RESBYTESPAN]]) <{member = "data"}> : (!emitc.ptr<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.ptr<ui8>
+  // CHECK-NEXT: emitc.assign %[[RESBYTESPANDATA]] : !emitc.ptr<ui8> to %[[RESSDATA]] : !emitc.ptr<ui8>
   // CHECK-NEXT: emitc.call_opaque "memset"(%[[RESBYTESPANDATA]], %[[RESULTSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
 
   // Pack the arguments into the struct.
   // Here we also create pointers for non-pointer types.
-  // CHECK-NEXT: %[[ARGS:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"arguments">]}
-  // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.opaque<"iree_byte_span_t">
-  // CHECK-NEXT: %[[ARGSPTR:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[ARGS]]) {args = [0 : index, #emitc.opaque<"data">]}
-  // CHECK-SAME:     : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<ui8>
+  // CHECK-NEXT: %[[ARGS:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.opaque<"iree_byte_span_t">
+  // CHECK-NEXT: %[[ARGS_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "arguments"}> : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.opaque<"iree_byte_span_t">
+  // CHECK-NEXT: emitc.assign %[[ARGS_MEMBER]] : !emitc.opaque<"iree_byte_span_t"> to %[[ARGS]] : !emitc.opaque<"iree_byte_span_t">
+  // CHECK-NEXT: %[[ARGSPTR:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.ptr<ui8>
+  // CHECK-NEXT: %[[ARGSPTR_MEMBER:.+]] = "emitc.member"(%[[ARGS]]) <{member = "data"}> : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<ui8>
+  // CHECK-NEXT: emitc.assign %[[ARGSPTR_MEMBER]] : !emitc.ptr<ui8> to %[[ARGSPTR]] : !emitc.ptr<ui8>
   // CHECK-NEXT: %[[ARGHOSTSIZE:.+]] = emitc.call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
   // CHECK-NEXT: %[[A1PTR:.+]] = emitc.apply "&"(%arg2) : (i32) -> !emitc.ptr<i32>
   // CHECK-NEXT: emitc.call_opaque "memcpy"(%[[ARGSPTR]], %[[A1PTR]], %[[ARGHOSTSIZE]])
@@ -505,16 +522,19 @@ vm.module @my_module {
   // CHECK-NEXT: emitc.call_opaque "memcpy"(%[[A3ADDR]], %[[A4PTR]], %[[A3SIZE:.+]])
 
   // Create the call to the imported function.
-  // CHECK-NEXT: %[[IMPORTMOD:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg1) {args = [0 : index, #emitc.opaque<"module">]}
-  // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
-  // CHECK-NEXT: %{{.+}} = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_CALL"(%[[IMPORTMOD]], %arg0, %[[ARGSTRUCT]])
-  // CHECK-SAME:     {args = [0 : index, #emitc.opaque<"begin_call">, 0 : index, 1 : index, 2 : index]}
+  // CHECK-NEXT: %[[IMPORTMOD:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
+  // CHECK-NEXT: %[[MODULE_MEMBER:.+]] = "emitc.member_of_ptr"(%arg1) <{member = "module"}> : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
+  // CHECK-NEXT: emitc.assign %[[MODULE_MEMBER]] : !emitc.ptr<!emitc.opaque<"iree_vm_module_t">> to %[[IMPORTMOD]] : !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
+  // CHECK-NEXT: %[[BEGIN_CALL:.+]] = "emitc.member_of_ptr"(%[[IMPORTMOD]]) <{member = "begin_call"}> : (!emitc.ptr<!emitc.opaque<"iree_vm_module_t">>) -> !emitc.ptr<!emitc.opaque<"void">>
+  // CHECK-NEXT: %{{.+}} = emitc.call_opaque "EMITC_CALL_INDIRECT"(%[[BEGIN_CALL]], %[[IMPORTMOD]], %arg0, %[[ARGSTRUCT]])
 
   // Unpack the function results.
-  //      CHECK: %[[RES:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"results">]}
-  // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.opaque<"iree_byte_span_t">
-  // CHECK-NEXT: %[[RESPTR:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[RES]]) {args = [0 : index, #emitc.opaque<"data">]}
-  // CHECK-SAME:     : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<ui8>
+  //      CHECK: %[[RES:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.opaque<"iree_byte_span_t">
+  // CHECK-NEXT: %[[RES_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "results"}> : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.opaque<"iree_byte_span_t">
+  // CHECK-NEXT: emitc.assign %[[RES_MEMBER]] : !emitc.opaque<"iree_byte_span_t"> to %[[RES]] : !emitc.opaque<"iree_byte_span_t">
+  // CHECK-NEXT: %[[RESPTR:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.ptr<ui8>
+  // CHECK-NEXT: %[[RESPTR_MEMBER:.+]] = "emitc.member"(%[[RES]]) <{member = "data"}> : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<ui8>
+  // CHECK-NEXT: emitc.assign %[[RESPTR_MEMBER]] : !emitc.ptr<ui8> to %[[RESPTR]] : !emitc.ptr<ui8>
   // CHECK-NEXT: %[[RESHOSTSIZE:.+]] = emitc.call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
   // CHECK-NEXT: emitc.call_opaque "memcpy"(%arg6, %[[RESPTR]], %[[RESHOSTSIZE]])
 
@@ -556,34 +576,39 @@ vm.module @my_module {
   // Create a struct for the arguments and results.
   // CHECK: %[[ARGSTRUCT:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.opaque<"iree_vm_function_call_t">
   // CHECK-NEXT: %[[ARGSTRUCTFN:.+]] = emitc.apply "*"(%arg1) : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.opaque<"iree_vm_function_t">
-  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_MEMBER_ASSIGN"(%[[ARGSTRUCT]], %[[ARGSTRUCTFN]]) {args = [0 : index, #emitc.opaque<"function">, 1 : index]}
+  // CHECK-NEXT: %[[ARGSTRUCTFN_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "function"}> : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.opaque<"iree_vm_function_t">
+  // CHECK-NEXT: emitc.assign %[[ARGSTRUCTFN]] : !emitc.opaque<"iree_vm_function_t"> to %[[ARGSTRUCTFN_MEMBER]] : !emitc.opaque<"iree_vm_function_t">
 
   // Allocate space for the arguments.
-  // CHECK-NEXT: %[[ARGBYTESPAN:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER_ADDRESS"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"arguments">]}
-  // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.ptr<!emitc.opaque<"iree_byte_span_t">>
-  // CHECK-NEXT: %[[ARGBYTESPANDATAVOID:.+]] = emitc.call_opaque "iree_alloca"(%[[ARGSIZE]])
-  // CHECK-SAME:     : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
+  // CHECK-NEXT: %[[ARGBYTESPAN_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "arguments"}> : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.opaque<"iree_byte_span_t">
+  // CHECK-NEXT: %[[ARGBYTESPAN:.+]] = emitc.apply "&"(%[[ARGBYTESPAN_MEMBER]]) : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<!emitc.opaque<"iree_byte_span_t">>
+  // CHECK-NEXT: %[[ARGBYTESPANDATAVOID:.+]] = emitc.call_opaque "iree_alloca"(%[[ARGSIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
   // CHECK-NEXT: %[[ARGBYTESPANDATA:.+]] = emitc.cast %[[ARGBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
-  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[ARGBYTESPAN]], %[[ARGSIZE]]) {args = [0 : index, #emitc.opaque<"data_length">, 1 : index]}
-  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[ARGBYTESPAN]], %[[ARGBYTESPANDATA]]) {args = [0 : index, #emitc.opaque<"data">, 1 : index]}
+  // CHECK-NEXT: %[[ARGSDATALENGTH:.+]] = "emitc.member_of_ptr"(%[[ARGBYTESPAN]]) <{member = "data_length"}> : (!emitc.ptr<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: emitc.assign %[[ARGSIZE]] : !emitc.opaque<"iree_host_size_t"> to %[[ARGSDATALENGTH]] : !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: %[[ARGSDATA:.+]] = "emitc.member_of_ptr"(%[[ARGBYTESPAN]]) <{member = "data"}> : (!emitc.ptr<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.ptr<ui8>
+  // CHECK-NEXT: emitc.assign %[[ARGBYTESPANDATA]] : !emitc.ptr<ui8> to %[[ARGSDATA]] : !emitc.ptr<ui8>
   // CHECK-NEXT: emitc.call_opaque "memset"(%[[ARGBYTESPANDATA]], %[[ARGSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
 
   // Allocate space for the result.
-  // CHECK-NEXT: %[[RESBYTESPAN:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER_ADDRESS"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"results">]}
-  // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.ptr<!emitc.opaque<"iree_byte_span_t">>
-  // CHECK-NEXT: %[[RESBYTESPANDATAVOID:.+]] = emitc.call_opaque "iree_alloca"(%[[RESULTSIZE]])
-  // CHECK-SAME:     : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
+  // CHECK-NEXT: %[[RESBYTESPAN_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "results"}> : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.opaque<"iree_byte_span_t">
+  // CHECK-NEXT: %[[RESBYTESPAN:.+]] = emitc.apply "&"(%[[RESBYTESPAN_MEMBER]]) : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<!emitc.opaque<"iree_byte_span_t">>
+  // CHECK-NEXT: %[[RESBYTESPANDATAVOID:.+]] = emitc.call_opaque "iree_alloca"(%[[RESULTSIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
   // CHECK-NEXT: %[[RESBYTESPANDATA:.+]] = emitc.cast %[[RESBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
-  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[RESBYTESPAN]], %[[RESULTSIZE]]) {args = [0 : index, #emitc.opaque<"data_length">, 1 : index]}
-  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[RESBYTESPAN]], %[[RESBYTESPANDATA]]) {args = [0 : index, #emitc.opaque<"data">, 1 : index]}
+  // CHECK-NEXT: %[[RESSDATALENGTH:.+]] = "emitc.member_of_ptr"(%[[RESBYTESPAN]]) <{member = "data_length"}> : (!emitc.ptr<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: emitc.assign %[[RESULTSIZE]] : !emitc.opaque<"iree_host_size_t"> to %[[RESSDATALENGTH]] : !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: %[[RESSDATA:.+]] = "emitc.member_of_ptr"(%[[RESBYTESPAN]]) <{member = "data"}> : (!emitc.ptr<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.ptr<ui8>
+  // CHECK-NEXT: emitc.assign %[[RESBYTESPANDATA]] : !emitc.ptr<ui8> to %[[RESSDATA]] : !emitc.ptr<ui8>
   // CHECK-NEXT: emitc.call_opaque "memset"(%[[RESBYTESPANDATA]], %[[RESULTSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
 
   // Pack the arguments into the struct.
   // Here we also create pointers for non-pointer types.
-  // CHECK-NEXT: %[[ARGS:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"arguments">]}
-  // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.opaque<"iree_byte_span_t">
-  // CHECK-NEXT: %[[ARGSPTR:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[ARGS]]) {args = [0 : index, #emitc.opaque<"data">]}
-  // CHECK-SAME:     : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<ui8>
+  // CHECK-NEXT: %[[ARGS:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.opaque<"iree_byte_span_t">
+  // CHECK-NEXT: %[[ARGS_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "arguments"}> : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.opaque<"iree_byte_span_t">
+  // CHECK-NEXT: emitc.assign %[[ARGS_MEMBER]] : !emitc.opaque<"iree_byte_span_t"> to %[[ARGS]] : !emitc.opaque<"iree_byte_span_t">
+  // CHECK-NEXT: %[[ARGSPTR:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.ptr<ui8>
+  // CHECK-NEXT: %[[ARGSPTR_MEMBER:.+]] = "emitc.member"(%[[ARGS]]) <{member = "data"}> : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<ui8>
+  // CHECK-NEXT: emitc.assign %[[ARGSPTR_MEMBER]] : !emitc.ptr<ui8> to %[[ARGSPTR]] : !emitc.ptr<ui8>
   // CHECK-NEXT: %[[ARGHOSTSIZE:.+]] = emitc.call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
   // CHECK-NEXT: %[[A1PTR:.+]] = emitc.apply "&"(%arg2) : (i32) -> !emitc.ptr<i32>
   // CHECK-NEXT: emitc.call_opaque "memcpy"(%[[ARGSPTR]], %[[A1PTR]], %[[ARGHOSTSIZE]])
@@ -595,16 +620,19 @@ vm.module @my_module {
   // CHECK-NEXT: emitc.call_opaque "memcpy"(%[[A1ADDR]], %[[A2PTR]], %[[A1SIZE]])
 
   // Create the call to the imported function.
-  // CHECK-NEXT: %[[IMPORTMOD:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg1) {args = [0 : index, #emitc.opaque<"module">]}
-  // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
-  // CHECK-NEXT: %{{.+}} = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_CALL"(%[[IMPORTMOD]], %arg0, %[[ARGSTRUCT]])
-  // CHECK-SAME:     {args = [0 : index, #emitc.opaque<"begin_call">, 0 : index, 1 : index, 2 : index]}
+  // CHECK-NEXT: %[[IMPORTMOD:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
+  // CHECK-NEXT: %[[MODULE_MEMBER:.+]] = "emitc.member_of_ptr"(%arg1) <{member = "module"}> : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
+  // CHECK-NEXT: emitc.assign %[[MODULE_MEMBER]] : !emitc.ptr<!emitc.opaque<"iree_vm_module_t">> to %[[IMPORTMOD]] : !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
+  // CHECK-NEXT: %[[BEGIN_CALL:.+]] = "emitc.member_of_ptr"(%[[IMPORTMOD]]) <{member = "begin_call"}> : (!emitc.ptr<!emitc.opaque<"iree_vm_module_t">>) -> !emitc.ptr<!emitc.opaque<"void">>
+  // CHECK-NEXT: %{{.+}} = emitc.call_opaque "EMITC_CALL_INDIRECT"(%[[BEGIN_CALL]], %[[IMPORTMOD]], %arg0, %[[ARGSTRUCT]])
 
   // Unpack the function results.
-  //      CHECK: %[[RES:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"results">]}
-  // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.opaque<"iree_byte_span_t">
-  // CHECK-NEXT: %[[RESPTR:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[RES]]) {args = [0 : index, #emitc.opaque<"data">]}
-  // CHECK-SAME:     : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<ui8>
+  //      CHECK: %[[RES:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.opaque<"iree_byte_span_t">
+  // CHECK-NEXT: %[[RES_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "results"}> : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.opaque<"iree_byte_span_t">
+  // CHECK-NEXT: emitc.assign %[[RES_MEMBER]] : !emitc.opaque<"iree_byte_span_t"> to %[[RES]] : !emitc.opaque<"iree_byte_span_t">
+  // CHECK-NEXT: %[[RESPTR:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.ptr<ui8>
+  // CHECK-NEXT: %[[RESPTR_MEMBER:.+]] = "emitc.member"(%[[RES]]) <{member = "data"}> : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<ui8>
+  // CHECK-NEXT: emitc.assign %[[RESPTR_MEMBER]] : !emitc.ptr<ui8> to %[[RESPTR]] : !emitc.ptr<ui8>
   // CHECK-NEXT: %[[RESHOSTSIZE:.+]] = emitc.call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
   // CHECK-NEXT: emitc.call_opaque "memcpy"(%arg4, %[[RESPTR]], %[[RESHOSTSIZE]])
 
@@ -643,45 +671,55 @@ vm.module @my_module {
   // Create a struct for the arguments and results.
   // CHECK: %[[ARGSTRUCT:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.opaque<"iree_vm_function_call_t">
   // CHECK-NEXT: %[[ARGSTRUCTFN:.+]] = emitc.apply "*"(%arg1) : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.opaque<"iree_vm_function_t">
-  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_MEMBER_ASSIGN"(%[[ARGSTRUCT]], %[[ARGSTRUCTFN]]) {args = [0 : index, #emitc.opaque<"function">, 1 : index]}
+  // CHECK-NEXT: %[[ARGSTRUCTFN_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "function"}> : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.opaque<"iree_vm_function_t">
+  // CHECK-NEXT: emitc.assign %[[ARGSTRUCTFN]] : !emitc.opaque<"iree_vm_function_t"> to %[[ARGSTRUCTFN_MEMBER]] : !emitc.opaque<"iree_vm_function_t">
 
   // Allocate space for the arguments.
-  // CHECK-NEXT: %[[ARGBYTESPAN:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER_ADDRESS"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"arguments">]}
-  // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.ptr<!emitc.opaque<"iree_byte_span_t">>
+  // CHECK-NEXT: %[[ARGBYTESPAN_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "arguments"}> : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.opaque<"iree_byte_span_t">
+  // CHECK-NEXT: %[[ARGBYTESPAN:.+]] = emitc.apply "&"(%[[ARGBYTESPAN_MEMBER]]) : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<!emitc.opaque<"iree_byte_span_t">>
   // CHECK-NEXT: %[[ARGBYTESPANDATAVOID:.+]] = emitc.call_opaque "iree_alloca"(%[[ARGSIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
   // CHECK-NEXT: %[[ARGBYTESPANDATA:.+]] = emitc.cast %[[ARGBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
-  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[ARGBYTESPAN]], %[[ARGSIZE]]) {args = [0 : index, #emitc.opaque<"data_length">, 1 : index]}
-  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[ARGBYTESPAN]], %[[ARGBYTESPANDATA]]) {args = [0 : index, #emitc.opaque<"data">, 1 : index]}
+  // CHECK-NEXT: %[[ARGSDATALENGTH:.+]] = "emitc.member_of_ptr"(%[[ARGBYTESPAN]]) <{member = "data_length"}> : (!emitc.ptr<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: emitc.assign %[[ARGSIZE]] : !emitc.opaque<"iree_host_size_t"> to %[[ARGSDATALENGTH]] : !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: %[[ARGSDATA:.+]] = "emitc.member_of_ptr"(%[[ARGBYTESPAN]]) <{member = "data"}> : (!emitc.ptr<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.ptr<ui8>
+  // CHECK-NEXT: emitc.assign %[[ARGBYTESPANDATA]] : !emitc.ptr<ui8> to %[[ARGSDATA]] : !emitc.ptr<ui8>
   // CHECK-NEXT: emitc.call_opaque "memset"(%[[ARGBYTESPANDATA]], %[[ARGSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
 
   // Allocate space for the result.
-  // CHECK-NEXT: %[[RESBYTESPAN:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER_ADDRESS"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"results">]}
-  // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.ptr<!emitc.opaque<"iree_byte_span_t">>
+  // CHECK-NEXT: %[[RESBYTESPAN_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "results"}> : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.opaque<"iree_byte_span_t">
+  // CHECK-NEXT: %[[RESBYTESPAN:.+]] = emitc.apply "&"(%[[RESBYTESPAN_MEMBER]]) : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<!emitc.opaque<"iree_byte_span_t">>
   // CHECK-NEXT: %[[RESBYTESPANDATAVOID:.+]] = emitc.call_opaque "iree_alloca"(%[[RESULTSIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
   // CHECK-NEXT: %[[RESBYTESPANDATA:.+]] = emitc.cast %[[RESBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
-  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[RESBYTESPAN]], %[[RESULTSIZE]]) {args = [0 : index, #emitc.opaque<"data_length">, 1 : index]}
-  // CHECK-NEXT: emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ASSIGN"(%[[RESBYTESPAN]], %[[RESBYTESPANDATA]]) {args = [0 : index, #emitc.opaque<"data">, 1 : index]}
+  // CHECK-NEXT: %[[RESSDATALENGTH:.+]] = "emitc.member_of_ptr"(%[[RESBYTESPAN]]) <{member = "data_length"}> : (!emitc.ptr<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: emitc.assign %[[RESULTSIZE]] : !emitc.opaque<"iree_host_size_t"> to %[[RESSDATALENGTH]] : !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: %[[RESSDATA:.+]] = "emitc.member_of_ptr"(%[[RESBYTESPAN]]) <{member = "data"}> : (!emitc.ptr<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.ptr<ui8>
+  // CHECK-NEXT: emitc.assign %[[RESBYTESPANDATA]] : !emitc.ptr<ui8> to %[[RESSDATA]] : !emitc.ptr<ui8>
   // CHECK-NEXT: emitc.call_opaque "memset"(%[[RESBYTESPANDATA]], %[[RESULTSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
 
   // Pack the argument into the struct.
-  // CHECK-NEXT: %[[ARGS:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"arguments">]}
-  // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.opaque<"iree_byte_span_t">
-  // CHECK-NEXT: %[[ARGSPTR:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[ARGS]]) {args = [0 : index, #emitc.opaque<"data">]}
-  // CHECK-SAME:     : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<ui8>
+  // CHECK-NEXT: %[[ARGS:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.opaque<"iree_byte_span_t">
+  // CHECK-NEXT: %[[ARGS_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "arguments"}> : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.opaque<"iree_byte_span_t">
+  // CHECK-NEXT: emitc.assign %[[ARGS_MEMBER]] : !emitc.opaque<"iree_byte_span_t"> to %[[ARGS]] : !emitc.opaque<"iree_byte_span_t">
+  // CHECK-NEXT: %[[ARGSPTR:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.ptr<ui8>
+  // CHECK-NEXT: %[[ARGSPTR_MEMBER:.+]] = "emitc.member"(%[[ARGS]]) <{member = "data"}> : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<ui8>
+  // CHECK-NEXT: emitc.assign %[[ARGSPTR_MEMBER]] : !emitc.ptr<ui8> to %[[ARGSPTR]] : !emitc.ptr<ui8>
   // CHECK-NEXT: %[[ARG:.+]] = emitc.cast %[[ARGSPTR]] : !emitc.ptr<ui8> to !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
   // CHECK-NEXT: emitc.call_opaque "iree_vm_ref_assign"(%arg2, %[[ARG]])
 
   // Create the call to the imported function.
-  // CHECK-NEXT: %[[IMPORTMOD:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg1) {args = [0 : index, #emitc.opaque<"module">]}
-  // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
-  // CHECK-NEXT: %{{.+}} = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_CALL"(%[[IMPORTMOD]], %arg0, %[[ARGSTRUCT]])
-  // CHECK-SAME:     {args = [0 : index, #emitc.opaque<"begin_call">, 0 : index, 1 : index, 2 : index]}
+  // CHECK-NEXT: %[[IMPORTMOD:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
+  // CHECK-NEXT: %[[MODULE_MEMBER:.+]] = "emitc.member_of_ptr"(%arg1) <{member = "module"}> : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
+  // CHECK-NEXT: emitc.assign %[[MODULE_MEMBER]] : !emitc.ptr<!emitc.opaque<"iree_vm_module_t">> to %[[IMPORTMOD]] : !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
+  // CHECK-NEXT: %[[BEGIN_CALL:.+]] = "emitc.member_of_ptr"(%[[IMPORTMOD]]) <{member = "begin_call"}> : (!emitc.ptr<!emitc.opaque<"iree_vm_module_t">>) -> !emitc.ptr<!emitc.opaque<"void">>
+  // CHECK-NEXT: %{{.+}} = emitc.call_opaque "EMITC_CALL_INDIRECT"(%[[BEGIN_CALL]], %[[IMPORTMOD]], %arg0, %[[ARGSTRUCT]])
 
   // Unpack the function results.
-  //      CHECK: %[[RES:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"results">]}
-  // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.opaque<"iree_byte_span_t">
-  // CHECK-NEXT: %[[RESPTR:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%[[RES]]) {args = [0 : index, #emitc.opaque<"data">]}
-  // CHECK-SAME:     : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<ui8>
+  //      CHECK: %[[RES:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.opaque<"iree_byte_span_t">
+  // CHECK-NEXT: %[[RES_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "results"}> : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.opaque<"iree_byte_span_t">
+  // CHECK-NEXT: emitc.assign %[[RES_MEMBER]] : !emitc.opaque<"iree_byte_span_t"> to %[[RES]] : !emitc.opaque<"iree_byte_span_t">
+  // CHECK-NEXT: %[[RESPTR:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.ptr<ui8>
+  // CHECK-NEXT: %[[RESPTR_MEMBER:.+]] = "emitc.member"(%[[RES]]) <{member = "data"}> : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<ui8>
+  // CHECK-NEXT: emitc.assign %[[RESPTR_MEMBER]] : !emitc.ptr<ui8> to %[[RESPTR]] : !emitc.ptr<ui8>
   // CHECK-NEXT: %[[RESREFPTR:.+]] = emitc.cast %[[RESPTR]] : !emitc.ptr<ui8> to !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
   // CHECK-NEXT: emitc.call_opaque "iree_vm_ref_move"(%[[RESREFPTR]], %arg3)
 
@@ -714,20 +752,23 @@ vm.module @my_module {
   // CHECK-NEXT: %[[MODSTATECASTED:.+]] = emitc.cast %arg5 : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<!emitc.opaque<"struct my_module_state_t">>
 
   // Cast argument and result structs.
-  // CHECK-NEXT: %[[ARGDATA:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"data">]}
-  // CHECK-SAME:     : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<ui8>
+  // CHECK-NEXT: %[[ARGDATA:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.ptr<ui8>
+  // CHECK-NEXT: %[[ARGDATA_MEMBER:.+]] = "emitc.member"(%arg2) <{member = "data"}> : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<ui8>
+  // CHECK-NEXT: emitc.assign %[[ARGDATA_MEMBER]] : !emitc.ptr<ui8> to %[[ARGDATA]] : !emitc.ptr<ui8>
   // CHECK-NEXT: %[[ARGS:.+]] = emitc.cast %[[ARGDATA]] : !emitc.ptr<ui8> to !emitc.ptr<!emitc.opaque<"struct my_module_fn_args_t">>
-  // CHECK-NEXT: %[[RESULTDATA:.+]] = emitc.call_opaque "EMITC_STRUCT_MEMBER"(%arg3) {args = [0 : index, #emitc.opaque<"data">]}
-  // CHECK-SAME:     : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<ui8>
+  // CHECK-NEXT: %[[RESULTDATA:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.ptr<ui8>
+  // CHECK-NEXT: %[[RESULTDATA_MEMBER:.+]] = "emitc.member"(%arg3) <{member = "data"}> : (!emitc.opaque<"iree_byte_span_t">) -> !emitc.ptr<ui8>
+  // CHECK-NEXT: emitc.assign %[[RESULTDATA_MEMBER]] : !emitc.ptr<ui8> to %[[RESULTDATA]] : !emitc.ptr<ui8>
   // CHECK-NEXT: %[[RESULTS:.+]] = emitc.cast %[[RESULTDATA]] : !emitc.ptr<ui8> to !emitc.ptr<!emitc.opaque<"struct my_module_fn_result_t">>
 
   // Unpack the argument from the struct.
-  // CHECK-NEXT: %[[MARG:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%[[ARGS]]) {args = [0 : index, #emitc.opaque<"arg0">]}
-  // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"struct my_module_fn_args_t">>) -> i32
+  // CHECK-NEXT: %[[MARG:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> i32
+  // CHECK-NEXT: %[[MARG_MEMBER:.+]] = "emitc.member_of_ptr"(%[[ARGS]]) <{member = "arg0"}> : (!emitc.ptr<!emitc.opaque<"struct my_module_fn_args_t">>) -> i32
+  // CHECK-NEXT: emitc.assign %[[MARG_MEMBER]] : i32 to %[[MARG]] : i32
 
   // Unpack the result pointer from the struct.
-  // CHECK-NEXT: %[[MRES:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER_ADDRESS"(%[[RESULTS]]) {args = [0 : index, #emitc.opaque<"res0">]}
-  // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"struct my_module_fn_result_t">>) -> !emitc.ptr<i32>
+  // CHECK-NEXT: %[[MRES_MEMBER:.+]] = "emitc.member_of_ptr"(%[[RESULTS]]) <{member = "res0"}> : (!emitc.ptr<!emitc.opaque<"struct my_module_fn_result_t">>) -> i32
+  // CHECK-NEXT: %[[MRES:.+]] = emitc.apply "&"(%[[MRES_MEMBER]]) : (i32) -> !emitc.ptr<i32>
 
   // Call the internal function.
   // CHECK-NEXT: %{{.+}} = emitc.call @my_module_fn(%arg0, %[[MODULECASTED]], %[[MODSTATECASTED]], %[[MARG]], %[[MRES]])
@@ -778,9 +819,13 @@ vm.module @my_module {
   vm.import private optional @optional_import_fn(%arg0 : i32) -> i32
   // CHECK-LABEL: emitc.func private @my_module_call_fn
   vm.func @call_fn() -> i32 {
-    // CHECK-NEXT: %[[IMPORTS:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"imports">]} : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
-    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.call_opaque "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[IMPORTS]]) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
-    // CHECK-NEXT: %[[MODULE:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%[[IMPORT]]) {args = [0 : index, #emitc.opaque<"module">]} : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
+    // CHECK-NEXT: %[[IMPORTS_VAR:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[IMPORTS:.+]] = "emitc.member_of_ptr"(%arg2) <{member = "imports"}> : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: emitc.assign %[[IMPORTS]] : !emitc.ptr<!emitc.opaque<"iree_vm_function_t">> to %[[IMPORTS_VAR]] : !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.call_opaque "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[IMPORTS_VAR]]) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[MODULE:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
+    // CHECK-NEXT: %[[MODULE_MEMBER:.+]] = "emitc.member_of_ptr"(%[[IMPORT]]) <{member = "module"}> : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
+    // CHECK-NEXT: emitc.assign %[[MODULE_MEMBER]] : !emitc.ptr<!emitc.opaque<"iree_vm_module_t">> to %[[MODULE]] : !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
     // CHECK-NEXT: %[[CONDITION0:.+]] = emitc.logical_not %[[MODULE]] : !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
     // CHECK-NEXT: %[[CONDITION1:.+]] = emitc.logical_not %[[CONDITION0]] : i1
     // CHECK-NEXT: %[[RESULT:.+]] = emitc.cast %[[CONDITION1]] : i1 to i32

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/global_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/global_ops.mlir
@@ -5,8 +5,10 @@ vm.module @my_module {
 
   // CHECK-LABEL: emitc.func private @my_module_global_load_i32
   vm.func @global_load_i32() -> i32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"rwdata">]} : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.ptr<ui8>
-    // CHECK-NEXT: %1 = emitc.call_opaque "vm_global_load_i32"(%0) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<ui8>) -> i32
+    // CHECK-NEXT: %[[RWDATA_VAR:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.ptr<ui8>
+    // CHECK-NEXT: %[[RWDATA:.+]] = "emitc.member_of_ptr"(%arg2) <{member = "rwdata"}> : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.ptr<ui8>
+    // CHECK-NEXT: emitc.assign %[[RWDATA]] : !emitc.ptr<ui8> to %[[RWDATA_VAR]] : !emitc.ptr<ui8>
+    // CHECK-NEXT: %[[RES:.+]] = emitc.call_opaque "vm_global_load_i32"(%[[RWDATA_VAR]]) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<ui8>) -> i32
     %0 = vm.global.load.i32 @c42 : i32
     vm.return %0 : i32
   }
@@ -19,8 +21,10 @@ vm.module @my_module {
 
   // CHECK-LABEL: emitc.func private @my_module_global_store_i32
   vm.func @global_store_i32(%arg0 : i32) {
-    // CHECK-NEXT: %0 = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"rwdata">]} : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.ptr<ui8>
-    // CHECK-NEXT: emitc.call_opaque "vm_global_store_i32"(%0, %arg3) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.ptr<ui8>, i32) -> ()
+    // CHECK-NEXT: %[[RWDATA_VAR:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.ptr<ui8>
+    // CHECK-NEXT: %[[RWDATA:.+]] = "emitc.member_of_ptr"(%arg2) <{member = "rwdata"}> : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.ptr<ui8>
+    // CHECK-NEXT: emitc.assign %[[RWDATA]] : !emitc.ptr<ui8> to %[[RWDATA_VAR]] : !emitc.ptr<ui8>
+    // CHECK-NEXT: emitc.call_opaque "vm_global_store_i32"(%[[RWDATA_VAR]], %arg3) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.ptr<ui8>, i32) -> ()
     vm.global.store.i32 %arg0, @c107_mut : i32
     vm.return
   }
@@ -33,10 +37,12 @@ vm.module @my_module {
 
   // CHECK-LABEL: emitc.func private @my_module_global_load_ref
   vm.func @global_load_ref() -> !vm.buffer {
-    // CHECK: %[[A:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"refs">]} : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
-    // CHECK: %[[B:.+]] = emitc.call_opaque "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[A]]) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
+    // CHECK: %[[REFS_VAR:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
+    // CHECK-NEXT: %[[REFS:.+]] = "emitc.member_of_ptr"(%arg2) <{member = "refs"}> : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
+    // CHECK-NEXT: emitc.assign %[[REFS]] : !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">> to %[[REFS_VAR]] : !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
+    // CHECK: %[[REF_0:.+]] = emitc.call_opaque "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[REFS_VAR]]) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
     // CHECK: %[[C:.+]] = emitc.call_opaque "iree_vm_type_def_as_ref"(%{{.+}}) : (!emitc.opaque<"iree_vm_type_def_t">) -> !emitc.opaque<"iree_vm_ref_type_t">
-    // CHECK: %{{.+}} = emitc.call_opaque "iree_vm_ref_retain_or_move_checked"(%[[B]], %[[C]], %arg3) {args = [false, 0 : index, 1 : index, 2 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.opaque<"iree_vm_ref_type_t">, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %{{.+}} = emitc.call_opaque "iree_vm_ref_retain_or_move_checked"(%[[REF_0]], %[[C]], %arg3) {args = [false, 0 : index, 1 : index, 2 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.opaque<"iree_vm_ref_type_t">, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
     %0 = vm.global.load.ref @g0 : !vm.buffer
     vm.return %0 : !vm.buffer
   }
@@ -49,10 +55,12 @@ vm.module @my_module {
 
   // CHECK-LABEL: emitc.func private @my_module_global_store_ref
   vm.func @global_store_ref(%arg0 : !vm.buffer) {
-    // CHECK: %[[A:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"refs">]} : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
-    // CHECK: %[[B:.+]] = emitc.call_opaque "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[A]]) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
+    // CHECK: %[[REFS_VAR:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
+    // CHECK-NEXT: %[[REFS:.+]] = "emitc.member_of_ptr"(%arg2) <{member = "refs"}> : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
+    // CHECK-NEXT: emitc.assign %[[REFS]] : !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">> to %[[REFS_VAR]] : !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
+    // CHECK: %[[REF_0:.+]] = emitc.call_opaque "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[REFS_VAR]]) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
     // CHECK: %[[C:.+]] = emitc.call_opaque "iree_vm_type_def_as_ref"(%{{.+}}) : (!emitc.opaque<"iree_vm_type_def_t">) -> !emitc.opaque<"iree_vm_ref_type_t">
-    // CHECK: %{{.+}} = emitc.call_opaque "iree_vm_ref_retain_or_move_checked"(%arg3, %[[C]], %[[B]]) {args = [false, 0 : index, 1 : index, 2 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.opaque<"iree_vm_ref_type_t">, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %{{.+}} = emitc.call_opaque "iree_vm_ref_retain_or_move_checked"(%arg3, %[[C]], %[[REF_0]]) {args = [false, 0 : index, 1 : index, 2 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.opaque<"iree_vm_ref_type_t">, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
     vm.global.store.ref %arg0, @g0_mut : !vm.buffer
     vm.return
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/global_ops_f32.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/global_ops_f32.mlir
@@ -5,8 +5,10 @@ vm.module @my_module {
 
   // CHECK-LABEL: emitc.func private @my_module_global_load_f32
   vm.func @global_load_f32() -> f32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"rwdata">]} : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.ptr<ui8>
-    // CHECK-NEXT: %1 = emitc.call_opaque "vm_global_load_f32"(%0) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<ui8>) -> f32
+    // CHECK-NEXT: %[[RWDATA_VAR:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.ptr<ui8>
+    // CHECK-NEXT: %[[RWDATA:.+]] = "emitc.member_of_ptr"(%arg2) <{member = "rwdata"}> : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.ptr<ui8>
+    // CHECK-NEXT: emitc.assign %[[RWDATA]] : !emitc.ptr<ui8> to %[[RWDATA_VAR]] : !emitc.ptr<ui8>
+    // CHECK-NEXT: %[[RES:.+]] = emitc.call_opaque "vm_global_load_f32"(%[[RWDATA_VAR]]) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<ui8>) -> f32
     %0 = vm.global.load.f32 @c42 : f32
     vm.return %0 : f32
   }
@@ -19,8 +21,10 @@ vm.module @my_module {
 
   // CHECK-LABEL: emitc.func private @my_module_global_store_f32
   vm.func @global_store_f32(%arg0 : f32) {
-    // CHECK-NEXT: %0 = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"rwdata">]} : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.ptr<ui8>
-    // CHECK-NEXT: emitc.call_opaque "vm_global_store_f32"(%0, %arg3) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.ptr<ui8>, f32) -> ()
+    // CHECK-NEXT: %[[RWDATA_VAR:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.ptr<ui8>
+    // CHECK-NEXT: %[[RWDATA:.+]] = "emitc.member_of_ptr"(%arg2) <{member = "rwdata"}> : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.ptr<ui8>
+    // CHECK-NEXT: emitc.assign %[[RWDATA]] : !emitc.ptr<ui8> to %[[RWDATA_VAR]] : !emitc.ptr<ui8>
+    // CHECK-NEXT: emitc.call_opaque "vm_global_store_f32"(%[[RWDATA_VAR]], %arg3) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.ptr<ui8>, f32) -> ()
     vm.global.store.f32 %arg0, @c107_mut : f32
     vm.return
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/global_ops_i64.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/global_ops_i64.mlir
@@ -5,8 +5,10 @@ vm.module @my_module {
 
   // CHECK-LABEL: emitc.func private @my_module_global_load_i64
   vm.func @global_load_i64() -> i64 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"rwdata">]} : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.ptr<ui8>
-    // CHECK-NEXT: %1 = emitc.call_opaque "vm_global_load_i64"(%0) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<ui8>) -> i64
+    // CHECK-NEXT: %[[RWDATA_VAR:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.ptr<ui8>
+    // CHECK-NEXT: %[[RWDATA:.+]] = "emitc.member_of_ptr"(%arg2) <{member = "rwdata"}> : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.ptr<ui8>
+    // CHECK-NEXT: emitc.assign %[[RWDATA]] : !emitc.ptr<ui8> to %[[RWDATA_VAR]] : !emitc.ptr<ui8>
+    // CHECK-NEXT: %[[RES:.+]] = emitc.call_opaque "vm_global_load_i64"(%[[RWDATA_VAR]]) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<ui8>) -> i64
     %0 = vm.global.load.i64 @c42 : i64
     vm.return %0 : i64
   }
@@ -19,8 +21,10 @@ vm.module @my_module {
 
   // CHECK-LABEL: emitc.func private @my_module_global_store_i64
   vm.func @global_store_i64(%arg0 : i64) {
-    // CHECK-NEXT: %0 = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"rwdata">]} : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.ptr<ui8>
-    // CHECK-NEXT: emitc.call_opaque "vm_global_store_i64"(%0, %arg3) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.ptr<ui8>, i64) -> ()
+    // CHECK-NEXT: %[[RWDATA_VAR:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.ptr<ui8>
+    // CHECK-NEXT: %[[RWDATA:.+]] = "emitc.member_of_ptr"(%arg2) <{member = "rwdata"}> : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.ptr<ui8>
+    // CHECK-NEXT: emitc.assign %[[RWDATA]] : !emitc.ptr<ui8> to %[[RWDATA_VAR]] : !emitc.ptr<ui8>
+    // CHECK-NEXT: emitc.call_opaque "vm_global_store_i64"(%[[RWDATA_VAR]], %arg3) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.ptr<ui8>, i64) -> ()
     vm.global.store.i64 %arg0, @c107_mut : i64
     vm.return
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/list_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/list_ops.mlir
@@ -5,10 +5,12 @@ vm.module @my_module {
   vm.func @list_alloc(%arg0: i32) -> !vm.list<i32> {
     // CHECK: %[[LIST:.+]] = "emitc.variable"() <{value = #emitc.opaque<"NULL">}> : () -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
     // CHECK: %[[LIST_PTR:.+]] = emitc.apply "&"(%3) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>) -> !emitc.ptr<!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>>
-    // CHECK: %[[ALLOCATOR:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg2) {args = [0 : index, #emitc.opaque<"allocator">]} : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.opaque<"iree_allocator_t">
+    // CHECK: %[[ALLOCATOR_VAR:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.opaque<"iree_allocator_t">
+    // CHECK-NEXT: %[[ALLOCATOR:.+]] = "emitc.member_of_ptr"(%arg2) <{member = "allocator"}> : (!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>) -> !emitc.opaque<"iree_allocator_t">
+    // CHECK-NEXT: emitc.assign %[[ALLOCATOR]] : !emitc.opaque<"iree_allocator_t"> to %[[ALLOCATOR_VAR]] : !emitc.opaque<"iree_allocator_t">
 
     // CHECK: %[[TYPE_DEF:.+]] = emitc.call_opaque "iree_vm_make_value_type_def"() {args = [#emitc.opaque<"IREE_VM_VALUE_TYPE_I32">]} : () -> !emitc.opaque<"iree_vm_type_def_t">
-    // CHECK-NEXT: %[[STATUS:.+]] = emitc.call_opaque "iree_vm_list_create"(%[[TYPE_DEF]], %arg3, %[[ALLOCATOR]], %[[LIST_PTR]]) : (!emitc.opaque<"iree_vm_type_def_t">, i32, !emitc.opaque<"iree_allocator_t">, !emitc.ptr<!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>>) -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %[[STATUS:.+]] = emitc.call_opaque "iree_vm_list_create"(%[[TYPE_DEF]], %arg3, %[[ALLOCATOR_VAR]], %[[LIST_PTR]]) : (!emitc.opaque<"iree_vm_type_def_t">, i32, !emitc.opaque<"iree_allocator_t">, !emitc.ptr<!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>>) -> !emitc.opaque<"iree_status_t">
 
     // CHECK: %[[LIST_TYPE_ID:.+]] = emitc.call_opaque "iree_vm_list_type"() : () -> !emitc.opaque<"iree_vm_ref_type_t">
     // CHECK-NEXT:  %[[STATUS2:.+]] = emitc.call_opaque "iree_vm_ref_wrap_assign"(%[[LIST]], %[[LIST_TYPE_ID]], %arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, !emitc.opaque<"iree_vm_ref_type_t">, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
@@ -80,12 +82,14 @@ vm.module @my_module {
     // CHECK-NEXT: %0 = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
     // CHECK-NEXT: %1 = emitc.call_opaque "iree_vm_list_deref"(%0) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
     // CHECK: %{{.+}} = emitc.call_opaque "iree_vm_list_get_ref_retain"(%1, %arg4, %arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
-    // CHECK: %[[A:.+]] = emitc.call_opaque "EMITC_STRUCT_PTR_MEMBER"(%arg3) {args = [0 : index, #emitc.opaque<"type">]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_type_t">
+    // CHECK: %[[TYPE_VAR:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.opaque<"iree_vm_ref_type_t">
+    // CHECK-NEXT: %[[TYPE:.+]] = "emitc.member_of_ptr"(%arg3) <{member = "type"}> : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_type_t">
+    // CHECK-NEXT: emitc.assign %[[TYPE]] : !emitc.opaque<"iree_vm_ref_type_t"> to %[[TYPE_VAR]] : !emitc.opaque<"iree_vm_ref_type_t">
     // CHECK: %[[B:.+]] = "emitc.constant"() <{value = #emitc.opaque<"IREE_VM_REF_TYPE_NULL">}> : () -> !emitc.opaque<"iree_vm_ref_type_t">
-    // CHECK: %[[C:.+]] = emitc.cmp ne, %[[A]], %[[B]] : (!emitc.opaque<"iree_vm_ref_type_t">, !emitc.opaque<"iree_vm_ref_type_t">) -> i1
+    // CHECK: %[[C:.+]] = emitc.cmp ne, %[[TYPE_VAR]], %[[B]] : (!emitc.opaque<"iree_vm_ref_type_t">, !emitc.opaque<"iree_vm_ref_type_t">) -> i1
     // CHECK: %[[D:.+]] = emitc.call_opaque "iree_vm_type_def_is_value"(%{{.+}}) : (!emitc.opaque<"iree_vm_type_def_t">) -> i1
     // CHECK: %[[E:.+]] = emitc.call_opaque "iree_vm_type_def_as_ref"(%{{.+}}) : (!emitc.opaque<"iree_vm_type_def_t">) -> !emitc.opaque<"iree_vm_ref_type_t">
-    // CHECK: %[[F:.+]] = emitc.cmp ne, %[[A]], %[[E]] : (!emitc.opaque<"iree_vm_ref_type_t">, !emitc.opaque<"iree_vm_ref_type_t">) -> i1
+    // CHECK: %[[F:.+]] = emitc.cmp ne, %[[TYPE_VAR]], %[[E]] : (!emitc.opaque<"iree_vm_ref_type_t">, !emitc.opaque<"iree_vm_ref_type_t">) -> i1
     // CHECK: %[[G:.+]] = emitc.logical_or %[[D]], %[[F]] : i1, i1
     // CHECK: %{{.+}} = emitc.logical_and %[[C]], %[[G]] : i1, i1
     // CHECK: cf.cond_br %{{.+}}, ^[[FAIL:.+]], ^[[CONTINUE:.+]]

--- a/compiler/src/iree/compiler/Dialect/VM/Target/C/test/constant_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/C/test/constant_ops.mlir
@@ -29,7 +29,8 @@ vm.module @rodata_ops {
   // CHECK-NEXT: [[SIZE_1:[^ ]*]] = sizeof(rodata_ops_buffer_1);
   // CHECK-NEXT: [[BYTE_SPAN_1:[^ ]*]] = iree_make_byte_span([[VOID_PTR_1]], [[SIZE_1]]);
   // CHECK-NEXT: [[ALLOCATOR_1:[^ ]*]] = iree_allocator_null();
-  // CHECK-NEXT: [[BUFFERS_1:[^ ]*]] = EMITC_STRUCT_PTR_MEMBER([[STATE]], rodata_buffers);
+  // CHECK-NEXT: ;
+  // CHECK-NEXT: [[BUFFERS_1:[^ ]*]] = [[STATE]]->rodata_buffers;
   // CHECK-NEXT: [[BUFFER_1:[^ ]*]] = EMITC_ARRAY_ELEMENT_ADDRESS([[BUFFERS_1]], 0);
   // CHECK-NEXT: iree_vm_buffer_initialize(IREE_VM_BUFFER_ACCESS_ORIGIN_MODULE, [[BYTE_SPAN_1]], [[ALLOCATOR_1]], [[BUFFER_1]]);
 
@@ -38,7 +39,8 @@ vm.module @rodata_ops {
   // CHECK-NEXT: [[SIZE_2:[^ ]*]] = sizeof(rodata_ops_buffer_2);
   // CHECK-NEXT: [[BYTE_SPAN_2:[^ ]*]] = iree_make_byte_span([[VOID_PTR_2]], [[SIZE_2]]);
   // CHECK-NEXT: [[ALLOCATOR_2:[^ ]*]] = iree_allocator_null();
-  // CHECK-NEXT: [[BUFFERS_2:[^ ]*]] = EMITC_STRUCT_PTR_MEMBER([[STATE]], rodata_buffers);
+  // CHECK-NEXT: ;
+  // CHECK-NEXT: [[BUFFERS_2:[^ ]*]] = [[STATE]]->rodata_buffers;
   // CHECK-NEXT: [[BUFFER_2:[^ ]*]] = EMITC_ARRAY_ELEMENT_ADDRESS([[BUFFERS_2]], 1);
   // CHECK-NEXT: iree_vm_buffer_initialize(IREE_VM_BUFFER_ACCESS_ORIGIN_MODULE, [[BYTE_SPAN_2]], [[ALLOCATOR_2]], [[BUFFER_2]]);
 }

--- a/compiler/src/iree/compiler/Dialect/VM/Target/C/test/global_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/C/test/global_ops.mlir
@@ -19,7 +19,8 @@ vm.module @global_ops {
     // CHECK-NEXT: uint8_t* v5;
     // CHECK-NEXT: int32_t v6;
     // CHECK-NEXT: iree_status_t v7;
-    // CHECK-NEXT: v5 = EMITC_STRUCT_PTR_MEMBER(v3, rwdata);
+    // CHECK-NEXT: ;
+    // CHECK-NEXT: v5 = v3->rwdata;
     // CHECK-NEXT: v6 = vm_global_load_i32(v5, 0);
     %value = vm.global.load.i32 @c42 : i32
     vm.return %value : i32
@@ -35,10 +36,12 @@ vm.module @global_ops {
     // CHECK-NEXT: iree_status_t v9;
     // CHECK-NEXT: v5 = 17;
     %c17 = vm.const.i32 17
-    // CHECK-NEXT: v6 = EMITC_STRUCT_PTR_MEMBER(v3, rwdata);
+    // CHECK-NEXT: ;
+    // CHECK-NEXT: v6 = v3->rwdata;
     // CHECK-NEXT: vm_global_store_i32(v6, 4, v5);
     vm.global.store.i32 %c17, @c107_mut : i32
-    // CHECK-NEXT: v7 = EMITC_STRUCT_PTR_MEMBER(v3, rwdata);
+    // CHECK-NEXT: ;
+    // CHECK-NEXT: v7 = v3->rwdata;
     // CHECK-NEXT: v8 = vm_global_load_i32(v7, 4);
     %value = vm.global.load.i32 @c107_mut : i32
     vm.return %value : i32

--- a/runtime/src/iree/vm/ops_emitc.h
+++ b/runtime/src/iree/vm/ops_emitc.h
@@ -16,29 +16,8 @@
 // Assign a value pointed to by `ptr` through a pointer variable
 #define EMITC_DEREF_ASSIGN_PTR(ptr, value) *(ptr) = *(value)
 
-// Access a member of a struct
-#define EMITC_STRUCT_MEMBER(struct, member) (struct).member
-
-// Access the address of a member of a struct
-#define EMITC_STRUCT_MEMBER_ADDRESS(struct, member) &(struct).member
-
-// Assign a value to a member of a struct
-#define EMITC_STRUCT_MEMBER_ASSIGN(struct, member, value) \
-  (struct).member = (value)
-
-// Access a member of a pointer to a struct
-#define EMITC_STRUCT_PTR_MEMBER(struct, member) (struct)->member
-
-// Call a function pointer of a pointer to a struct with the given arguments
-#define EMITC_STRUCT_PTR_MEMBER_CALL(struct, member, ...) \
-  (struct)->member(__VA_ARGS__)
-
-// Access the address of a member of a pointer to a struct
-#define EMITC_STRUCT_PTR_MEMBER_ADDRESS(struct, member) &(struct)->member
-
-// Assign a value to a member of a pointer to a struct
-#define EMITC_STRUCT_PTR_MEMBER_ASSIGN(struct, member, value) \
-  (struct)->member = (value)
+// Call a function pointer with the given arguments
+#define EMITC_CALL_INDIRECT(func, ...) (func)(__VA_ARGS__)
 
 // Get an array element
 #define EMITC_ARRAY_ELEMENT(array, index) (array)[index]


### PR DESCRIPTION
This removes struct related helper macros by using the member operations of the EmitC dialect which were added in https://github.com/llvm/llvm-project/pull/98460.