### PR TITLE
Add pass to generalize pack ops if they are consumed by flow.dispatch.tensor.store ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -111,6 +111,7 @@ iree_compiler_cc_library(
         "FoldTensorSubsetIntoVectorTransferOps.cpp",
         "ForOpCanonicalizationPass.cpp",
         "FuseTensorPadWithConsumer.cpp",
+        "GeneralizeTensorPackPass.cpp",
         "GenericVectorization.cpp",
         "HoistStaticallyBoundAllocations.cpp",
         "HoistUnrolledVectorExtractInsertSlice.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -102,6 +102,7 @@ iree_cc_library(
     "FoldTensorSubsetIntoVectorTransferOps.cpp"
     "ForOpCanonicalizationPass.cpp"
     "FuseTensorPadWithConsumer.cpp"
+    "GeneralizeTensorPackPass.cpp"
     "GenericVectorization.cpp"
     "HoistStaticallyBoundAllocations.cpp"
     "HoistUnrolledVectorExtractInsertSlice.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/GeneralizeTensorPackPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GeneralizeTensorPackPass.cpp
@@ -1,0 +1,159 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/LLVMCPU/Passes.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/IndexingUtils.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_GENERALIZETENSORPACKPASS
+#include "iree/compiler/Codegen/Common/Passes.h.inc"
+
+// Indicates whether the given permutation vector is a minor identity
+// for a permutation of the given |rank|.
+static bool isIdentityIndices(llvm::ArrayRef<int64_t> indices) {
+  if (indices.empty()) {
+    return true;
+  }
+  int64_t base = indices[0];
+  return llvm::all_of(llvm::enumerate(indices),
+                      [base](auto e) { return e.value() - base == e.index(); });
+}
+
+namespace {
+
+// This generalizes pack ops that are consumed by flow.dispatch.tensor.store
+// into linalg::transpose. E.g   %pack = tensor.pack %2 outer_dims_perm = [0, 1]
+// inner_dims_pos = [0, 1] inner_tiles = [8, 1] into %3 : tensor<8x768xf32> ->
+// tensor<1x768x8x1xf32> is converted into %transposed = linalg.transpose ins(%2
+// : tensor<8x768xf32>) outs(%5 : tensor<768x8xf32>) permutation = [1, 0].
+
+LogicalResult ConvertPackToTranspose(tensor::PackOp packOp,
+                                     IRRewriter &rewriter) {
+  // Bail if the user is not a `flow.dispatch.tensor.store`.
+  for (auto user : packOp->getUsers()) {
+    if (!isa<IREE::Flow::DispatchTensorStoreOp>(user))
+      return success();
+  }
+  // Padding is not supported by the pattern.
+  if (packOp.getPaddingValue())
+    return success();
+  llvm::ArrayRef<int64_t> permutation = packOp.getOuterDimsPerm();
+
+  // Outer dim permutations are not supported by the pattern.
+  if (!isIdentityIndices(permutation)) {
+    return success();
+  }
+  Location loc = packOp.getLoc();
+  llvm::ArrayRef<int64_t> innerTiles = packOp.getStaticInnerTiles();
+  llvm::ArrayRef<int64_t> innerDimsPos = packOp.getInnerDimsPos();
+
+  // Currently we only handle pack op with static inner tile sizes.
+  if (llvm::any_of(innerTiles,
+                   [](int64_t size) { return ShapedType::isDynamic(size); })) {
+    return success();
+  }
+  SmallVector<OpFoldResult> newInnerTiles;
+  SmallVector<int64_t> newInnerDimsPos;
+
+  for (size_t i = 0; i < innerTiles.size(); ++i) {
+    if (innerTiles[i] != 1) {
+      newInnerTiles.push_back(rewriter.getIndexAttr(innerTiles[i]));
+      // newPermutation.push_back(permutation[i]);
+      newInnerDimsPos.push_back(innerDimsPos[i]);
+    }
+  }
+
+  rewriter.setInsertionPoint(packOp);
+
+  // construct a packOp in which unit inner tiles are removed.
+  Value empty = tensor::PackOp::createDestinationTensor(
+      rewriter, loc, packOp.getSource(), newInnerTiles, newInnerDimsPos,
+      SmallVector<int64_t>{});
+
+  auto newPackOp = rewriter.create<tensor::PackOp>(
+      loc, packOp.getSource(), empty, newInnerDimsPos, newInnerTiles,
+      /*padding=*/std::nullopt, SmallVector<int64_t>{});
+
+  RankedTensorType destType =
+      cast<RankedTensorType>(newPackOp.getDest().getType());
+  ArrayRef<int64_t> destShape = destType.getShape();
+  innerDimsPos = newPackOp.getInnerDimsPos();
+
+  // If we have outer dims that are not unit then this is not a tranpose so we
+  // bail.
+  if (llvm::any_of(innerDimsPos, [destShape](int64_t index) {
+        return destShape[index] != 1;
+      })) {
+    return success();
+  }
+
+  // Collect the set of transposed dimensions.
+  llvm::DenseSet<int64_t> innerDims;
+  for (auto innerDim : innerDimsPos) {
+    innerDims.insert(innerDim);
+  }
+
+  // Construct the permutation for the transpose. It is constructed as
+  // [untiled_outer_dims, inner_dims_pos].
+  int64_t srcRank = newPackOp.getSourceRank();
+  SmallVector<int64_t> perm;
+  for (int i = 0, e = srcRank; i < e; i++) {
+    if (!innerDims.count(i)) {
+      perm.push_back(i);
+    }
+  }
+  perm.append(innerDimsPos.begin(), innerDimsPos.end());
+
+  SmallVector<OpFoldResult> mixedSizes =
+      tensor::getMixedSizes(rewriter, loc, newPackOp.getSource());
+  applyPermutationToVector(mixedSizes, perm);
+  empty = rewriter.create<tensor::EmptyOp>(loc, mixedSizes,
+                                           destType.getElementType());
+  Value transposed =
+      rewriter
+          .create<linalg::TransposeOp>(loc, newPackOp.getSource(), empty, perm)
+          .getResult()[0];
+
+  /*Value replacement = rewriter.create<IREE::Flow::TensorReshapeOp>(
+      loc, packOp.getType(), transposed, SmallVector<Value>{},
+      SmallVector<Value>{});*/
+
+  rewriter.replaceAllUsesWith(packOp, transposed);
+  packOp->erase();
+  newPackOp->erase();
+
+  return success();
+}
+
+struct GeneralizeTensorPackPass
+    : public impl::GeneralizeTensorPackPassBase<GeneralizeTensorPackPass> {
+  /*void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<linalg::LinalgDialect>();
+  }*/
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    IRRewriter rewriter(context);
+    auto walkResult =
+        getOperation()->walk([&rewriter](tensor::PackOp op) -> WalkResult {
+          if (failed(ConvertPackToTranspose(op, rewriter))) {
+            return WalkResult::interrupt();
+          }
+          return WalkResult::advance();
+        });
+    if (walkResult.wasInterrupted())
+      signalPassFailure();
+  }
+};
+} // namespace
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -271,6 +271,15 @@ def FuseTensorPadWithConsumerPass :
   let summary = "Fuse tensor.pad op into its consumer op's tiled loop nest";
 }
 
+def GeneralizeTensorPackPass :
+    Pass<"iree-codegen-generalize-tensor-pack", ""> {
+  let summary =
+      "Generalize tensor pack operations";
+  let description = [{
+    Pass that folds unit dims in tenosr.pack to convert to linalg.transpose when legal.
+  }];
+}
+
 def GenericVectorizationPass :
     InterfacePass<"iree-codegen-generic-vectorization", "mlir::FunctionOpInterface"> {
   let summary = "Pass to perform vectorization on tensor/linalg ops.";

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -44,6 +44,7 @@ iree_lit_test_suite(
             "fold_affine_min_of_block_id.mlir",
             "fold_tensor_extract_op.mlir",
             "forop_canonicalization.mlir",
+            "generalize_tensor_pack.mlir",
             "generic_vectorization.mlir",
             "hoist_statically_bound_allocations.mlir",
             "hoist_unrolled_vector_extract_insert_slice.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -40,6 +40,7 @@ iree_lit_test_suite(
     "fold_affine_min_of_block_id.mlir"
     "fold_tensor_extract_op.mlir"
     "forop_canonicalization.mlir"
+    "generalize_tensor_pack.mlir"
     "generic_vectorization.mlir"
     "hoist_statically_bound_allocations.mlir"
     "hoist_unrolled_vector_extract_insert_slice.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/generalize_tensor_pack.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/generalize_tensor_pack.mlir
@@ -1,0 +1,52 @@
+// RUN: iree-opt %s --split-input-file --iree-codegen-generalize-tensor-pack | FileCheck %s
+
+func.func @not_transpose() {
+  %c0 = arith.constant 0 : index
+  %c24576 = arith.constant 24576 : index
+  %0 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !flow.dispatch.tensor<readonly:tensor<768x768xf32>>
+  %1 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c24576) flags(Indirect) : !flow.dispatch.tensor<writeonly:tensor<192x768x4x1xf32>>
+  %2 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [768, 768], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<768x768xf32>> -> tensor<768x768xf32>
+  %3 = tensor.empty() : tensor<192x768x4x1xf32>
+  %pack = tensor.pack %2 outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [4, 1] into %3 : tensor<768x768xf32> -> tensor<192x768x4x1xf32>
+  flow.dispatch.tensor.store %pack, %1, offsets = [0, 0, 0, 0], sizes = [192, 768, 4, 1], strides = [1, 1, 1, 1] : tensor<192x768x4x1xf32> -> !flow.dispatch.tensor<writeonly:tensor<192x768x4x1xf32>>
+  return
+}
+// CHECK-LABEL:   func.func @not_transpose
+// CHECK:         %[[PACK:.*]] =  tensor.pack {{.*}} tensor<768x768xf32> -> tensor<192x768x4x1xf32>
+// CHECK:          flow.dispatch.tensor.store %[[PACK]]
+
+// -----
+
+func.func @tranpose() {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !flow.dispatch.tensor<readonly:tensor<8x768xf32>>
+  %1 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags(Indirect) : !flow.dispatch.tensor<writeonly:tensor<1x768x8x1xf32>>
+  %2 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 768], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<8x768xf32>> -> tensor<8x768xf32>
+  %3 = tensor.empty() : tensor<1x768x8x1xf32>
+  %pack = tensor.pack %2 outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [8, 1] into %3 : tensor<8x768xf32> -> tensor<1x768x8x1xf32>
+  flow.dispatch.tensor.store %pack, %1, offsets = [0, 0, 0, 0], sizes = [1, 768, 8, 1], strides = [1, 1, 1, 1] : tensor<1x768x8x1xf32> -> !flow.dispatch.tensor<writeonly:tensor<1x768x8x1xf32>>
+  return
+}
+
+// CHECK-LABEL:   func.func @tranpose
+// CHECK:         %[[TRANSPOSE:.*]] =  linalg.transpose ins(%{{.*}} : tensor<8x768xf32>) outs(%{{.*}} : tensor<768x8xf32>) permutation = [1, 0]
+// CHECK:          flow.dispatch.tensor.store %[[TRANSPOSE]]
+
+// -----
+
+func.func @not_store_consumed() {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !flow.dispatch.tensor<readonly:tensor<8x768xf32>>
+  %1 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags(Indirect) : !flow.dispatch.tensor<writeonly:tensor<1x768x8x1xf32>>
+  %2 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 768], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<8x768xf32>> -> tensor<8x768xf32>
+  %3 = tensor.empty() : tensor<1x768x8x1xf32>
+  %pack = tensor.pack %2 outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [8, 1] into %3 : tensor<8x768xf32> -> tensor<1x768x8x1xf32>
+  %arith = arith.negf %pack : tensor<1x768x8x1xf32>
+  flow.dispatch.tensor.store %arith, %1, offsets = [0, 0, 0, 0], sizes = [1, 768, 8, 1], strides = [1, 1, 1, 1] : tensor<1x768x8x1xf32> -> !flow.dispatch.tensor<writeonly:tensor<1x768x8x1xf32>>
+  return
+}
+
+// CHECK-LABEL:   func.func @not_store_consumed
+// CHECK:         %[[PACK:.*]] = tensor.pack {{.*}} tensor<8x768xf32> -> tensor<1x768x8x1xf32>
+// CHECK:         %[[ARITH:.*]] = arith.negf %[[PACK]] : tensor<1x768x8x1xf32>
+// CHECK:          flow.dispatch.tensor.store %[[ARITH]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -769,6 +769,7 @@ void buildLLVMCPUCodegenConfigurationPassPipelineImpl(
       // TODO(#13888): This(createExpandF16OpToF32Pass()) pass is being added
       // way to late and should insted be be done during lowering to LLVM.
       .addPass(createExpandF16OpToF32Pass)
+      .addPass(createGeneralizeTensorPackPass)
       .addPass(createCPUMaterializeDeviceEncodingPass)
       // TODO: Remove the following pass the plumb support for
       // #hal.descriptor_type memory space through the stack.


### PR DESCRIPTION
Pack ops can affect tiling decisions and hence it is beneficial to generalize them, for e.g for below IR
```
    %5 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} outs(%4 : tensor<8x768xf32>) {
    ^bb0(%out: f32):
      %6 = linalg.index 0 : index
      %7 = linalg.index 1 : index
      %extracted = tensor.extract %2[%6, %c0, %7] : tensor<8x128x768xf32>
      linalg.yield %extracted : f32
    } -> tensor<8x768xf32>
    %pack = tensor.pack %5 outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [8, 1] into %3 : tensor<8x768xf32> -> tensor<1x768x8x1xf32>
```
The gather linalg.generic will get the following tiling config `{lowering_config = #iree_codegen.lowering_config<tile_sizes = [[8, 512], [8, 1], [0, 0], [0, 0]]>}`
This is not supported by current upstream vectorization  https://github.com/llvm/llvm-project/issues/107476 (it should be and that is being worked on but we didnt need to reach this tiling config)

With this PR the above IR will simplify to
```
  %4 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} outs(%3 : tensor<8x768xf32>) {
  ^bb0(%out: f32):
    %6 = linalg.index 0 : index
    %7 = linalg.index 1 : index
    %extracted = tensor.extract %2[%6, %c128, %7] : tensor<8x128x768xf32>
    linalg.yield %extracted : f32
  } -> tensor<8x768xf32>
  %5 = tensor.empty() : tensor<768x8xf32>
  %transposed = linalg.transpose ins(%4 : tensor<8x768xf32>) outs(%5 : tensor<768x8xf32>) permutation = [1, 0] 
  ```
  with which we will get the following vectorizable tiling config `{lowering_config = #iree_codegen.lowering_config<tile_sizes = [[64, 8], [1, 4], [0, 0], [0, 0]]>}`
  
 We only want to do this when the pack is being consumed only by `flow.dispatch.tensor.store` and we dont do any transforms for other cases as that would have implications on codegeneration that we dont want. 
  
 
Fixes : https://github.com/iree-org/iree/issues/18413
