### PR TITLE
Adding `IREE_STATUS_INCOMPATIBLE`.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/InitializeDevices.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/InitializeDevices.cpp
@@ -67,7 +67,7 @@ static void initializeDeviceGlobal(
   initializerBuilder.create<scf::IfOp>(
       loc, isNull, [&](OpBuilder &thenBuilder, Location thenLoc) {
         Value status = thenBuilder.create<arith::ConstantIntOp>(
-            thenLoc, static_cast<int64_t>(IREE::Util::StatusCode::NotFound),
+            thenLoc, static_cast<int64_t>(IREE::Util::StatusCode::Incompatible),
             32);
         std::string str;
         {

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/initialize_devices.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/initialize_devices.mlir
@@ -10,7 +10,7 @@ util.global private @device_123 = #hal.device.ordinal<123> : !hal.device
 //  CHECK-DAG: %[[NULL_DEVICE:.+]] = util.null : !hal.device
 //  CHECK-DAG: %[[IS_NULL:.+]] = util.cmp.eq %[[DEVICE]], %[[NULL_DEVICE]]
 // CHECK-NEXT: scf.if %[[IS_NULL]] {
-//      CHECK:   util.status.check_ok %c5_i32, "HAL device `device_123` not found or unavailable: #hal.device.ordinal<123>"
+//      CHECK:   util.status.check_ok %c18_i32, "HAL device `device_123` not found or unavailable: #hal.device.ordinal<123>"
 //      CHECK: util.global.store %[[DEVICE]], @device_123
 
 // -----
@@ -26,7 +26,7 @@ util.global private @device_fallback = #hal.device.fallback<@device_base> : !hal
 //  CHECK-DAG: %[[DEVICE:.+]] = util.global.load @device_base : !hal.device
 //  CHECK-DAG: %[[IS_NULL:.+]] = util.cmp.eq %[[DEVICE]], %{{.+}}
 // CHECK-NEXT: scf.if %[[IS_NULL]] {
-//      CHECK:   util.status.check_ok %c5_i32, "HAL device `device_fallback` not found or unavailable: #hal.device.fallback<@device_base>"
+//      CHECK:   util.status.check_ok %c18_i32, "HAL device `device_fallback` not found or unavailable: #hal.device.fallback<@device_base>"
 //      CHECK: util.global.store %[[DEVICE]], @device_fallback
 
 // -----
@@ -80,7 +80,7 @@ util.global private @device_a = #hal.device.target<"a", {
 // Error out if no device was found because at least one match is required.
 //  CHECK-DAG: %[[IS_NULL:.+]] = util.cmp.eq %[[WHILE]]#2, %[[NULL_DEVICE]]
 // CHECK-NEXT: scf.if %[[IS_NULL]] {
-//      CHECK:   util.status.check_ok %c5_i32, "HAL device `device_a` not found or unavailable: #hal.device.target<{{.+}}>"
+//      CHECK:   util.status.check_ok %c18_i32, "HAL device `device_a` not found or unavailable: #hal.device.target<{{.+}}>"
 //      CHECK: util.global.store %[[WHILE]]#2, @device_a
 
 // -----
@@ -115,5 +115,5 @@ util.global private @selected = #hal.device.select<[
 // CHECK-NEXT: }
 //  CHECK-DAG: %[[IS_NULL:.+]] = util.cmp.eq %[[IF_0]], %[[NULL_DEVICE]]
 // CHECK-NEXT: scf.if %[[IS_NULL]] {
-//      CHECK:   util.status.check_ok %c5_i32, "HAL device `selected` not found or unavailable: #hal.device.select<{{.+}}>"
+//      CHECK:   util.status.check_ok %c18_i32, "HAL device `selected` not found or unavailable: #hal.device.select<{{.+}}>"
 //      CHECK: util.global.store %[[IF_0]], @selected

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.h
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.h
@@ -62,6 +62,7 @@ enum class StatusCode : int32_t {
   DataLoss = 15,
   Unauthenticated = 16,
   Deferred = 17,
+  Incompatible = 18,
   DoNotUseReservedForFutureExpansionUseDefaultInSwitchInstead_ = 20
 };
 

--- a/integrations/pjrt/src/iree_pjrt/common/api_impl.cc
+++ b/integrations/pjrt/src/iree_pjrt/common/api_impl.cc
@@ -236,6 +236,9 @@ void ErrorInstance::BindApi(PJRT_Api* api) {
       case IREE_STATUS_DEFERRED:
         args->code = PJRT_Error_Code_UNKNOWN;  // No mapping
         break;
+      case IREE_STATUS_INCOMPATIBLE:
+        args->code = PJRT_Error_Code_NOT_FOUND;
+        break;
       default:
         // Should not happen.
         args->code = PJRT_Error_Code_UNKNOWN;

--- a/runtime/src/iree/base/status.c
+++ b/runtime/src/iree/base/status.c
@@ -281,6 +281,8 @@ IREE_API_EXPORT const char* iree_status_code_string(iree_status_code_t code) {
       return "UNAUTHENTICATED";
     case IREE_STATUS_DEFERRED:
       return "DEFERRED";
+    case IREE_STATUS_INCOMPATIBLE:
+      return "INCOMPATIBLE";
     default:
       return "";
   }

--- a/runtime/src/iree/base/status.h
+++ b/runtime/src/iree/base/status.h
@@ -154,6 +154,11 @@ typedef enum iree_status_code_e {
   // Callers that do not handle deferred execution can treat this as a failure.
   IREE_STATUS_DEFERRED = 17,
 
+  // The program or a component of it is incompatible with the hosting
+  // environment. This may indicate the operating system, host hardware, or
+  // device hardware does not match expectations.
+  IREE_STATUS_INCOMPATIBLE = 18,
+
   IREE_STATUS_CODE_MASK = 0x1Fu,
 } iree_status_code_t;
 
@@ -216,6 +221,8 @@ typedef struct iree_status_handle_t* iree_status_t;
   (iree_status_code(value) == IREE_STATUS_UNAUTHENTICATED)
 #define iree_status_is_deferred(value) \
   (iree_status_code(value) == IREE_STATUS_DEFERRED)
+#define iree_status_is_incompatible(value) \
+  (iree_status_code(value) == IREE_STATUS_INCOMPATIBLE)
 
 #define IREE_STATUS_IMPL_CONCAT_INNER_(x, y) x##y
 #define IREE_STATUS_IMPL_CONCAT_(x, y) IREE_STATUS_IMPL_CONCAT_INNER_(x, y)

--- a/runtime/src/iree/base/status_cc.h
+++ b/runtime/src/iree/base/status_cc.h
@@ -90,6 +90,7 @@ enum class StatusCode : uint32_t {
   kDataLoss = IREE_STATUS_DATA_LOSS,
   kUnauthenticated = IREE_STATUS_UNAUTHENTICATED,
   kDeferred = IREE_STATUS_DEFERRED,
+  kIncompatible = IREE_STATUS_INCOMPATIBLE,
 };
 
 static inline const char* StatusCodeToString(StatusCode code) {


### PR DESCRIPTION
This allows error handling code to detect cases where the program is incompatible with the hosting environment. One day when status payloads are implemented we could attach exactly why in a programmatically accessible way but for now a hosting application can dump the whole supported environment/topology/etc.

Progress on #18749.