### PR TITLE
Adding build config for HSA runtime headers.

### DIFF
--- a/build_tools/bazel/workspace.bzl
+++ b/build_tools/bazel/workspace.bzl
@@ -149,6 +149,13 @@ def configure_iree_submodule_deps(iree_repo_alias = "@", iree_path = "./"):
 
     maybe(
         native.new_local_repository,
+        name = "hsa_runtime_headers",
+        build_file = iree_repo_alias + "//:build_tools/third_party/hsa-runtime-headers/BUILD.overlay",
+        path = paths.join(iree_path, "third_party/hsa-runtime-headers"),
+    )
+
+    maybe(
+        native.new_local_repository,
         name = "webgpu_headers",
         build_file = iree_repo_alias + "//:build_tools/third_party/webgpu-headers/BUILD.overlay",
         path = paths.join(iree_path, "third_party/webgpu-headers"),

--- a/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
@@ -113,6 +113,7 @@ class TargetConverter:
                 "@com_google_googletest//:gtest": ["gmock", "gtest"],
                 "@spirv_cross//:spirv_cross_lib": ["spirv-cross-msl"],
                 "@cpuinfo": ["${IREE_CPUINFO_TARGET}"],
+                "@hsa_runtime_headers": ["hsa_runtime::headers"],
                 "@webgpu_headers": [],
             }
         )

--- a/build_tools/third_party/hsa-runtime-headers/BUILD.overlay
+++ b/build_tools/third_party/hsa-runtime-headers/BUILD.overlay
@@ -1,0 +1,16 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "hsa_runtime_headers",
+    hdrs = glob([
+        "include/hsa/*.h",
+    ]),
+    include_prefix = "third_party/hsa-runtime-headers/",
+    includes = ["include"],
+)

--- a/build_tools/third_party/hsa-runtime-headers/CMakeLists.txt
+++ b/build_tools/third_party/hsa-runtime-headers/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+set(HSA_RUNTIME_HEADERS_ROOT "${IREE_ROOT_DIR}/third_party/hsa-runtime-headers/")
+
+external_cc_library(
+  PACKAGE
+    hsa_runtime
+  NAME
+    headers
+  ROOT
+    ${HSA_RUNTIME_HEADERS_ROOT}
+  SYSTEM_INCLUDES
+    ${HSA_RUNTIME_HEADERS_ROOT}/include/
+  PUBLIC
+)
+
+iree_install_targets(
+  TARGETS
+    hsa_runtime_headers
+  COMPONENT
+    IREEBundledLibraries
+  EXPORT_SET
+    Runtime
+)


### PR DESCRIPTION
This bumps the HSA submodule to include an upstream that fixes MSVC builds: https://github.com/ROCm/ROCR-Runtime/pull/254