### PR TITLE
[PJRT] Fix tensor element type for signed integers

### DIFF
--- a/integrations/pjrt/src/iree_pjrt/common/api_impl.cc
+++ b/integrations/pjrt/src/iree_pjrt/common/api_impl.cc
@@ -103,19 +103,19 @@ iree_status_t MapElementTypeToMlirType(iree_hal_element_type_t element_type,
       *ty = "i1";
       return iree_ok_status();
     case IREE_HAL_ELEMENT_TYPE_SINT_4:
-      *ty = "si4";
+      *ty = "i4";
       return iree_ok_status();
     case IREE_HAL_ELEMENT_TYPE_SINT_8:
-      *ty = "si8";
+      *ty = "i8";
       return iree_ok_status();
     case IREE_HAL_ELEMENT_TYPE_SINT_16:
-      *ty = "si16";
+      *ty = "i16";
       return iree_ok_status();
     case IREE_HAL_ELEMENT_TYPE_SINT_32:
-      *ty = "si32";
+      *ty = "i32";
       return iree_ok_status();
     case IREE_HAL_ELEMENT_TYPE_SINT_64:
-      *ty = "si64";
+      *ty = "i64";
       return iree_ok_status();
     case IREE_HAL_ELEMENT_TYPE_UINT_4:
       *ty = "ui4";


### PR DESCRIPTION
In PJRT, `MapElementTypeToMlirType` is used in `DeviceInstance::TransposeBroadcastDeviceBuffer` to generate stablehlo programs for transpose and broadcast tensors.

In the current implementation, `IREE_HAL_ELEMENT_TYPE_SINT_N` is mapped to MLIR type `siN`, which is straightforward. But it can produce errors, because in StableHLO ranked tensors of signed integers are not supported (due to a historical reason, I think).

For example, `stablehlo.tranpose` requires [a tensor with constraint `HLO_TensorOrPerAxisQuantizedTensor`](https://github.com/openxla/stablehlo/blob/9e0c9e34d02af255bfe8f896ba7dc910758c6ecf/stablehlo/dialect/StablehloOps.td#L3056-L3058). And `HLO_TensorOrPerAxisQuantizedTensor` is defined as [ranked tensor of many types](https://github.com/openxla/stablehlo/blob/9e0c9e34d02af255bfe8f896ba7dc910758c6ecf/stablehlo/dialect/Base.td#L174), including `HLO_Int`.

Here's the interesting thing: `HLO_Int` is defined as `HLO_SInt` or `HLO_UInt`, and `HLO_SInt` is defined as signless integers instead of signed integers:

https://github.com/openxla/stablehlo/blob/9e0c9e34d02af255bfe8f896ba7dc910758c6ecf/stablehlo/dialect/Base.td#L39-L43

And above this definition we can see a TODO that states it's due to legacy reasons.

In PJRT plugin MLIR type `siN` will be used to generate some code like `stablehlo.transpose %x : tensor<2x2xsi32>`, which is invalid in StableHLO and will lead to a verification error.

ci-exactly: build_packages, test_pjrt