### PR TITLE
[cmake] Disable HIP on Apple platforms by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,7 +260,7 @@ endif()
 # HIP support is enabled by default if not cross compiling. Note: a HIP-compatible
 # GPU with drivers is still required to actually run HIP workloads.
 set(IREE_HAL_DRIVER_HIP_DEFAULT ${IREE_HAL_DRIVER_DEFAULTS})
-if(CMAKE_CROSSCOMPILING)
+if(APPLE OR CMAKE_CROSSCOMPILING)
   set(IREE_HAL_DRIVER_HIP_DEFAULT OFF)
 endif()
 


### PR DESCRIPTION
HIP does not support Apple platforms.