### PR TITLE
Renaming iree_vm_native_function_target2_t.

### DIFF
--- a/runtime/src/iree/modules/hal/loader/module.c
+++ b/runtime/src/iree/modules/hal/loader/module.c
@@ -289,7 +289,7 @@ static iree_status_t iree_hal_loader_module_executable_dispatch(
 static iree_status_t iree_vm_shim_dispatch_v(
     iree_vm_stack_t* IREE_RESTRICT stack, iree_vm_native_function_flags_t flags,
     iree_byte_span_t args_storage, iree_byte_span_t rets_storage,
-    iree_vm_native_function_target2_t target_fn, void* IREE_RESTRICT module,
+    iree_vm_native_function_target_t target_fn, void* IREE_RESTRICT module,
     void* IREE_RESTRICT module_state) {
   // TODO(benvanik): support multiple variadic segments in one call.
   // For now we inline what it would do in a very painful way.

--- a/runtime/src/iree/modules/vmvx/module.c
+++ b/runtime/src/iree/modules/vmvx/module.c
@@ -239,7 +239,7 @@ IREE_VMVX_ABI_FIXED_STRUCT(ukernel_x32b_2d, rIIIrIIIrIIIII, {
 static iree_status_t iree_vm_shim_ukernel_x32b_2d_v(
     iree_vm_stack_t* IREE_RESTRICT stack, iree_vm_native_function_flags_t flags,
     iree_byte_span_t args_storage, iree_byte_span_t rets_storage,
-    iree_vm_native_function_target2_t target_fn, void* IREE_RESTRICT module,
+    iree_vm_native_function_target_t target_fn, void* IREE_RESTRICT module,
     void* IREE_RESTRICT module_state) {
   // TODO: Figure out how to identify this with the actual target fn.
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -308,7 +308,7 @@ IREE_VMVX_ABI_FIXED_STRUCT(ukernel_x32u_2d, rIIIrIIIII, {
 static iree_status_t iree_vm_shim_ukernel_x32u_2d_v(
     iree_vm_stack_t* IREE_RESTRICT stack, iree_vm_native_function_flags_t flags,
     iree_byte_span_t args_storage, iree_byte_span_t rets_storage,
-    iree_vm_native_function_target2_t target_fn, void* IREE_RESTRICT module,
+    iree_vm_native_function_target_t target_fn, void* IREE_RESTRICT module,
     void* IREE_RESTRICT module_state) {
   // TODO: Figure out how to identify this with the actual target fn.
   IREE_TRACE_ZONE_BEGIN(z0);

--- a/runtime/src/iree/vm/shims.h
+++ b/runtime/src/iree/vm/shims.h
@@ -66,7 +66,7 @@
 // Shim function declaration/definition and accessor utilities
 //===----------------------------------------------------------------------===//
 
-typedef iree_status_t(IREE_API_PTR* iree_vm_native_function_target2_t)(
+typedef iree_status_t(IREE_API_PTR* iree_vm_native_function_target_t)(
     iree_vm_stack_t* IREE_RESTRICT stack, void* IREE_RESTRICT module,
     void* IREE_RESTRICT module_state, const void* IREE_RESTRICT args,
     void* IREE_RESTRICT rets);
@@ -76,7 +76,7 @@ typedef iree_status_t(IREE_API_PTR* iree_vm_native_function_target2_t)(
       iree_vm_stack_t* IREE_RESTRICT stack,                                    \
       iree_vm_native_function_flags_t flags, iree_byte_span_t args_storage,    \
       iree_byte_span_t rets_storage,                                           \
-      iree_vm_native_function_target2_t target_fn, void* IREE_RESTRICT module, \
+      iree_vm_native_function_target_t target_fn, void* IREE_RESTRICT module, \
       void* IREE_RESTRICT module_state);
 
 #define IREE_VM_ABI_DEFINE_SHIM(arg_types, ret_types)                          \
@@ -84,7 +84,7 @@ typedef iree_status_t(IREE_API_PTR* iree_vm_native_function_target2_t)(
       iree_vm_stack_t* IREE_RESTRICT stack,                                    \
       iree_vm_native_function_flags_t flags, iree_byte_span_t args_storage,    \
       iree_byte_span_t rets_storage,                                           \
-      iree_vm_native_function_target2_t target_fn, void* IREE_RESTRICT module, \
+      iree_vm_native_function_target_t target_fn, void* IREE_RESTRICT module, \
       void* IREE_RESTRICT module_state) {                                      \
     const IREE_VM_ABI_TYPE_NAME(arg_types)* args =                             \
         iree_vm_abi_##arg_types##_checked_deref(args_storage);                 \


### PR DESCRIPTION
Fixing a TODO from February 3rd, 2021.