### PR TITLE
Run opt-in GPU test jobs when changing tests/e2e/*.

### DIFF
--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -138,6 +138,8 @@ NVGPU_PATHS = [
     "runtime/src/iree/hal/drivers/cuda/*",
     # Common code likely enough to affect code paths unique to NVIDIA GPUs:
     "compiler/src/iree/compiler/GlobalOptimization/*",
+    # Tests.
+    "tests/e2e/*",
 ]
 
 AMDGPU_PATHS = [
@@ -146,6 +148,8 @@ AMDGPU_PATHS = [
     "runtime/src/iree/hal/drivers/hip/*",
     # Common code likely enough to affect code paths unique to AMDGPU:
     "compiler/src/iree/compiler/GlobalOptimization/*",
+    # Tests.
+    "tests/e2e/*",
 ]
 
 # Jobs to run in presumbit if files under the corresponding path see changes.


### PR DESCRIPTION
Would have been nice to run tests on https://github.com/iree-org/iree/pull/18134, without needing to use the `ci-extra` git trailer.