### PR TITLE
Adding HAL semaphore support for statuses-as-failure-payloads.

### DIFF
--- a/runtime/src/iree/hal/cts/semaphore_submission_test.h
+++ b/runtime/src/iree/hal/cts/semaphore_submission_test.h
@@ -882,7 +882,7 @@ TEST_F(SemaphoreSubmissionTest, PropagateFailSignal) {
   EXPECT_EQ(iree_status_code(wait_status), IREE_STATUS_ABORTED);
   uint64_t value = 1234;
   iree_status_t query_status = iree_hal_semaphore_query(semaphore2, &value);
-  EXPECT_EQ(value, IREE_HAL_SEMAPHORE_FAILURE_VALUE);
+  EXPECT_GE(value, IREE_HAL_SEMAPHORE_FAILURE_VALUE);
   CheckStatusContains(query_status, status);
 
   signal_thread.join();

--- a/runtime/src/iree/hal/cts/semaphore_test.h
+++ b/runtime/src/iree/hal/cts/semaphore_test.h
@@ -406,7 +406,7 @@ TEST_F(SemaphoreTest, FailThenWait) {
   EXPECT_EQ(iree_status_code(wait_status), IREE_STATUS_ABORTED);
   uint64_t value = 1234;
   iree_status_t query_status = iree_hal_semaphore_query(semaphore, &value);
-  EXPECT_EQ(value, IREE_HAL_SEMAPHORE_FAILURE_VALUE);
+  EXPECT_GE(value, IREE_HAL_SEMAPHORE_FAILURE_VALUE);
   CheckStatusContains(query_status, status);
 
   iree_hal_semaphore_release(semaphore);
@@ -431,7 +431,7 @@ TEST_F(SemaphoreTest, WaitThenFail) {
   EXPECT_EQ(iree_status_code(wait_status), IREE_STATUS_ABORTED);
   uint64_t value = 1234;
   iree_status_t query_status = iree_hal_semaphore_query(semaphore, &value);
-  EXPECT_EQ(value, IREE_HAL_SEMAPHORE_FAILURE_VALUE);
+  EXPECT_GE(value, IREE_HAL_SEMAPHORE_FAILURE_VALUE);
   CheckStatusContains(query_status, status);
 
   signal_thread.join();
@@ -467,7 +467,7 @@ TEST_F(SemaphoreTest, MultiWaitThenFail) {
   uint64_t value = 1234;
   iree_status_t semaphore1_query_status =
       iree_hal_semaphore_query(semaphore1, &value);
-  EXPECT_EQ(value, IREE_HAL_SEMAPHORE_FAILURE_VALUE);
+  EXPECT_GE(value, IREE_HAL_SEMAPHORE_FAILURE_VALUE);
   CheckStatusContains(semaphore1_query_status, status);
 
   // semaphore2 must not have changed.
@@ -511,7 +511,7 @@ TEST_F(SemaphoreTest, DeviceMultiWaitThenFail) {
   uint64_t value = 1234;
   iree_status_t semaphore1_query_status =
       iree_hal_semaphore_query(semaphore1, &value);
-  EXPECT_EQ(value, IREE_HAL_SEMAPHORE_FAILURE_VALUE);
+  EXPECT_GE(value, IREE_HAL_SEMAPHORE_FAILURE_VALUE);
   CheckStatusContains(semaphore1_query_status, status);
 
   // semaphore2 must not have changed.

--- a/runtime/src/iree/hal/drivers/cuda/event_semaphore.c
+++ b/runtime/src/iree/hal/drivers/cuda/event_semaphore.c
@@ -325,7 +325,7 @@ static iree_status_t iree_hal_cuda_semaphore_wait(
   }
 
   iree_slim_mutex_lock(&semaphore->mutex);
-  if (semaphore->current_value == IREE_HAL_SEMAPHORE_FAILURE_VALUE) {
+  if (semaphore->current_value >= IREE_HAL_SEMAPHORE_FAILURE_VALUE) {
     iree_slim_mutex_unlock(&semaphore->mutex);
     IREE_TRACE_ZONE_END(z0);
     return iree_make_status(IREE_STATUS_ABORTED);
@@ -350,7 +350,7 @@ static iree_status_t iree_hal_cuda_semaphore_wait(
   }
 
   iree_slim_mutex_lock(&semaphore->mutex);
-  if (semaphore->current_value == IREE_HAL_SEMAPHORE_FAILURE_VALUE) {
+  if (semaphore->current_value >= IREE_HAL_SEMAPHORE_FAILURE_VALUE) {
     status = iree_make_status(IREE_STATUS_ABORTED);
   }
   iree_slim_mutex_unlock(&semaphore->mutex);
@@ -444,7 +444,7 @@ iree_status_t iree_hal_cuda_semaphore_multi_wait(
     iree_hal_cuda_semaphore_t* semaphore =
         iree_hal_cuda_semaphore_cast(semaphore_list.semaphores[i]);
     iree_slim_mutex_lock(&semaphore->mutex);
-    if (semaphore->current_value == IREE_HAL_SEMAPHORE_FAILURE_VALUE) {
+    if (semaphore->current_value >= IREE_HAL_SEMAPHORE_FAILURE_VALUE) {
       iree_slim_mutex_unlock(&semaphore->mutex);
       status = iree_make_status(IREE_STATUS_ABORTED);
       break;

--- a/runtime/src/iree/hal/drivers/hip/event_semaphore.c
+++ b/runtime/src/iree/hal/drivers/hip/event_semaphore.c
@@ -323,7 +323,7 @@ static iree_status_t iree_hal_hip_semaphore_wait(
   }
 
   iree_slim_mutex_lock(&semaphore->mutex);
-  if (semaphore->current_value == IREE_HAL_SEMAPHORE_FAILURE_VALUE) {
+  if (semaphore->current_value >= IREE_HAL_SEMAPHORE_FAILURE_VALUE) {
     iree_slim_mutex_unlock(&semaphore->mutex);
     IREE_TRACE_ZONE_END(z0);
     return iree_make_status(IREE_STATUS_ABORTED);
@@ -346,7 +346,7 @@ static iree_status_t iree_hal_hip_semaphore_wait(
   }
 
   iree_slim_mutex_lock(&semaphore->mutex);
-  if (semaphore->current_value == IREE_HAL_SEMAPHORE_FAILURE_VALUE) {
+  if (semaphore->current_value >= IREE_HAL_SEMAPHORE_FAILURE_VALUE) {
     status = iree_make_status(IREE_STATUS_ABORTED);
   }
   iree_slim_mutex_unlock(&semaphore->mutex);
@@ -440,7 +440,7 @@ iree_status_t iree_hal_hip_semaphore_multi_wait(
     iree_hal_hip_semaphore_t* semaphore =
         iree_hal_hip_semaphore_cast(semaphore_list.semaphores[i]);
     iree_slim_mutex_lock(&semaphore->mutex);
-    if (semaphore->current_value == IREE_HAL_SEMAPHORE_FAILURE_VALUE) {
+    if (semaphore->current_value >= IREE_HAL_SEMAPHORE_FAILURE_VALUE) {
       iree_slim_mutex_unlock(&semaphore->mutex);
       status = iree_make_status(IREE_STATUS_ABORTED);
       break;


### PR DESCRIPTION
This allows an implementation to have a single atomic value for a semaphore that encodes the user payload or an error payload that optionally references an iree_status_t object. Implementations not using the status feature can ignore it but must perform a greater-than-or-equal check on `IREE_HAL_SEMAPHORE_FAILURE_VALUE` instead of equality.