### PR TITLE
[compiler][doc] Add HAL passes to doc

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/BUILD.bazel
@@ -108,3 +108,18 @@ iree_gentbl_cc_library(
         "@llvm-project//mlir:PassBaseTdFiles",
     ],
 )
+
+iree_tablegen_doc(
+    name = "HALPassesDocGen",
+    tbl_outs = [
+        (
+            [
+                "--gen-pass-doc",
+            ],
+            "HALPasses.md",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "Passes.td",
+    deps = [":td_files"],
+)

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/BUILD.bazel
@@ -125,5 +125,7 @@ iree_tablegen_doc(
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "Passes.td",
-    deps = [":td_files"],
+    deps = [
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ],
 )

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/BUILD.bazel
@@ -4,7 +4,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("//build_tools/bazel:build_defs.oss.bzl", "iree_compiler_cc_library", "iree_gentbl_cc_library")
+load("//build_tools/bazel:build_defs.oss.bzl",
+    "iree_compiler_cc_library",
+    "iree_gentbl_cc_library",
+    "iree_tablegen_doc",
+)
 
 package(
     default_visibility = ["//visibility:public"],

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/BUILD.bazel
@@ -4,7 +4,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("//build_tools/bazel:build_defs.oss.bzl",
+load(
+    "//build_tools/bazel:build_defs.oss.bzl",
     "iree_compiler_cc_library",
     "iree_gentbl_cc_library",
     "iree_tablegen_doc",

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
@@ -100,4 +100,13 @@ iree_tablegen_library(
     --gen-pass-decls Passes.h.inc
 )
 
+iree_tablegen_doc(
+  NAME
+    HALPassesDocGen
+  TD_FILE
+    "Passes.td"
+  OUTS
+    --gen-pass-doc HALPasses.md
+)
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/docs/website/docs/guides/deployment-configurations/index.md
+++ b/docs/website/docs/guides/deployment-configurations/index.md
@@ -32,7 +32,7 @@ Compiler target backends are used to generate executable code for hardware APIs
 and device architectures. Compiler targets may implement special optimizations
 or generate distinct code for certain device/architecture/performance profiles.
 
-When compiling programs, a list of target backends must be specified via
+When compiling programs, a list of target backends can be specified via
 
 * `--iree-hal-target-backends=` (command-line)
 * `target_backends=[...]` (Python)

--- a/docs/website/docs/reference/Passes.md
+++ b/docs/website/docs/reference/Passes.md
@@ -1,0 +1,10 @@
+# Compiler Passes
+
+[TOC]
+
+## `HAL` dialect passes
+
+{%
+  include-markdown "./mlir-dialects/HALPasses.md"
+  heading-offset=1
+%}

--- a/docs/website/docs/reference/index.md
+++ b/docs/website/docs/reference/index.md
@@ -14,6 +14,8 @@ repository.
 
 * [Index page](./mlir-dialects/index.md)
 
+## [Compiler passes](./Passes.md)
+
 ## Other topics
 
 * [Glossary](./glossary.md)

--- a/docs/website/docs/reference/mlir-dialects/HAL.md
+++ b/docs/website/docs/reference/mlir-dialects/HAL.md
@@ -1,5 +1,0 @@
-[include "HALDialect.md"]
-
-## Passes
-
-[include "HALPasses.md"]

--- a/docs/website/docs/reference/mlir-dialects/HAL.md
+++ b/docs/website/docs/reference/mlir-dialects/HAL.md
@@ -1,0 +1,5 @@
+[include "HALDialect.md"]
+
+## Passes
+
+[include "HALPasses.md"]

--- a/docs/website/mkdocs.yml
+++ b/docs/website/mkdocs.yml
@@ -291,3 +291,7 @@ plugins:
         # "Developers" section was added
         "guides/developer-tips.md": "developers/general/developer-tips.md"
         "developers/building/cmake-options-and-variables.md": "developers/building/cmake-options.md"
+
+validation:
+  nav:
+    omitted_files: info

--- a/docs/website/mkdocs.yml
+++ b/docs/website/mkdocs.yml
@@ -181,6 +181,7 @@ nav:
           # Dialects from llvm-external-projects/iree-dialects/
           - "Public dialects":
               - IREEInput: "reference/mlir-dialects/IREEInput.md"
+      - "Compiler passes": "reference/Passes.md"
       - "Other topics":
           - Glossary: "reference/glossary.md"
           - Optimization options: "reference/optimization-options.md"
@@ -241,6 +242,9 @@ plugins:
       blog_toc: true
       post_url_date_format: yyyy-MM-dd
       post_url_format: "{date}-{slug}"
+
+  # https://github.com/mondeja/mkdocs-include-markdown-plugin
+  - include-markdown
 
   # https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/
   - search

--- a/docs/website/postprocess_dialect_docs.py
+++ b/docs/website/postprocess_dialect_docs.py
@@ -90,7 +90,6 @@ def main(args):
         filename = pathlib.Path(file).name
         relative_path = dialect_sources_map.get(filename, None)
         if not relative_path:
-            print("Warning: missing dialect source path for '%s'" % filename)
             continue
 
         full_url = base_url + relative_path

--- a/docs/website/requirements.txt
+++ b/docs/website/requirements.txt
@@ -1,2 +1,3 @@
+mkdocs-include-markdown-plugin==6.2.2
 mkdocs-material==9.5.19
 mkdocs-redirects==1.2.1


### PR DESCRIPTION
We are not generating documentation for passes. Only for dialect ops, attributes, etc.
This is meant to serve as a pattern example that can be used for other dialects' passes.