### PR TITLE
Migrate linux_x64_clang_debug to new Dockerfile from base-docker-images.

### DIFF
--- a/.github/workflows/ci_linux_x64_clang_debug.yml
+++ b/.github/workflows/ci_linux_x64_clang_debug.yml
@@ -39,7 +39,7 @@ jobs:
       - environment=${{ needs.setup.outputs.runner-env }}
       - cpu
       - os-family=Linux
-    container: ghcr.io/iree-org/cpubuilder_ubuntu_jammy_x86_64@sha256:4dbd22649c8ca91188ae5b914d0b725e07617726b1631d6908ad35d721e63858
+    container: ghcr.io/iree-org/cpubuilder_ubuntu_jammy_x86_64@sha256:54d9d17a79caa083aeff1243b27e767df2629b533c26e0b65d41beb160f197e4
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci_linux_x64_clang_debug.yml
+++ b/.github/workflows/ci_linux_x64_clang_debug.yml
@@ -39,7 +39,7 @@ jobs:
       - environment=${{ needs.setup.outputs.runner-env }}
       - cpu
       - os-family=Linux
-    container: gcr.io/iree-oss/base@sha256:dc314b4fe30fc1315742512891357bffed4d1b62ffcb46258b1e0761c737b446
+    container: ghcr.io/iree-org/cpubuilder_ubuntu_jammy_x86_64@sha256:4dbd22649c8ca91188ae5b914d0b725e07617726b1631d6908ad35d721e63858
     defaults:
       run:
         shell: bash
@@ -51,7 +51,7 @@ jobs:
         with:
           submodules: true
       - name: Install Python requirements
-        run: pip install -r ./runtime/bindings/python/iree/runtime/build_requirements.txt
+        run: python3 -m pip install -r ./runtime/bindings/python/iree/runtime/build_requirements.txt
       # Note: Not using ccache here. Debug builds need a lot of cache space
       # and caching only provides marginal build time improvements.
       - name: CMake - configure
@@ -59,6 +59,7 @@ jobs:
           cmake \
             -G Ninja \
             -B ${BUILD_DIR} \
+            -DPython3_EXECUTABLE="$(which python)" \
             -DCMAKE_BUILD_TYPE=Debug \
             -DIREE_BUILD_PYTHON_BINDINGS=ON \
             -DIREE_ENABLE_LLD=ON \


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree/issues/15332. This uses a new `cpubuilder_ubuntu_jammy_x86_64` dockerfile from https://github.com/iree-org/base-docker-images/pull/4. If this looks good, I'll continue to switch other workflows from `gcr.io/iree-oss/base` to this image, installing new deps and pushing new package versions as needed. Once all the workflows are changed, we can delete https://github.com/iree-org/iree/tree/main/build_tools/docker.

skip-ci: does not affect other builds