### PR TITLE
Fix broken link to onnx_ops test suite.

### DIFF
--- a/docs/website/docs/developers/general/testing-guide.md
+++ b/docs/website/docs/developers/general/testing-guide.md
@@ -415,7 +415,7 @@ tests are planned to be migrated into
 ### ONNX operator tests
 
 Tests for individual ONNX operators are included at
-[`onnx-ops/`](https://github.com/iree-org/iree-test-suites/tree/main/onnx-ops)
+[`onnx_ops/`](https://github.com/iree-org/iree-test-suites/tree/main/onnx_ops)
 in the
 [iree-org/iree-test-suites](https://github.com/iree-org/iree-test-suites)
 repository. These tests are generated from the upstream tests at


### PR DESCRIPTION
We renamed the folder from `onnx-ops` to `onnx_ops` in https://github.com/iree-org/iree-test-suites/pull/10.