### PR TITLE
[LLVMGPU] Tune tile sizes for large matmuls in TileAndFuse

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -103,9 +103,10 @@ LogicalResult setMatmulLoweringConfig(IREE::GPU::TargetAttr target,
              /*bestKElementCountPerSubgroup*/ kCacheLineSizeBits / inBitWidth};
   } else {
     seeds = {/*bestSubgroupCountPerWorkgroup=*/4,
-             /*bestMNTileCountPerSubgroup=*/8,
+             /*bestMNTileCountPerSubgroup=*/16,
              /*bestKTileCountPerSubgroup=*/4,
-             /*bestKElementCountPerSubgroup*/ kCacheLineSizeBits / inBitWidth};
+             /*bestKElementCountPerSubgroup*/ kCacheLineSizeBits / 2 /
+                 inBitWidth};
   }
 
   int64_t maxSharedMemoryBytes = target.getWgp().getMaxWorkgroupMemoryBytes();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
@@ -59,9 +59,9 @@ func.func @mfma_matmul_1024x1024x1024(%lhs: tensor<1024x1024xf16>, %rhs: tensor<
 
 //       CHECK:   linalg.matmul {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
-//  CHECK-SAME:     reduction = [0 : index, 0 : index, 4 : index]
-//  CHECK-SAME:     subgroup = [2 : index, 4 : index, 0 : index]
-//  CHECK-SAME:     workgroup = [64 : index, 128 : index, 0 : index]
+//  CHECK-SAME:     reduction = [0 : index, 0 : index, 2 : index]
+//  CHECK-SAME:     subgroup = [4 : index, 4 : index, 0 : index]
+//  CHECK-SAME:     workgroup = [128 : index, 128 : index, 0 : index]
 
 // -----
 


### PR DESCRIPTION
This tunes the tile size seeds for large matmuls in TileAndFuse, which improves overall conv performance on SDXL convolutions.