### PR TITLE
Update docs and samples to use latest iree-turbine.

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -85,8 +85,6 @@ release process:
 * https://pypi.org/project/iree-compiler/
 * https://pypi.org/project/iree-runtime/
 * https://pypi.org/project/iree-turbine/
-* https://pypi.org/project/shark-turbine/ (transitional until switched to
-  iree-turbine)
 * https://pypi.org/project/iree-tools-tf/
 * https://pypi.org/project/iree-tools-tflite/
 
@@ -101,109 +99,7 @@ Deprecated projects no longer updated:
 
 There are presently two build promotion processes documented:
 
-* Old one focused purely on releasing IREE core packages:
-https://iree.dev/developers/general/release-management/
-* New one driven by the Torch frontend and documented below.
-
-The versioning scheme for
-[iree-turbine](https://github.com/iree-org/iree-turbine) is rooted on the
-then-current PyTorch released version, with optional date-based dev/pre-release
-suffixes (i.e. `rcYYYYMMDD` or `devYYYYMMDD`) or intra PyTorch releases
-(i.e. `postVVVV`).
-
-This process is being trialed to correspond with the 2.3.0 release of PyTorch.
-In this scenario, the pinned nightly build of IREE is considered current and
-promoted as part of the Turbine release to PyPI (and the release is marked as
-not pre-release on the GitHub releases page).
-
-Promotions are done roughly monthly or at need. The schedule is shifted to
-account for extra factors as needed.
-
-In the future, we would like to adopt a real versioning scheme (beyond the
-nightly calver+build number scheme) and manage promotion and pinning of the
-core IREE dep more explicitly and in alignment with how downstreams are using
-it.
-
-### Steps to Promote
-
-There are multiple release artifacts that are deployed from this project:
-
-* shark-turbine wheel (transitional while switching to iree-turbine)
-* iree-turbine wheel
-* iree-compiler wheels
-* iree-runtime wheels
-
-Typically we deploy IREE compiler and runtime wheels along with a turbine
-release, effectively promoting a nightly.
-
-#### Building Artifacts
-
-Start with a clean clone of iree-turbine:
-
-```
-cd scratch
-git clone git@github.com:iree-org/iree-turbine.git
-cd iree-turbine
-```
-
-Build a pre-release:
-
-```
-./build_tools/build_release.py --core-version 2.3.0 --core-pre-version=rcYYYYMMDD
-```
-
-Build an official release:
-
-```
-./build_tools/build_release.py --core-version 2.3.0
-```
-
-This will download all deps, including wheels for all supported platforms and
-Python versions for iree-compiler and iree-runtime. All wheels will be placed
-in the `wheelhouse/` directory.
-
-
-#### Testing
-
-TODO: Write a script for this.
-
-```
-python -m venv wheelhouse/test.venv
-source wheelhouse/test.venv/bin/activate
-pip install -f wheelhouse iree-turbine[testing]
-# Temp: tests require torchvision.
-pip install -f wheelhouse torchvision
-pytest core/tests
-```
-
-#### Push
-
-From the testing venv, verify that everything is sane:
-
-```
-pip freeze
-```
-
-Push IREE deps (if needed/updated):
-
-```
-twine upload wheelhouse/iree_compiler-* wheelhouse/iree_runtime-*
-```
-
-Push built wheels:
-
-```
-twine upload wheelhouse/iree_turbine-* wheelhouse/shark_turbine-*
-```
-
-#### Install from PyPI and Sanity Check
-
-TODO: Script this
-
-From the testing venv:
-
-```
-pip uninstall -y shark-turbine iree-turbine iree-compiler iree-runtime
-pip install iree-turbine
-pytest core/tests
-```
+* Releasing IREE core packages:
+  https://iree.dev/developers/general/release-management/
+* Releasing iree-turbine packages:
+  https://github.com/iree-org/iree-turbine/blob/main/docs/releasing.md

--- a/docs/website/docs/guides/ml-frameworks/pytorch.md
+++ b/docs/website/docs/guides/ml-frameworks/pytorch.md
@@ -22,8 +22,8 @@ status: new
 
 ## :octicons-book-16: Overview
 
-[iree-turbine](https://pypi.org/project/iree-turbine/) (rebrand pending from
-"shark-turbine") offers a tight integration between compatible versions of IREE,
+[iree-turbine](https://pypi.org/project/iree-turbine/) offers a tight
+integration between compatible versions of IREE,
 [torch-mlir](https://github.com/llvm/torch-mlir), and
 [PyTorch](https://pytorch.org/).
 
@@ -193,7 +193,7 @@ graph LR
 ```python
 import iree.runtime as ireert
 import numpy as np
-import shark_turbine.aot as aot
+import iree.turbine.aot as aot
 import torch
 
 # Define the `nn.Module` to export.
@@ -264,7 +264,7 @@ graph LR
 ```
 
 Advanced export workflows can use the
-[`aot.CompiledModule`](https://github.com/iree-org/iree-turbine/tree/main/shark_turbine/aot/compiled_module.py)
+[`aot.CompiledModule`](https://github.com/iree-org/iree-turbine/blob/main/iree/turbine/aot/compiled_module.py)
 class to define and constrain the structure of a program prior to compiling it.
 
 <!-- TODO(scotttodd): API reference pages for aot.CompiledModule etc.?
@@ -272,7 +272,7 @@ class to define and constrain the structure of a program prior to compiling it.
 -->
 
 ```python
-import shark_turbine.aot as aot
+import iree.turbine.aot as aot
 
 # A minimal program, with no functions or variables.
 class BasicModule(aot.CompiledModule):
@@ -339,7 +339,7 @@ models parameters on disk, so that they can be loaded later during runtime.
 import torch
 from safetensors.torch import save_file
 import numpy as np
-import shark_turbine.aot as aot
+import iree.turbine.aot as aot
 
 class LinearModule(torch.nn.Module):
     def __init__(self, in_features, out_features):

--- a/samples/colab/pytorch_aot_advanced.ipynb
+++ b/samples/colab/pytorch_aot_advanced.ipynb
@@ -37,7 +37,7 @@
         "cellView": "form",
         "id": "FqsvmKpjBJO2"
       },
-      "execution_count": null,
+      "execution_count": 1,
       "outputs": []
     },
     {
@@ -76,23 +76,24 @@
         "id": "KsPubQSvCbXd",
         "cellView": "form"
       },
-      "execution_count": 1,
+      "execution_count": 2,
       "outputs": []
     },
     {
       "cell_type": "code",
       "source": [
-        "#@title Install Pytorch 2.3.0 (prerelease)\n",
-        "!python -m pip install --pre --index-url https://download.pytorch.org/whl/test/cpu --upgrade torch==2.3.0"
+        "#@title Install Pytorch 2.3.0 (for CPU)\n",
+        "!python -m pip install --index-url https://download.pytorch.org/whl/test/cpu --upgrade torch==2.3.0"
       ],
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "oO1tirq2ggmO",
-        "outputId": "401ec66b-213b-4b56-de3f-f1130ca8a6a3"
+        "outputId": "2f36a84a-ac8d-453c-c8ed-3d19161b8866",
+        "cellView": "form"
       },
-      "execution_count": 2,
+      "execution_count": 3,
       "outputs": [
         {
           "output_type": "stream",
@@ -101,34 +102,36 @@
             "Looking in indexes: https://download.pytorch.org/whl/test/cpu\n",
             "Collecting torch==2.3.0\n",
             "  Downloading https://download.pytorch.org/whl/test/cpu/torch-2.3.0%2Bcpu-cp310-cp310-linux_x86_64.whl (190.4 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m190.4/190.4 MB\u001b[0m \u001b[31m2.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hRequirement already satisfied: filelock in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (3.13.4)\n",
-            "Requirement already satisfied: typing-extensions>=4.8.0 in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (4.11.0)\n",
-            "Requirement already satisfied: sympy in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (1.12)\n",
-            "Requirement already satisfied: networkx in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (3.3)\n",
-            "Requirement already satisfied: jinja2 in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (3.1.3)\n",
-            "Requirement already satisfied: fsspec in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (2023.6.0)\n",
-            "Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.10/dist-packages (from jinja2->torch==2.3.0) (2.1.5)\n",
-            "Requirement already satisfied: mpmath>=0.19 in /usr/local/lib/python3.10/dist-packages (from sympy->torch==2.3.0) (1.3.0)\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m190.4/190.4 MB\u001b[0m \u001b[31m4.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hRequirement already satisfied: filelock in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (3.16.1)\n",
+            "Requirement already satisfied: typing-extensions>=4.8.0 in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (4.12.2)\n",
+            "Requirement already satisfied: sympy in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (1.13.1)\n",
+            "Requirement already satisfied: networkx in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (3.4.2)\n",
+            "Requirement already satisfied: jinja2 in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (3.1.4)\n",
+            "Requirement already satisfied: fsspec in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (2024.10.0)\n",
+            "Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.10/dist-packages (from jinja2->torch==2.3.0) (3.0.2)\n",
+            "Requirement already satisfied: mpmath<1.4,>=1.1.0 in /usr/local/lib/python3.10/dist-packages (from sympy->torch==2.3.0) (1.3.0)\n",
             "Installing collected packages: torch\n",
             "  Attempting uninstall: torch\n",
-            "    Found existing installation: torch 2.2.1+cu121\n",
-            "    Uninstalling torch-2.2.1+cu121:\n",
-            "      Successfully uninstalled torch-2.2.1+cu121\n",
-            "Successfully installed torch-2.3.0+cpu\n"
+            "    Found existing installation: torch 2.5.0+cu121\n",
+            "    Uninstalling torch-2.5.0+cu121:\n",
+            "      Successfully uninstalled torch-2.5.0+cu121\n",
+            "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
+            "timm 1.0.11 requires torchvision, which is not installed.\u001b[0m\u001b[31m\n",
+            "\u001b[0mSuccessfully installed torch-2.3.0+cpu\n"
           ]
         }
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": 4,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "4iJFDHbsAzo4",
-        "outputId": "0f6f81e8-deb6-4e35-cd30-563c335329d7"
+        "outputId": "0234c0d1-94b0-4a4d-8876-2feb320c4ae5"
       },
       "outputs": [
         {
@@ -136,27 +139,29 @@
           "name": "stdout",
           "text": [
             "Collecting iree-turbine\n",
-            "  Downloading iree_turbine-2.3.0rc20240410-py3-none-any.whl (150 kB)\n",
-            "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/150.4 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r\u001b[2K     \u001b[91m━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m61.4/150.4 kB\u001b[0m \u001b[31m1.6 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m150.4/150.4 kB\u001b[0m \u001b[31m2.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hRequirement already satisfied: numpy in /usr/local/lib/python3.10/dist-packages (from iree-turbine) (1.25.2)\n",
-            "Collecting iree-compiler>=20240410.859 (from iree-turbine)\n",
-            "  Downloading iree_compiler-20240410.859-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (64.4 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m64.4/64.4 MB\u001b[0m \u001b[31m9.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting iree-runtime>=20240410.859 (from iree-turbine)\n",
-            "  Downloading iree_runtime-20240410.859-cp310-cp310-manylinux_2_28_x86_64.whl (7.4 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m7.4/7.4 MB\u001b[0m \u001b[31m57.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hRequirement already satisfied: torch>=2.1.0 in /usr/local/lib/python3.10/dist-packages (from iree-turbine) (2.3.0+cpu)\n",
-            "Requirement already satisfied: PyYAML in /usr/local/lib/python3.10/dist-packages (from iree-compiler>=20240410.859->iree-turbine) (6.0.1)\n",
-            "Requirement already satisfied: filelock in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->iree-turbine) (3.13.4)\n",
-            "Requirement already satisfied: typing-extensions>=4.8.0 in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->iree-turbine) (4.11.0)\n",
-            "Requirement already satisfied: sympy in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->iree-turbine) (1.12)\n",
-            "Requirement already satisfied: networkx in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->iree-turbine) (3.3)\n",
-            "Requirement already satisfied: jinja2 in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->iree-turbine) (3.1.3)\n",
-            "Requirement already satisfied: fsspec in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->iree-turbine) (2023.6.0)\n",
-            "Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.10/dist-packages (from jinja2->torch>=2.1.0->iree-turbine) (2.1.5)\n",
-            "Requirement already satisfied: mpmath>=0.19 in /usr/local/lib/python3.10/dist-packages (from sympy->torch>=2.1.0->iree-turbine) (1.3.0)\n",
-            "Installing collected packages: iree-runtime, iree-compiler, iree-turbine\n",
-            "Successfully installed iree-compiler-20240410.859 iree-runtime-20240410.859 iree-turbine-2.3.0rc20240410\n"
+            "  Downloading iree_turbine-2.5.0-py3-none-any.whl.metadata (5.7 kB)\n",
+            "Requirement already satisfied: numpy>=1.26.3 in /usr/local/lib/python3.10/dist-packages (from iree-turbine) (1.26.4)\n",
+            "Collecting iree-compiler (from iree-turbine)\n",
+            "  Downloading iree_compiler-20241104.1068-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl.metadata (615 bytes)\n",
+            "Collecting iree-runtime (from iree-turbine)\n",
+            "  Downloading iree_runtime-20241104.1068-cp310-cp310-manylinux_2_28_x86_64.whl.metadata (798 bytes)\n",
+            "Requirement already satisfied: torch>=2.3.0 in /usr/local/lib/python3.10/dist-packages (from iree-turbine) (2.3.0+cpu)\n",
+            "Requirement already satisfied: Jinja2>=3.1.3 in /usr/local/lib/python3.10/dist-packages (from iree-turbine) (3.1.4)\n",
+            "Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.10/dist-packages (from Jinja2>=3.1.3->iree-turbine) (3.0.2)\n",
+            "Requirement already satisfied: filelock in /usr/local/lib/python3.10/dist-packages (from torch>=2.3.0->iree-turbine) (3.16.1)\n",
+            "Requirement already satisfied: typing-extensions>=4.8.0 in /usr/local/lib/python3.10/dist-packages (from torch>=2.3.0->iree-turbine) (4.12.2)\n",
+            "Requirement already satisfied: sympy in /usr/local/lib/python3.10/dist-packages (from torch>=2.3.0->iree-turbine) (1.13.1)\n",
+            "Requirement already satisfied: networkx in /usr/local/lib/python3.10/dist-packages (from torch>=2.3.0->iree-turbine) (3.4.2)\n",
+            "Requirement already satisfied: fsspec in /usr/local/lib/python3.10/dist-packages (from torch>=2.3.0->iree-turbine) (2024.10.0)\n",
+            "Requirement already satisfied: mpmath<1.4,>=1.1.0 in /usr/local/lib/python3.10/dist-packages (from sympy->torch>=2.3.0->iree-turbine) (1.3.0)\n",
+            "Downloading iree_turbine-2.5.0-py3-none-any.whl (271 kB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m271.3/271.3 kB\u001b[0m \u001b[31m4.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading iree_compiler-20241104.1068-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (70.7 MB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m70.7/70.7 MB\u001b[0m \u001b[31m13.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading iree_runtime-20241104.1068-cp310-cp310-manylinux_2_28_x86_64.whl (8.0 MB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.0/8.0 MB\u001b[0m \u001b[31m59.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hInstalling collected packages: iree-runtime, iree-compiler, iree-turbine\n",
+            "Successfully installed iree-compiler-20241104.1068 iree-runtime-20241104.1068 iree-turbine-2.5.0\n"
           ]
         }
       ],
@@ -182,7 +187,7 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "nkVLzRpcDnVL",
-        "outputId": "2c0a2229-0ab9-4eb3-e302-e75e15d08cce"
+        "outputId": "f989db15-1644-4c9e-f307-ea5e2abbbc82"
       },
       "execution_count": 5,
       "outputs": [
@@ -190,12 +195,12 @@
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "Installed iree-turbine, Version: 2.3.0rc20240410\n",
+            "Installed iree-turbine, Version: 2.5.0\n",
             "\n",
             "Installed IREE, compiler version information:\n",
             "IREE (https://iree.dev):\n",
-            "  IREE compiler version 20240410.859 @ b4273a4bfc66ba6dd8f62f6483d74d42a7b936f1\n",
-            "  LLVM version 19.0.0git\n",
+            "  IREE compiler version 20241104.1068 @ 9c85e30df30d6efcf68a7a1b594e89322bd6085d\n",
+            "  LLVM version 20.0.0git\n",
             "  Optimized build\n",
             "\n",
             "Installed PyTorch, version: 2.3.0+cpu\n"
@@ -253,7 +258,7 @@
       "source": [
         "#@title 2. Define the API and properties of that program by using aot.CompiledModule\n",
         "\n",
-        "import shark_turbine.aot as aot\n",
+        "import iree.turbine.aot as aot\n",
         "\n",
         "example_weight = torch.randn(4, 3)\n",
         "example_bias = torch.randn(3)\n",
@@ -280,7 +285,7 @@
       "metadata": {
         "id": "Ua3tNtUIozoa"
       },
-      "execution_count": 7,
+      "execution_count": 8,
       "outputs": []
     },
     {
@@ -292,7 +297,7 @@
       "metadata": {
         "id": "eK2fWVfiSQ8f"
       },
-      "execution_count": 12,
+      "execution_count": 9,
       "outputs": []
     },
     {
@@ -324,9 +329,9 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "eMRNdFdos900",
-        "outputId": "29aaa0ad-a424-4856-d03f-b0bd0a839a29"
+        "outputId": "fae696f2-8dbe-4873-f392-953673b6094f"
       },
-      "execution_count": 13,
+      "execution_count": 10,
       "outputs": [
         {
           "output_type": "stream",
@@ -351,7 +356,7 @@
         "export_output.print_readable()\n",
         "export_output.save_mlir(mlir_file_path)\n",
         "\n",
-        "!iree-compile --iree-input-type=torch --iree-hal-target-backends=llvm-cpu {mlir_file_path} -o {vmfb_file_path}\n",
+        "!iree-compile --iree-input-type=torch --iree-hal-target-backends=llvm-cpu --iree-llvmcpu-target-cpu=host {mlir_file_path} -o {vmfb_file_path}\n",
         "!iree-run-module --module={vmfb_file_path} --device=local-task --function=main --input=\"4xf32=[1.0, 2.0, 3.0, 4.0]\""
       ],
       "metadata": {
@@ -359,9 +364,9 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "0AdkXY8VNL2-",
-        "outputId": "c4faaf27-59b7-4ee1-88aa-b6c209e8a1cf"
+        "outputId": "66335f65-2e9a-4a3a-b9ae-638490063a6e"
       },
-      "execution_count": 15,
+      "execution_count": 12,
       "outputs": [
         {
           "output_type": "stream",

--- a/samples/colab/pytorch_aot_simple.ipynb
+++ b/samples/colab/pytorch_aot_simple.ipynb
@@ -82,15 +82,16 @@
     {
       "cell_type": "code",
       "source": [
-        "#@title Install Pytorch 2.3.0 (prerelease)\n",
-        "!python -m pip install --pre --index-url https://download.pytorch.org/whl/test/cpu --upgrade torch==2.3.0"
+        "#@title Install Pytorch 2.3.0 (for CPU)\n",
+        "!python -m pip install --index-url https://download.pytorch.org/whl/test/cpu --upgrade torch==2.3.0"
       ],
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "3ebWazfjJ6en",
-        "outputId": "a04009ab-92d2-4796-a476-e7912fc84410"
+        "outputId": "913c0ccf-9895-4c3f-cd12-20c8185c747d",
+        "cellView": "form"
       },
       "execution_count": 3,
       "outputs": [
@@ -101,21 +102,23 @@
             "Looking in indexes: https://download.pytorch.org/whl/test/cpu\n",
             "Collecting torch==2.3.0\n",
             "  Downloading https://download.pytorch.org/whl/test/cpu/torch-2.3.0%2Bcpu-cp310-cp310-linux_x86_64.whl (190.4 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m190.4/190.4 MB\u001b[0m \u001b[31m3.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hRequirement already satisfied: filelock in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (3.13.4)\n",
-            "Requirement already satisfied: typing-extensions>=4.8.0 in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (4.11.0)\n",
-            "Requirement already satisfied: sympy in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (1.12)\n",
-            "Requirement already satisfied: networkx in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (3.3)\n",
-            "Requirement already satisfied: jinja2 in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (3.1.3)\n",
-            "Requirement already satisfied: fsspec in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (2023.6.0)\n",
-            "Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.10/dist-packages (from jinja2->torch==2.3.0) (2.1.5)\n",
-            "Requirement already satisfied: mpmath>=0.19 in /usr/local/lib/python3.10/dist-packages (from sympy->torch==2.3.0) (1.3.0)\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m190.4/190.4 MB\u001b[0m \u001b[31m5.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hRequirement already satisfied: filelock in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (3.16.1)\n",
+            "Requirement already satisfied: typing-extensions>=4.8.0 in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (4.12.2)\n",
+            "Requirement already satisfied: sympy in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (1.13.1)\n",
+            "Requirement already satisfied: networkx in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (3.4.2)\n",
+            "Requirement already satisfied: jinja2 in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (3.1.4)\n",
+            "Requirement already satisfied: fsspec in /usr/local/lib/python3.10/dist-packages (from torch==2.3.0) (2024.10.0)\n",
+            "Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.10/dist-packages (from jinja2->torch==2.3.0) (3.0.2)\n",
+            "Requirement already satisfied: mpmath<1.4,>=1.1.0 in /usr/local/lib/python3.10/dist-packages (from sympy->torch==2.3.0) (1.3.0)\n",
             "Installing collected packages: torch\n",
             "  Attempting uninstall: torch\n",
-            "    Found existing installation: torch 2.2.1+cu121\n",
-            "    Uninstalling torch-2.2.1+cu121:\n",
-            "      Successfully uninstalled torch-2.2.1+cu121\n",
-            "Successfully installed torch-2.3.0+cpu\n"
+            "    Found existing installation: torch 2.5.0+cu121\n",
+            "    Uninstalling torch-2.5.0+cu121:\n",
+            "      Successfully uninstalled torch-2.5.0+cu121\n",
+            "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
+            "timm 1.0.11 requires torchvision, which is not installed.\u001b[0m\u001b[31m\n",
+            "\u001b[0mSuccessfully installed torch-2.3.0+cpu\n"
           ]
         }
       ]
@@ -128,7 +131,7 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "4iJFDHbsAzo4",
-        "outputId": "72f7e43a-fbec-4140-d15b-9df10691e984"
+        "outputId": "5ba8936d-0cf4-40e8-d012-d987ee9ad9e3"
       },
       "outputs": [
         {
@@ -136,27 +139,29 @@
           "name": "stdout",
           "text": [
             "Collecting iree-turbine\n",
-            "  Downloading iree_turbine-2.3.0rc20240410-py3-none-any.whl (150 kB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m150.4/150.4 kB\u001b[0m \u001b[31m3.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hRequirement already satisfied: numpy in /usr/local/lib/python3.10/dist-packages (from iree-turbine) (1.25.2)\n",
-            "Collecting iree-compiler>=20240410.859 (from iree-turbine)\n",
-            "  Downloading iree_compiler-20240410.859-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (64.4 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m64.4/64.4 MB\u001b[0m \u001b[31m7.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hCollecting iree-runtime>=20240410.859 (from iree-turbine)\n",
-            "  Downloading iree_runtime-20240410.859-cp310-cp310-manylinux_2_28_x86_64.whl (7.4 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m7.4/7.4 MB\u001b[0m \u001b[31m23.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hRequirement already satisfied: torch>=2.1.0 in /usr/local/lib/python3.10/dist-packages (from iree-turbine) (2.3.0+cpu)\n",
-            "Requirement already satisfied: PyYAML in /usr/local/lib/python3.10/dist-packages (from iree-compiler>=20240410.859->iree-turbine) (6.0.1)\n",
-            "Requirement already satisfied: filelock in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->iree-turbine) (3.13.4)\n",
-            "Requirement already satisfied: typing-extensions>=4.8.0 in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->iree-turbine) (4.11.0)\n",
-            "Requirement already satisfied: sympy in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->iree-turbine) (1.12)\n",
-            "Requirement already satisfied: networkx in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->iree-turbine) (3.3)\n",
-            "Requirement already satisfied: jinja2 in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->iree-turbine) (3.1.3)\n",
-            "Requirement already satisfied: fsspec in /usr/local/lib/python3.10/dist-packages (from torch>=2.1.0->iree-turbine) (2023.6.0)\n",
-            "Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.10/dist-packages (from jinja2->torch>=2.1.0->iree-turbine) (2.1.5)\n",
-            "Requirement already satisfied: mpmath>=0.19 in /usr/local/lib/python3.10/dist-packages (from sympy->torch>=2.1.0->iree-turbine) (1.3.0)\n",
-            "Installing collected packages: iree-runtime, iree-compiler, iree-turbine\n",
-            "Successfully installed iree-compiler-20240410.859 iree-runtime-20240410.859 iree-turbine-2.3.0rc20240410\n"
+            "  Downloading iree_turbine-2.5.0-py3-none-any.whl.metadata (5.7 kB)\n",
+            "Requirement already satisfied: numpy>=1.26.3 in /usr/local/lib/python3.10/dist-packages (from iree-turbine) (1.26.4)\n",
+            "Collecting iree-compiler (from iree-turbine)\n",
+            "  Downloading iree_compiler-20241104.1068-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl.metadata (615 bytes)\n",
+            "Collecting iree-runtime (from iree-turbine)\n",
+            "  Downloading iree_runtime-20241104.1068-cp310-cp310-manylinux_2_28_x86_64.whl.metadata (798 bytes)\n",
+            "Requirement already satisfied: torch>=2.3.0 in /usr/local/lib/python3.10/dist-packages (from iree-turbine) (2.3.0+cpu)\n",
+            "Requirement already satisfied: Jinja2>=3.1.3 in /usr/local/lib/python3.10/dist-packages (from iree-turbine) (3.1.4)\n",
+            "Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.10/dist-packages (from Jinja2>=3.1.3->iree-turbine) (3.0.2)\n",
+            "Requirement already satisfied: filelock in /usr/local/lib/python3.10/dist-packages (from torch>=2.3.0->iree-turbine) (3.16.1)\n",
+            "Requirement already satisfied: typing-extensions>=4.8.0 in /usr/local/lib/python3.10/dist-packages (from torch>=2.3.0->iree-turbine) (4.12.2)\n",
+            "Requirement already satisfied: sympy in /usr/local/lib/python3.10/dist-packages (from torch>=2.3.0->iree-turbine) (1.13.1)\n",
+            "Requirement already satisfied: networkx in /usr/local/lib/python3.10/dist-packages (from torch>=2.3.0->iree-turbine) (3.4.2)\n",
+            "Requirement already satisfied: fsspec in /usr/local/lib/python3.10/dist-packages (from torch>=2.3.0->iree-turbine) (2024.10.0)\n",
+            "Requirement already satisfied: mpmath<1.4,>=1.1.0 in /usr/local/lib/python3.10/dist-packages (from sympy->torch>=2.3.0->iree-turbine) (1.3.0)\n",
+            "Downloading iree_turbine-2.5.0-py3-none-any.whl (271 kB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m271.3/271.3 kB\u001b[0m \u001b[31m3.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading iree_compiler-20241104.1068-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (70.7 MB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m70.7/70.7 MB\u001b[0m \u001b[31m8.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading iree_runtime-20241104.1068-cp310-cp310-manylinux_2_28_x86_64.whl (8.0 MB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m8.0/8.0 MB\u001b[0m \u001b[31m52.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hInstalling collected packages: iree-runtime, iree-compiler, iree-turbine\n",
+            "Successfully installed iree-compiler-20241104.1068 iree-runtime-20241104.1068 iree-turbine-2.5.0\n"
           ]
         }
       ],
@@ -183,7 +188,7 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "nkVLzRpcDnVL",
-        "outputId": "c8687418-f2c4-42af-974f-2733a5797c1c"
+        "outputId": "0481a14b-e261-4ea5-8d4e-228078b775f6"
       },
       "execution_count": 5,
       "outputs": [
@@ -191,12 +196,12 @@
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "Installed iree-turbine, Version: 2.3.0rc20240410\n",
+            "Installed iree-turbine, Version: 2.5.0\n",
             "\n",
             "Installed IREE, compiler version information:\n",
             "IREE (https://iree.dev):\n",
-            "  IREE compiler version 20240410.859 @ b4273a4bfc66ba6dd8f62f6483d74d42a7b936f1\n",
-            "  LLVM version 19.0.0git\n",
+            "  IREE compiler version 20241104.1068 @ 9c85e30df30d6efcf68a7a1b594e89322bd6085d\n",
+            "  LLVM version 20.0.0git\n",
             "  Optimized build\n",
             "\n",
             "Installed PyTorch, version: 2.3.0+cpu\n"
@@ -251,7 +256,7 @@
       "cell_type": "code",
       "source": [
         "#@title 2. Export the program using `aot.export()`\n",
-        "import shark_turbine.aot as aot\n",
+        "import iree.turbine.aot as aot\n",
         "\n",
         "example_arg = torch.randn(4)\n",
         "export_output = aot.export(linear_module, example_arg)"
@@ -259,7 +264,7 @@
       "metadata": {
         "id": "eK2fWVfiSQ8f"
       },
-      "execution_count": null,
+      "execution_count": 7,
       "outputs": []
     },
     {
@@ -291,7 +296,7 @@
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "2b4db1b2-12d5-4b63-8f0e-9635dfe48277"
+        "outputId": "073486bf-1590-4838-ebc8-b76b80e87d32"
       },
       "execution_count": 8,
       "outputs": [
@@ -320,7 +325,7 @@
         "export_output.save_mlir(mlir_file_path)\n",
         "\n",
         "print(\"Compiling and running...\")\n",
-        "!iree-compile --iree-input-type=torch --iree-hal-target-backends=llvm-cpu {mlir_file_path} -o {vmfb_file_path}\n",
+        "!iree-compile --iree-input-type=torch --iree-hal-target-backends=llvm-cpu --iree-llvmcpu-target-cpu=host {mlir_file_path} -o {vmfb_file_path}\n",
         "!iree-run-module --module={vmfb_file_path} --device=local-task --input=\"4xf32=[1.0, 2.0, 3.0, 4.0]\""
       ],
       "metadata": {
@@ -328,7 +333,7 @@
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "75ca37ad-0321-4a40-9f54-5c6613f01e9e"
+        "outputId": "3381872c-d048-4f99-b35d-a0ebfef00dfc"
       },
       "execution_count": 9,
       "outputs": [
@@ -338,7 +343,7 @@
           "text": [
             "Exported .mlir:\n",
             "module @module {\n",
-            "  func.func @main(%arg0: !torch.vtensor<[4],f32>) -> !torch.vtensor<[3],f32> {\n",
+            "  func.func @main(%arg0: !torch.vtensor<[4],f32>) -> !torch.vtensor<[3],f32> attributes {torch.assume_strict_symbolic_shapes} {\n",
             "    %int0 = torch.constant.int 0\n",
             "    %0 = torch.aten.unsqueeze %arg0, %int0 : !torch.vtensor<[4],f32>, !torch.int -> !torch.vtensor<[1,4],f32>\n",
             "    %1 = torch.vtensor.literal(dense_resource<torch_tensor_4_3_torch.float32> : tensor<4x3xf32>) : !torch.vtensor<[4,3],f32>\n",

--- a/samples/dynamic_shapes/README.md
+++ b/samples/dynamic_shapes/README.md
@@ -13,6 +13,10 @@ Steps 1-2 are performed in Python via the
 [`tensorflow_dynamic_shapes.ipynb`](./tensorflow_dynamic_shapes.ipynb)
 [Colab](https://colab.google/) notebooks:
 
+> [!WARNING]
+> The PyTorch sample code below is outdated, as the `@aot.jittable` API is
+> unstable.
+
 | Framework | Notebook |
 | --------- | -------- |
 PyTorch | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/iree-org/iree/blob/main/samples/dynamic_shapes/pytorch_dynamic_shapes.ipynb)
@@ -27,7 +31,7 @@ dynamic shapes:
 
 ```python
 import torch
-import shark_turbine.aot as aot
+import iree.turbine.aot as aot
 
 class DynamicShapesModule(aot.CompiledModule, export_name="module"):
   # reduce_sum_1d (dynamic input size, static output size)


### PR DESCRIPTION
This adapts docs and samples to https://github.com/iree-org/iree-turbine/releases/tag/v2.5.0.

* Switched from `import shark_turbine.aot as aot` to `import iree.turbine.aot as aot` (see also https://github.com/iree-org/iree-turbine/issues/28).
* Redirected notes from `/RELEASING.md` to https://github.com/iree-org/iree-turbine/blob/main/docs/releasing.md. The release process is changing now with https://github.com/iree-org/iree/issues/18938 and I'll want to fold the notes there in to https://iree.dev/developers/general/release-management/ instead.
* Re-ran some Colab notebooks and adapted to the latest changes across projects. Note that the https://github.com/iree-org/iree/tree/main/samples/dynamic_shapes sample still has code using `@aot.jittable`, so I have re-opened https://github.com/iree-org/iree/issues/18564 to migrate it. I spent some time trying to update it but wasn't sure how to demonstrate dynamic shapes using the "modern canonical usage" effectively.
  * This fixes the recent test failures: https://github.com/iree-org/iree/actions/runs/11697207429/job/32575551934. Test run: https://github.com/ScottTodd/iree/actions/runs/11713816651/job/32627295562