### PR TITLE
Post to Discord on failures in more workflows.

### DIFF
--- a/.github/workflows/ci_linux_arm64_clang.yml
+++ b/.github/workflows/ci_linux_arm64_clang.yml
@@ -24,11 +24,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  setup:
-    uses: ./.github/workflows/setup.yml
-
   linux_arm64_clang:
-    needs: setup
     # See https://gitlab.arm.com/tooling/gha-runner-docs
     runs-on: ah-ubuntu_22_04-c7g_4x-50
     container:
@@ -71,3 +67,11 @@ jobs:
         run: ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
       - name: Test iree-dialects
         run: ./build_tools/cmake/test_iree_dialects.sh "${BUILD_DIR}"
+
+      - name: Post to Discord on Failure
+        uses: sarisia/actions-status-discord@ce8cc68e4e626000136b3c702d049a154243e490 # v1.14.7
+        if: failure() && github.ref_name == 'main' && github.repository_owner == 'iree-org'
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          description: "The ${{ github.workflow }} workflow failed"
+          url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"

--- a/.github/workflows/ci_linux_x64_bazel.yml
+++ b/.github/workflows/ci_linux_x64_bazel.yml
@@ -53,3 +53,11 @@ jobs:
           cp ./build_tools/scripts/fetch_cuda_deps.sh /usr/local/bin
           /usr/local/bin/fetch_cuda_deps.sh ${IREE_CUDA_DEPS_DIR}
           ./build_tools/bazel/build_test_all.sh
+
+      - name: Post to Discord on Failure
+        uses: sarisia/actions-status-discord@ce8cc68e4e626000136b3c702d049a154243e490 # v1.14.7
+        if: failure() && github.ref_name == 'main' && github.repository_owner == 'iree-org'
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          description: "The ${{ github.workflow }} workflow failed"
+          url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"

--- a/.github/workflows/ci_linux_x64_clang.yml
+++ b/.github/workflows/ci_linux_x64_clang.yml
@@ -70,3 +70,11 @@ jobs:
         run: ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
       - name: Test iree-dialects
         run: ./build_tools/cmake/test_iree_dialects.sh "${BUILD_DIR}"
+
+      - name: Post to Discord on Failure
+        uses: sarisia/actions-status-discord@ce8cc68e4e626000136b3c702d049a154243e490 # v1.14.7
+        if: failure() && github.ref_name == 'main' && github.repository_owner == 'iree-org'
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          description: "The ${{ github.workflow }} workflow failed"
+          url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"

--- a/.github/workflows/ci_linux_x64_clang_asan.yml
+++ b/.github/workflows/ci_linux_x64_clang_asan.yml
@@ -53,3 +53,11 @@ jobs:
           source build_tools/cmake/setup_sccache.sh
           ./build_tools/cmake/build_and_test_asan.sh
           sccache --show-stats
+
+      - name: Post to Discord on Failure
+        uses: sarisia/actions-status-discord@ce8cc68e4e626000136b3c702d049a154243e490 # v1.14.7
+        if: failure() && github.ref_name == 'main' && github.repository_owner == 'iree-org'
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          description: "The ${{ github.workflow }} workflow failed"
+          url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"

--- a/.github/workflows/ci_linux_x64_clang_byollvm.yml
+++ b/.github/workflows/ci_linux_x64_clang_byollvm.yml
@@ -37,3 +37,11 @@ jobs:
           submodules: true
       - name: "Building and testing with bring-your-own-LLVM"
         run: ./build_tools/cmake/build_and_test_byo_llvm.sh
+
+      - name: Post to Discord on Failure
+        uses: sarisia/actions-status-discord@ce8cc68e4e626000136b3c702d049a154243e490 # v1.14.7
+        if: failure() && github.ref_name == 'main' && github.repository_owner == 'iree-org'
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          description: "The ${{ github.workflow }} workflow failed"
+          url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"

--- a/.github/workflows/ci_linux_x64_clang_debug.yml
+++ b/.github/workflows/ci_linux_x64_clang_debug.yml
@@ -24,13 +24,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  setup:
-    uses: ./.github/workflows/setup.yml
-
   # This may run out of memory / disk space on standard GitHub-hosted runners,
   # so run on self-hosted CPU build runners instead.
   linux_x64_clang_debug:
-    needs: setup
     runs-on: azure-linux-scale
     container: ghcr.io/iree-org/cpubuilder_ubuntu_jammy@sha256:78a558b999b230f7e1da376639e14b44f095f30f1777d6a272ba48c0bbdd4ccb
     defaults:
@@ -67,3 +63,11 @@ jobs:
       # We could build `iree-test-deps` or run some unit tests here, but the
       # main thing we want coverage for is the build itself and those steps
       # would add 10+ minutes to the job.
+
+      - name: Post to Discord on Failure
+        uses: sarisia/actions-status-discord@ce8cc68e4e626000136b3c702d049a154243e490 # v1.14.7
+        if: failure() && github.ref_name == 'main' && github.repository_owner == 'iree-org'
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          description: "The ${{ github.workflow }} workflow failed"
+          url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"

--- a/.github/workflows/ci_linux_x64_clang_tsan.yml
+++ b/.github/workflows/ci_linux_x64_clang_tsan.yml
@@ -61,3 +61,11 @@ jobs:
           source build_tools/cmake/setup_sccache.sh
           ./build_tools/cmake/build_and_test_tsan.sh
           sccache --show-stats
+
+      - name: Post to Discord on Failure
+        uses: sarisia/actions-status-discord@ce8cc68e4e626000136b3c702d049a154243e490 # v1.14.7
+        if: failure() && github.ref_name == 'main' && github.repository_owner == 'iree-org'
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          description: "The ${{ github.workflow }} workflow failed"
+          url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"

--- a/.github/workflows/ci_linux_x64_gcc.yml
+++ b/.github/workflows/ci_linux_x64_gcc.yml
@@ -45,3 +45,11 @@ jobs:
           IREE_TARGET_BACKEND_WEBGPU_SPIRV: OFF
           IREE_BUILD_SETUP_PYTHON_VENV: ${{ env.BUILD_DIR }}/.venv
         run: ./build_tools/cmake/build_all.sh "${BUILD_DIR}"
+
+      - name: Post to Discord on Failure
+        uses: sarisia/actions-status-discord@ce8cc68e4e626000136b3c702d049a154243e490 # v1.14.7
+        if: failure() && github.ref_name == 'main' && github.repository_owner == 'iree-org'
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          description: "The ${{ github.workflow }} workflow failed"
+          url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"

--- a/.github/workflows/ci_macos_x64_clang.yml
+++ b/.github/workflows/ci_macos_x64_clang.yml
@@ -56,3 +56,11 @@ jobs:
         run: bash ./build_tools/cmake/build_all.sh "${BUILD_DIR}"
       - name: "Testing IREE"
         run: bash ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
+
+      - name: Post to Discord on Failure
+        uses: sarisia/actions-status-discord@ce8cc68e4e626000136b3c702d049a154243e490 # v1.14.7
+        if: failure() && github.ref_name == 'main' && github.repository_owner == 'iree-org'
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          description: "The ${{ github.workflow }} workflow failed"
+          url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"

--- a/.github/workflows/ci_windows_x64_msvc.yml
+++ b/.github/workflows/ci_windows_x64_msvc.yml
@@ -72,3 +72,11 @@ jobs:
       - name: "Clean up build dir"
         if: always()
         run: if (Test-Path -Path "$Env:BUILD_DIR_POWERSHELL") {Remove-Item -Path "$Env:BUILD_DIR_POWERSHELL" -Recurse -Force}
+
+      - name: Post to Discord on Failure
+        uses: sarisia/actions-status-discord@ce8cc68e4e626000136b3c702d049a154243e490 # v1.14.7
+        if: failure() && github.ref_name == 'main' && github.repository_owner == 'iree-org'
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          description: "The ${{ github.workflow }} workflow failed"
+          url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}"

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -3,8 +3,8 @@
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-#
-# Workflow for running Examples of IREE usage against releases periodically.
+
+# Workflow for running in-tree samples against releases periodically.
 
 name: samples
 
@@ -100,3 +100,15 @@ jobs:
         run: |
           source ${VENV_DIR}/bin/activate
           ./experimental/web/build_and_test_samples.sh ${HOST_TOOLS_BINARY_DIR}
+
+  # Aggregate job status and alerting on failures.
+  samples_summary:
+    if: always()
+    needs:
+      - colab
+      - samples
+      - web
+    uses: ./.github/workflows/workflow_summary.yml
+    secrets: inherit
+    with:
+      jobs-json: ${{ toJson(needs) }}

--- a/.github/workflows/workflow_summary.yml
+++ b/.github/workflows/workflow_summary.yml
@@ -54,7 +54,7 @@ jobs:
             echo "The following jobs failed: ${FAILED_JOBS}"
             exit 1
           fi
-      - name: Posting to Discord
+      - name: Post to Discord on Failure
         uses: sarisia/actions-status-discord@ce8cc68e4e626000136b3c702d049a154243e490 # v1.14.7
         if: failure() && github.ref_name == 'main' && github.repository_owner == 'iree-org'
         with:


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree/issues/9305.

See also https://github.com/iree-org/iree/pull/19445, which triggers the presubmit workflows (`linux_x64_bazel`, `linux_x64_clang`, `linux_x64_clang_asan`) from `ci.yml`, removing the need to add alerting code to those files. If that PR lands, the changes in those workflows can be merged with these other changes.