### PR TITLE
Block dynamic dimensions of contraction-like operations.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BlockDynamicDimensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BlockDynamicDimensions.cpp
@@ -339,6 +339,9 @@ void BlockDynamicDimensionsPass::runOnOperation() {
                                                        context);
     tensor::CollapseShapeOp::getCanonicalizationPatterns(
         removeBarrierOpsPatterns, context);
+    tensor::populateFoldTensorEmptyPatterns(removeBarrierOpsPatterns);
+    memref::populateResolveRankedShapedTypeResultDimsPatterns(
+        removeBarrierOpsPatterns);
     if (failed(applyPatternsAndFoldGreedily(
             operation, std::move(removeBarrierOpsPatterns)))) {
       operation->emitOpError("failed in cleanup patterns");

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -23,9 +23,6 @@ def BlockDynamicDimensionsPass
     : Pass<"iree-codegen-block-dynamic-dimensions"> {
   let summary = "Expand dynamic dimensions that are known to be multiples of "
                 "statically known values.";
-  let options = [
-    Option<"test", "test", "bool", /*default=*/"false", "Enable test mode">
-  ];
 }
 
 def BubbleUpOrdinalOpsPass : Pass<"iree-codegen-bubble-up-ordinal-ops", ""> {

--- a/compiler/src/iree/compiler/Codegen/Common/test/block_dynamic_dims.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/block_dynamic_dims.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-block-dynamic-dimensions{test}, cse))" --split-input-file --mlir-print-local-scope %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-block-dynamic-dimensions, cse))" --split-input-file --mlir-print-local-scope %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<constants = 4, bindings = [
     #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,

--- a/compiler/src/iree/compiler/Codegen/Common/test/block_dynamic_dims.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/block_dynamic_dims.mlir
@@ -102,36 +102,60 @@ func.func @block_attention_dims() {
 
 // -----
 
-func.func @basic_blocking_test(%arg0 : index) -> tensor<?xf32> {
+func.func @basic_blocking_test(%arg0 : index) -> tensor<?x4096xf32> {
   %0 = util.assume.int %arg0<umin = 0, umax = 1024, udiv = 16> : index
-  %1 = tensor.empty(%0) : tensor<?xf32>
-  return %1 : tensor<?xf32>
+  %lhs = tensor.empty(%0) : tensor<?x2048xf32>
+  %rhs = tensor.empty() : tensor<2048x4096xf32>
+  %init = tensor.empty(%0) : tensor<?x4096xf32>
+  %matmul = linalg.matmul ins(%lhs, %rhs : tensor<?x2048xf32>, tensor<2048x4096xf32>)
+      outs(%init : tensor<?x4096xf32>) -> tensor<?x4096xf32>
+  return %matmul : tensor<?x4096xf32>
 }
 // CHECK-LABEL: func @basic_blocking_test(
-//       CHECK:   %[[EMPTY:.+]] = tensor.empty(%{{.+}}) : tensor<?x16xf32>
-//       CHECK:   %[[COLLAPSE:.+]] = tensor.collapse_shape %[[EMPTY]]
+//   CHECK-DAG:   %[[LHS:.+]] = tensor.empty(%{{.+}}) : tensor<?x16x2048xf32>
+//   CHECK-DAG:   %[[INIT:.+]] = tensor.empty(%{{.+}}) : tensor<?x16x4096xf32>
+//       CHECK:   %[[MATMUL:.+]] = linalg.generic
+//  CHECK-SAME:       ins(%[[LHS]],
+//  CHECK-SAME:       outs(%[[INIT]] :
+//       CHECK:   %[[COLLAPSE:.+]] = tensor.collapse_shape %[[MATMUL]]
 //       CHECK:   return %[[COLLAPSE]]
 
 // -----
 
-func.func @no_blocking(%arg0 : index) -> tensor<?xf32> {
-  %1 = tensor.empty(%arg0) : tensor<?xf32>
-  return %1 : tensor<?xf32>
+func.func @no_blocking(%arg0 : index) -> tensor<?x4096xf32> {
+  %lhs = tensor.empty(%arg0) : tensor<?x2048xf32>
+  %rhs = tensor.empty() : tensor<2048x4096xf32>
+  %init = tensor.empty(%arg0) : tensor<?x4096xf32>
+  %matmul = linalg.matmul ins(%lhs, %rhs : tensor<?x2048xf32>, tensor<2048x4096xf32>)
+      outs(%init : tensor<?x4096xf32>) -> tensor<?x4096xf32>
+  return %matmul : tensor<?x4096xf32>
 }
 // CHECK-LABEL: func @no_blocking(
-//       CHECK:   %[[EMPTY:.+]] = tensor.empty(%{{.+}}) : tensor<?xf32>
-//       CHECK:   return %[[EMPTY]]
+//   CHECK-DAG:   %[[LHS:.+]] = tensor.empty(%{{.+}}) : tensor<?x2048xf32>
+//   CHECK-DAG:   %[[INIT:.+]] = tensor.empty(%{{.+}}) : tensor<?x4096xf32>
+//       CHECK:   %[[MATMUL:.+]] = linalg.matmul
+//  CHECK-SAME:       ins(%[[LHS]],
+//  CHECK-SAME:       outs(%[[INIT]] :
+//       CHECK:   return %[[MATMUL]]
 
 // -----
 
-func.func @no_unit_blocking(%arg0 : index) -> tensor<?xf32> {
+func.func @no_unit_blocking(%arg0 : index) -> tensor<?x4096xf32> {
   %0 = util.assume.int %arg0<umin = 0, umax = 1024, udiv = 1> : index
-  %1 = tensor.empty(%0) : tensor<?xf32>
-  return %1 : tensor<?xf32>
+  %lhs = tensor.empty(%0) : tensor<?x2048xf32>
+  %rhs = tensor.empty() : tensor<2048x4096xf32>
+  %init = tensor.empty(%0) : tensor<?x4096xf32>
+  %matmul = linalg.matmul ins(%lhs, %rhs : tensor<?x2048xf32>, tensor<2048x4096xf32>)
+      outs(%init : tensor<?x4096xf32>) -> tensor<?x4096xf32>
+  return %matmul : tensor<?x4096xf32>
 }
 // CHECK-LABEL: func @no_unit_blocking(
-//       CHECK:   %[[EMPTY:.+]] = tensor.empty(%{{.+}}) : tensor<?xf32>
-//       CHECK:   return %[[EMPTY]]
+//   CHECK-DAG:   %[[LHS:.+]] = tensor.empty(%{{.+}}) : tensor<?x2048xf32>
+//   CHECK-DAG:   %[[INIT:.+]] = tensor.empty(%{{.+}}) : tensor<?x4096xf32>
+//       CHECK:   %[[MATMUL:.+]] = linalg.matmul
+//  CHECK-SAME:       ins(%[[LHS]],
+//  CHECK-SAME:       outs(%[[INIT]] :
+//       CHECK:   return %[[MATMUL]]
 
 
 // -----
@@ -158,39 +182,49 @@ func.func @contract_op_interface_op(%rhs : tensor<2048x4096xf16>, %m : index)
   return %1 : tensor<?x2048xf32>
 }
 // CHECK-LABEL: func @contract_op_interface_op(
-//  CHECK-SAME:     %[[ARG0:.+]]: tensor<2048x4096xf16>
-//  CHECK-SAME:     %[[ARG1:.+]]: index)
-//       CHECK:   %[[DIM:.+]] = util.assume.int %[[ARG1]]
-//       CHECK:   %[[EXPANDED_DIM:.+]] = affine.apply affine_map<()[s0] -> (s0 floordiv 16)>()[%[[DIM]]]
-//   CHECK-DAG:   %[[LHS:.+]] = tensor.empty(%[[EXPANDED_DIM:.+]]) : tensor<?x16x4096xf16>
-//   CHECK-DAG:   %[[INIT:.+]] = tensor.empty(%[[EXPANDED_DIM:.+]]) : tensor<?x16x2048xf32>
+//   CHECK-DAG:   %[[LHS:.+]] = tensor.empty(%{{.+}}) : tensor<?x16x4096xf16>
+//   CHECK-DAG:   %[[INIT:.+]] = tensor.empty(%{{.+}}) : tensor<?x16x2048xf32>
 //       CHECK:   %[[GENERIC:.+]] = linalg.generic
-//  CHECK-SAME:       ins(%[[LHS]], %[[ARG0]] :
+//  CHECK-SAME:       ins(%[[LHS]],
 //  CHECK-SAME:       outs(%[[INIT]] :
 //       CHECK:   %[[COLLAPSED:.+]] = tensor.collapse_shape %[[GENERIC]] {{\[}}[0, 1], [2]{{\]}}
 //       CHECK:   return %[[COLLAPSED]]
 
 // -----
 
-func.func @matmul_transpose_b(%lhs : tensor<2048x4096xf16>, %m : index)
-    -> tensor<2048x?xf32> {
+func.func @reshape_propagation_test(%rhs : tensor<2048x4096xf16>, %m : index)
+    -> tensor<?x2048xf16> {
+  %cst = arith.constant 0.0 : f32
   %0 = util.assume.int %m<udiv = 16> : index
-  %rhs = tensor.empty(%0) : tensor<?x4096xf16>
-  %init = tensor.empty(%0) : tensor<2048x?xf32>
+  %lhs = tensor.empty(%0) : tensor<?x4096xf16>
+  %init = tensor.empty(%0) : tensor<?x2048xf32>
+  %init2 = tensor.empty(%0) : tensor<?x2048xf16>
+  %fill = linalg.fill ins(%cst : f32) outs(%init : tensor<?x2048xf32>) -> tensor<?x2048xf32>
   %1 = linalg.matmul_transpose_b
-      ins(%lhs, %rhs : tensor<2048x4096xf16>, tensor<?x4096xf16>)
-      outs(%init : tensor<2048x?xf32>) -> tensor<2048x?xf32>
-  return %1 : tensor<2048x?xf32>
+      ins(%lhs, %rhs : tensor<?x4096xf16>, tensor<2048x4096xf16>)
+      outs(%fill : tensor<?x2048xf32>) -> tensor<?x2048xf32>
+  %2 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                       affine_map<(d0, d1) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel"]}
+      ins(%1 : tensor<?x2048xf32>) outs(%init2 : tensor<?x2048xf16>) {
+    ^bb0(%b0 : f32, %b1 : f16):
+      %3 = arith.truncf %b0 : f32 to f16
+      linalg.yield %3 : f16
+  } -> tensor<?x2048xf16>
+  return %2 : tensor<?x2048xf16>
 }
-// CHECK-LABEL: func @matmul_transpose_b(
-//  CHECK-SAME:     %[[ARG0:.+]]: tensor<2048x4096xf16>
-//  CHECK-SAME:     %[[ARG1:.+]]: index)
-//       CHECK:   %[[DIM:.+]] = util.assume.int %[[ARG1]]
-//       CHECK:   %[[EXPANDED_DIM:.+]] = affine.apply affine_map<()[s0] -> (s0 floordiv 16)>()[%[[DIM]]]
-//   CHECK-DAG:   %[[LHS:.+]] = tensor.empty(%[[EXPANDED_DIM:.+]]) : tensor<?x16x4096xf16>
-//   CHECK-DAG:   %[[INIT:.+]] = tensor.empty(%[[EXPANDED_DIM:.+]]) : tensor<2048x?x16xf32>
-//       CHECK:   %[[GENERIC:.+]] = linalg.generic
-//  CHECK-SAME:       ins(%[[ARG0]], %[[LHS]] :
+// CHECK-LABEL: func @reshape_propagation_test(
+//   CHECK-DAG:   %[[LHS:.+]] = tensor.empty(%{{.+}}) : tensor<?x16x4096xf16>
+//   CHECK-DAG:   %[[INIT:.+]] = tensor.empty(%{{.+}}) : tensor<?x16x2048xf32>
+//       CHECK:   %[[FILL:.+]] = linalg.fill
 //  CHECK-SAME:       outs(%[[INIT]] :
-//       CHECK:   %[[COLLAPSED:.+]] = tensor.collapse_shape %[[GENERIC]] {{\[}}[0], [1, 2]{{\]}}
+//       CHECK:   %[[GENERIC:.+]] = linalg.generic
+//  CHECK-SAME:       ins(%[[LHS]],
+//  CHECK-SAME:       outs(%[[FILL]] :
+//       CHECK:   %[[EMPTY:.+]] = tensor.empty(%{{.+}}) : tensor<?x16x2048xf16>
+//       CHECK:   %[[TRUNC:.+]] = linalg.generic
+//  CHECK-SAME:       ins(%[[GENERIC]] :
+//  CHECK-SAME:       outs(%[[EMPTY]] :
+//       CHECK:   %[[COLLAPSED:.+]] = tensor.collapse_shape %[[TRUNC]]
 //       CHECK:   return %[[COLLAPSED]]

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/OptimizeIntArithmetic.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/OptimizeIntArithmetic.cpp
@@ -231,38 +231,6 @@ struct RemUIDivisibilityByConstant : public OpRewritePattern<arith::RemUIOp> {
   DataFlowSolver &solver;
 };
 
-struct DivUIDivisibilityByConstant : public OpRewritePattern<arith::DivUIOp> {
-  DivUIDivisibilityByConstant(MLIRContext *context, DataFlowSolver &solver)
-      : OpRewritePattern(context), solver(solver) {}
-
-  LogicalResult matchAndRewrite(arith::DivUIOp op,
-                                PatternRewriter &rewriter) const override {
-    APInt rhsConstant;
-    if (!matchPattern(op.getRhs(), m_ConstantInt(&rhsConstant)))
-      return rewriter.notifyMatchFailure(op, "rhs is not constant");
-
-    ConstantIntDivisibility lhsDiv;
-    if (failed(getDivisibility(solver, op, op.getLhs(), rewriter, lhsDiv)))
-      return failure();
-
-    uint64_t rhsValue = rhsConstant.getZExtValue();
-    if (rhsValue > 0 && lhsDiv.udiv() > 0) {
-      if (lhsDiv.udiv() % rhsValue != 0)
-        return rewriter.notifyMatchFailure(op, "rhs does not divide lhs");
-
-      uint64_t divValue = lhsDiv.udiv() / rhsValue;
-      rewriter.replaceOpWithNewOp<arith::ConstantOp>(
-          op, rewriter.getIntegerAttr(op.getResult().getType(),
-                                      static_cast<int64_t>(divValue)));
-      return success();
-    }
-
-    return failure();
-  }
-
-  DataFlowSolver &solver;
-};
-
 //===----------------------------------------------------------------------===//
 // Affine expansion
 // affine.apply expansion can fail after producing a lot of IR. Since this is
@@ -409,8 +377,7 @@ class OptimizeIntArithmeticPass
                                                                       solver);
 
     // Populate divisibility patterns.
-    patterns.add<DivUIDivisibilityByConstant, RemUIDivisibilityByConstant>(
-        ctx, solver);
+    patterns.add<RemUIDivisibilityByConstant>(ctx, solver);
 
     GreedyRewriteConfig config;
     // Results in fewer recursive data flow flushes/cycles on modification.

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/integer_divisibility.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/integer_divisibility.mlir
@@ -48,25 +48,36 @@ util.func @missing_udiv_skipped(%arg0 : index) -> index {
 
 // -----
 
-util.func @muli_divisibility(%arg0 : index) -> index {
-  %cst = arith.constant 16 : index
-  %0 = arith.muli %arg0, %cst : index
-  %1 = arith.divui %0, %cst : index
-  util.return %1 : index
+util.func @muli_divisibility(%arg0 : index) -> (index, index) {
+  %cst16 = arith.constant 16 : index
+  %cst32 = arith.constant 32 : index
+  %0 = arith.muli %arg0, %cst16 : index
+  %1 = arith.remui %0, %cst16 : index
+  %2 = arith.remui %0, %cst32 : index
+  util.return %1, %2 : index, index
 }
 // CHECK-LABEL: @muli_divisibility
-//       CHECK:   %[[C1:.+]] = arith.constant 1 : index
-//       CHECK:   return %[[C1]]
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[C32:.+]] = arith.constant 32 : index
+//       CHECK:   %[[V:.+]] = arith.muli
+//       CHECK:   %[[REM:.+]] = arith.remui %[[V]], %[[C32]]
+//       CHECK:   return %[[C0]], %[[REM]]
 
 // -----
 
-util.func @muli_compounded_divisibility(%arg0 : index) -> index {
-  %cst = arith.constant 16 : index
+util.func @muli_compounded_divisibility(%arg0 : index) -> (index, index) {
+  %cst16 = arith.constant 16 : index
+  %cst64 = arith.constant 64 : index
+  %cst128 = arith.constant 128 : index
   %0 = util.assume.int %arg0<udiv = 4> : index
-  %1 = arith.muli %0, %cst : index
-  %2 = arith.divui %1, %cst : index
-  util.return %2 : index
+  %1 = arith.muli %0, %cst16 : index
+  %2 = arith.remui %1, %cst64 : index
+  %3 = arith.remui %1, %cst128 : index
+  util.return %2, %3 : index, index
 }
 // CHECK-LABEL: @muli_compounded_divisibility
-//       CHECK:   %[[C4:.+]] = arith.constant 4 : index
-//       CHECK:   return %[[C4]]
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[C128:.+]] = arith.constant 128 : index
+//       CHECK:   %[[V:.+]] = arith.muli
+//       CHECK:   %[[REM:.+]] = arith.remui %[[V]], %[[C128]]
+//       CHECK:   return %[[C0]], %[[REM]]

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/integer_divisibility.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/integer_divisibility.mlir
@@ -49,11 +49,11 @@ util.func @missing_udiv_skipped(%arg0 : index) -> index {
 // -----
 
 util.func @muli_divisibility(%arg0 : index) -> (index, index) {
-  %cst16 = arith.constant 16 : index
-  %cst32 = arith.constant 32 : index
-  %0 = arith.muli %arg0, %cst16 : index
-  %1 = arith.remui %0, %cst16 : index
-  %2 = arith.remui %0, %cst32 : index
+  %c16 = arith.constant 16 : index
+  %c32 = arith.constant 32 : index
+  %0 = arith.muli %arg0, %c16 : index
+  %1 = arith.remui %0, %c16 : index
+  %2 = arith.remui %0, %c32 : index
   util.return %1, %2 : index, index
 }
 // CHECK-LABEL: @muli_divisibility
@@ -66,13 +66,13 @@ util.func @muli_divisibility(%arg0 : index) -> (index, index) {
 // -----
 
 util.func @muli_compounded_divisibility(%arg0 : index) -> (index, index) {
-  %cst16 = arith.constant 16 : index
-  %cst64 = arith.constant 64 : index
-  %cst128 = arith.constant 128 : index
+  %c16 = arith.constant 16 : index
+  %c64 = arith.constant 64 : index
+  %c128 = arith.constant 128 : index
   %0 = util.assume.int %arg0<udiv = 4> : index
-  %1 = arith.muli %0, %cst16 : index
-  %2 = arith.remui %1, %cst64 : index
-  %3 = arith.remui %1, %cst128 : index
+  %1 = arith.muli %0, %c16 : index
+  %2 = arith.remui %1, %c64 : index
+  %3 = arith.remui %1, %c128 : index
   util.return %2, %3 : index, index
 }
 // CHECK-LABEL: @muli_compounded_divisibility
@@ -80,4 +80,23 @@ util.func @muli_compounded_divisibility(%arg0 : index) -> (index, index) {
 //   CHECK-DAG:   %[[C128:.+]] = arith.constant 128 : index
 //       CHECK:   %[[V:.+]] = arith.muli
 //       CHECK:   %[[REM:.+]] = arith.remui %[[V]], %[[C128]]
+//       CHECK:   return %[[C0]], %[[REM]]
+
+// -----
+
+util.func @divui_divisibility(%arg0 : index) -> (index, index) {
+  %c4 = arith.constant 4 : index
+  %c16 = arith.constant 16 : index
+  %c32 = arith.constant 32 : index
+  %0 = util.assume.int %arg0<udiv = 64> : index
+  %1 = arith.divui %0, %c4 : index
+  %2 = arith.remui %1, %c16 : index
+  %3 = arith.remui %1, %c32 : index
+  util.return %2, %3 : index, index
+}
+// CHECK-LABEL: @divui_divisibility
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[C32:.+]] = arith.constant 32 : index
+//       CHECK:   %[[V:.+]] = arith.divui
+//       CHECK:   %[[REM:.+]] = arith.remui %[[V]], %[[C32]]
 //       CHECK:   return %[[C0]], %[[REM]]

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/integer_divisibility.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/integer_divisibility.mlir
@@ -51,9 +51,22 @@ util.func @missing_udiv_skipped(%arg0 : index) -> index {
 util.func @muli_divisibility(%arg0 : index) -> index {
   %cst = arith.constant 16 : index
   %0 = arith.muli %arg0, %cst : index
-  %1 = arith.remui %0, %cst : index
+  %1 = arith.divui %0, %cst : index
   util.return %1 : index
 }
 // CHECK-LABEL: @muli_divisibility
-//       CHECK:   %[[C0:.+]] = arith.constant 0 : index
-//       CHECK:   return %[[C0]]
+//       CHECK:   %[[C1:.+]] = arith.constant 1 : index
+//       CHECK:   return %[[C1]]
+
+// -----
+
+util.func @muli_compounded_divisibility(%arg0 : index) -> index {
+  %cst = arith.constant 16 : index
+  %0 = util.assume.int %arg0<udiv = 4> : index
+  %1 = arith.muli %0, %cst : index
+  %2 = arith.divui %1, %cst : index
+  util.return %2 : index
+}
+// CHECK-LABEL: @muli_compounded_divisibility
+//       CHECK:   %[[C4:.+]] = arith.constant 4 : index
+//       CHECK:   return %[[C4]]


### PR DESCRIPTION
Block the dynamic dimensions of contraction-like operations when the dynamic dimensions are known to be multiples of a static value.

This also fixes a couple of bugs
1) Fix a bug in the integer divisibility propagation function for
   `arith.muli`
2) Add divisiblity propagation for `arith.divui`
3) Add better tests in `integer_divisibility.mlir` to check the computed divisibility.