### PR TITLE
[LLVMGPU][ROCm] Move kernel annotation before serialization

### DIFF
--- a/compiler/plugins/target/ROCM/test/external_function_validation.mlir
+++ b/compiler/plugins/target/ROCM/test/external_function_validation.mlir
@@ -31,7 +31,7 @@ builtin.module {
       }
       builtin.module {
         llvm.func @external_func() attributes {sym_visibility = "private"}
-        llvm.func @test() {
+        llvm.func @test() attributes { rocdl.kernel } {
           llvm.call @external_func() : () -> ()
           llvm.return
         }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
@@ -107,6 +107,7 @@ iree_compiler_cc_library(
         "LLVMGPUVectorLowering.cpp",
         "LLVMGPUVectorToGPU.cpp",
         "Passes.cpp",
+        "ROCDLAnnotateKernelForTranslation.cpp",
         "ROCDLKernelConfig.cpp",
         "ROCDLLowerExecutableTarget.cpp",
         "ROCDLSelectLoweringStrategy.cpp",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -92,6 +92,7 @@ iree_cc_library(
     "LLVMGPUVectorLowering.cpp"
     "LLVMGPUVectorToGPU.cpp"
     "Passes.cpp"
+    "ROCDLAnnotateKernelForTranslation.cpp"
     "ROCDLKernelConfig.cpp"
     "ROCDLLowerExecutableTarget.cpp"
     "ROCDLSelectLoweringStrategy.cpp"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -33,6 +33,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Bufferization/Transforms/Passes.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Linalg/Passes.h"
 #include "mlir/Dialect/MemRef/Transforms/Passes.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -1099,6 +1100,8 @@ static void addLowerToLLVMGPUPasses(OpPassManager &modulePassManager,
   if (forROCDL) {
     // convert to ROCDL.
     modulePassManager.addPass(createConvertToROCDLPass());
+    modulePassManager.addNestedPass<LLVM::LLVMFuncOp>(
+        createROCDLAnnotateKernelForTranslationPass());
   } else {
     // convert to NVVM.
     modulePassManager.addPass(createConvertToNVVMPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLAnnotateKernelForTranslation.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLAnnotateKernelForTranslation.cpp
@@ -1,0 +1,130 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cassert>
+#include "iree/compiler/Codegen/Common/PassUtils.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
+#include "iree/compiler/Codegen/LLVMGPU/ROCDLPasses.h"
+#include "iree/compiler/Codegen/Utils/GPUUtils.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
+#include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
+#include "llvm/Support/LogicalResult.h"
+#include "mlir/Dialect/AMDGPU/IR/AMDGPUDialect.h"
+#include "mlir/Dialect/AMDGPU/Utils/Chipset.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_ROCDLANNOTATEKERNELFORTRANSLATIONPASS
+#include "iree/compiler/Codegen/LLVMGPU/ROCDLPasses.h.inc"
+
+namespace {
+// Extracts the amdgpu chipset version from the chip architecture in the
+// executable target attribute.
+static FailureOr<amdgpu::Chipset>
+getChipsetVersion(IREE::HAL::ExecutableTargetAttr targetAttr) {
+  IREE::GPU::TargetAttr gpuTarget = getGPUTargetAttr(targetAttr);
+  assert(gpuTarget);
+  return amdgpu::Chipset::parse(gpuTarget.getArch());
+}
+
+// Set attributes on `funcOp` in order to use upstream's translation of
+// ROCDL dialect attributes to LLVM. Primarily this is `rocdl.kernel`
+// (sets the calling convention and workgroup size uniformity) but this will
+// also set both forms of workgroup size metadata from `exportOp` (if it is set)
+// and will set the waves_per_eq flag where relevant. Finally, it will mark
+// kernel arguments `inreg` to enable argument preloading on supported
+// architectures.
+static LogicalResult
+annotateKernelForTranslation(LLVM::LLVMFuncOp funcOp,
+                             IREE::HAL::ExecutableVariantOp variantOp,
+                             IREE::HAL::ExecutableExportOp exportOp) {
+  OpBuilder builder(funcOp);
+  auto *rocdlDialect =
+      funcOp.getContext()->getLoadedDialect<ROCDL::ROCDLDialect>();
+  assert(rocdlDialect && "ROCDL dialect not loaded");
+  UnitAttr unitAttr = builder.getUnitAttr();
+  rocdlDialect->getKernelAttrHelper().setAttr(funcOp, unitAttr);
+  std::optional<ArrayAttr> workgroupSizeAttr = exportOp.getWorkgroupSize();
+  if (workgroupSizeAttr && workgroupSizeAttr->size() <= 3) {
+    std::array<int32_t, 3> wgSizes;
+    int32_t flatWgSize = 1;
+    for (auto [value, attr] : llvm::zip_equal(
+             wgSizes, workgroupSizeAttr->getAsRange<IntegerAttr>())) {
+      value = attr.getInt();
+      flatWgSize *= value;
+    }
+    rocdlDialect->getReqdWorkGroupSizeAttrHelper().setAttr(
+        funcOp, builder.getDenseI32ArrayAttr(wgSizes));
+    rocdlDialect->getFlatWorkGroupSizeAttrHelper().setAttr(
+        funcOp,
+        builder.getStringAttr(Twine(flatWgSize) + "," + Twine(flatWgSize)));
+  }
+
+  IREE::HAL::ExecutableTargetAttr targetAttr = variantOp.getTarget();
+  if (std::optional<IntegerAttr> attr =
+          getConfigIntegerAttr(targetAttr, "waves_per_eu")) {
+    rocdlDialect->getWavesPerEuAttrHelper().setAttr(funcOp, *attr);
+  }
+
+  // Kernel argument preloading is only supported on gfx940 and newer targets
+  // from the CDNA family. This is enabled using the `inreg` function argument
+  // attribute.
+  FailureOr<amdgpu::Chipset> chipset = getChipsetVersion(targetAttr);
+  if (failed(chipset))
+    return variantOp.emitError() << "failed to parse amdgpu chipset";
+
+  if (chipset->majorVersion != 9 || *chipset < amdgpu::Chipset(9, 4, 0))
+    return success();
+
+  auto inRegAttrName =
+      builder.getStringAttr(LLVM::LLVMDialect::getInRegAttrName());
+  for (unsigned i = 0, e = funcOp.getNumArguments(); i < e; ++i)
+    funcOp.setArgAttr(i, inRegAttrName, unitAttr);
+
+  return success();
+}
+
+/// Lowers an IREE hal.executable.variant operation using a suitable pass
+/// pipeline.
+struct ROCDLAnnotateKernelForTranslationPass final
+    : impl::ROCDLAnnotateKernelForTranslationPassBase<
+          ROCDLAnnotateKernelForTranslationPass> {
+  void runOnOperation() override {
+    LLVM::LLVMFuncOp funcOp = getOperation();
+    StringRef funcName = funcOp.getName();
+
+    auto variantOp = funcOp->getParentOfType<IREE::HAL::ExecutableVariantOp>();
+    if (!variantOp) {
+      funcOp.emitError() << "cannot find parent hal.executable.variant op";
+      return signalPassFailure();
+    }
+
+    IREE::HAL::ExecutableExportOp exportOp;
+    // Try to find the matching executable export op.
+    for (IREE::HAL::ExecutableExportOp candidate : variantOp.getExportOps()) {
+      if (candidate.getSymName() == funcName) {
+        exportOp = candidate;
+        break;
+      }
+    }
+
+    // Un-exported functions are library functions or otherwise not kernels, so
+    // don't need these annotations.
+    if (!exportOp)
+      return;
+
+    if (failed(annotateKernelForTranslation(funcOp, variantOp, exportOp))) {
+      return signalPassFailure();
+    }
+  }
+};
+} // namespace
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLPasses.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLPasses.h
@@ -8,6 +8,7 @@
 #define IREE_COMPILER_CODEGEN_LLVMGPU_ROCDLPASSES_H_
 
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
 #include "mlir/Pass/Pass.h"
 
 namespace mlir::iree_compiler {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLPasses.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLPasses.td
@@ -13,6 +13,12 @@ include "mlir/Pass/PassBase.td"
 // ROCDL Passes (keep alphabetical)
 //===----------------------------------------------------------------------===//
 
+def ROCDLAnnotateKernelForTranslationPass : Pass<
+    "iree-rocdl-annotate-kernel-for-translation", "LLVM::LLVMFuncOp"> {
+  let summary = "Set function attributes before translating to LLVM IR";
+  let dependentDialects = ["ROCDL::ROCDLDialect"];
+}
+
 def ROCDLLowerExecutableTargetPass : InterfacePass<
     "iree-rocdl-lower-executable-target", "mlir::FunctionOpInterface"> {
   let summary = "Lower an IREE hal.executable.variant op using a suitable "
@@ -24,6 +30,5 @@ def ROCDLSelectLoweringStrategyPass :
   let summary = "Select a suitable lowering strategy for an IREE "
                 "hal.executable.variant op";
 }
-
 
 #endif // IREE_CODEGEN_LLVMGPU_ROCDLPASSES

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/BUILD.bazel
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "annotate_kernel_for_translation.mlir",
             "config_tile_and_fuse.mlir",
             "config_vector_distribute.mlir",
             "config_user_vector_distribute.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "annotate_kernel_for_translation.mlir"
     "config_tile_and_fuse.mlir"
     "config_user_vector_distribute.mlir"
     "config_vector_distribute.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/annotate_kernel_for_translation.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/annotate_kernel_for_translation.mlir
@@ -28,47 +28,6 @@ builtin.module {
         llvm.func @test() {
           llvm.return
         }
-      }
-    }
-  }
-}
-
-// CHECK-LABEL: llvm.func @test()
-// CHECK-SAME:    rocdl.flat_work_group_size = "256,256"
-// CHECK-SAME:    rocdl.kernel
-// CHECK-SAME:    rocdl.reqd_work_group_size = array<i32: 128, 2, 1>
-
-// -----
-
-// Check that we *do not* annotate not exported functions.
-
-#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb",
-  {iree.gpu.target = #iree_gpu.target<arch = "gfx90a", features = "",
-                                      wgp = <compute = int32, storage =  b32,
-                                      subgroup =  none, dot =  none, mma = [],
-                                      subgroup_size_choices = [64],
-                                      max_workgroup_sizes = [1024, 1024, 1024],
-                                      max_thread_count_per_workgroup = 1024,
-                                      max_workgroup_memory_bytes = 65536,
-                                      max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>,
-   ukernels = "none"}>
-#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, Indirect>],
-                                        flags = Indirect>
-builtin.module {
-  hal.executable public @test_exported {
-    hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
-      hal.executable.export public @test_exported ordinal(0) layout(#pipeline_layout)
-        attributes {subgroup_size = 64 : index, workgroup_size = [128 : index, 2 : index, 1 : index]} {
-      ^bb0(%arg0: !hal.device):
-        %c128 = arith.constant 128 : index
-        %c2 = arith.constant 2 : index
-        %c1 = arith.constant 1 : index
-        hal.return %c128, %c2, %c1 : index, index, index
-      }
-      builtin.module {
-        llvm.func @test_exported() {
-          llvm.return
-        }
         llvm.func @test_not_exported() {
           llvm.return
         }
@@ -77,8 +36,11 @@ builtin.module {
   }
 }
 
-// CHECK-LABEL: llvm.func @test_exported() attributes {
+// CHECK-LABEL: llvm.func @test() attributes {
+// CHECK-SAME:    rocdl.flat_work_group_size = "256,256"
 // CHECK-SAME:    rocdl.kernel
+// CHECK-SAME:    rocdl.reqd_work_group_size = array<i32: 128, 2, 1>
+//
 // CHECK-LABEL: llvm.func @test_not_exported() {
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/annotate_kernel_for_translation.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/annotate_kernel_for_translation.mlir
@@ -1,0 +1,160 @@
+// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(builtin.module(llvm.func(iree-rocdl-annotate-kernel-for-translation)))))' \
+// RUN:   --split-input-file %s | FileCheck %s
+
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb",
+  {iree.gpu.target = #iree_gpu.target<arch = "gfx942", features = "",
+                                      wgp = <compute = int32, storage =  b32,
+                                      subgroup =  none, dot =  none, mma = [],
+                                      subgroup_size_choices = [64],
+                                      max_workgroup_sizes = [1024, 1024, 1024],
+                                      max_thread_count_per_workgroup = 1024,
+                                      max_workgroup_memory_bytes = 65536,
+                                      max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>,
+   ukernels = "none"}>
+#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, Indirect>],
+                                        flags = Indirect>
+builtin.module {
+  hal.executable public @test {
+    hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
+      hal.executable.export public @test ordinal(0) layout(#pipeline_layout)
+        attributes {subgroup_size = 64 : index, workgroup_size = [128 : index, 2 : index, 1 : index]} {
+      ^bb0(%arg0: !hal.device):
+        %c128 = arith.constant 128 : index
+        %c2 = arith.constant 2 : index
+        %c1 = arith.constant 1 : index
+        hal.return %c128, %c2, %c1 : index, index, index
+      }
+      builtin.module {
+        llvm.func @test() {
+          llvm.return
+        }
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: llvm.func @test()
+// CHECK-SAME:    rocdl.flat_work_group_size = "256,256"
+// CHECK-SAME:    rocdl.kernel
+// CHECK-SAME:    rocdl.reqd_work_group_size = array<i32: 128, 2, 1>
+
+// -----
+
+// Check that we *do not* annotate not exported functions.
+
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb",
+  {iree.gpu.target = #iree_gpu.target<arch = "gfx90a", features = "",
+                                      wgp = <compute = int32, storage =  b32,
+                                      subgroup =  none, dot =  none, mma = [],
+                                      subgroup_size_choices = [64],
+                                      max_workgroup_sizes = [1024, 1024, 1024],
+                                      max_thread_count_per_workgroup = 1024,
+                                      max_workgroup_memory_bytes = 65536,
+                                      max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>,
+   ukernels = "none"}>
+#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, Indirect>],
+                                        flags = Indirect>
+builtin.module {
+  hal.executable public @test_exported {
+    hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
+      hal.executable.export public @test_exported ordinal(0) layout(#pipeline_layout)
+        attributes {subgroup_size = 64 : index, workgroup_size = [128 : index, 2 : index, 1 : index]} {
+      ^bb0(%arg0: !hal.device):
+        %c128 = arith.constant 128 : index
+        %c2 = arith.constant 2 : index
+        %c1 = arith.constant 1 : index
+        hal.return %c128, %c2, %c1 : index, index, index
+      }
+      builtin.module {
+        llvm.func @test_exported() {
+          llvm.return
+        }
+        llvm.func @test_not_exported() {
+          llvm.return
+        }
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: llvm.func @test_exported() attributes {
+// CHECK-SAME:    rocdl.kernel
+// CHECK-LABEL: llvm.func @test_not_exported() {
+
+// -----
+
+// Check that we annotate kernel arguments on gfx940-series.
+
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb",
+  {iree.gpu.target = #iree_gpu.target<arch = "gfx940", features = "",
+                                      wgp = <compute = int32, storage =  b32,
+                                      subgroup =  none, dot =  none, mma = [],
+                                      subgroup_size_choices = [64],
+                                      max_workgroup_sizes = [1024, 1024, 1024],
+                                      max_thread_count_per_workgroup = 1024,
+                                      max_workgroup_memory_bytes = 65536,
+                                      max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>,
+   ukernels = "none"}>
+#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, Indirect>],
+                                        flags = Indirect>
+builtin.module {
+  hal.executable public @test_kern_arg {
+    hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
+      hal.executable.export public @test_kern_arg ordinal(0) layout(#pipeline_layout)
+        attributes {subgroup_size = 64 : index, workgroup_size = [128 : index, 2 : index, 1 : index]} {
+      ^bb0(%arg0: !hal.device):
+        %c128 = arith.constant 128 : index
+        %c2 = arith.constant 2 : index
+        %c1 = arith.constant 1 : index
+        hal.return %c128, %c2, %c1 : index, index, index
+      }
+      builtin.module {
+        llvm.func @test_kern_arg(%arg0: i32) {
+          llvm.return
+        }
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: llvm.func @test_kern_arg
+// CHECK-SAME:    (%{{.+}}: i32 {llvm.inreg})
+
+// -----
+
+// Check that we *do not* annotate kernel arguments on gfx90a (not supported by the firmware).
+
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb",
+  {iree.gpu.target = #iree_gpu.target<arch = "gfx90a", features = "",
+                                      wgp = <compute = int32, storage =  b32,
+                                      subgroup =  none, dot =  none, mma = [],
+                                      subgroup_size_choices = [64],
+                                      max_workgroup_sizes = [1024, 1024, 1024],
+                                      max_thread_count_per_workgroup = 1024,
+                                      max_workgroup_memory_bytes = 65536,
+                                      max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>,
+   ukernels = "none"}>
+#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, Indirect>],
+                                        flags = Indirect>
+builtin.module {
+  hal.executable public @test_no_kern_arg {
+    hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
+      hal.executable.export public @test_no_kern_arg ordinal(0) layout(#pipeline_layout)
+        attributes {subgroup_size = 64 : index, workgroup_size = [128 : index, 2 : index, 1 : index]} {
+      ^bb0(%arg0: !hal.device):
+        %c128 = arith.constant 128 : index
+        %c2 = arith.constant 2 : index
+        %c1 = arith.constant 1 : index
+        hal.return %c128, %c2, %c1 : index, index, index
+      }
+      builtin.module {
+        llvm.func @test_no_kern_arg(%arg0: i32) {
+          llvm.return
+        }
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: llvm.func @test_no_kern_arg
+// CHECK-SAME:    (%{{.+}}: i32)


### PR DESCRIPTION
ROCMTarget serialization is not the best location for this code because it violates the following invariant in `buildLLVMGPUCodegenPassPipeline`:
>  - The module contains the final llvm.module ready to be serialized.

Specifically, requiring the ROCDL dialect to be loaded is problemantic during serialization, as target-agnostic serialization in (`iree-hal-serialize-executables`) does not register dependent dialects.

This PR moves kernel annotation just after conversion to ROCDL in the `LowerToGPUPasses` pass pipeline.

Also add kernel annotation tests that were not straightforward to add before, as annotation was not a freestanding pass whose output could be inspected.