### PR TITLE
Enabling indirect command buffers and memoization by default.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
@@ -29,7 +29,7 @@ static llvm::cl::opt<bool> clIndirectCommandBuffers{
     "iree-hal-indirect-command-buffers",
     llvm::cl::desc("Whether to turn buffer bindings into indirect references "
                    "when recording command buffers."),
-    llvm::cl::init(false),
+    llvm::cl::init(true),
 };
 
 struct ContextResolveOpPattern

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
@@ -45,7 +45,7 @@ static llvm::cl::opt<bool> clMemoization{
     "iree-hal-memoization",
     llvm::cl::desc(
         "Whether to memoize device resources such as command buffers."),
-    llvm::cl::init(false),
+    llvm::cl::init(true),
 };
 
 static llvm::cl::opt<unsigned> clBenchmarkDispatchRepeatCount{


### PR DESCRIPTION
The new flag defaults:
* `--iree-hal-memoization=true`
* `--iree-hal-indirect-command-buffers=true`

Progress on #17875.