### PR TITLE
Fix Windows+macOS CI by updating to Python 3.11.

### DIFF
--- a/.github/workflows/ci_macos_x64_clang.yml
+++ b/.github/workflows/ci_macos_x64_clang.yml
@@ -43,7 +43,7 @@ jobs:
       - name: "Setting up Python"
         uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.1.0
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache: "pip"
       - name: "Installing Python packages"
         run: pip install -r runtime/bindings/python/iree/runtime/build_requirements.txt

--- a/.github/workflows/ci_windows_x64_msvc.yml
+++ b/.github/workflows/ci_windows_x64_msvc.yml
@@ -36,7 +36,7 @@ jobs:
       - name: "Setting up Python"
         uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.1.0
         with:
-          python-version: "3.10" # Needs pybind >= 2.10.1 for Python >= 3.11
+          python-version: "3.11"
       - name: "Installing Python packages"
         run: |
           python3 -m venv .venv

--- a/compiler/bindings/python/test/build_api/mnist_builder_test.py
+++ b/compiler/bindings/python/test/build_api/mnist_builder_test.py
@@ -112,8 +112,8 @@ class MnistBuilderTest(unittest.TestCase):
             mod, args=["mnist/mnist.mlir"] + DEFAULT_TARGET_ARGS, stdout=out_file
         )
         output = out_file.getvalue().strip()
-        self.assertIn("genfiles/mnist/mnist.mlir", output)
         output_path = Path(output)
+        self.assertIn("genfiles/mnist/mnist.mlir", output_path.as_posix())
         contents = output_path.read_text()
         self.assertIn("module", contents)
 


### PR DESCRIPTION
Pending CI builds (since these are nightly / on-demand and take hours):
* Windows: https://github.com/iree-org/iree/actions/runs/11689195978
* macOS: https://github.com/iree-org/iree/actions/runs/11689197108

The new `iree.build` package depends on Python 3.11: https://github.com/iree-org/iree/pull/18630#discussion_r1829702786. We currently publish Python packages for 3.9+ on Linux but only 3.11+ on macOS and Windows:
* https://github.com/iree-org/iree/blob/9650bfe441d5f8ce4a16395ee6b3ad43968caa2e/build_tools/python_deploy/build_linux_packages.sh#L68
* https://github.com/iree-org/iree/blob/9650bfe441d5f8ce4a16395ee6b3ad43968caa2e/.github/workflows/build_package.yml#L259-L266
* https://github.com/iree-org/iree/blob/9650bfe441d5f8ce4a16395ee6b3ad43968caa2e/.github/workflows/build_package.yml#L247-L254

We can relax the 3.11 dependency in the package, but we might as well update these workflows to test with the version that we distribute packages for.