### PR TITLE
Cleanup `ConvertToStream` to accomodate  llvm/llvm-project@3f136f7

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
@@ -44,9 +44,9 @@ static Value buildResultSizeOf(Location loc, Value tensorValue,
 }
 
 struct ConvertTensorConstantOp
-    : public AffinityOneToNOpConversionPattern<IREE::Flow::TensorConstantOp> {
+    : public AffinityOpConversionPattern<IREE::Flow::TensorConstantOp> {
 public:
-  using AffinityOneToNOpConversionPattern::AffinityOneToNOpConversionPattern;
+  using AffinityOpConversionPattern::AffinityOpConversionPattern;
   LogicalResult matchAndRewriteOnAffinity(
       IREE::Flow::TensorConstantOp constantOp, OneToNOpAdaptor adaptor,
       IREE::Stream::AffinityAttr executionAffinityAttr,
@@ -76,10 +76,9 @@ public:
 };
 
 struct ConvertTensorDynamicConstantOp
-    : public AffinityOneToNOpConversionPattern<
-          IREE::Flow::TensorDynamicConstantOp> {
+    : public AffinityOpConversionPattern<IREE::Flow::TensorDynamicConstantOp> {
 public:
-  using AffinityOneToNOpConversionPattern::AffinityOneToNOpConversionPattern;
+  using AffinityOpConversionPattern::AffinityOpConversionPattern;
   LogicalResult matchAndRewriteOnAffinity(
       IREE::Flow::TensorDynamicConstantOp constantOp, OneToNOpAdaptor adaptor,
       IREE::Stream::AffinityAttr executionAffinityAttr,
@@ -160,8 +159,8 @@ struct ConvertTensorCastLikeOp
 };
 
 struct ConvertTensorAllocaOp
-    : public AffinityOneToNOpConversionPattern<IREE::Flow::TensorAllocaOp> {
-  using AffinityOneToNOpConversionPattern::AffinityOneToNOpConversionPattern;
+    : public AffinityOpConversionPattern<IREE::Flow::TensorAllocaOp> {
+  using AffinityOpConversionPattern::AffinityOpConversionPattern;
   LogicalResult matchAndRewriteOnAffinity(
       IREE::Flow::TensorAllocaOp op, OneToNOpAdaptor adaptor,
       IREE::Stream::AffinityAttr executionAffinityAttr,
@@ -178,8 +177,8 @@ struct ConvertTensorAllocaOp
 };
 
 struct ConvertTensorEmptyOp
-    : public AffinityOneToNOpConversionPattern<IREE::Flow::TensorEmptyOp> {
-  using AffinityOneToNOpConversionPattern::AffinityOneToNOpConversionPattern;
+    : public AffinityOpConversionPattern<IREE::Flow::TensorEmptyOp> {
+  using AffinityOpConversionPattern::AffinityOpConversionPattern;
   LogicalResult matchAndRewriteOnAffinity(
       IREE::Flow::TensorEmptyOp op, OneToNOpAdaptor adaptor,
       IREE::Stream::AffinityAttr executionAffinityAttr,
@@ -198,8 +197,8 @@ struct ConvertTensorEmptyOp
 };
 
 struct ConvertTensorSplatOp
-    : public AffinityOneToNOpConversionPattern<IREE::Flow::TensorSplatOp> {
-  using AffinityOneToNOpConversionPattern::AffinityOneToNOpConversionPattern;
+    : public AffinityOpConversionPattern<IREE::Flow::TensorSplatOp> {
+  using AffinityOpConversionPattern::AffinityOpConversionPattern;
   LogicalResult matchAndRewriteOnAffinity(
       IREE::Flow::TensorSplatOp op, OneToNOpAdaptor adaptor,
       IREE::Stream::AffinityAttr executionAffinityAttr,
@@ -218,8 +217,8 @@ struct ConvertTensorSplatOp
 };
 
 struct ConvertTensorCloneOp
-    : public AffinityOneToNOpConversionPattern<IREE::Flow::TensorCloneOp> {
-  using AffinityOneToNOpConversionPattern::AffinityOneToNOpConversionPattern;
+    : public AffinityOpConversionPattern<IREE::Flow::TensorCloneOp> {
+  using AffinityOpConversionPattern::AffinityOpConversionPattern;
   LogicalResult matchAndRewriteOnAffinity(
       IREE::Flow::TensorCloneOp op, OneToNOpAdaptor adaptor,
       IREE::Stream::AffinityAttr executionAffinityAttr,
@@ -239,8 +238,8 @@ struct ConvertTensorCloneOp
 };
 
 struct ConvertTensorTransferOp
-    : public AffinityOneToNOpConversionPattern<IREE::Flow::TensorTransferOp> {
-  using AffinityOneToNOpConversionPattern::AffinityOneToNOpConversionPattern;
+    : public AffinityOpConversionPattern<IREE::Flow::TensorTransferOp> {
+  using AffinityOpConversionPattern::AffinityOpConversionPattern;
   LogicalResult matchAndRewriteOnAffinity(
       IREE::Flow::TensorTransferOp op, OneToNOpAdaptor adaptor,
       IREE::Stream::AffinityAttr executionAffinityAttr,
@@ -262,8 +261,8 @@ struct ConvertTensorTransferOp
 };
 
 struct ConvertTensorSliceOp
-    : public AffinityOneToNOpConversionPattern<IREE::Flow::TensorSliceOp> {
-  using AffinityOneToNOpConversionPattern::AffinityOneToNOpConversionPattern;
+    : public AffinityOpConversionPattern<IREE::Flow::TensorSliceOp> {
+  using AffinityOpConversionPattern::AffinityOpConversionPattern;
   LogicalResult matchAndRewriteOnAffinity(
       IREE::Flow::TensorSliceOp op, OneToNOpAdaptor adaptor,
       IREE::Stream::AffinityAttr executionAffinityAttr,
@@ -288,8 +287,8 @@ struct ConvertTensorSliceOp
 };
 
 struct ConvertTensorUpdateOp
-    : public AffinityOneToNOpConversionPattern<IREE::Flow::TensorUpdateOp> {
-  using AffinityOneToNOpConversionPattern::AffinityOneToNOpConversionPattern;
+    : public AffinityOpConversionPattern<IREE::Flow::TensorUpdateOp> {
+  using AffinityOpConversionPattern::AffinityOpConversionPattern;
   LogicalResult matchAndRewriteOnAffinity(
       IREE::Flow::TensorUpdateOp op, OneToNOpAdaptor adaptor,
       IREE::Stream::AffinityAttr executionAffinityAttr,
@@ -477,8 +476,8 @@ struct ConvertTensorTraceOp
 };
 
 struct ConvertChannelDefaultOp
-    : public AffinityOneToNOpConversionPattern<IREE::Flow::ChannelDefaultOp> {
-  using AffinityOneToNOpConversionPattern::AffinityOneToNOpConversionPattern;
+    : public AffinityOpConversionPattern<IREE::Flow::ChannelDefaultOp> {
+  using AffinityOpConversionPattern::AffinityOpConversionPattern;
   LogicalResult matchAndRewriteOnAffinity(
       IREE::Flow::ChannelDefaultOp op, OneToNOpAdaptor adaptor,
       IREE::Stream::AffinityAttr executionAffinityAttr,
@@ -529,9 +528,9 @@ struct ConvertChannelCountOp
   }
 };
 
-struct ConvertAllGatherOp : public AffinityOneToNOpConversionPattern<
-                                IREE::Flow::CollectiveAllGatherOp> {
-  using AffinityOneToNOpConversionPattern::AffinityOneToNOpConversionPattern;
+struct ConvertAllGatherOp
+    : public AffinityOpConversionPattern<IREE::Flow::CollectiveAllGatherOp> {
+  using AffinityOpConversionPattern::AffinityOpConversionPattern;
   LogicalResult matchAndRewriteOnAffinity(
       IREE::Flow::CollectiveAllGatherOp op, OneToNOpAdaptor adaptor,
       IREE::Stream::AffinityAttr executionAffinityAttr,
@@ -572,9 +571,9 @@ struct ConvertAllGatherOp : public AffinityOneToNOpConversionPattern<
   }
 };
 
-struct ConvertAllReduceOp : public AffinityOneToNOpConversionPattern<
-                                IREE::Flow::CollectiveAllReduceOp> {
-  using AffinityOneToNOpConversionPattern::AffinityOneToNOpConversionPattern;
+struct ConvertAllReduceOp
+    : public AffinityOpConversionPattern<IREE::Flow::CollectiveAllReduceOp> {
+  using AffinityOpConversionPattern::AffinityOpConversionPattern;
   LogicalResult matchAndRewriteOnAffinity(
       IREE::Flow::CollectiveAllReduceOp op, OneToNOpAdaptor adaptor,
       IREE::Stream::AffinityAttr executionAffinityAttr,
@@ -615,9 +614,9 @@ struct ConvertAllReduceOp : public AffinityOneToNOpConversionPattern<
   }
 };
 
-struct ConvertAllToAllOp : public AffinityOneToNOpConversionPattern<
-                               IREE::Flow::CollectiveAllToAllOp> {
-  using AffinityOneToNOpConversionPattern::AffinityOneToNOpConversionPattern;
+struct ConvertAllToAllOp
+    : public AffinityOpConversionPattern<IREE::Flow::CollectiveAllToAllOp> {
+  using AffinityOpConversionPattern::AffinityOpConversionPattern;
   LogicalResult matchAndRewriteOnAffinity(
       IREE::Flow::CollectiveAllToAllOp op, OneToNOpAdaptor adaptor,
       IREE::Stream::AffinityAttr executionAffinityAttr,
@@ -658,9 +657,9 @@ struct ConvertAllToAllOp : public AffinityOneToNOpConversionPattern<
   }
 };
 
-struct ConvertReduceScatterOp : public AffinityOneToNOpConversionPattern<
+struct ConvertReduceScatterOp : public AffinityOpConversionPattern<
                                     IREE::Flow::CollectiveReduceScatterOp> {
-  using AffinityOneToNOpConversionPattern::AffinityOneToNOpConversionPattern;
+  using AffinityOpConversionPattern::AffinityOpConversionPattern;
   LogicalResult matchAndRewriteOnAffinity(
       IREE::Flow::CollectiveReduceScatterOp op, OneToNOpAdaptor adaptor,
       IREE::Stream::AffinityAttr executionAffinityAttr,
@@ -701,9 +700,9 @@ struct ConvertReduceScatterOp : public AffinityOneToNOpConversionPattern<
   }
 };
 
-struct ConvertCollectiveSendRecvOp : public AffinityOneToNOpConversionPattern<
-                                         IREE::Flow::CollectiveSendRecvOp> {
-  using AffinityOneToNOpConversionPattern::AffinityOneToNOpConversionPattern;
+struct ConvertCollectiveSendRecvOp
+    : public AffinityOpConversionPattern<IREE::Flow::CollectiveSendRecvOp> {
+  using AffinityOpConversionPattern::AffinityOpConversionPattern;
   LogicalResult matchAndRewriteOnAffinity(
       IREE::Flow::CollectiveSendRecvOp op, OneToNOpAdaptor adaptor,
       IREE::Stream::AffinityAttr executionAffinityAttr,
@@ -759,8 +758,8 @@ struct ConvertCollectiveSendRecvOp : public AffinityOneToNOpConversionPattern<
 };
 
 struct ConvertDispatchOp
-    : public AffinityOneToNOpConversionPattern<IREE::Flow::DispatchOp> {
-  using AffinityOneToNOpConversionPattern::AffinityOneToNOpConversionPattern;
+    : public AffinityOpConversionPattern<IREE::Flow::DispatchOp> {
+  using AffinityOpConversionPattern::AffinityOpConversionPattern;
   LogicalResult matchAndRewriteOnAffinity(
       IREE::Flow::DispatchOp op, OneToNOpAdaptor adaptor,
       IREE::Stream::AffinityAttr executionAffinityAttr,
@@ -874,9 +873,8 @@ struct ConvertFuncOp : public OpConversionPattern<IREE::Flow::FuncOp> {
   }
 };
 
-struct ConvertCallOp
-    : public AffinityOneToNOpConversionPattern<IREE::Flow::CallOp> {
-  using AffinityOneToNOpConversionPattern::AffinityOneToNOpConversionPattern;
+struct ConvertCallOp : public AffinityOpConversionPattern<IREE::Flow::CallOp> {
+  using AffinityOpConversionPattern::AffinityOpConversionPattern;
   LogicalResult matchAndRewriteOnAffinity(
       IREE::Flow::CallOp op, OneToNOpAdaptor adaptor,
       IREE::Stream::AffinityAttr executionAffinityAttr,

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/Patterns.cpp
@@ -83,10 +83,11 @@ struct ConvertTensorImportOp
     }
 
     auto unknownType = rewriter.getType<IREE::Stream::ResourceType>();
-    rewriter.replaceOpWithNewOp<IREE::Stream::AsyncTransferOp>(
-        op, unknownType, resource, resultSize, resultSize,
+    Value newImport = rewriter.create<IREE::Stream::AsyncTransferOp>(
+        op.getLoc(), unknownType, resource, resultSize, resultSize,
         /*source_affinity=*/executionAffinityAttr,
         /*target_affinity=*/executionAffinityAttr);
+    rewriter.replaceOpWithMultiple(op, {{newImport, resultSize}});
     return success();
   }
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/PatternUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/PatternUtils.cpp
@@ -120,4 +120,21 @@ ConvertedTensor transferTensorOperand(
   return {requiredAffinityAttr, resource, resourceSize};
 }
 
+Value getStreamResourceFromOneToNOpOperandAdaptor(ValueRange values) {
+  assert(values.size() >= 1 &&
+         "expected ValueRange from adaptor to have two entries");
+  if (auto castOp =
+          values.front().getDefiningOp<UnrealizedConversionCastOp>()) {
+    return castOp->getOperand(0);
+  }
+  return values.front();
+}
+
+SmallVector<Value>
+getStreamResourcesFromOneToNOpOperandAdaptors(ArrayRef<ValueRange> values) {
+  return llvm::map_to_vector(values, [](ValueRange r) -> Value {
+    return getStreamResourceFromOneToNOpOperandAdaptor(r);
+  });
+}
+
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/PatternUtils.h
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/PatternUtils.h
@@ -57,6 +57,15 @@ ConvertedTensor transferTensorOperand(
     IREE::Stream::AffinityAttr requiredAffinityAttr,
     IREE::Stream::AffinityAnalysis *affinityAnalysis, OpBuilder &builder);
 
+ConvertedTensor resolveTensorOperands(
+    Location loc, Value originalOperand, ValueRange convertedOperand,
+    IREE::Stream::AffinityAnalysis *affinityAnalysis, OpBuilder &builder);
+ConvertedTensor transferTensorOperands(
+    Location loc, Value originalOperand, ValueRange convertedOperand,
+    IREE::Stream::AffinityAttr requiredAffinityAttr,
+    IREE::Stream::AffinityAnalysis *affinityAnalysis, OpBuilder &builder);
+
+
 template <typename OpT>
 struct AffinityAwareConversionPattern : public OpConversionPattern<OpT> {
 public:
@@ -78,6 +87,12 @@ protected:
     return mlir::iree_compiler::resolveTensorOperand(
         loc, originalOperand, convertedOperand, affinityAnalysis, builder);
   }
+  ConvertedTensor resolveTensorOperands(Location loc, Value originalOperand,
+                                       ValueRange convertedOperand,
+                                       OpBuilder &builder) const {
+    return mlir::iree_compiler::resolveTensorOperands(
+        loc, originalOperand, convertedOperand, affinityAnalysis, builder);
+  }
 
   ConvertedTensor
   transferTensorOperand(Location loc, Value originalOperand,
@@ -85,6 +100,16 @@ protected:
                         IREE::Stream::AffinityAttr requiredAffinityAttr,
                         OpBuilder &builder) const {
     return mlir::iree_compiler::transferTensorOperand(
+        loc, originalOperand, convertedOperand, requiredAffinityAttr,
+        affinityAnalysis, builder);
+  }
+
+  ConvertedTensor
+  transferTensorOperands(Location loc, Value originalOperand,
+                        ValueRange convertedOperand,
+                        IREE::Stream::AffinityAttr requiredAffinityAttr,
+                        OpBuilder &builder) const {
+    return mlir::iree_compiler::transferTensorOperands(
         loc, originalOperand, convertedOperand, requiredAffinityAttr,
         affinityAnalysis, builder);
   }

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/PatternUtils.h
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/PatternUtils.h
@@ -103,41 +103,6 @@ public:
 
 protected:
   virtual LogicalResult matchAndRewriteOnAffinity(
-      OpT op, typename OpConversionPattern<OpT>::OpAdaptor adaptor,
-      IREE::Stream::AffinityAttr executionAffinityAttr,
-      ConversionPatternRewriter &rewriter) const = 0;
-
-private:
-  LogicalResult
-  matchAndRewrite(OpT op, typename OpConversionPattern<OpT>::OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override final {
-    auto executionAffinityAttr =
-        tryLookupExecutionAffinity(op, this->getAffinityAnalysis());
-    return matchAndRewriteOnAffinity(op, adaptor, executionAffinityAttr,
-                                     rewriter);
-  }
-};
-
-void replaceOpWithMultiple(Operation *op,
-                           ArrayRef<SmallVector<Value>> replacements,
-                           ConversionPatternRewriter &rewriter);
-void replaceOpWithMultiple(Operation *op, ValueRange resources,
-                           ValueRange sizes,
-                           ConversionPatternRewriter &rewriter);
-
-template <typename OpT>
-struct AffinityOneToNOpConversionPattern
-    : public AffinityAwareConversionPattern<OpT> {
-public:
-  AffinityOneToNOpConversionPattern(
-      const TypeConverter &typeConverter, MLIRContext *context,
-      IREE::Stream::AffinityAnalysis *affinityAnalysis,
-      PatternBenefit benefit = 1)
-      : AffinityAwareConversionPattern<OpT>(typeConverter, context,
-                                            affinityAnalysis, benefit) {}
-
-protected:
-  virtual LogicalResult matchAndRewriteOnAffinity(
       OpT op, typename OpConversionPattern<OpT>::OneToNOpAdaptor adaptor,
       IREE::Stream::AffinityAttr executionAffinityAttr,
       ConversionPatternRewriter &rewriter) const = 0;
@@ -153,6 +118,13 @@ private:
                                      rewriter);
   }
 };
+
+void replaceOpWithMultiple(Operation *op,
+                           ArrayRef<SmallVector<Value>> replacements,
+                           ConversionPatternRewriter &rewriter);
+void replaceOpWithMultiple(Operation *op, ValueRange resources,
+                           ValueRange sizes,
+                           ConversionPatternRewriter &rewriter);
 
 } // namespace mlir::iree_compiler
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/Patterns.cpp
@@ -143,9 +143,8 @@ struct SelectOpConversion
     auto sizeSelectOp = rewriter.create<mlir::arith::SelectOp>(
         op.getLoc(), adaptor.getCondition().front(), trueOperand.resourceSize,
         falseOperand.resourceSize);
-    rewriter.replaceOpWithNewOp<mlir::UnrealizedConversionCastOp>(
-        op, convertedTrueValue.getType(),
-        ValueRange{resourceSelectOp.getResult(), sizeSelectOp.getResult()});
+    rewriter.replaceOpWithMultiple(op, {ValueRange{resourceSelectOp.getResult(),
+                                                   sizeSelectOp.getResult()}});
     return success();
   }
 };

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/Patterns.cpp
@@ -38,8 +38,8 @@ static SmallVector<Value> flattenValues(ArrayRef<ValueRange> values) {
 }
 
 struct ConvertTensorConstantOp
-    : public AffinityOneToNOpConversionPattern<arith::ConstantOp> {
-  using AffinityOneToNOpConversionPattern::AffinityOneToNOpConversionPattern;
+    : public AffinityOpConversionPattern<arith::ConstantOp> {
+  using AffinityOpConversionPattern::AffinityOpConversionPattern;
   LogicalResult matchAndRewriteOnAffinity(
       arith::ConstantOp constantOp, OneToNOpAdaptor adaptor,
       IREE::Stream::AffinityAttr executionAffinityAttr,

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/Patterns.cpp
@@ -38,10 +38,10 @@ static SmallVector<Value> flattenValues(ArrayRef<ValueRange> values) {
 }
 
 struct ConvertTensorConstantOp
-    : public AffinityOpConversionPattern<arith::ConstantOp> {
-  using AffinityOpConversionPattern::AffinityOpConversionPattern;
+    : public AffinityOneToNOpConversionPattern<arith::ConstantOp> {
+  using AffinityOneToNOpConversionPattern::AffinityOneToNOpConversionPattern;
   LogicalResult matchAndRewriteOnAffinity(
-      arith::ConstantOp constantOp, OpAdaptor adaptor,
+      arith::ConstantOp constantOp, OneToNOpAdaptor adaptor,
       IREE::Stream::AffinityAttr executionAffinityAttr,
       ConversionPatternRewriter &rewriter) const override {
     // Only handle tensor types - other arith.constant types (like i32) are

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/Patterns.cpp
@@ -114,7 +114,6 @@ struct CallOpConversion
     SmallVector<Value> resourceSizes;
     for (auto result : resultMap) {
       if (llvm::isa<IREE::Stream::ResourceType>(result.newType)) {
-        auto oldType = op.getResult(result.originalIndex).getType();
         auto resource = callOp.getResult(result.newIndex + 0);
         auto resourceSize = callOp.getResult(result.newIndex + 1);
         results.push_back(resource);

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/test/compiler_hints.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/test/compiler_hints.mlir
@@ -3,9 +3,9 @@
 // CHECK-LABEL: @optimizationBarrier
 util.func public @optimizationBarrier(%arg0: tensor<i32>) -> tensor<i32> {
   // CHECK-SAME: %[[ARG0:.+]]: !stream.resource<*>
+  // CHECK-SAME: %[[ARG1:.+]]: index
   // CHECK: %[[RESOURCE:.*]] = util.optimization_barrier %[[ARG0]]
-  // CHECK: %[[SIZE:.*]] = stream.resource.size %[[RESOURCE]] : !stream.resource<*>
-  // CHECK: util.return %[[RESOURCE]], %[[SIZE]] : !stream.resource<*>, index
+  // CHECK: util.return %[[RESOURCE]], %[[ARG1]] : !stream.resource<*>, index
   %0 = util.optimization_barrier %arg0 : tensor<i32>
   util.return %0 : tensor<i32>
 }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/convert_to_stream.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/convert_to_stream.mlir
@@ -130,8 +130,7 @@ util.func public @while_test() {
   // CHECK: %[[INITIAL_DNO:.+]] = util.optimization_barrier %[[INITIAL]] : !stream.resource<*>
   %0 = util.optimization_barrier %cst : tensor<i32>
 
-  // CHECK: %[[VAR_SIZE:.+]] = stream.resource.size %[[INITIAL_DNO]] : !stream.resource<*>
-  // CHECK: cf.br ^bb1(%[[INITIAL_DNO]], %[[VAR_SIZE]] : !stream.resource<*>, index)
+  // CHECK: cf.br ^bb1(%[[INITIAL_DNO]], %[[CONSTANT_SIZE]] : !stream.resource<*>, index)
   cf.br ^bb1(%0 : tensor<i32>)
 
 // CHECK: ^bb1(%[[BB1_ARG:.+]]: !stream.resource<*>, %[[BB1_ARG_SIZE:.+]]: index):


### PR DESCRIPTION
The upstream change https://github.com/llvm/llvm-project/commit/3f136f7 allows `ConvertToStream` to better handle the 1:N type conversion, specifically the type conversion of a `tensor<...>` to `!stream.resource<*>, index`. Now instead of trying to work around `builtin.unrealized_conversion_cast`s the conversion can get the converted values directly using the `OneToNAdaptor` and can also replace a `tensor<..>` directly with multiple values using the `ConversionPatternRewriter::replaceOpWithMultiple`.

These changes are required to drop the revert of  https://github.com/llvm/llvm-project/pull/116470 in the IREE ToM. The change drops these reverts as well.

Fixes #19448