### PR TITLE
Enable arithmetic optimizations as part of the stream simplification pipeline.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
@@ -37,6 +37,11 @@ static void addCleanupPatterns(OpPassManager &passManager) {
       .addPass(mlir::createCanonicalizerPass)
       .addPass(mlir::createCSEPass)
 
+      // Integer optimizations. These operate best on a canonical form both
+      // for performance (post-simplifications cause less analysis) and
+      // simplified pattern matching.
+      .addPass(IREE::Util::createOptimizeIntArithmeticPass)
+
       // Simplify util.global accesses; this can help with data flow tracking as
       // redundant store-loads are removed.
       .addPass(IREE::Util::createSimplifyGlobalAccessesPass);


### PR DESCRIPTION
I ran this on some relatively large models and couldn't really discern a performance difference at the whole model level.

This unblocks a number of latent optimizations in the pipeline. Specifically, the compiler will now very often discover that dispatch arguments are only 32bit, elide the high bits and then cast from i32 in the dispatch.