### PR TITLE
[docs] Update docs regarding ROCm support

### DIFF
--- a/docs/website/docs/guides/deployment-configurations/gpu-rocm.md
+++ b/docs/website/docs/guides/deployment-configurations/gpu-rocm.md
@@ -30,8 +30,6 @@ or [Linux](https://rocm.docs.amd.com/en/latest/deploy/linux/quick_start.html).
 
 #### :octicons-package-16: Download the compiler from a release
 
-!!! note "Currently ROCm is **NOT supported** for the Python interface."
-
 #### :material-hammer-wrench: Build the compiler from source
 
 Please make sure you have followed the


### PR DESCRIPTION
ROCm / HIP is supported in the IREE wheels, see:
* https://github.com/iree-org/iree/blob/e45c570997586d327ca78342f3644f0c134d88ea/build_tools/pkgci/build_linux_packages.sh#L193
* https://github.com/iree-org/iree/blob/e45c570997586d327ca78342f3644f0c134d88ea/build_tools/pkgci/build_linux_packages.sh#L200