### PR TITLE
[NFC] Add a CMake option IREE_VISIBILITY_HIDDEN.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,7 @@ option(BUILD_SHARED_LIBS "Instructs CMake to build libraries as shared if possib
 set(IREE_RUNTIME_OPTIMIZATION_PROFILE "" CACHE STRING
     "Build optimization profile to apply. One of '', 'lto', 'size'.")
 set(IREE_LTO_MODE "full" CACHE STRING "LTO type, 'thin' or 'full'. Only consulted on clang-like compilers.")
+option(IREE_VISIBILITY_HIDDEN "Builds all C/C++ libraries with hidden visibility" ON)
 
 #-------------------------------------------------------------------------------
 # IREE command-line tooling configuration

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -68,11 +68,21 @@ set(IREE_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(IREE_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(IREE_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
-# Key compilation options
+# By default we apply visibility control explicitly. However, this is available
+# as an option for users who need to control this explicitly (i.e. if
+# re-exporting, etc). Defaulting this to on with explicit API control macros
+# makes Linux and Windows behave similarly with respect to shared libraries
+# and DLLs.
+if(IREE_VISIBILITY_HIDDEN)
 iree_select_compiler_opts(IREE_DEFAULT_COPTS
   CLANG_OR_GCC
     "-fvisibility=hidden"
+)
+endif()
 
+# Key compilation options
+iree_select_compiler_opts(IREE_DEFAULT_COPTS
+  CLANG_OR_GCC
     # NOTE: The RTTI setting must match what LLVM was compiled with (defaults
     # to RTTI disabled).
     "$<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>"


### PR DESCRIPTION
This allows disabling the implicit `-fvisibility=hidden` that gets added to the default COPTS. This whole area needs a bit of modernization, but for the moment, having an option at least makes the runtime usable in a consumer that wishes to apply its own export control.