### PR TITLE
Bump Keras to a newer version

### DIFF
--- a/integrations/tensorflow/test/requirements.txt
+++ b/integrations/tensorflow/test/requirements.txt
@@ -1,5 +1,5 @@
 # Requirements for running TF tests
 tensorflow>=2.16.1
-keras>=2.7.0
+keras>=2.13.1
 Pillow>=9.2.0
 pytest


### PR DESCRIPTION
An arbitrary code injection vulnerability was fixed with Keras 2.13.1rc0 (GHSA-x4wf-678h-2pmq). This raises the minimum version to be installed to the next higher non-rc version.

ci-exactly: build_packages,test_tensorflow