### PR TITLE
Warn when `--iree-llvmcpu-target-cpu` defaults to "generic".

### DIFF
--- a/compiler/plugins/target/LLVMCPU/LLVMTargetOptions.cpp
+++ b/compiler/plugins/target/LLVMCPU/LLVMTargetOptions.cpp
@@ -40,14 +40,15 @@ bool resolveCPUAndCPUFeatures(llvm::StringRef inCpu,
   // Resolve "host" cpu and cpu features.
   // Note: CPU feature detection in LLVM may be incomplete. Passing explicit
   // feature lists instead of "host" should be preferred when possible.
-  if (inCpu == "host" || inCpuFeatures == "host") {
-    bool isCpuHostOrEmpty = inCpu.empty() || inCpu == "host";
+  if (cpu == "host" || cpuFeatures == "host") {
+    bool isCpuHostOrEmpty = cpu.empty() || cpu == "host";
     bool isCpuFeaturesHostOrEmpty =
-        inCpuFeatures.empty() || inCpuFeatures == "host";
+        cpuFeatures.empty() || cpuFeatures == "host";
     if (!(isCpuHostOrEmpty && isCpuFeaturesHostOrEmpty)) {
       llvm::errs() << "error: If either Cpu or CpuFeatures is 'host', the "
                       "other must also be 'host' or empty (Cpu: '"
-                   << inCpu << "', CpuFeatures: '" << inCpuFeatures << "')\n";
+                   << cpu << "', CpuFeatures: '" << cpuFeatures << "')\n";
+      // Note: not populating outCpu or outCpuFeatures here! Fatal error later.
       return false;
     }
     cpu = llvm::sys::getHostCPUName().str();
@@ -133,9 +134,9 @@ LLVMTarget::LLVMTarget() {
   llvmTargetOptions.UniqueSectionNames = true;
 }
 
-std::optional<LLVMTarget> LLVMTarget::create(std::string_view triple,
-                                             std::string_view cpu,
-                                             std::string_view cpuFeatures,
+std::optional<LLVMTarget> LLVMTarget::create(std::string triple,
+                                             std::string cpu,
+                                             std::string cpuFeatures,
                                              bool requestLinkEmbedded) {
   LLVMTarget target;
   target.linkEmbedded = requestLinkEmbedded;
@@ -355,8 +356,9 @@ LLVMTarget::loadFromConfigAttr(Location loc, DictionaryAttr config,
       return {};
     }
 
-    std::optional<LLVMTarget> maybeTarget = LLVMTarget::create(
-        *triple, cpu.value_or(""), cpuFeatures.value_or(""), linkEmbedded);
+    std::optional<LLVMTarget> maybeTarget =
+        LLVMTarget::create(triple->str(), cpu.value_or("").str(),
+                           cpuFeatures.value_or("").str(), linkEmbedded);
     if (!maybeTarget) {
       return {};
     }

--- a/compiler/plugins/target/LLVMCPU/LLVMTargetOptions.h
+++ b/compiler/plugins/target/LLVMCPU/LLVMTargetOptions.h
@@ -66,9 +66,8 @@ struct LLVMTarget {
   void storeToConfigAttrs(MLIRContext *context,
                           SmallVector<NamedAttribute> &config) const;
 
-  static std::optional<LLVMTarget> create(std::string_view triple,
-                                          std::string_view cpu,
-                                          std::string_view cpuFeatures,
+  static std::optional<LLVMTarget> create(std::string triple, std::string cpu,
+                                          std::string cpuFeatures,
                                           bool requestLinkEmbedded);
 
   static std::optional<LLVMTarget> createForHost();

--- a/compiler/plugins/target/LLVMCPU/LLVMTargetOptions.h
+++ b/compiler/plugins/target/LLVMCPU/LLVMTargetOptions.h
@@ -177,7 +177,7 @@ struct LLVMCPUTargetCLOptions {
 
   // Default device options.
   std::string targetTriple = "";
-  std::string targetCPU = "generic";
+  std::string targetCPU = "";
   std::string targetCPUFeatures = "";
   bool linkEmbedded = LLVMTarget::DEFAULT_LINK_EMBEDDED;
   bool linkStatic = LLVMTarget::DEFAULT_LINK_STATIC;


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree/issues/18561.

We have these high level flags (and MLIR attributes) controlling what code the llvm-cpu compiler target generates using LLVM:
* `--iree-llvmcpu-target-triple`
  * e.g. `x86_64-pc-windows-msvc`
  * See https://github.com/llvm/llvm-project/blob/main/llvm/include/llvm/TargetParser/Triple.h
* `--iree-llvmcpu-target-cpu`
  * e.g. `znver2`
* `--iree-llvmcpu-target-cpu-features`
  * e.g. `+prfchw,-cldemote,+avx,+aes,+sahf,+pclmul,-xop,...`

Some targets (x86 and riscv64) in LLVM can infer the "features" for a given "cpu" with the `getFeaturesForCPU()` functions. Other targets may be able to look up available features on the host via `llvm::sys::getHostCPUFeatures()`. Short of either of those, we must fall back to having users explicitly list the features they want the compiler to use.

If the target CPU and target CPU features are both omitted, we currently fall back to "generic", meaning no "features". This PR sends more warning information to stderr if that case is detected. We could go a step further and make the default case propagate an error through the compiler, requiring users to explicit set "host", "generic", a known cpu type, or a known list of features.

---

TODO

- [ ] Update docs (https://iree.dev/guides/deployment-configurations/cpu/, source: [`docs/website/docs/guides/deployment-configurations/cpu.md`](https://github.com/iree-org/iree/blob/main/docs/website/docs/guides/deployment-configurations/cpu.md))
- [ ] Audit the repository and other projects for usage of `--iree-hal-target-backends=llvm-cpu` that is missing an explicit `--iree-llvmcpu-target-cpu` or `--iree-llvmcpu-target-cpu-features`
- [ ] Test the different code paths (manually or with lit tests / automation)
- [ ] Add more context to error messages and docs, including an enumeration of accepted values for each flag

---

Debugging tips while working on this:

* Run with `--debug-only=iree-llvm-cpu-target` to see the computed `LLVMTarget` get logged
* Note that multiple code paths run this code, including CLI flags that build `defaultOptions_` for `getDefaultExecutableTargets()` and `getVariantTarget`/`loadFromConfigAttr` that may come from already constructed IR. We want error handling for all of them.