### PR TITLE
[LLVMGPU] Don't use IGEMM when unable to target intrinsics

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h
@@ -7,6 +7,7 @@
 #ifndef IREE_COMPILER_CODEGEN_DIALECT_GPU_TARGETUTILS_CONFIGUTILS_H_
 #define IREE_COMPILER_CODEGEN_DIALECT_GPU_TARGETUTILS_CONFIGUTILS_H_
 
+#include "iree/compiler/Codegen/Common/GPU/GPUHeuristics.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "mlir/IR/Operation.h"
@@ -20,6 +21,11 @@ LogicalResult
 setDataTiledMultiMmaLoweringConfig(IREE::GPU::TargetAttr target,
                                    mlir::FunctionOpInterface entryPoint,
                                    Operation *op);
+
+std::optional<GPUMMASchedule>
+getMmaScheduleFromProblemAndTarget(IREE::GPU::TargetAttr target,
+                                   GPUMatmulShapeType problem,
+                                   bool transposedLhs, bool transposedRhs);
 
 /// Helper for setting up a matmul config based on the specified target.
 /// TODO: Currently this only succeeds if the target supports an mma

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -10,7 +10,6 @@
 #include <numeric>
 #include <optional>
 
-#include "iree/compiler/Codegen/Common/GPU/GPUHeuristics.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.h"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConvolutionToIGEMM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConvolutionToIGEMM.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Common/Transforms.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
+#include "iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.h"
 #include "iree/compiler/Codegen/LLVMGPU/Passes.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
@@ -39,12 +40,77 @@ static LogicalResult llvmgpuConfigFn(linalg::GenericOp genericOp,
   return success();
 }
 
+/// Get the equivalent contraction problem from a conv_2d op. The N, H, and W
+/// dimensions become M dimensions; P * Q * C becomes K; and F becomes N.
+template <typename ConvOpTy>
+static GPUMatmulShapeType getConvProblem(ConvOpTy convOp) {
+  static_assert(llvm::is_one_of<ConvOpTy, linalg::Conv2DNchwFchwOp,
+                                linalg::Conv2DNhwcHwcfOp>::value,
+                "expected nchw conv or nhwc conv op");
+  const bool isNchw = std::is_same_v<ConvOpTy, linalg::Conv2DNchwFchwOp>;
+  auto inputType = cast<RankedTensorType>(convOp.getOperandTypes()[0]);
+  auto accType = cast<RankedTensorType>(convOp.getResultTypes()[0]);
+  ArrayRef<int64_t> accShape = accType.getShape();
+  auto filterType = cast<RankedTensorType>(convOp.getOperandTypes()[1]);
+  ArrayRef<int64_t> filterShape = filterType.getShape();
+  // Result dims
+  const int64_t NDim = 0;
+  const int64_t HDim = isNchw ? 2 : 1;
+  const int64_t WDim = isNchw ? 3 : 2;
+  // Filter dims
+  const int64_t CDim = isNchw ? 1 : 2;
+  const int64_t PDim = isNchw ? 2 : 0;
+  const int64_t QDim = isNchw ? 3 : 1;
+  const int64_t FDim = isNchw ? 0 : 3;
+  SmallVector<int64_t> mSizes, nSizes, kSizes;
+  mSizes.append({accShape[NDim], accShape[HDim], accShape[WDim]});
+  kSizes.append({filterShape[CDim] * filterShape[PDim] * filterShape[QDim]});
+  nSizes.append({filterShape[FDim]});
+  auto filterDynamicSizes = [](SmallVector<int64_t> sizes) {
+    SmallVector<int64_t> filteredSizes;
+    for (auto size : sizes)
+      if (!ShapedType::isDynamic(size))
+        filteredSizes.push_back(size);
+    return filteredSizes;
+  };
+  Type lhsElemType = inputType.getElementType();
+  Type rhsElemType = filterType.getElementType();
+  Type accElemType = accType.getElementType();
+  GPUMatmulShapeType problem{filterDynamicSizes(mSizes),
+                             filterDynamicSizes(nSizes),
+                             filterDynamicSizes(kSizes),
+                             lhsElemType,
+                             rhsElemType,
+                             accElemType};
+  return problem;
+}
+
+/// Control function for using IGEMM. For now, don't use IGEMM for any conv
+/// that would not be able to target MMA intrinsics.
+/// TODO(Max191): Remove the restriction for hitting MMA intrinsics once the
+/// TileAndFuse pipeline can target intrinsics for unaligned cases.
 static bool llvmgpuControlFn(Operation *op) {
   // Do not convert anything that already has a lowering configuration.
   if (getLoweringConfig(op)) {
     return false;
   }
-  return true;
+  auto convNchw = dyn_cast<linalg::Conv2DNchwFchwOp>(op);
+  auto convNhwc = dyn_cast<linalg::Conv2DNhwcHwcfOp>(op);
+  if (!convNchw && !convNhwc) {
+    return false;
+  }
+  GPUMatmulShapeType problem =
+      convNchw ? getConvProblem(convNchw) : getConvProblem(convNhwc);
+  auto funcOp = op->getParentOfType<FunctionOpInterface>();
+  if (!funcOp)
+    return false;
+  IREE::GPU::TargetAttr target = getGPUTargetAttr(funcOp);
+  if (!target)
+    return false;
+  std::optional<GPUMMASchedule> schedule = getMmaScheduleFromProblemAndTarget(
+      target, problem, /*transposedLhs=*/static_cast<bool>(convNchw),
+      /*transposedRhs=*/static_cast<bool>(convNchw));
+  return schedule.has_value();
 }
 
 struct LLVMGPUConvolutionToIGEMMPass final

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/llvmgpu_convolution_to_igemm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/llvmgpu_convolution_to_igemm.mlir
@@ -37,6 +37,44 @@ func.func public @set_lowering_config(%arg0: tensor<1x34x34x128xf32>, %arg1: ten
 
 // -----
 
+func.func public @set_lowering_config_nchw(%arg0: tensor<1x128x34x34xf32>, %arg1: tensor<128x128x3x3xf32>) -> tensor<1x128x32x32xf32> {
+  %cst = arith.constant 0.0 : f32
+  %empty = tensor.empty() : tensor<1x128x32x32xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<1x128x32x32xf32>) -> tensor<1x128x32x32xf32>
+  %0 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
+    ins(%arg0, %arg1: tensor<1x128x34x34xf32>, tensor<128x128x3x3xf32>)
+    outs(%fill: tensor<1x128x32x32xf32>) -> tensor<1x128x32x32xf32>
+  return %0 : tensor<1x128x32x32xf32>
+}
+// CHECK:      func.func public @set_lowering_config_nchw
+// CHECK:        iree_linalg_ext.im2col
+// CHECK:        linalg.generic
+// CHECK-SAME:     lowering_config = #iree_gpu.lowering_config<
+// CHECK-SAME:         {mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
+// CHECK-SAME:          promote_operands = [0, 1], reduction = [0, 0, 0, 0, 8],
+// CHECK-SAME:          subgroup = [1, 2, 2, 1, 0], workgroup = [1, 4, 2, 2, 0]}>
+
+// -----
+
+func.func public @set_lowering_config_stride2(%arg0: tensor<1x34x34x128xf32>, %arg1: tensor<3x3x128x128xf32>) -> tensor<1x16x16x128xf32> {
+  %cst = arith.constant 0.0 : f32
+  %empty = tensor.empty() : tensor<1x16x16x128xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<1x16x16x128xf32>) -> tensor<1x16x16x128xf32>
+  %0 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>}
+    ins(%arg0, %arg1: tensor<1x34x34x128xf32>, tensor<3x3x128x128xf32>)
+    outs(%fill: tensor<1x16x16x128xf32>) -> tensor<1x16x16x128xf32>
+  return %0 : tensor<1x16x16x128xf32>
+}
+// CHECK:      func.func public @set_lowering_config_stride2
+// CHECK:        iree_linalg_ext.im2col
+// CHECK:        linalg.generic
+// CHECK-SAME:     lowering_config = #iree_gpu.lowering_config<
+// CHECK-SAME:         {mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
+// CHECK-SAME:          promote_operands = [0, 1], reduction = [0, 0, 0, 0, 8],
+// CHECK-SAME:          subgroup = [1, 2, 1, 2, 0], workgroup = [1, 2, 1, 8, 0]}>
+
+// -----
+
 func.func public @cannot_target_mfma(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<3x3x4x16xf32>) -> tensor<1x14x14x16xf32> {
   %cst = arith.constant 0.0 : f32
   %empty = tensor.empty() : tensor<1x14x14x16xf32>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/llvmgpu_convolution_to_igemm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/llvmgpu_convolution_to_igemm.mlir
@@ -34,3 +34,18 @@ func.func public @set_lowering_config(%arg0: tensor<1x34x34x128xf32>, %arg1: ten
 // CHECK-SAME:         {mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
 // CHECK-SAME:          promote_operands = [0, 1], reduction = [0, 0, 0, 0, 8],
 // CHECK-SAME:          subgroup = [1, 1, 2, 2, 0], workgroup = [1, 1, 2, 8, 0]}>
+
+// -----
+
+func.func public @cannot_target_mfma(%arg0: tensor<1x16x16x4xf32>, %arg1: tensor<3x3x4x16xf32>) -> tensor<1x14x14x16xf32> {
+  %cst = arith.constant 0.0 : f32
+  %empty = tensor.empty() : tensor<1x14x14x16xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32>
+  %0 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
+    ins(%arg0, %arg1: tensor<1x16x16x4xf32>, tensor<3x3x4x16xf32>)
+    outs(%fill: tensor<1x14x14x16xf32>) -> tensor<1x14x14x16xf32>
+  return %0 : tensor<1x14x14x16xf32>
+}
+// CHECK:      func.func public @cannot_target_mfma
+// CHECK-NOT:    iree_linalg_ext.im2col
+// CHECK:        linalg.conv_2d_nhwc_hwcf


### PR DESCRIPTION
This PR restricts the IGEMM transformation to only cases where intrinsics can be targeted. Since the TileAndFuse pipeline is not able to pad to intrinsic shapes yet, unaligned shapes are slow on the IGEMM path compared to VectorDistribute. This turns off IGEMM for such cases for now.