### PR TITLE
Disable `-Wno-error=parentheses` on gcc to fix torch-mlir build.

### DIFF
--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -222,7 +222,6 @@ iree_select_compiler_opts(IREE_DEFAULT_COPTS
     "-Wall"
     "$<$<BOOL:${IREE_ENABLE_WERROR_FLAG}>:-Werror>"
     "-Wno-error=deprecated-declarations"  # Want to see them but defaults to error.
-    "-Wno-error=parentheses"  # Not useful enough to enable, and some deps aren't clean on this.
 
     "-Wno-address"  # https://github.com/iree-org/iree/issues/16016
     "-Wno-address-of-packed-member"

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -222,6 +222,7 @@ iree_select_compiler_opts(IREE_DEFAULT_COPTS
     "-Wall"
     "$<$<BOOL:${IREE_ENABLE_WERROR_FLAG}>:-Werror>"
     "-Wno-error=deprecated-declarations"  # Want to see them but defaults to error.
+    "-Wno-error=parentheses"  # Not useful enough to enable, and some deps aren't clean on this.
 
     "-Wno-address"  # https://github.com/iree-org/iree/issues/16016
     "-Wno-address-of-packed-member"

--- a/compiler/plugins/input/Torch/torch-mlir/CMakeLists.txt
+++ b/compiler/plugins/input/Torch/torch-mlir/CMakeLists.txt
@@ -10,7 +10,7 @@
 if(MSVC)
   add_compile_options(/wd4996)
 else()
-  if(GCC)
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     add_compile_options(-Wno-error=parentheses)
   endif()
   add_compile_options(-Wno-deprecated-declarations)

--- a/compiler/plugins/input/Torch/torch-mlir/CMakeLists.txt
+++ b/compiler/plugins/input/Torch/torch-mlir/CMakeLists.txt
@@ -10,6 +10,9 @@
 if(MSVC)
   add_compile_options(/wd4996)
 else()
+  if(GCC)
+    add_compile_options(-Wno-error=parentheses)
+  endif()
   add_compile_options(-Wno-deprecated-declarations)
 endif()
 


### PR DESCRIPTION
Test runs:
* https://github.com/iree-org/iree/actions/runs/11689400528 (global error disable)
* https://github.com/iree-org/iree/actions/runs/11714927110 (local error disable)
* https://github.com/iree-org/iree/actions/runs/11716788601 (local error disable, different check)

Working around the build break reported here:
* https://github.com/iree-org/iree/pull/18897#issuecomment-2451833463
* https://github.com/llvm/torch-mlir/pull/3813#discussion_r1826102619

Logs:
```
 FAILED: compiler/plugins/input/Torch/torch-mlir/CMakeFiles/iree_compiler_plugins_input_Torch_torch-mlir_TorchDialectIR.objects.dir/__/__/__/__/__/third_party/torch-mlir/lib/Dialect/Torch/IR/TorchOps.cpp.o 
/usr/local/bin/ccache /usr/bin/g++-9  -I/__w/iree/iree -I/__w/iree/iree/build-gcc -I/__w/iree/iree/third_party/torch-mlir/include -I/__w/iree/iree/compiler/plugins/input/Torch -I/__w/iree/iree/build-gcc/compiler/plugins/input/Torch -I/__w/iree/iree/third_party/llvm-project/llvm/include -I/__w/iree/iree/build-gcc/llvm-project/include -I/__w/iree/iree/third_party/llvm-project/mlir/include -I/__w/iree/iree/build-gcc/llvm-project/tools/mlir/include -I/__w/iree/iree/third_party/llvm-project/lld/include -I/__w/iree/iree/build-gcc/llvm-project/tools/lld/include -O3  -fPIC -Wno-deprecated-declarations -fvisibility=hidden -fno-rtti -fno-exceptions -Wall -Werror -Wno-error=deprecated-declarations -Wno-address -Wno-address-of-packed-member -Wno-comment -Wno-format-zero-length -Wno-uninitialized -Wno-overloaded-virtual -Wno-invalid-offsetof -Wno-sign-compare -Wno-unused-function -Wno-unknown-pragmas -Wno-unused-but-set-variable -Wno-misleading-indentation -fmacro-prefix-map=/__w/iree/iree=iree -std=gnu++17 -MD -MT compiler/plugins/input/Torch/torch-mlir/CMakeFiles/iree_compiler_plugins_input_Torch_torch-mlir_TorchDialectIR.objects.dir/__/__/__/__/__/third_party/torch-mlir/lib/Dialect/Torch/IR/TorchOps.cpp.o -MF compiler/plugins/input/Torch/torch-mlir/CMakeFiles/iree_compiler_plugins_input_Torch_torch-mlir_TorchDialectIR.objects.dir/__/__/__/__/__/third_party/torch-mlir/lib/Dialect/Torch/IR/TorchOps.cpp.o.d -o compiler/plugins/input/Torch/torch-mlir/CMakeFiles/iree_compiler_plugins_input_Torch_torch-mlir_TorchDialectIR.objects.dir/__/__/__/__/__/third_party/torch-mlir/lib/Dialect/Torch/IR/TorchOps.cpp.o -c /__w/iree/iree/third_party/torch-mlir/lib/Dialect/Torch/IR/TorchOps.cpp
In file included from /usr/include/c++/9/cassert:44,
                 from /__w/iree/iree/third_party/llvm-project/llvm/include/llvm/Support/TypeSize.h:22,
                 from /__w/iree/iree/third_party/llvm-project/mlir/include/mlir/Interfaces/DataLayoutInterfaces.h:21,
                 from /__w/iree/iree/third_party/llvm-project/mlir/include/mlir/IR/BuiltinOps.h:21,
                 from /__w/iree/iree/third_party/llvm-project/mlir/include/mlir/IR/PatternMatch.h:13,
                 from /__w/iree/iree/third_party/torch-mlir/include/torch-mlir/Dialect/Torch/Utils/Utils.h:12,
                 from /__w/iree/iree/third_party/torch-mlir/lib/Dialect/Torch/IR/TorchOps.cpp:11:
/__w/iree/iree/third_party/torch-mlir/lib/Dialect/Torch/IR/TorchOps.cpp: In member function 'mlir::OpFoldResult mlir::torch::Torch::AtenSliceTensorOp::fold(mlir::torch::Torch::AtenSliceTensorOp::FoldAdaptor)':
/__w/iree/iree/third_party/torch-mlir/lib/Dialect/Torch/IR/TorchOps.cpp:4005:42: error: suggest parentheses around '&&' within '||' [-Werror=parentheses]
 4005 |            (stride < 0 && begin > limit) &&
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
 4006 |                "aten.slice.Tensor iteration args are statically invalid.");
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```