### PR TITLE
[HAL] Use util.assume.int for memref alignments

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.cpp
@@ -55,6 +55,9 @@ std::optional<uint64_t> lookupOffsetOrAlignment(Value value) {
     }
   } else if (auto castOp = dyn_cast<arith::IndexCastUIOp>(op)) {
     return lookupOffsetOrAlignment(castOp.getOperand());
+  } else if (auto assumeOp = dyn_cast<IREE::Util::AssumeIntOp>(op)) {
+    return assumeOp.getUnionedUnsignedDivisor(
+        cast<OpResult>(value).getResultNumber());
   }
 
   // TODO(benvanik): more searching using util.align and other ops.


### PR DESCRIPTION
When bufferizing, use util.assume.int to construct memref.assume_alignment, since we can use the divisibility on those assumptions constrain the subspan offset.