### PR TITLE
[GPU] Do not treat pad as a tilable producer for operand promotion

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromoteMatmulOperands.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromoteMatmulOperands.cpp
@@ -56,7 +56,8 @@ void promoteOperand(OpBuilder &builder, Operation *op, unsigned index) {
 
     // We only support thread tile size derivation of linalgOp and Im2colOp for
     // now.
-    if (isa<linalg::LinalgOp, IREE::LinalgExt::Im2colOp>(op)) {
+    if (isa<linalg::LinalgOp, IREE::LinalgExt::Im2colOp>(
+            producer.getOperation())) {
       setLoweringConfig(producer, IREE::GPU::DerivedThreadConfigAttr::get(
                                       builder.getContext()));
       return;

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromoteMatmulOperands.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromoteMatmulOperands.cpp
@@ -54,12 +54,9 @@ void promoteOperand(OpBuilder &builder, Operation *op, unsigned index) {
       }
     }
 
-    bool promoteProducer = true;
-    if (isa<tensor::PadOp>(producer)) {
-      promoteProducer = false;
-    }
-
-    if (promoteProducer) {
+    // We only support thread tile size derivation of linalgOp and Im2colOp for
+    // now.
+    if (isa<linalg::LinalgOp, IREE::LinalgExt::Im2colOp>(op)) {
       setLoweringConfig(producer, IREE::GPU::DerivedThreadConfigAttr::get(
                                       builder.getContext()));
       return;

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromoteMatmulOperands.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromoteMatmulOperands.cpp
@@ -53,9 +53,17 @@ void promoteOperand(OpBuilder &builder, Operation *op, unsigned index) {
         return;
       }
     }
-    setLoweringConfig(producer, IREE::GPU::DerivedThreadConfigAttr::get(
-                                    builder.getContext()));
-    return;
+
+    bool promoteProducer = true;
+    if (isa<tensor::PadOp>(producer)) {
+      promoteProducer = false;
+    }
+
+    if (promoteProducer) {
+      setLoweringConfig(producer, IREE::GPU::DerivedThreadConfigAttr::get(
+                                      builder.getContext()));
+      return;
+    }
   }
 
   auto tensorType = dyn_cast<RankedTensorType>(operand.getType());


### PR DESCRIPTION
PadOp doesn't have an implementation for deriving thread configuration from derived_thread_config, so ignore promoting it until an implementation is added.