### PR TITLE
[GPU] Add workgroup/subgroup scope specification to mma attr interface

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -550,6 +550,10 @@ int64_t MMAAttr::getSubgroupSize() const {
   return getIntrinsicSubgroupSize(getIntrinsic().getValue());
 }
 
+FailureOr<IREE::GPU::MMAScope> MMAAttr::getMmaScope() const {
+  return IREE::GPU::MMAScope::Subgroup;
+}
+
 MMASingleSubgroupLayout getSingleSubgroupLayout(MMAIntrinsic intrinsic,
                                                 MMAFragment fragment) {
   switch (intrinsic) {
@@ -906,6 +910,10 @@ DataTiledMMAAttr::getABCVectorTypes() const {
 
 int64_t DataTiledMMAAttr::getSubgroupSize() const {
   return getIntrinsicSubgroupSize(getIntrinsic().getValue());
+}
+
+FailureOr<IREE::GPU::MMAScope> DataTiledMMAAttr::getMmaScope() const {
+  return IREE::GPU::MMAScope::Workgroup;
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -129,6 +129,7 @@ class IREEGPU_MmaVectorLayoutAttr<string attrname, string mmaintrinsic> :
     "getContractionLayout",
     "getMNKShape",
     "getSubgroupSize",
+    "getMmaScope",
     "buildMmaOperation",
     "populateOperandOffsetsSizesStrides",
     "materializeOperandConcreteShape",
@@ -221,6 +222,7 @@ def IREEGPU_DataTiledMMAAttr :
     "getABCVectorTypes",
     "getMNKShape",
     "getSubgroupSize",
+    "getMmaScope",
     // TODO: Implement the interface method.
     // "populateOperandOffsetsSizesStrides",
   ]>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td
@@ -144,6 +144,15 @@ def IREEGPU_MMAFragment : IREEGPU_I32MmaEnumAttr<"MMAFragment",
       MMA_ACC
     ]>;
 
+def MMA_Workgroup : I32EnumAttrCase<"Workgroup", 0>;
+def MMA_Subgroup : I32EnumAttrCase<"Subgroup", 1>;
+
+def IREEGPU_MMAScope : IREEGPU_I32MmaEnumAttr<"MMAScope",
+    "Descriptor for a particular scope of an MMA operation", [
+      MMA_Workgroup,
+      MMA_Subgroup
+    ]>;
+
 //===----------------------------------------------------------------------===//
 // Tiling levels
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.td
@@ -129,8 +129,8 @@ def IREEGPU_MmaInterfaceAttr : AttrInterface<"MmaInterfaceAttr"> {
     >,
     InterfaceMethod<
       /*desc=*/[{
-        Constructs the offsets/sizes/strides for extracting the per-thread
-        slice of the given operand fragment.
+        Populates the reassociation indices and result shape to materialize the
+        thread layout shape from the subgroup block shape.
       }],
       /*retTy=*/"::mlir::LogicalResult",
       /*methodName=*/"materializeOperandConcreteShape",
@@ -142,6 +142,19 @@ def IREEGPU_MmaInterfaceAttr : AttrInterface<"MmaInterfaceAttr"> {
         "::llvm::SmallVector<::mlir::SmallVector<int64_t, 2>>&":$reassociations,
         "::mlir::RankedTensorType&":$result_type
       ),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return failure();
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Populates the reassociation indices and result shape to materialize the
+        thread layout shape from the subgroup block shape.
+      }],
+      /*retTy=*/"::mlir::FailureOr<::mlir::iree_compiler::IREE::GPU::MMAScope>",
+      /*methodName=*/"getMmaScope",
+      /*args=*/(ins),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
         return failure();

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.cpp
@@ -510,8 +510,9 @@ convertContractionToMultiMma(RewriterBase &rewriter, linalg::LinalgOp linalgOp,
 // MultiMmaOp Distribution
 //===----------------------------------------------------------------------===//
 
-FailureOr<Operation *> distributeMultiMmaOp(RewriterBase &rewriter,
-                                            IREE::GPU::MultiMmaOp mmaOp) {
+FailureOr<Operation *>
+distributeMultiMmaOp(RewriterBase &rewriter, IREE::GPU::MultiMmaOp mmaOp,
+                     std::optional<SmallVector<int64_t>> workgroupSize) {
   if (!mmaOp.hasTensorSemantics() || mmaOp.hasThreadSemantics()) {
     return rewriter.notifyMatchFailure(
         mmaOp, "mmaOp must have vector and subgroup for distribution.");
@@ -526,12 +527,31 @@ FailureOr<Operation *> distributeMultiMmaOp(RewriterBase &rewriter,
   OpFoldResult one = rewriter.getIndexAttr(1);
 
   // Step 1. Create the new scf.forall op with a lane id mapping.
+  OpFoldResult ub;
+  Attribute mappingType;
+  FailureOr<IREE::GPU::MMAScope> mmaScope = mmaOp.getKind().getMmaScope();
+  if (failed(mmaScope)) {
+    return failure();
+  }
+  switch (mmaScope.value()) {
+  case IREE::GPU::MMAScope::Workgroup:
+    if (!workgroupSize) {
+      mmaOp.emitOpError("Mma op with workgroup scope needs workgroup size.");
+      return failure();
+    }
+    mappingType =
+        gpu::GPUThreadMappingAttr::get(context, gpu::MappingId::LinearDim0);
+    ub = rewriter.getIndexAttr(
+        ShapedType::getNumElements(workgroupSize.value()));
+    break;
+  case IREE::GPU::MMAScope::Subgroup:
+    ub = rewriter.getIndexAttr(mmaOp.getKind().getSubgroupSize());
+    mappingType = IREE::GPU::LaneIdAttr::get(context, 0);
+  }
   auto newForallOp = rewriter.create<scf::ForallOp>(
-      loc, ArrayRef<OpFoldResult>{zero},
-      ArrayRef<OpFoldResult>{
-          rewriter.getIndexAttr(mmaOp.getKind().getSubgroupSize())},
+      loc, ArrayRef<OpFoldResult>{zero}, ArrayRef<OpFoldResult>{ub},
       ArrayRef<OpFoldResult>{one}, mmaOp.getAcc(),
-      ArrayAttr::get(context, {IREE::GPU::LaneIdAttr::get(context, 0)}));
+      ArrayAttr::get(context, {mappingType}));
 
   rewriter.setInsertionPointToStart(newForallOp.getBody());
 
@@ -544,7 +564,7 @@ FailureOr<Operation *> distributeMultiMmaOp(RewriterBase &rewriter,
     }
     return llvm::to_vector(llvm::seq(static_cast<int64_t>(0), rank));
   };
-  Value laneId = newForallOp.getInductionVar(0);
+  Value id = newForallOp.getInductionVar(0);
 
   // LHS slice offsets.
   int64_t lhsOuterRank = mmaOp.getLhsOuterRank();
@@ -557,7 +577,7 @@ FailureOr<Operation *> distributeMultiMmaOp(RewriterBase &rewriter,
   SmallVector<int64_t> lhsPermutation = getOrInferPermutationOfRank(
       mmaOp.getLhsPermutation(), mmaOp.getLhsInnerShape().size());
   if (failed(mmaOp.getKind().populateOperandOffsetsSizesStrides(
-          rewriter, loc, IREE::GPU::MMAFragment::Lhs, laneId, lhsPermutation,
+          rewriter, loc, IREE::GPU::MMAFragment::Lhs, id, lhsPermutation,
           lhsOffsets, lhsSizes, lhsStrides))) {
     return mmaOp->emitOpError("failed to populate lhs offsets");
   }
@@ -577,7 +597,7 @@ FailureOr<Operation *> distributeMultiMmaOp(RewriterBase &rewriter,
   SmallVector<int64_t> rhsPermutation = getOrInferPermutationOfRank(
       mmaOp.getRhsPermutation(), mmaOp.getRhsInnerShape().size());
   if (failed(mmaOp.getKind().populateOperandOffsetsSizesStrides(
-          rewriter, loc, IREE::GPU::MMAFragment::Rhs, laneId, rhsPermutation,
+          rewriter, loc, IREE::GPU::MMAFragment::Rhs, id, rhsPermutation,
           rhsOffsets, rhsSizes, rhsStrides))) {
     return mmaOp->emitOpError("failed to populate rhs offsets");
   }
@@ -597,7 +617,7 @@ FailureOr<Operation *> distributeMultiMmaOp(RewriterBase &rewriter,
   SmallVector<int64_t> accPermutation = getOrInferPermutationOfRank(
       mmaOp.getAccPermutation(), mmaOp.getAccInnerShape().size());
   if (failed(mmaOp.getKind().populateOperandOffsetsSizesStrides(
-          rewriter, loc, IREE::GPU::MMAFragment::Acc, laneId, accPermutation,
+          rewriter, loc, IREE::GPU::MMAFragment::Acc, id, accPermutation,
           accOffsets, accSizes, accStrides))) {
     return mmaOp->emitOpError("failed to populate acc offsets");
   }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.h
@@ -55,8 +55,9 @@ convertContractionToMultiMma(RewriterBase &rewriter, linalg::LinalgOp linalgOp,
                              IREE::GPU::MmaInterfaceAttr mmaKind);
 
 // Helper to distribute a multi_mma op to lanes.
-FailureOr<Operation *> distributeMultiMmaOp(RewriterBase &rewriter,
-                                            IREE::GPU::MultiMmaOp mmaOp);
+FailureOr<Operation *> distributeMultiMmaOp(
+    RewriterBase &rewriter, IREE::GPU::MultiMmaOp mmaOp,
+    std::optional<SmallVector<int64_t>> workgroupSize = std::nullopt);
 
 // Helper to map all scf.forall ops on lanes.
 void mapLaneForalls(RewriterBase &rewriter, Operation *funcOp,


### PR DESCRIPTION
The new DataTiledMMAAttr represents the workload of a full workgroup, while the regular MMAAttr represents the workload of a single subgroup. The scope of the workload is needed when distributing multi_mma ops to threads/lanes.

This PR adds an interface function to the MMAAttr interface to return the scope of the attribute's workload, as a new `IREE::GPU::MMAScope` enum. The data tiled attribute returns `IREE::GPU::MMAScope::Workgroup`, and the normal MMAAttr returns `IREE::GPU::MMAScope:Subgroup`.