### PR TITLE
[LLVMGPU] Add tests for VectorDistribution subgroup reductipon pipeline

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.cpp
@@ -68,10 +68,10 @@ void setSubgroupNCount(MLIRContext *context,
       IntegerAttr::get(IntegerType::get(context, 64), subgroup_n_count));
 }
 
-const char *kSubgroupBasisName = "subgroup_basis";
-const char *kThreadBasisName = "thread_basis";
+const StringLiteral kSubgroupBasisName = "subgroup_basis";
+const StringLiteral kThreadBasisName = "thread_basis";
 
-static std::string getBasisLevelName(IREE::GPU::TilingLevel level) {
+static StringLiteral getBasisLevelName(IREE::GPU::TilingLevel level) {
   switch (level) {
   case GPU::TilingLevel::Thread:
     return kThreadBasisName;
@@ -107,14 +107,16 @@ LogicalResult getBasis(IREE::GPU::LoweringConfigAttr config,
     return failure();
   }
 
-  auto maybeBasis = getIntegerVector(dyn_cast_or_null<ArrayAttr>(attrs[0]));
-  auto maybeMapping = getIntegerVector(dyn_cast_or_null<ArrayAttr>(attrs[1]));
+  std::optional<SmallVector<int64_t>> maybeBasis =
+      getIntegerVector(dyn_cast_or_null<ArrayAttr>(attrs[0]));
+  std::optional<SmallVector<int64_t>> maybeMapping =
+      getIntegerVector(dyn_cast_or_null<ArrayAttr>(attrs[1]));
 
   if (!maybeBasis.has_value() || !maybeMapping.has_value()) {
     return failure();
   }
-  basis = maybeBasis.value();
-  mapping = maybeMapping.value();
+  basis = std::move(maybeBasis.value());
+  mapping = std::move(maybeMapping.value());
 
   return success();
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.h
@@ -28,6 +28,15 @@ void setSubgroupNCount(MLIRContext *context,
                        SmallVectorImpl<NamedAttribute> &attrs,
                        int64_t subgroupNCount);
 
+// Helper to retrieve/set distribution basis.
+LogicalResult getBasis(IREE::GPU::LoweringConfigAttr config,
+                       IREE::GPU::TilingLevel level,
+                       SmallVector<int64_t> &basis,
+                       SmallVector<int64_t> &mapping);
+void setBasis(MLIRContext *context, SmallVector<NamedAttribute> &attrs,
+              IREE::GPU::TilingLevel level, ArrayRef<int64_t> basis,
+              ArrayRef<int64_t> mapping);
+
 /// Helper to retrieve/set a list of operand indices to promote.
 std::optional<SmallVector<int64_t>>
 getPromotedOperandList(LoweringConfigAttr config);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.h
@@ -28,8 +28,6 @@ void setSubgroupNCount(MLIRContext *context,
                        SmallVectorImpl<NamedAttribute> &attrs,
                        int64_t subgroupNCount);
 
-// Helper to retrieve/set distribution basis.
-//
 // The basis consists of two integer arrays:
 //   - "counts": number of resource to use per dimension in the basis.
 //   - "mapping": a projected permutation to map to basis to the operations
@@ -40,13 +38,16 @@ void setSubgroupNCount(MLIRContext *context,
 //
 // b = delinearize(x, counts)
 // idx = apply(b, mapping)
-LogicalResult getBasis(IREE::GPU::LoweringConfigAttr config,
-                       IREE::GPU::TilingLevel level,
-                       SmallVector<int64_t> &basis,
-                       SmallVector<int64_t> &mapping);
+struct Basis {
+  SmallVector<int64_t> counts;
+  SmallVector<int64_t> mapping;
+};
+
+// Helper to retrieve/set distribution basis.
+FailureOr<Basis> getBasis(IREE::GPU::LoweringConfigAttr config,
+                          IREE::GPU::TilingLevel level);
 void setBasis(MLIRContext *context, SmallVector<NamedAttribute> &attrs,
-              IREE::GPU::TilingLevel level, ArrayRef<int64_t> basis,
-              ArrayRef<int64_t> mapping);
+              IREE::GPU::TilingLevel level, const Basis &basis);
 
 /// Helper to retrieve/set a list of operand indices to promote.
 std::optional<SmallVector<int64_t>>

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.h
@@ -29,6 +29,17 @@ void setSubgroupNCount(MLIRContext *context,
                        int64_t subgroupNCount);
 
 // Helper to retrieve/set distribution basis.
+//
+// The basis consists of two integer arrays:
+//   - "counts": number of resource to use per dimension in the basis.
+//   - "mapping": a projected permutation to map to basis to the operations
+//     iteration space.
+//
+// Given a resource "x", the "basis" can be used to determine the distribution
+// of an iteration space using:
+//
+// b = delinearize(x, counts)
+// idx = apply(b, mapping)
 LogicalResult getBasis(IREE::GPU::LoweringConfigAttr config,
                        IREE::GPU::TilingLevel level,
                        SmallVector<int64_t> &basis,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUCastTypeToFitMMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUCastTypeToFitMMA.cpp
@@ -122,14 +122,7 @@ struct LLVMGPUCastTypeToFitMMAPass final
     auto func = getOperation();
 
     // Set MMA type from config embedded in toLayoutOp of contraction.
-    func.walk([&](vector::ContractionOp contract) {
-      inferMmaKind(contract);
-      if (!contract->hasAttr("iree.amdgpu.mma")) {
-        func.emitOpError("Failed to detect valid to_layout consumer of "
-                         "vector.contract to infer MMA kind.");
-        return signalPassFailure();
-      }
-    });
+    func.walk([&](vector::ContractionOp contract) { inferMmaKind(contract); });
 
     MLIRContext *context = &getContext();
     RewritePatternSet patterns(context);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
@@ -686,7 +686,8 @@ static IREE::VectorExt::VectorLayoutInterface
 getLayoutForMap(VectorLayoutInterface layout, AffineMap map) {
   // Project out unusued dims in layout.
   SmallVector<bool> projectedDims(layout.getRank(), false);
-  for (int dim : getUnusedDimsBitVector(map).set_bits()) {
+  llvm::SmallBitVector unusedBits = getUnusedDimsBitVector(map);
+  for (int dim : unusedBits.set_bits()) {
     projectedDims[dim] = true;
   }
   IREE::VectorExt::VectorLayoutInterface projectedLayout =

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/BUILD.bazel
@@ -28,6 +28,7 @@ iree_lit_test_suite(
             "pipeline_igemm_tile_and_fuse.mlir",
             "pipeline_tile_and_fuse.mlir",
             "pipeline_vector_distribute_gfx942.mlir",
+            "pipeline_vector_distribute_reduction_gfx942.mlir",
             "pipeline_vector_distribute_gfx1100.mlir",
             "pipeline_warp_reduction.mlir",
         ],

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_lit_test_suite(
     "pipeline_tile_and_fuse.mlir"
     "pipeline_vector_distribute_gfx1100.mlir"
     "pipeline_vector_distribute_gfx942.mlir"
+    "pipeline_vector_distribute_reduction_gfx942.mlir"
     "pipeline_warp_reduction.mlir"
   TOOLS
     FileCheck

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_reduction_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_reduction_gfx942.mlir
@@ -3,13 +3,15 @@
 // RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-llvmgpu-lower-executable-target)))))" \
 // RUN:   %s | FileCheck %s
 
-#config = #iree_gpu.lowering_config< {workgroup = [1, 4, 0],
-                                      reduction = [0, 0, 512],
+#config = #iree_gpu.lowering_config< {workgroup = [0, 4, 0],
+                                      reduction = [0, 0, 128],
                                       thread = [0, 0, 8],
-                                      subgroup_basis = [[1, 4, 1], [0, 1, 2]],
-                                      thread_basis   = [[1, 1, 64], [0, 1, 2]]}
+                                      subgroup_basis = [[1, 1, 1], [0, 1, 2]],
+                                      thread_basis   = [[1, 4, 16], [0, 1, 2]]}
 >
-#translation = #iree_codegen.translation_info< pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {}>
+#translation = #iree_codegen.translation_info< pipeline = LLVMGPUVectorDistribute
+                                               workgroup_size = [64, 1, 1]
+                                               subgroup_size = 64, {}>
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -48,9 +50,129 @@ hal.executable private @matvec_fp16 {
 }
 
 //     CHECK-LABEL: func.func @matvec_fp16
+//          CHECK:    scf.for {{.*}} = %c0 to %c4096 step %c128
+//          CHECK:      %[[OUT:.+]] = vector.contract
+//     CHECK-SAME:      vector<1x1x8xf16>, vector<1x1x1x1x1x8xf16> into vector<1x1x1xf16>
+//          CHECK:      %[[SCALAR:.+]] = vector.extract %[[OUT]]
+//          CHECK:      gpu.subgroup_reduce  add %[[SCALAR]]
+
+//          CHECK:      scf.yield
+//          CHECK:    vector.transfer_write
+
+// -----
+
+#config = #iree_gpu.lowering_config< {workgroup = [1, 4, 0],
+                                      reduction = [0, 0, 512],
+                                      thread = [0, 0, 8],
+                                      subgroup_basis = [[1, 4, 1], [0, 1, 2]],
+                                      thread_basis   = [[1, 1, 64], [0, 1, 2]]}
+>
+#translation = #iree_codegen.translation_info< pipeline = LLVMGPUVectorDistribute
+                                               workgroup_size = [256, 1, 1]
+                                               subgroup_size = 64, {}>
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable private @matvec_fp16_parallel_subgroup {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @matvec_fp16_parallel_subgroup ordinal(0) layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_slice
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matvec_fp16_parallel_subgroup() attributes {translation_info = #translation} {
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0.000000e+00 : f16
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<1x4096xf16>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<32000x4096xf16>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<1x32000xf16>>
+        %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1, 4096], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<1x4096xf16>> -> tensor<1x4096xf16>
+        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [32000, 4096], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<32000x4096xf16>> -> tensor<32000x4096xf16>
+        %5 = tensor.empty() : tensor<1x32000xf16>
+        %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<1x32000xf16>) -> tensor<1x32000xf16>
+        %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%3, %4 : tensor<1x4096xf16>, tensor<32000x4096xf16>) outs(%6 : tensor<1x32000xf16>) attrs = { lowering_config = #config } {
+        ^bb0(%in: f16, %in_0: f16, %out: f16):
+          %8 = arith.mulf %in, %in_0 : f16
+          %9 = arith.addf %out, %8 : f16
+          linalg.yield %9 : f16
+        } -> tensor<1x32000xf16>
+        flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [1, 32000], strides = [1, 1] : tensor<1x32000xf16> -> !flow.dispatch.tensor<writeonly:tensor<1x32000xf16>>
+        return
+      }
+    }
+  }
+}
+
+//     CHECK-LABEL: func.func @matvec_fp16_parallel_subgroup
 //          CHECK:    scf.for {{.*}} = %c0 to %c4096 step %c512
 //          CHECK:      %[[OUT:.+]] = vector.contract
 //     CHECK-SAME:      vector<1x1x8xf16>, vector<1x1x1x1x1x8xf16> into vector<1x1x1xf16>
+//          CHECK:      %[[SCALAR:.+]] = vector.extract %[[OUT]]
+//          CHECK:      gpu.subgroup_reduce  add %[[SCALAR]]
+
+//          CHECK:      scf.yield
+//          CHECK:    vector.transfer_write
+
+// -----
+
+#config = #iree_gpu.lowering_config< {workgroup = [0, 4, 0],
+                                      reduction = [0, 0, 512],
+                                      thread = [0, 0, 8],
+                                      subgroup_basis = [[1, 4, 1], [0, 1, 2]],
+                                      thread_basis   = [[1, 1, 64], [0, 1, 2]],
+                                      promote_operands = [1]}
+>
+#translation = #iree_codegen.translation_info< pipeline = LLVMGPUVectorDistribute
+                                               workgroup_size = [256, 1, 1]
+                                               subgroup_size = 64, {}>
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable private @matvec_fp16_promote_rhs {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @matvec_fp16_promote_rhs ordinal(0) layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_slice
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matvec_fp16_promote_rhs() attributes {translation_info = #translation} {
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0.000000e+00 : f16
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<1x4096xf16>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<32000x4096xf16>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<1x32000xf16>>
+        %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1, 4096], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<1x4096xf16>> -> tensor<1x4096xf16>
+        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [32000, 4096], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<32000x4096xf16>> -> tensor<32000x4096xf16>
+        %5 = tensor.empty() : tensor<1x32000xf16>
+        %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<1x32000xf16>) -> tensor<1x32000xf16>
+        %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%3, %4 : tensor<1x4096xf16>, tensor<32000x4096xf16>) outs(%6 : tensor<1x32000xf16>) attrs = { lowering_config = #config } {
+        ^bb0(%in: f16, %in_0: f16, %out: f16):
+          %8 = arith.mulf %in, %in_0 : f16
+          %9 = arith.addf %out, %8 : f16
+          linalg.yield %9 : f16
+        } -> tensor<1x32000xf16>
+        flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [1, 32000], strides = [1, 1] : tensor<1x32000xf16> -> !flow.dispatch.tensor<writeonly:tensor<1x32000xf16>>
+        return
+      }
+    }
+  }
+}
+
+//     CHECK-LABEL: func.func @matvec_fp16_promote_rhs
+//          CHECK:    %[[ALLOC:.+]] = memref.alloc() : memref<4x516xf16, #gpu.address_space<workgroup>>
+//          CHECK:    scf.for {{.*}} = %c0 to %c4096 step %c512
+//          CHECK:      %[[RHS_SHARED_READ:.+]] = vector.transfer_read %alloc
+//          CHECK:      %[[RHS_INSERT:.+]] = vector.insert_strided_slice %[[RHS_SHARED_READ]]
+//          CHECK:      %[[OUT:.+]] = vector.contract
+//     CHECK-SAME:      %{{.*}}, %[[RHS_INSERT]], %{{.*}} : vector<1x1x8xf16>, vector<1x1x1x1x1x8xf16> into vector<1x1x1xf16>
 //          CHECK:      %[[SCALAR:.+]] = vector.extract %[[OUT]]
 //          CHECK:      gpu.subgroup_reduce  add %[[SCALAR]]
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_reduction_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_reduction_gfx942.mlir
@@ -1,0 +1,58 @@
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 \
+// RUN:   --iree-codegen-llvmgpu-use-vector-distribution --iree-llvmgpu-enable-prefetch=true \
+// RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-llvmgpu-lower-executable-target)))))" \
+// RUN:   %s | FileCheck %s
+
+#config = #iree_gpu.lowering_config< {workgroup = [1, 4, 0],
+                                      reduction = [0, 0, 512],
+                                      thread = [0, 0, 8],
+                                      subgroup_basis = [[1, 4, 1], [0, 1, 2]],
+                                      thread_basis   = [[1, 1, 64], [0, 1, 2]]}
+>
+#translation = #iree_codegen.translation_info< pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {}>
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable private @matvec_fp16 {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @matvec_fp16 ordinal(0) layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_slice
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matvec_fp16() attributes {translation_info = #translation} {
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0.000000e+00 : f16
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<1x4096xf16>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<32000x4096xf16>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<1x32000xf16>>
+        %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1, 4096], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<1x4096xf16>> -> tensor<1x4096xf16>
+        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [32000, 4096], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<32000x4096xf16>> -> tensor<32000x4096xf16>
+        %5 = tensor.empty() : tensor<1x32000xf16>
+        %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<1x32000xf16>) -> tensor<1x32000xf16>
+        %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%3, %4 : tensor<1x4096xf16>, tensor<32000x4096xf16>) outs(%6 : tensor<1x32000xf16>) attrs = { lowering_config = #config } {
+        ^bb0(%in: f16, %in_0: f16, %out: f16):
+          %8 = arith.mulf %in, %in_0 : f16
+          %9 = arith.addf %out, %8 : f16
+          linalg.yield %9 : f16
+        } -> tensor<1x32000xf16>
+        flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [1, 32000], strides = [1, 1] : tensor<1x32000xf16> -> !flow.dispatch.tensor<writeonly:tensor<1x32000xf16>>
+        return
+      }
+    }
+  }
+}
+
+//     CHECK-LABEL: func.func @matvec_fp16
+//          CHECK:    scf.for {{.*}} = %c0 to %c4096 step %c512
+//          CHECK:      %[[OUT:.+]] = vector.contract
+//     CHECK-SAME:      vector<1x1x8xf16>, vector<1x1x1x1x1x8xf16> into vector<1x1x1xf16>
+//          CHECK:      %[[SCALAR:.+]] = vector.extract %[[OUT]]
+//          CHECK:      gpu.subgroup_reduce  add %[[SCALAR]]
+
+//          CHECK:      scf.yield
+//          CHECK:    vector.transfer_write


### PR DESCRIPTION
This patch adds two things:

- A way to set how resources (subgroups/threads) are distributed over a basis.
- A test showing subgroup reduction for matvec using vector distribution pipeline

There are some differences from the current WarpReduction pipeline:

- Currently, the pipeline doesn't do a split reduction. This can be configured in the lowering config later (partial_reduction tile sizes instead of just reduction)
- The writeback to global memory is not gaurded, i.e. all threads are writing to global memory. This will be fixed as a followup patch to only make one thread write at a time.