### PR TITLE
[NFC] Move linalgext external model registration

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.cpp
@@ -52,134 +52,13 @@ struct IREELinalgExtInlinerInterface : public DialectInlinerInterface {
   }
 };
 
-// Used to register the LinalgFusionOpInterface with the linalg ops.
-template <typename ConcreteType>
-struct LinalgFusionOpInterfaceAdapter
-    : public LinalgFusionOpInterface::ExternalModel<
-          LinalgFusionOpInterfaceAdapter<ConcreteType>, ConcreteType> {
-public:
-  SmallVector<AffineMap> getIndexingMapsForOperands(mlir::Operation *op) const {
-    auto maps = llvm::cast<ConcreteType>(op)
-                    .getIndexingMaps()
-                    .template getAsValueRange<AffineMapAttr>();
-    return {maps.begin(),
-            maps.end() - llvm::cast<ConcreteType>(op).getNumResults()};
-  }
-
-  SmallVector<AffineMap> getIndexingMapsForResults(mlir::Operation *op) const {
-    auto maps = llvm::cast<ConcreteType>(op)
-                    .getIndexingMaps()
-                    .template getAsValueRange<AffineMapAttr>();
-    return {maps.end() - llvm::cast<ConcreteType>(op).getNumResults(),
-            maps.end()};
-  }
-
-  // Forward all the interface methods to the corresponding linalg op.
-  unsigned getNumParallelLoops(mlir::Operation *op) const {
-    return (llvm::cast<ConcreteType>(op).getNumParallelLoops());
-  }
-
-  unsigned getNumLoops(mlir::Operation *op) const {
-    return (llvm::cast<ConcreteType>(op).getNumLoops());
-  }
-
-  FailureOr<SmallVector<int64_t>>
-  getStaticLoopRanges(mlir::Operation *op) const {
-    return SmallVector<int64_t>(
-        llvm::cast<ConcreteType>(op).getStaticLoopRanges());
-  }
-
-  AffineMap getIndexingMapMatchingResult(mlir::Operation *op,
-                                         OpResult result) const {
-    return (llvm::cast<ConcreteType>(op).getIndexingMapMatchingResult(result));
-  }
-
-  AffineMap getMatchingIndexingMap(mlir::Operation *op,
-                                   OpOperand *operand) const {
-    return (llvm::cast<ConcreteType>(op).getMatchingIndexingMap(operand));
-  }
-
-  SmallVector<AffineMap> getIndexingMapsArray(mlir::Operation *op) const {
-    auto inputMaps = getIndexingMapsForOperands(op);
-    llvm::append_range(inputMaps, getIndexingMapsForResults(op));
-    return inputMaps;
-  }
-};
-
-struct SoftmaxFusionOpInterfaceAdapter
-    : public LinalgFusionOpInterface::ExternalModel<
-          SoftmaxFusionOpInterfaceAdapter, linalg::SoftmaxOp> {
-public:
-  SmallVector<AffineMap> getIndexingMapsForOperands(mlir::Operation *op) const {
-    Builder b(op->getContext());
-    return llvm::to_vector(llvm::map_range(
-        llvm::cast<linalg::SoftmaxOp>(op).getDpsInputs(),
-        [&b](Value operand) -> AffineMap {
-          auto rank = cast<ShapedType>(operand.getType()).getRank();
-          return b.getMultiDimIdentityMap(rank);
-        }));
-  }
-
-  SmallVector<AffineMap> getIndexingMapsForResults(mlir::Operation *op) const {
-    Builder b(op->getContext());
-    return llvm::to_vector(llvm::map_range(
-        llvm::cast<linalg::SoftmaxOp>(op).getDpsInits(),
-        [&b](Value operand) -> AffineMap {
-          auto rank = cast<ShapedType>(operand.getType()).getRank();
-          return b.getMultiDimIdentityMap(rank);
-        }));
-  }
-
-  FailureOr<SmallVector<int64_t>> getStaticLoopRanges(Operation *op) const {
-    auto softmaxOp = cast<linalg::SoftmaxOp>(op);
-    // Softmax loop range is the input shape.
-    return SmallVector<int64_t>(softmaxOp.getInputOperandType().getShape());
-  }
-
-  AffineMap getIndexingMapMatchingResult(mlir::Operation *op,
-                                         OpResult result) const {
-    return getIndexingMapsForResults(op)[result.getResultNumber()];
-  }
-
-  AffineMap getMatchingIndexingMap(mlir::Operation *op,
-                                   OpOperand *operand) const {
-    return getIndexingMapsForOperands(op)[operand->getOperandNumber()];
-  }
-
-  SmallVector<AffineMap> getIndexingMapsArray(mlir::Operation *op) const {
-    auto inputMaps = getIndexingMapsForOperands(op);
-    llvm::append_range(inputMaps, getIndexingMapsForResults(op));
-    return inputMaps;
-  }
-};
-} // namespace
-
 struct IREELinalgExtDialectOpAsmInterface : public OpAsmDialectInterface {
   using OpAsmDialectInterface::OpAsmDialectInterface;
 };
 
-template <typename... Args>
-static void registerOpsWithLinalgExtOpInterface(mlir::MLIRContext *context) {
-  (Args::template attachInterface<LinalgFusionOpInterfaceAdapter<Args>>(
-       *context),
-   ...);
-}
+} // namespace
 
 void IREELinalgExtDialect::initialize() {
-  mlir::MLIRContext *context = getContext();
-  context->loadDialect<mlir::linalg::LinalgDialect>();
-
-#define GET_OP_LIST
-  declarePromisedInterfaces<LinalgFusionOpInterface,
-#include "mlir/Dialect/Linalg/IR/LinalgStructuredOps.cpp.inc"
-                            >();
-
-#define GET_OP_LIST
-  registerOpsWithLinalgExtOpInterface<
-#include "mlir/Dialect/Linalg/IR/LinalgStructuredOps.cpp.inc"
-      >(context);
-  linalg::SoftmaxOp::attachInterface<SoftmaxFusionOpInterfaceAdapter>(*context);
-
   addInterfaces<IREELinalgExtInlinerInterface>();
 
   addInterfaces<IREELinalgExtDialectOpAsmInterface>();

--- a/compiler/src/iree/compiler/ExternalInterfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/ExternalInterfaces/BUILD.bazel
@@ -17,12 +17,14 @@ iree_compiler_cc_library(
     srcs = [
         "FlowExternalModels.cpp",
         "Interfaces.cpp",
+        "LinalgExtExternalModels.cpp",
         "StreamExternalModels.cpp",
         "UtilExternalModels.cpp",
     ],
     hdrs = [
         "FlowExternalModels.h",
         "Interfaces.h",
+        "LinalgExtExternalModels.h",
         "StreamExternalModels.h",
         "UtilExternalModels.h",
     ],

--- a/compiler/src/iree/compiler/ExternalInterfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/ExternalInterfaces/CMakeLists.txt
@@ -16,11 +16,13 @@ iree_cc_library(
   HDRS
     "FlowExternalModels.h"
     "Interfaces.h"
+    "LinalgExtExternalModels.h"
     "StreamExternalModels.h"
     "UtilExternalModels.h"
   SRCS
     "FlowExternalModels.cpp"
     "Interfaces.cpp"
+    "LinalgExtExternalModels.cpp"
     "StreamExternalModels.cpp"
     "UtilExternalModels.cpp"
   DEPS

--- a/compiler/src/iree/compiler/ExternalInterfaces/Interfaces.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/Interfaces.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/ExternalInterfaces/Interfaces.h"
 
 #include "iree/compiler/ExternalInterfaces/FlowExternalModels.h"
+#include "iree/compiler/ExternalInterfaces/LinalgExtExternalModels.h"
 #include "iree/compiler/ExternalInterfaces/StreamExternalModels.h"
 #include "iree/compiler/ExternalInterfaces/UtilExternalModels.h"
 
@@ -14,6 +15,7 @@ namespace mlir::iree_compiler {
 
 void registerExternalInterfaces(DialectRegistry &registry) {
   registerFlowExternalModels(registry);
+  registerLinalgExtExternalModels(registry);
   registerStreamExternalModels(registry);
   registerUtilExternalModels(registry);
 }

--- a/compiler/src/iree/compiler/ExternalInterfaces/LinalgExtExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/LinalgExtExternalModels.cpp
@@ -1,0 +1,138 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/ExternalInterfaces/LinalgExtExternalModels.h"
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtInterfaces.h"
+#include "mlir/IR/AffineMap.h"
+#include "mlir/IR/BuiltinAttributes.h"
+
+namespace mlir::iree_compiler {
+namespace {
+// Used to register the LinalgFusionOpInterface with the linalg ops.
+template <typename ConcreteType>
+struct LinalgFusionOpInterfaceAdapter
+    : public IREE::LinalgExt::LinalgFusionOpInterface::ExternalModel<
+          LinalgFusionOpInterfaceAdapter<ConcreteType>, ConcreteType> {
+public:
+  SmallVector<AffineMap> getIndexingMapsForOperands(mlir::Operation *op) const {
+    auto maps = llvm::cast<ConcreteType>(op)
+                    .getIndexingMaps()
+                    .template getAsValueRange<AffineMapAttr>();
+    return {maps.begin(),
+            maps.end() - llvm::cast<ConcreteType>(op).getNumResults()};
+  }
+
+  SmallVector<AffineMap> getIndexingMapsForResults(mlir::Operation *op) const {
+    auto maps = llvm::cast<ConcreteType>(op)
+                    .getIndexingMaps()
+                    .template getAsValueRange<AffineMapAttr>();
+    return {maps.end() - llvm::cast<ConcreteType>(op).getNumResults(),
+            maps.end()};
+  }
+
+  // Forward all the interface methods to the corresponding linalg op.
+  unsigned getNumParallelLoops(mlir::Operation *op) const {
+    return (llvm::cast<ConcreteType>(op).getNumParallelLoops());
+  }
+
+  unsigned getNumLoops(mlir::Operation *op) const {
+    return (llvm::cast<ConcreteType>(op).getNumLoops());
+  }
+
+  FailureOr<SmallVector<int64_t>>
+  getStaticLoopRanges(mlir::Operation *op) const {
+    return SmallVector<int64_t>(
+        llvm::cast<ConcreteType>(op).getStaticLoopRanges());
+  }
+
+  AffineMap getIndexingMapMatchingResult(mlir::Operation *op,
+                                         OpResult result) const {
+    return (llvm::cast<ConcreteType>(op).getIndexingMapMatchingResult(result));
+  }
+
+  AffineMap getMatchingIndexingMap(mlir::Operation *op,
+                                   OpOperand *operand) const {
+    return (llvm::cast<ConcreteType>(op).getMatchingIndexingMap(operand));
+  }
+
+  SmallVector<AffineMap> getIndexingMapsArray(mlir::Operation *op) const {
+    auto inputMaps = getIndexingMapsForOperands(op);
+    llvm::append_range(inputMaps, getIndexingMapsForResults(op));
+    return inputMaps;
+  }
+};
+
+struct SoftmaxFusionOpInterfaceAdapter
+    : public IREE::LinalgExt::LinalgFusionOpInterface::ExternalModel<
+          SoftmaxFusionOpInterfaceAdapter, linalg::SoftmaxOp> {
+public:
+  SmallVector<AffineMap> getIndexingMapsForOperands(mlir::Operation *op) const {
+    Builder b(op->getContext());
+    return llvm::to_vector(llvm::map_range(
+        llvm::cast<linalg::SoftmaxOp>(op).getDpsInputs(),
+        [&b](Value operand) -> AffineMap {
+          auto rank = cast<ShapedType>(operand.getType()).getRank();
+          return b.getMultiDimIdentityMap(rank);
+        }));
+  }
+
+  SmallVector<AffineMap> getIndexingMapsForResults(mlir::Operation *op) const {
+    Builder b(op->getContext());
+    return llvm::to_vector(llvm::map_range(
+        llvm::cast<linalg::SoftmaxOp>(op).getDpsInits(),
+        [&b](Value operand) -> AffineMap {
+          auto rank = cast<ShapedType>(operand.getType()).getRank();
+          return b.getMultiDimIdentityMap(rank);
+        }));
+  }
+
+  FailureOr<SmallVector<int64_t>> getStaticLoopRanges(Operation *op) const {
+    auto softmaxOp = cast<linalg::SoftmaxOp>(op);
+    // Softmax loop range is the input shape.
+    return SmallVector<int64_t>(softmaxOp.getInputOperandType().getShape());
+  }
+
+  AffineMap getIndexingMapMatchingResult(mlir::Operation *op,
+                                         OpResult result) const {
+    return getIndexingMapsForResults(op)[result.getResultNumber()];
+  }
+
+  AffineMap getMatchingIndexingMap(mlir::Operation *op,
+                                   OpOperand *operand) const {
+    return getIndexingMapsForOperands(op)[operand->getOperandNumber()];
+  }
+
+  SmallVector<AffineMap> getIndexingMapsArray(mlir::Operation *op) const {
+    auto inputMaps = getIndexingMapsForOperands(op);
+    llvm::append_range(inputMaps, getIndexingMapsForResults(op));
+    return inputMaps;
+  }
+};
+
+template <typename... Args>
+void registerOpsWithLinalgExtOpInterface(mlir::MLIRContext *context) {
+  (Args::template attachInterface<LinalgFusionOpInterfaceAdapter<Args>>(
+       *context),
+   ...);
+}
+
+} // namespace
+
+void registerLinalgExtExternalModels(DialectRegistry &registry) {
+  registry.addExtension(+[](MLIRContext *ctx,
+                            IREE::LinalgExt::IREELinalgExtDialect *dialect) {
+    ctx->loadDialect<mlir::linalg::LinalgDialect>();
+
+#define GET_OP_LIST
+    registerOpsWithLinalgExtOpInterface<
+#include "mlir/Dialect/Linalg/IR/LinalgStructuredOps.cpp.inc"
+        >(ctx);
+    linalg::SoftmaxOp::attachInterface<SoftmaxFusionOpInterfaceAdapter>(*ctx);
+  });
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/ExternalInterfaces/LinalgExtExternalModels.h
+++ b/compiler/src/iree/compiler/ExternalInterfaces/LinalgExtExternalModels.h
@@ -1,0 +1,20 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_EXTERNALINTERFACES_LINALGEXTEXTERNALMODELS_H_
+#define IREE_COMPILER_EXTERNALINTERFACES_LINALGEXTEXTERNALMODELS_H_
+
+namespace mlir {
+class DialectRegistry;
+} // namespace mlir
+
+namespace mlir::iree_compiler {
+
+void registerLinalgExtExternalModels(DialectRegistry &registry);
+
+} // namespace mlir::iree_compiler
+
+#endif // IREE_COMPILER_EXTERNALINTERFACES_LINALGEXTEXTERNALMODELS_H_


### PR DESCRIPTION
Cleanup LinalgExtDialect.cpp by moving the registration of `linalg` ops with `LinalgFusionOpInterface` into ExternalInterfaces/*. When I initially wrote this, I put the registration in the wrong place. Similar to the other external interface registrations in the new directory, `linalg` shouldn't have its interfaces registered from within `LinalgExt` dialect.