### PR TITLE
[DT] Fold tensor.extract_slice away when turning encodings into NOP.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoNop.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoNop.cpp
@@ -11,6 +11,7 @@
 #include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -25,6 +26,18 @@ using namespace IREE::Encoding;
 
 namespace {
 
+/// Folds the tensor.extract_slice ops away when
+///    1. The source is unset_encoding
+///    2. The converted source and the result of the tensor.extract_slice op
+///       have the same type.
+/// If they static shapes, it can be folded away iff they have the same type.
+/// If one of dimensions is dynamic we can unconditionally remove the
+/// tensor.extract_slice op because the op won't be folded away unless the
+/// folding extract_slice(extract_slice) patterns are kicked in. This pattern is
+/// fragile in the case that we set encoding at program level. Because we can't
+/// expect what patterns are run after SetEncoding pass. However, it should be
+/// fine when we switch to data-tiling fusion path which set the encodings at
+/// dispatch level.
 struct FoldAwayExtractSliceOnUnsetEncodingPattern
     : public OpConversionPattern<tensor::ExtractSliceOp> {
   using OpConversionPattern<tensor::ExtractSliceOp>::OpConversionPattern;
@@ -37,6 +50,9 @@ struct FoldAwayExtractSliceOnUnsetEncodingPattern
     if (!unsetEncodingOp) {
       return rewriter.notifyMatchFailure(op,
                                          "source is not an unset_encoding op");
+    }
+    if (adaptor.getSource().getType() != op.getResultType()) {
+      return failure();
     }
     rewriter.replaceOp(op, adaptor.getSource());
     return success();

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_into_nop.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_into_nop.mlir
@@ -239,14 +239,19 @@ func.func @drop_encoding_for_hal_flow_ops_dynamic() {
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d1, d2)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#encoding_lhs = #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], round_dims_to = array<i64: 32, 32, 32>>
+#encoding_rhs = #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], round_dims_to = array<i64: 32, 32, 32>>
+#encoding_acc = #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], round_dims_to = array<i64: 32, 32, 32>>
 func.func @fold_extract_slice_away(%arg0: tensor<?x16384xf16>, %arg1: tensor<16384x16384xf16>, %arg2: tensor<?x16384xf32>) -> tensor<?x16384xf32> {
   %c0 = arith.constant 0 : index
-  %0 = iree_encoding.set_encoding %arg0 : tensor<?x16384xf16> -> tensor<?x16384xf16, #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], round_dims_to = array<i64: 32, 32, 32>>>
-  %1 = iree_encoding.set_encoding %arg1 : tensor<16384x16384xf16> -> tensor<16384x16384xf16, #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], round_dims_to = array<i64: 32, 32, 32>>>
-  %2 = iree_encoding.set_encoding %arg2 : tensor<?x16384xf32> -> tensor<?x16384xf32, #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], round_dims_to = array<i64: 32, 32, 32>>>
-  %3 = linalg.matmul_transpose_b ins(%0, %1 : tensor<?x16384xf16, #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], round_dims_to = array<i64: 32, 32, 32>>>, tensor<16384x16384xf16, #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], round_dims_to = array<i64: 32, 32, 32>>>) outs(%2 : tensor<?x16384xf32, #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], round_dims_to = array<i64: 32, 32, 32>>>) -> tensor<?x16384xf32, #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], round_dims_to = array<i64: 32, 32, 32>>>
+  %0 = iree_encoding.set_encoding %arg0 : tensor<?x16384xf16> -> tensor<?x16384xf16, #encoding_lhs>
+  %1 = iree_encoding.set_encoding %arg1 : tensor<16384x16384xf16> -> tensor<16384x16384xf16, #encoding_rhs>
+  %2 = iree_encoding.set_encoding %arg2 : tensor<?x16384xf32> -> tensor<?x16384xf32, #encoding_acc>
+  %3 = linalg.matmul_transpose_b
+    ins(%0, %1 : tensor<?x16384xf16, #encoding_lhs>, tensor<16384x16384xf16, #encoding_rhs>)
+    outs(%2 : tensor<?x16384xf32, #encoding_acc>) -> tensor<?x16384xf32, #encoding_acc>
   %dim = tensor.dim %arg2, %c0 : tensor<?x16384xf32>
-  %4 = iree_encoding.unset_encoding %3 : tensor<?x16384xf32, #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], round_dims_to = array<i64: 32, 32, 32>>> -> tensor<?x16384xf32>
+  %4 = iree_encoding.unset_encoding %3 : tensor<?x16384xf32, #encoding_acc> -> tensor<?x16384xf32>
   %extracted_slice = tensor.extract_slice %4[0, 0] [%dim, 16384] [1, 1] : tensor<?x16384xf32> to tensor<?x16384xf32>
   return %extracted_slice : tensor<?x16384xf32>
 }


### PR DESCRIPTION
For static cases, it happens natrually because all the shapes are statically-known. In the dynamic case, it is not easy to idenfity the pattern because it could be a chain of the linalg/tensor operations. See below snippet for examples.

Thus, the revision adds a pattern which turns tensor.extract_slice op away when the source was from unset_encoding op.

```mlir
%41 = arith.muli %0, %c4 : index
%42 = tensor.empty(%41) : tensor<?x16384xf32>
%43 = linalg.fill ins(%cst : f32) outs(%42 : tensor<?x16384xf32>) -> tensor<?x16384xf32>
%44 = linalg.matmul_transpose_b ins(%lhs, %rhs : tensor<?x16384xf16>, tensor<16384x16384xf16>) outs(%43 : tensor<?x16384xf32>) -> tensor<?x16384xf32>
%extracted_slice_11 = tensor.extract_slice %44[0, 0] [%41, 16384] [1, 1] : tensor<?x16384xf32> to tensor<?x16384xf32>
```

Fixes https://github.com/iree-org/iree/issues/18956