### PR TITLE
[COMMON] Select the last compute op that has workgroup tilin…

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
@@ -53,18 +53,17 @@ struct TilingInfo {
 static FailureOr<TilingInfo>
 getTiledAndDistributionInfo(RewriterBase &rewriter,
                             ArrayRef<Operation *> computeOps) {
-  // It is expected that at most one compute op has a workgroup tiling level.
+  // TODO: It is expected that at most one compute op has a workgroup tiling
+  // level. Currently, it selects the last compute op that has workgroup tiling
+  // level.
   Operation *tilableOp = nullptr;
   for (Operation *op : llvm::reverse(computeOps)) {
     if (getLoweringConfig(op)) {
       if (!getLoweringConfig(op).hasWorkgroupTilingLevel()) {
         continue;
       }
-      if (tilableOp) {
-        return op->emitOpError("expected only one op with a workgroup tiling"
-                               "level.");
-      }
       tilableOp = op;
+      break;
     }
   }
   if (!tilableOp) {


### PR DESCRIPTION
…g level

Remove the check "expected only one op with a workgroup tiling level".