### PR TITLE
Fix incorrect offset in fd_file.c

### DIFF
--- a/runtime/src/iree/hal/utils/fd_file.c
+++ b/runtime/src/iree/hal/utils/fd_file.c
@@ -319,8 +319,7 @@ static iree_status_t iree_hal_fd_file_read(iree_hal_file_t* base_file,
   if (iree_status_is_ok(status) &&
       !iree_all_bits_set(iree_hal_buffer_memory_type(buffer),
                          IREE_HAL_MEMORY_TYPE_HOST_COHERENT)) {
-    status =
-        iree_hal_buffer_mapping_flush_range(&mapping, buffer_offset, length);
+    status = iree_hal_buffer_mapping_flush_range(&mapping, 0, length);
   }
 
   return iree_status_join(status, iree_hal_buffer_unmap_range(&mapping));
@@ -342,8 +341,7 @@ static iree_status_t iree_hal_fd_file_write(iree_hal_file_t* base_file,
   iree_status_t status = iree_ok_status();
   if (!iree_all_bits_set(iree_hal_buffer_memory_type(buffer),
                          IREE_HAL_MEMORY_TYPE_HOST_COHERENT)) {
-    status = iree_hal_buffer_mapping_invalidate_range(&mapping, buffer_offset,
-                                                      length);
+    status = iree_hal_buffer_mapping_invalidate_range(&mapping, 0, length);
   }
 
   const uint8_t* buffer_ptr = mapping.contents.data;


### PR DESCRIPTION
iree_hal_buffer_mapping_{flush,invalidate}_range take values that are relative to the mappings, not the buffers themselves.