### PR TITLE
[Codegen] Add a pass option to control input -> dest pattern

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
@@ -624,9 +624,11 @@ void ConvertToDestinationPassingStylePass::runOnOperation() {
     return signalPassFailure();
   }
 
-  if (failed(adaptComputeConsumerToAvoidStackAllocation(
-          funcOp, useWARForCooperativeMatrixCodegen))) {
-    return signalPassFailure();
+  if (convertInputsToDestinations) {
+    if (failed(adaptComputeConsumerToAvoidStackAllocation(
+            funcOp, useWARForCooperativeMatrixCodegen))) {
+      return signalPassFailure();
+    }
   }
 
   {

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -70,6 +70,9 @@ def ConvertToDestinationPassingStylePass :
     comprehensive bufferization pass.
   }];
   let options = [
+    Option<"convertInputsToDestinations", "convert-inputs-to-destinations",
+           "bool", /*default=*/"true",
+           "Controls whether to adjust consumers to convert one of its inputs to a destination">,
     Option<"useWARForCooperativeMatrixCodegen", "use-war-for-cooperative-matrix-codegen",
            "bool", /*default=*/"false",
            "WAR for failure in Cooperative matrix codegen pipelines. See #10648.">

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
@@ -509,11 +509,21 @@ hal.executable public @main {
 
 #translation_info = #iree_codegen.translation_info<LLVMGPUTileAndFuse workgroup_size = [8, 4, 1] subgroup_size = 32>
 
+#pipeline_layout = #hal.pipeline.layout<
+  push_constants = 0,
+  sets = [
+    <0, bindings = [
+      <0, storage_buffer, "ReadOnly|Indirect">,
+      <1, storage_buffer, ReadOnly>,
+      <2, storage_buffer, Indirect>
+    ], flags = Indirect>
+  ]>
+
 hal.executable public @main {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @conv_nchw_fused ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, "ReadOnly|Indirect">, <1, storage_buffer, ReadOnly>, <2, storage_buffer, Indirect>], flags = Indirect>]>) attributes {hal.interface.bindings = [#hal.interface.binding<0, 0>, #hal.interface.binding<0, 1>, #hal.interface.binding<0, 2>]} {
+    hal.executable.export public @conv_nchw_fused ordinal(0) layout(#pipeline_layout) attributes {hal.interface.bindings = [#hal.interface.binding<0, 0>, #hal.interface.binding<0, 1>, #hal.interface.binding<0, 2>]} {
     ^bb0(%arg0: !hal.device):
-      %x, %y, %z = flow.dispatch.workgroup_count_from_slice 
+      %x, %y, %z = flow.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {


### PR DESCRIPTION
ConvertToDestinationPassingStyle has a pattern to work around a bufferization issue that converts input operands of elementwise consumer linalg ops to destinations. This is an anti-pattern and causes issues with tile + fuse. This adds a pass option to disable this pattern that do not need to worry about it.