### PR TITLE
[GPU] Fix e2e matmul generator to extract the input element type.

### DIFF
--- a/tests/e2e/matmul/generate_e2e_matmul_tests.py
+++ b/tests/e2e/matmul/generate_e2e_matmul_tests.py
@@ -309,10 +309,10 @@ def get_rocm_test_compilation_infos(
     for schedule in schedules:
         # Skip schedules with an intrinsic which element type does not
         # match the requested one.
-        # Extracts the input type from strings containing either 'MFMA' or 'WMMA'
-        # followed by an underscore.
-        extract_input_type = lambda s: re.search(r"(?:MFMA|WMMA)_([^_]+)_", s).group(1)
-        if lhs_rhs_type.value.upper() != extract_input_type(schedule.intrinsic):
+        # Extracts the input type from strings. The naming convention is
+        # [output_type]_MxNxK_[input_type].
+        input_type = schedule.intrinsic.split('_')[-1]
+        if lhs_rhs_type.value.upper() != input_type:
             continue
 
         if schedule.intrinsic == "MFMA_F32_16x16x4_F32":

--- a/tests/e2e/matmul/generate_e2e_matmul_tests.py
+++ b/tests/e2e/matmul/generate_e2e_matmul_tests.py
@@ -311,7 +311,7 @@ def get_rocm_test_compilation_infos(
         # match the requested one.
         # Extracts the input type from strings. The naming convention is
         # [output_type]_MxNxK_[input_type].
-        input_type = schedule.intrinsic.split('_')[-1]
+        input_type = schedule.intrinsic.split("_")[-1]
         if lhs_rhs_type.value.upper() != input_type:
             continue
 


### PR DESCRIPTION
It is a follow-up for https://github.com/iree-org/iree/pull/18134#issuecomment-2273160595

ci-extra: build_packages,test_amd_mi250,test_amd_mi300,test_amd_w7900,test_nvidia_t4