### PR TITLE
[Codegen][CPU] Eliminate all-true vector masks after vectorization

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization.mlir
@@ -457,7 +457,6 @@ func.func @depthwise_conv_fold_away_masking(%arg0: tensor<1x68x120x96xf32>, %arg
   attributes {hal.executable.target = #aarch64_sve}
 {
   %c3 = arith.constant 3 : index
-  %c96 = arith.constant 96 : index
   %c120 = arith.constant 120 : index
   %c68 = arith.constant 68 : index
   %c4 = arith.constant 4 : index


### PR DESCRIPTION
This enables an upstream transform that eliminates all true `vector.create_mask` ops. This is particularly beneficial for scalable vectors, which use dynamic tensor types, which results in masks that otherwise would not fold away till much later, preventing some optimizations.

Depends on llvm/llvm-project#99314.