### PR TITLE
[GlobalOpt] Prevent fusing transposed extend in RaiseSpecialOps

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/RaiseSpecialOps.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/RaiseSpecialOps.cpp
@@ -304,6 +304,10 @@ public:
           return false;
         }
 
+        if (!llvm::all_of(producer.getIndexingMapsArray(),
+                      [](AffineMap map) { return map.isIdentity(); }))
+          return false;
+
         std::optional<CastOpInterface> castOp =
             getDefiningNonI1ExtendingCastOp(operand.get());
         if (!castOp) {

--- a/compiler/src/iree/compiler/GlobalOptimization/RaiseSpecialOps.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/RaiseSpecialOps.cpp
@@ -305,7 +305,7 @@ public:
         }
 
         if (!llvm::all_of(producer.getIndexingMapsArray(),
-                      [](AffineMap map) { return map.isIdentity(); }))
+                          [](AffineMap map) { return map.isIdentity(); }))
           return false;
 
         std::optional<CastOpInterface> castOp =


### PR DESCRIPTION
NamedImplicitCastOpConversion pattern is incorrectly fusing transposed element-wise extend into Linalg op.