### PR TITLE
[Codegen][ROCM] Update pass signature in ROCDL pipeline

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -125,6 +125,10 @@ struct ConvertToROCDLPass final
       // rocdl intrinsics (e.g. fp8 conversions).
       StringRef chipset = getGPUTargetAttr(m).getArch();
       FailureOr<amdgpu::Chipset> maybeChipset = amdgpu::Chipset::parse(chipset);
+      if (failed(maybeChipset)) {
+        m.emitOpError() << "Invalid chipset name: " << chipset;
+        return signalPassFailure();
+      }
       arith::populateArithToAMDGPUConversionPatterns(
           patterns, /*convertFP8Arithmetic=*/true, /*saturateFP8Truncf=*/false,
           /*allowPackedF16Rtz=*/false, /*chipset=*/*maybeChipset);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -123,8 +123,11 @@ struct ConvertToROCDLPass final
       RewritePatternSet patterns(&getContext());
       // These patterns only convert a subset of arith that target specific
       // rocdl intrinsics (e.g. fp8 conversions).
+      StringRef chipset = getGPUTargetAttr(m).getArch();
+      FailureOr<amdgpu::Chipset> maybeChipset = amdgpu::Chipset::parse(chipset);
       arith::populateArithToAMDGPUConversionPatterns(
-          patterns, /*saturateFP8Truncf=*/false);
+          patterns, /*convertFP8Arithmetic=*/true, /*saturateFP8Truncf=*/false,
+          /*allowPackedF16Rtz=*/false, /*chipset=*/*maybeChipset);
       populateConvertGPUToAMDGPUPatterns(patterns);
       populateConvertSharedMemoryAllocOps(patterns);
       populateDropSharedMemoryDeallocOpPatterns(patterns);


### PR DESCRIPTION
Recent LLVM integrate (https://github.com/iree-org/iree/pull/18384) carried a couple of reverts owing to various failures. This patch drops one of the reverts (https://github.com/iree-org/llvm-project/commit/f6935c777f675490ecb2327887dbac5c7d7fce1f) fixed by updating the function signature in ROCDL pipeline.