### PR TITLE
simplify `DataTiledMMAAttr::buildMmaOperation`

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -1088,13 +1088,11 @@ FailureOr<Value> DataTiledMMAAttr::buildMmaOperation(OpBuilder &builder,
       });
   SmallVector<int64_t> strides(intrinsicCType.getRank(), 1);
   SmallVector<int64_t> indices(accCrossIntrinsicShape.size(), 0);
-  for (int mu = 0; mu < getUnrollM(); ++mu) {
-    for (int nu = 0; nu < getUnrollN(); ++nu) {
-      acc = builder.create<vector::InsertStridedSliceOp>(
-          loc, intrinsicsAcc[mu * getUnrollN() + nu], acc, indices, strides);
-      incrementIndices(indices, accCrossIntrinsicShape);
-    }
-  }
+  int intrinsicsAccIndex = 0;
+  do {
+    acc = builder.create<vector::InsertStridedSliceOp>(
+        loc, intrinsicsAcc[intrinsicsAccIndex++], acc, indices, strides);
+  } while (incrementIndices(indices, accCrossIntrinsicShape));
   return acc;
 }
 


### PR DESCRIPTION
No need to compute `crossIntrinsicCount` and size the result vector accordingly when we can just have the `incrementIndices` helper tell when we have exhausted the index space.