### PR TITLE
[docs] Remove call to `t()` in external param example.

### DIFF
--- a/docs/website/docs/guides/ml-frameworks/pytorch.md
+++ b/docs/website/docs/guides/ml-frameworks/pytorch.md
@@ -355,8 +355,8 @@ linear_module = LinearModule(4,3)
 # Create a params dictionary. Note that the keys here match LinearModule's
 # attributes. We will use the saved safetensor file for use from the command
 # line.
-wt = linear_module.weight.t().contiguous()
-bias = linear_module.bias.t().contiguous()
+wt = linear_module.weight.data.contiguous()
+bias = linear_module.bias.data.contiguous()
 params = { "weight": wt, "bias": bias }
 save_file(params, "params.safetensors")
 


### PR DESCRIPTION
Fixes https://github.com/iree-org/iree/issues/18564.

The example in https://iree.dev/guides/ml-frameworks/pytorch/#using-external-parameters has an erroneous call to `t()` that actually transposes the underlying tensor instead of accessing it unmodified.

This patch fixes this error, and the example now outputs a numerical match with the torch output.