### PR TITLE
[Codegen] Add pass to further tile large linalg ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -146,6 +146,7 @@ iree_compiler_cc_library(
         "TileAndDistributeToWorkgroupsPass.cpp",
         "TileDispatchUsingForall.cpp",
         "TileDispatchUsingInterface.cpp",
+        "TileLargeTensors.cpp",
         "TileSizeSelection.cpp",
         "TypePropagationPass.cpp",
         "UnrollAnnotatedLoops.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -138,6 +138,7 @@ iree_cc_library(
     "TileAndDistributeToWorkgroupsPass.cpp"
     "TileDispatchUsingForall.cpp"
     "TileDispatchUsingInterface.cpp"
+    "TileLargeTensors.cpp"
     "TileSizeSelection.cpp"
     "TypePropagationPass.cpp"
     "UnrollAnnotatedLoops.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -574,6 +574,21 @@ def TileAndDistributeToWorkgroupsUsingForallOpPass :
   ];
 }
 
+def TileLargeTensorsPass :
+    InterfacePass<"iree-codegen-tile-large-tensors", "mlir::FunctionOpInterface"> {
+  let summary = "Greedily tiles all linalg ops that are beyond a certain size";
+  let dependentDialects = [
+    "::mlir::arith::ArithDialect",
+    "::mlir::affine::AffineDialect",
+    "::mlir::scf::SCFDialect",
+  ];
+  let options = [
+    Option<"maxVectorSize", "max-vector-size", "int64_t",
+           /*default=*/"64",
+           "Maximum static size to tile to (i.e. all remaining ops will be smaller)">,
+  ];
+}
+
 def TransformDialectInterpreterPass :
     Pass<"iree-transform-dialect-interpreter"> {
   let summary = "Pass to apply transform dialect operations.";

--- a/compiler/src/iree/compiler/Codegen/Common/TileLargeTensors.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileLargeTensors.cpp
@@ -1,0 +1,187 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/Passes.h"
+#include "llvm/ADT/STLExtras.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/Dialect/Utils/StructuredOpsUtils.h"
+#include "mlir/Interfaces/TilingInterface.h"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_TILELARGETENSORSPASS
+#include "iree/compiler/Codegen/Common/Passes.h.inc"
+
+namespace {
+
+struct TileLargeTensorsPass final
+    : public impl::TileLargeTensorsPassBase<TileLargeTensorsPass> {
+  using Base::Base;
+  void runOnOperation() override;
+};
+} // namespace
+
+/// Finds the largest factor of |val| less than or equal to the given
+/// |upperBound|. All 2 element factorizations of the value must include a
+/// term less than or equal to floor(sqrt(val)), so we search until we find
+/// the first factor whose reciprocal is <= the upper bound.
+int64_t getLargestFactorLessThan(int64_t val, int64_t upperBound) {
+  assert(val >= 1);
+  for (int64_t i = 1, e = std::sqrt(val); i <= e; ++i) {
+    if (val % i == 0 && val / i <= upperBound) {
+      return val / i;
+    }
+  }
+  return 1;
+}
+
+/// Helper to tile and greedily fuse the given operation. This does not yield
+/// any fused operation and only replaces the tiling root. Because this pass is
+/// primarily concerned with managing large vector sizes, we only handle linalg
+/// ops here.
+/// TODO: Handle all vectorizable ops that might yield a large vector.
+///
+/// If tiling fails this returns silently (tiling is best effort). Later
+/// verification steps will throw an error if distribution does not occur.
+static void tileToMaxVectorSize(RewriterBase &rewriter,
+                                linalg::LinalgOp linalgOp,
+                                int64_t maxVectorSize) {
+  assert(maxVectorSize >= 1 && "maximum vector size must be at least 1");
+  SmallVector<int64_t> staticTileSizes = linalgOp.getStaticLoopRanges();
+
+  // Collect the total statically known parallel iterations of the linalg op.
+  // We are expected this to be the minimum required vector size for the op
+  // because outputs should reflect the full parallel iteration space.
+  int64_t staticNumTrips = 1;
+  for (auto [size, type] :
+       llvm::zip_equal(staticTileSizes, linalgOp.getIteratorTypesArray())) {
+    // Skip reduction iterators.
+    if (type == utils::IteratorType::reduction) {
+      continue;
+    }
+    if (ShapedType::isDynamic(size)) {
+      size = 1;
+    } else {
+      staticNumTrips *= size;
+    }
+  }
+
+  int64_t expectedMinVectorSize = staticNumTrips;
+  for (int64_t i = 0, e = staticTileSizes.size() - 1; i < e; ++i) {
+    // While we exceed the maximum vector size, set the tile size for all
+    // loops except the inner most to 1. This assumes that the only dimension
+    // that can be meaningfully vectorized is the inner most which is not always
+    // true. Considering this is fallback logic, this is fine.
+    if (expectedMinVectorSize > maxVectorSize) {
+      // These two quantities are always divisible.
+      expectedMinVectorSize /= staticTileSizes[i];
+      staticTileSizes[i] = 1;
+    }
+  }
+
+  // For the inner most loop, pick the largest static integer factor that is
+  // less than the maximum vector size. This might not be a great approximation
+  // and we may opt for a smaller default in the future.
+  if (expectedMinVectorSize > maxVectorSize) {
+    staticTileSizes.back() =
+        getLargestFactorLessThan(expectedMinVectorSize, maxVectorSize);
+  }
+
+  // Check if nothing to do.
+  if (staticTileSizes == linalgOp.getStaticLoopRanges()) {
+    return;
+  }
+
+  rewriter.setInsertionPoint(linalgOp);
+  SmallVector<OpFoldResult> tileSizes =
+      getAsIndexOpFoldResult(rewriter.getContext(), staticTileSizes);
+
+  scf::SCFTilingOptions tilingOptions;
+  tilingOptions.setTileSizes(tileSizes);
+  tilingOptions.setLoopType(scf::SCFTilingOptions::LoopType::ForOp);
+
+  scf::SCFTileAndFuseOptions tileAndFuseOptions;
+  tileAndFuseOptions.setTilingOptions(tilingOptions);
+
+  scf::SCFTileAndFuseOptions::ControlFnTy controlFn =
+      [&](tensor::ExtractSliceOp candidateSliceOp, OpResult originalProducer,
+          bool isDestinationOperand)
+      -> std::optional<scf::SCFTileAndFuseOptions::ControlFnResult> {
+    // Always fuse tilable ops but never yield a replacement.
+    if (!isa<TilingInterface>(originalProducer.getOwner())) {
+      return {};
+    }
+    return scf::SCFTileAndFuseOptions::ControlFnResult{
+        /*yieldProducerReplacement=*/false};
+  };
+  tileAndFuseOptions.setFusionControlFn(controlFn);
+
+  FailureOr<scf::SCFTileAndFuseResult> tiledResults =
+      scf::tileConsumerAndFuseProducersUsingSCF(
+          rewriter, cast<TilingInterface>(&*linalgOp), tileAndFuseOptions);
+  if (failed(tiledResults)) {
+    return;
+  }
+
+  // Perform the replacement of the tiling root.
+  for (OpResult res : linalgOp->getResults()) {
+    if (auto replacement = tiledResults->replacements.lookup(res)) {
+      rewriter.replaceAllUsesWith(res, replacement);
+    }
+  }
+
+  if (linalgOp->use_empty()) {
+    rewriter.eraseOp(linalgOp);
+  }
+}
+
+/// Recursively process the given region and tile all linalg operations that
+/// are too large. The assumption is that all operations have been sufficiently
+/// tiled or lowered by this point and this is a fallback to avoid large vector
+/// sizes.
+static void processRegion(RewriterBase &rewriter, Region *region,
+                          int64_t maxVectorSize) {
+  // Process the region blocks in reverse.
+  for (Block &block : llvm::reverse(region->getBlocks())) {
+    // Save a reversed list of operations within the block. Ops will be
+    // greedily tiled + fused in reverse so that if a producer can be fused
+    // with a consumer we only distribute the producer once via fusion.
+    SmallVector<Operation *> targetOps =
+        llvm::map_to_vector(llvm::reverse(block.getOperations()),
+                            [](Operation &op) { return &op; });
+    // Skip all unused ops (possibly from tiling).
+    for (Operation *op : targetOps) {
+      if (op->use_empty()) {
+        continue;
+      }
+
+      // Try to greedily tile + fuse linalg ops.
+      if (auto linalgOp = dyn_cast<linalg::LinalgOp>(op)) {
+        tileToMaxVectorSize(rewriter, linalgOp, maxVectorSize);
+        continue;
+      }
+
+      // Else recursively process all nested operations.
+      for (auto &region : op->getRegions()) {
+        processRegion(rewriter, &region, maxVectorSize);
+      }
+    }
+  }
+}
+
+void TileLargeTensorsPass::runOnOperation() {
+  auto funcOp = getOperation();
+
+  IRRewriter rewriter(funcOp->getContext());
+  for (auto &region : funcOp->getRegions()) {
+    processRegion(rewriter, &region, maxVectorSize);
+  }
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -71,6 +71,7 @@ iree_lit_test_suite(
             "tile_and_distribute_to_workgroups_func_scope.mlir",
             "tile_and_distribute_to_workgroups.mlir",
             "tile_and_distribute_workgroups_using_forall.mlir",
+            "tile_large_tensors.mlir",
             "transform_buffer_opt.mlir",
             "transform_copy_operand.mlir",
             "transform_flatten_forall.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -67,6 +67,7 @@ iree_lit_test_suite(
     "tile_and_distribute_to_workgroups.mlir"
     "tile_and_distribute_to_workgroups_func_scope.mlir"
     "tile_and_distribute_workgroups_using_forall.mlir"
+    "tile_large_tensors.mlir"
     "transform_buffer_opt.mlir"
     "transform_copy_operand.mlir"
     "transform_flatten_forall.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/tile_large_tensors.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tile_large_tensors.mlir
@@ -1,0 +1,86 @@
+// RUN: iree-opt %s --split-input-file --mlir-print-local-scope \
+// RUN:   --pass-pipeline="builtin.module(func.func(iree-codegen-tile-large-tensors, canonicalize, cse))" | \
+// RUN:   FileCheck %s
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+func.func @simple_generic(%3: tensor<64x256xf32>, %4: tensor<64x256xf32>, %5: tensor<64x256xf32>) -> tensor<64x256xf32> {
+  %6 = linalg.generic {
+    indexing_maps = [#map, #map, #map],
+    iterator_types = ["parallel", "parallel"]
+    } ins(%3, %4 : tensor<64x256xf32>, tensor<64x256xf32>) outs(%5 : tensor<64x256xf32>) {
+  ^bb0(%in: f32, %in_0: f32, %out: f32):
+    %7 = arith.addf %in, %in_0 : f32
+    linalg.yield %7 : f32
+  } -> tensor<64x256xf32>
+  return %6 : tensor<64x256xf32>
+}
+
+// CHECK-LABEL: func.func @simple_generic
+//       CHECK:   scf.for %{{.*}} = %c0 to %c64 step %c1
+//       CHECK:     scf.for %{{.*}} = %c0 to %c256 step %c64
+//       CHECK:       linalg.generic {{.*}} outs({{.*}}: tensor<1x64xf32>)
+
+// -----
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+func.func @fuse_destination(%3: tensor<64x64xf32>, %4: tensor<64x64xf32>) -> tensor<64x64xf32> {
+  %empty = tensor.empty() : tensor<64x64xf32>
+  %cst = arith.constant 0.0 : f32
+  %5 = linalg.fill ins(%cst : f32) outs(%empty : tensor<64x64xf32>) -> tensor<64x64xf32>
+  %7 = linalg.matmul ins(%3, %4 : tensor<64x64xf32>, tensor<64x64xf32>) outs(%5 : tensor<64x64xf32>) -> tensor<64x64xf32>
+  return %7 : tensor<64x64xf32>
+}
+
+// CHECK-LABEL: func.func @fuse_destination
+//       CHECK:   %[[EMPTY:.+]] = tensor.empty() : tensor<64x64xf32>
+//       CHECK:   scf.for %{{.*}} = %c0 to %c64 step %c1
+//       CHECK:     linalg.fill {{.*}} -> tensor<1x64xf32>
+
+// Additionally verify that reduction dimensions do not get tiled.
+//       CHECK:     linalg.matmul ins({{.*}}: tensor<1x64xf32>, tensor<64x64xf32>)
+
+// -----
+
+func.func @in_nested_region(%3: tensor<64x64xf32>, %4: tensor<64x64xf32>, %5: tensor<64x64xf32>) -> tensor<64x64xf32> {
+  %c8 = arith.constant 8 : index
+  %c64 = arith.constant 64 : index
+  %c0 = arith.constant 0 : index
+  %6 = scf.for %arg0 = %c0 to %c64 step %c8 iter_args(%arg1 = %5) -> (tensor<64x64xf32>) {
+    %extracted_slice = tensor.extract_slice %3[0, %arg0] [64, 8] [1, 1] : tensor<64x64xf32> to tensor<64x8xf32>
+    %extracted_slice_0 = tensor.extract_slice %4[0, %arg0] [64, 8] [1, 1] : tensor<64x64xf32> to tensor<64x8xf32>
+    %extracted_slice_1 = tensor.extract_slice %arg1[0, %arg0] [64, 8] [1, 1] : tensor<64x64xf32> to tensor<64x8xf32>
+    %7 = linalg.add
+      ins(%extracted_slice, %extracted_slice_0 : tensor<64x8xf32>, tensor<64x8xf32>)
+      outs(%extracted_slice_1 : tensor<64x8xf32>) -> tensor<64x8xf32>
+    %insert = tensor.insert_slice %7 into %arg1[0, %arg0] [64, 8] [1, 1] : tensor<64x8xf32> into tensor<64x64xf32>
+    scf.yield %insert : tensor<64x64xf32>
+  }
+  return %6 : tensor<64x64xf32>
+}
+
+// CHECK-LABEL: func.func @in_nested_region
+//       CHECK:   scf.for
+//       CHECK:     scf.for %{{.*}} = %c0 to %c64 step %c1
+//       CHECK:       linalg.add {{.*}} -> tensor<1x8xf32>
+
+// -----
+
+func.func @multiple_use_tilable_op(%3: tensor<64x256xf32>, %4: tensor<64x256xf32>) -> (tensor<64x256xf32>, tensor<256x64xf32>) {
+  %add_empty = tensor.empty() : tensor<64x256xf32>
+  %6 = linalg.add
+    ins(%3, %4 : tensor<64x256xf32>, tensor<64x256xf32>)
+    outs(%add_empty : tensor<64x256xf32>) -> tensor<64x256xf32>
+  %transpose_empty = tensor.empty() : tensor<256x64xf32>
+  %7 = linalg.transpose
+    ins(%6 : tensor<64x256xf32>)
+    outs(%transpose_empty : tensor<256x64xf32>) permutation = [1, 0]
+  return %6, %7 : tensor<64x256xf32>, tensor<256x64xf32>
+}
+
+// CHECK-LABEL: func.func @multiple_use_tilable_op
+//       CHECK:   %[[ADD_TILING:.+]] = scf.for
+//       CHECK:     linalg.add {{.*}} -> tensor<1x64xf32>
+//       CHECK:   %[[T_TILING:.+]] = scf.for
+//       CHECK:     %[[FUSED_ADD:.+]] = linalg.add {{.*}} -> tensor<64x1xf32>
+//       CHECK:     linalg.transpose ins(%[[FUSED_ADD]]
+//       CHECK:   return %[[ADD_TILING]], %[[T_TILING]]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -425,6 +425,7 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
   // Step 5. Greedily fuse parallel loops and hoist from serial loops.
   funcPassManager.addPass(IREE::GPU::createFuseAndHoistParallelLoopsPass());
   funcPassManager.addPass(createGPUGreedilyDistributeToThreadsPass());
+  funcPassManager.addPass(createTileLargeTensorsPass());
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
   funcPassManager.addPass(createIREELoopInvariantCodeMotionPass());


### PR DESCRIPTION
In certain cases/configurations we can end up with excessively large static `linalg.generic` ops that will then vectorize and emit code with huge vector sizes. This at a minimum will yield terrible code, and can even crash/hang LLVM when trying to compile such an enormous function.

The implementation here only looks at parallel dims and linalg ops. Large reductions and other vectorizable ops will likely need handling as well, but "vectorizability" isn't really queryable today.

The pass has an options for a maximum vector size to tile to, but the logic here could potentially use some future improvement (e.g. maybe expose a target vector size too to use when we choose to tile).

Also note that in many cases where we hit this is likely to generate poor code because we can often end up with large local/stack allocations, but by the time we get to this point there isn't much else we can do. Better to ask for an allocation than 10k lines of unrolled IR.