### PR TITLE
[DispatchCreation] Enable bubble up extract slice for `linalg.generic` op with a single use.

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/BubbleUpExtractSlices.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/BubbleUpExtractSlices.cpp
@@ -41,9 +41,10 @@ struct BubbleUpExtract : OpRewritePattern<tensor::ExtractSliceOp> {
                    "single result");
     }
 
-    if (!IREE::LinalgExt::isBitExtendOp(genericOp)) {
+    if (!IREE::LinalgExt::isBitExtendOp(genericOp) && !genericOp->hasOneUse()) {
       return rewriter.notifyMatchFailure(
-          sliceOp, "expected source to be dequantize-like");
+          sliceOp,
+          "expected source to be dequantize-like op or have a single use");
     }
 
     if (!sliceOp.hasUnitStride()) {


### PR DESCRIPTION
For a `linalg.generic` -> `tensor.extract_slice` pattern where the producer has a single use, this is always good to do.

TODO: This pattern could be generalized for any `LinalgOp`, but not done now because of the rank-reduction slices need to fold the unit dimensions.

Fixes #19173 