### PR TITLE
Fix broken link on website and stop publishing some asset files.

### DIFF
--- a/docs/website/docs/community/blog/posts/microkernels.md
+++ b/docs/website/docs/community/blog/posts/microkernels.md
@@ -165,12 +165,12 @@ interesting happens *to* it.:
 
 [➤ Appendix: IR dump after WrapEntryPointsPass](#ir-dump-after-wrapentrypointspass)
 
-Next, the first interesting thing is the `CPUMaterializeEncoding` pass, where
+Next, the first interesting thing is the `CPUMaterializeHostEncoding` pass, where
 the `linalg.matmul` gets rewritten into a `linalg.mmt4d` which is a matmul with
 a tiled data layout. This is where we start specializing to the target ISA
 feature set, AVX-512, favoring a 16x16 tile size for this float32 matmul.
 
-[➤ Appendix: IR Dump After CPUMaterializeEncoding](#ir-dump-after-cpumaterializeencoding)
+[➤ Appendix: IR Dump After CPUMaterializeHostEncoding](#ir-dump-after-cpumaterializehostencoding)
 
 The idea is that `linalg.mmt4d` is what we will have a microkernel for, below.
 There is no need to have microkernels for anything but the target-optimal tiled

--- a/docs/website/mkdocs.yml
+++ b/docs/website/mkdocs.yml
@@ -74,6 +74,10 @@ extra_css:
   - assets/stylesheets/extra.css
   - assets/stylesheets/iree.css
 
+exclude_docs: |
+  *.gz
+  assets/images/README.md
+
 copyright: Copyright &copy; 2024 The IREE Authors
 
 markdown_extensions:


### PR DESCRIPTION
We don't need to publish the `iree_architecture.excalidraw.gz` file or the README from https://github.com/iree-org/iree/tree/main/docs/website/docs/assets/images.