### PR TITLE
Trim installed packages in samples.yml.

### DIFF
--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -49,7 +49,7 @@ jobs:
       - name: "Installing build dependencies"
         run: |
           sudo apt update
-          sudo apt install -y cmake clang ninja-build libstdc++-12-dev
+          sudo apt install -y ninja-build
           echo "CC=clang" >> $GITHUB_ENV
           echo "CXX=clang++" >> $GITHUB_ENV
       - name: "Setting up Python"


### PR DESCRIPTION
This fixes the nightly 'samples' workflow.

I thought this `libstdc++-12-dev` dep would help use clang instead of gcc here: https://github.com/iree-org/iree/pull/18076. Turns out that package doesn't exist on ubuntu-20.04: https://github.com/iree-org/iree/actions/runs/10260247034/job/28385997161#step:4:43 `E: Unable to locate package libstdc++-12-dev`. A working clang toolchain also already exists. Ugh Linux. Tested here: https://github.com/ScottTodd/iree/actions/runs/10269229609.

(Yes, we could use Docker to manage toolchains / system deps like this, but I'd really rather not)

skip-ci: no impact on regular workflows (and soon this won't trigger them at all)