### PR TITLE
[DispatchFormation] Fix CollapseDimensions for dynamic dimensions (and other things)

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ReshapeFusion.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ReshapeFusion.cpp
@@ -654,12 +654,6 @@ collapseOpIterationDims(AttentionOp op,
       }))
     return failure();
 
-  FailureOr<SmallVector<int64_t>> staticLoops = op.getStaticLoopRanges();
-  if (failed(staticLoops) ||
-      llvm::any_of(staticLoops.value(), ShapedType::isDynamic)) {
-    return failure();
-  }
-
   CollapsingInfo collapsingInfo;
   if (failed(
           collapsingInfo.initialize(op.getNumLoops(), foldedIterationDims))) {


### PR DESCRIPTION
- Fixes CollapseDimensions to work properly on dynamic dimensions
- Fixes CollapseDimensions thinking that the first input map in a linalg.generic represents the whole iteration space (why :( )
- Fixes CollapseDimensions to not assume that a loop for a producer is not collapsable if the consumer doesn't contain it. This always happens for reduction dimensions.

Depends on:

- https://github.com/llvm/llvm-project/pull/118202
- https://github.com/llvm/llvm-project/pull/118203
- https://github.com/llvm/llvm-project/pull/118208