### PR TITLE
[NFC][Codegen] Move LLVMCPUDropVectorUnitDims to Common

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -100,6 +100,7 @@ iree_compiler_cc_library(
         "DecomposeLinalgGeneric.cpp",
         "DecomposePackUnPackOps.cpp",
         "DecomposeSoftmax.cpp",
+        "DropVectorUnitDims.cpp",
         "EmulateNarrowType.cpp",
         "EncodingUtils.cpp",
         "EraseDeadAllocAndStores.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -92,6 +92,7 @@ iree_cc_library(
     "DecomposeLinalgGeneric.cpp"
     "DecomposePackUnPackOps.cpp"
     "DecomposeSoftmax.cpp"
+    "DropVectorUnitDims.cpp"
     "EmulateNarrowType.cpp"
     "EncodingUtils.cpp"
     "EraseDeadAllocAndStores.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/DropVectorUnitDims.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DropVectorUnitDims.cpp
@@ -4,26 +4,25 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "iree/compiler/Codegen/LLVMCPU/Passes.h"
+#include "iree/compiler/Codegen/Common/Passes.h"
 #include "mlir/Dialect/Vector/Transforms/LoweringPatterns.h"
 #include "mlir/Dialect/Vector/Transforms/VectorTransforms.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
-#define DEBUG_TYPE "iree-llvmcpu-drop-vector-unit-dims"
+#define DEBUG_TYPE "iree-codegen-drop-vector-unit-dims"
 
 namespace mlir::iree_compiler {
 
-#define GEN_PASS_DEF_LLVMCPUDROPVECTORUNITDIMSPASS
-#include "iree/compiler/Codegen/LLVMCPU/Passes.h.inc"
+#define GEN_PASS_DEF_DROPVECTORUNITDIMSPASS
+#include "iree/compiler/Codegen/Common/Passes.h.inc"
 
 namespace {
-class LLVMCPUDropVectorUnitDimsPass
-    : public impl::LLVMCPUDropVectorUnitDimsPassBase<
-          LLVMCPUDropVectorUnitDimsPass> {
+class DropVectorUnitDimsPass
+    : public impl::DropVectorUnitDimsPassBase<DropVectorUnitDimsPass> {
 public:
-  using impl::LLVMCPUDropVectorUnitDimsPassBase<
-      LLVMCPUDropVectorUnitDimsPass>::LLVMCPUDropVectorUnitDimsPassBase;
+  using impl::DropVectorUnitDimsPassBase<
+      DropVectorUnitDimsPass>::DropVectorUnitDimsPassBase;
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<memref::MemRefDialect, vector::VectorDialect>();
@@ -31,7 +30,7 @@ public:
   void runOnOperation() override;
 };
 
-void LLVMCPUDropVectorUnitDimsPass::runOnOperation() {
+void DropVectorUnitDimsPass::runOnOperation() {
   MLIRContext *ctx = &getContext();
   auto funcOp = getOperation();
 

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -79,6 +79,12 @@ def ConvertToDestinationPassingStylePass :
   ];
 }
 
+def ConvolutionToIGEMMPass :
+    InterfacePass<"iree-codegen-convolution-to-igemm", "mlir::FunctionOpInterface"> {
+  let summary =
+      "Transforms convolution operations into an implicit GEMM format.";
+}
+
 def DecomposeAffineOpsPass: Pass<"iree-codegen-decompose-affine-ops"> {
   let summary = "Decompose `affine.apply` operations into sub `affine.apply`";
   let description = [{
@@ -123,12 +129,6 @@ def DecomposeAffineOpsPass: Pass<"iree-codegen-decompose-affine-ops"> {
   ];
 }
 
-def ConvolutionToIGEMMPass :
-    InterfacePass<"iree-codegen-convolution-to-igemm", "mlir::FunctionOpInterface"> {
-  let summary =
-      "Transforms convolution operations into an implicit GEMM format.";
-}
-
 def DecomposeConvolutionToLowerDimOpsPass :
     Pass<"iree-codegen-decompose-convolution-to-lower-dim-ops", ""> {
   let summary = "Decomposes linalg convolution ops to lower dim ops";
@@ -168,6 +168,11 @@ def DecomposeSoftmaxPass :
            "bool", /*default=*/"true",
            "Whether to use the internal pass fusion logic for the exp function. See #15862.">
   ];
+}
+
+def DropVectorUnitDimsPass :
+    InterfacePass<"iree-codegen-drop-vector-unit-dims", "mlir::FunctionOpInterface"> {
+  let summary = "Pass to drop vector unit dims.";
 }
 
 def ReconcileTranslationInfoPass

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD.bazel
@@ -55,7 +55,6 @@ iree_compiler_cc_library(
         "LLVMCPUAssignConstantOrdinals.cpp",
         "LLVMCPUAssignImportOrdinals.cpp",
         "LLVMCPUCheckIRBeforeLLVMConversion.cpp",
-        "LLVMCPUDropVectorUnitDims.cpp",
         "LLVMCPUEmitVectorizationRemarks.cpp",
         "LLVMCPULinkExecutables.cpp",
         "LLVMCPULowerExecutableTarget.cpp",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
@@ -56,7 +56,6 @@ iree_cc_library(
     "LLVMCPUAssignConstantOrdinals.cpp"
     "LLVMCPUAssignImportOrdinals.cpp"
     "LLVMCPUCheckIRBeforeLLVMConversion.cpp"
-    "LLVMCPUDropVectorUnitDims.cpp"
     "LLVMCPUEmitVectorizationRemarks.cpp"
     "LLVMCPULinkExecutables.cpp"
     "LLVMCPULowerExecutableTarget.cpp"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -297,7 +297,7 @@ LogicalResult verifyConvTileAndDecomposeExpertConfig(
 void buildLLVMCPUVectorLoweringPipeline(
     OpPassManager &funcPassManager,
     const LLVMCPUVectorLoweringPassOptions &options) {
-  funcPassManager.addPass(createLLVMCPUDropVectorUnitDimsPass());
+  funcPassManager.addPass(createDropVectorUnitDimsPass());
   funcPassManager.addPass(createLLVMCPUVirtualVectorLoweringPass(
       LLVMCPUVirtualVectorLoweringPassOptions{options.splitVectorTransfersTo,
                                               options.enableArmI8mm}));

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
@@ -187,11 +187,6 @@ def LLVMCPUUnfuseFMAOpsPass :
   let summary = "Convert llvm.fma into unfused mulf and addf ops";
 }
 
-def LLVMCPUDropVectorUnitDimsPass :
-    InterfacePass<"iree-llvmcpu-drop-vector-unit-dims", "mlir::FunctionOpInterface"> {
-  let summary = "Pass to drop vector unit dims.";
-}
-
 def LLVMCPUVirtualVectorLoweringPass :
     InterfacePass<"iree-llvmcpu-virtual-vector-lowering", "mlir::FunctionOpInterface"> {
   let summary = "Pass to lower high level vector operations like contract or multidim reduce ops to lower level vector ops.";


### PR DESCRIPTION
The pass does not depend on anything LLVMCPU specific. Move it to common for reuse with other backends.