### PR TITLE
[docs] Fix diagram rendering on C API reference page.

### DIFF
--- a/docs/website/docs/reference/bindings/c-api.md
+++ b/docs/website/docs/reference/bindings/c-api.md
@@ -34,7 +34,7 @@ graph TD
     C API's exported symbols.
   }
 
-  subgraph compiler[libIREECompiler.so / IREECompiler.dll]
+  subgraph compiler[libIREECompiler.so]
     pipelines("Pipelines
 
     • Flow
@@ -95,10 +95,13 @@ stateDiagram-v2
   InputBuffer --> Source2 : wrap buffer
 
   state Session {
+    Invocation1: Invocation1<br>(run pipelines on this)
     Source1 --> Invocation1
+
+    --
+
+    Invocation2: Invocation2<br>(run pipelines on this)
     Source2 --> Invocation2
-    Invocation1 --> Invocation1 : run pipeline
-    Invocation2 --> Invocation2 : run pipeline
   }
 
   Invocation1 --> Output1File   : write file
@@ -238,7 +241,6 @@ API.
       subgraph iree_runtime[IREE Runtime]
         subgraph base
           base_types("Types
-
           • allocator
           • status
           • etc.")
@@ -246,13 +248,11 @@ API.
 
         subgraph hal[HAL]
           hal_types("Types
-
           • buffer
           • device
           • etc.")
 
           hal_drivers("Drivers
-
           • local-*
           • vulkan
           • etc.")
@@ -260,7 +260,6 @@ API.
 
         subgraph vm[VM]
           vm_types("Types
-
           • context
           • invocation
           • etc.")
@@ -292,7 +291,6 @@ API.
       subgraph iree_runtime[IREE Runtime]
         subgraph base
           base_types("Types
-
           • allocator
           • status
           • etc.")
@@ -300,13 +298,11 @@ API.
 
         subgraph hal[HAL]
           hal_types("Types
-
           • buffer
           • device
           • etc.")
 
           hal_drivers("Drivers
-
           • local-*
           • vulkan
           • etc.")
@@ -314,14 +310,12 @@ API.
 
         subgraph vm[VM]
           vm_types("Types
-
           • context
           • invocation
           • etc.")
         end
 
         runtime_api("Runtime API
-
         • instance
         • session
         • call")


### PR DESCRIPTION
Possibly broken by updating past https://github.com/squidfunk/mkdocs-material/releases/tag/9.5.34 in https://github.com/iree-org/iree/pull/19482.

> Updated Mermaid.js to version 11 (latest)

## API diagrams

Broken: 
![image](https://github.com/user-attachments/assets/c2caff21-6f32-4ecc-a0fe-7f6eef1f980b)

Fixed: 
![image](https://github.com/user-attachments/assets/57e92506-62a8-4b69-8752-1642120c9e24)

## Concepts diagram

Before: 
![image](https://github.com/user-attachments/assets/72fb7bdc-bc1c-470e-b0cc-19df37f77a4c)

Current (broken): 
![image](https://github.com/user-attachments/assets/022eff49-6f11-41e9-8cd8-29564540f13b)

Fixed: ![image](https://github.com/user-attachments/assets/76d0da19-a52a-49fa-a209-5653a124839e)
