### PR TITLE
Revert "Skip test_sharktank job until quota issues are fixed."

### DIFF
--- a/.github/workflows/pkgci.yml
+++ b/.github/workflows/pkgci.yml
@@ -104,11 +104,10 @@ jobs:
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_onnx')
     uses: ./.github/workflows/pkgci_test_onnx.yml
 
-  # TODO(https://github.com/iree-org/iree-test-suites/issues/56): re-enable when git LFS quota is available
   test_sharktank:
     name: Test Sharktank
     needs: [setup, build_packages]
-    if: false && contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_sharktank')
+    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_sharktank')
     uses: ./.github/workflows/pkgci_test_sharktank.yml
 
   test_tensorflow:


### PR DESCRIPTION
Reverts iree-org/iree#19458.

Re-enable the tests now that we have some quota.

ci-exactly: build_packages, test_sharktank