### PR TITLE
Skip ROCM/test/opt_pass_plugin on Windows while broken.

### DIFF
--- a/compiler/plugins/target/ROCM/test/opt_pass_plugin/CMakeLists.txt
+++ b/compiler/plugins/target/ROCM/test/opt_pass_plugin/CMakeLists.txt
@@ -1,3 +1,8 @@
+# Disabled on Windows until the shared library handling is cross-platform.
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+  return()
+endif()
+
 iree_cc_library(
   NAME
     GPUHello


### PR DESCRIPTION
This test is failing to link on CI machines and failing to run on my local machine. See discussion starting here: https://github.com/iree-org/iree/pull/18347#issuecomment-2419737321.

Disabling for now so we can (hopefully) get a working nightly Windows build and release for the first time in several weeks, but we could also revert the PR or fix-forward.