### PR TITLE
[ONNX Regression Suite] Move einsum_inner_prod test

### DIFF
--- a/tests/external/iree-test-suites/onnx_ops/onnx_ops_cpu_llvm_sync.json
+++ b/tests/external/iree-test-suites/onnx_ops/onnx_ops_cpu_llvm_sync.json
@@ -9,6 +9,7 @@
   ],
   "skip_compile_tests": [
     "onnx/node/generated/test_dequantizelinear",
+    "onnx/node/generated/test_einsum_inner_prod",
     "onnx/node/generated/test_group_normalization_epsilon_expanded",
     "onnx/node/generated/test_group_normalization_example_expanded"
   ],
@@ -133,7 +134,6 @@
     "onnx/node/generated/test_dft_opset19",
     "onnx/node/generated/test_edge_pad",
     "onnx/node/generated/test_einsum_batch_matmul",
-    "onnx/node/generated/test_einsum_inner_prod",
     "onnx/node/generated/test_einsum_sum",
     "onnx/node/generated/test_gridsample_bicubic",
     "onnx/node/generated/test_gridsample_bicubic_align_corners_0_additional_1",

--- a/tests/external/iree-test-suites/onnx_ops/onnx_ops_gpu_cuda.json
+++ b/tests/external/iree-test-suites/onnx_ops/onnx_ops_gpu_cuda.json
@@ -9,6 +9,7 @@
   ],
   "skip_compile_tests": [
     "onnx/node/generated/test_dequantizelinear",
+    "onnx/node/generated/test_einsum_inner_prod",
     "onnx/node/generated/test_group_normalization_example_expanded",
     "onnx/node/generated/test_group_normalization_epsilon_expanded"
   ],
@@ -142,7 +143,6 @@
     "onnx/node/generated/test_dft_opset19",
     "onnx/node/generated/test_edge_pad",
     "onnx/node/generated/test_einsum_batch_matmul",
-    "onnx/node/generated/test_einsum_inner_prod",
     "onnx/node/generated/test_einsum_sum",
     "onnx/node/generated/test_gridsample_bicubic",
     "onnx/node/generated/test_gridsample_bicubic_align_corners_0_additional_1",

--- a/tests/external/iree-test-suites/onnx_ops/onnx_ops_gpu_vulkan.json
+++ b/tests/external/iree-test-suites/onnx_ops/onnx_ops_gpu_vulkan.json
@@ -10,6 +10,7 @@
   "skip_compile_tests": [
     "onnx/node/generated/test_dequantizelinear",
     "onnx/node/generated/test_det_nd",
+    "onnx/node/generated/test_einsum_inner_prod",
     "onnx/node/generated/test_group_normalization_epsilon_expanded",
     "onnx/node/generated/test_group_normalization_example_expanded"
   ],
@@ -165,7 +166,6 @@
     "onnx/node/generated/test_dft_opset19",
     "onnx/node/generated/test_edge_pad",
     "onnx/node/generated/test_einsum_batch_matmul",
-    "onnx/node/generated/test_einsum_inner_prod",
     "onnx/node/generated/test_einsum_sum",
     "onnx/node/generated/test_gridsample",
     "onnx/node/generated/test_gridsample_aligncorners_true",


### PR DESCRIPTION
This test is creating flaky results as an expected compilation failure test so moving the test to skipped tests.