### PR TITLE
Revert path filter changes from ci*.yml workflows.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,43 +27,11 @@ name: CI
 # https://docs.github.com/en/actions/hosting-your-own-runners/using-self-hosted-runners-in-a-workflow
 
 on:
+  workflow_dispatch:
+  pull_request:
   push:
     branches:
       - main
-    paths:
-      - ".github/workflows/ci.yml"
-      - ".github/workflows/setup.yml"
-      - ".bazelrc"
-      - ".bazelversion"
-      - "WORKSPACE"
-      - "CMakeLists.txt"
-      - "build_tools/**"
-      - "compiler/**"
-      - "llvm-external-projects/**"
-      - "runtime/**"
-      - "samples/**"
-      - "tests/**"
-      - "third_party/**"
-      - "tools/**"
-  pull_request:
-    branches:
-      - main
-    paths:
-      - ".github/workflows/ci.yml"
-      - ".github/workflows/setup.yml"
-      - ".bazelrc"
-      - ".bazelversion"
-      - "WORKSPACE"
-      - "CMakeLists.txt"
-      - "build_tools/**"
-      - "compiler/**"
-      - "llvm-external-projects/**"
-      - "runtime/**"
-      - "samples/**"
-      - "tests/**"
-      - "third_party/**"
-      - "tools/**"
-  workflow_dispatch:
 
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels

--- a/.github/workflows/ci_linux_x64_clang.yml
+++ b/.github/workflows/ci_linux_x64_clang.yml
@@ -7,37 +7,11 @@
 name: CI - Linux x64 clang
 
 on:
+  workflow_dispatch:
+  pull_request:
   push:
     branches:
       - main
-    paths:
-      - ".github/workflows/ci_linux_x64_clang.yml"
-      - ".github/workflows/setup.yml"
-      - "CMakeLists.txt"
-      - "build_tools/**"
-      - "compiler/**"
-      - "llvm-external-projects/**"
-      - "runtime/**"
-      - "samples/**"
-      - "tests/**"
-      - "third_party/**"
-      - "tools/**"
-  pull_request:
-    branches:
-      - main
-    paths:
-      - ".github/workflows/ci_linux_x64_clang.yml"
-      - ".github/workflows/setup.yml"
-      - "CMakeLists.txt"
-      - "build_tools/**"
-      - "compiler/**"
-      - "llvm-external-projects/**"
-      - "runtime/**"
-      - "samples/**"
-      - "tests/**"
-      - "third_party/**"
-      - "tools/**"
-  workflow_dispatch:
 
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels

--- a/.github/workflows/ci_linux_x64_clang_asan.yml
+++ b/.github/workflows/ci_linux_x64_clang_asan.yml
@@ -7,37 +7,11 @@
 name: CI - Linux x64 clang ASan
 
 on:
+  workflow_dispatch:
+  pull_request:
   push:
     branches:
       - main
-    paths:
-      - ".github/workflows/ci_linux_x64_clang_asan.yml"
-      - ".github/workflows/setup.yml"
-      - "CMakeLists.txt"
-      - "build_tools/**"
-      - "compiler/**"
-      - "llvm-external-projects/**"
-      - "runtime/**"
-      - "samples/**"
-      - "tests/**"
-      - "third_party/**"
-      - "tools/**"
-  pull_request:
-    branches:
-      - main
-    paths:
-      - ".github/workflows/ci_linux_x64_clang_asan.yml"
-      - ".github/workflows/setup.yml"
-      - "CMakeLists.txt"
-      - "build_tools/**"
-      - "compiler/**"
-      - "llvm-external-projects/**"
-      - "runtime/**"
-      - "samples/**"
-      - "tests/**"
-      - "third_party/**"
-      - "tools/**"
-  workflow_dispatch:
 
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels


### PR DESCRIPTION
These are incompatible with required checks. We'll need to continue using our `configure_ci.py` script and the `if: ` conditions.

https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks