### PR TITLE
Switch from w7900 to using any persistent cache runner for CPU.

### DIFF
--- a/.github/workflows/pkgci_regression_test.yml
+++ b/.github/workflows/pkgci_regression_test.yml
@@ -133,7 +133,11 @@ jobs:
           # CPU
           - name: cpu_llvm_task
             models-config-file: models_cpu_llvm_task.json
-            runs-on: persistent-cache
+            runs-on:
+              - self-hosted # must come first
+              - persistent-cache
+              - Linux
+              - X64
 
           # AMD GPU
           - name: amdgpu_rocm_mi250_gfx90a

--- a/.github/workflows/pkgci_regression_test.yml
+++ b/.github/workflows/pkgci_regression_test.yml
@@ -133,7 +133,7 @@ jobs:
           # CPU
           - name: cpu_llvm_task
             models-config-file: models_cpu_llvm_task.json
-            runs-on: nodai-amdgpu-w7900-x86-64
+            runs-on: persistent-cache
 
           # AMD GPU
           - name: amdgpu_rocm_mi250_gfx90a
@@ -234,7 +234,7 @@ jobs:
           - name: cpu_llvm_task
             models-config-file: models_cpu_llvm_task.json
             backend: cpu
-            runs-on: nodai-amdgpu-w7900-x86-64
+            runs-on: persistent-cache
 
           # AMD GPU
           - name: amdgpu_rocm_mi250_gfx90a

--- a/.github/workflows/pkgci_regression_test.yml
+++ b/.github/workflows/pkgci_regression_test.yml
@@ -238,7 +238,11 @@ jobs:
           - name: cpu_llvm_task
             models-config-file: models_cpu_llvm_task.json
             backend: cpu
-            runs-on: persistent-cache
+            runs-on:
+              - self-hosted # must come first
+              - persistent-cache
+              - Linux
+              - X64
 
           # AMD GPU
           - name: amdgpu_rocm_mi250_gfx90a


### PR DESCRIPTION
This commit switches from w7900 to using any persistent cache runner for CPU model testing.
I also removed the persistent cache label from the w7900 runners because we don't have many and want to alleviate the load.
These jobs should now be running on the 16 mi250/mi300 runners we have

ci-exactly: build_packages,regression_test