### PR TITLE
Disable Vulkan driver in macOS runtime packages.

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -38,38 +38,38 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Ubuntu packages.
-          - runs-on: ubuntu-20.04
-            build-family: linux-x86_64
-            build-package: main-dist-linux
-            experimental: false
-          - runs-on:
-              [self-hosted, arm64, os-family=Linux, runner-group=postsubmit]
-            build-family: linux-aarch64
-            build-package: main-dist-linux
-            experimental: true
-          - runs-on: ubuntu-20.04
-            build-family: linux-x86_64
-            build-package: py-compiler-pkg
-            experimental: false
-          - runs-on:
-              [self-hosted, arm64, os-family=Linux, runner-group=postsubmit]
-            build-family: linux-aarch64
-            build-package: py-compiler-pkg
-            experimental: true
-          - runs-on: ubuntu-20.04
-            build-family: linux-x86_64
-            build-package: py-runtime-pkg
-            experimental: false
-          - runs-on:
-              [self-hosted, arm64, os-family=Linux, runner-group=postsubmit]
-            build-family: linux-aarch64
-            build-package: py-runtime-pkg
-            experimental: true
-          - runs-on: ubuntu-20.04
-            build-family: linux-x86_64
-            build-package: py-tf-compiler-tools-pkg
-            experimental: false
+          # # Ubuntu packages.
+          # - runs-on: ubuntu-20.04
+          #   build-family: linux-x86_64
+          #   build-package: main-dist-linux
+          #   experimental: false
+          # - runs-on:
+          #     [self-hosted, arm64, os-family=Linux, runner-group=postsubmit]
+          #   build-family: linux-aarch64
+          #   build-package: main-dist-linux
+          #   experimental: true
+          # - runs-on: ubuntu-20.04
+          #   build-family: linux-x86_64
+          #   build-package: py-compiler-pkg
+          #   experimental: false
+          # - runs-on:
+          #     [self-hosted, arm64, os-family=Linux, runner-group=postsubmit]
+          #   build-family: linux-aarch64
+          #   build-package: py-compiler-pkg
+          #   experimental: true
+          # - runs-on: ubuntu-20.04
+          #   build-family: linux-x86_64
+          #   build-package: py-runtime-pkg
+          #   experimental: false
+          # - runs-on:
+          #     [self-hosted, arm64, os-family=Linux, runner-group=postsubmit]
+          #   build-family: linux-aarch64
+          #   build-package: py-runtime-pkg
+          #   experimental: true
+          # - runs-on: ubuntu-20.04
+          #   build-family: linux-x86_64
+          #   build-package: py-tf-compiler-tools-pkg
+          #   experimental: false
 
           # MacOS packages.
           # TODO(scotttodd): build on larger runner when available (self-hosted or GitHub)
@@ -77,27 +77,27 @@ jobs:
           #     - ${{ github.repository == 'iree-org/iree' && 'self-hosted' || 'macos-14' }}
           #     - os-family=macOS
           #     - runner-group=postsubmit
-          - runs-on: macos-14
-            build-family: macos
-            build-package: py-compiler-pkg
-            experimental: true
+          # - runs-on: macos-14
+          #   build-family: macos
+          #   build-package: py-compiler-pkg
+          #   experimental: true
           - runs-on: macos-14
             build-family: macos
             build-package: py-runtime-pkg
             experimental: true
 
-          # Windows packages.
-          # TODO(scotttodd): build on larger runner when available (self-hosted or GitHub)
-          # - runs-on:
-          #     - ${{ github.repository == 'iree-org/iree' && 'windows-2022-64core' || 'windows-2022'}}
-          - runs-on: windows-2022
-            build-family: windows
-            build-package: py-compiler-pkg
-            experimental: true
-          - runs-on: windows-2022
-            build-family: windows
-            build-package: py-runtime-pkg
-            experimental: true
+          # # Windows packages.
+          # # TODO(scotttodd): build on larger runner when available (self-hosted or GitHub)
+          # # - runs-on:
+          # #     - ${{ github.repository == 'iree-org/iree' && 'windows-2022-64core' || 'windows-2022'}}
+          # - runs-on: windows-2022
+          #   build-family: windows
+          #   build-package: py-compiler-pkg
+          #   experimental: true
+          # - runs-on: windows-2022
+          #   build-family: windows
+          #   build-package: py-runtime-pkg
+          #   experimental: true
 
     env:
       # These are also set in: build_tools/python_deploy/build_linux_packages.sh

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -38,38 +38,38 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # # Ubuntu packages.
-          # - runs-on: ubuntu-20.04
-          #   build-family: linux-x86_64
-          #   build-package: main-dist-linux
-          #   experimental: false
-          # - runs-on:
-          #     [self-hosted, arm64, os-family=Linux, runner-group=postsubmit]
-          #   build-family: linux-aarch64
-          #   build-package: main-dist-linux
-          #   experimental: true
-          # - runs-on: ubuntu-20.04
-          #   build-family: linux-x86_64
-          #   build-package: py-compiler-pkg
-          #   experimental: false
-          # - runs-on:
-          #     [self-hosted, arm64, os-family=Linux, runner-group=postsubmit]
-          #   build-family: linux-aarch64
-          #   build-package: py-compiler-pkg
-          #   experimental: true
-          # - runs-on: ubuntu-20.04
-          #   build-family: linux-x86_64
-          #   build-package: py-runtime-pkg
-          #   experimental: false
-          # - runs-on:
-          #     [self-hosted, arm64, os-family=Linux, runner-group=postsubmit]
-          #   build-family: linux-aarch64
-          #   build-package: py-runtime-pkg
-          #   experimental: true
-          # - runs-on: ubuntu-20.04
-          #   build-family: linux-x86_64
-          #   build-package: py-tf-compiler-tools-pkg
-          #   experimental: false
+          # Ubuntu packages.
+          - runs-on: ubuntu-20.04
+            build-family: linux-x86_64
+            build-package: main-dist-linux
+            experimental: false
+          - runs-on:
+              [self-hosted, arm64, os-family=Linux, runner-group=postsubmit]
+            build-family: linux-aarch64
+            build-package: main-dist-linux
+            experimental: true
+          - runs-on: ubuntu-20.04
+            build-family: linux-x86_64
+            build-package: py-compiler-pkg
+            experimental: false
+          - runs-on:
+              [self-hosted, arm64, os-family=Linux, runner-group=postsubmit]
+            build-family: linux-aarch64
+            build-package: py-compiler-pkg
+            experimental: true
+          - runs-on: ubuntu-20.04
+            build-family: linux-x86_64
+            build-package: py-runtime-pkg
+            experimental: false
+          - runs-on:
+              [self-hosted, arm64, os-family=Linux, runner-group=postsubmit]
+            build-family: linux-aarch64
+            build-package: py-runtime-pkg
+            experimental: true
+          - runs-on: ubuntu-20.04
+            build-family: linux-x86_64
+            build-package: py-tf-compiler-tools-pkg
+            experimental: false
 
           # MacOS packages.
           # TODO(scotttodd): build on larger runner when available (self-hosted or GitHub)
@@ -77,27 +77,27 @@ jobs:
           #     - ${{ github.repository == 'iree-org/iree' && 'self-hosted' || 'macos-14' }}
           #     - os-family=macOS
           #     - runner-group=postsubmit
-          # - runs-on: macos-14
-          #   build-family: macos
-          #   build-package: py-compiler-pkg
-          #   experimental: true
+          - runs-on: macos-14
+            build-family: macos
+            build-package: py-compiler-pkg
+            experimental: true
           - runs-on: macos-14
             build-family: macos
             build-package: py-runtime-pkg
             experimental: true
 
-          # # Windows packages.
-          # # TODO(scotttodd): build on larger runner when available (self-hosted or GitHub)
-          # # - runs-on:
-          # #     - ${{ github.repository == 'iree-org/iree' && 'windows-2022-64core' || 'windows-2022'}}
-          # - runs-on: windows-2022
-          #   build-family: windows
-          #   build-package: py-compiler-pkg
-          #   experimental: true
-          # - runs-on: windows-2022
-          #   build-family: windows
-          #   build-package: py-runtime-pkg
-          #   experimental: true
+          # Windows packages.
+          # TODO(scotttodd): build on larger runner when available (self-hosted or GitHub)
+          # - runs-on:
+          #     - ${{ github.repository == 'iree-org/iree' && 'windows-2022-64core' || 'windows-2022'}}
+          - runs-on: windows-2022
+            build-family: windows
+            build-package: py-compiler-pkg
+            experimental: true
+          - runs-on: windows-2022
+            build-family: windows
+            build-package: py-runtime-pkg
+            experimental: true
 
     env:
       # These are also set in: build_tools/python_deploy/build_linux_packages.sh

--- a/build_tools/python_deploy/build_macos_packages.sh
+++ b/build_tools/python_deploy/build_macos_packages.sh
@@ -72,9 +72,7 @@ function run() {
 }
 
 function build_iree_runtime() {
-  # TODO(antiagainst): remove Vulkan once IREE_HAL_DRIVER_METAL is stable
   export IREE_RUNTIME_BUILD_TRACY=ON
-  IREE_HAL_DRIVER_VULKAN=ON \
   python3 -m pip wheel -v -w $output_dir $repo_root/runtime/
 }
 

--- a/runtime/setup.py
+++ b/runtime/setup.py
@@ -275,10 +275,6 @@ def build_configuration(cmake_build_dir, cmake_install_dir, extra_cmake_args=())
         "-DIREE_BUILD_TESTS=OFF",
         "-DPython3_EXECUTABLE={}".format(sys.executable),
         "-DCMAKE_BUILD_TYPE={}".format(cfg),
-        get_env_cmake_option(
-            "IREE_HAL_DRIVER_VULKAN",
-            "OFF" if platform.system() == "Darwin" else "ON",
-        ),
         get_env_cmake_list("IREE_EXTERNAL_HAL_DRIVERS", ""),
         get_env_cmake_option("IREE_ENABLE_CPUINFO", "ON"),
     ] + list(extra_cmake_args)


### PR DESCRIPTION
Rather than use custom logic in the release package build, this falls back to using the base CMake logic that disables Vulkan in favor of Metal on Apple platforms: https://github.com/iree-org/iree/blob/8e42839893f40788357e38b2856ca5930cb4b47b/CMakeLists.txt#L267-L272

This should fix the `macos :: Build py-runtime-pkg` nightly release build, which started failing a few weeks ago
* Latest failing logs: https://github.com/iree-org/iree/actions/runs/10506137072/job/29105159765

    ```
      ld: building fixups: pointer not aligned at __ZN4iree3hal6vulkan12_GLOBAL__N_124kDynamicFunctionPtrInfosE+0xC from /tmp/lto.o
      clang: error: linker command failed with exit code 1 (use -v to see invocation)
    ```

* Test logs with this PR on my fork: https://github.com/ScottTodd/iree/actions/runs/10513089016/job/29127873585