### PR TITLE
[Flow] Make CollapseDimensions iterative

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -147,6 +147,12 @@ def CloneProducersIntoDispatchRegionsPass :
 def CollapseDimensionsPass :
     InterfacePass<"iree-flow-collapse-dimensions", "mlir::FunctionOpInterface"> {
   let summary = "Collapse dimensions of Linalg Ops on tensor ops.";
+  let options = [
+    Option<"maxIterations", "max-iterations", "int",
+    /*default=*/"10",
+    "Maximum number of iterations to wait for collapse dimensions to converge"
+>,
+  ];
   let description = [{
     Collapse dimensions of Linalg Ops on tensor ops inside dispatch.region ops
     and hoist the reshaping operations out of the dispatch.


### PR DESCRIPTION
Each operation must propagate it's collapse information to every other node in the dispatch to ensure that no `collapse_shape` ops are needed between ops in the dispatch.

If a directed edge is defined as going from
consumer -> producer, information is first propagated by going N steps following the direction of the edge, and then M steps opposite the edge. This is "1 iteration". It will take >1 iteration to propagate this information. The failing IR was similar to:

```
    Root
   /    \
Child1  Child2
```

First, each child is updated. Then the root is updated from each child. However, no information can be propageted between Child1 <-> Child2.