### PR TITLE
[GPU] Fix out of bounds access in setTileAndFuseLoweringConfig

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -248,7 +248,7 @@ LogicalResult setTileAndFuseLoweringConfig(IREE::GPU::TargetAttr target,
   const unsigned loopDepth = linalgOp.getNumLoops();
 
   // Configurations we need to decide.
-  int64_t workgroupSize = 1;
+  int64_t flatWorkgroupSize = 1;
   SmallVector<int64_t> workgroupTileSizes(loopDepth, 0);
   SmallVector<int64_t> threadTileSizes(loopDepth, 0);
 
@@ -289,7 +289,7 @@ LogicalResult setTileAndFuseLoweringConfig(IREE::GPU::TargetAttr target,
                                      std::nullopt) {
     LDBG("Loss factor: " << lossFactor << "\n");
     // Initialize the configuration.
-    workgroupSize = 1;
+    flatWorkgroupSize = 1;
     // Initialize tiling along all partitioned loops with size 1.
     for (int64_t loopIndex : partitionableLoops) {
       workgroupTileSizes[loopIndex] = threadTileSizes[loopIndex] = 1;
@@ -383,7 +383,7 @@ LogicalResult setTileAndFuseLoweringConfig(IREE::GPU::TargetAttr target,
         break;
       }
 
-      workgroupSize *= candidateWorkgroupSize;
+      flatWorkgroupSize *= candidateWorkgroupSize;
 
       // Stop if we have distributed all threads.
       if (numThreads == 1)
@@ -479,7 +479,7 @@ LogicalResult setTileAndFuseLoweringConfig(IREE::GPU::TargetAttr target,
   return setOpConfigAndEntryPointFnTranslation(
       entryPoint, op, loweringConfig,
       IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUTileAndFuse,
-      {workgroupSize, 1, 1}, subgroupSize, DictionaryAttr());
+      {flatWorkgroupSize, 1, 1}, subgroupSize, DictionaryAttr());
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -249,22 +249,8 @@ LogicalResult setTileAndFuseLoweringConfig(IREE::GPU::TargetAttr target,
 
   // Configurations we need to decide.
   std::array<int64_t, 3> workgroupSize;
-  SmallVector<int64_t> workgroupTileSizes;
-  SmallVector<int64_t> threadTileSizes;
-
-  // Initialize the configuration.
-  auto initConfiguration = [&]() {
-    workgroupSize = {subgroupSize, 1, 1};
-    workgroupTileSizes.resize(loopDepth, 0);
-    threadTileSizes.resize(loopDepth, 0);
-
-    // Initialize tiling along all partitioned loops with size 1.
-    for (int64_t loopIndex : partitionableLoops) {
-      workgroupTileSizes[loopIndex] = threadTileSizes[loopIndex] = 1;
-    }
-    // Override the innermost dimension to distribute to threads in a subgroup.
-    workgroupTileSizes[partitionableLoops.back()] = subgroupSize;
-  };
+  SmallVector<int64_t> workgroupTileSizes(loopDepth, 0);
+  SmallVector<int64_t> threadTileSizes(loopDepth, 0);
 
   // Common case for all linalg ops.
 
@@ -302,7 +288,15 @@ LogicalResult setTileAndFuseLoweringConfig(IREE::GPU::TargetAttr target,
                                  std::optional<int64_t> lossFactor =
                                      std::nullopt) {
     LDBG("Loss factor: " << lossFactor << "\n");
-    initConfiguration();
+    // Initialize the configuration.
+    workgroupSize = {subgroupSize, 1, 1};
+    // Initialize tiling along all partitioned loops with size 1.
+    for (int64_t loopIndex : partitionableLoops) {
+      workgroupTileSizes[loopIndex] = threadTileSizes[loopIndex] = 1;
+    }
+    // Override the innermost dimension to distribute to threads in a subgroup.
+    workgroupTileSizes[partitionableLoops.back()] = subgroupSize;
+
     // If there are more than 3 parallel dim try to tile the extra higher level
     // dimensions to 1 for extra dimensions.
     if (isa<linalg::GenericOp>(linalgOp.getOperation())) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
@@ -153,4 +153,4 @@ module @elementwise_large_rank {
 // Verify that a lowering config is set on large rank tensors with unaligned
 // shapes.
 // CHECK-LABEL: func.func @elementwise_large_rank
-//  CHECK-SAME:   #iree_codegen.translation_info
+//  CHECK-SAME:   #iree_codegen.translation_info<LLVMGPUVectorize workgroup_size = [128, 1, 1] subgroup_size = 64>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
@@ -138,3 +138,19 @@ module @elementwise_unaligned {
 // dynamic scf.forall loops.
 // CHECK-LABEL: module @elementwise_unaligned
 //  CHECK-NOT:   LLVMGPUTileAndFuse
+
+// -----
+
+module @elementwise_large_rank {
+  func.func @elementwise_large_rank(%11: tensor<3x5x7x11x13x17x19x23xf16>, %12: tensor<3x5x7x11x13x17x19x23xf16>) -> tensor<3x5x7x11x13x17x19x23xf16> {
+    %cst = arith.constant 0.000000e+00 : f32
+    %13 = tensor.empty() : tensor<3x5x7x11x13x17x19x23xf16>
+    %15 = linalg.add ins(%11, %12 : tensor<3x5x7x11x13x17x19x23xf16>, tensor<3x5x7x11x13x17x19x23xf16>) outs(%13 : tensor<3x5x7x11x13x17x19x23xf16>) -> tensor<3x5x7x11x13x17x19x23xf16>
+    return %15 : tensor<3x5x7x11x13x17x19x23xf16>
+  }
+}
+
+// Verify that a lowering config is set on large rank tensors with unaligned
+// shapes.
+// CHECK-LABEL: func.func @elementwise_large_rank
+//  CHECK-SAME:   #iree_codegen.translation_info


### PR DESCRIPTION
The `setTileAndFuseLoweringConfig` function had potential out of bounds accesses for large iteration spaces. This fixes the bug.