### PR TITLE
Extend hoist collapse out of scf.forall pattern to use same offsets for all users

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/propagate_reshapes_by_expansion.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/propagate_reshapes_by_expansion.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-propagate-reshapes-by-expansion), cse)" \
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-propagate-reshapes-by-expansion))" \
 // RUN:   --split-input-file %s --mlir-print-local-scope | FileCheck %s
 
 func.func @reshape_and_lowering_config(%src: tensor<3x4xf16>, %dest: tensor<12xf16>, %dest2: tensor<12xf16>) -> tensor<12xf16> {


### PR DESCRIPTION
The existing pattern added in https://github.com/iree-org/iree/pull/19044 created different offsets for each user even though we previously checked that the offsets will be exactly same. This was preventing recursive application of the pattern as the comparison of the offsets for the next application of patten would fail. The change in this PR is tested by removing cse in test file which was added by https://github.com/iree-org/iree/pull/19044 to workaround this exact issue. 