### PR TITLE
Bump LLVM to llvm/llvm-project@ddda37a

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
@@ -146,7 +146,7 @@ struct EmulateNarrowTypePass final
     }
 
     RewritePatternSet sinkBroadcast(ctx);
-    vector::populateSinkVectorBroadcastPatterns(sinkBroadcast);
+    vector::populateSinkVectorOpsPatterns(sinkBroadcast);
     if (failed(applyPatternsAndFoldGreedily(getOperation(),
                                             std::move(sinkBroadcast)))) {
       getOperation()->emitOpError("failed in sinking of broadcasts");

--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -409,6 +409,7 @@ void GenericVectorizationPass::runOnOperation() {
     vector::populateVectorTransferPermutationMapLoweringPatterns(
         vectorizationPatterns);
     vector::populateVectorReductionToContractPatterns(vectorizationPatterns);
+    vector::populateSinkVectorOpsPatterns(vectorizationPatterns);
   }
   if (foldCastIntoContract) {
     vector::populateFoldArithExtensionPatterns(vectorizationPatterns);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
@@ -167,7 +167,7 @@ struct ConvertToNVVMPass final
           LLVM::RoundEvenOp, LLVM::RoundOp, LLVM::SinOp, LLVM::SqrtOp>();
 
       // TODO: Remove once we support replacing non-root ops.
-      target.addLegalOp<gpu::YieldOp, gpu::GPUModuleOp, gpu::ModuleEndOp>();
+      target.addLegalOp<gpu::YieldOp, gpu::GPUModuleOp>();
 
       if (failed(applyPartialConversion(m, target, std::move(llvmPatterns)))) {
         signalPassFailure();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorCoreVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorCoreVectorization.cpp
@@ -96,6 +96,7 @@ public:
       vector::populateVectorTransferPermutationMapLoweringPatterns(
           contractionPatterns);
       vector::populateVectorReductionToContractPatterns(contractionPatterns);
+      vector::populateSinkVectorOpsPatterns(contractionPatterns);
       if (failed(applyPatternsAndFoldGreedily(
               funcOp, std::move(contractionPatterns)))) {
         return signalPassFailure();

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVInitialVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVInitialVectorLowering.cpp
@@ -314,6 +314,7 @@ public:
       // cancel them or embed into contract ops. Embedding in the flexible
       // contract ops will help to sustain the structure through various
       // transformations.
+      vector::populateSinkVectorOpsPatterns(patterns);
       vector::populateVectorReductionToContractPatterns(patterns);
       // Pull in patterns to canonicalize transfer ops.
       vector::populateVectorTransferPermutationMapLoweringPatterns(patterns);

--- a/compiler/src/iree/compiler/Tools/BUILD.bazel
+++ b/compiler/src/iree/compiler/Tools/BUILD.bazel
@@ -105,6 +105,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:GPUTransforms",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LLVMDialect",
+        "@llvm-project//mlir:LLVMIRTransforms",
         "@llvm-project//mlir:LinalgDialect",
         "@llvm-project//mlir:LinalgPassIncGen",
         "@llvm-project//mlir:LinalgTransforms",

--- a/compiler/src/iree/compiler/Tools/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Tools/CMakeLists.txt
@@ -90,6 +90,7 @@ iree_cc_library(
     MLIRGPUToSPIRV
     MLIRIR
     MLIRLLVMDialect
+    MLIRLLVMIRTransforms
     MLIRLinalgDialect
     MLIRLinalgTransforms
     MLIRMLProgramDialect

--- a/compiler/src/iree/compiler/Tools/init_mlir_dialects.h
+++ b/compiler/src/iree/compiler/Tools/init_mlir_dialects.h
@@ -29,6 +29,7 @@
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/GPU/TransformOps/GPUTransformOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/TransformOps/DialectExtension.h"
 #include "mlir/Dialect/MLProgram/IR/MLProgram.h"
@@ -94,6 +95,7 @@ inline void registerMlirDialects(DialectRegistry &registry) {
   // clang-format on
   cf::registerBufferizableOpInterfaceExternalModels(registry);
   func::registerInlinerExtension(registry);
+  LLVM::registerInlinerInterface(registry);
   tensor::registerInferTypeOpInterfaceExternalModels(registry);
   tensor::registerTilingInterfaceExternalModels(registry);
 

--- a/llvm-external-projects/iree-dialects/BUILD.bazel
+++ b/llvm-external-projects/iree-dialects/BUILD.bazel
@@ -400,6 +400,8 @@ cc_binary(
         "@llvm-project//mlir:FuncExtensions",
         "@llvm-project//mlir:FunctionInterfaces",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LLVMDialect",
+        "@llvm-project//mlir:LLVMIRTransforms",
         "@llvm-project//mlir:LinalgDialect",
         "@llvm-project//mlir:LinalgTransformOps",
         "@llvm-project//mlir:LinalgTransforms",

--- a/llvm-external-projects/iree-dialects/tools/iree-dialects-opt/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/tools/iree-dialects-opt/CMakeLists.txt
@@ -13,6 +13,8 @@ set(LIBS
   MLIRFuncDialect
   MLIRFuncInlinerExtension
   MLIRIndexToLLVM
+  MLIRLLVMDialect
+  MLIRLLVMIRTransforms
   MLIRLinalgDialect
   MLIRLinalgTransformOps
   MLIRMemRefDialect

--- a/llvm-external-projects/iree-dialects/tools/iree-dialects-opt/iree-dialects-opt.cpp
+++ b/llvm-external-projects/iree-dialects/tools/iree-dialects-opt/iree-dialects-opt.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
 #include "mlir/Dialect/Func/Extensions/InlinerExtension.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/TransformOps/DialectExtension.h"
 #include "mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.h"
@@ -74,6 +75,7 @@ int main(int argc, char **argv) {
 
   // External models.
   mlir::func::registerInlinerExtension(registry);
+  mlir::LLVM::registerInlinerInterface(registry);
   mlir::linalg::registerTilingInterfaceExternalModels(registry);
 
   registry.addExtensions<transform_ext::StructuredTransformOpsExtension>();


### PR DESCRIPTION
Bump LLVM upstream while reverting https://github.com/llvm/llvm-project/pull/104630 due to issues which will be detailed below.

Potential fixes:
https://github.com/llvm/llvm-project/pull/104630 for issue no.1
https://github.com/llvm/llvm-project/pull/104648 for issue no.2

https://github.com/llvm/llvm-project/pull/104630 breaks 2 things:

1.vm.call + emitc to c code generation.
```mlir
error: null operand found
    vm.check.eq %ref_dno, %res, "_v_r()=NULL" : !vm.ref<?>
%11 = "emitc.call_opaque"(%8, <<NULL VALUE>>) <{callee = "vm_cmp_eq_ref"}> : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, <<NULL TYPE>>) -> i32
```
2.  memref_util_test failure due to populateMemrefUtilPatterns not properly legalizing `builtin.unrealized_conversion_cast`, even though we expected `builtin.unrealized_conversion_cast`. 
```mlir
memref_util_test.mlir:1:79: error: failed to legalize unresolved materialization from ('i32') to 'i16' that remained live after conversion
util.func @load_store_i16(%buffer: memref<?xi16>, %idx0: index, %idx1: index, %value: i16) -> i16 {
                                                                              ^
memref_util_test.mlir:1:79: note: see current operation: %0 = "builtin.unrealized_conversion_cast"(%arg3) : (i32) -> i16
memref_util_test.mlir:7:3: note: see existing live user here: "util.buffer.store"(%0, %arg0, %4, %6, %5) : (i16, !util.buffer, index, index, index) -> ()
  memref.store %value, %buffer[%idx0] : memref<?xi16>
  ^
memref_util_test.mlir:0:0: error: conversion to util failed
memref_util_test.mlir:0:0: note: see current operation:
"builtin.module"() ({
  "util.func"() <{function_type = (memref<?xi16>, index, index, i16) -> i16, sym_name = "load_store_i16", tied_operands = [-1 : index]}> ({
  ^bb0(%arg0: memref<?xi16>, %arg1: index, %arg2: index, %arg3: i16):
    "memref.store"(%arg3, %arg0, %arg1) : (i16, memref<?xi16>, index) -> ()
    %0 = "memref.load"(%arg0, %arg2) : (memref<?xi16>, index) -> i16
    "util.return"(%0) : (i16) -> ()
  }) : () -> ()
}) : () -> ()
```

