### PR TITLE
Update actions/cache version to latest release.

### DIFF
--- a/.github/workflows/pkgci_build_packages.yml
+++ b/.github/workflows/pkgci_build_packages.yml
@@ -74,7 +74,7 @@ jobs:
           cat runtime/version_local.json
 
       - name: Enable cache
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           path: ${{ env.CACHE_DIR }}
           key: iree-pkgci-linux-release-x86_64-v1-${{ github.sha }}
@@ -139,7 +139,7 @@ jobs:
 #         realpath version_info.json
 #         cat version_info.json
 #     - name: Enable cache
-#       uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8  # v3.3.1
+#       uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
 #       with:
 #         path: ${{ env.CACHE_DIR }}
 #         key: iree-pkgci-linux-release-asserts-x86_64-v1-${{ github.sha }}


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree/issues/18185.

Version before this PR: https://github.com/actions/cache/releases/tag/v3.3.1.
Version with this PR: https://github.com/actions/cache/releases/tag/v4.1.2.

This cuts the time for `Post Enable cache` down from ~3m30s to ~1m30s. Saving 2 minutes on the critical path - nice!