### PR TITLE
[Codegen] Add pass to convert splat constants to fills

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -93,6 +93,7 @@ iree_compiler_cc_library(
         "ConcretizePadResultShape.cpp",
         "ConvertBf16ArithToF32.cpp",
         "ConvertBf16ToUInt16Buffers.cpp",
+        "ConvertSplatConstantToFill.cpp",
         "ConvertToDestinationPassingStylePass.cpp",
         "ConvolutionToIGEMM.cpp",
         "DecomposeAffineOpsPass.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -84,6 +84,7 @@ iree_cc_library(
     "ConcretizePadResultShape.cpp"
     "ConvertBf16ArithToF32.cpp"
     "ConvertBf16ToUInt16Buffers.cpp"
+    "ConvertSplatConstantToFill.cpp"
     "ConvertToDestinationPassingStylePass.cpp"
     "ConvolutionToIGEMM.cpp"
     "DecomposeAffineOpsPass.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertSplatConstantToFill.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertSplatConstantToFill.cpp
@@ -1,0 +1,63 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/Passes.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_CONVERTSPLATCONSTANTTOFILLPASS
+#include "iree/compiler/Codegen/Common/Passes.h.inc"
+
+namespace {
+
+struct ConvertSplatToFill final : OpRewritePattern<arith::ConstantOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(arith::ConstantOp constant,
+                                PatternRewriter &rewriter) const override {
+    auto resultType = dyn_cast<RankedTensorType>(constant.getType());
+    if (!resultType) {
+      return failure();
+    }
+
+    auto splatAttr = llvm::dyn_cast<SplatElementsAttr>(constant.getValue());
+    if (!splatAttr) {
+      return failure();
+    }
+
+    Location loc = constant.getLoc();
+
+    // Constants have no dynamic sizes.
+    Value empty = rewriter.create<tensor::EmptyOp>(constant.getLoc(),
+                                                   resultType, ValueRange{});
+    auto fillAttr = splatAttr.getSplatValue<TypedAttr>();
+    Value fillValue = rewriter.create<arith::ConstantOp>(
+        loc, resultType.getElementType(), fillAttr);
+    rewriter.replaceOpWithNewOp<linalg::FillOp>(constant, resultType, fillValue,
+                                                empty);
+    return success();
+  }
+};
+
+struct ConvertSplatConstantToFillPass final
+    : impl::ConvertSplatConstantToFillPassBase<ConvertSplatConstantToFillPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<linalg::LinalgDialect, tensor::TensorDialect>();
+  }
+  void runOnOperation() override {
+    MLIRContext *ctx = &getContext();
+    auto funcOp = getOperation();
+
+    RewritePatternSet patterns(ctx);
+    patterns.add<ConvertSplatToFill>(ctx);
+    (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
+  }
+};
+
+} // namespace
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -60,6 +60,11 @@ def ConvertBf16ToUInt16BuffersPass :
   let summary = "Convert BF16 buffer ops and conversions to simulated behavior with uint16.";
 }
 
+def ConvertSplatConstantToFillPass :
+    Pass<"iree-codegen-convert-splat-constant-to-fill", ""> {
+  let summary = "Converts arith.constant ops with splat tensors to linalg.fill";
+}
+
 def ConvertToDestinationPassingStylePass :
     InterfacePass<"iree-codegen-convert-to-destination-passing-style", "mlir::FunctionOpInterface"> {
   let summary =

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -26,6 +26,7 @@ iree_lit_test_suite(
             "canonicalize_interface_load_store.mlir",
             "convert_bf16_to_uint16_buffers.mlir",
             "convert_bf16_arith_to_f32.mlir",
+            "convert_splat_to_fill.mlir",
             "convert_to_destination_passing_style.mlir",
             "convolution_to_igemm.mlir",
             "convolutions.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -22,6 +22,7 @@ iree_lit_test_suite(
     "canonicalize_interface_load_store.mlir"
     "convert_bf16_arith_to_f32.mlir"
     "convert_bf16_to_uint16_buffers.mlir"
+    "convert_splat_to_fill.mlir"
     "convert_to_destination_passing_style.mlir"
     "convolution_to_igemm.mlir"
     "convolutions.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/convert_splat_to_fill.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/convert_splat_to_fill.mlir
@@ -1,0 +1,26 @@
+// RUN: iree-opt --split-input-file --mlir-print-local-scope %s \
+// RUN:   --pass-pipeline="builtin.module(func.func(iree-codegen-convert-splat-constant-to-fill))" | FileCheck %s
+
+func.func @tensor_splat() -> tensor<1x2x3xi32> {
+  %cst = arith.constant dense<5> : tensor<1x2x3xi32>
+  return %cst : tensor<1x2x3xi32>
+}
+
+// CHECK-LABEL: func.func @tensor_splat
+//   CHECK-DAG:   %[[C5:.+]] = arith.constant 5 : i32
+//   CHECK-DAG:   %[[EMPTY:.+]] = tensor.empty() : tensor<1x2x3xi32>
+//       CHECK:   %[[FILL:.+]] = linalg.fill ins(%[[C5]]
+//  CHECK-SAME:     outs(%[[EMPTY]]
+//       CHECK:   return %[[FILL]]
+
+// -----
+
+func.func @vector_splat() -> vector<1x2x3xi32> {
+  %cst = arith.constant dense<5> : vector<1x2x3xi32>
+  return %cst : vector<1x2x3xi32>
+}
+
+// Verify that non-tensor splats are not converted.
+// CHECK-LABEL: func.func @vector_splat
+//       CHECK:   %[[CST:.+]] = arith.constant dense<5> : vector<1x2x3xi32>
+//       CHECK:   return %[[CST]]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -325,6 +325,7 @@ static void addGPUBufferizePasses(OpPassManager &funcPassManager) {
 
 void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
                                    const GPUPipelineOptions &pipelineOptions) {
+  funcPassManager.addPass(createConvertSplatConstantToFillPass());
   tileAndDistributeToWorkgroup(funcPassManager,
                                /*convertToDpsOptions=*/std::nullopt);
 


### PR DESCRIPTION
Splat constants are the non-canonical form for codegen, we instead prefer fills for 2 reasons:

1. Consistency with dynamic shapes
2. Fills are tilable and compose well with tile + fuse