### PR TITLE
Revert "[Flow] Convert from tensor.cast to flow.tensor.reshape early …(#18256)"

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Patterns.cpp
@@ -326,9 +326,4 @@ void populateTensorToFlowConversionPatterns(MLIRContext *context,
               ConvertTensorReshapePattern<tensor::ExpandShapeOp>>(context);
 }
 
-void populateTensorDialectCastOpPattern(MLIRContext *context,
-                                        RewritePatternSet &patterns) {
-  patterns.insert<ConvertTensorCastPattern>(context);
-}
-
 } // namespace mlir::iree_compiler::IREE::Flow

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Patterns.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Patterns.h
@@ -16,10 +16,6 @@ namespace mlir::iree_compiler::IREE::Flow {
 void populateTensorToFlowConversionPatterns(MLIRContext *context,
                                             RewritePatternSet &patterns);
 
-// Add pattern to convert tensor.cast -> flow.tensor.reshape.
-void populateTensorDialectCastOpPattern(MLIRContext *context,
-                                        RewritePatternSet &patterns);
-
 } // namespace mlir::iree_compiler::IREE::Flow
 
 #endif // IREE_COMPILER_DIALECT_FLOW_CONVERSION_TENSORTOFLOW_PATTERNS_H_

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Canonicalizer.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Canonicalizer.cpp
@@ -4,7 +4,6 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Patterns.h"
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -104,11 +103,6 @@ struct CanonicalizerPass
       CanonicalizerPass>::CanonicalizerPassBase;
   /// Initialize the canonicalizer by building the set of patterns used during
   /// execution.
-
-  void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<IREE::Flow::FlowDialect>();
-  }
-
   LogicalResult initialize(MLIRContext *context) override {
     // Inherit the same config defaults from the upstream canonicalizer pass.
     config.useTopDownTraversal = true;
@@ -123,7 +117,6 @@ struct CanonicalizerPass
     // Pull in some borderline/downstream canonicalizations for the Flow
     // compilation phase.
     tensor::populateMergeConsecutiveInsertExtractSlicePatterns(owningPatterns);
-    IREE::Flow::populateTensorDialectCastOpPattern(context, owningPatterns);
     owningPatterns.add<FoldConsecutiveConstantPadding>(context);
 
     patterns =

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/flow_canonicalize.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/flow_canonicalize.mlir
@@ -82,27 +82,3 @@ util.func public @dont_merge_constant_padding_different_vals(
 // CHECK-LABEL: util.func public @dont_merge_constant_padding_different_vals
 //       CHECK:   tensor.pad
 //       CHECK:   tensor.pad
-
-// -----
-
-util.func public @tensor_cast_to_reshape(%reshape_17 : tensor<?x?x?x?xf32>, %65 : tensor<?x12x?x64xf32>, %0 : index, %1 : index) -> tensor<?x?x?x?xf32> {
-  %cast = tensor.cast %reshape_17 : tensor<?x?x?x?xf32> to tensor<?x?x12x64xf32>
-  %66 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>,
-    affine_map<(d0, d1, d2, d3) -> (d0, d2, d1, d3)>],
-    iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
-    ins(%cast : tensor<?x?x12x64xf32>) outs(%65 : tensor<?x12x?x64xf32>) {
-  ^bb0(%in: f32, %out: f32):
-    linalg.yield %in : f32
-  } -> tensor<?x12x?x64xf32>
-  %cast_18 = tensor.cast %66 : tensor<?x12x?x64xf32> to tensor<?x?x?x?xf32>
-  util.return  %cast_18 : tensor<?x?x?x?xf32>
-}
-
-// CHECK-LABEL: util.func public @tensor_cast_to_reshape
-//       CHECK:   flow.tensor.reshape
-//       CHECK-SAME: tensor<?x?x?x?xf32>
-//       CHECK-SAME: -> tensor<?x?x12x64xf32>
-//       CHECK:   linalg.generic
-//       CHECK:   flow.tensor.reshape
-//       CHECK-SAME: tensor<?x12x?x64xf32>
-//       CHECK-SAME: -> tensor<?x?x?x?xf32>


### PR DESCRIPTION
This reverts commit 1c0c5a6ff64bedb1cb1275eaba16aab3fc26acdf.

This is causing an issue with  https://github.com/iree-org/iree/actions/runs/10505447157/job/29119827242#step:5:2269
iree/tests/e2e/regression/check_regression_llvm-cpu_layernorm.mlir

Triaging the bug I see that one of the dispatches is slightly different but should result to the same numerics but it does not
Here is how the problem dispatch used to be originally
```
        func.func @old_dispatch2(%11 : tensor<128x384xf32>, %12: tensor<128xf32>) -> tensor<128x384xf32> {
        %cst = arith.constant 5.000000e+00 : f32
        %cst_0 = arith.constant 0.000000e+00 : f32
        %13 = tensor.empty() : tensor<128x384xf32>
        %14 = tensor.empty() : tensor<128xf32>
        %15 = linalg.fill ins(%cst_0 : f32) outs(%14 : tensor<128xf32>) -> tensor<128xf32>
        %16 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%11 : tensor<128x384xf32>) outs(%15 : tensor<128xf32>) {
        ^bb0(%in: f32, %out: f32):
          %18 = arith.addf %in, %out : f32
          linalg.yield %18 : f32
        } -> tensor<128xf32>
        %17 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%11, %16, %12 : tensor<128x384xf32>, tensor<128xf32>, tensor<128xf32>) outs(%13 : tensor<128x384xf32>) {
        ^bb0(%og_in : f32, %in: f32, %in_1: f32, %out: f32):
          %18 = arith.mulf %in, %in_1 : f32
          %19 = arith.subf %og_in, %18 : f32
          linalg.yield %19 : f32
        } -> tensor<128x384xf32>
        return %17 :  tensor<128x384xf32>
        }
  ```
  with the reverting PR this dispatch is becoming
  ```
          func.func @new_dispatch2(%11 : tensor<128x384xf32>, %12: tensor<128xf32>) -> tensor<128x384xf32> {
        %cst = arith.constant 5.000000e+00 : f32
        %cst_0 = arith.constant 0.000000e+00 : f32
        %13 = tensor.empty() : tensor<128x384xf32>
        %14 = tensor.empty() : tensor<128xf32>
        %15 = linalg.fill ins(%cst_0 : f32) outs(%14 : tensor<128xf32>) -> tensor<128xf32>
        %16 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%11 : tensor<128x384xf32>) outs(%15 : tensor<128xf32>) {
        ^bb0(%in: f32, %out: f32):
          %18 = arith.addf %in, %out : f32
          linalg.yield %18 : f32
        } -> tensor<128xf32>
        %17 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%16, %12 : tensor<128xf32>, tensor<128xf32>) outs(%13 : tensor<128x384xf32>) {
        ^bb0(%in: f32, %in_1: f32, %out: f32):
          %18 = arith.mulf %in, %in_1 : f32
          %19 = arith.subf %cst, %18 : f32
          linalg.yield %19 : f32
        } -> tensor<128x384xf32>
        return %17 :  tensor<128x384xf32>
        }
   ```
   The difference is at `%19 = arith.subf %cst, %18 : f32`
   Note that in both cases `%11 : tensor<128x384xf32>` is `5.0` from the model input and hence the output *should* be same, however on `arch64` it is not but on x86 it is, the IR at the mlir llvm dialect is identicalbetween x86 and arch64 so its not some easy to  spot intrinsics / fast math kind of bug AFAICS
             