### PR TITLE
Redirect links from GCP to Azure for RISCV/ARM files.

### DIFF
--- a/.github/workflows/pkgci_test_riscv64.yml
+++ b/.github/workflows/pkgci_test_riscv64.yml
@@ -69,7 +69,7 @@ jobs:
             --fetch-gh-workflow=${{ inputs.artifact_run_id }}
       - name: Bootstrap
         env:
-          IREE_ARTIFACT_URL: "https://storage.googleapis.com/iree-shared-files"
+          IREE_ARTIFACT_URL: "https://sharkpublic.blob.core.windows.net/sharkpublic/GCP-Migration-Files"
           RISCV_CLANG_TOOLCHAIN_FILE_NAME: "toolchain_iree_manylinux_2_28_20231012.tar.gz"
           QEMU_FILE_NAME: "qemu-riscv_8.1.2_manylinux_2.28_20231026.tar.gz"
         run: |

--- a/build_tools/docker/dockerfiles/base-arm64.Dockerfile
+++ b/build_tools/docker/dockerfiles/base-arm64.Dockerfile
@@ -76,7 +76,7 @@ ENV PYTHON_BIN /usr/bin/python3
 
 WORKDIR /install-qemu
 
-RUN wget --no-verbose "https://storage.googleapis.com/iree-shared-files/qemu-aarch64"
+RUN wget --no-verbose "https://sharkpublic.blob.core.windows.net/sharkpublic/GCP-Migration-Files/qemu-aarch64"
 RUN chmod +x ./qemu-aarch64 && cp ./qemu-aarch64 /usr/bin/qemu-aarch64 && rm -rf /install-qemu
 
 ##############


### PR DESCRIPTION
Updated several links to point to files in azure shark-public container instead of gcp. Progress on https://github.com/iree-org/iree/issues/18518.