### PR TITLE
[Codegen][GPU] Add gpu configuration heuristics for attention

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -22,14 +22,14 @@ namespace mlir::iree_compiler {
 
 static llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
                                      const GPUMMASchedule &schedule) {
-  os << "mSize: " << schedule.mSize << "\n";
-  os << "nSize: " << schedule.nSize << "\n";
-  os << "kSize: " << schedule.kSize << "\n";
-  os << "mTileCount: " << schedule.mTileCount << "\n";
-  os << "nTileCount: " << schedule.nTileCount << "\n";
-  os << "kTileCount: " << schedule.kTileCount << "\n";
-  os << "mWarpCount: " << schedule.mWarpCount << "\n";
-  os << "nWarpCount: " << schedule.nWarpCount << "\n";
+  os << "mSize: " << schedule.mSize << ", ";
+  os << "nSize: " << schedule.nSize << ", ";
+  os << "kSize: " << schedule.kSize << ", ";
+  os << "mTileCount: " << schedule.mTileCount << ", ";
+  os << "nTileCount: " << schedule.nTileCount << ", ";
+  os << "kTileCount: " << schedule.kTileCount << ", ";
+  os << "mWarpCount: " << schedule.mWarpCount << ", ";
+  os << "nWarpCount: " << schedule.nWarpCount;
   return os;
 }
 
@@ -269,13 +269,7 @@ FailureOr<GPUMMASchedule> deduceMMASchedule(
 
     LLVM_DEBUG({
       llvm::dbgs() << "chosen MMA schedule:\n";
-      llvm::dbgs() << "  intrinsic (M, N, K) = (" << intrinsic.mSize << ", "
-                   << intrinsic.nSize << ", " << intrinsic.kSize << ")\n";
-      llvm::dbgs() << "  subgroup count (M, N) = (" << schedule.mWarpCount
-                   << ", " << schedule.nWarpCount << ")\n";
-      llvm::dbgs() << "  subgroup tile count (M, N, K) = ("
-                   << schedule.mTileCount << ", " << schedule.nTileCount << ", "
-                   << schedule.kTileCount << ")\n";
+      llvm::dbgs() << "  " << schedule << "\n";
     });
 
     auto isValidSchedule = [&](const GPUMMASchedule &schedule) -> bool {
@@ -327,13 +321,7 @@ FailureOr<GPUMMASchedule> deduceAttentionSchedule(
 
     LLVM_DEBUG({
       llvm::dbgs() << "chosen MMA schedule:\n";
-      llvm::dbgs() << "  intrinsic (M, N, K) = (" << intrinsic.mSize << ", "
-                   << intrinsic.nSize << ", " << intrinsic.kSize << ")\n";
-      llvm::dbgs() << "  subgroup count (M, N) = (" << schedule.mWarpCount
-                   << ", " << schedule.nWarpCount << ")\n";
-      llvm::dbgs() << "  subgroup tile count (M, N, K) = ("
-                   << schedule.mTileCount << ", " << schedule.nTileCount << ", "
-                   << schedule.kTileCount << ")\n";
+      llvm::dbgs() << "  " << schedule << "\n";
     });
 
     int64_t intrinsicK = intrinsic.kSize;

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -29,10 +29,9 @@ static int64_t calculateSharedMemoryUsedInBytes(const GPUMMASchedule &schedule,
   return (tileM * tileK * lhsBitwidth + tileN * tileK * rhsBitwidth) / 8;
 }
 
-bool isValidSchedule(const GPUMatmulShapeType &problem,
-                     const GPUMMASchedule &schedule, const bool mustBeAligned,
-                     const int64_t subgroupSize, const bool transposedLhs,
-                     const bool transposedRhs) {
+static bool isScheduleAligned(const GPUMatmulShapeType &problem,
+                              const GPUMMASchedule &schedule,
+                              const int64_t mustBeAligned) {
   auto alignedMSize =
       mustBeAligned
           ? problem.mSize
@@ -50,6 +49,14 @@ bool isValidSchedule(const GPUMatmulShapeType &problem,
   bool isValidN = (alignedNSize % (schedule.nSize * schedule.nTileCount *
                                    schedule.nWarpCount)) == 0;
   bool isValidK = (alignedKSize % (schedule.kSize * schedule.kTileCount)) == 0;
+  return isValidM && isValidN && isValidK;
+}
+
+static bool isValidMMASchedule(const GPUMatmulShapeType &problem,
+                               const GPUMMASchedule &schedule,
+                               bool mustBeAligned, int64_t subgroupSize,
+                               bool transposedLhs, bool transposedRhs) {
+  bool isAligned = isScheduleAligned(problem, schedule, mustBeAligned);
 
   // Constraint to ensure wgTileSize is distributable by wgSize.
   // such that we can distribute to it's corresponding vector.transfer_read.
@@ -71,26 +78,17 @@ bool isValidSchedule(const GPUMatmulShapeType &problem,
       (innerRhsDimSize / elemsPerThread) % wgThreads == 0 ||
       wgThreads % (innerRhsDimSize / elemsPerThread) == 0;
 
-  return isValidN && isValidM && isValidK && isDistributableLhs &&
-         isDistributableRhs;
+  return isAligned && isDistributableLhs && isDistributableRhs;
 }
 
-FailureOr<GPUMMASchedule> fitScheduleInSharedMemory(
-    const GPUMatmulShapeType &problem, ArrayRef<GPUMatmulShapeType> intrinsics,
-    GPUMMASchedule schedule, int64_t sharedMemLimitInBytes,
-    int64_t subgroupSize, bool transposedLhs, bool transposedRhs,
-    bool mustBeAligned) {
-  int64_t lhsBitwidth =
-      intrinsics[schedule.index].aType.getIntOrFloatBitWidth();
-  int64_t rhsBitwidth =
-      intrinsics[schedule.index].bType.getIntOrFloatBitWidth();
+static FailureOr<GPUMMASchedule> fitScheduleInSharedMemory(
+    GPUMatmulShapeType intrinsic, GPUMMASchedule schedule,
+    const std::function<bool(const GPUMMASchedule &schedule)>
+        &isScheduleValid) {
 
-  while (!isValidSchedule(problem, schedule, mustBeAligned, subgroupSize,
-                          transposedLhs, transposedRhs) ||
-         calculateSharedMemoryUsedInBytes(schedule, lhsBitwidth, rhsBitwidth) >
-             sharedMemLimitInBytes) {
+  while (!isScheduleValid(schedule)) {
     LLVM_DEBUG({
-      llvm::dbgs() << "Shrinking schedule\n";
+      llvm::dbgs() << "Chosen schedule is invalid:\n";
       llvm::dbgs() << "mSize: " << schedule.mSize << "\n";
       llvm::dbgs() << "nSize: " << schedule.nSize << "\n";
       llvm::dbgs() << "kSize: " << schedule.kSize << "\n";
@@ -99,6 +97,7 @@ FailureOr<GPUMMASchedule> fitScheduleInSharedMemory(
       llvm::dbgs() << "kTileCount: " << schedule.kTileCount << "\n";
       llvm::dbgs() << "mWarpCount: " << schedule.mWarpCount << "\n";
       llvm::dbgs() << "nWarpCount: " << schedule.nWarpCount << "\n";
+      llvm::dbgs() << "Shrinking schedule...\n";
     });
 
     auto decrementIfPossible = [](int64_t &c) -> LogicalResult {
@@ -132,7 +131,128 @@ FailureOr<GPUMMASchedule> fitScheduleInSharedMemory(
     // If no dimension can be shrunk, give up.
     return failure();
   }
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "Chosen schedule is valid:\n";
+    llvm::dbgs() << "mSize: " << schedule.mSize << "\n";
+    llvm::dbgs() << "nSize: " << schedule.nSize << "\n";
+    llvm::dbgs() << "kSize: " << schedule.kSize << "\n";
+    llvm::dbgs() << "mTileCount: " << schedule.mTileCount << "\n";
+    llvm::dbgs() << "nTileCount: " << schedule.nTileCount << "\n";
+    llvm::dbgs() << "kTileCount: " << schedule.kTileCount << "\n";
+    llvm::dbgs() << "mWarpCount: " << schedule.mWarpCount << "\n";
+    llvm::dbgs() << "nWarpCount: " << schedule.nWarpCount << "\n";
+  });
+
   return schedule;
+}
+
+static LogicalResult canTargetIntrinsic(const GPUMatmulShapeType &problem,
+                                        const GPUMatmulShapeType &intrinsic,
+                                        bool canUpcastAcc, bool mustBeAligned) {
+  if (problem.aType != intrinsic.aType || problem.bType != intrinsic.bType) {
+    return failure(); // Cannot use this intrinsic for mismatched types
+  }
+  if (problem.cType != intrinsic.cType) {
+    auto isFpCase =
+        isa<FloatType>(problem.cType) && isa<FloatType>(intrinsic.cType);
+    auto isUpcast = problem.cType.getIntOrFloatBitWidth() <
+                    intrinsic.cType.getIntOrFloatBitWidth();
+    if (!(canUpcastAcc && isFpCase && isUpcast)) {
+      return failure(); // Cannot use this intrinsic if not upcasting
+    }
+  }
+
+  if (mustBeAligned && (problem.mSize % intrinsic.mSize != 0 ||
+                        problem.nSize % intrinsic.nSize != 0 ||
+                        problem.kSize % intrinsic.kSize != 0)) {
+    return failure(); // Cannot use this intrinsic for misaligned cases
+  }
+
+  // Cannot use the intrinsic when the tile size is greater than problem size.
+  // Because tiling is a no-op, and we can't infer tiling sizes from IR.
+  if (!mustBeAligned &&
+      (problem.mSize < intrinsic.mSize || problem.nSize < intrinsic.nSize ||
+       problem.kSize < intrinsic.kSize)) {
+    return failure();
+  }
+
+  return success();
+}
+
+/// Choose an optimal mma schedule with the heuristic that minimized the total
+/// amount of data read from global memory, per workgroup, respecting the
+/// heuristic seeds.
+static GPUMMASchedule getOptimalMMASchedule(const GPUMatmulShapeType &problem,
+                                            const GPUMatmulShapeType &intrinsic,
+                                            const GPUMMAHeuristicSeeds &seeds,
+                                            uint64_t intrinsicIndex) {
+  int64_t mTotalTileCount = llvm::divideCeil(problem.mSize, intrinsic.mSize);
+  int64_t nTotalTileCount = llvm::divideCeil(problem.nSize, intrinsic.nSize);
+
+  int64_t remainingWarps = seeds.bestSubgroupCountPerWorkgroup;
+  int64_t remainingTiles = seeds.bestMNTileCountPerSubgroup;
+  // Assign more warps to the M dimension (used later) to balance thread
+  // counts along X and Y dimensions.
+  int64_t warpSqrt =
+      1ull << (llvm::divideCeil(llvm::Log2_64(remainingWarps), 2));
+  int64_t tileSqrt = 1ull << (llvm::Log2_64(remainingTiles) / 2);
+
+  int64_t mWarpCount = 0, nWarpCount = 0;
+  int64_t mTileCount = 0, nTileCount = 0;
+
+  // See if the square root can divide mTotalTileCount. If so it means we can
+  // distribute to both dimensions evenly. Otherwise, try to distribute to N
+  // and then M.
+  if (mTotalTileCount > (warpSqrt * tileSqrt) &&
+      mTotalTileCount % (warpSqrt * tileSqrt) == 0) {
+    mWarpCount = warpSqrt;
+    mTileCount = tileSqrt;
+
+    remainingWarps /= warpSqrt;
+    remainingTiles /= tileSqrt;
+
+    APInt nGCD = GreatestCommonDivisor(APInt(64, nTotalTileCount),
+                                       APInt(64, remainingWarps));
+    nWarpCount = nGCD.getSExtValue();
+    nTotalTileCount /= nWarpCount;
+    remainingWarps /= nWarpCount;
+
+    nGCD = GreatestCommonDivisor(APInt(64, nTotalTileCount),
+                                 APInt(64, remainingTiles));
+    nTileCount = nGCD.getSExtValue();
+  } else {
+    APInt nGCD = GreatestCommonDivisor(APInt(64, nTotalTileCount),
+                                       APInt(64, remainingWarps));
+    nWarpCount = nGCD.getSExtValue();
+    nTotalTileCount /= nWarpCount;
+    remainingWarps /= nWarpCount;
+
+    nGCD = GreatestCommonDivisor(APInt(64, nTotalTileCount),
+                                 APInt(64, remainingTiles));
+    nTileCount = nGCD.getSExtValue();
+    remainingTiles /= nTileCount;
+
+    APInt mGCD = GreatestCommonDivisor(APInt(64, mTotalTileCount),
+                                       APInt(64, remainingWarps));
+    mWarpCount = mGCD.getSExtValue();
+    mTotalTileCount /= mWarpCount;
+    remainingWarps /= mWarpCount;
+
+    mGCD = GreatestCommonDivisor(APInt(64, mTotalTileCount),
+                                 APInt(64, remainingTiles));
+    mTileCount = mGCD.getSExtValue();
+  }
+
+  const uint64_t kTotalTileCount =
+      llvm::divideCeil(problem.kSize, intrinsic.kSize);
+  APInt kGCD = GreatestCommonDivisor(
+      APInt(64, kTotalTileCount), APInt(64, seeds.bestKTileCountPerSubgroup));
+  int64_t kTileCount = kGCD.getSExtValue();
+
+  return GPUMMASchedule{intrinsicIndex,  intrinsic.mSize, intrinsic.nSize,
+                        intrinsic.kSize, mWarpCount,      nWarpCount,
+                        mTileCount,      nTileCount,      kTileCount};
 }
 
 FailureOr<GPUMMASchedule> deduceMMASchedule(
@@ -141,113 +261,131 @@ FailureOr<GPUMMASchedule> deduceMMASchedule(
     int64_t subgroupSize, bool transposedLhs, bool transposedRhs,
     bool canUpcastAcc, bool mustBeAligned) {
   for (auto [index, intrinsic] : llvm::enumerate(intrinsics)) {
-    if (problem.aType != intrinsic.aType || problem.bType != intrinsic.bType) {
-      continue; // Cannot use this intrinsic for mismatched types
-    }
-    if (problem.cType != intrinsic.cType) {
-      auto isFpCase =
-          isa<FloatType>(problem.cType) && isa<FloatType>(intrinsic.cType);
-      auto isUpcast = problem.cType.getIntOrFloatBitWidth() <
-                      intrinsic.cType.getIntOrFloatBitWidth();
-      if (!(canUpcastAcc && isFpCase && isUpcast)) {
-        continue; // Cannot use this intrinsic if not upcasting
-      }
-    }
-
-    if (mustBeAligned && (problem.mSize % intrinsic.mSize != 0 ||
-                          problem.nSize % intrinsic.nSize != 0 ||
-                          problem.kSize % intrinsic.kSize != 0)) {
-      continue; // Cannot use this intrinsic for misaligned cases
-    }
-
-    // Cannot use the intrinsic when the tile size is greater than problem size.
-    // Because tiling is a no-op, and we can't infer tiling sizes from IR.
-    if (!mustBeAligned &&
-        (problem.mSize < intrinsic.mSize || problem.nSize < intrinsic.nSize ||
-         problem.kSize < intrinsic.kSize)) {
+    if (failed(canTargetIntrinsic(problem, intrinsic, canUpcastAcc,
+                                  mustBeAligned))) {
       continue;
     }
 
-    int64_t mTotalTileCount = llvm::divideCeil(problem.mSize, intrinsic.mSize);
-    int64_t nTotalTileCount = llvm::divideCeil(problem.nSize, intrinsic.nSize);
-
-    int64_t remainingWarps = seeds.bestSubgroupCountPerWorkgroup;
-    int64_t remainingTiles = seeds.bestMNTileCountPerSubgroup;
-    // Assign more warps to the M dimension (used later) to balance thread
-    // counts along X and Y dimensions.
-    int64_t warpSqrt = 1ull
-                       << (llvm::divideCeil(llvm::Log2_64(remainingWarps), 2));
-    int64_t tileSqrt = 1ull << (llvm::Log2_64(remainingTiles) / 2);
-
-    int64_t mWarpCount = 0, nWarpCount = 0;
-    int64_t mTileCount = 0, nTileCount = 0;
-
-    // See if the square root can divide mTotalTileCount. If so it means we can
-    // distribute to both dimensions evenly. Otherwise, try to distribute to N
-    // and then M.
-    if (mTotalTileCount > (warpSqrt * tileSqrt) &&
-        mTotalTileCount % (warpSqrt * tileSqrt) == 0) {
-      mWarpCount = warpSqrt;
-      mTileCount = tileSqrt;
-
-      remainingWarps /= warpSqrt;
-      remainingTiles /= tileSqrt;
-
-      APInt nGCD = GreatestCommonDivisor(APInt(64, nTotalTileCount),
-                                         APInt(64, remainingWarps));
-      nWarpCount = nGCD.getSExtValue();
-      nTotalTileCount /= nWarpCount;
-      remainingWarps /= nWarpCount;
-
-      nGCD = GreatestCommonDivisor(APInt(64, nTotalTileCount),
-                                   APInt(64, remainingTiles));
-      nTileCount = nGCD.getSExtValue();
-    } else {
-      APInt nGCD = GreatestCommonDivisor(APInt(64, nTotalTileCount),
-                                         APInt(64, remainingWarps));
-      nWarpCount = nGCD.getSExtValue();
-      nTotalTileCount /= nWarpCount;
-      remainingWarps /= nWarpCount;
-
-      nGCD = GreatestCommonDivisor(APInt(64, nTotalTileCount),
-                                   APInt(64, remainingTiles));
-      nTileCount = nGCD.getSExtValue();
-      remainingTiles /= nTileCount;
-
-      APInt mGCD = GreatestCommonDivisor(APInt(64, mTotalTileCount),
-                                         APInt(64, remainingWarps));
-      mWarpCount = mGCD.getSExtValue();
-      mTotalTileCount /= mWarpCount;
-      remainingWarps /= mWarpCount;
-
-      mGCD = GreatestCommonDivisor(APInt(64, mTotalTileCount),
-                                   APInt(64, remainingTiles));
-      mTileCount = mGCD.getSExtValue();
-    }
-
-    const uint64_t kTotalTileCount =
-        llvm::divideCeil(problem.kSize, intrinsic.kSize);
-    APInt kGCD = GreatestCommonDivisor(
-        APInt(64, kTotalTileCount), APInt(64, seeds.bestKTileCountPerSubgroup));
-    int64_t kTileCount = kGCD.getSExtValue();
+    GPUMMASchedule schedule =
+        getOptimalMMASchedule(problem, intrinsic, seeds, index);
 
     LLVM_DEBUG({
       llvm::dbgs() << "chosen MMA schedule:\n";
       llvm::dbgs() << "  intrinsic (M, N, K) = (" << intrinsic.mSize << ", "
                    << intrinsic.nSize << ", " << intrinsic.kSize << ")\n";
-      llvm::dbgs() << "  subgroup count (M, N) = (" << mWarpCount << ", "
-                   << nWarpCount << ")\n";
-      llvm::dbgs() << "  subgroup tile count (M, N, K) = (" << mTileCount
-                   << ", " << nTileCount << ", " << kTileCount << ")\n";
+      llvm::dbgs() << "  subgroup count (M, N) = (" << schedule.mWarpCount
+                   << ", " << schedule.nWarpCount << ")\n";
+      llvm::dbgs() << "  subgroup tile count (M, N, K) = ("
+                   << schedule.mTileCount << ", " << schedule.nTileCount << ", "
+                   << schedule.kTileCount << ")\n";
     });
-    return fitScheduleInSharedMemory(
-        problem, intrinsics,
-        GPUMMASchedule{index, intrinsic.mSize, intrinsic.nSize, intrinsic.kSize,
-                       mWarpCount, nWarpCount, mTileCount, nTileCount,
-                       kTileCount},
-        sharedMemLimitInBytes, subgroupSize, transposedLhs, transposedRhs,
-        mustBeAligned);
+
+    auto isValidSchedule = [&](const GPUMMASchedule &schedule) -> bool {
+      int64_t lhsBitwidth =
+          intrinsics[schedule.index].aType.getIntOrFloatBitWidth();
+      int64_t rhsBitwidth =
+          intrinsics[schedule.index].bType.getIntOrFloatBitWidth();
+      bool isAligned =
+          isValidMMASchedule(problem, schedule, mustBeAligned, subgroupSize,
+                             transposedLhs, transposedRhs);
+      int64_t sharedMemoryUsed =
+          calculateSharedMemoryUsedInBytes(schedule, lhsBitwidth, rhsBitwidth);
+
+      LLVM_DEBUG({
+        llvm::dbgs() << "Available Shared Memory: ";
+        llvm::dbgs() << sharedMemLimitInBytes << " bytes\n";
+        llvm::dbgs() << "Predicted Shared Memory Used by Schedule: ";
+        llvm::dbgs() << sharedMemoryUsed << " bytes\n";
+      });
+
+      return isAligned && sharedMemoryUsed <= sharedMemLimitInBytes;
+    };
+
+    return fitScheduleInSharedMemory(intrinsic, schedule, isValidSchedule);
   }
+  return failure();
+}
+
+FailureOr<GPUMMASchedule> deduceAttentionSchedule(
+    const GPUMatmulShapeType &qkMatmul, const GPUMatmulShapeType &pvMatmul,
+    ArrayRef<GPUMatmulShapeType> intrinsics,
+    const GPUMMAHeuristicSeeds &pvMatmulSeeds, int64_t sharedMemLimitInBytes,
+    int64_t subgroupSize, bool transposedQ, bool transposedK, bool transposedV,
+    bool canUpcastAcc, bool mustBeAligned) {
+
+  for (auto [index, intrinsic] : llvm::enumerate(intrinsics)) {
+    if (failed(canTargetIntrinsic(qkMatmul, intrinsic, canUpcastAcc,
+                                  mustBeAligned))) {
+      continue;
+    }
+
+    if (failed(canTargetIntrinsic(pvMatmul, intrinsic, canUpcastAcc,
+                                  mustBeAligned))) {
+      continue;
+    }
+
+    GPUMMASchedule schedule =
+        getOptimalMMASchedule(pvMatmul, intrinsic, pvMatmulSeeds, index);
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "chosen MMA schedule:\n";
+      llvm::dbgs() << "  intrinsic (M, N, K) = (" << intrinsic.mSize << ", "
+                   << intrinsic.nSize << ", " << intrinsic.kSize << ")\n";
+      llvm::dbgs() << "  subgroup count (M, N) = (" << schedule.mWarpCount
+                   << ", " << schedule.nWarpCount << ")\n";
+      llvm::dbgs() << "  subgroup tile count (M, N, K) = ("
+                   << schedule.mTileCount << ", " << schedule.nTileCount << ", "
+                   << schedule.kTileCount << ")\n";
+    });
+
+    int64_t intrinsicK = intrinsic.kSize;
+    auto isValidSchedule = [&](const GPUMMASchedule &schedule) -> bool {
+      // Create a mma schedule for qkMatmul in attention.
+      // qkMatmul.M = pvMatmul.M
+      // qkMatmul.N = pvMatmul.K
+      // qkMatmul.K = problem.K
+      GPUMMASchedule qkSchedule{schedule.index,
+                                schedule.mSize,
+                                schedule.kSize,
+                                intrinsicK,
+                                /*mWarpCount=*/schedule.mWarpCount,
+                                /*nWarpCount=*/1,
+                                schedule.mTileCount,
+                                schedule.kTileCount,
+                                qkMatmul.kSize / intrinsicK};
+
+      bool isQKAligned =
+          isValidMMASchedule(qkMatmul, qkSchedule, mustBeAligned, subgroupSize,
+                             transposedQ, transposedK);
+      // P doesn't need to be distributable by wgSize, since it's not loaded
+      // from global memory, but for now, it is okay to ensure it is, as in
+      // practice, it should be distributable by wgSize.
+      bool isPVAligned = isValidMMASchedule(pvMatmul, schedule, mustBeAligned,
+                                            subgroupSize, false, transposedV);
+
+      int64_t lhsBitwidth =
+          intrinsics[schedule.index].aType.getIntOrFloatBitWidth();
+      int64_t rhsBitwidth =
+          intrinsics[schedule.index].bType.getIntOrFloatBitWidth();
+      int64_t sharedMemoryUsed =
+          calculateSharedMemoryUsedInBytes(qkSchedule, lhsBitwidth,
+                                           rhsBitwidth) +
+          calculateSharedMemoryUsedInBytes(schedule, lhsBitwidth, rhsBitwidth);
+
+      LLVM_DEBUG({
+        llvm::dbgs() << "Available Shared Memory: ";
+        llvm::dbgs() << sharedMemLimitInBytes << " bytes\n";
+        llvm::dbgs() << "Predicted Shared Memory Used by Schedule: ";
+        llvm::dbgs() << sharedMemoryUsed << " bytes\n";
+      });
+
+      return isQKAligned && isPVAligned &&
+             sharedMemoryUsed <= sharedMemLimitInBytes;
+    };
+
+    return fitScheduleInSharedMemory(intrinsic, schedule, isValidSchedule);
+  }
+
   return failure();
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -101,7 +101,7 @@ static FailureOr<GPUMMASchedule> fitScheduleInSharedMemory(
   while (!isScheduleValid(schedule)) {
     LLVM_DEBUG({
       llvm::dbgs() << "Chosen schedule is invalid:\n";
-      llvm::dbgs() << schedule;
+      llvm::dbgs() << schedule << "\n";
       llvm::dbgs() << "Shrinking schedule...\n";
     });
 
@@ -139,7 +139,7 @@ static FailureOr<GPUMMASchedule> fitScheduleInSharedMemory(
 
   LLVM_DEBUG({
     llvm::dbgs() << "Chosen schedule is valid:\n";
-    llvm::dbgs() << schedule;
+    llvm::dbgs() << schedule << "\n";
   });
 
   return schedule;

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
@@ -54,4 +54,15 @@ deduceMMASchedule(const GPUMatmulShapeType &problem,
                   bool transposedLhs = false, bool transposedRhs = false,
                   bool canUpcastAcc = false, bool mustBeAligned = true);
 
+/// Returns a schedule for the pvMatmul in attention using one of the given MMA
+/// |intrinsics| to target the given attention matmul problems, |qkMatmul|
+/// and |pvMatmul|. Returns std::nullopt if we cannot find such a schedule.
+FailureOr<GPUMMASchedule> deduceAttentionSchedule(
+    const GPUMatmulShapeType &qkMatmul, const GPUMatmulShapeType &pvMatmul,
+    ArrayRef<GPUMatmulShapeType> intrinsics,
+    const GPUMMAHeuristicSeeds &pvMatmulSeeds, int64_t sharedMemLimitInBytes,
+    int64_t subgroupSize, bool transposedQ = false, bool transposedK = true,
+    bool transposedV = false, bool canUpcastAcc = false,
+    bool mustBeAligned = true);
+
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -655,6 +655,8 @@ setAttentionVectorDistributionConfig(IREE::GPU::TargetAttr target,
   // TODO: Do we need a matvec-like attention pipeline? Probably not,
   // considering M is generally the largest dimension.
 
+  Value qMatrix = op.getQuery();
+  Value kMatrix = op.getKey();
   Value vMatrix = op.getValue();
 
   SmallVector<GPUMatmulShapeType> intrinsics;
@@ -669,53 +671,61 @@ setAttentionVectorDistributionConfig(IREE::GPU::TargetAttr target,
   if (intrinsics.empty())
     return failure();
 
-  // We select the tile sizes based on the second matmul. We can probably
-  // use a better heuristic, but all tile sizes can be determined from the
-  // second matmul.
-  //
-  // We assume that the second matmul uses the element type of V for input
-  // and f32 as output. It is possible to use other element types also.
+  // We assume that P uses the element type of V for input
+  // and both matmuls have f32 as output. It is possible to use other element
+  // types also.
+  Type qElementType = getElementTypeOrSelf(qMatrix);
+  Type kElementType = getElementTypeOrSelf(kMatrix);
   Type vElementType = getElementTypeOrSelf(vMatrix);
   Type f32Type = b.getF32Type();
-  GPUMatmulShapeType problem{bounds[mDim],
-                             bounds[nDim],
-                             bounds[k2Dim],
-                             /*lhsType=*/vElementType,
-                             /*rhsType=*/vElementType,
-                             /*accType=*/f32Type};
+  GPUMatmulShapeType qkMatmul{
+      /*m=*/bounds[mDim],
+      /*n=*/bounds[k2Dim],
+      /*k=*/bounds[k1Dim],
+      /*lhsType=*/qElementType,
+      /*rhsType=*/kElementType,
+      /*accType=*/f32Type,
+  };
+  GPUMatmulShapeType pvMatmul{/*m=*/bounds[mDim],
+                              /*n=*/bounds[nDim],
+                              /*k=*/bounds[k2Dim],
+                              /*lhsType=*/vElementType,
+                              /*rhsType=*/vElementType,
+                              /*accType=*/f32Type};
 
   // TODO: Currently, we are forcing number of subgroups to be 1. This can be
   // fixed by teaching vector distribution chained matmul.
-  GPUMMAHeuristicSeeds seeds = {/*bestSubgroupCountPerWorkgroup=*/1,
-                                /*bestMNTileCountPerSubgroup=*/8,
-                                /*bestKTileCountPerSubgroup=*/4};
+  GPUMMAHeuristicSeeds pvMatmulSeeds = {/*bestSubgroupCountPerWorkgroup=*/1,
+                                        /*bestMNTileCountPerSubgroup=*/8,
+                                        /*bestKTileCountPerSubgroup=*/4};
 
   LDBG("Attention Vector Distribution Config");
 
   auto pipeline = CodeGenPipeline::LLVMGPUVectorDistribute;
 
-  // Infer if lhs or rhs is transposed to help generate better schedule.
-  AffineMap sMap = opInfo.getSMap();
-  AffineMap vMap = op.getValueMap();
-
-  bool transposedLhs =
-      (k2Dim !=
-       llvm::cast<AffineDimExpr>(sMap.getResults().back()).getPosition());
-  bool transposedRhs =
-      (nDim !=
-       llvm::cast<AffineDimExpr>(vMap.getResults().back()).getPosition());
+  // Infer if Q, K and V are transposed to help generate better schedule.
+  bool transposedQ =
+      k1Dim != llvm::cast<AffineDimExpr>(op.getQueryMap().getResults().back())
+                   .getPosition();
+  bool transposedK =
+      k1Dim != llvm::cast<AffineDimExpr>(op.getKeyMap().getResults().back())
+                   .getPosition();
+  bool transposedV =
+      k2Dim != llvm::cast<AffineDimExpr>(op.getValueMap().getResults().back())
+                   .getPosition();
 
   int64_t maxSharedMemoryBytes = target.getWgp().getMaxWorkgroupMemoryBytes();
 
   // First try to find a schedule with an exactly matching intrinsic.
-  std::optional<GPUMMASchedule> schedule = deduceMMASchedule(
-      problem, intrinsics, seeds, maxSharedMemoryBytes, targetSubgroupSize);
+  std::optional<GPUMMASchedule> schedule = deduceAttentionSchedule(
+      qkMatmul, pvMatmul, intrinsics, pvMatmulSeeds, maxSharedMemoryBytes,
+      targetSubgroupSize, transposedQ, transposedK, transposedV);
   if (!schedule) {
     // Then try again by allowing upcasting accumulator.
-    schedule =
-        deduceMMASchedule(problem, intrinsics, seeds, maxSharedMemoryBytes,
-                          targetSubgroupSize, transposedLhs, transposedRhs,
-                          /*canUpcastAcc=*/true);
+    schedule = deduceAttentionSchedule(
+        qkMatmul, pvMatmul, intrinsics, pvMatmulSeeds, maxSharedMemoryBytes,
+        targetSubgroupSize, transposedQ, transposedK, transposedV,
+        /*canUpcastAcc=*/true);
   }
 
   if (!schedule) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute.mlir
@@ -374,3 +374,41 @@ func.func @attention_20x4096x64x4096x64() {
   flow.dispatch.tensor.store %8, %3, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : tensor<20x4096x64xf16> -> !flow.dispatch.tensor<writeonly:tensor<20x4096x64xf16>>
   return
 }
+
+// -----
+
+// CHECK:       #[[$TILE_SIZES:.+]] = #iree_codegen.lowering_config<tile_sizes =  {{\[}}[16, 0, 32, 16]{{\]}}
+// CHECK:       #iree_codegen.translation_info<LLVMGPUVectorDistribute
+// CHECK-SAME:  subgroup_m_count = 1, subgroup_n_count = 1
+// CHECK-NOT:   prefetch_shared_memory
+
+// CHECK-LABEL: func.func @attention_large_head_dim_shared_mem()
+
+// Test to check if having a large head dim, which would lead to high shared
+// memory usage, can select tile sizes that fit shared memory.
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @attention_large_k1_shared_mem() {
+  %cst = arith.constant 1.250000e-01 : f16
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<1024x512xf16>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<128x512xf16>>
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<128x512xf16>>
+  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<1024x512xf16>>
+  %4 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1024, 512], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<1024x512xf16>> -> tensor<1024x512xf16>
+  %5 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [128, 512], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<128x512xf16>> -> tensor<128x512xf16>
+  %6 = flow.dispatch.tensor.load %2, offsets = [0, 0], sizes = [128, 512], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<128x512xf16>> -> tensor<128x512xf16>
+  %7 = tensor.empty() : tensor<1024x512xf16>
+  %8 = iree_linalg_ext.attention  {indexing_maps = [affine_map<(d1, d2, d3, d4) -> (d1, d2)>,
+                     affine_map<(d1, d2, d3, d4) -> (d3, d2)>,
+                     affine_map<(d1, d2, d3, d4) -> (d3, d4)>,
+                     affine_map<(d1, d2, d3, d4) -> (d1, d4)>]}
+                     ins(%4, %5, %6, %cst : tensor<1024x512xf16>, tensor<128x512xf16>, tensor<128x512xf16>, f16) outs(%7 : tensor<1024x512xf16>) -> tensor<1024x512xf16>
+  flow.dispatch.tensor.store %8, %3, offsets = [0, 0], sizes = [1024, 512], strides = [1, 1] : tensor<1024x512xf16> -> !flow.dispatch.tensor<writeonly:tensor<1024x512xf16>>
+  return
+}

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute.mlir
@@ -393,7 +393,7 @@ func.func @attention_20x4096x64x4096x64() {
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @attention_large_k1_shared_mem() {
+func.func @attention_large_head_dim_shared_mem() {
   %cst = arith.constant 1.250000e-01 : f16
   %c0 = arith.constant 0 : index
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<1024x512xf16>>


### PR DESCRIPTION
MMA heuristics are refactored into utilities, and these utilities are used to generate a schedule for attention. For now, attention still uses the same heuristic as GEMM to calculate required tile sizes. This heuristic will be improved in future (the heuristic for attention is to have as many M tiles as possible).

This does not modify any tests, as MMA configuration logic is same. Attention configuration logic is also same, but now has more checks for shared memory and alignment for the QK  matmul.