### PR TITLE
[hip] Don't join the status in dispatch_thread.

### DIFF
--- a/runtime/src/iree/hal/drivers/hip/dispatch_thread.c
+++ b/runtime/src/iree/hal/drivers/hip/dispatch_thread.c
@@ -62,8 +62,8 @@ static int iree_hal_hip_dispatch_thread_main(void* param) {
       iree_hal_hip_dispatch_queue_pop_front(&thread->queue, 1);
       iree_slim_mutex_unlock(&thread->mutex);
 
-      status = iree_status_join(status,
-                                dispatch.dispatch(dispatch.user_data, status));
+      // The status passed will be joined and returned.
+      status = dispatch.dispatch(dispatch.user_data, status);
       iree_slim_mutex_lock(&thread->mutex);
       if (!iree_status_is_ok(status)) {
         // We don't join here as the failure status was already


### PR DESCRIPTION
If the status was an error status that we are passing in, then it will be passed back to us. It is incorrect to join it.