### PR TITLE
[DT][NFC] Refactor encoding utilities. (2/n)

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPUMaterializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPUMaterializeEncodings.cpp
@@ -31,6 +31,8 @@
 namespace mlir::iree_compiler {
 
 using IREE::Codegen::MaterializeEncodingInfo;
+using IREE::Codegen::MaterializeEncodingValueFn;
+using IREE::Codegen::MaterializeEncodingValueInfo;
 using IREE::Codegen::TileMxNxK;
 
 #define GEN_PASS_DEF_CPUMATERIALIZEDEVICEENCODINGPASS

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoNop.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoNop.cpp
@@ -23,6 +23,8 @@ namespace mlir::iree_compiler {
 
 using namespace IREE::Encoding;
 using IREE::Codegen::MaterializeEncodingInfo;
+using IREE::Codegen::MaterializeEncodingValueFn;
+using IREE::Codegen::MaterializeEncodingValueInfo;
 
 namespace {
 struct MaterializeEncodingIntoNopPass final


### PR DESCRIPTION
The revision moves the below structs and functions to the Codegen dialect:
  - MaterializeEncodingValueInfo
  - MaterializeEncodingValueFn
  - lowerSetEncodingOpToPackOp
  - lowerUnsetEncodingToUnpackOp

Additionally, it makes few local functions public and moves them to the Codegen dialect:
  - transposeInPlace
  - getInnerTileSizesOfr

There are no changes in the implementation. The only difference is that the encoding lowering functions no longer take the type converter in inputs. Instead, they take ResolveEncodingInfoFn inputs.