### PR TITLE
Bump nanobind to v2.4.0

### DIFF
--- a/runtime/bindings/python/CMakeLists.txt
+++ b/runtime/bindings/python/CMakeLists.txt
@@ -9,7 +9,7 @@ include(FetchContent)
 FetchContent_Declare(
   nanobind
   GIT_REPOSITORY https://github.com/wjakob/nanobind.git
-  GIT_TAG        784efa2a0358a4dc5432c74f5685ee026e20f2b6 # 2.2.0
+  GIT_TAG        0f9ce749b257fdfe701edb3cf6f7027ba029434a # v2.4.0
 )
 FetchContent_MakeAvailable(nanobind)
 


### PR DESCRIPTION
Upstream MLIR will require nanobind 2.4.0 (and pins it accordingly) with the changes porting Python core code to nanobind.