### PR TITLE
Fixes a range inference overflow with util.align.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOpFolders.cpp
@@ -505,7 +505,7 @@ static bool isAlignedTo(Value value, Value alignment) {
   APInt staticAlignment;
   bool hasStaticAlignment =
       matchPattern(alignment, m_ConstantInt(&staticAlignment));
-  if (hasStaticValue && hasStaticAlignment) {
+  if (hasStaticValue && hasStaticAlignment && !staticAlignment.isZero()) {
     // If this value is itself a multiple of the alignment then we can fold.
     if (staticValue.urem(staticAlignment).isZero()) {
       return true; // value % alignment == 0

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/OptimizeIntArithmetic.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/OptimizeIntArithmetic.cpp
@@ -216,12 +216,16 @@ struct RemUIDivisibilityByConstant : public OpRewritePattern<arith::RemUIOp> {
       return failure();
 
     uint64_t rhsValue = rhsConstant.getZExtValue();
-    if (rhsValue > 0 && lhsDiv.udiv() > 0 && lhsDiv.udiv() % rhsValue != 0)
-      return rewriter.notifyMatchFailure(op, "rhs does not divide lhs");
+    if (rhsValue > 0 && lhsDiv.udiv() > 0) {
+      if (lhsDiv.udiv() % rhsValue != 0)
+        return rewriter.notifyMatchFailure(op, "rhs does not divide lhs");
 
-    rewriter.replaceOpWithNewOp<arith::ConstantOp>(
-        op, rewriter.getZeroAttr(op.getResult().getType()));
-    return success();
+      rewriter.replaceOpWithNewOp<arith::ConstantOp>(
+          op, rewriter.getZeroAttr(op.getResult().getType()));
+      return success();
+    }
+
+    return failure();
   }
 
   DataFlowSolver &solver;


### PR DESCRIPTION
* In the present state we were folding a non-analyzable util.align lhs to a constant zero because the next power of two of the maximal range is zero.
* Detects overflow and will not infer a range.
* Fixes some issues with a RHS of zero that were discovered when writing tests for this case (which isn't really valid but was asserting the compiler).