### PR TITLE
Fix `error: 'main' should not be 'extern "C"' [-Werror,-Wmain]`

### DIFF
--- a/runtime/src/iree/task/executor_demo.cc
+++ b/runtime/src/iree/task/executor_demo.cc
@@ -37,7 +37,9 @@ static void simulate_work(const iree_task_tile_context_t* tile_context) {
   }
 }
 
-extern "C" int main(int argc, char* argv[]) {
+}  // namespace
+
+int main(int argc, char* argv[]) {
   IREE_TRACE_APP_ENTER();
   IREE_TRACE_SCOPE_NAMED("ExecutorTest::Any");
 
@@ -168,5 +170,3 @@ extern "C" int main(int argc, char* argv[]) {
   IREE_TRACE_APP_EXIT(0);
   return 0;
 }
-
-}  // namespace

--- a/runtime/src/iree/testing/gtest_main.cc
+++ b/runtime/src/iree/testing/gtest_main.cc
@@ -8,7 +8,7 @@
 #include "iree/base/internal/flags.h"
 #include "iree/testing/gtest.h"
 
-extern "C" int main(int argc, char** argv) {
+int main(int argc, char** argv) {
   IREE_TRACE_APP_ENTER();
 
   // Pass through flags to gtest (allowing --help to fall through).

--- a/runtime/src/iree/vm/bytecode/module_size_benchmark.cc
+++ b/runtime/src/iree/vm/bytecode/module_size_benchmark.cc
@@ -9,7 +9,7 @@
 #include "iree/vm/bytecode/module.h"
 #include "iree/vm/bytecode/module_size_benchmark_module_c.h"
 
-extern "C" int main(int argc, char** argv) {
+int main(int argc, char** argv) {
   iree_vm_instance_t* instance = nullptr;
   iree_vm_instance_create(IREE_VM_TYPE_CAPACITY_DEFAULT,
                           iree_allocator_system(), &instance);

--- a/tools/iree-check-module-main.cc
+++ b/tools/iree-check-module-main.cc
@@ -145,9 +145,7 @@ iree_status_t Run(iree_allocator_t host_allocator, int* out_exit_code) {
   return iree_ok_status();
 }
 
-}  // namespace
-
-extern "C" int main(int argc, char** argv) {
+int RealMain(int argc, char** argv) {
   IREE_TRACE_APP_ENTER();
 
   // Pass through flags to gtest (allowing --help to fall through).
@@ -180,4 +178,7 @@ extern "C" int main(int argc, char** argv) {
   return exit_code;
 }
 
+}  // namespace
 }  // namespace iree
+
+int main(int argc, char** argv) { return iree::RealMain(argc, argv); }


### PR DESCRIPTION
According to the C++ standard, the main function shall not be declared with a linkage-specification. For upcomming

[Clang] Strengthen checks for `main`  to meet `[basic.start.main]p3`’s requirements (#101853)

which will lead to breakages when compiling `extern "C" int main...`.

This removes `extern "C"` from `main` and, if necessary, moves `main()` to the global namespace or creates a new `main()` calling to the corresponding function in the namespace.

This should be landable before the next integrate, but can also be included as part of.