### PR TITLE
Mark failing Colab notebook tests as XFAIL.

### DIFF
--- a/samples/colab/test_notebooks.py
+++ b/samples/colab/test_notebooks.py
@@ -22,7 +22,9 @@ NOTEBOOKS_TO_SKIP = [
 ]
 
 NOTEBOOKS_EXPECTED_TO_FAIL = [
-    # None!
+    # See https://github.com/iree-org/iree/issues/18919
+    "tensorflow_hub_import.ipynb",
+    "tflite_text_classification.ipynb",
 ]
 
 


### PR DESCRIPTION
See https://github.com/iree-org/iree/issues/18919.

Tested here: https://github.com/iree-org/iree/actions/runs/11689771962

* I was able to reproduce the `tensorflow_hub_import.ipynb` compile failure in Colab. Might be a real compiler regression in there.
* I was _not_ able to reproduce the `tflite_text_classification.ipynb` error - likely some diff between the simulated test environment we have and what is running in hosted Colab instances.