### PR TITLE
[LLVMGPU] Improve mfma tile sizes for TileAndFuse pipeline

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -244,8 +244,13 @@ static GPUMMASchedule getOptimalMMASchedule(const GPUMatmulShapeType &problem,
 
   const uint64_t kTotalTileCount =
       llvm::divideCeil(problem.kSize, intrinsic.kSize);
-  APInt kGCD = GreatestCommonDivisor(
-      APInt(64, kTotalTileCount), APInt(64, seeds.bestKTileCountPerSubgroup));
+  int64_t bestKTileCountPerSubgroup =
+      seeds.bestKElementCountPerSubgroup
+          ? llvm::divideCeil(seeds.bestKElementCountPerSubgroup,
+                             intrinsic.kSize)
+          : seeds.bestKTileCountPerSubgroup;
+  APInt kGCD = GreatestCommonDivisor(APInt(64, kTotalTileCount),
+                                     APInt(64, bestKTileCountPerSubgroup));
   int64_t kTileCount = kGCD.getSExtValue();
 
   return GPUMMASchedule{intrinsicIndex,  intrinsic.mSize, intrinsic.nSize,

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
@@ -29,6 +29,10 @@ struct GPUMMAHeuristicSeeds {
   int64_t bestMNTileCountPerSubgroup;
   // The best number of tiles along K dimension per subgroup
   int64_t bestKTileCountPerSubgroup;
+  // The best number of elements along K dimension per subgroup. This is
+  // equivalent to `bestKTileCountPerSubgroup * bestIntrinsic.kSize`, for
+  // some chosen intrinsic `bestIntrinsic`.
+  int64_t bestKElementCountPerSubgroup = 0;
 };
 
 struct GPUMMASchedule {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -87,6 +87,7 @@ LogicalResult setMatmulLoweringConfig(IREE::GPU::TargetAttr target,
 
   GPUMMAHeuristicSeeds seeds;
   int64_t inBitWidth = lhsElemType.getIntOrFloatBitWidth();
+  int64_t cacheLineSizeBits = 1024;
 
   // Note that the following heuristic seeds are just placeholder values.
   // We need to clean it up and make it adjusting to different targets.
@@ -98,12 +99,12 @@ LogicalResult setMatmulLoweringConfig(IREE::GPU::TargetAttr target,
     seeds = {/*bestSubgroupCountPerWorkgroup=*/4,
              /*bestMNTileCountPerSubgroup=*/4,
              /*bestKTileCountPerSubgroup=*/8,
-             /*bestKElementCountPerSubgroup*/ 512 / inBitWidth};
+             /*bestKElementCountPerSubgroup*/ cacheLineSizeBits / inBitWidth};
   } else {
     seeds = {/*bestSubgroupCountPerWorkgroup=*/4,
              /*bestMNTileCountPerSubgroup=*/16,
              /*bestKTileCountPerSubgroup=*/4,
-             /*bestKElementCountPerSubgroup*/ 512 / inBitWidth};
+             /*bestKElementCountPerSubgroup*/ cacheLineSizeBits / inBitWidth};
   }
 
   int64_t maxSharedMemoryBytes = target.getWgp().getMaxWorkgroupMemoryBytes();

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -102,7 +102,7 @@ LogicalResult setMatmulLoweringConfig(IREE::GPU::TargetAttr target,
              /*bestKElementCountPerSubgroup*/ cacheLineSizeBits / inBitWidth};
   } else {
     seeds = {/*bestSubgroupCountPerWorkgroup=*/4,
-             /*bestMNTileCountPerSubgroup=*/16,
+             /*bestMNTileCountPerSubgroup=*/8,
              /*bestKTileCountPerSubgroup=*/4,
              /*bestKElementCountPerSubgroup*/ cacheLineSizeBits / inBitWidth};
   }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -86,6 +86,7 @@ LogicalResult setMatmulLoweringConfig(IREE::GPU::TargetAttr target,
     return failure();
 
   GPUMMAHeuristicSeeds seeds;
+  int64_t inBitWidth = lhsElemType.getIntOrFloatBitWidth();
 
   // Note that the following heuristic seeds are just placeholder values.
   // We need to clean it up and make it adjusting to different targets.
@@ -96,11 +97,13 @@ LogicalResult setMatmulLoweringConfig(IREE::GPU::TargetAttr target,
     // and a larger bestKTileCountPerSubgroup.
     seeds = {/*bestSubgroupCountPerWorkgroup=*/4,
              /*bestMNTileCountPerSubgroup=*/4,
-             /*bestKTileCountPerSubgroup=*/8};
+             /*bestKTileCountPerSubgroup=*/8,
+             /*bestKElementCountPerSubgroup*/ 512 / inBitWidth};
   } else {
     seeds = {/*bestSubgroupCountPerWorkgroup=*/4,
-             /*bestMNTileCountPerSubgroup=*/8,
-             /*bestKTileCountPerSubgroup=*/4};
+             /*bestMNTileCountPerSubgroup=*/16,
+             /*bestKTileCountPerSubgroup=*/4,
+             /*bestKElementCountPerSubgroup*/ 512 / inBitWidth};
   }
 
   int64_t maxSharedMemoryBytes = target.getWgp().getMaxWorkgroupMemoryBytes();

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -27,6 +27,8 @@
 
 namespace mlir::iree_compiler::IREE::GPU {
 
+constexpr int64_t kCacheLineSizeBits = 128 * 8;
+
 LogicalResult setMatmulLoweringConfig(IREE::GPU::TargetAttr target,
                                       mlir::FunctionOpInterface entryPoint,
                                       Operation *op) {
@@ -87,7 +89,6 @@ LogicalResult setMatmulLoweringConfig(IREE::GPU::TargetAttr target,
 
   GPUMMAHeuristicSeeds seeds;
   int64_t inBitWidth = lhsElemType.getIntOrFloatBitWidth();
-  int64_t cacheLineSizeBits = 1024;
 
   // Note that the following heuristic seeds are just placeholder values.
   // We need to clean it up and make it adjusting to different targets.
@@ -99,12 +100,12 @@ LogicalResult setMatmulLoweringConfig(IREE::GPU::TargetAttr target,
     seeds = {/*bestSubgroupCountPerWorkgroup=*/4,
              /*bestMNTileCountPerSubgroup=*/4,
              /*bestKTileCountPerSubgroup=*/8,
-             /*bestKElementCountPerSubgroup*/ cacheLineSizeBits / inBitWidth};
+             /*bestKElementCountPerSubgroup*/ kCacheLineSizeBits / inBitWidth};
   } else {
     seeds = {/*bestSubgroupCountPerWorkgroup=*/4,
              /*bestMNTileCountPerSubgroup=*/8,
              /*bestKTileCountPerSubgroup=*/4,
-             /*bestKElementCountPerSubgroup*/ cacheLineSizeBits / inBitWidth};
+             /*bestKElementCountPerSubgroup*/ kCacheLineSizeBits / inBitWidth};
   }
 
   int64_t maxSharedMemoryBytes = target.getWgp().getMaxWorkgroupMemoryBytes();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
@@ -34,7 +34,7 @@ func.func @expanded_matmul_transpose_b(%lhs: tensor<2x64x2048xf16>, %rhs: tensor
 
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
-//  CHECK-SAME:     reduction = [0 : index, 0 : index, 0 : index, 0 : index, 2 : index]
+//  CHECK-SAME:     reduction = [0 : index, 0 : index, 0 : index, 0 : index, 4 : index]
 //  CHECK-SAME:     subgroup = [0 : index, 0 : index, 4 : index, 1 : index, 0 : index]
 //  CHECK-SAME:     workgroup = [1 : index, 1 : index, 64 : index, 64 : index, 0 : index]
 
@@ -57,9 +57,9 @@ func.func @mfma_matmul_1024x1024x1024(%lhs: tensor<1024x1024xf16>, %rhs: tensor<
 
 //       CHECK:   linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
-//  CHECK-SAME:     reduction = [0 : index, 0 : index, 2 : index]
-//  CHECK-SAME:     subgroup = [4 : index, 4 : index, 0 : index]
-//  CHECK-SAME:     workgroup = [128 : index, 128 : index, 0 : index]
+//  CHECK-SAME:     reduction = [0 : index, 0 : index, 4 : index]
+//  CHECK-SAME:     subgroup = [2 : index, 4 : index, 0 : index]
+//  CHECK-SAME:     workgroup = [64 : index, 128 : index, 0 : index]
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
@@ -34,7 +34,7 @@ func.func @expanded_matmul_transpose_b(%lhs: tensor<2x64x2048xf16>, %rhs: tensor
 
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
-//  CHECK-SAME:     reduction = [0 : index, 0 : index, 0 : index, 0 : index, 8 : index]
+//  CHECK-SAME:     reduction = [0 : index, 0 : index, 0 : index, 0 : index, 2 : index]
 //  CHECK-SAME:     subgroup = [0 : index, 0 : index, 4 : index, 1 : index, 0 : index]
 //  CHECK-SAME:     workgroup = [1 : index, 1 : index, 64 : index, 64 : index, 0 : index]
 
@@ -57,9 +57,9 @@ func.func @mfma_matmul_1024x1024x1024(%lhs: tensor<1024x1024xf16>, %rhs: tensor<
 
 //       CHECK:   linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
-//  CHECK-SAME:     reduction = [0 : index, 0 : index, 4 : index]
-//  CHECK-SAME:     subgroup = [2 : index, 4 : index, 0 : index]
-//  CHECK-SAME:     workgroup = [64 : index, 128 : index, 0 : index]
+//  CHECK-SAME:     reduction = [0 : index, 0 : index, 2 : index]
+//  CHECK-SAME:     subgroup = [4 : index, 4 : index, 0 : index]
+//  CHECK-SAME:     workgroup = [128 : index, 128 : index, 0 : index]
 
 // -----
 


### PR DESCRIPTION
This attempts to select better tile sizes on the TileAndFuse pipeline based on the number of elements loaded along the K dimension tile. A new field is added to `GPUMMAHeuristicSeeds` called `bestKElementCountPerSubgroup`, which represents the best number of elements to have along the K dimension of a subgroup tile. This can be more useful than the existing `bestKTileCountPerSubgroup`, since it takes into account the size of the intrinsic being selected. Having control over the specific number of elements loaded helps give better control over overall VGPR utilization and load queue saturation.

The tile size selection logic in `setMatmulLoweringConfig` has been tuned using this new field. The current tile sizes improve overall performance on SDXL for the TileAndFuse pipeline over the old tile size selection logic.