### PR TITLE
Replace iree-compiler with iree-base-compiler in deps of PJRT plugin

### DIFF
--- a/integrations/pjrt/python_packages/_setup_support/iree_pjrt_setup.py
+++ b/integrations/pjrt/python_packages/_setup_support/iree_pjrt_setup.py
@@ -44,7 +44,7 @@ with requirements_path.open() as requirements_txt:
     pin_versions = dict(pin_pairs)
     print(f"requirements.txt pins: {pin_versions}")
     # Convert pinned versions to >= for install_requires.
-    for pin_name in ("iree-compiler", "jaxlib"):
+    for pin_name in ("iree-base-compiler", "jaxlib"):
         pin_version = pin_versions[pin_name]
         install_requires.append(f"{pin_name}>={pin_version}")
 

--- a/integrations/pjrt/requirements.txt
+++ b/integrations/pjrt/requirements.txt
@@ -1,4 +1,4 @@
 -f https://iree.dev/pip-release-links.html
 -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-iree-compiler==20230922.653
+iree-base-compiler==3.0.0
 jaxlib==0.4.17.dev20230922


### PR DESCRIPTION
From [RELEASING.md](https://github.com/iree-org/iree/blob/main/RELEASING.md) we can see that `iree-compiler` is deprecated and replaced by `iree-base-compiler`.

So here we just follow such changes in the requirements.txt of the PJRT plugin. Note that in requirements.txt these versions are pinned (`==`) but they'll converted to `>=` in `setup.py`.

ci-exactly: build_packages, test_pjrt