### PR TITLE
Removed the iree_thread_join in the cleanup of deferred_work_queue.c

### DIFF
--- a/runtime/src/iree/hal/utils/deferred_work_queue.c
+++ b/runtime/src/iree/hal/utils/deferred_work_queue.c
@@ -598,10 +598,7 @@ void iree_hal_deferred_work_queue_destroy(
   // Request the workers to exit.
   iree_hal_deferred_work_queue_request_exit(work_queue);
 
-  iree_thread_join(work_queue->worker_thread);
   iree_thread_release(work_queue->worker_thread);
-
-  iree_thread_join(work_queue->completion_thread);
   iree_thread_release(work_queue->completion_thread);
 
   iree_hal_deferred_work_queue_working_area_deinitialize(


### PR DESCRIPTION
This was cuasing ASAN errors as pthread_join was getting called twice. We don't actually need to explicitly join these threads as iree_thread_release will join the thread on our behalf anyway.

Fixes #18449