### PR TITLE
[LLVMGPU] Add KernelConfig for data tiled multi_mma ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.cpp
@@ -61,12 +61,12 @@ getThreadTileSizesFromLoopRanges(SmallVector<int64_t> loopRanges,
     if (loopRanges[i] > vectorSize) {
       tileSizes[i] = vectorSize;
       residualNumThreads = numThreads / (loopRanges.back() / vectorSize);
-      i--;
+      --i;
       break;
     }
     tileSizes[i] = 0;
     vectorSize /= loopRanges[i];
-    i--;
+    --i;
   }
   // Set as many remaining tile sizes to 1 as possible to use all threads.
   while (i >= 0) {
@@ -77,7 +77,7 @@ getThreadTileSizesFromLoopRanges(SmallVector<int64_t> loopRanges,
     }
     tileSizes[i] = 1;
     residualNumThreads /= loopRanges[i];
-    i--;
+    --i;
   }
 
   return tileSizes;

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -49,7 +49,7 @@ setDataTiledMultiMmaLoweringConfig(IREE::GPU::TargetAttr target,
   // number of subgroups. The number of subgroups is found by the product of
   // subgroup unrolling factors, since the non-unrolled inner kernel takes a
   // single subgroup.
-  const int64_t targetSubgroupSize = target.getPreferredSubgroupSize();
+  const int64_t targetSubgroupSize = dataTiledMmaAttr.getSubgroupSize();
   int64_t flatWorkgroupSize = targetSubgroupSize *
                               dataTiledMmaAttr.getUnrollMToSubgroups() *
                               dataTiledMmaAttr.getUnrollNToSubgroups();
@@ -70,7 +70,7 @@ setDataTiledMultiMmaLoweringConfig(IREE::GPU::TargetAttr target,
     reductionTileSizes[kDim] = 1;
   }
 
-  // Set tile sizes
+  // Set tile sizes.
   MLIRContext *context = multiMmaOp.getContext();
   SmallVector<NamedAttribute, 1> attrs;
   Builder b(context);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -74,11 +74,11 @@ setDataTiledMultiMmaLoweringConfig(IREE::GPU::TargetAttr target,
   MLIRContext *context = multiMmaOp.getContext();
   SmallVector<NamedAttribute, 1> attrs;
   Builder b(context);
-  attrs.emplace_back(StringAttr::get(context, "workgroup"),
+  attrs.emplace_back(b.getStringAttr("workgroup"),
                      b.getI64ArrayAttr(workgroupTileSizes));
-  attrs.emplace_back(StringAttr::get(context, "reduction"),
+  attrs.emplace_back(b.getStringAttr("reduction"),
                      b.getI64ArrayAttr(reductionTileSizes));
-  auto configDict = DictionaryAttr::get(context, attrs);
+  auto configDict = b.getDictionaryAttr(attrs);
   auto loweringConfig = IREE::GPU::LoweringConfigAttr::get(context, configDict);
 
   // Don't add any special padding or prefetching, since the data-tiled layout
@@ -89,10 +89,9 @@ setDataTiledMultiMmaLoweringConfig(IREE::GPU::TargetAttr target,
       /*no_reduce_shared_memory_bank_conflicts=*/true,
       /*reorder_workgroups_strategy=*/std::nullopt);
   pipelineAttrs.emplace_back(
-      StringAttr::get(context,
-                      IREE::GPU::GPUPipelineOptionsAttr::getDictKeyName()),
+      b.getStringAttr(IREE::GPU::GPUPipelineOptionsAttr::getDictKeyName()),
       pipelineOptions);
-  auto pipelineConfig = DictionaryAttr::get(context, pipelineAttrs);
+  auto pipelineConfig = b.getDictionaryAttr(pipelineAttrs);
 
   // TODO(qedawkins): Use a shared pipeline identifier here.
   return setOpConfigAndEntryPointFnTranslation(

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h
@@ -14,6 +14,13 @@
 
 namespace mlir::iree_compiler::IREE::GPU {
 
+/// Helper for setting up a data tiled multi_mma config based on the specified
+/// target.
+LogicalResult
+setDataTiledMultiMmaLoweringConfig(IREE::GPU::TargetAttr target,
+                                   mlir::FunctionOpInterface entryPoint,
+                                   Operation *op);
+
 /// Helper for setting up a matmul config based on the specified target.
 /// TODO: Currently this only succeeds if the target supports an mma
 /// kind. Add support for a fallback direct lowering path.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -1981,6 +1981,11 @@ static LogicalResult setRootConfig(IREE::GPU::TargetAttr target,
     LDBG("Transform Dialect Config");
     return success();
   }
+  if (succeeded(setDataTiledMultiMmaLoweringConfig(target, entryPointFn,
+                                                   computeOp))) {
+    LDBG("Tile and fuse data tiled multi_mma config");
+    return success();
+  }
   if (clGPUTestTileAndFuseMatmul) {
     if (succeeded(IREE::GPU::setMatmulLoweringConfig(target, entryPointFn,
                                                      computeOp))) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLKernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLKernelConfig.cpp
@@ -272,6 +272,10 @@ setWarpReductionConfig(IREE::GPU::TargetAttr target,
 static LogicalResult setRootConfig(IREE::GPU::TargetAttr target,
                                    mlir::FunctionOpInterface entryPointFn,
                                    Operation *computeOp) {
+  if (succeeded(setDataTiledMultiMmaLoweringConfig(target, entryPointFn,
+                                                   computeOp))) {
+    return success();
+  }
   if (auto linalgOp = dyn_cast<linalg::LinalgOp>(computeOp)) {
     if (succeeded(IREE::GPU::setMatmulLoweringConfig(target, entryPointFn,
                                                      linalgOp))) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
@@ -154,3 +154,35 @@ module @elementwise_large_rank {
 // shapes.
 // CHECK-LABEL: func.func @elementwise_large_rank
 //  CHECK-SAME:   #iree_codegen.translation_info<LLVMGPUVectorize workgroup_size = [128, 1, 1] subgroup_size = 64>
+
+// -----
+
+module {
+  func.func @multi_mma_data_tiled_unrolled_MFMA_F32_16x16x4_F32(
+        %3: tensor<1x8x8x4x16x4xf32>, %4: tensor<1x8x4x2x4x16x4xf32>, %5: tensor<1x1x8x4x2x4x16x4xf32>) -> tensor<1x1x8x4x2x4x16x4xf32> {
+    %c0 = arith.constant 0 : index
+    %c65536 = arith.constant 65536 : index
+    %c131072 = arith.constant 131072 : index
+    %6 = iree_gpu.multi_mma %3, %4, %5 {
+        indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
+                         affine_map<(d0, d1, d2) -> (d1, d2)>,
+                         affine_map<(d0, d1, d2) -> (d0, d1)>],
+        iterator_types = [#iree_gpu.iterator_type<parallel>,
+                          #iree_gpu.iterator_type<parallel>,
+                          #iree_gpu.iterator_type<reduction>],
+        kind = #iree_gpu.data_tiled_mma_layout<
+                          intrinsic =  MFMA_F32_16x16x4_F32,
+                          unroll_m = 8, unroll_n = 2,
+                          unroll_n_to_subgroups = 4,
+                          unroll_k = 4>}
+        : tensor<1x8x8x4x16x4xf32>, tensor<1x8x4x2x4x16x4xf32> into tensor<1x1x8x4x2x4x16x4xf32>
+    return %6 : tensor<1x1x8x4x2x4x16x4xf32>
+  }
+}
+
+// CHECK-LABEL: func.func @multi_mma_data_tiled_unrolled_MFMA_F32_16x16x4_F32
+//  CHECK-SAME:   #iree_codegen.translation_info<LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64
+//  CHECK-SAME:   {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = false, no_reduce_shared_memory_bank_conflicts = true>}
+//       CHECK:   iree_gpu.multi_mma {{.*}}lowering_config = #iree_gpu.lowering_config
+//  CHECK-SAME:     reduction = [0, 0, 1]
+//  CHECK-SAME:     workgroup = [1, 1, 0]


### PR DESCRIPTION
This PR adds the KernelConfig logic needed for data tiled multi_mma ops. The PR does 2 things:

1. Adds config logic for iree_gpu.multi_mma ops with a DataTiledMmaAttr kind. The logic here is simple, setting workgroup and reduction tile sizes to 1, and computing the workgroup_size based on the DataTiledMmaAttr.
2. Modify the logic for `getThreadTileSizesFromLoopRanges` to allow for inner dimensions that are smaller than the `vectorSize` (preferred load size). This is needed for data tiled kernels, since the swizzled inputs often have inner vector sizes that are expanded out into multiple dimensions as a result of K interleaving. The config logic will now fill as much of the `vectorSize` with the inner dimensions as possible.