### PR TITLE
[Dispatch] Fold `collapse(expand)` unit dims

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
@@ -23,7 +23,6 @@
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
-#include "mlir/IR/Verifier.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
@@ -115,11 +114,11 @@ struct DropUnitDimsFromCollapseOfExpand
         };
 
     auto dropOutputOfr = [&toDrop](const SmallVector<OpFoldResult> &sizes) {
-      return llvm::to_vector(llvm::map_range(
+      return llvm::map_to_vector(
           llvm::make_filter_range(
               llvm::enumerate(sizes),
               [&toDrop](auto pair) { return !toDrop.contains(pair.index()); }),
-          [](auto pair) -> OpFoldResult { return pair.value(); }));
+          [](auto pair) -> OpFoldResult { return pair.value(); });
     };
 
     auto isIdentityReassociation = [](ArrayRef<ReassociationIndices> reassoc) {

--- a/compiler/src/iree/compiler/DispatchCreation/test/fold_unit_dims.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/fold_unit_dims.mlir
@@ -115,6 +115,7 @@ util.func @collapse_of_expand_0(%arg0: tensor<?x128xf16>, %arg1: index) -> tenso
   %collapsed = tensor.collapse_shape %expanded [[0], [1, 2, 3], [4]] : tensor<4x?x1x1x128xf16> into tensor<4x?x128xf16>
   util.return %collapsed : tensor<4x?x128xf16>
 }
+
 // CHECK-LABEL: util.func public @collapse_of_expand_0
 //  CHECK-SAME:   %[[ARG0:.+]]: tensor<?x128xf16>, %[[ARG1:.+]]: index
 //       CHECK:   %[[EXPAND:.+]] = tensor.expand_shape %[[ARG0]]
@@ -128,6 +129,7 @@ util.func @collapse_of_expand_1(%arg0: tensor<?x128xf16>, %arg1: index) -> tenso
   %collapsed = tensor.collapse_shape %expanded [[0], [1, 2, 3], [4]] : tensor<4x?x1x2x64xf16> into tensor<4x?x64xf16>
   util.return %collapsed : tensor<4x?x64xf16>
 }
+
 // CHECK-LABEL: util.func public @collapse_of_expand_1
 //  CHECK-SAME:   %[[ARG0:.+]]: tensor<?x128xf16>, %[[ARG1:.+]]: index
 //       CHECK:   %[[EXPAND:.+]] = tensor.expand_shape %[[ARG0]]
@@ -175,3 +177,17 @@ util.func @collapse_of_expand_4(%arg0: tensor<1x1xf16>, %arg1: index, %arg2: ind
 //       CHECK:   %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG0]]
 //  CHECK-SAME:     tensor<1x1xf16> into tensor<1xf16>
 //       CHECK:   util.return %[[COLLAPSED]] : tensor<1xf16>
+
+// -----
+
+util.func @collapse_of_expand_5(%arg0: tensor<1x?x4x32xf16>, %arg1: index) -> tensor<?x4x32xf16> {
+  %expanded = tensor.expand_shape %arg0 [[0], [1], [2], [3, 4]] output_shape [1, %arg1, 4, 1, 32] : tensor<1x?x4x32xf16> into tensor<1x?x4x1x32xf16>
+  %collapsed = tensor.collapse_shape %expanded [[0, 1], [2, 3], [4]] : tensor<1x?x4x1x32xf16> into tensor<?x4x32xf16>
+  util.return %collapsed : tensor<?x4x32xf16>
+}
+
+// CHECK-LABEL: util.func public @collapse_of_expand_5
+//  CHECK-SAME:   %[[ARG0:.+]]: tensor<1x?x4x32xf16>
+//       CHECK:   %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG0]]
+//  CHECK-SAME:     tensor<1x?x4x32xf16> into tensor<?x4x32xf16>
+//       CHECK:   util.return %[[COLLAPSED]] : tensor<?x4x32xf16>


### PR DESCRIPTION
Fold unit dimensions for the pattern `collapse(expand)` by removing any unnecessary unit dims that are expanded out and subsequently collapsed again. This prevents the collapse/expand ops, which contain unneeded unit dims, from being propagated and introducing unit dims back to linalg ops.


-----

Doesn't quite resolve https://github.com/iree-org/iree/issues/19263 because there are `flow.tensor.bitcast` ops that are preventing the unit dims from being completely folded:

```mlir
%expanded_24 = tensor.expand_shape %214 [[0, 1, 2], [3]] output_shape [4, %21, 1, 128] : tensor<?x128xf16> into tensor<4x?x1x128xf16>
%323 = flow.tensor.bitcast %expanded_24 : tensor<4x?x1x128xf16>{%21} -> tensor<4x?x1x64xcomplex<f16>>{%21}
%collapsed_40 = tensor.collapse_shape %323 [[0], [1, 2], [3]] : tensor<4x?x1x64xcomplex<f16>> into tensor<4x?x64xcomplex<f16>>
```