### PR TITLE
[Flow] Add TensorReshapeOp canonicalization

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -1017,8 +1017,9 @@ struct ResolveShapedDim : public OpRewritePattern<tensor::DimOp> {
   }
 };
 
-// Remove flow.tensor.reshapes around `op` (`expand_shape` or `collapse_shape`)
-// that only cast from static -> dynamic and back but are no-ops.
+// Remove flow.tensor.reshapes around `lastReshapeOp` (`expand_shape` or
+// `collapse_shape`) that only cast from static -> dynamic and back but are
+// no-ops.
 template <typename OpTy>
 struct EraseReshapesAroundOp : public OpRewritePattern<Flow::TensorReshapeOp> {
   using OpRewritePattern<Flow::TensorReshapeOp>::OpRewritePattern;
@@ -1035,8 +1036,8 @@ struct EraseReshapesAroundOp : public OpRewritePattern<Flow::TensorReshapeOp> {
       return failure();
     }
 
-    if (firstReshapeOp.getSourceDims().size() != 0 ||
-        lastReshapeOp.getResultDims().size() != 0) {
+    if (!firstReshapeOp.getSourceDims().empty() ||
+        !lastReshapeOp.getResultDims().empty()) {
       return failure();
     }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
@@ -758,8 +758,8 @@ util.func public @canonicalizeReshapeExpand(%arg0: tensor<4x1x8192xf16>) -> tens
   %c1 = arith.constant 1 : index
   %c4 = arith.constant 4 : index
   %0 = flow.tensor.reshape %arg0: tensor<4x1x8192xf16> -> tensor<?x?x8192xf16>{%c4, %c1}
-  %expanded_0 = tensor.expand_shape %0 [[0], [1], [2, 3]] output_shape [%c4, %c1, 256, 32] : tensor<?x?x8192xf16> into tensor<?x?x256x32xf16>
-  %1 = flow.tensor.reshape %expanded_0 : tensor<?x?x256x32xf16>{%c4, %c1} -> tensor<4x1x256x32xf16>
+  %expanded = tensor.expand_shape %0 [[0], [1], [2, 3]] output_shape [%c4, %c1, 256, 32] : tensor<?x?x8192xf16> into tensor<?x?x256x32xf16>
+  %1 = flow.tensor.reshape %expanded : tensor<?x?x256x32xf16>{%c4, %c1} -> tensor<4x1x256x32xf16>
   util.return %1 : tensor<4x1x256x32xf16>
 }
 
@@ -774,8 +774,8 @@ util.func public @canonicalizeReshapeCollapse(%arg0: tensor<4x1x256x32xf16>) -> 
   %c1 = arith.constant 1 : index
   %c4 = arith.constant 4 : index
   %0 = flow.tensor.reshape %arg0: tensor<4x1x256x32xf16> -> tensor<?x?x256x32xf16>{%c4, %c1}
-  %expanded_0 = tensor.collapse_shape %0 [[0], [1], [2, 3]] : tensor<?x?x256x32xf16> into tensor<?x?x8192xf16>
-  %1 = flow.tensor.reshape %expanded_0 : tensor<?x?x8192xf16>{%c4, %c1} -> tensor<4x1x8192xf16>
+  %collapsed = tensor.collapse_shape %0 [[0], [1], [2, 3]] : tensor<?x?x256x32xf16> into tensor<?x?x8192xf16>
+  %1 = flow.tensor.reshape %collapsed : tensor<?x?x8192xf16>{%c4, %c1} -> tensor<4x1x8192xf16>
   util.return %1 : tensor<4x1x8192xf16>
 }
 


### PR DESCRIPTION
Canonicalize `flow.tensor.reshape` -> tensor collapse/expand -> `flow.tensor.reshape` where the first `flow.tensor.reshape` only converts from static to dynamic dims and the second converts back.

#### For example:
```mlir
%0 = flow.tensor.reshape %arg0: tensor<4x1x8192xf16> -> tensor<?x?x8192xf16>{%c4, %c1}
%expanded_0 = tensor.expand_shape %0 [[0], [1], [2, 3]] output_shape [%c4, %c1, 256, 32] : tensor<?x?x8192xf16> into tensor<?x?x256x32xf16>
%1 = flow.tensor.reshape %expanded_0 : tensor<?x?x256x32xf16>{%c4, %c1} -> tensor<4x1x256x32xf16>

// transformed to...

%expanded_0 = tensor.expand_shape %0 [[0], [1], [2, 3]] output_shape [4, 1, 256, 32] : tensor<4x1x8192xf16> into tensor<4x1x256x32xf16>
```

```mlir
%0 = flow.tensor.reshape %arg0: tensor<4x1x256x32xf16> -> tensor<?x?x256x32xf16>{%c4, %c1}
%collapsed= tensor.collapse_shape %0 [[0], [1], [2, 3]] : tensor<?x?x256x32xf16> into tensor<?x?x8192xf16>
%1 = flow.tensor.reshape %collapsed: tensor<?x?x8192xf16>{%c4, %c1} -> tensor<4x1x8192xf16>

// transformed to...

%collapsed= tensor.collapse_shape %0 [[0], [1], [2, 3]] : tensor<4x1x256x32xf16> into tensor<4x1x8192xf16>

```
