### PR TITLE
Integrate LLVM at llvm/llvm-project@68ddd6c80e917b

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_split_reduction_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_split_reduction_tests.mlir
@@ -40,7 +40,7 @@ func.func @split_reduction_innermost_reduction_no_dynamic_perfect_tiling_support
 // CHECK:             scf.for
 // CHECK:               scf.for %[[ARG3:.+]] = %[[C0]] to %[[C64]] step %[[C1]]
 // CHECK:                 arith.addi
-// CHECK:                 scf.yield %{{.*}} : vector<1x1x4xi32>
+// CHECK:                 scf.yield %{{.*}} : vector<4xi32>
 // CHECK:               vector.reduction <add>, %{{.+}} %{{.+}} : vector<4xi32> into i32
 // CHECK:             arith.addi %{{.+}}, %{{.+}} : vector<4xi32>
 
@@ -77,7 +77,7 @@ func.func @split_reduction_innermost_reduction_no_dynamic_perfect_tiling_float_s
 }
 
 // CHECK-LABEL: func.func @split_reduction_innermost_reduction_no_dynamic_perfect_tiling_float_supported_with_flag()
-// CHECK-NOT:     scf.yield %{{.+}} : vector<1x1x4xf32>
+// CHECK-NOT:     arith.addf : vector<4xf32>
 
 // REORDERCHECK-LABEL: func.func @split_reduction_innermost_reduction_no_dynamic_perfect_tiling_float_supported_with_flag()
 // REORDERCHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
@@ -88,7 +88,7 @@ func.func @split_reduction_innermost_reduction_no_dynamic_perfect_tiling_float_s
 // REORDERCHECK:             scf.for
 // REORDERCHECK:               scf.for %[[ARG3:.+]] = %[[C0]] to %[[C64]] step %[[C1]]
 // REORDERCHECK:                 arith.addf
-// REORDERCHECK:                 scf.yield %{{.*}} : vector<1x1x4xf32>
+// REORDERCHECK:                 scf.yield %{{.*}} : vector<4xf32>
 // REORDERCHECK:               vector.reduction <add>, %{{.+}} %{{.+}} : vector<4xf32> into f32
 // REORDERCHECK:             arith.addf %{{.+}}, %{{.+}} : vector<4xf32>
 
@@ -129,7 +129,7 @@ func.func @split_reduction_innermost_reduction_next_dynamic_supported() attribut
 // CHECK:              scf.for
 // CHECK:                scf.for %[[ARG3:.+]] = %[[C0]] to %[[C64]] step %[[C1]]
 // CHECK:                  arith.addi
-// CHECK:                  scf.yield %{{.*}} : vector<1x1x4xi32>
+// CHECK:                  scf.yield %{{.*}} : vector<4xi32>
 // CHECK:                vector.reduction <add>, %{{.+}} %{{.+}} : vector<4xi32> into i32
 
 // -----
@@ -165,7 +165,7 @@ func.func @split_reduction_innermost_reduction_next_imperfect_tiling_supported()
 // CHECK:              scf.for
 // CHECK:                scf.for %[[ARG3:.+]] = %[[C0]] to %[[C64]] step %[[C1]]
 // CHECK:                  arith.addi
-// CHECK:                  scf.yield %{{.*}} : vector<1x1x4xi32>
+// CHECK:                  scf.yield %{{.*}} : vector<4xi32>
 // CHECK:                vector.reduction <add>, %{{.+}} %{{.+}} : vector<4xi32> into i32
 
 // -----
@@ -249,7 +249,6 @@ func.func @split_reduction_not_innermost_reduction_unsupported() attributes {hal
 }
 
 // CHECK-LABEL:  func.func @split_reduction_not_innermost_reduction_unsupported()
-// CHECK-NOT:      scf.yield %{{.+}} : vector<1x1x4xi32>
 // CHECK-NOT:      vector.reduction
 
 // -----


### PR DESCRIPTION
Carrying local reverts:

- https://github.com/llvm/llvm-project/commit/852b6486246141e44cc9f126f542a2ae0d73b3d6
- https://github.com/llvm/llvm-project/commit/d1297638a381c4c7da93af4cd48173f4cef4252d
- https://github.com/llvm/llvm-project/commit/bf25ecb6caff22ac7f3e44a396fb2e5aa830db49

https://github.com/llvm/llvm-project/commit/852b6486246141e44cc9f126f542a2ae0d73b3d6 breaks the stablehlo build. We need to wait stablehlo bumping LLVM ahead of it and fix the issue. Then we can bump stablehlo and drop the local commit together.

https://github.com/llvm/llvm-project/commit/d1297638a381c4c7da93af4cd48173f4cef4252d is the corresponding change to https://github.com/llvm/llvm-project/commit/852b6486246141e44cc9f126f542a2ae0d73b3d6, so they are reverted altogether.