### PR TITLE
[ROCM] Turn on SLP vectorization

### DIFF
--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -64,7 +64,7 @@ struct ROCMOptions {
   int wavesPerEu = 0;
   std::string enableROCMUkernels = "none";
   bool legacySync = true;
-  bool slpVectorization = false;
+  bool slpVectorization = true;
   bool globalISel = false;
 
   /// List of LLVM opt pass pluggins to be loaded during GPU code
@@ -113,11 +113,9 @@ struct ROCMOptions {
                  "to be passed to the target backend compiler during HIP "
                  "executable serialization"),
         cl::ZeroOrMore, cl::cat(category));
-    binder.opt<bool>(
-        "iree-hip-llvm-slp-vec", slpVectorization, cl::cat(category),
-        cl::desc(
-            "Enable slp vectorization in llvm opt. This can have an impact on "
-            "performance/numerics so its turned off by default currently."));
+    binder.opt<bool>("iree-hip-llvm-slp-vec", slpVectorization,
+                     cl::cat(category),
+                     cl::desc("Enable slp vectorization in llvm opt."));
     binder.opt<bool>("iree-hip-llvm-global-isel", globalISel, cl::cat(category),
                      cl::desc("Enable global instruction selection in llvm."));
   }


### PR DESCRIPTION
After doing review on the benchmarks we see that this is not causing any model regression and we also did a benchmarking suite of attention kernels for which in the past we thought this could cause a regression. However, we didnt find any significant perf change. See [here](https://docs.google.com/spreadsheets/d/102hYwdOGehmi_HhnLxHevwAVzMraKgKEjdTdUlJ4_TU/edit?usp=sharing)
As this is needed for correctness issue found in https://github.com/iree-org/iree/issues/18798 we are turning on the SLP vectorizer.