### PR TITLE
[GPU] Add config and pass to do padding in TileAndFuse pipeline

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
@@ -69,6 +69,7 @@ iree_compiler_cc_library(
         "GPUMultiBuffering.cpp",
         "GPUNestedLayoutDistributionPatterns.cpp",
         "GPUPackToIntrinsics.cpp",
+        "GPUPadOperands.cpp",
         "GPUPatterns.cpp",
         "GPUPipelining.cpp",
         "GPUPromoteMatmulOperands.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
@@ -67,6 +67,7 @@ iree_cc_library(
     "GPUMultiBuffering.cpp"
     "GPUNestedLayoutDistributionPatterns.cpp"
     "GPUPackToIntrinsics.cpp"
+    "GPUPadOperands.cpp"
     "GPUPatterns.cpp"
     "GPUPipelining.cpp"
     "GPUPromoteMatmulOperands.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPadOperands.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPadOperands.cpp
@@ -1,0 +1,82 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Transforms/Passes.h"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_GPUPADOPERANDSPASS
+#include "iree/compiler/Codegen/Common/GPU/Passes.h.inc"
+
+namespace {
+
+static LogicalResult padLinalgOpToStaticSizes(RewriterBase &rewriter,
+                                              linalg::LinalgOp linalgOp,
+                                              ArrayRef<int64_t> padding) {
+  SmallVector<int64_t> paddingDims =
+      llvm::to_vector(llvm::seq<int64_t>(0, linalgOp.getNumLoops()));
+  SmallVector<bool> nofoldFlags(linalgOp.getNumDpsInputs(), /*nofold=*/false);
+  SmallVector<Attribute> paddingValueAttributes;
+  for (auto &operand : linalgOp->getOpOperands()) {
+    Type elemType = getElementTypeOrSelf(operand.get().getType());
+    paddingValueAttributes.push_back(rewriter.getZeroAttr(elemType));
+  }
+
+  auto options =
+      linalg::LinalgPaddingOptions()
+          .setPaddingDimensions(paddingDims)
+          .setPaddingValues(paddingValueAttributes)
+          .setPadToMultipleOf(padding)
+          .setNofoldFlags(nofoldFlags)
+          .setCopyBackOp(linalg::LinalgPaddingOptions::CopyBackOp::None);
+
+  linalg::LinalgOp paddedOp;
+  SmallVector<Value> newResults;
+  SmallVector<tensor::PadOp> padOps;
+  if (failed(rewriteAsPaddedOp(rewriter, linalgOp, options, paddedOp,
+                               newResults, padOps))) {
+    return rewriter.notifyMatchFailure(linalgOp,
+                                       "failed to pad contraction op");
+  }
+  rewriter.replaceOp(linalgOp, newResults.front());
+  return success();
+}
+
+struct GPUPadOperandsPass final
+    : impl::GPUPadOperandsPassBase<GPUPadOperandsPass> {
+  void runOnOperation() override {
+    FunctionOpInterface funcOp = getOperation();
+
+    IRRewriter rewriter(funcOp);
+    funcOp.walk([&](linalg::LinalgOp op) {
+      auto loweringConfig =
+          getLoweringConfig<IREE::GPU::LoweringConfigAttr>(op);
+      if (!loweringConfig) {
+        return;
+      }
+
+      std::optional<SmallVector<int64_t>> paddingTileSizes =
+          getPaddingList(loweringConfig);
+      if (!paddingTileSizes) {
+        return;
+      }
+
+      rewriter.setInsertionPoint(op);
+      if (failed(padLinalgOpToStaticSizes(rewriter, op,
+                                          paddingTileSizes.value()))) {
+        return signalPassFailure();
+      }
+    });
+  }
+};
+
+} // namespace
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -134,6 +134,16 @@ def GPUPackToIntrinsicsPass :
   ];
 }
 
+def GPUPadOperandsPass :
+    InterfacePass<"iree-codegen-gpu-pad-operands",
+                  "mlir::FunctionOpInterface"> {
+  let summary = "Pass to pad operands of ops with padding configuration provided. ";
+  let dependentDialects = [
+    "::mlir::linalg::LinalgDialect",
+    "::mlir::iree_compiler::IREE::GPU::IREEGPUDialect"
+  ];
+}
+
 def GPUPipeliningPass :
     InterfacePass<"iree-codegen-gpu-pipelining", "mlir::FunctionOpInterface"> {
   let summary = "Pass to do software pipelining.";

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
@@ -39,6 +39,7 @@ iree_lit_test_suite(
             "gpu_nested_layout_contract_amdgpu.mlir",
             "gpu_nested_layout_vector_distribution.mlir",
             "gpu_nested_layout_vector_distribution_step.mlir",
+            "gpu_pad_operands.mlir",
             "gpu_pipeline.mlir",
             "gpu_promote_matmul_operands.mlir",
             "gpu_reorder_workgroups_static.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
@@ -35,6 +35,7 @@ iree_lit_test_suite(
     "gpu_nested_layout_vector_distribution.mlir"
     "gpu_nested_layout_vector_distribution_step.mlir"
     "gpu_pack_to_instrinsics.mlir"
+    "gpu_pad_operands.mlir"
     "gpu_pipeline.mlir"
     "gpu_promote_matmul_operands.mlir"
     "gpu_reorder_workgroups.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_pad_operands.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_pad_operands.mlir
@@ -1,0 +1,26 @@
+// RUN: iree-opt %s --split-input-file --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-pad-operands))" | FileCheck %s
+
+#lowering_config = #iree_gpu.lowering_config<{padding = [3, 7, 11]}>
+
+func.func @matmul(%a: tensor<32x1024xf32>, %b: tensor<1024x128xf32>) -> tensor<32x128xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %empty = tensor.empty() : tensor<32x128xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<32x128xf32>) -> tensor<32x128xf32>
+  %mm = linalg.matmul {lowering_config = #lowering_config}
+    ins(%a, %b : tensor<32x1024xf32>, tensor<1024x128xf32>) outs(%fill : tensor<32x128xf32>) -> tensor<32x128xf32>
+  return %mm : tensor<32x128xf32>
+}
+
+// CHECK-LABEL: func.func @matmul
+//  CHECK-SAME:   %[[A:[A-Za-z0-9]+]]: tensor<32x1024xf32>
+//  CHECK-SAME:   %[[B:[A-Za-z0-9]+]]: tensor<1024x128xf32>
+//       CHECK:   %[[FILL:.+]] = linalg.fill {{.*}} -> tensor<32x128xf32>
+//       CHECK:   %[[PADDED_LHS:.+]] = tensor.pad %[[A]] low[0, 0] high[1, 10]
+//       CHECK:   %[[PADDED_RHS:.+]] = tensor.pad %[[B]] low[0, 0] high[10, 5]
+//       CHECK:   %[[PADDED_INIT:.+]] = tensor.pad %[[FILL]] low[0, 0] high[1, 5]
+//       CHECK:   %[[PADDED_RESULT:.+]] = linalg.matmul
+//  CHECK-SAME:     ins(%[[PADDED_LHS]], %[[PADDED_RHS]] : tensor<33x1034xf32>, tensor<1034x133xf32>)
+//  CHECK-SAME:     outs(%[[PADDED_INIT]] : tensor<33x133xf32>) -> tensor<33x133xf32>
+//       CHECK:   %[[EXTRACT:.+]] = tensor.extract_slice %[[PADDED_RESULT]][0, 0] [32, 128] [1, 1]
+//  CHECK-SAME:     : tensor<33x133xf32> to tensor<32x128xf32>
+//       CHECK:   return %[[EXTRACT]] : tensor<32x128xf32>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.cpp
@@ -87,4 +87,14 @@ void setPromotedOperandList(MLIRContext *context,
                      b.getI64ArrayAttr(operands));
 }
 
+constexpr StringLiteral kPaddingName = "padding";
+
+std::optional<SmallVector<int64_t>> getPaddingList(LoweringConfigAttr config) {
+  auto array = config.getAttributes().getAs<ArrayAttr>(kPaddingName);
+  if (!array) {
+    return std::nullopt;
+  }
+  return getIntegerVector(array);
+}
+
 } // namespace mlir::iree_compiler::IREE::GPU

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.h
@@ -35,6 +35,9 @@ void setPromotedOperandList(MLIRContext *context,
                             SmallVectorImpl<NamedAttribute> &attrs,
                             ArrayRef<int64_t> operands);
 
+/// Helper to retrieve  list of operand to pad.
+std::optional<SmallVector<int64_t>> getPaddingList(LoweringConfigAttr config);
+
 } // namespace mlir::iree_compiler::IREE::GPU
 
 #endif // IREE_COMPILER_CODEGEN_DIALECT_GPU_IR_GPULOWERINGCONFIGUTILS_H_

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -108,10 +108,9 @@ setDataTiledMultiMmaLoweringConfig(IREE::GPU::TargetAttr target,
 
 /// Given a target and a matmul problem, try to find an MMA schedule for the
 /// problem based on the available mma intrinsics.
-static std::optional<GPUMMASchedule>
-getMmaScheduleFromProblemAndTarget(IREE::GPU::TargetAttr target,
-                                   GPUMatmulShapeType problem,
-                                   bool transposedLhs, bool transposedRhs) {
+static std::optional<GPUMMASchedule> getMmaScheduleFromProblemAndTarget(
+    IREE::GPU::TargetAttr target, GPUMatmulShapeType problem,
+    bool transposedLhs, bool transposedRhs, bool mustBeAligned = true) {
   const int64_t targetSubgroupSize = target.getPreferredSubgroupSize();
   SmallVector<GPUMatmulShapeType> intrinsics;
   for (IREE::GPU::MMAAttr mma : target.getWgp().getMma()) {
@@ -153,14 +152,16 @@ getMmaScheduleFromProblemAndTarget(IREE::GPU::TargetAttr target,
   int64_t maxSharedMemoryBytes = target.getWgp().getMaxWorkgroupMemoryBytes();
 
   // First try to find a schedule with an exactly matching intrinsic.
-  std::optional<GPUMMASchedule> schedule =
-      deduceMMASchedule(problem, intrinsics, seeds, maxSharedMemoryBytes,
-                        targetSubgroupSize, transposedLhs, transposedRhs);
+  std::optional<GPUMMASchedule> schedule = deduceMMASchedule(
+      problem, intrinsics, seeds, maxSharedMemoryBytes, targetSubgroupSize,
+      transposedLhs, transposedRhs, /*canUpcastAcc=*/false,
+      /*mustBeAligned*/ mustBeAligned);
   if (!schedule) {
     // Then try again by allowing upcasting accumulator.
     schedule = deduceMMASchedule(
         problem, intrinsics, seeds, maxSharedMemoryBytes, targetSubgroupSize,
-        transposedLhs, transposedRhs, /*canUpcastAcc=*/true);
+        transposedLhs, transposedRhs, /*canUpcastAcc=*/true,
+        /*mustBeAligned*/ mustBeAligned);
   }
   return schedule;
 }
@@ -173,7 +174,8 @@ static FailureOr<std::pair<LoweringConfigAttr, int64_t>>
 getMatmulLoweringConfigAndWorkgroupSize(SmallVector<int64_t> bounds,
                                         ArrayRef<AffineMap> maps,
                                         ArrayRef<Value> operands,
-                                        IREE::GPU::TargetAttr target) {
+                                        IREE::GPU::TargetAttr target,
+                                        bool hasFusedLeadingOp) {
   if (target.getWgp().getMma().empty())
     return failure();
 
@@ -238,8 +240,22 @@ getMatmulLoweringConfigAndWorkgroupSize(SmallVector<int64_t> bounds,
       nDims.back() !=
       llvm::cast<AffineDimExpr>(maps[1].getResults().back()).getPosition();
 
+  bool mustBeAligned = true;
   std::optional<GPUMMASchedule> schedule = getMmaScheduleFromProblemAndTarget(
       target, problem, transposedLhs, transposedRhs);
+
+  // TODO (nirvedhmeshram, jerryyin): Support all GEMM types.
+  // TODO (nirvedhmeshram): Support fused leading op.
+  // TODO (nirvedhmeshram, qedawkins): The performance with this will be bad if
+  // the GEMM is accumulating (i.e doesnt have a zero fill dpsInit) as that
+  // buffer currently gets materialized as private memory. We need to add
+  // missing patterns to fix that.
+  if (!schedule && !contractionDims.batch.empty() && !hasFusedLeadingOp) {
+    LDBG("Attempting to deduce unaligned TileAndFuse MMA schedulee");
+    mustBeAligned = false;
+    schedule = getMmaScheduleFromProblemAndTarget(
+        target, problem, transposedLhs, transposedRhs, mustBeAligned);
+  }
 
   if (!schedule) {
     LDBG("Failed to deduce TileAndFuse MMA schedule");
@@ -269,14 +285,6 @@ getMatmulLoweringConfigAndWorkgroupSize(SmallVector<int64_t> bounds,
   for (int64_t k : llvm::drop_end(contractionDims.k)) {
     reductionTileSizes[k] = 1;
   }
-
-  // Adjust the inner bound size for packing to intrinsic shapes, since tiling
-  // happens after packing.
-  assert(bounds[mDims.back()] % schedule->mSize == 0 &&
-         bounds[nDims.back()] % schedule->nSize == 0 &&
-         "expected inner bound to be evenly divisible by schedule sizes.");
-  bounds[mDims.back()] /= schedule->mSize;
-  bounds[nDims.back()] /= schedule->nSize;
 
   // Compute the M/N dimension tile sizes by multiplying subgroup information.
   for (auto [i, mDim] : llvm::enumerate(mDims)) {
@@ -318,7 +326,22 @@ getMatmulLoweringConfigAndWorkgroupSize(SmallVector<int64_t> bounds,
   attrs.emplace_back(StringAttr::get(context, "subgroup"),
                      b.getI64ArrayAttr(subgroupTileSizes));
   attrs.emplace_back(StringAttr::get(context, "mma_kind"), mmaKind);
-  GPU::setPromotedOperandList(context, attrs, {0, 1});
+  if (mustBeAligned) {
+    GPU::setPromotedOperandList(context, attrs, {0, 1});
+  } else {
+    // TODO (nirvedhmeshram, Max191, jerryyin) : Add support so that unaligned
+    // shapes do not require c promotion.
+    // TODO (nirvedhmeshram, jerryyin) : When using c promotion the heuristics
+    // used during finding a schedule need to be updated to account for the
+    // extra shared memory for the result.
+    GPU::setPromotedOperandList(context, attrs, {0, 1, 2});
+    SmallVector<int64_t> paddingTileSizes = workgroupTileSizes;
+    int64_t innerKDim = contractionDims.k.back();
+    int64_t kPackFactor = std::get<2>(mmaKind.getMNKShape());
+    paddingTileSizes[innerKDim] = reductionTileSizes[innerKDim] * kPackFactor;
+    attrs.emplace_back(StringAttr::get(context, "padding"),
+                       b.getI64ArrayAttr(paddingTileSizes));
+  }
   auto configDict = DictionaryAttr::get(context, attrs);
   auto loweringConfig = IREE::GPU::LoweringConfigAttr::get(context, configDict);
   int64_t flatWorkgroupSize =
@@ -357,7 +380,8 @@ setIGEMMConvolutionLoweringConfig(IREE::GPU::TargetAttr target,
   SmallVector<int64_t> bounds = igemmLoopBounds.value();
   FailureOr<std::pair<LoweringConfigAttr, int64_t>> configAndWgSize =
       getMatmulLoweringConfigAndWorkgroupSize(
-          bounds, igemmContractionMaps.value(), igemmOperands.value(), target);
+          bounds, igemmContractionMaps.value(), igemmOperands.value(), target,
+          /*hasFusedLeadingOp=*/true);
   if (failed(configAndWgSize)) {
     return failure();
   }
@@ -400,7 +424,8 @@ LogicalResult setMatmulLoweringConfig(IREE::GPU::TargetAttr target,
   LDBG("Matmul TileAndFuse Config");
 
   FailureOr<std::pair<LoweringConfigAttr, int64_t>> configAndWgSize =
-      getMatmulLoweringConfigAndWorkgroupSize(bounds, maps, operands, target);
+      getMatmulLoweringConfigAndWorkgroupSize(bounds, maps, operands, target,
+                                              hasFusedLeadingOp(linalgOp));
   if (failed(configAndWgSize)) {
     return failure();
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -351,6 +351,7 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
                                /*convertToDpsOptions=*/std::nullopt);
 
   // Step 1. Promote matmul operands and pack to intrinsic shapes.
+  funcPassManager.addPass(createGPUPadOperandsPass());
   funcPassManager.addPass(createGPUPromoteMatmulOperandsPass());
   funcPassManager.addPass(createGPUPackToIntrinsicsPass());
   // Decompose packs and unpacks that are at the function boundary.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
@@ -256,3 +256,25 @@ module {
 //       CHECK:   iree_gpu.multi_mma {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     reduction = [0, 0, 1]
 //  CHECK-SAME:     workgroup = [1, 1, 0]
+
+// -----
+
+module {
+func.func @unaligned_to_intrinsic_batched_matmul(%lhs : tensor<12x577x577xf32>, %rhs : tensor<12x577x64xf32>) -> tensor<12x577x64xf32> {
+    %c0 = arith.constant 0.0 : f32
+    %empty = tensor.empty() : tensor<12x577x64xf32>
+    %fill = linalg.fill ins(%c0 : f32) outs(%empty : tensor<12x577x64xf32>) -> tensor<12x577x64xf32>
+    %mm = linalg.batch_matmul ins(%lhs, %rhs : tensor<12x577x577xf32>, tensor<12x577x64xf32>) outs(%fill : tensor<12x577x64xf32>) -> tensor<12x577x64xf32>
+    return %mm :  tensor<12x577x64xf32>
+}
+}
+
+// CHECK-LABEL: func.func @unaligned_to_intrinsic_batched_matmul
+// CHECK-SAME:    #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64
+// CHECK-SAME:    {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}
+//      CHECK:    linalg.batch_matmul {{.*}}lowering_config = #iree_gpu.lowering_config
+//  CHECK-SAME:     padding = [1, 16, 64, 4]
+//  CHECK-SAME:     promote_operands = [0, 1, 2]
+//  CHECK-SAME:     reduction = [0, 0, 0, 1]
+//  CHECK-SAME:     subgroup = [0, 1, 1, 0]
+//  CHECK-SAME:     workgroup = [1, 16, 64, 0]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
@@ -260,21 +260,21 @@ module {
 // -----
 
 module {
-func.func @unaligned_to_intrinsic_batched_matmul(%lhs : tensor<12x577x577xf32>, %rhs : tensor<12x577x64xf32>) -> tensor<12x577x64xf32> {
+func.func @unaligned_to_intrinsic_batched_matmul(%lhs : tensor<12x577x577xf32>, %rhs : tensor<12x577x577xf32>) -> tensor<12x577x577xf32> {
     %c0 = arith.constant 0.0 : f32
-    %empty = tensor.empty() : tensor<12x577x64xf32>
-    %fill = linalg.fill ins(%c0 : f32) outs(%empty : tensor<12x577x64xf32>) -> tensor<12x577x64xf32>
-    %mm = linalg.batch_matmul ins(%lhs, %rhs : tensor<12x577x577xf32>, tensor<12x577x64xf32>) outs(%fill : tensor<12x577x64xf32>) -> tensor<12x577x64xf32>
-    return %mm :  tensor<12x577x64xf32>
+    %empty = tensor.empty() : tensor<12x577x577xf32>
+    %fill = linalg.fill ins(%c0 : f32) outs(%empty : tensor<12x577x577xf32>) -> tensor<12x577x577xf32>
+    %mm = linalg.batch_matmul ins(%lhs, %rhs : tensor<12x577x577xf32>, tensor<12x577x577xf32>) outs(%fill : tensor<12x577x577xf32>) -> tensor<12x577x577xf32>
+    return %mm :  tensor<12x577x577xf32>
 }
 }
 
 // CHECK-LABEL: func.func @unaligned_to_intrinsic_batched_matmul
-// CHECK-SAME:    #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64
+// CHECK-SAME:    #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64
 // CHECK-SAME:    {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}
 //      CHECK:    linalg.batch_matmul {{.*}}lowering_config = #iree_gpu.lowering_config
-//  CHECK-SAME:     padding = [1, 16, 64, 4]
+//  CHECK-SAME:     padding = [1, 16, 16, 4]
 //  CHECK-SAME:     promote_operands = [0, 1, 2]
 //  CHECK-SAME:     reduction = [0, 0, 0, 1]
 //  CHECK-SAME:     subgroup = [0, 1, 1, 0]
-//  CHECK-SAME:     workgroup = [1, 16, 64, 0]
+//  CHECK-SAME:     workgroup = [1, 16, 16, 0]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
@@ -1116,7 +1116,7 @@ hal.executable public @main {
 >
 hal.executable public @main {
   hal.executable.variant public @rocm_hsaco_fb target(#hal.executable.target<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @unaligned_to_intrinsic_batched_matmul_dispatch_0_batch_matmul_12x577x64x577_f32 ordinal(0) layout(#pipeline_layout) {
+    hal.executable.export public @unaligned_to_intrinsic_batched_matmul_dispatch_0_batch_matmul_12x577x577x577_f32 ordinal(0) layout(#pipeline_layout) {
     ^bb0(%arg0: !hal.device):
       %x, %y, %z = flow.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
@@ -1126,14 +1126,14 @@ hal.executable public @main {
         %cst = arith.constant 0.000000e+00 : f32
         %c0 = arith.constant 0 : index
         %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !flow.dispatch.tensor<readonly:tensor<12x577x577xf32>>
-        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !flow.dispatch.tensor<readonly:tensor<12x577x64xf32>>
-        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(Indirect) : !flow.dispatch.tensor<writeonly:tensor<12x577x64xf32>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !flow.dispatch.tensor<readonly:tensor<12x577x577xf32>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(Indirect) : !flow.dispatch.tensor<writeonly:tensor<12x577x577xf32>>
         %3 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [12, 577, 577], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<12x577x577xf32>> -> tensor<12x577x577xf32>
-        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [12, 577, 64], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<12x577x64xf32>> -> tensor<12x577x64xf32>
-        %5 = tensor.empty() : tensor<12x577x64xf32>
-        %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<12x577x64xf32>) -> tensor<12x577x64xf32>
-        %7 = linalg.batch_matmul {lowering_config = #config} ins(%3, %4 : tensor<12x577x577xf32>, tensor<12x577x64xf32>) outs(%6 : tensor<12x577x64xf32>) -> tensor<12x577x64xf32>
-        flow.dispatch.tensor.store %7, %2, offsets = [0, 0, 0], sizes = [12, 577, 64], strides = [1, 1, 1] : tensor<12x577x64xf32> -> !flow.dispatch.tensor<writeonly:tensor<12x577x64xf32>>
+        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [12, 577, 577], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<12x577x577xf32>> -> tensor<12x577x577xf32>
+        %5 = tensor.empty() : tensor<12x577x577xf32>
+        %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<12x577x577xf32>) -> tensor<12x577x577xf32>
+        %7 = linalg.batch_matmul {lowering_config = #config} ins(%3, %4 : tensor<12x577x577xf32>, tensor<12x577x577xf32>) outs(%6 : tensor<12x577x577xf32>) -> tensor<12x577x577xf32>
+        flow.dispatch.tensor.store %7, %2, offsets = [0, 0, 0], sizes = [12, 577, 577], strides = [1, 1, 1] : tensor<12x577x577xf32> -> !flow.dispatch.tensor<writeonly:tensor<12x577x577xf32>>
         return
       }
     }
@@ -1147,7 +1147,7 @@ hal.executable public @main {
 //   CHECK-DAG:   memref.alloc() : memref<1x4x66xf32, #gpu.address_space<workgroup>>
 //   CHECK-DAG:   memref.alloc() : memref<1x16x6xf32, #gpu.address_space<workgroup>>
 //   CHECK-DAG:   memref.alloc() : memref<1x1x16x4x16xf32, #gpu.address_space<workgroup>>
-//       CHECK:   scf.forall ({{.*}}) in (12, 37) {
+//       CHECK:   scf.forall ({{.*}}) in (12, 37, 10) {
 //       CHECK:     %[[LOOP:.+]] = scf.for %[[IV:.+]] = %c0 to %c145 step %c1 {{.*}} -> (vector<1x1x1x4x1xf32>)
 //       CHECK:       gpu.barrier
 //   CHECK-DAG:       %[[LHS_RD:.+]] = vector.transfer_read {{.*}} vector<4xf32>
@@ -1162,7 +1162,7 @@ hal.executable public @main {
 //       CHECK:     %[[LOOP_T:.+]] = vector.shape_cast %[[LOOP]] : vector<1x1x1x4x1xf32> to vector<4x1x1xf32>
 //       CHECK:     vector.transfer_write %[[LOOP_T]]
 //       CHECK:     scf.for {{.*}} {
-//       CHECK:       %[[SHARED_READ:.+]] = vector.transfer_read {{.*}} #gpu.address_space<workgroup>>, vector<4xf32>
+//       CHECK:       %[[SHARED_READ:.+]] = vector.transfer_read {{.*}} #gpu.address_space<workgroup>>, vector<1xf32>
 //       CHECK:       vector.transfer_write %[[SHARED_READ]], %[[B2]]
 //       CHECK:    }
-//       CHECK:   } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
+//       CHECK:   } {mapping = [#iree_codegen.workgroup_mapping<z>, #iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
@@ -1087,3 +1087,82 @@ hal.executable public @main {
 //       CHECK:       vector.transfer_write %[[SHARED_READ]], %[[B2]]
 //       CHECK:    }
 //       CHECK:   } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+#config = #iree_gpu.lowering_config<{
+  mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>,
+  padding = [1, 16, 64, 4],
+  promote_operands = [0, 1, 2],
+  reduction = [0, 0, 0, 1],
+  subgroup = [0, 1, 1, 0],
+  workgroup = [1, 16, 64, 0]
+}>
+#translation = #iree_codegen.translation_info<pipeline =
+  LLVMGPUTileAndFuse
+  workgroup_size = [256, 1, 1]
+  subgroup_size = 64,
+  {
+    gpu_pipeline_options = #iree_gpu.pipeline_options<
+      prefetch_shared_memory = true,
+      no_reduce_shared_memory_bank_conflicts = false,
+      use_igemm_convolution = false>
+  }
+>
+hal.executable public @main {
+  hal.executable.variant public @rocm_hsaco_fb target(#hal.executable.target<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @unaligned_to_intrinsic_batched_matmul_dispatch_0_batch_matmul_12x577x64x577_f32 ordinal(0) layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_slice
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @unaligned_to_intrinsic_batched_matmul() attributes {translation_info = #translation} {
+        %cst = arith.constant 0.000000e+00 : f32
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !flow.dispatch.tensor<readonly:tensor<12x577x577xf32>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !flow.dispatch.tensor<readonly:tensor<12x577x64xf32>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(Indirect) : !flow.dispatch.tensor<writeonly:tensor<12x577x64xf32>>
+        %3 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [12, 577, 577], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<12x577x577xf32>> -> tensor<12x577x577xf32>
+        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [12, 577, 64], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<12x577x64xf32>> -> tensor<12x577x64xf32>
+        %5 = tensor.empty() : tensor<12x577x64xf32>
+        %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<12x577x64xf32>) -> tensor<12x577x64xf32>
+        %7 = linalg.batch_matmul {lowering_config = #config} ins(%3, %4 : tensor<12x577x577xf32>, tensor<12x577x64xf32>) outs(%6 : tensor<12x577x64xf32>) -> tensor<12x577x64xf32>
+        flow.dispatch.tensor.store %7, %2, offsets = [0, 0, 0], sizes = [12, 577, 64], strides = [1, 1, 1] : tensor<12x577x64xf32> -> !flow.dispatch.tensor<writeonly:tensor<12x577x64xf32>>
+        return
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: func @unaligned_to_intrinsic_batched_matmul
+//   CHECK-DAG:   %[[B0:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)
+//   CHECK-DAG:   %[[B1:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)
+//   CHECK-DAG:   %[[B2:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(2)
+//   CHECK-DAG:   memref.alloc() : memref<1x4x66xf32, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   memref.alloc() : memref<1x16x6xf32, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   memref.alloc() : memref<1x1x16x4x16xf32, #gpu.address_space<workgroup>>
+//       CHECK:   scf.forall ({{.*}}) in (12, 37) {
+//       CHECK:     %[[LOOP:.+]] = scf.for %[[IV:.+]] = %c0 to %c145 step %c1 {{.*}} -> (vector<1x1x1x4x1xf32>)
+//       CHECK:       gpu.barrier
+//   CHECK-DAG:       %[[LHS_RD:.+]] = vector.transfer_read {{.*}} vector<4xf32>
+//   CHECK-DAG:       vector.transfer_write %[[LHS_RD]]
+//   CHECK-DAG:       %[[RHS_RD:.+]] = vector.transfer_read {{.*}} vector<1xf32>
+//   CHECK-DAG:       vector.transfer_write %[[RHS_RD]]
+//       CHECK:       gpu.barrier
+//   CHECK-DAG:       vector.transfer_read {{.*}} #gpu.address_space<workgroup>>, vector<1xf32>
+//   CHECK-DAG:       vector.transfer_read {{.*}} #gpu.address_space<workgroup>>, vector<1xf32>
+// CHECK-COUNT-1:     amdgpu.mfma {{.*}}blocks = 1 : i32, k = 4 : i32, m = 16 : i32, n = 16 : i32
+//       CHECK:       scf.yield
+//       CHECK:     %[[LOOP_T:.+]] = vector.shape_cast %[[LOOP]] : vector<1x1x1x4x1xf32> to vector<4x1x1xf32>
+//       CHECK:     vector.transfer_write %[[LOOP_T]]
+//       CHECK:     scf.for {{.*}} {
+//       CHECK:       %[[SHARED_READ:.+]] = vector.transfer_read {{.*}} #gpu.address_space<workgroup>>, vector<4xf32>
+//       CHECK:       vector.transfer_write %[[SHARED_READ]], %[[B2]]
+//       CHECK:    }
+//       CHECK:   } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}


### PR DESCRIPTION
We add a padding config which is set for unaligned to intrinsic shapes in TileAndFuse pipeline when an unaligned schedule is found. With this PR we can now check-in an example of an unaligned to intrinsic batch matmul using intrinsics as a pipeline lowering test.