### PR TITLE
[LinalgExt] Remove default implementation for getStaticLoopRanges

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -672,7 +672,12 @@ setAttentionVectorDistributionConfig(IREE::GPU::TargetAttr target,
 
   // Get iteration domain bounds.
   OpBuilder b(op);
-  SmallVector<int64_t, 4> bounds = op.getStaticLoopRanges();
+  FailureOr<SmallVector<int64_t>> maybeBounds = op.getStaticLoopRanges();
+  if (failed(maybeBounds)) {
+    return failure();
+  }
+
+  ArrayRef<int64_t> bounds = maybeBounds.value();
 
   auto opInfo =
       IREE::LinalgExt::AttentionOpDetail::get(op.getIndexingMapsArray())

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.cpp
@@ -128,6 +128,12 @@ public:
         }));
   }
 
+  SmallVector<int64_t, 4> getStaticLoopRanges(Operation *op) const {
+    auto softmaxOp = cast<linalg::SoftmaxOp>(op);
+    // Softmax loop range is the input shape.
+    return SmallVector<int64_t, 4>(softmaxOp.getInputOperandType().getShape());
+  }
+
   AffineMap getIndexingMapMatchingResult(mlir::Operation *op,
                                          OpResult result) const {
     return getIndexingMapsForResults(op)[result.getResultNumber()];

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.cpp
@@ -83,8 +83,10 @@ public:
     return (llvm::cast<ConcreteType>(op).getNumLoops());
   }
 
-  SmallVector<int64_t, 4> getStaticLoopRanges(mlir::Operation *op) const {
-    return (llvm::cast<ConcreteType>(op).getStaticLoopRanges());
+  FailureOr<SmallVector<int64_t>>
+  getStaticLoopRanges(mlir::Operation *op) const {
+    return SmallVector<int64_t>(
+        llvm::cast<ConcreteType>(op).getStaticLoopRanges());
   }
 
   AffineMap getIndexingMapMatchingResult(mlir::Operation *op,
@@ -128,10 +130,10 @@ public:
         }));
   }
 
-  SmallVector<int64_t, 4> getStaticLoopRanges(Operation *op) const {
+  FailureOr<SmallVector<int64_t>> getStaticLoopRanges(Operation *op) const {
     auto softmaxOp = cast<linalg::SoftmaxOp>(op);
     // Softmax loop range is the input shape.
-    return SmallVector<int64_t, 4>(softmaxOp.getInputOperandType().getShape());
+    return SmallVector<int64_t>(softmaxOp.getInputOperandType().getShape());
   }
 
   AffineMap getIndexingMapMatchingResult(mlir::Operation *op,

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtInterfaces.td
@@ -113,16 +113,7 @@ def LinalgFusionInterface : OpInterface<"LinalgFusionOpInterface"> {
       /*retTy=*/"SmallVector<int64_t, 4>",
       /*methodName=*/"getStaticLoopRanges",
       /*args=*/(ins),
-      /*methodBody=*/"",
-      /*defaultImplementation=*/[{
-          SmallVector<int64_t, 4> loopRanges;
-          llvm::for_each($_op.getOperands(), [&](Value operand) {
-          if (auto shapedType = dyn_cast<ShapedType>(operand.getType())) {
-            llvm::append_range(loopRanges, shapedType.getShape());
-            }
-          });
-          return loopRanges;
-      }]
+      /*methodBody=*/""
     >,
     InterfaceMethod<
       /*desc=*/[{

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtInterfaces.td
@@ -110,10 +110,13 @@ def LinalgFusionInterface : OpInterface<"LinalgFusionOpInterface"> {
       /*desc=*/[{
         Return the static loop ranges.
       }],
-      /*retTy=*/"SmallVector<int64_t, 4>",
+      /*retTy=*/"FailureOr<SmallVector<int64_t>>",
       /*methodName=*/"getStaticLoopRanges",
       /*args=*/(ins),
-      /*methodBody=*/""
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return failure();
+      }]
     >,
     InterfaceMethod<
       /*desc=*/[{

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -252,9 +252,9 @@ ScatterOp::reifyResultShapes(OpBuilder &b,
       .reifyResultShapes(b, reifiedReturnShapes);
 }
 
-SmallVector<int64_t, 4> ScatterOp::getStaticLoopRanges() {
+FailureOr<SmallVector<int64_t>> ScatterOp::getStaticLoopRanges() {
   // Scatter loop ranges are loop ranges for update.
-  return SmallVector<int64_t, 4>(getUpdateType().getShape());
+  return SmallVector<int64_t>(getUpdateType().getShape());
 }
 
 SmallVector<AffineMap> ScatterOp::getIndexingMapsForOperands() {
@@ -1326,8 +1326,8 @@ SmallVector<AffineMap> AttentionOp::getIndexingMapsArray() {
       getIndexingMaps().getAsValueRange<AffineMapAttr>());
 }
 
-SmallVector<int64_t, 4> AttentionOp::getStaticLoopRanges() {
-  SmallVector<int64_t, 4> bounds(getIterationDomainRank());
+FailureOr<SmallVector<int64_t>> AttentionOp::getStaticLoopRanges() {
+  SmallVector<int64_t> bounds(getIterationDomainRank());
   SmallVector<bool> dimsFound(getIterationDomainRank(), false);
 
   // batch(s), m, k1
@@ -1841,10 +1841,6 @@ LogicalResult CustomOp::verify() {
 }
 
 /// Start `LinalgFusionInterface` implementation.
-
-SmallVector<int64_t, 4> CustomOp::getStaticLoopRanges() {
-  llvm_unreachable("Not Yet Implemented");
-}
 
 SmallVector<AffineMap> CustomOp::getIndexingMapsForOperands() {
   return llvm::map_to_vector(

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -252,6 +252,11 @@ ScatterOp::reifyResultShapes(OpBuilder &b,
       .reifyResultShapes(b, reifiedReturnShapes);
 }
 
+SmallVector<int64_t, 4> ScatterOp::getStaticLoopRanges() {
+  // Scatter loop ranges are loop ranges for update.
+  return SmallVector<int64_t, 4>(getUpdateType().getShape());
+}
+
 SmallVector<AffineMap> ScatterOp::getIndexingMapsForOperands() {
   Builder builder(getContext());
   return {builder.getMultiDimIdentityMap(getUpdateType().getRank()),
@@ -1836,6 +1841,10 @@ LogicalResult CustomOp::verify() {
 }
 
 /// Start `LinalgFusionInterface` implementation.
+
+SmallVector<int64_t, 4> CustomOp::getStaticLoopRanges() {
+  llvm_unreachable("Not Yet Implemented");
+}
 
 SmallVector<AffineMap> CustomOp::getIndexingMapsForOperands() {
   return llvm::map_to_vector(

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -469,7 +469,8 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_PureOp<"attention",
     [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
      DestinationStyleOpInterface, LinalgExtInterface,
      DeclareOpInterfaceMethods<LinalgFusionInterface,
-      ["getIndexingMapsForResults", "getIndexingMapsForOperands"]>,
+      ["getIndexingMapsForResults", "getIndexingMapsForOperands",
+       "getStaticLoopRanges"]>,
      DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
      DeclareOpInterfaceMethods<TilingInterface,
       ["getIterationDomain",
@@ -527,8 +528,6 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_PureOp<"attention",
     MutableOperandRange getDpsInitsMutable();
 
     SmallVector<AffineMap> getIndexingMapsArray();
-
-    SmallVector<int64_t, 4> getStaticLoopRanges();
 
     AffineMap getQueryMap() {
       return cast<AffineMap>(getIndexingMapsArray()[0]);

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -94,7 +94,9 @@ let opDocGroup = OpGroupNonStructuredOps in {
 
 def IREELinalgExt_ScatterOp : IREELinalgExt_Op<"scatter",
     [DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
-     DeclareOpInterfaceMethods<LinalgFusionInterface>,
+     DeclareOpInterfaceMethods<LinalgFusionInterface,
+      ["getIndexingMapsForResults", "getIndexingMapsForOperands",
+       "getStaticLoopRanges"]>,
      DeclareOpInterfaceMethods<TilingInterface,
         ["generateScalarImplementation",
          "getIterationDomain",

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ReshapeFusion.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ReshapeFusion.cpp
@@ -67,8 +67,12 @@ LogicalResult ExpansionInfo::compute(OpTy op, OpOperand *fusableOpOperand,
   if (reassociationMaps.empty())
     return failure();
   AffineMap fusedIndexMap = op.getMatchingIndexingMap(fusableOpOperand);
-  SmallVector<int64_t, 4> originalLoopRange = op.getStaticLoopRanges();
-  originalLoopExtent.assign(originalLoopRange.begin(), originalLoopRange.end());
+  FailureOr<SmallVector<int64_t>> originalLoopRange = op.getStaticLoopRanges();
+  if (failed(originalLoopRange)) {
+    return failure();
+  }
+  originalLoopExtent.assign(originalLoopRange->begin(),
+                            originalLoopRange->end());
 
   reassociation.clear();
   expandedShapeMap.clear();

--- a/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
@@ -568,9 +568,15 @@ isFusableWithConsumer(OpOperand &fusedOperand,
   // TODO(#12664): This is unnecessary requirement, but we need a better config
   // to tile the consumer with a larger iteration space.
   if (!options.aggressiveFusion) {
-    auto producerIterationSpace = producerFusionOp.getStaticLoopRanges();
-    auto consumerIterationSpace = consumerFusionOp.getStaticLoopRanges();
-    if (producerIterationSpace.size() < consumerIterationSpace.size()) {
+    FailureOr<SmallVector<int64_t>> producerIterationSpace =
+        producerFusionOp.getStaticLoopRanges();
+    FailureOr<SmallVector<int64_t>> consumerIterationSpace =
+        consumerFusionOp.getStaticLoopRanges();
+    if (failed(producerIterationSpace) || failed(consumerIterationSpace)) {
+      return false;
+    }
+    if (producerIterationSpace.value().size() <
+        consumerIterationSpace.value().size()) {
       return false;
     }
   }


### PR DESCRIPTION
The default implementation of getStaticLoopRanges is dangerous and causes unexpected bugs. It only works for operands with distinct loop ranges as dimensions. It's better to have operations specify it.