### PR TITLE
Moving synchronous HAL file APIs to the public API.

### DIFF
--- a/runtime/src/iree/hal/file.c
+++ b/runtime/src/iree/hal/file.c
@@ -31,3 +31,56 @@ IREE_API_EXPORT iree_status_t iree_hal_file_import(
   IREE_TRACE_ZONE_END(z0);
   return status;
 }
+
+IREE_API_EXPORT iree_hal_memory_access_t
+iree_hal_file_allowed_access(iree_hal_file_t* file) {
+  IREE_ASSERT_ARGUMENT(file);
+  return _VTABLE_DISPATCH(file, allowed_access)(file);
+}
+
+IREE_API_EXPORT uint64_t iree_hal_file_length(iree_hal_file_t* file) {
+  IREE_ASSERT_ARGUMENT(file);
+  return _VTABLE_DISPATCH(file, length)(file);
+}
+
+IREE_API_EXPORT iree_hal_buffer_t* iree_hal_file_storage_buffer(
+    iree_hal_file_t* file) {
+  IREE_ASSERT_ARGUMENT(file);
+  return _VTABLE_DISPATCH(file, storage_buffer)(file);
+}
+
+IREE_API_EXPORT bool iree_hal_file_supports_synchronous_io(
+    iree_hal_file_t* file) {
+  IREE_ASSERT_ARGUMENT(file);
+  return _VTABLE_DISPATCH(file, supports_synchronous_io)(file);
+}
+
+IREE_API_EXPORT iree_status_t iree_hal_file_read(
+    iree_hal_file_t* file, uint64_t file_offset, iree_hal_buffer_t* buffer,
+    iree_device_size_t buffer_offset, iree_device_size_t length) {
+  IREE_ASSERT_ARGUMENT(file);
+  IREE_ASSERT_ARGUMENT(buffer);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, file_offset);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (int64_t)buffer_offset);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (int64_t)length);
+  iree_status_t status = _VTABLE_DISPATCH(file, read)(file, file_offset, buffer,
+                                                      buffer_offset, length);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+IREE_API_EXPORT iree_status_t iree_hal_file_write(
+    iree_hal_file_t* file, uint64_t file_offset, iree_hal_buffer_t* buffer,
+    iree_device_size_t buffer_offset, iree_device_size_t length) {
+  IREE_ASSERT_ARGUMENT(file);
+  IREE_ASSERT_ARGUMENT(buffer);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, file_offset);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (int64_t)buffer_offset);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (int64_t)length);
+  iree_status_t status = _VTABLE_DISPATCH(file, write)(
+      file, file_offset, buffer, buffer_offset, length);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}

--- a/runtime/src/iree/hal/utils/BUILD.bazel
+++ b/runtime/src/iree/hal/utils/BUILD.bazel
@@ -99,7 +99,6 @@ iree_runtime_cc_library(
     srcs = ["file_transfer.c"],
     hdrs = ["file_transfer.h"],
     deps = [
-        ":memory_file",
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/internal",
         "//runtime/src/iree/hal",

--- a/runtime/src/iree/hal/utils/CMakeLists.txt
+++ b/runtime/src/iree/hal/utils/CMakeLists.txt
@@ -120,7 +120,6 @@ iree_cc_library(
   SRCS
     "file_transfer.c"
   DEPS
-    ::memory_file
     iree::base
     iree::base::internal
     iree::hal

--- a/runtime/src/iree/hal/utils/file_transfer.h
+++ b/runtime/src/iree/hal/utils/file_transfer.h
@@ -52,8 +52,9 @@ typedef struct iree_hal_file_transfer_options_t {
 // The provided |options.loop| is used for any asynchronous host operations
 // performed as part of the transfer.
 //
-// WARNING: this only works with memory files as created via
-// iree_hal_memory_file_wrap.
+// Only files that support synchronous I/O are supported. Callers must use
+// iree_hal_file_supports_synchronous_io and route asynchronous files to native
+// implementations.
 IREE_API_EXPORT iree_status_t iree_hal_device_queue_read_streaming(
     iree_hal_device_t* device, iree_hal_queue_affinity_t queue_affinity,
     const iree_hal_semaphore_list_t wait_semaphore_list,
@@ -75,8 +76,9 @@ IREE_API_EXPORT iree_status_t iree_hal_device_queue_read_streaming(
 // The provided |options.loop| is used for any asynchronous host operations
 // performed as part of the transfer.
 //
-// WARNING: this only works with memory files as created via
-// iree_hal_memory_file_wrap.
+// Only files that support synchronous I/O are supported. Callers must use
+// iree_hal_file_supports_synchronous_io and route asynchronous files to native
+// implementations.
 IREE_API_EXPORT iree_status_t iree_hal_device_queue_write_streaming(
     iree_hal_device_t* device, iree_hal_queue_affinity_t queue_affinity,
     const iree_hal_semaphore_list_t wait_semaphore_list,

--- a/runtime/src/iree/hal/utils/memory_file.h
+++ b/runtime/src/iree/hal/utils/memory_file.h
@@ -19,51 +19,14 @@ extern "C" {
 // iree_hal_memory_file_t
 //===----------------------------------------------------------------------===//
 
-// Creates a file handle backed by |contents| without copying the data.
-// |release_callback| will be called when the file is destroyed.
+// Creates a file backed by |handle| without copying the data.
+// Only supports file handles of IREE_IO_FILE_HANDLE_TYPE_HOST_ALLOCATION.
 // If the memory can be imported into a usable staging buffer |device_allocator|
 // will be used to do so.
 IREE_API_EXPORT iree_status_t iree_hal_memory_file_wrap(
     iree_hal_queue_affinity_t queue_affinity, iree_hal_memory_access_t access,
     iree_io_file_handle_t* handle, iree_hal_allocator_t* device_allocator,
     iree_allocator_t host_allocator, iree_hal_file_t** out_file);
-
-//===----------------------------------------------------------------------===//
-// EXPERIMENTAL: synchronous file read/write API
-//===----------------------------------------------------------------------===//
-// This is incomplete and may not appear like this on the iree_hal_file_t
-// vtable; this does work for memory files though.
-
-// Returns the memory access allowed to the file.
-// This may be more strict than the original file handle backing the resource
-// if for example we want to prevent particular users from mutating the file.
-IREE_API_EXPORT iree_hal_memory_access_t
-iree_hal_file_allowed_access(iree_hal_file_t* file);
-
-// Returns the total accessible range of the file.
-// This may be a portion of the original file backing this handle.
-IREE_API_EXPORT uint64_t iree_hal_file_length(iree_hal_file_t* file);
-
-// Returns an optional device-accessible storage buffer representing the file.
-// Available if the implementation is able to perform import/address-space
-// mapping/etc such that device-side transfers can directly access the resources
-// as if they were a normal device buffer.
-IREE_API_EXPORT iree_hal_buffer_t* iree_hal_file_storage_buffer(
-    iree_hal_file_t* file);
-
-// TODO(benvanik): truncate/extend? (both can be tricky with async)
-
-// Synchronously reads a segment of |file| into |buffer|.
-// Blocks the caller until completed. Buffers are always host mappable.
-IREE_API_EXPORT iree_status_t iree_hal_file_read(
-    iree_hal_file_t* file, uint64_t file_offset, iree_hal_buffer_t* buffer,
-    iree_device_size_t buffer_offset, iree_device_size_t length);
-
-// Synchronously writes a segment of |buffer| into |file|.
-// Blocks the caller until completed. Buffers are always host mappable.
-IREE_API_EXPORT iree_status_t iree_hal_file_write(
-    iree_hal_file_t* file, uint64_t file_offset, iree_hal_buffer_t* buffer,
-    iree_device_size_t buffer_offset, iree_device_size_t length);
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
Implementations backed by device APIs like cuFile/DirectStorage/etc will return false for iree_hal_file_supports_synchronous_io and the respective HAL implementations will handle I/O themselves.