### PR TITLE
[GlobalOpt] Decompose low parallelism attention ops

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
+++ b/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
@@ -48,6 +48,7 @@ iree_compiler_cc_library(
         "Convert1X1FilterConv2DToMatmul.cpp",
         "DataLayoutPropagation.cpp",
         "DecomposeConcat.cpp",
+        "DecomposeLowParallelismAttentionPass.cpp",
         "DemoteContractionInputsToBF16.cpp",
         "DetachElementwiseFromNamedOps.cpp",
         "EraseUnusedLinalgOperands.cpp",

--- a/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
+++ b/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
@@ -44,6 +44,7 @@ iree_cc_library(
     "Convert1X1FilterConv2DToMatmul.cpp"
     "DataLayoutPropagation.cpp"
     "DecomposeConcat.cpp"
+    "DecomposeLowParallelismAttentionPass.cpp"
     "DemoteContractionInputsToBF16.cpp"
     "DetachElementwiseFromNamedOps.cpp"
     "EraseUnusedLinalgOperands.cpp"

--- a/compiler/src/iree/compiler/GlobalOptimization/DecomposeLowParallelismAttentionPass.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/DecomposeLowParallelismAttentionPass.cpp
@@ -1,0 +1,97 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "iree/compiler/Dialect/LinalgExt/Utils/IndexingUtils.h"
+#include "iree/compiler/GlobalOptimization/Passes.h"
+
+namespace mlir::iree_compiler::GlobalOptimization {
+
+#define GEN_PASS_DEF_DECOMPOSELOWPARALLELISMATTENTIONPASS
+#include "iree/compiler/GlobalOptimization/Passes.h.inc"
+
+using namespace IREE::LinalgExt;
+
+namespace {
+
+const int64_t kDynamicDimMaxValue = 65536; // 2^16
+/// TODO: The M heuristic is a conservative choice I(Groverkss) made.
+/// We ideally need more data to determine when it is good to
+/// decompose.
+const int64_t kMParallelismThreshold = 4;
+/// The K1 heuristic is simply based on the fact that if we have a tile size
+/// bigger than 256, we should probably be tiling that dimension. Non decomposed
+/// attention is not tilable along K1 diomension.
+const int64_t kK1ParallelismThreshold = 256;
+
+static int64_t calculateSize(ArrayRef<int64_t> bounds, ArrayRef<int64_t> dims) {
+  int64_t size = 1;
+  for (int64_t dim : dims) {
+    if (ShapedType::isDynamic(bounds[dim])) {
+      // TODO: We should query range information to find the maximum value
+      // possible instead.
+      size *= kDynamicDimMaxValue;
+    } else {
+      size *= bounds[dim];
+    }
+  }
+  return size;
+}
+
+static bool hasLowParallelism(AttentionOp attnOp) {
+  FailureOr<AttentionOpDetail> opInfo =
+      AttentionOpDetail::get(attnOp.getIndexingMapsArray());
+
+  FailureOr<SmallVector<int64_t>> maybeBounds = attnOp.getStaticLoopRanges();
+  if (failed(maybeBounds)) {
+    return false;
+  }
+
+  SmallVector<int64_t> bounds = maybeBounds.value();
+
+  int64_t mSize = calculateSize(bounds, opInfo->getMDims());
+  int64_t k1Size = calculateSize(bounds, opInfo->getK1Dims());
+
+  // TODO: Should we take batch size into account? Sometimes doing split-k
+  // gives you good parallelism.
+  if (mSize <= kMParallelismThreshold) {
+    return true;
+  }
+
+  if (k1Size >= kK1ParallelismThreshold) {
+    return true;
+  }
+
+  return false;
+}
+
+struct DecomposeLowParallelismAttentionPass
+    : public impl::DecomposeLowParallelismAttentionPassBase<
+          DecomposeLowParallelismAttentionPass> {
+
+  void runOnOperation() override {
+    SmallVector<AttentionOp> candidates;
+
+    getOperation()->walk([&candidates](AttentionOp attnOp) {
+      if (hasLowParallelism(attnOp)) {
+        candidates.push_back(attnOp);
+      }
+    });
+
+    for (AttentionOp attnOp : candidates) {
+      auto aggregateOp =
+          cast<linalg::AggregatedOpInterface>(attnOp.getOperation());
+      OpBuilder b(attnOp);
+      if (failed(aggregateOp.decomposeOperation(b))) {
+        return signalPassFailure();
+      }
+    }
+  }
+};
+
+} // namespace
+
+} // namespace mlir::iree_compiler::GlobalOptimization

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
@@ -110,6 +110,9 @@ void buildGlobalOptimizationPassPipeline(
   mainPassManager.addPass(createExpandTensorShapesPass());
 
   FunctionLikeNest(mainPassManager)
+      // Decompose attention operations which do not have enough parallelism to
+      // justify fused attention.
+      .addPass(createDecomposeLowParallelismAttentionPass)
       // Preprocess the input to a form more amenable for fusion
       // - Convert all elementwise ops to Linalg
       // - Remove unit-extent dimensions.

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.td
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.td
@@ -30,7 +30,7 @@ def DecomposeConcatPass :
 }
 
 def DecomposeLowParallelismAttentionPass :
-    Pass<"iree-global-opt-decompose-low-parallelism-attention-pass", ""> {
+    Pass<"iree-global-opt-decompose-low-parallelism-attention", ""> {
   let summary = "Decompose attention when we don't have enough parallelism"
                 "available in the attention operation.";
 }

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.td
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.td
@@ -29,6 +29,12 @@ def DecomposeConcatPass :
   ];
 }
 
+def DecomposeLowParallelismAttentionPass :
+    Pass<"iree-global-opt-decompose-low-parallelism-attention-pass", ""> {
+  let summary = "Decompose attention when we don't have enough parallelism"
+                "available in the attention operation.";
+}
+
 def DemoteContractionInputsToBF16Pass
     : Pass<"iree-global-opt-demote-contraction-inputs-to-bf16", ""> {
   let summary =

--- a/compiler/src/iree/compiler/GlobalOptimization/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/BUILD.bazel
@@ -20,6 +20,7 @@ iree_lit_test_suite(
             "conv1x1_to_matmul.mlir",
             "data_layout_propagation.mlir",
             "demote_contraction_inputs_to_bf16.mlir",
+            "decompose_low_parallelism_attention.mlir",
             "detach_elementwise_from_named_ops.mlir",
             "expand_tensor_shapes.mlir",
             "fuse_dequantization_matmul.mlir",

--- a/compiler/src/iree/compiler/GlobalOptimization/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/CMakeLists.txt
@@ -17,6 +17,7 @@ iree_lit_test_suite(
     "cleanup_numeric_narrowing.mlir"
     "conv1x1_to_matmul.mlir"
     "data_layout_propagation.mlir"
+    "decompose_low_parallelism_attention.mlir"
     "demote_contraction_inputs_to_bf16.mlir"
     "detach_elementwise_from_named_ops.mlir"
     "expand_tensor_shapes.mlir"

--- a/compiler/src/iree/compiler/GlobalOptimization/test/decompose_low_parallelism_attention.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/decompose_low_parallelism_attention.mlir
@@ -1,0 +1,67 @@
+// RUN: iree-opt --split-input-file --iree-global-opt-decompose-low-parallelism-attention --cse %s | FileCheck %s
+
+// CHECK-LABEL: @attention_small_m
+// CHECK-NOT: iree_linalg_ext.attention
+util.func @attention_small_m(%q : tensor<128x1x32x64xf16>,
+                             %k : tensor<128x1024x32x64xf16>,
+                             %v : tensor<128x1024x32x64xf16>)
+                             -> tensor<128x32x1x64xf16> {
+  %cst = arith.constant 1.250000e-01 : f16
+  %empty = tensor.empty() : tensor<128x32x1x64xf16>
+  %out = iree_linalg_ext.attention
+          {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d1, d4)>,
+          affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d5, d1, d4)>,
+          affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d5, d1, d3)>,
+          affine_map<(d0, d1, d2, d3, d4, d5) -> ()>,
+          affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>]}
+          ins(%q, %k, %v, %cst : tensor<128x1x32x64xf16>, tensor<128x1024x32x64xf16>, tensor<128x1024x32x64xf16>, f16)
+          outs(%empty : tensor<128x32x1x64xf16>) {
+            ^bb0(%score : f32):
+              iree_linalg_ext.yield %score : f32
+          }-> tensor<128x32x1x64xf16>
+  util.return %out : tensor<128x32x1x64xf16>
+}
+
+// CHECK-LABEL: @attention_large_k1
+// CHECK-NOT: iree_linalg_ext.attention
+util.func @attention_large_k1(%q : tensor<128x1024x32x512xf16>,
+                             %k : tensor<128x1024x32x512xf16>,
+                             %v : tensor<128x1024x32x64xf16>)
+                             -> tensor<128x32x1024x64xf16> {
+  %cst = arith.constant 1.250000e-01 : f16
+  %empty = tensor.empty() : tensor<128x32x1024x64xf16>
+  %out = iree_linalg_ext.attention
+          {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d1, d4)>,
+          affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d5, d1, d4)>,
+          affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d5, d1, d3)>,
+          affine_map<(d0, d1, d2, d3, d4, d5) -> ()>,
+          affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>]}
+          ins(%q, %k, %v, %cst : tensor<128x1024x32x512xf16>, tensor<128x1024x32x512xf16>, tensor<128x1024x32x64xf16>, f16)
+          outs(%empty : tensor<128x32x1024x64xf16>) {
+            ^bb0(%score : f32):
+              iree_linalg_ext.yield %score : f32
+          }-> tensor<128x32x1024x64xf16>
+  util.return %out : tensor<128x32x1024x64xf16>
+}
+
+// CHECK-LABEL: @attention_normal
+// CHECK: iree_linalg_ext.attention
+util.func @attention_normal(%q : tensor<128x1024x32x64xf16>,
+                             %k : tensor<128x1024x32x64xf16>,
+                             %v : tensor<128x1024x32x64xf16>)
+                             -> tensor<128x32x1024x64xf16> {
+  %cst = arith.constant 1.250000e-01 : f16
+  %empty = tensor.empty() : tensor<128x32x1024x64xf16>
+  %out = iree_linalg_ext.attention
+          {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d1, d4)>,
+          affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d5, d1, d4)>,
+          affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d5, d1, d3)>,
+          affine_map<(d0, d1, d2, d3, d4, d5) -> ()>,
+          affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>]}
+          ins(%q, %k, %v, %cst : tensor<128x1024x32x64xf16>, tensor<128x1024x32x64xf16>, tensor<128x1024x32x64xf16>, f16)
+          outs(%empty : tensor<128x32x1024x64xf16>) {
+            ^bb0(%score : f32):
+              iree_linalg_ext.yield %score : f32
+          }-> tensor<128x32x1024x64xf16>
+  util.return %out : tensor<128x32x1024x64xf16>
+}


### PR DESCRIPTION
This patch adds a pass in global optimization to decompose attention when there isn't enough parallelism to justify using fused attention.