### PR TITLE
Migrate ci_linux_arm64_clang to new dockerfile.

### DIFF
--- a/.github/workflows/ci_linux_arm64_clang.yml
+++ b/.github/workflows/ci_linux_arm64_clang.yml
@@ -7,6 +7,9 @@
 name: CI - Linux arm64 clang
 
 on:
+  pull_request:
+    paths:
+      - ".github/workflows/ci_linux_arm64_clang.yml"
   schedule:
     # Weekday mornings at 09:15 UTC = 01:15 PST (UTC - 8).
     - cron: "15 9 * * 1-5"
@@ -34,6 +37,10 @@ jobs:
       - environment=${{ needs.setup.outputs.runner-env }}
       - arm64
       - os-family=Linux
+    container: ghcr.io/iree-org/cpubuilder_ubuntu_jammy@sha256:48654cf56d6ec28788ea35d80b0546b1ef57281d7998dbe94b78fd4a5f2d33f0
+    defaults:
+      run:
+        shell: bash
     env:
       BUILD_DIR: build-arm64
     steps:
@@ -41,22 +48,18 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           submodules: true
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
+      - name: Install Python requirements
+        run: python3 -m pip install -r ./runtime/bindings/python/iree/runtime/build_requirements.txt
       - name: "Building IREE"
         env:
           IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
+          CCACHE_NAMESPACE: ci_linux_arm64_clang
         run: |
-          ./build_tools/github_actions/docker_run.sh \
-            --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
-            --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
-            --env "CCACHE_NAMESPACE=gcr.io/iree-oss/base-arm64@sha256:9daa1cdbbf12da8527319ece76a64d06219e04ecb99a4cff6e6364235ddf6c59" \
-            --env "IREE_BUILD_SETUP_PYTHON_VENV=${BUILD_DIR}/.venv" \
-            gcr.io/iree-oss/base-arm64@sha256:9daa1cdbbf12da8527319ece76a64d06219e04ecb99a4cff6e6364235ddf6c59 \
-            ./build_tools/cmake/build_all.sh \
-            "${BUILD_DIR}"
+          export IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)"
+          ./build_tools/cmake/build_all.sh "${BUILD_DIR}"
       - name: "Testing IREE"
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-            --env "IREE_ARM_SME_QEMU_AARCH64_BIN=/usr/bin/qemu-aarch64" \
-            gcr.io/iree-oss/base-arm64@sha256:9daa1cdbbf12da8527319ece76a64d06219e04ecb99a4cff6e6364235ddf6c59 \
-            ./build_tools/cmake/ctest_all.sh \
-            "${BUILD_DIR}"
+        env:
+          IREE_ARM_SME_QEMU_AARCH64_BIN: /usr/bin/qemu-aarch64
+        run: ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"

--- a/.github/workflows/ci_linux_arm64_clang.yml
+++ b/.github/workflows/ci_linux_arm64_clang.yml
@@ -60,7 +60,7 @@ jobs:
           IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
           CCACHE_NAMESPACE: ci_linux_arm64_clang
         run: |
-          export IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)"
+          export IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)
           ./build_tools/cmake/build_all.sh "${BUILD_DIR}"
       - name: "Testing IREE"
         env:

--- a/.github/workflows/ci_linux_arm64_clang.yml
+++ b/.github/workflows/ci_linux_arm64_clang.yml
@@ -37,10 +37,6 @@ jobs:
       - environment=${{ needs.setup.outputs.runner-env }}
       - arm64
       - os-family=Linux
-    container: ghcr.io/iree-org/cpubuilder_ubuntu_jammy@sha256:48654cf56d6ec28788ea35d80b0546b1ef57281d7998dbe94b78fd4a5f2d33f0
-    defaults:
-      run:
-        shell: bash
     env:
       BUILD_DIR: build-arm64
     steps:
@@ -48,21 +44,22 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           submodules: true
-      - name: Set up QEMU
-        run: |
-          wget --no-verbose "https://sharkpublic.blob.core.windows.net/sharkpublic/GCP-Migration-Files/qemu-aarch64"
-          chmod +x ./qemu-aarch64
-          cp ./qemu-aarch64 /usr/bin/qemu-aarch64
-      - name: Install Python requirements
-        run: python3 -m pip install -r ./runtime/bindings/python/iree/runtime/build_requirements.txt
       - name: "Building IREE"
         env:
           IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
-          CCACHE_NAMESPACE: ci_linux_arm64_clang
         run: |
-          export IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)
-          ./build_tools/cmake/build_all.sh "${BUILD_DIR}"
+          ./build_tools/github_actions/docker_run.sh \
+            --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
+            --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
+            --env "CCACHE_NAMESPACE=ci_linux_arm64_clang" \
+            --env "IREE_BUILD_SETUP_PYTHON_VENV=${BUILD_DIR}/.venv" \
+            ghcr.io/iree-org/cpubuilder_ubuntu_jammy@sha256:af7f082731b8947b91975a825d212855038e310328c0bdb1c8202a6693d1fa77 \
+            ./build_tools/cmake/build_all.sh \
+            "${BUILD_DIR}"
       - name: "Testing IREE"
-        env:
-          IREE_ARM_SME_QEMU_AARCH64_BIN: /usr/bin/qemu-aarch64
-        run: ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            --env "IREE_ARM_SME_QEMU_AARCH64_BIN=/usr/bin/qemu-aarch64" \
+            ghcr.io/iree-org/cpubuilder_ubuntu_jammy@sha256:af7f082731b8947b91975a825d212855038e310328c0bdb1c8202a6693d1fa77 \
+            ./build_tools/cmake/ctest_all.sh \
+            "${BUILD_DIR}"

--- a/.github/workflows/ci_linux_arm64_clang.yml
+++ b/.github/workflows/ci_linux_arm64_clang.yml
@@ -49,7 +49,10 @@ jobs:
         with:
           submodules: true
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
+        run: |
+          wget --no-verbose "https://sharkpublic.blob.core.windows.net/sharkpublic/GCP-Migration-Files/qemu-aarch64"
+          chmod +x ./qemu-aarch64
+          cp ./qemu-aarch64 /usr/bin/qemu-aarch64
       - name: Install Python requirements
         run: python3 -m pip install -r ./runtime/bindings/python/iree/runtime/build_requirements.txt
       - name: "Building IREE"


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree/issues/15332. This was the last active use of [`build_tools/docker/`](https://github.com/iree-org/iree/tree/main/build_tools/docker), so we can now delete that directory: https://github.com/iree-org/iree/pull/18566.

This uses the same "cpubuilder" dockerfile as the x86_64 builds, which is now built for multiple architectures thanks to https://github.com/iree-org/base-docker-images/pull/11. As before, we install a qemu binary in the dockerfile, this time using the approach in https://github.com/iree-org/base-docker-images/pull/13 instead of a forked dockerfile.

Prior PRs for context:
* https://github.com/iree-org/iree/pull/14372
* https://github.com/iree-org/iree/pull/16331

Build time varies pretty wildly depending on cache hit rate and the phase of the moon:

| Scenario | Cache hit rate | Time | Logs |
| -- | -- | -- | -- |
Cold cache | 0% | 1h45m | [Logs](https://github.com/iree-org/iree/actions/runs/10962049593/job/30440393279)
Warm (?) cache | 61% | 48m | [Logs](https://github.com/iree-org/iree/actions/runs/10963546631/job/30445257323)
Warm (hot?) cache | 98% | 16m | [Logs](https://github.com/iree-org/iree/actions/runs/10964289304/job/30447618503?pr=18569)

CI history (https://github.com/iree-org/iree/actions/workflows/ci_linux_arm64_clang.yml?query=branch%3Amain) shows that regular 97% cache hit rates and 17 minute job times are possible. I'm not sure why one test run only got 61% cache hits. This job only runs nightly, so that's not a super high priority to investigate and fix.

If we migrate the arm64 runner off of GCP (https://github.com/iree-org/iree/issues/18238) we can further simplify this workflow by dropping its reliance on `gcloud auth application-default print-access-token` and the `docker_run.sh` script. Other workflows are now using `source setup_sccache.sh` and some other code.