### PR TITLE
Remove fixed XFAILED test `test_mod_uint64`

### DIFF
--- a/build_tools/pkgci/external_test_suite/onnx_cpu_llvm_sync.json
+++ b/build_tools/pkgci/external_test_suite/onnx_cpu_llvm_sync.json
@@ -514,7 +514,6 @@
     "onnx/node/generated/test_mod_mixed_sign_int32",
     "onnx/node/generated/test_mod_mixed_sign_int64",
     "onnx/node/generated/test_mod_mixed_sign_int8",
-    "onnx/node/generated/test_mod_uint64",
     "onnx/node/generated/test_pow",
     "onnx/node/generated/test_pow_example",
     "onnx/node/generated/test_pow_types_float32_int32",


### PR DESCRIPTION
caused by revious commit:
* 66ed1389b8 - [CPU] Make VectorPreProcStrategy consider undefined behaviors (#18146)