### PR TITLE
Remove todo given upstream changes have landed

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/ImportResources.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/ImportResources.cpp
@@ -21,13 +21,6 @@ namespace mlir::iree_compiler::IREE::Util {
 
 namespace {
 
-// TODO: Just use the DenseResourceElementsAttr::get()
-// builder once https://reviews.llvm.org/D157064 lands.
-class DenseBlobResourceElementsAttr : public DenseResourceElementsAttr {
-public:
-  using DenseResourceElementsAttr::get;
-};
-
 template <typename ElementType, unsigned numBits = sizeof(ElementType) * 8>
 static void copyIntAttrIntoBlob(AsmResourceBlob &blob,
                                 DenseIntElementsAttr attr) {
@@ -134,32 +127,32 @@ public:
         blob = HeapAsmResourceBlob::allocate(numElements, /*align=*/64,
                                              /*dataIsMutable=*/true);
         copyIntAttrIntoBlob<uint8_t, /*numBits=*/1>(blob, attr);
-        return DenseBlobResourceElementsAttr::get(st, "dense_elements_i1",
-                                                  std::move(blob));
+        return DenseResourceElementsAttr::get(st, "dense_elements_i1",
+                                              std::move(blob));
       case 8:
         blob = HeapAsmResourceBlob::allocate(numElements, /*align=*/64,
                                              /*dataIsMutable=*/true);
         copyIntAttrIntoBlob<uint8_t>(blob, attr);
-        return DenseBlobResourceElementsAttr::get(st, "dense_elements_i8",
-                                                  std::move(blob));
+        return DenseResourceElementsAttr::get(st, "dense_elements_i8",
+                                              std::move(blob));
       case 16:
         blob = HeapAsmResourceBlob::allocate(2 * numElements, /*align=*/64,
                                              /*dataIsMutable=*/true);
         copyIntAttrIntoBlob<uint16_t>(blob, attr);
-        return DenseBlobResourceElementsAttr::get(st, "dense_elements_i16",
-                                                  std::move(blob));
+        return DenseResourceElementsAttr::get(st, "dense_elements_i16",
+                                              std::move(blob));
       case 32:
         blob = HeapAsmResourceBlob::allocate(4 * numElements, /*align=*/64,
                                              /*dataIsMutable=*/true);
         copyIntAttrIntoBlob<uint32_t>(blob, attr);
-        return DenseBlobResourceElementsAttr::get(st, "dense_elements_i32",
-                                                  std::move(blob));
+        return DenseResourceElementsAttr::get(st, "dense_elements_i32",
+                                              std::move(blob));
       case 64:
         blob = HeapAsmResourceBlob::allocate(8 * numElements, /*align=*/64,
                                              /*dataIsMutable=*/true);
         copyIntAttrIntoBlob<uint64_t>(blob, attr);
-        return DenseBlobResourceElementsAttr::get(st, "dense_elements_i64",
-                                                  std::move(blob));
+        return DenseResourceElementsAttr::get(st, "dense_elements_i64",
+                                              std::move(blob));
       default:
         return {};
       }
@@ -170,26 +163,26 @@ public:
         blob = HeapAsmResourceBlob::allocate(numElements, /*align=*/64,
                                              /*dataIsMutable=*/true);
         copyFPAttrIntoBlob<uint8_t>(blob, attr);
-        return DenseBlobResourceElementsAttr::get(st, "dense_elements_f8",
-                                                  std::move(blob));
+        return DenseResourceElementsAttr::get(st, "dense_elements_f8",
+                                              std::move(blob));
       case 16:
         blob = HeapAsmResourceBlob::allocate(2 * numElements, /*align=*/64,
                                              /*dataIsMutable=*/true);
         copyFPAttrIntoBlob<uint16_t>(blob, attr);
-        return DenseBlobResourceElementsAttr::get(st, "dense_elements_f16",
-                                                  std::move(blob));
+        return DenseResourceElementsAttr::get(st, "dense_elements_f16",
+                                              std::move(blob));
       case 32:
         blob = HeapAsmResourceBlob::allocate(4 * numElements, /*align=*/64,
                                              /*dataIsMutable=*/true);
         copyFPAttrIntoBlob<uint32_t>(blob, attr);
-        return DenseBlobResourceElementsAttr::get(st, "dense_elements_f32",
-                                                  std::move(blob));
+        return DenseResourceElementsAttr::get(st, "dense_elements_f32",
+                                              std::move(blob));
       case 64:
         blob = HeapAsmResourceBlob::allocate(8 * numElements, /*align=*/64,
                                              /*dataIsMutable=*/true);
         copyFPAttrIntoBlob<uint64_t>(blob, attr);
-        return DenseBlobResourceElementsAttr::get(st, "dense_elements_f64",
-                                                  std::move(blob));
+        return DenseResourceElementsAttr::get(st, "dense_elements_f64",
+                                              std::move(blob));
       default:
         return {};
       }


### PR DESCRIPTION
The referred to change has already been integrated, so should be possible to remove TODO.