### PR TITLE
[Codegen] Refactor RemoveSingleIteratinLoop  to use ValueBoundsOpInte…

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -534,6 +534,7 @@ def PolynomialApproximationPass :
 def PropagateDispatchSizeBoundsPass :
     InterfacePass<"iree-codegen-propagate-dispatch-size-bounds", "mlir::FunctionOpInterface"> {
   let summary = "Pass to annotate workitem and workgroup IDs with known bounds";
+  let dependentDialects = ["::mlir::arith::ArithDialect"];
 }
 
 def PropagateReshapesByExpansionPass :

--- a/compiler/src/iree/compiler/Codegen/Common/RemoveSingleIterationLoop.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/RemoveSingleIterationLoop.cpp
@@ -24,89 +24,9 @@ namespace mlir::iree_compiler {
 #define GEN_PASS_DEF_REMOVESINGLEITERATIONLOOPPASS
 #include "iree/compiler/Codegen/Common/Passes.h.inc"
 
-/// Converts a symbolic GPU processor dimension to its numeric one.
-static unsigned dimToIndex(gpu::Dimension dim) {
-  switch (dim) {
-  case gpu::Dimension::x:
-    return 0;
-  case gpu::Dimension::y:
-    return 1;
-  case gpu::Dimension::z:
-    return 2;
-  default:
-    assert(false && "invalid dimension");
-    return 0;
-  }
-}
-
-/// If the value is a threadID return the range [0, workgroupSize-1].
-/// If the number of workgroup is known also return the range of workgroupId ad
-/// workgroupCount.
-static std::optional<std::pair<AffineExpr, AffineExpr>>
-getWorkgroupRange(Value processorValue, SmallVectorImpl<Value> & /*dims*/,
-                  SmallVectorImpl<Value> & /*symbols*/,
-                  ArrayRef<int64_t> workgroupCount,
-                  ArrayRef<int64_t> workgroupSize) {
-  if (!workgroupSize.empty()) {
-    if (auto idOp = processorValue.getDefiningOp<gpu::ThreadIdOp>()) {
-      unsigned index = dimToIndex(idOp.getDimension());
-      OpBuilder b(processorValue.getContext());
-      AffineExpr zero = b.getAffineConstantExpr(0);
-      AffineExpr ubExpr = b.getAffineConstantExpr(workgroupSize[index]);
-      return std::make_pair(zero, ubExpr - 1);
-    }
-    if (auto dimOp = processorValue.getDefiningOp<gpu::BlockDimOp>()) {
-      OpBuilder builder(processorValue.getContext());
-      unsigned index = dimToIndex(dimOp.getDimension());
-      AffineExpr bound = builder.getAffineConstantExpr(workgroupSize[index]);
-      return std::make_pair(bound, bound);
-    }
-  }
-
-  if (workgroupCount.empty() ||
-      llvm::any_of(workgroupCount, ShapedType::isDynamic))
-    return std::nullopt;
-
-  if (auto idOp =
-          processorValue.getDefiningOp<IREE::HAL::InterfaceWorkgroupIDOp>()) {
-    OpBuilder builder(processorValue.getContext());
-
-    // Can't infer the range when workroupCount is unknown.
-    unsigned index = idOp.getDimension().getZExtValue();
-    if (!workgroupCount[index])
-      return std::nullopt;
-
-    AffineExpr zero = builder.getAffineConstantExpr(0);
-    AffineExpr ubExpr = builder.getAffineConstantExpr(workgroupCount[index]);
-    return std::make_pair(zero, ubExpr - 1);
-  }
-  if (auto dimOp = processorValue
-                       .getDefiningOp<IREE::HAL::InterfaceWorkgroupCountOp>()) {
-    OpBuilder builder(processorValue.getContext());
-
-    // Can't infer the range when workroupCount is unknown.
-    unsigned index = dimOp.getDimension().getZExtValue();
-    if (!workgroupCount[index])
-      return std::nullopt;
-
-    AffineExpr bound = builder.getAffineConstantExpr(workgroupCount[index]);
-    return std::make_pair(bound, bound);
-  }
-  return std::nullopt;
-}
-
-static LogicalResult removeOneTripTiledLoops(mlir::FunctionOpInterface funcOp,
-                                             ArrayRef<int64_t> workgroupSize,
-                                             ArrayRef<int64_t> numWorkgroups) {
-  auto getWorkgroupRangeFn = [numWorkgroups,
-                              workgroupSize](Value processorValue,
-                                             SmallVectorImpl<Value> &dims,
-                                             SmallVectorImpl<Value> &symbols) {
-    return getWorkgroupRange(processorValue, dims, symbols, numWorkgroups,
-                             workgroupSize);
-  };
+static LogicalResult removeOneTripTiledLoops(mlir::FunctionOpInterface funcOp) {
   RewritePatternSet patterns(funcOp.getContext());
-  populateRemoveSingleIterationLoopPattern(patterns, getWorkgroupRangeFn);
+  populateRemoveSingleIterationLoopPattern(patterns);
   return applyPatternsGreedily(funcOp, std::move(patterns));
 }
 
@@ -118,15 +38,7 @@ class RemoveSingleIterationLoopPass final
   void runOnOperation() override {
     auto funcOp = getOperation();
 
-    std::optional<SmallVector<int64_t>> workgroupSize =
-        getWorkgroupSize(funcOp);
-    if (!workgroupSize) {
-      return;
-    }
-    SmallVector<int64_t> numWorkgroups = getStaticNumWorkgroups(funcOp);
-
-    if (failed(removeOneTripTiledLoops(funcOp, workgroupSize.value(),
-                                       numWorkgroups))) {
+    if (failed(removeOneTripTiledLoops(funcOp))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/test/propagate_dispatch_size_bounds.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/propagate_dispatch_size_bounds.mlir
@@ -27,37 +27,37 @@ hal.executable private @static {
     builtin.module {
 // CHECK-LABEL: func.func @static()
       func.func @static() {
-// CHECK: gpu.thread_id x upper_bound 64
-// CHECK: gpu.thread_id y upper_bound 2
-// CHECK: gpu.thread_id z upper_bound 1
+// CHECK-NEXT: gpu.thread_id x upper_bound 64
+// CHECK-NEXT: gpu.thread_id y upper_bound 2
+// CHECK-NEXT: gpu.thread_id z upper_bound 1
         %thread_id_x = gpu.thread_id x
         %thread_id_y = gpu.thread_id y
         %thread_id_z = gpu.thread_id z
 
-// CHECK: gpu.block_dim x upper_bound 64
-// CHECK: gpu.block_dim y upper_bound 2
-// CHECK: gpu.block_dim z upper_bound 1
+// CHECK-NEXT: arith.constant 64
+// CHECK-NEXT: arith.constant 2
+// CHECK-NEXT: arith.constant 1
         %block_dim_x = gpu.block_dim x
         %block_dim_y = gpu.block_dim y
         %block_dim_z = gpu.block_dim z
 
-// CHECK: hal.interface.workgroup.size[0] upper_bound 64
-// CHECK: hal.interface.workgroup.size[1] upper_bound 2
-// CHECK: hal.interface.workgroup.size[2] upper_bound 1
+// CHECK-NEXT: arith.constant 64
+// CHECK-NEXT: arith.constant 2
+// CHECK-NEXT: arith.constant 1
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_size_z = hal.interface.workgroup.size[2] : index
 
-// CHECK: hal.interface.workgroup.id[0] upper_bound 32
-// CHECK: hal.interface.workgroup.id[1] upper_bound 8
-// CHECK: hal.interface.workgroup.id[2] upper_bound 1
+// CHECK-NEXT: hal.interface.workgroup.id[0] upper_bound 32
+// CHECK-NEXT: hal.interface.workgroup.id[1] upper_bound 8
+// CHECK-NEXT: hal.interface.workgroup.id[2] upper_bound 1
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
         %workgroup_id_y = hal.interface.workgroup.id[1] : index
         %workgroup_id_z = hal.interface.workgroup.id[2] : index
 
-// CHECK: hal.interface.workgroup.count[0] upper_bound 32
-// CHECK: hal.interface.workgroup.count[1] upper_bound 8
-// CHECK: hal.interface.workgroup.count[2] upper_bound 1
+// CHECK-NEXT: arith.constant 32
+// CHECK-NEXT: arith.constant 8
+// CHECK-NEXT: arith.constant 1
         %workgroup_conut_x = hal.interface.workgroup.count[0] : index
         %workgroup_count_y = hal.interface.workgroup.count[1] : index
         %workgroup_count_z = hal.interface.workgroup.count[2] : index
@@ -95,30 +95,37 @@ hal.executable private @dynamic {
     builtin.module {
 // CHECK-LABEL: func.func @dynamic()
       func.func @dynamic() {
-// CHECK: gpu.thread_id x upper_bound 1024
-// CHECK: gpu.thread_id y upper_bound 1024
-// CHECK: gpu.thread_id z upper_bound 1024
+// CHECK-NEXT: gpu.thread_id x upper_bound 1024
+// CHECK-NEXT: gpu.thread_id y upper_bound 1024
+// CHECK-NEXT: gpu.thread_id z upper_bound 1024
         %thread_id_x = gpu.thread_id x
         %thread_id_y = gpu.thread_id y
         %thread_id_z = gpu.thread_id z
 
-// CHECK: hal.interface.workgroup.size[0] upper_bound 1024
-// CHECK: hal.interface.workgroup.size[1] upper_bound 1024
-// CHECK: hal.interface.workgroup.size[2] upper_bound 1024
+// CHECK-NEXT: gpu.block_dim x upper_bound 1024
+// CHECK-NEXT: gpu.block_dim y upper_bound 1024
+// CHECK-NEXT: gpu.block_dim z upper_bound 1024
+        %block_dim_x = gpu.block_dim x
+        %block_dim_y = gpu.block_dim y
+        %block_dim_z = gpu.block_dim z
+
+// CHECK-NEXT: hal.interface.workgroup.size[0] upper_bound 1024
+// CHECK-NEXT: hal.interface.workgroup.size[1] upper_bound 1024
+// CHECK-NEXT: hal.interface.workgroup.size[2] upper_bound 1024
         %workgroup_size_x = hal.interface.workgroup.size[0] : index
         %workgroup_size_y = hal.interface.workgroup.size[1] : index
         %workgroup_size_z = hal.interface.workgroup.size[2] : index
 
-// CHECK: hal.interface.workgroup.id[0] upper_bound 2147483647
-// CHECK: hal.interface.workgroup.id[1] upper_bound 2147483647
-// CHECK: hal.interface.workgroup.id[2] upper_bound 1
+// CHECK-NEXT: hal.interface.workgroup.id[0] upper_bound 2147483647
+// CHECK-NEXT: hal.interface.workgroup.id[1] upper_bound 2147483647
+// CHECK-NEXT: hal.interface.workgroup.id[2] upper_bound 1
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
         %workgroup_id_y = hal.interface.workgroup.id[1] : index
         %workgroup_id_z = hal.interface.workgroup.id[2] : index
 
-// CHECK: hal.interface.workgroup.count[0] upper_bound 2147483647
-// CHECK: hal.interface.workgroup.count[1] upper_bound 2147483647
-// CHECK: hal.interface.workgroup.count[2] upper_bound 1
+// CHECK-NEXT: hal.interface.workgroup.count[0] upper_bound 2147483647
+// CHECK-NEXT: hal.interface.workgroup.count[1] upper_bound 2147483647
+// CHECK-NEXT: arith.constant 1
         %workgroup_conut_x = hal.interface.workgroup.count[0] : index
         %workgroup_count_y = hal.interface.workgroup.count[1] : index
         %workgroup_count_z = hal.interface.workgroup.count[2] : index
@@ -146,16 +153,16 @@ hal.executable private @static_cpu {
     builtin.module {
 // CHECK-LABEL: func.func @static_cpu()
       func.func @static_cpu() {
-// CHECK: hal.interface.workgroup.id[0] upper_bound 32
-// CHECK: hal.interface.workgroup.id[1] upper_bound 8
-// CHECK: hal.interface.workgroup.id[2] upper_bound 1
+// CHECK-NEXT: hal.interface.workgroup.id[0] upper_bound 32
+// CHECK-NEXT: hal.interface.workgroup.id[1] upper_bound 8
+// CHECK-NEXT: hal.interface.workgroup.id[2] upper_bound 1
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
         %workgroup_id_y = hal.interface.workgroup.id[1] : index
         %workgroup_id_z = hal.interface.workgroup.id[2] : index
 
-// CHECK: hal.interface.workgroup.count[0] upper_bound 32
-// CHECK: hal.interface.workgroup.count[1] upper_bound 8
-// CHECK: hal.interface.workgroup.count[2] upper_bound 1
+// CHECK-NEXT: arith.constant 32
+// CHECK-NEXT: arith.constant 8
+// CHECK-NEXT: arith.constant 1
         %workgroup_conut_x = hal.interface.workgroup.count[0] : index
         %workgroup_count_y = hal.interface.workgroup.count[1] : index
         %workgroup_count_z = hal.interface.workgroup.count[2] : index
@@ -183,16 +190,16 @@ hal.executable private @dynamic_cpu {
     builtin.module {
 // CHECK-LABEL: @dynamic_cpu()
       func.func @dynamic_cpu() {
-// CHECK: hal.interface.workgroup.id[0] : index
-// CHECK: hal.interface.workgroup.id[1] : index
-// CHECK: hal.interface.workgroup.id[2] upper_bound 1 : index
+// CHECK-NEXT: hal.interface.workgroup.id[0] : index
+// CHECK-NEXT: hal.interface.workgroup.id[1] : index
+// CHECK-NEXT: hal.interface.workgroup.id[2] upper_bound 1 : index
         %workgroup_id_x = hal.interface.workgroup.id[0] : index
         %workgroup_id_y = hal.interface.workgroup.id[1] : index
         %workgroup_id_z = hal.interface.workgroup.id[2] : index
 
-// CHECK: hal.interface.workgroup.count[0] : index
-// CHECK: hal.interface.workgroup.count[1] : index
-// CHECK: hal.interface.workgroup.count[2] upper_bound 1 : index
+// CHECK-NEXT: hal.interface.workgroup.count[0] : index
+// CHECK-NEXT: hal.interface.workgroup.count[1] : index
+// CHECK-NEXT: arith.constant 1 : index
         %workgroup_conut_x = hal.interface.workgroup.count[0] : index
         %workgroup_count_y = hal.interface.workgroup.count[1] : index
         %workgroup_count_z = hal.interface.workgroup.count[2] : index

--- a/compiler/src/iree/compiler/Codegen/Interfaces/Interfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/Interfaces.cpp
@@ -64,6 +64,7 @@ void registerCodegenInterfaces(DialectRegistry &registry) {
   affine::registerValueBoundsOpInterfaceExternalModels(registry);
   arith::registerValueBoundsOpInterfaceExternalModels(registry);
   bufferization::registerTransformDialectExtension(registry);
+  gpu::registerValueBoundsOpInterfaceExternalModels(registry);
   gpu::registerTransformDialectExtension(registry);
   gpu::registerValueBoundsOpInterfaceExternalModels(registry);
   linalg::registerTransformDialectExtension(registry);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -126,6 +126,7 @@ static void addTileAndDistributePasses(OpPassManager &funcPassManager) {
   funcPassManager.addPass(createCSEPass());
   funcPassManager.addPass(createFuseTensorPadWithConsumerPass());
   funcPassManager.addPass(createConcretizePadResultShapePass());
+  funcPassManager.addPass(createPropagateDispatchSizeBoundsPass());
 }
 
 //===---------------------------------------------------------------------===//
@@ -447,6 +448,7 @@ void addMultiTilingExpertPassPipeline(OpPassManager &funcPassManager,
   addCPUBufferizePasses(funcPassManager);
 
   // Run IREE specific passes before vector lowering expert.
+  funcPassManager.addPass(createPropagateDispatchSizeBoundsPass());
   funcPassManager.addPass(createRemoveSingleIterationLoopPass());
 
   {
@@ -510,6 +512,7 @@ void addConvTileAndDecomposeExpertPassPipeline(
   addCPUBufferizePasses(funcPassManager);
 
   // Run IREE specific passes before vector lowering expert.
+  funcPassManager.addPass(createPropagateDispatchSizeBoundsPass());
   funcPassManager.addPass(createRemoveSingleIterationLoopPass());
 
   {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -163,6 +163,7 @@ static void addLoopMaterializationPasses(OpPassManager &funcPassManager) {
   funcPassManager.addPass(IREE::LinalgExt::createLinalgExtToLoopsPass());
   funcPassManager.addPass(createMemrefCopyToLinalgPass());
   funcPassManager.addPass(createConvertLinalgToLoopsPass());
+  funcPassManager.addPass(createPropagateDispatchSizeBoundsPass());
   funcPassManager.addPass(createRemoveSingleIterationLoopPass());
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
@@ -394,6 +395,7 @@ void addSPIRVCooperativeMatrixVectorizePassPipeline(
   funcPassManager.addPass(
       createSPIRVTileAndPromotePass(SPIRVTileAndPromotePassOptions{
           /*promoteCMatrix=*/true, /*skipThreadLevel=*/true}));
+  funcPassManager.addPass(createPropagateDispatchSizeBoundsPass());
   funcPassManager.addPass(createRemoveSingleIterationLoopPass());
   // Run canonicalization patterns to propagate constant shape sizes after
   // removing trip-one loops.
@@ -421,6 +423,7 @@ void addSPIRVCooperativeMatrixVectorizePassPipeline(
     funcPassManager.addPass(createGPUReduceBankConflictsPass(options));
   }
 
+  funcPassManager.addPass(createPropagateDispatchSizeBoundsPass());
   // Performs high-level n-D mechanical vectorization. This does not perform
   // unrolling or lowering, which is done later.
   {
@@ -513,6 +516,7 @@ void addSPIRVMatmulPromoteVectorizePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createGPUDistributeSharedMemoryCopyPass());
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
+  funcPassManager.addPass(createPropagateDispatchSizeBoundsPass());
 
   {
     GPUReduceBankConflictsPassOptions options = {};
@@ -532,6 +536,7 @@ void addSPIRVMatmulPromoteVectorizePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createForOpCanonicalizationPass());
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
+  funcPassManager.addPass(createPropagateDispatchSizeBoundsPass());
   funcPassManager.addPass(createOptimizeVectorTransferPass());
 
   // Hoist loop invariant code to avoid pipelining it.
@@ -560,6 +565,7 @@ void addSPIRVSubgroupReducePassPipeline(OpPassManager &funcPassManager) {
   funcPassManager.addPass(createGPUTileReductionPass());
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
+  funcPassManager.addPass(createPropagateDispatchSizeBoundsPass());
 
   // Performs high-level n-D mechanical vectorization. This does not perform
   // unrolling or lowering, which is done later.
@@ -588,6 +594,7 @@ void addSPIRVSubgroupReducePassPipeline(OpPassManager &funcPassManager) {
 
   // Perform various vector-level cross-op optimizations like load-store
   // forwarding, shape casting and casting op cancelling.
+  funcPassManager.addPass(createPropagateDispatchSizeBoundsPass());
   funcPassManager.addPass(createOptimizeVectorTransferPass());
 
   // Simplify the IR for vector distribution.

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_reduction.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_reduction.mlir
@@ -142,8 +142,8 @@ func.func @warp_reduction_dispatch() attributes {hal.executable.target = #execut
 
 //     CHECK-DAG:    %[[F0:.+]] = arith.constant 0.000000e+00 : f16
 
-//     CHECK-DAG:    %[[WGIDX:.+]] = hal.interface.workgroup.id[0] : index
-//     CHECK-DAG:    %[[WGIDY:.+]] = hal.interface.workgroup.id[1] : index
+//     CHECK-DAG:    %[[WGIDX:.+]] = hal.interface.workgroup.id[0] upper_bound 65535 : index
+//     CHECK-DAG:    %[[WGIDY:.+]] = hal.interface.workgroup.id[1] upper_bound 65535 : index
 //     CHECK-DAG:    %[[TIDX:.+]] = gpu.thread_id  x
 
 //     CHECK-DAG:    %[[SPAN0:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.h
@@ -96,10 +96,8 @@ using GetMinMaxExprFn =
         SmallVectorImpl<Value> &symbols)>;
 
 /// Insert pattern to remove single iteration loop. The pattern will detect
-/// single iteration loops based on the range returned by the lambda
-/// |getMinMaxFn| for some know values.
-void populateRemoveSingleIterationLoopPattern(RewritePatternSet &patterns,
-                                              GetMinMaxExprFn getMinMaxFn);
+/// single iteration loops based on the range returned ValueBoundsOpInterface.
+void populateRemoveSingleIterationLoopPattern(RewritePatternSet &patterns);
 
 /// Populate patterns that fold tensor.expand/collapse_shape into the source
 /// hal.interface.binding.subspan.

--- a/compiler/src/iree/compiler/Codegen/VMVX/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/Passes.cpp
@@ -71,6 +71,7 @@ void addVMVXDefaultPassPipeline(OpPassManager &funcPassManager,
   addCPUBufferizePasses(funcPassManager);
 
   // Cleanup the IR that may now have unused loops.
+  funcPassManager.addPass(createPropagateDispatchSizeBoundsPass());
   funcPassManager.addPass(createRemoveSingleIterationLoopPass());
 
   // Convert buffer-level microkernels.

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -3039,9 +3039,10 @@ class HAL_InterfaceWorkgroupOp<string mnemonic, list<Trait> traits = []>
   let results = (outs HAL_Dim:$result);
 
   let builders = [
-    OpBuilder<(ins "unsigned":$dim),
+    OpBuilder<(ins "unsigned":$dim, CArg<"std::optional<::llvm::APInt>", "std::nullopt">:$upper_bound),
     [{
-      build($_builder, $_state, $_builder.getIndexType(), $_builder.getIndexAttr(dim), ::mlir::IntegerAttr{});
+      build($_builder, $_state, $_builder.getIndexType(), $_builder.getIndexAttr(dim),
+        upper_bound.has_value() ? $_builder.getIndexAttr(upper_bound->getSExtValue()) : ::mlir::IntegerAttr{});
     }]>,
   ];
 

--- a/compiler/src/iree/compiler/ExternalInterfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/ExternalInterfaces/BUILD.bazel
@@ -16,6 +16,7 @@ iree_compiler_cc_library(
     name = "ExternalModels",
     srcs = [
         "FlowExternalModels.cpp",
+        "HALExternalModels.cpp",
         "Interfaces.cpp",
         "LinalgExtExternalModels.cpp",
         "StreamExternalModels.cpp",
@@ -23,6 +24,7 @@ iree_compiler_cc_library(
     ],
     hdrs = [
         "FlowExternalModels.h",
+        "HALExternalModels.h",
         "Interfaces.h",
         "LinalgExtExternalModels.h",
         "StreamExternalModels.h",

--- a/compiler/src/iree/compiler/ExternalInterfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/ExternalInterfaces/CMakeLists.txt
@@ -15,12 +15,14 @@ iree_cc_library(
     ExternalModels
   HDRS
     "FlowExternalModels.h"
+    "HALExternalModels.h"
     "Interfaces.h"
     "LinalgExtExternalModels.h"
     "StreamExternalModels.h"
     "UtilExternalModels.h"
   SRCS
     "FlowExternalModels.cpp"
+    "HALExternalModels.cpp"
     "Interfaces.cpp"
     "LinalgExtExternalModels.cpp"
     "StreamExternalModels.cpp"

--- a/compiler/src/iree/compiler/ExternalInterfaces/HALExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/HALExternalModels.cpp
@@ -1,0 +1,66 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/ExternalInterfaces/HALExternalModels.h"
+
+#include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "mlir/Interfaces/ValueBoundsOpInterface.h"
+
+namespace mlir::iree_compiler {
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// ValueBoundsOpInterface
+//===----------------------------------------------------------------------===//
+
+template <typename IDOp>
+struct IDOpValueBoundsInterface : public ValueBoundsOpInterface::ExternalModel<
+                                      IDOpValueBoundsInterface<IDOp>, IDOp> {
+  void populateBoundsForIndexValue(Operation *op, Value value,
+                                   ValueBoundsConstraintSet &cstr) const {
+    auto boundOp = cast<IDOp>(op);
+    assert(value == boundOp.getResult() && "value must be op result");
+    cstr.bound(value) >= 0;
+    if (boundOp.getUpperBound()) {
+      cstr.bound(value) < boundOp.getUpperBound()->getSExtValue();
+    }
+  }
+};
+
+template <typename CountOp>
+struct CountOpValueBoundsInterface
+    : public ValueBoundsOpInterface::ExternalModel<
+          CountOpValueBoundsInterface<CountOp>, CountOp> {
+  void populateBoundsForIndexValue(Operation *op, Value value,
+                                   ValueBoundsConstraintSet &cstr) const {
+    auto boundOp = cast<CountOp>(op);
+    assert(value == boundOp.getResult() && "value must be op result");
+    cstr.bound(value) >= 1;
+    if (boundOp.getUpperBound()) {
+      cstr.bound(value) <= boundOp.getUpperBound()->getSExtValue();
+    }
+  }
+};
+
+} // namespace
+
+void registerHALExternalModels(DialectRegistry &registry) {
+  registry.addExtension(+[](MLIRContext *context,
+                            IREE::HAL::HALDialect *dialect) {
+    IREE::HAL::InterfaceWorkgroupIDOp::attachInterface<
+        IDOpValueBoundsInterface<IREE::HAL::InterfaceWorkgroupIDOp>>(*context);
+
+    IREE::HAL::InterfaceWorkgroupSizeOp::attachInterface<
+        CountOpValueBoundsInterface<IREE::HAL::InterfaceWorkgroupSizeOp>>(
+        *context);
+    IREE::HAL::InterfaceWorkgroupCountOp::attachInterface<
+        CountOpValueBoundsInterface<IREE::HAL::InterfaceWorkgroupCountOp>>(
+        *context);
+  });
+}
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/ExternalInterfaces/HALExternalModels.h
+++ b/compiler/src/iree/compiler/ExternalInterfaces/HALExternalModels.h
@@ -1,0 +1,20 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_EXTERNALINTERFACES_HALEXTERNALMODELS_H_
+#define IREE_COMPILER_EXTERNALINTERFACES_HALEXTERNALMODELS_H_
+
+namespace mlir {
+class DialectRegistry;
+} // namespace mlir
+
+namespace mlir::iree_compiler {
+
+void registerHALExternalModels(DialectRegistry &registry);
+
+} // namespace mlir::iree_compiler
+
+#endif // IREE_COMPILER_EXTERNALINTERFACES_HALEXTERNALMODELS_H_

--- a/compiler/src/iree/compiler/ExternalInterfaces/Interfaces.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/Interfaces.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/ExternalInterfaces/Interfaces.h"
 
 #include "iree/compiler/ExternalInterfaces/FlowExternalModels.h"
+#include "iree/compiler/ExternalInterfaces/HALExternalModels.h"
 #include "iree/compiler/ExternalInterfaces/LinalgExtExternalModels.h"
 #include "iree/compiler/ExternalInterfaces/StreamExternalModels.h"
 #include "iree/compiler/ExternalInterfaces/UtilExternalModels.h"
@@ -15,6 +16,7 @@ namespace mlir::iree_compiler {
 
 void registerExternalInterfaces(DialectRegistry &registry) {
   registerFlowExternalModels(registry);
+  registerHALExternalModels(registry);
   registerLinalgExtExternalModels(registry);
   registerStreamExternalModels(registry);
   registerUtilExternalModels(registry);


### PR DESCRIPTION
…rface

Now, RemoveLingleIterationLoop uses the same ValueBoundsOpInterface logic as IREELoopInvariantCodeMotion, unifying the two passes and getting rid of a half-baked implementation of that constraint analysis.

In order to preserve existing functionality,
PropagateDispatchSizeBounds is updated to correctly propagate constant sizes to constants.

Also, add a test to make sure that the eliminator now understands the constraints imposed by delinearize and linearize.