### PR TITLE
Switch build_package to arm-hosted runner.

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -43,8 +43,7 @@ jobs:
             build-family: linux-x86_64
             build-package: main-dist-linux
             experimental: false
-          - runs-on:
-              [self-hosted, arm64, os-family=Linux, runner-group=postsubmit]
+          - runs-on: ah-ubuntu_22_04-c7g_4x-50
             build-family: linux-aarch64
             build-package: main-dist-linux
             experimental: true
@@ -52,8 +51,7 @@ jobs:
             build-family: linux-x86_64
             build-package: py-compiler-pkg
             experimental: false
-          - runs-on:
-              [self-hosted, arm64, os-family=Linux, runner-group=postsubmit]
+          - runs-on: ah-ubuntu_22_04-c7g_4x-50
             build-family: linux-aarch64
             build-package: py-compiler-pkg
             experimental: true
@@ -61,8 +59,7 @@ jobs:
             build-family: linux-x86_64
             build-package: py-runtime-pkg
             experimental: false
-          - runs-on:
-              [self-hosted, arm64, os-family=Linux, runner-group=postsubmit]
+          - runs-on: ah-ubuntu_22_04-c7g_4x-50
             build-family: linux-aarch64
             build-package: py-runtime-pkg
             experimental: true


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree/issues/18238. See also https://github.com/iree-org/iree/pull/18643.

This is for nightly package builds / releases.

Untested. We can roll this back if it fails to build.

skip-ci: no impact on other workflows.