### PR TITLE
[GlobalOpt] Adding NCHW quantized conv to conv lowering support

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/QuantizedConvToConv.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/QuantizedConvToConv.cpp
@@ -318,12 +318,13 @@ private:
 
     // Collapse the length-1 ending dimension away.
     ArrayRef<int64_t> collapseShape;
+    llvm::SmallVector<int64_t, 4> new_shape;
     if (isNHWC) {
       collapseShape = poolTy.getShape().drop_back();
     } else {
       auto shape = poolTy.getShape();
-      llvm::SmallVector<int64_t, 4> new_shape{shape[0], shape[2], shape[3]};
-      collapseShape = ArrayRef<int64_t>(new_shape);
+      new_shape = {shape[0], shape[2], shape[3]};
+      collapseShape = new_shape;
     }
 
     auto collapseTy = RankedTensorType::get(collapseShape, accETy);


### PR DESCRIPTION
This PR extends the original lowering from quantized conv to conv, such that:
- (Originally support) `linalg::Conv2DNhwcHwcfQOp` will be lowered to `linalg::Conv2DNhwcHwcfOp`
- (Added support) `linalg::Conv2DNchwFchwQOp` will be lowered to `linalg::Conv2DNchwFchwOp`

The changes mainly includes explicitly handling the dimension index difference between nchw and nhwc layout. It no longer use hard-coded dimension index and this is now derived from the type of the convolution.

The motivation of this PR is to allow resnet50 NCHW convolution plumb in the global optimization pipeline.