### PR TITLE
Always run unit tests, opt-in for onnx and model tests.

### DIFF
--- a/.github/workflows/pkgci.yml
+++ b/.github/workflows/pkgci.yml
@@ -68,13 +68,13 @@ jobs:
     uses: ./.github/workflows/pkgci_test_nvidia_t4.yml
 
   test_models:
-    name: Regression Test
+    name: Test Models
     needs: [setup, build_packages]
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_models')
     uses: ./.github/workflows/pkgci_test_models.yml
 
   test_onnx:
-    name: Regression Test
+    name: Test ONNX
     needs: [setup, build_packages]
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_onnx')
     uses: ./.github/workflows/pkgci_test_onnx.yml

--- a/.github/workflows/pkgci.yml
+++ b/.github/workflows/pkgci.yml
@@ -43,12 +43,6 @@ jobs:
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'unit_test')
     uses: ./.github/workflows/pkgci_unit_test.yml
 
-  regression_test:
-    name: Regression Test
-    needs: [setup, build_packages]
-    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'regression_test')
-    uses: ./.github/workflows/pkgci_regression_test.yml
-
   test_amd_mi250:
     name: Test AMD MI250
     needs: [setup, build_packages]
@@ -72,6 +66,18 @@ jobs:
     needs: [setup, build_packages]
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_nvidia_t4')
     uses: ./.github/workflows/pkgci_test_nvidia_t4.yml
+
+  test_models:
+    name: Regression Test
+    needs: [setup, build_packages]
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_models')
+    uses: ./.github/workflows/pkgci_test_models.yml
+
+  test_onnx:
+    name: Regression Test
+    needs: [setup, build_packages]
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_onnx')
+    uses: ./.github/workflows/pkgci_test_onnx.yml
 
   test_tensorflow_cpu:
     name: Test TensorFlow CPU

--- a/.github/workflows/pkgci_test_models.yml
+++ b/.github/workflows/pkgci_test_models.yml
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-name: PkgCI Regression Test
+name: PkgCI Test Models
 on:
   workflow_call:
     inputs:
@@ -18,108 +18,6 @@ on:
         default: ""
 
 jobs:
-  test_onnx:
-    name: "test_onnx :: ${{ matrix.name }}"
-    runs-on: ${{ matrix.runs-on }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # CPU
-          - name: cpu_llvm_sync
-            config-file: onnx_ops_cpu_llvm_sync.json
-            numprocesses: auto
-            runs-on: ubuntu-20.04
-
-          # AMD GPU
-          - name: amdgpu_rocm_rdna3
-            numprocesses: 1
-            config-file: onnx_ops_gpu_rocm_rdna3.json
-            runs-on: nodai-amdgpu-w7900-x86-64
-          - name: amdgpu_vulkan
-            numprocesses: 4
-            config-file: onnx_ops_gpu_vulkan.json
-            runs-on: nodai-amdgpu-w7900-x86-64
-
-          # NVIDIA GPU
-          - name: nvidiagpu_cuda
-            config-file: onnx_ops_gpu_cuda.json
-            numprocesses: 4
-            runs-on:
-              - self-hosted # must come first
-              - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
-              - environment=prod
-              - gpu # TODO(scotttodd): qualify further with vendor/model
-              - os-family=Linux
-          - name: nvidiagpu_vulkan
-            config-file: onnx_ops_gpu_vulkan.json
-            numprocesses: 4
-            runs-on:
-              - self-hosted # must come first
-              - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
-              - environment=prod
-              - gpu # TODO(scotttodd): qualify further with vendor/model
-              - os-family=Linux
-    env:
-      PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
-      CONFIG_FILE_PATH: tests/external/iree-test-suites/onnx_ops/${{ matrix.config-file }}
-      NUMPROCESSES: ${{ matrix.numprocesses }}
-      LOG_FILE_PATH: /tmp/test_onnx_ops_${{ matrix.name }}_logs.json
-      VENV_DIR: ${{ github.workspace }}/venv
-    steps:
-      - name: Checking out IREE repository
-        uses: actions/checkout@v4.1.7
-        with:
-          submodules: false
-      - uses: actions/setup-python@v5.1.0
-        with:
-          # Must match the subset of versions built in pkgci_build_packages.
-          python-version: "3.11"
-      - uses: actions/download-artifact@v4.1.7
-        with:
-          name: linux_x86_64_release_packages
-          path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
-      - name: Setup venv
-        run: |
-          ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
-            --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
-            --fetch-gh-workflow=${{ inputs.artifact_run_id }}
-
-      - name: Checkout test suites repository
-        uses: actions/checkout@v4.1.7
-        with:
-          repository: iree-org/iree-test-suites
-          ref: 323c2df477544d789c56e4dfda9b047580b77cbf
-          path: iree-test-suites
-      - name: Install ONNX ops test suite requirements
-        run: |
-          source ${VENV_DIR}/bin/activate
-          python -m pip install -r iree-test-suites/onnx_ops/requirements.txt
-      - name: Run ONNX ops test suite
-        run: |
-          source ${VENV_DIR}/bin/activate
-          pytest iree-test-suites/onnx_ops/ \
-              -rpfE \
-              --numprocesses ${NUMPROCESSES} \
-              --timeout=30 \
-              --durations=20 \
-              --config-files=${CONFIG_FILE_PATH} \
-              --report-log=${LOG_FILE_PATH}
-      - name: "Updating config file with latest XFAIL lists"
-        if: failure()
-        run: |
-          source ${VENV_DIR}/bin/activate
-          python iree-test-suites/onnx_ops/update_config_xfails.py \
-            --log-file=${LOG_FILE_PATH} \
-            --config-file=${CONFIG_FILE_PATH}
-          cat ${CONFIG_FILE_PATH}
-      - name: "Uploading new config file"
-        if: failure()
-        uses: actions/upload-artifact@v4.3.3
-        with:
-          name: ${{ matrix.config-file }}
-          path: ${{ env.CONFIG_FILE_PATH }}
-
   test_models:
     name: "test_models :: ${{ matrix.name }}"
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/pkgci_test_onnx.yml
+++ b/.github/workflows/pkgci_test_onnx.yml
@@ -1,0 +1,121 @@
+# Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+name: PkgCI Test ONNX
+on:
+  workflow_call:
+    inputs:
+      artifact_run_id:
+        type: string
+        default: ""
+  workflow_dispatch:
+    inputs:
+      artifact_run_id:
+        type: string
+        default: ""
+
+jobs:
+  test_onnx:
+    name: "test_onnx :: ${{ matrix.name }}"
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # CPU
+          - name: cpu_llvm_sync
+            config-file: onnx_ops_cpu_llvm_sync.json
+            numprocesses: auto
+            runs-on: ubuntu-20.04
+
+          # AMD GPU
+          - name: amdgpu_rocm_rdna3
+            numprocesses: 1
+            config-file: onnx_ops_gpu_rocm_rdna3.json
+            runs-on: nodai-amdgpu-w7900-x86-64
+          - name: amdgpu_vulkan
+            numprocesses: 4
+            config-file: onnx_ops_gpu_vulkan.json
+            runs-on: nodai-amdgpu-w7900-x86-64
+
+          # NVIDIA GPU
+          - name: nvidiagpu_cuda
+            config-file: onnx_ops_gpu_cuda.json
+            numprocesses: 4
+            runs-on:
+              - self-hosted # must come first
+              - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+              - environment=prod
+              - gpu # TODO(scotttodd): qualify further with vendor/model
+              - os-family=Linux
+          - name: nvidiagpu_vulkan
+            config-file: onnx_ops_gpu_vulkan.json
+            numprocesses: 4
+            runs-on:
+              - self-hosted # must come first
+              - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+              - environment=prod
+              - gpu # TODO(scotttodd): qualify further with vendor/model
+              - os-family=Linux
+    env:
+      PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
+      CONFIG_FILE_PATH: tests/external/iree-test-suites/onnx_ops/${{ matrix.config-file }}
+      NUMPROCESSES: ${{ matrix.numprocesses }}
+      LOG_FILE_PATH: /tmp/test_onnx_ops_${{ matrix.name }}_logs.json
+      VENV_DIR: ${{ github.workspace }}/venv
+    steps:
+      - name: Checking out IREE repository
+        uses: actions/checkout@v4.1.7
+        with:
+          submodules: false
+      - uses: actions/setup-python@v5.1.0
+        with:
+          # Must match the subset of versions built in pkgci_build_packages.
+          python-version: "3.11"
+      - uses: actions/download-artifact@v4.1.7
+        with:
+          name: linux_x86_64_release_packages
+          path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
+      - name: Setup venv
+        run: |
+          ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
+            --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
+            --fetch-gh-workflow=${{ inputs.artifact_run_id }}
+
+      - name: Checkout test suites repository
+        uses: actions/checkout@v4.1.7
+        with:
+          repository: iree-org/iree-test-suites
+          ref: 323c2df477544d789c56e4dfda9b047580b77cbf
+          path: iree-test-suites
+      - name: Install ONNX ops test suite requirements
+        run: |
+          source ${VENV_DIR}/bin/activate
+          python -m pip install -r iree-test-suites/onnx_ops/requirements.txt
+      - name: Run ONNX ops test suite
+        run: |
+          source ${VENV_DIR}/bin/activate
+          pytest iree-test-suites/onnx_ops/ \
+              -rpfE \
+              --numprocesses ${NUMPROCESSES} \
+              --timeout=30 \
+              --durations=20 \
+              --config-files=${CONFIG_FILE_PATH} \
+              --report-log=${LOG_FILE_PATH}
+      - name: "Updating config file with latest XFAIL lists"
+        if: failure()
+        run: |
+          source ${VENV_DIR}/bin/activate
+          python iree-test-suites/onnx_ops/update_config_xfails.py \
+            --log-file=${LOG_FILE_PATH} \
+            --config-file=${CONFIG_FILE_PATH}
+          cat ${CONFIG_FILE_PATH}
+      - name: "Uploading new config file"
+        if: failure()
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: ${{ matrix.config-file }}
+          path: ${{ env.CONFIG_FILE_PATH }}

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -119,57 +119,22 @@ CONTROL_JOBS = frozenset(["setup", "summary"])
 # They may also run on presubmit only under certain conditions.
 DEFAULT_POSTSUBMIT_ONLY_JOBS = frozenset(
     [
-        "test_nvidia_t4",
-        # "test_nvidia_a100",  # Currently disabled
-        "test_amd_mi250",
-        "test_amd_mi300",
-        "test_amd_w7900",
+        "test_models",
+        "test_onnx",
     ]
 )
-
-NVGPU_PATHS = [
-    # Directly related to NVIDIA GPU code generation and execution:
-    "compiler/plugins/target/CUDA/*",
-    "compiler/plugins/target/VulkanSPIRV/*",
-    "compiler/src/iree/compiler/Codegen/LLVMGPU/*",
-    "compiler/src/iree/compiler/Codegen/SPIRV/*",
-    "runtime/src/iree/hal/drivers/cuda/*",
-    "runtime/src/iree/hal/drivers/vulkan/*",
-    # Common code likely enough to affect code paths unique to NVIDIA GPUs:
-    "compiler/src/iree/compiler/GlobalOptimization/*",
-    # Tests.
-    "tests/e2e/*",
-]
-
-AMDGPU_PATHS = [
-    # Directly related to AMDGPU code generation and execution:
-    "compiler/plugins/target/ROCM/*",
-    "compiler/plugins/target/VulkanSPIRV/*",
-    "compiler/src/iree/compiler/Codegen/LLVMGPU/*",
-    "compiler/src/iree/compiler/Codegen/SPIRV/*",
-    "runtime/src/iree/hal/drivers/hip/*",
-    "runtime/src/iree/hal/drivers/vulkan/*",
-    # Common code likely enough to affect code paths unique to AMDGPU:
-    "compiler/src/iree/compiler/GlobalOptimization/*",
-    # Tests.
-    "tests/e2e/*",
-]
 
 # Jobs to run in presumbit if files under the corresponding path see changes.
 # Each tuple consists of the CI job name and a list of file paths to match.
 # The file paths should be specified using Unix shell-style wildcards.
 # Note: these jobs should also be included in DEFAULT_POSTSUBMIT_ONLY_JOBS.
 PRESUBMIT_TOUCH_ONLY_JOBS = [
-    # The runners with GPUs for these jobs can be unstable or in short supply,
-    # so limit jobs to only code paths most likely to affect the tests.
-    ("test_nvidia_t4", NVGPU_PATHS),
-    # Due to the outstock of A100, only run this test in postsubmit.
-    # ("test_nvidia_a100", NVGPU_PATHS),
-    ("test_amd_mi250", AMDGPU_PATHS),
-    ("test_amd_mi300", AMDGPU_PATHS),
-    # Due to the instability issues at the current runner,
-    # only run this test in postsubmit.
-    # ("test_amd_w7900", AMDGPU_PATHS),
+    (
+        "test_onnx",
+        [
+            "third_party/torch-mlir",
+        ],
+    ),
 ]
 
 PR_DESCRIPTION_TEMPLATE = string.Template("${title}\n\n${body}")

--- a/docs/website/docs/developers/general/contributing.md
+++ b/docs/website/docs/developers/general/contributing.md
@@ -371,10 +371,16 @@ runner-env: [testing|prod]
 Copy/paste any of these at the bottom of a PR description to change what the CI
 runs.
 
-* Also run GPU tests (opt-in due to low availability):
+* Also run ONNX tests:
 
     ``` text
-    ci-extra: test_nvidia_t4,test_amd_mi250,test_amd_mi300,test_amd_w7900
+    ci-extra: test_onnx
+    ```
+
+* Also run model tests:
+
+    ``` text
+    ci-extra: test_models
     ```
 
 * Skip all CI builds and tests, e.g. for comment-only changes:


### PR DESCRIPTION
This is a different approach compared to https://github.com/iree-org/iree/pull/18312.

See the CI load table here: https://gist.github.com/ScottTodd/5f3b457e59a684b5264dd6b5d0119487. The unit tests are pretty fast, while the model tests are slow (as expected). If this distribution of jobs works well, we can make opting in to running them easier.

Just trying to get a handle on the 2h+ queue for running tests. A better longer term fix will be to have more runners or make the jobs themselves faster.