### PR TITLE
Simplifications around narrow dimensions in encodings.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
@@ -199,9 +199,7 @@ bool isNarrowNResult(EncodingAttr encoding) {
     return false;
   }
 
-  int64_t narrowM = encoding.getMatmulNarrowM();
-  int64_t narrowN = encoding.getMatmulNarrowN();
-  return narrowN && (!narrowM || narrowM > narrowN);
+  return IREE::Encoding::getMatmulNarrowDim(encoding).isN();
 }
 
 SmallVector<int64_t>

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingBase.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingBase.td
@@ -110,14 +110,6 @@ def EncodingAttr :
 
     /// Clones an encoding with a new bcast_map
     EncodingAttr clone(AffineMap bcastMap);
-
-    /// Returns the M size from `round_dims_to` if the value is less than
-    /// kNarrowThreshold. Otherwise, returns zero.
-    int64_t getMatmulNarrowM();
-
-    /// Returns the N size from `round_dims_to` if the value is less than
-    /// kNarrowThreshold. Otherwise, returns zero.
-    int64_t getMatmulNarrowN();
   }];
 
   let genVerifyDecl = 0;


### PR DESCRIPTION
* Drop the `kNarrowThreshold` constant, relying instead on the default padding value.
  * When reading an `encoding` attribute to tell if a `round_dims_to` entry should be considered narrow, rely on the fact that we only ever need one narrowest dimension in a given matmul to be considered narrow, so the smallest `round_dims_to` entry is the narrow one; if all `round_dims_to` entries are equal, the matmul is not narrow.
* Introduce a `MatmulNarrowDim` struct to unify helpers and group them in `EncodingOps.{h,cpp}`.
  * This enforces in the type system that at most one of the M or N dimensions may be narrow, not both. Previously, we had different structs/tuples, none of which enforced that, so we felt compiled to write comments about the unenforced contract, and the concerned code was scattered across different files.
* Remove the `getMatmulNarrow{M,N}` getters on `EncodingAttr`.
  * Generally we are over-relying on TableGen class methods, which only obfuscates things compared to functions declared manually in C++ files, and the new `MatmulNarrowDim` struct allows replacing both these methods by a single `getMatmulNarrowDim`, which also simplifies callers.