### PR TITLE
[GPU] Avoid fusing slices of already tiled ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUFuseAndHoistParallelLoops.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUFuseAndHoistParallelLoops.cpp
@@ -256,6 +256,11 @@ struct FuseTilableSliceProducers final
       return failure();
     }
 
+    auto producerParent = tilableProducer->getParentOfType<scf::ForallOp>();
+    if (producerParent && producerParent == parentForall) {
+      return failure();
+    }
+
     SmallVector<LoopLikeOpInterface> loops = {parentForall};
     std::optional<scf::SCFFuseProducerOfSliceResult> fusionResult =
         mlir::scf::tileAndFuseProducerOfSlice(rewriter, sliceOp, loops);


### PR DESCRIPTION
This fixes a bug in FuseAndHoistParallelLoops that can cause an infinite loop for imperfectly aligned unpack producer fusion. The FuseTilableSliceProducers pattern does not check that the producer operation is not already in the tiled loop, and the tiling implementation of imperfectly aligned unpack ops generates an extract_slice on the result of the tiled unpack. This would cause an infinite recursive application of the producer fusion pattern. This fixes the bug by enforcing that the producer operation is outside of the slice's parent loop.