### PR TITLE
[runtime] Prevent assert failure in `iree_hal_deferred_work_queue_action_list_fail_locked`.

### DIFF
--- a/runtime/src/iree/hal/utils/deferred_work_queue.c
+++ b/runtime/src/iree/hal/utils/deferred_work_queue.c
@@ -879,13 +879,10 @@ static void iree_hal_deferred_work_queue_ready_action_list_fail_locked(
 static void iree_hal_deferred_work_queue_action_list_fail_locked(
     iree_hal_deferred_work_queue_action_list_t* list, iree_status_t status) {
   iree_hal_deferred_work_queue_action_t* action;
-  if (iree_hal_deferred_work_queue_action_list_is_empty(list)) {
-    return;
-  }
-  do {
+  while (!iree_hal_deferred_work_queue_action_list_is_empty(list)) {
     action = iree_hal_deferred_work_queue_action_list_pop_front(list);
     iree_hal_deferred_work_queue_action_fail_locked(action, status);
-  } while (action);
+  }
 }
 
 // Fails and destroys all actions and sets status of |actions|.


### PR DESCRIPTION
While debugging a different error, I noticed that in some situations `iree_hal_deferred_work_queue_action_list_fail_locked` would get an assert failure caused by trying to call `iree_hal_deferred_work_queue_action_list_pop_front` on an empty list. 

It seems to me like this logic was written under the assumption that `iree_hal_deferred_work_queue_action_list_pop_front` would return null for an empty list, but it does not.

This PR changes the loop to check that the list is non-empty.
