### PR TITLE
E2e gpu convolution test

### DIFF
--- a/tests/e2e/convolution/CMakeLists.txt
+++ b/tests/e2e/convolution/CMakeLists.txt
@@ -324,7 +324,6 @@ iree_generated_e2e_runner_test(
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###
 
-set(IREE_HIP_TEST_TARGET_CHIP gfx942)
 # To distinguish between CDNA(gfx9) and RDNA3(gfx11)
 if(IREE_HIP_TEST_TARGET_CHIP MATCHES "^gfx9")
 

--- a/tests/e2e/convolution/CMakeLists.txt
+++ b/tests/e2e/convolution/CMakeLists.txt
@@ -323,3 +323,177 @@ iree_generated_e2e_runner_test(
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###
+
+set(IREE_HIP_TEST_TARGET_CHIP gfx942)
+# To distinguish between CDNA(gfx9) and RDNA3(gfx11)
+if(IREE_HIP_TEST_TARGET_CHIP MATCHES "^gfx9")
+
+unset(IREE_HIP_TEST_COMPILER_FLAGS)
+list(APPEND IREE_HIP_TEST_COMPILER_FLAGS
+  "--iree-rocm-target-chip=${IREE_HIP_TEST_TARGET_CHIP}"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_conv2d_rocm_f16_f16_f32_large_cdna3
+  TEST_TYPE
+    conv2d
+  GENERATOR
+    "generate_e2e_conv2d_tests.py"
+  GENERATOR_ARGS
+    "--input_type=f16"
+    "--input_layout=nhwc"
+    "--kernel_type=f16"
+    "--kernel_layout=hwcf"
+    "--acc_type=f32"
+    "--shapes=gpu_large"
+    "--compilation_info=LLVMGPUVectorDistributeMFMA"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-conv2d-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-cdna3"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_conv2d_rocm_f16_f16_f32_large_gpu_vectorize_cdna3
+  TEST_TYPE
+    conv2d
+  GENERATOR
+    "generate_e2e_conv2d_tests.py"
+  GENERATOR_ARGS
+    "--input_type=f16"
+    "--input_layout=nhwc"
+    "--kernel_type=f16"
+    "--kernel_layout=hwcf"
+    "--acc_type=f32"
+    "--shapes=gpu_large"
+    "--compilation_info=LLVMGPUVectorizeCDNA"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-conv2d-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-cdna3"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_conv2d_rocm_nchw_f16_f16_f32_large_gpu_vectorize_cdna3
+  TEST_TYPE
+    conv2d
+  GENERATOR
+    "generate_e2e_conv2d_tests.py"
+  GENERATOR_ARGS
+    "--input_type=f16"
+    "--input_layout=nchw"
+    "--kernel_type=f16"
+    "--kernel_layout=fchw"
+    "--acc_type=f32"
+    "--shapes=gpu_large"
+    "--compilation_info=LLVMGPUVectorizeCDNA"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-conv2d-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-cdna3"
+)
+
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_conv2d_rocm_i8_large_cdna3
+  TEST_TYPE
+    conv2d
+  GENERATOR
+    "generate_e2e_conv2d_tests.py"
+  GENERATOR_ARGS
+    "--input_type=i8"
+    "--input_layout=nhwc"
+    "--kernel_type=i8"
+    "--kernel_layout=hwcf"
+    "--acc_type=i32"
+    "--shapes=gpu_large"
+    "--compilation_info=LLVMGPUVectorDistributeMFMA"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-conv2d-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-cdna3"
+)
+
+elseif(IREE_HIP_TEST_TARGET_CHIP MATCHES "^gfx11")
+
+unset(IREE_HIP_TEST_COMPILER_FLAGS)
+list(APPEND IREE_HIP_TEST_COMPILER_FLAGS
+  "--iree-rocm-target-chip=${IREE_HIP_TEST_TARGET_CHIP}"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_conv2d_rocm_f16_f16_f32_large_cdna3
+  TEST_TYPE
+    conv2d
+  GENERATOR
+    "generate_e2e_conv2d_tests.py"
+  GENERATOR_ARGS
+    "--input_type=f16"
+    "--input_layout=nhwc"
+    "--kernel_type=f16"
+    "--kernel_layout=hwcf"
+    "--acc_type=f32"
+    "--shapes=gpu_large"
+    "--compilation_info=LLVMGPUVectorDistributeWMMA"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-conv2d-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-rdna3"
+)
+
+endif()

--- a/tests/e2e/convolution/generate_e2e_conv2d_tests.py
+++ b/tests/e2e/convolution/generate_e2e_conv2d_tests.py
@@ -584,13 +584,6 @@ def generate_function(
     if compilation_info:
         requested_pipeline = compilation_info.dispatch_lowering_pass_pipeline
         compiler_pipeline = requested_pipeline
-        if requested_pipeline == "SPIRVVectorizeMali":
-            compiler_pipeline = "SPIRVBaseVectorize"
-        elif requested_pipeline == "SPIRVCooperativeMatrixVectorize":
-            compiler_pipeline = "SPIRVCooperativeMatrixVectorize"
-        elif requested_pipeline == "SPIRVVectorizeNVIDIA":
-            # TODO: change to test SPIRVMatmulPromoteVectorize too
-            compiler_pipeline = "SPIRVBaseVectorize"
 
         mma_schedule = ""
         if compilation_info.mma_schedule is not None:
@@ -608,9 +601,7 @@ def generate_function(
             f"  {{ pipeline_depth = {compilation_info.software_pipeline_depth}, "
             f"  store_stage = 1{mma_schedule} }}>>\n"
         )
-        # compilation_info_attr = (
-        #     f"{{compilation_info = #compilation{generate_function.compilation_index}}} "
-        # )
+
         func_definition = func_definition + compilation_info_string
         conv_attr = f"{{compilation_info = #compilation{generate_function.compilation_index}, dilations = dense<{list(conv2d_attr.DILATION)}> : tensor<2xi64>, strides = dense<{list(conv2d_attr.STRIDE)}> : tensor<2xi64>}}"
         generate_function.compilation_index += 1

--- a/tools/testing/e2e/iree-e2e-conv2d-test.cc
+++ b/tools/testing/e2e/iree-e2e-conv2d-test.cc
@@ -9,8 +9,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <stdexcept>
-
 #include "iree/base/api.h"
 #include "iree/base/internal/flags.h"
 #include "iree/base/internal/math.h"


### PR DESCRIPTION
- Added end-to-end (e2e) tests for the VectorDistribute pipeline.
- Added end-to-end (e2e) tests for the GPUVectorize pipeline.
- Updated the correctness check to be layout-based, considering that the output tensor can have different layouts.
- Correct some hidden bugs in the existing code base like `acc_type` is as same as `input_type`, the `kernel_layout` remains same while it should be different, etc.

Note: The numerical behavior of the VectorDistribute pipeline is unstable. Occasionally, tests related to this pipeline may fail.
