### PR TITLE
Make `iree_gpu.value_barrier` accept multiple operands (and return multiple results)

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -361,9 +361,32 @@ LogicalResult ShuffleTensorOp::verifyRegions() {
 //===----------------------------------------------------------------------===//
 
 void ValueBarrierOp::build(OpBuilder &builder, OperationState &result,
-                           Value input) {
-  result.addOperands({input});
-  result.addTypes(input.getType());
+                           ValueRange input) {
+  result.addOperands(input);
+  result.addTypes(llvm::map_range(input, [](Value v) { return v.getType(); }));
+}
+
+LogicalResult ValueBarrierOp::verify() {
+  // Make sure we either have all tensors or all vectors.
+  if (hasTensorSemantics()) {
+    bool allTensor = llvm::all_of(getInputTypes(), [](ShapedType ty) {
+      return isa<RankedTensorType>(ty);
+    });
+    if (!allTensor) {
+      return emitOpError(
+          "All inputs should be either of tensor or vector type");
+    }
+    return success();
+  }
+
+  bool allVector = llvm::all_of(
+      getInputTypes(), [](ShapedType ty) { return isa<VectorType>(ty); });
+
+  if (!allVector) {
+    return emitOpError("All inputs should be either of tensor or vector type");
+  }
+
+  return success();
 }
 
 } // namespace mlir::iree_compiler::IREE::GPU

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -438,39 +438,50 @@ def IREEGPU_ShuffleTensorOp : Op<IREEGPU_Dialect, "shuffle_tensor", [
 //===----------------------------------------------------------------------===//
 
 def IREEGPU_ValueBarrierOp : Op<IREEGPU_Dialect, "value_barrier", [
-    Pure,
-    AllTypesMatch<["input", "result"]>,
-    ]> {
+  Pure,
+  AllTypesMatch<["inputs", "results"]>]> {
   let summary = "Shuffles a private tensor across a shared allocation";
   let description = [{
-    This operation acts as a barrier on a value semantic SSA value (tensor or
-    vector). It takes a single operand and produces a value equivalent to the
+    This operation acts as a barrier on a value semantic SSA values (tensor or
+    vector). It takes multiple operands and produces a value equivalent to each
     input. This does not have copy and/or data movement semantics and simply
     represents a barrier on all writes in the tensor case, and a barrier until
     all threads acquire the input vector in the vector case.
+
+    The inputs must be either all tensors, or all vectors.
 
     This operation is a no-op when not present in a parallel context. This
     operation is pure as it only requires synchronization for the value it
     produces.
   }];
 
-  let arguments = (ins AnyRankedTensorOrVector:$input);
-  let results = (outs AnyRankedTensorOrVector:$result);
+  let arguments = (ins  Variadic<AnyRankedTensorOrVector>:$inputs);
+  let results   = (outs Variadic<AnyRankedTensorOrVector>:$results);
 
   let assemblyFormat = [{
-    $input attr-dict `:` type($result)
+    $inputs attr-dict `:` type($inputs)
   }];
 
   let builders = [
-    OpBuilder<(ins "Value":$input)>
+    OpBuilder<(ins "ValueRange":$inputs)>
   ];
+
+  let hasVerifier = 1;
 
   let extraClassDeclaration = [{
     bool hasTensorSemantics() {
-      return isa<::mlir::RankedTensorType>(getInput().getType());
+      return isa<::mlir::RankedTensorType>(getOperand(0).getType());
     }
-    ::mlir::ShapedType getInputType() {
-      return ::llvm::cast<::mlir::ShapedType>(getInput().getType());
+    ::mlir::ShapedType getInputType(int operandNum) {
+      return ::llvm::cast<::mlir::ShapedType>(
+          getInputs()[operandNum].getType());
+    }
+    SmallVector<::mlir::ShapedType> getInputTypes() {
+      return llvm::map_to_vector(
+          getInputs(),
+          [](Value v) {
+            return ::llvm::cast<::mlir::ShapedType>(v.getType());
+          });
     }
   }];
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
@@ -243,11 +243,22 @@ func.func @vector_barrier(%input: vector<8xf16>) -> vector<8xf16> {
 
 // -----
 
-func.func @vector_barrier(%input: vector<8xf16>) -> (vector<8xf16>, vector<8xf16>) {
+func.func @vector_barrier_multiple_inputs(%input: vector<8xf16>) -> (vector<8xf16>, vector<8xf16>) {
   %out:2 = iree_gpu.value_barrier %input, %input : vector<8xf16>, vector<8xf16>
   return %out#0, %out#1 : vector<8xf16>, vector<8xf16>
 }
 
-// CHECK-LABEL: func @vector_barrier
+// CHECK-LABEL: func @vector_barrier_multiple_inputs
 //  CHECK-SAME:   %[[INPUT:[A-Za-z0-9]+]]: vector<8xf16>
 //       CHECK:   iree_gpu.value_barrier %[[INPUT]], %[[INPUT]] : vector<8xf16>, vector<8xf16>
+
+// -----
+
+func.func @tensor_barrier_multiple_inputs(%input: tensor<?xf16>) -> (tensor<?xf16>, tensor<?xf16>) {
+  %out:2 = iree_gpu.value_barrier %input, %input : tensor<?xf16>, tensor<?xf16>
+  return %out#0, %out#1 : tensor<?xf16>, tensor<?xf16>
+}
+
+// CHECK-LABEL: func @tensor_barrier_multiple_inputs
+//  CHECK-SAME:   %[[INPUT:[A-Za-z0-9]+]]: tensor<?xf16>
+//       CHECK:   iree_gpu.value_barrier %[[INPUT]], %[[INPUT]] : tensor<?xf16>, tensor<?xf16>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
@@ -240,3 +240,14 @@ func.func @vector_barrier(%input: vector<8xf16>) -> vector<8xf16> {
 // CHECK-LABEL: func @vector_barrier
 //  CHECK-SAME:   %[[INPUT:[A-Za-z0-9]+]]: vector<8xf16>
 //       CHECK:   iree_gpu.value_barrier %[[INPUT]] : vector<8xf16>
+
+// -----
+
+func.func @vector_barrier(%input: vector<8xf16>) -> (vector<8xf16>, vector<8xf16>) {
+  %out:2 = iree_gpu.value_barrier %input, %input : vector<8xf16>, vector<8xf16>
+  return %out#0, %out#1 : vector<8xf16>, vector<8xf16>
+}
+
+// CHECK-LABEL: func @vector_barrier
+//  CHECK-SAME:   %[[INPUT:[A-Za-z0-9]+]]: vector<8xf16>
+//       CHECK:   iree_gpu.value_barrier %[[INPUT]], %[[INPUT]] : vector<8xf16>, vector<8xf16>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/lower_vector_barrier.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/lower_vector_barrier.mlir
@@ -5,6 +5,13 @@ func.func @lower_value_barrier(%input: vector<4xf32>) -> vector<4xf32> {
   return %0 : vector<4xf32>
 }
 
+func.func @lower_value_barrier_multiple_inputs(%input: vector<4xf32>,
+                                               %input_t : vector<4xf32>)
+                                               -> (vector<4xf32>, vector<4xf32>) {
+  %0:2 = iree_gpu.value_barrier %input, %input_t : vector<4xf32>, vector<4xf32>
+  return %0#0, %0#1 : vector<4xf32>, vector<4xf32>
+}
+
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
     %func = transform.structured.match ops{["func.func"]} in %root : (!transform.any_op) -> !transform.any_op
@@ -19,3 +26,9 @@ module attributes { transform.with_named_sequence } {
 //  CHECK-SAME:   %[[INPUT:[A-Za-z0-9]+]]: vector<4xf32>
 //  CHECK-NEXT:   gpu.barrier
 //  CHECK-NEXT:   return %[[INPUT]]
+
+// CHECK-LABEL: func @lower_value_barrier_multiple_inputs
+//  CHECK-SAME:   %[[INPUT:[A-Za-z0-9]+]]: vector<4xf32>
+//  CHECK-SAME:   %[[INPUT_T:[A-Za-z0-9]+]]: vector<4xf32>
+//  CHECK-NEXT:   gpu.barrier
+//  CHECK-NEXT:   return %[[INPUT]], %[[INPUT_T]]


### PR DESCRIPTION
This patch extends the iree_gpu.value_barrier op to accept multiple inputs/results. This allows us to do optimizations like combining multiple value_barriers into 1 op. Optimizations will be submitted as further patches.