### PR TITLE
[Codegen][GPU] Support all kinds in combiningKindToAllReduce()

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_reduction.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_reduction.mlir
@@ -342,7 +342,7 @@ func.func @dynamic_softmax() attributes {hal.executable.target = #executable_tar
 
 // Finish the first reduction.
 // CHECK:         vector.transfer_read {{.*}} : memref<1x64xf16, #gpu.address_space<workgroup>>, vector<1xf16>
-// CHECK-COUNT-6: gpu.shuffle  xor {{.*}} : i32
+// CHECK:         gpu.subgroup_reduce maxnumf
 
 // Do the elementwise scaling and second local reduction.
 // CHECK:         vector.transfer_write %[[ADD_PAD]], %{{.*}} : vector<1xf16>, memref<1x64xf16, #gpu.address_space<workgroup>>

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -522,28 +522,31 @@ Value getCombiningIdentityValue(Location loc, OpBuilder &builder,
 }
 
 /// Return a matching GPU reduction operations.
-static std::optional<gpu::AllReduceOperation>
+static gpu::AllReduceOperation
 combiningKindToAllReduce(vector::CombiningKind kind) {
-  using gpu::AllReduceOperation;
-  using vector::CombiningKind;
-
   switch (kind) {
-  case CombiningKind::ADD:
-    return AllReduceOperation::ADD;
-  case CombiningKind::AND:
-    return AllReduceOperation::AND;
-  case CombiningKind::MUL:
-    return AllReduceOperation::MUL;
-  case CombiningKind::OR:
-    return AllReduceOperation::OR;
-  case CombiningKind::XOR:
-    return AllReduceOperation::XOR;
-  // Currently, the min/max reductions are not well-defined in the gpu dialect.
-  // See https://github.com/llvm/llvm-project/issues/72354.
-  default:
-    break;
+#define MAP_CASE(X)                                                            \
+  case vector::CombiningKind::X:                                               \
+    return gpu::AllReduceOperation::X
+
+    MAP_CASE(ADD);
+    MAP_CASE(MUL);
+    MAP_CASE(MINUI);
+    MAP_CASE(MINSI);
+    MAP_CASE(MINNUMF);
+    MAP_CASE(MAXSI);
+    MAP_CASE(MAXUI);
+    MAP_CASE(MAXNUMF);
+    MAP_CASE(AND);
+    MAP_CASE(OR);
+    MAP_CASE(XOR);
+    MAP_CASE(MINIMUMF);
+    MAP_CASE(MAXIMUMF);
+#undef MAP_CASE
   }
-  return std::nullopt;
+  // Upstream LLVM has the same assertion for the reverse direction (see
+  // mlir::gpu::convertReductionKind).
+  llvm_unreachable("Vector and GPU reduction kinds should match 1:1");
 }
 
 /// Emit reduction across a group for a given input.
@@ -555,12 +558,11 @@ Value emitGPUGroupReduction(Location loc, OpBuilder &builder, Value input,
       "Group reduction only support for sizes aligned on warp size for now.");
 
   if (!expandSubgroupReduce && size == warpSize) {
-    if (auto gpuReduceKind = combiningKindToAllReduce(kind)) {
-      // Simple case -- emit `gpu.subgroup_reduce` directly.
-      Value laneVal = builder.create<vector::ReductionOp>(loc, kind, input);
-      return builder.create<gpu::SubgroupReduceOp>(loc, laneVal, *gpuReduceKind,
-                                                   /*uniform=*/false);
-    }
+    auto gpuReduceKind = combiningKindToAllReduce(kind);
+    // Simple case -- emit `gpu.subgroup_reduce` directly.
+    Value laneVal = builder.create<vector::ReductionOp>(loc, kind, input);
+    return builder.create<gpu::SubgroupReduceOp>(loc, laneVal, gpuReduceKind,
+                                                 /*uniform=*/false);
   }
 
   // More-involved case -- generate `gpu.shuffle` ops over i32 values (using the


### PR DESCRIPTION
Changes this function so it supports all members of the CombiningKind enum; the min/max discrepancies that originally motivated their exclusion no longer exist. Since it covers all enum members, it is changed to no longer return an optional. Note that this changes the generated MLIR (gpu.subgroup_reduce is generated), but that should ultimately lower to the same pattern of shuffles as before.

Function is made `static` as it is not used anywhere else and has no prototype in a header.