### PR TITLE
Migrate manylinux dockerfiles from nod-ai to iree-org namespace.

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -101,7 +101,7 @@ jobs:
 
     env:
       # These are also set in: build_tools/python_deploy/build_linux_packages.sh
-      MANYLINUX_X86_64_IMAGE: ghcr.io/iree-org/manylinux_x86_64:main
+      MANYLINUX_X86_64_IMAGE: ghcr.io/iree-org/manylinux_x86_64@sha256:facedb71df670016e74e646d71e869e6fff70d4cdbaa6634d4d0a10d6e174399
       MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux_2_28_aarch64
 
     steps:

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -101,7 +101,7 @@ jobs:
 
     env:
       # These are also set in: build_tools/python_deploy/build_linux_packages.sh
-      MANYLINUX_X86_64_IMAGE: ghcr.io/nod-ai/manylinux_x86_64:main
+      MANYLINUX_X86_64_IMAGE: ghcr.io/iree-org/manylinux_x86_64:main
       MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux_2_28_aarch64
 
     steps:

--- a/.github/workflows/pkgci_build_packages.yml
+++ b/.github/workflows/pkgci_build_packages.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
     env:
       CACHE_DIR: ${{ github.workspace }}/.iree-container-cache
-      MANYLINUX_DOCKER_IMAGE: ghcr.io/nod-ai/manylinux_x86_64:main
+      MANYLINUX_DOCKER_IMAGE: ghcr.io/iree-org/manylinux_x86_64:main
       PACKAGE_SUFFIX: ""
     steps:
       - name: Prefetch Docker
@@ -90,7 +90,7 @@ jobs:
 #     fail-fast: false
 #   env:
 #     CACHE_DIR: ${{ github.workspace }}/.iree-container-cache
-#     MANYLINUX_DOCKER_IMAGE: ghcr.io/nod-ai/manylinux_x86_64:main
+#     MANYLINUX_DOCKER_IMAGE: ghcr.io/iree-org/manylinux_x86_64:main
 #     PACKAGE_SUFFIX: "-asserts"
 #   steps:
 #     - name: Prefetch Docker

--- a/.github/workflows/pkgci_build_packages.yml
+++ b/.github/workflows/pkgci_build_packages.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
     env:
       CACHE_DIR: ${{ github.workspace }}/.iree-container-cache
-      MANYLINUX_DOCKER_IMAGE: ghcr.io/iree-org/manylinux_x86_64:main
+      MANYLINUX_DOCKER_IMAGE: ghcr.io/iree-org/manylinux_x86_64@sha256:facedb71df670016e74e646d71e869e6fff70d4cdbaa6634d4d0a10d6e174399
       PACKAGE_SUFFIX: ""
     steps:
       - name: Prefetch Docker
@@ -90,7 +90,7 @@ jobs:
 #     fail-fast: false
 #   env:
 #     CACHE_DIR: ${{ github.workspace }}/.iree-container-cache
-#     MANYLINUX_DOCKER_IMAGE: ghcr.io/iree-org/manylinux_x86_64:main
+#     MANYLINUX_DOCKER_IMAGE: ghcr.io/iree-org/manylinux_x86_64@sha256:facedb71df670016e74e646d71e869e6fff70d4cdbaa6634d4d0a10d6e174399
 #     PACKAGE_SUFFIX: "-asserts"
 #   steps:
 #     - name: Prefetch Docker

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -38,32 +38,31 @@ A number of packages are produced automatically:
 
 #### Linux Builds
 
-Binary Linux packages are built using a custom `manylinux` based Docker
-image hosted here: https://github.com/nod-ai/base-docker-images/pkgs/container/manylinux_x86_64
-(TODO: this repository of Docker images should be moved into `iree-org`) using
-isolated self-hosted runners (only used for building checked in code) of
+Binary Linux packages are built using a custom `manylinux` based Docker image
+hosted here:
+https://github.com/iree-org/base-docker-images/pkgs/container/manylinux_x86_64
+using isolated self-hosted runners (only used for building checked in code) of
 sufficient size for building large components and GitHub managed runners for
 smaller components. The project aims to target all non-EOL Python versions with
 Linux builds on x86_64 and aarch64.
 
 #### Windows Builds
 
-Windows builds are built using GitHub managed large Windows runners. Due to the
-cost, the project aims to target the most recent version of Python only while
-building version N-1 for the first year of the lifecycle of the next version.
+Windows builds are built using GitHub-hosted runners. Due to the cost, the
+project aims to target the most recent version of Python only while building
+version N-1 for the first year of the lifecycle of the next version.
 
 Only the Python `iree-compiler` and `iree-runtime` packages are built for
 Windows.
 
-The release is published even if the MacOS build fails. When this happens, it
+The release is published even if the Windows build fails. When this happens, it
 is fixed forward for the next snapshot.
 
 #### MacOS Builds
 
-MacOS builds are performed using self hosted MacOS runners in a dedicated
-post-submit pool. Due to the cost, the project aims to target the most recent
-version of Python only while building version N-1 for the first year of the
-lifecycle of the next version.
+MacOS builds are performed using GitHub-hosted runners. Due to the cost, the
+project aims to target the most recent version of Python only while building
+version N-1 for the first year of the lifecycle of the next version.
 
 Only the Python `iree-compiler` and `iree-runtime` packages are built for
 MacOS.

--- a/build_tools/docker/README.md
+++ b/build_tools/docker/README.md
@@ -1,5 +1,15 @@
 # IREE Docker Configuration
 
+**⚠️ DEPRECATED ⚠️**
+
+These files are moving to https://github.com/iree-org/base-docker-images.
+
+Existing documentation is included here to ease the transition.
+
+---
+---
+---
+
 This directory contains the Dockerfiles that specify the container images used
 for IREE. Images are uploaded to
 [Google Container Registry (GCR)](https://cloud.google.com/container-registry).

--- a/build_tools/pkgci/build_linux_packages.sh
+++ b/build_tools/pkgci/build_linux_packages.sh
@@ -64,7 +64,7 @@ function find_git_dir_parent() {
 this_dir="$(cd $(dirname $0) && pwd)"
 script_name="$(basename $0)"
 repo_root=$(cd "${this_dir}" && find_git_dir_parent)
-manylinux_docker_image="${manylinux_docker_image:-$(uname -m | awk '{print ($1 == "aarch64") ? "quay.io/pypa/manylinux_2_28_aarch64" : "ghcr.io/iree-org/manylinux_x86_64:main" }')}"
+manylinux_docker_image="${manylinux_docker_image:-$(uname -m | awk '{print ($1 == "aarch64") ? "quay.io/pypa/manylinux_2_28_aarch64" : "ghcr.io/iree-org/manylinux_x86_64@sha256:facedb71df670016e74e646d71e869e6fff70d4cdbaa6634d4d0a10d6e174399" }')}"
 python_versions="${override_python_versions:-cp311-cp311}"
 output_dir="${output_dir:-${this_dir}/wheelhouse}"
 cache_dir="${cache_dir:-}"

--- a/build_tools/pkgci/build_linux_packages.sh
+++ b/build_tools/pkgci/build_linux_packages.sh
@@ -64,7 +64,7 @@ function find_git_dir_parent() {
 this_dir="$(cd $(dirname $0) && pwd)"
 script_name="$(basename $0)"
 repo_root=$(cd "${this_dir}" && find_git_dir_parent)
-manylinux_docker_image="${manylinux_docker_image:-$(uname -m | awk '{print ($1 == "aarch64") ? "quay.io/pypa/manylinux_2_28_aarch64" : "ghcr.io/nod-ai/manylinux_x86_64:main" }')}"
+manylinux_docker_image="${manylinux_docker_image:-$(uname -m | awk '{print ($1 == "aarch64") ? "quay.io/pypa/manylinux_2_28_aarch64" : "ghcr.io/iree-org/manylinux_x86_64:main" }')}"
 python_versions="${override_python_versions:-cp311-cp311}"
 output_dir="${output_dir:-${this_dir}/wheelhouse}"
 cache_dir="${cache_dir:-}"

--- a/build_tools/python_deploy/build_linux_packages.sh
+++ b/build_tools/python_deploy/build_linux_packages.sh
@@ -64,7 +64,7 @@ function find_git_dir_parent() {
 this_dir="$(cd $(dirname $0) && pwd)"
 script_name="$(basename $0)"
 repo_root=$(cd "${this_dir}" && find_git_dir_parent)
-manylinux_docker_image="${manylinux_docker_image:-$(uname -m | awk '{print ($1 == "aarch64") ? "quay.io/pypa/manylinux_2_28_aarch64" : "ghcr.io/iree-org/manylinux_x86_64:main" }')}"
+manylinux_docker_image="${manylinux_docker_image:-$(uname -m | awk '{print ($1 == "aarch64") ? "quay.io/pypa/manylinux_2_28_aarch64" : "ghcr.io/iree-org/manylinux_x86_64@sha256:facedb71df670016e74e646d71e869e6fff70d4cdbaa6634d4d0a10d6e174399" }')}"
 python_versions="${override_python_versions:-cp39-cp39 cp310-cp310 cp311-cp311 cp312-cp312}"
 output_dir="${output_dir:-${this_dir}/wheelhouse}"
 packages="${packages:-iree-runtime iree-compiler}"

--- a/build_tools/python_deploy/build_linux_packages.sh
+++ b/build_tools/python_deploy/build_linux_packages.sh
@@ -64,7 +64,7 @@ function find_git_dir_parent() {
 this_dir="$(cd $(dirname $0) && pwd)"
 script_name="$(basename $0)"
 repo_root=$(cd "${this_dir}" && find_git_dir_parent)
-manylinux_docker_image="${manylinux_docker_image:-$(uname -m | awk '{print ($1 == "aarch64") ? "quay.io/pypa/manylinux_2_28_aarch64" : "ghcr.io/nod-ai/manylinux_x86_64:main" }')}"
+manylinux_docker_image="${manylinux_docker_image:-$(uname -m | awk '{print ($1 == "aarch64") ? "quay.io/pypa/manylinux_2_28_aarch64" : "ghcr.io/iree-org/manylinux_x86_64:main" }')}"
 python_versions="${override_python_versions:-cp39-cp39 cp310-cp310 cp311-cp311 cp312-cp312}"
 output_dir="${output_dir:-${this_dir}/wheelhouse}"
 packages="${packages:-iree-runtime iree-compiler}"


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree/issues/15332.

See the RFC: https://groups.google.com/g/iree-discuss/c/IPLzMsPb5UI. I have forked https://github.com/nod-ai/base-docker-images/ into https://github.com/iree-org/base-docker-images.

Now, dockerfiles are built and published as packages in the iree-org namespace using GitHub's container registry. Future changes will migrate what remains in https://github.com/iree-org/iree/tree/main/build_tools/docker.