### PR TITLE
[Codegen] Harden yielding logic in TileDispatchUsingForall

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
@@ -265,8 +265,12 @@ static LogicalResult dropUnitDistributedDims(RewriterBase &rewriter,
 // Pass implementation.
 //===---------------------------------------------------------------------===//
 
-static void fuseConsumers(RewriterBase &rewriter, Operation *tiledOp) {
-
+// Fuse all consumers of the given `tiledOp` into the surrounding scf.forall.
+// Returns a list of new `tensor.extract_slice` ops with new fusion
+// opportunities, as well as the new surrounding `scf.forall` (because consumer
+// fusion replaces the loop).
+static std::pair<std::deque<Operation *>, scf::ForallOp>
+fuseConsumers(RewriterBase &rewriter, Operation *tiledOp) {
   auto addCandidateSlices =
       [](Operation *fusedOp,
          std::queue<tensor::ParallelInsertSliceOp> &candidates) {
@@ -283,6 +287,8 @@ static void fuseConsumers(RewriterBase &rewriter, Operation *tiledOp) {
   std::queue<tensor::ParallelInsertSliceOp> candidates;
   addCandidateSlices(tiledOp, candidates);
 
+  std::deque<Operation *> newFusionOpportunities;
+  scf::ForallOp newLoop = tiledOp->getParentOfType<scf::ForallOp>();
   while (!candidates.empty()) {
 
     // Traverse the slices in BFS fashion.
@@ -301,11 +307,63 @@ static void fuseConsumers(RewriterBase &rewriter, Operation *tiledOp) {
     rewriter.replaceOp(fusedResult->origConsumerOperand->getOwner(),
                        fusedResult->tiledOps.front());
 
-    // The result of the fused conumers might themselved be slices of
+    // The result of the fused consumers might themselved be slices of
     // values produced by operations that implement the `TilingInterface`.
     // Add these operations to the worklist.
     addCandidateSlices(fusedResult->tiledAndFusedConsumerOperand->getOwner(),
                        candidates);
+
+    // Add the list of new producer fusion opportunities.
+    for (auto tiledOp : fusedResult.value().tiledOps) {
+      for (auto operand : tiledOp->getOperands()) {
+        if (auto sliceProducer =
+                operand.getDefiningOp<tensor::ExtractSliceOp>()) {
+          if (llvm::isa_and_present<TilingInterface>(
+                  sliceProducer.getSource().getDefiningOp())) {
+            newFusionOpportunities.push_back(sliceProducer);
+          }
+        }
+      }
+      // Store the new loop for follow up producer fusion.
+      newLoop = tiledOp->getParentOfType<scf::ForallOp>();
+    }
+  }
+  return std::make_pair(newFusionOpportunities, newLoop);
+}
+
+static void fuseProducersOfSlices(RewriterBase &rewriter,
+                                  std::deque<Operation *> &worklist,
+                                  scf::SCFTileAndFuseOptions &options,
+                                  scf::ForallOp forallOp) {
+  SmallVector<LoopLikeOpInterface> loops = {
+      cast<LoopLikeOpInterface>(&*forallOp)};
+  while (!worklist.empty()) {
+    auto candidateSlice = cast<tensor::ExtractSliceOp>(worklist.front());
+    worklist.pop_front();
+
+    auto fusableProducer =
+        candidateSlice.getSource().getDefiningOp<TilingInterface>();
+    if (!fusableProducer)
+      continue;
+
+    std::optional<scf::SCFTileAndFuseOptions::ControlFnResult> controlFnResult =
+        options.fusionControlFn(candidateSlice,
+                                cast<OpResult>(candidateSlice.getSource()),
+                                /*destinationInitArg=*/false);
+    if (!controlFnResult)
+      continue;
+
+    // The operands of the fused producer might themselved be slices of
+    // values produced by operations that implement the `TilingInterface`.
+    // Add these operations to the worklist.
+    std::optional<scf::SCFFuseProducerOfSliceResult> fusedResult =
+        scf::tileAndFuseProducerOfSlice(rewriter, candidateSlice, loops);
+    if (!fusedResult)
+      continue;
+
+    for (auto newSlice : fusedResult->generatedSlices) {
+      worklist.push_back(newSlice);
+    }
   }
 }
 
@@ -319,6 +377,7 @@ static void collectTiledAndFusedOps(Operation *rootOp,
   result.insert(rootOp);
   while (!worklist.empty()) {
     Operation *current = worklist.pop_back_val();
+    // Collect all tilable producers.
     for (OpOperand &operand : current->getOpOperands()) {
       Operation *producer = operand.get().getDefiningOp();
       if (!producer || !isa<TilingInterface>(producer) ||
@@ -326,6 +385,16 @@ static void collectTiledAndFusedOps(Operation *rootOp,
         continue;
       worklist.push_back(producer);
       result.insert(producer);
+    }
+    // Collect all tilable consumers.
+    for (auto user : current->getUsers()) {
+      if (result.count(user)) {
+        continue;
+      }
+      if (isa<TilingInterface>(user)) {
+        worklist.push_back(user);
+        result.insert(user);
+      }
     }
   }
 }
@@ -352,9 +421,18 @@ void TileAndDistributeToWorkgroupsUsingForallOpPass::runOnOperation() {
 
   llvm::DenseSet<Operation *> yieldReplacementsFor;
   for (auto op : tiledAndFusedOps) {
-    if (llvm::any_of(op->getUsers(), [&](Operation *user) {
-          return dominanceInfo.properlyDominates(tilableOp, user);
-        })) {
+    // Yield a replacement if:
+    //  a) All users of fused op are dominated by the tiling root.
+    //  b) There is at most a single tiled user. If there is more than one
+    //     then yielding a replacement may result in multiple incompatible
+    //     consumer fusions.
+    if (llvm::any_of(op->getUsers(),
+                     [&](Operation *user) {
+                       return dominanceInfo.properlyDominates(tilableOp, user);
+                     }) &&
+        (llvm::count_if(op->getUsers(), [&](Operation *user) {
+           return tiledAndFusedOps.contains(user);
+         }) < 2)) {
       yieldReplacementsFor.insert(op);
     }
   }
@@ -429,7 +507,15 @@ void TileAndDistributeToWorkgroupsUsingForallOpPass::runOnOperation() {
     }
 
     if (rootTiledOp) {
-      fuseConsumers(rewriter, rootTiledOp);
+      auto [newFusionOpportunities, newLoop] =
+          fuseConsumers(rewriter, rootTiledOp);
+
+      // Because we restrict to at most a single tilable consumer for yielding
+      // a replacement, no new fusion opportunities will yield a replacement,
+      // meaning there is no need to run consumer fusion again afterwards.
+      // TODO: run producer and consumer fusion in one worklist.
+      fuseProducersOfSlices(rewriter, newFusionOpportunities,
+                            tileAndFuseOptions, newLoop);
     }
   }
 


### PR DESCRIPTION
Currently the TileDispatchUsingForall pass chooses to yield replacements for fused producers based on dominance relative to the tiling root. Now that this pass includes consumer fusion, this can create situations where a single operation is consuming two loop yielded values, blocking fusion.

This patch disables yielding of values when there is more than one tilable consumer. As a result, it's common to have remaining producer fusion opportunities after fusing in consumers, so we add another iteration of producer fusion. In the future the fusion worklist needs to include both producer and consumer fusions to enable covering all cases.