### PR TITLE
[Codegen][GPU] Improve loop fusion pattern verification

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/FuseAndHoistParallelLoops.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/FuseAndHoistParallelLoops.cpp
@@ -4,8 +4,6 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <functional>
-#include <numeric>
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/FuseAndHoistParallelLoops.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/FuseAndHoistParallelLoops.cpp
@@ -246,7 +246,8 @@ void FuseAndHoistParallelLoopsPass::runOnOperation() {
     // potentially nested loops, hoisting from said loops, and continued fusion.
     if (maybeFlatWorkgroupSize) {
       // Forall fusion requires knowing the workgroup size to verify the fusion
-      // is valid.
+      // is valid. Without validation we risk putting barriers inside
+      // conditioned regions (e.g. scf.if/for).
       patterns.add<FuseForalls>(context, *maybeFlatWorkgroupSize,
                                 /*benefit=*/1);
     }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/FuseAndHoistParallelLoops.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/FuseAndHoistParallelLoops.cpp
@@ -81,7 +81,7 @@ static bool forallTripCountMatchesWorkgroupSize(scf::ForallOp forallOp,
       return false;
     }
 
-    return *maybeParentTripCount * *maybeParentTripCount == flatWorkgroupSize;
+    return *maybeParentTripCount * *maybeTripCount == flatWorkgroupSize;
   }
 
   // All other loops must be mapped to threads to compare.

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/FuseAndHoistParallelLoops.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/FuseAndHoistParallelLoops.cpp
@@ -4,16 +4,23 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <functional>
+#include <numeric>
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
 #include "iree/compiler/Codegen/Dialect/GPU/Transforms/Passes.h"
 #include "iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.h"
 #include "iree/compiler/Codegen/Transforms/Transforms.h"
+#include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Casting.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/Interfaces/DestinationStyleOpInterface.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Interfaces/LoopLikeInterface.h"
@@ -36,36 +43,58 @@ struct FuseAndHoistParallelLoopsPass final
 };
 } // namespace
 
-struct FuseForalls final : OpRewritePattern<tensor::ExtractSliceOp> {
+static bool forallTripCountMatchesWorkgroupSize(scf::ForallOp forallOp,
+                                                int64_t flatWorkgroupSize) {
+  // True for lane mapped loops.
+  if (forallOpHasMappingType<IREE::GPU::LaneIdAttr>(forallOp)) {
+    return true;
+  }
+
+  // All other loops must be mapped to threads to compare. Also give up on
+  // non-normalized loops.
+  if (!forallOpHasMappingType<gpu::GPUThreadMappingAttr>(forallOp) ||
+      !forallOp.isNormalized()) {
+    return false;
+  }
+
+  int64_t tripCount = 1;
+  for (OpFoldResult ub : forallOp.getMixedUpperBound()) {
+    std::optional<int64_t> maybeConstantUb = getConstantIntValue(ub);
+    if (!maybeConstantUb) {
+      return false;
+    }
+    tripCount *= *maybeConstantUb;
+  }
+  return tripCount == flatWorkgroupSize;
+}
+struct FuseForalls final : OpRewritePattern<scf::ForallOp> {
   using OpRewritePattern::OpRewritePattern;
-  LogicalResult matchAndRewrite(tensor::ExtractSliceOp sliceOp,
+  FuseForalls(MLIRContext *ctx, int64_t flatWorkgroupSize, PatternBenefit b = 1)
+      : OpRewritePattern<scf::ForallOp>(ctx, b),
+        flatWorkgroupSize(flatWorkgroupSize) {}
+  LogicalResult matchAndRewrite(scf::ForallOp producerForall,
                                 PatternRewriter &rewriter) const override {
-    auto sliceParent = sliceOp->getParentOfType<scf::ForallOp>();
-    if (!sliceParent) {
-      return failure();
+    if (!producerForall->hasOneUse()) {
+      return rewriter.notifyMatchFailure(producerForall,
+                                         "multi-use producer forall");
     }
 
-    SmallVector<Operation *> consumerChain = {sliceOp};
-    Operation *currProducer = sliceOp.getSource().getDefiningOp();
-    while (currProducer && !llvm::isa<scf::ForallOp>(currProducer) &&
-           currProducer->hasOneUse()) {
-      consumerChain.insert(consumerChain.begin(), currProducer);
-      currProducer =
-          llvm::TypeSwitch<Operation *, Operation *>(currProducer)
-              .Case<tensor::ExpandShapeOp>([](tensor::ExpandShapeOp expand) {
-                return expand.getSrc().getDefiningOp();
-              })
-              .Case<tensor::CollapseShapeOp>(
-                  [](tensor::CollapseShapeOp collapse) {
-                    return collapse.getSrc().getDefiningOp();
-                  })
-              .Default([](Operation *) { return nullptr; });
+    SmallVector<Operation *> consumerChain;
+    Operation *currProducer = *producerForall->user_begin();
+    while (currProducer && currProducer->hasOneUse()) {
+      consumerChain.push_back(currProducer);
+      if (!isa<tensor::ExpandShapeOp, tensor::CollapseShapeOp>(currProducer)) {
+        break;
+      }
+      currProducer = *currProducer->user_begin();
     }
 
-    auto producerForall =
-        llvm::dyn_cast_if_present<scf::ForallOp>(currProducer);
-    if (!producerForall) {
-      return failure();
+    auto consumerForall = currProducer->getParentOfType<scf::ForallOp>();
+    if (!consumerForall || !forallTripCountMatchesWorkgroupSize(
+                               consumerForall, flatWorkgroupSize)) {
+      return rewriter.notifyMatchFailure(
+          producerForall,
+          "no consumer forall with trip count matching workgroup size");
     }
 
     // TODO: Allow extracting multiple uses within the same consumer loop. Still
@@ -75,9 +104,12 @@ struct FuseForalls final : OpRewritePattern<tensor::ExtractSliceOp> {
       return failure();
     }
 
-    return fuseForallIntoConsumer(rewriter, producerForall, sliceParent,
+    return fuseForallIntoConsumer(rewriter, producerForall, consumerForall,
                                   consumerChain);
   }
+
+private:
+  int64_t flatWorkgroupSize;
 };
 
 struct FuseTilableDestinationProducers final : OpRewritePattern<scf::ForallOp> {
@@ -198,12 +230,26 @@ void FuseAndHoistParallelLoopsPass::runOnOperation() {
 
   FunctionOpInterface funcOp = getOperation();
 
+  // Try to get the flat workgroup size if possible.
+  std::optional<int64_t> maybeFlatWorkgroupSize = std::nullopt;
+  if (std::optional<SmallVector<int64_t>> workgroupSize =
+          getWorkgroupSize(funcOp)) {
+    maybeFlatWorkgroupSize =
+        std::accumulate(workgroupSize->begin(), workgroupSize->end(), 1,
+                        std::multiplies<int64_t>());
+  }
+
   // First run the hoisting and fusion patterns.
   {
     RewritePatternSet patterns(context);
     // These two patterns are run to a fixed point, allowing fusion within
     // potentially nested loops, hoisting from said loops, and continued fusion.
-    patterns.add<FuseForalls>(context);
+    if (maybeFlatWorkgroupSize) {
+      // Forall fusion requires knowing the workgroup size to verify the fusion
+      // is valid.
+      patterns.add<FuseForalls>(context, *maybeFlatWorkgroupSize,
+                                /*benefit=*/1);
+    }
     patterns.add<FuseTilableForallConsumers>(context);
     populateForallLoopHoistingPattern(patterns);
     if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/fuse_and_hoist_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/fuse_and_hoist_forall.mlir
@@ -379,7 +379,7 @@ func.func @no_fuse_forall_without_workgroup_size(%arg0: tensor<128x128xf32>) -> 
 }
 
 //   CHECK-LABEL: func @no_fuse_forall_without_workgroup_size
-// CHECK-COUNT-2:   scf.forall
+// CHECK-COUNT-2:   scf.forall {{.*}} -> (tensor<128x128xf32>)
 
 // -----
 
@@ -413,7 +413,7 @@ func.func @no_fuse_forall_workgroup_size_mismatch(%arg0: tensor<128x128xf32>) ->
 }
 
 //   CHECK-LABEL: func @no_fuse_forall_workgroup_size_mismatch
-// CHECK-COUNT-2:   scf.forall
+// CHECK-COUNT-2:   scf.forall {{.*}} -> (tensor<128x128xf32>)
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
@@ -400,7 +400,7 @@ hal.executable public @main {
 #config = #iree_gpu.lowering_config<{
   workgroup = [64, 64, 0],
   reduction = [0, 0, 2],
-  subgroup = [2, 2],
+  subgroup = [1, 1],
   mma_kind = #iree_gpu.mma_layout<MFMA_I32_32x32x16_I8>,
   promote_operands = [0, 1]
 }>
@@ -440,8 +440,8 @@ hal.executable public @main {
 // CHECK-LABEL: func @matmul_transpose_b_mfma_32x32x16_i8
 //   CHECK-DAG:   memref.alloc() : memref<64x40xi8, #gpu.address_space<workgroup>>
 //   CHECK-DAG:   memref.alloc() : memref<64x40xi8, #gpu.address_space<workgroup>>
-//       CHECK:   scf.for %{{.*}} = %c0 to %c80 step %c2 {{.*}} -> (vector<2x2x4x4x1xi32>)
-// CHECK-COUNT-8:   amdgpu.mfma {{.*}}blocks = 1 : i32, k = 16 : i32, m = 32 : i32, n = 32 : i32
+//       CHECK:   scf.for %{{.*}} = %c0 to %c80 step %c2 {{.*}} -> (vector<1x1x4x4x1xi32>)
+// CHECK-COUNT-2:   amdgpu.mfma {{.*}}blocks = 1 : i32, k = 16 : i32, m = 32 : i32, n = 32 : i32
 //       CHECK:     scf.yield
 
 // -----


### PR DESCRIPTION
The current loop fusion patterns don't verify that the consumer loop won't be
predicated after resolution. This is required because the loop fusion pattern
introduces barrier semantics to the loop body which will result in invalid IR
if the loop resolves to an `scf.if` (or anything that could lead to thread
divergence).

This also makes it so the loop fusion pattern does not require the consumer
loop to have a `tensor.extract_slice`, improving the robustness of the pattern.