### PR TITLE
[infra] Add `--force` flag to `git submodule update` in script.

### DIFF
--- a/build_tools/scripts/git/update_runtime_submodules.sh
+++ b/build_tools/scripts/git/update_runtime_submodules.sh
@@ -13,6 +13,6 @@ set -xeuo pipefail
 SCRIPT_DIR="$(dirname -- "$( readlink -f -- "$0"; )")"
 
 # Read lines from runtime_submodules.txt, stripping \r characters on Windows.
-readarray -t RUNTIME_SUBMODULES < <(cat build_tools/scripts/git/runtime_submodules.txt | tr -d '\r')
+readarray -t RUNTIME_SUBMODULES < <(cat ${SCRIPT_DIR}/runtime_submodules.txt | tr -d '\r')
 
-git submodule sync && git submodule update --init --jobs 8 --depth 1 ${RUNTIME_SUBMODULES[@]}
+git submodule sync && git submodule update --init --force --jobs 8 --depth 1 ${RUNTIME_SUBMODULES[@]}


### PR DESCRIPTION
Context: https://github.com/iree-org/iree/pull/19538#discussion_r1894220373

One workflow failed on a self-hosted runner after changing a submodule pin:
```
+ git submodule update --init --jobs 8 --depth 1 third_party/benchmark third_party/cpuinfo third_party/flatcc third_party/googletest third_party/hip-build-deps third_party/hsa-runtime-headers third_party/musl third_party/spirv_cross third_party/tracy third_party/vulkan_headers third_party/webgpu-headers
From https://github.com/google/benchmark
 + c19cfee...f4f93b5 main       -> origin/main  (forced update)
From https://github.com/google/benchmark
 * branch            99bdb2127d1fa1cff444bbefb814e105c7d20c45 -> FETCH_HEAD
error: Your local changes to the following files would be overwritten by checkout:
	.github/workflows/pre-commit.yml
	.github/workflows/test_bindings.yml
       ...

Please commit your changes or stash them before you switch branches.
Aborting
fatal: Unable to checkout '99bdb2127d1fa1cff444bbefb814e105c7d20c45' in submodule path 'third_party/benchmark'
```

This adds the `--force` flag to try proceeding anyways. Anyone calling this script is already delegating the submodule update behavior to it.