### PR TITLE
[Codegen][llvmgpu] Compute gemmC size when C promotion is done in padding matmul

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.cpp
@@ -48,9 +48,8 @@ static int64_t prod(ArrayRef<int64_t> values) {
   return ShapedType::getNumElements(values);
 }
 
-static int64_t calculateSharedMemoryUsedInBytes(const GPUMMASchedule &schedule,
-                                                int64_t lhsBitwidth,
-                                                int64_t rhsBitwidth) {
+static int64_t calculateOperandsSharedMemoryUsedInBytes(
+    const GPUMMASchedule &schedule, int64_t lhsBitwidth, int64_t rhsBitwidth) {
 
   int64_t tileM = schedule.mSize * prod(schedule.mTileSizes) *
                   prod(schedule.mSubgroupCounts);
@@ -58,6 +57,17 @@ static int64_t calculateSharedMemoryUsedInBytes(const GPUMMASchedule &schedule,
                   prod(schedule.nSubgroupCounts);
   int64_t tileK = schedule.kSize * prod(schedule.kTileSizes);
   return (tileM * tileK * lhsBitwidth + tileN * tileK * rhsBitwidth) / 8;
+}
+
+static int64_t
+calculateResultSharedMemoryUsedInBytes(const GPUMMASchedule &schedule,
+                                       int64_t resultBitwidth) {
+
+  int64_t tileM = schedule.mSize * prod(schedule.mTileSizes) *
+                  prod(schedule.mSubgroupCounts);
+  int64_t tileN = schedule.nSize * prod(schedule.nTileSizes) *
+                  prod(schedule.nSubgroupCounts);
+  return (tileM * tileN * resultBitwidth) / 8;
 }
 
 /// Check that a GPUMMASchedule fits alignment restrictions. To be aligned,
@@ -377,7 +387,7 @@ FailureOr<GPUMMASchedule> deduceMMASchedule(
     const GPUMatmulShapeType &problem, ArrayRef<GPUMatmulShapeType> intrinsics,
     const GPUMMAHeuristicSeeds &seeds, int64_t sharedMemLimitInBytes,
     int64_t subgroupSize, bool transposedLhs, bool transposedRhs,
-    bool canUpcastAcc, bool mustBeAligned) {
+    bool canUpcastAcc, bool mustBeAligned, bool doCPromotion) {
   for (auto [index, intrinsic] : llvm::enumerate(intrinsics)) {
     if (failed(canTargetIntrinsic(problem, intrinsic, canUpcastAcc,
                                   mustBeAligned))) {
@@ -397,11 +407,17 @@ FailureOr<GPUMMASchedule> deduceMMASchedule(
           intrinsics[schedule.index].aType.getIntOrFloatBitWidth();
       int64_t rhsBitwidth =
           intrinsics[schedule.index].bType.getIntOrFloatBitWidth();
+      int64_t resultBitwidth =
+          intrinsics[schedule.index].cType.getIntOrFloatBitWidth();
       bool isAligned =
           isValidMMASchedule(problem, schedule, mustBeAligned, subgroupSize,
                              transposedLhs, transposedRhs);
-      int64_t sharedMemoryUsed =
-          calculateSharedMemoryUsedInBytes(schedule, lhsBitwidth, rhsBitwidth);
+      int64_t sharedMemoryUsed = calculateOperandsSharedMemoryUsedInBytes(
+          schedule, lhsBitwidth, rhsBitwidth);
+      if (doCPromotion) {
+        sharedMemoryUsed +=
+            calculateResultSharedMemoryUsedInBytes(schedule, resultBitwidth);
+      }
 
       LLVM_DEBUG({
         llvm::dbgs() << "Available Shared Memory: ";
@@ -475,10 +491,10 @@ FailureOr<GPUMMASchedule> deduceAttentionSchedule(
           intrinsics[schedule.index].aType.getIntOrFloatBitWidth();
       int64_t rhsBitwidth =
           intrinsics[schedule.index].bType.getIntOrFloatBitWidth();
-      int64_t sharedMemoryUsed =
-          calculateSharedMemoryUsedInBytes(qkSchedule, lhsBitwidth,
-                                           rhsBitwidth) +
-          calculateSharedMemoryUsedInBytes(schedule, lhsBitwidth, rhsBitwidth);
+      int64_t sharedMemoryUsed = calculateOperandsSharedMemoryUsedInBytes(
+                                     qkSchedule, lhsBitwidth, rhsBitwidth) +
+                                 calculateOperandsSharedMemoryUsedInBytes(
+                                     schedule, lhsBitwidth, rhsBitwidth);
 
       LLVM_DEBUG({
         llvm::dbgs() << "Available Shared Memory: ";

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUHeuristics.h
@@ -81,13 +81,12 @@ struct GPUMMASchedule {
 
 /// Returns a schedule for using one of the given MMA |intrinsics| to target the
 /// input |problem|. Returns std::nullopt if we cannot find such a schedule.
-FailureOr<GPUMMASchedule>
-deduceMMASchedule(const GPUMatmulShapeType &problem,
-                  ArrayRef<GPUMatmulShapeType> intrinsics,
-                  const GPUMMAHeuristicSeeds &seeds,
-                  int64_t sharedMemLimitInBytes, int64_t subgroupSize,
-                  bool transposedLhs = false, bool transposedRhs = false,
-                  bool canUpcastAcc = false, bool mustBeAligned = true);
+FailureOr<GPUMMASchedule> deduceMMASchedule(
+    const GPUMatmulShapeType &problem, ArrayRef<GPUMatmulShapeType> intrinsics,
+    const GPUMMAHeuristicSeeds &seeds, int64_t sharedMemLimitInBytes,
+    int64_t subgroupSize, bool transposedLhs = false,
+    bool transposedRhs = false, bool canUpcastAcc = false,
+    bool mustBeAligned = true, bool doCPromotion = false);
 
 /// Returns a schedule for the pvMatmul in attention using one of the given MMA
 /// |intrinsics| to target the given attention matmul problems, |qkMatmul|

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
@@ -278,3 +278,32 @@ func.func @unaligned_to_intrinsic_batched_matmul(%lhs : tensor<12x577x577xf32>, 
 //  CHECK-SAME:     reduction = [0, 0, 0, 1]
 //  CHECK-SAME:     subgroup = [0, 1, 1, 0]
 //  CHECK-SAME:     workgroup = [1, 16, 16, 0]
+
+// -----
+
+module {
+func.func @unaligned_to_intrinsic_batched_matmul_tiling_check(%lhs : tensor<12x577x577xf32>, %rhs : tensor<12x577x1024xf32>) -> tensor<12x577x1024xf32> {
+    %c0 = arith.constant 0.0 : f32
+    %empty = tensor.empty() : tensor<12x577x1024xf32>
+    %fill = linalg.fill ins(%c0 : f32) outs(%empty : tensor<12x577x1024xf32>) -> tensor<12x577x1024xf32>
+    %mm = linalg.batch_matmul ins(%lhs, %rhs : tensor<12x577x577xf32>, tensor<12x577x1024xf32>) outs(%fill : tensor<12x577x1024xf32>) -> tensor<12x577x1024xf32>
+    return %mm :  tensor<12x577x1024xf32>
+}
+}
+
+// Note this test is used to check if a tuning parameter of right size can be
+// derived through deduceMMASchedule() in the case of unaligned shapes.
+// For existing unaligned shapes, C promotion always happens and failure in
+// considering this will severely underestimates the required shared memory.
+// In this unit test, if C promotion is not considered, it will deduce a MMA
+// schedule with nTileSize of 16 while in reality it should be 8.
+
+// CHECK-LABEL: func.func @unaligned_to_intrinsic_batched_matmul_tiling_check
+// CHECK-SAME:    #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [256, 1, 1] subgroup_size = 64
+// CHECK-SAME:    {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true, no_reduce_shared_memory_bank_conflicts = false, use_igemm_convolution = false>}
+//      CHECK:    linalg.batch_matmul {{.*}}lowering_config = #iree_gpu.lowering_config
+//  CHECK-SAME:     padding = [1, 16, 512, 4]
+//  CHECK-SAME:     promote_operands = [0, 1, 2]
+//  CHECK-SAME:     reduction = [0, 0, 0, 1]
+//  CHECK-SAME:     subgroup = [0, 1, 8, 0]
+//  CHECK-SAME:     workgroup = [1, 16, 512, 0]


### PR DESCRIPTION
This PR depends on #19271.

The existing implementation of #19271 doesn't take gemmC into consideration when computing shared memory size. Though in condition of #19271, gemmC always get promoted and we ended always allocating the C tensor in shared memory. Ignoring C tensor will severely underestimate the amount of shared memory used and eventually cause `deduceMMASchedule()` to pick a tile size too large and go beyond the space limit for shared memory.

This PR addressed this by adding `calculateResultSharedMemoryUsedInBytes()` and apply it to matmul tiling size derive process.