### PR TITLE
[HAL] Implement AssignLegacyTargetDevices::getDependentDialects.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/AssignLegacyTargetDevices.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/AssignLegacyTargetDevices.cpp
@@ -37,6 +37,13 @@ struct AssignLegacyTargetDevicesPass
   using IREE::HAL::impl::AssignLegacyTargetDevicesPassBase<
       AssignLegacyTargetDevicesPass>::AssignLegacyTargetDevicesPassBase;
 
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<IREE::HAL::HALDialect>();
+    for (StringRef name : targetRegistry->getRegisteredTargetBackends()) {
+      targetRegistry->getTargetBackend(name)->getDependentDialects(registry);
+    }
+  }
+
   void runOnOperation() override {
     auto moduleOp = getOperation();
 


### PR DESCRIPTION
Similar to https://github.com/iree-org/iree/commit/ef5cc6e0d7de162206f3d0245f86e83d78a26a10

The pass needs to register related dialects. Those dialects are hidden behind interfaces (in OOP concept). The child classes already implement it and the pass needs to register them using the interface method.