### PR TITLE
[Codegen][Common] Add a pass to linearize memrefs

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -123,6 +123,7 @@ iree_compiler_cc_library(
         "IREEExpandStridedMetadata.cpp",
         "IREELoopInvariantCodeMotion.cpp",
         "InstrumentMemoryAccesses.cpp",
+        "LinearizeMemRefs.cpp",
         "LinkTuningSpecsPass.cpp",
         "LowerExecutableUsingTransformDialect.cpp",
         "LowerUKernelsToCalls.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -115,6 +115,7 @@ iree_cc_library(
     "IREEExpandStridedMetadata.cpp"
     "IREELoopInvariantCodeMotion.cpp"
     "InstrumentMemoryAccesses.cpp"
+    "LinearizeMemRefs.cpp"
     "LinkTuningSpecsPass.cpp"
     "LowerExecutableUsingTransformDialect.cpp"
     "LowerUKernelsToCalls.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/LinearizeMemRefs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LinearizeMemRefs.cpp
@@ -1,0 +1,343 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===- LinearizeMemRefs.cpp - Flatten n-D MemRef subspan ------------------===//
+//
+// This file implements an interprocedural pass to linearize memrefs.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Affine/Utils.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
+#include "mlir/Dialect/Linalg/Transforms/Hoisting.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/MemRef/Transforms/Passes.h"
+#include "mlir/Dialect/MemRef/Utils/MemRefUtils.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "iree-linearize-memrefs"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_LINEARIZEMEMREFS
+#include "iree/compiler/Codegen/Common/Passes.h.inc"
+
+namespace {
+
+static SmallVector<int64_t> getLinearizedShape(MemRefType ty, int srcBits,
+                                               int dstBits) {
+  if (ty.getRank() == 0)
+    return {};
+
+  int64_t linearizedShape = 1;
+  for (auto shape : ty.getShape()) {
+    if (shape == ShapedType::kDynamic)
+      return {ShapedType::kDynamic};
+    linearizedShape *= shape;
+  }
+  int scale = dstBits / srcBits;
+  // Scale the size to the ceilDiv(linearizedShape, scale)
+  // to accomodate all the values.
+  linearizedShape = (linearizedShape + scale - 1) / scale;
+  return {linearizedShape};
+}
+
+static LogicalResult linearizeType(MemRefType memrefType,
+                                   MemRefType &newMemrefType) {
+  // Fetch linearized shape.
+  // TODO(avarma): Take into account different src/dst bits.
+  int srcBits = memrefType.getElementType().getIntOrFloatBitWidth();
+  SmallVector<int64_t> linearizedShape =
+      getLinearizedShape(memrefType, srcBits, srcBits);
+  // Fetch offset and strides of the old memref.
+  SmallVector<int64_t> strides;
+  int64_t offset;
+  if (failed(getStridesAndOffset(memrefType, strides, offset)))
+    return failure();
+  if (!strides.empty() && strides.back() != 1)
+    return failure();
+  // Form layout for the linearized memref.
+  StridedLayoutAttr layoutAttr;
+  // If the offset is 0, we do not need a strided layout as the stride is
+  // 1, so we only use the strided layout if the offset is not 0.
+  if (offset != 0) {
+    layoutAttr = StridedLayoutAttr::get(memrefType.getContext(), offset,
+                                        ArrayRef<int64_t>{1});
+  }
+  Type elementType = memrefType.getElementType();
+  newMemrefType = MemRefType::get(linearizedShape, elementType, layoutAttr,
+                                  memrefType.getMemorySpace());
+  return success();
+}
+
+static LogicalResult
+getLinearizedTypeFromSourceType(MemRefType currentTypeOfSourceMemref,
+                                MemRefType &linearizedType) {
+  if (!currentTypeOfSourceMemref)
+    return failure();
+  if (currentTypeOfSourceMemref.getRank() < 2)
+    return success();
+  // Convert current type later.
+  return linearizeType(currentTypeOfSourceMemref, linearizedType);
+}
+
+template <typename OpTy>
+struct LinearizeMemrefAlloc : public OpRewritePattern<OpTy> {
+  LinearizeMemrefAlloc(MLIRContext *context, PatternBenefit benefit = 10)
+      : OpRewritePattern<OpTy>(context, benefit) {}
+
+  LogicalResult matchAndRewrite(OpTy allocOp,
+                                PatternRewriter &rewriter) const override {
+    static_assert(std::is_same<OpTy, memref::AllocOp>() ||
+                      std::is_same<OpTy, memref::AllocaOp>(),
+                  "expected only memref::AllocOp or memref::AllocaOp");
+    Location loc = allocOp->getLoc();
+    MemRefType currentTypeOfSourceMemref =
+        dyn_cast<MemRefType>(allocOp.getMemref().getType());
+    MemRefType newTypeOfSourceMemref;
+    if (failed(getLinearizedTypeFromSourceType(currentTypeOfSourceMemref,
+                                               newTypeOfSourceMemref))) {
+      return failure();
+    }
+    if (currentTypeOfSourceMemref.getRank() < 2)
+      return success();
+
+    auto elementType = currentTypeOfSourceMemref.getElementType();
+    int srcBits = elementType.getIntOrFloatBitWidth();
+
+    OpFoldResult zero = rewriter.getIndexAttr(0);
+
+    // Get linearized type.
+    int dstBits = srcBits;
+    SmallVector<OpFoldResult> sizes = allocOp.getMixedSizes();
+
+    memref::LinearizedMemRefInfo linearizedMemRefInfo =
+        memref::getLinearizedMemRefOffsetAndSize(
+            rewriter, loc, srcBits, dstBits, /*offset =*/zero, sizes);
+    SmallVector<Value> dynamicLinearizedSize;
+    if (!newTypeOfSourceMemref.hasStaticShape()) {
+      dynamicLinearizedSize.push_back(getValueOrCreateConstantIndexOp(
+          rewriter, loc, linearizedMemRefInfo.linearizedSize));
+    }
+
+    rewriter.replaceOpWithNewOp<OpTy>(
+        allocOp, newTypeOfSourceMemref, dynamicLinearizedSize,
+        allocOp.getSymbolOperands(), allocOp.getAlignmentAttr());
+    return success();
+  }
+};
+
+static Value linearizeOperand(Location loc, PatternRewriter &rewriter,
+                              Value operand, MemRefType linearizedType) {
+  return rewriter.create<memref::ReinterpretCastOp>(
+      loc, linearizedType, operand, 0, linearizedType.getShape(),
+      ArrayRef<int64_t>({1}));
+}
+
+struct LinearizeMemrefLoad : public OpRewritePattern<memref::LoadOp> {
+  using OpRewritePattern<memref::LoadOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(memref::LoadOp loadOp,
+                                PatternRewriter &rewriter) const override {
+    Location loc = loadOp->getLoc();
+    MemRefType currentTypeOfSourceMemref = loadOp.getMemRefType();
+    MemRefType newTypeOfSourceMemref;
+    if (failed(getLinearizedTypeFromSourceType(currentTypeOfSourceMemref,
+                                               newTypeOfSourceMemref))) {
+      return failure();
+    }
+    if (currentTypeOfSourceMemref.getRank() < 2 &&
+        loadOp.getIndices().size() < 2)
+      return success();
+
+    Value linearizedIndices = rewriter.create<affine::AffineLinearizeIndexOp>(
+        loc, loadOp.getIndices(), currentTypeOfSourceMemref.getShape(), true);
+    Value linearizedOperand = linearizeOperand(
+        loc, rewriter, loadOp.getMemref(), newTypeOfSourceMemref);
+    Value linearizedLoad = rewriter.create<memref::LoadOp>(
+        loc, linearizedOperand, linearizedIndices);
+
+    rewriter.replaceOp(loadOp, {linearizedLoad});
+    return success();
+  }
+};
+
+struct LinearizeMemrefStore : public OpRewritePattern<memref::StoreOp> {
+  using OpRewritePattern<memref::StoreOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(memref::StoreOp storeOp,
+                                PatternRewriter &rewriter) const override {
+    Location loc = storeOp->getLoc();
+    MemRefType currentTypeOfSourceMemref = storeOp.getMemRefType();
+    MemRefType newTypeOfSourceMemref;
+    if (failed(getLinearizedTypeFromSourceType(currentTypeOfSourceMemref,
+                                               newTypeOfSourceMemref))) {
+      return failure();
+    }
+    if (currentTypeOfSourceMemref.getRank() < 2 &&
+        storeOp.getIndices().size() < 2)
+      return success();
+
+    auto elementType = storeOp.getMemRefType().getElementType();
+    int srcBits = elementType.getIntOrFloatBitWidth();
+    Value linearizedIndices = rewriter.create<affine::AffineLinearizeIndexOp>(
+        loc, storeOp.getIndices(), currentTypeOfSourceMemref.getShape(), true);
+    Value linearizedOperand = linearizeOperand(
+        loc, rewriter, storeOp.getMemref(), newTypeOfSourceMemref);
+    rewriter.replaceOpWithNewOp<memref::StoreOp>(
+        storeOp, storeOp.getValueToStore(), linearizedOperand,
+        linearizedIndices, srcBits);
+
+    return success();
+  }
+};
+
+struct LinearizeMemrefDealloc : public OpRewritePattern<memref::DeallocOp> {
+  using OpRewritePattern<memref::DeallocOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(memref::DeallocOp deallocOp,
+                                PatternRewriter &rewriter) const override {
+    Location loc = deallocOp->getLoc();
+    MemRefType currentTypeOfSourceMemref =
+        dyn_cast<MemRefType>(deallocOp.getMemref().getType());
+    MemRefType newTypeOfSourceMemref;
+    if (failed(getLinearizedTypeFromSourceType(currentTypeOfSourceMemref,
+                                               newTypeOfSourceMemref))) {
+      return failure();
+    }
+    if (currentTypeOfSourceMemref.getRank() < 2)
+      return success();
+
+    Value linearizedOperand = linearizeOperand(
+        loc, rewriter, deallocOp.getMemref(), newTypeOfSourceMemref);
+
+    rewriter.replaceOpWithNewOp<memref::DeallocOp>(deallocOp,
+                                                   linearizedOperand);
+    return success();
+  }
+};
+
+struct LinearizeMemrefCopy : public OpRewritePattern<memref::CopyOp> {
+  using OpRewritePattern<memref::CopyOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(memref::CopyOp copyOp,
+                                PatternRewriter &rewriter) const override {
+    Location loc = copyOp->getLoc();
+    MemRefType currentTypeOfSourceMemref =
+        dyn_cast<MemRefType>(copyOp.getSource().getType());
+    MemRefType currentTypeOfTargetMemref =
+        dyn_cast<MemRefType>(copyOp.getTarget().getType());
+    MemRefType newTypeOfSourceMemref;
+    if (failed(getLinearizedTypeFromSourceType(currentTypeOfSourceMemref,
+                                               newTypeOfSourceMemref))) {
+      return failure();
+    }
+    if (currentTypeOfSourceMemref.getRank() < 2 &&
+        currentTypeOfTargetMemref.getRank() < 2)
+      return success();
+
+    Value linearizedSource = linearizeOperand(loc, rewriter, copyOp.getSource(),
+                                              newTypeOfSourceMemref);
+    Value linearizedTarget = linearizeOperand(loc, rewriter, copyOp.getTarget(),
+                                              newTypeOfSourceMemref);
+
+    rewriter.replaceOpWithNewOp<memref::CopyOp>(copyOp, linearizedSource,
+                                                linearizedTarget);
+    return success();
+  }
+};
+
+struct LinearizeVectorLoad : public OpRewritePattern<vector::LoadOp> {
+  using OpRewritePattern<vector::LoadOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(vector::LoadOp loadOp,
+                                PatternRewriter &rewriter) const override {
+    Location loc = loadOp->getLoc();
+    MemRefType currentTypeOfSourceMemref = loadOp.getMemRefType();
+    MemRefType newTypeOfSourceMemref;
+    if (failed(getLinearizedTypeFromSourceType(currentTypeOfSourceMemref,
+                                               newTypeOfSourceMemref))) {
+      return failure();
+    }
+    if (currentTypeOfSourceMemref.getRank() < 2 &&
+        loadOp.getIndices().size() < 2)
+      return success();
+
+    Value linearizedIndices = rewriter.create<affine::AffineLinearizeIndexOp>(
+        loc, loadOp.getIndices(), currentTypeOfSourceMemref.getShape(), true);
+    Value linearizedOperand = linearizeOperand(loc, rewriter, loadOp.getBase(),
+                                               newTypeOfSourceMemref);
+    Value linearizedLoad = rewriter.create<vector::LoadOp>(
+        loc, loadOp.getType(), linearizedOperand, linearizedIndices);
+
+    rewriter.replaceOp(loadOp, {linearizedLoad});
+    return success();
+  }
+};
+
+struct LinearizeVectorStore : public OpRewritePattern<vector::StoreOp> {
+  using OpRewritePattern<vector::StoreOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(vector::StoreOp storeOp,
+                                PatternRewriter &rewriter) const override {
+    Location loc = storeOp->getLoc();
+    MemRefType currentTypeOfSourceMemref = storeOp.getMemRefType();
+    MemRefType newTypeOfSourceMemref;
+    if (failed(getLinearizedTypeFromSourceType(currentTypeOfSourceMemref,
+                                               newTypeOfSourceMemref))) {
+      return failure();
+    }
+    if (currentTypeOfSourceMemref.getRank() < 2 &&
+        storeOp.getIndices().size() < 2)
+      return success();
+
+    Value linearizedIndices = rewriter.create<affine::AffineLinearizeIndexOp>(
+        loc, storeOp.getIndices(), currentTypeOfSourceMemref.getShape(), true);
+    Value linearizedOperand = linearizeOperand(loc, rewriter, storeOp.getBase(),
+                                               newTypeOfSourceMemref);
+    rewriter.replaceOpWithNewOp<vector::StoreOp>(
+        storeOp, storeOp.getValueToStore(), linearizedOperand,
+        linearizedIndices);
+
+    return success();
+  }
+};
+//===----------------------------------------------------------------------===//
+// Pass
+//===----------------------------------------------------------------------===//
+
+struct LinearizeMemRefs final : impl::LinearizeMemRefsBase<LinearizeMemRefs> {
+  void runOnOperation() override;
+};
+
+void LinearizeMemRefs::runOnOperation() {
+  LLVM_DEBUG(llvm::dbgs() << "Linearizing Memrefs...\n");
+  ModuleOp moduleOp = getOperation();
+  MLIRContext *context = &getContext();
+  IRRewriter rewriter(context);
+
+  RewritePatternSet patterns(context);
+  patterns.add<LinearizeMemrefAlloc<memref::AllocOp>>(context);
+  patterns.add<LinearizeMemrefAlloc<memref::AllocaOp>>(context);
+  patterns.add<LinearizeMemrefLoad>(context);
+  patterns.add<LinearizeMemrefStore>(context);
+  patterns.add<LinearizeMemrefDealloc>(context);
+  patterns.add<LinearizeMemrefCopy>(context);
+  patterns.add<LinearizeVectorLoad>(context);
+  patterns.add<LinearizeVectorStore>(context);
+
+  (void)applyPatternsAndFoldGreedily(moduleOp, std::move(patterns));
+
+  return;
+}
+} // namespace
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/LinearizeMemRefs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LinearizeMemRefs.cpp
@@ -450,7 +450,7 @@ void LinearizeMemRefs::runOnOperation() {
   patterns.add<LinearizeVectorLoad>(context);
   patterns.add<LinearizeVectorStore>(context);
 
-  (void)applyPatternsAndFoldGreedily(moduleOp, std::move(patterns));
+  (void)applyPatternsGreedily(moduleOp, std::move(patterns));
 
   return;
 }

--- a/compiler/src/iree/compiler/Codegen/Common/LinearizeMemRefs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LinearizeMemRefs.cpp
@@ -52,7 +52,7 @@ static FailureOr<MemRefType> linearizeType(MemRefType memrefType) {
   // Fetch offset and strides of the old memref.
   SmallVector<int64_t> strides;
   int64_t offset;
-  if (failed(getStridesAndOffset(memrefType, strides, offset)))
+  if (failed(memrefType.getStridesAndOffset(strides, offset)))
     return failure();
   if (strides.empty())
     return failure();
@@ -83,7 +83,7 @@ static Value linearizeOperand(Location loc, PatternRewriter &rewriter,
   // Fetch offset and strides of the old memref.
   SmallVector<int64_t> strides;
   int64_t offset;
-  if (failed(getStridesAndOffset(linearizedType, strides, offset))) {
+  if (failed(linearizedType.getStridesAndOffset(strides, offset))) {
     // TODO(avarma): Change function signature.
     return nullptr;
   }

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -411,6 +411,21 @@ def InstrumentMemoryAccessesPass :
   let summary = "Instruments memory reads and writes for address tracking when dispatch instrumentation is enabled.";
 }
 
+def LinearizeMemRefs : Pass<"iree-linearize-memrefs", "ModuleOp"> {
+  let summary =
+      "An inter-procedural pass to linearize memrefs";
+  let description = [{
+    An inter-procedural pass to linearize memrefs.
+    Currently operates on :-
+    1. memref.load/store
+    2. vector.load/store
+    3. memref.alloc*
+    4. memref.dealloc
+    5. memref.copy
+  }];
+  let dependentDialects = ["affine::AffineDialect", "memref::MemRefDialect", "vector::VectorDialect"];
+}
+
 def LinkTuningSpecsPass : Pass<"iree-codegen-link-tuning-specs", "ModuleOp"> {
   let summary =
       "Link nested transform dialect tuning specs named sequences into a single entry point";

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -57,6 +57,7 @@ iree_lit_test_suite(
             "iree_comprehensive_bufferize.mlir",
             "iree_expand_strided_metadata.mlir",
             "iree_loop_invariant_code_motion.mlir",
+            "linearize_memrefs.mlir",
             "link_tuning_specs.mlir",
             "llvmcpu_materialize_encoding.mlir",
             "lower_ukernel_to_calls.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -53,6 +53,7 @@ iree_lit_test_suite(
     "iree_comprehensive_bufferize.mlir"
     "iree_expand_strided_metadata.mlir"
     "iree_loop_invariant_code_motion.mlir"
+    "linearize_memrefs.mlir"
     "link_tuning_specs.mlir"
     "llvmcpu_materialize_encoding.mlir"
     "lower_ukernel_to_calls.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/linearize_memrefs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/linearize_memrefs.mlir
@@ -1,6 +1,10 @@
 // RUN: iree-opt -iree-linearize-memrefs -allow-unregistered-dialect %s | FileCheck %s
 
-// CHECK-LABEL: @vector_load_store(
+//--------------------------------------------------------------------------
+//---------------------------- VECTOR OPS ----------------------------------
+//--------------------------------------------------------------------------
+
+// CHECK-LABEL: @vector_load_store_static(
 // CHECK-SAME:    %[[ARG0:.*]]: memref<2x3x4xi32>)
 // CHECK-DAG:     %[[C6:.*]] = arith.constant 6 : index
 // CHECK:         %[[CAST:.*]] = memref.reinterpret_cast %[[ARG0]] to
@@ -12,7 +16,7 @@
 // CHECK-SAME:                    memref<2x3x4xi32> to memref<24xi32>
 // CHECK:         vector.store %[[LOAD]], %[[CAST_2]][%[[C6]]]
 // CHECK:         return %[[LOAD]]
-func.func @vector_load_store(%arg0: memref<2x3x4xi32>) -> vector<2x3xi32> {
+func.func @vector_load_store_static(%arg0: memref<2x3x4xi32>) -> vector<2x3xi32> {
   %c2 = arith.constant 2 : index
   %c1 = arith.constant 1 : index
   %c0 = arith.constant 0 : index
@@ -21,14 +25,56 @@ func.func @vector_load_store(%arg0: memref<2x3x4xi32>) -> vector<2x3xi32> {
   return %1 : vector<2x3xi32>
 }
 
+// CHECK-LABEL: @vector_load_store_dynamic(
+// CHECK-SAME:    %[[DIM0:.*]]: index, %[[DIM1:.*]]: index, %[[DIM2:.*]]: index, %[[I0:.*]]: index, %[[I1:.*]]: index, %[[I2:.*]]: index)
+// CHECK-DAG:     %[[C0:.*]] = arith.constant 0 : index
+// CHECK:         %[[LINEAR_SIZE:.*]] = affine.linearize_index disjoint [%[[DIM0]], %[[C0]], %[[C0]]
+// CHECK-SAME:                              by (%[[DIM0]], %[[DIM1]], %[[DIM2]]) : index
+// CHECK:         %[[ALLOC:.*]] = memref.alloca(%[[LINEAR_SIZE]]) : memref<?xi32>
+// CHECK:         %[[EXPAND_SHAPE:.*]] = memref.expand_shape %[[ALLOC]]
+// CHECK{LITERAL}:                          [[0, 1, 2]]
+// CHECK-SAME:                              output_shape [%[[DIM0]], %[[DIM1]], %[[DIM2]]]
+// CHECK-SAME:                              : memref<?xi32> into memref<?x?x?xi32>
+// CHECK:         %[[LINEAR_INDEX:.*]] = affine.linearize_index disjoint [%[[I0]], %[[I1]], %[[I2]]
+// CHECK-SAME:                              by (%[[DIM0]], %[[DIM1]], %[[DIM2]]) : index
+// CHECK:         %[[LINEAR_SIZE:.*]] = affine.linearize_index disjoint [%[[DIM0]], %[[C0]], %[[C0]]
+// CHECK-SAME:                              by (%[[DIM0]], %[[DIM1]], %[[DIM2]]) : index
+// CHECK:         %[[CAST:.*]] = memref.reinterpret_cast %[[EXPAND_SHAPE]] to
+// CHECK-SAME:                        offset: [0], sizes: [%[[LINEAR_SIZE]]], strides: [1] :
+// CHECK-SAME:                        memref<?x?x?xi32> to memref<?xi32>
+// CHECK:         %[[LOAD:.*]] = vector.load %[[CAST]][%[[LINEAR_INDEX]]] : memref<?xi32>, vector<2x3xi32>
+// CHECK:         %[[LINEAR_INDEX:.*]] = affine.linearize_index disjoint [%[[I0]], %[[I1]], %[[I2]]
+// CHECK-SAME:                              by (%[[DIM0]], %[[DIM1]], %[[DIM2]]) : index
+// CHECK:         %[[LINEAR_SIZE:.*]] = affine.linearize_index disjoint [%[[DIM0]], %[[C0]], %[[C0]]
+// CHECK-SAME:                              by (%[[DIM0]], %[[DIM1]], %[[DIM2]]) : index
+// CHECK:         %[[CAST:.*]] = memref.reinterpret_cast %[[EXPAND_SHAPE]] to
+// CHECK-SAME:                        offset: [0], sizes: [%[[LINEAR_SIZE]]], strides: [1] :
+// CHECK-SAME:                        memref<?x?x?xi32> to memref<?xi32>
+// CHECK:         vector.store %[[LOAD]], %[[CAST]][%[[LINEAR_INDEX]]] : memref<?xi32>, vector<2x3xi32>
+// CHECK:         return %[[LOAD]] : vector<2x3xi32>
+func.func @vector_load_store_dynamic(%dim0 : index, %dim1: index, %dim2: index, %i0: index, %i1: index, %i2: index) -> vector<2x3xi32> {
+  %c2 = arith.constant 2 : index
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %alloc = memref.alloca(%dim0, %dim1, %dim2) : memref<?x?x?xi32>
+  %1 = vector.load %alloc[%i0, %i1, %i2] : memref<?x?x?xi32>, vector<2x3xi32>
+  vector.store %1, %alloc[%i0, %i1, %i2] : memref<?x?x?xi32>, vector<2x3xi32>
+  return %1 : vector<2x3xi32>
+}
+
 // -----
 
-// CHECK-LABEL: @memref_load_store_alloc_dealloc(
+//--------------------------------------------------------------------------
+//---------------------------- MEMREF OPS ----------------------------------
+//--------------------------------------------------------------------------
+
+
+// CHECK-LABEL: @memref_load_store_alloc_dealloc_static(
 // CHECK-DAG:     %[[C6:.*]] = arith.constant 6 : index
 // CHECK-DAG:     %[[C7:.*]] = arith.constant 7 : index
 // CHECK:         %[[ALLOC:.*]] = memref.alloc() : memref<24xi32>
 // CHECK:         %[[EXPAND_ALLOC:.*]] = memref.expand_shape %[[ALLOC]]
-// CHECK{LITERAL}:                 [[0, 1, 2]] output_shape [2, 3, 4]
+// CHECK{LITERAL}:                       [[0, 1, 2]] output_shape [2, 3, 4]
 // CHECK-SAME:                           : memref<24xi32> into memref<2x3x4xi32>
 // CHECK:         %[[RESHAPE_ALLOC:.*]] = memref.reinterpret_cast %[[EXPAND_ALLOC]] to offset: [0], sizes: [24], strides: [1]
 // CHECK-SAME:                           : memref<2x3x4xi32> to memref<24xi32>
@@ -45,22 +91,67 @@ func.func @vector_load_store(%arg0: memref<2x3x4xi32>) -> vector<2x3xi32> {
 // CHECK:         %[[RESHAPE_ALLOCA_2:.*]] = memref.reinterpret_cast %[[EXPAND_ALLOCA]]
 // CHECK:         memref.dealloc %[[RESHAPE_ALLOCA_2]]
 // CHECK:         return %[[LOAD]]
-func.func @memref_load_store_alloc_dealloc() -> i32 {
+func.func @memref_load_store_alloc_dealloc_static() -> i32 {
   %c2 = arith.constant 2 : index
   %c1 = arith.constant 1 : index
   %c0 = arith.constant 0 : index
   %0 = memref.alloc() : memref<2x3x4xi32>
   %1 = memref.load %0[%c0, %c1, %c2] : memref<2x3x4xi32>
   %2 = memref.alloca() : memref<3x4x5xi32>
-  memref.store %1, %2[%c0, %c1, %c2] : memref<3x4x5xi32>
+  memref.store %1, %2[%c0, %c1, %c2] {nontemporal = true} : memref<3x4x5xi32>
   memref.dealloc %0 : memref<2x3x4xi32>
   memref.dealloc %2 : memref<3x4x5xi32>
   return %1 : i32
 }
 
+// CHECK-LABEL: @memref_load_store_alloc_dealloc_dynamic(
+// CHECK-SAME:    %[[DIM0:.*]]: index, %[[DIM1:.*]]: index, %[[DIM2:.*]]: index, %[[I0:.*]]: index, %[[I1:.*]]: index, %[[I2:.*]]: index)
+// CHECK-DAG:     %[[C2:.*]] = arith.constant 2 : index
+// CHECK-DAG:     %[[C1:.*]] = arith.constant 1 : index
+// CHECK-DAG:     %[[C0:.*]] = arith.constant 0 : index
+// CHECK:         %[[LINEAR_SIZE:.*]] = affine.linearize_index disjoint [%[[DIM0]], %[[C0]], %[[C0]]
+// CHECK-SAME:                              by (%[[DIM0]], %[[DIM1]], %[[DIM2]]) : index
+// CHECK:         %[[ALLOC:.*]] = memref.alloca(%[[LINEAR_SIZE]]) : memref<?xf32>
+// CHECK:         %[[EXPAND_SHAPE:.*]] = memref.expand_shape %[[ALLOC]]
+// CHECK{LITERAL}:                          [[0, 1, 2]]
+// CHECK-SAME:                              output_shape [%[[DIM0]], %[[DIM1]], %[[DIM2]]]
+// CHECK-SAME:                              : memref<?xf32> into memref<?x?x?xf32>
+// CHECK:         %[[LINEAR_INDEX:.*]] = affine.linearize_index disjoint [%[[I0]], %[[I1]], %[[I2]]
+// CHECK-SAME:                              by (%[[DIM0]], %[[DIM1]], %[[DIM2]]) : index
+// CHECK:         %[[LINEAR_SIZE:.*]] = affine.linearize_index disjoint [%[[DIM0]], %[[C0]], %[[C0]]
+// CHECK-SAME:                              by (%[[DIM0]], %[[DIM1]], %[[DIM2]]) : index
+// CHECK:         %[[CAST:.*]] = memref.reinterpret_cast %[[EXPAND_SHAPE]] to
+// CHECK-SAME:                        offset: [0], sizes: [%[[LINEAR_SIZE]]], strides: [1] :
+// CHECK-SAME:                        memref<?x?x?xf32> to memref<?xf32>
+// CHECK:         %[[LOAD:.*]] = memref.load %[[CAST]][%[[LINEAR_INDEX]]] : memref<?xf32>
+// CHECK:         %[[LINEAR_INDEX:.*]] = affine.linearize_index disjoint [%[[C2]], %[[C1]], %[[C0]]
+// CHECK-SAME:                              by (%[[DIM0]], %[[DIM1]], %[[DIM2]]) : index
+// CHECK:         %[[LINEAR_SIZE:.*]] = affine.linearize_index disjoint [%[[DIM0]], %[[C0]], %[[C0]]
+// CHECK-SAME:                              by (%[[DIM0]], %[[DIM1]], %[[DIM2]]) : index
+// CHECK:         %[[CAST:.*]] = memref.reinterpret_cast %[[EXPAND_SHAPE]] to
+// CHECK-SAME:                        offset: [0], sizes: [%[[LINEAR_SIZE]]], strides: [1] :
+// CHECK-SAME:                        memref<?x?x?xf32> to memref<?xf32>
+// CHECK:         memref.store %[[LOAD]], %[[CAST]][%[[LINEAR_INDEX]]] : memref<?xf32>
+// CHECK:         %[[LINEAR_SIZE:.*]] = affine.linearize_index disjoint [%[[DIM0]], %[[C0]], %[[C0]]
+// CHECK-SAME:                              by (%[[DIM0]], %[[DIM1]], %[[DIM2]]) : index
+// CHECK:         %[[CAST:.*]] = memref.reinterpret_cast %[[EXPAND_SHAPE]] to
+// CHECK-SAME:                        offset: [0], sizes: [%[[LINEAR_SIZE]]], strides: [1] :
+// CHECK-SAME:                        memref<?x?x?xf32> to memref<?xf32>
+// CHECK:         memref.dealloc %[[CAST]] : memref<?xf32>
+// CHECK:         return %[[LOAD]] : f32
+func.func @memref_load_store_alloc_dealloc_dynamic(%dim0 : index, %dim1: index, %dim2: index, %i0: index, %i1: index, %i2: index) -> f32 {
+  %c2 = arith.constant 2 : index
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %alloc = memref.alloca(%dim0, %dim1, %dim2) : memref<?x?x?xf32>
+  %1 = memref.load %alloc[%i0, %i1, %i2] : memref<?x?x?xf32>
+  memref.store %1, %alloc[%c2, %c1, %c0] : memref<?x?x?xf32>
+  memref.dealloc %alloc : memref<?x?x?xf32>
+  return %1 : f32
+}
 // -----
 
-// CHECK-LABEL: @memref_copy(
+// CHECK-LABEL: @memref_copy_static(
 // CHECK-SAME:    %[[ARG0:.*]]: memref<2x3x4xi32>,
 // CHECK-SAME:    %[[ARG1:.*]]: memref<2x3x4xi32>)
 // CHECK:         %[[CAST_1:.*]] = memref.reinterpret_cast %[[ARG0]] to
@@ -71,7 +162,43 @@ func.func @memref_load_store_alloc_dealloc() -> i32 {
 // CHECK-SAME:                    memref<2x3x4xi32> to memref<24xi32>
 // CHECK:         memref.copy %[[CAST_1]], %[[CAST_2]]
 // CHECK:         return
-func.func @memref_copy(%arg0: memref<2x3x4xi32>, %arg1: memref<2x3x4xi32>) {
+func.func @memref_copy_static(%arg0: memref<2x3x4xi32>, %arg1: memref<2x3x4xi32>) {
   memref.copy %arg0, %arg1 : memref<2x3x4xi32> to memref<2x3x4xi32>
+  return
+}
+
+// CHECK-LABEL: @memref_copy_dynamic(
+// CHECK-SAME:    %[[DIM0:.*]]: index, %[[DIM1:.*]]: index, %[[DIM2:.*]]: index, %[[DIM3:.*]]: index, %[[DIM4:.*]]: index, %[[DIM5:.*]]: index)
+// CHECK-DAG:     %[[C0:.*]] = arith.constant 0 : index
+// CHECK:         %[[LINEAR_SIZE:.*]] = affine.linearize_index disjoint [%[[DIM0]], %[[C0]], %[[C0]]
+// CHECK-SAME:                              by (%[[DIM0]], %[[DIM1]], %[[DIM2]]) : index
+// CHECK:         %[[ALLOC:.*]] = memref.alloca(%[[LINEAR_SIZE]]) : memref<?xf32>
+// CHECK:         %[[EXPAND_SHAPE:.*]] = memref.expand_shape %[[ALLOC]]
+// CHECK{LITERAL}:                          [[0, 1, 2]]
+// CHECK-SAME:                              output_shape [%[[DIM0]], %[[DIM1]], %[[DIM2]]]
+// CHECK-SAME:                              : memref<?xf32> into memref<?x?x?xf32>
+// CHECK:         %[[LINEAR_SIZE_1:.*]] = affine.linearize_index disjoint [%[[DIM3]], %[[C0]], %[[C0]]
+// CHECK-SAME:                              by (%[[DIM3]], %[[DIM4]], %[[DIM5]]) : index
+// CHECK:         %[[ALLOC_1:.*]] = memref.alloca(%[[LINEAR_SIZE_1]]) : memref<?xf32>
+// CHECK:         %[[EXPAND_SHAPE_1:.*]] = memref.expand_shape %[[ALLOC]]
+// CHECK{LITERAL}:                          [[0, 1, 2]]
+// CHECK-SAME:                              output_shape [%[[DIM3]], %[[DIM4]], %[[DIM5]]]
+// CHECK-SAME:                              : memref<?xf32> into memref<?x?x?xf32>
+// CHECK:         %[[LINEAR_SIZE:.*]] = affine.linearize_index disjoint [%[[DIM0]], %[[C0]], %[[C0]]
+// CHECK-SAME:                              by (%[[DIM0]], %[[DIM1]], %[[DIM2]]) : index
+// CHECK:         %[[CAST:.*]] = memref.reinterpret_cast %[[EXPAND_SHAPE]] to
+// CHECK-SAME:                        offset: [0], sizes: [%[[LINEAR_SIZE]]], strides: [1] :
+// CHECK-SAME:                        memref<?x?x?xf32> to memref<?xf32>
+// CHECK:         %[[LINEAR_SIZE_1:.*]] = affine.linearize_index disjoint [%[[DIM3]], %[[C0]], %[[C0]]
+// CHECK-SAME:                              by (%[[DIM3]], %[[DIM4]], %[[DIM5]]) : index
+// CHECK:         %[[CAST_1:.*]] = memref.reinterpret_cast %[[EXPAND_SHAPE_1]] to
+// CHECK-SAME:                        offset: [0], sizes: [%[[LINEAR_SIZE_1]]], strides: [1] :
+// CHECK-SAME:                        memref<?x?x?xf32> to memref<?xf32>
+// CHECK:         memref.copy %[[CAST]], %[[CAST_1]] : memref<?xf32> to memref<?xf32>
+// CHECK:         return
+func.func @memref_copy_dynamic(%dim0 : index, %dim1: index, %dim2: index, %dim3 : index, %dim4: index, %dim5: index) {
+  %alloc = memref.alloca(%dim0, %dim1, %dim2) : memref<?x?x?xf32>
+  %alloc1 = memref.alloca(%dim3, %dim4, %dim5) : memref<?x?x?xf32>
+  memref.copy %alloc, %alloc1 : memref<?x?x?xf32> to memref<?x?x?xf32>
   return
 }

--- a/compiler/src/iree/compiler/Codegen/Common/test/linearize_memrefs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/linearize_memrefs.mlir
@@ -1,0 +1,65 @@
+// RUN: iree-opt -iree-linearize-memrefs -allow-unregistered-dialect %s | FileCheck %s
+
+// CHECK-LABEL: @vector_load_store(
+// CHECK-SAME:    %[[ARG0:.*]]: memref<2x3x4xi32>)
+// CHECK-DAG:     %[[C6:.*]] = arith.constant 6 : index
+// CHECK:         %[[CAST:.*]] = memref.reinterpret_cast %[[ARG0]] to
+// CHECK-SAME:                    offset: [0], sizes: [24], strides: [1] :
+// CHECK-SAME:                    memref<2x3x4xi32> to memref<24xi32>
+// CHECK:         %[[LOAD:.*]] = vector.load %[[CAST]][%[[C6]]]
+// CHECK:         %[[CAST_2:.*]] = memref.reinterpret_cast %[[ARG0]] to
+// CHECK-SAME:                    offset: [0], sizes: [24], strides: [1] :
+// CHECK-SAME:                    memref<2x3x4xi32> to memref<24xi32>
+// CHECK:         vector.store %[[LOAD]], %[[CAST_2]][%[[C6]]]
+// CHECK:         return %[[LOAD]]
+func.func @vector_load_store(%arg0: memref<2x3x4xi32>) -> vector<2xi32> {
+  %c2 = arith.constant 2 : index
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %1 = vector.load %arg0[%c0, %c1, %c2] : memref<2x3x4xi32>, vector<2xi32>
+  vector.store %1, %arg0[%c0, %c1, %c2] : memref<2x3x4xi32>, vector<2xi32>
+  return %1 : vector<2xi32>
+}
+
+// -----
+
+// CHECK-LABEL: @memref_load_store_alloc_dealloc(
+// CHECK-DAG:     %[[C6:.*]] = arith.constant 6 : index
+// CHECK-DAG:     %[[C7:.*]] = arith.constant 7 : index
+// CHECK:         %[[ALLOC:.*]] = memref.alloc() : memref<24xi32>
+// CHECK:         %[[LOAD:.*]] = memref.load %[[ALLOC]][%[[C6]]]
+// CHECK:         %[[ALLOCA:.*]] = memref.alloca() : memref<60xi32>
+// CHECK:         memref.store %[[LOAD]], %[[ALLOCA]][%[[C7]]] {nontemporal = true} : memref<60xi32>
+// CHECK:         memref.dealloc %[[ALLOC]]
+// CHECK:         memref.dealloc %[[ALLOCA]]
+// CHECK:         return %[[LOAD]]
+func.func @memref_load_store_alloc_dealloc() -> i32 {
+  %c2 = arith.constant 2 : index
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %0 = memref.alloc() : memref<2x3x4xi32>
+  %1 = memref.load %0[%c0, %c1, %c2] : memref<2x3x4xi32>
+  %2 = memref.alloca() : memref<3x4x5xi32>
+  memref.store %1, %2[%c0, %c1, %c2] : memref<3x4x5xi32>
+  memref.dealloc %0 : memref<2x3x4xi32>
+  memref.dealloc %2 : memref<3x4x5xi32>
+  return %1 : i32
+}
+
+// -----
+
+// CHECK-LABEL: @memref_copy(
+// CHECK-SAME:    %[[ARG0:.*]]: memref<2x3x4xi32>,
+// CHECK-SAME:    %[[ARG1:.*]]: memref<2x3x4xi32>)
+// CHECK:         %[[CAST_1:.*]] = memref.reinterpret_cast %[[ARG0]] to
+// CHECK-SAME:                    offset: [0], sizes: [24], strides: [1] :
+// CHECK-SAME:                    memref<2x3x4xi32> to memref<24xi32>
+// CHECK:         %[[CAST_2:.*]] = memref.reinterpret_cast %[[ARG1]] to
+// CHECK-SAME:                    offset: [0], sizes: [24], strides: [1] :
+// CHECK-SAME:                    memref<2x3x4xi32> to memref<24xi32>
+// CHECK:         memref.copy %[[CAST_1]], %[[CAST_2]]
+// CHECK:         return
+func.func @memref_copy(%arg0: memref<2x3x4xi32>, %arg1: memref<2x3x4xi32>) {
+  memref.copy %arg0, %arg1 : memref<2x3x4xi32> to memref<2x3x4xi32>
+  return
+}

--- a/compiler/src/iree/compiler/Codegen/Common/test/linearize_memrefs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/linearize_memrefs.mlir
@@ -12,13 +12,13 @@
 // CHECK-SAME:                    memref<2x3x4xi32> to memref<24xi32>
 // CHECK:         vector.store %[[LOAD]], %[[CAST_2]][%[[C6]]]
 // CHECK:         return %[[LOAD]]
-func.func @vector_load_store(%arg0: memref<2x3x4xi32>) -> vector<2xi32> {
+func.func @vector_load_store(%arg0: memref<2x3x4xi32>) -> vector<2x3xi32> {
   %c2 = arith.constant 2 : index
   %c1 = arith.constant 1 : index
   %c0 = arith.constant 0 : index
-  %1 = vector.load %arg0[%c0, %c1, %c2] : memref<2x3x4xi32>, vector<2xi32>
-  vector.store %1, %arg0[%c0, %c1, %c2] : memref<2x3x4xi32>, vector<2xi32>
-  return %1 : vector<2xi32>
+  %1 = vector.load %arg0[%c0, %c1, %c2] : memref<2x3x4xi32>, vector<2x3xi32>
+  vector.store %1, %arg0[%c0, %c1, %c2] : memref<2x3x4xi32>, vector<2x3xi32>
+  return %1 : vector<2x3xi32>
 }
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/Common/test/linearize_memrefs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/linearize_memrefs.mlir
@@ -27,11 +27,23 @@ func.func @vector_load_store(%arg0: memref<2x3x4xi32>) -> vector<2x3xi32> {
 // CHECK-DAG:     %[[C6:.*]] = arith.constant 6 : index
 // CHECK-DAG:     %[[C7:.*]] = arith.constant 7 : index
 // CHECK:         %[[ALLOC:.*]] = memref.alloc() : memref<24xi32>
-// CHECK:         %[[LOAD:.*]] = memref.load %[[ALLOC]][%[[C6]]]
+// CHECK:         %[[EXPAND_ALLOC:.*]] = memref.expand_shape %[[ALLOC]]
+// CHECK{LITERAL}:                 [[0, 1, 2]] output_shape [2, 3, 4]
+// CHECK-SAME:                           : memref<24xi32> into memref<2x3x4xi32>
+// CHECK:         %[[RESHAPE_ALLOC:.*]] = memref.reinterpret_cast %[[EXPAND_ALLOC]] to offset: [0], sizes: [24], strides: [1]
+// CHECK-SAME:                           : memref<2x3x4xi32> to memref<24xi32>
+// CHECK:         %[[LOAD:.*]] = memref.load %[[RESHAPE_ALLOC]][%[[C6]]]
 // CHECK:         %[[ALLOCA:.*]] = memref.alloca() : memref<60xi32>
-// CHECK:         memref.store %[[LOAD]], %[[ALLOCA]][%[[C7]]] {nontemporal = true} : memref<60xi32>
-// CHECK:         memref.dealloc %[[ALLOC]]
-// CHECK:         memref.dealloc %[[ALLOCA]]
+// CHECK:         %[[EXPAND_ALLOCA:.*]] = memref.expand_shape %[[ALLOCA]]
+// CHECK{LITERAL}:                 [[0, 1, 2]] output_shape [3, 4, 5]
+// CHECK-SAME:                           : memref<60xi32> into memref<3x4x5xi32>
+// CHECK:         %[[RESHAPE_ALLOCA:.*]] = memref.reinterpret_cast %[[EXPAND_ALLOCA]] to offset: [0], sizes: [60], strides: [1]
+// CHECK-SAME:                           : memref<3x4x5xi32> to memref<60xi32>
+// CHECK:         memref.store %[[LOAD]], %[[RESHAPE_ALLOCA]][%[[C7]]] {nontemporal = true} : memref<60xi32>
+// CHECK:         %[[RESHAPE_ALLOC_2:.*]] = memref.reinterpret_cast %[[EXPAND_ALLOC]]
+// CHECK:         memref.dealloc %[[RESHAPE_ALLOC_2]]
+// CHECK:         %[[RESHAPE_ALLOCA_2:.*]] = memref.reinterpret_cast %[[EXPAND_ALLOCA]]
+// CHECK:         memref.dealloc %[[RESHAPE_ALLOCA_2]]
 // CHECK:         return %[[LOAD]]
 func.func @memref_load_store_alloc_dealloc() -> i32 {
   %c2 = arith.constant 2 : index


### PR DESCRIPTION
-- This commit creates a pass to linearize memrefs.
-- The pass `iree-linearize-memrefs` will be iteratively worked upon to make it an inter-procedural pass.
-- Currently it supports limited operations.

Signed-off-by: Abhishek Varma <avarma094@gmail.com>