### PR TITLE
[CodeGen][DT] Make the TypeConverter carry targetAttr info.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPUMaterializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPUMaterializeEncodings.cpp
@@ -437,15 +437,6 @@ materializeEncodingForTarget(RankedTensorType tensorType,
   return getEncodingInfoForMatmul(encoding, rank, chosenTileMxNxK);
 }
 
-static MaterializeEncodingFn
-getMaterializeEncodingFn(IREE::HAL::ExecutableTargetAttr targetAttr) {
-  return
-      [targetAttr](
-          RankedTensorType tensorType) -> FailureOr<MaterializeEncodingInfo> {
-        return materializeEncodingForTarget(tensorType, targetAttr);
-      };
-}
-
 static FailureOr<MaterializeEncodingValueInfo>
 chooseDynamicEncodingInfoVMVXMicrokernels(RankedTensorType tensorType,
                                           OpBuilder &builder, Location loc) {
@@ -465,18 +456,14 @@ getMaterializeEncodingValueFn(IREE::HAL::ExecutableTargetAttr targetAttr) {
   return {};
 }
 
-static LogicalResult materializeFuncOpEncodings(
-    FunctionOpInterface funcOp,
-    IREE::HAL::ExecutableTargetAttr executableTargetAttr) {
+static LogicalResult
+materializeFuncOpEncodings(FunctionOpInterface funcOp,
+                           IREE::HAL::ExecutableTargetAttr targetAttr) {
   RewritePatternSet materializeEncodingPattern(funcOp.getContext());
-  auto materializeEncodingFn = getMaterializeEncodingFn(executableTargetAttr);
-  if (!materializeEncodingFn) {
-    return failure();
-  }
-  MaterializeEncodingTypeConverter typeConverter(materializeEncodingFn);
+  MaterializeEncodingTypeConverter typeConverter(materializeEncodingForTarget,
+                                                 targetAttr);
   MaterializeEncodingConversionTarget target(*funcOp.getContext());
-  auto materializeEncodingValueFn =
-      getMaterializeEncodingValueFn(executableTargetAttr);
+  auto materializeEncodingValueFn = getMaterializeEncodingValueFn(targetAttr);
   populateMaterializeEncodingIntoPackUnPackPatterns(materializeEncodingPattern,
                                                     target, typeConverter,
                                                     materializeEncodingValueFn);

--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.h
@@ -21,8 +21,8 @@ struct MaterializeEncodingInfo {
   unsigned srcRank = 0;
 };
 
-using MaterializeEncodingFn =
-    std::function<FailureOr<MaterializeEncodingInfo>(RankedTensorType)>;
+using MaterializeEncodingFn = std::function<FailureOr<MaterializeEncodingInfo>(
+    RankedTensorType, IREE::HAL::ExecutableTargetAttr targetAttr)>;
 
 struct MaterializeEncodingValueInfo {
   SmallVector<Value> innerTileSizes;
@@ -37,14 +37,25 @@ using MaterializeEncodingValueFn =
 //===---------------------------------------------------------------------===//
 
 /// TypeConverter to use for materializing the encoding.
-struct MaterializeEncodingTypeConverter : public TypeConverter {
-  MaterializeEncodingTypeConverter(MaterializeEncodingFn fn);
+class MaterializeEncodingTypeConverter : public TypeConverter {
+public:
+  MaterializeEncodingTypeConverter(MaterializeEncodingFn fn,
+                                   IREE::HAL::ExecutableTargetAttr targetAttr);
+
   const MaterializeEncodingFn &getMaterializeEncodingFn() const {
     return materializeEncodingFn;
   }
 
+  IREE::HAL::ExecutableTargetAttr getTargetAttr() const { return targetAttr; }
+
+  FailureOr<MaterializeEncodingInfo>
+  getEncodingInfo(RankedTensorType type) const {
+    return materializeEncodingFn(type, targetAttr);
+  }
+
 private:
   const MaterializeEncodingFn materializeEncodingFn;
+  const IREE::HAL::ExecutableTargetAttr targetAttr;
 };
 
 /// Conversion target to use for for materializing the encoding.

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoNop.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoNop.cpp
@@ -8,6 +8,7 @@
 #include "iree/compiler/Codegen/Common/PassUtils.h"
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingOps.h"
+#include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Pass/PassManager.h"
@@ -33,10 +34,9 @@ struct MaterializeEncodingIntoNopPass final
     MLIRContext *context = &getContext();
     auto operation = getOperation();
 
-    auto materializeEncodingFn =
-        [](RankedTensorType tensorType) -> FailureOr<MaterializeEncodingInfo> {
-      return failure();
-    };
+    auto materializeEncodingFn = [](RankedTensorType,
+                                    IREE::HAL::ExecutableTargetAttr)
+        -> FailureOr<MaterializeEncodingInfo> { return failure(); };
     auto materializeEncodingValueFn =
         [](RankedTensorType, OpBuilder &,
            Location) -> FailureOr<MaterializeEncodingValueInfo> {
@@ -44,7 +44,8 @@ struct MaterializeEncodingIntoNopPass final
     };
 
     RewritePatternSet materializeEncodingPattern(context);
-    MaterializeEncodingTypeConverter typeConverter(materializeEncodingFn);
+    MaterializeEncodingTypeConverter typeConverter(
+        materializeEncodingFn, IREE::HAL::ExecutableTargetAttr());
     MaterializeEncodingConversionTarget target(*context);
     populateMaterializeEncodingIntoPackUnPackPatterns(
         materializeEncodingPattern, target, typeConverter,


### PR DESCRIPTION
The revision adds `ExecutableTargetAttr`  the MaterializeEncodingTypeConverter's data member; updates the MaterializeEncodingFn function to take an additional `ExecutableTargetAttr`. The type converter should know what the target device it. This mostly changes ABI, so there are no changes on lit tests.

It was not done in this way because we wanted to upstream Encoding dialect when we're developing data-tiling. We tried to decouple the deps between Encoding and IREE hard. However, there are IREE specifics in the encodings, so we end up with collapsing them into IREE main source tree. Given that the type converter needs all target attribute details (to figure out the best option for materialization), the revision makes the change; removes one level of nesting logics in the setup. I.e., the `getMaterializeEncodingFn` wrapper function is removed.

This revisions also applies the cleanups. The type converter has an additional function to query encoding info. Instead of passing private `MaterializeEncodingFn` data member, it now passes the whole type converter to the helper functions in materialization patterns. Because the type converter has the all information, and it is more structurally.