### PR TITLE
[Codegen] Add patterns for folding away no-op slices

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
@@ -207,10 +207,9 @@ void hoistSubsetWithLoopInvariantTensor(RewriterBase &rewriter,
 }
 
 namespace {
-class CastLikeExtractSliceOpFolder final
-    : public OpRewritePattern<tensor::ExtractSliceOp> {
-public:
-  using OpRewritePattern<tensor::ExtractSliceOp>::OpRewritePattern;
+struct CastLikeExtractSliceOpFolder final
+    : OpRewritePattern<tensor::ExtractSliceOp> {
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(tensor::ExtractSliceOp sliceOp,
                                 PatternRewriter &rewriter) const override {
@@ -223,10 +222,9 @@ public:
   }
 };
 
-class CastLikeInsertSliceOpFolder final
-    : public OpRewritePattern<tensor::InsertSliceOp> {
-public:
-  using OpRewritePattern<tensor::InsertSliceOp>::OpRewritePattern;
+struct CastLikeInsertSliceOpFolder final
+    : OpRewritePattern<tensor::InsertSliceOp> {
+  using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(tensor::InsertSliceOp sliceOp,
                                 PatternRewriter &rewriter) const override {

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
@@ -8,6 +8,8 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/Transforms/Hoisting.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Tensor/Utils/Utils.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Dialect/Vector/Transforms/VectorTransforms.h"
 #include "mlir/Interfaces/SubsetOpInterface.h"
@@ -29,6 +31,10 @@ namespace {
 class OptimizeTensorInsertExtractSlicesPass final
     : public impl::OptimizeTensorInsertExtractSlicesPassBase<
           OptimizeTensorInsertExtractSlicesPass> {
+  using impl::OptimizeTensorInsertExtractSlicesPassBase<
+      OptimizeTensorInsertExtractSlicesPass>::
+      OptimizeTensorInsertExtractSlicesPassBase;
+
 public:
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<scf::SCFDialect, vector::VectorDialect>();
@@ -200,6 +206,40 @@ void hoistSubsetWithLoopInvariantTensor(RewriterBase &rewriter,
   }
 }
 
+namespace {
+class CastLikeExtractSliceOpFolder final
+    : public OpRewritePattern<tensor::ExtractSliceOp> {
+public:
+  using OpRewritePattern<tensor::ExtractSliceOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tensor::ExtractSliceOp sliceOp,
+                                PatternRewriter &rewriter) const override {
+    if (!tensor::isCastLikeExtractSliceOp(sliceOp) ||
+        sliceOp.getSourceType() != sliceOp.getResultType()) {
+      return failure();
+    }
+    rewriter.replaceOp(sliceOp, sliceOp.getSource());
+    return success();
+  }
+};
+
+class CastLikeInsertSliceOpFolder final
+    : public OpRewritePattern<tensor::InsertSliceOp> {
+public:
+  using OpRewritePattern<tensor::InsertSliceOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tensor::InsertSliceOp sliceOp,
+                                PatternRewriter &rewriter) const override {
+    if (!tensor::isCastLikeInsertSliceOp(sliceOp) ||
+        sliceOp.getSourceType() != sliceOp.getResultType()) {
+      return failure();
+    }
+    rewriter.replaceOp(sliceOp, sliceOp.getSource());
+    return success();
+  }
+};
+} // namespace
+
 void OptimizeTensorInsertExtractSlicesPass::runOnOperation() {
   auto funcOp = getOperation();
   linalg::hoistRedundantVectorTransfers(cast<func::FuncOp>(funcOp));
@@ -223,6 +263,10 @@ void OptimizeTensorInsertExtractSlicesPass::runOnOperation() {
   populateVectorTransferTensorSliceTransforms(patterns);
   scf::ForOp::getCanonicalizationPatterns(patterns, context);
   vector::TransferWriteOp::getCanonicalizationPatterns(patterns, context);
+  if (foldIdentitySlices) {
+    patterns.add<CastLikeExtractSliceOpFolder>(context);
+    patterns.add<CastLikeInsertSliceOpFolder>(context);
+  }
   if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
     return signalPassFailure();
   }

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -301,6 +301,10 @@ def OptimizeTensorInsertExtractSlicesPass
                     "mlir::FunctionOpInterface"> {
   let summary = "Optimize tensor.insert_slice/tensor.extract_slice operations "
                 "(e.g. hoist and fold)";
+  let options = [
+    Option<"foldIdentitySlices", "fold-identity-slices", "bool", "false",
+           "Enable folding of identity tensor.*_slice ops.">
+  ];
 }
 
 def HoistUnrolledVectorExtractInsertSlicePass :

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -395,6 +395,12 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager) {
   // hoisting and fusion pass, as well as a lack of a fallback distribution
   // pass.
   funcPassManager.addPass(createLoopInvariantCodeMotionPass());
+  {
+    OptimizeTensorInsertExtractSlicesPassOptions options;
+    options.foldIdentitySlices = true;
+    funcPassManager.addPass(
+        createOptimizeTensorInsertExtractSlicesPass(options));
+  }
 
   // Step 5. Greedily fuse parallel loops and hoist from serial loops.
   funcPassManager.addPass(IREE::GPU::createFuseAndHoistParallelLoopsPass());


### PR DESCRIPTION
Adds a pattern to fold away no-op slices to
OptimizeTensorInsertExtractSlices that calls an upstream utility that
uses the ValueBoundsInterface to determine whether the sizes of
a `tensor.extract_slice`/`tensor.insert_slice` are no-ops.

This folding is a pass option because some other pipelines are sensitive
to insert/extract_slice structure.

Depends on #18418