### PR TITLE
Fixes for switch statements on enums

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -302,6 +302,8 @@ static std::tuple<Type, Type, Type> getABCElementTypes(MLIRContext *context,
     return {f16, f16, f32};
   }
   }
+  assert(false && "unexpected enum value");
+  return {};
 }
 
 static OpaqueMmaLayout getOpaqueMFMALayout(MLIRContext *context,
@@ -667,6 +669,7 @@ MMASingleSubgroupLayout getSingleSubgroupLayout(MMAIntrinsic intrinsic,
   case MMAIntrinsic::NV_WMMA_F16_16x16x16_F16:
     return {};
   }
+  assert(false && "unexpected enum value");
   return {};
 }
 
@@ -696,7 +699,6 @@ SmallVector<VirtualMMAIntrinsic> MMAAttr::getVirtualIntrinsics() const {
   default:
     return {};
   }
-  return {};
 }
 
 // Generates amdgpu.mfma/wmma operation on the given inputs for this attribute
@@ -1281,7 +1283,6 @@ VirtualMMAAttr::getABCVectorTypes() const {
     return {aType, bType, cType};
   }
   }
-  // This should not happen but just to make GCC happy.
   assert(false && "unhandled virtual mma layout type.");
   return {VectorType{}, VectorType{}, VectorType{}};
 }
@@ -1301,7 +1302,6 @@ int64_t VirtualMMAAttr::getSubgroupSize() const {
     return 64;
   }
   }
-  // This should not happen but just to make GCC happy.
   assert(false && "unhandled virtual mma layout type.");
   return 0;
 }
@@ -1356,7 +1356,6 @@ int64_t VirtualMMAAttr::getUnrollK() const {
     return 1;
   }
   }
-  // This should not happen but just to make GCC happy.
   assert(false && "unhandled virtual mma layout type.");
   return 0;
 }
@@ -1424,7 +1423,6 @@ int64_t VirtualMMAAttr::getBlockSize() const {
     return 1;
   }
   }
-  // This should not happen but just to make GCC happy.
   assert(false && "unhandled virtual mma layout type.");
   return 0;
 }


### PR DESCRIPTION
* Adds a missing `return`, to fix the GCC error flagged here: https://github.com/iree-org/iree/pull/19099/files/ab2aa4c5e9487c5f51effdc0d123c2f369dc9c41#r1840709707
* Adds some assertions on these error-case returns which are reachable but would only be reached if there is a bug in our program (as opposed to being triggerable by user input).
* Drops some comments erroneously suggesting that it's GCC being difficult. Here, GCC is right and Clang is having a false-negative bug: https://github.com/llvm/llvm-project/issues/115345
* Drops a redundant `return` after a `default: return`.