### PR TITLE
GPU data tiling: reimplement getConcreteMFMALayout

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/amdgpu_set_anchor_layouts.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/amdgpu_set_anchor_layouts.mlir
@@ -80,7 +80,7 @@ builtin.module attributes { transform.with_named_sequence } {
     %rhs = vector.transfer_read %b[%c0, %c0], %cst_0 {in_bounds = [true, true]} : memref<16x16xf16>, vector<16x16xf16>
     // expected-remark @above {{layout of result #0 is #iree_vector_ext.layout<<[ BATCHX,  LANEX], [1, 16]>, <[ BATCHY,  LANEY,  VECTORX], [1, 1, 16]>>}}
     %output = vector.contract {indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %lhs, %rhs, %init : vector<16x16xf16>, vector<16x16xf16> into vector<16x16xf32>
-    // expected-remark @above {{layout of result #0 is #iree_vector_ext.layout<<[ BATCHX,  VECTORY,  LANEY,  VECTORX], [1, 8, 2, 1]>, <[ BATCHY,  LANEX], [1, 16]>>}}
+    // expected-remark @above {{layout of result #0 is #iree_vector_ext.layout<<[ BATCHX,  VECTORX,  LANEY], [1, 8, 2]>, <[ BATCHY,  LANEX], [1, 16]>>}}
     return %output : vector<16x16xf32>
   }
   transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {


### PR DESCRIPTION
This `getConcreteMFMALayout` function had its own independent database of layout details for MMA intrinsics. Instead, reimplement it using the tile swizzle infra (which gets its information about layout of MMA intrinsics from `getSingleSubgroupLayout`).

Since this function is exercised by lit tests covering RDNA3 WMMA intrinsics with zero strides, this forced solving the issue about that in GPUTileSwizzleUtils.cpp, a blocker for GPU data tiling on RDNA3.