### PR TITLE
[PJRT] Fix stablehlo attribute parameters for buffer transpose and broadcast

### DIFF
--- a/integrations/pjrt/src/iree_pjrt/common/api_impl.cc
+++ b/integrations/pjrt/src/iree_pjrt/common/api_impl.cc
@@ -955,17 +955,17 @@ iree_status_t DeviceInstance::TransposeBroadcastDeviceBuffer(
 
   auto arrayBuilder = [](const int64_t* vals, int64_t sz) {
     std::stringstream ss;
-    ss << " {permutation = dense<[" << vals[0];
+    ss << " {permutation = array<i64: " << vals[0];
     for (int i = 1; i < sz; ++i) ss << ", " << vals[i];
-    ss << "]> : tensor<" << sz << "xi64>}";
+    ss << ">}";
     return ss.str();
   };
 
   auto broadcastBuilder = [](int64_t sz) {
     std::stringstream ss;
-    ss << "{broadcast_dimensions = dense<[0";
+    ss << "{broadcast_dimensions = array<i64: 0";
     for (int i = 1; i < sz; ++i) ss << ", " << i;
-    ss << "]> : tensor<" << sz << "xi64>}";
+    ss << ">}";
     return ss.str();
   };
 


### PR DESCRIPTION
If we copy a tensor from host to device in a multi-GPU environment (i.e. sharding is enabled, not a trivial copy), the frontend call of `jax.device_put` will go to `DeviceInstance::TransposeBroadcastDeviceBuffer` eventually.

And this function will generate a stablehlo program to be compiled and executed then. In the generated code, two operations (`stablehlo.broadcast_in_dim` and `stablehlo.transpose`) are included. According to [the spec of StableHLO](https://github.com/openxla/stablehlo/blob/main/docs/spec.md#transpose) (and also [the tblgen definitions](https://github.com/openxla/stablehlo/blob/38fe0f49d9b2bb70a36d3c535680070f6a5595e7/stablehlo/dialect/StablehloOps.td#L3058)), the parameter attribute `permutation` of `stablehlo.transpose` is typed `DenseI64ArrayAttr`.

However, in the function `DeviceInstance::TransposeBroadcastDeviceBuffer`, it will generate some code like `"stablehlo.transpose"(%x) {permutation = dense<[1,2,3]> : tensor<3xi64>} : ...`, which does not meet the definition of `stablehlo.transpose` and should be corrected as something like `"stablehlo.transpose"(%x) {permutation = array<i64: 1,2,3>} : ...`.

This PR is to fix it.

ci-exactly: build_packages, test_pjrt