### PR TITLE
[Codegen][GPU] Add pass to combine adjacent barrier_region ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BUILD.bazel
@@ -51,6 +51,7 @@ iree_gentbl_cc_library(
 iree_compiler_cc_library(
     name = "GPUTransforms",
     srcs = [
+        "CombineBarrierRegions.cpp",
         "ConcretizeMmaShapes.cpp",
         "DistributeMmaToLanes.cpp",
         "FuseAndHoistParallelLoops.cpp",

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/CMakeLists.txt
@@ -45,6 +45,7 @@ iree_cc_library(
     "Passes.h.inc"
     "Transforms.h"
   SRCS
+    "CombineBarrierRegions.cpp"
     "ConcretizeMmaShapes.cpp"
     "DistributeMmaToLanes.cpp"
     "FuseAndHoistParallelLoops.cpp"

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/CombineBarrierRegions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/CombineBarrierRegions.cpp
@@ -1,0 +1,133 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===----------------------------------------------------------------------===//
+// This file implements the pass to combine multiple `iree_gpu.barrier_region`
+// ops.
+//===----------------------------------------------------------------------===//
+
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
+#include "iree/compiler/Codegen/Dialect/GPU/Transforms/Passes.h"
+#include "llvm/Support/Casting.h"
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/RegionUtils.h"
+
+#define DEBUG_TYPE "iree-gpu-combine-barrier-regions"
+
+namespace mlir::iree_compiler::IREE::GPU {
+
+#define GEN_PASS_DEF_COMBINEBARRIERREGIONSPASS
+#include "iree/compiler/Codegen/Dialect/GPU/Transforms/Passes.h.inc"
+
+namespace {
+
+struct CombineBarrierRegionsPass final
+    : impl::CombineBarrierRegionsPassBase<CombineBarrierRegionsPass> {
+  void runOnOperation() override;
+};
+
+/// Given two barriers, barrierA and barrierB where A is the op immediately
+/// before B in the block, combine them into a single barrier.
+static LogicalResult
+combineBarrierRegionPair(RewriterBase &rewriter,
+                         IREE::GPU::BarrierRegionOp barrierA,
+                         IREE::GPU::BarrierRegionOp barrierB) {
+  // barrierB must immediately follow barrierA.
+  assert(barrierA->getBlock() == barrierB->getBlock());
+  if (barrierA->getNextNode() != barrierB) {
+    return failure();
+  }
+
+  // Fail if barrierA is used by barrierB, either directly or by implicit
+  // capture.
+  for (auto user : barrierA->getUsers()) {
+    if (user == barrierB || barrierB->isProperAncestor(user)) {
+      return failure();
+    }
+  }
+
+  Location fusedLoc =
+      rewriter.getFusedLoc({barrierA.getLoc(), barrierB.getLoc()});
+
+  // Get the combined operands, result types, and yielded values.
+  SmallVector<Value> combinedOperands = barrierA.getInputs();
+  combinedOperands.append(barrierB.getInputs().begin(),
+                          barrierB.getInputs().end());
+  SmallVector<Type> combinedTypes(barrierA->getResultTypes());
+  combinedTypes.append(barrierB->getResultTypes().begin(),
+                       barrierB->getResultTypes().end());
+
+  auto aYield = cast<IREE::GPU::YieldOp>(barrierA.getBody()->getTerminator());
+  auto bYield = cast<IREE::GPU::YieldOp>(barrierB.getBody()->getTerminator());
+  SmallVector<Value> combinedYields = aYield.getValues();
+  combinedYields.append(bYield.getValues().begin(), bYield.getValues().end());
+
+  // Create the new barrier op.
+  auto combinedBarrierOp = rewriter.create<IREE::GPU::BarrierRegionOp>(
+      fusedLoc, combinedTypes, combinedOperands);
+
+  MutableArrayRef<BlockArgument> barrierABbArgReplacements =
+      combinedBarrierOp.getBody()->getArguments().take_front(
+          barrierA->getNumOperands());
+  MutableArrayRef<BlockArgument> barrierBBbArgReplacements =
+      combinedBarrierOp.getBody()->getArguments().take_back(
+          barrierB->getNumOperands());
+
+  // Merge the bodies of the old barriers into the new one.
+  rewriter.mergeBlocks(barrierA.getBody(), combinedBarrierOp.getBody(),
+                       barrierABbArgReplacements);
+  rewriter.mergeBlocks(barrierB.getBody(), combinedBarrierOp.getBody(),
+                       barrierBBbArgReplacements);
+
+  // Erase the old terminators and create a new one with a concatenated list of
+  // values.
+  rewriter.eraseOp(aYield);
+  rewriter.eraseOp(bYield);
+
+  rewriter.setInsertionPointToEnd(combinedBarrierOp.getBody());
+  rewriter.create<IREE::GPU::YieldOp>(fusedLoc, combinedYields);
+
+  SmallVector<Value> valuesToReplace = barrierA.getResults();
+  ValueRange bResults = barrierB.getResults();
+  valuesToReplace.append(bResults.begin(), bResults.end());
+  rewriter.replaceAllUsesWith(valuesToReplace, combinedBarrierOp.getResults());
+  rewriter.eraseOp(barrierA);
+  rewriter.eraseOp(barrierB);
+  return success();
+}
+
+struct CombineAdjacentBarrierRegions final
+    : OpRewritePattern<IREE::GPU::BarrierRegionOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(IREE::GPU::BarrierRegionOp barrierOp,
+                                PatternRewriter &rewriter) const override {
+    auto prevBarrier = llvm::dyn_cast_if_present<IREE::GPU::BarrierRegionOp>(
+        barrierOp->getPrevNode());
+    if (!prevBarrier) {
+      return failure();
+    }
+    return combineBarrierRegionPair(rewriter, prevBarrier, barrierOp);
+  }
+};
+
+void CombineBarrierRegionsPass::runOnOperation() {
+  MLIRContext *context = &getContext();
+  RewritePatternSet patterns(context);
+  // These two patterns are run to a fixed point, allowing fusion within
+  // potentially nested loops, hoisting from said loops, and continued fusion.
+  patterns.add<CombineAdjacentBarrierRegions>(context);
+  if (failed(
+          applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
+    return signalPassFailure();
+  }
+
+  return;
+}
+
+} // namespace
+
+} // namespace mlir::iree_compiler::IREE::GPU

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/CombineBarrierRegions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/CombineBarrierRegions.cpp
@@ -36,11 +36,8 @@ static LogicalResult
 combineBarrierRegionPair(RewriterBase &rewriter,
                          IREE::GPU::BarrierRegionOp barrierA,
                          IREE::GPU::BarrierRegionOp barrierB) {
-  // barrierB must immediately follow barrierA.
-  assert(barrierA->getBlock() == barrierB->getBlock());
-  if (barrierA->getNextNode() != barrierB) {
-    return failure();
-  }
+  assert(barrierA->getBlock() == barrierB->getBlock() &&
+         barrierA->getNextNode() == barrierB && "Expected adjacent barriers");
 
   // Fail if barrierA is used by barrierB, either directly or by implicit
   // capture.

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Passes.td
@@ -9,15 +9,10 @@
 
 include "mlir/Pass/PassBase.td"
 
-def DistributeMmaToLanesPass :
-    InterfacePass<"iree-gpu-distribute-mma-to-lanes", "mlir::FunctionOpInterface"> {
-  let summary = "Distributes iree_gpu.multi_mma ops to lanes";
-  let dependentDialects = [
-    "::mlir::arith::ArithDialect",
-    "::mlir::affine::AffineDialect",
-    "::mlir::scf::SCFDialect",
-    "::mlir::tensor::TensorDialect",
-  ];
+def CombineBarrierRegionsPass :
+    Pass<"iree-gpu-combine-barrier-regions", ""> {
+  let summary = "Combines `iree_gpu.barrier_region` ops";
+  let dependentDialects = ["::mlir::iree_compiler::IREE::GPU::IREEGPUDialect"];
 }
 
 def ConcretizeMmaShapesPass :
@@ -34,6 +29,17 @@ def ConcretizeMmaShapesPass :
     Option<"concretizeResult", "concretize-result",
       "bool", /*default=*/"true",
       "Expand the inner dimensions for the acc operand of the multi_mma ops.">,
+  ];
+}
+
+def DistributeMmaToLanesPass :
+    InterfacePass<"iree-gpu-distribute-mma-to-lanes", "mlir::FunctionOpInterface"> {
+  let summary = "Distributes iree_gpu.multi_mma ops to lanes";
+  let dependentDialects = [
+    "::mlir::arith::ArithDialect",
+    "::mlir::affine::AffineDialect",
+    "::mlir::scf::SCFDialect",
+    "::mlir::tensor::TensorDialect",
   ];
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/BUILD.bazel
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "combine_barrier_regions.mlir",
             "concretize_mma_shapes.mlir",
             "distribute_mma_to_lanes.mlir",
             "fuse_and_hoist_forall.mlir",

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "combine_barrier_regions.mlir"
     "concretize_mma_shapes.mlir"
     "distribute_mma_to_lanes.mlir"
     "fuse_and_hoist_forall.mlir"

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/combine_barrier_regions.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/combine_barrier_regions.mlir
@@ -1,0 +1,101 @@
+// RUN: iree-opt %s --pass-pipeline="builtin.module(func.func(iree-gpu-combine-barrier-regions))" --split-input-file | FileCheck %s
+
+func.func @combine_barrier_region(%arg0: tensor<6xf32>, %arg1: tensor<7xf32>) -> (tensor<1xf32>, tensor<2xf32>) {
+  %0 = iree_gpu.barrier_region ins(%arg0 : tensor<6xf32>) {
+  ^bb0(%intermediate: tensor<6xf32>):
+    %slice = tensor.extract_slice %intermediate[1] [1] [1] : tensor<6xf32> to tensor<1xf32>
+    iree_gpu.yield %slice : tensor<1xf32>
+  } : tensor<1xf32>
+  %1 = iree_gpu.barrier_region ins(%arg1 : tensor<7xf32>) {
+  ^bb0(%intermediate: tensor<7xf32>):
+    %slice = tensor.extract_slice %intermediate[2] [2] [2] : tensor<7xf32> to tensor<2xf32>
+    iree_gpu.yield %slice : tensor<2xf32>
+  } : tensor<2xf32>
+  return %0, %1 : tensor<1xf32>, tensor<2xf32>
+}
+
+// CHECK-LABEL: func @combine_barrier_region
+//  CHECK-SAME:   %[[ARG0:[A-Za-z0-9]+]]: tensor<6xf32>
+//  CHECK-SAME:   %[[ARG1:[A-Za-z0-9]+]]: tensor<7xf32>
+//       CHECK:   %[[B:.+]]:2 = iree_gpu.barrier_region ins(%[[ARG0]], %[[ARG1]] : tensor<6xf32>, tensor<7xf32>) {
+//       CHECK:     ^bb0(%[[I0:.+]]: tensor<6xf32>, %[[I1:.+]]: tensor<7xf32>):
+//       CHECK:       %[[S0:.+]] = tensor.extract_slice %[[I0]][1] [1] [1]
+//       CHECK:       %[[S1:.+]] = tensor.extract_slice %[[I1]][2] [2] [2]
+//       CHECK:       iree_gpu.yield %[[S0]], %[[S1]] : tensor<1xf32>, tensor<2xf32>
+//       CHECK:   } : tensor<1xf32>, tensor<2xf32>
+//       CHECK:   return %[[B]]#0, %[[B]]#1
+
+// -----
+
+func.func @combine_barrier_region(
+    %arg0: tensor<6xf32>,
+    %arg1: tensor<7xf32>,
+    %arg2: tensor<8xf32>) -> (tensor<1xf32>, tensor<2xf32>, tensor<3xf32>) {
+  %0 = iree_gpu.barrier_region ins(%arg0 : tensor<6xf32>) {
+  ^bb0(%intermediate: tensor<6xf32>):
+    %slice = tensor.extract_slice %intermediate[1] [1] [1] : tensor<6xf32> to tensor<1xf32>
+    iree_gpu.yield %slice : tensor<1xf32>
+  } : tensor<1xf32>
+  %1 = iree_gpu.barrier_region ins(%arg1 : tensor<7xf32>) {
+  ^bb0(%intermediate: tensor<7xf32>):
+    %slice = tensor.extract_slice %intermediate[2] [2] [2] : tensor<7xf32> to tensor<2xf32>
+    iree_gpu.yield %slice : tensor<2xf32>
+  } : tensor<2xf32>
+  %2 = iree_gpu.barrier_region ins(%arg2 : tensor<8xf32>) {
+  ^bb0(%intermediate: tensor<8xf32>):
+    %slice = tensor.extract_slice %intermediate[3] [3] [1] : tensor<8xf32> to tensor<3xf32>
+    iree_gpu.yield %slice : tensor<3xf32>
+  } : tensor<3xf32>
+  return %0, %1, %2 : tensor<1xf32>, tensor<2xf32>, tensor<3xf32>
+}
+
+// CHECK-LABEL: func @combine_barrier_region
+//  CHECK-SAME:   %[[ARG0:[A-Za-z0-9]+]]: tensor<6xf32>
+//  CHECK-SAME:   %[[ARG1:[A-Za-z0-9]+]]: tensor<7xf32>
+//  CHECK-SAME:   %[[ARG2:[A-Za-z0-9]+]]: tensor<8xf32>
+//       CHECK:   %[[B:.+]]:3 = iree_gpu.barrier_region ins(%[[ARG0]], %[[ARG1]], %[[ARG2]]
+//       CHECK:     ^bb0(%[[I0:.+]]: tensor<6xf32>, %[[I1:.+]]: tensor<7xf32>, %[[I2:.+]]: tensor<8xf32>):
+//       CHECK:       %[[S0:.+]] = tensor.extract_slice %[[I0]][1] [1] [1]
+//       CHECK:       %[[S1:.+]] = tensor.extract_slice %[[I1]][2] [2] [2]
+//       CHECK:       %[[S2:.+]] = tensor.extract_slice %[[I2]][3] [3] [1]
+//       CHECK:       iree_gpu.yield %[[S0]], %[[S1]], %[[S2]] : tensor<1xf32>, tensor<2xf32>, tensor<3xf32>
+//       CHECK:   } : tensor<1xf32>, tensor<2xf32>, tensor<3xf32>
+//       CHECK:   return %[[B]]#0, %[[B]]#1, %[[B]]#2
+
+// -----
+
+func.func @dont_combine_dependent_barriers(%arg0: tensor<6xf32>) -> (tensor<1xf32>, tensor<1xf32>) {
+  %0 = iree_gpu.barrier_region ins(%arg0 : tensor<6xf32>) {
+  ^bb0(%intermediate: tensor<6xf32>):
+    %slice = tensor.extract_slice %intermediate[1] [1] [1] : tensor<6xf32> to tensor<1xf32>
+    iree_gpu.yield %slice : tensor<1xf32>
+  } : tensor<1xf32>
+  %1 = iree_gpu.barrier_region ins(%0 : tensor<1xf32>) {
+  ^bb0(%intermediate: tensor<1xf32>):
+    iree_gpu.yield %intermediate : tensor<1xf32>
+  } : tensor<1xf32>
+  return %0, %1 : tensor<1xf32>, tensor<1xf32>
+}
+
+// CHECK-LABEL: func @dont_combine_dependent_barriers
+// CHECK-COUNT-2:   iree_gpu.barrier_region
+
+// -----
+
+func.func @dont_combine_implicit_capture(%arg0: tensor<6xf32>, %arg1: tensor<7xf32>) -> (tensor<1xf32>, tensor<2xf32>) {
+  %0 = iree_gpu.barrier_region ins(%arg0 : tensor<6xf32>) {
+  ^bb0(%intermediate: tensor<6xf32>):
+    %slice = tensor.extract_slice %intermediate[1] [1] [1] : tensor<6xf32> to tensor<1xf32>
+    iree_gpu.yield %slice : tensor<1xf32>
+  } : tensor<1xf32>
+  %1 = iree_gpu.barrier_region ins(%arg1 : tensor<7xf32>) {
+  ^bb0(%intermediate: tensor<7xf32>):
+    %slice = tensor.extract_slice %intermediate[1] [1] [1] : tensor<7xf32> to tensor<1xf32>
+    %concat = tensor.concat dim(0) %slice, %0 : (tensor<1xf32>, tensor<1xf32>) -> tensor<2xf32>
+    iree_gpu.yield %concat : tensor<2xf32>
+  } : tensor<2xf32>
+  return %0, %1 : tensor<1xf32>, tensor<2xf32>
+}
+
+// CHECK-LABEL: func @dont_combine_implicit_capture
+// CHECK-COUNT-2:   iree_gpu.barrier_region


### PR DESCRIPTION
This adds a basic pass + pattern for combining adjacent and independent
`iree_gpu.barrier_region` ops into a single region. More involved
analysis/combination (similar to what exists for `iree_gpu.value_barrier`)
is left as TODO.

Depends on #18490