### PR TITLE
Expand runtime_tracing job to include Windows and macOS.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@ed74d11c0b343532753ecead8a951bb09bb34bc9 # v1.2.14
         with:
-          key: ${{ github.job }}-${{ matrix.provider }}
+          key: ${{ github.job }}-${{ matrix.runs-on}}-${{ matrix.provider }}
           save: ${{ needs.setup.outputs.write-caches == 1 }}
       - name: CMake - configure
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,10 @@ jobs:
       matrix:
         runs-on: [ubuntu-24.04, windows-2022, macos-14]
         provider: [tracy, console]
+        # TODO: re-enable macOS Tracy build once it has no errors
+        exclude:
+          - runs-on: macos-14
+            provider: tracy
     env:
       BUILD_DIR: build-tracing
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,24 +157,43 @@ jobs:
 
   runtime_tracing:
     needs: setup
-    name: "runtime_tracing :: ${{ matrix.provider }} provider"
+    name: "runtime_tracing :: ${{ matrix.runs-on }} :: ${{ matrix.provider }}"
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'runtime_tracing')
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.runs-on }}
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - provider: tracy
-          - provider: console
+        runs-on: [ubuntu-24.04, windows-2022, macos-14]
+        provider: [tracy, console]
     env:
       BUILD_DIR: build-tracing
-      CC: clang
-      CXX: clang++
-      TRACING_PROVIDER: ${{ matrix.provider }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Install requirements
-        run: sudo apt update && sudo apt install -y ninja-build
+
+      - name: (Linux) Install requirements
+        if: contains(matrix.runs-on, 'ubuntu')
+        run: |
+          sudo apt update
+          sudo apt install -y ninja-build
+          echo "CC=clang" >> $GITHUB_ENV
+          echo "CXX=clang++" >> $GITHUB_ENV
+      - name: (Windows) Configure MSVC
+        if: contains(matrix.runs-on, 'windows')
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+      - name: (macOS) Install requirements
+        if: contains(matrix.runs-on, 'macos')
+        run: brew install ninja ccache coreutils bash
+
+      - name: (Linux/Windows) Set driver options
+        if: contains(matrix.runs-on, 'ubuntu') || contains(matrix.runs-on, 'windows')
+        run: echo IREE_DRIVER_OPTIONS="-DIREE_HAL_DRIVER_CUDA=ON -DIREE_HAL_DRIVER_HIP=ON -DIREE_HAL_DRIVER_VULKAN=ON" >> $GITHUB_ENV
+      - name: (macOS) Set driver options
+        if: contains(matrix.runs-on, 'macos')
+        run: echo IREE_DRIVER_OPTIONS="-DIREE_HAL_DRIVER_METAL=ON -DIREE_HAL_DRIVER_VULKAN=OFF" >> $GITHUB_ENV
+
       - name: Checkout runtime submodules
         run: bash ./build_tools/scripts/git/update_runtime_submodules.sh
       - name: ccache
@@ -193,9 +212,8 @@ jobs:
             -DIREE_BUILD_COMPILER=OFF \
             -DIREE_ENABLE_LLD=ON \
             -DIREE_ENABLE_RUNTIME_TRACING=ON \
-            -DIREE_TRACING_PROVIDER=${TRACING_PROVIDER} \
-            -DIREE_HAL_DRIVER_CUDA=ON \
-            -DIREE_HAL_DRIVER_HIP=ON
+            -DIREE_TRACING_PROVIDER=${{ matrix.provider }} \
+            ${IREE_DRIVER_OPTIONS}
       - name: CMake - build
         run: cmake --build ${BUILD_DIR} -- -k 0
 


### PR DESCRIPTION
This is very similar to the `runtime` job matrix up higher in the file. Could merge the jobs into a more complicated matrix, though this does let us filter the enabled jobs 🤔.

Configuration | Timing | Logs
-- | -- | --
Cold cache | 8m14s | https://github.com/ScottTodd/iree/actions/runs/12698152001
Warm cache | 3m14s| https://github.com/ScottTodd/iree/actions/runs/12698381905

ci-exactly: runtime_tracing