### PR TITLE
Fix iree-compile command line call

### DIFF
--- a/docs/website/docs/guides/ml-frameworks/onnx.md
+++ b/docs/website/docs/guides/ml-frameworks/onnx.md
@@ -106,9 +106,9 @@ graph LR
       -o model_cpu.vmfb
 
     iree-run-module \
-      model_cpu.vmfb \
+      --module=model_cpu.vmfb \
       --device=local-task \
-      --entry_function=... \
+      --function=... \
       --input=... \
       ...
     ```


### PR DESCRIPTION
Providing a module (by file path) requires passing it via `--module=`.
Function need to be specified via `--function=`.

skip-ci: doc update only.