### PR TITLE
[LLVMGPU][ROCm] Add validation on finalized llvm bitcode

### DIFF
--- a/compiler/plugins/target/ROCM/test/CMakeLists.txt
+++ b/compiler/plugins/target/ROCM/test/CMakeLists.txt
@@ -9,6 +9,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "external_function_validation.mlir"
     "smoketest.mlir"
     "target_device_features.mlir"
   TOOLS

--- a/compiler/plugins/target/ROCM/test/external_function_validation.mlir
+++ b/compiler/plugins/target/ROCM/test/external_function_validation.mlir
@@ -1,4 +1,5 @@
-// RUN: iree-opt --iree-hal-post-configuration-transformation-pipeline --verify-diagnostics %s -o -
+// RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-transformation-pipeline{start=executable-configurations})' \
+// RUN:   --verify-diagnostics %s -o -
 
 // The final bitcode validation should error out on any external functions that
 // remain in the final bitcode (post device bitcode linking).

--- a/compiler/plugins/target/ROCM/test/external_function_validation.mlir
+++ b/compiler/plugins/target/ROCM/test/external_function_validation.mlir
@@ -1,23 +1,28 @@
-// RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-transformation-pipeline{start=executable-configurations})' \
-// RUN:   --iree-gpu-test-target=gfx90a --verify-diagnostics %s -o -
+// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(iree-hal-serialize-target-executables{target=rocm}))' \
+// RUN:   --verify-diagnostics %s -o -
 
 // The final bitcode validation should error out on any external functions that
 // remain in the final bitcode (post device bitcode linking).
 
-#target = #iree_gpu.target<arch = "gfx942", features = "",
-                            wgp = <compute = fp16, storage = b16, subgroup = none, dot = none,
-                                  mma = [], subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024],
-                                  max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536,
-                                  max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>
-module {
-  util.global public @__device_0 = #hal.device.target<"hip", {legacy_sync}, [#hal.executable.target<"rocm", "rocm-hsaco-fb",
-     {iree.gpu.target = #target, ukernels = "none"}>]> : !hal.device
-  // expected-error @+1 {{failed to serialize executables}}
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb",
+  {iree.gpu.target = #iree_gpu.target<arch = "gfx942", features = "",
+                                      wgp = <compute = fp16, storage =  b16,
+                                      subgroup =  none, dot =  none, mma = [],
+                                      subgroup_size_choices = [64],
+                                      max_workgroup_sizes = [1024, 1024, 1024],
+                                      max_thread_count_per_workgroup = 1024,
+                                      max_workgroup_memory_bytes = 65536,
+                                      max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>,
+   ukernels = "none"}>
+#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, Indirect>],
+                                        flags = Indirect>
+builtin.module {
   hal.executable public @test {
     // expected-error @+2 {{found an unresolved external function 'external_func' in the final bitcode}}
     // expected-error @+1 {{failed to serialize executable for target backend rocm}}
-    hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb", {iree.gpu.target = #target, ukernels = "none"}>) {
-      hal.executable.export public @test ordinal(0) layout(#hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) {
+    hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
+      hal.executable.export public @test ordinal(0) layout(#pipeline_layout)
+        attributes {subgroup_size = 64 : index, workgroup_size = [128 : index, 2 : index, 1 : index]} {
       ^bb0(%arg0: !hal.device):
         %c128 = arith.constant 128 : index
         %c2 = arith.constant 2 : index
@@ -25,11 +30,10 @@ module {
         hal.return %c128, %c2, %c1 : index, index, index
       }
       builtin.module {
-        func.func private @external_func() -> ()
-
-        func.func @test() attributes {translation_info = #iree_codegen.translation_info<None workgroup_size = [128, 2, 1] subgroup_size = 64>} {
-          func.call @external_func() : () -> ()
-          return
+        llvm.func @external_func() attributes {sym_visibility = "private"}
+        llvm.func @test() {
+          llvm.call @external_func() : () -> ()
+          llvm.return
         }
       }
     }

--- a/compiler/plugins/target/ROCM/test/external_function_validation.mlir
+++ b/compiler/plugins/target/ROCM/test/external_function_validation.mlir
@@ -1,17 +1,23 @@
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-transformation-pipeline{start=executable-configurations})' \
-// RUN:   --verify-diagnostics %s -o -
+// RUN:   --iree-gpu-test-target=gfx90a --verify-diagnostics %s -o -
 
 // The final bitcode validation should error out on any external functions that
 // remain in the final bitcode (post device bitcode linking).
 
-module attributes {stream.affinity.default = #hal.device.affinity<@__device_0>} {
-  util.global private @__device_0 = #hal.device.target<"hip", {legacy_sync}, [#hal.executable.target<"rocm", "rocm-hsaco-fb", {iree.gpu.target = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, mma = [<MFMA_F32_16x16x4_F32>, <MFMA_F32_16x16x16_F16>, <MFMA_F32_32x32x8_F16>, <MFMA_F32_16x16x32_F8E4M3FNUZ>, <MFMA_I32_16x16x32_I8>, <MFMA_I32_32x32x16_I8>], subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>, ukernels = "none"}>]> : !hal.device
+#target = #iree_gpu.target<arch = "gfx942", features = "",
+                            wgp = <compute = fp16, storage = b16, subgroup = none, dot = none,
+                                  mma = [], subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024],
+                                  max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536,
+                                  max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>
+module {
+  util.global public @__device_0 = #hal.device.target<"hip", {legacy_sync}, [#hal.executable.target<"rocm", "rocm-hsaco-fb",
+     {iree.gpu.target = #target, ukernels = "none"}>]> : !hal.device
   // expected-error @+1 {{failed to serialize executables}}
-  hal.executable private @test {
+  hal.executable public @test {
     // expected-error @+2 {{found an unresolved external function 'external_func' in the final bitcode}}
     // expected-error @+1 {{failed to serialize executable for target backend rocm}}
-    hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb", {iree.gpu.target = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, mma = [<MFMA_F32_16x16x4_F32>, <MFMA_F32_16x16x16_F16>, <MFMA_F32_32x32x8_F16>, <MFMA_F32_16x16x32_F8E4M3FNUZ>, <MFMA_I32_16x16x32_I8>, <MFMA_I32_32x32x16_I8>], subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>, ukernels = "none"}>) {
-      hal.executable.export public @test ordinal(0) layout(#hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) {
+    hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb", {iree.gpu.target = #target, ukernels = "none"}>) {
+      hal.executable.export public @test ordinal(0) layout(#hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) {
       ^bb0(%arg0: !hal.device):
         %c128 = arith.constant 128 : index
         %c2 = arith.constant 2 : index
@@ -19,42 +25,13 @@ module attributes {stream.affinity.default = #hal.device.affinity<@__device_0>} 
         hal.return %c128, %c2, %c1 : index, index, index
       }
       builtin.module {
-        func.func private @external_func(vector<1xf16>) -> vector<1xf16>
+        func.func private @external_func() -> ()
 
         func.func @test() attributes {translation_info = #iree_codegen.translation_info<None workgroup_size = [128, 2, 1] subgroup_size = 64>} {
-          %c0 = arith.constant 0 : index
-          %thread_id_x = gpu.thread_id  x
-          %thread_id_y = gpu.thread_id  y
-          %0 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : memref<4096x4096xf16, strided<[4096, 1], offset: ?>>
-          %1 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : memref<4096x4096xf16, strided<[4096, 1], offset: ?>>
-          %2 = vector.load %0[%thread_id_x, %thread_id_y] : memref<4096x4096xf16, strided<[4096, 1], offset: ?>>, vector<1xf16>
-          %3 = func.call @external_func(%2) : (vector<1xf16>) -> vector<1xf16>
-          vector.store %3, %1[%thread_id_x, %thread_id_y] : memref<4096x4096xf16, strided<[4096, 1], offset: ?>>, vector<1xf16>
+          func.call @external_func() : () -> ()
           return
         }
       }
     }
-  }
-  util.func public @isolated_benchmark(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view) -> !hal.buffer_view attributes {iree.abi.stub, iree.reflection = {iree.abi.declaration = "sync func @isolated_benchmark(%input0: tensor<4096x4096xf16>, %input1: tensor<4096x4096xf16>) -> (%output0: tensor<4096x4096xf16>)"}} {
-    %c33554432 = arith.constant 33554432 : index
-    %c0 = arith.constant 0 : index
-    %c4096 = arith.constant 4096 : index
-    %element_type_f16 = hal.element_type<f16> : i32
-    %dense_row_major = hal.encoding_type<dense_row_major> : i32
-    hal.buffer_view.assert<%arg0 : !hal.buffer_view> message("input0") shape([%c4096, %c4096]) type(%element_type_f16) encoding(%dense_row_major)
-    %0 = stream.tensor.import on(#hal.device.affinity<@__device_0>) %arg0 : !hal.buffer_view -> tensor<4096x4096xf16> in !stream.resource<external>{%c33554432}
-    hal.buffer_view.assert<%arg1 : !hal.buffer_view> message("input1") shape([%c4096, %c4096]) type(%element_type_f16) encoding(%dense_row_major)
-    %1 = stream.tensor.import on(#hal.device.affinity<@__device_0>) %arg1 : !hal.buffer_view -> tensor<4096x4096xf16> in !stream.resource<external>{%c33554432}
-    %result, %result_timepoint = stream.resource.alloca uninitialized on(#hal.device.affinity<@__device_0>) : !stream.resource<external>{%c33554432} => !stream.timepoint
-    %2 = stream.cmd.execute on(#hal.device.affinity<@__device_0>) await(%result_timepoint) => with(%0 as %arg2: !stream.resource<external>{%c33554432}, %1 as %arg3: !stream.resource<external>{%c33554432}, %result as %arg4: !stream.resource<external>{%c33554432}) {
-      stream.cmd.dispatch @test::@rocm_hsaco_fb::@test {
-        ro %arg2[%c0 for %c33554432] : !stream.resource<external>{%c33554432},
-        ro %arg3[%c0 for %c33554432] : !stream.resource<external>{%c33554432},
-        wo %arg4[%c0 for %c33554432] : !stream.resource<external>{%c33554432}
-      }
-    } => !stream.timepoint
-    %3 = stream.timepoint.await %2 => %result : !stream.resource<external>{%c33554432}
-    %4 = stream.tensor.export on(#hal.device.affinity<@__device_0>) %3 : tensor<4096x4096xf16> in !stream.resource<external>{%c33554432} -> !hal.buffer_view
-    util.return %4 : !hal.buffer_view
   }
 }

--- a/compiler/plugins/target/ROCM/test/external_function_validation.mlir
+++ b/compiler/plugins/target/ROCM/test/external_function_validation.mlir
@@ -1,0 +1,73 @@
+// RUN: iree-opt --iree-hal-post-configuration-transformation-pipeline --verify-diagnostics %s -o -
+
+// The final bitcode validation should error out on any external functions that
+// remain in the final bitcode (post device bitcode linking).
+
+module attributes {stream.affinity.default = #hal.device.affinity<@__device_0>} {
+  util.global private @__device_0 = #hal.device.target<"hip", {legacy_sync}, [#hal.executable.target<"rocm", "rocm-hsaco-fb", {iree.gpu.target = #iree_gpu.target<arch = "gfx1100", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, mma = [<WMMA_F32_16x16x16_F16>, <WMMA_F16_16x16x16_F16>, <WMMA_I32_16x16x16_I8>], subgroup_size_choices = [32, 64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>, ukernels = "none"}>]> : !hal.device
+  // expected-error @+1 {{failed to serialize executables}}
+  hal.executable private @test_dispatch_0 {
+    // expected-error @+2 {{found an unresolved external function 'external_func' in the final bitcode}}
+    // expected-error @+1 {{failed to serialize executable for target backend rocm}}
+    hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb", {iree.gpu.target = #iree_gpu.target<arch = "gfx1100", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, mma = [<WMMA_F32_16x16x16_F16>, <WMMA_F16_16x16x16_F16>, <WMMA_I32_16x16x16_I8>], subgroup_size_choices = [32, 64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>, ukernels = "none"}>) {
+      hal.executable.export public @test_dispatch_0_elementwise_D_i32 ordinal(0) layout(#hal.pipeline.layout<constants = 2, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) {
+      ^bb0(%arg0: !hal.device, %arg1: index):
+        %x, %y, %z = flow.dispatch.workgroup_count_from_slice %arg1
+        hal.return %x, %y, %z : index, index, index
+      }
+      builtin.module {
+        func.func private @external_func(i32) -> i32
+
+        func.func @test_dispatch_0_elementwise_D_i32() attributes {translation_info = #iree_codegen.translation_info<LLVMGPUVectorize workgroup_size = [64, 1, 1] subgroup_size = 32>} {
+          %c0 = arith.constant 0 : index
+          %c32_i64 = arith.constant 32 : i64
+          %c1_i32 = arith.constant 1 : i32
+          %0 = hal.interface.constant.load layout(<constants = 2, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) ordinal(0) : i32
+          %1 = hal.interface.constant.load layout(<constants = 2, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) ordinal(1) : i32
+          %2 = arith.extui %0 : i32 to i64
+          %3 = arith.extui %1 : i32 to i64
+          %4 = arith.shli %3, %c32_i64 : i64
+          %5 = arith.ori %2, %4 : i64
+          %6 = arith.index_castui %5 : i64 to index
+          %7 = flow.dispatch.workload.ordinal %6, 0 : index
+          %8 = hal.interface.binding.subspan layout(<constants = 2, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !flow.dispatch.tensor<readonly:tensor<?xi32>>{%7}
+          %9 = hal.interface.binding.subspan layout(<constants = 2, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags(Indirect) : !flow.dispatch.tensor<writeonly:tensor<?xi32>>{%7}
+          %10 = flow.dispatch.tensor.load %8, offsets = [0], sizes = [%7], strides = [1] : !flow.dispatch.tensor<readonly:tensor<?xi32>>{%7} -> tensor<?xi32>
+          %11 = tensor.empty(%7) : tensor<?xi32>
+          %12 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%10 : tensor<?xi32>) outs(%11 : tensor<?xi32>) attrs =  {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[64]]>} {
+          ^bb0(%in: i32, %out: i32):
+            %13 = func.call @external_func(%in) : (i32) -> i32
+            linalg.yield %13 : i32
+          } -> tensor<?xi32>
+          flow.dispatch.tensor.store %12, %9, offsets = [0], sizes = [%7], strides = [1] : tensor<?xi32> -> !flow.dispatch.tensor<writeonly:tensor<?xi32>>{%7}
+          return
+        }
+      }
+    }
+  }
+  util.func public @test(%arg0: !hal.buffer_view) -> !hal.buffer_view attributes {iree.abi.stub, iree.reflection = {iree.abi.declaration = "sync func @test(%input0: tensor<?xi32>) -> (%output0: tensor<?xi32>)"}} {
+    %c32_i64 = arith.constant 32 : i64
+    %c4 = arith.constant 4 : index
+    %c0 = arith.constant 0 : index
+    %0 = hal.buffer_view.dim<%arg0 : !hal.buffer_view>[0] : index
+    %element_type_i32 = hal.element_type<i32> : i32
+    %dense_row_major = hal.encoding_type<dense_row_major> : i32
+    hal.buffer_view.assert<%arg0 : !hal.buffer_view> message("input0") shape([%0]) type(%element_type_i32) encoding(%dense_row_major)
+    %1 = arith.muli %0, %c4 : index
+    %2 = stream.tensor.import on(#hal.device.affinity<@__device_0>) %arg0 : !hal.buffer_view -> tensor<?xi32>{%0} in !stream.resource<external>{%1}
+    %result, %result_timepoint = stream.resource.alloca uninitialized on(#hal.device.affinity<@__device_0>) : !stream.resource<external>{%1} => !stream.timepoint
+    %3 = arith.index_castui %0 : index to i64
+    %4 = arith.trunci %3 : i64 to i32
+    %5 = arith.shrui %3, %c32_i64 : i64
+    %6 = arith.trunci %5 : i64 to i32
+    %7 = stream.cmd.execute on(#hal.device.affinity<@__device_0>) await(%result_timepoint) => with(%2 as %arg1: !stream.resource<external>{%1}, %result as %arg2: !stream.resource<external>{%1}) {
+      stream.cmd.dispatch @test_dispatch_0::@rocm_hsaco_fb::@test_dispatch_0_elementwise_D_i32[%0](%4, %6 : i32, i32) {
+        ro %arg1[%c0 for %1] : !stream.resource<external>{%1},
+        wo %arg2[%c0 for %1] : !stream.resource<external>{%1}
+      }
+    } => !stream.timepoint
+    %8 = stream.timepoint.await %7 => %result : !stream.resource<external>{%1}
+    %9 = stream.tensor.export on(#hal.device.affinity<@__device_0>) %8 : tensor<?xi32>{%0} in !stream.resource<external>{%1} -> !hal.buffer_view
+    util.return %9 : !hal.buffer_view
+  }
+}

--- a/compiler/plugins/target/ROCM/test/external_function_validation.mlir
+++ b/compiler/plugins/target/ROCM/test/external_function_validation.mlir
@@ -4,70 +4,56 @@
 // remain in the final bitcode (post device bitcode linking).
 
 module attributes {stream.affinity.default = #hal.device.affinity<@__device_0>} {
-  util.global private @__device_0 = #hal.device.target<"hip", {legacy_sync}, [#hal.executable.target<"rocm", "rocm-hsaco-fb", {iree.gpu.target = #iree_gpu.target<arch = "gfx1100", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, mma = [<WMMA_F32_16x16x16_F16>, <WMMA_F16_16x16x16_F16>, <WMMA_I32_16x16x16_I8>], subgroup_size_choices = [32, 64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>, ukernels = "none"}>]> : !hal.device
+  util.global private @__device_0 = #hal.device.target<"hip", {legacy_sync}, [#hal.executable.target<"rocm", "rocm-hsaco-fb", {iree.gpu.target = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, mma = [<MFMA_F32_16x16x4_F32>, <MFMA_F32_16x16x16_F16>, <MFMA_F32_32x32x8_F16>, <MFMA_F32_16x16x32_F8E4M3FNUZ>, <MFMA_I32_16x16x32_I8>, <MFMA_I32_32x32x16_I8>], subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>, ukernels = "none"}>]> : !hal.device
   // expected-error @+1 {{failed to serialize executables}}
-  hal.executable private @test_dispatch_0 {
+  hal.executable private @test {
     // expected-error @+2 {{found an unresolved external function 'external_func' in the final bitcode}}
     // expected-error @+1 {{failed to serialize executable for target backend rocm}}
-    hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb", {iree.gpu.target = #iree_gpu.target<arch = "gfx1100", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, mma = [<WMMA_F32_16x16x16_F16>, <WMMA_F16_16x16x16_F16>, <WMMA_I32_16x16x16_I8>], subgroup_size_choices = [32, 64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>, ukernels = "none"}>) {
-      hal.executable.export public @test_dispatch_0_elementwise_D_i32 ordinal(0) layout(#hal.pipeline.layout<constants = 2, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) {
-      ^bb0(%arg0: !hal.device, %arg1: index):
-        %x, %y, %z = flow.dispatch.workgroup_count_from_slice %arg1
-        hal.return %x, %y, %z : index, index, index
+    hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb", {iree.gpu.target = #iree_gpu.target<arch = "gfx942", features = "", wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8, subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32, mma = [<MFMA_F32_16x16x4_F32>, <MFMA_F32_16x16x16_F16>, <MFMA_F32_32x32x8_F16>, <MFMA_F32_16x16x32_F8E4M3FNUZ>, <MFMA_I32_16x16x32_I8>, <MFMA_I32_32x32x16_I8>], subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536, max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>, ukernels = "none"}>) {
+      hal.executable.export public @test ordinal(0) layout(#hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) {
+      ^bb0(%arg0: !hal.device):
+        %c128 = arith.constant 128 : index
+        %c2 = arith.constant 2 : index
+        %c1 = arith.constant 1 : index
+        hal.return %c128, %c2, %c1 : index, index, index
       }
       builtin.module {
-        func.func private @external_func(i32) -> i32
+        func.func private @external_func(vector<1xf16>) -> vector<1xf16>
 
-        func.func @test_dispatch_0_elementwise_D_i32() attributes {translation_info = #iree_codegen.translation_info<LLVMGPUVectorize workgroup_size = [64, 1, 1] subgroup_size = 32>} {
+        func.func @test() attributes {translation_info = #iree_codegen.translation_info<None workgroup_size = [128, 2, 1] subgroup_size = 64>} {
           %c0 = arith.constant 0 : index
-          %c32_i64 = arith.constant 32 : i64
-          %c1_i32 = arith.constant 1 : i32
-          %0 = hal.interface.constant.load layout(<constants = 2, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) ordinal(0) : i32
-          %1 = hal.interface.constant.load layout(<constants = 2, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) ordinal(1) : i32
-          %2 = arith.extui %0 : i32 to i64
-          %3 = arith.extui %1 : i32 to i64
-          %4 = arith.shli %3, %c32_i64 : i64
-          %5 = arith.ori %2, %4 : i64
-          %6 = arith.index_castui %5 : i64 to index
-          %7 = flow.dispatch.workload.ordinal %6, 0 : index
-          %8 = hal.interface.binding.subspan layout(<constants = 2, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !flow.dispatch.tensor<readonly:tensor<?xi32>>{%7}
-          %9 = hal.interface.binding.subspan layout(<constants = 2, bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags(Indirect) : !flow.dispatch.tensor<writeonly:tensor<?xi32>>{%7}
-          %10 = flow.dispatch.tensor.load %8, offsets = [0], sizes = [%7], strides = [1] : !flow.dispatch.tensor<readonly:tensor<?xi32>>{%7} -> tensor<?xi32>
-          %11 = tensor.empty(%7) : tensor<?xi32>
-          %12 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%10 : tensor<?xi32>) outs(%11 : tensor<?xi32>) attrs =  {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[64]]>} {
-          ^bb0(%in: i32, %out: i32):
-            %13 = func.call @external_func(%in) : (i32) -> i32
-            linalg.yield %13 : i32
-          } -> tensor<?xi32>
-          flow.dispatch.tensor.store %12, %9, offsets = [0], sizes = [%7], strides = [1] : tensor<?xi32> -> !flow.dispatch.tensor<writeonly:tensor<?xi32>>{%7}
+          %thread_id_x = gpu.thread_id  x
+          %thread_id_y = gpu.thread_id  y
+          %0 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : memref<4096x4096xf16, strided<[4096, 1], offset: ?>>
+          %1 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : memref<4096x4096xf16, strided<[4096, 1], offset: ?>>
+          %2 = vector.load %0[%thread_id_x, %thread_id_y] : memref<4096x4096xf16, strided<[4096, 1], offset: ?>>, vector<1xf16>
+          %3 = func.call @external_func(%2) : (vector<1xf16>) -> vector<1xf16>
+          vector.store %3, %1[%thread_id_x, %thread_id_y] : memref<4096x4096xf16, strided<[4096, 1], offset: ?>>, vector<1xf16>
           return
         }
       }
     }
   }
-  util.func public @test(%arg0: !hal.buffer_view) -> !hal.buffer_view attributes {iree.abi.stub, iree.reflection = {iree.abi.declaration = "sync func @test(%input0: tensor<?xi32>) -> (%output0: tensor<?xi32>)"}} {
-    %c32_i64 = arith.constant 32 : i64
-    %c4 = arith.constant 4 : index
+  util.func public @isolated_benchmark(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view) -> !hal.buffer_view attributes {iree.abi.stub, iree.reflection = {iree.abi.declaration = "sync func @isolated_benchmark(%input0: tensor<4096x4096xf16>, %input1: tensor<4096x4096xf16>) -> (%output0: tensor<4096x4096xf16>)"}} {
+    %c33554432 = arith.constant 33554432 : index
     %c0 = arith.constant 0 : index
-    %0 = hal.buffer_view.dim<%arg0 : !hal.buffer_view>[0] : index
-    %element_type_i32 = hal.element_type<i32> : i32
+    %c4096 = arith.constant 4096 : index
+    %element_type_f16 = hal.element_type<f16> : i32
     %dense_row_major = hal.encoding_type<dense_row_major> : i32
-    hal.buffer_view.assert<%arg0 : !hal.buffer_view> message("input0") shape([%0]) type(%element_type_i32) encoding(%dense_row_major)
-    %1 = arith.muli %0, %c4 : index
-    %2 = stream.tensor.import on(#hal.device.affinity<@__device_0>) %arg0 : !hal.buffer_view -> tensor<?xi32>{%0} in !stream.resource<external>{%1}
-    %result, %result_timepoint = stream.resource.alloca uninitialized on(#hal.device.affinity<@__device_0>) : !stream.resource<external>{%1} => !stream.timepoint
-    %3 = arith.index_castui %0 : index to i64
-    %4 = arith.trunci %3 : i64 to i32
-    %5 = arith.shrui %3, %c32_i64 : i64
-    %6 = arith.trunci %5 : i64 to i32
-    %7 = stream.cmd.execute on(#hal.device.affinity<@__device_0>) await(%result_timepoint) => with(%2 as %arg1: !stream.resource<external>{%1}, %result as %arg2: !stream.resource<external>{%1}) {
-      stream.cmd.dispatch @test_dispatch_0::@rocm_hsaco_fb::@test_dispatch_0_elementwise_D_i32[%0](%4, %6 : i32, i32) {
-        ro %arg1[%c0 for %1] : !stream.resource<external>{%1},
-        wo %arg2[%c0 for %1] : !stream.resource<external>{%1}
+    hal.buffer_view.assert<%arg0 : !hal.buffer_view> message("input0") shape([%c4096, %c4096]) type(%element_type_f16) encoding(%dense_row_major)
+    %0 = stream.tensor.import on(#hal.device.affinity<@__device_0>) %arg0 : !hal.buffer_view -> tensor<4096x4096xf16> in !stream.resource<external>{%c33554432}
+    hal.buffer_view.assert<%arg1 : !hal.buffer_view> message("input1") shape([%c4096, %c4096]) type(%element_type_f16) encoding(%dense_row_major)
+    %1 = stream.tensor.import on(#hal.device.affinity<@__device_0>) %arg1 : !hal.buffer_view -> tensor<4096x4096xf16> in !stream.resource<external>{%c33554432}
+    %result, %result_timepoint = stream.resource.alloca uninitialized on(#hal.device.affinity<@__device_0>) : !stream.resource<external>{%c33554432} => !stream.timepoint
+    %2 = stream.cmd.execute on(#hal.device.affinity<@__device_0>) await(%result_timepoint) => with(%0 as %arg2: !stream.resource<external>{%c33554432}, %1 as %arg3: !stream.resource<external>{%c33554432}, %result as %arg4: !stream.resource<external>{%c33554432}) {
+      stream.cmd.dispatch @test::@rocm_hsaco_fb::@test {
+        ro %arg2[%c0 for %c33554432] : !stream.resource<external>{%c33554432},
+        ro %arg3[%c0 for %c33554432] : !stream.resource<external>{%c33554432},
+        wo %arg4[%c0 for %c33554432] : !stream.resource<external>{%c33554432}
       }
     } => !stream.timepoint
-    %8 = stream.timepoint.await %7 => %result : !stream.resource<external>{%1}
-    %9 = stream.tensor.export on(#hal.device.affinity<@__device_0>) %8 : tensor<?xi32>{%0} in !stream.resource<external>{%1} -> !hal.buffer_view
-    util.return %9 : !hal.buffer_view
+    %3 = stream.timepoint.await %2 => %result : !stream.resource<external>{%c33554432}
+    %4 = stream.tensor.export on(#hal.device.affinity<@__device_0>) %3 : tensor<4096x4096xf16> in !stream.resource<external>{%c33554432} -> !hal.buffer_view
+    util.return %4 : !hal.buffer_view
   }
 }

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
@@ -629,6 +629,16 @@ void registerHALPasses() {
                                       transformOptions, PipelineHooks{},
                                       PipelinePhase::Start, PipelinePhase::End);
       });
+  PassPipelineRegistration<TransformOptions>(
+      "iree-hal-post-configuration-transformation-pipeline",
+      "Runs the IREE HAL conversion/lowering pipeline starting from executable "
+      "configurations.",
+      [](OpPassManager &passManager, const TransformOptions &transformOptions) {
+        buildHALTransformPassPipeline(
+            passManager, TargetRegistry::getGlobal(),
+            TargetOptions::FromFlags::get(), transformOptions, PipelineHooks{},
+            PipelinePhase::ExecutableConfigurations, PipelinePhase::End);
+      });
 }
 
 } // namespace mlir::iree_compiler::IREE::HAL

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
@@ -14,6 +14,7 @@
 #include "iree/compiler/Dialect/Util/Transforms/Passes.h"
 #include "iree/compiler/Utils/OptionUtils.h"
 #include "iree/compiler/Utils/PassUtils.h"
+#include "llvm/Support/CommandLine.h"
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
 #include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
 #include "mlir/Dialect/Affine/Passes.h"
@@ -39,6 +40,36 @@ struct TransformOptions : public PassPipelineOptions<TransformOptions> {
       llvm::cl::desc("Whether to link hal.executable ops together."),
       llvm::cl::init(true),
   };
+  Option<PipelinePhase> start{
+      *this,
+      "start",
+      llvm::cl::desc("Start compilation from the specified phase."),
+      llvm::cl::values(
+          clEnumValN(PipelinePhase::Start, "start",
+                     "Start from pipeline entry point"),
+          clEnumValN(PipelinePhase::ExecutableSources, "executable-sources",
+                     "Start from executable sources"),
+          clEnumValN(PipelinePhase::ExecutableConfigurations,
+                     "executable-configurations",
+                     "Start from executable configurations"),
+          clEnumValN(PipelinePhase::ExecutableTargets, "executable-targets",
+                     "Start from executable targets")),
+      llvm::cl::init(PipelinePhase::Start),
+  };
+  Option<PipelinePhase> stop{
+      *this, "stop",
+      llvm::cl::desc("Start compilation after the specified phase."),
+      llvm::cl::values(
+          clEnumValN(PipelinePhase::ExecutableSources, "executable-sources",
+                     "Stop after executable sources"),
+          clEnumValN(PipelinePhase::ExecutableConfigurations,
+                     "executable-configurations",
+                     "Stop after executable configurations"),
+          clEnumValN(PipelinePhase::ExecutableTargets, "executable-targets",
+                     "Stop after executable targets"),
+          clEnumValN(PipelinePhase::End, "end",
+                     "Run until the end of the pipeline")),
+      llvm::cl::init(PipelinePhase::End)};
 };
 
 static llvm::cl::opt<bool> clMemoization{
@@ -291,9 +322,9 @@ void buildHALTransformPassPipeline(OpPassManager &passManager,
                                    const TargetRegistry &targetRegistry,
                                    const TargetOptions &targetOptions,
                                    const TransformOptions &transformOptions,
-                                   PipelineHooks hooks,
-                                   PipelinePhase compileFrom,
-                                   PipelinePhase compileTo) {
+                                   PipelineHooks hooks) {
+  PipelinePhase compileFrom = transformOptions.start;
+  PipelinePhase compileTo = transformOptions.stop;
   //----------------------------------------------------------------------------
   // Device assignment and interface materialization
   //----------------------------------------------------------------------------
@@ -572,9 +603,10 @@ void buildHALTransformPassPipeline(OpPassManager &passManager,
                                    PipelinePhase compileFrom,
                                    PipelinePhase compileTo) {
   TransformOptions transformOptions;
+  transformOptions.start = compileFrom;
+  transformOptions.stop = compileTo;
   buildHALTransformPassPipeline(passManager, targetRegistry, targetOptions,
-                                transformOptions, hooks, compileFrom,
-                                compileTo);
+                                transformOptions, hooks);
 }
 
 //===----------------------------------------------------------------------===//
@@ -622,22 +654,11 @@ void registerHALPasses() {
                              });
   PassPipelineRegistration<TransformOptions>(
       "iree-hal-transformation-pipeline",
-      "Runs the full IREE HAL conversion/lowering pipeline.",
+      "Runs the IREE HAL conversion/lowering pipeline.",
       [](OpPassManager &passManager, const TransformOptions &transformOptions) {
         buildHALTransformPassPipeline(passManager, TargetRegistry::getGlobal(),
                                       TargetOptions::FromFlags::get(),
-                                      transformOptions, PipelineHooks{},
-                                      PipelinePhase::Start, PipelinePhase::End);
-      });
-  PassPipelineRegistration<TransformOptions>(
-      "iree-hal-post-configuration-transformation-pipeline",
-      "Runs the IREE HAL conversion/lowering pipeline starting from executable "
-      "configurations.",
-      [](OpPassManager &passManager, const TransformOptions &transformOptions) {
-        buildHALTransformPassPipeline(
-            passManager, TargetRegistry::getGlobal(),
-            TargetOptions::FromFlags::get(), transformOptions, PipelineHooks{},
-            PipelinePhase::ExecutableConfigurations, PipelinePhase::End);
+                                      transformOptions, PipelineHooks{});
       });
 }
 


### PR DESCRIPTION
Check that there are no unresolved external functions that will otherwise compile fine but be rejected by the driver.

The validation happens on the llvm bitcode after bitcode linking, when there is no chance for anything to resolve these external functions.

This is to guard against future issues similar to
https://github.com/iree-org/iree/issues/18534 that are close to undebuggable for end users.