### PR TITLE
[Codegen][NFC] Switch Dim::Kind output stream to use existing methods.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.cpp
@@ -36,18 +36,7 @@ bool operator!=(const TileSwizzle &lhs, const TileSwizzle &rhs) {
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
                               TileSwizzle::Dim::Kind kind) {
-  switch (kind) {
-  case TileSwizzle::Dim::Kind::Internal:
-    return os << "Internal";
-  case TileSwizzle::Dim::Kind::CrossThread:
-    return os << "CrossThread";
-  case TileSwizzle::Dim::Kind::CrossIntrinsic:
-    return os << "CrossIntrinsic";
-  default:
-    // Required by GCC.
-    assert(false);
-    return os;
-  }
+  return os << convertSwizzleKindToString(kind);
 }
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, TileSwizzle::Dim dim) {


### PR DESCRIPTION
The `convertSwizzleKindToString` has the same implementation. The revision switch the implementation to use the method directly.