### PR TITLE
[runtime][python] Add debug sink to bindings

### DIFF
--- a/runtime/bindings/python/CMakeLists.txt
+++ b/runtime/bindings/python/CMakeLists.txt
@@ -118,6 +118,7 @@ iree_py_library(
     "iree/runtime/io.py"
     "iree/runtime/system_api.py"
     "iree/runtime/system_setup.py"
+    "iree/runtime/typing.py"
     "iree/runtime/version.py"
     "iree/_runtime/__init__.py"
     "iree/_runtime/libs.py"
@@ -231,13 +232,6 @@ iree_py_test(
 
 iree_py_test(
   NAME
-    hal_test
-  SRCS
-    "tests/hal_test.py"
-)
-
-iree_py_test(
-  NAME
     io_test
   SRCS
     "tests/io_test.py"
@@ -260,6 +254,13 @@ if(IREE_BUILD_COMPILER AND IREE_BUILD_BUNDLED_LLVM)
       benchmark_test
     SRCS
       "tests/benchmark_test.py"
+  )
+
+  iree_py_test(
+    NAME
+      hal_test
+    SRCS
+      "tests/hal_test.py"
   )
 
   iree_py_test(

--- a/runtime/bindings/python/binding.h
+++ b/runtime/bindings/python/binding.h
@@ -45,7 +45,9 @@ class ApiRefCounted {
  public:
   using RawPtrType = T*;
   ApiRefCounted() : instance_(nullptr) {}
-  ApiRefCounted(ApiRefCounted& other) : instance_(other.instance_) { Retain(); }
+  ApiRefCounted(const ApiRefCounted& other) : instance_(other.instance_) {
+    Retain();
+  }
   ApiRefCounted(ApiRefCounted&& other) : instance_(other.instance_) {
     other.instance_ = nullptr;
   }

--- a/runtime/bindings/python/initialize_module.cc
+++ b/runtime/bindings/python/initialize_module.cc
@@ -4,7 +4,10 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <nanobind/intrusive/counter.h>
+
 #include <memory>
+#include <nanobind/intrusive/counter.inl>
 
 #include "./binding.h"
 #include "./hal.h"
@@ -78,6 +81,16 @@ NB_MODULE(_runtime, m) {
   });
 
   m.def("disable_leak_checker", []() { py::set_leak_warnings(false); });
+
+  py::intrusive_init(
+      [](PyObject *o) noexcept {
+        py::gil_scoped_acquire guard;
+        Py_INCREF(o);
+      },
+      [](PyObject *o) noexcept {
+        py::gil_scoped_acquire guard;
+        Py_DECREF(o);
+      });
 }
 
 }  // namespace python

--- a/runtime/bindings/python/iree/runtime/__init__.py
+++ b/runtime/bindings/python/iree/runtime/__init__.py
@@ -56,6 +56,10 @@ from ._binding import (
     VmRef,
 )
 
+# Debug imports
+from ._binding import HalModuleDebugSink
+from .typing import HalModuleBufferViewTraceCallback
+
 from .array_interop import *
 from .benchmark import *
 from .system_api import *

--- a/runtime/bindings/python/iree/runtime/_binding.pyi
+++ b/runtime/bindings/python/iree/runtime/_binding.pyi
@@ -1,13 +1,23 @@
-from typing import Any, Callable, ClassVar, List, Optional, Sequence, Tuple, Union
-
-from typing import overload
-
+from typing import (
+    Any,
+    Callable,
+    ClassVar,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    overload,
+)
 import asyncio
+
+from .typing import HalModuleBufferViewTraceCallback
 
 def create_hal_module(
     instance: VmInstance,
     device: Optional[HalDevice] = None,
     devices: Optional[List[HalDevice]] = None,
+    debug_sink: Optional[HalModuleDebugSink] = None,
 ) -> VmModule: ...
 def create_io_parameters_module(
     instance: VmInstance, *providers: ParameterProvider
@@ -309,6 +319,36 @@ class HalSemaphore:
         timeout: Optional[int] = None,
         deadline: Optional[int] = None,
     ) -> None: ...
+
+class HalModuleDebugSink:
+    def __init__(
+        self, buffer_view_trace_callback: Optional[HalModuleBufferViewTraceCallback]
+    ):
+        """The function object buffer_view_trace_callback must not include the
+        corresponding HAL VmModule, VmInstance or VmContext in its closure.
+        Native runtime objects are managed by reference counting and do not track
+        cyclic references. This will create an uncollectible cycle.
+        E.g.
+
+        ```
+        vm_context = ...
+        def callback(key, hal_buffer_view):
+            print(vm_context)
+        hal_module = iree.runtime.create_hal_module(
+            vm_instance,
+            device,
+            debug_sink=iree.runtime.HalModuleDebugSink(callback),
+        )
+        ```
+
+        This callback will cause the VM context to never be destroyed.
+        """
+
+        ...
+    @property
+    def buffer_view_trace_callback(
+        self,
+    ) -> Optional[HalModuleBufferViewTraceCallback]: ...
 
 class Linkage(int):
     EXPORT: ClassVar[Linkage] = ...

--- a/runtime/bindings/python/iree/runtime/typing.py
+++ b/runtime/bindings/python/iree/runtime/typing.py
@@ -1,0 +1,25 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Type hints."""
+
+from typing import Callable, List, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from . import HalBufferView
+
+TraceKey = str
+HalModuleBufferViewTraceCallback = Callable[[TraceKey, List["HalBufferView"]], None]
+"""Tracing function for buffers to pass to the runtime.
+This allows custom behavior when executing an IREE module with tensor tracing
+instructions. MLIR e.g.
+
+```
+flow.tensor.trace "MyTensors" [
+    %tensor1 : tensor<1xf32>,
+    %tensor2 : tensor<2xf32>
+]
+```
+"""

--- a/runtime/bindings/python/vm.cc
+++ b/runtime/bindings/python/vm.cc
@@ -20,6 +20,7 @@
 #include "iree/modules/hal/module.h"
 #include "iree/tooling/modules/resolver.h"
 #include "iree/vm/api.h"
+#include "nanobind/nanobind.h"
 
 using namespace nanobind::literals;
 

--- a/runtime/src/iree/modules/check/check_test.cc
+++ b/runtime/src/iree/modules/check/check_test.cc
@@ -231,7 +231,7 @@ TEST_F(CheckTest, HalModuleDebugSinkDestroyCallbackIsCalled) {
     bool is_callback_called = false;
   };
 
-  iree_hal_module_debug_sink_t sink = {0};
+  iree_hal_module_debug_sink_t sink = {};
   sink.destroy.fn = [](void* user_data) {
     reinterpret_cast<UserData*>(user_data)->is_callback_called = true;
     return iree_ok_status();

--- a/runtime/src/iree/modules/check/check_test.cc
+++ b/runtime/src/iree/modules/check/check_test.cc
@@ -208,6 +208,9 @@ class CheckTest : public ::testing::Test {
     return Invoke(function_name);
   }
 
+  static iree_hal_device_t*& device() { return CheckTest::device_; }
+  static iree_vm_instance_t*& instance() { return CheckTest::instance_; }
+
  private:
   static iree_hal_device_t* device_;
   static iree_vm_instance_t* instance_;
@@ -222,6 +225,27 @@ iree_hal_device_t* CheckTest::device_ = nullptr;
 iree_vm_instance_t* CheckTest::instance_ = nullptr;
 iree_vm_module_t* CheckTest::check_module_ = nullptr;
 iree_vm_module_t* CheckTest::hal_module_ = nullptr;
+
+TEST_F(CheckTest, HalModuleDebugSinkDestroyCallbackIsCalled) {
+  struct UserData {
+    bool is_callback_called = false;
+  };
+
+  iree_hal_module_debug_sink_t sink = {0};
+  sink.destroy.fn = [](void* user_data) {
+    reinterpret_cast<UserData*>(user_data)->is_callback_called = true;
+    return iree_ok_status();
+  };
+  UserData user_data;
+  sink.destroy.user_data = &user_data;
+  iree_vm_module_t* hal_module;
+  IREE_ASSERT_OK(iree_hal_module_create(
+      instance(), /*device_count=*/1, &device(), IREE_HAL_MODULE_FLAG_NONE,
+      sink, iree_allocator_system(), &hal_module));
+  IREE_ASSERT_FALSE(user_data.is_callback_called);
+  iree_vm_module_release(hal_module);
+  IREE_ASSERT_TRUE(user_data.is_callback_called);
+}
 
 TEST_F(CheckTest, ExpectTrueSuccess) {
   IREE_ASSERT_OK(InvokeValue("expect_true", {iree_vm_value_make_i32(1)}));

--- a/runtime/src/iree/modules/hal/debugging.h
+++ b/runtime/src/iree/modules/hal/debugging.h
@@ -30,12 +30,23 @@ typedef struct iree_hal_module_buffer_view_trace_callback_t {
   void* user_data;
 } iree_hal_module_buffer_view_trace_callback_t;
 
+typedef iree_status_t(
+    IREE_API_PTR* iree_hal_module_debug_sink_destroy_callback_fn_t)(
+    void* user_data);
+
+// Called by the runtime when the HAL module no longer needs the debug sink.
+typedef struct iree_hal_module_debug_sink_destroy_callback_t {
+  iree_hal_module_debug_sink_destroy_callback_fn_t fn;
+  void* user_data;
+} iree_hal_module_debug_sink_destroy_callback_t;
+
 // Interface for a HAL module debug event sink.
 // Any referenced user data must remain live for the lifetime of the HAL module
 // the sink is provided to.
 typedef struct iree_hal_module_debug_sink_t {
   // Called on each hal.buffer_view.trace.
   iree_hal_module_buffer_view_trace_callback_t buffer_view_trace;
+  iree_hal_module_debug_sink_destroy_callback_t destroy;
 } iree_hal_module_debug_sink_t;
 
 // Returns a default debug sink that outputs nothing.

--- a/runtime/src/iree/modules/hal/module.c
+++ b/runtime/src/iree/modules/hal/module.c
@@ -48,6 +48,11 @@ typedef struct iree_hal_module_t {
 
 static void IREE_API_PTR iree_hal_module_destroy(void* base_module) {
   iree_hal_module_t* module = IREE_HAL_MODULE_CAST(base_module);
+
+  if (module->debug_sink.destroy.fn) {
+    module->debug_sink.destroy.fn(module->debug_sink.destroy.user_data);
+  }
+
   for (iree_host_size_t i = 0; i < module->device_count; ++i) {
     iree_hal_device_release(module->devices[i]);
   }


### PR DESCRIPTION
We don't support custom debug sinks in the Runtime Python bindings.
In particular the ability to register a custom callback when tracing
tensors.

This change makes it possible to create a HAL module with a Python
function as a callback.
This implementation does not handle the case of referencing directly or
indirectly the HAL module, VM context or VM instance in the callback
function object. In such a scenario the circular reference will not be
collected by the garbage collector and will leak. No no check is done
to guard against this. It is possible to traverse the Python object
structure to detect a reference to VM objects but it would require more
effort.

Here is added a callback to the debug sink in the IREE native runtime
API that signals when the runtime is done using the debug sink.
We need this since the Python objects corresponding to native runtime
objects are ephemeral and can not be used to hold the reference to the
debug sink.