### PR TITLE
Add pattern to bubble expand through collapse

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
@@ -151,7 +151,10 @@ void BubbleUpExpandShapesPass::runOnOperation() {
         if (auto consumerLinalgOp = dyn_cast<linalg::LinalgOp>(consumer)) {
           return isa<linalg::GenericOp>(consumerLinalgOp) &&
                  llvm::all_of(consumerLinalgOp.getIteratorTypesArray(),
-                              linalg::isParallelIterator);
+                              linalg::isParallelIterator) &&
+                 !llvm::any_of(consumerLinalgOp->getUsers(), [](Operation *op) {
+                   return llvm::isa<tensor::InsertSliceOp>(op);
+                 });
         }
         // Fuse in all other cases.
         return true;

--- a/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
@@ -199,6 +199,7 @@ void BubbleUpExpandShapesPass::runOnOperation() {
   };
   IREE::LinalgExt::populateFoldReshapeOpsByExpansionPatterns(
       bubbleExpandShapePatterns, linalgExtExpansionFn);
+  tensor::populateBubbleUpExpandShapePatterns(bubbleExpandShapePatterns);
 
   // Add patterns to do some additional cleanup (on top of canonicalizations
   // that can be done later) of reshape ops.

--- a/compiler/src/iree/compiler/DispatchCreation/FuseMultiUseElementwiseProducer.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FuseMultiUseElementwiseProducer.cpp
@@ -198,7 +198,8 @@ static FailureOr<unsigned> fuseMultiUseProducers(Operation *funcOp,
 
           // 7. Skip dequantization-like `producer` ops as we would rather fuse
           //    by cloning the producer instead of multi-use fusion.
-          if (IREE::LinalgExt::isBitExtendOp(producer)) {
+          if (IREE::LinalgExt::isBitTruncateOp(producer) ||
+              IREE::LinalgExt::isBitExtendOp(producer)) {
             return;
           }
 

--- a/compiler/src/iree/compiler/DispatchCreation/FusionUtils.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FusionUtils.cpp
@@ -65,7 +65,9 @@ bool areFusableAsElementwiseOps(MLIRContext *context, OpOperand *fusedOperand,
   // (except for bit-extend ops). If the consumer has only one use, then this
   // fusion is fine since cloning wont result in redundant computation of the
   // producer. (Also note that the producer is always an elementwise operation).
-  if (IREE::LinalgExt::isBitExtendOp(consumerOp) && !consumerOp->hasOneUse()) {
+  if (IREE::LinalgExt::isBitExtendOp(consumerOp) &&
+      (!consumerOp->hasOneUse() ||
+       IREE::LinalgExt::isBitTruncateOp(producerOp))) {
     return false;
   }
 

--- a/compiler/src/iree/compiler/DispatchCreation/FusionUtils.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FusionUtils.cpp
@@ -11,6 +11,7 @@
 #include "compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
 
 namespace mlir::iree_compiler::DispatchCreation {
 
@@ -43,13 +44,20 @@ bool areFusableAsElementwiseOps(MLIRContext *context, OpOperand *fusedOperand,
     }
   }
 
-  // If the generic op is "just" copy, then fuse always.
-  Block &body = producerOp->getRegion(0).front();
-  if (std::begin(body)->hasTrait<OpTrait::IsTerminator>())
-    return true;
-  if (llvm::all_of(body.getArguments(),
-                   [](BlockArgument arg) { return arg.use_empty(); })) {
+  auto shouldAlwaysFuse = [](Operation *op) {
+    // If the generic op is "just" copy, then fuse always.
+    Block &body = op->getRegion(0).front();
+    if (std::begin(body)->hasTrait<OpTrait::IsTerminator>()) {
+      return true;
+    }
     // The operands aren't used, its just an `linalg.index` op.
+    if (llvm::all_of(body.getArguments(),
+                     [](BlockArgument arg) { return arg.use_empty(); })) {
+      return true;
+    }
+    return false;
+  };
+  if (shouldAlwaysFuse(producerOp) || shouldAlwaysFuse(consumerOp)) {
     return true;
   }
 
@@ -65,7 +73,7 @@ bool areFusableAsElementwiseOps(MLIRContext *context, OpOperand *fusedOperand,
   // (except for bit-extend ops). If the consumer has only one use, then this
   // fusion is fine since cloning wont result in redundant computation of the
   // producer. (Also note that the producer is always an elementwise operation).
-  if (IREE::LinalgExt::isBitExtendOp(consumerOp) &&
+  if (IREE::LinalgExt::isBitExtendOp(consumerOp) ||
       (!consumerOp->hasOneUse() ||
        IREE::LinalgExt::isBitTruncateOp(producerOp))) {
     return false;


### PR DESCRIPTION
Use pattern from upstream commit https://github.com/llvm/llvm-project/commit/a95ad2da36b6a996b05c79df6b385cd98bac286d


About a week ago, this was causing regressions with int8 sdxl, but I'm now unable to repro locally.

https://github.com/iree-org/iree/pull/18424 addresses the compilation failures, but im still trying to reproduce the correctness issues with sdxl