### PR TITLE
[Im2col] Add option to unroll decomposed im2col loops

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeIm2col.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeIm2col.cpp
@@ -36,6 +36,8 @@ static LogicalResult decomposeIm2col(Im2colOp im2colOp, RewriterBase &rewriter,
 
   // Unroll the loop nest created by the im2col op decomposition.
   auto outerLoop = decomposedIm2col.value().front().getDefiningOp<scf::ForOp>();
+  assert(outerLoop &&
+         "expected im2col op decomposition to produce scf.for loop nest.");
   SmallVector<scf::ForOp> loopNest({outerLoop});
   while (auto innerLoop =
              outerLoop.getYieldedValues()[0].getDefiningOp<scf::ForOp>()) {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.td
@@ -54,6 +54,10 @@ def DecomposeIm2colPass :
     InterfacePass<"iree-linalg-ext-decompose-im2col", "mlir::FunctionOpInterface"> {
   let summary =
       "Decomposes im2col ops into insert and extract slice ops";
+  let options = [
+    Option<"unroll", "unroll", "bool", /*default=*/"true",
+           "Unroll the resulting loop nest after decomposition.">,
+  ];
 }
 
 def DecomposeWinogradTransformPass :


### PR DESCRIPTION
This adds an option to the DecomposeIm2colPass to unroll the resulting loop nest of the decomposition, and sets it to true by default. This is an easier form to handle in most lowerings of the op. In particular, it is easier to generate better barrier placement on GPU lowerings, and unrolling the loops results in better overall barrier placement with the current pipeline.