### PR TITLE
Update LLVM to llvm/llvm-project@ac8bb735

### DIFF
--- a/compiler/plugins/input/StableHLO/Conversion/LegalizeCHLO.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/LegalizeCHLO.cpp
@@ -2182,8 +2182,7 @@ struct LegalizeChlo final : impl::LegalizeChloBase<LegalizeChlo> {
       mlir::shape::CstrBroadcastableOp::getCanonicalizationPatterns(patterns,
                                                                     ctx);
       mlir::tensor::CastOp::getCanonicalizationPatterns(patterns, ctx);
-      if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                              std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
         return signalPassFailure();
       }
     }

--- a/compiler/plugins/input/StableHLO/Conversion/LegalizeShapeComputations.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/LegalizeShapeComputations.cpp
@@ -170,7 +170,7 @@ struct LegalizeShapeComputations final
 
     auto func = this->getOperation();
     populateLegalizeShapeComputationPatterns(&ctx, &patterns);
-    if (failed(applyPatternsAndFoldGreedily(func, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(func, std::move(patterns)))) {
       this->signalPassFailure();
     }
   }

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/Canonicalization.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/Canonicalization.cpp
@@ -1156,8 +1156,7 @@ struct StableHLOCanonicalize final
     MLIRContext *ctx = &getContext();
     RewritePatternSet patterns(ctx);
     populateCanonicalizationPatterns(ctx, &patterns);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       signalPassFailure();
     }
   }

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/DotGeneralToDot.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/DotGeneralToDot.cpp
@@ -419,8 +419,7 @@ struct DotGeneralToDot final : impl::DotGeneralToDotBase<DotGeneralToDot> {
   void runOnOperation() override {
     RewritePatternSet patterns(&getContext());
     populatePreprocessingDotGeneralToDotPatterns(&getContext(), &patterns);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/EinsumToDotGeneral.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/EinsumToDotGeneral.cpp
@@ -160,8 +160,7 @@ struct EinsumToDotGeneral final
   void runOnOperation() override {
     RewritePatternSet patterns(&getContext());
     populatePreprocessingEinsumToDotGeneralPatterns(&getContext(), &patterns);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/FlattenTuplesInCFG.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/FlattenTuplesInCFG.cpp
@@ -359,8 +359,7 @@ struct FlattenTuplesInCFG final
     patterns.insert<DetupleCallOp, DetupleIndirectCallOp, DetupleConditionOp,
                     DetupleReturnOp, DetupleBranchOp>(ctx);
     populateCanonicalizationPatterns(ctx, &patterns);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/FlattenTuplesInSCF.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/FlattenTuplesInSCF.cpp
@@ -255,8 +255,7 @@ struct FlattenTuplesInSCF final
     patterns
         .add<DetupleYieldOp, DetupleConditionOp, DetupleIfOp, DetupleWhileOp>(
             ctx);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/GatherToTorchIndexSelect.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/GatherToTorchIndexSelect.cpp
@@ -127,8 +127,7 @@ struct GatherToTorchIndexSelect final
     MLIRContext *ctx = &getContext();
     RewritePatternSet patterns(ctx);
     populatePreprocessingGatherToTorchIndexSelectPatterns(ctx, &patterns);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/LowerComplex.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/LowerComplex.cpp
@@ -74,8 +74,7 @@ struct LowerComplex final : impl::LowerComplexBase<LowerComplex> {
     RewritePatternSet patterns(ctx);
     populatePreprocessingComplexPatterns(ctx, &patterns);
     populateCanonicalizationPatterns(ctx, &patterns);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       signalPassFailure();
     }
   }

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/StableHLOToStableHLO.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/StableHLOToStableHLO.cpp
@@ -1968,8 +1968,7 @@ struct StableHLOToStableHLOPreprocessing final
       patterns.insert<ReorderConvOpKernelDimensions>(context);
       patterns.insert<ReorderConvOpOutputDimensions>(context);
     }
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/UnfuseBatchNorm.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/UnfuseBatchNorm.cpp
@@ -346,8 +346,7 @@ struct UnfuseBatchNorm final : impl::UnfuseBatchNormBase<UnfuseBatchNorm> {
   void runOnOperation() override {
     RewritePatternSet patterns(&getContext());
     populatePreprocessingUnfuseBatchNormPatterns(&getContext(), &patterns);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/plugins/input/StableHLO/Conversion/StableHLOCustomCalls.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/StableHLOCustomCalls.cpp
@@ -254,7 +254,7 @@ struct LegalizeStableHLOCustomCalls final
 
     RewritePatternSet patterns(ctx);
     patterns.add<HouseholderReflectorRewriter, ShapeAssertionDrop>(ctx);
-    if (failed(applyPatternsAndFoldGreedily(f, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(f, std::move(patterns)))) {
       signalPassFailure();
     }
   }

--- a/compiler/plugins/input/StableHLO/Conversion/StableHLOToIREEInputDialects.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/StableHLOToIREEInputDialects.cpp
@@ -504,6 +504,8 @@ struct ConvertStableHloToIreeInputDialects final
     std::unique_ptr<TypeConverter> typeConverter =
         createStableHloToLinalgTypeConverter();
     typeConverter->addArgumentMaterialization(scalarToTensor);
+    typeConverter->addSourceMaterialization(scalarToTensor);
+    typeConverter->addTargetMaterialization(scalarToTensor);
 
     // Run stablehlo canonicalization patterns with a high benefit to avoid some
     // expensive expansions.

--- a/compiler/plugins/input/StableHLO/Conversion/StableHLOToIREEInputDialects.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/StableHLOToIREEInputDialects.cpp
@@ -612,7 +612,7 @@ struct ConvertStableHloToIreeInputDialects final
       RewritePatternSet removeUnusedOperandsResultsPatterns(context);
       linalg::populateEraseUnusedOperandsAndResultsPatterns(
           removeUnusedOperandsResultsPatterns);
-      if (failed(applyPatternsAndFoldGreedily(
+      if (failed(applyPatternsGreedily(
               getOperation(),
               std::move(removeUnusedOperandsResultsPatterns)))) {
         return signalPassFailure();

--- a/compiler/plugins/input/StableHLO/Conversion/TypeConversion.cpp
+++ b/compiler/plugins/input/StableHLO/Conversion/TypeConversion.cpp
@@ -86,6 +86,8 @@ RemoveSignTypeConverter::RemoveSignTypeConverter() {
 
 LinalgTypeConverter::LinalgTypeConverter() : RemoveSignTypeConverter() {
   addArgumentMaterialization(scalarToTensor);
+  addSourceMaterialization(scalarToTensor);
+  addTargetMaterialization(scalarToTensor);
 }
 
 } // namespace mlir::iree_compiler::stablehlo

--- a/compiler/plugins/input/Torch/InputConversion/BitCastQuantTensor.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/BitCastQuantTensor.cpp
@@ -160,8 +160,7 @@ class BitCastQuantTensorPass final
     MLIRContext *context = &getContext();
     RewritePatternSet patterns(context);
     patterns.add<BitCastQuantizedMatmul, BitCastViewDtype>(context);
-    if (failed(
-            applyPatternsAndFoldGreedily(getOperation(), std::move(patterns))))
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
       signalPassFailure();
   }
 };

--- a/compiler/plugins/input/Torch/InputConversion/ConvertTMTensorToLinalgExt.cpp
+++ b/compiler/plugins/input/Torch/InputConversion/ConvertTMTensorToLinalgExt.cpp
@@ -214,8 +214,7 @@ public:
     patterns.add<ScatterOpConversion>(context);
     patterns.add<AttentionOpConversion>(context);
 
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/BlockDynamicDimensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BlockDynamicDimensions.cpp
@@ -353,8 +353,8 @@ void BlockDynamicDimensionsPass::runOnOperation() {
     memref::populateResolveRankedShapedTypeResultDimsPatterns(
         bubbleExpandShapePatterns);
     populateRemoveDeadMemAllocPatterns(bubbleExpandShapePatterns);
-    if (failed(applyPatternsAndFoldGreedily(
-            operation, std::move(bubbleExpandShapePatterns)))) {
+    if (failed(applyPatternsGreedily(operation,
+                                     std::move(bubbleExpandShapePatterns)))) {
       operation->emitOpError(
           "failed in application of bubble up expand shape patterns");
       return signalPassFailure();
@@ -380,8 +380,8 @@ void BlockDynamicDimensionsPass::runOnOperation() {
                                                 context);
     memref::populateResolveRankedShapedTypeResultDimsPatterns(
         removeBarrierOpsPatterns);
-    if (failed(applyPatternsAndFoldGreedily(
-            operation, std::move(removeBarrierOpsPatterns)))) {
+    if (failed(applyPatternsGreedily(operation,
+                                     std::move(removeBarrierOpsPatterns)))) {
       operation->emitOpError("failed in cleanup patterns");
       return signalPassFailure();
     }

--- a/compiler/src/iree/compiler/Codegen/Common/BubbleUpOrdinalOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BubbleUpOrdinalOps.cpp
@@ -74,8 +74,7 @@ void BubbleUpOrdinalOpsPass::runOnOperation() {
   MLIRContext *context = &getContext();
   RewritePatternSet patterns(context);
   patterns.insert<BubbleUpAcrossCastOp<arith::IndexCastUIOp>>(context);
-  if (failed(
-          applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
+  if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
     return signalPassFailure();
   }
 }

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPULowerToUKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPULowerToUKernels.cpp
@@ -622,8 +622,7 @@ void CPULowerToUKernelsPass::runOnOperation() {
   // These patterns are inherently specific to the VMVX backend.
   patterns.insert<LowerToUKernelPattern<IREE::Codegen::QueryTileSizesOp>>(
       context, isVMVXBackend);
-  if (failed(
-          applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
+  if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
     return signalPassFailure();
   }
 }

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CPUPrepareUkernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CPUPrepareUkernels.cpp
@@ -440,7 +440,7 @@ void CPUPrepareUkernelsPass::runOnOperation() {
   tensor::UnPackOp::getCanonicalizationPatterns(patterns, ctx);
   tensor::CastOp::getCanonicalizationPatterns(patterns, ctx);
   tensor::populateFoldTensorEmptyPatterns(patterns);
-  if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+  if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
     return signalPassFailure();
   }
 }

--- a/compiler/src/iree/compiler/Codegen/Common/CleanupBufferAllocViewPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CleanupBufferAllocViewPass.cpp
@@ -37,8 +37,7 @@ struct CleanupBufferAllocViewPass final
     RewritePatternSet patterns(&getContext());
     populateReshapeToInterfaceTensorPatterns(patterns);
     populateRemoveDeadMemAllocPatterns(patterns);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/ConcretizePadResultShape.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConcretizePadResultShape.cpp
@@ -143,8 +143,7 @@ public:
     {
       RewritePatternSet patterns(context);
       populateConcretizePadResultShapePatterns(patterns);
-      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns),
-                                              config))) {
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns), config))) {
         return signalPassFailure();
       }
     }

--- a/compiler/src/iree/compiler/Codegen/Common/ConfigTrackingCanonicalizer.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConfigTrackingCanonicalizer.cpp
@@ -95,7 +95,7 @@ public:
     {
       config.listener = &listener;
       LogicalResult didConverge =
-          applyPatternsAndFoldGreedily(getOperation(), *patterns, config);
+          applyPatternsGreedily(getOperation(), *patterns, config);
       config.listener = nullptr;
       if (this->testConvergence && failed(didConverge)) {
         getOperation()->emitError("Canonicalizer failed to converge");

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ArithToF32.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertBf16ArithToF32.cpp
@@ -304,8 +304,7 @@ struct ConvertBf16ArithToF32Pass final
     cleanupPatterns
         .insert<PropagateCastF<arith::TruncFOp>, PropagateCastF<arith::ExtFOp>>(
             context);
-    if (applyPatternsAndFoldGreedily(this->getOperation(),
-                                     std::move(cleanupPatterns))
+    if (applyPatternsGreedily(this->getOperation(), std::move(cleanupPatterns))
             .failed()) {
       return this->signalPassFailure();
     }

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
@@ -615,7 +615,7 @@ void ConvertToDestinationPassingStylePass::runOnOperation() {
   {
     RewritePatternSet patterns(context);
     patterns.insert<RemoveCstOutsDependency>(context);
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       return signalPassFailure();
     }
   }
@@ -632,7 +632,7 @@ void ConvertToDestinationPassingStylePass::runOnOperation() {
   {
     RewritePatternSet patterns(context);
     linalg::populateEraseUnusedOperandsAndResultsPatterns(patterns);
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       return signalPassFailure();
     }
   }
@@ -640,7 +640,7 @@ void ConvertToDestinationPassingStylePass::runOnOperation() {
   {
     RewritePatternSet patterns(context);
     patterns.insert<SwitchStoreOfIfResultValue>(context);
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/ConvolutionToIGEMM.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvolutionToIGEMM.cpp
@@ -107,7 +107,7 @@ convertToIGEMMAndSetConfig(FunctionOpInterface funcOp,
     if (configFn.has_value()) {
       patterns.add<SetIGEMMConfiguration>(context, configFn.value());
     }
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       return failure();
     }
   }
@@ -150,8 +150,8 @@ convertToIGEMMAndSetConfig(FunctionOpInterface funcOp,
     tensor::ExpandShapeOp::getCanonicalizationPatterns(
         bubbleCollapseShapePatterns, context);
     populateReshapeToInterfaceTensorPatterns(bubbleCollapseShapePatterns);
-    if (failed(applyPatternsAndFoldGreedily(
-            funcOp, std::move(bubbleCollapseShapePatterns)))) {
+    if (failed(applyPatternsGreedily(funcOp,
+                                     std::move(bubbleCollapseShapePatterns)))) {
       return failure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/DecomposeConvolutionToLowerDimOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DecomposeConvolutionToLowerDimOps.cpp
@@ -152,8 +152,7 @@ class DecomposeConvolutionToLowerDimOpsPass final
     // 2. Run the patterns. This is the key part of this pass.
     RewritePatternSet patterns(context);
     linalg::populateDecomposeConvolutionPatterns(patterns);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
 

--- a/compiler/src/iree/compiler/Codegen/Common/DecomposeLinalgGeneric.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DecomposeLinalgGeneric.cpp
@@ -28,8 +28,7 @@ class DecomposeLinalgGenericPass final
     RewritePatternSet patterns(context);
     linalg::populateDecomposeLinalgOpsPattern(patterns);
     linalg::GenericOp::getCanonicalizationPatterns(patterns, context);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/DecomposePackUnPackOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DecomposePackUnPackOps.cpp
@@ -110,7 +110,7 @@ static LogicalResult commonRunOnOperation(
     RewritePatternSet patterns(ctx);
     patterns.add<linalg::DecomposeOuterUnitDimsPackOpPattern,
                  linalg::DecomposeOuterUnitDimsUnPackOpPattern>(ctx);
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       funcOp.emitError(
           "failed to apply generalization patterns on pack/unpack ops for "
           "outer unit dims cases");
@@ -123,7 +123,7 @@ static LogicalResult commonRunOnOperation(
   if (!tileOuterToOne) {
     RewritePatternSet patterns(ctx);
     patterns.add<LowerPackPattern, LowerUnPackPattern>(ctx, controlFn);
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       funcOp.emitError(
           "failed to apply generalization patterns on pack/unpack ops for "
           "general cases.");
@@ -223,7 +223,7 @@ static LogicalResult commonRunOnOperation(
     memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);
     ctx->getOrLoadDialect<tensor::TensorDialect>()->getCanonicalizationPatterns(
         patterns);
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       return failure();
     }
   }
@@ -242,7 +242,7 @@ static LogicalResult commonRunOnOperation(
       patterns.add<linalg::DecomposeOuterUnitDimsPackOpPattern,
                    linalg::DecomposeOuterUnitDimsUnPackOpPattern>(ctx);
     }
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       return failure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/DropVectorUnitDims.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DropVectorUnitDims.cpp
@@ -47,7 +47,7 @@ void DropVectorUnitDimsPass::runOnOperation() {
   vector::populateDropUnitDimWithShapeCastPatterns(patterns);
   vector::InsertOp::getCanonicalizationPatterns(patterns, ctx);
   vector::ExtractOp::getCanonicalizationPatterns(patterns, ctx);
-  (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
+  (void)applyPatternsGreedily(funcOp, std::move(patterns));
 }
 } // namespace
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
@@ -147,8 +147,8 @@ struct EmulateNarrowTypePass final
 
     RewritePatternSet sinkBroadcast(ctx);
     vector::populateSinkVectorOpsPatterns(sinkBroadcast);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(sinkBroadcast)))) {
+    if (failed(
+            applyPatternsGreedily(getOperation(), std::move(sinkBroadcast)))) {
       getOperation()->emitOpError("failed in sinking of broadcasts");
       return signalPassFailure();
     }
@@ -156,8 +156,8 @@ struct EmulateNarrowTypePass final
     // Also do the `bitcast -> extui/extsi` rewrite.
     RewritePatternSet foldExtPatterns(ctx);
     vector::populateVectorNarrowTypeRewritePatterns(foldExtPatterns);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(foldExtPatterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(),
+                                     std::move(foldExtPatterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/ExtractAddressComputation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ExtractAddressComputation.cpp
@@ -105,8 +105,7 @@ struct ExtractAddressComputationPass final
 void ExtractAddressComputationPass::runOnOperation() {
   RewritePatternSet patterns(&getContext());
   populateExtractAddressComputationPatterns(patterns);
-  if (failed(
-          applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
+  if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
     return signalPassFailure();
   }
 }

--- a/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
@@ -757,7 +757,7 @@ struct FlattenMemRefSubspanPass final
     // This pass currently doesn't support alignment hints so remove them first.
     RewritePatternSet patterns(context);
     patterns.add<RemoveAssumeAlignOp>(context);
-    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+    (void)applyPatternsGreedily(getOperation(), std::move(patterns));
 
     RewritePatternSet flattenPatterns(context);
 
@@ -879,8 +879,8 @@ struct FlattenMemRefSubspanPass final
     // Fold subviews if any new oportuinity has been created.
     RewritePatternSet foldSubviewPatterns(context);
     memref::populateFoldMemRefAliasOpPatterns(foldSubviewPatterns);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(foldSubviewPatterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(),
+                                     std::move(foldSubviewPatterns)))) {
       return signalPassFailure();
     }
 
@@ -894,8 +894,8 @@ struct FlattenMemRefSubspanPass final
     memref::SubViewOp::getCanonicalizationPatterns(cleanupPatterns, context);
     cleanupPatterns.add<RemoveDynamicCastOp>(context);
 
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(cleanupPatterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(),
+                                     std::move(cleanupPatterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/FoldAffineMinInDistributedLoops.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FoldAffineMinInDistributedLoops.cpp
@@ -162,8 +162,7 @@ struct FoldAffineMinInDistributedLoopsPass final
     RewritePatternSet patterns(&getContext());
     SmallVector<int64_t> numWorkgroups = getStaticNumWorkgroups(getOperation());
     populateFoldAffineMinInDistributedLoopsPatterns(patterns, numWorkgroups);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       // TODO(#4759): This does not converge after the max number of iterations.
       // It indicates that some pattern upstream is generating ops even when the
       // pattern failed to match. Not related to correctness, but would be good

--- a/compiler/src/iree/compiler/Codegen/Common/FoldTensorExtractOpPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FoldTensorExtractOpPass.cpp
@@ -60,7 +60,7 @@ class FoldTensorExtractOpPass final
 void FoldTensorExtractOpPass::runOnOperation() {
   RewritePatternSet patterns(&getContext());
   populateWithGenerated(patterns);
-  if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns))))
+  if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
     signalPassFailure();
 }
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/ForOpCanonicalizationPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ForOpCanonicalizationPass.cpp
@@ -302,12 +302,12 @@ struct ForOpCanonicalizationPass final
     // so we apply that first.
     RewritePatternSet canonPatterns(&getContext());
     canonPatterns.insert<CanonicalizeForOpInductionVarShape>(fn.getContext());
-    if (failed(applyPatternsAndFoldGreedily(fn, std::move(canonPatterns)))) {
+    if (failed(applyPatternsGreedily(fn, std::move(canonPatterns)))) {
       return signalPassFailure();
     }
     RewritePatternSet packPatterns(&getContext());
     packPatterns.insert<PackForOpInductionVarVector>(fn.getContext());
-    if (failed(applyPatternsAndFoldGreedily(fn, std::move(packPatterns)))) {
+    if (failed(applyPatternsGreedily(fn, std::move(packPatterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/FuseTensorPadWithConsumer.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FuseTensorPadWithConsumer.cpp
@@ -25,7 +25,7 @@ struct FuseTensorPadWithConsumerPass final
     RewritePatternSet patterns(context);
     patterns.insert<linalg::ExtractSliceOfPadTensorSwapPattern>(
         context, [](tensor::ExtractSliceOp) { return false; });
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/ExpandGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/ExpandGPUOps.cpp
@@ -37,7 +37,7 @@ struct ExpandGPUOpsPass final : impl::ExpandGPUOpsPassBase<ExpandGPUOpsPass> {
         patterns, /* maxShuffleBitwidth=*/32, PatternBenefit(2));
     populateGpuLowerClusteredSubgroupReduceToShufflePatterns(
         patterns, *subgroupSize, /* shuffleBitwidth=*/32, PatternBenefit(1));
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       return signalPassFailure();
     }
   };

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyTilingLevel.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyTilingLevel.cpp
@@ -424,7 +424,7 @@ void GPUApplyTilingLevelPass::runOnOperation() {
     tensor::InsertSliceOp::getCanonicalizationPatterns(patterns, context);
     tensor::ExtractSliceOp::getCanonicalizationPatterns(patterns, context);
     scf::ForOp::getCanonicalizationPatterns(patterns, context);
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       funcOp.emitError() << "tiling cleanup failed\n";
       return signalPassFailure();
     }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCreateFastSlowPath.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCreateFastSlowPath.cpp
@@ -144,7 +144,7 @@ struct GPUCreateFastSlowPathPass final
     // tensor.pad op.
     RewritePatternSet patterns(context);
     scf::IfOp::getCanonicalizationPatterns(patterns, context);
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeScfFor.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeScfFor.cpp
@@ -103,8 +103,7 @@ struct GPUDistributeScfForPass final
     MLIRContext *context = &getContext();
     RewritePatternSet patterns(context);
     patterns.add<DistributeLoop>(context, useBlockDims);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributeSharedMemoryCopy.cpp
@@ -440,7 +440,7 @@ LogicalResult gpuDistributeSharedMemoryCopy(mlir::FunctionOpInterface funcOp) {
         linalg::getLinalgTilingCanonicalizationPatterns(context);
     populateAffineMinSCFCanonicalizationPattern(
         threadTilingCanonicalizationPatterns);
-    if (failed(applyPatternsAndFoldGreedily(
+    if (failed(applyPatternsGreedily(
             funcOp, std::move(threadTilingCanonicalizationPatterns)))) {
       return failure();
     }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUFuseAndHoistParallelLoops.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUFuseAndHoistParallelLoops.cpp
@@ -353,7 +353,7 @@ void GPUFuseAndHoistParallelLoopsPass::runOnOperation() {
     }
     patterns.add<FuseTilableForallConsumers>(context);
     populateForallLoopHoistingPattern(patterns);
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       return signalPassFailure();
     }
   }
@@ -371,7 +371,7 @@ void GPUFuseAndHoistParallelLoopsPass::runOnOperation() {
     patterns.add<FuseTilableForallConsumers>(context);
     tensor::populateFoldTensorEmptyPatterns(patterns);
     scf::ForallOp::getCanonicalizationPatterns(patterns, context);
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       return signalPassFailure();
     }
   }
@@ -385,7 +385,7 @@ void GPUFuseAndHoistParallelLoopsPass::runOnOperation() {
     patterns.add<FuseTilableSliceProducers>(context);
     tensor::populateFoldTensorEmptyPatterns(patterns);
     scf::ForallOp::getCanonicalizationPatterns(patterns, context);
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPULowerToUKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPULowerToUKernels.cpp
@@ -144,8 +144,7 @@ struct GPULowerToUKernelsPass final
     // fusions for these ops.
     patterns.add<LowerArgmaxToUKernelPattern, LowerMultiMmaToUKernelPattern>(
         context);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPackToIntrinsics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUPackToIntrinsics.cpp
@@ -121,7 +121,7 @@ void GPUPackToIntrinsicsPass::runOnOperation() {
   {
     RewritePatternSet patterns(context);
     patterns.add<ConvertToMultiMma>(context);
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       funcOp.emitError() << "failed to convert linalg to multi_mma";
       return signalPassFailure();
     }
@@ -137,8 +137,7 @@ void GPUPackToIntrinsicsPass::runOnOperation() {
   };
 
   linalg::populateDataLayoutPropagationPatterns(patterns, control);
-  if (failed(
-          applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
+  if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
     return signalPassFailure();
   }
 }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTensorAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTensorAlloc.cpp
@@ -202,7 +202,7 @@ public:
       MLIRContext *context = &getContext();
       RewritePatternSet patterns(context);
       patterns.add<SwapAllocTensorPattern>(context);
-      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
         return signalPassFailure();
       }
     }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTensorTile.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTensorTile.cpp
@@ -211,8 +211,7 @@ LogicalResult tileReductionToSerialLoops(mlir::FunctionOpInterface funcOp,
     // same size.
     RewritePatternSet wgTilingPatterns(funcOp.getContext());
     populateTilingPatterns(wgTilingPatterns, fuseInputProducer, coalesceLoops);
-    if (failed(applyPatternsAndFoldGreedily(funcOp,
-                                            std::move(wgTilingPatterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(wgTilingPatterns)))) {
       return failure();
     }
   }
@@ -224,7 +223,7 @@ LogicalResult tileReductionToSerialLoops(mlir::FunctionOpInterface funcOp,
         wgTilingCanonicalizationPatterns);
     scf::populateSCFForLoopCanonicalizationPatterns(
         wgTilingCanonicalizationPatterns);
-    if (failed(applyPatternsAndFoldGreedily(
+    if (failed(applyPatternsGreedily(
             funcOp, std::move(wgTilingCanonicalizationPatterns)))) {
       return failure();
     }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTile.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUTile.cpp
@@ -183,7 +183,7 @@ static void fusePadIntoConsumer(mlir::FunctionOpInterface funcOp) {
   RewritePatternSet patterns(context);
   patterns.insert<linalg::ExtractSliceOfPadTensorSwapPattern>(
       context, [](tensor::ExtractSliceOp) { return false; });
-  (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
+  (void)applyPatternsGreedily(funcOp, std::move(patterns));
 
   LLVM_DEBUG({
     llvm::dbgs() << "--- After fusing padding into consumers ---\n";
@@ -199,7 +199,7 @@ static void concretizePadShape(mlir::FunctionOpInterface funcOp) {
   SmallVector<int64_t> numWorkgroups = getStaticNumWorkgroups(funcOp);
   populateConcretizePadResultShapePatterns(patterns, numWorkgroups);
   populateFoldAffineMinInDistributedLoopsPatterns(patterns, numWorkgroups);
-  (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
+  (void)applyPatternsGreedily(funcOp, std::move(patterns));
 
   LLVM_DEBUG({
     llvm::dbgs() << "--- After concretizing pad result shape ---\n";
@@ -329,7 +329,7 @@ struct GPUTilePass final : impl::GPUTilePassBase<GPUTilePass> {
       // Pull in scf.for op canonicalization patterns to help hoisting across
       // multiple loops and remove loop carried values unused in the body.
       scf::ForOp::getCanonicalizationPatterns(patterns, context);
-      (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
+      (void)applyPatternsGreedily(funcOp, std::move(patterns));
 
       LLVM_DEBUG({
         llvm::dbgs() << "--- After Downsizing N-D convolution to 1-D  ---\n";

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.cpp
@@ -318,7 +318,7 @@ LogicalResult distributeVectorOps(Operation *root,
                                                          root->getContext());
   IREE::VectorExt::ToSIMTOp::getCanonicalizationPatterns(patterns,
                                                          root->getContext());
-  if (failed(applyPatternsAndFoldGreedily(root, std::move(patterns)))) {
+  if (failed(applyPatternsGreedily(root, std::move(patterns)))) {
     return failure();
   }
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
@@ -211,7 +211,7 @@ struct VectorReductionToGPUPass final
       vector::ShapeCastOp::getCanonicalizationPatterns(patterns, ctx);
       vector::BroadcastOp::getCanonicalizationPatterns(patterns, ctx);
       vector::ExtractOp::getCanonicalizationPatterns(patterns, ctx);
-      (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+      (void)applyPatternsGreedily(getOperation(), std::move(patterns));
     }
 
     debugPrint(funcOp, "after step #1: preprocessing reduction ops");
@@ -288,7 +288,7 @@ struct VectorReductionToGPUPass final
           patterns, distributionFn, maxWriteElementsToExtract);
       patterns.add<WarpOpBarrier>(patterns.getContext(), 3);
       vector::ReductionOp::getCanonicalizationPatterns(patterns, ctx);
-      (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+      (void)applyPatternsGreedily(getOperation(), std::move(patterns));
     }
 
     debugPrint(funcOp, "after step #4: propagating distribution");
@@ -303,7 +303,7 @@ struct VectorReductionToGPUPass final
         builder.create<gpu::BarrierOp>(loc);
       };
       vector::populateWarpExecuteOnLane0OpToScfForPattern(patterns, options);
-      (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+      (void)applyPatternsGreedily(getOperation(), std::move(patterns));
     }
 
     debugPrint(funcOp, "after step #5: lowering remaining ops");

--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -399,8 +399,7 @@ void GenericVectorizationPass::runOnOperation() {
                                                         funcOp.getContext());
     vector::MaskOp::getCanonicalizationPatterns(maskCanonPatterns,
                                                 funcOp.getContext());
-    if (failed(applyPatternsAndFoldGreedily(funcOp,
-                                            std::move(maskCanonPatterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(maskCanonPatterns)))) {
       return signalPassFailure();
     }
   }
@@ -431,7 +430,7 @@ void GenericVectorizationPass::runOnOperation() {
     vector::TransferWriteOp::getCanonicalizationPatterns(vectorizationPatterns,
                                                          funcOp.getContext());
   }
-  (void)applyPatternsAndFoldGreedily(funcOp, std::move(vectorizationPatterns));
+  (void)applyPatternsGreedily(funcOp, std::move(vectorizationPatterns));
 
   // Apply the pad tensor op vectorization separately to avoid running the
   // GenericPadOpVectorizationPattern too early.
@@ -440,7 +439,7 @@ void GenericVectorizationPass::runOnOperation() {
   if (vectorizePadding) {
     RewritePatternSet patterns(funcOp.getContext());
     linalg::populatePadOpVectorizationPatterns(patterns);
-    (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
+    (void)applyPatternsGreedily(funcOp, std::move(patterns));
   }
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/HoistUnrolledVectorExtractInsertSlice.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/HoistUnrolledVectorExtractInsertSlice.cpp
@@ -224,7 +224,7 @@ void HoistUnrolledVectorExtractInsertSlicePass::runOnOperation() {
   scf::ForOp::getCanonicalizationPatterns(patterns, ctx);
   vector::InsertStridedSliceOp::getCanonicalizationPatterns(patterns, ctx);
   vector::ExtractStridedSliceOp::getCanonicalizationPatterns(patterns, ctx);
-  if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+  if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
     LLVM_DEBUG(llvm::dbgs() << "----- cleanup failed -----\n");
     return signalPassFailure();
   }

--- a/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
@@ -183,7 +183,7 @@ void EliminateEmptyTensorsPass::runOnOperation() {
   {
     RewritePatternSet patterns(context);
     linalg::populateConvertToDestinationStylePatterns(patterns);
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       funcOp->emitOpError("Failed in conversion to destination style patterns");
       return signalPassFailure();
     }
@@ -235,7 +235,7 @@ void IREEComprehensiveBufferizePass::runOnOperation() {
   {
     RewritePatternSet patterns(&getContext());
     linalg::populateEraseUnusedOperandsAndResultsPatterns(patterns);
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
@@ -271,8 +271,7 @@ void IREEExpandStridedMetadataPass::runOnOperation() {
   RewritePatternSet patterns(context);
   populateIREEResolveExtractStridedMetadataPatterns(context, patterns);
   populateRemoveDeadMemAllocPatterns(patterns);
-  if (failed(
-          applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
+  if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
     return signalPassFailure();
   }
 

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
@@ -112,7 +112,7 @@ materializeFuncOpEncodings(FunctionOpInterface funcOp,
     tensor::CastOp::getCanonicalizationPatterns(patterns, ctx);
     tensor::populateFoldIntoPackAndUnpackPatterns(patterns);
     memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       funcOp.emitOpError("folding patterns failed");
       return failure();
     }

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoNop.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoNop.cpp
@@ -64,8 +64,7 @@ struct MaterializeEncodingIntoNopPass final
       memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);
       context->getOrLoadDialect<tensor::TensorDialect>()
           ->getCanonicalizationPatterns(patterns);
-      if (failed(
-              applyPatternsAndFoldGreedily(operation, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(operation, std::move(patterns)))) {
         operation.emitOpError("folding patterns failed");
         return signalPassFailure();
       }

--- a/compiler/src/iree/compiler/Codegen/Common/MemrefCopyToLinalg.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MemrefCopyToLinalg.cpp
@@ -42,8 +42,7 @@ struct MemrefCopyToLinalgPass final
     MLIRContext *context = &getContext();
     RewritePatternSet patterns(&getContext());
     patterns.insert<MemrefCopyOpToLinalg>(context);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeTensorInsertExtractSlices.cpp
@@ -265,7 +265,7 @@ void OptimizeTensorInsertExtractSlicesPass::runOnOperation() {
     patterns.add<CastLikeExtractSliceOpFolder>(context);
     patterns.add<CastLikeInsertSliceOpFolder>(context);
   }
-  if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+  if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
     return signalPassFailure();
   }
 

--- a/compiler/src/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/OptimizeVectorTransferPass.cpp
@@ -80,7 +80,7 @@ struct OptimizeVectorTransferPass final
       mlir::vector::
           populateVectorTransferCollapseInnerMostContiguousDimsPatterns(
               patterns);
-      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
         return signalPassFailure();
       }
     }
@@ -104,7 +104,7 @@ struct OptimizeVectorTransferPass final
     {
       RewritePatternSet patterns(&getContext());
       vector::populateBubbleVectorBitCastOpPatterns(patterns);
-      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
         return signalPassFailure();
       }
     }
@@ -115,7 +115,7 @@ struct OptimizeVectorTransferPass final
     if (flatten) {
       RewritePatternSet patterns(&getContext());
       mlir::vector::populateFlattenVectorTransferPatterns(patterns);
-      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
         return signalPassFailure();
       }
     }

--- a/compiler/src/iree/compiler/Codegen/Common/PolynomialApproximationPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/PolynomialApproximationPass.cpp
@@ -47,8 +47,8 @@ class PolynomialApproximationPass final
       populateMathPolynomialApproximationPatterns(mathPatterns);
       populateExpandRoundEvenPattern(mathPatterns);
     }
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(mathPatterns)))) {
+    if (failed(
+            applyPatternsGreedily(getOperation(), std::move(mathPatterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/PropagateReshapesByExpansion.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/PropagateReshapesByExpansion.cpp
@@ -300,8 +300,7 @@ void PropagateReshapesByExpansionPass::runOnOperation() {
     // Preemptively attempt to fold any reshapes into interface bindings if
     // possible to simplify subsequent reshape propagation.
     populateReshapeToInterfaceTensorPatterns(patterns);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }
@@ -335,8 +334,8 @@ void PropagateReshapesByExpansionPass::runOnOperation() {
   populateReshapeToInterfaceTensorPatterns(bubbleExpandShapePatterns);
   bubbleExpandShapePatterns.add<ExpandDestinationForallOp>(context);
 
-  if (failed(applyPatternsAndFoldGreedily(
-          getOperation(), std::move(bubbleExpandShapePatterns)))) {
+  if (failed(applyPatternsGreedily(getOperation(),
+                                   std::move(bubbleExpandShapePatterns)))) {
     getOperation()->emitOpError("Failed to propagate reshapes");
     return signalPassFailure();
   }

--- a/compiler/src/iree/compiler/Codegen/Common/RematerializeParallelOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/RematerializeParallelOps.cpp
@@ -70,8 +70,7 @@ struct RematerializeParallelOpsPass final
     RewritePatternSet fusionPatterns(funcOp.getContext());
     fusionPatterns.insert<RematerializeParallelOpsPattern>(funcOp.getContext());
     linalg::populateEraseUnusedOperandsAndResultsPatterns(fusionPatterns);
-    if (failed(
-            applyPatternsAndFoldGreedily(funcOp, std::move(fusionPatterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(fusionPatterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/RemoveSingleIterationLoop.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/RemoveSingleIterationLoop.cpp
@@ -107,7 +107,7 @@ static LogicalResult removeOneTripTiledLoops(mlir::FunctionOpInterface funcOp,
   };
   RewritePatternSet patterns(funcOp.getContext());
   populateRemoveSingleIterationLoopPattern(patterns, getWorkgroupRangeFn);
-  return applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
+  return applyPatternsGreedily(funcOp, std::move(patterns));
 }
 
 namespace {

--- a/compiler/src/iree/compiler/Codegen/Common/ReplaceSlowMinMaxOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReplaceSlowMinMaxOps.cpp
@@ -79,8 +79,7 @@ void populateReplaceSlowMinMaxOpsPatterns(RewritePatternSet &patterns) {
 void ReplaceSlowMinMaxOpsPass::runOnOperation() {
   RewritePatternSet patterns(&getContext());
   populateReplaceSlowMinMaxOpsPatterns(patterns);
-  if (failed(
-          applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
+  if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
     return signalPassFailure();
   }
 }

--- a/compiler/src/iree/compiler/Codegen/Common/SplitFullPartialTransferPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/SplitFullPartialTransferPass.cpp
@@ -38,8 +38,7 @@ struct SplitFullPartialTransferPass final
                   vector::VectorTransferSplit::VectorTransfer)
             .Default(vector::VectorTransferSplit::None));
     populateVectorTransferFullPartialPatterns(patterns, options);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/TensorToVectorVectorizePad.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TensorToVectorVectorizePad.cpp
@@ -246,8 +246,7 @@ struct TensorToVectorVectorizePadPass final
     MLIRContext *context = &getContext();
     RewritePatternSet patterns(context);
     populateVectorizePadPatterns(patterns);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/TestPartitionableLoopsInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TestPartitionableLoopsInterface.cpp
@@ -57,8 +57,7 @@ struct TestPartitionableLoopsInterfacePass final
   void runOnOperation() override {
     RewritePatternSet patterns(&getContext());
     patterns.add<TestPartitionableLoopsInterfacePattern>(patterns.getContext());
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
@@ -293,7 +293,7 @@ void TileAndDistributeToWorkgroupsPass::runOnOperation() {
   {
     RewritePatternSet patterns(context);
     populateReshapeToInterfaceTensorPatterns(patterns);
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       funcOp.emitOpError("reshape to interface tensor patterns failed");
       return signalPassFailure();
     }
@@ -403,8 +403,8 @@ void TileAndDistributeToWorkgroupsPass::runOnOperation() {
     {
       RewritePatternSet patterns(exportOp->getContext());
       memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);
-      if (failed(applyPatternsAndFoldGreedily(exportOp.value(),
-                                              std::move(patterns)))) {
+      if (failed(
+              applyPatternsGreedily(exportOp.value(), std::move(patterns)))) {
         exportOp->emitOpError("`tensor.dim` resolution in exportOp failed");
         return signalPassFailure();
       }
@@ -414,7 +414,7 @@ void TileAndDistributeToWorkgroupsPass::runOnOperation() {
   {
     RewritePatternSet patterns(context);
     populateTileAndDistributeToWorkgroupsCleanupPatterns(patterns);
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       funcOp.emitOpError("Tile+Distribute clean up patterns failed");
       return signalPassFailure();
     }
@@ -439,7 +439,7 @@ void TileAndDistributeToWorkgroupsPass::runOnOperation() {
         ->getCanonicalizationPatterns(patterns);
     context->getOrLoadDialect<IREE::LinalgExt::IREELinalgExtDialect>()
         ->getCanonicalizationPatterns(patterns);
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       funcOp.emitOpError("tiling canonicalizations failed");
       return signalPassFailure();
     }
@@ -455,7 +455,7 @@ void TileAndDistributeToWorkgroupsPass::runOnOperation() {
   // operations only in `tensor.dim` ops. Resolve these.
   RewritePatternSet resolveDimOps(context);
   memref::populateResolveRankedShapedTypeResultDimsPatterns(resolveDimOps);
-  if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(resolveDimOps)))) {
+  if (failed(applyPatternsGreedily(funcOp, std::move(resolveDimOps)))) {
     funcOp.emitOpError("resolving ranked shaped results dims failed");
     return signalPassFailure();
   }

--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
@@ -530,7 +530,7 @@ void TileAndDistributeToWorkgroupsUsingForallOpPass::runOnOperation() {
         ->getCanonicalizationPatterns(patterns);
     memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);
     scf::ForallOp::getCanonicalizationPatterns(patterns, context);
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       funcOp.emitOpError("tiling canonicalization failed");
       return signalPassFailure();
     }

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -930,7 +930,7 @@ DiagnosedSilenceableFailure transform_dialect::IREEBufferizeOp::apply(
     // Manually gather list of ops because the other GreedyPatternRewriteDriver
     // overloads only accepts ops that are isolated from above.
     LogicalResult result =
-        applyOpPatternsAndFold(target, std::move(patterns), config);
+        applyOpPatternsGreedily(target, std::move(patterns), config);
     if (failed(result)) {
       return mlir::emitDefiniteFailure(target,
                                        "greedy pattern application failed");

--- a/compiler/src/iree/compiler/Codegen/Common/TypePropagationPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TypePropagationPass.cpp
@@ -81,7 +81,7 @@ namespace {
 
 /// Materialize
 Value materializeAsConvertElementType(OpBuilder &builder, Type type,
-                                  ValueRange inputs, Location loc) {
+                                      ValueRange inputs, Location loc) {
   assert(inputs.size() == 1 && "expected exactly one input");
   return convertElementType(builder, loc, type, inputs[0]);
 }

--- a/compiler/src/iree/compiler/Codegen/Common/UnrollAnnotatedLoops.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/UnrollAnnotatedLoops.cpp
@@ -67,7 +67,7 @@ struct UnrollAnnotatedLoopsPass final
       MLIRContext *context = &getContext();
       RewritePatternSet patterns(context);
       scf::ForOp::getCanonicalizationPatterns(patterns, context);
-      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
         funcOp->emitError("Failed to apply post unroll cleanup");
         return signalPassFailure();
       }

--- a/compiler/src/iree/compiler/Codegen/Common/VectorizeMemrefCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorizeMemrefCopy.cpp
@@ -44,7 +44,7 @@ struct VectorizeMemrefCopyPass final
     RewritePatternSet patterns(ctx);
     patterns.add<linalg::CopyVectorizationPattern>(&getContext());
     patterns.add<ConvertLinalgCopyToMemrefCopy>(&getContext());
-    (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
+    (void)applyPatternsGreedily(funcOp, std::move(patterns));
   }
 };
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/CombineBarrierRegions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/CombineBarrierRegions.cpp
@@ -116,8 +116,7 @@ void CombineBarrierRegionsPass::runOnOperation() {
   // These two patterns are run to a fixed point, allowing fusion within
   // potentially nested loops, hoisting from said loops, and continued fusion.
   patterns.add<CombineAdjacentBarrierRegions>(context);
-  if (failed(
-          applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
+  if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
     return signalPassFailure();
   }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/ConcretizeMmaShapes.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/ConcretizeMmaShapes.cpp
@@ -228,7 +228,7 @@ void ConcretizeMmaShapesPass::runOnOperation() {
   if (concretizeResult) {
     patterns.insert<ConcretizeMmaOperandShape>(context, MMAFragment::Acc);
   }
-  if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+  if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
     return signalPassFailure();
   }
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/DistributeMmaToLanes.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/DistributeMmaToLanes.cpp
@@ -117,7 +117,7 @@ void DistributeMmaToLanesPass::runOnOperation() {
     tensor::InsertSliceOp::getCanonicalizationPatterns(patterns, context);
     tensor::ExtractSliceOp::getCanonicalizationPatterns(patterns, context);
     scf::ForOp::getCanonicalizationPatterns(patterns, context);
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       funcOp.emitError() << "cleanup failed\n";
       return signalPassFailure();
     }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/LowerIREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/LowerIREEGPUOps.cpp
@@ -28,8 +28,7 @@ void LowerIREEGPUOpsPass::runOnOperation() {
   RewritePatternSet patterns(context);
   populateIREEGPULowerValueBarrierPatterns(patterns);
   populateIREEGPULowerMultiMmaPatterns(patterns);
-  if (failed(
-          applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
+  if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
     return signalPassFailure();
   }
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/UnrollToIntrinsics.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/UnrollToIntrinsics.cpp
@@ -37,8 +37,7 @@ void UnrollToIntrinsicsPass::runOnOperation() {
   {
     RewritePatternSet patterns(context);
     GPU::populateIREEGPUVectorUnrollPatterns(patterns);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }
@@ -48,8 +47,7 @@ void UnrollToIntrinsicsPass::runOnOperation() {
   {
     RewritePatternSet patterns(context);
     GPU::populateIREEGPUDropUnitDimsPatterns(patterns);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/VectorizeIREEGPUOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/VectorizeIREEGPUOps.cpp
@@ -28,8 +28,7 @@ void VectorizeIREEGPUOpsPass::runOnOperation() {
   MLIRContext *context = &getContext();
   RewritePatternSet patterns(context);
   populateIREEGPUVectorizationPatterns(patterns);
-  if (failed(
-          applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
+  if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
     return signalPassFailure();
   }
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorExtFoldUnitExtentDims.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorExtFoldUnitExtentDims.cpp
@@ -92,8 +92,7 @@ struct VectorExtFoldUnitExtentDimsPass final
     MLIRContext *ctx = &getContext();
     RewritePatternSet patterns(ctx);
     patterns.add<DropToLayoutUnitDims>(ctx);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorizeIREEVectorExtOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorizeIREEVectorExtOps.cpp
@@ -75,8 +75,7 @@ struct VectorizeIREEVectorExtOpsPass final
     MLIRContext *ctx = &getContext();
     RewritePatternSet patterns(ctx);
     patterns.add<VectorizeToLayoutOpPattern>(ctx);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -983,8 +983,7 @@ void ConvertToLLVMPass::runOnOperation() {
     vector::populateVectorTransposeLoweringPatterns(
         patterns, vector::VectorTransformsOptions());
     populateConvertArmNeon2dToIntrPatterns(patterns);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }
@@ -992,8 +991,8 @@ void ConvertToLLVMPass::runOnOperation() {
     RewritePatternSet vectorToLoopsPatterns(&getContext());
     populateVectorToSCFConversionPatterns(
         vectorToLoopsPatterns, VectorTransferToSCFOptions().enableFullUnroll());
-    if (failed(applyPatternsAndFoldGreedily(
-            getOperation(), std::move(vectorToLoopsPatterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(),
+                                     std::move(vectorToLoopsPatterns)))) {
       return signalPassFailure();
     }
   }
@@ -1103,7 +1102,7 @@ void ConvertToLLVMPass::runOnOperation() {
     RewritePatternSet patterns(&getContext());
     patterns.insert<RewriteExternCallOpToDynamicImportCallOp, RewriteCallOpABI,
                     RewriteFuncOpABI>(abi, typeConverter);
-    if (failed(applyPatternsAndFoldGreedily(module, std::move(patterns))))
+    if (failed(applyPatternsGreedily(module, std::move(patterns))))
       return signalPassFailure();
   }
 
@@ -1115,7 +1114,7 @@ void ConvertToLLVMPass::runOnOperation() {
     if (triple.isWasm()) {
       populateUnfusedFMAOpsPassPatterns(&getContext(), postPatterns);
     }
-    if (failed(applyPatternsAndFoldGreedily(module, std::move(postPatterns)))) {
+    if (failed(applyPatternsGreedily(module, std::move(postPatterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ExpandF16OpToF32Pass.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ExpandF16OpToF32Pass.cpp
@@ -66,8 +66,7 @@ struct ExpandF16OpToF32Pass
     // TODO(#15661): Remove the expansion for math.powf op after fixing
     // approximation issue.
     patterns.insert<ExpandF16OpToF32Pattern<math::PowFOp>>(context);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -3227,7 +3227,7 @@ LogicalResult initCPULaunchConfig(FunctionOpInterface funcOp) {
   // Resolve those away.
   RewritePatternSet patterns(funcOp.getContext());
   memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);
-  return applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
+  return applyPatternsGreedily(funcOp, std::move(patterns));
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUMmt4dVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUMmt4dVectorLowering.cpp
@@ -62,8 +62,8 @@ void LLVMCPUMmt4dVectorLoweringPass::runOnOperation() {
     RewritePatternSet canonicalizationPatterns(context);
     vector::ContractionOp::getCanonicalizationPatterns(canonicalizationPatterns,
                                                        context);
-    if (failed(applyPatternsAndFoldGreedily(
-            funcOp, std::move(canonicalizationPatterns)))) {
+    if (failed(applyPatternsGreedily(funcOp,
+                                     std::move(canonicalizationPatterns)))) {
       return signalPassFailure();
     }
 
@@ -80,8 +80,8 @@ void LLVMCPUMmt4dVectorLoweringPass::runOnOperation() {
     RewritePatternSet castAwayUnitDimPatterns(&getContext());
     vector::populateCastAwayVectorLeadingOneDimPatterns(
         castAwayUnitDimPatterns);
-    if (failed(applyPatternsAndFoldGreedily(
-            funcOp, std::move(castAwayUnitDimPatterns)))) {
+    if (failed(applyPatternsGreedily(funcOp,
+                                     std::move(castAwayUnitDimPatterns)))) {
       return signalPassFailure();
     }
 
@@ -90,8 +90,8 @@ void LLVMCPUMmt4dVectorLoweringPass::runOnOperation() {
         reductionToContractPatterns);
     vector::ExtractOp::getCanonicalizationPatterns(reductionToContractPatterns,
                                                    context);
-    if (failed(applyPatternsAndFoldGreedily(
-            funcOp, std::move(reductionToContractPatterns)))) {
+    if (failed(applyPatternsGreedily(funcOp,
+                                     std::move(reductionToContractPatterns)))) {
       return signalPassFailure();
     }
   }
@@ -102,7 +102,7 @@ void LLVMCPUMmt4dVectorLoweringPass::runOnOperation() {
     RewritePatternSet patterns(context);
     auto target = IREE::HAL::ExecutableTargetAttr::lookup(funcOp);
     populateVectorContractCustomKernelsPatterns(target, patterns);
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUPeel.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUPeel.cpp
@@ -88,7 +88,7 @@ void LLVMCPUPeelPass::runOnOperation() {
   memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);
   context->getLoadedDialect<tensor::TensorDialect>()
       ->getCanonicalizationPatterns(patterns);
-  if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+  if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
     LLVM_DEBUG(llvm::dbgs() << "----- cleanup failed -----\n");
     return signalPassFailure();
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTile.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTile.cpp
@@ -111,7 +111,7 @@ void LLVMCPUTilePass::runOnOperation() {
   memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);
   context->getLoadedDialect<tensor::TensorDialect>()
       ->getCanonicalizationPatterns(patterns);
-  if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+  if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
     LLVM_DEBUG(llvm::dbgs() << "----- cleanup failed -----\n");
     return signalPassFailure();
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileAndFuse.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileAndFuse.cpp
@@ -296,7 +296,7 @@ void LLVMCPUTileAndFusePass::runOnOperation() {
   // into producers when possible.
   context->getLoadedDialect<tensor::TensorDialect>()
       ->getCanonicalizationPatterns(patterns);
-  if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+  if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
     LLVM_DEBUG(llvm::dbgs() << "----- cleanup failed -----\n");
     return signalPassFailure();
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileRootAndFuseProducerConsumer.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUTileRootAndFuseProducerConsumer.cpp
@@ -279,7 +279,7 @@ void LLVMCPUTileRootAndFuseProducerConsumer::runOnOperation() {
   // into producers when possible.
   context->getLoadedDialect<tensor::TensorDialect>()
       ->getCanonicalizationPatterns(patterns);
-  if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+  if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
     LLVM_DEBUG(llvm::dbgs() << "----- cleanup failed -----\n");
     return signalPassFailure();
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUUnfuseFMAOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUUnfuseFMAOps.cpp
@@ -56,7 +56,7 @@ void LLVMCPUUnfuseFMAOpsPass::runOnOperation() {
   auto context = funcOp.getContext();
   RewritePatternSet patterns(&getContext());
   populateUnfusedFMAOpsPassPatterns(context, patterns);
-  if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+  if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
     return signalPassFailure();
   }
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVectorShapeCastLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVectorShapeCastLowering.cpp
@@ -38,7 +38,7 @@ void LLVMCPUVectorShapeCastLoweringPass::runOnOperation() {
 
   RewritePatternSet patterns(ctx);
   vector::populateVectorShapeCastLoweringPatterns(patterns);
-  (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
+  (void)applyPatternsGreedily(funcOp, std::move(patterns));
 }
 } // namespace
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVectorTransferLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVectorTransferLowering.cpp
@@ -49,7 +49,7 @@ void LLVMCPUVectorTransferLoweringPass::runOnOperation() {
   }
 
   populateVectorToSCFConversionPatterns(patterns, vectorTransferToSCFOptions);
-  (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
+  (void)applyPatternsGreedily(funcOp, std::move(patterns));
 }
 } // namespace
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVectorTransposeLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVectorTransposeLowering.cpp
@@ -82,7 +82,7 @@ void LLVMCPUVectorTransposeLoweringPass::runOnOperation() {
     x86vector::avx2::populateSpecializedTransposeLoweringPatterns(
         patterns, avx2LoweringOptions, kSpecializedBenefit);
   }
-  (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
+  (void)applyPatternsGreedily(funcOp, std::move(patterns));
 }
 } // namespace
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVirtualVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVirtualVectorLowering.cpp
@@ -60,7 +60,7 @@ void LLVMCPUVirtualVectorLoweringPass::runOnOperation() {
     if (enableArmI8mm) {
       RewritePatternSet patterns(ctx);
       arm_neon::populateLowerContractionToSMMLAPatternPatterns(patterns);
-      (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
+      (void)applyPatternsGreedily(funcOp, std::move(patterns));
     }
   }
 
@@ -82,7 +82,7 @@ void LLVMCPUVirtualVectorLoweringPass::runOnOperation() {
     vector::populateVectorMultiReductionLoweringPatterns(
         patterns, vectorMultiReductionLowering);
     populateVectorTransferFullPartialPatterns(patterns, vectorTransformOptions);
-    (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
+    (void)applyPatternsGreedily(funcOp, std::move(patterns));
   }
 }
 } // namespace

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/VectorContractCustomKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/VectorContractCustomKernels.cpp
@@ -1130,7 +1130,7 @@ public:
     auto funcOp = getOperation();
     auto target = IREE::HAL::ExecutableTargetAttr::lookup(funcOp);
     populateVectorContractCustomKernelsPatterns(target, patterns);
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
@@ -195,8 +195,7 @@ class TestLLVMGPULegalizeOpPass final
     RewritePatternSet patterns(&getContext());
     populateScalarizeMathOps(patterns);
     populateConvertSharedMemoryAllocOps(patterns);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
@@ -114,14 +114,14 @@ struct ConvertToNVVMPass final
           patterns, vector::VectorTransformsOptions());
       vector::populateVectorTransferLoweringPatterns(patterns);
       arith::populateExpandBFloat16Patterns(patterns);
-      if (failed(applyPatternsAndFoldGreedily(m, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(m, std::move(patterns)))) {
         return signalPassFailure();
       }
     }
     {
       RewritePatternSet patterns(&getContext());
       populateGpuRewritePatterns(patterns);
-      if (failed(applyPatternsAndFoldGreedily(m, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(m, std::move(patterns)))) {
         return signalPassFailure();
       }
     }
@@ -134,7 +134,7 @@ struct ConvertToNVVMPass final
       if (!cc || cc.value() < 80) {
         RewritePatternSet patterns(&getContext());
         populateReplaceSlowMinMaxOpsPatterns(patterns);
-        if (failed(applyPatternsAndFoldGreedily(m, std::move(patterns)))) {
+        if (failed(applyPatternsGreedily(m, std::move(patterns)))) {
           return signalPassFailure();
         }
       }
@@ -184,7 +184,7 @@ struct ConvertToNVVMPass final
     {
       RewritePatternSet patterns(&getContext());
       populateNVVMToLLVMConversionPatterns(patterns);
-      if (failed(applyPatternsAndFoldGreedily(m, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(m, std::move(patterns)))) {
         return signalPassFailure();
       }
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -179,7 +179,7 @@ struct ConvertToROCDLPass final
           patterns, vector::VectorTransformsOptions());
       vector::populateVectorTransferLoweringPatterns(patterns);
       arith::populateExpandBFloat16Patterns(patterns);
-      if (failed(applyPatternsAndFoldGreedily(m, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(m, std::move(patterns)))) {
         return signalPassFailure();
       }
     }
@@ -189,7 +189,7 @@ struct ConvertToROCDLPass final
     {
       RewritePatternSet patterns(&getContext());
       populateGpuRewritePatterns(patterns);
-      if (failed(applyPatternsAndFoldGreedily(m, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(m, std::move(patterns)))) {
         return signalPassFailure();
       }
     }
@@ -203,7 +203,7 @@ struct ConvertToROCDLPass final
       // (https://github.com/llvm/llvm-project/issues/67815).
       RewritePatternSet patterns(&getContext());
       populateReplaceSlowMinMaxOpsPatterns(patterns);
-      if (failed(applyPatternsAndFoldGreedily(m, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(m, std::move(patterns)))) {
         return signalPassFailure();
       }
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ExtractAddressComputationGPUPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ExtractAddressComputationGPUPass.cpp
@@ -92,8 +92,7 @@ struct ExtractAddressComputationGPUPass final
 void ExtractAddressComputationGPUPass::runOnOperation() {
   RewritePatternSet patterns(&getContext());
   populateExtractAddressComputationGPUPatterns(patterns);
-  if (failed(
-          applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
+  if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
     return signalPassFailure();
   }
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUCastTypeToFitMMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUCastTypeToFitMMA.cpp
@@ -128,7 +128,7 @@ struct LLVMGPUCastTypeToFitMMAPass final
     RewritePatternSet patterns(context);
     patterns.add<UpcastContractOutput>(context);
 
-    if (failed(applyPatternsAndFoldGreedily(func, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(func, std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUPromoteMatmulToFitMMA.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUPromoteMatmulToFitMMA.cpp
@@ -104,7 +104,7 @@ public:
       ctx->getLoadedDialect<tensor::TensorDialect>()
           ->getCanonicalizationPatterns(patterns);
       tensor::PadOp::getCanonicalizationPatterns(patterns, ctx);
-      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
         LLVM_DEBUG(llvm::dbgs() << "----- cleanup failed -----\n");
         return signalPassFailure();
       }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorCoreVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorCoreVectorization.cpp
@@ -97,8 +97,8 @@ public:
           contractionPatterns);
       vector::populateVectorReductionToContractPatterns(contractionPatterns);
       vector::populateSinkVectorOpsPatterns(contractionPatterns);
-      if (failed(applyPatternsAndFoldGreedily(
-              funcOp, std::move(contractionPatterns)))) {
+      if (failed(
+              applyPatternsGreedily(funcOp, std::move(contractionPatterns)))) {
         return signalPassFailure();
       }
       LLVM_DEBUG({
@@ -112,8 +112,8 @@ public:
       // This pattern folds the arithmetic extensions into the vector.contract.
       RewritePatternSet foldArithExtPatterns(context);
       vector::populateFoldArithExtensionPatterns(foldArithExtPatterns);
-      if (failed(applyPatternsAndFoldGreedily(
-              funcOp, std::move(foldArithExtPatterns)))) {
+      if (failed(
+              applyPatternsGreedily(funcOp, std::move(foldArithExtPatterns)))) {
         return signalPassFailure();
       }
 
@@ -123,8 +123,8 @@ public:
           canonicalizationPatterns, context);
       populateCombineVectorTransferReadBroadcastPatterns(
           canonicalizationPatterns);
-      if (failed(applyPatternsAndFoldGreedily(
-              funcOp, std::move(canonicalizationPatterns)))) {
+      if (failed(applyPatternsGreedily(funcOp,
+                                       std::move(canonicalizationPatterns)))) {
         return signalPassFailure();
       }
       LLVM_DEBUG({
@@ -141,8 +141,8 @@ public:
             vectorContractPatterns);
         mlir::populatePrepareVectorToMMAPatterns(vectorContractPatterns,
                                                  /*useMMASync=*/true);
-        if (failed(applyPatternsAndFoldGreedily(
-                getOperation(), std::move(vectorContractPatterns)))) {
+        if (failed(applyPatternsGreedily(getOperation(),
+                                         std::move(vectorContractPatterns)))) {
           return signalPassFailure();
         }
       }
@@ -157,8 +157,8 @@ public:
       // Step 4. Break and unroll warp tile size to native math and load sizes.
       RewritePatternSet vectorUnrollPatterns(context);
       populateVectorUnrollPatterns(vectorUnrollPatterns, useMmaSyncShape);
-      if (failed(applyPatternsAndFoldGreedily(
-              funcOp, std::move(vectorUnrollPatterns)))) {
+      if (failed(
+              applyPatternsGreedily(funcOp, std::move(vectorUnrollPatterns)))) {
         return signalPassFailure();
       }
       LLVM_DEBUG({

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
@@ -81,7 +81,7 @@ static LogicalResult tileToSerialLoops(mlir::FunctionOpInterface funcOp) {
         wgTilingCanonicalizationPatterns);
     scf::populateSCFForLoopCanonicalizationPatterns(
         wgTilingCanonicalizationPatterns);
-    if (failed(applyPatternsAndFoldGreedily(
+    if (failed(applyPatternsGreedily(
             funcOp, std::move(wgTilingCanonicalizationPatterns)))) {
       return failure();
     }
@@ -220,8 +220,7 @@ public:
     {
       RewritePatternSet promotionPatterns(&getContext());
       populateContractPromotionPatterns(promotionPatterns, {2});
-      if (failed(applyPatternsAndFoldGreedily(funcOp,
-                                              std::move(promotionPatterns)))) {
+      if (failed(applyPatternsGreedily(funcOp, std::move(promotionPatterns)))) {
         return signalPassFailure();
       }
       propagateSharedMemoryCopy(funcOp);
@@ -256,8 +255,7 @@ public:
 
       populateContractPromotionPatterns(promotionPatterns, {0, 1});
 
-      if (failed(applyPatternsAndFoldGreedily(funcOp,
-                                              std::move(promotionPatterns)))) {
+      if (failed(applyPatternsGreedily(funcOp, std::move(promotionPatterns)))) {
         return signalPassFailure();
       }
       // Insert barriers before and after copies to workgroup memory.
@@ -267,8 +265,8 @@ public:
     {
       RewritePatternSet promotionCanonicalization =
           linalg::getLinalgTilingCanonicalizationPatterns(context);
-      if (failed(applyPatternsAndFoldGreedily(
-              funcOp, std::move(promotionCanonicalization)))) {
+      if (failed(applyPatternsGreedily(funcOp,
+                                       std::move(promotionCanonicalization)))) {
         return signalPassFailure();
       }
     }
@@ -296,7 +294,7 @@ public:
           linalg::getLinalgTilingCanonicalizationPatterns(context);
       populateAffineMinSCFCanonicalizationPattern(
           threadTilingCanonicalizationPatterns);
-      if (failed(applyPatternsAndFoldGreedily(
+      if (failed(applyPatternsGreedily(
               funcOp, std::move(threadTilingCanonicalizationPatterns)))) {
         return signalPassFailure();
       }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
@@ -105,8 +105,8 @@ struct LLVMGPUVectorLoweringPass final
       vector::populateVectorMultiReductionLoweringPatterns(
           contractLoweringPatterns,
           vector::VectorMultiReductionLowering::InnerParallel);
-      if (failed(applyPatternsAndFoldGreedily(
-              funcOp, std::move(contractLoweringPatterns)))) {
+      if (failed(applyPatternsGreedily(funcOp,
+                                       std::move(contractLoweringPatterns)))) {
         return signalPassFailure();
       }
     }
@@ -118,8 +118,8 @@ struct LLVMGPUVectorLoweringPass final
                                           vectorToSCFOptions);
     memref::populateFoldMemRefAliasOpPatterns(vectorToLoopsPatterns);
     vector::populateVectorTransferLoweringPatterns(vectorToLoopsPatterns);
-    if (failed(applyPatternsAndFoldGreedily(
-            funcOp, std::move(vectorToLoopsPatterns)))) {
+    if (failed(
+            applyPatternsGreedily(funcOp, std::move(vectorToLoopsPatterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorToGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorToGPU.cpp
@@ -57,16 +57,14 @@ struct LLVMGPUVectorToGPUPass final
     bool targetMmaSync = tensorCoreType == GPUTensorCoreType::MMA_SYNC;
     RewritePatternSet flatternpatterns(funcOp.getContext());
     populateVectorTransferToGPUMMAPreparationPatterns(flatternpatterns);
-    if (failed(applyPatternsAndFoldGreedily(funcOp,
-                                            std::move(flatternpatterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(flatternpatterns)))) {
       return signalPassFailure();
     }
 
     RewritePatternSet patterns(funcOp.getContext());
     mlir::vector::populateCastAwayVectorLeadingOneDimPatterns(patterns);
     populatePrepareVectorToMMAPatterns(patterns, targetMmaSync);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
 
@@ -79,8 +77,8 @@ struct LLVMGPUVectorToGPUPass final
       RewritePatternSet f32ToTF32patterns(funcOp.getContext());
       nvgpu::populateMmaSyncF32ToTF32Patterns(f32ToTF32patterns,
                                               nvgpu::MmaSyncF32Lowering::TF32);
-      if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                              std::move(f32ToTF32patterns)))) {
+      if (failed(applyPatternsGreedily(getOperation(),
+                                       std::move(f32ToTF32patterns)))) {
         return signalPassFailure();
       }
     } else {
@@ -95,7 +93,7 @@ struct LLVMGPUVectorToGPUPass final
       // swizzling optimization.
       RewritePatternSet pattern(funcOp.getContext());
       memref::populateFoldMemRefAliasOpPatterns(pattern);
-      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(pattern)))) {
+      if (failed(applyPatternsGreedily(funcOp, std::move(pattern)))) {
         return signalPassFailure();
       }
       swizzleSharedMemory(funcOp);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -606,8 +606,8 @@ transform_dialect::VectorWarpDistributionOp::applyToOne(
   });
   GreedyRewriteConfig config;
   config.listener = &listener;
-  if (failed(applyPatternsAndFoldGreedily(
-          target, std::move(preProcessingPatterns), config))) {
+  if (failed(applyPatternsGreedily(target, std::move(preProcessingPatterns),
+                                   config))) {
     return mlir::emitDefiniteFailure(target,
                                      "multi-reduce patterns failed to apply");
   }
@@ -618,8 +618,7 @@ transform_dialect::VectorWarpDistributionOp::applyToOne(
   unsigned subgroupSizeU = static_cast<unsigned>(subgroupSize.value());
   populatePropagateVectorDistribution(target, patterns,
                                       /*benefit=*/1, subgroupSizeU);
-  if (failed(
-          applyPatternsAndFoldGreedily(target, std::move(patterns), config))) {
+  if (failed(applyPatternsGreedily(target, std::move(patterns), config))) {
     return mlir::emitDefiniteFailure(
         target, "warp distribution patterns failed to apply");
   }
@@ -630,8 +629,7 @@ transform_dialect::VectorWarpDistributionOp::applyToOne(
   options.warpSyncronizationFn = warpSyncronizationFn;
   populateWarpExecuteOnLane0ToScf(target, endPatterns, options,
                                   /*benefit=*/0);
-  if (failed(applyPatternsAndFoldGreedily(target, std::move(endPatterns),
-                                          config))) {
+  if (failed(applyPatternsGreedily(target, std::move(endPatterns), config))) {
     return mlir::emitDefiniteFailure(
         target, "warp execute on lane 0 to scf patterns failed to apply");
   }
@@ -681,8 +679,7 @@ transform_dialect::VectorToMMAConversionOp::applyToOne(
   RewritePatternSet patterns(ctx);
   mlir::vector::populateCastAwayVectorLeadingOneDimPatterns(patterns);
   populatePrepareVectorToMMAPatterns(patterns, getUseMmaSync());
-  if (failed(
-          applyPatternsAndFoldGreedily(target, std::move(patterns), config))) {
+  if (failed(applyPatternsGreedily(target, std::move(patterns), config))) {
     target->emitOpError("vector to mma preparation patterns failed to apply");
     return emitDefaultDefiniteFailure(target);
   }
@@ -715,8 +712,8 @@ transform_dialect::VectorToMMAConversionOp::applyToOne(
   RewritePatternSet f32ToTF32patterns(funcOp.getContext());
   nvgpu::populateMmaSyncF32ToTF32Patterns(f32ToTF32patterns,
                                           nvgpu::MmaSyncF32Lowering::TF32);
-  if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(f32ToTF32patterns),
-                                          config)))
+  if (failed(
+          applyPatternsGreedily(funcOp, std::move(f32ToTF32patterns), config)))
     return mlir::emitDefiniteFailure(
         target, "vector to mma F32ToTF32 patterns failed to apply");
 
@@ -1414,8 +1411,7 @@ transform_dialect::EliminateGpuBarriersOp::applyToOne(
   });
   GreedyRewriteConfig config;
   config.listener = &listener;
-  if (failed(
-          applyPatternsAndFoldGreedily(target, std::move(patterns), config))) {
+  if (failed(applyPatternsGreedily(target, std::move(patterns), config))) {
     return emitDefaultSilenceableFailure(target);
   }
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
@@ -541,8 +541,7 @@ void ConvertToSPIRVPass::runOnOperation() {
   for (auto funcOp : moduleOp.getOps<mlir::FunctionOpInterface>()) {
     RewritePatternSet shapePatterns(context);
     shapePatterns.add<RemoveStaticDynamicCast>(context);
-    if (failed(
-            applyPatternsAndFoldGreedily(funcOp, std::move(shapePatterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(shapePatterns)))) {
       funcOp.emitOpError() << "failed running shape patterns";
       return signalPassFailure();
     }
@@ -562,8 +561,7 @@ void ConvertToSPIRVPass::runOnOperation() {
   for (auto funcOp : moduleOp.getOps<mlir::FunctionOpInterface>()) {
     RewritePatternSet narrowingPatterns(context);
     vector::populateVectorNarrowTypeRewritePatterns(narrowingPatterns);
-    if (failed(applyPatternsAndFoldGreedily(funcOp,
-                                            std::move(narrowingPatterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(narrowingPatterns)))) {
       funcOp.emitOpError() << "failed running narrowing patterns";
       return signalPassFailure();
     }
@@ -574,7 +572,7 @@ void ConvertToSPIRVPass::runOnOperation() {
     RewritePatternSet patterns(context);
     arith::populateExpandBFloat16Patterns(patterns);
     arith::BitcastOp::getCanonicalizationPatterns(patterns, context);
-    if (failed(applyPatternsAndFoldGreedily(moduleOp, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(moduleOp, std::move(patterns)))) {
       moduleOp.emitOpError() << "failed running bf16 extf/trunc patterns";
       return signalPassFailure();
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVBreakDownLargeVector.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVBreakDownLargeVector.cpp
@@ -157,8 +157,7 @@ struct SPIRVBreakDownLargeVectorPass final
         });
     vector::InsertOp::getCanonicalizationPatterns(patterns, context);
     vector::ExtractOp::getCanonicalizationPatterns(patterns, context);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEmulateI64.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEmulateI64.cpp
@@ -219,7 +219,7 @@ struct SPIRVEmulateI64Pass final
       vector::InsertStridedSliceOp::getCanonicalizationPatterns(patterns, ctx);
       vector::ShapeCastOp::getCanonicalizationPatterns(patterns, ctx);
 
-      if (failed(applyPatternsAndFoldGreedily(op, std::move(patterns))))
+      if (failed(applyPatternsGreedily(op, std::move(patterns))))
         return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEraseStorageBufferStaticShape.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEraseStorageBufferStaticShape.cpp
@@ -123,8 +123,7 @@ void EraseStorageBufferStaticShapePass::runOnOperation() {
   {
     RewritePatternSet patterns(&getContext());
     populateRemoveDeadMemAllocPatterns(patterns);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVFinalVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVFinalVectorLowering.cpp
@@ -61,7 +61,7 @@ public:
       vector::ExtractStridedSliceOp::getCanonicalizationPatterns(patterns,
                                                                  context);
       vector::populateVectorTransferPermutationMapLoweringPatterns(patterns);
-      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
         return signalPassFailure();
       }
     }
@@ -84,7 +84,7 @@ public:
       vector::populateVectorGatherLoweringPatterns(patterns);
       vector::populateVectorMaskOpLoweringPatterns(patterns);
       vector::CreateMaskOp::getCanonicalizationPatterns(patterns, context);
-      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
         return signalPassFailure();
       }
     }
@@ -102,7 +102,7 @@ public:
       populateVectorTransferTensorSliceTransforms(patterns);
       vector::ReductionOp::getCanonicalizationPatterns(patterns, context);
       scf::IfOp::getCanonicalizationPatterns(patterns, context);
-      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
         return signalPassFailure();
       }
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVInitialVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVInitialVectorLowering.cpp
@@ -300,7 +300,7 @@ public:
       RewritePatternSet patterns(context);
       // Pull in additional vectorization patterns in IREE.
       populateVectorizePadPatterns(patterns);
-      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
         return signalPassFailure();
       }
     }
@@ -323,7 +323,7 @@ public:
       // Fold transpose ops if possible as we cannot unroll it later.
       vector::TransposeOp::getCanonicalizationPatterns(patterns, context);
 
-      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
         return signalPassFailure();
       }
     }
@@ -359,7 +359,7 @@ public:
       vector::TransferWriteOp::getCanonicalizationPatterns(patterns, context);
       populateVectorTransferTensorSliceTransforms(patterns);
 
-      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
         return signalPassFailure();
       }
     }
@@ -383,7 +383,7 @@ public:
       RewritePatternSet patterns(context);
       vector::populateVectorMultiReductionLoweringPatterns(
           patterns, vector::VectorMultiReductionLowering::InnerParallel);
-      if (failed(applyOpPatternsAndFold(reductionOps, std::move(patterns)))) {
+      if (failed(applyOpPatternsGreedily(reductionOps, std::move(patterns)))) {
         funcOp.emitOpError("vector lowering failed");
         return signalPassFailure();
       }
@@ -396,7 +396,7 @@ public:
       RewritePatternSet patterns(context);
       vector::populateVectorContractCanonicalizeMatmulToMMT(
           patterns, detectI8ToI32Matmul);
-      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
         return signalPassFailure();
       }
 
@@ -408,7 +408,7 @@ public:
     {
       RewritePatternSet patterns(context);
       populateVectorUnrollPatterns(patterns, emitIntegerDotProdOps);
-      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
         return signalPassFailure();
       }
     }
@@ -430,7 +430,7 @@ public:
       // It also generates broadcast/extract ops. Clean up them too.
       vector::BroadcastOp::getCanonicalizationPatterns(patterns, context);
       vector::ExtractOp::getCanonicalizationPatterns(patterns, context);
-      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
         return signalPassFailure();
       }
     }
@@ -448,7 +448,7 @@ public:
               vector::VectorTransposeLowering::EltWise);
       vector::populateVectorTransposeLoweringPatterns(patterns, options);
       vector::populateVectorShapeCastLoweringPatterns(patterns);
-      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
         return signalPassFailure();
       }
     }
@@ -484,7 +484,7 @@ public:
       vector::TransferWriteOp::getCanonicalizationPatterns(patterns, context);
       populateVectorTransferTensorSliceTransforms(patterns);
 
-      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
         return signalPassFailure();
       }
     }
@@ -495,7 +495,7 @@ public:
     if (emitIntegerDotProdOps) {
       RewritePatternSet patterns(context);
       populateVectorReductionToSPIRVDotProductPatterns(patterns);
-      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
         return signalPassFailure();
       }
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndDistribute.cpp
@@ -160,8 +160,8 @@ void SPIRVTileAndDistributePass::runOnOperation() {
     populateFoldAffineMinInDistributedLoopsPatterns(canonicalizationPatterns,
                                                     numWorkgroups);
 
-    if (failed(applyPatternsAndFoldGreedily(
-            funcOp, std::move(canonicalizationPatterns)))) {
+    if (failed(applyPatternsGreedily(funcOp,
+                                     std::move(canonicalizationPatterns)))) {
       // TODO(#4759): This does not converge after the max number of iterations.
       // It indicates that some pattern upstream is generating ops even when the
       // pattern failed to match. Not related to correctness, but would be good
@@ -185,8 +185,8 @@ void SPIRVTileAndDistributePass::runOnOperation() {
     RewritePatternSet canonicalizationPatterns =
         linalg::getLinalgTilingCanonicalizationPatterns(context);
     scf::populateSCFForLoopCanonicalizationPatterns(canonicalizationPatterns);
-    if (failed(applyPatternsAndFoldGreedily(
-            funcOp, std::move(canonicalizationPatterns)))) {
+    if (failed(applyPatternsGreedily(funcOp,
+                                     std::move(canonicalizationPatterns)))) {
       funcOp.emitOpError() << "failing canonicalizing after tile reduction";
       return signalPassFailure();
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndPromote.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndPromote.cpp
@@ -164,7 +164,7 @@ void SPIRVTileAndPromotePass::runOnOperation() {
     RewritePatternSet patterns =
         linalg::getLinalgTilingCanonicalizationPatterns(context);
     scf::populateSCFForLoopCanonicalizationPatterns(patterns);
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       return signalPassFailure();
     }
   }
@@ -203,8 +203,7 @@ void SPIRVTileAndPromotePass::runOnOperation() {
 
     RewritePatternSet promotionPatterns(context);
     populatePromotionPatterns(promotionPatterns, workgroupMarker);
-    if (failed(applyPatternsAndFoldGreedily(funcOp,
-                                            std::move(promotionPatterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(promotionPatterns)))) {
       return signalPassFailure();
     }
 
@@ -254,7 +253,7 @@ void SPIRVTileAndPromotePass::runOnOperation() {
         linalg::getLinalgTilingCanonicalizationPatterns(context);
     SmallVector<int64_t> numWorkgroups = getStaticNumWorkgroups(funcOp);
     populateFoldAffineMinInDistributedLoopsPatterns(patterns, numWorkgroups);
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       // TODO(#4759): This does not converge after the max number of iterations.
       // It indicates that some pattern upstream is generating ops even when the
       // pattern failed to match. Not related to correctness, but would be good
@@ -319,7 +318,7 @@ LogicalResult SPIRVTileAndPromotePass::doPromoteCMatrix(
   // Finally do promote C matrix.
   RewritePatternSet patterns(context);
   populateContractPromotionPatterns(patterns, {2});
-  if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+  if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
     return failure();
   }
   LLVM_DEBUG({

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndVectorizeToCooperativeOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndVectorizeToCooperativeOps.cpp
@@ -383,8 +383,8 @@ public:
       SmallVector<int64_t> numWorkgroups = getStaticNumWorkgroups(funcOp);
       populateFoldAffineMinInDistributedLoopsPatterns(canonicalizationPatterns,
                                                       numWorkgroups);
-      if (failed(applyPatternsAndFoldGreedily(
-              funcOp, std::move(canonicalizationPatterns)))) {
+      if (failed(applyPatternsGreedily(funcOp,
+                                       std::move(canonicalizationPatterns)))) {
         return signalPassFailure();
       }
     }
@@ -424,7 +424,7 @@ public:
       populateCombineVectorTransferReadBroadcastPatterns(patterns);
       populatePrepareVectorToMMAPatterns(patterns,
                                          /*useNvGPU=*/false);
-      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
         return signalPassFailure();
       }
     }
@@ -434,7 +434,7 @@ public:
     {
       RewritePatternSet patterns(context);
       populateVectorUnrollPatterns(cooperativeOpSize, patterns);
-      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
         return signalPassFailure();
       }
     }
@@ -447,7 +447,7 @@ public:
     {
       RewritePatternSet patterns(context);
       patterns.add<CombineContractTranspose>(context);
-      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
         return signalPassFailure();
       }
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorToGPUSubgroupMMAOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorToGPUSubgroupMMAOps.cpp
@@ -32,16 +32,14 @@ struct SPIRVVectorToGPUSubgroupMMAPass final
 
     RewritePatternSet flatternpatterns(funcOp.getContext());
     populateVectorTransferToGPUMMAPreparationPatterns(flatternpatterns);
-    if (failed(applyPatternsAndFoldGreedily(funcOp,
-                                            std::move(flatternpatterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(flatternpatterns)))) {
       return signalPassFailure();
     }
 
     RewritePatternSet patterns(funcOp.getContext());
     mlir::vector::populateCastAwayVectorLeadingOneDimPatterns(patterns);
     populatePrepareVectorToMMAPatterns(patterns, /*useNvGpu=*/false);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
@@ -1099,8 +1099,7 @@ void SPIRVVectorizeLoadStorePass::runOnOperation() {
                         ScalarizeVectorTransferWrite>(context);
   rewritingPatterns.add<ReifyExtractOfCreateMask>(context);
 
-  if (failed(
-          applyPatternsAndFoldGreedily(funcOp, std::move(rewritingPatterns)))) {
+  if (failed(applyPatternsGreedily(funcOp, std::move(rewritingPatterns)))) {
     return signalPassFailure();
   }
 }

--- a/compiler/src/iree/compiler/Codegen/Transforms/AffineMinDistributedSCFCanonicalization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/AffineMinDistributedSCFCanonicalization.cpp
@@ -205,7 +205,7 @@ struct AffineMinDistributedSCFCanonicalizationPass
     funcOp.walk([&minOps](affine::AffineMinOp minOp) {
       minOps.push_back(minOp.getOperation());
     });
-    (void)applyOpPatternsAndFold(minOps, frozenPatterns);
+    (void)applyOpPatternsGreedily(minOps, frozenPatterns);
   }
 };
 } // namespace

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -504,8 +504,7 @@ LogicalResult setDefaultCustomOpLoweringConfig(
   memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);
   GreedyRewriteConfig config;
   config.listener = &customOpConfigListener;
-  if (failed(applyPatternsAndFoldGreedily(dummyFuncOp, std::move(patterns),
-                                          config))) {
+  if (failed(applyPatternsGreedily(dummyFuncOp, std::move(patterns), config))) {
     return customOp.emitOpError(
         "failed to canonicalize during custom op configuration setting");
   }

--- a/compiler/src/iree/compiler/Codegen/VMVX/VMVXLowerLinalgMicrokernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/VMVXLowerLinalgMicrokernels.cpp
@@ -937,8 +937,7 @@ class VMVXLowerLinalgMicrokernelsPass
                 LinalgTrivialGenericConversion, LinalgUnaryGenericConversion>(
             &getContext());
 
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Canonicalizer.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Canonicalizer.cpp
@@ -113,7 +113,7 @@ struct CanonicalizerPass
   void runOnOperation() override {
     // Canonicalization is best-effort. Non-convergence is not a pass failure.
     LogicalResult didConverge =
-        applyPatternsAndFoldGreedily(getOperation(), *patterns, config);
+        applyPatternsGreedily(getOperation(), *patterns, config);
     if (this->testConvergence && failed(didConverge)) {
       getOperation()->emitError("Canonicalizer failed to converge");
       return signalPassFailure();

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertMeshToFlow.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertMeshToFlow.cpp
@@ -268,7 +268,7 @@ convertCollectives(ModuleOp moduleOp,
                                            useNamedDefaultChannels, builder);
         }
       });
-  return applyPatternsAndFoldGreedily(moduleOp, std::move(patterns));
+  return applyPatternsGreedily(moduleOp, std::move(patterns));
 }
 
 static void removeMeshOps(MeshAndAxesSet &meshAndAxesSet) {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertToFlow.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertToFlow.cpp
@@ -30,8 +30,8 @@ struct ConvertToFlowPass
                                                        convertToFlowPatterns);
     memref::populateResolveRankedShapedTypeResultDimsPatterns(
         convertToFlowPatterns);
-    if (failed(applyPatternsAndFoldGreedily(
-            getOperation(), std::move(convertToFlowPatterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(),
+                                     std::move(convertToFlowPatterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/InitializeEmptyTensors.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/InitializeEmptyTensors.cpp
@@ -94,8 +94,7 @@ struct InitializeEmptyTensorsPass
     } else {
       patterns.insert<RewriteTensorEmptyToEmpty>(context);
     }
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
@@ -560,7 +560,7 @@ convertDispatchWorkgroupInfoOps(IREE::HAL::ExecutableOp executableOp) {
       ConvertDispatchWorkgroupInfoPattern<IREE::Stream::DispatchWorkgroupSizeOp,
                                           IREE::HAL::InterfaceWorkgroupSizeOp>,
       InlineConstantWorkgroupSizePattern>(executableOp.getContext());
-  return applyPatternsAndFoldGreedily(executableOp, std::move(patterns));
+  return applyPatternsGreedily(executableOp, std::move(patterns));
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConv2DToIm2ColOp.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConv2DToIm2ColOp.cpp
@@ -317,8 +317,7 @@ struct ConvertConv2DToIm2ColOpPass final
   void runOnOperation() override {
     RewritePatternSet patterns(&getContext());
     populateConv2DToIm2colOpPatterns(patterns);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConv2DToWinograd.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConv2DToWinograd.cpp
@@ -420,8 +420,7 @@ struct ConvertConv2DToWinogradPass final
     patterns.insert<ConvertConvToWinograd<linalg::Conv2DNhwcHwcfOp>,
                     ConvertConvToWinograd<linalg::Conv2DNchwFchwOp>>(
         context, /*replaceAllConvs=*/replaceAllConvs);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertToLoops.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertToLoops.cpp
@@ -113,8 +113,7 @@ struct LinalgExtToLoopsPass final
 
     RewritePatternSet patterns(context);
     patterns.insert<TilingInterfaceLowerToLoopsPattern>(context);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeIm2col.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeIm2col.cpp
@@ -89,8 +89,7 @@ void DecomposeIm2colPass::runOnOperation() {
 
   RewritePatternSet patterns(context);
   memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);
-  if (failed(
-          applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
+  if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
     return signalPassFailure();
   }
 }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeWinogradPass.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/DecomposeWinogradPass.cpp
@@ -360,8 +360,7 @@ void DecomposeWinogradTransformPass::runOnOperation() {
   patterns.add<DecomposeWinogradFilterTransform>(context);
   patterns.add<DecomposeWinogradInputTransform>(context);
   patterns.add<DecomposeWinogradOutputTransform>(context);
-  if (failed(
-          applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
+  if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
     return signalPassFailure();
   }
 }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/EncodeTensors.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/EncodeTensors.cpp
@@ -604,7 +604,7 @@ struct EncodeHostTensorsPass
         EncodeTensorUpdateOp, EncodeTensorLoadOp, EncodeTensorStoreOp>(
         &getContext());
     FrozenRewritePatternSet frozenPatterns(std::move(patterns));
-    if (failed(applyPatternsAndFoldGreedily(getOperation(), frozenPatterns))) {
+    if (failed(applyPatternsGreedily(getOperation(), frozenPatterns))) {
       return signalPassFailure();
     }
   }
@@ -735,7 +735,7 @@ struct EncodeDeviceTensorsPass
     patterns.insert<EncodeBindingSubspanOp, EncodeDispatchTensorLoadOp,
                     EncodeDispatchTensorStoreOp>(&getContext());
     FrozenRewritePatternSet frozenPatterns(std::move(patterns));
-    if (failed(applyPatternsAndFoldGreedily(getOperation(), frozenPatterns))) {
+    if (failed(applyPatternsGreedily(getOperation(), frozenPatterns))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/RefineUsage.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/RefineUsage.cpp
@@ -462,8 +462,8 @@ struct RefineUsagePass
     FrozenRewritePatternSet frozenPatterns(std::move(patterns));
     GreedyRewriteConfig rewriteConfig;
     rewriteConfig.useTopDownTraversal = true;
-    if (failed(applyPatternsAndFoldGreedily(moduleOp, frozenPatterns,
-                                            rewriteConfig))) {
+    if (failed(
+            applyPatternsGreedily(moduleOp, frozenPatterns, rewriteConfig))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
@@ -348,7 +348,7 @@ struct ScheduleExecutionPass
       op.getCanonicalizationPatterns(patterns, context);
     }
     FrozenRewritePatternSet frozenPatterns(std::move(patterns));
-    if (failed(applyPatternsAndFoldGreedily(getOperation(), frozenPatterns))) {
+    if (failed(applyPatternsGreedily(getOperation(), frozenPatterns))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/ApplyPatterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/ApplyPatterns.cpp
@@ -43,7 +43,7 @@ public:
     IREE::Util::populateCommonPatterns(context, patterns);
 
     FrozenRewritePatternSet frozenPatterns(std::move(patterns));
-    if (failed(applyPatternsAndFoldGreedily(getOperation(), frozenPatterns))) {
+    if (failed(applyPatternsGreedily(getOperation(), frozenPatterns))) {
       getOperation()->emitError()
           << "failed to apply patterns, likely due to a bad pattern that "
              "causes an infinite fixed point iteration";

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/DropCompilerHints.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/DropCompilerHints.cpp
@@ -21,7 +21,7 @@ class DropCompilerHintsPass
     : public impl::DropCompilerHintsPassBase<DropCompilerHintsPass> {
 public:
   void runOnOperation() override {
-    // We can't use patterns and applyPatternsAndFoldGreedily because that
+    // We can't use patterns and applyPatternsGreedily because that
     // automatically does canonicalization.
     getOperation()->walk([&](Operation *genericOp) {
       if (auto op = dyn_cast<IREE::Util::OptimizationBarrierOp>(genericOp)) {

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/FoldGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/FoldGlobals.cpp
@@ -372,7 +372,7 @@ public:
     beforeFoldingGlobals = globalTable.size();
     for (int i = 0; i < 10; ++i) {
       // TODO(benvanik): determine if we need this expensive folding.
-      if (failed(applyPatternsAndFoldGreedily(moduleOp, frozenPatterns))) {
+      if (failed(applyPatternsGreedily(moduleOp, frozenPatterns))) {
         signalPassFailure();
         return;
       }

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/OptimizeIntArithmetic.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/OptimizeIntArithmetic.cpp
@@ -363,8 +363,7 @@ class OptimizeIntArithmeticPass
       LLVM_DEBUG(
           dbgs() << "  * Finished Running Solver -- Applying Patterns\n");
       bool changed = false;
-      if (failed(applyPatternsAndFoldGreedily(op, frozenPatterns, config,
-                                              &changed))) {
+      if (failed(applyPatternsGreedily(op, frozenPatterns, config, &changed))) {
         emitError(op->getLoc())
             << "int arithmetic optimization failed to converge on iteration "
             << i;

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/DropUnusedCalls.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/DropUnusedCalls.cpp
@@ -87,8 +87,7 @@ public:
     patterns.insert<EraseUnusedCallOp<IREE::VM::CallOp>,
                     EraseUnusedCallOp<IREE::VM::CallVariadicOp>>(
         &getContext(), noSideEffectsSymbols);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/ResolveBufferDescriptors.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/ResolveBufferDescriptors.cpp
@@ -422,8 +422,7 @@ public:
     patterns.insert<FromAllocation, FromGlobal, FromHalInterfaceBindingSubspan,
                     FromMemRefSubView>(&getContext());
 
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
 

--- a/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
@@ -207,9 +207,9 @@ void BubbleUpExpandShapesPass::runOnOperation() {
 
   GreedyRewriteConfig rewriteConfig;
   rewriteConfig.maxIterations = GreedyRewriteConfig::kNoLimit;
-  if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                          std::move(bubbleExpandShapePatterns),
-                                          rewriteConfig))) {
+  if (failed(applyPatternsGreedily(getOperation(),
+                                   std::move(bubbleExpandShapePatterns),
+                                   rewriteConfig))) {
     getOperation()->emitOpError("Failed to perform elementwise operations");
     return signalPassFailure();
   }

--- a/compiler/src/iree/compiler/DispatchCreation/BubbleUpExtractSlices.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/BubbleUpExtractSlices.cpp
@@ -149,8 +149,7 @@ struct BubbleUpExtractSlicesPass
       patterns.insert<BubbleUpExtract>(context);
       patterns.insert<SwapExtractSliceOfFill>(context);
       tensor::populateFoldTensorEmptyPatterns(patterns, false);
-      if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                              std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
         return signalPassFailure();
       }
     }

--- a/compiler/src/iree/compiler/DispatchCreation/CollapseDimensions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/CollapseDimensions.cpp
@@ -1042,7 +1042,7 @@ void CollapseDimensionsPass::runOnOperation() {
       }
     });
     if (failed(
-            applyOpPatternsAndFold(candidateOps, std::move(moveReshapeOps)))) {
+            applyOpPatternsGreedily(candidateOps, std::move(moveReshapeOps)))) {
       funcOp.emitOpError(
           "failed to propagate reshape ops introduced during collapse");
       return signalPassFailure();

--- a/compiler/src/iree/compiler/DispatchCreation/CollapseReductionDimensions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/CollapseReductionDimensions.cpp
@@ -74,8 +74,7 @@ struct CollapseReductionDimensionsPass final
   void runOnOperation() override {
     RewritePatternSet patterns(&getContext());
     linalg::populateCollapseDimensions(patterns, collapseDimensions);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/DispatchCreation/ConvertTensorToFlow.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/ConvertTensorToFlow.cpp
@@ -191,8 +191,7 @@ void ConvertTensorToFlowPass::runOnOperation() {
       convertToFlowPatterns, context);
   IREE::Flow::TensorBitCastOp::getCanonicalizationPatterns(
       convertToFlowPatterns, context);
-  if (failed(applyPatternsAndFoldGreedily(funcOp,
-                                          std::move(convertToFlowPatterns)))) {
+  if (failed(applyPatternsGreedily(funcOp, std::move(convertToFlowPatterns)))) {
     funcOp->emitOpError("failed conversion to flow.tensor ops");
     return signalPassFailure();
   }
@@ -202,8 +201,8 @@ void ConvertTensorToFlowPass::runOnOperation() {
   RewritePatternSet foldExtractInsertSliceOps(context);
   IREE::Flow::populateTensorSliceOpWithDispatchTensorOpFoldingPatterns(
       foldExtractInsertSliceOps, context);
-  if (failed(applyPatternsAndFoldGreedily(
-          funcOp, std::move(foldExtractInsertSliceOps)))) {
+  if (failed(applyPatternsGreedily(funcOp,
+                                   std::move(foldExtractInsertSliceOps)))) {
     funcOp->emitOpError("failed to insert/extract_slice with "
                         "flow.dispatch.tensor.load/store");
     return signalPassFailure();

--- a/compiler/src/iree/compiler/DispatchCreation/ElementwiseOpFusion.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/ElementwiseOpFusion.cpp
@@ -141,7 +141,7 @@ void ElementwiseOpFusionPass::runOnOperation() {
 
   GreedyRewriteConfig rewriteConfig;
   rewriteConfig.maxIterations = GreedyRewriteConfig::kNoLimit;
-  if (failed(applyPatternsAndFoldGreedily(
+  if (failed(applyPatternsGreedily(
           getOperation(), std::move(linalgFusionPatterns), rewriteConfig))) {
     getOperation()->emitOpError(
         "Failed to fuse elementwise ops with upstream patterns.");
@@ -159,7 +159,7 @@ void ElementwiseOpFusionPass::runOnOperation() {
   IREE::LinalgExt::populateFuseLinalgExtOpsWithTransposes(
       linalgExtFusionPatterns, foldTransposeControlFn);
   linalgExtFusionPatterns.insert<GatherFusionPattern>(context);
-  if (failed(applyPatternsAndFoldGreedily(
+  if (failed(applyPatternsGreedily(
           getOperation(), std::move(linalgExtFusionPatterns), rewriteConfig))) {
     getOperation()->emitOpError(
         "Failed to fuse elementwise ops with linalgExt patterns.");

--- a/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
@@ -155,8 +155,8 @@ void FoldUnitExtentDimsPass::runOnOperation() {
   };
   linalg::populateFoldUnitExtentDimsPatterns(foldUnitDimsPatterns, options);
   linalg::populateMoveInitOperandsToInputPattern(foldUnitDimsPatterns);
-  if (failed(applyPatternsAndFoldGreedily(moduleOp,
-                                          std::move(foldUnitDimsPatterns)))) {
+  if (failed(
+          applyPatternsGreedily(moduleOp, std::move(foldUnitDimsPatterns)))) {
     return signalPassFailure();
   }
 }

--- a/compiler/src/iree/compiler/DispatchCreation/FuseEncodingOpsIntoDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FuseEncodingOpsIntoDispatchRegions.cpp
@@ -89,7 +89,7 @@ struct FuseEncodingOpsIntoDispatchRegionsPass
     // producer dispatch regions, so we need to resolve tensor.dim ops.
     RewritePatternSet patterns(context);
     memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/DispatchCreation/FuseHorizontalContractions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FuseHorizontalContractions.cpp
@@ -652,8 +652,8 @@ void FuseHorizontalContractionsPass::runOnOperation() {
     RewritePatternSet foldReshapePatterns(context);
     tensor::populateFoldTensorEmptyPatterns(foldReshapePatterns);
     linalg::FillOp::getCanonicalizationPatterns(foldReshapePatterns, context);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(foldReshapePatterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(),
+                                     std::move(foldReshapePatterns)))) {
       getOperation()->emitOpError("failed during reshape folding patterns");
       return signalPassFailure();
     }
@@ -661,8 +661,8 @@ void FuseHorizontalContractionsPass::runOnOperation() {
     RewritePatternSet foldPatterns(context);
     tensor::populateFoldTensorEmptyPatterns(foldPatterns);
     linalg::FillOp::getCanonicalizationPatterns(foldPatterns, context);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(foldPatterns)))) {
+    if (failed(
+            applyPatternsGreedily(getOperation(), std::move(foldPatterns)))) {
       getOperation()->emitOpError("failed to fold empty/fill with concats");
       return signalPassFailure();
     }
@@ -673,8 +673,7 @@ void FuseHorizontalContractionsPass::runOnOperation() {
   // these patterns should be dropped.
   RewritePatternSet patterns(context);
   tensor::populateDecomposeTensorConcatPatterns(patterns);
-  if (failed(
-          applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
+  if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
     return signalPassFailure();
   }
 }

--- a/compiler/src/iree/compiler/DispatchCreation/FuseMultiUseElementwiseProducer.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FuseMultiUseElementwiseProducer.cpp
@@ -239,7 +239,7 @@ static FailureOr<unsigned> fuseMultiUseProducers(Operation *funcOp,
 
   RewritePatternSet fusionPatterns(context);
   linalg::populateEraseUnusedOperandsAndResultsPatterns(fusionPatterns);
-  if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(fusionPatterns)))) {
+  if (failed(applyPatternsGreedily(funcOp, std::move(fusionPatterns)))) {
     return funcOp->emitOpError("multi use producer -> consumer fusion failed");
   }
   return fusedOps.size();

--- a/compiler/src/iree/compiler/DispatchCreation/FusionPreprocessing.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FusionPreprocessing.cpp
@@ -161,8 +161,7 @@ struct FusionPreprocessingPass final
     memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);
     memref::populateResolveShapedTypeResultDimsPatterns(patterns);
     tensor::populateFoldIntoPackAndUnpackPatterns(patterns);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
@@ -189,8 +189,7 @@ void HoistEncodingOpsPass::runOnOperation() {
 
   RewritePatternSet bubblingPatterns(ctx);
   bubblingPatterns.insert<BubbleUpSetEncodingOp>(ctx);
-  if (failed(
-          applyPatternsAndFoldGreedily(funcOp, std::move(bubblingPatterns)))) {
+  if (failed(applyPatternsGreedily(funcOp, std::move(bubblingPatterns)))) {
     return signalPassFailure();
   }
 
@@ -210,7 +209,7 @@ void HoistEncodingOpsPass::runOnOperation() {
   RewritePatternSet cleanPatterns(ctx);
   memref::populateResolveRankedShapedTypeResultDimsPatterns(cleanPatterns);
   IREE::Flow::DispatchRegionOp::getCanonicalizationPatterns(cleanPatterns, ctx);
-  if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(cleanPatterns)))) {
+  if (failed(applyPatternsGreedily(funcOp, std::move(cleanPatterns)))) {
     return signalPassFailure();
   }
 }

--- a/compiler/src/iree/compiler/DispatchCreation/SetEncoding.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SetEncoding.cpp
@@ -277,8 +277,7 @@ struct SetEncodingPass final
     linalg::FillOp::getCanonicalizationPatterns(patterns, context);
     patterns.insert<FoldFillWithSetEncoding>(context);
     memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/DispatchCreation/SinkReshapes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SinkReshapes.cpp
@@ -169,8 +169,8 @@ void SinkReshapesPass::runOnOperation() {
                                                      shouldSinkExpandShapeOp);
   // Add patterns to fold `tensor.empty` and reshape ops.
   tensor::populateFoldTensorEmptyPatterns(sinkReshapePatterns);
-  if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                          std::move(sinkReshapePatterns)))) {
+  if (failed(applyPatternsGreedily(getOperation(),
+                                   std::move(sinkReshapePatterns)))) {
     getOperation()->emitOpError("failed to sink reshape ops");
     return signalPassFailure();
   }

--- a/compiler/src/iree/compiler/DispatchCreation/TensorPadToTensorInsertSlice.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/TensorPadToTensorInsertSlice.cpp
@@ -92,8 +92,7 @@ struct TensorPadToTensorInsertSlicePass final
     MLIRContext *context = &getContext();
     RewritePatternSet patterns(context);
     patterns.insert<TensorPadOpConversion>(context, skipSingleLinalgOpUses);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/DispatchCreation/TransposeGenericOps.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/TransposeGenericOps.cpp
@@ -119,8 +119,7 @@ struct TransposeGenericOpsPass final
     RewritePatternSet patterns(&getContext());
     patterns.add<MakeReductionInnermostPattern, TransposeGenericOpPattern>(
         &getContext());
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/GlobalOptimization/Convert1X1FilterConv2DToMatmul.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Convert1X1FilterConv2DToMatmul.cpp
@@ -89,8 +89,7 @@ struct Convert1X1FilterConv2DToMatmulPass
     patterns.insert<Convert1x1FilterConvToMatmul<linalg::Conv2DNhwcHwcfOp>,
                     Convert1x1FilterConvToMatmul<linalg::Conv2DNchwFchwOp>>(
         context);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/GlobalOptimization/DataLayoutPropagation.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/DataLayoutPropagation.cpp
@@ -35,7 +35,7 @@ struct DataLayoutPropagationPass
           }
           return false;
         });
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
       funcOp.emitOpError("folding patterns failed");
       return signalPassFailure();
     }

--- a/compiler/src/iree/compiler/GlobalOptimization/DecomposeConcat.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/DecomposeConcat.cpp
@@ -127,8 +127,7 @@ struct DecomposeConcatPass
     if (enableConcatTransposition) {
       patterns.insert<TransposeInnerConcatenation>(context, /*benefit=*/2);
     }
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/GlobalOptimization/DemoteContractionInputsToBF16.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/DemoteContractionInputsToBF16.cpp
@@ -148,8 +148,7 @@ public:
     RewritePatternSet patterns(context);
     patterns.insert<DemoteContractionInputsToBF16Pattern>(
         context, demoteOnly.getValue());
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/GlobalOptimization/DetachElementwiseFromNamedOps.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/DetachElementwiseFromNamedOps.cpp
@@ -194,8 +194,7 @@ struct DetachElementwiseFromNamedOpsPass
                  DetachSplatConstantOutsOperands<IREE::LinalgExt::LinalgExtOp>,
                  DetachSplatConstantOutsOperands<linalg::LinalgOp>>(
         &getContext());
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/GlobalOptimization/EraseUnusedLinalgOperands.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/EraseUnusedLinalgOperands.cpp
@@ -24,8 +24,7 @@ struct EraseUnusedLinalgOperandsPass
     MLIRContext *context = &getContext();
     RewritePatternSet patterns(context);
     linalg::populateEraseUnusedOperandsAndResultsPatterns(patterns);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/GlobalOptimization/FuseSiluHorizontalMatmul.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/FuseSiluHorizontalMatmul.cpp
@@ -185,8 +185,7 @@ void FuseSiluHorizontalMatmulPass::runOnOperation() {
 
   RewritePatternSet patterns(context);
   patterns.insert<FuseSiluHorizontalMatmulPattern>(context);
-  if (failed(
-          applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
+  if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
     return signalPassFailure();
   }
 }

--- a/compiler/src/iree/compiler/GlobalOptimization/OptimizeNumerics.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/OptimizeNumerics.cpp
@@ -269,8 +269,7 @@ class OptimizeNumericsPass
     patterns.insert<TensorEmptyCast>(context);
     patterns.insert<LinalgFillCast>(context);
 
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
@@ -1038,8 +1038,7 @@ void PropagateLinalgTransposePass::runOnOperation() {
     populateCommonCanonicalizationPatterns(context, sinkingPatterns);
     sinkingPatterns.add<SinkTransposeThroughUnaryElementwiseInput>(
         context, /*benefit=*/2);
-    if (failed(
-            applyPatternsAndFoldGreedily(funcOp, std::move(sinkingPatterns)))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(sinkingPatterns)))) {
       funcOp.emitError("Transpose initial sinking patterns failed");
       return signalPassFailure();
     }
@@ -1107,8 +1106,8 @@ void PropagateLinalgTransposePass::runOnOperation() {
 
     GreedyRewriteConfig config;
     config.maxIterations = GreedyRewriteConfig::kNoLimit;
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(bubblingPatterns),
-                                            config))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(bubblingPatterns),
+                                     config))) {
       funcOp.emitError("Transpose bubbling patterns failed");
       return signalPassFailure();
     }
@@ -1166,8 +1165,8 @@ void PropagateLinalgTransposePass::runOnOperation() {
     // TODO: This is inefficient. Consider rewriting this pass to use a
     // worklist of just the transpose operations.
     config.maxIterations = GreedyRewriteConfig::kNoLimit;
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(sinkingPatterns),
-                                            config))) {
+    if (failed(applyPatternsGreedily(funcOp, std::move(sinkingPatterns),
+                                     config))) {
       funcOp.emitError("Transpose sinking patterns failed");
       return signalPassFailure();
     }

--- a/compiler/src/iree/compiler/GlobalOptimization/QuantizedConvToConv.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/QuantizedConvToConv.cpp
@@ -350,7 +350,7 @@ public:
     patterns.add<QuantizedConvToConv, QuantizedDepthwiseConvToDepthwiseConv>(
         context);
     memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);
-    if (failed(applyPatternsAndFoldGreedily(op, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(op, std::move(patterns)))) {
       signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/GlobalOptimization/QuantizedMatmulToMatmul.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/QuantizedMatmulToMatmul.cpp
@@ -186,7 +186,7 @@ public:
     RewritePatternSet patterns(context);
     patterns.add<QuantizedMatmulToMatmul>(context);
     memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);
-    if (failed(applyPatternsAndFoldGreedily(op, std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(op, std::move(patterns)))) {
       signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/GlobalOptimization/RaiseSpecialOps.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/RaiseSpecialOps.cpp
@@ -1053,7 +1053,7 @@ struct RaiseSpecialOpsPass
       patterns.insert<InsertSliceNegateAndSlicePattern>(context);
       patterns.insert<ConcatenateNegateAndSlicePattern>(context);
       patterns.insert<RaiseInsertSliceToPad>(context);
-      if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
         return signalPassFailure();
       }
     }

--- a/compiler/src/iree/compiler/GlobalOptimization/RemoveZeroExtentTensors.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/RemoveZeroExtentTensors.cpp
@@ -97,7 +97,7 @@ void RemoveZeroExtentTensorsPass::runOnOperation() {
   RewritePatternSet patterns(context);
   patterns.insert<FoldZeroExtentInserts, ReplaceZeroExtentOperands>(context);
   memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);
-  if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+  if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
     funcOp->emitOpError("failed to run canonicalizations (proxy for DCE)");
     return signalPassFailure();
   }

--- a/compiler/src/iree/compiler/GlobalOptimization/SimplifyPackUnpack.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/SimplifyPackUnpack.cpp
@@ -26,8 +26,7 @@ void SimplifyPackUnpackPass::runOnOperation() {
   MLIRContext *context = &getContext();
   RewritePatternSet patterns(context);
   tensor::populateSimplifyPackAndUnpackPatterns(patterns);
-  if (failed(
-          applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
+  if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
     return signalPassFailure();
   }
 }

--- a/compiler/src/iree/compiler/Preprocessing/Common/ApplyPDLPatterns.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/ApplyPDLPatterns.cpp
@@ -558,7 +558,7 @@ public:
 
     // Apply the patterns.
     auto operation = getOperation();
-    if (failed(applyPatternsAndFoldGreedily(operation, patterns))) {
+    if (failed(applyPatternsGreedily(operation, patterns))) {
       operation->emitOpError("failed to apply patterns specified in ")
           << patternsFile;
       return signalPassFailure();

--- a/compiler/src/iree/compiler/Preprocessing/Common/ConvertConv2DToImg2Col.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/ConvertConv2DToImg2Col.cpp
@@ -560,8 +560,7 @@ class ConvertConv2DToImg2ColPass
     RewritePatternSet patterns(&getContext());
     patterns.insert<ConvertConv2DNhwcHwcf, ConvertDepthwiseConv2DNhwcHwc,
                     ConvertConv2DNchwFchw>(context);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvToChannelsLast.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvToChannelsLast.cpp
@@ -671,7 +671,7 @@ public:
         patterns.insert<ConvertLinalgConvNchwFchw>(context);
       }
       patterns.insert<ConvertLinalgConvOp>(context, tilingFactor);
-      if (failed(applyPatternsAndFoldGreedily(op, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(op, std::move(patterns)))) {
         return signalPassFailure();
       }
     }
@@ -687,8 +687,7 @@ public:
       config.maxIterations = GreedyRewriteConfig::kNoLimit;
       linalg::populateDataLayoutPropagationPatterns(
           patterns, [](OpOperand *opOperand) { return true; });
-      if (failed(
-              applyPatternsAndFoldGreedily(op, std::move(patterns), config))) {
+      if (failed(applyPatternsGreedily(op, std::move(patterns), config))) {
         return signalPassFailure();
       }
     }
@@ -701,7 +700,7 @@ public:
       tensor::PackOp::getCanonicalizationPatterns(patterns, context);
       tensor::UnPackOp::getCanonicalizationPatterns(patterns, context);
       linalg::FillOp::getCanonicalizationPatterns(patterns, context);
-      if (failed(applyPatternsAndFoldGreedily(op, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(op, std::move(patterns)))) {
         return signalPassFailure();
       }
     }
@@ -715,7 +714,7 @@ public:
       RewritePatternSet patterns(context);
       patterns.insert<GeneralizeOuterUnitDimsPackOp>(context);
       patterns.insert<GeneralizeOuterUnitDimsUnPackOp>(context);
-      if (failed(applyPatternsAndFoldGreedily(op, std::move(patterns)))) {
+      if (failed(applyPatternsGreedily(op, std::move(patterns)))) {
         return signalPassFailure();
       }
     }

--- a/compiler/src/iree/compiler/Preprocessing/Common/FoldAttentionWithTranspose.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/FoldAttentionWithTranspose.cpp
@@ -192,8 +192,7 @@ struct FoldAttentionWithTransposePass
     MLIRContext *context = &getContext();
     RewritePatternSet patterns(context);
     patterns.insert<FoldAttentionAndTranspose>(context);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Preprocessing/Common/PadLinalgOps.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/PadLinalgOps.cpp
@@ -165,8 +165,7 @@ public:
     MLIRContext *context = &getContext();
     RewritePatternSet patterns(context);
     patterns.insert<PadMatmulOp>(context, paddingSize);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Preprocessing/Common/TransposeMatmul.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/TransposeMatmul.cpp
@@ -25,8 +25,7 @@ struct TransposeMatmulPass
 
     RewritePatternSet patterns(&getContext());
     linalg::populateTransposeMatmulPatterns(patterns, transposeLHS);
-    if (failed(applyPatternsAndFoldGreedily(getOperation(),
-                                            std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }
   }


### PR DESCRIPTION
Update LLVM to llvm/llvm-project@ac8bb735. C++ changes are related to change in behavior of TypeConverter changed in 
 https://github.com/iree-org/llvm-project/commit/3cc311ab8674eab6b9101cdf3823b55ea23d6535. It used to generate UnrealizedConversionCastOp, during applySignatureConversion in GenericOpTypePropagation of TypePropagationPass.cpp, however now it's not. This causes unrealized_conversion_cast to be generated later and hence survive the pass. To repro above behavior, try undo the C++ change in this PR and then:

```
wget https://gist.githubusercontent.com/raikonenfnu/dfb3b274007df8c4be87daf9ee67a5f4/raw/e48cc07e5fa558cd2c450b0e3ae46568136e1be6/type_propagate_repro.mlir
iree-opt --pass-pipeline='builtin.module(func.func(iree-codegen-type-propagation))' propagate_test.mlir -o /dev/null

error: failed to legalize unresolved materialization from ('i8') to ('i1') that remained live after conversion
  ^bb0(%in: i1, %in_0: f32, %in_1: f32, %out: f32):
       ^
propagate_test.mlir:5:8: note: see current operation: %10 = "builtin.unrealized_conversion_cast"(%arg0) : (i8) -> i1
propagate_test.mlir:6:11: note: see existing live user here: %10 = arith.select %9, %in_0, %in_1 : f32
```

Additionally, we made API changes in 6ed89249d91e1e60931f43305f609ed46c20e16e from: 
1. `applyPatternsAndFoldGreedily` -> `applyPatternsGreedily`
2. `applyOpPatternsAndFold` -> `applyOpPatternsGreedily`
To resolve depracated API error in bazel 

This PR also carries the following reverts:

https://github.com/llvm/llvm-project/pull/119461

The main issue with PR 119461 is it breaks e2e riscv test by making it get stuck on infinite loop.
```
/path/to/iree-build/tools/iree-compile --output-format=vm-bytecode --mlir-print-op-on-diagnostic=false --iree-hal-target-backends=llvm-cpu --iree-input-type=stablehlo --iree-input-demote-f64-to-f32 --iree-llvmcpu-target-cpu=generic /path/to/iree/tests/e2e/stablehlo_ops/three_fry.mlir -o three_fly_exec_target.mlir --iree-llvmcpu-target-triple=riscv64 --iree-llvmcpu-target-abi=lp64d --iree-llvmcpu-target-cpu-features=+m,+a,+d,+zvl512b,+v --mlir-disable-threading
> infinite loop
```