### PR TITLE
[hip] Implement asynchronous file reads in hip.

### DIFF
--- a/runtime/src/iree/hal/drivers/hip/api.h
+++ b/runtime/src/iree/hal/drivers/hip/api.h
@@ -91,6 +91,14 @@ typedef struct iree_hal_hip_device_params_t {
   // device. Defaults to true when the device supports it.
   bool async_allocations;
 
+  // The reserved buffer size for asynchronous file transfers.
+  iree_device_size_t file_transfer_buffer_size;
+
+  // The maximum chunk size for any single asynchronous file transfer.
+  // This should be smaller than the full buffer size to allow overlapping
+  // cpu and gpu workloads.
+  iree_device_size_t file_transfer_chunk_size;
+
   // Parameters for each hipMemPool_t used for queue-ordered allocations.
   iree_hal_hip_memory_pooling_params_t memory_pools;
 

--- a/runtime/src/iree/hal/drivers/hip/hip_device.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_device.c
@@ -35,6 +35,9 @@
 #include "iree/hal/utils/file_transfer.h"
 #include "iree/hal/utils/stream_tracing.h"
 
+#define IREE_HAL_DEVICE_TRANSFER_DEFAULT_BUFFER_SIZE (128 * 1024 * 1024)
+#define IREE_HAL_DEVICE_MAX_TRANSFER_DEFAULT_CHUNK_SIZE (64 * 1024 * 1024)
+
 //===----------------------------------------------------------------------===//
 // iree_hal_hip_device_t
 //===----------------------------------------------------------------------===//
@@ -221,6 +224,10 @@ IREE_API_EXPORT void iree_hal_hip_device_params_initialize(
   out_params->command_buffer_mode = IREE_HAL_HIP_COMMAND_BUFFER_MODE_STREAM;
   out_params->stream_tracing = 0;
   out_params->async_allocations = true;
+  out_params->file_transfer_buffer_size =
+      IREE_HAL_DEVICE_TRANSFER_DEFAULT_BUFFER_SIZE;
+  out_params->file_transfer_chunk_size =
+      IREE_HAL_DEVICE_MAX_TRANSFER_DEFAULT_CHUNK_SIZE;
   out_params->allow_inline_execution = false;
 }
 
@@ -368,6 +375,34 @@ static iree_status_t iree_hal_hip_device_initialize_internal(
     }
   }
 
+  if (iree_status_is_ok(status)) {
+    for (iree_host_size_t i = 0; i < device->device_count; ++i) {
+      iree_hal_buffer_params_t buffer_params = {
+          .usage = IREE_HAL_BUFFER_USAGE_TRANSFER |
+                   IREE_HAL_BUFFER_USAGE_MAPPING_SCOPED,
+          .access = IREE_HAL_MEMORY_ACCESS_READ | IREE_HAL_MEMORY_ACCESS_WRITE |
+                    IREE_HAL_MEMORY_ACCESS_DISCARD,
+          .type = IREE_HAL_MEMORY_TYPE_HOST_VISIBLE |
+                  IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
+          .queue_affinity = (iree_hal_queue_affinity_t)1 << i,
+          .min_alignment = 0,
+      };
+      status = iree_hal_allocator_allocate_buffer(
+          device->device_allocator, buffer_params,
+          params->file_transfer_buffer_size,
+          &device->devices[i].file_transfer_staging_buffer);
+      if (!iree_status_is_ok(status)) {
+        break;
+      }
+      device->devices[i].file_transfer_staging_buffer_head = 0;
+      device->devices[i].file_transfer_staging_buffer_tail = 0;
+      iree_slim_mutex_initialize(
+          &device->devices[i].file_transfer_staging_buffer_lock);
+      iree_notification_initialize(
+          &device->devices[i].file_transfer_staging_buffer_notify);
+    }
+  }
+
   if (!iree_status_is_ok(status)) {
     iree_hal_device_release((iree_hal_device_t*)device);
   }
@@ -478,6 +513,14 @@ static void iree_hal_hip_device_destroy(iree_hal_device_t* base_device) {
 
   iree_hal_hip_cleanup_thread_deinitialize(device->cleanup_thread);
   iree_hal_hip_cleanup_thread_deinitialize(device->buffer_free_thread);
+
+  for (iree_host_size_t i = 0; i < device->device_count; ++i) {
+    iree_hal_resource_release(device->devices[i].file_transfer_staging_buffer);
+    iree_slim_mutex_deinitialize(
+        &device->devices[i].file_transfer_staging_buffer_lock);
+    iree_notification_deinitialize(
+        &device->devices[i].file_transfer_staging_buffer_notify);
+  }
 
   // There should be no more buffers live that use the allocator.
   iree_hal_allocator_release(device->device_allocator);
@@ -933,10 +976,10 @@ typedef struct iree_hal_hip_semaphore_callback_data_t {
   iree_status_t status;
 } iree_hal_hip_semaphore_callback_data_t;
 
-iree_host_size_t iree_hal_hip_semaphore_callback_data_get_additional_allocation_size(
-  iree_hal_semaphore_list_t wait_semaphore_list,
-  iree_hal_semaphore_list_t signal_semaphore_list
-) {
+iree_host_size_t
+iree_hal_hip_semaphore_callback_data_get_additional_allocation_size(
+    iree_hal_semaphore_list_t wait_semaphore_list,
+    iree_hal_semaphore_list_t signal_semaphore_list) {
   const iree_host_size_t wait_semaphore_list_size =
       wait_semaphore_list.count * sizeof(*wait_semaphore_list.semaphores) +
       wait_semaphore_list.count * sizeof(*wait_semaphore_list.payload_values);
@@ -947,17 +990,17 @@ iree_host_size_t iree_hal_hip_semaphore_callback_data_get_additional_allocation_
   return wait_semaphore_list_size + signal_semaphore_list_size;
 }
 
-void iree_hal_hip_semaphore_callback_data_init(iree_allocator_t host_allocator,
-  iree_hal_hip_device_t* device,
-  iree_hal_queue_affinity_t queue_affinity,
-  iree_hal_hip_dispatch_callback_t dispatch_fn,
-  iree_hal_semaphore_list_t wait_semaphore_list,
-  iree_hal_semaphore_list_t signal_semaphore_list,
-  void* additional_data_offset,
-  iree_hal_hip_semaphore_callback_data_t* data) {
+void iree_hal_hip_semaphore_callback_data_init(
+    iree_allocator_t host_allocator, iree_hal_hip_device_t* device,
+    iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_hip_dispatch_callback_t dispatch_fn,
+    iree_hal_semaphore_list_t wait_semaphore_list,
+    iree_hal_semaphore_list_t signal_semaphore_list,
+    void* additional_data_offset,
+    iree_hal_hip_semaphore_callback_data_t* data) {
   data->host_allocator = host_allocator;
-  iree_atomic_store(&data->wait_semaphore_count,
-                    wait_semaphore_list.count, iree_memory_order_relaxed);
+  iree_atomic_store(&data->wait_semaphore_count, wait_semaphore_list.count,
+                    iree_memory_order_relaxed);
 
   data->device = device;
   data->queue_affinity = queue_affinity;
@@ -969,10 +1012,8 @@ void iree_hal_hip_semaphore_callback_data_init(iree_allocator_t host_allocator,
       wait_semaphore_list.count * sizeof(*wait_semaphore_list.semaphores) +
       wait_semaphore_list.count * sizeof(*wait_semaphore_list.payload_values);
   data->wait_semaphore_list.count = wait_semaphore_list.count;
-  data->wait_semaphore_list.semaphores =
-      (iree_hal_semaphore_t**)callback_ptr;
-  memcpy(data->wait_semaphore_list.semaphores,
-         wait_semaphore_list.semaphores,
+  data->wait_semaphore_list.semaphores = (iree_hal_semaphore_t**)callback_ptr;
+  memcpy(data->wait_semaphore_list.semaphores, wait_semaphore_list.semaphores,
          wait_semaphore_list.count * sizeof(*wait_semaphore_list.semaphores));
   data->wait_semaphore_list.payload_values =
       (uint64_t*)(callback_ptr + wait_semaphore_list.count *
@@ -988,11 +1029,9 @@ void iree_hal_hip_semaphore_callback_data_init(iree_allocator_t host_allocator,
 
   // Copy signal list for later access.
   data->signal_semaphore_list.count = signal_semaphore_list.count;
-  data->signal_semaphore_list.semaphores =
-      (iree_hal_semaphore_t**)callback_ptr;
+  data->signal_semaphore_list.semaphores = (iree_hal_semaphore_t**)callback_ptr;
   memcpy(
-      data->signal_semaphore_list.semaphores,
-      signal_semaphore_list.semaphores,
+      data->signal_semaphore_list.semaphores, signal_semaphore_list.semaphores,
       signal_semaphore_list.count * sizeof(*signal_semaphore_list.semaphores));
   data->signal_semaphore_list.payload_values =
       (uint64_t*)(callback_ptr + signal_semaphore_list.count *
@@ -1010,7 +1049,7 @@ void iree_hal_hip_semaphore_callback_data_init(iree_allocator_t host_allocator,
 }
 
 void iree_hal_hip_semaphore_callback_data_deinit(
-  iree_hal_hip_semaphore_callback_data_t* data) {
+    iree_hal_hip_semaphore_callback_data_t* data) {
   iree_slim_mutex_deinitialize(&data->status_mutex);
   for (iree_host_size_t i = 0; i < data->wait_semaphore_list.count; ++i) {
     iree_hal_resource_release(data->wait_semaphore_list.semaphores[i]);
@@ -1026,6 +1065,30 @@ typedef enum iree_hal_hip_device_semaphore_buffer_operation_type_e {
   IREE_HAL_HIP_DEVICE_SEMAPHORE_OPERATION_MAX =
       IREE_HAL_HIP_DEVICE_SEMAPHORE_OPERATION_ASYNC_DEALLOC,
 } iree_hal_hip_device_semaphore_buffer_operation_type_t;
+
+static iree_status_t iree_hal_hip_device_stream_add_cleanup(
+    iree_hal_hip_device_t* device, iree_hal_hip_cleanup_thread_t* thread,
+    iree_host_size_t device_ordinal, iree_hal_hip_cleanup_callback_t callback,
+    void* user_data) {
+  iree_hal_hip_event_t* event = NULL;
+  iree_status_t status = iree_hal_hip_event_pool_acquire(
+      device->devices[device_ordinal].device_event_pool, 1, &event);
+
+  if (iree_status_is_ok(status)) {
+    status = IREE_HIP_CALL_TO_STATUS(
+        device->hip_symbols,
+        hipEventRecord(iree_hal_hip_event_handle(event),
+                       device->devices[device_ordinal].hip_dispatch_stream));
+  }
+
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_hip_cleanup_thread_add_cleanup(thread, event, callback,
+                                                     user_data);
+  } else {
+    iree_hal_hip_event_release(event);
+  }
+  return status;
+}
 
 static iree_status_t
 iree_hal_hip_device_stream_signal_semaphores_and_add_cleanup(
@@ -1054,26 +1117,10 @@ iree_hal_hip_device_stream_signal_semaphores_and_add_cleanup(
         signal_semaphore_list.payload_values[i]);
   }
 
-  iree_hal_hip_event_t* event = NULL;
   if (iree_status_is_ok(status)) {
-    status = iree_hal_hip_event_pool_acquire(
-        device->devices[device_ordinal].device_event_pool, 1, &event);
+    status = iree_hal_hip_device_stream_add_cleanup(
+        device, thread, device_ordinal, callback, user_data);
   }
-
-  if (iree_status_is_ok(status)) {
-    status = IREE_HIP_CALL_TO_STATUS(
-        device->hip_symbols,
-        hipEventRecord(iree_hal_hip_event_handle(event),
-                       device->devices[device_ordinal].hip_dispatch_stream));
-  }
-
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_hip_cleanup_thread_add_cleanup(thread, event, callback,
-                                                     user_data);
-  } else {
-    iree_hal_hip_event_release(event);
-  }
-
   IREE_TRACE_ZONE_END(z0);
   return status;
 }
@@ -1138,64 +1185,6 @@ static iree_status_t iree_hal_hip_async_free_buffer(void* user_data,
   return status;
 }
 
-typedef struct iree_hal_hip_device_semaphore_buffer_operation_callback_data_t {
-  iree_hal_hip_semaphore_callback_data_t base;
-  iree_hal_buffer_t* buffer;
-  iree_hal_hip_device_semaphore_buffer_operation_type_t type;
-} iree_hal_hip_device_semaphore_buffer_operation_callback_data_t;
-
-void iree_hal_hip_device_destroy_buffer_callback_data(
-    iree_hal_hip_device_semaphore_buffer_operation_callback_data_t* data) {
-  if (!data) {
-    return;
-  }
-  iree_hal_buffer_release(data->buffer);
-  iree_hal_hip_semaphore_callback_data_deinit(&data->base);
-  iree_allocator_free(data->base.host_allocator, data);
-}
-
-static iree_status_t iree_hal_hip_device_complete_buffer_operation(
-    void* user_data, iree_hal_hip_event_t* event, iree_status_t status) {
-  IREE_TRACE_ZONE_BEGIN(z0);
-  iree_hal_hip_device_semaphore_buffer_operation_callback_data_t* data =
-      (iree_hal_hip_device_semaphore_buffer_operation_callback_data_t*)
-          user_data;
-
-  // Free the event we specifically created.
-  iree_hal_hip_event_release(event);
-
-  // Notify all of the signal semaphores that they have been incremented.
-  for (iree_host_size_t i = 0; i < data->base.signal_semaphore_list.count; ++i) {
-    iree_status_ignore(iree_hal_hip_event_semaphore_advance(
-        data->base.signal_semaphore_list.semaphores[i]));
-  }
-
-  if (data->buffer &&
-      data->type == IREE_HAL_HIP_DEVICE_SEMAPHORE_OPERATION_ASYNC_DEALLOC) {
-    int device_ordinal =
-        iree_math_count_trailing_zeros_u64(data->base.queue_affinity);
-    if (data->base.device->supports_memory_pools) {
-      status = iree_status_join(
-          status, iree_hal_hip_memory_pools_deallocate(
-                      &data->base.device->devices[device_ordinal].memory_pools,
-                      data->base.device->devices[device_ordinal].hip_dispatch_stream,
-                      data->buffer));
-    } else {
-      status = iree_status_join(
-          status,
-          iree_hal_hip_allocator_free_async(
-              iree_hal_device_allocator((iree_hal_device_t*)data->base.device),
-              data->base.device->devices[device_ordinal].hip_dispatch_stream,
-              data->buffer));
-    }
-  }
-
-  iree_hal_hip_device_destroy_buffer_callback_data(data);
-
-  IREE_TRACE_ZONE_END(z0);
-  return status;
-}
-
 static iree_status_t iree_hal_hip_device_stream_wait_for_semaphores(
     iree_hal_hip_device_t* device,
     iree_hal_semaphore_list_t wait_semaphore_list,
@@ -1234,6 +1223,91 @@ static iree_status_t iree_hal_hip_device_stream_wait_for_semaphores(
   return status;
 }
 
+static iree_status_t iree_hal_hip_device_semaphore_callback(
+    void* user_context, iree_hal_semaphore_t* semaphore, iree_status_t status) {
+  iree_hal_hip_semaphore_callback_data_t* data =
+      (iree_hal_hip_semaphore_callback_data_t*)user_context;
+
+  if (!iree_status_is_ok(status)) {
+    iree_slim_mutex_lock(&data->status_mutex);
+    data->status = iree_status_join(data->status, status);
+    iree_slim_mutex_unlock(&data->status_mutex);
+  }
+  if (iree_atomic_fetch_sub(&data->wait_semaphore_count, 1,
+                            iree_memory_order_acq_rel) != 1) {
+    return iree_ok_status();
+  }
+
+  int device_ordinal = iree_math_count_trailing_zeros_u64(data->queue_affinity);
+
+  // Now the actual submit happens, as all semaphore have been satisfied
+  // (by satisfied here, we specifically mean that the semaphore has been
+  // scheduled, not necessarily completed)
+  return iree_hal_hip_dispatch_thread_add_dispatch(
+      data->device->devices[device_ordinal].dispatch_thread, data->dispatch_fn,
+      data);
+}
+
+typedef struct iree_hal_hip_device_semaphore_buffer_operation_callback_data_t {
+  iree_hal_hip_semaphore_callback_data_t base;
+  iree_hal_buffer_t* buffer;
+  iree_hal_hip_device_semaphore_buffer_operation_type_t type;
+} iree_hal_hip_device_semaphore_buffer_operation_callback_data_t;
+
+void iree_hal_hip_device_destroy_buffer_callback_data(
+    iree_hal_hip_device_semaphore_buffer_operation_callback_data_t* data) {
+  if (!data) {
+    return;
+  }
+  iree_hal_buffer_release(data->buffer);
+  iree_hal_hip_semaphore_callback_data_deinit(&data->base);
+  iree_allocator_free(data->base.host_allocator, data);
+}
+
+static iree_status_t iree_hal_hip_device_complete_buffer_operation(
+    void* user_data, iree_hal_hip_event_t* event, iree_status_t status) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_hal_hip_device_semaphore_buffer_operation_callback_data_t* data =
+      (iree_hal_hip_device_semaphore_buffer_operation_callback_data_t*)
+          user_data;
+
+  // Free the event we specifically created.
+  iree_hal_hip_event_release(event);
+
+  // Notify all of the signal semaphores that they have been incremented.
+  for (iree_host_size_t i = 0; i < data->base.signal_semaphore_list.count;
+       ++i) {
+    iree_status_ignore(iree_hal_hip_event_semaphore_advance(
+        data->base.signal_semaphore_list.semaphores[i]));
+  }
+
+  if (data->buffer &&
+      data->type == IREE_HAL_HIP_DEVICE_SEMAPHORE_OPERATION_ASYNC_DEALLOC) {
+    int device_ordinal =
+        iree_math_count_trailing_zeros_u64(data->base.queue_affinity);
+    if (data->base.device->supports_memory_pools) {
+      status = iree_status_join(
+          status,
+          iree_hal_hip_memory_pools_deallocate(
+              &data->base.device->devices[device_ordinal].memory_pools,
+              data->base.device->devices[device_ordinal].hip_dispatch_stream,
+              data->buffer));
+    } else {
+      status = iree_status_join(
+          status,
+          iree_hal_hip_allocator_free_async(
+              iree_hal_device_allocator((iree_hal_device_t*)data->base.device),
+              data->base.device->devices[device_ordinal].hip_dispatch_stream,
+              data->buffer));
+    }
+  }
+
+  iree_hal_hip_device_destroy_buffer_callback_data(data);
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 static iree_status_t iree_hal_hip_device_perform_buffer_operation_now(
     void* user_data, iree_status_t status) {
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -1251,7 +1325,8 @@ static iree_status_t iree_hal_hip_device_perform_buffer_operation_now(
     status = iree_status_join(data->base.status, status);
   }
 
-  int device_ordinal = iree_math_count_trailing_zeros_u64(data->base.queue_affinity);
+  int device_ordinal =
+      iree_math_count_trailing_zeros_u64(data->base.queue_affinity);
 
   if (iree_status_is_ok(status)) {
     status = IREE_HIP_CALL_TO_STATUS(
@@ -1299,7 +1374,8 @@ static iree_status_t iree_hal_hip_device_perform_buffer_operation_now(
         device, device->cleanup_thread, data->base.signal_semaphore_list,
         device_ordinal, &iree_hal_hip_device_complete_buffer_operation, data);
   } else {
-    for (iree_host_size_t i = 0; i < data->base.signal_semaphore_list.count; ++i) {
+    for (iree_host_size_t i = 0; i < data->base.signal_semaphore_list.count;
+         ++i) {
       iree_hal_semaphore_fail(data->base.signal_semaphore_list.semaphores[i],
                               iree_status_clone(data->base.status));
     }
@@ -1325,17 +1401,22 @@ static iree_status_t iree_hal_hip_device_make_buffer_callback_data(
   iree_hal_hip_device_semaphore_buffer_operation_callback_data_t*
       callback_data = NULL;
 
-  const iree_host_size_t additional_data_for_base = 
-    iree_hal_hip_semaphore_callback_data_get_additional_allocation_size(wait_semaphore_list, signal_semaphore_list);
+  const iree_host_size_t additional_data_for_base =
+      iree_hal_hip_semaphore_callback_data_get_additional_allocation_size(
+          wait_semaphore_list, signal_semaphore_list);
 
-  const iree_host_size_t total_callback_size = sizeof(*callback_data) + additional_data_for_base;
+  const iree_host_size_t total_callback_size =
+      sizeof(*callback_data) + additional_data_for_base;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_allocator_malloc(host_allocator, total_callback_size,
                                 (void**)&callback_data));
-  iree_hal_hip_semaphore_callback_data_init(host_allocator, 
-    device, queue_affinity, &iree_hal_hip_device_perform_buffer_operation_now, wait_semaphore_list, signal_semaphore_list,
-    (void*)((uint8_t*)callback_data + sizeof(*callback_data)), &callback_data->base);
-  
+  iree_hal_hip_semaphore_callback_data_init(
+      host_allocator, device, queue_affinity,
+      &iree_hal_hip_device_perform_buffer_operation_now, wait_semaphore_list,
+      signal_semaphore_list,
+      (void*)((uint8_t*)callback_data + sizeof(*callback_data)),
+      &callback_data->base);
+
   callback_data->buffer = buffer;
   iree_hal_buffer_retain(buffer);
   callback_data->type = type;
@@ -1343,31 +1424,6 @@ static iree_status_t iree_hal_hip_device_make_buffer_callback_data(
   *out_data = callback_data;
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
-}
-
-static iree_status_t iree_hal_hip_device_semaphore_callback(
-    void* user_context, iree_hal_semaphore_t* semaphore, iree_status_t status) {
-  iree_hal_hip_semaphore_callback_data_t* data =
-      (iree_hal_hip_semaphore_callback_data_t*)user_context;
-
-  if (!iree_status_is_ok(status)) {
-    iree_slim_mutex_lock(&data->status_mutex);
-    data->status = iree_status_join(data->status, status);
-    iree_slim_mutex_unlock(&data->status_mutex);
-  }
-  if (iree_atomic_fetch_sub(&data->wait_semaphore_count, 1,
-                            iree_memory_order_acq_rel) != 1) {
-    return iree_ok_status();
-  }
-
-  int device_ordinal = iree_math_count_trailing_zeros_u64(data->queue_affinity);
-
-  // Now the actual submit happens, as all semaphore have been satisfied
-  // (by satisfied here, we specifically mean that the semaphore has been
-  // scheduled, not necessarily completed)
-  return iree_hal_hip_dispatch_thread_add_dispatch(
-      data->device->devices[device_ordinal].dispatch_thread,
-      data->dispatch_fn, data);
 }
 
 // TODO: implement multiple streams; today we only have one and queue_affinity
@@ -1424,8 +1480,7 @@ static iree_status_t iree_hal_hip_device_queue_alloca(
                 wait_semaphore_list.semaphores[i],
                 wait_semaphore_list.payload_values[i],
                 device->devices[device_ordinal].device_event_pool,
-                &iree_hal_hip_device_semaphore_callback,
-                callback_data));
+                &iree_hal_hip_device_semaphore_callback, callback_data));
       }
     } else {
       iree_hal_hip_device_destroy_buffer_callback_data(callback_data);
@@ -1515,8 +1570,7 @@ static iree_status_t iree_hal_hip_device_queue_dealloca(
                 wait_semaphore_list.semaphores[i],
                 wait_semaphore_list.payload_values[i],
                 device->devices[device_ordinal].device_event_pool,
-                &iree_hal_hip_device_semaphore_callback,
-                callback_data));
+                &iree_hal_hip_device_semaphore_callback, callback_data));
       }
     } else {
       iree_hal_hip_device_destroy_buffer_callback_data(callback_data);
@@ -1552,6 +1606,367 @@ static iree_status_t iree_hal_hip_device_queue_dealloca(
   return status;
 }
 
+typedef struct iree_hal_hip_device_semaphore_queue_read_callback_data_t {
+  iree_hal_hip_semaphore_callback_data_t base;
+  iree_hal_file_t* source_file;
+  uint64_t source_offset;
+  iree_hal_buffer_t* target_buffer;
+  iree_device_size_t target_offset;
+  iree_device_size_t length;
+  iree_hal_read_flags_t flags;
+  int64_t read_chunks_completed;
+  uint64_t num_read_chunks;
+  uint64_t* read_chunk_sizes;
+  iree_hal_command_buffer_t** command_buffers;
+} iree_hal_hip_device_semaphore_queue_read_callback_data_t;
+
+void iree_hal_hip_device_destroy_queue_read_callback_data(
+    iree_hal_hip_device_semaphore_queue_read_callback_data_t* data) {
+  if (!data) {
+    return;
+  }
+  iree_hal_resource_release(data->target_buffer);
+  iree_hal_hip_semaphore_callback_data_deinit(&data->base);
+  iree_allocator_free(data->base.host_allocator, data);
+}
+
+static iree_status_t iree_hal_hip_device_complete_queue_read_operation(
+    void* user_data, iree_hal_hip_event_t* event, iree_status_t status) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_hal_hip_device_semaphore_queue_read_callback_data_t* data =
+      (iree_hal_hip_device_semaphore_queue_read_callback_data_t*)user_data;
+
+  // Free the event we specifically created.
+  iree_hal_hip_event_release(event);
+
+  // Release the next chunk of buffer back to the ring.
+  int device_ordinal =
+      iree_math_count_trailing_zeros_u64(data->base.queue_affinity);
+  iree_slim_mutex_lock(&data->base.device->devices[device_ordinal]
+                            .file_transfer_staging_buffer_lock);
+  data->base.device->devices[device_ordinal]
+      .file_transfer_staging_buffer_tail +=
+      data->read_chunk_sizes[data->read_chunks_completed];
+  data->base.device->devices[device_ordinal]
+      .file_transfer_staging_buffer_tail %=
+      data->base.device->params.file_transfer_buffer_size;
+  if (data->base.device->devices[device_ordinal]
+          .file_transfer_staging_buffer_head ==
+      data->base.device->devices[device_ordinal]
+          .file_transfer_staging_buffer_tail) {
+    // Slight optimization here. If the buffer is empty, reset it to 0, so that
+    // we are less likely to wrap.
+    data->base.device->devices[device_ordinal]
+        .file_transfer_staging_buffer_head = 0;
+    data->base.device->devices[device_ordinal]
+        .file_transfer_staging_buffer_tail = 0;
+  }
+  iree_slim_mutex_unlock(&data->base.device->devices[device_ordinal]
+                              .file_transfer_staging_buffer_lock);
+  iree_notification_post(&data->base.device->devices[device_ordinal]
+                              .file_transfer_staging_buffer_notify,
+                         IREE_ALL_WAITERS);
+
+  iree_hal_command_buffer_t* command_buffer =
+      data->command_buffers[data->read_chunks_completed];
+  if (iree_hal_hip_multi_queue_command_buffer_isa(command_buffer)) {
+    status = iree_hal_hip_multi_queue_command_buffer_get(
+        command_buffer, data->base.queue_affinity, &command_buffer);
+  }
+
+  status = iree_status_join(
+      status,
+      iree_hal_stream_tracing_context_collect_list(
+          // Get the tracing context from the device/stream/queue affinity.
+          data->base.device->devices[device_ordinal].tracing_context,
+          // Get the tracing event list from the command buffer.
+          iree_hal_hip_stream_command_buffer_tracing_events(command_buffer)
+              .head));
+
+  iree_hal_resource_release(data->command_buffers[data->read_chunks_completed]);
+  // If there are more chunks to this transfer don't destroy and advance
+  // the semaphores yet.
+  if (++data->read_chunks_completed != data->num_read_chunks) {
+    IREE_TRACE_ZONE_END(z0);
+    return status;
+  }
+
+  // Notify all of the signal semaphores that they have been incremented.
+  for (iree_host_size_t i = 0; i < data->base.signal_semaphore_list.count;
+       ++i) {
+    iree_status_ignore(iree_hal_hip_event_semaphore_advance(
+        data->base.signal_semaphore_list.semaphores[i]));
+  }
+
+  iree_hal_hip_device_destroy_queue_read_callback_data(data);
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+iree_device_size_t iree_hal_hip_transfer_buffer_size_left(
+    iree_hal_hip_device_t* device, iree_hal_hip_per_device_info_t* info) {
+  iree_slim_mutex_lock(&info->file_transfer_staging_buffer_lock);
+  iree_device_size_t size_left =
+      info->file_transfer_staging_buffer_head >=
+              info->file_transfer_staging_buffer_tail
+          ? device->params.file_transfer_buffer_size -
+                (info->file_transfer_staging_buffer_head -
+                 info->file_transfer_staging_buffer_tail)
+          : info->file_transfer_staging_buffer_tail -
+                info->file_transfer_staging_buffer_head;
+  iree_slim_mutex_unlock(&info->file_transfer_staging_buffer_lock);
+  return size_left;
+}
+
+typedef struct iree_hal_hip_transfer_buffer_chunk_t {
+  iree_device_size_t offset;
+  iree_device_size_t size;
+} iree_hal_hip_transfer_buffer_chunk_t;
+
+typedef struct iree_hal_hip_transfer_buffer_size_check_data_t {
+  iree_host_size_t device_ordinal;
+  iree_device_size_t num_bytes;
+  iree_hal_hip_device_t* device;
+} iree_hal_hip_transfer_buffer_size_check_data_t;
+
+bool iree_hal_hip_transfer_buffer_size_check_condition(void* user_data) {
+  iree_hal_hip_transfer_buffer_size_check_data_t* data =
+      (iree_hal_hip_transfer_buffer_size_check_data_t*)user_data;
+  return iree_hal_hip_transfer_buffer_size_left(
+             data->device, &data->device->devices[data->device_ordinal]) >
+         data->num_bytes;
+}
+
+// Returns two chunks that are needed to cover the buffer. Pass in an
+// array of 2 chunks to be filled in. It will wait on the availability
+// of the chunks if there are transfers in progress. It is possible that
+// either of the chunks may have a size of 0. The requested size must be
+// less than or equal to the file_transfer_chunk_size.
+void iree_hal_hip_transfer_buffer_reserve_chunks(
+    iree_hal_hip_device_t* device, iree_host_size_t device_ordinal,
+    iree_device_size_t size, iree_hal_hip_transfer_buffer_chunk_t* out_chunks) {
+  IREE_ASSERT_ARGUMENT(out_chunks);
+  IREE_ASSERT(size <= device->params.file_transfer_chunk_size,
+              "Trying to allocate a chunk that is too large.");
+  iree_hal_hip_transfer_buffer_size_check_data_t size_check = {
+      .device_ordinal = device_ordinal, .num_bytes = size, .device = device};
+
+  iree_notification_await(
+      &device->devices[device_ordinal].file_transfer_staging_buffer_notify,
+      iree_hal_hip_transfer_buffer_size_check_condition, (void*)&size_check,
+      iree_infinite_timeout());
+
+  iree_hal_hip_per_device_info_t* info = &device->devices[device_ordinal];
+  iree_slim_mutex_lock(&info->file_transfer_staging_buffer_lock);
+  out_chunks[0].offset = info->file_transfer_staging_buffer_head;
+  out_chunks[0].size =
+      iree_min(size, device->params.file_transfer_buffer_size -
+                         info->file_transfer_staging_buffer_head);
+  if (size != out_chunks->size) {
+    out_chunks[1].offset = 0;
+    out_chunks[1].size = size - out_chunks[0].size;
+    info->file_transfer_staging_buffer_head = out_chunks[1].size;
+  } else {
+    out_chunks[1].offset = 0;
+    out_chunks[1].size = 0;
+    info->file_transfer_staging_buffer_head += size;
+  }
+  iree_slim_mutex_unlock(&info->file_transfer_staging_buffer_lock);
+}
+
+static iree_status_t iree_hal_hip_device_perform_queue_read_now(
+    void* user_data, iree_status_t status) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_hal_hip_device_semaphore_queue_read_callback_data_t* data =
+      (iree_hal_hip_device_semaphore_queue_read_callback_data_t*)user_data;
+
+  iree_hal_hip_device_t* device = data->base.device;
+
+  // If we had a semaphore failure then we should propagate it
+  // but not run anything.
+  if (!iree_status_is_ok(data->base.status)) {
+    status = iree_status_join(data->base.status, status);
+  }
+
+  int device_ordinal =
+      iree_math_count_trailing_zeros_u64(data->base.queue_affinity);
+
+  if (iree_status_is_ok(status)) {
+    status = IREE_HIP_CALL_TO_STATUS(
+        device->hip_symbols,
+        hipCtxPushCurrent(device->devices[device_ordinal].hip_context));
+  }
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, device_ordinal);
+
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_hip_device_stream_wait_for_semaphores(
+        device, data->base.wait_semaphore_list, device_ordinal);
+  }
+  const iree_hal_hip_dynamic_symbols_t* symbols = device->hip_symbols;
+  iree_device_size_t amount_left = data->length;
+  iree_device_size_t offset = 0;
+
+  for (iree_host_size_t i = 0;
+       i < data->num_read_chunks && iree_status_is_ok(status); ++i) {
+    iree_device_size_t chunk_size =
+        iree_min(device->params.file_transfer_chunk_size, amount_left);
+    iree_hal_hip_transfer_buffer_chunk_t chunks[2];
+    iree_hal_hip_transfer_buffer_reserve_chunks(device, device_ordinal,
+                                                chunk_size, &chunks[0]);
+
+    iree_device_size_t read_offset = offset;
+    for (iree_host_size_t j = 0; j < 2; ++j) {
+      if (chunks[j].size) {
+        status = iree_hal_file_read(
+            data->source_file, data->source_offset + read_offset,
+            device->devices[device_ordinal].file_transfer_staging_buffer,
+            chunks[j].offset, chunks[j].size);
+        if (!iree_status_is_ok(status)) {
+          break;
+        }
+        read_offset += chunks[j].size;
+      }
+    }
+
+    // We use a command buffer because it allows us to easily get tracing events
+    // into the trace, and the actual overhead is quite minimal We only start it
+    // here, rather than creating up above the read which is more natural,
+    // because it will show up as actively doing work while we are recording,
+    // because hip stream command buffers are executed at record-time, so we
+    // don't want to get the file io mixed with the record.
+    iree_hal_command_buffer_t* stream_command_buffer = NULL;
+    status = iree_hal_hip_device_create_stream_command_buffer(
+        (iree_hal_device_t*)device,
+        IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT |
+            IREE_HAL_COMMAND_BUFFER_MODE_ALLOW_INLINE_EXECUTION |
+            IREE_HAL_COMMAND_BUFFER_MODE_UNVALIDATED,
+        IREE_HAL_COMMAND_CATEGORY_TRANSFER, data->base.queue_affinity, 0,
+        &stream_command_buffer);
+
+    if (iree_status_is_ok(status)) {
+      status = iree_hal_command_buffer_begin(stream_command_buffer);
+    }
+    for (iree_host_size_t j = 0; j < 2; ++j) {
+      if (iree_status_is_ok(status)) {
+        iree_hal_buffer_ref_t src = {0};
+        src.buffer =
+            device->devices[device_ordinal].file_transfer_staging_buffer;
+        src.offset = chunks[j].offset;
+        src.length = chunks[j].size;
+
+        iree_hal_buffer_ref_t dst = {0};
+        dst.buffer = data->target_buffer;
+        dst.offset = data->target_offset + offset;
+        dst.length = chunks[j].size;
+
+        status = iree_hal_command_buffer_copy_buffer(
+            stream_command_buffer, src, dst, IREE_HAL_COPY_FLAG_NONE);
+      }
+      offset += chunks[j].size;
+      amount_left -= chunks[j].size;
+    }
+
+    if (iree_status_is_ok(status)) {
+      status = iree_hal_command_buffer_end(stream_command_buffer);
+      data->command_buffers[i] = stream_command_buffer;
+    }
+
+    if (iree_status_is_ok(status)) {
+      data->read_chunk_sizes[i] = chunk_size;
+      // We only want to signal the semaphores on the final
+      // chunk.
+      if (i == data->num_read_chunks - 1) {
+        status = iree_hal_hip_device_stream_signal_semaphores_and_add_cleanup(
+            device, device->cleanup_thread, data->base.signal_semaphore_list,
+            device_ordinal, &iree_hal_hip_device_complete_queue_read_operation,
+            data);
+      } else {
+        status = iree_hal_hip_device_stream_add_cleanup(
+            device, device->cleanup_thread, device_ordinal,
+            &iree_hal_hip_device_complete_queue_read_operation, data);
+      }
+    }
+  }
+
+  if (!iree_status_is_ok(status)) {
+    for (iree_host_size_t i = 0; i < data->base.signal_semaphore_list.count;
+         ++i) {
+      iree_hal_semaphore_fail(data->base.signal_semaphore_list.semaphores[i],
+                              iree_status_clone(data->base.status));
+    }
+    iree_hal_hip_device_destroy_queue_read_callback_data(data);
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return iree_status_join(
+      status, IREE_HIP_CALL_TO_STATUS(symbols, hipCtxPopCurrent(NULL)));
+}
+
+static iree_status_t iree_hal_hip_device_make_queue_read_callback_data(
+    iree_hal_hip_device_t* device, iree_allocator_t host_allocator,
+    iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_hal_file_t* source_file, uint64_t source_offset,
+    iree_hal_buffer_t* target_buffer, iree_device_size_t target_offset,
+    iree_device_size_t length, iree_hal_read_flags_t flags,
+    iree_hal_hip_device_semaphore_queue_read_callback_data_t** out_data) {
+  *out_data = NULL;
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_hal_hip_device_semaphore_queue_read_callback_data_t* callback_data =
+      NULL;
+
+  uint64_t chunk_count =
+      (length + device->params.file_transfer_chunk_size - 1) /
+      device->params.file_transfer_chunk_size;
+
+  const iree_host_size_t additional_data_for_base =
+      iree_hal_hip_semaphore_callback_data_get_additional_allocation_size(
+          wait_semaphore_list, signal_semaphore_list);
+  const iree_host_size_t additional_data_for_chunks =
+      sizeof(*callback_data->read_chunk_sizes) * chunk_count +
+      sizeof(*callback_data->command_buffers) * chunk_count;
+
+  const iree_host_size_t total_callback_size = sizeof(*callback_data) +
+                                               additional_data_for_base +
+                                               additional_data_for_chunks;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_allocator_malloc(host_allocator, total_callback_size,
+                                (void**)&callback_data));
+  iree_hal_hip_semaphore_callback_data_init(
+      host_allocator, device, queue_affinity,
+      &iree_hal_hip_device_perform_queue_read_now, wait_semaphore_list,
+      signal_semaphore_list,
+      (void*)((uint8_t*)callback_data + sizeof(*callback_data)),
+      &callback_data->base);
+
+  uint64_t* chunk_base =
+      (void*)((uint8_t*)callback_data + sizeof(*callback_data) +
+              additional_data_for_base);
+  iree_hal_command_buffer_t** command_buffer_base =
+      (iree_hal_command_buffer_t**)((uint8_t*)chunk_base +
+                                    sizeof(*callback_data->read_chunk_sizes) *
+                                        chunk_count);
+  callback_data->source_file = source_file;
+  callback_data->source_offset = source_offset;
+  callback_data->target_buffer = target_buffer;
+  iree_hal_resource_retain(target_buffer);
+  callback_data->target_offset = target_offset;
+  callback_data->length = length;
+  callback_data->flags = flags;
+  callback_data->read_chunks_completed = 0;
+  callback_data->num_read_chunks = chunk_count;
+  callback_data->read_chunk_sizes = chunk_base;
+  callback_data->command_buffers = command_buffer_base;
+
+  *out_data = callback_data;
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
 static iree_status_t iree_hal_hip_device_queue_read(
     iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
     const iree_hal_semaphore_list_t wait_semaphore_list,
@@ -1561,21 +1976,39 @@ static iree_status_t iree_hal_hip_device_queue_read(
     iree_device_size_t length, iree_hal_read_flags_t flags) {
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  // TODO: expose streaming chunk count/size options.
-  iree_status_t loop_status = iree_ok_status();
-  iree_hal_file_transfer_options_t options = {
-      .loop = iree_loop_inline(&loop_status),
-      .chunk_count = IREE_HAL_FILE_TRANSFER_CHUNK_COUNT_DEFAULT,
-      .chunk_size = IREE_HAL_FILE_TRANSFER_CHUNK_SIZE_DEFAULT,
-  };
-  IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_hal_device_queue_read_streaming(
-              base_device, queue_affinity, wait_semaphore_list,
-              signal_semaphore_list, source_file, source_offset, target_buffer,
-              target_offset, length, flags, options));
+  if (queue_affinity == IREE_HAL_QUEUE_AFFINITY_ANY) {
+    queue_affinity = 0x1;
+  }
 
+  iree_hal_hip_device_t* device = iree_hal_hip_device_cast(base_device);
+  const int device_ordinal = iree_math_count_trailing_zeros_u64(queue_affinity);
+
+  iree_hal_hip_device_semaphore_queue_read_callback_data_t* callback_data =
+      NULL;
+  iree_status_t status = iree_hal_hip_device_make_queue_read_callback_data(
+      device, device->host_allocator, queue_affinity, wait_semaphore_list,
+      signal_semaphore_list, source_file, source_offset, target_buffer,
+      target_offset, length, flags, &callback_data);
+
+  if (iree_status_is_ok(status) && wait_semaphore_list.count == 0) {
+    status = iree_hal_hip_dispatch_thread_add_dispatch(
+        device->devices[device_ordinal].dispatch_thread,
+        &iree_hal_hip_device_perform_queue_read_now, callback_data);
+  } else if (iree_status_is_ok(status) && wait_semaphore_list.count != 0) {
+    for (iree_host_size_t i = 0;
+         i < wait_semaphore_list.count && iree_status_is_ok(status); ++i) {
+      status = iree_status_join(
+          status, iree_hal_hip_semaphore_notify_work(
+                      wait_semaphore_list.semaphores[i],
+                      wait_semaphore_list.payload_values[i],
+                      device->devices[device_ordinal].device_event_pool,
+                      &iree_hal_hip_device_semaphore_callback, callback_data));
+    }
+  } else {
+    iree_hal_hip_device_destroy_queue_read_callback_data(callback_data);
+  }
   IREE_TRACE_ZONE_END(z0);
-  return loop_status;
+  return status;
 }
 
 static iree_status_t iree_hal_hip_device_queue_write(
@@ -1630,7 +2063,8 @@ static iree_status_t iree_hal_hip_device_complete_submission(
   iree_hal_hip_device_t* device = data->base.device;
 
   // Get the device_context from the queue_affinity.
-  int device_ordinal = iree_math_count_trailing_zeros_u64(data->base.queue_affinity);
+  int device_ordinal =
+      iree_math_count_trailing_zeros_u64(data->base.queue_affinity);
 
   // Read any tracing events that were submitted.
 
@@ -1664,7 +2098,8 @@ static iree_status_t iree_hal_hip_device_complete_submission(
   iree_hal_hip_event_release(event);
 
   // Notify all of the signal semaphores that they have been incremented.
-  for (iree_host_size_t i = 0; i < data->base.signal_semaphore_list.count; ++i) {
+  for (iree_host_size_t i = 0; i < data->base.signal_semaphore_list.count;
+       ++i) {
     iree_status_ignore(iree_hal_hip_event_semaphore_advance(
         data->base.signal_semaphore_list.semaphores[i]));
   }
@@ -1689,7 +2124,8 @@ static iree_status_t iree_hal_hip_device_execute_now(void* user_data,
   // but not run anything.
   status = iree_status_join(status, data->base.status);
 
-  int device_ordinal = iree_math_count_trailing_zeros_u64(data->base.queue_affinity);
+  int device_ordinal =
+      iree_math_count_trailing_zeros_u64(data->base.queue_affinity);
   IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, device_ordinal);
 
   if (iree_status_is_ok(status)) {
@@ -1725,9 +2161,8 @@ static iree_status_t iree_hal_hip_device_execute_now(void* user_data,
                ? IREE_HAL_COMMAND_BUFFER_MODE_UNVALIDATED
                : 0);
       status = iree_hal_hip_device_create_stream_command_buffer(
-          (iree_hal_device_t*)device, mode,
-          command_buffer->allowed_categories, data->base.queue_affinity, 0,
-          &stream_command_buffer);
+          (iree_hal_device_t*)device, mode, command_buffer->allowed_categories,
+          data->base.queue_affinity, 0, &stream_command_buffer);
       if (iree_status_is_ok(status)) {
         status = iree_hal_resource_set_insert(data->resource_set, 1,
                                               &stream_command_buffer);
@@ -1774,7 +2209,8 @@ static iree_status_t iree_hal_hip_device_execute_now(void* user_data,
   }
 
   if (!iree_status_is_ok(status)) {
-    for (iree_host_size_t i = 0; i < data->base.signal_semaphore_list.count; ++i) {
+    for (iree_host_size_t i = 0; i < data->base.signal_semaphore_list.count;
+         ++i) {
       iree_hal_semaphore_fail(data->base.signal_semaphore_list.semaphores[i],
                               iree_status_clone(data->base.status));
     }
@@ -1805,18 +2241,21 @@ static iree_status_t iree_hal_hip_device_make_callback_data(
   const iree_host_size_t payload_size =
       binding_table.count * sizeof(*binding_table.bindings);
 
-  const iree_host_size_t additional_data_for_base = 
-    iree_hal_hip_semaphore_callback_data_get_additional_allocation_size(wait_semaphore_list, signal_semaphore_list);
+  const iree_host_size_t additional_data_for_base =
+      iree_hal_hip_semaphore_callback_data_get_additional_allocation_size(
+          wait_semaphore_list, signal_semaphore_list);
 
   const iree_host_size_t total_callback_size =
       sizeof(*callback_data) + additional_data_for_base + payload_size;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_allocator_malloc(host_allocator, total_callback_size,
                                 (void**)&callback_data));
-  
-  iree_hal_hip_semaphore_callback_data_init(host_allocator, 
-    device, queue_affinity, &iree_hal_hip_device_execute_now, wait_semaphore_list, signal_semaphore_list,
-    (void*)((uint8_t*)callback_data + sizeof(*callback_data)), &callback_data->base);
+
+  iree_hal_hip_semaphore_callback_data_init(
+      host_allocator, device, queue_affinity, &iree_hal_hip_device_execute_now,
+      wait_semaphore_list, signal_semaphore_list,
+      (void*)((uint8_t*)callback_data + sizeof(*callback_data)),
+      &callback_data->base);
 
   // Copy the execution resources for later access.
   callback_data->command_buffer = command_buffer;
@@ -1841,7 +2280,9 @@ static iree_status_t iree_hal_hip_device_make_callback_data(
 
   callback_data->binding_table = binding_table;
   iree_hal_buffer_binding_t* binding_element_ptr =
-      (iree_hal_buffer_binding_t*)((uint8_t*)callback_data + sizeof(*callback_data) + additional_data_for_base);
+      (iree_hal_buffer_binding_t*)((uint8_t*)callback_data +
+                                   sizeof(*callback_data) +
+                                   additional_data_for_base);
   callback_data->binding_table.bindings = binding_element_ptr;
   memcpy(binding_element_ptr, binding_table.bindings,
          sizeof(*binding_element_ptr) * binding_table.count);
@@ -1898,12 +2339,11 @@ static iree_status_t iree_hal_hip_device_queue_execute(
   if (iree_status_is_ok(status)) {
     for (iree_host_size_t i = 0; i < wait_semaphore_list.count; ++i) {
       status = iree_status_join(
-          status,
-          iree_hal_hip_semaphore_notify_work(
-              wait_semaphore_list.semaphores[i],
-              wait_semaphore_list.payload_values[i],
-              device->devices[device_ordinal].device_event_pool,
-              &iree_hal_hip_device_semaphore_callback, callback_data));
+          status, iree_hal_hip_semaphore_notify_work(
+                      wait_semaphore_list.semaphores[i],
+                      wait_semaphore_list.payload_values[i],
+                      device->devices[device_ordinal].device_event_pool,
+                      &iree_hal_hip_device_semaphore_callback, callback_data));
     }
   } else {
     iree_hal_hip_device_destroy_callback_data(callback_data);

--- a/runtime/src/iree/hal/drivers/hip/per_device_information.h
+++ b/runtime/src/iree/hal/drivers/hip/per_device_information.h
@@ -7,6 +7,7 @@
 #ifndef IREE_HAL_DRIVERS_HIP_PER_DEVICE_INFORMATION_H_
 #define IREE_HAL_DRIVERS_HIP_PER_DEVICE_INFORMATION_H_
 
+#include "iree/base/internal/synchronization.h"
 #include "iree/hal/drivers/hip/dispatch_thread.h"
 #include "iree/hal/drivers/hip/hip_headers.h"
 #include "iree/hal/drivers/hip/memory_pools.h"
@@ -25,6 +26,12 @@ typedef struct iree_hal_hip_per_device_info_t {
   iree_hal_hip_event_pool_t* device_event_pool;
 
   iree_hal_hip_dispatch_thread_t* dispatch_thread;
+
+  iree_hal_buffer_t* file_transfer_staging_buffer;
+  iree_host_size_t file_transfer_staging_buffer_head;
+  iree_host_size_t file_transfer_staging_buffer_tail;
+  iree_slim_mutex_t file_transfer_staging_buffer_lock;
+  iree_notification_t file_transfer_staging_buffer_notify;
 
   iree_hal_hip_memory_pools_t memory_pools;
 } iree_hal_hip_per_device_info_t;

--- a/runtime/src/iree/hal/drivers/hip/per_device_information.h
+++ b/runtime/src/iree/hal/drivers/hip/per_device_information.h
@@ -27,11 +27,13 @@ typedef struct iree_hal_hip_per_device_info_t {
 
   iree_hal_hip_dispatch_thread_t* dispatch_thread;
 
-  iree_hal_buffer_t* file_transfer_staging_buffer;
-  iree_host_size_t file_transfer_staging_buffer_head;
-  iree_host_size_t file_transfer_staging_buffer_tail;
-  iree_slim_mutex_t file_transfer_staging_buffer_lock;
-  iree_notification_t file_transfer_staging_buffer_notify;
+  struct {
+    iree_hal_buffer_t* buffer;
+    iree_host_size_t head;
+    iree_host_size_t tail;
+    iree_slim_mutex_t mutex;
+    iree_notification_t notify;
+  } file_transfer_staging_buffer;
 
   iree_hal_hip_memory_pools_t memory_pools;
 } iree_hal_hip_per_device_info_t;


### PR DESCRIPTION
This moves the blocking reads off the main thread, and so long
as your PCI bandwidth outpaces your file IO bandwith, reduces
the amount of time required to read files dramatically.

Signed-off-by: Andrew Woloszyn <andrew.woloszyn@gmail.com>