### PR TITLE
[ROCM] Disable mixed precision fma instructions that cause numeric issues

### DIFF
--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -449,6 +449,11 @@ public:
         if (!targetFeatures.empty()) {
           features += (features.empty() ? "" : ",") + targetFeatures.str();
         }
+        // Mixed precision fma instructions have complicated semantics on
+        // gf9+ GPUs and can lead to numeric issues as seen in
+        // https://github.com/iree-org/iree/issues/18746 so we disable this
+        // feature.
+        features += "-fma-mix-insts";
 
         targetMachine.reset(target->createTargetMachine(
             triple.str(), targetArch, features, opt, llvm::Reloc::Model::PIC_,

--- a/experimental/regression_suite/shark-test-suite-models/sdxl/test_unet.py
+++ b/experimental/regression_suite/shark-test-suite-models/sdxl/test_unet.py
@@ -93,7 +93,7 @@ sdxl_punet_int8_inference_input_5 = fetch_source_fixture(
 )
 
 sdxl_punet_int8_fp16_inference_output_0 = fetch_source_fixture(
-    "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-punet/punet_out.0.bin",
+    "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-punet/new_punet_out.0.bin",
     group="sdxl_punet_int8_fp16",
 )
 
@@ -110,7 +110,7 @@ sdxl_punet_int8_fp16_mlir = fetch_source_fixture(
 # INT8 Punet + FP8 Attention
 
 sdxl_punet_int8_fp8_inference_output_0 = fetch_source_fixture(
-    "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-punet/punet_fp8_out.0.bin",
+    "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-punet/new_punet_fp8_out.0.bin",
     group="sdxl_punet_int8_fp8",
 )
 


### PR DESCRIPTION
Scalar mixed precision fma instructions are rare in codegen as we dont generate something like that from the MLIR side but a multiplication followed by a truncation can result in them and unfortunately they have issues with the zeroing semantics that the llvm backend has trouble with. 
See this issue https://github.com/iree-org/iree/issues/18746

We can opt out of this feature which is what this PR does.

We also update the punet regression suite outputs which were affected by this bug with the new results.

 