### PR TITLE
[LLVMGPU] Fix prefetching pass for nested loops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/PrefetchSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/PrefetchSharedMemoryCopy.cpp
@@ -78,6 +78,8 @@ public:
   void emitPrologue(RewriterBase &rewriter) {
     Location loc = forOp.getLoc();
     Value zero = rewriter.create<arith::ConstantIndexOp>(loc, lb);
+    // Emit barrier to ensure we can reuse shared memory.
+    emitBarrier(loc, rewriter);
     // Directly write in the prologue and use the shared memory to communicate
     // data instead of the loop carried values. Read (0)
     emitRead(mapping[0], rewriter, zero);


### PR DESCRIPTION
The prefetch pass assumes that shared memory can be reused in the prologue. This may not be true when nested loops are involved, so we need to explicitly insert a barrier to ensure we can reuse this memory.