### PR TITLE
[Stream] Implement SpecializeEncodings pass (1/n)

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
@@ -114,7 +114,7 @@ EncodingAttr EncodingAttr::clone(AffineMap bcastMap) {
              AffineMapAttr::get(bcastMap), getRoundDimsTo(), getLayouts());
 }
 
-EncodingAttr EncodingAttr::cloneWithLayouts(SmallVector<Attribute> layouts) {
+EncodingAttr EncodingAttr::cloneWithLayouts(ArrayRef<Attribute> layouts) {
   MLIRContext *ctx = getContext();
   return get(ctx, getOperandIndex(), getOpType(), getElementTypes(),
              /*user_indexing_maps=*/ArrayAttr(),

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
@@ -15,6 +15,7 @@
 #include "mlir/Dialect/Utils/StructuredOpsUtils.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Support/LLVM.h"
@@ -111,6 +112,15 @@ EncodingAttr EncodingAttr::clone(AffineMap bcastMap) {
   return get(bcastMap.getContext(), getOperandIndex(), getOpType(),
              getElementTypes(), getUserIndexingMaps(),
              AffineMapAttr::get(bcastMap), getRoundDimsTo(), getLayouts());
+}
+
+EncodingAttr EncodingAttr::cloneWithLayouts(SmallVector<Attribute> layouts) {
+  MLIRContext *ctx = getContext();
+  return get(ctx, getOperandIndex(), getOpType(), getElementTypes(),
+             /*user_indexing_maps=*/ArrayAttr(),
+             /*bcast_map=*/AffineMapAttr(),
+             /*round_dims_to=*/DenseI64ArrayAttr(),
+             ArrayAttr::get(ctx, layouts));
 }
 
 /// Returns the bit-width of the scalar type. If the type is complex, it returns

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -113,6 +113,10 @@ def EncodingAttr :
 
     /// Clones an encoding with a new bcast_map
     EncodingAttr clone(AffineMap bcastMap);
+
+    /// Clones an encoding with a new layout list and drops other optional
+    /// parameters (because they are resolved).
+    EncodingAttr cloneWithLayouts(SmallVector<Attribute> layouts);
   }];
 
   let genVerifyDecl = 0;

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -116,7 +116,7 @@ def EncodingAttr :
 
     /// Clones an encoding with a new layout list and drops other optional
     /// parameters (because they are resolved).
-    EncodingAttr cloneWithLayouts(SmallVector<Attribute> layouts);
+    EncodingAttr cloneWithLayouts(ArrayRef<Attribute> layouts);
   }];
 
   let genVerifyDecl = 0;

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/BUILD.bazel
@@ -101,7 +101,9 @@ iree_compiler_cc_library(
     deps = [
         ":IR",
         "//compiler/src/iree/compiler/Dialect/HAL:hal_imports",
+        "//compiler/src/iree/compiler/Dialect/HAL/Analysis",
         "//compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM",
+        "//compiler/src/iree/compiler/Dialect/Stream/IR",
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "//compiler/src/iree/compiler/Dialect/VM/Conversion",
         "@llvm-project//llvm:Support",

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
@@ -79,8 +79,10 @@ iree_cc_library(
     MLIRParser
     MLIRSCFDialect
     MLIRTransformUtils
+    iree::compiler::Dialect::HAL::Analysis
     iree::compiler::Dialect::HAL::Conversion::HALToVM
     iree::compiler::Dialect::HAL::hal_imports
+    iree::compiler::Dialect::Stream::IR
     iree::compiler::Dialect::Util::IR
     iree::compiler::Dialect::VM::Conversion
   PUBLIC

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/BUILD.bazel
@@ -50,6 +50,7 @@ iree_compiler_cc_library(
     hdrs = [
         "StreamDialect.h",
         "StreamEnums.h.inc",
+        "StreamInterfaces.h",
         "StreamOpInterfaces.h.inc",
         "StreamOps.h",
         "StreamOps.h.inc",

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_cc_library(
   HDRS
     "StreamDialect.h"
     "StreamEnums.h.inc"
+    "StreamInterfaces.h"
     "StreamOpInterfaces.h.inc"
     "StreamOps.h"
     "StreamOps.h.inc"

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamInterfaces.h
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamInterfaces.h
@@ -1,4 +1,4 @@
-// Copyright 2024 The IREE Authors
+// Copyright 2025 The IREE Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamInterfaces.h
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamInterfaces.h
@@ -16,7 +16,7 @@
 
 namespace mlir::iree_compiler::IREE::Stream {
 
-using LayoutAttrSolverFn = std::function<LogicalResult(
+using ResolveLayoutAttrFn = std::function<LogicalResult(
     AffinityAttr, Operation *, SetVector<Attribute> &)>;
 
 class AffinityAnalysisDialectInterface
@@ -24,7 +24,11 @@ class AffinityAnalysisDialectInterface
 public:
   AffinityAnalysisDialectInterface(Dialect *dialect) : Base(dialect) {}
 
-  virtual LayoutAttrSolverFn makeLayoutAttrSolver(ModuleOp moduleOp) const = 0;
+  /// The `moduleOp` must remain live and unmodified for as long as the returned
+  /// capture is. Otherwise, it will likely be incorrect or crash if the module
+  /// op is mutated, especially when module scope analysis is run.
+  virtual ResolveLayoutAttrFn
+  makeLayoutAttrResolver(ModuleOp moduleOp) const = 0;
 };
 
 } // namespace mlir::iree_compiler::IREE::Stream

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamInterfaces.h
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamInterfaces.h
@@ -1,0 +1,32 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_DIALECT_STREAM_IR_STREAMINTERACES_H_
+#define IREE_COMPILER_DIALECT_STREAM_IR_STREAMINTERACES_H_
+
+#include "iree/compiler/Dialect/Stream/IR/StreamOps.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/DialectInterface.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir::iree_compiler::IREE::Stream {
+
+using LayoutAttrSolverFn = std::function<LogicalResult(
+    AffinityAttr, Operation *, SetVector<Attribute> &)>;
+
+class AffinityAnalysisDialectInterface
+    : public DialectInterface::Base<AffinityAnalysisDialectInterface> {
+public:
+  AffinityAnalysisDialectInterface(Dialect *dialect) : Base(dialect) {}
+
+  virtual LayoutAttrSolverFn makeLayoutAttrSolver(ModuleOp moduleOp) const = 0;
+};
+
+} // namespace mlir::iree_compiler::IREE::Stream
+
+#endif // IREE_COMPILER_DIALECT_STREAM_IR_STREAM_INTERFACES_H_

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/BUILD.bazel
@@ -39,6 +39,7 @@ iree_compiler_cc_library(
         "ScheduleConcurrency.cpp",
         "ScheduleExecution.cpp",
         "SpecializeDispatches.cpp",
+        "SpecializeEncodings.cpp",
         "VerifyAffinities.cpp",
         "VerifyAsyncAccessRanges.cpp",
         "VerifyLowerings.cpp",

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/CMakeLists.txt
@@ -40,6 +40,7 @@ iree_cc_library(
     "ScheduleConcurrency.cpp"
     "ScheduleExecution.cpp"
     "SpecializeDispatches.cpp"
+    "SpecializeEncodings.cpp"
     "VerifyAffinities.cpp"
     "VerifyAsyncAccessRanges.cpp"
     "VerifyLowerings.cpp"

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
@@ -22,6 +22,15 @@ static llvm::cl::opt<bool> clAnnotateInputAffinities(
                    "the pipeline for debugging."),
     llvm::cl::init(false));
 
+// TODO(hanchung): Enable the pass by default once the implementation is done.
+static llvm::cl::opt<bool> clSpecializeEncodings(
+    "iree-stream-experimental-specialize-encodings",
+    llvm::cl::desc(
+        "Enables SpecializeEncodingPass in Stream pass pipeline. This pass is "
+        "currently under development, so it is not enabled by default. It can "
+        "only handle limited cases at this moment."),
+    llvm::cl::init(false));
+
 namespace mlir::iree_compiler::IREE::Stream {
 
 using FunctionLikeNest =
@@ -139,6 +148,10 @@ void buildStreamAsyncPassPipeline(OpPassManager &passManager,
   //----------------------------------------------------------------------------
   // Tensor lowering and resource management
   //----------------------------------------------------------------------------
+
+  if (clSpecializeEncodings) {
+    passManager.addPass(IREE::Stream::createSpecializeEncodingsPass());
+  }
 
   // Lower stream.tensor.* ops to stream.async.* ops based on
   // affinity/configuration assigned during placement.

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
@@ -414,6 +414,16 @@ def SpecializeDispatchesPass :
   ];
 }
 
+def SpecializeEncodingsPass :
+    Pass<"iree-stream-specialize-encodings", "mlir::ModuleOp"> {
+  let summary = "Specializes data-tiling encodings based on device analysis.";
+  let description = [{
+    Attaches layouts to encodings and duplicates executables based on device
+    analysis.
+    TODO: Unpack the context. The pass is not fully implemented yet.
+  }];
+}
+
 def AnnotateDispatchArgumentsPass :
     Pass<"iree-stream-annotate-dispatch-arguments", "mlir::ModuleOp"> {
   let summary = "Annotates dispatch arguments with potential values derived from dispatch sites.";

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
@@ -149,11 +149,10 @@ struct SpecializeEncodingsPass
       return signalPassFailure();
     }
 
-    llvm::MapVector<StringRef, IREE::Stream::ExecutableOp> executableOp(
-        llvm::map_range(moduleOp.getOps<IREE::Stream::ExecutableOp>(),
-                        [](auto op) {
-                          return {op.getName(), op};
-                        }));
+    llvm::MapVector<StringRef, IREE::Stream::ExecutableOp> executableOps;
+    for (auto executableOp : moduleOp.getOps<IREE::Stream::ExecutableOp>()) {
+      executableOps[executableOp.getName()] = executableOp;
+    }
 
     IREE::Stream::ResolveLayoutAttrFn resolveLayoutAttr =
         usedDialects[0]->makeLayoutAttrResolver(moduleOp);

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 The IREE Authors
+// Copyright 2025 The IREE Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -118,7 +118,7 @@ static LogicalResult addLayoutsToTensorPhaseOps(
               }
               std::optional<IREE::Encoding::EncodingAttr> encodingAttr =
                   getEncodingWithNewLayouts(encodingType);
-              if (!encodingAttr.has_value()) {
+              if (!encodingAttr) {
                 return success();
               }
               rewriter.modifyOpInPlace(sizeOfOp, [&] {
@@ -149,10 +149,11 @@ struct SpecializeEncodingsPass
       return signalPassFailure();
     }
 
-    llvm::MapVector<StringRef, IREE::Stream::ExecutableOp> executableOps;
-    for (auto executableOp : moduleOp.getOps<IREE::Stream::ExecutableOp>()) {
-      executableOps[executableOp.getName()] = executableOp;
-    }
+    llvm::MapVector<StringRef, IREE::Stream::ExecutableOp> executableOp(
+        llvm::map_range(moduleOp.getOps<IREE::Stream::ExecutableOp>(),
+                        [](auto op) {
+                          return {op.getName(), op};
+                        }));
 
     IREE::Stream::ResolveLayoutAttrFn resolveLayoutAttr =
         usedDialects[0]->makeLayoutAttrResolver(moduleOp);

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
@@ -1,0 +1,172 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Encoding/IR/EncodingTypes.h"
+#include "iree/compiler/Dialect/Stream/Analysis/Affinity.h"
+#include "iree/compiler/Dialect/Stream/IR/StreamInterfaces.h"
+#include "iree/compiler/Dialect/Stream/IR/StreamOps.h"
+#include "iree/compiler/Dialect/Stream/IR/StreamTraits.h"
+#include "iree/compiler/Dialect/Stream/IR/StreamTypes.h"
+#include "iree/compiler/Dialect/Stream/Transforms/Passes.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/LogicalResult.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::iree_compiler::IREE::Stream {
+
+#define DEBUG_TYPE "iree-stream-specialize-encodings"
+
+#define GEN_PASS_DEF_SPECIALIZEENCODINGSPASS
+#include "iree/compiler/Dialect/Stream/Transforms/Passes.h.inc"
+
+namespace {
+/// Returns a stably sorted list of dialect interfaces of T for all dialects
+/// used within the given module.
+template <typename T>
+SmallVector<const T *> gatherUsedDialectInterfaces(mlir::ModuleOp moduleOp) {
+  SmallPtrSet<const T *, 4> resultSet;
+  for (auto dialect : moduleOp.getContext()->getLoadedDialects()) {
+    auto *dialectInterface = dialect->getRegisteredInterface<T>();
+    if (!dialectInterface)
+      continue;
+    resultSet.insert(dialectInterface);
+  }
+
+  // NOTE: to ensure deterministic output we sort the result so that imports are
+  // always added in a consistent order.
+  SmallVector<const T *> results = {resultSet.begin(), resultSet.end()};
+  llvm::sort(
+      results, +[](const T *a, const T *b) {
+        return a->getDialect()->getNamespace().compare(
+                   b->getDialect()->getNamespace()) < 0;
+      });
+  return results;
+}
+
+// TODO(hanchung): Add "cloneWithEncoding" method to RankedTensorType.
+static RankedTensorType cloneWithEncoding(RankedTensorType type,
+                                          Attribute encoding) {
+  return RankedTensorType::get(type.getShape(), type.getElementType(),
+                               encoding);
+}
+
+static LogicalResult
+addLayoutsToTensorPhaseOps(ModuleOp moduleOp, FunctionOpInterface funcOp,
+                           LayoutAttrSolverFn makeLayoutAttrFn) {
+  SmallVector<AffinityOpInterface> candidates;
+  funcOp.walk([&](AffinityOpInterface affinityOp) {
+    // Only need to update encoding types for ops that have TensorPhaseOp trait.
+    if (!affinityOp->hasTrait<OpTrait::IREE::Stream::TensorPhaseOp>()) {
+      return;
+    }
+
+    // Bail out if the operation does not have an affinity attribute.
+    // TODO(hanchung): We should use the default device in this case. However,
+    // it is not guaranteed that default device attribute will always be set in
+    // the IR. (Is the statement correct?)
+    auto affAttr = affinityOp.getAffinityAttr();
+    if (!affAttr) {
+      return;
+    }
+    candidates.push_back(affinityOp);
+  });
+
+  if (candidates.empty()) {
+    return success();
+  }
+
+  IRRewriter rewriter(funcOp.getContext());
+  for (auto affinityOp : candidates) {
+    auto affAttr = affinityOp.getAffinityAttr();
+    SetVector<Attribute> layouts;
+    if (failed(makeLayoutAttrFn(affAttr, moduleOp, layouts))) {
+      affinityOp.emitError("failed on making layouts");
+      return failure();
+    }
+
+    auto getEncodingWithNewLayouts =
+        [=](Type type) -> std::optional<IREE::Encoding::EncodingAttr> {
+      auto rankedTensorType = dyn_cast<RankedTensorType>(type);
+      if (!rankedTensorType) {
+        return std::nullopt;
+      }
+      auto encoding = IREE::Encoding::getEncodingAttr(rankedTensorType);
+      if (!encoding) {
+        return std::nullopt;
+      }
+      SmallVector<Attribute> attrs(layouts.begin(), layouts.end());
+      return encoding.cloneWithLayouts(attrs);
+    };
+    // TODO(hanchung): Update other Stream operations.
+    LogicalResult result =
+        TypeSwitch<Operation *, LogicalResult>(affinityOp)
+            .Case<Stream::TensorSizeOfOp>([&](auto sizeOfOp) {
+              auto encodingType =
+                  dyn_cast<RankedTensorType>(sizeOfOp.getEncoding());
+              if (!encodingType) {
+                return success();
+              }
+              std::optional<IREE::Encoding::EncodingAttr> encoding =
+                  getEncodingWithNewLayouts(encodingType);
+              if (!encoding.has_value()) {
+                return success();
+              }
+              rewriter.modifyOpInPlace(sizeOfOp, [&] {
+                sizeOfOp.setEncoding(
+                    cloneWithEncoding(encodingType, encoding.value()));
+              });
+              return success();
+            })
+            .Default([](auto *op) { return success(); });
+
+    if (failed(result)) {
+      return failure();
+    }
+  }
+  return success();
+}
+} // namespace
+
+struct SpecializeEncodingsPass
+    : public impl::SpecializeEncodingsPassBase<SpecializeEncodingsPass> {
+  void runOnOperation() override {
+    ModuleOp moduleOp = getOperation();
+    auto usedDialects =
+        gatherUsedDialectInterfaces<AffinityAnalysisDialectInterface>(moduleOp);
+    if (usedDialects.size() != 1) {
+      moduleOp.emitError("expected only one dialect implementing "
+                         "AffinityAnalysisDialectInterface");
+      return signalPassFailure();
+    }
+
+    SymbolTable symbolTable(moduleOp);
+    llvm::MapVector<StringRef, IREE::Stream::ExecutableOp> executableOps;
+    for (auto executableOp : moduleOp.getOps<IREE::Stream::ExecutableOp>()) {
+      executableOps[executableOp.getName()] = executableOp;
+    }
+
+    LayoutAttrSolverFn makeLayoutAttrFn =
+        usedDialects[0]->makeLayoutAttrSolver(moduleOp);
+    for (auto funcOp : moduleOp.getOps<mlir::FunctionOpInterface>()) {
+      if (failed(
+              addLayoutsToTensorPhaseOps(moduleOp, funcOp, makeLayoutAttrFn))) {
+        funcOp.emitError(
+            "failed on adding layouts to Stream::TensorPhaseOp with encodings");
+        return signalPassFailure();
+      }
+
+      // TODO(hanchung): Duplicate executables and update dispatch ops.
+    }
+  }
+};
+
+} // namespace mlir::iree_compiler::IREE::Stream

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
@@ -70,9 +70,6 @@ static LogicalResult addLayoutsToTensorPhaseOps(
     }
 
     // Bail out if the operation does not have an affinity attribute.
-    // TODO(hanchung): We should use the default device in this case. However,
-    // it is not guaranteed that default device attribute will always be set in
-    // the IR. (Is the statement correct?)
     auto affinityAttr = affinityOp.getAffinityAttr();
     if (!affinityAttr) {
       return;

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/BUILD.bazel
@@ -46,6 +46,7 @@ iree_lit_test_suite(
             "schedule_concurrency.mlir",
             "schedule_execution.mlir",
             "specialize_dispatches.mlir",
+            "specialize_encodings.mlir",
             "verify_affinities.mlir",
             "verify_async_access_ranges.mlir",
         ],

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/CMakeLists.txt
@@ -44,6 +44,7 @@ iree_lit_test_suite(
     "schedule_concurrency.mlir"
     "schedule_execution.mlir"
     "specialize_dispatches.mlir"
+    "specialize_encodings.mlir"
     "verify_affinities.mlir"
     "verify_async_access_ranges.mlir"
   TOOLS

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
@@ -1,0 +1,19 @@
+// RUN: iree-opt --split-input-file --iree-stream-specialize-encodings %s | FileCheck %s
+
+#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {encoding_layout = #iree_cpu.vmvx_encoding_layout<>, ukernels = "all"}>
+#device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
+#encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32]>
+module {
+  util.global private @device_a = #device_target_local_0_
+
+  util.func public @main(%d0: index, %d1: index) -> index {
+    %size = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<?x?xf32, #encoding>{%d0, %d1} : index
+    util.return %size : index
+  }
+}
+// CHECK:       #[[EXECUTABLE:.+]] = #hal.executable.target<"vmvx",
+// CHECK:       #[[$ENCODING:.+]] = #iree_encoding.encoding
+// CHECK-SAME:    layouts = [#[[EXECUTABLE]]]
+// CHECK-LABEL: util.func public @main
+// CHECK:         %[[RES:.+]] = stream.tensor.sizeof {{.+}} tensor<?x?xf32, #[[$ENCODING]]>
+// CHECK:         return %[[RES]]

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
@@ -1,12 +1,17 @@
 // RUN: iree-opt --split-input-file --iree-stream-specialize-encodings %s | FileCheck %s
 
-#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {encoding_layout = #iree_cpu.vmvx_encoding_layout<>, ukernels = "all"}>
+//------------------------------------------------------------------------------
+// Stream ops that have TensorPhaseOp trait. This test suite tests that the
+// encoding is updated that carries resolved layouts.
+//------------------------------------------------------------------------------
+
+#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {encoding_layout = #iree_cpu.vmvx_encoding_layout<>}>
 #device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
 #encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32]>
 module {
   util.global private @device_a = #device_target_local_0_
 
-  util.func public @main(%d0: index, %d1: index) -> index {
+  util.func public @tensor_sizeof(%d0: index, %d1: index) -> index {
     %size = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<?x?xf32, #encoding>{%d0, %d1} : index
     util.return %size : index
   }
@@ -14,6 +19,6 @@ module {
 // CHECK:       #[[EXECUTABLE:.+]] = #hal.executable.target<"vmvx",
 // CHECK:       #[[$ENCODING:.+]] = #iree_encoding.encoding
 // CHECK-SAME:    layouts = [#[[EXECUTABLE]]]
-// CHECK-LABEL: util.func public @main
+// CHECK-LABEL: util.func public @tensor_sizeof
 // CHECK:         %[[RES:.+]] = stream.tensor.sizeof {{.+}} tensor<?x?xf32, #[[$ENCODING]]>
 // CHECK:         return %[[RES]]


### PR DESCRIPTION
There are three major changes in the revision:

- Introduce `AffinityAnalysisDialectInterface` Stream dialect interface. It is used to fetch attributes that are defined by other dialects. In the revision, HAL implements the dialect interface, and it can return whatever attribute attached in HAL::ExecutableTarget attributes. The main idea of the dialect interface is that Stream **does not** need to depend on HAL to get the layout information.
- Add `cloneWithLayouts` method to the EncodingAttr. It is used in the encoding specialization pass where it can resolve the layout requirements and add it to the `layouts` field. The other optional parameters are dropped because the layout is already resolved. It can be a new Encoding dialect attribute because it is just describing the layout. The stream tensor ops do not need to know the `op_type`, `element_types` and `operand_index` parameters. It only needs the layout information, and the attribute should implement the interface method.
- Partially implement the SpecializeEncodings pass. The responsibility of the pass is large, so I decide to implement it incrementally. This revision only implements the mechanism of updating stream tensor ops' encoding, and only stream.tensor.sizeof op is supported. The rest of the support for other stream tensor op can be added later on. The executable duplication and the update of dispatch ops will be implemented in subsequent PRs.