### PR TITLE
[Codegen][NFC] Remove duplicate c++ constants.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
@@ -20,7 +20,6 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp.inc"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/LoweringConfigEnums.cpp.inc"
 
-static const char kConfigAttrName[] = "lowering_config";
 static const char kTranslationInfoAttrName[] = "translation_info";
 static const char kCompilationInfoAttrName[] = "compilation_info";
 


### PR DESCRIPTION
The constant is defined in [IREECodegenAttrs.h](https://github.com/iree-org/iree/blob/f2abfa8b5bdf17ad363cad0af198278c2e700113/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h#L41). The revision removes the one in the `.cpp` file.