### PR TITLE
[PJRT] Fix ninja not found error while re-building the plugin

### DIFF
--- a/integrations/pjrt/python_packages/iree_cpu_plugin/pyproject.toml
+++ b/integrations/pjrt/python_packages/iree_cpu_plugin/pyproject.toml
@@ -3,5 +3,6 @@ requires = [
     "setuptools>=42",
     "wheel",
     "ninja",
+    "cmake",
 ]
 build-backend = "setuptools.build_meta"

--- a/integrations/pjrt/python_packages/iree_cuda_plugin/pyproject.toml
+++ b/integrations/pjrt/python_packages/iree_cuda_plugin/pyproject.toml
@@ -3,5 +3,6 @@ requires = [
     "setuptools>=42",
     "wheel",
     "ninja",
+    "cmake",
 ]
 build-backend = "setuptools.build_meta"

--- a/integrations/pjrt/python_packages/iree_rocm_plugin/pyproject.toml
+++ b/integrations/pjrt/python_packages/iree_rocm_plugin/pyproject.toml
@@ -3,5 +3,6 @@ requires = [
     "setuptools>=42",
     "wheel",
     "ninja",
+    "cmake",
 ]
 build-backend = "setuptools.build_meta"

--- a/integrations/pjrt/python_packages/iree_vulkan_plugin/pyproject.toml
+++ b/integrations/pjrt/python_packages/iree_vulkan_plugin/pyproject.toml
@@ -3,5 +3,6 @@ requires = [
     "setuptools>=42",
     "wheel",
     "ninja",
+    "cmake",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
If we want to build the PJRT CPU plugin, we'll run something like
```
pip install --no-deps -v ./integrations/pjrt/python_packages/iree_cpu_plugin/
```

It works well in the first run. But if we did some changes, and want to run it the second time, some errors will appear: cmake cannot find the ninja in the first run anymore because it's in a temp build environment and removed after the first build is finished.

We can remove the build dir to solve this problem. But it will cause a full rebuild, and is quite annoying : )

Since IREE compiler doesn't have such issue so I checked its build script, and I found that it's solved via the function `maybe_nuke_cmake_cache` in its [setup.py](https://github.com/iree-org/iree/blob/76a7b893e4c62d52eae2c165bdb23952a8589689/compiler/setup.py#L177). So I copy it into setup.py of the PJRT plugin and did some modification:
- I think the PJRT plugin doesn't rely on CPython API (although it builds a shared library) so we don't need to pin Python version;
- the build dir should be passed via a parameter since we have plugins for different platforms (cpu/cuda/rocm..).

Also, I used this chance to add `cmake` to build dependencies, in case of some users don't have cmake installed in the system.

ci-exactly: build_packages, test_pjrt