### PR TITLE
Only build the deferred_work_queue when threading is enabled.

### DIFF
--- a/runtime/src/iree/hal/utils/BUILD.bazel
+++ b/runtime/src/iree/hal/utils/BUILD.bazel
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("//build_tools/bazel:build_defs.oss.bzl", "iree_runtime_cc_library", "iree_runtime_cc_test")
+load("//build_tools/bazel:build_defs.oss.bzl", "iree_cmake_extra_content", "iree_runtime_cc_library", "iree_runtime_cc_test")
 load("//build_tools/bazel:cc_binary_benchmark.bzl", "cc_binary_benchmark")
 
 package(
@@ -200,6 +200,15 @@ iree_runtime_cc_test(
         "//runtime/src/iree/testing:gtest",
         "//runtime/src/iree/testing:gtest_main",
     ],
+)
+
+iree_cmake_extra_content(
+    content = """
+if(NOT IREE_ENABLE_THREADING)
+  return()
+endif()
+""",
+    inline = True,
 )
 
 iree_runtime_cc_library(

--- a/runtime/src/iree/hal/utils/CMakeLists.txt
+++ b/runtime/src/iree/hal/utils/CMakeLists.txt
@@ -238,6 +238,10 @@ iree_cc_test(
     iree::testing::gtest_main
 )
 
+if(NOT IREE_ENABLE_THREADING)
+  return()
+endif()
+
 iree_cc_library(
   NAME
     deferred_work_queue


### PR DESCRIPTION
Since iree::base::internal::threading only exists when IREE_ENABLE_THREADING is on, we have to hide deferred_work_queue behind threading.