### PR TITLE
[LLVMGPUVectorDistribute] Refactor vector.contract distribute

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrs.td
@@ -218,7 +218,15 @@ def NestedLayoutAttr : IREEVectorExt_Attr<"NestedLayout",
                      "ArrayRef<int64_t>":$threadTile,
                      "ArrayRef<int64_t>":$elementTile,
                      "ArrayRef<int64_t>":$subgroupStrides,
-                     "ArrayRef<int64_t>":$threadStrides)>
+                     "ArrayRef<int64_t>":$threadStrides)>,
+    AttrBuilder<(ins "NestedLayoutAttr":$source,
+                     "ArrayRef<int64_t>":$appendSubGroupLens,
+                     "ArrayRef<int64_t>":$appendBatchLens,
+                     "ArrayRef<int64_t>":$appendOuterLens,
+                     "ArrayRef<int64_t>":$appendThreadLens,
+                     "ArrayRef<int64_t>":$appendElementLens,
+                     "ArrayRef<int64_t>":$appendSubgroupStrides,
+                     "ArrayRef<int64_t>":$appendThreadStrides)>
   ];
 
   let extraClassDeclaration = [{

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtInterfaces.td
@@ -36,6 +36,12 @@ def VectorLayoutInterface : AttrInterface<"VectorLayoutInterface"> {
       /*args=*/(ins "::llvm::ArrayRef<bool>":$droppedDims)
     >,
     InterfaceMethod<
+      /*description=*/"Get the expected undistributed shape for the given vector type.",
+      /*retTy=*/"SmallVector<int64_t>",
+      /*methodName=*/"getUndistributedShape",
+      /*args=*/(ins)
+    >,
+    InterfaceMethod<
       /*description=*/"Get the distributed shape for the given vector type.",
       /*retTy=*/"SmallVector<int64_t>",
       /*methodName=*/"getDistributedShape",


### PR DESCRIPTION
Currently, vector.contract distribution is implemented as a standalone distribution closely following vector.multi_reduce. Therefore, we have to duplicate code/effort when we improve either one.

This commit changes vector.contract just to distribute the "contract" part of it. Then it creates a new vector.multi_reduce to be re-distributed with partial reduction semantics. Thus, allowing the improvements of vector.multi_reduce to be re-used by vector.contract

closes : https://github.com/iree-org/iree/issues/19620