### PR TITLE
[docs] Refresh `status: new` usage across website pages.

### DIFF
--- a/docs/website/docs/developers/general/versioning-scheme.md
+++ b/docs/website/docs/developers/general/versioning-scheme.md
@@ -1,5 +1,6 @@
 ---
 icon: octicons/versions-16
+status: new
 ---
 
 # Versioning scheme

--- a/docs/website/docs/guides/ml-frameworks/onnx.md
+++ b/docs/website/docs/guides/ml-frameworks/onnx.md
@@ -6,7 +6,6 @@ tags:
   - Python
   - PyTorch
 icon: simple/onnx
-status: new
 ---
 
 # ONNX support

--- a/docs/website/docs/guides/ml-frameworks/pytorch.md
+++ b/docs/website/docs/guides/ml-frameworks/pytorch.md
@@ -5,7 +5,6 @@ tags:
   - Python
   - PyTorch
 icon: simple/pytorch
-status: new
 ---
 
 # PyTorch + IREE = :octicons-heart-16:

--- a/docs/website/docs/guides/parameters.md
+++ b/docs/website/docs/guides/parameters.md
@@ -1,6 +1,5 @@
 ---
 icon: octicons/file-symlink-file-16
-status: new
 ---
 
 # Parameters

--- a/docs/website/docs/reference/tuning.md
+++ b/docs/website/docs/reference/tuning.md
@@ -1,5 +1,6 @@
 ---
 icon: octicons/meter-16
+status: new
 ---
 
 # Tuning


### PR DESCRIPTION
This puts a little icon to the right of each "new" page in the nav: 
![image](https://github.com/user-attachments/assets/949fb830-b48d-4348-9a26-d382498af901)

Docs: https://squidfunk.github.io/mkdocs-material/reference/?#setting-the-page-status

I liked having the "new" status next to the ONNX and PyTorch guides.... but those pages were added multiple months ago, so it's time to move on from that label.