### PR TITLE
Add `--pre` flag to pip installs for using nightly versions.

### DIFF
--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -86,6 +86,7 @@ jobs:
           python3 -m pip install \
             --find-links https://iree.dev/pip-release-links.html \
             --upgrade \
+            --pre \
             iree-base-compiler \
             iree-base-runtime
       - name: "Setup emsdk"

--- a/docs/website/docs/developers/debugging/integration-tests.md
+++ b/docs/website/docs/developers/debugging/integration-tests.md
@@ -71,9 +71,9 @@ All steps here assume starting from the IREE root directory.
     Install distributed packages
 
     ```bash
-    # Install packages from nightly releases
+    # Install packages from nightly pre-releases
     # This should work for most cases, as the importers change infrequently
-    python -m pip install \
+    python -m pip install --pre \
       iree-base-compiler iree-base-runtime iree-tools-tf iree-tools-tflite \
       --find-links https://iree.dev/pip-release-links.html
     ```

--- a/docs/website/docs/guides/deployment-configurations/snippets/_iree-compiler-from-release.md
+++ b/docs/website/docs/guides/deployment-configurations/snippets/_iree-compiler-from-release.md
@@ -9,13 +9,13 @@
 
 === ":material-alert: Nightly releases"
 
-    Nightly releases are published on
+    Nightly pre-releases are published on
     [GitHub releases](https://github.com/iree-org/iree/releases).
 
     ``` shell
     python -m pip install \
       --find-links https://iree.dev/pip-release-links.html \
-      --upgrade iree-base-compiler
+      --upgrade --pre iree-base-compiler
     ```
 
 !!! tip

--- a/docs/website/docs/guides/deployment-configurations/snippets/_iree-runtime-from-release.md
+++ b/docs/website/docs/guides/deployment-configurations/snippets/_iree-runtime-from-release.md
@@ -9,11 +9,11 @@
 
 === ":material-alert: Nightly releases"
 
-    Nightly releases are published on
+    Nightly pre-releases are published on
     [GitHub releases](https://github.com/iree-org/iree/releases).
 
     ``` shell
     python -m pip install \
       --find-links https://iree.dev/pip-release-links.html \
-      --upgrade iree-base-runtime
+      --upgrade --pre iree-base-runtime
     ```

--- a/docs/website/docs/guides/ml-frameworks/onnx.md
+++ b/docs/website/docs/guides/ml-frameworks/onnx.md
@@ -70,13 +70,14 @@ graph LR
 
     === ":material-alert: Nightly releases"
 
-        Nightly releases are published on
+        Nightly pre-releases are published on
         [GitHub releases](https://github.com/iree-org/iree/releases).
 
         ``` shell
         python -m pip install \
           --find-links https://iree.dev/pip-release-links.html \
           --upgrade \
+          --pre \
           iree-base-compiler[onnx] \
           iree-base-runtime
         ```

--- a/docs/website/docs/guides/ml-frameworks/tensorflow.md
+++ b/docs/website/docs/guides/ml-frameworks/tensorflow.md
@@ -80,6 +80,7 @@ graph LR
         python -m pip install \
           --find-links https://iree.dev/pip-release-links.html \
           --upgrade \
+          --pre \
           iree-base-compiler \
           iree-base-runtime \
           iree-tools-tf

--- a/docs/website/docs/guides/ml-frameworks/tflite.md
+++ b/docs/website/docs/guides/ml-frameworks/tflite.md
@@ -75,6 +75,7 @@ graph LR
         python -m pip install \
           --find-links https://iree.dev/pip-release-links.html \
           --upgrade \
+          --pre \
           iree-base-compiler \
           iree-base-runtime \
           iree-tools-tflite

--- a/docs/website/docs/reference/bindings/python.md
+++ b/docs/website/docs/reference/bindings/python.md
@@ -83,15 +83,16 @@ To use IREE's Python bindings, you will first need to install
       iree-base-runtime
     ```
 
-=== ":material-alert: Nightly releases"
+=== ":material-alert: Nightly pre-releases"
 
-    Nightly releases are published on
+    Nightly pre-releases are published on
     [GitHub releases](https://github.com/iree-org/iree/releases).
 
     ``` shell
     python -m pip install \
       --find-links https://iree.dev/pip-release-links.html \
       --upgrade \
+      --pre \
       iree-base-compiler \
       iree-base-runtime
     ```

--- a/experimental/web/generate_web_metrics.sh
+++ b/experimental/web/generate_web_metrics.sh
@@ -65,7 +65,7 @@ trap "deactivate 2> /dev/null" EXIT
 # Skip package installs when you want by commenting this out. Freezing to a
 # specific version when iterating on metrics is useful, and fetching is slow.
 
-python -m pip install --upgrade \
+python -m pip install --upgrade --pre \
   --find-links https://iree.dev/pip-release-links.html \
   iree-base-compiler iree-tools-tflite
 

--- a/samples/colab/low_level_invoke_function.ipynb
+++ b/samples/colab/low_level_invoke_function.ipynb
@@ -66,7 +66,7 @@
         "outputId": "0339165a-a35f-4b46-9cf8-f22adc69a7fe"
       },
       "source": [
-        "!python -m pip install --pre iree-compiler iree-runtime -f https://iree.dev/pip-release-links.html"
+        "!python -m pip install --pre iree-base-compiler iree-base-runtime -f https://iree.dev/pip-release-links.html"
       ],
       "execution_count": 2,
       "outputs": [

--- a/samples/colab/low_level_invoke_function.ipynb
+++ b/samples/colab/low_level_invoke_function.ipynb
@@ -66,7 +66,7 @@
         "outputId": "0339165a-a35f-4b46-9cf8-f22adc69a7fe"
       },
       "source": [
-        "!python -m pip install iree-compiler iree-runtime -f https://iree.dev/pip-release-links.html"
+        "!python -m pip install --pre iree-compiler iree-runtime -f https://iree.dev/pip-release-links.html"
       ],
       "execution_count": 2,
       "outputs": [

--- a/samples/colab/tensorflow_edge_detection.ipynb
+++ b/samples/colab/tensorflow_edge_detection.ipynb
@@ -78,7 +78,7 @@
         "outputId": "b6126fa9-b170-45dc-c0fd-8081e7ab2732"
       },
       "source": [
-        "!python -m pip install iree-compiler iree-runtime iree-tools-tf -f https://iree.dev/pip-release-links.html"
+        "!python -m pip install --pre iree-compiler iree-runtime iree-tools-tf -f https://iree.dev/pip-release-links.html"
       ],
       "execution_count": 3,
       "outputs": [

--- a/samples/colab/tensorflow_edge_detection.ipynb
+++ b/samples/colab/tensorflow_edge_detection.ipynb
@@ -78,7 +78,7 @@
         "outputId": "b6126fa9-b170-45dc-c0fd-8081e7ab2732"
       },
       "source": [
-        "!python -m pip install --pre iree-compiler iree-runtime iree-tools-tf -f https://iree.dev/pip-release-links.html"
+        "!python -m pip install --pre iree-base-compiler iree-base-runtime iree-tools-tf -f https://iree.dev/pip-release-links.html"
       ],
       "execution_count": 3,
       "outputs": [

--- a/samples/colab/tensorflow_hub_import.ipynb
+++ b/samples/colab/tensorflow_hub_import.ipynb
@@ -77,7 +77,7 @@
       },
       "source": [
         "%%capture\n",
-        "!python -m pip install iree-compiler iree-runtime iree-tools-tf -f https://iree.dev/pip-release-links.html"
+        "!python -m pip install --pre iree-compiler iree-runtime iree-tools-tf -f https://iree.dev/pip-release-links.html"
       ],
       "execution_count": 11,
       "outputs": []

--- a/samples/colab/tensorflow_hub_import.ipynb
+++ b/samples/colab/tensorflow_hub_import.ipynb
@@ -77,7 +77,7 @@
       },
       "source": [
         "%%capture\n",
-        "!python -m pip install --pre iree-compiler iree-runtime iree-tools-tf -f https://iree.dev/pip-release-links.html"
+        "!python -m pip install --pre iree-base-compiler iree-base-runtime iree-tools-tf -f https://iree.dev/pip-release-links.html"
       ],
       "execution_count": 11,
       "outputs": []

--- a/samples/colab/tensorflow_mnist_training.ipynb
+++ b/samples/colab/tensorflow_mnist_training.ipynb
@@ -83,7 +83,7 @@
       },
       "source": [
         "%%capture\n",
-        "!python -m pip install iree-compiler iree-runtime iree-tools-tf -f https://iree.dev/pip-release-links.html"
+        "!python -m pip install --pre iree-compiler iree-runtime iree-tools-tf -f https://iree.dev/pip-release-links.html"
       ],
       "execution_count": 21,
       "outputs": []

--- a/samples/colab/tensorflow_mnist_training.ipynb
+++ b/samples/colab/tensorflow_mnist_training.ipynb
@@ -83,7 +83,7 @@
       },
       "source": [
         "%%capture\n",
-        "!python -m pip install --pre iree-compiler iree-runtime iree-tools-tf -f https://iree.dev/pip-release-links.html"
+        "!python -m pip install --pre iree-base-compiler iree-base-runtime iree-tools-tf -f https://iree.dev/pip-release-links.html"
       ],
       "execution_count": 21,
       "outputs": []

--- a/samples/colab/tensorflow_resnet.ipynb
+++ b/samples/colab/tensorflow_resnet.ipynb
@@ -77,7 +77,7 @@
         "outputId": "51635ebb-cf05-4b5a-f2ef-a0e3c935d113"
       },
       "source": [
-        "!python -m pip install --pre iree-compiler iree-runtime iree-tools-tf -f https://iree.dev/pip-release-links.html"
+        "!python -m pip install --pre iree-base-compiler iree-base-runtime iree-tools-tf -f https://iree.dev/pip-release-links.html"
       ],
       "execution_count": 3,
       "outputs": [

--- a/samples/colab/tensorflow_resnet.ipynb
+++ b/samples/colab/tensorflow_resnet.ipynb
@@ -77,7 +77,7 @@
         "outputId": "51635ebb-cf05-4b5a-f2ef-a0e3c935d113"
       },
       "source": [
-        "!python -m pip install iree-compiler iree-runtime iree-tools-tf -f https://iree.dev/pip-release-links.html"
+        "!python -m pip install --pre iree-compiler iree-runtime iree-tools-tf -f https://iree.dev/pip-release-links.html"
       ],
       "execution_count": 3,
       "outputs": [

--- a/samples/colab/tflite_text_classification.ipynb
+++ b/samples/colab/tflite_text_classification.ipynb
@@ -53,7 +53,7 @@
       "source": [
         "%%capture\n",
         "!python -m pip install --upgrade tensorflow\n",
-        "!python -m pip install --pre iree-compiler iree-runtime iree-tools-tflite -f https://iree.dev/pip-release-links.html\n",
+        "!python -m pip install --pre iree-base-compiler iree-base-runtime iree-tools-tflite -f https://iree.dev/pip-release-links.html\n",
         "!python -m pip install tflite-runtime-nightly"
       ]
     },

--- a/samples/colab/tflite_text_classification.ipynb
+++ b/samples/colab/tflite_text_classification.ipynb
@@ -53,7 +53,7 @@
       "source": [
         "%%capture\n",
         "!python -m pip install --upgrade tensorflow\n",
-        "!python -m pip install iree-compiler iree-runtime iree-tools-tflite -f https://iree.dev/pip-release-links.html\n",
+        "!python -m pip install --pre iree-compiler iree-runtime iree-tools-tflite -f https://iree.dev/pip-release-links.html\n",
         "!python -m pip install tflite-runtime-nightly"
       ]
     },

--- a/samples/dynamic_shapes/tensorflow_dynamic_shapes.ipynb
+++ b/samples/dynamic_shapes/tensorflow_dynamic_shapes.ipynb
@@ -177,7 +177,7 @@
       },
       "source": [
         "%%capture\n",
-        "!python -m pip install --pre iree-compiler iree-runtime iree-tools-tf -f https://iree.dev/pip-release-links.html"
+        "!python -m pip install --pre iree-base-compiler iree-base-runtime iree-tools-tf -f https://iree.dev/pip-release-links.html"
       ],
       "execution_count": 6,
       "outputs": []

--- a/samples/dynamic_shapes/tensorflow_dynamic_shapes.ipynb
+++ b/samples/dynamic_shapes/tensorflow_dynamic_shapes.ipynb
@@ -177,7 +177,7 @@
       },
       "source": [
         "%%capture\n",
-        "!python -m pip install iree-compiler iree-runtime iree-tools-tf -f https://iree.dev/pip-release-links.html"
+        "!python -m pip install --pre iree-compiler iree-runtime iree-tools-tf -f https://iree.dev/pip-release-links.html"
       ],
       "execution_count": 6,
       "outputs": []

--- a/samples/dynamic_shapes/test.sh
+++ b/samples/dynamic_shapes/test.sh
@@ -33,6 +33,7 @@ trap "deactivate 2> /dev/null" EXIT
 python -m pip install \
   --find-links https://iree.dev/pip-release-links.html \
   --upgrade \
+  --pre \
   iree-base-compiler
 
 # 3. Compile `dynamic_shapes.mlir` using `iree-compile`.

--- a/samples/variables_and_state/variables_and_state.ipynb
+++ b/samples/variables_and_state/variables_and_state.ipynb
@@ -182,7 +182,7 @@
       },
       "source": [
         "%%capture\n",
-        "!python -m pip install --pre iree-compiler iree-runtime iree-tools-tf -f https://iree.dev/pip-release-links.html"
+        "!python -m pip install --pre iree-base-compiler iree-base-runtime iree-tools-tf -f https://iree.dev/pip-release-links.html"
       ],
       "execution_count": 6,
       "outputs": []

--- a/samples/variables_and_state/variables_and_state.ipynb
+++ b/samples/variables_and_state/variables_and_state.ipynb
@@ -182,7 +182,7 @@
       },
       "source": [
         "%%capture\n",
-        "!python -m pip install iree-compiler iree-runtime iree-tools-tf -f https://iree.dev/pip-release-links.html"
+        "!python -m pip install --pre iree-compiler iree-runtime iree-tools-tf -f https://iree.dev/pip-release-links.html"
       ],
       "execution_count": 6,
       "outputs": []


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree/issues/18938.

Pip will only install "pre-release" versions if `--pre` is set or the version is set explicitly: https://pip.pypa.io/en/stable/cli/pip_install/#pre-release-versions. The `rc` part of our `rcYYYYMMDD` suffix used in the nightly packages is considered a "Pre-release segment" in the version string: https://packaging.python.org/en/latest/specifications/version-specifiers/#public-version-identifiers.

Also switched sample Colab notebooks to use the new package names. I tested these lightly, but did not fully regenerate them, so the embedded logs still reference old versions of packages:
* Manually ran a few notebooks from my branch like https://colab.research.google.com/github/ScottTodd/iree/blob/release-pre/samples/colab/tensorflow_edge_detection.ipynb
* Ran the 'samples' workflow on my fork: https://github.com/ScottTodd/iree/actions/runs/11828250281