### PR TITLE
[test] Check depthwise conv is vectorized in test (NFC)

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization.mlir
@@ -503,3 +503,6 @@ func.func @depthwise_conv_fold_away_masking(%arg0: tensor<1x68x120x96xf32>, %arg
 // CHECK-MASK-LABEL: func.func @depthwise_conv_fold_away_masking
 // CHECK-MASK-NOT: vector.create_mask
 // CHECK-MASK-NOT: vector.constant_mask
+// CHECK-MASK:     vector.fma
+// CHECK-MASK-NOT: vector.create_mask
+// CHECK-MASK-NOT: vector.constant_mask


### PR DESCRIPTION
Quick follow-up to #18190, as I realized the test may also pass if the conv fails to vectorize.