### PR TITLE
Adding iree_hal_file_from_handle factory for common file impls.

### DIFF
--- a/experimental/webgpu/BUILD.bazel
+++ b/experimental/webgpu/BUILD.bazel
@@ -55,7 +55,7 @@ iree_runtime_cc_library(
         "//runtime/src/iree/hal/utils:buffer_transfer",
         "//runtime/src/iree/hal/utils:executable_debug_info",
         "//runtime/src/iree/hal/utils:file_transfer",
-        "//runtime/src/iree/hal/utils:memory_file",
+        "//runtime/src/iree/hal/utils:files",
         "//runtime/src/iree/schemas:executable_debug_info_c_fbs",
         "//runtime/src/iree/schemas:webgpu_executable_def_c_fbs",
         "@webgpu_headers",

--- a/experimental/webgpu/CMakeLists.txt
+++ b/experimental/webgpu/CMakeLists.txt
@@ -49,7 +49,7 @@ iree_cc_library(
     iree::experimental::webgpu::platform
     iree::experimental::webgpu::shaders
     iree::hal::utils::file_transfer
-    iree::hal::utils::memory_file
+    iree::hal::utils::files
     iree::schemas::webgpu_executable_def_c_fbs
   PUBLIC
 )

--- a/experimental/webgpu/webgpu_device.c
+++ b/experimental/webgpu/webgpu_device.c
@@ -20,8 +20,8 @@
 #include "experimental/webgpu/simple_allocator.h"
 #include "experimental/webgpu/staging_buffer.h"
 #include "iree/base/internal/arena.h"
+#include "iree/hal/utils/file_registry.h"
 #include "iree/hal/utils/file_transfer.h"
-#include "iree/hal/utils/memory_file.h"
 
 //===----------------------------------------------------------------------===//
 // iree_hal_webgpu_device_t
@@ -283,14 +283,8 @@ static iree_status_t iree_hal_webgpu_device_import_file(
     iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
     iree_hal_memory_access_t access, iree_io_file_handle_t* handle,
     iree_hal_external_file_flags_t flags, iree_hal_file_t** out_file) {
-  if (iree_io_file_handle_type(handle) !=
-      IREE_IO_FILE_HANDLE_TYPE_HOST_ALLOCATION) {
-    return iree_make_status(
-        IREE_STATUS_UNAVAILABLE,
-        "implementation does not support the external file type");
-  }
-  return iree_hal_memory_file_wrap(
-      queue_affinity, access, handle, iree_hal_device_allocator(base_device),
+  return iree_hal_file_from_handle(
+      iree_hal_device_allocator(base_device), queue_affinity, access, handle,
       iree_hal_device_host_allocator(base_device), out_file);
 }
 

--- a/runtime/src/iree/hal/drivers/cuda/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/cuda/BUILD.bazel
@@ -63,7 +63,7 @@ iree_runtime_cc_library(
         "//runtime/src/iree/hal/utils:deferred_work_queue",
         "//runtime/src/iree/hal/utils:executable_debug_info",
         "//runtime/src/iree/hal/utils:file_transfer",
-        "//runtime/src/iree/hal/utils:memory_file",
+        "//runtime/src/iree/hal/utils:files",
         "//runtime/src/iree/hal/utils:resource_set",
         "//runtime/src/iree/hal/utils:semaphore_base",
         "//runtime/src/iree/hal/utils:stream_tracing",

--- a/runtime/src/iree/hal/drivers/cuda/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/cuda/CMakeLists.txt
@@ -60,7 +60,7 @@ iree_cc_library(
     iree::hal::utils::deferred_work_queue
     iree::hal::utils::executable_debug_info
     iree::hal::utils::file_transfer
-    iree::hal::utils::memory_file
+    iree::hal::utils::files
     iree::hal::utils::resource_set
     iree::hal::utils::semaphore_base
     iree::hal::utils::stream_tracing

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.c
@@ -27,8 +27,8 @@
 #include "iree/hal/drivers/cuda/timepoint_pool.h"
 #include "iree/hal/utils/deferred_command_buffer.h"
 #include "iree/hal/utils/deferred_work_queue.h"
+#include "iree/hal/utils/file_registry.h"
 #include "iree/hal/utils/file_transfer.h"
-#include "iree/hal/utils/memory_file.h"
 #include "iree/hal/utils/stream_tracing.h"
 
 //===----------------------------------------------------------------------===//
@@ -897,14 +897,8 @@ static iree_status_t iree_hal_cuda_device_import_file(
     iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
     iree_hal_memory_access_t access, iree_io_file_handle_t* handle,
     iree_hal_external_file_flags_t flags, iree_hal_file_t** out_file) {
-  if (iree_io_file_handle_type(handle) !=
-      IREE_IO_FILE_HANDLE_TYPE_HOST_ALLOCATION) {
-    return iree_make_status(
-        IREE_STATUS_UNAVAILABLE,
-        "implementation does not support the external file type");
-  }
-  return iree_hal_memory_file_wrap(
-      queue_affinity, access, handle, iree_hal_device_allocator(base_device),
+  return iree_hal_file_from_handle(
+      iree_hal_device_allocator(base_device), queue_affinity, access, handle,
       iree_hal_device_host_allocator(base_device), out_file);
 }
 

--- a/runtime/src/iree/hal/drivers/hip/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/hip/CMakeLists.txt
@@ -70,7 +70,7 @@ iree_cc_library(
     iree::hal::utils::executable_debug_info
     iree::hal::utils::deferred_command_buffer
     iree::hal::utils::file_transfer
-    iree::hal::utils::memory_file
+    iree::hal::utils::files
     iree::hal::utils::resource_set
     iree::hal::utils::semaphore_base
     iree::hal::utils::stream_tracing

--- a/runtime/src/iree/hal/drivers/hip/hip_device.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_device.c
@@ -31,8 +31,8 @@
 #include "iree/hal/drivers/hip/status_util.h"
 #include "iree/hal/drivers/hip/stream_command_buffer.h"
 #include "iree/hal/utils/deferred_command_buffer.h"
+#include "iree/hal/utils/file_registry.h"
 #include "iree/hal/utils/file_transfer.h"
-#include "iree/hal/utils/memory_file.h"
 #include "iree/hal/utils/stream_tracing.h"
 
 //===----------------------------------------------------------------------===//
@@ -849,15 +849,8 @@ static iree_status_t iree_hal_hip_device_import_file(
     iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
     iree_hal_memory_access_t access, iree_io_file_handle_t* handle,
     iree_hal_external_file_flags_t flags, iree_hal_file_t** out_file) {
-  *out_file = NULL;
-  if (iree_io_file_handle_type(handle) !=
-      IREE_IO_FILE_HANDLE_TYPE_HOST_ALLOCATION) {
-    return iree_make_status(
-        IREE_STATUS_UNAVAILABLE,
-        "implementation does not support the external file type");
-  }
-  return iree_hal_memory_file_wrap(
-      queue_affinity, access, handle, iree_hal_device_allocator(base_device),
+  return iree_hal_file_from_handle(
+      iree_hal_device_allocator(base_device), queue_affinity, access, handle,
       iree_hal_device_host_allocator(base_device), out_file);
 }
 

--- a/runtime/src/iree/hal/drivers/local_sync/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/local_sync/BUILD.bazel
@@ -37,7 +37,7 @@ iree_runtime_cc_library(
         "//runtime/src/iree/hal/local:executable_environment",
         "//runtime/src/iree/hal/utils:deferred_command_buffer",
         "//runtime/src/iree/hal/utils:file_transfer",
-        "//runtime/src/iree/hal/utils:memory_file",
+        "//runtime/src/iree/hal/utils:files",
         "//runtime/src/iree/hal/utils:semaphore_base",
     ],
 )

--- a/runtime/src/iree/hal/drivers/local_sync/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/local_sync/CMakeLists.txt
@@ -34,7 +34,7 @@ iree_cc_library(
     iree::hal::local::executable_environment
     iree::hal::utils::deferred_command_buffer
     iree::hal::utils::file_transfer
-    iree::hal::utils::memory_file
+    iree::hal::utils::files
     iree::hal::utils::semaphore_base
   PUBLIC
 )

--- a/runtime/src/iree/hal/drivers/local_sync/sync_device.c
+++ b/runtime/src/iree/hal/drivers/local_sync/sync_device.c
@@ -18,8 +18,8 @@
 #include "iree/hal/local/inline_command_buffer.h"
 #include "iree/hal/local/local_executable_cache.h"
 #include "iree/hal/utils/deferred_command_buffer.h"
+#include "iree/hal/utils/file_registry.h"
 #include "iree/hal/utils/file_transfer.h"
-#include "iree/hal/utils/memory_file.h"
 
 typedef struct iree_hal_sync_device_t {
   iree_hal_resource_t resource;
@@ -267,14 +267,8 @@ static iree_status_t iree_hal_sync_device_import_file(
     iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
     iree_hal_memory_access_t access, iree_io_file_handle_t* handle,
     iree_hal_external_file_flags_t flags, iree_hal_file_t** out_file) {
-  if (iree_io_file_handle_type(handle) !=
-      IREE_IO_FILE_HANDLE_TYPE_HOST_ALLOCATION) {
-    return iree_make_status(
-        IREE_STATUS_UNAVAILABLE,
-        "implementation does not support the external file type");
-  }
-  return iree_hal_memory_file_wrap(
-      queue_affinity, access, handle, iree_hal_device_allocator(base_device),
+  return iree_hal_file_from_handle(
+      iree_hal_device_allocator(base_device), queue_affinity, access, handle,
       iree_hal_device_host_allocator(base_device), out_file);
 }
 

--- a/runtime/src/iree/hal/drivers/local_task/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/local_task/BUILD.bazel
@@ -49,7 +49,7 @@ iree_runtime_cc_library(
         "//runtime/src/iree/hal/local:executable_library",
         "//runtime/src/iree/hal/utils:deferred_command_buffer",
         "//runtime/src/iree/hal/utils:file_transfer",
-        "//runtime/src/iree/hal/utils:memory_file",
+        "//runtime/src/iree/hal/utils:files",
         "//runtime/src/iree/hal/utils:resource_set",
         "//runtime/src/iree/hal/utils:semaphore_base",
         "//runtime/src/iree/task",

--- a/runtime/src/iree/hal/drivers/local_task/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/local_task/CMakeLists.txt
@@ -43,7 +43,7 @@ iree_cc_library(
     iree::hal::local::executable_library
     iree::hal::utils::deferred_command_buffer
     iree::hal::utils::file_transfer
-    iree::hal::utils::memory_file
+    iree::hal::utils::files
     iree::hal::utils::resource_set
     iree::hal::utils::semaphore_base
     iree::task

--- a/runtime/src/iree/hal/drivers/local_task/task_device.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_device.c
@@ -19,8 +19,8 @@
 #include "iree/hal/local/executable_environment.h"
 #include "iree/hal/local/local_executable_cache.h"
 #include "iree/hal/utils/deferred_command_buffer.h"
+#include "iree/hal/utils/file_registry.h"
 #include "iree/hal/utils/file_transfer.h"
-#include "iree/hal/utils/memory_file.h"
 
 typedef struct iree_hal_task_device_t {
   iree_hal_resource_t resource;
@@ -346,14 +346,8 @@ static iree_status_t iree_hal_task_device_import_file(
     iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
     iree_hal_memory_access_t access, iree_io_file_handle_t* handle,
     iree_hal_external_file_flags_t flags, iree_hal_file_t** out_file) {
-  if (iree_io_file_handle_type(handle) !=
-      IREE_IO_FILE_HANDLE_TYPE_HOST_ALLOCATION) {
-    return iree_make_status(
-        IREE_STATUS_UNAVAILABLE,
-        "implementation does not support the external file type");
-  }
-  return iree_hal_memory_file_wrap(
-      queue_affinity, access, handle, iree_hal_device_allocator(base_device),
+  return iree_hal_file_from_handle(
+      iree_hal_device_allocator(base_device), queue_affinity, access, handle,
       iree_hal_device_host_allocator(base_device), out_file);
 }
 

--- a/runtime/src/iree/hal/drivers/metal/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/metal/CMakeLists.txt
@@ -42,7 +42,7 @@ iree_cc_library(
     iree::hal::utils::deferred_command_buffer
     iree::hal::utils::executable_debug_info
     iree::hal::utils::file_transfer
-    iree::hal::utils::memory_file
+    iree::hal::utils::files
     iree::hal::utils::resource_set
     iree::schemas::executable_debug_info_c_fbs
     iree::schemas::metal_executable_def_c_fbs

--- a/runtime/src/iree/hal/drivers/metal/metal_device.m
+++ b/runtime/src/iree/hal/drivers/metal/metal_device.m
@@ -17,8 +17,8 @@
 #include "iree/hal/drivers/metal/shared_event.h"
 #include "iree/hal/drivers/metal/staging_buffer.h"
 #include "iree/hal/utils/deferred_command_buffer.h"
+#include "iree/hal/utils/file_registry.h"
 #include "iree/hal/utils/file_transfer.h"
-#include "iree/hal/utils/memory_file.h"
 #include "iree/hal/utils/resource_set.h"
 
 typedef struct iree_hal_metal_device_t {
@@ -288,13 +288,8 @@ static iree_status_t iree_hal_metal_device_import_file(iree_hal_device_t* base_d
                                                        iree_io_file_handle_t* handle,
                                                        iree_hal_external_file_flags_t flags,
                                                        iree_hal_file_t** out_file) {
-  if (iree_io_file_handle_type(handle) != IREE_IO_FILE_HANDLE_TYPE_HOST_ALLOCATION) {
-    return iree_make_status(IREE_STATUS_UNAVAILABLE,
-                            "implementation does not support the external file type");
-  }
-  return iree_hal_memory_file_wrap(queue_affinity, access, handle,
-                                   iree_hal_device_allocator(base_device),
-                                   iree_hal_device_host_allocator(base_device), out_file);
+  return iree_hal_file_from_handle(iree_hal_device_allocator(base_device), queue_affinity, access,
+                                   handle, iree_hal_device_host_allocator(base_device), out_file);
 }
 
 static iree_status_t iree_hal_metal_device_create_semaphore(iree_hal_device_t* base_device,

--- a/runtime/src/iree/hal/drivers/null/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/null/BUILD.bazel
@@ -44,7 +44,7 @@ iree_runtime_cc_library(
         "//runtime/src/iree/base/internal",
         "//runtime/src/iree/hal",
         "//runtime/src/iree/hal/utils:file_transfer",
-        "//runtime/src/iree/hal/utils:memory_file",
+        "//runtime/src/iree/hal/utils:files",
         "//runtime/src/iree/hal/utils:semaphore_base",
     ],
 )

--- a/runtime/src/iree/hal/drivers/null/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/null/CMakeLists.txt
@@ -41,7 +41,7 @@ iree_cc_library(
     iree::base::internal
     iree::hal
     iree::hal::utils::file_transfer
-    iree::hal::utils::memory_file
+    iree::hal::utils::files
     iree::hal::utils::semaphore_base
   PUBLIC
 )

--- a/runtime/src/iree/hal/drivers/null/device.c
+++ b/runtime/src/iree/hal/drivers/null/device.c
@@ -14,8 +14,8 @@
 #include "iree/hal/drivers/null/executable.h"
 #include "iree/hal/drivers/null/executable_cache.h"
 #include "iree/hal/drivers/null/semaphore.h"
+#include "iree/hal/utils/file_registry.h"
 #include "iree/hal/utils/file_transfer.h"
-#include "iree/hal/utils/memory_file.h"
 
 //===----------------------------------------------------------------------===//
 // iree_hal_null_device_t
@@ -273,14 +273,8 @@ static iree_status_t iree_hal_null_device_import_file(
   // definitely prefer that. The emulated file I/O present here as a default is
   // inefficient. The queue affinity specifies which queues may access the file
   // via read and write queue operations.
-  if (iree_io_file_handle_type(handle) !=
-      IREE_IO_FILE_HANDLE_TYPE_HOST_ALLOCATION) {
-    return iree_make_status(
-        IREE_STATUS_UNAVAILABLE,
-        "implementation does not support the external file type");
-  }
-  return iree_hal_memory_file_wrap(
-      queue_affinity, access, handle, iree_hal_device_allocator(base_device),
+  return iree_hal_file_from_handle(
+      iree_hal_device_allocator(base_device), queue_affinity, access, handle,
       iree_hal_device_host_allocator(base_device), out_file);
 }
 

--- a/runtime/src/iree/hal/drivers/vulkan/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/vulkan/BUILD.bazel
@@ -81,7 +81,7 @@ iree_runtime_cc_library(
         "//runtime/src/iree/hal/utils:deferred_command_buffer",
         "//runtime/src/iree/hal/utils:executable_debug_info",
         "//runtime/src/iree/hal/utils:file_transfer",
-        "//runtime/src/iree/hal/utils:memory_file",
+        "//runtime/src/iree/hal/utils:files",
         "//runtime/src/iree/hal/utils:resource_set",
         "//runtime/src/iree/hal/utils:semaphore_base",
         "//runtime/src/iree/schemas:executable_debug_info_c_fbs",

--- a/runtime/src/iree/hal/drivers/vulkan/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/vulkan/CMakeLists.txt
@@ -76,7 +76,7 @@ iree_cc_library(
     iree::hal::utils::deferred_command_buffer
     iree::hal::utils::executable_debug_info
     iree::hal::utils::file_transfer
-    iree::hal::utils::memory_file
+    iree::hal::utils::files
     iree::hal::utils::resource_set
     iree::hal::utils::semaphore_base
     iree::schemas::executable_debug_info_c_fbs

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
@@ -31,8 +31,8 @@
 #include "iree/hal/drivers/vulkan/util/arena.h"
 #include "iree/hal/drivers/vulkan/util/ref_ptr.h"
 #include "iree/hal/utils/deferred_command_buffer.h"
+#include "iree/hal/utils/file_registry.h"
 #include "iree/hal/utils/file_transfer.h"
-#include "iree/hal/utils/memory_file.h"
 
 using namespace iree::hal::vulkan;
 
@@ -1599,14 +1599,8 @@ static iree_status_t iree_hal_vulkan_device_import_file(
     iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
     iree_hal_memory_access_t access, iree_io_file_handle_t* handle,
     iree_hal_external_file_flags_t flags, iree_hal_file_t** out_file) {
-  if (iree_io_file_handle_type(handle) !=
-      IREE_IO_FILE_HANDLE_TYPE_HOST_ALLOCATION) {
-    return iree_make_status(
-        IREE_STATUS_UNAVAILABLE,
-        "implementation does not support the external file type");
-  }
-  return iree_hal_memory_file_wrap(
-      queue_affinity, access, handle, iree_hal_device_allocator(base_device),
+  return iree_hal_file_from_handle(
+      iree_hal_device_allocator(base_device), queue_affinity, access, handle,
       iree_hal_device_host_allocator(base_device), out_file);
 }
 

--- a/runtime/src/iree/hal/utils/BUILD.bazel
+++ b/runtime/src/iree/hal/utils/BUILD.bazel
@@ -106,6 +106,23 @@ iree_runtime_cc_library(
 )
 
 iree_runtime_cc_library(
+    name = "files",
+    srcs = [
+        "file_registry.c",
+        "memory_file.c",
+    ],
+    hdrs = [
+        "file_registry.h",
+        "memory_file.h",
+    ],
+    deps = [
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/hal",
+        "//runtime/src/iree/io:file_handle",
+    ],
+)
+
+iree_runtime_cc_library(
     name = "libmpi",
     srcs = ["libmpi.c"],
     hdrs = [
@@ -127,17 +144,6 @@ iree_runtime_cc_test(
         "//runtime/src/iree/base",
         "//runtime/src/iree/testing:gtest",
         "//runtime/src/iree/testing:gtest_main",
-    ],
-)
-
-iree_runtime_cc_library(
-    name = "memory_file",
-    srcs = ["memory_file.c"],
-    hdrs = ["memory_file.h"],
-    deps = [
-        "//runtime/src/iree/base",
-        "//runtime/src/iree/hal",
-        "//runtime/src/iree/io:file_handle",
     ],
 )
 

--- a/runtime/src/iree/hal/utils/CMakeLists.txt
+++ b/runtime/src/iree/hal/utils/CMakeLists.txt
@@ -128,6 +128,22 @@ iree_cc_library(
 
 iree_cc_library(
   NAME
+    files
+  HDRS
+    "file_registry.h"
+    "memory_file.h"
+  SRCS
+    "file_registry.c"
+    "memory_file.c"
+  DEPS
+    iree::base
+    iree::hal
+    iree::io::file_handle
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
     libmpi
   HDRS
     "libmpi.h"
@@ -151,20 +167,6 @@ iree_cc_test(
     iree::base
     iree::testing::gtest
     iree::testing::gtest_main
-)
-
-iree_cc_library(
-  NAME
-    memory_file
-  HDRS
-    "memory_file.h"
-  SRCS
-    "memory_file.c"
-  DEPS
-    iree::base
-    iree::hal
-    iree::io::file_handle
-  PUBLIC
 )
 
 iree_cc_library(

--- a/runtime/src/iree/hal/utils/file_registry.c
+++ b/runtime/src/iree/hal/utils/file_registry.c
@@ -1,0 +1,38 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/utils/file_registry.h"
+
+#include "iree/hal/utils/memory_file.h"
+
+IREE_API_EXPORT iree_status_t iree_hal_file_from_handle(
+    iree_hal_allocator_t* device_allocator,
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_memory_access_t access,
+    iree_io_file_handle_t* handle, iree_allocator_t host_allocator,
+    iree_hal_file_t** out_file) {
+  IREE_ASSERT_ARGUMENT(handle);
+  IREE_ASSERT_ARGUMENT(out_file);
+  *out_file = NULL;
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_status_t status = iree_ok_status();
+  switch (iree_io_file_handle_type(handle)) {
+    case IREE_IO_FILE_HANDLE_TYPE_HOST_ALLOCATION:
+      status =
+          iree_hal_memory_file_wrap(device_allocator, queue_affinity, access,
+                                    handle, host_allocator, out_file);
+      break;
+    default:
+      status = iree_make_status(
+          IREE_STATUS_UNIMPLEMENTED,
+          "no common implementation supported for file handles of type %d",
+          (int)iree_io_file_handle_type(handle));
+      break;
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}

--- a/runtime/src/iree/hal/utils/file_registry.h
+++ b/runtime/src/iree/hal/utils/file_registry.h
@@ -1,0 +1,35 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_UTILS_FILE_REGISTRY_H_
+#define IREE_HAL_UTILS_FILE_REGISTRY_H_
+
+#include "iree/base/api.h"
+#include "iree/hal/api.h"
+#include "iree/io/file_handle.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// Creates a file backed by |handle| using a common host implementation.
+// Supported file handle types are determined based on compile configuration.
+//
+// Some implementations - such as for IREE_IO_FILE_HANDLE_TYPE_HOST_ALLOCATION -
+// will try to import the backing storage directly into a usable staging buffer
+// using |device_allocator| and available with |queue_affinity|. Otherwise the
+// file is allowed to be use with any device or queue.
+IREE_API_EXPORT iree_status_t iree_hal_file_from_handle(
+    iree_hal_allocator_t* device_allocator,
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_memory_access_t access,
+    iree_io_file_handle_t* handle, iree_allocator_t host_allocator,
+    iree_hal_file_t** out_file);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_UTILS_FILE_REGISTRY_H_

--- a/runtime/src/iree/hal/utils/memory_file.c
+++ b/runtime/src/iree/hal/utils/memory_file.c
@@ -118,9 +118,10 @@ static void iree_hal_memory_file_try_import_buffer(
     iree_hal_allocator_t* device_allocator);
 
 IREE_API_EXPORT iree_status_t iree_hal_memory_file_wrap(
+    iree_hal_allocator_t* device_allocator,
     iree_hal_queue_affinity_t queue_affinity, iree_hal_memory_access_t access,
-    iree_io_file_handle_t* handle, iree_hal_allocator_t* device_allocator,
-    iree_allocator_t host_allocator, iree_hal_file_t** out_file) {
+    iree_io_file_handle_t* handle, iree_allocator_t host_allocator,
+    iree_hal_file_t** out_file) {
   IREE_ASSERT_ARGUMENT(out_file);
   *out_file = NULL;
 

--- a/runtime/src/iree/hal/utils/memory_file.h
+++ b/runtime/src/iree/hal/utils/memory_file.h
@@ -24,9 +24,10 @@ extern "C" {
 // If the memory can be imported into a usable staging buffer |device_allocator|
 // will be used to do so.
 IREE_API_EXPORT iree_status_t iree_hal_memory_file_wrap(
+    iree_hal_allocator_t* device_allocator,
     iree_hal_queue_affinity_t queue_affinity, iree_hal_memory_access_t access,
-    iree_io_file_handle_t* handle, iree_hal_allocator_t* device_allocator,
-    iree_allocator_t host_allocator, iree_hal_file_t** out_file);
+    iree_io_file_handle_t* handle, iree_allocator_t host_allocator,
+    iree_hal_file_t** out_file);
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
This lets us hide the details from HAL implementations. Implementations are expected to snoop the file handle type to see if they can do better and otherwise fall back to the common implementations.