### PR TITLE
Switch from w7900 to using any persistent cache runner for CPU.

### DIFF
--- a/.github/workflows/pkgci_regression_test.yml
+++ b/.github/workflows/pkgci_regression_test.yml
@@ -134,7 +134,7 @@ jobs:
           - name: cpu_llvm_task
             models-config-file: models_cpu_llvm_task.json
             iree-tests-cache: ~/iree_tests_cache
-            runs-on: nodai-amdgpu-w7900-x86-64
+            runs-on: persistent-cache
 
           # AMD GPU
           - name: amdgpu_rocm_mi250_gfx90a
@@ -241,7 +241,7 @@ jobs:
             models-config-file: models_cpu_llvm_task.json
             backend: cpu
             iree-tests-cache: ~/iree_tests_cache
-            runs-on: nodai-amdgpu-w7900-x86-64
+            runs-on: persistent-cache
 
           # AMD GPU
           - name: amdgpu_rocm_mi250_gfx90a


### PR DESCRIPTION
This commit switches from w7900 to using any persistent cache runner for CPU model testing.

ci-exactly: build_packages,regression_test