### PR TITLE
[Codegen] Fix bug in IGEMM pass for non conv contractions

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ConvolutionToIGEMM.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvolutionToIGEMM.cpp
@@ -45,6 +45,9 @@ struct SetIGEMMConfiguration final : OpRewritePattern<linalg::GenericOp> {
         break;
       }
     }
+    if (!im2colOp) {
+      return rewriter.notifyMatchFailure(genericOp, "no im2colOp producer.");
+    }
 
     if (getLoweringConfig(genericOp)) {
       return rewriter.notifyMatchFailure(genericOp,


### PR DESCRIPTION
Adds back a match condition in the ConvolutionToIGEMM pass that got lost in code cleanup. Checks that the im2col op producer exists, and adds a test for the failing case.