### PR TITLE
Remove unused macro

### DIFF
--- a/runtime/bindings/python/CMakeLists.txt
+++ b/runtime/bindings/python/CMakeLists.txt
@@ -114,10 +114,6 @@ target_compile_options(iree_runtime_bindings_python_PyExtRt
   # Default COPTS disable exceptions/rtti. Re-enable them.
   ${_RTTI_AND_EXCEPTION_COPTS}
 )
-target_compile_definitions(iree_runtime_bindings_python_PyExtRt
-  PRIVATE
-  IREE_TRACING_HOOK_CPP_NEW_DELETE=0
-)
 
 set_target_properties(
   iree_runtime_bindings_python_PyExtRt


### PR DESCRIPTION
IREE_TRACING_HOOK_CPP_NEW_DELETE macro was added to override `operator new` in b251a949d5480b5b54b9c2e5aa6b2c5445711d96 but the override was removed in 307576dc037d17b9d0dc404f382b1a9c7ae02468 .