### PR TITLE
Refactor existing MMA intrinsics

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -59,9 +59,9 @@ namespace mlir::iree_compiler::IREE::GPU {
 namespace {
 // Struct containing abstract MMA shape and type information.
 struct OpaqueMmaLayout {
-  int64_t mSize;
-  int64_t nSize;
-  int64_t kSize;
+  int64_t mSize = 0;
+  int64_t nSize = 0;
+  int64_t kSize = 0;
   Type aType;
   Type bType;
   Type cType;
@@ -209,63 +209,77 @@ getContractionLayout(vector::ContractionOp contract, ConcreteMmaLayout layout) {
 // Layout Attribute Building Helpers
 //===----------------------------------------------------------------------===//
 
-static OpaqueMmaLayout getOpaqueMFMALayout(MLIRContext *context,
-                                           MMAIntrinsic type) {
+static std::tuple<Type, Type, Type> getABCElementTypes(MLIRContext *context,
+                                                       MMAIntrinsic intrinsic) {
   Type f8E4M3FNUZ = Float8E4M3FNUZType::get(context);
   Type f8E5M2FNUZ = Float8E5M2FNUZType::get(context);
   Type f16 = Float16Type::get(context);
   Type bf16 = BFloat16Type::get(context);
   Type f32 = Float32Type::get(context);
-
   Type i8 = IntegerType::get(context, 8);
   Type i32 = IntegerType::get(context, 32);
-
-  switch (type) {
+  switch (intrinsic) {
   case MMAIntrinsic::MFMA_F32_16x16x4_F32: {
-    return OpaqueMmaLayout{16, 16, 4, f32, f32, f32};
+    return {f32, f32, f32};
   }
   case MMAIntrinsic::MFMA_F32_16x16x16_F16: {
-    return OpaqueMmaLayout{16, 16, 16, f16, f16, f32};
+    return {f16, f16, f32};
   }
   case MMAIntrinsic::MFMA_F32_32x32x8_F16: {
-    return OpaqueMmaLayout{32, 32, 8, f16, f16, f32};
+    return {f16, f16, f32};
   }
   case MMAIntrinsic::MFMA_F32_16x16x16_BF16: {
-    return OpaqueMmaLayout{16, 16, 16, bf16, bf16, f32};
+    return {bf16, bf16, f32};
   }
   case MMAIntrinsic::MFMA_F32_32x32x8_BF16: {
-    return OpaqueMmaLayout{32, 32, 8, bf16, bf16, f32};
+    return {bf16, bf16, f32};
   }
   case MMAIntrinsic::MFMA_F32_16x16x32_F8E4M3FNUZ: {
-    return OpaqueMmaLayout{16, 16, 32, f8E4M3FNUZ, f8E4M3FNUZ, f32};
+    return {f8E4M3FNUZ, f8E4M3FNUZ, f32};
   }
   case MMAIntrinsic::MFMA_F32_16x16x32_F8E5M2FNUZ: {
-    return OpaqueMmaLayout{16, 16, 32, f8E5M2FNUZ, f8E5M2FNUZ, f32};
+    return {f8E5M2FNUZ, f8E5M2FNUZ, f32};
   }
   case MMAIntrinsic::MFMA_I32_16x16x32_I8: {
-    return OpaqueMmaLayout{16, 16, 32, i8, i8, i32};
+    return {i8, i8, i32};
   }
   case MMAIntrinsic::MFMA_I32_32x32x16_I8: {
-    return OpaqueMmaLayout{32, 32, 16, i8, i8, i32};
+    return {i8, i8, i32};
   }
   case MMAIntrinsic::MFMA_I32_32x32x8_I8: {
-    return OpaqueMmaLayout{32, 32, 8, i8, i8, i32};
+    return {i8, i8, i32};
   }
   case MMAIntrinsic::MFMA_I32_16x16x16_I8: {
-    return OpaqueMmaLayout{16, 16, 16, i8, i8, i32};
+    return {i8, i8, i32};
   }
   case MMAIntrinsic::WMMA_F32_16x16x16_F16: {
-    return OpaqueMmaLayout{16, 16, 16, f16, f16, f32};
+    return {f16, f16, f32};
   }
   case MMAIntrinsic::WMMA_F16_16x16x16_F16: {
-    return OpaqueMmaLayout{16, 16, 16, f16, f16, f16};
+    return {f16, f16, f16};
   }
   case MMAIntrinsic::WMMA_I32_16x16x16_I8: {
-    return OpaqueMmaLayout{16, 16, 16, i8, i8, i32};
+    return {i8, i8, i32};
+  }
+  case MMAIntrinsic::NV_WMMA_F16_16x16x16_F16: {
+    return {f16, f16, f16};
+  }
+  case MMAIntrinsic::NV_WMMA_F32_16x16x16_F16: {
+    return {f16, f16, f32};
   }
   }
-  llvm_unreachable("unhandled mfma layout type");
-  return OpaqueMmaLayout{};
+}
+
+static OpaqueMmaLayout getOpaqueMFMALayout(MLIRContext *context,
+                                           MMAIntrinsic intrinsic) {
+  OpaqueMmaLayout o;
+  std::tie(o.aType, o.bType, o.cType) = getABCElementTypes(context, intrinsic);
+  auto lhs = getSingleSubgroupLayout(intrinsic, MMAFragment::Lhs);
+  auto rhs = getSingleSubgroupLayout(intrinsic, MMAFragment::Rhs);
+  o.mSize = lhs.outer[0] * lhs.thread[0] * lhs.element[0];
+  o.kSize = lhs.outer[1] * lhs.thread[1] * lhs.element[1];
+  o.nSize = rhs.outer[1] * rhs.thread[1] * rhs.element[1];
+  return o;
 }
 
 static std::tuple<PerDimLayoutAttr, PerDimLayoutAttr>
@@ -416,67 +430,25 @@ std::tuple<int64_t, int64_t, int64_t> MMAAttr::getMNKShape() const {
   return {getMSize(), getNSize(), getKSize()};
 }
 
-// NOTE: For layout specifications of the WMMA intrinsics
-//       below we are assuming subgroupsize of 32.
+static VectorType getVectorType(MLIRContext *context, MMAIntrinsic intrinsic,
+                                MMAFragment fragment) {
+  auto o = getOpaqueMFMALayout(context, intrinsic);
+  auto s = getSingleSubgroupLayout(intrinsic, fragment);
+  Type elemType = (fragment == MMAFragment::Lhs)   ? o.aType
+                  : (fragment == MMAFragment::Rhs) ? o.bType
+                                                   : o.cType;
+  return VectorType::get(
+      {s.element[0] * s.element[1] * s.outer[0] * s.outer[1]}, elemType);
+}
+
 std::tuple<VectorType, VectorType, VectorType>
 MMAAttr::getABCVectorTypes() const {
-  // Check https://github.com/ROCm/amd_matrix_instruction_calculator for
-  // instruction details. Note here we are returning the number elements, while
-  // amd_matrix_instruction_calculator tells us about the number of 32-bit
-  // registers. So need to adjust accordingly. All vectors should be 1-D.
-  switch (getIntrinsic().getValue()) {
-  case MMAIntrinsic::MFMA_F32_16x16x4_F32: {
-    auto aType = VectorType::get({1}, getAType());
-    auto bType = VectorType::get({1}, getBType());
-    auto cType = VectorType::get({4}, getCType());
-    return std::make_tuple(aType, bType, cType);
-  }
-  case MMAIntrinsic::MFMA_I32_16x16x16_I8:
-  case MMAIntrinsic::MFMA_F32_16x16x16_F16:
-  case MMAIntrinsic::MFMA_F32_16x16x16_BF16: {
-    auto aType = VectorType::get({4}, getAType());
-    auto bType = VectorType::get({4}, getBType());
-    auto cType = VectorType::get({4}, getCType());
-    return std::make_tuple(aType, bType, cType);
-  }
-  case MMAIntrinsic::MFMA_I32_32x32x8_I8:
-  case MMAIntrinsic::MFMA_F32_32x32x8_F16:
-  case MMAIntrinsic::MFMA_F32_32x32x8_BF16: {
-    auto aType = VectorType::get({4}, getAType());
-    auto bType = VectorType::get({4}, getBType());
-    auto cType = VectorType::get({16}, getCType());
-    return std::make_tuple(aType, bType, cType);
-  }
-  case MMAIntrinsic::MFMA_F32_16x16x32_F8E4M3FNUZ:
-  case MMAIntrinsic::MFMA_F32_16x16x32_F8E5M2FNUZ:
-  case MMAIntrinsic::MFMA_I32_16x16x32_I8: {
-    auto aType = VectorType::get({8}, getAType());
-    auto bType = VectorType::get({8}, getBType());
-    auto cType = VectorType::get({4}, getCType());
-    return std::make_tuple(aType, bType, cType);
-  }
-  case MMAIntrinsic::MFMA_I32_32x32x16_I8: {
-    auto aType = VectorType::get({8}, getAType());
-    auto bType = VectorType::get({8}, getBType());
-    auto cType = VectorType::get({16}, getCType());
-    return std::make_tuple(aType, bType, cType);
-  }
-  case MMAIntrinsic::WMMA_F32_16x16x16_F16:
-  case MMAIntrinsic::WMMA_I32_16x16x16_I8: {
-    auto aType = VectorType::get({16}, getAType());
-    auto bType = VectorType::get({16}, getBType());
-    auto cType = VectorType::get({8}, getCType());
-    return std::make_tuple(aType, bType, cType);
-  }
-  case MMAIntrinsic::WMMA_F16_16x16x16_F16: {
-    auto aType = VectorType::get({16}, getAType());
-    auto bType = VectorType::get({16}, getBType());
-    auto cType = VectorType::get({16}, getCType());
-    return std::make_tuple(aType, bType, cType);
-  }
-  }
-  // This should not happen but just to make GCC happy.
-  return std::make_tuple(VectorType{}, VectorType{}, VectorType{});
+  MLIRContext *context = getContext();
+  MMAIntrinsic intrinsic = getIntrinsic().getValue();
+  VectorType aVecType = getVectorType(context, intrinsic, MMAFragment::Lhs);
+  VectorType bVecType = getVectorType(context, intrinsic, MMAFragment::Rhs);
+  VectorType cVecType = getVectorType(context, intrinsic, MMAFragment::Acc);
+  return {aVecType, bVecType, cVecType};
 }
 
 FailureOr<std::tuple<VectorLayoutInterface, VectorLayoutInterface,
@@ -488,51 +460,26 @@ MMAAttr::getContractionLayout(vector::ContractionOp contract) const {
 }
 
 int64_t MMAAttr::getBlockSize() const {
-  switch (getIntrinsic().getValue()) {
-  case MMAIntrinsic::MFMA_F32_16x16x4_F32:
-  case MMAIntrinsic::MFMA_F32_16x16x16_F16:
-  case MMAIntrinsic::MFMA_F32_16x16x16_BF16:
-  case MMAIntrinsic::MFMA_I32_16x16x16_I8:
-  case MMAIntrinsic::MFMA_F32_32x32x8_F16:
-  case MMAIntrinsic::MFMA_F32_32x32x8_BF16:
-  case MMAIntrinsic::MFMA_I32_32x32x8_I8:
-  case MMAIntrinsic::MFMA_F32_16x16x32_F8E4M3FNUZ:
-  case MMAIntrinsic::MFMA_F32_16x16x32_F8E5M2FNUZ:
-  case MMAIntrinsic::MFMA_I32_16x16x32_I8:
-  case MMAIntrinsic::MFMA_I32_32x32x16_I8:
-  case MMAIntrinsic::WMMA_F16_16x16x16_F16:
-  case MMAIntrinsic::WMMA_F32_16x16x16_F16:
-  case MMAIntrinsic::WMMA_I32_16x16x16_I8: {
-    return 1;
-  }
-  }
-  // This should not happen but just to make GCC happy.
-  return 0;
+  // Not supporting any block size other than 1 at the moment.
+  return 1;
+}
+
+static uint32_t getArchID(MMAIntrinsic intrinsic) {
+  return static_cast<int>(intrinsic) & 0xFF00;
+}
+
+static bool is_AMD_MFMA(MMAIntrinsic intrinsic) {
+  return getArchID(intrinsic) >= 0x1000 && getArchID(intrinsic) <= 0x17FF;
+}
+
+static bool is_AMD_WMMA(MMAIntrinsic intrinsic) {
+  return getArchID(intrinsic) >= 0x1800 && getArchID(intrinsic) <= 0x1FFF;
 }
 
 static int64_t getIntrinsicSubgroupSize(MMAIntrinsic intrinsic) {
-  switch (intrinsic) {
-  case MMAIntrinsic::MFMA_F32_16x16x4_F32:
-  case MMAIntrinsic::MFMA_F32_16x16x16_F16:
-  case MMAIntrinsic::MFMA_F32_16x16x16_BF16:
-  case MMAIntrinsic::MFMA_I32_16x16x16_I8:
-  case MMAIntrinsic::MFMA_F32_32x32x8_F16:
-  case MMAIntrinsic::MFMA_F32_32x32x8_BF16:
-  case MMAIntrinsic::MFMA_I32_32x32x8_I8:
-  case MMAIntrinsic::MFMA_F32_16x16x32_F8E4M3FNUZ:
-  case MMAIntrinsic::MFMA_F32_16x16x32_F8E5M2FNUZ:
-  case MMAIntrinsic::MFMA_I32_16x16x32_I8:
-  case MMAIntrinsic::MFMA_I32_32x32x16_I8: {
-    return 64;
-  }
-  case MMAIntrinsic::WMMA_F32_16x16x16_F16:
-  case MMAIntrinsic::WMMA_F16_16x16x16_F16:
-  case MMAIntrinsic::WMMA_I32_16x16x16_I8: {
-    return 32;
-  }
-  }
-  // This should not happen but just to make GCC happy.
-  return 0;
+  // Not using Wave64 at all at the moment, so the only place where the
+  // subgroup size is CDNA* architectures.
+  return is_AMD_MFMA(intrinsic) ? 64 : 32;
 }
 
 int64_t MMAAttr::getSubgroupSize() const {
@@ -637,6 +584,9 @@ MMASingleSubgroupLayout getSingleSubgroupLayout(MMAIntrinsic intrinsic,
       return {/*outer=*/{16, 1}, /*thread=*/{1, 16}, /*tstrides=*/{0, 1},
               /*element=*/{1, 1}};
     }
+  case MMAIntrinsic::NV_WMMA_F32_16x16x16_F16:
+  case MMAIntrinsic::NV_WMMA_F16_16x16x16_F16:
+    return {};
   }
   return {};
 }
@@ -683,40 +633,23 @@ FailureOr<Value> MMAAttr::buildMmaOperation(OpBuilder &builder, Location loc,
   if (cType != resultType) {
     return failure();
   }
-  switch (getIntrinsic().getValue()) {
-  case MMAIntrinsic::MFMA_F32_16x16x4_F32: {
-    // Update the lhs and rhs to extract the first element since vector<1xT> is
-    // not supoorted by amgpu.mfma op.
-    lhs = builder.create<vector::ExtractOp>(loc, lhs, ArrayRef{int64_t{0}});
-    rhs = builder.create<vector::ExtractOp>(loc, rhs, ArrayRef{int64_t{0}});
+  auto getVecOrSingleElem = [&](Value vec) -> Value {
+    bool one = llvm::cast<VectorType>(vec.getType()).getNumElements() == 1;
+    return one ? builder.create<vector::ExtractOp>(loc, vec, 0) : vec;
+  };
+  MMAIntrinsic intrinsic = getIntrinsic().getValue();
+  if (is_AMD_MFMA(intrinsic)) {
+    // MFMA intrinsics want single-element operands of element type, not vector.
+    lhs = getVecOrSingleElem(lhs);
+    rhs = getVecOrSingleElem(rhs);
     auto [m, n, k] = getMNKShape();
     return builder
         .create<amdgpu::MFMAOp>(loc, resultType, m, n, k, getBlockSize(), lhs,
                                 rhs, acc)
         .getResult();
-  }
-  case MMAIntrinsic::MFMA_I32_16x16x16_I8:
-  case MMAIntrinsic::MFMA_F32_16x16x16_F16:
-  case MMAIntrinsic::MFMA_F32_16x16x16_BF16:
-  case MMAIntrinsic::MFMA_I32_32x32x8_I8:
-  case MMAIntrinsic::MFMA_F32_32x32x8_F16:
-  case MMAIntrinsic::MFMA_F32_32x32x8_BF16:
-  case MMAIntrinsic::MFMA_F32_16x16x32_F8E4M3FNUZ:
-  case MMAIntrinsic::MFMA_F32_16x16x32_F8E5M2FNUZ:
-  case MMAIntrinsic::MFMA_I32_16x16x32_I8:
-  case MMAIntrinsic::MFMA_I32_32x32x16_I8: {
-    auto [m, n, k] = getMNKShape();
-    return builder
-        .create<amdgpu::MFMAOp>(loc, resultType, m, n, k, getBlockSize(), lhs,
-                                rhs, acc)
-        .getResult();
-  }
-  case MMAIntrinsic::WMMA_F32_16x16x16_F16:
-  case MMAIntrinsic::WMMA_F16_16x16x16_F16:
-  case MMAIntrinsic::WMMA_I32_16x16x16_I8: {
+  } else if (is_AMD_WMMA(intrinsic)) {
     return builder.create<amdgpu::WMMAOp>(loc, resultType, lhs, rhs, acc)
         .getResult();
-  }
   }
   return failure();
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.td
@@ -98,76 +98,101 @@ class IREEGPU_I32MmaEnumAttr<string name, string summary, list<I32EnumAttrCase> 
   let genSpecializedAttr = 0;
 }
 
-// Format: <virtual><kind>_<output-type>_<M>x<N>x<K>_<input-type>
+// These enum values are loosely named to match the target intrinsics that they
+// lower to, with wiggle room. The general name format used here is, similar to
+// typical target intrinsics:
+//     <kind>_<elem-type-C>_<M>x<N>x<K>_<elem-type-A>[_<elem-type-B>]
 //
-// "virtual": Prefixes intrinsic with "V" to represent Non native-MFMA
-//             emulating a larger MMA with smaller ones. This is useful
-//             to interleave reads in K-dim, S.T we can have wider reads
-//             or align layouts between matmuls.
+// Deviations from target intrinsic naming include:
+// * The same enum values are reused when the same intrinsic exists in different
+//   architecture versions with slightly different target intrinsic name. For
+//   instance, our MFMA_F32_16x16x4_F32 lowers to:
+//   - v_mfma_f32_16x16x4f32 on CDNA1/CDNA2.
+//   - v_mfma_f32_16x16x4_f32 on CDNA3.
+// * Each enum value corresponds to one fully type-specialized intrinsic, in
+//   contrast to target intrinsics which are sometimes type-generic. For
+//   instance, on RDNA3, our WMMA_I32_16x16x16_I8 lowers to
+//   v_wmma_i32_16x16x16_iu8 specialized for signed int8 operands.
+// * Each enum value uses IREE-style naming of element type. For example,
+//   our MFMA_F32_16x16x32_F8E5M2FNUZ_F8E4M3FNUZ lowers to
+//   v_mfma_f32_16x16x32_bf8_fp8.
 //
 // Values: 0xABCD where:
 // * A = vendor:
-//   * 0 = AMD
-//   * 1 = NVIDIA
-// * B is architecture:
+//   * 1 = AMD
+//   * 2 = NVIDIA
+// * B = architecture. When an intrinsic exists in multiple architectures, this
+//       should be the architecture it was introduced in, as long as it still
+//       has the same semantics. If a new architecture breaks an existing
+//       intrinsic's semantics, we can use that field for versioning.
 //   * For AMD:
-//     * 0 = RDNA3
-//     * 8 = CDNA2
-//     * 9 = CDNA3
-// * C is A/B data type:
-//   * 0 = f32
-//   * 1 = f16
-//   * 2 = bf16
-//   * 3 = f8e5m2 (and variants like fnuz).
-//   * 4 = f8e4m3 (and variants like fnuz).
-//   * 8 = i8
-// * D enumerates intrinsics for the same data type.
+//     * 0 = CDNA1
+//     * 1 = CDNA2
+//     * 2 = CDNA3
+//     * 8 = RDNA3
+// * C = element type of A-matrix:
+//   * 0 = 64-bit float (e.g. IEEE754 double precision)
+//   * 1 = 32-bit float (e.g. IEEE754 single precision, and "xf32" fast variants)
+//   * 2 = 16-bit float (incl. IREE754 half and bf16)
+//   * 3 = 8-bit float (incl. f8E5M2, f8E4M3, and "FNUZ" variants)
+//   * C = 8-bit integer (any signedness)
+// * D enumerates intrinsics that share the same 0xABC* bits.
 //
-// CDNA3 instrinsics
-def MFMA_F32_16x16x4_F32 : I32EnumAttrCase<"MFMA_F32_16x16x4_F32", 0x0900>;
-def MFMA_F32_16x16x16_F16 : I32EnumAttrCase<"MFMA_F32_16x16x16_F16", 0x0910>;
-def MFMA_F32_32x32x8_F16  : I32EnumAttrCase<"MFMA_F32_32x32x8_F16", 0x0911>;
-def VMFMA_F32_16x16x32_F16  : I32EnumAttrCase<"VMFMA_F32_16x16x32_F16", 0x0912>;
-def VMFMA_F32_32x32x16_F16  : I32EnumAttrCase<"VMFMA_F32_32x32x16_F16", 0x0913>;
-def MFMA_F32_16x16x16_BF16  : I32EnumAttrCase<"MFMA_F32_16x16x16_BF16", 0x0920>;
-def MFMA_F32_32x32x8_BF16  : I32EnumAttrCase<"MFMA_F32_32x32x8_BF16", 0x0921>;
-def MFMA_F32_16x16x32_F8E5M2FNUZ  : I32EnumAttrCase<"MFMA_F32_16x16x32_F8E5M2FNUZ", 0x0930>;
-def MFMA_F32_16x16x32_F8E4M3FNUZ  : I32EnumAttrCase<"MFMA_F32_16x16x32_F8E4M3FNUZ", 0x0940>;
-// V-Intrinsic below interleaves read from K-dim from one 8xF8 to two 4xF8.
-// (Useful in F8 chained-MM to align B-layout of 2nd MM to C-layout of 1st MM)
-def VMFMA_F32_16x16x32_F8E4M3FNUZ  : I32EnumAttrCase<"VMFMA_F32_16x16x32_F8E4M3FNUZ", 0x0941>;
-def MFMA_I32_16x16x32_I8  : I32EnumAttrCase<"MFMA_I32_16x16x32_I8", 0x0980>;
-def MFMA_I32_32x32x16_I8  : I32EnumAttrCase<"MFMA_I32_32x32x16_I8", 0x0981>;
 
-// CDNA2 instrinsics
-def MFMA_I32_16x16x16_I8  : I32EnumAttrCase<"MFMA_I32_16x16x16_I8", 0x0880>;
-def MFMA_I32_32x32x8_I8  : I32EnumAttrCase<"MFMA_I32_32x32x8_I8", 0x0881>;
+// Introduced in CDNA1
+def MFMA_F32_16x16x4_F32 : I32EnumAttrCase<"MFMA_F32_16x16x4_F32", 0x1010>;
+def MFMA_F32_16x16x16_F16 : I32EnumAttrCase<"MFMA_F32_16x16x16_F16", 0x1020>;
+def MFMA_F32_32x32x8_F16 : I32EnumAttrCase<"MFMA_F32_32x32x8_F16", 0x1021>;
+def MFMA_I32_16x16x16_I8 : I32EnumAttrCase<"MFMA_I32_16x16x16_I8", 0x10C0>;
+def MFMA_I32_32x32x8_I8 : I32EnumAttrCase<"MFMA_I32_32x32x8_I8", 0x10C1>;
 
-// TODO: Create separate WMMA ops for AMD and NVIDIA GPUs
-def WMMA_F32_16x16x16_F16 : I32EnumAttrCase<"WMMA_F32_16x16x16_F16", 0x0010>;
-def WMMA_F16_16x16x16_F16 : I32EnumAttrCase<"WMMA_F16_16x16x16_F16", 0x0011>;
+// Introduced in CDNA3
+def MFMA_F32_16x16x16_BF16 : I32EnumAttrCase<"MFMA_F32_16x16x16_BF16", 0x1220>;
+def MFMA_F32_32x32x8_BF16 : I32EnumAttrCase<"MFMA_F32_32x32x8_BF16", 0x1221>;
+def MFMA_F32_16x16x32_F8E5M2FNUZ : I32EnumAttrCase<"MFMA_F32_16x16x32_F8E5M2FNUZ", 0x1230>;
+def MFMA_F32_16x16x32_F8E4M3FNUZ : I32EnumAttrCase<"MFMA_F32_16x16x32_F8E4M3FNUZ", 0x1232>;
+def MFMA_I32_16x16x32_I8 : I32EnumAttrCase<"MFMA_I32_16x16x32_I8", 0x12C0>;
+def MFMA_I32_32x32x16_I8 : I32EnumAttrCase<"MFMA_I32_32x32x16_I8", 0x12C1>;
 
-// TODO: The actual I8 instruction allows specifying (mixed) signedness.
-// This will need to become its own class of MMA attribute.
-def WMMA_I32_16x16x16_I8 : I32EnumAttrCase<"WMMA_I32_16x16x16_I8", 0x0080>;
+// Introduced in RDNA3
+def WMMA_F32_16x16x16_F16 : I32EnumAttrCase<"WMMA_F32_16x16x16_F16", 0x1820>;
+def WMMA_F16_16x16x16_F16 : I32EnumAttrCase<"WMMA_F16_16x16x16_F16", 0x1821>;
+def WMMA_I32_16x16x16_I8 : I32EnumAttrCase<"WMMA_I32_16x16x16_I8", 0x18C0>;
+
+// NV intrinsics
+def NV_WMMA_F32_16x16x16_F16 : I32EnumAttrCase<"NV_WMMA_F32_16x16x16_F16", 0x2020>;
+def NV_WMMA_F16_16x16x16_F16 : I32EnumAttrCase<"NV_WMMA_F16_16x16x16_F16", 0x2021>;
 
 def IREEGPU_MMAIntrinsic : IREEGPU_I32MmaEnumAttr<"MMAIntrinsic",
     "Descriptor for different MMA intrinsics", [
+      // Introduced in CDNA1
       MFMA_F32_16x16x4_F32,
       MFMA_F32_16x16x16_F16,
       MFMA_F32_32x32x8_F16,
-      MFMA_F32_16x16x16_BF16,
-      MFMA_F32_32x32x8_BF16,
-      MFMA_F32_16x16x32_F8E4M3FNUZ,
-      MFMA_F32_16x16x32_F8E5M2FNUZ,
-      MFMA_I32_16x16x32_I8,
-      MFMA_I32_32x32x16_I8,
       MFMA_I32_16x16x16_I8,
       MFMA_I32_32x32x8_I8,
+
+      // Introduced in CDNA3
+      MFMA_F32_16x16x16_BF16,
+      MFMA_F32_32x32x8_BF16,
+      MFMA_F32_16x16x32_F8E5M2FNUZ,
+      MFMA_F32_16x16x32_F8E4M3FNUZ,
+      MFMA_I32_16x16x32_I8,
+      MFMA_I32_32x32x16_I8,
+
+      // RDNA3 intrinsics
       WMMA_F32_16x16x16_F16,
       WMMA_F16_16x16x16_F16,
-      WMMA_I32_16x16x16_I8
+      WMMA_I32_16x16x16_I8,
+
+      // NV intrinsics
+      NV_WMMA_F32_16x16x16_F16,
+      NV_WMMA_F16_16x16x16_F16,
     ]>;
+
+def VMFMA_F32_16x16x32_F16  : I32EnumAttrCase<"VMFMA_F32_16x16x32_F16", 0>;
+def VMFMA_F32_32x32x16_F16  : I32EnumAttrCase<"VMFMA_F32_32x32x16_F16", 1>;
+def VMFMA_F32_16x16x32_F8E4M3FNUZ  : I32EnumAttrCase<"VMFMA_F32_16x16x32_F8E4M3FNUZ", 2>;
 
 def IREEGPU_VirtualMMAIntrinsic : IREEGPU_I32MmaEnumAttr<"VirtualMMAIntrinsic",
     "Descriptor for different Virtual MMA intrinsics", [

--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -94,7 +94,10 @@ PREPROCESSING_PEEL = "--iree-llvmcpu-vector-pproc-strategy=peel"
     test_type = "matmul",
 ) for dtype in [
     "f32",
-    # "f64" (also supported for ArmSME, but not by the test generator)
+    # f64 disabled because it wasn't supported by the test generator at the time
+    # this was added. When adding it in the future, consider passing
+    # --iree-input-demote-f64-to-f32=false to the compiler.
+    # "f64"
 ] for transpose_lhs in [
     True,
     False,
@@ -135,12 +138,14 @@ X86_64_AVX512_BF16 = X86_64_AVX512 + [
     ),
     compiler_flags = [
         "--iree-opt-data-tiling",
-    ] + ["--iree-llvmcpu-enable-ukernels=%s" % ("all" if use_uk else "none")],
+    ] + [
+        "--iree-llvmcpu-enable-ukernels=%s" % ("all" if use_uk else "none"),
+    ] + (["--iree-input-demote-f64-to-f32=false"] if acc_type == "f64" else []),
     generator = ":generate_e2e_matmul_tests",
     generator_args = [
         "--lhs_rhs_type=%s" % lhs_rhs_type,
         "--acc_type=%s" % acc_type,
-    ],
+    ] + (["--shapes=small"] if acc_type == "f64" else []),
     tags = ([
         # f16/bf16 trigger internal LLVM assertion errors on riscv and wasm.
         "noriscv",
@@ -185,6 +190,7 @@ X86_64_AVX512_BF16 = X86_64_AVX512 + [
     [
         ("i8", "i32"),
         ("f32", "f32"),
+        ("f64", "f64"),
         ("f16", "f16"),
         ("f16", "f32"),
         ("bf16", "bf16"),

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -175,6 +175,33 @@ iree_generated_e2e_runner_test(
 
 iree_generated_e2e_runner_test(
   NAME
+    e2e_matmul_cpu_dt_f64_f64
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f64"
+    "--acc_type=f64"
+    "--shapes=small"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling"
+    "--iree-llvmcpu-enable-ukernels=none"
+    "--iree-input-demote-f64-to-f32=false"
+  LABELS
+
+  TARGET_CPU_FEATURES_VARIANTS
+    "generic"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
     e2e_matmul_cpu_dt_f16_f16
   TEST_TYPE
     matmul
@@ -344,6 +371,33 @@ iree_generated_e2e_runner_test(
     "generic"
     "x86_64:avx2:+avx,+avx2,+fma,+f16c"
     "x86_64:avx512:+avx,+avx2,+fma,+f16c,+avx512f,+avx512vl,+avx512cd,+avx512bw,+avx512dq"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_matmul_cpu_dt_uk_f64_f64
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f64"
+    "--acc_type=f64"
+    "--shapes=small"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "llvm-cpu"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-opt-data-tiling"
+    "--iree-llvmcpu-enable-ukernels=all"
+    "--iree-input-demote-f64-to-f32=false"
+  LABELS
+
+  TARGET_CPU_FEATURES_VARIANTS
+    "generic"
 )
 
 iree_generated_e2e_runner_test(

--- a/tests/e2e/matmul/generate_e2e_matmul_tests.py
+++ b/tests/e2e/matmul/generate_e2e_matmul_tests.py
@@ -25,6 +25,7 @@ class MatrixElemTypeId(enum.Enum):
     NONE = ""
     I8 = "i8"
     I32 = "i32"
+    F64 = "f64"
     F32 = "f32"
     F16 = "f16"
     BF16 = "bf16"
@@ -896,6 +897,7 @@ def parse_arguments():
         choices=[
             "i32",
             "i8",
+            "f64",
             "f32",
             "f16",
             "bf16",
@@ -910,7 +912,7 @@ def parse_arguments():
     parser.add_argument(
         "--acc_type",
         type=str,
-        choices=["i32", "f32", "f16", "bf16"],
+        choices=["i32", "f64", "f32", "f16", "bf16"],
         help="Numeric type of the accumulator and result matrices",
         required=True,
     )

--- a/tools/testing/e2e/iree-e2e-matmul-test.cc
+++ b/tools/testing/e2e/iree-e2e-matmul-test.cc
@@ -43,19 +43,10 @@
     result_data[n + m * n_size] = acc;                                         \
   }
 
-// Reference mamtul instantiations from macro REFERENCE_MATMUL
-// for the f32 input, f32 accumlation, and f32 result.
-// [float <= float * float + float]
+// Reference matmul instantiations
 REFERENCE_MATMUL(float, float, float, float)
-
-// Reference mamtul instantiations from macro REFERENCE_MATMUL
-// for the int8_t input, int32_t accumlation, and int32_t result.
-// [i32 <= i8 * i8 + i32]
+REFERENCE_MATMUL(double, double, double, double)
 REFERENCE_MATMUL(int8_t, int8_t, int32_t, int32_t)
-
-// Reference mamtul instantiations from macro REFERENCE_MATMUL
-// for the int32_t input, int32_t accumlation, and int32_t result.
-// [i32 <= i32 * i32 + i32]
 REFERENCE_MATMUL(int32_t, int32_t, int32_t, int32_t)
 
 // Reference mamtul for the f16 input, f16 accumlation, and f16 result.
@@ -166,6 +157,13 @@ static iree_status_t reference_matmul_element(
         m_size, k_size, n_size, lhs_type, rhs_type, acc_type, transpose_rhs,
         (const float*)lhs_data, (const float*)rhs_data, (const float*)acc_data,
         (float*)result_data, m, n);
+  } else if (lhs_type == IREE_HAL_ELEMENT_TYPE_FLOAT_64 &&
+             rhs_type == IREE_HAL_ELEMENT_TYPE_FLOAT_64 &&
+             acc_type == IREE_HAL_ELEMENT_TYPE_FLOAT_64) {
+    reference_matmul_double_double_double_double(
+        m_size, k_size, n_size, lhs_type, rhs_type, acc_type, transpose_rhs,
+        (const double*)lhs_data, (const double*)rhs_data,
+        (const double*)acc_data, (double*)result_data, m, n);
   } else if (iree_hal_element_type_is_integer(lhs_type, 8) &&
              iree_hal_element_type_is_integer(rhs_type, 8) &&
              iree_hal_element_type_is_integer(acc_type, 32)) {

--- a/tools/testing/e2e/test_utils.c
+++ b/tools/testing/e2e/test_utils.c
@@ -144,6 +144,13 @@ iree_test_utils_e2e_value_t iree_test_utils_value_make_f32(float value) {
   return result;
 }
 
+iree_test_utils_e2e_value_t iree_test_utils_value_make_f64(float value) {
+  iree_test_utils_e2e_value_t result;
+  result.type = IREE_TEST_UTILS_VALUE_TYPE_F64;
+  result.f64 = value;
+  return result;
+}
+
 iree_test_utils_e2e_value_t iree_test_utils_read_buffer_element(
     iree_hal_dim_t index, iree_hal_element_type_t result_type,
     const void* data) {
@@ -167,6 +174,8 @@ iree_test_utils_e2e_value_t iree_test_utils_read_buffer_element(
     return iree_test_utils_value_make_bf16(((uint16_t*)data)[index]);
   } else if (result_type == IREE_HAL_ELEMENT_TYPE_FLOAT_32) {
     return iree_test_utils_value_make_f32(((float*)data)[index]);
+  } else if (result_type == IREE_HAL_ELEMENT_TYPE_FLOAT_64) {
+    return iree_test_utils_value_make_f64(((double*)data)[index]);
   }
   iree_status_abort(iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                                      "unhandled matmul result type"));
@@ -273,6 +282,10 @@ bool iree_test_utils_result_elements_agree(iree_test_utils_e2e_value_t expected,
       if (actual.f32 == expected.f32) return true;
       if (iree_test_utils_require_exact_results()) return false;
       return fabsf(actual.f32 - expected.f32) < acceptable_fp_delta;
+    case IREE_TEST_UTILS_VALUE_TYPE_F64:
+      if (actual.f64 == expected.f64) return true;
+      if (iree_test_utils_require_exact_results()) return false;
+      return fabs(actual.f64 - expected.f64) < acceptable_fp_delta;
     default:
       iree_status_abort(iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                                          "unhandled value type"));
@@ -387,7 +400,7 @@ void iree_test_utils_get_min_max_for_element_type(
     case IREE_HAL_ELEMENT_TYPE_SINT_64:
     case IREE_HAL_ELEMENT_TYPE_FLOAT_64:
       *min = -16;
-      *min = +16;
+      *max = +16;
       break;
     case IREE_HAL_ELEMENT_TYPE_UINT_64:
       *min = 0;


### PR DESCRIPTION
Some code simplifications in `IREEGPUAttrs.cpp`, and some shuffling of the MMAIntrinsic enum, making it easier to add more MMAIntrinsics in the future (see #19099).