### PR TITLE
Adding flag placeholders to semaphores/events.

### DIFF
--- a/experimental/web/sample_webgpu/main.c
+++ b/experimental/web/sample_webgpu/main.c
@@ -782,7 +782,8 @@ static iree_status_t process_call_outputs(
   }
   iree_hal_semaphore_t* signal_semaphore = NULL;
   if (iree_status_is_ok(status)) {
-    status = iree_hal_semaphore_create(device, 0ull, &signal_semaphore);
+    status = iree_hal_semaphore_create(
+        device, 0ull, IREE_HAL_SEMAPHORE_FLAG_NONE, &signal_semaphore);
   }
   uint64_t signal_value = 1ull;
   if (iree_status_is_ok(status)) {

--- a/experimental/webgpu/nop_event.c
+++ b/experimental/webgpu/nop_event.c
@@ -24,8 +24,9 @@ static iree_hal_webgpu_nop_event_t* iree_hal_webgpu_nop_event_cast(
   return (iree_hal_webgpu_nop_event_t*)base_value;
 }
 
-iree_status_t iree_hal_webgpu_nop_event_create(iree_allocator_t host_allocator,
-                                               iree_hal_event_t** out_event) {
+iree_status_t iree_hal_webgpu_nop_event_create(
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_event_flags_t flags,
+    iree_allocator_t host_allocator, iree_hal_event_t** out_event) {
   IREE_ASSERT_ARGUMENT(out_event);
   *out_event = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);

--- a/experimental/webgpu/nop_event.h
+++ b/experimental/webgpu/nop_event.h
@@ -14,8 +14,9 @@
 extern "C" {
 #endif  // __cplusplus
 
-iree_status_t iree_hal_webgpu_nop_event_create(iree_allocator_t host_allocator,
-                                               iree_hal_event_t** out_event);
+iree_status_t iree_hal_webgpu_nop_event_create(
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_event_flags_t flags,
+    iree_allocator_t host_allocator, iree_hal_event_t** out_event);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/experimental/webgpu/webgpu_device.c
+++ b/experimental/webgpu/webgpu_device.c
@@ -263,9 +263,11 @@ static iree_status_t iree_hal_webgpu_device_create_descriptor_set_layout(
 }
 
 static iree_status_t iree_hal_webgpu_device_create_event(
-    iree_hal_device_t* base_device, iree_hal_event_t** out_event) {
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_event_flags_t flags, iree_hal_event_t** out_event) {
   iree_hal_webgpu_device_t* device = iree_hal_webgpu_device_cast(base_device);
-  return iree_hal_webgpu_nop_event_create(device->host_allocator, out_event);
+  return iree_hal_webgpu_nop_event_create(queue_affinity, flags,
+                                          device->host_allocator, out_event);
 }
 
 static iree_status_t iree_hal_webgpu_device_create_executable_cache(
@@ -305,7 +307,7 @@ static iree_status_t iree_hal_webgpu_device_create_pipeline_layout(
 
 static iree_status_t iree_hal_webgpu_device_create_semaphore(
     iree_hal_device_t* base_device, uint64_t initial_value,
-    iree_hal_semaphore_t** out_semaphore) {
+    iree_hal_semaphore_flags_t flags, iree_hal_semaphore_t** out_semaphore) {
   iree_hal_webgpu_device_t* device = iree_hal_webgpu_device_cast(base_device);
   return iree_hal_webgpu_nop_semaphore_create(
       initial_value, device->host_allocator, out_semaphore);

--- a/integrations/pjrt/src/iree_pjrt/common/api_impl.cc
+++ b/integrations/pjrt/src/iree_pjrt/common/api_impl.cc
@@ -528,8 +528,8 @@ iree_status_t BufferInstance::CopyToHost(void* dst, iree_host_size_t dst_size,
   dst_buffer.reset();
 
   iree::vm::ref<iree_hal_semaphore_t> semaphore;
-  IREE_RETURN_IF_ERROR(
-      iree_hal_semaphore_create(device_.device(), 0ull, &semaphore));
+  IREE_RETURN_IF_ERROR(iree_hal_semaphore_create(
+      device_.device(), 0ull, IREE_HAL_SEMAPHORE_FLAG_NONE, &semaphore));
 
   // Signaled when `dst_buffer` is ready to be consumed.
   iree::vm::ref<iree_hal_fence_t> dst_buffer_ready_fence;
@@ -759,10 +759,10 @@ iree_status_t DeviceInstance::OpenDevice() {
       driver_, /*device_id=*/info_.device_id(),
       /*param_count=*/0, /*params=*/nullptr, client_.host_allocator(),
       &device_));
-  IREE_RETURN_IF_ERROR(
-      iree_hal_semaphore_create(device(), 0ull, &main_timeline_));
-  IREE_RETURN_IF_ERROR(
-      iree_hal_semaphore_create(device(), 0ull, &transfer_timeline_));
+  IREE_RETURN_IF_ERROR(iree_hal_semaphore_create(
+      device(), 0ull, IREE_HAL_SEMAPHORE_FLAG_NONE, &main_timeline_));
+  IREE_RETURN_IF_ERROR(iree_hal_semaphore_create(
+      device(), 0ull, IREE_HAL_SEMAPHORE_FLAG_NONE, &transfer_timeline_));
 
   return iree_ok_status();
 }

--- a/runtime/bindings/python/hal.cc
+++ b/runtime/bindings/python/hal.cc
@@ -371,8 +371,10 @@ void HalDevice::EndProfiling() {
 
 HalSemaphore HalDevice::CreateSemaphore(uint64_t initial_value) {
   iree_hal_semaphore_t* out_sem;
-  CheckApiStatus(iree_hal_semaphore_create(raw_ptr(), initial_value, &out_sem),
-                 "creating semaphore");
+  CheckApiStatus(
+      iree_hal_semaphore_create(raw_ptr(), initial_value,
+                                IREE_HAL_SEMAPHORE_FLAG_NONE, &out_sem),
+      "creating semaphore");
   return HalSemaphore::StealFromRawPtr(out_sem);
 }
 

--- a/runtime/bindings/python/loop.cc
+++ b/runtime/bindings/python/loop.cc
@@ -36,7 +36,8 @@ class HalDeviceLoopBridge {
     IREE_PY_TRACEF("new HalDeviceLoopBridge (%p)", this);
     iree_slim_mutex_initialize(&mu_);
     CheckApiStatus(
-        iree_hal_semaphore_create(device_.raw_ptr(), 0, &control_sem_),
+        iree_hal_semaphore_create(device_.raw_ptr(), 0,
+                                  IREE_HAL_SEMAPHORE_FLAG_NONE, &control_sem_),
         "create semaphore");
 
     loop_call_soon_ = loop_.attr("call_soon_threadsafe");

--- a/runtime/src/iree/hal/BUILD.bazel
+++ b/runtime/src/iree/hal/BUILD.bazel
@@ -63,6 +63,7 @@ iree_runtime_cc_library(
         "file.h",
         "pipeline_layout.c",
         "pipeline_layout.h",
+        "queue.h",
         "resource.h",
         "semaphore.c",
         "semaphore.h",

--- a/runtime/src/iree/hal/CMakeLists.txt
+++ b/runtime/src/iree/hal/CMakeLists.txt
@@ -56,6 +56,7 @@ iree_cc_library(
     "file.h"
     "pipeline_layout.c"
     "pipeline_layout.h"
+    "queue.h"
     "resource.h"
     "semaphore.c"
     "semaphore.h"

--- a/runtime/src/iree/hal/allocator.h
+++ b/runtime/src/iree/hal/allocator.h
@@ -12,6 +12,7 @@
 
 #include "iree/base/api.h"
 #include "iree/hal/buffer.h"
+#include "iree/hal/queue.h"
 #include "iree/hal/resource.h"
 
 #ifdef __cplusplus
@@ -21,22 +22,6 @@ extern "C" {
 //===----------------------------------------------------------------------===//
 // Types and Enums
 //===----------------------------------------------------------------------===//
-
-// A bitmap indicating logical device queue affinity.
-// Used to direct submissions to specific device queues or locate memory nearby
-// where it will be used. The meaning of the bits in the bitmap is
-// implementation-specific: a bit may represent a logical queue in an underlying
-// API such as a VkQueue or a physical queue such as a discrete virtual device.
-//
-// Bitwise operations can be performed on affinities; for example AND'ing two
-// affinities will produce the intersection and OR'ing will produce the union.
-// This enables just-in-time selection as a command buffer could be made
-// available to some set of queues when recorded and then AND'ed with an actual
-// set of queues to execute on during submission.
-typedef uint64_t iree_hal_queue_affinity_t;
-
-// Specifies that any queue may be selected.
-#define IREE_HAL_QUEUE_AFFINITY_ANY ((iree_hal_queue_affinity_t)(-1))
 
 // TBD: placeholder for reserving unique pools.
 // The intent is that semantically meaningful pools can be defined like

--- a/runtime/src/iree/hal/api.h
+++ b/runtime/src/iree/hal/api.h
@@ -26,6 +26,7 @@
 #include "iree/hal/fence.h"             // IWYU pragma: export
 #include "iree/hal/file.h"              // IWYU pragma: export
 #include "iree/hal/pipeline_layout.h"   // IWYU pragma: export
+#include "iree/hal/queue.h"             // IWYU pragma: export
 #include "iree/hal/resource.h"          // IWYU pragma: export
 #include "iree/hal/semaphore.h"         // IWYU pragma: export
 #include "iree/hal/string_util.h"       // IWYU pragma: export

--- a/runtime/src/iree/hal/buffer_transfer.c
+++ b/runtime/src/iree/hal/buffer_transfer.c
@@ -62,8 +62,8 @@ static iree_status_t iree_hal_device_transfer_and_wait(
   // run out-of-order/overlapped with other work and return earlier than device
   // idle.
   iree_hal_semaphore_t* fence_semaphore = NULL;
-  iree_status_t status =
-      iree_hal_semaphore_create(device, 0ull, &fence_semaphore);
+  iree_status_t status = iree_hal_semaphore_create(
+      device, 0ull, IREE_HAL_SEMAPHORE_FLAG_NONE, &fence_semaphore);
   uint64_t signal_value = 1ull;
   if (iree_status_is_ok(status)) {
     iree_hal_semaphore_list_t wait_semaphores = {

--- a/runtime/src/iree/hal/channel.h
+++ b/runtime/src/iree/hal/channel.h
@@ -11,7 +11,7 @@
 #include <stdint.h>
 
 #include "iree/base/api.h"
-#include "iree/hal/allocator.h"
+#include "iree/hal/queue.h"
 #include "iree/hal/resource.h"
 
 #ifdef __cplusplus

--- a/runtime/src/iree/hal/command_buffer.h
+++ b/runtime/src/iree/hal/command_buffer.h
@@ -17,6 +17,7 @@
 #include "iree/hal/event.h"
 #include "iree/hal/executable.h"
 #include "iree/hal/pipeline_layout.h"
+#include "iree/hal/queue.h"
 #include "iree/hal/resource.h"
 
 #ifdef __cplusplus

--- a/runtime/src/iree/hal/cts/cts_test_base.h
+++ b/runtime/src/iree/hal/cts/cts_test_base.h
@@ -231,8 +231,8 @@ class CTSTestBase : public BaseType, public CTSTestResources {
 
     // One signal semaphore from 0 -> 1.
     iree_hal_semaphore_t* signal_semaphore = NULL;
-    IREE_RETURN_IF_ERROR(
-        iree_hal_semaphore_create(device_, 0ull, &signal_semaphore));
+    IREE_RETURN_IF_ERROR(iree_hal_semaphore_create(
+        device_, 0ull, IREE_HAL_SEMAPHORE_FLAG_NONE, &signal_semaphore));
     uint64_t target_payload_value = 1ull;
     iree_hal_semaphore_list_t signal_semaphores = {
         /*count=*/1,
@@ -267,7 +267,8 @@ class CTSTestBase : public BaseType, public CTSTestResources {
 
   iree_hal_semaphore_t* CreateSemaphore() {
     iree_hal_semaphore_t* semaphore = NULL;
-    IREE_EXPECT_OK(iree_hal_semaphore_create(device_, 0, &semaphore));
+    IREE_EXPECT_OK(iree_hal_semaphore_create(
+        device_, 0, IREE_HAL_SEMAPHORE_FLAG_NONE, &semaphore));
     return semaphore;
   }
 

--- a/runtime/src/iree/hal/cts/event_test.h
+++ b/runtime/src/iree/hal/cts/event_test.h
@@ -21,13 +21,15 @@ class EventTest : public CTSTestBase<> {};
 
 TEST_F(EventTest, Create) {
   iree_hal_event_t* event = NULL;
-  IREE_ASSERT_OK(iree_hal_event_create(device_, &event));
+  IREE_ASSERT_OK(iree_hal_event_create(device_, IREE_HAL_QUEUE_AFFINITY_ANY,
+                                       IREE_HAL_EVENT_FLAG_NONE, &event));
   iree_hal_event_release(event);
 }
 
 TEST_F(EventTest, SignalAndReset) {
   iree_hal_event_t* event = NULL;
-  IREE_ASSERT_OK(iree_hal_event_create(device_, &event));
+  IREE_ASSERT_OK(iree_hal_event_create(device_, IREE_HAL_QUEUE_AFFINITY_ANY,
+                                       IREE_HAL_EVENT_FLAG_NONE, &event));
 
   iree_hal_command_buffer_t* command_buffer = NULL;
   IREE_ASSERT_OK(iree_hal_command_buffer_create(
@@ -50,7 +52,8 @@ TEST_F(EventTest, SignalAndReset) {
 
 TEST_F(EventTest, SubmitWithChainedCommandBuffers) {
   iree_hal_event_t* event = NULL;
-  IREE_ASSERT_OK(iree_hal_event_create(device_, &event));
+  IREE_ASSERT_OK(iree_hal_event_create(device_, IREE_HAL_QUEUE_AFFINITY_ANY,
+                                       IREE_HAL_EVENT_FLAG_NONE, &event));
 
   iree_hal_command_buffer_t* command_buffer_1 = NULL;
   iree_hal_command_buffer_t* command_buffer_2 = NULL;

--- a/runtime/src/iree/hal/cts/file_test.h
+++ b/runtime/src/iree/hal/cts/file_test.h
@@ -93,7 +93,8 @@ TEST_F(FileTest, ReadEntireFile) {
   CreatePatternedDeviceBuffer(file_size, 0xCD, &buffer);
 
   iree_hal_semaphore_t* semaphore = NULL;
-  IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 0ull, &semaphore));
+  IREE_ASSERT_OK(iree_hal_semaphore_create(
+      device_, 0ull, IREE_HAL_SEMAPHORE_FLAG_NONE, &semaphore));
   iree_hal_fence_t* wait_fence = NULL;
   IREE_ASSERT_OK(iree_hal_fence_create_at(
       semaphore, 1ull, iree_allocator_system(), &wait_fence));

--- a/runtime/src/iree/hal/cts/semaphore_submission_test.h
+++ b/runtime/src/iree/hal/cts/semaphore_submission_test.h
@@ -77,7 +77,8 @@ TEST_F(SemaphoreSubmissionTest, SubmitWithWait) {
       wait_payload_values,
   };
   iree_hal_semaphore_t* signal_semaphore = NULL;
-  IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 100, &signal_semaphore));
+  IREE_ASSERT_OK(iree_hal_semaphore_create(
+      device_, 100, IREE_HAL_SEMAPHORE_FLAG_NONE, &signal_semaphore));
   uint64_t signal_payload_values[] = {101};
   iree_hal_semaphore_list_t signal_semaphores = {
       1,

--- a/runtime/src/iree/hal/cts/semaphore_test.h
+++ b/runtime/src/iree/hal/cts/semaphore_test.h
@@ -26,7 +26,8 @@ class SemaphoreTest : public CTSTestBase<> {};
 // Tests that a semaphore that is unused properly cleans itself up.
 TEST_F(SemaphoreTest, NoOp) {
   iree_hal_semaphore_t* semaphore = NULL;
-  IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 123ull, &semaphore));
+  IREE_ASSERT_OK(iree_hal_semaphore_create(
+      device_, 123ull, IREE_HAL_SEMAPHORE_FLAG_NONE, &semaphore));
 
   uint64_t value;
   IREE_ASSERT_OK(iree_hal_semaphore_query(semaphore, &value));
@@ -38,7 +39,8 @@ TEST_F(SemaphoreTest, NoOp) {
 // Tests that a semaphore will accept new values as it is signaled.
 TEST_F(SemaphoreTest, NormalSignaling) {
   iree_hal_semaphore_t* semaphore = NULL;
-  IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 2ull, &semaphore));
+  IREE_ASSERT_OK(iree_hal_semaphore_create(
+      device_, 2ull, IREE_HAL_SEMAPHORE_FLAG_NONE, &semaphore));
 
   uint64_t value;
   IREE_ASSERT_OK(iree_hal_semaphore_query(semaphore, &value));
@@ -60,7 +62,8 @@ TEST_F(SemaphoreTest, NormalSignaling) {
 // Tests semaphore failure handling.
 TEST_F(SemaphoreTest, Failure) {
   iree_hal_semaphore_t* semaphore = NULL;
-  IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 2ull, &semaphore));
+  IREE_ASSERT_OK(iree_hal_semaphore_create(
+      device_, 2ull, IREE_HAL_SEMAPHORE_FLAG_NONE, &semaphore));
 
   IREE_ASSERT_OK(iree_hal_semaphore_signal(semaphore, 3ull));
   uint64_t value;
@@ -98,7 +101,8 @@ TEST_F(SemaphoreTest, EmptyWait) {
 // Tests waiting on a semaphore that has already been signaled.
 TEST_F(SemaphoreTest, WaitAlreadySignaled) {
   iree_hal_semaphore_t* semaphore = NULL;
-  IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 2ull, &semaphore));
+  IREE_ASSERT_OK(iree_hal_semaphore_create(
+      device_, 2ull, IREE_HAL_SEMAPHORE_FLAG_NONE, &semaphore));
 
   // Test both previous and current values.
   IREE_ASSERT_OK(iree_hal_semaphore_wait(
@@ -117,7 +121,8 @@ TEST_F(SemaphoreTest, WaitAlreadySignaled) {
 // Tests waiting on a semaphore that has not been signaled.
 TEST_F(SemaphoreTest, WaitUnsignaled) {
   iree_hal_semaphore_t* semaphore = NULL;
-  IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 2ull, &semaphore));
+  IREE_ASSERT_OK(iree_hal_semaphore_create(
+      device_, 2ull, IREE_HAL_SEMAPHORE_FLAG_NONE, &semaphore));
 
   // NOTE: we don't actually block here because otherwise we'd lock up.
   // Result status is undefined - some backends may return DeadlineExceededError
@@ -131,7 +136,8 @@ TEST_F(SemaphoreTest, WaitUnsignaled) {
 // Tests waiting on a semaphore that has signals past the desired value.
 TEST_F(SemaphoreTest, WaitLaterSignaledBeyond) {
   iree_hal_semaphore_t* semaphore = NULL;
-  IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 2ull, &semaphore));
+  IREE_ASSERT_OK(iree_hal_semaphore_create(
+      device_, 2ull, IREE_HAL_SEMAPHORE_FLAG_NONE, &semaphore));
 
   std::thread thread([&]() {
     // Wait for a short period before signaling.
@@ -154,8 +160,10 @@ TEST_F(SemaphoreTest, WaitLaterSignaledBeyond) {
 TEST_F(SemaphoreTest, WaitAllButNotAllSignaled) {
   iree_hal_semaphore_t* semaphore_a = NULL;
   iree_hal_semaphore_t* semaphore_b = NULL;
-  IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 0ull, &semaphore_a));
-  IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 1ull, &semaphore_b));
+  IREE_ASSERT_OK(iree_hal_semaphore_create(
+      device_, 0ull, IREE_HAL_SEMAPHORE_FLAG_NONE, &semaphore_a));
+  IREE_ASSERT_OK(iree_hal_semaphore_create(
+      device_, 1ull, IREE_HAL_SEMAPHORE_FLAG_NONE, &semaphore_b));
 
   iree_hal_semaphore_list_t semaphore_list;
   iree_hal_semaphore_t* semaphore_ptrs[] = {semaphore_a, semaphore_b};
@@ -179,8 +187,10 @@ TEST_F(SemaphoreTest, WaitAllButNotAllSignaled) {
 TEST_F(SemaphoreTest, WaitAllAndAllSignaled) {
   iree_hal_semaphore_t* semaphore_a = NULL;
   iree_hal_semaphore_t* semaphore_b = NULL;
-  IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 1ull, &semaphore_a));
-  IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 1ull, &semaphore_b));
+  IREE_ASSERT_OK(iree_hal_semaphore_create(
+      device_, 1ull, IREE_HAL_SEMAPHORE_FLAG_NONE, &semaphore_a));
+  IREE_ASSERT_OK(iree_hal_semaphore_create(
+      device_, 1ull, IREE_HAL_SEMAPHORE_FLAG_NONE, &semaphore_b));
 
   iree_hal_semaphore_list_t semaphore_list;
   iree_hal_semaphore_t* semaphore_ptrs[] = {semaphore_a, semaphore_b};
@@ -204,8 +214,10 @@ TEST_F(SemaphoreTest, WaitAllAndAllSignaled) {
 TEST_F(SemaphoreTest, WaitAnyAlreadySignaled) {
   iree_hal_semaphore_t* semaphore_a = NULL;
   iree_hal_semaphore_t* semaphore_b = NULL;
-  IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 0ull, &semaphore_a));
-  IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 1ull, &semaphore_b));
+  IREE_ASSERT_OK(iree_hal_semaphore_create(
+      device_, 0ull, IREE_HAL_SEMAPHORE_FLAG_NONE, &semaphore_a));
+  IREE_ASSERT_OK(iree_hal_semaphore_create(
+      device_, 1ull, IREE_HAL_SEMAPHORE_FLAG_NONE, &semaphore_b));
 
   iree_hal_semaphore_list_t semaphore_list;
   iree_hal_semaphore_t* semaphore_ptrs[] = {semaphore_a, semaphore_b};
@@ -225,8 +237,10 @@ TEST_F(SemaphoreTest, WaitAnyAlreadySignaled) {
 TEST_F(SemaphoreTest, WaitAnyLaterSignaled) {
   iree_hal_semaphore_t* semaphore_a = NULL;
   iree_hal_semaphore_t* semaphore_b = NULL;
-  IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 0ull, &semaphore_a));
-  IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 0ull, &semaphore_b));
+  IREE_ASSERT_OK(iree_hal_semaphore_create(
+      device_, 0ull, IREE_HAL_SEMAPHORE_FLAG_NONE, &semaphore_a));
+  IREE_ASSERT_OK(iree_hal_semaphore_create(
+      device_, 0ull, IREE_HAL_SEMAPHORE_FLAG_NONE, &semaphore_b));
 
   iree_hal_semaphore_list_t semaphore_list;
   iree_hal_semaphore_t* semaphore_ptrs[] = {semaphore_a, semaphore_b};
@@ -255,8 +269,10 @@ TEST_F(SemaphoreTest, WaitAnyLaterSignaled) {
 TEST_F(SemaphoreTest, PingPong) {
   iree_hal_semaphore_t* a2b = NULL;
   iree_hal_semaphore_t* b2a = NULL;
-  IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 0ull, &a2b));
-  IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 0ull, &b2a));
+  IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 0ull,
+                                           IREE_HAL_SEMAPHORE_FLAG_NONE, &a2b));
+  IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 0ull,
+                                           IREE_HAL_SEMAPHORE_FLAG_NONE, &b2a));
   std::thread thread([&]() {
     // Should advance right past this because the value is already set.
     IREE_ASSERT_OK(iree_hal_semaphore_wait(

--- a/runtime/src/iree/hal/device.h
+++ b/runtime/src/iree/hal/device.h
@@ -21,6 +21,7 @@
 #include "iree/hal/fence.h"
 #include "iree/hal/file.h"
 #include "iree/hal/pipeline_layout.h"
+#include "iree/hal/queue.h"
 #include "iree/hal/resource.h"
 #include "iree/hal/semaphore.h"
 
@@ -530,8 +531,9 @@ typedef struct iree_hal_device_vtable_t {
       const iree_hal_descriptor_set_layout_binding_t* bindings,
       iree_hal_descriptor_set_layout_t** out_descriptor_set_layout);
 
-  iree_status_t(IREE_API_PTR* create_event)(iree_hal_device_t* device,
-                                            iree_hal_event_t** out_event);
+  iree_status_t(IREE_API_PTR* create_event)(
+      iree_hal_device_t* device, iree_hal_queue_affinity_t queue_affinity,
+      iree_hal_event_flags_t flags, iree_hal_event_t** out_event);
 
   iree_status_t(IREE_API_PTR* create_executable_cache)(
       iree_hal_device_t* device, iree_string_view_t identifier,
@@ -550,7 +552,7 @@ typedef struct iree_hal_device_vtable_t {
 
   iree_status_t(IREE_API_PTR* create_semaphore)(
       iree_hal_device_t* device, uint64_t initial_value,
-      iree_hal_semaphore_t** out_semaphore);
+      iree_hal_semaphore_flags_t flags, iree_hal_semaphore_t** out_semaphore);
 
   iree_hal_semaphore_compatibility_t(
       IREE_API_PTR* query_semaphore_compatibility)(

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.c
@@ -573,7 +573,8 @@ static iree_status_t iree_hal_cuda_device_create_descriptor_set_layout(
 }
 
 static iree_status_t iree_hal_cuda_device_create_event(
-    iree_hal_device_t* base_device, iree_hal_event_t** out_event) {
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_event_flags_t flags, iree_hal_event_t** out_event) {
   return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
                           "event not yet implmeneted");
 }
@@ -615,7 +616,7 @@ static iree_status_t iree_hal_cuda_device_create_pipeline_layout(
 
 static iree_status_t iree_hal_cuda_device_create_semaphore(
     iree_hal_device_t* base_device, uint64_t initial_value,
-    iree_hal_semaphore_t** out_semaphore) {
+    iree_hal_semaphore_flags_t flags, iree_hal_semaphore_t** out_semaphore) {
   iree_hal_cuda_device_t* device = iree_hal_cuda_device_cast(base_device);
   return iree_hal_cuda_event_semaphore_create(
       initial_value, device->cuda_symbols, device->timepoint_pool,

--- a/runtime/src/iree/hal/drivers/hip/hip_device.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_device.c
@@ -575,7 +575,8 @@ static iree_status_t iree_hal_hip_device_create_descriptor_set_layout(
 }
 
 static iree_status_t iree_hal_hip_device_create_event(
-    iree_hal_device_t* base_device, iree_hal_event_t** out_event) {
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_event_flags_t flags, iree_hal_event_t** out_event) {
   return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
                           "event not yet implmeneted");
 }
@@ -617,7 +618,7 @@ static iree_status_t iree_hal_hip_device_create_pipeline_layout(
 
 static iree_status_t iree_hal_hip_device_create_semaphore(
     iree_hal_device_t* base_device, uint64_t initial_value,
-    iree_hal_semaphore_t** out_semaphore) {
+    iree_hal_semaphore_flags_t flags, iree_hal_semaphore_t** out_semaphore) {
   iree_hal_hip_device_t* device = iree_hal_hip_device_cast(base_device);
   return iree_hal_hip_event_semaphore_create(
       initial_value, device->hip_symbols, device->timepoint_pool,

--- a/runtime/src/iree/hal/drivers/local_sync/sync_device.c
+++ b/runtime/src/iree/hal/drivers/local_sync/sync_device.c
@@ -259,8 +259,10 @@ static iree_status_t iree_hal_sync_device_create_descriptor_set_layout(
 }
 
 static iree_status_t iree_hal_sync_device_create_event(
-    iree_hal_device_t* base_device, iree_hal_event_t** out_event) {
-  return iree_hal_sync_event_create(iree_hal_device_host_allocator(base_device),
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_event_flags_t flags, iree_hal_event_t** out_event) {
+  return iree_hal_sync_event_create(queue_affinity, flags,
+                                    iree_hal_device_host_allocator(base_device),
                                     out_event);
 }
 
@@ -300,7 +302,7 @@ static iree_status_t iree_hal_sync_device_create_pipeline_layout(
 
 static iree_status_t iree_hal_sync_device_create_semaphore(
     iree_hal_device_t* base_device, uint64_t initial_value,
-    iree_hal_semaphore_t** out_semaphore) {
+    iree_hal_semaphore_flags_t flags, iree_hal_semaphore_t** out_semaphore) {
   iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
   return iree_hal_sync_semaphore_create(&device->semaphore_state, initial_value,
                                         device->host_allocator, out_semaphore);

--- a/runtime/src/iree/hal/drivers/local_sync/sync_event.c
+++ b/runtime/src/iree/hal/drivers/local_sync/sync_event.c
@@ -21,8 +21,9 @@ static iree_hal_sync_event_t* iree_hal_sync_event_cast(
   return (iree_hal_sync_event_t*)base_value;
 }
 
-iree_status_t iree_hal_sync_event_create(iree_allocator_t host_allocator,
-                                         iree_hal_event_t** out_event) {
+iree_status_t iree_hal_sync_event_create(
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_event_flags_t flags,
+    iree_allocator_t host_allocator, iree_hal_event_t** out_event) {
   IREE_ASSERT_ARGUMENT(out_event);
   *out_event = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);

--- a/runtime/src/iree/hal/drivers/local_sync/sync_event.h
+++ b/runtime/src/iree/hal/drivers/local_sync/sync_event.h
@@ -14,8 +14,9 @@
 extern "C" {
 #endif  // __cplusplus
 
-iree_status_t iree_hal_sync_event_create(iree_allocator_t host_allocator,
-                                         iree_hal_event_t** out_event);
+iree_status_t iree_hal_sync_event_create(
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_event_flags_t flags,
+    iree_allocator_t host_allocator, iree_hal_event_t** out_event);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/hal/drivers/local_task/task_device.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_device.c
@@ -329,8 +329,10 @@ static iree_status_t iree_hal_task_device_create_descriptor_set_layout(
 }
 
 static iree_status_t iree_hal_task_device_create_event(
-    iree_hal_device_t* base_device, iree_hal_event_t** out_event) {
-  return iree_hal_task_event_create(iree_hal_device_host_allocator(base_device),
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_event_flags_t flags, iree_hal_event_t** out_event) {
+  return iree_hal_task_event_create(queue_affinity, flags,
+                                    iree_hal_device_host_allocator(base_device),
                                     out_event);
 }
 
@@ -379,7 +381,7 @@ static iree_status_t iree_hal_task_device_create_pipeline_layout(
 
 static iree_status_t iree_hal_task_device_create_semaphore(
     iree_hal_device_t* base_device, uint64_t initial_value,
-    iree_hal_semaphore_t** out_semaphore) {
+    iree_hal_semaphore_flags_t flags, iree_hal_semaphore_t** out_semaphore) {
   iree_hal_task_device_t* device = iree_hal_task_device_cast(base_device);
   return iree_hal_task_semaphore_create(
       iree_hal_task_device_shared_event_pool(device), initial_value,

--- a/runtime/src/iree/hal/drivers/local_task/task_event.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_event.c
@@ -21,8 +21,9 @@ static iree_hal_task_event_t* iree_hal_task_event_cast(
   return (iree_hal_task_event_t*)base_value;
 }
 
-iree_status_t iree_hal_task_event_create(iree_allocator_t host_allocator,
-                                         iree_hal_event_t** out_event) {
+iree_status_t iree_hal_task_event_create(
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_event_flags_t flags,
+    iree_allocator_t host_allocator, iree_hal_event_t** out_event) {
   IREE_ASSERT_ARGUMENT(out_event);
   *out_event = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);

--- a/runtime/src/iree/hal/drivers/local_task/task_event.h
+++ b/runtime/src/iree/hal/drivers/local_task/task_event.h
@@ -14,8 +14,9 @@
 extern "C" {
 #endif  // __cplusplus
 
-iree_status_t iree_hal_task_event_create(iree_allocator_t host_allocator,
-                                         iree_hal_event_t** out_event);
+iree_status_t iree_hal_task_event_create(
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_event_flags_t flags,
+    iree_allocator_t host_allocator, iree_hal_event_t** out_event);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/hal/drivers/metal/metal_device.m
+++ b/runtime/src/iree/hal/drivers/metal/metal_device.m
@@ -278,6 +278,8 @@ static iree_status_t iree_hal_metal_device_create_descriptor_set_layout(
 }
 
 static iree_status_t iree_hal_metal_device_create_event(iree_hal_device_t* base_device,
+                                                        iree_hal_queue_affinity_t queue_affinity,
+                                                        iree_hal_event_flags_t flags,
                                                         iree_hal_event_t** out_event) {
   return iree_make_status(IREE_STATUS_UNIMPLEMENTED, "event not yet supported");
 }
@@ -316,6 +318,7 @@ static iree_status_t iree_hal_metal_device_create_pipeline_layout(
 
 static iree_status_t iree_hal_metal_device_create_semaphore(iree_hal_device_t* base_device,
                                                             uint64_t initial_value,
+                                                            iree_hal_semaphore_flags_t flags,
                                                             iree_hal_semaphore_t** out_semaphore) {
   iree_hal_metal_device_t* device = iree_hal_metal_device_cast(base_device);
   return iree_hal_metal_shared_event_create(device->device, initial_value, device->event_listener,

--- a/runtime/src/iree/hal/drivers/vulkan/native_event.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/native_event.cc
@@ -51,7 +51,8 @@ static void iree_hal_vulkan_destroy_event(VkDeviceHandle* logical_device,
 }
 
 iree_status_t iree_hal_vulkan_native_event_create(
-    VkDeviceHandle* logical_device, iree_hal_event_t** out_event) {
+    VkDeviceHandle* logical_device, iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_event_flags_t flags, iree_hal_event_t** out_event) {
   IREE_ASSERT_ARGUMENT(logical_device);
   IREE_ASSERT_ARGUMENT(out_event);
   *out_event = NULL;

--- a/runtime/src/iree/hal/drivers/vulkan/native_event.h
+++ b/runtime/src/iree/hal/drivers/vulkan/native_event.h
@@ -18,6 +18,7 @@ extern "C" {
 // Creates a native Vulkan VkEvent object.
 iree_status_t iree_hal_vulkan_native_event_create(
     iree::hal::vulkan::VkDeviceHandle* logical_device,
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_event_flags_t flags,
     iree_hal_event_t** out_event);
 
 // Returns Vulkan event handle.

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
@@ -1584,9 +1584,11 @@ static iree_status_t iree_hal_vulkan_device_create_descriptor_set_layout(
 }
 
 static iree_status_t iree_hal_vulkan_device_create_event(
-    iree_hal_device_t* base_device, iree_hal_event_t** out_event) {
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_event_flags_t flags, iree_hal_event_t** out_event) {
   iree_hal_vulkan_device_t* device = iree_hal_vulkan_device_cast(base_device);
-  return iree_hal_vulkan_native_event_create(device->logical_device, out_event);
+  return iree_hal_vulkan_native_event_create(device->logical_device,
+                                             queue_affinity, flags, out_event);
 }
 
 static iree_status_t iree_hal_vulkan_device_create_executable_cache(
@@ -1625,7 +1627,7 @@ static iree_status_t iree_hal_vulkan_device_create_pipeline_layout(
 
 static iree_status_t iree_hal_vulkan_device_create_semaphore(
     iree_hal_device_t* base_device, uint64_t initial_value,
-    iree_hal_semaphore_t** out_semaphore) {
+    iree_hal_semaphore_flags_t flags, iree_hal_semaphore_t** out_semaphore) {
   iree_hal_vulkan_device_t* device = iree_hal_vulkan_device_cast(base_device);
   return iree_hal_vulkan_native_semaphore_create(device->logical_device,
                                                  initial_value, out_semaphore);

--- a/runtime/src/iree/hal/event.c
+++ b/runtime/src/iree/hal/event.c
@@ -17,14 +17,16 @@
 
 IREE_HAL_API_RETAIN_RELEASE(event);
 
-IREE_API_EXPORT iree_status_t
-iree_hal_event_create(iree_hal_device_t* device, iree_hal_event_t** out_event) {
+IREE_API_EXPORT iree_status_t iree_hal_event_create(
+    iree_hal_device_t* device, iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_event_flags_t flags, iree_hal_event_t** out_event) {
   IREE_ASSERT_ARGUMENT(device);
   IREE_ASSERT_ARGUMENT(out_event);
   *out_event = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
-  iree_status_t status = IREE_HAL_VTABLE_DISPATCH(
-      device, iree_hal_device, create_event)(device, out_event);
+  iree_status_t status =
+      IREE_HAL_VTABLE_DISPATCH(device, iree_hal_device, create_event)(
+          device, queue_affinity, flags, out_event);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }

--- a/runtime/src/iree/hal/event.h
+++ b/runtime/src/iree/hal/event.h
@@ -11,6 +11,7 @@
 #include <stdint.h>
 
 #include "iree/base/api.h"
+#include "iree/hal/queue.h"
 #include "iree/hal/resource.h"
 
 #ifdef __cplusplus
@@ -18,6 +19,16 @@ extern "C" {
 #endif  // __cplusplus
 
 typedef struct iree_hal_device_t iree_hal_device_t;
+
+//===----------------------------------------------------------------------===//
+// Types and Enums
+//===----------------------------------------------------------------------===//
+
+// A bitmask of flags controlling the behavior of an event.
+enum iree_hal_event_flag_bits_t {
+  IREE_HAL_EVENT_FLAG_NONE = 0u,
+};
+typedef uint32_t iree_hal_event_flags_t;
 
 //===----------------------------------------------------------------------===//
 // iree_hal_event_t
@@ -35,10 +46,12 @@ typedef struct iree_hal_device_t iree_hal_device_t;
 typedef struct iree_hal_event_t iree_hal_event_t;
 
 // Creates an event for recording into command buffers.
-// The returned event object is only usable with this device and events must
-// only be used to synchronize within the same queue.
-IREE_API_EXPORT iree_status_t
-iree_hal_event_create(iree_hal_device_t* device, iree_hal_event_t** out_event);
+// The returned event object is only usable with the device it is created on and
+// only on the queues specified. Events must only be used to synchronize within
+// the same queue.
+IREE_API_EXPORT iree_status_t iree_hal_event_create(
+    iree_hal_device_t* device, iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_event_flags_t flags, iree_hal_event_t** out_event);
 
 // Retains the given |event| for the caller.
 IREE_API_EXPORT void iree_hal_event_retain(iree_hal_event_t* event);

--- a/runtime/src/iree/hal/file.h
+++ b/runtime/src/iree/hal/file.h
@@ -10,8 +10,8 @@
 #include <stdint.h>
 
 #include "iree/base/api.h"
-#include "iree/hal/allocator.h"
 #include "iree/hal/buffer.h"
+#include "iree/hal/queue.h"
 #include "iree/hal/resource.h"
 #include "iree/io/file_handle.h"
 

--- a/runtime/src/iree/hal/queue.h
+++ b/runtime/src/iree/hal/queue.h
@@ -1,0 +1,42 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_QUEUE_H_
+#define IREE_HAL_QUEUE_H_
+
+#include <stdint.h>
+
+#include "iree/base/api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+//===----------------------------------------------------------------------===//
+// Types and Enums
+//===----------------------------------------------------------------------===//
+
+// A bitmap indicating logical device queue affinity.
+// Used to direct submissions to specific device queues or locate memory nearby
+// where it will be used. The meaning of the bits in the bitmap is
+// implementation-specific: a bit may represent a logical queue in an underlying
+// API such as a VkQueue or a physical queue such as a discrete virtual device.
+//
+// Bitwise operations can be performed on affinities; for example AND'ing two
+// affinities will produce the intersection and OR'ing will produce the union.
+// This enables just-in-time selection as a command buffer could be made
+// available to some set of queues when recorded and then AND'ed with an actual
+// set of queues to execute on during submission.
+typedef uint64_t iree_hal_queue_affinity_t;
+
+// Specifies that any queue may be selected.
+#define IREE_HAL_QUEUE_AFFINITY_ANY ((iree_hal_queue_affinity_t)(-1))
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_QUEUE_H_

--- a/runtime/src/iree/hal/semaphore.c
+++ b/runtime/src/iree/hal/semaphore.c
@@ -20,9 +20,9 @@
 
 IREE_HAL_API_RETAIN_RELEASE(semaphore);
 
-IREE_API_EXPORT iree_status_t
-iree_hal_semaphore_create(iree_hal_device_t* device, uint64_t initial_value,
-                          iree_hal_semaphore_t** out_semaphore) {
+IREE_API_EXPORT iree_status_t iree_hal_semaphore_create(
+    iree_hal_device_t* device, uint64_t initial_value,
+    iree_hal_semaphore_flags_t flags, iree_hal_semaphore_t** out_semaphore) {
   IREE_ASSERT_ARGUMENT(device);
   IREE_ASSERT_ARGUMENT(out_semaphore);
   *out_semaphore = NULL;
@@ -30,7 +30,7 @@ iree_hal_semaphore_create(iree_hal_device_t* device, uint64_t initial_value,
   IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, initial_value);
   iree_status_t status =
       IREE_HAL_VTABLE_DISPATCH(device, iree_hal_device, create_semaphore)(
-          device, initial_value, out_semaphore);
+          device, initial_value, flags, out_semaphore);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }

--- a/runtime/src/iree/hal/semaphore.h
+++ b/runtime/src/iree/hal/semaphore.h
@@ -11,6 +11,7 @@
 #include <stdint.h>
 
 #include "iree/base/api.h"
+#include "iree/hal/queue.h"
 #include "iree/hal/resource.h"
 
 #ifdef __cplusplus
@@ -18,6 +19,16 @@ extern "C" {
 #endif  // __cplusplus
 
 typedef struct iree_hal_device_t iree_hal_device_t;
+
+//===----------------------------------------------------------------------===//
+// Types and Enums
+//===----------------------------------------------------------------------===//
+
+// A bitmask of flags controlling the behavior of a semaphore.
+enum iree_hal_semaphore_flag_bits_t {
+  IREE_HAL_SEMAPHORE_FLAG_NONE = 0u,
+};
+typedef uint32_t iree_hal_semaphore_flags_t;
 
 //===----------------------------------------------------------------------===//
 // iree_hal_semaphore_t
@@ -81,9 +92,9 @@ typedef struct iree_hal_semaphore_t iree_hal_semaphore_t;
 // Creates a semaphore that can be used with command queues owned by this
 // device. To use the semaphores with other devices or instances they must
 // first be exported.
-IREE_API_EXPORT iree_status_t
-iree_hal_semaphore_create(iree_hal_device_t* device, uint64_t initial_value,
-                          iree_hal_semaphore_t** out_semaphore);
+IREE_API_EXPORT iree_status_t iree_hal_semaphore_create(
+    iree_hal_device_t* device, uint64_t initial_value,
+    iree_hal_semaphore_flags_t flags, iree_hal_semaphore_t** out_semaphore);
 
 // Retains the given |semaphore| for the caller.
 IREE_API_EXPORT void iree_hal_semaphore_retain(iree_hal_semaphore_t* semaphore);

--- a/runtime/src/iree/hal/utils/debug_allocator.c
+++ b/runtime/src/iree/hal/utils/debug_allocator.c
@@ -158,7 +158,8 @@ static iree_status_t iree_hal_debug_allocator_fill_on_device(
               IREE_HAL_QUEUE_AFFINITY_ANY, 1, &command, &command_buffer));
 
   iree_hal_semaphore_t* semaphore = NULL;
-  iree_status_t status = iree_hal_semaphore_create(device, 0ull, &semaphore);
+  iree_status_t status = iree_hal_semaphore_create(
+      device, 0ull, IREE_HAL_SEMAPHORE_FLAG_NONE, &semaphore);
 
   uint64_t signal_value = 1ull;
   if (iree_status_is_ok(status)) {

--- a/runtime/src/iree/hal/utils/file_transfer.c
+++ b/runtime/src/iree/hal/utils/file_transfer.c
@@ -279,6 +279,7 @@ static iree_status_t iree_hal_transfer_operation_create(
     // Create semaphore for tracking worker progress.
     worker->pending_timepoint = 0ull;
     status = iree_hal_semaphore_create(device, worker->pending_timepoint,
+                                       IREE_HAL_SEMAPHORE_FLAG_NONE,
                                        &worker->semaphore);
     if (!iree_status_is_ok(status)) break;
   }

--- a/runtime/src/iree/io/parameter_index_provider.c
+++ b/runtime/src/iree/io/parameter_index_provider.c
@@ -405,6 +405,7 @@ static iree_status_t iree_io_parameter_op_batch_advance_timeline(
     IREE_RETURN_AND_END_ZONE_IF_ERROR(
         z0, iree_hal_semaphore_create(
                 batch->device, batch->timeline_values[timeline_index],
+                IREE_HAL_SEMAPHORE_FLAG_NONE,
                 &batch->timeline_semaphores[timeline_index]));
     timeline_semaphore = batch->timeline_semaphores[timeline_index];
   }

--- a/runtime/src/iree/modules/check/module.cc
+++ b/runtime/src/iree/modules/check/module.cc
@@ -217,7 +217,8 @@ TransferBuffersToHost(
 
   IREE_RETURN_IF_ERROR(iree_hal_command_buffer_end(command_buffer.get()));
   vm::ref<iree_hal_semaphore_t> semaphore;
-  IREE_RETURN_IF_ERROR(iree_hal_semaphore_create(device, 0ull, &semaphore));
+  IREE_RETURN_IF_ERROR(iree_hal_semaphore_create(
+      device, 0ull, IREE_HAL_SEMAPHORE_FLAG_NONE, &semaphore));
   vm::ref<iree_hal_fence_t> fence;
   IREE_RETURN_IF_ERROR(iree_hal_fence_create_at(
       semaphore.get(), 1ull, iree_hal_device_host_allocator(device), &fence));

--- a/runtime/src/iree/modules/hal/module.c
+++ b/runtime/src/iree/modules/hal/module.c
@@ -1305,7 +1305,8 @@ IREE_VM_ABI_EXPORT(iree_hal_module_fence_create,  //
   // This should be reworked to just create the fence.
 
   iree_hal_semaphore_t* semaphore = NULL;
-  IREE_RETURN_IF_ERROR(iree_hal_semaphore_create(device, 0ull, &semaphore));
+  IREE_RETURN_IF_ERROR(iree_hal_semaphore_create(
+      device, 0ull, IREE_HAL_SEMAPHORE_FLAG_NONE, &semaphore));
 
   // Create fence with room for our single semaphore.
   iree_hal_fence_t* fence = NULL;

--- a/runtime/src/iree/tooling/function_util.c
+++ b/runtime/src/iree/tooling/function_util.c
@@ -25,7 +25,8 @@ iree_status_t iree_tooling_append_async_fences(
   // Create the signal fence as a 0->1 transition. The caller will wait on that.
   iree_hal_semaphore_t* semaphore = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_hal_semaphore_create(device, 0ull, &semaphore));
+      z0, iree_hal_semaphore_create(device, 0ull, IREE_HAL_SEMAPHORE_FLAG_NONE,
+                                    &semaphore));
   iree_hal_fence_t* signal_fence = NULL;
   iree_status_t status = iree_hal_fence_create_at(
       semaphore, 1ull, iree_hal_device_host_allocator(device), &signal_fence);
@@ -109,7 +110,8 @@ static iree_status_t iree_tooling_submit_transfer(
   if (needs_wait) {
     iree_hal_semaphore_t* semaphore = NULL;
     IREE_RETURN_AND_END_ZONE_IF_ERROR(
-        z0, iree_hal_semaphore_create(device, 0ull, &semaphore));
+        z0, iree_hal_semaphore_create(
+                device, 0ull, IREE_HAL_SEMAPHORE_FLAG_NONE, &semaphore));
     status = iree_hal_fence_create_at(
         semaphore, 1ull, iree_hal_device_host_allocator(device), &signal_fence);
     iree_hal_semaphore_release(semaphore);

--- a/samples/custom_module/async/main.c
+++ b/samples/custom_module/async/main.c
@@ -105,7 +105,8 @@ int main(int argc, char** argv) {
   // We'll pass these in with the timeline at T=0 so that the runtime isn't
   // allowed to execute anything until we give it the go-ahead.
   iree_hal_semaphore_t* semaphore = NULL;
-  IREE_CHECK_OK(iree_hal_semaphore_create(device, 0ull, &semaphore));
+  IREE_CHECK_OK(iree_hal_semaphore_create(
+      device, 0ull, IREE_HAL_SEMAPHORE_FLAG_NONE, &semaphore));
   iree_hal_fence_t* fence_t1 = NULL;
   IREE_CHECK_OK(
       iree_hal_fence_create_at(semaphore, 1ull, host_allocator, &fence_t1));

--- a/samples/custom_module/async/module.cc
+++ b/samples/custom_module/async/module.cc
@@ -202,8 +202,8 @@ class CustomModuleState final {
       const vm::ref<iree_hal_fence_t> signal_fence) {
     // TODO(benvanik): better fence helpers when timelines are not needed.
     vm::ref<iree_hal_semaphore_t> semaphore;
-    IREE_RETURN_IF_ERROR(
-        iree_hal_semaphore_create(device_.get(), 0ull, &semaphore));
+    IREE_RETURN_IF_ERROR(iree_hal_semaphore_create(
+        device_.get(), 0ull, IREE_HAL_SEMAPHORE_FLAG_NONE, &semaphore));
     vm::ref<iree_hal_fence_t> alloca_fence;
     IREE_RETURN_IF_ERROR(iree_hal_fence_create_at(
         semaphore.get(), 1ull, host_allocator_, &alloca_fence));

--- a/tools/iree-benchmark-executable-main.c
+++ b/tools/iree-benchmark-executable-main.c
@@ -221,8 +221,9 @@ static iree_status_t iree_benchmark_executable_run(
 
   iree_hal_semaphore_t* fence_semaphore = NULL;
   uint64_t fence_value = 0ull;
-  IREE_RETURN_IF_ERROR(
-      iree_hal_semaphore_create(args->device, fence_value, &fence_semaphore));
+  IREE_RETURN_IF_ERROR(iree_hal_semaphore_create(args->device, fence_value,
+                                                 IREE_HAL_SEMAPHORE_FLAG_NONE,
+                                                 &fence_semaphore));
   iree_hal_semaphore_list_t wait_semaphore_list =
       iree_hal_semaphore_list_empty();
   iree_hal_semaphore_list_t signal_semaphore_list = {

--- a/tools/iree-benchmark-module-main.cc
+++ b/tools/iree-benchmark-module-main.cc
@@ -252,8 +252,8 @@ static void BenchmarkAsyncFunction(
     std::vector<vm::ref<iree_hal_semaphore_t>> timeline_semaphores;
     for (int32_t i = 0; i < batch_concurrency; ++i) {
       vm::ref<iree_hal_semaphore_t> timeline_semaphore;
-      IREE_CHECK_OK(
-          iree_hal_semaphore_create(device, 0ull, &timeline_semaphore));
+      IREE_CHECK_OK(iree_hal_semaphore_create(
+          device, 0ull, IREE_HAL_SEMAPHORE_FLAG_NONE, &timeline_semaphore));
       timeline_semaphores.push_back(std::move(timeline_semaphore));
     }
 


### PR DESCRIPTION
Events also gain a queue affinity that can be used to indicate which queues a particular event may be set/waited on. The flags are currently unused but will allow us to specify behavior modes in the future (such as making exportable semaphores opt-in).

Since semaphores and events aren't yet exposed in the compiler there were no changes needed there. The compiler will not (in common usage) ever return new semaphores so will not need exportable flags and other things we'll potentially add - applications will be setting those via the C API.

Progress on #18121 (event queue affinity needed for [VK_KHR_device_group](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_device_group.html)).