### PR TITLE
Use new cpubuilder dockerfile for ASan and TSan jobs.

### DIFF
--- a/.github/workflows/ci_linux_x64_clang.yml
+++ b/.github/workflows/ci_linux_x64_clang.yml
@@ -29,7 +29,7 @@ jobs:
     needs: setup
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'linux_x64_clang')
     runs-on: azure-linux
-    container: ghcr.io/iree-org/cpubuilder_ubuntu_jammy_x86_64@sha256:54d9d17a79caa083aeff1243b27e767df2629b533c26e0b65d41beb160f197e4
+    container: ghcr.io/iree-org/cpubuilder_ubuntu_jammy_x86_64@sha256:ba10d33ef502d8b33aaa43800e640a6866983ef353b73fda2ed6595c4275e066
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci_linux_x64_clang_asan.yml
+++ b/.github/workflows/ci_linux_x64_clang_asan.yml
@@ -29,8 +29,7 @@ jobs:
     needs: setup
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'linux_x64_clang_asan')
     runs-on: azure-linux
-    # TODO(scotttodd): use ghcr.io/iree-org/cpubuilder_ubuntu_jammy_x86_64 here
-    container: gcr.io/iree-oss/base-bleeding-edge@sha256:cf2e78194e64fd0166f4141317366261d7a62432b72e9a324cb8c2ff4e1a515a
+    container: ghcr.io/iree-org/cpubuilder_ubuntu_jammy_x86_64@sha256:ba10d33ef502d8b33aaa43800e640a6866983ef353b73fda2ed6595c4275e066
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci_linux_x64_clang_byollvm.yml
+++ b/.github/workflows/ci_linux_x64_clang_byollvm.yml
@@ -8,8 +8,6 @@ name: CI - Linux x64 clang BYO LLVM
 
 on:
   pull_request:
-    branches:
-      - main
     paths:
       - ".github/workflows/ci_linux_x64_clang_byollvm.yml"
   schedule:
@@ -28,7 +26,7 @@ concurrency:
 jobs:
   linux_x64_clang_byollvm:
     runs-on: ubuntu-20.04
-    container: ghcr.io/iree-org/cpubuilder_ubuntu_jammy_x86_64@sha256:54d9d17a79caa083aeff1243b27e767df2629b533c26e0b65d41beb160f197e4
+    container: ghcr.io/iree-org/cpubuilder_ubuntu_jammy_x86_64@sha256:ba10d33ef502d8b33aaa43800e640a6866983ef353b73fda2ed6595c4275e066
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci_linux_x64_clang_debug.yml
+++ b/.github/workflows/ci_linux_x64_clang_debug.yml
@@ -8,8 +8,6 @@ name: CI - Linux x64 clang debug
 
 on:
   pull_request:
-    branches:
-      - main
     paths:
       - ".github/workflows/ci_linux_x64_clang_debug.yml"
   schedule:
@@ -34,7 +32,7 @@ jobs:
   linux_x64_clang_debug:
     needs: setup
     runs-on: azure-linux
-    container: ghcr.io/iree-org/cpubuilder_ubuntu_jammy_x86_64@sha256:54d9d17a79caa083aeff1243b27e767df2629b533c26e0b65d41beb160f197e4
+    container: ghcr.io/iree-org/cpubuilder_ubuntu_jammy_x86_64@sha256:ba10d33ef502d8b33aaa43800e640a6866983ef353b73fda2ed6595c4275e066
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci_linux_x64_clang_tsan.yml
+++ b/.github/workflows/ci_linux_x64_clang_tsan.yml
@@ -31,8 +31,7 @@ jobs:
     needs: setup
     runs-on: azure-linux
     container:
-      # TODO(scotttodd): use ghcr.io/iree-org/cpubuilder_ubuntu_jammy_x86_64 here
-      image: gcr.io/iree-oss/base-bleeding-edge@sha256:cf2e78194e64fd0166f4141317366261d7a62432b72e9a324cb8c2ff4e1a515a
+      image: ghcr.io/iree-org/cpubuilder_ubuntu_jammy_x86_64@sha256:ba10d33ef502d8b33aaa43800e640a6866983ef353b73fda2ed6595c4275e066
       # TSan in particular needs some settings that this option includes:
       #   * https://github.com/google/sanitizers/issues/1716
       #   * https://security.stackexchange.com/q/214923

--- a/.github/workflows/ci_linux_x64_gcc.yml
+++ b/.github/workflows/ci_linux_x64_gcc.yml
@@ -8,8 +8,6 @@ name: CI - Linux x64 gcc
 
 on:
   pull_request:
-    branches:
-      - main
     paths:
       - ".github/workflows/ci_linux_x64_gcc.yml"
   schedule:
@@ -28,7 +26,7 @@ concurrency:
 jobs:
   linux_x64_gcc:
     runs-on: ubuntu-20.04
-    container: ghcr.io/iree-org/cpubuilder_ubuntu_jammy_x86_64@sha256:54d9d17a79caa083aeff1243b27e767df2629b533c26e0b65d41beb160f197e4
+    container: ghcr.io/iree-org/cpubuilder_ubuntu_jammy_x86_64@sha256:ba10d33ef502d8b33aaa43800e640a6866983ef353b73fda2ed6595c4275e066
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Following https://github.com/iree-org/base-docker-images/pull/6, the new cpubuilder dockerfile should have all the software needed for ASan and TSan building + testing (specifically `clang-19` instead of just `clang-14`).

Progress on https://github.com/iree-org/iree/issues/15332. The only remaining uses of `gcr.io/iree-oss/base.*` are:

* `build_test_all_bazel` uses `gcr.io/iree-oss/base-bleeding-edge`
* `publish_website` uses `gcr.io/iree-oss/base`
* arm64 workflows use `gcr.io/iree-oss/base-arm64`
* `gcr.io/iree-oss/emscripten` (used by web test workflows) depends on `gcr.io/iree-oss/base`