### PR TITLE
Rename base packages

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -1,9 +1,9 @@
 # Builds release packages on supported platforms:
 #   * main-dist-linux (CMake 'install')
-#   * py-compiler-pkg (`iree-compiler` Python package)
+#   * py-compiler-pkg (`iree-base-compiler` Python package)
 #     * Linux, macOS, Windows
 #     * All supported Python versions (e.g. 3.9, 3.10, 3.11)
-#   * py-runtime-pkg (`iree-runtime` Python package)
+#   * py-runtime-pkg (`iree-base-runtime` Python package)
 #     * Linux, macOS, Windows
 #     * All supported Python versions (e.g. 3.9, 3.10, 3.11)
 #   * py-tf-compiler-tools-pkg (`iree-tools-[tf, tflite]`, pure Python packages)
@@ -187,7 +187,7 @@ jobs:
 
       ##########################################################################
       # py-runtime-pkg
-      # Builds the iree-runtime wheels.
+      # Builds the iree-base-runtime wheels.
       # One step per OS.
       ##########################################################################
 
@@ -196,7 +196,7 @@ jobs:
         shell: bash
         env:
           package_suffix: ${{ github.event.inputs.package_suffix }}
-          packages: "iree-runtime"
+          packages: "iree-base-runtime"
           output_dir: "${{ github.workspace }}/bindist"
         run: |
           [ -e ./bindist/* ] && rm ./bindist/*
@@ -207,7 +207,7 @@ jobs:
         shell: bash
         env:
           package_suffix: ${{ github.event.inputs.package_suffix }}
-          packages: "iree-runtime"
+          packages: "iree-base-runtime"
           output_dir: "${{ github.workspace }}/bindist"
           override_python_versions: "3.11 3.12 3.13"
         run: |
@@ -219,7 +219,7 @@ jobs:
         shell: powershell
         env:
           package_suffix: ${{ github.event.inputs.package_suffix }}
-          packages: "iree-runtime"
+          packages: "iree-base-runtime"
           output_dir: "${{ github.workspace }}/bindist"
           override_python_versions: "3.11 3.12 3.13"
         run: |
@@ -230,7 +230,7 @@ jobs:
 
       ##########################################################################
       # py-compiler-pkg
-      # Builds the iree-compiler wheel.
+      # Builds the iree-base-compiler wheel.
       # One step per OS.
       ##########################################################################
       - name: Build compiler wheels (Linux, x86_64 and Arm64)
@@ -238,7 +238,7 @@ jobs:
         shell: bash
         env:
           package_suffix: ${{ github.event.inputs.package_suffix }}
-          packages: "iree-compiler"
+          packages: "iree-base-compiler"
           output_dir: "${{ github.workspace }}/bindist"
         run: |
           [ -e ./bindist/* ] && rm ./bindist/*
@@ -249,7 +249,7 @@ jobs:
         shell: bash
         env:
           package_suffix: ${{ github.event.inputs.package_suffix }}
-          packages: "iree-compiler"
+          packages: "iree-base-compiler"
           output_dir: "${{ github.workspace }}/bindist"
           override_python_versions: "3.11 3.12 3.13"
         run: |
@@ -261,7 +261,7 @@ jobs:
         shell: powershell
         env:
           package_suffix: ${{ github.event.inputs.package_suffix }}
-          packages: "iree-compiler"
+          packages: "iree-base-compiler"
           output_dir: "${{ github.workspace }}/bindist"
           override_python_versions: "3.11 3.12 3.13"
         run: |

--- a/.github/workflows/pkgci_build_packages.yml
+++ b/.github/workflows/pkgci_build_packages.yml
@@ -60,7 +60,7 @@ jobs:
           export manylinux_docker_image="$MANYLINUX_DOCKER_IMAGE"
           export package_suffix="$PACKAGE_SUFFIX"
           # If just iterating locally, uncomment this to build a cheap wheel.
-          # export packages="iree-runtime"
+          # export packages="iree-base-runtime"
           ./build_tools/pkgci/build_linux_packages.sh
           # Some things put stuff in cache with weird, root read-only
           # permissions. Take them back.
@@ -125,7 +125,7 @@ jobs:
 #         export manylinux_docker_image="$MANYLINUX_DOCKER_IMAGE"
 #         export package_suffix="$PACKAGE_SUFFIX"
 #         # If just iterating locally, uncomment this to build a cheap wheel.
-#         # export packages="iree-runtime"
+#         # export packages="iree-base-runtime"
 #         ./build_tools/pkgci/build_linux_packages.sh
 #         # Some things put stuff in cache with weird, root read-only
 #         # permissions. Take them back.

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -86,8 +86,8 @@ jobs:
           python3 -m pip install \
             --find-links https://iree.dev/pip-release-links.html \
             --upgrade \
-            iree-compiler \
-            iree-runtime
+            iree-base-compiler \
+            iree-base-runtime
       - name: "Setup emsdk"
         uses: mymindstorm/setup-emsdk@6ab9eb1bda2574c4ddb79809fc9247783eaf9021 # v14
         with:

--- a/.github/workflows/validate_and_publish_release.yml
+++ b/.github/workflows/validate_and_publish_release.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Install python packages
         id: install_python_packages
         run: |
-          python -m pip install -f file://$PWD/wheels-linux-x86_64-py-compiler-pkg/ iree-compiler[onnx]
-          python -m pip install -f file://$PWD/wheels-linux-x86_64-py-runtime-pkg/ iree-runtime
+          python -m pip install -f file://$PWD/wheels-linux-x86_64-py-compiler-pkg/ iree-base-compiler[onnx]
+          python -m pip install -f file://$PWD/wheels-linux-x86_64-py-runtime-pkg/ iree-base-runtime
           python -m pip install -f file://$PWD/wheels-linux-x86_64-py-tf-compiler-tools-pkg/ iree-tools-tflite iree-tools-tf
       - name: Validate IREE Compiler Package
         id: validate_compiler_package

--- a/build_tools/github_actions/build_dist.py
+++ b/build_tools/github_actions/build_dist.py
@@ -7,8 +7,7 @@
 
 This script runs as the CIBW_BEFORE_BUILD command within cibuildwheel:
   - Main distribution .tar.bz2 file (the result of `ninja install`).
-  - The python_packages/iree_compiler wheel, which is python version
-    independent but platform specific.
+  - The python_packages/iree_base_compiler wheel.
   - Installable tests.
 
 It uses cibuildwheel for all of this as a convenience since it already knows

--- a/build_tools/pkgci/build_linux_packages.sh
+++ b/build_tools/pkgci/build_linux_packages.sh
@@ -17,7 +17,7 @@
 #
 # Build specific Python versions and packages to custom directory:
 #   override_python_versions="cp39-cp39 cp310-cp310" \
-#   packages="iree-runtime" \
+#   packages="iree-base-runtime" \
 #   output_dir="/tmp/wheelhouse" \
 #   ./build_tools/python_deploy/build_linux_packages.sh
 #
@@ -26,8 +26,8 @@
 #   cp39-cp39 cp310-cp310
 #
 # Valid packages:
-#   iree-runtime
-#   iree-compiler
+#   iree-base-runtime
+#   iree-base-compiler
 #
 # Note that this script is meant to be run on CI and it will pollute both the
 # output directory and in-tree build/ directories (under runtime/ and
@@ -68,7 +68,7 @@ manylinux_docker_image="${manylinux_docker_image:-$(uname -m | awk '{print ($1 =
 python_versions="${override_python_versions:-cp311-cp311}"
 output_dir="${output_dir:-${this_dir}/wheelhouse}"
 cache_dir="${cache_dir:-}"
-packages="${packages:-iree-runtime iree-compiler}"
+packages="${packages:-iree-base-runtime iree-base-compiler}"
 package_suffix="${package_suffix:-}"
 toolchain_suffix="${toolchain_suffix:-release}"
 # Return ON if we are on a supported platform for CUDA.
@@ -155,15 +155,15 @@ function run_in_docker() {
       # replace dashes with underscores
       package_suffix="${package_suffix//-/_}"
       case "${package}" in
-        iree-runtime)
-          clean_wheels "iree_runtime${package_suffix}" "${python_version}"
+        iree-base-runtime)
+          clean_wheels "iree_base_runtime${package_suffix}" "${python_version}"
           build_iree_runtime
-          run_audit_wheel "iree_runtime${package_suffix}" "${python_version}"
+          run_audit_wheel "iree_base_runtime${package_suffix}" "${python_version}"
           ;;
-        iree-compiler)
-          clean_wheels "iree_compiler${package_suffix}" "${python_version}"
+        iree-base-compiler)
+          clean_wheels "iree_base_compiler${package_suffix}" "${python_version}"
           build_iree_compiler
-          run_audit_wheel "iree_compiler${package_suffix}" "${python_version}"
+          run_audit_wheel "iree_base_compiler${package_suffix}" "${python_version}"
           ;;
         *)
           echo "Unrecognized package '${package}'"

--- a/build_tools/pkgci/setup_venv.py
+++ b/build_tools/pkgci/setup_venv.py
@@ -120,8 +120,8 @@ def main(args):
     artifact_prefix = f"{platform.system().lower()}_{platform.machine()}"
     wheels = []
     for package_stem, variant in [
-        ("iree-compiler", args.compiler_variant),
-        ("iree-runtime", args.runtime_variant),
+        ("iree-base-compiler", args.compiler_variant),
+        ("iree-base-runtime", args.runtime_variant),
     ]:
         wheels.append(
             find_wheel_for_variants(args, artifact_prefix, package_stem, variant)

--- a/build_tools/python_deploy/build_linux_packages.sh
+++ b/build_tools/python_deploy/build_linux_packages.sh
@@ -17,7 +17,7 @@
 #
 # Build specific Python versions and packages to custom directory:
 #   override_python_versions="cp39-cp39 cp310-cp310" \
-#   packages="iree-runtime" \
+#   packages="iree-base-runtime" \
 #   output_dir="/tmp/wheelhouse" \
 #   ./build_tools/python_deploy/build_linux_packages.sh
 #
@@ -26,8 +26,8 @@
 #   cp39-cp39 cp310-cp310
 #
 # Valid packages:
-#   iree-runtime
-#   iree-compiler
+#   iree-base-runtime
+#   iree-base-compiler
 #
 # Note that this script is meant to be run on CI and it will pollute both the
 # output directory and in-tree build/ directories (under runtime/ and
@@ -67,7 +67,7 @@ repo_root=$(cd "${this_dir}" && find_git_dir_parent)
 manylinux_docker_image="${manylinux_docker_image:-$(uname -m | awk '{print ($1 == "aarch64") ? "quay.io/pypa/manylinux_2_28_aarch64" : "ghcr.io/iree-org/manylinux_x86_64@sha256:2e0246137819cf10ed84240a971f9dd75cc3eb62dc6907dfd2080ee966b3c9f4" }')}"
 python_versions="${override_python_versions:-cp39-cp39 cp310-cp310 cp311-cp311 cp312-cp312 cp313-cp313 cp313-cp313t}"
 output_dir="${output_dir:-${this_dir}/wheelhouse}"
-packages="${packages:-iree-runtime iree-compiler}"
+packages="${packages:-iree-base-runtime iree-base-compiler}"
 package_suffix="${package_suffix:-}"
 toolchain_suffix="${toolchain_suffix:-release}"
 # Return ON if we are on a supported platform for CUDA.
@@ -130,17 +130,17 @@ function run_in_docker() {
       # replace dashes with underscores
       package_suffix="${package_suffix//-/_}"
       case "${package}" in
-        iree-runtime)
-          clean_wheels "iree_runtime${package_suffix}" "${python_version}"
-          install_deps "iree_runtime${package_suffix}" "${python_version}"
+        iree-base-runtime)
+          clean_wheels "iree_base_runtime${package_suffix}" "${python_version}"
+          install_deps "iree_base_runtime${package_suffix}" "${python_version}"
           build_iree_runtime
-          run_audit_wheel "iree_runtime${package_suffix}" "${python_version}"
+          run_audit_wheel "iree_base_runtime${package_suffix}" "${python_version}"
           ;;
-        iree-compiler)
-          clean_wheels "iree_compiler${package_suffix}" "${python_version}"
-          install_deps "iree_runtime${package_suffix}" "${python_version}"
+        iree-base-compiler)
+          clean_wheels "iree_base_compiler${package_suffix}" "${python_version}"
+          install_deps "iree_base_runtime${package_suffix}" "${python_version}"
           build_iree_compiler
-          run_audit_wheel "iree_compiler${package_suffix}" "${python_version}"
+          run_audit_wheel "iree_base_compiler${package_suffix}" "${python_version}"
           ;;
         *)
           echo "Unrecognized package '${package}'"

--- a/build_tools/python_deploy/build_macos_packages.sh
+++ b/build_tools/python_deploy/build_macos_packages.sh
@@ -14,8 +14,8 @@
 #
 # MacOS convention is to refer to this as major.minor (i.e. "3.9", "3.10").
 # Valid packages:
-#   iree-runtime
-#   iree-compiler
+#   iree-base-runtime
+#   iree-base-compiler
 
 set -eu -o errtrace
 
@@ -23,7 +23,7 @@ this_dir="$(cd $(dirname $0) && pwd)"
 repo_root="$(cd $this_dir/../../ && pwd)"
 python_versions="${override_python_versions:-3.11}"
 output_dir="${output_dir:-${this_dir}/wheelhouse}"
-packages="${packages:-iree-runtime iree-compiler}"
+packages="${packages:-iree-base-runtime iree-base-compiler}"
 
 # Note that this typically is selected to match the version that the official
 # Python distributed is built at.
@@ -50,12 +50,12 @@ function run() {
       export PATH=$python_dir/bin:$orig_path
       echo ":::: Python version $(python3 --version)"
       case "$package" in
-        iree-runtime)
-          clean_wheels iree_runtime $python_version
+        iree-base-runtime)
+          clean_wheels iree_base_runtime $python_version
           build_iree_runtime
           ;;
-        iree-compiler)
-          clean_wheels iree_compiler $python_version
+        iree-base-compiler)
+          clean_wheels iree_base_compiler $python_version
           build_iree_compiler
           ;;
         *)

--- a/build_tools/python_deploy/build_windows_packages.ps1
+++ b/build_tools/python_deploy/build_windows_packages.ps1
@@ -10,7 +10,7 @@
 # Configure settings with script parameters.
 param(
     [array]$python_versions=@("3.11"),
-    [array]$packages=@("iree-runtime", "iree-compiler"),
+    [array]$packages=@("iree-base-runtime", "iree-base-compiler"),
     [System.String]$output_dir
 )
 
@@ -47,12 +47,12 @@ function run() {
 
       Write-Host ":::: Version: $(py -${python_version} --version)"
       switch ($package) {
-          "iree-runtime" {
-            clean_wheels iree_runtime $python_version
+          "iree-base-runtime" {
+            clean_wheels iree_base_runtime $python_version
             build_iree_runtime $python_version
           }
-          "iree-compiler" {
-            clean_wheels iree_compiler $python_version
+          "iree-base-compiler" {
+            clean_wheels iree_base_compiler $python_version
             build_iree_compiler $python_version
           }
           Default {

--- a/compiler/bindings/python/iree/compiler/api/ctypes_dl.py
+++ b/compiler/bindings/python/iree/compiler/api/ctypes_dl.py
@@ -535,7 +535,7 @@ def _probe_iree_compiler_dylib() -> str:
     if not paths:
         paths = _mlir_libs.__path__
 
-    logging.debug("Found installed iree-compiler package %r", version_dict)
+    logging.debug("Found installed IREE compiler package %r", version_dict)
     dylib_basename = "libIREECompiler.so"
     system = platform.system()
     if system == "Darwin":

--- a/compiler/setup.py
+++ b/compiler/setup.py
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# Build/install the iree-compiler python package.
+# Build/install the iree-base-compiler python package.
 # Note that this includes a relatively large build of LLVM (~2400 C++ files)
 # and can take a considerable amount of time, especially with defaults.
 # To install:
@@ -415,7 +415,7 @@ custom_package_suffix = os.getenv("IREE_COMPILER_CUSTOM_PACKAGE_SUFFIX", "")
 custom_package_prefix = os.getenv("IREE_COMPILER_CUSTOM_PACKAGE_PREFIX", "")
 
 setup(
-    name=f"{custom_package_prefix}iree-compiler{custom_package_suffix}{PACKAGE_SUFFIX}",
+    name=f"{custom_package_prefix}iree-base-compiler{custom_package_suffix}{PACKAGE_SUFFIX}",
     version=f"{PACKAGE_VERSION}",
     author="IREE Authors",
     author_email="iree-technical-discussion@lists.lfaidata.foundation",

--- a/docs/website/docs/developers/general/release-management.md
+++ b/docs/website/docs/developers/general/release-management.md
@@ -21,8 +21,10 @@ on GitHub. We also push the Python packages for this release to PyPI.
 | -- | -- |
 GitHub release (stable) | [![GitHub Release](https://img.shields.io/github/v/release/iree-org/iree)](https://github.com/iree-org/iree/releases/latest)
 GitHub release (nightly) | [![GitHub Release](https://img.shields.io/github/v/release/iree-org/iree?include_prereleases)](https://github.com/iree-org/iree/releases)
-Python iree-compiler | [![PyPI version](https://badge.fury.io/py/iree-compiler.svg)](https://badge.fury.io/py/iree-compiler)
-Python iree-runtime | [![PyPI version](https://badge.fury.io/py/iree-runtime.svg)](https://badge.fury.io/py/iree-runtime)
+Python iree-base-compiler | [![PyPI version](https://badge.fury.io/py/iree-base-compiler.svg)](https://badge.fury.io/py/iree-base-compiler)
+Python iree-base-runtime | [![PyPI version](https://badge.fury.io/py/iree-base-runtime.svg)](https://badge.fury.io/py/iree-base-runtime)
+Python iree-compiler (deprecated) | [![PyPI version](https://badge.fury.io/py/iree-compiler.svg)](https://badge.fury.io/py/iree-compiler)
+Python iree-runtime (deprecated) | [![PyPI version](https://badge.fury.io/py/iree-runtime.svg)](https://badge.fury.io/py/iree-runtime)
 
 ## Running a release
 

--- a/runtime/setup.py
+++ b/runtime/setup.py
@@ -518,7 +518,7 @@ populate_built_package(
 )
 
 setup(
-    name=f"{custom_package_prefix}iree-runtime{custom_package_suffix}{PACKAGE_SUFFIX}",
+    name=f"{custom_package_prefix}iree-base-runtime{custom_package_suffix}{PACKAGE_SUFFIX}",
     version=f"{PACKAGE_VERSION}",
     author="IREE Authors",
     author_email="iree-technical-discussion@lists.lfaidata.foundation",


### PR DESCRIPTION
As part of applying the new versioning scheme proposed with #18938, this renames the Python packages `iree-compiler` to `iree-base-compiler` and `iree-runtime` to `iree-base-runtime`.