### PR TITLE
Fix path filtering in ci_linux_x86_clang_asan.yml.

### DIFF
--- a/.github/workflows/ci_linux_x64_clang_asan.yml
+++ b/.github/workflows/ci_linux_x64_clang_asan.yml
@@ -13,28 +13,28 @@ on:
     paths:
       - ".github/workflows/ci_linux_x64_clang_asan.yml"
       - "CMakeLists.txt"
-      - "build_tools/*"
-      - "compiler/*"
-      - "llvm-external-projects/*"
-      - "runtime/*"
-      - "samples/*"
-      - "tests/*"
-      - "third_party/*"
-      - "tools/*"
+      - "build_tools/**"
+      - "compiler/**"
+      - "llvm-external-projects/**"
+      - "runtime/**"
+      - "samples/**"
+      - "tests/**"
+      - "third_party/**"
+      - "tools/**"
   pull_request:
     branches:
       - main
     paths:
       - ".github/workflows/ci_linux_x64_clang_asan.yml"
       - "CMakeLists.txt"
-      - "build_tools/*"
-      - "compiler/*"
-      - "llvm-external-projects/*"
-      - "runtime/*"
-      - "samples/*"
-      - "tests/*"
-      - "third_party/*"
-      - "tools/*"
+      - "build_tools/**"
+      - "compiler/**"
+      - "llvm-external-projects/**"
+      - "runtime/**"
+      - "samples/**"
+      - "tests/**"
+      - "third_party/**"
+      - "tools/**"
   workflow_dispatch:
 
 concurrency:

--- a/samples/custom_dispatch/cpu/embedded/example_hal.mlir
+++ b/samples/custom_dispatch/cpu/embedded/example_hal.mlir
@@ -48,7 +48,8 @@
 #pipeline_layout = #hal.pipeline.layout<push_constants = 1, sets = [
   <0, bindings = [
       <0, storage_buffer, ReadOnly>,
-      <1, storage_buffer>
+      <1, storage_buffer, ReadOnly>,
+      <2, storage_buffer>
   ]>
 ]>
 


### PR DESCRIPTION
This ASan job should be running on every PR and push that affects the compiler code, but it wasn't. Oops.

* https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore
* https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet