### PR TITLE
Set CC and CXX environment variables using 'env' in workflows.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,14 +156,12 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       BUILD_DIR: build-runtime
+      CC: clang
+      CXX: clang++
     steps:
       - uses: actions/checkout@v4.1.7
       - name: Install requirements
-        run: |
-          sudo apt update
-          sudo apt install -y ninja-build
-          echo "CC=clang" >> $GITHUB_ENV
-          echo "CXX=clang++" >> $GITHUB_ENV
+        run: sudo apt update && sudo apt install -y ninja-build
       - name: Checkout runtime submodules
         run: bash ./build_tools/scripts/git/update_runtime_submodules.sh
       - name: ccache
@@ -200,15 +198,13 @@ jobs:
           - provider: console
     env:
       BUILD_DIR: build-tracing
+      CC: clang
+      CXX: clang++
       TRACING_PROVIDER: ${{ matrix.provider }}
     steps:
       - uses: actions/checkout@v4.1.7
       - name: Install requirements
-        run: |
-          sudo apt update
-          sudo apt install -y ninja-build
-          echo "CC=clang" >> $GITHUB_ENV
-          echo "CXX=clang++" >> $GITHUB_ENV
+        run: sudo apt update && sudo apt install -y ninja-build
       - name: Checkout runtime submodules
         run: bash ./build_tools/scripts/git/update_runtime_submodules.sh
       - name: ccache

--- a/.github/workflows/pkgci_test_amd_mi250.yml
+++ b/.github/workflows/pkgci_test_amd_mi250.yml
@@ -24,6 +24,8 @@ jobs:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
       BUILD_DIR: build-tests
       VENV_DIR: ${{ github.workspace }}/.venv
+      CC: clang
+      CXX: clang++
       IREE_CPU_DISABLE: 1
       IREE_VULKAN_DISABLE: 1
       IREE_CUDA_DISABLE: 1
@@ -49,10 +51,6 @@ jobs:
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
             --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
             --fetch-gh-workflow=${{ inputs.artifact_run_id }}
-      - name: Configure build toolchain
-        run: |
-          echo "CC=clang" >> $GITHUB_ENV
-          echo "CXX=clang++" >> $GITHUB_ENV
 
       - name: Build tests
         run: ./build_tools/pkgci/build_tests_using_package.sh ${VENV_DIR}/bin

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -24,6 +24,8 @@ jobs:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
       BUILD_DIR: build-tests
       VENV_DIR: ${{ github.workspace }}/.venv
+      CC: clang
+      CXX: clang++
       IREE_CPU_DISABLE: 1
       IREE_VULKAN_DISABLE: 1
       IREE_CUDA_DISABLE: 1
@@ -49,10 +51,6 @@ jobs:
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
             --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
             --fetch-gh-workflow=${{ inputs.artifact_run_id }}
-      - name: Configure build toolchain
-        run: |
-          echo "CC=clang" >> $GITHUB_ENV
-          echo "CXX=clang++" >> $GITHUB_ENV
 
       - name: Build tests
         run: ./build_tools/pkgci/build_tests_using_package.sh ${VENV_DIR}/bin

--- a/.github/workflows/pkgci_test_android.yml
+++ b/.github/workflows/pkgci_test_android.yml
@@ -37,6 +37,8 @@ jobs:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
       VENV_DIR: ${{ github.workspace }}/.venv
       IREE_TARGET_BUILD_DIR: build-android-arm_64
+      CC: clang
+      CXX: clang++
     steps:
       # General setup.
       - name: "Checking out repository"
@@ -62,11 +64,7 @@ jobs:
             --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
             --fetch-gh-workflow=${{ inputs.artifact_run_id }}
       - name: Install build dependencies
-        run: |
-          sudo apt update
-          sudo apt install -y ninja-build
-          echo "CC=clang" >> $GITHUB_ENV
-          echo "CXX=clang++" >> $GITHUB_ENV
+        run: sudo apt update && sudo apt install -y ninja-build
 
       - uses: nttld/setup-ndk@v1
         with:

--- a/.github/workflows/pkgci_test_nvidia_t4.yml
+++ b/.github/workflows/pkgci_test_nvidia_t4.yml
@@ -29,6 +29,8 @@ jobs:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
       BUILD_DIR: build-tests
       VENV_DIR: ${{ github.workspace }}/.venv
+      CC: clang
+      CXX: clang++
       IREE_CPU_DISABLE: 1
       IREE_VULKAN_DISABLE: 0
       IREE_CUDA_DISABLE: 0
@@ -61,8 +63,6 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y cmake clang ninja-build libstdc++-12-dev
-          echo "CC=clang" >> $GITHUB_ENV
-          echo "CXX=clang++" >> $GITHUB_ENV
 
       - name: Build tests
         run: ./build_tools/pkgci/build_tests_using_package.sh ${VENV_DIR}/bin

--- a/.github/workflows/pkgci_test_riscv64.yml
+++ b/.github/workflows/pkgci_test_riscv64.yml
@@ -36,6 +36,8 @@ jobs:
     env:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
       VENV_DIR: ${{ github.workspace }}/.venv
+      CC: clang
+      CXX: clang++
       BOOTSTRAP_WORK_DIR: ${{ github.workspace }}/.bootstrap
       RISCV_RV64_LINUX_TOOLCHAIN_ROOT: ${{ github.workspace }}/riscv/toolchain
       QEMU_PATH_PREFIX: ${{ github.workspace }}/riscv/qemu
@@ -59,11 +61,7 @@ jobs:
           name: linux_x86_64_release_packages
           path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
       - name: Install build dependencies
-        run: |
-          sudo apt update
-          sudo apt install -y ninja-build
-          echo "CC=clang" >> $GITHUB_ENV
-          echo "CXX=clang++" >> $GITHUB_ENV
+        run: sudo apt update && sudo apt install -y ninja-build
       - name: Setup base venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -30,6 +30,9 @@ jobs:
   publish_website:
     # Note: a clean build of `iree-tblgen` takes ~5 minutes on standard runners.
     runs-on: ubuntu-20.04
+    env:
+      CC: clang
+      CXX: clang++
     steps:
       - name: Checkout out repository
         uses: actions/checkout@v4.1.7
@@ -50,8 +53,6 @@ jobs:
           pip install requests
           sudo apt update
           sudo apt install -y ninja-build
-          echo "CC=clang" >> $GITHUB_ENV
-          echo "CXX=clang++" >> $GITHUB_ENV
       - name: Generating release index
         run: |
           ./build_tools/scripts/generate_release_index.py \

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -41,17 +41,16 @@ jobs:
 
   samples:
     runs-on: ubuntu-20.04
+    env:
+      CC: clang
+      CXX: clang++
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@v4.1.7
       - name: "Checking out runtime submodules"
         run: ./build_tools/scripts/git/update_runtime_submodules.sh
       - name: "Installing build dependencies"
-        run: |
-          sudo apt update
-          sudo apt install -y ninja-build
-          echo "CC=clang" >> $GITHUB_ENV
-          echo "CXX=clang++" >> $GITHUB_ENV
+        run: sudo apt update && sudo apt install -y ninja-build
       - name: "Setting up Python"
         uses: actions/setup-python@v5.1.0
         with:
@@ -63,6 +62,8 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       VENV_DIR: ${{ github.workspace }}/.venv
+      CC: clang
+      CXX: clang++
     defaults:
       run:
         shell: bash
@@ -74,11 +75,7 @@ jobs:
       - name: "Check out runtime submodules"
         run: ./build_tools/scripts/git/update_runtime_submodules.sh
       - name: "Installing build dependencies"
-        run: |
-          sudo apt update
-          sudo apt install -y ninja-build
-          echo "CC=clang" >> $GITHUB_ENV
-          echo "CXX=clang++" >> $GITHUB_ENV
+        run: sudo apt update && sudo apt install -y ninja-build
       - uses: actions/setup-python@v5.1.0
         with:
           python-version: "3.11"


### PR DESCRIPTION
Follow-up to https://github.com/iree-org/iree/pull/18422#discussion_r1742752372 and https://github.com/iree-org/iree/pull/18421#discussion_r1742758455.

This style is more compact, but it does remove some context that could be useful - that the CC/CXX environment variables are for the build toolchain and are related to CMake and Ninja.

The 'runtime' workflow is cross platform and also sets this conditionally: https://github.com/iree-org/iree/blob/1124be8025995b64804e9f02b62a0354b25dfb2b/.github/workflows/ci.yml#L112-L124 See https://github.com/iree-org/iree-template-runtime-cmake/blob/main/.github/workflows/build-and-test.yml for a more comprehensive example where we also branch on gcc and clang in the same matrix.