### PR TITLE
[Global Opt] Fix transpose propagation failure

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
@@ -1104,8 +1104,11 @@ void PropagateLinalgTransposePass::runOnOperation() {
         context, /*benefit=*/2);
     bubblingPatterns.insert<ComposeTransposes>(context);
     populateCommonCanonicalizationPatterns(context, bubblingPatterns);
-    if (failed(applyPatternsAndFoldGreedily(funcOp,
-                                            std::move(bubblingPatterns)))) {
+
+    GreedyRewriteConfig config;
+    config.maxIterations = GreedyRewriteConfig::kNoLimit;
+    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(bubblingPatterns),
+                                            config))) {
       funcOp.emitError("Transpose bubbling patterns failed");
       return signalPassFailure();
     }


### PR DESCRIPTION
When applying the "bubbling" patterns in the transpose propagation pass, the greedy rewriter was failing because it reached 10 iterations before converging. This PR sets the iteration limit to `kNoLimit` which is the same config used for the "sinking" patterns that are applied afterwards. This is needed because these patterns take a bit to converge.


Fixes https://github.com/iree-org/iree/issues/19320