### PR TITLE
Update PkgCI test_amd to use MI300x conductor cluster

### DIFF
--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: linux-mi300-gpu-1
     container:
       image: rocm/dev-ubuntu-22.04:6.3
+      options: --user root --device=/dev/kfd --device=/dev/dri --ipc=host --group-add video --group-add $render_gid --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
     env:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
       BUILD_DIR: build-tests

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -39,9 +39,7 @@ jobs:
         with:
           submodules: false
       - name: "Install depencies"
-        run: |
-        sudo apt-get update
-        sudo apt-get install -y cmake ninja-build clang lld git
+        run: sudo apt-get update & sudo apt-get install -y cmake ninja-build clang lld git
       - name: Check out runtime submodules
         run: ./build_tools/scripts/git/update_runtime_submodules.sh
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: linux-mi300-gpu-1
     container:
       image: rocm/dev-ubuntu-22.04:6.3
-      options: --user root --device=/dev/kfd --device=/dev/dri --ipc=host --group-add video --group-add $render_gid --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
+      options: --user root --device=/dev/kfd --device=/dev/dri --ipc=host --group-add video --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
     env:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
       BUILD_DIR: build-tests

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -53,7 +53,7 @@ jobs:
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
             --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
             --fetch-gh-workflow=${{ inputs.artifact_run_id }}
-          sudo apt install -y cmake ninja-build clang lld git  
+          sudo apt install -y cmake ninja-build clang lld git
 
       - name: Build tests
         run: ./build_tools/pkgci/build_tests_using_package.sh ${VENV_DIR}/bin

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -53,6 +53,7 @@ jobs:
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
             --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
             --fetch-gh-workflow=${{ inputs.artifact_run_id }}
+          sudo apt install -y cmake ninja-build clang lld git  
 
       - name: Build tests
         run: ./build_tools/pkgci/build_tests_using_package.sh ${VENV_DIR}/bin

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   test_mi300:
-    runs-on: nodai-amdgpu-mi300-x86-64
+    runs-on: arc-iree-gpu-1
     env:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
       BUILD_DIR: build-tests

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -43,7 +43,9 @@ jobs:
         with:
           submodules: false
       - name: Check out runtime submodules
-        run: ./build_tools/scripts/git/update_runtime_submodules.sh
+        run: |
+          git config --global --add safe.directory /__w/iree/iree
+          ./build_tools/scripts/git/update_runtime_submodules.sh
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           # Must match the subset of versions built in pkgci_build_packages.

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   test_mi300:
-    runs-on: arc-iree-gpu-1
+    runs-on: linux-mi300-gpu-1
     env:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
       BUILD_DIR: build-tests

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -38,8 +38,12 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: false
+      - name: "Install depencies"
+        run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake ninja-build clang lld git
       - name: Check out runtime submodules
-        run: sudo apt update & sudo apt install -y git & ./build_tools/scripts/git/update_runtime_submodules.sh
+        run: ./build_tools/scripts/git/update_runtime_submodules.sh
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           # Must match the subset of versions built in pkgci_build_packages.
@@ -53,7 +57,6 @@ jobs:
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
             --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
             --fetch-gh-workflow=${{ inputs.artifact_run_id }}
-          sudo apt install -y cmake ninja-build clang lld git
 
       - name: Build tests
         run: ./build_tools/pkgci/build_tests_using_package.sh ${VENV_DIR}/bin

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -44,9 +44,7 @@ jobs:
         with:
           submodules: false
       - name: Check out runtime submodules
-        run: |
-          git config --global --add safe.directory /__w/iree/iree
-          ./build_tools/scripts/git/update_runtime_submodules.sh
+        run: ./build_tools/scripts/git/update_runtime_submodules.sh
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           # Must match the subset of versions built in pkgci_build_packages.

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -39,9 +39,7 @@ jobs:
         with:
           submodules: false
       - name: Check out runtime submodules
-        run:
-        sudo apt install -y cmake ninja-build clang lld git
-        ./build_tools/scripts/git/update_runtime_submodules.sh
+        run: sudo apt install -y cmake ninja-build clang lld git & ./build_tools/scripts/git/update_runtime_submodules.sh
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           # Must match the subset of versions built in pkgci_build_packages.
@@ -55,7 +53,7 @@ jobs:
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
             --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
             --fetch-gh-workflow=${{ inputs.artifact_run_id }}
-
+          sudo apt install -y cmake ninja-build clang lld git
 
       - name: Build tests
         run: ./build_tools/pkgci/build_tests_using_package.sh ${VENV_DIR}/bin

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -39,7 +39,9 @@ jobs:
         with:
           submodules: false
       - name: Check out runtime submodules
-        run: ./build_tools/scripts/git/update_runtime_submodules.sh
+        run: |
+        sudo apt install -y cmake ninja-build clang lld git
+        ./build_tools/scripts/git/update_runtime_submodules.sh
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           # Must match the subset of versions built in pkgci_build_packages.
@@ -53,7 +55,7 @@ jobs:
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
             --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
             --fetch-gh-workflow=${{ inputs.artifact_run_id }}
-          sudo apt install -y cmake ninja-build clang lld git
+
 
       - name: Build tests
         run: ./build_tools/pkgci/build_tests_using_package.sh ${VENV_DIR}/bin

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           submodules: false
       - name: "Install depencies"
-        run: sudo apt-get update & sudo apt-get install -y cmake ninja-build clang lld git
+        run: cat /etc/apt/sources.list & sudo apt-get update & sudo apt-get install -y cmake ninja-build clang lld git
       - name: Check out runtime submodules
         run: ./build_tools/scripts/git/update_runtime_submodules.sh
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -43,6 +43,8 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: false
+      - name: "Mark git safe.directory"
+        run: git config --global --add safe.directory '*'
       - name: Check out runtime submodules
         run: ./build_tools/scripts/git/update_runtime_submodules.sh
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -20,6 +20,8 @@ on:
 jobs:
   test_mi300:
     runs-on: linux-mi300-gpu-1
+    container:
+      image: rocm/dev-ubuntu-22.04:6.3
     env:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
       BUILD_DIR: build-tests

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           submodules: false
       - name: Check out runtime submodules
-        run: |
+        run:
         sudo apt install -y cmake ninja-build clang lld git
         ./build_tools/scripts/git/update_runtime_submodules.sh
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           submodules: false
       - name: Check out runtime submodules
-        run: sudo apt install -y cmake ninja-build clang lld git & ./build_tools/scripts/git/update_runtime_submodules.sh
+        run: sudo apt update & sudo apt install -y git & ./build_tools/scripts/git/update_runtime_submodules.sh
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           # Must match the subset of versions built in pkgci_build_packages.

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -34,14 +34,14 @@ jobs:
       IREE_HIP_ENABLE: 1
       IREE_HIP_TEST_TARGET_CHIP: "gfx942"
     steps:
-      - name: Check out repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          submodules: false
       - name: "Install dependencies"
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake ninja-build clang lld git
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: false
       - name: Check out runtime submodules
         run: ./build_tools/scripts/git/update_runtime_submodules.sh
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -39,7 +39,9 @@ jobs:
         with:
           submodules: false
       - name: "Install dependencies"
-        run: sudo apt-get update && sudo apt-get install -y cmake ninja-build clang lld git
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build clang lld git
       - name: Check out runtime submodules
         run: ./build_tools/scripts/git/update_runtime_submodules.sh
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -39,10 +39,7 @@ jobs:
         with:
           submodules: false
       - name: "Install dependencies"
-        run: |
-        cat /etc/apt/sources.list
-        sudo apt-get update
-        sudo apt-get install -y cmake ninja-build clang lld git
+        run: sudo apt-get update && sudo apt-get install -y cmake ninja-build clang lld git
       - name: Check out runtime submodules
         run: ./build_tools/scripts/git/update_runtime_submodules.sh
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -38,8 +38,11 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: false
-      - name: "Install depencies"
-        run: cat /etc/apt/sources.list & sudo apt-get update & sudo apt-get install -y cmake ninja-build clang lld git
+      - name: "Install dependencies"
+        run: |
+        cat /etc/apt/sources.list
+        sudo apt-get update
+        sudo apt-get install -y cmake ninja-build clang lld git
       - name: Check out runtime submodules
         run: ./build_tools/scripts/git/update_runtime_submodules.sh
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0


### PR DESCRIPTION
We want to migrate the workflows use MI300 and do not require cache support to migrate to our conductor cluster. A new runner with one GPU has been created

- label: linux-mi300-gpu-1
- namespace: arc-iree-gpu-1
- gitconfig url: https://github.com/iree-org/iree

This PR is to update the run label.