### PR TITLE
[mlir][DispatchCreation] Avoid cloning for ops that are index return type dispatch operands.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -765,10 +765,9 @@ static bool hasUnfusableUseInDispatch(Value v, Operation *dispatchOp) {
     // Do not fuse operations if they are already an operand of the
     // owner and have an index return type as that means its a shape
     // computation that needs to happen on the host.
-    if (auto op = v.getDefiningOp()) {
-      if (user == dispatchOp && v.getType().isIndex()) {
-        return true;
-      }
+    auto op = v.getDefiningOp();
+    if (op && user == dispatchOp && v.getType().isIndex()) {
+      return true;
     }
 
     Operation *ownerWorkgroupsOp =

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -765,8 +765,8 @@ static bool hasUnfusableUseInDispatch(Value v, Operation *dispatchOp) {
     // Do not fuse operations if they are already an operand of the
     // owner and have an index return type as that means its a shape
     // computation that needs to happen on the host.
-    auto op = v.getDefiningOp();
-    if (op && user == dispatchOp && v.getType().isIndex()) {
+    if (user == dispatchOp && v.getType().isIndex() &&
+        isa<IREE::Flow::DispatchRegionOp>(dispatchOp)) {
       return true;
     }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -762,10 +762,11 @@ static bool hasUnfusableUseInDispatch(Value v, Operation *dispatchOp) {
   for (OpOperand &use : v.getUses()) {
     Operation *user = use.getOwner();
 
-    // Do not fuse `index_cast` operations if it is already an operand of the
-    // owner.
-    if (auto indexCastOp = v.getDefiningOp<arith::IndexCastOp>()) {
-      if (user == dispatchOp) {
+    // Do not fuse operations if they are already an operand of the
+    // owner and have an index return type as that means its a shape
+    // computation that needs to happen on the host.
+    if (auto op = v.getDefiningOp()) {
+      if (user == dispatchOp && v.getType().isIndex()) {
         return true;
       }
     }


### PR DESCRIPTION
Such operations are shape computations that need to happen on host.

Fixes: https://github.com/iree-org/iree/issues/18229