### PR TITLE
[LLVMCPU] Enable tileDispatchUsingForall for multiTilingExpert

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
@@ -271,25 +271,6 @@ convertToDestinationPassingStyle(OpBuilder &b,
   return success(!walkResult.wasInterrupted());
 }
 
-/// Multiple uses of `tensor.empty()` results in a copy since upstream
-/// treats `tensor.empty()` as an allocation and sees uses as a data-hazard
-/// creating copies/allocations. Since the `empty` op is a proxy for
-/// undef, these could just be duplicated to have a single use. This removes
-/// unnecessary data-hazards.
-static LogicalResult duplicateTensorEmptyOps(OpBuilder &b,
-                                             tensor::EmptyOp emptyOp) {
-  OpBuilder::InsertionGuard g(b);
-  b.setInsertionPoint(emptyOp);
-  SmallVector<OpOperand *> uses = llvm::map_to_vector(
-      emptyOp->getUses(), [](OpOperand &use) { return &use; });
-  for (auto use : llvm::make_range(std::next(uses.begin()), uses.end())) {
-    auto newOp = cast<tensor::EmptyOp>(b.clone(*emptyOp.getOperation()));
-    Operation *user = use->getOwner();
-    user->setOperand(use->getOperandNumber(), newOp);
-  }
-  return success();
-}
-
 // Checks if the `inOperand` can be used in place of the `initOperand`
 // to mimic in-place update behavior for parallel elementwise ops.
 static bool

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -385,7 +385,7 @@ void addMultiTilingExpertPassPipeline(OpPassManager &funcPassManager,
                                       TilingConfig &tilingConfig,
                                       LLVMCPUPipelineOptions &pipelineOpt) {
   addTileAndDistributePasses(funcPassManager,
-                             /*enableTileDispatchUsingForall=*/false);
+                             /*enableTileDispatchUsingForall=*/true);
 
   SmallVector<int64_t> allFusableLevels(tilingConfig.getFusableLevels());
   // Apply tile and fuse to all the non-distribution fusable levels. Skip

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_pack_unpack_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_pack_unpack_tests.mlir
@@ -79,9 +79,8 @@ module {
 
 // CHECK-LABEL:     func.func @aligned_unpack_generic
 // CHECK:             %[[SRC:.+]] = hal.interface.binding.subspan {{.*}} : memref<24x32x16x16xf32, #hal.descriptor_type<storage_buffer>>
-// CHECK:               %[[SUBVIEW:.+]] = memref.subview %{{.*}} memref<24x32x16x16xf32, #hal.descriptor_type<storage_buffer>> to memref<
-// CHECK-COUNT-15:        vector.load %[[SUBVIEW]]
-// CHECK:                 %[[LAST_LOAD:.+]] = vector.load %[[SUBVIEW]]
+// CHECK-COUNT-15:        vector.load %[[SRC]]
+// CHECK:                 %[[LAST_LOAD:.+]] = vector.load %[[SRC]]
 // CHECK:                 %[[IN_0:.+]] = vector.broadcast %{{.+}} : vector<16xf32> to vector<16x16xf32>
 // CHECK:                 %[[T0:.+]] = arith.addf %[[IN_0]], %{{.+}} : vector<16x16xf32>
 // CHECK:                 %[[T1:.+]] = arith.minimumf %[[T0]], %{{.+}} : vector<16x16xf32>

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_peel_and_vectorize_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_peel_and_vectorize_tests.mlir
@@ -106,8 +106,7 @@ func.func @peel_dynamic_matmul() attributes {hal.executable.target = #executable
 
 // CHECK-LABEL: func @peel_dynamic_matmul()
 // Distribution:
-// CHECK:         scf.for
-// CHECK:           scf.for
+// CHECK:         scf.forall
 
 // Vectorization:
 // CHECK:             scf.for

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -261,6 +261,19 @@ bool isReadOnly(Value v) {
       .Default([&](Operation *op) { return false; });
 }
 
+LogicalResult duplicateTensorEmptyOps(OpBuilder &b, tensor::EmptyOp emptyOp) {
+  OpBuilder::InsertionGuard g(b);
+  b.setInsertionPoint(emptyOp);
+  SmallVector<OpOperand *> uses = llvm::map_to_vector(
+      emptyOp->getUses(), [](OpOperand &use) { return &use; });
+  for (auto use : llvm::make_range(std::next(uses.begin()), uses.end())) {
+    auto newOp = cast<tensor::EmptyOp>(b.clone(*emptyOp.getOperation()));
+    Operation *user = use->getOwner();
+    user->setOperand(use->getOperandNumber(), newOp);
+  }
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // Utility functions to set configurations
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -92,6 +92,13 @@ bool isRISCV32(IREE::HAL::ExecutableTargetAttr targetAttr);
 /// operation.
 bool isReadOnly(Value v);
 
+/// Multiple uses of `tensor.empty()` results in a copy since upstream
+/// treats `tensor.empty()` as an allocation and sees uses as a data-hazard
+/// creating copies/allocations. Since the `empty` op is a proxy for
+/// undef, these could just be duplicated to have a single use. This removes
+/// unnecessary data-hazards.
+LogicalResult duplicateTensorEmptyOps(OpBuilder &b, tensor::EmptyOp emptyOp);
+
 /// Return the static number of workgroup dispatched if it is known and
 /// constant. If it is not known, it will return ShapedType::kDynamic.
 SmallVector<int64_t> getStaticNumWorkgroups(mlir::FunctionOpInterface funcOp);

--- a/compiler/src/iree/compiler/ConstEval/test/jit_globals.mlir
+++ b/compiler/src/iree/compiler/ConstEval/test/jit_globals.mlir
@@ -405,7 +405,7 @@ module @dispatch_inline {
 module @dispatch_executable {
   flow.executable private @exe {
     flow.executable.export public @dispatch_fn workgroups(%arg0: index) -> (index, index, index) {
-      %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg0
+      %x, %y, %z = flow.dispatch.workgroup_count_from_slice %arg0
       flow.return %x, %y, %z : index, index, index
     }
     builtin.module {


### PR DESCRIPTION
Enable tileDispatchUsingForall for multi-tiling expert pass.
In the tileDispatchUsingForall pass, we don't use the destinationPassingStyle pass, which has
duplicateEmptyTensor fn as a preprocessing for bufferization to work correctly. It's now moved
to IREEComprehensiceBufferizePass.
