### PR TITLE
[DT][NFC] Remove redundant variables from MaterializeEncodingTypeConverter.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPUMaterializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPUMaterializeEncodings.cpp
@@ -43,12 +43,6 @@ using IREE::Codegen::TileMxNxK;
 #define GEN_PASS_DEF_CPUMATERIALIZEHOSTENCODINGPASS
 #include "iree/compiler/Codegen/Common/CPU/Passes.h.inc"
 
-static FailureOr<MaterializeEncodingInfo>
-materializeEncodingForTarget(RankedTensorType tensorType,
-                             IREE::HAL::ExecutableTargetAttr targetAttr) {
-  return failure();
-}
-
 static FailureOr<MaterializeEncodingValueInfo>
 chooseDynamicEncodingInfoVMVXMicrokernels(RankedTensorType tensorType,
                                           OpBuilder &builder, Location loc) {
@@ -92,8 +86,7 @@ materializeFuncOpEncodings(FunctionOpInterface funcOp,
         IREE::CPU::CPUEncodingLayoutAttr::get(ctx, targetConfig));
   }
   MaterializeEncodingTypeConverter typeConverter(
-      materializeEncodingForTarget, targetAttr, /*transposeNarrowN=*/true,
-      layoutAttr);
+      /*transposeNarrowN=*/true, layoutAttr);
   MaterializeEncodingConversionTarget target(*ctx);
   auto materializeEncodingValueFn = getMaterializeEncodingValueFn(targetAttr);
   populateMaterializeEncodingIntoPackUnPackPatterns(

--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
@@ -88,11 +88,8 @@ static RankedTensorType transposeIfNarrowNResult(RankedTensorType tensorType) {
 }
 
 MaterializeEncodingTypeConverter::MaterializeEncodingTypeConverter(
-    MaterializeEncodingFn materializeEncodingFn,
-    IREE::HAL::ExecutableTargetAttr targetAttr, bool transposeNarrowN,
-    IREE::Codegen::LayoutAttrInterface layoutAttr)
-    : materializeEncodingFn(materializeEncodingFn), targetAttr(targetAttr),
-      transposeNarrowN(transposeNarrowN), layoutAttr(layoutAttr) {
+    bool transposeNarrowN, IREE::Codegen::LayoutAttrInterface layoutAttr)
+    : transposeNarrowN(transposeNarrowN), layoutAttr(layoutAttr) {
   addConversion([](IntegerType intType) { return intType; });
   addConversion([](IndexType indexType) { return indexType; });
   addConversion([](FloatType floatType) { return floatType; });

--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.h
@@ -36,39 +36,23 @@ using MaterializeEncodingValueFn =
 class MaterializeEncodingTypeConverter : public TypeConverter {
 public:
   MaterializeEncodingTypeConverter(
-      MaterializeEncodingFn fn, IREE::HAL::ExecutableTargetAttr targetAttr,
       bool transposeNarrowN, IREE::Codegen::LayoutAttrInterface layoutAttr);
 
   const IREE::Codegen::LayoutAttrInterface &getLayoutAttr() const {
     return layoutAttr;
   }
 
-  const MaterializeEncodingFn &getMaterializeEncodingFn() const {
-    return materializeEncodingFn;
-  }
-
-  IREE::HAL::ExecutableTargetAttr getTargetAttr() const { return targetAttr; }
-
   FailureOr<IREE::Codegen::MaterializeEncodingInfo>
   getEncodingInfo(RankedTensorType type) const {
-    if (layoutAttr) {
-      return layoutAttr.getEncodingInfo(type);
-    }
-    return materializeEncodingFn(type, targetAttr);
+    return layoutAttr.getEncodingInfo(type);
   }
 
   bool getTransposeNarrowN() const { return transposeNarrowN; }
 
 private:
-  const MaterializeEncodingFn materializeEncodingFn;
-  const IREE::HAL::ExecutableTargetAttr targetAttr;
   bool transposeNarrowN = false;
-  // The `layoutAttr` implements the logic of encoding materialization. It has
-  // a higher priority when it is present.
-  // TODO(hanchung): Move the logic that takes `targetAttr` and
-  // `transposeNarrowN` into account to their own attribute implementation. It
-  // is in a transition state, so we have two paths atm. We're incrementally
-  // moving the logic to attributes.
+  // TODO(hanchung): Move the logic that takes `transposeNarrowN` into account
+  // to their own attribute implementation.
   const IREE::Codegen::LayoutAttrInterface layoutAttr;
 };
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUMaterializeEncoding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUMaterializeEncoding.cpp
@@ -37,12 +37,6 @@ namespace mlir::iree_compiler {
 using IREE::Codegen::MaterializeEncodingInfo;
 using IREE::Codegen::TileSwizzle;
 
-static FailureOr<MaterializeEncodingInfo>
-materializeEncodingForTarget(RankedTensorType tensorType,
-                             IREE::HAL::ExecutableTargetAttr targetAttr) {
-  return failure();
-}
-
 namespace {
 
 // TODO(hanchung): Delete this pass and rely on tensor-based analysis to
@@ -297,7 +291,7 @@ materializeFuncOpEncodings(FunctionOpInterface funcOp,
       gpuTargetAttr = getCLGPUTarget(ctx);
     }
     MaterializeEncodingTypeConverter typeConverter(
-        materializeEncodingForTarget, targetAttr, /*transposeNarrowN=*/false,
+        /*transposeNarrowN=*/false,
         cast<IREE::Codegen::LayoutAttrInterface>(
             IREE::GPU::GPUEncodingLayoutAttr::get(ctx, gpuTargetAttr)));
     MaterializeEncodingConversionTarget target(*ctx);

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoNop.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoNop.cpp
@@ -38,9 +38,6 @@ struct MaterializeEncodingIntoNopPass final
     MLIRContext *context = &getContext();
     auto operation = getOperation();
 
-    auto materializeEncodingFn = [](RankedTensorType,
-                                    IREE::HAL::ExecutableTargetAttr)
-        -> FailureOr<MaterializeEncodingInfo> { return failure(); };
     auto materializeEncodingValueFn =
         [](RankedTensorType, OpBuilder &,
            Location) -> FailureOr<MaterializeEncodingValueInfo> {
@@ -49,7 +46,6 @@ struct MaterializeEncodingIntoNopPass final
 
     RewritePatternSet materializeEncodingPattern(context);
     MaterializeEncodingTypeConverter typeConverter(
-        materializeEncodingFn, IREE::HAL::ExecutableTargetAttr(),
         /*transposeNarrowN=*/false,
         IREE::Codegen::EncodingNopLayoutAttr::get(context));
     MaterializeEncodingConversionTarget target(*context);


### PR DESCRIPTION
The materialization logic is implemented through layout attributes (i.e., `IREE::Codegen::LayoutAttrInterface`). They are no longer needed because the encoding information can be queried from `layoutAttr` now.