### PR TITLE
[Codegen] Avoid distributing unit-extent dimensions.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -190,6 +190,15 @@ def WorkgroupMappingAttr :
     static LogicalResult verifyAttrList(::mlir::MLIRContext *context,
       ::llvm::function_ref<::mlir::InFlightDiagnostic ()> emitError,
       ArrayRef<Attribute> attrs);
+
+    // Convert from mapping ID to attribute.
+    static ::mlir::iree_compiler::IREE::Codegen::WorkgroupMappingAttr
+    getAttributeFromMappingId(MLIRContext *context, int64_t mappingId);
+
+    // Less than operator for easy comparison.
+    bool operator<(
+        const ::mlir::iree_compiler::IREE::Codegen::WorkgroupMappingAttr &rhs)
+        const;
   }];
 
   let genVerifyDecl = 1;


### PR DESCRIPTION
Existing distribution to workgroups has logic to avoid distributing
unit-trip dimensions. This is easily handled by using `scf.forall`
since a pattern can be used to drop the loop dimensions that are unit.

Signed-off-by: MaheshRavishankar <mahesh.ravishankar@gmail.com>