### PR TITLE
[CPU] Return std::nullopt when failing on creating host target.

### DIFF
--- a/compiler/plugins/target/LLVMCPU/LLVMTargetOptions.cpp
+++ b/compiler/plugins/target/LLVMCPU/LLVMTargetOptions.cpp
@@ -82,7 +82,7 @@ std::optional<LLVMTarget> LLVMTarget::createForHost() {
   if (status != ResolveCPUAndCPUFeaturesStatus::OK) {
     llvm::errs() << "Internal error while creating host target: "
                  << getMessage(status, triple) << "\n";
-    assert(false);
+    return std::nullopt;
   }
   if (target)
     target->populateDefaultsFromTargetMachine();


### PR DESCRIPTION
We should not have an assertion because it crashes in debug build. Given that the return type is std::optional, the caller should handle the error themselves. Otherwise, we're not able to compile any MLIR programs targeting CPUs when there are troubles in host CPU setup.