### PR TITLE
Emit error on missing resources attributes.

### DIFF
--- a/compiler/src/iree/compiler/ConstEval/Runtime.cpp
+++ b/compiler/src/iree/compiler/ConstEval/Runtime.cpp
@@ -165,7 +165,6 @@ LogicalResult FunctionCall::initialize(Location loc) {
 FailureOr<iree::vm::ref<iree_hal_buffer_t>>
 FunctionCall::importSerializableAttr(
     Location loc, IREE::Util::SerializableAttrInterface serializableAttr) {
-
   // Allocate buffer.
   int64_t storageSize = serializableAttr.getStorageSize();
   if (storageSize < 0) {
@@ -206,7 +205,6 @@ FunctionCall::importSerializableAttr(
   }
 
   if (!iree_status_is_ok(status)) {
-    iree_hal_buffer_release(buffer.get());
     return handleRuntimeError(loc, status);
   }
 

--- a/compiler/src/iree/compiler/ConstEval/test/jit_globals_vmvx_errors.mlir
+++ b/compiler/src/iree/compiler/ConstEval/test/jit_globals_vmvx_errors.mlir
@@ -62,3 +62,13 @@ module @eval_i4_tensor {
     util.return
   }
 }
+
+// -----
+
+// expected-error @+2 {{resource data missing in input IR}}
+// expected-error @+1 {{serializeToBuffer failed}}
+util.global private @resource = dense_resource<missing> : tensor<f32>
+util.initializer attributes {iree.compiler.consteval} {
+  %0 = util.global.load @resource : tensor<f32>
+  util.return
+}

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.cpp
@@ -227,7 +227,14 @@ static LogicalResult
 serializeResourceRawData(Location loc,
                          DenseResourceElementsAttr resourceElementsAttr,
                          llvm::raw_ostream &os) {
-  auto rawData = resourceElementsAttr.getRawHandle().getBlob()->getData();
+  auto *blob = resourceElementsAttr.getRawHandle().getBlob();
+  if (!blob) {
+    return mlir::emitError(loc)
+           << "resource data missing in input IR (removed by user?); "
+              "cannot serialize resource: "
+           << resourceElementsAttr << "\n";
+  }
+  auto rawData = blob->getData();
   os.write(rawData.data(), rawData.size());
   return success();
 }


### PR DESCRIPTION
Should give better errors for cases like #18353.