### PR TITLE
[CPU][NFC] Collapsing methods that query a config is enabled.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -2703,7 +2703,7 @@ adjustTileSizesForUnPackOp(mlir::FunctionOpInterface entryPointFn,
   auto tInfo = getTranslationInfo(entryPointFn);
   auto pipeline = tInfo.getPassPipeline().getValue();
   auto pipelineConfig = tInfo.getConfiguration();
-  if (isLoopPeelingEnabled(entryPointFn)) {
+  if (isOptEnabled(entryPointFn, getEnableLoopPeelingStr())) {
     // See #16406
     LLVM_DEBUG(KD_DBGS() << "unpack fusion does not work with peeling, falling "
                             "back to non-peeling path");

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -97,11 +97,17 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
     return;
   }
 
+  IREE::Codegen::TranslationInfoAttr translationInfo =
+      getTranslationInfo(funcOp);
+  if (!translationInfo)
+    return;
+
   LLVMCPUPipelineOptions pipelineOpts;
   if (isX86(target) || isRISCV(target)) {
     pipelineOpts.useConfiguredVectorSizes = false;
   }
-  pipelineOpts.decomposePackUnPackOps = isDecompositionEnabled(funcOp);
+  pipelineOpts.decomposePackUnPackOps =
+      isOptEnabled(funcOp, getEnableDecompositionStr());
   pipelineOpts.lowerToAVX2 = hasAVX2Feature(target);
   pipelineOpts.enableVectorMasking =
       isX86(target) || isRISCV(target) ||
@@ -109,12 +115,7 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
   pipelineOpts.enableAArch64SME =
       isAArch64(target) && hasAnySVEFeature(target) && hasSMEFeature(target);
   pipelineOpts.enableAArch64I8mm = isAArch64(target) && hasI8mmFeature(target);
-  pipelineOpts.enablePeeling = isLoopPeelingEnabled(funcOp);
-
-  IREE::Codegen::TranslationInfoAttr translationInfo =
-      getTranslationInfo(funcOp);
-  if (!translationInfo)
-    return;
+  pipelineOpts.enablePeeling = isOptEnabled(funcOp, getEnableLoopPeelingStr());
 
   OpPassManager pipeline(func::FuncOp::getOperationName());
   switch (translationInfo.getDispatchLoweringPassPipeline()) {

--- a/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.cpp
@@ -19,9 +19,6 @@
 
 namespace mlir::iree_compiler {
 
-static const char kLoopPeelingAttrName[] = "enable_loop_peeling";
-static const char kDecompositionAttrName[] = "enable_decomposition";
-
 FailureOr<Operation *> getRootOperation(ArrayRef<Operation *> computeOps) {
   Operation *rootOperation = nullptr;
   for (auto op : llvm::reverse(computeOps)) {
@@ -67,24 +64,21 @@ FailureOr<Operation *> getRootOperation(ArrayRef<Operation *> computeOps) {
   return rootOperation;
 }
 
+static const char kDecompositionAttrName[] = "enable_decomposition";
 StringAttr getEnableDecompositionAttrName(MLIRContext *ctx) {
   return StringAttr::get(ctx, kDecompositionAttrName);
 }
+std::string getEnableDecompositionStr() { return kDecompositionAttrName; }
 
-bool isDecompositionEnabled(FunctionOpInterface funcOp) {
-  DictionaryAttr config = getTranslationInfo(funcOp).getConfiguration();
-
-  return config && config.contains(kDecompositionAttrName);
-}
-
+static const char kLoopPeelingAttrName[] = "enable_loop_peeling";
 StringAttr getEnableLoopPeelingAttrName(MLIRContext *ctx) {
   return StringAttr::get(ctx, kLoopPeelingAttrName);
 }
+std::string getEnableLoopPeelingStr() { return kLoopPeelingAttrName; }
 
-bool isLoopPeelingEnabled(FunctionOpInterface funcOp) {
+bool isOptEnabled(FunctionOpInterface funcOp, StringRef label) {
   DictionaryAttr config = getTranslationInfo(funcOp).getConfiguration();
-
-  return config && config.contains(kLoopPeelingAttrName);
+  return config && config.contains(label);
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/CPUUtils.h
@@ -22,20 +22,17 @@ FailureOr<Operation *> getRootOperation(ArrayRef<Operation *> computeOps);
 /// Creates a string attribute containing the name of the attribute that is
 /// used to enable decomposition.
 StringAttr getEnableDecompositionAttrName(MLIRContext *ctx);
-
-/// Checks whether loop peeling has been enabled for the input function. This
-/// is infered from the config dict. attribute that's part of to the
-/// translation info corresponding to this funciton.
-bool isDecompositionEnabled(FunctionOpInterface funcOp);
+std::string getEnableDecompositionStr();
 
 /// Creates a string attribute containing the name of the attribute that is
 /// used to enable loop peeling.
 StringAttr getEnableLoopPeelingAttrName(MLIRContext *ctx);
+std::string getEnableLoopPeelingStr();
 
-/// Checks whether loop peeling has been enabled for the input function. This
-/// is infered from the config dictt. attribute that's part of to the
-/// translation info corresponding to this funciton.
-bool isLoopPeelingEnabled(FunctionOpInterface funcOp);
+/// Returns true if the UnitAttr of the `label` is enabled for the input
+/// function. This is is infered from the config dictionary. attribute that's
+/// part of to the translation info corresponding to this funciton.
+bool isOptEnabled(FunctionOpInterface funcOp, StringRef label);
 
 } // namespace mlir::iree_compiler
 


### PR DESCRIPTION
It just looks if the UnitAttr is set in the dictionary or not.

The `translationInfo` check is moved above LLVMCPUPipelineOptions setup because some configs are set to `translationInfo`. We can bail out earlier when it does not exist.

It is a follow-up for https://github.com/iree-org/iree/commit/903ab0a7cefec46ddade4278e6d547dc9e4598a8