### PR TITLE
[docs] Update copyright year to 2025 in the website footer.

### DIFF
--- a/docs/website/mkdocs.yml
+++ b/docs/website/mkdocs.yml
@@ -83,7 +83,7 @@ exclude_docs: |
   **/snippets/*.md
 
 copyright: |
-  Copyright &copy; 2024 IREE a Series of LF Projects, LLC.
+  Copyright &copy; 2025 IREE a Series of LF Projects, LLC.
   For web site terms of use, trademark policy and other project policies please
   see <a href="https://lfprojects.org">https://lfprojects.org</a>.
 


### PR DESCRIPTION
See prior updates: https://github.com/iree-org/iree/pull/16028

> Happy New Year 🎉
> 
> Yes, this is a bit silly. We still like to intentionally update the copyright year in this one location so the website appears fresh.

