### PR TITLE
Remove condition from loop_sync causing busy wait.

### DIFF
--- a/runtime/src/iree/base/loop_sync.c
+++ b/runtime/src/iree/base/loop_sync.c
@@ -985,8 +985,7 @@ static iree_status_t iree_loop_sync_drain_scope(iree_loop_sync_t* loop_sync,
     IREE_RETURN_AND_END_ZONE_IF_ERROR(
         z0, iree_loop_wait_list_scan(loop_sync->wait_list, loop_sync->run_ring,
                                      &earliest_deadline_ns));
-    if (earliest_deadline_ns != IREE_TIME_INFINITE_PAST &&
-        earliest_deadline_ns != IREE_TIME_INFINITE_FUTURE) {
+    if (earliest_deadline_ns != IREE_TIME_INFINITE_PAST) {
       // Commit the wait operation, waiting up until the minimum of the user
       // specified and wait list derived values.
       iree_time_t wait_deadline_ns = earliest_deadline_ns < deadline_ns


### PR DESCRIPTION
* Discussed with benvanik offline and this appears to have just been a bug in the original implementation.
* The effect in certain situations is that the loop can busy wait at high frequency. Everything still functions but high CPU use occurs and trace event counts are excessive.
* Ran shortfin's test suite, which is the heaviest user of this and verified it works. Manually inspected traces to verify that the high frequency looping does not happen.