### PR TITLE
Migrate gcc and byollvm workflows to new Dockerfile.

### DIFF
--- a/.github/workflows/ci_linux_x64_clang_byollvm.yml
+++ b/.github/workflows/ci_linux_x64_clang_byollvm.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   linux_x64_clang_byollvm:
     runs-on: ubuntu-20.04
-    container: ghcr.io/iree-org/cpubuilder_ubuntu_jammy_x86_64@sha256:4dbd22649c8ca91188ae5b914d0b725e07617726b1631d6908ad35d721e63858
+    container: ghcr.io/iree-org/cpubuilder_ubuntu_jammy_x86_64@sha256:54d9d17a79caa083aeff1243b27e767df2629b533c26e0b65d41beb160f197e4
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci_linux_x64_clang_byollvm.yml
+++ b/.github/workflows/ci_linux_x64_clang_byollvm.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   linux_x64_clang_byollvm:
     runs-on: ubuntu-20.04
-    container: gcr.io/iree-oss/base@sha256:dc314b4fe30fc1315742512891357bffed4d1b62ffcb46258b1e0761c737b446
+    container: ghcr.io/iree-org/cpubuilder_ubuntu_jammy_x86_64@sha256:4dbd22649c8ca91188ae5b914d0b725e07617726b1631d6908ad35d721e63858
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci_linux_x64_gcc.yml
+++ b/.github/workflows/ci_linux_x64_gcc.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   linux_x64_gcc:
     runs-on: ubuntu-20.04
-    container: ghcr.io/iree-org/cpubuilder_ubuntu_jammy_x86_64@sha256:4dbd22649c8ca91188ae5b914d0b725e07617726b1631d6908ad35d721e63858
+    container: ghcr.io/iree-org/cpubuilder_ubuntu_jammy_x86_64@sha256:54d9d17a79caa083aeff1243b27e767df2629b533c26e0b65d41beb160f197e4
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci_linux_x64_gcc.yml
+++ b/.github/workflows/ci_linux_x64_gcc.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   linux_x64_gcc:
     runs-on: ubuntu-20.04
-    container: gcr.io/iree-oss/base@sha256:dc314b4fe30fc1315742512891357bffed4d1b62ffcb46258b1e0761c737b446
+    container: ghcr.io/iree-org/cpubuilder_ubuntu_jammy_x86_64@sha256:4dbd22649c8ca91188ae5b914d0b725e07617726b1631d6908ad35d721e63858
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree/issues/15332. This uses a new `cpubuilder_ubuntu_jammy_x86_64` dockerfile from https://github.com/iree-org/base-docker-images/pull/4. Once all the workflows are changed, we can delete https://github.com/iree-org/iree/tree/main/build_tools/docker.

Logs:
* byollvm: https://github.com/iree-org/iree/actions/runs/10567230124/job/29275748653?pr=18356
* gcc: https://github.com/iree-org/iree/actions/runs/10567230125/job/29275748639?pr=18356

skip-ci: does not affect other builds