### PR TITLE
[Flow] Fix error in CollapseDimensionsPass

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/CollapseDimensions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/CollapseDimensions.cpp
@@ -650,7 +650,7 @@ hoistTensorReshapesOutOfDispatchRegion(RewriterBase &rewriter,
 // does this automatically).
 static void updateConsumersFromProducers(
     ArrayRef<Operation *> slice,
-    llvm::MapVector<linalg::GenericOp, CollapseInfo> &opMap) {
+    llvm::DenseMap<linalg::GenericOp, CollapseInfo> &opMap) {
 
   // Slice is topologically sorted to ensure that `op`'s producers have been
   // updated before we visit it.
@@ -703,7 +703,7 @@ static void updateConsumersFromProducers(
 // does this automatically).
 static void updateProducersFromConsumers(
     ArrayRef<Operation *> slice,
-    llvm::MapVector<linalg::GenericOp, CollapseInfo> &opMap) {
+    llvm::DenseMap<linalg::GenericOp, CollapseInfo> &opMap) {
 
   // Iterate over `slice` in reverse so that we visit each `op` 's consumer
   // before visiting `op`.
@@ -775,7 +775,7 @@ static bool collapseDimensionsForDispatch(IRRewriter &rewriter,
 
   // Step 3. Populate each op's info with a maximally collapsable reassociation
   // indicies
-  llvm::MapVector<linalg::GenericOp, CollapseInfo> opMap;
+  llvm::DenseMap<linalg::GenericOp, CollapseInfo> opMap;
   for (auto *op : slice) {
     auto genericOp = cast<linalg::GenericOp>(op);
     opMap[genericOp] = CollapseInfo(getCollapsibleLoops(genericOp));


### PR DESCRIPTION
There was a crash described in https://github.com/iree-org/iree/issues/18126. The problem was that I was getting a reference to `CollapseInfo` and then using the bracket operator to access the map (MapVector) again, which can modify the map and invalidate the reference. This was occurring because opMap was not populated with all the generic ops in the dispatch region (because of isEligibleForCollapse). The logic to find a producer/consumer looked for a generic with the same parent, which can include ops not in the map, causing elements to be added to the map when there was a reference to an object in the map.

In addition, I changed MapVector to DenseMap because there is no need to iterate over the map.
