### PR TITLE
[Codegen][GPU] Allow odd workgroup sizes when resolving non-warp foralls

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeForall.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeForall.cpp
@@ -182,9 +182,12 @@ void GPUDistributeForallPass::runOnOperation() {
                       std::multiplies<int64_t>());
   int64_t subgroupSize = *maybeSubgroupSize;
 
-  if (flatWorkgroupSize % subgroupSize != 0) {
-    funcOp.emitOpError(
-        "Invalid workgroup size is not divisible by subgroup size.");
+  if (flatWorkgroupSize % subgroupSize != 0 &&
+      llvm::any_of(forallOps, [](scf::ForallOp forall) {
+        return forallOpHasMappingType<gpu::GPUWarpMappingAttr>(forall);
+      })) {
+    funcOp.emitOpError("Invalid workgroup size is not divisible by subgroup "
+                       "size for warp distribution.");
     return signalPassFailure();
   }
 


### PR DESCRIPTION
If there are no scf.forall ops with `#gpu.warp` mappings, then there is no need to verify that the workgroup size is divisible by the subgroup size.