### PR TITLE
Fix excluded_tests names for failing Windows tests.

### DIFF
--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -114,8 +114,8 @@ if [[ "${OSTYPE}" =~ ^msys ]]; then
   # These tests are failing on Windows.
   excluded_tests+=(
     # TODO(#11077): INVALID_ARGUMENT: argument/result signature mismatch
-    "iree/tests/e2e/matmul/e2e_matmul_vmvx_dt_uk_i8_small_vmvx_local-task"
-    "iree/tests/e2e/matmul/e2e_matmul_vmvx_dt_uk_f32_small_vmvx_local-task"
+    "iree/tests/e2e/matmul/e2e_matmul_vmvx_dt_uk_i8_small_vmvx_local-task_generic"
+    "iree/tests/e2e/matmul/e2e_matmul_vmvx_dt_uk_f32_small_vmvx_local-task_generic"
     # TODO: Regressed when `pack` ukernel gained a uint64_t parameter in #13264.
     "iree/tests/e2e/tensor_ops/check_vmvx_ukernel_local-task_pack.mlir"
     "iree/tests/e2e/tensor_ops/check_vmvx_ukernel_local-task_pack_dynamic_inner_tiles.mlir"


### PR DESCRIPTION
Fixes these error logs: https://github.com/iree-org/iree/actions/runs/11407589945/job/31743932060#step:8:2241

Follow-up to https://github.com/iree-org/iree/pull/18682, which changed these target names.