### PR TITLE
[EmitC] Adapt lit tests to emitc.funcs default dialect

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: emitc.func private @my_module_add_i32
 vm.module @my_module {
   vm.func @add_i32(%arg0: i32, %arg1: i32) {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_add_i32"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK-NEXT: %0 = call_opaque "vm_add_i32"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.add.i32 %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -14,7 +14,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_sub_i32
 vm.module @my_module {
   vm.func @sub_i32(%arg0: i32, %arg1: i32) {
-    // CHECK: %0 = emitc.call_opaque "vm_sub_i32"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK: %0 = call_opaque "vm_sub_i32"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.sub.i32 %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -25,7 +25,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_mul_i32
 vm.module @my_module {
   vm.func @mul_i32(%arg0: i32, %arg1: i32) {
-    // CHECK: %0 = emitc.call_opaque "vm_mul_i32"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK: %0 = call_opaque "vm_mul_i32"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.mul.i32 %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -36,7 +36,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_div_i32_s
 vm.module @my_module {
   vm.func @div_i32_s(%arg0: i32, %arg1: i32) {
-    // CHECK: %0 = emitc.call_opaque "vm_div_i32s"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK: %0 = call_opaque "vm_div_i32s"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.div.i32.s %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -47,7 +47,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_div_i32_u
 vm.module @my_module {
   vm.func @div_i32_u(%arg0: i32, %arg1: i32) {
-    // CHECK: %0 = emitc.call_opaque "vm_div_i32u"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK: %0 = call_opaque "vm_div_i32u"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.div.i32.u %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -58,7 +58,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_rem_i32_s
 vm.module @my_module {
   vm.func @rem_i32_s(%arg0: i32, %arg1: i32) {
-    // CHECK: %0 = emitc.call_opaque "vm_rem_i32s"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK: %0 = call_opaque "vm_rem_i32s"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.rem.i32.s %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -69,7 +69,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_rem_i32_u
 vm.module @my_module {
   vm.func @rem_i32_u(%arg0: i32, %arg1: i32) {
-    // CHECK: %0 = emitc.call_opaque "vm_rem_i32u"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK: %0 = call_opaque "vm_rem_i32u"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.rem.i32.u %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -80,7 +80,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_fma_i32
 vm.module @my_module {
   vm.func @fma_i32(%arg0: i32, %arg1: i32, %arg2: i32) {
-    // CHECK: %0 = emitc.call_opaque "vm_fma_i32"(%arg3, %arg4, %arg5) : (i32, i32, i32) -> i32
+    // CHECK: %0 = call_opaque "vm_fma_i32"(%arg3, %arg4, %arg5) : (i32, i32, i32) -> i32
     %0 = vm.fma.i32 %arg0, %arg1, %arg2 : i32
     vm.return %0 : i32
   }
@@ -91,7 +91,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_abs_i32
 vm.module @my_module {
   vm.func @abs_i32(%arg0 : i32) -> i32 {
-    // CHECK: %0 = emitc.call_opaque "vm_abs_i32"(%arg3) : (i32) -> i32
+    // CHECK: %0 = call_opaque "vm_abs_i32"(%arg3) : (i32) -> i32
     %0 = vm.abs.i32 %arg0 : i32
     vm.return %0 : i32
   }
@@ -102,7 +102,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_min_i32_s
 vm.module @my_module {
   vm.func @min_i32_s(%arg0: i32, %arg1: i32) {
-    // CHECK: %0 = emitc.call_opaque "vm_min_i32s"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK: %0 = call_opaque "vm_min_i32s"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.min.i32.s %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -113,7 +113,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_not_i32
 vm.module @my_module {
   vm.func @not_i32(%arg0 : i32) -> i32 {
-    // CHECK: %0 = emitc.call_opaque "vm_not_i32"(%arg3) : (i32) -> i32
+    // CHECK: %0 = call_opaque "vm_not_i32"(%arg3) : (i32) -> i32
     %0 = vm.not.i32 %arg0 : i32
     vm.return %0 : i32
   }
@@ -124,7 +124,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_and_i32
 vm.module @my_module {
   vm.func @and_i32(%arg0 : i32, %arg1 : i32) -> i32 {
-    // CHECK: %0 = emitc.call_opaque "vm_and_i32"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK: %0 = call_opaque "vm_and_i32"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.and.i32 %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -135,7 +135,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_or_i32
 vm.module @my_module {
   vm.func @or_i32(%arg0 : i32, %arg1 : i32) -> i32 {
-    // CHECK: %0 = emitc.call_opaque "vm_or_i32"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK: %0 = call_opaque "vm_or_i32"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.or.i32 %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -146,7 +146,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_xor_i32
 vm.module @my_module {
   vm.func @xor_i32(%arg0 : i32, %arg1 : i32) -> i32 {
-    // CHECK: %0 = emitc.call_opaque "vm_xor_i32"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK: %0 = call_opaque "vm_xor_i32"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.xor.i32 %arg0, %arg1 : i32
     vm.return %0 : i32
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops_f32.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops_f32.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: emitc.func private @my_module_add_f32
 vm.module @my_module {
   vm.func @add_f32(%arg0 : f32, %arg1 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_add_f32"(%arg3, %arg4) : (f32, f32) -> f32
+    // CHECK-NEXT: %0 = call_opaque "vm_add_f32"(%arg3, %arg4) : (f32, f32) -> f32
     %0 = vm.add.f32 %arg0, %arg1 : f32
     vm.return %0 : f32
   }
@@ -14,7 +14,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_sub_f32
 vm.module @my_module {
   vm.func @sub_f32(%arg0 : f32, %arg1 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_sub_f32"(%arg3, %arg4) : (f32, f32) -> f32
+    // CHECK-NEXT: %0 = call_opaque "vm_sub_f32"(%arg3, %arg4) : (f32, f32) -> f32
     %0 = vm.sub.f32 %arg0, %arg1 : f32
     vm.return %0 : f32
   }
@@ -25,7 +25,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_mul_f32
 vm.module @my_module {
   vm.func @mul_f32(%arg0 : f32, %arg1 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_mul_f32"(%arg3, %arg4) : (f32, f32) -> f32
+    // CHECK-NEXT: %0 = call_opaque "vm_mul_f32"(%arg3, %arg4) : (f32, f32) -> f32
     %0 = vm.mul.f32 %arg0, %arg1 : f32
     vm.return %0 : f32
   }
@@ -36,7 +36,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_div_f32
 vm.module @my_module {
   vm.func @div_f32(%arg0 : f32, %arg1 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_div_f32"(%arg3, %arg4) : (f32, f32) -> f32
+    // CHECK-NEXT: %0 = call_opaque "vm_div_f32"(%arg3, %arg4) : (f32, f32) -> f32
     %0 = vm.div.f32 %arg0, %arg1 : f32
     vm.return %0 : f32
   }
@@ -47,7 +47,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_rem_f32
 vm.module @my_module {
   vm.func @rem_f32(%arg0 : f32, %arg1 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_rem_f32"(%arg3, %arg4) : (f32, f32) -> f32
+    // CHECK-NEXT: %0 = call_opaque "vm_rem_f32"(%arg3, %arg4) : (f32, f32) -> f32
     %0 = vm.rem.f32 %arg0, %arg1 : f32
     vm.return %0 : f32
   }
@@ -58,7 +58,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_fma_f32
 vm.module @my_module {
   vm.func @fma_f32(%arg0: f32, %arg1: f32, %arg2: f32) {
-    // CHECK: %0 = emitc.call_opaque "vm_fma_f32"(%arg3, %arg4, %arg5) : (f32, f32, f32) -> f32
+    // CHECK: %0 = call_opaque "vm_fma_f32"(%arg3, %arg4, %arg5) : (f32, f32, f32) -> f32
     %0 = vm.fma.f32 %arg0, %arg1, %arg2 : f32
     vm.return %0 : f32
   }
@@ -69,7 +69,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_abs_f32
 vm.module @my_module {
   vm.func @abs_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_abs_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = call_opaque "vm_abs_f32"(%arg3) : (f32) -> f32
     %0 = vm.abs.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -80,7 +80,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_neg_f32
 vm.module @my_module {
   vm.func @neg_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_neg_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = call_opaque "vm_neg_f32"(%arg3) : (f32) -> f32
     %0 = vm.neg.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -91,7 +91,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_ceil_f32
 vm.module @my_module {
   vm.func @ceil_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_ceil_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = call_opaque "vm_ceil_f32"(%arg3) : (f32) -> f32
     %0 = vm.ceil.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -102,7 +102,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_floor_f32
 vm.module @my_module {
   vm.func @floor_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_floor_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = call_opaque "vm_floor_f32"(%arg3) : (f32) -> f32
     %0 = vm.floor.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -113,7 +113,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_min_f32
 vm.module @my_module {
   vm.func @min_f32(%arg0 : f32, %arg1 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_min_f32"(%arg3, %arg4) : (f32, f32) -> f32
+    // CHECK-NEXT: %0 = call_opaque "vm_min_f32"(%arg3, %arg4) : (f32, f32) -> f32
     %0 = vm.min.f32 %arg0, %arg1 : f32
     vm.return %0 : f32
   }
@@ -124,7 +124,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_max_f32
 vm.module @my_module {
   vm.func @max_f32(%arg0 : f32, %arg1 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_max_f32"(%arg3, %arg4) : (f32, f32) -> f32
+    // CHECK-NEXT: %0 = call_opaque "vm_max_f32"(%arg3, %arg4) : (f32, f32) -> f32
     %0 = vm.max.f32 %arg0, %arg1 : f32
     vm.return %0 : f32
   }
@@ -135,7 +135,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_atan_f32
 vm.module @my_module {
   vm.func @atan_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_atan_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = call_opaque "vm_atan_f32"(%arg3) : (f32) -> f32
     %0 = vm.atan.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -146,7 +146,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_atan2_f32
 vm.module @my_module {
   vm.func @atan2_f32(%arg0 : f32, %arg1 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_atan2_f32"(%arg3, %arg4) : (f32, f32) -> f32
+    // CHECK-NEXT: %0 = call_opaque "vm_atan2_f32"(%arg3, %arg4) : (f32, f32) -> f32
     %0 = vm.atan2.f32 %arg0, %arg1 : f32
     vm.return %0 : f32
   }
@@ -157,7 +157,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_cos_f32
 vm.module @my_module {
   vm.func @cos_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cos_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = call_opaque "vm_cos_f32"(%arg3) : (f32) -> f32
     %0 = vm.cos.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -168,7 +168,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_sin_f32
 vm.module @my_module {
   vm.func @sin_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_sin_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = call_opaque "vm_sin_f32"(%arg3) : (f32) -> f32
     %0 = vm.sin.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -179,7 +179,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_exp_f32
 vm.module @my_module {
   vm.func @exp_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_exp_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = call_opaque "vm_exp_f32"(%arg3) : (f32) -> f32
     %0 = vm.exp.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -190,7 +190,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_exp2_f32
 vm.module @my_module {
   vm.func @exp2_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_exp2_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = call_opaque "vm_exp2_f32"(%arg3) : (f32) -> f32
     %0 = vm.exp2.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -201,7 +201,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_expm1_f32
 vm.module @my_module {
   vm.func @expm1_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_expm1_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = call_opaque "vm_expm1_f32"(%arg3) : (f32) -> f32
     %0 = vm.expm1.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -212,7 +212,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_log_f32
 vm.module @my_module {
   vm.func @log_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_log_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = call_opaque "vm_log_f32"(%arg3) : (f32) -> f32
     %0 = vm.log.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -223,7 +223,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_log10_f32
 vm.module @my_module {
   vm.func @log10_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_log10_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = call_opaque "vm_log10_f32"(%arg3) : (f32) -> f32
     %0 = vm.log10.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -234,7 +234,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_log1p_f32
 vm.module @my_module {
   vm.func @log1p_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_log1p_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = call_opaque "vm_log1p_f32"(%arg3) : (f32) -> f32
     %0 = vm.log1p.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -245,7 +245,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_log2_f32
 vm.module @my_module {
   vm.func @log2_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_log2_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = call_opaque "vm_log2_f32"(%arg3) : (f32) -> f32
     %0 = vm.log2.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -256,7 +256,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_pow_f32
 vm.module @my_module {
   vm.func @pow_f32(%arg0 : f32, %arg1 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_pow_f32"(%arg3, %arg4) : (f32, f32) -> f32
+    // CHECK-NEXT: %0 = call_opaque "vm_pow_f32"(%arg3, %arg4) : (f32, f32) -> f32
     %0 = vm.pow.f32 %arg0, %arg1 : f32
     vm.return %0 : f32
   }
@@ -267,7 +267,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_rsqrt_f32
 vm.module @my_module {
   vm.func @rsqrt_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_rsqrt_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = call_opaque "vm_rsqrt_f32"(%arg3) : (f32) -> f32
     %0 = vm.rsqrt.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -278,7 +278,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_sqrt_f32
 vm.module @my_module {
   vm.func @sqrt_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_sqrt_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = call_opaque "vm_sqrt_f32"(%arg3) : (f32) -> f32
     %0 = vm.sqrt.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -289,7 +289,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_tanh_f32
 vm.module @my_module {
   vm.func @tanh_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_tanh_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = call_opaque "vm_tanh_f32"(%arg3) : (f32) -> f32
     %0 = vm.tanh.f32 %arg0 : f32
     vm.return %0 : f32
   }
@@ -300,7 +300,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_erf_f32
 vm.module @my_module {
   vm.func @erf_f32(%arg0 : f32) -> f32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_erf_f32"(%arg3) : (f32) -> f32
+    // CHECK-NEXT: %0 = call_opaque "vm_erf_f32"(%arg3) : (f32) -> f32
     %0 = vm.erf.f32 %arg0 : f32
     vm.return %0 : f32
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops_i64.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops_i64.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: emitc.func private @my_module_add_i64
 vm.module @my_module {
   vm.func @add_i64(%arg0: i64, %arg1: i64) {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_add_i64"(%arg3, %arg4) : (i64, i64) -> i64
+    // CHECK-NEXT: %0 = call_opaque "vm_add_i64"(%arg3, %arg4) : (i64, i64) -> i64
     %0 = vm.add.i64 %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -14,7 +14,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_sub_i64
 vm.module @my_module {
   vm.func @sub_i64(%arg0: i64, %arg1: i64) {
-    // CHECK: %0 = emitc.call_opaque "vm_sub_i64"(%arg3, %arg4) : (i64, i64) -> i64
+    // CHECK: %0 = call_opaque "vm_sub_i64"(%arg3, %arg4) : (i64, i64) -> i64
     %0 = vm.sub.i64 %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -25,7 +25,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_mul_i64
 vm.module @my_module {
   vm.func @mul_i64(%arg0: i64, %arg1: i64) {
-    // CHECK: %0 = emitc.call_opaque "vm_mul_i64"(%arg3, %arg4) : (i64, i64) -> i64
+    // CHECK: %0 = call_opaque "vm_mul_i64"(%arg3, %arg4) : (i64, i64) -> i64
     %0 = vm.mul.i64 %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -36,7 +36,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_div_i64_s
 vm.module @my_module {
   vm.func @div_i64_s(%arg0: i64, %arg1: i64) {
-    // CHECK: %0 = emitc.call_opaque "vm_div_i64s"(%arg3, %arg4) : (i64, i64) -> i64
+    // CHECK: %0 = call_opaque "vm_div_i64s"(%arg3, %arg4) : (i64, i64) -> i64
     %0 = vm.div.i64.s %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -47,7 +47,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_div_i64_u
 vm.module @my_module {
   vm.func @div_i64_u(%arg0: i64, %arg1: i64) {
-    // CHECK: %0 = emitc.call_opaque "vm_div_i64u"(%arg3, %arg4) : (i64, i64) -> i64
+    // CHECK: %0 = call_opaque "vm_div_i64u"(%arg3, %arg4) : (i64, i64) -> i64
     %0 = vm.div.i64.u %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -58,7 +58,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_rem_i64_s
 vm.module @my_module {
   vm.func @rem_i64_s(%arg0: i64, %arg1: i64) {
-    // CHECK: %0 = emitc.call_opaque "vm_rem_i64s"(%arg3, %arg4) : (i64, i64) -> i64
+    // CHECK: %0 = call_opaque "vm_rem_i64s"(%arg3, %arg4) : (i64, i64) -> i64
     %0 = vm.rem.i64.s %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -69,7 +69,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_rem_i64_u
 vm.module @my_module {
   vm.func @rem_i64_u(%arg0: i64, %arg1: i64) {
-    // CHECK: %0 = emitc.call_opaque "vm_rem_i64u"(%arg3, %arg4) : (i64, i64) -> i64
+    // CHECK: %0 = call_opaque "vm_rem_i64u"(%arg3, %arg4) : (i64, i64) -> i64
     %0 = vm.rem.i64.u %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -80,7 +80,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_fma_i64
 vm.module @my_module {
   vm.func @fma_i64(%arg0: i64, %arg1: i64, %arg2: i64) {
-    // CHECK: %0 = emitc.call_opaque "vm_fma_i64"(%arg3, %arg4, %arg5) : (i64, i64, i64) -> i64
+    // CHECK: %0 = call_opaque "vm_fma_i64"(%arg3, %arg4, %arg5) : (i64, i64, i64) -> i64
     %0 = vm.fma.i64 %arg0, %arg1, %arg2 : i64
     vm.return %0 : i64
   }
@@ -91,7 +91,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_abs_i64
 vm.module @my_module {
   vm.func @abs_i64(%arg0 : i64) -> i64 {
-    // CHECK: %0 = emitc.call_opaque "vm_abs_i64"(%arg3) : (i64) -> i64
+    // CHECK: %0 = call_opaque "vm_abs_i64"(%arg3) : (i64) -> i64
     %0 = vm.abs.i64 %arg0 : i64
     vm.return %0 : i64
   }
@@ -102,7 +102,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_min_i64_s
 vm.module @my_module {
   vm.func @min_i64_s(%arg0: i64, %arg1: i64) {
-    // CHECK: %0 = emitc.call_opaque "vm_min_i64s"(%arg3, %arg4) : (i64, i64) -> i64
+    // CHECK: %0 = call_opaque "vm_min_i64s"(%arg3, %arg4) : (i64, i64) -> i64
     %0 = vm.min.i64.s %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -113,7 +113,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_not_i64
 vm.module @my_module {
   vm.func @not_i64(%arg0 : i64) -> i64 {
-    // CHECK: %0 = emitc.call_opaque "vm_not_i64"(%arg3) : (i64) -> i64
+    // CHECK: %0 = call_opaque "vm_not_i64"(%arg3) : (i64) -> i64
     %0 = vm.not.i64 %arg0 : i64
     vm.return %0 : i64
   }
@@ -124,7 +124,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_and_i64
 vm.module @my_module {
   vm.func @and_i64(%arg0 : i64, %arg1 : i64) -> i64 {
-    // CHECK: %0 = emitc.call_opaque "vm_and_i64"(%arg3, %arg4) : (i64, i64) -> i64
+    // CHECK: %0 = call_opaque "vm_and_i64"(%arg3, %arg4) : (i64, i64) -> i64
     %0 = vm.and.i64 %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -135,7 +135,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_or_i64
 vm.module @my_module {
   vm.func @or_i64(%arg0 : i64, %arg1 : i64) -> i64 {
-    // CHECK: %0 = emitc.call_opaque "vm_or_i64"(%arg3, %arg4) : (i64, i64) -> i64
+    // CHECK: %0 = call_opaque "vm_or_i64"(%arg3, %arg4) : (i64, i64) -> i64
     %0 = vm.or.i64 %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -146,7 +146,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_xor_i64
 vm.module @my_module {
   vm.func @xor_i64(%arg0 : i64, %arg1 : i64) -> i64 {
-    // CHECK: %0 = emitc.call_opaque "vm_xor_i64"(%arg3, %arg4) : (i64, i64) -> i64
+    // CHECK: %0 = call_opaque "vm_xor_i64"(%arg3, %arg4) : (i64, i64) -> i64
     %0 = vm.xor.i64 %arg0, %arg1 : i64
     vm.return %0 : i64
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: emitc.func private @my_module_select_i32
 vm.module @my_module {
   vm.func @select_i32(%arg0 : i32, %arg1 : i32, %arg2 : i32) -> i32 {
-    // CHECK: %0 = emitc.call_opaque "vm_select_i32"(%arg3, %arg4, %arg5) : (i32, i32, i32) -> i32
+    // CHECK: %0 = call_opaque "vm_select_i32"(%arg3, %arg4, %arg5) : (i32, i32, i32) -> i32
     %0 = vm.select.i32 %arg0, %arg1, %arg2 : i32
     vm.return %0 : i32
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops_f32.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops_f32.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: emitc.func private @my_module_select_f32
 vm.module @my_module {
   vm.func @select_f32(%arg0 : i32, %arg1 : f32, %arg2 : f32) -> f32 {
-    // CHECK: %0 = emitc.call_opaque "vm_select_f32"(%arg3, %arg4, %arg5) : (i32, f32, f32) -> f32
+    // CHECK: %0 = call_opaque "vm_select_f32"(%arg3, %arg4, %arg5) : (i32, f32, f32) -> f32
     %0 = vm.select.f32 %arg0, %arg1, %arg2 : f32
     vm.return %0 : f32
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops_i64.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/assignment_ops_i64.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: emitc.func private @my_module_select_i64
 vm.module @my_module {
   vm.func @select_i64(%arg0 : i32, %arg1 : i64, %arg2 : i64) -> i64 {
-    // CHECK: %0 = emitc.call_opaque "vm_select_i64"(%arg3, %arg4, %arg5) : (i32, i64, i64) -> i64
+    // CHECK: %0 = call_opaque "vm_select_i64"(%arg3, %arg4, %arg5) : (i32, i64, i64) -> i64
     %0 = vm.select.i64 %arg0, %arg1, %arg2 : i64
     vm.return %0 : i64
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/buffer_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/buffer_ops.mlir
@@ -6,17 +6,17 @@ vm.module @my_module {
     // CHECK: %[[SIZE:.+]] = "emitc.constant"() <{value = 128 : i64}> : () -> i64
     // CHECK-DAG: %[[ALIGNMENT:.+]] = "emitc.constant"() <{value = 32 : i32}> : () -> i32
     // CHECK-DAG: %[[BUFFER_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"NULL">}> : () -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>>
-    // CHECK-DAG: %[[BUFFER_PTR:.+]] = emitc.apply "&"(%[[BUFFER_LVAL]]) : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>>) -> !emitc.ptr<!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>>
+    // CHECK-DAG: %[[BUFFER_PTR:.+]] = apply "&"(%[[BUFFER_LVAL]]) : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>>) -> !emitc.ptr<!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>>
     // CHECK-DAG: %[[STATE_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
-    // CHECK-DAG: emitc.assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
+    // CHECK-DAG: assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
     // CHECK-DAG: %[[ALLOCATOR_LVAL:.+]] = "emitc.member_of_ptr"(%[[STATE_LVAL]]) <{member = "allocator"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>) -> !emitc.lvalue<!emitc.opaque<"iree_allocator_t">>
-    // CHECK-DAG: %[[ALLOCATOR:.+]] = emitc.load %[[ALLOCATOR_LVAL]] : <!emitc.opaque<"iree_allocator_t">>
+    // CHECK-DAG: %[[ALLOCATOR:.+]] = load %[[ALLOCATOR_LVAL]] : <!emitc.opaque<"iree_allocator_t">>
     // CHECK-DAG: %[[BUFFER_ACCESS:.+]] = "emitc.constant"() <{value = #emitc.opaque<"IREE_VM_BUFFER_ACCESS_MUTABLE | IREE_VM_BUFFER_ACCESS_ORIGIN_GUEST">}> : () -> !emitc.opaque<"iree_vm_buffer_access_t">
-    // CHECK-NEXT: %[[STATUS:.+]] = emitc.call_opaque "iree_vm_buffer_create"(%[[BUFFER_ACCESS]], %[[SIZE]], %[[ALIGNMENT]], %[[ALLOCATOR]], %[[BUFFER_PTR]]) : (!emitc.opaque<"iree_vm_buffer_access_t">, i64, i32, !emitc.opaque<"iree_allocator_t">, !emitc.ptr<!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>>) -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %[[STATUS:.+]] = call_opaque "iree_vm_buffer_create"(%[[BUFFER_ACCESS]], %[[SIZE]], %[[ALIGNMENT]], %[[ALLOCATOR]], %[[BUFFER_PTR]]) : (!emitc.opaque<"iree_vm_buffer_access_t">, i64, i32, !emitc.opaque<"iree_allocator_t">, !emitc.ptr<!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>>) -> !emitc.opaque<"iree_status_t">
 
-    // CHECK: %[[BUFFER_TYPE_ID:.+]] = emitc.call_opaque "iree_vm_buffer_type"() : () -> !emitc.opaque<"iree_vm_ref_type_t">
-    // CHECK-NEXT: %[[BUFFER:.+]] = emitc.load %[[BUFFER_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>>
-    // CHECK-NEXT: %[[STATUS2:.+]] = emitc.call_opaque "iree_vm_ref_wrap_assign"(%[[BUFFER]], %[[BUFFER_TYPE_ID]], %1) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, !emitc.opaque<"iree_vm_ref_type_t">, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %[[BUFFER_TYPE_ID:.+]] = call_opaque "iree_vm_buffer_type"() : () -> !emitc.opaque<"iree_vm_ref_type_t">
+    // CHECK-NEXT: %[[BUFFER:.+]] = load %[[BUFFER_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>>
+    // CHECK-NEXT: %[[STATUS2:.+]] = call_opaque "iree_vm_ref_wrap_assign"(%[[BUFFER]], %[[BUFFER_TYPE_ID]], %1) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, !emitc.opaque<"iree_vm_ref_type_t">, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
 
     %c128 = vm.const.i64 128
     %alignment = vm.const.i32 32
@@ -35,16 +35,16 @@ vm.module @my_module {
     // CHECK-DAG: %[[ALIGNMENT:.+]] = "emitc.constant"() <{value = 64 : i32}> : () -> i32
 
     // CHECK: %[[BUFFER_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"NULL">}> : () -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>>
-    // CHECK-DAG: %[[BUFFER_PTR:.+]] = emitc.apply "&"(%[[BUFFER_LVAL]]) : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>>) -> !emitc.ptr<!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>>
+    // CHECK-DAG: %[[BUFFER_PTR:.+]] = apply "&"(%[[BUFFER_LVAL]]) : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>>) -> !emitc.ptr<!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>>
     // CHECK-DAG: %[[STATE_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
-    // CHECK-DAG: emitc.assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
+    // CHECK-DAG: assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
     // CHECK-DAG: %[[ALLOCATOR_LVAL:.+]] = "emitc.member_of_ptr"(%[[STATE_LVAL]]) <{member = "allocator"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>) -> !emitc.lvalue<!emitc.opaque<"iree_allocator_t">>
-    // CHECK-DAG: %[[ALLOCATOR:.+]] = emitc.load %[[ALLOCATOR_LVAL]] : <!emitc.opaque<"iree_allocator_t">>
+    // CHECK-DAG: %[[ALLOCATOR:.+]] = load %[[ALLOCATOR_LVAL]] : <!emitc.opaque<"iree_allocator_t">>
     // CHECK-DAG: %[[BUFFER_ACCESS:.+]] = "emitc.constant"() <{value = #emitc.opaque<"IREE_VM_BUFFER_ACCESS_MUTABLE | IREE_VM_BUFFER_ACCESS_ORIGIN_GUEST">}> : () -> !emitc.opaque<"iree_vm_buffer_access_t">
-    // CHECK-DAG: %[[BUFFER_REF2:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-DAG: %[[BUFFER_PTR2:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF2]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK-DAG: %[[BUFFER_REF2:.+]] = apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK-DAG: %[[BUFFER_PTR2:.+]] = call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF2]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
-    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "iree_vm_buffer_clone"(%[[BUFFER_ACCESS]], %[[BUFFER_PTR2]], %[[C0]], %[[C32]], %[[ALIGNMENT]], %[[ALLOCATOR]], %[[BUFFER_PTR]]) : (!emitc.opaque<"iree_vm_buffer_access_t">, !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64, i32, !emitc.opaque<"iree_allocator_t">, !emitc.ptr<!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>>) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %[[STATUS:.+]] = call_opaque "iree_vm_buffer_clone"(%[[BUFFER_ACCESS]], %[[BUFFER_PTR2]], %[[C0]], %[[C32]], %[[ALIGNMENT]], %[[ALLOCATOR]], %[[BUFFER_PTR]]) : (!emitc.opaque<"iree_vm_buffer_access_t">, !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64, i32, !emitc.opaque<"iree_allocator_t">, !emitc.ptr<!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>>) -> !emitc.opaque<"iree_status_t">
     %c0 = vm.const.i64 0
     %c32 = vm.const.i64 32
     %alignment = vm.const.i32 64
@@ -58,10 +58,10 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_buffer_length
 vm.module @my_module {
   vm.func @buffer_length(%buf : !vm.buffer) {
-    // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK: %[[BUFFER_REF:.+]] = apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
-    // CHECK: %[[LENGTH:.+]] = emitc.call_opaque "iree_vm_buffer_length"(%[[BUFFER_PTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>) -> i64
+    // CHECK: %[[LENGTH:.+]] = call_opaque "iree_vm_buffer_length"(%[[BUFFER_PTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>) -> i64
 
     %length = vm.buffer.length %buf : !vm.buffer -> i64
     vm.return
@@ -76,15 +76,15 @@ vm.module @my_module {
     // CHECK: %[[C0:.+]] = "emitc.constant"() <{value = 0 : i64}> : () -> i64
     // CHECK: %[[C16:.+]] = "emitc.constant"() <{value = 16 : i64}> : () -> i64
 
-    // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK: %[[BUFFER_REF:.+]] = apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
-    // CHECK: %[[BUFFER_REF2:.+]] = emitc.apply "*"(%arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR2:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF2]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK: %[[BUFFER_REF2:.+]] = apply "*"(%arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK-NEXT: %[[BUFFER_PTR2:.+]] = call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF2]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
     // CHECK: %[[RESULT:.+]] = "emitc.variable"() <{value = 0 : i32}> : () -> !emitc.lvalue<i32>
-    // CHECK-NEXT: %[[RESULT_PTR:.+]] = emitc.apply "&"(%[[RESULT]]) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
-    // CHECK-NEXT: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_compare"(%[[BUFFER_PTR]], %[[C0]], %[[BUFFER_PTR2]], %[[C16]], %[[C16]], %[[RESULT_PTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64, !emitc.ptr<i32>) -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %[[RESULT_PTR:.+]] = apply "&"(%[[RESULT]]) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
+    // CHECK-NEXT: %[[STATUS:.+]] = call_opaque "vm_buffer_compare"(%[[BUFFER_PTR]], %[[C0]], %[[BUFFER_PTR2]], %[[C16]], %[[C16]], %[[RESULT_PTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64, !emitc.ptr<i32>) -> !emitc.opaque<"iree_status_t">
     %c0 = vm.const.i64 0
     %c16 = vm.const.i64 16
     %cmp = vm.buffer.compare %buf, %c0, %buf2, %c16, %c16 : !vm.buffer, !vm.buffer
@@ -100,13 +100,13 @@ vm.module @my_module {
     // CHECK: %[[C0:.+]] = "emitc.constant"() <{value = 0 : i64}> : () -> i64
     // CHECK: %[[C16:.+]] = "emitc.constant"() <{value = 16 : i64}> : () -> i64
 
-    // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK: %[[BUFFER_REF:.+]] = apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
-    // CHECK: %[[BUFFER_REF2:.+]] = emitc.apply "*"(%arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR2:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF2]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK: %[[BUFFER_REF2:.+]] = apply "*"(%arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK-NEXT: %[[BUFFER_PTR2:.+]] = call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF2]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
-    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "iree_vm_buffer_copy_bytes"(%[[BUFFER_PTR]], %[[C0]], %[[BUFFER_PTR2]], %[[C16]], %[[C16]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %[[STATUS:.+]] = call_opaque "iree_vm_buffer_copy_bytes"(%[[BUFFER_PTR]], %[[C0]], %[[BUFFER_PTR2]], %[[C16]], %[[C16]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64) -> !emitc.opaque<"iree_status_t">
     %c0 = vm.const.i64 0
     %c16 = vm.const.i64 16
     vm.buffer.copy %buf, %c0, %buf2, %c16, %c16 : !vm.buffer -> !vm.buffer
@@ -123,10 +123,10 @@ vm.module @my_module {
     // CHECK: %[[C16:.+]] = "emitc.constant"() <{value = 16 : i64}> : () -> i64
     // CHECK: %[[C102:.+]] = "emitc.constant"() <{value = 102 : i32}> : () -> i32
 
-    // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK: %[[BUFFER_REF:.+]] = apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
-    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_fill_i8"(%[[BUFFER_PTR]], %[[C0]], %[[C16]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64, i32) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %[[STATUS:.+]] = call_opaque "vm_buffer_fill_i8"(%[[BUFFER_PTR]], %[[C0]], %[[C16]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64, i32) -> !emitc.opaque<"iree_status_t">
     %c0 = vm.const.i64 0
     %c16 = vm.const.i64 16
     %c102 = vm.const.i32 102
@@ -136,7 +136,7 @@ vm.module @my_module {
 
   // CHECK-LABEL: emitc.func private @my_module_buffer_fill_i16
   vm.func @buffer_fill_i16(%buf : !vm.buffer) {
-    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_fill_i16"
+    // CHECK: %[[STATUS:.+]] = call_opaque "vm_buffer_fill_i16"
     %c0 = vm.const.i64 0
     %c16 = vm.const.i64 16
     %c102 = vm.const.i32 102
@@ -146,7 +146,7 @@ vm.module @my_module {
 
     // CHECK-LABEL: emitc.func private @my_module_buffer_fill_i32
   vm.func @buffer_fill_i32(%buf : !vm.buffer) {
-    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_fill_i32"
+    // CHECK: %[[STATUS:.+]] = call_opaque "vm_buffer_fill_i32"
     %c0 = vm.const.i64 0
     %c16 = vm.const.i64 16
     %c102 = vm.const.i32 102
@@ -162,12 +162,12 @@ vm.module @my_module {
   vm.func @buffer_load_i8s(%buf : !vm.buffer) {
     // CHECK: %[[C0:.+]] = "emitc.constant"() <{value = 0 : i64}> : () -> i64
 
-    // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK: %[[BUFFER_REF:.+]] = apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
     // CHECK: %[[RESULT:.+]] = "emitc.variable"() <{value = 0 : i32}> : () -> !emitc.lvalue<i32>
-    // CHECK-NEXT: %[[RESULT_PTR:.+]] = emitc.apply "&"(%[[RESULT]]) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
-    // CHECK-NEXT: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_load_i8s"(%[[BUFFER_PTR]], %[[C0]], %[[RESULT_PTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, !emitc.ptr<i32>) -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %[[RESULT_PTR:.+]] = apply "&"(%[[RESULT]]) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
+    // CHECK-NEXT: %[[STATUS:.+]] = call_opaque "vm_buffer_load_i8s"(%[[BUFFER_PTR]], %[[C0]], %[[RESULT_PTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, !emitc.ptr<i32>) -> !emitc.opaque<"iree_status_t">
 
     %c0 = vm.const.i64 0
     %v0 = vm.buffer.load.i8.s %buf[%c0] : !vm.buffer -> i32
@@ -176,7 +176,7 @@ vm.module @my_module {
 
   // CHECK-LABEL: emitc.func private @my_module_buffer_load_i8u
   vm.func @buffer_load_i8u(%buf : !vm.buffer) {
-    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_load_i8u"
+    // CHECK: %[[STATUS:.+]] = call_opaque "vm_buffer_load_i8u"
     %c0 = vm.const.i64 0
     %v0 = vm.buffer.load.i8.u %buf[%c0] : !vm.buffer -> i32
     vm.return
@@ -184,7 +184,7 @@ vm.module @my_module {
 
   // CHECK-LABEL: emitc.func private @my_module_buffer_load_i16s
   vm.func @buffer_load_i16s(%buf : !vm.buffer) {
-    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_load_i16s"
+    // CHECK: %[[STATUS:.+]] = call_opaque "vm_buffer_load_i16s"
     %c0 = vm.const.i64 0
     %v0 = vm.buffer.load.i16.s %buf[%c0] : !vm.buffer -> i32
     vm.return
@@ -192,7 +192,7 @@ vm.module @my_module {
 
   // CHECK-LABEL: emitc.func private @my_module_buffer_load_i16u
   vm.func @buffer_load_i16u(%buf : !vm.buffer) {
-    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_load_i16u"
+    // CHECK: %[[STATUS:.+]] = call_opaque "vm_buffer_load_i16u"
     %c0 = vm.const.i64 0
     %v0 = vm.buffer.load.i16.u %buf[%c0] : !vm.buffer -> i32
     vm.return
@@ -200,7 +200,7 @@ vm.module @my_module {
 
   // CHECK-LABEL: emitc.func private @my_module_buffer_load_i32
   vm.func @buffer_load_i32(%buf : !vm.buffer) {
-    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_load_i32"
+    // CHECK: %[[STATUS:.+]] = call_opaque "vm_buffer_load_i32"
     %c0 = vm.const.i64 0
     %v0 = vm.buffer.load.i32 %buf[%c0] : !vm.buffer -> i32
     vm.return
@@ -215,10 +215,10 @@ vm.module @my_module {
     // CHECK: %[[C0:.+]] = "emitc.constant"() <{value = 0 : i64}> : () -> i64
     // CHECK: %[[C102:.+]] = "emitc.constant"() <{value = 102 : i32}> : () -> i32
 
-    // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK: %[[BUFFER_REF:.+]] = apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
-    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_store_i8"(%[[BUFFER_PTR]], %[[C0]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i32) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %[[STATUS:.+]] = call_opaque "vm_buffer_store_i8"(%[[BUFFER_PTR]], %[[C0]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i32) -> !emitc.opaque<"iree_status_t">
     %c0 = vm.const.i64 0
     %c102 = vm.const.i32 102
     vm.buffer.store.i8 %c102, %buf[%c0] : i32 -> !vm.buffer
@@ -227,7 +227,7 @@ vm.module @my_module {
 
   // CHECK-LABEL: emitc.func private @my_module_buffer_store_i16
   vm.func @buffer_store_i16(%buf : !vm.buffer) {
-    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_store_i16"
+    // CHECK: %[[STATUS:.+]] = call_opaque "vm_buffer_store_i16"
     %c0 = vm.const.i64 0
     %c102 = vm.const.i32 102
     vm.buffer.store.i16 %c102, %buf[%c0] : i32 -> !vm.buffer
@@ -236,7 +236,7 @@ vm.module @my_module {
 
     // CHECK-LABEL: emitc.func private @my_module_buffer_store_i32
   vm.func @buffer_store_i32(%buf : !vm.buffer) {
-    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_store_i32"
+    // CHECK: %[[STATUS:.+]] = call_opaque "vm_buffer_store_i32"
     %c0 = vm.const.i64 0
     %c102 = vm.const.i32 102
     vm.buffer.store.i32 %c102, %buf[%c0] : i32 -> !vm.buffer
@@ -249,7 +249,7 @@ vm.module @my_module {
 vm.module @my_module {
   // CHECK-LABEL: emitc.func private @my_module_buffer_hash
   vm.func @buffer_hash(%buf : !vm.buffer) {
-    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "iree_vm_buffer_hash"
+    // CHECK: %[[STATUS:.+]] = call_opaque "iree_vm_buffer_hash"
     %c0 = vm.const.i64 0
     %c10 = vm.const.i64 10
     %v0 = vm.buffer.hash %buf, %c0, %c10 : !vm.buffer -> i64

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/buffer_ops_f32.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/buffer_ops_f32.mlir
@@ -7,10 +7,10 @@ vm.module @my_module {
     // CHECK: %[[C16:.+]] = "emitc.constant"() <{value = 16 : i64}> : () -> i64
     // CHECK: %[[C102:.+]] = "emitc.constant"() <{value = 1.020000e+02 : f32}> : () -> f32
 
-    // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK: %[[BUFFER_REF:.+]] = apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
-    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_fill_f32"(%[[BUFFER_PTR]], %[[C0]], %[[C16]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64, f32) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %[[STATUS:.+]] = call_opaque "vm_buffer_fill_f32"(%[[BUFFER_PTR]], %[[C0]], %[[C16]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64, f32) -> !emitc.opaque<"iree_status_t">
     %c0 = vm.const.i64 0
     %c16 = vm.const.i64 16
     %c102 = vm.const.f32 102.0
@@ -26,12 +26,12 @@ vm.module @my_module {
   vm.func @buffer_load_f32(%buf : !vm.buffer) {
     // CHECK: %[[C0:.+]] = "emitc.constant"() <{value = 0 : i64}> : () -> i64
 
-    // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK: %[[BUFFER_REF:.+]] = apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
     // CHECK: %[[RESULT:.+]] = "emitc.variable"() <{value = 0.000000e+00 : f32}> : () -> !emitc.lvalue<f32>
-    // CHECK-NEXT: %[[RESULT_PTR:.+]] = emitc.apply "&"(%[[RESULT]]) : (!emitc.lvalue<f32>) -> !emitc.ptr<f32>
-    // CHECK-NEXT: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_load_f32"(%[[BUFFER_PTR]], %[[C0]], %[[RESULT_PTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, !emitc.ptr<f32>) -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %[[RESULT_PTR:.+]] = apply "&"(%[[RESULT]]) : (!emitc.lvalue<f32>) -> !emitc.ptr<f32>
+    // CHECK-NEXT: %[[STATUS:.+]] = call_opaque "vm_buffer_load_f32"(%[[BUFFER_PTR]], %[[C0]], %[[RESULT_PTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, !emitc.ptr<f32>) -> !emitc.opaque<"iree_status_t">
 
     %c0 = vm.const.i64 0
     %v0 = vm.buffer.load.f32 %buf[%c0] : !vm.buffer -> f32
@@ -47,10 +47,10 @@ vm.module @my_module {
     // CHECK: %[[C0:.+]] = "emitc.constant"() <{value = 0 : i64}> : () -> i64
     // CHECK: %[[C102:.+]] = "emitc.constant"() <{value = 1.020000e+02 : f32}> : () -> f32
 
-    // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK: %[[BUFFER_REF:.+]] = apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
-    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_store_f32"(%[[BUFFER_PTR]], %[[C0]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, f32) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %[[STATUS:.+]] = call_opaque "vm_buffer_store_f32"(%[[BUFFER_PTR]], %[[C0]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, f32) -> !emitc.opaque<"iree_status_t">
     %c0 = vm.const.i64 0
     %c102 = vm.const.f32 102.0
     vm.buffer.store.f32 %c102, %buf[%c0] : f32 -> !vm.buffer

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/buffer_ops_f64.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/buffer_ops_f64.mlir
@@ -7,10 +7,10 @@ vm.module @my_module {
     // CHECK: %[[C16:.+]] = "emitc.constant"() <{value = 16 : i64}> : () -> i64
     // CHECK: %[[C102:.+]] = "emitc.constant"() <{value = 1.020000e+02 : f64}> : () -> f64
 
-    // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK: %[[BUFFER_REF:.+]] = apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
-    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_fill_f64"(%[[BUFFER_PTR]], %[[C0]], %[[C16]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64, f64) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %[[STATUS:.+]] = call_opaque "vm_buffer_fill_f64"(%[[BUFFER_PTR]], %[[C0]], %[[C16]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64, f64) -> !emitc.opaque<"iree_status_t">
     %c0 = vm.const.i64 0
     %c16 = vm.const.i64 16
     %c102 = vm.const.f64 102.0
@@ -26,12 +26,12 @@ vm.module @my_module {
   vm.func @buffer_load_f64(%buf : !vm.buffer) {
     // CHECK: %[[C0:.+]] = "emitc.constant"() <{value = 0 : i64}> : () -> i64
 
-    // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK: %[[BUFFER_REF:.+]] = apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
     // CHECK: %[[RESULT:.+]] = "emitc.variable"() <{value = 0.000000e+00 : f64}> : () -> !emitc.lvalue<f64>
-    // CHECK-NEXT: %[[RESULT_PTR:.+]] = emitc.apply "&"(%[[RESULT]]) : (!emitc.lvalue<f64>) -> !emitc.ptr<f64>
-    // CHECK-NEXT: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_load_f64"(%[[BUFFER_PTR]], %[[C0]], %[[RESULT_PTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, !emitc.ptr<f64>) -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %[[RESULT_PTR:.+]] = apply "&"(%[[RESULT]]) : (!emitc.lvalue<f64>) -> !emitc.ptr<f64>
+    // CHECK-NEXT: %[[STATUS:.+]] = call_opaque "vm_buffer_load_f64"(%[[BUFFER_PTR]], %[[C0]], %[[RESULT_PTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, !emitc.ptr<f64>) -> !emitc.opaque<"iree_status_t">
 
     %c0 = vm.const.i64 0
     %v0 = vm.buffer.load.f64 %buf[%c0] : !vm.buffer -> f64
@@ -47,10 +47,10 @@ vm.module @my_module {
     // CHECK: %[[C0:.+]] = "emitc.constant"() <{value = 0 : i64}> : () -> i64
     // CHECK: %[[C102:.+]] = "emitc.constant"() <{value = 1.020000e+02 : f64}> : () -> f64
 
-    // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK: %[[BUFFER_REF:.+]] = apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
-    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_store_f64"(%[[BUFFER_PTR]], %[[C0]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, f64) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %[[STATUS:.+]] = call_opaque "vm_buffer_store_f64"(%[[BUFFER_PTR]], %[[C0]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, f64) -> !emitc.opaque<"iree_status_t">
     %c0 = vm.const.i64 0
     %c102 = vm.const.f64 102.0
     vm.buffer.store.f64 %c102, %buf[%c0] : f64 -> !vm.buffer

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/buffer_ops_i64.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/buffer_ops_i64.mlir
@@ -7,10 +7,10 @@ vm.module @my_module {
     // CHECK: %[[C16:.+]] = "emitc.constant"() <{value = 16 : i64}> : () -> i64
     // CHECK: %[[C102:.+]] = "emitc.constant"() <{value = 102 : i64}> : () -> i64
 
-    // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK: %[[BUFFER_REF:.+]] = apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
-    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_fill_i64"(%[[BUFFER_PTR]], %[[C0]], %[[C16]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64, i64) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %[[STATUS:.+]] = call_opaque "vm_buffer_fill_i64"(%[[BUFFER_PTR]], %[[C0]], %[[C16]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64, i64) -> !emitc.opaque<"iree_status_t">
     %c0 = vm.const.i64 0
     %c16 = vm.const.i64 16
     %c102 = vm.const.i64 102
@@ -26,12 +26,12 @@ vm.module @my_module {
   vm.func @buffer_load_i64(%buf : !vm.buffer) {
     // CHECK: %[[C0:.+]] = "emitc.constant"() <{value = 0 : i64}> : () -> i64
 
-    // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK: %[[BUFFER_REF:.+]] = apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
     // CHECK: %[[RESULT:.+]] = "emitc.variable"() <{value = 0 : i64}> : () -> !emitc.lvalue<i64>
-    // CHECK-NEXT: %[[RESULT_PTR:.+]] = emitc.apply "&"(%[[RESULT]]) : (!emitc.lvalue<i64>) -> !emitc.ptr<i64>
-    // CHECK-NEXT: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_load_i64"(%[[BUFFER_PTR]], %[[C0]], %[[RESULT_PTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, !emitc.ptr<i64>) -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %[[RESULT_PTR:.+]] = apply "&"(%[[RESULT]]) : (!emitc.lvalue<i64>) -> !emitc.ptr<i64>
+    // CHECK-NEXT: %[[STATUS:.+]] = call_opaque "vm_buffer_load_i64"(%[[BUFFER_PTR]], %[[C0]], %[[RESULT_PTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, !emitc.ptr<i64>) -> !emitc.opaque<"iree_status_t">
 
     %c0 = vm.const.i64 0
     %v0 = vm.buffer.load.i64 %buf[%c0] : !vm.buffer -> i64
@@ -47,10 +47,10 @@ vm.module @my_module {
     // CHECK: %[[C0:.+]] = "emitc.constant"() <{value = 0 : i64}> : () -> i64
     // CHECK: %[[C102:.+]] = "emitc.constant"() <{value = 102 : i64}> : () -> i64
 
-    // CHECK: %[[BUFFER_REF:.+]] = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = emitc.call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
+    // CHECK: %[[BUFFER_REF:.+]] = apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK-NEXT: %[[BUFFER_PTR:.+]] = call_opaque "iree_vm_buffer_deref"(%[[BUFFER_REF]]) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>
 
-    // CHECK: %[[STATUS:.+]] = emitc.call_opaque "vm_buffer_store_i64"(%[[BUFFER_PTR]], %[[C0]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %[[STATUS:.+]] = call_opaque "vm_buffer_store_i64"(%[[BUFFER_PTR]], %[[C0]], %[[C102]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_buffer_t">>, i64, i64) -> !emitc.opaque<"iree_status_t">
     %c0 = vm.const.i64 0
     %c102 = vm.const.i64 102
     vm.buffer.store.i64 %c102, %buf[%c0] : i64 -> !vm.buffer

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/comparison_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/comparison_ops.mlir
@@ -3,7 +3,7 @@
 vm.module @module {
   // CHECK-LABEL: emitc.func private @module_cmp_eq_i32
   vm.func @cmp_eq_i32(%arg0 : i32, %arg1 : i32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_eq_i32"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK-NEXT: %0 = call_opaque "vm_cmp_eq_i32"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.cmp.eq.i32 %arg0, %arg1 : i32
     vm.return
   }
@@ -14,7 +14,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: emitc.func private @module_cmp_ne_i32
   vm.func @cmp_ne_i32(%arg0 : i32, %arg1 : i32) {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_ne_i32"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK-NEXT: %0 = call_opaque "vm_cmp_ne_i32"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.cmp.ne.i32 %arg0, %arg1 : i32
     vm.return
   }
@@ -25,7 +25,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: emitc.func private @module_cmp_lt_i32_s
   vm.func @cmp_lt_i32_s(%arg0 : i32, %arg1 : i32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_lt_i32s"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK-NEXT: %0 = call_opaque "vm_cmp_lt_i32s"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.cmp.lt.i32.s %arg0, %arg1 : i32
     vm.return
   }
@@ -36,7 +36,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: emitc.func private @module_cmp_lt_i32_u
   vm.func @cmp_lt_i32_u(%arg0 : i32, %arg1 : i32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_lt_i32u"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK-NEXT: %0 = call_opaque "vm_cmp_lt_i32u"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.cmp.lt.i32.u %arg0, %arg1 : i32
     vm.return
   }
@@ -47,7 +47,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: emitc.func private @module_cmp_nz_i32
   vm.func @cmp_nz_i32(%arg0 : i32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_nz_i32"(%arg3) : (i32) -> i32
+    // CHECK-NEXT: %0 = call_opaque "vm_cmp_nz_i32"(%arg3) : (i32) -> i32
     %0 = vm.cmp.nz.i32 %arg0 : i32
     vm.return
   }
@@ -58,7 +58,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: emitc.func private @module_cmp_eq_ref
   vm.func @cmp_eq_ref(%arg0 : !vm.ref<?>, %arg1 : !vm.ref<?>) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_eq_ref"(%arg3, %arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> i32
+    // CHECK-NEXT: %0 = call_opaque "vm_cmp_eq_ref"(%arg3, %arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> i32
     %0 = vm.cmp.eq.ref %arg0, %arg1 : !vm.ref<?>
     vm.return %0 : i32
   }
@@ -69,7 +69,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: emitc.func private @module_cmp_ne_ref
   vm.func @cmp_ne_ref(%arg0 : !vm.ref<?>, %arg1 : !vm.ref<?>) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_ne_ref"(%arg3, %arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> i32
+    // CHECK-NEXT: %0 = call_opaque "vm_cmp_ne_ref"(%arg3, %arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> i32
     %0 = vm.cmp.ne.ref %arg0, %arg1 : !vm.ref<?>
     vm.return %0 : i32
   }
@@ -80,7 +80,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: emitc.func private @module_cmp_nz_ref
   vm.func @cmp_nz_ref(%arg0 : !vm.ref<?>) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_nz_ref"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> i32
+    // CHECK-NEXT: %0 = call_opaque "vm_cmp_nz_ref"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> i32
     %0 = vm.cmp.nz.ref %arg0 : !vm.ref<?>
     vm.return %0 : i32
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/comparison_ops_f32.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/comparison_ops_f32.mlir
@@ -3,7 +3,7 @@
 vm.module @module {
   // CHECK-LABEL: emitc.func private @module_cmp_eq_f32o
   vm.func @cmp_eq_f32o(%arg0 : f32, %arg1 : f32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_eq_f32o"(%arg3, %arg4) : (f32, f32) -> i32
+    // CHECK-NEXT: %0 = call_opaque "vm_cmp_eq_f32o"(%arg3, %arg4) : (f32, f32) -> i32
     %0 = vm.cmp.eq.f32.o %arg0, %arg1 : f32
     vm.return
   }
@@ -14,7 +14,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: emitc.func private @module_cmp_eq_f32u
   vm.func @cmp_eq_f32u(%arg0 : f32, %arg1 : f32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_eq_f32u"(%arg3, %arg4) : (f32, f32) -> i32
+    // CHECK-NEXT: %0 = call_opaque "vm_cmp_eq_f32u"(%arg3, %arg4) : (f32, f32) -> i32
     %0 = vm.cmp.eq.f32.u %arg0, %arg1 : f32
     vm.return
   }
@@ -25,7 +25,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: emitc.func private @module_cmp_ne_f32o
   vm.func @cmp_ne_f32o(%arg0 : f32, %arg1 : f32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_ne_f32o"(%arg3, %arg4) : (f32, f32) -> i32
+    // CHECK-NEXT: %0 = call_opaque "vm_cmp_ne_f32o"(%arg3, %arg4) : (f32, f32) -> i32
     %0 = vm.cmp.ne.f32.o %arg0, %arg1 : f32
     vm.return
   }
@@ -36,7 +36,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: emitc.func private @module_cmp_ne_f32u
   vm.func @cmp_ne_f32u(%arg0 : f32, %arg1 : f32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_ne_f32u"(%arg3, %arg4) : (f32, f32) -> i32
+    // CHECK-NEXT: %0 = call_opaque "vm_cmp_ne_f32u"(%arg3, %arg4) : (f32, f32) -> i32
     %0 = vm.cmp.ne.f32.u %arg0, %arg1 : f32
     vm.return
   }
@@ -47,7 +47,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: emitc.func private @module_cmp_lt_f32o
   vm.func @cmp_lt_f32o(%arg0 : f32, %arg1 : f32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_lt_f32o"(%arg3, %arg4) : (f32, f32) -> i32
+    // CHECK-NEXT: %0 = call_opaque "vm_cmp_lt_f32o"(%arg3, %arg4) : (f32, f32) -> i32
     %0 = vm.cmp.lt.f32.o %arg0, %arg1 : f32
     vm.return
   }
@@ -58,7 +58,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: emitc.func private @module_cmp_lt_f32u
   vm.func @cmp_lt_f32u(%arg0 : f32, %arg1 : f32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_lt_f32u"(%arg3, %arg4) : (f32, f32) -> i32
+    // CHECK-NEXT: %0 = call_opaque "vm_cmp_lt_f32u"(%arg3, %arg4) : (f32, f32) -> i32
     %0 = vm.cmp.lt.f32.u %arg0, %arg1 : f32
     vm.return
   }
@@ -69,7 +69,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: emitc.func private @module_cmp_lte_f32o
   vm.func @cmp_lte_f32o(%arg0 : f32, %arg1 : f32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_lte_f32o"(%arg3, %arg4) : (f32, f32) -> i32
+    // CHECK-NEXT: %0 = call_opaque "vm_cmp_lte_f32o"(%arg3, %arg4) : (f32, f32) -> i32
     %0 = vm.cmp.lte.f32.o %arg0, %arg1 : f32
     vm.return
   }
@@ -80,7 +80,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: emitc.func private @module_cmp_lte_f32u
   vm.func @cmp_lte_f32u(%arg0 : f32, %arg1 : f32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_lte_f32u"(%arg3, %arg4) : (f32, f32) -> i32
+    // CHECK-NEXT: %0 = call_opaque "vm_cmp_lte_f32u"(%arg3, %arg4) : (f32, f32) -> i32
     %0 = vm.cmp.lte.f32.u %arg0, %arg1 : f32
     vm.return
   }
@@ -91,7 +91,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: emitc.func private @module_cmp_nan_f32
   vm.func @cmp_nan_f32(%arg0 : f32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_nan_f32"(%arg3) : (f32) -> i32
+    // CHECK-NEXT: %0 = call_opaque "vm_cmp_nan_f32"(%arg3) : (f32) -> i32
     %0 = vm.cmp.nan.f32 %arg0 : f32
     vm.return
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/comparison_ops_i64.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/comparison_ops_i64.mlir
@@ -3,7 +3,7 @@
 vm.module @module {
   // CHECK-LABEL: emitc.func private @module_cmp_eq_i64
   vm.func @cmp_eq_i64(%arg0 : i64, %arg1 : i64) -> i64 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_eq_i64"(%arg3, %arg4) : (i64, i64) -> i32
+    // CHECK-NEXT: %0 = call_opaque "vm_cmp_eq_i64"(%arg3, %arg4) : (i64, i64) -> i32
     %0 = vm.cmp.eq.i64 %arg0, %arg1 : i64
     vm.return
   }
@@ -14,7 +14,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: emitc.func private @module_cmp_ne_i64
   vm.func @cmp_ne_i64(%arg0 : i64, %arg1 : i64) {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_ne_i64"(%arg3, %arg4) : (i64, i64) -> i32
+    // CHECK-NEXT: %0 = call_opaque "vm_cmp_ne_i64"(%arg3, %arg4) : (i64, i64) -> i32
     %0 = vm.cmp.ne.i64 %arg0, %arg1 : i64
     vm.return
   }
@@ -25,7 +25,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: emitc.func private @module_cmp_lt_i64_s
   vm.func @cmp_lt_i64_s(%arg0 : i64, %arg1 : i64) -> i64 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_lt_i64s"(%arg3, %arg4) : (i64, i64) -> i32
+    // CHECK-NEXT: %0 = call_opaque "vm_cmp_lt_i64s"(%arg3, %arg4) : (i64, i64) -> i32
     %0 = vm.cmp.lt.i64.s %arg0, %arg1 : i64
     vm.return
   }
@@ -36,7 +36,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: emitc.func private @module_cmp_lt_i64_u
   vm.func @cmp_lt_i64_u(%arg0 : i64, %arg1 : i64) -> i64 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_lt_i64u"(%arg3, %arg4) : (i64, i64) -> i32
+    // CHECK-NEXT: %0 = call_opaque "vm_cmp_lt_i64u"(%arg3, %arg4) : (i64, i64) -> i32
     %0 = vm.cmp.lt.i64.u %arg0, %arg1 : i64
     vm.return
   }
@@ -47,7 +47,7 @@ vm.module @module {
 vm.module @module {
   // CHECK-LABEL: emitc.func private @module_cmp_nz_i64
   vm.func @cmp_nz_i64(%arg0 : i64) -> i64 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cmp_nz_i64"(%arg3) : (i64) -> i32
+    // CHECK-NEXT: %0 = call_opaque "vm_cmp_nz_i64"(%arg3) : (i64) -> i32
     %0 = vm.cmp.nz.i64 %arg0 : i64
     vm.return
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/const_ops.mlir
@@ -31,10 +31,10 @@ vm.module @my_module {
   // CHECK-LABEL: emitc.func private @my_module_const_ref_zero
   vm.func @const_ref_zero() {
     // CHECK: %[[REF:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.opaque<"iree_vm_ref_t">>
-    // CHECK-NEXT: %[[REFPTR:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.lvalue<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
-    // CHECK-NEXT: %[[SIZE:.+]] = emitc.call_opaque "sizeof"() {args = [!emitc.opaque<"iree_vm_ref_t">]} : () -> !emitc.opaque<"iree_host_size_t">
-    // CHECK-NEXT: emitc.call_opaque "memset"(%[[REFPTR]], %[[SIZE]]) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.opaque<"iree_host_size_t">) -> ()
-    // CHECK-NEXT: emitc.call_opaque "iree_vm_ref_release"(%[[REFPTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> ()
+    // CHECK-NEXT: %[[REFPTR:.+]] = apply "&"(%[[REF]]) : (!emitc.lvalue<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
+    // CHECK-NEXT: %[[SIZE:.+]] = call_opaque "sizeof"() {args = [!emitc.opaque<"iree_vm_ref_t">]} : () -> !emitc.opaque<"iree_host_size_t">
+    // CHECK-NEXT: call_opaque "memset"(%[[REFPTR]], %[[SIZE]]) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.opaque<"iree_host_size_t">) -> ()
+    // CHECK-NEXT: call_opaque "iree_vm_ref_release"(%[[REFPTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> ()
     %null = vm.const.ref.zero : !vm.ref<?>
     vm.return
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/control_flow_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/control_flow_ops.mlir
@@ -68,19 +68,19 @@ vm.module @my_module {
 
     // Lookup import from module struct.
     // CHECK-NEXT: %[[STATE_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
-    // CHECK-NEXT: emitc.assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
+    // CHECK-NEXT: assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
     // CHECK-NEXT: %[[IMPORTS_LVAL:.+]] = "emitc.member_of_ptr"(%[[STATE_LVAL]]) <{member = "imports"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>) -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
-    // CHECK-NEXT: %[[IMPORTS:.+]] = emitc.load %[[IMPORTS_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
-    // CHECK-NEXT: %[[IMPORT_INDEX:.+]] = emitc.literal "0" : !emitc.opaque<"iree_host_size_t">
-    // CHECK-NEXT: %[[IMPORT_SUBSCRIPT:.+]] = emitc.subscript %[[IMPORTS]][%[[IMPORT_INDEX]]] : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>, !emitc.opaque<"iree_host_size_t">) -> !emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>
-    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.apply "&"(%[[IMPORT_SUBSCRIPT]]) : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[IMPORTS:.+]] = load %[[IMPORTS_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
+    // CHECK-NEXT: %[[IMPORT_INDEX:.+]] = literal "0" : !emitc.opaque<"iree_host_size_t">
+    // CHECK-NEXT: %[[IMPORT_SUBSCRIPT:.+]] = subscript %[[IMPORTS]][%[[IMPORT_INDEX]]] : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>, !emitc.opaque<"iree_host_size_t">) -> !emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[IMPORT:.+]] = apply "&"(%[[IMPORT_SUBSCRIPT]]) : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
 
     // Create a variable for the function result.
     // CHECK-NEXT: %[[RESULT:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<i32>
-    // CHECK-NEXT: %[[RESPTR:.+]] = emitc.apply "&"(%[[RESULT]]) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
+    // CHECK-NEXT: %[[RESPTR:.+]] = apply "&"(%[[RESULT]]) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
 
     // Call the function created by the vm.import conversion.
-    // CHECK-NEXT: %{{.+}} = emitc.call @my_module_call_[[IMPORTFN]](%arg0, %[[IMPORT]], %arg3, %[[RESPTR]])
+    // CHECK-NEXT: %{{.+}} = call @my_module_call_[[IMPORTFN]](%arg0, %[[IMPORT]], %arg3, %[[RESPTR]])
     // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_stack_t">>, !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>, i32, !emitc.ptr<i32>)
     // CHECK-SAME:     -> !emitc.opaque<"iree_status_t">
     %0 = vm.call @imported_fn(%arg0) : (i32) -> i32
@@ -97,19 +97,19 @@ vm.module @my_module {
 
     // Lookup import from module struct.
     // CHECK-NEXT: %[[STATE_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
-    // CHECK-NEXT: emitc.assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
+    // CHECK-NEXT: assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
     // CHECK-NEXT: %[[IMPORTS_LVAL:.+]] = "emitc.member_of_ptr"(%[[STATE_LVAL]]) <{member = "imports"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>) -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
-    // CHECK-NEXT: %[[IMPORTS:.+]] = emitc.load %[[IMPORTS_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
-    // CHECK-NEXT: %[[IMPORT_INDEX:.+]] = emitc.literal "0" : !emitc.opaque<"iree_host_size_t">
-    // CHECK-NEXT: %[[IMPORT_SUBSCRIPT:.+]] = emitc.subscript %[[IMPORTS]][%[[IMPORT_INDEX]]] : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>, !emitc.opaque<"iree_host_size_t">) -> !emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>
-    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.apply "&"(%[[IMPORT_SUBSCRIPT]]) : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[IMPORTS:.+]] = load %[[IMPORTS_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
+    // CHECK-NEXT: %[[IMPORT_INDEX:.+]] = literal "0" : !emitc.opaque<"iree_host_size_t">
+    // CHECK-NEXT: %[[IMPORT_SUBSCRIPT:.+]] = subscript %[[IMPORTS]][%[[IMPORT_INDEX]]] : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>, !emitc.opaque<"iree_host_size_t">) -> !emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[IMPORT:.+]] = apply "&"(%[[IMPORT_SUBSCRIPT]]) : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
 
     // Create a variable for the function result.
     // CHECK-NEXT: %[[RESULT:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<i32>
-    // CHECK-NEXT: %[[RESPTR:.+]] = emitc.apply "&"(%[[RESULT]]) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
+    // CHECK-NEXT: %[[RESPTR:.+]] = apply "&"(%[[RESULT]]) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
 
     // Call the function created by the vm.import conversion.
-    // CHECK-NEXT: %{{.+}} = emitc.call @my_module_call_[[IMPORTFN:[^\(]+]](%arg0, %[[IMPORT]], %arg3, %[[RESPTR]])
+    // CHECK-NEXT: %{{.+}} = call @my_module_call_[[IMPORTFN:[^\(]+]](%arg0, %[[IMPORT]], %arg3, %[[RESPTR]])
     // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_stack_t">>, !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>, i32, !emitc.ptr<i32>)
     // CHECK-SAME:     -> !emitc.opaque<"iree_status_t">
     %0 = vm.call @imported_fn(%arg0) : (i32) -> i32
@@ -133,10 +133,10 @@ vm.module @my_module {
 
     // Create a variable for the result.
     // CHECK-NEXT: %[[RESULT:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<i32>
-    // CHECK-NEXT: %[[RESPTR:.+]] = emitc.apply "&"(%[[RESULT]]) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
+    // CHECK-NEXT: %[[RESPTR:.+]] = apply "&"(%[[RESULT]]) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
 
     // Call the function created by the vm.import conversion.
-    // CHECK-NEXT: %{{.+}} = emitc.call @my_module_internal_fn(%arg0, %arg1, %arg2, %arg3, %[[RESPTR]])
+    // CHECK-NEXT: %{{.+}} = call @my_module_internal_fn(%arg0, %arg1, %arg2, %arg3, %[[RESPTR]])
     // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_stack_t">>, !emitc.ptr<!emitc.opaque<"struct my_module_t">>,
     // CHECK-SAME:        !emitc.ptr<!emitc.opaque<"struct my_module_state_t">>, i32, !emitc.ptr<i32>)
     // CHECK-SAME:     -> !emitc.opaque<"iree_status_t">
@@ -157,22 +157,22 @@ vm.module @my_module {
 
     // Lookup import from module struct.
     // CHECK-NEXT: %[[STATE_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
-    // CHECK-NEXT: emitc.assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
+    // CHECK-NEXT: assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
     // CHECK-NEXT: %[[IMPORTS_LVAL:.+]] = "emitc.member_of_ptr"(%[[STATE_LVAL]]) <{member = "imports"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>) -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
-    // CHECK-NEXT: %[[IMPORTS:.+]] = emitc.load %[[IMPORTS_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
-    // CHECK-NEXT: %[[IMPORT_INDEX:.+]] = emitc.literal "0" : !emitc.opaque<"iree_host_size_t">
-    // CHECK-NEXT: %[[IMPORT_SUBSCRIPT:.+]] = emitc.subscript %[[IMPORTS]][%[[IMPORT_INDEX]]] : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>, !emitc.opaque<"iree_host_size_t">) -> !emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>
-    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.apply "&"(%[[IMPORT_SUBSCRIPT]]) : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[IMPORTS:.+]] = load %[[IMPORTS_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
+    // CHECK-NEXT: %[[IMPORT_INDEX:.+]] = literal "0" : !emitc.opaque<"iree_host_size_t">
+    // CHECK-NEXT: %[[IMPORT_SUBSCRIPT:.+]] = subscript %[[IMPORTS]][%[[IMPORT_INDEX]]] : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>, !emitc.opaque<"iree_host_size_t">) -> !emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[IMPORT:.+]] = apply "&"(%[[IMPORT_SUBSCRIPT]]) : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
 
     // This holds the number of variadic arguments.
     // CHECK-NEXT: %[[NARGS:.+]] = "emitc.constant"() <{value = 2 : i32}> : () -> i32
 
     // Create a variable for the result.
     // CHECK-NEXT: %[[RESULT:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<i32>
-    // CHECK-NEXT: %[[RESPTR:.+]] = emitc.apply "&"(%[[RESULT]]) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
+    // CHECK-NEXT: %[[RESPTR:.+]] = apply "&"(%[[RESULT]]) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
 
     // Call the function created by the vm.import conversion.
-    // CHECK-NEXT: %{{.+}} = emitc.call @my_module_call_[[VARIADICFN]](%arg0, %[[IMPORT]], %[[NARGS]], %arg3, %arg4, %[[RESPTR]])
+    // CHECK-NEXT: %{{.+}} = call @my_module_call_[[VARIADICFN]](%arg0, %[[IMPORT]], %[[NARGS]], %arg3, %arg4, %[[RESPTR]])
     // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_stack_t">>, !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>,
     // CHECK-SAME:        i32, i32, i32, !emitc.ptr<i32>)
     // CHECK-SAME:     -> !emitc.opaque<"iree_status_t">
@@ -193,22 +193,22 @@ vm.module @my_module {
 
     // Lookup import from module struct.
     // CHECK-NEXT: %[[STATE_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
-    // CHECK-NEXT: emitc.assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
+    // CHECK-NEXT: assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
     // CHECK-NEXT: %[[IMPORTS_LVAL:.+]] = "emitc.member_of_ptr"(%[[STATE_LVAL]]) <{member = "imports"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>) -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
-    // CHECK-NEXT: %[[IMPORTS:.+]] = emitc.load %[[IMPORTS_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
-    // CHECK-NEXT: %[[IMPORT_INDEX:.+]] = emitc.literal "0" : !emitc.opaque<"iree_host_size_t">
-    // CHECK-NEXT: %[[IMPORT_SUBSCRIPT:.+]] = emitc.subscript %[[IMPORTS]][%[[IMPORT_INDEX]]] : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>, !emitc.opaque<"iree_host_size_t">) -> !emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>
-    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.apply "&"(%[[IMPORT_SUBSCRIPT]]) : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[IMPORTS:.+]] = load %[[IMPORTS_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
+    // CHECK-NEXT: %[[IMPORT_INDEX:.+]] = literal "0" : !emitc.opaque<"iree_host_size_t">
+    // CHECK-NEXT: %[[IMPORT_SUBSCRIPT:.+]] = subscript %[[IMPORTS]][%[[IMPORT_INDEX]]] : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>, !emitc.opaque<"iree_host_size_t">) -> !emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[IMPORT:.+]] = apply "&"(%[[IMPORT_SUBSCRIPT]]) : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
 
     // This holds the number of variadic arguments.
     // CHECK-NEXT: %[[NARGS:.+]] = "emitc.constant"() <{value = 0 : i32}> : () -> i32
 
     // Create a variable for the result.
     // CHECK-NEXT: %[[RESULT:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<i32>
-    // CHECK-NEXT: %[[RESPTR:.+]] = emitc.apply "&"(%[[RESULT]]) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
+    // CHECK-NEXT: %[[RESPTR:.+]] = apply "&"(%[[RESULT]]) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
 
     // Call the function created by the vm.import conversion.
-    // CHECK-NEXT: %{{.+}} = emitc.call @my_module_call_[[VARIADICFN]](%arg0, %[[IMPORT]], %[[NARGS]], %[[RESPTR]])
+    // CHECK-NEXT: %{{.+}} = call @my_module_call_[[VARIADICFN]](%arg0, %[[IMPORT]], %[[NARGS]], %[[RESPTR]])
     // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_stack_t">>, !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>,
     // CHECK-SAME:        i32, !emitc.ptr<i32>)
     // CHECK-SAME:     -> !emitc.opaque<"iree_status_t">
@@ -318,12 +318,12 @@ vm.module @my_module {
     //  CHECK-NOT: vm.br_table
     //      CHECK:  cf.br ^bb1
     // CHECK-NEXT: ^bb1:
-    //      CHECK:  emitc.call_opaque "vm_cmp_eq_i32"
-    //      CHECK:  emitc.call_opaque "vm_cmp_nz_i32"
+    //      CHECK:  call_opaque "vm_cmp_eq_i32"
+    //      CHECK:  call_opaque "vm_cmp_nz_i32"
     //      CHECK:  cf.cond_br %{{.+}}, ^bb5(%arg4 : i32), ^bb2
     //      CHECK: ^bb2:
-    //      CHECK:  emitc.call_opaque "vm_cmp_eq_i32"
-    //      CHECK:  emitc.call_opaque "vm_cmp_nz_i32"
+    //      CHECK:  call_opaque "vm_cmp_eq_i32"
+    //      CHECK:  call_opaque "vm_cmp_nz_i32"
     //      CHECK:  cf.cond_br %{{.+}}, ^bb5(%arg5 : i32), ^bb3
     //      CHECK: ^bb3:
     //      CHECK:  cf.br ^bb4(%arg3 : i32)
@@ -346,26 +346,26 @@ vm.module @my_module {
   vm.func @fail(%arg0 : i32) {
 
     // Typecast the argument to fail and branch respectively.
-    // CHECK-NEXT: %[[COND:.+]] = emitc.cast %arg3 : i32 to i1
+    // CHECK-NEXT: %[[COND:.+]] = cast %arg3 : i32 to i1
     // CHECK-NEXT: cf.cond_br %[[COND]], ^[[FAIL:.+]], ^[[OK:.+]]
 
     // In case of success, return ok status.
     // CHECK-NEXT: ^[[OK]]:
-    // CHECK-NEXT: %[[OKSTATUS:.+]] = emitc.call_opaque "iree_ok_status"() : () -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %[[OKSTATUS:.+]] = call_opaque "iree_ok_status"() : () -> !emitc.opaque<"iree_status_t">
     // CHECK-NEXT: return %[[OKSTATUS]] : !emitc.opaque<"iree_status_t">
 
     // In case of fail, return status message.
     // CHECK-NEXT: ^[[FAIL]]:
-    // CHECK-NEXT: %[[MSG:.+]] = emitc.call_opaque "iree_make_cstring_view"() {args = [#emitc.opaque<"\22message\22">]}
+    // CHECK-NEXT: %[[MSG:.+]] = call_opaque "iree_make_cstring_view"() {args = [#emitc.opaque<"\22message\22">]}
     // CHECK-SAME:     : () -> !emitc.opaque<"iree_string_view_t">
     // CHECK-NEXT: %[[MSG_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.opaque<"iree_string_view_t">>
-    // CHECK-NEXT: emitc.assign %[[MSG]] : !emitc.opaque<"iree_string_view_t"> to %[[MSG_LVAL]] : <!emitc.opaque<"iree_string_view_t">>
+    // CHECK-NEXT: assign %[[MSG]] : !emitc.opaque<"iree_string_view_t"> to %[[MSG_LVAL]] : <!emitc.opaque<"iree_string_view_t">>
     // CHECK-NEXT: %[[MSGSIZE_LVAL:.+]] = "emitc.member"(%[[MSG_LVAL]]) <{member = "size"}> : (!emitc.lvalue<!emitc.opaque<"iree_string_view_t">>) -> !emitc.lvalue<!emitc.opaque<"iree_host_size_t">>
-    // CHECK-NEXT: %[[MSGSIZE:.+]] = emitc.load %[[MSGSIZE_LVAL]] : <!emitc.opaque<"iree_host_size_t">>
-    // CHECK-NEXT: %[[MSGSIZEINT:.+]] = emitc.cast %[[MSGSIZE]] : !emitc.opaque<"iree_host_size_t"> to !emitc.opaque<"int">
+    // CHECK-NEXT: %[[MSGSIZE:.+]] = load %[[MSGSIZE_LVAL]] : <!emitc.opaque<"iree_host_size_t">>
+    // CHECK-NEXT: %[[MSGSIZEINT:.+]] = cast %[[MSGSIZE]] : !emitc.opaque<"iree_host_size_t"> to !emitc.opaque<"int">
     // CHECK-NEXT: %[[MSGDATA_LVAL:.+]] = "emitc.member"(%[[MSG_LVAL]]) <{member = "data"}> : (!emitc.lvalue<!emitc.opaque<"iree_string_view_t">>) -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"const char">>>
-    // CHECK-NEXT: %[[MSGDATA:.+]] = emitc.load %[[MSGDATA_LVAL]] : <!emitc.ptr<!emitc.opaque<"const char">>>
-    // CHECK-NEXT: %[[FAILSTATUS:.+]] = emitc.call_opaque "iree_status_allocate_f"(%[[MSGSIZEINT]], %[[MSGDATA]])
+    // CHECK-NEXT: %[[MSGDATA:.+]] = load %[[MSGDATA_LVAL]] : <!emitc.ptr<!emitc.opaque<"const char">>>
+    // CHECK-NEXT: %[[FAILSTATUS:.+]] = call_opaque "iree_status_allocate_f"(%[[MSGSIZEINT]], %[[MSGDATA]])
     // CHECK-SAME:     {args = [#emitc.opaque<"IREE_STATUS_FAILED_PRECONDITION">, #emitc.opaque<"\22<vm>\22">, 0 : i32, #emitc.opaque<"\22%.*s\22">, 0 : index, 1 : index]}
     // CHECK-SAME:     : (!emitc.opaque<"int">, !emitc.ptr<!emitc.opaque<"const char">>) -> !emitc.opaque<"iree_status_t">
     // CHECK-NEXT: return %[[FAILSTATUS]] : !emitc.opaque<"iree_status_t">
@@ -388,37 +388,37 @@ vm.module @my_module {
   // CHECK-NEXT: %[[RESULTSIZE:.+]] = "emitc.constant"() <{value = #emitc.opaque<"0">}> : () -> !emitc.opaque<"iree_host_size_t">
 
   // CHECK-NEXT: %[[FUNC_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
-  // CHECK-NEXT: emitc.assign %arg1 : !emitc.ptr<!emitc.opaque<"iree_vm_function_t">> to %[[FUNC_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
+  // CHECK-NEXT: assign %arg1 : !emitc.ptr<!emitc.opaque<"iree_vm_function_t">> to %[[FUNC_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
 
   // Create a struct for the arguments and results.
   // CHECK: %[[ARGSTRUCT:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.opaque<"iree_vm_function_call_t">>
-  // CHECK-NEXT: %[[ARGSTRUCTFN:.+]] = emitc.apply "*"(%arg1) : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.opaque<"iree_vm_function_t">
+  // CHECK-NEXT: %[[ARGSTRUCTFN:.+]] = apply "*"(%arg1) : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.opaque<"iree_vm_function_t">
   // CHECK-NEXT: %[[ARGSTRUCTFN_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "function"}> : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_call_t">>) -> !emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>
-  // CHECK-NEXT: emitc.assign %[[ARGSTRUCTFN]] : !emitc.opaque<"iree_vm_function_t"> to %[[ARGSTRUCTFN_MEMBER]] : <!emitc.opaque<"iree_vm_function_t">>
+  // CHECK-NEXT: assign %[[ARGSTRUCTFN]] : !emitc.opaque<"iree_vm_function_t"> to %[[ARGSTRUCTFN_MEMBER]] : <!emitc.opaque<"iree_vm_function_t">>
 
   // Allocate space for the arguments.
   // CHECK-NEXT: %[[ARGBYTESPAN_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "arguments"}> : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_call_t">>) -> !emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>
   // alloca_(0) can return NULL on Windows. So we always allocate at least one byte
   // CHECK-NEXT: %[[ARGALLOCASIZE:.+]] = "emitc.constant"() <{value = #emitc.opaque<"1">}> : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[ARGBYTESPANDATAVOID:.+]] = emitc.call_opaque "iree_alloca"(%[[ARGALLOCASIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
-  // CHECK-NEXT: %[[ARGBYTESPANDATA:.+]] = emitc.cast %[[ARGBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
+  // CHECK-NEXT: %[[ARGBYTESPANDATAVOID:.+]] = call_opaque "iree_alloca"(%[[ARGALLOCASIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
+  // CHECK-NEXT: %[[ARGBYTESPANDATA:.+]] = cast %[[ARGBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
   // CHECK-NEXT: %[[ARGSDATALENGTH:.+]] = "emitc.member"(%[[ARGBYTESPAN_MEMBER]]) <{member = "data_length"}> : (!emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.lvalue<!emitc.opaque<"iree_host_size_t">>
-  // CHECK-NEXT: emitc.assign %[[ARGSIZE]] : !emitc.opaque<"iree_host_size_t"> to %[[ARGSDATALENGTH]] : <!emitc.opaque<"iree_host_size_t">>
+  // CHECK-NEXT: assign %[[ARGSIZE]] : !emitc.opaque<"iree_host_size_t"> to %[[ARGSDATALENGTH]] : <!emitc.opaque<"iree_host_size_t">>
   // CHECK-NEXT: %[[ARGSDATA:.+]] = "emitc.member"(%[[ARGBYTESPAN_MEMBER]]) <{member = "data"}> : (!emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.lvalue<!emitc.ptr<ui8>>
-  // CHECK-NEXT: emitc.assign %[[ARGBYTESPANDATA]] : !emitc.ptr<ui8> to %[[ARGSDATA]] : <!emitc.ptr<ui8>>
-  // CHECK-NEXT: emitc.call_opaque "memset"(%[[ARGBYTESPANDATA]], %[[ARGALLOCASIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
+  // CHECK-NEXT: assign %[[ARGBYTESPANDATA]] : !emitc.ptr<ui8> to %[[ARGSDATA]] : <!emitc.ptr<ui8>>
+  // CHECK-NEXT: call_opaque "memset"(%[[ARGBYTESPANDATA]], %[[ARGALLOCASIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
 
   // Allocate space for the result.
   // CHECK-NEXT: %[[RESBYTESPAN_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "results"}> : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_call_t">>) -> !emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>
   // alloca_(0) can return NULL on Windows. So we always allocate at least one byte
   // CHECK-NEXT: %[[RESALLOCASIZE:.+]] = "emitc.constant"() <{value = #emitc.opaque<"1">}> : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[RESBYTESPANDATAVOID:.+]] = emitc.call_opaque "iree_alloca"(%[[RESALLOCASIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
-  // CHECK-NEXT: %[[RESBYTESPANDATA:.+]] = emitc.cast %[[RESBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
+  // CHECK-NEXT: %[[RESBYTESPANDATAVOID:.+]] = call_opaque "iree_alloca"(%[[RESALLOCASIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
+  // CHECK-NEXT: %[[RESBYTESPANDATA:.+]] = cast %[[RESBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
   // CHECK-NEXT: %[[RESSDATALENGTH:.+]] = "emitc.member"(%[[RESBYTESPAN_MEMBER]]) <{member = "data_length"}> : (!emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.lvalue<!emitc.opaque<"iree_host_size_t">>
-  // CHECK-NEXT: emitc.assign %[[RESULTSIZE]] : !emitc.opaque<"iree_host_size_t"> to %[[RESSDATALENGTH]] : <!emitc.opaque<"iree_host_size_t">>
+  // CHECK-NEXT: assign %[[RESULTSIZE]] : !emitc.opaque<"iree_host_size_t"> to %[[RESSDATALENGTH]] : <!emitc.opaque<"iree_host_size_t">>
   // CHECK-NEXT: %[[RESSDATA:.+]] = "emitc.member"(%[[RESBYTESPAN_MEMBER]]) <{member = "data"}> : (!emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.lvalue<!emitc.ptr<ui8>>
-  // CHECK-NEXT: emitc.assign %[[RESBYTESPANDATA]] : !emitc.ptr<ui8> to %[[RESSDATA]] : <!emitc.ptr<ui8>>
-  // CHECK-NEXT: emitc.call_opaque "memset"(%[[RESBYTESPANDATA]], %[[RESALLOCASIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
+  // CHECK-NEXT: assign %[[RESBYTESPANDATA]] : !emitc.ptr<ui8> to %[[RESSDATA]] : <!emitc.ptr<ui8>>
+  // CHECK-NEXT: call_opaque "memset"(%[[RESBYTESPANDATA]], %[[RESALLOCASIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
 
   // Check that we don't pack anything into the argument struct.
   // CHECK-NOT: "emitc.member"(%{{.+}}) <{member = "arguments"}>
@@ -427,17 +427,17 @@ vm.module @my_module {
   // Create the call to the imported function.
   // CHECK-NEXT: %[[MODULE_LVAL:.+]] = "emitc.member_of_ptr"(%[[FUNC_LVAL]]) <{member = "module"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>) -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_module_t">>>
   // CHECK-NEXT: %[[BEGIN_CALL_LVAL:.+]] = "emitc.member_of_ptr"(%[[MODULE_LVAL]]) <{member = "begin_call"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_module_t">>>) -> !emitc.lvalue<!emitc.opaque<"begin_call_t">>
-  // CHECK-NEXT: %[[BEGIN_CALL:.+]] = emitc.load %[[BEGIN_CALL_LVAL]] : <!emitc.opaque<"begin_call_t">>
-  // CHECK-NEXT: %[[MODULE:.+]] = emitc.load %[[MODULE_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_module_t">>>
-  // CHECK-NEXT: %[[ARGSTRUCT_RVAL:.+]] = emitc.load %[[ARGSTRUCT]] : <!emitc.opaque<"iree_vm_function_call_t">>
-  // CHECK-NEXT: %{{.+}} = emitc.call_opaque "EMITC_CALL_INDIRECT"(%[[BEGIN_CALL]], %[[MODULE]], %arg0, %[[ARGSTRUCT_RVAL]])
+  // CHECK-NEXT: %[[BEGIN_CALL:.+]] = load %[[BEGIN_CALL_LVAL]] : <!emitc.opaque<"begin_call_t">>
+  // CHECK-NEXT: %[[MODULE:.+]] = load %[[MODULE_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_module_t">>>
+  // CHECK-NEXT: %[[ARGSTRUCT_RVAL:.+]] = load %[[ARGSTRUCT]] : <!emitc.opaque<"iree_vm_function_call_t">>
+  // CHECK-NEXT: %{{.+}} = call_opaque "EMITC_CALL_INDIRECT"(%[[BEGIN_CALL]], %[[MODULE]], %arg0, %[[ARGSTRUCT_RVAL]])
 
   // Check that we don't unpack anything from the result struct.
   // CHECK-NOT: "emitc.member"(%[[ARGSTRUCT]]) <{member = "results"}>
   // CHECK-NOT: "emitc.member"(%{{.+}}) <{member = "data"}>
 
   // Return ok status.
-  //      CHECK: %[[OK:.+]] = emitc.call_opaque "iree_ok_status"()
+  //      CHECK: %[[OK:.+]] = call_opaque "iree_ok_status"()
   // CHECK-NEXT: return %[[OK]]
   vm.import private @ref_fn() -> ()
 
@@ -458,106 +458,106 @@ vm.module @my_module {
 
   // Calculate the size of the arguments.
   // CHECK-NEXT: %[[ARGSIZE0:.+]] = "emitc.constant"() <{value = #emitc.opaque<"0">}> : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[ARGSIZE1:.+]] = emitc.call_opaque "sizeof"() {args = [i32]}
-  // CHECK-NEXT: %[[ARGSIZE01:.+]] = emitc.add %[[ARGSIZE0]], %[[ARGSIZE1]]
+  // CHECK-NEXT: %[[ARGSIZE1:.+]] = call_opaque "sizeof"() {args = [i32]}
+  // CHECK-NEXT: %[[ARGSIZE01:.+]] = add %[[ARGSIZE0]], %[[ARGSIZE1]]
   // CHECK-SAME:     : (!emitc.opaque<"iree_host_size_t">, !emitc.opaque<"iree_host_size_t">) -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[ARGSIZE2:.+]] = emitc.call_opaque "sizeof"() {args = [i32]}
-  // CHECK-NEXT: %[[ARGSIZE012:.+]] = emitc.add %[[ARGSIZE01]], %[[ARGSIZE2]]
+  // CHECK-NEXT: %[[ARGSIZE2:.+]] = call_opaque "sizeof"() {args = [i32]}
+  // CHECK-NEXT: %[[ARGSIZE012:.+]] = add %[[ARGSIZE01]], %[[ARGSIZE2]]
   // CHECK-SAME:     : (!emitc.opaque<"iree_host_size_t">, !emitc.opaque<"iree_host_size_t">) -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[ARGSIZE3:.+]] = emitc.call_opaque "sizeof"() {args = [i32]}
-  // CHECK-NEXT: %[[ARGSIZE0123:.+]] = emitc.add %[[ARGSIZE012]], %[[ARGSIZE3]]
+  // CHECK-NEXT: %[[ARGSIZE3:.+]] = call_opaque "sizeof"() {args = [i32]}
+  // CHECK-NEXT: %[[ARGSIZE0123:.+]] = add %[[ARGSIZE012]], %[[ARGSIZE3]]
   // CHECK-SAME:     : (!emitc.opaque<"iree_host_size_t">, !emitc.opaque<"iree_host_size_t">) -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[ARGSIZE4:.+]] = emitc.call_opaque "sizeof"() {args = [i32]}
-  // CHECK-NEXT: %[[ARGSIZE:.+]] = emitc.add %[[ARGSIZE0123]], %[[ARGSIZE4]]
+  // CHECK-NEXT: %[[ARGSIZE4:.+]] = call_opaque "sizeof"() {args = [i32]}
+  // CHECK-NEXT: %[[ARGSIZE:.+]] = add %[[ARGSIZE0123]], %[[ARGSIZE4]]
   // CHECK-SAME:     : (!emitc.opaque<"iree_host_size_t">, !emitc.opaque<"iree_host_size_t">) -> !emitc.opaque<"iree_host_size_t">
 
   // Calculate the size of the result.
   // CHECK-NEXT: %[[RESULTSIZE0:.+]] = "emitc.constant"() <{value = #emitc.opaque<"0">}> : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[RESULTSIZE1:.+]] = emitc.call_opaque "sizeof"() {args = [i32]}
-  // CHECK-NEXT: %[[RESULTSIZE:.+]] = emitc.add %[[RESULTSIZE0]], %[[RESULTSIZE1]]
+  // CHECK-NEXT: %[[RESULTSIZE1:.+]] = call_opaque "sizeof"() {args = [i32]}
+  // CHECK-NEXT: %[[RESULTSIZE:.+]] = add %[[RESULTSIZE0]], %[[RESULTSIZE1]]
   // CHECK-SAME:     : (!emitc.opaque<"iree_host_size_t">, !emitc.opaque<"iree_host_size_t">) -> !emitc.opaque<"iree_host_size_t">
 
   // CHECK-NEXT: %[[FUNC_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
-  // CHECK-NEXT: emitc.assign %arg1 : !emitc.ptr<!emitc.opaque<"iree_vm_function_t">> to %[[FUNC_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
+  // CHECK-NEXT: assign %arg1 : !emitc.ptr<!emitc.opaque<"iree_vm_function_t">> to %[[FUNC_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
 
   // Create a struct for the arguments and results.
   // CHECK: %[[ARGSTRUCT:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.opaque<"iree_vm_function_call_t">>
-  // CHECK-NEXT: %[[ARGSTRUCTFN:.+]] = emitc.apply "*"(%arg1) : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.opaque<"iree_vm_function_t">
+  // CHECK-NEXT: %[[ARGSTRUCTFN:.+]] = apply "*"(%arg1) : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.opaque<"iree_vm_function_t">
   // CHECK-NEXT: %[[ARGSTRUCTFN_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "function"}> : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_call_t">>) -> !emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>
-  // CHECK-NEXT: emitc.assign %[[ARGSTRUCTFN]] : !emitc.opaque<"iree_vm_function_t"> to %[[ARGSTRUCTFN_MEMBER]] : <!emitc.opaque<"iree_vm_function_t">>
+  // CHECK-NEXT: assign %[[ARGSTRUCTFN]] : !emitc.opaque<"iree_vm_function_t"> to %[[ARGSTRUCTFN_MEMBER]] : <!emitc.opaque<"iree_vm_function_t">>
 
   // Allocate space for the arguments.
   // CHECK-NEXT: %[[ARGBYTESPAN_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "arguments"}> : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_call_t">>) -> !emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>
-  // CHECK-NEXT: %[[ARGBYTESPANDATAVOID:.+]] = emitc.call_opaque "iree_alloca"(%[[ARGSIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
-  // CHECK-NEXT: %[[ARGBYTESPANDATA:.+]] = emitc.cast %[[ARGBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
+  // CHECK-NEXT: %[[ARGBYTESPANDATAVOID:.+]] = call_opaque "iree_alloca"(%[[ARGSIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
+  // CHECK-NEXT: %[[ARGBYTESPANDATA:.+]] = cast %[[ARGBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
   // CHECK-NEXT: %[[ARGSDATALENGTH:.+]] = "emitc.member"(%[[ARGBYTESPAN_MEMBER]]) <{member = "data_length"}> : (!emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.lvalue<!emitc.opaque<"iree_host_size_t">>
-  // CHECK-NEXT: emitc.assign %[[ARGSIZE]] : !emitc.opaque<"iree_host_size_t"> to %[[ARGSDATALENGTH]] : <!emitc.opaque<"iree_host_size_t">>
+  // CHECK-NEXT: assign %[[ARGSIZE]] : !emitc.opaque<"iree_host_size_t"> to %[[ARGSDATALENGTH]] : <!emitc.opaque<"iree_host_size_t">>
   // CHECK-NEXT: %[[ARGSDATA:.+]] = "emitc.member"(%[[ARGBYTESPAN_MEMBER]]) <{member = "data"}> : (!emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.lvalue<!emitc.ptr<ui8>>
-  // CHECK-NEXT: emitc.assign %[[ARGBYTESPANDATA]] : !emitc.ptr<ui8> to %[[ARGSDATA]] : <!emitc.ptr<ui8>>
-  // CHECK-NEXT: emitc.call_opaque "memset"(%[[ARGBYTESPANDATA]], %[[ARGSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
+  // CHECK-NEXT: assign %[[ARGBYTESPANDATA]] : !emitc.ptr<ui8> to %[[ARGSDATA]] : <!emitc.ptr<ui8>>
+  // CHECK-NEXT: call_opaque "memset"(%[[ARGBYTESPANDATA]], %[[ARGSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
 
   // Allocate space for the result.
   // CHECK-NEXT: %[[RESBYTESPAN_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "results"}> : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_call_t">>) -> !emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>
-  // CHECK-NEXT: %[[RESBYTESPANDATAVOID:.+]] = emitc.call_opaque "iree_alloca"(%[[RESULTSIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
-  // CHECK-NEXT: %[[RESBYTESPANDATA:.+]] = emitc.cast %[[RESBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
+  // CHECK-NEXT: %[[RESBYTESPANDATAVOID:.+]] = call_opaque "iree_alloca"(%[[RESULTSIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
+  // CHECK-NEXT: %[[RESBYTESPANDATA:.+]] = cast %[[RESBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
   // CHECK-NEXT: %[[RESSDATALENGTH:.+]] = "emitc.member"(%[[RESBYTESPAN_MEMBER]]) <{member = "data_length"}> : (!emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.lvalue<!emitc.opaque<"iree_host_size_t">>
-  // CHECK-NEXT: emitc.assign %[[RESULTSIZE]] : !emitc.opaque<"iree_host_size_t"> to %[[RESSDATALENGTH]] : <!emitc.opaque<"iree_host_size_t">>
+  // CHECK-NEXT: assign %[[RESULTSIZE]] : !emitc.opaque<"iree_host_size_t"> to %[[RESSDATALENGTH]] : <!emitc.opaque<"iree_host_size_t">>
   // CHECK-NEXT: %[[RESSDATA:.+]] = "emitc.member"(%[[RESBYTESPAN_MEMBER]]) <{member = "data"}> : (!emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.lvalue<!emitc.ptr<ui8>>
-  // CHECK-NEXT: emitc.assign %[[RESBYTESPANDATA]] : !emitc.ptr<ui8> to %[[RESSDATA]] : <!emitc.ptr<ui8>>
-  // CHECK-NEXT: emitc.call_opaque "memset"(%[[RESBYTESPANDATA]], %[[RESULTSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
+  // CHECK-NEXT: assign %[[RESBYTESPANDATA]] : !emitc.ptr<ui8> to %[[RESSDATA]] : <!emitc.ptr<ui8>>
+  // CHECK-NEXT: call_opaque "memset"(%[[RESBYTESPANDATA]], %[[RESULTSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
 
   // Pack the arguments into the struct.
   // Here we also create pointers for non-pointer types.
   // CHECK-NEXT: %[[ARGS:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "arguments"}> : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_call_t">>) -> !emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>
   // CHECK-NEXT: %[[ARGSPTR_LVAL:.+]] = "emitc.member"(%[[ARGS]]) <{member = "data"}> : (!emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.lvalue<!emitc.ptr<ui8>>
-  // CHECK-NEXT: %[[ARGSPTR:.+]] = emitc.load %[[ARGSPTR_LVAL]] : <!emitc.ptr<ui8>>
+  // CHECK-NEXT: %[[ARGSPTR:.+]] = load %[[ARGSPTR_LVAL]] : <!emitc.ptr<ui8>>
   // CHECK-NEXT: %[[A1_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<i32>
-  // CHECK-NEXT: emitc.assign %arg2 : i32 to %[[A1_LVAL]] : <i32>
-  // CHECK-NEXT: %[[A1SIZE:.+]] = emitc.call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[A1PTR:.+]] = emitc.apply "&"(%[[A1_LVAL]]) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
-  // CHECK-NEXT: emitc.call_opaque "memcpy"(%[[ARGSPTR]], %[[A1PTR]], %[[A1SIZE]])
-  // CHECK-NEXT: %[[ARGHOSTSIZE2:.+]] = emitc.call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[A1ADDR:.+]] = emitc.add %[[ARGSPTR]], %[[ARGHOSTSIZE2]]
+  // CHECK-NEXT: assign %arg2 : i32 to %[[A1_LVAL]] : <i32>
+  // CHECK-NEXT: %[[A1SIZE:.+]] = call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: %[[A1PTR:.+]] = apply "&"(%[[A1_LVAL]]) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
+  // CHECK-NEXT: call_opaque "memcpy"(%[[ARGSPTR]], %[[A1PTR]], %[[A1SIZE]])
+  // CHECK-NEXT: %[[ARGHOSTSIZE2:.+]] = call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: %[[A1ADDR:.+]] = add %[[ARGSPTR]], %[[ARGHOSTSIZE2]]
   // CHECK-SAME:     : (!emitc.ptr<ui8>, !emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<ui8>
   // CHECK-NEXT: %[[A2_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<i32>
-  // CHECK-NEXT: emitc.assign %arg3 : i32 to %[[A2_LVAL]] : <i32>
-  // CHECK-NEXT: %[[A1SIZE:.+]] = emitc.call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[A2PTR:.+]] = emitc.apply "&"(%[[A2_LVAL]]) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
-  // CHECK-NEXT: emitc.call_opaque "memcpy"(%[[A1ADDR]], %[[A2PTR]], %[[A1SIZE]])
-  // CHECK-NEXT: %[[A1SIZE2:.+]] = emitc.call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[A2ADDR:.+]] = emitc.add %[[A1ADDR]], %[[A1SIZE2]]
+  // CHECK-NEXT: assign %arg3 : i32 to %[[A2_LVAL]] : <i32>
+  // CHECK-NEXT: %[[A1SIZE:.+]] = call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: %[[A2PTR:.+]] = apply "&"(%[[A2_LVAL]]) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
+  // CHECK-NEXT: call_opaque "memcpy"(%[[A1ADDR]], %[[A2PTR]], %[[A1SIZE]])
+  // CHECK-NEXT: %[[A1SIZE2:.+]] = call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: %[[A2ADDR:.+]] = add %[[A1ADDR]], %[[A1SIZE2]]
   // CHECK-SAME:     : (!emitc.ptr<ui8>, !emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<ui8>
   // CHECK-NEXT: %[[A3_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<i32>
-  // CHECK-NEXT: emitc.assign %arg4 : i32 to %[[A3_LVAL]] : <i32>
-  // CHECK-NEXT: %[[A2SIZE:.+]] = emitc.call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[A3PTR:.+]] = emitc.apply "&"(%[[A3_LVAL]]) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
-  // CHECK-NEXT: emitc.call_opaque "memcpy"(%[[A2ADDR]], %[[A3PTR]], %[[A2SIZE]])
-  // CHECK-NEXT: %[[A2SIZE2:.+]] = emitc.call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[A3ADDR:.+]] = emitc.add %[[A2ADDR]], %[[A2SIZE2]]
+  // CHECK-NEXT: assign %arg4 : i32 to %[[A3_LVAL]] : <i32>
+  // CHECK-NEXT: %[[A2SIZE:.+]] = call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: %[[A3PTR:.+]] = apply "&"(%[[A3_LVAL]]) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
+  // CHECK-NEXT: call_opaque "memcpy"(%[[A2ADDR]], %[[A3PTR]], %[[A2SIZE]])
+  // CHECK-NEXT: %[[A2SIZE2:.+]] = call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: %[[A3ADDR:.+]] = add %[[A2ADDR]], %[[A2SIZE2]]
   // CHECK-SAME:     : (!emitc.ptr<ui8>, !emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<ui8>
   // CHECK-NEXT: %[[A4_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<i32>
-  // CHECK-NEXT: emitc.assign %arg5 : i32 to %[[A4_LVAL]] : <i32>
-  // CHECK-NEXT: %[[A3SIZE:.+]] = emitc.call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[A4PTR:.+]] = emitc.apply "&"(%[[A4_LVAL]]) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
-  // CHECK-NEXT: emitc.call_opaque "memcpy"(%[[A3ADDR]], %[[A4PTR]], %[[A3SIZE:.+]])
+  // CHECK-NEXT: assign %arg5 : i32 to %[[A4_LVAL]] : <i32>
+  // CHECK-NEXT: %[[A3SIZE:.+]] = call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: %[[A4PTR:.+]] = apply "&"(%[[A4_LVAL]]) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
+  // CHECK-NEXT: call_opaque "memcpy"(%[[A3ADDR]], %[[A4PTR]], %[[A3SIZE:.+]])
 
   // Create the call to the imported function.
   // CHECK-NEXT: %[[MODULE_LVAL:.+]] = "emitc.member_of_ptr"(%[[FUNC_LVAL]]) <{member = "module"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>) -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_module_t">>>
   // CHECK-NEXT: %[[BEGIN_CALL_LVAL:.+]] = "emitc.member_of_ptr"(%[[MODULE_LVAL]]) <{member = "begin_call"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_module_t">>>) -> !emitc.lvalue<!emitc.opaque<"begin_call_t">>
-  // CHECK-NEXT: %[[BEGIN_CALL:.+]] = emitc.load %[[BEGIN_CALL_LVAL]] : <!emitc.opaque<"begin_call_t">>
-  // CHECK-NEXT: %[[MODULE:.+]] = emitc.load %[[MODULE_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_module_t">>>
-  // CHECK-NEXT: %[[ARGSTRUCT_RVAL:.+]] = emitc.load %[[ARGSTRUCT]] : <!emitc.opaque<"iree_vm_function_call_t">>
-  // CHECK-NEXT: %{{.+}} = emitc.call_opaque "EMITC_CALL_INDIRECT"(%[[BEGIN_CALL]], %[[MODULE]], %arg0, %[[ARGSTRUCT_RVAL]])
+  // CHECK-NEXT: %[[BEGIN_CALL:.+]] = load %[[BEGIN_CALL_LVAL]] : <!emitc.opaque<"begin_call_t">>
+  // CHECK-NEXT: %[[MODULE:.+]] = load %[[MODULE_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_module_t">>>
+  // CHECK-NEXT: %[[ARGSTRUCT_RVAL:.+]] = load %[[ARGSTRUCT]] : <!emitc.opaque<"iree_vm_function_call_t">>
+  // CHECK-NEXT: %{{.+}} = call_opaque "EMITC_CALL_INDIRECT"(%[[BEGIN_CALL]], %[[MODULE]], %arg0, %[[ARGSTRUCT_RVAL]])
 
   // Unpack the function results.
   // CHECK:      %[[RES_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "results"}> : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_call_t">>) -> !emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>
   // CHECK-NEXT: %[[RESPTR_MEMBER:.+]] = "emitc.member"(%[[RES_MEMBER]]) <{member = "data"}> : (!emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.lvalue<!emitc.ptr<ui8>>
-  // CHECK-NEXT: %[[RESPTR:.+]] = emitc.load %[[RESPTR_MEMBER]] : <!emitc.ptr<ui8>>
-  // CHECK-NEXT: %[[RESHOSTSIZE:.+]] = emitc.call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: emitc.call_opaque "memcpy"(%arg6, %[[RESPTR]], %[[RESHOSTSIZE]])
+  // CHECK-NEXT: %[[RESPTR:.+]] = load %[[RESPTR_MEMBER]] : <!emitc.ptr<ui8>>
+  // CHECK-NEXT: %[[RESHOSTSIZE:.+]] = call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: call_opaque "memcpy"(%arg6, %[[RESPTR]], %[[RESHOSTSIZE]])
 
   // Return ok status.
-  // CHECK-NEXT: %[[OK:.+]] = emitc.call_opaque "iree_ok_status"()
+  // CHECK-NEXT: %[[OK:.+]] = call_opaque "iree_ok_status"()
   // CHECK-NEXT: return %[[OK]]
   vm.import private @variadic_fn(%arg0 : i32, %arg1 : i32 ...) -> i32
 
@@ -578,84 +578,84 @@ vm.module @my_module {
 
   // Calculate the size of the arguments.
   // CHECK-NEXT: %[[ARGSIZE0:.+]] = "emitc.constant"() <{value = #emitc.opaque<"0">}> : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[ARGSIZE1:.+]] = emitc.call_opaque "sizeof"() {args = [i32]}
-  // CHECK-NEXT: %[[ARGSIZE01:.+]] = emitc.add %[[ARGSIZE0]], %[[ARGSIZE1]]
+  // CHECK-NEXT: %[[ARGSIZE1:.+]] = call_opaque "sizeof"() {args = [i32]}
+  // CHECK-NEXT: %[[ARGSIZE01:.+]] = add %[[ARGSIZE0]], %[[ARGSIZE1]]
   // CHECK-SAME:     : (!emitc.opaque<"iree_host_size_t">, !emitc.opaque<"iree_host_size_t">) -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[ARGSIZE2:.+]] = emitc.call_opaque "sizeof"() {args = [i32]}
-  // CHECK-NEXT: %[[ARGSIZE:.+]] = emitc.add %[[ARGSIZE01]], %[[ARGSIZE2]]
+  // CHECK-NEXT: %[[ARGSIZE2:.+]] = call_opaque "sizeof"() {args = [i32]}
+  // CHECK-NEXT: %[[ARGSIZE:.+]] = add %[[ARGSIZE01]], %[[ARGSIZE2]]
   // CHECK-SAME:     : (!emitc.opaque<"iree_host_size_t">, !emitc.opaque<"iree_host_size_t">) -> !emitc.opaque<"iree_host_size_t">
 
   // Calculate the size of the result.
   // CHECK-NEXT: %[[RESULTSIZE0:.+]] = "emitc.constant"() <{value = #emitc.opaque<"0">}> : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[RESULTSIZE1:.+]] = emitc.call_opaque "sizeof"() {args = [i32]}
-  // CHECK-NEXT: %[[RESULTSIZE:.+]] = emitc.add %[[RESULTSIZE0]], %[[RESULTSIZE1]]
+  // CHECK-NEXT: %[[RESULTSIZE1:.+]] = call_opaque "sizeof"() {args = [i32]}
+  // CHECK-NEXT: %[[RESULTSIZE:.+]] = add %[[RESULTSIZE0]], %[[RESULTSIZE1]]
   // CHECK-SAME:     : (!emitc.opaque<"iree_host_size_t">, !emitc.opaque<"iree_host_size_t">) -> !emitc.opaque<"iree_host_size_t">
 
   // CHECK-NEXT: %[[FUNC_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
-  // CHECK-NEXT: emitc.assign %arg1 : !emitc.ptr<!emitc.opaque<"iree_vm_function_t">> to %[[FUNC_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
+  // CHECK-NEXT: assign %arg1 : !emitc.ptr<!emitc.opaque<"iree_vm_function_t">> to %[[FUNC_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
 
   // Create a struct for the arguments and results.
   // CHECK: %[[ARGSTRUCT:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.opaque<"iree_vm_function_call_t">>
-  // CHECK-NEXT: %[[ARGSTRUCTFN:.+]] = emitc.apply "*"(%arg1) : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.opaque<"iree_vm_function_t">
+  // CHECK-NEXT: %[[ARGSTRUCTFN:.+]] = apply "*"(%arg1) : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.opaque<"iree_vm_function_t">
   // CHECK-NEXT: %[[ARGSTRUCTFN_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "function"}> : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_call_t">>) -> !emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>
-  // CHECK-NEXT: emitc.assign %[[ARGSTRUCTFN]] : !emitc.opaque<"iree_vm_function_t"> to %[[ARGSTRUCTFN_MEMBER]] : <!emitc.opaque<"iree_vm_function_t">>
+  // CHECK-NEXT: assign %[[ARGSTRUCTFN]] : !emitc.opaque<"iree_vm_function_t"> to %[[ARGSTRUCTFN_MEMBER]] : <!emitc.opaque<"iree_vm_function_t">>
 
   // Allocate space for the arguments.
   // CHECK-NEXT: %[[ARGBYTESPAN_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "arguments"}> : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_call_t">>) -> !emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>
-  // CHECK-NEXT: %[[ARGBYTESPANDATAVOID:.+]] = emitc.call_opaque "iree_alloca"(%[[ARGSIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
-  // CHECK-NEXT: %[[ARGBYTESPANDATA:.+]] = emitc.cast %[[ARGBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
+  // CHECK-NEXT: %[[ARGBYTESPANDATAVOID:.+]] = call_opaque "iree_alloca"(%[[ARGSIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
+  // CHECK-NEXT: %[[ARGBYTESPANDATA:.+]] = cast %[[ARGBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
   // CHECK-NEXT: %[[ARGSDATALENGTH:.+]] = "emitc.member"(%[[ARGBYTESPAN_MEMBER]]) <{member = "data_length"}> : (!emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.lvalue<!emitc.opaque<"iree_host_size_t">>
-  // CHECK-NEXT: emitc.assign %[[ARGSIZE]] : !emitc.opaque<"iree_host_size_t"> to %[[ARGSDATALENGTH]] : <!emitc.opaque<"iree_host_size_t">>
+  // CHECK-NEXT: assign %[[ARGSIZE]] : !emitc.opaque<"iree_host_size_t"> to %[[ARGSDATALENGTH]] : <!emitc.opaque<"iree_host_size_t">>
   // CHECK-NEXT: %[[ARGSDATA:.+]] = "emitc.member"(%[[ARGBYTESPAN_MEMBER]]) <{member = "data"}> : (!emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.lvalue<!emitc.ptr<ui8>>
-  // CHECK-NEXT: emitc.assign %[[ARGBYTESPANDATA]] : !emitc.ptr<ui8> to %[[ARGSDATA]] : <!emitc.ptr<ui8>>
-  // CHECK-NEXT: emitc.call_opaque "memset"(%[[ARGBYTESPANDATA]], %[[ARGSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
+  // CHECK-NEXT: assign %[[ARGBYTESPANDATA]] : !emitc.ptr<ui8> to %[[ARGSDATA]] : <!emitc.ptr<ui8>>
+  // CHECK-NEXT: call_opaque "memset"(%[[ARGBYTESPANDATA]], %[[ARGSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
 
   // Allocate space for the result.
   // CHECK-NEXT: %[[RESBYTESPAN_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "results"}> : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_call_t">>) -> !emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>
-  // CHECK-NEXT: %[[RESBYTESPANDATAVOID:.+]] = emitc.call_opaque "iree_alloca"(%[[RESULTSIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
-  // CHECK-NEXT: %[[RESBYTESPANDATA:.+]] = emitc.cast %[[RESBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
+  // CHECK-NEXT: %[[RESBYTESPANDATAVOID:.+]] = call_opaque "iree_alloca"(%[[RESULTSIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
+  // CHECK-NEXT: %[[RESBYTESPANDATA:.+]] = cast %[[RESBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
   // CHECK-NEXT: %[[RESSDATALENGTH:.+]] = "emitc.member"(%[[RESBYTESPAN_MEMBER]]) <{member = "data_length"}> : (!emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.lvalue<!emitc.opaque<"iree_host_size_t">>
-  // CHECK-NEXT: emitc.assign %[[RESULTSIZE]] : !emitc.opaque<"iree_host_size_t"> to %[[RESSDATALENGTH]] : <!emitc.opaque<"iree_host_size_t">>
+  // CHECK-NEXT: assign %[[RESULTSIZE]] : !emitc.opaque<"iree_host_size_t"> to %[[RESSDATALENGTH]] : <!emitc.opaque<"iree_host_size_t">>
   // CHECK-NEXT: %[[RESSDATA:.+]] = "emitc.member"(%[[RESBYTESPAN_MEMBER]]) <{member = "data"}> : (!emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.lvalue<!emitc.ptr<ui8>>
-  // CHECK-NEXT: emitc.assign %[[RESBYTESPANDATA]] : !emitc.ptr<ui8> to %[[RESSDATA]] : <!emitc.ptr<ui8>>
-  // CHECK-NEXT: emitc.call_opaque "memset"(%[[RESBYTESPANDATA]], %[[RESULTSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
+  // CHECK-NEXT: assign %[[RESBYTESPANDATA]] : !emitc.ptr<ui8> to %[[RESSDATA]] : <!emitc.ptr<ui8>>
+  // CHECK-NEXT: call_opaque "memset"(%[[RESBYTESPANDATA]], %[[RESULTSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
 
   // Pack the arguments into the struct.
   // Here we also create pointers for non-pointer types.
   // CHECK-NEXT: %[[ARGS:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "arguments"}> : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_call_t">>) -> !emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>
   // CHECK-NEXT: %[[ARGSPTR_LVAL:.+]] = "emitc.member"(%[[ARGS]]) <{member = "data"}> : (!emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.lvalue<!emitc.ptr<ui8>>
-  // CHECK-NEXT: %[[ARGSPTR:.+]] = emitc.load %[[ARGSPTR_LVAL]] : <!emitc.ptr<ui8>>
+  // CHECK-NEXT: %[[ARGSPTR:.+]] = load %[[ARGSPTR_LVAL]] : <!emitc.ptr<ui8>>
   // CHECK-NEXT: %[[A1_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<i32>
-  // CHECK-NEXT: emitc.assign %arg2 : i32 to %[[A1_LVAL]] : <i32>
-  // CHECK-NEXT: %[[A1SIZE:.+]] = emitc.call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[A1PTR:.+]] = emitc.apply "&"(%[[A1_LVAL]]) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
-  // CHECK-NEXT: emitc.call_opaque "memcpy"(%[[ARGSPTR]], %[[A1PTR]], %[[A1SIZE]])
-  // CHECK-NEXT: %[[ARGHOSTSIZE2:.+]] = emitc.call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[A1ADDR:.+]] = emitc.add %[[ARGSPTR]], %[[ARGHOSTSIZE2]]
+  // CHECK-NEXT: assign %arg2 : i32 to %[[A1_LVAL]] : <i32>
+  // CHECK-NEXT: %[[A1SIZE:.+]] = call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: %[[A1PTR:.+]] = apply "&"(%[[A1_LVAL]]) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
+  // CHECK-NEXT: call_opaque "memcpy"(%[[ARGSPTR]], %[[A1PTR]], %[[A1SIZE]])
+  // CHECK-NEXT: %[[ARGHOSTSIZE2:.+]] = call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: %[[A1ADDR:.+]] = add %[[ARGSPTR]], %[[ARGHOSTSIZE2]]
   // CHECK-SAME:     : (!emitc.ptr<ui8>, !emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<ui8>
   // CHECK-NEXT: %[[A2_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<i32>
-  // CHECK-NEXT: emitc.assign %arg3 : i32 to %[[A2_LVAL]] : <i32>
-  // CHECK-NEXT: %[[A1SIZE:.+]] = emitc.call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[A2PTR:.+]] = emitc.apply "&"(%[[A2_LVAL]]) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
-  // CHECK-NEXT: emitc.call_opaque "memcpy"(%[[A1ADDR]], %[[A2PTR]], %[[A1SIZE]])
+  // CHECK-NEXT: assign %arg3 : i32 to %[[A2_LVAL]] : <i32>
+  // CHECK-NEXT: %[[A1SIZE:.+]] = call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: %[[A2PTR:.+]] = apply "&"(%[[A2_LVAL]]) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
+  // CHECK-NEXT: call_opaque "memcpy"(%[[A1ADDR]], %[[A2PTR]], %[[A1SIZE]])
 
   // Create the call to the imported function.
   // CHECK-NEXT: %[[MODULE_LVAL:.+]] = "emitc.member_of_ptr"(%[[FUNC_LVAL]]) <{member = "module"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>) -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_module_t">>>
   // CHECK-NEXT: %[[BEGIN_CALL_LVAL:.+]] = "emitc.member_of_ptr"(%[[MODULE_LVAL]]) <{member = "begin_call"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_module_t">>>) -> !emitc.lvalue<!emitc.opaque<"begin_call_t">>
-  // CHECK-NEXT: %[[BEGIN_CALL:.+]] = emitc.load %[[BEGIN_CALL_LVAL]] : <!emitc.opaque<"begin_call_t">>
-  // CHECK-NEXT: %[[MODULE:.+]] = emitc.load %[[MODULE_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_module_t">>>
-  // CHECK-NEXT: %[[ARGSTRUCT_RVAL:.+]] = emitc.load %[[ARGSTRUCT]] : <!emitc.opaque<"iree_vm_function_call_t">>
-  // CHECK-NEXT: %{{.+}} = emitc.call_opaque "EMITC_CALL_INDIRECT"(%[[BEGIN_CALL]], %[[MODULE]], %arg0, %[[ARGSTRUCT_RVAL]])
+  // CHECK-NEXT: %[[BEGIN_CALL:.+]] = load %[[BEGIN_CALL_LVAL]] : <!emitc.opaque<"begin_call_t">>
+  // CHECK-NEXT: %[[MODULE:.+]] = load %[[MODULE_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_module_t">>>
+  // CHECK-NEXT: %[[ARGSTRUCT_RVAL:.+]] = load %[[ARGSTRUCT]] : <!emitc.opaque<"iree_vm_function_call_t">>
+  // CHECK-NEXT: %{{.+}} = call_opaque "EMITC_CALL_INDIRECT"(%[[BEGIN_CALL]], %[[MODULE]], %arg0, %[[ARGSTRUCT_RVAL]])
 
   // Unpack the function results.
   // CHECK:      %[[RES_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "results"}> : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_call_t">>) -> !emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>
   // CHECK-NEXT: %[[RESPTR_MEMBER:.+]] = "emitc.member"(%[[RES_MEMBER]]) <{member = "data"}> : (!emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.lvalue<!emitc.ptr<ui8>>
-  // CHECK-NEXT: %[[RESPTR:.+]] = emitc.load %[[RESPTR_MEMBER]] : <!emitc.ptr<ui8>>
-  // CHECK-NEXT: %[[RESHOSTSIZE:.+]] = emitc.call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: emitc.call_opaque "memcpy"(%arg4, %[[RESPTR]], %[[RESHOSTSIZE]])
+  // CHECK-NEXT: %[[RESPTR:.+]] = load %[[RESPTR_MEMBER]] : <!emitc.ptr<ui8>>
+  // CHECK-NEXT: %[[RESHOSTSIZE:.+]] = call_opaque "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
+  // CHECK-NEXT: call_opaque "memcpy"(%arg4, %[[RESPTR]], %[[RESHOSTSIZE]])
 
   // Return ok status.
-  // CHECK-NEXT: %[[OK:.+]] = emitc.call_opaque "iree_ok_status"()
+  // CHECK-NEXT: %[[OK:.+]] = call_opaque "iree_ok_status"()
   // CHECK-NEXT: return %[[OK]]
   vm.import private @variadic_fn(%arg0 : i32, %arg1 : i32 ...) -> i32
 
@@ -676,69 +676,69 @@ vm.module @my_module {
 
   // Calculate the size of the arguments.
   // CHECK-NEXT: %[[ARGSIZE0:.+]] = "emitc.constant"() <{value = #emitc.opaque<"0">}> : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[ARGSIZE1:.+]] = emitc.call_opaque "sizeof"() {args = [!emitc.opaque<"iree_vm_ref_t">]}
-  // CHECK-NEXT: %[[ARGSIZE:.+]] = emitc.add %[[ARGSIZE0]], %[[ARGSIZE1]]
+  // CHECK-NEXT: %[[ARGSIZE1:.+]] = call_opaque "sizeof"() {args = [!emitc.opaque<"iree_vm_ref_t">]}
+  // CHECK-NEXT: %[[ARGSIZE:.+]] = add %[[ARGSIZE0]], %[[ARGSIZE1]]
   // CHECK-SAME:     : (!emitc.opaque<"iree_host_size_t">, !emitc.opaque<"iree_host_size_t">) -> !emitc.opaque<"iree_host_size_t">
 
   // Calculate the size of the result.
   // CHECK-NEXT: %[[RESULTSIZE0:.+]] = "emitc.constant"() <{value = #emitc.opaque<"0">}> : () -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: %[[RESULTSIZE1:.+]] = emitc.call_opaque "sizeof"() {args = [!emitc.opaque<"iree_vm_ref_t">]}
-  // CHECK-NEXT: %[[RESULTSIZE:.+]] = emitc.add %[[RESULTSIZE0]], %[[RESULTSIZE1]]
+  // CHECK-NEXT: %[[RESULTSIZE1:.+]] = call_opaque "sizeof"() {args = [!emitc.opaque<"iree_vm_ref_t">]}
+  // CHECK-NEXT: %[[RESULTSIZE:.+]] = add %[[RESULTSIZE0]], %[[RESULTSIZE1]]
   // CHECK-SAME:     : (!emitc.opaque<"iree_host_size_t">, !emitc.opaque<"iree_host_size_t">) -> !emitc.opaque<"iree_host_size_t">
 
   // CHECK-NEXT: %[[FUNC_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
-  // CHECK-NEXT: emitc.assign %arg1 : !emitc.ptr<!emitc.opaque<"iree_vm_function_t">> to %[[FUNC_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
+  // CHECK-NEXT: assign %arg1 : !emitc.ptr<!emitc.opaque<"iree_vm_function_t">> to %[[FUNC_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
 
   // Create a struct for the arguments and results.
   // CHECK: %[[ARGSTRUCT:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.opaque<"iree_vm_function_call_t">>
-  // CHECK-NEXT: %[[ARGSTRUCTFN:.+]] = emitc.apply "*"(%arg1) : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.opaque<"iree_vm_function_t">
+  // CHECK-NEXT: %[[ARGSTRUCTFN:.+]] = apply "*"(%arg1) : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.opaque<"iree_vm_function_t">
   // CHECK-NEXT: %[[ARGSTRUCTFN_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "function"}> : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_call_t">>) -> !emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>
-  // CHECK-NEXT: emitc.assign %[[ARGSTRUCTFN]] : !emitc.opaque<"iree_vm_function_t"> to %[[ARGSTRUCTFN_MEMBER]] : <!emitc.opaque<"iree_vm_function_t">>
+  // CHECK-NEXT: assign %[[ARGSTRUCTFN]] : !emitc.opaque<"iree_vm_function_t"> to %[[ARGSTRUCTFN_MEMBER]] : <!emitc.opaque<"iree_vm_function_t">>
 
   // Allocate space for the arguments.
   // CHECK-NEXT: %[[ARGBYTESPAN_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "arguments"}> : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_call_t">>) -> !emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>
-  // CHECK-NEXT: %[[ARGBYTESPANDATAVOID:.+]] = emitc.call_opaque "iree_alloca"(%[[ARGSIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
-  // CHECK-NEXT: %[[ARGBYTESPANDATA:.+]] = emitc.cast %[[ARGBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
+  // CHECK-NEXT: %[[ARGBYTESPANDATAVOID:.+]] = call_opaque "iree_alloca"(%[[ARGSIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
+  // CHECK-NEXT: %[[ARGBYTESPANDATA:.+]] = cast %[[ARGBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
   // CHECK-NEXT: %[[ARGSDATALENGTH:.+]] = "emitc.member"(%[[ARGBYTESPAN_MEMBER]]) <{member = "data_length"}> : (!emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.lvalue<!emitc.opaque<"iree_host_size_t">>
-  // CHECK-NEXT: emitc.assign %[[ARGSIZE]] : !emitc.opaque<"iree_host_size_t"> to %[[ARGSDATALENGTH]] : <!emitc.opaque<"iree_host_size_t">>
+  // CHECK-NEXT: assign %[[ARGSIZE]] : !emitc.opaque<"iree_host_size_t"> to %[[ARGSDATALENGTH]] : <!emitc.opaque<"iree_host_size_t">>
   // CHECK-NEXT: %[[ARGSDATA:.+]] = "emitc.member"(%[[ARGBYTESPAN_MEMBER]]) <{member = "data"}> : (!emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.lvalue<!emitc.ptr<ui8>>
-  // CHECK-NEXT: emitc.assign %[[ARGBYTESPANDATA]] : !emitc.ptr<ui8> to %[[ARGSDATA]] : <!emitc.ptr<ui8>>
-  // CHECK-NEXT: emitc.call_opaque "memset"(%[[ARGBYTESPANDATA]], %[[ARGSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
+  // CHECK-NEXT: assign %[[ARGBYTESPANDATA]] : !emitc.ptr<ui8> to %[[ARGSDATA]] : <!emitc.ptr<ui8>>
+  // CHECK-NEXT: call_opaque "memset"(%[[ARGBYTESPANDATA]], %[[ARGSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
 
   // Allocate space for the result.
   // CHECK-NEXT: %[[RESBYTESPAN_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "results"}> : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_call_t">>) -> !emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>
-  // CHECK-NEXT: %[[RESBYTESPANDATAVOID:.+]] = emitc.call_opaque "iree_alloca"(%[[RESULTSIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
-  // CHECK-NEXT: %[[RESBYTESPANDATA:.+]] = emitc.cast %[[RESBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
+  // CHECK-NEXT: %[[RESBYTESPANDATAVOID:.+]] = call_opaque "iree_alloca"(%[[RESULTSIZE]]) : (!emitc.opaque<"iree_host_size_t">) -> !emitc.ptr<!emitc.opaque<"void">>
+  // CHECK-NEXT: %[[RESBYTESPANDATA:.+]] = cast %[[RESBYTESPANDATAVOID]] : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<ui8>
   // CHECK-NEXT: %[[RESSDATALENGTH:.+]] = "emitc.member"(%[[RESBYTESPAN_MEMBER]]) <{member = "data_length"}> : (!emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.lvalue<!emitc.opaque<"iree_host_size_t">>
-  // CHECK-NEXT: emitc.assign %[[RESULTSIZE]] : !emitc.opaque<"iree_host_size_t"> to %[[RESSDATALENGTH]] : <!emitc.opaque<"iree_host_size_t">>
+  // CHECK-NEXT: assign %[[RESULTSIZE]] : !emitc.opaque<"iree_host_size_t"> to %[[RESSDATALENGTH]] : <!emitc.opaque<"iree_host_size_t">>
   // CHECK-NEXT: %[[RESSDATA:.+]] = "emitc.member"(%[[RESBYTESPAN_MEMBER]]) <{member = "data"}> : (!emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.lvalue<!emitc.ptr<ui8>>
-  // CHECK-NEXT: emitc.assign %[[RESBYTESPANDATA]] : !emitc.ptr<ui8> to %[[RESSDATA]] : <!emitc.ptr<ui8>>
-  // CHECK-NEXT: emitc.call_opaque "memset"(%[[RESBYTESPANDATA]], %[[RESULTSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
+  // CHECK-NEXT: assign %[[RESBYTESPANDATA]] : !emitc.ptr<ui8> to %[[RESSDATA]] : <!emitc.ptr<ui8>>
+  // CHECK-NEXT: call_opaque "memset"(%[[RESBYTESPANDATA]], %[[RESULTSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
 
   // Pack the argument into the struct.
   // CHECK-NEXT: %[[ARGS:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "arguments"}> : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_call_t">>) -> !emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>
   // CHECK-NEXT: %[[ARGSDATA_LVAL:.+]] = "emitc.member"(%[[ARGS]]) <{member = "data"}> : (!emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.lvalue<!emitc.ptr<ui8>>
-  // CHECK-NEXT: %[[ARGSDATA:.+]] = emitc.load %[[ARGSDATA_LVAL]] : <!emitc.ptr<ui8>>
-  // CHECK-NEXT: %[[ARG:.+]] = emitc.cast %[[ARGSDATA]] : !emitc.ptr<ui8> to !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
-  // CHECK-NEXT: emitc.call_opaque "iree_vm_ref_assign"(%arg2, %[[ARG]])
+  // CHECK-NEXT: %[[ARGSDATA:.+]] = load %[[ARGSDATA_LVAL]] : <!emitc.ptr<ui8>>
+  // CHECK-NEXT: %[[ARG:.+]] = cast %[[ARGSDATA]] : !emitc.ptr<ui8> to !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
+  // CHECK-NEXT: call_opaque "iree_vm_ref_assign"(%arg2, %[[ARG]])
 
   // Create the call to the imported function.
   // CHECK-NEXT: %[[MODULE_LVAL:.+]] = "emitc.member_of_ptr"(%[[FUNC_LVAL]]) <{member = "module"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>) -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_module_t">>>
   // CHECK-NEXT: %[[BEGIN_CALL_LVAL:.+]] = "emitc.member_of_ptr"(%[[MODULE_LVAL]]) <{member = "begin_call"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_module_t">>>) -> !emitc.lvalue<!emitc.opaque<"begin_call_t">>
-  // CHECK-NEXT: %[[BEGIN_CALL:.+]] = emitc.load %[[BEGIN_CALL_LVAL]] : <!emitc.opaque<"begin_call_t">>
-  // CHECK-NEXT: %[[MODULE:.+]] = emitc.load %[[MODULE_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_module_t">>>
-  // CHECK-NEXT: %[[ARGSTRUCT_RVAL:.+]] = emitc.load %[[ARGSTRUCT]] : <!emitc.opaque<"iree_vm_function_call_t">>
-  // CHECK-NEXT: %{{.+}} = emitc.call_opaque "EMITC_CALL_INDIRECT"(%[[BEGIN_CALL]], %[[MODULE]], %arg0, %[[ARGSTRUCT_RVAL]])
+  // CHECK-NEXT: %[[BEGIN_CALL:.+]] = load %[[BEGIN_CALL_LVAL]] : <!emitc.opaque<"begin_call_t">>
+  // CHECK-NEXT: %[[MODULE:.+]] = load %[[MODULE_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_module_t">>>
+  // CHECK-NEXT: %[[ARGSTRUCT_RVAL:.+]] = load %[[ARGSTRUCT]] : <!emitc.opaque<"iree_vm_function_call_t">>
+  // CHECK-NEXT: %{{.+}} = call_opaque "EMITC_CALL_INDIRECT"(%[[BEGIN_CALL]], %[[MODULE]], %arg0, %[[ARGSTRUCT_RVAL]])
 
   // Unpack the function results.
   // CHECK:      %[[RES_MEMBER:.+]] = "emitc.member"(%[[ARGSTRUCT]]) <{member = "results"}> : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_call_t">>) -> !emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>
   // CHECK-NEXT: %[[RESPTR_MEMBER:.+]] = "emitc.member"(%[[RES_MEMBER]]) <{member = "data"}> : (!emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.lvalue<!emitc.ptr<ui8>>
-  // CHECK-NEXT: %[[RESPTR:.+]] = emitc.load %[[RESPTR_MEMBER]] : <!emitc.ptr<ui8>>
-  // CHECK-NEXT: %[[RESREFPTR:.+]] = emitc.cast %[[RESPTR]] : !emitc.ptr<ui8> to !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
-  // CHECK-NEXT: emitc.call_opaque "iree_vm_ref_move"(%[[RESREFPTR]], %arg3)
+  // CHECK-NEXT: %[[RESPTR:.+]] = load %[[RESPTR_MEMBER]] : <!emitc.ptr<ui8>>
+  // CHECK-NEXT: %[[RESREFPTR:.+]] = cast %[[RESPTR]] : !emitc.ptr<ui8> to !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
+  // CHECK-NEXT: call_opaque "iree_vm_ref_move"(%[[RESREFPTR]], %arg3)
 
   // Return ok status.
-  // CHECK-NEXT: %[[OK:.+]] = emitc.call_opaque "iree_ok_status"()
+  // CHECK-NEXT: %[[OK:.+]] = call_opaque "iree_ok_status"()
   // CHECK-NEXT: return %[[OK]]
   vm.import private @ref_fn(%arg0 : !vm.ref<?>) -> !vm.ref<?>
 
@@ -762,40 +762,40 @@ vm.module @my_module {
   // CHECK-SAME:     -> !emitc.opaque<"iree_status_t">
 
   // Cast module and module state structs.
-  // CHECK-NEXT: %[[MODULECASTED:.+]] = emitc.cast %arg4 : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<!emitc.opaque<"struct my_module_t">>
-  // CHECK-NEXT: %[[MODSTATECASTED:.+]] = emitc.cast %arg5 : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<!emitc.opaque<"struct my_module_state_t">>
+  // CHECK-NEXT: %[[MODULECASTED:.+]] = cast %arg4 : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<!emitc.opaque<"struct my_module_t">>
+  // CHECK-NEXT: %[[MODSTATECASTED:.+]] = cast %arg5 : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<!emitc.opaque<"struct my_module_state_t">>
 
   // Cast argument and result structs.
   // CHECK-NEXT: %[[ARG_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>
-  // CHECK-NEXT: emitc.assign %arg2 : !emitc.opaque<"iree_byte_span_t"> to %[[ARG_LVAL]] : <!emitc.opaque<"iree_byte_span_t">>
+  // CHECK-NEXT: assign %arg2 : !emitc.opaque<"iree_byte_span_t"> to %[[ARG_LVAL]] : <!emitc.opaque<"iree_byte_span_t">>
   // CHECK-NEXT: %[[ARGDATA_MEMBER:.+]] = "emitc.member"(%[[ARG_LVAL]]) <{member = "data"}> : (!emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.lvalue<!emitc.ptr<ui8>>
-  // CHECK-NEXT: %[[ARGDATA:.+]] = emitc.load %[[ARGDATA_MEMBER]] : <!emitc.ptr<ui8>
-  // CHECK-NEXT: %[[ARGS:.+]] = emitc.cast %[[ARGDATA]] : !emitc.ptr<ui8> to !emitc.ptr<!emitc.opaque<"struct my_module_fn_args_t">>
+  // CHECK-NEXT: %[[ARGDATA:.+]] = load %[[ARGDATA_MEMBER]] : <!emitc.ptr<ui8>
+  // CHECK-NEXT: %[[ARGS:.+]] = cast %[[ARGDATA]] : !emitc.ptr<ui8> to !emitc.ptr<!emitc.opaque<"struct my_module_fn_args_t">>
   // CHECK-NEXT: %[[ARGS_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_fn_args_t">>>
-  // CHECK-NEXT: emitc.assign %[[ARGS]] : !emitc.ptr<!emitc.opaque<"struct my_module_fn_args_t">> to %[[ARGS_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_fn_args_t">>>
+  // CHECK-NEXT: assign %[[ARGS]] : !emitc.ptr<!emitc.opaque<"struct my_module_fn_args_t">> to %[[ARGS_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_fn_args_t">>>
   // CHECK-NEXT: %[[BYTESPAN_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>
-  // CHECK-NEXT: emitc.assign %arg3 : !emitc.opaque<"iree_byte_span_t"> to %[[BYTESPAN_LVAL]] : <!emitc.opaque<"iree_byte_span_t">>
+  // CHECK-NEXT: assign %arg3 : !emitc.opaque<"iree_byte_span_t"> to %[[BYTESPAN_LVAL]] : <!emitc.opaque<"iree_byte_span_t">>
   // CHECK-NEXT: %[[BYTESPANDATA_LVAL:.+]] = "emitc.member"(%[[BYTESPAN_LVAL]]) <{member = "data"}> : (!emitc.lvalue<!emitc.opaque<"iree_byte_span_t">>) -> !emitc.lvalue<!emitc.ptr<ui8>>
-  // CHECK-NEXT: %[[BYTESPANDATA:.+]] = emitc.load %[[BYTESPANDATA_LVAL]] : <!emitc.ptr<ui8>>
-  // CHECK-NEXT: %[[RESULTS:.+]] = emitc.cast %[[BYTESPANDATA]] : !emitc.ptr<ui8> to !emitc.ptr<!emitc.opaque<"struct my_module_fn_result_t">>
+  // CHECK-NEXT: %[[BYTESPANDATA:.+]] = load %[[BYTESPANDATA_LVAL]] : <!emitc.ptr<ui8>>
+  // CHECK-NEXT: %[[RESULTS:.+]] = cast %[[BYTESPANDATA]] : !emitc.ptr<ui8> to !emitc.ptr<!emitc.opaque<"struct my_module_fn_result_t">>
   // CHECK-NEXT: %[[RESULTS_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_fn_result_t">>>
-  // CHECK-NEXT: emitc.assign %[[RESULTS]] : !emitc.ptr<!emitc.opaque<"struct my_module_fn_result_t">> to %[[RESULTS_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_fn_result_t">>>
+  // CHECK-NEXT: assign %[[RESULTS]] : !emitc.ptr<!emitc.opaque<"struct my_module_fn_result_t">> to %[[RESULTS_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_fn_result_t">>>
 
   // Unpack the argument from the struct.
   // CHECK-NEXT: %[[ARG_LVAL:.+]] = "emitc.member_of_ptr"(%{{.*}}) <{member = "arg0"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_fn_args_t">>>) -> !emitc.lvalue<i32>
-  // CHECK-NEXT: %[[ARG:.+]] = emitc.load %[[ARG_LVAL]] : <i32>
+  // CHECK-NEXT: %[[ARG:.+]] = load %[[ARG_LVAL]] : <i32>
 
   // Unpack the result pointer from the struct.
   // CHECK-NEXT: %[[RESULT_LVAL:.+]] = "emitc.member_of_ptr"(%[[RESULTS_LVAL]]) <{member = "res0"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_fn_result_t">>>) -> !emitc.lvalue<i32>
-  // CHECK-NEXT: %[[RES:.+]] = emitc.apply "&"(%[[RESULT_LVAL]]) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
+  // CHECK-NEXT: %[[RES:.+]] = apply "&"(%[[RESULT_LVAL]]) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
 
   // Call the internal function.
-  // CHECK-NEXT: %{{.+}} = emitc.call @my_module_fn(%arg0, %[[MODULECASTED]], %[[MODSTATECASTED]], %[[ARG]], %[[RES]])
+  // CHECK-NEXT: %{{.+}} = call @my_module_fn(%arg0, %[[MODULECASTED]], %[[MODSTATECASTED]], %[[ARG]], %[[RES]])
   // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_stack_t">>, !emitc.ptr<!emitc.opaque<"struct my_module_t">>,
   // CHECK-SAME:        !emitc.ptr<!emitc.opaque<"struct my_module_state_t">>, i32, !emitc.ptr<i32>) -> !emitc.opaque<"iree_status_t">
 
   // Return ok status.
-  // CHECK: %[[STATUS:.+]] = emitc.call_opaque "iree_ok_status"() : () -> !emitc.opaque<"iree_status_t">
+  // CHECK: %[[STATUS:.+]] = call_opaque "iree_ok_status"() : () -> !emitc.opaque<"iree_status_t">
   // CHECK: return %[[STATUS]] : !emitc.opaque<"iree_status_t">
 
   vm.export @fn
@@ -812,21 +812,21 @@ vm.module @my_module {
   vm.func @return(%arg0 : i32, %arg1 : !vm.ref<?>) -> (i32, !vm.ref<?>) {
 
     // Move the i32 value and ref into the result function arguments.
-    // CHECK-NEXT: emitc.call_opaque "EMITC_DEREF_ASSIGN_VALUE"(%arg5, %arg3) : (!emitc.ptr<i32>, i32) -> ()
+    // CHECK-NEXT: call_opaque "EMITC_DEREF_ASSIGN_VALUE"(%arg5, %arg3) : (!emitc.ptr<i32>, i32) -> ()
 
     // Create duplicate ref for
     // CHECK-NEXT: %[[REF:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.opaque<"iree_vm_ref_t">>
-    // CHECK-NEXT: %[[REFPTR:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.lvalue<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
-    // CHECK-NEXT: %[[REFSIZE:.+]] = emitc.call_opaque "sizeof"() {args = [!emitc.opaque<"iree_vm_ref_t">]} : () -> !emitc.opaque<"iree_host_size_t">
-    // CHECK-NEXT: emitc.call_opaque "memset"(%[[REFPTR]], %[[REFSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.opaque<"iree_host_size_t">) -> ()
-    // CHECK-NEXT: emitc.call_opaque "iree_vm_ref_move"(%arg4, %[[REFPTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> ()
-    // CHECK-NEXT: emitc.call_opaque "iree_vm_ref_move"(%[[REFPTR]], %arg6) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> ()
+    // CHECK-NEXT: %[[REFPTR:.+]] = apply "&"(%[[REF]]) : (!emitc.lvalue<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
+    // CHECK-NEXT: %[[REFSIZE:.+]] = call_opaque "sizeof"() {args = [!emitc.opaque<"iree_vm_ref_t">]} : () -> !emitc.opaque<"iree_host_size_t">
+    // CHECK-NEXT: call_opaque "memset"(%[[REFPTR]], %[[REFSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.opaque<"iree_host_size_t">) -> ()
+    // CHECK-NEXT: call_opaque "iree_vm_ref_move"(%arg4, %[[REFPTR]]) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> ()
+    // CHECK-NEXT: call_opaque "iree_vm_ref_move"(%[[REFPTR]], %arg6) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> ()
 
     // Release the ref.
-    // CHECK-NEXT: emitc.call_opaque "iree_vm_ref_release"(%arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> ()
+    // CHECK-NEXT: call_opaque "iree_vm_ref_release"(%arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> ()
 
     // Return ok status.
-    // CHECK-NEXT: %[[STATUS:.+]] = emitc.call_opaque "iree_ok_status"() : () -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %[[STATUS:.+]] = call_opaque "iree_ok_status"() : () -> !emitc.opaque<"iree_status_t">
     // CHECK-NEXT: return %[[STATUS]] : !emitc.opaque<"iree_status_t">
     vm.return %arg0, %arg1 : i32, !vm.ref<?>
   }
@@ -839,19 +839,19 @@ vm.module @my_module {
   // CHECK-LABEL: emitc.func private @my_module_call_fn
   vm.func @call_fn() -> i32 {
     // CHECK-NEXT: %[[STATE_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
-    // CHECK-NEXT: emitc.assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
+    // CHECK-NEXT: assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
     // CHECK-NEXT: %[[IMPORTS_LVAL:.+]] = "emitc.member_of_ptr"(%[[STATE_LVAL]]) <{member = "imports"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>) -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
-    // CHECK-NEXT: %[[IMPORTS:.+]] = emitc.load %[[IMPORTS_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
-    // CHECK-NEXT: %[[IMPORT_INDEX:.+]] = emitc.literal "0" : !emitc.opaque<"iree_host_size_t">
-    // CHECK-NEXT: %[[IMPORT_SUBSCRIPT:.+]] = emitc.subscript %[[IMPORTS]][%[[IMPORT_INDEX]]] : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>, !emitc.opaque<"iree_host_size_t">) -> !emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>
-    // CHECK-NEXT: %[[IMPORT:.+]] = emitc.apply "&"(%[[IMPORT_SUBSCRIPT]]) : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[IMPORTS:.+]] = load %[[IMPORTS_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
+    // CHECK-NEXT: %[[IMPORT_INDEX:.+]] = literal "0" : !emitc.opaque<"iree_host_size_t">
+    // CHECK-NEXT: %[[IMPORT_SUBSCRIPT:.+]] = subscript %[[IMPORTS]][%[[IMPORT_INDEX]]] : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>, !emitc.opaque<"iree_host_size_t">) -> !emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>
+    // CHECK-NEXT: %[[IMPORT:.+]] = apply "&"(%[[IMPORT_SUBSCRIPT]]) : (!emitc.lvalue<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_t">>
     // CHECK-NEXT: %[[IMPORT_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
-    // CHECK-NEXT: emitc.assign %[[IMPORT]] : !emitc.ptr<!emitc.opaque<"iree_vm_function_t">> to %[[IMPORT_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
+    // CHECK-NEXT: assign %[[IMPORT]] : !emitc.ptr<!emitc.opaque<"iree_vm_function_t">> to %[[IMPORT_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>
     // CHECK-NEXT: %[[MODULE_LVAL:.+]] = "emitc.member_of_ptr"(%[[IMPORT_LVAL]]) <{member = "module"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>>) -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_module_t">>>
-    // CHECK-NEXT: %[[MODULE:.+]] = emitc.load %[[MODULE_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_module_t">>>
-    // CHECK-NEXT: %[[CONDITION0:.+]] = emitc.logical_not %[[MODULE]] : !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
-    // CHECK-NEXT: %[[CONDITION1:.+]] = emitc.logical_not %[[CONDITION0]] : i1
-    // CHECK-NEXT: %[[RESULT:.+]] = emitc.cast %[[CONDITION1]] : i1 to i32
+    // CHECK-NEXT: %[[MODULE:.+]] = load %[[MODULE_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_module_t">>>
+    // CHECK-NEXT: %[[CONDITION0:.+]] = logical_not %[[MODULE]] : !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
+    // CHECK-NEXT: %[[CONDITION1:.+]] = logical_not %[[CONDITION0]] : i1
+    // CHECK-NEXT: %[[RESULT:.+]] = cast %[[CONDITION1]] : i1 to i32
     %has_optional_import_fn = vm.import.resolved @optional_import_fn : i32
     vm.return %has_optional_import_fn : i32
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops.mlir
@@ -3,9 +3,9 @@
 // CHECK-LABEL: emitc.func private @my_module_trunc
 vm.module @my_module {
   vm.func @trunc(%arg0 : i32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_trunc_i32i8"(%arg3) : (i32) -> i32
+    // CHECK-NEXT: %0 = call_opaque "vm_trunc_i32i8"(%arg3) : (i32) -> i32
     %0 = vm.trunc.i32.i8 %arg0 : i32 -> i32
-    // CHECK-NEXT: %1 = emitc.call_opaque "vm_trunc_i32i16"(%0) : (i32) -> i32
+    // CHECK-NEXT: %1 = call_opaque "vm_trunc_i32i16"(%0) : (i32) -> i32
     %1 = vm.trunc.i32.i16 %0 : i32 -> i32
     vm.return %1 : i32
   }
@@ -16,13 +16,13 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_ext
 vm.module @my_module {
   vm.func @ext(%arg0 : i32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_ext_i8i32s"(%arg3) : (i32) -> i32
+    // CHECK-NEXT: %0 = call_opaque "vm_ext_i8i32s"(%arg3) : (i32) -> i32
     %0 = vm.ext.i8.i32.s %arg0 : i32 -> i32
-    // CHECK-NEXT: %1 = emitc.call_opaque "vm_ext_i8i32u"(%0) : (i32) -> i32
+    // CHECK-NEXT: %1 = call_opaque "vm_ext_i8i32u"(%0) : (i32) -> i32
     %1 = vm.ext.i8.i32.u %0 : i32 -> i32
-    // CHECK-NEXT: %2 = emitc.call_opaque "vm_ext_i16i32s"(%1) : (i32) -> i32
+    // CHECK-NEXT: %2 = call_opaque "vm_ext_i16i32s"(%1) : (i32) -> i32
     %2 = vm.ext.i16.i32.s %1 : i32 -> i32
-    // CHECK-NEXT: %3 = emitc.call_opaque "vm_ext_i16i32u"(%2) : (i32) -> i32
+    // CHECK-NEXT: %3 = call_opaque "vm_ext_i16i32u"(%2) : (i32) -> i32
     %3 = vm.ext.i16.i32.u %2 : i32 -> i32
     vm.return %3 : i32
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops_f32.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops_f32.mlir
@@ -3,9 +3,9 @@
 // CHECK-LABEL: emitc.func private @my_module_bitcast
 vm.module @my_module {
   vm.func @bitcast(%arg0 : i32) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_bitcast_i32f32"(%arg3) : (i32) -> f32
+    // CHECK-NEXT: %0 = call_opaque "vm_bitcast_i32f32"(%arg3) : (i32) -> f32
     %0 = vm.bitcast.i32.f32 %arg0 : i32 -> f32
-    // CHECK-NEXT: %1 = emitc.call_opaque "vm_bitcast_f32i32"(%0) : (f32) -> i32
+    // CHECK-NEXT: %1 = call_opaque "vm_bitcast_f32i32"(%0) : (f32) -> i32
     %1 = vm.bitcast.f32.i32 %0 : f32 -> i32
     vm.return %1 : i32
   }
@@ -16,13 +16,13 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_cast
 vm.module @my_module {
   vm.func @cast(%arg0 : i32) -> (i32, i32) {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_cast_si32f32"(%arg3) : (i32) -> f32
+    // CHECK-NEXT: %0 = call_opaque "vm_cast_si32f32"(%arg3) : (i32) -> f32
     %0 = vm.cast.si32.f32 %arg0 : i32 -> f32
-    // CHECK-NEXT: %1 = emitc.call_opaque "vm_cast_ui32f32"(%arg3) : (i32) -> f32
+    // CHECK-NEXT: %1 = call_opaque "vm_cast_ui32f32"(%arg3) : (i32) -> f32
     %1 = vm.cast.ui32.f32 %arg0 : i32 -> f32
-    // CHECK-NEXT: %2 = emitc.call_opaque "vm_cast_f32si32"(%0) : (f32) -> i32
+    // CHECK-NEXT: %2 = call_opaque "vm_cast_f32si32"(%0) : (f32) -> i32
     %2 = vm.cast.f32.si32 %0 : f32 -> i32
-    // CHECK-NEXT: %3 = emitc.call_opaque "vm_cast_f32ui32"(%1) : (f32) -> i32
+    // CHECK-NEXT: %3 = call_opaque "vm_cast_f32ui32"(%1) : (f32) -> i32
     %3 = vm.cast.f32.ui32 %1 : f32 -> i32
     vm.return %2, %3 : i32, i32
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops_i64.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/conversion_ops_i64.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: emitc.func private @my_module_trunc_i64
 vm.module @my_module {
   vm.func @trunc_i64(%arg0 : i64) -> i32 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_trunc_i64i32"(%arg3) : (i64) -> i32
+    // CHECK-NEXT: %0 = call_opaque "vm_trunc_i64i32"(%arg3) : (i64) -> i32
     %0 = vm.trunc.i64.i32 %arg0 : i64 -> i32
     vm.return %0 : i32
   }
@@ -14,9 +14,9 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_ext_i64
 vm.module @my_module {
   vm.func @ext_i64(%arg0 : i32) -> i64 {
-    // CHECK-NEXT: %0 = emitc.call_opaque "vm_ext_i32i64s"(%arg3) : (i32) -> i64
+    // CHECK-NEXT: %0 = call_opaque "vm_ext_i32i64s"(%arg3) : (i32) -> i64
     %0 = vm.ext.i32.i64.s %arg0 : i32 -> i64
-    // CHECK-NEXT: %1 = emitc.call_opaque "vm_ext_i32i64u"(%arg3) : (i32) -> i64
+    // CHECK-NEXT: %1 = call_opaque "vm_ext_i32i64u"(%arg3) : (i32) -> i64
     %1 = vm.ext.i32.i64.u %arg0 : i32 -> i64
     vm.return %1 : i64
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/global_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/global_ops.mlir
@@ -6,10 +6,10 @@ vm.module @my_module {
   // CHECK-LABEL: emitc.func private @my_module_global_load_i32
   vm.func @global_load_i32() -> i32 {
     // CHECK-NEXT: %[[STATE_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
-    // CHECK-NEXT: emitc.assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
+    // CHECK-NEXT: assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
     // CHECK-NEXT: %[[RWDATA_LVAL:.+]] = "emitc.member_of_ptr"(%[[STATE_LVAL]]) <{member = "rwdata"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>) -> !emitc.lvalue<!emitc.ptr<ui8>>
-    // CHECK-NEXT: %[[RWDATA:.+]] = emitc.load %[[RWDATA_LVAL]] : <!emitc.ptr<ui8>>
-    // CHECK-NEXT: %[[RES:.+]] = emitc.call_opaque "vm_global_load_i32"(%[[RWDATA]]) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<ui8>) -> i32
+    // CHECK-NEXT: %[[RWDATA:.+]] = load %[[RWDATA_LVAL]] : <!emitc.ptr<ui8>>
+    // CHECK-NEXT: %[[RES:.+]] = call_opaque "vm_global_load_i32"(%[[RWDATA]]) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<ui8>) -> i32
     %0 = vm.global.load.i32 @c42 : i32
     vm.return %0 : i32
   }
@@ -23,10 +23,10 @@ vm.module @my_module {
   // CHECK-LABEL: emitc.func private @my_module_global_store_i32
   vm.func @global_store_i32(%arg0 : i32) {
     // CHECK-NEXT: %[[STATE_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
-    // CHECK-NEXT: emitc.assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
+    // CHECK-NEXT: assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
     // CHECK-NEXT: %[[RWDATA_LVAL:.+]] = "emitc.member_of_ptr"(%[[STATE_LVAL]]) <{member = "rwdata"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>) -> !emitc.lvalue<!emitc.ptr<ui8>>
-    // CHECK-NEXT: %[[RWDATA:.+]] = emitc.load %[[RWDATA_LVAL]] : <!emitc.ptr<ui8>>
-    // CHECK-NEXT: emitc.call_opaque "vm_global_store_i32"(%[[RWDATA]], %arg3) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.ptr<ui8>, i32) -> ()
+    // CHECK-NEXT: %[[RWDATA:.+]] = load %[[RWDATA_LVAL]] : <!emitc.ptr<ui8>>
+    // CHECK-NEXT: call_opaque "vm_global_store_i32"(%[[RWDATA]], %arg3) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.ptr<ui8>, i32) -> ()
     vm.global.store.i32 %arg0, @c107_mut : i32
     vm.return
   }
@@ -40,14 +40,14 @@ vm.module @my_module {
   // CHECK-LABEL: emitc.func private @my_module_global_load_ref
   vm.func @global_load_ref() -> !vm.buffer {
     // CHECK: %[[STATE_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
-    // CHECK-NEXT: emitc.assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
+    // CHECK-NEXT: assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
     // CHECK-NEXT: %[[REFS_LVAL:.+]] = "emitc.member_of_ptr"(%[[STATE_LVAL]]) <{member = "refs"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>) -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>>
-    // CHECK-NEXT: %[[REFS:.+]] = emitc.load %[[REFS_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>>
-    // CHECK: %[[REF_INDEX:.+]] = emitc.literal "0" : !emitc.opaque<"iree_host_size_t">
-    // CHECK-NEXT: %[[REF:.+]] = emitc.subscript %[[REFS]][%[[REF_INDEX]]] : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.opaque<"iree_host_size_t">) -> !emitc.lvalue<!emitc.opaque<"iree_vm_ref_t">>
-    // CHECK-NEXT: %[[REF_0:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.lvalue<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
-    // CHECK: %[[C:.+]] = emitc.call_opaque "iree_vm_type_def_as_ref"(%{{.+}}) : (!emitc.opaque<"iree_vm_type_def_t">) -> !emitc.opaque<"iree_vm_ref_type_t">
-    // CHECK: %{{.+}} = emitc.call_opaque "iree_vm_ref_retain_or_move_checked"(%[[REF_0]], %[[C]], %arg3) {args = [false, 0 : index, 1 : index, 2 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.opaque<"iree_vm_ref_type_t">, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %[[REFS:.+]] = load %[[REFS_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>>
+    // CHECK: %[[REF_INDEX:.+]] = literal "0" : !emitc.opaque<"iree_host_size_t">
+    // CHECK-NEXT: %[[REF:.+]] = subscript %[[REFS]][%[[REF_INDEX]]] : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.opaque<"iree_host_size_t">) -> !emitc.lvalue<!emitc.opaque<"iree_vm_ref_t">>
+    // CHECK-NEXT: %[[REF_0:.+]] = apply "&"(%[[REF]]) : (!emitc.lvalue<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
+    // CHECK: %[[C:.+]] = call_opaque "iree_vm_type_def_as_ref"(%{{.+}}) : (!emitc.opaque<"iree_vm_type_def_t">) -> !emitc.opaque<"iree_vm_ref_type_t">
+    // CHECK: %{{.+}} = call_opaque "iree_vm_ref_retain_or_move_checked"(%[[REF_0]], %[[C]], %arg3) {args = [false, 0 : index, 1 : index, 2 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.opaque<"iree_vm_ref_type_t">, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
     %0 = vm.global.load.ref @g0 : !vm.buffer
     vm.return %0 : !vm.buffer
   }
@@ -61,14 +61,14 @@ vm.module @my_module {
   // CHECK-LABEL: emitc.func private @my_module_global_store_ref
   vm.func @global_store_ref(%arg0 : !vm.buffer) {
     // CHECK: %[[STATE_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
-    // CHECK-NEXT: emitc.assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
+    // CHECK-NEXT: assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
     // CHECK-NEXT: %[[REFS_LVAL:.+]] = "emitc.member_of_ptr"(%[[STATE_LVAL]]) <{member = "refs"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>) -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>>
-    // CHECK-NEXT: %[[REFS:.+]] = emitc.load %[[REFS_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>>
-    // CHECK: %[[REF_INDEX:.+]] = emitc.literal "0" : !emitc.opaque<"iree_host_size_t">
-    // CHECK-NEXT: %[[REF:.+]] = emitc.subscript %[[REFS]][%[[REF_INDEX]]] : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.opaque<"iree_host_size_t">) -> !emitc.lvalue<!emitc.opaque<"iree_vm_ref_t">>
-    // CHECK-NEXT: %[[REF_0:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.lvalue<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
-    // CHECK: %[[C:.+]] = emitc.call_opaque "iree_vm_type_def_as_ref"(%{{.+}}) : (!emitc.opaque<"iree_vm_type_def_t">) -> !emitc.opaque<"iree_vm_ref_type_t">
-    // CHECK: %{{.+}} = emitc.call_opaque "iree_vm_ref_retain_or_move_checked"(%arg3, %[[C]], %[[REF_0]]) {args = [false, 0 : index, 1 : index, 2 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.opaque<"iree_vm_ref_type_t">, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %[[REFS:.+]] = load %[[REFS_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>>
+    // CHECK: %[[REF_INDEX:.+]] = literal "0" : !emitc.opaque<"iree_host_size_t">
+    // CHECK-NEXT: %[[REF:.+]] = subscript %[[REFS]][%[[REF_INDEX]]] : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.opaque<"iree_host_size_t">) -> !emitc.lvalue<!emitc.opaque<"iree_vm_ref_t">>
+    // CHECK-NEXT: %[[REF_0:.+]] = apply "&"(%[[REF]]) : (!emitc.lvalue<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
+    // CHECK: %[[C:.+]] = call_opaque "iree_vm_type_def_as_ref"(%{{.+}}) : (!emitc.opaque<"iree_vm_type_def_t">) -> !emitc.opaque<"iree_vm_ref_type_t">
+    // CHECK: %{{.+}} = call_opaque "iree_vm_ref_retain_or_move_checked"(%arg3, %[[C]], %[[REF_0]]) {args = [false, 0 : index, 1 : index, 2 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>, !emitc.opaque<"iree_vm_ref_type_t">, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
     vm.global.store.ref %arg0, @g0_mut : !vm.buffer
     vm.return
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/global_ops_f32.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/global_ops_f32.mlir
@@ -6,10 +6,10 @@ vm.module @my_module {
   // CHECK-LABEL: emitc.func private @my_module_global_load_f32
   vm.func @global_load_f32() -> f32 {
     // CHECK-NEXT: %[[STATE_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
-    // CHECK-NEXT: emitc.assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
+    // CHECK-NEXT: assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
     // CHECK-NEXT: %[[RWDATA_LVAL:.+]] = "emitc.member_of_ptr"(%[[STATE_LVAL]]) <{member = "rwdata"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>) -> !emitc.lvalue<!emitc.ptr<ui8>>
-    // CHECK-NEXT: %[[RWDATA:.+]] = emitc.load %[[RWDATA_LVAL]] : <!emitc.ptr<ui8>>
-    // CHECK-NEXT: %[[RES:.+]] = emitc.call_opaque "vm_global_load_f32"(%[[RWDATA]]) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<ui8>) -> f32
+    // CHECK-NEXT: %[[RWDATA:.+]] = load %[[RWDATA_LVAL]] : <!emitc.ptr<ui8>>
+    // CHECK-NEXT: %[[RES:.+]] = call_opaque "vm_global_load_f32"(%[[RWDATA]]) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<ui8>) -> f32
     %0 = vm.global.load.f32 @c42 : f32
     vm.return %0 : f32
   }
@@ -23,10 +23,10 @@ vm.module @my_module {
   // CHECK-LABEL: emitc.func private @my_module_global_store_f32
   vm.func @global_store_f32(%arg0 : f32) {
     // CHECK-NEXT: %[[STATE_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
-    // CHECK-NEXT: emitc.assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
+    // CHECK-NEXT: assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
     // CHECK-NEXT: %[[RWDATA_LVAL:.+]] = "emitc.member_of_ptr"(%[[STATE_LVAL]]) <{member = "rwdata"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>) -> !emitc.lvalue<!emitc.ptr<ui8>>
-    // CHECK-NEXT: %[[RWDATA:.+]] = emitc.load %[[RWDATA_LVAL]] : <!emitc.ptr<ui8>>
-    // CHECK-NEXT: emitc.call_opaque "vm_global_store_f32"(%[[RWDATA]], %arg3) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.ptr<ui8>, f32) -> ()
+    // CHECK-NEXT: %[[RWDATA:.+]] = load %[[RWDATA_LVAL]] : <!emitc.ptr<ui8>>
+    // CHECK-NEXT: call_opaque "vm_global_store_f32"(%[[RWDATA]], %arg3) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.ptr<ui8>, f32) -> ()
     vm.global.store.f32 %arg0, @c107_mut : f32
     vm.return
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/global_ops_i64.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/global_ops_i64.mlir
@@ -6,10 +6,10 @@ vm.module @my_module {
   // CHECK-LABEL: emitc.func private @my_module_global_load_i64
   vm.func @global_load_i64() -> i64 {
     // CHECK-NEXT: %[[STATE_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
-    // CHECK-NEXT: emitc.assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
+    // CHECK-NEXT: assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
     // CHECK-NEXT: %[[RWDATA_LVAL:.+]] = "emitc.member_of_ptr"(%[[STATE_LVAL]]) <{member = "rwdata"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>) -> !emitc.lvalue<!emitc.ptr<ui8>>
-    // CHECK-NEXT: %[[RWDATA:.+]] = emitc.load %[[RWDATA_LVAL]] : <!emitc.ptr<ui8>>
-    // CHECK-NEXT: %[[RES:.+]] = emitc.call_opaque "vm_global_load_i64"(%[[RWDATA]]) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<ui8>) -> i64
+    // CHECK-NEXT: %[[RWDATA:.+]] = load %[[RWDATA_LVAL]] : <!emitc.ptr<ui8>>
+    // CHECK-NEXT: %[[RES:.+]] = call_opaque "vm_global_load_i64"(%[[RWDATA]]) {args = [0 : index, 0 : ui32]} : (!emitc.ptr<ui8>) -> i64
     %0 = vm.global.load.i64 @c42 : i64
     vm.return %0 : i64
   }
@@ -23,10 +23,10 @@ vm.module @my_module {
   // CHECK-LABEL: emitc.func private @my_module_global_store_i64
   vm.func @global_store_i64(%arg0 : i64) {
     // CHECK-NEXT: %[[STATE_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
-    // CHECK-NEXT: emitc.assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
+    // CHECK-NEXT: assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
     // CHECK-NEXT: %[[RWDATA_LVAL:.+]] = "emitc.member_of_ptr"(%[[STATE_LVAL]]) <{member = "rwdata"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>) -> !emitc.lvalue<!emitc.ptr<ui8>>
-    // CHECK-NEXT: %[[RWDATA:.+]] = emitc.load %[[RWDATA_LVAL]] : <!emitc.ptr<ui8>>
-    // CHECK-NEXT: emitc.call_opaque "vm_global_store_i64"(%[[RWDATA]], %arg3) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.ptr<ui8>, i64) -> ()
+    // CHECK-NEXT: %[[RWDATA:.+]] = load %[[RWDATA_LVAL]] : <!emitc.ptr<ui8>>
+    // CHECK-NEXT: call_opaque "vm_global_store_i64"(%[[RWDATA]], %arg3) {args = [0 : index, 0 : ui32, 1 : index]} : (!emitc.ptr<ui8>, i64) -> ()
     vm.global.store.i64 %arg0, @c107_mut : i64
     vm.return
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/list_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/list_ops.mlir
@@ -4,18 +4,18 @@ vm.module @my_module {
   // CHECK-LABEL: emitc.func private @my_module_list_alloc
   vm.func @list_alloc(%arg0: i32) -> !vm.list<i32> {
     // CHECK: %[[LIST_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"NULL">}> : () -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>>
-    // CHECK: %[[LIST_PTR:.+]] = emitc.apply "&"(%3) : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>>) -> !emitc.ptr<!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>>
+    // CHECK: %[[LIST_PTR:.+]] = apply "&"(%3) : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>>) -> !emitc.ptr<!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>>
     // CHECK-DAG: %[[STATE_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
-    // CHECK-DAG: emitc.assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
+    // CHECK-DAG: assign %arg2 : !emitc.ptr<!emitc.opaque<"struct my_module_state_t">> to %[[STATE_LVAL]] : <!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>
     // CHECK-DAG: %[[ALLOCATOR_LVAL:.+]] = "emitc.member_of_ptr"(%[[STATE_LVAL]]) <{member = "allocator"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"struct my_module_state_t">>>) -> !emitc.lvalue<!emitc.opaque<"iree_allocator_t">>
-    // CHECK-DAG: %[[ALLOCATOR:.+]] = emitc.load %[[ALLOCATOR_LVAL]] : <!emitc.opaque<"iree_allocator_t">>
+    // CHECK-DAG: %[[ALLOCATOR:.+]] = load %[[ALLOCATOR_LVAL]] : <!emitc.opaque<"iree_allocator_t">>
 
-    // CHECK: %[[TYPE_DEF:.+]] = emitc.call_opaque "iree_vm_make_value_type_def"() {args = [#emitc.opaque<"IREE_VM_VALUE_TYPE_I32">]} : () -> !emitc.opaque<"iree_vm_type_def_t">
-    // CHECK-NEXT: %[[STATUS:.+]] = emitc.call_opaque "iree_vm_list_create"(%[[TYPE_DEF]], %arg3, %[[ALLOCATOR]], %[[LIST_PTR]]) : (!emitc.opaque<"iree_vm_type_def_t">, i32, !emitc.opaque<"iree_allocator_t">, !emitc.ptr<!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>>) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %[[TYPE_DEF:.+]] = call_opaque "iree_vm_make_value_type_def"() {args = [#emitc.opaque<"IREE_VM_VALUE_TYPE_I32">]} : () -> !emitc.opaque<"iree_vm_type_def_t">
+    // CHECK-NEXT: %[[STATUS:.+]] = call_opaque "iree_vm_list_create"(%[[TYPE_DEF]], %arg3, %[[ALLOCATOR]], %[[LIST_PTR]]) : (!emitc.opaque<"iree_vm_type_def_t">, i32, !emitc.opaque<"iree_allocator_t">, !emitc.ptr<!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>>) -> !emitc.opaque<"iree_status_t">
 
-    // CHECK: %[[LIST_TYPE_ID:.+]] = emitc.call_opaque "iree_vm_list_type"() : () -> !emitc.opaque<"iree_vm_ref_type_t">
-    // CHECK-NEXT: %[[LIST:.+]] = emitc.load %[[LIST_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>>
-    // CHECK-NEXT: %[[STATUS2:.+]] = emitc.call_opaque "iree_vm_ref_wrap_assign"(%[[LIST]], %[[LIST_TYPE_ID]], %arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, !emitc.opaque<"iree_vm_ref_type_t">, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
+    // CHECK: %[[LIST_TYPE_ID:.+]] = call_opaque "iree_vm_list_type"() : () -> !emitc.opaque<"iree_vm_ref_type_t">
+    // CHECK-NEXT: %[[LIST:.+]] = load %[[LIST_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>>
+    // CHECK-NEXT: %[[STATUS2:.+]] = call_opaque "iree_vm_ref_wrap_assign"(%[[LIST]], %[[LIST_TYPE_ID]], %arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, !emitc.opaque<"iree_vm_ref_type_t">, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
 
     %0 = vm.list.alloc %arg0 : (i32) -> !vm.list<i32>
     vm.return %0 : !vm.list<i32>
@@ -27,9 +27,9 @@ vm.module @my_module {
 vm.module @my_module {
   // CHECK-LABEL: emitc.func private @my_module_list_reserve
   vm.func @list_reserve(%arg0: !vm.list<i32>, %arg1: i32) {
-    // CHECK-NEXT: %0 = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %1 = emitc.call_opaque "iree_vm_list_deref"(%0) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
-    // CHECK: %{{.+}} = emitc.call_opaque "iree_vm_list_reserve"(%1, %arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32) -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %0 = apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK-NEXT: %1 = call_opaque "iree_vm_list_deref"(%0) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
+    // CHECK: %{{.+}} = call_opaque "iree_vm_list_reserve"(%1, %arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32) -> !emitc.opaque<"iree_status_t">
     vm.list.reserve %arg0, %arg1 : (!vm.list<i32>, i32)
     vm.return
   }
@@ -40,9 +40,9 @@ vm.module @my_module {
 vm.module @my_module {
   // CHECK-LABEL: emitc.func private @my_module_list_resize
   vm.func @list_resize(%arg0: !vm.list<i32>, %arg1: i32) {
-    // CHECK-NEXT: %0 = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %1 = emitc.call_opaque "iree_vm_list_deref"(%0) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
-    // CHECK: %{{.+}} = emitc.call_opaque "iree_vm_list_resize"(%1, %arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32) -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %0 = apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK-NEXT: %1 = call_opaque "iree_vm_list_deref"(%0) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
+    // CHECK: %{{.+}} = call_opaque "iree_vm_list_resize"(%1, %arg4) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32) -> !emitc.opaque<"iree_status_t">
     vm.list.resize %arg0, %arg1 : (!vm.list<i32>, i32)
     vm.return
   }
@@ -53,9 +53,9 @@ vm.module @my_module {
 vm.module @my_module {
   // CHECK-LABEL: emitc.func private @my_module_list_size
   vm.func @list_size(%arg0: !vm.list<i32>) -> i32 {
-    // CHECK-NEXT: %0 = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %1 = emitc.call_opaque "iree_vm_list_deref"(%0) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
-    // CHECK: %{{.+}} = emitc.call_opaque "iree_vm_list_size"(%1) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>) -> i32
+    // CHECK-NEXT: %0 = apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK-NEXT: %1 = call_opaque "iree_vm_list_deref"(%0) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
+    // CHECK: %{{.+}} = call_opaque "iree_vm_list_size"(%1) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>) -> i32
     %0 = vm.list.size %arg0 : (!vm.list<i32>) -> i32
     vm.return %0 : i32
   }
@@ -67,10 +67,10 @@ vm.module @my_module {
   // CHECK-LABEL: emitc.func private @my_module_list_get_i32
   vm.func @list_get_i32(%arg0: !vm.list<i32>, %arg1: i32) -> i32 {
     // CHECK-NEXT: %0 = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.opaque<"iree_vm_value_t">>
-    // CHECK-NEXT: %1 = emitc.apply "&"(%0) : (!emitc.lvalue<!emitc.opaque<"iree_vm_value_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_value_t">>
-    // CHECK-NEXT: %2 = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %3 = emitc.call_opaque "iree_vm_list_deref"(%2) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
-    // CHECK: %{{.+}} = emitc.call_opaque "iree_vm_list_get_value_as"(%3, %arg4, %1) {args = [0 : index, 1 : index, #emitc.opaque<"IREE_VM_VALUE_TYPE_I32">, 2 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32, !emitc.ptr<!emitc.opaque<"iree_vm_value_t">>) -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %1 = apply "&"(%0) : (!emitc.lvalue<!emitc.opaque<"iree_vm_value_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_value_t">>
+    // CHECK-NEXT: %2 = apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK-NEXT: %3 = call_opaque "iree_vm_list_deref"(%2) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
+    // CHECK: %{{.+}} = call_opaque "iree_vm_list_get_value_as"(%3, %arg4, %1) {args = [0 : index, 1 : index, #emitc.opaque<"IREE_VM_VALUE_TYPE_I32">, 2 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32, !emitc.ptr<!emitc.opaque<"iree_vm_value_t">>) -> !emitc.opaque<"iree_status_t">
     %0 = vm.list.get.i32 %arg0, %arg1 : (!vm.list<i32>, i32) -> i32
     vm.return %0 : i32
   }
@@ -81,23 +81,23 @@ vm.module @my_module {
 vm.module @my_module {
   // CHECK-LABEL: emitc.func private @my_module_list_get_ref
   vm.func @list_get_ref(%arg0: !vm.list<!vm.ref<?>>, %arg1: i32) -> !vm.buffer {
-    // CHECK-NEXT: %0 = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %1 = emitc.call_opaque "iree_vm_list_deref"(%0) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
-    // CHECK: %{{.+}} = emitc.call_opaque "iree_vm_list_get_ref_retain"(%1, %arg4, %arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %0 = apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK-NEXT: %1 = call_opaque "iree_vm_list_deref"(%0) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
+    // CHECK: %{{.+}} = call_opaque "iree_vm_list_get_ref_retain"(%1, %arg4, %arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
     // CHECK: %[[REF_LVAL:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>>
-    // CHECK-NEXT: emitc.assign %arg3 : !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">> to %[[REF_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>>
+    // CHECK-NEXT: assign %arg3 : !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">> to %[[REF_LVAL]] : <!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>>
     // CHECK: %[[TYPE_LVAL:.+]] = "emitc.member_of_ptr"(%[[REF_LVAL]]) <{member = "type"}> : (!emitc.lvalue<!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>>) -> !emitc.lvalue<!emitc.opaque<"iree_vm_ref_type_t">>
-    // CHECK-NEXT: %[[TYPE:.+]] = emitc.load %[[TYPE_LVAL]] : <!emitc.opaque<"iree_vm_ref_type_t">>
+    // CHECK-NEXT: %[[TYPE:.+]] = load %[[TYPE_LVAL]] : <!emitc.opaque<"iree_vm_ref_type_t">>
     // CHECK: %[[B:.+]] = "emitc.constant"() <{value = #emitc.opaque<"IREE_VM_REF_TYPE_NULL">}> : () -> !emitc.opaque<"iree_vm_ref_type_t">
-    // CHECK: %[[C:.+]] = emitc.cmp ne, %[[TYPE]], %[[B]] : (!emitc.opaque<"iree_vm_ref_type_t">, !emitc.opaque<"iree_vm_ref_type_t">) -> i1
-    // CHECK: %[[D:.+]] = emitc.call_opaque "iree_vm_type_def_is_value"(%{{.+}}) : (!emitc.opaque<"iree_vm_type_def_t">) -> i1
-    // CHECK: %[[E:.+]] = emitc.call_opaque "iree_vm_type_def_as_ref"(%{{.+}}) : (!emitc.opaque<"iree_vm_type_def_t">) -> !emitc.opaque<"iree_vm_ref_type_t">
-    // CHECK: %[[F:.+]] = emitc.cmp ne, %[[TYPE]], %[[E]] : (!emitc.opaque<"iree_vm_ref_type_t">, !emitc.opaque<"iree_vm_ref_type_t">) -> i1
-    // CHECK: %[[G:.+]] = emitc.logical_or %[[D]], %[[F]] : i1, i1
-    // CHECK: %{{.+}} = emitc.logical_and %[[C]], %[[G]] : i1, i1
+    // CHECK: %[[C:.+]] = cmp ne, %[[TYPE]], %[[B]] : (!emitc.opaque<"iree_vm_ref_type_t">, !emitc.opaque<"iree_vm_ref_type_t">) -> i1
+    // CHECK: %[[D:.+]] = call_opaque "iree_vm_type_def_is_value"(%{{.+}}) : (!emitc.opaque<"iree_vm_type_def_t">) -> i1
+    // CHECK: %[[E:.+]] = call_opaque "iree_vm_type_def_as_ref"(%{{.+}}) : (!emitc.opaque<"iree_vm_type_def_t">) -> !emitc.opaque<"iree_vm_ref_type_t">
+    // CHECK: %[[F:.+]] = cmp ne, %[[TYPE]], %[[E]] : (!emitc.opaque<"iree_vm_ref_type_t">, !emitc.opaque<"iree_vm_ref_type_t">) -> i1
+    // CHECK: %[[G:.+]] = logical_or %[[D]], %[[F]] : i1, i1
+    // CHECK: %{{.+}} = logical_and %[[C]], %[[G]] : i1, i1
     // CHECK: cf.cond_br %{{.+}}, ^[[FAIL:.+]], ^[[CONTINUE:.+]]
     // CHECK: ^[[FAIL]]:
-    // CHECK-NEXT: emitc.call_opaque "iree_vm_ref_release"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> ()
+    // CHECK-NEXT: call_opaque "iree_vm_ref_release"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> ()
     // CHECK-NEXT: cf.br ^[[CONTINUE]]
     %0 = vm.list.get.ref %arg0, %arg1 : (!vm.list<!vm.ref<?>>, i32) -> !vm.buffer
     vm.return %0 : !vm.buffer
@@ -109,13 +109,13 @@ vm.module @my_module {
 vm.module @my_module {
   // CHECK-LABEL: emitc.func private @my_module_list_set_i32
   vm.func @list_set_i32(%arg0: !vm.list<i32>, %arg1: i32, %arg2: i32) {
-    // CHECK-NEXT: %0 = emitc.call_opaque "iree_vm_value_make_i32"(%arg5) : (i32) -> !emitc.opaque<"iree_vm_value_t">
+    // CHECK-NEXT: %0 = call_opaque "iree_vm_value_make_i32"(%arg5) : (i32) -> !emitc.opaque<"iree_vm_value_t">
     // CHECK-NEXT: %1 = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.opaque<"iree_vm_value_t">>
-    // CHECK-NEXT: emitc.assign %0 : !emitc.opaque<"iree_vm_value_t"> to %1 : <!emitc.opaque<"iree_vm_value_t">>
-    // CHECK-NEXT: %2 = emitc.apply "&"(%1) : (!emitc.lvalue<!emitc.opaque<"iree_vm_value_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_value_t">>
-    // CHECK-NEXT: %3 = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %4 = emitc.call_opaque "iree_vm_list_deref"(%3) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
-    // CHECK: %{{.+}} = emitc.call_opaque "iree_vm_list_set_value"(%4, %arg4, %2) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32, !emitc.ptr<!emitc.opaque<"iree_vm_value_t">>) -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: assign %0 : !emitc.opaque<"iree_vm_value_t"> to %1 : <!emitc.opaque<"iree_vm_value_t">>
+    // CHECK-NEXT: %2 = apply "&"(%1) : (!emitc.lvalue<!emitc.opaque<"iree_vm_value_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_value_t">>
+    // CHECK-NEXT: %3 = apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK-NEXT: %4 = call_opaque "iree_vm_list_deref"(%3) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
+    // CHECK: %{{.+}} = call_opaque "iree_vm_list_set_value"(%4, %arg4, %2) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32, !emitc.ptr<!emitc.opaque<"iree_vm_value_t">>) -> !emitc.opaque<"iree_status_t">
     vm.list.set.i32 %arg0, %arg1, %arg2 : (!vm.list<i32>, i32, i32)
     vm.return
   }
@@ -126,9 +126,9 @@ vm.module @my_module {
 vm.module @my_module {
   // CHECK-LABEL: emitc.func private @my_module_list_set_ref
   vm.func @list_set_ref(%arg0: !vm.list<!vm.ref<?>>, %arg1: i32, %arg2: !vm.buffer) {
-    // CHECK-NEXT: %0 = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %1 = emitc.call_opaque "iree_vm_list_deref"(%0) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
-    // CHECK: %{{.+}} = emitc.call_opaque "iree_vm_list_set_ref_retain"(%1, %arg4, %arg5) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %0 = apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK-NEXT: %1 = call_opaque "iree_vm_list_deref"(%0) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
+    // CHECK: %{{.+}} = call_opaque "iree_vm_list_set_ref_retain"(%1, %arg4, %arg5) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32, !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_status_t">
     vm.list.set.ref %arg0, %arg1, %arg2 : (!vm.list<!vm.ref<?>>, i32, !vm.buffer)
     vm.return
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/list_ops_i64.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/list_ops_i64.mlir
@@ -4,10 +4,10 @@ vm.module @my_module {
   // CHECK-LABEL: emitc.func private @my_module_list_get_i64
   vm.func @list_get_i64(%arg0: !vm.list<i64>, %arg1: i32) -> i64 {
     // CHECK-NEXT: %0 = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.opaque<"iree_vm_value_t">>
-    // CHECK-NEXT: %1 = emitc.apply "&"(%0) : (!emitc.lvalue<!emitc.opaque<"iree_vm_value_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_value_t">>
-    // CHECK-NEXT: %2 = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %3 = emitc.call_opaque "iree_vm_list_deref"(%2) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
-    // CHECK: %{{.+}} = emitc.call_opaque "iree_vm_list_get_value_as"(%3, %arg4, %1) {args = [0 : index, 1 : index, #emitc.opaque<"IREE_VM_VALUE_TYPE_I64">, 2 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32, !emitc.ptr<!emitc.opaque<"iree_vm_value_t">>) -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: %1 = apply "&"(%0) : (!emitc.lvalue<!emitc.opaque<"iree_vm_value_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_value_t">>
+    // CHECK-NEXT: %2 = apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK-NEXT: %3 = call_opaque "iree_vm_list_deref"(%2) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
+    // CHECK: %{{.+}} = call_opaque "iree_vm_list_get_value_as"(%3, %arg4, %1) {args = [0 : index, 1 : index, #emitc.opaque<"IREE_VM_VALUE_TYPE_I64">, 2 : index]} : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32, !emitc.ptr<!emitc.opaque<"iree_vm_value_t">>) -> !emitc.opaque<"iree_status_t">
     %0 = vm.list.get.i64 %arg0, %arg1 : (!vm.list<i64>, i32) -> i64
     vm.return %0 : i64
   }
@@ -18,13 +18,13 @@ vm.module @my_module {
 vm.module @my_module {
   // CHECK-LABEL: emitc.func private @my_module_list_set_i64
   vm.func @list_set_i64(%arg0: !vm.list<i64>, %arg1: i32, %arg2: i64) {
-    // CHECK-NEXT: %0 = emitc.call_opaque "iree_vm_value_make_i64"(%arg5) : (i64) -> !emitc.opaque<"iree_vm_value_t">
+    // CHECK-NEXT: %0 = call_opaque "iree_vm_value_make_i64"(%arg5) : (i64) -> !emitc.opaque<"iree_vm_value_t">
     // CHECK-NEXT: %1 = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.opaque<"iree_vm_value_t">>
-    // CHECK-NEXT: emitc.assign %0 : !emitc.opaque<"iree_vm_value_t"> to %1 : <!emitc.opaque<"iree_vm_value_t">>
-    // CHECK-NEXT: %2 = emitc.apply "&"(%1) : (!emitc.lvalue<!emitc.opaque<"iree_vm_value_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_value_t">>
-    // CHECK-NEXT: %3 = emitc.apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
-    // CHECK-NEXT: %4 = emitc.call_opaque "iree_vm_list_deref"(%3) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
-    // CHECK: %{{.+}} = emitc.call_opaque "iree_vm_list_set_value"(%4, %arg4, %2) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32, !emitc.ptr<!emitc.opaque<"iree_vm_value_t">>) -> !emitc.opaque<"iree_status_t">
+    // CHECK-NEXT: assign %0 : !emitc.opaque<"iree_vm_value_t"> to %1 : <!emitc.opaque<"iree_vm_value_t">>
+    // CHECK-NEXT: %2 = apply "&"(%1) : (!emitc.lvalue<!emitc.opaque<"iree_vm_value_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_value_t">>
+    // CHECK-NEXT: %3 = apply "*"(%arg3) : (!emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.opaque<"iree_vm_ref_t">
+    // CHECK-NEXT: %4 = call_opaque "iree_vm_list_deref"(%3) : (!emitc.opaque<"iree_vm_ref_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_list_t">>
+    // CHECK: %{{.+}} = call_opaque "iree_vm_list_set_value"(%4, %arg4, %2) : (!emitc.ptr<!emitc.opaque<"iree_vm_list_t">>, i32, !emitc.ptr<!emitc.opaque<"iree_vm_value_t">>) -> !emitc.opaque<"iree_status_t">
     vm.list.set.i64 %arg0, %arg1, %arg2 : (!vm.list<i64>, i32, i64)
     vm.return
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/shift_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/shift_ops.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: emitc.func private @my_module_shl_i32
 vm.module @my_module {
   vm.func @shl_i32(%arg0 : i32, %arg1 : i32) -> i32 {
-    // CHECK: %0 = emitc.call_opaque "vm_shl_i32"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK: %0 = call_opaque "vm_shl_i32"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.shl.i32 %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -14,7 +14,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_shr_i32_s
 vm.module @my_module {
   vm.func @shr_i32_s(%arg0 : i32, %arg1 : i32) -> i32 {
-    // CHECK: %0 = emitc.call_opaque "vm_shr_i32s"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK: %0 = call_opaque "vm_shr_i32s"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.shr.i32.s %arg0, %arg1 : i32
     vm.return %0 : i32
   }
@@ -25,7 +25,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_shr_i32_u
 vm.module @my_module {
   vm.func @shr_i32_u(%arg0 : i32, %arg1 : i32) -> i32 {
-    // CHECK: %0 = emitc.call_opaque "vm_shr_i32u"(%arg3, %arg4) : (i32, i32) -> i32
+    // CHECK: %0 = call_opaque "vm_shr_i32u"(%arg3, %arg4) : (i32, i32) -> i32
     %0 = vm.shr.i32.u %arg0, %arg1 : i32
     vm.return %0 : i32
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/shift_ops_i64.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/shift_ops_i64.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: emitc.func private @my_module_shl_i64
 vm.module @my_module {
   vm.func @shl_i64(%arg0 : i64, %arg1 : i32) -> i64 {
-    // CHECK: %0 = emitc.call_opaque "vm_shl_i64"(%arg3, %arg4) : (i64, i32) -> i64
+    // CHECK: %0 = call_opaque "vm_shl_i64"(%arg3, %arg4) : (i64, i32) -> i64
     %0 = vm.shl.i64 %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -14,7 +14,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_shr_i64_s
 vm.module @my_module {
   vm.func @shr_i64_s(%arg0 : i64, %arg1 : i32) -> i64 {
-    // CHECK: %0 = emitc.call_opaque "vm_shr_i64s"(%arg3, %arg4) : (i64, i32) -> i64
+    // CHECK: %0 = call_opaque "vm_shr_i64s"(%arg3, %arg4) : (i64, i32) -> i64
     %0 = vm.shr.i64.s %arg0, %arg1 : i64
     vm.return %0 : i64
   }
@@ -25,7 +25,7 @@ vm.module @my_module {
 // CHECK-LABEL: emitc.func private @my_module_shr_i64_u
 vm.module @my_module {
   vm.func @shr_i64_u(%arg0 : i64, %arg1 : i32) -> i64 {
-    // CHECK: %0 = emitc.call_opaque "vm_shr_i64u"(%arg3, %arg4) : (i64, i32) -> i64
+    // CHECK: %0 = call_opaque "vm_shr_i64u"(%arg3, %arg4) : (i64, i32) -> i64
     %0 = vm.shr.i64.u %arg0, %arg1 : i64
     vm.return %0 : i64
   }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/type_conversion.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/type_conversion.mlir
@@ -4,7 +4,7 @@ vm.module @my_module {
   // CHECK-LABEL: emitc.func private @my_module_list_alloc
   vm.func @list_alloc(%arg0: i32) {
     // CHECK: %[[REF:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.opaque<"iree_vm_ref_t">>
-    // CHECK: %[[REFPTR:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.lvalue<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
+    // CHECK: %[[REFPTR:.+]] = apply "&"(%[[REF]]) : (!emitc.lvalue<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
     %list = vm.list.alloc %arg0 : (i32) -> !vm.list<i32>
     %list_dno = util.optimization_barrier %list : !vm.list<i32>
     // CHECK: util.optimization_barrier %[[REFPTR]] : !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
@@ -15,9 +15,9 @@ vm.module @my_module {
   vm.func @list_size(%arg0: i32) {
     %list = vm.list.alloc %arg0 : (i32) -> !vm.list<i32>
     // CHECK: %[[REF:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.opaque<"iree_vm_ref_t">>
-    // CHECK: %[[REFPTR:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.lvalue<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
+    // CHECK: %[[REFPTR:.+]] = apply "&"(%[[REF]]) : (!emitc.lvalue<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
     %size = vm.list.size %list : (!vm.list<i32>) -> i32
-    // CHECK: %[[SIZE:.+]] = emitc.call_opaque "iree_vm_list_size"(%{{.+}})
+    // CHECK: %[[SIZE:.+]] = call_opaque "iree_vm_list_size"(%{{.+}})
     %size_dno = util.optimization_barrier %size : i32
     // CHECK: util.optimization_barrier %[[SIZE]] : i32
     vm.return
@@ -32,7 +32,7 @@ vm.module @my_module {
   vm.export @ref
   vm.func @ref(%arg0: i32) {
     // CHECK: %[[REF:.+]] = "emitc.variable"() <{value = #emitc.opaque<"">}> : () -> !emitc.lvalue<!emitc.opaque<"iree_vm_ref_t">>
-    // CHECK: %[[REFPTR:.+]] = emitc.apply "&"(%[[REF]]) : (!emitc.lvalue<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
+    // CHECK: %[[REFPTR:.+]] = apply "&"(%[[REF]]) : (!emitc.lvalue<!emitc.opaque<"iree_vm_ref_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>
     %buffer = vm.const.ref.rodata @byte_buffer : !vm.buffer
     %buffer_dno = util.optimization_barrier %buffer : !vm.buffer
     // CHECK: util.optimization_barrier %[[REFPTR]] : !emitc.ptr<!emitc.opaque<"iree_vm_ref_t">>


### PR DESCRIPTION
Changes needed to integrate https://github.com/llvm/llvm-project/pull/116297

Generated by:
```bash
for op in call_opaque apply assign load literal subscript call cast add logical_not cmp logical_or logical_and; do sed -i "s/emitc.$op/$op/g" compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/*.mlir; done
```