### PR TITLE
Add explicit tolerances to SDXL benchmark test times.

### DIFF
--- a/.github/workflows/pkgci_regression_test.yml
+++ b/.github/workflows/pkgci_regression_test.yml
@@ -155,7 +155,7 @@ jobs:
             --goldensize-rocm-clip-bytes 860000  \
             --goldensize-rocm-vae-bytes 840000 \
             --goldentime-rocm-punet-int8-fp16-ms 50.0 \
-            --goldentime-rocm-punet-int8-fp8-ms 50.0 \
+            --goldentime-rocm-punet-int8-fp8-ms 52.0 \
             --goldendispatch-rocm-punet-int8-fp16 1424 \
             --goldendispatch-rocm-punet-int8-fp8 1704 \
             --goldensize-rocm-punet-int8-fp8-bytes 2800000 \

--- a/.github/workflows/pkgci_regression_test.yml
+++ b/.github/workflows/pkgci_regression_test.yml
@@ -111,17 +111,18 @@ jobs:
           ROCM_CHIP: ${{ matrix.rocm-chip }}
 
       # Note: mi250 benchmark times are more lenient than mi300 (allowing about
-      # 20% deviation from observed averages), since the mi250 runners we use
+      # 30% deviation from observed averages), since the mi250 runners we use
       # are more unstable and we care most about peak performance on mi300.
       - name: "Running SDXL rocm pipeline benchmark (mi250)"
         if: contains(matrix.name, 'rocm_mi250_gfx90a')
         run: |
           source ${VENV_DIR}/bin/activate
           pytest ./experimental/benchmarks/sdxl/benchmark_sdxl_rocm.py \
-            --goldentime-rocm-e2e-ms 1300.0 \
-            --goldentime-rocm-unet-ms 310.0 \
-            --goldentime-rocm-clip-ms 18.0 \
-            --goldentime-rocm-vae-ms 370.0 \
+            --goldentime-tolerance-multiplier 1.3 \
+            --goldentime-rocm-e2e-ms 1100.0 \
+            --goldentime-rocm-unet-ms 255.0 \
+            --goldentime-rocm-clip-ms 14.5 \
+            --goldentime-rocm-vae-ms 310.0 \
             --goldendispatch-rocm-unet 1602 \
             --goldendispatch-rocm-clip 1139 \
             --goldendispatch-rocm-vae 246 \
@@ -135,25 +136,26 @@ jobs:
           echo "$(<job_summary.md )" >> $GITHUB_STEP_SUMMARY
           rm job_summary.md
 
-      # Note: allowing 10% deviation, rounded up based on significant digits,
-      # from observed averages here to account for different runner conditions.
+      # Note: allowing 10% deviation from observed averages here to account for
+      # different runner conditions.
       - name: "Running SDXL rocm pipeline benchmark (mi300)"
         if: contains(matrix.name, 'rocm_mi300_gfx942')
         run: |
           source ${VENV_DIR}/bin/activate
           pytest ./experimental/benchmarks/sdxl/benchmark_sdxl_rocm.py \
-            --goldentime-rocm-e2e-ms 360.0 \
-            --goldentime-rocm-unet-ms 90.0 \
-            --goldentime-rocm-clip-ms 17.0 \
-            --goldentime-rocm-vae-ms 90.0 \
+            --goldentime-tolerance-multiplier 1.1 \
+            --goldentime-rocm-e2e-ms 325.0 \
+            --goldentime-rocm-unet-ms 80.0 \
+            --goldentime-rocm-clip-ms 15.0 \
+            --goldentime-rocm-vae-ms 75.0 \
             --goldendispatch-rocm-unet 1602 \
             --goldendispatch-rocm-clip 1139 \
             --goldendispatch-rocm-vae 246 \
             --goldensize-rocm-unet-bytes 2270000 \
             --goldensize-rocm-clip-bytes 860000  \
             --goldensize-rocm-vae-bytes 840000 \
-            --goldentime-rocm-punet-int8-fp16-ms 55.0 \
-            --goldentime-rocm-punet-int8-fp8-ms 55.0 \
+            --goldentime-rocm-punet-int8-fp16-ms 50.0 \
+            --goldentime-rocm-punet-int8-fp8-ms 50.0 \
             --goldendispatch-rocm-punet-int8-fp16 1424 \
             --goldendispatch-rocm-punet-int8-fp8 1704 \
             --goldensize-rocm-punet-int8-fp8-bytes 2800000 \

--- a/.github/workflows/pkgci_regression_test.yml
+++ b/.github/workflows/pkgci_regression_test.yml
@@ -111,17 +111,17 @@ jobs:
           ROCM_CHIP: ${{ matrix.rocm-chip }}
 
       # Note: mi250 benchmark times are more lenient than mi300 (allowing about
-      # 10% deviation from observed averages), since the mi250 runners we use
+      # 20% deviation from observed averages), since the mi250 runners we use
       # are more unstable and we care most about peak performance on mi300.
       - name: "Running SDXL rocm pipeline benchmark (mi250)"
         if: contains(matrix.name, 'rocm_mi250_gfx90a')
         run: |
           source ${VENV_DIR}/bin/activate
           pytest ./experimental/benchmarks/sdxl/benchmark_sdxl_rocm.py \
-            --goldentime-rocm-e2e-ms 1616.0 \
-            --goldentime-rocm-unet-ms 419.0 \
-            --goldentime-rocm-clip-ms 18.5 \
-            --goldentime-rocm-vae-ms 337.0 \
+            --goldentime-rocm-e2e-ms 1300.0 \
+            --goldentime-rocm-unet-ms 310.0 \
+            --goldentime-rocm-clip-ms 18.0 \
+            --goldentime-rocm-vae-ms 370.0 \
             --goldendispatch-rocm-unet 1602 \
             --goldendispatch-rocm-clip 1139 \
             --goldendispatch-rocm-vae 246 \
@@ -135,27 +135,29 @@ jobs:
           echo "$(<job_summary.md )" >> $GITHUB_STEP_SUMMARY
           rm job_summary.md
 
+      # Note: allowing 10% deviation, rounded up based on significant digits,
+      # from observed averages here to account for different runner conditions.
       - name: "Running SDXL rocm pipeline benchmark (mi300)"
         if: contains(matrix.name, 'rocm_mi300_gfx942')
         run: |
           source ${VENV_DIR}/bin/activate
           pytest ./experimental/benchmarks/sdxl/benchmark_sdxl_rocm.py \
-            --goldentime-rocm-e2e-ms 330.0 \
-            --goldentime-rocm-unet-ms 80.0 \
-            --goldentime-rocm-clip-ms 15.5 \
-            --goldentime-rocm-vae-ms 80.0 \
+            --goldentime-rocm-e2e-ms 360.0 \
+            --goldentime-rocm-unet-ms 90.0 \
+            --goldentime-rocm-clip-ms 17.0 \
+            --goldentime-rocm-vae-ms 90.0 \
             --goldendispatch-rocm-unet 1602 \
             --goldendispatch-rocm-clip 1139 \
             --goldendispatch-rocm-vae 246 \
             --goldensize-rocm-unet-bytes 2270000 \
             --goldensize-rocm-clip-bytes 860000  \
             --goldensize-rocm-vae-bytes 840000 \
-            --goldentime-rocm-punet-int8-fp16-ms 51 \
+            --goldentime-rocm-punet-int8-fp16-ms 55.0 \
+            --goldentime-rocm-punet-int8-fp8-ms 55.0 \
             --goldendispatch-rocm-punet-int8-fp16 1424 \
-            --goldensize-rocm-punet-int8-fp16-bytes 2560000 \
-            --goldentime-rocm-punet-int8-fp8-ms 51 \
             --goldendispatch-rocm-punet-int8-fp8 1704 \
             --goldensize-rocm-punet-int8-fp8-bytes 2800000 \
+            --goldensize-rocm-punet-int8-fp16-bytes 2560000 \
             --rocm-chip gfx942 \
             --log-cli-level=info \
             --timeout=600 \

--- a/experimental/benchmarks/sdxl/benchmark_sdxl_rocm.py
+++ b/experimental/benchmarks/sdxl/benchmark_sdxl_rocm.py
@@ -240,6 +240,7 @@ def job_summary_process(ret_value, output):
 
 
 def test_sdxl_rocm_benchmark(
+    goldentime_tolerance_multiplier,
     goldentime_rocm_e2e,
     goldentime_rocm_unet,
     goldentime_rocm_punet_int8_fp16,
@@ -522,13 +523,13 @@ def test_sdxl_rocm_benchmark(
 
     check.less_equal(
         benchmark_e2e_mean_time,
-        goldentime_rocm_e2e,
-        "SDXL e2e benchmark time should not regress",
+        goldentime_rocm_e2e * goldentime_tolerance_multiplier,
+        f"SDXL e2e benchmark time should not regress more than a factor of {goldentime_tolerance_multiplier}",
     )
     check.less_equal(
         benchmark_unet_mean_time,
-        goldentime_rocm_unet,
-        "SDXL unet benchmark time should not regress",
+        goldentime_rocm_unet * goldentime_tolerance_multiplier,
+        f"SDXL unet benchmark time should not regress more than a factor of {goldentime_tolerance_multiplier}",
     )
     check.less_equal(
         unet_dispatch_count,
@@ -543,8 +544,8 @@ def test_sdxl_rocm_benchmark(
     if rocm_chip == "gfx942":
         check.less_equal(
             benchmark_punet_int8_fp16_mean_time,
-            goldentime_rocm_punet_int8_fp16,
-            "SDXL punet f16 benchmark time should not regress",
+            goldentime_rocm_punet_int8_fp16 * goldentime_tolerance_multiplier,
+            f"SDXL punet f16 benchmark time should not regress more than a factor of {goldentime_tolerance_multiplier}",
         )
         check.less_equal(
             punet_int8_fp16_dispatch_count,
@@ -558,8 +559,8 @@ def test_sdxl_rocm_benchmark(
         )
         check.less_equal(
             benchmark_punet_int8_fp8_mean_time,
-            goldentime_rocm_punet_int8_fp8,
-            "SDXL punet f8 benchmark time should not regress",
+            goldentime_rocm_punet_int8_fp8 * goldentime_tolerance_multiplier,
+            f"SDXL punet f8 benchmark time should not regress more than a factor of {goldentime_tolerance_multiplier}",
         )
         check.less_equal(
             punet_int8_fp8_dispatch_count,
@@ -573,8 +574,8 @@ def test_sdxl_rocm_benchmark(
         )
     check.less_equal(
         benchmark_clip_mean_time,
-        goldentime_rocm_clip,
-        "SDXL prompt encoder benchmark time should not regress",
+        goldentime_rocm_clip * goldentime_tolerance_multiplier,
+        f"SDXL prompt encoder benchmark time should not regress more than a factor of {goldentime_tolerance_multiplier}",
     )
     check.less_equal(
         clip_dispatch_count,
@@ -588,8 +589,8 @@ def test_sdxl_rocm_benchmark(
     )
     check.less_equal(
         benchmark_vae_mean_time,
-        goldentime_rocm_vae,
-        "SDXL vae decode benchmark time should not regress",
+        goldentime_rocm_vae * goldentime_tolerance_multiplier,
+        f"SDXL vae decode benchmark time should not regress more than a factor of {goldentime_tolerance_multiplier}",
     )
     check.less_equal(
         vae_dispatch_count,

--- a/experimental/benchmarks/sdxl/conftest.py
+++ b/experimental/benchmarks/sdxl/conftest.py
@@ -1,7 +1,20 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 import pytest
 
 
 def pytest_addoption(parser):
+    parser.addoption(
+        "--goldentime-tolerance-multiplier",
+        action="store",
+        default=1.0,
+        type=float,
+        help="Multiplier to use for time regression checking. For example, 1.1 will allow regressions of up to 10%",
+    )
     parser.addoption(
         "--goldentime-rocm-e2e-ms",
         action="store",
@@ -115,6 +128,11 @@ def pytest_addoption(parser):
         type=str,
         help="ROCm target chip configuration of GPU",
     )
+
+
+@pytest.fixture
+def goldentime_tolerance_multiplier(request):
+    return request.config.getoption("--goldentime-tolerance-multiplier")
 
 
 @pytest.fixture


### PR DESCRIPTION
These tests that look at exact thresholds have been flaky, so this adjusts the tolerances to be explicitly defined as percentages.

ci-exactly: build_packages, regression_test