### PR TITLE
[Encoding] Introduce EncodingLayoutAttrInterface.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/BUILD.bazel
@@ -19,6 +19,7 @@ iree_td_library(
         [
             "EncodingAttrs.td",
             "EncodingBase.td",
+            "EncodingInterfaces.td",
             "EncodingOps.td",
         ],
         include = ["*.td"],
@@ -45,6 +46,7 @@ iree_compiler_cc_library(
         "EncodingDialect.cpp",
         "EncodingDialect.cpp.inc",
         "EncodingEnums.cpp.inc",
+        "EncodingInterfaces.cpp.inc",
         "EncodingOps.cpp",
         "EncodingOps.cpp.inc",
         "EncodingTypes.cpp.inc",
@@ -54,6 +56,7 @@ iree_compiler_cc_library(
         "EncodingDialect.h",
         "EncodingDialect.h.inc",
         "EncodingEnums.h.inc",
+        "EncodingInterfaces.h.inc",
         "EncodingOps.h",
         "EncodingOps.h.inc",
         "EncodingTypes.h",
@@ -61,6 +64,7 @@ iree_compiler_cc_library(
     ],
     deps = [
         ":EncodingEnumsGen",
+        ":EncodingInterfacesGen",
         ":EncodingOpsIncGen",
         ":EncodingTypesGen",
         "@llvm-project//llvm:Support",
@@ -136,6 +140,23 @@ iree_gentbl_cc_library(
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "EncodingOps.td",
+    deps = [":td_files"],
+)
+
+iree_gentbl_cc_library(
+    name = "EncodingInterfacesGen",
+    tbl_outs = [
+        (
+            ["--gen-attr-interface-decls"],
+            "EncodingInterfaces.h.inc",
+        ),
+        (
+            ["--gen-attr-interface-defs"],
+            "EncodingInterfaces.cpp.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "EncodingInterfaces.td",
     deps = [":td_files"],
 )
 

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/CMakeLists.txt
@@ -18,6 +18,7 @@ iree_cc_library(
     "EncodingDialect.h"
     "EncodingDialect.h.inc"
     "EncodingEnums.h.inc"
+    "EncodingInterfaces.h.inc"
     "EncodingOps.h"
     "EncodingOps.h.inc"
     "EncodingTypes.h"
@@ -28,11 +29,13 @@ iree_cc_library(
     "EncodingDialect.cpp"
     "EncodingDialect.cpp.inc"
     "EncodingEnums.cpp.inc"
+    "EncodingInterfaces.cpp.inc"
     "EncodingOps.cpp"
     "EncodingOps.cpp.inc"
     "EncodingTypes.cpp.inc"
   DEPS
     ::EncodingEnumsGen
+    ::EncodingInterfacesGen
     ::EncodingOpsIncGen
     ::EncodingTypesGen
     LLVMSupport
@@ -81,6 +84,16 @@ iree_tablegen_library(
     --gen-op-defs EncodingOps.cpp.inc
     --dialect=iree_encoding --gen-dialect-decls EncodingDialect.h.inc
     --dialect=iree_encoding --gen-dialect-defs EncodingDialect.cpp.inc
+)
+
+iree_tablegen_library(
+  NAME
+    EncodingInterfacesGen
+  TD_FILE
+    "EncodingInterfaces.td"
+  OUTS
+    --gen-attr-interface-decls EncodingInterfaces.h.inc
+    --gen-attr-interface-defs EncodingInterfaces.cpp.inc
 )
 
 iree_tablegen_library(

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingDialect.cpp
@@ -20,6 +20,7 @@
 #define GET_ATTRDEF_CLASSES
 #include "iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp.inc"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingEnums.cpp.inc"
+#include "iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.cpp.inc"
 #undef GET_ATTRDEF_CLASSES
 
 namespace mlir::iree_compiler::IREE::Encoding {

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
@@ -39,6 +39,7 @@ def IREEEncoding_EncodingLayoutAttrInterface :
       ),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
+        assert(false && "unimplemented interface method");
         return {};
       }]
     >

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
@@ -1,0 +1,48 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_DIALECT_ENCODING_INTERFACES
+#define IREE_DIALECT_ENCODING_INTERFACES
+
+include "iree/compiler/Dialect/Encoding/IR/EncodingBase.td"
+include "mlir/IR/BuiltinAttributeInterfaces.td"
+
+def IREEEncoding_EncodingLayoutAttrInterface :
+  AttrInterface<"EncodingLayoutAttrInterface"> {
+  let cppNamespace = "::mlir::iree_compiler::IREE::Encoding";
+  let description = [{
+    Interface used to query layout information needed to materialize encoding
+    attributes.
+
+    Any backend can implement the interface to interpret an encoding layout
+    based on their needs.
+
+    TBD. The current expectation of the interface is to propagate layout
+    information from backends to the host compliation or other targets.
+  }];
+
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns the storage size (in bytes) for the tensor types with an
+        optional encoding.
+      }],
+      /*retTy=*/"::mlir::OpFoldResult",
+      /*methodName=*/"calculateStorageSizeInBytes",
+      /*args=*/(ins
+        "::mlir::OpBuilder &":$builder,
+        "RankedTensorType":$type,
+        "ValueRange":$dynamicDims
+      ),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return {};
+      }]
+    >
+  ];
+}
+
+#endif // IREE_DIALECT_ENCODING_INTERFACES

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.h
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.h
@@ -19,6 +19,7 @@
 
 // clang-format off
 #include "iree/compiler/Dialect/Encoding/IR/EncodingEnums.h.inc" // IWYU pragma: export
+#include "iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.h.inc" // IWYU pragma: export
 #define GET_ATTRDEF_CLASSES
 #include "iree/compiler/Dialect/Encoding/IR/EncodingAttrs.h.inc" // IWYU pragma: export
 #undef GET_ATTRDEF_CLASSES


### PR DESCRIPTION
The revisions introduces a new attribute interface in the Encoding dialect. The interface is used to query layout information needed to materialize encoding attributes.

Any backend can implement the interface to interpret an encoding layout based on their needs.

The current expectation of the interface is to propagate layout information from backends to the host compilation or other targets. The expectation can be adjusted as long as we identify additional needs for encodings/layouts.

It is a step towards https://github.com/iree-org/iree/issues/17924