### PR TITLE
Update references to nod-ai/SHARK-* repository names.

### DIFF
--- a/build_tools/cmake/presets/turbine.json
+++ b/build_tools/cmake/presets/turbine.json
@@ -13,7 +13,7 @@
         {
             "name": "turbine",
             "displayName": "Minimal Turbine Dev",
-            "description": "Enable minimal development of SHARK-Turbine with a CPU backend",
+            "description": "Enable minimal development of iree-turbine with a CPU backend",
             "inherits": [
                 "minimal",
                 "python-bindings"

--- a/docs/website/docs/community/index.md
+++ b/docs/website/docs/community/index.md
@@ -2,17 +2,17 @@
 
 Projects built by community members:
 
-* The [SHARK](https://github.com/nod-ai/SHARK) project offers user interfaces
-  for running a large corpus of machine learning programs.
+* The [SHARK-Studio](https://github.com/nod-ai/SHARK-Studio) project offers user
+  interfaces for running a large corpus of machine learning programs.
 
-* The [sharktank](https://github.com/nod-ai/sharktank) project contains
-  modeling and serving libraries for popular genai applications.
+* The [SHARK-Platform](https://github.com/nod-ai/SHARK-Platform) project
+  contains modeling and serving libraries.
 
-* The [SHARK-Turbine](https://github.com/nod-ai/SHARK-Turbine) project is an
+* The [SHARK-ModelDev](https://github.com/nod-ai/SHARK-ModelDev) project is an
   integration repository for various model bringup activities. Several parts
-  of SHARK-Turbine graduated to
+  of SHARK-ModelDev graduated to
   [iree-turbine](https://github.com/iree-org/iree-turbine) and
-  [sharktank](https://github.com/nod-ai/sharktank).
+  [SHARK-Platform](https://github.com/nod-ai/SHARK-Platform).
 
 * The [IREE C++ Template](https://github.com/iml130/iree-template-cpp) *(archived)*
   showed one way to integrate IREE's runtime into a project with CMake.

--- a/docs/website/docs/developers/debugging/model-development.md
+++ b/docs/website/docs/developers/debugging/model-development.md
@@ -9,9 +9,10 @@ icon: octicons/bug-16
 
 Bringing up new models or diagnosing regressions in existing models written
 using one of IREE's supported [ML frameworks](../../guides/ml-frameworks/index.md)
-or downstream projects like [sharktank](https://github.com/nod-ai/sharktank) can
-involve debugging up and down the tech stack. Here are some tips to make that
-process easier.
+or downstream projects like
+[SHARK-Platform](https://github.com/nod-ai/SHARK-Platform) can involve
+debugging up and down the tech stack. Here are some tips to make that process
+easier.
 
 ## Helpful build settings
 

--- a/docs/website/docs/guides/ml-frameworks/onnx.md
+++ b/docs/website/docs/guides/ml-frameworks/onnx.md
@@ -16,7 +16,7 @@ status: new
     Support for a broad set of [ONNX operators](https://onnx.ai/onnx/operators/)
     and [data types](https://onnx.ai/onnx/intro/concepts.html#supported-types)
     is an active investment area. See the
-    [ONNX Op Support tracking issue](https://github.com/nod-ai/SHARK-Turbine/issues/215)
+    [ONNX Op Support tracking issue](https://github.com/nod-ai/SHARK-ModelDev/issues/215)
     for the latest status.
 
 ## :octicons-book-16: Overview
@@ -140,7 +140,7 @@ There are several possible scenarios:
 1. The operator is not implemented, or the implementation is missing a case.
    Search for a matching issue in one of these places:
      * <https://github.com/llvm/torch-mlir/issues>
-     * <https://github.com/nod-ai/SHARK-Turbine/issues>
+     * <https://github.com/nod-ai/SHARK-ModelDev/issues>
 2. The operator is implemented but only for a more recent ONNX version. You can
    try upgrading your .onnx file using the
    [ONNX Version Converter](https://github.com/onnx/onnx/blob/main/docs/VersionConverter.md):

--- a/docs/website/docs/guides/ml-frameworks/pytorch.md
+++ b/docs/website/docs/guides/ml-frameworks/pytorch.md
@@ -23,8 +23,7 @@ status: new
 ## :octicons-book-16: Overview
 
 [iree-turbine](https://pypi.org/project/iree-turbine/) (rebrand pending from
-[SHARK-Turbine](https://github.com/nod-ai/SHARK-Turbine)) offers a tight
-integration between compatible versions of IREE,
+"shark-turbine") offers a tight integration between compatible versions of IREE,
 [torch-mlir](https://github.com/llvm/torch-mlir), and
 [PyTorch](https://pytorch.org/).
 
@@ -84,7 +83,7 @@ Just-in-time integration allows for Python code using TorchDynamo to optimize
 PyTorch models/functions using IREE, all within an interactive Python session.
 
 <!-- TODO(scotttodd): mention targets like AMD GPUs when supported
-                      https://github.com/nod-ai/SHARK-Turbine/issues/94 -->
+                      https://github.com/iree-org/iree-turbine/issues/78 -->
 
 ``` mermaid
 graph TD
@@ -268,7 +267,7 @@ Advanced export workflows can use the
 class to define and constrain the structure of a program prior to compiling it.
 
 <!-- TODO(scotttodd): API reference pages for aot.CompiledModule etc.?
-                      https://github.com/nod-ai/SHARK-Turbine/issues/106
+                      https://github.com/iree-org/iree-turbine/issues/77
 -->
 
 ```python
@@ -414,4 +413,4 @@ Advanced AOT export notebook | [![Open in Colab](https://colab.research.google.c
 PyTorch dynamic shapes notebook | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/iree-org/iree/blob/main/samples/dynamic_shapes/pytorch_dynamic_shapes.ipynb)
 AOT unit tests | [`tests/aot/`](https://github.com/iree-org/iree-turbine/tree/main/tests/aot)
 Dynamic MLP export | [`core/examples/aot_mlp/mlp_export_dynamic.py`](https://github.com/iree-org/iree-turbine/tree/main/examples/aot_mlp/mlp_export_dynamic.py)
-stateless llama2 | [`models/turbine_models/custom_models/stateless_llama.py`](https://github.com/nod-ai/SHARK-Turbine/blob/main/models/turbine_models/custom_models/stateless_llama.py)
+stateless llama2 | [`models/turbine_models/custom_models/stateless_llama.py`](https://github.com/nod-ai/SHARK-ModelDev/blob/main/models/turbine_models/custom_models/stateless_llama.py)


### PR DESCRIPTION
These repositories were just renamed:

Before | After
-- | --
https://github.com/nod-ai/SHARK | https://github.com/nod-ai/SHARK-Studio
https://github.com/nod-ai/sharktank | https://github.com/nod-ai/SHARK-Platform
https://github.com/nod-ai/SHARK-Turbine | https://github.com/nod-ai/SHARK-ModelDev

There are still references to "shark turbine" pending the namespace migration tracked in https://github.com/iree-org/iree-turbine/issues/28