### PR TITLE
Always run GPU test jobs, regardless of path filters.

### DIFF
--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -119,57 +119,17 @@ CONTROL_JOBS = frozenset(["setup", "summary"])
 # They may also run on presubmit only under certain conditions.
 DEFAULT_POSTSUBMIT_ONLY_JOBS = frozenset(
     [
-        "test_nvidia_t4",
-        # "test_nvidia_a100",  # Currently disabled
-        "test_amd_mi250",
-        "test_amd_mi300",
-        "test_amd_w7900",
+        # None.
     ]
 )
 
-NVGPU_PATHS = [
-    # Directly related to NVIDIA GPU code generation and execution:
-    "compiler/plugins/target/CUDA/*",
-    "compiler/plugins/target/VulkanSPIRV/*",
-    "compiler/src/iree/compiler/Codegen/LLVMGPU/*",
-    "compiler/src/iree/compiler/Codegen/SPIRV/*",
-    "runtime/src/iree/hal/drivers/cuda/*",
-    "runtime/src/iree/hal/drivers/vulkan/*",
-    # Common code likely enough to affect code paths unique to NVIDIA GPUs:
-    "compiler/src/iree/compiler/GlobalOptimization/*",
-    # Tests.
-    "tests/e2e/*",
-]
-
-AMDGPU_PATHS = [
-    # Directly related to AMDGPU code generation and execution:
-    "compiler/plugins/target/ROCM/*",
-    "compiler/plugins/target/VulkanSPIRV/*",
-    "compiler/src/iree/compiler/Codegen/LLVMGPU/*",
-    "compiler/src/iree/compiler/Codegen/SPIRV/*",
-    "runtime/src/iree/hal/drivers/hip/*",
-    "runtime/src/iree/hal/drivers/vulkan/*",
-    # Common code likely enough to affect code paths unique to AMDGPU:
-    "compiler/src/iree/compiler/GlobalOptimization/*",
-    # Tests.
-    "tests/e2e/*",
-]
-
 # Jobs to run in presumbit if files under the corresponding path see changes.
 # Each tuple consists of the CI job name and a list of file paths to match.
-# The file paths should be specified using Unix shell-style wildcards.
+# The file paths should be specified using Unix shell-style wildcards. Sample:
+#   ("test_nvidia_a100", ["compiler/plugins/target/CUDA/*"]),
 # Note: these jobs should also be included in DEFAULT_POSTSUBMIT_ONLY_JOBS.
 PRESUBMIT_TOUCH_ONLY_JOBS = [
-    # The runners with GPUs for these jobs can be unstable or in short supply,
-    # so limit jobs to only code paths most likely to affect the tests.
-    ("test_nvidia_t4", NVGPU_PATHS),
-    # Due to the outstock of A100, only run this test in postsubmit.
-    # ("test_nvidia_a100", NVGPU_PATHS),
-    ("test_amd_mi250", AMDGPU_PATHS),
-    ("test_amd_mi300", AMDGPU_PATHS),
-    # Due to the instability issues at the current runner,
-    # only run this test in postsubmit.
-    # ("test_amd_w7900", AMDGPU_PATHS),
+    # None.
 ]
 
 PR_DESCRIPTION_TEMPLATE = string.Template("${title}\n\n${body}")

--- a/build_tools/github_actions/configure_ci_test.py
+++ b/build_tools/github_actions/configure_ci_test.py
@@ -64,6 +64,7 @@ class ConfigureCITest(unittest.TestCase):
         )
         self.assertCountEqual(jobs, all_jobs)
 
+    @unittest.skip("skipped while there are no postsubmit only jobs")
     def test_get_enabled_jobs_postsubmit(self):
         trailers = {}
         default_jobs = {"job1", "job2", "job3"}
@@ -81,6 +82,7 @@ class ConfigureCITest(unittest.TestCase):
         )
         self.assertCountEqual(jobs, all_jobs)
 
+    @unittest.skip("skipped while there are no postsubmit only jobs")
     def test_get_enabled_jobs_no_postsubmit(self):
         trailers = {}
         default_jobs = {"job1", "job2", "job3"}
@@ -98,6 +100,7 @@ class ConfigureCITest(unittest.TestCase):
         )
         self.assertCountEqual(jobs, default_jobs)
 
+    @unittest.skip("skipped while there are no postsubmit only jobs")
     def test_get_enabled_jobs_llvm_integrate(self):
         trailers = {}
         default_jobs = {"job1", "job2", "job3"}
@@ -115,6 +118,7 @@ class ConfigureCITest(unittest.TestCase):
         )
         self.assertCountEqual(jobs, all_jobs)
 
+    @unittest.skip("skipped while there are no postsubmit only jobs")
     def test_get_enabled_jobs_no_modifies(self):
         trailers = {}
         default_jobs = {"job1", "job2", "job3"}
@@ -132,6 +136,7 @@ class ConfigureCITest(unittest.TestCase):
         )
         self.assertCountEqual(jobs, {})
 
+    @unittest.skip("skipped while there are no postsubmit only jobs")
     def test_get_enabled_jobs_skip(self):
         trailers = {configure_ci.Trailer.SKIP_JOBS: "job1,job2"}
         default_jobs = {"job1", "job2", "job3"}
@@ -149,6 +154,7 @@ class ConfigureCITest(unittest.TestCase):
         )
         self.assertCountEqual(jobs, {"job3"})
 
+    @unittest.skip("skipped while there are no postsubmit only jobs")
     def test_get_enabled_jobs_skip_all(self):
         trailers = {configure_ci.Trailer.SKIP_JOBS: "all"}
         default_jobs = {"job1", "job2", "job3"}
@@ -166,6 +172,7 @@ class ConfigureCITest(unittest.TestCase):
         )
         self.assertCountEqual(jobs, {})
 
+    @unittest.skip("skipped while there are no postsubmit only jobs")
     def test_get_enabled_jobs_extra(self):
         postsubmit_job = next(iter(configure_ci.DEFAULT_POSTSUBMIT_ONLY_JOBS))
         trailers = {configure_ci.Trailer.EXTRA_JOBS: postsubmit_job}
@@ -183,6 +190,7 @@ class ConfigureCITest(unittest.TestCase):
         )
         self.assertCountEqual(jobs, all_jobs)
 
+    @unittest.skip("skipped while there are no postsubmit only jobs")
     def test_get_enabled_jobs_exactly(self):
         postsubmit_job = next(iter(configure_ci.DEFAULT_POSTSUBMIT_ONLY_JOBS))
         trailers = {configure_ci.Trailer.EXACTLY_JOBS: postsubmit_job}


### PR DESCRIPTION
These workflows were opt-in to limit the load on test runners. Let's see if we have enough runner capacity to support always running them.