### PR TITLE
[NFC] Fixing typo (mutli -> multi).

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
@@ -2172,7 +2172,7 @@ func.func @operand_fusion() {
 #map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
 #map4 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
 #map5 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
-func.func @dot_general_nontrivial_batching_mutliple_parallel_dimension() {
+func.func @dot_general_nontrivial_batching_multiple_parallel_dimension() {
   %cst = arith.constant dense<0.000000e+00> : vector<1x4x2xf32>
   %c1 = arith.constant 1 : index
   %c6 = arith.constant 6 : index
@@ -2217,7 +2217,7 @@ func.func @dot_general_nontrivial_batching_mutliple_parallel_dimension() {
   }
   return
 }
-// CHECK-LABEL: func.func @dot_general_nontrivial_batching_mutliple_parallel_dimension()
+// CHECK-LABEL: func.func @dot_general_nontrivial_batching_multiple_parallel_dimension()
 //   CHECK-NOT:   memref.alloc
 
 // -----

--- a/runtime/src/iree/schemas/vulkan_executable_def.fbs
+++ b/runtime/src/iree/schemas/vulkan_executable_def.fbs
@@ -93,7 +93,7 @@ table ExecutableDef {
   descriptor_set_layouts:[DescriptorSetLayoutDef];
 
   // A list of pipeline layouts. Exports reference layouts in this list and
-  // multiple exports present in mutliple shader modules may share layouts.
+  // multiple exports present in multiple shader modules may share layouts.
   // This list may not have the same size as the pipelines list.
   pipeline_layouts:[PipelineLayoutDef];
 

--- a/tests/e2e/stablehlo_ops/dot_general.mlir
+++ b/tests/e2e/stablehlo_ops/dot_general.mlir
@@ -126,7 +126,7 @@ func.func @large_dot_general() {
   return
 }
 
-func.func @dot_general_nontrivial_batching_mutliple_parallel_dimension() {
+func.func @dot_general_nontrivial_batching_multiple_parallel_dimension() {
   %lhs = util.unfoldable_constant dense<[
     [[[0.0], [1.0]], [[2.0], [3.0]], [[ 4.0], [ 5.0]]],
     [[[6.0], [7.0]], [[8.0], [9.0]], [[10.0], [11.0]]]

--- a/tools/test/iree-run-module-multi.mlir
+++ b/tools/test/iree-run-module-multi.mlir
@@ -11,17 +11,17 @@
 // RUN:      --iree-hal-local-target-device-backends=vmvx | \
 // RUN:  iree-run-module \
 // RUN:      --module=- \
-// RUN:      --function=mutli_device_mul \
+// RUN:      --function=multi_device_mul \
 // RUN:      --input=4xf32=10,11,12,13 \
 // RUN:      --device=local-task \
 // RUN:      --device=local-task \
 // RUN:      --task_topology_group_count=1) | \
 // RUN: FileCheck %s
 
-// CHECK: EXEC @mutli_device_mul
+// CHECK: EXEC @multi_device_mul
 // CHECK-NEXT: result[0]: hal.buffer_view
 // CHECK-NEXT: 4xf32=0 55 144 273
-func.func public @mutli_device_mul(
+func.func public @multi_device_mul(
   // Input argument is resident on device_a (tooling default to first device).
   %input_a: tensor<4xf32> {iree.abi.affinity = #hal.device.promise<@device_a>}
 ) -> (


### PR DESCRIPTION
I found the typo when I'm working on multi-device related work, the revision fixes the issue. And I verified that there are no "mutli" typo in IREE repo with the fix.