### PR TITLE
Initialize nanobind at top-level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -773,6 +773,18 @@ endif()
 # MLIR/LLVM Dependency
 #-------------------------------------------------------------------------------
 
+# Both the IREE and MLIR Python bindings require nanobind. We initialize it here
+# at the top level so that everything uses ours consistently.
+if(IREE_BUILD_PYTHON_BINDINGS OR IREE_BUILD_COMPILER)
+  include(FetchContent)
+  FetchContent_Declare(
+    nanobind
+    GIT_REPOSITORY https://github.com/wjakob/nanobind.git
+    GIT_TAG        0f9ce749b257fdfe701edb3cf6f7027ba029434a # v2.4.0
+  )
+  FetchContent_MakeAvailable(nanobind)
+endif()
+
 # Both the IREE and MLIR Python bindings require pybind11. We initialize it here
 # at the top level so that everything uses ours consistently.
 if(IREE_BUILD_PYTHON_BINDINGS AND IREE_BUILD_COMPILER)

--- a/runtime/bindings/python/CMakeLists.txt
+++ b/runtime/bindings/python/CMakeLists.txt
@@ -4,15 +4,6 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# nanobind
-include(FetchContent)
-FetchContent_Declare(
-  nanobind
-  GIT_REPOSITORY https://github.com/wjakob/nanobind.git
-  GIT_TAG        0f9ce749b257fdfe701edb3cf6f7027ba029434a # v2.4.0
-)
-FetchContent_MakeAvailable(nanobind)
-
 set(_EXTRA_INSTALL_TOOL_TARGETS)
 set(_TRACY_ENABLED OFF)
 


### PR DESCRIPTION
Initalizes nanobind at the top-level as MLIR is switching over to nanobind with https://github.com/llvm/llvm-project/pull/118583.