### PR TITLE
Skip sccache when the github secret is not available.

### DIFF
--- a/.github/workflows/ci_linux_x64_clang.yml
+++ b/.github/workflows/ci_linux_x64_clang.yml
@@ -47,9 +47,9 @@ jobs:
           submodules: true
       - name: Install Python requirements
         run: python3 -m pip install -r ./runtime/bindings/python/iree/runtime/build_requirements.txt
-      # TODO(#18238): add local or remote ccache
       - name: CMake - configure
         run: |
+          source ./build_tools/cmake/setup_sccache.sh
           cmake \
             -G Ninja \
             -B ${BUILD_DIR} \
@@ -59,13 +59,9 @@ jobs:
             -DIREE_ENABLE_LLD=ON \
             -DIREE_ENABLE_ASSERTIONS=ON \
             -DIREE_BUILD_DOCS=ON \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
-            -DCMAKE_C_COMPILER_LAUNCHER=sccache \
             -DIREE_TARGET_BACKEND_WEBGPU_SPIRV=ON
       - name: CMake - build
         run: |
-          sccache --zero-stats
-          sccache --show-stats
           cmake --build ${BUILD_DIR} -- -k 0
           cmake --build ${BUILD_DIR} --target install -- -k 0
           cmake --build ${BUILD_DIR} --target iree-test-deps -- -k 0

--- a/build_tools/cmake/setup_sccache.sh
+++ b/build_tools/cmake/setup_sccache.sh
@@ -1,0 +1,35 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# sccache (https://github.com/mozilla/sccache/) setup, focused on Azure Blob
+# Storage. See https://github.com/mozilla/sccache/blob/main/docs/Azure.md.
+#
+# If the `SCCACHE_AZURE_CONNECTION_STRING` environment variable is set, this
+# will enable sccache. Note that `SCCACHE_AZURE_BLOB_CONTAINER` should also be
+# set. The `SCCACHE_CACHE_ZSTD_LEVEL` and `SCCACHE_AZURE_KEY_PREFIX`
+# environment variables are also recommended. We could give them default values
+# here if we wanted.
+#
+# If the `SCCACHE_AZURE_CONNECTION_STRING` environment variable is _not_ set,
+# this keeps sccache disabled. It does _not_ use a readonly cache.
+#
+# Note: this file must be *sourced* not executed.
+
+set -eo pipefail
+
+if [ -n "$SCCACHE_AZURE_CONNECTION_STRING" ]; then
+  echo "Connection string set, using sccache"
+  export IREE_USE_SCCACHE=1
+  export CMAKE_C_COMPILER_LAUNCHER="$(which sccache)"
+  export CMAKE_CXX_COMPILER_LAUNCHER="$(which sccache)"
+else
+  echo "Connection string _not_ set, skipping sccache setup"
+  unset SCCACHE_AZURE_CONNECTION_STRING
+  export IREE_USE_SCCACHE=0
+fi
+
+sccache --zero-stats
+sccache --show-stats


### PR DESCRIPTION
This fixes the issue shown here: https://github.com/iree-org/iree/actions/runs/10800586282/job/29958939877#step:6:16 where `SCCACHE_AZURE_CONNECTION_STRING` is defined to empty string instead of being undefined. It also introduces a config script, as discussed here: https://github.com/iree-org/iree/pull/18489#discussion_r1755277304.

We may still want to limit writing to the cache to `push` events.

ci-exactly: linux_x64_clang