### PR TITLE
[Codegen] Check for workgroup level tile sizes in workgroup tiling

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
@@ -56,6 +56,9 @@ getTiledAndDistributionInfo(RewriterBase &rewriter,
   Operation *tilableOp = nullptr;
   for (Operation *op : llvm::reverse(computeOps)) {
     if (getLoweringConfig(op)) {
+      if (getLoweringConfig(op).getWorkgroupTileSizes().empty()) {
+        continue;
+      }
       tilableOp = op;
       break;
     }

--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
@@ -53,19 +53,18 @@ struct TilingInfo {
 static FailureOr<TilingInfo>
 getTiledAndDistributionInfo(RewriterBase &rewriter,
                             ArrayRef<Operation *> computeOps) {
-  // TODO(Max191): We choose the root for tiling as the first op that has a
-  // lowering config with workgroup tile sizes. It is probably cleaner to
-  // reuse some logic for finding the root operation during lowering strategy
-  // selection, but root op selection logic would need to either be unified or
-  // passed as an option to this pass.
+  // It is expected that at most one compute op has a workgroup tiling level.
   Operation *tilableOp = nullptr;
   for (Operation *op : llvm::reverse(computeOps)) {
     if (getLoweringConfig(op)) {
-      if (getLoweringConfig(op).hasWorkgroupTilingLevel()) {
+      if (!getLoweringConfig(op).hasWorkgroupTilingLevel()) {
         continue;
       }
+      if (tilableOp) {
+        return op->emitOpError("expected only one op with a workgroup tiling"
+                               "level.");
+      }
       tilableOp = op;
-      break;
     }
   }
   if (!tilableOp) {

--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
@@ -53,10 +53,15 @@ struct TilingInfo {
 static FailureOr<TilingInfo>
 getTiledAndDistributionInfo(RewriterBase &rewriter,
                             ArrayRef<Operation *> computeOps) {
+  // TODO(Max191): We choose the root for tiling as the first op that has a
+  // lowering config with workgroup tile sizes. It is probably cleaner to
+  // reuse some logic for finding the root operation during lowering strategy
+  // selection, but root op selection logic would need to either be unified or
+  // passed as an option to this pass.
   Operation *tilableOp = nullptr;
   for (Operation *op : llvm::reverse(computeOps)) {
     if (getLoweringConfig(op)) {
-      if (getLoweringConfig(op).getWorkgroupTileSizes().empty()) {
+      if (getLoweringConfig(op).hasWorkgroupTilingLevel()) {
         continue;
       }
       tilableOp = op;

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
@@ -323,6 +323,10 @@ bool LoweringConfigAttr::hasTilingLevel(unsigned level) const {
   return !getTileSizeVals(level).empty();
 }
 
+bool LoweringConfigAttr::hasWorkgroupTilingLevel() const {
+  return !getWorkgroupTileSizes().empty();
+}
+
 LogicalResult
 LoweringConfigAttr::verify(function_ref<InFlightDiagnostic()> emitError,
                            LoweringConfigTilingLevelsAttr levels,

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -296,6 +296,7 @@ def IREECodegen_LoweringConfigAttr :
         "getStaticTilingLevelSizes",
         "getTilingLevelSizes",
         "hasTilingLevel",
+        "hasWorkgroupTilingLevel",
       ]>
     ]> {
   let mnemonic = "lowering_config";

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
@@ -70,7 +70,7 @@ def IREECodegen_LoweringConfigAttrInterface :
       /*args=*/(ins),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
-        return !getWorkgroupTileSizes().empty();
+        return false;
       }]
     >,
     InterfaceMethod<

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
@@ -62,6 +62,19 @@ def IREECodegen_LoweringConfigAttrInterface :
     >,
     InterfaceMethod<
       /*desc=*/[{
+        Returns true if the lowering config specifies tile sizes for the
+        workgroup tiling level.
+      }],
+      /*retTy=*/"bool",
+      /*methodName=*/"hasWorkgroupTilingLevel",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return !getWorkgroupTileSizes().empty();
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
         Returns the tile sizes for the specified tiling level. The
         interpretation of |level| is attribute and backend dependent. The
         |target| is the operation this lowering configuration annotates.

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -1348,6 +1348,10 @@ bool LoweringConfigAttr::hasTilingLevel(unsigned level) const {
               .empty();
 }
 
+bool LoweringConfigAttr::hasWorkgroupTilingLevel() const {
+  return !getWorkgroupTileSizes().empty();
+}
+
 constexpr StringLiteral kMmaKindName = "mma_kind";
 
 IREE::GPU::MmaInterfaceAttr LoweringConfigAttr::getMmaKind() const {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -39,6 +39,7 @@ def IREEGPU_LoweringConfigAttr :
         "getStaticTilingLevelSizes",
         "getTilingLevelSizes",
         "hasTilingLevel",
+        "hasWorkgroupTilingLevel",
       ]>
     ]> {
   let mnemonic = "lowering_config";


### PR DESCRIPTION
TileDispatchUsingForall relies on lowering configurations having workgroup level tile sizes, so this PR adds the additional check that the tilableOp has workgroup level tile sizes. It also adds verification that there is only one op with a workgroup tiling level.