### PR TITLE
Skip tests that have been failing on Windows nightly builds.

### DIFF
--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -124,6 +124,10 @@ if [[ "${OSTYPE}" =~ ^msys ]]; then
     # TODO(#11070): Fix argument/result signature mismatch
     "iree/tests/e2e/tosa_ops/check_vmvx_local-sync_microkernels_fully_connected.mlir"
     "iree/tests/e2e/tosa_ops/check_vmvx_local-sync_microkernels_matmul.mlir"
+    # TODO(#18428): Fix these tests failing on GitHub-hosted Windows runners
+    "iree/tests/e2e/stablehlo_models/mnist_fake_weights_llvm_cpu_static_c_test"
+    "iree/tests/e2e/stablehlo_models/simple_mul_llvm_cpu_static_c_test"
+    "iree/samples/static_library/static_library_demo_c_test"
   )
 elif [[ "${OSTYPE}" =~ ^darwin ]]; then
   excluded_tests+=(


### PR DESCRIPTION
See https://github.com/iree-org/iree/issues/18428

CI history: https://github.com/iree-org/iree/actions/workflows/ci_windows_x64_msvc.yml