### PR TITLE
Fix error in FuseMultiUseElementwiseProducersPass

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/test/fuse_multiuse_elementwise_producer.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/fuse_multiuse_elementwise_producer.mlir
@@ -152,11 +152,11 @@ util.func public @fuse_by_moving_consumer(%arg0: tensor<5x5xf32>, %arg1: tensor<
     %8 = arith.addf %arg2, %cst : f32
     linalg.yield %8 : f32
   } -> tensor<5x5xf32>
-  // expected-note @below {{prior use here}}
   %collapsed = tensor.collapse_shape %4 [[0, 1]] : tensor<5x5xf32> into tensor<25xf32>
   %5 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%4 : tensor<5x5xf32>) outs(%arg1 : tensor<5x5xf32>) {
   ^bb0(%arg2: f32, %arg3: f32):
-    %8 = arith.subf %arg2, %cst_0 : f32
+    %cst_2 = arith.constant 2.000000e+00 : f32
+    %8 = arith.subf %arg2, %cst_2 : f32
     linalg.yield %8 : f32
   } -> tensor<5x5xf32>
   util.return %5, %collapsed: tensor<5x5xf32>, tensor<25xf32>

--- a/compiler/src/iree/compiler/DispatchCreation/test/fuse_multiuse_elementwise_producer.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/fuse_multiuse_elementwise_producer.mlir
@@ -164,3 +164,58 @@ util.func public @fuse_by_moving_consumer(%arg0: tensor<5x5xf32>, %arg1: tensor<
 // CHECK-LABEL: util.func public @fuse_by_moving_consumer
 // CHECK:         linalg.generic
 // CHECK-NOT:     linalg.generic
+
+// -----
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+util.func public @dont_fuse_use_from_above(%arg0: tensor<5x5xf32>, %arg1: tensor<5x5xf32>) -> (tensor<5x5xf32>, tensor<25xf32>) {
+  %cst = arith.constant 1.000000e+00 : f32
+  %cst_0 = arith.constant 2.000000e+00 : f32
+  %cst_1 = arith.constant 3.000000e+00 : f32
+  %0 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg0 : tensor<5x5xf32>) outs(%arg1 : tensor<5x5xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %2 = arith.addf %in, %cst : f32
+    linalg.yield %2 : f32
+  } -> tensor<5x5xf32>
+  %collapsed = tensor.collapse_shape %0 [[0, 1]] : tensor<5x5xf32> into tensor<25xf32>
+  %1 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%0 : tensor<5x5xf32>) outs(%arg1 : tensor<5x5xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %c2 = arith.constant 2 : index
+    %extracted = tensor.extract %collapsed[%c2] : tensor<25xf32>
+    %2 = arith.addf %extracted, %extracted : f32
+    linalg.yield %2 : f32
+  } -> tensor<5x5xf32>
+  util.return %1, %collapsed : tensor<5x5xf32>, tensor<25xf32>
+}
+
+// CHECK-LABEL: util.func public @dont_fuse_use_from_above
+// CHECK:         linalg.generic
+// CHECK:         linalg.generic
+
+
+// -----
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+util.func public @do_fuse_use_from_above(%arg0: tensor<5x5xf32>, %arg1: tensor<5x5xf32>) -> (tensor<5x5xf32>, tensor<25xf32>) {
+  %cst = arith.constant 1.000000e+00 : f32
+  %cst_0 = arith.constant 2.000000e+00 : f32
+  %cst_1 = arith.constant 3.000000e+00 : f32
+  %0 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%arg0 : tensor<5x5xf32>) outs(%arg1 : tensor<5x5xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %2 = arith.addf %in, %cst : f32
+    linalg.yield %2 : f32
+  } -> tensor<5x5xf32>
+  %collapsed = tensor.collapse_shape %0 [[0, 1]] : tensor<5x5xf32> into tensor<25xf32>
+  %1 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%0 : tensor<5x5xf32>) outs(%arg1 : tensor<5x5xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %c2 = arith.constant 2 : index
+    %extracted = tensor.extract %arg0[%c2, %c2] : tensor<5x5xf32>
+    %2 = arith.addf %extracted, %extracted : f32
+    linalg.yield %2 : f32
+  } -> tensor<5x5xf32>
+  util.return %1, %collapsed : tensor<5x5xf32>, tensor<25xf32>
+}
+
+// CHECK-LABEL: util.func public @do_fuse_use_from_above
+// CHECK:         linalg.generic
+// CHECK-NOT:         linalg.generic


### PR DESCRIPTION
`isHorizontalToGroup` doesn't check `op` to make sure it doesn't use any values defined above. This is a workaround for the fact that `getBackwardsSlice` doesn't track ops if they are used in the region but not as an operand to the operation.

Closes https://github.com/iree-org/iree/issues/18847