### PR TITLE
Switch some workflows to use `container:` instead of docker_run.sh.

### DIFF
--- a/.github/workflows/ci_linux_x64_clang_byollvm.yml
+++ b/.github/workflows/ci_linux_x64_clang_byollvm.yml
@@ -28,13 +28,14 @@ concurrency:
 jobs:
   linux_x64_clang_byollvm:
     runs-on: ubuntu-20.04
+    container: gcr.io/iree-oss/base@sha256:dc314b4fe30fc1315742512891357bffed4d1b62ffcb46258b1e0761c737b446
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@v4.1.7
         with:
           submodules: true
       - name: "Building and testing with bring-your-own-LLVM"
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-            gcr.io/iree-oss/base@sha256:dc314b4fe30fc1315742512891357bffed4d1b62ffcb46258b1e0761c737b446 \
-            ./build_tools/cmake/build_and_test_byo_llvm.sh
+        run: ./build_tools/cmake/build_and_test_byo_llvm.sh

--- a/.github/workflows/ci_linux_x64_gcc.yml
+++ b/.github/workflows/ci_linux_x64_gcc.yml
@@ -28,6 +28,10 @@ concurrency:
 jobs:
   linux_x64_gcc:
     runs-on: ubuntu-20.04
+    container: gcr.io/iree-oss/base@sha256:dc314b4fe30fc1315742512891357bffed4d1b62ffcb46258b1e0761c737b446
+    defaults:
+      run:
+        shell: bash
     env:
       BUILD_DIR: build-gcc
     steps:
@@ -36,13 +40,10 @@ jobs:
         with:
           submodules: true
       - name: "Building IREE with gcc"
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-            --env CC=/usr/bin/gcc-9 \
-            --env CXX=/usr/bin/g++-9 \
-            --env CMAKE_BUILD_TYPE=Release \
-            --env "IREE_TARGET_BACKEND_WEBGPU_SPIRV=OFF" \
-            --env "IREE_BUILD_SETUP_PYTHON_VENV=${BUILD_DIR}/.venv" \
-            gcr.io/iree-oss/base@sha256:dc314b4fe30fc1315742512891357bffed4d1b62ffcb46258b1e0761c737b446 \
-            ./build_tools/cmake/build_all.sh \
-            "${BUILD_DIR}"
+        env:
+          CC: /usr/bin/gcc-9
+          CXX: /usr/bin/g++-9
+          CMAKE_BUILD_TYPE: Release
+          IREE_TARGET_BACKEND_WEBGPU_SPIRV: OFF
+          IREE_BUILD_SETUP_PYTHON_VENV: ${{ env.BUILD_DIR }}/.venv
+        run: ./build_tools/cmake/build_all.sh "${BUILD_DIR}"


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree/issues/15332 and https://github.com/iree-org/iree/issues/18238 .

The [`build_tools/docker/docker_run.sh`](https://github.com/iree-org/iree/blob/main/build_tools/docker/docker_run.sh) script does a bunch of weird/hacky setup, including setup for `gcloud` (for working with GCP) and Bazel-specific Docker workarounds. Most CMake builds can just use a container for the entire workflow (https://docs.github.com/en/actions/writing-workflows/choosing-where-your-workflow-runs/running-jobs-in-a-container). Note that GitHub in its infinite wisdom changed the default shell _just_ for jobs that run in a container, from `bash` to `sh`, so we flip it back.

These jobs run nightly on GitHub-hosted runners, so I tested here:
* https://github.com/iree-org/iree/actions/runs/10396020082/job/28789218696
* https://github.com/iree-org/iree/actions/runs/10422541951/job/28867245589

(Those jobs should also run on this PR, but they'll take a while)

skip-ci: no impact on other workflows