### PR TITLE
Populate more metadata in compiler and runtime Python packages.

### DIFF
--- a/compiler/bindings/python/iree/compiler/README.md
+++ b/compiler/bindings/python/iree/compiler/README.md
@@ -1,0 +1,3 @@
+# IREE Python Compiler API
+
+This package provides an API for compiling IREE binaries from common input formats.

--- a/compiler/setup.py
+++ b/compiler/setup.py
@@ -439,7 +439,6 @@ setup(
     description="IREE Python Compiler API",
     long_description=README,
     long_description_content_type="text/markdown",
-    long_description="",
     license="Apache-2.0",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/compiler/setup.py
+++ b/compiler/setup.py
@@ -414,6 +414,20 @@ packages = find_namespace_packages(
 )
 print(f"Found compiler packages: {packages}")
 
+with open(
+    os.path.join(
+        IREE_SOURCE_DIR,
+        "compiler",
+        "bindings",
+        "python",
+        "iree",
+        "compiler",
+        "README.md",
+    ),
+    "rt",
+) as f:
+    README = f.read()
+
 custom_package_suffix = os.getenv("IREE_COMPILER_CUSTOM_PACKAGE_SUFFIX", "")
 custom_package_prefix = os.getenv("IREE_COMPILER_CUSTOM_PACKAGE_PREFIX", "")
 
@@ -422,7 +436,9 @@ setup(
     version=f"{PACKAGE_VERSION}",
     author="IREE Authors",
     author_email="iree-technical-discussion@lists.lfaidata.foundation",
-    description="IREE Compiler API",
+    description="IREE Python Compiler API",
+    long_description=README,
+    long_description_content_type="text/markdown",
     long_description="",
     license="Apache-2.0",
     classifiers=[
@@ -435,6 +451,11 @@ setup(
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
     ],
+    project_urls={
+        "homepage": "https://iree.dev/",
+        "repository": "https://github.com/iree-org/iree",
+        "documentation": "https://iree.dev/reference/bindings/python/",
+    },
     ext_modules=[
         CMakeExtension("iree.compiler._mlir_libs._mlir"),
         CMakeExtension("iree.compiler._mlir_libs._ireeDialects"),

--- a/runtime/setup.py
+++ b/runtime/setup.py
@@ -539,7 +539,11 @@ setup(
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
     ],
-    url="https://github.com/iree-org/iree",
+    project_urls={
+        "homepage": "https://iree.dev/",
+        "repository": "https://github.com/iree-org/iree",
+        "documentation": "https://iree.dev/reference/bindings/python/",
+    },
     python_requires=">=3.9",
     ext_modules=(
         [


### PR DESCRIPTION
This will add more content to https://pypi.org/project/iree-base-compiler/ and https://pypi.org/project/iree-base-runtime/. We can also add more text to the README files or use the repository root README instead.

Docs I followed:

* https://packaging.python.org/en/latest/specifications/core-metadata/
* https://packaging.python.org/en/latest/specifications/well-known-project-urls/#well-known-project-urls