### PR TITLE
[Codegen] Don't require full slice to decompose boundary pack and unpack ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/decompose_boundary_pack_unpack_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/decompose_boundary_pack_unpack_ops.mlir
@@ -133,7 +133,7 @@ func.func @load_non_full_slice() {
   return
 }
 // CHECK-LABEL: func.func @load_non_full_slice
-// CHECK:         tensor.pack
+// CHECK-NOT:     tensor.pack
 
 // -----
 
@@ -152,7 +152,7 @@ func.func @store_non_full_slice() {
   return
 }
 // CHECK-LABEL: func.func @store_non_full_slice
-// CHECK:         tensor.unpack
+// CHECK-NOT:     tensor.unpack
 
 // -----
 


### PR DESCRIPTION
This PR loosens the restrictions on decomposing boundary pack and unpack ops. The current restriction is that the dispatch.tensor.load/store ops are full slices, but this is not necessary for the current use case in the TileAndFuse pipeline. 

Instead, it is better for the time being to decompose non-padded pack/unpack ops at function boundaries regardless of the dispatch.tensor.load/store ops being full slices, because decomposing such ops later on can cause issues with DPS. The DPS issues are tracked in https://github.com/iree-org/iree/issues/18902, but we can loosen the restrictions regardless, since it does not pose any issues to decompose in such cases.