### PR TITLE
Clean up e2e matmul tests on CDNA3

### DIFF
--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -458,15 +458,17 @@ function(iree_check_test_suite)
     list(GET _RULE_TARGET_BACKENDS ${_INDEX} _TARGET_BACKEND)
     list(GET _RULE_DRIVERS ${_INDEX} _DRIVER)
     foreach(_VARIANT_STRING IN LISTS _TARGET_CPU_FEATURES_VARIANTS)
-      parse_target_cpu_features_variant("${_VARIANT_STRING}"
-        _ENABLED _TARGET_CPU_FEATURES_NAME _VARIANT_COMPILER_FLAGS)
-      if(NOT _ENABLED)
-        # The current entry is disabled on the target CPU architecture.
-        continue()
+      if(_TARGET_BACKEND STREQUAL "llvm-cpu")
+        parse_target_cpu_features_variant("${_VARIANT_STRING}"
+          _ENABLED _TARGET_CPU_FEATURES_NAME _VARIANT_COMPILER_FLAGS)
+        if(NOT _ENABLED)
+          # The current entry is disabled on the target CPU architecture.
+          continue()
+        endif()
       endif()
       set(_TARGET_CPU_FEATURES_SUFFIX "")
       set(_LABELS "${_RULE_LABELS}")
-      if (_TARGET_CPU_FEATURES_NAME)
+      if(_TARGET_CPU_FEATURES_NAME)
         set(_TARGET_CPU_FEATURES_SUFFIX "_${_TARGET_CPU_FEATURES_NAME}")
         list(APPEND _LABELS "cpu_features=${_TARGET_CPU_FEATURES_NAME}")
       endif()

--- a/build_tools/cmake/iree_e2e_generated_runner_test.cmake
+++ b/build_tools/cmake/iree_e2e_generated_runner_test.cmake
@@ -454,11 +454,13 @@ function(iree_generated_e2e_runner_test)
     list(GET _RULE_TARGET_BACKENDS ${_INDEX} _TARGET_BACKEND)
     list(GET _RULE_DRIVERS ${_INDEX} _DRIVER)
     foreach(_VARIANT_STRING IN LISTS _TARGET_CPU_FEATURES_VARIANTS)
-      parse_target_cpu_features_variant("${_VARIANT_STRING}"
-        _ENABLED _TARGET_CPU_FEATURES_NAME _VARIANT_COMPILER_FLAGS)
-      if(NOT _ENABLED)
-        # The current entry is disabled on the target CPU architecture.
-        continue()
+      if(_TARGET_BACKEND STREQUAL "llvm-cpu")
+        parse_target_cpu_features_variant("${_VARIANT_STRING}"
+          _ENABLED _TARGET_CPU_FEATURES_NAME _VARIANT_COMPILER_FLAGS)
+        if(NOT _ENABLED)
+          # The current entry is disabled on the target CPU architecture.
+          continue()
+        endif()
       endif()
       set(_TARGET_CPU_FEATURES_SUFFIX "")
       set(_LABELS "${_RULE_LABELS}")

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -1368,7 +1368,7 @@ list(APPEND IREE_HIP_TEST_COMPILER_FLAGS
 
 iree_generated_e2e_runner_test(
   NAME
-    e2e_matmul_rocm_f16_large_cdna3_mfma
+    e2e_matmul_cdna3_vecdistmfma_f16
   TEST_TYPE
     matmul
   GENERATOR
@@ -1396,7 +1396,7 @@ iree_generated_e2e_runner_test(
 
 iree_generated_e2e_runner_test(
   NAME
-    e2e_matmul_rocm_f32_large_cdna3_mfma
+    e2e_matmul_cdna3_vecdistmfma_f32
   TEST_TYPE
     matmul
   GENERATOR
@@ -1424,7 +1424,7 @@ iree_generated_e2e_runner_test(
 
 iree_generated_e2e_runner_test(
   NAME
-    e2e_matmul_rocm_f16_large_cdna3_mfma_tb
+    e2e_matmul_cdna3_vecdistmfma_tb_f16
   TEST_TYPE
     matmul
   GENERATOR
@@ -1458,7 +1458,7 @@ if(IREE_HIP_TEST_TARGET_CHIP MATCHES "^gfx94")
 
 iree_generated_e2e_runner_test(
   NAME
-    e2e_matmul_rocm_f8_large_cdna3_mfma
+    e2e_matmul_cdna3_vecdistmfma_f8E4M3FNUZ
   TEST_TYPE
     matmul
   GENERATOR
@@ -1486,7 +1486,7 @@ iree_generated_e2e_runner_test(
 
 iree_generated_e2e_runner_test(
   NAME
-    e2e_matmul_rocm_i8_large_cdna3_mfma_tb
+    e2e_matmul_cdna3_vecdistmfma_i8
   TEST_TYPE
     matmul
   GENERATOR
@@ -1515,35 +1515,7 @@ iree_generated_e2e_runner_test(
 
 iree_generated_e2e_runner_test(
   NAME
-    e2e_matmul_cdna_experimental_dt_f32_f32
-  TEST_TYPE
-    matmul
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=f32"
-    "--acc_type=f32"
-  TEST_RUNNER
-    iree_tools_testing_e2e_iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "rocm"
-  DRIVERS
-    "hip"
-  COMPILER_FLAGS
-    ${IREE_HIP_TEST_COMPILER_FLAGS}
-    "--iree-opt-data-tiling"
-    "--iree-global-opt-enable-early-materialization=false"
-  LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
-    "requires-gpu-cdna3"
-)
-
-iree_generated_e2e_runner_test(
-  NAME
-    e2e_matmul_rocm_f16_cdna3_mfma_data_tiled
+    e2e_matmul_cdna3_dt_f16
   TEST_TYPE
     matmul
   GENERATOR
@@ -1572,7 +1544,7 @@ iree_generated_e2e_runner_test(
 
 iree_generated_e2e_runner_test(
   NAME
-    e2e_matmul_rocm_bf16_cdna3_mfma_data_tiled
+    e2e_matmul_cdna3_dt_bf16
   TEST_TYPE
     matmul
   GENERATOR
@@ -1601,7 +1573,7 @@ iree_generated_e2e_runner_test(
 
 iree_generated_e2e_runner_test(
   NAME
-    e2e_matmul_rocm_i8_cdna3_mfma_data_tiled
+    e2e_matmul_cdna3_dt_i8
   TEST_TYPE
     matmul
   GENERATOR
@@ -1630,7 +1602,7 @@ iree_generated_e2e_runner_test(
 
 iree_generated_e2e_runner_test(
   NAME
-    e2e_matmul_rocm_f32_cdna3_mfma_data_tiled
+    e2e_matmul_cdna3_dt_f32
   TEST_TYPE
     matmul
   GENERATOR
@@ -1659,7 +1631,7 @@ iree_generated_e2e_runner_test(
 
 iree_generated_e2e_runner_test(
   NAME
-    e2e_matmul_rocm_f8E5M2FNUZ_cdna3_mfma_data_tiled
+    e2e_matmul_cdna3_dt_f8E5M2FNUZ
   TEST_TYPE
     matmul
   GENERATOR
@@ -1688,7 +1660,7 @@ iree_generated_e2e_runner_test(
 
 iree_generated_e2e_runner_test(
   NAME
-    e2e_matmul_rocm_f8E4M3FNUZ_cdna3_mfma_data_tiled
+    e2e_matmul_cdna3_dt_f8E4M3FNUZ
   TEST_TYPE
     matmul
   GENERATOR
@@ -1808,35 +1780,6 @@ iree_generated_e2e_runner_test(
     "hip"
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
-  LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
-    "requires-gpu-rdna3"
-)
-
-iree_generated_e2e_runner_test(
-  NAME
-    e2e_matmul_rdna3_experimental_dt_f32_f32
-  TEST_TYPE
-    matmul
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=f32"
-    "--acc_type=f32"
-    "--shapes=small"
-  TEST_RUNNER
-    iree_tools_testing_e2e_iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "rocm"
-  DRIVERS
-    "hip"
-  COMPILER_FLAGS
-    ${IREE_HIP_TEST_COMPILER_FLAGS}
-    "--iree-opt-data-tiling"
-    "--iree-global-opt-enable-early-materialization=false"
   LABELS
     "noasan"
     "nomsan"


### PR DESCRIPTION
* Rename to a more concise, consistent naming scheme.
  * No need for `rocm` in the name, that gets added from the specified target backend.
* Remove some "dt" (ie "data tiling") tests that weren't really data tiling.