### PR TITLE
[Encoding] Introduce getElementTypesArray helper in EncodingAttr.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPULowerToUKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPULowerToUKernels.cpp
@@ -475,7 +475,7 @@ matchDAGForUKernel(RewriterBase &rewriter, tensor::UnPackOp op,
 
 static uint32_t
 getFlagForUserAndOperandTypes(IREE::Encoding::EncodingAttr encoding,
-                              ArrayRef<Attribute> operandTypes) {
+                              ArrayRef<Type> operandTypes) {
   // There are currently no batch_mmt4d ukernels, so check for no batch
   // dimension.
   auto cDims = IREE::Encoding::getEncodingContractionDims(encoding);
@@ -483,9 +483,9 @@ getFlagForUserAndOperandTypes(IREE::Encoding::EncodingAttr encoding,
     return IREE_UK_FLAG_QUERY_TILE_SIZES_OPERATION_NONE;
   }
 
-  Type lhs = cast<TypeAttr>(operandTypes[0]).getValue();
-  Type rhs = cast<TypeAttr>(operandTypes[1]).getValue();
-  Type out = cast<TypeAttr>(operandTypes[2]).getValue();
+  Type lhs = operandTypes[0];
+  Type rhs = operandTypes[1];
+  Type out = operandTypes[2];
 
   if (lhs.isF32() && rhs.isF32() && out.isF32()) {
     return IREE_UK_FLAG_QUERY_TILE_SIZES_OPERATION_MATMUL_F32F32F32;
@@ -545,8 +545,8 @@ matchDAGForUKernel(RewriterBase &rewriter, IREE::Codegen::QueryTileSizesOp op,
   for (int64_t i : tensorType.getShape()) {
     inputValues.push_back(rewriter.create<arith::ConstantIndexOp>(loc, i));
   }
-  uint32_t flagForUserAndOperandTypes = getFlagForUserAndOperandTypes(
-      encoding, encoding.getElementTypes().getValue());
+  uint32_t flagForUserAndOperandTypes =
+      getFlagForUserAndOperandTypes(encoding, encoding.getElementTypesArray());
   uint32_t flagForIndex =
       getFlagForIndex(encoding.getOperandIndex().getValue().getZExtValue());
   if (!flagForUserAndOperandTypes || !flagForIndex) {

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPUMaterializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPUMaterializeEncodings.cpp
@@ -405,10 +405,7 @@ enumerateMatmulTileMxNxK(IREE::Encoding::EncodingAttr encoding,
     return {};
   }
   // Enumerate available tile shapes for the given encoding and target.
-  auto elementTypes = llvm::to_vector(
-      llvm::map_range(encoding.getElementTypes().getValue(), [](Attribute a) {
-        return cast<TypeAttr>(a).getValue();
-      }));
+  SmallVector<Type> elementTypes = encoding.getElementTypesArray();
   if (isVMVXBackend(target)) {
     return enumerateMatmulTilesVMVX(*cDims, encoding, target);
   }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUMaterializeEncoding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUMaterializeEncoding.cpp
@@ -110,12 +110,8 @@ materializeEncodingForTarget(RankedTensorType tensorType,
   } else {
     gpuTargetAttr = getCLGPUTarget(tensorType.getContext());
   }
-  auto elementTypes = llvm::to_vector(
-      llvm::map_range(encoding.getElementTypes().getValue(), [](Attribute a) {
-        return cast<TypeAttr>(a).getValue();
-      }));
   std::optional<IREE::GPU::DataTiledMMAAttr> mma =
-      chooseDataTiledMMAAttr(elementTypes, gpuTargetAttr);
+      chooseDataTiledMMAAttr(encoding.getElementTypesArray(), gpuTargetAttr);
   if (!mma) {
     return failure();
   }
@@ -377,11 +373,8 @@ public:
     } else {
       gpuTargetAttr = getCLGPUTarget(op.getContext());
     }
-    auto elementTypes = llvm::to_vector(llvm::map_range(
-        resultEncoding.getElementTypes().getValue(),
-        [](Attribute a) { return cast<TypeAttr>(a).getValue(); }));
-    std::optional<IREE::GPU::DataTiledMMAAttr> mma =
-        chooseDataTiledMMAAttr(elementTypes, gpuTargetAttr);
+    std::optional<IREE::GPU::DataTiledMMAAttr> mma = chooseDataTiledMMAAttr(
+        resultEncoding.getElementTypesArray(), gpuTargetAttr);
     if (!mma) {
       LLVM_DEBUG(llvm::dbgs() << "can't find supported Mma intrinsic\n");
       return failure();

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPackUnPack.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPackUnPack.cpp
@@ -332,9 +332,7 @@ static FailureOr<Operation *> lowerContractionOpWithEncoding(
   } else {
     bool transpose =
         typeConverter.getTransposeNarrowN() && isNarrowNResult(resultEncoding);
-    auto elemTypes = llvm::map_to_vector(
-        lhsEncoding.getElementTypes().getValue(),
-        [](Attribute a) { return cast<TypeAttr>(a).getValue(); });
+    SmallVector<Type> elemTypes = lhsEncoding.getElementTypesArray();
     SmallVector<ReassociationIndices> ri;
     Value newLhs = getMmt4dOperand(operands[0], linalgOp, transpose, rewriter,
                                    ri, elemTypes, /*operandIdx=*/0);

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingBase.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingBase.td
@@ -108,6 +108,9 @@ def EncodingAttr :
     /// Returns an integer array with values in `round_dims_to`.
     ArrayRef<int64_t> getRoundDimsToArray();
 
+    /// Returns a vector with values in `element_types`.
+    SmallVector<Type> getElementTypesArray();
+
     /// Clones an encoding with a new bcast_map
     EncodingAttr clone(AffineMap bcastMap);
   }];

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.cpp
@@ -172,6 +172,12 @@ ArrayRef<int64_t> EncodingAttr::getRoundDimsToArray() {
   return llvm::cast<DenseI64ArrayAttr>(roundDimsTo).asArrayRef();
 }
 
+SmallVector<Type> EncodingAttr::getElementTypesArray() {
+  return llvm::map_to_vector(getElementTypes().getValue(), [](Attribute a) {
+    return llvm::cast<TypeAttr>(a).getValue();
+  });
+}
+
 EncodingAttr EncodingAttr::clone(AffineMap bcastMap) {
   return get(bcastMap.getContext(), getOperandIndex(), getOpType(),
              getElementTypes(), getUserIndexingMaps(),


### PR DESCRIPTION
The new method returns the vector of the element types (in `Type` type). The revision implements the method and replaces the current code with it.

This is an NFC change in terms of data-tiling.