### PR TITLE
[Codegen][GPU] Add reshape fusion and cleanup to tiling pass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
@@ -149,6 +149,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:TilingInterface",
         "@llvm-project//mlir:TransformUtils",
         "@llvm-project//mlir:Transforms",
+        "@llvm-project//mlir:ValueBoundsOpInterface",
         "@llvm-project//mlir:VectorDialect",
         "@llvm-project//mlir:VectorToSCF",
         "@llvm-project//mlir:VectorTransforms",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
@@ -124,6 +124,7 @@ iree_cc_library(
     MLIRTilingInterface
     MLIRTransformUtils
     MLIRTransforms
+    MLIRValueBoundsOpInterface
     MLIRVectorDialect
     MLIRVectorToSCF
     MLIRVectorTransforms

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyTilingLevel.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyTilingLevel.cpp
@@ -17,11 +17,13 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Transforms/TileUsingInterface.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Tensor/Transforms/Transforms.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/Dominance.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Interfaces/TilingInterface.h"
+#include "mlir/Interfaces/ValueBoundsOpInterface.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "iree-codegen-gpu-apply-tiling-level"
@@ -38,6 +40,132 @@ struct GPUApplyTilingLevelPass final
   void runOnOperation() override;
 };
 } // namespace
+
+/// Pattern to convert `tensor.extract_slice(tensor.expand_shape)` to
+/// `tensor.expand_shape(tensor.extract_slice)`.
+LogicalResult swapExpandShapeWithSlice(RewriterBase &rewriter,
+                                       tensor::ExpandShapeOp expandShapeOp,
+                                       tensor::ExtractSliceOp sliceOp) {
+
+  SmallVector<OpFoldResult> offsets = sliceOp.getMixedOffsets();
+  SmallVector<OpFoldResult> sizes = sliceOp.getMixedSizes();
+
+  // Helper variables and function for accumulating the new offset and length
+  // values.
+  Location loc = expandShapeOp->getLoc();
+  AffineExpr d0, d1, d2;
+  bindDims(rewriter.getContext(), d0, d1, d2);
+  // Multiply two integers.
+  auto mul = [&](OpFoldResult v1, OpFoldResult v2) {
+    auto mulMap = AffineMap::get(2, 0, {d0 * d1});
+    return affine::makeComposedFoldedAffineApply(rewriter, loc, mulMap,
+                                                 {v1, v2});
+  };
+  auto mulAdd = [&](OpFoldResult v1, OpFoldResult v2, OpFoldResult v3) {
+    auto mulMap = AffineMap::get(3, 0, {d0 * d1 + d2});
+    return affine::makeComposedFoldedAffineApply(rewriter, loc, mulMap,
+                                                 {v1, v2, v3});
+  };
+
+  SmallVector<OpFoldResult> outputShape =
+      getMixedValues(expandShapeOp.getStaticOutputShape(),
+                     expandShapeOp.getOutputShape(), rewriter);
+
+  // Compute new offsets, lengths, and strides.
+  SmallVector<OpFoldResult> newOffsets, newLengths, newStrides;
+
+  auto isZeroOffsetAndFullSize = [](OpFoldResult offset, OpFoldResult sliceSize,
+                                    OpFoldResult size) {
+    if (!isConstantIntValue(offset, 0))
+      return false;
+    FailureOr<bool> maybeEqual =
+        ValueBoundsConstraintSet::areEqual(sliceSize, size);
+    return llvm::succeeded(maybeEqual) && maybeEqual.value();
+  };
+
+  for (const ReassociationIndices &indices :
+       expandShapeOp.getReassociationIndices()) {
+    OpFoldResult newOffset = rewriter.getIndexAttr(0);
+    OpFoldResult newSize = rewriter.getIndexAttr(1);
+
+    int64_t i = 0;
+    int64_t e = indices.size();
+    for (; i < e; ++i) {
+      int64_t expandedDim = indices[i];
+      if (!isConstantIntValue(sizes[expandedDim], 1))
+        break;
+
+      newOffset =
+          mulAdd(newOffset, outputShape[expandedDim], offsets[expandedDim]);
+    }
+
+    if (i != e) {
+      int64_t expandedDim = indices[i];
+      newOffset =
+          mulAdd(newOffset, outputShape[expandedDim], offsets[expandedDim]);
+      newSize = sizes[expandedDim];
+      i++;
+    }
+
+    for (; i < e; ++i) {
+      int64_t expandedDim = indices[i];
+      OpFoldResult offset = offsets[expandedDim];
+      OpFoldResult fullSize = outputShape[expandedDim];
+      if (!isZeroOffsetAndFullSize(offset, sizes[expandedDim], fullSize)) {
+        llvm::errs() << "failed! " << offset << " " << sizes[expandedDim] << " "
+                     << fullSize << "\n";
+        return failure();
+      }
+
+      newOffset = mul(newOffset, fullSize);
+      newSize = mul(newSize, fullSize);
+    }
+
+    newOffsets.push_back(newOffset);
+    newLengths.push_back(newSize);
+
+    // Only unit stride supported.
+    newStrides.push_back(rewriter.getIndexAttr(1));
+  }
+
+  // The shape of the result can be obtained from the sizes passed in.
+  SmallVector<Value> dynDims;
+  SmallVector<int64_t> shape;
+  dispatchIndexOpFoldResults(sizes, dynDims, shape);
+  RankedTensorType resultType = RankedTensorType::get(
+      shape, expandShapeOp.getResultType().getElementType());
+
+  // Create a new ExtractSliceOp and ExpandShapeOp.
+  Value newSliceOp = rewriter.create<tensor::ExtractSliceOp>(
+      loc, expandShapeOp.getSrc(), newOffsets, newLengths, newStrides);
+  auto newExpandShapeOp = rewriter.create<tensor::ExpandShapeOp>(
+      loc, resultType, newSliceOp, expandShapeOp.getReassociationIndices(),
+      sizes);
+  rewriter.replaceOp(sliceOp, newExpandShapeOp);
+  return success();
+}
+
+/// tensor.empty does not define any tensor contents, so an unpadded pack
+/// can be folded away.
+struct SwapExpandShapeWithSlicePattern
+    : public OpRewritePattern<tensor::ExtractSliceOp> {
+  using OpRewritePattern<tensor::ExtractSliceOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tensor::ExtractSliceOp sliceOp,
+                                PatternRewriter &rewriter) const override {
+    auto expandOp = sliceOp.getSource().getDefiningOp<tensor::ExpandShapeOp>();
+    if (!expandOp) {
+      return failure();
+    }
+
+    if (!sliceOp.hasUnitStride()) {
+      return rewriter.notifyMatchFailure(sliceOp,
+                                         "unsupported: non-unit stride");
+    }
+
+    return swapExpandShapeWithSlice(rewriter, expandOp, sliceOp);
+  }
+};
 
 /// This collects the set of operations to tile + fuse starting from the given
 /// root |op| and walking up to its producers. Stops at operations given by
@@ -176,6 +304,18 @@ static LogicalResult applyTileAndFuseToEachRoot(
       };
       cleanupPatterns.add<linalg::ExtractSliceOfPadTensorSwapPattern>(
           context, zeroSliceGuard);
+    }
+
+    // Avoid cleanup for subgroup level tiling because cleanup/fusion must
+    // happen later during lane tiling because failure to fuse at the lane
+    // tiling level is irrecoverable if fusion happens now.
+    if (tilingLevel != IREE::GPU::TilingLevel::Subgroup) {
+      tensor::ExtractSliceOp::getCanonicalizationPatterns(cleanupPatterns,
+                                                          context);
+      tensor::DimOp::getCanonicalizationPatterns(cleanupPatterns, context);
+      tensor::populateMergeConsecutiveInsertExtractSlicePatterns(
+          cleanupPatterns);
+      cleanupPatterns.add<SwapExpandShapeWithSlicePattern>(context);
     }
 
     tileAndFuseOptions.cleanupPatterns =

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_tiling_level.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_tiling_level.mlir
@@ -558,7 +558,6 @@ func.func @distribute_multi_result_generic(
 //  THREAD-SAME:       outs(%{{.*}}, %{{.*}}: tensor<1x1x?xf32>, tensor<1x1x?xf32>)
 //       THREAD:   return %[[FORALL]]#0, %[[FORALL]]#1
 
-<<<<<<< HEAD
 //  -----
 
 func.func @dont_yield_replacement_in_reduction_tiling(%arg0: tensor<4x77xbf16>, %arg1: tensor<4x77xf32>) -> (tensor<4x77xf32>, tensor<4xf32>) {
@@ -595,7 +594,7 @@ func.func @dont_yield_replacement_in_reduction_tiling(%arg0: tensor<4x77xbf16>, 
 // Note: if we yield replacement then we would see a large result of
 // tensor<4x77xf32> also being yielded which is not what we want in such a case.
 //   CHECK-SAME:  -> (tensor<4xf32>) {
-=======
+
 // -----
 
 #config = #iree_gpu.lowering_config<{thread = [2, 16], subgroup = [2, 16]}>
@@ -699,4 +698,3 @@ module {
 //       THREAD:     %[[SLICE:.+]] = tensor.extract_slice %{{.*}}[%[[APPLY0]], %[[APPLY1]]] [20, 4] [1, 1]
 //       THREAD:     %[[EXPAND:.+]] = tensor.expand_shape %[[SLICE]] {{\[\[}}0, 1, 2], [3, 4]] output_shape [1, 2, 10, 1, 4]
 //       THREAD:     linalg.exp {{.*}} ins(%[[EXPAND]]
->>>>>>> e6e562d39b ([Codegen][GPU] Add reshape fusion and cleanup to tiling pass)

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_tiling_level.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_tiling_level.mlir
@@ -655,7 +655,7 @@ module {
   }
 }
 
-// THREAD-LABEL: func.func @swap_expand_shape_with_extract_slice
+// THREAD-LABEL: func.func @swap_expand_shape_with_extract_slice_full_inner_dim
 //       THREAD:   scf.forall (%[[X:[A-Za-z0-9]+]], %[[Y:[A-Za-z0-9]+]])
 //       THREAD:     %[[APPLY:.+]] = affine.apply affine_map<(d0, d1) -> (d0 * 40 + d1 * 10)>(%[[X]], %[[Y]])
 //       THREAD:     %[[SLICE:.+]] = tensor.extract_slice %{{.*}}[%[[APPLY]]] [20] [1] : tensor<120xf32> to tensor<20xf32>
@@ -683,7 +683,7 @@ module {
 
 #config = #iree_gpu.lowering_config<{thread = [1, 2, 0, 1, 4]}>
 module {
-  func.func @swap_expand_shape_with_extract_slice_multiple_groups(%0: tensor<120x56xf32>) -> tensor<3x4x10x7x8xf32> {
+  func.func @swap_expand_shape_with_extract_slice_multiple_expanded_dims(%0: tensor<120x56xf32>) -> tensor<3x4x10x7x8xf32> {
     %expand = tensor.expand_shape %0 [[0, 1, 2], [3, 4]] output_shape [3, 4, 10, 7, 8] : tensor<120x56xf32> into tensor<3x4x10x7x8xf32>
     %empty = tensor.empty() : tensor<3x4x10x7x8xf32>
     %exp = linalg.exp {lowering_config = #config}
@@ -692,7 +692,7 @@ module {
   }
 }
 
-// THREAD-LABEL: func.func @swap_expand_shape_with_extract_slice_multiple_groups
+// THREAD-LABEL: func.func @swap_expand_shape_with_extract_slice_multiple_expanded_dims
 //       THREAD:   scf.forall (%[[ID0:[A-Za-z0-9]+]], %[[ID1:[A-Za-z0-9]+]], %[[ID2:[A-Za-z0-9]+]], %[[ID3:[A-Za-z0-9]+]])
 //       THREAD:     %[[APPLY0:.+]] = affine.apply affine_map<(d0, d1) -> (d0 * 40 + d1 * 10)>(%[[ID0]], %[[ID1]])
 //       THREAD:     %[[APPLY1:.+]] = affine.apply affine_map<(d0, d1) -> (d0 * 8 + d1)>(%[[ID2]], %[[ID3]])


### PR DESCRIPTION
This adds a pattern to the cleanup pattern set for the SCFTileAndFuse options used in GPUApplyTilingLevel for swapping tensor.expand_shape ops with tensor.extract_slice ops. This enables decomposing pack/unpack ops before tiling.