### PR TITLE
[Flow] Don't fuse with truncate ops with consumer

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/FusionUtils.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FusionUtils.cpp
@@ -73,6 +73,12 @@ bool areFusableAsElementwiseOps(MLIRContext *context, OpOperand *fusedOperand,
     return false;
   }
 
+  // Do not fuse truncate-like with consumer, they should be fused with their
+  // producer.
+  if (LinalgExt::isBitTruncateOp(producerOp)) {
+    return false;
+  }
+
   auto linalgConsumerOp = dyn_cast<linalg::LinalgOp>(consumerOp);
   if (!linalgConsumerOp) {
     return false;

--- a/compiler/src/iree/compiler/DispatchCreation/FusionUtils.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FusionUtils.cpp
@@ -75,7 +75,7 @@ bool areFusableAsElementwiseOps(MLIRContext *context, OpOperand *fusedOperand,
 
   // Do not fuse truncate-like with consumer, they should be fused with their
   // producer.
-  if (LinalgExt::isBitTruncateOp(producerOp)) {
+  if (IREE::LinalgExt::isBitTruncateOp(producerOp)) {
     return false;
   }
 


### PR DESCRIPTION
To ensure truncate ops get fused with their producers, don't fuse them with their consumer.