### PR TITLE
Emit an error when affinity analysis fails.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ConvertToStream.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ConvertToStream.cpp
@@ -224,6 +224,11 @@ struct ConvertToStreamPass final
     // for all SSA values we'll use during conversion are available.
     AffinityAnalysis affinityAnalysis(getOperation());
     if (failed(affinityAnalysis.run())) {
+      getOperation().emitError()
+          << "affinity analysis failed to converge (input program may have "
+             "invalid affinities assigned); use"
+             "`--iree-stream-annotate-input-affinities` to help identify the "
+             "invalid affinities";
       return signalPassFailure();
     }
 


### PR DESCRIPTION
Includes the flag I'd tell anyone to use if they filed a bug.

Fixes #18878.