### PR TITLE
[EmitC] Remove array related macros from `ops_emitc.h`

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -272,7 +272,7 @@ createVmTypeDefPtr(ConversionPatternRewriter &rewriter, Location loc,
     TypedValue<emitc::PointerType> typeArray =
         cast<TypedValue<emitc::PointerType>>(emitc_builders::structPtrMember(
             rewriter, loc, typeRefArrayType, "types", moduleArgLValue));
-    Value refType = emitc_builders::arrayElement(rewriter, loc, typeRefType,
+    Value refType = emitc_builders::arrayElement(rewriter, loc,
                                                  typeIndex.value(), typeArray);
 
     elementTypeValue =
@@ -719,12 +719,7 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
               /*memberName=*/"rodata_buffers", /*operand=*/state));
 
       auto buffer = emitc_builders::arrayElementAddress(
-          builder, loc,
-          /*type=*/
-          emitc::PointerType::get(
-              emitc::OpaqueType::get(ctx, "iree_vm_buffer_t")),
-          /*index=*/builder.getUI32IntegerAttr(ordinal),
-          /*operand=*/buffers);
+          builder, loc, /*index=*/ordinal, /*operand=*/buffers);
 
       builder.create<emitc::CallOpaqueOp>(
           /*location=*/loc,
@@ -761,12 +756,7 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
 
       for (int i = 0; i < numGlobalRefs; i++) {
         auto refPtrOp = emitc_builders::arrayElementAddress(
-            builder, loc,
-            /*type=*/
-            emitc::PointerType::get(
-                emitc::OpaqueType::get(ctx, "iree_vm_ref_t")),
-            /*index=*/builder.getUI32IntegerAttr(i),
-            /*operand=*/refs);
+            builder, loc, /*index=*/i, /*operand=*/refs);
 
         if (failed(clearStruct(builder, refPtrOp))) {
           return failure();
@@ -853,12 +843,7 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
 
       for (int i = 0; i < numGlobalRefs; i++) {
         auto refPtrOp = emitc_builders::arrayElementAddress(
-            builder, loc,
-            /*type=*/
-            emitc::PointerType::get(
-                emitc::OpaqueType::get(ctx, "iree_vm_ref_t")),
-            /*index=*/builder.getUI32IntegerAttr(i),
-            /*operand=*/refs);
+            builder, loc, /*index=*/i, /*operand=*/refs);
 
         emitc_builders::ireeVmRefRelease(builder, loc, refPtrOp);
       }
@@ -947,10 +932,7 @@ LogicalResult createAPIFunctions(IREE::VM::ModuleOp moduleOp,
             /*operand=*/stateOpLValue));
 
     auto import = emitc_builders::arrayElementAddress(
-        builder, loc, /*type=*/
-        emitc::PointerType::get(
-            emitc::OpaqueType::get(ctx, "iree_vm_function_t")),
-        /*index=*/ordinalArg, /*operand=*/imports);
+        builder, loc, /*index=*/ordinalArg, /*operand=*/imports);
 
     builder.create<emitc::CallOpaqueOp>(
         /*location=*/loc,
@@ -2703,12 +2685,7 @@ class CallOpConversion : public EmitCConversionPattern<OpTy> {
             /*operand=*/stateArgLValue));
 
     auto import = emitc_builders::arrayElementAddress(
-        rewriter, loc,
-        /*type=*/
-        emitc::PointerType::get(
-            emitc::OpaqueType::get(ctx, "iree_vm_function_t")),
-        /*index=*/rewriter.getUI32IntegerAttr(importOrdinal),
-        /*operand=*/imports);
+        rewriter, loc, /*index=*/importOrdinal, /*operand=*/imports);
 
     updatedOperands = {stackArg, import};
 
@@ -3123,13 +3100,7 @@ class ConstRefRodataOpConversion
             /*operand=*/stateArgLValue));
 
     auto byteBufferPtrOp = emitc_builders::arrayElementAddress(
-        rewriter, loc,
-        /*type=*/
-        emitc::PointerType::get(
-            emitc::OpaqueType::get(ctx, "iree_vm_buffer_t")),
-        /*index=*/
-        rewriter.getUI32IntegerAttr(
-            static_cast<uint32_t>(rodataOp.getOrdinal()->getZExtValue())),
+        rewriter, loc, /*index=*/rodataOp.getOrdinal()->getZExtValue(),
         /*operand=*/rodataBuffersPtr);
 
     auto typeIdOp = rewriter.create<emitc::CallOpaqueOp>(
@@ -3438,12 +3409,7 @@ private:
             /*operand=*/stateArgLValue));
 
     auto import = emitc_builders::arrayElementAddress(
-        rewriter, loc,
-        /*type=*/
-        emitc::PointerType::get(
-            emitc::OpaqueType::get(ctx, "iree_vm_function_t")),
-        /*index=*/rewriter.getUI32IntegerAttr(importOrdinal),
-        /*operand=*/imports);
+        rewriter, loc, /*index=*/importOrdinal, /*operand=*/imports);
     auto importLValue = emitc_builders::asLValue(rewriter, loc, import);
 
     // (iree_vm_function_t*)->module
@@ -3677,11 +3643,7 @@ class GlobalLoadStoreRefOpConversion : public EmitCConversionPattern<OpTy> {
             /*operand=*/stateArgLValue));
 
     auto stateRef = emitc_builders::arrayElementAddress(
-        rewriter, loc,
-        /*type=*/
-        emitc::PointerType::get(emitc::OpaqueType::get(ctx, "iree_vm_ref_t")),
-        /*index=*/rewriter.getUI32IntegerAttr(globalOrdinal),
-        /*operand=*/refs);
+        rewriter, loc, /*index=*/globalOrdinal, /*operand=*/refs);
 
     auto moduleOp = op->getParentOfType<IREE::VM::ModuleOp>();
     auto parentFuncOp = op->getParentOfType<mlir::emitc::FuncOp>();

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCBuilders.h
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCBuilders.h
@@ -77,15 +77,14 @@ void memcpy(OpBuilder builder, Location location, Value dest, Value src,
 void memset(OpBuilder builder, Location location, Value dest, int ch,
             Value count);
 
-Value arrayElement(OpBuilder builder, Location location, Type type,
-                   size_t index, TypedValue<emitc::PointerType> operand);
+Value arrayElement(OpBuilder builder, Location location, size_t index,
+                   TypedValue<emitc::PointerType> operand);
 
-Value arrayElementAddress(OpBuilder builder, Location location, Type type,
-                          IntegerAttr index,
+Value arrayElementAddress(OpBuilder builder, Location location, size_t index,
                           TypedValue<emitc::PointerType> operand);
 
-Value arrayElementAddress(OpBuilder builder, Location location, Type type,
-                          Value index, TypedValue<emitc::PointerType> operand);
+Value arrayElementAddress(OpBuilder builder, Location location, Value index,
+                          TypedValue<emitc::PointerType> operand);
 
 void arrayElementAssign(OpBuilder builder, Location location,
                         TypedValue<emitc::PointerType> array, size_t index,

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/control_flow_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/control_flow_ops.mlir
@@ -71,8 +71,9 @@ vm.module @my_module {
     // CHECK-NEXT: emitc.assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
     // CHECK-NEXT: %[[IMPORTS_LVAL:.+]] = "emitc.member_of_ptr"(%[[STATE_LVAL]]) <{member = "imports"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>) -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
     // CHECK-NEXT: %[[IMPORTS:.+]] = emitc.load %[[IMPORTS_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
-    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.call_opaque "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[IMPORTS]]) {args = [0 : index, 0 : ui32]}
-    // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[IMPORT_INDEX:.+]] = emitc.literal "0" : !emitc.opaque<"iree_host_size_t">
+    // CHECK-NEXT: %[[IMPORT_SUBSCRIPT:.+]] = emitc.subscript %[[IMPORTS]][%[[IMPORT_INDEX]]] : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>, !emitc.opaque<"iree_host_size_t">) -> !emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.apply "&"(%[[IMPORT_SUBSCRIPT]]) : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
 
     // Create a variable for the function result.
     // CHECK-NEXT: %[[RESULT:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<i32>
@@ -99,8 +100,9 @@ vm.module @my_module {
     // CHECK-NEXT: emitc.assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
     // CHECK-NEXT: %[[IMPORTS_LVAL:.+]] = "emitc.member_of_ptr"(%[[STATE_LVAL]]) <{member = "imports"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>) -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
     // CHECK-NEXT: %[[IMPORTS:.+]] = emitc.load %[[IMPORTS_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
-    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.call_opaque "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[IMPORTS]]) {args = [0 : index, 0 : ui32]}
-    // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[IMPORT_INDEX:.+]] = emitc.literal "0" : !emitc.opaque<"iree_host_size_t">
+    // CHECK-NEXT: %[[IMPORT_SUBSCRIPT:.+]] = emitc.subscript %[[IMPORTS]][%[[IMPORT_INDEX]]] : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>, !emitc.opaque<"iree_host_size_t">) -> !emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.apply "&"(%[[IMPORT_SUBSCRIPT]]) : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
 
     // Create a variable for the function result.
     // CHECK-NEXT: %[[RESULT:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<i32>
@@ -158,8 +160,9 @@ vm.module @my_module {
     // CHECK-NEXT: emitc.assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
     // CHECK-NEXT: %[[IMPORTS_LVAL:.+]] = "emitc.member_of_ptr"(%[[STATE_LVAL]]) <{member = "imports"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>) -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
     // CHECK-NEXT: %[[IMPORTS:.+]] = emitc.load %[[IMPORTS_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
-    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.call_opaque "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[IMPORTS]]) {args = [0 : index, 0 : ui32]}
-    // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[IMPORT_INDEX:.+]] = emitc.literal "0" : !emitc.opaque<"iree_host_size_t">
+    // CHECK-NEXT: %[[IMPORT_SUBSCRIPT:.+]] = emitc.subscript %[[IMPORTS]][%[[IMPORT_INDEX]]] : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>, !emitc.opaque<"iree_host_size_t">) -> !emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.apply "&"(%[[IMPORT_SUBSCRIPT]]) : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
 
     // This holds the number of variadic arguments.
     // CHECK-NEXT: %[[NARGS:.+]] = "emitc.constant"() <{value = 2 : i32}> : () -> i32
@@ -193,8 +196,9 @@ vm.module @my_module {
     // CHECK-NEXT: emitc.assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
     // CHECK-NEXT: %[[IMPORTS_LVAL:.+]] = "emitc.member_of_ptr"(%[[STATE_LVAL]]) <{member = "imports"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>) -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
     // CHECK-NEXT: %[[IMPORTS:.+]] = emitc.load %[[IMPORTS_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
-    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.call_opaque "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[IMPORTS]]) {args = [0 : index, 0 : ui32]}
-    // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[IMPORT_INDEX:.+]] = emitc.literal "0" : !emitc.opaque<"iree_host_size_t">
+    // CHECK-NEXT: %[[IMPORT_SUBSCRIPT:.+]] = emitc.subscript %[[IMPORTS]][%[[IMPORT_INDEX]]] : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>, !emitc.opaque<"iree_host_size_t">) -> !emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.apply "&"(%[[IMPORT_SUBSCRIPT]]) : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
 
     // This holds the number of variadic arguments.
     // CHECK-NEXT: %[[NARGS:.+]] = "emitc.constant"() <{value = 0 : i32}> : () -> i32
@@ -834,8 +838,9 @@ vm.module @my_module {
     // CHECK-NEXT: emitc.assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
     // CHECK-NEXT: %[[IMPORTS_LVAL:.+]] = "emitc.member_of_ptr"(%[[STATE_LVAL]]) <{member = "imports"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>) -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
     // CHECK-NEXT: %[[IMPORTS:.+]] = emitc.load %[[IMPORTS_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
-    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.call_opaque "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[IMPORTS]]) {args = [0 : index, 0 : ui32]}
-    // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[IMPORT_INDEX:.+]] = emitc.literal "0" : !emitc.opaque<"iree_host_size_t">
+    // CHECK-NEXT: %[[IMPORT_SUBSCRIPT:.+]] = emitc.subscript %[[IMPORTS]][%[[IMPORT_INDEX]]] : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>, !emitc.opaque<"iree_host_size_t">) -> !emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.apply "&"(%[[IMPORT_SUBSCRIPT]]) : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
     // CHECK-NEXT: %[[IMPORT_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
     // CHECK-NEXT: emitc.assign %[[IMPORT]] : !emitc.ptr<!emitc.opaque<"iree_vm_function_t">> to %[[IMPORT_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
     // CHECK-NEXT: %[[MODULE_LVAL:.+]] = "emitc.member_of_ptr"(%[[IMPORT_LVAL]]) <{member = "module"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>) -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_module_t">>>

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/global_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/global_ops.mlir
@@ -43,7 +43,9 @@ vm.module @my_module {
     // CHECK-NEXT: emitc.assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
     // CHECK-NEXT: %[[REFS_LVAL:.+]] = "emitc.member_of_ptr"(%[[STATE_LVAL]]) <{member = "refs"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>) -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>>
     // CHECK-NEXT: %[[REFS:.+]] = emitc.load %[[REFS_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>>
-    // CHECK: %[[REF_0:.+]] = emitc.call_opaque "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[REFS]]) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
+    // CHECK: %[[REF_INDEX:.+]] = emitc.literal "0" : !emitc.opaque<"iree_host_size_t">
+    // CHECK-NEXT: %[[REF:.+]] = emitc.subscript %[[REFS]][%[[REF_INDEX]]] : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.opaque<"iree_host_size_t">) -> !emitc.lvalue<!emitc.opaque<"iree_vm_ref_t">>
+    // CHECK-NEXT: %[[REF_0:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.lvalue<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
     // CHECK: %[[C:.+]] = emitc.call_opaque "iree_vm_type_def_as_ref"(%{{.+}}) : (!emitc.opaque<"iree_vm_type_def_t">) -> !emitc.opaque<"iree_vm_ref_type_t">
     // CHECK: %{{.+}} = emitc.call_opaque "iree_vm_ref_retain_or_move_checked"(%[[REF_0]], %[[C]], %arg3) {args = [false, 0 : index, 1 : index, 2 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.opaque<"iree_vm_ref_type_t">, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
     %0 = vm.global.load.ref @g0 : !vm.buffer
@@ -62,7 +64,9 @@ vm.module @my_module {
     // CHECK-NEXT: emitc.assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
     // CHECK-NEXT: %[[REFS_LVAL:.+]] = "emitc.member_of_ptr"(%[[STATE_LVAL]]) <{member = "refs"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>) -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>>
     // CHECK-NEXT: %[[REFS:.+]] = emitc.load %[[REFS_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>>
-    // CHECK: %[[REF_0:.+]] = emitc.call_opaque "EMITC_ARRAY_ELEMENT_ADDRESS"(%[[REFS]]) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
+    // CHECK: %[[REF_INDEX:.+]] = emitc.literal "0" : !emitc.opaque<"iree_host_size_t">
+    // CHECK-NEXT: %[[REF:.+]] = emitc.subscript %[[REFS]][%[[REF_INDEX]]] : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.opaque<"iree_host_size_t">) -> !emitc.lvalue<!emitc.opaque<"iree_vm_ref_t">>
+    // CHECK-NEXT: %[[REF_0:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.lvalue<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
     // CHECK: %[[C:.+]] = emitc.call_opaque "iree_vm_type_def_as_ref"(%{{.+}}) : (!emitc.opaque<"iree_vm_type_def_t">) -> !emitc.opaque<"iree_vm_ref_type_t">
     // CHECK: %{{.+}} = emitc.call_opaque "iree_vm_ref_retain_or_move_checked"(%arg3, %[[C]], %[[REF_0]]) {args = [false, 0 : index, 1 : index, 2 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.opaque<"iree_vm_ref_type_t">, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
     vm.global.store.ref %arg0, @g0_mut : !vm.buffer

--- a/compiler/src/iree/compiler/Dialect/VM/Target/C/test/constant_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/C/test/constant_ops.mlir
@@ -31,7 +31,7 @@ vm.module @rodata_ops {
   // CHECK-NEXT: [[BYTE_SPAN_1:[^ ]*]] = iree_make_byte_span([[VOID_PTR_1]], [[SIZE_1]]);
   // CHECK-NEXT: [[ALLOCATOR_1:[^ ]*]] = iree_allocator_null();
   // CHECK-NEXT: [[BUFFERS_1:[^ ]*]] = [[STATE]]->rodata_buffers;
-  // CHECK-NEXT: [[BUFFER_1:[^ ]*]] = EMITC_ARRAY_ELEMENT_ADDRESS([[BUFFERS_1]], 0);
+  // CHECK-NEXT: [[BUFFER_1:[^ ]*]] = &[[BUFFERS_1]][0];
   // CHECK-NEXT: iree_vm_buffer_initialize(IREE_VM_BUFFER_ACCESS_ORIGIN_MODULE, [[BYTE_SPAN_1]], [[ALLOCATOR_1]], [[BUFFER_1]]);
 
   // CHECK: [[BUFFER_PTR_2:[^ ]*]] = rodata_ops_buffer_2;
@@ -41,7 +41,7 @@ vm.module @rodata_ops {
   // CHECK-NEXT: [[BYTE_SPAN_2:[^ ]*]] = iree_make_byte_span([[VOID_PTR_2]], [[SIZE_2]]);
   // CHECK-NEXT: [[ALLOCATOR_2:[^ ]*]] = iree_allocator_null();
   // CHECK-NEXT: [[BUFFERS_2:[^ ]*]] = [[STATE]]->rodata_buffers;
-  // CHECK-NEXT: [[BUFFER_2:[^ ]*]] = EMITC_ARRAY_ELEMENT_ADDRESS([[BUFFERS_2]], 1);
+  // CHECK-NEXT: [[BUFFER_2:[^ ]*]] = &[[BUFFERS_2]][1];
   // CHECK-NEXT: iree_vm_buffer_initialize(IREE_VM_BUFFER_ACCESS_ORIGIN_MODULE, [[BYTE_SPAN_2]], [[ALLOCATOR_2]], [[BUFFER_2]]);
 }
 

--- a/runtime/src/iree/vm/ops_emitc.h
+++ b/runtime/src/iree/vm/ops_emitc.h
@@ -19,13 +19,4 @@
 // Call a function pointer with the given arguments
 #define EMITC_CALL_INDIRECT(func, ...) (func)(__VA_ARGS__)
 
-// Get an array element
-#define EMITC_ARRAY_ELEMENT(array, index) (array)[index]
-
-// Get the address of an array element
-#define EMITC_ARRAY_ELEMENT_ADDRESS(array, index) &(array)[index]
-
-// Assign a value to an array at a given index
-#define EMITC_ARRAY_ELEMENT_ASSIGN(array, index, value) (array)[index] = (value)
-
 #endif  // IREE_VM_OPS_EMITC_H_


### PR DESCRIPTION
Replace array related helper macros with the `emitc.subscript` operation introduced in https://github.com/llvm/llvm-project/pull/84783.