### PR TITLE
Switch linux_arm64_clang workflow to arm-hosted runner.

### DIFF
--- a/.github/workflows/ci_linux_arm64_clang.yml
+++ b/.github/workflows/ci_linux_arm64_clang.yml
@@ -65,6 +65,9 @@ jobs:
           cmake --build ${BUILD_DIR} --target install -- -k 0
           cmake --build ${BUILD_DIR} --target iree-test-deps -- -k 0
       - name: Run CTest
+        env:
+          # (For now) QEMU is required to run tests with SME
+          IREE_ARM_SME_QEMU_AARCH64_BIN: /usr/bin/qemu-aarch64
         run: ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
       - name: Test iree-dialects
         run: ./build_tools/cmake/test_iree_dialects.sh "${BUILD_DIR}"

--- a/.github/workflows/ci_linux_arm64_clang.yml
+++ b/.github/workflows/ci_linux_arm64_clang.yml
@@ -27,16 +27,15 @@ jobs:
   setup:
     uses: ./.github/workflows/setup.yml
 
-  # TODO(#18238): migrate to new runner cluster
-  #   Or switch to GitHub-hosted arm64 runners when available?
   linux_arm64_clang:
     needs: setup
-    runs-on:
-      - self-hosted # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.runner-env }}
-      - arm64
-      - os-family=Linux
+    # See https://gitlab.arm.com/tooling/gha-runner-docs
+    runs-on: ah-ubuntu_22_04-c7g_4x-50
+    container:
+      image: ghcr.io/iree-org/cpubuilder_ubuntu_jammy@sha256:f3e2c56680b6007f29c8e191d93dfcb4f8800802e3caeb4851da90f2a1a0b5a5
+    defaults:
+      run:
+        shell: bash
     env:
       BUILD_DIR: build-arm64
     steps:
@@ -44,22 +43,28 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           submodules: true
-      - name: "Building IREE"
-        env:
-          IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
+      - name: Install Python requirements
+        run: python3 -m pip install -r ./runtime/bindings/python/iree/runtime/build_requirements.txt
+      # TODO(#18557): enable sccache (watching for network bandwidth charges
+      #               between the cache server and AWS VMs)
+      - name: CMake - configure
         run: |
-          ./build_tools/github_actions/docker_run.sh \
-            --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
-            --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
-            --env "CCACHE_NAMESPACE=ci_linux_arm64_clang" \
-            --env "IREE_BUILD_SETUP_PYTHON_VENV=${BUILD_DIR}/.venv" \
-            ghcr.io/iree-org/cpubuilder_ubuntu_jammy@sha256:f3e2c56680b6007f29c8e191d93dfcb4f8800802e3caeb4851da90f2a1a0b5a5 \
-            ./build_tools/cmake/build_all.sh \
-            "${BUILD_DIR}"
-      - name: "Testing IREE"
+          cmake \
+            -G Ninja \
+            -B ${BUILD_DIR} \
+            -DPython3_EXECUTABLE="$(which python3)" \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DIREE_BUILD_PYTHON_BINDINGS=ON \
+            -DIREE_ENABLE_LLD=ON \
+            -DIREE_ENABLE_ASSERTIONS=ON \
+            -DIREE_BUILD_DOCS=ON \
+            -DIREE_TARGET_BACKEND_WEBGPU_SPIRV=ON
+      - name: CMake - build
         run: |
-          ./build_tools/github_actions/docker_run.sh \
-            --env "IREE_ARM_SME_QEMU_AARCH64_BIN=/usr/bin/qemu-aarch64" \
-            ghcr.io/iree-org/cpubuilder_ubuntu_jammy@sha256:f3e2c56680b6007f29c8e191d93dfcb4f8800802e3caeb4851da90f2a1a0b5a5 \
-            ./build_tools/cmake/ctest_all.sh \
-            "${BUILD_DIR}"
+          cmake --build ${BUILD_DIR} -- -k 0
+          cmake --build ${BUILD_DIR} --target install -- -k 0
+          cmake --build ${BUILD_DIR} --target iree-test-deps -- -k 0
+      - name: Run CTest
+        run: ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
+      - name: Test iree-dialects
+        run: ./build_tools/cmake/test_iree_dialects.sh "${BUILD_DIR}"


### PR DESCRIPTION
Context: https://github.com/iree-org/iree/issues/18238#issuecomment-2383652809

This uses https://gitlab.arm.com/tooling/gha-runner-docs to run on Arm Hosted GitHub Action (GHA) Runners, instead of the runners that Google has been hosting. Note that GitHub also offers Arm runners, but they are expensive and require a paid GitHub plan to use (https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners/about-larger-runners).

For now this is continuing to run nightly, but we could also explore running more regularly if Arm wants and approves. We'd want to figure out how to use a build cache efficiently for that though. We can use sccache storage on Azure, but there might be charges between Azure and AWS for the several gigabytes of data moving back and forth. If we set up a dedicated cache server (https://github.com/iree-org/iree/issues/18557), we'll at least have more visibility into and control over the storage and compute side of billing.

Test runs:
* https://github.com/iree-org/iree/actions/runs/11114007934 (42 minutes)
* https://github.com/iree-org/iree/actions/runs/11114658487 (40 minutes)
* https://github.com/iree-org/iree/actions/runs/11114757082 (38 minutes)
* https://github.com/iree-org/iree/actions/runs/11128634554 (40 minutes)

skip-ci: no impact on other builds