### PR TITLE
AMDGPU ukernels: fix address spaces to fix inlining

### DIFF
--- a/compiler/plugins/target/ROCM/builtins/ukernel/common.h
+++ b/compiler/plugins/target/ROCM/builtins/ukernel/common.h
@@ -64,6 +64,13 @@ typedef __UINT64_TYPE__ uint64_t;
 typedef __attribute__((__vector_size__(4 * 4))) int32_t int32x4_t;
 
 //===----------------------------------------------------------------------===//
+// Address spaces
+//===----------------------------------------------------------------------===//
+
+#define GLOBAL [[clang::address_space(1)]]
+#define LOCAL [[clang::address_space(3)]]
+
+//===----------------------------------------------------------------------===//
 // Declarations for Clangd, which may be slightly older than actual clang.
 // Drop these as clangd versions used in practice gain these builtins.
 // Unconditionally declaring these, regardless of clang version, ensures that

--- a/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_f16i32.c
+++ b/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_f16i32.c
@@ -7,9 +7,9 @@
 #include "compiler/plugins/target/ROCM/builtins/ukernel/common.h"
 
 [[clang::always_inline]] void
-iree_uk_amdgpu_argmax_f16i32(const _Float16 *inputBuffer, int64_t input_offset,
-                             int32_t *outputBuffer, int64_t output_offset,
-                             int64_t reductionSize) {
+iree_uk_amdgpu_argmax_f16i32(const _Float16 GLOBAL *inputBuffer,
+                             int64_t input_offset, int32_t GLOBAL *outputBuffer,
+                             int64_t output_offset, int64_t reductionSize) {
   const int warpSize = __builtin_amdgcn_wavefrontsize();
   _Float16 NEG_F16_MAX = (_Float16)(-65504.0f);
   int32_t laneID = __builtin_amdgcn_workitem_id_x();

--- a/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_f16i64.c
+++ b/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_f16i64.c
@@ -7,9 +7,9 @@
 #include "compiler/plugins/target/ROCM/builtins/ukernel/common.h"
 
 [[clang::always_inline]] void
-iree_uk_amdgpu_argmax_f16i64(const _Float16 *inputBuffer, int64_t input_offset,
-                             int64_t *outputBuffer, int64_t output_offset,
-                             int64_t reductionSize) {
+iree_uk_amdgpu_argmax_f16i64(const _Float16 GLOBAL *inputBuffer,
+                             int64_t input_offset, int64_t GLOBAL *outputBuffer,
+                             int64_t output_offset, int64_t reductionSize) {
   const int warpSize = __builtin_amdgcn_wavefrontsize();
   _Float16 NEG_F16_MAX = (_Float16)(-65504.0f);
   int32_t laneID = __builtin_amdgcn_workitem_id_x();

--- a/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_f32i32.c
+++ b/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_f32i32.c
@@ -7,9 +7,9 @@
 #include "compiler/plugins/target/ROCM/builtins/ukernel/common.h"
 
 [[clang::always_inline]] void
-iree_uk_amdgpu_argmax_f32i32(const float *inputBuffer, int64_t input_offset,
-                             int32_t *outputBuffer, int64_t output_offset,
-                             int64_t reductionSize) {
+iree_uk_amdgpu_argmax_f32i32(const float GLOBAL *inputBuffer,
+                             int64_t input_offset, int32_t GLOBAL *outputBuffer,
+                             int64_t output_offset, int64_t reductionSize) {
   const int warpSize = __builtin_amdgcn_wavefrontsize();
   int32_t laneID = __builtin_amdgcn_workitem_id_x();
   // Set identity value to handle problem non divisible by subgroupSize.

--- a/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_f32i64.c
+++ b/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_f32i64.c
@@ -7,9 +7,9 @@
 #include "compiler/plugins/target/ROCM/builtins/ukernel/common.h"
 
 [[clang::always_inline]] void
-iree_uk_amdgpu_argmax_f32i64(const float *inputBuffer, int64_t input_offset,
-                             int64_t *outputBuffer, int64_t output_offset,
-                             int64_t reductionSize) {
+iree_uk_amdgpu_argmax_f32i64(const float GLOBAL *inputBuffer,
+                             int64_t input_offset, int64_t GLOBAL *outputBuffer,
+                             int64_t output_offset, int64_t reductionSize) {
   const int warpSize = __builtin_amdgcn_wavefrontsize();
   int32_t laneID = __builtin_amdgcn_workitem_id_x();
   // Set identity value to handle problem non divisible by subgroupSize.

--- a/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_multi_mma_mfma_i32_16x16x32_i8.c
+++ b/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_multi_mma_mfma_i32_16x16x32_i8.c
@@ -7,59 +7,46 @@
 #include "compiler/plugins/target/ROCM/builtins/ukernel/common.h"
 
 // Very naive kernel. TODO(bjacob):
-// 1. Inlining: the `always_inline` attribute here is correctly preserved in
-//    the bitcode, but isn't having the intended effect of inlining calls to
-//    this function. Making that work is key as various function parameters
-//    (e.g. `unroll_m`) are meant to be constants.
-// 2. Shared memory: can't allocate it within the microkernel (which is just a
+// 1. Shared memory: can't allocate it within the microkernel (which is just a
 //    helper device function, not the actual amdgpu_kernel). Need to get it
-//    passed down here as a `T [[clang::address_space(3)]] *` parameter.
-// 3. Better scheduling via either barrier intrinsics or inline assemby.
-// 4. Subgroups1x4 being asymmetric is a historical accident... should be 2x2.
+//    passed down here as a `int8_t LOCAL *` parameter.
+// 2. Better scheduling via either barrier intrinsics or inline assemby.
 [[clang::always_inline]] void iree_uk_amdgpu_multi_mma_mfma_i32_16x16x32_i8(
-    const int8_t *a_buffer, int64_t a_offset, const int8_t *b_buffer,
-    int64_t b_offset, int32_t *c_buffer, int64_t c_offset, int32_t k_size,
-    int32_t unroll_m, int32_t subgroups_m, int32_t unroll_n,
-    int32_t subgroups_n, int32_t unroll_k) {
-  /*
-    TODO(bjacob): reenable this once inlining works.
-    // Load existing accumulators. This is a VLA, but should become fixed-size
-    // once this function is inlined and unroll_* factors become constants.
-    int32x4_t c[unroll_m][unroll_n];
-  */
-  // Load existing accumulators.
-  if (unroll_m > 8 || unroll_n > 2) {
-    __builtin_trap();
-  }
-  int32x4_t c[8][2];
-  int32x4_t *c_global = (int32x4_t *)(c_buffer + c_offset);
+    const int8_t GLOBAL *a_buffer, int64_t a_offset,
+    const int8_t GLOBAL *b_buffer, int64_t b_offset, int32_t GLOBAL *c_buffer,
+    int64_t c_offset, int32_t k_size, int32_t unroll_m, int32_t subgroups_m,
+    int32_t unroll_n, int32_t subgroups_n, int32_t unroll_k) {
+  // Load existing accumulators. This VLA becomes a regular fixed-size array
+  // after inlining into the caller where these values are constants.
+  int32x4_t c[unroll_m][unroll_n];
+  int32x4_t GLOBAL *c_ptr = (int32x4_t GLOBAL *)(c_buffer + c_offset);
   for (int m = 0; m < unroll_m; ++m) {
     for (int n = 0; n < unroll_n; ++n) {
-      c[m][n] = c_global[64 * (m * unroll_n + n)];
+      c[m][n] = c_ptr[64 * (m * unroll_n + n)];
     }
   }
 
   // Arithmetic loop.
-  const int64_t *a_global = (const int64_t *)(a_buffer + a_offset);
-  const int64_t *b_global = (const int64_t *)(b_buffer + b_offset);
+  const int64_t GLOBAL *a_ptr = (const int64_t GLOBAL *)(a_buffer + a_offset);
+  const int64_t GLOBAL *b_ptr = (const int64_t GLOBAL *)(b_buffer + b_offset);
   for (int k_outer = 0; k_outer < k_size; ++k_outer) {
     for (int m = 0; m < unroll_m; ++m) {
       for (int n = 0; n < unroll_n; ++n) {
         for (int k = 0; k < unroll_k; ++k) {
           c[m][n] = __builtin_amdgcn_mfma_i32_16x16x32_i8(
-              a_global[64 * unroll_k * m + k], b_global[64 * unroll_k * n + k],
+              a_ptr[64 * unroll_k * m + k], b_ptr[64 * unroll_k * n + k],
               c[m][n], 0, 0, 0);
         }
       }
     }
-    a_global += 64 * unroll_m * subgroups_m * unroll_k;
-    b_global += 64 * unroll_n * subgroups_n * unroll_k;
+    a_ptr += 64 * unroll_m * subgroups_m * unroll_k;
+    b_ptr += 64 * unroll_n * subgroups_n * unroll_k;
   }
 
   // Store accumulators.
   for (int m = 0; m < unroll_m; ++m) {
     for (int n = 0; n < unroll_n; ++n) {
-      c_global[64 * (m * unroll_n + n)] = c[m][n];
+      c_ptr[64 * (m * unroll_n + n)] = c[m][n];
     }
   }
 }


### PR DESCRIPTION
AMDGPU ukernels weren't getting inlined into their callers. This was a symptom of another problem: the ukernel definitions had the default address space 0 on their pointer parameters, but the caller had address space 1 (global memory).

The choice of unprefixed macros GLOBAL and LOCAL is reasonable here because this completely self-contained, isolated code won't conflict with anything, and as these need to get sprinkled on every pointer type, short identifiers are valuable.

The inlining works perfectly: the VLA gets optimized away, allowing us to use a VLA in the C source code of the ukernel to represent the accumulator register tile generically, before it gets specialized in the caller.