### PR TITLE
[Codegen][Tuner] Clarify tuning spec linking order. NFC.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.h
@@ -56,7 +56,8 @@ void addEncodingToNopPasses(FunctionLikeNest &passManager);
 /// Links nested transform dialect tuning specs named sequences into a single
 /// entry point. Returns the new named sequence op (inserted into the `module`)
 /// that includes the nested tuning specs, or a null op when no nested named
-/// sequences were found.
+/// sequences were found. The order of inclusion is the same as the in which
+/// these nested tuning specs appear in the IR.
 FailureOr<transform::NamedSequenceOp> linkTuningSpecs(ModuleOp module);
 
 //------------------------------------------------------------------------------

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.h
@@ -56,8 +56,8 @@ void addEncodingToNopPasses(FunctionLikeNest &passManager);
 /// Links nested transform dialect tuning specs named sequences into a single
 /// entry point. Returns the new named sequence op (inserted into the `module`)
 /// that includes the nested tuning specs, or a null op when no nested named
-/// sequences were found. The order of inclusion is the same as the in which
-/// these nested tuning specs appear in the IR.
+/// sequences were found. The order of inclusion is the same as the order in
+/// which these nested tuning specs appear in the IR.
 FailureOr<transform::NamedSequenceOp> linkTuningSpecs(ModuleOp module);
 
 //------------------------------------------------------------------------------

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -412,7 +412,7 @@ def LinkTuningSpecsPass : Pass<"iree-codegen-link-tuning-specs", "ModuleOp"> {
   let description = [{
     Given a module with multiple nested tuning specs, introduce a new named sequence
     that includes all the other tuning spec entry points. The order of inclusion is the same
-    as the in which these nested tuning specs appear in the IR.
+    as the order in which these nested tuning specs appear in the IR.
 
     A tuning spec entry point is a `transform.named_sequence` op annotated with the
     `iree_codegen.tuning_spec` unit attribute. We require it to perform in-place op


### PR DESCRIPTION
This clarification was suggested in https://github.com/iree-org/iree/pull/19337#discussion_r1868494935.