### PR TITLE
IREE Custom tilable op (`iree_linalg_ext.custom_op`).

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/BUILD.bazel
@@ -28,6 +28,7 @@ iree_td_library(
         "@llvm-project//mlir:CallInterfacesTdFiles",
         "@llvm-project//mlir:ControlFlowInterfacesTdFiles",
         "@llvm-project//mlir:DestinationStyleOpInterfaceTdFiles",
+        "@llvm-project//mlir:DialectUtilsTdFiles",
         "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
         "@llvm-project//mlir:LinalgOpsTdFiles",
         "@llvm-project//mlir:OpBaseTdFiles",
@@ -45,7 +46,6 @@ iree_compiler_cc_library(
         "LinalgExtAttrs.cpp.inc",
         "LinalgExtDialect.cpp",
         "LinalgExtDialect.cpp.inc",
-        "LinalgExtEnums.cpp.inc",
         "LinalgExtInterfaces.cpp",
         "LinalgExtInterfaces.cpp.inc",
         "LinalgExtOps.cpp",
@@ -56,7 +56,6 @@ iree_compiler_cc_library(
         "LinalgExtAttrs.h.inc",
         "LinalgExtDialect.h",
         "LinalgExtDialect.h.inc",
-        "LinalgExtEnums.h.inc",
         "LinalgExtInterfaces.h",
         "LinalgExtInterfaces.h.inc",
         "LinalgExtOps.h",
@@ -64,7 +63,6 @@ iree_compiler_cc_library(
         "LinalgExtTypes.h.inc",
     ],
     deps = [
-        ":LinalgExtEnumsGen",
         ":LinalgExtInterfacesIncGen",
         ":LinalgExtOpsIncGen",
         ":LinalgExtTypesGen",
@@ -96,23 +94,6 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:TilingInterface",
         "@llvm-project//mlir:ViewLikeInterface",
     ],
-)
-
-iree_gentbl_cc_library(
-    name = "LinalgExtEnumsGen",
-    tbl_outs = [
-        (
-            ["--gen-enum-decls"],
-            "LinalgExtEnums.h.inc",
-        ),
-        (
-            ["--gen-enum-defs"],
-            "LinalgExtEnums.cpp.inc",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "LinalgExtBase.td",
-    deps = [":td_files"],
 )
 
 iree_gentbl_cc_library(

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/CMakeLists.txt
@@ -17,7 +17,6 @@ iree_cc_library(
     "LinalgExtAttrs.h.inc"
     "LinalgExtDialect.h"
     "LinalgExtDialect.h.inc"
-    "LinalgExtEnums.h.inc"
     "LinalgExtInterfaces.h"
     "LinalgExtInterfaces.h.inc"
     "LinalgExtOps.h"
@@ -27,14 +26,12 @@ iree_cc_library(
     "LinalgExtAttrs.cpp.inc"
     "LinalgExtDialect.cpp"
     "LinalgExtDialect.cpp.inc"
-    "LinalgExtEnums.cpp.inc"
     "LinalgExtInterfaces.cpp"
     "LinalgExtInterfaces.cpp.inc"
     "LinalgExtOps.cpp"
     "LinalgExtOps.cpp.inc"
     "LinalgExtTypes.cpp.inc"
   DEPS
-    ::LinalgExtEnumsGen
     ::LinalgExtInterfacesIncGen
     ::LinalgExtOpsIncGen
     ::LinalgExtTypesGen
@@ -64,16 +61,6 @@ iree_cc_library(
     MLIRViewLikeInterface
     iree::compiler::Dialect::LinalgExt::Utils
   PUBLIC
-)
-
-iree_tablegen_library(
-  NAME
-    LinalgExtEnumsGen
-  TD_FILE
-    "LinalgExtBase.td"
-  OUTS
-    --gen-enum-decls LinalgExtEnums.h.inc
-    --gen-enum-defs LinalgExtEnums.cpp.inc
 )
 
 iree_tablegen_library(

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtBase.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtBase.td
@@ -7,6 +7,7 @@
 #ifndef IREE_DIALECT_LINALGEXT_BASE
 #define IREE_DIALECT_LINALGEXT_BASE
 
+include "mlir/Dialect/Utils/StructuredOpsUtils.td"
 include "mlir/IR/OpBase.td"
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/EnumAttr.td"
@@ -25,6 +26,7 @@ def IREELinalgExt_Dialect : Dialect {
     A dialect designed for experimenting with non-structured operations that
     cannot be represented efficiently/directly by the Linalg dialect.
   }];
+  let useDefaultAttributePrinterParser = 1;
 }
 
 //===----------------------------------------------------------------------===//
@@ -37,5 +39,24 @@ class RankedTensorOrMemRefOf<list<Type> allowedTypes> :
   "ranked tensor or memref", "::mlir::ShapedType">;
 
 def AnyRankedTensorOrMemRefType : RankedTensorOrMemRefOf<[AnyType]>;
+
+class RankedTensorOrScalarType<list<Type> allowedTypes> :
+  AnyTypeOf<[RankedTensorOf<allowedTypes>, AnyTypeOf<allowedTypes>]>;
+
+def AnyRankedTensorOrScalarType :
+  RankedTensorOrScalarType<[AnySignlessIntegerOrIndex, AnyFloat]>;
+
+//===----------------------------------------------------------------------===//
+// Enum definitions
+//===----------------------------------------------------------------------===//
+
+def IREELinalgExt_IteratorTypeEnum : EnumAttr<IREELinalgExt_Dialect,
+    IteratorType, "iterator_type"> {
+  let assemblyFormat = "`<` $value `>`";
+}
+
+def IREELinalgExt_IteratorTypeArrayAttr :
+    TypedArrayAttrBase<IREELinalgExt_IteratorTypeEnum,
+    "LinalgExt iterator type">;
 
 #endif // IREE_DIALECT_LINALGEXT_BASE

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.cpp
@@ -26,12 +26,11 @@
 using namespace mlir;
 using namespace mlir::iree_compiler::IREE::LinalgExt;
 
-#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtEnums.cpp.inc" // IWYU pragma: keep
-
 #define GET_ATTRDEF_CLASSES
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtAttrs.cpp.inc" // IWYU pragma: keep
 
 // Used to control inlining behavior.
+namespace {
 struct IREELinalgExtInlinerInterface : public DialectInlinerInterface {
   using DialectInlinerInterface::DialectInlinerInterface;
 
@@ -105,7 +104,6 @@ public:
   }
 };
 
-namespace {
 struct SoftmaxFusionOpInterfaceAdapter
     : public LinalgFusionOpInterface::ExternalModel<
           SoftmaxFusionOpInterfaceAdapter, linalg::SoftmaxOp> {
@@ -148,6 +146,10 @@ public:
 };
 } // namespace
 
+struct IREELinalgExtDialectOpAsmInterface : public OpAsmDialectInterface {
+  using OpAsmDialectInterface::OpAsmDialectInterface;
+};
+
 template <typename... Args>
 static void registerOpsWithLinalgExtOpInterface(mlir::MLIRContext *context) {
   (Args::template attachInterface<LinalgFusionOpInterfaceAdapter<Args>>(
@@ -172,6 +174,7 @@ void IREELinalgExtDialect::initialize() {
 
   addInterfaces<IREELinalgExtInlinerInterface>();
 
+  addInterfaces<IREELinalgExtDialectOpAsmInterface>();
   addAttributes<
 #define GET_ATTRDEF_LIST
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtAttrs.cpp.inc"

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h
@@ -21,8 +21,6 @@
 
 // clang-format off
 
-#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtEnums.h.inc" // IWYU pragma: export
-
 #define GET_ATTRDEF_CLASSES
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtAttrs.h.inc" // IWYU pragma: export
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -1570,4 +1570,100 @@ def IREELinalgExt_WinogradOutputTransformOp : IREELinalgExt_Op<"winograd.output_
 
 } // OpGroupWinogradOps
 
+//===---------------------------------------------------------------------===//
+// Custom tilable op
+//===---------------------------------------------------------------------===//
+
+def IREELinalgExt_CustomOp : IREELinalgExt_Op<"custom_op"> {
+  let summary = "Custom operation for compiling with IREE";
+  let description = [{
+    This operation is meant to allow computation sequences that are fused at
+    tile level prescriptively. This is to account for cases where such fusion
+    cannot/is not yet discovered appropriately.
+
+    The operation implements all the interfaces needed to be able to
+    1. Compile e2e using IREE
+    2. Still be able to fuse with other operations that the compiler can
+       figure out automatically.
+
+    Similar to how `LinalgOp`s represent a perfectly nested loop computation
+    with
+    - `indexing_maps` representing how the `ins`/`outs` are accessed
+    - `region` representing the scalar computation performed
+    - `iterator_types` representing the dependence along each iteration space
+      dimension
+    this operation represent a tiled computation with perfectly nested
+    inter-tile loop nest.
+    - `indexing_maps` represent what slices slices of the `ins`/`outs` are
+      needed for each iteration of the tiled computation.
+    - `region` represents the tiled computation performed using these slices
+    - `iterator_types` represents the dependence between tiles along each
+      iteration space.
+
+    Some modifications required to handle the tile-level semantics are
+    - Some dimensions of operands might not be accessed by dimensions of the
+      inter-tile iteration space. This means that along these dimensions the
+      slice size matches the dimension size. This access pattern of operands
+      is captured in the respective indexing map using a `symbol` to represent
+      that the entire dimension needs to be sliced.
+    - The basic block arguments of the region represent the slice of the
+      operand. These are either scalar types (if the corresponding operand is a
+      scalar), or a `tensor` type with dynamic shapes (if the corresponding
+      operand is a `tensor` type).
+
+    For example, one could represent a prescriptively fused matmul computation
+    as follows
+
+    ```
+    %0:2 = iree_linalg_ext.custom_op {
+        indexing_maps = [affine_map<(d0, d1)[s0, s1] -> (d0, s0)>,
+                         affine_map<(d0, d1)[s0, s1] -> (s0, s1)>,
+                         affine_map<(d0, d1)[s0, s1] -> (s1, d1)>,
+                         affine_map<(d0, d1)[s0, s1] -> (d0, s1)>,
+                         affine_map<(d0, d1)[s0, s1] -> (d0, d1)],
+        iterator_types = ["parallel", "parallel"]}
+        ins(%lhs1, %rhs1, %rhs2
+            : tensor<1000000x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>)
+        outs(%outs1, %outs2 : tensor<1000000x?xf32>, tensor<1000000x?xf32>) {
+      ^bb0(%t0 : tensor<?x?xf32>, %t1 : tensor<?x?xf32>, %t2 : tensor<?x?xf32>,
+           %t3 : tensor<?x?xf32>, %t4 : tensor<?x?xf32>) :
+        %0 = linalg.matmul ins(%t0, %t1 : tensor<?x?xf32>, tensor<?x?xf32>)
+            outs(%t3 : tensor<?x?xf32>) -> tensor<?x?xf32>
+        %1 = linalg.matmul ins(%0, %t2 : tensor<?x?xf32>, tensor<?x?xf32>)
+            outs(%t4 : tensor<?x?xf32>) -> tensor<?x?xf32>
+        iree_linalg_ext.yield %0, %1 : tensor<?x?xf32>, tensor<?x?xf32>
+    } -> tensor<1000000x?xf32>, tensor<x?xf32>
+    ```
+  }];
+  let arguments = (ins
+    Variadic<AnyRankedTensorOrScalarType>:$inputs,
+    Variadic<AnyRankedTensor>:$outputs,
+    AffineMapArrayAttr:$indexing_maps,
+    IREELinalgExt_IteratorTypeArrayAttr:$iterator_types);
+  let results = (outs Variadic<AnyRankedTensor>:$results);
+  let regions = (region SizedRegion<1>:$region);
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    `{` `indexing_maps` `=` $indexing_maps `,`
+    `iterator_types` `=` $iterator_types `}`
+    (`ins` `(` $inputs^ `:` type($inputs) `)`)?
+    (`outs` `(` $outputs^ `:` type($outputs) `)`)?
+    $region
+    attr-dict (`->` type($results)^)?
+  }];
+
+  let extraClassDeclaration =[{
+    // Helper accessor methods.
+    unsigned getNumLoops();
+    int64_t getRank(Value);
+
+    // DestinationStyleOpInterface methods
+    MutableOperandRange getDpsInitsMutable() {
+      return getOutputsMutable();
+    }
+  }];
+}
+
 #endif  // IREE_DIALECT_LINALGEXT_OPS

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
@@ -1207,3 +1207,180 @@ func.func @cross_attention_transposev_dyn(%query: tensor<?x?x?xf32>, %key: tenso
 // CHECK-SAME:     tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
 // CHECK:        return %[[D1]] : tensor<?x?x?xf32>
 // CHECK:      }
+
+// -----
+
+func.func @custom_op_default(%arg0 : tensor<?xf32>, %arg1 : tensor<?xf32>) -> tensor<?xf32> {
+  %0 = iree_linalg_ext.custom_op {
+      indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+      iterator_types = [#iree_linalg_ext.iterator_type<parallel>]}
+      ins(%arg0 : tensor<?xf32>) outs(%arg1 : tensor<?xf32>) {
+    ^bb0(%b0 : tensor<?xf32>, %b1 : tensor<?xf32>):
+      iree_linalg_ext.yield %b0 : tensor<?xf32>
+  } -> tensor<?xf32>
+  return %0 : tensor<?xf32>
+}
+//       CHECK: #[[MAP:.+]] = affine_map<(d0) -> (d0)>
+//       CHECK: func @custom_op_default(
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?xf32>
+//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?xf32>
+//       CHECK:   %[[RESULT:.+]] = iree_linalg_ext.custom_op
+//  CHECK-SAME:       indexing_maps = [#[[MAP]], #[[MAP]]]
+//  CHECK-SAME:       iterator_types = [#iree_linalg_ext.iterator_type<parallel>]
+//  CHECK-SAME:       ins(%[[ARG0]] : tensor<?xf32>) outs(%[[ARG1]] : tensor<?xf32>)
+//  CHECK-NEXT:     ^bb0(%[[B0:[a-zA-Z0-9]+]]: tensor<?xf32>, %[[B1:[a-zA-Z0-9]+]]: tensor<?xf32>)
+//  CHECK-NEXT:       iree_linalg_ext.yield %[[B0]]
+//       CHECK:   return %[[RESULT]]
+
+// -----
+
+func.func @custom_op_scalar_arg(%arg0 : tensor<?xf32>, %arg1 : f32, %arg2 : tensor<?xf32>, %arg3 : index) -> tensor<?xf32> {
+  %0 = iree_linalg_ext.custom_op {
+      indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> ()>, affine_map<(d0) -> (d0)>],
+      iterator_types = [#iree_linalg_ext.iterator_type<parallel>]}
+      ins(%arg0, %arg1 : tensor<?xf32>, f32) outs(%arg2 : tensor<?xf32>) {
+    ^bb0(%b0 : tensor<?xf32>, %b1 : f32, %b2 : tensor<?xf32>):
+      %1 = tensor.insert %b1 into %b0[%arg3] : tensor<?xf32>
+      iree_linalg_ext.yield %1 : tensor<?xf32>
+  } -> tensor<?xf32>
+  return %0 : tensor<?xf32>
+}
+//       CHECK: #[[MAP:.+]] = affine_map<(d0) -> ()>
+//       CHECK: func @custom_op_scalar_arg(
+//  CHECK-SAME:     %[[SCALAR_ARG:[a-zA-Z0-9]+]]: f32
+//       CHECK:   iree_linalg_ext.custom_op
+//  CHECK-SAME:       indexing_maps = [#{{.+}}, #[[MAP]], #{{.+}}]
+//  CHECK-SAME:       ins(%{{.+}}, %[[SCALAR_ARG]] : tensor<?xf32>, f32)
+//  CHECK-NEXT:     %[[B1:.+]]: f32
+
+// -----
+
+func.func @custom_op_empty_affine_map(%arg0 : tensor<?xf32>, %arg1 : tensor<?x?xf32>, %arg2 : tensor<?xf32>, %arg3 : index) -> tensor<?xf32> {
+  %0 = iree_linalg_ext.custom_op {
+      indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<() -> ()>, affine_map<(d0) -> (d0)>],
+      iterator_types = [#iree_linalg_ext.iterator_type<parallel>]}
+      ins(%arg0, %arg1 : tensor<?xf32>, tensor<?x?xf32>) outs(%arg2 : tensor<?xf32>) {
+    ^bb0(%b0 : tensor<?xf32>, %b1 : tensor<?x?xf32>, %b2 : tensor<?xf32>):
+      iree_linalg_ext.yield %b0 : tensor<?xf32>
+  } -> tensor<?xf32>
+  return %0 : tensor<?xf32>
+}
+//       CHECK: #[[MAP:.+]] = affine_map<() -> ()>
+//       CHECK: func @custom_op_empty_affine_map(
+//       CHECK:   iree_linalg_ext.custom_op
+//  CHECK-SAME:       indexing_maps = [#{{.+}}, #[[MAP]], #{{.+}}]
+
+// -----
+
+func.func @custom_op_static_args(%arg0 : tensor<10xf32>, %arg1 : tensor<10xf32>) -> tensor<10xf32> {
+  %0 = iree_linalg_ext.custom_op {
+      indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+      iterator_types = [#iree_linalg_ext.iterator_type<parallel>]}
+      ins(%arg0 : tensor<10xf32>) outs(%arg1 : tensor<10xf32>) {
+    ^bb0(%b0 : tensor<?xf32>, %b1 : tensor<?xf32>):
+      iree_linalg_ext.yield %b0 : tensor<?xf32>
+  } -> tensor<10xf32>
+  return %0 : tensor<10xf32>
+}
+//       CHECK: #[[MAP:.+]] = affine_map<(d0) -> (d0)>
+//       CHECK: func @custom_op_static_args(
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<10xf32>
+//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<10xf32>
+//       CHECK:   iree_linalg_ext.custom_op
+//  CHECK-SAME:     ins(%[[ARG0]] : tensor<10xf32>) outs(%[[ARG1]] : tensor<10xf32>)
+//  CHECK-NEXT:     ^bb0(%[[B0:[a-zA-Z0-9]+]]: tensor<?xf32>, %[[B1:[a-zA-Z0-9]+]]: tensor<?xf32>)
+
+// -----
+
+func.func @custom_op_reduction(%arg0 : tensor<?x?xf32>, %arg1 : f32,
+    %arg2 : tensor<?xf32>) -> tensor<?xf32> {
+  %0 = iree_linalg_ext.custom_op {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                       affine_map<(d0, d1) -> ()>,
+                       affine_map<(d0, d1) -> (d0)>],
+      iterator_types = [#iree_linalg_ext.iterator_type<parallel>,
+                        #iree_linalg_ext.iterator_type<reduction>]}
+      ins(%arg0, %arg1 : tensor<?x?xf32>, f32) outs(%arg2 : tensor<?xf32>) {
+    ^bb0(%b0 : tensor<?x?xf32>, %b1 : f32, %b2 : tensor<?xf32>):
+      %1 = linalg.generic {
+          indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                           affine_map<(d0, d1) -> ()>,
+                           affine_map<(d0, d1) -> (d0)>],
+          iterator_types = ["parallel", "reduction"]}
+          ins(%b0, %b1 : tensor<?x?xf32>, f32)
+          outs(%b2 : tensor<?xf32>) {
+        ^bb0(%b00 : f32, %b01 : f32, %b02 : f32):
+          %2 = arith.addf %b00, %b01 : f32
+          linalg.yield %2 : f32
+      } -> tensor<?xf32>
+      iree_linalg_ext.yield %1 : tensor<?xf32>
+  } -> tensor<?xf32>
+  return %0 : tensor<?xf32>
+}
+//       CHECK: func @custom_op_reduction(
+//       CHECK:   iree_linalg_ext.custom_op
+//  CHECK-SAME:     iterator_types = [#iree_linalg_ext.iterator_type<parallel>, #iree_linalg_ext.iterator_type<reduction>]
+//  CHECK-NEXT:   ^bb0
+//       CHECK:     %[[GENERIC:.+]] = linalg.generic
+//       CHECK:     iree_linalg_ext.yield %[[GENERIC]]
+
+// -----
+
+func.func @custom_op_multiple_results(%arg0 : tensor<?xf32>, %arg1 : tensor<?xf32>)
+    -> (tensor<?xf32>, tensor<?xf32>) {
+  %0:2 = iree_linalg_ext.custom_op {
+      indexing_maps = [affine_map<(d0) -> (d0)>,
+                       affine_map<(d0) -> (d0)>,
+                       affine_map<(d0) -> (d0)>],
+      iterator_types = [#iree_linalg_ext.iterator_type<parallel>]}
+      ins(%arg0 : tensor<?xf32>) outs(%arg1, %arg1 : tensor<?xf32>, tensor<?xf32>) {
+    ^bb0(%b0 : tensor<?xf32>, %b1 : tensor<?xf32>, %b2 : tensor<?xf32>):
+      iree_linalg_ext.yield %b0, %b0 : tensor<?xf32>, tensor<?xf32>
+  } -> tensor<?xf32>, tensor<?xf32>
+  return %0#0, %0#1 : tensor<?xf32>, tensor<?xf32>
+}
+//       CHECK: #[[MAP:.+]] = affine_map<(d0) -> (d0)>
+//       CHECK: func @custom_op_multiple_results(
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?xf32>
+//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?xf32>
+//       CHECK:   %[[RESULT:.+]]:2 = iree_linalg_ext.custom_op
+//  CHECK-SAME:       outs(%[[ARG1]], %[[ARG1]] : tensor<?xf32>, tensor<?xf32>)
+//  CHECK-NEXT:     ^bb0(%[[B0:[a-zA-Z0-9]+]]: tensor<?xf32>, %[[B1:[a-zA-Z0-9]+]]: tensor<?xf32>, %[[B2:[a-zA-Z0-9]+]]: tensor<?xf32>)
+//  CHECK-NEXT:       iree_linalg_ext.yield %[[B0]], %[[B0]]
+//       CHECK:   return %[[RESULT]]#0, %[[RESULT]]#1
+
+// -----
+
+func.func @custom_op_symbolic_dims(%lhs1 : tensor<1000000x?xf32>,
+    %rhs1 : tensor<?x?xf32>, %rhs2 : tensor<?x?xf32>,
+    %outs1 : tensor<1000000x?xf32>, %outs2 : tensor<1000000x?xf32>)
+    -> (tensor<1000000x?xf32>, tensor<1000000x?xf32>) {
+  %0:2 = iree_linalg_ext.custom_op {
+        indexing_maps = [affine_map<(d0, d1)[s0, s1] -> (d0, s0)>,
+                         affine_map<(d0, d1)[s0, s1] -> (s0, s1)>,
+                         affine_map<(d0, d1)[s0, s1] -> (s1, d1)>,
+                         affine_map<(d0, d1)[s0, s1] -> (d0, s1)>,
+                         affine_map<(d0, d1)[s0, s1] -> (d0, d1)>],
+        iterator_types = [#iree_linalg_ext.iterator_type<parallel>,
+                          #iree_linalg_ext.iterator_type<parallel>]}
+        ins(%lhs1, %rhs1, %rhs2
+            : tensor<1000000x?xf32>, tensor<?x?xf32>, tensor<?x?xf32>)
+        outs(%outs1, %outs2 : tensor<1000000x?xf32>, tensor<1000000x?xf32>) {
+      ^bb0(%t0 : tensor<?x?xf32>, %t1 : tensor<?x?xf32>, %t2 : tensor<?x?xf32>,
+           %t3 : tensor<?x?xf32>, %t4 : tensor<?x?xf32>) :
+        %0 = linalg.matmul ins(%t0, %t1 : tensor<?x?xf32>, tensor<?x?xf32>)
+            outs(%t3 : tensor<?x?xf32>) -> tensor<?x?xf32>
+        %1 = linalg.matmul ins(%0, %t2 : tensor<?x?xf32>, tensor<?x?xf32>)
+            outs(%t4 : tensor<?x?xf32>) -> tensor<?x?xf32>
+        iree_linalg_ext.yield %0, %1 : tensor<?x?xf32>, tensor<?x?xf32>
+    } -> tensor<1000000x?xf32>, tensor<1000000x?xf32>
+  return %0#0, %0#1 : tensor<1000000x?xf32>, tensor<1000000x?xf32>
+}
+//  CHECK-DAG: #[[MAP:.+]] = affine_map<(d0, d1)[s0, s1] -> (d0, s0)>
+//  CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1)[s0, s1] -> (s0, s1)>
+//  CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1)[s0, s1] -> (s1, d1)>
+//  CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0, d1)[s0, s1] -> (d0, s1)>
+//  CHECK-DAG: #[[MAP4:.+]] = affine_map<(d0, d1)[s0, s1] -> (d0, d1)>
+//      CHECK: func @custom_op_symbolic_dims
+//      CHECK:   iree_linalg_ext.custom_op
+// CHECK-SAME:       indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]], #[[MAP3]], #[[MAP4]]]


### PR DESCRIPTION
This operation is meant to allow users/front ends to specify computations that can be fused at a tile granularity. IREE by default fuses certain operations (like linalg/linalg_ext ops) at tile granularity, but there might be certain sequences that IREE cannot/is not able to fuse. Previously such custom fusions could only be implemented by using a "black-box" approach where it would by-pass the entire compilation stack and either inject a manually generated binary or use a transform dialect script that implements a custom lowering sequence.

This operation allows front ends/users to specify such a fusions within the region of the operation. The `indexing_maps` and `iterator_types` capture all the information necessary for IREE to distribute these operations to tile/distribute this operation, as well as fuse with other operations (like elementwise operations).

The operation is meant to implement all interfaces necessary to be able to compiled/executed with IREE.