### PR TITLE
[Codegen][GPU] Force linalg ops to always use the same vector size

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.cpp
@@ -49,8 +49,7 @@ getVectorTileSizesFromLoopRanges(SmallVector<int64_t> loopRanges,
                                  bool allowMultiDimCollapse = true) {
   // If any loop ranges are dynamic, default to a simple vector size based
   // tile size.
-  if (llvm::any_of(loopRanges,
-                   [](int64_t s) { return ShapedType::isDynamic(s); })) {
+  if (llvm::any_of(loopRanges, &ShapedType::isDynamic)) {
     return getVectorSizeTileSizes(loopRanges.size(), loopRanges.back(),
                                   vectorSize);
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
@@ -268,10 +268,10 @@ hal.executable public @main {
 //   CHECK-DAG:   memref.alloc() : memref<64x36xf16, #gpu.address_space<workgroup>>
 //       CHECK:   %[[LOOP:.+]] = scf.for %[[IV:.+]] = %c0 to %c80 step %c2 {{.*}} -> (vector<2x2x8x1x1xf32>)
 //       CHECK:     gpu.barrier
-//   CHECK-DAG:     %[[LHS_RD:.+]] = vector.transfer_read %[[B0]]{{.*}} vector<2x8xf16>
-//   CHECK-DAG:     vector.transfer_write %[[LHS_RD]]
-//   CHECK-DAG:     %[[RHS_RD:.+]] = vector.transfer_read %[[B1]]{{.*}} vector<2x8xf16>
-//   CHECK-DAG:     vector.transfer_write %[[RHS_RD]]
+//   CHECK-DAG:     vector.transfer_read %[[B0]]{{.*}} vector<8xf16>
+//   CHECK-DAG:     vector.transfer_read %[[B0]]{{.*}} vector<8xf16>
+//   CHECK-DAG:     vector.transfer_read %[[B1]]{{.*}} vector<8xf16>
+//   CHECK-DAG:     vector.transfer_read %[[B1]]{{.*}} vector<8xf16>
 //       CHECK:     gpu.barrier
 //   CHECK-DAG:     vector.transfer_read {{.*}} vector<2x1x2x16xf16>
 //   CHECK-DAG:     vector.transfer_read {{.*}} vector<2x1x2x16xf16>


### PR DESCRIPTION
The current method of distributing linalg ops does not properly
guarantee coalesced memory accesses because the tile sizes beyond the
inner most are not distributed cyclically. This changes the tile sizes
for derived_thread_config to always pick the optimal vector size or
smaller for the inner most dims, and one for all outer dims. This will
turn into a loop that gets unrolled later on.