### PR TITLE
[VectorExt] Rename NestedLayout attribute fields

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_contract_amdgpu.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_contract_amdgpu.mlir
@@ -8,11 +8,11 @@
 
 // A: shape = 32x8, layout = layoutA
 #layout_a = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup    = [1, 1],
-  outers_per_batch        = [1, 1],
-  threads_per_outer       = [32, 2],
-  elements_per_thread     = [1, 4],
+  subgroup_tile = [1, 1],
+  batch_tile    = [1, 1],
+  outer_tile        = [1, 1],
+  thread_tile       = [32, 2],
+  element_tile     = [1, 4],
 
   subgroup_strides        = [1, 1],
   thread_strides          = [1, 32]
@@ -20,11 +20,11 @@
 
 // B: shape = 8x32, layout = layoutB
 #layout_b = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup    = [1, 1],
-  outers_per_batch        = [1, 1],
-  threads_per_outer       = [2, 32],
-  elements_per_thread     = [4, 1],
+  subgroup_tile = [1, 1],
+  batch_tile    = [1, 1],
+  outer_tile        = [1, 1],
+  thread_tile       = [2, 32],
+  element_tile     = [4, 1],
 
   subgroup_strides        = [1, 1],
   thread_strides          = [32, 1]
@@ -32,11 +32,11 @@
 
 // C: shape = 32x32, layout = layoutC
 #layout_c = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup    = [1, 1],
-  outers_per_batch        = [4, 1],
-  threads_per_outer       = [2, 32],
-  elements_per_thread     = [4, 1],
+  subgroup_tile = [1, 1],
+  batch_tile    = [1, 1],
+  outer_tile        = [4, 1],
+  thread_tile       = [2, 32],
+  element_tile     = [4, 1],
 
   subgroup_strides        = [1, 1],
   thread_strides          = [32, 1]
@@ -95,11 +95,11 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // A: shape = 16x16, layout = layoutA
 #layout_a = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup    = [1, 1],
-  outers_per_batch        = [1, 1],
-  threads_per_outer       = [16, 4],
-  elements_per_thread     = [1, 4],
+  subgroup_tile = [1, 1],
+  batch_tile    = [1, 1],
+  outer_tile        = [1, 1],
+  thread_tile       = [16, 4],
+  element_tile     = [1, 4],
 
   subgroup_strides        = [1, 1],
   thread_strides          = [1, 16]
@@ -107,11 +107,11 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // B: shape = 16x16, layout = layoutB
 #layout_b = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup    = [1, 1],
-  outers_per_batch        = [1, 1],
-  threads_per_outer       = [4, 16],
-  elements_per_thread     = [4, 1],
+  subgroup_tile = [1, 1],
+  batch_tile    = [1, 1],
+  outer_tile        = [1, 1],
+  thread_tile       = [4, 16],
+  element_tile     = [4, 1],
 
   subgroup_strides        = [1, 1],
   thread_strides          = [16, 1]
@@ -173,11 +173,11 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // A: shape = 64x8, layout = layoutA
 #layout_a = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup    = [2, 1],
-  outers_per_batch        = [1, 1],
-  threads_per_outer       = [32, 2],
-  elements_per_thread     = [1, 4],
+  subgroup_tile = [1, 1],
+  batch_tile    = [2, 1],
+  outer_tile        = [1, 1],
+  thread_tile       = [32, 2],
+  element_tile     = [1, 4],
 
   subgroup_strides        = [1, 1],
   thread_strides          = [1, 32]
@@ -185,11 +185,11 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // B: shape = 8x32, layout = layoutB
 #layout_b = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup    = [1, 1],
-  outers_per_batch        = [1, 1],
-  threads_per_outer       = [2, 32],
-  elements_per_thread     = [4, 1],
+  subgroup_tile = [1, 1],
+  batch_tile    = [1, 1],
+  outer_tile        = [1, 1],
+  thread_tile       = [2, 32],
+  element_tile     = [4, 1],
 
   subgroup_strides        = [1, 1],
   thread_strides          = [32, 1]
@@ -197,11 +197,11 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // C: shape = 64x32, layout = layoutC
 #layout_c = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup    = [2, 1],
-  outers_per_batch        = [4, 1],
-  threads_per_outer       = [2, 32],
-  elements_per_thread     = [4, 1],
+  subgroup_tile = [1, 1],
+  batch_tile    = [2, 1],
+  outer_tile        = [4, 1],
+  thread_tile       = [2, 32],
+  element_tile     = [4, 1],
 
   subgroup_strides        = [1, 1],
   thread_strides          = [32, 1]
@@ -262,11 +262,11 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // A: shape = 32x16, layout = layoutA
 #layout_a = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup    = [1, 2],
-  outers_per_batch        = [1, 1],
-  threads_per_outer       = [32, 2],
-  elements_per_thread     = [1, 4],
+  subgroup_tile = [1, 1],
+  batch_tile    = [1, 2],
+  outer_tile        = [1, 1],
+  thread_tile       = [32, 2],
+  element_tile     = [1, 4],
 
   subgroup_strides        = [1, 1],
   thread_strides          = [1, 32]
@@ -274,11 +274,11 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // B: shape = 16x32, layout = layoutB
 #layout_b = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup    = [2, 1],
-  outers_per_batch        = [1, 1],
-  threads_per_outer       = [2, 32],
-  elements_per_thread     = [4, 1],
+  subgroup_tile = [1, 1],
+  batch_tile    = [2, 1],
+  outer_tile        = [1, 1],
+  thread_tile       = [2, 32],
+  element_tile     = [4, 1],
 
   subgroup_strides         = [1, 1],
   thread_strides          = [32, 1]
@@ -286,11 +286,11 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // C: shape = 32x32, layout = layoutC
 #layout_c = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup    = [1, 1],
-  outers_per_batch        = [4, 1],
-  threads_per_outer       = [2, 32],
-  elements_per_thread     = [4, 1],
+  subgroup_tile = [1, 1],
+  batch_tile    = [1, 1],
+  outer_tile        = [4, 1],
+  thread_tile       = [2, 32],
+  element_tile     = [4, 1],
 
   subgroup_strides         = [1, 1],
   thread_strides          = [32, 1]
@@ -345,11 +345,11 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // A: shape = 64x8, layout = layoutA
 #layout_a = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup    = [2, 1],
-  outers_per_batch        = [1, 1],
-  threads_per_outer       = [32, 2],
-  elements_per_thread     = [1, 4],
+  subgroup_tile = [1, 1],
+  batch_tile    = [2, 1],
+  outer_tile        = [1, 1],
+  thread_tile       = [32, 2],
+  element_tile     = [1, 4],
 
   subgroup_strides        = [1, 1],
   thread_strides          = [1, 32]
@@ -357,11 +357,11 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // B: shape = 8x96, layout = layoutB
 #layout_b = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup    = [1, 3],
-  outers_per_batch        = [1, 1],
-  threads_per_outer       = [2, 32],
-  elements_per_thread     = [4, 1],
+  subgroup_tile = [1, 1],
+  batch_tile    = [1, 3],
+  outer_tile        = [1, 1],
+  thread_tile       = [2, 32],
+  element_tile     = [4, 1],
 
   subgroup_strides        = [1, 1],
   thread_strides          = [32, 1]
@@ -369,11 +369,11 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // C: shape = 64x96, layout = layoutC
 #layout_c = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup    = [2, 3],
-  outers_per_batch        = [4, 1],
-  threads_per_outer       = [2, 32],
-  elements_per_thread     = [4, 1],
+  subgroup_tile = [1, 1],
+  batch_tile    = [2, 3],
+  outer_tile        = [4, 1],
+  thread_tile       = [2, 32],
+  element_tile     = [4, 1],
 
   subgroup_strides        = [1, 1],
   thread_strides          = [32, 1]
@@ -436,11 +436,11 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // A: shape = 32x8, layout = layoutA
 #layout_a = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup    = [1, 1],
-  outers_per_batch        = [1, 1],
-  threads_per_outer       = [32, 2],
-  elements_per_thread     = [1, 4],
+  subgroup_tile = [1, 1],
+  batch_tile    = [1, 1],
+  outer_tile        = [1, 1],
+  thread_tile       = [32, 2],
+  element_tile     = [1, 4],
 
   subgroup_strides        = [1, 1],
   thread_strides          = [1, 32]
@@ -448,11 +448,11 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // B: shape = 64x8, layout = layoutB
 #layout_b = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup    = [2, 1],
-  outers_per_batch        = [1, 1],
-  threads_per_outer       = [32, 2],
-  elements_per_thread     = [1, 4],
+  subgroup_tile = [1, 1],
+  batch_tile    = [2, 1],
+  outer_tile        = [1, 1],
+  thread_tile       = [32, 2],
+  element_tile     = [1, 4],
 
   subgroup_strides        = [1, 1],
   thread_strides          = [1, 32]
@@ -460,11 +460,11 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // C: shape = 32x64, layout = layoutC
 #layout_c = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup    = [1, 2],
-  outers_per_batch        = [4, 1],
-  threads_per_outer       = [2, 32],
-  elements_per_thread     = [4, 1],
+  subgroup_tile = [1, 1],
+  batch_tile    = [1, 2],
+  outer_tile        = [4, 1],
+  thread_tile       = [2, 32],
+  element_tile     = [4, 1],
 
   subgroup_strides        = [1, 1],
   thread_strides          = [32, 1]
@@ -515,11 +515,11 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // A: shape = 16x16, layout = layoutA
 #layout_a = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup    = [1, 1],
-  outers_per_batch        = [1, 1],
-  threads_per_outer       = [16, 1],
-  elements_per_thread     = [1, 16],
+  subgroup_tile = [1, 1],
+  batch_tile    = [1, 1],
+  outer_tile        = [1, 1],
+  thread_tile       = [16, 1],
+  element_tile     = [1, 16],
 
   subgroup_strides        = [1, 1],
   thread_strides          = [1, 16]
@@ -527,11 +527,11 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // B: shape = 16x16, layout = layoutB
 #layout_b = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup    = [1, 1],
-  outers_per_batch        = [1, 1],
-  threads_per_outer       = [1, 16],
-  elements_per_thread     = [16, 1],
+  subgroup_tile = [1, 1],
+  batch_tile    = [1, 1],
+  outer_tile        = [1, 1],
+  thread_tile       = [1, 16],
+  element_tile     = [16, 1],
 
   subgroup_strides        = [1, 1],
   thread_strides          = [16, 1]
@@ -539,11 +539,11 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // C: shape = 16x16, layout = layoutC
 #layout_c = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup    = [1, 1],
-  outers_per_batch        = [8, 1],
-  threads_per_outer       = [2, 16],
-  elements_per_thread     = [1, 1],
+  subgroup_tile = [1, 1],
+  batch_tile    = [1, 1],
+  outer_tile        = [8, 1],
+  thread_tile       = [2, 16],
+  element_tile     = [1, 1],
 
   subgroup_strides        = [1, 1],
   thread_strides          = [16, 1]

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
@@ -1,11 +1,11 @@
 // RUN: iree-opt --iree-transform-dialect-interpreter --split-input-file --canonicalize --cse %s | FileCheck %s
 
 #layout_col_major = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup    = [1, 2],
-  outers_per_batch        = [1, 1],
-  threads_per_outer       = [4, 8],
-  elements_per_thread     = [4, 1],
+  subgroup_tile = [1, 1],
+  batch_tile    = [1, 2],
+  outer_tile        = [1, 1],
+  thread_tile       = [4, 8],
+  element_tile     = [4, 1],
 
   subgroup_strides        = [1, 1],
   thread_strides          = [8, 1]
@@ -45,11 +45,11 @@ builtin.module attributes { transform.with_named_sequence } {
 // -----
 
 #layout_row_major = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup    = [2, 2],
-  outers_per_batch        = [1, 1],
-  threads_per_outer       = [8, 1],
-  elements_per_thread     = [1, 8],
+  subgroup_tile = [1, 1],
+  batch_tile    = [2, 2],
+  outer_tile        = [1, 1],
+  thread_tile       = [8, 1],
+  element_tile     = [1, 8],
 
   subgroup_strides        = [1, 1],
   thread_strides          = [1, 1]
@@ -92,11 +92,11 @@ builtin.module attributes { transform.with_named_sequence } {
 // -----
 
 #layout_col_major = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup    = [1, 2],
-  outers_per_batch        = [1, 1],
-  threads_per_outer       = [4, 8],
-  elements_per_thread     = [4, 1],
+  subgroup_tile = [1, 1],
+  batch_tile    = [1, 2],
+  outer_tile        = [1, 1],
+  thread_tile       = [4, 8],
+  element_tile     = [4, 1],
 
   subgroup_strides        = [1, 1],
   thread_strides          = [8, 1]
@@ -133,11 +133,11 @@ builtin.module attributes { transform.with_named_sequence } {
 // -----
 
 #layout_row_major = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup    = [2, 2],
-  outers_per_batch        = [1, 1],
-  threads_per_outer       = [8, 1],
-  elements_per_thread     = [1, 8],
+  subgroup_tile = [1, 1],
+  batch_tile    = [2, 2],
+  outer_tile        = [1, 1],
+  thread_tile       = [8, 1],
+  element_tile     = [1, 8],
 
   subgroup_strides        = [1, 1],
   thread_strides          = [1, 1]
@@ -182,11 +182,11 @@ builtin.module attributes { transform.with_named_sequence } {
 // -----
 
 #layout_col_major = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup    = [1, 2],
-  outers_per_batch        = [1, 1],
-  threads_per_outer       = [4, 8],
-  elements_per_thread     = [4, 1],
+  subgroup_tile = [1, 1],
+  batch_tile    = [1, 2],
+  outer_tile        = [1, 1],
+  thread_tile       = [4, 8],
+  element_tile     = [4, 1],
 
   subgroup_strides        = [1, 1],
   thread_strides          = [8, 1]
@@ -220,11 +220,11 @@ builtin.module attributes { transform.with_named_sequence } {
 // -----
 
 #layout = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [7, 3, 1, 1],
-  batches_per_subgroup    = [3, 5, 2, 1],
-  outers_per_batch        = [1, 1, 2, 4],
-  threads_per_outer       = [1, 1, 2, 2],
-  elements_per_thread     = [1, 1, 1, 2],
+  subgroup_tile = [7, 3, 1, 1],
+  batch_tile    = [3, 5, 2, 1],
+  outer_tile        = [1, 1, 2, 4],
+  thread_tile       = [1, 1, 2, 2],
+  element_tile     = [1, 1, 1, 2],
 
   subgroup_strides        = [3, 1, 1, 1],
   thread_strides          = [1, 1, 1, 2]
@@ -258,11 +258,11 @@ builtin.module attributes { transform.with_named_sequence } {
 // -----
 
 #layout = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1],
-  batches_per_subgroup    = [1],
-  outers_per_batch        = [1],
-  threads_per_outer       = [4],
-  elements_per_thread     = [4],
+  subgroup_tile = [1],
+  batch_tile    = [1],
+  outer_tile        = [1],
+  thread_tile       = [4],
+  element_tile     = [4],
 
   subgroup_strides        = [1],
   thread_strides          = [16]
@@ -295,11 +295,11 @@ builtin.module attributes { transform.with_named_sequence } {
 // -----
 
 #layout = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [2],
-  batches_per_subgroup    = [1],
-  outers_per_batch        = [1],
-  threads_per_outer       = [16],
-  elements_per_thread     = [4],
+  subgroup_tile = [2],
+  batch_tile    = [1],
+  outer_tile        = [1],
+  thread_tile       = [16],
+  element_tile     = [4],
 
   subgroup_strides        = [1],
   thread_strides          = [1]
@@ -332,11 +332,11 @@ builtin.module attributes { transform.with_named_sequence } {
 // -----
 
 #layout_row_major = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup    = [2, 2],
-  outers_per_batch        = [1, 1],
-  threads_per_outer       = [8, 1],
-  elements_per_thread     = [1, 8],
+  subgroup_tile = [1, 1],
+  batch_tile    = [2, 2],
+  outer_tile        = [1, 1],
+  thread_tile       = [8, 1],
+  element_tile     = [1, 8],
 
   subgroup_strides        = [1, 1],
   thread_strides          = [1, 1]
@@ -378,11 +378,11 @@ builtin.module attributes { transform.with_named_sequence } {
 // -----
 
 #layout_col_major = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup    = [1, 2],
-  outers_per_batch        = [1, 1],
-  threads_per_outer       = [4, 8],
-  elements_per_thread     = [4, 1],
+  subgroup_tile = [1, 1],
+  batch_tile    = [1, 2],
+  outer_tile        = [1, 1],
+  thread_tile       = [4, 8],
+  element_tile     = [4, 1],
 
   subgroup_strides        = [1, 1],
   thread_strides          = [8, 1]
@@ -422,11 +422,11 @@ builtin.module attributes { transform.with_named_sequence } {
 // -----
 
 #layout_row_major = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup    = [2, 2],
-  outers_per_batch        = [1, 1],
-  threads_per_outer       = [8, 1],
-  elements_per_thread     = [1, 8],
+  subgroup_tile = [1, 1],
+  batch_tile    = [2, 2],
+  outer_tile        = [1, 1],
+  thread_tile       = [8, 1],
+  element_tile     = [1, 8],
 
   subgroup_strides        = [1, 1],
   thread_strides          = [1, 1]
@@ -474,11 +474,11 @@ builtin.module attributes { transform.with_named_sequence } {
 // -----
 
 #layout_row_major = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup    = [2, 2],
-  outers_per_batch        = [1, 1],
-  threads_per_outer       = [8, 1],
-  elements_per_thread     = [1, 8],
+  subgroup_tile = [1, 1],
+  batch_tile    = [2, 2],
+  outer_tile        = [1, 1],
+  thread_tile       = [8, 1],
+  element_tile     = [1, 8],
 
   subgroup_strides        = [1, 1],
   thread_strides          = [1, 1]
@@ -524,11 +524,11 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // A: shape = 128x8, layout = layoutA
 #layout_a = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [4, 1],
-  batches_per_subgroup    = [1, 1],
-  outers_per_batch        = [1, 1],
-  threads_per_outer       = [32, 2],
-  elements_per_thread     = [1, 4],
+  subgroup_tile = [4, 1],
+  batch_tile    = [1, 1],
+  outer_tile        = [1, 1],
+  thread_tile       = [32, 2],
+  element_tile     = [1, 4],
 
   subgroup_strides        = [2, 1],
   thread_strides          = [1, 32]
@@ -536,11 +536,11 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // B: shape = 8x64, layout = layoutB
 #layout_b = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 2],
-  batches_per_subgroup    = [1, 1],
-  outers_per_batch        = [1, 1],
-  threads_per_outer       = [2, 32],
-  elements_per_thread     = [4, 1],
+  subgroup_tile = [1, 2],
+  batch_tile    = [1, 1],
+  outer_tile        = [1, 1],
+  thread_tile       = [2, 32],
+  element_tile     = [4, 1],
 
   subgroup_strides        = [1, 1],
   thread_strides          = [32, 1]
@@ -548,11 +548,11 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // C: shape = 128x64, layout = layoutC
 #layout_c = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [4, 2],
-  batches_per_subgroup    = [1, 1],
-  outers_per_batch        = [4, 1],
-  threads_per_outer       = [2, 32],
-  elements_per_thread     = [4, 1],
+  subgroup_tile = [4, 2],
+  batch_tile    = [1, 1],
+  outer_tile        = [4, 1],
+  thread_tile       = [2, 32],
+  element_tile     = [4, 1],
 
   subgroup_strides        = [2, 1],
   thread_strides          = [32, 1]
@@ -626,11 +626,11 @@ builtin.module attributes { transform.with_named_sequence } {
 // -----
 
 #layout = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [2, 1],
-  batches_per_subgroup    = [1, 1],
-  outers_per_batch        = [1, 1],
-  threads_per_outer       = [32, 2],
-  elements_per_thread     = [1, 4],
+  subgroup_tile = [2, 1],
+  batch_tile    = [1, 1],
+  outer_tile        = [1, 1],
+  thread_tile       = [32, 2],
+  element_tile     = [1, 4],
 
   subgroup_strides        = [2, 1],
   thread_strides          = [1, 32]
@@ -671,11 +671,11 @@ builtin.module attributes { transform.with_named_sequence } {
 // -----
 
 #layout = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [2, 2],
-  batches_per_subgroup = [2, 4],
-  outers_per_batch = [1, 1],
-  threads_per_outer = [4, 16],
-  elements_per_thread = [4, 1],
+  subgroup_tile = [2, 2],
+  batch_tile = [2, 4],
+  outer_tile = [1, 1],
+  thread_tile = [4, 16],
+  element_tile = [4, 1],
   subgroup_strides = [2, 1],
   thread_strides   = [16, 1]
 >
@@ -715,11 +715,11 @@ builtin.module attributes { transform.with_named_sequence } {
 // -----
 
 #layout = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [2, 2, 2],
-  batches_per_subgroup = [2, 2, 1],
-  outers_per_batch = [2, 1, 1],
-  threads_per_outer = [4, 16, 8],
-  elements_per_thread = [1, 4, 4],
+  subgroup_tile = [2, 2, 2],
+  batch_tile = [2, 2, 1],
+  outer_tile = [2, 1, 1],
+  thread_tile = [4, 16, 8],
+  element_tile = [1, 4, 4],
   subgroup_strides = [4, 2, 1],
   thread_strides   = [128, 8, 1]
 >
@@ -753,11 +753,11 @@ builtin.module attributes { transform.with_named_sequence } {
 // -----
 
 #layout = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [2, 2, 2],
-  batches_per_subgroup = [2, 2, 1],
-  outers_per_batch = [2, 1, 1],
-  threads_per_outer = [4, 16, 8],
-  elements_per_thread = [1, 4, 4],
+  subgroup_tile = [2, 2, 2],
+  batch_tile = [2, 2, 1],
+  outer_tile = [2, 1, 1],
+  thread_tile = [4, 16, 8],
+  element_tile = [1, 4, 4],
   subgroup_strides = [4, 2, 1],
   thread_strides = [128, 8, 1]
 >
@@ -784,11 +784,11 @@ builtin.module attributes { transform.with_named_sequence } {
 // -----
 
 #layout = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [2, 2],
-  batches_per_subgroup = [2, 4],
-  outers_per_batch = [2, 1],
-  threads_per_outer = [4, 16],
-  elements_per_thread = [2, 2],
+  subgroup_tile = [2, 2],
+  batch_tile = [2, 4],
+  outer_tile = [2, 1],
+  thread_tile = [4, 16],
+  element_tile = [2, 2],
   subgroup_strides = [2, 1],
   thread_strides = [16, 1]
 >
@@ -818,11 +818,11 @@ builtin.module attributes { transform.with_named_sequence } {
 // -----
 
 #layout = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [2, 2],
-  batches_per_subgroup = [2, 4],
-  outers_per_batch = [2, 1],
-  threads_per_outer = [4, 16],
-  elements_per_thread = [2, 2],
+  subgroup_tile = [2, 2],
+  batch_tile = [2, 4],
+  outer_tile = [2, 1],
+  thread_tile = [4, 16],
+  element_tile = [2, 2],
   subgroup_strides = [2, 1],
   thread_strides = [16, 1]
 >
@@ -844,11 +844,11 @@ builtin.module attributes { transform.with_named_sequence } {
 }
 
 // CHECK:      #[[$LAYOUT:.+]] = #iree_vector_ext.nested_layout
-// CHECK-SAME:   subgroups_per_workgroup = [2, 2],
-// CHECK-SAME:   batches_per_subgroup = [4, 2]
-// CHECK-SAME:   outers_per_batch = [1, 2]
-// CHECK-SAME:   threads_per_outer = [16, 4]
-// CHECK-SAME:   elements_per_thread = [2, 2]
+// CHECK-SAME:   subgroup_tile = [2, 2],
+// CHECK-SAME:   batch_tile = [4, 2]
+// CHECK-SAME:   outer_tile = [1, 2]
+// CHECK-SAME:   thread_tile = [16, 4]
+// CHECK-SAME:   element_tile = [2, 2]
 // CHECK-SAME:   subgroup_strides = [1, 2],
 // CHECK-SAME:   thread_strides = [1, 16]
 
@@ -862,11 +862,11 @@ builtin.module attributes { transform.with_named_sequence } {
 // -----
 
 #layout = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [2, 1, 1],
-  batches_per_subgroup = [1, 2, 4],
-  outers_per_batch = [1, 1, 1],
-  threads_per_outer = [4, 8, 2],
-  elements_per_thread = [4, 1, 2],
+  subgroup_tile = [2, 1, 1],
+  batch_tile = [1, 2, 4],
+  outer_tile = [1, 1, 1],
+  thread_tile = [4, 8, 2],
+  element_tile = [4, 1, 2],
 
   subgroup_strides = [1, 1, 1],
   thread_strides = [16, 2, 1]
@@ -934,15 +934,15 @@ builtin.module attributes { transform.with_named_sequence } {
 // -----
 
 #nested = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
+  subgroup_tile = [1, 1],
   // We are reducing along dim=1, so each thread will reduce
   // 2 batches x 4 elements = 8 elements.
-  batches_per_subgroup = [2, 2],
-  outers_per_batch = [1, 1],
+  batch_tile = [2, 2],
+  outer_tile = [1, 1],
   // We are reducing on dim=1, which is distributed over 4 threads. Based
   // on the subgroup basis and thread order, the shuffle offset is 16.
-  threads_per_outer = [16, 4],
-  elements_per_thread = [1, 4],
+  thread_tile = [16, 4],
+  element_tile = [1, 4],
 
   subgroup_strides = [1, 1],
   thread_strides = [1, 16]
@@ -983,15 +983,15 @@ builtin.module attributes { transform.with_named_sequence } {
 // -----
 
 #nested = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
+  subgroup_tile = [1, 1],
   // We are reducing along dim=1, so each thread will reduce
   // 4 batches x 4 elements = 16 elements.
-  batches_per_subgroup    = [1, 4],
-  outers_per_batch        = [1, 1],
+  batch_tile    = [1, 4],
+  outer_tile        = [1, 1],
   // We are reducing on dim=1, which is distributed over 2 threads. Based
   // on the subgroup basis and thread order, the shuffle offset is 32.
-  threads_per_outer       = [32, 2],
-  elements_per_thread     = [1, 4],
+  thread_tile       = [32, 2],
+  element_tile     = [1, 4],
 
   subgroup_strides        = [1, 1],
   thread_strides          = [1, 32]

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_alloc.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_alloc.mlir
@@ -1,11 +1,11 @@
 // RUN: iree-opt %s --split-input-file --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-vector-alloc))" | FileCheck %s
 
 #layout = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup = [1, 1],
-  outers_per_batch = [1, 1],
-  threads_per_outer = [4, 16],
-  elements_per_thread = [4, 1],
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [4, 16],
+  element_tile = [4, 1],
 
   subgroup_strides = [1, 1],
   thread_strides   = [0, 0]

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_distribution.mlir
@@ -42,11 +42,11 @@ func.func @distribute_elementwise_i32(%a: vector<16x16xi32>, %b: vector<16x16xi3
 }
 
 #nested = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [2, 1, 1],
-  batches_per_subgroup    = [8, 2, 4],
-  outers_per_batch        = [1, 4, 4],
-  threads_per_outer       = [8, 2, 4],
-  elements_per_thread     = [1, 8, 2],
+  subgroup_tile = [2, 1, 1],
+  batch_tile    = [8, 2, 4],
+  outer_tile        = [1, 4, 4],
+  thread_tile       = [8, 2, 4],
+  element_tile     = [1, 8, 2],
 
   subgroup_strides        = [1, 1, 1],
   thread_strides          = [1, 8, 16]

--- a/compiler/src/iree/compiler/Codegen/Common/test/vector_layout_analysis.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/vector_layout_analysis.mlir
@@ -274,11 +274,11 @@ builtin.module attributes { transform.with_named_sequence } {
 // -----
 
 #layout = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup = [1, 1],
-  outers_per_batch = [1, 1],
-  threads_per_outer = [4, 16],
-  elements_per_thread = [4, 1],
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [4, 16],
+  element_tile = [4, 1],
 
   subgroup_strides = [1, 1],
   thread_strides   = [1, 4]
@@ -313,11 +313,11 @@ builtin.module attributes { transform.with_named_sequence } {
 // -----
 
 #layout = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup = [1, 1],
-  outers_per_batch = [1, 1],
-  threads_per_outer = [4, 16],
-  elements_per_thread = [4, 1],
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [4, 16],
+  element_tile = [4, 1],
 
   subgroup_strides = [1, 1],
   thread_strides   = [1, 4]
@@ -352,11 +352,11 @@ builtin.module attributes { transform.with_named_sequence } {
 // -----
 
 #layout = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [2, 1, 1],
-  batches_per_subgroup = [1, 2, 4],
-  outers_per_batch = [1, 1, 1],
-  threads_per_outer = [4, 8, 2],
-  elements_per_thread = [4, 1, 2],
+  subgroup_tile = [2, 1, 1],
+  batch_tile = [1, 2, 4],
+  outer_tile = [1, 1, 1],
+  thread_tile = [4, 8, 2],
+  element_tile = [4, 1, 2],
 
   subgroup_strides = [1, 2, 2],
   thread_strides   = [1, 4, 32]
@@ -391,11 +391,11 @@ builtin.module attributes { transform.with_named_sequence } {
 // -----
 
 #layout = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup = [4, 1],
-  outers_per_batch = [1, 1],
-  threads_per_outer = [32, 4],
-  elements_per_thread = [1, 32],
+  subgroup_tile = [1, 1],
+  batch_tile = [4, 1],
+  outer_tile = [1, 1],
+  thread_tile = [32, 4],
+  element_tile = [1, 32],
 
   subgroup_strides = [1, 1],
   thread_strides = [1, 32]
@@ -438,11 +438,11 @@ builtin.module attributes { transform.with_named_sequence } {
 // -----
 
 #layout = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [2, 1, 1],
-  batches_per_subgroup = [1, 2, 4],
-  outers_per_batch = [1, 1, 1],
-  threads_per_outer = [4, 8, 2],
-  elements_per_thread = [4, 1, 2],
+  subgroup_tile = [2, 1, 1],
+  batch_tile = [1, 2, 4],
+  outer_tile = [1, 1, 1],
+  thread_tile = [4, 8, 2],
+  element_tile = [4, 1, 2],
 
   subgroup_strides = [1, 2, 2],
   thread_strides   = [1, 4, 32]
@@ -469,11 +469,11 @@ builtin.module attributes { transform.with_named_sequence } {
 // -----
 
 #layout2 = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup = [2, 4],
-  outers_per_batch = [1, 1],
-  threads_per_outer = [8, 2],
-  elements_per_thread = [2, 2],
+  subgroup_tile = [1, 1],
+  batch_tile = [2, 4],
+  outer_tile = [1, 1],
+  thread_tile = [8, 2],
+  element_tile = [2, 2],
 
   subgroup_strides = [0, 0],
   thread_strides   = [1, 8]
@@ -484,7 +484,7 @@ builtin.module attributes { transform.with_named_sequence } {
   func.func @invalid_size_nested_layout_anchor(%a: vector<16x16xf16>, %b: vector<16x16xf16>) -> vector<16x16xf16> {
     %c = arith.addf %a, %b : vector<16x16xf16>
     %cl = iree_vector_ext.to_layout %c to #layout2 : vector<16x16xf16>
-    // expected-error @above {{Vector shape: [16, 16] does not match the layout (nested_layout<subgroups_per_workgroup = [1, 1], batches_per_subgroup = [2, 4], outers_per_batch = [1, 1], threads_per_outer = [8, 2], elements_per_thread = [2, 2], subgroup_strides = [0, 0], thread_strides = [1, 8]>) at dim 0. Dimension expected by layout: 32 actual: 16}}
+    // expected-error @above {{Vector shape: [16, 16] does not match the layout (nested_layout<subgroup_tile = [1, 1], batch_tile = [2, 4], outer_tile = [1, 1], thread_tile = [8, 2], element_tile = [2, 2], subgroup_strides = [0, 0], thread_strides = [1, 8]>) at dim 0. Dimension expected by layout: 32 actual: 16}}
     func.return %cl : vector<16x16xf16>
   }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrs.td
@@ -139,10 +139,10 @@ def NestedLayoutAttr : IREEVectorExt_Attr<"NestedLayout",
 
     The subgroups are placed contiguously with their shape and ordering
     determined by:
-      - `subgroups_per_workgroup`: Sizes of this level of tiling
+      - `subgroup_tile`: Sizes of this level of tiling
       - `subgroup_order`: Ordering of dimensions, from outermost to innermost
 
-    For example, subgroups_per_workgroup=[4, 2], subgroup_order=[1, 0] will
+    For example, subgroup_tile=[4, 2], subgroup_order=[1, 0] will
     arrange the subgroups in the order:
 
     0 4
@@ -151,7 +151,7 @@ def NestedLayoutAttr : IREEVectorExt_Attr<"NestedLayout",
     3 7
 
     The total number of subgroups used (computed by multiplying each dim in
-    subgroups_per_workgroup) should be a multiple of number of subgroups in the
+    subgroup_tile) should be a multiple of number of subgroups in the
     harware. If the total number of subgroups used exceeds the number of
     subgroups of the hardware, then the subgroup used (say x) is
     x mod num_subgroups:
@@ -177,7 +177,7 @@ def NestedLayoutAttr : IREEVectorExt_Attr<"NestedLayout",
       for b_1 in range(batch_1):
         ...
 
-    `batches_per_subgroup` represents the range of each loop.
+    `batch_tile` represents the range of each loop.
 
     The second level, outers, is a way to represent thread layout duplication
     required by a particular intrinsic. For example, some AMDGPU matrix
@@ -187,23 +187,23 @@ def NestedLayoutAttr : IREEVectorExt_Attr<"NestedLayout",
     0 1 2 3 4
     5 6 7 8 9
     --------- --> Thread Layout of shape 2x5 duplicated 2 times, to get a layout of shape 4x5
-    0 1 2 3 4     outers_per_batch=[2, 1]
-    5 6 7 8 9     threads_per_outer=[2, 5]
+    0 1 2 3 4     outer_tile=[2, 1]
+    5 6 7 8 9     thread_tile=[2, 5]
 
-    `outers_per_batch` represents the number of outers in a batch.
+    `outer_tile` represents the number of outers in a batch.
 
     Finally, threads are distributed in a single outer. The thread
     distribution is represented by:
 
-      - threads_per_outer: Sizes of this level of tiling
+      - thread_tile: Sizes of this level of tiling
       - thread_order: Ordering of dimensions, from outermost to innermost
 
     Examples of thread distribution over a 8x4 shape:
 
     {
-      batches_per_subgroup = [2, 1]
-      outers_per_batch = [2, 2]
-      threads_per_outer = [2, 2]
+      batch_tile = [2, 1]
+      outer_tile = [2, 2]
+      thread_tile = [2, 2]
 
       thread_order = [1, 0]
     }
@@ -236,7 +236,7 @@ def NestedLayoutAttr : IREEVectorExt_Attr<"NestedLayout",
     [1 3 1 3]
 
     The total number of threads used (computed by multiplying each dim in
-    threads_per_outer) should be a multiple of subgroup size of the
+    thread_tile) should be a multiple of subgroup size of the
     harware. If the total number of threads used exceeds the subgroup size of
     the hardware, then the threads used (say tid) is tid mod subgroup_size:
 
@@ -252,26 +252,26 @@ def NestedLayoutAttr : IREEVectorExt_Attr<"NestedLayout",
     The final level of tiling, representing the minimum shape of vector that
     is treated as an atom.
 
-    `elements_per_thread` represents the native size of the vector.
+    `element_tile` represents the native size of the vector.
   }];
 
   let parameters = (ins
-    ArrayRefParameter<"int64_t", "subgroups_per_workgroup">:$subgroupsPerWorkgroup,
-    ArrayRefParameter<"int64_t", "batches_per_subgroup">:$batchesPerSubgroup,
-    ArrayRefParameter<"int64_t", "outers_per_batch">:$outersPerBatch,
-    ArrayRefParameter<"int64_t", "threads_per_outer">:$threadsPerOuter,
-    ArrayRefParameter<"int64_t", "elements_per_thread">:$elementsPerThread,
+    ArrayRefParameter<"int64_t", "subgroup_tile">:$subgroupTile,
+    ArrayRefParameter<"int64_t", "batch_tile">:$batchTile,
+    ArrayRefParameter<"int64_t", "outer_tile">:$outerTile,
+    ArrayRefParameter<"int64_t", "thread_tile">:$threadTile,
+    ArrayRefParameter<"int64_t", "element_tile">:$elementTile,
 
     ArrayRefParameter<"int64_t", "subgroup_strides">:$subgroupStrides,
     ArrayRefParameter<"int64_t", "thread_strides">:$threadStrides
   );
 
   let assemblyFormat = [{
-    `<` `subgroups_per_workgroup` `=` `[` $subgroupsPerWorkgroup `]` `,`
-        `batches_per_subgroup`    `=` `[` $batchesPerSubgroup `]` `,`
-        `outers_per_batch`        `=` `[` $outersPerBatch `]` `,`
-        `threads_per_outer`       `=` `[` $threadsPerOuter `]` `,`
-        `elements_per_thread`     `=` `[` $elementsPerThread `]` `,`
+    `<` `subgroup_tile` `=` `[` $subgroupTile `]` `,`
+        `batch_tile`    `=` `[` $batchTile `]` `,`
+        `outer_tile`        `=` `[` $outerTile `]` `,`
+        `thread_tile`       `=` `[` $threadTile `]` `,`
+        `element_tile`     `=` `[` $elementTile `]` `,`
 
         `subgroup_strides`        `=` `[` $subgroupStrides `]` `,`
         `thread_strides`          `=` `[` $threadStrides `]`
@@ -280,11 +280,11 @@ def NestedLayoutAttr : IREEVectorExt_Attr<"NestedLayout",
 
   let skipDefaultBuilders = 1;
   let builders = [
-    AttrBuilder<(ins "ArrayRef<int64_t>":$subgroupsPerWorkgroup,
-                     "ArrayRef<int64_t>":$batchesPerSubgroup,
-                     "ArrayRef<int64_t>":$outersPerBatch,
-                     "ArrayRef<int64_t>":$threadsPerOuter,
-                     "ArrayRef<int64_t>":$elementsPerThread,
+    AttrBuilder<(ins "ArrayRef<int64_t>":$subgroupTile,
+                     "ArrayRef<int64_t>":$batchTile,
+                     "ArrayRef<int64_t>":$outerTile,
+                     "ArrayRef<int64_t>":$threadTile,
+                     "ArrayRef<int64_t>":$elementTile,
                      "ArrayRef<int64_t>":$subgroupStrides,
                      "ArrayRef<int64_t>":$threadStrides)>
   ];

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/test/invalid.mlir
@@ -32,11 +32,11 @@ func.func @invalid_to_simt_vector_element_type(%simt : vector<64xf32>) -> vector
 
 // expected-error @+1 {{all fields must have the same rank as the layout}}
 #layout = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1],
-  batches_per_subgroup = [1],
-  outers_per_batch = [1],
-  threads_per_outer = [1],
-  elements_per_thread = [1],
+  subgroup_tile = [1],
+  batch_tile = [1],
+  outer_tile = [1],
+  thread_tile = [1],
+  element_tile = [1],
 
   subgroup_strides = [0, 0],
   thread_strides = [0]

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/test/roundtrip.mlir
@@ -18,22 +18,22 @@ func.func @specify_layout(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
 // -----
 
 #nested_0 = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup = [2, 4],
-  outers_per_batch = [4, 1],
-  threads_per_outer = [4, 2],
-  elements_per_thread = [1, 4],
+  subgroup_tile = [1, 1],
+  batch_tile = [2, 4],
+  outer_tile = [4, 1],
+  thread_tile = [4, 2],
+  element_tile = [1, 4],
 
   subgroup_strides = [0, 0],
   thread_strides   = [1, 4]
 >
 
 #nested_1 = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup = [4, 2],
-  outers_per_batch = [1, 4],
-  threads_per_outer = [2, 4],
-  elements_per_thread = [4, 1],
+  subgroup_tile = [1, 1],
+  batch_tile = [4, 2],
+  outer_tile = [1, 4],
+  thread_tile = [2, 4],
+  element_tile = [4, 1],
 
   subgroup_strides = [0, 0],
   thread_strides = [8, 2]
@@ -51,20 +51,20 @@ func.func @specify_nested(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
 }
 
 // CHECK: #[[$LAYOUT0:.+]] = #iree_vector_ext.nested_layout<
-// CHECK-SAME: subgroups_per_workgroup = [1, 1],
-// CHECK-SAME: batches_per_subgroup = [2, 4],
-// CHECK-SAME: outers_per_batch = [4, 1],
-// CHECK-SAME: threads_per_outer = [4, 2],
-// CHECK-SAME: elements_per_thread = [1, 4],
+// CHECK-SAME: subgroup_tile = [1, 1],
+// CHECK-SAME: batch_tile = [2, 4],
+// CHECK-SAME: outer_tile = [4, 1],
+// CHECK-SAME: thread_tile = [4, 2],
+// CHECK-SAME: element_tile = [1, 4],
 // CHECK-SAME: subgroup_strides = [0, 0],
 // CHECK-SAME: thread_strides = [1, 4]>
 
 // CHECK: #[[$LAYOUT1:.+]] = #iree_vector_ext.nested_layout<
-// CHECK-SAME: subgroups_per_workgroup = [1, 1],
-// CHECK-SAME: batches_per_subgroup = [4, 2],
-// CHECK-SAME: outers_per_batch = [1, 4],
-// CHECK-SAME: threads_per_outer = [2, 4],
-// CHECK-SAME: elements_per_thread = [4, 1],
+// CHECK-SAME: subgroup_tile = [1, 1],
+// CHECK-SAME: batch_tile = [4, 2],
+// CHECK-SAME: outer_tile = [1, 4],
+// CHECK-SAME: thread_tile = [2, 4],
+// CHECK-SAME: element_tile = [4, 1],
 // CHECK-SAME: subgroup_strides = [0, 0],
 // CHECK-SAME: thread_strides = [8, 2]>
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/test/vectorize_vector_ext_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/test/vectorize_vector_ext_ops.mlir
@@ -1,11 +1,11 @@
 // RUN: iree-opt %s -pass-pipeline='builtin.module(func.func(iree-vector-ext-vectorize-ops, iree-codegen-generic-vectorization))' | FileCheck %s
 
 #layout = #iree_vector_ext.nested_layout<
-  subgroups_per_workgroup = [1, 1],
-  batches_per_subgroup = [1, 1],
-  outers_per_batch = [1, 1],
-  threads_per_outer = [1, 1],
-  elements_per_thread = [64, 64],
+  subgroup_tile = [1, 1],
+  batch_tile = [1, 1],
+  outer_tile = [1, 1],
+  thread_tile = [1, 1],
+  element_tile = [64, 64],
 
   subgroup_strides = [0, 0],
   thread_strides   = [0, 0]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/configure_tensor_layout.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/configure_tensor_layout.mlir
@@ -36,9 +36,9 @@ func.func @matmul_96x64x16_mfma(%lhs: tensor<96x16xf16>,
   return %out : tensor<96x64xf32>
 }
 
-// CHECK-DAG: #[[$NESTED:.+]] = #iree_vector_ext.nested_layout<subgroups_per_workgroup = [1, 1], batches_per_subgroup = [3, 2], outers_per_batch = [1, 1], threads_per_outer = [32, 2], elements_per_thread = [1, 4], subgroup_strides = [0, 0], thread_strides = [1, 32]>
-// CHECK-DAG: #[[$NESTED1:.+]] = #iree_vector_ext.nested_layout<subgroups_per_workgroup = [1, 1], batches_per_subgroup = [2, 2], outers_per_batch = [1, 1], threads_per_outer = [32, 2], elements_per_thread = [1, 4], subgroup_strides = [0, 0], thread_strides = [1, 32]>
-// CHECK-DAG: #[[$NESTED2:.+]] = #iree_vector_ext.nested_layout<subgroups_per_workgroup = [1, 1], batches_per_subgroup = [3, 2], outers_per_batch = [4, 1], threads_per_outer = [2, 32], elements_per_thread = [4, 1], subgroup_strides = [0, 0], thread_strides = [32, 1]>
+// CHECK-DAG: #[[$NESTED:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [1, 1], batch_tile = [3, 2], outer_tile = [1, 1], thread_tile = [32, 2], element_tile = [1, 4], subgroup_strides = [0, 0], thread_strides = [1, 32]>
+// CHECK-DAG: #[[$NESTED1:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [1, 1], batch_tile = [2, 2], outer_tile = [1, 1], thread_tile = [32, 2], element_tile = [1, 4], subgroup_strides = [0, 0], thread_strides = [1, 32]>
+// CHECK-DAG: #[[$NESTED2:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [1, 1], batch_tile = [3, 2], outer_tile = [4, 1], thread_tile = [2, 32], element_tile = [4, 1], subgroup_strides = [0, 0], thread_strides = [32, 1]>
 
 // CHECK-LABEL: func.func @matmul_96x64x16_mfma
 
@@ -87,9 +87,9 @@ func.func @matmul_96x64x16_wmma(%lhs: tensor<96x16xf16>,
   return %out : tensor<96x64xf32>
 }
 
-// CHECK-DAG: #[[$NESTED:.+]] = #iree_vector_ext.nested_layout<subgroups_per_workgroup = [1, 1], batches_per_subgroup = [6, 1], outers_per_batch = [1, 1], threads_per_outer = [16, 1], elements_per_thread = [1, 16], subgroup_strides = [0, 0], thread_strides = [1, 0]>
-// CHECK-DAG: #[[$NESTED1:.+]] = #iree_vector_ext.nested_layout<subgroups_per_workgroup = [1, 1], batches_per_subgroup = [4, 1], outers_per_batch = [1, 1], threads_per_outer = [16, 1], elements_per_thread = [1, 16], subgroup_strides = [0, 0], thread_strides = [1, 0]>
-// CHECK-DAG: #[[$NESTED2:.+]] = #iree_vector_ext.nested_layout<subgroups_per_workgroup = [1, 1], batches_per_subgroup = [6, 4], outers_per_batch = [8, 1], threads_per_outer = [2, 16], elements_per_thread = [1, 1], subgroup_strides = [0, 0], thread_strides = [16, 1]>
+// CHECK-DAG: #[[$NESTED:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [1, 1], batch_tile = [6, 1], outer_tile = [1, 1], thread_tile = [16, 1], element_tile = [1, 16], subgroup_strides = [0, 0], thread_strides = [1, 0]>
+// CHECK-DAG: #[[$NESTED1:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [1, 1], batch_tile = [4, 1], outer_tile = [1, 1], thread_tile = [16, 1], element_tile = [1, 16], subgroup_strides = [0, 0], thread_strides = [1, 0]>
+// CHECK-DAG: #[[$NESTED2:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [1, 1], batch_tile = [6, 4], outer_tile = [8, 1], thread_tile = [2, 16], element_tile = [1, 1], subgroup_strides = [0, 0], thread_strides = [16, 1]>
 
 // CHECK-LABEL: func.func @matmul_96x64x16_wmma
 
@@ -138,9 +138,9 @@ func.func @matmul_128x64x16_multi_subgroup(%lhs: tensor<128x16xf16>,
   return %out : tensor<128x64xf32>
 }
 
-// CHECK-DAG: #[[$NESTED:.+]] = #iree_vector_ext.nested_layout<subgroups_per_workgroup = [4, 1]
-// CHECK-DAG: #[[$NESTED1:.+]] = #iree_vector_ext.nested_layout<subgroups_per_workgroup = [1, 1]
-// CHECK-DAG: #[[$NESTED2:.+]] = #iree_vector_ext.nested_layout<subgroups_per_workgroup = [4, 1]
+// CHECK-DAG: #[[$NESTED:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [4, 1]
+// CHECK-DAG: #[[$NESTED1:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [1, 1]
+// CHECK-DAG: #[[$NESTED2:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [4, 1]
 
 // CHECK-LABEL: func.func @matmul_128x64x16_multi_subgroup
 
@@ -190,9 +190,9 @@ func.func @packed_matmul_128x128x128(%lhs: tensor<8x16x16xf16>,
 }
 
 
-// CHECK-DAG: #[[$NESTED:.+]] = #iree_vector_ext.nested_layout<subgroups_per_workgroup = [2, 1, 1], batches_per_subgroup = [4, 1, 1], outers_per_batch = [1, 1, 1], threads_per_outer = [1, 16, 4], elements_per_thread = [1, 1, 4], subgroup_strides = [2, 0, 0], thread_strides = [0, 1, 16]>
-// CHECK-DAG: #[[$NESTED1:.+]] = #iree_vector_ext.nested_layout<subgroups_per_workgroup = [2, 1, 1], batches_per_subgroup = [4, 1, 1], outers_per_batch = [1, 1, 1], threads_per_outer = [1, 16, 4], elements_per_thread = [1, 1, 4], subgroup_strides = [1, 0, 0], thread_strides = [0, 1, 16]>
-// CHECK-DAG: #[[$NESTED2:.+]] = #iree_vector_ext.nested_layout<subgroups_per_workgroup = [2, 1, 2, 1], batches_per_subgroup = [4, 1, 4, 1], outers_per_batch = [1, 1, 1, 1], threads_per_outer = [1, 4, 1, 16], elements_per_thread = [1, 4, 1, 1], subgroup_strides = [2, 0, 1, 0], thread_strides = [0, 16, 0, 1]>
+// CHECK-DAG: #[[$NESTED:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [2, 1, 1], batch_tile = [4, 1, 1], outer_tile = [1, 1, 1], thread_tile = [1, 16, 4], element_tile = [1, 1, 4], subgroup_strides = [2, 0, 0], thread_strides = [0, 1, 16]>
+// CHECK-DAG: #[[$NESTED1:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [2, 1, 1], batch_tile = [4, 1, 1], outer_tile = [1, 1, 1], thread_tile = [1, 16, 4], element_tile = [1, 1, 4], subgroup_strides = [1, 0, 0], thread_strides = [0, 1, 16]>
+// CHECK-DAG: #[[$NESTED2:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [2, 1, 2, 1], batch_tile = [4, 1, 4, 1], outer_tile = [1, 1, 1, 1], thread_tile = [1, 4, 1, 16], element_tile = [1, 4, 1, 1], subgroup_strides = [2, 0, 1, 0], thread_strides = [0, 16, 0, 1]>
 // CHECK-LABEL: func.func @packed_matmul_128x128x128
 
 // CHECK-DAG: %[[LHS:.+]] = iree_vector_ext.to_layout %{{.*}} to #[[$NESTED]] {shared_memory_conversion}

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/configure_vector_layout.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/configure_vector_layout.mlir
@@ -7,8 +7,8 @@
                                               subgroup_size = 64,
       {mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_m_count = 1, subgroup_n_count = 1>}>
 
-// CHECK-DAG: #[[$NESTED:.+]] = #iree_vector_ext.nested_layout<subgroups_per_workgroup = [1, 1], batches_per_subgroup = [1, 1], outers_per_batch = [1, 1], threads_per_outer = [16, 4], elements_per_thread = [1, 8], subgroup_strides = [0, 0], thread_strides = [4, 1]>
-// CHECK-DAG: #[[$NESTED1:.+]] = #iree_vector_ext.nested_layout<subgroups_per_workgroup = [1, 1], batches_per_subgroup = [1, 1], outers_per_batch = [1, 1], threads_per_outer = [4, 16], elements_per_thread = [8, 1], subgroup_strides = [0, 0], thread_strides = [1, 4]>
+// CHECK-DAG: #[[$NESTED:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [1, 1], batch_tile = [1, 1], outer_tile = [1, 1], thread_tile = [16, 4], element_tile = [1, 8], subgroup_strides = [0, 0], thread_strides = [4, 1]>
+// CHECK-DAG: #[[$NESTED1:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [1, 1], batch_tile = [1, 1], outer_tile = [1, 1], thread_tile = [4, 16], element_tile = [8, 1], subgroup_strides = [0, 0], thread_strides = [1, 4]>
 
 // CHECK-LABEL: func.func @transfer_read_permute
 func.func @transfer_read_permute(%lhs: memref<16x256xf16, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>,
@@ -43,7 +43,7 @@ func.func @transfer_read_permute(%lhs: memref<16x256xf16, strided<[256, 1], offs
                                               subgroup_size = 32,
       {mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<WMMA_F32_16x16x16_F16>, subgroup_m_count = 1, subgroup_n_count = 4>}>
 
-// CHECK-DAG: #[[$NESTED:.+]] = #iree_vector_ext.nested_layout<subgroups_per_workgroup = [1, 1], batches_per_subgroup = [4, 1], outers_per_batch = [1, 1], threads_per_outer = [32, 4], elements_per_thread = [1, 32], subgroup_strides = [0, 0], thread_strides = [4, 1]>
+// CHECK-DAG: #[[$NESTED:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [1, 1], batch_tile = [4, 1], outer_tile = [1, 1], thread_tile = [32, 4], element_tile = [1, 32], subgroup_strides = [0, 0], thread_strides = [4, 1]>
 
 // CHECK-LABEL: func.func @dequant_anchors_on_quant_only
 func.func @dequant_anchors_on_quant_only(%quant: memref<128x128xi4, strided<[4096, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>,


### PR DESCRIPTION
Reasons for change:

1. field names are too long
2. they really are just tiles, the "per_..." doesnt add anything
3. deleting a field requires updating 3 fields instead of 1