### PR TITLE
[Codegen][GPU] Fix allocation space in iree_gpu.shuffle_tensor lowering

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -385,10 +385,7 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager) {
   funcPassManager.addPass(createCleanupBufferAllocViewPass());
 
   // Step 7. Bufferize.
-  // TODO: This is a workaround for a bug in the lowering of
-  // `iree_gpu.shuffle_tensor` which does not properly represent the concurrent
-  // nature of the write to the intermediate tensor.
-  addBufferizePasses(funcPassManager, /*allowPrivateAllocations=*/false);
+  addBufferizePasses(funcPassManager, /*allowPrivateAllocations=*/true);
 
   // Step 8. Resolve remaining parallel loops.
   funcPassManager.addPass(createGPUVerifyDistributionPass());


### PR DESCRIPTION
The memory space for the destination of an `iree_gpu.shuffle_tensor` op must always be shared once lowered. Before lowering it is valid for it to be unspecified, but up until now the lowering was making no guarantee that we ended up with a shared memory space. This changes the memory space and re-enables private allocations from bufferization. This fixes any potential correctness problems arising from vectorization failures.