### PR TITLE
Legalize newly added compiler hints ops.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Conversion/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Util/Conversion/test/BUILD.bazel
@@ -15,7 +15,10 @@ package(
 iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
-        ["structural_ops.mlir"],
+        [
+            "compiler_hints.mlir",
+            "structural_ops.mlir",
+        ],
         include = ["*.mlir"],
     ),
     cfg = "//compiler:lit.cfg.py",

--- a/compiler/src/iree/compiler/Dialect/Util/Conversion/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Util/Conversion/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "compiler_hints.mlir"
     "structural_ops.mlir"
   TOOLS
     FileCheck

--- a/compiler/src/iree/compiler/Dialect/Util/Conversion/test/compiler_hints.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Conversion/test/compiler_hints.mlir
@@ -1,0 +1,32 @@
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-util-test-conversion{widen-integers})' %s | FileCheck %s
+
+// CHECK-LABEL: @assumeDivisibleOp
+util.func public @assumeDivisibleOp(%arg0 : i16) -> i16 {
+  // CHECK: util.assume.divisible {{.*}} by 4 : i32
+  %0 = util.assume.divisible %arg0 by 4 : i16
+  util.return %0 : i16
+}
+
+// -----
+// CHECK-LABEL: @assumeNarrowOp
+util.func public @assumeNarrowOp(%arg0 : i16) -> i16 {
+  // CHECK: util.assume.narrow %arg0 : i32 to i8
+  %0 = util.assume.narrow %arg0 : i16 to i8
+  util.return %0 : i16
+}
+
+// -----
+// CHECK-LABEL: @assumeRangeOp
+util.func public @assumeRangeOp(%arg0 : i16) -> i16 {
+  // CHECK: util.assume.range %arg0 in [4, 12] : i32
+  %0 = util.assume.range %arg0 in [4, 12] : i16
+  util.return %0 : i16
+}
+
+// -----
+// CHECK-LABEL: @optimizationBarrier
+util.func public @optimizationBarrier(%arg0 : i16) -> i16 {
+  // CHECK: util.optimization_barrier %arg0 : i32
+  %0 = util.optimization_barrier %arg0 : i16
+  util.return %0 : i16
+}


### PR DESCRIPTION
This was missed in the prior patch adding the util.assume.* ops.

Adds tests, including for the untested util.optimization_barrier op.