### PR TITLE
[LLVMGPU] Disable scf.forall distribution for matmulSimt

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -530,7 +530,7 @@ void addGPUWinogradVectorizePassPipeline(OpPassManager &funcPassManager) {
 
 void addGPUMatmulSimtPassPipeline(OpPassManager &funcPassManager,
                                   const GPUPipelineOptions &options) {
-  tileAndDistributeToWorkgroup(funcPassManager, /*useForall=*/true);
+  tileAndDistributeToWorkgroup(funcPassManager, /*useForall=*/false);
 
   funcPassManager.addPass(createConfigTrackingCanonicalizerPass());
   funcPassManager.addPass(createConfigTrackingCanonicalizerPass());


### PR DESCRIPTION
We are moving towards tile&fuse pipeline. `matmulSimt` pipeline is to be deprecated. Meanwhile, all existing tests that depend on matmulsimt pipeline shouldn't break and hence disabling the forall distribution for the pipeline.