### PR TITLE
[Codegen][GPU] Add pass to annotate memory spaces on allocations

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
@@ -58,6 +58,7 @@ iree_compiler_cc_library(
         "GPUDistributeSharedMemoryCopy.cpp",
         "GPUDistributionPatterns.cpp",
         "GPUGeneralizeNamedOps.cpp",
+        "GPUInferMemorySpace.cpp",
         "GPULowerToUKernels.cpp",
         "GPUMultiBuffering.cpp",
         "GPUNestedLayoutDistributionPatterns.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
@@ -56,6 +56,7 @@ iree_cc_library(
     "GPUDistributeSharedMemoryCopy.cpp"
     "GPUDistributionPatterns.cpp"
     "GPUGeneralizeNamedOps.cpp"
+    "GPUInferMemorySpace.cpp"
     "GPULowerToUKernels.cpp"
     "GPUMultiBuffering.cpp"
     "GPUNestedLayoutDistributionPatterns.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUInferMemorySpace.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUInferMemorySpace.cpp
@@ -1,0 +1,127 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/GPU/Passes.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
+#include "iree/compiler/Codegen/Utils/GPUUtils.h"
+#include "llvm/ADT/STLExtras.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/Visitors.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_GPUINFERMEMORYSPACEPASS
+#include "iree/compiler/Codegen/Common/GPU/Passes.h.inc"
+
+namespace {
+
+/// Pass to infer the memory spaces of unmarked `bufferization.alloc_tensor`
+/// ops. Inferring the memory space during bufferization (in the allocation
+/// function) is infeasible due to some limited analysis of surrounding loop
+/// structures needed. After this pass, any unexpected allocations are then
+/// treated as a compiler failure indicating something went wrong during or
+/// near bufferization.
+struct GPUInferMemorySpacePass final
+    : impl::GPUInferMemorySpacePassBase<GPUInferMemorySpacePass> {
+
+  void runOnOperation() override;
+};
+
+bool isDefinitelyThreadLocal(bufferization::AllocTensorOp alloc) {
+  ArrayRef<int64_t> allocShape = alloc.getType().getShape();
+  // Give up on dynamic shapes because we can't easily verify that
+  // the destination is overwritten.
+  if (ShapedType::isDynamicShape(allocShape)) {
+    return false;
+  }
+
+  // An allocation can safely be allocated as private if from within a
+  // distributed context all threads overwrite the whole allocation. The logic
+  // below checks for a limited version of this by only looking for
+  // `vector.transfer_write` ops that fully overwrite the tensor.
+  for (auto user : alloc->getUsers()) {
+    if (!operationHasParentForallOfMappingType<gpu::GPUThreadMappingAttr,
+                                               IREE::GPU::LaneIdAttr>(user)) {
+      return false;
+    }
+    auto write = dyn_cast<vector::TransferWriteOp>(user);
+    // TODO: look through reshapes and linalg op destinations if necessary.
+    if (!write) {
+      return false;
+    }
+
+    ArrayRef<int64_t> sourceVecShape = write.getVectorType().getShape();
+    if (!llvm::all_of_zip(allocShape, sourceVecShape,
+                          [](int64_t l, int64_t r) { return l == r; })) {
+      return false;
+    }
+
+    if (!llvm::all_of(write.getIndices(), [](Value value) {
+          return getConstantIntValue(value) == static_cast<int64_t>(0);
+        })) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool isDefinitelyShared(bufferization::AllocTensorOp alloc) {
+  // An allocation can be inferred as shared if it is the destination of a
+  // thread distributed `scf.forall` op. All other shared allocations are
+  // expected to be properly indicated in advance.
+  for (auto user : alloc->getUsers()) {
+    auto forallOp = dyn_cast<scf::ForallOp>(user);
+    if (!forallOp ||
+        !forallOpHasMappingType<gpu::GPUThreadMappingAttr,
+                                gpu::GPUWarpMappingAttr>(forallOp)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void GPUInferMemorySpacePass::runOnOperation() {
+  MLIRContext *context = &getContext();
+  FunctionOpInterface funcOp = getOperation();
+
+  gpu::AddressSpaceAttr privateAddressSpace = gpu::AddressSpaceAttr::get(
+      context, gpu::GPUDialect::getPrivateAddressSpace());
+  gpu::AddressSpaceAttr sharedAddressSpace = gpu::AddressSpaceAttr::get(
+      context, gpu::GPUDialect::getWorkgroupAddressSpace());
+
+  WalkResult res = funcOp.walk([&](bufferization::AllocTensorOp alloc) {
+    // Continue if the allocation already has a memory space.
+    if (alloc.getMemorySpace().has_value()) {
+      return WalkResult::advance();
+    }
+
+    if (isDefinitelyThreadLocal(alloc)) {
+      alloc.setMemorySpaceAttr(privateAddressSpace);
+      return WalkResult::advance();
+    }
+
+    if (isDefinitelyShared(alloc)) {
+      alloc.setMemorySpaceAttr(sharedAddressSpace);
+      return WalkResult::advance();
+    }
+
+    alloc->emitOpError("failed to infer missing memory space.");
+    return WalkResult::interrupt();
+  });
+
+  if (res.wasInterrupted()) {
+    funcOp->emitOpError("failed to set the gpu memory space for all "
+                        "`bufferization.alloc_tensor` ops");
+    return signalPassFailure();
+  }
+}
+
+} // namespace
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVerifyDistribution.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVerifyDistribution.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
+#include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/IR/Visitors.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
@@ -18,28 +19,6 @@ namespace mlir::iree_compiler {
 #include "iree/compiler/Codegen/Common/GPU/Passes.h.inc"
 
 namespace {
-
-template <typename... Type>
-bool forallOpHasMappingType(scf::ForallOp forallOp) {
-  std::optional<ArrayAttr> mapping = forallOp.getMapping();
-  if (!mapping || mapping.value().empty()) {
-    return false;
-  }
-
-  return isa<Type...>(*mapping.value().begin());
-}
-
-template <typename... Type>
-bool operationHasParentForallOfMappingType(Operation *op) {
-  auto parentForallOp = op->getParentOfType<scf::ForallOp>();
-  while (parentForallOp) {
-    if (forallOpHasMappingType<Type...>(parentForallOp)) {
-      return true;
-    }
-    parentForallOp = parentForallOp->getParentOfType<scf::ForallOp>();
-  }
-  return false;
-}
 
 /// Pass to verify that writes only happen in distributed contexts. Code in
 /// shared contexts are executed uniformly across all threads after resolution

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -59,6 +59,14 @@ def GPUGeneralizeNamedOpsPass :
   let summary = "Convert named Linalg ops to linalg.generic ops";
 }
 
+def GPUInferMemorySpacePass :
+    InterfacePass<"iree-codegen-gpu-infer-memory-space", "mlir::FunctionOpInterface"> {
+  let summary = "Pass to infer and set the memory space for all alloc_tensor ops.";
+  let dependentDialects = [
+    "::mlir::gpu::GPUDialect"
+  ];
+}
+
 def GPULowerToUKernelsPass :
     Pass<"iree-codegen-gpu-lower-to-ukernels", ""> {
   let summary = "Separate out parts of the IR that lower to a micro-kernel";

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
@@ -25,6 +25,7 @@ iree_lit_test_suite(
             "gpu_distribute_scf_for.mlir",
             "gpu_distribute_shared_memory.mlir",
             "gpu_generalize_named_ops.mlir",
+            "gpu_infer_memory_space.mlir",
             "gpu_lower_to_ukernels.mlir",
             "gpu_nested_layout_contract_amdgpu.mlir",
             "gpu_nested_layout_vector_distribution.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
@@ -21,6 +21,7 @@ iree_lit_test_suite(
     "gpu_distribute_scf_for.mlir"
     "gpu_distribute_shared_memory.mlir"
     "gpu_generalize_named_ops.mlir"
+    "gpu_infer_memory_space.mlir"
     "gpu_lower_to_ukernels.mlir"
     "gpu_nested_layout_contract_amdgpu.mlir"
     "gpu_nested_layout_vector_distribution.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_infer_memory_space.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_infer_memory_space.mlir
@@ -47,28 +47,8 @@ func.func @already_annotated_alloc() -> tensor<2x3xi32> {
 // -----
 
 // expected-error@+1 {{failed to set the gpu memory space for all `bufferization.alloc_tensor` ops}}
-func.func @write_in_unspecified_forall(%dest : tensor<4x3xi32>) -> tensor<4x3xi32> {
-  // expected-error@+1 {{op failed to infer missing memory space}}
-  %alloc = bufferization.alloc_tensor() : tensor<2x3xi32>
-  %cst = arith.constant dense<0> : vector<2x3xi32>
-  %c0 = arith.constant 0 : index
-  %res = scf.forall (%arg0) in (2) shared_outs(%arg1 = %dest) -> tensor<4x3xi32> {
-    %w = vector.transfer_write %cst, %alloc[%c0, %c0] {in_bounds = [true, true]} : vector<2x3xi32>, tensor<2x3xi32>
-    scf.forall.in_parallel {
-      tensor.parallel_insert_slice %w into %arg1[%arg0, 0] [2, 3] [1, 1] : tensor<2x3xi32> into tensor<4x3xi32>
-    }
-  }
-  return %res : tensor<4x3xi32>
-}
-
-// -----
-
-// expected-error@+1 {{failed to set the gpu memory space for all `bufferization.alloc_tensor` ops}}
-func.func @write_outside_forall() -> tensor<2x3xi32> {
-  // expected-error@+1 {{op failed to infer missing memory space}}
-  %alloc = bufferization.alloc_tensor() : tensor<2x3xi32>
-  %cst = arith.constant dense<0> : vector<2x3xi32>
-  %c0 = arith.constant 0 : index
-  %w = vector.transfer_write %cst, %alloc[%c0, %c0] {in_bounds = [true, true]} : vector<2x3xi32>, tensor<2x3xi32>
-  return %w : tensor<2x3xi32>
+func.func @unknown_memory_space() -> tensor<2x3xi32> {
+  // expected-error@+1 {{unexpected gpu memory space must be private or workgroup.}}
+  %alloc = bufferization.alloc_tensor() {memory_space = "bad"} : tensor<2x3xi32>
+  return %alloc : tensor<2x3xi32>
 }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_infer_memory_space.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_infer_memory_space.mlir
@@ -1,0 +1,74 @@
+// RUN: iree-opt %s --split-input-file --verify-diagnostics \
+// RUN:   --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-infer-memory-space))" | FileCheck %s
+
+func.func @write_in_lane_forall(%dest : tensor<4x3xi32>) -> tensor<4x3xi32> {
+  %alloc = bufferization.alloc_tensor() : tensor<2x3xi32>
+  %cst = arith.constant dense<0> : vector<2x3xi32>
+  %c0 = arith.constant 0 : index
+  %res = scf.forall (%arg0) in (2) shared_outs(%arg1 = %dest) -> tensor<4x3xi32> {
+    %w = vector.transfer_write %cst, %alloc[%c0, %c0] {in_bounds = [true, true]} : vector<2x3xi32>, tensor<2x3xi32>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %w into %arg1[%arg0, 0] [2, 3] [1, 1] : tensor<2x3xi32> into tensor<4x3xi32>
+    }
+  } {mapping = [#iree_gpu.lane_id<0>]}
+  return %res : tensor<4x3xi32>
+}
+
+// CHECK: func @write_in_lane_forall
+// CHECK:   %[[ALLOC:.+]] = bufferization.alloc_tensor() {memory_space = #gpu.address_space<private>}
+// CHECK:   vector.transfer_write %{{.*}}, %[[ALLOC]]
+
+// -----
+
+func.func @forall_shared_dest(%w : tensor<2x3xi32>) -> tensor<4x3xi32> {
+  %dest = bufferization.alloc_tensor() : tensor<4x3xi32>
+  %res = scf.forall (%arg0) in (2) shared_outs(%arg1 = %dest) -> tensor<4x3xi32> {
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %w into %arg1[%arg0, 0] [2, 3] [1, 1] : tensor<2x3xi32> into tensor<4x3xi32>
+    }
+  } {mapping = [#gpu.warp<x>]}
+  return %res : tensor<4x3xi32>
+}
+
+// CHECK: func @forall_shared_dest
+// CHECK:   %[[ALLOC:.+]] = bufferization.alloc_tensor() {memory_space = #gpu.address_space<workgroup>}
+// CHECK:   scf.forall {{.*}} shared_outs(%{{.*}} = %[[ALLOC]])
+
+// -----
+
+func.func @already_annotated_alloc() -> tensor<2x3xi32> {
+  %alloc = bufferization.alloc_tensor() {memory_space = #gpu.address_space<private>} : tensor<2x3xi32>
+  return %alloc : tensor<2x3xi32>
+}
+
+// CHECK: func @already_annotated_alloc
+// CHECK:   bufferization.alloc_tensor() {memory_space = #gpu.address_space<private>}
+
+// -----
+
+// expected-error@+1 {{failed to set the gpu memory space for all `bufferization.alloc_tensor` ops}}
+func.func @write_in_unspecified_forall(%dest : tensor<4x3xi32>) -> tensor<4x3xi32> {
+  // expected-error@+1 {{op failed to infer missing memory space}}
+  %alloc = bufferization.alloc_tensor() : tensor<2x3xi32>
+  %cst = arith.constant dense<0> : vector<2x3xi32>
+  %c0 = arith.constant 0 : index
+  %res = scf.forall (%arg0) in (2) shared_outs(%arg1 = %dest) -> tensor<4x3xi32> {
+    %w = vector.transfer_write %cst, %alloc[%c0, %c0] {in_bounds = [true, true]} : vector<2x3xi32>, tensor<2x3xi32>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %w into %arg1[%arg0, 0] [2, 3] [1, 1] : tensor<2x3xi32> into tensor<4x3xi32>
+    }
+  }
+  return %res : tensor<4x3xi32>
+}
+
+// -----
+
+// expected-error@+1 {{failed to set the gpu memory space for all `bufferization.alloc_tensor` ops}}
+func.func @write_outside_forall() -> tensor<2x3xi32> {
+  // expected-error@+1 {{op failed to infer missing memory space}}
+  %alloc = bufferization.alloc_tensor() : tensor<2x3xi32>
+  %cst = arith.constant dense<0> : vector<2x3xi32>
+  %c0 = arith.constant 0 : index
+  %w = vector.transfer_write %cst, %alloc[%c0, %c0] {in_bounds = [true, true]} : vector<2x3xi32>, tensor<2x3xi32>
+  return %w : tensor<2x3xi32>
+}

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
@@ -166,6 +166,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:ArithToLLVM",
         "@llvm-project//mlir:ArithTransforms",
         "@llvm-project//mlir:BufferizationDialect",
+        "@llvm-project//mlir:BufferizationTransforms",
         "@llvm-project//mlir:ComplexToLLVM",
         "@llvm-project//mlir:ComplexToStandard",
         "@llvm-project//mlir:ControlFlowToLLVM",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -116,6 +116,7 @@ iree_cc_library(
     MLIRArithToLLVM
     MLIRArithTransforms
     MLIRBufferizationDialect
+    MLIRBufferizationTransforms
     MLIRComplexToLLVM
     MLIRComplexToStandard
     MLIRControlFlowToLLVM

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
@@ -558,6 +558,7 @@ hal.executable public @main {
 // CHECK-LABEL: func @conv_nchw_fused
 //       CHECK:   scf.for %{{.*}} = %c0 to %c64 step %c1
 //       CHECK:     linalg.conv_2d_nchw_fchw
+//  CHECK-SAME:       outs(%{{.*}} : memref<1x1x1x1xf32, #gpu.address_space<private>>)
 //       CHECK:   arith.addf
 //       CHECK:   arith.cmpf
 //       CHECK:   arith.select

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -39,6 +39,32 @@ llvm::SmallVector<linalg::ProcInfo, 2>
 getSubgroupIdsAndCounts(OpBuilder &builder, Location loc, unsigned warpSize,
                         unsigned numDims, llvm::ArrayRef<int64_t> numSubgroups);
 
+// Indicates whether the given `scf.forall` op has a processor ID mapping of
+// the template type(s).
+template <typename... Type>
+bool forallOpHasMappingType(scf::ForallOp forallOp) {
+  std::optional<ArrayAttr> mapping = forallOp.getMapping();
+  if (!mapping || mapping.value().empty()) {
+    return false;
+  }
+
+  return isa<Type...>(*mapping.value().begin());
+}
+
+// Indicates whether an operation is within a distributed context with the
+// specified mapping type(s).
+template <typename... Type>
+bool operationHasParentForallOfMappingType(Operation *op) {
+  auto parentForallOp = op->getParentOfType<scf::ForallOp>();
+  while (parentForallOp) {
+    if (forallOpHasMappingType<Type...>(parentForallOp)) {
+      return true;
+    }
+    parentForallOp = parentForallOp->getParentOfType<scf::ForallOp>();
+  }
+  return false;
+}
+
 //===----------------------------------------------------------------------===//
 // GPU vectorization
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Trying to infer the memory space of an allocation from within the
bufferization alloc callback function is too late. This adds a
rudimentary pass to annotate the memory space in obvious situations
and then disallows all cases of a bufferization allocation without an
already pre-determined memory space (for the LLVMGPUTileAndFuse
pipeline). This gives us correctness guarantees that were somewhat hand
wavy before.

This makes all allocations that aren't marked explicitly as shared (or can
be obviously inferred as shared) as thread local. Any previous lowerings
that violate this invariant is a bug (most likely from a failure to tile an
operation).