### PR TITLE
Adding command buffer recording state validation.

### DIFF
--- a/runtime/src/iree/hal/command_buffer.c
+++ b/runtime/src/iree/hal/command_buffer.c
@@ -587,10 +587,16 @@ IREE_API_EXPORT iree_status_t iree_hal_command_buffer_dispatch_indirect(
 // Validation support
 //===----------------------------------------------------------------------===//
 
-IREE_API_EXPORT iree_status_t iree_hal_command_buffer_validate_binding_table(
+IREE_API_EXPORT iree_status_t iree_hal_command_buffer_validate_submission(
     iree_hal_command_buffer_t* command_buffer,
     const iree_hal_buffer_binding_table_t* binding_table) {
   IREE_ASSERT_ARGUMENT(command_buffer);
+
+  // Validate the command buffer has been recorded properly.
+  IF_VALIDATING(command_buffer, {
+    IREE_RETURN_IF_ERROR(iree_hal_command_buffer_submission_validation(
+        command_buffer, VALIDATION_STATE(command_buffer)));
+  });
 
   // Only check binding tables when one is required and otherwise ignore any
   // bindings provided. Require at least as many bindings in the table as there

--- a/runtime/src/iree/hal/command_buffer.h
+++ b/runtime/src/iree/hal/command_buffer.h
@@ -761,7 +761,7 @@ IREE_API_EXPORT iree_status_t iree_hal_command_buffer_dispatch_indirect(
 // requirements of |command_buffer| as recorded. If the command buffer does not
 // use any indirect bindings the table will be ignored. If more bindings than
 // are used by the command buffer are provided they will be ignored.
-IREE_API_EXPORT iree_status_t iree_hal_command_buffer_validate_binding_table(
+IREE_API_EXPORT iree_status_t iree_hal_command_buffer_validate_submission(
     iree_hal_command_buffer_t* command_buffer,
     const iree_hal_buffer_binding_table_t* binding_table);
 

--- a/runtime/src/iree/hal/command_buffer_validation.h
+++ b/runtime/src/iree/hal/command_buffer_validation.h
@@ -30,10 +30,12 @@ typedef struct iree_hal_command_buffer_validation_state_t {
   // Allocator from the device the command buffer is targeting.
   // Used to verify buffer compatibility.
   iree_hal_allocator_t* device_allocator;
-  // 1 when in a begin/end recording sequence.
-  int32_t is_recording : 1;
+  // 1 when begin has been called.
+  int32_t has_began : 1;
+  // 1 when end has been called.
+  int32_t has_ended : 1;
   // Debug group depth for tracking proper begin/end pairing.
-  int32_t debug_group_depth : 31;
+  int32_t debug_group_depth : 30;
   // TODO(benvanik): current pipeline layout/descriptor set layout info.
   // TODO(benvanik): valid push constant bit ranges.
   // Requirements for each binding table entry.
@@ -139,6 +141,10 @@ iree_status_t iree_hal_command_buffer_dispatch_indirect_validation(
     iree_hal_executable_t* executable, int32_t entry_point,
     iree_hal_buffer_ref_t workgroups_ref, iree_const_byte_span_t constants,
     iree_hal_buffer_ref_list_t bindings, iree_hal_dispatch_flags_t flags);
+
+iree_status_t iree_hal_command_buffer_submission_validation(
+    iree_hal_command_buffer_t* command_buffer,
+    const iree_hal_command_buffer_validation_state_t* validation_state);
 
 iree_status_t iree_hal_command_buffer_binding_table_validation(
     iree_hal_command_buffer_t* command_buffer,

--- a/runtime/src/iree/hal/device.c
+++ b/runtime/src/iree/hal/device.c
@@ -313,7 +313,7 @@ IREE_API_EXPORT iree_status_t iree_hal_device_queue_execute(
   for (iree_host_size_t i = 0; i < command_buffer_count; ++i) {
     IREE_RETURN_AND_END_ZONE_IF_ERROR(
         z0,
-        iree_hal_command_buffer_validate_binding_table(
+        iree_hal_command_buffer_validate_submission(
             command_buffers[i], binding_tables ? &binding_tables[i] : NULL));
   }
 


### PR DESCRIPTION
This will error out if command buffers are re-recorded or if a submission is made with a command buffer that has not been recorded or that is still in the recording state.