### PR TITLE
Adding iree_hal_buffer_placement_t info to allocated HAL buffers.

### DIFF
--- a/experimental/web/sample_webgpu/main.c
+++ b/experimental/web/sample_webgpu/main.c
@@ -666,6 +666,10 @@ static iree_status_t allocate_mappable_device_buffer(
                             "unable to allocate buffer of size %" PRIdsz,
                             data_length);
   }
+  const iree_hal_buffer_placement_t placement = {
+      .device = device,
+      .queue_affinity = IREE_HAL_QUEUE_AFFINITY_ANY,
+  };
   const iree_hal_buffer_params_t target_params = {
       .usage = IREE_HAL_BUFFER_USAGE_TRANSFER | IREE_HAL_BUFFER_USAGE_MAPPING,
       .type =
@@ -673,8 +677,8 @@ static iree_status_t allocate_mappable_device_buffer(
       .access = IREE_HAL_MEMORY_ACCESS_ALL,
   };
   return iree_hal_webgpu_buffer_wrap(
-      device, iree_hal_device_allocator(device), target_params.type,
-      target_params.access, target_params.usage, data_length,
+      origin, target_params.type, target_params.access, target_params.usage,
+      data_length,
       /*byte_offset=*/0,
       /*byte_length=*/data_length, device_buffer_handle,
       iree_allocator_system(), out_buffer);

--- a/experimental/webgpu/buffer.h
+++ b/experimental/webgpu/buffer.h
@@ -19,8 +19,8 @@ extern "C" {
 // we start to support pooling.
 
 iree_status_t iree_hal_webgpu_buffer_wrap(
-    iree_hal_device_t* device, iree_hal_allocator_t* device_allocator,
-    iree_hal_memory_type_t memory_type, iree_hal_memory_access_t allowed_access,
+    iree_hal_buffer_placement_t placement, iree_hal_memory_type_t memory_type,
+    iree_hal_memory_access_t allowed_access,
     iree_hal_buffer_usage_t allowed_usage, iree_device_size_t allocation_size,
     iree_device_size_t byte_offset, iree_device_size_t byte_length,
     WGPUBuffer handle, iree_allocator_t host_allocator,

--- a/experimental/webgpu/simple_allocator.c
+++ b/experimental/webgpu/simple_allocator.c
@@ -195,9 +195,14 @@ static iree_status_t iree_hal_webgpu_simple_allocator_allocate_buffer(
                             allocation_size);
   }
 
+  const iree_hal_buffer_placement_t placement = {
+      .device = allocator->device,
+      .queue_affinity = params->queue_affinity ? params->queue_affinity
+                                               : IREE_HAL_QUEUE_AFFINITY_ANY,
+      .flags = IREE_HAL_BUFFER_PLACEMENT_FLAG_NONE,
+  };
   iree_status_t status = iree_hal_webgpu_buffer_wrap(
-      allocator->device, base_allocator, params->type, params->access,
-      params->usage, allocation_size,
+      placement, params->type, params->access, params->usage, allocation_size,
       /*byte_offset=*/0,
       /*byte_length=*/allocation_size, buffer_handle, allocator->host_allocator,
       out_buffer);

--- a/runtime/src/iree/hal/allocator.h
+++ b/runtime/src/iree/hal/allocator.h
@@ -495,6 +495,8 @@ IREE_HAL_ASSERT_VTABLE_LAYOUT(iree_hal_allocator_vtable_t);
 IREE_API_EXPORT void iree_hal_allocator_destroy(
     iree_hal_allocator_t* IREE_RESTRICT allocator);
 
+// TODO(#19159): remove iree_hal_allocator_deallocate_buffer when pooling no
+// longer requires the pooling_allocator on iree_hal_buffer_t.
 IREE_API_EXPORT void iree_hal_allocator_deallocate_buffer(
     iree_hal_allocator_t* IREE_RESTRICT allocator,
     iree_hal_buffer_t* IREE_RESTRICT buffer);

--- a/runtime/src/iree/hal/allocator_heap.c
+++ b/runtime/src/iree/hal/allocator_heap.c
@@ -198,8 +198,8 @@ static iree_status_t iree_hal_heap_allocator_allocate_buffer(
   IREE_STATISTICS(statistics = &allocator->statistics);
   iree_hal_buffer_t* buffer = NULL;
   IREE_RETURN_IF_ERROR(iree_hal_heap_buffer_create(
-      base_allocator, statistics, &compat_params, allocation_size,
-      allocator->data_allocator, allocator->host_allocator, &buffer));
+      statistics, &compat_params, allocation_size, allocator->data_allocator,
+      allocator->host_allocator, &buffer));
 
   *out_buffer = buffer;
   return iree_ok_status();
@@ -219,6 +219,9 @@ static iree_status_t iree_hal_heap_allocator_import_buffer(
     iree_hal_external_buffer_t* IREE_RESTRICT external_buffer,
     iree_hal_buffer_release_callback_t release_callback,
     iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
+  iree_hal_heap_allocator_t* allocator =
+      iree_hal_heap_allocator_cast(base_allocator);
+
   // Coerce options into those required for use by heap-based devices.
   iree_hal_buffer_params_t compat_params = *params;
   iree_device_size_t allocation_size = external_buffer->size;
@@ -243,11 +246,17 @@ static iree_status_t iree_hal_heap_allocator_import_buffer(
                               "external buffer type not supported");
   }
 
+  const iree_hal_buffer_placement_t placement = {
+      .device = NULL,
+      .queue_affinity = compat_params.queue_affinity
+                            ? compat_params.queue_affinity
+                            : IREE_HAL_QUEUE_AFFINITY_ANY,
+      .flags = IREE_HAL_BUFFER_PLACEMENT_FLAG_NONE,
+  };
   return iree_hal_heap_buffer_wrap(
-      base_allocator, compat_params.type, compat_params.access,
-      compat_params.usage, external_buffer->size,
-      iree_make_byte_span(ptr, external_buffer->size), release_callback,
-      out_buffer);
+      placement, compat_params.type, compat_params.access, compat_params.usage,
+      external_buffer->size, iree_make_byte_span(ptr, external_buffer->size),
+      release_callback, allocator->host_allocator, out_buffer);
 }
 
 static iree_status_t iree_hal_heap_allocator_export_buffer(

--- a/runtime/src/iree/hal/buffer.c
+++ b/runtime/src/iree/hal/buffer.c
@@ -122,49 +122,34 @@ IREE_API_EXPORT iree_string_view_t iree_hal_buffer_usage_format(
 // Subspan indirection buffer
 //===----------------------------------------------------------------------===//
 
+typedef struct iree_hal_subspan_buffer_t {
+  iree_hal_buffer_t base;
+  iree_allocator_t host_allocator;
+} iree_hal_subspan_buffer_t;
+
 static const iree_hal_buffer_vtable_t iree_hal_subspan_buffer_vtable;
-
-IREE_API_EXPORT void iree_hal_subspan_buffer_initialize(
-    iree_hal_buffer_t* allocated_buffer, iree_device_size_t byte_offset,
-    iree_device_size_t byte_length, iree_hal_allocator_t* device_allocator,
-    iree_allocator_t host_allocator, iree_hal_buffer_t* out_buffer) {
-  IREE_ASSERT_ARGUMENT(allocated_buffer);
-  IREE_ASSERT_ARGUMENT(out_buffer);
-  iree_hal_buffer_initialize(host_allocator, device_allocator, allocated_buffer,
-                             allocated_buffer->allocation_size, byte_offset,
-                             byte_length, allocated_buffer->memory_type,
-                             allocated_buffer->allowed_access,
-                             allocated_buffer->allowed_usage,
-                             &iree_hal_subspan_buffer_vtable, out_buffer);
-}
-
-IREE_API_EXPORT void iree_hal_subspan_buffer_deinitialize(
-    iree_hal_buffer_t* buffer) {
-  IREE_ASSERT_ARGUMENT(buffer);
-  iree_hal_buffer_release(buffer->allocated_buffer);
-  buffer->allocated_buffer = NULL;
-}
 
 IREE_API_EXPORT iree_status_t iree_hal_subspan_buffer_create(
     iree_hal_buffer_t* allocated_buffer, iree_device_size_t byte_offset,
-    iree_device_size_t byte_length, iree_hal_allocator_t* device_allocator,
-    iree_allocator_t host_allocator, iree_hal_buffer_t** out_buffer) {
+    iree_device_size_t byte_length, iree_allocator_t host_allocator,
+    iree_hal_buffer_t** out_buffer) {
   IREE_ASSERT_ARGUMENT(allocated_buffer);
   IREE_ASSERT_ARGUMENT(out_buffer);
   *out_buffer = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  iree_hal_buffer_t* buffer = NULL;
+  iree_hal_subspan_buffer_t* buffer = NULL;
   iree_status_t status =
       iree_allocator_malloc(host_allocator, sizeof(*buffer), (void**)&buffer);
   if (iree_status_is_ok(status)) {
     iree_hal_buffer_initialize(
-        host_allocator, device_allocator, allocated_buffer,
+        iree_hal_buffer_placement_undefined(), allocated_buffer,
         allocated_buffer->allocation_size, byte_offset, byte_length,
         allocated_buffer->memory_type, allocated_buffer->allowed_access,
         allocated_buffer->allowed_usage, &iree_hal_subspan_buffer_vtable,
-        buffer);
-    *out_buffer = buffer;
+        &buffer->base);
+    buffer->host_allocator = host_allocator;
+    *out_buffer = &buffer->base;
   }
 
   IREE_TRACE_ZONE_END(z0);
@@ -172,11 +157,12 @@ IREE_API_EXPORT iree_status_t iree_hal_subspan_buffer_create(
 }
 
 static void iree_hal_subspan_buffer_destroy(iree_hal_buffer_t* base_buffer) {
-  iree_allocator_t host_allocator = base_buffer->host_allocator;
+  iree_hal_subspan_buffer_t* buffer = (iree_hal_subspan_buffer_t*)base_buffer;
+  iree_allocator_t host_allocator = buffer->host_allocator;
   IREE_TRACE_ZONE_BEGIN(z0);
 
   iree_hal_buffer_release(base_buffer->allocated_buffer);
-  iree_allocator_free(host_allocator, base_buffer);
+  iree_allocator_free(host_allocator, buffer);
 
   IREE_TRACE_ZONE_END(z0);
 }
@@ -222,161 +208,18 @@ static const iree_hal_buffer_vtable_t iree_hal_subspan_buffer_vtable = {
 };
 
 //===----------------------------------------------------------------------===//
-// iree_hal_deferred_buffer_t
-//===----------------------------------------------------------------------===//
-
-typedef struct iree_hal_deferred_buffer_t {
-  iree_hal_buffer_t base;
-  iree_hal_queue_affinity_t queue_affinity;
-  iree_device_size_t min_alignment;
-} iree_hal_deferred_buffer_t;
-
-static const iree_hal_buffer_vtable_t iree_hal_deferred_buffer_vtable;
-
-IREE_API_EXPORT iree_status_t iree_hal_deferred_buffer_create_reserved(
-    iree_hal_allocator_t* device_allocator, iree_device_size_t allocation_size,
-    iree_device_size_t byte_offset, iree_device_size_t byte_length,
-    iree_hal_buffer_params_t params, iree_allocator_t host_allocator,
-    iree_hal_buffer_t** out_buffer) {
-  IREE_ASSERT_ARGUMENT(out_buffer);
-  *out_buffer = NULL;
-  IREE_TRACE_ZONE_BEGIN(z0);
-
-  iree_hal_deferred_buffer_t* buffer = NULL;
-  IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0,
-      iree_allocator_malloc(host_allocator, sizeof(*buffer), (void**)&buffer));
-  iree_hal_buffer_initialize(host_allocator, device_allocator, NULL,
-                             allocation_size, byte_offset, byte_length,
-                             params.type, params.access, params.usage,
-                             &iree_hal_deferred_buffer_vtable, &buffer->base);
-  buffer->queue_affinity = params.queue_affinity;
-  buffer->min_alignment = params.min_alignment;
-  *out_buffer = &buffer->base;
-
-  IREE_TRACE_ZONE_END(z0);
-  return iree_ok_status();
-}
-
-static void iree_hal_deferred_buffer_destroy(iree_hal_buffer_t* base_buffer) {
-  iree_allocator_t host_allocator = base_buffer->host_allocator;
-  IREE_TRACE_ZONE_BEGIN(z0);
-
-  if (base_buffer->allocated_buffer) {
-    iree_hal_buffer_release(base_buffer->allocated_buffer);
-  }
-  iree_allocator_free(host_allocator, base_buffer);
-
-  IREE_TRACE_ZONE_END(z0);
-}
-
-IREE_API_EXPORT iree_status_t
-iree_hal_deferred_buffer_commit(iree_hal_buffer_t* base_buffer) {
-  iree_hal_deferred_buffer_t* buffer = (iree_hal_deferred_buffer_t*)base_buffer;
-  if (IREE_UNLIKELY(base_buffer->allocated_buffer)) {
-    // Already committed - no-op.
-    return iree_ok_status();
-  }
-  IREE_TRACE_ZONE_BEGIN(z0);
-  iree_hal_buffer_params_t params = {
-      .usage = base_buffer->allowed_usage,
-      .access = base_buffer->allowed_access,
-      .type = base_buffer->memory_type,
-      .queue_affinity = buffer->queue_affinity,
-      .min_alignment = buffer->min_alignment,
-  };
-  iree_status_t status = iree_hal_allocator_allocate_buffer(
-      base_buffer->device_allocator, params, base_buffer->allocation_size,
-      &base_buffer->allocated_buffer);
-  IREE_TRACE_ZONE_END(z0);
-  return status;
-}
-
-IREE_API_EXPORT iree_status_t
-iree_hal_deferred_buffer_decommit(iree_hal_buffer_t* buffer) {
-  IREE_TRACE_ZONE_BEGIN(z0);
-  if (IREE_LIKELY(buffer->allocated_buffer)) {
-    iree_hal_buffer_release(buffer->allocated_buffer);
-    buffer->allocated_buffer = NULL;
-  }
-  IREE_TRACE_ZONE_END(z0);
-  return iree_ok_status();
-}
-
-static iree_status_t iree_hal_deferred_buffer_map_range(
-    iree_hal_buffer_t* buffer, iree_hal_mapping_mode_t mapping_mode,
-    iree_hal_memory_access_t memory_access,
-    iree_device_size_t local_byte_offset, iree_device_size_t local_byte_length,
-    iree_hal_buffer_mapping_t* mapping) {
-  if (IREE_UNLIKELY(!buffer->allocated_buffer)) {
-    // Performance warning: this is likely to be happening synchronously in the
-    // caller in an unexpected way. We could FAILED_PRECONDITION if we wanted
-    // to be strict but by doing this on-demand we allow deferred buffers to be
-    // used with callers that may not know that this is a reserved deferred
-    // buffer (particularly useful for outputs/copy targets).
-    IREE_RETURN_IF_ERROR(iree_hal_deferred_buffer_commit(buffer));
-  }
-  return _VTABLE_DISPATCH(buffer->allocated_buffer, map_range)(
-      buffer->allocated_buffer, mapping_mode, memory_access, local_byte_offset,
-      local_byte_length, mapping);
-}
-
-static iree_status_t iree_hal_deferred_buffer_unmap_range(
-    iree_hal_buffer_t* buffer, iree_device_size_t local_byte_offset,
-    iree_device_size_t local_byte_length, iree_hal_buffer_mapping_t* mapping) {
-  if (IREE_UNLIKELY(!buffer->allocated_buffer)) {
-    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
-                            "buffer does not have committed storage");
-  }
-  return _VTABLE_DISPATCH(buffer->allocated_buffer, unmap_range)(
-      buffer->allocated_buffer, local_byte_offset, local_byte_length, mapping);
-}
-
-static iree_status_t iree_hal_deferred_buffer_invalidate_range(
-    iree_hal_buffer_t* buffer, iree_device_size_t local_byte_offset,
-    iree_device_size_t local_byte_length) {
-  if (IREE_UNLIKELY(!buffer->allocated_buffer)) {
-    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
-                            "buffer does not have committed storage");
-  }
-  return _VTABLE_DISPATCH(buffer->allocated_buffer, invalidate_range)(
-      buffer->allocated_buffer, local_byte_offset, local_byte_length);
-}
-
-static iree_status_t iree_hal_deferred_buffer_flush_range(
-    iree_hal_buffer_t* buffer, iree_device_size_t local_byte_offset,
-    iree_device_size_t local_byte_length) {
-  if (IREE_UNLIKELY(!buffer->allocated_buffer)) {
-    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
-                            "buffer does not have committed storage");
-  }
-  return _VTABLE_DISPATCH(buffer->allocated_buffer, flush_range)(
-      buffer->allocated_buffer, local_byte_offset, local_byte_length);
-}
-
-static const iree_hal_buffer_vtable_t iree_hal_deferred_buffer_vtable = {
-    .recycle = iree_hal_buffer_recycle,
-    .destroy = iree_hal_deferred_buffer_destroy,
-    .map_range = iree_hal_deferred_buffer_map_range,
-    .unmap_range = iree_hal_deferred_buffer_unmap_range,
-    .invalidate_range = iree_hal_deferred_buffer_invalidate_range,
-    .flush_range = iree_hal_deferred_buffer_flush_range,
-};
-
-//===----------------------------------------------------------------------===//
 // iree_hal_buffer_t
 //===----------------------------------------------------------------------===//
 
 IREE_API_EXPORT void iree_hal_buffer_initialize(
-    iree_allocator_t host_allocator, iree_hal_allocator_t* device_allocator,
-    iree_hal_buffer_t* allocated_buffer, iree_device_size_t allocation_size,
-    iree_device_size_t byte_offset, iree_device_size_t byte_length,
-    iree_hal_memory_type_t memory_type, iree_hal_memory_access_t allowed_access,
+    iree_hal_buffer_placement_t placement, iree_hal_buffer_t* allocated_buffer,
+    iree_device_size_t allocation_size, iree_device_size_t byte_offset,
+    iree_device_size_t byte_length, iree_hal_memory_type_t memory_type,
+    iree_hal_memory_access_t allowed_access,
     iree_hal_buffer_usage_t allowed_usage,
     const iree_hal_buffer_vtable_t* vtable, iree_hal_buffer_t* buffer) {
   iree_hal_resource_initialize(vtable, &buffer->resource);
-  buffer->host_allocator = host_allocator;
-  buffer->device_allocator = device_allocator;
+  buffer->placement = placement;
   buffer->allocated_buffer = allocated_buffer;
   buffer->allocation_size = allocation_size;
   buffer->byte_offset = byte_offset;
@@ -395,8 +238,8 @@ IREE_API_EXPORT void iree_hal_buffer_initialize(
 IREE_API_EXPORT void iree_hal_buffer_recycle(iree_hal_buffer_t* buffer) {
   if (IREE_LIKELY(buffer)) {
     IREE_TRACE_ZONE_BEGIN(z0);
-    if (buffer->device_allocator) {
-      iree_hal_allocator_deallocate_buffer(buffer->device_allocator, buffer);
+    if (buffer->pooling_allocator) {
+      iree_hal_allocator_deallocate_buffer(buffer->pooling_allocator, buffer);
     } else {
       iree_hal_buffer_destroy(buffer);
     }
@@ -633,7 +476,8 @@ IREE_API_EXPORT iree_hal_buffer_overlap_t iree_hal_buffer_test_overlap(
 
 IREE_API_EXPORT iree_status_t iree_hal_buffer_subspan(
     iree_hal_buffer_t* buffer, iree_device_size_t byte_offset,
-    iree_device_size_t byte_length, iree_hal_buffer_t** out_buffer) {
+    iree_device_size_t byte_length, iree_allocator_t host_allocator,
+    iree_hal_buffer_t** out_buffer) {
   IREE_ASSERT_ARGUMENT(buffer);
   IREE_ASSERT_ARGUMENT(out_buffer);
   *out_buffer = NULL;
@@ -657,12 +501,11 @@ IREE_API_EXPORT iree_status_t iree_hal_buffer_subspan(
       iree_hal_buffer_allocated_buffer(buffer);
   if (allocated_buffer && allocated_buffer != buffer) {
     return iree_hal_buffer_subspan(allocated_buffer, byte_offset, byte_length,
-                                   out_buffer);
+                                   host_allocator, out_buffer);
   }
 
   return iree_hal_subspan_buffer_create(buffer, byte_offset, byte_length,
-                                        /*device_allocator=*/NULL,
-                                        buffer->host_allocator, out_buffer);
+                                        host_allocator, out_buffer);
 }
 
 IREE_API_EXPORT iree_hal_buffer_t* iree_hal_buffer_allocated_buffer(
@@ -675,6 +518,14 @@ IREE_API_EXPORT iree_device_size_t
 iree_hal_buffer_allocation_size(const iree_hal_buffer_t* buffer) {
   IREE_ASSERT_ARGUMENT(buffer);
   return buffer->allocation_size;
+}
+
+IREE_API_EXPORT iree_hal_buffer_placement_t
+iree_hal_buffer_allocation_placement(const iree_hal_buffer_t* buffer) {
+  IREE_ASSERT_ARGUMENT(buffer);
+  return buffer == buffer->allocated_buffer
+             ? buffer->placement
+             : buffer->allocated_buffer->placement;
 }
 
 IREE_API_EXPORT iree_device_size_t

--- a/runtime/src/iree/hal/buffer_heap_impl.h
+++ b/runtime/src/iree/hal/buffer_heap_impl.h
@@ -31,7 +31,6 @@ typedef struct iree_hal_heap_allocator_statistics_t {
 // |data_allocator| and |host_allocator| are the same the buffer will be created
 // as a flat slab. |out_buffer| must be released by the caller.
 iree_status_t iree_hal_heap_buffer_create(
-    iree_hal_allocator_t* allocator,
     iree_hal_heap_allocator_statistics_t* statistics,
     const iree_hal_buffer_params_t* params, iree_device_size_t allocation_size,
     iree_allocator_t data_allocator, iree_allocator_t host_allocator,

--- a/runtime/src/iree/hal/cts/buffer_mapping_test.h
+++ b/runtime/src/iree/hal/cts/buffer_mapping_test.h
@@ -140,8 +140,9 @@ TEST_F(BufferMappingTest, ZeroSubspan) {
   // Create a subspan.
   iree_device_size_t subspan_length = 8;
   iree_hal_buffer_t* buffer_subspan = NULL;
-  IREE_ASSERT_OK(iree_hal_buffer_subspan(buffer, /*byte_offset=*/4,
-                                         subspan_length, &buffer_subspan));
+  IREE_ASSERT_OK(
+      iree_hal_buffer_subspan(buffer, /*byte_offset=*/4, subspan_length,
+                              iree_allocator_system(), &buffer_subspan));
 
   // Zero part of the subspan.
   IREE_ASSERT_OK(iree_hal_buffer_map_zero(buffer_subspan, /*byte_offset=*/4,
@@ -253,8 +254,9 @@ TEST_F(BufferMappingTest, FillSubspan) {
   // Create a subspan.
   iree_device_size_t subspan_length = 8;
   iree_hal_buffer_t* buffer_subspan = NULL;
-  IREE_ASSERT_OK(iree_hal_buffer_subspan(buffer, /*byte_offset=*/4,
-                                         subspan_length, &buffer_subspan));
+  IREE_ASSERT_OK(
+      iree_hal_buffer_subspan(buffer, /*byte_offset=*/4, subspan_length,
+                              iree_allocator_system(), &buffer_subspan));
 
   // Fill part of the subspan.
   uint8_t fill_value = 0xFF;
@@ -342,8 +344,9 @@ TEST_F(BufferMappingTest, ReadDataSubspan) {
   // Create a subspan.
   iree_device_size_t subspan_length = 8;
   iree_hal_buffer_t* buffer_subspan = NULL;
-  IREE_ASSERT_OK(iree_hal_buffer_subspan(buffer, /*byte_offset=*/4,
-                                         subspan_length, &buffer_subspan));
+  IREE_ASSERT_OK(
+      iree_hal_buffer_subspan(buffer, /*byte_offset=*/4, subspan_length,
+                              iree_allocator_system(), &buffer_subspan));
 
   // Read the entire buffer subspan.
   std::vector<uint8_t> actual_data(subspan_length);
@@ -426,8 +429,9 @@ TEST_F(BufferMappingTest, WriteDataSubspan) {
   // Create a subspan.
   iree_device_size_t subspan_length = 8;
   iree_hal_buffer_t* buffer_subspan = NULL;
-  IREE_ASSERT_OK(iree_hal_buffer_subspan(buffer, /*byte_offset=*/4,
-                                         subspan_length, &buffer_subspan));
+  IREE_ASSERT_OK(
+      iree_hal_buffer_subspan(buffer, /*byte_offset=*/4, subspan_length,
+                              iree_allocator_system(), &buffer_subspan));
 
   // Write over part of the subspan.
   std::vector<uint8_t> fill_buffer{0x11, 0x22, 0x33, 0x44};

--- a/runtime/src/iree/hal/cts/command_buffer_update_buffer_test.h
+++ b/runtime/src/iree/hal/cts/command_buffer_update_buffer_test.h
@@ -116,8 +116,9 @@ TEST_F(CommandBufferUpdateBufferTest, UpdateBufferSubspan) {
   // Create a subspan.
   iree_device_size_t subspan_length = 8;
   iree_hal_buffer_t* buffer_subspan;
-  IREE_ASSERT_OK(iree_hal_buffer_subspan(device_buffer, /*byte_offset=*/4,
-                                         subspan_length, &buffer_subspan));
+  IREE_ASSERT_OK(
+      iree_hal_buffer_subspan(device_buffer, /*byte_offset=*/4, subspan_length,
+                              iree_allocator_system(), &buffer_subspan));
 
   iree_hal_command_buffer_t* command_buffer = NULL;
   IREE_CHECK_OK(iree_hal_command_buffer_create(

--- a/runtime/src/iree/hal/drivers/cuda/cuda_allocator.h
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_allocator.h
@@ -22,6 +22,7 @@ extern "C" {
 // and the pointer must remain valid for the lifetime of the allocator. Pools
 // may not be supported on all devices and can be NULL.
 iree_status_t iree_hal_cuda_allocator_create(
+    iree_hal_device_t* parent_device,
     const iree_hal_cuda_dynamic_symbols_t* cuda_symbols, CUdevice device,
     CUstream stream, iree_hal_cuda_memory_pools_t* pools,
     iree_allocator_t host_allocator, iree_hal_allocator_t** out_allocator);

--- a/runtime/src/iree/hal/drivers/cuda/cuda_buffer.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_buffer.c
@@ -14,6 +14,7 @@
 
 typedef struct iree_hal_cuda_buffer_t {
   iree_hal_buffer_t base;
+  iree_allocator_t host_allocator;
   iree_hal_cuda_buffer_type_t type;
   void* host_ptr;
   CUdeviceptr device_ptr;
@@ -35,7 +36,7 @@ static const iree_hal_cuda_buffer_t* iree_hal_cuda_buffer_const_cast(
 }
 
 iree_status_t iree_hal_cuda_buffer_wrap(
-    iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
+    iree_hal_buffer_placement_t placement, iree_hal_memory_type_t memory_type,
     iree_hal_memory_access_t allowed_access,
     iree_hal_buffer_usage_t allowed_usage, iree_device_size_t allocation_size,
     iree_device_size_t byte_offset, iree_device_size_t byte_length,
@@ -56,10 +57,11 @@ iree_status_t iree_hal_cuda_buffer_wrap(
   iree_status_t status =
       iree_allocator_malloc(host_allocator, sizeof(*buffer), (void**)&buffer);
   if (iree_status_is_ok(status)) {
-    iree_hal_buffer_initialize(host_allocator, allocator, &buffer->base,
-                               allocation_size, byte_offset, byte_length,
-                               memory_type, allowed_access, allowed_usage,
+    iree_hal_buffer_initialize(placement, &buffer->base, allocation_size,
+                               byte_offset, byte_length, memory_type,
+                               allowed_access, allowed_usage,
                                &iree_hal_cuda_buffer_vtable, &buffer->base);
+    buffer->host_allocator = host_allocator;
     buffer->type = buffer_type;
     buffer->host_ptr = host_ptr;
     buffer->device_ptr = device_ptr;
@@ -73,7 +75,7 @@ iree_status_t iree_hal_cuda_buffer_wrap(
 
 static void iree_hal_cuda_buffer_destroy(iree_hal_buffer_t* base_buffer) {
   iree_hal_cuda_buffer_t* buffer = iree_hal_cuda_buffer_cast(base_buffer);
-  iree_allocator_t host_allocator = base_buffer->host_allocator;
+  iree_allocator_t host_allocator = buffer->host_allocator;
   IREE_TRACE_ZONE_BEGIN(z0);
   if (buffer->release_callback.fn) {
     buffer->release_callback.fn(buffer->release_callback.user_data,

--- a/runtime/src/iree/hal/drivers/cuda/cuda_buffer.h
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_buffer.h
@@ -34,7 +34,7 @@ typedef enum iree_hal_cuda_buffer_type_e {
 
 // Wraps a CUDA allocation in an iree_hal_buffer_t.
 iree_status_t iree_hal_cuda_buffer_wrap(
-    iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
+    iree_hal_buffer_placement_t placement, iree_hal_memory_type_t memory_type,
     iree_hal_memory_access_t allowed_access,
     iree_hal_buffer_usage_t allowed_usage, iree_device_size_t allocation_size,
     iree_device_size_t byte_offset, iree_device_size_t byte_length,

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.c
@@ -496,13 +496,13 @@ static iree_status_t iree_hal_cuda_device_create_internal(
   // Create memory pools first so that we can share them with the allocator.
   if (iree_status_is_ok(status) && device->supports_memory_pools) {
     status = iree_hal_cuda_memory_pools_initialize(
-        cuda_symbols, cu_device, &params->memory_pools, host_allocator,
-        &device->memory_pools);
+        (iree_hal_device_t*)device, cuda_symbols, cu_device,
+        &params->memory_pools, host_allocator, &device->memory_pools);
   }
 
   if (iree_status_is_ok(status)) {
     status = iree_hal_cuda_allocator_create(
-        cuda_symbols, cu_device, dispatch_stream,
+        (iree_hal_device_t*)device, cuda_symbols, cu_device, dispatch_stream,
         device->supports_memory_pools ? &device->memory_pools : NULL,
         host_allocator, &device->device_allocator);
   }

--- a/runtime/src/iree/hal/drivers/cuda/memory_pools.h
+++ b/runtime/src/iree/hal/drivers/cuda/memory_pools.h
@@ -25,6 +25,7 @@ typedef struct iree_hal_cuda_memory_pools_t {
   // Used for any host-visible/host-local memory types.
   CUmemoryPool other;
 
+  iree_hal_device_t* parent_device;
   const iree_hal_cuda_dynamic_symbols_t* cuda_symbols;
   iree_allocator_t host_allocator;
 
@@ -38,6 +39,7 @@ typedef struct iree_hal_cuda_memory_pools_t {
 
 // Initializes |out_pools| by configuring new CUDA memory pools.
 iree_status_t iree_hal_cuda_memory_pools_initialize(
+    iree_hal_device_t* parent_device,
     const iree_hal_cuda_dynamic_symbols_t* cuda_symbols, CUdevice cu_device,
     const iree_hal_cuda_memory_pooling_params_t* pooling_params,
     iree_allocator_t host_allocator,

--- a/runtime/src/iree/hal/drivers/hip/hip_allocator.h
+++ b/runtime/src/iree/hal/drivers/hip/hip_allocator.h
@@ -21,6 +21,7 @@ extern "C" {
 // |pools| provides memory pools that may be shared across multiple allocators
 // and the pointer must remain valid for the lifetime of the allocator.
 iree_status_t iree_hal_hip_allocator_create(
+    iree_hal_device_t* parent_device,
     const iree_hal_hip_dynamic_symbols_t* hip_symbols, hipDevice_t device,
     hipCtx_t hip_context, hipStream_t stream,
     iree_hal_hip_memory_pools_t* pools, iree_allocator_t host_allocator,

--- a/runtime/src/iree/hal/drivers/hip/hip_buffer.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_buffer.c
@@ -16,6 +16,7 @@
 
 typedef struct iree_hal_hip_buffer_t {
   iree_hal_buffer_t base;
+  iree_allocator_t host_allocator;
   iree_hal_hip_buffer_type_t type;
   void* host_ptr;
   hipDeviceptr_t device_ptr;
@@ -40,7 +41,7 @@ static const iree_hal_hip_buffer_t* iree_hal_hip_buffer_const_cast(
 }
 
 iree_status_t iree_hal_hip_buffer_wrap(
-    iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
+    iree_hal_buffer_placement_t placement, iree_hal_memory_type_t memory_type,
     iree_hal_memory_access_t allowed_access,
     iree_hal_buffer_usage_t allowed_usage, iree_device_size_t allocation_size,
     iree_device_size_t byte_offset, iree_device_size_t byte_length,
@@ -61,10 +62,11 @@ iree_status_t iree_hal_hip_buffer_wrap(
   iree_status_t status =
       iree_allocator_malloc(host_allocator, sizeof(*buffer), (void**)&buffer);
   if (iree_status_is_ok(status)) {
-    iree_hal_buffer_initialize(host_allocator, allocator, &buffer->base,
-                               allocation_size, byte_offset, byte_length,
-                               memory_type, allowed_access, allowed_usage,
+    iree_hal_buffer_initialize(placement, &buffer->base, allocation_size,
+                               byte_offset, byte_length, memory_type,
+                               allowed_access, allowed_usage,
                                &iree_hal_hip_buffer_vtable, &buffer->base);
+    buffer->host_allocator = host_allocator;
     buffer->type = buffer_type;
     buffer->host_ptr = host_ptr;
     buffer->device_ptr = device_ptr;
@@ -101,7 +103,7 @@ void iree_hal_hip_buffer_set_allocation_empty(iree_hal_buffer_t* base_buffer) {
 
 static void iree_hal_hip_buffer_destroy(iree_hal_buffer_t* base_buffer) {
   iree_hal_hip_buffer_t* buffer = iree_hal_hip_buffer_cast(base_buffer);
-  iree_allocator_t host_allocator = base_buffer->host_allocator;
+  iree_allocator_t host_allocator = buffer->host_allocator;
   IREE_TRACE_ZONE_BEGIN(z0);
   if (buffer->release_callback.fn) {
     buffer->release_callback.fn(buffer->release_callback.user_data,

--- a/runtime/src/iree/hal/drivers/hip/hip_buffer.h
+++ b/runtime/src/iree/hal/drivers/hip/hip_buffer.h
@@ -34,7 +34,7 @@ typedef enum iree_hal_hip_buffer_type_e {
 
 // Wraps a HIP allocation in an iree_hal_buffer_t.
 iree_status_t iree_hal_hip_buffer_wrap(
-    iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
+    iree_hal_buffer_placement_t placement, iree_hal_memory_type_t memory_type,
     iree_hal_memory_access_t allowed_access,
     iree_hal_buffer_usage_t allowed_usage, iree_device_size_t allocation_size,
     iree_device_size_t byte_offset, iree_device_size_t byte_length,

--- a/runtime/src/iree/hal/drivers/hip/memory_pools.h
+++ b/runtime/src/iree/hal/drivers/hip/memory_pools.h
@@ -32,6 +32,7 @@ typedef struct iree_hal_hip_memory_pools_t {
   // Used for any host-visible/host-local memory types.
   hipMemPool_t other;
 
+  iree_hal_device_t* parent_device;
   const iree_hal_hip_dynamic_symbols_t* hip_symbols;
   hipCtx_t hip_context;
   iree_allocator_t host_allocator;
@@ -46,6 +47,7 @@ typedef struct iree_hal_hip_memory_pools_t {
 
 // Initializes |out_pools| by configuring new HIP memory pools.
 iree_status_t iree_hal_hip_memory_pools_initialize(
+    iree_hal_device_t* parent_device,
     const iree_hal_hip_dynamic_symbols_t* hip_symbols, hipDevice_t hip_device,
     hipCtx_t hip_context,
     const iree_hal_hip_memory_pooling_params_t* pooling_params,

--- a/runtime/src/iree/hal/drivers/metal/direct_allocator.h
+++ b/runtime/src/iree/hal/drivers/metal/direct_allocator.h
@@ -26,7 +26,7 @@ extern "C" {
 // |out_allocator| must be released by the caller (see
 // iree_hal_allocator_release).
 iree_status_t iree_hal_metal_allocator_create(
-    id<MTLDevice> device,
+    iree_hal_device_t* parent_device, id<MTLDevice> device,
 #if defined(IREE_PLATFORM_MACOS)
     id<MTLCommandQueue> queue,
 #endif  // IREE_PLATFORM_MACOS

--- a/runtime/src/iree/hal/drivers/metal/metal_buffer.h
+++ b/runtime/src/iree/hal/drivers/metal/metal_buffer.h
@@ -20,15 +20,16 @@ extern "C" {
 //
 // |out_buffer| must be released by the caller (see iree_hal_buffer_release).
 iree_status_t iree_hal_metal_buffer_wrap(
+    iree_hal_buffer_placement_t placement,
 #if defined(IREE_PLATFORM_MACOS)
     id<MTLCommandQueue> queue,
 #endif  // IREE_PLATFORM_MACOS
-    id<MTLBuffer> metal_buffer, iree_hal_allocator_t* allocator,
-    iree_hal_memory_type_t memory_type, iree_hal_memory_access_t allowed_access,
+    id<MTLBuffer> metal_buffer, iree_hal_memory_type_t memory_type,
+    iree_hal_memory_access_t allowed_access,
     iree_hal_buffer_usage_t allowed_usage, iree_device_size_t allocation_size,
     iree_device_size_t byte_offset, iree_device_size_t byte_length,
     iree_hal_buffer_release_callback_t release_callback,
-    iree_hal_buffer_t** out_buffer);
+    iree_allocator_t host_allocator, iree_hal_buffer_t** out_buffer);
 
 // Returns true if the buffer was wrapped from an external handle instead of
 // allocated by the HAL allocator.

--- a/runtime/src/iree/hal/drivers/metal/metal_device.m
+++ b/runtime/src/iree/hal/drivers/metal/metal_device.m
@@ -122,7 +122,7 @@ static iree_status_t iree_hal_metal_device_create_internal(
       initWithDispatchQueue:device->semaphore_notification_queue];  // +1
   device->capture_manager = NULL;
 
-  iree_status_t status = iree_hal_metal_allocator_create(metal_device,
+  iree_status_t status = iree_hal_metal_allocator_create((iree_hal_device_t*)device, metal_device,
 #if defined(IREE_PLATFORM_MACOS)
                                                          metal_queue,
 #endif  // IREE_PLATFORM_MACOS

--- a/runtime/src/iree/hal/drivers/null/buffer.h
+++ b/runtime/src/iree/hal/drivers/null/buffer.h
@@ -16,7 +16,7 @@
 
 // Wraps a {Null} allocation in an iree_hal_buffer_t.
 iree_status_t iree_hal_null_buffer_wrap(
-    iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
+    iree_hal_buffer_placement_t placement, iree_hal_memory_type_t memory_type,
     iree_hal_memory_access_t allowed_access,
     iree_hal_buffer_usage_t allowed_usage, iree_device_size_t allocation_size,
     iree_device_size_t byte_offset, iree_device_size_t byte_length,

--- a/runtime/src/iree/hal/drivers/vulkan/base_buffer.h
+++ b/runtime/src/iree/hal/drivers/vulkan/base_buffer.h
@@ -98,6 +98,7 @@ iree_status_t iree_hal_vulkan_query_memory_heaps(
 // to get access to the API VkBuffer handle.
 typedef struct iree_hal_vulkan_base_buffer_t {
   iree_hal_buffer_t base;
+  iree_allocator_t host_allocator;
   // NOTE: may be VK_NULL_HANDLE if sparse residency is used to back the buffer
   // with multiple device memory allocations.
   VkDeviceMemory device_memory;

--- a/runtime/src/iree/hal/drivers/vulkan/native_allocator.h
+++ b/runtime/src/iree/hal/drivers/vulkan/native_allocator.h
@@ -18,7 +18,8 @@ extern "C" {
 // Creates a native Vulkan API-based allocator that directly allocates memory
 // from the underlying implementation with no pooling or suballocation.
 iree_status_t iree_hal_vulkan_native_allocator_create(
-    const iree_hal_vulkan_device_options_t* options, VkInstance instance,
+    const iree_hal_vulkan_device_options_t* options,
+    iree_hal_device_t* parent_device, VkInstance instance,
     VkPhysicalDevice physical_device,
     iree::hal::vulkan::VkDeviceHandle* logical_device,
     iree_hal_allocator_t** out_allocator);

--- a/runtime/src/iree/hal/drivers/vulkan/native_buffer.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/native_buffer.cc
@@ -32,7 +32,7 @@ static iree_hal_vulkan_native_buffer_t* iree_hal_vulkan_native_buffer_cast(
 }
 
 iree_status_t iree_hal_vulkan_native_buffer_wrap(
-    iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
+    iree_hal_buffer_placement_t placement, iree_hal_memory_type_t memory_type,
     iree_hal_memory_access_t allowed_access,
     iree_hal_buffer_usage_t allowed_usage, iree_device_size_t allocation_size,
     iree_device_size_t byte_offset, iree_device_size_t byte_length,
@@ -40,24 +40,23 @@ iree_status_t iree_hal_vulkan_native_buffer_wrap(
     VkDeviceMemory device_memory, VkBuffer handle,
     iree_hal_vulkan_native_buffer_release_callback_t internal_release_callback,
     iree_hal_buffer_release_callback_t user_release_callback,
-    iree_hal_buffer_t** out_buffer) {
-  IREE_ASSERT_ARGUMENT(allocator);
+    iree_allocator_t host_allocator, iree_hal_buffer_t** out_buffer) {
+  IREE_ASSERT_ARGUMENT(placement.device);
   IREE_ASSERT_ARGUMENT(logical_device);
   IREE_ASSERT_ARGUMENT(handle);
   IREE_ASSERT_ARGUMENT(out_buffer);
   IREE_TRACE_ZONE_BEGIN(z0);
   IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (int64_t)allocation_size);
 
-  iree_allocator_t host_allocator =
-      iree_hal_allocator_host_allocator(allocator);
   iree_hal_vulkan_native_buffer_t* buffer = NULL;
   iree_status_t status =
       iree_allocator_malloc(host_allocator, sizeof(*buffer), (void**)&buffer);
   if (iree_status_is_ok(status)) {
     iree_hal_buffer_initialize(
-        host_allocator, allocator, &buffer->base.base, allocation_size,
-        byte_offset, byte_length, memory_type, allowed_access, allowed_usage,
+        placement, &buffer->base.base, allocation_size, byte_offset,
+        byte_length, memory_type, allowed_access, allowed_usage,
         &iree_hal_vulkan_native_buffer_vtable, &buffer->base.base);
+    buffer->base.host_allocator = host_allocator;
     buffer->base.device_memory = device_memory;
     buffer->base.handle = handle;
     buffer->logical_device = logical_device;
@@ -75,7 +74,7 @@ static void iree_hal_vulkan_native_buffer_destroy(
     iree_hal_buffer_t* base_buffer) {
   iree_hal_vulkan_native_buffer_t* buffer =
       iree_hal_vulkan_native_buffer_cast(base_buffer);
-  iree_allocator_t host_allocator = base_buffer->host_allocator;
+  iree_allocator_t host_allocator = buffer->base.host_allocator;
   IREE_TRACE_ZONE_BEGIN(z0);
   IREE_TRACE_ZONE_APPEND_VALUE_I64(
       z0, (int64_t)iree_hal_buffer_allocation_size(base_buffer));

--- a/runtime/src/iree/hal/drivers/vulkan/native_buffer.h
+++ b/runtime/src/iree/hal/drivers/vulkan/native_buffer.h
@@ -35,7 +35,7 @@ typedef struct {
 // HAL. The provided callback is made when the buffer is destroyed to allow the
 // caller to clean up as appropriate.
 iree_status_t iree_hal_vulkan_native_buffer_wrap(
-    iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
+    iree_hal_buffer_placement_t placement, iree_hal_memory_type_t memory_type,
     iree_hal_memory_access_t allowed_access,
     iree_hal_buffer_usage_t allowed_usage, iree_device_size_t allocation_size,
     iree_device_size_t byte_offset, iree_device_size_t byte_length,
@@ -43,7 +43,7 @@ iree_status_t iree_hal_vulkan_native_buffer_wrap(
     VkDeviceMemory device_memory, VkBuffer handle,
     iree_hal_vulkan_native_buffer_release_callback_t internal_release_callback,
     iree_hal_buffer_release_callback_t user_release_callback,
-    iree_hal_buffer_t** out_buffer);
+    iree_allocator_t host_allocator, iree_hal_buffer_t** out_buffer);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/hal/drivers/vulkan/sparse_buffer.h
+++ b/runtime/src/iree/hal/drivers/vulkan/sparse_buffer.h
@@ -26,14 +26,14 @@ extern "C" {
 // This will eventually be replaced with HAL device APIs for controlling the
 // reserve/commit/decommit/release behavior of the virtual/physical storage.
 iree_status_t iree_hal_vulkan_sparse_buffer_create_bound_sync(
-    iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
+    iree_hal_buffer_placement_t placement, iree_hal_memory_type_t memory_type,
     iree_hal_memory_access_t allowed_access,
     iree_hal_buffer_usage_t allowed_usage, iree_device_size_t allocation_size,
     iree_device_size_t byte_offset, iree_device_size_t byte_length,
     iree::hal::vulkan::VkDeviceHandle* logical_device, VkQueue queue,
     VkBuffer handle, VkMemoryRequirements requirements,
     uint32_t memory_type_index, VkDeviceSize max_allocation_size,
-    iree_hal_buffer_t** out_buffer);
+    iree_allocator_t host_allocator, iree_hal_buffer_t** out_buffer);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
@@ -755,8 +755,8 @@ static iree_status_t iree_hal_vulkan_device_create_internal(
   // Create the device memory allocator that will service all buffer
   // allocation requests.
   iree_status_t status = iree_hal_vulkan_native_allocator_create(
-      options, instance, physical_device, logical_device,
-      &device->device_allocator);
+      options, (iree_hal_device_t*)device, instance, physical_device,
+      logical_device, &device->device_allocator);
 
   // Create command pools for each queue family. If we don't have a transfer
   // queue then we'll ignore that one and just use the dispatch pool.

--- a/runtime/src/iree/hal/utils/caching_allocator.c
+++ b/runtime/src/iree/hal/utils/caching_allocator.c
@@ -730,7 +730,12 @@ static iree_status_t iree_hal_caching_allocator_allocate_buffer(
       pool, &compat_params, allocation_size, out_buffer));
 
   // Point the buffer back to us for deallocation.
-  (*out_buffer)->device_allocator = base_allocator;
+  //
+  // TODO(#19159): remove iree_hal_allocator_deallocate_buffer when pooling no
+  // longer requires the pooling_allocator on iree_hal_buffer_t. We should
+  // instead be creating a new iree_hal_cached_buffer_t that we return as if it
+  // were an allocated buffer and that can store a reference back to the pool.
+  (*out_buffer)->pooling_allocator = base_allocator;
 
   return iree_ok_status();
 }
@@ -750,6 +755,9 @@ static void iree_hal_caching_allocator_deallocate_buffer(
           iree_hal_buffer_allowed_usage(buffer));
   IREE_ASSERT(pool, "pool to return cached buffer to not found");
   if (!pool) return;
+
+  // TODO(#19159): remove iree_hal_allocator_deallocate_buffer when pooling no
+  // longer requires the pooling_allocator on iree_hal_buffer_t.
 
   // Release back to pool (which may deallocate).
   iree_hal_caching_allocator_pool_release(pool, buffer);

--- a/runtime/src/iree/modules/hal/inline/module.c
+++ b/runtime/src/iree/modules/hal/inline/module.c
@@ -366,7 +366,7 @@ IREE_VM_ABI_EXPORT(iree_hal_inline_module_buffer_subspan,  //
   iree_hal_buffer_t* subspan_buffer = NULL;
   IREE_RETURN_IF_ERROR(
       iree_hal_buffer_subspan(source_buffer, source_offset, length,
-                              &subspan_buffer),
+                              state->host_allocator, &subspan_buffer),
       "invalid subspan of an existing buffer (source_offset=%" PRIdsz
       ", length=%" PRIdsz ")",
       source_offset, length);
@@ -424,7 +424,7 @@ IREE_VM_ABI_EXPORT(iree_hal_inline_module_buffer_view_create,  //
       source_length != iree_hal_buffer_byte_length(source_buffer)) {
     IREE_RETURN_IF_ERROR(
         iree_hal_buffer_subspan(source_buffer, source_offset, source_length,
-                                &subspan_buffer),
+                                state->host_allocator, &subspan_buffer),
         "invalid subspan of an existing buffer (source_offset=%" PRIdsz
         ", length=%" PRIdsz ")",
         source_offset, source_length);

--- a/runtime/src/iree/modules/hal/module.c
+++ b/runtime/src/iree/modules/hal/module.c
@@ -462,7 +462,7 @@ IREE_VM_ABI_EXPORT(iree_hal_module_buffer_subspan,  //
   iree_hal_buffer_t* subspan_buffer = NULL;
   IREE_RETURN_IF_ERROR(
       iree_hal_buffer_subspan(source_buffer, source_offset, length,
-                              &subspan_buffer),
+                              state->host_allocator, &subspan_buffer),
       "invalid subspan of an existing buffer (source_offset=%" PRIdsz
       ", length=%" PRIdsz ")",
       source_offset, length);
@@ -549,7 +549,7 @@ IREE_VM_ABI_EXPORT(iree_hal_module_buffer_view_create,  //
       source_length != iree_hal_buffer_byte_length(source_buffer)) {
     IREE_RETURN_IF_ERROR(
         iree_hal_buffer_subspan(source_buffer, source_offset, source_length,
-                                &subspan_buffer),
+                                state->host_allocator, &subspan_buffer),
         "invalid subspan of an existing buffer (source_offset=%" PRIdsz
         ", length=%" PRIdsz ")",
         source_offset, source_length);


### PR DESCRIPTION
This allows users to query for the device, queue affinity, and origin flags of an allocated buffer so that they can decide whether to copy buffers when moving across devices/queues, perform synchronous or asynchronous deallocations, and select queues to perform such operations. The downside is that prior to this buffers could be defined as shared across multiple devices that share a single allocator - because it's still the case that they can be shared "placement" was used as it's not "availability" or "access permissions" but only indicating the origin of the buffer and where it's preferred location is. Buffer compatibility queries are still the way to determine access visibility.

The base `iree_hal_buffer_t` structure was cleaned up a bit and though still ugly is better prepared for removal of the device allocator back reference. #19159 tracks removing the allocator reference that is currently only used by the caching allocator due to our lack of dynamic casts.

Breaking API changes:
* `iree_hal_buffer_subspan` now requires an `iree_allocator_t host_allocator` that was previously implicit.
* `iree_hal_subspan_buffer_initialize` removed as it was not safe and shouldn't have been used.
* `iree_hal_deferred_buffer_t` removed as it is not possible to do the placement checks without an allocated buffer reference. This is used in a branch for async allocations on CPU but either a different approach is required there or it can be moved into `iree/hal/local/` where we can make assertions about universal accessibility.
* `iree_hal_heap_buffer_wrap` and all other buffer creation now requires a placement.
* `iree_hal_buffer_initialize` used by HAL implementations now requires a placement.
