### PR TITLE
[GPU] Add C promotion capability in promote matmul operands pass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromoteMatmulOperands.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromoteMatmulOperands.cpp
@@ -40,7 +40,8 @@ Value promoteValue(OpBuilder &builder, Location loc, Value v) {
   return copy.getResult(0);
 }
 
-/// Helper to promote results.
+/// Helper to promote results. If the target value is consumed only by a
+/// `tensor.extract_slice`, this will promote the result of the slice instead.
 void promoteResult(OpBuilder &builder, Operation *op, Value valToMakeShared) {
   IRRewriter rewriter(builder);
   Location loc = op->getLoc();
@@ -54,6 +55,9 @@ void promoteResult(OpBuilder &builder, Operation *op, Value valToMakeShared) {
     if (extractSliceOp) {
       // If the result is consumed by an extract_slice then we expect there to
       // be exactly one extract slice that is then consumed.
+      // TODO (nirvedhmeshram) : This is fairly special case. Instead we should
+      // just promote results before doing padding which introduces the extract
+      // slice.
       if (!valToMakeShared.hasOneUse())
         return;
       valueToReplace = extractSliceOp.getResult();

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromoteMatmulOperands.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPromoteMatmulOperands.cpp
@@ -8,8 +8,12 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUEnums.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUInterfaces.h"
 #include "iree/compiler/Codegen/Utils/LinalgOpInfo.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
@@ -24,11 +28,79 @@ namespace mlir::iree_compiler {
 #include "iree/compiler/Codegen/Common/GPU/Passes.h.inc"
 
 namespace {
+/// Helper to insert copy with derived thread config.
+Value promoteValue(OpBuilder &builder, Location loc, Value v) {
+  auto tensorType = cast<RankedTensorType>(v.getType());
+  SmallVector<OpFoldResult> mixedSizes = tensor::getMixedSizes(builder, loc, v);
+  Value empty = builder.create<tensor::EmptyOp>(loc, mixedSizes,
+                                                tensorType.getElementType());
+  auto copy = builder.create<linalg::CopyOp>(loc, v, empty);
+  setLoweringConfig(
+      copy, IREE::GPU::DerivedThreadConfigAttr::get(builder.getContext()));
+  return copy.getResult(0);
+}
+
+/// Helper to promote results.
+void promoteResult(OpBuilder &builder, Operation *op, Value valToMakeShared) {
+  IRRewriter rewriter(builder);
+  Location loc = op->getLoc();
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPointAfterValue(valToMakeShared);
+  tensor::ExtractSliceOp extractSliceOp;
+  SetVector<Operation *> opsToReplaceUseIn;
+  Value valueToReplace = valToMakeShared;
+  for (auto user : valToMakeShared.getUsers()) {
+    extractSliceOp = dyn_cast<tensor::ExtractSliceOp>(user);
+    if (extractSliceOp) {
+      // If the result is consumed by an extract_slice then we expect there to
+      // be exactly one extract slice that is then consumed.
+      if (!valToMakeShared.hasOneUse())
+        return;
+      valueToReplace = extractSliceOp.getResult();
+      for (auto user : extractSliceOp->getUsers()) {
+        opsToReplaceUseIn.insert(user);
+      }
+      break;
+    }
+    opsToReplaceUseIn.insert(user);
+  }
+  auto tensorType = cast<RankedTensorType>(valToMakeShared.getType());
+  if (!tensorType) {
+    return;
+  }
+  SmallVector<Value> dynamicSizes;
+  for (auto [idx, size] : llvm::enumerate(tensorType.getShape())) {
+    if (ShapedType::isDynamic(size)) {
+      dynamicSizes.push_back(
+          rewriter.create<tensor::DimOp>(loc, valToMakeShared, idx));
+    }
+  }
+  Attribute addressSpace = gpu::AddressSpaceAttr::get(
+      rewriter.getContext(), gpu::GPUDialect::getWorkgroupAddressSpace());
+  auto alloc = rewriter.create<bufferization::AllocTensorOp>(loc, tensorType,
+                                                             dynamicSizes);
+  alloc.setMemorySpaceAttr(addressSpace);
+  auto copy =
+      rewriter.create<linalg::CopyOp>(loc, valToMakeShared, alloc.getResult());
+
+  Value replacement = copy.getResult(0);
+  // If in extract slice is present we make it consume the new copy.
+  if (extractSliceOp) {
+    extractSliceOp.getSourceMutable().assign(replacement);
+    replacement = valueToReplace;
+  }
+
+  rewriter.setInsertionPointAfterValue(replacement);
+  replacement = promoteValue(rewriter, loc, replacement);
+  valueToReplace.replaceUsesWithIf(replacement, [&](OpOperand &use) {
+    return opsToReplaceUseIn.contains(use.getOwner());
+  });
+}
 
 /// Inserts a `linalg.copy` directly before the given operation on the
 /// specified operand, for example with operand index = 1:
 ///
-///   linalg.matmul ins(%0, %1)
+///   %2 = linalg.matmul ins(%0, %1)
 ///
 /// becomes
 ///
@@ -40,7 +112,24 @@ namespace {
 /// If the producer is already a tilable op, the producer is just annotated with
 /// #iree_gpu.derived_thread_config to indicate that it should be distributed
 /// to threads independently of the matmul.
+/// Additionally we can also promote results so in above example we will
+/// generate for index = 2 :
+///   %out_buffer = bufferization.alloc_tensor
+///   %copy1 = linalg.copy %2 to %out_buffer
+///   %copy2 = linalg.copy %copy1 to %empty {
+///     lowering_config = #iree_gpu.derived_thread_config}
 void promoteOperand(OpBuilder &builder, Operation *op, unsigned index) {
+  auto dpsOp = dyn_cast<DestinationStyleOpInterface>(op);
+  if (!dpsOp)
+    return;
+  // We use the convention that if we are passing an index beyond the inputs
+  // then we promote the result of the corresponding dps init.
+  if (index >= dpsOp.getNumDpsInputs()) {
+    index -= dpsOp.getNumDpsInputs();
+    assert(index < op->getNumResults() &&
+           "trying to promote out of bound result index");
+    return promoteResult(builder, op, op->getResult(index));
+  }
   Value operand = op->getOperand(index);
 
   if (auto producer = operand.getDefiningOp<TilingInterface>()) {
@@ -69,14 +158,8 @@ void promoteOperand(OpBuilder &builder, Operation *op, unsigned index) {
     return;
   }
 
-  SmallVector<OpFoldResult> mixedSizes =
-      tensor::getMixedSizes(builder, op->getLoc(), operand);
-  Value empty = builder.create<tensor::EmptyOp>(op->getLoc(), mixedSizes,
-                                                tensorType.getElementType());
-  auto copy = builder.create<linalg::CopyOp>(op->getLoc(), operand, empty);
-  setLoweringConfig(
-      copy, IREE::GPU::DerivedThreadConfigAttr::get(builder.getContext()));
-  op->setOperand(index, copy.getResult(0));
+  auto replacement = promoteValue(builder, op->getLoc(), operand);
+  op->setOperand(index, replacement);
 }
 
 struct GPUPromoteMatmulOperandsPass final

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -142,6 +142,8 @@ def GPUPromoteMatmulOperandsPass :
   let summary = "Pass to insert copies with a different thread configuration "
                 "on matmul operands";
   let dependentDialects = [
+    "::mlir::bufferization::BufferizationDialect",
+    "::mlir::gpu::GPUDialect",
     "::mlir::linalg::LinalgDialect",
     "::mlir::iree_compiler::IREE::GPU::IREEGPUDialect"
   ];


### PR DESCRIPTION
This PR sets up the convention that when the operand index for promotion is beyond the dpsInputs then we promote the corresponding dpsInit's tied-result.
Result promotion is implemented in this PR.

Co-authored-by : Quinn Dawkins <quinn.dawkins@gmail.com>