### PR TITLE
[VectorExt] Fix to_layout op

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_contract_amdgpu.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_contract_amdgpu.mlir
@@ -43,9 +43,9 @@
 >
 
 func.func @contract_to_mfma_32x32x8_mm(%a : vector<32x8xf16>, %b : vector<8x32xf16>, %c : vector<32x32xf32>) -> vector<32x32xf32> {
-  %A = iree_vector_ext.to_layout %a to #layout_a : vector<32x8xf16>
-  %B = iree_vector_ext.to_layout %b to #layout_b : vector<8x32xf16>
-  %C = iree_vector_ext.to_layout %c to #layout_c : vector<32x32xf32>
+  %A = iree_vector_ext.to_layout %a to layout(#layout_a) : vector<32x8xf16>
+  %B = iree_vector_ext.to_layout %b to layout(#layout_b) : vector<8x32xf16>
+  %C = iree_vector_ext.to_layout %c to layout(#layout_c) : vector<32x32xf32>
 
   %output = vector.contract {
     indexing_maps = [#map1, #map2, #map3],
@@ -54,7 +54,7 @@ func.func @contract_to_mfma_32x32x8_mm(%a : vector<32x8xf16>, %b : vector<8x32xf
     iree.amdgpu.mma = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>
   } %A, %B, %C : vector<32x8xf16>, vector<8x32xf16> into vector<32x32xf32>
 
-  %O = iree_vector_ext.to_layout %output to #layout_c : vector<32x32xf32>
+  %O = iree_vector_ext.to_layout %output to layout(#layout_c) : vector<32x32xf32>
   return %O : vector<32x32xf32>
 }
 
@@ -120,9 +120,9 @@ builtin.module attributes { transform.with_named_sequence } {
 // C: shape = 16x16, layout = layoutB
 
 func.func @contract_to_mfma_16x16x16_mm(%a : vector<16x16xf16>, %b : vector<16x16xf16>, %c : vector<16x16xf32>) -> vector<16x16xf32> {
-  %A = iree_vector_ext.to_layout %a to #layout_a : vector<16x16xf16>
-  %B = iree_vector_ext.to_layout %b to #layout_b : vector<16x16xf16>
-  %C = iree_vector_ext.to_layout %c to #layout_b : vector<16x16xf32>
+  %A = iree_vector_ext.to_layout %a to layout(#layout_a) : vector<16x16xf16>
+  %B = iree_vector_ext.to_layout %b to layout(#layout_b) : vector<16x16xf16>
+  %C = iree_vector_ext.to_layout %c to layout(#layout_b) : vector<16x16xf32>
 
   %output = vector.contract {
     indexing_maps = [#map1, #map2, #map3],
@@ -131,7 +131,7 @@ func.func @contract_to_mfma_16x16x16_mm(%a : vector<16x16xf16>, %b : vector<16x1
     iree.amdgpu.mma = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>
   } %A, %B, %C : vector<16x16xf16>, vector<16x16xf16> into vector<16x16xf32>
 
-  %O = iree_vector_ext.to_layout %output to #layout_b : vector<16x16xf32>
+  %O = iree_vector_ext.to_layout %output to layout(#layout_b) : vector<16x16xf32>
   return %O : vector<16x16xf32>
 }
 
@@ -208,9 +208,9 @@ builtin.module attributes { transform.with_named_sequence } {
 >
 
 func.func @contract_to_mfma_32x32x8_mm_mnbatch(%a : vector<64x8xf16>, %b : vector<8x32xf16>, %c : vector<64x32xf32>) -> vector<64x32xf32> {
-  %A = iree_vector_ext.to_layout %a to #layout_a : vector<64x8xf16>
-  %B = iree_vector_ext.to_layout %b to #layout_b : vector<8x32xf16>
-  %C = iree_vector_ext.to_layout %c to #layout_c : vector<64x32xf32>
+  %A = iree_vector_ext.to_layout %a to layout(#layout_a) : vector<64x8xf16>
+  %B = iree_vector_ext.to_layout %b to layout(#layout_b) : vector<8x32xf16>
+  %C = iree_vector_ext.to_layout %c to layout(#layout_c) : vector<64x32xf32>
 
   %output = vector.contract {
     indexing_maps = [#map1, #map2, #map3],
@@ -219,7 +219,7 @@ func.func @contract_to_mfma_32x32x8_mm_mnbatch(%a : vector<64x8xf16>, %b : vecto
     iree.amdgpu.mma = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>
   } %A, %B, %C : vector<64x8xf16>, vector<8x32xf16> into vector<64x32xf32>
 
-  %O = iree_vector_ext.to_layout %output to #layout_c : vector<64x32xf32>
+  %O = iree_vector_ext.to_layout %output to layout(#layout_c) : vector<64x32xf32>
   return %O : vector<64x32xf32>
 }
 
@@ -297,9 +297,9 @@ builtin.module attributes { transform.with_named_sequence } {
 >
 
 func.func @contract_to_mfma_32x32x8_mm_kbatch(%a : vector<32x16xf16>, %b : vector<16x32xf16>, %c : vector<32x32xf32>) -> vector<32x32xf32> {
-  %A = iree_vector_ext.to_layout %a to #layout_a : vector<32x16xf16>
-  %B = iree_vector_ext.to_layout %b to #layout_b : vector<16x32xf16>
-  %C = iree_vector_ext.to_layout %c to #layout_c : vector<32x32xf32>
+  %A = iree_vector_ext.to_layout %a to layout(#layout_a) : vector<32x16xf16>
+  %B = iree_vector_ext.to_layout %b to layout(#layout_b) : vector<16x32xf16>
+  %C = iree_vector_ext.to_layout %c to layout(#layout_c) : vector<32x32xf32>
 
   %output = vector.contract {
     indexing_maps = [#map1, #map2, #map3],
@@ -308,7 +308,7 @@ func.func @contract_to_mfma_32x32x8_mm_kbatch(%a : vector<32x16xf16>, %b : vecto
     iree.amdgpu.mma = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>
   } %A, %B, %C : vector<32x16xf16>, vector<16x32xf16> into vector<32x32xf32>
 
-  %O = iree_vector_ext.to_layout %output to #layout_c : vector<32x32xf32>
+  %O = iree_vector_ext.to_layout %output to layout(#layout_c) : vector<32x32xf32>
   return %O : vector<32x32xf32>
 }
 
@@ -380,9 +380,9 @@ builtin.module attributes { transform.with_named_sequence } {
 >
 
 func.func @contract_to_mfma_32x32x8_mm_mnbatch_order(%a : vector<64x8xf16>, %b : vector<8x96xf16>, %c : vector<64x96xf32>) -> vector<64x96xf32> {
-  %A = iree_vector_ext.to_layout %a to #layout_a : vector<64x8xf16>
-  %B = iree_vector_ext.to_layout %b to #layout_b : vector<8x96xf16>
-  %C = iree_vector_ext.to_layout %c to #layout_c : vector<64x96xf32>
+  %A = iree_vector_ext.to_layout %a to layout(#layout_a) : vector<64x8xf16>
+  %B = iree_vector_ext.to_layout %b to layout(#layout_b) : vector<8x96xf16>
+  %C = iree_vector_ext.to_layout %c to layout(#layout_c) : vector<64x96xf32>
 
   %output = vector.contract {
     indexing_maps = [#map1, #map2, #map3],
@@ -391,7 +391,7 @@ func.func @contract_to_mfma_32x32x8_mm_mnbatch_order(%a : vector<64x8xf16>, %b :
     iree.amdgpu.mma = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>
   } %A, %B, %C : vector<64x8xf16>, vector<8x96xf16> into vector<64x96xf32>
 
-  %O = iree_vector_ext.to_layout %output to #layout_c : vector<64x96xf32>
+  %O = iree_vector_ext.to_layout %output to layout(#layout_c) : vector<64x96xf32>
   return %O : vector<64x96xf32>
 }
 
@@ -471,9 +471,9 @@ builtin.module attributes { transform.with_named_sequence } {
 >
 
 func.func @contract_to_mfma_32x32x8_mmt(%a : vector<32x8xf16>, %b : vector<64x8xf16>, %c : vector<32x64xf32>) -> vector<32x64xf32> {
-  %A = iree_vector_ext.to_layout %a to #layout_a : vector<32x8xf16>
-  %B = iree_vector_ext.to_layout %b to #layout_b : vector<64x8xf16>
-  %C = iree_vector_ext.to_layout %c to #layout_c : vector<32x64xf32>
+  %A = iree_vector_ext.to_layout %a to layout(#layout_a) : vector<32x8xf16>
+  %B = iree_vector_ext.to_layout %b to layout(#layout_b) : vector<64x8xf16>
+  %C = iree_vector_ext.to_layout %c to layout(#layout_c) : vector<32x64xf32>
 
   %output = vector.contract {
     indexing_maps = [#map1, #map2, #map3],
@@ -482,7 +482,7 @@ func.func @contract_to_mfma_32x32x8_mmt(%a : vector<32x8xf16>, %b : vector<64x8x
     iree.amdgpu.mma = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>
   } %A, %B, %C : vector<32x8xf16>, vector<64x8xf16> into vector<32x64xf32>
 
-  %O = iree_vector_ext.to_layout %output to #layout_c : vector<32x64xf32>
+  %O = iree_vector_ext.to_layout %output to layout(#layout_c) : vector<32x64xf32>
   return %O : vector<32x64xf32>
 }
 
@@ -550,9 +550,9 @@ builtin.module attributes { transform.with_named_sequence } {
 >
 
 func.func @contract_to_wmma_16x16x16_mm(%a : vector<16x16xf16>, %b : vector<16x16xf16>, %c : vector<16x16xf32>) -> vector<16x16xf32> {
-  %A = iree_vector_ext.to_layout %a to #layout_a : vector<16x16xf16>
-  %B = iree_vector_ext.to_layout %b to #layout_b : vector<16x16xf16>
-  %C = iree_vector_ext.to_layout %c to #layout_c : vector<16x16xf32>
+  %A = iree_vector_ext.to_layout %a to layout(#layout_a) : vector<16x16xf16>
+  %B = iree_vector_ext.to_layout %b to layout(#layout_b) : vector<16x16xf16>
+  %C = iree_vector_ext.to_layout %c to layout(#layout_c) : vector<16x16xf32>
 
   %output = vector.contract {
     indexing_maps = [#map1, #map2, #map3],
@@ -561,7 +561,7 @@ func.func @contract_to_wmma_16x16x16_mm(%a : vector<16x16xf16>, %b : vector<16x1
     iree.amdgpu.mma = #iree_gpu.mma_layout<WMMA_F32_16x16x16_F16>
   } %A, %B, %C : vector<16x16xf16>, vector<16x16xf16> into vector<16x16xf32>
 
-  %O = iree_vector_ext.to_layout %output to #layout_c : vector<16x16xf32>
+  %O = iree_vector_ext.to_layout %output to layout(#layout_c) : vector<16x16xf32>
   return %O : vector<16x16xf32>
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
@@ -20,7 +20,7 @@ func.func @distribute_transfer_read_col_major(%arg0: memref<32x32xf16>) -> vecto
   %cst = arith.constant 0.0 : f16
   %root = vector.transfer_read %arg0[%c0, %c0], %cst {in_bounds = [true, true]}
                   : memref<32x32xf16>, vector<16x16xf16>
-  %rootl = iree_vector_ext.to_layout %root to #layout_col_major : vector<16x16xf16>
+  %rootl = iree_vector_ext.to_layout %root to layout(#layout_col_major) : vector<16x16xf16>
   func.return %rootl : vector<16x16xf16>
 }
 
@@ -66,7 +66,7 @@ func.func @distribute_transfer_read_row_major_with_nontrivial_index(%a: index, %
           {in_bounds = [true, true],
            permutation_map = affine_map<(d0, d1, d2, d3) -> (d2, d3)>}
                   : memref<32x32x32x32xf16>, vector<16x16xf16>
-  %rootl = iree_vector_ext.to_layout %root to #layout_row_major : vector<16x16xf16>
+  %rootl = iree_vector_ext.to_layout %root to layout(#layout_row_major) : vector<16x16xf16>
   func.return %rootl : vector<16x16xf16>
 }
 
@@ -109,7 +109,7 @@ func.func @distribute_transfer_read_col_major_with_broadcast(%a: index, %b: inde
           {in_bounds = [true, true],
            permutation_map = affine_map<(d0, d1, d2, d3) -> (0, 0)>}
                   : memref<32x32x32x32xf16>, vector<16x16xf16>
-  %rootl = iree_vector_ext.to_layout %root to #layout_col_major : vector<16x16xf16>
+  %rootl = iree_vector_ext.to_layout %root to layout(#layout_col_major) : vector<16x16xf16>
   func.return %rootl : vector<16x16xf16>
 }
 
@@ -155,7 +155,7 @@ func.func @distribute_transfer_read_row_major_transpose(%a: index, %b: index, %a
           {in_bounds = [true, true],
            permutation_map = affine_map<(d0, d1, d2, d3) -> (d3, d2)>}
                   : memref<32x32x32x32xf16>, vector<16x16xf16>
-  %rootl = iree_vector_ext.to_layout %root to #layout_row_major : vector<16x16xf16>
+  %rootl = iree_vector_ext.to_layout %root to layout(#layout_row_major) : vector<16x16xf16>
   func.return %rootl : vector<16x16xf16>
 }
 
@@ -202,7 +202,7 @@ func.func @distribute_transfer_read_col_major_transpose(%a: index, %b: index, %a
           {in_bounds = [true, true],
            permutation_map = affine_map<(d0, d1, d2, d3) -> (d3, d2)>}
                   : memref<32x32x32x32xf16>, vector<16x16xf16>
-  %rootl = iree_vector_ext.to_layout %root to #layout_col_major : vector<16x16xf16>
+  %rootl = iree_vector_ext.to_layout %root to layout(#layout_col_major) : vector<16x16xf16>
   func.return %rootl : vector<16x16xf16>
 }
 
@@ -237,7 +237,7 @@ func.func @distribute_transfer_read_row_major_with_permutations(%a: index, %b: i
           {in_bounds = [true, true, true, true],
            permutation_map = affine_map<(d0, d1, d2, d3) -> (d0, d3, 0, d1)>}
                   : memref<32x32x32x32xf16>, vector<21x15x8x16xf16>
-  %rootl = iree_vector_ext.to_layout %root to #layout : vector<21x15x8x16xf16>
+  %rootl = iree_vector_ext.to_layout %root to layout(#layout) : vector<21x15x8x16xf16>
   func.return %rootl : vector<21x15x8x16xf16>
 }
 
@@ -276,7 +276,7 @@ func.func @distribute_transfer_read_broadcast(%arg0: memref<32x32xf16>) -> vecto
   %cst = arith.constant 0.0 : f16
   %root = vector.transfer_read %arg0[%c0, %c0], %cst
           {in_bounds = [true]} : memref<32x32xf16>, vector<16xf16>
-  %rootl = iree_vector_ext.to_layout %root to #layout : vector<16xf16>
+  %rootl = iree_vector_ext.to_layout %root to layout(#layout) : vector<16xf16>
   func.return %rootl : vector<16xf16>
 }
 
@@ -313,7 +313,7 @@ func.func @distribute_transfer_read_broadcast2(%arg0: memref<32x128xf16>) -> vec
   %cst = arith.constant 0.0 : f16
   %root = vector.transfer_read %arg0[%c0, %c0], %cst
           {in_bounds = [true]} : memref<32x128xf16>, vector<128xf16>
-  %rootl = iree_vector_ext.to_layout %root to #layout : vector<128xf16>
+  %rootl = iree_vector_ext.to_layout %root to layout(#layout) : vector<128xf16>
   func.return %rootl : vector<128xf16>
 }
 
@@ -348,7 +348,7 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK-LABEL: @distribute_transfer_write_row_major
 func.func @distribute_transfer_write_row_major(%root: vector<16x16xf16>, %alloc: memref<64x64xf16>) {
   %c0 = arith.constant 0 : index
-  %rootl = iree_vector_ext.to_layout %root to #layout_row_major : vector<16x16xf16>
+  %rootl = iree_vector_ext.to_layout %root to layout(#layout_row_major) : vector<16x16xf16>
   vector.transfer_write %rootl, %alloc[%c0, %c0]
           {in_bounds = [true, true]}
                   : vector<16x16xf16>, memref<64x64xf16>
@@ -395,7 +395,7 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK-LABEL: @distribute_transfer_write_col_major
 func.func @distribute_transfer_write_col_major(%root: vector<16x16xf16>, %alloc: memref<64x64xf16>) {
   %c0 = arith.constant 0 : index
-  %rootl = iree_vector_ext.to_layout %root to #layout_col_major : vector<16x16xf16>
+  %rootl = iree_vector_ext.to_layout %root to layout(#layout_col_major) : vector<16x16xf16>
   vector.transfer_write %rootl, %alloc[%c0, %c0]
           {in_bounds = [true, true]}
                   : vector<16x16xf16>, memref<64x64xf16>
@@ -439,7 +439,7 @@ builtin.module attributes { transform.with_named_sequence } {
 
 func.func @distribute_transfer_write_row_major_with_nontrivial_index(%root: vector<16x16xf16>, %a: index, %b: index, %alloc: memref<32x32x32x32xf16>) {
   %c0 = arith.constant 0 : index
-  %rootl = iree_vector_ext.to_layout %root to #layout_row_major : vector<16x16xf16>
+  %rootl = iree_vector_ext.to_layout %root to layout(#layout_row_major) : vector<16x16xf16>
   vector.transfer_write %rootl, %alloc[%c0, %c0, %a, %b]
           {in_bounds = [true, true],
            permutation_map = affine_map<(d0, d1, d2, d3) -> (d3, d2)>}
@@ -494,7 +494,7 @@ func.func @distribute_transfer_read_write(%a: index, %b: index,
            permutation_map = affine_map<(d0, d1, d2, d3) -> (d2, d3)>}
                   : memref<32x32x32x32xf16>, vector<16x16xf16>
 
-  %rootl = iree_vector_ext.to_layout %root to #layout_row_major : vector<16x16xf16>
+  %rootl = iree_vector_ext.to_layout %root to layout(#layout_row_major) : vector<16x16xf16>
 
   vector.transfer_write %rootl, %arg1[%c0, %c0, %a, %b]
           {in_bounds = [true, true],
@@ -608,9 +608,9 @@ func.func @mfma_64x128x8_read(%mem: memref<128x8xf16>,
           {in_bounds = [true, true]}
   : memref<128x64xf16>, vector<128x64xf16>
 
-  %A = iree_vector_ext.to_layout %a to #layout_a : vector<128x8xf16>
-  %B = iree_vector_ext.to_layout %b to #layout_b : vector<8x64xf16>
-  %C = iree_vector_ext.to_layout %c to #layout_c : vector<128x64xf16>
+  %A = iree_vector_ext.to_layout %a to layout(#layout_a) : vector<128x8xf16>
+  %B = iree_vector_ext.to_layout %b to layout(#layout_b) : vector<8x64xf16>
+  %C = iree_vector_ext.to_layout %c to layout(#layout_c) : vector<128x64xf16>
 
   return %A, %B, %C : vector<128x8xf16>, vector<8x64xf16>, vector<128x64xf16>
 }
@@ -645,7 +645,7 @@ func.func @transposed_read_64x8(%mem: memref<8x64xf16>)
   %read = vector.transfer_read %mem[%c0, %c0], %cst
           {in_bounds = [true, true], permutation_map = affine_map<(d0, d1) -> (d1, d0)>}
   : memref<8x64xf16>, vector<64x8xf16>
-  %readl = iree_vector_ext.to_layout %read to #layout : vector<64x8xf16>
+  %readl = iree_vector_ext.to_layout %read to layout(#layout) : vector<64x8xf16>
 
   return %readl : vector<64x8xf16>
 }
@@ -683,7 +683,7 @@ builtin.module attributes { transform.with_named_sequence } {
 func.func @broadcast(%src: vector<128xf16>) -> (vector<64x128xf16>) {
   %bcast = vector.broadcast %src
     : vector<128xf16> to vector<64x128xf16>
-  %bcastl = iree_vector_ext.to_layout %bcast to #layout : vector<64x128xf16>
+  %bcastl = iree_vector_ext.to_layout %bcast to layout(#layout) : vector<64x128xf16>
   return %bcastl : vector<64x128xf16>
 }
 
@@ -727,7 +727,7 @@ builtin.module attributes { transform.with_named_sequence } {
 func.func @broadcast(%src: vector<64xf16>) -> (vector<32x256x64xf16>) {
   %bcast = vector.broadcast %src
     : vector<64xf16> to vector<32x256x64xf16>
-  %bcastl = iree_vector_ext.to_layout %bcast to #layout : vector<32x256x64xf16>
+  %bcastl = iree_vector_ext.to_layout %bcast to layout(#layout) : vector<32x256x64xf16>
   return %bcastl : vector<32x256x64xf16>
 }
 
@@ -764,7 +764,7 @@ builtin.module attributes { transform.with_named_sequence } {
 
 func.func @scalar_broadcast(%src: f16) -> (vector<32x256x64xf16>) {
   %bcast = vector.broadcast %src : f16 to vector<32x256x64xf16>
-  %bcastl = iree_vector_ext.to_layout %bcast to #layout : vector<32x256x64xf16>
+  %bcastl = iree_vector_ext.to_layout %bcast to layout(#layout) : vector<32x256x64xf16>
   return %bcastl : vector<32x256x64xf16>
 }
 
@@ -796,7 +796,7 @@ builtin.module attributes { transform.with_named_sequence } {
 func.func @transpose(%src: vector<256x64xf16>) -> (vector<64x256xf16>) {
   %transp = vector.transpose %src, [1, 0]
     : vector<256x64xf16> to vector<64x256xf16>
-  %transpl = iree_vector_ext.to_layout %transp to #layout : vector<64x256xf16>
+  %transpl = iree_vector_ext.to_layout %transp to layout(#layout) : vector<64x256xf16>
   %sqrt = math.sqrt %transpl : vector<64x256xf16>
   return %sqrt : vector<64x256xf16>
 }
@@ -828,7 +828,7 @@ builtin.module attributes { transform.with_named_sequence } {
 >
 
 func.func @transpose(%src: vector<64x256xf16>) -> (vector<256x64xf16>) {
-  %srcl = iree_vector_ext.to_layout %src to #layout : vector<64x256xf16>
+  %srcl = iree_vector_ext.to_layout %src to layout(#layout) : vector<64x256xf16>
   %transp = vector.transpose %srcl, [1, 0]
     : vector<64x256xf16> to vector<256x64xf16>
   %sqrt = math.sqrt %transp : vector<256x64xf16>
@@ -879,7 +879,7 @@ func.func @transpose_3d(%arr: memref<32x32x32xf16>) -> () {
   %root = vector.transfer_read %arr[%c0, %c0, %c0], %cst_0 {
     in_bounds = [true, true, true]
   } : memref<32x32x32xf16>, vector<32x16x16xf16>
-  %rootl = iree_vector_ext.to_layout %root to #layout : vector<32x16x16xf16>
+  %rootl = iree_vector_ext.to_layout %root to layout(#layout) : vector<32x16x16xf16>
   %t = vector.transpose %rootl, [1, 2, 0] : vector<32x16x16xf16> to vector<16x16x32xf16>
   vector.transfer_write %t, %arr[%c0, %c0, %c0] {in_bounds = [true, true, true]} : vector<16x16x32xf16>, memref<32x32x32xf16>
   func.return
@@ -949,7 +949,7 @@ builtin.module attributes { transform.with_named_sequence } {
 >
 
 func.func @mfma_16x16x16_out_reduced_dim1(%arg0: vector<32x32xf32>, %arg1: vector<32xf32>) -> vector<32xf32> {
-  %arg0l = iree_vector_ext.to_layout %arg0 to #nested : vector<32x32xf32>
+  %arg0l = iree_vector_ext.to_layout %arg0 to layout(#nested) : vector<32x32xf32>
   %0 = vector.multi_reduction <maximumf>, %arg0l, %arg1 [1] : vector<32x32xf32> to vector<32xf32>
   return %0 : vector<32xf32>
 }
@@ -992,7 +992,7 @@ builtin.module attributes { transform.with_named_sequence } {
 >
 
 func.func @mfma_32x32x8_out_reduced_dim1(%arg0: vector<32x32xf32>, %arg1: vector<32xf32>) -> vector<32xf32> {
-  %arg0l = iree_vector_ext.to_layout %arg0 to #nested : vector<32x32xf32>
+  %arg0l = iree_vector_ext.to_layout %arg0 to layout(#nested) : vector<32x32xf32>
   %0 = vector.multi_reduction <maximumf>, %arg0l, %arg1 [1] : vector<32x32xf32> to vector<32xf32>
   return %0 : vector<32xf32>
 }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_alloc.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_alloc.mlir
@@ -12,7 +12,7 @@
 >
 
 func.func @test(%vector: vector<16x16xf16>) -> vector<16x16xf16> {
-  %out = iree_vector_ext.to_layout %vector to #layout {shared_memory_conversion} : vector<16x16xf16>
+  %out = iree_vector_ext.to_layout %vector to layout(#layout) {shared_memory_conversion} : vector<16x16xf16>
   return %out : vector<16x16xf16>
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_vector_distribution.mlir
@@ -8,7 +8,7 @@ func.func @distribute_elementwise_f16(%a: vector<16x16xf16>, %b: vector<16x16xf1
   %cst_0 = arith.constant 0.0 : f16
   // CHECK: %[[ROOT:.*]] = arith.constant dense<0.000000e+00> : vector<16xf16>
   %root = arith.constant dense<0.0> : vector<16x16xf16>
-  %rootl = iree_vector_ext.to_layout %root to #layout : vector<16x16xf16>
+  %rootl = iree_vector_ext.to_layout %root to layout(#layout) : vector<16x16xf16>
   // CHECK-DAG: %[[B:.*]] = iree_vector_ext.to_simt %{{.*}} : vector<16x16xf16> -> vector<16xf16>
   // CHECK-DAG: %[[C:.*]] = arith.mulf %[[B]], %[[ROOT]] {{.*}} : vector<16xf16>
   %c = arith.mulf %rootl, %b : vector<16x16xf16>
@@ -30,7 +30,7 @@ func.func @distribute_elementwise_i32(%a: vector<16x16xi32>, %b: vector<16x16xi3
   %cst_0 = arith.constant 0 : i32
   // CHECK: %[[ROOT:.*]] = arith.constant dense<2> : vector<16xi32>
   %root = arith.constant dense<2> : vector<16x16xi32>
-  %rootl = iree_vector_ext.to_layout %root to #layout : vector<16x16xi32>
+  %rootl = iree_vector_ext.to_layout %root to layout(#layout) : vector<16x16xi32>
   // CHECK-DAG: %[[B:.*]] = iree_vector_ext.to_simt %{{.*}} : vector<16x16xi32> -> vector<16xi32>
   // CHECK-DAG: %[[C:.*]] = arith.muli %[[B]], %[[ROOT]] {{.*}} : vector<16xi32>
   %c = arith.muli %rootl, %b : vector<16x16xi32>
@@ -58,7 +58,7 @@ func.func @distribute_elementwise_nested_layout_f16(%a: vector<128x128x128xf16>,
   %cst_0 = arith.constant 0.0 : f16
   // CHECK: %[[ROOT:.*]] = arith.constant dense<0.000000e+00> : vector<8x2x4x1x4x4x1x8x2xf16>
   %root = arith.constant dense<0.0> : vector<128x128x128xf16>
-  %rootl = iree_vector_ext.to_layout %root to #nested : vector<128x128x128xf16>
+  %rootl = iree_vector_ext.to_layout %root to layout(#nested) : vector<128x128x128xf16>
   // CHECK-DAG: %[[B:.*]] = iree_vector_ext.to_simt %{{.*}} : vector<128x128x128xf16> -> vector<8x2x4x1x4x4x1x8x2xf16>
   // CHECK-DAG: %[[C:.*]] = arith.mulf %[[B]], %[[ROOT]] {{.*}} : vector<8x2x4x1x4x4x1x8x2xf16>
   %c = arith.mulf %rootl, %b : vector<128x128x128xf16>
@@ -77,7 +77,7 @@ func.func @distribute_scf_for(%a: vector<16x16xi32>, %b: vector<16x16xi32>) -> v
   %cst_0 = arith.constant 0 : i32
   // CHECK: %[[ROOT:.*]] = arith.constant dense<0> : vector<16xi32>
   %root = arith.constant dense<0> : vector<16x16xi32>
-  %rootl = iree_vector_ext.to_layout %root to #layout : vector<16x16xi32>
+  %rootl = iree_vector_ext.to_layout %root to layout(#layout) : vector<16x16xi32>
   // CHECK: iter_args(%[[ARG0:.*]] = %[[ROOT]]) -> (vector<16xi32>)
   %out = scf.for %i = %c0 to %c128 step %c1 iter_args(%arg0 = %rootl) -> (vector<16x16xi32>) {
     // These should be ideally folded if canonicalization was ever ran.
@@ -115,7 +115,7 @@ func.func @distribute_transfer_read_row_major(%alloc: memref<4x4xf16>) -> vector
   %root = vector.transfer_read %alloc[%c0, %c0], %cst
           {in_bounds = [false, false]}
                   : memref<4x4xf16>, vector<16x16xf16>
-  %rootl = iree_vector_ext.to_layout %root to #layout_row_major : vector<16x16xf16>
+  %rootl = iree_vector_ext.to_layout %root to layout(#layout_row_major) : vector<16x16xf16>
   // CHECK-COUNT-4: vector.load {{.*}}, vector<8xf16>
   func.return %rootl : vector<16x16xf16>
 }
@@ -127,7 +127,7 @@ func.func @distribute_transfer_read_col_major(%alloc: memref<32x32xf16>) -> vect
   %root = vector.transfer_read %alloc[%c0, %c0], %cst
           {in_bounds = [true, true]}
                   : memref<32x32xf16>, vector<16x16xf16>
-  %rootl = iree_vector_ext.to_layout %root to #layout_col_major : vector<16x16xf16>
+  %rootl = iree_vector_ext.to_layout %root to layout(#layout_col_major) : vector<16x16xf16>
   // CHECK-COUNT-8: vector.load {{.*}}, vector<1xf16>
   func.return %rootl : vector<16x16xf16>
 }
@@ -140,7 +140,7 @@ func.func @distribute_transfer_read_row_major_with_broadcast(%a: index, %b: inde
           {in_bounds = [true, true],
            permutation_map = affine_map<(d0, d1, d2, d3) -> (d2, d3)>}
                   : memref<32x32x32x32xf16>, vector<16x16xf16>
-  %rootl = iree_vector_ext.to_layout %root to #layout_row_major : vector<16x16xf16>
+  %rootl = iree_vector_ext.to_layout %root to layout(#layout_row_major) : vector<16x16xf16>
   // CHECK-COUNT-4: vector.load {{.*}}, vector<8xf16>
   func.return %rootl : vector<16x16xf16>
 }
@@ -153,7 +153,7 @@ func.func @distribute_transfer_read_col_major_with_broadcast(%a: index, %b: inde
           {in_bounds = [true, true],
            permutation_map = affine_map<(d0, d1, d2, d3) -> (d2, d3)>}
                   : memref<32x32x32x32xf16>, vector<16x16xf16>
-  %rootl = iree_vector_ext.to_layout %root to #layout_col_major : vector<16x16xf16>
+  %rootl = iree_vector_ext.to_layout %root to layout(#layout_col_major) : vector<16x16xf16>
   // CHECK-COUNT-8: vector.load {{.*}}, vector<1xf16>
   func.return %rootl : vector<16x16xf16>
 }
@@ -166,7 +166,7 @@ func.func @distribute_transfer_read_row_major_transpose(%a: index, %b: index, %a
           {in_bounds = [true, true],
            permutation_map = affine_map<(d0, d1, d2, d3) -> (d3, d2)>}
                   : memref<32x32x32x32xf16>, vector<16x16xf16>
-  %rootl = iree_vector_ext.to_layout %root to #layout_row_major : vector<16x16xf16>
+  %rootl = iree_vector_ext.to_layout %root to layout(#layout_row_major) : vector<16x16xf16>
   // CHECK-COUNT-32: vector.load {{.*}}, vector<1xf16>
   func.return %rootl : vector<16x16xf16>
 }
@@ -179,7 +179,7 @@ func.func @distribute_transfer_read_col_major_transpose(%a: index, %b: index, %a
           {in_bounds = [true, true],
            permutation_map = affine_map<(d0, d1, d2, d3) -> (d3, d2)>}
                   : memref<32x32x32x32xf16>, vector<16x16xf16>
-  %rootl = iree_vector_ext.to_layout %root to #layout_col_major : vector<16x16xf16>
+  %rootl = iree_vector_ext.to_layout %root to layout(#layout_col_major) : vector<16x16xf16>
   // CHECK-COUNT-2: vector.load {{.*}}, vector<4xf16>
   func.return %rootl : vector<16x16xf16>
 }
@@ -202,7 +202,7 @@ builtin.module attributes { transform.with_named_sequence } {
 
 func.func @distribute_transfer_write_row_major(%root: vector<16x16xf16>, %alloc: memref<64x64xf16>) {
   %c0 = arith.constant 0 : index
-  %rootl = iree_vector_ext.to_layout %root to #layout_row_major : vector<16x16xf16>
+  %rootl = iree_vector_ext.to_layout %root to layout(#layout_row_major) : vector<16x16xf16>
   vector.transfer_write %rootl, %alloc[%c0, %c0]
           {in_bounds = [true, true]}
                   : vector<16x16xf16>, memref<64x64xf16>
@@ -232,7 +232,7 @@ func.func @distribute_transfer_write_row_major(%root: vector<16x16xf16>, %alloc:
 
 func.func @distribute_transfer_write_col_major(%root: vector<16x16xf16>, %alloc: memref<64x64xf16>) {
   %c0 = arith.constant 0 : index
-  %rootl = iree_vector_ext.to_layout %root to #layout_col_major : vector<16x16xf16>
+  %rootl = iree_vector_ext.to_layout %root to layout(#layout_col_major) : vector<16x16xf16>
   vector.transfer_write %rootl, %alloc[%c0, %c0]
           {in_bounds = [true, true]}
                   : vector<16x16xf16>, memref<64x64xf16>
@@ -243,7 +243,7 @@ func.func @distribute_transfer_write_col_major(%root: vector<16x16xf16>, %alloc:
 
 func.func @distribute_transfer_write_row_major_with_broadcast(%root: vector<16x16xf16>, %a: index, %b: index, %alloc: memref<32x32x32x32xf16>) {
   %c0 = arith.constant 0 : index
-  %rootl = iree_vector_ext.to_layout %root to #layout_row_major : vector<16x16xf16>
+  %rootl = iree_vector_ext.to_layout %root to layout(#layout_row_major) : vector<16x16xf16>
   vector.transfer_write %rootl, %alloc[%c0, %c0, %a, %b]
           {in_bounds = [true, true],
            permutation_map = affine_map<(d0, d1, d2, d3) -> (d2, d3)>}
@@ -255,7 +255,7 @@ func.func @distribute_transfer_write_row_major_with_broadcast(%root: vector<16x1
 
 func.func @distribute_transfer_write_col_major_with_broadcast(%root: vector<16x16xf16>, %a: index, %b: index, %alloc: memref<32x32x32x32xf16>) {
   %c0 = arith.constant 0 : index
-  %rootl = iree_vector_ext.to_layout %root to #layout_col_major : vector<16x16xf16>
+  %rootl = iree_vector_ext.to_layout %root to layout(#layout_col_major) : vector<16x16xf16>
   vector.transfer_write %rootl, %alloc[%c0, %c0, %a, %b]
           {in_bounds = [true, true],
            permutation_map = affine_map<(d0, d1, d2, d3) -> (d2, d3)>}
@@ -267,7 +267,7 @@ func.func @distribute_transfer_write_col_major_with_broadcast(%root: vector<16x1
 
 func.func @distribute_transfer_write_row_major_transpose(%root: vector<16x16xf16>, %a: index, %b: index, %alloc: memref<32x32x32x32xf16>) {
   %c0 = arith.constant 0 : index
-  %rootl = iree_vector_ext.to_layout %root to #layout_row_major : vector<16x16xf16>
+  %rootl = iree_vector_ext.to_layout %root to layout(#layout_row_major) : vector<16x16xf16>
   vector.transfer_write %rootl, %alloc[%c0, %c0, %a, %b]
           {in_bounds = [true, true],
            permutation_map = affine_map<(d0, d1, d2, d3) -> (d3, d2)>}
@@ -279,7 +279,7 @@ func.func @distribute_transfer_write_row_major_transpose(%root: vector<16x16xf16
 
 func.func @distribute_transfer_write_col_major_transpose(%root: vector<16x16xf16>, %a: index, %b: index, %alloc: memref<32x32x32x32xf16>) {
   %c0 = arith.constant 0 : index
-  %rootl = iree_vector_ext.to_layout %root to #layout_col_major : vector<16x16xf16>
+  %rootl = iree_vector_ext.to_layout %root to layout(#layout_col_major) : vector<16x16xf16>
   vector.transfer_write %rootl, %alloc[%c0, %c0, %a, %b]
           {in_bounds = [true, true],
            permutation_map = affine_map<(d0, d1, d2, d3) -> (d3, d2)>}
@@ -292,7 +292,7 @@ func.func @distribute_transfer_write_col_major_transpose(%root: vector<16x16xf16
 
 func.func @distribute_transfer_write_with_non_contiguous_broadcast(%root: vector<16x16xf16>, %a: index, %b: index, %alloc: memref<32x32x32x32xf16>) {
   %c0 = arith.constant 0 : index
-  %rootl = iree_vector_ext.to_layout %root to #layout_row_major : vector<16x16xf16>
+  %rootl = iree_vector_ext.to_layout %root to layout(#layout_row_major) : vector<16x16xf16>
   vector.transfer_write %rootl, %alloc[%c0, %a, %c0, %b]
           {in_bounds = [true, true],
            permutation_map = affine_map<(d0, d1, d2, d3) -> (d1, d3)>}
@@ -323,7 +323,7 @@ builtin.module attributes { transform.with_named_sequence } {
 module {
   func.func @distribute_reduction_f16(%source: vector<16x16xf16>, %init: vector<16xf16>) -> vector<16xf16>
   attributes {hal.executable.target = #executable_target_rocm_hsaco_fb, translation_info = #translation_info} {
-    %sourcel = iree_vector_ext.to_layout %source to #layout2d : vector<16x16xf16>
+    %sourcel = iree_vector_ext.to_layout %source to layout(#layout2d) : vector<16x16xf16>
     %result = vector.multi_reduction <maximumf>, %sourcel, %init [0]
                     : vector<16x16xf16> to vector<16xf16>
     func.return %result : vector<16xf16>
@@ -370,7 +370,7 @@ module {
 module {
   func.func @distribute_reduction_f32(%source: vector<16x16xf32>, %init: vector<16xf32>) -> vector<16xf32>
   attributes {hal.executable.target = #executable_target_rocm_hsaco_fb, translation_info = #translation_info} {
-    %sourcel = iree_vector_ext.to_layout %source to #layout2d : vector<16x16xf32>
+    %sourcel = iree_vector_ext.to_layout %source to layout(#layout2d) : vector<16x16xf32>
     %result = vector.multi_reduction <maximumf>, %sourcel, %init [0]
                 : vector<16x16xf32> to vector<16xf32>
     func.return %result : vector<16xf32>
@@ -425,7 +425,7 @@ func.func @distribute_transpose(%mem: memref<32x32xf16>, %mem1: memref<32x32xf16
   %b_t = vector.transpose %b, [1, 0] : vector<16x32xf16> to vector<32x16xf16>
   // CHECK: %[[ADD:.*]] = arith.addf %{{.*}}, %{{.*}} : vector<4xf16>
   %c = arith.addf %a, %b_t : vector<32x16xf16>
-  %cl = iree_vector_ext.to_layout %c to #transpose_test_layout : vector<32x16xf16>
+  %cl = iree_vector_ext.to_layout %c to layout(#transpose_test_layout) : vector<32x16xf16>
   // CHECK: iree_vector_ext.to_simd %[[ADD]] : vector<4xf16> -> vector<32x16xf16>
   func.return %cl : vector<32x16xf16>
 }
@@ -439,7 +439,7 @@ func.func @distribute_transpose(%mem: memref<32x32xf16>, %mem1: memref<32x32xf16
 
 func.func @distribute_broadcast_row_col(%source: vector<32xf32>) -> vector<32x32xf32> {
   %result = vector.broadcast %source : vector<32xf32> to vector<32x32xf32>
-  %resultl = iree_vector_ext.to_layout %result to #layout_broadcast_2d : vector<32x32xf32>
+  %resultl = iree_vector_ext.to_layout %result to layout(#layout_broadcast_2d) : vector<32x32xf32>
   // CHECK-DAG: %[[S00:.*]] = vector.extract %[[SOURCE:.*]][0, 0]
   // CHECK-DAG: vector.insert %[[S00]], %{{.*}} [0, 0, 0]
   // CHECK-DAG: vector.insert %[[S00]], %{{.*}} [1, 0, 0]
@@ -470,7 +470,7 @@ func.func @distribute_broadcast_row_col(%source: vector<32xf32>) -> vector<32x32
 
 func.func @distribute_broadcast_col_row(%source: vector<32xf32>) -> vector<32x32xf32> {
   %result = vector.broadcast %source : vector<32xf32> to vector<32x32xf32>
-  %resultl = iree_vector_ext.to_layout %result to #layout_broadcast_2d_t : vector<32x32xf32>
+  %resultl = iree_vector_ext.to_layout %result to layout(#layout_broadcast_2d_t) : vector<32x32xf32>
   // CHECK-DAG: %[[S0:.*]] = vector.extract %[[SOURCE:.*]][0]
   // CHECK-DAG: vector.insert %[[S0]], %{{.*}} [0, 0, 0]
   // CHECK-DAG: vector.insert %[[S0]], %{{.*}} [0, 0, 1]
@@ -508,7 +508,7 @@ func.func @distribute_broadcast_col_row(%source: vector<32xf32>) -> vector<32x32
 // needs to know the range of vectorx.
 func.func @distribute_broadcast_vectory(%source: vector<4xf32>) -> vector<4x4xf32> {
   %result = vector.broadcast %source : vector<4xf32> to vector<4x4xf32>
-  %resultl = iree_vector_ext.to_layout %result to #layout_broadcast_vectory_2d : vector<4x4xf32>
+  %resultl = iree_vector_ext.to_layout %result to layout(#layout_broadcast_vectory_2d) : vector<4x4xf32>
   // CHECK-DAG: %[[S00:.*]] = vector.extract %[[SOURCE:.*]][0, 0] : f32 from vector<1x4xf32>
   // CHECK-DAG: %[[S01:.*]] = vector.extract %[[SOURCE:.*]][0, 1] : f32 from vector<1x4xf32>
   // CHECK-DAG: %[[S02:.*]] = vector.extract %[[SOURCE:.*]][0, 2] : f32 from vector<1x4xf32>
@@ -573,9 +573,9 @@ func.func @resolve_wmma_layout_conflict_with_shared_memory(%15 : vector<16x16xf1
                                                                 workgroup_size = [32, 2, 1]
                                                                 subgroup_size = 32>} {
 
-  %A = iree_vector_ext.to_layout %15 to #layoutA : vector<16x16xf16>
-  %B = iree_vector_ext.to_layout %14 to #layoutB : vector<16x16xf16>
-  %C = iree_vector_ext.to_layout %16 to #layoutC : vector<16x16xf32>
+  %A = iree_vector_ext.to_layout %15 to layout(#layoutA) : vector<16x16xf16>
+  %B = iree_vector_ext.to_layout %14 to layout(#layoutB) : vector<16x16xf16>
+  %C = iree_vector_ext.to_layout %16 to layout(#layoutC) : vector<16x16xf32>
 
   %M1 = vector.contract {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
                                           affine_map<(d0, d1, d2) -> (d1, d2)>,
@@ -587,9 +587,9 @@ func.func @resolve_wmma_layout_conflict_with_shared_memory(%15 : vector<16x16xf1
 
   %TM1 = arith.truncf %M1 : vector<16x16xf32> to vector<16x16xf16>
 
-  %A2 = iree_vector_ext.to_layout %35  to #layoutA2 : vector<16x16xf16>
-  %B2 = iree_vector_ext.to_layout %TM1 to #layoutB2 : vector<16x16xf16>
-  %C2 = iree_vector_ext.to_layout %33  to #layoutC2 : vector<16x16xf32>
+  %A2 = iree_vector_ext.to_layout %35  to layout(#layoutA2) : vector<16x16xf16>
+  %B2 = iree_vector_ext.to_layout %TM1 to layout(#layoutB2) : vector<16x16xf16>
+  %C2 = iree_vector_ext.to_layout %33  to layout(#layoutC2) : vector<16x16xf32>
 
   %M2 = vector.contract {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
                                           affine_map<(d0, d1, d2) -> (d2, d1)>,
@@ -655,12 +655,12 @@ builtin.module attributes { transform.with_named_sequence } {
 
 builtin.module attributes { transform.with_named_sequence } {
   func.func @resolve_constant_with_multiple_layout_uses(%A : vector<64x64xf16>, %B : vector<64x64xf16>) -> vector<64x64xf16> {
-    %a = iree_vector_ext.to_layout %A to #layoutA : vector<64x64xf16>
-    %b = iree_vector_ext.to_layout %B to #layoutB : vector<64x64xf16>
+    %a = iree_vector_ext.to_layout %A to layout(#layoutA) : vector<64x64xf16>
+    %b = iree_vector_ext.to_layout %B to layout(#layoutB) : vector<64x64xf16>
     %zero = arith.constant dense<0.0> : vector<64x64xf16>
     %add_0 = arith.addf %a, %zero : vector<64x64xf16>
     %add_1 = arith.addf %b, %zero : vector<64x64xf16>
-    %layout_change = iree_vector_ext.to_layout %add_1 to #layoutA : vector<64x64xf16>
+    %layout_change = iree_vector_ext.to_layout %add_1 to layout(#layoutA) : vector<64x64xf16>
     %out = arith.addf %layout_change, %add_0 : vector<64x64xf16>
     func.return %out : vector<64x64xf16>
   }
@@ -696,11 +696,11 @@ func.func @resolved_layout_conflict(%a : memref<32x16xf16>, %b : memref<32x16xf1
   %cst = arith.constant 0.0 : f16
   // CHECK-COUNT-8: vector.load %[[MEM]]
   %vec = vector.transfer_read  %a[%c0, %c0], %cst : memref<32x16xf16>, vector<32x16xf16>
-  %vecl = iree_vector_ext.to_layout %vec to #layout1 : vector<32x16xf16>
+  %vecl = iree_vector_ext.to_layout %vec to layout(#layout1) : vector<32x16xf16>
   // CHECK: %[[R0:.+]] = vector.insert_strided_slice {{.*}} {offsets = [0, 0, 7], strides = [1]} : vector<1xf16> into vector<1x1x8xf16>
   // CHECK: %[[ADD:.*]] = arith.addf %[[R0]], %[[R0]] {{.*}} : vector<1x1x8xf16>
   %vec2 = arith.addf %vecl, %vecl : vector<32x16xf16>
-  %vec2l = iree_vector_ext.to_layout %vec2 to #layout0 : vector<32x16xf16>
+  %vec2l = iree_vector_ext.to_layout %vec2 to layout(#layout0) : vector<32x16xf16>
   // CHECK: %[[R1:.*]] = vector.extract_strided_slice %[[ADD]] {offsets = [0, 0, 0], sizes = [1, 1, 4], strides = [1, 1, 1]} : vector<1x1x8xf16> to vector<1x1x4xf16>
   // CHECK: %[[R2:.*]] = vector.extract_strided_slice %[[ADD]] {offsets = [0, 0, 4], sizes = [1, 1, 4], strides = [1, 1, 1]} : vector<1x1x8xf16> to vector<1x1x4xf16>
   vector.transfer_write %vec2l, %b[%c0, %c0] {in_bounds = [true, true]} : vector<32x16xf16>, memref<32x16xf16>
@@ -715,11 +715,11 @@ func.func @unresolved_layout_conflict(%a : memref<32x16xf16>, %b : memref<32x16x
   %vcst = arith.constant dense<0.0> : vector<32x16xf16>
   // CHECK-COUNT-8: vector.load %[[MEM]]
   %vec = vector.transfer_read  %a[%c0, %c0], %cst : memref<32x16xf16>, vector<32x16xf16>
-  %vecl = iree_vector_ext.to_layout %vec to #layout1 : vector<32x16xf16>
+  %vecl = iree_vector_ext.to_layout %vec to layout(#layout1) : vector<32x16xf16>
   // CHECK: iree_vector_ext.to_layout {{.*}}
   %vec2 = arith.addf %vecl, %vcst : vector<32x16xf16>
   // CHECK-COUNT-16: vector.store {{.*}}, vector<1xf16>
-  %vec2l = iree_vector_ext.to_layout %vec2 to #layout2 : vector<32x16xf16>
+  %vec2l = iree_vector_ext.to_layout %vec2 to layout(#layout2) : vector<32x16xf16>
   vector.transfer_write %vec2l, %b[%c0, %c0] {in_bounds = [true, true]} : vector<32x16xf16>, memref<32x16xf16>
   func.return
 }

--- a/compiler/src/iree/compiler/Codegen/Common/test/vector_layout_analysis.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/vector_layout_analysis.mlir
@@ -9,7 +9,7 @@ builtin.module attributes { transform.with_named_sequence } {
     %cst_0 = arith.constant 0.0 : f16
     %root = vector.transfer_read %arr[%c0, %c0], %cst_0 {in_bounds = [true, true]} : memref<16x16xf16>, vector<16x16xf16>
     // expected-remark @above {{layout of result #0 is #iree_vector_ext.layout<<[ VECTORY], [16]>, <[ VECTORX], [16]>>}}
-    %rootl = iree_vector_ext.to_layout %root to #layout : vector<16x16xf16>
+    %rootl = iree_vector_ext.to_layout %root to layout(#layout) : vector<16x16xf16>
     %c = arith.mulf %rootl, %b : vector<16x16xf16>
     // expected-remark @above {{layout of result #0 is #iree_vector_ext.layout<<[ VECTORY], [16]>, <[ VECTORX], [16]>>}}
     %d = arith.addf %c, %a : vector<16x16xf16>
@@ -41,7 +41,7 @@ builtin.module attributes { transform.with_named_sequence } {
     // expected-remark @above {{layout of result #0 is #iree_vector_ext.layout<<[ VECTORY], [16]>, <[ VECTORX], [16]>>}}
     %d = arith.addf %c, %a : vector<16x16xf16>
     // expected-remark @above {{layout of result #0 is #iree_vector_ext.layout<<[ VECTORY], [16]>, <[ VECTORX], [16]>>}}
-    %dl = iree_vector_ext.to_layout %d to #layout : vector<16x16xf16>
+    %dl = iree_vector_ext.to_layout %d to layout(#layout) : vector<16x16xf16>
     vector.transfer_write %dl, %arr[%c0, %c0] {in_bounds = [true, true]} : vector<16x16xf16>, memref<16x16xf16>
     func.return %d : vector<16x16xf16>
   }
@@ -64,7 +64,7 @@ builtin.module attributes { transform.with_named_sequence } {
     %cst_0 = arith.constant 0.0 : f16
     %root = vector.transfer_read %arr[%c0, %c0], %cst_0 {in_bounds = [true, true]} : memref<16x16xf16>, vector<16x16xf16>
     // expected-remark @above {{layout of result #0 is #iree_vector_ext.layout<<[ VECTORY], [16]>, <[ VECTORX], [16]>>}}
-    %rootl = iree_vector_ext.to_layout %root to #layout : vector<16x16xf16>
+    %rootl = iree_vector_ext.to_layout %root to layout(#layout) : vector<16x16xf16>
     %root2 = vector.transfer_read %arr2[%c0, %c0], %cst_0 {in_bounds = [true, true]} : memref<16x16xf16>, vector<16x16xf16>
     // expected-remark @above {{layout of result #0 is #iree_vector_ext.layout<<[ VECTORY], [16]>, <[ VECTORX], [16]>>}}
     %c = arith.mulf %rootl, %b : vector<16x16xf16>
@@ -96,7 +96,7 @@ builtin.module attributes { transform.with_named_sequence } {
     // expected-remark @above {{layout of result #0 is #iree_vector_ext.layout<<[ BATCHY,  VECTORX], [2, 8]>>}}
     %root = vector.transfer_read %arr[%c0, %c0], %cst_0 {in_bounds = [true, true]} : memref<16x16xf16>, vector<16x16xf16>
     // expected-remark @above {{layout of result #0 is #iree_vector_ext.layout<<[ VECTORY], [16]>, <[ BATCHY,  VECTORX], [2, 8]>>}}
-    %rootl = iree_vector_ext.to_layout %root to #layout : vector<16x16xf16>
+    %rootl = iree_vector_ext.to_layout %root to layout(#layout) : vector<16x16xf16>
     %root2 = vector.transfer_read %arr2[%c0], %cst_0 {in_bounds = [true]} : memref<16xf16>, vector<16xf16>
     // expected-remark @above {{layout of result #0 is #iree_vector_ext.layout<<[ BATCHY,  VECTORX], [2, 8]>>}}
     %root_red = vector.multi_reduction<add>, %rootl, %cst0_1 [0]  : vector<16x16xf16> to vector<16xf16>
@@ -130,7 +130,7 @@ builtin.module attributes { transform.with_named_sequence } {
     // expected-remark @above {{layout of result #0 is #iree_vector_ext.layout<<[ VECTORY], [16]>>}}
     %root = vector.transfer_read %arr[%c0, %c0], %cst_0 {in_bounds = [true, true]} : memref<16x16xf16>, vector<16x16xf16>
     // expected-remark @above {{layout of result #0 is #iree_vector_ext.layout<<[ VECTORY], [16]>, <[ BATCHY,  VECTORX], [2, 8]>>}}
-    %rootl = iree_vector_ext.to_layout %root to #layout : vector<16x16xf16>
+    %rootl = iree_vector_ext.to_layout %root to layout(#layout) : vector<16x16xf16>
     %root2 = vector.transfer_read %arr2[%c0], %cst_0 {in_bounds = [true]} : memref<16xf16>, vector<16xf16>
     // expected-remark @above {{layout of result #0 is #iree_vector_ext.layout<<[ VECTORY], [16]>>}}
     %root_transpose = vector.transpose %rootl, [1, 0] : vector<16x16xf16> to vector<16x16xf16>
@@ -166,9 +166,9 @@ builtin.module attributes { transform.with_named_sequence } {
 // Propagate through vector.contract.
 builtin.module attributes { transform.with_named_sequence } {
   func.func @contract(%A : vector<32x64xf16>, %B : vector<128x64xf16>, %C : vector<128x32xf32>) -> vector<128x32xf32> {
-    %a = iree_vector_ext.to_layout %A to #layoutA : vector<32x64xf16>
-    %b = iree_vector_ext.to_layout %B to #layoutB : vector<128x64xf16>
-    %c = iree_vector_ext.to_layout %C to #layoutC : vector<128x32xf32>
+    %a = iree_vector_ext.to_layout %A to layout(#layoutA) : vector<32x64xf16>
+    %b = iree_vector_ext.to_layout %B to layout(#layoutB) : vector<128x64xf16>
+    %c = iree_vector_ext.to_layout %C to layout(#layoutC) : vector<128x32xf32>
 
     // Check if the layout of %C was properly propagated to %D.
     // expected-remark @below {{layout of result #0 is #iree_vector_ext.layout<<[ VECTORY], [128]>, <[ VECTORX], [32]>>}}
@@ -202,8 +202,8 @@ builtin.module attributes { transform.with_named_sequence } {
 
 builtin.module attributes { transform.with_named_sequence } {
   func.func @resolve_select(%A : vector<64x64xf16>, %B : vector<64x64xf16>, %condition : i1) -> vector<64x64xf16> {
-    %a = iree_vector_ext.to_layout %A to #layoutA : vector<64x64xf16>
-    %b = iree_vector_ext.to_layout %B to #layoutB : vector<64x64xf16>
+    %a = iree_vector_ext.to_layout %A to layout(#layoutA) : vector<64x64xf16>
+    %b = iree_vector_ext.to_layout %B to layout(#layoutB) : vector<64x64xf16>
     // expected-remark @below {{layout of result #0 is #iree_vector_ext.layout<<[ BATCHY,  LANEX], [2, 32]>, <[ BATCHX,  VECTORY,  LANEY,  VECTORX], [2, 4, 2, 4]>>}}
     %offset_0 = arith.constant dense<2.0> : vector<64x64xf16>
     // expected-remark @below {{layout of result #0 is #iree_vector_ext.layout<<[ BATCHY,  LANEX], [2, 32]>, <[ BATCHX,  VECTORY,  LANEY,  VECTORX], [2, 4, 2, 4]>>}}
@@ -213,7 +213,7 @@ builtin.module attributes { transform.with_named_sequence } {
     %sel = arith.select %condition, %offset_0, %offset_1 : vector<64x64xf16>
     // expected-remark @below {{layout of result #0 is #iree_vector_ext.layout<<[ BATCHY,  LANEX], [2, 32]>, <[ BATCHX,  VECTORY,  LANEY,  VECTORX], [2, 4, 2, 4]>>}}
     %add = arith.addf %a, %sel : vector<64x64xf16>
-    %add_layout = iree_vector_ext.to_layout %add to #layoutB : vector<64x64xf16>
+    %add_layout = iree_vector_ext.to_layout %add to layout(#layoutB) : vector<64x64xf16>
     // CHECK-COUNT-3: iree_vector_ext.to_layout
     // expected-remark @below {{layout of result #0 is #iree_vector_ext.layout<<[ BATCHY,  LANEX], [2, 32]>, <[ BATCHX,  LANEY,  VECTORX], [2, 4, 8]>>}}
     %add_1 = arith.addf %add_layout, %b : vector<64x64xf16>
@@ -245,7 +245,7 @@ builtin.module attributes { transform.with_named_sequence } {
       // expected-remark @above {{layout of result #0 is #iree_vector_ext.layout<<[ VECTORY], [16]>>}}
       %root = vector.transfer_read %arr[%c0, %c0], %cst_0 {in_bounds = [true, true]} : memref<16x16xf16>, vector<16x16xf16>
       // expected-remark @above {{layout of result #0 is #iree_vector_ext.layout<<[ VECTORY], [16]>, <[ BATCHY,  VECTORX], [2, 8]>>}}
-      %rootl = iree_vector_ext.to_layout %root to #layout : vector<16x16xf16>
+      %rootl = iree_vector_ext.to_layout %root to layout(#layout) : vector<16x16xf16>
       %root2 = vector.transfer_read %arr2[%c0], %cst_0 {in_bounds = [true]} : memref<16xf16>, vector<16xf16>
       // expected-remark @above {{layout of result #0 is #iree_vector_ext.layout<<[ VECTORY], [16]>>}}
       %root_transpose = vector.transpose %rootl, [1, 0] : vector<16x16xf16> to vector<16x16xf16>
@@ -295,7 +295,7 @@ builtin.module attributes { transform.with_named_sequence } {
     // expected-remark @above {{thread_strides = [4]}}
     %root = vector.transfer_read %arr[%c0, %c0], %cst_0 {in_bounds = [true, true]} : memref<16x16xf16>, vector<16x16xf16>
     // expected-remark @above {{thread_strides = [1, 4]}}
-    %rootl = iree_vector_ext.to_layout %root to #layout : vector<16x16xf16>
+    %rootl = iree_vector_ext.to_layout %root to layout(#layout) : vector<16x16xf16>
     %root_red = vector.multi_reduction<add>, %rootl, %cst0_1 [0]  : vector<16x16xf16> to vector<16xf16>
     // expected-remark @above {{thread_strides = [4]}}
     %c = arith.mulf %root_red, %a : vector<16xf16>
@@ -334,7 +334,7 @@ builtin.module attributes { transform.with_named_sequence } {
     // expected-remark @above {{thread_strides = [1]}}
     %root = vector.transfer_read %arr[%c0, %c0], %cst_0 {in_bounds = [true, true]} : memref<16x16xf16>, vector<16x16xf16>
     // expected-remark @above {{thread_strides = [1, 4]}}
-    %rootl = iree_vector_ext.to_layout %root to #layout : vector<16x16xf16>
+    %rootl = iree_vector_ext.to_layout %root to layout(#layout) : vector<16x16xf16>
     %root_red = vector.multi_reduction<add>, %rootl, %cst0_1 [1]  : vector<16x16xf16> to vector<16xf16>
     // expected-remark @above {{thread_strides = [1]}}
     %c = arith.mulf %root_red, %a : vector<16xf16>
@@ -374,7 +374,7 @@ builtin.module attributes { transform.with_named_sequence } {
     %root = vector.transfer_read %arr[%c0, %c0, %c0], %cst_0 {
       in_bounds = [true, true, true]
     } : memref<32x32x32xf16>, vector<32x16x16xf16>
-    %rootl = iree_vector_ext.to_layout %root to #layout : vector<32x16x16xf16>
+    %rootl = iree_vector_ext.to_layout %root to layout(#layout) : vector<32x16x16xf16>
     %t = vector.transpose %rootl, [1, 2, 0] : vector<32x16x16xf16> to vector<16x16x32xf16>
     // expected-remark-re @above {{thread_strides = [4, 32, 1]}}
     vector.transfer_write %t, %arr[%c0, %c0, %c0] {in_bounds = [true, true, true]} : vector<16x16x32xf16>, memref<32x32x32xf16>
@@ -411,7 +411,7 @@ builtin.module attributes { transform.with_named_sequence } {
     %c0 = arith.constant 0 : index
     %0 = vector.transfer_read %quant[%c0, %c0], %c0_i4 {in_bounds = [true, true]} : memref<128x128xi4>, vector<128x128xi4>
     // expected-remark @above {{thread_strides = [1, 32]}}
-    %00 = iree_vector_ext.to_layout %0 to #layout : vector<128x128xi4>
+    %00 = iree_vector_ext.to_layout %0 to layout(#layout) : vector<128x128xi4>
     %1 = vector.transfer_read %scale[%c0], %cst {in_bounds = [true]} : memref<128xf16>, vector<128xf16>
     // expected-remark @above {{thread_strides = [1]}}
     %2 = vector.broadcast %1 : vector<128xf16> to vector<128x128xf16>
@@ -454,7 +454,7 @@ builtin.module attributes { transform.with_named_sequence } {
 builtin.module attributes { transform.with_named_sequence } {
   func.func @invalid_rank_nested_layout_anchor(%a: vector<16x16xf16>, %b: vector<16x16xf16>) -> vector<16x16xf16> {
     %c = arith.addf %a, %b : vector<16x16xf16>
-    %cl = iree_vector_ext.to_layout %c to #layout : vector<16x16xf16>
+    %cl = iree_vector_ext.to_layout %c to layout(#layout) : vector<16x16xf16>
     // expected-error @above {{Rank of vector (2) does not match rank of layout (3)}}
     func.return %cl : vector<16x16xf16>
   }
@@ -483,7 +483,7 @@ builtin.module attributes { transform.with_named_sequence } {
 builtin.module attributes { transform.with_named_sequence } {
   func.func @invalid_size_nested_layout_anchor(%a: vector<16x16xf16>, %b: vector<16x16xf16>) -> vector<16x16xf16> {
     %c = arith.addf %a, %b : vector<16x16xf16>
-    %cl = iree_vector_ext.to_layout %c to #layout2 : vector<16x16xf16>
+    %cl = iree_vector_ext.to_layout %c to layout(#layout2) : vector<16x16xf16>
     // expected-error @above {{Vector shape: [16, 16] does not match the layout (nested_layout<subgroup_tile = [1, 1], batch_tile = [2, 4], outer_tile = [1, 1], thread_tile = [8, 2], element_tile = [2, 2], subgroup_strides = [0, 0], thread_strides = [1, 8]>) at dim 0. Dimension expected by layout: 32 actual: 16}}
     func.return %cl : vector<16x16xf16>
   }

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
@@ -61,7 +61,7 @@ def IREEVectorExt_ToLayoutOp : IREEVectorExt_PureOp<"to_layout", [
       return isa<RankedTensorType>(getOutput().getType());
     }
   }];
-  let assemblyFormat = "$input `to` $layout attr-dict `:` type($input)";
+  let assemblyFormat = "$input `to` `layout` `(` $layout `)` attr-dict `:` type($input)";
   let hasVerifier = 1;
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/test/invalid.mlir
@@ -8,7 +8,7 @@ func.func @invalid_layout(%lhs: memref<32x32xf16>, %rhs: memref<32x32xf16>) -> v
   %c0 = arith.constant 0 : index
   %result = vector.transfer_read %lhs[%c0, %c0], %cst_0 {in_bounds = [true, true]} : memref<32x32xf16>, vector<32x32xf16>
   // expected-error @+1 {{Vector shape: [32, 32] does not match the layout (layout<<[ BATCHX,  LANEX,  VECTORY], [1, 1, 1]>, <[ BATCHY,  LANEY,  VECTORX], [4, 2, 4]>>) at dim 0. Dimension expected by layout: 1 actual: 32}}
-  %2 = iree_vector_ext.to_layout %result to #layout1 : vector<32x32xf16>
+  %2 = iree_vector_ext.to_layout %result to layout(#layout1) : vector<32x32xf16>
   return %2 : vector<32x32xf16>
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/test/roundtrip.mlir
@@ -17,6 +17,19 @@ func.func @specify_layout(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
 
 // -----
 
+func.func @specify_inline_layout(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
+  %cst_0 = arith.constant 0.0 : f16
+  %c0 = arith.constant 0 : index
+  %result = vector.transfer_read %lhs[%c0, %c0], %cst_0 {in_bounds = [true, true]} : memref<32x32xf16>, vector<32x32xf16>
+  %2 = iree_vector_ext.to_layout %result to layout(#iree_vector_ext.nested_layout<subgroup_tile = [1, 1], batch_tile = [2, 4], outer_tile = [4, 1], thread_tile = [4, 2], element_tile = [1, 4], subgroup_strides = [0, 0], thread_strides = [1, 4]>) : vector<32x32xf16>
+  return %2 : vector<32x32xf16>
+}
+
+// CHECK-LABEL: func.func @specify_inline_layout
+// CHECK:      iree_vector_ext.to_layout {{.*}} to layout({{.*}})
+
+// -----
+
 #nested_0 = #iree_vector_ext.nested_layout<
   subgroup_tile = [1, 1],
   batch_tile = [2, 4],

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/test/roundtrip.mlir
@@ -7,13 +7,13 @@ func.func @specify_layout(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
   %cst_0 = arith.constant 0.0 : f16
   %c0 = arith.constant 0 : index
   %result = vector.transfer_read %lhs[%c0, %c0], %cst_0 {in_bounds = [true, true]} : memref<32x32xf16>, vector<32x32xf16>
-  %2 = iree_vector_ext.to_layout %result to #layout2 : vector<32x32xf16>
+  %2 = iree_vector_ext.to_layout %result to layout(#layout2) : vector<32x32xf16>
   return %2 : vector<32x32xf16>
 }
 
 // CHECK-DAG: #[[$LAYOUT0:.+]] = #iree_vector_ext.layout<<[ BATCHY,  LANEY,  VECTORX], [4, 2, 4]>, <[ BATCHX,  LANEX,  VECTORY], [2, 4, 4]>>
 // CHECK-LABEL: func.func @specify_layout
-// CHECK:      iree_vector_ext.to_layout {{.*}} to #[[$LAYOUT0]]
+// CHECK:      iree_vector_ext.to_layout {{.*}} to layout(#[[$LAYOUT0]])
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/configure_tensor_layout.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/configure_tensor_layout.mlir
@@ -42,9 +42,9 @@ func.func @matmul_96x64x16_mfma(%lhs: tensor<96x16xf16>,
 
 // CHECK-LABEL: func.func @matmul_96x64x16_mfma
 
-// CHECK-DAG: %[[LHS:.+]] = iree_vector_ext.to_layout %{{.*}} to #[[$NESTED]] {shared_memory_conversion}
-// CHECK-DAG: %[[RHS:.+]] = iree_vector_ext.to_layout %{{.*}} to #[[$NESTED1]] {shared_memory_conversion}
-// CHECK-DAG: %[[ACC:.+]] = iree_vector_ext.to_layout %{{.*}} to #[[$NESTED2]]
+// CHECK-DAG: %[[LHS:.+]] = iree_vector_ext.to_layout %{{.*}} to layout(#[[$NESTED]]) {shared_memory_conversion}
+// CHECK-DAG: %[[RHS:.+]] = iree_vector_ext.to_layout %{{.*}} to layout(#[[$NESTED1]]) {shared_memory_conversion}
+// CHECK-DAG: %[[ACC:.+]] = iree_vector_ext.to_layout %{{.*}} to layout(#[[$NESTED2]])
 // CHECK: linalg.generic
 // CHECK-SAME: ins(%[[LHS]], %[[RHS]]
 // CHECK-SAME: outs(%[[ACC]]
@@ -93,9 +93,9 @@ func.func @matmul_96x64x16_wmma(%lhs: tensor<96x16xf16>,
 
 // CHECK-LABEL: func.func @matmul_96x64x16_wmma
 
-// CHECK-DAG: %[[LHS:.+]] = iree_vector_ext.to_layout %{{.*}} to #[[$NESTED]] {shared_memory_conversion}
-// CHECK-DAG: %[[RHS:.+]] = iree_vector_ext.to_layout %{{.*}} to #[[$NESTED1]] {shared_memory_conversion}
-// CHECK-DAG: %[[ACC:.+]] = iree_vector_ext.to_layout %{{.*}} to #[[$NESTED2]]
+// CHECK-DAG: %[[LHS:.+]] = iree_vector_ext.to_layout %{{.*}} to layout(#[[$NESTED]]) {shared_memory_conversion}
+// CHECK-DAG: %[[RHS:.+]] = iree_vector_ext.to_layout %{{.*}} to layout(#[[$NESTED1]]) {shared_memory_conversion}
+// CHECK-DAG: %[[ACC:.+]] = iree_vector_ext.to_layout %{{.*}} to layout(#[[$NESTED2]])
 // CHECK: linalg.generic
 // CHECK-SAME: ins(%[[LHS]], %[[RHS]]
 // CHECK-SAME: outs(%[[ACC]]
@@ -144,9 +144,9 @@ func.func @matmul_128x64x16_multi_subgroup(%lhs: tensor<128x16xf16>,
 
 // CHECK-LABEL: func.func @matmul_128x64x16_multi_subgroup
 
-// CHECK-DAG: %[[LHS:.+]] = iree_vector_ext.to_layout %{{.*}} to #[[$NESTED]] {shared_memory_conversion}
-// CHECK-DAG: %[[RHS:.+]] = iree_vector_ext.to_layout %{{.*}} to #[[$NESTED1]] {shared_memory_conversion}
-// CHECK-DAG: %[[ACC:.+]] = iree_vector_ext.to_layout %{{.*}} to #[[$NESTED2]]
+// CHECK-DAG: %[[LHS:.+]] = iree_vector_ext.to_layout %{{.*}} to layout(#[[$NESTED]]) {shared_memory_conversion}
+// CHECK-DAG: %[[RHS:.+]] = iree_vector_ext.to_layout %{{.*}} to layout(#[[$NESTED1]]) {shared_memory_conversion}
+// CHECK-DAG: %[[ACC:.+]] = iree_vector_ext.to_layout %{{.*}} to layout(#[[$NESTED2]])
 // CHECK: linalg.generic
 // CHECK-SAME: ins(%[[LHS]], %[[RHS]]
 // CHECK-SAME: outs(%[[ACC]]
@@ -195,9 +195,9 @@ func.func @packed_matmul_128x128x128(%lhs: tensor<8x16x16xf16>,
 // CHECK-DAG: #[[$NESTED2:.+]] = #iree_vector_ext.nested_layout<subgroup_tile = [2, 1, 2, 1], batch_tile = [4, 1, 4, 1], outer_tile = [1, 1, 1, 1], thread_tile = [1, 4, 1, 16], element_tile = [1, 4, 1, 1], subgroup_strides = [2, 0, 1, 0], thread_strides = [0, 16, 0, 1]>
 // CHECK-LABEL: func.func @packed_matmul_128x128x128
 
-// CHECK-DAG: %[[LHS:.+]] = iree_vector_ext.to_layout %{{.*}} to #[[$NESTED]] {shared_memory_conversion}
-// CHECK-DAG: %[[RHS:.+]] = iree_vector_ext.to_layout %{{.*}} to #[[$NESTED1]] {shared_memory_conversion}
-// CHECK-DAG: %[[ACC:.+]] = iree_vector_ext.to_layout %{{.*}} to #[[$NESTED2]]
+// CHECK-DAG: %[[LHS:.+]] = iree_vector_ext.to_layout %{{.*}} to layout(#[[$NESTED]]) {shared_memory_conversion}
+// CHECK-DAG: %[[RHS:.+]] = iree_vector_ext.to_layout %{{.*}} to layout(#[[$NESTED1]]) {shared_memory_conversion}
+// CHECK-DAG: %[[ACC:.+]] = iree_vector_ext.to_layout %{{.*}} to layout(#[[$NESTED2]])
 // CHECK: linalg.generic
 // CHECK-SAME: ins(%[[LHS]], %[[RHS]]
 // CHECK-SAME: outs(%[[ACC]]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/configure_vector_layout.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/configure_vector_layout.mlir
@@ -26,9 +26,9 @@ func.func @transfer_read_permute(%lhs: memref<16x256xf16, strided<[256, 1], offs
   %6 = vector.transfer_read %lhs[%c0, %c0], %cst {in_bounds = [true, true]} : memref<16x256xf16, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>, vector<16x32xf16>
   %7 = vector.transfer_read %rhs[%c0, %c0], %cst {in_bounds = [true, true], permutation_map = affine_map<(d0, d1) -> (d1, d0)>} : memref<16x256xf16, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>, vector<32x16xf16>
   // CHECK: %[[READ0:.+]] = vector.transfer_read
-  // CHECK: to_layout %[[READ0]] to #[[$NESTED]]
+  // CHECK: to_layout %[[READ0]] to layout(#[[$NESTED]])
   // CHECK: %[[READ1:.+]] = vector.transfer_read
-  // CHECK: to_layout %[[READ1]] to #[[$NESTED1]]
+  // CHECK: to_layout %[[READ1]] to layout(#[[$NESTED1]])
   vector.transfer_write %6, %alloc_0[%c0, %c0] {in_bounds = [true, true]} : vector<16x32xf16>, memref<16x32xf16, #gpu.address_space<workgroup>>
   vector.transfer_write %7, %alloc[%c0, %c0] {in_bounds = [true, true]} : vector<32x16xf16>, memref<32x16xf16, #gpu.address_space<workgroup>>
   memref.dealloc %alloc_0 : memref<16x32xf16, #gpu.address_space<workgroup>>
@@ -59,7 +59,7 @@ func.func @dequant_anchors_on_quant_only(%quant: memref<128x128xi4, strided<[409
   %c0 = arith.constant 0 : index
   %0 = vector.transfer_read %quant[%c0, %c0], %c0_i4 {in_bounds = [true, true]} : memref<128x128xi4, strided<[4096, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>, vector<128x128xi4>
   // CHECK: %[[READ:.+]] = vector.transfer_read
-  // CHECK: to_layout %[[READ]] to #[[$NESTED]]
+  // CHECK: to_layout %[[READ]] to layout(#[[$NESTED]])
   %1 = vector.transfer_read %scale[%c0], %cst {in_bounds = [true]} : memref<128xf16, strided<[32], offset: ?>, #hal.descriptor_type<storage_buffer>>, vector<128xf16>
   %2 = vector.broadcast %1 : vector<128xf16> to vector<128x128xf16>
   %3 = vector.transpose %2, [1, 0] : vector<128x128xf16> to vector<128x128xf16>


### PR DESCRIPTION
The layout attr directly before `: vector<...>` leads to ambiguous parsing when attributes are printed inline. This PR wraps the attr in parens, fixes tests, and adds a test to verify the inline layout attr can be parsed.




Closes #18612