### PR TITLE
[Util] Erase state of modified ops

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/OptimizeIntArithmetic.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/OptimizeIntArithmetic.cpp
@@ -292,6 +292,13 @@ protected:
       s.eraseState(res);
   }
 
+  void notifyOperationModified(Operation *op) override {
+    s.eraseState(s.getProgramPointAfter(op));
+    for (Value res : op->getResults()) {
+      s.eraseState(res);
+    }
+  }
+
   DataFlowSolver &s;
 };
 


### PR DESCRIPTION
This was hard to debug and I haven't yet been able to track down which op was modified causing the issue nor which pattern was triggering this. I was encountering the following assert during `Stream` pipeline (but not global opt):

```shell
APInt.cpp:285: int llvm::APInt::compare(const APInt &) const: Assertion `BitWidth == RHS.BitWidth && "Bit widths must be same for comparison"' failed.
```

It might be worth reverting https://github.com/iree-org/iree/pull/19130 instead of this patch since I wasn't able to track this down fully.


2/2 fix for https://github.com/iree-org/iree/issues/19167. 