### PR TITLE
Creating reusable command buffers in stream->hal lowering.

### DIFF
--- a/compiler/plugins/target/VulkanSPIRV/VulkanSPIRVTarget.cpp
+++ b/compiler/plugins/target/VulkanSPIRV/VulkanSPIRVTarget.cpp
@@ -103,10 +103,6 @@ public:
       configItems.emplace_back(b.getStringAttr(name), value);
     };
 
-    if (indirectBindings) {
-      addConfig("hal.bindings.indirect", b.getUnitAttr());
-    }
-
     // We only care about the architecture right now.
     StringRef arch = StringRef(options_.targetTriple).split("-").first;
     if (auto target = GPU::getVulkanTargetDetails(arch, context)) {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVMapMemRefStorageClass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVMapMemRefStorageClass.cpp
@@ -99,10 +99,7 @@ struct SPIRVMapMemRefStorageClassPass final
     MLIRContext *context = &getContext();
     Operation *op = getOperation();
 
-    bool useIndirectBindings = false;
-    if (UnitAttr indirectBindingsAttr = getIndirectBindingsAttr(op)) {
-      useIndirectBindings = true;
-    };
+    bool useIndirectBindings = usesIndirectBindingsAttr(op);
 
     spirv::MemorySpaceToStorageClassMap memorySpaceMap;
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Utils.cpp
@@ -41,12 +41,10 @@ DictionaryAttr getTargetConfigAttr(Operation *op) {
   return targetAttr.getConfiguration();
 }
 
-UnitAttr getIndirectBindingsAttr(Operation *op) {
-  DictionaryAttr config = getTargetConfigAttr(op);
-  if (!config)
-    return nullptr;
-
-  return config.getAs<UnitAttr>("hal.bindings.indirect");
+bool usesIndirectBindingsAttr(Operation *op) {
+  auto targetAttr = IREE::HAL::ExecutableTargetAttr::lookup(op);
+  return targetAttr ? targetAttr.getFormat().getValue().ends_with("-ptr")
+                    : false;
 }
 
 FailureOr<SmallVector<int64_t>>

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Utils.h
@@ -31,8 +31,9 @@ const char *getSPIRVDistributeAttrName();
 /// Given an operation, returns the HAL target config attribute.
 DictionaryAttr getTargetConfigAttr(Operation *op);
 
-/// Given an operation, returns the `hal.bindings.indirect` attribute.
-UnitAttr getIndirectBindingsAttr(Operation *op);
+/// Returns whether indirect bindings are supported based on the target config
+/// applicable to the given |op|.
+bool usesIndirectBindingsAttr(Operation *op);
 
 /// Returns the tile sizes at the given `tilingLevel` for compute ops in
 /// `funcOp`.

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/materialize_executable_conditions.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/materialize_executable_conditions.mlir
@@ -244,7 +244,7 @@ hal.executable private @dispatch_executable {
 
   // CHECK-LABEL: hal.executable.variant public @test_address_capabilities
   //  CHECK-SAME: target(<"vulkan-spirv", "vulkan-spirv-fb-ptr",
-  //  CHECK-SAME:   {hal.bindings.indirect, iree.spirv.features = ["vulkan-spirv", "compute.bitwidths.int=4", "address.mode=1"]}>)
+  //  CHECK-SAME:   {iree.spirv.features = ["vulkan-spirv", "compute.bitwidths.int=4", "address.mode=1"]}>)
   //       CHECK:   %{{.+}}, %[[V0:.+]] = hal.device.query<%{{.+}} : !hal.device>
   //  CHECK-SAME:     key("hal.dispatch" :: "compute.bitwidths.int") : i1, i32 = 0 : i32
   //       CHECK:   %[[TARGET0:.+]] = arith.constant 4 : i32
@@ -258,8 +258,8 @@ hal.executable private @dispatch_executable {
         spirv.target_env = #spirv.target_env<#spirv.vce<v1.5,
                                                         [Int64, PhysicalStorageBufferAddresses],
                                                         [SPV_KHR_physical_storage_buffer]>,
-                                             #spirv.resource_limits<>>,
-        hal.bindings.indirect}>
+                                             #spirv.resource_limits<>>
+      }>
     ) {
     hal.executable.export public @test_address_capabilities ordinal(0) layout(#indirect_pipeline_layout) {
     ^bb0(%arg0: !hal.device):

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/physical_storage_buffer_addresses.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/physical_storage_buffer_addresses.mlir
@@ -10,7 +10,7 @@
   ], flags = Indirect>
 ]>
 hal.executable private @interface_binding {
-  hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb-ptr", {hal.bindings.indirect}>) {
+  hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb-ptr">) {
     hal.executable.export @interface_binding layout(#pipeline_layout) attributes {
       workgroup_size = [32: index, 1: index, 1: index]
     }

--- a/compiler/src/iree/compiler/Dialect/HAL/Analysis/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Analysis/BUILD.bazel
@@ -16,11 +16,13 @@ iree_compiler_cc_library(
     name = "Analysis",
     srcs = [
         "BindingLayout.cpp",
+        "Captures.cpp",
         "DeviceAnalysis.cpp",
         "DeviceSet.cpp",
     ],
     hdrs = [
         "BindingLayout.h",
+        "Captures.h",
         "DeviceAnalysis.h",
         "DeviceSet.h",
     ],

--- a/compiler/src/iree/compiler/Dialect/HAL/Analysis/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Analysis/CMakeLists.txt
@@ -15,10 +15,12 @@ iree_cc_library(
     Analysis
   HDRS
     "BindingLayout.h"
+    "Captures.h"
     "DeviceAnalysis.h"
     "DeviceSet.h"
   SRCS
     "BindingLayout.cpp"
+    "Captures.cpp"
     "DeviceAnalysis.cpp"
     "DeviceSet.cpp"
   DEPS

--- a/compiler/src/iree/compiler/Dialect/HAL/Analysis/Captures.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Analysis/Captures.cpp
@@ -1,0 +1,48 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/HAL/Analysis/Captures.h"
+
+#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "mlir/IR/Operation.h"
+
+namespace mlir::iree_compiler::IREE::HAL {
+
+ValueOrigin categorizeValue(Value value) {
+  // If this is a captured argument of an execution region then look up to the
+  // SSA value that was captured.
+  if (auto blockArg = dyn_cast<BlockArgument>(value)) {
+    if (auto closureOp = dyn_cast<IREE::Util::ClosureOpInterface>(
+            blockArg.getOwner()->getParentOp())) {
+      return categorizeValue(
+          closureOp.getClosureOperands()[blockArg.getArgNumber()]);
+    }
+  }
+
+  // If we wanted to pull in entire IR slices this would have to use a
+  // worklist (selects of globals based on globals, etc). For now this analysis
+  // only looks at the value provided.
+  auto *definingOp = value.getDefiningOp();
+  if (definingOp && definingOp->hasTrait<OpTrait::ConstantLike>()) {
+    // Op producing the value is constant-like and we should be able to
+    // outline it by cloning.
+    return ValueOrigin::LocalConstant;
+  } else if (auto loadOp =
+                 dyn_cast_if_present<IREE::Util::GlobalLoadOp>(definingOp)) {
+    // We only support immutable global loads - mutable ones are dynamic
+    // values that may change over time and we can't memoize with them.
+    if (loadOp.isGlobalImmutable()) {
+      return ValueOrigin::ImmutableGlobal;
+    } else {
+      return ValueOrigin::MutableGlobal;
+    }
+  } else {
+    // Dynamic value that is only available at the memoization site.
+    return ValueOrigin::Unknown;
+  }
+}
+
+} // namespace mlir::iree_compiler::IREE::HAL

--- a/compiler/src/iree/compiler/Dialect/HAL/Analysis/Captures.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Analysis/Captures.h
@@ -1,0 +1,31 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_DIALECT_HAL_ANALYSIS_CAPTURES_H_
+#define IREE_COMPILER_DIALECT_HAL_ANALYSIS_CAPTURES_H_
+
+#include "mlir/IR/Value.h"
+
+namespace mlir::iree_compiler::IREE::HAL {
+
+// Describes the origin of an SSA value within a region.
+enum class ValueOrigin {
+  // Value origin is unknown or dynamic.
+  Unknown,
+  // Value is produced by a constant-like op in the local scope.
+  LocalConstant,
+  // Value is loaded from a mutable global.
+  MutableGlobal,
+  // Value is loaded from an immutable global.
+  ImmutableGlobal,
+};
+
+// Categories a value based on the operation in the local scope producing it.
+ValueOrigin categorizeValue(Value value);
+
+} // namespace mlir::iree_compiler::IREE::HAL
+
+#endif // IREE_COMPILER_DIALECT_HAL_ANALYSIS_CAPTURES_H_

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/BUILD.bazel
@@ -49,6 +49,7 @@ iree_compiler_cc_library(
         "Utils.h",
     ],
     deps = [
+        "//compiler/src/iree/compiler/Dialect/HAL/Analysis",
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
         "//compiler/src/iree/compiler/Dialect/HAL/IR:HALDialect",
         "//compiler/src/iree/compiler/Dialect/HAL/Target",

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/CMakeLists.txt
@@ -49,6 +49,7 @@ iree_cc_library(
     MLIRArithDialect
     MLIRIR
     MLIRSCFDialect
+    iree::compiler::Dialect::HAL::Analysis
     iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::HAL::IR::HALDialect
     iree::compiler::Dialect::HAL::Target

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Utils.h
@@ -67,21 +67,78 @@ deriveAllowedResourceBufferBits(Location loc,
                                 IREE::HAL::MemoryTypeBitfield &memoryTypes,
                                 IREE::HAL::BufferUsageBitfield &bufferUsage);
 
+class BindingTable {
+public:
+  BindingTable() = default;
+  // TODO(benvanik): interface for execution regions so this can be reused.
+  BindingTable(IREE::Stream::CmdExecuteOp executeOp, ValueRange bufferValues,
+               ValueRange bufferSizes, IndexSet &indexSet);
+
+  // True if binding tables are supported for the consumer.
+  bool isSupported() const { return !hasUnsupportedOps; }
+
+  // True if the binding table is empty.
+  bool empty() const { return indirectBuffers.empty(); }
+
+  // Maximum binding table capacity.
+  size_t size() const { return indirectBuffers.size(); }
+
+  // Builds a binding table (buffer, offset, length) based on the analysis.
+  ArrayRef<IREE::HAL::BindingTableValue> getValues() { return indirectBuffers; }
+
+  // Returns the binding table slot for the given resource, if it's used
+  // indirectly.
+  std::optional<Value> lookupResourceSlot(Value resourceValue);
+
+private:
+  // True if any ops are nested that may prevent binding table usage.
+  bool hasUnsupportedOps = false;
+  // Buffer binding table with <buffer, offset, length>.
+  SmallVector<IREE::HAL::BindingTableValue> indirectBuffers;
+  // A mapping of resources to binding table slot ordinals.
+  DenseMap<Value, Value> indirectSlots;
+};
+
+class CommandBufferConversionMapping {
+public:
+  CommandBufferConversionMapping(Value handle, BindingTable bindingTable)
+      : handle(handle), bindingTable(std::move(bindingTable)) {}
+
+  // Returns the handle to the !hal.command_buffer.
+  Value getHandle() const { return handle; }
+
+  // Resolves a resource range to either a direct or indirect buffer reference.
+  // The returned range may differ from the provided used range in cases where
+  // an indirect binding table reference may have already factored in the
+  // offset.
+  IREE::HAL::BindingTableValue resolveBinding(Location loc, Value resourceValue,
+                                              Value bufferValue,
+                                              Value useOffset, Value useLength,
+                                              OpBuilder &builder);
+
+private:
+  Value handle;
+  BindingTable bindingTable;
+};
+
 class StreamConversionMapping {
 public:
   // Maps the stream dialect |executeOp| to the hal dialect |commandBuffer|
   // value used during recording. Patterns can use this to find the SSA value
   // they need to make hal.command_buffer.* ops.
   void mapCommandBuffer(IREE::Stream::CmdExecuteOp executeOp,
-                        Value commandBuffer);
+                        Value commandBuffer, BindingTable bindingTable);
 
   // Looks up a mapped command buffer SSA value that can be used by the given
   // stream.cmd.* op.
-  Value lookupCommandBufferFor(Operation *cmdOp) const;
+  CommandBufferConversionMapping &
+  lookupCommandBufferFor(Operation *cmdOp) const;
 
 private:
+  // All cached command buffer results.
+  SmallVector<std::shared_ptr<CommandBufferConversionMapping>> commandBuffers;
   // Ops within stream.cmd.execute ops -> !hal.command_buffer.
-  DenseMap<Operation *, Value> commandBuffers;
+  DenseMap<Operation *, CommandBufferConversionMapping *> opCommandBufferMap;
 };
 
 template <typename OpT>

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALAttrs.cpp
@@ -86,8 +86,32 @@ uint32_t CollectiveAttr::getEncodedValue() const {
 }
 
 //===----------------------------------------------------------------------===//
+// hal.descriptor_set.layout<*>
+//===----------------------------------------------------------------------===//
+
+DescriptorSetBindingAttr
+DescriptorSetLayoutAttr::getBinding(int64_t ordinal) const {
+  for (auto binding : getBindings()) {
+    if (binding.getOrdinal() == ordinal) {
+      return binding;
+    }
+  }
+  return {};
+}
+
+//===----------------------------------------------------------------------===//
 // hal.pipeline.layout<*>
 //===----------------------------------------------------------------------===//
+
+DescriptorSetLayoutAttr
+PipelineLayoutAttr::getSetLayout(int64_t ordinal) const {
+  for (auto setLayout : getSetLayouts()) {
+    if (setLayout.getOrdinal() == ordinal) {
+      return setLayout;
+    }
+  }
+  return {};
+}
 
 int64_t PipelineLayoutAttr::getFlatBindingIndex(int64_t set,
                                                 int64_t binding) const {

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALAttrs.td
@@ -423,6 +423,9 @@ def HAL_DescriptorSetLayoutAttr :
     (`,` `flags` `=` $flags^)?
     `>`
   }];
+  let extraClassDeclaration = [{
+    DescriptorSetBindingAttr getBinding(int64_t ordinal) const;
+  }];
 }
 
 //===----------------------------------------------------------------------===//
@@ -449,6 +452,8 @@ def HAL_PipelineLayoutAttr :
     `>`
   }];
   let extraClassDeclaration = [{
+    DescriptorSetLayoutAttr getSetLayout(int64_t ordinal) const;
+
     // Returns the binding index in a flattened list of all sets and bindings.
     // For example, if the layout is [set(bindings[4]), set(bindings[2])] then
     // a query for set 1 binding 0 would return 4.

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
@@ -273,12 +273,9 @@ makePipelineLayoutAttr(const PipelineLayout &pipelineLayout,
               ? binding.flags
               : std::optional<IREE::HAL::DescriptorFlags>{}));
     }
-    std::optional<IREE::HAL::DescriptorSetLayoutFlags> flags;
-    if (targetAttr.hasConfigurationAttr("hal.bindings.indirect")) {
-      flags = IREE::HAL::DescriptorSetLayoutFlags::Indirect;
-    }
     setLayoutAttrs.push_back(IREE::HAL::DescriptorSetLayoutAttr::get(
-        builder.getContext(), setLayout.ordinal, bindingAttrs, flags));
+        builder.getContext(), setLayout.ordinal, bindingAttrs,
+        setLayout.flags));
   }
   return IREE::HAL::PipelineLayoutAttr::get(
       builder.getContext(), pipelineLayout.pushConstantCount, setLayoutAttrs);
@@ -354,8 +351,10 @@ cloneFuncWithInterface(mlir::func::FuncOp sourceFuncOp,
       continue; // unhandled arg type (primitive/etc)
     }
     auto setBinding = resourceMap[resourceIdx++];
-    auto setLayoutAttr = layoutAttr.getSetLayouts()[setBinding.first];
-    auto bindingAttr = setLayoutAttr.getBindings()[setBinding.second];
+    auto setLayoutAttr = layoutAttr.getSetLayout(setBinding.first);
+    assert(setLayoutAttr && "layout must be consistent");
+    auto bindingAttr = setLayoutAttr.getBinding(setBinding.second);
+    assert(bindingAttr && "layout must be consistent");
     convertBindingUsage(sourceFuncOp, arg, layoutAttr, setLayoutAttr,
                         bindingAttr);
   }

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/ipo.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/ipo.mlir
@@ -469,14 +469,33 @@ util.func public @nonuniform_result_caller(%arg0: i1) -> index {
 
 // CHECK-LABEL: util.func private @passthrough_callee() {
 util.func private @passthrough_callee(%arg0: index) -> index {
+  // Prevent DCE.
+  arith.constant 4 : index
   // CHECK: util.return
   util.return %arg0 : index
 }
 
 // CHECK: util.func public @passthrough_caller(%[[ARG0:.+]]: index)
 util.func public @passthrough_caller(%arg0: index) -> index {
-  // CHECK: call @passthrough_callee() : () -> ()
+  // CHECK: util.call @passthrough_callee() : () -> ()
   %ret0 = util.call @passthrough_callee(%arg0) : (index) -> index
+  // CHECK: util.return %[[ARG0]]
+  util.return %ret0 : index
+}
+
+// -----
+
+// Tests that functions which become empty are removed.
+
+// CHECK-NOT: util.func private @empty_passthrough_callee() {
+util.func private @empty_passthrough_callee(%arg0: index) -> index {
+  util.return %arg0 : index
+}
+
+// CHECK: util.func public @empty_passthrough_caller(%[[ARG0:.+]]: index)
+util.func public @empty_passthrough_caller(%arg0: index) -> index {
+  // CHECK-NOT: util.call
+  %ret0 = util.call @empty_passthrough_callee(%arg0) : (index) -> index
   // CHECK: util.return %[[ARG0]]
   util.return %ret0 : index
 }


### PR DESCRIPTION
An extremely naive "analysis" is used to create binding tables. This will need to improve in the future for more complex programs but seems to be sufficient today. Dynamic push constants currently disable reuse until future changes move those into uniform buffers.

This is disabled by default and requires opting in via the `--iree-hal-indirect-command-buffers=true` and
`--iree-hal-memoization=true` flags. As testing progresses the flags will flip to default but remain present in order to allow debugging target-specific issues with reusable/indirect command buffers. There should be no significant changes with the flags disabled.

Progress on #17875.