### PR TITLE
 [VectorDistribution]Add distribution pattern and test mlir file for vector.gather

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
@@ -1041,6 +1041,55 @@ struct DistributeTrivialLayoutConversions final
   }
 };
 
+struct DistributeGather final : OpDistributionPattern<vector::GatherOp> {
+  using OpDistributionPattern::OpDistributionPattern;
+
+  LogicalResult matchAndRewrite(vector::GatherOp gatherOp,
+                                DistributionSignature &signature,
+                                PatternRewriter &rewriter) const override {
+    VectorValue result = gatherOp.getResult();
+    VectorValue indexVec = gatherOp.getIndexVec();
+    VectorValue mask = gatherOp.getMask();
+    VectorValue passThru = gatherOp.getPassThru();
+
+    VectorLayoutInterface resultLayout = signature[result];
+    VectorLayoutInterface indicesLayout = signature[indexVec];
+    VectorLayoutInterface maskLayout = signature[mask];
+    VectorLayoutInterface passThruLayout = signature[passThru];
+
+    if (!resultLayout) {
+      return rewriter.notifyMatchFailure(gatherOp,
+                                         "result does not have layout");
+    }
+    if (!indicesLayout) {
+      return rewriter.notifyMatchFailure(gatherOp,
+                                         "indices does not have layout");
+    }
+    if (!maskLayout) {
+      return rewriter.notifyMatchFailure(gatherOp, "mask does not have layout");
+    }
+    if (!passThruLayout) {
+      return rewriter.notifyMatchFailure(gatherOp,
+                                         "passThru does not have layout");
+    }
+
+    SmallVector<int64_t> distributedShape = resultLayout.getDistributedShape();
+    Type elementType = result.getType().getElementType();
+    VectorType distributedType = VectorType::get(distributedShape, elementType);
+
+    // Simply distribute all operands and results.
+    VectorValue distributed = rewriter.create<vector::GatherOp>(
+        gatherOp.getLoc(), distributedType, gatherOp.getBase(),
+        gatherOp.getIndices(),
+        getDistributed(rewriter, indexVec, indicesLayout),
+        getDistributed(rewriter, mask, maskLayout),
+        getDistributed(rewriter, passThru, passThruLayout));
+
+    replaceOpWithDistributedValues(rewriter, gatherOp, distributed);
+    return success();
+  }
+};
+
 } // namespace
 
 void populateGPUReductionDistributionPatterns(RewritePatternSet &patterns,
@@ -1053,6 +1102,8 @@ void populateGPUDistributionPatterns(RewritePatternSet &patterns) {
   // Elementwise patterns.
   patterns.add<DistributeElementwise>(patterns.getContext());
   patterns.add<DistributeTrivialLayoutConversions>(patterns.getContext());
+  // Gather patterns.
+  patterns.add<DistributeGather>(patterns.getContext());
 }
 
 void populateGPUDistributionLayoutAttrPatterns(Value laneId,

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
@@ -798,7 +798,7 @@ func.func @gather(%base: memref<32x256x64xf16>, %index_vec: vector<32x256x64xind
   %mask = arith.constant dense<true> : vector<32x256x64xi1>
   %pass = arith.constant dense<0.000000e+00> : vector<32x256x64xf16>
   %0 = vector.gather %base[%c0, %c0, %c0] [%index_vec], %mask, %pass : memref<32x256x64xf16>, vector<32x256x64xindex>, vector<32x256x64xi1>, vector<32x256x64xf16> into vector<32x256x64xf16>
-  %1 = iree_vector_ext.to_layout %0 to #layout :  vector<32x256x64xf16>
+  %1 = iree_vector_ext.to_layout %0 to layout(#layout) :  vector<32x256x64xf16>
   return %1 : vector<32x256x64xf16>
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
@@ -784,6 +784,41 @@ builtin.module attributes { transform.with_named_sequence } {
 // -----
 
 #layout = #iree_vector_ext.nested_layout<
+  subgroup_tile = [2, 2, 2],
+  batch_tile = [2, 2, 1],
+  outer_tile = [2, 1, 1],
+  thread_tile = [4, 16, 8],
+  element_tile = [1, 4, 4],
+  subgroup_strides = [4, 2, 1],
+  thread_strides   = [128, 8, 1]
+>
+
+func.func @gather(%base: memref<32x256x64xf16>, %index_vec: vector<32x256x64xindex>)-> (vector<32x256x64xf16>){
+  %c0 = arith.constant 0 : index
+  %mask = arith.constant dense<true> : vector<32x256x64xi1>
+  %pass = arith.constant dense<0.000000e+00> : vector<32x256x64xf16>
+  %0 = vector.gather %base[%c0, %c0, %c0] [%index_vec], %mask, %pass : memref<32x256x64xf16>, vector<32x256x64xindex>, vector<32x256x64xi1>, vector<32x256x64xf16> into vector<32x256x64xf16>
+  %1 = iree_vector_ext.to_layout %0 to #layout :  vector<32x256x64xf16>
+  return %1 : vector<32x256x64xf16>
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @gather
+// CHECK-SAME:  (%[[SRC:.*]]: memref<32x256x64xf16>, %[[INDEX:.*]]: vector<32x256x64xindex>)
+// CHECK: %[[DIST_INDEX:.*]] = iree_vector_ext.to_simt %[[INDEX]] : vector<32x256x64xindex> -> vector<2x2x1x2x1x1x1x4x4xindex>
+// CHECK: %[[GATHER:.*]] = vector.gather %[[SRC]][%c0, %c0, %c0] [%[[DIST_INDEX]]]
+// CHECK: iree_vector_ext.to_simd %[[GATHER]] : vector<2x2x1x2x1x1x1x4x4xf16> -> vector<32x256x64xf16>
+
+// -----
+
+#layout = #iree_vector_ext.nested_layout<
   subgroup_tile = [2, 2],
   batch_tile = [2, 4],
   outer_tile = [2, 1],

--- a/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
@@ -548,10 +548,6 @@ static void propagateLayoutToGatherOp(
     ArrayRef<DistributionLayout *> resultLattices,
     std::function<void(DistributionLayout *, ChangeResult)> update) {
 
-  // We do not support multiple results yet.
-  if (resultLattices.size() != 1)
-    return;
-
   DistributionLayout *result = resultLattices[0];
 
   const DistributionLayout *indicesLayout = operandLattices[0];
@@ -559,11 +555,6 @@ static void propagateLayoutToGatherOp(
   // If result lattice already has a layout, we cannot do anything. We do not
   // impose layout conflicts on results.
   if (result->hasLayout()) {
-    return;
-  }
-
-  // Cannot propagate layout if value is uninitialized.
-  if (indicesLayout->isUninitialized()) {
     return;
   }
 

--- a/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
@@ -765,8 +765,6 @@ void enforcementTransferFunction(
     ArrayRef<const DistributionLayout *> resultLattices,
     std::function<void(DistributionLayout *, ChangeResult)> update) {
 
-  llvm::dbgs() << "*op " << *op << "\n";
-
   if (auto toLayout = dyn_cast<ToLayoutOp>(op)) {
     enforceLayoutToLayoutOp(toLayout, operandLattices, resultLattices, update);
   }


### PR DESCRIPTION
This PR adds the distribution pattern for the vector.gather operation, along with the corresponding layout analysis. Additionally, test IRs for both distributing the operation and performing vector layout analysis have been included.