### PR TITLE
Bump Pillow to a newer version

### DIFF
--- a/integrations/tensorflow/test/requirements.txt
+++ b/integrations/tensorflow/test/requirements.txt
@@ -1,5 +1,5 @@
 # Requirements for running TF tests
 tensorflow>=2.16.1
 keras>=2.7.0
-Pillow>=9.2.0
+Pillow>=10.3.0
 pytest


### PR DESCRIPTION
There are multiple vulnerabilities in older pillow versions.

ci-exactly: build_packages,test_tensorflow