### PR TITLE
Update LLVM to llvm/llvm-project@dd6f6a0

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
@@ -125,6 +125,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:GPUDialect",
         "@llvm-project//mlir:GPUTransformOps",
         "@llvm-project//mlir:GPUTransforms",
+        "@llvm-project//mlir:GPUUtils",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LLVMCommonConversion",
         "@llvm-project//mlir:LinalgDialect",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
@@ -103,6 +103,7 @@ iree_cc_library(
     MLIRGPUDialect
     MLIRGPUTransformOps
     MLIRGPUTransforms
+    MLIRGPUUtils
     MLIRIR
     MLIRLLVMCommonConversion
     MLIRLinalgDialect

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -17,7 +17,7 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/Utils.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
-#include "mlir/Dialect/GPU/Transforms/Utils.h"
+#include "mlir/Dialect/GPU/Utils/GPUUtils.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/AffineExpr.h"


### PR DESCRIPTION
Update LLVM to https://github.com/llvm/llvm-project/commit/3f136f7 (https://github.com/iree-org/iree/pull/19479)
Carrying the following reverts

- https://github.com/llvm/llvm-project/pull/116470
- https://github.com/llvm/llvm-project/pull/117424
- https://github.com/llvm/llvm-project/pull/119671
- https://github.com/llvm/llvm-project/pull/119970

First two are carry over from previous-previous integrate. It is being fixed in
https://github.com/iree-org/iree/pull/19451 . The last one is a from the previous integrate.
The last one is a new error being tracked in https://github.com/iree-org/iree/issues/19498