### PR TITLE
Set MLIR_LINK_MLIR_DYLIB to not link shared libMLIR

### DIFF
--- a/build_tools/llvm/mlir_config.cmake
+++ b/build_tools/llvm/mlir_config.cmake
@@ -19,6 +19,10 @@ if(NOT EXISTS ${LLVM_DIR})
   message(FATAL_ERROR "LLVM_DIR (${LLVM_DIR}) does not exist")
 endif()
 
+# TODO: Fixes needed to allow setting to `ON` to allow that
+# all the tools will use libMLIR shared library
+set(MLIR_LINK_MLIR_DYLIB OFF CACHE BOOL "")
+
 # When exceptions are disabled, unwind tables are large and useless
 set(LLVM_ENABLE_UNWIND_TABLES OFF CACHE BOOL "")
 


### PR DESCRIPTION
With llvm/llvm-project@10ef20f, support for `MLIR_LINK_MLIR_DYLIB` was introduced. With `LLVM_LINK_LLVM_DYLIB` set to `ON` at https://github.com/iree-org/iree/blob/cdf24b9be0354f06879ba08db85ff8a5dbe49b14/build_tools/llvm/llvm_config.cmake#L30, this setting is propagated to `MLIR_LINK_MLIR_DYLIB`. This break the BYO LLVM workflow, see #19549, hence, setting to `OFF`.