### PR TITLE
[Torch] Add patterns to convert complex conversions to bitcasts

### DIFF
--- a/compiler/plugins/input/Torch/InputConversion/CMakeLists.txt
+++ b/compiler/plugins/input/Torch/InputConversion/CMakeLists.txt
@@ -39,6 +39,7 @@ iree_cc_library(
     "ConvertTMTensorToLinalgExt.cpp"
     "FuncConversion.cpp"
     "SetStrictSymbolicShapes.cpp"
+    "TorchToIREE.cpp"
     "Passes.cpp"
   DEPS
     ::PassHeaders

--- a/compiler/plugins/input/Torch/InputConversion/Passes.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/Passes.cpp
@@ -45,6 +45,7 @@ void createTorchToIREEPipeline(
     pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   }
   pm.addNestedPass<func::FuncOp>(createBitCastQuantTensorPass());
+  pm.addNestedPass<func::FuncOp>(createTorchToIREEPass());
   pm.addNestedPass<func::FuncOp>(
       torch::Torch::createReduceOpVariantsPass(llvm::StringRef()));
   pm.addNestedPass<func::FuncOp>(

--- a/compiler/plugins/input/Torch/InputConversion/Passes.td
+++ b/compiler/plugins/input/Torch/InputConversion/Passes.td
@@ -29,6 +29,11 @@ def SetStrictSymbolicShapesPass :
   let summary = "Adds the attribute indicating strict symbolic shapes in Torch IR";
 }
 
+def TorchToIREEPass :
+    InterfacePass<"torch-convert-to-iree", "mlir::FunctionOpInterface"> {
+  let summary = "IREE specific lowerings of certain Torch ops";
+}
+
 def FuncConversionPass :
     Pass<"torch-iree-func-conversion", "ModuleOp"> {
   let summary = "Finalizes conversion from torch to IREE";

--- a/compiler/plugins/input/Torch/InputConversion/TorchToIREE.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/TorchToIREE.cpp
@@ -1,0 +1,95 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
+#include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionOps.h"
+#include "torch-mlir/Dialect/TorchConversion/Transforms/Passes.h"
+
+namespace mlir::iree_compiler::TorchInput {
+
+#define GEN_PASS_DEF_TORCHTOIREEPASS
+#include "compiler/plugins/input/Torch/InputConversion/Passes.h.inc"
+
+namespace {
+
+template <typename ViewAsTy>
+class BitCastViewAsType : public OpRewritePattern<ViewAsTy> {
+public:
+  using OpRewritePattern<ViewAsTy>::OpRewritePattern;
+  LogicalResult matchAndRewrite(ViewAsTy op,
+                                PatternRewriter &rewriter) const override {
+
+    Value in = op.getSelf();
+    auto loc = op.getLoc();
+    auto inType = cast<torch::Torch::ValueTensorType>(in.getType());
+    auto resultType = cast<torch::Torch::ValueTensorType>(op.getType());
+
+    auto bType = inType.toBuiltinTensor();
+
+    if (auto dtype = dyn_cast<IntegerType>(bType.getElementType())) {
+      bType = bType.clone(
+          rewriter.getType<IntegerType>(dtype.getIntOrFloatBitWidth()));
+    }
+
+    // Cast to the builtin tensor type.
+    Value builtinCast =
+        rewriter.create<torch::TorchConversion::ToBuiltinTensorOp>(loc, bType,
+                                                                   in);
+
+    auto rType = resultType.toBuiltinTensor();
+    if (auto dtype = dyn_cast<IntegerType>(rType.getElementType())) {
+      rType = rType.clone(
+          rewriter.getType<IntegerType>(dtype.getIntOrFloatBitWidth()));
+    }
+
+    // Both `view_as_real` and `view_as_complex` only affect the element type
+    // and insert/remove the inner most static dimension (size 2), thus the
+    // source and result share the same dynamic dims.
+    ValueRange dynamicDims =
+        IREE::Util::buildDynamicDimsForValue(loc, builtinCast, rewriter);
+    // Both view like ops are just bitcasts. Upstream bitcasting operations only
+    // allow changing element types without changing bitwidth or any tensor
+    // dimensions, so we use our own bitcasting operation here.
+    Value flowBitcast = rewriter.create<IREE::Flow::TensorBitCastOp>(
+        loc, rType, builtinCast, dynamicDims, dynamicDims);
+
+    auto torchCast =
+        rewriter.create<torch::TorchConversion::FromBuiltinTensorOp>(
+            loc, resultType, flowBitcast);
+    rewriter.replaceOp(op, torchCast);
+    return success();
+  }
+};
+} // namespace
+
+namespace {
+class TorchToIREEPass final
+    : public impl::TorchToIREEPassBase<TorchToIREEPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<IREE::Flow::FlowDialect>();
+    registry.insert<tensor::TensorDialect>();
+    registry.insert<torch::TorchConversion::TorchConversionDialect>();
+  }
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(context);
+    patterns.add<BitCastViewAsType<torch::Torch::AtenViewAsRealOp>,
+                 BitCastViewAsType<torch::Torch::AtenViewAsComplexOp>>(context);
+    if (failed(
+            applyPatternsAndFoldGreedily(getOperation(), std::move(patterns))))
+      signalPassFailure();
+  }
+};
+} // namespace
+
+} // namespace mlir::iree_compiler::TorchInput

--- a/compiler/plugins/input/Torch/InputConversion/test/CMakeLists.txt
+++ b/compiler/plugins/input/Torch/InputConversion/test/CMakeLists.txt
@@ -8,6 +8,7 @@ iree_lit_test_suite(
     "attention.mlir"
     "bind_symbolic_shapes.mlir"
     "bitcast_quant_tensor.mlir"
+    "convert_to_iree.mlir"
     "func_conversion.mlir"
     "func_conversion_invalid.mlir"
     "scan.mlir"

--- a/compiler/plugins/input/Torch/InputConversion/test/convert_to_iree.mlir
+++ b/compiler/plugins/input/Torch/InputConversion/test/convert_to_iree.mlir
@@ -1,0 +1,42 @@
+// RUN: iree-opt %s --pass-pipeline="builtin.module(func.func(torch-convert-to-iree))" -split-input-file -verify-diagnostics | FileCheck %s
+
+func.func @view_as_real(%arg0: !torch.vtensor<[8],complex<f32>>) -> !torch.vtensor<[8,2],f32> {
+    %0 = torch.aten.view_as_real %arg0 : !torch.vtensor<[8],complex<f32>> -> !torch.vtensor<[8,2],f32>
+    return %0 : !torch.vtensor<[8,2],f32>
+}
+
+// CHECK-LABEL: @view_as_real
+//  CHECK-SAME:   %[[ARG0:.+]]: !torch.vtensor<[8],complex<f32>>
+//       CHECK:   %[[IN:.+]] = torch_c.to_builtin_tensor %[[ARG0]]
+//       CHECK:   %[[BITCAST:.+]] = flow.tensor.bitcast %[[IN]] : tensor<8xcomplex<f32>> -> tensor<8x2xf32>
+//       CHECK:   %[[RES:.+]] = torch_c.from_builtin_tensor %[[BITCAST]]
+//       CHECK:   return %[[RES]]
+
+// -----
+
+func.func @view_as_complex(%arg0: !torch.vtensor<[8,2],f32>) -> !torch.vtensor<[8],complex<f32>> {
+    %0 = torch.aten.view_as_complex %arg0 : !torch.vtensor<[8,2],f32> -> !torch.vtensor<[8],complex<f32>>
+    return %0 : !torch.vtensor<[8],complex<f32>>
+}
+
+// CHECK-LABEL: @view_as_complex
+//  CHECK-SAME:   %[[ARG0:.+]]: !torch.vtensor<[8,2],f32>
+//       CHECK:   %[[IN:.+]] = torch_c.to_builtin_tensor %[[ARG0]]
+//       CHECK:   %[[BITCAST:.+]] = flow.tensor.bitcast %[[IN]] : tensor<8x2xf32> -> tensor<8xcomplex<f32>>
+//       CHECK:   %[[RES:.+]] = torch_c.from_builtin_tensor %[[BITCAST]]
+//       CHECK:   return %[[RES]]
+
+// -----
+
+func.func @view_as_real_dynamic(%arg0: !torch.vtensor<[?],complex<f32>>) -> !torch.vtensor<[?,2],f32> {
+    %0 = torch.aten.view_as_real %arg0 : !torch.vtensor<[?],complex<f32>> -> !torch.vtensor<[?,2],f32>
+    return %0 : !torch.vtensor<[?,2],f32>
+}
+
+// CHECK-LABEL: @view_as_real_dynamic
+//  CHECK-SAME:   %[[ARG0:.+]]: !torch.vtensor<[?],complex<f32>>
+//       CHECK:   %[[IN:.+]] = torch_c.to_builtin_tensor %[[ARG0]]
+//       CHECK:   %[[DIM:.+]] = tensor.dim %[[IN]], %c0 : tensor<?xcomplex<f32>>
+//       CHECK:   %[[BITCAST:.+]] = flow.tensor.bitcast %[[IN]] : tensor<?xcomplex<f32>>{%[[DIM]]} -> tensor<?x2xf32>{%[[DIM]]}
+//       CHECK:   %[[RES:.+]] = torch_c.from_builtin_tensor %[[BITCAST]]
+//       CHECK:   return %[[RES]]


### PR DESCRIPTION
The `torch.view_as_complex` and `torch.view_as_real` ops are better suited to be represented as bitcasts, however there isn't a suitable bitcast op upstream. Currently torch-mlir lowers to a difficult to analyze linalg.generic, but in IREE we can instead lower to `flow.tensor.bitcast`.