### PR TITLE
Revert "[CPU] Enable tileDispatchUsingForall for mmt4d and convolution pipelines. "

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info.mlir
@@ -3,6 +3,19 @@
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>
 ]>
+hal.executable private @err_multiple_entry_point {
+  // expected-error @+1 {{reconciliation for multiple export ops unsupported}}
+  hal.executable.variant public @reconcile_workgroup_size target(#hal.executable.target<"", "", {}>) {
+    hal.executable.export public @entry_point1 layout(#pipeline_layout)
+    hal.executable.export public @entry_point2 layout(#pipeline_layout)
+  }
+}
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
 hal.executable private @reconcile_workgroup_size {
   hal.executable.variant public @reconcile_workgroup_size target(#hal.executable.target<"", "", {}>) {
     hal.executable.export public @entry_point layout(#pipeline_layout)

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
@@ -276,7 +276,8 @@ func.func @ukernel_dispatch() attributes {hal.executable.target = #executable_ta
 }
 // CHECK-LABEL: func @ukernel_dispatch()
 // Checks scf.for for distribution loops.
-//       CHECK:   scf.forall
+//       CHECK:   scf.for
+//       CHECK:     scf.for
 // Checks scf.for for outer and inner parallel loops.
 //       CHECK:       scf.for
 //       CHECK:         scf.for


### PR DESCRIPTION
Reverts iree-org/iree#18618

It breaks `PkgCI / Regression Test / test_models :: cpu_llvm_task (push)`. I think we should address the issue before landing the patch.

Sample log: https://github.com/iree-org/iree/actions/runs/11199607624/job/31132512036