### PR TITLE
ConstExpr: expand to parents of nested consumers, fixes #18779

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.cpp
@@ -176,8 +176,15 @@ ConstExprAnalysis::ConstExprAnalysis(Operation *rootOp)
         for (auto &use : definingOp->getUses()) {
           Operation *useOp = use.getOwner();
           // Skip expanding of ops within dispatch or nested regions.
-          if (definingOp->getParentOp() != useOp->getParentOp())
+          if (definingOp->getParentOp() != useOp->getParentOp()) {
+            // check if we can expand to the parent op instead
+            if (auto parentOp = useOp->getParentOp()) {
+              if (definingOp->getParentOp() == parentOp->getParentOp()) {
+                expandToOp(parentOp);
+              }
+            }
             continue;
+          }
           expandToOp(useOp);
         }
       }

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals_linalg.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals_linalg.mlir
@@ -63,7 +63,7 @@ module @broadcast_treated_as_leaf {
 
 // -----
 
-// Checks that a constantOp which only has a consumer within a nest gets hoisted
+// Checks that a ConstantOp which only has a consumer within a nest gets hoisted.
 module @nested_consumer {
   // CHECK: util.global private @[[HOISTED:.*]] : tensor<2xf32>
   // CHECK: util.initializer


### PR DESCRIPTION
This change fixes the problem where constExprs, which only have a consumer within a nested region, can end up with 0 consumers. This leads to the issue that these constExprs can't get hoisted, as the ConstExprHoistingPolicy will determine them as invalid because they can't have a legal escape if they don't have any consumers. A more detailed description of what happens is in https://github.com/iree-org/iree/issues/18779.