### PR TITLE
[Bufferization] Fix alias mapping for ValueBarrierOpBufferizationInterface

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
@@ -42,10 +42,8 @@ struct ValueBarrierOpBufferizationInterface
   getAliasingValues(Operation *op, OpOperand &opOperand,
                     const AnalysisState &state) const {
     SmallVector<bufferization::AliasingValue> alist;
-    alist.reserve(op->getNumResults());
-    for (Value result : op->getResults()) {
-      alist.push_back({result, BufferRelation::Equivalent});
-    }
+    alist.push_back({op->getResult(opOperand.getOperandNumber()),
+                     BufferRelation::Equivalent});
     return alist;
   }
 


### PR DESCRIPTION
When the ValueBarrierOp contains multiple values, the implementation of `getAliasingValues` in the bufferization interface mapped each operand to all results, but each operand is only tied to the corresponding result. This bug caused extra unnecessary buffers to be added due to false RaW conflicts. This PR fixes the bug.