### PR TITLE
Update LLVM to llvm/llvm-project@b13592219c421820b

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPUPrepareUkernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPUPrepareUkernels.cpp
@@ -75,7 +75,7 @@ static void tileNonPackedDimsFor3DPackOps(RewriterBase &rewriter,
     FailureOr<scf::SCFTilingResult> tilingResult =
         scf::tileUsingSCF(rewriter, tilingInterfaceOp, options);
     assert(succeeded(tilingResult));
-    rewriter.replaceOp(packOp, tilingResult->replacements);
+    rewriter.replaceOp(packOp, tilingResult->mergeResult.replacements);
   });
 }
 
@@ -110,7 +110,7 @@ static void tileNonPackedDimsFor5DPUnpackOps(RewriterBase &rewriter,
     FailureOr<scf::SCFTilingResult> tilingResult =
         scf::tileUsingSCF(rewriter, tilingInterfaceOp, options);
     assert(succeeded(tilingResult));
-    rewriter.replaceOp(unpackOp, tilingResult->replacements);
+    rewriter.replaceOp(unpackOp, tilingResult->mergeResult.replacements);
   });
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/DecomposePackUnPackOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DecomposePackUnPackOps.cpp
@@ -200,7 +200,7 @@ static LogicalResult commonRunOnOperation(
             unpackTilingOptions);
         if (failed(tilingResult))
           return WalkResult::interrupt();
-        rewriter.replaceOp(op, tilingResult->replacements);
+        rewriter.replaceOp(op, tilingResult->mergeResult.replacements);
         return WalkResult::advance();
       });
       if (status.wasInterrupted()) {

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTensorTile.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTensorTile.cpp
@@ -90,7 +90,7 @@ public:
     }
 
     // Replace the tiled op with replacements.
-    rewriter.replaceOp(op, tilingResult->replacements);
+    rewriter.replaceOp(op, tilingResult->mergeResult.replacements);
     filter.replaceLinalgTransformationFilter(rewriter,
                                              tilingResult->tiledOps.front());
 
@@ -292,7 +292,7 @@ static LogicalResult tileParallelDims(mlir::FunctionOpInterface funcOp,
     if (failed(tilingResult)) {
       return tilingOp->emitOpError("failed to tile to scf.forall");
     }
-    rewriter.replaceOp(tilingOp, tilingResult->replacements);
+    rewriter.replaceOp(tilingOp, tilingResult->mergeResult.replacements);
   }
   return success();
 }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTileReduction.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTileReduction.cpp
@@ -38,7 +38,7 @@ static LogicalResult tileReduction(linalg::LinalgOp op) {
     sizes.push_back(rewriter.getIndexAttr(size));
   }
   rewriter.setInsertionPoint(op);
-  FailureOr<scf::SCFReductionTilingResult> results = scf::tileReductionUsingScf(
+  FailureOr<scf::SCFTilingResult> results = scf::tileReductionUsingScf(
       rewriter, cast<PartialReductionOpInterface>(op.getOperation()), sizes);
   if (failed(results))
     return failure();

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPU2DScalableTo1DScalable.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPU2DScalableTo1DScalable.cpp
@@ -161,7 +161,7 @@ dropScalabilityFromUnsupportedOperations(mlir::FunctionOpInterface funcOp,
         setLoweringConfig(newOp, newLoweringConfig);
     }
 
-    rewriter.replaceOp(tilingOp, tilingResult->replacements);
+    rewriter.replaceOp(tilingOp, tilingResult->mergeResult.replacements);
   }
   return success();
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSplitReduction.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUSplitReduction.cpp
@@ -132,7 +132,7 @@ LogicalResult splitReductionImpl(Operation *op, int64_t size,
     LLVM_DEBUG(llvm::dbgs() << "failed on step 1 (SCFTiling)\n");
     return failure();
   }
-  rewriter.replaceOp(linalgOp, tileResFirst->replacements);
+  rewriter.replaceOp(linalgOp, tileResFirst->mergeResult.replacements);
 
   // 2) Apply splitReduction on the single vector-length array.
   // splitReduction already replaces the op.
@@ -159,7 +159,8 @@ LogicalResult splitReductionImpl(Operation *op, int64_t size,
     LLVM_DEBUG(llvm::dbgs() << "failed on step 3 (SCFTiling)\n");
     return failure();
   }
-  rewriter.replaceOp(splitRes->splitLinalgOp, tileRes->replacements);
+  rewriter.replaceOp(splitRes->splitLinalgOp,
+                     tileRes->mergeResult.replacements);
   return success();
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTile.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTile.cpp
@@ -101,7 +101,7 @@ void LLVMCPUTilePass::runOnOperation() {
         scf::tileUsingSCF(rewriter, op, options);
     if (failed(tiledResults))
       continue;
-    rewriter.replaceOp(op, tiledResults->replacements);
+    rewriter.replaceOp(op, tiledResults->mergeResult.replacements);
   }
 
   RewritePatternSet patterns =

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -1256,7 +1256,7 @@ LogicalResult tileLinalgOpsWithFilter(mlir::FunctionOpInterface funcOp,
     for (auto tiledOp : tiledResults->tiledOps) {
       filter.replaceLinalgTransformationFilter(rewriter, tiledOp);
     }
-    rewriter.replaceOp(op, tiledResults->replacements);
+    rewriter.replaceOp(op, tiledResults->mergeResult.replacements);
   }
 
   return success();


### PR DESCRIPTION
Update LLVM to llvm/llvm-project@b13592219c421820b (https://github.com/llvm/llvm-project/pull/85376)
Changes in C++ mostly handle changes done in https://github.com/llvm/llvm-project/commit/4b56345895729fda3bc3c094bc3f237ba3a49686 that combines SCFTilingResult and SCFReductionTilingResult.

This PR also carries the following reverts

- https://github.com/llvm/llvm-project/pull/119671
- https://github.com/llvm/llvm-project/pull/119970

The first one is a from the previous integrate. The last one is a new error being tracked in https://github.com/iree-org/iree/issues/19498.