### PR TITLE
[Codegen][GPU] Defer ConvertToDPS until after pack/reshape propagation

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -206,13 +206,14 @@ static void addBufferizePasses(OpPassManager &funcPassManager) {
 static void
 tileAndDistributeToWorkgroup(OpPassManager &funcPassManager,
                              bool useWARForCooperativeMatrixCodegen = false,
-                             bool convertInputsToDestinations = true) {
+                             bool convertInputsToDestinations = true,
+                             bool convertToDps = true) {
   funcPassManager.addPass(createTileAndDistributeToWorkgroupsPass(
       kNumMaxParallelDims,
       linalg::DistributionMethod::CyclicNumProcsEqNumIters));
   funcPassManager.addPass(createCSEPass());
 
-  {
+  if (convertToDps) {
     ConvertToDestinationPassingStylePassOptions options;
     options.convertInputsToDestinations = convertInputsToDestinations;
     options.useWARForCooperativeMatrixCodegen =
@@ -327,7 +328,8 @@ static void addGPUBufferizePasses(OpPassManager &funcPassManager) {
 void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager) {
   tileAndDistributeToWorkgroup(funcPassManager,
                                /*useWARForCooperativeMatrixCodegen=*/false,
-                               /*convertInputsToDestinations=*/false);
+                               /*convertInputsToDestinations=*/false,
+                               /*convertToDps=*/false);
 
   // Step 1. Promote matmul operands and pack to intrinsic shapes.
   funcPassManager.addPass(createGPUPromoteMatmulOperandsPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -203,23 +203,18 @@ static void addBufferizePasses(OpPassManager &funcPassManager) {
   funcPassManager.addPass(createCSEPass());
 }
 
-static void
-tileAndDistributeToWorkgroup(OpPassManager &funcPassManager,
-                             bool useWARForCooperativeMatrixCodegen = false,
-                             bool convertInputsToDestinations = true,
-                             bool convertToDps = true) {
+static void tileAndDistributeToWorkgroup(
+    OpPassManager &funcPassManager,
+    std::optional<ConvertToDestinationPassingStylePassOptions>
+        convertToDpsOptions = ConvertToDestinationPassingStylePassOptions{}) {
   funcPassManager.addPass(createTileAndDistributeToWorkgroupsPass(
       kNumMaxParallelDims,
       linalg::DistributionMethod::CyclicNumProcsEqNumIters));
   funcPassManager.addPass(createCSEPass());
 
-  if (convertToDps) {
-    ConvertToDestinationPassingStylePassOptions options;
-    options.convertInputsToDestinations = convertInputsToDestinations;
-    options.useWARForCooperativeMatrixCodegen =
-        useWARForCooperativeMatrixCodegen;
+  if (convertToDpsOptions) {
     funcPassManager.addPass(
-        createConvertToDestinationPassingStylePass(options));
+        createConvertToDestinationPassingStylePass(*convertToDpsOptions));
   }
   // TODO(#16421): Disable decomposition due to failure in bufferization.
   // funcPassManager.addPass(
@@ -229,8 +224,9 @@ tileAndDistributeToWorkgroup(OpPassManager &funcPassManager,
 }
 
 static void tileAndBufferize(OpPassManager &funcPassManager) {
-  tileAndDistributeToWorkgroup(funcPassManager,
-                               /*useWARForCooperativeMatrixCodegen=*/true);
+  ConvertToDestinationPassingStylePassOptions options;
+  options.useWARForCooperativeMatrixCodegen = true;
+  tileAndDistributeToWorkgroup(funcPassManager, options);
   addBufferizePasses(funcPassManager);
 }
 
@@ -327,9 +323,7 @@ static void addGPUBufferizePasses(OpPassManager &funcPassManager) {
 
 void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager) {
   tileAndDistributeToWorkgroup(funcPassManager,
-                               /*useWARForCooperativeMatrixCodegen=*/false,
-                               /*convertInputsToDestinations=*/false,
-                               /*convertToDps=*/false);
+                               /*convertToDpsOptions=*/std::nullopt);
 
   // Step 1. Promote matmul operands and pack to intrinsic shapes.
   funcPassManager.addPass(createGPUPromoteMatmulOperandsPass());
@@ -961,8 +955,9 @@ void addGPUSimpleDistributePassPipeline(OpPassManager &funcPassManager) {
 
 void addGPUDefaultPassPipeline(OpPassManager &funcPassManager,
                                const LLVMGPUPipelineOptions &options) {
-  tileAndDistributeToWorkgroup(funcPassManager,
-                               /*useWARForCooperativeMatrixCodegen=*/true);
+  ConvertToDestinationPassingStylePassOptions dpsOptions;
+  dpsOptions.useWARForCooperativeMatrixCodegen = true;
+  tileAndDistributeToWorkgroup(funcPassManager, dpsOptions);
   if (options.enableUkernels) {
     funcPassManager.addPass(createGPULowerToUKernelsPass());
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
@@ -616,16 +616,12 @@ hal.executable public @main {
 
 // -----
 
-#layout = #hal.pipeline.layout<
-  push_constants = 0,
-  sets = [
-    <0, bindings = [
-      <0, storage_buffer, "ReadOnly|Indirect">,
-      <1, storage_buffer, ReadOnly>,
-      <2, storage_buffer, Indirect>,
-      <3, storage_buffer, Indirect>
-    ],
-  flags = Indirect>]>
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer, Indirect>,
+  #hal.pipeline.binding<storage_buffer, Indirect>
+]>
 
 #translation_info = #iree_codegen.translation_info<LLVMGPUTileAndFuse workgroup_size = [64, 2, 1] subgroup_size = 32>
 
@@ -637,12 +633,7 @@ hal.executable public @main {
 
 hal.executable public @main {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @matmul_fused_multi_result ordinal(0) layout(#layout) attributes {
-      hal.interface.bindings = [
-        #hal.interface.binding<0, 0>,
-        #hal.interface.binding<0, 1>,
-        #hal.interface.binding<0, 2>,
-        #hal.interface.binding<0, 3>]} {
+    hal.executable.export public @matmul_fused_multi_result ordinal(0) layout(#pipeline_layout) {
     ^bb0(%arg0: !hal.device):
       %x, %y, %z = flow.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
@@ -651,12 +642,12 @@ hal.executable public @main {
       func.func @matmul_fused_multi_result() attributes {translation_info = #translation_info} {
         %c0_i32 = arith.constant 0 : i32
         %c0 = arith.constant 0 : index
-        %0 = hal.interface.binding.subspan layout(#layout) set(0) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !flow.dispatch.tensor<readonly:tensor<3136x64xi8>>
-        %1 = hal.interface.binding.subspan layout(#layout) set(0) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<64x256xi8>>
-        %2 = hal.interface.binding.subspan layout(#layout) set(0) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<256xi32>>
-        %3 = hal.interface.binding.subspan layout(#layout) set(0) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !flow.dispatch.tensor<readonly:tensor<256x3136xi8>>
-        %4 = hal.interface.binding.subspan layout(#layout) set(0) binding(2) alignment(64) offset(%c0) flags(Indirect) : !flow.dispatch.tensor<writeonly:tensor<256x3136xi8>>
-        %5 = hal.interface.binding.subspan layout(#layout) set(0) binding(3) alignment(64) offset(%c0) flags(Indirect) : !flow.dispatch.tensor<writeonly:tensor<3136x256xi8>>
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !flow.dispatch.tensor<readonly:tensor<3136x64xi8>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<64x256xi8>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<256xi32>>
+        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !flow.dispatch.tensor<readonly:tensor<256x3136xi8>>
+        %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(Indirect) : !flow.dispatch.tensor<writeonly:tensor<256x3136xi8>>
+        %5 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) flags(Indirect) : !flow.dispatch.tensor<writeonly:tensor<3136x256xi8>>
         %6 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [3136, 64], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<3136x64xi8>> -> tensor<3136x64xi8>
         %7 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [64, 256], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<64x256xi8>> -> tensor<64x256xi8>
         %8 = flow.dispatch.tensor.load %2, offsets = [0], sizes = [256], strides = [1] : !flow.dispatch.tensor<readonly:tensor<256xi32>> -> tensor<256xi32>


### PR DESCRIPTION
Previously multi-result dispatches would have the destination of one of the results unlinked by pack/unpack propagation if ConvertToDPS happens too early. This moves it later after we have finised propagation of packs and reshapes.