### PR TITLE
[IGEMM] Set lowering config on IGEMM matmuls

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ConvolutionToIGEMM.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvolutionToIGEMM.cpp
@@ -5,10 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Codegen/Common/Passes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Transforms/Transforms.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
 #include "iree/compiler/Dialect/LinalgExt/Transforms/Passes.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Pass/Pass.h"
@@ -24,8 +26,53 @@ namespace {
 
 using iree_compiler::IREE::LinalgExt::IREELinalgExtDialect;
 
+struct SetIGEMMConfiguration : public OpRewritePattern<linalg::GenericOp> {
+  using OpRewritePattern<linalg::GenericOp>::OpRewritePattern;
+
+  SetIGEMMConfiguration(MLIRContext *context, ConfigFn configFn)
+      : OpRewritePattern(context), configFn(configFn) {}
+
+  LogicalResult matchAndRewrite(linalg::GenericOp genericOp,
+                                PatternRewriter &rewriter) const override {
+    if (!linalg::isaContractionOpInterface(genericOp)) {
+      return failure();
+    }
+
+    auto im2colOp =
+        genericOp.getOperand(0).getDefiningOp<IREE::LinalgExt::Im2colOp>();
+    if (!im2colOp) {
+      return rewriter.notifyMatchFailure(genericOp, "no im2colOp producer.");
+    }
+
+    if (getLoweringConfig(genericOp)) {
+      return rewriter.notifyMatchFailure(genericOp,
+                                         "genericOp has a lowering config.");
+    }
+    if (getLoweringConfig(im2colOp)) {
+      return rewriter.notifyMatchFailure(im2colOp,
+                                         "im2colOp has a lowering config.");
+    }
+
+    if (failed(configFn(genericOp, im2colOp))) {
+      return rewriter.notifyMatchFailure(genericOp,
+                                         "failed to set config on igemm_conv.");
+    }
+
+    return success();
+  }
+
+private:
+  ConfigFn configFn;
+};
+
 class ConvolutionToIGEMMPass final
     : public impl::ConvolutionToIGEMMPassBase<ConvolutionToIGEMMPass> {
+public:
+  using impl::ConvolutionToIGEMMPassBase<
+      ConvolutionToIGEMMPass>::ConvolutionToIGEMMPassBase;
+
+  explicit ConvolutionToIGEMMPass(ConfigFn configFn) : configFn(configFn) {}
+
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<tensor::TensorDialect, IREELinalgExtDialect>();
   }
@@ -41,9 +88,11 @@ class ConvolutionToIGEMMPass final
         }
         return true;
       };
-      RewritePatternSet patterns(&getContext());
+      MLIRContext *context = &getContext();
+      RewritePatternSet patterns(context);
       iree_compiler::IREE::LinalgExt::populateConv2DToIm2colOpPatterns(
           patterns, conv2dToIm2colControlFn);
+      patterns.insert<SetIGEMMConfiguration>(context, configFn);
       if (failed(applyPatternsAndFoldGreedily(getOperation(),
                                               std::move(patterns)))) {
         return signalPassFailure();
@@ -94,7 +143,19 @@ class ConvolutionToIGEMMPass final
       }
     }
   }
+
+private:
+  ConfigFn configFn = [](linalg::GenericOp genericOp,
+                         IREE::LinalgExt::Im2colOp im2colOp) {
+    return success();
+  };
 };
 
 } // namespace
+
+std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
+createConvolutionToIGEMMPass(ConfigFn configFn) {
+  return std::make_unique<ConvolutionToIGEMMPass>(configFn);
+}
+
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/ConvolutionToIGEMM.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvolutionToIGEMM.cpp
@@ -26,8 +26,8 @@ namespace {
 
 using iree_compiler::IREE::LinalgExt::IREELinalgExtDialect;
 
-struct SetIGEMMConfiguration : public OpRewritePattern<linalg::GenericOp> {
-  using OpRewritePattern<linalg::GenericOp>::OpRewritePattern;
+struct SetIGEMMConfiguration final : OpRewritePattern<linalg::GenericOp> {
+  using OpRewritePattern::OpRewritePattern;
 
   SetIGEMMConfiguration(MLIRContext *context, ConfigFn configFn)
       : OpRewritePattern(context), configFn(configFn) {}
@@ -68,8 +68,7 @@ private:
 class ConvolutionToIGEMMPass final
     : public impl::ConvolutionToIGEMMPassBase<ConvolutionToIGEMMPass> {
 public:
-  using impl::ConvolutionToIGEMMPassBase<
-      ConvolutionToIGEMMPass>::ConvolutionToIGEMMPassBase;
+  using ConvolutionToIGEMMPassBase::ConvolutionToIGEMMPassBase;
 
   explicit ConvolutionToIGEMMPass(ConfigFn configFn) : configFn(configFn) {}
 
@@ -92,7 +91,7 @@ public:
       RewritePatternSet patterns(context);
       iree_compiler::IREE::LinalgExt::populateConv2DToIm2colOpPatterns(
           patterns, conv2dToIm2colControlFn);
-      patterns.insert<SetIGEMMConfiguration>(context, configFn);
+      patterns.add<SetIGEMMConfiguration>(context, configFn);
       if (failed(applyPatternsAndFoldGreedily(getOperation(),
                                               std::move(patterns)))) {
         return signalPassFailure();
@@ -147,7 +146,7 @@ public:
 private:
   ConfigFn configFn = [](linalg::GenericOp genericOp,
                          IREE::LinalgExt::Im2colOp im2colOp) {
-    return success();
+    return failure();
   };
 };
 

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.h
@@ -17,6 +17,7 @@
 #include "iree/compiler/Codegen/Common/PassUtils.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Transform/IR/TransformDialect.h"
@@ -58,6 +59,13 @@ void addEncodingToNopPasses(FunctionLikeNest &passManager);
 std::unique_ptr<InterfacePass<FunctionOpInterface>>
 createConvertToDestinationPassingStylePass(
     bool useWARForCooperativeMatrixCodegen);
+
+using ConfigFn =
+    std::function<LogicalResult(linalg::GenericOp, IREE::LinalgExt::Im2colOp)>;
+/// Pass to convert Conv2D ops into IGEMM (Im2colOp + matmul). `configFn` is
+/// used to set lowering configurations on the resulting ops, if necessary.
+std::unique_ptr<InterfacePass<FunctionOpInterface>>
+createConvolutionToIGEMMPass(ConfigFn configFn);
 
 std::unique_ptr<InterfacePass<FunctionOpInterface>>
 createDecomposePackUnPackOpsPass(bool tileOuterToOne);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1110,7 +1110,10 @@ static LogicalResult igemmConfigFn(linalg::GenericOp genericOp,
   if (!target) {
     return funcOp.emitError("missing GPU target in parent funcOp");
   }
-  return IREE::GPU::setMatmulLoweringConfig(target, funcOp, genericOp);
+  if (failed(IREE::GPU::setMatmulLoweringConfig(target, funcOp, genericOp))) {
+    return IREE::GPU::setTileAndFuseLoweringConfig(target, funcOp, genericOp);
+  }
+  return success();
 }
 
 static void buildLLVMGPUCodegenConfigurationPassPipelineImpl(

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1117,7 +1117,7 @@ static void buildLLVMGPUCodegenConfigurationPassPipelineImpl(
     OpPassManager &modulePassManager) {
   {
     FunctionLikeNest funcPassManager(modulePassManager);
-    funcPassManager.addPredicatedPass(clLLVMGPUUseIgemm, [&]() {
+    funcPassManager.addPredicatedPass(clLLVMGPUUseIgemm, []() {
       return createConvolutionToIGEMMPass(igemmConfigFn);
     });
     funcPassManager.addPass(createGPUGeneralizeNamedOpsPass);


### PR DESCRIPTION
This PR adds lowering config setting for the IGEMM pipeline, without the need to turn on TileAndFuse by default for matmul. The lowering config is set by a callback function passed to the ConvolutionToIGEMMPass, and the current callback calls `setMatmulLoweringConfig` (fallback to `setTileAndFuseLoweringConfig`), which sets the TileAndFuse pipeline configuration.