### PR TITLE
[Codegen][Tuner] attr verifier for tuning specs

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
@@ -126,8 +126,7 @@ emitLinkedTuningSpec(ModuleOp module, ArrayRef<NamedSequenceOp> specsToLink) {
   builder.create<transform::YieldOp>(loc, operand);
 
   if (failed(mlir::verify(module))) {
-    module.emitError("Linked tuning spec failed to verify");
-    return failure();
+    return module.emitError("Linked tuning spec failed to verify");
   }
 
   return newSpec;

--- a/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
@@ -124,6 +124,12 @@ emitLinkedTuningSpec(ModuleOp module, ArrayRef<NamedSequenceOp> specsToLink) {
   }
 
   builder.create<transform::YieldOp>(loc, operand);
+
+  if (failed(mlir::verify(module))) {
+    module.emitError("verification failed for operation in linked "
+                     "tuning spec");
+  }
+
   return newSpec;
 }
 
@@ -144,9 +150,6 @@ struct LinkTuningSpecsPass final
 
 FailureOr<NamedSequenceOp> linkTuningSpecs(ModuleOp module) {
   SmallVector<NamedSequenceOp> tuningSpecs;
-
-  if (failed(mlir::verify(module)))
-    return failure();
 
   for (ModuleOp nested : findNestedModulesWithNamedSequences(module)) {
     llvm::append_range(tuningSpecs, findTuningSpecs(nested));

--- a/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
@@ -71,6 +71,13 @@ static LogicalResult validateTuningSpec(NamedSequenceOp op) {
                                "single any_op argument";
   }
 
+  // Validate that the attribute is present.
+  if (!op->hasAttr(kTuningSpecEntrypointAttrName)) {
+    return op.emitError()
+           << "Expected the `iree_codegen.tuning_spec_entrypoint` attribute on "
+              "tuning specs";
+  }
+
   return success();
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
@@ -71,13 +71,6 @@ static LogicalResult validateTuningSpec(NamedSequenceOp op) {
                                "single any_op argument";
   }
 
-  // Validate that the attribute is present.
-  if (!op->hasAttr(kTuningSpecEntrypointAttrName)) {
-    return op.emitError()
-           << "Expected the `iree_codegen.tuning_spec_entrypoint` attribute on "
-              "tuning specs";
-  }
-
   return success();
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
@@ -61,7 +61,7 @@ static bool consumesInputOp(NamedSequenceOp op) {
   return false;
 }
 
-static NamedSequenceOp
+static FailureOr<NamedSequenceOp>
 emitLinkedTuningSpec(ModuleOp module, ArrayRef<NamedSequenceOp> specsToLink) {
   OpBuilder builder(module->getContext());
   builder.setInsertionPointToEnd(module.getBody());
@@ -126,8 +126,8 @@ emitLinkedTuningSpec(ModuleOp module, ArrayRef<NamedSequenceOp> specsToLink) {
   builder.create<transform::YieldOp>(loc, operand);
 
   if (failed(mlir::verify(module))) {
-    module.emitError("verification failed for operation in linked "
-                     "tuning spec");
+    module.emitError("Linked tuning spec failed to verify");
+    return failure();
   }
 
   return newSpec;

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeTuningSpecsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeTuningSpecsPass.cpp
@@ -143,6 +143,11 @@ getDefaultTuningSpec(ModuleOp module,
       dialect.getOrParseTransformLibraryModule(defaultTuningSpecName,
                                                *defaultTuningSpecSource);
 
+  if (failed(defaultTransformLibrary)) {
+    return module->emitError()
+           << "Failed to load  default tuning spec" << defaultTuningSpecName;
+  }
+
 #ifndef NDEBUG
   if (failed(mlir::verify(*defaultTransformLibrary)))
     return (*defaultTransformLibrary).emitError()
@@ -247,13 +252,6 @@ struct MaterializeTuningSpecsPass final
         linkTuningSpecs(linkedTuningSpec.get());
     if (failed(newEntrypoint)) {
       module->emitError("Failed to link tuning specs");
-      return signalPassFailure();
-    }
-
-    if (failed(mlir::verify(linkedTuningSpec.get()))) {
-      linkedTuningSpec.get().emitError(
-          "Attribute verification failed for operation in linked "
-          "tuning spec");
       return signalPassFailure();
     }
 

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeTuningSpecsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeTuningSpecsPass.cpp
@@ -143,15 +143,12 @@ getDefaultTuningSpec(ModuleOp module,
       dialect.getOrParseTransformLibraryModule(defaultTuningSpecName,
                                                *defaultTuningSpecSource);
 
-  if (failed(defaultTransformLibrary)) {
-    return module->emitError()
-           << "Failed to load  default tuning spec" << defaultTuningSpecName;
-  }
-
 #ifndef NDEBUG
-  if (failed(mlir::verify(*defaultTransformLibrary)))
+  if (succeeded(defaultTransformLibrary) &&
+      failed(mlir::verify(*defaultTransformLibrary)))
     return (*defaultTransformLibrary).emitError()
-           << "Verification failed for default tuning spec";
+           << "Default tuning spec " << defaultTuningSpecName
+           << " failed to verify";
 #endif
 
   return *defaultTransformLibrary;

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeTuningSpecsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeTuningSpecsPass.cpp
@@ -151,7 +151,7 @@ getDefaultTuningSpec(ModuleOp module,
            << " failed to verify";
 #endif
 
-  return *defaultTransformLibrary;
+  return defaultTransformLibrary;
 }
 
 static FailureOr<DenseElementsAttr>

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -96,6 +96,7 @@ iree_lit_test_suite(
             "vector_layout_analysis.mlir",
             "vectorize_memref_copy.mlir",
             "vectorize_tensor_pad.mlir",
+            "verify_tuning_specs.mlir",
             "verify_workgroup_distribution.mlir",
             "vmvx_materialize_encoding.mlir",
         ],

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -92,6 +92,7 @@ iree_lit_test_suite(
     "vector_layout_analysis.mlir"
     "vectorize_memref_copy.mlir"
     "vectorize_tensor_pad.mlir"
+    "verify_tuning_specs.mlir"
     "verify_workgroup_distribution.mlir"
     "vmvx_materialize_encoding.mlir"
   TOOLS

--- a/compiler/src/iree/compiler/Codegen/Common/test/verify_tuning_specs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/verify_tuning_specs.mlir
@@ -1,0 +1,18 @@
+// RUN: iree-opt --no-implicit-module --verify-diagnostics -split-input-file --mlir-disable-threading %s
+
+module @td_module attributes { transform.with_named_sequence } {
+  module @foo_module attributes { transform.with_named_sequence } {
+    // expected-error @+1{{found unsupported 'iree_codegen.something' attribute on operation}}
+    transform.named_sequence @foo(%arg0: !transform.any_op {transform.readonly}) -> !transform.any_op
+      attributes { iree_codegen.something } {
+      transform.yield %arg0 : !transform.any_op
+    }
+    transform.named_sequence @bar(%arg0: !transform.any_op {transform.readonly}) -> !transform.any_op
+      attributes { iree_codegen.tuning_spec_entrypoint } {
+      transform.yield %arg0 : !transform.any_op
+    }
+    func.func @baz(%arg0: i32) -> () {
+      return
+    }
+  }
+}

--- a/compiler/src/iree/compiler/Codegen/Common/test/verify_tuning_specs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/verify_tuning_specs.mlir
@@ -1,17 +1,17 @@
 // RUN: iree-opt --verify-diagnostics --split-input-file %s
 
 module @foo_module attributes { transform.with_named_sequence } {
-  // expected-error @+1{{'iree_codegen.tuning_spec_entrypoint' attribute must be a UnitAttr}}
-  transform.named_sequence @foo(%arg0: !transform.any_op {transform.readonly}) -> !transform.any_op
-    attributes { iree_codegen.tuning_spec_entrypoint = "foo" } {
-    transform.yield %arg0 : !transform.any_op
+  func.func @baz(%arg0: i32) -> () {
+    return
   }
   transform.named_sequence @bar(%arg0: !transform.any_op {transform.readonly}) -> !transform.any_op
     attributes { iree_codegen.something } {
     transform.yield %arg0 : !transform.any_op
   }
-  func.func @baz(%arg0: i32) -> () {
-    return
+  // expected-error @+1{{'iree_codegen.tuning_spec_entrypoint' attribute must be a UnitAttr}}
+  transform.named_sequence @foo(%arg0: !transform.any_op {transform.readonly}) -> !transform.any_op
+    attributes { iree_codegen.tuning_spec_entrypoint = "foo" } {
+    transform.yield %arg0 : !transform.any_op
   }
 }
 
@@ -30,9 +30,7 @@ module @foo_module attributes { transform.with_named_sequence } {
 module @foo_module attributes { transform.with_named_sequence } {
   // expected-error @+1{{Tuning spec entry point expected to have a single any_op argument}}
   transform.named_sequence @foo(%arg0: i32) -> !transform.any_op
-    attributes { iree_codegen.tuning_spec_entrypoint } {
-
-  }
+    attributes { iree_codegen.tuning_spec_entrypoint } {}
 }
 
 // -----
@@ -51,7 +49,5 @@ module @foo_module attributes { transform.with_named_sequence } {
 module @foo_module attributes { transform.with_named_sequence } {
   // expected-error @+1{{Tuning spec entry point expected to return any_op}}
   transform.named_sequence @foo(%arg0: !transform.any_op {transform.readonly})
-    attributes { iree_codegen.tuning_spec_entrypoint } {
-
-  }
+    attributes { iree_codegen.tuning_spec_entrypoint } {}
 }

--- a/compiler/src/iree/compiler/Codegen/Common/test/verify_tuning_specs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/verify_tuning_specs.mlir
@@ -2,9 +2,9 @@
 
 module @td_module attributes { transform.with_named_sequence } {
   module @foo_module attributes { transform.with_named_sequence } {
-    // expected-error @+1{{found unsupported 'iree_codegen.something' attribute on operation}}
+    // expected-error @+1{{'iree_codegen.tuning_spec_entrypoint' attribute must be a UnitAttr}}
     transform.named_sequence @foo(%arg0: !transform.any_op {transform.readonly}) -> !transform.any_op
-      attributes { iree_codegen.something } {
+      attributes { iree_codegen.tuning_spec_entrypoint = "foo" } {
       transform.yield %arg0 : !transform.any_op
     }
     transform.named_sequence @bar(%arg0: !transform.any_op {transform.readonly}) -> !transform.any_op

--- a/compiler/src/iree/compiler/Codegen/Common/test/verify_tuning_specs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/verify_tuning_specs.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --no-implicit-module --verify-diagnostics -split-input-file --mlir-disable-threading %s
+// RUN: iree-opt  --verify-diagnostics --split-input-file  %s
 
 module @td_module attributes { transform.with_named_sequence } {
   module @foo_module attributes { transform.with_named_sequence } {
@@ -8,8 +8,54 @@ module @td_module attributes { transform.with_named_sequence } {
       transform.yield %arg0 : !transform.any_op
     }
     transform.named_sequence @bar(%arg0: !transform.any_op {transform.readonly}) -> !transform.any_op
+      attributes { iree_codegen.something } {
+      transform.yield %arg0 : !transform.any_op
+    }
+    func.func @baz(%arg0: i32) -> () {
+      return
+    }
+  }
+}
+
+// -----
+
+module @td_module attributes { transform.with_named_sequence } {
+  module @foo_module attributes { transform.with_named_sequence } {
+    // expected-error @+1{{Tuning spec entry point expected to have a single any_op argument}}
+    transform.named_sequence @foo(%arg0: !transform.any_op {transform.readonly}, %arg1: !transform.any_op {transform.readonly}) -> !transform.any_op
       attributes { iree_codegen.tuning_spec_entrypoint } {
       transform.yield %arg0 : !transform.any_op
+    }
+    func.func @baz(%arg0: i32) -> () {
+      return
+    }
+  }
+}
+
+// -----
+
+module @td_module attributes { transform.with_named_sequence } {
+  module @foo_module attributes { transform.with_named_sequence } {
+    // expected-error @+1{{Tuning spec entry point expected to return any_op}}
+    transform.named_sequence @foo(%arg0: !transform.any_op {transform.readonly}) -> i32
+      attributes { iree_codegen.tuning_spec_entrypoint } {
+      %0 = arith.constant 0 : i32
+      transform.yield %0 : i32
+    }
+    func.func @baz(%arg0: i32) -> () {
+      return
+    }
+  }
+}
+
+// -----
+
+module @td_module attributes { transform.with_named_sequence } {
+  module @foo_module attributes { transform.with_named_sequence } {
+    // expected-error @+1{{Tuning spec entry point expected to have a single any_op argument}}
+    transform.named_sequence @foo(%arg0: i32) -> !transform.any_op
+      attributes { iree_codegen.tuning_spec_entrypoint } {
+
     }
     func.func @baz(%arg0: i32) -> () {
       return

--- a/compiler/src/iree/compiler/Codegen/Common/test/verify_tuning_specs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/verify_tuning_specs.mlir
@@ -1,64 +1,57 @@
-// RUN: iree-opt  --verify-diagnostics --split-input-file  %s
+// RUN: iree-opt --verify-diagnostics --split-input-file %s
 
-module @td_module attributes { transform.with_named_sequence } {
-  module @foo_module attributes { transform.with_named_sequence } {
-    // expected-error @+1{{'iree_codegen.tuning_spec_entrypoint' attribute must be a UnitAttr}}
-    transform.named_sequence @foo(%arg0: !transform.any_op {transform.readonly}) -> !transform.any_op
-      attributes { iree_codegen.tuning_spec_entrypoint = "foo" } {
-      transform.yield %arg0 : !transform.any_op
-    }
-    transform.named_sequence @bar(%arg0: !transform.any_op {transform.readonly}) -> !transform.any_op
-      attributes { iree_codegen.something } {
-      transform.yield %arg0 : !transform.any_op
-    }
-    func.func @baz(%arg0: i32) -> () {
-      return
-    }
+module @foo_module attributes { transform.with_named_sequence } {
+  // expected-error @+1{{'iree_codegen.tuning_spec_entrypoint' attribute must be a UnitAttr}}
+  transform.named_sequence @foo(%arg0: !transform.any_op {transform.readonly}) -> !transform.any_op
+    attributes { iree_codegen.tuning_spec_entrypoint = "foo" } {
+    transform.yield %arg0 : !transform.any_op
+  }
+  transform.named_sequence @bar(%arg0: !transform.any_op {transform.readonly}) -> !transform.any_op
+    attributes { iree_codegen.something } {
+    transform.yield %arg0 : !transform.any_op
+  }
+  func.func @baz(%arg0: i32) -> () {
+    return
   }
 }
 
 // -----
 
-module @td_module attributes { transform.with_named_sequence } {
-  module @foo_module attributes { transform.with_named_sequence } {
-    // expected-error @+1{{Tuning spec entry point expected to have a single any_op argument}}
-    transform.named_sequence @foo(%arg0: !transform.any_op {transform.readonly}, %arg1: !transform.any_op {transform.readonly}) -> !transform.any_op
-      attributes { iree_codegen.tuning_spec_entrypoint } {
-      transform.yield %arg0 : !transform.any_op
-    }
-    func.func @baz(%arg0: i32) -> () {
-      return
-    }
+module @foo_module attributes { transform.with_named_sequence } {
+  // expected-error @+1{{Tuning spec entry point expected to have a single any_op argument}}
+  transform.named_sequence @foo(%arg0: !transform.any_op {transform.readonly}, %arg1: !transform.any_op {transform.readonly}) -> !transform.any_op
+    attributes { iree_codegen.tuning_spec_entrypoint } {
+    transform.yield %arg0 : !transform.any_op
   }
 }
 
 // -----
 
-module @td_module attributes { transform.with_named_sequence } {
-  module @foo_module attributes { transform.with_named_sequence } {
-    // expected-error @+1{{Tuning spec entry point expected to return any_op}}
-    transform.named_sequence @foo(%arg0: !transform.any_op {transform.readonly}) -> i32
-      attributes { iree_codegen.tuning_spec_entrypoint } {
-      %0 = arith.constant 0 : i32
-      transform.yield %0 : i32
-    }
-    func.func @baz(%arg0: i32) -> () {
-      return
-    }
+module @foo_module attributes { transform.with_named_sequence } {
+  // expected-error @+1{{Tuning spec entry point expected to have a single any_op argument}}
+  transform.named_sequence @foo(%arg0: i32) -> !transform.any_op
+    attributes { iree_codegen.tuning_spec_entrypoint } {
+
   }
 }
 
 // -----
 
-module @td_module attributes { transform.with_named_sequence } {
-  module @foo_module attributes { transform.with_named_sequence } {
-    // expected-error @+1{{Tuning spec entry point expected to have a single any_op argument}}
-    transform.named_sequence @foo(%arg0: i32) -> !transform.any_op
-      attributes { iree_codegen.tuning_spec_entrypoint } {
+module @foo_module attributes { transform.with_named_sequence } {
+  // expected-error @+1{{Tuning spec entry point expected to return any_op}}
+  transform.named_sequence @foo(%arg0: !transform.any_op {transform.readonly}) -> i32
+    attributes { iree_codegen.tuning_spec_entrypoint } {
+    %0 = arith.constant 0 : i32
+    transform.yield %0 : i32
+  }
+}
 
-    }
-    func.func @baz(%arg0: i32) -> () {
-      return
-    }
+// -----
+
+module @foo_module attributes { transform.with_named_sequence } {
+  // expected-error @+1{{Tuning spec entry point expected to return any_op}}
+  transform.named_sequence @foo(%arg0: !transform.any_op {transform.readonly})
+    attributes { iree_codegen.tuning_spec_entrypoint } {
+
   }
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.cpp
@@ -45,4 +45,10 @@ void IREECodegenDialect::initialize() {
       >();
 }
 
+LogicalResult
+IREECodegenDialect::verifyOperationAttribute(Operation *op,
+                                             NamedAttribute namedAttr) {
+  return success();
+}
+
 } // namespace mlir::iree_compiler::IREE::Codegen

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.cpp
@@ -66,7 +66,6 @@ IREECodegenDialect::verifyOperationAttribute(Operation *op,
   if (symbol != kTuningSpecEntrypointAttrName)
     return success();
 
-  // Verify that the attribute is a UnitAttr.
   if (!isa<UnitAttr>(attr)) {
     return op->emitError("'") << symbol << "' attribute must be a UnitAttr";
   }

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.cpp
@@ -50,7 +50,6 @@ IREECodegenDialect::verifyOperationAttribute(Operation *op,
                                              NamedAttribute attribute) {
   StringRef symbol = attribute.getName().strref();
   Attribute attr = attribute.getValue();
-
   if (symbol == kTuningSpecEntrypointAttrName) {
     if (!llvm::isa<UnitAttr>(attr)) {
       return op->emitError("'") << symbol << "' attribute must be a UnitAttr";
@@ -59,22 +58,6 @@ IREECodegenDialect::verifyOperationAttribute(Operation *op,
     return op->emitError("found unsupported '")
            << symbol << "' attribute on operation";
   }
-  return success();
-}
-
-LogicalResult IREECodegenDialect::verifyRegionArgAttribute(
-    Operation *op, unsigned regionIndex, unsigned argIndex,
-    NamedAttribute attribute) {
-  StringRef symbol = attribute.getName().strref();
-  llvm::outs() << "symbol Arg " << symbol << "\n";
-  return success();
-}
-
-LogicalResult IREECodegenDialect::verifyRegionResultAttribute(
-    Operation *op, unsigned /*regionIndex*/, unsigned /*resultIndex*/,
-    NamedAttribute attribute) {
-  StringRef symbol = attribute.getName().strref();
-  llvm::outs() << "symbol Res " << symbol << "\n";
   return success();
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.cpp
@@ -47,7 +47,34 @@ void IREECodegenDialect::initialize() {
 
 LogicalResult
 IREECodegenDialect::verifyOperationAttribute(Operation *op,
-                                             NamedAttribute namedAttr) {
+                                             NamedAttribute attribute) {
+  StringRef symbol = attribute.getName().strref();
+  Attribute attr = attribute.getValue();
+
+  if (symbol == kTuningSpecEntrypointAttrName) {
+    if (!llvm::isa<UnitAttr>(attr)) {
+      return op->emitError("'") << symbol << "' attribute must be a UnitAttr";
+    }
+  } else {
+    return op->emitError("found unsupported '")
+           << symbol << "' attribute on operation";
+  }
+  return success();
+}
+
+LogicalResult IREECodegenDialect::verifyRegionArgAttribute(
+    Operation *op, unsigned regionIndex, unsigned argIndex,
+    NamedAttribute attribute) {
+  StringRef symbol = attribute.getName().strref();
+  llvm::outs() << "symbol Arg " << symbol << "\n";
+  return success();
+}
+
+LogicalResult IREECodegenDialect::verifyRegionResultAttribute(
+    Operation *op, unsigned /*regionIndex*/, unsigned /*resultIndex*/,
+    NamedAttribute attribute) {
+  StringRef symbol = attribute.getName().strref();
+  llvm::outs() << "symbol Res " << symbol << "\n";
   return success();
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.cpp
@@ -84,8 +84,6 @@ IREECodegenDialect::verifyOperationAttribute(Operation *op,
              << "Tuning spec entry point expected to have a "
                 "single any_op argument";
     }
-
-    return success();
   }
 
   return success();

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.td
@@ -69,8 +69,6 @@ def IREECodegen_Dialect : Dialect {
   }];
   let useDefaultAttributePrinterParser = 1;
   let hasOperationAttrVerify = 1;
-  let hasRegionArgAttrVerify = 1;
-  let hasRegionResultAttrVerify = 1;
 }
 
 def AnyRankedTensorOrMemRefType : AnyTypeOf<[AnyRankedTensor, AnyMemRef]>;

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.td
@@ -69,6 +69,8 @@ def IREECodegen_Dialect : Dialect {
   }];
   let useDefaultAttributePrinterParser = 1;
   let hasOperationAttrVerify = 1;
+  let hasRegionArgAttrVerify = 1;
+  let hasRegionResultAttrVerify = 1;
 }
 
 def AnyRankedTensorOrMemRefType : AnyTypeOf<[AnyRankedTensor, AnyMemRef]>;

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.td
@@ -68,6 +68,7 @@ def IREECodegen_Dialect : Dialect {
     std::mutex libraryMutex;
   }];
   let useDefaultAttributePrinterParser = 1;
+  let hasOperationAttrVerify = 1;
 }
 
 def AnyRankedTensorOrMemRefType : AnyTypeOf<[AnyRankedTensor, AnyMemRef]>;


### PR DESCRIPTION
This PR is relevant to task in https://github.com/iree-org/iree/issues/19214: add [a discardable attr verifier](https://mlir.llvm.org/docs/DefiningDialects/#discardable-attribute-verification) for entry points iree_codegen.tuning_spec_entrypoint
