### PR TITLE
Apply new versioning scheme

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -21,7 +21,6 @@ on:
       package_version:
         description: "Version of the package"
         required: true
-        default: "0.1a1"
       release_id:
         description: "Release id to upload artifacts to"
         default: ""
@@ -131,29 +130,98 @@ jobs:
         if: "matrix.build-family != 'windows'"
         shell: bash
         run: |
-          cat << EOF > ./c/version_info.json
+          echo "meta package"
+          cat << EOF > ./c/version_info_rc.json
           {
             "package-suffix": "${{ github.event.inputs.package_suffix }}",
             "package-version": "${{ github.event.inputs.package_version }}",
             "iree-revision": "$(cd ./c && git rev-parse HEAD)"
           }
           EOF
-          cat ./c/version_info.json
+          cat ./c/version_info_rc.json
+
+          echo "iree-base-compiler"
+          cat << EOF > ./c/compiler/version_info_rc.json
+          {
+            "package-suffix": "${{ github.event.inputs.package_suffix }}",
+            "package-version": "${{ github.event.inputs.compiler_package_version }}",
+            "iree-revision": "$(cd ./c && git rev-parse HEAD)"
+          }
+          EOF
+          cat ./c/compiler/version_info_rc.json
+
+          echo "iree-base-runtime"
+          cat << EOF > ./c/runtime/version_info_rc.json
+          {
+            "package-suffix": "${{ github.event.inputs.package_suffix }}",
+            "package-version": "${{ github.event.inputs.runtime_package_version }}",
+            "iree-revision": "$(cd ./c && git rev-parse HEAD)"
+          }
+          EOF
+          cat ./c/runtime/version_info_rc.json
+
+          echo "iree-tools-tf"
+          cat << EOF > ./c/integrations/tensorflow/python_projects/iree_tf/version_info_rc.json
+          {
+            "package-suffix": "${{ github.event.inputs.package_suffix }}",
+            "package-version": "${{ github.event.inputs.tf_package_version }}",
+            "iree-revision": "$(cd ./c && git rev-parse HEAD)"
+          }
+          EOF
+          cat ./c/integrations/tensorflow/python_projects/iree_tf/version_info_rc.json
+
+          echo "iree-tools-tflite"
+          cat << EOF > ./c/integrations/tensorflow/python_projects/iree_tflite/version_info_rc.json
+          {
+            "package-suffix": "${{ github.event.inputs.package_suffix }}",
+            "package-version": "${{ github.event.inputs.tflite_package_version }}",
+            "iree-revision": "$(cd ./c && git rev-parse HEAD)"
+          }
+          EOF
+          cat ./c/integrations/tensorflow/python_projects/iree_tflite/version_info_rc.json
+
 
       - name: Write version info Windows (release)
         if: "matrix.build-family == 'windows'"
         shell: powershell
         run: |
           cd c
-          $verinfoprop = @{
+
+          $compilerverinfoprop = @{
             'package-suffix'= "${{ github.event.inputs.package_suffix }}"
-            'package-version'= "${{ github.event.inputs.package_version }}"
+            'package-version'= "${{ github.event.inputs.compiler_package_version }}"
             'iree-revision'= $(git rev-parse HEAD)
           }
-
-          $info = New-Object -TypeName PSObject -Prop $verinfoprop
+          $info = New-Object -TypeName PSObject -Prop $compilerverinfoprop
           $info = $info | ConvertTo-JSON
-          $info | Out-File "version_info.json" -Encoding "ASCII"
+          $info | Out-File "compiler/version_info.json" -Encoding "ASCII"
+
+          $runtimeverinfoprop = @{
+            'package-suffix'= "${{ github.event.inputs.package_suffix }}"
+            'package-version'= "${{ github.event.inputs.runtime_package_version }}"
+            'iree-revision'= $(git rev-parse HEAD)
+          }
+          $info = New-Object -TypeName PSObject -Prop $runtimeverinfoprop
+          $info = $info | ConvertTo-JSON
+          $info | Out-File "runtime/version_info.json" -Encoding "ASCII"
+
+          $tfverinfoprop = @{
+            'package-suffix'= "${{ github.event.inputs.package_suffix }}"
+            'package-version'= "${{ github.event.inputs.tf_package_version }}"
+            'iree-revision'= $(git rev-parse HEAD)
+          }
+          $info = New-Object -TypeName PSObject -Prop $tfverinfoprop
+          $info = $info | ConvertTo-JSON
+          $info | Out-File "integrations/tensorflow/python_projects/iree_tf/version_info.json" -Encoding "ASCII"
+
+          $tfliteverinfoprop = @{
+            'package-suffix'= "${{ github.event.inputs.package_suffix }}"
+            'package-version'= "${{ github.event.inputs.tflite_package_version }}"
+            'iree-revision'= $(git rev-parse HEAD)
+          }
+          $info = New-Object -TypeName PSObject -Prop $tfliteverinfoprop
+          $info = $info | ConvertTo-JSON
+          $info | Out-File "integrations/tensorflow/python_projects/iree_tflite/version_info.json" -Encoding "ASCII"
 
       ##########################################################################
       # Build the main distribution tarball.

--- a/.github/workflows/pkgci_build_packages.yml
+++ b/.github/workflows/pkgci_build_packages.yml
@@ -30,18 +30,19 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           submodules: true
-      - name: Write version info
-        shell: bash
-        run: |
-          cat << EOF > version_info.json
-          {
-            "package-suffix": "${PACKAGE_SUFFIX}",
-            "package-version": "${{ inputs.package_version }}",
-            "iree-revision": "$(cd ../iree && git rev-parse HEAD)"
-          }
-          EOF
-          realpath version_info.json
-          cat version_info.json
+      # TODO: Generate `version_info_rc.json` instead and include PR number.
+      # - name: Write version info
+      #   shell: bash
+      #   run: |
+      #     cat << EOF > version_info.json
+      #     {
+      #       "package-suffix": "${PACKAGE_SUFFIX}",
+      #       "package-version": "${{ inputs.package_version }}",
+      #       "iree-revision": "$(cd ../iree && git rev-parse HEAD)"
+      #     }
+      #     EOF
+      #     realpath version_info.json
+      #     cat version_info.json
       - name: Enable cache
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:

--- a/.github/workflows/schedule_candidate_release.yml
+++ b/.github/workflows/schedule_candidate_release.yml
@@ -37,10 +37,27 @@ jobs:
 
       - name: Compute version
         run: |
-          package_version="$(printf '%(%Y%m%d)T.${{ github.run_number }}')"
+          # meta package + tag
+          package_version="$(python3 build_tools/gen_version_info_rc.py .)"
           tag_name="candidate-${package_version}"
           echo "package_version=${package_version}" >> $GITHUB_ENV
           echo "tag_name=${tag_name}" >> $GITHUB_ENV
+
+          # iree-base-compiler
+          compiler_package_version="$(python3 build_tools/gen_version_info_rc.py compiler)"
+          echo "compiler_package_version=${compiler_package_version}" >> $GITHUB_ENV
+
+          # iree-base-runtime
+          runtime_package_version="$(python3 build_tools/gen_version_info_rc.py runtime)"
+          echo "runtime_package_version=${runtime_package_version}" >> $GITHUB_ENV
+
+          # iree-base-tools-tf
+          tf_package_version="$(python3 build_tools/gen_version_info_rc.py integrations/tensorflow/python_projects/iree_tf)"
+          echo "tf_package_version=${tf_package_version}" >> $GITHUB_ENV
+
+          # iree-base-tools-tflite
+          tflite_package_version="$(python3 build_tools/gen_version_info_rc.py integrations/tensorflow/python_projects/iree_tflite)""
+          echo "tflite_package_version=${tflite_package_version}" >> $GITHUB_ENV
 
       - name: Updating candidate tag
         run: |
@@ -73,6 +90,10 @@ jobs:
             {
               "package_suffix": "",
               "package_version": "${{ env.package_version }}",
+              "compiler_package_version": "${{ env.compiler_package_version }}",
+              "runtime_package_version": "${{ env.runtime_package_version }}",
+              "tf_package_version": "${{ env.tf_package_version }}",
+              "tflite_package_version": "${{ env.tflite_package_version }}",
               "release_id": "${{ steps.create_release.outputs.id }}",
               "commit": "${{ steps.last_green_commit.outputs.release-commit }}"
             }

--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,6 @@ Testing/
 # Local-only config options
 configured.bazelrc
 user.bazelrc
-version_info.json
 CMakeUserPresets.json
 
 # Dear ImGui Ini files

--- a/build_tools/github_actions/build_dist.py
+++ b/build_tools/github_actions/build_dist.py
@@ -77,21 +77,22 @@ BUILD_REQUIREMENTS_TXT = os.path.join(
 CI_REQUIREMENTS_TXT = os.path.join(THIS_DIR, "ci_requirements.txt")
 CONFIGURE_BAZEL_PY = os.path.join(IREESRC_DIR, "configure_bazel.py")
 
+# Setup and get version information.
+VERSION_INFO_FILE = os.path.join(IREESRC_DIR, "version_info.json")
+VERSION_INFO_RC_FILE = os.path.join(IREESRC_DIR, "version_info_rc.json")
+
 
 # Load version info.
-def load_version_info():
-    with open(os.path.join(IREESRC_DIR, "version_info.json"), "rt") as f:
+def load_version_info(version_file):
+    with open(version_file, "rt") as f:
         return json.load(f)
 
 
 try:
-    version_info = load_version_info()
+    version_info = load_version_info(VERSION_INFO_RC_FILE)
 except FileNotFoundError:
-    print("version_info.json not found. Using defaults")
-    version_info = {
-        "package-version": "0.1dev1",
-        "package-suffix": "-dev",
-    }
+    print("version_info_rc.json not found. Default to dev build")
+    version_info = load_version_info(VERSION_INFO_FILE)
 
 
 def remove_cmake_cache():

--- a/build_tools/github_actions/gen_version_info_rc.py
+++ b/build_tools/github_actions/gen_version_info_rc.py
@@ -1,0 +1,49 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This scripts grabs the X.Y.Z[.dev]` version identifier from a
+# `version_info.json` and writes the corresponding
+# `X.Y.ZrcYYYYMMDD` version identifier to `version_rc_info.json`.
+
+import argparse
+from pathlib import Path
+import json
+from datetime import datetime
+
+from packaging.version import Version
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("path", type=Path)
+parser.add_argument("--write-json", action="store_true")
+args = parser.parse_args()
+
+VERSION_INFO_FILE = args.path / "version_info.json"
+VERSION_INFO_RC_FILE = args.path / "version_info_rc.json"
+
+
+def load_version_info():
+    with open(VERSION_INFO_FILE, "rt") as f:
+        return json.load(f)
+
+
+def write_version_info():
+    with open(VERSION_INFO_RC_FILE, "w") as f:
+        json.dump(version_info_rc, f, indent=2)
+        f.write("\n")
+
+
+version_info = load_version_info()
+
+PACKAGE_VERSION = version_info.get("package-version")
+PACKAGE_BASE_VERSION = Version(PACKAGE_VERSION).base_version
+PACKAGE_RC_VERSION = PACKAGE_BASE_VERSION + "rc" + datetime.today().strftime("%Y%m%d")
+
+if args.write_json:
+    version_info_rc = {"package-version": PACKAGE_RC_VERSION}
+    write_version_info()
+
+print(PACKAGE_RC_VERSION)

--- a/compiler/setup.py
+++ b/compiler/setup.py
@@ -106,11 +106,12 @@ else:
     )
 
 # Setup and get version information.
-VERSION_INFO_FILE = os.path.join(IREE_SOURCE_DIR, "version_info.json")
+VERSION_INFO_FILE = os.path.join(IREE_SOURCE_DIR, "compiler/version_info.json")
+VERSION_INFO_RC_FILE = os.path.join(IREE_SOURCE_DIR, "compiler/version_info_rc.json")
 
 
-def load_version_info():
-    with open(VERSION_INFO_FILE, "rt") as f:
+def load_version_info(version_file):
+    with open(version_file, "rt") as f:
         return json.load(f)
 
 
@@ -147,16 +148,14 @@ def find_git_submodule_revision(submodule_path):
 
 
 try:
-    version_info = load_version_info()
+    version_info = load_version_info(VERSION_INFO_RC_FILE)
 except FileNotFoundError:
-    print("version_info.json not found. Using defaults", file=sys.stderr)
-    version_info = {}
+    print("version_info_rc.json not found. Default to dev build")
+    version_info = load_version_info(VERSION_INFO_FILE)
 git_versions = find_git_versions()
 
 PACKAGE_SUFFIX = version_info.get("package-suffix") or ""
 PACKAGE_VERSION = version_info.get("package-version")
-if not PACKAGE_VERSION:
-    PACKAGE_VERSION = f"0.dev0+{git_versions.get('IREE') or '0'}"
 
 
 def get_cmake_version_info_args():

--- a/compiler/version_info.json
+++ b/compiler/version_info.json
@@ -1,0 +1,3 @@
+{
+  "package-version": "3.0.0.dev"
+}

--- a/integrations/tensorflow/python_projects/iree_tf/setup.py
+++ b/integrations/tensorflow/python_projects/iree_tf/setup.py
@@ -23,22 +23,22 @@ exe_suffix = ".exe" if platform.system() == "Windows" else ""
 
 # Setup and get version information.
 THIS_DIR = os.path.realpath(os.path.dirname(__file__))
-IREESRC_DIR = os.path.join(THIS_DIR, "..", "..", "..", "..")
-VERSION_INFO_FILE = os.path.join(IREESRC_DIR, "version_info.json")
+VERSION_INFO_FILE = os.path.join(THIS_DIR, "version_info.json")
+VERSION_INFO_RC_FILE = os.path.join(THIS_DIR, "version_info_rc.json")
 
 
-def load_version_info():
-    with open(VERSION_INFO_FILE, "rt") as f:
+def load_version_info(version_file):
+    with open(version_file, "rt") as f:
         return json.load(f)
 
 
 try:
-    version_info = load_version_info()
+    version_info = load_version_info(VERSION_INFO_RC_FILE)
 except FileNotFoundError:
-    print("version_info.json not found. Using defaults")
-    version_info = {}
+    print("version_info_rc.json not found. Default to dev build")
+    version_info = load_version_info(VERSION_INFO_FILE)
 
-PACKAGE_SUFFIX = version_info.get("package-suffix") or ""
+PACKAGE_SUFFIX = version_info.get("package-suffix")
 PACKAGE_VERSION = version_info.get("package-version") or "0.1dev1"
 
 setup(

--- a/integrations/tensorflow/python_projects/iree_tf/version_info.json
+++ b/integrations/tensorflow/python_projects/iree_tf/version_info.json
@@ -1,0 +1,3 @@
+{
+  "package-version": "3.0.0.dev"
+}

--- a/integrations/tensorflow/python_projects/iree_tflite/setup.py
+++ b/integrations/tensorflow/python_projects/iree_tflite/setup.py
@@ -23,23 +23,23 @@ exe_suffix = ".exe" if platform.system() == "Windows" else ""
 
 # Setup and get version information.
 THIS_DIR = os.path.realpath(os.path.dirname(__file__))
-IREESRC_DIR = os.path.join(THIS_DIR, "..", "..", "..", "..")
-VERSION_INFO_FILE = os.path.join(IREESRC_DIR, "version_info.json")
+VERSION_INFO_FILE = os.path.join(THIS_DIR, "version_info.json")
+VERSION_INFO_RC_FILE = os.path.join(THIS_DIR, "version_info_rc.json")
 
 
-def load_version_info():
-    with open(VERSION_INFO_FILE, "rt") as f:
+def load_version_info(version_file):
+    with open(version_file, "rt") as f:
         return json.load(f)
 
 
 try:
-    version_info = load_version_info()
+    version_info = load_version_info(VERSION_INFO_RC_FILE)
 except FileNotFoundError:
-    print("version_info.json not found. Using defaults")
-    version_info = {}
+    print("version_info_rc.json not found. Default to dev build")
+    version_info = load_version_info(VERSION_INFO_FILE)
 
 PACKAGE_SUFFIX = version_info.get("package-suffix") or ""
-PACKAGE_VERSION = version_info.get("package-version") or "0.1dev1"
+PACKAGE_VERSION = version_info.get("package-version")
 
 setup(
     name=f"iree-tools-tflite{PACKAGE_SUFFIX}",

--- a/integrations/tensorflow/python_projects/iree_tflite/version_info.json
+++ b/integrations/tensorflow/python_projects/iree_tflite/version_info.json
@@ -1,0 +1,3 @@
+{
+  "package-version": "3.0.0.dev"
+}

--- a/runtime/setup.py
+++ b/runtime/setup.py
@@ -128,11 +128,12 @@ print(
 )
 
 # Setup and get version information.
-VERSION_INFO_FILE = os.path.join(IREE_SOURCE_DIR, "version_info.json")
+VERSION_INFO_FILE = os.path.join(IREE_SOURCE_DIR, "runtime/version_info.json")
+VERSION_INFO_RC_FILE = os.path.join(IREE_SOURCE_DIR, "runtime/version_info_rc.json")
 
 
-def load_version_info():
-    with open(VERSION_INFO_FILE, "rt") as f:
+def load_version_info(version_file):
+    with open(version_file, "rt") as f:
         return json.load(f)
 
 
@@ -169,16 +170,14 @@ def find_git_submodule_revision(submodule_path):
 
 
 try:
-    version_info = load_version_info()
+    version_info = load_version_info(VERSION_INFO_RC_FILE)
 except FileNotFoundError:
-    print("version_info.json not found. Using defaults", file=sys.stderr)
-    version_info = {}
+    print("version_info_rc.json not found. Default to dev build")
+    version_info = load_version_info(VERSION_INFO_FILE)
 git_versions = find_git_versions()
 
 PACKAGE_SUFFIX = version_info.get("package-suffix") or ""
 PACKAGE_VERSION = version_info.get("package-version")
-if not PACKAGE_VERSION:
-    PACKAGE_VERSION = f"0.dev0+{git_versions.get('IREE') or '0'}"
 
 
 def maybe_nuke_cmake_cache(cmake_build_dir, cmake_install_dir):

--- a/runtime/version_info.json
+++ b/runtime/version_info.json
@@ -1,0 +1,3 @@
+{
+  "package-version": "3.0.0.dev"
+}

--- a/version_info.json
+++ b/version_info.json
@@ -1,0 +1,3 @@
+{
+  "package-version": "3.0.0.dev"
+}


### PR DESCRIPTION
This implements the new versioning scheme proposed with #18938. For the compiler, the runtime, the TF compiler tools and the TFLite compiler tools, `version_info.json` files to allow to set the patch level individually for each package. Furthermore, a `version_info.json` is added at root level to have a common version for a (future) meta package, now mainly used to determine the tag when publishing release candidates. This file might be moved in future and additional, per-package tags might be added.