### PR TITLE
[Codegen][Common] Reorder layout analysis to preserve anchored to_layout

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
@@ -345,19 +345,25 @@ static OpOperand &getOpOperand(Operation *op, unsigned operandLatticeIndex) {
   llvm::report_fatal_error("No vector operand found");
 }
 
-/// Get a layout if all the given layouts are same. If all layouts are not same,
-/// return nullptr.
+/// Get a layout if all the given initialized layouts are same.
+/// If any initialized layouts are not same, return nullptr.
 static const DistributionLayout *
 getAgreedLayout(ArrayRef<const DistributionLayout *> layouts) {
-  if (layouts.empty())
+  SmallVector<const DistributionLayout *> initializedLayouts;
+  for (auto layout : layouts) {
+    if (layout->isUninitialized())
+      continue;
+    initializedLayouts.push_back(layout);
+  }
+
+  if (initializedLayouts.empty())
     return nullptr;
 
   // Check if all layouts are same.
-  if (!llvm::all_equal(llvm::make_pointee_range(layouts))) {
+  if (!llvm::all_equal(llvm::make_pointee_range(initializedLayouts)))
     return nullptr;
-  }
 
-  return layouts[0];
+  return initializedLayouts[0];
 }
 
 /// Hueristic to use to choose the best layout when enforcing the same layout
@@ -1029,8 +1035,8 @@ LogicalResult VectorLayoutAnalysis::run() {
   // The order of loading matters here, because propagateLayout does anchoring
   // initialization which needs the lattice to know both enforcement and
   // propagation.
-  solver.load<EnforceLayout>(root->getContext());
   solver.load<PropagateLayout>(anchors, root->getContext());
+  solver.load<EnforceLayout>(root->getContext());
   return solver.initializeAndRun(root);
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
@@ -117,8 +117,11 @@ private:
 
 class EnforceLayout : public DataFlowAnalysis {
 public:
-  explicit EnforceLayout(DataFlowSolver &solver, MLIRContext *ctx)
-      : DataFlowAnalysis(solver), ctx(ctx) {}
+  explicit EnforceLayout(
+      DataFlowSolver &solver,
+      DenseMap<TypedValue<VectorType>, VectorLayoutInterface> &anchors,
+      MLIRContext *ctx)
+      : DataFlowAnalysis(solver), anchors(anchors), ctx(ctx) {}
 
   LogicalResult initialize(Operation *root) override;
 
@@ -136,6 +139,8 @@ private:
                              MutableArrayRef<OpOperand> operands);
 
   DistributionLayout *getLatticeElement(Value val);
+
+  DenseMap<TypedValue<VectorType>, VectorLayoutInterface> anchors;
 
   MLIRContext *ctx;
 };
@@ -776,7 +781,7 @@ void enforcementTransferFunction(
 /// ==========================================================================
 
 LogicalResult PropagateLayout::initialize(Operation *root) {
-  // Set layout for anchor ops.
+  // Set layout for anchor ops or resolve if need be.
   for (auto [val, layout] : anchors) {
     DistributionLayout *latticeEl = getLatticeElement(val);
     ChangeResult changed = latticeEl->resolve(layout);
@@ -905,6 +910,13 @@ DistributionLayout *PropagateLayout::getLatticeElement(Value val) {
 /// ==========================================================================
 
 LogicalResult EnforceLayout::initialize(Operation *root) {
+  // Set layout for anchor ops or resolve if need be.
+  for (auto [val, layout] : anchors) {
+    DistributionLayout *latticeEl = getLatticeElement(val);
+    ChangeResult changed = latticeEl->resolve(layout);
+    propagateIfChanged(latticeEl, changed);
+  }
+
   root->walk([&](Operation *traversed) { visitOperation(traversed); });
   return success();
 }
@@ -1036,7 +1048,7 @@ LogicalResult VectorLayoutAnalysis::run() {
   // initialization which needs the lattice to know both enforcement and
   // propagation.
   solver.load<PropagateLayout>(anchors, root->getContext());
-  solver.load<EnforceLayout>(root->getContext());
+  solver.load<EnforceLayout>(anchors, root->getContext());
   return solver.initializeAndRun(root);
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.h
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.h
@@ -131,7 +131,6 @@ private:
   VectorLayoutInterface getLayout(Value val);
 
   Operation *root;
-  DenseMap<TypedValue<VectorType>, VectorLayoutInterface> anchors;
   DataFlowSolver solver;
 };
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/vector_layout_analysis.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/vector_layout_analysis.mlir
@@ -196,8 +196,8 @@ builtin.module attributes { transform.with_named_sequence } {
 // redundant to_layout ops that convert elemwise ops to the 2nd layout
 // prematurely. Especially useful during chained contraction cases.
 
-#layoutA = #iree_vector_ext.layout<<[BATCHY, LANEX], [2, 32]>, <[BATCHX,  VECTORY,  LANEY,  VECTORX], [2, 4, 8]>>
-#layoutB = #iree_vector_ext.layout<<[BATCHX,  VECTORY,  LANEY,  VECTORX], [2, 4, 8]>, <[BATCHY, LANEX], [2, 32]>>
+#layoutA = #iree_vector_ext.layout<<[BATCHY, LANEX], [2, 32]>, <[BATCHX,  LANEY,  VECTORX], [2, 4, 8]>>
+#layoutB = #iree_vector_ext.layout<<[BATCHX,  LANEY,  VECTORX], [2, 4, 8]>, <[BATCHY, LANEX], [2, 32]>>
 #layoutC = #iree_vector_ext.layout<<[BATCHY, LANEX], [2, 32]>, <[BATCHX,  VECTORY,  LANEY,  VECTORX], [2, 4, 2, 4]>>
 
 #map1 = affine_map<(d0, d1, d2) -> (d1, d2)>

--- a/compiler/src/iree/compiler/Codegen/Common/test/vector_layout_analysis.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/vector_layout_analysis.mlir
@@ -4,7 +4,7 @@
 
 // Propagate the layout from transfer_read to everyone.
 builtin.module attributes { transform.with_named_sequence } {
-  func.func @propagate_simple(%arr: memref<16x16xf16>, %a: vector<16x16xf16>, %b: vector<16x16xf16>) -> vector<16x16xf16> {
+  func.func @propagate_simple(%arr: memref<16x16xf16>, %a: vector<16x16xf16>, %b: vector<16x16xf16>, %cond: i1) -> vector<16x16xf16> {
     %c0 = arith.constant 0 : index
     %cst_0 = arith.constant 0.0 : f16
     %root = vector.transfer_read %arr[%c0, %c0], %cst_0 {in_bounds = [true, true]} : memref<16x16xf16>, vector<16x16xf16>
@@ -14,7 +14,9 @@ builtin.module attributes { transform.with_named_sequence } {
     // expected-remark @above {{layout of result #0 is #iree_vector_ext.layout<<[ VECTORY], [16]>, <[ VECTORX], [16]>>}}
     %d = arith.addf %c, %a : vector<16x16xf16>
     // expected-remark @above {{layout of result #0 is #iree_vector_ext.layout<<[ VECTORY], [16]>, <[ VECTORX], [16]>>}}
-    func.return %d : vector<16x16xf16>
+    %e = arith.select %cond, %c, %d : vector<16x16xf16>
+    // expected-remark @above {{layout of result #0 is #iree_vector_ext.layout<<[ VECTORY], [16]>, <[ VECTORX], [16]>>}}
+    func.return %e : vector<16x16xf16>
   }
 
   transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
@@ -188,52 +190,34 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // -----
 
-// This test checks that we can propagate layout through arith.select.
-// arith.select is special since the condition that is part of arith.select
-// is not likely to have a layout.
+// This test checks that we can resolve layouts through arith.select
+// properly and that our layout analysis is not emitting redundant
+// to_layout conversions in between anchor ops.
 
-// This test is also useful to ensure that layout analysis is not emitting
-// redundant to_layout ops that convert elemwise ops to the 2nd layout
-// prematurely. Especially useful during chained contraction cases.
+// Useful proxy for ensuring that layout conversions on attention
+// happens where we intend it to happen.
 
-#layoutA = #iree_vector_ext.layout<<[BATCHY, LANEX], [2, 32]>, <[BATCHX,  LANEY,  VECTORX], [2, 4, 8]>>
-#layoutB = #iree_vector_ext.layout<<[BATCHX,  LANEY,  VECTORX], [2, 4, 8]>, <[BATCHY, LANEX], [2, 32]>>
-#layoutC = #iree_vector_ext.layout<<[BATCHY, LANEX], [2, 32]>, <[BATCHX,  VECTORY,  LANEY,  VECTORX], [2, 4, 2, 4]>>
-
-#map1 = affine_map<(d0, d1, d2) -> (d1, d2)>
-#map2 = affine_map<(d0, d1, d2) -> (d0, d2)>
-#map3 = affine_map<(d0, d1, d2) -> (d1, d0)>
+#layoutA = #iree_vector_ext.layout<<[BATCHY, LANEX], [2, 32]>, <[BATCHX,  VECTORY,  LANEY,  VECTORX], [2, 4, 2, 4]>>
+#layoutB = #iree_vector_ext.layout<<[BATCHY, LANEX], [2, 32]>, <[BATCHX,  LANEY,  VECTORX], [2, 4, 8]>>
 
 builtin.module attributes { transform.with_named_sequence } {
-  func.func @contract(%A : vector<64x64xf16>, %B : vector<64x64xf16>, %C : vector<64x64xf16>, %condition : i1) -> vector<64x64xf16> {
+  func.func @resolve_select(%A : vector<64x64xf16>, %B : vector<64x64xf16>, %condition : i1) -> vector<64x64xf16> {
     %a = iree_vector_ext.to_layout %A to #layoutA : vector<64x64xf16>
     %b = iree_vector_ext.to_layout %B to #layoutB : vector<64x64xf16>
-    %c = iree_vector_ext.to_layout %C to #layoutC : vector<64x64xf16>
     // expected-remark @below {{layout of result #0 is #iree_vector_ext.layout<<[ BATCHY,  LANEX], [2, 32]>, <[ BATCHX,  VECTORY,  LANEY,  VECTORX], [2, 4, 2, 4]>>}}
     %offset_0 = arith.constant dense<2.0> : vector<64x64xf16>
     // expected-remark @below {{layout of result #0 is #iree_vector_ext.layout<<[ BATCHY,  LANEX], [2, 32]>, <[ BATCHX,  VECTORY,  LANEY,  VECTORX], [2, 4, 2, 4]>>}}
     %offset_1 = arith.constant dense<4.0> : vector<64x64xf16>
-    // expected-remark @below {{layout of result #0 is #iree_vector_ext.layout<<[ BATCHY,  LANEX], [2, 32]>, <[ BATCHX,  VECTORY,  LANEY,  VECTORX], [2, 4, 2, 4]>>}}
-    %contract_0 = vector.contract
-        {indexing_maps = [#map1, #map2, #map3],
-         iterator_types = ["parallel", "parallel", "reduction"],
-         kind = #vector.kind<add>
-        } %a, %b, %c : vector<64x64xf16>, vector<64x64xf16> into vector<64x64xf16>
 
     // expected-remark @below {{layout of result #0 is #iree_vector_ext.layout<<[ BATCHY,  LANEX], [2, 32]>, <[ BATCHX,  VECTORY,  LANEY,  VECTORX], [2, 4, 2, 4]>>}}
     %sel = arith.select %condition, %offset_0, %offset_1 : vector<64x64xf16>
     // expected-remark @below {{layout of result #0 is #iree_vector_ext.layout<<[ BATCHY,  LANEX], [2, 32]>, <[ BATCHX,  VECTORY,  LANEY,  VECTORX], [2, 4, 2, 4]>>}}
-    %add = arith.addf %contract_0, %sel : vector<64x64xf16>
-    %add_layout = iree_vector_ext.to_layout %add to #layoutA : vector<64x64xf16>
-    // CHECK-COUNT-4: iree_vector_ext.to_layout
-    // expected-remark @below {{layout of result #0 is #iree_vector_ext.layout<<[ BATCHY,  LANEX], [2, 32]>, <[ BATCHX,  VECTORY,  LANEY,  VECTORX], [2, 4, 2, 4]>>}}
-    %contract_1 = vector.contract
-        {indexing_maps = [#map1, #map2, #map3],
-         iterator_types = ["parallel", "parallel", "reduction"],
-         kind = #vector.kind<add>
-        } %add_layout, %b, %c : vector<64x64xf16>, vector<64x64xf16> into vector<64x64xf16>
-
-    func.return %contract_1 : vector<64x64xf16>
+    %add = arith.addf %a, %sel : vector<64x64xf16>
+    %add_layout = iree_vector_ext.to_layout %add to #layoutB : vector<64x64xf16>
+    // CHECK-COUNT-3: iree_vector_ext.to_layout
+    // expected-remark @below {{layout of result #0 is #iree_vector_ext.layout<<[ BATCHY,  LANEX], [2, 32]>, <[ BATCHX,  LANEY,  VECTORX], [2, 4, 8]>>}}
+    %add_1 = arith.addf %add_layout, %b : vector<64x64xf16>
+    func.return %add_1 : vector<64x64xf16>
   }
 
   transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {


### PR DESCRIPTION
TL;DR: Re-ordered forward and backward layout + added support to propagate through arith.select S.T setting to_layout at certain locations in decomposition gets honored. 

This change makes it easier to honor to_layout conversions generated by the users and/or higher level decompositons. Since intuitively to_layout op has the effect that ops that come after it shall take/be based on it's layout. Loading the forward propagation first, also encourage priortize ops to take layouts from anchors / to_layout op that comes before it. 

The motivation behind this PR was to solve the issue where despite us emitting to_layout op at certain locations, we ended up generating redundant to_simd earlier in the graph. This results us to not have control on where the layout conversion actually happens.

One example of this case is when we emit a to_layout conversion for FP8 Attention. We emit a to_layout right before the 2nd contract and right after the truncf to FP8. Since we do enforcement(backward propagation) first and then propagate (forward propagation), we ended up generating two layout conversions, one the original one we emitted, the second one determined by layout analysis and placed in the middle of a elemwise op that is part of the softmax.

This forces us to do shuffles/layout resolution in FP32 which hurts the performance. Additionally, this is also not where we(compiler writers) intended the layout conversion to happen.

Additionally, we made modification to getAgreedLayout to handle elemwise propagation where some operands are not expected to have layout such as arith.select who's condition operand probably don't have layouts.