### PR TITLE
Add end-to-end tests for `iree_linalg_ext.custom_op`.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BufferizationAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BufferizationAnalysis.cpp
@@ -582,7 +582,7 @@ LogicalResult createTensorEquivalenceClasses(mlir::FunctionOpInterface funcOp,
             [&](scf::ForOp forOp) { return analyseScfForOp(forOp, plan); })
         .Case<scf::YieldOp, tensor::EmptyOp, tensor::DimOp, tensor::ExtractOp,
               tensor::GenerateOp, tensor::PadOp, bufferization::ToMemrefOp,
-              bufferization::AllocTensorOp>(
+              bufferization::AllocTensorOp, IREE::LinalgExt::YieldOp>(
             [&](Operation *op) { return success(); })
         .Default([&](Operation *op) -> LogicalResult {
           if (llvm::any_of(

--- a/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.cpp
@@ -267,6 +267,8 @@ void registerPartitionableLoopsInterfaceModels(DialectRegistry &registry) {
     IREE::LinalgExt::OnlineAttentionOp::attachInterface<
         AllParallelAsPartitionableLoops<IREE::LinalgExt::OnlineAttentionOp>>(
         *ctx);
+    IREE::LinalgExt::CustomOp::attachInterface<
+        AllParallelAsPartitionableLoops<IREE::LinalgExt::CustomOp>>(*ctx);
   });
   registry.addExtension(+[](MLIRContext *ctx, tensor::TensorDialect *dialect) {
     tensor::PadOp::attachInterface<

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -122,6 +122,7 @@ static void addTileAndDistributePasses(OpPassManager &funcPassManager) {
     funcPassManager.addPass(createConvertToDestinationPassingStylePass());
     funcPassManager.addPass(createFoldAffineMinInDistributedLoopsPass());
   }
+  funcPassManager.addPass(IREE::LinalgExt::createDecomposeAggregateOpsPass());
   funcPassManager.addPass(createConfigTrackingCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
   funcPassManager.addPass(createFuseTensorPadWithConsumerPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -218,6 +218,7 @@ static void tileAndDistributeToWorkgroup(
   // TODO(#16421): Disable decomposition due to failure in bufferization.
   // funcPassManager.addPass(
   //     IREE::LinalgExt::createTileAndDecomposeAttentionPass());
+  funcPassManager.addPass(IREE::LinalgExt::createDecomposeAggregateOpsPass());
   funcPassManager.addPass(createConfigTrackingCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
 }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/BUILD.bazel
@@ -33,6 +33,7 @@ iree_compiler_cc_library(
         "ConvertConv2DToWinograd.cpp",
         "ConvertConvToIm2ColOp.cpp",
         "ConvertToLoops.cpp",
+        "DecomposeAggregateOps.cpp",
         "DecomposeAttention.cpp",
         "DecomposeIm2col.cpp",
         "DecomposeWinogradPass.cpp",

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/CMakeLists.txt
@@ -30,6 +30,7 @@ iree_cc_library(
     "ConvertConv2DToWinograd.cpp"
     "ConvertConvToIm2ColOp.cpp"
     "ConvertToLoops.cpp"
+    "DecomposeAggregateOps.cpp"
     "DecomposeAttention.cpp"
     "DecomposeIm2col.cpp"
     "DecomposeWinogradPass.cpp"

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeAggregateOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeAggregateOps.cpp
@@ -1,0 +1,66 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "iree/compiler/Dialect/LinalgExt/Transforms/Passes.h"
+#include "llvm/ADT/StringSet.h"
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
+
+namespace mlir::iree_compiler::IREE::LinalgExt {
+
+#define GEN_PASS_DEF_DECOMPOSEAGGREGATEOPSPASS
+#include "iree/compiler/Dialect/LinalgExt/Transforms/Passes.h.inc"
+
+namespace {
+
+struct DecomposeAggregateOpsPass final
+    : impl::DecomposeAggregateOpsPassBase<DecomposeAggregateOpsPass> {
+  using Base::Base;
+
+  // Use the initializer to set default options for ListOption.
+  LogicalResult initialize(MLIRContext *context) override {
+    this->decomposeOps = {IREE::LinalgExt::CustomOp::getOperationName().str()};
+    return success();
+  }
+
+  void runOnOperation() override;
+};
+
+void DecomposeAggregateOpsPass::runOnOperation() {
+  SmallVector<linalg::AggregatedOpInterface> aggregateOps;
+  llvm::StringSet<> opNamesSet;
+  opNamesSet.insert(this->decomposeOps.begin(), this->decomposeOps.end());
+  auto walkResult = getOperation()->walk([&](Operation *op) -> WalkResult {
+    if (opNamesSet.contains(op->getName().getStringRef())) {
+      auto aggregateOp = dyn_cast<linalg::AggregatedOpInterface>(op);
+      if (!aggregateOp) {
+        return op->emitOpError(
+            "expected operation to implement AggregatedOpInterface");
+      }
+      aggregateOps.push_back(aggregateOp);
+    }
+    return WalkResult::advance();
+  });
+  if (walkResult.wasInterrupted()) {
+    return signalPassFailure();
+  }
+
+  MLIRContext *context = &getContext();
+  IRRewriter rewriter(context);
+  for (auto aggregateOp : llvm::make_early_inc_range(aggregateOps)) {
+    rewriter.setInsertionPoint(aggregateOp);
+    FailureOr<SmallVector<Value>> replacements =
+        aggregateOp.decomposeOperation(rewriter);
+    if (failed(replacements)) {
+      aggregateOp->emitOpError("failed to decompose operation");
+      return signalPassFailure();
+    }
+    rewriter.replaceOp(aggregateOp, replacements.value());
+  }
+}
+
+} // namespace
+} // namespace mlir::iree_compiler::IREE::LinalgExt

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.td
@@ -50,6 +50,14 @@ def TopkSplitReductionPass:
   ];
 }
 
+def DecomposeAggregateOpsPass : Pass<"iree-linalg-ext-decompose-aggregate-ops", ""> {
+  let summary = "Decompose aggregate operations";
+  let options = [
+    ListOption<"decomposeOps", "decompose-ops", "std::string",
+        "List of operation names that should be decomposed">
+  ];
+}
+
 def DecomposeIm2colPass :
     InterfacePass<"iree-linalg-ext-decompose-im2col", "mlir::FunctionOpInterface"> {
   let summary =

--- a/tests/e2e/linalg_ext_ops/BUILD.bazel
+++ b/tests/e2e/linalg_ext_ops/BUILD.bazel
@@ -27,6 +27,7 @@ ALL_SRCS = enforce_glob(
     include = ["*.mlir"],
     exclude = [
         "attention_i1_mask.mlir",
+        "custom_op.mlir",
     ],
 )
 
@@ -56,6 +57,21 @@ iree_check_single_backend_test_suite(
     tags = [
         # attention fails with a wasm target, just disable the tests there for now
         #   error: Yield operand #2 is not equivalent to the corresponding iter bbArg
+        "nowasm",
+    ],
+    target_backend = "llvm-cpu",
+)
+
+iree_check_single_backend_test_suite(
+    name = "check_no_dt_llvm-cpu_local-task",
+    srcs = [
+        "custom_op.mlir",
+    ],
+    compiler_flags = [
+        "--iree-opt-data-tiling=false",
+    ],
+    driver = "local-task",
+    tags = [
         "nowasm",
     ],
     target_backend = "llvm-cpu",
@@ -123,6 +139,7 @@ iree_check_single_backend_test_suite(
 ROCM_HIP_SRCS = enforce_glob(
     # keep sorted
     [
+        "custom_op.mlir",
         "gather.mlir",
         "scan.mlir",
         "scatter.mlir",

--- a/tests/e2e/linalg_ext_ops/CMakeLists.txt
+++ b/tests/e2e/linalg_ext_ops/CMakeLists.txt
@@ -50,6 +50,21 @@ iree_check_single_backend_test_suite(
 
 iree_check_single_backend_test_suite(
   NAME
+    check_no_dt_llvm-cpu_local-task
+  SRCS
+    "custom_op.mlir"
+  TARGET_BACKEND
+    "llvm-cpu"
+  DRIVER
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling=false"
+  LABELS
+    "nowasm"
+)
+
+iree_check_single_backend_test_suite(
+  NAME
     check_vmvx_local-task
   SRCS
     "gather.mlir"
@@ -92,6 +107,7 @@ iree_check_single_backend_test_suite(
   NAME
     check_rocm_hip
   SRCS
+    "custom_op.mlir"
     "gather.mlir"
     "scan.mlir"
     "scatter.mlir"

--- a/tests/e2e/linalg_ext_ops/custom_op.mlir
+++ b/tests/e2e/linalg_ext_ops/custom_op.mlir
@@ -1,0 +1,85 @@
+func.func private @init_tensor(%arg0 : index) -> tensor<?xf32> {
+  %0 = tensor.empty(%arg0) : tensor<?xf32>
+  %1 = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]}
+      outs(%0 : tensor<?xf32>) {
+    ^bb0(%b0 : f32) :
+      %index = linalg.index 0 : index
+      %index_i32 = arith.index_cast %index : index to i32
+      %index_f32 = arith.uitofp %index_i32 : i32 to f32
+      %arg0_i32 = arith.index_cast %arg0 : index to i32
+      %arg0_f32 = arith.uitofp %arg0_i32 : i32 to f32
+      %val = arith.divf %index_f32, %arg0_f32 : f32
+      linalg.yield %val : f32
+  } -> tensor<?xf32>
+  return %1 : tensor<?xf32>
+}
+
+func.func @matmul_bias_add() {
+  %c128 = arith.constant 128 : index
+  %c256 = arith.constant 256 : index
+  %c512 = arith.constant 512 : index
+  %lhs_size = arith.muli %c128, %c256 : index
+  %rhs_size = arith.muli %c256, %c512 : index
+  %lhs_linear = func.call @init_tensor(%lhs_size): (index) -> (tensor<?xf32>)
+  %lhs = tensor.expand_shape %lhs_linear [[0, 1]] output_shape [%c128, %c256]
+      : tensor<?xf32> into tensor<?x?xf32>
+  %lhs_static = tensor.cast %lhs : tensor<?x?xf32> to tensor<128x256xf32>
+  %rhs_linear = func.call @init_tensor(%rhs_size) : (index) -> (tensor<?xf32>)
+  %rhs = tensor.expand_shape %rhs_linear [[0, 1]] output_shape [%c256, %c512]
+      : tensor<?xf32> into tensor<?x?xf32>
+  %rhs_static = tensor.cast %rhs : tensor<?x?xf32> to tensor<256x512xf32>
+  %bias = func.call @init_tensor(%c512) : (index) -> (tensor<?xf32>)
+  %bias_static = tensor.cast %bias : tensor<?xf32> to tensor<512xf32>
+  %lhs_input = util.optimization_barrier %lhs_static : tensor<128x256xf32>
+  %rhs_input = util.optimization_barrier %rhs_static : tensor<256x512xf32>
+  %bias_input = util.optimization_barrier %bias_static : tensor<512xf32>
+  %empty = tensor.empty() : tensor<128x512xf32>
+  %cst = arith.constant 0.0 : f32
+  %fill = linalg.fill ins(%cst : f32)
+      outs(%empty : tensor<128x512xf32>) -> tensor<128x512xf32>
+  %matmul = linalg.matmul
+      ins(%lhs_input, %rhs_input : tensor<128x256xf32>, tensor<256x512xf32>)
+      outs(%fill : tensor<128x512xf32>) -> tensor<128x512xf32>
+  %bias_add = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                       affine_map<(d0, d1) -> (d1)>,
+                       affine_map<(d0, d1) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel"]}
+      ins(%matmul, %bias_input : tensor<128x512xf32>, tensor<512xf32>)
+      outs(%empty : tensor<128x512xf32>) {
+    ^bb0(%b0 : f32, %b1 : f32, %b2 :f32):
+      %addf = arith.addf %b0, %b1 : f32
+      linalg.yield %addf : f32
+  } -> tensor<128x512xf32>
+
+  %custom_op = iree_linalg_ext.custom_op {
+      indexing_maps = [affine_map<(d0, d1)[s0] -> (d0, s0)>,
+                       affine_map<(d0, d1)[s0] -> (s0, d1)>,
+                       affine_map<(d0, d1)[s0] -> (d1)>,
+                       affine_map<(d0, d1)[s0] -> (d0, d1)>],
+      iterator_types = [#iree_linalg_ext.iterator_type<parallel>,
+                        #iree_linalg_ext.iterator_type<parallel>]}
+      ins(%lhs_input, %rhs_input, %bias_input : tensor<128x256xf32>, tensor<256x512xf32>, tensor<512xf32>)
+      outs(%empty : tensor<128x512xf32>) {
+    ^bb0(%t0 : tensor<?x?xf32>, %t1 : tensor<?x?xf32>, %t2 : tensor<?xf32>, %t3 : tensor<?x?xf32>):
+      %2 = linalg.fill ins(%cst : f32) outs(%t3 : tensor<?x?xf32>) -> tensor<?x?xf32>
+      %3 = linalg.matmul ins(%t0, %t1 : tensor<?x?xf32>, tensor<?x?xf32>)
+          outs(%2 : tensor<?x?xf32>) -> tensor<?x?xf32>
+      %4 = linalg.generic {
+          indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                           affine_map<(d0, d1) -> (d1)>,
+                           affine_map<(d0, d1) -> (d0, d1)>],
+          iterator_types = ["parallel", "parallel"]}
+          ins(%3, %t2 : tensor<?x?xf32>, tensor<?xf32>)
+          outs(%t3 : tensor<?x?xf32>) {
+        ^bb0(%b0 : f32, %b1 : f32, %b2 : f32):
+          %5 = arith.addf %b0, %b1 : f32
+          linalg.yield %5 : f32
+      } -> tensor<?x?xf32>
+      iree_linalg_ext.yield %4 : tensor<?x?xf32>
+  } -> tensor<128x512xf32>
+  check.expect_eq(%bias_add, %custom_op) : tensor<128x512xf32>
+  return
+}


### PR DESCRIPTION
This PR plumbs through e2e tests for `iree_linalg_ext.custom_op` on
CPU and AMDGPU backends. The end-to-end test does a matmul + bias add
with and without the use of `custom_op` and checks that the same value
is obtained.

Signed-off-by: MaheshRavishankar <mahesh.ravishankar@gmail.com>