### PR TITLE
[LLVMGPU] Make FP8 VMFMA intrinsic discoverable by KernelConfig

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -655,6 +655,8 @@ SmallVector<MMAIntrinsic> MMAAttr::getVirtualIntrinsics() const {
     return {MMAIntrinsic::VMFMA_F32_16x16x32_F16};
   case MMAIntrinsic::MFMA_F32_32x32x8_F16:
     return {MMAIntrinsic::VMFMA_F32_32x32x16_F16};
+  case MMAIntrinsic::MFMA_F32_16x16x32_F8E4M3FNUZ:
+    return {MMAIntrinsic::VMFMA_F32_16x16x32_F8E4M3FNUZ};
   default:
     return {};
   }


### PR DESCRIPTION
Making VMFMA_F32_16x16x32_F8E4M3FNUZ visible/accessible from `getVirtualIntrinsics` S.T we can eventually pick this intrinsic from KernelConfig. 

Right now since by default since we always choose the "first" found intrinsic, it is practically guaranteed to never pick the virtual intrinsics by heuristics. Hence we are only specifying the intrinsics through tuning/spec script. 

However since we are planning to add some heuristics in the future on KernelConfig to be able to select this virtual intrinsic when necessary, we are making it visible now. 