### PR TITLE
Revert "Increase default threshold of TileLargeTensor pass (#19671)"

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -654,7 +654,7 @@ def TileLargeTensorsPass :
   ];
   let options = [
     Option<"maxVectorSize", "max-vector-size", "int64_t",
-           /*default=*/"256",
+           /*default=*/"64",
            "Maximum static size to tile to (i.e. all remaining ops will be smaller)">,
   ];
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
@@ -1013,8 +1013,9 @@ hal.executable public @main {
 //       CHECK:         scf.yield %[[REDUCE]]
 
 //       CHECK:   scf.for %{{.*}} = %{{.*}} to %c16 step %c1
-// CHECK-COUNT-4:     arith.addf {{.*}} : vector<9x9xf32>
-//       CHECK:       vector.transfer_write {{.*}} vector<9x9xi8>, memref<32x16x9x9xi8, #hal.descriptor_type<storage_buffer>>
+//       CHECK:     scf.for
+// CHECK-COUNT-4:     arith.addf {{.*}} : vector<9xf32>
+//       CHECK:       vector.transfer_write {{.*}} vector<9xi8>, memref<32x16x9x9xi8, #hal.descriptor_type<storage_buffer>>
 
 // -----
 


### PR DESCRIPTION
This reverts commit 3978ce6ffc652e3afd2ce479f3adb4edc7e6d680.

It may be causing regression in MI250 SDXL not observed on pre-submit 