### PR TITLE
[GPU] Move LLVMGPUPipelineOptions to iree_gpu dialect

### DIFF
--- a/build_tools/pkgci/external_test_suite/attention_and_matmul_spec.mlir
+++ b/build_tools/pkgci/external_test_suite/attention_and_matmul_spec.mlir
@@ -637,7 +637,7 @@ module attributes { transform.with_named_sequence } {
           {mma_schedule = #iree_gpu.mma_schedule<
               intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
               subgroup_m_count = 1, subgroup_n_count = 5>,
-           gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[ReorderWorkgroupsTranspose]>}>
+           gpu_pipeline_options = #iree_gpu.pipeline_options<reorder_workgroups_strategy = Transpose>}>
       > -> !transform.any_param
     transform.yield %conv, %config : !transform.any_op, !transform.any_param
   }
@@ -657,7 +657,7 @@ module attributes { transform.with_named_sequence } {
           {mma_schedule = #iree_gpu.mma_schedule<
               intrinsic = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>,
               subgroup_m_count = 1, subgroup_n_count = 4>,
-           gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[ReorderWorkgroupsTranspose]>,
+           gpu_pipeline_options = #iree_gpu.pipeline_options<reorder_workgroups_strategy = Transpose>,
            llvm_func_attrs = {"amdgpu-waves-per-eu" = "1"}}>
       > -> !transform.any_param
     transform.yield %conv, %config : !transform.any_op, !transform.any_param
@@ -678,7 +678,7 @@ module attributes { transform.with_named_sequence } {
           {mma_schedule = #iree_gpu.mma_schedule<
               intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
               subgroup_m_count = 1, subgroup_n_count = 5>,
-           gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[ReorderWorkgroupsTranspose]>}>
+           gpu_pipeline_options = #iree_gpu.pipeline_options<reorder_workgroups_strategy = Transpose>}>
       > -> !transform.any_param
     transform.yield %conv, %config : !transform.any_op, !transform.any_param
   }
@@ -698,7 +698,7 @@ module attributes { transform.with_named_sequence } {
           {mma_schedule = #iree_gpu.mma_schedule<
               intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
               subgroup_m_count = 1, subgroup_n_count = 5>,
-           gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[ReorderWorkgroupsTranspose]>}>
+           gpu_pipeline_options = #iree_gpu.pipeline_options<reorder_workgroups_strategy = Transpose>}>
       > -> !transform.any_param
     transform.yield %conv, %config : !transform.any_op, !transform.any_param
   }
@@ -718,7 +718,7 @@ module attributes { transform.with_named_sequence } {
           {mma_schedule = #iree_gpu.mma_schedule<
               intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
               subgroup_m_count = 4, subgroup_n_count = 2>,
-           gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[ReorderWorkgroupsTranspose]>,
+           gpu_pipeline_options = #iree_gpu.pipeline_options<reorder_workgroups_strategy = Transpose>,
            llvm_func_attrs = {"amdgpu-waves-per-eu" = "1"}}>
       > -> !transform.any_param
     transform.yield %conv, %config : !transform.any_op, !transform.any_param
@@ -739,7 +739,7 @@ module attributes { transform.with_named_sequence } {
           {mma_schedule = #iree_gpu.mma_schedule<
               intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
               subgroup_m_count = 1, subgroup_n_count = 5>,
-           gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[ReorderWorkgroupsTranspose]>}>
+           gpu_pipeline_options = #iree_gpu.pipeline_options<reorder_workgroups_strategy = Transpose>}>
       > -> !transform.any_param
     transform.yield %conv, %config : !transform.any_op, !transform.any_param
   }

--- a/build_tools/pkgci/external_test_suite/attention_and_matmul_spec.mlir
+++ b/build_tools/pkgci/external_test_suite/attention_and_matmul_spec.mlir
@@ -636,8 +636,8 @@ module attributes { transform.with_named_sequence } {
          workgroup_size = [320, 1, 1] subgroup_size = 64,
           {mma_schedule = #iree_gpu.mma_schedule<
               intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
-              subgroup_m_count = 1, subgroup_n_count = 5>
-           , reorder_workgroups = "transpose"}>
+              subgroup_m_count = 1, subgroup_n_count = 5>,
+           gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[ReorderWorkgroupsTranspose]>}>
       > -> !transform.any_param
     transform.yield %conv, %config : !transform.any_op, !transform.any_param
   }
@@ -656,8 +656,9 @@ module attributes { transform.with_named_sequence } {
          workgroup_size = [256, 1, 1] subgroup_size = 64,
           {mma_schedule = #iree_gpu.mma_schedule<
               intrinsic = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>,
-              subgroup_m_count = 1, subgroup_n_count = 4>
-           , reorder_workgroups = "transpose", llvm_func_attrs = {"amdgpu-waves-per-eu" = "1"}}>
+              subgroup_m_count = 1, subgroup_n_count = 4>,
+           gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[ReorderWorkgroupsTranspose]>,
+           llvm_func_attrs = {"amdgpu-waves-per-eu" = "1"}}>
       > -> !transform.any_param
     transform.yield %conv, %config : !transform.any_op, !transform.any_param
   }
@@ -676,8 +677,8 @@ module attributes { transform.with_named_sequence } {
          workgroup_size = [320, 1, 1] subgroup_size = 64,
           {mma_schedule = #iree_gpu.mma_schedule<
               intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
-              subgroup_m_count = 1, subgroup_n_count = 5>
-           , reorder_workgroups = "transpose"}>
+              subgroup_m_count = 1, subgroup_n_count = 5>,
+           gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[ReorderWorkgroupsTranspose]>}>
       > -> !transform.any_param
     transform.yield %conv, %config : !transform.any_op, !transform.any_param
   }
@@ -696,8 +697,8 @@ module attributes { transform.with_named_sequence } {
          workgroup_size = [320, 1, 1] subgroup_size = 64,
           {mma_schedule = #iree_gpu.mma_schedule<
               intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
-              subgroup_m_count = 1, subgroup_n_count = 5>
-           , reorder_workgroups = "transpose"}>
+              subgroup_m_count = 1, subgroup_n_count = 5>,
+           gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[ReorderWorkgroupsTranspose]>}>
       > -> !transform.any_param
     transform.yield %conv, %config : !transform.any_op, !transform.any_param
   }
@@ -716,8 +717,9 @@ module attributes { transform.with_named_sequence } {
          workgroup_size = [128, 4, 1] subgroup_size = 64,
           {mma_schedule = #iree_gpu.mma_schedule<
               intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
-              subgroup_m_count = 4, subgroup_n_count = 2>
-           , reorder_workgroups = "transpose", llvm_func_attrs = {"amdgpu-waves-per-eu" = "1"}}>
+              subgroup_m_count = 4, subgroup_n_count = 2>,
+           gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[ReorderWorkgroupsTranspose]>,
+           llvm_func_attrs = {"amdgpu-waves-per-eu" = "1"}}>
       > -> !transform.any_param
     transform.yield %conv, %config : !transform.any_op, !transform.any_param
   }
@@ -736,8 +738,8 @@ module attributes { transform.with_named_sequence } {
          workgroup_size = [320, 1, 1] subgroup_size = 64,
           {mma_schedule = #iree_gpu.mma_schedule<
               intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
-              subgroup_m_count = 1, subgroup_n_count = 5>
-           , reorder_workgroups = "transpose"}>
+              subgroup_m_count = 1, subgroup_n_count = 5>,
+           gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[ReorderWorkgroupsTranspose]>}>
       > -> !transform.any_param
     transform.yield %conv, %config : !transform.any_op, !transform.any_param
   }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
@@ -101,7 +101,9 @@ createGPUTensorAlloc(GPUPromoteSharedMemPattern promoteSharedMemPattern =
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createConvertVectorReductionToGPUPass(bool expandSubgroupReduction = true);
 
-enum class ReorderWorkgroupsStrategy { None, Swizzle, Transpose };
+using IREE::GPU::PipelineOptions::ReorderWorkgroupsStrategy;
+using IREE::GPU::PipelineOptions::UnitPipelineOption;
+// enum class ReorderWorkgroupsStrategy { None, Swizzle, Transpose };
 
 /// Reorders workgroup IDs.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
@@ -101,13 +101,12 @@ createGPUTensorAlloc(GPUPromoteSharedMemPattern promoteSharedMemPattern =
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createConvertVectorReductionToGPUPass(bool expandSubgroupReduction = true);
 
-using IREE::GPU::PipelineOptions::ReorderWorkgroupsStrategy;
+using IREE::GPU::ReorderWorkgroupsStrategy;
 
 /// Reorders workgroup IDs.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createReorderWorkgroups(
-    ReorderWorkgroupsStrategy strategy =
-        ReorderWorkgroupsStrategy::ReorderWorkgroupsNone,
+    ReorderWorkgroupsStrategy strategy = ReorderWorkgroupsStrategy::None,
     unsigned swizzleLogTile = 0,
     std::function<LogicalResult(mlir::FunctionOpInterface)> filterFn = nullptr);
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
@@ -102,13 +102,12 @@ std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createConvertVectorReductionToGPUPass(bool expandSubgroupReduction = true);
 
 using IREE::GPU::PipelineOptions::ReorderWorkgroupsStrategy;
-using IREE::GPU::PipelineOptions::UnitPipelineOption;
-// enum class ReorderWorkgroupsStrategy { None, Swizzle, Transpose };
 
 /// Reorders workgroup IDs.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createReorderWorkgroups(
-    ReorderWorkgroupsStrategy strategy = ReorderWorkgroupsStrategy::None,
+    ReorderWorkgroupsStrategy strategy =
+        ReorderWorkgroupsStrategy::ReorderWorkgroupsNone,
     unsigned swizzleLogTile = 0,
     std::function<LogicalResult(mlir::FunctionOpInterface)> filterFn = nullptr);
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -1353,6 +1353,17 @@ bool LaneIdAttr::isLinearMapping() const { return true; }
 int64_t LaneIdAttr::getRelativeIndex() const { return getDim(); }
 
 //===----------------------------------------------------------------------===//
+// GPU Pipeline Options
+//===----------------------------------------------------------------------===//
+
+GPUPipelineOptionsArrayAttr
+GPUPipelineOptionsArrayAttr::addOption(GPUPipelineOptionAttr optionAttr) {
+  SmallVector<GPUPipelineOptionAttr> optionAttrs(getValue());
+  optionAttrs.push_back(optionAttr);
+  return GPUPipelineOptionsArrayAttr::get(getContext(), optionAttrs);
+}
+
+//===----------------------------------------------------------------------===//
 // Attribute Registration
 //===----------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -1356,11 +1356,19 @@ int64_t LaneIdAttr::getRelativeIndex() const { return getDim(); }
 // GPU Pipeline Options
 //===----------------------------------------------------------------------===//
 
-GPUPipelineOptionsArrayAttr
-GPUPipelineOptionsArrayAttr::addOption(GPUPipelineOptionAttr optionAttr) {
-  SmallVector<GPUPipelineOptionAttr> optionAttrs(getValue());
-  optionAttrs.push_back(optionAttr);
-  return GPUPipelineOptionsArrayAttr::get(getContext(), optionAttrs);
+GPUPipelineOptionsAttr GPUPipelineOptionsAttr::get(
+    MLIRContext *context, bool prefetchSharedMemory,
+    bool noReduceSharedMemoryBankConflicts,
+    std::optional<ReorderWorkgroupsStrategy> reorderWorkgroupsStrategy) {
+  auto strategyAttr = ReorderWorkgroupsStrategyAttr();
+  if (reorderWorkgroupsStrategy.has_value()) {
+    strategyAttr = ReorderWorkgroupsStrategyAttr::get(
+        context, reorderWorkgroupsStrategy.value());
+  }
+  Builder b(context);
+  return Base::get(context, b.getBoolAttr(prefetchSharedMemory),
+                   b.getBoolAttr(noReduceSharedMemoryBankConflicts),
+                   strategyAttr);
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -1361,9 +1361,9 @@ GPUPipelineOptionsAttr GPUPipelineOptionsAttr::get(
     bool noReduceSharedMemoryBankConflicts,
     std::optional<ReorderWorkgroupsStrategy> reorderWorkgroupsStrategy) {
   auto strategyAttr = ReorderWorkgroupsStrategyAttr();
-  if (reorderWorkgroupsStrategy.has_value()) {
-    strategyAttr = ReorderWorkgroupsStrategyAttr::get(
-        context, reorderWorkgroupsStrategy.value());
+  if (reorderWorkgroupsStrategy) {
+    strategyAttr =
+        ReorderWorkgroupsStrategyAttr::get(context, *reorderWorkgroupsStrategy);
   }
   Builder b(context);
   return Base::get(context, b.getBoolAttr(prefetchSharedMemory),

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -430,4 +430,30 @@ def IREEGPU_LaneIdAttr : AttrDef<IREEGPU_Dialect, "LaneId", [
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// GPU Pipeline Options
+//===----------------------------------------------------------------------===//
+
+def IREEGPU_GPUPipelineOptionAttr :
+    EnumAttr<IREEGPU_Dialect, IREEGPU_GPUPipelineOptionEnum, ""> {
+  let assemblyFormat = "``$value";
+  let cppNamespace = "::mlir::iree_compiler::IREE::GPU";
+}
+
+def IREEGPU_GPUPipelineOptionsArrayAttr :
+    ArrayOfAttr<IREEGPU_Dialect, "GPUPipelineOptionsArray",
+        "gpu_pipeline_options", "GPUPipelineOptionAttr"> {
+  let cppNamespace = "::mlir::iree_compiler::IREE::GPU";
+  let extraClassDeclaration = [{
+    // Return the key name for GPUPipelineOptionsArray in the translation info
+    // config dictionary.
+    static StringRef getDictKeyName() {
+      return "gpu_pipeline_options";
+    }
+
+    // Return new GPUPipelineOptionsArray with an additional option.
+    GPUPipelineOptionsArrayAttr addOption(GPUPipelineOptionAttr optionAttr);
+  }];
+}
+
 #endif // IREE_COMPILER_CODEGEN_DIALECT_GPU_IREEGPUATTRS

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -434,25 +434,49 @@ def IREEGPU_LaneIdAttr : AttrDef<IREEGPU_Dialect, "LaneId", [
 // GPU Pipeline Options
 //===----------------------------------------------------------------------===//
 
-def IREEGPU_GPUPipelineOptionAttr :
-    EnumAttr<IREEGPU_Dialect, IREEGPU_GPUPipelineOptionEnum, ""> {
+def IREEGPU_ReorderWorkgroupsStrategyAttr :
+    EnumAttr<IREEGPU_Dialect, IREEGPU_ReorderWorkgroupsStrategy, ""> {
   let assemblyFormat = "``$value";
   let cppNamespace = "::mlir::iree_compiler::IREE::GPU";
 }
 
-def IREEGPU_GPUPipelineOptionsArrayAttr :
-    ArrayOfAttr<IREEGPU_Dialect, "GPUPipelineOptionsArray",
-        "gpu_pipeline_options", "GPUPipelineOptionAttr"> {
+def IREEGPU_GPUPipelineOptionsAttr : AttrDef<IREEGPU_Dialect, "GPUPipelineOptions"> {
+  let summary = "GPU pipeline options attribute.";
+  let description = [{
+    This attributes describes lowering pipeline specific configuration options:
+    * prefetch_shared_memory: Boolean option indicating whether or not to run
+      the loop prefetching pass in the lowering pipeline.
+    * no_reduce_shared_memory_bank_conflicts: Boolean option indicating whether
+      or not to skip the bank conflict reduction pass in the lowering pipeline.
+    * reorder_workgroups_strategy: Enum attribute indicating which strategy to
+      choose for the workgroup reordering pass. Options are `None`, `Swizzle`,
+      and `Transpose`.
+  }];
+
+  let mnemonic = "pipeline_options";
   let cppNamespace = "::mlir::iree_compiler::IREE::GPU";
+
+  let parameters = (ins
+    OptionalParameter<"BoolAttr">:$prefetch_shared_memory,
+    OptionalParameter<"BoolAttr">:$no_reduce_shared_memory_bank_conflicts,
+    OptionalParameter<"ReorderWorkgroupsStrategyAttr">:$reorder_workgroups_strategy
+  );
+
+  let builders = [
+    AttrBuilder<(ins
+        CArg<"bool", "false">:$prefetch_shared_memory,
+        CArg<"bool", "false">:$no_reduce_shared_memory_bank_conflicts,
+        CArg<"std::optional<ReorderWorkgroupsStrategy>", "{}">:$reorder_workgroups_strategy)>
+  ];
+
+  let assemblyFormat = "`<` struct(params) `>`";
+
   let extraClassDeclaration = [{
-    // Return the key name for GPUPipelineOptionsArray in the translation info
+    // Returns the key name for GPUPipelineOptionsAttr in the translation info
     // config dictionary.
     static StringRef getDictKeyName() {
       return "gpu_pipeline_options";
     }
-
-    // Return new GPUPipelineOptionsArray with an additional option.
-    GPUPipelineOptionsArrayAttr addOption(GPUPipelineOptionAttr optionAttr);
   }];
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td
@@ -178,25 +178,39 @@ class IREEGPU_I32PipelineEnumAttr<string name, string summary, list<I32EnumAttrC
   let genSpecializedAttr = 0;
 }
 
-def ReorderWorkgroups_None : I32EnumAttrCase<"None", 0>;
-def ReorderWorkgroups_Swizzle : I32EnumAttrCase<"Swizzle", 1>;
-def ReorderWorkgroups_Transpose : I32EnumAttrCase<"Transpose", 2>;
+// ReorderWorkgroups EnumAttrCases.
+def ReorderWorkgroupsNone : I32EnumAttrCase<"ReorderWorkgroupsNone", 0>;
+def ReorderWorkgroupsSwizzle : I32EnumAttrCase<"ReorderWorkgroupsSwizzle", 1>;
+def ReorderWorkgroupsTranspose : I32EnumAttrCase<"ReorderWorkgroupsTranspose", 2>;
 
+// EnumAttr for workgroup reordering strategy enums.
 def IREEGPU_ReorderWorkgroupsStrategy : IREEGPU_I32PipelineEnumAttr<"ReorderWorkgroupsStrategy",
     "Strategy for workgroup reordering", [
-      ReorderWorkgroups_None,
-      ReorderWorkgroups_Swizzle,
-      ReorderWorkgroups_Transpose
+      ReorderWorkgroupsNone,
+      ReorderWorkgroupsSwizzle,
+      ReorderWorkgroupsTranspose
     ]> {
 }
 
-def NoReduceSharedMemoryBankConflicts : I32EnumAttrCase<"NoReduceSharedMemoryBankConflicts", 0>;
-def PrefetchSharedMemory : I32EnumAttrCase<"PrefetchSharedMemory", 1>;
+// Other GPU pipeline option EnumAttrCases.
+def NoReduceSharedMemoryBankConflicts : I32EnumAttrCase<"NoReduceSharedMemoryBankConflicts", 3>;
+def PrefetchSharedMemory : I32EnumAttrCase<"PrefetchSharedMemory", 4>;
 
-def IREEGPU_UnitPipelineOption : IREEGPU_I32PipelineEnumAttr<"UnitPipelineOption",
-    "Pipeline options", [
-      NoReduceSharedMemoryBankConflicts,
-      PrefetchSharedMemory,
-    ]>;
+// EnumAttr for all GPU pipeline option enums.
+def IREEGPU_GPUPipelineOptionEnum : IREEGPU_I32PipelineEnumAttr<
+  "GPUPipelineOption",
+  "identifier for pass pipeline options", [
+    // ReorderWorkgroups
+    ReorderWorkgroupsNone,
+    ReorderWorkgroupsSwizzle,
+    ReorderWorkgroupsTranspose,
+
+    // Other Options
+    NoReduceSharedMemoryBankConflicts,
+    PrefetchSharedMemory
+  ]> {
+  let cppNamespace = "::mlir::iree_compiler::IREE::GPU::PipelineOptions";
+  let genSpecializedAttr = 0;
+}
 
 #endif // IREE_COMPILER_CODEGEN_DIALECT_GPU_IREEGPUENUMS

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td
@@ -168,4 +168,35 @@ def IREEGPU_TilingLevel : IREEGPU_I32MmaEnumAttr<"TilingLevel",
       Lane
     ]>;
 
+//===----------------------------------------------------------------------===//
+// Pipeline options
+//===----------------------------------------------------------------------===//
+
+class IREEGPU_I32PipelineEnumAttr<string name, string summary, list<I32EnumAttrCase> cases>
+    : I32EnumAttr<name, summary, cases> {
+  let cppNamespace = "::mlir::iree_compiler::IREE::GPU::PipelineOptions";
+  let genSpecializedAttr = 0;
+}
+
+def ReorderWorkgroups_None : I32EnumAttrCase<"None", 0>;
+def ReorderWorkgroups_Swizzle : I32EnumAttrCase<"Swizzle", 1>;
+def ReorderWorkgroups_Transpose : I32EnumAttrCase<"Transpose", 2>;
+
+def IREEGPU_ReorderWorkgroupsStrategy : IREEGPU_I32PipelineEnumAttr<"ReorderWorkgroupsStrategy",
+    "Strategy for workgroup reordering", [
+      ReorderWorkgroups_None,
+      ReorderWorkgroups_Swizzle,
+      ReorderWorkgroups_Transpose
+    ]> {
+}
+
+def NoReduceSharedMemoryBankConflicts : I32EnumAttrCase<"NoReduceSharedMemoryBankConflicts", 0>;
+def PrefetchSharedMemory : I32EnumAttrCase<"PrefetchSharedMemory", 1>;
+
+def IREEGPU_UnitPipelineOption : IREEGPU_I32PipelineEnumAttr<"UnitPipelineOption",
+    "Pipeline options", [
+      NoReduceSharedMemoryBankConflicts,
+      PrefetchSharedMemory,
+    ]>;
+
 #endif // IREE_COMPILER_CODEGEN_DIALECT_GPU_IREEGPUENUMS

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td
@@ -174,14 +174,14 @@ def IREEGPU_TilingLevel : IREEGPU_I32MmaEnumAttr<"TilingLevel",
 
 class IREEGPU_I32PipelineEnumAttr<string name, string summary, list<I32EnumAttrCase> cases>
     : I32EnumAttr<name, summary, cases> {
-  let cppNamespace = "::mlir::iree_compiler::IREE::GPU::PipelineOptions";
+  let cppNamespace = "::mlir::iree_compiler::IREE::GPU";
   let genSpecializedAttr = 0;
 }
 
 // ReorderWorkgroups EnumAttrCases.
-def ReorderWorkgroupsNone : I32EnumAttrCase<"ReorderWorkgroupsNone", 0>;
-def ReorderWorkgroupsSwizzle : I32EnumAttrCase<"ReorderWorkgroupsSwizzle", 1>;
-def ReorderWorkgroupsTranspose : I32EnumAttrCase<"ReorderWorkgroupsTranspose", 2>;
+def ReorderWorkgroupsNone : I32EnumAttrCase<"None", 0>;
+def ReorderWorkgroupsSwizzle : I32EnumAttrCase<"Swizzle", 1>;
+def ReorderWorkgroupsTranspose : I32EnumAttrCase<"Transpose", 2>;
 
 // EnumAttr for workgroup reordering strategy enums.
 def IREEGPU_ReorderWorkgroupsStrategy : IREEGPU_I32PipelineEnumAttr<"ReorderWorkgroupsStrategy",
@@ -190,27 +190,6 @@ def IREEGPU_ReorderWorkgroupsStrategy : IREEGPU_I32PipelineEnumAttr<"ReorderWork
       ReorderWorkgroupsSwizzle,
       ReorderWorkgroupsTranspose
     ]> {
-}
-
-// Other GPU pipeline option EnumAttrCases.
-def NoReduceSharedMemoryBankConflicts : I32EnumAttrCase<"NoReduceSharedMemoryBankConflicts", 3>;
-def PrefetchSharedMemory : I32EnumAttrCase<"PrefetchSharedMemory", 4>;
-
-// EnumAttr for all GPU pipeline option enums.
-def IREEGPU_GPUPipelineOptionEnum : IREEGPU_I32PipelineEnumAttr<
-  "GPUPipelineOption",
-  "identifier for pass pipeline options", [
-    // ReorderWorkgroups
-    ReorderWorkgroupsNone,
-    ReorderWorkgroupsSwizzle,
-    ReorderWorkgroupsTranspose,
-
-    // Other Options
-    NoReduceSharedMemoryBankConflicts,
-    PrefetchSharedMemory
-  ]> {
-  let cppNamespace = "::mlir::iree_compiler::IREE::GPU::PipelineOptions";
-  let genSpecializedAttr = 0;
 }
 
 #endif // IREE_COMPILER_CODEGEN_DIALECT_GPU_IREEGPUENUMS

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -536,8 +536,7 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
     }
   }
 
-  return os << "{"
-            << "enableReduceSharedMemoryBankConflicts = "
+  return os << "{" << "enableReduceSharedMemoryBankConflicts = "
             << options.enableReduceSharedMemoryBankConflicts << ", "
             << ", prefetchSharedMemory = " << options.prefetchSharedMemory
             << ", reorderWorkgroupsStrategy = " << reorderStr

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h
@@ -7,6 +7,7 @@
 #ifndef IREE_COMPILER_CODEGEN_DIALECT_GPU_TARGETUTILS_CONFIGUTILS_H_
 #define IREE_COMPILER_CODEGEN_DIALECT_GPU_TARGETUTILS_CONFIGUTILS_H_
 
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
@@ -25,6 +26,30 @@ LogicalResult setMatmulLoweringConfig(IREE::GPU::TargetAttr target,
 LogicalResult setTileAndFuseLoweringConfig(IREE::GPU::TargetAttr target,
                                            mlir::FunctionOpInterface entryPoint,
                                            Operation *op);
+
+//===----------------------------------------------------------------------===//
+// Pass Pipeline Options
+//===----------------------------------------------------------------------===//
+
+using IREE::GPU::PipelineOptions::ReorderWorkgroupsStrategy;
+using IREE::GPU::PipelineOptions::UnitPipelineOption;
+
+StringRef getPipelineOptionName(UnitPipelineOption option);
+StringRef getPipelineOptionName(ReorderWorkgroupsStrategy option);
+
+struct GPUPipelineOptions {
+  bool enableReduceSharedMemoryBankConflicts = true;
+  bool prefetchSharedMemory = false;
+  bool enableUkernels = false;
+  std::optional<ReorderWorkgroupsStrategy> reorderStrategy;
+};
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                              const GPUPipelineOptions &options);
+
+GPUPipelineOptions
+getPipelineOptions(FunctionOpInterface funcOp,
+                   IREE::Codegen::TranslationInfoAttr translationInfo);
 
 } // namespace mlir::iree_compiler::IREE::GPU
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h
@@ -31,11 +31,8 @@ LogicalResult setTileAndFuseLoweringConfig(IREE::GPU::TargetAttr target,
 // Pass Pipeline Options
 //===----------------------------------------------------------------------===//
 
+using IREE::GPU::PipelineOptions::GPUPipelineOption;
 using IREE::GPU::PipelineOptions::ReorderWorkgroupsStrategy;
-using IREE::GPU::PipelineOptions::UnitPipelineOption;
-
-StringRef getPipelineOptionName(UnitPipelineOption option);
-StringRef getPipelineOptionName(ReorderWorkgroupsStrategy option);
 
 struct GPUPipelineOptions {
   bool enableReduceSharedMemoryBankConflicts = true;

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h
@@ -31,8 +31,7 @@ LogicalResult setTileAndFuseLoweringConfig(IREE::GPU::TargetAttr target,
 // Pass Pipeline Options
 //===----------------------------------------------------------------------===//
 
-using IREE::GPU::PipelineOptions::GPUPipelineOption;
-using IREE::GPU::PipelineOptions::ReorderWorkgroupsStrategy;
+using IREE::GPU::ReorderWorkgroupsStrategy;
 
 struct GPUPipelineOptions {
   bool enableReduceSharedMemoryBankConflicts = true;

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -381,14 +381,14 @@ setConvolutionVectorDistributionConfig(IREE::GPU::TargetAttr target,
 
   // Prefetch shared memory if requested.
   if (clLLVMGPUEnablePrefetch) {
-    SmallVector<IREE::GPU::GPUPipelineOptionAttr> pipelineOptions;
-    pipelineOptions.push_back(IREE::GPU::GPUPipelineOptionAttr::get(
-        context,
-        IREE::GPU::PipelineOptions::GPUPipelineOption::PrefetchSharedMemory));
+    auto pipelineOptions = IREE::GPU::GPUPipelineOptionsAttr::get(
+        context, /*prefetchSharedMemory=*/true,
+        /*no_reduce_shared_memory_bank_conflicts=*/false,
+        /*reorder_workgroups_strategy=*/std::nullopt);
     attrs.emplace_back(
-        StringAttr::get(
-            context, IREE::GPU::GPUPipelineOptionsArrayAttr::getDictKeyName()),
-        IREE::GPU::GPUPipelineOptionsArrayAttr::get(context, pipelineOptions));
+        StringAttr::get(context,
+                        IREE::GPU::GPUPipelineOptionsAttr::getDictKeyName()),
+        pipelineOptions);
   }
 
   auto configDict = DictionaryAttr::get(context, attrs);
@@ -616,14 +616,14 @@ setMatmulVectorDistributionConfig(IREE::GPU::TargetAttr target,
 
   // Prefetch shared memory if requested.
   if (clLLVMGPUEnablePrefetch) {
-    SmallVector<IREE::GPU::GPUPipelineOptionAttr> pipelineOptions;
-    pipelineOptions.push_back(IREE::GPU::GPUPipelineOptionAttr::get(
-        context,
-        IREE::GPU::PipelineOptions::GPUPipelineOption::PrefetchSharedMemory));
+    auto pipelineOptions = IREE::GPU::GPUPipelineOptionsAttr::get(
+        context, /*prefetchSharedMemory=*/true,
+        /*no_reduce_shared_memory_bank_conflicts=*/false,
+        /*reorder_workgroups_strategy=*/std::nullopt);
     attrs.emplace_back(
-        StringAttr::get(
-            context, IREE::GPU::GPUPipelineOptionsArrayAttr::getDictKeyName()),
-        IREE::GPU::GPUPipelineOptionsArrayAttr::get(context, pipelineOptions));
+        StringAttr::get(context,
+                        IREE::GPU::GPUPipelineOptionsAttr::getDictKeyName()),
+        pipelineOptions);
   }
 
   auto configDict = DictionaryAttr::get(context, attrs);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -381,10 +381,14 @@ setConvolutionVectorDistributionConfig(IREE::GPU::TargetAttr target,
 
   // Prefetch shared memory if requested.
   if (clLLVMGPUEnablePrefetch) {
+    SmallVector<IREE::GPU::GPUPipelineOptionAttr> pipelineOptions;
+    pipelineOptions.push_back(IREE::GPU::GPUPipelineOptionAttr::get(
+        context,
+        IREE::GPU::PipelineOptions::GPUPipelineOption::PrefetchSharedMemory));
     attrs.emplace_back(
-        StringAttr::get(context, IREE::GPU::getPipelineOptionName(
-                                     UnitPipelineOption::PrefetchSharedMemory)),
-        UnitAttr::get(context));
+        StringAttr::get(
+            context, IREE::GPU::GPUPipelineOptionsArrayAttr::getDictKeyName()),
+        IREE::GPU::GPUPipelineOptionsArrayAttr::get(context, pipelineOptions));
   }
 
   auto configDict = DictionaryAttr::get(context, attrs);
@@ -612,10 +616,14 @@ setMatmulVectorDistributionConfig(IREE::GPU::TargetAttr target,
 
   // Prefetch shared memory if requested.
   if (clLLVMGPUEnablePrefetch) {
+    SmallVector<IREE::GPU::GPUPipelineOptionAttr> pipelineOptions;
+    pipelineOptions.push_back(IREE::GPU::GPUPipelineOptionAttr::get(
+        context,
+        IREE::GPU::PipelineOptions::GPUPipelineOption::PrefetchSharedMemory));
     attrs.emplace_back(
-        StringAttr::get(context, IREE::GPU::getPipelineOptionName(
-                                     UnitPipelineOption::PrefetchSharedMemory)),
-        UnitAttr::get(context));
+        StringAttr::get(
+            context, IREE::GPU::GPUPipelineOptionsArrayAttr::getDictKeyName()),
+        IREE::GPU::GPUPipelineOptionsArrayAttr::get(context, pipelineOptions));
   }
 
   auto configDict = DictionaryAttr::get(context, attrs);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -13,6 +13,7 @@
 #include "iree/compiler/Codegen/Common/GPU/GPUHeuristics.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.h"
 #include "iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h"
 #include "iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.h"
 #include "iree/compiler/Codegen/Interfaces/UKernelOpInterface.h"
@@ -381,7 +382,8 @@ setConvolutionVectorDistributionConfig(IREE::GPU::TargetAttr target,
   // Prefetch shared memory if requested.
   if (clLLVMGPUEnablePrefetch) {
     attrs.emplace_back(
-        StringAttr::get(context, LLVMGPUAttrNames::kPrefetchSharedMemory),
+        StringAttr::get(context, IREE::GPU::getPipelineOptionName(
+                                     UnitPipelineOption::PrefetchSharedMemory)),
         UnitAttr::get(context));
   }
 
@@ -611,7 +613,8 @@ setMatmulVectorDistributionConfig(IREE::GPU::TargetAttr target,
   // Prefetch shared memory if requested.
   if (clLLVMGPUEnablePrefetch) {
     attrs.emplace_back(
-        StringAttr::get(context, LLVMGPUAttrNames::kPrefetchSharedMemory),
+        StringAttr::get(context, IREE::GPU::getPipelineOptionName(
+                                     UnitPipelineOption::PrefetchSharedMemory)),
         UnitAttr::get(context));
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
@@ -8,6 +8,7 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
+#include "iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h"
 #include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h"
 #include "iree/compiler/Codegen/LLVMGPU/KernelConfig.h"
 #include "iree/compiler/Codegen/LLVMGPU/Passes.h"
@@ -76,50 +77,6 @@ public:
 
   void runOnOperation() override;
 };
-
-static LLVMGPUPipelineOptions
-getPipelineOptions(FunctionOpInterface funcOp,
-                   IREE::Codegen::TranslationInfoAttr translationInfo) {
-  LLVMGPUPipelineOptions pipelineOptions = {};
-  auto targetAttr = IREE::HAL::ExecutableTargetAttr::lookup(funcOp);
-
-  LLVM_DEBUG(llvm::dbgs() << "Translation Info: " << translationInfo << "\n");
-  LLVM_DEBUG(llvm::dbgs() << "Target Attr: " << targetAttr << "\n");
-
-  if (DictionaryAttr config = translationInfo.getConfiguration()) {
-    if (config.contains(LLVMGPUAttrNames::kNoReduceSharedMemoryBankConflicts))
-      pipelineOptions.enableReduceSharedMemoryBankConflicts = false;
-    if (config.contains(LLVMGPUAttrNames::kPrefetchSharedMemory))
-      pipelineOptions.prefetchSharedMemory = true;
-    if (config.contains(LLVMGPUAttrNames::kReorderWorkgroups)) {
-      // Get the workgroups reorder config and enable the workgroup reordering.
-      Attribute reorderWorkgroupOption =
-          config.get(LLVMGPUAttrNames::kReorderWorkgroups);
-      if (!isa<StringAttr>(reorderWorkgroupOption))
-        funcOp.emitOpError() << "'" << LLVMGPUAttrNames::kReorderWorkgroups
-                             << "' is expected to be a string attribute";
-      StringRef reorderStr = llvm::cast<StringAttr>(reorderWorkgroupOption);
-      if (reorderStr == "transpose") {
-        pipelineOptions.reorderStrategy = ReorderWorkgroupsStrategy::Transpose;
-      } else if (reorderStr == "swizzle") {
-        pipelineOptions.reorderStrategy = ReorderWorkgroupsStrategy::Swizzle;
-      } else {
-        if (reorderStr != "none")
-          funcOp.emitOpError()
-              << "Unknown " << LLVMGPUAttrNames::kReorderWorkgroups
-              << "value: " << reorderWorkgroupOption;
-        else
-          pipelineOptions.reorderStrategy = ReorderWorkgroupsStrategy::None;
-      }
-    }
-  }
-
-  pipelineOptions.enableUkernels = targetAttr && hasUkernel(targetAttr);
-
-  LLVM_DEBUG(llvm::dbgs() << "LLVMGPU Pipeline Options: " << pipelineOptions
-                          << "\n");
-  return pipelineOptions;
-}
 } // namespace
 
 void LLVMGPULowerExecutableTargetPass::runOnOperation() {
@@ -138,8 +95,8 @@ void LLVMGPULowerExecutableTargetPass::runOnOperation() {
   }
   OpPassManager &pipeline = maybePipeline.value();
 
-  LLVMGPUPipelineOptions pipelineOptions =
-      getPipelineOptions(funcOp, translationInfo);
+  IREE::GPU::GPUPipelineOptions pipelineOptions =
+      IREE::GPU::getPipelineOptions(funcOp, translationInfo);
 
   switch (translationInfo.getDispatchLoweringPassPipeline()) {
   case IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUDefault:

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -75,28 +75,6 @@ static llvm::cl::opt<bool>
                       llvm::cl::desc("Enable implicit gemm for convolutions."),
                       llvm::cl::init(false));
 
-llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
-                              const LLVMGPUPipelineOptions &options) {
-  StringRef reorderStr = "<not set>";
-  if (options.reorderStrategy) {
-    if (options.reorderStrategy == ReorderWorkgroupsStrategy::Transpose) {
-      reorderStr = "transpose";
-    } else if (options.reorderStrategy == ReorderWorkgroupsStrategy::Swizzle) {
-      reorderStr = "swizzle";
-    } else {
-      assert(options.reorderStrategy == ReorderWorkgroupsStrategy::None &&
-             "Unhandled reorder option");
-      reorderStr = "none";
-    }
-  }
-
-  return os << "{" << "enableReduceSharedMemoryBankConflicts = "
-            << options.enableReduceSharedMemoryBankConflicts << ", "
-            << ", prefetchSharedMemory = " << options.prefetchSharedMemory
-            << ", reorderWorkgroupsStrategy = " << reorderStr
-            << ", enableUkernels = " << options.enableUkernels << "}";
-}
-
 //===----------------------------------------------------------------------===//
 // Bufferization Configuration
 //===----------------------------------------------------------------------===//
@@ -488,7 +466,7 @@ void addGPUWinogradVectorizePassPipeline(OpPassManager &funcPassManager) {
 //===---------------------------------------------------------------------===//
 
 void addGPUMatmulSimtPassPipeline(OpPassManager &funcPassManager,
-                                  const LLVMGPUPipelineOptions &options) {
+                                  const GPUPipelineOptions &options) {
   tileAndDistributeToWorkgroup(funcPassManager);
 
   funcPassManager.addPass(createCanonicalizerPass());
@@ -549,7 +527,7 @@ void addGPUMatmulSimtPassPipeline(OpPassManager &funcPassManager,
 //===---------------------------------------------------------------------===//
 
 void addGPUMatmulTensorCorePassPipeline(OpPassManager &funcPassManager,
-                                        const LLVMGPUPipelineOptions &options,
+                                        const GPUPipelineOptions &options,
                                         unsigned pipelineDepth) {
   tileAndBufferize(funcPassManager);
 
@@ -619,7 +597,7 @@ void addGPUMatmulTensorCorePassPipeline(OpPassManager &funcPassManager,
 //===---------------------------------------------------------------------===//
 
 void addGPUMatmulTensorCoreMmaSyncPassPipeline(
-    OpPassManager &funcPassManager, const LLVMGPUPipelineOptions &options,
+    OpPassManager &funcPassManager, const GPUPipelineOptions &options,
     unsigned pipelineDepth) {
   tileAndBufferize(funcPassManager);
 
@@ -686,7 +664,7 @@ void addGPUMatmulTensorCoreMmaSyncPassPipeline(
 //===---------------------------------------------------------------------===//
 
 void addGPUTransposePassPipeline(OpPassManager &funcPassManager,
-                                 const LLVMGPUPipelineOptions &options) {
+                                 const GPUPipelineOptions &options) {
   tileAndDistributeToWorkgroup(funcPassManager);
 
   funcPassManager.addPass(createCanonicalizerPass());
@@ -790,7 +768,7 @@ static void addVectorBufferizePasses(OpPassManager &funcPassManager) {
 }
 
 void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager,
-                                        const LLVMGPUPipelineOptions &options,
+                                        const GPUPipelineOptions &options,
                                         bool usePadToModelSharedMemcpy) {
   tileAndDistributeToWorkgroup(funcPassManager);
 
@@ -965,7 +943,7 @@ void addGPUSimpleDistributePassPipeline(OpPassManager &funcPassManager) {
 }
 
 void addGPUDefaultPassPipeline(OpPassManager &funcPassManager,
-                               const LLVMGPUPipelineOptions &options) {
+                               const GPUPipelineOptions &options) {
   ConvertToDestinationPassingStylePassOptions dpsOptions;
   dpsOptions.useWARForCooperativeMatrixCodegen = true;
   tileAndDistributeToWorkgroup(funcPassManager, dpsOptions);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -51,14 +51,13 @@ constexpr int64_t kDefaultSubgroupSize = 32;
 static llvm::cl::opt<ReorderWorkgroupsStrategy> clReorderWorkgroupsStrategy(
     "iree-codegen-reorder-workgroups-strategy",
     llvm::cl::desc("Reorder workgroup IDs using the selected strategy"),
-    llvm::cl::values(
-        clEnumValN(ReorderWorkgroupsStrategy::ReorderWorkgroupsNone, "none",
-                   "No workgroup reordering"),
-        clEnumValN(ReorderWorkgroupsStrategy::ReorderWorkgroupsSwizzle,
-                   "swizzle", "Swizzle"),
-        clEnumValN(ReorderWorkgroupsStrategy::ReorderWorkgroupsTranspose,
-                   "transpose", "Transpose")),
-    llvm::cl::init(ReorderWorkgroupsStrategy::ReorderWorkgroupsNone));
+    llvm::cl::values(clEnumValN(ReorderWorkgroupsStrategy::None, "none",
+                                "No workgroup reordering"),
+                     clEnumValN(ReorderWorkgroupsStrategy::Swizzle, "swizzle",
+                                "Swizzle"),
+                     clEnumValN(ReorderWorkgroupsStrategy::Transpose,
+                                "transpose", "Transpose")),
+    llvm::cl::init(ReorderWorkgroupsStrategy::None));
 
 static llvm::cl::opt<unsigned> clReorderWorkgroupsLogSwizzleTile(
     "iree-codegen-reorder-workgroups-log-swizzle-tile",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -51,13 +51,14 @@ constexpr int64_t kDefaultSubgroupSize = 32;
 static llvm::cl::opt<ReorderWorkgroupsStrategy> clReorderWorkgroupsStrategy(
     "iree-codegen-reorder-workgroups-strategy",
     llvm::cl::desc("Reorder workgroup IDs using the selected strategy"),
-    llvm::cl::values(clEnumValN(ReorderWorkgroupsStrategy::None, "none",
-                                "No workgroup reordering"),
-                     clEnumValN(ReorderWorkgroupsStrategy::Swizzle, "swizzle",
-                                "Swizzle"),
-                     clEnumValN(ReorderWorkgroupsStrategy::Transpose,
-                                "transpose", "Transpose")),
-    llvm::cl::init(ReorderWorkgroupsStrategy::None));
+    llvm::cl::values(
+        clEnumValN(ReorderWorkgroupsStrategy::ReorderWorkgroupsNone, "none",
+                   "No workgroup reordering"),
+        clEnumValN(ReorderWorkgroupsStrategy::ReorderWorkgroupsSwizzle,
+                   "swizzle", "Swizzle"),
+        clEnumValN(ReorderWorkgroupsStrategy::ReorderWorkgroupsTranspose,
+                   "transpose", "Transpose")),
+    llvm::cl::init(ReorderWorkgroupsStrategy::ReorderWorkgroupsNone));
 
 static llvm::cl::opt<unsigned> clReorderWorkgroupsLogSwizzleTile(
     "iree-codegen-reorder-workgroups-log-swizzle-tile",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.h
@@ -14,33 +14,12 @@
 
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h"
 #include "mlir/Pass/Pass.h"
 
 namespace mlir::iree_compiler {
 
-//===----------------------------------------------------------------------===//
-// Pass Pipeline Options
-//===----------------------------------------------------------------------===//
-
-/// Named attributes used in the `translation_info`'s config dictionary
-/// attribute. These are used to override default pass heuristics at the
-/// function granularity.
-namespace LLVMGPUAttrNames {
-inline constexpr StringLiteral kReorderWorkgroups = "reorder_workgroups";
-inline constexpr StringLiteral kNoReduceSharedMemoryBankConflicts =
-    "no_reduce_shared_memory_bank_conflicts";
-inline constexpr StringLiteral kPrefetchSharedMemory = "prefetch_shared_memory";
-} //  namespace LLVMGPUAttrNames
-
-struct LLVMGPUPipelineOptions {
-  bool enableReduceSharedMemoryBankConflicts = true;
-  bool prefetchSharedMemory = false;
-  bool enableUkernels = false;
-  std::optional<ReorderWorkgroupsStrategy> reorderStrategy;
-};
-
-llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
-                              const LLVMGPUPipelineOptions &options);
+using IREE::GPU::GPUPipelineOptions;
 
 //----------------------------------------------------------------------------//
 // LLVMGPU backend Pass Pipelines.
@@ -48,16 +27,16 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
 
 /// Lowering using SIMT CUDA core operations.
 void addGPUMatmulSimtPassPipeline(OpPassManager &funcPassManager,
-                                  const LLVMGPUPipelineOptions &options);
+                                  const GPUPipelineOptions &options);
 
 /// Lowering using mma.sync Tensor Core operations.
 void addGPUMatmulTensorCoreMmaSyncPassPipeline(
-    OpPassManager &funcPassManager, const LLVMGPUPipelineOptions &options,
+    OpPassManager &funcPassManager, const GPUPipelineOptions &options,
     unsigned pipelineDepth);
 
 /// Lowering using wmma Tensor Core operations.
 void addGPUMatmulTensorCorePassPipeline(OpPassManager &funcPassManager,
-                                        const LLVMGPUPipelineOptions &options,
+                                        const GPUPipelineOptions &options,
                                         unsigned pipelineDepth);
 
 void addGPUPackUnPackPasses(OpPassManager &funcPassManager);
@@ -77,7 +56,7 @@ void addGPUTransformDialectPasses(OpPassManager &funcPassManager,
 
 /// Lowering transpose using shared memory.
 void addGPUTransposePassPipeline(OpPassManager &funcPassManager,
-                                 const LLVMGPUPipelineOptions &options);
+                                 const GPUPipelineOptions &options);
 
 /// Lowering calling vectorization patterns. Expects pass manager to be a
 /// module-level pass manager.
@@ -89,7 +68,7 @@ void addGPUWinogradVectorizePassPipeline(OpPassManager &funcPassManager);
 
 /// Lowering based on vector distribution patterns.
 void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager,
-                                        const LLVMGPUPipelineOptions &options,
+                                        const GPUPipelineOptions &options,
                                         bool usePadToModelSharedMemcpy);
 
 /// Lowering reductions to warp reductions.
@@ -97,7 +76,7 @@ void addGPUWarpReductionPassPipeline(OpPassManager &funcPassManager);
 
 /// Default pass pipeline on GPU, currently used only for the ukernel path.
 void addGPUDefaultPassPipeline(OpPassManager &funcPassManager,
-                               const LLVMGPUPipelineOptions &options);
+                               const GPUPipelineOptions &options);
 
 /// Pass pipeline to lower IREE HAL executables without tiling and distribution.
 void addGPUBaseLoweringPassPipeline(OpPassManager &pm);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute.mlir
@@ -345,7 +345,7 @@ func.func @matmul_dynamic_dim() {
 // CHECK:       #[[$TILE_SIZES:.+]] = #iree_codegen.lowering_config<tile_sizes =  {{\[}}[1, 32, 0, 64, 64]{{\]}}
 // CHECK:       #iree_codegen.translation_info<LLVMGPUVectorDistribute
 // CHECK-SAME:  subgroup_m_count = 1, subgroup_n_count = 1
-// CHECK-NOT:   PrefetchSharedMemory
+// CHECK-NOT:   prefetch_shared_memory = true
 
 // CHECK-LABEL: func.func @attention_20x4096x64x4096x64()
 
@@ -380,7 +380,7 @@ func.func @attention_20x4096x64x4096x64() {
 // CHECK:       #[[$TILE_SIZES:.+]] = #iree_codegen.lowering_config<tile_sizes =  {{\[}}[16, 0, 32, 16]{{\]}}
 // CHECK:       #iree_codegen.translation_info<LLVMGPUVectorDistribute
 // CHECK-SAME:  subgroup_m_count = 1, subgroup_n_count = 1
-// CHECK-NOT:   PrefetchSharedMemory
+// CHECK-NOT:   prefetch_shared_memory = true
 
 // CHECK-LABEL: func.func @attention_large_head_dim_shared_mem()
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_vector_distribute.mlir
@@ -345,7 +345,7 @@ func.func @matmul_dynamic_dim() {
 // CHECK:       #[[$TILE_SIZES:.+]] = #iree_codegen.lowering_config<tile_sizes =  {{\[}}[1, 32, 0, 64, 64]{{\]}}
 // CHECK:       #iree_codegen.translation_info<LLVMGPUVectorDistribute
 // CHECK-SAME:  subgroup_m_count = 1, subgroup_n_count = 1
-// CHECK-NOT:   prefetch_shared_memory
+// CHECK-NOT:   PrefetchSharedMemory
 
 // CHECK-LABEL: func.func @attention_20x4096x64x4096x64()
 
@@ -380,7 +380,7 @@ func.func @attention_20x4096x64x4096x64() {
 // CHECK:       #[[$TILE_SIZES:.+]] = #iree_codegen.lowering_config<tile_sizes =  {{\[}}[16, 0, 32, 16]{{\]}}
 // CHECK:       #iree_codegen.translation_info<LLVMGPUVectorDistribute
 // CHECK-SAME:  subgroup_m_count = 1, subgroup_n_count = 1
-// CHECK-NOT:   prefetch_shared_memory
+// CHECK-NOT:   PrefetchSharedMemory
 
 // CHECK-LABEL: func.func @attention_large_head_dim_shared_mem()
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute.mlir
@@ -46,7 +46,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 // Basic pipeline test to make sure it generates the instructions we expect.
 
 //       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64
-//  CHECK-SAME:   gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[PrefetchSharedMemory]>
+//  CHECK-SAME:   gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true
 //  CHECK-SAME:   mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
 //  CHECK-SAME:     subgroup_m_count = 2, subgroup_n_count = 2>
 
@@ -93,7 +93,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 }
 
 //       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64
-//  CHECK-SAME:   gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[PrefetchSharedMemory]>
+//  CHECK-SAME:   gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true
 //  CHECK-SAME:   mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
 //  CHECK-SAME:     subgroup_m_count = 2, subgroup_n_count = 2>
 
@@ -160,7 +160,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 }
 
 //          CHECK: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64
-//     CHECK-SAME: gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[PrefetchSharedMemory]>
+//     CHECK-SAME: gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true
 
 //          CHECK: func @expanded_matmul_transpose_b
 //     CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -212,7 +212,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 // Make sure it generates the mfma instructions we expect for f8 inputs.
 
 //       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64
-//  CHECK-SAME:   gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[PrefetchSharedMemory]>
+//  CHECK-SAME:   gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true
 //  CHECK-SAME:   mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F8E4M3FNUZ>,
 //  CHECK-SAME:     subgroup_m_count = 2, subgroup_n_count = 2>
 
@@ -261,7 +261,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 // Make sure it generates the mfma instructions we expect for integer inputs.
 
 //       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64
-//  CHECK-SAME:   gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[PrefetchSharedMemory]>
+//  CHECK-SAME:   gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true
 //  CHECK-SAME:   mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>,
 //  CHECK-SAME:     subgroup_m_count = 2, subgroup_n_count = 2>
 
@@ -310,7 +310,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 // Make sure it generates the mfma instructions we expect for integer inputs.
 
 //       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64
-//  CHECK-SAME:   gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[PrefetchSharedMemory]>
+//  CHECK-SAME:   gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true
 //  CHECK-SAME:   mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>,
 //  CHECK-SAME:     subgroup_m_count = 2, subgroup_n_count = 2>
 
@@ -413,7 +413,7 @@ hal.executable public @main_dispatch_expanded_matmul {
 
 
 //       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64
-//  CHECK-SAME:   gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[PrefetchSharedMemory]>
+//  CHECK-SAME:   gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true
 //  CHECK-SAME:   mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
 //  CHECK-SAME:     subgroup_m_count = 2, subgroup_n_count = 2>
 
@@ -462,7 +462,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 }
 
 //       RDNA3: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [64, 2, 1] subgroup_size = 32
-//  RDNA3-SAME:   gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[PrefetchSharedMemory]>
+//  RDNA3-SAME:   gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true
 //  RDNA3-SAME:   mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<WMMA_F32_16x16x16_F16>,
 //  RDNA3-SAME:     subgroup_m_count = 2, subgroup_n_count = 2>
 
@@ -512,7 +512,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 }
 
 //       RDNA3: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [64, 2, 1] subgroup_size = 32
-//  RDNA3-SAME:   gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[PrefetchSharedMemory]>
+//  RDNA3-SAME:   gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true
 //  RDNA3-SAME:   mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<WMMA_F16_16x16x16_F16>,
 //  RDNA3-SAME:     subgroup_m_count = 2, subgroup_n_count = 2>
 
@@ -563,7 +563,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 // Basic pipeline test to make sure it generates the instructions we expect.
 
 // CHECK:       #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUPadAndVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
-// CHECK-SAME:    gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[PrefetchSharedMemory]>
+// CHECK-SAME:    gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true
 // CHECK-SAME:    mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
 // CHECK-SAME:    subgroup_m_count = 1, subgroup_n_count = 1>
 
@@ -649,7 +649,7 @@ hal.executable public @contract_schedule_considering_read_layout {
 // Basic pipeline test to make sure it generates the instructions we expect.
 
 // CHECK:       #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64
-// CHECK-SAME:    gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[PrefetchSharedMemory]>
+// CHECK-SAME:    gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true
 // CHECK-SAME:    mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
 // CHECK-SAME:    subgroup_m_count = 1, subgroup_n_count = 4>
 
@@ -709,7 +709,7 @@ hal.executable private @attention_20x4096x64x4096x64 {
 // CHECK-SAME:    mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
 // CHECK-SAME:    subgroup_m_count = 1, subgroup_n_count = 1>
 // Prefetching is disabled for attention for now
-// CHECK-NOT:     gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[PrefetchSharedMemory]>
+// CHECK-NOT:     gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true
 
 // CHECK-LABEL: func.func @attention_20x4096x64x4096x64()
 // CHECK-SAME:    translation_info = #[[$TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute.mlir
@@ -46,9 +46,9 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 // Basic pipeline test to make sure it generates the instructions we expect.
 
 //       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64
+//  CHECK-SAME:   gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[PrefetchSharedMemory]>
 //  CHECK-SAME:   mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
 //  CHECK-SAME:     subgroup_m_count = 2, subgroup_n_count = 2>
-//  CHECK-SAME:   prefetch_shared_memory
 
 //    CHECK-LABEL: func.func @matmul_256x256x256_f16_f32()
 //     CHECK-SAME:    translation_info = #[[$TRANSLATION]]
@@ -93,9 +93,9 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 }
 
 //       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64
+//  CHECK-SAME:   gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[PrefetchSharedMemory]>
 //  CHECK-SAME:   mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
 //  CHECK-SAME:     subgroup_m_count = 2, subgroup_n_count = 2>
-//  CHECK-SAME:   prefetch_shared_memory
 
 //    CHECK-LABEL: func.func @matmul_256x256x256_f16_f16()
 //     CHECK-SAME:     translation_info = #[[$TRANSLATION]]
@@ -160,7 +160,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 }
 
 //          CHECK: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64
-//     CHECK-SAME: prefetch_shared_memory
+//     CHECK-SAME: gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[PrefetchSharedMemory]>
 
 //          CHECK: func @expanded_matmul_transpose_b
 //     CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -212,9 +212,9 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 // Make sure it generates the mfma instructions we expect for f8 inputs.
 
 //       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64
+//  CHECK-SAME:   gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[PrefetchSharedMemory]>
 //  CHECK-SAME:   mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x32_F8E4M3FNUZ>,
 //  CHECK-SAME:     subgroup_m_count = 2, subgroup_n_count = 2>
-//  CHECK-SAME:   prefetch_shared_memory
 
 //    CHECK-LABEL: func.func @matmul_256x256x256_f8_f32()
 //     CHECK-SAME:    translation_info = #[[$TRANSLATION]]
@@ -261,9 +261,9 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 // Make sure it generates the mfma instructions we expect for integer inputs.
 
 //       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64
+//  CHECK-SAME:   gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[PrefetchSharedMemory]>
 //  CHECK-SAME:   mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>,
 //  CHECK-SAME:     subgroup_m_count = 2, subgroup_n_count = 2>
-//  CHECK-SAME:   prefetch_shared_memory
 
 //    CHECK-LABEL: func.func @matmul_256x256x256_i8_i32()
 //     CHECK-SAME:    translation_info = #[[$TRANSLATION]]
@@ -310,9 +310,9 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 // Make sure it generates the mfma instructions we expect for integer inputs.
 
 //       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64
+//  CHECK-SAME:   gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[PrefetchSharedMemory]>
 //  CHECK-SAME:   mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_I32_16x16x32_I8>,
 //  CHECK-SAME:     subgroup_m_count = 2, subgroup_n_count = 2>
-//  CHECK-SAME:   prefetch_shared_memory
 
 //    CHECK-LABEL: func.func @matmul_transpose_b_256x256x256_i8_i32()
 //     CHECK-SAME:    translation_info = #[[$TRANSLATION]]
@@ -413,9 +413,9 @@ hal.executable public @main_dispatch_expanded_matmul {
 
 
 //       CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64
+//  CHECK-SAME:   gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[PrefetchSharedMemory]>
 //  CHECK-SAME:   mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
 //  CHECK-SAME:     subgroup_m_count = 2, subgroup_n_count = 2>
-//  CHECK-SAME: prefetch_shared_memory
 
 //    CHECK-LABEL: func.func @generic_2x1024x20x64x1280_f16
 // This has more than 2 iteartions. So we have prefetching enabled for this case. Due to
@@ -462,9 +462,9 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 }
 
 //       RDNA3: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [64, 2, 1] subgroup_size = 32
+//  RDNA3-SAME:   gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[PrefetchSharedMemory]>
 //  RDNA3-SAME:   mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<WMMA_F32_16x16x16_F16>,
 //  RDNA3-SAME:     subgroup_m_count = 2, subgroup_n_count = 2>
-//  RDNA3-SAME:   prefetch_shared_memory
 
 //    RDNA3-LABEL: func.func @matmul_256x256x256_f16_f32
 //     RDNA3-SAME:    translation_info = #[[$TRANSLATION]]
@@ -512,9 +512,9 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 }
 
 //       RDNA3: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [64, 2, 1] subgroup_size = 32
+//  RDNA3-SAME:   gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[PrefetchSharedMemory]>
 //  RDNA3-SAME:   mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<WMMA_F16_16x16x16_F16>,
 //  RDNA3-SAME:     subgroup_m_count = 2, subgroup_n_count = 2>
-//  RDNA3-SAME:   prefetch_shared_memory
 
 //    RDNA3-LABEL: func.func @matmul_256x256x256_f16_f16
 //     RDNA3-SAME:    translation_info = #[[$TRANSLATION]]
@@ -563,9 +563,9 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 // Basic pipeline test to make sure it generates the instructions we expect.
 
 // CHECK:       #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUPadAndVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
+// CHECK-SAME:    gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[PrefetchSharedMemory]>
 // CHECK-SAME:    mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
 // CHECK-SAME:    subgroup_m_count = 1, subgroup_n_count = 1>
-// CHECK-SAME:    prefetch_shared_memory
 
 // CHECK-LABEL: func.func @unaligned_nk_batch_matmul()
 // CHECK-SAME:    translation_info = #[[$TRANSLATION]]
@@ -649,9 +649,9 @@ hal.executable public @contract_schedule_considering_read_layout {
 // Basic pipeline test to make sure it generates the instructions we expect.
 
 // CHECK:       #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64
+// CHECK-SAME:    gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[PrefetchSharedMemory]>
 // CHECK-SAME:    mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
 // CHECK-SAME:    subgroup_m_count = 1, subgroup_n_count = 4>
-// CHECK-SAME:    prefetch_shared_memory
 
 // CHECK-LABEL: func.func @contract_schedule_considering_read_layout()
 // CHECK-SAME:    translation_info = #[[$TRANSLATION]]
@@ -709,7 +709,7 @@ hal.executable private @attention_20x4096x64x4096x64 {
 // CHECK-SAME:    mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
 // CHECK-SAME:    subgroup_m_count = 1, subgroup_n_count = 1>
 // Prefetching is disabled for attention for now
-// CHECK-NOT:     prefetch_shared_memory
+// CHECK-NOT:     gpu_pipeline_options = #iree_gpu<gpu_pipeline_options[PrefetchSharedMemory]>
 
 // CHECK-LABEL: func.func @attention_20x4096x64x4096x64()
 // CHECK-SAME:    translation_info = #[[$TRANSLATION]]


### PR DESCRIPTION
This moves `LLVMGPUPipelineOptions` to `Codegen/Dialect/GPU` so that pipeline options can be set by iree_gpu lowering configuration logic (like `setMatmulLoweringConfig` in `ConfigUtils.cpp`).

A new attribute `GPUPipelineOptionsAttr` is added, with optional parameters defined for each existing pipeline option. The assembly of the pipline attributes has changed, since the options are now part of the `iree_gpu` dialect. For the purposes of setting user configurations with transform dialect this PR changes the following:

All pipeline option attributes should now be contained in a single `#iree_gpu.pipeline_options<>`
 - `reorder_workgroups = "none"/"swizzle"/"transpose"` becomes one of the pipeline options `reorder_workgroups_strategy = None/Swizzle/Transpose`
 - `prefetch_shared_memory` becomes the pipeline option `prefetch_shared_memory = true/false`
 - `no_reduce_shared_memory_bank_conflicts` becomes the pipeline option `no_reduce_shared_memory_bank_conflicts = true/false`

Example:

After this change, the translation_info config dict changes from
```
{reorder_workgroups = "swizzle", prefetch_shared_memory}
```
to
```
{gpu_pipeline_options =
    #iree_gpu.pipeline_options<
        prefetch_shared_memory = true, reorder_workgroups_strategy = Swizzle
    >}
```