### PR TITLE
[BUILD] Enable cuda for aarch64 packages

### DIFF
--- a/build_tools/python_deploy/build_linux_packages.sh
+++ b/build_tools/python_deploy/build_linux_packages.sh
@@ -71,7 +71,7 @@ packages="${packages:-iree-runtime iree-compiler}"
 package_suffix="${package_suffix:-}"
 toolchain_suffix="${toolchain_suffix:-release}"
 # Return ON if we are on a supported platform for CUDA.
-enable_cuda="$(uname -m | awk '{print ($1 == "x86_64") ? "ON" : "OFF"}')"
+enable_cuda="$(uname -m | awk '{print ($1 == "x86_64" || $1 == "aarch64") ? "ON" : "OFF"}')"
 
 function run_on_host() {
   echo "Running on host"


### PR DESCRIPTION
This enables CUDA only for the packages for Aarch64 builds. This is useful to use Jetson boards.

@ScottTodd This change is super easy now. I don't think there is something blocking this now, right?