### PR TITLE
Add pass to verify dispatches

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/BUILD.bazel
+++ b/compiler/src/iree/compiler/DispatchCreation/BUILD.bazel
@@ -38,6 +38,7 @@ iree_compiler_cc_library(
         "SplitReduction.cpp",
         "TensorPadToTensorInsertSlice.cpp",
         "TransposeGenericOps.cpp",
+        "VerifyDispatches.cpp",
     ],
     hdrs = [
         "FusionUtils.h",

--- a/compiler/src/iree/compiler/DispatchCreation/CMakeLists.txt
+++ b/compiler/src/iree/compiler/DispatchCreation/CMakeLists.txt
@@ -40,6 +40,7 @@ iree_cc_library(
     "SplitReduction.cpp"
     "TensorPadToTensorInsertSlice.cpp"
     "TransposeGenericOps.cpp"
+    "VerifyDispatches.cpp"
   DEPS
     ::PassHeaders
     ::PassesIncGen

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -299,6 +299,7 @@ void buildDispatchCreationPassPipeline(
   addDispatchRegionCreationPasses(passManager);
 
   FunctionLikeNest(passManager)
+      .addPass(DispatchCreation::createVerifyDispatchesPass)
       .addPass(DispatchCreation::createConvertDispatchRegionsToWorkgroupsPass)
       // Convert tensor operations to flow.tensor ops.
       // - Convert extract/insert slice to flow update ops when the tensor op

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -319,4 +319,12 @@ def HoistEncodingOpsPass :
   ];
 }
 
+def VerifyDispatchesPass :
+  InterfacePass<"iree-dispatch-creation-verify-dispatches", "mlir::FunctionOpInterface"> {
+  let summary = "";
+  let dependentDialects = [
+    "IREE::Flow::FlowDialect",
+  ];
+}
+
 #endif // IREE_COMPILER_DISPATCHCREATION_PASSES

--- a/compiler/src/iree/compiler/DispatchCreation/VerifyDispatches.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/VerifyDispatches.cpp
@@ -1,0 +1,79 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/DispatchCreation/Passes.h"
+#include "llvm/Support/Casting.h"
+#include "mlir/Interfaces/TilingInterface.h"
+
+namespace mlir::iree_compiler::DispatchCreation {
+
+#define GEN_PASS_DEF_VERIFYDISPATCHESPASS
+#include "iree/compiler/DispatchCreation/Passes.h.inc"
+
+namespace {
+
+struct VerifyDispatchesPass final
+    : public impl::VerifyDispatchesPassBase<VerifyDispatchesPass> {
+  using Base::Base;
+  void runOnOperation() override;
+};
+
+} // namespace
+
+void VerifyDispatchesPass::runOnOperation() {
+  bool isError = false;
+  auto funcOp = getOperation();
+  // Keep track of if an op or any of its producers (that are inside a
+  // dispatch) implement the `TilingInterface`
+  llvm::DenseMap<Operation *, bool> isOpOrProducersTileable;
+  funcOp.walk([&](Operation *op) {
+    // Only check for ops directly nested in a dispatch
+    IREE::Flow::DispatchRegionOp dispatchOp =
+        op->getParentOfType<IREE::Flow::DispatchRegionOp>();
+    if (!dispatchOp) {
+      return;
+    }
+
+    bool isTileable = isa<TilingInterface>(op);
+    bool hasTileableProducer = false;
+    for (Value operand : op->getOperands()) {
+      auto producer = operand.getDefiningOp();
+      if (isOpOrProducersTileable[producer]) {
+        hasTileableProducer = true;
+        break;
+      }
+    }
+
+    isOpOrProducersTileable[op] = isTileable || hasTileableProducer;
+    // If this op is tileable, it won't cause any issues
+    if (isTileable) {
+      return;
+    }
+
+    bool hasTileableConsumer = false;
+    for (Operation *user : op->getUsers()) {
+      if (isa_and_nonnull<TilingInterface>(user)) {
+        hasTileableConsumer = true;
+      }
+    }
+
+    // If this op has a producer that is tileable and a consumer that is
+    // tileable but isn't itsself tileable, then it will cause codegen issues
+    if (hasTileableConsumer && hasTileableProducer) {
+      auto error = dispatchOp->emitOpError(
+          "contains a non-tileable op in a dispatch between tileable ops");
+      error.attachNote(op->getLoc()) << " non-tileable op:\n";
+      isError = true;
+    }
+  });
+
+  if (isError) {
+    return signalPassFailure();
+  }
+}
+
+} // namespace mlir::iree_compiler::DispatchCreation

--- a/compiler/src/iree/compiler/DispatchCreation/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/DispatchCreation/test/BUILD.bazel
@@ -18,6 +18,7 @@ iree_lit_test_suite(
         [
             "clone_producers_into_dispatch_regions.mlir",
             "collapse_dimensions.mlir",
+            "verify_dispatches.mlir",
             "collapse_linalg_generic_on_tensors.mlir",
             "collapse_reduction.mlir",
             "attention_fuse_by_expansion.mlir",

--- a/compiler/src/iree/compiler/DispatchCreation/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/DispatchCreation/test/CMakeLists.txt
@@ -42,6 +42,7 @@ iree_lit_test_suite(
     "tensor_pad_to_tensor_insert_slice.mlir"
     "transform_dispatch_region_formation.mlir"
     "transpose_generic_ops.mlir"
+    "verify_dispatches.mlir"
   TOOLS
     FileCheck
     iree-opt

--- a/compiler/src/iree/compiler/DispatchCreation/test/verify_dispatches.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/verify_dispatches.mlir
@@ -1,0 +1,33 @@
+// RUN: iree-opt --split-input-file --verify-diagnostics --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-verify-dispatches))" %s
+
+util.func public @test(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view) -> !hal.buffer_view {
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = hal.tensor.import %arg0 "input0" : !hal.buffer_view -> tensor<2x32xf32>
+  %1 = hal.tensor.import %arg1 "input1" : !hal.buffer_view -> tensor<2x32x10x16384xf16>
+  %collapsed = tensor.collapse_shape %1 [[0, 1, 2, 3]] : tensor<2x32x10x16384xf16> into tensor<10485760xf16>
+  %collapsed_0 = tensor.collapse_shape %0 [[0, 1]] : tensor<2x32xf32> into tensor<64xf32>
+  // expected-error @+1 {{contains a non-tileable op in a dispatch between tileable ops}}
+  %2 = flow.dispatch.region -> (tensor<64xf32>) {
+    %4 = tensor.empty() : tensor<10485760xf32>
+    %5 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%collapsed : tensor<10485760xf16>) outs(%4 : tensor<10485760xf32>) {
+    ^bb0(%in: f16, %out: f32):
+      %9 = arith.extf %in : f16 to f32
+      linalg.yield %9 : f32
+    } -> tensor<10485760xf32>
+    // expected-note-re @+1 {{non-tileable op:}}
+    %expanded_1 = tensor.expand_shape %5 [[0, 1]] output_shape [64, 163840] : tensor<10485760xf32> into tensor<64x163840xf32>
+    %6 = tensor.empty() : tensor<64xf32>
+    %7 = linalg.fill ins(%cst : f32) outs(%6 : tensor<64xf32>) -> tensor<64xf32>
+    %8 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%expanded_1, %collapsed_0 : tensor<64x163840xf32>, tensor<64xf32>) outs(%7 : tensor<64xf32>) {
+    ^bb0(%in: f32, %in_2: f32, %out: f32):
+      %9 = arith.subf %in, %in_2 : f32
+      %10 = arith.mulf %9, %9 : f32
+      %11 = arith.addf %10, %out : f32
+      linalg.yield %11 : f32
+    } -> tensor<64xf32>
+    flow.return %8 : tensor<64xf32>
+  }
+  %expanded = tensor.expand_shape %2 [[0, 1]] output_shape [2, 32] : tensor<64xf32> into tensor<2x32xf32>
+  %3 = hal.tensor.export %expanded "output0" : tensor<2x32xf32> -> !hal.buffer_view
+  util.return %3 : !hal.buffer_view
+}


### PR DESCRIPTION
Try to catch errors in codegen like `op exceeded stack allocation limit` earlier, when they are actually caused by issues related to how dispatches are formed.

Mainly something like: `linalgOp-> op -> linalgOp` where op doesn't implement the tiling interface (e.g. tensor.extract_slice, tensor.collapse_shape, etc.)


closes https://github.com/iree-org/iree/issues/18337