### PR TITLE
[Codegen] Replace LLVMGPUVectorize with LLVMGPUTileAndFuse for supported cases

### DIFF
--- a/compiler/plugins/target/CUDA/test/smoketest.mlir
+++ b/compiler/plugins/target/CUDA/test/smoketest.mlir
@@ -62,7 +62,7 @@ stream.executable public @mul_dispatch_executable {
 }
 
 // PTX: .entry add_dispatch
-// PTX: .maxntid 64, 1, 1
+// PTX: .maxntid 32, 1, 1
 // PTX:   add.rn.f32
 
 // PTX: .entry mul_dispatch

--- a/compiler/plugins/target/CUDA/test/smoketest.mlir
+++ b/compiler/plugins/target/CUDA/test/smoketest.mlir
@@ -66,7 +66,7 @@ stream.executable public @mul_dispatch_executable {
 // PTX:   add.rn.f32
 
 // PTX: .entry mul_dispatch
-// PTX: .maxntid 64, 1, 1
+// PTX: .maxntid 32, 1, 1
 // PTX:   mul.rn.f32
 
 //      CHECK: hal.executable public @smoketest_linked

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.cpp
@@ -106,10 +106,6 @@ SmallVector<int64_t> deriveLinalgOpThreadTileSizes(linalg::LinalgOp linalgOp,
   if (!linalgOp.hasPureTensorSemantics()) {
     return {};
   }
-  // TODO: Support multi-result
-  if (linalgOp->getNumResults() != 1) {
-    return {};
-  }
   SmallVector<int64_t> loopRanges = linalgOp.getStaticLoopRanges();
   int64_t vectorSize = kPreferredCopyNumBits /
                        getElementTypeOrSelf(linalgOp->getResultTypes()[0])

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -57,8 +57,8 @@ llvm::cl::opt<bool> clGPUTestTileAndFuseVectorize(
         "test the tile and fuse pipeline for all supported operations"),
     llvm::cl::init(false));
 
-llvm::cl::opt<bool> clUseLLVMGPUVectorizePipeline(
-    "iree-codegen-llvmgpu-use-legacy-default-pipeline",
+llvm::cl::opt<bool> clLLVMGPUVectorizePipeline(
+    "iree-codegen-llvmgpu-vectorize-pipeline",
     llvm::cl::desc("forces use of the legacy LLVMGPU vectorize pipeline"),
     llvm::cl::init(false));
 
@@ -2180,7 +2180,7 @@ static LogicalResult setRootConfig(IREE::GPU::TargetAttr target,
       })
       .Default([&](auto op) {
         LDBG("Default Config");
-        if (!clUseLLVMGPUVectorizePipeline) {
+        if (!clLLVMGPUVectorizePipeline) {
           if (succeeded(IREE::GPU::setTileAndFuseLoweringConfig(
                   target, entryPointFn, computeOp))) {
             LDBG("Tile and fuse default config");

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -57,6 +57,11 @@ llvm::cl::opt<bool> clGPUTestTileAndFuseVectorize(
         "test the tile and fuse pipeline for all supported operations"),
     llvm::cl::init(false));
 
+llvm::cl::opt<bool> clUseLLVMGPUVectorizePipeline(
+    "iree-codegen-llvmgpu-use-legacy-default-pipeline",
+    llvm::cl::desc("forces use of the legacy LLVMGPU vectorize pipeline"),
+    llvm::cl::init(false));
+
 llvm::cl::opt<bool> clGPUEnableVectorDistribution(
     "iree-codegen-llvmgpu-use-vector-distribution",
     llvm::cl::desc("enable the usage of the vector distribution pipeline"),
@@ -2175,6 +2180,13 @@ static LogicalResult setRootConfig(IREE::GPU::TargetAttr target,
       })
       .Default([&](auto op) {
         LDBG("Default Config");
+        if (!clUseLLVMGPUVectorizePipeline) {
+          if (succeeded(IREE::GPU::setTileAndFuseLoweringConfig(
+                  target, entryPointFn, computeOp))) {
+            LDBG("Tile and fuse default config");
+            return success();
+          }
+        }
         return setRootDefaultConfig(target, entryPointFn, computeOp);
       });
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -386,8 +386,6 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createPropagateReshapesByExpansionPass());
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
-  funcPassManager.addPass(createConvertToDestinationPassingStylePass(
-      /*useWARForCooperativeMatrixCodegen=*/false));
 
   // Step 4. Tile and fuse tileable ops to subgroups/threads.
   {
@@ -403,6 +401,8 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
     funcPassManager.addPass(createGPUApplyTilingLevelPass(options));
   }
   funcPassManager.addPass(IREE::GPU::createDistributeMmaToLanesPass());
+  funcPassManager.addPass(createConvertToDestinationPassingStylePass(
+      /*useWARForCooperativeMatrixCodegen=*/false));
 
   // Normalize loop bounds for later lowerings.
   funcPassManager.addPass(iree_compiler::createNormalizeLoopBoundsPass(

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -401,8 +401,6 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
     funcPassManager.addPass(createGPUApplyTilingLevelPass(options));
   }
   funcPassManager.addPass(IREE::GPU::createDistributeMmaToLanesPass());
-  funcPassManager.addPass(createConvertToDestinationPassingStylePass(
-      /*useWARForCooperativeMatrixCodegen=*/false));
 
   // Normalize loop bounds for later lowerings.
   funcPassManager.addPass(iree_compiler::createNormalizeLoopBoundsPass(

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
@@ -206,10 +206,8 @@ module @elementwise_unaligned {
   }
 }
 
-// Verify that this does not select this pipeline due to issues with resolving
-// dynamic scf.forall loops.
-// CHECK-LABEL: module @elementwise_unaligned
-//  CHECK-NOT:   LLVMGPUTileAndFuse
+// CHECK-LABEL: func.func @elementwise_unaligned
+//  CHECK-SAME:   #iree_codegen.translation_info<LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
 
 // -----
 
@@ -225,7 +223,7 @@ module @elementwise_large_rank {
 // Verify that a lowering config is set on large rank tensors with unaligned
 // shapes.
 // CHECK-LABEL: func.func @elementwise_large_rank
-//  CHECK-SAME:   #iree_codegen.translation_info<LLVMGPUVectorize workgroup_size = [128, 1, 1] subgroup_size = 64>
+//  CHECK-SAME:   #iree_codegen.translation_info<LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/elementwise_pipeline.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/elementwise_pipeline.mlir
@@ -13,7 +13,8 @@ func.func @forward_dispatch_0_generic_320x320x3x3() {
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<320x320x3x3xf32>>
   %2 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [3, 320, 320, 3], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<3x320x320x3xf32>> -> tensor<3x320x320x3xf32>
   %3 = tensor.empty() : tensor<320x320x3x3xf32>
-  %4 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%2 : tensor<3x320x320x3xf32>) outs(%3 : tensor<320x320x3x3xf32>) {
+  %4 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+    ins(%2 : tensor<3x320x320x3xf32>) outs(%3 : tensor<320x320x3x3xf32>) {
   ^bb0(%in: f32, %out: f32):
     %5 = arith.addf %in, %cst : f32
     linalg.yield %5 : f32
@@ -21,6 +22,6 @@ func.func @forward_dispatch_0_generic_320x320x3x3() {
   flow.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0], sizes = [320, 320, 3, 3], strides = [1, 1, 1, 1] : tensor<320x320x3x3xf32> -> !flow.dispatch.tensor<writeonly:tensor<320x320x3x3xf32>>
   return
 }
-//      CHECK: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorize workgroup_size = [3, 3, 7] subgroup_size = 32>
+//      CHECK: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
 //      CHECK: func.func @forward_dispatch_0_generic_320x320x3x3()
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
@@ -28,12 +28,11 @@ func.func @add_dispatch_0() {
   return
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[256]{{\]}}>
-//      CHECK: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorize workgroup_size = [64, 1, 1] subgroup_size = 32>
+//      CHECK: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
 //      CHECK: func.func @add_dispatch_0
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.generic
-// CHECK-SAME:       lowering_config = #[[CONFIG]]
+// CHECK-SAME:       lowering_config = #iree_gpu.lowering_config<{thread = [4], workgroup = [128]}>
 
 // -----
 
@@ -153,14 +152,15 @@ func.func @reduction_aligned2() {
   return
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 128, 4]{{\]}}>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorize workgroup_size = [64, 1, 1] subgroup_size = 32>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
 //      CHECK: func.func @reduction_aligned2()
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.fill
-// CHECK-SAME:   lowering_config = #[[CONFIG]]
 //      CHECK: linalg.generic
-// CHECK-SAME:   lowering_config = #[[CONFIG]]
+// CHECK-SAME:   lowering_config = #iree_gpu.lowering_config
+// CHECK-SAME:     reduction = [0, 0, 4]
+// CHECK-SAME:     thread = [1, 4, 0]
+// CHECK-SAME:     workgroup = [1, 128, 0]
 
 // -----
 
@@ -436,7 +436,7 @@ func.func @contract_reduction() {
   return
 }
 
-//  SM80-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorize workgroup_size = [64, 1, 1] subgroup_size = 32
+//  SM80-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32
 //      SM80: func.func @contract_reduction()
 // SM80-SAME:     translation_info = #[[TRANSLATION]]
 
@@ -563,12 +563,11 @@ func.func @inner_unit_dim() {
   return
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64]{{\]}}>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUVectorize workgroup_size = [64, 1, 1] subgroup_size = 32>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUTileAndFuse workgroup_size = [32, 1, 1] subgroup_size = 32>
 //      CHECK: func.func @inner_unit_dim()
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.generic
-// CHECK-SAME:       lowering_config = #[[CONFIG]]
+// CHECK-SAME:       lowering_config = #iree_gpu.lowering_config<{thread = [1, 1], workgroup = [32, 1]}>
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_cuda.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_cuda.mlir
@@ -276,9 +276,8 @@ hal.executable.variant public @cuda_nvptx_fb target(<"cuda", "cuda-nvptx-fb">) {
 
 // Small reduction computes the whole reduction on a single thread.
 //   CHECK-LABEL: func.func @small_reduction
-//         CHECK: scf.for %{{.*}} = %c0 to %c13 step %c4
-//         CHECK:   linalg.generic
-//         CHECK:     arith.addf
+//         CHECK:   %[[READ:.+]] = vector.transfer_read {{.*}} #hal.descriptor_type<storage_buffer>>, vector<4x13xf32>
+//         CHECK:   vector.multi_reduction <add>, %[[READ]], {{.*}} : vector<4x13xf32> to vector<4xf32>
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_pipeline_test.mlir
@@ -2,7 +2,7 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx940 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline), iree-codegen-linalg-to-rocdl-pipeline)))" %s | FileCheck %s --check-prefix=CDNA3
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx1100 --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-llvmgpu-configuration-pipeline), iree-codegen-linalg-to-rocdl-pipeline)))" %s | FileCheck %s --check-prefix=RDNA3
 
-// Verify that a simple element wise op gets lowered succefully all the way to
+// Verify that a simple element wise op gets lowered successfully all the way to
 // nvvm/llvm dialect.
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
@@ -142,7 +142,7 @@ hal.executable @ext_fp8_dispatch {
 
 //   CDNA3-LABEL: hal.executable public @ext_fp8_dispatch
 //         CDNA3:   hal.executable.variant public @rocm
-//     CDNA3-DAG:     %[[EXTF8E4M3:.+]] = rocdl.cvt.f32.fp8 %{{.*}} : f32
-//     CDNA3-DAG:     %[[EXTF8E5M2:.+]] = rocdl.cvt.f32.bf8 %{{.*}} : f32
-//         CDNA3:     %[[ADD:.+]] = llvm.fadd %[[EXTF8E4M3]], %[[EXTF8E5M2]] : f32
-//         CDNA3:     llvm.store %[[ADD]], %{{.*}} : f32, !llvm.ptr<1>
+// CDNA3-COUNT-4:     rocdl.cvt.f32.fp8 %{{.*}} : f32
+// CDNA3-COUNT-4:     rocdl.cvt.f32.bf8 %{{.*}} : f32
+//         CDNA3:     %[[ADD:.+]] = llvm.fadd %{{.*}}, %{{.*}} : vector<4xf32>
+//         CDNA3:     llvm.store %[[ADD]], %{{.*}} : vector<4xf32>, !llvm.ptr<1>

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -1545,8 +1545,6 @@ struct HoistForallFromFor : public OpRewritePattern<scf::ForOp> {
         // Step 5. Inline the body of the original forall into the new for loop.
         OpBuilder::InsertionGuard g2(rewriter);
         SmallVector<Value> argReplacements(newForallOp.getInductionVars());
-        // If there is no paired slice (for a single trip count loop) then
-        // replace the iter arg of the forall op directly.
         for (auto [forallIterArg, forIterArg, maybeSlice] :
              llvm::zip_equal(newForallOp.getRegionIterArgs(),
                              newLoop.getRegionIterArgs(), pairedSlices)) {


### PR DESCRIPTION
The plan is to deprecate the LLVMGPUVectorize pipeline as it is no
longer maintained. This patch is the first step towards deprecating it.
The pipeline is still used by default for convolutions (if
LLVMGPUVectorDistribute does not pick it up).

1) (this) Replace default use cases of LLVMGPUVectorize with
   LLVMGPUTileAndFuse.
2) Replace convolution focused uses of LLVMGPUVectorize.
3) Separate out the lowering config logic for pre-bufferized dispatches
   (that targets LLVMGPUBaseDistribute).
4) Delete the vectorize pipeline.

Depends on #18679