### PR TITLE
[IGEMM] Generate matmuls with expanded H and W dims

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
@@ -220,6 +220,93 @@ hal.executable private @main {
 // -----
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+#config = #iree_gpu.lowering_config<{
+  workgroup = [1, 4, 16, 256, 0],
+  reduction = [0, 0, 0, 0, 2],
+  subgroup = [1, 4, 1, 4, 0],
+  mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
+  promote_operands = [0, 1]
+}>
+hal.executable private @main {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @conv_igemm_im2col_expanded ordinal(0) layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_slice
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @conv_igemm_im2col_expanded() attributes {translation_info = #iree_codegen.translation_info<LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64>} {
+        %cst = arith.constant 0.000000e+00 : f32
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2x34x34x1280xf16>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<3x3x1280x1280xf16>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2x16x16x1280xf32>>
+        %3 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 34, 34, 1280], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<2x34x34x1280xf16>> -> tensor<2x34x34x1280xf16>
+        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [3, 3, 1280, 1280], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<3x3x1280x1280xf16>> -> tensor<3x3x1280x1280xf16>
+        %5 = tensor.empty() : tensor<2x16x16x1280xf32>
+        %6 = tensor.empty() : tensor<2x16x16x11520xf16>
+        %7 = iree_linalg_ext.im2col
+            strides = [2, 2] dilations = [1, 1] kernel_size = [3, 3]
+            m_offset = [0, 0] * [32, 1] k_offset = [0] * [1]
+            batch_pos = [0] m_pos = [1, 2] k_pos = [3]
+          ins(%3 : tensor<2x34x34x1280xf16>)
+          outs(%6 : tensor<2x16x16x11520xf16>) -> tensor<2x16x16x11520xf16>
+        %collapsed = tensor.collapse_shape %4 [[0, 1, 2], [3]] : tensor<3x3x1280x1280xf16> into tensor<11520x1280xf16>
+        %8 = linalg.fill ins(%cst : f32) outs(%5 : tensor<2x16x16x1280xf32>) -> tensor<2x16x16x1280xf32>
+        %9 = linalg.generic {
+          indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d4)>,
+                           affine_map<(d0, d1, d2, d3, d4) -> (d4, d3)>,
+                           affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>],
+          iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]}
+          ins(%7, %collapsed : tensor<2x16x16x11520xf16>, tensor<11520x1280xf16>)
+          outs(%8 : tensor<2x16x16x1280xf32>) attrs =  {lowering_config = #config} {
+        ^bb0(%in: f16, %in_1: f16, %out: f32):
+          %10 = arith.extf %in : f16 to f32
+          %11 = arith.extf %in_1 : f16 to f32
+          %12 = arith.mulf %10, %11 : f32
+          %13 = arith.addf %12, %out : f32
+          linalg.yield %13 : f32
+        } -> tensor<2x16x16x1280xf32>
+        flow.dispatch.tensor.store %9, %2, offsets = [0, 0, 0, 0], sizes = [2, 16, 16, 1280], strides = [1, 1, 1, 1] : tensor<2x16x16x1280xf32> -> !flow.dispatch.tensor<writeonly:tensor<2x16x16x1280xf32>>
+        return
+      }
+    }
+  }
+}
+
+//    CHECK-LABEL: func @conv_igemm_im2col_expanded
+//      CHECK-DAG:   %[[B0:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)
+//      CHECK-DAG:   %[[B1:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)
+//      CHECK-DAG:   %[[B2:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(2)
+//      CHECK-DAG:   memref.alloc() : memref<1x4x16x36xf16, #gpu.address_space<workgroup>>
+//      CHECK-DAG:   memref.alloc() : memref<32x260xf16, #gpu.address_space<workgroup>>
+//      CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//      CHECK-DAG:   %[[C720:.+]] = arith.constant 720 : index
+//      CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : index
+//          CHECK:   %[[LOOP:.+]] = scf.for %[[IV:.+]] = %[[C0]] to %[[C720]] step %[[C2]] {{.*}} -> (vector<1x4x1x4x4x1xf32>)
+//          CHECK:     gpu.barrier
+//      CHECK-DAG:     %[[LHS_RD:.+]] = vector.transfer_read %[[B0]]{{.*}} vector<8xf16>
+//      CHECK-DAG:     vector.transfer_write %[[LHS_RD]]
+//      CHECK-DAG:     %[[RHS_RD:.+]] = vector.transfer_read %[[B1]]{{.*}} vector<8xf16>
+//      CHECK-DAG:     vector.transfer_write %[[RHS_RD]]
+//          CHECK:     gpu.barrier
+//      CHECK-DAG:     %[[LHS_MM0:.+]] = vector.transfer_read {{.*}} vector<4x1x1x2x4xf16>
+//      CHECK-DAG:     %[[LHS_MM1:.+]] = vector.broadcast {{.*}} vector<4x1x1x2x4xf16> to vector<1x4x1x1x2x4xf16>
+//      CHECK-DAG:     %[[RHS_MM:.+]] = vector.transfer_read {{.*}} vector<2x4x4x1xf16>
+//      CHECK-DAG:     vector.transpose %[[LHS_MM1]], [0, 1, 2, 4, 3, 5] : vector<1x4x1x1x2x4xf16> to vector<1x4x1x2x1x4xf16>
+//      CHECK-DAG:     vector.transpose %[[RHS_MM]], [0, 2, 3, 1] : vector<2x4x4x1xf16> to vector<2x4x1x4xf16>
+// CHECK-COUNT-32:     amdgpu.mfma {{.*}}blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32
+//          CHECK:   %[[LOOP_T:.+]] = vector.transpose %[[LOOP]], [0, 1, 2, 4, 3, 5] : vector<1x4x1x4x4x1xf32> to vector<1x4x1x4x4x1xf32>
+//          CHECK:   %[[EXTRACT:.+]] = vector.extract %[[LOOP_T]][0] : vector<4x1x4x4x1xf32> from vector<1x4x1x4x4x1xf32>
+//          CHECK:   vector.transfer_write %[[EXTRACT]], %[[B2]]
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConv2DToIm2ColOp.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConv2DToIm2ColOp.cpp
@@ -186,7 +186,7 @@ public:
         });
     Value result = genericOp.getResults().front();
 
-    rewriter.replaceOp(convOp, ArrayRef<Value>{result});
+    rewriter.replaceOp(convOp, result);
 
     return success();
   }
@@ -308,7 +308,7 @@ public:
         });
     Value result = genericOp.getResults().front();
 
-    rewriter.replaceOp(convOp, ArrayRef<Value>{result});
+    rewriter.replaceOp(convOp, result);
 
     return success();
   }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConv2DToIm2ColOp.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConv2DToIm2ColOp.cpp
@@ -10,7 +10,6 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
-#include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir::iree_compiler::IREE::LinalgExt {
@@ -125,11 +124,9 @@ public:
 
     auto loc = convOp.getLoc();
 
-    SmallVector<int64_t> colTensorShape = {n, oh * ow, fh * fw * ic};
+    SmallVector<int64_t> colTensorShape = {n, oh, ow, fh * fw * ic};
 
     SmallVector<ReassociationIndices> outputReassocIndices = {{0}, {1, 2}, {3}};
-    auto reshapedOutputType =
-        RankedTensorType::get({n, oh * ow, oc}, outputType.getElementType());
 
     Value colTensor = rewriter.create<tensor::EmptyOp>(
         loc, colTensorShape, inputType.getElementType());
@@ -137,10 +134,12 @@ public:
     SmallVector<int64_t> dilations(convOp.getDilations().getValues<int64_t>());
     SmallVector<OpFoldResult> kernelSize = {rewriter.getIndexAttr(fh),
                                             rewriter.getIndexAttr(fw)};
-    SmallVector<OpFoldResult> mOffset = {rewriter.getIndexAttr(0)};
-    SmallVector<OpFoldResult> mBasis = {rewriter.getIndexAttr(1)};
-    SmallVector<OpFoldResult> kOffset = {rewriter.getIndexAttr(0)};
-    SmallVector<OpFoldResult> kBasis = {rewriter.getIndexAttr(1)};
+    OpFoldResult zero = rewriter.getIndexAttr(0);
+    OpFoldResult one = rewriter.getIndexAttr(1);
+    SmallVector<OpFoldResult> mOffset = {zero, zero};
+    SmallVector<OpFoldResult> mBasis = {rewriter.getIndexAttr(ow), one};
+    SmallVector<OpFoldResult> kOffset = {zero};
+    SmallVector<OpFoldResult> kBasis = {one};
     SmallVector<int64_t> batchPos = {0};
     SmallVector<int64_t> mPos = {1, 2};
     SmallVector<int64_t> kPos = {3};
@@ -158,22 +157,21 @@ public:
     Value reshapedFilter = rewriter.create<tensor::CollapseShapeOp>(
         loc, reshapedFilterType, filter, filterReassocIndices);
 
-    Value reshapedOutput = rewriter.create<tensor::CollapseShapeOp>(
-        loc, reshapedOutputType, output, outputReassocIndices);
-
-    AffineExpr bDim, mDim, nDim, kDim;
-    bindDims(getContext(), bDim, mDim, nDim, kDim);
-    auto lhsMap = AffineMap::get(4, 0, {bDim, mDim, kDim}, getContext());
-    auto rhsMap = AffineMap::get(4, 0, {kDim, nDim}, getContext());
-    auto resultMap = AffineMap::get(4, 0, {bDim, mDim, nDim}, getContext());
+    AffineExpr bDim, m0Dim, m1Dim, nDim, kDim;
+    bindDims(getContext(), bDim, m0Dim, m1Dim, nDim, kDim);
+    auto lhsMap =
+        AffineMap::get(5, 0, {bDim, m0Dim, m1Dim, kDim}, getContext());
+    auto rhsMap = AffineMap::get(5, 0, {kDim, nDim}, getContext());
+    auto resultMap =
+        AffineMap::get(5, 0, {bDim, m0Dim, m1Dim, nDim}, getContext());
     auto parallel = utils::IteratorType::parallel;
     auto reduction = utils::IteratorType::reduction;
-    SmallVector<utils::IteratorType> genericIterators = {parallel, parallel,
-                                                         parallel, reduction};
+    SmallVector<utils::IteratorType> genericIterators = {
+        parallel, parallel, parallel, parallel, reduction};
     auto genericOp = rewriter.create<linalg::GenericOp>(
-        loc, reshapedOutputType,
+        loc, outputType,
         /*inputs=*/ValueRange{img2ColTensor, reshapedFilter},
-        /*outputs=*/ValueRange{reshapedOutput},
+        /*outputs=*/ValueRange{output},
         ArrayRef<AffineMap>{lhsMap, rhsMap, resultMap}, genericIterators,
         [](OpBuilder &nestedBuilder, Location nestedLoc, ValueRange args) {
           Value lhs = convertScalarToDtype(nestedBuilder, nestedLoc, args[0],
@@ -188,10 +186,7 @@ public:
         });
     Value result = genericOp.getResults().front();
 
-    auto reshapedResult = rewriter.create<tensor::ExpandShapeOp>(
-        loc, outputType, result, outputReassocIndices);
-
-    rewriter.replaceOp(convOp, ArrayRef<Value>{reshapedResult});
+    rewriter.replaceOp(convOp, ArrayRef<Value>{result});
 
     return success();
   }
@@ -254,7 +249,7 @@ public:
 
     auto loc = convOp.getLoc();
 
-    SmallVector<int64_t> colTensorShape = {n, oh * ow, ic * fh * fw};
+    SmallVector<int64_t> colTensorShape = {n, oh, ow, fh * fw * ic};
 
     Value colTensor = rewriter.create<tensor::EmptyOp>(
         loc, colTensorShape, inputType.getElementType());
@@ -262,10 +257,12 @@ public:
     SmallVector<int64_t> dilations(convOp.getDilations().getValues<int64_t>());
     SmallVector<OpFoldResult> kernelSize = {rewriter.getIndexAttr(fh),
                                             rewriter.getIndexAttr(fw)};
-    SmallVector<OpFoldResult> mOffset = {rewriter.getIndexAttr(0)};
-    SmallVector<OpFoldResult> mBasis = {rewriter.getIndexAttr(1)};
-    SmallVector<OpFoldResult> kOffset = {rewriter.getIndexAttr(0)};
-    SmallVector<OpFoldResult> kBasis = {rewriter.getIndexAttr(1)};
+    OpFoldResult zero = rewriter.getIndexAttr(0);
+    OpFoldResult one = rewriter.getIndexAttr(1);
+    SmallVector<OpFoldResult> mOffset = {zero, zero};
+    SmallVector<OpFoldResult> mBasis = {rewriter.getIndexAttr(ow), one};
+    SmallVector<OpFoldResult> kOffset = {zero};
+    SmallVector<OpFoldResult> kBasis = {one};
     SmallVector<int64_t> batchPos = {0};
     SmallVector<int64_t> mPos = {2, 3};
     SmallVector<int64_t> kPos = {1};
@@ -282,26 +279,21 @@ public:
     Value reshapedFilter = rewriter.create<tensor::CollapseShapeOp>(
         loc, reshapedFilterType, filter, filterReassocIndices);
 
-    SmallVector<ReassociationIndices> outputReassocIndices = {{0}, {1}, {2, 3}};
-    RankedTensorType reshapedOutputType =
-        RankedTensorType::get({n, oc, oh * ow}, outputType.getElementType());
-
-    Value reshapedOutput = rewriter.create<tensor::CollapseShapeOp>(
-        loc, reshapedOutputType, output, outputReassocIndices);
-
-    AffineExpr bDim, mDim, nDim, kDim;
-    bindDims(getContext(), bDim, mDim, nDim, kDim);
-    auto lhsMap = AffineMap::get(4, 0, {mDim, kDim}, getContext());
-    auto rhsMap = AffineMap::get(4, 0, {bDim, nDim, kDim}, getContext());
-    auto resultMap = AffineMap::get(4, 0, {bDim, mDim, nDim}, getContext());
+    AffineExpr bDim, mDim, nDim0, nDim1, kDim;
+    bindDims(getContext(), bDim, mDim, nDim0, nDim1, kDim);
+    auto lhsMap = AffineMap::get(5, 0, {mDim, kDim}, getContext());
+    auto rhsMap =
+        AffineMap::get(5, 0, {bDim, nDim0, nDim1, kDim}, getContext());
+    auto resultMap =
+        AffineMap::get(5, 0, {bDim, mDim, nDim0, nDim1}, getContext());
     auto parallel = utils::IteratorType::parallel;
     auto reduction = utils::IteratorType::reduction;
-    SmallVector<utils::IteratorType> genericIterators = {parallel, parallel,
-                                                         parallel, reduction};
+    SmallVector<utils::IteratorType> genericIterators = {
+        parallel, parallel, parallel, parallel, reduction};
     auto genericOp = rewriter.create<linalg::GenericOp>(
-        loc, reshapedOutputType,
+        loc, outputType,
         /*inputs=*/ValueRange{reshapedFilter, img2ColTensor},
-        /*outputs=*/ValueRange{reshapedOutput},
+        /*outputs=*/ValueRange{output},
         ArrayRef<AffineMap>{lhsMap, rhsMap, resultMap}, genericIterators,
         [](OpBuilder &nestedBuilder, Location nestedLoc, ValueRange args) {
           Value lhs = convertScalarToDtype(nestedBuilder, nestedLoc, args[0],
@@ -316,10 +308,7 @@ public:
         });
     Value result = genericOp.getResults().front();
 
-    auto reshapedResult = rewriter.create<tensor::ExpandShapeOp>(
-        loc, outputType, result, outputReassocIndices);
-
-    rewriter.replaceOp(convOp, ArrayRef<Value>{reshapedResult});
+    rewriter.replaceOp(convOp, ArrayRef<Value>{result});
 
     return success();
   }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv2d_to_im2col.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv2d_to_im2col.mlir
@@ -7,32 +7,30 @@ util.func public @conv_2d_nhwc_hwcf(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<
     outs(%arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32>
   util.return %0 : tensor<1x14x14x16xf32>
 }
-// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
-// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d3, d2)>
-// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d4)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d4, d3)>
+// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
 // CHECK:      util.func public @conv_2d_nhwc_hwcf(
 // CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x16x16x4xf32>
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<3x3x4x16xf32>
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<1x14x14x16xf32>
-// CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<1x196x36xf32>
+// CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<1x14x14x36xf32>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-// CHECK-SAME:   m_offset = [0] * [1] k_offset = [0] * [1]
+// CHECK-SAME:   m_offset = [0, 0] * [14, 1] k_offset = [0] * [1]
 // CHECK-SAME:   batch_pos = [0] m_pos = [1, 2] k_pos = [3]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<1x16x16x4xf32>)
-// CHECK-SAME:   outs(%[[EMPTY]] : tensor<1x196x36xf32>) -> tensor<1x196x36xf32>
+// CHECK-SAME:   outs(%[[EMPTY]] : tensor<1x14x14x36xf32>) -> tensor<1x14x14x36xf32>
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0, 1, 2], [3]] : tensor<3x3x4x16xf32> into tensor<36x16xf32>
-// CHECK-DAG:  %[[COLLAPSED_0:.+]] = tensor.collapse_shape %[[ARG2]] {{\[}}[0], [1, 2], [3]] : tensor<1x14x14x16xf32> into tensor<1x196x16xf32>
 // CHECK:      %[[MATMUL:.+]] = linalg.generic
 // CHECK-SAME:   indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
-// CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "reduction"]
-// CHECK-SAME:   ins(%[[IM2COL]], %[[COLLAPSED]] : tensor<1x196x36xf32>, tensor<36x16xf32>)
-// CHECK-SAME:   outs(%[[COLLAPSED_0]] : tensor<1x196x16xf32>) {
+// CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]
+// CHECK-SAME:   ins(%[[IM2COL]], %[[COLLAPSED]] : tensor<1x14x14x36xf32>, tensor<36x16xf32>)
+// CHECK-SAME:   outs(%[[ARG2]] : tensor<1x14x14x16xf32>) {
 // CHECK:          arith.mulf
 // CHECK:          arith.addf
-// CHECK:      } -> tensor<1x196x16xf32>
-// CHECK:      %[[EXPANDED:.+]] = tensor.expand_shape %[[MATMUL]] {{\[}}[0], [1, 2], [3]] output_shape [1, 14, 14, 16] : tensor<1x196x16xf32> into tensor<1x14x14x16xf32>
-// CHECK:      util.return %[[EXPANDED]] : tensor<1x14x14x16xf32>
+// CHECK:      } -> tensor<1x14x14x16xf32>
+// CHECK:      util.return %[[MATMUL]] : tensor<1x14x14x16xf32>
 
 // -----
 
@@ -43,32 +41,30 @@ util.func public @conv_2d_nchw_fchw(%arg0: tensor<1x4x16x16xf32>, %arg1: tensor<
     outs(%arg2: tensor<1x16x14x14xf32>) -> tensor<1x16x14x14xf32>
   util.return %0 : tensor<1x16x14x14xf32>
 }
-// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
-// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
-// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d1, d4)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d3, d4)>
+// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
 // CHECK:      util.func public @conv_2d_nchw_fchw(
 // CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x4x16x16xf32>
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<16x4x3x3xf32>
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<1x16x14x14xf32>
-// CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<1x196x36xf32>
+// CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<1x14x14x36xf32>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-// CHECK-SAME:   m_offset = [0] * [1] k_offset = [0] * [1]
+// CHECK-SAME:   m_offset = [0, 0] * [14, 1] k_offset = [0] * [1]
 // CHECK-SAME:   batch_pos = [0] m_pos = [2, 3] k_pos = [1]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<1x4x16x16xf32>)
-// CHECK-SAME:   outs(%[[EMPTY]] : tensor<1x196x36xf32>) -> tensor<1x196x36xf32>
+// CHECK-SAME:   outs(%[[EMPTY]] : tensor<1x14x14x36xf32>) -> tensor<1x14x14x36xf32>
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0], [1, 2, 3]] : tensor<16x4x3x3xf32> into tensor<16x36xf32>
-// CHECK-DAG:  %[[COLLAPSED_0:.+]] = tensor.collapse_shape %[[ARG2]] {{\[}}[0], [1], [2, 3]] : tensor<1x16x14x14xf32> into tensor<1x16x196xf32>
 // CHECK:      %[[MATMUL:.+]] = linalg.generic
 // CHECK-SAME:   indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
-// CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "reduction"]
-// CHECK-SAME:   ins(%[[COLLAPSED]], %[[IM2COL]] : tensor<16x36xf32>, tensor<1x196x36xf32>)
-// CHECK-SAME:   outs(%[[COLLAPSED_0]] : tensor<1x16x196xf32>) {
+// CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]
+// CHECK-SAME:   ins(%[[COLLAPSED]], %[[IM2COL]] : tensor<16x36xf32>, tensor<1x14x14x36xf32>)
+// CHECK-SAME:   outs(%[[ARG2]] : tensor<1x16x14x14xf32>) {
 // CHECK:          arith.mulf
 // CHECK:          arith.addf
-// CHECK:      } -> tensor<1x16x196xf32>
-// CHECK:      %[[EXPANDED:.+]] = tensor.expand_shape %[[MATMUL]] {{\[}}[0], [1], [2, 3]] output_shape [1, 16, 14, 14] : tensor<1x16x196xf32> into tensor<1x16x14x14xf32>
-// CHECK:      util.return %[[EXPANDED]] : tensor<1x16x14x14xf32>
+// CHECK:      } -> tensor<1x16x14x14xf32>
+// CHECK:      util.return %[[MATMUL]] : tensor<1x16x14x14xf32>
 
 // -----
 
@@ -79,34 +75,32 @@ util.func public @conv_mixed_types(%arg0: tensor<1x16x16x4xf16>, %arg1: tensor<3
     outs(%arg2: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32>
   util.return %0 : tensor<1x14x14x16xf32>
 }
-// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
-// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d3, d2)>
-// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d4)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d4, d3)>
+// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
 // CHECK:      util.func public @conv_mixed_types(
 // CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x16x16x4xf16>
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<3x3x4x16xf16>
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<1x14x14x16xf32>
-// CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<1x196x36xf16>
+// CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<1x14x14x36xf16>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
-// CHECK-SAME:   m_offset = [0] * [1] k_offset = [0] * [1]
+// CHECK-SAME:   m_offset = [0, 0] * [14, 1] k_offset = [0] * [1]
 // CHECK-SAME:   batch_pos = [0] m_pos = [1, 2] k_pos = [3]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<1x16x16x4xf16>)
-// CHECK-SAME:   outs(%[[EMPTY]] : tensor<1x196x36xf16>) -> tensor<1x196x36xf16>
+// CHECK-SAME:   outs(%[[EMPTY]] : tensor<1x14x14x36xf16>) -> tensor<1x14x14x36xf16>
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0, 1, 2], [3]] : tensor<3x3x4x16xf16> into tensor<36x16xf16>
-// CHECK-DAG:  %[[COLLAPSED_0:.+]] = tensor.collapse_shape %[[ARG2]] {{\[}}[0], [1, 2], [3]] : tensor<1x14x14x16xf32> into tensor<1x196x16xf32>
 // CHECK:      %[[MATMUL:.+]] = linalg.generic
 // CHECK-SAME:   indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
-// CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "reduction"]
-// CHECK-SAME:   ins(%[[IM2COL]], %[[COLLAPSED]] : tensor<1x196x36xf16>, tensor<36x16xf16>)
-// CHECK-SAME:   outs(%[[COLLAPSED_0]] : tensor<1x196x16xf32>) {
+// CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]
+// CHECK-SAME:   ins(%[[IM2COL]], %[[COLLAPSED]] : tensor<1x14x14x36xf16>, tensor<36x16xf16>)
+// CHECK-SAME:   outs(%[[ARG2]] : tensor<1x14x14x16xf32>) {
 // CHECK:          arith.extf
 // CHECK:          arith.extf
 // CHECK:          arith.mulf
 // CHECK:          arith.addf
-// CHECK:      } -> tensor<1x196x16xf32>
-// CHECK:      %[[EXPANDED:.+]] = tensor.expand_shape %[[MATMUL]] {{\[}}[0], [1, 2], [3]] output_shape [1, 14, 14, 16] : tensor<1x196x16xf32> into tensor<1x14x14x16xf32>
-// CHECK:      util.return %[[EXPANDED]] : tensor<1x14x14x16xf32>
+// CHECK:      } -> tensor<1x14x14x16xf32>
+// CHECK:      util.return %[[MATMUL]] : tensor<1x14x14x16xf32>
 
 // -----
 
@@ -117,31 +111,29 @@ util.func public @conv_strided(%arg0: tensor<1x16x16x4xf16>, %arg1: tensor<3x3x4
     outs(%arg2: tensor<1x7x7x16xf32>) -> tensor<1x7x7x16xf32>
   util.return %0 : tensor<1x7x7x16xf32>
 }
-// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
-// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d3, d2)>
-// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d4)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d4, d3)>
+// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
 // CHECK:      util.func public @conv_strided(
 // CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x16x16x4xf16>
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<3x3x4x16xf16>
 // CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<1x7x7x16xf32>
-// CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<1x49x36xf16>
+// CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<1x7x7x36xf16>
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [2, 2] dilations = [1, 1] kernel_size = [3, 3]
-// CHECK-SAME:   m_offset = [0] * [1] k_offset = [0] * [1]
+// CHECK-SAME:   m_offset = [0, 0] * [7, 1] k_offset = [0] * [1]
 // CHECK-SAME:   batch_pos = [0] m_pos = [1, 2] k_pos = [3]
 // CHECK-SAME:   ins(%[[ARG0]] : tensor<1x16x16x4xf16>)
-// CHECK-SAME:   outs(%[[EMPTY]] : tensor<1x49x36xf16>) -> tensor<1x49x36xf16>
+// CHECK-SAME:   outs(%[[EMPTY]] : tensor<1x7x7x36xf16>) -> tensor<1x7x7x36xf16>
 // CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0, 1, 2], [3]] : tensor<3x3x4x16xf16> into tensor<36x16xf16>
-// CHECK-DAG:  %[[COLLAPSED_0:.+]] = tensor.collapse_shape %[[ARG2]] {{\[}}[0], [1, 2], [3]] : tensor<1x7x7x16xf32> into tensor<1x49x16xf32>
 // CHECK:      %[[MATMUL:.+]] = linalg.generic
 // CHECK-SAME:   indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
-// CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "reduction"]
-// CHECK-SAME:   ins(%[[IM2COL]], %[[COLLAPSED]] : tensor<1x49x36xf16>, tensor<36x16xf16>)
-// CHECK-SAME:   outs(%[[COLLAPSED_0]] : tensor<1x49x16xf32>) {
+// CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]
+// CHECK-SAME:   ins(%[[IM2COL]], %[[COLLAPSED]] : tensor<1x7x7x36xf16>, tensor<36x16xf16>)
+// CHECK-SAME:   outs(%[[ARG2]] : tensor<1x7x7x16xf32>) {
 // CHECK:          arith.extf
 // CHECK:          arith.extf
 // CHECK:          arith.mulf
 // CHECK:          arith.addf
-// CHECK:      } -> tensor<1x49x16xf32>
-// CHECK:      %[[EXPANDED:.+]] = tensor.expand_shape %[[MATMUL]] {{\[}}[0], [1, 2], [3]] output_shape [1, 7, 7, 16] : tensor<1x49x16xf32> into tensor<1x7x7x16xf32>
-// CHECK:      util.return %[[EXPANDED]] : tensor<1x7x7x16xf32>
+// CHECK:      } -> tensor<1x7x7x16xf32>
+// CHECK:      util.return %[[MATMUL]] : tensor<1x7x7x16xf32>


### PR DESCRIPTION
This is following up on https://github.com/iree-org/iree/pull/18593, which enabled support for expanded result shapes in the im2col op. This PR changes the rewrite patterns for conv into IGEMM to use the expanded H and W dimensions, rather than inserting collapse_shape and expand_shape ops.