### PR TITLE
[runtime][hip] Fix format errors and conflicting types.

### DIFF
--- a/runtime/src/iree/hal/drivers/hip/hip_multi_queue_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_multi_queue_command_buffer.c
@@ -116,8 +116,8 @@ IREE_API_EXPORT iree_status_t iree_hal_hip_multi_queue_command_buffer_get(
       iree_hal_hip_multi_queue_command_buffer_cast(base_command_buffer);
   if (!(command_buffer->base.queue_affinity & queue_affinity)) {
     return iree_make_status(IREE_STATUS_NOT_FOUND,
-                            "no command buffer for affinity %lu",
-                            (unsigned long)queue_affinity);
+                            "no command buffer for affinity %llu",
+                            queue_affinity);
   }
   int index = iree_math_count_ones_u64(command_buffer->base.queue_affinity &
                                        (queue_affinity - 1));

--- a/runtime/src/iree/hal/drivers/hip/hip_multi_queue_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_multi_queue_command_buffer.c
@@ -117,7 +117,7 @@ IREE_API_EXPORT iree_status_t iree_hal_hip_multi_queue_command_buffer_get(
   if (!(command_buffer->base.queue_affinity & queue_affinity)) {
     return iree_make_status(IREE_STATUS_NOT_FOUND,
                             "no command buffer for affinity %lu",
-                            queue_affinity);
+                            (unsigned long)queue_affinity);
   }
   int index = iree_math_count_ones_u64(command_buffer->base.queue_affinity &
                                        (queue_affinity - 1));

--- a/runtime/src/iree/hal/drivers/hip/hip_multi_queue_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_multi_queue_command_buffer.c
@@ -116,7 +116,7 @@ IREE_API_EXPORT iree_status_t iree_hal_hip_multi_queue_command_buffer_get(
       iree_hal_hip_multi_queue_command_buffer_cast(base_command_buffer);
   if (!(command_buffer->base.queue_affinity & queue_affinity)) {
     return iree_make_status(IREE_STATUS_NOT_FOUND,
-                            "no command buffer for affinity %llu",
+                            "no command buffer for affinity %" PRIu64,
                             queue_affinity);
   }
   int index = iree_math_count_ones_u64(command_buffer->base.queue_affinity &

--- a/runtime/src/iree/hal/drivers/hip/stream_command_buffer.h
+++ b/runtime/src/iree/hal/drivers/hip/stream_command_buffer.h
@@ -32,7 +32,7 @@ iree_status_t iree_hal_hip_stream_command_buffer_create(
     iree_hal_stream_tracing_context_t* tracing_context,
     iree_hal_command_buffer_mode_t mode,
     iree_hal_command_category_t command_categories,
-    iree_host_size_t binding_capacity, iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_queue_affinity_t queue_affinity, iree_host_size_t binding_capacity,
     hipStream_t stream, iree_arena_block_pool_t* block_pool,
     iree_allocator_t host_allocator,
     iree_hal_command_buffer_t** out_command_buffer);


### PR DESCRIPTION
`iree_hal_queue_affinity_t` is a `uint64_t` type. It is defined differently depending on platform and 32/64-bit mode variant. The revision updates it to use `PRIu64` to fix the error from `-Wformat`.

```
runtime/src/iree/hal/drivers/hip/hip_multi_queue_command_buffer.c:120:29:
error: format specifies type 'unsigned long' but the argument has type
'iree_hal_queue_affinity_t' (aka 'unsigned long long') [-Werror,-Wformat]
```

The revision also fixes the conflicting types for `iree_hal_hip_stream_command_buffer_create`. The order was wrong. The only usage is in `hip_devices.c` and the eighth argument is `binding_capacity`.

https://github.com/iree-org/iree/blob/c7086cf78ce0a719ac1f5a70b9ee837e7706594f/runtime/src/iree/hal/drivers/hip/hip_device.c#L786-L794