### PR TITLE
Enable `hip` tests for the Sharktank CI

### DIFF
--- a/.github/workflows/pkgci_test_sharktank.yml
+++ b/.github/workflows/pkgci_test_sharktank.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: iree-org/iree-test-suites
-          ref: b31d953828a385c07ffc8c1489fc0ed81c21b2a6
+          ref: c644a9dfc3e5e1a9d071d5e786b79cf612e9b1d3
           path: iree-test-suites
           lfs: true
       - name: Install Sharktank models test suite requirements

--- a/.github/workflows/pkgci_test_sharktank.yml
+++ b/.github/workflows/pkgci_test_sharktank.yml
@@ -27,7 +27,7 @@ jobs:
         include:
           # CPU
           - name: cpu_llvm_task
-            runs-on: ubuntu-20.04
+            runs-on: nodai-amdgpu-w7900-x86-64
 
     env:
       VENV_DIR: ${{ github.workspace }}/venv
@@ -64,9 +64,8 @@ jobs:
       - name: Run Sharktank models test suite
         run: |
           source ${VENV_DIR}/bin/activate
-          pytest iree-test-suites/sharktank_models/ \
+          HIP_TARGET=gfx1100 pytest iree-test-suites/sharktank_models/ \
               -rA \
-              -m "target_cpu" \
               --log-cli-level=info \
               --override-ini=xfail_strict=false \
               --timeout=120 \

--- a/.github/workflows/pkgci_test_sharktank.yml
+++ b/.github/workflows/pkgci_test_sharktank.yml
@@ -25,8 +25,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # CPU
-          - name: cpu_llvm_task
+          - name: cpu_task
+            target: target_cpu
+            gpu: none
+            runs-on: nodai-amdgpu-w7900-x86-64
+
+          - name: hip_task
+            target: target_hip
+            gpu: gfx1100
             runs-on: nodai-amdgpu-w7900-x86-64
 
     env:
@@ -64,9 +70,10 @@ jobs:
       - name: Run Sharktank models test suite
         run: |
           source ${VENV_DIR}/bin/activate
-          HIP_TARGET=gfx1100 pytest iree-test-suites/sharktank_models/ \
+          HIP_TARGET=${{ matrix.gpu }} pytest iree-test-suites/sharktank_models/ \
               -rA \
               --log-cli-level=info \
               --override-ini=xfail_strict=false \
+              -m ${{ matrix.target }}
               --timeout=120 \
               --durations=0

--- a/.github/workflows/pkgci_test_sharktank.yml
+++ b/.github/workflows/pkgci_test_sharktank.yml
@@ -74,6 +74,6 @@ jobs:
               -rA \
               --log-cli-level=info \
               --override-ini=xfail_strict=false \
-              -m ${{ matrix.target }}
+              -m ${{ matrix.target }} \
               --timeout=120 \
               --durations=0

--- a/.github/workflows/pkgci_test_sharktank.yml
+++ b/.github/workflows/pkgci_test_sharktank.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: iree-org/iree-test-suites
-          ref: a0c84d59c4332463dd46a3c4877d8e0ab2e0a80d
+          ref: b31d953828a385c07ffc8c1489fc0ed81c21b2a6
           path: iree-test-suites
           lfs: true
       - name: Install Sharktank models test suite requirements

--- a/.github/workflows/pkgci_test_sharktank.yml
+++ b/.github/workflows/pkgci_test_sharktank.yml
@@ -28,7 +28,7 @@ jobs:
           - name: cpu_task
             target: target_cpu
             gpu: none
-            runs-on: nodai-amdgpu-w7900-x86-64
+            runs-on: ubuntu-20.04
 
           - name: hip_task
             target: target_hip


### PR DESCRIPTION
Switching this to run on a w7900 machine we can run presubmits on hip.