### PR TITLE
Avoid compound literal struct init for better C/C++ compat.

### DIFF
--- a/runtime/src/iree/base/alignment.h
+++ b/runtime/src/iree/base/alignment.h
@@ -238,19 +238,19 @@ static inline iree_page_range_t iree_page_range_union(
     const iree_page_range_t a, const iree_page_range_t b) {
   iree_host_size_t start = iree_min(a.offset, b.offset);
   iree_host_size_t end = iree_max(a.offset + a.length, b.offset + b.length);
-  return (iree_page_range_t){
-      /*.offset=*/start,
-      /*.length=*/end - start,
-  };
+  iree_page_range_t page_range;
+  page_range.offset = start;
+  page_range.length = end - start;
+  return page_range;
 }
 
 // Aligns a byte range to page boundaries defined by |page_alignment|.
 static inline iree_page_range_t iree_align_byte_range_to_pages(
     const iree_byte_range_t byte_range, iree_host_size_t page_alignment) {
-  return (iree_page_range_t){
-      /*.offset=*/iree_host_align(byte_range.offset, page_alignment),
-      /*.length=*/iree_host_align(byte_range.length, page_alignment),
-  };
+  iree_page_range_t page_range;
+  page_range.offset = iree_host_align(byte_range.offset, page_alignment);
+  page_range.length = iree_host_align(byte_range.length, page_alignment);
+  return page_range;
 }
 
 // Computes a page-aligned range base and total length from a range.

--- a/runtime/src/iree/base/alignment.h
+++ b/runtime/src/iree/base/alignment.h
@@ -238,7 +238,7 @@ static inline iree_page_range_t iree_page_range_union(
     const iree_page_range_t a, const iree_page_range_t b) {
   iree_host_size_t start = iree_min(a.offset, b.offset);
   iree_host_size_t end = iree_max(a.offset + a.length, b.offset + b.length);
-  iree_page_range_t page_range;
+  iree_page_range_t page_range = {0};
   page_range.offset = start;
   page_range.length = end - start;
   return page_range;
@@ -247,7 +247,7 @@ static inline iree_page_range_t iree_page_range_union(
 // Aligns a byte range to page boundaries defined by |page_alignment|.
 static inline iree_page_range_t iree_align_byte_range_to_pages(
     const iree_byte_range_t byte_range, iree_host_size_t page_alignment) {
-  iree_page_range_t page_range;
+  iree_page_range_t page_range = {0};
   page_range.offset = iree_host_align(byte_range.offset, page_alignment);
   page_range.length = iree_host_align(byte_range.length, page_alignment);
   return page_range;

--- a/runtime/src/iree/hal/command_buffer.h
+++ b/runtime/src/iree/hal/command_buffer.h
@@ -115,25 +115,25 @@ typedef struct iree_hal_buffer_ref_t {
 static inline iree_hal_buffer_ref_t iree_hal_make_buffer_ref(
     iree_hal_buffer_t* buffer, iree_device_size_t offset,
     iree_device_size_t length) {
-  iree_hal_buffer_ref_t hal_buffer_ref;
-  hal_buffer_ref.reserved = 0;
-  hal_buffer_ref.buffer_slot = 0;
-  hal_buffer_ref.buffer = buffer;
-  hal_buffer_ref.offset = offset;
-  hal_buffer_ref.length = length;
-  return hal_buffer_ref;
+  iree_hal_buffer_ref_t buffer_ref = {0};
+  buffer_ref.reserved = 0;
+  buffer_ref.buffer_slot = 0;
+  buffer_ref.buffer = buffer;
+  buffer_ref.offset = offset;
+  buffer_ref.length = length;
+  return buffer_ref;
 }
 
 static inline iree_hal_buffer_ref_t iree_hal_make_indirect_buffer_ref(
     uint32_t buffer_slot, iree_device_size_t offset,
     iree_device_size_t length) {
-  iree_hal_buffer_ref_t hal_buffer_ref;
-  hal_buffer_ref.reserved = 0;
-  hal_buffer_ref.buffer_slot = 0;
-  hal_buffer_ref.buffer = NULL;
-  hal_buffer_ref.offset = offset;
-  hal_buffer_ref.length = length;
-  return hal_buffer_ref;
+  iree_hal_buffer_ref_t buffer_ref = {0};
+  buffer_ref.reserved = 0;
+  buffer_ref.buffer_slot = 0;
+  buffer_ref.buffer = NULL;
+  buffer_ref.offset = offset;
+  buffer_ref.length = length;
+  return buffer_ref;
 }
 
 // A list of buffer references.

--- a/runtime/src/iree/hal/command_buffer.h
+++ b/runtime/src/iree/hal/command_buffer.h
@@ -115,13 +115,25 @@ typedef struct iree_hal_buffer_ref_t {
 static inline iree_hal_buffer_ref_t iree_hal_make_buffer_ref(
     iree_hal_buffer_t* buffer, iree_device_size_t offset,
     iree_device_size_t length) {
-  return (iree_hal_buffer_ref_t){0, 0, buffer, offset, length};
+  iree_hal_buffer_ref_t hal_buffer_ref;
+  hal_buffer_ref.reserved = 0;
+  hal_buffer_ref.buffer_slot = 0;
+  hal_buffer_ref.buffer = buffer;
+  hal_buffer_ref.offset = offset;
+  hal_buffer_ref.length = length;
+  return hal_buffer_ref;
 }
 
 static inline iree_hal_buffer_ref_t iree_hal_make_indirect_buffer_ref(
     uint32_t buffer_slot, iree_device_size_t offset,
     iree_device_size_t length) {
-  return (iree_hal_buffer_ref_t){0, buffer_slot, NULL, offset, length};
+  iree_hal_buffer_ref_t hal_buffer_ref;
+  hal_buffer_ref.reserved = 0;
+  hal_buffer_ref.buffer_slot = 0;
+  hal_buffer_ref.buffer = NULL;
+  hal_buffer_ref.offset = offset;
+  hal_buffer_ref.length = length;
+  return hal_buffer_ref;
 }
 
 // A list of buffer references.

--- a/runtime/src/iree/hal/command_buffer.h
+++ b/runtime/src/iree/hal/command_buffer.h
@@ -129,7 +129,7 @@ static inline iree_hal_buffer_ref_t iree_hal_make_indirect_buffer_ref(
     iree_device_size_t length) {
   iree_hal_buffer_ref_t buffer_ref = {0};
   buffer_ref.reserved = 0;
-  buffer_ref.buffer_slot = 0;
+  buffer_ref.buffer_slot = buffer_slot;
   buffer_ref.buffer = NULL;
   buffer_ref.offset = offset;
   buffer_ref.length = length;


### PR DESCRIPTION
Progress on this downstream build issue: https://github.com/nod-ai/shark-ai/issues/534.

I haven't figured out specifically why the downstream build hits errors here while upstream is fine, but these changes aren't that intrusive.