### PR TITLE
[Codegen] Remove memref optimizations from OptimizeTensorInsertExtractSlices

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -549,7 +549,9 @@ void addGPUMatmulSimtPassPipeline(OpPassManager &funcPassManager,
   // still rely on buffer level transformations for transfer ops hoisting and
   // store to load forwarding. This relies on shacky alias analysis and we need
   // to move this to tensor level once we have better abstractions.
-  funcPassManager.addPass(createOptimizeTensorInsertExtractSlicesPass());
+  // TODO: We should be to start hoisting out accumulator load/store out
+  // after https://github.com/llvm/llvm-project/pull/111533.
+  funcPassManager.addPass(createOptimizeVectorTransferPass());
 
   // Hoist loop invariant code to avoid pipelining it.
   funcPassManager.addPass(createLoopInvariantCodeMotionPass());

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_to_cooperative_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_to_cooperative_ops.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=volta@vulkan \
-// RUN:   --pass-pipeline='builtin.module(func.func(iree-spirv-tile-to-cooperative-ops, iree-codegen-generic-vectorization, iree-spirv-vectorize-to-cooperative-ops, iree-codegen-optimize-tensor-insert-extract-slices, canonicalize, cse))' \
+// RUN:   --pass-pipeline='builtin.module(func.func(iree-spirv-tile-to-cooperative-ops, iree-codegen-generic-vectorization, iree-spirv-vectorize-to-cooperative-ops, iree-codegen-optimize-vector-transfer, canonicalize, cse))' \
 // RUN:   %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
@@ -102,9 +102,9 @@ func.func @matmul_256x1024x128_div_add() attributes {translation_info = #transla
 //       CHECK:       vector.transfer_write %[[ZERO]], {{.+}} : vector<16x16xf16>, memref<16x16xf16, strided<[128, 1], offset: ?>>
 //       CHECK:   scf.for %{{.+}} = %[[C0]] to %[[C1024]] step %[[C32]]
 //       CHECK:     gpu.barrier
-//       CHECK:     vector.transfer_read {{.+}} vector<1x8xf16>
+//       CHECK:     vector.transfer_read {{.+}} vector<8xf16>
 //       CHECK:     vector.transfer_write
-//       CHECK:     vector.transfer_read {{.+}} vector<1x8xf16>
+//       CHECK:     vector.transfer_read {{.+}} vector<8xf16>
 //       CHECK:     vector.transfer_write
 //       CHECK:     gpu.barrier
 //       CHECK:     scf.for %[[IV_Y:.+]] = %[[OFFSET_Y]] to %[[C32]] step %[[C32]]
@@ -219,7 +219,7 @@ func.func @matmul_256x1024x128_div_add() attributes {translation_info = #transla
 //   CHECK-DAG:   %[[C16:.+]] = arith.constant 16 : index
 //   CHECK-DAG:   %[[C32:.+]] = arith.constant 32 : index
 //   CHECK-DAG:   %[[C512:.+]] = arith.constant 512 : index
-//   CHECK-DAG:   %[[ZERO:.+]] = arith.constant dense<0.000000e+00> : vector<1x16x16xf16>
+//   CHECK-DAG:   %[[ZERO:.+]] = arith.constant dense<0.000000e+00> : vector<16x16xf16>
 
 //   CHECK-DAG:   %[[ID_X:.+]] = gpu.thread_id  x
 //   CHECK-DAG:   %[[ID_Y:.+]] = gpu.thread_id  y
@@ -234,13 +234,13 @@ func.func @matmul_256x1024x128_div_add() attributes {translation_info = #transla
 //       CHECK:   scf.for %{{.+}} = %[[ID_Z]] to %[[C1]] step %[[C1]]
 //       CHECK:     scf.for %{{.+}} = %[[OFFSET_Y]] to %[[C32]] step %[[C32]]
 //       CHECK:       scf.for %{{.+}} = %[[OFFSET_X]] to %[[C32]] step %[[C32]]
-//       CHECK:         vector.transfer_write %[[ZERO]], {{.+}} : vector<1x16x16xf16>, memref<1x16x16xf16, strided<[32768, 256, 1], offset: ?>>
+//       CHECK:         vector.transfer_write %[[ZERO]], {{.+}} : vector<16x16xf16>, memref<1x16x16xf16, strided<[32768, 256, 1], offset: ?>>
 
 //       CHECK:   scf.for %{{.+}} = %[[C0]] to %[[C512]] step %[[C32]]
 //       CHECK:     gpu.barrier
-//       CHECK:     vector.transfer_read {{.+}} vector<1x1x8xf16>
+//       CHECK:     vector.transfer_read {{.+}} vector<8xf16>
 //       CHECK:     vector.transfer_write
-//       CHECK:     vector.transfer_read {{.+}} vector<1x1x8xf16>
+//       CHECK:     vector.transfer_read {{.+}} vector<8xf16>
 //       CHECK:     vector.transfer_write
 //       CHECK:     gpu.barrier
 //       CHECK:     scf.for %[[IV_Z:.+]] = %[[ID_Z]] to %[[C1]] step %[[C1]]
@@ -254,16 +254,16 @@ func.func @matmul_256x1024x128_div_add() attributes {translation_info = #transla
 //       CHECK:           %[[READ3:.+]] = vector.transfer_read %[[RHS_VIEW]][%[[C0]], %[[C16]], %[[C0]]]
 //       CHECK:           %[[READ4:.+]] = vector.transfer_read %{{.+}}[%[[C0]], %[[C0]], %[[C0]]]
 //       CHECK:           %[[CT0:.+]] = vector.contract
-//  CHECK-SAME:             %[[READ0]], %[[READ2]], %[[READ4]] : vector<1x16x16xf16>, vector<1x16x16xf16> into vector<1x16x16xf16>
+//  CHECK-SAME:             %[[READ0]], %[[READ2]], %[[READ4]] : vector<16x16xf16>, vector<16x16xf16> into vector<16x16xf16>
 //       CHECK:           %[[CT1:.+]] = vector.contract
-//  CHECK-SAME:             %[[READ1]], %[[READ3]], %[[CT0]] : vector<1x16x16xf16>, vector<1x16x16xf16> into vector<1x16x16xf16>
+//  CHECK-SAME:             %[[READ1]], %[[READ3]], %[[CT0]] : vector<16x16xf16>, vector<16x16xf16> into vector<16x16xf16>
 //       CHECK:           vector.transfer_write %[[CT1]], %{{.+}}[%[[C0]], %[[C0]], %[[C0]]]
 //       CHECK:   scf.for %{{.+}} = %[[ID_Z]] to %[[C1]] step %[[C1]]
 //       CHECK:     scf.for %{{.+}} = %[[OFFSET_Y]] to %[[C32]] step %[[C32]]
 //       CHECK:       scf.for %{{.+}} = %[[OFFSET_X]] to %[[C32]] step %[[C32]]
 //       CHECK:         %[[READ5:.+]] = vector.transfer_read %{{.+}}[%[[C0]], %[[C0]], %[[C0]]]
 //       CHECK:         %[[READ6:.+]] = vector.transfer_read %{{.+}}[%[[C0]], %[[C0]], %[[C0]]]
-//       CHECK:         %[[DIV:.+]] = arith.divf %[[READ6]], %[[READ5]] : vector<1x16x16xf16>
+//       CHECK:         %[[DIV:.+]] = arith.divf %[[READ6]], %[[READ5]] : vector<16x16xf16>
 //       CHECK:         vector.transfer_write %[[DIV]], %{{.+}}[%[[C0]], %[[C0]], %[[C0]]]
 
 // -----
@@ -362,9 +362,9 @@ func.func @matmul_256x1024x128_mixed_signedness_int8() {
 //       CHECK:       vector.transfer_write %[[ZERO]], {{.+}} : vector<16x16xi32>, memref<16x16xi32, strided<[128, 1], offset: ?>>
 //       CHECK:   scf.for %{{.+}} = %[[C0]] to %[[C1024]] step %[[C32]]
 //       CHECK:     gpu.barrier
-//       CHECK:     vector.transfer_read {{.+}} vector<1x8xi8>
+//       CHECK:     vector.transfer_read {{.+}} vector<8xi8>
 //       CHECK:     vector.transfer_write
-//       CHECK:     vector.transfer_read {{.+}} vector<1x8xi8>
+//       CHECK:     vector.transfer_read {{.+}} vector<8xi8>
 //       CHECK:     vector.transfer_write
 //       CHECK:     gpu.barrier
 //       CHECK:     scf.for %[[IV_Y:.+]] = %[[OFFSET_Y]] to %[[C32]] step %[[C32]]


### PR DESCRIPTION
This pass is meant to be run on tensor code, but has slowly accumulated unrelated optimizations. This patch makes this pass run only tensor optimizations.

No test additions because this pass only has tensor tests.

Depends on https://github.com/iree-org/iree/pull/18731