### PR TITLE
Skip test_sharktank job until quota issues are fixed.

### DIFF
--- a/.github/workflows/pkgci.yml
+++ b/.github/workflows/pkgci.yml
@@ -104,10 +104,11 @@ jobs:
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_onnx')
     uses: ./.github/workflows/pkgci_test_onnx.yml
 
+  # TODO(https://github.com/iree-org/iree-test-suites/issues/56): re-enable when git LFS quota is available
   test_sharktank:
     name: Test Sharktank
     needs: [setup, build_packages]
-    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_sharktank')
+    if: false && contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_sharktank')
     uses: ./.github/workflows/pkgci_test_sharktank.yml
 
   test_tensorflow:


### PR DESCRIPTION
This job will fail until we get more quota for git LFS.

Context: https://github.com/iree-org/iree-test-suites/issues/56

Sample errors: https://github.com/iree-org/iree/actions/runs/12278845603/job/34262001578
```
Fetching LFS objects
  /usr/bin/git lfs fetch origin c644a9dfc3e5e1a9d071d5e786b79cf612e9b1d3
  fetch: Fetching reference c644a9dfc3e5e1a9d071d5e786b79cf612e9b1d3
  batch response: This repository is over its data quota. Account responsible for LFS bandwidth should purchase more data packs to restore access.
  Error: error: failed to fetch some objects from 'https://github.com/iree-org/iree-test-suites.git/info/lfs'
  The process '/usr/bin/git' failed with exit code 2
```

ci-exactly: build_packages, test_sharktank