### PR TITLE
Use ccache in runtime builds.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,78 +172,52 @@ jobs:
         include:
           - name: ubuntu-20.04
             runs-on: ubuntu-20.04
-            container: gcr.io/iree-oss/base@sha256:dc314b4fe30fc1315742512891357bffed4d1b62ffcb46258b1e0761c737b446
           - name: windows-2022
             runs-on: windows-2022
-            # No container, (unnecessary, and Windows https://github.com/actions/runner/issues/904).
           - name: macos-14
             runs-on: macos-14
-            # No container, just install what we need directly.
-          # Disabled while we are short on arm64 runners. Could also make this opt-in, but the matrix complicates that.
-          # - name: arm64
-          #   runs-on:
-          #     - self-hosted # must come first
-          #     - runner-group=${{ needs.setup.outputs.runner-group }}
-          #     - environment=${{ needs.setup.outputs.runner-env }}
-          #     - arm64
-          #     - os-family=Linux
-          #   container: gcr.io/iree-oss/base-arm64@sha256:9daa1cdbbf12da8527319ece76a64d06219e04ecb99a4cff6e6364235ddf6c59
     env:
       BUILD_DIR: build-runtime
       BUILD_PRESET: test
-      CONTAINER: ${{ matrix.container }}
+      IREE_READ_REMOTE_CCACHE: 0
+      IREE_WRITE_REMOTE_CCACHE: 0
+      IREE_READ_LOCAL_CCACHE: 1
+      IREE_WRITE_LOCAL_CCACHE: ${{ needs.setup.outputs.write-caches }}
     steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4.1.7
+      - uses: actions/setup-python@v5.1.0
+        with:
+          python-version: "3.11"
 
-      - name: "(Windows) Configuring MSVC"
+      - name: (Linux) Install requirements
+        if: contains(matrix.name, 'ubuntu')
+        run: |
+          sudo apt update
+          sudo apt install -y ninja-build
+          echo "CC=clang" >> $GITHUB_ENV
+          echo "CXX=clang++" >> $GITHUB_ENV
+      - name: (Windows) Configure MSVC
         if: contains(matrix.name, 'windows')
         uses: ilammy/msvc-dev-cmd@v1.13.0
-
-      - name: "(macOS) Installing requirements"
+      - name: (macOS) Install requirements
         if: contains(matrix.name, 'macos')
         run: brew install ninja ccache coreutils bash
 
-      - name: "Checking out runtime submodules"
+      - name: Checkout runtime submodules
         run: bash ./build_tools/scripts/git/update_runtime_submodules.sh
 
-      # Windows/macOS (no Docker): install requirements -> build -> test.
-      #
-      # Note: Python is a mess across operating systems and GitHub runners so...
-      #   * On Windows just install at the system level
-      #   * On macOS install in a venv
-      - name: "(Windows) Installing Python requirements"
-        if: contains(matrix.name, 'windows')
-        run: pip install -r ./runtime/bindings/python/iree/runtime/build_requirements.txt
-      - name: "(Windows) Building runtime"
-        if: contains(matrix.name, 'windows')
-        run: bash ./build_tools/cmake/build_runtime.sh "${BUILD_DIR}"
-      - name: "(macOS) Building runtime"
-        if: contains(matrix.name, 'macos')
-        env:
-          IREE_BUILD_SETUP_PYTHON_VENV: build-runtime/.venv
-        run: bash ./build_tools/cmake/build_runtime.sh "${BUILD_DIR}"
-      - name: "Testing runtime"
-        if: contains(matrix.name, 'windows') || contains(matrix.name, 'macos')
-        run: bash ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.job }}-${{ matrix.name }}
+          save: ${{ needs.setup.outputs.write-caches == 1 }}
 
-      # With a Docker container: build under Docker -> test under Docker.
-      - name: "(Docker) Building runtime"
-        if: ${{ env.CONTAINER != '' }}
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-            --env "BUILD_PRESET=test" \
-            --env "IREE_BUILD_SETUP_PYTHON_VENV=${BUILD_DIR}/.venv" \
-            ${CONTAINER} \
-            ./build_tools/cmake/build_runtime.sh \
-            "${BUILD_DIR}"
-      - name: "(Docker) Testing runtime"
-        if: ${{ env.CONTAINER != '' }}
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-            ${CONTAINER} \
-            ./build_tools/cmake/ctest_all.sh \
-            "${BUILD_DIR}"
+      - name: Install Python requirements
+        run: pip install -r ./runtime/bindings/python/iree/runtime/build_requirements.txt
+      - name: Build runtime
+        run: bash ./build_tools/cmake/build_runtime.sh "${BUILD_DIR}"
+      - name: Test runtime
+        run: bash ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
 
   small_runtime:
     needs: setup

--- a/build_tools/cmake/build_runtime.sh
+++ b/build_tools/cmake/build_runtime.sh
@@ -21,7 +21,7 @@ CMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-RelWithDebInfo}"
 IREE_BUILD_PYTHON_BINDINGS="${IREE_BUILD_PYTHON_BINDINGS:-ON}"
 
 source build_tools/cmake/setup_build.sh
-# Note: not using ccache since the runtime build should be fast already.
+source build_tools/cmake/setup_ccache.sh
 
 declare -a args
 args=(
@@ -31,8 +31,8 @@ args=(
   "-DIREE_BUILD_COMPILER=OFF"
   "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
 
-  "-DIREE_RUNTIME_OPTIMIZATION_PROFILE=lto"
-  "-DIREE_FORCE_LTO_COMPAT_BINUTILS_ON_LINUX=ON"
+  # Use `lld` for faster linking.
+  "-DIREE_ENABLE_LLD=ON"
 
   "-DIREE_BUILD_PYTHON_BINDINGS=${IREE_BUILD_PYTHON_BINDINGS}"
   "-DPython3_EXECUTABLE=${IREE_PYTHON3_EXECUTABLE}"
@@ -81,3 +81,7 @@ case "${BUILD_PRESET}" in
     exit 1
     ;;
 esac
+
+if (( IREE_USE_CCACHE == 1 )); then
+  ccache --show-stats
+fi


### PR DESCRIPTION
This uses https://github.com/hendrikmuhs/ccache-action to set up https://ccache.dev/ together with https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows to create cache entries at https://github.com/iree-org/iree/actions/caches and then pull them down at the start of each build job.

* Right now the cache keys are just `${{ github.job }}-${{ matrix.name }}`, which will create entries named like `ccache-build_test_runtime-ubuntu-20.04-2024-08-01T22:19:46.787Z`.
  * We can turn off the timestamps with `append-timestamp: false` if we find that our 10GB cache limit gets overrun enough to have workflows get cache misses (PkgCI already produces 800MB cache entries, so we're always floating way over that limit and old entries continually get evicted).
  * We could do something more sophisticated like put the LLVM commit hash in the cache entry name, but that shouldn't matter for runtime builds 🤞
* The Windows build in particular has large binaries (mainly HAL CTS tests). Reducing the size there will speed up link time during building and hopefully also trim the cache size.
* I'm matching the `write-caches` logic we have in other workflows for now, which should maintain cache integrity (only reviewed + merged code writes to the cache) while also limiting the number of entries we generate.

## Sample job run

https://github.com/ScottTodd/iree/actions/runs/10206588680/job/28239799198

* Load from cache:
  ![image](https://github.com/user-attachments/assets/62fca6d6-c45a-4efd-8628-558096dcf643)

* Save to cache:
  ![image](https://github.com/user-attachments/assets/bfac1b30-2c3c-40a4-89b1-05b334a5d4f9)

* View cache files (https://github.com/ScottTodd/iree/actions/caches?query=key%3Accache):
  ![image](https://github.com/user-attachments/assets/a51bc82b-6778-41fc-9d5d-76df0beace39)

---

Also
* dropped support for using Docker containers in the build/test runtime jobs - just install and configure clang etc. as needed
* enabled LLD for linking

ci-exactly: build_test_runtime