### PR TITLE
[Codegen][GPU] Add pass to unroll to native mma widths

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/IREEGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/IREEGPUExtensions.cpp
@@ -66,64 +66,9 @@ void transform_dialect::ApplyLowerValueBarrierOp::populatePatterns(
 // ApplyUnrollMultiMmaOp
 //===---------------------------------------------------------------------===//
 
-static bool isReductionIterator(Attribute attr) {
-  return cast<IREE::GPU::IteratorTypeAttr>(attr).getValue() ==
-         utils::IteratorType::reduction;
-}
-static bool isParallelIterator(Attribute attr) {
-  return cast<IREE::GPU::IteratorTypeAttr>(attr).getValue() ==
-         utils::IteratorType::parallel;
-}
-
-/// Pick an unrolling order that reuses the LHS register.
-static std::optional<SmallVector<int64_t>>
-gpuMultiMmaUnrollOrder(Operation *op) {
-  IREE::GPU::MultiMmaOp mmaOp = dyn_cast<IREE::GPU::MultiMmaOp>(op);
-  if (!mmaOp) {
-    return std::nullopt;
-  }
-  SmallVector<int64_t> order;
-  // First make reduction the outer dimensions.
-  for (auto [index, iter] : llvm::enumerate(mmaOp.getIteratorTypes())) {
-    if (isReductionIterator(iter)) {
-      order.push_back(index);
-    }
-  }
-
-  llvm::SmallDenseSet<int64_t> dims;
-  for (AffineExpr expr : mmaOp.getIndexingMapsArray()[0].getResults()) {
-    dims.insert(cast<AffineDimExpr>(expr).getPosition());
-  }
-  // Then parallel dimensions that are part of Lhs as we want to re-use Lhs.
-  for (auto [index, iter] : llvm::enumerate(mmaOp.getIteratorTypes())) {
-    if (isParallelIterator(iter) && dims.count(index)) {
-      order.push_back(index);
-    }
-  }
-  // Then the remaining parallel loops.
-  for (auto [index, iter] : llvm::enumerate(mmaOp.getIteratorTypes())) {
-    if (isParallelIterator(iter) && !dims.count(index)) {
-      order.push_back(index);
-    }
-  }
-  return order;
-}
-
-static std::optional<SmallVector<int64_t>> getMultiMmaUnitShape(Operation *op) {
-  IREE::GPU::MultiMmaOp mmaOp = dyn_cast<IREE::GPU::MultiMmaOp>(op);
-  if (!mmaOp) {
-    return std::nullopt;
-  }
-  SmallVector<int64_t> targetOuterShape(mmaOp.getIteratorTypes().size(), 1);
-  return targetOuterShape;
-}
-
 void transform_dialect::ApplyUnrollMultiMmaOp::populatePatterns(
     RewritePatternSet &patterns) {
-  GPU::populateIREEGPUVectorUnrollPatterns(
-      patterns, vector::UnrollVectorOptions()
-                    .setNativeShapeFn(getMultiMmaUnitShape)
-                    .setUnrollTraversalOrderFn(gpuMultiMmaUnrollOrder));
+  GPU::populateIREEGPUVectorUnrollPatterns(patterns);
 }
 
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BUILD.bazel
@@ -57,6 +57,7 @@ iree_compiler_cc_library(
         "PackToIntrinsics.cpp",
         "Passes.cpp",
         "Transforms.cpp",
+        "UnrollToIntrinsics.cpp",
         "VectorizeIREEGPUOps.cpp",
     ],
     hdrs = [

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/CMakeLists.txt
@@ -51,6 +51,7 @@ iree_cc_library(
     "PackToIntrinsics.cpp"
     "Passes.cpp"
     "Transforms.cpp"
+    "UnrollToIntrinsics.cpp"
     "VectorizeIREEGPUOps.cpp"
   DEPS
     ::PassesIncGen

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Passes.td
@@ -30,6 +30,13 @@ def FuseAndHoistParallelLoopsPass :
   ];
 }
 
+def LowerIREEGPUOpsPass :
+    InterfacePass<"iree-gpu-lower-ops", "mlir::FunctionOpInterface"> {
+  let summary = "Post bufferization lowerings of iree_gpu ops before late lowerings";
+  let dependentDialects = [
+    "::mlir::gpu::GPUDialect",
+  ];
+}
 
 def PackToIntrinsicsPass :
     InterfacePass<"iree-gpu-pack-to-intrinsics", "mlir::FunctionOpInterface"> {
@@ -40,6 +47,15 @@ def PackToIntrinsicsPass :
   ];
 }
 
+def UnrollToIntrinsicsPass :
+    InterfacePass<"iree-gpu-unroll-to-intrinsics", "mlir::FunctionOpInterface"> {
+  let summary = "Unrolls iree_gpu.multi_mma ops to their inner vector size.";
+  let dependentDialects = [
+    "::mlir::arith::ArithDialect",
+    "::mlir::vector::VectorDialect",
+  ];
+}
+
 def VectorizeIREEGPUOpsPass :
     InterfacePass<"iree-gpu-vectorize-ops", "mlir::FunctionOpInterface"> {
   let summary = "Vectorizes then lowers a few iree_gpu ops before vectorization.";
@@ -47,14 +63,6 @@ def VectorizeIREEGPUOpsPass :
     "::mlir::vector::VectorDialect",
     "::mlir::arith::ArithDialect",
     "::mlir::iree_compiler::IREE::GPU::IREEGPUDialect"
-  ];
-}
-
-def LowerIREEGPUOpsPass :
-    InterfacePass<"iree-gpu-lower-ops", "mlir::FunctionOpInterface"> {
-  let summary = "Post bufferization lowerings of iree_gpu ops before late lowerings";
-  let dependentDialects = [
-    "::mlir::gpu::GPUDialect",
   ];
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.h
@@ -63,6 +63,8 @@ void populateIREEGPULowerShuffleTensorPatterns(RewritePatternSet &patterns);
 void populateIREEGPULowerValueBarrierPatterns(RewritePatternSet &patterns);
 void populateIREEGPUVectorUnrollPatterns(
     RewritePatternSet &patterns, const vector::UnrollVectorOptions &options);
+// Version of unrolling with a preset configuration.
+void populateIREEGPUVectorUnrollPatterns(RewritePatternSet &patterns);
 void populateIREEGPUVectorizationPatterns(RewritePatternSet &patterns);
 
 } // namespace mlir::iree_compiler::IREE::GPU

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/UnrollToIntrinsics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/UnrollToIntrinsics.cpp
@@ -1,0 +1,58 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h"
+#include "iree/compiler/Codegen/Dialect/GPU/Transforms/Passes.h"
+#include "iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::iree_compiler::IREE::GPU {
+
+#define GEN_PASS_DEF_UNROLLTOINTRINSICSPASS
+#include "iree/compiler/Codegen/Dialect/GPU/Transforms/Passes.h.inc"
+
+namespace {
+struct UnrollToIntrinsicsPass final
+    : impl::UnrollToIntrinsicsPassBase<UnrollToIntrinsicsPass> {
+  void runOnOperation() override;
+};
+} // namespace
+
+void UnrollToIntrinsicsPass::runOnOperation() {
+  MLIRContext *context = &getContext();
+
+  {
+    RewritePatternSet patterns(context);
+    GPU::populateIREEGPUVectorUnrollPatterns(patterns);
+    if (failed(applyPatternsAndFoldGreedily(getOperation(),
+                                            std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+
+  // Post unrolling unit dim folding patterns in preparation for later
+  // lowerings.
+  {
+    RewritePatternSet patterns(context);
+    GPU::populateIREEGPUDropUnitDimsPatterns(patterns);
+    if (failed(applyPatternsAndFoldGreedily(getOperation(),
+                                            std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+}
+
+} // namespace mlir::iree_compiler::IREE::GPU

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -369,6 +369,11 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager) {
   // Vectorize copies that came out of vectorization.
   funcPassManager.addPass(createVectorizeMemrefCopyPass());
 
+  // Step 7. Unroll operations to native intrinsic widths.
+  funcPassManager.addPass(IREE::GPU::createUnrollToIntrinsicsPass());
+  funcPassManager.addPass(createCanonicalizerPass());
+  funcPassManager.addPass(createCSEPass());
+
   // Step 8. Remaining post-bufferization optimizations/lowerings.
   funcPassManager.addPass(IREE::GPU::createLowerIREEGPUOpsPass());
   funcPassManager.addPass(createLoopInvariantCodeMotionPass());


### PR DESCRIPTION
Left as TODO is to extend this pass to also unroll consumers/producers. To eventually connect everything we should add a pattern that unrolls iter args of `scf.for` loops.

Note that the unrolling pattern is already tested in its own test, so simply updating the pipeline test is fine here. Once extending this pass to do more unrolling a test can be added.