### PR TITLE
Triage onnx suite regressions

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -13,6 +13,7 @@ include "mlir/Pass/PassBase.td"
 // Common Passes used for GPU-like backends (keep alphabetical)
 //===---------------------------------------------------------------------===//
 
+
 def GPUCheckResourceUsagePass :
     InterfacePass<"iree-codegen-gpu-check-resource-usage", "mlir::FunctionOpInterface"> {
   let summary = "Checks GPU specific resource usage constraints like shared memory limits";


### PR DESCRIPTION
Ever since 12/19 the onnx suite coverage that is reported [here](https://github.com/nod-ai/e2eshark-reports/blob/main/2024-12-19/ci_reports_onnx/rocm/combined-reports/summary.md) has been in the 50 percents. There were some other regressions that were fixed and I think something else slipped through while those were tracked. What's interesting is that  when individual PRs are being tested for example like [here](https://github.com/nod-ai/e2eshark-reports/blob/main/2024-12-20-iree-test/ci_reports_onnx/rocm/combined-reports/summary.md) the coverage is in the high 80s like it was before. I will use this PR to track down if there is a missing regression and what commit causes it.