### PR TITLE
Add missing definition of `build` method in `Flow::CallOp`

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -1601,6 +1601,17 @@ void CallOp::build(OpBuilder &builder, OperationState &state,
                      }));
 }
 
+void CallOp::build(OpBuilder &builder, OperationState &state,
+                   SymbolRefAttr callee, TypeRange resultTypes,
+                   ValueRange resultDims, ValueRange arguments,
+                   ArrayAttr tiedOperands,
+                   ArrayRef<NamedAttribute> attributes) {
+  build(
+      builder, state, callee, resultTypes, resultDims, arguments,
+      IREE::Util::buildDynamicDimsForValues(state.location, arguments, builder),
+      tiedOperands, attributes);
+}
+
 FunctionType CallOp::getCalleeType() {
   auto argumentTypes = llvm::map_to_vector(
       getArgOperands(), [](Value arg) { return arg.getType(); });

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -986,16 +986,7 @@ def FLOW_CallOp : FLOW_Op<"call", [
       "TypeRange":$resultTypes, "ValueRange":$resultDims,
       "ValueRange":$arguments,
       "ArrayAttr":$tiedOperands,
-      CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes),
-    [{
-      build($_builder, $_state,
-          callee,
-          resultTypes, resultDims,
-          arguments,
-          IREE::Util::buildDynamicDimsForValues($_state.location, arguments, $_builder),
-          tiedOperands,
-          attributes);
-    }]>,
+      CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes)>,
     OpBuilder<(ins
       "SymbolRefAttr":$callee,
       "TypeRange":$resultTypes, "ValueRange":$resultDims,

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -983,10 +983,19 @@ def FLOW_CallOp : FLOW_Op<"call", [
   let builders = [
     OpBuilder<(ins
       "SymbolRefAttr":$callee,
-      "TypeRange":$resultTypes,
+      "TypeRange":$resultTypes, "ValueRange":$resultDims,
       "ValueRange":$arguments,
       "ArrayAttr":$tiedOperands,
-      CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes)>,
+      CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes),
+    [{
+      build($_builder, $_state,
+          callee,
+          resultTypes, resultDims,
+          arguments,
+          IREE::Util::buildDynamicDimsForValues($_state.location, arguments, $_builder),
+          tiedOperands,
+          attributes);
+    }]>,
     OpBuilder<(ins
       "SymbolRefAttr":$callee,
       "TypeRange":$resultTypes, "ValueRange":$resultDims,


### PR DESCRIPTION
In `flow.call` op, there are two custom `OpBuilder` declarations:
https://github.com/iree-org/iree/blob/76a7b893e4c62d52eae2c165bdb23952a8589689/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td#L983-L996

And the second one is defined in `FlowOp.cpp`:
https://github.com/iree-org/iree/blob/76a7b893e4c62d52eae2c165bdb23952a8589689/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp#L1579-L1583

However, the function definition of the first one is missing. If we try to use it, we'll get a linker error like "undefined symbol" in the build phase.

So in this PR I try to add a definition for the first `OpBuilder` (inside the tblgen file instead of `FlowOp.cpp`, since it's simple).