### PR TITLE
[docs] Fix permalink css styling on Firefox.

### DIFF
--- a/docs/website/docs/assets/stylesheets/iree.css
+++ b/docs/website/docs/assets/stylesheets/iree.css
@@ -16,6 +16,7 @@
   position: relative;
   top: 5px;
   left: 0;
+  display: inline;
 }
 
 pre.highlight code {


### PR DESCRIPTION
This has been bothering me. The display has always looked correct in Chrome, but Firefox splits the icon (technically the text `icon` using the `Material Icons` font-family, not an actual image) over two lines:

Before:
![image](https://github.com/user-attachments/assets/3d32c898-e056-4881-8d77-c930e3e1404b)


After: 
![image](https://github.com/user-attachments/assets/561df6e4-59fe-4ec0-8e3c-ad0289da42c7)

I found two possible fixes: set `letter-spacing: initial;` or `display: inline;`. I don't have a preference.