### PR TITLE
Update LLVM to llvm/llvm-project@b13592219c421820b

### DIFF
--- a/.github/workflows/pkgci_regression_test.yml
+++ b/.github/workflows/pkgci_regression_test.yml
@@ -85,7 +85,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: nod-ai/SHARK-TestSuite
-          ref: 7c65de7a322fdc0a68646b57cce69c702ba625ec
+          ref: 601db0e472600a94ddb69b37d05cd7d4a17f89b2
           path: SHARK-TestSuite
           submodules: false
           lfs: true

--- a/.github/workflows/pkgci_regression_test.yml
+++ b/.github/workflows/pkgci_regression_test.yml
@@ -85,7 +85,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: nod-ai/SHARK-TestSuite
-          ref: f5615ab29da491c0047146258dfa3a0c40c735e5
+          ref: 7c65de7a322fdc0a68646b57cce69c702ba625ec
           path: SHARK-TestSuite
           submodules: false
           lfs: true

--- a/experimental/regression_suite/shark-test-suite-models/sd3/test_clip.py
+++ b/experimental/regression_suite/shark-test-suite-models/sd3/test_clip.py
@@ -63,7 +63,7 @@ sd3_clip_real_weights = fetch_source_fixture(
 )
 
 sd3_clip_mlir = fetch_source_fixture(
-    "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sd3-prompt-encoder/model.mlirbc",
+    "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sd3-prompt-encoder/model.mlir",
     group="sd3_clip",
 )
 

--- a/experimental/regression_suite/shark-test-suite-models/sd3/test_mmdit.py
+++ b/experimental/regression_suite/shark-test-suite-models/sd3/test_mmdit.py
@@ -48,7 +48,7 @@ sd3_mmdit_real_weights = fetch_source_fixture(
 )
 
 sd3_mmdit_mlir = fetch_source_fixture(
-    "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sd3-mmdit/model.mlirbc",
+    "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sd3-mmdit/model.mlir",
     group="sd3_mmdit",
 )
 

--- a/experimental/regression_suite/shark-test-suite-models/sd3/test_vae.py
+++ b/experimental/regression_suite/shark-test-suite-models/sd3/test_vae.py
@@ -33,7 +33,7 @@ sd3_vae_real_weights = fetch_source_fixture(
 )
 
 sd3_vae_mlir = fetch_source_fixture(
-    "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sd3-vae/model.mlirbc",
+    "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sd3-vae/model.mlir",
     group="sd3_vae",
 )
 

--- a/experimental/regression_suite/shark-test-suite-models/sdxl/test_clip.py
+++ b/experimental/regression_suite/shark-test-suite-models/sdxl/test_clip.py
@@ -53,7 +53,7 @@ sdxl_clip_real_weights = fetch_source_fixture(
 )
 
 sdxl_clip_mlir = fetch_source_fixture(
-    "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/model.mlirbc",
+    "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-prompt-encoder/model.mlir",
     group="sdxl_clip",
 )
 

--- a/experimental/regression_suite/shark-test-suite-models/sdxl/test_unet.py
+++ b/experimental/regression_suite/shark-test-suite-models/sdxl/test_unet.py
@@ -52,7 +52,7 @@ sdxl_unet_fp16_real_weights = fetch_source_fixture(
 )
 
 sdxl_unet_fp16_mlir = fetch_source_fixture(
-    "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/model.mlirbc",
+    "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-scheduled-unet/model.mlir",
     group="sdxl_unet_fp16",
 )
 

--- a/experimental/regression_suite/shark-test-suite-models/sdxl/test_vae.py
+++ b/experimental/regression_suite/shark-test-suite-models/sdxl/test_vae.py
@@ -33,7 +33,7 @@ sdxl_vae_real_weights = fetch_source_fixture(
 )
 
 sdxl_vae_mlir = fetch_source_fixture(
-    "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-vae-decode/model.mlirbc",
+    "https://sharkpublic.blob.core.windows.net/sharkpublic/sai/sdxl-vae-decode/model.mlir",
     group="sdxl_vae",
 )
 


### PR DESCRIPTION
Update LLVM to llvm/llvm-project@b13592219c421820b (https://github.com/llvm/llvm-project/pull/85376) Changes done to resolve mlirbc issue in https://github.com/iree-org/iree/issues/19498 through updating/regen of input IRs in azure and SHARK-TestSuite to work with latest mlir-opt.

This PR also carries the following reverts:

https://github.com/llvm/llvm-project/pull/120115
https://github.com/llvm/llvm-project/pull/119461

The main issue with PR 120115 is it breaks matvec codegen generating scf.if instead of scf.for(s). An issue will be pushed up for repro.

The main issue with PR 119461 is it breaks e2e riscv test by making it get stuck on infinite loop.
```
/path/to/iree-build/tools/iree-compile --output-format=vm-bytecode --mlir-print-op-on-diagnostic=false --iree-hal-target-backends=llvm-cpu --iree-input-type=stablehlo --iree-input-demote-f64-to-f32 --iree-llvmcpu-target-cpu=generic /path/to/iree/tests/e2e/stablehlo_ops/three_fry.mlir -o three_fly_exec_target.mlir --iree-llvmcpu-target-triple=riscv64 --iree-llvmcpu-target-abi=lp64d --iree-llvmcpu-target-cpu-features=+m,+a,+d,+zvl512b,+v --mlir-disable-threading
> infinite loop
```