### PR TITLE
Strip .egg-info folders from iree-base-compiler whl files.

### DIFF
--- a/build_tools/python_deploy/build_linux_packages.sh
+++ b/build_tools/python_deploy/build_linux_packages.sh
@@ -138,7 +138,7 @@ function run_in_docker() {
           ;;
         iree-base-compiler)
           clean_wheels "iree_base_compiler${package_suffix}" "${python_version}"
-          install_deps "iree_base_runtime${package_suffix}" "${python_version}"
+          install_deps "iree_base_compiler${package_suffix}" "${python_version}"
           build_iree_compiler
           run_audit_wheel "iree_base_compiler${package_suffix}" "${python_version}"
           ;;


### PR DESCRIPTION
Fixes https://github.com/iree-org/iree/issues/19155

The `.egg-info/PKG-INFO` file is not handled by `promote_whl_from_rc_to_final.py` (since the underlying `change_wheel_version` package doesn't handle it), resulting in partial version promotions.