### PR TITLE
Adding `iree_vm_context_fork` to fork a context.

### DIFF
--- a/runtime/bindings/python/py_module.cc
+++ b/runtime/bindings/python/py_module.cc
@@ -40,6 +40,7 @@ class PyModuleInterface {
     interface_.lookup_function = &PyModuleInterface::ModuleLookupFunction;
     interface_.alloc_state = &PyModuleInterface::ModuleAllocState;
     interface_.free_state = &PyModuleInterface::ModuleFreeState;
+    interface_.fork_state = &PyModuleInterface::ModuleForkState;
     interface_.resolve_import = &PyModuleInterface::ModuleResolveImport;
     interface_.notify = &PyModuleInterface::ModuleNotify;
     interface_.begin_call = &PyModuleInterface::ModuleBeginCall;
@@ -156,6 +157,15 @@ class PyModuleInterface {
     auto retained_handle =
         py::handle(reinterpret_cast<PyObject*>(module_state));
     retained_handle.dec_ref();
+  }
+
+  static iree_status_t ModuleForkState(
+      void* self, iree_vm_module_state_t* parent_state,
+      iree_allocator_t allocator, iree_vm_module_state_t** out_child_state) {
+    // TODO: call into python to clone the state (mostly what ctor_ is doing
+    // but each module will want to handle things differently).
+    return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                            "python module fork not supported");
   }
 
   static iree_status_t ModuleResolveImport(

--- a/runtime/src/iree/modules/check/module.cc
+++ b/runtime/src/iree/modules/check/module.cc
@@ -497,6 +497,12 @@ class CheckModule final : public vm::NativeModule<CheckModuleState> {
     auto state = std::make_unique<CheckModuleState>(allocator);
     return state;
   }
+
+  StatusOr<std::unique_ptr<CheckModuleState>> ForkState(
+      CheckModuleState* parent_state, iree_allocator_t allocator) override {
+    // No state needs to be forked.
+    return CreateState(allocator);
+  }
 };
 
 }  // namespace

--- a/runtime/src/iree/modules/hal/inline/module.c
+++ b/runtime/src/iree/modules/hal/inline/module.c
@@ -189,6 +189,20 @@ static void IREE_API_PTR iree_hal_inline_module_free_state(
   IREE_TRACE_ZONE_END(z0);
 }
 
+static iree_status_t IREE_API_PTR iree_hal_inline_module_fork_state(
+    void* self, iree_vm_module_state_t* parent_state,
+    iree_allocator_t allocator, iree_vm_module_state_t** out_child_state) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // NOTE: parent state contains nothing useful and is unused.
+  // We just realloc new state.
+  iree_status_t status =
+      iree_hal_inline_module_alloc_state(self, allocator, out_child_state);
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 static iree_status_t IREE_API_PTR iree_hal_inline_module_notify(
     void* self, iree_vm_module_state_t* module_state, iree_vm_signal_t signal) {
   switch (signal) {
@@ -597,6 +611,7 @@ IREE_API_EXPORT iree_status_t iree_hal_inline_module_create(
       .destroy = iree_hal_inline_module_destroy,
       .alloc_state = iree_hal_inline_module_alloc_state,
       .free_state = iree_hal_inline_module_free_state,
+      .fork_state = iree_hal_inline_module_fork_state,
       .notify = iree_hal_inline_module_notify,
   };
 

--- a/runtime/src/iree/modules/hal/loader/module.c
+++ b/runtime/src/iree/modules/hal/loader/module.c
@@ -72,6 +72,20 @@ static void IREE_API_PTR iree_hal_loader_module_free_state(
   IREE_TRACE_ZONE_END(z0);
 }
 
+static iree_status_t IREE_API_PTR iree_hal_loader_module_fork_state(
+    void* self, iree_vm_module_state_t* parent_state,
+    iree_allocator_t allocator, iree_vm_module_state_t** out_child_state) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // NOTE: parent state contains nothing useful and is unused.
+  // We just realloc new state.
+  iree_status_t status =
+      iree_hal_loader_module_alloc_state(self, allocator, out_child_state);
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 static iree_status_t IREE_API_PTR iree_hal_loader_module_notify(
     void* self, iree_vm_module_state_t* module_state, iree_vm_signal_t signal) {
   switch (signal) {
@@ -392,6 +406,7 @@ IREE_API_EXPORT iree_status_t iree_hal_loader_module_create(
       .destroy = iree_hal_loader_module_destroy,
       .alloc_state = iree_hal_loader_module_alloc_state,
       .free_state = iree_hal_loader_module_free_state,
+      .fork_state = iree_hal_loader_module_fork_state,
       .notify = iree_hal_loader_module_notify,
   };
 

--- a/runtime/src/iree/modules/io/parameters/module.c
+++ b/runtime/src/iree/modules/io/parameters/module.c
@@ -67,6 +67,20 @@ static void IREE_API_PTR iree_io_parameters_module_free_state(
   IREE_TRACE_ZONE_END(z0);
 }
 
+static iree_status_t IREE_API_PTR iree_io_parameters_module_fork_state(
+    void* self, iree_vm_module_state_t* parent_state,
+    iree_allocator_t host_allocator, iree_vm_module_state_t** out_child_state) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // NOTE: parent state contains nothing useful and is unused.
+  // We just realloc new state.
+  iree_status_t status = iree_io_parameters_module_alloc_state(
+      self, host_allocator, out_child_state);
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 static iree_status_t IREE_API_PTR iree_io_parameters_module_notify(
     void* self, iree_vm_module_state_t* module_state, iree_vm_signal_t signal) {
   iree_io_parameters_module_t* module = IREE_IO_PARAMETERS_MODULE_CAST(self);

--- a/runtime/src/iree/modules/vmvx/module.c
+++ b/runtime/src/iree/modules/vmvx/module.c
@@ -91,6 +91,13 @@ iree_vmvx_module_free_state(void* self, iree_vm_module_state_t* module_state) {
   iree_allocator_free(state->host_allocator, state);
 }
 
+static iree_status_t IREE_API_PTR iree_vmvx_module_fork_state(
+    void* self, iree_vm_module_state_t* parent_state,
+    iree_allocator_t allocator, iree_vm_module_state_t** out_child_state) {
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                          "vmvx module forking not implemented");
+}
+
 //===----------------------------------------------------------------------===//
 // Argument validation and marshalling
 //===----------------------------------------------------------------------===//
@@ -796,6 +803,7 @@ IREE_API_EXPORT iree_status_t iree_vmvx_module_create(
       .destroy = iree_vmvx_module_destroy,
       .alloc_state = iree_vmvx_module_alloc_state,
       .free_state = iree_vmvx_module_free_state,
+      .fork_state = iree_vmvx_module_fork_state,
   };
 
   // Allocate shared module state.

--- a/runtime/src/iree/vm/context.h
+++ b/runtime/src/iree/vm/context.h
@@ -69,6 +69,14 @@ IREE_API_EXPORT iree_status_t iree_vm_context_create_with_modules(
     iree_host_size_t module_count, iree_vm_module_t** modules,
     iree_allocator_t allocator, iree_vm_context_t** out_context);
 
+// Forks the provided |parent_context| into |out_child_context|.
+// The new context will have all of the same modules loaded and a shallow copy
+// of the per-module state. Modules may decide to retain subresources
+// by-reference or completely reinitialize themselves.
+IREE_API_EXPORT iree_status_t iree_vm_context_fork(
+    const iree_vm_context_t* parent_context, iree_allocator_t allocator,
+    iree_vm_context_t** out_child_context);
+
 // Retains the given |context| for the caller.
 IREE_API_EXPORT void iree_vm_context_retain(iree_vm_context_t* context);
 

--- a/runtime/src/iree/vm/dynamic/module.c
+++ b/runtime/src/iree/vm/dynamic/module.c
@@ -164,6 +164,14 @@ static void IREE_API_PTR iree_vm_dynamic_module_free_state(
   module->user_module->free_state(module->user_module->self, module_state);
 }
 
+static iree_status_t IREE_API_PTR iree_vm_dynamic_module_fork_state(
+    void* self, iree_vm_module_state_t* parent_state,
+    iree_allocator_t allocator, iree_vm_module_state_t** out_child_state) {
+  iree_vm_dynamic_module_t* module = (iree_vm_dynamic_module_t*)self;
+  return iree_status_freeze(module->user_module->fork_state(
+      module->user_module->self, parent_state, allocator, out_child_state));
+}
+
 static iree_status_t IREE_API_PTR iree_vm_dynamic_module_resolve_import(
     void* self, iree_vm_module_state_t* module_state, iree_host_size_t ordinal,
     const iree_vm_function_t* function,
@@ -230,6 +238,7 @@ static iree_status_t iree_vm_dynamic_module_create(
       iree_vm_dynamic_module_resolve_source_location;
   module->interface.alloc_state = iree_vm_dynamic_module_alloc_state;
   module->interface.free_state = iree_vm_dynamic_module_free_state;
+  module->interface.fork_state = iree_vm_dynamic_module_fork_state;
   module->interface.resolve_import = iree_vm_dynamic_module_resolve_import;
   module->interface.notify = iree_vm_dynamic_module_notify;
   module->interface.begin_call = iree_vm_dynamic_module_begin_call;

--- a/runtime/src/iree/vm/native_module_test.cc
+++ b/runtime/src/iree/vm/native_module_test.cc
@@ -29,7 +29,11 @@ class VMNativeModuleTest : public ::testing::Test {
   virtual void SetUp() {
     IREE_CHECK_OK(iree_vm_instance_create(IREE_VM_TYPE_CAPACITY_DEFAULT,
                                           iree_allocator_system(), &instance_));
+  }
 
+  virtual void TearDown() { iree_vm_instance_release(instance_); }
+
+  iree_vm_context_t* CreateContext() {
     // Create both modules shared instances. These are generally immutable and
     // can be shared by multiple contexts.
     iree_vm_module_t* module_a = nullptr;
@@ -42,29 +46,28 @@ class VMNativeModuleTest : public ::testing::Test {
     // Create the context with both modules and perform runtime linkage.
     // Imports from module_a -> module_b will be resolved and per-context state
     // will be allocated.
+    iree_vm_context_t* context = NULL;
     std::vector<iree_vm_module_t*> modules = {module_a, module_b};
     IREE_CHECK_OK(iree_vm_context_create_with_modules(
         instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.size(), modules.data(),
-        iree_allocator_system(), &context_));
+        iree_allocator_system(), &context));
 
     // No longer need the modules as the context retains them.
     iree_vm_module_release(module_a);
     iree_vm_module_release(module_b);
+
+    return context;
   }
 
-  virtual void TearDown() {
-    iree_vm_context_release(context_);
-    iree_vm_instance_release(instance_);
-  }
-
-  StatusOr<int32_t> RunFunction(iree_string_view_t function_name,
+  StatusOr<int32_t> RunFunction(iree_vm_context_t* context,
+                                iree_string_view_t function_name,
                                 int32_t arg0) {
     // Lookup the entry function. This can be cached in an application if
     // multiple calls will be made.
     iree_vm_function_t function;
     IREE_RETURN_IF_ERROR(
         iree_vm_context_resolve_function(
-            context_, iree_make_cstring_view("module_b.entry"), &function),
+            context, iree_make_cstring_view("module_b.entry"), &function),
         "unable to resolve entry point");
 
     // Setup I/O lists and pass in the argument. The result list will be
@@ -83,7 +86,7 @@ class VMNativeModuleTest : public ::testing::Test {
 
     // Invoke the entry function to do our work. Runs synchronously.
     IREE_RETURN_IF_ERROR(
-        iree_vm_invoke(context_, function, IREE_VM_INVOCATION_FLAG_NONE,
+        iree_vm_invoke(context, function, IREE_VM_INVOCATION_FLAG_NONE,
                        /*policy=*/nullptr, input_list.get(), output_list.get(),
                        iree_allocator_system()));
 
@@ -96,19 +99,64 @@ class VMNativeModuleTest : public ::testing::Test {
 
  private:
   iree_vm_instance_t* instance_ = nullptr;
-  iree_vm_context_t* context_ = nullptr;
 };
 
 TEST_F(VMNativeModuleTest, Example) {
+  iree_vm_context_t* context = CreateContext();
+
   IREE_ASSERT_OK_AND_ASSIGN(
-      int32_t v0, RunFunction(iree_make_cstring_view("module_b.entry"), 1));
+      int32_t v0,
+      RunFunction(context, iree_make_cstring_view("module_b.entry"), 1));
   ASSERT_EQ(v0, 1);
   IREE_ASSERT_OK_AND_ASSIGN(
-      int32_t v1, RunFunction(iree_make_cstring_view("module_b.entry"), 2));
+      int32_t v1,
+      RunFunction(context, iree_make_cstring_view("module_b.entry"), 2));
   ASSERT_EQ(v1, 4);
   IREE_ASSERT_OK_AND_ASSIGN(
-      int32_t v2, RunFunction(iree_make_cstring_view("module_b.entry"), 3));
+      int32_t v2,
+      RunFunction(context, iree_make_cstring_view("module_b.entry"), 3));
   ASSERT_EQ(v2, 8);
+
+  iree_vm_context_release(context);
+}
+
+TEST_F(VMNativeModuleTest, Fork) {
+  iree_vm_context_t* parent_context = CreateContext();
+
+  // Run one tick of the parent context to mutate state.
+  IREE_ASSERT_OK_AND_ASSIGN(
+      int32_t parent_v0,
+      RunFunction(parent_context, iree_make_cstring_view("module_b.entry"), 1));
+  ASSERT_EQ(parent_v0, 1);
+
+  // Fork the parent context, preserving its state.
+  iree_vm_context_t* child_context = NULL;
+  IREE_ASSERT_OK(iree_vm_context_fork(parent_context, iree_allocator_system(),
+                                      &child_context));
+
+  // Run a tick in both the parent and child contexts; the values should match
+  // as they should have started from the same forked state but operate
+  // independently.
+  IREE_ASSERT_OK_AND_ASSIGN(
+      int32_t parent_v1,
+      RunFunction(parent_context, iree_make_cstring_view("module_b.entry"), 2));
+  ASSERT_EQ(parent_v1, 4);
+  IREE_ASSERT_OK_AND_ASSIGN(
+      int32_t child_v1,
+      RunFunction(child_context, iree_make_cstring_view("module_b.entry"), 2));
+  ASSERT_EQ(child_v1, 4);
+
+  // Drop the parent context; the forked one should be independent.
+  iree_vm_context_release(parent_context);
+
+  // Run another step in the child context to ensure it isn't relying on the
+  // parent.
+  IREE_ASSERT_OK_AND_ASSIGN(
+      int32_t child_v2,
+      RunFunction(child_context, iree_make_cstring_view("module_b.entry"), 3));
+  ASSERT_EQ(child_v2, 8);
+
+  iree_vm_context_release(child_context);
 }
 
 }  // namespace

--- a/samples/custom_module/async/module.cc
+++ b/samples/custom_module/async/module.cc
@@ -290,6 +290,16 @@ class CustomModule final : public vm::NativeModule<CustomModuleState> {
     return state;
   }
 
+  // Forks a parent state into a child state, preserving any module state
+  // by-reference.
+  StatusOr<std::unique_ptr<CustomModuleState>> ForkState(
+      CustomModuleState* parent_state,
+      iree_allocator_t host_allocator) override {
+    // No special state to preserve; the device is the same for all states
+    // created from this module.
+    return CreateState(host_allocator);
+  }
+
  private:
   vm::ref<iree_hal_device_t> device_;
 };

--- a/samples/custom_module/basic/module.cc
+++ b/samples/custom_module/basic/module.cc
@@ -192,6 +192,15 @@ class CustomModule final : public vm::NativeModule<CustomModuleState> {
     auto state = std::make_unique<CustomModuleState>(allocator);
     return state;
   }
+
+  // Forks a parent state into a child state, preserving any module state
+  // by-reference.
+  StatusOr<std::unique_ptr<CustomModuleState>> ForkState(
+      CustomModuleState* parent_state,
+      iree_allocator_t host_allocator) override {
+    // No special state to preserve.
+    return CreateState(host_allocator);
+  }
 };
 
 }  // namespace

--- a/samples/custom_module/dynamic/module.cc
+++ b/samples/custom_module/dynamic/module.cc
@@ -189,6 +189,15 @@ class CustomModule final : public vm::NativeModule<CustomModuleState> {
     auto state = std::make_unique<CustomModuleState>(host_allocator);
     return state;
   }
+
+  // Forks a parent state into a child state, preserving any module state
+  // by-reference.
+  StatusOr<std::unique_ptr<CustomModuleState>> ForkState(
+      CustomModuleState* parent_state,
+      iree_allocator_t host_allocator) override {
+    // No special state to preserve.
+    return CreateState(host_allocator);
+  }
 };
 
 }  // namespace

--- a/samples/custom_module/static/module.cc
+++ b/samples/custom_module/static/module.cc
@@ -182,6 +182,15 @@ class CustomModule final : public vm::NativeModule<CustomModuleState> {
     auto state = std::make_unique<CustomModuleState>(host_allocator);
     return state;
   }
+
+  // Forks a parent state into a child state, preserving any module state
+  // by-reference.
+  StatusOr<std::unique_ptr<CustomModuleState>> ForkState(
+      CustomModuleState* parent_state,
+      iree_allocator_t host_allocator) override {
+    // No special state to preserve.
+    return CreateState(host_allocator);
+  }
 };
 
 }  // namespace

--- a/samples/custom_module/sync/module.cc
+++ b/samples/custom_module/sync/module.cc
@@ -171,6 +171,16 @@ class CustomModule final : public vm::NativeModule<CustomModuleState> {
     return state;
   }
 
+  // Forks a parent state into a child state, preserving any module state
+  // by-reference.
+  StatusOr<std::unique_ptr<CustomModuleState>> ForkState(
+      CustomModuleState* parent_state,
+      iree_allocator_t host_allocator) override {
+    // No special state to preserve; the device is always the same and derived
+    // from the module.
+    return CreateState(host_allocator);
+  }
+
  private:
   vm::ref<iree_hal_device_t> device_;
 };

--- a/tools/testing/e2e/iree-e2e-attention-test.cc
+++ b/tools/testing/e2e/iree-e2e-attention-test.cc
@@ -443,6 +443,11 @@ struct AttentionTestModule final
       iree_allocator_t host_allocator) override {
     return std::make_unique<AttentionTestModuleState>(host_allocator);
   }
+  StatusOr<std::unique_ptr<AttentionTestModuleState>> ForkState(
+      AttentionTestModuleState* parent_state,
+      iree_allocator_t host_allocator) override {
+    return std::make_unique<AttentionTestModuleState>(host_allocator);
+  }
 };
 
 }  // namespace iree

--- a/tools/testing/e2e/iree-e2e-conv2d-test.cc
+++ b/tools/testing/e2e/iree-e2e-conv2d-test.cc
@@ -522,6 +522,11 @@ struct Conv2dTestModule final : public vm::NativeModule<Conv2dTestModuleState> {
       iree_allocator_t host_allocator) override {
     return std::make_unique<Conv2dTestModuleState>(host_allocator);
   }
+  StatusOr<std::unique_ptr<Conv2dTestModuleState>> ForkState(
+      Conv2dTestModuleState* parent_state,
+      iree_allocator_t host_allocator) override {
+    return CreateState(host_allocator);
+  }
 };
 
 }  // namespace iree

--- a/tools/testing/e2e/iree-e2e-matmul-test.cc
+++ b/tools/testing/e2e/iree-e2e-matmul-test.cc
@@ -698,6 +698,11 @@ struct MatmulTestModule final : public vm::NativeModule<MatmulTestModuleState> {
       iree_allocator_t host_allocator) override {
     return std::make_unique<MatmulTestModuleState>(host_allocator);
   }
+  StatusOr<std::unique_ptr<MatmulTestModuleState>> ForkState(
+      MatmulTestModuleState* parent_state,
+      iree_allocator_t host_allocator) override {
+    return CreateState(host_allocator);
+  }
 };
 
 }  // namespace iree


### PR DESCRIPTION
Contexts will be cloned with the same set of modules and in the same frozen state. All module state within the context will be cloned via a module-defined function to allow for selective reinitialization and shallow/deep cloning choices. Module initializers are not re-run on the child context but at the end of the fork all modules will receive an `IREE_VM_SIGNAL_FORK` notification and can selectively reinitialize any resources they want. Once forked the parent and child context lifetimes are independent and different modules can be loaded in each.

emitc and python modules do not yet support forking and a fork request will fail if one is loaded in the context. It'd be possible to fork a context without one of those modules loaded and then load them into the new forked contexts afterward.

The compiler currently does nothing special for reinitializing after a fork. We should probably change mutable global tensors to be reinitialized by outlining the initializers for them and calling the same initialization function during `__init` and the fork signal handler. For now every global will be forked by reference.

Fixes #18747.