### PR TITLE
[LinalgExt] Add support for fusing scatter with producers

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -102,7 +102,9 @@ def IREELinalgExt_ScatterOp : IREELinalgExt_Op<"scatter",
          "getIterationDomain",
          "getLoopIteratorTypes",
          "getResultTilePosition",
-         "getTiledImplementation"]>]> {
+         "getTiledImplementation",
+         "getIterationDomainTileFromOperandTile",
+         "getTiledImplementationFromOperandTile"]>]> {
   let summary = "Scatter operator";
   let description = [{
     Based on XLA operation semantics, takes two `inputs` (`update` and

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -193,8 +193,8 @@ LogicalResult ScatterOp::getIterationDomainTileFromOperandTile(
   if (!getUniqueIndices()) {
     return failure();
   }
-  // Fusion with a producer is only possible if fusing along the |input|
-  // operand.
+  // TODO: Support fusion along the index operand. For the index operand, the
+  // offset + size must be the full size for the inner most dim.
   if (getInputs().getBeginOperandIndex() != operandNumber) {
     return failure();
   }


### PR DESCRIPTION
This adds implementations for "getIterationDomainTileFromOperandTile" and "getTiledImplementationFromOperandTile" to linalg_ext.scatter. This allows fusing scatters with producer loops during tiling. The implementation of these methods is trivial because the iteration domain is already defined in terms of the input operands, so we can just invoke the tiling implementation.