### PR TITLE
Integrate LLVM at 9fa55ec3

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -100,8 +100,8 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
   LLVMCPUPipelineOptions pipelineOpts;
   if (isX86(target) || isRISCV(target)) {
     pipelineOpts.useConfiguredVectorSizes = false;
-    pipelineOpts.decomposePackUnPackOps = false;
   }
+  pipelineOpts.decomposePackUnPackOps = isDecompositionEnabled(funcOp);
   pipelineOpts.lowerToAVX2 = hasAVX2Feature(target);
   pipelineOpts.enableVectorMasking =
       isX86(target) || isRISCV(target) ||

--- a/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.cpp
@@ -20,6 +20,7 @@
 namespace mlir::iree_compiler {
 
 static const char kLoopPeelingAttrName[] = "enable_loop_peeling";
+static const char kDecompositionAttrName[] = "enable_decomposition";
 
 FailureOr<Operation *> getRootOperation(ArrayRef<Operation *> computeOps) {
   Operation *rootOperation = nullptr;
@@ -64,6 +65,16 @@ FailureOr<Operation *> getRootOperation(ArrayRef<Operation *> computeOps) {
   }
 
   return rootOperation;
+}
+
+StringAttr getEnableDecompositionAttrName(MLIRContext *ctx) {
+  return StringAttr::get(ctx, kDecompositionAttrName);
+}
+
+bool isDecompositionEnabled(FunctionOpInterface funcOp) {
+  DictionaryAttr config = getTranslationInfo(funcOp).getConfiguration();
+
+  return config && config.contains(kDecompositionAttrName);
 }
 
 StringAttr getEnableLoopPeelingAttrName(MLIRContext *ctx) {

--- a/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.h
@@ -20,6 +20,15 @@ namespace mlir::iree_compiler {
 FailureOr<Operation *> getRootOperation(ArrayRef<Operation *> computeOps);
 
 /// Creates a string attribute containing the name of the attribute that is
+/// used to enable decomposition.
+StringAttr getEnableDecompositionAttrName(MLIRContext *ctx);
+
+/// Checks whether loop peeling has been enabled for the input function. This
+/// is infered from the config dict. attribute that's part of to the
+/// translation info corresponding to this funciton.
+bool isDecompositionEnabled(FunctionOpInterface funcOp);
+
+/// Creates a string attribute containing the name of the attribute that is
 /// used to enable loop peeling.
 StringAttr getEnableLoopPeelingAttrName(MLIRContext *ctx);
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
@@ -176,7 +176,8 @@ static void addExecutableSubstitutionPasses(OpPassManager &passManager,
   }
   if (!substitutions.empty()) {
     SubstituteExecutablesPassOptions substituteOptions;
-    substituteOptions.substitutions = substitutions;
+    substituteOptions.substitutions.assign(substitutions.begin(),
+                                           substitutions.end());
     passManager.addPass(
         IREE::HAL::createSubstituteExecutablesPass(substituteOptions));
   }
@@ -197,12 +198,19 @@ void buildHALDeviceAssignmentPassPipeline(
     // Today we just assign devices from parameters but we should instead be
     // performing analysis at the flow level and then doing magic device
     // database lookups here.
-    passManager.addPass(IREE::HAL::createAssignLegacyTargetDevicesPass(
-        {&targetRegistry, assignmentOptions.legacyTargetBackends}));
+    AssignLegacyTargetDevicesPassOptions options;
+    options.targetRegistry = &targetRegistry;
+    options.targetBackends.assign(
+        assignmentOptions.legacyTargetBackends.begin(),
+        assignmentOptions.legacyTargetBackends.end());
+    passManager.addPass(
+        IREE::HAL::createAssignLegacyTargetDevicesPass(options));
   }
   if (!assignmentOptions.targetDevices.empty()) {
-    passManager.addPass(IREE::HAL::createAssignTargetDevicesPass(
-        {assignmentOptions.targetDevices}));
+    AssignTargetDevicesPassOptions options;
+    options.targetDevices.assign(assignmentOptions.targetDevices.begin(),
+                                 assignmentOptions.targetDevices.end());
+    passManager.addPass(IREE::HAL::createAssignTargetDevicesPass(options));
   }
 
   // Create globals for each device (if needed).

--- a/compiler/src/iree/compiler/Dialect/VM/Tools/VMOpEncoderGen.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Tools/VMOpEncoderGen.cpp
@@ -62,7 +62,7 @@ bool emitEncodeFnDefs(const llvm::RecordKeeper &recordKeeper, raw_ostream &os) {
     }
 
     os << "  if (";
-    auto printOneCondition = [&](Record *encodingExpr) {
+    auto printOneCondition = [&](const Record *encodingExpr) {
       StringRef expr = encodingExpr->getValueAsString("expr");
       std::vector<StringRef> params =
           encodingExpr->getValueAsListOfStrings("params");

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
@@ -81,9 +81,12 @@ void buildGlobalOptimizationPassPipeline(
   // parameters are available for folding.
   if (!transformOptions.options.parameterImportPaths.empty()) {
     IREE::IO::Parameters::ImportParametersPassOptions importParametersOptions;
-    importParametersOptions.scopePaths =
-        transformOptions.options.parameterImportPaths;
-    importParametersOptions.keys = transformOptions.options.parameterImportKeys;
+    importParametersOptions.scopePaths.assign(
+        transformOptions.options.parameterImportPaths.begin(),
+        transformOptions.options.parameterImportPaths.end());
+    importParametersOptions.keys.assign(
+        transformOptions.options.parameterImportKeys.begin(),
+        transformOptions.options.parameterImportKeys.end());
     importParametersOptions.maximumSize =
         transformOptions.options.parameterImportMaximumSize;
     mainPassManager.addPass(IREE::IO::Parameters::createImportParametersPass(


### PR DESCRIPTION
Cherry-picks:
1. https://github.com/llvm/llvm-project/pull/110918
2. https://github.com/llvm/llvm-project/pull/110904
3. https://github.com/llvm/llvm-project/pull/110927

The revision disables the pack/unpack decomposition when any of inner tiles is dynamic. Because it leads to unbounded stack allocation (which is introduced by tensor.pad op). It's broken by the `Extend the logic to generalise tensor.pack` commits. See https://github.com/llvm/llvm-project/commit/66f84c8b8a762832af39e91370018f8f8307a0fc and https://github.com/llvm/llvm-project/commit/1c01bcb35088a5509d31748298b9467e647f4287.