### PR TITLE
Increase all timeouts in pkgci_regression_test.yml.

### DIFF
--- a/.github/workflows/pkgci_regression_test.yml
+++ b/.github/workflows/pkgci_regression_test.yml
@@ -189,7 +189,7 @@ jobs:
             -rpfE \
             --capture=no \
             --log-cli-level=info \
-            --timeout=240 \
+            --timeout=600 \
             --durations=0
         env:
           ROCM_CHIP: ${{ matrix.rocm-chip }}
@@ -203,7 +203,7 @@ jobs:
             -rpfE \
             --capture=no \
             --log-cli-level=info \
-            --timeout=240 \
+            --timeout=600 \
             --durations=0
         env:
           ROCM_CHIP: ${{ matrix.rocm-chip }}
@@ -227,7 +227,7 @@ jobs:
             --goldensize-rocm-clip-bytes 860000 \
             --goldensize-rocm-vae-bytes 840000 \
             --rocm-chip gfx90a \
-            --timeout=240 \
+            --timeout=600 \
             --log-cli-level=info \
             --retries 7
           echo "$(<job_summary.md )" >> $GITHUB_STEP_SUMMARY
@@ -256,6 +256,6 @@ jobs:
             --goldensize-rocm-punet-int8-fp8-bytes 2800000 \
             --rocm-chip gfx942 \
             --log-cli-level=info \
-            --timeout=240 \
+            --timeout=600 \
             --retries 7
           echo "$(<job_summary.md )" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Follow-up to https://github.com/iree-org/iree/pull/19472. CI is still showing timeouts: https://github.com/iree-org/iree/actions/runs/12300081495/job/34328004297#step:6:390

ci-exactly: build_packages, regression_test