### PR TITLE
[iree.build] Wire up out of process concurrency.

### DIFF
--- a/compiler/bindings/python/CMakeLists.txt
+++ b/compiler/bindings/python/CMakeLists.txt
@@ -268,6 +268,7 @@ SOURCES
   net_actions.py
   onnx_actions.py
   target_machine.py
+  test_actions.py
 )
 
 add_mlir_python_modules(IREECompilerBuildPythonModules

--- a/compiler/bindings/python/iree/build/test_actions.py
+++ b/compiler/bindings/python/iree/build/test_actions.py
@@ -1,0 +1,31 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from typing import Callable
+from iree.build.executor import ActionConcurrency, BuildAction
+
+
+class _ThunkTrampoline:
+    def __init__(self, thunk, args):
+        self.thunk = thunk
+        self.args = args
+
+    def __call__(self):
+        self.thunk(*self.args)
+
+
+class ExecuteOutOfProcessThunkAction(BuildAction):
+    """Executes a callback thunk with arguments.
+
+    Both the thunk and args must be pickleable.
+    """
+
+    def __init__(self, thunk, args, concurrency=ActionConcurrency.PROCESS, **kwargs):
+        super().__init__(concurrency=concurrency, **kwargs)
+        self.trampoline = _ThunkTrampoline(thunk, args)
+
+    def _remotable_thunk(self) -> Callable[[], None]:
+        return self.trampoline

--- a/compiler/bindings/python/test/build_api/CMakeLists.txt
+++ b/compiler/bindings/python/test/build_api/CMakeLists.txt
@@ -13,3 +13,10 @@ if(IREE_INPUT_TORCH)
       "mnist_builder_test.py"
   )
 endif()
+
+iree_py_test(
+  NAME
+    concurrency_test
+  SRCS
+    "concurrency_test.py"
+)

--- a/compiler/bindings/python/test/build_api/concurrency_test.py
+++ b/compiler/bindings/python/test/build_api/concurrency_test.py
@@ -1,0 +1,61 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import os
+from pathlib import Path
+import tempfile
+import unittest
+
+from iree.build import *
+from iree.build.executor import BuildContext
+from iree.build.test_actions import ExecuteOutOfProcessThunkAction
+
+
+@entrypoint
+def write_out_of_process_pid():
+    context = BuildContext.current()
+    output_file = context.allocate_file("pid.txt")
+    action = ExecuteOutOfProcessThunkAction(
+        _write_pid_file,
+        args=[output_file.get_fs_path()],
+        desc="Writing pid file",
+        executor=context.executor,
+    )
+    output_file.deps.add(action)
+    return output_file
+
+
+def _write_pid_file(output_path: Path):
+    pid = os.getpid()
+    print(f"Running action out of process: pid={pid}")
+    output_path.write_text(str(pid))
+
+
+class ConcurrencyTest(unittest.TestCase):
+    def setUp(self):
+        self._temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        self._temp_dir.__enter__()
+        self.output_path = Path(self._temp_dir.name)
+
+    def tearDown(self) -> None:
+        self._temp_dir.__exit__(None, None, None)
+
+    def testProcessConcurrency(self):
+        parent_pid = os.getpid()
+        print(f"Testing out of process concurrency: pid={parent_pid}")
+        iree_build_main(
+            args=["write_out_of_process_pid", "--output-dir", str(self.output_path)]
+        )
+        pid_file = (
+            self.output_path / "genfiles" / "write_out_of_process_pid" / "pid.txt"
+        )
+        child_pid = int(pid_file.read_text())
+        print(f"Got child pid={child_pid}")
+        self.assertNotEqual(parent_pid, child_pid)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
* Introduces an explicit thunk creation stage which gives a way to create a fully remotable object.
* Reworks process concurrency to occupy a host thread in addition to a sub-process, which keeps the task concurrency accounting simple and makes errors propagate more easily.
* Adds a test action for invoking a thunk out of process.
* This is the boilerplate required while implementing a turbine AOT export action.