### PR TITLE
[VectorDistribution] Fix 0-rank vector.broadcast distribution

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -305,9 +305,9 @@ struct DistributeBroadcast final : OpDistributionPattern<vector::BroadcastOp> {
     auto vectorType = VectorType::get(distShape, elementType);
 
     VectorValue srcVector = dyn_cast<VectorValue>(broadcastOp.getSource());
-    // If the srcVector is a scalar (like f32) or a rank-0 vector (like
-    // vector<f32>), we proceed with the scalar distribution branch.
-    if (!srcVector || !isNonZeroRank(srcVector)) {
+    // If the srcVector is a scalar (like f32) we proceed with the scalar
+    // distribution branch.
+    if (!srcVector) {
       // The way distribution currently works, there is no partial thread
       // distribution, so a scalar is available to all threads. Scalar
       // distribution is simply a broadcast from scalar to the distributed

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.cpp
@@ -132,16 +132,14 @@ void DistributionPattern::replaceOpWithDistributedValues(
   for (auto [opResult, replacement] :
        llvm::zip_equal(op->getOpResults(), values)) {
     // If this value is a vector type, it must be converted back to simd.
-    if (auto replacementType = dyn_cast<VectorType>(replacement.getType())) {
-      if (replacementType.getRank() != 0) {
-        auto oldResult = cast<VectorValue>(opResult);
-        // Create a toSIMD op to convert the value back to the simd.
-        rewriter.setInsertionPointAfterValue(oldResult);
-        Value toSIMD = rewriter.create<IREE::VectorExt::ToSIMDOp>(
-            oldResult.getLoc(), oldResult.getType(), replacement);
-        // Add to replacements.
-        replacement = toSIMD;
-      }
+    if (isa<VectorType>(replacement.getType())) {
+      auto oldResult = cast<VectorValue>(opResult);
+      // Create a toSIMD op to convert the value back to the simd.
+      rewriter.setInsertionPointAfterValue(oldResult);
+      Value toSIMD = rewriter.create<IREE::VectorExt::ToSIMDOp>(
+          oldResult.getLoc(), oldResult.getType(), replacement);
+      // Add to replacements.
+      replacement = toSIMD;
     }
     replacements.push_back(replacement);
   }


### PR DESCRIPTION
Fixes: https://github.com/iree-org/iree/issues/18955

Also removes locally carried revert