### PR TITLE
[VectorDistribution] Reuse intrinsic layout in chained gemm

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
@@ -104,6 +104,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Utils:VectorOpUtils",
         "//compiler/src/iree/compiler/Dialect/Encoding/IR",
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
+        "//compiler/src/iree/compiler/Utils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AMDGPUDialect",
         "@llvm-project//mlir:AffineDialect",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
@@ -135,6 +135,7 @@ iree_cc_library(
     iree::compiler::Codegen::Utils::VectorOpUtils
     iree::compiler::Dialect::Encoding::IR
     iree::compiler::Dialect::HAL::IR
+    iree::compiler::Utils
   PUBLIC
 )
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
@@ -1020,10 +1020,16 @@ struct DistributeTrivialLayoutConversions final
                                 PatternRewriter &rewriter) const override {
     auto input = cast<VectorValue>(toLayoutOp.getInput());
     auto output = cast<VectorValue>(toLayoutOp.getOutput());
-    VectorLayoutInterface currentLayout =
-        dyn_cast<LayoutAttr>(signature[input]);
-    VectorLayoutInterface targetLayout =
-        dyn_cast<LayoutAttr>(signature[output]);
+    VectorLayoutInterface currentLayout = signature[input];
+    VectorLayoutInterface targetLayout = signature[output];
+
+    if (!currentLayout) {
+      return rewriter.notifyMatchFailure(toLayoutOp, "No layout set on input");
+    }
+
+    if (!targetLayout) {
+      return rewriter.notifyMatchFailure(toLayoutOp, "No layout set on output");
+    }
 
     if (currentLayout != targetLayout) {
       return rewriter.notifyMatchFailure(toLayoutOp,

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -10,6 +10,7 @@
 #include "iree/compiler/Codegen/Common/VectorLayoutAnalysis.h"
 #include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
+#include "iree/compiler/Utils/Permutation.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/FormatVariadic.h"
@@ -601,6 +602,93 @@ struct DistributeTranspose final : OpDistributionPattern<vector::TransposeOp> {
   }
 };
 
+struct DistributeBatchOuterToLayoutConversions final
+    : OpDistributionPattern<IREE::VectorExt::ToLayoutOp> {
+  using OpDistributionPattern::OpDistributionPattern;
+
+  LogicalResult matchAndRewrite(IREE::VectorExt::ToLayoutOp toLayoutOp,
+                                DistributionSignature &signature,
+                                PatternRewriter &rewriter) const override {
+    Location loc = toLayoutOp.getLoc();
+    auto input = cast<VectorValue>(toLayoutOp.getInput());
+    auto output = cast<VectorValue>(toLayoutOp.getOutput());
+    auto layoutA = dyn_cast<NestedLayoutAttr>(signature[input]);
+    auto layoutB = dyn_cast<NestedLayoutAttr>(signature[output]);
+
+    if (!layoutA || !layoutB) {
+      return rewriter.notifyMatchFailure(toLayoutOp, "non-nested layout");
+    }
+
+    // Check if everything other than batch and outer tile matches.
+    if (layoutA.getSubgroupTile() != layoutB.getSubgroupTile()) {
+      return failure();
+    }
+    if (layoutA.getSubgroupStrides() != layoutB.getSubgroupStrides()) {
+      return failure();
+    }
+    if (layoutA.getThreadTile() != layoutB.getThreadTile()) {
+      return failure();
+    }
+    if (layoutA.getThreadStrides() != layoutB.getThreadStrides()) {
+      return failure();
+    }
+    if (layoutA.getElementTile() != layoutB.getElementTile()) {
+      return failure();
+    }
+
+    auto batchTileA = SmallVector<int64_t>(layoutA.getBatchTile());
+    auto outerTileA = SmallVector<int64_t>(layoutA.getOuterTile());
+    auto batchTileB = SmallVector<int64_t>(layoutB.getBatchTile());
+    auto outerTileB = SmallVector<int64_t>(layoutB.getOuterTile());
+
+    // Check if there is a batch/outer tile mismatch.
+    if (batchTileA == batchTileB && outerTileA == outerTileB) {
+      return rewriter.notifyMatchFailure(toLayoutOp,
+                                         "trivial layout conversion");
+    }
+
+    SmallVector<int64_t> shapeA = layoutA.getDistributedShape();
+    SmallVector<int64_t> shapeB = layoutB.getDistributedShape();
+    int64_t rank = layoutA.getRank();
+
+    // Interleave batch and outer dims by transposing.
+
+    // Build a permutation for interleaving.
+    SmallVector<int64_t> interleavePermutation(shapeA.size());
+    std::iota(interleavePermutation.begin(), interleavePermutation.end(), 0);
+    for (int i = 0; i < rank; i++) {
+      // Batch tile : [0...rank]
+      // OuterTile : [rank+1...2*rank]
+      // Interleave : [batch0, outer0, batch1, outer1,...]
+      interleavePermutation[2 * i] = i;
+      interleavePermutation[2 * i + 1] = i + rank;
+    }
+
+    auto interleaved = rewriter.create<vector::TransposeOp>(
+        loc, getDistributed(rewriter, input, layoutA), interleavePermutation);
+
+    // Shape cast to match the new layout.
+
+    SmallVector<int64_t> transposedShapeB(shapeB);
+    applyPermutationToVector(transposedShapeB, interleavePermutation);
+    Type reshapedType = VectorType::get(
+        transposedShapeB, interleaved.getResultVectorType().getElementType());
+
+    auto reshaped =
+        rewriter.create<vector::ShapeCastOp>(loc, reshapedType, interleaved);
+
+    // Inverse transpose to preserve original order.
+    SmallVector<int64_t> invertedPermutation =
+        invertPermutationVector(interleavePermutation);
+
+    auto layouted = rewriter.create<vector::TransposeOp>(loc, reshaped,
+                                                         invertedPermutation);
+
+    replaceOpWithDistributedValues(rewriter, toLayoutOp, layouted.getResult());
+    return success();
+  }
+};
+
 } // namespace
 
 void populateGPUDistributeNestedLayoutAttrPatterns(RewritePatternSet &patterns,
@@ -612,6 +700,7 @@ void populateGPUDistributeNestedLayoutAttrPatterns(RewritePatternSet &patterns,
   patterns.add<DistributeBroadcast, DistributeTranspose>(patterns.getContext());
   patterns.add<DistributeMultiReduction>(patterns.getContext(), subgroupSize,
                                          maxBitsPerShuffle);
+  patterns.add<DistributeBatchOuterToLayoutConversions>(patterns.getContext());
 }
 
 }; // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -654,9 +654,9 @@ struct DistributeBatchOuterToLayoutConversions final
     // Interleave batch and outer dims by transposing.
 
     // Build a permutation for interleaving.
-    SmallVector<int64_t> interleavePermutation(shapeA.size());
-    std::iota(interleavePermutation.begin(), interleavePermutation.end(), 0);
-    for (int i = 0; i < rank; i++) {
+    auto interleavePermutation =
+        llvm::to_vector(llvm::seq<int64_t>(shapeA.size()));
+    for (int i = 0; i < rank; ++i) {
       // Batch tile : [0...rank]
       // OuterTile : [rank+1...2*rank]
       // Interleave : [batch0, outer0, batch1, outer1,...]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
@@ -245,16 +245,15 @@ setAttentionMatmulAnchor(IREE::GPU::MMAScheduleAttr schedule,
   bool transposeIntrinsic = false;
 
   auto intrinsic = cast<IREE::GPU::MMAAttr>(schedule.getIntrinsic());
-  IREE::GPU::MMAAttr::SingleSubgroupLayout lhsLayout =
+  IREE::GPU::MMASingleSubgroupLayout lhsLayout =
       intrinsic.getASingleSubgroupLayout();
-  IREE::GPU::MMAAttr::SingleSubgroupLayout rhsLayout =
+  IREE::GPU::MMASingleSubgroupLayout rhsLayout =
       intrinsic.getBSingleSubgroupLayout();
-  IREE::GPU::MMAAttr::SingleSubgroupLayout outLayout =
+  IREE::GPU::MMASingleSubgroupLayout outLayout =
       intrinsic.getCSingleSubgroupLayout();
 
-  auto matchLayout =
-      [](IREE::GPU::MMAAttr::SingleSubgroupLayout layoutA,
-         IREE::GPU::MMAAttr::SingleSubgroupLayout layoutB) -> bool {
+  auto matchLayout = [](IREE::GPU::MMASingleSubgroupLayout layoutA,
+                        IREE::GPU::MMASingleSubgroupLayout layoutB) -> bool {
     return (layoutA.element == layoutB.element) &&
            (layoutA.thread == layoutB.thread) &&
            (layoutA.tstrides == layoutB.tstrides);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -868,7 +868,6 @@ void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager,
 
   // Preprocessing for vector distribution.
   funcPassManager.addPass(createLLVMGPUCastTypeToFitMMAPass());
-  funcPassManager.addPass(createAMDGPUPrepareForChainedMatmulPass());
 
   // Vector SIMD -> Vector SIMT
   funcPassManager.addPass(createLLVMGPUConfigureVectorLayoutsPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx940.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx940.mlir
@@ -591,7 +591,7 @@ hal.executable private @attention_20x4096x64x4096x64 {
 // CHECK: transfer_read
 
 // CHECK: scf.for %{{.*}} = %c0 to %c4096 step %c64
-// CHECK-SAME: -> (vector<2x1x4xf32>, vector<2x1x4xf32>, vector<2x4x1x1x4x1xf32>)
+// CHECK-SAME: -> (vector<2x1x1xf32>, vector<2x1x1xf32>, vector<2x4x1x1x1x4xf32>)
 // CHECK-COUNT-48:  amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
 // CHECK: scf.yield
 
@@ -640,6 +640,6 @@ hal.executable private @attention_multiple_m_transpose {
 
 // CHECK-LABEL: func.func @attention_multiple_m_transpose()
 // CHECK: scf.for %{{.*}} = %c0 to %c72 step %c1
-// CHECK-SAME: -> (vector<2x1x4xf32>, vector<2x1x4xf32>, vector<2x8x1x1x4x1xf32>)
+// CHECK-SAME: -> (vector<2x1x1xf32>, vector<2x1x1xf32>, vector<2x8x1x1x1x4xf32>)
 // CHECK-COUNT-96:  amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
 // CHECK: scf.yield

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx940.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx940.mlir
@@ -3,6 +3,11 @@
 // RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-llvmgpu-lower-executable-target)))))" \
 // RUN:   %s | FileCheck %s
 
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx940 \
+// RUN:   --iree-codegen-llvmgpu-use-vector-distribution --iree-llvmgpu-enable-prefetch=true \
+// RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-llvmgpu-lower-executable-target)))))" \
+// RUN:   %s | FileCheck %s --check-prefix=MEMORY
+
 #config = #iree_codegen.lowering_config<tile_sizes = [[64, 64, 128]]>
 #translation = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [128, 2, 1] subgroup_size = 64, {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false>, mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, subgroup_m_count = 2, subgroup_n_count = 2>}>
 
@@ -595,6 +600,10 @@ hal.executable private @attention_20x4096x64x4096x64 {
 // CHECK-COUNT-48:  amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
 // CHECK: scf.yield
 
+// Check that we only use alloc for Q, K, and V. No shared memory for S is
+// needed because the intrinsic layout mathes.
+// MEMORY-COUNT-3: memref.alloc
+
 // -----
 
 #config = #iree_codegen.lowering_config<tile_sizes = [[1, 1, 64, 0, 64, 64]]>
@@ -643,3 +652,60 @@ hal.executable private @attention_multiple_m_transpose {
 // CHECK-SAME: -> (vector<2x1x1xf32>, vector<2x1x1xf32>, vector<2x8x1x1x1x4xf32>)
 // CHECK-COUNT-96:  amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
 // CHECK: scf.yield
+
+// Check that we only use alloc for Q, K, and V. No shared memory for S is
+// needed because the intrinsic layout mathes.
+// MEMORY-COUNT-3: memref.alloc
+
+// -----
+
+#config = #iree_codegen.lowering_config<tile_sizes = [[1, 1, 128, 0, 32, 64]]>
+#translation = #iree_codegen.translation_info<LLVMGPUVectorDistribute workgroup_size = [64, 4, 1] subgroup_size = 64, {mma_schedule = #iree_gpu.mma_schedule<intrinsic = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>, subgroup_m_count = 4, subgroup_n_count = 1>}>
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable private @attention_mfma_32x32x8 {
+  hal.executable.variant public @rocm target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @attention_mfma_32x32x8 ordinal(0) layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_slice
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @attention_mfma_32x32x8() attributes {translation_info = #translation} {
+        %cst = arith.constant 1.0 : f16
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<24x64x4608x128xf16>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<24x4608x128xf16>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<24x4608x128xf16>>
+        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<64x4608x24x128xf16>>
+        %4 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [24, 64, 4608, 128], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<24x64x4608x128xf16>> -> tensor<24x64x4608x128xf16>
+        %5 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [24, 4608, 128], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<24x4608x128xf16>> -> tensor<24x4608x128xf16>
+        %6 = flow.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [24, 4608, 128], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<24x4608x128xf16>> -> tensor<24x4608x128xf16>
+        %7 = tensor.empty() : tensor<64x4608x24x128xf16>
+        %8 = tensor.empty() : tensor<24x64x4608x128xf16>
+        %9 = iree_linalg_ext.attention {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d4, d3)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d4, d5)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d5)>], lowering_config = #config} ins(%4, %5, %6, %cst : tensor<24x64x4608x128xf16>, tensor<24x4608x128xf16>, tensor<24x4608x128xf16>, f16) outs(%8 : tensor<24x64x4608x128xf16>) -> tensor<24x64x4608x128xf16>
+        %10 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d1, d2, d0, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"], lowering_config = #config} ins(%9 : tensor<24x64x4608x128xf16>) outs(%7 : tensor<64x4608x24x128xf16>) {
+        ^bb0(%in: f16, %out: f16):
+          linalg.yield %in : f16
+        } -> tensor<64x4608x24x128xf16>
+        flow.dispatch.tensor.store %10, %3, offsets = [0, 0, 0, 0], sizes = [64, 4608, 24, 128], strides = [1, 1, 1, 1] : tensor<64x4608x24x128xf16> -> !flow.dispatch.tensor<writeonly:tensor<64x4608x24x128xf16>>
+        return
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: func.func @attention_mfma_32x32x8()
+// CHECK: scf.for %{{.*}} = %c0 to %c144 step %c1
+// CHECK-SAME: -> (vector<1x1x1xf32>, vector<1x1x1xf32>, vector<1x4x1x4x1x4xf32>)
+// CHECK-COUNT-32:  amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 8 : i32, m = 32 : i32, n = 32 : i32} blgp =  none : vector<4xf16>, vector<4xf16>, vector<16xf32>
+// CHECK: scf.yield
+
+// Check that we only use alloc for Q, K, and V. No shared memory for S is
+// needed because the intrinsic layout mathes.
+// MEMORY-COUNT-3: memref.alloc

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx940.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx940.mlir
@@ -602,7 +602,9 @@ hal.executable private @attention_20x4096x64x4096x64 {
 
 // Check that we only use alloc for Q, K, and V. No shared memory for S is
 // needed because the intrinsic layout mathes.
+// MEMORY-LABEL: func.func @attention_20x4096x64x4096x64()
 // MEMORY-COUNT-3: memref.alloc
+// MEMORY-NOT: memref.alloc
 
 // -----
 
@@ -655,7 +657,9 @@ hal.executable private @attention_multiple_m_transpose {
 
 // Check that we only use alloc for Q, K, and V. No shared memory for S is
 // needed because the intrinsic layout mathes.
+// MEMORY-LABEL: func.func @attention_multiple_m_transpose()
 // MEMORY-COUNT-3: memref.alloc
+// MEMORY-NOT: memref.alloc
 
 // -----
 
@@ -708,4 +712,6 @@ hal.executable private @attention_mfma_32x32x8 {
 
 // Check that we only use alloc for Q, K, and V. No shared memory for S is
 // needed because the intrinsic layout mathes.
+// MEMORY-LABEL: func.func @attention_mfma_32x32x8()
 // MEMORY-COUNT-3: memref.alloc
+// MEMORY-NOT: memref.alloc


### PR DESCRIPTION
This patch teaches attention codegen pipeline to reuse the intrinsic layout of output of the first matmul as the lhs of the second matmul. This is possible for 16x16x16 and 32x32x8 MFMA intrinsic layouts.