### PR TITLE
[Python] Disable build_api concurrency test

### DIFF
--- a/compiler/bindings/python/test/build_api/CMakeLists.txt
+++ b/compiler/bindings/python/test/build_api/CMakeLists.txt
@@ -14,9 +14,10 @@ if(IREE_INPUT_TORCH)
   )
 endif()
 
-iree_py_test(
-  NAME
-    concurrency_test
-  SRCS
-    "concurrency_test.py"
-)
+# FIXME: This test fails on python3.10.
+# iree_py_test(
+#   NAME
+#   concurrency_test
+#  SRCS
+#    "concurrency_test.py"
+#)


### PR DESCRIPTION
This test currently fails with python3.10.

Error message: https://gist.github.com/kuhar/7af56cf5a760bead6af9176b99e26cef.