### PR TITLE
Add relative error for buffer comparison

### DIFF
--- a/runtime/src/iree/tooling/buffer_view_matchers.c
+++ b/runtime/src/iree/tooling/buffer_view_matchers.c
@@ -76,21 +76,14 @@ static bool iree_hal_compare_strided_elements_exact(
   return true;
 }
 
-static bool iree_hal_compare_strided_elements_approximate_f16(
+static bool iree_hal_compare_strided_elements_approximate_absolute_f16(
     iree_hal_buffer_equality_t equality, iree_host_size_t element_count,
     const uint16_t* expected_ptr, iree_host_size_t expected_stride,
     const uint16_t* actual_ptr, iree_host_size_t actual_stride,
-    bool use_relative_error, iree_host_size_t* out_index) {
+    iree_host_size_t* out_index) {
   for (iree_host_size_t i = 0; i < element_count; ++i) {
-    float error;
-    if (use_relative_error)
-      error = fabsf((iree_math_f16_to_f32(*expected_ptr) -
-                     iree_math_f16_to_f32(*actual_ptr)) /
-                    iree_math_f16_to_f32(*expected_ptr));
-    else
-      error = fabsf(iree_math_f16_to_f32(*expected_ptr) -
-                    iree_math_f16_to_f32(*actual_ptr));
-    if (error > equality.f16_threshold) {
+    if (fabsf(iree_math_f16_to_f32(*expected_ptr) -
+              iree_math_f16_to_f32(*actual_ptr)) > equality.f16_threshold) {
       *out_index = i;
       return false;
     }
@@ -100,18 +93,13 @@ static bool iree_hal_compare_strided_elements_approximate_f16(
   return true;
 }
 
-static bool iree_hal_compare_strided_elements_approximate_f32(
+static bool iree_hal_compare_strided_elements_approximate_absolute_f32(
     iree_hal_buffer_equality_t equality, iree_host_size_t element_count,
     const float* expected_ptr, iree_host_size_t expected_stride,
     const float* actual_ptr, iree_host_size_t actual_stride,
-    bool use_relative_error, iree_host_size_t* out_index) {
+    iree_host_size_t* out_index) {
   for (iree_host_size_t i = 0; i < element_count; ++i) {
-    float error;
-    if (use_relative_error)
-      error = fabsf((*expected_ptr - *actual_ptr) / *expected_ptr);
-    else
-      error = fabsf(*expected_ptr - *actual_ptr);
-    if (error > equality.f32_threshold) {
+    if (fabsf(*expected_ptr - *actual_ptr) > equality.f32_threshold) {
       *out_index = i;
       return false;
     }
@@ -121,18 +109,13 @@ static bool iree_hal_compare_strided_elements_approximate_f32(
   return true;
 }
 
-static bool iree_hal_compare_strided_elements_approximate_f64(
+static bool iree_hal_compare_strided_elements_approximate_absolute_f64(
     iree_hal_buffer_equality_t equality, iree_host_size_t element_count,
     const double* expected_ptr, iree_host_size_t expected_stride,
     const double* actual_ptr, iree_host_size_t actual_stride,
-    bool use_relative_error, iree_host_size_t* out_index) {
+    iree_host_size_t* out_index) {
   for (iree_host_size_t i = 0; i < element_count; ++i) {
-    double error;
-    if (use_relative_error)
-      error = fabs((*expected_ptr - *actual_ptr) / *expected_ptr);
-    else
-      error = fabs(*expected_ptr - *actual_ptr);
-    if (error > equality.f64_threshold) {
+    if (fabs(*expected_ptr - *actual_ptr) > equality.f64_threshold) {
       *out_index = i;
       return false;
     }
@@ -142,28 +125,107 @@ static bool iree_hal_compare_strided_elements_approximate_f64(
   return true;
 }
 
-static bool iree_hal_compare_strided_elements_approximate(
+static bool iree_hal_compare_strided_elements_approximate_relative_f16(
+    iree_hal_buffer_equality_t equality, iree_host_size_t element_count,
+    const uint16_t* expected_ptr, iree_host_size_t expected_stride,
+    const uint16_t* actual_ptr, iree_host_size_t actual_stride,
+    iree_host_size_t* out_index) {
+  for (iree_host_size_t i = 0; i < element_count; ++i) {
+    if (fabsf((iree_math_f16_to_f32(*expected_ptr) -
+               iree_math_f16_to_f32(*actual_ptr)) /
+              iree_math_f16_to_f32(*expected_ptr)) > equality.f16_threshold) {
+      *out_index = i;
+      return false;
+    }
+    expected_ptr += expected_stride;
+    actual_ptr += actual_stride;
+  }
+  return true;
+}
+
+static bool iree_hal_compare_strided_elements_approximate_relative_f32(
+    iree_hal_buffer_equality_t equality, iree_host_size_t element_count,
+    const float* expected_ptr, iree_host_size_t expected_stride,
+    const float* actual_ptr, iree_host_size_t actual_stride,
+    iree_host_size_t* out_index) {
+  for (iree_host_size_t i = 0; i < element_count; ++i) {
+    if (fabsf((*expected_ptr - *actual_ptr) / *expected_ptr) >
+        equality.f32_threshold) {
+      *out_index = i;
+      return false;
+    }
+    expected_ptr += expected_stride;
+    actual_ptr += actual_stride;
+  }
+  return true;
+}
+
+static bool iree_hal_compare_strided_elements_approximate_relative_f64(
+    iree_hal_buffer_equality_t equality, iree_host_size_t element_count,
+    const double* expected_ptr, iree_host_size_t expected_stride,
+    const double* actual_ptr, iree_host_size_t actual_stride,
+    iree_host_size_t* out_index) {
+  for (iree_host_size_t i = 0; i < element_count; ++i) {
+    if (fabs((*expected_ptr - *actual_ptr) / *expected_ptr) >
+        equality.f64_threshold) {
+      *out_index = i;
+      return false;
+    }
+    expected_ptr += expected_stride;
+    actual_ptr += actual_stride;
+  }
+  return true;
+}
+
+static bool iree_hal_compare_strided_elements_approximate_absolute(
     iree_hal_buffer_equality_t equality, iree_hal_element_type_t element_type,
     iree_host_size_t element_count, iree_const_byte_span_t expected_elements,
     iree_host_size_t expected_stride, iree_const_byte_span_t actual_elements,
-    iree_host_size_t actual_stride, bool use_relative_error,
-    iree_host_size_t* out_index) {
+    iree_host_size_t actual_stride, iree_host_size_t* out_index) {
   switch (element_type) {
     case IREE_HAL_ELEMENT_TYPE_FLOAT_16:
-      return iree_hal_compare_strided_elements_approximate_f16(
+      return iree_hal_compare_strided_elements_approximate_absolute_f16(
           equality, element_count, (const uint16_t*)expected_elements.data,
           expected_stride, (const uint16_t*)actual_elements.data, actual_stride,
-          use_relative_error, out_index);
+          out_index);
     case IREE_HAL_ELEMENT_TYPE_FLOAT_32:
-      return iree_hal_compare_strided_elements_approximate_f32(
+      return iree_hal_compare_strided_elements_approximate_absolute_f32(
           equality, element_count, (const float*)expected_elements.data,
           expected_stride, (const float*)actual_elements.data, actual_stride,
-          use_relative_error, out_index);
+          out_index);
     case IREE_HAL_ELEMENT_TYPE_FLOAT_64:
-      return iree_hal_compare_strided_elements_approximate_f64(
+      return iree_hal_compare_strided_elements_approximate_absolute_f64(
           equality, element_count, (const double*)expected_elements.data,
           expected_stride, (const double*)actual_elements.data, actual_stride,
-          use_relative_error, out_index);
+          out_index);
+    default:
+      return iree_hal_compare_strided_elements_exact(
+          element_type, element_count, expected_elements, expected_stride,
+          actual_elements, actual_stride, out_index);
+  }
+}
+
+static bool iree_hal_compare_strided_elements_approximate_relative(
+    iree_hal_buffer_equality_t equality, iree_hal_element_type_t element_type,
+    iree_host_size_t element_count, iree_const_byte_span_t expected_elements,
+    iree_host_size_t expected_stride, iree_const_byte_span_t actual_elements,
+    iree_host_size_t actual_stride, iree_host_size_t* out_index) {
+  switch (element_type) {
+    case IREE_HAL_ELEMENT_TYPE_FLOAT_16:
+      return iree_hal_compare_strided_elements_approximate_relative_f16(
+          equality, element_count, (const uint16_t*)expected_elements.data,
+          expected_stride, (const uint16_t*)actual_elements.data, actual_stride,
+          out_index);
+    case IREE_HAL_ELEMENT_TYPE_FLOAT_32:
+      return iree_hal_compare_strided_elements_approximate_relative_f32(
+          equality, element_count, (const float*)expected_elements.data,
+          expected_stride, (const float*)actual_elements.data, actual_stride,
+          out_index);
+    case IREE_HAL_ELEMENT_TYPE_FLOAT_64:
+      return iree_hal_compare_strided_elements_approximate_relative_f64(
+          equality, element_count, (const double*)expected_elements.data,
+          expected_stride, (const double*)actual_elements.data, actual_stride,
+          out_index);
     default:
       return iree_hal_compare_strided_elements_exact(
           element_type, element_count, expected_elements, expected_stride,
@@ -184,15 +246,13 @@ static bool iree_hal_compare_strided_elements(
           element_type, element_count, expected_elements, expected_stride,
           actual_elements, actual_stride, out_index);
     case IREE_HAL_BUFFER_EQUALITY_APPROXIMATE_ABSOLUTE:
-      return iree_hal_compare_strided_elements_approximate(
+      return iree_hal_compare_strided_elements_approximate_absolute(
           equality, element_type, element_count, expected_elements,
-          expected_stride, actual_elements, actual_stride,
-          /*use_relative_error=*/false, out_index);
+          expected_stride, actual_elements, actual_stride, out_index);
     case IREE_HAL_BUFFER_EQUALITY_APPROXIMATE_RELATIVE:
-      return iree_hal_compare_strided_elements_approximate(
+      return iree_hal_compare_strided_elements_approximate_relative(
           equality, element_type, element_count, expected_elements,
-          expected_stride, actual_elements, actual_stride,
-          /*use_relative_error=*/true, out_index);
+          expected_stride, actual_elements, actual_stride, out_index);
     default:
       IREE_ASSERT(false && "unhandled equality mode");
       return false;

--- a/runtime/src/iree/tooling/buffer_view_matchers.h
+++ b/runtime/src/iree/tooling/buffer_view_matchers.h
@@ -40,6 +40,8 @@ typedef enum {
   IREE_HAL_BUFFER_EQUALITY_EXACT = 0,
   // abs(a - b) <= threshold
   IREE_HAL_BUFFER_EQUALITY_APPROXIMATE_ABSOLUTE,
+  // abs((a - b)/a) <= threshold
+  IREE_HAL_BUFFER_EQUALITY_APPROXIMATE_RELATIVE,
 } iree_hal_buffer_equality_mode_t;
 
 // TODO(benvanik): initializers/configuration for equality comparisons.

--- a/runtime/src/iree/tooling/buffer_view_matchers_test.cc
+++ b/runtime/src/iree/tooling/buffer_view_matchers_test.cc
@@ -160,9 +160,18 @@ static const iree_hal_buffer_equality_t kExactEquality = ([]() {
   return equality;
 })();
 
-static const iree_hal_buffer_equality_t kApproximateEquality = ([]() {
+static const iree_hal_buffer_equality_t kApproximateAbsoluteEquality = ([]() {
   iree_hal_buffer_equality_t equality;
   equality.mode = IREE_HAL_BUFFER_EQUALITY_APPROXIMATE_ABSOLUTE;
+  equality.f16_threshold = 0.001f;
+  equality.f32_threshold = 0.0001f;
+  equality.f64_threshold = 0.0001;
+  return equality;
+})();
+
+static const iree_hal_buffer_equality_t kApproximateRelativeEquality = ([]() {
+  iree_hal_buffer_equality_t equality;
+  equality.mode = IREE_HAL_BUFFER_EQUALITY_APPROXIMATE_RELATIVE;
   equality.f16_threshold = 0.001f;
   equality.f32_threshold = 0.0001f;
   equality.f64_threshold = 0.0001;
@@ -213,7 +222,7 @@ TEST_F(BufferViewMatchersTest, CompareBroadcastI8EQ) {
   const int8_t rhs[] = {1, 1, 1};
   iree_host_size_t index = 0;
   EXPECT_TRUE(iree_hal_compare_buffer_elements_broadcast(
-      kApproximateEquality, iree_hal_make_buffer_element_i8(lhs),
+      kApproximateAbsoluteEquality, iree_hal_make_buffer_element_i8(lhs),
       IREE_ARRAYSIZE(rhs), iree_make_const_byte_span(rhs, sizeof(rhs)),
       &index));
 }
@@ -223,7 +232,7 @@ TEST_F(BufferViewMatchersTest, CompareBroadcastI8NE) {
   const int8_t rhs[] = {1, 2, 3};
   iree_host_size_t index = 0;
   EXPECT_FALSE(iree_hal_compare_buffer_elements_broadcast(
-      kApproximateEquality, iree_hal_make_buffer_element_i8(lhs),
+      kApproximateAbsoluteEquality, iree_hal_make_buffer_element_i8(lhs),
       IREE_ARRAYSIZE(rhs), iree_make_const_byte_span(rhs, sizeof(rhs)),
       &index));
   EXPECT_EQ(index, 1);
@@ -234,7 +243,7 @@ TEST_F(BufferViewMatchersTest, CompareBroadcastI64EQ) {
   const int64_t rhs[] = {1, 1, 1};
   iree_host_size_t index = 0;
   EXPECT_TRUE(iree_hal_compare_buffer_elements_broadcast(
-      kApproximateEquality, iree_hal_make_buffer_element_i64(lhs),
+      kApproximateAbsoluteEquality, iree_hal_make_buffer_element_i64(lhs),
       IREE_ARRAYSIZE(rhs), iree_make_const_byte_span(rhs, sizeof(rhs)),
       &index));
 }
@@ -244,7 +253,7 @@ TEST_F(BufferViewMatchersTest, CompareBroadcastI64NE) {
   const int64_t rhs[] = {1, 2, 3};
   iree_host_size_t index = 0;
   EXPECT_FALSE(iree_hal_compare_buffer_elements_broadcast(
-      kApproximateEquality, iree_hal_make_buffer_element_i64(lhs),
+      kApproximateAbsoluteEquality, iree_hal_make_buffer_element_i64(lhs),
       IREE_ARRAYSIZE(rhs), iree_make_const_byte_span(rhs, sizeof(rhs)),
       &index));
   EXPECT_EQ(index, 1);
@@ -259,7 +268,21 @@ TEST_F(BufferViewMatchersTest, CompareBroadcastF16EQ) {
   };
   iree_host_size_t index = 0;
   EXPECT_TRUE(iree_hal_compare_buffer_elements_broadcast(
-      kApproximateEquality, iree_hal_make_buffer_element_f16(lhs),
+      kApproximateAbsoluteEquality, iree_hal_make_buffer_element_f16(lhs),
+      IREE_ARRAYSIZE(rhs), iree_make_const_byte_span(rhs, sizeof(rhs)),
+      &index));
+}
+
+TEST_F(BufferViewMatchersTest, CompareBroadcastF16EQRelative) {
+  const float lhs = 1.0f;
+  const uint16_t rhs[] = {
+      iree_math_f32_to_f16(1.0f),
+      iree_math_f32_to_f16(1.0f),
+      iree_math_f32_to_f16(1.0f),
+  };
+  iree_host_size_t index = 0;
+  EXPECT_TRUE(iree_hal_compare_buffer_elements_broadcast(
+      kApproximateRelativeEquality, iree_hal_make_buffer_element_f16(lhs),
       IREE_ARRAYSIZE(rhs), iree_make_const_byte_span(rhs, sizeof(rhs)),
       &index));
 }
@@ -273,7 +296,22 @@ TEST_F(BufferViewMatchersTest, CompareBroadcastF16NE) {
   };
   iree_host_size_t index = 0;
   EXPECT_FALSE(iree_hal_compare_buffer_elements_broadcast(
-      kApproximateEquality, iree_hal_make_buffer_element_f16(lhs),
+      kApproximateAbsoluteEquality, iree_hal_make_buffer_element_f16(lhs),
+      IREE_ARRAYSIZE(rhs), iree_make_const_byte_span(rhs, sizeof(rhs)),
+      &index));
+  EXPECT_EQ(index, 1);
+}
+
+TEST_F(BufferViewMatchersTest, CompareBroadcastF16NERelative) {
+  const float lhs = 1.0f;
+  const uint16_t rhs[] = {
+      iree_math_f32_to_f16(1.0f),
+      iree_math_f32_to_f16(3.0f),
+      iree_math_f32_to_f16(4.0f),
+  };
+  iree_host_size_t index = 0;
+  EXPECT_FALSE(iree_hal_compare_buffer_elements_broadcast(
+      kApproximateRelativeEquality, iree_hal_make_buffer_element_f16(lhs),
       IREE_ARRAYSIZE(rhs), iree_make_const_byte_span(rhs, sizeof(rhs)),
       &index));
   EXPECT_EQ(index, 1);
@@ -284,7 +322,17 @@ TEST_F(BufferViewMatchersTest, CompareBroadcastF32EQ) {
   const float rhs[] = {1.0f, 1.0f, 1.0f};
   iree_host_size_t index = 0;
   EXPECT_TRUE(iree_hal_compare_buffer_elements_broadcast(
-      kApproximateEquality, iree_hal_make_buffer_element_f32(lhs),
+      kApproximateAbsoluteEquality, iree_hal_make_buffer_element_f32(lhs),
+      IREE_ARRAYSIZE(rhs), iree_make_const_byte_span(rhs, sizeof(rhs)),
+      &index));
+}
+
+TEST_F(BufferViewMatchersTest, CompareBroadcastF32EQRelative) {
+  const float lhs = 1.0f;
+  const float rhs[] = {1.0f, 1.0f, 1.0f};
+  iree_host_size_t index = 0;
+  EXPECT_TRUE(iree_hal_compare_buffer_elements_broadcast(
+      kApproximateRelativeEquality, iree_hal_make_buffer_element_f32(lhs),
       IREE_ARRAYSIZE(rhs), iree_make_const_byte_span(rhs, sizeof(rhs)),
       &index));
 }
@@ -294,7 +342,18 @@ TEST_F(BufferViewMatchersTest, CompareBroadcastF32NE) {
   const float rhs[] = {1.0f, 3.0f, 4.0f};
   iree_host_size_t index = 0;
   EXPECT_FALSE(iree_hal_compare_buffer_elements_broadcast(
-      kApproximateEquality, iree_hal_make_buffer_element_f32(lhs),
+      kApproximateAbsoluteEquality, iree_hal_make_buffer_element_f32(lhs),
+      IREE_ARRAYSIZE(rhs), iree_make_const_byte_span(rhs, sizeof(rhs)),
+      &index));
+  EXPECT_EQ(index, 1);
+}
+
+TEST_F(BufferViewMatchersTest, CompareBroadcastF32NERelative) {
+  const float lhs = 1.0f;
+  const float rhs[] = {1.0f, 3.0f, 4.0f};
+  iree_host_size_t index = 0;
+  EXPECT_FALSE(iree_hal_compare_buffer_elements_broadcast(
+      kApproximateRelativeEquality, iree_hal_make_buffer_element_f32(lhs),
       IREE_ARRAYSIZE(rhs), iree_make_const_byte_span(rhs, sizeof(rhs)),
       &index));
   EXPECT_EQ(index, 1);
@@ -305,7 +364,17 @@ TEST_F(BufferViewMatchersTest, CompareBroadcastF64EQ) {
   const double rhs[] = {1.0, 1.0, 1.0};
   iree_host_size_t index = 0;
   EXPECT_TRUE(iree_hal_compare_buffer_elements_broadcast(
-      kApproximateEquality, iree_hal_make_buffer_element_f64(lhs),
+      kApproximateAbsoluteEquality, iree_hal_make_buffer_element_f64(lhs),
+      IREE_ARRAYSIZE(rhs), iree_make_const_byte_span(rhs, sizeof(rhs)),
+      &index));
+}
+
+TEST_F(BufferViewMatchersTest, CompareBroadcastF64EQRelative) {
+  const double lhs = 1.0;
+  const double rhs[] = {1.0, 1.0, 1.0};
+  iree_host_size_t index = 0;
+  EXPECT_TRUE(iree_hal_compare_buffer_elements_broadcast(
+      kApproximateRelativeEquality, iree_hal_make_buffer_element_f64(lhs),
       IREE_ARRAYSIZE(rhs), iree_make_const_byte_span(rhs, sizeof(rhs)),
       &index));
 }
@@ -315,7 +384,18 @@ TEST_F(BufferViewMatchersTest, CompareBroadcastF64NE) {
   const double rhs[] = {1.0, 3.0, 4.0};
   iree_host_size_t index = 0;
   EXPECT_FALSE(iree_hal_compare_buffer_elements_broadcast(
-      kApproximateEquality, iree_hal_make_buffer_element_f64(lhs),
+      kApproximateAbsoluteEquality, iree_hal_make_buffer_element_f64(lhs),
+      IREE_ARRAYSIZE(rhs), iree_make_const_byte_span(rhs, sizeof(rhs)),
+      &index));
+  EXPECT_EQ(index, 1);
+}
+
+TEST_F(BufferViewMatchersTest, CompareBroadcastF64NERelative) {
+  const double lhs = 1.0;
+  const double rhs[] = {1.0, 3.0, 4.0};
+  iree_host_size_t index = 0;
+  EXPECT_FALSE(iree_hal_compare_buffer_elements_broadcast(
+      kApproximateRelativeEquality, iree_hal_make_buffer_element_f64(lhs),
       IREE_ARRAYSIZE(rhs), iree_make_const_byte_span(rhs, sizeof(rhs)),
       &index));
   EXPECT_EQ(index, 1);
@@ -334,8 +414,8 @@ TEST_F(BufferViewMatchersTest, CompareElementwiseF16EQ) {
   };
   iree_host_size_t index = 0;
   EXPECT_TRUE(iree_hal_compare_buffer_elements_elementwise(
-      kApproximateEquality, IREE_HAL_ELEMENT_TYPE_FLOAT_16, IREE_ARRAYSIZE(lhs),
-      iree_make_const_byte_span(lhs, sizeof(lhs)),
+      kApproximateAbsoluteEquality, IREE_HAL_ELEMENT_TYPE_FLOAT_16,
+      IREE_ARRAYSIZE(lhs), iree_make_const_byte_span(lhs, sizeof(lhs)),
       iree_make_const_byte_span(rhs, sizeof(rhs)), &index));
 }
 
@@ -354,8 +434,28 @@ TEST_F(BufferViewMatchersTest, CompareElementwiseF16NearEQ) {
   };
   iree_host_size_t index = 0;
   EXPECT_TRUE(iree_hal_compare_buffer_elements_elementwise(
-      kApproximateEquality, IREE_HAL_ELEMENT_TYPE_FLOAT_16, IREE_ARRAYSIZE(lhs),
-      iree_make_const_byte_span(lhs, sizeof(lhs)),
+      kApproximateAbsoluteEquality, IREE_HAL_ELEMENT_TYPE_FLOAT_16,
+      IREE_ARRAYSIZE(lhs), iree_make_const_byte_span(lhs, sizeof(lhs)),
+      iree_make_const_byte_span(rhs, sizeof(rhs)), &index));
+}
+
+TEST_F(BufferViewMatchersTest, CompareElementwiseF16NearEQRelative) {
+  const uint16_t lhs[] = {
+      iree_math_f32_to_f16(100.0f),
+      iree_math_f32_to_f16(19.99f),
+      iree_math_f32_to_f16(0.00001f),
+      iree_math_f32_to_f16(4.0f),
+  };
+  const uint16_t rhs[] = {
+      iree_math_f32_to_f16(100.01f),
+      iree_math_f32_to_f16(20.00f),
+      iree_math_f32_to_f16(0.0f),
+      iree_math_f32_to_f16(4.0f),
+  };
+  iree_host_size_t index = 0;
+  EXPECT_TRUE(iree_hal_compare_buffer_elements_elementwise(
+      kApproximateRelativeEquality, IREE_HAL_ELEMENT_TYPE_FLOAT_16,
+      IREE_ARRAYSIZE(lhs), iree_make_const_byte_span(lhs, sizeof(lhs)),
       iree_make_const_byte_span(rhs, sizeof(rhs)), &index));
 }
 
@@ -372,8 +472,8 @@ TEST_F(BufferViewMatchersTest, CompareElementwiseF16NE) {
   };
   iree_host_size_t index = 0;
   EXPECT_FALSE(iree_hal_compare_buffer_elements_elementwise(
-      kApproximateEquality, IREE_HAL_ELEMENT_TYPE_FLOAT_16, IREE_ARRAYSIZE(lhs),
-      iree_make_const_byte_span(lhs, sizeof(lhs)),
+      kApproximateAbsoluteEquality, IREE_HAL_ELEMENT_TYPE_FLOAT_16,
+      IREE_ARRAYSIZE(lhs), iree_make_const_byte_span(lhs, sizeof(lhs)),
       iree_make_const_byte_span(rhs, sizeof(rhs)), &index));
   EXPECT_EQ(index, 1);
 }
@@ -383,8 +483,8 @@ TEST_F(BufferViewMatchersTest, CompareElementwiseF32EQ) {
   const float rhs[] = {1.0f, 2.0f, 3.0f};
   iree_host_size_t index = 0;
   EXPECT_TRUE(iree_hal_compare_buffer_elements_elementwise(
-      kApproximateEquality, IREE_HAL_ELEMENT_TYPE_FLOAT_32, IREE_ARRAYSIZE(lhs),
-      iree_make_const_byte_span(lhs, sizeof(lhs)),
+      kApproximateAbsoluteEquality, IREE_HAL_ELEMENT_TYPE_FLOAT_32,
+      IREE_ARRAYSIZE(lhs), iree_make_const_byte_span(lhs, sizeof(lhs)),
       iree_make_const_byte_span(rhs, sizeof(rhs)), &index));
 }
 
@@ -393,8 +493,8 @@ TEST_F(BufferViewMatchersTest, CompareElementwiseF32NE) {
   const float rhs[] = {1.0f, 3.0f, 4.0f};
   iree_host_size_t index = 0;
   EXPECT_FALSE(iree_hal_compare_buffer_elements_elementwise(
-      kApproximateEquality, IREE_HAL_ELEMENT_TYPE_FLOAT_32, IREE_ARRAYSIZE(lhs),
-      iree_make_const_byte_span(lhs, sizeof(lhs)),
+      kApproximateAbsoluteEquality, IREE_HAL_ELEMENT_TYPE_FLOAT_32,
+      IREE_ARRAYSIZE(lhs), iree_make_const_byte_span(lhs, sizeof(lhs)),
       iree_make_const_byte_span(rhs, sizeof(rhs)), &index));
   EXPECT_EQ(index, 1);
 }
@@ -404,8 +504,8 @@ TEST_F(BufferViewMatchersTest, CompareElementwiseF64EQ) {
   const double rhs[] = {1.0, 2.0, 3.0};
   iree_host_size_t index = 0;
   EXPECT_TRUE(iree_hal_compare_buffer_elements_elementwise(
-      kApproximateEquality, IREE_HAL_ELEMENT_TYPE_FLOAT_64, IREE_ARRAYSIZE(lhs),
-      iree_make_const_byte_span(lhs, sizeof(lhs)),
+      kApproximateAbsoluteEquality, IREE_HAL_ELEMENT_TYPE_FLOAT_64,
+      IREE_ARRAYSIZE(lhs), iree_make_const_byte_span(lhs, sizeof(lhs)),
       iree_make_const_byte_span(rhs, sizeof(rhs)), &index));
 }
 
@@ -414,8 +514,8 @@ TEST_F(BufferViewMatchersTest, CompareElementwiseF64NE) {
   const double rhs[] = {1.0, 3.0, 4.0};
   iree_host_size_t index = 0;
   EXPECT_FALSE(iree_hal_compare_buffer_elements_elementwise(
-      kApproximateEquality, IREE_HAL_ELEMENT_TYPE_FLOAT_64, IREE_ARRAYSIZE(lhs),
-      iree_make_const_byte_span(lhs, sizeof(lhs)),
+      kApproximateAbsoluteEquality, IREE_HAL_ELEMENT_TYPE_FLOAT_64,
+      IREE_ARRAYSIZE(lhs), iree_make_const_byte_span(lhs, sizeof(lhs)),
       iree_make_const_byte_span(rhs, sizeof(rhs)), &index));
   EXPECT_EQ(index, 1);
 }

--- a/runtime/src/iree/tooling/buffer_view_matchers_test.cc
+++ b/runtime/src/iree/tooling/buffer_view_matchers_test.cc
@@ -443,13 +443,13 @@ TEST_F(BufferViewMatchersTest, CompareElementwiseF16NearEQRelative) {
   const uint16_t lhs[] = {
       iree_math_f32_to_f16(100.0f),
       iree_math_f32_to_f16(19.99f),
-      iree_math_f32_to_f16(0.00001f),
+      iree_math_f32_to_f16(1.00001f),
       iree_math_f32_to_f16(4.0f),
   };
   const uint16_t rhs[] = {
       iree_math_f32_to_f16(100.01f),
       iree_math_f32_to_f16(20.00f),
-      iree_math_f32_to_f16(0.0f),
+      iree_math_f32_to_f16(1.0f),
       iree_math_f32_to_f16(4.0f),
   };
   iree_host_size_t index = 0;

--- a/runtime/src/iree/tooling/comparison.cc
+++ b/runtime/src/iree/tooling/comparison.cc
@@ -25,7 +25,8 @@ IREE_FLAG(float, expected_f32_threshold, 0.0001f,
 IREE_FLAG(double, expected_f64_threshold, 0.0001,
           "Threshold under which two f64 values are considered equal.");
 IREE_FLAG(string, equality_mode, "absolute",
-          "Choose between absolute, relative or exact comparison");
+          "Choose the type of comparison desired between buffers from "
+          "[`absolute`, `relative`, `exact`].");
 
 static iree_hal_buffer_equality_t iree_tooling_equality_from_flags(void) {
   iree_hal_buffer_equality_t equality;

--- a/runtime/src/iree/tooling/comparison.cc
+++ b/runtime/src/iree/tooling/comparison.cc
@@ -24,10 +24,16 @@ IREE_FLAG(float, expected_f32_threshold, 0.0001f,
           "Threshold under which two f32 values are considered equal.");
 IREE_FLAG(double, expected_f64_threshold, 0.0001,
           "Threshold under which two f64 values are considered equal.");
+IREE_FLAG(bool, use_relative_error, false,
+          "Use relative errors when comparing floats. By default "
+          "we use absolute error.");
 
 static iree_hal_buffer_equality_t iree_tooling_equality_from_flags(void) {
   iree_hal_buffer_equality_t equality;
-  equality.mode = IREE_HAL_BUFFER_EQUALITY_APPROXIMATE_ABSOLUTE;
+  if (FLAG_use_relative_error)
+    equality.mode = IREE_HAL_BUFFER_EQUALITY_APPROXIMATE_RELATIVE;
+  else
+    equality.mode = IREE_HAL_BUFFER_EQUALITY_APPROXIMATE_ABSOLUTE;
   equality.f16_threshold = FLAG_expected_f16_threshold;
   equality.f32_threshold = FLAG_expected_f32_threshold;
   equality.f64_threshold = FLAG_expected_f64_threshold;

--- a/runtime/src/iree/tooling/comparison.cc
+++ b/runtime/src/iree/tooling/comparison.cc
@@ -24,16 +24,20 @@ IREE_FLAG(float, expected_f32_threshold, 0.0001f,
           "Threshold under which two f32 values are considered equal.");
 IREE_FLAG(double, expected_f64_threshold, 0.0001,
           "Threshold under which two f64 values are considered equal.");
-IREE_FLAG(bool, use_relative_error, false,
-          "Use relative errors when comparing floats. By default "
-          "we use absolute error.");
+IREE_FLAG(string, equality_mode, "absolute",
+          "Choose between absolute, relative or exact comparison");
 
 static iree_hal_buffer_equality_t iree_tooling_equality_from_flags(void) {
   iree_hal_buffer_equality_t equality;
-  if (FLAG_use_relative_error)
-    equality.mode = IREE_HAL_BUFFER_EQUALITY_APPROXIMATE_RELATIVE;
-  else
+  if (strcmp(FLAG_equality_mode, "absolute") == 0) {
     equality.mode = IREE_HAL_BUFFER_EQUALITY_APPROXIMATE_ABSOLUTE;
+  } else if (strcmp(FLAG_equality_mode, "relative") == 0) {
+    equality.mode = IREE_HAL_BUFFER_EQUALITY_APPROXIMATE_RELATIVE;
+  } else if (strcmp(FLAG_equality_mode, "exact") == 0) {
+    equality.mode = IREE_HAL_BUFFER_EQUALITY_EXACT;
+  } else {
+    IREE_ASSERT(false && "unhandled equality mode");
+  }
   equality.f16_threshold = FLAG_expected_f16_threshold;
   equality.f32_threshold = FLAG_expected_f32_threshold;
   equality.f64_threshold = FLAG_expected_f64_threshold;

--- a/runtime/src/iree/tooling/comparison.cc
+++ b/runtime/src/iree/tooling/comparison.cc
@@ -37,7 +37,7 @@ static iree_hal_buffer_equality_t iree_tooling_equality_from_flags(void) {
   } else if (strcmp(FLAG_equality_mode, "exact") == 0) {
     equality.mode = IREE_HAL_BUFFER_EQUALITY_EXACT;
   } else {
-    IREE_ASSERT(false && "unhandled equality mode");
+    IREE_ASSERT_UNREACHABLE("unhandled equality mode");
   }
   equality.f16_threshold = FLAG_expected_f16_threshold;
   equality.f32_threshold = FLAG_expected_f32_threshold;


### PR DESCRIPTION
For large values using relative error for buffer comparison can be helpful as shown by the `CompareElementwiseF16NearEQRelative` test