### PR TITLE
Integrates/llvm 20240910

### DIFF
--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -188,7 +188,7 @@ static void annotateKernelForTranslation(LLVM::LLVMFuncOp funcOp,
   FailureOr<amdgpu::Chipset> chipset = getChipsetVersion(targetAttr);
   if (failed(chipset))
     return;
-  if (chipset->majorVersion != 9 && chipset->minorVersion < 0x40)
+  if (chipset->majorVersion != 9 || *chipset < amdgpu::Chipset(9, 4, 0))
     return;
 
   auto inRegAttrName =

--- a/compiler/plugins/target/ROCM/ROCMTargetUtils.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTargetUtils.cpp
@@ -164,6 +164,7 @@ static void overridePlatformGlobal(llvm::Module *module, StringRef globalName,
 
 LogicalResult setHIPGlobals(Location loc, llvm::Module *module,
                             StringRef targetChip) {
+  // TODO : This needs to be updated with recent chipset changes.
   // Link target chip ISA version as global.
   const int kLenOfChipPrefix = 3;
   StringRef chipId = targetChip.substr(kLenOfChipPrefix);

--- a/compiler/plugins/target/ROCM/ROCMTargetUtils.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTargetUtils.cpp
@@ -164,7 +164,7 @@ static void overridePlatformGlobal(llvm::Module *module, StringRef globalName,
 
 LogicalResult setHIPGlobals(Location loc, llvm::Module *module,
                             StringRef targetChip) {
-  // TODO : This needs to be updated with recent chipset changes.
+  // TODO: This should be updated to use `amdgpu::Chipset`.
   // Link target chip ISA version as global.
   const int kLenOfChipPrefix = 3;
   StringRef chipId = targetChip.substr(kLenOfChipPrefix);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.cpp
@@ -143,7 +143,7 @@ ExecutableLibraryDI::getPtrOf(LLVM::DITypeAttr typeAttr) {
 LLVM::DICompositeTypeAttr
 ExecutableLibraryDI::getArrayOf(LLVM::DITypeAttr typeAttr, int64_t count) {
   return LLVM::DICompositeTypeAttr::get(
-      builder.getContext(), llvm::dwarf::DW_TAG_array_type, /*recId=*/{},
+      builder.getContext(), llvm::dwarf::DW_TAG_array_type,
       /*name=*/builder.getStringAttr(""), fileAttr,
       /*line=*/227, fileAttr,
       /*baseType=*/typeAttr, LLVM::DIFlags::Zero,
@@ -221,7 +221,7 @@ LLVM::DITypeAttr ExecutableLibraryDI::getBasicType(Type type) {
 LLVM::DICompositeTypeAttr ExecutableLibraryDI::getProcessorV0T() {
   unsigned offsetInBits = 0;
   return LLVM::DICompositeTypeAttr::get(
-      builder.getContext(), llvm::dwarf::DW_TAG_structure_type, /*recId=*/{},
+      builder.getContext(), llvm::dwarf::DW_TAG_structure_type,
       builder.getStringAttr("iree_hal_processor_v0_t"), fileAttr,
       /*line=*/227, fileAttr,
       /*baseType=*/nullptr, LLVM::DIFlags::Zero, /*sizeInBits=*/512,
@@ -239,7 +239,6 @@ LLVM::DIDerivedTypeAttr ExecutableLibraryDI::getEnvironmentV0T() {
       "iree_hal_executable_environment_v0_t",
       LLVM::DICompositeTypeAttr::get(
           builder.getContext(), llvm::dwarf::DW_TAG_structure_type,
-          /*recId=*/{},
           builder.getStringAttr("iree_hal_executable_environment_v0_t"),
           fileAttr,
           /*line=*/246, fileAttr,
@@ -268,7 +267,6 @@ LLVM::DIDerivedTypeAttr ExecutableLibraryDI::getDispatchStateV0T() {
       "iree_hal_executable_dispatch_state_v0_t",
       LLVM::DICompositeTypeAttr::get(
           builder.getContext(), llvm::dwarf::DW_TAG_structure_type,
-          /*recId=*/{},
           builder.getStringAttr("iree_hal_executable_dispatch_state_v0_t"),
           fileAttr, /*line=*/275, fileAttr,
           /*baseType=*/nullptr, LLVM::DIFlags::Zero, /*sizeInBits=*/384,
@@ -304,7 +302,6 @@ LLVM::DIDerivedTypeAttr ExecutableLibraryDI::getWorkgroupStateV0T() {
       "iree_hal_executable_workgroup_state_v0_t",
       LLVM::DICompositeTypeAttr::get(
           builder.getContext(), llvm::dwarf::DW_TAG_structure_type,
-          /*recId=*/{},
           builder.getStringAttr("iree_hal_executable_workgroup_state_v0_t"),
           fileAttr, /*line=*/321, fileAttr,
           /*baseType=*/nullptr, LLVM::DIFlags::Zero, /*sizeInBits=*/256,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -25,6 +25,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
 #include "mlir/Conversion/ComplexToStandard/ComplexToStandard.h"
+#include "mlir/Conversion/MathToLLVM/MathToLLVM.h"
 #include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
 #include "mlir/Dialect/Affine/Passes.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -1071,6 +1072,8 @@ static void addLowerToLLVMGPUPasses(OpPassManager &modulePassManager,
   if (forROCDL) {
     // convert to ROCDL.
     modulePassManager.addPass(createConvertToROCDLPass());
+    // Handle leftover math ops.
+    modulePassManager.addPass(createConvertMathToLLVMPass());
   } else {
     // convert to NVVM.
     modulePassManager.addPass(createConvertToNVVMPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1072,10 +1072,6 @@ static void addLowerToLLVMGPUPasses(OpPassManager &modulePassManager,
   if (forROCDL) {
     // convert to ROCDL.
     modulePassManager.addPass(createConvertToROCDLPass());
-    // Handle leftover math ops.
-    // TODO (nirvedhmeshram) : Remove this after
-    // https://github.com/llvm/llvm-project/pull/108266 is integrated in
-    modulePassManager.addPass(createConvertMathToLLVMPass());
   } else {
     // convert to NVVM.
     modulePassManager.addPass(createConvertToNVVMPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1073,6 +1073,8 @@ static void addLowerToLLVMGPUPasses(OpPassManager &modulePassManager,
     // convert to ROCDL.
     modulePassManager.addPass(createConvertToROCDLPass());
     // Handle leftover math ops.
+    // TODO (nirvedhmeshram) : Remove this after
+    // https://github.com/llvm/llvm-project/pull/108266 is integrated in
     modulePassManager.addPass(createConvertMathToLLVMPass());
   } else {
     // convert to NVVM.

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/DumpStatistics.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/DumpStatistics.cpp
@@ -293,8 +293,8 @@ static void prettyPrintStreamInfo(const UsageInfo &usageInfo,
                                   llvm::raw_fd_ostream &os) {
   auto parentOp = executeOp->getParentOfType<mlir::FunctionOpInterface>();
 
-  prettyPrintItemHeader(llvm::formatv("stream.cmd.execute {0}",
-                                      parentOp->getName().getStringRef()),
+  prettyPrintItemHeader(llvm::Twine("stream.cmd.execute ") +
+                            parentOp->getName().getStringRef(),
                         os);
   os << "// ";
   prettyPrintOpBreadcrumb(executeOp, os);

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/DumpStatistics.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/DumpStatistics.cpp
@@ -293,9 +293,9 @@ static void prettyPrintStreamInfo(const UsageInfo &usageInfo,
                                   llvm::raw_fd_ostream &os) {
   auto parentOp = executeOp->getParentOfType<mlir::FunctionOpInterface>();
 
-  prettyPrintItemHeader(
-      llvm::formatv("stream.cmd.execute", parentOp->getName().getStringRef()),
-      os);
+  prettyPrintItemHeader(llvm::formatv(false, "stream.cmd.execute",
+                                      parentOp->getName().getStringRef()),
+                        os);
   os << "// ";
   prettyPrintOpBreadcrumb(executeOp, os);
   os << "\n";

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/DumpStatistics.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/DumpStatistics.cpp
@@ -293,7 +293,7 @@ static void prettyPrintStreamInfo(const UsageInfo &usageInfo,
                                   llvm::raw_fd_ostream &os) {
   auto parentOp = executeOp->getParentOfType<mlir::FunctionOpInterface>();
 
-  prettyPrintItemHeader(llvm::formatv(false, "stream.cmd.execute",
+  prettyPrintItemHeader(llvm::formatv("stream.cmd.execute {0}",
                                       parentOp->getName().getStringRef()),
                         os);
   os << "// ";

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ElideTimepoints.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ElideTimepoints.cpp
@@ -474,8 +474,8 @@ private:
         .Case([&](mlir::CallOpInterface callOp) {
           // Step into callees and get a coverage intersection of all return
           // sites.
-          auto callableOp =
-              callOp.resolveCallable(&solver.getExplorer().getSymbolTables());
+          auto callableOp = callOp.resolveCallableInTable(
+              &solver.getExplorer().getSymbolTables());
           unsigned resultIndex = llvm::cast<OpResult>(value).getResultNumber();
           gatherRegionReturns(callableOp, resultIndex);
         })

--- a/compiler/src/iree/compiler/Dialect/VM/Tools/VMOpEncoderGen.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Tools/VMOpEncoderGen.cpp
@@ -73,13 +73,13 @@ bool emitEncodeFnDefs(const llvm::RecordKeeper &recordKeeper, raw_ostream &os) {
       // really needed.
       switch (params.size()) {
       case 0: {
-        os << formatv("failed({0})", formatv(expr.data()));
+        os << "failed(" << formatv(expr.data()) << ")";
         break;
       }
       case 1: {
         std::string param =
             "get" + llvm::convertToCamelFromSnakeCase(params.front(), true);
-        os << formatv("failed({0})", formatv(expr.data(), param));
+        os << "failed(" << formatv(expr.data(), param) << ")";
         break;
       }
       default: {

--- a/compiler/src/iree/compiler/Dialect/VM/Tools/VMOpEncoderGen.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Tools/VMOpEncoderGen.cpp
@@ -83,7 +83,7 @@ bool emitEncodeFnDefs(const llvm::RecordKeeper &recordKeeper, raw_ostream &os) {
         break;
       }
       default: {
-        assert(0 && "unhandled parameter size");
+        assert(false && "unhandled parameter size");
         break;
       }
       }

--- a/compiler/src/iree/compiler/Dialect/VM/Tools/VMOpEncoderGen.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Tools/VMOpEncoderGen.cpp
@@ -66,19 +66,27 @@ bool emitEncodeFnDefs(const llvm::RecordKeeper &recordKeeper, raw_ostream &os) {
       StringRef expr = encodingExpr->getValueAsString("expr");
       std::vector<StringRef> params =
           encodingExpr->getValueAsListOfStrings("params");
-      assert(params.size() <= 1);
 
-      // Note the following relies on the fact that only encoding expressions
-      // involving operands/results have one parameter. It's a bit inflexible,
+      // Note the following relies on the fact that encoding expressions
+      // have zero or one parameter. It's a bit inflexible,
       // but it works for now and we can change when the extra flexibility is
       // really needed.
-      std::string param;
-      if (params.size() == 1) {
-        param = "get" + llvm::convertToCamelFromSnakeCase(params.front(), true);
-      } else {
-        param = expr;
+      switch (params.size()) {
+      case 0: {
+        os << formatv("failed({0})", formatv(expr.data()));
+        break;
       }
-      os << formatv("failed({0})", formatv(expr.data(), param));
+      case 1: {
+        std::string param =
+            "get" + llvm::convertToCamelFromSnakeCase(params.front(), true);
+        os << formatv("failed({0})", formatv(expr.data(), param));
+        break;
+      }
+      default: {
+        assert(0 && "unhandled parameter size");
+        break;
+      }
+      }
     };
     interleave(encodingExprs, os, printOneCondition, " ||\n      ");
     os << ") {\n";


### PR DESCRIPTION
Bumps llvm to commit: https://github.com/iree-org/llvm-project/commit/e268afbfed678de5da8cac6bec488c9abca97b24
in branch https://github.com/iree-org/llvm-project/tree/shared/integrates_20240910

Following changes are made:
  1. Fix formatv call to pass validation added by https://github.com/llvm/llvm-project/pull/105745
  2. API changes in DICompositeTypeAttr::get introduced by https://github.com/llvm/llvm-project/pull/106571
  3. Fix API call from https://github.com/llvm/llvm-project/pull/100361
  4. Fix chipset comparison in ROCMTarget.cpp

There are two cherry-picks from upstream main as they contain fixes we need and one cheery-pick that is yet to land
1. https://github.com/iree-org/llvm-project/commit/0d5d3555ef0ffd3c41e7dc52728e03b7aae08dcf
2. https://github.com/iree-org/llvm-project/commit/650d8527f1e8e6990a513f0a3bca3820a097c186
3. https://github.com/iree-org/llvm-project/commit/e268afbfed678de5da8cac6bec488c9abca97b24 (the upstream PR for this one is https://github.com/llvm/llvm-project/pull/108302

And a revert due to an outstanding torch-mlir issue
https://github.com/iree-org/llvm-project/commit/cf227978129bc4eabb5826072cd2277d1cf5fe63
