### PR TITLE
Add crash reproducer instrumentation

### DIFF
--- a/compiler/src/iree/compiler/Tools/iree_compile_lib.cc
+++ b/compiler/src/iree/compiler/Tools/iree_compile_lib.cc
@@ -147,7 +147,7 @@ int mlir::iree_compiler::runIreecMain(int argc, char **argv) {
   llvm::cl::opt<bool> dumpLocalCrashReproducers(
       "dump-local-crash-reproducers",
       llvm::cl::desc("When generating a crash reproducer, generate the "
-                     "smallest possible pass pipeline possible."),
+                     "smallest pass pipeline possible."),
       llvm::cl::init(false));
 
   llvm::cl::opt<bool> emitMLIRBytecode(

--- a/compiler/src/iree/compiler/Tools/iree_compile_lib.cc
+++ b/compiler/src/iree/compiler/Tools/iree_compile_lib.cc
@@ -142,7 +142,7 @@ int mlir::iree_compiler::runIreecMain(int argc, char **argv) {
   llvm::cl::opt<std::string> dumpCrashReproducersTo(
       "dump-crash-reproducers-to",
       llvm::cl::desc("Generate a .mlir reproducer file at the given output "
-                     "path if the pass manager crashes or fails"),
+                     "path if the pass manager crashes or fails."),
       llvm::cl::init(""));
   llvm::cl::opt<bool> dumpLocalCrashReproducers(
       "dump-local-crash-reproducers",

--- a/compiler/src/iree/compiler/Tools/iree_compile_lib.cc
+++ b/compiler/src/iree/compiler/Tools/iree_compile_lib.cc
@@ -257,15 +257,17 @@ int mlir::iree_compiler::runIreecMain(int argc, char **argv) {
     };
     InvState r(s);
 
-    auto onCrashCallback = [](iree_compiler_output_t **output,
-                              void *userData) -> iree_compiler_error_t * {
-      iree_compiler_output_t *reproOutput =
-          static_cast<iree_compiler_output_t *>(userData);
-      *output = reproOutput;
-      return nullptr;
-    };
-    ireeCompilerInvocationSetCrashHandler(r.inv, dumpLocalCrashReproducers,
-                                          onCrashCallback, reproducer);
+    if (reproducer) {
+      auto onCrashCallback = [](iree_compiler_output_t **output,
+                                void *userData) -> iree_compiler_error_t * {
+        iree_compiler_output_t *reproOutput =
+            static_cast<iree_compiler_output_t *>(userData);
+        *output = reproOutput;
+        return nullptr;
+      };
+      ireeCompilerInvocationSetCrashHandler(r.inv, dumpLocalCrashReproducers,
+                                            onCrashCallback, reproducer);
+    }
 
     ireeCompilerInvocationEnableConsoleDiagnostics(r.inv);
     ireeCompilerInvocationSetCompileFromPhase(


### PR DESCRIPTION
This pr adds flags:

```
--dump-crash-reproducers-to=
--dump-local-crash-reproducers
```

which allows dumping a crash reproducer if the pass manager crashes. This is useful to produce better reproducers for issues.