### PR TITLE
Only add cpu-features test suffixes on `llvm-cpu` target backend

### DIFF
--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -458,15 +458,17 @@ function(iree_check_test_suite)
     list(GET _RULE_TARGET_BACKENDS ${_INDEX} _TARGET_BACKEND)
     list(GET _RULE_DRIVERS ${_INDEX} _DRIVER)
     foreach(_VARIANT_STRING IN LISTS _TARGET_CPU_FEATURES_VARIANTS)
-      parse_target_cpu_features_variant("${_VARIANT_STRING}"
-        _ENABLED _TARGET_CPU_FEATURES_NAME _VARIANT_COMPILER_FLAGS)
-      if(NOT _ENABLED)
-        # The current entry is disabled on the target CPU architecture.
-        continue()
+      if(_TARGET_BACKEND STREQUAL "llvm-cpu")
+        parse_target_cpu_features_variant("${_VARIANT_STRING}"
+          _ENABLED _TARGET_CPU_FEATURES_NAME _VARIANT_COMPILER_FLAGS)
+        if(NOT _ENABLED)
+          # The current entry is disabled on the target CPU architecture.
+          continue()
+        endif()
       endif()
       set(_TARGET_CPU_FEATURES_SUFFIX "")
       set(_LABELS "${_RULE_LABELS}")
-      if (_TARGET_CPU_FEATURES_NAME)
+      if(_TARGET_CPU_FEATURES_NAME)
         set(_TARGET_CPU_FEATURES_SUFFIX "_${_TARGET_CPU_FEATURES_NAME}")
         list(APPEND _LABELS "cpu_features=${_TARGET_CPU_FEATURES_NAME}")
       endif()

--- a/build_tools/cmake/iree_e2e_generated_runner_test.cmake
+++ b/build_tools/cmake/iree_e2e_generated_runner_test.cmake
@@ -454,11 +454,13 @@ function(iree_generated_e2e_runner_test)
     list(GET _RULE_TARGET_BACKENDS ${_INDEX} _TARGET_BACKEND)
     list(GET _RULE_DRIVERS ${_INDEX} _DRIVER)
     foreach(_VARIANT_STRING IN LISTS _TARGET_CPU_FEATURES_VARIANTS)
-      parse_target_cpu_features_variant("${_VARIANT_STRING}"
-        _ENABLED _TARGET_CPU_FEATURES_NAME _VARIANT_COMPILER_FLAGS)
-      if(NOT _ENABLED)
-        # The current entry is disabled on the target CPU architecture.
-        continue()
+      if(_TARGET_BACKEND STREQUAL "llvm-cpu")
+        parse_target_cpu_features_variant("${_VARIANT_STRING}"
+          _ENABLED _TARGET_CPU_FEATURES_NAME _VARIANT_COMPILER_FLAGS)
+        if(NOT _ENABLED)
+          # The current entry is disabled on the target CPU architecture.
+          continue()
+        endif()
       endif()
       set(_TARGET_CPU_FEATURES_SUFFIX "")
       set(_LABELS "${_RULE_LABELS}")


### PR DESCRIPTION
CPU features only concern `llvm-cpu` and the current logic was adding useless `_generic` suffixes to all non-llvmcpu tests.