### PR TITLE
Fix newlines in markdown mermaid.js diagrams.

### DIFF
--- a/docs/website/docs/developers/general/testing-guide.md
+++ b/docs/website/docs/developers/general/testing-guide.md
@@ -438,7 +438,7 @@ Testing ONNX programs follows several stages:
 
 ```mermaid
 graph LR
-  Import -. "\n(offline)" .-> Compile
+  Import -. "<br>(offline)" .-> Compile
   Compile --> Run
 ```
 

--- a/docs/website/docs/guides/ml-frameworks/onnx.md
+++ b/docs/website/docs/guides/ml-frameworks/onnx.md
@@ -34,8 +34,8 @@ graph LR
     Compiled programs are used by the runtime.
   }
 
-  A["ONNX\n(protobuf)"]
-  B["MLIR\n(torch-mlir)"]
+  A["ONNX<br>(protobuf)"]
+  B["MLIR<br>(torch-mlir)"]
   C[IREE compiler]
   D[Runtime deployment]
 

--- a/docs/website/docs/guides/ml-frameworks/pytorch.md
+++ b/docs/website/docs/guides/ml-frameworks/pytorch.md
@@ -285,7 +285,7 @@ graph LR
   }
 
   subgraph Python
-    compiledmodule("aot.CompiledModule\n\n- extend nn.Module\n- export globals\n- set shapes/dtypes")
+    compiledmodule("aot.CompiledModule<br><br>- extend nn.Module<br>- export globals<br>- set shapes/dtypes")
     export(["ExportOutput (MLIR)"])
     compiledmodule -- "aot.export()" --> export
   end


### PR DESCRIPTION
Current (broken):
![image](https://github.com/user-attachments/assets/1f090cf3-f77f-4b1a-abed-1209e7e7b2f7)

Fixed:
![image](https://github.com/user-attachments/assets/dd3b630e-f529-495e-98b4-e081a336367b)
