### PR TITLE
[TileSwizzle] Make the dump and variable name match. (NFC)

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileSwizzle.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileSwizzle.cpp
@@ -41,7 +41,7 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
                               const TileSwizzle &swizzle) {
   os << "{expandShape = [";
   llvm::interleaveComma(swizzle.expandShape, os);
-  os << "], swizzle = [";
+  os << "], permutation = [";
   llvm::interleaveComma(swizzle.permutation, os);
   os << "]}";
   return os;


### PR DESCRIPTION
The output field is permutation, but not swizzle. The revision replaces the string with field's name.