### PR TITLE
Implement ValueBoundsOpInterface on HAL ID/count ops, util.assume.int

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Interfaces/Interfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/Interfaces.cpp
@@ -64,6 +64,7 @@ void registerCodegenInterfaces(DialectRegistry &registry) {
   affine::registerValueBoundsOpInterfaceExternalModels(registry);
   arith::registerValueBoundsOpInterfaceExternalModels(registry);
   bufferization::registerTransformDialectExtension(registry);
+  gpu::registerValueBoundsOpInterfaceExternalModels(registry);
   gpu::registerTransformDialectExtension(registry);
   gpu::registerValueBoundsOpInterfaceExternalModels(registry);
   linalg::registerTransformDialectExtension(registry);

--- a/compiler/src/iree/compiler/ExternalInterfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/ExternalInterfaces/BUILD.bazel
@@ -16,6 +16,7 @@ iree_compiler_cc_library(
     name = "ExternalModels",
     srcs = [
         "FlowExternalModels.cpp",
+        "HALExternalModels.cpp",
         "Interfaces.cpp",
         "LinalgExtExternalModels.cpp",
         "StreamExternalModels.cpp",
@@ -23,6 +24,7 @@ iree_compiler_cc_library(
     ],
     hdrs = [
         "FlowExternalModels.h",
+        "HALExternalModels.h",
         "Interfaces.h",
         "LinalgExtExternalModels.h",
         "StreamExternalModels.h",

--- a/compiler/src/iree/compiler/ExternalInterfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/ExternalInterfaces/CMakeLists.txt
@@ -15,12 +15,14 @@ iree_cc_library(
     ExternalModels
   HDRS
     "FlowExternalModels.h"
+    "HALExternalModels.h"
     "Interfaces.h"
     "LinalgExtExternalModels.h"
     "StreamExternalModels.h"
     "UtilExternalModels.h"
   SRCS
     "FlowExternalModels.cpp"
+    "HALExternalModels.cpp"
     "Interfaces.cpp"
     "LinalgExtExternalModels.cpp"
     "StreamExternalModels.cpp"

--- a/compiler/src/iree/compiler/ExternalInterfaces/HALExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/HALExternalModels.cpp
@@ -1,0 +1,66 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/ExternalInterfaces/HALExternalModels.h"
+
+#include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "mlir/Interfaces/ValueBoundsOpInterface.h"
+
+namespace mlir::iree_compiler {
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// ValueBoundsOpInterface
+//===----------------------------------------------------------------------===//
+
+template <typename IDOp>
+struct IDOpValueBoundsInterface : public ValueBoundsOpInterface::ExternalModel<
+                                      IDOpValueBoundsInterface<IDOp>, IDOp> {
+  void populateBoundsForIndexValue(Operation *op, Value value,
+                                   ValueBoundsConstraintSet &cstr) const {
+    auto boundOp = cast<IDOp>(op);
+    assert(value == boundOp.getResult() && "value must be op result");
+    cstr.bound(value) >= 0;
+    if (boundOp.getUpperBound()) {
+      cstr.bound(value) < boundOp.getUpperBound()->getSExtValue();
+    }
+  }
+};
+
+template <typename CountOp>
+struct CountOpValueBoundsInterface
+    : public ValueBoundsOpInterface::ExternalModel<
+          CountOpValueBoundsInterface<CountOp>, CountOp> {
+  void populateBoundsForIndexValue(Operation *op, Value value,
+                                   ValueBoundsConstraintSet &cstr) const {
+    auto boundOp = cast<CountOp>(op);
+    assert(value == boundOp.getResult() && "value must be op result");
+    cstr.bound(value) >= 1;
+    if (boundOp.getUpperBound()) {
+      cstr.bound(value) <= boundOp.getUpperBound()->getSExtValue();
+    }
+  }
+};
+
+} // namespace
+
+void registerHALExternalModels(DialectRegistry &registry) {
+  registry.addExtension(+[](MLIRContext *context,
+                            IREE::HAL::HALDialect *dialect) {
+    IREE::HAL::InterfaceWorkgroupIDOp::attachInterface<
+        IDOpValueBoundsInterface<IREE::HAL::InterfaceWorkgroupIDOp>>(*context);
+
+    IREE::HAL::InterfaceWorkgroupSizeOp::attachInterface<
+        CountOpValueBoundsInterface<IREE::HAL::InterfaceWorkgroupSizeOp>>(
+        *context);
+    IREE::HAL::InterfaceWorkgroupCountOp::attachInterface<
+        CountOpValueBoundsInterface<IREE::HAL::InterfaceWorkgroupCountOp>>(
+        *context);
+  });
+}
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/ExternalInterfaces/HALExternalModels.h
+++ b/compiler/src/iree/compiler/ExternalInterfaces/HALExternalModels.h
@@ -1,0 +1,20 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_EXTERNALINTERFACES_HALEXTERNALMODELS_H_
+#define IREE_COMPILER_EXTERNALINTERFACES_HALEXTERNALMODELS_H_
+
+namespace mlir {
+class DialectRegistry;
+} // namespace mlir
+
+namespace mlir::iree_compiler {
+
+void registerHALExternalModels(DialectRegistry &registry);
+
+} // namespace mlir::iree_compiler
+
+#endif // IREE_COMPILER_EXTERNALINTERFACES_HALEXTERNALMODELS_H_

--- a/compiler/src/iree/compiler/ExternalInterfaces/Interfaces.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/Interfaces.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/ExternalInterfaces/Interfaces.h"
 
 #include "iree/compiler/ExternalInterfaces/FlowExternalModels.h"
+#include "iree/compiler/ExternalInterfaces/HALExternalModels.h"
 #include "iree/compiler/ExternalInterfaces/LinalgExtExternalModels.h"
 #include "iree/compiler/ExternalInterfaces/StreamExternalModels.h"
 #include "iree/compiler/ExternalInterfaces/UtilExternalModels.h"
@@ -15,6 +16,7 @@ namespace mlir::iree_compiler {
 
 void registerExternalInterfaces(DialectRegistry &registry) {
   registerFlowExternalModels(registry);
+  registerHALExternalModels(registry);
   registerLinalgExtExternalModels(registry);
   registerStreamExternalModels(registry);
   registerUtilExternalModels(registry);


### PR DESCRIPTION
Add a model of ValueBoundsOpInterface (the one used for reasoning
about affine maps and loops) to the HAL ID ops and util.assume.int to
improve both loop invariant code motion and, in the future,
single-iteration loop removal.