### PR TITLE
[Stream] Attach layouts to tensor ops in encoding specialization pass.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/BUILD.bazel
@@ -18,11 +18,13 @@ iree_compiler_cc_library(
         "CPUEncodingExternalModels.cpp",
         "GPUEncodingExternalModels.cpp",
         "Interfaces.cpp",
+        "Utils.cpp",
     ],
     hdrs = [
         "CPUEncodingExternalModels.h",
         "GPUEncodingExternalModels.h",
         "Interfaces.h",
+        "Utils.h",
     ],
     deps = [
         "//compiler/src/iree/compiler/Codegen/Dialect/CPU/IR:IREECPUDialect",

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CMakeLists.txt
@@ -17,10 +17,12 @@ iree_cc_library(
     "CPUEncodingExternalModels.h"
     "GPUEncodingExternalModels.h"
     "Interfaces.h"
+    "Utils.h"
   SRCS
     "CPUEncodingExternalModels.cpp"
     "GPUEncodingExternalModels.cpp"
     "Interfaces.cpp"
+    "Utils.cpp"
   DEPS
     LLVMSupport
     MLIRIR

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -768,7 +768,7 @@ struct VMVXHostEncodingLayoutAttrInterface
     SmallVector<NamedAttribute> configItems;
     storeNamedAttrIfPresent(configItems, config, "ukernels");
     return VMVXEncodingLayoutAttr::get(ctx,
-                                      DictionaryAttr::get(ctx, configItems));
+                                       DictionaryAttr::get(ctx, configItems));
   }
 
   Attribute getLayout(Attribute attr, RankedTensorType type) const {

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.cpp
@@ -1,0 +1,28 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/ExternalInterfaces/Utils.h"
+
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.h"
+#include "llvm/Support/Casting.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/MLIRContext.h"
+
+namespace mlir::iree_compiler::IREE {
+using Codegen::MaterializeEncodingInfo;
+
+DictionaryAttr getLayoutImpl(Attribute attr, RankedTensorType type) {
+  MLIRContext *ctx = attr.getContext();
+  auto deviceLayoutAttr = cast<IREE::Codegen::LayoutAttrInterface>(attr);
+  const MaterializeEncodingInfo info = deviceLayoutAttr.getEncodingInfo(type);
+  auto strAttr = StringAttr::get(ctx, "encoding_info");
+  Attribute encodingInfoAttr =
+      IREE::Codegen::serializeEncodingInfo(attr.getContext(), info);
+  return DictionaryAttr::get(ctx, {NamedAttribute(strAttr, encodingInfoAttr)});
+}
+
+} // namespace mlir::iree_compiler::IREE

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.h
@@ -1,0 +1,22 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_EXTERNALINTERFACES_UTILS_H_
+#define IREE_COMPILER_CODEGEN_EXTERNALINTERFACES_UTILS_H_
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+
+namespace mlir::iree_compiler::IREE {
+
+/// Returns a dictionary attribute that contains the materialized encoding info,
+/// i.e., serialized MaterializeEncodingInfo struct.
+/// Requirement: `attr` must implement IREE::Codegen::LayoutAttrInterface.
+DictionaryAttr getLayoutImpl(Attribute attr, RankedTensorType type);
+
+} // namespace mlir::iree_compiler::IREE
+
+#endif // IREE_COMPILER_CODEGEN_EXTERNALINTERFACES_UTILSS_H_

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
@@ -256,6 +256,9 @@ EncodingAttr getEncodingAttr(RankedTensorType type) {
 FailureOr<linalg::ContractionDimensions>
 getEncodingContractionDims(EncodingAttr encoding) {
   auto indexingMapsAttr = encoding.getUserIndexingMaps();
+  if (!indexingMapsAttr) {
+    return failure();
+  }
   SmallVector<AffineMap> indexingMaps = llvm::map_to_vector(
       indexingMapsAttr.getValue(), [](Attribute m) -> AffineMap {
         return cast<AffineMapAttr>(m).getAffineMap();

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
@@ -43,6 +43,48 @@ def IREEEncoding_EncodingLayoutAttrInterface :
         assert(false && "unimplemented interface method");
         return {};
       }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns the attribute with simplified configuration/layouts. Attribute
+        is immutable in MLIR concept. Different attributes can implement
+        attribute interface methods differently, and they can carry target
+        configuration (e.g., cpu features) for further lowering. However, some
+        configuration/parameters can be dropped as long as they are no longer
+        needed in the progressively lowering. This method provides a mechanism
+        for such attribute to drop the outdated paramters and makes IR dump less
+        verbose.
+      }],
+      /*retTy=*/"::mlir::Attribute",
+      /*methodName=*/"cloneWithSimplifiedConfig",
+      /*args=*/(ins
+        "::mlir::DictionaryAttr":$config
+      ),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        assert(false && "unimplemented interface method");
+        return {};
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns the serialized layout, which is either common format or wrapped
+        by an attribute that implements EncodingLayoutAttrInterface interface.
+        If it is in common format (e.g., a regular tensor type), we can easily
+        calculate the storage size. Otherwise, we will need a hook from
+        external, and the hook can come from an attribute that implements the
+        interface.
+      }],
+      /*retTy=*/"::mlir::Attribute",
+      /*methodName=*/"getLayout",
+      /*args=*/(ins
+        "::mlir::RankedTensorType":$type
+      ),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        assert(false && "unimplemented interface method");
+        return {};
+      }]
     >
   ];
 }

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/BUILD.bazel
@@ -100,6 +100,7 @@ iree_compiler_cc_library(
     hdrs = ["HALDialect.h"],
     deps = [
         ":IR",
+        "//compiler/src/iree/compiler/Dialect/Encoding/IR",
         "//compiler/src/iree/compiler/Dialect/HAL:hal_imports",
         "//compiler/src/iree/compiler/Dialect/HAL/Analysis",
         "//compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM",

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/CMakeLists.txt
@@ -79,6 +79,7 @@ iree_cc_library(
     MLIRParser
     MLIRSCFDialect
     MLIRTransformUtils
+    iree::compiler::Dialect::Encoding::IR
     iree::compiler::Dialect::HAL::Analysis
     iree::compiler::Dialect::HAL::Conversion::HALToVM
     iree::compiler::Dialect::HAL::hal_imports

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALDialect.cpp
@@ -137,8 +137,7 @@ public:
                                                      resultSet);
       for (auto targetAttr : resultSet) {
         Attribute result = targetAttr;
-        if (auto attr =
-                targetAttr.getConfiguration().getNamed("encoding")) {
+        if (auto attr = targetAttr.getConfiguration().getNamed("encoding")) {
           if (auto encodingLayoutAttr =
                   dyn_cast<IREE::Encoding::EncodingLayoutAttrInterface>(
                       attr->getValue())) {

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
@@ -5,20 +5,31 @@
 // encoding is updated that carries resolved layouts.
 //------------------------------------------------------------------------------
 
-#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {encoding_layout = #iree_cpu.vmvx_encoding_layout<>}>
+#map0 = affine_map<(m, n, k) -> (m, k)>
+#map1 = affine_map<(m, n, k) -> (k, n)>
+#map2 = affine_map<(m, n, k) -> (m, n)>
+#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {encoding = #iree_cpu.vmvx_encoding_layout<>}>
+#executable_target_x86_64 = #hal.executable.target<"llvm-cpu", "xyz", {encoding = #iree_cpu.cpu_encoding_layout<>, target_triple="x86_64-xyz-xyz", cpu_features="+avx512f"}>
 #device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
-#encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32]>
+#device_target_local_1_ = #hal.device.target<"local", {ordinal = 1 : index}, [#executable_target_x86_64]> : !hal.device
+#encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map0, #map1, #map2]>
 module {
   util.global private @device_a = #device_target_local_0_
+  util.global private @device_b = #device_target_local_1_
 
-  util.func public @tensor_sizeof(%d0: index, %d1: index) -> index {
-    %size = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<?x?xf32, #encoding>{%d0, %d1} : index
-    util.return %size : index
+  util.func public @tensor_sizeof(%d0: index, %d1: index) -> (index, index) {
+    %size0 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<?x?xf32, #encoding>{%d0, %d1} : index
+    %size1 = stream.tensor.sizeof on(#hal.device.affinity<@device_b>) tensor<?x?xf32, #encoding>{%d0, %d1} : index
+    util.return %size0, %size1 : index, index
   }
 }
-// CHECK:       #[[EXECUTABLE:.+]] = #hal.executable.target<"vmvx",
-// CHECK:       #[[$ENCODING:.+]] = #iree_encoding.encoding
-// CHECK-SAME:    layouts = [#[[EXECUTABLE]]]
+// CHECK:       #[[$ENCODING0:.+]] = #iree_encoding.encoding
+// CHECK-SAME:    #iree_cpu.vmvx_encoding_layout
+// CHECK-SAME:    encoding_info = {innerDimsPos = [{{.+}}], innerTileSizes = [{{.+}}], outerDimsPerm = [{{.+}}]}
+// CHECK:       #[[$ENCODING1:.+]] = #iree_encoding.encoding
+// CHECK-SAME:    #iree_cpu.cpu_encoding_layout
+// CHECK-SAME:    encoding_info = {innerDimsPos = [{{.+}}], innerTileSizes = [{{.+}}], outerDimsPerm = [{{.+}}]}
 // CHECK-LABEL: util.func public @tensor_sizeof
-// CHECK:         %[[RES:.+]] = stream.tensor.sizeof {{.+}} tensor<?x?xf32, #[[$ENCODING]]>
-// CHECK:         return %[[RES]]
+// CHECK:         %[[D0_RES:.+]] = stream.tensor.sizeof {{.+}} tensor<?x?xf32, #[[$ENCODING0]]>
+// CHECK:         %[[D1_RES:.+]] = stream.tensor.sizeof {{.+}} tensor<?x?xf32, #[[$ENCODING1]]>
+// CHECK:         return %[[D0_RES]], %[[D1_RES]]


### PR DESCRIPTION
The revision attaches the layouts to Stream tensor ops, e.g., stream.tensor.sizeof, etc. Each layout is wrapped with an attribute where the attribute should implement the `calculateStorageSizeInBytes` interface method. Because only the device/target knows the details. It provides a way to materialize the serialized layouts into actual storage size.

To teach the pass about layouts, there are few core changes happening in the revision.

1. The revision introduces `cloneWithSimplifiedConfig` interface method to EncodingLayoutAttrInterface. Each backend encoding attribute can filter needed configurations when making layout resolvers in HALAffinityAnalysisDialectInterface. This is needed because attributes are not mutable. We always need to create a new attribute if we want to update the parameters. The main benifit is that it makes the IR dump much less verbose.
2. The revision also introduces `getLayout` interface method, which returns the encoded layouts into encoding attributes. The CPU and VMVX encoding attributes implement it in the revision, and it returns the serialized MaterializeEncodingInfo struct as a dictionary attribute. See below example for more details.

```
... layouts = [#iree_cpu.vmvx_encoding_layout<configuration =
  {encoding_info =
    {innerDimsPos = [0, 1],
     innerTileSizes = [8, 4],
     outerDimsPerm = [0, 1]}}>
]
```