### PR TITLE
Enable ccache in riscv build script and workflow.

### DIFF
--- a/build_tools/cmake/build_riscv.sh
+++ b/build_tools/cmake/build_riscv.sh
@@ -27,6 +27,7 @@ RISCV_COMPILER_FLAGS="${RISCV_COMPILER_FLAGS:--O3}"
 IREE_HOST_BIN_DIR="$(realpath ${IREE_HOST_BIN_DIR})"
 
 source build_tools/cmake/setup_build.sh
+source build_tools/cmake/setup_ccache.sh
 
 RISCV_PLATFORM_ARCH="${RISCV_PLATFORM}-${RISCV_ARCH}"
 echo "Build riscv target with the config of ${RISCV_PLATFORM_ARCH}"


### PR DESCRIPTION
The workflow tries to use ccache, but the CMake command needs it set.

Sample logs:
* Without this change: https://github.com/iree-org/iree/actions/runs/10705800906/job/29682537880
* With this change: https://github.com/iree-org/iree/actions/runs/10706762701/job/29685692151?pr=18429#step:20:4

ci-exactly: build_packages,test_riscv64