### PR TITLE
Drop unnecessary arg-ids in `llvm::formatv`

### DIFF
--- a/compiler/plugins/target/LLVMCPU/internal/WindowsLinkerTool.cpp
+++ b/compiler/plugins/target/LLVMCPU/internal/WindowsLinkerTool.cpp
@@ -220,12 +220,12 @@ public:
       return std::nullopt;
     }
     flags.push_back(
-        llvm::formatv("/libpath:\"{0}\\lib\\{1}\"", "%VCToolsInstallDir%", arch)
+        llvm::formatv("/libpath:\"{}\\lib\\{}\"", "%VCToolsInstallDir%", arch)
             .str());
-    flags.push_back(llvm::formatv("/libpath:\"{0}\\Lib\\{1}\\ucrt\\{2}\"",
+    flags.push_back(llvm::formatv("/libpath:\"{}\\Lib\\{}\\ucrt\\{}\"",
                                   "%UniversalCRTSdkDir%", "%UCRTVersion%", arch)
                         .str());
-    flags.push_back(llvm::formatv("/libpath:\"{0}\\Lib\\{1}\\um\\{2}\"",
+    flags.push_back(llvm::formatv("/libpath:\"{}\\Lib\\{}\\um\\{}\"",
                                   "%UniversalCRTSdkDir%", "%UCRTVersion%", arch)
                         .str());
 

--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -348,7 +348,7 @@ public:
         return variantOp.emitError()
                << "found an unresolved external function '" << func.getName()
                << "' in the final bitcode. A remaining live user is\n"
-               << llvm::formatv("{0}", *liveUser);
+               << llvm::formatv("{}", *liveUser);
       }
     }
     return success();

--- a/compiler/plugins/target/ROCM/test/opt_pass_plugin/GPUHello.cpp
+++ b/compiler/plugins/target/ROCM/test/opt_pass_plugin/GPUHello.cpp
@@ -47,7 +47,7 @@ bool GpuHello::runOnModule(llvm::Module &module) {
         if (!debugLocation) {
           sourceInfo = function.getName().str();
         } else {
-          sourceInfo = llvm::formatv("{0}\t{1}:{2}:{3}", function.getName(),
+          sourceInfo = llvm::formatv("{}\t{}:{}:{}", function.getName(),
                                      debugLocation->getFilename(),
                                      debugLocation->getLine(),
                                      debugLocation->getColumn())

--- a/compiler/plugins/target/WebGPUSPIRV/WebGPUSPIRVTarget.cpp
+++ b/compiler/plugins/target/WebGPUSPIRV/WebGPUSPIRVTarget.cpp
@@ -165,7 +165,7 @@ public:
       auto entryPointFunc = dyn_cast<spirv::FuncOp>(
           SymbolTable::lookupSymbolIn(spvModuleOp, exportOp.getSymName()));
 
-      std::string symbolName = llvm::formatv("d{0}", exportOp.getOrdinal());
+      std::string symbolName = llvm::formatv("d{}", exportOp.getOrdinal());
       mlir::StringAttr nameAttr =
           mlir::StringAttr::get(variantOp->getContext(), symbolName);
 

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ToUInt16Buffers.cpp
@@ -88,7 +88,7 @@ struct ConvertHalInterfaceBindingSubspan final
     if (!newResultTy)
       return rewriter.notifyMatchFailure(
           op->getLoc(),
-          llvm::formatv("failed to legalize memref type: {0}", op.getType()));
+          llvm::formatv("failed to legalize memref type: {}", op.getType()));
 
     auto newOp =
         rewriter.replaceOpWithNewOp<IREE::HAL::InterfaceBindingSubspanOp>(
@@ -111,7 +111,7 @@ struct ConvertMemRefAlloc final : OpConversionPattern<memref::AllocOp> {
     if (!newTy)
       return rewriter.notifyMatchFailure(
           op->getLoc(),
-          llvm::formatv("failed to convert memref type: {0}", op.getType()));
+          llvm::formatv("failed to convert memref type: {}", op.getType()));
 
     rewriter.replaceOpWithNewOp<memref::AllocOp>(
         op, newTy, adaptor.getDynamicSizes(), adaptor.getSymbolOperands(),
@@ -196,7 +196,7 @@ struct ConvertMemRefLoad final : OpConversionPattern<memref::LoadOp> {
     Type newResTy = getTypeConverter()->convertType(op.getType());
     if (!newResTy)
       return rewriter.notifyMatchFailure(
-          op->getLoc(), llvm::formatv("failed to convert memref type: {0}",
+          op->getLoc(), llvm::formatv("failed to convert memref type: {}",
                                       op.getMemRefType()));
 
     rewriter.replaceOpWithNewOp<memref::LoadOp>(
@@ -215,7 +215,7 @@ struct ConvertMemRefStore final : OpConversionPattern<memref::StoreOp> {
     Type newTy = getTypeConverter()->convertType(op.getMemRefType());
     if (!newTy)
       return rewriter.notifyMatchFailure(
-          op->getLoc(), llvm::formatv("failed to convert memref type: {0}",
+          op->getLoc(), llvm::formatv("failed to convert memref type: {}",
                                       op.getMemRefType()));
 
     rewriter.replaceOpWithNewOp<memref::StoreOp>(

--- a/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
@@ -51,7 +51,7 @@ struct ConvertHalInterfaceBindingSubspan final
     if (!newResultType) {
       return rewriter.notifyMatchFailure(
           op->getLoc(),
-          llvm::formatv("failed to legalize memref type: {0}", op.getType()));
+          llvm::formatv("failed to legalize memref type: {}", op.getType()));
     }
     Location loc = op.getLoc();
     OpFoldResult zero = rewriter.getIndexAttr(0);

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPULowerToUKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPULowerToUKernels.cpp
@@ -45,8 +45,7 @@ getUKernelBitcode(OpBuilder &builder,
     return {};
   }
   StringRef gpuArch = gpuTarget.getArch();
-  std::string bitcodeFilename =
-      llvm::formatv("{0}.{1}.bc", ukernelName, gpuArch);
+  std::string bitcodeFilename = llvm::formatv("{}.{}.bc", ukernelName, gpuArch);
 
   // Early-return if the source executable.objects already contain an object
   // with the expected file name. This happens with user-provided bitcode in the
@@ -121,7 +120,7 @@ getFnNameAndDefAttrs(const char *name, std::string &suffix,
                      IREE::HAL::ExecutableTargetAttr targetAttr) {
   FnNameAndDefAttrs result;
   if (isROCMBackend(targetAttr)) {
-    result.name = llvm::formatv("iree_uk_amdgpu_{0}_{1}", name, suffix);
+    result.name = llvm::formatv("iree_uk_amdgpu_{}_{}", name, suffix);
     result.defAttrs.emplace_back(rewriter.getStringAttr("vm.import.module"),
                                  rewriter.getStringAttr("rocm"));
   }

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/UKernelOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/UKernelOps.cpp
@@ -143,7 +143,7 @@ static FailureOr<func::CallOp> lowerUKernelGenericToFunctionCall(
     if (failed(getCallOpType(rewriter.getContext(), microKernelOpOperandType,
                              stridedOuterDimsAttr, callArgumentTypes))) {
       return rewriter.notifyMatchFailure(
-          op, llvm::formatv("failed to lower operand type {0}",
+          op, llvm::formatv("failed to lower operand type {}",
                             microKernelOpOperandType));
     }
   }
@@ -156,7 +156,7 @@ static FailureOr<func::CallOp> lowerUKernelGenericToFunctionCall(
     if (failed(getCallOpType(rewriter.getContext(), resultType,
                              stridedOuterDimsAttr, callResultTypes))) {
       return rewriter.notifyMatchFailure(
-          op, llvm::formatv("failed to lower result type {0}", resultType));
+          op, llvm::formatv("failed to lower result type {}", resultType));
     }
   }
 
@@ -242,7 +242,7 @@ struct UKernelOpsBufferizationInterface
         FailureOr<Value> memrefOperand = getBuffer(rewriter, operand, options);
         if (failed(memrefOperand)) {
           return op->emitOpError(
-              llvm::formatv("failed to bufferize operand {0} ", index));
+              llvm::formatv("failed to bufferize operand {} ", index));
         }
         bufferOpOperands.push_back(memrefOperand.value());
         continue;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULinkExecutables.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULinkExecutables.cpp
@@ -34,7 +34,7 @@ struct LLVMCPULinkExecutablesPass
 
     // Create our new "linked" hal.executable.
     SymbolTable moduleTable(moduleOp);
-    std::string linkedExecutableName = llvm::formatv("{0}_linked", moduleName);
+    std::string linkedExecutableName = llvm::formatv("{}_linked", moduleName);
     auto linkedExecutableOp = moduleBuilder.create<IREE::HAL::ExecutableOp>(
         moduleOp.getLoc(), linkedExecutableName);
     linkedExecutableOp.setVisibility(
@@ -55,7 +55,7 @@ struct LLVMCPULinkExecutablesPass
       std::string linkedVariantName =
           executableTargetAttrs.size() == 1
               ? targetAttr.getSymbolNameFragment()
-              : llvm::formatv("{0}_{1}", targetAttr.getSymbolNameFragment(),
+              : llvm::formatv("{}_{}", targetAttr.getSymbolNameFragment(),
                               index);
       auto linkedTargetOp =
           executableBuilder.create<IREE::HAL::ExecutableVariantOp>(

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/VectorContractCustomKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/VectorContractCustomKernels.cpp
@@ -831,8 +831,8 @@ private:
         // Perform the code replacement for the operand.
         // Example:   $(lhs:1)   =>   $5
         replaceAllSubstrsInPlace(
-            code, llvm::formatv("$({0}:{1})", name, unprocessedIdx),
-            llvm::formatv("${0}", processedIdx));
+            code, llvm::formatv("$({}:{})", name, unprocessedIdx),
+            llvm::formatv("${}", processedIdx));
       }
     };
     processOperands(Constraints::Kind::InputOutput, "acc", kernel.accRegs);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULinkExecutables.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULinkExecutables.cpp
@@ -73,7 +73,7 @@ struct LLVMGPULinkExecutablesPass
 
     // Create our new "linked" hal.executable.
     SymbolTable moduleTable(moduleOp);
-    std::string linkedExecutableName = llvm::formatv("{0}_linked", moduleName);
+    std::string linkedExecutableName = llvm::formatv("{}_linked", moduleName);
     auto linkedExecutableOp = moduleBuilder.create<IREE::HAL::ExecutableOp>(
         moduleOp.getLoc(), linkedExecutableName);
     linkedExecutableOp.setVisibility(
@@ -94,7 +94,7 @@ struct LLVMGPULinkExecutablesPass
       std::string linkedVariantName =
           executableTargetAttrs.size() == 1
               ? targetAttr.getSymbolNameFragment()
-              : llvm::formatv("{0}_{1}", targetAttr.getSymbolNameFragment(),
+              : llvm::formatv("{}_{}", targetAttr.getSymbolNameFragment(),
                               index);
       auto linkedTargetOp =
           executableBuilder.create<IREE::HAL::ExecutableVariantOp>(

--- a/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
@@ -96,15 +96,15 @@ createResourceVariable(Location loc, const SubspanResourceInfo &resource,
   OpBuilder builder(moduleOp.getContext());
   spirv::GlobalVariableOp variable;
   if (!isIndirect) {
-    std::string name = llvm::formatv("__resource_var_{0}_{1}_", resource.set,
-                                     resource.binding);
+    std::string name =
+        llvm::formatv("__resource_var_{}_{}_", resource.set, resource.binding);
     variable = builder.create<spirv::GlobalVariableOp>(
         loc, globalVariableType, name, resource.set, resource.binding);
     if (resource.aliased)
       variable->setAttr("aliased", builder.getUnitAttr());
   } else {
     std::string name =
-        llvm::formatv("__resource_var_indirect_{0}_", resource.set);
+        llvm::formatv("__resource_var_indirect_{}_", resource.set);
     variable = builder.create<spirv::GlobalVariableOp>(
         loc, globalVariableType, name, kIndirectBindingsSetIndex, resource.set);
   }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEmulateI64.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEmulateI64.cpp
@@ -57,7 +57,7 @@ struct ConvertHalInterfaceBindingSubspan final
     if (!newResultTy)
       return rewriter.notifyMatchFailure(
           op->getLoc(),
-          llvm::formatv("failed to legalize memref type: {0}", op.getType()));
+          llvm::formatv("failed to legalize memref type: {}", op.getType()));
 
     auto newOp =
         rewriter.replaceOpWithNewOp<IREE::HAL::InterfaceBindingSubspanOp>(

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLinkExecutables.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLinkExecutables.cpp
@@ -140,7 +140,7 @@ struct SPIRVLinkExecutablesPass final
       std::string moduleName =
           executableBuckets.size() == 1
               ? baseModuleName
-              : llvm::formatv("{0}_{1}", baseModuleName, bucketIndex);
+              : llvm::formatv("{}_{}", baseModuleName, bucketIndex);
 
       LLVM_DEBUG({
         llvm::dbgs() << "executable bucket #" << bucketIndex << " targets:\n";
@@ -179,7 +179,7 @@ struct SPIRVLinkExecutablesPass final
       std::string linkedVariantName =
           executableTargetAttrs.size() == 1
               ? attr.getSymbolNameFragment()
-              : llvm::formatv("{0}_{1}", attr.getSymbolNameFragment(), index);
+              : llvm::formatv("{}_{}", attr.getSymbolNameFragment(), index);
       auto linkedTargetOp =
           executableBuilder.create<IREE::HAL::ExecutableVariantOp>(
               moduleOp.getLoc(), linkedVariantName, attr);

--- a/compiler/src/iree/compiler/Codegen/Utils/LinkingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/LinkingUtils.cpp
@@ -56,7 +56,7 @@ renameWithDisambiguatedName(Operation *op, Operation *moduleOp,
   int uniqueingCounter = 0;
   do {
     disambiguatedName =
-        llvm::formatv("{0}_{1}", originalName, uniqueingCounter++).str();
+        llvm::formatv("{}_{}", originalName, uniqueingCounter++).str();
   } while (
       targetSymbolMap.lookup(disambiguatedName) ||
       (optionalSymbolTable && optionalSymbolTable->lookup(disambiguatedName)));

--- a/compiler/src/iree/compiler/Codegen/VMVX/VMVXLinkExecutables.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/VMVXLinkExecutables.cpp
@@ -33,7 +33,7 @@ struct VMVXLinkExecutablesPass
 
     // Create our new "linked" hal.executable.
     std::string linkedExecutableName =
-        llvm::formatv("{0}_linked_{1}", moduleName, "vmvx");
+        llvm::formatv("{}_linked_{}", moduleName, "vmvx");
     auto linkedExecutableOp = moduleBuilder.create<IREE::HAL::ExecutableOp>(
         moduleOp.getLoc(), linkedExecutableName);
     linkedExecutableOp.setVisibility(
@@ -48,7 +48,7 @@ struct VMVXLinkExecutablesPass
       std::string linkedVariantName =
           executableTargetAttrs.size() == 1
               ? targetAttr.getSymbolNameFragment()
-              : llvm::formatv("{0}_{1}", targetAttr.getSymbolNameFragment(),
+              : llvm::formatv("{}_{}", targetAttr.getSymbolNameFragment(),
                               index);
       auto linkedTargetOp =
           executableBuilder.create<IREE::HAL::ExecutableVariantOp>(

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/DumpStatistics.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/DumpStatistics.cpp
@@ -225,36 +225,34 @@ static void prettyPrintStatistics(const UsageInfo &usageInfo,
   Statistics stats;
   stats.analyze(usageInfo);
 
-  os << llvm::formatv("//   Constants: {0}, ", stats.constantCount);
-  os << llvm::formatv("estimated storage of {0}{1} B ({2:F2} MiB)\n",
+  os << llvm::formatv("//   Constants: {}, ", stats.constantCount);
+  os << llvm::formatv("estimated storage of {}{} B ({:F2} MiB)\n",
                       stats.constantSizeDynamic ? "minimum " : "",
                       stats.constantSize,
                       stats.constantSize / (1 * 1024 * 1024.0f));
-  os << llvm::formatv("//   Variables: {0}, ", stats.variableCount);
-  os << llvm::formatv("(TBD) {0}{1} B ({2:F2} MiB)\n",
-                      stats.variableSizeDynamic ? "minimum " : "",
-                      stats.variableSize,
-                      stats.variableSize / (1 * 1024 * 1024.0f));
+  os << llvm::formatv("//   Variables: {}, ", stats.variableCount);
+  os << llvm::formatv(
+      "(TBD) {}{} B ({:F2} MiB)\n", stats.variableSizeDynamic ? "minimum " : "",
+      stats.variableSize, stats.variableSize / (1 * 1024 * 1024.0f));
 
-  os << llvm::formatv("//  D->H Syncs: {0}\n", stats.awaitCount);
+  os << llvm::formatv("//  D->H Syncs: {}\n", stats.awaitCount);
 
-  os << llvm::formatv("// Submissions: {0}, using cumulative ",
+  os << llvm::formatv("// Submissions: {}, using cumulative ",
                       stats.submissionCount);
   os << llvm::formatv(
-      "{0}{1} B ({2:F2} MiB)\n", stats.transientSizeDynamic ? "minimum " : "",
+      "{}{} B ({:F2} MiB)\n", stats.transientSizeDynamic ? "minimum " : "",
       stats.transientSize, stats.transientSize / (1 * 1024 * 1024.0f));
 
-  os << llvm::formatv("//   DMA Fills: {0}\n", stats.fillCount);
-  os << llvm::formatv("//  DMA Copies: {0}\n", stats.copyCount);
-  os << llvm::formatv("// Collectives: {0}\n", stats.collectiveCount);
-  os << llvm::formatv("//  Dispatches: {0}\n", stats.dispatchCount);
-  os << llvm::formatv("// Async Calls: {0}\n", stats.callCount);
+  os << llvm::formatv("//   DMA Fills: {}\n", stats.fillCount);
+  os << llvm::formatv("//  DMA Copies: {}\n", stats.copyCount);
+  os << llvm::formatv("// Collectives: {}\n", stats.collectiveCount);
+  os << llvm::formatv("//  Dispatches: {}\n", stats.dispatchCount);
+  os << llvm::formatv("// Async Calls: {}\n", stats.callCount);
 
-  os << llvm::formatv(
-      "// Executables: {0}, {1}% reuse\n", stats.executableCount,
-      (int)std::roundf(
-          (1.0f - (stats.executableCount / (float)stats.dispatchCount)) *
-          100.0f));
+  os << llvm::formatv("// Executables: {}, {}% reuse\n", stats.executableCount,
+                      (int)std::roundf((1.0f - (stats.executableCount /
+                                                (float)stats.dispatchCount)) *
+                                       100.0f));
 
   os << "//\n";
 }
@@ -331,7 +329,7 @@ static void prettyPrintExecutableExportInfo(
     const UsageInfo &usageInfo, IREE::Stream::ExecutableOp executableOp,
     IREE::Stream::ExecutableExportOp exportOp, llvm::raw_fd_ostream &os) {
   auto funcOp = exportOp.lookupFunctionRef();
-  prettyPrintItemHeader(llvm::formatv("stream.executable.export @{0}::@{1}",
+  prettyPrintItemHeader(llvm::formatv("stream.executable.export @{}::@{}",
                                       executableOp.getName(),
                                       exportOp.getName()),
                         os);
@@ -406,20 +404,19 @@ static void dumpAggregateCSVTable(const UsageInfo &usageInfo,
   os << "\n";
 
   // Globals:
-  os << llvm::formatv("{0},{1},{2},{3},", stats.constantCount,
-                      stats.constantSize, stats.variableCount,
-                      stats.variableSize);
+  os << llvm::formatv("{},{},{},{},", stats.constantCount, stats.constantSize,
+                      stats.variableCount, stats.variableSize);
 
   // Synchronization:
-  os << llvm::formatv("{0},", stats.awaitCount);
+  os << llvm::formatv("{},", stats.awaitCount);
 
   // Execution:
-  os << llvm::formatv("{0},{1},{2},{3},{4},{5},", stats.submissionCount,
+  os << llvm::formatv("{},{},{},{},{},{},", stats.submissionCount,
                       stats.transientSize, stats.fillCount, stats.copyCount,
                       stats.dispatchCount, stats.callCount);
 
   // Executables:
-  os << llvm::formatv("{0}", stats.executableCount);
+  os << llvm::formatv("{}", stats.executableCount);
 
   os << "\n";
   os << "\n";
@@ -452,13 +449,13 @@ static void dumpExecutionCSVTable(const UsageInfo &usageInfo,
         .Case<IREE::Stream::CmdFillOp>([&](auto op) {
           APInt length;
           matchPattern(op.getTargetLength(), m_ConstantInt(&length));
-          os << llvm::formatv(R"({0},"fill",,{1},,,,)", depth, length);
+          os << llvm::formatv(R"({},"fill",,{},,,,)", depth, length);
           os << "\n";
         })
         .Case<IREE::Stream::CmdCopyOp>([&](auto op) {
           APInt length;
           matchPattern(op.getLength(), m_ConstantInt(&length));
-          os << llvm::formatv(R"({0},"copy",,{1},,,,)", depth, length);
+          os << llvm::formatv(R"({},"copy",,{},,,,)", depth, length);
           os << "\n";
         })
         .Case<IREE::Stream::CmdDispatchOp>([&](auto op) {

--- a/compiler/src/iree/compiler/Dialect/VM/Analysis/RegisterAllocation.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Analysis/RegisterAllocation.cpp
@@ -68,7 +68,7 @@ LogicalResult RegisterAllocation::annotateIR(IREE::VM::FuncOp funcOp) {
             registerAllocation.remapSuccessorRegisters(terminatorOp, i);
         SmallVector<std::string, 8> remappingStrs;
         for (auto &srcDstReg : srcDstRegs) {
-          remappingStrs.push_back(llvm::formatv("{0}->{1}",
+          remappingStrs.push_back(llvm::formatv("{}->{}",
                                                 srcDstReg.first.toString(),
                                                 srcDstReg.second.toString())
                                       .str());

--- a/compiler/src/iree/compiler/Dialect/VM/Analysis/ValueLiveness.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Analysis/ValueLiveness.cpp
@@ -67,11 +67,10 @@ LogicalResult ValueLiveness::annotateIR(IREE::VM::FuncOp funcOp) {
       std::string str;
       if (auto blockArg = llvm::dyn_cast<BlockArgument>(value)) {
         if (blockArg.getOwner()->isEntryBlock()) {
-          str = llvm::formatv("%arg{0}", blockArg.getArgNumber());
+          str = llvm::formatv("%arg{}", blockArg.getArgNumber());
         } else {
-          str =
-              llvm::formatv("%bb{0}_arg{1}", blockOrdinals[blockArg.getOwner()],
-                            blockArg.getArgNumber());
+          str = llvm::formatv("%bb{}_arg{}", blockOrdinals[blockArg.getOwner()],
+                              blockArg.getArgNumber());
         }
       } else {
         llvm::raw_string_ostream os(str);

--- a/compiler/src/iree/compiler/Dialect/VM/Tools/VMOpTableGen.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Tools/VMOpTableGen.cpp
@@ -31,11 +31,11 @@ void emitOpTable(const llvm::RecordKeeper &recordKeeper, const Record &tableDef,
   os << "typedef enum {\n";
   for (int i = 0; i < 256; ++i) {
     if (auto *opcode = opEncodings[i]) {
-      os << formatv("  IREE_VM_OP_{0}_{1} = {2}",
+      os << formatv("  IREE_VM_OP_{}_{} = {}",
                     tableDef.getValueAsString("opcodeEnumTag"),
                     opcode->getValueAsString("symbol"), format_hex(i, 4, true));
     } else {
-      os << formatv("  IREE_VM_OP_{0}_RSV_{1}",
+      os << formatv("  IREE_VM_OP_{}_RSV_{}",
                     tableDef.getValueAsString("opcodeEnumTag"),
                     format_hex(i, 4, true));
     }
@@ -44,14 +44,14 @@ void emitOpTable(const llvm::RecordKeeper &recordKeeper, const Record &tableDef,
   os << "} " << tableDef.getValueAsString("opcodeEnumName") << ";\n";
   os << "\n";
 
-  os << formatv("#define IREE_VM_OP_{0}_TABLE(OPC, RSV) \\\n",
+  os << formatv("#define IREE_VM_OP_{}_TABLE(OPC, RSV) \\\n",
                 tableDef.getValueAsString("opcodeEnumTag"));
   for (int i = 0; i < 256; ++i) {
     if (auto *opcode = opEncodings[i]) {
-      os << formatv("    OPC({0}, {1})", format_hex(i, 4, true),
+      os << formatv("    OPC({}, {})", format_hex(i, 4, true),
                     opcode->getValueAsString("symbol"));
     } else {
-      os << formatv("    RSV({0})", format_hex(i, 4, true));
+      os << formatv("    RSV({})", format_hex(i, 4, true));
     }
     if (i != 255) {
       os << " \\\n";

--- a/compiler/src/iree/compiler/Utils/ConversionUtils.cpp
+++ b/compiler/src/iree/compiler/Utils/ConversionUtils.cpp
@@ -28,7 +28,7 @@ static void emitLegalizationErrors(Location loc,
   errorMessages.reserve(opNameCounts.size());
   for (const auto &opInfo : opNameCounts) {
     errorMessages.push_back(
-        llvm::formatv("\t{0} (count: {1})", opInfo.first, opInfo.second));
+        llvm::formatv("\t{} (count: {})", opInfo.first, opInfo.second));
   }
   emitError(loc) << "The following illegal operations still remain: \n"
                  << llvm::join(errorMessages, "\n") << "\n";

--- a/compiler/src/iree/compiler/Utils/ModuleUtils.cpp
+++ b/compiler/src/iree/compiler/Utils/ModuleUtils.cpp
@@ -79,7 +79,7 @@ static void renameWithDisambiguatedName(Operation *op, Operation *moduleOp,
   int uniqueingCounter = 0;
   do {
     disambiguatedName =
-        llvm::formatv("{0}_{1}", originalName, uniqueingCounter++).str();
+        llvm::formatv("{}_{}", originalName, uniqueingCounter++).str();
   } while (symbolTable0.lookup(disambiguatedName) ||
            symbolTable1.lookup(disambiguatedName));
 

--- a/compiler/src/iree/compiler/Utils/unittests/UtilsTest.cpp
+++ b/compiler/src/iree/compiler/Utils/unittests/UtilsTest.cpp
@@ -38,7 +38,7 @@ TEST(EmbeddedDataDirectory, WithGlobal) {
   for (int i = 0; i < 3; ++i) {
     threads.emplace_back([i] {
       EmbeddedDataDirectory::withGlobal([i](EmbeddedDataDirectory &globalDir) {
-        EXPECT_TRUE(globalDir.addFile(llvm::formatv("filename{0}", i).str(),
+        EXPECT_TRUE(globalDir.addFile(llvm::formatv("filename{}", i).str(),
                                       "file contents xxx"));
       });
     });


### PR DESCRIPTION
`llvm::formatv` supports (approximately?) the same format syntax as `std::format` described [here](https://en.cppreference.com/w/cpp/utility/format/format). The general pattern is `{arg-id}` or `{arg-id:format-spec}` where `arg-id` is optional and may be omitted to default to consuming the args in the order in which they are provided. So the only reason to ever specify `arg-id` is to consume the same arg repeatedly or in a different order.

It turns out that 100% of the call sites were consuming args in the order in which they were specified, so the arg-ids were unnecessary.