### PR TITLE
[Codegen] Add pass to tile and distribute workgroups using `scf.forall` op.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -139,6 +139,7 @@ iree_compiler_cc_library(
         "TestExecutablePreprocessing.cpp",
         "TestPartitionableLoopsInterface.cpp",
         "TileAndDistributeToWorkgroupsPass.cpp",
+        "TileDispatchUsingForall.cpp",
         "TileDispatchUsingInterface.cpp",
         "TileSizeSelection.cpp",
         "TypePropagationPass.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -130,6 +130,7 @@ iree_cc_library(
     "TestExecutablePreprocessing.cpp"
     "TestPartitionableLoopsInterface.cpp"
     "TileAndDistributeToWorkgroupsPass.cpp"
+    "TileDispatchUsingForall.cpp"
     "TileDispatchUsingInterface.cpp"
     "TileSizeSelection.cpp"
     "TypePropagationPass.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -497,6 +497,19 @@ def TileAndDistributeToWorkgroupsPass :
   ];
 }
 
+def TileAndDistributeToWorkgroupsUsingForallOpPass :
+    InterfacePass<"iree-codegen-tile-and-distribute-to-workgroups-using-forall-op",
+                  "mlir::FunctionOpInterface"> {
+  let summary = "Tile and distribute operation to workgroups (using scf.forall op)";
+  let dependentDialects = [
+    "affine::AffineDialect",
+    "IREE::Codegen::IREECodegenDialect",
+    "IREE::LinalgExt::IREELinalgExtDialect",
+    "scf::SCFDialect",
+    "tensor::TensorDialect",
+  ];
+}
+
 def TransformDialectInterpreterPass :
     Pass<"iree-transform-dialect-interpreter"> {
   let summary = "Pass to apply transform dialect operations.";

--- a/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
@@ -413,8 +413,7 @@ void TileAndDistributeToWorkgroupsPass::runOnOperation() {
 
   {
     RewritePatternSet patterns(context);
-    populateTileAndDistributeToWorkgroupsCleanupPatterns(patterns,
-                                                         linalgTilingOptions);
+    populateTileAndDistributeToWorkgroupsCleanupPatterns(patterns);
     if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
       funcOp.emitOpError("Tile+Distribute clean up patterns failed");
       return signalPassFailure();

--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
@@ -1,0 +1,202 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/Passes.h"
+#include "iree/compiler/Codegen/Common/Transforms.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
+#include "iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/MemRef/Transforms/Transforms.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/SCF/Transforms/TileUsingInterface.h"
+#include "mlir/Dialect/Tensor/Transforms/Transforms.h"
+#include "mlir/IR/StorageUniquerSupport.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_TILEANDDISTRIBUTETOWORKGROUPSUSINGFORALLOPPASS
+#include "iree/compiler/Codegen/Common/Passes.h.inc"
+
+namespace {
+
+struct TileAndDistributeToWorkgroupsUsingForallOpPass final
+    : public impl::TileAndDistributeToWorkgroupsUsingForallOpPassBase<
+          TileAndDistributeToWorkgroupsUsingForallOpPass> {
+  using Base::Base;
+  void runOnOperation() override;
+};
+
+} // namespace
+
+/// Find the lowering config to use for getting the tile sizes.
+// TODO: For now this is taking the "last op" in the dispatch, but
+// ideally this should take the "root op" that gets tiled and everything
+// gets fused with it. For now to keep consistent with the legacy
+// tile-and-distribute it is still looking for the "last compute operation".
+struct TilingInfo {
+  Operation *tilableOp;
+  SmallVector<OpFoldResult> tileSizes;
+  SmallVector<int64_t> interchange;
+};
+
+static FailureOr<TilingInfo>
+getTiledAndDistributionInfo(RewriterBase &rewriter,
+                            ArrayRef<Operation *> computeOps) {
+  Operation *tilableOp = nullptr;
+  for (Operation *op : llvm::reverse(computeOps)) {
+    if (getLoweringConfig(op)) {
+      tilableOp = op;
+      break;
+    }
+  }
+  if (!tilableOp) {
+    // There is no lowering config. Return `null`.
+    return TilingInfo{nullptr, {}, {}};
+  }
+
+  IREE::Codegen::LoweringConfigAttrInterface tilableOpConfig =
+      getLoweringConfig(tilableOp);
+  if (!tilableOpConfig) {
+    return tilableOp->emitOpError("unable to find configuration of root op to "
+                                  "define workgroup count region");
+  }
+  auto tileSizes = llvm::map_to_vector(
+      tilableOpConfig.getWorkgroupTileSizes(),
+      [&](int64_t t) -> OpFoldResult { return rewriter.getIndexAttr(t); });
+  SmallVector<int64_t> interchange = tilableOpConfig.getWorkgroupInterchange();
+
+  // Avoid distributing unit-trip count loops.
+
+  // Set tile sizes for non-partitioned loops to zero.
+  if (auto partitionableLoopsInterface =
+          dyn_cast<PartitionableLoopsInterface>(tilableOp)) {
+    SmallVector<unsigned> partitionableLoops =
+        partitionableLoopsInterface.getPartitionableLoops(std::nullopt);
+    llvm::SmallDenseSet<unsigned> partitionableLoopsSet(
+        partitionableLoops.begin(), partitionableLoops.end());
+    OpFoldResult zero = rewriter.getIndexAttr(0);
+    for (auto loopId : llvm::seq<unsigned>(0, tileSizes.size())) {
+      if (partitionableLoopsSet.count(loopId)) {
+        continue;
+      }
+      tileSizes[loopId] = zero;
+    }
+  }
+
+  return TilingInfo{tilableOp, tileSizes, interchange};
+}
+
+/// Helper function to return the mapping attribute to use given the tile sizes.
+static SmallVector<Attribute> getMapping(MLIRContext *context,
+                                         ArrayRef<OpFoldResult> tileSizes) {
+  SmallVector<Attribute> mapping;
+  mapping.reserve(tileSizes.size());
+  for (auto tileSize : llvm::reverse(tileSizes)) {
+    if (isConstantIntValue(tileSize, 0)) {
+      continue;
+    }
+    uint64_t currSize = mapping.size();
+    switch (currSize) {
+    case 0:
+    case 1:
+    case 2:
+      mapping.push_back(IREE::Codegen::WorkgroupMappingAttr::get(
+          context, IREE::Codegen::symbolizeWorkgroupId(currSize).value()));
+      break;
+    default:
+      mapping.push_back(IREE::Codegen::WorkgroupMappingAttr::get(
+          context, IREE::Codegen::WorkgroupId::IdZ, currSize - 2));
+    }
+  }
+  return llvm::to_vector(llvm::reverse(mapping));
+}
+
+void TileAndDistributeToWorkgroupsUsingForallOpPass::runOnOperation() {
+  auto funcOp = getOperation();
+  auto *context = &getContext();
+  SmallVector<Operation *> computeOps = getComputeOps(funcOp);
+
+  IRRewriter rewriter(context);
+  FailureOr<TilingInfo> tilingInfo =
+      getTiledAndDistributionInfo(rewriter, computeOps);
+  if (failed(tilingInfo)) {
+    return signalPassFailure();
+  }
+  auto tilableOp = dyn_cast_or_null<TilingInterface>(tilingInfo->tilableOp);
+  if (!tilableOp) {
+    // Did not find a tileable op. So do nothing.
+    return;
+  }
+
+  scf::SCFTilingOptions tilingOptions;
+  tilingOptions.setTileSizes(tilingInfo->tileSizes);
+  tilingOptions.setInterchange(tilingInfo->interchange);
+  tilingOptions.setLoopType(scf::SCFTilingOptions::LoopType::ForallOp);
+  SmallVector<Attribute> deviceMappingAttribute =
+      getMapping(context, tilingInfo->tileSizes);
+  if (failed(IREE::Codegen::WorkgroupMappingAttr::verifyAttrList(
+          context, ::mlir::detail::getDefaultDiagnosticEmitFn(funcOp.getLoc()),
+          deviceMappingAttribute))) {
+    return signalPassFailure();
+  }
+  tilingOptions.setMapping(deviceMappingAttribute);
+
+  scf::SCFTileAndFuseOptions tileAndFuseOptions;
+  tileAndFuseOptions.setTilingOptions(tilingOptions);
+  // TODO: For now use the default tile and fuse control function. That needs
+  // to be modified to allow for returning the values of the producer when
+  // needed.
+  rewriter.setInsertionPoint(tilableOp);
+
+  // If the `tilableOp` is a `memref` op, then just tile the operation.
+  SmallVector<LoopLikeOpInterface> tilingLoops;
+  if (tilableOp->getNumResults() == 0) {
+    FailureOr<scf::SCFTilingResult> tilingResult =
+        scf::tileUsingSCF(rewriter, tilableOp, tilingOptions);
+    if (failed(tilingResult)) {
+      funcOp.emitOpError("tiling failed");
+      return signalPassFailure();
+    }
+    rewriter.eraseOp(tilableOp);
+    std::swap(tilingResult->loops, tilingLoops);
+  } else {
+    FailureOr<scf::SCFTileAndFuseResult> tileAndFuseResult =
+        scf::tileConsumerAndFuseProducersUsingSCF(rewriter, tilableOp,
+                                                  tileAndFuseOptions);
+    if (failed(tileAndFuseResult)) {
+      funcOp.emitOpError("tile and fuse greedily failed");
+      return signalPassFailure();
+    }
+    for (auto [origValue, replacement] : tileAndFuseResult->replacements) {
+      rewriter.replaceAllUsesWith(origValue, replacement);
+    }
+    std::swap(tileAndFuseResult->loops, tilingLoops);
+  }
+
+  // Cleanup patterns for tile and distribute
+  {
+    RewritePatternSet patterns(context);
+    linalg::populateLinalgTilingCanonicalizationPatterns(patterns);
+    tensor::populateFoldTensorEmptyPatterns(patterns);
+    context->getOrLoadDialect<tensor::TensorDialect>()
+        ->getCanonicalizationPatterns(patterns);
+    context->getOrLoadDialect<IREE::LinalgExt::IREELinalgExtDialect>()
+        ->getCanonicalizationPatterns(patterns);
+    memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);
+    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      funcOp.emitOpError("tiling canonicalization failed");
+      return signalPassFailure();
+    }
+  }
+
+  return;
+}
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingInterface.cpp
@@ -611,7 +611,7 @@ struct SwapExtractSliceWithTensorEmpty
 } // namespace
 
 void populateTileAndDistributeToWorkgroupsCleanupPatterns(
-    RewritePatternSet &patterns, linalg::LinalgTilingOptions options) {
+    RewritePatternSet &patterns) {
   MLIRContext *context = patterns.getContext();
   patterns.insert<SwapExtractSliceWithDispatchTensorLoad,
                   SwapExtractSliceWithTensorEmpty>(context);

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.h
@@ -60,7 +60,7 @@ tileDispatchUsingSCFFopOp(RewriterBase &rewriter, TilingInterface op,
 /// Populate patterns related to clean up the IR after tile and distribute
 /// to workgroups.
 void populateTileAndDistributeToWorkgroupsCleanupPatterns(
-    RewritePatternSet &patterns, linalg::LinalgTilingOptions options);
+    RewritePatternSet &patterns);
 
 /// Populate IREE patterns related to resolving
 /// `memref.extract_strided_metadata`.

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -66,6 +66,7 @@ iree_lit_test_suite(
             "replace_slow_min_max_ops.mlir",
             "test_partitionable_loops_interface.mlir",
             "tile_and_distribute_to_workgroups.mlir",
+            "tile_and_distribute_workgroups_using_forall.mlir",
             "transform_buffer_opt.mlir",
             "transform_copy_operand.mlir",
             "transform_flatten_forall.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -62,6 +62,7 @@ iree_lit_test_suite(
     "replace_slow_min_max_ops.mlir"
     "test_partitionable_loops_interface.mlir"
     "tile_and_distribute_to_workgroups.mlir"
+    "tile_and_distribute_workgroups_using_forall.mlir"
     "transform_buffer_opt.mlir"
     "transform_copy_operand.mlir"
     "transform_flatten_forall.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_workgroups_using_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_workgroups_using_forall.mlir
@@ -1,0 +1,353 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-tile-and-distribute-to-workgroups-using-forall-op, cse))" --mlir-print-local-scope --split-input-file %s | FileCheck %s
+
+func.func @matmul_tensors(%0 : tensor<?x?xf32>, %1 : tensor<?x?xf32>, %2 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %3 = linalg.matmul {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[64, 64, 0]]>}
+      ins(%0, %1 : tensor<?x?xf32>, tensor<?x?xf32>)
+      outs(%2 : tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %3 : tensor<?x?xf32>
+}
+// CHECK-LABEL: func @matmul_tensors(
+//  CHECK-SAME:     %[[LHS:[a-zA-Z0-9]+]]: tensor<?x?xf32>,
+//  CHECK-SAME:     %[[RHS:[a-zA-Z0-9]+]]: tensor<?x?xf32>,
+//  CHECK-SAME:     %[[INIT:[a-zA-Z0-9]+]]: tensor<?x?xf32>)
+//       CHECK:   %[[RESULT:.+]] = scf.forall (%[[IV0:[a-zA-Z0-9]+]], %[[IV1:[a-zA-Z0-9]+]])
+//  CHECK-SAME:       shared_outs(%[[OUTS:.+]] = %[[INIT]])
+//   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]][%[[IV0]], 0]
+//   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]][0, %[[IV1]]
+//   CHECK-DAG:     %[[INIT_SLICE:.+]] = tensor.extract_slice %[[OUTS]][%[[IV0]], %[[IV1]]{{\]}}
+//       CHECK:     %[[MATMUL_SLICE:.+]] = linalg.matmul
+//  CHECK-SAME:         ins(%[[LHS_SLICE]], %[[RHS_SLICE]] :
+//  CHECK-SAME:         outs(%[[INIT_SLICE]] :
+//       CHECK:     scf.forall.in_parallel
+//       CHECK:       tensor.parallel_insert_slice %[[MATMUL_SLICE]] into %[[OUTS]][%[[IV0]], %[[IV1]]]
+//       CHECK:     mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]
+//       CHECK:   return %[[RESULT]]
+
+// -----
+
+func.func @add4D(%0 : index, %1 : index, %2 : index, %3 : index,
+    %7 : tensor<?x?x?x?xf32>, %8 : tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32> {
+  %9 = tensor.empty(%0, %1, %2, %3) : tensor<?x?x?x?xf32>
+  %10 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>,
+                       affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>,
+                       affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
+      iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+      ins(%7, %8 : tensor<?x?x?x?xf32>, tensor<?x?x?x?xf32>)
+      outs(%9 : tensor<?x?x?x?xf32>)
+      attrs = {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[0, 64, 64, 64]]>} {
+    ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
+      %11 = arith.addf %arg0, %arg1 : f32
+      linalg.yield %11 : f32
+    } -> tensor<?x?x?x?xf32>
+  return %10 : tensor<?x?x?x?xf32>
+}
+// CHECK-LABEL: func.func @add4D(
+//       CHECK:   %[[RESULT:.+]] = scf.forall (%[[IV0:[a-zA-Z0-9]+]], %[[IV1:[a-zA-Z0-9]+]], %[[IV2:[a-zA-Z0-9]+]]) =
+//       CHECK:     %[[TILED_GENERIC:.+]] = linalg.generic
+//       CHECK:     scf.forall.in_parallel {
+//       CHECK:       tensor.parallel_insert_slice %[[TILED_GENERIC]] into %{{.+}}[0, %[[IV0]], %[[IV1]], %[[IV2]]{{\]}}
+//       CHECK:   mapping = [#iree_codegen.workgroup_mapping<z>, #iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]
+//       CHECK:   return %[[RESULT]]
+
+// -----
+
+func.func @add_distribute4D(%0 : index, %1 : index, %2 : index, %3 : index,
+  %7 : tensor<?x?x?x?xf32>, %8 : tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32> {
+  %9 = tensor.empty(%0, %1, %2, %3) : tensor<?x?x?x?xf32>
+  %10 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>,
+                       affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>,
+                       affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
+      iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+      ins(%7, %8 : tensor<?x?x?x?xf32>, tensor<?x?x?x?xf32>)
+      outs(%9 : tensor<?x?x?x?xf32>)
+      attrs =  {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[2, 64, 64, 64]]>} {
+    ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
+      %11 = arith.addf %arg0, %arg1 : f32
+      linalg.yield %11 : f32
+    } -> tensor<?x?x?x?xf32>
+  return %10 : tensor<?x?x?x?xf32>
+}
+// CHECK-LABEL: func.func @add_distribute4D(
+//       CHECK:   %[[RESULT:.+]] = scf.forall
+//  CHECK-SAME:       (%[[IV0:[a-zA-Z0-9]+]], %[[IV1:[a-zA-Z0-9]+]], %[[IV2:[a-zA-Z0-9]+]], %[[IV3:[a-zA-Z0-9]+]]) =
+//       CHECK:     %[[TILED_GENERIC:.+]] = linalg.generic
+//       CHECK:     scf.forall.in_parallel {
+//       CHECK:       tensor.parallel_insert_slice %[[TILED_GENERIC]] into %{{.+}}[%[[IV0]], %[[IV1]], %[[IV2]], %[[IV3]]{{\]}}
+//       CHECK:   mapping = [#iree_codegen.workgroup_mapping<z:1>, #iree_codegen.workgroup_mapping<z>, #iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]
+//       CHECK:   return %[[RESULT]]
+
+// -----
+
+func.func @add_distribute4D_zero_tile_size(%0 : index, %1 : index, %2 : index, %3 : index,
+  %7 : tensor<?x?x?x?xf32>, %8 : tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32> {
+  %9 = tensor.empty(%0, %1, %2, %3) : tensor<?x?x?x?xf32>
+  %10 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>,
+                       affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>,
+                       affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
+      iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+      ins(%7, %8 : tensor<?x?x?x?xf32>, tensor<?x?x?x?xf32>)
+      outs(%9 : tensor<?x?x?x?xf32>)
+      attrs =  {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[2, 64, 0, 64]]>} {
+    ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
+      %11 = arith.addf %arg0, %arg1 : f32
+      linalg.yield %11 : f32
+    } -> tensor<?x?x?x?xf32>
+  return %10 : tensor<?x?x?x?xf32>
+}
+// CHECK-LABEL: func.func @add_distribute4D_zero_tile_size(
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : index
+//   CHECK-DAG:   %[[C3:.+]] = arith.constant 3 : index
+//   CHECK-DAG:   %[[D0:.+]] = tensor.dim %{{.+}}, %[[C0]]
+//   CHECK-DAG:   %[[D1:.+]] = tensor.dim %{{.+}}, %[[C1]]
+//   CHECK-DAG:   %[[D2:.+]] = tensor.dim %{{.+}}, %[[C2]]
+//   CHECK-DAG:   %[[D3:.+]] = tensor.dim %{{.+}}, %[[C3]]
+//       CHECK:   %[[RESULT:.+]] = scf.forall
+//  CHECK-SAME:       (%[[IV0:[a-zA-Z0-9]+]], %[[IV1:[a-zA-Z0-9]+]], %[[IV2:[a-zA-Z0-9]+]]) =
+//  CHECK-SAME:       to (%[[D0]], %[[D1]], %[[D3]])
+//       CHECK:     %[[SLICE:.+]] = tensor.extract_slice %{{.+}}[%[[IV0]], %[[IV1]], 0, %[[IV2]]] [%{{.+}}, %{{.+}}, %[[D2]], %{{.+}}]
+//       CHECK:     %[[TILED_GENERIC:.+]] = linalg.generic
+//  CHECK-SAME:         ins(%[[SLICE]],
+//       CHECK:     scf.forall.in_parallel {
+//       CHECK:       tensor.parallel_insert_slice %[[TILED_GENERIC]] into %{{.+}}[%[[IV0]], %[[IV1]], 0, %[[IV2]]{{\]}}
+//       CHECK:   mapping = [#iree_codegen.workgroup_mapping<z>, #iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]
+//       CHECK:   return %[[RESULT]]
+
+// -----
+
+func.func @gemm_unit_N(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x1xf32>,
+    %arg2 : tensor<?x1xf32>) -> tensor<?x1xf32> {
+  %0 = linalg.matmul {
+      lowering_config = #iree_codegen.lowering_config<tile_sizes = [[64, 64, 64]]>}
+      ins(%arg0, %arg1 : tensor<?x?xf32>, tensor<?x1xf32>)
+      outs(%arg2 : tensor<?x1xf32>) -> tensor<?x1xf32>
+  return %0 : tensor<?x1xf32>
+}
+// CHECK-LABEL: func.func @gemm_unit_N(
+//       CHECK:   %[[RESULT:.+]] = scf.forall (%[[IV0:[a-zA-Z0-9]+]])
+//       CHECK:     %[[MATMUL:.+]] = linalg.matmul
+//       CHECK:     scf.forall.in_parallel {
+//       CHECK:       tensor.parallel_insert_slice %[[MATMUL]] into %{{.+}}[%[[IV0]], 0] [%{{.+}}, 1]
+
+// -----
+
+func.func @gemm_unit_N(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x1xf32>,
+    %arg2 : tensor<?x1xf32>) -> tensor<?x1xf32> {
+  %0 = linalg.matmul {
+      lowering_config = #iree_codegen.lowering_config<tile_sizes = [[64, 64, 64]]>}
+      ins(%arg0, %arg1 : tensor<?x?xf32>, tensor<?x1xf32>)
+      outs(%arg2 : tensor<?x1xf32>) -> tensor<?x1xf32>
+  return %0 : tensor<?x1xf32>
+}
+// CHECK-LABEL: func.func @gemm_unit_N(
+//       CHECK:   %[[RESULT:.+]] = scf.forall (%[[IV0:[a-zA-Z0-9]+]])
+//       CHECK:     %[[MATMUL:.+]] = linalg.matmul
+//       CHECK:     scf.forall.in_parallel {
+//       CHECK:       tensor.parallel_insert_slice %[[MATMUL]] into %{{.+}}[%[[IV0]], 0] [%{{.+}}, 1]
+
+// -----
+
+func.func @gemm_unit_M_unit_N(%arg0 : tensor<1x1xf32>, %arg1 : tensor<1x1xf32>,
+    %arg2 : tensor<1x1xf32>) -> tensor<1x1xf32> {
+  %0 = linalg.matmul {
+      lowering_config = #iree_codegen.lowering_config<tile_sizes = [[64, 64, 64]]>}
+      ins(%arg0, %arg1 : tensor<1x1xf32>, tensor<1x1xf32>)
+      outs(%arg2 : tensor<1x1xf32>) -> tensor<1x1xf32>
+  return %0 : tensor<1x1xf32>
+}
+// CHECK-LABEL: func.func @gemm_unit_M_unit_N(
+//   CHECK-NOT:   scf.forall
+
+// -----
+
+func.func @generic_unit_dims(%arg0 : tensor<1x?x1x1x?x?x1x?xf32>) -> tensor<1x?x1x1x?x?x1x?xf32> {
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  %c5 = arith.constant 5 : index
+  %c7 = arith.constant 7 : index
+  %d1 = tensor.dim %arg0, %c1 : tensor<1x?x1x1x?x?x1x?xf32>
+  %d4 = tensor.dim %arg0, %c4 : tensor<1x?x1x1x?x?x1x?xf32>
+  %d5 = tensor.dim %arg0, %c5 : tensor<1x?x1x1x?x?x1x?xf32>
+  %d7 = tensor.dim %arg0, %c7 : tensor<1x?x1x1x?x?x1x?xf32>
+  %empty = tensor.empty(%d1, %d4, %d5, %d7) : tensor<1x?x1x1x?x?x1x?xf32>
+  %0 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3, d4, d5, d6, d7)>,
+                       affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3, d4, d5, d6, d7)>],
+      iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel", "parallel"]}
+      ins(%arg0 : tensor<1x?x1x1x?x?x1x?xf32>) outs(%empty : tensor<1x?x1x1x?x?x1x?xf32>)
+      attrs = {lowering_config = #iree_codegen.lowering_config<tile_sizes=[[0, 0, 0, 0, 64, 64, 0, 64]]>} {
+    ^bb0(%b0: f32, %b1: f32):
+      %9 = arith.addf %b0, %b0 : f32
+      linalg.yield %9 : f32
+  } -> tensor<1x?x1x1x?x?x1x?xf32>
+  return %0 : tensor<1x?x1x1x?x?x1x?xf32>
+}
+// CHECK-LABEL: func.func @generic_unit_dims(
+//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG:   %[[C4:.+]] = arith.constant 4 : index
+//   CHECK-DAG:   %[[C5:.+]] = arith.constant 5 : index
+//   CHECK-DAG:   %[[C7:.+]] = arith.constant 7 : index
+//   CHECK-DAG:   %[[D1:.+]] = tensor.dim %{{.+}}, %[[C1]]
+//   CHECK-DAG:   %[[D4:.+]] = tensor.dim %{{.+}}, %[[C4]]
+//   CHECK-DAG:   %[[D5:.+]] = tensor.dim %{{.+}}, %[[C5]]
+//   CHECK-DAG:   %[[D7:.+]] = tensor.dim %{{.+}}, %[[C7]]
+//       CHECK:   %[[RESULT:.+]] = scf.forall
+//  CHECK-SAME:       (%[[IV0:[a-zA-Z0-9]+]], %[[IV1:[a-zA-Z0-9]+]], %[[IV2:[a-zA-Z0-9]+]]) =
+//  CHECK-SAME:       to (%[[D4]], %[[D5]], %[[D7]])
+//       CHECK:     %[[SLICE:.+]] = tensor.extract_slice %{{.+}}[0, 0, 0, 0, %[[IV0]], %[[IV1]], 0, %[[IV2]]]
+//  CHECK-SAME:         [1, %[[D1]], 1, 1, %{{.+}}, %{{.+}}, 1, %{{.+}}]
+//       CHECK:     %[[TILED_GENERIC:.+]] = linalg.generic
+//  CHECK-SAME:         ins(%[[SLICE]] :
+//       CHECK:     scf.forall.in_parallel {
+//       CHECK:       tensor.parallel_insert_slice %[[TILED_GENERIC]] into %{{.+}}[0, 0, 0, 0, %[[IV0]], %[[IV1]], 0, %[[IV2]]{{\]}}
+//  CHECK-SAME:           [1, %[[D1]], 1, 1, %{{.+}}, %{{.+}}, 1, %{{.+}}]
+//       CHECK:   mapping = [#iree_codegen.workgroup_mapping<z>, #iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]
+//       CHECK:   return %[[RESULT]]
+
+// -----
+
+func.func @reduce_to_scalar(%arg0 : tensor<?xf32>, %arg1 : tensor<f32>) -> tensor<f32> {
+  %0 = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> ()>],
+      iterator_types = ["reduction"]}
+      ins(%arg0 : tensor<?xf32>) outs(%arg1 : tensor<f32>)
+      attrs = {lowering_config = #iree_codegen.lowering_config<tile_sizes=[[]]>} {
+    ^bb0(%b0 : f32, %b1 : f32) :
+      %1 = arith.addf %b0, %b1 : f32
+      linalg.yield %1 : f32
+  } -> tensor<f32>
+  return %0 : tensor<f32>
+}
+// CHECK-LABEL: func @reduce_to_scalar(
+//   CHECK-NOT:   scf.forall
+
+// -----
+
+func.func @scalar(%arg0 : tensor<f32>) -> tensor<f32> {
+  %0 = tensor.empty() : tensor<f32>
+  %1 = linalg.generic {
+      indexing_maps = [affine_map<() -> ()>, affine_map<() -> ()>], iterator_types = []}
+      ins(%arg0 : tensor<f32>) outs(%0 : tensor<f32>)
+      attrs = {lowering_config = #iree_codegen.lowering_config<tile_sizes=[[]]>} {
+    ^bb0(%b0 : f32, %b1 : f32) :
+      %1 = arith.addf %b0, %b0 : f32
+      linalg.yield %1 : f32
+  } -> tensor<f32>
+  return %1 : tensor<f32>
+}
+// CHECK-LABEL: func @scalar(
+//   CHECK-NOT:   scf.forall
+
+// -----
+
+func.func @matmul_interchange(%0 : tensor<?x?xf32>,
+    %1 : tensor<?x?xf32>, %2 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %3 = linalg.matmul
+      {lowering_config = #iree_codegen.lowering_config<tile_sizes = [{sizes = [32, 64, 0], interchange = [1, 0, 2]}]>}
+      ins(%0, %1 : tensor<?x?xf32>, tensor<?x?xf32>)
+      outs(%2 : tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %3 : tensor<?x?xf32>
+}
+// CHECK-LABEL: func @matmul_interchange(
+//  CHECK-SAME:     %[[LHS:[a-zA-Z0-9]+]]: tensor<?x?xf32>,
+//  CHECK-SAME:     %[[RHS:[a-zA-Z0-9]+]]: tensor<?x?xf32>,
+//  CHECK-SAME:     %[[INIT:[a-zA-Z0-9]+]]: tensor<?x?xf32>)
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0
+//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1
+//   CHECK-DAG:   %[[M:.+]] = tensor.dim %[[LHS]], %[[C0]]
+//   CHECK-DAG:   %[[N:.+]] = tensor.dim %[[RHS]], %[[C1]]
+//       CHECK:   %[[RESULT:.+]] = scf.forall (%[[IV0:[a-zA-Z0-9]+]], %[[IV1:[a-zA-Z0-9]+]])
+//  CHECK-SAME:       to (%[[N]], %[[M]]) step (64, 32)
+//  CHECK-SAME:       shared_outs(%[[OUTS:.+]] = %[[INIT]])
+//   CHECK-DAG:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[LHS]][%[[IV1]], 0]
+//   CHECK-DAG:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[RHS]][0, %[[IV0]]
+//   CHECK-DAG:     %[[INIT_SLICE:.+]] = tensor.extract_slice %[[OUTS]][%[[IV1]], %[[IV0]]{{\]}}
+//       CHECK:     %[[MATMUL_SLICE:.+]] = linalg.matmul
+//  CHECK-SAME:         ins(%[[LHS_SLICE]], %[[RHS_SLICE]] :
+//  CHECK-SAME:         outs(%[[INIT_SLICE]] :
+//       CHECK:     scf.forall.in_parallel
+//       CHECK:       tensor.parallel_insert_slice %[[MATMUL_SLICE]] into %[[OUTS]][%[[IV1]], %[[IV0]]]
+//       CHECK:     mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]
+//       CHECK:   return %[[RESULT]]
+
+// -----
+
+func.func @no_compute(%arg0 : memref<?x?x?xf32>, %arg1 : memref<?x?x?xf32>) {
+  memref.assume_alignment %arg0, 64 : memref<?x?x?xf32>
+  memref.assume_alignment %arg1, 64 : memref<?x?x?xf32>
+  return
+}
+// CHECK-LABEL: @no_compute(
+//   CHECK-NOT:   scf.forall
+
+// -----
+
+func.func @matmul_memrefs(%0 : memref<?x?xf32>, %1 : memref<?x?xf32>, %2 : memref<?x?xf32>) {
+  linalg.matmul {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[64, 64, 0]]>}
+      ins(%0, %1 : memref<?x?xf32>, memref<?x?xf32>)
+      outs(%2 : memref<?x?xf32>)
+  return
+}
+// CHECK-LABEL: func @matmul_memrefs(
+//       CHECK:   scf.forall
+//       CHECK:     linalg.matmul
+//       CHECK:   mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]
+
+// -----
+
+func.func @matmul_fusion_test(%arg0 : tensor<?x?xf16>,
+    %arg1 : tensor<?x?xf16>) -> tensor<?x?xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %cst0 = arith.constant 0.0 : f32
+  %M = tensor.dim %arg0, %c0 : tensor<?x?xf16>
+  %N = tensor.dim %arg1, %c1 : tensor<?x?xf16>
+  %K = tensor.dim %arg0, %c1 : tensor<?x?xf16>
+  %empty_lhs = tensor.empty(%M, %K) : tensor<?x?xf32>
+  %extf_lhs = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel"]}
+    ins(%arg0 : tensor<?x?xf16>) outs(%empty_lhs : tensor<?x?xf32>) {
+    ^bb0(%b0 : f16, %b1 : f32) :
+      %0 = arith.extf %b0 : f16 to f32
+      linalg.yield %0 : f32
+  } -> tensor<?x?xf32>
+  %empty_rhs = tensor.empty(%K, %N) : tensor<?x?xf32>
+  %extf_rhs = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel"]}
+    ins(%arg1 : tensor<?x?xf16>) outs(%empty_rhs : tensor<?x?xf32>) {
+    ^bb0(%b0 : f16, %b1 : f32) :
+      %0 = arith.extf %b0 : f16 to f32
+      linalg.yield %0 : f32
+  } -> tensor<?x?xf32>
+  %empty = tensor.empty(%M, %N) : tensor<?x?xf32>
+  %fill = linalg.fill ins(%cst0 : f32) outs(%empty : tensor<?x?xf32>) -> tensor<?x?xf32>
+  %matmul = linalg.matmul
+      {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[64, 64]]>}
+      ins(%extf_lhs, %extf_rhs : tensor<?x?xf32>, tensor<?x?xf32>)
+      outs(%fill : tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %matmul : tensor<?x?xf32>
+}
+// CHECK-LABEL: func @matmul_fusion_test
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf16>
+//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?xf16>
+//       CHECK:   %[[RESULT:.+]] = scf.forall (%[[IV0:[a-zA-Z0-9]+]], %[[IV1:[a-zA-Z0-9]+]]) =
+//       CHECK:     %[[LHS_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[IV0]], 0]
+//       CHECK:     %[[LHS:.+]] = linalg.generic
+//  CHECK-SAME:         ins(%[[LHS_SLICE]] :
+//       CHECK:     %[[RHS_SLICE:.+]] = tensor.extract_slice %[[ARG1]][0, %[[IV1]]]
+//       CHECK:     %[[RHS:.+]] = linalg.generic
+//  CHECK-SAME:         ins(%[[RHS_SLICE]] :
+//       CHECK:     %[[FILL:.+]] = linalg.fill
+//       CHECK:     %[[MATMUL:.+]] = linalg.matmul
+//  CHECK-SAME:         ins(%[[LHS]], %[[RHS]] :
+//  CHECK-SAME:         outs(%[[FILL]] :
+//       CHECK:     scf.forall.in_parallel
+//       CHECK:       tensor.parallel_insert_slice %[[MATMUL]]
+//       CHECK:   return %[[RESULT]]


### PR DESCRIPTION
This adds a pass that does the workgroup-level tile and distribution
using `scf.forall` op. For now this pass only handles tiling a single
operation.
TODO:
1. Add support for removing distribution of unit-trip loops.
2. Ensure that setting `iree_gpu.lowering_config` works as well.