### PR TITLE
Update references to SHARK-Platform using new shark-ai name.

### DIFF
--- a/docs/website/docs/community/index.md
+++ b/docs/website/docs/community/index.md
@@ -5,14 +5,14 @@ Projects built by community members:
 * The [SHARK-Studio](https://github.com/nod-ai/SHARK-Studio) project offers user
   interfaces for running a large corpus of machine learning programs.
 
-* The [SHARK-Platform](https://github.com/nod-ai/SHARK-Platform) project
+* The [shark-ai](https://github.com/nod-ai/shark-ai) project
   contains modeling and serving libraries.
 
 * The [SHARK-ModelDev](https://github.com/nod-ai/SHARK-ModelDev) project is an
   integration repository for various model bringup activities. Several parts
   of SHARK-ModelDev graduated to
   [iree-turbine](https://github.com/iree-org/iree-turbine) and
-  [SHARK-Platform](https://github.com/nod-ai/SHARK-Platform).
+  [shark-ai](https://github.com/nod-ai/shark-ai).
 
 * The [IREE C++ Template](https://github.com/iml130/iree-template-cpp) *(archived)*
   showed one way to integrate IREE's runtime into a project with CMake.

--- a/docs/website/docs/developers/debugging/model-development.md
+++ b/docs/website/docs/developers/debugging/model-development.md
@@ -9,10 +9,9 @@ icon: octicons/bug-16
 
 Bringing up new models or diagnosing regressions in existing models written
 using one of IREE's supported [ML frameworks](../../guides/ml-frameworks/index.md)
-or downstream projects like
-[SHARK-Platform](https://github.com/nod-ai/SHARK-Platform) can involve
-debugging up and down the tech stack. Here are some tips to make that process
-easier.
+or downstream projects like [shark-ai](https://github.com/nod-ai/shark-ai) can
+involve debugging up and down the tech stack. Here are some tips to make that
+process easier.
 
 ## Helpful build settings
 


### PR DESCRIPTION
We renamed the https://github.com/nod-ai/SHARK-Platform repository to https://github.com/nod-ai/shark-ai.

See also https://github.com/nod-ai/shark-ai/pull/545