### PR TITLE
[DT] Omit tensor.extract_slice when setting the encodings.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPackUnPack.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPackUnPack.cpp
@@ -280,7 +280,8 @@ FailureOr<tensor::UnPackOp> lowerUnsetEncodingToUnpackOp(
   // Create an `tensor.empty` for the result of the unpack operation.
   Location loc = encodingOp.getLoc();
   SmallVector<OpFoldResult> resultDims =
-      tensor::getMixedSizes(rewriter, loc, encodingOp.getSource());
+      getMixedValues(encodingOp.getResultType().getShape(),
+                     encodingOp.getResultDims(), rewriter);
   auto emptyOp = rewriter.create<tensor::EmptyOp>(loc, resultDims,
                                                   sourceType.getElementType());
   FailureOr<SmallVector<OpFoldResult>> innerTileSizesOfr = getInnerTileSizesOfr(

--- a/compiler/src/iree/compiler/DispatchCreation/SetEncoding.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SetEncoding.cpp
@@ -45,9 +45,8 @@ Value setEncoding(OpBuilder &builder, Location loc, Value source,
   return builder.create<IREE::Encoding::SetEncodingOp>(loc, resultType, source);
 };
 
-static Value unsetEncodingAndExtractSlice(OpBuilder &builder, Location loc,
-                                          Value source,
-                                          SmallVector<OpFoldResult> sizes) {
+static Value unsetEncoding(OpBuilder &builder, Location loc, Value source,
+                           SmallVector<OpFoldResult> sizes) {
   SmallVector<Value> dynamicSizesVec;
   SmallVector<int64_t> staticSizesVec;
   dispatchIndexOpFoldResults(sizes, dynamicSizesVec, staticSizesVec);
@@ -55,16 +54,8 @@ static Value unsetEncodingAndExtractSlice(OpBuilder &builder, Location loc,
   auto sourceType = cast<RankedTensorType>(source.getType());
   auto unsetEncodingReturnType =
       RankedTensorType::get(sourceType.getShape(), sourceType.getElementType());
-  auto unsetEncoding =
-      builder
-          .create<IREE::Encoding::UnsetEncodingOp>(loc, unsetEncodingReturnType,
-                                                   source, dynamicSizesVec)
-          .getResult();
-  auto rank = sourceType.getRank();
-  SmallVector<OpFoldResult> offsets(rank, builder.getIndexAttr(0));
-  SmallVector<OpFoldResult> strides(rank, builder.getIndexAttr(1));
-  return builder.create<tensor::ExtractSliceOp>(loc, unsetEncoding, offsets,
-                                                sizes, strides);
+  return builder.create<IREE::Encoding::UnsetEncodingOp>(
+      loc, unsetEncodingReturnType, source, dynamicSizesVec);
 }
 
 /// Given a LinalgOp and one of its OpOperands, return the element type,
@@ -240,8 +231,7 @@ public:
     // Sizes are computed by original output size.
     SmallVector<OpFoldResult> outSizes =
         tensor::getMixedSizes(rewriter, loc, out);
-    Value result =
-        unsetEncodingAndExtractSlice(rewriter, loc, opTiled, outSizes);
+    Value result = unsetEncoding(rewriter, loc, opTiled, outSizes);
 
     rewriter.replaceOp(linalgOp, result);
     return success();

--- a/compiler/src/iree/compiler/DispatchCreation/test/set_encoding.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/set_encoding.mlir
@@ -51,8 +51,7 @@ util.func public @matmul_f32f32f32_dynamic(%arg0 : tensor<?x?xf32>, %arg1 : tens
 // CHECK-SAME:       outs(%[[OUTS]] :
 //  CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG2]], %[[C0]]
 //  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG2]], %[[C1]]
-//      CHECK:   %[[RESULT_PADDED:.+]] = iree_encoding.unset_encoding %[[MATMUL]]{{.+}} -> tensor<?x?xf32>{%[[D0]], %[[D1]]}
-//      CHECK:   %[[RESULT:.+]] = tensor.extract_slice %[[RESULT_PADDED]][0, 0] [%[[D0]], %[[D1]]] [1, 1]
+//      CHECK:   %[[RESULT:.+]] = iree_encoding.unset_encoding %[[MATMUL]]{{.+}} -> tensor<?x?xf32>{%[[D0]], %[[D1]]}
 //      CHECK:   util.return %[[RESULT]]
 
 // -----
@@ -245,8 +244,7 @@ util.func public @batch_matmul_f32f32f32_dynamic(%arg0 : tensor<?x?x?xf32>, %arg
 //  CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG2]], %[[C0]]
 //  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG2]], %[[C1]]
 //  CHECK-DAG:   %[[D2:.+]] = tensor.dim %[[ARG2]], %[[C2]]
-//      CHECK:   %[[RESULT_PADDED:.+]] = iree_encoding.unset_encoding %[[BATCH_MATMUL]]{{.+}} -> tensor<?x?x?xf32>{%[[D0]], %[[D1]], %[[D2]]}
-//      CHECK:   %[[RESULT:.+]] = tensor.extract_slice %[[RESULT_PADDED]][0, 0, 0] [%[[D0]], %[[D1]], %[[D2]]] [1, 1, 1]
+//      CHECK:   %[[RESULT:.+]] = iree_encoding.unset_encoding %[[BATCH_MATMUL]]{{.+}} -> tensor<?x?x?xf32>{%[[D0]], %[[D1]], %[[D2]]}
 //      CHECK:   util.return %[[RESULT]]
 
 // -----
@@ -491,8 +489,7 @@ util.func public @batch_matvec_f32f32f32_dynamic(%arg0 : tensor<?x?x?xf32>, %arg
 // CHECK-SAME:       outs(%[[OUTS]] :
 //  CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG2]], %[[C0]]
 //  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG2]], %[[C1]]
-//      CHECK:   %[[RESULT_PADDED:.+]] = iree_encoding.unset_encoding %[[BATCH_MATVEC]]{{.+}} -> tensor<?x?xf32>{%[[D0]], %[[D1]]}
-//      CHECK:   %[[RESULT:.+]] = tensor.extract_slice %[[RESULT_PADDED]][0, 0] [%[[D0]], %[[D1]]] [1, 1]
+//      CHECK:   %[[RESULT:.+]] = iree_encoding.unset_encoding %[[BATCH_MATVEC]]{{.+}} -> tensor<?x?xf32>{%[[D0]], %[[D1]]}
 //      CHECK:   util.return %[[RESULT]]
 
 // -----
@@ -990,5 +987,4 @@ util.func public @broadcasting_dequant_op(%arg0: !hal.buffer_view, %arg1: !hal.b
 // CHECK-SAME:     ins(%[[LHS]], %[[RHS]]
 // CHECK-SAME:    outs(%[[FILL]]
 // CHECK:        %[[UNSET:.+]] = iree_encoding.unset_encoding %[[GEMM]]{{.+}} -> tensor<?x?x?xi32>{%[[ARG1_D0]], %[[ARG0_D0]], %[[ARG1_D1]]}
-// CHECK:        %[[SLICE:.+]] = tensor.extract_slice %[[UNSET]]
-// CHECK:        flow.return %[[SLICE]]
+// CHECK:        flow.return %[[UNSET]]


### PR DESCRIPTION
The unset_encoding op carries dynamic result dimensions since https://github.com/iree-org/iree/pull/19023, so the revision removes the tensor.extract_slice creation in SetEncoding pass. It is no longer needed. For static dimensions, the information are already carried in tensor types. For dynamic dimensions, they are carried on the op itself. With these changes, the revision also updates the materialization methods when lowering an unset_encoding ops to tensor.unpack ops. It infers the destination shape and create the tensor.empty op correspondingly.

Fixes https://github.com/iree-org/iree/issues/18956
Fixes https://github.com/iree-org/iree/issues/18976