### PR TITLE
Fix typo in serializeExecutable of CUDA target

### DIFF
--- a/compiler/plugins/target/CUDA/CUDATarget.cpp
+++ b/compiler/plugins/target/CUDA/CUDATarget.cpp
@@ -657,7 +657,7 @@ public:
       auto ordinalAttr = exportOp.getOrdinalAttr();
       if (!ordinalAttr) {
         return mlir::emitError(exportOp.getLoc())
-               << "could not compile rocm binary: export op is missing ordinal";
+               << "could not compile cuda binary: export op is missing ordinal";
       }
       int64_t ordinal = ordinalAttr.getInt();
 


### PR DESCRIPTION
If I understand correctly, it should be `cuda` instead of `rocm` in this error message.