### PR TITLE
[VectorDistribution]reduction support along LLVMGPUVectorDistribute pipeline

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
@@ -598,8 +598,12 @@ struct DistributeScfFor final : OpDistributionPattern<scf::ForOp> {
     SmallVector<Value> operands;
     for (Value operand : yieldOp->getOperands()) {
       if (auto vectorOperand = dyn_cast<VectorValue>(operand)) {
-        operand = DistributionPattern::getDistributed(rewriter, vectorOperand,
-                                                      signature[vectorOperand]);
+        // Types such as vector<f32> can pass this condition. An additional rank
+        // check is added here to ensure that the type is indeed a vector value.
+        if (vectorOperand.getType().getRank() != 0) {
+          operand = DistributionPattern::getDistributed(
+              rewriter, vectorOperand, signature[vectorOperand]);
+        }
       }
       operands.push_back(operand);
     }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
@@ -107,7 +107,6 @@ struct DistributeConstants final : OpDistributionPattern<arith::ConstantOp> {
     Type elementType = constant.getType().getElementType();
     auto vectorType =
         VectorType::get(layout.getDistributedShape(), elementType);
-
     //@Bangtian: will revisit this part later
     bool isScalar = cast<ShapedType>(vectorType).getRank() == 0;
     if (!isScalar) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -643,7 +643,7 @@ struct DistributeContract final : OpDistributionPattern<vector::ContractionOp> {
     auto maps = contractOp.getIndexingMapsArray();
 
     // Reduction dimensions will have the 'reduction' iterator type.
-    SmallVector<unsigned> reductionDims;
+    // SmallVector<unsigned> reductionDims;
     MLIRContext *ctx = maps[0].getContext();
     for (auto [index, iteratorType] :
          llvm::enumerate(contractOp.getIteratorTypes())) {
@@ -686,7 +686,7 @@ struct DistributeContract final : OpDistributionPattern<vector::ContractionOp> {
 
     auto localContractOp = rewriter.create<vector::ContractionOp>(
         loc, disLhs, disRhs, localInit, rewriter.getAffineMapArrayAttr(newMaps),
-        rewriter.getArrayAttr(newIterators));
+        rewriter.getArrayAttr(newIterators), contractOp.getKind());
     localContractOp->setDiscardableAttrs(
         contractOp->getDiscardableAttrDictionary());
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -305,7 +305,12 @@ struct DistributeBroadcast final : OpDistributionPattern<vector::BroadcastOp> {
     auto vectorType = VectorType::get(distShape, elementType);
 
     VectorValue srcVector = dyn_cast<VectorValue>(broadcastOp.getSource());
-    if (!srcVector) {
+    // Types such as vector<f32> can return a valid pointer. An additional
+    // rank check is added to ensure that the type is indeed a vector
+    // value.
+    bool isSrcVector =
+        (srcVector != nullptr) && (srcVector.getType().getRank() != 0);
+    if (!isSrcVector) {
       // The way distribution currently works, there is no partial thread
       // distribution, so a scalar is available to all threads. Scalar
       // distribution is simply a broadcast from scalar to the distributed

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -413,12 +413,27 @@ struct DistributeMultiReduction final
                                 DistributionSignature &signature,
                                 PatternRewriter &rewriter) const override {
     VectorValue srcVector = multiReduceOp.getSource();
-    auto accVector = dyn_cast<VectorValue>(multiReduceOp.getAcc());
-    auto resVector = dyn_cast<VectorValue>(multiReduceOp.getResult());
-    Type accType = multiReduceOp.getAcc().getType();
-    Type resType = multiReduceOp.getResult().getType();
+    Value acc = multiReduceOp.getAcc();
+    Value res = multiReduceOp.getResult();
+    auto accVector = dyn_cast<VectorValue>(acc);
+    auto resVector = dyn_cast<VectorValue>(res);
+    Type accType = acc.getType();
+    Type resType = res.getType();
+    Type accElemTy;
+    if (accVector) {
+      accElemTy = accVector.getType().getElementType();
+    } else {
+      accElemTy = accType;
+    }
 
-    if (!accType.isIntOrFloat() || !resType.isIntOrFloat()) {
+    Type resElemTy;
+    if (resVector) {
+      resElemTy = resVector.getType().getElementType();
+    } else {
+      resElemTy = resType;
+    }
+
+    if (!accElemTy.isIntOrFloat() || !resElemTy.isIntOrFloat()) {
       return rewriter.notifyMatchFailure(multiReduceOp,
                                          "unsupported reduction type");
     }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.cpp
@@ -132,7 +132,10 @@ void DistributionPattern::replaceOpWithDistributedValues(
   for (auto [opResult, replacement] :
        llvm::zip_equal(op->getOpResults(), values)) {
     // If this value is a vector type, it must be converted back to simd.
-    if (isa<VectorType>(replacement.getType())) {
+    // From @Bangtian:  arith.constant dense<0.000000e+00> : vector<f32>  can
+    // pss the check, so here I add extra rank check.
+    if (isa<VectorType>(replacement.getType()) &&
+        cast<ShapedType>(replacement.getType()).getRank() != 0) {
       auto oldResult = cast<VectorValue>(opResult);
       // Create a toSIMD op to convert the value back to the simd.
       rewriter.setInsertionPointAfterValue(oldResult);

--- a/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
@@ -634,6 +634,8 @@ static void enforceLayoutToMultiReductionOp(
     ArrayRef<DistributionLayout *> operandLattices,
     ArrayRef<const DistributionLayout *> resultLattices,
     std::function<void(DistributionLayout *, ChangeResult)> update) {
+  if (resultLattices.empty())
+    return;
   // Reductions should always propagate value layout to result. Result can
   // enforce it's layout on init.
   const DistributionLayout *result = resultLattices[0];
@@ -699,6 +701,8 @@ static void enforceLayoutToBroadcastOp(
 
   auto resultShape = broadcast.getResultVectorType().getShape();
   auto inputType = broadcast.getSourceType();
+  if (!isa<VectorType>(inputType))
+    return;
   assert(isa<VectorType>(inputType) &&
          "Scalar broadcast not supported for now.");
   auto inputShape = cast<VectorType>(inputType).getShape();

--- a/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
@@ -731,6 +731,8 @@ static void enforceLayoutToContractionOp(
     ArrayRef<DistributionLayout *> operandLattices,
     ArrayRef<const DistributionLayout *> resultLattices,
     std::function<void(DistributionLayout *, ChangeResult)> update) {
+  if (resultLattices.empty())
+    return;
   // Contraction has only one vector result.
   const DistributionLayout *result = resultLattices[0];
   // Contraction has init value at position 2.

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -623,6 +623,8 @@ getPipelineOptions(FunctionOpInterface funcOp,
     if (reorderWorkgroupsStrategy) {
       pipelineOptions.reorderStrategy = reorderWorkgroupsStrategy.getValue();
     }
+  } else {
+    pipelineOptions.generateContract = false;
   }
 
   pipelineOptions.enableUkernels = targetAttr && hasUkernel(targetAttr);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h
@@ -44,6 +44,7 @@ struct GPUPipelineOptions {
   bool enableReduceSharedMemoryBankConflicts = true;
   bool prefetchSharedMemory = false;
   bool enableUkernels = false;
+  bool generateContract = true;
   std::optional<ReorderWorkgroupsStrategy> reorderStrategy;
 };
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
@@ -341,8 +341,12 @@ struct LLVMGPUConfigureTensorLayoutsPass final
     llvm::StringLiteral scheduleAttrName =
         IREE::GPU::MMAScheduleAttr::getMnemonic();
     DictionaryAttr configDict = getTranslationInfo(func).getConfiguration();
-    auto scheduleAttr = dyn_cast_or_null<IREE::GPU::MMAScheduleAttr>(
-        configDict.get(scheduleAttrName));
+    // auto scheduleAttr = dyn_cast_or_null<IREE::GPU::MMAScheduleAttr>(
+    //     configDict.get(scheduleAttrName));
+    IREE::GPU::MMAScheduleAttr scheduleAttr = nullptr;
+    if (configDict)
+      scheduleAttr = dyn_cast_or_null<IREE::GPU::MMAScheduleAttr>(
+          configDict.get(scheduleAttrName));
 
     // Vector layout option setter aimed at contractions and convolutions. For
     // now, layout setting for other problems like reductions is TODO.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureVectorLayouts.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureVectorLayouts.cpp
@@ -268,8 +268,10 @@ struct LLVMGPUConfigureVectorLayoutsPass final
         func->getAttrOfType<IREE::GPU::MMAScheduleAttr>(scheduleAttrName);
     if (!scheduleAttr) {
       DictionaryAttr configDict = getTranslationInfo(func).getConfiguration();
-      scheduleAttr = dyn_cast_or_null<IREE::GPU::MMAScheduleAttr>(
-          configDict.get(scheduleAttrName));
+      if (configDict) {
+        scheduleAttr = dyn_cast_or_null<IREE::GPU::MMAScheduleAttr>(
+            configDict.get(scheduleAttrName));
+      }
     }
 
     // Vector layout option setter aimed at contractions. Currently this only

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureVectorLayouts.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureVectorLayouts.cpp
@@ -190,8 +190,16 @@ LogicalResult setTransferReadAnchor(ArrayRef<int64_t> workgroupSize,
     int64_t vectorSize = vectorShape[dim];
     // Set the element count for the innermost vector dimension.
     if (residualElements != 1) {
-      elementSizes[dim] = residualElements;
       vectorSize /= residualElements;
+      // residualElements = 1;
+      while (residualThreads % vectorSize != 0 &&
+             vectorSize % residualThreads != 0) {
+        if (residualElements == 1)
+          break;
+        residualElements >>= 1;
+        vectorSize <<= 1;
+      }
+      elementSizes[dim] = residualElements;
       residualElements = 1;
     }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -861,11 +861,12 @@ void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createOptimizeTensorInsertExtractSlicesPass());
 
   // Linalg -> Vector
-  if (options.generateContract)
+  if (options.generateContract) {
     addGPUVectorizationPasses(funcPassManager);
-  else
-    addGPUVectorizationPasses(funcPassManager, options.generateContract);
-
+  } else {
+    // addGPUVectorizationPasses(funcPassManager, options.generateContract);
+    addGPUVectorizationPasses(funcPassManager);
+  }
   // Allocate tensors for copies to shared memory.
   funcPassManager.addPass(createGPUVectorAllocPass());
   funcPassManager.addPass(createCanonicalizerPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -227,6 +227,9 @@ static void addGPUVectorizationPasses(OpPassManager &funcPassManager) {
   options.vectorizeGatherAccesses = true;
   options.enableCleanup = false;
   options.foldCastIntoContract = true;
+  // used for supporting reduction along VectorDistribute pipeline
+  // disable conversion for reduction ops to contraction ops.
+  options.generateContract = false;
   funcPassManager.addPass(createGenericVectorizationPass(options));
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());


### PR DESCRIPTION
Adding support for Linalg operations with reduction dimensions using the LLVMGPUVectorDistribute pipeline. Currently, there are unknown issues (debugging) when compiling sdxl, so this is marked as a draft until the bugs are resolved