### PR TITLE
[Codegen] Fix use after erase bug in optimize-tensor-extract-slices

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
@@ -127,8 +127,9 @@ hoistLoopInvariantSubsetAtIterArg(RewriterBase &rewriter,
           loopLike.replaceWithAdditionalYields(
               rewriter, extraction.getResult(),
               /*replaceInitOperandUsesInLoop=*/true, newYieldValuesFn);
-      if (failed(newLoop))
+      if (failed(newLoop)) {
         return loopLike;
+      }
       loopLike = *newLoop;
 
       BlockArgument iterArg = loopLike.getRegionIterArgs()[idx];
@@ -136,12 +137,12 @@ hoistLoopInvariantSubsetAtIterArg(RewriterBase &rewriter,
       OpResult newLoopResult = loopLike.getLoopResults()->back();
       rewriter.moveOpBefore(extraction, loopLike);
 
-      // Hoist the extraction/insertion ops
+      // Hoist the extraction/insertion ops.
       extraction.getSourceOperand().set(
           loopLike.getTiedLoopInit(iterArg)->get());
 
       // Clone the insertion to outside the not removing the final insertion, as
-      // it still can be used by other extraction ops. loop.
+      // it still can be used by other extraction ops loop.
       rewriter.setInsertionPointAfter(loopLike);
       SubsetInsertionOpInterface newInsertion =
           cast<SubsetInsertionOpInterface>(

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
@@ -84,63 +84,73 @@ hoistLoopInvariantSubsetAtIterArg(RewriterBase &rewriter,
     return loopLike;
   }
 
-  // Get all subset extraction uses of this iter_arg and try to hoist them
-  // out of the loop.
-  for (Operation *op : loopLike.getRegionIterArgs()[idx].getUsers()) {
-    auto extraction = dyn_cast<SubsetExtractionOpInterface>(op);
-    if (!extraction) {
-      continue;
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    // Get all subset extraction uses of this iter_arg and try to hoist them
+    // out of the loop.
+    for (Operation *op : loopLike.getRegionIterArgs()[idx].getUsers()) {
+      auto extraction = dyn_cast<SubsetExtractionOpInterface>(op);
+      if (!extraction) {
+        continue;
+      }
+
+      // Check if this extraction is operating on the same subset as the
+      // insertion.
+      bool equivalent = extraction.operatesOnEquivalentSubset(
+          insertion, [](Value v1, Value v2) {
+            // The callback to this method checks if the given two values are
+            // aliasing tensors/buffers from which the subset slice comes from.
+            // For our case, we only care if the slices are same, so we can
+            // always return true.
+            return true;
+          });
+
+      if (!equivalent) {
+        continue;
+      }
+
+      // Hoist out the extraction/insertion ops.
+      NewYieldValuesFn newYieldValuesFn =
+          [&](OpBuilder &b, Location loc,
+              ArrayRef<BlockArgument> innerNewBBArgs) -> SmallVector<Value> {
+        return {insertion.getSourceOperand().get()};
+      };
+
+      // replaceInitOperandUsesInLoop is set to true S.T we will use new IV
+      // instead of hoisted out extract.
+      FailureOr<LoopLikeOpInterface> newLoop =
+          loopLike.replaceWithAdditionalYields(
+              rewriter, extraction.getResult(),
+              /*replaceInitOperandUsesInLoop=*/true, newYieldValuesFn);
+      if (failed(newLoop))
+        return loopLike;
+      loopLike = *newLoop;
+
+      BlockArgument iterArg = loopLike.getRegionIterArgs()[idx];
+      OpResult loopResult = loopLike.getTiedLoopResult(iterArg);
+      OpResult newLoopResult = loopLike.getLoopResults()->back();
+      rewriter.moveOpBefore(extraction, loopLike);
+
+      // Hoist the extraction/insertion ops
+      extraction.getSourceOperand().set(
+          loopLike.getTiedLoopInit(iterArg)->get());
+
+      // Clone the insertion to outside the not removing the final insertion, as
+      // it still can be used by other extraction ops. loop.
+      rewriter.setInsertionPointAfter(loopLike);
+      SubsetInsertionOpInterface newInsertion =
+          cast<SubsetInsertionOpInterface>(
+              rewriter.clone(*insertion.getOperation()));
+
+      rewriter.replaceAllUsesWith(loopResult,
+                                  newInsertion.getUpdatedDestination());
+      newInsertion.getSourceOperand().set(newLoopResult);
+
+      // loopLike changed, restart the check.
+      changed = true;
+      break;
     }
-
-    // Check if this extraction is operating on the same subset as the
-    // insertion.
-    bool equivalent = extraction.operatesOnEquivalentSubset(
-        insertion, [](Value v1, Value v2) {
-          // The callback to this method checks if the given two values are
-          // aliasing tensors/buffers from which the subset slice comes from.
-          // For our case, we only care if the slices are same, so we can always
-          // return true.
-          return true;
-        });
-
-    if (!equivalent) {
-      continue;
-    }
-
-    // Hoist out the extraction/insertion ops.
-    NewYieldValuesFn newYieldValuesFn =
-        [&](OpBuilder &b, Location loc,
-            ArrayRef<BlockArgument> innerNewBBArgs) -> SmallVector<Value> {
-      return {insertion.getSourceOperand().get()};
-    };
-
-    // replaceInitOperandUsesInLoop is set to true S.T we will use new IV
-    // instead of hoisted out extract.
-    FailureOr<LoopLikeOpInterface> newLoop =
-        loopLike.replaceWithAdditionalYields(
-            rewriter, extraction.getResult(),
-            /*replaceInitOperandUsesInLoop=*/true, newYieldValuesFn);
-    if (failed(newLoop))
-      return loopLike;
-    loopLike = *newLoop;
-
-    BlockArgument iterArg = loopLike.getRegionIterArgs()[idx];
-    OpResult loopResult = loopLike.getTiedLoopResult(iterArg);
-    OpResult newLoopResult = loopLike.getLoopResults()->back();
-    rewriter.moveOpBefore(extraction, loopLike);
-
-    // Hoist the extraction/insertion ops
-    extraction.getSourceOperand().set(loopLike.getTiedLoopInit(iterArg)->get());
-
-    // Clone the insertion to outside the not removing the final insertion, as
-    // it still can be used by other extraction ops. loop.
-    rewriter.setInsertionPointAfter(loopLike);
-    SubsetInsertionOpInterface newInsertion = cast<SubsetInsertionOpInterface>(
-        rewriter.clone(*insertion.getOperation()));
-
-    rewriter.replaceAllUsesWith(loopResult,
-                                newInsertion.getUpdatedDestination());
-    newInsertion.getSourceOperand().set(newLoopResult);
   }
 
   return loopLike;

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
@@ -85,7 +85,11 @@ hoistLoopInvariantSubsetAtIterArg(RewriterBase &rewriter,
   }
 
   bool changed = true;
-  while (changed) {
+  // The below `while` loop is a WAR for the core issue that is unidentified.
+  // To avoid infinite loops, limit number of iterations to 10.
+  int numIterations = 0;
+  while (changed && numIterations < 10) {
+    numIterations++;
     changed = false;
     // Get all subset extraction uses of this iter_arg and try to hoist them
     // out of the loop.


### PR DESCRIPTION
The loop here is iterating on arguments of a dead operation. This sometimes works if the operation decided to use the same memory for it's iter arguments, but is relying on undefined behavior. This patch restarts the check each time a new loop is created.

No tests for this one, because it sometimes works, depending on how the memory allocator allocates the operation.