### PR TITLE
[Vulkan] Disable matmul large test for rdna3

### DIFF
--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -660,29 +660,4 @@ iree_generated_e2e_runner_test(
     ("f32", "f32"),
 ]]
 
-iree_generated_e2e_runner_test(
-    name = "e2e_matmul_vulkan_f16_large_rdna3",
-    compiler_flags = [
-        "--iree-vulkan-target=rdna3",
-    ],
-    generator = ":generate_e2e_matmul_tests",
-    generator_args = [
-        "--lhs_rhs_type=f16",
-        "--acc_type=f32",
-        "--shapes=easy_large_static",
-        "--compilation_info=SPIRVCooperativeMatrixVectorize",
-    ],
-    runner_args = [
-        "--require_exact_results=false",
-    ],
-    tags = [
-        "requires-gpu",
-        "requires-gpu-rdna3",
-        "vulkan_uses_vk_khr_shader_float16_int8",
-    ],
-    target_backends_and_drivers = [
-        ("vulkan-spirv", "vulkan"),
-    ],
-    test_runner = "//tools/testing/e2e:iree-e2e-matmul-test",
-    test_type = "matmul",
-)
+# TODO(#19465): add large matmul tests for rdna3.

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -1382,34 +1382,6 @@ iree_generated_e2e_runner_test(
     "vulkan_uses_vk_khr_shader_float16_int8"
 )
 
-iree_generated_e2e_runner_test(
-  NAME
-    e2e_matmul_vulkan_f16_large_rdna3
-  TEST_TYPE
-    matmul
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=f16"
-    "--acc_type=f32"
-    "--shapes=easy_large_static"
-    "--compilation_info=SPIRVCooperativeMatrixVectorize"
-  TEST_RUNNER
-    iree_tools_testing_e2e_iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "vulkan-spirv"
-  DRIVERS
-    "vulkan"
-  COMPILER_FLAGS
-    "--iree-vulkan-target=rdna3"
-  RUNNER_ARGS
-    "--require_exact_results=false"
-  LABELS
-    "requires-gpu"
-    "requires-gpu-rdna3"
-    "vulkan_uses_vk_khr_shader_float16_int8"
-)
-
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###
 
 # To distinguish between CDNA(gfx9) and RDNA3(gfx11)


### PR DESCRIPTION
This test is known to crash the kernel driver. Removing it until we investigate/fix.

Issue: https://github.com/iree-org/iree/issues/19465