### PR TITLE
 Fixing issues found when enabling indirect command buffers.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -3037,12 +3037,12 @@ setTranslationInfoAndRootConfig(mlir::FunctionOpInterface entryPointFn,
     return failure();
   Operation *rootOperation = rootOp.value();
 
-  LLVM_DEBUG(KD_DBGS() << "Root op: " << *rootOperation << "\n");
-
   // Handle the case with no known root operation.
   if (!rootOperation) {
     return lowerUsingDefaultPipeline(entryPointFn);
   }
+
+  LLVM_DEBUG(KD_DBGS() << "Root op: " << *rootOperation << "\n");
 
   auto targetAttr = IREE::HAL::ExecutableTargetAttr::lookup(entryPointFn);
   auto targetMLTransInfo =

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/BUILD.bazel
@@ -22,6 +22,7 @@ iree_compiler_cc_library(
     ],
     deps = [
         ":Utils",
+        "//compiler/src/iree/compiler/Dialect/HAL/Analysis",
         "//compiler/src/iree/compiler/Dialect/HAL/Conversion",
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
         "//compiler/src/iree/compiler/Dialect/HAL/IR:HALDialect",

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/CMakeLists.txt
@@ -28,6 +28,7 @@ iree_cc_library(
     MLIRSCFDialect
     MLIRTransformUtils
     MLIRTransforms
+    iree::compiler::Dialect::HAL::Analysis
     iree::compiler::Dialect::HAL::Conversion
     iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::HAL::IR::HALDialect

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Utils.cpp
@@ -251,15 +251,6 @@ BindingTable::BindingTable(IREE::Stream::CmdExecuteOp executeOp,
   auto resourceValues = executeOp.getResourceOperands();
   auto capturedValues = executeOp.getBody().getArguments();
 
-  // TODO(benvanik): support stream.cmd.call with indirect bindings; today the
-  // simple analysis that happens here can't handle generating binding tables
-  // for them as the target would need to know if it's taking a buffer or a
-  // binding table slot. A `variant<!hal.buffer, i32>` may let us do that.
-  executeOp->walk([&](IREE::Stream::CmdCallOp) { hasUnsupportedOps = true; });
-  if (hasUnsupportedOps) {
-    return;
-  }
-
   // Categorize each resource value and add it to the table.
   for (auto [resourceValue, capturedValue, bufferValue, bufferSize] :
        llvm::zip_equal(resourceValues, capturedValues, bufferValues,

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Utils.h
@@ -75,7 +75,7 @@ public:
                ValueRange bufferSizes, IndexSet &indexSet);
 
   // True if binding tables are supported for the consumer.
-  bool isSupported() const { return !hasUnsupportedOps; }
+  bool isSupported() const { return true; }
 
   // True if the binding table is empty.
   bool empty() const { return indirectBuffers.empty(); }
@@ -91,8 +91,6 @@ public:
   std::optional<Value> lookupResourceSlot(Value resourceValue);
 
 private:
-  // True if any ops are nested that may prevent binding table usage.
-  bool hasUnsupportedOps = false;
   // Buffer binding table with <buffer, offset, length>.
   SmallVector<IREE::HAL::BindingValue> indirectBuffers;
   // A mapping of resources to binding table slot ordinals.

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -48,10 +48,10 @@ static void printDescriptorType(OpAsmPrinter &p, Operation *,
 
 //===----------------------------------------------------------------------===//
 // custom<PipelineBindings>($binding_ordinals,
-//                               $binding_buffers,
-//                               type($binding_buffers),
-//                               $binding_offsets,
-//                               $binding_lengths)
+//                          $binding_buffers,
+//                          type($binding_buffers),
+//                          $binding_offsets,
+//                          $binding_lengths)
 //===----------------------------------------------------------------------===//
 
 static ParseResult parsePipelineBindings(
@@ -240,8 +240,9 @@ static FunctionType getTargetConditionRegionType(MLIRContext *context) {
 static LogicalResult verifyTargetConditionRegion(Operation *op,
                                                  Region &region) {
   // Ignore if empty.
-  if (region.empty())
+  if (region.empty()) {
     return success();
+  }
 
   // Verify region takes a !hal.device.
   if (region.getNumArguments() != 1 ||

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
@@ -507,10 +507,6 @@ void buildHALTransformPassPipeline(OpPassManager &passManager,
   // with them in their original target specification.
   passManager.addPass(IREE::HAL::createInitializeDevicesPass({targetRegistry}));
 
-  // Combine the initializers we emitted during resource cache
-  // materialization.
-  passManager.addPass(IREE::Util::createCombineInitializersPass());
-
   // TODO: Maybe this should be a part of Affine lowering pass.
   // Remove if it is added there.
   // https://github.com/llvm/llvm-project/issues/78458

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/CombineInitializers.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/CombineInitializers.cpp
@@ -48,10 +48,10 @@ public:
       return;
     auto fusedLoc = FusedLoc::get(&getContext(), locs);
 
-    // Make the new initializer op in the same location as the last initializer
+    // Make the new initializer op in the same location as the first initializer
     // we are combining - this ensures that module initialization order is
     // preserved.
-    OpBuilder builder(initializerOps.back());
+    OpBuilder builder(initializerOps.front());
     auto newOp = builder.create<IREE::Util::InitializerOp>(fusedLoc);
     builder.setInsertionPointToStart(newOp.addEntryBlock());
     InlinerInterface inlinerInterface(&getContext());

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/combine_initializers.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/combine_initializers.mlir
@@ -6,22 +6,6 @@ util.func private @extern() -> index
 
 // CHECK: util.global private mutable @global0 : index
 util.global private mutable @global0 : index
-util.initializer {
-  %value0 = util.call @extern() : () -> index
-  util.global.store %value0, @global0 : index
-  util.return
-}
-// CHECK-NEXT: util.global private @global1 : index
-util.global private @global1 : index
-// CHECK-NEXT: util.global private @global2 : index
-util.global private @global2 : index
-util.initializer {
-  %value1 = util.call @extern() : () -> index
-  util.global.store %value1, @global1 : index
-  %value2 = util.call @extern() : () -> index
-  util.global.store %value2, @global2 : index
-  util.return
-}
 // CHECK-NEXT: util.initializer {
 // CHECK-NEXT: %[[VALUE0:.+]] = util.call @extern()
 // CHECK-NEXT: util.global.store %[[VALUE0]], @global0
@@ -30,6 +14,23 @@ util.initializer {
 // CHECK-NEXT: %[[VALUE2:.+]] = util.call @extern()
 // CHECK-NEXT: util.global.store %[[VALUE2]], @global2
 // CHECK-NEXT: util.return
+util.initializer {
+  %value0 = util.call @extern() : () -> index
+  util.global.store %value0, @global0 : index
+  util.return
+}
+// CHECK: util.global private @global1 : index
+util.global private @global1 : index
+// CHECK-NEXT: util.global private @global2 : index
+util.global private @global2 : index
+// CHECK-NOT: util.initializer
+util.initializer {
+  %value1 = util.call @extern() : () -> index
+  util.global.store %value1, @global1 : index
+  %value2 = util.call @extern() : () -> index
+  util.global.store %value2, @global2 : index
+  util.return
+}
 
 // CHECK-LABEL: @orderedCombining
 util.func @orderedCombining(%arg0: index) -> (index, index, index) {
@@ -47,6 +48,16 @@ util.func @orderedCombining(%arg0: index) -> (index, index, index) {
 
 // CHECK: util.global private mutable @globalA : index
 util.global private mutable @globalA : index
+// CHECK: util.initializer {
+// CHECK: ^bb1:
+// CHECK:   cf.br ^bb3
+// CHECK: ^bb2:
+// CHECK:   cf.br ^bb3
+// CHECK: ^bb3:
+// CHECK:   cf.br ^bb4
+// CHECK: ^bb4:
+// CHECK:   util.return
+// CHECK: }
 util.initializer {
   %cond = arith.constant 1 : i1
   cf.cond_br %cond, ^bb1, ^bb2
@@ -63,18 +74,9 @@ util.initializer {
 }
 // CHECK-NEXT: util.global private @globalB : index
 util.global private @globalB : index
+// CHECK-NOT: util.initializer
 util.initializer {
   %c300 = arith.constant 300 : index
   util.global.store %c300, @globalB : index
   util.return
 }
-// CHECK: util.initializer {
-// CHECK: ^bb1:
-// CHECK:   cf.br ^bb3
-// CHECK: ^bb2:
-// CHECK:   cf.br ^bb3
-// CHECK: ^bb3:
-// CHECK:   cf.br ^bb4
-// CHECK: ^bb4:
-// CHECK:   util.return
-// CHECK: }

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/Passes.cpp
@@ -64,6 +64,10 @@ void buildVMTransformPassPipeline(OpPassManager &passManager,
   passManager.addPass(mlir::createInlinerPass());
   passManager.addPass(mlir::createSymbolDCEPass());
 
+  // Combine the initializers for all globals to allow us to optimize them
+  // together.
+  passManager.addPass(IREE::Util::createCombineInitializersPass());
+
   FunctionLikeNest(passManager)
       .addPass(mlir::createSCFForLoopCanonicalizationPass);
 

--- a/runtime/src/iree/hal/utils/deferred_work_queue.c
+++ b/runtime/src/iree/hal/utils/deferred_work_queue.c
@@ -981,7 +981,6 @@ static iree_status_t iree_hal_deferred_work_queue_issue_execution(
       iree_hal_command_buffer_mode_t mode =
           iree_hal_command_buffer_mode(command_buffer) |
           IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT |
-          IREE_HAL_COMMAND_BUFFER_MODE_ALLOW_INLINE_EXECUTION |
           // NOTE: we need to validate if a binding table is provided as the
           // bindings were not known when it was originally recorded.
           (iree_hal_buffer_binding_table_is_empty(binding_table)


### PR DESCRIPTION
This is in preparation for making `--iree-hal-indirect-command-buffers=true` the default as part of #17875.

Most of the fixes required were related to analysis failures that required stricter handling of duplicate call graph traversal and
care around when initializers are combined (which still needs improvement but at a general level not related to this work). A TODO was fixed for supporting `stream.cmd.call` in reusable command buffers by passing binding table ordinals along with buffers to the `stream.cmd.func` ops once lowered into the HAL dialect - there are no users of this functionality today but now it won't be a special case.