### PR TITLE
Fix (cross) compiling for 32-bit targets

### DIFF
--- a/runtime/src/iree/hal/semaphore.h
+++ b/runtime/src/iree/hal/semaphore.h
@@ -72,7 +72,7 @@ typedef uint32_t iree_hal_semaphore_flags_t;
 static inline uint64_t iree_hal_status_as_semaphore_failure(
     iree_status_t status) {
   return IREE_HAL_SEMAPHORE_FAILURE_VALUE_STATUS_BIT |
-         (((uint64_t)status) >> 1);
+         (((uint64_t)(uintptr_t)status) >> 1);
 }
 
 // Returns OK if the |value| does not indicate an error.
@@ -92,7 +92,8 @@ static inline iree_status_t iree_hal_semaphore_failure_as_status(
       //
       // See:
       // https://en.wikipedia.org/wiki/X86-64#Canonical_form_addresses
-      return iree_status_clone((iree_status_t)(((int64_t)value << 1) >> 1));
+      return iree_status_clone(
+          (iree_status_t)(intptr_t)(((int64_t)value << 1) >> 1));
     } else {
       return iree_status_from_code(IREE_STATUS_INTERNAL);
     }
@@ -105,7 +106,7 @@ static inline iree_status_t iree_hal_semaphore_failure_as_status(
 IREE_ATTRIBUTE_ALWAYS_INLINE static inline void iree_hal_semaphore_failure_free(
     uint64_t value) {
   if (value & IREE_HAL_SEMAPHORE_FAILURE_VALUE_STATUS_BIT) {
-    iree_status_free((iree_status_t)(((int64_t)value << 1) >> 1));
+    iree_status_free((iree_status_t)(intptr_t)(((int64_t)value << 1) >> 1));
   }
 }
 


### PR DESCRIPTION
The patch fixes the following build errors that occur when cross-compiling with GCC for a 32-bit target:
```
iree-bare-metal-arm/third_party/iree/runtime/src/iree/hal/semaphore.h: In function 'iree_hal_status_as_semaphore_failure':
iree-bare-metal-arm/third_party/iree/runtime/src/iree/hal/semaphore.h:75:12: error: cast from pointer to integer of different size [-Werror=pointer-to-int-cast]
   75 |          (((uint64_t)status) >> 1);
      |            ^
iree-bare-metal-arm/third_party/iree/runtime/src/iree/hal/semaphore.h: In function 'iree_hal_semaphore_failure_as_status':
iree-bare-metal-arm/third_party/iree/runtime/src/iree/hal/semaphore.h:95:32: error: cast to pointer from integer of different size [-Werror=int-to-pointer-cast]
   95 |       return iree_status_clone((iree_status_t)(((int64_t)value << 1) >> 1));
      |                                ^
iree-bare-metal-arm/third_party/iree/runtime/src/iree/hal/semaphore.h: In function 'iree_hal_semaphore_failure_free':
iree-bare-metal-arm/third_party/iree/runtime/src/iree/hal/semaphore.h:107:22: error: cast to pointer from integer of different size [-Werror=int-to-pointer-cast]
  107 |     iree_status_free((iree_status_t)(((int64_t)value << 1) >> 1));
      |                      ^
cc1: all warnings being treated as errors
```