### PR TITLE
[runtime][hip] Do not error when peered memory access already enabled

### DIFF
--- a/runtime/src/iree/hal/drivers/hip/hip_device.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_device.c
@@ -463,8 +463,11 @@ iree_status_t iree_hal_hip_device_create(
         if (j == device->devices[i].hip_device) {
           continue;
         }
-        status =
-            IREE_HIP_CALL_TO_STATUS(symbols, hipDeviceEnablePeerAccess(j, 0));
+        hipError_t hip_error = symbols->hipDeviceEnablePeerAccess(j, 0);
+        if (hip_error == hipErrorPeerAccessAlreadyEnabled) {
+          continue;
+        }
+        status = IREE_HIP_RESULT_TO_STATUS(symbols, hip_error);
       }
     }
   }


### PR DESCRIPTION
This fixes the error

```
FAILED sharktank/tests/models/clip/clip_test.py::ClipTextIreeTest::testCompareLargeIreeBf16AgainstTorchEagerF32 - RuntimeError: Error creating device: c/runtime/src/iree/hal/drivers/hip/hip_device.c:467: ALREADY_EXISTS; HIP driver error 'hipErrorPeerAccessAlreadyEnabled' (704): peer access is already enabled; creating device 'hip'
```

This should not be treated as an error.