### PR TITLE
Add a pass for simplifying numeric/index arithmetic.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Attributes/PotentialValues.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Attributes/PotentialValues.cpp
@@ -7,12 +7,33 @@
 #include "iree/compiler/Dialect/Util/Analysis/Attributes/PotentialValues.h"
 
 #include "llvm/Support/Debug.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/Matchers.h"
 
 #define DEBUG_TYPE "iree-util-attributes"
 using llvm::dbgs;
 
 namespace mlir::iree_compiler::IREE::Util {
+
+static std::string
+getPVSAsStr(const DFX::PotentialConstantIntValuesState &pvs) {
+  std::string str;
+  llvm::raw_string_ostream sstream(str);
+  sstream << "pvs: ";
+  if (pvs.isValidState()) {
+    sstream << "[";
+    if (pvs.isUndefContained()) {
+      sstream << "undef, ";
+    }
+    llvm::interleaveComma(pvs.getAssumedSet(), sstream,
+                          [&](APInt value) { value.print(sstream, false); });
+    sstream << "]";
+  } else {
+    sstream << "(invalid)";
+  }
+  sstream.flush();
+  return str;
+}
 
 //===----------------------------------------------------------------------===//
 // ConstantAttributePVS
@@ -71,6 +92,128 @@ const std::string ConstantAttributePVS::getAsStr(AsmState &asmState) const {
   }
   sstream.flush();
   return str;
+}
+
+//===----------------------------------------------------------------------===//
+// GlobalPVS
+//===----------------------------------------------------------------------===//
+
+const char GlobalPVS::ID = 0;
+
+void GlobalPVS::initializeOperation(IREE::Util::GlobalOp globalOp,
+                                    DFX::Solver &solver) {
+  auto *globalInfo = solver.getExplorer().getGlobalInfo(globalOp);
+  if (!globalInfo || globalInfo->isIndirect) {
+    // Cannot perform analysis.
+    indicatePessimisticFixpoint();
+  } else if (globalInfo) {
+    if (auto initialValue = llvm::dyn_cast_if_present<IntegerAttr>(
+            globalOp.getInitialValueAttr())) {
+      // Initial value is available for use; stored values from the rest of the
+      // program will come during iteration.
+      unionAssumed(initialValue.getValue());
+    }
+  }
+}
+
+ChangeStatus GlobalPVS::updateOperation(IREE::Util::GlobalOp globalOp,
+                                        DFX::Solver &solver) {
+  StateType newState;
+  auto *globalInfo = solver.getExplorer().getGlobalInfo(globalOp);
+  for (auto use : globalInfo->uses) {
+    auto storeOp = dyn_cast<IREE::Util::GlobalStoreOpInterface>(use);
+    if (!storeOp)
+      continue;
+    auto value = solver.getElementFor<IntValuePVS>(
+        *this, Position::forValue(storeOp.getStoredGlobalValue()),
+        DFX::Resolution::REQUIRED);
+    if (value.isValidState()) {
+      newState.unionAssumed(value);
+    } else {
+      newState.unionAssumedWithUndef();
+      newState.indicatePessimisticFixpoint();
+    }
+  }
+  return DFX::clampStateAndIndicateChange(getState(), newState);
+}
+
+const std::string GlobalPVS::getAsStr(AsmState &asmState) const {
+  return getPVSAsStr(getState());
+}
+
+//===----------------------------------------------------------------------===//
+// IntValuePVS
+//===----------------------------------------------------------------------===//
+
+const char IntValuePVS::ID = 0;
+
+void IntValuePVS::initializeValue(Value value, DFX::Solver &solver) {
+  APInt staticValue;
+  if (matchPattern(value, m_ConstantInt(&staticValue))) {
+    LLVM_DEBUG(dbgs() << "IntValuePVS: Match constant " << staticValue << "\n");
+    unionAssumed(staticValue);
+    indicateOptimisticFixpoint();
+  }
+}
+
+ChangeStatus IntValuePVS::updateValue(Value value, DFX::Solver &solver) {
+  StateType newState;
+  if (solver.getExplorer().walkDefiningOps(value, [&](OpResult result) {
+        APInt staticValue;
+        if (matchPattern(result, m_ConstantInt(&staticValue))) {
+          newState.unionAssumed(staticValue);
+          return WalkResult::advance();
+        }
+
+        if (auto loadOp = dyn_cast<IREE::Util::GlobalLoadOpInterface>(
+                result.getDefiningOp())) {
+          auto *globalInfo = solver.getExplorer().queryGlobalInfoFrom(
+              loadOp.getGlobalName(), loadOp);
+          auto global = solver.getElementFor<GlobalPVS>(
+              *this, Position::forOperation(globalInfo->op),
+              DFX::Resolution::REQUIRED);
+          if (global.isValidState()) {
+            newState.unionAssumed(global);
+            return WalkResult::advance();
+          }
+        }
+
+        // TODO(benvanik): more ops supported for joining. We could for
+        // example walk the lhs/rhs of elementwise ops and perform the set
+        // operations (so addi %lhs, %rhs could produce a PVS of all of %lhs
+        // summed to all of %rhs). May not be worth it, though.
+        // TODO(benvanik): move select op walking to the explorer.
+        if (auto selectOp =
+                dyn_cast<mlir::arith::SelectOp>(result.getDefiningOp())) {
+          auto lhs = solver.getElementFor<IntValuePVS>(
+              *this, Position::forValue(selectOp.getTrueValue()),
+              DFX::Resolution::REQUIRED);
+          auto rhs = solver.getElementFor<IntValuePVS>(
+              *this, Position::forValue(selectOp.getFalseValue()),
+              DFX::Resolution::REQUIRED);
+          if (!lhs.isValidState() || !rhs.isValidState()) {
+            newState.unionAssumedWithUndef();
+            newState.indicatePessimisticFixpoint();
+          } else {
+            newState.unionAssumed(lhs);
+            newState.unionAssumed(rhs);
+          }
+          return WalkResult::advance();
+        }
+
+        // Some other dynamic value we can't analyze (yet).
+        newState.unionAssumedWithUndef();
+        newState.indicatePessimisticFixpoint();
+        return WalkResult::advance();
+      }) == TraversalResult::INCOMPLETE) {
+    newState.unionAssumedWithUndef();
+    newState.indicatePessimisticFixpoint();
+  }
+  return DFX::clampStateAndIndicateChange(getState(), newState);
+}
+
+const std::string IntValuePVS::getAsStr(AsmState &asmState) const {
+  return getPVSAsStr(getState());
 }
 
 } // namespace mlir::iree_compiler::IREE::Util

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Attributes/PotentialValues.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Attributes/PotentialValues.h
@@ -10,9 +10,12 @@
 #include "iree/compiler/Dialect/Util/Analysis/DFX/Element.h"
 #include "iree/compiler/Dialect/Util/Analysis/DFX/Solver.h"
 #include "iree/compiler/Dialect/Util/Analysis/DFX/State.h"
+#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 
 namespace mlir::iree_compiler::IREE::Util {
 
+//===----------------------------------------------------------------------===//
+// ConstantAttributePVS
 // Potential value set of Attribute instances representing constant values.
 // The yielded set of potential values will consist of |mlir::Attribute|
 // instances representing the values of any constants or immutable globals
@@ -20,6 +23,8 @@ namespace mlir::iree_compiler::IREE::Util {
 // control-flow without alteration. If the program flow passes any
 // unrecognized operations, the set will include undef, indicating that
 // there may be non-constants in the data-flow.
+//===----------------------------------------------------------------------===//
+
 class ConstantAttributePVS
     : public DFX::StateWrapper<DFX::PotentialValuesState<Attribute>,
                                DFX::ValueElement> {
@@ -46,6 +51,80 @@ public:
 private:
   void initializeValue(Value value, DFX::Solver &solver) override;
   ChangeStatus updateValue(Value value, DFX::Solver &solver) override;
+};
+
+//===----------------------------------------------------------------------===//
+// GlobalPVS
+// Potential value set of global operations.
+//===----------------------------------------------------------------------===//
+
+class GlobalPVS : public DFX::StateWrapper<
+                      DFX::PotentialConstantIntValuesState,
+                      DFX::TypedOperationElement<IREE::Util::GlobalOp>> {
+public:
+  using BaseType =
+      DFX::StateWrapper<DFX::PotentialConstantIntValuesState,
+                        DFX::TypedOperationElement<IREE::Util::GlobalOp>>;
+
+  static GlobalPVS &createForPosition(const Position &pos,
+                                      DFX::Solver &solver) {
+    return *(new (solver.getAllocator()) GlobalPVS(pos));
+  }
+
+  const std::string getName() const override { return "GlobalPVS"; }
+  const void *getID() const override { return &ID; }
+  static bool classof(const DFX::AbstractElement *element) {
+    return (element->getID() == &ID);
+  }
+  static const char ID;
+
+  const std::string getAsStr(AsmState &asmState) const override;
+
+private:
+  explicit GlobalPVS(const Position &pos) : BaseType(pos) {}
+
+  void initializeOperation(IREE::Util::GlobalOp globalOp,
+                           DFX::Solver &solver) override;
+  ChangeStatus updateOperation(IREE::Util::GlobalOp globalOp,
+                               DFX::Solver &solver) override;
+
+  friend class DFX::Solver;
+};
+
+//===----------------------------------------------------------------------===//
+// IntValuePVS
+// Potential value set of global operations.
+// TODO: This is really ConstantIntPVS. Rename.
+//===----------------------------------------------------------------------===//
+
+class IntValuePVS
+    : public DFX::StateWrapper<DFX::PotentialConstantIntValuesState,
+                               DFX::ValueElement> {
+public:
+  using BaseType = DFX::StateWrapper<DFX::PotentialConstantIntValuesState,
+                                     DFX::ValueElement>;
+
+  static IntValuePVS &createForPosition(const Position &pos,
+                                        DFX::Solver &solver) {
+    return *(new (solver.getAllocator()) IntValuePVS(pos));
+  }
+
+  const std::string getName() const override { return "IntValuePVS"; }
+  const void *getID() const override { return &ID; }
+  static bool classof(const DFX::AbstractElement *element) {
+    return (element->getID() == &ID);
+  }
+  static const char ID;
+
+  const std::string getAsStr(AsmState &asmState) const override;
+
+private:
+  explicit IntValuePVS(const Position &pos) : BaseType(pos) {}
+
+  void initializeValue(Value value, DFX::Solver &solver) override;
+
+  ChangeStatus updateValue(Value value, DFX::Solver &solver) override;
+  friend class DFX::Solver;
 };
 
 } // namespace mlir::iree_compiler::IREE::Util

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/BUILD.bazel
@@ -31,6 +31,7 @@ iree_compiler_cc_library(
         "Patterns.cpp",
         "PropagateSubranges.cpp",
         "SimplifyGlobalAccesses.cpp",
+        "SimplifyIndexArithmetic.cpp",
         "StripAndSplatConstants.cpp",
         "StripDebugOps.cpp",
         "TestConversion.cpp",

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/CMakeLists.txt
@@ -34,6 +34,7 @@ iree_cc_library(
     "Patterns.cpp"
     "PropagateSubranges.cpp"
     "SimplifyGlobalAccesses.cpp"
+    "SimplifyIndexArithmetic.cpp"
     "StripAndSplatConstants.cpp"
     "StripDebugOps.cpp"
     "TestConversion.cpp"

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.h
@@ -32,6 +32,7 @@ std::unique_ptr<OperationPass<mlir::ModuleOp>> createFuseGlobalsPass();
 std::unique_ptr<OperationPass<mlir::ModuleOp>> createIPOPass();
 std::unique_ptr<OperationPass<mlir::ModuleOp>> createPropagateSubrangesPass();
 std::unique_ptr<OperationPass<void>> createSimplifyGlobalAccessesPass();
+std::unique_ptr<OperationPass<void>> createSimplifyIndexArithmeticPass();
 std::unique_ptr<OperationPass<mlir::ModuleOp>>
 createStripAndSplatConstantsPass();
 std::unique_ptr<OperationPass<void>> createStripDebugOpsPass();

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.td
@@ -124,6 +124,13 @@ def SimplifyGlobalAccesses :
   }];
 }
 
+def SimplifyIndexArithmetic : Pass<"iree-util-simplify-index-arithmetic", ""> {
+  let summary = "Simplify index arithmetic.";
+  let constructor = [{
+    mlir::iree_compiler::IREE::Util::createSimplifyIndexArithmeticPass()
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Resource Management
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/SimplifyIndexArithmetic.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/SimplifyIndexArithmetic.cpp
@@ -1,0 +1,549 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Util/Analysis/Attributes/PotentialValues.h"
+#include "iree/compiler/Dialect/Util/Analysis/DFX/Solver.h"
+#include "iree/compiler/Dialect/Util/Analysis/DFX/State.h"
+#include "iree/compiler/Dialect/Util/Analysis/Explorer.h"
+#include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
+#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTraits.h"
+#include "iree/compiler/Dialect/Util/Transforms/PassDetail.h"
+#include "iree/compiler/Dialect/Util/Transforms/Passes.h"
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassRegistry.h"
+
+#define DEBUG_TYPE "iree-util-index"
+
+using llvm::dbgs;
+
+namespace mlir::iree_compiler::IREE::Util {
+namespace {
+
+//===----------------------------------------------------------------------===//
+// APIntStateBase
+//===----------------------------------------------------------------------===//
+
+class APIntStateBase : public DFX::AbstractState {
+public:
+  APIntStateBase(unsigned numBits, APInt known, APInt assumed)
+      : numBits(numBits), known(known), assumed(assumed) {}
+
+  static APInt getUndefValue() {
+    // Zero bit APInt.
+    return APInt::getZeroWidth();
+  }
+  static bool isUndefValue(APInt value) { return value.getBitWidth() == 0; }
+
+  bool isValidState() const override { return !isUndefValue(assumed); }
+  bool isAtFixpoint() const override { return assumed == known; }
+
+  ChangeStatus indicateOptimisticFixpoint() override {
+    known = assumed;
+    return ChangeStatus::UNCHANGED;
+  }
+
+  ChangeStatus indicatePessimisticFixpoint() override {
+    assumed = known;
+    return ChangeStatus::CHANGED;
+  }
+
+  APInt getKnown() const { return known; }
+  APInt getAssumed() const { return assumed; }
+
+protected:
+  unsigned numBits;
+  APInt known;
+  APInt assumed;
+};
+
+//===----------------------------------------------------------------------===//
+// IncAPIntState
+// APIntStateBase specialization for increasing values where larger quantities
+// are better.
+//===----------------------------------------------------------------------===//
+
+class IncAPIntState : public APIntStateBase {
+public:
+  using APIntStateBase::APIntStateBase;
+
+  // "Clamps" this state with |rhs|. The result is subtype dependent but it is
+  // intended that only information assumed in both states will be assumed in
+  // this one afterwards.
+  void operator^=(const IncAPIntState &rhs) {
+    takeAssumedMinimum(rhs.getAssumed());
+  }
+
+  IncAPIntState &takeAssumedMinimum(APInt assumed) {
+    // The undef value is effectively -inf (lowest possible value).
+    if (isUndefValue(assumed) || isUndefValue(this->assumed)) {
+      this->assumed = this->known;
+      return *this;
+    }
+
+    APInt assumedMin = llvm::APIntOps::umin(this->assumed, assumed);
+    if (!isUndefValue(this->known)) {
+      // Don't lose any known value.
+      assumedMin = llvm::APIntOps::umax(assumedMin, this->known);
+    }
+    this->assumed = assumedMin;
+
+    return *this;
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// DecAPIntState
+// APIntStateBase specialization for decreasing values where smaller quantities
+// are better.
+//===----------------------------------------------------------------------===//
+
+class DecAPIntState : public APIntStateBase {
+public:
+  using APIntStateBase::APIntStateBase;
+
+  // "Clamps" this state with |rhs|. The result is subtype dependent but it is
+  // intended that only information assumed in both states will be assumed in
+  // this one afterwards.
+  void operator^=(const DecAPIntState &rhs) {
+    takeAssumedMaximum(rhs.getAssumed());
+  }
+
+  DecAPIntState &takeAssumedMaximum(APInt assumed) {
+    // The undef value is effectively +inf (largest possible value).
+    if (isUndefValue(assumed) || isUndefValue(this->assumed)) {
+      this->assumed = this->known;
+      return *this;
+    }
+
+    APInt assumedMax = llvm::APIntOps::umax(this->assumed, assumed);
+    if (!isUndefValue(this->known)) {
+      // Don't lose any known value.
+      assumedMax = llvm::APIntOps::umin(assumedMax, this->known);
+    }
+    this->assumed = assumedMax;
+
+    return *this;
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// ValueAPIntMax
+// ValueElement which tracks the maximum possible value of a bit-vector.
+//===----------------------------------------------------------------------===//
+
+class ValueAPIntMax : public DFX::StateWrapper<IncAPIntState, DFX::ValueElement,
+                                               IncAPIntState> {
+public:
+  using BaseType =
+      DFX::StateWrapper<IncAPIntState, DFX::ValueElement, IncAPIntState>;
+
+  static ValueAPIntMax &createForPosition(const Position &pos,
+                                          DFX::Solver &solver) {
+    return *(new (solver.getAllocator()) ValueAPIntMax(pos));
+  }
+
+  const std::string getName() const override { return "ValueAPIntMax"; }
+  const void *getID() const override { return &ID; }
+  static bool classof(const DFX::AbstractElement *element) {
+    return (element->getID() == &ID);
+  }
+  static const char ID;
+
+  const std::string getAsStr(AsmState &asmState) const override;
+
+private:
+  static IncAPIntState defaultState(const Position &pos) {
+    if (pos.isValue()) {
+      Value value = pos.getValue();
+      Type type = value.getType();
+      if (auto intType = dyn_cast<IntegerType>(type)) {
+        unsigned bitWidth = intType.getWidth();
+        return IncAPIntState(bitWidth, /*known=*/APInt::getZero(bitWidth),
+                             /*assumed=*/APInt::getMaxValue(bitWidth));
+      } else if (auto indexType = dyn_cast<IndexType>(type)) {
+        // Assume that index is 64 bits for the purpose of this accounting.
+        return IncAPIntState(64, /*known=*/APInt::getZero(64),
+                             /*assumed=*/APInt::getMaxValue(64));
+      }
+    }
+    return IncAPIntState(0, IncAPIntState::getUndefValue(),
+                         IncAPIntState::getUndefValue());
+  }
+
+  ValueAPIntMax(const Position &pos) : BaseType(pos, defaultState(pos)) {}
+  void initializeValue(Value value, DFX::Solver &solver) override {
+    if (!value.getType().isIndex() && !value.getType().isInteger()) {
+      indicatePessimisticFixpoint();
+      return;
+    }
+  }
+
+  ChangeStatus updateValue(Value value, DFX::Solver &solver) override {
+    StateType newState = getState();
+
+    // If we can get a full PVS, then we can derive the min from that.
+    auto pvs = solver.getElementFor<IntValuePVS>(
+        *this, Position::forValue(value), DFX::Resolution::OPTIONAL);
+    if (pvs.isValidState() && !pvs.isUndefContained()) {
+      LLVM_DEBUG(dbgs() << "ValueAPIntMax::updateValue: PVS VALID\n");
+      auto &set = pvs.getAssumedSet();
+      if (!set.empty()) {
+        for (auto value : set) {
+          LLVM_DEBUG(dbgs()
+                     << "ValueAPIntMax::updateValue: VALUE =" << value << "\n");
+          newState.takeAssumedMinimum(value);
+        }
+        newState.indicateOptimisticFixpoint();
+      }
+    } else {
+      LLVM_DEBUG(dbgs() << "ValueAPIntMin::updateValue: PVS INVALID\n");
+    }
+
+    if (!newState.isAtFixpoint()) {
+      // Scan IR to infer more information.
+      if (solver.getExplorer().walkDefiningOps(value, [&](OpResult result) {
+            Operation *definingOp = result.getDefiningOp();
+            if (auto assumeRangeOp =
+                    dyn_cast<IREE::Util::AssumeRangeOp>(definingOp)) {
+              // Clamp the max range.
+              APInt maxValue = assumeRangeOp.getMaxValue();
+              newState.takeAssumedMinimum(maxValue);
+            } else if (auto indexCastOp =
+                           dyn_cast<arith::IndexCastOp>(definingOp)) {
+              // arith.index_cast (note that this is a signed cast to/from
+              // index).
+              // TODO: Verify bitwidth is the same or trunc/extend.
+              auto max = solver.getElementFor<ValueAPIntMax>(
+                  *this, Position::forValue(indexCastOp.getOperand()),
+                  DFX::Resolution::REQUIRED);
+              newState ^= max;
+            }
+            return WalkResult::advance();
+          }) == TraversalResult::INCOMPLETE) {
+        newState.indicatePessimisticFixpoint();
+      }
+    }
+
+    return DFX::clampStateAndIndicateChange(getState(), newState);
+  }
+};
+
+const char ValueAPIntMax::ID = 0;
+
+const std::string ValueAPIntMax::getAsStr(AsmState &asmState) const {
+  std::string s;
+  llvm::raw_string_ostream out(s);
+  out << "apint-max: ";
+  APInt assumed = getAssumed();
+  if (IncAPIntState::isUndefValue(assumed)) {
+    out << "<UNDEF-VALUE>";
+  } else if (assumed == APInt::getMaxValue(assumed.getBitWidth())) {
+    out << "<MAX-VALUE>";
+  } else {
+    assumed.print(out, /*signed=*/false);
+  }
+  return s;
+}
+
+//===----------------------------------------------------------------------===//
+// ValueAPIntMin
+// ValueElement which tracks the minimum possible value of a bit-vector.
+//===----------------------------------------------------------------------===//
+
+class ValueAPIntMin : public DFX::StateWrapper<DecAPIntState, DFX::ValueElement,
+                                               DecAPIntState> {
+public:
+  using BaseType =
+      DFX::StateWrapper<DecAPIntState, DFX::ValueElement, DecAPIntState>;
+
+  static ValueAPIntMin &createForPosition(const Position &pos,
+                                          DFX::Solver &solver) {
+    return *(new (solver.getAllocator()) ValueAPIntMin(pos));
+  }
+
+  const std::string getName() const override { return "ValueAPIntMin"; }
+  const void *getID() const override { return &ID; }
+  static bool classof(const DFX::AbstractElement *element) {
+    return (element->getID() == &ID);
+  }
+  static const char ID;
+
+  const std::string getAsStr(AsmState &asmState) const override;
+
+private:
+  static DecAPIntState defaultState(const Position &pos) {
+    if (pos.isValue()) {
+      Value value = pos.getValue();
+      Type type = value.getType();
+      if (auto intType = dyn_cast<IntegerType>(type)) {
+        unsigned bitWidth = intType.getWidth();
+        return DecAPIntState(bitWidth, /*known=*/APInt::getMaxValue(bitWidth),
+                             /*assumed=*/APInt::getZero(bitWidth));
+      } else if (auto indexType = dyn_cast<IndexType>(type)) {
+        // Assume that index is 64 bits for the purpose of this accounting.
+        return DecAPIntState(64, /*known=*/APInt::getMaxValue(64),
+                             /*assumed=*/APInt::getZero(64));
+      }
+    }
+    return DecAPIntState(0, DecAPIntState::getUndefValue(),
+                         DecAPIntState::getUndefValue());
+  }
+
+  ValueAPIntMin(const Position &pos) : BaseType(pos, defaultState(pos)) {}
+  void initializeValue(Value value, DFX::Solver &solver) override {
+    if (!value.getType().isIndex() && !value.getType().isInteger()) {
+      indicatePessimisticFixpoint();
+      return;
+    }
+  }
+
+  ChangeStatus updateValue(Value value, DFX::Solver &solver) override {
+    StateType newState = getState();
+    LLVM_DEBUG(dbgs() << "ValueAPIntMin::updateValue: " << value << "\n");
+
+    // If we can get a full PVS, then we can derive the min from that.
+    auto pvs = solver.getElementFor<IntValuePVS>(
+        *this, Position::forValue(value), DFX::Resolution::OPTIONAL);
+    if (pvs.isValidState() && !pvs.isUndefContained()) {
+      LLVM_DEBUG(dbgs() << "ValueAPIntMin::updateValue: PVS VALID\n");
+      auto &set = pvs.getAssumedSet();
+      if (!set.empty()) {
+        for (auto value : set) {
+          LLVM_DEBUG(dbgs()
+                     << "ValueAPIntMin::updateValue: VALUE =" << value << "\n");
+          newState.takeAssumedMaximum(value);
+        }
+        newState.indicateOptimisticFixpoint();
+      }
+    } else {
+      LLVM_DEBUG(dbgs() << "ValueAPIntMin::updateValue: PVS INVALID\n");
+    }
+
+    if (!newState.isAtFixpoint()) {
+      // Scan IR to infer more information.
+      if (solver.getExplorer().walkDefiningOps(value, [&](OpResult result) {
+            Operation *definingOp = result.getDefiningOp();
+            if (auto assumeRangeOp =
+                    dyn_cast<IREE::Util::AssumeRangeOp>(definingOp)) {
+              // Clamp the max range.
+              APInt minValue = assumeRangeOp.getMinValue();
+              newState.takeAssumedMaximum(minValue);
+            } else if (auto indexCastOp =
+                           dyn_cast<arith::IndexCastOp>(definingOp)) {
+              // arith.index_cast (note that this is a signed cast to/from
+              // index).
+              // TODO: Verify bitwidth is the same or trunc/extend.
+              auto max = solver.getElementFor<ValueAPIntMin>(
+                  *this, Position::forValue(indexCastOp.getOperand()),
+                  DFX::Resolution::REQUIRED);
+              newState ^= max;
+            }
+            return WalkResult::advance();
+          }) == TraversalResult::INCOMPLETE) {
+        newState.indicatePessimisticFixpoint();
+      }
+    }
+
+    return DFX::clampStateAndIndicateChange(getState(), newState);
+  }
+};
+
+const char ValueAPIntMin::ID = 0;
+
+const std::string ValueAPIntMin::getAsStr(AsmState &asmState) const {
+  std::string s;
+  llvm::raw_string_ostream out(s);
+  out << "apint-min: ";
+  APInt assumed = getAssumed();
+  if (IncAPIntState::isUndefValue(assumed)) {
+    out << "<UNDEF-VALUE>";
+  } else {
+    assumed.print(out, /*signed=*/false);
+  }
+  return s;
+}
+
+//===----------------------------------------------------------------------===//
+// IndexArithmeticAnalysis
+//===----------------------------------------------------------------------===//
+
+class IndexArithmeticAnalysis {
+public:
+  enum class OpAction {
+    SIMPLIFY_CMPIOP,
+  };
+  explicit IndexArithmeticAnalysis(Operation *rootOp)
+      : explorer(rootOp, TraversalAction::SHALLOW),
+        solver(explorer, allocator) {
+    rootOp->walk([&](arith::CmpIOp cmpOp) { addOp(cmpOp); });
+  }
+
+  const SmallVector<std::pair<OpAction, Operation *>> &getOpActions() const {
+    return opActions;
+  }
+
+  void addOp(arith::CmpIOp cmpOp) {
+    opActions.emplace_back(OpAction::SIMPLIFY_CMPIOP, cmpOp);
+    for (Value v : {cmpOp.getLhs(), cmpOp.getRhs()}) {
+      auto pos = Position::forValue(v);
+      solver.getOrCreateElementFor<IntValuePVS>(pos);
+      solver.getOrCreateElementFor<ValueAPIntMax>(pos);
+      solver.getOrCreateElementFor<ValueAPIntMin>(pos);
+    }
+  }
+
+  LogicalResult run() { return solver.run(); }
+
+  const ValueAPIntMin &getMinElement(Value value) {
+    return solver.getOrCreateElementFor<ValueAPIntMin>(
+        Position::forValue(value));
+  }
+  const ValueAPIntMax &getMaxElement(Value value) {
+    return solver.getOrCreateElementFor<ValueAPIntMax>(
+        Position::forValue(value));
+  }
+
+  std::optional<APInt> getKnownMinValue(Value value) {
+    auto &elt = getMinElement(value);
+    if (!elt.isAtFixpoint() || !elt.isValidState())
+      return {};
+    return elt.getKnown();
+  }
+
+  std::optional<APInt> getKnownMaxValue(Value value) {
+    auto &elt = getMaxElement(value);
+    if (!elt.isAtFixpoint() || !elt.isValidState())
+      return {};
+    return elt.getKnown();
+  }
+
+private:
+  Explorer explorer;
+  llvm::BumpPtrAllocator allocator;
+  DFX::Solver solver;
+  SmallVector<std::pair<OpAction, Operation *>> opActions;
+};
+
+bool simplifyCmpIOp(IndexArithmeticAnalysis &analysis, arith::CmpIOp cmpOp) {
+  auto lhsMin = analysis.getKnownMinValue(cmpOp.getLhs());
+  auto lhsMax = analysis.getKnownMaxValue(cmpOp.getLhs());
+  auto rhsMin = analysis.getKnownMinValue(cmpOp.getRhs());
+  auto rhsMax = analysis.getKnownMaxValue(cmpOp.getRhs());
+
+  auto reportValue = [](const char *label, std::optional<APInt> intValue) {
+    if (intValue) {
+      dbgs() << "  " << label << ": " << *intValue << "\n";
+    } else {
+      dbgs() << "  " << label << ": INVALID\n";
+    }
+  };
+  LLVM_DEBUG(dbgs() << "Attempt CmpIOp simplification:\n";
+             reportValue("lhsMin", lhsMin); reportValue("lhsMax", lhsMax);
+             reportValue("rhsMin", rhsMin); reportValue("rhsMax", rhsMax););
+
+  // For signed comparisons, we have to be conservative and ensure that the
+  // ranges are completely disjoint. We could be more liberal if we checked
+  // additional facets of the bit patterns to work around signed order and
+  // overflow possibilities (i.e. whether it is safe to promote a signed to
+  // an unsigned compare).
+  if (!lhsMin || !lhsMax || !rhsMin || !rhsMax) {
+    LLVM_DEBUG(dbgs() << "Cannot simplify " << cmpOp << "\n");
+    return false;
+  }
+
+  auto predicate = cmpOp.getPredicate();
+  auto compare = [&](APInt lhs, APInt rhs) -> std::optional<bool> {
+    switch (predicate) {
+    case arith::CmpIPredicate::slt:
+      return lhs.slt(rhs);
+      break;
+
+    default:
+      return {};
+    }
+  };
+
+  int trueCount = 0;
+  int falseCount = 0;
+  for (auto result : {
+           compare(*lhsMin, *rhsMin),
+           compare(*lhsMin, *rhsMax),
+           compare(*lhsMax, *rhsMin),
+           compare(*lhsMax, *rhsMax),
+       }) {
+    if (!result)
+      return false; // Has an undef value.
+    if (*result)
+      ++trueCount;
+    else
+      ++falseCount;
+  }
+
+  OpBuilder builder(cmpOp);
+  auto rewrite = [&](bool resultValue) {
+    Value newValue = builder.create<arith::ConstantOp>(
+        cmpOp.getLoc(), builder.getBoolAttr(resultValue));
+    cmpOp.getResult().replaceAllUsesWith(newValue);
+  };
+  if (trueCount && !falseCount) {
+    // Replace with true.
+    rewrite(true);
+    return true;
+  } else if (!trueCount && falseCount) {
+    // Replace with false.
+    rewrite(true);
+    return true;
+  }
+
+  return false;
+}
+
+class SimplifyIndexArithmeticPass
+    : public SimplifyIndexArithmeticBase<SimplifyIndexArithmeticPass> {
+public:
+  LogicalResult runRangeSimplifications() {
+    IndexArithmeticAnalysis analysis(getOperation());
+    if (failed(analysis.run())) {
+      return failure();
+    }
+
+    int changeCount = 0;
+    for (auto [action, op] : analysis.getOpActions()) {
+      switch (action) {
+      case IndexArithmeticAnalysis::OpAction::SIMPLIFY_CMPIOP:
+        if (simplifyCmpIOp(analysis, cast<arith::CmpIOp>(op))) {
+          changeCount += 1;
+        }
+        break;
+      }
+    }
+
+    LLVM_DEBUG(dbgs() << "Simplification made " << changeCount << " changes\n");
+
+    (void)changeCount;
+    return success();
+  }
+
+  void runOnOperation() override {
+    if (failed(runRangeSimplifications())) {
+      return signalPassFailure();
+    }
+  }
+};
+
+} // namespace
+
+std::unique_ptr<OperationPass<void>> createSimplifyIndexArithmeticPass() {
+  return std::make_unique<SimplifyIndexArithmeticPass>();
+}
+
+} // namespace mlir::iree_compiler::IREE::Util

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/SimplifyIndexArithmetic.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/SimplifyIndexArithmetic.cpp
@@ -490,6 +490,7 @@ bool simplifyCmpIOp(IndexArithmeticAnalysis &analysis, arith::CmpIOp cmpOp) {
 
   OpBuilder builder(cmpOp);
   auto rewrite = [&](bool resultValue) {
+    LLVM_DEBUG(dbgs() << "Rewrite " << cmpOp << " -> " << resultValue << "\n");
     Value newValue = builder.create<arith::ConstantOp>(
         cmpOp.getLoc(), builder.getBoolAttr(resultValue));
     cmpOp.getResult().replaceAllUsesWith(newValue);
@@ -500,7 +501,7 @@ bool simplifyCmpIOp(IndexArithmeticAnalysis &analysis, arith::CmpIOp cmpOp) {
     return true;
   } else if (!trueCount && falseCount) {
     // Replace with false.
-    rewrite(true);
+    rewrite(false);
     return true;
   }
 

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/SimplifyIndexArithmetic.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/SimplifyIndexArithmetic.cpp
@@ -226,6 +226,13 @@ private:
                   *this, Position::forValue(indexCastOp.getOperand()),
                   DFX::Resolution::REQUIRED);
               newState ^= max;
+            } else if (auto assumeDivOp =
+                           dyn_cast<IREE::Util::AssumeDivisibleOp>(
+                               definingOp)) {
+              auto max = solver.getElementFor<ValueAPIntMax>(
+                  *this, Position::forValue(assumeDivOp.getOperand()),
+                  DFX::Resolution::REQUIRED);
+              newState ^= max;
             }
             return WalkResult::advance();
           }) == TraversalResult::INCOMPLETE) {
@@ -344,6 +351,13 @@ private:
               // TODO: Verify bitwidth is the same or trunc/extend.
               auto max = solver.getElementFor<ValueAPIntMin>(
                   *this, Position::forValue(indexCastOp.getOperand()),
+                  DFX::Resolution::REQUIRED);
+              newState ^= max;
+            } else if (auto assumeDivOp =
+                           dyn_cast<IREE::Util::AssumeDivisibleOp>(
+                               definingOp)) {
+              auto max = solver.getElementFor<ValueAPIntMin>(
+                  *this, Position::forValue(assumeDivOp.getOperand()),
                   DFX::Resolution::REQUIRED);
               newState ^= max;
             }


### PR DESCRIPTION
The new `iree-util-simplify-index-arithmetic` pass uses the new range annotations to do range analysis and simplification.

Currently it is looping to:

* Rewrite redundant comparison ops to constant true/false.
* Performing arith canonicalization plus grab bag of other simplification patterns.
* Keep going until no analysis driven redundancies are eliminated.

The existing DFX elements which were based on C++ int types were insufficient. Given that MLIR integers/indexes are signless, we have to be precise and do detailed emulation with APInt. New elements were added based on APInt. Also some integer constant PVS support was pulled into the main analysis directory from a pass that had it locally.

Ultimately, this analysis will become its own standalone entity and used from multiple places which need to query range and divisibility.