### PR TITLE
Distribute a launcher for iree-opt with the compiler wheel.

### DIFF
--- a/compiler/bindings/python/CMakeLists.txt
+++ b/compiler/bindings/python/CMakeLists.txt
@@ -129,6 +129,7 @@ declare_mlir_python_sources(IREECompilerAPIPythonTools
     tools/import_onnx/__main__.py
     tools/ir_tool/__main__.py
     tools/scripts/ireec/__main__.py
+    tools/scripts/iree_opt/__main__.py
 )
 
 # The Python bindings are monolithic and we don't have a good way for the
@@ -248,6 +249,13 @@ add_iree_compiler_busybox_tool(
   OUTPUT_NAME iree-compile
   SRCS
     IREECompileTool.c
+)
+
+add_iree_compiler_busybox_tool(
+  IREECompilerIREEOptTool
+  OUTPUT_NAME iree-opt
+  SRCS
+    IREEOptTool.c
 )
 
 if(TARGET lld)

--- a/compiler/bindings/python/IREEOptTool.c
+++ b/compiler/bindings/python/IREEOptTool.c
@@ -1,0 +1,9 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/tool_entry_points_api.h"
+
+int main(int argc, char **argv) { return ireeOptRunMain(argc, argv); }

--- a/compiler/bindings/python/iree/compiler/_package_test.py
+++ b/compiler/bindings/python/iree/compiler/_package_test.py
@@ -36,6 +36,7 @@ print("IREE version:", v.VERSION)
 
 check_tool("iree-compile", ["--help"], "IREE compilation driver")
 check_tool("iree-ir-tool", ["--help"], "IREE IR Tool")
+check_tool("iree-opt", ["--help"], "IREE modular optimizer driver")
 
 # ONNX dependent.
 onnx_available = False

--- a/compiler/bindings/python/iree/compiler/tools/binaries.py
+++ b/compiler/bindings/python/iree/compiler/tools/binaries.py
@@ -31,6 +31,7 @@ __all__ = [
 _BUILTIN_TOOLS = [
     "iree-compile",
     "iree-lld",
+    "iree-opt",
 ]
 
 # In normal distribution circumstances, each named tool is associated with

--- a/compiler/bindings/python/iree/compiler/tools/scripts/iree_opt/__main__.py
+++ b/compiler/bindings/python/iree/compiler/tools/scripts/iree_opt/__main__.py
@@ -1,0 +1,21 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import subprocess
+import sys
+
+from iree.compiler.tools import binaries
+
+
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
+    exe = binaries.find_tool("iree-opt")
+    return subprocess.call(args=[exe] + args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/compiler/setup.py
+++ b/compiler/setup.py
@@ -459,6 +459,7 @@ setup(
             "ireec = iree.compiler.tools.scripts.ireec.__main__:main",
             "iree-import-onnx = iree.compiler.tools.import_onnx.__main__:_cli_main",
             "iree-ir-tool = iree.compiler.tools.ir_tool.__main__:_cli_main",
+            "iree-opt = iree.compiler.tools.scripts.iree_opt.__main__:main",
         ],
     },
     install_requires=[


### PR DESCRIPTION
We've been exporting the driver symbol for iree-opt since forever but never provided an entry-point for it. Distributing it gives some basic IR manipulation capabilities and access to passes we think are important to distribute.

Note that we make no promises about which passes get included in a distributed iree-opt. Currently that is just about "all of them", which comes with a large binary/build time cost. In the future, we can strip this down to some minimal set. But for the moment, we are already paying for things how they are and there is no sense denying access.

Signed-off-by: Stella Laurenzo <stellaraccident@gmail.com>