### PR TITLE
Fix experimental/web/ samples after recent changes.

### DIFF
--- a/experimental/web/sample_dynamic/CMakeLists.txt
+++ b/experimental/web/sample_dynamic/CMakeLists.txt
@@ -37,7 +37,7 @@ target_link_libraries(${_NAME}
 
 target_link_options(${_NAME} PRIVATE
   # https://emscripten.org/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.html#interacting-with-code-ccall-cwrap
-  "-sEXPORTED_FUNCTIONS=['_setup_sample', '_cleanup_sample', '_load_program', '_inspect_program', '_unload_program', '_call_function', '_malloc']"
+  "-sEXPORTED_FUNCTIONS=['_setup_sample', '_cleanup_sample', '_load_program', '_inspect_program', '_unload_program', '_call_function', '_malloc', '_free']"
   "-sEXPORTED_RUNTIME_METHODS=['ccall','cwrap','UTF8ToString']"
   #
   "-sASSERTIONS=1"

--- a/experimental/web/sample_dynamic/device_sync.c
+++ b/experimental/web/sample_dynamic/device_sync.c
@@ -34,7 +34,7 @@ iree_status_t create_device_with_loaders(iree_allocator_t host_allocator,
         &loaders[loader_count++]);
   }
 
-  iree_string_view_t identifier = iree_make_cstring_view("sync");
+  iree_string_view_t identifier = iree_make_cstring_view("local-sync");
   iree_hal_allocator_t* device_allocator = NULL;
   if (iree_status_is_ok(status)) {
     status = iree_hal_allocator_create_heap(identifier, host_allocator,

--- a/experimental/web/sample_static/device_sync.c
+++ b/experimental/web/sample_static/device_sync.c
@@ -23,7 +23,7 @@ iree_status_t create_device_with_static_loader(iree_allocator_t host_allocator,
       iree_hal_executable_import_provider_null(), host_allocator,
       &library_loader);
 
-  iree_string_view_t identifier = iree_make_cstring_view("sync");
+  iree_string_view_t identifier = iree_make_cstring_view("local-sync");
   iree_hal_allocator_t* device_allocator = NULL;
   if (iree_status_is_ok(status)) {
     status = iree_hal_allocator_create_heap(identifier, host_allocator,


### PR DESCRIPTION
Tested the WebAssembly static and dynamic samples locally. Both still work today with these changes. The WebGPU sample has some build errors (needs to be updated after HAL command buffer bindings refactoring).