### PR TITLE
[Util][GPU] Add TiedOpInterface and HoistableOpInterface for iree_gpu.multi_mma op

### DIFF
--- a/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
@@ -170,6 +170,9 @@ struct LinalgOpTiedOpInterfaceHelper {
   }
 };
 
+// TODO(Max191): Remove this interface once GPU data tiling stops using early
+// materialization. This only exists for handling multi_mma ops before dispatch
+// workgroups are created, which only happens with early materialization.
 struct MultiMmaOpTiedOpInterface
     : public IREE::Util::TiedOpInterface::ExternalModel<
           MultiMmaOpTiedOpInterface, IREE::GPU::MultiMmaOp>{
@@ -247,6 +250,9 @@ struct HoistableLinalgOpInterface
   }
 };
 
+// TODO(Max191): Remove this interface once GPU data tiling stops using early
+// materialization. This only exists for handling multi_mma ops before dispatch
+// workgroups are created, which only happens with early materialization.
 struct HoistableMultiMmaOpInterface
     : public IREE::Util::HoistableOpInterface::ExternalModel<
           HoistableMultiMmaOpInterface, IREE::GPU::MultiMmaOp> {

--- a/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
@@ -175,7 +175,7 @@ struct LinalgOpTiedOpInterfaceHelper {
 // workgroups are created, which only happens with early materialization.
 struct MultiMmaOpTiedOpInterface
     : public IREE::Util::TiedOpInterface::ExternalModel<
-          MultiMmaOpTiedOpInterface, IREE::GPU::MultiMmaOp>{
+          MultiMmaOpTiedOpInterface, IREE::GPU::MultiMmaOp> {
   Value getTiedResult(Operation *op, unsigned resultIndex) const {
     auto linalgOp = cast<IREE::GPU::MultiMmaOp>(op);
     return IREE::Util::TiedOpInterface::findTiedBaseValue(linalgOp.getAcc());
@@ -328,11 +328,10 @@ void registerUtilExternalModels(DialectRegistry &registry) {
             *context);
       });
 
-  registry.addExtension(
-      +[](MLIRContext *context, IREE::GPU::IREEGPUDialect *dialect) {
-        IREE::GPU::MultiMmaOp::attachInterface<MultiMmaOpTiedOpInterface>(
-            *context);
-      });
+  registry.addExtension(+[](MLIRContext *context,
+                            IREE::GPU::IREEGPUDialect *dialect) {
+    IREE::GPU::MultiMmaOp::attachInterface<MultiMmaOpTiedOpInterface>(*context);
+  });
 
   registry.addExtension(
       +[](MLIRContext *context, linalg::LinalgDialect *dialect) {
@@ -405,7 +404,7 @@ void registerUtilExternalModels(DialectRegistry &registry) {
 #include "mlir/Dialect/Linalg/IR/LinalgOps.cpp.inc"
             >::registerOpInterface(context);
       });
-  
+
   registry.addExtension(
       +[](MLIRContext *context, IREE::GPU::IREEGPUDialect *dialect) {
         IREE::GPU::MultiMmaOp::attachInterface<HoistableMultiMmaOpInterface>(


### PR DESCRIPTION
This PR is a temporary solution for some issues with e2e enablement of GPU data tiling. This is not intended to exist past when GPU data tiling materialization gets deferred to codegen, but it is needed in order to have e2e tests while developing the GPU data tiling path. It is left as TODO to revert this PR and remove the interfaces once late materialization is achieved.

The PR implements interfaces for the iree_gpu.multi_mma op, so that it can be handled similarly to a linalg.matmul before dispatch workgroups are created. With late materialization, there will be no multi_mma ops until codegen, and this can be removed.