### PR TITLE
[Stream] Fix unused tied transients inside concurrent regions

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
@@ -244,6 +244,12 @@ computeExecutionRegionLivenessIntervals(IREE::Stream::AsyncExecuteOp executeOp,
         for (auto value : op->getResults()) {
           if (!llvm::isa<IREE::Stream::ResourceType>(value.getType()))
             continue;
+          if (auto tiedOp = dyn_cast<Util::TiedOpInterface>(op)) {
+            // Skip tied results as their liveness is determined by the tied
+            // operand.
+            if (tiedOp.getTiedResultOperand(value))
+              continue;
+          }
           if (!value.use_empty())
             continue;
           LivenessInterval interval;


### PR DESCRIPTION
Unused transient values inside concurrent regions currently always get their own allocation as otherwise there is nothing allocated for the (unused) written values. This works for unused write only values because such values include an implicit allocation. For tied operands, however, the result already has a backing allocation that may potentially be used elsewhere by aliasing outside the `stream.async.concurrent`.