### PR TITLE
Limit transposition of narrow-N to only CPUMaterializeEncoding

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
@@ -92,8 +92,9 @@ static RankedTensorType transposeIfNarrowNResult(RankedTensorType tensorType) {
 
 MaterializeEncodingTypeConverter::MaterializeEncodingTypeConverter(
     MaterializeEncodingFn materializeEncodingFn,
-    IREE::HAL::ExecutableTargetAttr targetAttr)
-    : materializeEncodingFn(materializeEncodingFn), targetAttr(targetAttr) {
+    IREE::HAL::ExecutableTargetAttr targetAttr, bool transposeNarrowN)
+    : materializeEncodingFn(materializeEncodingFn), targetAttr(targetAttr),
+      transposeNarrowN(transposeNarrowN) {
   addConversion([](IntegerType intType) { return intType; });
   addConversion([](IndexType indexType) { return indexType; });
   addConversion([](FloatType floatType) { return floatType; });
@@ -102,7 +103,8 @@ MaterializeEncodingTypeConverter::MaterializeEncodingTypeConverter(
     // For a given tensor type with an encoding, return the materialized
     // type to use for it. If no encoding is set, then return the tensor type
     // itself.
-    RankedTensorType tensorType = transposeIfNarrowNResult(type);
+    RankedTensorType tensorType =
+        transposeNarrowN ? transposeIfNarrowNResult(type) : type;
     FailureOr<MaterializeEncodingInfo> maybeEncodingInfo =
         getEncodingInfo(tensorType);
     if (failed(maybeEncodingInfo)) {

--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.h
@@ -47,7 +47,8 @@ using MaterializeEncodingValueFn =
 class MaterializeEncodingTypeConverter : public TypeConverter {
 public:
   MaterializeEncodingTypeConverter(MaterializeEncodingFn fn,
-                                   IREE::HAL::ExecutableTargetAttr targetAttr);
+                                   IREE::HAL::ExecutableTargetAttr targetAttr,
+                                   bool transposeNarrowN);
 
   const MaterializeEncodingFn &getMaterializeEncodingFn() const {
     return materializeEncodingFn;
@@ -60,9 +61,12 @@ public:
     return materializeEncodingFn(type, targetAttr);
   }
 
+  bool getTransposeNarrowN() const { return transposeNarrowN; }
+
 private:
   const MaterializeEncodingFn materializeEncodingFn;
   const IREE::HAL::ExecutableTargetAttr targetAttr;
+  bool transposeNarrowN = false;
 };
 
 /// Conversion target to use for for materializing the encoding.

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUMaterializeEncoding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUMaterializeEncoding.cpp
@@ -436,7 +436,7 @@ materializeFuncOpEncodings(FunctionOpInterface funcOp,
     // 1. As linalg.matmul materializes into iree_gpu.multi_mma, which inherits
     //    its semantics from the wrapped intrinsic, we can't rely on any kind of
     //    LHS<->RHS symmetry.
-    // 2. We do not currently use ukernels, which would be one of the main ares
+    // 2. We do not currently use ukernels, which would be one of the main areas
     //    to benefit from transposeNarrowN.
     // 3. Heuristics for cache-friendly dispatch tiling are internal to the GPU
     //    runtime, so we don't need a simplification at that level either.

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoNop.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoNop.cpp
@@ -45,7 +45,8 @@ struct MaterializeEncodingIntoNopPass final
 
     RewritePatternSet materializeEncodingPattern(context);
     MaterializeEncodingTypeConverter typeConverter(
-        materializeEncodingFn, IREE::HAL::ExecutableTargetAttr());
+        materializeEncodingFn, IREE::HAL::ExecutableTargetAttr(),
+        /*transposeNarrowN=*/false);
     MaterializeEncodingConversionTarget target(*context);
     populateMaterializeEncodingIntoPackUnPackPatterns(
         materializeEncodingPattern, typeConverter, materializeEncodingValueFn);


### PR DESCRIPTION
The comments added in this PR explain why this is wanted on CPU, and not wanted on GPU.

This fixes e2e correctness issues that we were experiencing on GPU data tiling, as transposition of narrow-N was not fully implemented there.