### PR TITLE
Ignore multi-line git trailers in configure_ci.py.

### DIFF
--- a/build_tools/github_actions/configure_ci_test.py
+++ b/build_tools/github_actions/configure_ci_test.py
@@ -235,6 +235,17 @@ key: value"""
         )
         self.assertDictEqual(trailer_map, {"key": "value"})
 
+    def test_parse_trailer_map_text_after_trailers(self):
+        trailer_map = configure_ci.parse_trailer_map_from_description(
+            """First line
+
+key: value
+
+More non-trailer text here"""
+        )
+        # Trailers can't appear in the middle of the description.
+        self.assertDictEqual(trailer_map, {})
+
     def test_parse_trailer_map_two_trailers(self):
         trailer_map = configure_ci.parse_trailer_map_from_description(
             """First line

--- a/build_tools/github_actions/configure_ci_test.py
+++ b/build_tools/github_actions/configure_ci_test.py
@@ -251,8 +251,19 @@ key2: value2"""
 key: value line 1
   value line 2"""
         )
-        # Note: Discarding the multi-line part of the key.
+        # Note: Only using the first non-empty line of the trailer.
         self.assertDictEqual(trailer_map, {"key": "value line 1"})
+
+    def test_parse_trailer_map_multiline_trailer_skip_first(self):
+        trailer_map = configure_ci.parse_trailer_map_from_description(
+            """First line
+
+key:
+  value line 2
+  value line 3"""
+        )
+        # Note: Only using the first non-empty line of the trailer.
+        self.assertDictEqual(trailer_map, {"key": "value line 2"})
 
 
 if __name__ == "__main__":

--- a/build_tools/github_actions/configure_ci_test.py
+++ b/build_tools/github_actions/configure_ci_test.py
@@ -223,6 +223,37 @@ class ConfigureCITest(unittest.TestCase):
             ),
         )
 
+    def test_parse_trailer_map_no_trailers(self):
+        trailer_map = configure_ci.parse_trailer_map_from_description("""No trailers""")
+        self.assertDictEqual(trailer_map, {})
+
+    def test_parse_trailer_map_one_trailer(self):
+        trailer_map = configure_ci.parse_trailer_map_from_description(
+            """First line
+
+key: value"""
+        )
+        self.assertDictEqual(trailer_map, {"key": "value"})
+
+    def test_parse_trailer_map_two_trailers(self):
+        trailer_map = configure_ci.parse_trailer_map_from_description(
+            """First line
+
+key1: value1
+key2: value2"""
+        )
+        self.assertDictEqual(trailer_map, {"key1": "value1", "key2": "value2"})
+
+    def test_parse_trailer_map_multiline_trailer(self):
+        trailer_map = configure_ci.parse_trailer_map_from_description(
+            """First line
+
+key: value line 1
+  value line 2"""
+        )
+        # Note: Discarding the multi-line part of the key.
+        self.assertDictEqual(trailer_map, {"key": "value line 1"})
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes https://github.com/iree-org/iree/issues/19240 (ugh string parsing).