### PR TITLE
[docs] Refresh package install instructions across the website.

### DIFF
--- a/build_tools/pkgci/setup_venv.py
+++ b/build_tools/pkgci/setup_venv.py
@@ -148,19 +148,19 @@ def get_latest_workflow_run_id_for_main() -> int:
     workflow_run_output = subprocess.check_output(workflow_run_args)
     workflow_run_json_output = json.loads(workflow_run_output)
     latest_run = workflow_run_json_output["workflow_runs"][0]
-    print(f"Found workflow run: {latest_run['html_url']}")
+    print(f"\nFound workflow run: {latest_run['html_url']}")
     return latest_run["id"]
 
 
 def get_latest_workflow_run_id_for_ref(ref: str) -> int:
-    print(f"Normalizing ref: {ref}")
+    print(f"Finding workflow run for ref: {ref}")
     normalized_ref = (
         subprocess.check_output(["git", "rev-parse", ref], cwd=REPO_ROOT)
         .decode()
         .strip()
     )
 
-    print(f"Using normalized ref: {normalized_ref}")
+    print(f"  Using normalized ref: {normalized_ref}")
     workflow_run_args = [
         "gh",
         "api",
@@ -170,14 +170,14 @@ def get_latest_workflow_run_id_for_ref(ref: str) -> int:
         "X-GitHub-Api-Version: 2022-11-28",
         f"{BASE_API_PATH}/actions/workflows/pkgci.yml/runs?head_sha={normalized_ref}",
     ]
-    print(f"Running command to list workflow runs:\n  {' '.join(workflow_run_args)}")
+    print(f"\nRunning command to list workflow runs:\n  {' '.join(workflow_run_args)}")
     workflow_run_output = subprocess.check_output(workflow_run_args)
     workflow_run_json_output = json.loads(workflow_run_output)
     if workflow_run_json_output["total_count"] == 0:
         raise RuntimeError("Workflow did not run at this commit")
 
     latest_run = workflow_run_json_output["workflow_runs"][-1]
-    print(f"Found workflow run: {latest_run['html_url']}")
+    print(f"\nFound workflow run: {latest_run['html_url']}")
     return latest_run["id"]
 
 
@@ -203,7 +203,7 @@ def list_gh_artifacts(run_id: str) -> Dict[str, str]:
         rec["name"]: f"{BASE_API_PATH}/actions/artifacts/{rec['id']}/zip"
         for rec in data["artifacts"]
     }
-    print("Found artifacts:")
+    print("\nFound artifacts:")
     for k, v in artifacts.items():
         print(f"  {k}: {v}")
     return artifacts
@@ -309,7 +309,7 @@ def main(args):
         wheels.append(
             find_wheel_for_variants(args, artifact_prefix, package_stem, variant)
         )
-    print("Installing wheels:", wheels)
+    print("\nInstalling wheels:", wheels)
 
     # Set up venv.
     venv_path = args.venv_dir
@@ -340,6 +340,9 @@ def main(args):
         ]
         print(f"Running command: {' '.join([str(c) for c in cmd])}")
         subprocess.check_call(cmd)
+
+    print(f"\nvenv setup complete at '{venv_path}'. Activate it with")
+    print(f"  source {venv_path}/bin/activate")
 
     return 0
 

--- a/docs/website/docs/building-from-source/getting-started.md
+++ b/docs/website/docs/building-from-source/getting-started.md
@@ -431,7 +431,7 @@ Extend your `PYTHONPATH` with IREE's `bindings/python` paths and try importing:
     python -c "import iree.runtime; help(iree.runtime)"
     ```
 
-Using IREE's ML framework importers requires a few extra steps:
+Using IREE's TensorFlow/TFLite importers requires a few extra steps:
 
 ``` shell
 # Install test requirements

--- a/docs/website/docs/developers/design-docs/cuda-hal-driver.md
+++ b/docs/website/docs/developers/design-docs/cuda-hal-driver.md
@@ -52,7 +52,7 @@ See [synchronization](#synchronization) section regarding the details.
 
 #### Async allocation
 
-The CUDA HAL drivers supports async allocation
+The CUDA HAL driver supports async allocation
 (`iree_hal_device_queue_alloca()` and `iree_hal_device_queue_dealloca()`)
 via [CUDA stream ordered memory allocation][cuda-stream-ordered-alloc].
 

--- a/docs/website/docs/developers/design-docs/hip-hal-driver.md
+++ b/docs/website/docs/developers/design-docs/hip-hal-driver.md
@@ -52,7 +52,7 @@ See synchronization section regarding the details.
 
 #### Async allocation
 
-The HIP HAL drivers supports async allocation
+The HIP HAL driver supports async allocation
 (`iree_hal_device_queue_alloca()` and `iree_hal_device_queue_dealloca()`)
 via HIP stream ordered memory allocation.
 

--- a/docs/website/docs/guides/deployment-configurations/cpu.md
+++ b/docs/website/docs/guides/deployment-configurations/cpu.md
@@ -39,12 +39,12 @@ At runtime, CPU executables can be loaded using one of IREE's CPU HAL drivers:
 
 ### Get the IREE compiler
 
-#### :octicons-package-16: Download the compiler from a release
+#### :octicons-download-16: Download the compiler from a release
 
-Python packages are regularly published to
-[PyPI](https://pypi.org/user/google-iree-pypi-deploy/). See the
+Python packages are distributed through multiple channels. See the
 [Python Bindings](../../reference/bindings/python.md) page for more details.
-The core `iree-base-compiler` package includes the LLVM-based CPU compiler:
+The core [`iree-base-compiler`](https://pypi.org/project/iree-base-compiler/)
+package includes the LLVM-based CPU compiler:
 
 --8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-compiler-from-release.md"
 
@@ -77,12 +77,12 @@ drivers:
 --8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-driver-list.md"
 ```
 
-#### :octicons-package-16: Download the runtime from a release
+#### :octicons-download-16: Download the runtime from a release
 
-Python packages are regularly published to
-[PyPI](https://pypi.org/user/google-iree-pypi-deploy/). See the
+Python packages are distributed through multiple channels. See the
 [Python Bindings](../../reference/bindings/python.md) page for more details.
-The core `iree-base-runtime` package includes the local CPU HAL drivers:
+The core [`iree-base-runtime`](https://pypi.org/project/iree-base-runtime/)
+package includes the local CPU HAL drivers:
 
 --8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-runtime-from-release.md"
 

--- a/docs/website/docs/guides/deployment-configurations/gpu-cuda.md
+++ b/docs/website/docs/guides/deployment-configurations/gpu-cuda.md
@@ -26,12 +26,12 @@ If `nvidia-smi` does not exist, you will need to
 
 ### Get the IREE compiler
 
-#### :octicons-package-16: Download the compiler from a release
+#### :octicons-download-16: Download the compiler from a release
 
-Python packages are regularly published to
-[PyPI](https://pypi.org/user/google-iree-pypi-deploy/). See the
+Python packages are distributed through multiple channels. See the
 [Python Bindings](../../reference/bindings/python.md) page for more details.
-The core `iree-base-compiler` package includes the CUDA compiler:
+The core [`iree-base-compiler`](https://pypi.org/project/iree-base-compiler/)
+package includes the CUDA compiler:
 
 --8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-compiler-from-release.md"
 
@@ -64,12 +64,12 @@ $ iree-run-module --list_devices
   local-task://
 ```
 
-#### :octicons-package-16: Download the runtime from a release
+#### :octicons-download-16: Download the runtime from a release
 
-Python packages are regularly published to
-[PyPI](https://pypi.org/user/google-iree-pypi-deploy/). See the
+Python packages are distributed through multiple channels. See the
 [Python Bindings](../../reference/bindings/python.md) page for more details.
-The core `iree-base-runtime` package includes the CUDA HAL driver:
+The core [`iree-base-runtime`](https://pypi.org/project/iree-base-runtime/)
+package includes the CUDA HAL driver:
 
 --8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-runtime-from-release.md"
 

--- a/docs/website/docs/guides/deployment-configurations/gpu-rocm.md
+++ b/docs/website/docs/guides/deployment-configurations/gpu-rocm.md
@@ -28,12 +28,12 @@ or [Linux](https://rocm.docs.amd.com/en/latest/deploy/linux/quick_start.html).
 
 ### Get the IREE compiler
 
-#### :octicons-package-16: Download the compiler from a release
+#### :octicons-download-16: Download the compiler from a release
 
-Python packages are regularly published to
-[PyPI](https://pypi.org/user/google-iree-pypi-deploy/). See the
+Python packages are distributed through multiple channels. See the
 [Python Bindings](../../reference/bindings/python.md) page for more details.
-The core `iree-base-compiler` package includes the ROCm compiler:
+The core [`iree-base-compiler`](https://pypi.org/project/iree-base-compiler/)
+package includes the ROCm compiler:
 
 --8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-compiler-from-release.md"
 
@@ -66,12 +66,12 @@ $ iree-run-module --list_devices
   local-task://
 ```
 
-#### :octicons-package-16: Download the runtime from a release
+#### :octicons-download-16: Download the runtime from a release
 
-Python packages are regularly published to
-[PyPI](https://pypi.org/user/google-iree-pypi-deploy/). See the
+Python packages are distributed through multiple channels. See the
 [Python Bindings](../../reference/bindings/python.md) page for more details.
-The core `iree-base-runtime` package includes the HIP HAL driver:
+The core [`iree-base-runtime`](https://pypi.org/project/iree-base-runtime/)
+package includes the HIP HAL driver:
 
 --8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-runtime-from-release.md"
 

--- a/docs/website/docs/guides/deployment-configurations/gpu-vulkan.md
+++ b/docs/website/docs/guides/deployment-configurations/gpu-vulkan.md
@@ -76,12 +76,12 @@ Vulkan expects the program running on GPU to be expressed by the
 [SPIR-V](https://www.khronos.org/registry/spir-v/) binary exchange format, which
 the model must be compiled into.
 
-#### :octicons-package-16: Download the compiler from a release
+#### :octicons-download-16: Download the compiler from a release
 
-Python packages are regularly published to
-[PyPI](https://pypi.org/user/google-iree-pypi-deploy/). See the
+Python packages are distributed through multiple channels. See the
 [Python Bindings](../../reference/bindings/python.md) page for more details.
-The core `iree-base-compiler` package includes the SPIR-V compiler:
+The core [`iree-base-compiler`](https://pypi.org/project/iree-base-compiler/)
+package includes the SPIR-V compiler:
 
 --8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-compiler-from-release.md"
 
@@ -120,12 +120,12 @@ $ iree-run-module --list_devices
   vulkan://00000000-1111-2222-3333-444444444444
 ```
 
-#### :octicons-package-16: Download the runtime from a release
+#### :octicons-download-16: Download the runtime from a release
 
-Python packages are regularly published to
-[PyPI](https://pypi.org/user/google-iree-pypi-deploy/). See the
+Python packages are distributed through multiple channels. See the
 [Python Bindings](../../reference/bindings/python.md) page for more details.
-The core `iree-base-runtime` package includes the Vulkan HAL drivers:
+The core [`iree-base-runtime`](https://pypi.org/project/iree-base-runtime/)
+package includes the Vulkan HAL drivers:
 
 --8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-runtime-from-release.md"
 

--- a/docs/website/docs/guides/deployment-configurations/gpu-vulkan.md
+++ b/docs/website/docs/guides/deployment-configurations/gpu-vulkan.md
@@ -125,7 +125,7 @@ $ iree-run-module --list_devices
 Python packages are distributed through multiple channels. See the
 [Python Bindings](../../reference/bindings/python.md) page for more details.
 The core [`iree-base-runtime`](https://pypi.org/project/iree-base-runtime/)
-package includes the Vulkan HAL drivers:
+package includes the Vulkan HAL driver:
 
 --8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-runtime-from-release.md"
 

--- a/docs/website/docs/guides/deployment-configurations/snippets/_iree-compiler-from-release.md
+++ b/docs/website/docs/guides/deployment-configurations/snippets/_iree-compiler-from-release.md
@@ -1,13 +1,12 @@
-=== "Stable releases"
+=== ":octicons-package-16: Stable releases"
 
-    Stable release packages are
-    [published to PyPI](https://pypi.org/user/google-iree-pypi-deploy/).
+    Stable release packages are [published to PyPI](https://pypi.org/).
 
     ``` shell
     python -m pip install iree-base-compiler
     ```
 
-=== ":material-alert: Nightly releases"
+=== ":octicons-beaker-16: Nightly releases"
 
     Nightly pre-releases are published on
     [GitHub releases](https://github.com/iree-org/iree/releases).
@@ -17,6 +16,8 @@
       --find-links https://iree.dev/pip-release-links.html \
       --upgrade --pre iree-base-compiler
     ```
+
+--8<-- "docs/website/docs/snippets/_iree-dev-packages.md"
 
 !!! tip
     `iree-compile` and other tools are installed to your python module

--- a/docs/website/docs/guides/deployment-configurations/snippets/_iree-runtime-from-release.md
+++ b/docs/website/docs/guides/deployment-configurations/snippets/_iree-runtime-from-release.md
@@ -1,13 +1,12 @@
-=== "Stable releases"
+=== ":octicons-package-16: Stable releases"
 
-    Stable release packages are
-    [published to PyPI](https://pypi.org/user/google-iree-pypi-deploy/).
+    Stable release packages are [published to PyPI](https://pypi.org/).
 
     ``` shell
     python -m pip install iree-base-runtime
     ```
 
-=== ":material-alert: Nightly releases"
+=== ":octicons-beaker-16: Nightly releases"
 
     Nightly pre-releases are published on
     [GitHub releases](https://github.com/iree-org/iree/releases).
@@ -17,3 +16,5 @@
       --find-links https://iree.dev/pip-release-links.html \
       --upgrade --pre iree-base-runtime
     ```
+
+--8<-- "docs/website/docs/snippets/_iree-dev-packages.md"

--- a/docs/website/docs/guides/index.md
+++ b/docs/website/docs/guides/index.md
@@ -8,10 +8,11 @@
 
 Guides for specific frameworks:
 
+* [:simple-python: JAX](./ml-frameworks/jax.md)
+* [:simple-onnx: ONNX](./ml-frameworks/onnx.md)
+* [:simple-pytorch: PyTorch](./ml-frameworks/pytorch.md)
 * [:simple-tensorflow: TensorFlow](./ml-frameworks/tensorflow.md) and
   [:simple-tensorflow: TensorFlow Lite](./ml-frameworks/tflite.md)
-* [:simple-python: JAX](./ml-frameworks/jax.md)
-* [:simple-pytorch: PyTorch](./ml-frameworks/pytorch.md)
 
 ## Deployment configurations
 

--- a/docs/website/docs/guides/ml-frameworks/onnx.md
+++ b/docs/website/docs/guides/ml-frameworks/onnx.md
@@ -57,10 +57,9 @@ graph LR
     [building from source](../../building-from-source/getting-started.md#python-bindings)
     or from pip:
 
-    === "Stable releases"
+    === ":octicons-package-16: Stable releases"
 
-        Stable release packages are
-        [published to PyPI](https://pypi.org/user/google-iree-pypi-deploy/).
+        Stable release packages are [published to PyPI](https://pypi.org/).
 
         ``` shell
         python -m pip install \
@@ -68,7 +67,7 @@ graph LR
           iree-base-runtime
         ```
 
-    === ":material-alert: Nightly releases"
+    === ":octicons-beaker-16: Nightly releases"
 
         Nightly pre-releases are published on
         [GitHub releases](https://github.com/iree-org/iree/releases).

--- a/docs/website/docs/guides/ml-frameworks/pytorch.md
+++ b/docs/website/docs/guides/ml-frameworks/pytorch.md
@@ -72,6 +72,9 @@ python -m pip install \
   --index-url https://download.pytorch.org/whl/test/cpu torch==2.4.1
 ```
 
+<!-- TODO(scotttodd): mention nightly releases after
+     https://github.com/iree-org/iree/issues/19193 is fixed -->
+
 Install iree-turbine:
 
 ``` shell

--- a/docs/website/docs/guides/ml-frameworks/tensorflow.md
+++ b/docs/website/docs/guides/ml-frameworks/tensorflow.md
@@ -61,8 +61,7 @@ graph LR
 
     === "Stable releases"
 
-        Stable release packages are
-        [published to PyPI](https://pypi.org/user/google-iree-pypi-deploy/).
+        Stable release packages are [published to PyPI](https://pypi.org/).
 
         ``` shell
         python -m pip install \

--- a/docs/website/docs/guides/ml-frameworks/tflite.md
+++ b/docs/website/docs/guides/ml-frameworks/tflite.md
@@ -56,8 +56,7 @@ graph LR
 
     === "Stable releases"
 
-        Stable release packages are
-        [published to PyPI](https://pypi.org/user/google-iree-pypi-deploy/).
+        Stable release packages are [published to PyPI](https://pypi.org/).
 
         ``` shell
         python -m pip install \

--- a/docs/website/docs/reference/bindings/c-api.md
+++ b/docs/website/docs/reference/bindings/c-api.md
@@ -4,7 +4,7 @@ icon: octicons/code-16
 
 # C API bindings
 
-## Overview
+## :octicons-book-16: Overview
 
 The IREE compiler and IREE runtime both have their own C/C++ APIs. This page
 introduces the available APIs and describes how to use them from your

--- a/docs/website/docs/reference/bindings/python.md
+++ b/docs/website/docs/reference/bindings/python.md
@@ -8,25 +8,29 @@ icon: simple/python
 
 # Python bindings
 
-## Overview
+## :octicons-book-16: Overview
 
-IREE offers Python bindings split into several packages, covering different
-components:
+IREE offers several Python packages, including API bindings, utilities, and
+integrations with frameworks:
 
-| PIP package name             | Description                                                                 |
-|------------------------------|-----------------------------------------------------------------------------|
-| `iree-base-compiler` | IREE's generic compiler tools and helpers                                   |
-| `iree-base-runtime`  | IREE's runtime, including CPU and GPU backends                              |
-| `iree-tools-tf`      | Tools for importing from [TensorFlow](https://www.tensorflow.org/)          |
-| `iree-tools-tflite`  | Tools for importing from [TensorFlow Lite](https://www.tensorflow.org/lite) |
-| `iree-jax`           | Tools for importing from [JAX](https://github.com/google/jax)               |
+PIP package name | Description
+-- | --
+[`iree-base-compiler`](https://pypi.org/project/iree-base-compiler/) | IREE's generic compiler tools and helpers
+[`iree-base-runtime`](https://pypi.org/project/iree-base-runtime/) | IREE's runtime, including CPU and GPU backends
+[`iree-tools-tf`](https://pypi.org/project/iree-tools-tf/) | Tools for importing from [TensorFlow](https://www.tensorflow.org/)
+[`iree-tools-tflite`](https://pypi.org/project/iree-tools-tflite/) | Tools for importing from [TensorFlow Lite](https://www.tensorflow.org/lite)
+[`iree-turbine`](https://pypi.org/project/iree-turbine/) | IREE's frontend for [PyTorch](https://pytorch.org/)
 
 Collectively, these packages allow for importing from frontends, compiling
 towards various targets, and executing compiled code on IREE's backends.
 
-???+ Note "Note - `iree-compiler` and `iree-runtime` are deprecated"
-    The Python packages `iree-compiler` and `iree-runtime` have been
-    renamed to `iree-base-compiler` and `iree-base-runtime`
+???+ Info "Note - `iree-compiler` and `iree-runtime` are deprecated"
+    The Python packages
+    [`iree-compiler`](https://pypi.org/project/iree-compiler/) and
+    [`iree-runtime`](https://pypi.org/project/iree-runtime/) have been
+    renamed to
+    [`iree-base-compiler`](https://pypi.org/project/iree-base-compiler/) and
+    [`iree-base-runtime`](https://pypi.org/project/iree-base-runtime/)
     respectively, thus effectively deprecating the old packages.
     This name change only affects the names of the packages but not
     the modules. To make sure the new packages are used, run
@@ -70,12 +74,11 @@ To use IREE's Python bindings, you will first need to install
 
 ## Installing IREE packages
 
-### :octicons-package-16: Prebuilt packages
+### :octicons-package-dependents-24: Prebuilt packages
 
-=== "Stable releases"
+=== ":octicons-package-16: Stable releases"
 
-    Stable release packages are
-    [published to PyPI](https://pypi.org/user/google-iree-pypi-deploy/).
+    Stable release packages are [published to PyPI](https://pypi.org/).
 
     ``` shell
     python -m pip install \
@@ -83,24 +86,24 @@ To use IREE's Python bindings, you will first need to install
       iree-base-runtime
     ```
 
-=== ":material-alert: Nightly pre-releases"
+=== ":octicons-beaker-16: Nightly pre-releases"
 
     Nightly pre-releases are published on
     [GitHub releases](https://github.com/iree-org/iree/releases).
 
-    ``` shell
+    ``` shell hl_lines="2-4"
     python -m pip install \
       --find-links https://iree.dev/pip-release-links.html \
-      --upgrade \
       --pre \
+      --upgrade \
       iree-base-compiler \
       iree-base-runtime
     ```
 
-=== ":octicons-git-branch-24: Development packages"
+=== ":octicons-git-branch-16: Development packages"
 
-    Development packages are produced for every commit, including pull requests,
-    for limited configurations.
+    Development packages are built at every commit and on pull requests, for
+    limited configurations.
 
     On **Linux** with **Python 3.11**, these packages can be installed into
     a [Python `venv`](https://docs.python.org/3/library/venv.html) using the
@@ -108,14 +111,20 @@ To use IREE's Python bindings, you will first need to install
     script:
 
     ``` shell
-    # Latest completed run on the `main` branch.
-    ./build_tools/pkgci/setup_venv.py /tmp/.venv --fetch-latest-main
+    # Install packages from a specific commit ref.
+    python ./build_tools/pkgci/setup_venv.py /tmp/.venv --fetch-git-ref=8230f41d
 
-    # A specific commit ref.
-    ./build_tools/pkgci/setup_venv.py /tmp/.venv --fetch-git-ref=8230f41d
+    # Install packages from the latest completed run on the `main` branch.
+    # python ./build_tools/pkgci/setup_venv.py /tmp/.venv --fetch-latest-main
 
-    # A specific workflow run (such as on a pull request).
-    ./build_tools/pkgci/setup_venv.py /tmp/.venv --fetch-gh-workflow=11977414405
+    # Install packages from a  specific workflow run (such as on a pull request).
+    # python ./build_tools/pkgci/setup_venv.py /tmp/.venv --fetch-gh-workflow=11977414405
+
+    # Activate the venv and see what was installed.
+    source /tmp/.venv/bin/activate
+    pip freeze
+    # iree-base-compiler==3.1.0.dev0+8230f41d53eeb30bf48238d47282a9ca124c3117
+    # iree-base-runtime==3.1.0.dev0+8230f41d53eeb30bf48238d47282a9ca124c3117
     ```
 
 ### :material-hammer-wrench: Building from source

--- a/docs/website/docs/reference/bindings/python.md
+++ b/docs/website/docs/reference/bindings/python.md
@@ -74,7 +74,7 @@ To use IREE's Python bindings, you will first need to install
 
 ## Installing IREE packages
 
-### :octicons-package-dependents-24: Prebuilt packages
+### :octicons-download-16: Prebuilt packages
 
 === ":octicons-package-16: Stable releases"
 

--- a/docs/website/docs/reference/bindings/python.md
+++ b/docs/website/docs/reference/bindings/python.md
@@ -97,6 +97,27 @@ To use IREE's Python bindings, you will first need to install
       iree-base-runtime
     ```
 
+=== ":octicons-git-branch-24: Development packages"
+
+    Development packages are produced for every commit, including pull requests,
+    for limited configurations.
+
+    On **Linux** with **Python 3.11**, these packages can be installed into
+    a [Python `venv`](https://docs.python.org/3/library/venv.html) using the
+    [`build_tools/pkgci/setup_venv.py`](https://github.com/iree-org/iree/blob/main/build_tools/pkgci/setup_venv.py)
+    script:
+
+    ``` shell
+    # Latest completed run on the `main` branch.
+    ./build_tools/pkgci/setup_venv.py /tmp/.venv --fetch-latest-main
+
+    # A specific commit ref.
+    ./build_tools/pkgci/setup_venv.py /tmp/.venv --fetch-git-ref=8230f41d
+
+    # A specific workflow run (such as on a pull request).
+    ./build_tools/pkgci/setup_venv.py /tmp/.venv --fetch-gh-workflow=11977414405
+    ```
+
 ### :material-hammer-wrench: Building from source
 
 See [Building Python bindings](../../building-from-source/getting-started.md#python-bindings)

--- a/docs/website/docs/reference/bindings/python.md
+++ b/docs/website/docs/reference/bindings/python.md
@@ -100,32 +100,7 @@ To use IREE's Python bindings, you will first need to install
       iree-base-runtime
     ```
 
-=== ":octicons-git-branch-16: Development packages"
-
-    Development packages are built at every commit and on pull requests, for
-    limited configurations.
-
-    On **Linux** with **Python 3.11**, these packages can be installed into
-    a [Python `venv`](https://docs.python.org/3/library/venv.html) using the
-    [`build_tools/pkgci/setup_venv.py`](https://github.com/iree-org/iree/blob/main/build_tools/pkgci/setup_venv.py)
-    script:
-
-    ``` shell
-    # Install packages from a specific commit ref.
-    python ./build_tools/pkgci/setup_venv.py /tmp/.venv --fetch-git-ref=8230f41d
-
-    # Install packages from the latest completed run on the `main` branch.
-    # python ./build_tools/pkgci/setup_venv.py /tmp/.venv --fetch-latest-main
-
-    # Install packages from a  specific workflow run (such as on a pull request).
-    # python ./build_tools/pkgci/setup_venv.py /tmp/.venv --fetch-gh-workflow=11977414405
-
-    # Activate the venv and see what was installed.
-    source /tmp/.venv/bin/activate
-    pip freeze
-    # iree-base-compiler==3.1.0.dev0+8230f41d53eeb30bf48238d47282a9ca124c3117
-    # iree-base-runtime==3.1.0.dev0+8230f41d53eeb30bf48238d47282a9ca124c3117
-    ```
+--8<-- "docs/website/docs/snippets/_iree-dev-packages.md"
 
 ### :material-hammer-wrench: Building from source
 

--- a/docs/website/docs/snippets/_iree-dev-packages.md
+++ b/docs/website/docs/snippets/_iree-dev-packages.md
@@ -1,0 +1,17 @@
+=== ":octicons-git-branch-16: Development packages"
+
+    Development packages are built at every commit and on pull requests, for
+    limited configurations.
+
+    On **Linux** with **Python 3.11**, development packages can be installed
+    into a [Python `venv`](https://docs.python.org/3/library/venv.html) using
+    the
+    [`build_tools/pkgci/setup_venv.py`](https://github.com/iree-org/iree/blob/main/build_tools/pkgci/setup_venv.py)
+    script:
+
+    ``` shell
+    # Install packages from a specific commit ref.
+    # See also the `--fetch-latest-main` and `--fetch-gh-workflow` options.
+    python ./build_tools/pkgci/setup_venv.py /tmp/.venv --fetch-git-ref=8230f41d
+    source /tmp/.venv/bin/activate
+    ```


### PR DESCRIPTION
Assorted documentation updates following some recent release infrastructure work and improvements to the [`setup_venv.py`](https://github.com/iree-org/iree/blob/main/build_tools/pkgci/setup_venv.py) script:

* Mention "development packages" next to "stable releases" and "nightly pre-releases", per https://github.com/iree-org/iree/pull/19362#discussion_r1871947915 ![image](https://github.com/user-attachments/assets/25266060-cd70-4b7d-9dd7-4f79a53f572e)
  * Could keep that scoped to one page... but duplicating it across pages helps with discoverability. Definitely open to hearing more opinions on this.
* Converted package names into links to pypi where applicable, like [`iree-base-runtime`](https://pypi.org/project/iree-base-runtime/)
* Removed references to https://pypi.org/user/google-iree-pypi-deploy/. That account is no longer a good reference for which projects are relevant. We could use an [organization account](https://docs.pypi.org/organization-accounts/) for a similar purpose.
* Adjusted icons used in several places
    
    Before | After
    -- | --
    ![image](https://github.com/user-attachments/assets/27c5603e-94c0-4dee-b2c8-c4c1b7a1b3ab) | ![image](https://github.com/user-attachments/assets/88f1e0d1-eecf-4b96-8098-d1a1040c213c)

* Misc proofreading and style tweaks