### PR TITLE
Bump LLVM to llvm/llvm-project@21edac25f09faee23015c6a69d95fcbda287efe2

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_extract_address_computation.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_extract_address_computation.mlir
@@ -44,7 +44,7 @@
 // CHECK-DAG: %[[TID_Y_EXT:.*]] = llvm.sext %[[TID_Y]] : i32 to i64
 // CHECK-DAG: %[[LANEID:.*]] = nvvm.read.ptx.sreg.laneid range <i32, 0, 32> : i32
 // CHECK-DAG: %[[LANEID_EXT:.*]] = llvm.sext %[[LANEID]] : i32 to i64
-// CHECK-DAG: %[[TID_Y_IDX:.*]] = llvm.mul %[[TID_Y_EXT]], %[[C64]]  : i64
+// CHECK-DAG: %[[TID_Y_IDX:.*]] = llvm.mul %[[TID_Y_EXT]], %[[C64]] overflow<nsw> : i64
 //
 // Match the loop invariant math on the special registers.
 // CHECK: %[[GRP_IDX:.*]] = llvm.add %[[TID_Y_IDX]], %[[LANEID_EXT]]  : i64

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matvec.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matvec.mlir
@@ -199,11 +199,11 @@ hal.executable @i4_dequant_matvec_f16_subgroup_64 {
 
 // Load the quantized weight and get 4xi4 out of it. Ensure that the offset
 // calculation avoids excessive scaling down in computing the element offset.
-//         CHECK:   spirv.IMul %{{.*}}, %[[C64]] : i32
+//         CHECK:   spirv.IMul %{{.*}}, %[[C64]]  {no_signed_wrap} : i32
 //         CHECK:   spirv.IAdd %{{.*}}, %[[STREAMBINDING]] : i32
-//         CHECK:   spirv.IMul %{{.*}}, %[[C5504]] : i32
+//         CHECK:   spirv.IMul %{{.*}}, %[[C5504]] {no_signed_wrap} : i32
 //         CHECK:   spirv.IAdd %{{.*}}, %{{.*}} : i32
-//         CHECK:   spirv.IMul %[[WIDX]], %[[C2]] : i32
+//         CHECK:   spirv.IMul %[[WIDX]], %[[C2]] {no_signed_wrap} : i32
 //         CHECK:   spirv.IAdd %{{.*}}, %{{.*}} : i32
 //         CHECK:   %[[OFFSET:.+]] = spirv.SDiv %{{.*}}, %[[C4]] : i32
 //         CHECK:   %[[ACCESS:.+]] = spirv.AccessChain %[[RADDR]][{{.*}}, %[[OFFSET]]] : !spirv.ptr<!spirv.struct<(!spirv.rtarray<i32, stride=4> [0])>, StorageBuffer>, i32, i32


### PR DESCRIPTION
Carries 4 reverts

Related to Nanobind issues

- https://github.com/llvm/llvm-project/commit/5cd427477218d8bdb659c6c53a7758f741c3990a 
- https://github.com/llvm/llvm-project/commit/08e2c15a287df132ca2186f2d56669219a7ed8a1 
- https://github.com/llvm/llvm-project/commit/b56d1ec6cb8b5cb3ff46cba39a1049ecf3831afb

Related to RISC-V compilation

https://github.com/llvm/llvm-project/commit/169c32eb49fa9b559d388b9b8f4374ff9e1be9be