### PR TITLE
[DT][NFC] Remove FailureOr<> from getEncodingInfo methods.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
@@ -100,16 +100,13 @@ MaterializeEncodingTypeConverter::MaterializeEncodingTypeConverter(
     // itself.
     RankedTensorType tensorType =
         transposeNarrowN ? transposeIfNarrowNResult(type) : type;
-    FailureOr<MaterializeEncodingInfo> maybeEncodingInfo =
-        getEncodingInfo(tensorType);
-    if (failed(maybeEncodingInfo) ||
-        IREE::Codegen::isIdentityLayout(maybeEncodingInfo.value())) {
+    MaterializeEncodingInfo encodingInfo = getEncodingInfo(tensorType);
+    if (IREE::Codegen::isIdentityLayout(encodingInfo)) {
       return dropEncoding(type);
     }
-    auto encodingInfo = *maybeEncodingInfo;
     auto packedType = cast<RankedTensorType>(tensor::PackOp::inferPackedType(
-        tensorType, maybeEncodingInfo->innerTileSizes,
-        maybeEncodingInfo->innerDimsPos, maybeEncodingInfo->outerDimsPerm));
+        tensorType, encodingInfo.innerTileSizes, encodingInfo.innerDimsPos,
+        encodingInfo.outerDimsPerm));
 
     // There is no swizzle, we are already done. Typically the case on CPU.
     if (!encodingInfo.swizzle) {

--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.h
@@ -42,7 +42,7 @@ public:
     return layoutAttr;
   }
 
-  FailureOr<IREE::Codegen::MaterializeEncodingInfo>
+  IREE::Codegen::MaterializeEncodingInfo
   getEncodingInfo(RankedTensorType type) const {
     return layoutAttr.getEncodingInfo(type);
   }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUMaterializeEncoding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUMaterializeEncoding.cpp
@@ -108,13 +108,9 @@ struct GPUSetEncodingOpLoweringConversion
       return success();
     }
 
-    FailureOr<MaterializeEncodingInfo> maybeEncodingInfo =
+    MaterializeEncodingInfo encodingInfo =
         converter->getEncodingInfo(encodingOp.getResultType());
-    if (failed(maybeEncodingInfo)) {
-      return rewriter.notifyMatchFailure(encodingOp,
-                                         "unhandled result encoding");
-    }
-    if (!maybeEncodingInfo->swizzle) {
+    if (!encodingInfo.swizzle) {
       rewriter.replaceOp(encodingOp, packedValue.value());
       return success();
     }
@@ -128,18 +124,18 @@ struct GPUSetEncodingOpLoweringConversion
             .getShape()
             .take_front(origRank));
     expandShapeShape.append(
-        getExpandedTileShape(maybeEncodingInfo->swizzle->expandShape));
+        getExpandedTileShape(encodingInfo.swizzle->expandShape));
     RankedTensorType expandShapeType =
         encodingOp.getSourceType().clone(expandShapeShape);
 
-    SmallVector<ReassociationIndices> reassociation = getReassociationIndices(
-        origRank, maybeEncodingInfo->swizzle->expandShape);
+    SmallVector<ReassociationIndices> reassociation =
+        getReassociationIndices(origRank, encodingInfo.swizzle->expandShape);
     auto expandShapeOp = rewriter.create<tensor::ExpandShapeOp>(
         loc, expandShapeType, packedValue.value(), reassociation);
 
     SmallVector<int64_t> transposePerm =
         llvm::to_vector(llvm::seq<int64_t>(0, origRank));
-    for (auto perm : maybeEncodingInfo->swizzle->permutation) {
+    for (auto perm : encodingInfo.swizzle->permutation) {
       transposePerm.push_back(origRank + perm);
     }
     SmallVector<OpFoldResult> transposeResultDims =
@@ -168,9 +164,9 @@ struct GPUUnsetEncodingOpLoweringConversion
     auto converter = static_cast<const MaterializeEncodingTypeConverter *>(
         getTypeConverter());
 
-    FailureOr<MaterializeEncodingInfo> maybeEncodingInfo =
+    MaterializeEncodingInfo encodingInfo =
         converter->getEncodingInfo(unsetEncodingOp.getSource().getType());
-    if (failed(maybeEncodingInfo)) {
+    if (IREE::Codegen::isIdentityLayout(encodingInfo)) {
       Type targetType =
           getTypeConverter()->convertType(unsetEncodingOp.getSourceType());
       Value result = rewriter.createOrFold<tensor::CastOp>(
@@ -181,15 +177,14 @@ struct GPUUnsetEncodingOpLoweringConversion
 
     Location loc = unsetEncodingOp.getLoc();
     Value unpackSrc = adaptor.getSource();
-    if (maybeEncodingInfo->swizzle) {
+    if (encodingInfo.swizzle) {
       int targetRank = unsetEncodingOp.getResultType().getRank();
       auto srcConvertedType =
           cast<RankedTensorType>(adaptor.getSource().getType());
       SmallVector<OpFoldResult> emptyShape =
           tensor::getMixedSizes(rewriter, loc, adaptor.getSource());
       emptyShape.resize(targetRank);
-      for (auto i :
-           getExpandedTileShape(maybeEncodingInfo->swizzle->expandShape)) {
+      for (auto i : getExpandedTileShape(encodingInfo.swizzle->expandShape)) {
         emptyShape.push_back(rewriter.getIndexAttr(i));
       }
       auto emptyTensor = rewriter.create<tensor::EmptyOp>(
@@ -197,7 +192,7 @@ struct GPUUnsetEncodingOpLoweringConversion
 
       SmallVector<int64_t> transposePerm =
           llvm::to_vector(llvm::seq<int64_t>(0, targetRank));
-      for (auto perm : maybeEncodingInfo->swizzle->permutation) {
+      for (auto perm : encodingInfo.swizzle->permutation) {
         transposePerm.push_back(targetRank + perm);
       }
       auto invertedTransposePerm = invertPermutationVector(transposePerm);
@@ -205,11 +200,11 @@ struct GPUUnsetEncodingOpLoweringConversion
           loc, adaptor.getSource(), emptyTensor, invertedTransposePerm);
 
       SmallVector<ReassociationIndices> reassociation = getReassociationIndices(
-          targetRank, maybeEncodingInfo->swizzle->expandShape);
+          targetRank, encodingInfo.swizzle->expandShape);
       SmallVector<int64_t> unpackSrcShape(
           srcConvertedType.getShape().take_front(targetRank));
-      unpackSrcShape.append(maybeEncodingInfo->innerTileSizes.begin(),
-                            maybeEncodingInfo->innerTileSizes.end());
+      unpackSrcShape.append(encodingInfo.innerTileSizes.begin(),
+                            encodingInfo.innerTileSizes.end());
       RankedTensorType unpackSrcType =
           unsetEncodingOp.getResultType().clone(unpackSrcShape);
       unpackSrc = rewriter.create<tensor::CollapseShapeOp>(

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.h
@@ -90,8 +90,5 @@ struct MaterializeEncodingInfo {
   std::optional<TileSwizzle> swizzle;
 };
 
-using ResolveEncodingInfoFn =
-    std::function<FailureOr<MaterializeEncodingInfo>(RankedTensorType type)>;
-
 } // namespace mlir::iree_compiler::IREE::Codegen
 #endif // IREE_COMPILER_CODEGEN_DIALECT_CODEGEN_IR_IREECODEGENTYPES_H_

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.h
@@ -7,6 +7,7 @@
 #ifndef IREE_COMPILER_CODEGEN_DIALECT_CODEGEN_UTILS_H_
 #define IREE_COMPILER_CODEGEN_DIALECT_CODEGEN_UTILS_H_
 
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.h"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingOps.h"
 #include "llvm/Support/raw_ostream.h"
@@ -95,7 +96,7 @@ TileMxNxK chooseMatmulTile(ArrayRef<TileMxNxK> enumeratedTiles,
 FailureOr<Operation *>
 lowerContractionOpWithEncoding(OpBuilder &builder, linalg::LinalgOp linalgOp,
                                ValueRange operands, bool transposeNarrowN,
-                               ResolveEncodingInfoFn getEncodingInfo);
+                               LayoutAttrInterface layoutAttr);
 
 } // namespace mlir::iree_compiler::IREE::Codegen
 

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.h"
 
 #include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
@@ -308,12 +309,9 @@ struct CPUDeviceEncodingLayoutAttrInterface
       return nullptr;
     }
 
-    auto resolver =
-        [&](RankedTensorType type) -> FailureOr<MaterializeEncodingInfo> {
-      return getEncodingInfo(layoutAttr, type);
-    };
     FailureOr<Operation *> newOp = Codegen::lowerContractionOpWithEncoding(
-        b, linalgOp, convertedOperands, /*transposeNarrowN=*/true, resolver);
+        b, linalgOp, convertedOperands, /*transposeNarrowN=*/true,
+        cast<IREE::Codegen::LayoutAttrInterface>(layoutAttr));
     return newOp.value_or(nullptr);
   }
 };
@@ -395,12 +393,9 @@ struct VMVXDeviceEncodingLayoutAttrInterface
       return nullptr;
     }
 
-    auto resolver =
-        [&](RankedTensorType type) -> FailureOr<MaterializeEncodingInfo> {
-      return getEncodingInfo(layoutAttr, type);
-    };
     FailureOr<Operation *> newOp = Codegen::lowerContractionOpWithEncoding(
-        b, linalgOp, convertedOperands, /*transposeNarrowN=*/true, resolver);
+        b, linalgOp, convertedOperands, /*transposeNarrowN=*/true,
+        cast<IREE::Codegen::LayoutAttrInterface>(layoutAttr));
     return newOp.value_or(nullptr);
   }
 };


### PR DESCRIPTION
We are able to use identity MaterializationEncodingInfo to represent the "failure". Thus, we no longer need the `FailureOr` wrapper. The revision removes the wrapper and updates the `lowerContractionOpWithEncoding` function type signature. It does not need to pass a callback function. Instead, we can pass the `IREE::Codegen::LayoutAttrInterface` which has the method to query the materialization information.