### PR TITLE
Refresh project status in README and website homepage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,17 @@ guides, and instructions on building from source.
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8738/badge)](https://www.bestpractices.dev/projects/8738)
 
-#### Project Status
+## Project news
 
-IREE is still in its early phase. We have settled down on the overarching
-infrastructure and are actively improving various software components as well as
-project logistics. It is still quite far from ready for everyday use and is made
-available without any support at the moment. With that said, we welcome any kind
-of feedback on any [communication channels](#communication-channels)
+* 2024-05-23: [IREE joins the LF AI & Data Foundation as a sandbox-stage project](https://lfaidata.foundation/blog/2024/05/23/announcing-iree-a-new-initiative-for-machine-learning-deployment/)
 
-#### Release status
+## Project status
+
+### Release status
+
+Releases notes are
+[published on GitHub releases](https://github.com/iree-org/iree/releases?q=prerelease%3Afalse).
+
 
 | Package | Release status |
 | -- | -- |
@@ -32,7 +34,7 @@ GitHub release (nightly) | [![GitHub Release](https://img.shields.io/github/v/re
 Python iree-base-compiler | [![PyPI version](https://badge.fury.io/py/iree-base-compiler.svg)](https://badge.fury.io/py/iree-base-compiler)
 Python iree-base-runtime | [![PyPI version](https://badge.fury.io/py/iree-base-runtime.svg)](https://badge.fury.io/py/iree-base-runtime)
 
-#### Build status
+### Build status
 
 [![CI](https://github.com/iree-org/iree/actions/workflows/ci.yml/badge.svg?query=branch%3Amain+event%3Apush)](https://github.com/iree-org/iree/actions/workflows/ci.yml?query=branch%3Amain+event%3Apush)
 [![PkgCI](https://github.com/iree-org/iree/actions/workflows/pkgci.yml/badge.svg?query=branch%3Amain+event%3Apush)](https://github.com/iree-org/iree/actions/workflows/pkgci.yml?query=branch%3Amain+event%3Apush)
@@ -46,7 +48,7 @@ Windows | [![CI - Windows x64 MSVC](https://github.com/iree-org/iree/actions/wor
 For the full list of workflows see
 https://iree.dev/developers/general/github-actions/.
 
-## Communication Channels
+## Communication channels
 
 *   [GitHub issues](https://github.com/iree-org/iree/issues): Feature requests,
     bugs, and other work tracking
@@ -59,14 +61,14 @@ https://iree.dev/developers/general/github-actions/.
 *   (Legacy) [iree-discuss email list](https://groups.google.com/forum/#!forum/iree-discuss):
     Announcements, general and low-priority discussion
 
-#### Related Project Channels
+### Related project channels
 
 *   [MLIR topic within LLVM Discourse](https://llvm.discourse.group/c/llvm-project/mlir/31):
     IREE is enabled by and heavily relies on [MLIR](https://mlir.llvm.org). IREE
     sometimes is referred to in certain MLIR discussions. Useful if you are also
     interested in MLIR evolution.
 
-## Architecture Overview
+## Architecture overview
 
 <!-- TODO(scotttodd): switch to <picture> once better supported? https://github.blog/changelog/2022-05-19-specify-theme-context-for-images-in-markdown-beta/ -->
 ![IREE Architecture](docs/website/docs/assets/images/iree_architecture_dark.svg#gh-dark-mode-only)
@@ -74,21 +76,16 @@ https://iree.dev/developers/general/github-actions/.
 
 See [our website](https://iree.dev/) for more information.
 
-## Presentations and Talks
+## Presentations and talks
 
 Community meeting recordings: [IREE YouTube channel](https://www.youtube.com/@iree4356)
 
-*   2021-06-09: IREE Runtime Design Tech Talk ([recording](https://drive.google.com/file/d/1p0DcysaIg8rC7ErKYEgutQkOJGPFCU3s/view) and [slides](https://drive.google.com/file/d/1ikgOdZxnMz1ExqwrAiuTY9exbe3yMWbB/view?usp=sharing))
-*   2020-08-20: IREE CodeGen: MLIR Open Design Meeting Presentation
-    ([recording](https://drive.google.com/file/d/1325zKXnNIXGw3cdWrDWJ1-bp952wvC6W/view?usp=sharing)
-    and
-    [slides](https://docs.google.com/presentation/d/1NetHjKAOYg49KixY5tELqFp6Zr2v8_ujGzWZ_3xvqC8/edit))
-*   2020-03-18: Interactive HAL IR Walkthrough
-    ([recording](https://drive.google.com/file/d/1_sWDgAPDfrGQZdxAapSA90AD1jVfhp-f/view?usp=sharing))
-*   2020-01-31: End-to-end MLIR Workflow in IREE: MLIR Open Design Meeting Presentation
-    ([recording](https://drive.google.com/open?id=1os9FaPodPI59uj7JJI3aXnTzkuttuVkR)
-    and
-    [slides](https://drive.google.com/open?id=1RCQ4ZPQFK9cVgu3IH1e5xbrBcqy7d_cEZ578j84OvYI))
+Date | Title | Recording | Slides
+---- | ----- | --------- | ------
+2021-06-09 | IREE Runtime Design Tech Talk | [recording](https://drive.google.com/file/d/1p0DcysaIg8rC7ErKYEgutQkOJGPFCU3s/view) | [slides](https://drive.google.com/file/d/1ikgOdZxnMz1ExqwrAiuTY9exbe3yMWbB/view?usp=sharing)
+2020-08-20 | IREE CodeGen (MLIR Open Design Meeting) | [recording](https://drive.google.com/file/d/1325zKXnNIXGw3cdWrDWJ1-bp952wvC6W/view?usp=sharing) | [slides](https://docs.google.com/presentation/d/1NetHjKAOYg49KixY5tELqFp6Zr2v8_ujGzWZ_3xvqC8/edit)
+2020-03-18 | Interactive HAL IR Walkthrough | [recording](https://drive.google.com/file/d/1_sWDgAPDfrGQZdxAapSA90AD1jVfhp-f/view?usp=sharing) |
+2020-01-31 | End-to-end MLIR Workflow in IREE (MLIR Open Design Meeting) | [recording](https://drive.google.com/open?id=1os9FaPodPI59uj7JJI3aXnTzkuttuVkR) | [slides](https://drive.google.com/open?id=1RCQ4ZPQFK9cVgu3IH1e5xbrBcqy7d_cEZ578j84OvYI)
 
 ## License
 

--- a/docs/website/docs/developers/general/release-management.md
+++ b/docs/website/docs/developers/general/release-management.md
@@ -15,6 +15,9 @@ We periodically promote one of these candidates to a "stable" release by
 removing the "pre-release" status. This makes it show up as a "latest" release
 on GitHub. We also push the Python packages for this release to PyPI.
 
+All stable (non-prerelease) releases can be viewed at
+<https://github.com/iree-org/iree/releases?q=prerelease%3Afalse>.
+
 ## Release status
 
 | Package | Release status |

--- a/docs/website/docs/index.md
+++ b/docs/website/docs/index.md
@@ -209,7 +209,7 @@ See how IREE is used:
 
 ## :octicons-project-24: Project operations
 
-### :octicons-file-code-24: Developer documentation
+### :octicons-book-24: Developer documentation
 
 Interested in contributing to IREE? Check out our developer documentation:
 

--- a/docs/website/docs/index.md
+++ b/docs/website/docs/index.md
@@ -11,7 +11,7 @@ lowers Machine Learning (ML) models to a unified IR that scales up to meet the
 needs of the datacenter and down to satisfy the constraints and special
 considerations of mobile and edge deployments.
 
-## Key features
+## :octicons-sparkles-fill-16: Key features
 
 <div class="grid cards" markdown>
 
@@ -61,7 +61,7 @@ considerations of mobile and edge deployments.
 
 </div>
 
-## Support matrix
+## :material-table-star: Support matrix
 
 IREE supports importing from a variety of ML frameworks:
 
@@ -97,7 +97,7 @@ Support for hardware accelerators and APIs is also included:
 - [ ] AMD AIE (experimental)
 - [ ] WebGPU (experimental)
 
-## Project architecture
+## :octicons-telescope-fill-24: Project architecture
 
 IREE adopts a _holistic_ approach towards ML model compilation: the IR produced
 contains both the _scheduling_ logic, required to communicate data dependencies
@@ -109,7 +109,7 @@ like [SPIR-V](https://www.khronos.org/spir/).
 ![IREE Architecture](./assets/images/iree_architecture_dark.svg#gh-dark-mode-only)
 ![IREE Architecture](./assets/images/iree_architecture.svg#gh-light-mode-only)
 
-## Workflow overview
+## :octicons-book-16: Workflow overview
 
 Using IREE involves the following general steps:
 
@@ -132,7 +132,7 @@ Using IREE involves the following general steps:
 
     Use IREE's runtime components to execute your compiled model
 
-### Importing models from ML frameworks
+### :octicons-package-dependents-16: Importing models from ML frameworks
 
 IREE supports importing models from a growing list of
 [ML frameworks](./guides/ml-frameworks/index.md) and model formats:
@@ -143,7 +143,7 @@ IREE supports importing models from a growing list of
 * [:simple-tensorflow: TensorFlow](./guides/ml-frameworks/tensorflow.md) and
   [:simple-tensorflow: TensorFlow Lite](./guides/ml-frameworks/tflite.md)
 
-### Selecting deployment configurations
+### :octicons-rocket-24: Selecting deployment configurations
 
 IREE provides a flexible set of tools for various
 [deployment scenarios](./guides/deployment-configurations/index.md). Fully
@@ -159,7 +159,7 @@ runtime entirely or interface with custom accelerators.
 IREE supports the full set of these configurations using the same underlying
 technology.
 
-### Compiling models
+### :octicons-file-code-24: Compiling models
 
 Model compilation is performed ahead-of-time on a _host_ machine for any
 combination of _targets_. The compilation process converts from layers and
@@ -172,13 +172,27 @@ SPIR-V kernels and Vulkan API calls. For
 [CPU execution](./guides/deployment-configurations/cpu.md), native code with
 static or dynamic linkage and the associated function calls are generated.
 
-### Running models
+### :octicons-terminal-24: Running models
 
 IREE offers a low level C API, as well as several sets of
 [API bindings](./reference/bindings/index.md) for compiling and running programs
 using various languages.
 
-## Communication channels
+## :octicons-people-24: Community
+
+IREE is a [sandbox-stage project](https://lfaidata.foundation/projects/iree/)
+of [LF AI & Data Foundation](https://lfaidata.foundation/) made possible thanks
+to a growing community of developers.
+
+See how IREE is used:
+
+[:octicons-arrow-right-24: Community](./community/index.md)
+
+### :material-newspaper: Project news
+
+* 2024-05-23: [IREE joins the LF AI & Data Foundation as a sandbox-stage project](https://lfaidata.foundation/blog/2024/05/23/announcing-iree-a-new-initiative-for-machine-learning-deployment/)
+
+### :octicons-broadcast-24: Communication channels
 
 * :fontawesome-brands-github:
   [GitHub issues](https://github.com/iree-org/iree/issues): Feature requests,
@@ -193,10 +207,19 @@ using various languages.
 * :fontawesome-solid-envelope: (Legacy) [iree-discuss email list](https://groups.google.com/forum/#!forum/iree-discuss):
   Announcements, general and low-priority discussion
 
-## Roadmap
+## :octicons-project-24: Project operations
 
-IREE is in the early stages of development and is not yet ready for broad
-adoption. We use both
+### :octicons-file-code-24: Developer documentation
+
+Interested in contributing to IREE? Check out our developer documentation:
+
+[:octicons-arrow-right-24: Developers](./developers/index.md)
+
+### :octicons-project-roadmap-24: Roadmap
+
+IREE uses
+[GitHub Issues](https://github.com/iree-org/iree/issues) for most work
+planning. Some subprojects use both
 [GitHub Projects](https://github.com/iree-org/iree/projects) and
 [GitHub Milestones](https://github.com/iree-org/iree/milestones) to track
 progress.

--- a/docs/website/requirements.txt
+++ b/docs/website/requirements.txt
@@ -1,2 +1,2 @@
-mkdocs-material==9.5.19
+mkdocs-material==9.5.48
 mkdocs-redirects==1.2.1


### PR DESCRIPTION
* Replace "IREE is still in its early phase." language with information about IREE being a sandbox project at the LF AI & Data Foundation.
* Link to release notes via the non-prerelease releases page since the standard https://github.com/iree-org/iree/releases page is littered with nightly releases. Grouping prereleases under a single release like in iree-turbine and other projects would help here too.
* Format "Presentations and talks" section with a table. We've had a few talks that aren't yet included here and the community meetings are now split between YouTube and Zoom (LF AI) ... not sure how best to organize them.
* Add more icons to https://iree.dev/ homepage and expand on sections: 
![image](https://github.com/user-attachments/assets/ecfc2fbb-46af-4d7c-bb19-f11d4d20f229)
