### PR TITLE
Add iree_codegen and iree_gpu dialects to Python readthedocs.

### DIFF
--- a/docs/api_docs/python/compiler/index.rst
+++ b/docs/api_docs/python/compiler/index.rst
@@ -9,5 +9,6 @@ Compiler API
    tools.rst
    build.rst
    mlir.rst
+   iree_dialects.rst
    iree_input_dialect.rst
    mlir_dialects.rst

--- a/docs/api_docs/python/compiler/iree_dialects.rst
+++ b/docs/api_docs/python/compiler/iree_dialects.rst
@@ -1,0 +1,18 @@
+IREE Dialects
+==================
+
+`iree_codegen` dialect
+----------------------
+
+.. automodule:: iree.compiler.dialects.iree_codegen
+  :imported-members:
+  :members:
+  :undoc-members:
+
+`iree_gpu` dialect
+------------------
+
+.. automodule:: iree.compiler.dialects.iree_gpu
+  :imported-members:
+  :members:
+  :undoc-members:


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree/issues/5477.

See discussion [here on Discord](https://discord.com/channels/689900678990135345/1255609343689097318/1309257875323097210) asking about the APIs to use these dialects from Python.

We can organize these pages better over time and address any other areas that are missing doc coverage.