### PR TITLE
Disable tests depending on iree-model-artifacts GCS bucket.

### DIFF
--- a/integrations/tensorflow/test/iree_tfl_tests/llvmcpu_mobilebert_tf2_quant.run
+++ b/integrations/tensorflow/test/iree_tfl_tests/llvmcpu_mobilebert_tf2_quant.run
@@ -1,4 +1,5 @@
 # REQUIRES: llvmcpu
 # REQUIRES: bugfix
 #           Numeric error (#9796)
+#           File is inaccessible (#18518)
 # RUN: %PYTHON -m iree_tfl_tests.mobilebert_tf2_quant_test --target_backend=llvmcpu --artifacts_dir=%t

--- a/integrations/tensorflow/test/iree_tfl_tests/llvmcpu_mobilenet_v1.run
+++ b/integrations/tensorflow/test/iree_tfl_tests/llvmcpu_mobilenet_v1.run
@@ -1,2 +1,4 @@
 # REQUIRES: llvmcpu
+# REQUIRES: bugfix
+#           File is inaccessible (#18518)
 # RUN: %PYTHON -m iree_tfl_tests.mobilenet_v1_test --target_backend=llvmcpu --artifacts_dir=%t

--- a/integrations/tensorflow/test/iree_tfl_tests/llvmcpu_mobilenet_v3-large_uint8.run
+++ b/integrations/tensorflow/test/iree_tfl_tests/llvmcpu_mobilenet_v3-large_uint8.run
@@ -1,4 +1,6 @@
 # REQUIRES: llvmcpu
+# REQUIRES: bugfix
+#           File is inaccessible (#18518)
 # RUN: %PYTHON -m iree_tfl_tests.mobilenet_v3-large_uint8_test --target_backend=llvmcpu --artifacts_dir=%t
 # TODO(#14830): Enable the test.
 # XFAIL: *

--- a/integrations/tensorflow/test/iree_tfl_tests/llvmcpu_posenet_i8.run
+++ b/integrations/tensorflow/test/iree_tfl_tests/llvmcpu_posenet_i8.run
@@ -1,3 +1,5 @@
 # REQUIRES: llvmcpu
+# REQUIRES: bugfix
+#           File is inaccessible (#18518)
 # RUN: %PYTHON -m iree_tfl_tests.posenet_i8_test --target_backend=llvmcpu --artifacts_dir=%t
 # XFAIL: *

--- a/integrations/tensorflow/test/iree_tfl_tests/llvmcpu_resnet_50_int8.run
+++ b/integrations/tensorflow/test/iree_tfl_tests/llvmcpu_resnet_50_int8.run
@@ -1,2 +1,4 @@
 # REQUIRES: llvmcpu
+# REQUIRES: bugfix
+#           File is inaccessible (#18518)
 # RUN: %PYTHON -m iree_tfl_tests.resnet_50_int8_test --target_backend=llvmcpu -artifacts_dir=%t

--- a/integrations/tensorflow/test/python/iree_tfl_tests/imagenet_test_data.py
+++ b/integrations/tensorflow/test/python/iree_tfl_tests/imagenet_test_data.py
@@ -7,6 +7,7 @@ from PIL import Image
 # Returns a sample image in the Imagenet dataset in uint8.
 def generate_input(workdir, input_details):
     # We use an image of apples since this is an easy example.
+    # TODO(#18518): Migrate this file to a new (ideally public) location
     img_path = "https://storage.googleapis.com/iree-model-artifacts/ILSVRC2012_val_00000023.JPEG"
     local_path = "/".join([workdir, "ILSVRC2012_val_00000023.JPEG"])
     urllib.request.urlretrieve(img_path, local_path)

--- a/integrations/tensorflow/test/python/iree_tfl_tests/mobilebert_tf2_quant_test.py
+++ b/integrations/tensorflow/test/python/iree_tfl_tests/mobilebert_tf2_quant_test.py
@@ -5,6 +5,7 @@ import numpy as np
 from . import squad_test_data
 from . import test_util
 
+# TODO(#18518): Migrate this file to a new (ideally public) location
 # Source https://tfhub.dev/iree/lite-model/mobilebert/int8/1
 model_path = "https://storage.googleapis.com/iree-model-artifacts/mobilebert-baseline-tf2-quant.tflite"
 

--- a/integrations/tensorflow/test/python/iree_tfl_tests/mobilenet_v1_test.py
+++ b/integrations/tensorflow/test/python/iree_tfl_tests/mobilenet_v1_test.py
@@ -8,6 +8,7 @@ import absl.testing
 import numpy
 from . import test_util
 
+# TODO(#18518): Migrate this file to a new (ideally public) location
 model_path = "https://storage.googleapis.com/iree-model-artifacts/tflite-integration-tests/mobilenet_v1.tflite"
 
 

--- a/integrations/tensorflow/test/python/iree_tfl_tests/mobilenet_v3-large_uint8_test.py
+++ b/integrations/tensorflow/test/python/iree_tfl_tests/mobilenet_v3-large_uint8_test.py
@@ -5,6 +5,7 @@ import numpy
 from . import imagenet_test_data
 from . import test_util
 
+# TODO(#18518): Migrate this file to a new (ideally public) location
 # Source https://tfhub.dev/iree/lite-model/mobilenet_v3_large_100_224/uint8/1
 model_path = "https://storage.googleapis.com/iree-model-artifacts/mobilenet_v3-large_224_1.0_uint8.tflite"
 

--- a/integrations/tensorflow/test/python/iree_tfl_tests/posenet_i8_test.py
+++ b/integrations/tensorflow/test/python/iree_tfl_tests/posenet_i8_test.py
@@ -11,6 +11,7 @@ import urllib.request
 
 from PIL import Image
 
+# TODO(#18518): Migrate these files to a new (ideally public) location
 model_path = "https://storage.googleapis.com/iree-model-artifacts/tflite-integration-tests/posenet_i8.tflite"
 model_input = "https://storage.googleapis.com/iree-model-artifacts/tflite-integration-tests/posenet_i8_input.jpg"
 

--- a/integrations/tensorflow/test/python/iree_tfl_tests/resnet_50_int8_test.py
+++ b/integrations/tensorflow/test/python/iree_tfl_tests/resnet_50_int8_test.py
@@ -5,6 +5,7 @@ import numpy
 from . import imagenet_test_data
 from . import test_util
 
+# TODO(#18518): Migrate this file to a new (ideally public) location
 # Model is INT8 quantized but inputs and outputs are FP32.
 model_path = "https://storage.googleapis.com/tf_model_garden/vision/resnet50_imagenet/resnet_50_224_int8.tflite"
 

--- a/tests/e2e/stablehlo_models/mnist_train_test/CMakeLists.txt
+++ b/tests/e2e/stablehlo_models/mnist_train_test/CMakeLists.txt
@@ -4,6 +4,9 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+# TODO(#18518): re-enable when the test remote files are accessible again
+return()
+
 # These tests use compiler APIs as well as runtime APIs.
 #
 # These tests perform linking via the Compiler API, which is only supported

--- a/tests/e2e/stablehlo_models/mnist_train_test/mnist_train_test.py
+++ b/tests/e2e/stablehlo_models/mnist_train_test/mnist_train_test.py
@@ -19,6 +19,7 @@ import numpy as np
 from iree.compiler.tools import InputType, compile_file
 from iree.runtime import load_vm_flatbuffer_file
 
+# TODO(#18518): Migrate this file to a new (ideally public) location
 MODEL_ARTIFACTS_URL = "https://storage.googleapis.com/iree-model-artifacts/mnist_train.2bec0cb356ae7c059e04624a627eb3b15b0a556cbd781bbed9f8d32e80a4311d.tar"
 
 Tensor = TypeVar("Tensor")


### PR DESCRIPTION
See https://github.com/iree-org/iree/issues/18518. These tests have started failing since the GCS bucket is now returning 403 errors.