### PR TITLE
[HAL] Add option to disable executable linking

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.h
@@ -51,7 +51,7 @@ namespace mlir::iree_compiler::IREE::HAL {
 //      filter="spirv-v1.2-desktop*"
 //          hal.executable.export @my_entry
 //          module { ... }
-//   [[-iree-hal-translate-executables]]
+//   [[-iree-hal-translate-all-executables]]
 //   -> hal.executable @my_exe
 //      + hal.executable.variant @spirv-v1.1-mobile filter="spirv-v1.1-mobile*"
 //          hal.executable.export @my_entry_1
@@ -66,9 +66,9 @@ namespace mlir::iree_compiler::IREE::HAL {
 //      filter="spirv-v1.2-desktop*"
 //          hal.executable.export @my_entry
 //          module { spirv.module { ... } }
-//   [[-iree-hal-link-executables]]
+//   [[-iree-hal-link-all-executables]]
 //   -> TODO(benvanik): linkage rules.
-//   [[-iree-hal-serialize-executables]]
+//   [[-iree-hal-serialize-all-executables]]
 //   -> hal.executable @my_exe
 //      + hal.executable.binary attributes { ... }
 //          data blob...

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetOptions.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetOptions.cpp
@@ -18,7 +18,7 @@ void TargetOptions::bindOptions(OptionsBinder &binder) {
       "IREE HAL executable target options");
 
   // This function is called as part of registering the pass
-  // TranslateExecutablesPass. Pass registry is also staticly
+  // TranslateAllExecutablesPass. Pass registry is also staticly
   // initialized, so targetBackendsFlags needs to be here to be initialized
   // first.
   binder.list<std::string>(

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/LinkExecutables.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/LinkExecutables.cpp
@@ -22,7 +22,7 @@
 
 namespace mlir::iree_compiler::IREE::HAL {
 
-#define GEN_PASS_DEF_LINKEXECUTABLESPASS
+#define GEN_PASS_DEF_LINKALLEXECUTABLESPASS
 #define GEN_PASS_DEF_LINKTARGETEXECUTABLESPASS
 #include "iree/compiler/Dialect/HAL/Transforms/Passes.h.inc"
 
@@ -66,13 +66,14 @@ struct LinkTargetExecutablesPass
 };
 
 //===----------------------------------------------------------------------===//
-// --iree-hal-link-executables
+// --iree-hal-link-all-executables
 //===----------------------------------------------------------------------===//
 
-struct LinkExecutablesPass
-    : public IREE::HAL::impl::LinkExecutablesPassBase<LinkExecutablesPass> {
-  using IREE::HAL::impl::LinkExecutablesPassBase<
-      LinkExecutablesPass>::LinkExecutablesPassBase;
+struct LinkAllExecutablesPass
+    : public IREE::HAL::impl::LinkAllExecutablesPassBase<
+          LinkAllExecutablesPass> {
+  using IREE::HAL::impl::LinkAllExecutablesPassBase<
+      LinkAllExecutablesPass>::LinkAllExecutablesPassBase;
   void runOnOperation() override {
     auto moduleOp = getOperation();
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
@@ -139,6 +139,15 @@ static llvm::cl::list<std::string> clPreprocessExecutablesWith{
         "will fail compilation."),
 };
 
+static llvm::cl::opt<bool> clDebugDisableLinkExecutables{
+    "iree-hal-debug-disable-link-executables",
+    llvm::cl::desc(
+        "Disables linking of executables. This allows inspecting serialization "
+        "of each executable in isolation and will dump a single binary per "
+        "executable when used in conjunction with "
+        "`--iree-hal-dump-executable-binaries-to`."),
+};
+
 } // namespace
 
 using FunctionLikeNest =
@@ -475,7 +484,7 @@ void buildHALTransformPassPipeline(OpPassManager &passManager,
   // example, the LLVM AOT backend may combine all executable targets for the
   // same architecture into a single executable and link it as a shared
   // library.
-  if (transformOptions.linkExecutables) {
+  if (transformOptions.linkExecutables && !clDebugDisableLinkExecutables) {
     passManager.addPass(IREE::HAL::createLinkExecutablesPass({targetRegistry}));
   }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
@@ -147,6 +147,7 @@ static llvm::cl::opt<bool> clLinkExecutables{
         "of each executable in isolation and will dump a single binary per "
         "executable when used in conjunction with "
         "`--iree-hal-dump-executable-binaries-to`."),
+    llvm::cl::init(true),
 };
 
 } // namespace

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.td
@@ -376,8 +376,8 @@ def ConfigureTargetExecutableVariantsPass :
   ];
 }
 
-def TranslateExecutablesPass :
-    Pass<"iree-hal-translate-executables", "IREE::HAL::ExecutableOp"> {
+def TranslateAllExecutablesPass :
+    Pass<"iree-hal-translate-all-executables", "IREE::HAL::ExecutableOp"> {
   let summary = "Translates hal.executable ops via a nested translation pipeline.";
   let description = [{
     Runs a nested pipeline on each executable to translate its variants from
@@ -426,8 +426,8 @@ def PruneExecutablesPass :
   }];
 }
 
-def LinkExecutablesPass :
-    Pass<"iree-hal-link-executables", "mlir::ModuleOp"> {
+def LinkAllExecutablesPass :
+    Pass<"iree-hal-link-all-executables", "mlir::ModuleOp"> {
   let summary = "Links hal.executable ops into one or more hal.executable ops.";
   let description = [{
     Runs a nested pipeline to link multiple `hal.executable` ops together if the
@@ -479,8 +479,8 @@ def ResolveExportOrdinalsPass :
   ];
 }
 
-def SerializeExecutablesPass :
-    Pass<"iree-hal-serialize-executables", "IREE::HAL::ExecutableOp"> {
+def SerializeAllExecutablesPass :
+    Pass<"iree-hal-serialize-all-executables", "IREE::HAL::ExecutableOp"> {
   let summary = "Converts hal.executable.variants to one or more hal.executable.binary ops.";
   let description = [{
     Runs a nested pipeline on each executable to serialize its variants from

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/SerializeExecutables.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/SerializeExecutables.cpp
@@ -23,7 +23,7 @@
 
 namespace mlir::iree_compiler::IREE::HAL {
 
-#define GEN_PASS_DEF_SERIALIZEEXECUTABLESPASS
+#define GEN_PASS_DEF_SERIALIZEALLEXECUTABLESPASS
 #define GEN_PASS_DEF_SERIALIZETARGETEXECUTABLESPASS
 #include "iree/compiler/Dialect/HAL/Transforms/Passes.h.inc"
 
@@ -96,14 +96,14 @@ struct SerializeTargetExecutablesPass
 };
 
 //===----------------------------------------------------------------------===//
-// --iree-hal-serialize-executables
+// --iree-hal-serialize-all-executables
 //===----------------------------------------------------------------------===//
 
-struct SerializeExecutablesPass
-    : public IREE::HAL::impl::SerializeExecutablesPassBase<
-          SerializeExecutablesPass> {
-  using IREE::HAL::impl::SerializeExecutablesPassBase<
-      SerializeExecutablesPass>::SerializeExecutablesPassBase;
+struct SerializeAllExecutablesPass
+    : public IREE::HAL::impl::SerializeAllExecutablesPassBase<
+          SerializeAllExecutablesPass> {
+  using IREE::HAL::impl::SerializeAllExecutablesPassBase<
+      SerializeAllExecutablesPass>::SerializeAllExecutablesPassBase;
   void runOnOperation() override {
     auto executableOp = getOperation();
     OpPassManager passManager(executableOp.getOperationName());

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/TranslateExecutables.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/TranslateExecutables.cpp
@@ -23,7 +23,7 @@
 
 namespace mlir::iree_compiler::IREE::HAL {
 
-#define GEN_PASS_DEF_TRANSLATEEXECUTABLESPASS
+#define GEN_PASS_DEF_TRANSLATEALLEXECUTABLESPASS
 #define GEN_PASS_DEF_TRANSLATETARGETEXECUTABLEVARIANTSPASS
 #include "iree/compiler/Dialect/HAL/Transforms/Passes.h.inc"
 
@@ -75,14 +75,14 @@ struct TranslateTargetExecutableVariantsPass
 };
 
 //===----------------------------------------------------------------------===//
-// --iree-hal-translate-executables
+// --iree-hal-translate-all-executables
 //===----------------------------------------------------------------------===//
 
-struct TranslateExecutablesPass
-    : public IREE::HAL::impl::TranslateExecutablesPassBase<
-          TranslateExecutablesPass> {
-  using IREE::HAL::impl::TranslateExecutablesPassBase<
-      TranslateExecutablesPass>::TranslateExecutablesPassBase;
+struct TranslateAllExecutablesPass
+    : public IREE::HAL::impl::TranslateAllExecutablesPassBase<
+          TranslateAllExecutablesPass> {
+  using IREE::HAL::impl::TranslateAllExecutablesPassBase<
+      TranslateAllExecutablesPass>::TranslateAllExecutablesPassBase;
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<IREE::HAL::HALDialect>();

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Transforms/Passes.cpp
@@ -72,7 +72,7 @@ void buildHALInlineStaticTransformPassPipeline(
   passManager.addNestedPass<IREE::HAL::ExecutableOp>(
       IREE::HAL::createConfigureExecutablesPass({targetRegistry}));
   passManager.addNestedPass<IREE::HAL::ExecutableOp>(
-      IREE::HAL::createTranslateExecutablesPass({targetRegistry}));
+      IREE::HAL::createTranslateAllExecutablesPass({targetRegistry}));
 
   // Inline the translated executable functions.
   // We preserve the executables for their metadata used during conversion.

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/Transforms/Passes.cpp
@@ -77,7 +77,7 @@ void buildHALInlineDynamicTransformPassPipeline(
   passManager.addNestedPass<IREE::HAL::ExecutableOp>(
       IREE::HAL::createConfigureExecutablesPass({targetRegistry}));
   passManager.addNestedPass<IREE::HAL::ExecutableOp>(
-      IREE::HAL::createTranslateExecutablesPass({targetRegistry}));
+      IREE::HAL::createTranslateAllExecutablesPass({targetRegistry}));
 
   //----------------------------------------------------------------------------
   // Conversion
@@ -91,7 +91,8 @@ void buildHALInlineDynamicTransformPassPipeline(
   //----------------------------------------------------------------------------
 
   // Link executables together.
-  passManager.addPass(IREE::HAL::createLinkExecutablesPass({targetRegistry}));
+  passManager.addPass(
+      IREE::HAL::createLinkAllExecutablesPass({targetRegistry}));
 
   // Resolve export ordinals from nested symbol references prior to
   // serialization.
@@ -99,7 +100,7 @@ void buildHALInlineDynamicTransformPassPipeline(
 
   // Serialize executables to their binary forms.
   passManager.addNestedPass<IREE::HAL::ExecutableOp>(
-      IREE::HAL::createSerializeExecutablesPass(
+      IREE::HAL::createSerializeAllExecutablesPass(
           {&targetRegistry, targetOptions.debugLevel,
            targetOptions.executableIntermediatesPath,
            targetOptions.executableBinariesPath}));

--- a/docs/website/docs/developers/debugging/compile-time-regressions.md
+++ b/docs/website/docs/developers/debugging/compile-time-regressions.md
@@ -193,7 +193,7 @@ See our documentation on
 the section on
 [tracing `iree-compile`](../performance/profiling-with-tracy.md#tracing-iree-compile).
 For compile time regressions, pay particular attention to the compilation
-phases (Flow/Stream/HAL), how many times `TranslateExecutablesPass` runs, and
+phases (Flow/Stream/HAL), how many times `TranslateAllExecutablesPass` runs, and
 if there are outlier passes that take significantly longer to run than others.
 
 Here are some previous analyses for inspiration:

--- a/tests/compiler_driver/hal_executable.mlir
+++ b/tests/compiler_driver/hal_executable.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-compile --compile-mode=hal-executable \
-// RUN:   --mlir-print-ir-after=iree-hal-serialize-executables \
+// RUN:   --mlir-print-ir-after=iree-hal-serialize-all-executables \
 // RUN:   --iree-hal-target-backends=vmvx %s \
 // RUN:   --o=/dev/null 2>&1 | FileCheck %s
 

--- a/tools/test/executable_configurations.mlir
+++ b/tools/test/executable_configurations.mlir
@@ -3,7 +3,7 @@
 // RUN:     --iree-hal-dump-executable-configurations-to=- | \
 // RUN: iree-compile - -o /dev/null \
 // RUN:     --compile-mode=hal-executable \
-// RUN:     --mlir-print-ir-before=iree-hal-serialize-executables 2>&1 | \
+// RUN:     --mlir-print-ir-before=iree-hal-serialize-all-executables 2>&1 | \
 // RUN: FileCheck %s
 
 // This test relies on piping stdout and that there is only a single
@@ -21,7 +21,7 @@
 //      --iree-hal-dump-executable-configurations-to=configs/ | \
 //  ls -1 sources/ | xargs -i sh -c "iree-compile configs/{}
 //      --compile-mode=hal-executable
-//      --mlir-print-ir-before=iree-hal-serialize-executables"
+//      --mlir-print-ir-before=iree-hal-serialize-all-executables"
 //
 // NOTE: executable configurations are not runnable: they only exist to allow
 // for iteration on executable translation. If you want to run them you need
@@ -38,7 +38,7 @@ func.func @abs(%input : tensor<f32>) -> tensor<f32> {
   return %result : tensor<f32>
 }
 
-// CHECK: IR Dump Before SerializeExecutablesPass
+// CHECK: IR Dump Before SerializeAllExecutablesPass
 // CHECK: hal.executable public @abs_dispatch_0
 // CHECK:   hal.executable.variant public @vmvx_bytecode_fb
 // CHECK:     vm.func private @abs_dispatch_0_elementwise

--- a/tools/test/executable_sources.mlir
+++ b/tools/test/executable_sources.mlir
@@ -3,7 +3,7 @@
 // RUN:     --iree-hal-dump-executable-sources-to=- | \
 // RUN: iree-compile - -o /dev/null \
 // RUN:     --compile-mode=hal-executable \
-// RUN:     --mlir-print-ir-before=iree-hal-serialize-executables 2>&1 | \
+// RUN:     --mlir-print-ir-before=iree-hal-serialize-all-executables 2>&1 | \
 // RUN: FileCheck %s
 
 // This test relies on us piping stdout and that there's only a single
@@ -19,7 +19,7 @@
 //  iree-compile some_input.mlir -o ignored.mlir \
 //      --iree-hal-target-backends=vmvx \
 //      --iree-hal-dump-executable-sources-to=sources/ | \
-//  ls -1 sources/ | xargs -i sh -c "iree-compile sources/{} --compile-mode=hal-executable --mlir-print-ir-before=iree-hal-serialize-executables"
+//  ls -1 sources/ | xargs -i sh -c "iree-compile sources/{} --compile-mode=hal-executable --mlir-print-ir-before=iree-hal-serialize-all-executables"
 //
 // NOTE: executable sources are not runnable: they only exist to allow for
 // iteration on executable translation. If you want to run them you need
@@ -36,7 +36,7 @@ func.func @abs(%input : tensor<f32>) -> (tensor<f32>) {
   return %result : tensor<f32>
 }
 
-// CHECK: IR Dump Before SerializeExecutablesPass
+// CHECK: IR Dump Before SerializeAllExecutablesPass
 // CHECK: hal.executable public @abs_dispatch_0
 // CHECK:   hal.executable.variant public @vmvx_bytecode_fb
 // CHECK:     vm.func private @abs_dispatch_0_elementwise


### PR DESCRIPTION
This is useful because without disabling linking,
`--iree-hal-dump-executable-binaries-to` and
`--iree-hal-dump-executable-intermediates-to` will dump a single large linked file rather than one file per executable.

This is expected to only ever be used for development/debugging purposes.