### PR TITLE
Avoid running `sudo apt update` on mi250 and mi300 runners.

### DIFF
--- a/.github/workflows/pkgci_test_amd_mi250.yml
+++ b/.github/workflows/pkgci_test_amd_mi250.yml
@@ -49,10 +49,8 @@ jobs:
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
             --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
             --fetch-gh-workflow=${{ inputs.artifact_run_id }}
-      - name: Install build dependencies
+      - name: Configure build toolchain
         run: |
-          sudo apt update
-          sudo apt install -y cmake clang ninja-build libstdc++-12-dev
           echo "CC=clang" >> $GITHUB_ENV
           echo "CXX=clang++" >> $GITHUB_ENV
 

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -54,10 +54,8 @@ jobs:
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
             --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
             --fetch-gh-workflow=${{ inputs.artifact_run_id }}
-      - name: Install build dependencies
+      - name: Configure build toolchain
         run: |
-          sudo apt update
-          sudo apt install -y cmake clang ninja-build libstdc++-12-dev
           echo "CC=clang" >> $GITHUB_ENV
           echo "CXX=clang++" >> $GITHUB_ENV
 


### PR DESCRIPTION
It seems like multiple instances / users on these machines can't be running these commands concurrently so for now we'll just rely on the runners having this software already installed. We could also use Docker.

ci-exactly: build_packages,test_amd_mi250,test_amd_mi300