### PR TITLE
[mlir][DispatchCreation] Avoid cloning of index_cast operations if they are operands to the dispatch.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -81,9 +81,8 @@ getLoopRangesImpl(ReifyRankedShapedTypeOpInterface shapedOp, Location loc,
   LogicalResult status = shapedOp.reifyResultShapes(builder, resultDims);
   (void)status;
   assert(succeeded(status) && "reifyResultShapes failed");
-  return llvm::map_to_vector(resultDims[0], [&](OpFoldResult v) {
-    return Range{zero, v, one};
-  });
+  return llvm::map_to_vector(
+      resultDims[0], [&](OpFoldResult v) { return Range{zero, v, one}; });
 }
 
 /// For a given operation returns the loop ranges needed to compute the op.

--- a/compiler/src/iree/compiler/DispatchCreation/test/clone_producers_into_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/clone_producers_into_dispatch_regions.mlir
@@ -326,3 +326,19 @@ util.func public @clone_broadcast_dequant_op(
 //  CHECK-SAME:         ins(%[[DEQUANT]] :
 //       CHECK:     flow.return %[[REDUCE]]
 //       CHECK:   return %[[RETURN]]
+
+// -----
+
+// Do no clone index cast operations when they are operands to the dispatch
+util.func public @dont_clone_index_cast(%arg0 : i64) {
+  %0 = arith.index_cast %arg0 : i64 to index
+  %1 = flow.dispatch.region[] -> (tensor<?xf32>{%0}) {
+    %2 = tensor.empty(%0) : tensor<?xf32>
+    flow.return %2 : tensor<?xf32>
+  }
+  util.return
+}
+// CHECK-LABEL: func public @dont_clone_index_cast
+//       CHECK:   arith.index_cast
+//       CHECK:   flow.dispatch.region
+//   CHECK-NOT:   arith.index_cast


### PR DESCRIPTION
Cloning an `index_cast` op which is already a operand to the dispatch is unnecessary. This op will need to be on the host anyway cause it represents the shape of the input/output tensors.

Fixes #18364