### PR TITLE
[Codegen][ROCm] Drop assume alignments

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -84,6 +84,23 @@ iree_compiler_cc_library(
 )
 
 iree_compiler_cc_library(
+    name = "LLVMLowerings",
+    srcs = [
+        "LLVMLowerings.cpp",
+    ],
+    hdrs = [
+        "LLVMLowerings.h",
+    ],
+    deps = [
+        "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
+        "//llvm-external-projects/iree-dialects:IREELinalgTransformDialect",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:LLVMCommonConversion",
+        "@llvm-project//mlir:LLVMDialect",
+    ],
+)
+
+iree_compiler_cc_library(
     name = "Common",
     srcs = [
         "AddFastMathFlags.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/BufferizeCopyOnlyDispatchesPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BufferizeCopyOnlyDispatchesPass.cpp
@@ -13,6 +13,7 @@
 
 #include "iree/compiler/Codegen/Common/PassUtils.h"
 #include "iree/compiler/Codegen/Common/Passes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
@@ -44,7 +45,8 @@ struct BufferizeCopyOnlyDispatchesPass final
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<affine::AffineDialect, bufferization::BufferizationDialect,
                     IREE::Flow::FlowDialect, linalg::LinalgDialect,
-                    memref::MemRefDialect, tensor::TensorDialect>();
+                    memref::MemRefDialect, tensor::TensorDialect,
+                    IREE::Codegen::IREECodegenDialect>();
   }
 
   void runOnOperation() override;

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -66,6 +66,22 @@ iree_cc_library(
 
 iree_cc_library(
   NAME
+    LLVMLowerings
+  HDRS
+    "LLVMLowerings.h"
+  SRCS
+    "LLVMLowerings.cpp"
+  DEPS
+    IREELinalgTransformDialect
+    LLVMSupport
+    MLIRLLVMCommonConversion
+    MLIRLLVMDialect
+    iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
     Common
   HDRS
     "BufferizationAnalysis.h"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/Common/GPU/Passes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
@@ -96,7 +97,8 @@ moveScalarAndBindingUniformCode(vector::WarpExecuteOnLane0Op warpOp) {
       return true;
 
     if (isa<IREE::HAL::InterfaceBindingSubspanOp,
-            IREE::HAL::InterfaceConstantLoadOp, memref::AssumeAlignmentOp>(op))
+            IREE::HAL::InterfaceConstantLoadOp, memref::AssumeAlignmentOp,
+            IREE::Codegen::AssumeAlignmentOp>(op))
       return true;
     if (isUniformLoad(op))
       return true;

--- a/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "iree/compiler/Codegen/Common/Passes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
 #include "iree/compiler/Codegen/Interfaces/BufferizationInterfaces.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
@@ -103,6 +104,7 @@ public:
                 bufferization::BufferizationDialect,
                 func::FuncDialect,
                 gpu::GPUDialect,
+                IREE::Codegen::IREECodegenDialect,
                 IREE::Flow::FlowDialect,
                 IREE::LinalgExt::IREELinalgExtDialect,
                 IREE::Util::UtilDialect,

--- a/compiler/src/iree/compiler/Codegen/Common/LLVMLowerings.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LLVMLowerings.cpp
@@ -1,0 +1,74 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/LLVMLowerings.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
+#include "llvm/Support/MathExtras.h"
+#include "mlir/Conversion/LLVMCommon/Pattern.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+
+#define DEBUG_TYPE "iree-codegen-expand-strided-metadata"
+
+namespace mlir::iree_compiler {
+
+namespace {
+
+struct AssumeAlignmentOpLowering
+    : public ConvertOpToLLVMPattern<IREE::Codegen::AssumeAlignmentOp> {
+  using ConvertOpToLLVMPattern<
+      IREE::Codegen::AssumeAlignmentOp>::ConvertOpToLLVMPattern;
+  explicit AssumeAlignmentOpLowering(const LLVMTypeConverter &converter)
+      : ConvertOpToLLVMPattern<IREE::Codegen::AssumeAlignmentOp>(converter) {}
+
+  LogicalResult
+  matchAndRewrite(IREE::Codegen::AssumeAlignmentOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Value memref = adaptor.getSource();
+    unsigned alignment = op.getAlignment();
+    auto loc = op.getLoc();
+
+    auto srcMemRefType = cast<MemRefType>(op.getSource().getType());
+    Value ptr = getStridedElementPtr(loc, srcMemRefType, memref, /*indices=*/{},
+                                     rewriter);
+
+    // TODO: Handle non-power of 2 alignments.
+    if (!llvm::isPowerOf2_32(alignment)) {
+      rewriter.eraseOp(op);
+      return success();
+    }
+
+    // Emit llvm.intr.ptrmask(memref, -alignment)) for power of 2
+    // alignments.
+    MemRefDescriptor memRefDescriptor(memref);
+    auto intPtrType =
+        getIntPtrType(memRefDescriptor.getElementPtrType().getAddressSpace());
+    // If alignment is a power of 2, -alignment will be
+    // 0b11...1[0 x log_2(alignment)] by 2's complement which is exactly the
+    // mask we want.
+    int64_t maskVal = -alignment;
+    Value mask = createIndexAttrConstant(rewriter, loc, intPtrType, maskVal);
+    StringAttr intrName = rewriter.getStringAttr("llvm.ptrmask");
+    Value newPtrValue = rewriter
+                            .create<LLVM::CallIntrinsicOp>(
+                                loc, memRefDescriptor.getElementPtrType(),
+                                intrName, ValueRange{ptr, mask})
+                            .getResult(0);
+    memRefDescriptor.setAllocatedPtr(rewriter, op.getLoc(), newPtrValue);
+    rewriter.replaceOp(op, (Value)memRefDescriptor);
+
+    return success();
+  }
+};
+
+} // namespace
+
+void populateConvertIREECodegenToLLVMPatterns(
+    const LLVMTypeConverter &typeConverter, RewritePatternSet &patterns) {
+  patterns.add<AssumeAlignmentOpLowering>(typeConverter);
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/LLVMLowerings.h
+++ b/compiler/src/iree/compiler/Codegen/Common/LLVMLowerings.h
@@ -1,0 +1,21 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_COMMON_LLVMLOWERINGS_H_
+#define IREE_COMPILER_CODEGEN_COMMON_LLVMLOWERINGS_H_
+
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/IR/PatternMatch.h"
+
+namespace mlir::iree_compiler {
+
+/// Populate patterns to lower iree_codegen ops to LLVM.
+void populateConvertIREECodegenToLLVMPatterns(
+    const LLVMTypeConverter &typeConverter, RewritePatternSet &patterns);
+
+} // namespace mlir::iree_compiler
+
+#endif // IREE_COMPILER_CODEGEN_COMMON_LLVMLOWERINGS_H_

--- a/compiler/src/iree/compiler/Codegen/Common/test/bufferize_copy_only_dispatches.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/bufferize_copy_only_dispatches.mlir
@@ -42,9 +42,11 @@ func.func @tensor_insert_slice() {
 //  CHECK-DAG:   %[[SOURCE_STRIDE_Y:.+]] = hal.interface.constant.load layout({{.+}}) ordinal(7)
 //  CHECK-DAG:   %[[SOURCE_STRIDE_X:.+]] = hal.interface.constant.load layout({{.+}}) ordinal(8)
 //  CHECK-DAG:   %[[SOURCE:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)
+//  CHECK-DAG:   %[[SOURCE_ASSUME:.+]] = iree_codegen.assume_alignment %[[SOURCE]]
 //  CHECK-DAG:   %[[DEST:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)
-//  CHECK-DAG:   %[[SOURCE_SUBVIEW:.+]] = memref.subview %[[SOURCE]][%[[SOURCE_OFFSET_Y]], %[[SOURCE_OFFSET_X]]] [1, %[[SLICE_SIZE]]] [%[[SOURCE_STRIDE_Y]], %[[SOURCE_STRIDE_X]]]
-//  CHECK-DAG:   %[[DEST_SUBVIEW:.+]] = memref.subview %[[DEST]][%[[DEST_OFFSET_Y]], %[[DEST_OFFSET_X]]] [%[[SLICE_SIZE]], 1] [%[[DEST_STRIDE_Y]], %[[DEST_STRIDE_X]]]
+//  CHECK-DAG:   %[[DEST_ASSUME:.+]] = iree_codegen.assume_alignment %[[DEST]]
+//  CHECK-DAG:   %[[SOURCE_SUBVIEW:.+]] = memref.subview %[[SOURCE_ASSUME]][%[[SOURCE_OFFSET_Y]], %[[SOURCE_OFFSET_X]]] [1, %[[SLICE_SIZE]]] [%[[SOURCE_STRIDE_Y]], %[[SOURCE_STRIDE_X]]]
+//  CHECK-DAG:   %[[DEST_SUBVIEW:.+]] = memref.subview %[[DEST_ASSUME]][%[[DEST_OFFSET_Y]], %[[DEST_OFFSET_X]]] [%[[SLICE_SIZE]], 1] [%[[DEST_STRIDE_Y]], %[[DEST_STRIDE_X]]]
 //      CHECK:   linalg.generic
 // CHECK-SAME:       ins(%[[SOURCE_SUBVIEW]] :
 // CHECK-SAME:       outs(%[[DEST_SUBVIEW]] :
@@ -66,9 +68,11 @@ func.func @UpSampling1D() {
 
 // CHECK-LABEL: func.func @UpSampling1D()
 //   CHECK-DAG:   %[[DEST:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)
+//   CHECK-DAG:   %[[DEST_ASSUME:.+]] = iree_codegen.assume_alignment %[[DEST]]
 //   CHECK-DAG:   %[[SOURCE:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)
-//   CHECK-DAG:   %[[SOURCE_SUBVIEW:.+]] = memref.subview %[[SOURCE]][0, 0, 0] [2, 1, 3]
-//   CHECK-DAG:   %[[DEST_SUBVIEW:.+]] = memref.subview %[[DEST]][0, 0, 0] [2, 1, 3]
+//   CHECK-DAG:   %[[SOURCE_ASSUME:.+]] = iree_codegen.assume_alignment %[[SOURCE]]
+//   CHECK-DAG:   %[[SOURCE_SUBVIEW:.+]] = memref.subview %[[SOURCE_ASSUME]][0, 0, 0] [2, 1, 3]
+//   CHECK-DAG:   %[[DEST_SUBVIEW:.+]] = memref.subview %[[DEST_ASSUME]][0, 0, 0] [2, 1, 3]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:       ins(%[[SOURCE_SUBVIEW]] : memref<2x3xf32, strided<[24, 1]>, #hal.descriptor_type<uniform_buffer>>)
 //  CHECK-SAME:       outs(%[[DEST_SUBVIEW]] : memref<2x3xf32, strided<[48, 1]>, #hal.descriptor_type<storage_buffer>>)
@@ -90,7 +94,8 @@ func.func @concatenate_cst() {
 //   CHECK-DAG:   %[[CST:.+]] = arith.constant dense<0> : tensor<2x3xi32>
 //   CHECK-DAG:   %[[ZERO:.+]] = bufferization.to_memref %[[CST]] : memref<2x3xi32
 //   CHECK-DAG:   %[[DEST_BINDING:.+]] = hal.interface.binding.subspan
-//   CHECK-DAG:   %[[SUBVIEW:.+]] = memref.subview %[[DEST_BINDING]][0, 2] [2, 3]
+//   CHECK-DAG:   %[[ASSUME:.+]] = iree_codegen.assume_alignment
+//   CHECK-DAG:   %[[SUBVIEW:.+]] = memref.subview %[[ASSUME]][0, 2] [2, 3]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:       ins(%[[ZERO]] :
 //  CHECK-SAME:       outs(%[[SUBVIEW]] :

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
@@ -16,6 +16,42 @@ include "mlir/Interfaces/InferTypeOpInterface.td"
 
 def TensorTypeAttr : TypeAttrBase<"TensorType", "Tensor type attribute">;
 
+//===----------------------------------------------------------------------===//
+// AssumeAlignmentOp
+//===----------------------------------------------------------------------===//
+
+def IREECodegen_AssumeAlignmentOp : Op<IREECodegen_Dialect, "assume_alignment", [
+    Pure,
+    ViewLikeOpInterface,
+    SameOperandsAndResultType]> {
+  let summary = "Assumes the base alignment of the given memref and returns it";
+  let description = [{
+    This op carries the same semantics as memref::AssumeAlignmentOp upstream,
+    except it also returns the source memref to keep the assume as a part of
+    the use-def chain.
+  }];
+
+  let arguments = (ins
+    AnyStridedMemRef:$source,
+    ConfinedAttr<I32Attr, [IntPositive]>:$alignment
+  );
+  let results = (outs
+    AnyStridedMemRef:$result
+  );
+
+  let assemblyFormat = [{
+    $source `,` $alignment attr-dict `:` type($result)
+  }];
+
+  let extraClassDeclaration = [{
+    ::mlir::Value getViewSource() { return getSource(); }
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// QueryTileSizesOp
+//===----------------------------------------------------------------------===//
+
 def IREECodegen_QueryTileSizesOp :
     Op<IREECodegen_Dialect, "query_tile_sizes", [Pure]> {
   let summary = "Query tile sizes";
@@ -100,8 +136,6 @@ def IREECodegen_ExtractStridedMetadataOp : Op<IREECodegen_Dialect, "extract_stri
     ::mlir::Value getViewSource() { return getSource(); }
   }];
 }
-
-
 
 
 #endif // IREE_CODEGEN_DIALECT_IREECODEGENOPS

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/invalid.mlir
@@ -1,5 +1,21 @@
 // RUN: iree-opt --split-input-file --verify-diagnostics %s
 
+module {
+  func.func @negative_alignment(%src: memref<?x?xi32>) -> memref<?x?xi32> {
+    %0 = iree_codegen.assume_alignment %src, -1 : memref<?x?xi32>
+    return %0 : memref<?x?xi32>
+  }
+}
+
+// -----
+
+module {
+  func.func @type_mismatch(%src: memref<?x?xi32>) -> memref<?xi32> {
+    %0 = iree_codegen.assume_alignment %src, 1 : memref<?xi32>
+    return %0 : memref<?xi32>
+  }
+}
+
 // -----
 
 module {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD.bazel
@@ -89,6 +89,7 @@ iree_compiler_cc_library(
         ":PassHeaders",
         ":PassesIncGen",
         "//compiler/src/iree/compiler/Codegen/Common",
+        "//compiler/src/iree/compiler/Codegen/Common:LLVMLowerings",
         "//compiler/src/iree/compiler/Codegen/Common:TransformDialectInterpreterPass",
         "//compiler/src/iree/compiler/Codegen/Common/CPU:CommonCPUPasses",
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
@@ -148,6 +148,7 @@ iree_cc_library(
     MLIRX86VectorTransforms
     iree::compiler::Codegen::Common
     iree::compiler::Codegen::Common::CPU::CommonCPUPasses
+    iree::compiler::Codegen::Common::LLVMLowerings
     iree::compiler::Codegen::Common::TransformDialectInterpreterPass
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
     iree::compiler::Codegen::Interfaces::PartitionableLoopsInterface

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -4,6 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree/compiler/Codegen/Common/LLVMLowerings.h"
 #include "iree/compiler/Codegen/Common/PassUtils.h"
 #include "iree/compiler/Codegen/LLVMCPU/DispatchABI.h"
 #include "iree/compiler/Codegen/LLVMCPU/Passes.h"
@@ -1051,6 +1052,7 @@ void ConvertToLLVMPass::runOnOperation() {
   populateVectorToLLVMMatrixConversionPatterns(typeConverter, patterns);
   populateVectorToLLVMConversionPatterns(typeConverter, patterns,
                                          reassociateFpReductions);
+  populateConvertIREECodegenToLLVMPatterns(typeConverter, patterns);
 
   if (isAArch64(targetAttr) &&
       (hasAnySVEFeature(targetAttr) || hasSMEFeature(targetAttr))) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
@@ -127,6 +127,7 @@ iree_compiler_cc_library(
         ":ROCDLPassHeaders",
         ":ROCDLPassesIncGen",
         "//compiler/src/iree/compiler/Codegen/Common",
+        "//compiler/src/iree/compiler/Codegen/Common:LLVMLowerings",
         "//compiler/src/iree/compiler/Codegen/Common:TransformDialectInterpreterPass",
         "//compiler/src/iree/compiler/Codegen/Common:VectorLayoutAnalysis",
         "//compiler/src/iree/compiler/Codegen/Common/GPU:CommonGPUPasses",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -172,6 +172,7 @@ iree_cc_library(
     iree::compiler::Codegen::Common
     iree::compiler::Codegen::Common::GPU::CommonGPUPasses
     iree::compiler::Codegen::Common::GPU::GPUHeuristics
+    iree::compiler::Codegen::Common::LLVMLowerings
     iree::compiler::Codegen::Common::TransformDialectInterpreterPass
     iree::compiler::Codegen::Common::VectorLayoutAnalysis
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -66,8 +66,21 @@ struct ReplaceGPUBarrierWithLDSBarrier
   }
 };
 
+struct RemoveAssumeAlignOp
+    : public OpRewritePattern<memref::AssumeAlignmentOp> {
+public:
+  using OpRewritePattern<memref::AssumeAlignmentOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(memref::AssumeAlignmentOp op,
+                                PatternRewriter &rewriter) const override {
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 static void populateConvertGPUToAMDGPUPatterns(RewritePatternSet &patterns) {
   patterns.add<ReplaceGPUBarrierWithLDSBarrier>(patterns.getContext());
+  patterns.add<RemoveAssumeAlignOp>(patterns.getContext());
 }
 
 } // namespace


### PR DESCRIPTION
This reportedly hurts the LLVM optimizer. We may want to find a better way to annotate alignments.