### PR TITLE
[PJRT] Set the target cpu to `host` in llvmcpu backend

### DIFF
--- a/integrations/pjrt/src/iree_pjrt/cpu/client.cc
+++ b/integrations/pjrt/src/iree_pjrt/cpu/client.cc
@@ -95,7 +95,8 @@ iree_status_t CPUClientInstance::CreateDriver(iree_hal_driver_t** out_driver) {
 }
 
 bool CPUClientInstance::SetDefaultCompilerFlags(CompilerJob* compiler_job) {
-  return compiler_job->SetFlag("--iree-hal-target-backends=llvm-cpu");
+  return compiler_job->SetFlag("--iree-hal-target-backends=llvm-cpu") &&
+         compiler_job->SetFlag("--iree-llvmcpu-target-cpu=host");
 }
 
 }  // namespace iree::pjrt::cpu


### PR DESCRIPTION
As mentioned in https://github.com/iree-org/iree/pull/19222#discussion_r1854323729, since PJRT is acting as a JIT compiler, we can always expect that the compilation and execution is in the same machine. So we can add `target-cpu=host` to it for performance.

ci-exactly: build_packages, test_pjrt