### PR TITLE
[LLVMCPU] Add fold unit extent to CPU codegen pipeline

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -109,6 +109,7 @@ static void addTileAndDistributePasses(OpPassManager &funcPassManager) {
   funcPassManager.addPass(createCSEPass());
   funcPassManager.addPass(createConvertToDestinationPassingStylePass());
   funcPassManager.addPass(createFoldAffineMinInDistributedLoopsPass());
+  funcPassManager.addPass(createLinalgFoldUnitExtentDimsPass());
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
   funcPassManager.addPass(createFuseTensorPadWithConsumerPass());


### PR DESCRIPTION
In case of broadcast + matmul kernels the outermost dimension (batch dim) is tiled to 1. We want to fold these into tensor.expand_shape after the distribution.