### PR TITLE
[tuner]: Add a utility function to query supported MMA intrinsics

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
@@ -112,6 +112,7 @@ iree_compiler_cc_library(
         "ROCDLKernelConfig.cpp",
         "ROCDLLowerExecutableTarget.cpp",
         "ROCDLSelectLoweringStrategy.cpp",
+        "TestLLVMGPUQueryMMAPass.cpp",
         "Verifiers.cpp",
     ],
     hdrs = [

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -97,6 +97,7 @@ iree_cc_library(
     "ROCDLKernelConfig.cpp"
     "ROCDLLowerExecutableTarget.cpp"
     "ROCDLSelectLoweringStrategy.cpp"
+    "TestLLVMGPUQueryMMAPass.cpp"
     "Verifiers.cpp"
   DEPS
     ::PassHeaders

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
@@ -163,4 +163,9 @@ def TestLLVMGPUScalarizeMathOpPass :
   let summary = "Test pass for several legalization patterns.";
 }
 
+def TestLLVMGPUQueryMMAPass :
+    Pass<"iree-test-llvmgpu-query-mma", "ModuleOp"> {
+  let summary = "Test pass for querying the supported mma intrinsic instructions.";
+}
+
 #endif // IREE_CODEGEN_LLVMGPU_PASSES

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TestLLVMGPUQueryMMAPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TestLLVMGPUQueryMMAPass.cpp
@@ -1,0 +1,48 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/LLVMGPU/Passes.h"
+#include "iree/compiler/Codegen/Utils/GPUUtils.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "iree-test-llvmgpu-query-mma"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_TESTLLVMGPUQUERYMMAPASS
+#include "iree/compiler/Codegen/LLVMGPU/Passes.h.inc"
+
+static void printMMAVector(SmallVector<IREE::GPU::MMAAttr> &mmaAttrs,
+                           const std::string &extraMessage = {}) {
+  llvm::outs() << "Printing MMA Collection" << extraMessage
+               << ", size: " << mmaAttrs.size() << "\n";
+  for (const auto &mma : mmaAttrs) {
+    llvm::outs() << mma << " ";
+  }
+  llvm::outs() << "\n";
+}
+
+namespace {
+
+struct TestLLVMGPUQueryMMAPass final
+    : impl::TestLLVMGPUQueryMMAPassBase<TestLLVMGPUQueryMMAPass> {
+  void runOnOperation() override {
+    ModuleOp moduleOp = getOperation();
+    SmallVector<IREE::GPU::MMAAttr> mmaCollecton;
+    // Print mma vector before collection.
+    printMMAVector(mmaCollecton,
+                   " Before querying supported mma instrinsic instructions");
+    // Collect mma intrinsic instructions.
+    QueryMMAIntrinsics(moduleOp, mmaCollecton);
+    // Print mma vector after collection.
+    printMMAVector(mmaCollecton,
+                   " After querying supported mma instrinsic instructions");
+  }
+};
+} // namespace
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TestLLVMGPUQueryMMAPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TestLLVMGPUQueryMMAPass.cpp
@@ -24,11 +24,8 @@ struct TestLLVMGPUQueryMMAPass final
   void runOnOperation() override {
     ModuleOp moduleOp = getOperation();
     llvm::SmallDenseMap<Operation *, SmallVector<IREE::GPU::MMAIntrinsic>>
-        mmaMap;
-    queryMMAIntrinsics(moduleOp, mmaMap);
-    for (const auto &entry : mmaMap) {
-      Operation *op = entry.first;
-      const SmallVector<IREE::GPU::MMAIntrinsic> &mmaAttrs = entry.second;
+        mmaMap = queryMMAIntrinsics(moduleOp);
+    for (const auto &[op, mmaAttrs] : mmaMap) {
       if (auto variantOp = llvm::dyn_cast<IREE::HAL::ExecutableVariantOp>(op)) {
         llvm::outs() << "Executable Variant Name: " << variantOp.getName()
                      << "\n";
@@ -37,9 +34,7 @@ struct TestLLVMGPUQueryMMAPass final
                      << "\n";
       }
       llvm::outs() << "MMA Intrinsics: ";
-      for (const auto &mma : mmaAttrs) {
-        llvm::outs() << mma << " ";
-      }
+      llvm::interleave(mmaAttrs, llvm::outs(), " ");
       llvm::outs() << "\n";
     }
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TestLLVMGPUQueryMMAPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TestLLVMGPUQueryMMAPass.cpp
@@ -23,16 +23,13 @@ struct TestLLVMGPUQueryMMAPass final
     : impl::TestLLVMGPUQueryMMAPassBase<TestLLVMGPUQueryMMAPass> {
   void runOnOperation() override {
     ModuleOp moduleOp = getOperation();
-    llvm::SmallDenseMap<Operation *, SmallVector<IREE::GPU::MMAIntrinsic>>
+    llvm::SmallDenseMap<IREE::HAL::ExecutableVariantOp,
+                        SmallVector<IREE::GPU::MMAIntrinsic>>
         mmaMap = queryMMAIntrinsics(moduleOp);
     for (const auto &[op, mmaAttrs] : mmaMap) {
-      if (auto variantOp = llvm::dyn_cast<IREE::HAL::ExecutableVariantOp>(op)) {
-        llvm::outs() << "Executable Variant Name: " << variantOp.getName()
-                     << "\n";
-      } else {
-        llvm::outs() << "Executable Variant Name: " << "Unnamed Operation"
-                     << "\n";
-      }
+      llvm::outs() << "Executable Variant Name: "
+                   << cast<IREE::HAL::ExecutableVariantOp>(*op).getName()
+                   << "\n";
       llvm::outs() << "MMA Intrinsics: ";
       llvm::interleave(mmaAttrs, llvm::outs(), " ");
       llvm::outs() << "\n";

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD.bazel
@@ -55,6 +55,7 @@ iree_lit_test_suite(
             "promote_matmul_to_fit_mma.mlir",
             "tensor_pad.mlir",
             "tensorcore_vectorization.mlir",
+            "test_query_mma.mlir",
             "transform_dialect_bufferize.mlir",
             "transform_dialect_eliminate_gpu_barriers.mlir",
             "transform_dialect_hoist_allocs.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -52,6 +52,7 @@ iree_lit_test_suite(
     "rocdl_pipeline_test.mlir"
     "tensor_pad.mlir"
     "tensorcore_vectorization.mlir"
+    "test_query_mma.mlir"
     "transform_dialect_bufferize.mlir"
     "transform_dialect_eliminate_gpu_barriers.mlir"
     "transform_dialect_hoist_allocs.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/test_query_mma.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/test_query_mma.mlir
@@ -2,15 +2,12 @@
 
 #executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb",
 {abi = "hip", iree.gpu.target = #iree_gpu.target<arch = "gfx942", features = "",
-wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8,
+wgp = <compute = int32, storage =  b32,
 subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32,
-mma = [<MFMA_F32_16x16x4_F32>, <MFMA_F32_16x16x16_F16>, <MFMA_F32_32x32x8_F16>,
-<MFMA_F32_16x16x16_BF16>, <MFMA_F32_32x32x8_BF16>, <MFMA_F32_16x16x32_F8E4M3FNUZ>,
-<MFMA_F32_16x16x32_F8E5M2FNUZ>, <MFMA_I32_16x16x32_I8>, <MFMA_I32_32x32x16_I8>],
+mma = [<MFMA_F32_16x16x4_F32>, <MFMA_F32_16x16x16_F16>],
 subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024],
 max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536,
-max_workgroup_counts = [2147483647, 2147483647, 2147483647], max_load_instruction_bits = 128,
-simds_per_wgp = 4, vgpr_space_bits = 16384>>, ukernels = "none", waves_per_eu = 2 : i64}>
+max_workgroup_counts = [2147483647]>>, waves_per_eu = 2 : i64}>
 #pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>
 module {
   hal.executable private @main {
@@ -25,18 +22,65 @@ module {
   }
 }
 
-// CHECK: Printing MMA Collection Before querying supported mma instrinsic instructions, size: 0
-// CHECK: Printing MMA Collection After querying supported mma instrinsic instructions, size: 9
-// CHECK: MFMA_F32_16x16x4_F32
+// CHECK:       Executable Variant Name
+// CHECK-SAME:  main
+// CHECK: MMA   Intrinsics
+// CHECK-SAME:  MFMA_F32_16x16x4_F32
+// CHECK-SAME:  MFMA_F32_16x16x16_F16
+// CHECK-LABEL: func.func @fn
+
+// -----
+
+#executable_target_rocm_hsaco_fb0 = #hal.executable.target<"rocm", "rocm-hsaco-fb",
+{abi = "hip", iree.gpu.target = #iree_gpu.target<arch = "gfx942", features = "",
+wgp = <compute = int32, storage =  b32,
+subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32,
+mma = [<MFMA_F32_16x16x4_F32>, <MFMA_F32_16x16x16_F16>],
+subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024],
+max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536,
+max_workgroup_counts = [2147483647]>>, waves_per_eu = 2 : i64}>
+#executable_target_rocm_hsaco_fb1 = #hal.executable.target<"rocm", "rocm-hsaco-fb",
+{abi = "hip", iree.gpu.target = #iree_gpu.target<arch = "gfx942", features = "",
+wgp = <compute = int32, storage =  b32,
+subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32,
+mma = [<MFMA_F32_32x32x8_F16>, <MFMA_F32_16x16x16_BF16>],
+subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024],
+max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536,
+max_workgroup_counts = [2147483647]>>, waves_per_eu = 2 : i64}>
+#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>
+module {
+  hal.executable private @main_0 {
+    hal.executable.variant public @main_0 target(#executable_target_rocm_hsaco_fb0) {
+      hal.executable.export public @entry_point_0 layout(#pipeline_layout)
+      builtin.module {
+        func.func @fn_0() {
+          return
+        }
+      }
+    }
+  }
+  hal.executable private @main_1 {
+    hal.executable.variant public @main_1 target(#executable_target_rocm_hsaco_fb1) {
+      hal.executable.export public @entry_point layout(#pipeline_layout)
+      builtin.module {
+        func.func @fn_1() {
+          return
+        }
+      }
+    }
+  }
+}
+
+// CHECK:      Executable Variant Name
+// CHECK-SAME: main_0
+// CHECK:      MMA Intrinsics
+// CHECK-SAME: MFMA_F32_16x16x4_F32
 // CHECK-SAME: MFMA_F32_16x16x16_F16
+// CHECK:      Executable Variant Name
+// CHECK-SAME: main_1
+// CHECK:      MMA Intrinsics
 // CHECK-SAME: MFMA_F32_32x32x8_F16
 // CHECK-SAME: MFMA_F32_16x16x16_BF16
-// CHECK-SAME: MFMA_F32_32x32x8_BF16
-// CHECK-SAME: MFMA_F32_16x16x32_F8E4M3FNUZ
-// CHECK-SAME: MFMA_F32_16x16x32_F8E5M2FNUZ
-// CHECK-SAME: MFMA_I32_16x16x32_I8
-// CHECK-SAME: MFMA_I32_32x32x16_I8
-// CHECK-LABEL: func.func @fn
 
 // -----
 
@@ -55,6 +99,6 @@ module {
   }
 }
 
-// CHECK: Printing MMA Collection Before querying supported mma instrinsic instructions, size: 0
-// CHECK: Printing MMA Collection After querying supported mma instrinsic instructions, size: 0
-// CHECK-LABEL: func.func @fn_empty
+// CHECK-NOT:   Executable Variant Name
+// CHECK-NOT:   MMA Intrinsics
+// CHECK-LABEL: func.func @fn

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/test_query_mma.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/test_query_mma.mlir
@@ -1,0 +1,60 @@
+// RUN: iree-opt --split-input-file --iree-test-llvmgpu-query-mma %s | FileCheck %s
+
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb",
+{abi = "hip", iree.gpu.target = #iree_gpu.target<arch = "gfx942", features = "",
+wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8,
+subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32,
+mma = [<MFMA_F32_16x16x4_F32>, <MFMA_F32_16x16x16_F16>, <MFMA_F32_32x32x8_F16>,
+<MFMA_F32_16x16x16_BF16>, <MFMA_F32_32x32x8_BF16>, <MFMA_F32_16x16x32_F8E4M3FNUZ>,
+<MFMA_F32_16x16x32_F8E5M2FNUZ>, <MFMA_I32_16x16x32_I8>, <MFMA_I32_32x32x16_I8>],
+subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024],
+max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536,
+max_workgroup_counts = [2147483647, 2147483647, 2147483647], max_load_instruction_bits = 128,
+simds_per_wgp = 4, vgpr_space_bits = 16384>>, ukernels = "none", waves_per_eu = 2 : i64}>
+#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>
+module {
+  hal.executable private @main {
+    hal.executable.variant public @main target(#executable_target_rocm_hsaco_fb) {
+      hal.executable.export public @entry_point layout(#pipeline_layout)
+      builtin.module {
+        func.func @fn() {
+          return
+        }
+      }
+    }
+  }
+}
+
+// CHECK: Printing MMA Collection Before querying supported mma instrinsic instructions, size: 0
+// CHECK: Printing MMA Collection After querying supported mma instrinsic instructions, size: 9
+// CHECK: MFMA_F32_16x16x4_F32
+// CHECK-SAME: MFMA_F32_16x16x16_F16
+// CHECK-SAME: MFMA_F32_32x32x8_F16
+// CHECK-SAME: MFMA_F32_16x16x16_BF16
+// CHECK-SAME: MFMA_F32_32x32x8_BF16
+// CHECK-SAME: MFMA_F32_16x16x32_F8E4M3FNUZ
+// CHECK-SAME: MFMA_F32_16x16x32_F8E5M2FNUZ
+// CHECK-SAME: MFMA_I32_16x16x32_I8
+// CHECK-SAME: MFMA_I32_32x32x16_I8
+// CHECK-LABEL: func.func @fn
+
+// -----
+
+#executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb">
+#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>
+module {
+  hal.executable private @main {
+    hal.executable.variant public @main target(#executable_target_rocm_hsaco_fb) {
+      hal.executable.export public @entry_point layout(#pipeline_layout)
+      builtin.module {
+        func.func @fn_empty() {
+          return
+        }
+      }
+    }
+  }
+}
+
+// CHECK: Printing MMA Collection Before querying supported mma instrinsic instructions, size: 0
+// CHECK: Printing MMA Collection After querying supported mma instrinsic instructions, size: 0
+// CHECK-LABEL: func.func @fn_empty

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/test_query_mma.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/test_query_mma.mlir
@@ -71,16 +71,10 @@ module {
   }
 }
 
-// CHECK:      Executable Variant Name
-// CHECK-SAME: main_0
-// CHECK:      MMA Intrinsics
-// CHECK-SAME: MFMA_F32_16x16x4_F32
-// CHECK-SAME: MFMA_F32_16x16x16_F16
-// CHECK:      Executable Variant Name
-// CHECK-SAME: main_1
-// CHECK:      MMA Intrinsics
-// CHECK-SAME: MFMA_F32_32x32x8_F16
-// CHECK-SAME: MFMA_F32_16x16x16_BF16
+// CHECK-DAG: main_0
+// CHECK-DAG: MMA Intrinsics: MFMA_F32_16x16x4_F32 MFMA_F32_16x16x16_F16
+// CHECK-DAG: main_1
+// CHECK-DAG: MMA Intrinsics: MFMA_F32_32x32x8_F16 MFMA_F32_16x16x16_BF16
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/test_query_mma.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/test_query_mma.mlir
@@ -1,13 +1,13 @@
 // RUN: iree-opt --split-input-file --iree-test-llvmgpu-query-mma %s | FileCheck %s
 
 #executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb",
-{abi = "hip", iree.gpu.target = #iree_gpu.target<arch = "gfx942", features = "",
+{iree.gpu.target = #iree_gpu.target<arch = "gfx942", features = "",
 wgp = <compute = int32, storage =  b32,
-subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32,
+subgroup = arithmetic, dot = dp4xi8toi32,
 mma = [<MFMA_F32_16x16x4_F32>, <MFMA_F32_16x16x16_F16>],
-subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024],
+subgroup_size_choices = [64], max_workgroup_sizes = [1024],
 max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536,
-max_workgroup_counts = [2147483647]>>, waves_per_eu = 2 : i64}>
+max_workgroup_counts = [2147483647]>>}>
 #pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>
 module {
   hal.executable private @main {
@@ -32,21 +32,21 @@ module {
 // -----
 
 #executable_target_rocm_hsaco_fb0 = #hal.executable.target<"rocm", "rocm-hsaco-fb",
-{abi = "hip", iree.gpu.target = #iree_gpu.target<arch = "gfx942", features = "",
+{iree.gpu.target = #iree_gpu.target<arch = "gfx942", features = "",
 wgp = <compute = int32, storage =  b32,
-subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32,
+subgroup = arithmetic, dot = dp4xi8toi32,
 mma = [<MFMA_F32_16x16x4_F32>, <MFMA_F32_16x16x16_F16>],
-subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024],
+subgroup_size_choices = [64], max_workgroup_sizes = [1024],
 max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536,
-max_workgroup_counts = [2147483647]>>, waves_per_eu = 2 : i64}>
+max_workgroup_counts = [2147483647]>>}>
 #executable_target_rocm_hsaco_fb1 = #hal.executable.target<"rocm", "rocm-hsaco-fb",
-{abi = "hip", iree.gpu.target = #iree_gpu.target<arch = "gfx942", features = "",
+{iree.gpu.target = #iree_gpu.target<arch = "gfx942", features = "",
 wgp = <compute = int32, storage =  b32,
-subgroup =  shuffle|arithmetic, dot =  dp4xi8toi32,
+subgroup = arithmetic, dot = dp4xi8toi32,
 mma = [<MFMA_F32_32x32x8_F16>, <MFMA_F32_16x16x16_BF16>],
-subgroup_size_choices = [64], max_workgroup_sizes = [1024, 1024, 1024],
+subgroup_size_choices = [64], max_workgroup_sizes = [1024],
 max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536,
-max_workgroup_counts = [2147483647]>>, waves_per_eu = 2 : i64}>
+max_workgroup_counts = [2147483647]>>}>
 #pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>
 module {
   hal.executable private @main_0 {

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -206,12 +206,12 @@ IREE::GPU::TargetAttr getGPUTargetAttr(Operation *op);
 /// Returns std::nullopt if none found.
 std::optional<int> getGPUSubgroupSize(mlir::FunctionOpInterface func);
 
-/// Returns supported MMA intrinsic instructions based on the GPU target
-/// description stored in `moduleOp` and populates them in `MMAIntrinsic`.
-void queryMMAIntrinsics(
-    mlir::ModuleOp moduleOp,
-    llvm::SmallDenseMap<Operation *, SmallVector<IREE::GPU::MMAIntrinsic>>
-        &mmaAttributesMap);
+/// Returns a map of supported MMA intrinsic instructions based on the
+/// GPU target descriptions in `moduleOp`. Each entry in the map associates
+/// an `Operation*` ( an `IREE::HAL::ExecutableVariantOp`) with a
+/// vector of `IREE::GPU::MMAIntrinsic` attributes.
+llvm::SmallDenseMap<Operation *, SmallVector<IREE::GPU::MMAIntrinsic>>
+queryMMAIntrinsics(mlir::ModuleOp moduleOp);
 
 } // namespace mlir::iree_compiler
 

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -207,9 +207,11 @@ IREE::GPU::TargetAttr getGPUTargetAttr(Operation *op);
 std::optional<int> getGPUSubgroupSize(mlir::FunctionOpInterface func);
 
 /// Returns supported MMA intrinsic instructions based on the GPU target
-/// description stored in `moduleOp` and populates them in `mmaAttrs`.
-void QueryMMAIntrinsics(mlir::ModuleOp moduleOp,
-                        SmallVector<IREE::GPU::MMAAttr> &mmaAttrs);
+/// description stored in `moduleOp` and populates them in `MMAIntrinsic`.
+void queryMMAIntrinsics(
+    mlir::ModuleOp moduleOp,
+    llvm::SmallDenseMap<Operation *, SmallVector<IREE::GPU::MMAIntrinsic>>
+        &mmaAttributesMap);
 
 } // namespace mlir::iree_compiler
 

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -209,8 +209,8 @@ std::optional<int> getGPUSubgroupSize(mlir::FunctionOpInterface func);
 
 /// Returns a map of supported MMA intrinsic instructions based on the
 /// GPU target descriptions in `moduleOp`. Each entry in the map associates
-/// an `Operation*` ( an `IREE::HAL::ExecutableVariantOp`) with a
-/// vector of `IREE::GPU::MMAIntrinsic` attributes.
+/// an `IREE::HAL::ExecutableVariantOp` with a vector of
+/// `IREE::GPU::MMAIntrinsic` attributes.
 llvm::SmallDenseMap<IREE::HAL::ExecutableVariantOp,
                     SmallVector<IREE::GPU::MMAIntrinsic>>
 queryMMAIntrinsics(mlir::ModuleOp moduleOp);

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -8,6 +8,7 @@
 #define IREE_COMPILER_CODEGEN_UTILS_GPUUTILS_H_
 
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
@@ -210,7 +211,8 @@ std::optional<int> getGPUSubgroupSize(mlir::FunctionOpInterface func);
 /// GPU target descriptions in `moduleOp`. Each entry in the map associates
 /// an `Operation*` ( an `IREE::HAL::ExecutableVariantOp`) with a
 /// vector of `IREE::GPU::MMAIntrinsic` attributes.
-llvm::SmallDenseMap<Operation *, SmallVector<IREE::GPU::MMAIntrinsic>>
+llvm::SmallDenseMap<IREE::HAL::ExecutableVariantOp,
+                    SmallVector<IREE::GPU::MMAIntrinsic>>
 queryMMAIntrinsics(mlir::ModuleOp moduleOp);
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -206,6 +206,11 @@ IREE::GPU::TargetAttr getGPUTargetAttr(Operation *op);
 /// Returns std::nullopt if none found.
 std::optional<int> getGPUSubgroupSize(mlir::FunctionOpInterface func);
 
+/// Returns supported MMA intrinsic instructions based on the GPU target
+/// description stored in `moduleOp` and populates them in `mmaAttrs`.
+void QueryMMAIntrinsics(mlir::ModuleOp moduleOp,
+                        SmallVector<IREE::GPU::MMAAttr> &mmaAttrs);
+
 } // namespace mlir::iree_compiler
 
 #endif // IREE_COMPILER_CODEGEN_UTILS_GPUUTILS_H_


### PR DESCRIPTION
This PR aims to address the task listed in https://github.com/nod-ai/SHARK-Platform/issues/453:  add a utility function (`QueryMMAIntrinsics`) to query supported MMA intrinsics. 

A new test pass `TestLLVMGPUQueryMMAPass` has been added to validate the correctness of this utility function, along with a corresponding test to ensure reliable functionality.

TODO: The function will be exposed to both the C API and Python in a follow-up PR.