### PR TITLE
[VectorDistribution] Add LICM to LLVMGPUVectorDistribute pipeline

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -828,8 +828,10 @@ void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
 
-  // Set anchors at tensor level for vector distribution later.
+  // Set anchors at tensor level for vector distribution later and hoist out
+  // loop invariant anchors.
   funcPassManager.addPass(createLLVMGPUConfigureTensorLayoutsPass());
+  funcPassManager.addPass(createLoopInvariantCodeMotionPass());
 
   // Generalize all named ops so that we can fold away unit extent dims. By this
   // point, all tiling is finished so the tiling configurations on those ops can

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute.mlir
@@ -714,6 +714,13 @@ hal.executable private @attention_20x4096x64x4096x64 {
 // CHECK-LABEL: func.func @attention_20x4096x64x4096x64()
 // CHECK-SAME:    translation_info = #[[$TRANSLATION]]
 
+// Make sure the Q matmul global read, shared memory write and shared memory
+// read is hoisted out.
+// CHECK: transfer_read
+// CHECK: transfer_write
+// CHECK: gpu.barrier
+// CHECK: transfer_read
+
 // CHECK: scf.for %{{.*}} = %c0 to %c4096 step %c64
 // CHECK-SAME: -> (vector<2x1x4xf32>, vector<2x1x4xf32>, vector<2x4x1x1x4x1xf32>)
 // CHECK-COUNT-48:  amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/pull/108032 we can hoist out linalg ops. Add this pass to vector distribution pipeline. This allows hoisting out Q anchor in attention, which would further materialize as a shared memory copy.