### PR TITLE
[DispatchCreation] Run preprocessing before elementwise fusion

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -127,10 +127,12 @@ static void addCleanupPatterns(OpPassManager &passManager) {
 //===----------------------------------------------------------------------===//
 
 void addDispatchRegionCreationPreprocessingPasses(OpPassManager &passManager) {
-  // 1. Do some simple elementwise op fusion. This could be skipped,
-  //    but could reduce the surface area of ops to handle later.
   FunctionLikeNest(passManager)
+      .addPass(IREE::Flow::createCanonicalizerPass)
+      .addPass(mlir::createCSEPass)
       .addPass(DispatchCreation::createFusionPreprocessingPass)
+      // 1. Do some simple elementwise op fusion. This could be skipped,
+      //    but could reduce the surface area of ops to handle later.
       .addPass([]() {
         return DispatchCreation::createElementwiseOpFusionPass(
             ElementwiseOpFusionPassOptions{
@@ -295,12 +297,6 @@ void buildDispatchCreationPassPipeline(
     passManager.addPass(
         IREE::Util::createFixedPointIteratorPass(std::move(ipoPipeline)));
   }
-
-  FunctionLikeNest(passManager)
-      // Preprocess the input to a form more amenable for fusion.
-      .addPass(DispatchCreation::createFusionPreprocessingPass)
-      .addPass(IREE::Flow::createCanonicalizerPass)
-      .addPass(mlir::createCSEPass);
 
   addDispatchRegionCreationPreprocessingPasses(passManager);
   addDispatchRegionCreationPasses(passManager);

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -130,6 +130,7 @@ void addDispatchRegionCreationPreprocessingPasses(OpPassManager &passManager) {
   // 1. Do some simple elementwise op fusion. This could be skipped,
   //    but could reduce the surface area of ops to handle later.
   FunctionLikeNest(passManager)
+      .addPass(DispatchCreation::createFusionPreprocessingPass)
       .addPass([]() {
         return DispatchCreation::createElementwiseOpFusionPass(
             ElementwiseOpFusionPassOptions{
@@ -148,6 +149,7 @@ void addDispatchRegionCreationPreprocessingPasses(OpPassManager &passManager) {
 
       // 3. Perform elementwise operation fusion again (now with higher
       //    dimensionality).
+      .addPass(DispatchCreation::createFusionPreprocessingPass)
       .addPass([]() {
         return DispatchCreation::createElementwiseOpFusionPass(
             ElementwiseOpFusionPassOptions{


### PR DESCRIPTION
I think it makes sense to run `FusionPreprocessingPass` before `ElementwiseOpFusionPass` because it helps put the IR in a better state for fusion (e.g. interchanging `linalg.generic` indexing maps). But also, reshapes have been propagated to the edges of the program, which allows the `GatherFusionPattern` to be more effective.


Fixes compilation error from https://github.com/iree-org/iree/issues/17226#issuecomment-2441200369.