### PR TITLE
[CMake] Don't update compile definitions for imported targets for MSCV

### DIFF
--- a/compiler/src/iree/compiler/API/CMakeLists.txt
+++ b/compiler/src/iree/compiler/API/CMakeLists.txt
@@ -110,7 +110,8 @@ foreach(_object_lib ${_EXPORT_OBJECT_LIBS})
   # It isn't super polite to be poking at other people's library definitions
   # like this, but MSVC is weird and given the structure of the projects, this
   # isn't so bad.
-  if(MSVC)
+  get_target_property(_imported ${_object_lib} IMPORTED)
+  if(MSVC AND NOT ${_imported})
     target_compile_definitions(${_object_lib} PRIVATE
       # See compiler/bindings/c/iree/compiler/api_support.h.
       # IREE embedded CAPI uses its own macros to enable


### PR DESCRIPTION
If one uses `-DIREE_BUILD_BUNDLED_LLVM=OFF` then targets for some libraries become imported/`INTERFACE` and CMake doesn't let you update their `target_compile_definitions`. I.e., CMake errors out (not that it would work anyway). So just check and skip in that case.