### PR TITLE
Re-enable aarch64 package builds

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -122,26 +122,26 @@ jobs:
             build-family: linux-x86_64
             build-package: main-dist-linux
             experimental: false
-           - runs-on: ah-ubuntu_22_04-c7g_4x-50
-             build-family: linux-aarch64
-             build-package: main-dist-linux
-             experimental: true
+          - runs-on: ah-ubuntu_22_04-c7g_4x-50
+            build-family: linux-aarch64
+            build-package: main-dist-linux
+            experimental: true
           - runs-on: ubuntu-20.04
             build-family: linux-x86_64
             build-package: py-compiler-pkg
             experimental: false
-           - runs-on: ah-ubuntu_22_04-c7g_4x-50
-             build-family: linux-aarch64
-             build-package: py-compiler-pkg
-             experimental: true
+          - runs-on: ah-ubuntu_22_04-c7g_4x-50
+            build-family: linux-aarch64
+            build-package: py-compiler-pkg
+            experimental: true
           - runs-on: ubuntu-20.04
             build-family: linux-x86_64
             build-package: py-runtime-pkg
             experimental: false
-           - runs-on: ah-ubuntu_22_04-c7g_4x-50
-             build-family: linux-aarch64
-             build-package: py-runtime-pkg
-             experimental: true
+          - runs-on: ah-ubuntu_22_04-c7g_4x-50
+            build-family: linux-aarch64
+            build-package: py-runtime-pkg
+            experimental: true
           - runs-on: ubuntu-20.04
             build-family: linux-x86_64
             build-package: py-tf-compiler-tools-pkg

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -122,27 +122,26 @@ jobs:
             build-family: linux-x86_64
             build-package: main-dist-linux
             experimental: false
-          # TODO(scotttodd): re-enable aarch64 package builds when runners are available again
-          # - runs-on: ah-ubuntu_22_04-c7g_4x-50
-          #   build-family: linux-aarch64
-          #   build-package: main-dist-linux
-          #   experimental: true
+           - runs-on: ah-ubuntu_22_04-c7g_4x-50
+             build-family: linux-aarch64
+             build-package: main-dist-linux
+             experimental: true
           - runs-on: ubuntu-20.04
             build-family: linux-x86_64
             build-package: py-compiler-pkg
             experimental: false
-          # - runs-on: ah-ubuntu_22_04-c7g_4x-50
-          #   build-family: linux-aarch64
-          #   build-package: py-compiler-pkg
-          #   experimental: true
+           - runs-on: ah-ubuntu_22_04-c7g_4x-50
+             build-family: linux-aarch64
+             build-package: py-compiler-pkg
+             experimental: true
           - runs-on: ubuntu-20.04
             build-family: linux-x86_64
             build-package: py-runtime-pkg
             experimental: false
-          # - runs-on: ah-ubuntu_22_04-c7g_4x-50
-          #   build-family: linux-aarch64
-          #   build-package: py-runtime-pkg
-          #   experimental: true
+           - runs-on: ah-ubuntu_22_04-c7g_4x-50
+             build-family: linux-aarch64
+             build-package: py-runtime-pkg
+             experimental: true
           - runs-on: ubuntu-20.04
             build-family: linux-x86_64
             build-package: py-tf-compiler-tools-pkg


### PR DESCRIPTION
I was told that the underlying issue has been resolved.
