### PR TITLE
Adding stream lowering to hal.device.queue.fill/hal.device.queue.copy.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
@@ -995,6 +995,49 @@ static void insertSerializationBarriers(Location loc, Block &block,
   }
 }
 
+// Checks if |executeOp| contains only a single transfer operation and returns
+// it. Non-transfer/dispatch operations like cache control will be ignored.
+//
+// Intended to match things like:
+//   stream.cmd.execute ... {
+//     stream.cmd.invalidate
+//     stream.cmd.fill        <----- returned
+//     stream.cmd.flush
+//   }
+// And not:
+//   stream.cmd.execute ... {
+//     stream.cmd.invalidate
+//     stream.cmd.fill
+//     stream.cmd.flush
+//     stream.cmd.dispatch
+//   }
+static Operation *matchSingleTransferOp(IREE::Stream::CmdExecuteOp executeOp) {
+  Operation *foundOp = nullptr;
+  for (auto &block : executeOp.getBodyRegion()) {
+    for (auto &op : block) {
+      if (!TypeSwitch<Operation *, bool>(&op)
+               // Ignore non-transfer/dispatch ops.
+               .Case<IREE::Stream::CmdInvalidateOp, IREE::Stream::CmdFlushOp,
+                     IREE::Stream::CmdDiscardOp, IREE::Stream::YieldOp>(
+                   [&](auto metaOp) { return true; })
+               .Case<IREE::Stream::CmdFillOp, IREE::Stream::CmdCopyOp>(
+                   [&](auto transferOp) {
+                     if (!foundOp) {
+                       foundOp = &op; // first found
+                       return true;
+                     } else {
+                       return false; // more than one transfer op
+                     }
+                   })
+               // Dispatch/collective/etc fail the search.
+               .Default([&](auto otherOp) { return false; })) {
+        return nullptr;
+      }
+    }
+  }
+  return foundOp;
+}
+
 struct CmdExecuteOpPattern
     : public StreamConversionPattern<IREE::Stream::CmdExecuteOp> {
   using StreamConversionPattern::StreamConversionPattern;
@@ -1004,6 +1047,52 @@ struct CmdExecuteOpPattern
     auto loc = executeOp.getLoc();
     auto [device, queueAffinity] =
         lookupDeviceAndQueueAffinityFor(executeOp, rewriter);
+
+    // If the command buffer only contains a single transfer command we may be
+    // able to convert it to a queue operation instead. This will have
+    // significantly less overhead than a command buffer especially if we are
+    // not able to memoize it.
+    if (auto *singleTransferOp = matchSingleTransferOp(executeOp)) {
+      // Gather wait/signal fence, which are optional.
+      Value waitFence =
+          getOrCreateWaitFence(loc, adaptor.getAwaitTimepoint(), rewriter);
+      Value signalFence = getOrCreateSignalFence(
+          loc, device, executeOp.getResultTimepoint(), rewriter);
+
+      // Replace the op with the queue operation.
+      // Note that since we are matching an op nested within the region we have
+      // to get the corresponding externally captured operand and lookup the
+      // remapped value from the conversion state.
+      //
+      // Example:
+      //   stream.cmd.execute ... with(%operand as %capture: !stream.resource)
+      //     stream.cmd.fill ... %capture
+      //  ->
+      //   hal.device.queue.fill ... target(%operand : !hal.buffer)
+      if (auto fillOp = dyn_cast<IREE::Stream::CmdFillOp>(*singleTransferOp)) {
+        auto fillTargetBuffer = rewriter.getRemappedValue(
+            executeOp.getClosureCapturedValue(fillOp.getTarget()));
+        rewriter.create<IREE::HAL::DeviceQueueFillOp>(
+            loc, device, queueAffinity, waitFence, signalFence,
+            fillTargetBuffer, fillOp.getTargetOffset(),
+            fillOp.getTargetLength(), fillOp.getValue(),
+            /*flags=*/0);
+      } else if (auto copyOp =
+                     dyn_cast<IREE::Stream::CmdCopyOp>(*singleTransferOp)) {
+        auto copySourceBuffer = rewriter.getRemappedValue(
+            executeOp.getClosureCapturedValue(copyOp.getSource()));
+        auto copyTargetBuffer = rewriter.getRemappedValue(
+            executeOp.getClosureCapturedValue(copyOp.getTarget()));
+        rewriter.create<IREE::HAL::DeviceQueueCopyOp>(
+            loc, device, queueAffinity, waitFence, signalFence,
+            copySourceBuffer, copyOp.getSourceOffset(), copyTargetBuffer,
+            copyOp.getTargetOffset(), copyOp.getLength(),
+            /*flags=*/0);
+      }
+
+      rewriter.replaceOp(executeOp, signalFence);
+      return success();
+    }
 
     // Until uniform buffers are implemented we can't reuse command buffers that
     // contain non-constant uniform values (i32, index, etc). We'll have a pass

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilInterfaces.td
@@ -52,6 +52,24 @@ def Util_ClosureOpInterface : OpInterface<"ClosureOpInterface"> {
     >,
     InterfaceMethod<
       /*desc=*/[{
+        Returns the value captured by the closure operands or the provided value
+        if it was not captured.
+      }],
+      /*retTy=*/"Value",
+      /*methodName=*/"getClosureCapturedValue",
+      /*args=*/(ins "Value":$closureValue),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        if (auto arg = dyn_cast<BlockArgument>(closureValue)) {
+          if (arg.getParentRegion() == &$_op.getClosureBodyRegion()) {
+            return $_op.getClosureOperands()[arg.getArgNumber()];
+          }
+        }
+        return closureValue;
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
         Returns true if the given operation can exist in the closure.
         Not all operations that a closure can contain are guaranteed to be folded
         into the closure, such as when the operation may have side-effects.


### PR DESCRIPTION
Stream execution regions that contain only a single transfer operation are now converted to queue operations. This avoids the additional command buffer overhead for individual operations that don't benefit from batching. At runtime these route to the HAL device queue methods which implementations can use to optimize standalone transfer requests (e.g. mapping to `cuMemcpyAsync`).

There's currently no `hal.device.queue.update` equivalent in the stream dialect but that will be added as part of the dynamic uniform values for reusable command buffers workstream.