### PR TITLE
Refactor how `linux_x64_clang_debug` uses Docker and scripts.

### DIFF
--- a/.github/workflows/ci_linux_x64_clang_debug.yml
+++ b/.github/workflows/ci_linux_x64_clang_debug.yml
@@ -39,6 +39,10 @@ jobs:
       - environment=${{ needs.setup.outputs.runner-env }}
       - cpu
       - os-family=Linux
+    container: gcr.io/iree-oss/base@sha256:dc314b4fe30fc1315742512891357bffed4d1b62ffcb46258b1e0761c737b446
+    defaults:
+      run:
+        shell: bash
     env:
       BUILD_DIR: build-debug
     steps:
@@ -46,16 +50,21 @@ jobs:
         uses: actions/checkout@v4.1.7
         with:
           submodules: true
-      - name: "Building IREE in Debug configuration"
-        env:
-          IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
+      - name: Install Python requirements
+        run: pip install -r ./runtime/bindings/python/iree/runtime/build_requirements.txt
+      # Note: not using ccache here. Debug builds need a lot of cache space
+      # and caching only provides marginal build time improvements.
+      - name: CMake - configure
         run: |
-          ./build_tools/github_actions/docker_run.sh \
-            --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
-            --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
-            --env "CMAKE_BUILD_TYPE=Debug" \
-            --env "CCACHE_NAMESPACE=gcr.io/iree-oss/base@sha256:dc314b4fe30fc1315742512891357bffed4d1b62ffcb46258b1e0761c737b446" \
-            --env "IREE_BUILD_SETUP_PYTHON_VENV=${BUILD_DIR}/.venv" \
-            gcr.io/iree-oss/base@sha256:dc314b4fe30fc1315742512891357bffed4d1b62ffcb46258b1e0761c737b446 \
-            ./build_tools/cmake/build_all.sh \
-            "${BUILD_DIR}"
+          cmake \
+            -G Ninja \
+            -B ${BUILD_DIR} \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DIREE_BUILD_PYTHON_BINDINGS=ON \
+            -DIREE_ENABLE_LLD=ON \
+            -DIREE_ENABLE_ASSERTIONS=ON
+      - name: CMake - build
+        run: cmake --build ${BUILD_DIR} -- -k 0
+      # We could build `iree-test-deps` or run some unit tests here, but the
+      # main thing we want coverage for is the build itself and those steps
+      # would add 10+ minutes to the job.

--- a/.github/workflows/ci_linux_x64_clang_debug.yml
+++ b/.github/workflows/ci_linux_x64_clang_debug.yml
@@ -52,7 +52,7 @@ jobs:
           submodules: true
       - name: Install Python requirements
         run: pip install -r ./runtime/bindings/python/iree/runtime/build_requirements.txt
-      # Note: not using ccache here. Debug builds need a lot of cache space
+      # Note: Not using ccache here. Debug builds need a lot of cache space
       # and caching only provides marginal build time improvements.
       - name: CMake - configure
         run: |


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree/issues/15332 and https://github.com/iree-org/iree/issues/18238 .

Similar to https://github.com/iree-org/iree/pull/18252, this drops a dependency on the [`build_tools/docker/docker_run.sh`](https://github.com/iree-org/iree/blob/main/build_tools/docker/docker_run.sh) script. Unlike that PR, this goes a step further and also stops using [`build_tools/cmake/build_all.sh`](https://github.com/iree-org/iree/blob/main/build_tools/cmake/build_all.sh).

Functional changes:
* No more building `iree-test-deps`
  * We only get marginal value out of compiling test files using a debug compiler
  * Those tests are on the path to being moved to https://github.com/iree-org/iree-test-suites
* No more ccache
  * The debug build cache is too large for a local / GitHub Actions cache
  * I want to limit our reliance on the remote cache at `http://storage.googleapis.com/iree-sccache/ccache` (which uses GCP for storage and needs GCP auth)
  * Experiments show that this build is not significantly faster when using a cache, or at least dropping `iree-test-deps` provides equivalent time savings

Logs before: https://github.com/iree-org/iree/actions/runs/10417779910/job/28864909582 (96% cache hits, 9 minute build but 19 minutes total, due to `iree-test-deps`)
Logs after: https://github.com/iree-org/iree/actions/runs/10423409599/job/28870060781?pr=18255 (no cache, 11 minute build)

ci-exactly: linux_x64_clang_debug