### PR TITLE
[DispatchCreation] Collapse dynamic dims

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ReshapeFusion.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ReshapeFusion.cpp
@@ -888,12 +888,6 @@ collapseOpIterationDims(AttentionOp op,
       }))
     return failure();
 
-  FailureOr<SmallVector<int64_t>> staticLoops = op.getStaticLoopRanges();
-  if (failed(staticLoops) ||
-      llvm::any_of(staticLoops.value(), ShapedType::isDynamic)) {
-    return failure();
-  }
-
   CollapsingInfo collapsingInfo;
   if (failed(
           collapsingInfo.initialize(op.getNumLoops(), foldedIterationDims))) {


### PR DESCRIPTION
Enable collapsing dynamic dimensions in `CollapseDimensionsPass`

~I'm fairly certain that the issue with the sharktank tests is unrelated to `CollapseDimensions`, I fully disabled it an still hit the same error. A similar issue was experienced when testing IREE with https://github.com/llvm/llvm-project/pull/113501. This was ran on CI on commit https://github.com/iree-org/iree/commit/62b4c1cac1d206097bb8cf398726bda556b7a186 (see parent commit for llvm submodule change)~