### PR TITLE
Enable macOS Tracy CI build.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,10 +168,6 @@ jobs:
       matrix:
         runs-on: [ubuntu-24.04, windows-2022, macos-14]
         provider: [tracy, console]
-        # TODO: re-enable macOS Tracy build once it has no errors
-        exclude:
-          - runs-on: macos-14
-            provider: tracy
     env:
       BUILD_DIR: build-tracing
     steps:


### PR DESCRIPTION
This has been broken since https://github.com/iree-org/iree/pull/19625 and is now fixed with https://github.com/iree-org/iree/pull/19653.

ci-exactly: runtime_tracing