### PR TITLE
[NFC] Fix pass declarations

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/DecomposeSoftmax.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DecomposeSoftmax.cpp
@@ -36,12 +36,12 @@ namespace {
 /// 4. Divide z and l. This gives the N-dimensional softmax.
 ///    softmax = z / l
 ///
-static LogicalResult convertSoftmaxToGenerics(mlir::FunctionOpInterface funcOp,
+static LogicalResult convertSoftmaxToGenerics(Operation *rootOp,
                                               bool useFusion) {
-  IRRewriter rewriter(funcOp.getContext());
+  IRRewriter rewriter(rootOp->getContext());
   SmallVector<Operation *> toDelete;
   SmallVector<Operation *> softmaxOpsToDecompose;
-  funcOp.walk([&](linalg::SoftmaxOp softmaxOp) {
+  rootOp->walk([&](linalg::SoftmaxOp softmaxOp) {
     softmaxOpsToDecompose.push_back(softmaxOp);
   });
 

--- a/compiler/src/iree/compiler/Codegen/Common/EraseDeadAllocAndStores.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EraseDeadAllocAndStores.cpp
@@ -32,9 +32,9 @@ public:
 };
 
 void EraseDeadAllocAndStoresPass::runOnOperation() {
-  auto funcOp = getOperation();
+  Operation *rootOp = getOperation();
   IRRewriter rewriter(&getContext());
-  memref::eraseDeadAllocAndStores(rewriter, funcOp);
+  memref::eraseDeadAllocAndStores(rewriter, rootOp);
 }
 
 } // namespace

--- a/compiler/src/iree/compiler/Codegen/Common/ForOpCanonicalizationPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ForOpCanonicalizationPass.cpp
@@ -296,18 +296,20 @@ struct ForOpCanonicalizationPass final
   }
 
   void runOnOperation() override {
-    auto fn = getOperation();
+    Operation *rootOp = getOperation();
     // These patterns collide so we apply them one after another. The
     // canonicalization pattern will be blocked by the packing pattern
     // so we apply that first.
     RewritePatternSet canonPatterns(&getContext());
-    canonPatterns.insert<CanonicalizeForOpInductionVarShape>(fn.getContext());
-    if (failed(applyPatternsAndFoldGreedily(fn, std::move(canonPatterns)))) {
+    canonPatterns.insert<CanonicalizeForOpInductionVarShape>(
+        rootOp->getContext());
+    if (failed(
+            applyPatternsAndFoldGreedily(rootOp, std::move(canonPatterns)))) {
       return signalPassFailure();
     }
     RewritePatternSet packPatterns(&getContext());
-    packPatterns.insert<PackForOpInductionVarVector>(fn.getContext());
-    if (failed(applyPatternsAndFoldGreedily(fn, std::move(packPatterns)))) {
+    packPatterns.insert<PackForOpInductionVarVector>(rootOp->getContext());
+    if (failed(applyPatternsAndFoldGreedily(rootOp, std::move(packPatterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/FuseTensorPadWithConsumer.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FuseTensorPadWithConsumer.cpp
@@ -20,12 +20,12 @@ struct FuseTensorPadWithConsumerPass final
     : impl::FuseTensorPadWithConsumerPassBase<FuseTensorPadWithConsumerPass> {
   void runOnOperation() override {
     MLIRContext *context = &getContext();
-    auto funcOp = getOperation();
+    Operation *rootOp = getOperation();
 
     RewritePatternSet patterns(context);
     patterns.insert<linalg::ExtractSliceOfPadTensorSwapPattern>(
         context, [](tensor::ExtractSliceOp) { return false; });
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    if (failed(applyPatternsAndFoldGreedily(rootOp, std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUGeneralizeNamedOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUGeneralizeNamedOps.cpp
@@ -51,9 +51,8 @@ namespace {
 struct GPUGeneralizeNamedOpsPass final
     : impl::GPUGeneralizeNamedOpsPassBase<GPUGeneralizeNamedOpsPass> {
   void runOnOperation() override {
-    FunctionOpInterface funcOp = getOperation();
     SmallVector<linalg::LinalgOp> namedOpCandidates;
-    funcOp.walk([&](linalg::LinalgOp linalgOp) {
+    getOperation()->walk([&](linalg::LinalgOp linalgOp) {
       if (isa<linalg::BatchMatmulTransposeBOp, linalg::MatmulTransposeBOp,
               linalg::VecmatOp, linalg::MatvecOp>(linalgOp))
         namedOpCandidates.push_back(linalgOp);

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUInferMemorySpace.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUInferMemorySpace.cpp
@@ -50,14 +50,14 @@ bool isDefinitelyShared(bufferization::AllocTensorOp alloc) {
 
 void GPUInferMemorySpacePass::runOnOperation() {
   MLIRContext *context = &getContext();
-  FunctionOpInterface funcOp = getOperation();
+  Operation *rootOp = getOperation();
 
   gpu::AddressSpaceAttr privateAddressSpace = gpu::AddressSpaceAttr::get(
       context, gpu::GPUDialect::getPrivateAddressSpace());
   gpu::AddressSpaceAttr sharedAddressSpace = gpu::AddressSpaceAttr::get(
       context, gpu::GPUDialect::getWorkgroupAddressSpace());
 
-  WalkResult res = funcOp.walk([&](bufferization::AllocTensorOp alloc) {
+  WalkResult res = rootOp->walk([&](bufferization::AllocTensorOp alloc) {
     // Continue if the allocation already has a valid memory space.
     std::optional<Attribute> currentMemSpace = alloc.getMemorySpace();
     if (currentMemSpace.has_value()) {
@@ -95,7 +95,7 @@ void GPUInferMemorySpacePass::runOnOperation() {
   });
 
   if (res.wasInterrupted()) {
-    funcOp->emitOpError("failed to set the gpu memory space for all "
+    rootOp->emitOpError("failed to set the gpu memory space for all "
                         "`bufferization.alloc_tensor` ops");
     return signalPassFailure();
   }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPipelining.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPipelining.cpp
@@ -670,10 +670,10 @@ struct GPUPipeliningPass final
   using GPUPipeliningPassBase::GPUPipeliningPassBase;
 
   void runOnOperation() override {
-    FunctionOpInterface funcOp = getOperation();
+    Operation *rootOp = getOperation();
     SmallVector<scf::ForOp> forOps;
     // Mark the loop with shared memory copy for pipelining.
-    funcOp.walk([&forOps](scf::ForOp forOp) { forOps.push_back(forOp); });
+    rootOp->walk([&forOps](scf::ForOp forOp) { forOps.push_back(forOp); });
     for (scf::ForOp forOp : forOps) {
       (void)applyPipelining(
           forOp, depth, epiloguePeeling,
@@ -681,7 +681,7 @@ struct GPUPipeliningPass final
     }
     // Remove extra barriers from the prologue assuming appropriate
     // multi-buffering.
-    funcOp.walk([](gpu::BarrierOp barrierOp) {
+    rootOp->walk([](gpu::BarrierOp barrierOp) {
       if (barrierOp->hasAttr(kPipeliningExtraBarrier))
         barrierOp->erase();
     });

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromoteMatmulOperands.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromoteMatmulOperands.cpp
@@ -95,10 +95,10 @@ bool isNonMatvecContraction(linalg::LinalgOp linalgOp) {
 struct GPUPromoteMatmulOperandsPass final
     : impl::GPUPromoteMatmulOperandsPassBase<GPUPromoteMatmulOperandsPass> {
   void runOnOperation() override {
-    FunctionOpInterface funcOp = getOperation();
+    Operation *rootOp = getOperation();
 
-    OpBuilder builder(funcOp);
-    funcOp.walk([&](linalg::LinalgOp linalgOp) {
+    OpBuilder builder(rootOp);
+    rootOp->walk([&](linalg::LinalgOp linalgOp) {
       if (!isNonMatvecContraction(linalgOp)) {
         return;
       }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorAlloc.cpp
@@ -11,13 +11,11 @@
 #include "iree/compiler/Codegen/Utils/LinalgOpInfo.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
-#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/Utils/StructuredOpsUtils.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
-#include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Transforms/Passes.h"
 
 namespace mlir::iree_compiler {
@@ -99,10 +97,9 @@ static Value readVectorFromTensor(OpBuilder &b, VectorType vectorType,
 struct GPUVectorAllocPass final
     : impl::GPUVectorAllocPassBase<GPUVectorAllocPass> {
   void runOnOperation() override {
-    FunctionOpInterface funcOp = getOperation();
 
     SmallVector<IREE::VectorExt::ToLayoutOp> opsToPromote;
-    funcOp.walk([&](IREE::VectorExt::ToLayoutOp op) {
+    getOperation()->walk([&](IREE::VectorExt::ToLayoutOp op) {
       if (op.getSharedMemoryConversion()) {
         opsToPromote.push_back(op);
       }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVerifyDistribution.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVerifyDistribution.cpp
@@ -28,9 +28,9 @@ struct GPUVerifyDistributionPass final
     : impl::GPUVerifyDistributionPassBase<GPUVerifyDistributionPass> {
 
   void runOnOperation() override {
-    FunctionOpInterface funcOp = getOperation();
+    Operation *rootOp = getOperation();
 
-    WalkResult res = funcOp.walk([](Operation *op) {
+    WalkResult res = rootOp->walk([](Operation *op) {
       if (auto forallOp = dyn_cast<scf::ForallOp>(op)) {
         std::optional<ArrayAttr> mapping = forallOp.getMapping();
         if (!mapping || mapping.value().empty()) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.h
@@ -93,7 +93,7 @@ createGPUCheckResourceUsagePass(
 
 // Creates a pass to create allocations for some tensor values to use GPU
 // shared memory.
-std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
+std::unique_ptr<Pass>
 createGPUTensorAlloc(GPUPromoteSharedMemPattern promoteSharedMemPattern =
                          GPUPromoteSharedMemPattern::ContractionOpPattern);
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -61,12 +61,11 @@ def GPUDistributeScfForPass :
 }
 
 def GPUGeneralizeNamedOpsPass :
-    InterfacePass<"iree-codegen-gpu-generalize-named-ops", "mlir::FunctionOpInterface"> {
+    Pass<"iree-codegen-gpu-generalize-named-ops", ""> {
   let summary = "Convert named Linalg ops to linalg.generic ops";
 }
 
-def GPUInferMemorySpacePass :
-    InterfacePass<"iree-codegen-gpu-infer-memory-space", "mlir::FunctionOpInterface"> {
+def GPUInferMemorySpacePass : Pass<"iree-codegen-gpu-infer-memory-space", ""> {
   let summary = "Pass to infer and set the memory space for all alloc_tensor ops.";
   let dependentDialects = [
     "::mlir::gpu::GPUDialect"
@@ -93,8 +92,7 @@ def GPUMultiBufferingPass :
   ];
 }
 
-def GPUPipeliningPass :
-    InterfacePass<"iree-codegen-gpu-pipelining", "mlir::FunctionOpInterface"> {
+def GPUPipeliningPass : Pass<"iree-codegen-gpu-pipelining", ""> {
   let summary = "Pass to do software pipelining.";
   let options = [
     Option<"epiloguePeeling", "epilogue-peeling", "bool",
@@ -115,8 +113,7 @@ def GPUPipeliningPass :
 }
 
 def GPUPromoteMatmulOperandsPass :
-    InterfacePass<"iree-codegen-gpu-promote-matmul-operands",
-                  "mlir::FunctionOpInterface"> {
+    Pass<"iree-codegen-gpu-promote-matmul-operands", ""> {
   let summary = "Pass to insert copies with a different thread configuration "
                 "on matmul operands";
   let dependentDialects = [
@@ -143,8 +140,7 @@ def GPUReuseSharedMemoryAllocsPass :
   ];
 }
 
-def GPUTensorAllocPass :
-    InterfacePass<"iree-codegen-gpu-tensor-alloc", "mlir::FunctionOpInterface"> {
+def GPUTensorAllocPass : Pass<"iree-codegen-gpu-tensor-alloc", ""> {
   let summary = "Pass to create allocations for some tensor values to use"
                 "GPU shared memory";
   let constructor = "mlir::iree_compiler::createGPUTensorAlloc()";
@@ -164,8 +160,7 @@ def GPUTensorTilePass :
   ];
 }
 
-def GPUApplyTilingLevelPass :
-    InterfacePass<"iree-codegen-gpu-apply-tiling-level", "mlir::FunctionOpInterface"> {
+def GPUApplyTilingLevelPass : Pass<"iree-codegen-gpu-apply-tiling-level", ""> {
   let summary = "Pass to tile tensor ops based on tiling configs";
   let dependentDialects = [
     "::mlir::affine::AffineDialect", "::mlir::gpu::GPUDialect",
@@ -187,7 +182,8 @@ def GPUApplyTilingLevelPass :
 }
 
 def GPUTensorTileToSerialLoopsPass :
-    InterfacePass<"iree-codegen-gpu-tensor-tile-to-serial-loops", "mlir::FunctionOpInterface"> {
+    InterfacePass<"iree-codegen-gpu-tensor-tile-to-serial-loops",
+                  "mlir::FunctionOpInterface"> {
   let summary = "Pass to tile reduction dimensions for certain GPU ops";
   let dependentDialects = ["::mlir::scf::SCFDialect"];
   let options = [
@@ -206,13 +202,11 @@ def GPUTileReductionPass :
   let dependentDialects = ["::mlir::scf::SCFDialect"];
 }
 
-def GPUVerifyDistributionPass :
-    InterfacePass<"iree-codegen-gpu-verify-distribution", "mlir::FunctionOpInterface"> {
+def GPUVerifyDistributionPass : Pass<"iree-codegen-gpu-verify-distribution", ""> {
   let summary = "Pass to verify writes before resolving distributed contexts.";
 }
 
-def GPUVectorAllocPass :
-    InterfacePass<"iree-codegen-gpu-vector-alloc", "mlir::FunctionOpInterface"> {
+def GPUVectorAllocPass : Pass<"iree-codegen-gpu-vector-alloc", ""> {
   let summary = "Pass to create allocations for contraction inputs to copy "
                 "to GPU shared memory";
   let dependentDialects = [

--- a/compiler/src/iree/compiler/Codegen/Common/HoistUnrolledVectorExtractInsertSlice.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/HoistUnrolledVectorExtractInsertSlice.cpp
@@ -212,9 +212,9 @@ public:
 };
 
 void HoistUnrolledVectorExtractInsertSlicePass::runOnOperation() {
-  auto funcOp = getOperation();
-  IRRewriter rewriter(funcOp->getContext());
-  funcOp.walk([&](scf::ForOp forOp) {
+  Operation *rootOp = getOperation();
+  IRRewriter rewriter(rootOp->getContext());
+  rootOp->walk([&](scf::ForOp forOp) {
     hoistUnrolledVectorExtractInsert(rewriter, forOp);
   });
 
@@ -224,7 +224,7 @@ void HoistUnrolledVectorExtractInsertSlicePass::runOnOperation() {
   scf::ForOp::getCanonicalizationPatterns(patterns, ctx);
   vector::InsertStridedSliceOp::getCanonicalizationPatterns(patterns, ctx);
   vector::ExtractStridedSliceOp::getCanonicalizationPatterns(patterns, ctx);
-  if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+  if (failed(applyPatternsAndFoldGreedily(rootOp, std::move(patterns)))) {
     LLVM_DEBUG(llvm::dbgs() << "----- cleanup failed -----\n");
     return signalPassFailure();
   }

--- a/compiler/src/iree/compiler/Codegen/Common/InstrumentMemoryAccesses.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/InstrumentMemoryAccesses.cpp
@@ -26,7 +26,7 @@ struct InstrumentMemoryAccessesPass
     // Lookup the root instrumentation op. If not present it means the dispatch
     // is not instrumented and we can skip it.
     IREE::HAL::InstrumentWorkgroupOp instrumentOp;
-    getOperation().walk([&](IREE::HAL::InstrumentWorkgroupOp op) {
+    getOperation()->walk([&](IREE::HAL::InstrumentWorkgroupOp op) {
       instrumentOp = op;
       return WalkResult::interrupt();
     });

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoNop.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoNop.cpp
@@ -32,7 +32,7 @@ struct MaterializeEncodingIntoNopPass final
 
   void runOnOperation() override {
     MLIRContext *context = &getContext();
-    auto operation = getOperation();
+    Operation *operation = getOperation();
 
     auto materializeEncodingFn = [](RankedTensorType,
                                     IREE::HAL::ExecutableTargetAttr)
@@ -53,7 +53,7 @@ struct MaterializeEncodingIntoNopPass final
 
     if (failed(applyPartialConversion(operation, target,
                                       std::move(materializeEncodingPattern)))) {
-      operation.emitOpError("materialization failed");
+      operation->emitOpError("materialization failed");
       return signalPassFailure();
     }
 
@@ -65,7 +65,7 @@ struct MaterializeEncodingIntoNopPass final
           ->getCanonicalizationPatterns(patterns);
       if (failed(
               applyPatternsAndFoldGreedily(operation, std::move(patterns)))) {
-        operation.emitOpError("folding patterns failed");
+        operation->emitOpError("folding patterns failed");
         return signalPassFailure();
       }
     }

--- a/compiler/src/iree/compiler/Codegen/Common/PadDynamicAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/PadDynamicAlloc.cpp
@@ -81,11 +81,11 @@ namespace {
 struct PadDynamicAllocPass final
     : impl::PadDynamicAllocPassBase<PadDynamicAllocPass> {
   void runOnOperation() override {
-    auto funcOp = getOperation();
+    Operation *rootOp = getOperation();
     MLIRContext *context = &getContext();
     SmallVector<memref::AllocOp> sharedMemAllocs;
     // Collect all the alloc operations.
-    funcOp.walk(
+    rootOp->walk(
         [&](memref::AllocOp allocOp) { sharedMemAllocs.push_back(allocOp); });
     for (memref::AllocOp alloc : sharedMemAllocs) {
       if (failed(padAlloc(context, alloc)))

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.h
@@ -59,8 +59,7 @@ std::unique_ptr<InterfacePass<FunctionOpInterface>>
 createConvertToDestinationPassingStylePass(
     bool useWARForCooperativeMatrixCodegen);
 
-std::unique_ptr<InterfacePass<FunctionOpInterface>>
-createDecomposePackUnPackOpsPass(bool tileOuterToOne);
+std::unique_ptr<Pass> createDecomposePackUnPackOpsPass(bool tileOuterToOne);
 
 std::unique_ptr<Pass> createDecomposeSoftmaxPass(bool useFusion);
 
@@ -72,8 +71,7 @@ std::unique_ptr<Pass> createDecomposeSoftmaxPass(bool useFusion);
 /// is specified, the default allocator generates an `std.alloc` instruction
 /// with the allocated MemRefType having no stride map (i.e. default row-major
 /// striding) and default memory space.
-std::unique_ptr<InterfacePass<FunctionOpInterface>>
-createIREEComprehensiveBufferizePass(
+std::unique_ptr<Pass> createIREEComprehensiveBufferizePass(
     std::optional<BufferizationOptions::AllocationFn> allocationFn,
     std::optional<BufferizationOptions::MemCpyFn> memCpyFn);
 

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -123,8 +123,7 @@ def DecomposeAffineOpsPass: Pass<"iree-codegen-decompose-affine-ops"> {
   ];
 }
 
-def ConvolutionToIGEMMPass :
-    InterfacePass<"iree-codegen-convolution-to-igemm", "mlir::FunctionOpInterface"> {
+def ConvolutionToIGEMMPass : Pass<"iree-codegen-convolution-to-igemm", ""> {
   let summary =
       "Transforms convolution operations into an implicit GEMM format.";
 }
@@ -149,7 +148,7 @@ def DecomposeLinalgGenericPass :
 }
 
 def DecomposePackUnPackOpsPass :
-    InterfacePass<"iree-codegen-decompose-pack-unpack-ops", "mlir::FunctionOpInterface"> {
+    Pass<"iree-codegen-decompose-pack-unpack-ops", ""> {
   let summary = "Decompose pack/unpack ops into vectorizable ops";
   let options = [
     Option<"tileOuterToOne", "tile-outer-to-one", "bool", "false",
@@ -157,8 +156,7 @@ def DecomposePackUnPackOpsPass :
   ];
 }
 
-def DecomposeSoftmaxPass :
-    InterfacePass<"iree-codegen-decompose-softmax", "mlir::FunctionOpInterface"> {
+def DecomposeSoftmaxPass : Pass<"iree-codegen-decompose-softmax", ""> {
   let summary =
       "Decomposes softmax op into a sequence of linalg ops";
   let options = [
@@ -177,19 +175,17 @@ def ReconcileTranslationInfoPass
 }
 
 def ReplaceSlowMinMaxOpsPass
-    : InterfacePass<"iree-codegen-replace-slow-min-max-ops", "mlir::FunctionOpInterface"> {
+    : Pass<"iree-codegen-replace-slow-min-max-ops", ""> {
   let summary =
       "Replace slow min/max operations that propagate NaNs and distinguish "
       "between +/-0.0 with faster min/max operations that ignore them.";
 }
 
-def EliminateEmptyTensorsPass :
-    InterfacePass<"iree-eliminate-empty-tensors", "mlir::FunctionOpInterface"> {
+def EliminateEmptyTensorsPass : Pass<"iree-eliminate-empty-tensors", ""> {
   let summary = "Eliminate tensor.empty ops to avoid buffer allocations";
 }
 
-def EmulateNarrowTypePass :
-    Pass<"iree-codegen-emulate-narrow-type", ""> {
+def EmulateNarrowTypePass : Pass<"iree-codegen-emulate-narrow-type", ""> {
   let summary = "Emulate narrow integer operations using wide integer operations";
   let description = [{
     A pass to emulate memref load operations that use narrow integer types
@@ -198,7 +194,7 @@ def EmulateNarrowTypePass :
 }
 
 def EraseDeadAllocAndStoresPass :
-    InterfacePass<"iree-codegen-erase-dead-alloc-and-stores", "mlir::FunctionOpInterface"> {
+    Pass<"iree-codegen-erase-dead-alloc-and-stores", ""> {
   let summary = "Erase alloc ops if all the uses are just stores";
 }
 
@@ -245,7 +241,8 @@ def FlattenMemRefSubspanPass : Pass<"iree-codegen-flatten-memref-subspan", "Modu
 }
 
 def FoldAffineMinInDistributedLoopsPass :
-  InterfacePass<"iree-codegen-fold-affinemin-in-distributed-loops", "mlir::FunctionOpInterface"> {
+  InterfacePass<"iree-codegen-fold-affinemin-in-distributed-loops",
+                "mlir::FunctionOpInterface"> {
   let summary = "Fold `affine.min` ops in distributed loops";
 }
 
@@ -260,14 +257,13 @@ def FoldTensorExtractOpPass :
   }];
 }
 
-def ForOpCanonicalizationPass :
-  InterfacePass<"iree-codegen-canonicalize-scf-for", "mlir::FunctionOpInterface"> {
+def ForOpCanonicalizationPass : Pass<"iree-codegen-canonicalize-scf-for", ""> {
   let summary =
       "Adhoc canonicalization of selected loop-carried values/dependencies for scf.for ops";
 }
 
 def FuseTensorPadWithConsumerPass :
-    InterfacePass<"iree-codegen-fuse-tensor-pad-with-consumer", "mlir::FunctionOpInterface"> {
+    Pass<"iree-codegen-fuse-tensor-pad-with-consumer", ""> {
   let summary = "Fuse tensor.pad op into its consumer op's tiled loop nest";
 }
 
@@ -297,14 +293,13 @@ def GenericVectorizationPass :
 }
 
 def OptimizeTensorInsertExtractSlicesPass
-    : InterfacePass<"iree-codegen-optimize-tensor-insert-extract-slices",
-                    "mlir::FunctionOpInterface"> {
+    : Pass<"iree-codegen-optimize-tensor-insert-extract-slices", ""> {
   let summary = "Optimize tensor.insert_slice/tensor.extract_slice operations "
                 "(e.g. hoist and fold)";
 }
 
 def HoistUnrolledVectorExtractInsertSlicePass :
-    InterfacePass<"iree-codegen-hoist-vector-extract-insert-slice", "mlir::FunctionOpInterface"> {
+    Pass<"iree-codegen-hoist-vector-extract-insert-slice", ""> {
   let summary = "Hoist unrolled vector (extract, insert) pairs out of scf.for op";
 }
 
@@ -327,7 +322,7 @@ def HoistStaticallyBoundAllocationsPass :
 }
 
 def IREEComprehensiveBufferizePass :
-    InterfacePass<"iree-codegen-iree-comprehensive-bufferize", "mlir::FunctionOpInterface"> {
+    Pass<"iree-codegen-iree-comprehensive-bufferize", ""> {
   let summary = "Convert from to Linalg ops on tensors to buffers";
   let options = [
     Option<"testAnalysisOnly", "test-analysis-only", "bool",
@@ -349,7 +344,7 @@ def IREEExpandStridedMetadataPass :
 }
 
 def InstrumentMemoryAccessesPass :
-    InterfacePass<"iree-codegen-instrument-memory-accesses", "mlir::FunctionOpInterface"> {
+    Pass<"iree-codegen-instrument-memory-accesses", ""> {
   let summary = "Instruments memory reads and writes for address tracking when dispatch instrumentation is enabled.";
 }
 
@@ -364,7 +359,7 @@ def LowerUKernelOpsToCallsPass :
 }
 
 def MaterializeEncodingIntoNopPass :
-    InterfacePass<"iree-codegen-materialize-encoding-into-nop", "mlir::FunctionOpInterface"> {
+    Pass<"iree-codegen-materialize-encoding-into-nop", ""> {
   let summary = "Drop the encodings from tensor types with encodings.";
 }
 
@@ -375,8 +370,7 @@ def MaterializeUserConfigsPass : Pass<"iree-codegen-materialize-user-configs", "
   ];
 }
 
-def MemrefCopyToLinalgPass :
-    InterfacePass<"iree-codegen-memrefcopy-to-linalg", "mlir::FunctionOpInterface"> {
+def MemrefCopyToLinalgPass : Pass<"iree-codegen-memrefcopy-to-linalg", ""> {
   let summary = "Convert memref.copy to linalg op";
 }
 
@@ -400,7 +394,7 @@ def NormalizeLoopBoundsPass :
 }
 
 def OptimizeVectorTransferPass :
-    InterfacePass<"iree-codegen-optimize-vector-transfer", "mlir::FunctionOpInterface"> {
+    Pass<"iree-codegen-optimize-vector-transfer", ""> {
   let summary =
       "Run optimization transformations on vector transfer operations";
   let options = [
@@ -412,8 +406,7 @@ def OptimizeVectorTransferPass :
   ];
 }
 
-def PadDynamicAllocPass :
-    InterfacePass<"iree-codegen-pad-dynamic-alloc", "mlir::FunctionOpInterface"> {
+def PadDynamicAllocPass : Pass<"iree-codegen-pad-dynamic-alloc", ""> {
   let summary = "Pass to pad dynamic alloc into static one.";
 }
 
@@ -432,7 +425,7 @@ def PropagateReshapesByExpansionPass :
 }
 
 def RematerializeParallelOpsPass :
-    InterfacePass<"iree-codegen-rematerialize-parallel-ops", "mlir::FunctionOpInterface"> {
+    Pass<"iree-codegen-rematerialize-parallel-ops", ""> {
   let summary = "Pass to rematerialize and merge parallel ops into consumers.";
 }
 
@@ -442,7 +435,7 @@ def RemoveSingleIterationLoopPass :
 }
 
 def SplitFullPartialTransferPass :
-    InterfacePass<"iree-codegen-split-full-partial-transfer", "mlir::FunctionOpInterface"> {
+    Pass<"iree-codegen-split-full-partial-transfer", ""> {
   let summary =
       "Split a vector.transfer operation into an in-bounds (i.e., no "
       "out-of-bounds masking) fastpath and a slowpath.";
@@ -459,7 +452,7 @@ def SplitFullPartialTransferPass :
 }
 
 def TensorToVectorVectorizePadPass :
-    InterfacePass<"iree-codegen-vectorize-tensor-pad", "mlir::FunctionOpInterface"> {
+    Pass<"iree-codegen-vectorize-tensor-pad", ""> {
   let summary = "Vectorize a very specific form of tensor.pad with "
                 "control flows";
 }

--- a/compiler/src/iree/compiler/Codegen/Common/RematerializeParallelOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/RematerializeParallelOps.cpp
@@ -66,12 +66,13 @@ struct RematerializeParallelOpsPattern
 struct RematerializeParallelOpsPass final
     : impl::RematerializeParallelOpsPassBase<RematerializeParallelOpsPass> {
   void runOnOperation() override {
-    auto funcOp = getOperation();
-    RewritePatternSet fusionPatterns(funcOp.getContext());
-    fusionPatterns.insert<RematerializeParallelOpsPattern>(funcOp.getContext());
+    Operation *rootOp = getOperation();
+    RewritePatternSet fusionPatterns(rootOp->getContext());
+    fusionPatterns.insert<RematerializeParallelOpsPattern>(
+        rootOp->getContext());
     linalg::populateEraseUnusedOperandsAndResultsPatterns(fusionPatterns);
     if (failed(
-            applyPatternsAndFoldGreedily(funcOp, std::move(fusionPatterns)))) {
+            applyPatternsAndFoldGreedily(rootOp, std::move(fusionPatterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeAttention.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeAttention.cpp
@@ -360,11 +360,11 @@ void DecomposeAttentionPass::runOnOperation() {
   if (tileSize.hasValue()) {
     optionalTileSize = tileSize.getValue();
   }
-  getOperation().walk([&](AttentionOp attnOp) {
+  getOperation()->walk([&](AttentionOp attnOp) {
     SmallVector<Operation *> ops;
     decomposeTiledAttention(attnOp, ops, rewriter, optionalTileSize);
   });
-  getOperation().walk([&](OnlineAttentionOp onlineAtt) {
+  getOperation()->walk([&](OnlineAttentionOp onlineAtt) {
     rewriter.setInsertionPoint(onlineAtt);
     FailureOr<SmallVector<Value>> results =
         onlineAtt.decomposeOperation(rewriter);

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeIm2col.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeIm2col.cpp
@@ -76,10 +76,9 @@ struct DecomposeIm2colPass final
 
 void DecomposeIm2colPass::runOnOperation() {
   MLIRContext *context = &getContext();
-  auto funcOp = getOperation();
 
   SmallVector<Im2colOp> candidates;
-  funcOp->walk([&](Im2colOp op) { candidates.push_back(op); });
+  getOperation()->walk([&](Im2colOp op) { candidates.push_back(op); });
   IRRewriter rewriter(context);
   for (auto im2colOp : candidates) {
     if (failed(decomposeIm2col(im2colOp, rewriter, unroll))) {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.td
@@ -9,8 +9,7 @@
 
 include "mlir/Pass/PassBase.td"
 
-def LinalgExtToLoopsPass :
-    InterfacePass<"iree-linalg-ext-to-loops", "mlir::FunctionOpInterface"> {
+def LinalgExtToLoopsPass : Pass<"iree-linalg-ext-to-loops", ""> {
   let summary = "Convert LinalgExt ops to loops and Linalg ops.";
 }
 
@@ -37,7 +36,7 @@ def PadContractionToBlockSizePass :
 }
 
 def TopkSplitReductionPass:
-    InterfacePass<"iree-linalg-ext-topk-split-reduction", "mlir::FunctionOpInterface"> {
+    Pass<"iree-linalg-ext-topk-split-reduction", ""> {
   let summary = "Topk split reduction pass.";
   let description = [{
     Produces a "map-reduce" style of parallelizing a Topk Op. The op is split
@@ -50,8 +49,7 @@ def TopkSplitReductionPass:
   ];
 }
 
-def DecomposeIm2colPass :
-    InterfacePass<"iree-linalg-ext-decompose-im2col", "mlir::FunctionOpInterface"> {
+def DecomposeIm2colPass : Pass<"iree-linalg-ext-decompose-im2col", ""> {
   let summary =
       "Decomposes im2col ops into insert and extract slice ops";
   let options = [
@@ -61,18 +59,18 @@ def DecomposeIm2colPass :
 }
 
 def DecomposeWinogradTransformPass :
-    InterfacePass<"iree-linalg-ext-decompose-winograd", "mlir::FunctionOpInterface"> {
+    Pass<"iree-linalg-ext-decompose-winograd", ""> {
   let summary =
       "Decomposes winograd transform ops into linalg ops";
 }
 
 def ConvertConv2DToIm2ColOpPass :
-    InterfacePass<"iree-linalg-ext-convert-conv2d-to-im2col-op", "mlir::FunctionOpInterface"> {
+    Pass<"iree-linalg-ext-convert-conv2d-to-im2col-op", ""> {
   let summary = "Convert linalg convolution ops to im2col gemm based implementation.";
 }
 
 def ConvertConv2DToWinogradPass :
-    InterfacePass<"iree-linalg-ext-convert-conv2d-to-winograd", "mlir::FunctionOpInterface"> {
+    Pass<"iree-linalg-ext-convert-conv2d-to-winograd", ""> {
   let summary = "Convert linalg convolution ops to winograd based implementation. By default, "
                 "only convs annotated with a `__winograd_conv` attribute will be rewritten.";
   let options = [
@@ -84,7 +82,7 @@ def ConvertConv2DToWinogradPass :
 }
 
 def TileAttentionPass :
-    InterfacePass<"iree-linalg-ext-tile-attention", "mlir::FunctionOpInterface"> {
+    Pass<"iree-linalg-ext-tile-attention", ""> {
   let summary =
       "Tile the attention op along the reduction dimension";
   let options = [
@@ -94,7 +92,7 @@ def TileAttentionPass :
 }
 
 def DecomposeAttentionPass :
-    InterfacePass<"iree-linalg-ext-decompose-attention", "mlir::FunctionOpInterface"> {
+    Pass<"iree-linalg-ext-decompose-attention", ""> {
   let summary =
       "Decomposes attention op into a sequence of linalg ops";
   let options = [
@@ -104,8 +102,7 @@ def DecomposeAttentionPass :
 }
 
 def ConvertAttentionToOnlineAttentionPass :
-    InterfacePass<"iree-linalg-ext-convert-attention-to-online-attention",
-    "mlir::FunctionOpInterface"> {
+    Pass<"iree-linalg-ext-convert-attention-to-online-attention", ""> {
   let summary = "Converts attention op to online_attention op";
 }
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/SplitReduction.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/SplitReduction.cpp
@@ -320,9 +320,9 @@ struct TopkSplitReductionPass final
     };
 
     IRRewriter rewriter(&getContext());
-    auto funcOp = getOperation();
     SmallVector<LinalgExt::TopkOp> topkCandidates;
-    funcOp->walk([&](LinalgExt::TopkOp op) { topkCandidates.push_back(op); });
+    getOperation()->walk(
+        [&](LinalgExt::TopkOp op) { topkCandidates.push_back(op); });
     for (auto op : topkCandidates) {
       (void)splitReduction(rewriter, op, splitReductionFn);
     }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TileAttention.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TileAttention.cpp
@@ -456,7 +456,7 @@ void TileAttentionPass::runOnOperation() {
   if (tileSize.hasValue()) {
     optionalTileSize = tileSize.getValue();
   }
-  getOperation().walk([&](AttentionOp attnOp) {
+  getOperation()->walk([&](AttentionOp attnOp) {
     SmallVector<Operation *> ops;
     tileAttention(attnOp, ops, rewriter, optionalTileSize);
   });
@@ -465,7 +465,7 @@ void TileAttentionPass::runOnOperation() {
 void ConvertAttentionToOnlineAttentionPass::runOnOperation() {
   MLIRContext *context = &getContext();
   IRRewriter rewriter(context);
-  getOperation().walk([&](AttentionOp attnOp) {
+  getOperation()->walk([&](AttentionOp attnOp) {
     SmallVector<Operation *> ops;
     convertToOnlineAttention(attnOp, ops, rewriter);
   });


### PR DESCRIPTION
A number of passes which do not require to be run on FunctionOpInterface are declared to do so. This patch declares them using `Pass` instead of `InterfacePass` for Common/Codegen/ Codegen/Common/GPU and Dialects/LinalgExt/ .

This also allows using these passes by using `--pass-pipeline` in `iree-opt`.