### PR TITLE
Harmonize scripts to compute versions

### DIFF
--- a/build_tools/python_deploy/compute_common_version.py
+++ b/build_tools/python_deploy/compute_common_version.py
@@ -8,6 +8,9 @@
 # This scripts grabs the X.Y.Z[.dev]` version identifier from the
 # compiler's and runtime's `version.json` files and computes the
 # shared version.
+#
+# Usage:
+#   ./compute_common_version.py --stable-release
 
 import argparse
 from pathlib import Path
@@ -19,17 +22,20 @@ from packaging.version import Version
 
 
 parser = argparse.ArgumentParser()
-release_type = parser.add_mutually_exclusive_group()
+
+release_type = parser.add_mutually_exclusive_group(required=True)
+release_type.add_argument("-stable", "--stable-release", action="store_true")
 release_type.add_argument("-rc", "--nightly-release", action="store_true")
 release_type.add_argument("-dev", "--development-release", action="store_true")
-release_type.add_argument("--custom-string", action="store", type=str)
+release_type.add_argument("--version-suffix", action="store", type=str)
+
 args = parser.parse_args()
 
 THIS_DIR = Path(__file__).parent.resolve()
 REPO_ROOT = THIS_DIR.parent.parent
 
-VERSION_FILE_COMPILER = REPO_ROOT / "compiler/version.json"
-VERSION_FILE_RUNTIME = REPO_ROOT / "runtime/version.json"
+VERSION_FILE_COMPILER_PATH = REPO_ROOT / "compiler/version.json"
+VERSION_FILE_RUNTIME_PATH = REPO_ROOT / "runtime/version.json"
 
 
 def load_version_info(version_file):
@@ -37,29 +43,27 @@ def load_version_info(version_file):
         return json.load(f)
 
 
-compiler_version = load_version_info(VERSION_FILE_COMPILER)
-COMPILER_PACKAGE_VERSION = compiler_version.get("package-version")
-COMPILER_BASE_VERSION = Version(COMPILER_PACKAGE_VERSION).base_version
+compiler_version = load_version_info(VERSION_FILE_COMPILER_PATH)
+compiler_package_version = compiler_version.get("package-version")
+compiler_base_version = Version(compiler_package_version).base_version
 
-runtime_version = load_version_info(VERSION_FILE_RUNTIME)
-RUNTIME_PACKAGE_VERSION = runtime_version.get("package-version")
-RUNTIME_BASE_VERSION = Version(RUNTIME_PACKAGE_VERSION).base_version
+runtime_version = load_version_info(VERSION_FILE_RUNTIME_PATH)
+runtime_package_version = runtime_version.get("package-version")
+runtime_base_version = Version(runtime_package_version).base_version
 
-if RUNTIME_BASE_VERSION > COMPILER_BASE_VERSION:
-    CURRENT_VERSION = RUNTIME_BASE_VERSION
+if runtime_base_version > compiler_base_version:
+    common_version = runtime_base_version
 else:
-    CURRENT_VERSION = COMPILER_BASE_VERSION
+    common_version = compiler_base_version
 
 if args.nightly_release:
-    CURRENT_VERSION += "rc" + datetime.today().strftime("%Y%m%d")
-
-if args.development_release:
-    CURRENT_VERSION += (
-        ".dev+"
+    common_version += "rc" + datetime.today().strftime("%Y%m%d")
+elif args.development_release:
+    common_version += (
+        ".dev0+"
         + subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("ascii").strip()
     )
+elif args.version_suffix:
+    common_version += args.version_suffix
 
-if args.custom_string:
-    CURRENT_VERSION += args.custom_string
-
-print(CURRENT_VERSION)
+print(common_version)

--- a/build_tools/python_deploy/compute_local_version.py
+++ b/build_tools/python_deploy/compute_local_version.py
@@ -6,14 +6,14 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # This scripts grabs the X.Y.Z[.dev]` version identifier from a
-# `version_info.json` and writes the corresponding
-# `X.Y.ZrcYYYYMMDD` version identifier to `version_rc_info.json`.
+# `version.json` and writes a version identifier for a stable,
+# nightly or development release, or a release with an arbitrary
+# `X.Y.ZrcYYYYMMDD` version identifier to `version_local.json`.
 
 import argparse
 from pathlib import Path
 import json
 from datetime import datetime
-import sys
 import subprocess
 
 from packaging.version import Version
@@ -23,58 +23,44 @@ parser = argparse.ArgumentParser()
 parser.add_argument("path", type=Path)
 parser.add_argument("--write-json", action="store_true")
 
-release_type = parser.add_mutually_exclusive_group()
-release_type.add_argument("-stable", "--stable-release", action="store_true")  # default
+release_type = parser.add_mutually_exclusive_group(required=True)
+release_type.add_argument("-stable", "--stable-release", action="store_true")
 release_type.add_argument("-rc", "--nightly-release", action="store_true")
 release_type.add_argument("-dev", "--development-release", action="store_true")
-release_type.add_argument("--custom-string", action="store", type=str)
+release_type.add_argument("--version-suffix", action="store", type=str)
 
 args = parser.parse_args()
 
-if not (
-    args.stable_release
-    or args.nightly_release
-    or args.development_release
-    or args.custom_string
-):
-    parser.print_usage(sys.stderr)
-    sys.stderr.write("error: A release type or custom string is required\n")
-    sys.exit(1)
-
-VERSION_FILE = args.path / "version.json"
-VERSION_FILE_LOCAL = args.path / "version_local.json"
+VERSION_FILE_PATH = args.path / "version.json"
+VERSION_FILE_LOCAL_PATH = args.path / "version_local.json"
 
 
-def load_version_info():
-    with open(VERSION_FILE, "rt") as f:
+def load_version_info(version_file):
+    with open(version_file, "rt") as f:
         return json.load(f)
 
 
-def write_version_info():
-    with open(VERSION_FILE_LOCAL, "w") as f:
-        json.dump(version_local, f, indent=2)
+def write_version_info(version_file, version):
+    with open(version_file, "w") as f:
+        json.dump({"package-version": version}, f, indent=2)
         f.write("\n")
 
 
-version_info = load_version_info()
-
-PACKAGE_VERSION = version_info.get("package-version")
-CURRENT_VERSION = Version(PACKAGE_VERSION).base_version
+version_info = load_version_info(VERSION_FILE_PATH)
+package_version = version_info.get("package-version")
+current_version = Version(package_version).base_version
 
 if args.nightly_release:
-    CURRENT_VERSION += "rc" + datetime.today().strftime("%Y%m%d")
-
-if args.development_release:
-    CURRENT_VERSION += (
-        ".dev+"
+    current_version += "rc" + datetime.today().strftime("%Y%m%d")
+elif args.development_release:
+    current_version += (
+        ".dev0+"
         + subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("ascii").strip()
     )
-
-if args.custom_string:
-    CURRENT_VERSION += args.custom_string
+elif args.version_suffix:
+    current_version += args.version_suffix
 
 if args.write_json:
-    version_local = {"package-version": CURRENT_VERSION}
-    write_version_info()
+    write_version_info(VERSION_FILE_LOCAL_PATH, current_version)
 
-print(CURRENT_VERSION)
+print(current_version)


### PR DESCRIPTION
Harmonizes the scripts to compute the versions. The `--version-suffix` argument can no longer be combined with other release types and now gives full control over defininfg a suffix to the user.