### PR TITLE
[iree.build] Make the fetch_http action more robust.

### DIFF
--- a/compiler/bindings/python/iree/build/net_actions.py
+++ b/compiler/bindings/python/iree/build/net_actions.py
@@ -7,7 +7,7 @@
 import urllib.error
 import urllib.request
 
-from iree.build.executor import BuildAction, BuildContext, BuildFile
+from iree.build.executor import BuildAction, BuildContext, BuildFile, BuildFileMetadata
 
 __all__ = [
     "fetch_http",
@@ -29,11 +29,49 @@ class FetchHttpAction(BuildAction):
         super().__init__(**kwargs)
         self.url = url
         self.output_file = output_file
+        self.original_desc = self.desc
 
     def _invoke(self):
+        # Determine whether metadata indicates that fetch is needed.
         path = self.output_file.get_fs_path()
+        needs_fetch = False
+        existing_metadata = self.output_file.access_metadata()
+        existing_url = existing_metadata.get("fetch_http.url")
+        if existing_url != self.url:
+            needs_fetch = True
+
+        # Always fetch if empty or absent.
+        if not path.exists() or path.stat().st_size == 0:
+            needs_fetch = True
+
+        # Bail if already obtained.
+        if not needs_fetch:
+            return
+
+        # Download to a staging file.
+        stage_path = path.with_name(f".{path.name}.download")
         self.executor.write_status(f"Fetching URL: {self.url} -> {path}")
+
+        def reporthook(received_blocks: int, block_size: int, total_size: int):
+            received_size = received_blocks * block_size
+            if total_size == 0:
+                self.desc = f"{self.original_desc} ({received_size} bytes received)"
+            else:
+                complete_percent = round(100 * received_size / total_size)
+                self.desc = f"{self.original_desc} ({complete_percent}% complete)"
+
         try:
-            urllib.request.urlretrieve(self.url, str(path))
+            urllib.request.urlretrieve(self.url, str(stage_path), reporthook=reporthook)
         except urllib.error.HTTPError as e:
             raise IOError(f"Failed to fetch URL '{self.url}': {e}") from None
+        finally:
+            self.desc = self.original_desc
+
+        # Commit the download.
+        def commit(metadata: BuildFileMetadata) -> bool:
+            metadata["fetch_http.url"] = self.url
+            path.unlink(missing_ok=True)
+            stage_path.rename(path)
+            return True
+
+        self.output_file.access_metadata(commit)

--- a/compiler/bindings/python/test/build_api/CMakeLists.txt
+++ b/compiler/bindings/python/test/build_api/CMakeLists.txt
@@ -20,3 +20,10 @@ iree_py_test(
  SRCS
    "basic_test.py"
 )
+
+iree_py_test(
+ NAME
+   net_test
+ SRCS
+   "net_test.py"
+)

--- a/compiler/bindings/python/test/build_api/mnist_builder_test.py
+++ b/compiler/bindings/python/test/build_api/mnist_builder_test.py
@@ -90,10 +90,7 @@ class MnistBuilderTest(unittest.TestCase):
         mod = load_build_module(THIS_DIR / "mnist_builder.py")
         out_file = io.StringIO()
         err_file = io.StringIO()
-        with self.assertRaisesRegex(
-            IOError,
-            re.escape("Failed to fetch URL 'https://github.com/iree-org/doesnotexist'"),
-        ):
+        with self.assertRaises(SystemExit):
             iree_build_main(
                 mod,
                 args=[
@@ -104,6 +101,7 @@ class MnistBuilderTest(unittest.TestCase):
                 stdout=out_file,
                 stderr=err_file,
             )
+        self.assertIn("ERROR:", err_file.getvalue())
 
     def testBuildNonDefaultSubTarget(self):
         mod = load_build_module(THIS_DIR / "mnist_builder.py")

--- a/compiler/bindings/python/test/build_api/net_test.py
+++ b/compiler/bindings/python/test/build_api/net_test.py
@@ -1,0 +1,100 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import io
+import os
+from pathlib import Path
+import tempfile
+import unittest
+
+from iree.build import *
+from iree.build.executor import BuildContext
+from iree.build.test_actions import ExecuteOutOfProcessThunkAction
+
+
+TEST_URL = None
+TEST_URL_1 = "https://huggingface.co/google-bert/bert-base-cased/resolve/cd5ef92a9fb2f889e972770a36d4ed042daf221e/tokenizer.json"
+TEST_URL_2 = "https://huggingface.co/google-bert/bert-base-cased/resolve/cd5ef92a9fb2f889e972770a36d4ed042daf221e/tokenizer_config.json"
+
+
+@entrypoint
+def tokenizer_via_http():
+    return fetch_http(
+        name="tokenizer.json",
+        url=TEST_URL,
+    )
+
+
+class BasicTest(unittest.TestCase):
+    def setUp(self):
+        self._temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        self._temp_dir.__enter__()
+        self.output_path = Path(self._temp_dir.name)
+
+    def tearDown(self) -> None:
+        self._temp_dir.__exit__(None, None, None)
+
+    def test_fetch_http(self):
+        # This just does a sanity check that rich console mode does not crash. Actual
+        # behavior can really only be completely verified visually.
+        out = None
+        err = None
+        global TEST_URL
+        path = self.output_path / "genfiles" / "tokenizer_via_http" / "tokenizer.json"
+
+        def run():
+            nonlocal out
+            nonlocal err
+            try:
+                out_io = io.StringIO()
+                err_io = io.StringIO()
+                iree_build_main(
+                    args=[
+                        "tokenizer_via_http",
+                        "--output-dir",
+                        str(self.output_path),
+                        "--test-force-console",
+                    ],
+                    stderr=err_io,
+                    stdout=out_io,
+                )
+            finally:
+                out = out_io.getvalue()
+                err = err_io.getvalue()
+                print(f"::test_fetch_http err: {err!r}")
+                print(f"::test_fetch_http out: {out!r}")
+
+        def assertExists():
+            self.assertTrue(path.exists(), msg=f"Path {path} exists")
+
+        # First run should fetch.
+        TEST_URL = TEST_URL_1
+        run()
+        self.assertIn("Fetching URL: https://", err)
+        assertExists()
+
+        # Second run should not fetch.
+        TEST_URL = TEST_URL_1
+        run()
+        self.assertNotIn("Fetching URL: https://", err)
+        assertExists()
+
+        # Fetching a different URL should download again.
+        TEST_URL = TEST_URL_2
+        run()
+        self.assertIn("Fetching URL: https://", err)
+        assertExists()
+
+        # Removing the file should fetch again.
+        TEST_URL = TEST_URL_2
+        path.unlink()
+        run()
+        self.assertIn("Fetching URL: https://", err)
+        assertExists()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
* Downloads to a staging file and then atomically renames into place, avoiding potential for partial downloads.
* Reports completion percent as part of the console updates.
* Persists metadata for the source URL and will refetch if changed.
* Fixes an error handling test for the onnx mnist_builder that missed the prior update.

More sophistication is possible but this brings it up to min-viable from a usability perspective.