### PR TITLE
Fix setting `Python3_EXECUTABLE`

### DIFF
--- a/.github/workflows/ci_linux_x64_clang_debug.yml
+++ b/.github/workflows/ci_linux_x64_clang_debug.yml
@@ -59,7 +59,7 @@ jobs:
           cmake \
             -G Ninja \
             -B ${BUILD_DIR} \
-            -DPython3_EXECUTABLE="$(which python)" \
+            -DPython3_EXECUTABLE="$(which python3)" \
             -DCMAKE_BUILD_TYPE=Debug \
             -DIREE_BUILD_PYTHON_BINDINGS=ON \
             -DIREE_ENABLE_LLD=ON \

--- a/docs/website/docs/building-from-source/getting-started.md
+++ b/docs/website/docs/building-from-source/getting-started.md
@@ -386,7 +386,7 @@ Python executable to use with `Python3_EXECUTABLE`:
 # Configure (including other options as discussed above)
 cmake -G Ninja -B ../iree-build/ \
   -DIREE_BUILD_PYTHON_BINDINGS=ON  \
-  -DPython3_EXECUTABLE="$(which python)" \
+  -DPython3_EXECUTABLE="$(which python3)" \
   .
 
 # Build


### PR DESCRIPTION
On Ubuntu `which python` quits with exit status 1 if the package `python-is-python3` isn't installed, Only with this package installed, `/usr/bin/python` does symlink to `python3`. See
https://packages.ubuntu.com/jammy/python-is-python3 and https://packages.ubuntu.com/jammy/all/python-is-python3/filelist.