### PR TITLE
Simplify and generalize GPU data-tiled encodings

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_materialize_encoding.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_materialize_encoding.mlir
@@ -26,20 +26,13 @@ func.func @set_encoding_LHS() {
 }
 
 // CHECK-LABEL: func.func @set_encoding_LHS
-// CHECK:         %[[EMPTY:.*]] = tensor.empty() : tensor<16x129x16x4xf32>
+// CHECK:         %[[EMPTY:.*]] = tensor.empty() : tensor<16x129x4x16xf32>
 // CHECK:         %[[PACK:.*]] = tensor.pack %{{.+}} padding_value(%{{.+}} : f32)
 // CHECK-SAME:      outer_dims_perm = [0, 1]
-// CHECK-SAME:      inner_dims_pos = [0, 1]
-// CHECK-SAME:      inner_tiles = [16, 4] into %[[EMPTY]]
-// CHECK-SAME:      : tensor<255x513xf32> -> tensor<16x129x16x4xf32>
-// CHECK:         %[[EXPAND_LHS:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME:      output_shape [16, 129, 16, 1, 4, 1] : tensor<16x129x16x4xf32> into tensor<16x129x16x1x4x1xf32>
-// CHECK:         %[[EMPTY_LHS2:.*]] = tensor.empty() : tensor<16x129x4x16x1x1xf32>
-// CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SASME:     ins(%[[EXPAND_LHS]]
-// CHECK-SAME:      outs(%[[EMPTY_LHS2]]
-// CHECK-SAME:      permutation = [0, 1, 4, 2, 5, 3]
-// CHECK:         flow.dispatch.tensor.store %[[TRANSPOSE]]
+// CHECK-SAME:      inner_dims_pos = [1, 0]
+// CHECK-SAME:      inner_tiles = [4, 16] into %[[EMPTY]]
+// CHECK-SAME:      : tensor<255x513xf32> -> tensor<16x129x4x16xf32>
+// CHECK:         flow.dispatch.tensor.store %[[PACK]]
 
 // -----
 
@@ -63,20 +56,13 @@ func.func @set_encoding_RHS() {
 }
 
 // CHECK-LABEL: func.func @set_encoding_RHS
-// CHECK:         %[[EMPTY:.*]] = tensor.empty() : tensor<33x64x16x4xf32>
+// CHECK:         %[[EMPTY:.*]] = tensor.empty() : tensor<33x64x4x16xf32>
 // CHECK:         %[[PACK:.*]] = tensor.pack %{{.+}} padding_value(%{{.+}} : f32)
 // CHECK-SAME:      outer_dims_perm = [1, 0]
-// CHECK-SAME:      inner_dims_pos = [1, 0]
-// CHECK-SAME:      inner_tiles = [16, 4] into %[[EMPTY]]
-// CHECK-SAME:      : tensor<255x513xf32> -> tensor<33x64x16x4xf32>
-// CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK-SAME:      output_shape [33, 64, 16, 1, 4, 1] : tensor<33x64x16x4xf32> into tensor<33x64x16x1x4x1xf32>
-// CHECK:         %[[EMPTY2:.*]] = tensor.empty() : tensor<33x64x4x16x1x1xf32>
-// CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
-// CHECK-SAME:      ins(%[[EXPAND]]
-// CHECK-SAME:      outs(%[[EMPTY2]]
-// CHECK-SAME:      permutation = [0, 1, 4, 2, 5, 3]
-// CHECK:         flow.dispatch.tensor.store %[[TRANSPOSE]]
+// CHECK-SAME:      inner_dims_pos = [0, 1]
+// CHECK-SAME:      inner_tiles = [4, 16] into %[[EMPTY]]
+// CHECK-SAME:      : tensor<255x513xf32> -> tensor<33x64x4x16xf32>
+// CHECK:         flow.dispatch.tensor.store %[[PACK]]
 
 // -----
 
@@ -107,11 +93,11 @@ func.func @set_encoding_ACC() {
 // CHECK-SAME:      inner_tiles = [16, 16] into %[[EMPTY]]
 // CHECK-SAME:      : tensor<255x513xf32> -> tensor<16x33x16x16xf32>
 // CHECK:         %[[EXPAND:.*]] = tensor.expand_shape %[[PACK]]
-// CHECK:         %[[EMPTY2:.*]] = tensor.empty() : tensor<16x33x4x16x4x1xf32>
+// CHECK:         %[[EMPTY2:.*]] = tensor.empty() : tensor<16x33x4x16x4xf32>
 // CHECK:         %[[TRANSPOSE:.*]] = linalg.transpose
 // CHECK-SAME:      ins(%[[EXPAND]]
 // CHECK-SAME:      outs(%[[EMPTY2]]
-// CHECK-SAME:      permutation = [0, 1, 2, 4, 3, 5]
+// CHECK-SAME:      permutation = [0, 1, 2, 4, 3]
 // CHECK:         flow.dispatch.tensor.store %[[TRANSPOSE]]
 
 // -----
@@ -136,14 +122,9 @@ func.func @unset_encoding_LHS() {
 }
 
 // CHECK-LABEL: func.func @unset_encoding_LHS() {
-// CHECK:         %[[UNSET_EMPTY:.*]] = tensor.empty() : tensor<16x129x16x1x4x1xf32>
-// CHECK:         %[[UNSET_TRANSPOSE:.*]] = linalg.transpose ins(%{{.+}} : tensor<16x129x4x16x1x1xf32>)
-// CHECK-SAME:      outs(%[[UNSET_EMPTY]] : tensor<16x129x16x1x4x1xf32>)
-// CHECK:         %[[UNSET_COLLAPSE:.*]] = tensor.collapse_shape %[[UNSET_TRANSPOSE]]
-// CHECK-SAME:      tensor<16x129x16x1x4x1xf32> into tensor<16x129x16x4xf32>
 // CHECK:         %[[UNSET_EMPTY:.*]] = tensor.empty() : tensor<255x513xf32>
-// CHECK:         tensor.unpack %[[UNSET_COLLAPSE:.*]] outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [16, 4]
-// CHECK-SAME:       tensor<16x129x16x4xf32> -> tensor<255x513xf32>
+// CHECK:         tensor.unpack {{.+}} outer_dims_perm = [0, 1] inner_dims_pos = [1, 0] inner_tiles = [4, 16]
+// CHECK-SAME:       tensor<16x129x4x16xf32> -> tensor<255x513xf32>
 
 // -----
 
@@ -167,14 +148,9 @@ func.func @unset_encoding_RHS() {
 }
 
 // CHECK-LABEL: func.func @unset_encoding_RHS() {
-// CHECK:         %[[UNSET_EMPTY:.*]] = tensor.empty() : tensor<33x64x16x1x4x1xf32>
-// CHECK:         %[[UNSET_TRANSPOSE:.*]] = linalg.transpose ins(%{{.+}} : tensor<33x64x4x16x1x1xf32>)
-// CHECK-SAME:      outs(%[[UNSET_EMPTY]] : tensor<33x64x16x1x4x1xf32>) permutation = [0, 1, 3, 5, 2, 4]
-// CHECK:         %[[UNSET_COLLAPSE:.*]] = tensor.collapse_shape %[[UNSET_TRANSPOSE]]
-// CHECK-SAME:      tensor<33x64x16x1x4x1xf32> into tensor<33x64x16x4xf32>
 // CHECK:         %[[UNSET_EMPTY:.*]] = tensor.empty() : tensor<255x513xf32>
-// CHECK:         tensor.unpack %[[UNSET_COLLAPSE:.*]] outer_dims_perm = [1, 0] inner_dims_pos = [1, 0] inner_tiles = [16, 4]
-// CHECK-SAME:      tensor<33x64x16x4xf32> -> tensor<255x513xf32>
+// CHECK:         tensor.unpack {{.+}} outer_dims_perm = [1, 0] inner_dims_pos = [0, 1] inner_tiles = [4, 16]
+// CHECK-SAME:      tensor<33x64x4x16xf32> -> tensor<255x513xf32>
 
 // -----
 
@@ -198,11 +174,11 @@ func.func @unset_encoding_ACC() {
 }
 
 // CHECK-LABEL: func.func @unset_encoding_ACC() {
-// CHECK:         %[[UNSET_EMPTY:.*]] = tensor.empty() : tensor<16x33x4x4x16x1xf32>
-// CHECK:         %[[UNSET_TRANSPOSE:.*]] = linalg.transpose ins(%{{.+}} : tensor<16x33x4x16x4x1xf32>)
-// CHECK-SAME:       outs(%[[UNSET_EMPTY]] : tensor<16x33x4x4x16x1xf32>) permutation = [0, 1, 2, 4, 3, 5]
+// CHECK:         %[[UNSET_EMPTY:.*]] = tensor.empty() : tensor<16x33x4x4x16xf32>
+// CHECK:         %[[UNSET_TRANSPOSE:.*]] = linalg.transpose ins(%{{.+}} : tensor<16x33x4x16x4xf32>)
+// CHECK-SAME:       outs(%[[UNSET_EMPTY]] : tensor<16x33x4x4x16xf32>) permutation = [0, 1, 2, 4, 3]
 // CHECK:         %[[UNSET_COLLAPSE:.*]] = tensor.collapse_shape %[[UNSET_TRANSPOSE]]
-// CHECK-SAME:      tensor<16x33x4x4x16x1xf32> into tensor<16x33x16x16xf32>
+// CHECK-SAME:      tensor<16x33x4x4x16xf32> into tensor<16x33x16x16xf32>
 // CHECK:         %[[UNSET_EMPTY:.*]] = tensor.empty() : tensor<255x513xf32>
 // CHECK:         tensor.unpack %[[UNSET_COLLAPSE:.*]] outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [16, 16] into
 // CHECK-SAME:      tensor<16x33x16x16xf32> -> tensor<255x513xf32>
@@ -259,11 +235,11 @@ func.func @matmul_lowering_f32f32f32() {
 // CHECK-DAG:   %[[LHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(0)
 // CHECK-DAG:   %[[RHS_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(1)
 // CHECK-DAG:   %[[ACC_BINDING:.+]] = hal.interface.binding.subspan {{.+}} binding(2)
-// CHECK-DAG:   %[[LHS:.+]] = flow.dispatch.tensor.load %[[LHS_BINDING]]{{.+}} -> tensor<?x?x4x16x1x1xf32>
-// CHECK-DAG:   %[[RHS:.+]] = flow.dispatch.tensor.load %[[RHS_BINDING]]{{.+}} -> tensor<?x?x4x16x1x1xf32>
-// CHECK-DAG:   %[[ACC:.+]] = flow.dispatch.tensor.load %[[ACC_BINDING]]{{.+}} -> tensor<?x?x4x16x4x1xf32>
+// CHECK-DAG:   %[[LHS:.+]] = flow.dispatch.tensor.load %[[LHS_BINDING]]{{.+}} -> tensor<?x?x4x16xf32>
+// CHECK-DAG:   %[[RHS:.+]] = flow.dispatch.tensor.load %[[RHS_BINDING]]{{.+}} -> tensor<?x?x4x16xf32>
+// CHECK-DAG:   %[[ACC:.+]] = flow.dispatch.tensor.load %[[ACC_BINDING]]{{.+}} -> tensor<?x?x4x16x4xf32>
 // CHECK:       %[[MMA:.+]] = iree_gpu.multi_mma %[[LHS]], %[[RHS]], %[[ACC]]
 // CHECK-SAME:    indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]],
 // CHECK-SAME:    iterator_types = [#iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<reduction>]
-// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<MFMA_F32_16x16x4_F32>
+// CHECK-SAME:    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x4_F32, unroll_m = 1, unroll_n = 1, unroll_k = 1>
 // CHECK:       flow.dispatch.tensor.store %[[MMA]], %[[ACC_BINDING]]

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -856,35 +856,6 @@ LogicalResult MMAAttr::materializeOperandConcreteShape(
 // DataTiledMMA Attributes
 //===----------------------------------------------------------------------===//
 
-DataTiledMMAAttr DataTiledMMAAttr::get(MLIRContext *context,
-                                       MMAIntrinsic type) {
-  return Base::get(context, MMAIntrinsicAttr::get(context, type));
-}
-
-Attribute DataTiledMMAAttr::parse(AsmParser &p, Type type) {
-  if (failed(p.parseLess()))
-    return {};
-
-  FailureOr<MMAIntrinsicAttr> mmaIntrinsic =
-      FieldParser<MMAIntrinsicAttr>::parse(p);
-  if (failed(mmaIntrinsic)) {
-    p.emitError(p.getCurrentLocation(), "failed to parse mfma type identifier");
-    return {};
-  }
-
-  if (failed(p.parseGreater()))
-    return {};
-
-  return get(p.getContext(), mmaIntrinsic->getValue());
-}
-
-void DataTiledMMAAttr::print(AsmPrinter &p) const {
-  auto &os = p.getStream();
-  os << "<";
-  os << stringifyMMAIntrinsic(getIntrinsic().getValue());
-  os << ">";
-}
-
 std::tuple<Type, Type, Type> DataTiledMMAAttr::getABCElementTypes() const {
   MLIRContext *ctx = getContext();
   auto opaqueLayout = getOpaqueMFMALayout(ctx, getIntrinsic().getValue());
@@ -899,8 +870,8 @@ std::tuple<int64_t, int64_t, int64_t> DataTiledMMAAttr::getMNKShape() const {
 
 std::tuple<VectorType, VectorType, VectorType>
 DataTiledMMAAttr::getABCVectorTypes() const {
-  // TODO: Implement the interface method.
-  return std::make_tuple(VectorType{}, VectorType{}, VectorType{});
+  return MMAAttr::get(getContext(), getIntrinsic().getValue())
+      .getABCVectorTypes();
 }
 
 int64_t DataTiledMMAAttr::getSubgroupSize() const {
@@ -920,34 +891,6 @@ int64_t DataTiledMMAAttr::getSubgroupSize() const {
   }
   // This should not happen but just to make GCC happy.
   return 0;
-}
-
-std::tuple<int64_t, int64_t, int64_t>
-DataTiledMMAAttr::getUnrollingFactor(ArrayRef<int64_t> lhsShape,
-                                     ArrayRef<int64_t> rhsShape,
-                                     ArrayRef<int64_t> accShape) {
-  auto multiplyAcc = [](ArrayRef<int64_t> shape) {
-    return std::accumulate(shape.begin(), shape.end(), 1,
-                           std::multiplies<int64_t>());
-  };
-  int64_t lhsInnerElementCount = multiplyAcc(lhsShape);
-  int64_t rhsInnerElementCount = multiplyAcc(rhsShape);
-  int64_t accInnerElementCount = multiplyAcc(accShape);
-
-  auto [m, n, k] = getMNKShape();
-  int64_t M0K0 = lhsInnerElementCount / m / k; // (M0M1K0K1) / M1 / K1 = M0K0
-  int64_t N0K0 = rhsInnerElementCount / n / k; // (N0N1K0K1) / N1 / K1 = N0K0
-  int64_t M0N0 = accInnerElementCount / m / n; // (M0M1N0N1) / M1 / N1 = M0N0
-
-  // Something goes wrong, returns {0, 0, 0} instead;
-  if (!M0K0 || !N0K0 || !M0N0) {
-    return {0, 0, 0};
-  }
-
-  int mUnrollFactor = std::sqrt(M0K0 * M0N0 / N0K0);
-  int nUnrollFactor = std::sqrt(M0N0 * N0K0 / M0K0);
-  int kUnrollFactor = std::sqrt(M0K0 * N0K0 / M0N0);
-  return {mUnrollFactor, nUnrollFactor, kUnrollFactor};
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -260,24 +260,14 @@ def IREEGPU_DataTiledMMAAttr :
     additional information can be added to `parameters`.
   }];
 
-  let hasCustomAssemblyFormat = 1;
-
-  let skipDefaultBuilders = 1;
-  let builders = [
-    AttrBuilder<(ins "MMAIntrinsic":$intrinsic)>
-  ];
+  let assemblyFormat = "`<` struct(params) `>`";
 
   let parameters = (ins
-    IREEGPU_MMAIntrinsicAttr:$intrinsic
+    "::mlir::iree_compiler::IREE::GPU::MMAIntrinsicAttr":$intrinsic,
+    "int64_t":$unroll_m,
+    "int64_t":$unroll_n,
+    "int64_t":$unroll_k
   );
-
-  let extraClassDeclaration = [{
-    /// Infers the unrolling factor for (M, N, K) dimensions from the inner
-    /// tile shapes after tile swizzling. If the provided shapes are not valid,
-    /// returns {0, 0, 0}.
-    std::tuple<int64_t, int64_t, int64_t> getUnrollingFactor(ArrayRef<int64_t>
-        lhsShape, ArrayRef<int64_t> rhsShape, ArrayRef<int64_t> accShape);
-  }];
 }
 
 def IREEGPU_MMAOpsArrayAttr : ArrayOfAttr<

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.cpp
@@ -212,9 +212,9 @@ LogicalResult MultiMmaOp::verify() {
   // land this part to main branch.
   if (auto dataTiledMmaAttr =
           dyn_cast<IREE::GPU::DataTiledMMAAttr>(getKind())) {
-    auto [mUnrollFactor, nUnrollFactor, kUnrollFactor] =
-        dataTiledMmaAttr.getUnrollingFactor(
-            getLhsInnerShape(), getRhsInnerShape(), getAccInnerShape());
+    int mUnrollFactor = dataTiledMmaAttr.getUnrollM();
+    int nUnrollFactor = dataTiledMmaAttr.getUnrollN();
+    int kUnrollFactor = dataTiledMmaAttr.getUnrollK();
     expectedNumLhsElem *= mUnrollFactor * kUnrollFactor;
     expectedNumRhsElem *= nUnrollFactor * kUnrollFactor;
     expectedNumAccElem *= mUnrollFactor * nUnrollFactor;

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_attrs.mlir
@@ -29,12 +29,12 @@ module {
 
 module {
   func.func @test_data_tiled_mfma_f32_16x16x4_f32() attributes {
-      mma_types = #iree_gpu.data_tiled_mma_layout<MFMA_F32_16x16x4_F32>} {
+      mma_types = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x4_F32, unroll_m = 1, unroll_n = 1, unroll_k = 1>} {
     return
   }
 }
 // CHECK-LABEL: func @test_data_tiled_mfma_f32_16x16x4_f32
-//  CHECK-SAME:   mma_types = #iree_gpu.data_tiled_mma_layout<MFMA_F32_16x16x4_F32>
+//  CHECK-SAME:   mma_types = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x4_F32, unroll_m = 1, unroll_n = 1, unroll_k = 1>
 
 module {
   func.func @test_any_lowering_config() attributes {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/test/iree_gpu_ops.mlir
@@ -230,7 +230,7 @@ func.func @data_tiled_1x1x1_tensor_multi_mma(%lhs: tensor<?x?x4x16x1x1xf32>, %rh
   %0 = iree_gpu.multi_mma %lhs, %rhs, %acc {
     indexing_maps = #contraction_accesses,
     iterator_types = [#iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<reduction>],
-    kind = #iree_gpu.data_tiled_mma_layout<MFMA_F32_16x16x4_F32>
+    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x4_F32, unroll_m = 1, unroll_n = 1, unroll_k = 1>
   } : tensor<?x?x4x16x1x1xf32>, tensor<?x?x4x16x1x1xf32> into tensor<?x?x4x16x4x1xf32>
   return %0 : tensor<?x?x4x16x4x1xf32>
 }
@@ -243,7 +243,7 @@ func.func @data_tiled_1x1x1_tensor_multi_mma(%lhs: tensor<?x?x4x16x1x1xf32>, %rh
 //       CHECK:   iree_gpu.multi_mma %arg0, %arg1, %arg2
 //  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]]]
 //  CHECK-SAME:       iterator_types = [#iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<reduction>]
-//  CHECK-SAME:       kind = #iree_gpu.data_tiled_mma_layout<MFMA_F32_16x16x4_F32>
+//  CHECK-SAME:       kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x4_F32, unroll_m = 1, unroll_n = 1, unroll_k = 1>
 //  CHECK-SAME:     : tensor<?x?x4x16x1x1xf32>, tensor<?x?x4x16x1x1xf32> into tensor<?x?x4x16x4x1xf32>
 
 // -----
@@ -257,7 +257,7 @@ func.func @data_tiled_2x2x4_tensor_multi_mma(%lhs: tensor<?x?x2x4x16x1x4xf32>, %
   %0 = iree_gpu.multi_mma %lhs, %rhs, %acc {
     indexing_maps = #contraction_accesses,
     iterator_types = [#iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<reduction>],
-    kind = #iree_gpu.data_tiled_mma_layout<MFMA_F32_16x16x4_F32>
+    kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x4_F32, unroll_m = 2, unroll_n = 2, unroll_k = 4>
   } : tensor<?x?x2x4x16x1x4xf32>, tensor<?x?x2x4x16x1x4xf32> into tensor<?x?x2x2x4x16x4x1xf32>
   return %0 : tensor<?x?x2x2x4x16x4x1xf32>
 }
@@ -270,7 +270,7 @@ func.func @data_tiled_2x2x4_tensor_multi_mma(%lhs: tensor<?x?x2x4x16x1x4xf32>, %
 //       CHECK:   iree_gpu.multi_mma %arg0, %arg1, %arg2
 //  CHECK-SAME:       indexing_maps = [#[[$MAP]], #[[$MAP1]], #[[$MAP2]]]
 //  CHECK-SAME:       iterator_types = [#iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<parallel>, #iree_gpu.iterator_type<reduction>]
-//  CHECK-SAME:       kind = #iree_gpu.data_tiled_mma_layout<MFMA_F32_16x16x4_F32>
+//  CHECK-SAME:       kind = #iree_gpu.data_tiled_mma_layout<intrinsic = MFMA_F32_16x16x4_F32, unroll_m = 2, unroll_n = 2, unroll_k = 4>
 //  CHECK-SAME:     : tensor<?x?x2x4x16x1x4xf32>, tensor<?x?x2x4x16x1x4xf32> into tensor<?x?x2x2x4x16x4x1xf32>
 
 // -----


### PR DESCRIPTION
* Changes to `IREEGPU_DataTiledMMAAttr`:
  * Add `unroll_{m,n,k}` parameters.
  * Drop custom builder/parser/printer code.
  * Implement `getABCVectorTypes()` by falling back on `MMAAttr::getABCVectorTypes()` since that is unchanged.
* Changes to `MaterializeEncodingInfo`:
  * Drop `intrinsicSize`, too specific to particular levels of swizzling. Also drop `innerTileShapes` and `srcRank` as redundant with the general expand_shape array that I wanted to introduce anyway (next point).
  * Introduce a single optional encapsulated `swizzle` containing just generic expandshape and permutation arrays, so they are agnostic and dont need to be generalized again.
* Changes to `MaterializeEncoding` logic:
  * Just create the `expand_shape` and `tranpose` dictated by the `swizzle` structure. So this is completely general and doesn't introduce unit dimensions to fit a rigid shape structure anymore.
    * The removal of the unit dims accounts for the bulk of the lit test differences, particularly in cases where the unit dims used to prevent folding. Now the folding happens, so the tests observe a single folded `pack` or `unpack` in some cases where the `expand_shape` and `transpose` were folded.
    * This relies on an upstream fix, https://github.com/llvm/llvm-project/pull/107271. This PR currently cherry-picks it, so you will need `git submodule update`.
  * Generalize some places that were hardcoding 2D matrices.
  * Generally drop lots of logic that where inferring kernel shapes that are now consistently something that the user passes, not something that we compute (in the diff, search for `std::sqrt` to see the kind of code being dropped here).
* Changes to `multi_mma` op:
  * Update the verifier.