### PR TITLE
Drop Docker and remote ccache usage from publish_website.yml.

### DIFF
--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -57,6 +57,10 @@ jobs:
           ./build_tools/scripts/generate_release_index.py \
             --repo="${GITHUB_REPOSITORY}" \
             --output=docs/website/docs/pip-release-links.html
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.job }}
       - name: Building documentation files
         run: ./docs/website/generate_extra_files.sh
       # - name: Setting git config

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -63,10 +63,10 @@ jobs:
           key: ${{ github.job }}
       - name: Building documentation files
         run: ./docs/website/generate_extra_files.sh
-      # - name: Setting git config
-      #   run: |
-      #     git config --local user.email "iree-github-actions-bot@google.com"
-      #     git config --local user.name "Website Publish Action"
-      # - name: Deploying to gh-pages
-      #   working-directory: docs/website
-      #   run: mkdocs gh-deploy
+      - name: Setting git config
+        run: |
+          git config --local user.email "iree-github-actions-bot@google.com"
+          git config --local user.name "Website Publish Action"
+      - name: Deploying to gh-pages
+        working-directory: docs/website
+        run: mkdocs gh-deploy

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -44,34 +44,25 @@ jobs:
         with:
           python-version: 3.x
           cache: "pip"
-      - id: "gcp-auth"
-        name: "Authenticating to Google Cloud"
-        uses: "google-github-actions/auth@v1"
-        with:
-          token_format: "access_token"
-          credentials_json: "${{ secrets.IREE_OSS_GITHUB_RUNNER_BASIC_TRUST_SERVICE_ACCOUNT_KEY }}"
-          create_credentials_file: false
       - name: Installing dependencies
         run: |
           pip install -r docs/website/requirements.txt
           pip install requests
+          sudo apt update
+          sudo apt install -y ninja-build
+          echo "CC=clang" >> $GITHUB_ENV
+          echo "CXX=clang++" >> $GITHUB_ENV
       - name: Generating release index
         run: |
           ./build_tools/scripts/generate_release_index.py \
             --repo="${GITHUB_REPOSITORY}" \
             --output=docs/website/docs/pip-release-links.html
       - name: Building documentation files
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-            --env "IREE_CCACHE_GCP_TOKEN=${{ steps.gcp-auth.outputs.access_token }}" \
-            --env "IREE_WRITE_REMOTE_CCACHE=1" \
-            --env "CCACHE_NAMESPACE=gcr.io/iree-oss/base@sha256:dc314b4fe30fc1315742512891357bffed4d1b62ffcb46258b1e0761c737b446" \
-            gcr.io/iree-oss/base@sha256:dc314b4fe30fc1315742512891357bffed4d1b62ffcb46258b1e0761c737b446 \
-            ./docs/website/generate_extra_files.sh
-      - name: Setting git config
-        run: |
-          git config --local user.email "iree-github-actions-bot@google.com"
-          git config --local user.name "Website Publish Action"
-      - name: Deploying to gh-pages
-        working-directory: docs/website
-        run: mkdocs gh-deploy
+        run: ./docs/website/generate_extra_files.sh
+      # - name: Setting git config
+      #   run: |
+      #     git config --local user.email "iree-github-actions-bot@google.com"
+      #     git config --local user.name "Website Publish Action"
+      # - name: Deploying to gh-pages
+      #   working-directory: docs/website
+      #   run: mkdocs gh-deploy


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree/issues/15332 - one less workflow needing the `gcr.io/iree-oss/base` dockerfile and a ccache storage on GCP.

Tested on my fork:
* Cold cache (5m30s): https://github.com/ScottTodd/iree/actions/runs/10690774251/job/29635889592
* Warm cache (3m30s): https://github.com/ScottTodd/iree/actions/runs/10690871405/job/29636198158

skip-ci: no impact on other workflows