### PR TITLE
[Codegen][GPU] Fuse into destinations for parallel tiling

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyTilingLevel.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyTilingLevel.cpp
@@ -140,8 +140,11 @@ applyTileAndFuseToEachRoot(RewriterBase &rewriter,
       if (auto tilingOwner = dyn_cast<TilingInterface>(owner)) {
         shouldFuse = !payloadOps.contains(tilingOwner);
       }
-      // Do not fuse destination operands.
-      shouldFuse &= !isDestinationOperand;
+      // Do not fuse destination operands for reduction tiling.
+      if (isDestinationOperand &&
+          tilingLevel == IREE::GPU::TilingLevel::Reduction) {
+        shouldFuse = false;
+      }
       if (shouldFuse) {
         return scf::SCFTileAndFuseOptions::ControlFnResult{
             yieldProducerReplacement};


### PR DESCRIPTION
Currently we disable fusion of destinations for all tiling levels, but that's only required for reduction tiling. Turn on fusion along destinations for parallel tiling levels.