### PR TITLE
Switch from build_runtime.sh to inlined CMake commands.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,11 +168,6 @@ jobs:
             runs-on: macos-14
     env:
       BUILD_DIR: build-runtime
-      BUILD_PRESET: test
-      IREE_READ_REMOTE_CCACHE: 0
-      IREE_WRITE_REMOTE_CCACHE: 0
-      IREE_READ_LOCAL_CCACHE: 1
-      IREE_WRITE_LOCAL_CCACHE: ${{ needs.setup.outputs.write-caches }}
     steps:
       - uses: actions/checkout@v4.1.7
       - uses: actions/setup-python@v5.1.0
@@ -195,18 +190,29 @@ jobs:
 
       - name: Checkout runtime submodules
         run: bash ./build_tools/scripts/git/update_runtime_submodules.sh
-
+      - name: Install Python requirements
+        run: pip install -r ./runtime/bindings/python/iree/runtime/build_requirements.txt
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.job }}-${{ matrix.name }}
           save: ${{ needs.setup.outputs.write-caches == 1 }}
-
-      - name: Install Python requirements
-        run: pip install -r ./runtime/bindings/python/iree/runtime/build_requirements.txt
-      - name: Build runtime
-        run: bash ./build_tools/cmake/build_runtime.sh "${BUILD_DIR}"
-      - name: Test runtime
+      - name: CMake - configure
+        run: |
+          cmake \
+            -G Ninja \
+            -B ${BUILD_DIR} \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DIREE_BUILD_COMPILER=OFF \
+            -DIREE_BUILD_PYTHON_BINDINGS=ON \
+            -DIREE_BUILD_SAMPLES=ON \
+            -DIREE_ENABLE_LLD=ON \
+            -DIREE_ENABLE_ASSERTIONS=ON
+      - name: CMake - build
+        run: cmake --build ${BUILD_DIR} -- -k 0
+      - name: CTest
         run: bash ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
 
   small_runtime:


### PR DESCRIPTION
I'm trying to reduce the number of scripts that we have in [`build_tools/cmake/`](https://github.com/iree-org/iree/tree/main/build_tools/cmake), so changes like https://github.com/iree-org/iree/pull/17996 will be easier to make with confidence.

This makes the `build_test_runtime` CI job no longer depend on these scripts:
* [`build_tools/cmake/build_runtime.sh`](https://github.com/iree-org/iree/blob/main/build_tools/cmake/build_runtime.sh)
  * After this, the last use will be deleted in https://github.com/iree-org/iree/pull/18144
* [`build_tools/cmake/setup_build.sh`](https://github.com/iree-org/iree/blob/main/build_tools/cmake/setup_build.sh)
* [`build_tools/cmake/setup_ccache.sh`](https://github.com/iree-org/iree/blob/main/build_tools/cmake/setup_ccache.sh)

These layers of scripts made it somewhat easier to have CI workflows just run scripts, but the scripts grew branches over time that obscured what was actually running. In many cases the commands are quite simple and can just be inlined.

Other ideas for simplification:
* Use https://github.com/marketplace/actions/get-cmake to install Ninja across platforms (with caching)
* Use https://github.com/marketplace/actions/run-cmake together with CMake presets ("configure"/"build"/"test", possibly also "workflow")
* Reduce reliance on [`build_tools/cmake/ctest_all.sh`](https://github.com/iree-org/iree/blob/main/build_tools/cmake/ctest_all.sh) - that excludes some tests based on platform (e.g. Windows) and adds exclude labels for tests that need special hardware (e.g. GPUs), but ideally `ctest` would work out of the box without such a script

ci-exactly: build_test_runtime