### PR TITLE
[GPU] Add support for materializing contraction ops.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.h
@@ -52,11 +52,7 @@ public:
     return materializeEncodingFn;
   }
 
-  IREE::HAL::ExecutableTargetAttr getTargetAttr() const {
-    puts("hi");
-    targetAttr.dump();
-    return targetAttr;
-  }
+  IREE::HAL::ExecutableTargetAttr getTargetAttr() const { return targetAttr; }
 
   FailureOr<MaterializeEncodingInfo>
   getEncodingInfo(RankedTensorType type) const {

--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.h
@@ -52,7 +52,11 @@ public:
     return materializeEncodingFn;
   }
 
-  IREE::HAL::ExecutableTargetAttr getTargetAttr() const { return targetAttr; }
+  IREE::HAL::ExecutableTargetAttr getTargetAttr() const {
+    puts("hi");
+    targetAttr.dump();
+    return targetAttr;
+  }
 
   FailureOr<MaterializeEncodingInfo>
   getEncodingInfo(RankedTensorType type) const {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUMaterializeEncoding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUMaterializeEncoding.cpp
@@ -427,9 +427,6 @@ public:
       LLVM_DEBUG(llvm::dbgs() << "can't find supported Mma intrinsic\n");
       return failure();
     }
-    mma =
-        IREE::GPU::MMAAttr::get(op.getContext(), mma->getIntrinsic().getValue(),
-                                /*isDataTiled=*/true);
     LLVM_DEBUG(llvm::dbgs() << "Target MMA: " << mma.value() << "\n");
 
     FailureOr<linalg::ContractionDimensions> contractionDims =
@@ -459,11 +456,56 @@ public:
         linalgOp.getIteratorTypesArray();
 
     // TODO(hanchung): Support batch gemms.
+    // The current multi_mma op is not able to represent the data-tiled mma
+    // layouts. There are internal details about layout after we data-tile a
+    // matrix. The matrix is in row-major fashion for outer dimensions. The
+    // inner dimensions were in row-major, and then we swizzle them to be
+    // column-major. The number of inner dimensions is greater than 2 after tile
+    // swizzling. Here we use the "row-major" layout for inner dimensions. The
+    // shape is exacatly innerTile[0]xinnerTile[1] where innerTile can be
+    // derived from the encoding info. The chunk of the inner tiles are in
+    // column-major fashion, but it does not really matter. Because they are
+    // opaque. I don't find a way to represent it, so I added a
+    // `__is_data_tiled__` magic attribute to the op. The expectation is that
+    // there is a pass to resolve the `__is_data_tiled__` attribute before
+    // additional lowering. It should unroll the op and resolve the layout; each
+    // multi_mma op maps to a single intrisic at subgroup level. Then we do the
+    // lowering that we've been doing in TileAndFuse pipeline.
+    //
+    // E.g., say that the intrinsic is MFMA_f32_16x16x4_f32, and the unrolling
+    // factors for [M, N, K] are [2, 4, 1], then we have:
+    //
+    //   iree_gpu.multi_mma %lhs, %rhs, %acc {
+    //     kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
+    //     lhs_permutation = array<i64: 0, 1>,
+    //     rhs_permutation = array<i64: 0, 1>,
+    //     __is_data_tiled__
+    //   } : tensor<?x?x32x4xf32>, tensor<?x?x16x4xf32>
+    //     into tensor<?x?x32x64xf32>
+    //
+    // The data-tiled chunk represents in row-major favor, so the permutation is
+    // identiy; the `__is_data_tiled__` attribute is attached.
+    //
+    // Then we resolve the `__is_data_tiled__` layout, which do the unrolling.
+    // It becomes a sequence of
+    //
+    //   iree_gpu.multi_mma %lhs_i, %rhs_i, %acc_i {
+    //     kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
+    //     lhs_permutation = array<i64: 1, 0>,
+    //     rhs_permutation = array<i64: 1, 0>,
+    //   } : tensor<?x?x4x16xf32>, tensor<?x?x4x16xf32>
+    //     into tensor<?x?x16x16xf32>
+    //
+    // This is what we usually have in TileAndFuse pipeline. IMO, this step
+    // happens after we distribute the op to subgroups/threads; before we
+    // distribute them to lanes.
     Location loc = op.getLoc();
+    SmallVector<int64_t> identityPerm = {0, 1};
     auto mmaOp = rewriter.create<IREE::GPU::MultiMmaOp>(
         loc, operands[0], operands[1], operands[2],
-        ArrayRef<AffineMap>{lhsMap, rhsMap, accMap}, iteratorTypes,
-        mma.value());
+        ArrayRef<AffineMap>{lhsMap, rhsMap, accMap}, iteratorTypes, mma.value(),
+        identityPerm, identityPerm, identityPerm);
+    mmaOp->setAttr("__is_data_tiled__", rewriter.getUnitAttr());
     rewriter.replaceOp(op, mmaOp);
     return success();
   }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUMaterializeEncoding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUMaterializeEncoding.cpp
@@ -6,15 +6,22 @@
 
 #include "iree/compiler/Codegen/Common/EncodingUtils.h"
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h"
+#include "iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingDialect.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/LogicalResult.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tensor/Transforms/Transforms.h"
@@ -22,6 +29,7 @@
 #include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
 #include "mlir/IR/BuiltinTypeInterfaces.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/MLIRContext.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "iree-codegen-gpu-materialize-encoding"
@@ -365,6 +373,98 @@ struct GPUUnsetEncodingOpLoweringConversion
   }
 };
 
+class GPUConvertToMultiMma final
+    : public OpInterfaceConversionPattern<linalg::ContractionOpInterface> {
+public:
+  using OpInterfaceConversionPattern<
+      linalg::ContractionOpInterface>::OpInterfaceConversionPattern;
+
+  GPUConvertToMultiMma(
+      MLIRContext *context,
+      const MaterializeEncodingTypeConverter &typeConverter,
+      MaterializeEncodingValueFn materializeEncodingValueFn = {},
+      PatternBenefit benefit = 1)
+      : OpInterfaceConversionPattern<mlir::linalg::ContractionOpInterface>(
+            typeConverter, context, benefit),
+        materializeEncodingValueFn(materializeEncodingValueFn) {}
+
+  LogicalResult
+  matchAndRewrite(linalg::ContractionOpInterface op, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto linalgOp = cast<linalg::LinalgOp>(op.getOperation());
+    auto inputs = linalgOp.getDpsInputOperands();
+    auto outputs = linalgOp.getDpsInits();
+    auto lhsType = cast<RankedTensorType>(inputs[0]->get().getType());
+    auto rhsType = cast<RankedTensorType>(inputs[1]->get().getType());
+    auto resultType = cast<RankedTensorType>(outputs[0].getType());
+    auto lhsEncoding = IREE::Encoding::getEncodingAttr(lhsType);
+    auto rhsEncoding = IREE::Encoding::getEncodingAttr(rhsType);
+    auto resultEncoding = IREE::Encoding::getEncodingAttr(resultType);
+    if (!lhsEncoding || !rhsEncoding || !resultEncoding) {
+      LLVM_DEBUG(llvm::dbgs() << "expect encodings on operand types\n");
+      return failure();
+    }
+
+    auto converter = static_cast<const MaterializeEncodingTypeConverter *>(
+        getTypeConverter());
+
+    IREE::GPU::TargetAttr gpuTargetAttr =
+        getGPUTargetAttr(converter->getTargetAttr());
+    auto elementTypes = llvm::to_vector(llvm::map_range(
+        resultEncoding.getElementTypes().getValue(),
+        [](Attribute a) { return cast<TypeAttr>(a).getValue(); }));
+    std::optional<IREE::GPU::MMAAttr> mma =
+        enumerateMmaIntrinsic(elementTypes, gpuTargetAttr);
+
+    if (!mma) {
+      LLVM_DEBUG(llvm::dbgs() << "can't find supported Mma intrinsic\n");
+      return failure();
+    }
+    LLVM_DEBUG(llvm::dbgs() << "Kind: " << mma.value() << "\n");
+
+    FailureOr<linalg::ContractionDimensions> contractionDims =
+        linalg::inferContractionDims(linalgOp);
+    assert(
+        succeeded(contractionDims) &&
+        "should always be able to infer contraction dims for contraction ops");
+   // TODO(hanchung): Support batch gemms.
+    if (!contractionDims->batch.empty()) {
+      LLVM_DEBUG(llvm::dbgs() << "batch gemm is not yet implemented\n");
+      return failure();
+    }
+
+    // TODO(hanchung): Support unrolling cases. We likely need to teach
+    // multi_mma op about interleaving K dimension.
+    MLIRContext *ctx = rewriter.getContext();
+    AffineExpr d0, d1, d2;
+    bindDims(ctx, d0, d1, d2);
+    AffineExpr mExpr = rewriter.getAffineDimExpr(0);
+    AffineExpr nExpr = rewriter.getAffineDimExpr(1);
+    AffineExpr kExpr = rewriter.getAffineDimExpr(2);
+
+    // The outer dims are all in row-major fasion after relayout.
+    auto lhsMap = AffineMap::get(3, 0, {mExpr, kExpr}, ctx);
+    auto rhsMap = AffineMap::get(3, 0, {nExpr, kExpr}, ctx);
+    auto accMap = AffineMap::get(3, 0, {mExpr, nExpr}, ctx);
+
+    SmallVector<utils::IteratorType> iteratorTypes =
+        linalgOp.getIteratorTypesArray();
+
+    // TODO(hanchung): Support batch gemms.
+    Location loc = op.getLoc();
+    SmallVector<int64_t> identityPerm = {0, 1};
+    auto mmaOp = rewriter.create<IREE::GPU::MultiMmaOp>(
+        loc, operands[0], operands[1], operands[2],
+        ArrayRef<AffineMap>{lhsMap, rhsMap, accMap}, iteratorTypes,
+        mma.value());
+    rewriter.replaceOp(op, mmaOp);
+    return success();
+  }
+
+protected:
+  const MaterializeEncodingValueFn materializeEncodingValueFn;
+};
+
 } // namespace
 
 void GPUMaterializeDeviceEncodingPass::runOnOperation() {
@@ -383,7 +483,7 @@ void GPUMaterializeDeviceEncodingPass::runOnOperation() {
         patterns, target, typeConverter, materializeEncodingValueFn);
 
     patterns.insert<GPUSetEncodingOpLoweringConversion,
-                    GPUUnsetEncodingOpLoweringConversion>(
+                    GPUUnsetEncodingOpLoweringConversion, GPUConvertToMultiMma>(
         ctx, typeConverter, materializeEncodingValueFn);
 
     if (failed(applyPartialConversion(funcOp, target, std::move(patterns)))) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUMaterializeEncoding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUMaterializeEncoding.cpp
@@ -42,10 +42,9 @@ namespace mlir::iree_compiler {
 
 /// Returns the corresponding native vector sizes defined by the `mma`
 /// intrinsic.
-static SmallVector<int64_t> getIntrinsicVectorSize(IREE::GPU::MMAAttr mma,
-                                                   int64_t roleIdx) {
-  if (mma.getIntrinsic().getValue() ==
-      IREE::GPU::MMAIntrinsic::MFMA_F32_16x16x4_F32) {
+static SmallVector<int64_t>
+getIntrinsicVectorSize(IREE::GPU::MMAIntrinsic mma, int64_t roleIdx) {
+  if (mma == IREE::GPU::MMAIntrinsic::MFMA_F32_16x16x4_F32) {
     // TODO: Query the value from GPU attributes.
     if (roleIdx == 0 || roleIdx == 1) {
       return {1, 1};
@@ -62,11 +61,10 @@ static SmallVector<int64_t> getIntrinsicVectorSize(IREE::GPU::MMAAttr mma,
 
 // Given encoding's role index and element types, return the transpose
 // permutation used in GPU materialization.
-static SmallVector<int64_t> getEncodingTransposePerm(IREE::GPU::MMAAttr mma,
-                                                     int64_t roleIdx) {
+static SmallVector<int64_t>
+getEncodingTransposePerm(IREE::GPU::MMAIntrinsic mma, int64_t roleIdx) {
   // TODO: Support other intrinsics.
-  if (mma.getIntrinsic().getValue() !=
-      IREE::GPU::MMAIntrinsic::MFMA_F32_16x16x4_F32) {
+  if (mma != IREE::GPU::MMAIntrinsic::MFMA_F32_16x16x4_F32) {
     return {};
   }
 
@@ -86,9 +84,10 @@ static SmallVector<int64_t> getEncodingTransposePerm(IREE::GPU::MMAAttr mma,
   }
 }
 
-static std::optional<IREE::GPU::MMAAttr>
+static std::optional<IREE::GPU::DataTiledMMAAttr>
 enumerateMmaIntrinsic(TypeRange elementTypes, IREE::GPU::TargetAttr target) {
   assert(elementTypes.size() == 3);
+  MLIRContext *ctx = target.getContext();
   Type lhs = elementTypes[0];
   Type rhs = elementTypes[1];
   Type out = elementTypes[2];
@@ -103,7 +102,7 @@ enumerateMmaIntrinsic(TypeRange elementTypes, IREE::GPU::TargetAttr target) {
     if (lhs != aType || rhs != bType || out != cType) {
       continue;
     }
-    return mma;
+    return IREE::GPU::DataTiledMMAAttr::get(ctx, mma.getIntrinsic().getValue());
   }
 
   // Fallback - no architecture-optimized tile size for this case.
@@ -136,7 +135,7 @@ materializeEncodingForTarget(RankedTensorType tensorType,
       llvm::map_range(encoding.getElementTypes().getValue(), [](Attribute a) {
         return cast<TypeAttr>(a).getValue();
       }));
-  std::optional<IREE::GPU::MMAAttr> mma =
+  std::optional<IREE::GPU::DataTiledMMAAttr> mma =
       enumerateMmaIntrinsic(elementTypes, gpuTargetAttr);
   if (!mma) {
     return failure();
@@ -152,11 +151,14 @@ materializeEncodingForTarget(RankedTensorType tensorType,
 
   // insert inner tile shapes and permutation info
   auto roleIdx = encoding.getOperandIndex().getInt();
-  auto intrinsicVectorSizes = getIntrinsicVectorSize(*mma, roleIdx);
-  auto permutation = getEncodingTransposePerm(*mma, roleIdx);
+  auto intrinsicVectorSizes =
+      getIntrinsicVectorSize(mma->getIntrinsic().getValue(), roleIdx);
+  auto permutation =
+      getEncodingTransposePerm(mma->getIntrinsic().getValue(), roleIdx);
   encodingInfo.innerTileShapes = intrinsicVectorSizes;
-  encodingInfo.intrinsicSize = {mma->getMSize(), mma->getNSize(),
-                                mma->getKSize()};
+  std::tuple<int64_t, int64_t, int64_t> mnkShape = mma->getMNKShape();
+  encodingInfo.intrinsicSize = {std::get<0>(mnkShape), std::get<1>(mnkShape),
+                                std::get<2>(mnkShape)};
   encodingInfo.permutation = permutation;
   return encodingInfo;
 }
@@ -421,7 +423,7 @@ public:
     auto elementTypes = llvm::to_vector(llvm::map_range(
         resultEncoding.getElementTypes().getValue(),
         [](Attribute a) { return cast<TypeAttr>(a).getValue(); }));
-    std::optional<IREE::GPU::MMAAttr> mma =
+    std::optional<IREE::GPU::DataTiledMMAAttr> mma =
         enumerateMmaIntrinsic(elementTypes, gpuTargetAttr);
     if (!mma) {
       LLVM_DEBUG(llvm::dbgs() << "can't find supported Mma intrinsic\n");
@@ -456,56 +458,11 @@ public:
         linalgOp.getIteratorTypesArray();
 
     // TODO(hanchung): Support batch gemms.
-    // The current multi_mma op is not able to represent the data-tiled mma
-    // layouts. There are internal details about layout after we data-tile a
-    // matrix. The matrix is in row-major fashion for outer dimensions. The
-    // inner dimensions were in row-major, and then we swizzle them to be
-    // column-major. The number of inner dimensions is greater than 2 after tile
-    // swizzling. Here we use the "row-major" layout for inner dimensions. The
-    // shape is exacatly innerTile[0]xinnerTile[1] where innerTile can be
-    // derived from the encoding info. The chunk of the inner tiles are in
-    // column-major fashion, but it does not really matter. Because they are
-    // opaque. I don't find a way to represent it, so I added a
-    // `__is_data_tiled__` magic attribute to the op. The expectation is that
-    // there is a pass to resolve the `__is_data_tiled__` attribute before
-    // additional lowering. It should unroll the op and resolve the layout; each
-    // multi_mma op maps to a single intrisic at subgroup level. Then we do the
-    // lowering that we've been doing in TileAndFuse pipeline.
-    //
-    // E.g., say that the intrinsic is MFMA_f32_16x16x4_f32, and the unrolling
-    // factors for [M, N, K] are [2, 4, 1], then we have:
-    //
-    //   iree_gpu.multi_mma %lhs, %rhs, %acc {
-    //     kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
-    //     lhs_permutation = array<i64: 0, 1>,
-    //     rhs_permutation = array<i64: 0, 1>,
-    //     __is_data_tiled__
-    //   } : tensor<?x?x32x4xf32>, tensor<?x?x16x4xf32>
-    //     into tensor<?x?x32x64xf32>
-    //
-    // The data-tiled chunk represents in row-major favor, so the permutation is
-    // identiy; the `__is_data_tiled__` attribute is attached.
-    //
-    // Then we resolve the `__is_data_tiled__` layout, which do the unrolling.
-    // It becomes a sequence of
-    //
-    //   iree_gpu.multi_mma %lhs_i, %rhs_i, %acc_i {
-    //     kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
-    //     lhs_permutation = array<i64: 1, 0>,
-    //     rhs_permutation = array<i64: 1, 0>,
-    //   } : tensor<?x?x4x16xf32>, tensor<?x?x4x16xf32>
-    //     into tensor<?x?x16x16xf32>
-    //
-    // This is what we usually have in TileAndFuse pipeline. IMO, this step
-    // happens after we distribute the op to subgroups/threads; before we
-    // distribute them to lanes.
     Location loc = op.getLoc();
-    SmallVector<int64_t> identityPerm = {0, 1};
     auto mmaOp = rewriter.create<IREE::GPU::MultiMmaOp>(
         loc, operands[0], operands[1], operands[2],
-        ArrayRef<AffineMap>{lhsMap, rhsMap, accMap}, iteratorTypes, mma.value(),
-        identityPerm, identityPerm, identityPerm);
-    mmaOp->setAttr("__is_data_tiled__", rewriter.getUnitAttr());
+        ArrayRef<AffineMap>{lhsMap, rhsMap, accMap}, iteratorTypes,
+        mma.value());
     rewriter.replaceOp(op, mmaOp);
     return success();
   }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUMaterializeEncoding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUMaterializeEncoding.cpp
@@ -427,6 +427,9 @@ public:
       LLVM_DEBUG(llvm::dbgs() << "can't find supported Mma intrinsic\n");
       return failure();
     }
+    mma =
+        IREE::GPU::MMAAttr::get(op.getContext(), mma->getIntrinsic().getValue(),
+                                /*isDataTiled=*/true);
     LLVM_DEBUG(llvm::dbgs() << "Target MMA: " << mma.value() << "\n");
 
     FailureOr<linalg::ContractionDimensions> contractionDims =
@@ -456,56 +459,11 @@ public:
         linalgOp.getIteratorTypesArray();
 
     // TODO(hanchung): Support batch gemms.
-    // The current multi_mma op is not able to represent the data-tiled mma
-    // layouts. There are internal details about layout after we data-tile a
-    // matrix. The matrix is in row-major fashion for outer dimensions. The
-    // inner dimensions were in row-major, and then we swizzle them to be
-    // column-major. The number of inner dimensions is greater than 2 after tile
-    // swizzling. Here we use the "row-major" layout for inner dimensions. The
-    // shape is exacatly innerTile[0]xinnerTile[1] where innerTile can be
-    // derived from the encoding info. The chunk of the inner tiles are in
-    // column-major fashion, but it does not really matter. Because they are
-    // opaque. I don't find a way to represent it, so I added a
-    // `__is_data_tiled__` magic attribute to the op. The expectation is that
-    // there is a pass to resolve the `__is_data_tiled__` attribute before
-    // additional lowering. It should unroll the op and resolve the layout; each
-    // multi_mma op maps to a single intrisic at subgroup level. Then we do the
-    // lowering that we've been doing in TileAndFuse pipeline.
-    //
-    // E.g., say that the intrinsic is MFMA_f32_16x16x4_f32, and the unrolling
-    // factors for [M, N, K] are [2, 4, 1], then we have:
-    //
-    //   iree_gpu.multi_mma %lhs, %rhs, %acc {
-    //     kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
-    //     lhs_permutation = array<i64: 0, 1>,
-    //     rhs_permutation = array<i64: 0, 1>,
-    //     __is_data_tiled__
-    //   } : tensor<?x?x32x4xf32>, tensor<?x?x16x4xf32>
-    //     into tensor<?x?x32x64xf32>
-    //
-    // The data-tiled chunk represents in row-major favor, so the permutation is
-    // identiy; the `__is_data_tiled__` attribute is attached.
-    //
-    // Then we resolve the `__is_data_tiled__` layout, which do the unrolling.
-    // It becomes a sequence of
-    //
-    //   iree_gpu.multi_mma %lhs_i, %rhs_i, %acc_i {
-    //     kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
-    //     lhs_permutation = array<i64: 1, 0>,
-    //     rhs_permutation = array<i64: 1, 0>,
-    //   } : tensor<?x?x4x16xf32>, tensor<?x?x4x16xf32>
-    //     into tensor<?x?x16x16xf32>
-    //
-    // This is what we usually have in TileAndFuse pipeline. IMO, this step
-    // happens after we distribute the op to subgroups/threads; before we
-    // distribute them to lanes.
     Location loc = op.getLoc();
-    SmallVector<int64_t> identityPerm = {0, 1};
     auto mmaOp = rewriter.create<IREE::GPU::MultiMmaOp>(
         loc, operands[0], operands[1], operands[2],
-        ArrayRef<AffineMap>{lhsMap, rhsMap, accMap}, iteratorTypes, mma.value(),
-        identityPerm, identityPerm, identityPerm);
-    mmaOp->setAttr("__is_data_tiled__", rewriter.getUnitAttr());
+        ArrayRef<AffineMap>{lhsMap, rhsMap, accMap}, iteratorTypes,
+        mma.value());
     rewriter.replaceOp(op, mmaOp);
     return success();
   }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUMaterializeEncoding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUMaterializeEncoding.cpp
@@ -42,8 +42,8 @@ namespace mlir::iree_compiler {
 
 /// Returns the corresponding native vector sizes defined by the `mma`
 /// intrinsic.
-static SmallVector<int64_t>
-getIntrinsicVectorSize(IREE::GPU::MMAIntrinsic mma, int64_t roleIdx) {
+static SmallVector<int64_t> getIntrinsicVectorSize(IREE::GPU::MMAIntrinsic mma,
+                                                   int64_t roleIdx) {
   if (mma == IREE::GPU::MMAIntrinsic::MFMA_F32_16x16x4_F32) {
     // TODO: Query the value from GPU attributes.
     if (roleIdx == 0 || roleIdx == 1) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_materialize_encoding.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_materialize_encoding.mlir
@@ -259,12 +259,11 @@ func.func @matmul_lowering_f32f32f32() {
 // CHECK-DAG:   %[[LHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(0)
 // CHECK-DAG:   %[[RHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(1)
 // CHECK-DAG:   %[[ACC_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(2)
-// CHECK-DAG:   %[[LHS:.+]] = flow.dispatch.tensor.load %[[LHS_BINDING]]{{.+}} -> tensor<?x?x16x4xf32>
-// CHECK-DAG:   %[[RHS:.+]] = flow.dispatch.tensor.load %[[RHS_BINDING]]{{.+}} -> tensor<?x?x16x4xf32>
-// CHECK-DAG:   %[[ACC:.+]] = flow.dispatch.tensor.load %[[ACC_BINDING]]{{.+}} -> tensor<?x?x16x16xf32>
+// CHECK-DAG:   %[[LHS:.+]] = flow.dispatch.tensor.load %[[LHS_BINDING]]{{.+}} -> tensor<?x?x4x16x1x1xf32>
+// CHECK-DAG:   %[[RHS:.+]] = flow.dispatch.tensor.load %[[RHS_BINDING]]{{.+}} -> tensor<?x?x4x16x1x1xf32>
+// CHECK-DAG:   %[[ACC:.+]] = flow.dispatch.tensor.load %[[ACC_BINDING]]{{.+}} -> tensor<?x?x4x16x4x1xf32>
 // CHECK:       %[[MMA:.+]] = iree_gpu.multi_mma %[[LHS]], %[[RHS]], %[[ACC]]
-// CHECK-SAME:    __is_data_tiled__
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<MFMA_F32_16x16x4_F32>
 // CHECK:       flow.dispatch.tensor.store %[[MMA]], %[[ACC_BINDING]]

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_materialize_encoding.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_materialize_encoding.mlir
@@ -206,3 +206,65 @@ func.func @unset_encoding_ACC() {
 // CHECK:         %[[UNSET_EMPTY:.*]] = tensor.empty() : tensor<255x513xf32>
 // CHECK:         tensor.unpack %[[UNSET_COLLAPSE:.*]] outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [16, 16] into
 // CHECK-SAME:      tensor<16x33x16x16xf32> -> tensor<255x513xf32>
+
+// -----
+
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#encoding_lhs = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], round_dims_to = array<i64: 16, 16, 16>>
+#encoding_rhs = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], round_dims_to = array<i64: 16, 16, 16>>
+#encoding_result = #iree_encoding.encoding<operand_index = 2, op_type = matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2], round_dims_to = array<i64: 16, 16, 16>>
+#pipeline_layout = #hal.pipeline.layout<push_constants = 3, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+func.func @matmul_lowering_f32f32f32() {
+  %c0 = arith.constant 0 : index
+  %M = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+  %N = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
+  %K = hal.interface.constant.load layout(#pipeline_layout) ordinal(2) : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) set(0) binding(0) alignment(64) offset(%c0)
+      : !flow.dispatch.tensor<readonly:tensor<?x?xf32, #encoding_lhs>>{%M, %K}
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) set(0) binding(1) alignment(64) offset(%c0)
+      : !flow.dispatch.tensor<readonly:tensor<?x?xf32, #encoding_rhs>>{%K, %N}
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) set(0) binding(2) alignment(64) offset(%c0)
+      : !flow.dispatch.tensor<readwrite:tensor<?x?xf32, #encoding_result>>{%M, %N}
+  %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [%M, %K], strides = [1, 1]
+      : !flow.dispatch.tensor<readonly:tensor<?x?xf32, #encoding_lhs>>{%M, %K}
+      -> tensor<?x?xf32, #encoding_lhs>
+  %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [%K, %N], strides = [1, 1]
+      : !flow.dispatch.tensor<readonly:tensor<?x?xf32, #encoding_rhs>>{%K, %N}
+      -> tensor<?x?xf32, #encoding_rhs>
+  %5 = flow.dispatch.tensor.load %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
+      : !flow.dispatch.tensor<readwrite:tensor<?x?xf32, #encoding_result>>{%M, %N}
+      -> tensor<?x?xf32, #encoding_result>
+  %6 = linalg.matmul
+      ins(%3, %4 : tensor<?x?xf32, #encoding_lhs>,
+                   tensor<?x?xf32, #encoding_rhs>)
+      outs(%5 : tensor<?x?xf32, #encoding_result>)
+      -> tensor<?x?xf32, #encoding_result>
+  flow.dispatch.tensor.store %6, %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
+      : tensor<?x?xf32, #encoding_result>
+      -> !flow.dispatch.tensor<readwrite:tensor<?x?xf32, #encoding_result>>{%M, %N}
+  return
+}
+// CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
+// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
+// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+// CHECK:     func.func @matmul_lowering_f32f32f32
+// CHECK-DAG:   %[[LHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(0)
+// CHECK-DAG:   %[[RHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(1)
+// CHECK-DAG:   %[[ACC_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(2)
+// CHECK-DAG:   %[[LHS:.+]] = flow.dispatch.tensor.load %[[LHS_BINDING]]{{.+}} -> tensor<?x?x16x4xf32>
+// CHECK-DAG:   %[[RHS:.+]] = flow.dispatch.tensor.load %[[RHS_BINDING]]{{.+}} -> tensor<?x?x16x4xf32>
+// CHECK-DAG:   %[[ACC:.+]] = flow.dispatch.tensor.load %[[ACC_BINDING]]{{.+}} -> tensor<?x?x16x16xf32>
+// CHECK:       %[[MMA:.+]] = iree_gpu.multi_mma %[[LHS]], %[[RHS]], %[[ACC]]
+// CHECK-SAME:    __is_data_tiled__
+// CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
+// CHECK-SAME:    iterator_types = [#iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<reduction>]
+// CHECK-SAME:    kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>
+// CHECK:       flow.dispatch.tensor.store %[[MMA]], %[[ACC_BINDING]]

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_materialize_encoding.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_materialize_encoding.mlir
@@ -259,12 +259,11 @@ func.func @matmul_lowering_f32f32f32() {
 // CHECK-DAG:   %[[LHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(0)
 // CHECK-DAG:   %[[RHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(1)
 // CHECK-DAG:   %[[ACC_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(2)
-// CHECK-DAG:   %[[LHS:.+]] = flow.dispatch.tensor.load %[[LHS_BINDING]]{{.+}} -> tensor<?x?x16x4xf32>
-// CHECK-DAG:   %[[RHS:.+]] = flow.dispatch.tensor.load %[[RHS_BINDING]]{{.+}} -> tensor<?x?x16x4xf32>
-// CHECK-DAG:   %[[ACC:.+]] = flow.dispatch.tensor.load %[[ACC_BINDING]]{{.+}} -> tensor<?x?x16x16xf32>
+// CHECK-DAG:   %[[LHS:.+]] = flow.dispatch.tensor.load %[[LHS_BINDING]]{{.+}} -> tensor<?x?x4x16x1x1xf32>
+// CHECK-DAG:   %[[RHS:.+]] = flow.dispatch.tensor.load %[[RHS_BINDING]]{{.+}} -> tensor<?x?x4x16x1x1xf32>
+// CHECK-DAG:   %[[ACC:.+]] = flow.dispatch.tensor.load %[[ACC_BINDING]]{{.+}} -> tensor<?x?x4x16x4x1xf32>
 // CHECK:       %[[MMA:.+]] = iree_gpu.multi_mma %[[LHS]], %[[RHS]], %[[ACC]]
-// CHECK-SAME:    __is_data_tiled__
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>
+// CHECK-SAME:    kind = #iree_gpu.mma_layout<data_tiled<MFMA_F32_16x16x4_F32>>
 // CHECK:       flow.dispatch.tensor.store %[[MMA]], %[[ACC_BINDING]]

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_materialize_encoding.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_materialize_encoding.mlir
@@ -259,11 +259,12 @@ func.func @matmul_lowering_f32f32f32() {
 // CHECK-DAG:   %[[LHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(0)
 // CHECK-DAG:   %[[RHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(1)
 // CHECK-DAG:   %[[ACC_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(2)
-// CHECK-DAG:   %[[LHS:.+]] = flow.dispatch.tensor.load %[[LHS_BINDING]]{{.+}} -> tensor<?x?x4x16x1x1xf32>
-// CHECK-DAG:   %[[RHS:.+]] = flow.dispatch.tensor.load %[[RHS_BINDING]]{{.+}} -> tensor<?x?x4x16x1x1xf32>
-// CHECK-DAG:   %[[ACC:.+]] = flow.dispatch.tensor.load %[[ACC_BINDING]]{{.+}} -> tensor<?x?x4x16x4x1xf32>
+// CHECK-DAG:   %[[LHS:.+]] = flow.dispatch.tensor.load %[[LHS_BINDING]]{{.+}} -> tensor<?x?x16x4xf32>
+// CHECK-DAG:   %[[RHS:.+]] = flow.dispatch.tensor.load %[[RHS_BINDING]]{{.+}} -> tensor<?x?x16x4xf32>
+// CHECK-DAG:   %[[ACC:.+]] = flow.dispatch.tensor.load %[[ACC_BINDING]]{{.+}} -> tensor<?x?x16x16xf32>
 // CHECK:       %[[MMA:.+]] = iree_gpu.multi_mma %[[LHS]], %[[RHS]], %[[ACC]]
+// CHECK-SAME:    __is_data_tiled__
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.mma_layout<data_tiled<MFMA_F32_16x16x4_F32>>
+// CHECK-SAME:    kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>
 // CHECK:       flow.dispatch.tensor.store %[[MMA]], %[[ACC_BINDING]]

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -20,6 +20,7 @@
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/LogicalResult.h"
 #include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -401,9 +402,19 @@ static ConcreteMmaLayout getConcreteMFMALayout(MLIRContext *context,
 // MFMA Attributes
 //===----------------------------------------------------------------------===//
 
+static constexpr StringLiteral kMmaDataTiledStr = "data_tiled";
+
 Attribute MMAAttr::parse(AsmParser &p, Type type) {
   if (failed(p.parseLess()))
     return {};
+
+  bool isDataTiled = false;
+  ParseResult r = p.parseOptionalKeyword(kMmaDataTiledStr);
+  if (llvm::succeeded(r)) {
+    isDataTiled = true;
+    if (failed(p.parseLess()))
+      return {};
+  }
 
   FailureOr<MMAIntrinsicAttr> mmaIntrinsic =
       FieldParser<MMAIntrinsicAttr>::parse(p);
@@ -412,24 +423,34 @@ Attribute MMAAttr::parse(AsmParser &p, Type type) {
     return {};
   }
 
+  if (isDataTiled && failed(p.parseGreater()))
+    return {};
+
   if (failed(p.parseGreater()))
     return {};
 
-  return get(p.getContext(), mmaIntrinsic->getValue());
+  return get(p.getContext(), mmaIntrinsic->getValue(), isDataTiled);
 }
 
 void MMAAttr::print(AsmPrinter &p) const {
   auto &os = p.getStream();
   os << "<";
+  if (getDataTiled()) {
+    os << kMmaDataTiledStr << "<";
+  }
   os << stringifyMMAIntrinsic(getIntrinsic().getValue());
+  if (getDataTiled()) {
+    os << ">";
+  }
   os << ">";
 }
 
-MMAAttr MMAAttr::get(MLIRContext *context, MMAIntrinsic type) {
+MMAAttr MMAAttr::get(MLIRContext *context, MMAIntrinsic type,
+                     bool isDataTiled) {
   auto layout = getOpaqueMFMALayout(context, type);
-  return Base::get(context, MMAIntrinsicAttr::get(context, type), layout.mSize,
-                   layout.nSize, layout.kSize, layout.aType, layout.bType,
-                   layout.cType);
+  return Base::get(context, MMAIntrinsicAttr::get(context, type), isDataTiled,
+                   layout.mSize, layout.nSize, layout.kSize, layout.aType,
+                   layout.bType, layout.cType);
 }
 
 std::tuple<Type, Type, Type> MMAAttr::getABCElementTypes() const {
@@ -500,12 +521,22 @@ MMAAttr::getABCVectorTypes() const {
 FailureOr<std::tuple<VectorLayoutInterface, VectorLayoutInterface,
                      VectorLayoutInterface>>
 MMAAttr::getContractionLayout(vector::ContractionOp contract) const {
+  if (getDataTiled()) {
+    assert(false && "expected non data-tiled layout, something went wrong?");
+    return failure();
+  }
+
   ConcreteMmaLayout layout =
       getConcreteMFMALayout(contract->getContext(), getIntrinsic().getValue());
   return IREE::GPU::getContractionLayout(contract, layout);
 }
 
 int64_t MMAAttr::getBlockSize() const {
+  if (getDataTiled()) {
+    assert(false && "expected non data-tiled layout, something went wrong?");
+    return 0;
+  }
+
   switch (getIntrinsic().getValue()) {
   case MMAIntrinsic::MFMA_F32_16x16x4_F32:
   case MMAIntrinsic::MFMA_F32_16x16x16_F16:
@@ -523,6 +554,10 @@ int64_t MMAAttr::getBlockSize() const {
 }
 
 int64_t MMAAttr::getSubgroupSize() const {
+  if (getDataTiled()) {
+    assert(false && "expected non data-tiled layout, something went wrong?");
+    return {};
+  }
   switch (getIntrinsic().getValue()) {
   case MMAIntrinsic::MFMA_F32_16x16x4_F32:
   case MMAIntrinsic::MFMA_F32_16x16x16_F16:
@@ -542,6 +577,10 @@ int64_t MMAAttr::getSubgroupSize() const {
 }
 
 MMAAttr::SingleSubgroupLayout MMAAttr::getASingleSubgroupLayout() const {
+  if (getDataTiled()) {
+    assert(false && "expected non data-tiled layout, something went wrong?");
+    return {};
+  }
   switch (getIntrinsic().getValue()) {
   case MMAIntrinsic::MFMA_F32_16x16x4_F32: {
     return {/*outer=*/{1, 1}, /*thread=*/{16, 4}, /*strides=*/{1, 16},
@@ -574,6 +613,10 @@ MMAAttr::SingleSubgroupLayout MMAAttr::getASingleSubgroupLayout() const {
 }
 
 MMAAttr::SingleSubgroupLayout MMAAttr::getBSingleSubgroupLayout() const {
+  if (getDataTiled()) {
+    assert(false && "expected non data-tiled layout, something went wrong?");
+    return {};
+  }
   switch (getIntrinsic().getValue()) {
   case MMAIntrinsic::MFMA_F32_16x16x4_F32: {
     return {/*outer=*/{1, 1}, /*thread=*/{4, 16}, /*strides=*/{16, 1},
@@ -606,6 +649,10 @@ MMAAttr::SingleSubgroupLayout MMAAttr::getBSingleSubgroupLayout() const {
 }
 
 MMAAttr::SingleSubgroupLayout MMAAttr::getCSingleSubgroupLayout() const {
+  if (getDataTiled()) {
+    assert(false && "expected non data-tiled layout, something went wrong?");
+    return {};
+  }
   switch (getIntrinsic().getValue()) {
   case MMAIntrinsic::MFMA_F32_16x16x4_F32:
   case MMAIntrinsic::MFMA_F32_16x16x16_F16:
@@ -636,6 +683,11 @@ MMAAttr::SingleSubgroupLayout MMAAttr::getCSingleSubgroupLayout() const {
 FailureOr<Value> MMAAttr::buildMmaOperation(OpBuilder &builder, Location loc,
                                             Type resultType, Value lhs,
                                             Value rhs, Value acc) const {
+  if (getDataTiled()) {
+    assert(false && "expected non data-tiled layout, something went wrong?");
+    return failure();
+  }
+
   auto [aType, bType, cType] = getABCVectorTypes();
   if (aType != lhs.getType() || bType != rhs.getType() ||
       cType != acc.getType()) {
@@ -745,6 +797,10 @@ LogicalResult MMAAttr::populateOperandOffsetsSizesStrides(
     Value laneId, ArrayRef<int64_t> permutation,
     SmallVector<OpFoldResult> &offsets, SmallVector<OpFoldResult> &sizes,
     SmallVector<OpFoldResult> &strides) const {
+  if (getDataTiled()) {
+    assert(false && "not yet implmented for data-tiled layout");
+    return failure();
+  }
 
   MMAAttr::SingleSubgroupLayout subgroupLayout;
   switch (fragment) {
@@ -780,6 +836,10 @@ LogicalResult MMAAttr::materializeOperandConcreteShape(
     std::optional<ArrayRef<int64_t>> permutation,
     SmallVector<ReassociationIndices> &reassociations,
     RankedTensorType &resultType) const {
+  if (getDataTiled()) {
+    assert(false && "expected non data-tiled layout, something went wrong?");
+    return failure();
+  }
 
   SmallVector<int64_t, 2> outerSizes;
   SmallVector<int64_t, 2> opaqueSizes;

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -899,57 +899,7 @@ std::tuple<int64_t, int64_t, int64_t> DataTiledMMAAttr::getMNKShape() const {
 
 std::tuple<VectorType, VectorType, VectorType>
 DataTiledMMAAttr::getABCVectorTypes() const {
-  // Check https://github.com/ROCm/amd_matrix_instruction_calculator for
-  // instruction details. Note here we are returning the number elements, while
-  // amd_matrix_instruction_calculator tells us about the number of 32-bit
-  // registers. So need to adjust accordingly. All vectors should be 1-D.
-  auto [aElemType, bElemType, cElemType] = getABCElementTypes();
-  switch (getIntrinsic().getValue()) {
-  case MMAIntrinsic::MFMA_F32_16x16x4_F32: {
-    auto aType = VectorType::get({1}, aElemType);
-    auto bType = VectorType::get({1}, bElemType);
-    auto cType = VectorType::get({4}, cElemType);
-    return std::make_tuple(aType, bType, cType);
-  }
-  case MMAIntrinsic::MFMA_F32_16x16x16_F16: {
-    auto aType = VectorType::get({4}, aElemType);
-    auto bType = VectorType::get({4}, bElemType);
-    auto cType = VectorType::get({4}, cElemType);
-    return std::make_tuple(aType, bType, cType);
-  }
-  case MMAIntrinsic::MFMA_F32_32x32x8_F16: {
-    auto aType = VectorType::get({4}, aElemType);
-    auto bType = VectorType::get({4}, bElemType);
-    auto cType = VectorType::get({16}, cElemType);
-    return std::make_tuple(aType, bType, cType);
-  }
-  case MMAIntrinsic::MFMA_F32_16x16x32_F8E4M3FNUZ:
-  case MMAIntrinsic::MFMA_I32_16x16x32_I8: {
-    auto aType = VectorType::get({8}, aElemType);
-    auto bType = VectorType::get({8}, bElemType);
-    auto cType = VectorType::get({4}, cElemType);
-    return std::make_tuple(aType, bType, cType);
-  }
-  case MMAIntrinsic::MFMA_I32_32x32x16_I8: {
-    auto aType = VectorType::get({8}, aElemType);
-    auto bType = VectorType::get({8}, bElemType);
-    auto cType = VectorType::get({16}, cElemType);
-    return std::make_tuple(aType, bType, cType);
-  }
-  case MMAIntrinsic::WMMA_F32_16x16x16_F16: {
-    auto aType = VectorType::get({16}, aElemType);
-    auto bType = VectorType::get({16}, bElemType);
-    auto cType = VectorType::get({8}, cElemType);
-    return std::make_tuple(aType, bType, cType);
-  }
-  case MMAIntrinsic::WMMA_F16_16x16x16_F16: {
-    auto aType = VectorType::get({16}, aElemType);
-    auto bType = VectorType::get({16}, bElemType);
-    auto cType = VectorType::get({16}, cElemType);
-    return std::make_tuple(aType, bType, cType);
-  }
-  }
-  // This should not happen but just to make GCC happy.
+  // TODO: Implement the interface method.
   return std::make_tuple(VectorType{}, VectorType{}, VectorType{});
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -251,6 +251,14 @@ def IREEGPU_DataTiledMMAAttr :
   let parameters = (ins
     IREEGPU_MMAIntrinsicAttr:$intrinsic
   );
+
+  let extraClassDeclaration = [{
+    /// Infers the unrolling factor for (M, N, K) dimensions from the inner
+    /// tile shapes after tile swizzling. If the provided shapes are not
+    /// invalid, returns {0, 0, 0}.
+    std::tuple<int64_t, int64_t, int64_t> getUnrollingFactor(ArrayRef<int64_t>
+        lhsShape, ArrayRef<int64_t> rhsShape, ArrayRef<int64_t> accShape);
+  }];
 }
 
 def IREEGPU_MMAOpsArrayAttr : ArrayOfAttr<

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -161,6 +161,7 @@ class IREEGPU_MmaVectorLayoutAttr<string attrname, string mmaintrinsic> :
 
   let parameters = (ins
     mmaintrinsic:$intrinsic,
+    "bool":$dataTiled,
     "int64_t":$mSize,
     "int64_t":$nSize,
     "int64_t":$kSize,
@@ -198,7 +199,10 @@ def IREEGPU_MMAAttr : IREEGPU_MmaVectorLayoutAttr<"MMA", "MMAIntrinsicAttr"> {
 
   let skipDefaultBuilders = 1;
   let builders = [
-    AttrBuilder<(ins "MMAIntrinsic":$intrinsic)>
+    AttrBuilder<(ins
+      "MMAIntrinsic":$intrinsic,
+      CArg<"bool", "false">:$isDataTiled
+    )>
   ];
 
   let extraClassDeclaration = [{

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -254,8 +254,8 @@ def IREEGPU_DataTiledMMAAttr :
 
   let extraClassDeclaration = [{
     /// Infers the unrolling factor for (M, N, K) dimensions from the inner
-    /// tile shapes after tile swizzling. If the provided shapes are not
-    /// invalid, returns {0, 0, 0}.
+    /// tile shapes after tile swizzling. If the provided shapes are not valid,
+    /// returns {0, 0, 0}.
     std::tuple<int64_t, int64_t, int64_t> getUnrollingFactor(ArrayRef<int64_t>
         lhsShape, ArrayRef<int64_t> rhsShape, ArrayRef<int64_t> accShape);
   }];

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -227,6 +227,9 @@ def IREEGPU_DataTiledMMAAttr :
     AttrDef<IREEGPU_Dialect, "DataTiledMMA", [
   DeclareAttrInterfaceMethods<IREEGPU_MmaInterfaceAttr, [
     "getABCElementTypes",
+    // TODO: Implement the interface method. The current implementation just
+    // returns {VectorType(), VectorType(), VectorType()} now because the dummy
+    // implementation is required by the MmaInterfaceAttr.
     "getABCVectorTypes",
     "getMNKShape",
     "getSubgroupSize",
@@ -238,7 +241,23 @@ def IREEGPU_DataTiledMMAAttr :
   let cppNamespace = "::mlir::iree_compiler::IREE::GPU";
 
   let description = [{
-    An mma instruction for data tiling :)
+    This mma variant represents MMA ops with data-tiling details. The
+    |intrinsic| field specifies which particular MMA intrinsic is targeted by
+    the data-tiling.
+
+    The tile swizzling already happens, so the attribute does not need to
+    implement materializeOperandConcreteShape interface method. E.g., if the
+    target intrinsic is MFMA_F32_16x16x4_F32:
+      - The inner tile shape of LHS is 4x16.
+      - The inner tile shape of RHS is 4x16.
+      - The inner tile shape of ACC is 4x16x4.
+
+    Furthermore, the unrolling and interleaving can be represented with the
+    attribute. In the concept of data-tiling, we always unroll the parallel
+    dimensions (i.e., M, N dimensions) to be outermost, and interleave the
+    unrolled K dimension. I.e., the unrolled K dimension becomes the innermost
+    dimension. The constraint can be relaxed based on data-tiling needs. The
+    additional information can be added to `parameters`.
   }];
 
   let hasCustomAssemblyFormat = 1;

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -161,7 +161,6 @@ class IREEGPU_MmaVectorLayoutAttr<string attrname, string mmaintrinsic> :
 
   let parameters = (ins
     mmaintrinsic:$intrinsic,
-    "bool":$dataTiled,
     "int64_t":$mSize,
     "int64_t":$nSize,
     "int64_t":$kSize,
@@ -199,10 +198,7 @@ def IREEGPU_MMAAttr : IREEGPU_MmaVectorLayoutAttr<"MMA", "MMAIntrinsicAttr"> {
 
   let skipDefaultBuilders = 1;
   let builders = [
-    AttrBuilder<(ins
-      "MMAIntrinsic":$intrinsic,
-      CArg<"bool", "false">:$isDataTiled
-    )>
+    AttrBuilder<(ins "MMAIntrinsic":$intrinsic)>
   ];
 
   let extraClassDeclaration = [{

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -223,6 +223,36 @@ def IREEGPU_MMAAttr : IREEGPU_MmaVectorLayoutAttr<"MMA", "MMAIntrinsicAttr"> {
   }];
 }
 
+def IREEGPU_DataTiledMMAAttr :
+    AttrDef<IREEGPU_Dialect, "DataTiledMMA", [
+  DeclareAttrInterfaceMethods<IREEGPU_MmaInterfaceAttr, [
+    "getABCElementTypes",
+    "getABCVectorTypes",
+    "getMNKShape",
+    "getSubgroupSize",
+    // TODO: Implement the interface method.
+    // "populateOperandOffsetsSizesStrides",
+  ]>
+]> {
+  let mnemonic = "data_tiled_mma_layout";
+  let cppNamespace = "::mlir::iree_compiler::IREE::GPU";
+
+  let description = [{
+    An mma instruction for data tiling :)
+  }];
+
+  let hasCustomAssemblyFormat = 1;
+
+  let skipDefaultBuilders = 1;
+  let builders = [
+    AttrBuilder<(ins "MMAIntrinsic":$intrinsic)>
+  ];
+
+  let parameters = (ins
+    IREEGPU_MMAIntrinsicAttr:$intrinsic
+  );
+}
+
 def IREEGPU_MMAOpsArrayAttr : ArrayOfAttr<
   IREEGPU_Dialect, "MMAOpsArray", "mma_ops", "MMAAttr"> {
   let cppNamespace = "::mlir::iree_compiler::IREE::GPU";

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -203,26 +203,8 @@ LogicalResult MultiMmaOp::verify() {
   int64_t accInnerElementCount = multiplyAcc(getAccInnerShape());
 
   auto [m, n, k] = getKind().getMNKShape();
-  int64_t expectedNumLhsElem = m * k;
-  int64_t expectedNumRhsElem = n * k;
-  int64_t expectedNumAccElem = m * n;
-
-  // The below variables have zero values when the op is at thread level.
-  int64_t M0K0 = lhsInnerElementCount / m / k; // (M0M1K0K1) / M1 / K1 = M0K0
-  int64_t N0K0 = rhsInnerElementCount / n / k; // (N0N1K0K1) / N1 / K1 = N0K0
-  int64_t M0N0 = accInnerElementCount / m / n; // (M0M1N0N1) / M1 / N1 = M0N0
-  if (hasPureTensorSemantics() && M0K0 && N0K0 && M0N0) {
-    int mUnrollFactor = std::sqrt(M0K0 * M0N0 / N0K0);
-    int nUnrollFactor = std::sqrt(M0N0 * N0K0 / M0K0);
-    int kUnrollFactor = std::sqrt(M0K0 * N0K0 / M0N0);
-    expectedNumLhsElem *= mUnrollFactor * kUnrollFactor;
-    expectedNumRhsElem *= nUnrollFactor * kUnrollFactor;
-    expectedNumAccElem *= mUnrollFactor * nUnrollFactor;
-  }
-
-  if (expectedNumLhsElem != lhsInnerElementCount ||
-      expectedNumRhsElem != rhsInnerElementCount ||
-      expectedNumAccElem != accInnerElementCount) {
+  if (m * k != lhsInnerElementCount || n * k != rhsInnerElementCount ||
+      m * n != accInnerElementCount) {
     auto [lhsThreadType, rhsThreadType, accThreadType] =
         getKind().getABCVectorTypes();
     int64_t lhsThreadElementCount = multiplyAcc(lhsThreadType.getShape());

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -208,7 +208,8 @@ LogicalResult MultiMmaOp::verify() {
   int64_t expectedNumRhsElem = n * k;
   int64_t expectedNumAccElem = m * n;
 
-  if (auto dataTiledMmaAttr = dyn_cast<IREE::GPU::DataTiledMMAAttr>(getKind())) {
+  if (auto dataTiledMmaAttr =
+          dyn_cast<IREE::GPU::DataTiledMMAAttr>(getKind())) {
     auto [mUnrollFactor, nUnrollFactor, kUnrollFactor] =
         dataTiledMmaAttr.getUnrollingFactor(
             getLhsInnerShape(), getRhsInnerShape(), getAccInnerShape());

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
 #include <functional>
+#include <memory>
 #include <numeric>
 
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
@@ -203,8 +204,22 @@ LogicalResult MultiMmaOp::verify() {
   int64_t accInnerElementCount = multiplyAcc(getAccInnerShape());
 
   auto [m, n, k] = getKind().getMNKShape();
-  if (m * k != lhsInnerElementCount || n * k != rhsInnerElementCount ||
-      m * n != accInnerElementCount) {
+  int64_t expectedNumLhsElem = m * k;
+  int64_t expectedNumRhsElem = n * k;
+  int64_t expectedNumAccElem = m * n;
+
+  if (auto dataTiledMmaAttr = dyn_cast<IREE::GPU::DataTiledMMAAttr>(getKind())) {
+    auto [mUnrollFactor, nUnrollFactor, kUnrollFactor] =
+        dataTiledMmaAttr.getUnrollingFactor(
+            getLhsInnerShape(), getRhsInnerShape(), getAccInnerShape());
+    expectedNumLhsElem *= mUnrollFactor * kUnrollFactor;
+    expectedNumRhsElem *= nUnrollFactor * kUnrollFactor;
+    expectedNumAccElem *= mUnrollFactor * nUnrollFactor;
+  }
+
+  if (expectedNumLhsElem != lhsInnerElementCount ||
+      expectedNumRhsElem != rhsInnerElementCount ||
+      expectedNumAccElem != accInnerElementCount) {
     auto [lhsThreadType, rhsThreadType, accThreadType] =
         getKind().getABCVectorTypes();
     int64_t lhsThreadElementCount = multiplyAcc(lhsThreadType.getShape());

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -208,6 +208,8 @@ LogicalResult MultiMmaOp::verify() {
   int64_t expectedNumRhsElem = n * k;
   int64_t expectedNumAccElem = m * n;
 
+  // TODO: Revisit if we can move below logic out of the MultiMmaOp before we
+  // land this part to main branch.
   if (auto dataTiledMmaAttr =
           dyn_cast<IREE::GPU::DataTiledMMAAttr>(getKind())) {
     auto [mUnrollFactor, nUnrollFactor, kUnrollFactor] =

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
@@ -10,15 +10,6 @@ module {
 //  CHECK-SAME:   mma_types = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
 
 module {
-  func.func @test_data_tiled_mfma_f16_16x16x16_f32() attributes {
-      mma_types = #iree_gpu.mma_layout<data_tiled<MFMA_F32_16x16x16_F16>>} {
-    return
-  }
-}
-// CHECK-LABEL: func @test_data_tiled_mfma_f16_16x16x16_f32
-//  CHECK-SAME:   mma_types = #iree_gpu.mma_layout<data_tiled<MFMA_F32_16x16x16_F16>>
-
-module {
   func.func @test_mfma_f16_32x32x8_f32() attributes {
       mma_types = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>} {
     return

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
@@ -28,6 +28,15 @@ module {
 //  CHECK-SAME:   mma_types = #iree_gpu.mma_layout<WMMA_F32_16x16x16_F16>
 
 module {
+  func.func @test_data_tiled_mfma_f32_16x16x4_f32() attributes {
+      mma_types = #iree_gpu.data_tiled_mma_layout<MFMA_F32_16x16x4_F32>} {
+    return
+  }
+}
+// CHECK-LABEL: func @test_data_tiled_mfma_f32_16x16x4_f32
+//  CHECK-SAME:   mma_types = #iree_gpu.data_tiled_mma_layout<MFMA_F32_16x16x4_F32>
+
+module {
   func.func @test_any_lowering_config() attributes {
       lowering_config = #iree_gpu.lowering_config<{workgroup = [16, 16], thread = [0, 4]}>} {
     return

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
@@ -10,6 +10,15 @@ module {
 //  CHECK-SAME:   mma_types = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
 
 module {
+  func.func @test_data_tiled_mfma_f16_16x16x16_f32() attributes {
+      mma_types = #iree_gpu.mma_layout<data_tiled<MFMA_F32_16x16x16_F16>>} {
+    return
+  }
+}
+// CHECK-LABEL: func @test_data_tiled_mfma_f16_16x16x16_f32
+//  CHECK-SAME:   mma_types = #iree_gpu.mma_layout<data_tiled<MFMA_F32_16x16x16_F16>>
+
+module {
   func.func @test_mfma_f16_32x32x8_f32() attributes {
       mma_types = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>} {
     return

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
@@ -83,7 +83,7 @@ func.func @vector_multi_mma(%lhs: vector<2x3x4xf16>, %rhs: vector<3x5x4xf16>, %a
 
 #contraction_accesses = [
  affine_map<(i, j, k) -> (i, k)>,
- affine_map<(i, j, k) -> (j, k)>,
+ affine_map<(i, j, k) -> (k, j)>,
  affine_map<(i, j, k) -> (i, j)>
 ]
 func.func @tensor_multi_mma(%lhs: tensor<?x?x4xf16>, %rhs: tensor<?x?x4xf16>, %acc: tensor<?x?x4xf32>) -> tensor<?x?x4xf32> {
@@ -96,7 +96,7 @@ func.func @tensor_multi_mma(%lhs: tensor<?x?x4xf16>, %rhs: tensor<?x?x4xf16>, %a
 }
 
 // CHECK: #[[$MAP:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
-// CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
+// CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
 // CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
 
 // CHECK-LABEL: func @tensor_multi_mma
@@ -218,61 +218,6 @@ func.func @tensor_subgroup_matmul_transpose_b_32x32x8_multi_mma(
 //  CHECK-SAME:     kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>,
 //  CHECK-SAME:     rhs_permutation = array<i64: 1, 0>}
 //  CHECK-SAME:     : tensor<?x?x32x8xf16>, tensor<?x?x32x8xf16> into tensor<?x?x32x32xf32>
-
-// -----
-
-#contraction_accesses = [
- affine_map<(i, j, k) -> (i, k)>,
- affine_map<(i, j, k) -> (k, j)>,
- affine_map<(i, j, k) -> (i, j)>
-]
-func.func @data_tiled_1x1x1_tensor_multi_mma(%lhs: tensor<?x?x4x16x1x1xf32>, %rhs: tensor<?x?x4x16x1x1xf32>, %acc: tensor<?x?x4x16x4x1xf32>) -> tensor<?x?x4x16x4x1xf32> {
-  %0 = iree_gpu.multi_mma %lhs, %rhs, %acc {
-    indexing_maps = #contraction_accesses,
-    iterator_types = [#iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<reduction>],
-    kind = #iree_gpu.mma_layout<data_tiled<MFMA_F32_16x16x4_F32>>
-  } : tensor<?x?x4x16x1x1xf32>, tensor<?x?x4x16x1x1xf32> into tensor<?x?x4x16x4x1xf32>
-  return %0 : tensor<?x?x4x16x4x1xf32>
-}
-
-// CHECK: #[[$MAP:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
-// CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
-// CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
-
-// CHECK-LABEL: func @data_tiled_1x1x1_tensor_multi_mma
-//       CHECK:   iree_gpu.multi_mma %arg0, %arg1, %arg2
-//  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]]]
-//  CHECK-SAME:       iterator_types = [#iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<reduction>]
-//  CHECK-SAME:       kind = #iree_gpu.mma_layout<data_tiled<MFMA_F32_16x16x4_F32>>
-//  CHECK-SAME:     : tensor<?x?x4x16x1x1xf32>, tensor<?x?x4x16x1x1xf32> into tensor<?x?x4x16x4x1xf32>
-
-// -----
-
-#contraction_accesses = [
- affine_map<(i, j, k) -> (i, k)>,
- affine_map<(i, j, k) -> (k, j)>,
- affine_map<(i, j, k) -> (i, j)>
-]
-func.func @data_tiled_2x2x4_tensor_multi_mma(%lhs: tensor<?x?x2x4x16x1x4xf32>, %rhs: tensor<?x?x2x4x16x1x4xf32>, %acc: tensor<?x?x2x2x4x16x4x1xf32>) -> tensor<?x?x2x2x4x16x4x1xf32> {
-  %0 = iree_gpu.multi_mma %lhs, %rhs, %acc {
-    indexing_maps = #contraction_accesses,
-    iterator_types = [#iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<reduction>],
-    kind = #iree_gpu.mma_layout<data_tiled<MFMA_F32_16x16x4_F32>>
-  } : tensor<?x?x2x4x16x1x4xf32>, tensor<?x?x2x4x16x1x4xf32> into tensor<?x?x2x2x4x16x4x1xf32>
-  return %0 : tensor<?x?x2x2x4x16x4x1xf32>
-}
-
-// CHECK: #[[$MAP:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
-// CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
-// CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
-
-// CHECK-LABEL: func @data_tiled_2x2x4_tensor_multi_mma
-//       CHECK:   iree_gpu.multi_mma %arg0, %arg1, %arg2
-//  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]]]
-//  CHECK-SAME:       iterator_types = [#iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<reduction>]
-//  CHECK-SAME:       kind = #iree_gpu.mma_layout<data_tiled<MFMA_F32_16x16x4_F32>>
-//  CHECK-SAME:     : tensor<?x?x2x4x16x1x4xf32>, tensor<?x?x2x4x16x1x4xf32> into tensor<?x?x2x2x4x16x4x1xf32>
-
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
@@ -83,7 +83,7 @@ func.func @vector_multi_mma(%lhs: vector<2x3x4xf16>, %rhs: vector<3x5x4xf16>, %a
 
 #contraction_accesses = [
  affine_map<(i, j, k) -> (i, k)>,
- affine_map<(i, j, k) -> (k, j)>,
+ affine_map<(i, j, k) -> (j, k)>,
  affine_map<(i, j, k) -> (i, j)>
 ]
 func.func @tensor_multi_mma(%lhs: tensor<?x?x4xf16>, %rhs: tensor<?x?x4xf16>, %acc: tensor<?x?x4xf32>) -> tensor<?x?x4xf32> {
@@ -96,7 +96,7 @@ func.func @tensor_multi_mma(%lhs: tensor<?x?x4xf16>, %rhs: tensor<?x?x4xf16>, %a
 }
 
 // CHECK: #[[$MAP:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
-// CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
+// CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
 // CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
 
 // CHECK-LABEL: func @tensor_multi_mma
@@ -218,6 +218,61 @@ func.func @tensor_subgroup_matmul_transpose_b_32x32x8_multi_mma(
 //  CHECK-SAME:     kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>,
 //  CHECK-SAME:     rhs_permutation = array<i64: 1, 0>}
 //  CHECK-SAME:     : tensor<?x?x32x8xf16>, tensor<?x?x32x8xf16> into tensor<?x?x32x32xf32>
+
+// -----
+
+#contraction_accesses = [
+ affine_map<(i, j, k) -> (i, k)>,
+ affine_map<(i, j, k) -> (k, j)>,
+ affine_map<(i, j, k) -> (i, j)>
+]
+func.func @data_tiled_1x1x1_tensor_multi_mma(%lhs: tensor<?x?x4x16x1x1xf32>, %rhs: tensor<?x?x4x16x1x1xf32>, %acc: tensor<?x?x4x16x4x1xf32>) -> tensor<?x?x4x16x4x1xf32> {
+  %0 = iree_gpu.multi_mma %lhs, %rhs, %acc {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<reduction>],
+    kind = #iree_gpu.mma_layout<data_tiled<MFMA_F32_16x16x4_F32>>
+  } : tensor<?x?x4x16x1x1xf32>, tensor<?x?x4x16x1x1xf32> into tensor<?x?x4x16x4x1xf32>
+  return %0 : tensor<?x?x4x16x4x1xf32>
+}
+
+// CHECK: #[[$MAP:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
+// CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
+// CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+// CHECK-LABEL: func @data_tiled_1x1x1_tensor_multi_mma
+//       CHECK:   iree_gpu.multi_mma %arg0, %arg1, %arg2
+//  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]]]
+//  CHECK-SAME:       iterator_types = [#iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<reduction>]
+//  CHECK-SAME:       kind = #iree_gpu.mma_layout<data_tiled<MFMA_F32_16x16x4_F32>>
+//  CHECK-SAME:     : tensor<?x?x4x16x1x1xf32>, tensor<?x?x4x16x1x1xf32> into tensor<?x?x4x16x4x1xf32>
+
+// -----
+
+#contraction_accesses = [
+ affine_map<(i, j, k) -> (i, k)>,
+ affine_map<(i, j, k) -> (k, j)>,
+ affine_map<(i, j, k) -> (i, j)>
+]
+func.func @data_tiled_2x2x4_tensor_multi_mma(%lhs: tensor<?x?x2x4x16x1x4xf32>, %rhs: tensor<?x?x2x4x16x1x4xf32>, %acc: tensor<?x?x2x2x4x16x4x1xf32>) -> tensor<?x?x2x2x4x16x4x1xf32> {
+  %0 = iree_gpu.multi_mma %lhs, %rhs, %acc {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<reduction>],
+    kind = #iree_gpu.mma_layout<data_tiled<MFMA_F32_16x16x4_F32>>
+  } : tensor<?x?x2x4x16x1x4xf32>, tensor<?x?x2x4x16x1x4xf32> into tensor<?x?x2x2x4x16x4x1xf32>
+  return %0 : tensor<?x?x2x2x4x16x4x1xf32>
+}
+
+// CHECK: #[[$MAP:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
+// CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
+// CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+// CHECK-LABEL: func @data_tiled_2x2x4_tensor_multi_mma
+//       CHECK:   iree_gpu.multi_mma %arg0, %arg1, %arg2
+//  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]]]
+//  CHECK-SAME:       iterator_types = [#iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<reduction>]
+//  CHECK-SAME:       kind = #iree_gpu.mma_layout<data_tiled<MFMA_F32_16x16x4_F32>>
+//  CHECK-SAME:     : tensor<?x?x2x4x16x1x4xf32>, tensor<?x?x2x4x16x1x4xf32> into tensor<?x?x2x2x4x16x4x1xf32>
+
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
@@ -221,6 +221,60 @@ func.func @tensor_subgroup_matmul_transpose_b_32x32x8_multi_mma(
 
 // -----
 
+#contraction_accesses = [
+ affine_map<(i, j, k) -> (i, k)>,
+ affine_map<(i, j, k) -> (k, j)>,
+ affine_map<(i, j, k) -> (i, j)>
+]
+func.func @data_tiled_1x1x1_tensor_multi_mma(%lhs: tensor<?x?x4x16x1x1xf32>, %rhs: tensor<?x?x4x16x1x1xf32>, %acc: tensor<?x?x4x16x4x1xf32>) -> tensor<?x?x4x16x4x1xf32> {
+  %0 = iree_gpu.multi_mma %lhs, %rhs, %acc {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<reduction>],
+    kind = #iree_gpu.data_tiled_mma_layout<MFMA_F32_16x16x4_F32>
+  } : tensor<?x?x4x16x1x1xf32>, tensor<?x?x4x16x1x1xf32> into tensor<?x?x4x16x4x1xf32>
+  return %0 : tensor<?x?x4x16x4x1xf32>
+}
+
+// CHECK: #[[$MAP:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
+// CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
+// CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+// CHECK-LABEL: func @data_tiled_1x1x1_tensor_multi_mma
+//       CHECK:   iree_gpu.multi_mma %arg0, %arg1, %arg2
+//  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]]]
+//  CHECK-SAME:       iterator_types = [#iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<reduction>]
+//  CHECK-SAME:       kind = #iree_gpu.data_tiled_mma_layout<MFMA_F32_16x16x4_F32>
+//  CHECK-SAME:     : tensor<?x?x4x16x1x1xf32>, tensor<?x?x4x16x1x1xf32> into tensor<?x?x4x16x4x1xf32>
+
+// -----
+
+#contraction_accesses = [
+ affine_map<(i, j, k) -> (i, k)>,
+ affine_map<(i, j, k) -> (k, j)>,
+ affine_map<(i, j, k) -> (i, j)>
+]
+func.func @data_tiled_2x2x4_tensor_multi_mma(%lhs: tensor<?x?x2x4x16x1x4xf32>, %rhs: tensor<?x?x2x4x16x1x4xf32>, %acc: tensor<?x?x2x2x4x16x4x1xf32>) -> tensor<?x?x2x2x4x16x4x1xf32> {
+  %0 = iree_gpu.multi_mma %lhs, %rhs, %acc {
+    indexing_maps = #contraction_accesses,
+    iterator_types = [#iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<reduction>],
+    kind = #iree_gpu.data_tiled_mma_layout<MFMA_F32_16x16x4_F32>
+  } : tensor<?x?x2x4x16x1x4xf32>, tensor<?x?x2x4x16x1x4xf32> into tensor<?x?x2x2x4x16x4x1xf32>
+  return %0 : tensor<?x?x2x2x4x16x4x1xf32>
+}
+
+// CHECK: #[[$MAP:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
+// CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
+// CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+// CHECK-LABEL: func @data_tiled_2x2x4_tensor_multi_mma
+//       CHECK:   iree_gpu.multi_mma %arg0, %arg1, %arg2
+//  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]]]
+//  CHECK-SAME:       iterator_types = [#iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<reduction>]
+//  CHECK-SAME:       kind = #iree_gpu.data_tiled_mma_layout<MFMA_F32_16x16x4_F32>
+//  CHECK-SAME:     : tensor<?x?x2x4x16x1x4xf32>, tensor<?x?x2x4x16x1x4xf32> into tensor<?x?x2x2x4x16x4x1xf32>
+
+// -----
+
 func.func @tensor_barrier(%input: tensor<?xf16>) -> tensor<?xf16> {
   %out = iree_gpu.value_barrier %input : tensor<?xf16>
   return %out : tensor<?xf16>


### PR DESCRIPTION
To serve the needs of data-tiled contraction op, we can't simply use regular mma intrinsic because they implement more interface methods. The multi_mma op with data-tiled mma intrinsic should be much more simpler because we already relayout (i.e., pack + tile swizzle) the matrix. Thus, the revision introduces `IREEGPU_DataTiledMMAAttr` which gives the hints to multi_mma op.

The new attribute implements minimal interface methods. Only `getABCElementTypes`, `getMNKShape` and `getSubgroupSize` is implemented. They are all trivial methods which provides intrinsic details like [amd_matrix_instruction_calculator](https://github.com/ROCm/amd_matrix_instruction_calculator) provided. The implementation detail of `getABCVectorTypes` is not clear at this moment. We can potentially implement it based on the needs of distributing data-tiled multi_mma op to lanes. The other missing implementation is `populateOperandOffsetsSizesStrides`. Both methods will be used in the later lowering, and we need to implement them to connect e2e pieces.

Different from regular MMA attribute, this attributes has data-tiling concept which can model unrolling and interleaving layouts. In the concept of data-tiling, we always unroll the parallel dimensions (i.e., M, N dimensions) to be outermost, and interleave the unrolled K dimension. I.e., the unrolled K dimension becomes the innermost dimension. The constraint can be relaxed based on data-tiling needs. The additional information can be added to `parameters`.

With the new DataTiledMMAAttr, the revision teaches the multi_mma op to take unrolling factor into accounts in verifier.

The revision sorts out the ambiguities of materialized ops in data-tiling and switch MMAAttr to DataTiledMMAAttr in materialization patterns.

Note: this is not merging into main branch. This is mainly for prototype, and we will contribute it to main later on.