### PR TITLE
Modernizing iree_atomic_*.

### DIFF
--- a/experimental/webgpu/nop_semaphore.c
+++ b/experimental/webgpu/nop_semaphore.c
@@ -38,8 +38,8 @@ iree_status_t iree_hal_webgpu_nop_semaphore_create(
     iree_hal_resource_initialize(&iree_hal_webgpu_nop_semaphore_vtable,
                                  &semaphore->resource);
     semaphore->host_allocator = host_allocator;
-    iree_atomic_store_int64(&semaphore->value, initial_value,
-                            iree_memory_order_seq_cst);
+    iree_atomic_store(&semaphore->value, initial_value,
+                      iree_memory_order_seq_cst);
     *out_semaphore = (iree_hal_semaphore_t*)semaphore;
   }
 
@@ -63,8 +63,7 @@ static iree_status_t iree_hal_webgpu_nop_semaphore_query(
     iree_hal_semaphore_t* base_semaphore, uint64_t* out_value) {
   iree_hal_webgpu_nop_semaphore_t* semaphore =
       iree_hal_webgpu_nop_semaphore_cast(base_semaphore);
-  *out_value =
-      iree_atomic_load_int64(&semaphore->value, iree_memory_order_seq_cst);
+  *out_value = iree_atomic_load(&semaphore->value, iree_memory_order_seq_cst);
   return iree_ok_status();
 }
 
@@ -72,8 +71,7 @@ static iree_status_t iree_hal_webgpu_nop_semaphore_signal(
     iree_hal_semaphore_t* base_semaphore, uint64_t new_value) {
   iree_hal_webgpu_nop_semaphore_t* semaphore =
       iree_hal_webgpu_nop_semaphore_cast(base_semaphore);
-  iree_atomic_store_int64(&semaphore->value, new_value,
-                          iree_memory_order_seq_cst);
+  iree_atomic_store(&semaphore->value, new_value, iree_memory_order_seq_cst);
   return iree_ok_status();
 }
 
@@ -88,7 +86,7 @@ static iree_status_t iree_hal_webgpu_nop_semaphore_wait(
   iree_hal_webgpu_nop_semaphore_t* semaphore =
       iree_hal_webgpu_nop_semaphore_cast(base_semaphore);
   uint64_t current_value =
-      iree_atomic_load_int64(&semaphore->value, iree_memory_order_seq_cst);
+      iree_atomic_load(&semaphore->value, iree_memory_order_seq_cst);
   if (current_value < value) {
     return iree_make_status(
         IREE_STATUS_FAILED_PRECONDITION,

--- a/runtime/src/iree/base/internal/atomics_clang.h
+++ b/runtime/src/iree/base/internal/atomics_clang.h
@@ -33,36 +33,37 @@ typedef enum iree_memory_order_e {
 
 typedef _Atomic int32_t iree_atomic_int32_t;
 typedef _Atomic int64_t iree_atomic_int64_t;
+typedef _Atomic uint32_t iree_atomic_uint32_t;
+typedef _Atomic uint64_t iree_atomic_uint64_t;
 // TODO(#3453): check for __int128 support before using
 // typedef _Atomic __int128 iree_atomic_int128_t;
 typedef _Atomic intptr_t iree_atomic_intptr_t;
 
-#define iree_atomic_load_auto(object, order) \
-  __c11_atomic_load((object), (order))
-#define iree_atomic_store_auto(object, desired, order) \
-  __c11_atomic_store((object), (desired), (order))
-#define iree_atomic_fetch_add_auto(object, operand, order) \
-  __c11_atomic_fetch_add((object), (operand), (order))
-#define iree_atomic_fetch_sub_auto(object, operand, order) \
-  __c11_atomic_fetch_sub((object), (operand), (order))
-#define iree_atomic_fetch_and_auto(object, operand, order) \
-  __c11_atomic_fetch_and((object), (operand), (order))
-#define iree_atomic_fetch_or_auto(object, operand, order) \
-  __c11_atomic_fetch_or((object), (operand), (order))
-#define iree_atomic_fetch_xor_auto(object, operand, order) \
-  __c11_atomic_fetch_xor((object), (operand), (order))
-#define iree_atomic_exchange_auto(object, operand, order) \
-  __c11_atomic_exchange((object), (operand), (order))
-#define iree_atomic_compare_exchange_strong_auto(object, expected, desired, \
-                                                 order_succ, order_fail)    \
-  __c11_atomic_compare_exchange_strong((object), (expected), (desired),     \
-                                       (order_succ), (order_fail))
-#define iree_atomic_compare_exchange_weak_auto(object, expected, desired, \
-                                               order_succ, order_fail)    \
-  __c11_atomic_compare_exchange_weak((object), (expected), (desired),     \
-                                     (order_succ), (order_fail))
-
 #define iree_atomic_thread_fence(order) __c11_atomic_thread_fence(order)
+
+#define iree_atomic_load(object, order) __c11_atomic_load((object), (order))
+#define iree_atomic_store(object, desired, order) \
+  __c11_atomic_store((object), (desired), (order))
+#define iree_atomic_fetch_add(object, operand, order) \
+  __c11_atomic_fetch_add((object), (operand), (order))
+#define iree_atomic_fetch_sub(object, operand, order) \
+  __c11_atomic_fetch_sub((object), (operand), (order))
+#define iree_atomic_fetch_and(object, operand, order) \
+  __c11_atomic_fetch_and((object), (operand), (order))
+#define iree_atomic_fetch_or(object, operand, order) \
+  __c11_atomic_fetch_or((object), (operand), (order))
+#define iree_atomic_fetch_xor(object, operand, order) \
+  __c11_atomic_fetch_xor((object), (operand), (order))
+#define iree_atomic_exchange(object, operand, order) \
+  __c11_atomic_exchange((object), (operand), (order))
+#define iree_atomic_compare_exchange_strong(object, expected, desired,  \
+                                            order_succ, order_fail)     \
+  __c11_atomic_compare_exchange_strong((object), (expected), (desired), \
+                                       (order_succ), (order_fail))
+#define iree_atomic_compare_exchange_weak(object, expected, desired,  \
+                                          order_succ, order_fail)     \
+  __c11_atomic_compare_exchange_weak((object), (expected), (desired), \
+                                     (order_succ), (order_fail))
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/base/internal/atomics_gcc.h
+++ b/runtime/src/iree/base/internal/atomics_gcc.h
@@ -34,6 +34,8 @@ typedef enum iree_memory_order_e {
 
 typedef int32_t iree_atomic_int32_t;
 typedef int64_t iree_atomic_int64_t;
+typedef uint32_t iree_atomic_uint32_t;
+typedef uint64_t iree_atomic_uint64_t;
 // typedef __int128 iree_atomic_int128_t;
 typedef intptr_t iree_atomic_intptr_t;
 
@@ -45,46 +47,46 @@ typedef intptr_t iree_atomic_intptr_t;
 #define __iree_auto_type __auto_type
 #endif
 
-#define iree_atomic_load_auto(object, order)                       \
-  __extension__({                                                  \
-    __iree_auto_type __atomic_load_ptr = (object);                 \
-    __typeof__(*__atomic_load_ptr) __atomic_load_tmp;              \
-    __atomic_load(__atomic_load_ptr, &__atomic_load_tmp, (order)); \
-    __atomic_load_tmp;                                             \
-  })
-#define iree_atomic_store_auto(object, desired, order)                \
-  __extension__({                                                     \
-    __iree_auto_type __atomic_store_ptr = (object);                   \
-    __typeof__(*__atomic_store_ptr) __atomic_store_tmp = (desired);   \
-    __atomic_store(__atomic_store_ptr, &__atomic_store_tmp, (order)); \
-  })
-#define iree_atomic_fetch_add_auto(object, operand, order) \
-  __atomic_fetch_add((object), (operand), (order))
-#define iree_atomic_fetch_sub_auto(object, operand, order) \
-  __atomic_fetch_sub((object), (operand), (order))
-#define iree_atomic_fetch_and_auto(object, operand, order) \
-  __atomic_fetch_and((object), (operand), (order))
-#define iree_atomic_fetch_or_auto(object, operand, order) \
-  __atomic_fetch_or((object), (operand), (order))
-#define iree_atomic_fetch_xor_auto(object, operand, order) \
-  __atomic_fetch_xor((object), (operand), (order))
-#define iree_atomic_exchange_auto(object, operand, order) \
-  __atomic_exchange_n((object), (operand), (order))
-#define iree_atomic_compare_exchange_strong_auto(object, expected, desired, \
-                                                 order_succ, order_fail)    \
-  __atomic_compare_exchange_n(object, expected, desired, /*weak=*/false,    \
-                              (order_succ), (order_fail))
-#define iree_atomic_compare_exchange_weak_auto(object, expected, desired, \
-                                               order_succ, order_fail)    \
-  __atomic_compare_exchange_n(object, expected, desired, /*weak=*/true,   \
-                              (order_succ), (order_fail))
-
 static inline void iree_atomic_thread_fence(int order) {
   // Ignore error where TSan does not support atomic thread fence.
   IREE_DISABLE_COMPILER_TSAN_ERRORS()
   __atomic_thread_fence(order);
   IREE_RESTORE_COMPILER_TSAN_ERRORS()
 }
+
+#define iree_atomic_load(object, order)                            \
+  __extension__({                                                  \
+    __iree_auto_type __atomic_load_ptr = (object);                 \
+    __typeof__(*__atomic_load_ptr) __atomic_load_tmp;              \
+    __atomic_load(__atomic_load_ptr, &__atomic_load_tmp, (order)); \
+    __atomic_load_tmp;                                             \
+  })
+#define iree_atomic_store(object, desired, order)                     \
+  __extension__({                                                     \
+    __iree_auto_type __atomic_store_ptr = (object);                   \
+    __typeof__(*__atomic_store_ptr) __atomic_store_tmp = (desired);   \
+    __atomic_store(__atomic_store_ptr, &__atomic_store_tmp, (order)); \
+  })
+#define iree_atomic_fetch_add(object, operand, order) \
+  __atomic_fetch_add((object), (operand), (order))
+#define iree_atomic_fetch_sub(object, operand, order) \
+  __atomic_fetch_sub((object), (operand), (order))
+#define iree_atomic_fetch_and(object, operand, order) \
+  __atomic_fetch_and((object), (operand), (order))
+#define iree_atomic_fetch_or(object, operand, order) \
+  __atomic_fetch_or((object), (operand), (order))
+#define iree_atomic_fetch_xor(object, operand, order) \
+  __atomic_fetch_xor((object), (operand), (order))
+#define iree_atomic_exchange(object, operand, order) \
+  __atomic_exchange_n((object), (operand), (order))
+#define iree_atomic_compare_exchange_strong(object, expected, desired,   \
+                                            order_succ, order_fail)      \
+  __atomic_compare_exchange_n(object, expected, desired, /*weak=*/false, \
+                              (order_succ), (order_fail))
+#define iree_atomic_compare_exchange_weak(object, expected, desired,    \
+                                          order_succ, order_fail)       \
+  __atomic_compare_exchange_n(object, expected, desired, /*weak=*/true, \
+                              (order_succ), (order_fail))
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/base/internal/atomics_test.cc
+++ b/runtime/src/iree/base/internal/atomics_test.cc
@@ -21,9 +21,9 @@ TEST(AtomicPtr, LoadStore) {
   intptr_t ptr_0 = 0x0;
   intptr_t ptr_1 = 0x1;
   iree_atomic_intptr_t value = IREE_ATOMIC_VAR_INIT(ptr_0);
-  EXPECT_EQ(ptr_0, iree_atomic_load_intptr(&value, iree_memory_order_seq_cst));
-  iree_atomic_store_intptr(&value, ptr_1, iree_memory_order_seq_cst);
-  EXPECT_EQ(ptr_1, iree_atomic_load_intptr(&value, iree_memory_order_seq_cst));
+  EXPECT_EQ(ptr_0, iree_atomic_load(&value, iree_memory_order_seq_cst));
+  iree_atomic_store(&value, ptr_1, iree_memory_order_seq_cst);
+  EXPECT_EQ(ptr_1, iree_atomic_load(&value, iree_memory_order_seq_cst));
 }
 
 TEST(AtomicPtr, AddSub) {
@@ -31,15 +31,15 @@ TEST(AtomicPtr, AddSub) {
   intptr_t ptr_1 = 0x1;
   intptr_t ptr_2 = 0x2;
   iree_atomic_intptr_t value = IREE_ATOMIC_VAR_INIT(ptr_0);
-  EXPECT_EQ(ptr_0, iree_atomic_fetch_add_intptr(&value, ptr_1,
-                                                iree_memory_order_seq_cst));
-  EXPECT_EQ(ptr_1, iree_atomic_fetch_add_intptr(&value, ptr_1,
-                                                iree_memory_order_seq_cst));
-  EXPECT_EQ(ptr_2, iree_atomic_fetch_sub_intptr(&value, ptr_1,
-                                                iree_memory_order_seq_cst));
-  EXPECT_EQ(ptr_1, iree_atomic_fetch_sub_intptr(&value, ptr_1,
-                                                iree_memory_order_seq_cst));
-  EXPECT_EQ(ptr_0, iree_atomic_load_intptr(&value, iree_memory_order_seq_cst));
+  EXPECT_EQ(ptr_0,
+            iree_atomic_fetch_add(&value, ptr_1, iree_memory_order_seq_cst));
+  EXPECT_EQ(ptr_1,
+            iree_atomic_fetch_add(&value, ptr_1, iree_memory_order_seq_cst));
+  EXPECT_EQ(ptr_2,
+            iree_atomic_fetch_sub(&value, ptr_1, iree_memory_order_seq_cst));
+  EXPECT_EQ(ptr_1,
+            iree_atomic_fetch_sub(&value, ptr_1, iree_memory_order_seq_cst));
+  EXPECT_EQ(ptr_0, iree_atomic_load(&value, iree_memory_order_seq_cst));
 }
 
 TEST(AtomicPtr, Exchange) {
@@ -47,11 +47,11 @@ TEST(AtomicPtr, Exchange) {
   intptr_t ptr_1 = 0x1;
   intptr_t ptr_2 = 0x2;
   iree_atomic_intptr_t value = IREE_ATOMIC_VAR_INIT(ptr_0);
-  EXPECT_EQ(ptr_0, iree_atomic_exchange_intptr(&value, ptr_1,
-                                               iree_memory_order_seq_cst));
-  EXPECT_EQ(ptr_1, iree_atomic_exchange_intptr(&value, ptr_2,
-                                               iree_memory_order_seq_cst));
-  EXPECT_EQ(ptr_2, iree_atomic_load_intptr(&value, iree_memory_order_seq_cst));
+  EXPECT_EQ(ptr_0,
+            iree_atomic_exchange(&value, ptr_1, iree_memory_order_seq_cst));
+  EXPECT_EQ(ptr_1,
+            iree_atomic_exchange(&value, ptr_2, iree_memory_order_seq_cst));
+  EXPECT_EQ(ptr_2, iree_atomic_load(&value, iree_memory_order_seq_cst));
 }
 
 TEST(AtomicPtr, CompareExchange) {
@@ -62,31 +62,31 @@ TEST(AtomicPtr, CompareExchange) {
   intptr_t ptr_expected = 0;
 
   // OK: value == ptr_0, CAS(ptr_0 -> ptr_1)
-  iree_atomic_store_intptr(&value, ptr_0, iree_memory_order_seq_cst);
+  iree_atomic_store(&value, ptr_0, iree_memory_order_seq_cst);
   ptr_expected = ptr_0;
-  EXPECT_TRUE(iree_atomic_compare_exchange_strong_intptr(
-      &value, &ptr_expected, ptr_1, iree_memory_order_seq_cst,
-      iree_memory_order_seq_cst));
+  EXPECT_TRUE(iree_atomic_compare_exchange_strong(&value, &ptr_expected, ptr_1,
+                                                  iree_memory_order_seq_cst,
+                                                  iree_memory_order_seq_cst));
   EXPECT_EQ(ptr_0, ptr_expected);
-  EXPECT_EQ(ptr_1, iree_atomic_load_intptr(&value, iree_memory_order_seq_cst));
+  EXPECT_EQ(ptr_1, iree_atomic_load(&value, iree_memory_order_seq_cst));
 
   // OK: value == ptr_1, CAS(ptr_1 -> ptr_2)
-  iree_atomic_store_intptr(&value, ptr_1, iree_memory_order_seq_cst);
+  iree_atomic_store(&value, ptr_1, iree_memory_order_seq_cst);
   ptr_expected = ptr_1;
-  EXPECT_TRUE(iree_atomic_compare_exchange_strong_intptr(
-      &value, &ptr_expected, ptr_2, iree_memory_order_seq_cst,
-      iree_memory_order_seq_cst));
+  EXPECT_TRUE(iree_atomic_compare_exchange_strong(&value, &ptr_expected, ptr_2,
+                                                  iree_memory_order_seq_cst,
+                                                  iree_memory_order_seq_cst));
   EXPECT_EQ(ptr_1, ptr_expected);
-  EXPECT_EQ(ptr_2, iree_atomic_load_intptr(&value, iree_memory_order_seq_cst));
+  EXPECT_EQ(ptr_2, iree_atomic_load(&value, iree_memory_order_seq_cst));
 
   // FAIL: value == ptr_0, CAS(ptr_1 -> ptr_2)
-  iree_atomic_store_intptr(&value, ptr_0, iree_memory_order_seq_cst);
+  iree_atomic_store(&value, ptr_0, iree_memory_order_seq_cst);
   ptr_expected = ptr_1;
-  EXPECT_FALSE(iree_atomic_compare_exchange_strong_intptr(
-      &value, &ptr_expected, ptr_2, iree_memory_order_seq_cst,
-      iree_memory_order_seq_cst));
+  EXPECT_FALSE(iree_atomic_compare_exchange_strong(&value, &ptr_expected, ptr_2,
+                                                   iree_memory_order_seq_cst,
+                                                   iree_memory_order_seq_cst));
   EXPECT_EQ(ptr_0, ptr_expected);
-  EXPECT_EQ(ptr_0, iree_atomic_load_intptr(&value, iree_memory_order_seq_cst));
+  EXPECT_EQ(ptr_0, iree_atomic_load(&value, iree_memory_order_seq_cst));
 }
 
 TEST(AtomicRefCount, IncDec) {

--- a/runtime/src/iree/base/internal/dynamic_library_win32.c
+++ b/runtime/src/iree/base/internal/dynamic_library_win32.c
@@ -91,7 +91,7 @@ static iree_status_t iree_dynamic_library_make_temp_file_path(
   static iree_atomic_int32_t next_unique_id = IREE_ATOMIC_VAR_INIT(0);
   // relaxed because we only care about uniqueness, we don't care about ordering
   // of accesses to unique_id w.r.t. other memory operations.
-  uint32_t unique_id = (uint32_t)iree_atomic_fetch_add_int32(
+  uint32_t unique_id = (uint32_t)iree_atomic_fetch_add(
       &next_unique_id, 1, iree_memory_order_relaxed);
 
   // Allocate storage for the full file path and format it in.

--- a/runtime/src/iree/base/internal/threading_darwin.c
+++ b/runtime/src/iree/base/internal/threading_darwin.c
@@ -104,9 +104,8 @@ iree_status_t iree_thread_create(iree_thread_entry_t entry, void* entry_arg,
   thread->entry_arg = entry_arg;
   iree_strncpy_s(thread->name, IREE_ARRAYSIZE(thread->name), params.name.data,
                  iree_min(params.name.size, IREE_ARRAYSIZE(thread->name) - 1));
-  iree_atomic_store_int32(&thread->is_suspended,
-                          params.create_suspended ? 1 : 0,
-                          iree_memory_order_relaxed);
+  iree_atomic_store(&thread->is_suspended, params.create_suspended ? 1 : 0,
+                    iree_memory_order_relaxed);
 
   pthread_attr_t thread_attr;
   pthread_attr_init(&thread_attr);
@@ -239,7 +238,7 @@ void iree_thread_resume(iree_thread_t* thread) {
   // always balance suspend/resume or else we'll mess with any
   // debuggers/profilers that may be suspending threads for their own uses.
   int32_t expected = 1;
-  if (iree_atomic_compare_exchange_strong_int32(
+  if (iree_atomic_compare_exchange_strong(
           &thread->is_suspended, &expected, 0, iree_memory_order_acq_rel,
           iree_memory_order_relaxed /* expected is unused */)) {
     thread_resume(thread->mach_port);

--- a/runtime/src/iree/base/internal/wait_handle_inproc.c
+++ b/runtime/src/iree/base/internal/wait_handle_inproc.c
@@ -240,7 +240,7 @@ static bool iree_wait_set_check(const iree_wait_set_check_params_t* params) {
     iree_wait_handle_t* wait_handle = &params->set->handles[i];
     iree_futex_handle_t* futex =
         (iree_futex_handle_t*)wait_handle->value.local_futex;
-    if (iree_atomic_load_int64(&futex->value, iree_memory_order_acquire) != 0) {
+    if (iree_atomic_load(&futex->value, iree_memory_order_acquire) != 0) {
       ++ready_count;
       if (params->wake_handle) {
         *params->wake_handle = *wait_handle;
@@ -292,7 +292,7 @@ iree_status_t iree_wait_any(iree_wait_set_t* set, iree_time_t deadline_ns,
 }
 
 static bool iree_futex_handle_check(iree_futex_handle_t* futex) {
-  return iree_atomic_load_int64(&futex->value, iree_memory_order_acquire) != 0;
+  return iree_atomic_load(&futex->value, iree_memory_order_acquire) != 0;
 }
 
 iree_status_t iree_wait_one(iree_wait_handle_t* handle,
@@ -335,8 +335,8 @@ iree_status_t iree_event_initialize(bool initial_state,
   if (iree_status_is_ok(status)) {
     out_event->type = IREE_WAIT_PRIMITIVE_TYPE_LOCAL_FUTEX;
     out_event->value.local_futex = (void*)futex;
-    iree_atomic_store_int64(&futex->value, initial_state ? 1 : 0,
-                            iree_memory_order_release);
+    iree_atomic_store(&futex->value, initial_state ? 1 : 0,
+                      iree_memory_order_release);
     iree_notification_initialize(&futex->notification);
   }
 
@@ -358,8 +358,7 @@ void iree_event_set(iree_event_t* event) {
   // Try to transition from unset -> set.
   // No-op if already set and otherwise we successfully signaled the event and
   // need to notify all waiters.
-  if (iree_atomic_exchange_int64(&futex->value, 1, iree_memory_order_release) ==
-      0) {
+  if (iree_atomic_exchange(&futex->value, 1, iree_memory_order_release) == 0) {
     // Notify those waiting on just this event.
     iree_notification_post(&futex->notification, IREE_ALL_WAITERS);
     // Notify any multi-waits that may have this event as part of their set.
@@ -371,7 +370,7 @@ void iree_event_reset(iree_event_t* event) {
   if (!event) return;
   iree_futex_handle_t* futex = (iree_futex_handle_t*)event->value.local_futex;
   if (!futex) return;
-  iree_atomic_store_int64(&futex->value, 0, iree_memory_order_release);
+  iree_atomic_store(&futex->value, 0, iree_memory_order_release);
 }
 
 #endif  // IREE_WAIT_API == IREE_WAIT_API_INPROC

--- a/runtime/src/iree/hal/drivers/cuda/memory_pools.c
+++ b/runtime/src/iree/hal/drivers/cuda/memory_pools.c
@@ -121,8 +121,8 @@ static void iree_hal_cuda_memory_pool_track_alloc(
     iree_atomic_int64_t* bytes_allocated =
         is_device_local ? &pools->statistics.device_bytes_allocated
                         : &pools->statistics.host_bytes_allocated;
-    iree_atomic_fetch_add_int64(bytes_allocated, allocation_size,
-                                iree_memory_order_relaxed);
+    iree_atomic_fetch_add(bytes_allocated, allocation_size,
+                          iree_memory_order_relaxed);
   });
 }
 
@@ -141,8 +141,8 @@ static void iree_hal_cuda_memory_pool_track_free(
                         : &pools->statistics.host_bytes_freed;
     iree_device_size_t allocation_size =
         iree_hal_buffer_allocation_size(buffer);
-    iree_atomic_fetch_add_int64(bytes_freed, allocation_size,
-                                iree_memory_order_relaxed);
+    iree_atomic_fetch_add(bytes_freed, allocation_size,
+                          iree_memory_order_relaxed);
   });
 }
 
@@ -150,13 +150,13 @@ void iree_hal_cuda_memory_pools_merge_statistics(
     iree_hal_cuda_memory_pools_t* pools,
     iree_hal_allocator_statistics_t* statistics) {
   IREE_STATISTICS({
-    statistics->device_bytes_allocated = iree_atomic_load_int64(
+    statistics->device_bytes_allocated = iree_atomic_load(
         &pools->statistics.device_bytes_allocated, iree_memory_order_relaxed);
-    statistics->host_bytes_allocated = iree_atomic_load_int64(
+    statistics->host_bytes_allocated = iree_atomic_load(
         &pools->statistics.host_bytes_allocated, iree_memory_order_relaxed);
-    statistics->device_bytes_freed = iree_atomic_load_int64(
+    statistics->device_bytes_freed = iree_atomic_load(
         &pools->statistics.device_bytes_freed, iree_memory_order_relaxed);
-    statistics->host_bytes_freed = iree_atomic_load_int64(
+    statistics->host_bytes_freed = iree_atomic_load(
         &pools->statistics.host_bytes_freed, iree_memory_order_relaxed);
     if (pools->device_local) {
       cuuint64_t pool_peak = 0;

--- a/runtime/src/iree/hal/drivers/hip/memory_pools.c
+++ b/runtime/src/iree/hal/drivers/hip/memory_pools.c
@@ -121,8 +121,8 @@ static void iree_hal_hip_memory_pool_track_alloc(
     iree_atomic_int64_t* bytes_allocated =
         is_device_local ? &pools->statistics.device_bytes_allocated
                         : &pools->statistics.host_bytes_allocated;
-    iree_atomic_fetch_add_int64(bytes_allocated, allocation_size,
-                                iree_memory_order_relaxed);
+    iree_atomic_fetch_add(bytes_allocated, allocation_size,
+                          iree_memory_order_relaxed);
   });
 }
 
@@ -141,8 +141,8 @@ static void iree_hal_hip_memory_pool_track_free(
                         : &pools->statistics.host_bytes_freed;
     iree_device_size_t allocation_size =
         iree_hal_buffer_allocation_size(buffer);
-    iree_atomic_fetch_add_int64(bytes_freed, allocation_size,
-                                iree_memory_order_relaxed);
+    iree_atomic_fetch_add(bytes_freed, allocation_size,
+                          iree_memory_order_relaxed);
   });
 }
 
@@ -150,13 +150,13 @@ void iree_hal_hip_memory_pools_merge_statistics(
     iree_hal_hip_memory_pools_t* pools,
     iree_hal_allocator_statistics_t* statistics) {
   IREE_STATISTICS({
-    statistics->device_bytes_allocated = iree_atomic_load_int64(
+    statistics->device_bytes_allocated = iree_atomic_load(
         &pools->statistics.device_bytes_allocated, iree_memory_order_relaxed);
-    statistics->host_bytes_allocated = iree_atomic_load_int64(
+    statistics->host_bytes_allocated = iree_atomic_load(
         &pools->statistics.host_bytes_allocated, iree_memory_order_relaxed);
-    statistics->device_bytes_freed = iree_atomic_load_int64(
+    statistics->device_bytes_freed = iree_atomic_load(
         &pools->statistics.device_bytes_freed, iree_memory_order_relaxed);
-    statistics->host_bytes_freed = iree_atomic_load_int64(
+    statistics->host_bytes_freed = iree_atomic_load(
         &pools->statistics.host_bytes_freed, iree_memory_order_relaxed);
 
     if (pools->device_local) {

--- a/runtime/src/iree/hal/drivers/metal/shared_event.m
+++ b/runtime/src/iree/hal/drivers/metal/shared_event.m
@@ -231,7 +231,7 @@ iree_status_t iree_hal_metal_shared_event_multi_wait(
   // Create an atomic to count how many semaphores have signaled. Mark it as `__block` so different
   // threads are sharing the same data via reference.
   __block iree_atomic_int32_t wait_count;
-  iree_atomic_store_int32(&wait_count, 0, iree_memory_order_release);
+  iree_atomic_store(&wait_count, 0, iree_memory_order_release);
   // The total count we are expecting to see.
   iree_host_size_t total_count = (wait_mode == IREE_HAL_WAIT_MODE_ALL) ? semaphore_list->count : 1;
   // Theoretically we don't really need to mark the semaphore handle as __block given that the
@@ -253,7 +253,7 @@ iree_status_t iree_hal_metal_shared_event_multi_wait(
                                         // Fail as a whole if any participating semaphore failed.
                                         if (v >= IREE_HAL_SEMAPHORE_FAILURE_VALUE) did_fail = true;
 
-                                        int32_t old_value = iree_atomic_fetch_add_int32(
+                                        int32_t old_value = iree_atomic_fetch_add(
                                             &wait_count, 1, iree_memory_order_release);
                                         // The last signaled semaphore send out the notification.
                                         // Atomic fetch add returns the old value, so need to +1.

--- a/runtime/src/iree/hal/drivers/metal/staging_buffer.m
+++ b/runtime/src/iree/hal/drivers/metal/staging_buffer.m
@@ -37,8 +37,7 @@ iree_status_t iree_hal_metal_staging_buffer_initialize(
   out_staging_buffer->host_buffer = metal_buffer.contents;
   iree_slim_mutex_initialize(&out_staging_buffer->offset_mutex);
   out_staging_buffer->offset = 0;
-  iree_atomic_store_int32(&out_staging_buffer->pending_command_buffers, 0,
-                          iree_memory_order_relaxed);
+  iree_atomic_store(&out_staging_buffer->pending_command_buffers, 0, iree_memory_order_relaxed);
 
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
@@ -97,14 +96,13 @@ void iree_hal_metal_staging_buffer_reset(iree_hal_metal_staging_buffer_t* stagin
 
 void iree_hal_metal_staging_buffer_increase_command_buffer_refcount(
     iree_hal_metal_staging_buffer_t* staging_buffer) {
-  iree_atomic_fetch_add_int32(&staging_buffer->pending_command_buffers, 1,
-                              iree_memory_order_relaxed);
+  iree_atomic_fetch_add(&staging_buffer->pending_command_buffers, 1, iree_memory_order_relaxed);
 }
 
 void iree_hal_metal_staging_buffer_decrease_command_buffer_refcount(
     iree_hal_metal_staging_buffer_t* staging_buffer) {
-  if (iree_atomic_fetch_sub_int32(&staging_buffer->pending_command_buffers, 1,
-                                  iree_memory_order_acq_rel) == 1) {
+  if (iree_atomic_fetch_sub(&staging_buffer->pending_command_buffers, 1,
+                            iree_memory_order_acq_rel) == 1) {
     iree_hal_metal_staging_buffer_reset(staging_buffer);
   }
 }

--- a/runtime/src/iree/hal/local/executable_plugin_manager.c
+++ b/runtime/src/iree/hal/local/executable_plugin_manager.c
@@ -432,8 +432,8 @@ static iree_status_t iree_hal_executable_plugin_manager_register(
 
   // Get the next provider slot. Note that we don't yet increment it as we need
   // to put the provider in there first.
-  int32_t slot = iree_atomic_load_int32(&manager->provider_count,
-                                        iree_memory_order_acquire);
+  int32_t slot =
+      iree_atomic_load(&manager->provider_count, iree_memory_order_acquire);
   if (slot >= manager->capacity) {
     iree_slim_mutex_unlock(&manager->mutex);
     return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
@@ -449,8 +449,7 @@ static iree_status_t iree_hal_executable_plugin_manager_register(
   }
 
   // Mark the slot as valid now that the provider is in it.
-  iree_atomic_fetch_add_int32(&manager->provider_count, 1,
-                              iree_memory_order_release);
+  iree_atomic_fetch_add(&manager->provider_count, 1, iree_memory_order_release);
 
   iree_slim_mutex_unlock(&manager->mutex);
   return iree_ok_status();
@@ -506,8 +505,8 @@ static iree_status_t iree_hal_executable_plugin_manager_resolve(
   // but that's ok: multithreaded registration/resolution is non-deterministic
   // by nature. Not holding the lock here means we allow multiple threads to
   // resolve imports at the same time.
-  int32_t provider_count = iree_atomic_load_int32(&manager->provider_count,
-                                                  iree_memory_order_acquire);
+  int32_t provider_count =
+      iree_atomic_load(&manager->provider_count, iree_memory_order_acquire);
 
   // Scan in reverse registration order so that more recently registered
   // providers get queried first. try_resolve will populate any function

--- a/runtime/src/iree/hal/utils/file_transfer.c
+++ b/runtime/src/iree/hal/utils/file_transfer.c
@@ -242,8 +242,8 @@ static iree_status_t iree_hal_transfer_operation_create(
   // steps are part of this transfer.
   IREE_TRACE({
     static iree_atomic_int32_t next_trace_id = IREE_ATOMIC_VAR_INIT(0);
-    operation->trace_id = iree_atomic_fetch_add_int32(
-        &next_trace_id, 1, iree_memory_order_seq_cst);
+    operation->trace_id =
+        iree_atomic_fetch_add(&next_trace_id, 1, iree_memory_order_seq_cst);
     IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, operation->trace_id);
   });
 

--- a/runtime/src/iree/task/affinity_set.h
+++ b/runtime/src/iree/task/affinity_set.h
@@ -61,25 +61,25 @@ typedef iree_atomic_int64_t iree_atomic_task_affinity_set_t;
 
 static inline iree_task_affinity_set_t iree_atomic_task_affinity_set_load(
     iree_atomic_task_affinity_set_t* set, iree_memory_order_t order) {
-  return iree_atomic_load_int64(set, order);
+  return iree_atomic_load(set, order);
 }
 
 static inline void iree_atomic_task_affinity_set_store(
     iree_atomic_task_affinity_set_t* set, iree_task_affinity_set_t value,
     iree_memory_order_t order) {
-  iree_atomic_store_int64(set, value, order);
+  iree_atomic_store(set, value, order);
 }
 
 static inline iree_task_affinity_set_t iree_atomic_task_affinity_set_fetch_and(
     iree_atomic_task_affinity_set_t* set, iree_task_affinity_set_t value,
     iree_memory_order_t order) {
-  return iree_atomic_fetch_and_int64(set, value, order);
+  return iree_atomic_fetch_and(set, value, order);
 }
 
 static inline iree_task_affinity_set_t iree_atomic_task_affinity_set_fetch_or(
     iree_atomic_task_affinity_set_t* set, iree_task_affinity_set_t value,
     iree_memory_order_t order) {
-  return iree_atomic_fetch_or_int64(set, value, order);
+  return iree_atomic_fetch_or(set, value, order);
 }
 
 #ifdef __cplusplus

--- a/runtime/src/iree/task/executor.c
+++ b/runtime/src/iree/task/executor.c
@@ -103,10 +103,9 @@ iree_status_t iree_task_executor_create(iree_task_executor_options_t options,
   IREE_TRACE({
     static iree_atomic_int32_t executor_id = IREE_ATOMIC_VAR_INIT(0);
     char trace_name[32];
-    int trace_name_length =
-        snprintf(trace_name, sizeof(trace_name), "iree-executor-%d",
-                 iree_atomic_fetch_add_int32(&executor_id, 1,
-                                             iree_memory_order_seq_cst));
+    int trace_name_length = snprintf(
+        trace_name, sizeof(trace_name), "iree-executor-%d",
+        iree_atomic_fetch_add(&executor_id, 1, iree_memory_order_seq_cst));
     IREE_LEAK_CHECK_DISABLE_PUSH();
     executor->trace_name = malloc(trace_name_length + 1);
     memcpy((void*)executor->trace_name, trace_name, trace_name_length + 1);
@@ -540,8 +539,7 @@ static iree_task_t* iree_task_executor_try_steal_task_from_affinity_set(
     worker_index += offset + 1;
     mask = iree_shr(mask, offset + 1);
     iree_task_worker_t* victim_worker = &executor->workers[victim_index];
-    if (iree_atomic_load_int32(&victim_worker->state,
-                               iree_memory_order_acquire) !=
+    if (iree_atomic_load(&victim_worker->state, iree_memory_order_acquire) !=
         IREE_TASK_WORKER_STATE_RUNNING) {
       return NULL;
     }

--- a/runtime/src/iree/task/executor_demo.cc
+++ b/runtime/src/iree/task/executor_demo.cc
@@ -89,8 +89,8 @@ extern "C" int main(int argc, char* argv[]) {
             IREE_TRACE_SCOPE_NAMED("tile0");
             IREE_ASSERT_EQ(0, user_context);
             simulate_work(tile_context);
-            iree_atomic_fetch_add_int32(&tile_context->statistics->reserved, 1,
-                                        iree_memory_order_relaxed);
+            iree_atomic_fetch_add(&tile_context->statistics->reserved, 1,
+                                  iree_memory_order_relaxed);
             return iree_ok_status();
           },
           0),
@@ -107,8 +107,8 @@ extern "C" int main(int argc, char* argv[]) {
             IREE_TRACE_SCOPE_NAMED("tile1");
             IREE_ASSERT_EQ(0, user_context);
             simulate_work(tile_context);
-            iree_atomic_fetch_add_int32(&tile_context->statistics->reserved, 1,
-                                        iree_memory_order_relaxed);
+            iree_atomic_fetch_add(&tile_context->statistics->reserved, 1,
+                                  iree_memory_order_relaxed);
             return iree_ok_status();
           },
           0),

--- a/runtime/src/iree/task/task.c
+++ b/runtime/src/iree/task/task.c
@@ -39,13 +39,13 @@ void iree_task_set_completion_task(iree_task_t* task,
                                    iree_task_t* completion_task) {
   IREE_ASSERT(!task->completion_task);
   task->completion_task = completion_task;
-  iree_atomic_fetch_add_int32(&completion_task->pending_dependency_count, 1,
-                              iree_memory_order_acq_rel);
+  iree_atomic_fetch_add(&completion_task->pending_dependency_count, 1,
+                        iree_memory_order_acq_rel);
 }
 
 bool iree_task_is_ready(iree_task_t* task) {
-  if (iree_atomic_load_int32(&task->pending_dependency_count,
-                             iree_memory_order_acquire) > 0) {
+  if (iree_atomic_load(&task->pending_dependency_count,
+                       iree_memory_order_acquire) > 0) {
     // At least one dependency is still pending.
     return false;
   }
@@ -62,7 +62,7 @@ static void iree_task_try_set_status(iree_atomic_intptr_t* permanent_status,
       z0, iree_status_code_string(iree_status_code(new_status)));
 
   iree_status_t old_status = iree_ok_status();
-  if (!iree_atomic_compare_exchange_strong_intptr(
+  if (!iree_atomic_compare_exchange_strong(
           permanent_status, (intptr_t*)&old_status, (intptr_t)new_status,
           iree_memory_order_acq_rel,
           iree_memory_order_relaxed /* old_status is unused */)) {
@@ -102,16 +102,15 @@ void iree_task_discard(iree_task_t* task, iree_task_list_t* discard_worklist) {
   // tasks in the appropriate order: if we had a DAG of A -> B, C -> D we must
   // discard respecting the same topological ordering.
 
-  IREE_ASSERT_EQ(0, iree_atomic_load_int32(&task->pending_dependency_count,
-                                           iree_memory_order_acquire));
+  IREE_ASSERT_EQ(0, iree_atomic_load(&task->pending_dependency_count,
+                                     iree_memory_order_acquire));
 
   // Almost all tasks will have a completion task; some may have additional
   // dependent tasks (like barriers) that will be handled below.
   const bool completion_task_ready =
       task->completion_task &&
-      iree_atomic_fetch_sub_int32(
-          &task->completion_task->pending_dependency_count, 1,
-          iree_memory_order_acq_rel) == 1;
+      iree_atomic_fetch_sub(&task->completion_task->pending_dependency_count, 1,
+                            iree_memory_order_acq_rel) == 1;
   if (completion_task_ready) {
     iree_task_list_push_back(discard_worklist, task->completion_task);
   }
@@ -147,8 +146,8 @@ void iree_task_discard(iree_task_t* task, iree_task_list_t* discard_worklist) {
 static void iree_task_retire(iree_task_t* task,
                              iree_task_submission_t* pending_submission,
                              iree_status_t status) {
-  IREE_ASSERT_EQ(0, iree_atomic_load_int32(&task->pending_dependency_count,
-                                           iree_memory_order_acquire));
+  IREE_ASSERT_EQ(0, iree_atomic_load(&task->pending_dependency_count,
+                                     iree_memory_order_acquire));
 
   // Decrement the pending count on the completion task, if any.
   iree_task_t* completion_task = task->completion_task;
@@ -159,8 +158,8 @@ static void iree_task_retire(iree_task_t* task,
     iree_task_cleanup(task, IREE_STATUS_OK);
     bool completion_task_ready =
         completion_task &&
-        iree_atomic_fetch_sub_int32(&completion_task->pending_dependency_count,
-                                    1, iree_memory_order_acq_rel) == 1;
+        iree_atomic_fetch_sub(&completion_task->pending_dependency_count, 1,
+                              iree_memory_order_acq_rel) == 1;
     if (completion_task_ready) {
       // This was the last pending dependency and the completion task is ready
       // to run.
@@ -180,8 +179,8 @@ static void iree_task_retire(iree_task_t* task,
 
     bool completion_task_ready =
         completion_task &&
-        iree_atomic_fetch_sub_int32(&completion_task->pending_dependency_count,
-                                    1, iree_memory_order_acq_rel) == 1;
+        iree_atomic_fetch_sub(&completion_task->pending_dependency_count, 1,
+                              iree_memory_order_acq_rel) == 1;
     if (completion_task_ready) {
       // This was the last pending dependency and we know that we can safely
       // abort the completion task by discarding.
@@ -239,7 +238,7 @@ void iree_task_call_initialize(iree_task_scope_t* scope,
                                iree_task_call_t* out_task) {
   iree_task_initialize(IREE_TASK_TYPE_CALL, scope, &out_task->header);
   out_task->closure = closure;
-  iree_atomic_store_intptr(&out_task->status, 0, iree_memory_order_release);
+  iree_atomic_store(&out_task->status, 0, iree_memory_order_release);
 }
 
 void iree_task_call_execute(iree_task_call_t* task,
@@ -272,9 +271,9 @@ void iree_task_call_execute(iree_task_call_t* task,
 
   // Check to see if there are no pending dependencies before retiring; the
   // dependency count can go up if new nested tasks were enqueued.
-  if (iree_atomic_load_int32(&task->header.pending_dependency_count,
-                             iree_memory_order_acquire) == 0) {
-    iree_status_t status = (iree_status_t)iree_atomic_exchange_intptr(
+  if (iree_atomic_load(&task->header.pending_dependency_count,
+                       iree_memory_order_acquire) == 0) {
+    iree_status_t status = (iree_status_t)iree_atomic_exchange(
         &task->status, 0, iree_memory_order_acq_rel);
     iree_task_retire(&task->header, pending_submission, status);
   }
@@ -295,8 +294,8 @@ void iree_task_barrier_initialize(iree_task_scope_t* scope,
   out_task->dependent_tasks = dependent_tasks;
   for (iree_host_size_t i = 0; i < out_task->dependent_task_count; ++i) {
     iree_task_t* dependent_task = out_task->dependent_tasks[i];
-    iree_atomic_fetch_add_int32(&dependent_task->pending_dependency_count, 1,
-                                iree_memory_order_acq_rel);
+    iree_atomic_fetch_add(&dependent_task->pending_dependency_count, 1,
+                          iree_memory_order_acq_rel);
   }
 }
 
@@ -314,8 +313,8 @@ void iree_task_barrier_set_dependent_tasks(
   task->dependent_tasks = dependent_tasks;
   for (iree_host_size_t i = 0; i < task->dependent_task_count; ++i) {
     iree_task_t* dependent_task = task->dependent_tasks[i];
-    iree_atomic_fetch_add_int32(&dependent_task->pending_dependency_count, 1,
-                                iree_memory_order_acq_rel);
+    iree_atomic_fetch_add(&dependent_task->pending_dependency_count, 1,
+                          iree_memory_order_acq_rel);
   }
 }
 
@@ -329,8 +328,8 @@ static void iree_task_barrier_discard(iree_task_barrier_t* task,
   for (iree_host_size_t i = 0; i < task->dependent_task_count; ++i) {
     iree_task_t* dependent_task = task->dependent_tasks[i];
     const bool dependent_task_ready =
-        iree_atomic_fetch_sub_int32(&dependent_task->pending_dependency_count,
-                                    1, iree_memory_order_acq_rel) == 1;
+        iree_atomic_fetch_sub(&dependent_task->pending_dependency_count, 1,
+                              iree_memory_order_acq_rel) == 1;
     if (dependent_task_ready) {
       // The dependent task has retired and can now be discard.
       iree_task_list_push_back(discard_worklist, dependent_task);
@@ -348,8 +347,8 @@ void iree_task_barrier_retire(iree_task_barrier_t* task,
   for (iree_host_size_t i = 0; i < task->dependent_task_count; ++i) {
     iree_task_t* dependent_task =
         task->dependent_tasks[task->dependent_task_count - i - 1];
-    if (iree_atomic_fetch_sub_int32(&dependent_task->pending_dependency_count,
-                                    1, iree_memory_order_acq_rel) == 1) {
+    if (iree_atomic_fetch_sub(&dependent_task->pending_dependency_count, 1,
+                              iree_memory_order_acq_rel) == 1) {
       // The dependent task has retired and can now be made ready.
       iree_task_submission_enqueue(pending_submission, dependent_task);
     }
@@ -530,13 +529,13 @@ static void iree_task_dispatch_initialize_base(
   memcpy(out_task->workgroup_size, workgroup_size,
          sizeof(out_task->workgroup_size));
   out_task->local_memory_size = 0;
-  iree_atomic_store_intptr(&out_task->status, 0, iree_memory_order_release);
+  iree_atomic_store(&out_task->status, 0, iree_memory_order_release);
   memset(&out_task->statistics, 0, sizeof(out_task->statistics));
 
   IREE_TRACE({
     static iree_atomic_int64_t next_dispatch_id = IREE_ATOMIC_VAR_INIT(0);
-    out_task->dispatch_id = iree_atomic_fetch_add_int64(
-        &next_dispatch_id, 1ll, iree_memory_order_acq_rel);
+    out_task->dispatch_id = iree_atomic_fetch_add(&next_dispatch_id, 1ll,
+                                                  iree_memory_order_acq_rel);
   });
 }
 
@@ -597,8 +596,7 @@ void iree_task_dispatch_issue(iree_task_dispatch_t* dispatch_task,
 #endif  // IREE_HAL_VERBOSE_TRACING_ENABLE
 
   // Setup the iteration space for shards to pull work from the complete grid.
-  iree_atomic_store_int32(&dispatch_task->tile_index, 0,
-                          iree_memory_order_relaxed);
+  iree_atomic_store(&dispatch_task->tile_index, 0, iree_memory_order_relaxed);
   dispatch_task->tile_count =
       workgroup_count[0] * workgroup_count[1] * workgroup_count[2];
 
@@ -672,7 +670,7 @@ void iree_task_dispatch_retire(iree_task_dispatch_t* dispatch_task,
   // any other has hit an error; failure in a dispatch should be so exceedingly
   // rare that allowing some shards to complete after one encounters an error is
   // not a problem.
-  iree_status_t status = (iree_status_t)iree_atomic_exchange_intptr(
+  iree_status_t status = (iree_status_t)iree_atomic_exchange(
       &dispatch_task->status, 0, iree_memory_order_acq_rel);
 
   iree_task_retire(&dispatch_task->header, pending_submission, status);
@@ -763,9 +761,9 @@ void iree_task_dispatch_shard_execute(
   const uint32_t tiles_per_reservation = dispatch_task->tiles_per_reservation;
   // relaxed order because we only care about atomic increments, not about
   // ordering of tile_index accesses w.r.t. other memory accesses.
-  uint32_t tile_base = iree_atomic_fetch_add_int32(&dispatch_task->tile_index,
-                                                   tiles_per_reservation,
-                                                   iree_memory_order_relaxed);
+  uint32_t tile_base =
+      iree_atomic_fetch_add(&dispatch_task->tile_index, tiles_per_reservation,
+                            iree_memory_order_relaxed);
   while (tile_base < tile_count) {
     const uint32_t tile_range =
         iree_min(tile_base + tiles_per_reservation, tile_count);
@@ -813,9 +811,9 @@ void iree_task_dispatch_shard_execute(
     }
 
     // Try to grab the next slice of tiles.
-    tile_base = iree_atomic_fetch_add_int32(&dispatch_task->tile_index,
-                                            tiles_per_reservation,
-                                            iree_memory_order_relaxed);
+    tile_base =
+        iree_atomic_fetch_add(&dispatch_task->tile_index, tiles_per_reservation,
+                              iree_memory_order_relaxed);
   }
 abort_shard:
 

--- a/runtime/src/iree/task/task_test_dispatch.cc
+++ b/runtime/src/iree/task/task_test_dispatch.cc
@@ -35,8 +35,7 @@ class GridCoverage {
   bool Verify() {
     fflush(stdout);
     for (iree_host_size_t i = 0; i < workgroup_count_; ++i) {
-      if (iree_atomic_load_int32(&storage_[i], iree_memory_order_seq_cst) !=
-          1) {
+      if (iree_atomic_load(&storage_[i], iree_memory_order_seq_cst) != 1) {
         return false;
       }
     }
@@ -52,8 +51,8 @@ class GridCoverage {
                                           tile_context->workgroup_count[0]) +
         tile_context->workgroup_xyz[1] * tile_context->workgroup_count[0] +
         tile_context->workgroup_xyz[0];
-    iree_atomic_fetch_add_int32(&coverage->storage_[slot], 1,
-                                iree_memory_order_seq_cst);
+    iree_atomic_fetch_add(&coverage->storage_[slot], 1,
+                          iree_memory_order_seq_cst);
 
     // Useful when testing large grids:
     // printf("%u, %u, %u\n", tile_context->workgroup_xyz[0],

--- a/runtime/src/iree/vm/context.c
+++ b/runtime/src/iree/vm/context.c
@@ -51,8 +51,8 @@ static iree_vm_context_id_t iree_vm_context_allocate_id(void) {
   static iree_atomic_int32_t next_context_id = IREE_ATOMIC_VAR_INIT(1);
   // relaxed because we only care about atomic increments, not ordering w.r.t.
   // other memory accesses.
-  uint32_t context_id = iree_atomic_fetch_add_int32(&next_context_id, 1,
-                                                    iree_memory_order_relaxed);
+  uint32_t context_id =
+      iree_atomic_fetch_add(&next_context_id, 1, iree_memory_order_relaxed);
 #if IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_FIBERS
   // This is what we pass to Tracy as the fiber name.
   // The string must remain live for the lifetime of the process.

--- a/runtime/src/iree/vm/invocation.c
+++ b/runtime/src/iree/vm/invocation.c
@@ -226,8 +226,8 @@ static iree_vm_invocation_id_t iree_vm_invoke_allocate_id(
     // The string must remain live for the lifetime of the process.
     // TODO(benvanik): name it based on the function?
     static iree_atomic_int32_t next_invocation_id = IREE_ATOMIC_VAR_INIT(1);
-    uint32_t invocation_id = iree_atomic_fetch_add_int32(
-        &next_invocation_id, 1, iree_memory_order_relaxed);
+    uint32_t invocation_id = iree_atomic_fetch_add(&next_invocation_id, 1,
+                                                   iree_memory_order_relaxed);
     IREE_LEAK_CHECK_DISABLE_PUSH();
     char* name = (char*)malloc(32);
     snprintf(name, 32, "invoke-%04d", invocation_id - 1);

--- a/runtime/src/iree/vm/ref_test.cc
+++ b/runtime/src/iree/vm/ref_test.cc
@@ -73,9 +73,9 @@ static iree_vm_ref_t MakeRef(InstancePtr& instance, const char* type_name) {
 // WARNING: this is an implementation detail and must never be relied on - it's
 // only here to test the expected behavior.
 static int32_t ReadCounter(iree_vm_ref_t* ref) {
-  return iree_atomic_load_int32((iree_atomic_ref_count_t*)ref->ptr +
-                                    (ref->type & IREE_VM_REF_TYPE_TAG_BIT_MASK),
-                                iree_memory_order_seq_cst);
+  return iree_atomic_load((iree_atomic_ref_count_t*)ref->ptr +
+                              (ref->type & IREE_VM_REF_TYPE_TAG_BIT_MASK),
+                          iree_memory_order_seq_cst);
 }
 
 }  // namespace


### PR DESCRIPTION
C11's _Generic lets us avoid the need for specifying the type in the name and more closely match the C11 atomic syntax. This assumes that any C compiler we have that goes down the disabled atomics path supports _Generic (modern GCC, Clang, and MSVC all have for awhile).

This allows us to drop-in replace C11-style atomics (useful in the new AMDGPU backend) and on MSVC will allow us to use their implementation when it's ready (it's way better than the Interlocked solution we have now).