### PR TITLE
[compiler][stream] Avoid circular dependency between partitions in execution scheduling

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/Partitioning/ReferencePartitioning.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/Partitioning/ReferencePartitioning.cpp
@@ -44,6 +44,14 @@ partitionStreamableOpsReference(IREE::Stream::PartitioningConfigAttr config,
                                 Block *block) {
   PartitionSet partitionSet;
 
+  struct OpInfo {
+    // Which partitions the op is contained within.
+    llvm::BitVector membership;
+    // Which partitions transitively depend on this operation.
+    llvm::BitVector hazards;
+  };
+  DenseMap<Operation *, OpInfo> opInfos;
+
   struct PartitionBuilder {
     unsigned ordinal;
     // Affinity of the partition.
@@ -52,24 +60,76 @@ partitionStreamableOpsReference(IREE::Stream::PartitioningConfigAttr config,
     SetVector<Operation *> ops;
     // Ops that were cloned and are known not to have their values escape.
     DenseSet<Operation *> clonedOps;
-    void insert(Operation *op) {
+    // Which partitions transitively depend on this partition.
+    llvm::BitVector hazards;
+    void insert(Operation *op, OpInfo &opInfo) {
       if (auto affinityOp = dyn_cast<IREE::Stream::AffinityOpInterface>(op)) {
         affinity = affinity ? affinity.joinAND(affinityOp.getAffinityAttr())
                             : affinityOp.getAffinityAttr();
       }
+      opInfo.membership.set(ordinal);
+      if (opInfo.hazards.size() > ordinal)
+        opInfo.hazards.reset(ordinal);
       ops.insert(op);
+      hazards |= opInfo.hazards;
     }
   };
   SmallVector<std::unique_ptr<PartitionBuilder>> builders;
   llvm::BitVector usableBuilders;
 
-  struct OpInfo {
-    // Which partitions the op is contained within.
-    llvm::BitVector membership;
-    // Which partitions transitively depend on this operation.
-    llvm::BitVector hazards;
+  auto willCreateCircularDependencyBetweenPartitions =
+      [&](unsigned sourceOrdinal, unsigned targetOrdinal) -> bool {
+    // Returns:
+    // If we are to make partition with ordinal targetOrdinal to
+    // depend on partition with ordinal sourceOrdinal,
+    // will this create a circular dependency.
+    if (sourceOrdinal == targetOrdinal)
+      return false;
+    return builders[sourceOrdinal]->hazards.size() > targetOrdinal &&
+           builders[sourceOrdinal]->hazards[targetOrdinal];
   };
-  DenseMap<Operation *, OpInfo> opInfos;
+
+  auto canAddOpToPartition = [&](Operation &op, OpInfo &opInfo,
+                                 unsigned partitionOrdinal) {
+    auto streamableOp = dyn_cast<IREE::Stream::StreamableOpInterface>(op);
+    if (!streamableOp)
+      return false;
+    IREE::Stream::AffinityAttr affinityAttr;
+    if (auto affinityOp = dyn_cast<IREE::Stream::AffinityOpInterface>(op))
+      affinityAttr = affinityOp.getAffinityAttr();
+    if (!IREE::Stream::AffinityAttr::canExecuteTogether(
+            affinityAttr, builders[partitionOrdinal]->affinity))
+      return false;
+
+    bool preferCloneToConsumers = streamableOp.preferCloneToConsumers();
+    llvm::BitVector *opHazards = nullptr;
+    llvm::BitVector opHazardsInCandidatePartition;
+    if (preferCloneToConsumers) {
+      // If we are cloning we care only about users that are a part of the
+      // candidate partition.
+      opHazards = &opHazardsInCandidatePartition;
+      for (auto user : op.getUsers()) {
+        if (builders[partitionOrdinal]->ops.contains(user))
+          opHazardsInCandidatePartition |= opInfos[user].hazards;
+      }
+    } else
+      opHazards = &opInfo.hazards;
+
+    for (auto opHazardOrdinal : opHazards->set_bits()) {
+      if (partitionOrdinal < opHazardOrdinal)
+        // Reject partition ordering that would require partition sorting.
+        // TODO: It is probably more optimal to reorder the partitions after
+        // their formation based on their dependency graph instead of rejecting
+        // here. Since this is considered not a good partitioning algorithm
+        // and will probably get removed, we leave it like that.
+        return false;
+      // Check for formation of circular dependency between partitions.
+      if (willCreateCircularDependencyBetweenPartitions(opHazardOrdinal,
+                                                        partitionOrdinal))
+        return false;
+    }
+    return true;
+  };
 
   auto asmState = getRootAsmState(block);
 
@@ -106,11 +166,6 @@ partitionStreamableOpsReference(IREE::Stream::PartitioningConfigAttr config,
     auto &opInfo = opInfos[&op];
     opInfo.hazards.reserve(builders.size() + 1);
     opInfo.hazards.resize(builders.size(), /*t=*/false);
-
-    IREE::Stream::AffinityAttr affinityAttr;
-    if (auto affinityOp = dyn_cast<IREE::Stream::AffinityOpInterface>(op)) {
-      affinityAttr = affinityOp.getAffinityAttr();
-    }
 
     LLVM_DEBUG({
       llvm::dbgs() << "====\nPartitioning op:\n";
@@ -149,8 +204,7 @@ partitionStreamableOpsReference(IREE::Stream::PartitioningConfigAttr config,
 
     // Prune candidates that do not have a compatible affinity.
     for (auto ordinal : candidates.set_bits()) {
-      if (!IREE::Stream::AffinityAttr::canExecuteTogether(
-              affinityAttr, builders[ordinal]->affinity)) {
+      if (!canAddOpToPartition(op, opInfo, ordinal)) {
         LLVM_DEBUG(llvm::dbgs()
                    << "Candidate partition " << ordinal << " incompatible\n");
         candidates.reset(ordinal);
@@ -181,19 +235,15 @@ partitionStreamableOpsReference(IREE::Stream::PartitioningConfigAttr config,
           LLVM_DEBUG(llvm::dbgs() << "Cloning into consumer partition "
                                   << consumerOrdinal << "\n");
           auto &consumerBuilder = builders[consumerOrdinal];
-          consumerBuilder->insert(&op);
+          consumerBuilder->insert(&op, opInfo);
           consumerBuilder->clonedOps.insert(&op);
-          opInfo.membership.set(consumerOrdinal);
-          opInfo.hazards.reset(consumerOrdinal);
         }
       } else {
         int consumerOrdinal = consumers.find_last();
         LLVM_DEBUG(llvm::dbgs() << "Moving into consumer partition "
                                 << consumerOrdinal << "\n");
         auto &consumerBuilder = builders[consumerOrdinal];
-        consumerBuilder->insert(&op);
-        opInfo.membership.set(consumerOrdinal);
-        opInfo.hazards.reset(consumerOrdinal);
+        consumerBuilder->insert(&op, opInfo);
       }
       LLVM_DEBUG(llvm::dbgs() << "Handled streamable (continue)\n");
       continue;
@@ -204,13 +254,13 @@ partitionStreamableOpsReference(IREE::Stream::PartitioningConfigAttr config,
     if (firstCandidateOrdinal != -1) {
       LLVM_DEBUG(llvm::dbgs() << "Moving to first candidate partition "
                               << firstCandidateOrdinal << " (continue)\n");
-      builders[firstCandidateOrdinal]->insert(&op);
-      opInfo.membership.set(firstCandidateOrdinal);
-      opInfo.hazards.reset(firstCandidateOrdinal);
+      builders[firstCandidateOrdinal]->insert(&op, opInfo);
       continue;
     }
 
     // Mark the op as having hazards against all other partitions.
+    // Why are we that conservative?
+    // Why we don't take the hazards for the users?
     if (!builders.empty()) {
       opInfo.hazards.set(0, builders.size() - 1);
     }
@@ -219,8 +269,7 @@ partitionStreamableOpsReference(IREE::Stream::PartitioningConfigAttr config,
     opInfo.membership.resize(opInfo.membership.size() + 1, /*t=*/true);
     auto builder = std::make_unique<PartitionBuilder>();
     builder->ordinal = builders.size();
-    builder->affinity = affinityAttr;
-    builder->insert(&op);
+    builder->insert(&op, opInfo);
     LLVM_DEBUG(llvm::dbgs()
                << "Created partition " << builder->ordinal << "\n");
     builders.push_back(std::move(builder));


### PR DESCRIPTION
Multi-device programs may produce circular dependency between partitions, which is an invalid partitioning.
One such example is provided as a test case.

To fix this, here we track partitions that transitively depend (hazards) on a partition. Not just per operation.
