### PR TITLE
[GlobalOpt] Make extract_slice a non-leaf op

### DIFF
--- a/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
@@ -366,8 +366,8 @@ void registerUtilExternalModels(DialectRegistry &registry) {
         // Never hoist empty and other pure metadata ops as a leaf. It's fine to
         // hoist them as a part of a larger constant tree that does actual work.
         HoistableNonLeafOpInterfaceHelper<
-            tensor::EmptyOp, tensor::ExpandShapeOp,
-            tensor::CollapseShapeOp>::registerOpInterface(context);
+            tensor::EmptyOp, tensor::ExpandShapeOp, tensor::CollapseShapeOp,
+            tensor::ExtractSliceOp>::registerOpInterface(context);
         // Cases of trivial pack/unpack should be handled as canonicalizations
         // before we get here, thus we're safe to always hoist.
         AlwaysHoistableOpInterfaceHelper<


### PR DESCRIPTION
`tensor.extract_slice` shouldn't be hoisted during HoistIntoGlobalsPass as a leaf because it doesn't preform any computation and acts as a 'view' of the tensor.

Partially addresses #18494, which reported an issue with excessive number of slow memcpys during initialization. This change brings the number of `slow_memcpy`s during initialization from 7808 to 4498 (overall from 8114 to 6990). There were a bunch of initializers that didnt actually do anything. e.g.

```mlir
util.initializer {
  %__auto.token_embd.weight = util.global.load immutable @__auto.token_embd.weight : tensor<656670720xi8>
  %0 = flow.tensor.bitcast %__auto.token_embd.weight : tensor<656670720xi8> -> tensor<328335360xi16>
  %expanded = tensor.expand_shape %0 [[0, 1, 2]] output_shape [128256, 256, 10] : tensor<328335360xi16> into tensor<128256x256x10xi16>
  %extracted_slice = tensor.extract_slice %expanded[0, 0, 0] [128256, 256, 1] [1, 1, 1] : tensor<128256x256x10xi16> to tensor<128256x256xi16>
  util.global.store %extracted_slice, @__hoisted_tensor_128256x256xi16 : tensor<128256x256xi16>
  util.return
}
```

