### PR TITLE
[LLVMGPUVectorDistribute] Fix batch dimensions extraction for attention-like ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1751,7 +1751,8 @@ static LogicalResult setRootConfig(mlir::FunctionOpInterface entryPointFn,
                                    IREE::LinalgExt::AttentionOp attnOp) {
   FailureOr<IREE::LinalgExt::AttentionOpDetail> maybeOpInfo =
       IREE::LinalgExt::AttentionOpDetail::get(
-          attnOp.getQueryMap(), attnOp.getKeyMap(), attnOp.getValueMap());
+          attnOp.getQueryMap(), attnOp.getKeyMap(), attnOp.getValueMap(),
+          attnOp.getOutputMap());
   assert(succeeded(maybeOpInfo) && "failed to infer attention dims");
   auto opInfo = maybeOpInfo.value();
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -733,9 +733,10 @@ setAttentionVectorDistributionConfig(IREE::GPU::TargetAttr target,
 
   ArrayRef<int64_t> bounds = maybeBounds.value();
 
-  auto opInfo = IREE::LinalgExt::AttentionOpDetail::get(
-                    op.getQueryMap(), op.getKeyMap(), op.getValueMap())
-                    .value();
+  auto opInfo =
+      IREE::LinalgExt::AttentionOpDetail::get(
+          op.getQueryMap(), op.getKeyMap(), op.getValueMap(), op.getOutputMap())
+          .value();
 
   int64_t mDim = opInfo.getMDims().back();
   int64_t k1Dim = opInfo.getK1Dims().back();

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/AggregatedOpInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/AggregatedOpInterfaceImpl.cpp
@@ -409,8 +409,8 @@ FailureOr<SmallVector<Value>> AttentionOp::decomposeOperation(OpBuilder &b) {
   }
   Value output = getOutput();
 
-  FailureOr<AttentionOpDetail> maybeOpInfo =
-      AttentionOpDetail::get(getQueryMap(), getKeyMap(), getValueMap());
+  FailureOr<AttentionOpDetail> maybeOpInfo = AttentionOpDetail::get(
+      getQueryMap(), getKeyMap(), getValueMap(), getOutputMap());
   assert(succeeded(maybeOpInfo) && "Invalid attention indexing maps");
   AttentionOpDetail opInfo = maybeOpInfo.value();
 
@@ -527,8 +527,8 @@ OnlineAttentionOp::decomposeOperation(OpBuilder &b) {
     pvAttrs = config.getAs<DictionaryAttr>(getPVAttrStr());
   }
 
-  FailureOr<AttentionOpDetail> maybeOpInfo =
-      AttentionOpDetail::get(getQueryMap(), getKeyMap(), getValueMap());
+  FailureOr<AttentionOpDetail> maybeOpInfo = AttentionOpDetail::get(
+      getQueryMap(), getKeyMap(), getValueMap(), getOutputMap());
   assert(succeeded(maybeOpInfo) && "Invalid attention indexing maps");
   AttentionOpDetail opInfo = maybeOpInfo.value();
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1224,8 +1224,8 @@ LogicalResult AttentionOp::verify() {
   if (indexingMaps.size() != getOperation()->getNumOperands()) {
     return attnOp->emitOpError("expected an indexing map for each operand");
   }
-  FailureOr<AttentionOpDetail> maybeOpInfo =
-      AttentionOpDetail::get(getQueryMap(), getKeyMap(), getValueMap());
+  FailureOr<AttentionOpDetail> maybeOpInfo = AttentionOpDetail::get(
+      getQueryMap(), getKeyMap(), getValueMap(), getOutputMap());
   if (failed(maybeOpInfo)) {
     return attnOp->emitOpError("failed to verify op's indexing maps");
   }
@@ -1397,8 +1397,8 @@ LogicalResult OnlineAttentionOp::verify() {
   SmallVector<AffineMap> indexingMaps = attnOp.getIndexingMapsArray();
 
   // Check if indexing maps can represent attention.
-  FailureOr<AttentionOpDetail> maybeOpInfo =
-      AttentionOpDetail::get(getQueryMap(), getKeyMap(), getValueMap());
+  FailureOr<AttentionOpDetail> maybeOpInfo = AttentionOpDetail::get(
+      getQueryMap(), getKeyMap(), getValueMap(), getOutputMap());
 
   // Check shape compatibility based on indexing maps.
   SmallVector<int64_t> shape(getIterationDomainRank());

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -1787,9 +1787,9 @@ getAttentionIterationDomain(Location loc, OpBuilder &b, int64_t domainRank,
 
 static SmallVector<utils::IteratorType>
 getAttentionIteratorTypes(int64_t domainRank, AffineMap qMap, AffineMap kMap,
-                          AffineMap vMap) {
+                          AffineMap vMap, AffineMap oMap) {
   FailureOr<AttentionOpDetail> maybeOpInfo =
-      AttentionOpDetail::get(qMap, kMap, vMap);
+      AttentionOpDetail::get(qMap, kMap, vMap, oMap);
   assert(succeeded(maybeOpInfo) && "Failed to infer attention op details");
   AttentionOpDetail opInfo = maybeOpInfo.value();
 
@@ -1838,7 +1838,7 @@ SmallVector<Range> AttentionOp::getIterationDomain(OpBuilder &b) {
 
 SmallVector<utils::IteratorType> AttentionOp::getLoopIteratorTypes() {
   return getAttentionIteratorTypes(getIterationDomainRank(), getQueryMap(),
-                                   getKeyMap(), getValueMap());
+                                   getKeyMap(), getValueMap(), getOutputMap());
 }
 
 FailureOr<TilingResult>
@@ -1991,7 +1991,7 @@ SmallVector<Range> OnlineAttentionOp::getIterationDomain(OpBuilder &b) {
 
 SmallVector<utils::IteratorType> OnlineAttentionOp::getLoopIteratorTypes() {
   return getAttentionIteratorTypes(getIterationDomainRank(), getQueryMap(),
-                                   getKeyMap(), getValueMap());
+                                   getKeyMap(), getValueMap(), getOutputMap());
 }
 
 FailureOr<TilingResult>

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TileAttention.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TileAttention.cpp
@@ -42,8 +42,9 @@ void convertToOnlineAttention(IREE::LinalgExt::AttentionOp attnOp,
   Location loc = attnOp.getLoc();
   MLIRContext *ctx = attnOp.getContext();
 
-  FailureOr<AttentionOpDetail> maybeOpInfo = AttentionOpDetail::get(
-      attnOp.getQueryMap(), attnOp.getKeyMap(), attnOp.getValueMap());
+  FailureOr<AttentionOpDetail> maybeOpInfo =
+      AttentionOpDetail::get(attnOp.getQueryMap(), attnOp.getKeyMap(),
+                             attnOp.getValueMap(), attnOp.getOutputMap());
   assert(succeeded(maybeOpInfo) && "Invalid attention indexing maps");
   AttentionOpDetail opInfo = maybeOpInfo.value();
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/IndexingUtils.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/IndexingUtils.h
@@ -41,7 +41,7 @@ namespace mlir::iree_compiler::IREE::LinalgExt {
 class AttentionOpDetail {
 public:
   static FailureOr<AttentionOpDetail> get(AffineMap qMap, AffineMap kMap,
-                                          AffineMap vMap);
+                                          AffineMap vMap, AffineMap oMap);
 
   int64_t getDomainRank() const { return domainRank; }
   ArrayRef<int64_t> getBatchDims() const { return batch; }
@@ -52,7 +52,8 @@ public:
   AffineMap getSMap() const;
 
 private:
-  void inferFromIndexingMaps(AffineMap qMap, AffineMap kMap, AffineMap vMap);
+  void inferFromIndexingMaps(AffineMap qMap, AffineMap kMap, AffineMap vMap,
+                             AffineMap oMap);
   MLIRContext *getContext() const { return context; }
   SmallVector<int64_t> batch;
   SmallVector<int64_t> m;


### PR DESCRIPTION
Depends on: https://github.com/iree-org/iree/pull/19042

Currently, the batch dimensions are extracted as the union of dimensions present across Q & K & V. This is not correct if one of the dims in inputs (Q,K and V) could be seen as broadcasting.

Therefore, this commit changes this to be:
B = Union ( Q & K & O , K & V & O ) 
where if parallel dimensions common between both matmuls will be treated as batching dimensions.