### PR TITLE
[DispatchCreation] Add flag for gather fusion

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -719,7 +719,7 @@ bool isClonableIntoDispatchOp(Operation *op) {
           tensor::ExtractSliceOp, complex::CreateOp>(op)) {
     return true;
   }
-  if (LinalgExt::isBitExtendOp(op)) {
+  if (LinalgExt::isBitExtendOp(op) || LinalgExt::isGatherlikeOp(op)) {
     return true;
   }
   if (isa<arith::ConstantOp>(op) || isa<complex::ConstantOp>(op)) {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -45,7 +45,7 @@ static llvm::cl::opt<int> clInlineConstantByteLength(
 
 // TODO(#18457, #18447): Remove once backends support gather fusion.
 static llvm::cl::opt<bool>
-    clEnableGatherFusion("iree-dispatch-creation-enable-gather-fusion",
+    clEnableGatherFusion("iree-flow-enable-gather-fusion",
                          llvm::cl::desc("Fuse gather-like ops with consumer."),
                          llvm::cl::init(false));
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -300,12 +300,8 @@ bool isGatherlikeOp(Operation *op) {
     return false;
   }
 
-  auto yieldOp = cast<linalg::YieldOp>(region.front().getTerminator());
-  if (yieldOp.getNumOperands() != 1) {
-    return false;
-  }
-
   // `yieldOp` should yield a single value from a `tensor.extract`
+  auto yieldOp = cast<linalg::YieldOp>(region.front().getTerminator());
   auto extractOp = yieldOp.getOperand(0).getDefiningOp<tensor::ExtractOp>();
   if (!extractOp) {
     return false;

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
@@ -139,6 +139,12 @@ bool isBitTruncateOp(Operation *op);
 ///     6. Has a body with only a linalg.yield op.
 bool isBroadcastingOp(linalg::LinalgOp op);
 
+/// Returns true if the operation is a `linalg.generic` that is similar in
+/// effect to a gather.
+/// This function checks that the genericOp:
+///     1. Has a single input and output.
+///     2. Has all parallel loops.
+///     2. `linalg.yield` consumes the result of a `tensor.extract_slice`
 bool isGatherlikeOp(Operation *op);
 
 } // namespace mlir::iree_compiler::IREE::LinalgExt

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
@@ -139,5 +139,7 @@ bool isBitTruncateOp(Operation *op);
 ///     6. Has a body with only a linalg.yield op.
 bool isBroadcastingOp(linalg::LinalgOp op);
 
+bool isGatherlikeOp(Operation *op);
+
 } // namespace mlir::iree_compiler::IREE::LinalgExt
 #endif // IREE_COMPILER_DIALECT_LINALGEXT_UTILS_UTILS_H_

--- a/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
@@ -810,7 +810,8 @@ decideFusableLinalgOps(Region &region, DominanceInfo const &dominanceInfo,
       // materializing large tensors between dispatches.
       if (!isa<linalg::LinalgOp, tensor::PadOp, tensor::PackOp,
                IREE::Encoding::SetEncodingOp>(op) ||
-          isa<linalg::FillOp>(op) || IREE::LinalgExt::isBitExtendOp(&op)) {
+          isa<linalg::FillOp>(op) || IREE::LinalgExt::isBitExtendOp(&op) ||
+          IREE::LinalgExt::isGatherlikeOp(&op)) {
         continue;
       }
 

--- a/compiler/src/iree/compiler/DispatchCreation/test/clone_producers_into_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/clone_producers_into_dispatch_regions.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-clone-producers-into-dispatch-regions))" %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-dispatch-creation-enable-gather-fusion --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-clone-producers-into-dispatch-regions))" %s | FileCheck %s
 
 util.func public @complex_element_type(%input: tensor<4xi32>, %table: tensor<8x2xcomplex<f32>>) -> tensor<4x2xcomplex<f32>> {
   %c4095 = arith.constant 4095 : i32

--- a/compiler/src/iree/compiler/DispatchCreation/test/clone_producers_into_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/clone_producers_into_dispatch_regions.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --iree-dispatch-creation-enable-gather-fusion --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-clone-producers-into-dispatch-regions))" %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-flow-enable-gather-fusion --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-clone-producers-into-dispatch-regions))" %s | FileCheck %s
 
 util.func public @complex_element_type(%input: tensor<4xi32>, %table: tensor<8x2xcomplex<f32>>) -> tensor<4x2xcomplex<f32>> {
   %c4095 = arith.constant 4095 : i32


### PR DESCRIPTION
Allow gather-like `linalg.generic` ops to be cloned into their dispatches. This is hidden behind a flag due to backend errors, but landing this on main should make dev easier.



#18457 #18447