### PR TITLE
Produce releases for Python 3.13.

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -39,34 +39,34 @@ jobs:
       matrix:
         include:
           # Ubuntu packages.
-          - runs-on: ubuntu-20.04
-            build-family: linux-x86_64
-            build-package: main-dist-linux
-            experimental: false
-          - runs-on: ah-ubuntu_22_04-c7g_4x-50
-            build-family: linux-aarch64
-            build-package: main-dist-linux
-            experimental: true
-          - runs-on: ubuntu-20.04
-            build-family: linux-x86_64
-            build-package: py-compiler-pkg
-            experimental: false
-          - runs-on: ah-ubuntu_22_04-c7g_4x-50
-            build-family: linux-aarch64
-            build-package: py-compiler-pkg
-            experimental: true
+          # - runs-on: ubuntu-20.04
+          #   build-family: linux-x86_64
+          #   build-package: main-dist-linux
+          #   experimental: false
+          # - runs-on: ah-ubuntu_22_04-c7g_4x-50
+          #   build-family: linux-aarch64
+          #   build-package: main-dist-linux
+          #   experimental: true
+          # - runs-on: ubuntu-20.04
+          #   build-family: linux-x86_64
+          #   build-package: py-compiler-pkg
+          #   experimental: false
+          # - runs-on: ah-ubuntu_22_04-c7g_4x-50
+          #   build-family: linux-aarch64
+          #   build-package: py-compiler-pkg
+          #   experimental: true
           - runs-on: ubuntu-20.04
             build-family: linux-x86_64
             build-package: py-runtime-pkg
             experimental: false
-          - runs-on: ah-ubuntu_22_04-c7g_4x-50
-            build-family: linux-aarch64
-            build-package: py-runtime-pkg
-            experimental: true
-          - runs-on: ubuntu-20.04
-            build-family: linux-x86_64
-            build-package: py-tf-compiler-tools-pkg
-            experimental: false
+          # - runs-on: ah-ubuntu_22_04-c7g_4x-50
+          #   build-family: linux-aarch64
+          #   build-package: py-runtime-pkg
+          #   experimental: true
+          # - runs-on: ubuntu-20.04
+          #   build-family: linux-x86_64
+          #   build-package: py-tf-compiler-tools-pkg
+          #   experimental: false
 
           # MacOS packages.
           # TODO(scotttodd): build on larger runner when available (self-hosted or GitHub)
@@ -74,10 +74,10 @@ jobs:
           #     - ${{ github.repository == 'iree-org/iree' && 'self-hosted' || 'macos-14' }}
           #     - os-family=macOS
           #     - runner-group=postsubmit
-          - runs-on: macos-14
-            build-family: macos
-            build-package: py-compiler-pkg
-            experimental: true
+          # - runs-on: macos-14
+          #   build-family: macos
+          #   build-package: py-compiler-pkg
+          #   experimental: true
           - runs-on: macos-14
             build-family: macos
             build-package: py-runtime-pkg
@@ -87,10 +87,10 @@ jobs:
           # TODO(scotttodd): build on larger runner when available (self-hosted or GitHub)
           # - runs-on:
           #     - ${{ github.repository == 'iree-org/iree' && 'windows-2022-64core' || 'windows-2022'}}
-          - runs-on: windows-2022
-            build-family: windows
-            build-package: py-compiler-pkg
-            experimental: true
+          # - runs-on: windows-2022
+          #   build-family: windows
+          #   build-package: py-compiler-pkg
+          #   experimental: true
           - runs-on: windows-2022
             build-family: windows
             build-package: py-runtime-pkg

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -98,8 +98,7 @@ jobs:
 
     env:
       # These are also set in: build_tools/python_deploy/build_linux_packages.sh
-      # TODO(#18652): bump these versions to include python 3.13
-      MANYLINUX_X86_64_IMAGE: ghcr.io/iree-org/manylinux_x86_64@sha256:facedb71df670016e74e646d71e869e6fff70d4cdbaa6634d4d0a10d6e174399
+      MANYLINUX_X86_64_IMAGE: ghcr.io/iree-org/manylinux_x86_64@sha256:2e0246137819cf10ed84240a971f9dd75cc3eb62dc6907dfd2080ee966b3c9f4
       MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux_2_28_aarch64
 
     steps:

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -121,7 +121,7 @@ jobs:
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       - name: Install dependencies (macOS)
         if: "matrix.build-family == 'macos'"
-        run: ./c/build_tools/python_deploy/install_macos_deps.sh
+        run: sudo ./c/build_tools/python_deploy/install_macos_deps.sh
 
       ##########################################################################
       # Write version_info.json

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -98,6 +98,7 @@ jobs:
 
     env:
       # These are also set in: build_tools/python_deploy/build_linux_packages.sh
+      # TODO(#18652): bump these versions to include python 3.13
       MANYLINUX_X86_64_IMAGE: ghcr.io/iree-org/manylinux_x86_64@sha256:facedb71df670016e74e646d71e869e6fff70d4cdbaa6634d4d0a10d6e174399
       MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux_2_28_aarch64
 
@@ -119,6 +120,9 @@ jobs:
       - name: "Configure MSVC (Windows)"
         if: "matrix.build-family == 'windows'"
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+      - name: Install dependencies (macOS)
+        if: "matrix.build-family == 'macos'"
+        run: ./c/build_tools/python_deploy/install_macos_deps.sh
 
       ##########################################################################
       # Write version_info.json
@@ -206,7 +210,7 @@ jobs:
           package_suffix: ${{ github.event.inputs.package_suffix }}
           packages: "iree-runtime"
           output_dir: "${{ github.workspace }}/bindist"
-          override_python_versions: "3.11 3.12"
+          override_python_versions: "3.11 3.12 3.13"
         run: |
           [ -e ./bindist/* ] && rm ./bindist/*
           ./c/build_tools/python_deploy/build_macos_packages.sh
@@ -218,7 +222,7 @@ jobs:
           package_suffix: ${{ github.event.inputs.package_suffix }}
           packages: "iree-runtime"
           output_dir: "${{ github.workspace }}/bindist"
-          override_python_versions: "3.11 3.12"
+          override_python_versions: "3.11 3.12 3.13"
         run: |
           if (Test-Path -Path "${{ github.workspace }}/bindist") {
             Remove-Item -Path "${{ github.workspace }}/bindist" -Recurse -Force
@@ -248,7 +252,7 @@ jobs:
           package_suffix: ${{ github.event.inputs.package_suffix }}
           packages: "iree-compiler"
           output_dir: "${{ github.workspace }}/bindist"
-          override_python_versions: "3.11 3.12"
+          override_python_versions: "3.11 3.12 3.13"
         run: |
           [ -e ./bindist/* ] && rm ./bindist/*
           ./c/build_tools/python_deploy/build_macos_packages.sh
@@ -260,7 +264,7 @@ jobs:
           package_suffix: ${{ github.event.inputs.package_suffix }}
           packages: "iree-compiler"
           output_dir: "${{ github.workspace }}/bindist"
-          override_python_versions: "3.11 3.12"
+          override_python_versions: "3.11 3.12 3.13"
         run: |
           if (Test-Path -Path "${{ github.workspace }}/bindist") {
             Remove-Item -Path "${{ github.workspace }}/bindist" -Recurse -Force

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -39,34 +39,34 @@ jobs:
       matrix:
         include:
           # Ubuntu packages.
-          # - runs-on: ubuntu-20.04
-          #   build-family: linux-x86_64
-          #   build-package: main-dist-linux
-          #   experimental: false
-          # - runs-on: ah-ubuntu_22_04-c7g_4x-50
-          #   build-family: linux-aarch64
-          #   build-package: main-dist-linux
-          #   experimental: true
-          # - runs-on: ubuntu-20.04
-          #   build-family: linux-x86_64
-          #   build-package: py-compiler-pkg
-          #   experimental: false
-          # - runs-on: ah-ubuntu_22_04-c7g_4x-50
-          #   build-family: linux-aarch64
-          #   build-package: py-compiler-pkg
-          #   experimental: true
+          - runs-on: ubuntu-20.04
+            build-family: linux-x86_64
+            build-package: main-dist-linux
+            experimental: false
+          - runs-on: ah-ubuntu_22_04-c7g_4x-50
+            build-family: linux-aarch64
+            build-package: main-dist-linux
+            experimental: true
+          - runs-on: ubuntu-20.04
+            build-family: linux-x86_64
+            build-package: py-compiler-pkg
+            experimental: false
+          - runs-on: ah-ubuntu_22_04-c7g_4x-50
+            build-family: linux-aarch64
+            build-package: py-compiler-pkg
+            experimental: true
           - runs-on: ubuntu-20.04
             build-family: linux-x86_64
             build-package: py-runtime-pkg
             experimental: false
-          # - runs-on: ah-ubuntu_22_04-c7g_4x-50
-          #   build-family: linux-aarch64
-          #   build-package: py-runtime-pkg
-          #   experimental: true
-          # - runs-on: ubuntu-20.04
-          #   build-family: linux-x86_64
-          #   build-package: py-tf-compiler-tools-pkg
-          #   experimental: false
+          - runs-on: ah-ubuntu_22_04-c7g_4x-50
+            build-family: linux-aarch64
+            build-package: py-runtime-pkg
+            experimental: true
+          - runs-on: ubuntu-20.04
+            build-family: linux-x86_64
+            build-package: py-tf-compiler-tools-pkg
+            experimental: false
 
           # MacOS packages.
           # TODO(scotttodd): build on larger runner when available (self-hosted or GitHub)
@@ -74,10 +74,10 @@ jobs:
           #     - ${{ github.repository == 'iree-org/iree' && 'self-hosted' || 'macos-14' }}
           #     - os-family=macOS
           #     - runner-group=postsubmit
-          # - runs-on: macos-14
-          #   build-family: macos
-          #   build-package: py-compiler-pkg
-          #   experimental: true
+          - runs-on: macos-14
+            build-family: macos
+            build-package: py-compiler-pkg
+            experimental: true
           - runs-on: macos-14
             build-family: macos
             build-package: py-runtime-pkg
@@ -87,10 +87,10 @@ jobs:
           # TODO(scotttodd): build on larger runner when available (self-hosted or GitHub)
           # - runs-on:
           #     - ${{ github.repository == 'iree-org/iree' && 'windows-2022-64core' || 'windows-2022'}}
-          # - runs-on: windows-2022
-          #   build-family: windows
-          #   build-package: py-compiler-pkg
-          #   experimental: true
+          - runs-on: windows-2022
+            build-family: windows
+            build-package: py-compiler-pkg
+            experimental: true
           - runs-on: windows-2022
             build-family: windows
             build-package: py-runtime-pkg

--- a/.github/workflows/pkgci_build_packages.yml
+++ b/.github/workflows/pkgci_build_packages.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
     env:
       CACHE_DIR: ${{ github.workspace }}/.iree-container-cache
-      MANYLINUX_DOCKER_IMAGE: ghcr.io/iree-org/manylinux_x86_64@sha256:facedb71df670016e74e646d71e869e6fff70d4cdbaa6634d4d0a10d6e174399
+      MANYLINUX_DOCKER_IMAGE: ghcr.io/iree-org/manylinux_x86_64@sha256:2e0246137819cf10ed84240a971f9dd75cc3eb62dc6907dfd2080ee966b3c9f4
       PACKAGE_SUFFIX: ""
     steps:
       - name: Prefetch Docker
@@ -85,7 +85,7 @@ jobs:
 #     fail-fast: false
 #   env:
 #     CACHE_DIR: ${{ github.workspace }}/.iree-container-cache
-#     MANYLINUX_DOCKER_IMAGE: ghcr.io/iree-org/manylinux_x86_64@sha256:facedb71df670016e74e646d71e869e6fff70d4cdbaa6634d4d0a10d6e174399
+#     MANYLINUX_DOCKER_IMAGE: ghcr.io/iree-org/manylinux_x86_64@sha256:2e0246137819cf10ed84240a971f9dd75cc3eb62dc6907dfd2080ee966b3c9f4
 #     PACKAGE_SUFFIX: "-asserts"
 #   steps:
 #     - name: Prefetch Docker

--- a/build_tools/pkgci/build_linux_packages.sh
+++ b/build_tools/pkgci/build_linux_packages.sh
@@ -64,7 +64,7 @@ function find_git_dir_parent() {
 this_dir="$(cd $(dirname $0) && pwd)"
 script_name="$(basename $0)"
 repo_root=$(cd "${this_dir}" && find_git_dir_parent)
-manylinux_docker_image="${manylinux_docker_image:-$(uname -m | awk '{print ($1 == "aarch64") ? "quay.io/pypa/manylinux_2_28_aarch64" : "ghcr.io/iree-org/manylinux_x86_64@sha256:facedb71df670016e74e646d71e869e6fff70d4cdbaa6634d4d0a10d6e174399" }')}"
+manylinux_docker_image="${manylinux_docker_image:-$(uname -m | awk '{print ($1 == "aarch64") ? "quay.io/pypa/manylinux_2_28_aarch64" : "ghcr.io/iree-org/manylinux_x86_64@sha256:2e0246137819cf10ed84240a971f9dd75cc3eb62dc6907dfd2080ee966b3c9f4" }')}"
 python_versions="${override_python_versions:-cp311-cp311}"
 output_dir="${output_dir:-${this_dir}/wheelhouse}"
 cache_dir="${cache_dir:-}"

--- a/build_tools/python_deploy/build_linux_packages.sh
+++ b/build_tools/python_deploy/build_linux_packages.sh
@@ -65,7 +65,7 @@ this_dir="$(cd $(dirname $0) && pwd)"
 script_name="$(basename $0)"
 repo_root=$(cd "${this_dir}" && find_git_dir_parent)
 manylinux_docker_image="${manylinux_docker_image:-$(uname -m | awk '{print ($1 == "aarch64") ? "quay.io/pypa/manylinux_2_28_aarch64" : "ghcr.io/iree-org/manylinux_x86_64@sha256:2e0246137819cf10ed84240a971f9dd75cc3eb62dc6907dfd2080ee966b3c9f4" }')}"
-python_versions="${override_python_versions:-cp39-cp39 cp310-cp310 cp311-cp311 cp312-cp312}"
+python_versions="${override_python_versions:-cp39-cp39 cp310-cp310 cp311-cp311 cp312-cp312 cp313-cp313 cp313-cp313t}"
 output_dir="${output_dir:-${this_dir}/wheelhouse}"
 packages="${packages:-iree-runtime iree-compiler}"
 package_suffix="${package_suffix:-}"

--- a/build_tools/python_deploy/build_linux_packages.sh
+++ b/build_tools/python_deploy/build_linux_packages.sh
@@ -64,8 +64,7 @@ function find_git_dir_parent() {
 this_dir="$(cd $(dirname $0) && pwd)"
 script_name="$(basename $0)"
 repo_root=$(cd "${this_dir}" && find_git_dir_parent)
-# TODO(#18652): bump these versions to include python 3.13
-manylinux_docker_image="${manylinux_docker_image:-$(uname -m | awk '{print ($1 == "aarch64") ? "quay.io/pypa/manylinux_2_28_aarch64" : "ghcr.io/iree-org/manylinux_x86_64@sha256:facedb71df670016e74e646d71e869e6fff70d4cdbaa6634d4d0a10d6e174399" }')}"
+manylinux_docker_image="${manylinux_docker_image:-$(uname -m | awk '{print ($1 == "aarch64") ? "quay.io/pypa/manylinux_2_28_aarch64" : "ghcr.io/iree-org/manylinux_x86_64@sha256:2e0246137819cf10ed84240a971f9dd75cc3eb62dc6907dfd2080ee966b3c9f4" }')}"
 python_versions="${override_python_versions:-cp39-cp39 cp310-cp310 cp311-cp311 cp312-cp312}"
 output_dir="${output_dir:-${this_dir}/wheelhouse}"
 packages="${packages:-iree-runtime iree-compiler}"

--- a/build_tools/python_deploy/build_linux_packages.sh
+++ b/build_tools/python_deploy/build_linux_packages.sh
@@ -16,7 +16,7 @@
 #   ./build_tools/python_deploy/build_linux_packages.sh
 #
 # Build specific Python versions and packages to custom directory:
-#   override_python_versions="cp39-cp39 cp310-310" \
+#   override_python_versions="cp39-cp39 cp310-cp310" \
 #   packages="iree-runtime" \
 #   output_dir="/tmp/wheelhouse" \
 #   ./build_tools/python_deploy/build_linux_packages.sh
@@ -64,6 +64,7 @@ function find_git_dir_parent() {
 this_dir="$(cd $(dirname $0) && pwd)"
 script_name="$(basename $0)"
 repo_root=$(cd "${this_dir}" && find_git_dir_parent)
+# TODO(#18652): bump these versions to include python 3.13
 manylinux_docker_image="${manylinux_docker_image:-$(uname -m | awk '{print ($1 == "aarch64") ? "quay.io/pypa/manylinux_2_28_aarch64" : "ghcr.io/iree-org/manylinux_x86_64@sha256:facedb71df670016e74e646d71e869e6fff70d4cdbaa6634d4d0a10d6e174399" }')}"
 python_versions="${override_python_versions:-cp39-cp39 cp310-cp310 cp311-cp311 cp312-cp312}"
 output_dir="${output_dir:-${this_dir}/wheelhouse}"

--- a/build_tools/python_deploy/install_macos_deps.sh
+++ b/build_tools/python_deploy/install_macos_deps.sh
@@ -18,8 +18,9 @@ if [[ "$(whoami)" != "root" ]]; then
   exit 1
 fi
 
+# These can be discovered at https://www.python.org/downloads/macos/
 PYTHON_SPECS=(
-  3.13@https://www.python.org/ftp/python/3.13.0/python-3.13.0rc3-macos11.pkg
+  3.13@https://www.python.org/ftp/python/3.13.0/python-3.13.0-macos11.pkg
   3.12@https://www.python.org/ftp/python/3.12.6/python-3.12.6-macos11.pkg
   3.11@https://www.python.org/ftp/python/3.11.9/python-3.11.9-macos11.pkg
   # 3.10@https://www.python.org/ftp/python/3.10.5/python-3.10.5-macos11.pkg

--- a/build_tools/python_deploy/install_macos_deps.sh
+++ b/build_tools/python_deploy/install_macos_deps.sh
@@ -19,9 +19,11 @@ if [[ "$(whoami)" != "root" ]]; then
 fi
 
 PYTHON_SPECS=(
-  3.11@https://www.python.org/ftp/python/3.11.2/python-3.11.2-macos11.pkg
-  3.10@https://www.python.org/ftp/python/3.10.5/python-3.10.5-macos11.pkg
-  3.9@https://www.python.org/ftp/python/3.9.13/python-3.9.13-macos11.pkg
+  3.13@https://www.python.org/ftp/python/3.13.0/python-3.13.0rc3-macos11.pkg
+  3.12@https://www.python.org/ftp/python/3.12.6/python-3.12.6-macos11.pkg
+  3.11@https://www.python.org/ftp/python/3.11.9/python-3.11.9-macos11.pkg
+  # 3.10@https://www.python.org/ftp/python/3.10.5/python-3.10.5-macos11.pkg
+  # 3.9@https://www.python.org/ftp/python/3.9.13/python-3.9.13-macos11.pkg
 )
 
 for python_spec in "${PYTHON_SPECS[@]}"; do

--- a/build_tools/python_deploy/install_windows_deps.ps1
+++ b/build_tools/python_deploy/install_windows_deps.ps1
@@ -7,19 +7,25 @@
 # Installs dependencies on Windows necessary to build IREE Python wheels.
 
 $PYTHON_VERSIONS = @(
+  "3.13" #,
+  "3.12" #,
   "3.11" #,
   # "3.10",
   # "3.9"
 )
 
 $PYTHON_VERSIONS_NO_DOT = @(
+  "313" #,
+  "312" #,
   "311" #,
   # "310",
   # "39"
 )
 
 $PYTHON_INSTALLER_URLS = @(
-  "https://www.python.org/ftp/python/3.11.2/python-3.11.2-amd64.exe" #,
+  "https://www.python.org/ftp/python/3.13.0/python-3.13.0rc3-amd64.exe" #,
+  "https://www.python.org/ftp/python/3.12.6/python-3.12.6-amd64.exe" #,
+  "https://www.python.org/ftp/python/3.11.9/python-3.11.9-amd64.exe" #,
   # "https://www.python.org/ftp/python/3.10.5/python-3.10.5-amd64.exe",
   # "https://www.python.org/ftp/python/3.9.13/python-3.9.13-amd64.exe"
 )

--- a/build_tools/python_deploy/install_windows_deps.ps1
+++ b/build_tools/python_deploy/install_windows_deps.ps1
@@ -22,8 +22,9 @@ $PYTHON_VERSIONS_NO_DOT = @(
   # "39"
 )
 
+# These can be discovered at https://www.python.org/downloads/windows/
 $PYTHON_INSTALLER_URLS = @(
-  "https://www.python.org/ftp/python/3.13.0/python-3.13.0rc3-amd64.exe" #,
+  "https://www.python.org/ftp/python/3.13.0/python-3.13.0-amd64.exe" #,
   "https://www.python.org/ftp/python/3.12.6/python-3.12.6-amd64.exe" #,
   "https://www.python.org/ftp/python/3.11.9/python-3.11.9-amd64.exe" #,
   # "https://www.python.org/ftp/python/3.10.5/python-3.10.5-amd64.exe",


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree/issues/18652. This builds release packages for:

| | 3.13 | 3.13t |
| -- | -- | -- |
| Linux | Yes | Yes |
| macOS | Yes | No |
| Windows | Yes | No |

Actually using the free-threading features in Python 3.13t may need changes like https://github.com/iree-org/iree/pull/18770.

Tested at https://github.com/iree-org/iree/actions/runs/11371528748 (Windows build will be fixed with a more recent commit and a few patches). Assets were uploaded to https://github.com/iree-org/iree/releases/tag/candidate-20241016.21.