### PR TITLE
[PJRT] Fix compile error while tracing is enabled

### DIFF
--- a/integrations/pjrt/src/iree_pjrt/common/api_impl.cc
+++ b/integrations/pjrt/src/iree_pjrt/common/api_impl.cc
@@ -1777,7 +1777,7 @@ void ExecutableImage::BindApi(PJRT_Api* api) {
   };
   api->PJRT_Executable_Name =
       +[](PJRT_Executable_Name_Args* args) -> PJRT_Error* {
-    IREE_TRACE_SCOPE_NAMED(PJRT_Executable_Name);
+    IREE_TRACE_SCOPE_NAMED("PJRT_Executable_Name");
     const char* dummy_name = "iree_vmfb";
     args->executable_name = dummy_name;
     args->executable_name_size = strlen(dummy_name);


### PR DESCRIPTION
While trace is enabled in the PJRT plugin, i.e. cmake option `-DIREE_ENABLE_RUNTIME_TRACING=ON` is passed, the compilation will abort due to a wrong use of `IREE_TRACE_SCOPE_NAMED`, where an undefined identifier is passed as a name. And it should be a string literal instead, as in other places.

ci-exactly: build_packages, test_pjrt