### PR TITLE
[python] Make detection of TimeoutError compatible with 3.10.

### DIFF
--- a/compiler/bindings/python/iree/build/executor.py
+++ b/compiler/bindings/python/iree/build/executor.py
@@ -519,6 +519,11 @@ class Scheduler:
                 completed_deps.add(completed_dep)
         except TimeoutError:
             pass
+        except concurrent.futures.TimeoutError:
+            # Python 3.10 doesn't have a builtin TimeoutError and raises this
+            # type. This was marked as a deprecated alias in 3.11.
+            # TODO: Remove this clause once 3.10 support is dropped.
+            pass
 
         # Purge done from in-flight list.
         self.in_flight_deps.difference_update(completed_deps)

--- a/compiler/bindings/python/iree/build/executor.py
+++ b/compiler/bindings/python/iree/build/executor.py
@@ -520,8 +520,9 @@ class Scheduler:
         except TimeoutError:
             pass
         except concurrent.futures.TimeoutError:
-            # Python 3.10 doesn't have a builtin TimeoutError and raises this
-            # type. This was marked as a deprecated alias in 3.11.
+            # In Python 3.10, future access throws concurrent.futures.TimeoutError.
+            # In 3.11, that was made a subclass of TimeoutError, which is advertised
+            # as thrown (and the original is marked as deprecated).
             # TODO: Remove this clause once 3.10 support is dropped.
             pass
 

--- a/compiler/bindings/python/test/build_api/CMakeLists.txt
+++ b/compiler/bindings/python/test/build_api/CMakeLists.txt
@@ -14,10 +14,9 @@ if(IREE_INPUT_TORCH)
   )
 endif()
 
-# FIXME: This test fails on python3.10.
-# iree_py_test(
-#   NAME
-#   concurrency_test
-#  SRCS
-#    "concurrency_test.py"
-#)
+iree_py_test(
+ NAME
+   concurrency_test
+ SRCS
+   "concurrency_test.py"
+)


### PR DESCRIPTION
* In python < 3.11, future methods throw concurrent.futures.TimeoutError.
* In python 3.11, concurrent.futures.TimeoutError is a subclass of TimeoutError and the former is deprecated.
* In python 3.10, TimeoutError exists so can have an except clause, but it is not thrown by futures.