### PR TITLE
Fix link to onnx ops test suite.

### DIFF
--- a/docs/website/docs/guides/ml-frameworks/onnx.md
+++ b/docs/website/docs/guides/ml-frameworks/onnx.md
@@ -117,8 +117,8 @@ graph LR
 
 | Code samples |  |
 | -- | -- |
+Generated op tests | [iree-test-suites `onnx_ops`](https://github.com/iree-org/iree-test-suites/tree/main/onnx_ops)
 Curated op and model tests | [SHARK-TestSuite `e2eshark/onnx`](https://github.com/nod-ai/SHARK-TestSuite/tree/main/e2eshark/onnx)
-Generated op tests | [SHARK-TestSuite `iree_tests/onnx`](https://github.com/nod-ai/SHARK-TestSuite/tree/main/iree_tests/onnx)
 Importer tests | [torch-mlir `test/python/onnx_importer`](https://github.com/llvm/torch-mlir/tree/main/test/python/onnx_importer)
 
 ## :octicons-question-16: Troubleshooting


### PR DESCRIPTION
Missed this on https://github.com/iree-org/iree/pull/18223 / https://github.com/nod-ai/SHARK-TestSuite/pull/326.