### PR TITLE
[compiler][python] Make target_backends optional

### DIFF
--- a/compiler/bindings/python/iree/compiler/tools/core.py
+++ b/compiler/bindings/python/iree/compiler/tools/core.py
@@ -176,8 +176,6 @@ def build_compile_command_line(
       List of strings of command line.
     """
     iree_compile = find_tool("iree-compile")
-    if not options.target_backends:
-        raise ValueError("Expected a non-empty list for 'target_backends'")
 
     cl = [
         iree_compile,
@@ -185,8 +183,9 @@ def build_compile_command_line(
         f"--iree-input-type={options.input_type!s}",
         f"--iree-vm-bytecode-module-output-format={options.output_format!s}",
     ]
-    for target_backend in options.target_backends:
-        cl.append(f"--iree-hal-target-backends={target_backend}")
+    if options.target_backends is not None:
+        for target_backend in options.target_backends:
+            cl.append(f"--iree-hal-target-backends={target_backend}")
 
     # Output file.
     if options.output_file:

--- a/compiler/bindings/python/test/tools/compiler_core_test.py
+++ b/compiler/bindings/python/test/tools/compiler_core_test.py
@@ -32,12 +32,6 @@ class CompilerTest(unittest.TestCase):
         # The VMVX target is always enabled.
         self.assertIn("vmvx", target_names)
 
-    def testNoTargetBackends(self):
-        with self.assertRaisesRegex(
-            ValueError, "Expected a non-empty list for 'target_backends'"
-        ):
-            binary = iree.compiler.tools.compile_str(SIMPLE_MUL_ASM)
-
     def testCompileStr(self):
         binary = iree.compiler.tools.compile_str(
             SIMPLE_MUL_ASM, target_backends=iree.compiler.tools.DEFAULT_TESTING_BACKENDS


### PR DESCRIPTION
When compiling through the iree-compile executable don't require the target backend(s) to be specified.
It should be allowed to specify multiple target devices instead of multiple backends.
This is inline with the deprecation of the target backends CLI option.