### PR TITLE
[DispatchCreation] Collapse `iree_linalg_ext.attention`

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Transforms.h
@@ -4,11 +4,12 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtInterfaces.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 
 namespace mlir::iree_compiler::IREE::LinalgExt {
 
-// Fold expand_shape ops with their producers (only `AttentionOp` supported)
+/// Fold expand_shape ops with their producers (only `AttentionOp` supported)
 void populateFoldReshapeOpsByExpansionPatterns(
     RewritePatternSet &patterns,
     const linalg::ControlFusionFn &controlFoldingReshapes);
@@ -16,5 +17,15 @@ void populateFoldReshapeOpsByExpansionPatterns(
 void populateFuseLinalgExtOpsWithTransposes(
     RewritePatternSet &patterns,
     const linalg::ControlFusionFn &controlFusionFn);
+
+struct CollapseResult {
+  SmallVector<Value> results;
+  Operation *collapsedOp;
+};
+
+FailureOr<CollapseResult>
+collapseOpIterationDims(AttentionOp op,
+                        ArrayRef<ReassociationIndices> foldedIterationDims,
+                        RewriterBase &rewriter);
 
 }; // namespace mlir::iree_compiler::IREE::LinalgExt

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Transforms.h
@@ -14,15 +14,20 @@ void populateFoldReshapeOpsByExpansionPatterns(
     RewritePatternSet &patterns,
     const linalg::ControlFusionFn &controlFoldingReshapes);
 
+/// Fuse transpose-like ops into LinalgExt ops (only `AttentionOp` supported).
 void populateFuseLinalgExtOpsWithTransposes(
     RewritePatternSet &patterns,
     const linalg::ControlFusionFn &controlFusionFn);
 
+/// Helper struct to hold the results of collapsing an operation.
 struct CollapseResult {
   SmallVector<Value> results;
   Operation *collapsedOp;
 };
 
+/// Collapse the iteration dimension of `op` as described by
+/// `foldedIterationDims`. Returns failure when the op cannot be collapsed or it
+/// is a no-op.
 FailureOr<CollapseResult>
 collapseOpIterationDims(AttentionOp op,
                         ArrayRef<ReassociationIndices> foldedIterationDims,

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -184,6 +184,9 @@ def CollapseDimensionsPass :
     Collapse dimensions of Linalg Ops on tensor ops inside dispatch.region ops
     and hoist the reshaping operations out of the dispatch.
   }];
+  let dependentDialects = [
+    "IREE::LinalgExt::IREELinalgExtDialect",
+  ];
 }
 
 def DispatchWithTransformDialectPass : Pass<"iree-dispatch-creation-dispatch-with-transform-dialect"> {

--- a/compiler/src/iree/compiler/DispatchCreation/test/collapse_dimensions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/collapse_dimensions.mlir
@@ -578,7 +578,10 @@ util.func public @collapse_attention(%arg0: tensor<20x4096x16xf16>, %arg1: tenso
 }
 
 // CHECK-LABEL: util.func public @collapse_attention
-//       CHECK:   flow.return {{.*}} : tensor<20x4096x64xf16>
+//       CHECK:   %[[ATTN:.*]] = iree_linalg_ext.attention
+//  CHECK-SAME:      tensor<20x4096x16xf16>, tensor<20x1024x16xf16>, tensor<20x1024x64xf16>, f16
+//  CHECK-SAME:      tensor<20x4096x64xf16>
+//       CHECK:   flow.return %[[ATTN]] : tensor<20x4096x64xf16>
 
 // -----
 
@@ -610,4 +613,9 @@ util.func public @collapse_attention_with_truncf(%arg0: tensor<20x4096x16xf32>, 
 }
 
 // CHECK-LABEL: util.func public @collapse_attention_with_truncf
-//       CHECK:   flow.return {{.*}} : tensor<20x4096x64xf16>
+//       CHECK:   %[[ATTN:.*]] = iree_linalg_ext.attention
+//  CHECK-SAME:      tensor<20x4096x16xf32>, tensor<20x1024x16xf32>, tensor<20x1024x64xf32>, f32
+//  CHECK-SAME:      tensor<20x4096x64xf32>
+//       CHECK:   %[[TRUNC:.*]] = linalg.generic
+//  CHECK-SAME:      ins(%[[ATTN]] : tensor<20x4096x64xf32>
+//       CHECK:   flow.return %[[TRUNC]] : tensor<20x4096x64xf16>


### PR DESCRIPTION
This change adds support for attention in `CollapseDimensionsPass` so that the attention op will be collapsed as much as possible. This is motivated by reducing the different variants of attention that the sdxl attention spec has to handle.


Changes to LinalgExt/Transforms/ReshapeFusion.cpp are mostly taken directly from https://github.com/llvm/llvm-project/blob/002a0a27bc4702d6f34434c1838cb1698a0b0098/mlir/lib/Dialect/Linalg/Transforms/ElementwiseOpFusion.cpp (attributed at the top of the file). I attempted to keep not modify the original logic as much as possible to keep it general in case it needs to be reused for other `LinalgExt` ops.