### PR TITLE
Refer to usage terms for logo asset

### DIFF
--- a/LICENSES/LicenseRef-LF-trademark-usage.txt
+++ b/LICENSES/LicenseRef-LF-trademark-usage.txt
@@ -1,0 +1,2 @@
+Please refer to Linux Foundation Trademark Usage page to learn about the usage
+policy and guidelines: https://www.linuxfoundation.org/trademark-usage.

--- a/docs/website/docs/assets/images/IREE_Logo_Icon_Color.svg.license
+++ b/docs/website/docs/assets/images/IREE_Logo_Icon_Color.svg.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: The Linux Foundation
+SPDX-License-Identifier: LicenseRef-LF-trademark-usage


### PR DESCRIPTION
This points to the Linux Foundation Trademark Usage page which applies to the IREE logo asset.