### PR TITLE
Add generalize matmul pass to sdxl fp16 benchmarks

### DIFF
--- a/experimental/regression_suite/shark-test-suite-models/sdxl/test_vae.py
+++ b/experimental/regression_suite/shark-test-suite-models/sdxl/test_vae.py
@@ -70,7 +70,7 @@ ROCM_COMPILE_FLAGS = [
     "--iree-dispatch-creation-enable-aggressive-fusion=true",
     "--iree-codegen-llvmgpu-use-vector-distribution=true",
     "--iree-execution-model=async-external",
-    "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline,iree-preprocessing-pad-to-intrinsics)",
+    "--iree-preprocessing-pass-pipeline=builtin.module(iree-preprocessing-transpose-convolution-pipeline,iree-preprocessing-pad-to-intrinsics,util.func(iree-preprocessing-generalize-linalg-matmul-experimental))",
     "--iree-scheduling-dump-statistics-format=json",
     "--iree-scheduling-dump-statistics-file=compilation_info.json",
 ]


### PR DESCRIPTION
Dispatch count is very sensitive to the placement of `tensor.expand_shape` and `tensor.collapse_shape` ops which often shows up as regressions in changes that shouldn't have a negative impact on dispatch count. These ops cannot be propagated through named ops, `iree-preprocessing-generalize-linalg-matmul-experimental` allows the compiler more freedom on where reshapes should be placed.