### PR TITLE
Support reshape propagation for online attention

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -526,7 +526,12 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_PureOp<"attention",
     "Value":$scale,
     "Value":$output,
     "ArrayAttr":$indexing_maps,
-    CArg<"std::optional<Value>", "std::nullopt">:$mask)>
+    CArg<"std::optional<Value>", "std::nullopt">:$mask)>,
+
+    OpBuilder<(ins "TypeRange":$results,
+    "ValueRange":$inputs,
+    "ValueRange":$outputs,
+    "ArrayAttr":$indexing_maps)>
   ];
 
   let extraClassDeclaration = [{
@@ -576,6 +581,9 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_PureOp<"attention",
 def IREELinalgExt_OnlineAttentionOp : IREELinalgExt_PureOp<"online_attention",
     [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
      SingleBlockImplicitTerminator<"::mlir::iree_compiler::IREE::LinalgExt::YieldOp">,
+     DeclareOpInterfaceMethods<LinalgFusionInterface,
+      ["getIndexingMapsForResults", "getIndexingMapsForOperands",
+       "getStaticLoopRanges"]>,
      DestinationStyleOpInterface, LinalgExtInterface,
      DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
      DeclareOpInterfaceMethods<AggregatedOpInterface, ["decomposeOperation"]>,
@@ -646,7 +654,12 @@ def IREELinalgExt_OnlineAttentionOp : IREELinalgExt_PureOp<"online_attention",
     "Value":$max,
     "Value":$sum,
     "ArrayAttr":$indexing_maps,
-    CArg<"std::optional<Value>", "std::nullopt">:$mask)>
+    CArg<"std::optional<Value>", "std::nullopt">:$mask)>,
+
+    OpBuilder<(ins "TypeRange":$results,
+    "ValueRange":$inputs,
+    "ValueRange":$outputs,
+    "ArrayAttr":$indexing_maps)>
   ];
 
 


### PR DESCRIPTION
Support bubbling `tensor.expand_shape` and sinking `tensor.collapse_shape` through online attention ops. This change does the following:

1. Implements `LinalgFusionInterface` for `iree_linalg_ext.online_attention`
2. Refactors `ReshapeFusion.cpp` to be more generic and handle both attention variants
3. Add test to `iree-dispatch-creation-bubble-up-expand-shapes`

