### PR TITLE
[Dispatch] Don't bubble extract slice ops through reduction ops

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/BubbleUpExtractSlices.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/BubbleUpExtractSlices.cpp
@@ -59,6 +59,13 @@ struct BubbleUpExtract : OpRewritePattern<tensor::ExtractSliceOp> {
           "expected generic op to have all projected permutation maps");
     }
 
+    if (!genericOp.isAllParallelLoops()) {
+      // TODO(#19230): causing codegen issues when the `extract_slice` was
+      // created during `PadToIntrinsics`.
+      return rewriter.notifyMatchFailure(genericOp,
+                                         "expected no reduction loops");
+    }
+
     if (genericOp.hasIndexSemantics()) {
       return rewriter.notifyMatchFailure(
           genericOp, "pattern doesn't support index semantics");


### PR DESCRIPTION
Fixes the compilation issue in https://github.com/iree-org/iree/issues/19230 but a more nuanced solution is needed since it can sometimes be beneficial to reduce the computation done by `linalg.generic`s with reduction iterators.