### PR TITLE
[Stream] Update executable functions in encoding specialization pass.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/BUILD.bazel
@@ -49,6 +49,7 @@ iree_compiler_cc_library(
         "EncodingInterfaces.cpp.inc",
         "EncodingOps.cpp",
         "EncodingOps.cpp.inc",
+        "EncodingTypeInterfaces.cpp.inc",
         "EncodingTypes.cpp.inc",
     ],
     hdrs = [
@@ -59,6 +60,7 @@ iree_compiler_cc_library(
         "EncodingInterfaces.h.inc",
         "EncodingOps.h",
         "EncodingOps.h.inc",
+        "EncodingTypeInterfaces.h.inc",
         "EncodingTypes.h",
         "EncodingTypes.h.inc",
     ],
@@ -153,6 +155,14 @@ iree_gentbl_cc_library(
         (
             ["--gen-attr-interface-defs"],
             "EncodingInterfaces.cpp.inc",
+        ),
+        (
+            ["--gen-type-interface-decls"],
+            "EncodingTypeInterfaces.h.inc",
+        ),
+        (
+            ["--gen-type-interface-defs"],
+            "EncodingTypeInterfaces.cpp.inc",
         ),
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/CMakeLists.txt
@@ -21,6 +21,7 @@ iree_cc_library(
     "EncodingInterfaces.h.inc"
     "EncodingOps.h"
     "EncodingOps.h.inc"
+    "EncodingTypeInterfaces.h.inc"
     "EncodingTypes.h"
     "EncodingTypes.h.inc"
   SRCS
@@ -32,6 +33,7 @@ iree_cc_library(
     "EncodingInterfaces.cpp.inc"
     "EncodingOps.cpp"
     "EncodingOps.cpp.inc"
+    "EncodingTypeInterfaces.cpp.inc"
     "EncodingTypes.cpp.inc"
   DEPS
     ::EncodingEnumsGen
@@ -94,6 +96,8 @@ iree_tablegen_library(
   OUTS
     --gen-attr-interface-decls EncodingInterfaces.h.inc
     --gen-attr-interface-defs EncodingInterfaces.cpp.inc
+    --gen-type-interface-decls EncodingTypeInterfaces.h.inc
+    --gen-type-interface-defs EncodingTypeInterfaces.cpp.inc
 )
 
 iree_tablegen_library(

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingDialect.cpp
@@ -21,6 +21,7 @@
 #include "iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp.inc"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingEnums.cpp.inc"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.cpp.inc"
+#include "iree/compiler/Dialect/Encoding/IR/EncodingTypeInterfaces.cpp.inc"
 #undef GET_ATTRDEF_CLASSES
 
 namespace mlir::iree_compiler::IREE::Encoding {

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
@@ -10,6 +10,10 @@
 include "iree/compiler/Dialect/Encoding/IR/EncodingBase.td"
 include "mlir/IR/BuiltinAttributeInterfaces.td"
 
+//===----------------------------------------------------------------------===//
+// Attribute Interfaces
+//===----------------------------------------------------------------------===//
+
 def IREEEncoding_EncodingLayoutAttrInterface :
   AttrInterface<"EncodingLayoutAttrInterface"> {
   let cppNamespace = "::mlir::iree_compiler::IREE::Encoding";
@@ -87,6 +91,40 @@ def IREEEncoding_EncodingLayoutAttrInterface :
         return {};
       }]
     >
+  ];
+}
+
+//===----------------------------------------------------------------------===//
+// Type Interfaces
+//===----------------------------------------------------------------------===//
+
+def IREEEncoding_EncodingTypeInterface :
+  TypeInterface<"EncodingTypeInterface"> {
+  let cppNamespace = "::mlir::iree_compiler::IREE::Encoding";
+
+  let description = [{
+    Interface used to access/update tensor types with encodings.
+  }];
+
+
+  let methods = [
+    InterfaceMethod<
+      [{
+        Returns the tensor type with the encoding.
+      }],
+      /*retTy=*/"::mlir::Type",
+      /*methodName=*/"getEncodingType",
+      /*args=*/(ins)
+    >,
+    InterfaceMethod<
+      [{
+        Returns the same type but with the updated encoding.
+      }],
+      /*retTy=*/"::mlir::Type",
+      /*methodName=*/"updateEncoding",
+      /*args=*/(ins
+        "::mlir::iree_compiler::IREE::Encoding::EncodingAttr":$encoding)
+    >,
   ];
 }
 

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.h
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.h
@@ -26,6 +26,10 @@
 #define GET_TYPEDEF_CLASSES
 #include "iree/compiler/Dialect/Encoding/IR/EncodingTypes.h.inc" // IWYU pragma: export
 #undef GET_TYPEDEF_CLASSES
+// The EncodingTypeInterfaces.h.inc needs to be included after
+// EncodingTypes.h.inc because an interface method could have EncodingAttr
+// types.
+#include "iree/compiler/Dialect/Encoding/IR/EncodingTypeInterfaces.h.inc" // IWYU pragma: export
 // clang-format on
 
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/BUILD.bazel
@@ -64,6 +64,7 @@ iree_compiler_cc_library(
         ":FlowInterfacesGen",
         ":FlowOpsGen",
         ":FlowTypesGen",
+        "//compiler/src/iree/compiler/Dialect/Encoding/IR",
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "//compiler/src/iree/compiler/Utils",
         "@llvm-project//llvm:Support",

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/CMakeLists.txt
@@ -57,6 +57,7 @@ iree_cc_library(
     MLIRTensorDialect
     MLIRTransformUtils
     MLIRViewLikeInterface
+    iree::compiler::Dialect::Encoding::IR
     iree::compiler::Dialect::Util::IR
     iree::compiler::Utils
   PUBLIC

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowTypes.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Dialect/Flow/IR/FlowTypes.h"
 
+#include "iree/compiler/Dialect/Encoding/IR/EncodingTypes.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -114,6 +115,14 @@ bool DispatchTensorType::hasStaticShape() const {
 
 bool DispatchTensorType::hasStaticShape(ArrayRef<int64_t> shape) const {
   return hasStaticShape() && getShape() == shape;
+}
+
+Type DispatchTensorType::getEncodingType() const { return getBoundType(); }
+
+Type DispatchTensorType::updateEncoding(
+    IREE::Encoding::EncodingAttr encoding) const {
+  return DispatchTensorType::get(getAccess(), getShape(), getBoundElementType(),
+                                 encoding);
 }
 
 LogicalResult

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowTypes.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowTypes.h
@@ -7,6 +7,7 @@
 #ifndef IREE_COMPILER_DIALECT_FLOW_IR_FLOWTYPES_H_
 #define IREE_COMPILER_DIALECT_FLOW_IR_FLOWTYPES_H_
 
+#include "iree/compiler/Dialect/Encoding/IR/EncodingTypes.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
 #include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
 #include "llvm/ADT/DenseMapInfo.h"
@@ -47,7 +48,8 @@ enum class TensorAccess : uint32_t {
 // we can't extend it and reuse all of this.
 class DispatchTensorType
     : public Type::TypeBase<DispatchTensorType, Type,
-                            detail::DispatchTensorTypeStorage> {
+                            detail::DispatchTensorTypeStorage,
+                            IREE::Encoding::EncodingTypeInterface::Trait> {
 public:
   using ImplType = detail::DispatchTensorTypeStorage;
 
@@ -132,6 +134,9 @@ public:
     }
     return llvm::cast<RankedTensorType>(boundType);
   }
+
+  Type getEncodingType() const;
+  Type updateEncoding(IREE::Encoding::EncodingAttr encoding) const;
 };
 
 void printType(DispatchTensorType &type, DialectAsmPrinter &p);

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
@@ -437,11 +437,33 @@ def SpecializeDispatchesPass :
 
 def SpecializeEncodingsPass :
     Pass<"iree-stream-specialize-encodings", "mlir::ModuleOp"> {
-  let summary = "Specializes data-tiling encodings based on device analysis.";
+  let summary = "Specializes data-tiling encodings based on layout analysis.";
   let description = [{
-    Attaches layouts to encodings and duplicates executables based on device
+    Attaches layouts to encodings and duplicates executables based on the
+    encoding layout analysis.
+
+    Some executables can be launched by different devices. It can produce
+    wrong codegen artifacts when bindings types are encoded (i.e., the
+    tensor type has an encoding attribute). Because they can result in
+    different layouts, especially when multi-device is involved. E.g., say
+    that device_a and device_b interpret a tensor type with encodings in
+    different layouts, and there is an executable that can be launched with
+    resources from either device_a or device_b. It is confusing what the
+    input layouts for the executable because there are two possibilities. In
+    this case, we have to duplicate the executable with updated encoding,
+    and modify the dispatch to launch proper executable based on device
     analysis.
-    TODO: Unpack the context. The pass is not fully implemented yet.
+
+    The pass resolves the layouts based on Stream affinity analysis. It updates
+    the encodings of all the Stream tensor ops with resolved layouts, duplicates
+    executables based on the set of incoming layouts and result layouts, and
+    updates bindings with resolved layouts.
+
+    It requires at least one of the dialect implements
+    AffinityAnalysisDialectInterface dialect interface, because Stream does not
+    need to know any dialect other than itself. It also requires the binding
+    types to implement EncodingTypeInterface, so it can updates the types
+    without accessing any other dialects.
   }];
 }
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
@@ -131,7 +131,7 @@ module attributes {stream.affinity.default = #hal.device.affinity<@device_a>} {
 }
 // CHECK-DAG:   #[[DEVICE_LOCAL_0:.+]] = #hal.device.target
 // CHECK-DAG:   #[[DEVICE_LOCAL_1:.+]] = #hal.device.target
-// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.encoding<{{.+}}encoding_info
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.encoding<{{.+}} layouts = [#iree_encoding.specialized_encoding<123, tensor<16xf32>>]
 // CHECK:       util.global private @[[$DEVICE_A:.+]] = #[[DEVICE_LOCAL_0]]
 // CHECK:       util.global private @[[$DEVICE_B:.+]] = #[[DEVICE_LOCAL_1]]
 // CHECK:       stream.executable private @[[$EX0:.+]] {
@@ -223,14 +223,13 @@ module attributes {stream.affinity.default = #hal.device.affinity<@device_a>} {
 // executable on both devices. We check that the executable is duplicated and
 // the encodings on bindings are updated.
 
-
-#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {encoding = #iree_cpu.vmvx_encoding_layout<>}>
-#executable_target_x86_64_ = #hal.executable.target<"llvm-cpu", "x86_64", {cpu_features = "+avx512f", encoding = #iree_cpu.cpu_encoding_layout<>, target_triple = "x86_64-xyz-xyz"}>
+#executable_target_a = #hal.executable.target<"target_a", "abc", {encoding = #iree_encoding.unspecialized_encoding<123>}>
+#executable_target_b = #hal.executable.target<"target_b", "xyz", {encoding = #iree_encoding.unspecialized_encoding<456>}>
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
-#device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
-#device_target_local_1_ = #hal.device.target<"local", {ordinal = 1 : index}, [#executable_target_x86_64_]> : !hal.device
+#device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_a]> : !hal.device
+#device_target_local_1_ = #hal.device.target<"local", {ordinal = 1 : index}, [#executable_target_b]> : !hal.device
 #encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2]>
 module attributes {stream.affinity.default = #hal.device.affinity<@device_a>} {
   util.global private @device_a = #device_target_local_0_
@@ -264,8 +263,8 @@ module attributes {stream.affinity.default = #hal.device.affinity<@device_a>} {
   }
 }
 
-// CHECK-DAG:   #[[DEVICE_A_ENCODING:.+]] = #iree_encoding.encoding{{.+}} layouts = [#iree_cpu.vmvx_encoding_layout
-// CHECK-DAG:   #[[DEVICE_B_ENCODING:.+]] = #iree_encoding.encoding{{.+}} layouts = [#iree_cpu.cpu_encoding_layout
+// CHECK-DAG:   #[[DEVICE_A_ENCODING:.+]] = #iree_encoding.encoding{{.+}} layouts = [#iree_encoding.specialized_encoding<123, tensor<?x?xf32>>]
+// CHECK-DAG:   #[[DEVICE_B_ENCODING:.+]] = #iree_encoding.encoding{{.+}} layouts = [#iree_encoding.specialized_encoding<456, tensor<?x?xf32>>]
 // CHECK-DAG:   #[[MAP0:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
 // CHECK-DAG:   #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
 // CHECK-DAG:   #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
@@ -314,13 +313,13 @@ module attributes {stream.affinity.default = #hal.device.affinity<@device_a>} {
 
 // This test is simliar to the set_encoding test, but with unset_encoding ops.
 
-#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {encoding = #iree_cpu.vmvx_encoding_layout<>}>
-#executable_target_x86_64_ = #hal.executable.target<"llvm-cpu", "x86_64", {cpu_features = "+avx512f", encoding = #iree_cpu.cpu_encoding_layout<>, target_triple = "x86_64-xyz-xyz"}>
+#executable_target_a = #hal.executable.target<"target_a", "abc", {encoding = #iree_encoding.unspecialized_encoding<123>}>
+#executable_target_b = #hal.executable.target<"target_b", "xyz", {encoding = #iree_encoding.unspecialized_encoding<456>}>
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
-#device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
-#device_target_local_1_ = #hal.device.target<"local", {ordinal = 1 : index}, [#executable_target_x86_64_]> : !hal.device
+#device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_a]> : !hal.device
+#device_target_local_1_ = #hal.device.target<"local", {ordinal = 1 : index}, [#executable_target_b]> : !hal.device
 #encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2]>
 module attributes {stream.affinity.default = #hal.device.affinity<@device_a>} {
   util.global private @device_a = #device_target_local_0_
@@ -353,8 +352,8 @@ module attributes {stream.affinity.default = #hal.device.affinity<@device_a>} {
     util.return
   }
 }
-// CHECK-DAG:   #[[DEVICE_A_ENCODING:.+]] = #iree_encoding.encoding{{.+}} layouts = [#iree_cpu.vmvx_encoding_layout
-// CHECK-DAG:   #[[DEVICE_B_ENCODING:.+]] = #iree_encoding.encoding{{.+}} layouts = [#iree_cpu.cpu_encoding_layout
+// CHECK-DAG:   #[[DEVICE_A_ENCODING:.+]] = #iree_encoding.encoding{{.+}} layouts = [#iree_encoding.specialized_encoding<123, tensor<?x?xf32>>]
+// CHECK-DAG:   #[[DEVICE_B_ENCODING:.+]] = #iree_encoding.encoding{{.+}} layouts = [#iree_encoding.specialized_encoding<456, tensor<?x?xf32>>]
 // CHECK-DAG:   #[[MAP0:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
 // CHECK-DAG:   #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
 // CHECK-DAG:   #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
@@ -404,13 +403,13 @@ module attributes {stream.affinity.default = #hal.device.affinity<@device_a>} {
 // This tests the computation ops on tensor encodings, where all the tensor
 // types are encoded. The computation body is fill + matmul.
 
-#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {encoding = #iree_cpu.vmvx_encoding_layout<>}>
-#executable_target_x86_64_ = #hal.executable.target<"llvm-cpu", "x86_64", {cpu_features = "+avx512f", encoding = #iree_cpu.cpu_encoding_layout<>, target_triple = "x86_64-xyz-xyz"}>
+#executable_target_a = #hal.executable.target<"target_a", "abc", {encoding = #iree_encoding.unspecialized_encoding<123>}>
+#executable_target_b = #hal.executable.target<"target_b", "xyz", {encoding = #iree_encoding.unspecialized_encoding<456>}>
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
-#device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
-#device_target_local_1_ = #hal.device.target<"local", {ordinal = 1 : index}, [#executable_target_x86_64_]> : !hal.device
+#device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_a]> : !hal.device
+#device_target_local_1_ = #hal.device.target<"local", {ordinal = 1 : index}, [#executable_target_b]> : !hal.device
 #encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2]>
 #encoding1 = #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2]>
 #encoding2 = #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2]>
@@ -473,12 +472,12 @@ module attributes {stream.affinity.default = #hal.device.affinity<@device_a>} {
   }
 }
 
-// CHECK-DAG:   #[[DEVICE_A_LHS_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 0{{.+}} layouts = [#iree_cpu.vmvx_encoding_layout
-// CHECK-DAG:   #[[DEVICE_A_RHS_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 1{{.+}} layouts = [#iree_cpu.vmvx_encoding_layout
-// CHECK-DAG:   #[[DEVICE_A_OUT_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 2{{.+}} layouts = [#iree_cpu.vmvx_encoding_layout
-// CHECK-DAG:   #[[DEVICE_B_LHS_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 0{{.+}} layouts = [#iree_cpu.cpu_encoding_layout
-// CHECK-DAG:   #[[DEVICE_B_RHS_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 1{{.+}} layouts = [#iree_cpu.cpu_encoding_layout
-// CHECK-DAG:   #[[DEVICE_B_OUT_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 2{{.+}} layouts = [#iree_cpu.cpu_encoding_layout
+// CHECK-DAG:   #[[DEVICE_A_LHS_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 0{{.+}} layouts = [#iree_encoding.specialized_encoding<123, tensor<?x?xf32>>]
+// CHECK-DAG:   #[[DEVICE_A_RHS_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 1{{.+}} layouts = [#iree_encoding.specialized_encoding<123, tensor<?x?xf32>>]
+// CHECK-DAG:   #[[DEVICE_A_OUT_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 2{{.+}} layouts = [#iree_encoding.specialized_encoding<123, tensor<?x?xf32>>]
+// CHECK-DAG:   #[[DEVICE_B_LHS_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 0{{.+}} layouts = [#iree_encoding.specialized_encoding<456, tensor<?x?xf32>>]
+// CHECK-DAG:   #[[DEVICE_B_RHS_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 1{{.+}} layouts = [#iree_encoding.specialized_encoding<456, tensor<?x?xf32>>]
+// CHECK-DAG:   #[[DEVICE_B_OUT_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 2{{.+}} layouts = [#iree_encoding.specialized_encoding<456, tensor<?x?xf32>>]
 // CHECK-DAG:   #[[MAP0:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
 // CHECK-DAG:   #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
 // CHECK-DAG:   #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
@@ -129,15 +129,20 @@ module attributes {stream.affinity.default = #hal.device.affinity<@device_a>} {
     util.return %9 : !hal.buffer_view
   }
 }
-// CHECK:       #[[DEVICE_LOCAL_0:.+]] = #hal.device.target
-// CHECK:       #[[DEVICE_LOCAL_1:.+]] = #hal.device.target
+// CHECK-DAG:   #[[DEVICE_LOCAL_0:.+]] = #hal.device.target
+// CHECK-DAG:   #[[DEVICE_LOCAL_1:.+]] = #hal.device.target
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.encoding<{{.+}}encoding_info
 // CHECK:       util.global private @[[$DEVICE_A:.+]] = #[[DEVICE_LOCAL_0]]
 // CHECK:       util.global private @[[$DEVICE_B:.+]] = #[[DEVICE_LOCAL_1]]
 // CHECK:       stream.executable private @[[$EX0:.+]] {
+// CHECK:         stream.binding.subspan{{.+}}#[[$ENCODING]]
+// CHECK:         stream.binding.subspan{{.+}}#[[$ENCODING]]
 // CHECK-NOT:   stream.executable private
 // CHECK-LABEL: util.func public @multi_device_with_same_executable_targets
 // CHECK:         stream.tensor.dispatch on(#hal.device.affinity<@[[$DEVICE_A]]>) @[[$EX0]]::@dispatch
+// CHECK-SAME:      #[[$ENCODING]]
 // CHECK:         stream.tensor.dispatch on(#hal.device.affinity<@[[$DEVICE_B]]>) @[[$EX0]]::@dispatch
+// CHECK-SAME:      #[[$ENCODING]]
 
 // -----
 
@@ -197,7 +202,11 @@ module attributes {stream.affinity.default = #hal.device.affinity<@device_a>} {
 // CHECK:       util.global private @[[$DEVICE_A:.+]] = #[[DEVICE_LOCAL_0]]
 // CHECK:       util.global private @[[$DEVICE_B:.+]] = #[[DEVICE_LOCAL_1]]
 // CHECK:       stream.executable private @[[$EX0:.+]] {
+// CHECK:         stream.binding.subspan{{.+}}#[[$DEVICE_A_ENCODING]]
+// CHECK:         stream.binding.subspan{{.+}}#[[$DEVICE_A_ENCODING]]
 // CHECK:       stream.executable private @[[$EX1:.+]] {
+// CHECK:         stream.binding.subspan{{.+}}#[[$DEVICE_A_ENCODING]]
+// CHECK:         stream.binding.subspan{{.+}}#[[$DEVICE_B_ENCODING]]
 // CHECK-LABEL: util.func public @multi_device_with_different_executable_targets
 // CHECK:         stream.tensor.dispatch on(#hal.device.affinity<@[[$DEVICE_A]]>) @[[$EX0]]::@dispatch
 // CHECK-SAME:      #[[$DEVICE_A_ENCODING]]
@@ -205,3 +214,335 @@ module attributes {stream.affinity.default = #hal.device.affinity<@device_a>} {
 // CHECK:         stream.tensor.dispatch on(#hal.device.affinity<@[[$DEVICE_B]]>) @[[$EX1]]::@dispatch
 // CHECK-SAME:      #[[$DEVICE_A_ENCODING]]
 // CHECK-SAME:      #[[$DEVICE_B_ENCODING]]
+
+// -----
+
+// This tests the set_encoding, where the destination tensor type is encoded.
+// The program has two external stream.resource. It imports transfer one to
+// the device_a and the other to the device_b. Then it launches the set_encoding
+// executable on both devices. We check that the executable is duplicated and
+// the encodings on bindings are updated.
+
+
+#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {encoding = #iree_cpu.vmvx_encoding_layout<>}>
+#executable_target_x86_64_ = #hal.executable.target<"llvm-cpu", "x86_64", {cpu_features = "+avx512f", encoding = #iree_cpu.cpu_encoding_layout<>, target_triple = "x86_64-xyz-xyz"}>
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
+#device_target_local_1_ = #hal.device.target<"local", {ordinal = 1 : index}, [#executable_target_x86_64_]> : !hal.device
+#encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2]>
+module attributes {stream.affinity.default = #hal.device.affinity<@device_a>} {
+  util.global private @device_a = #device_target_local_0_
+  util.global private @device_b = #device_target_local_1_
+  stream.executable private @ex {
+    stream.executable.export public @set_encoding
+    builtin.module {
+      func.func @set_encoding(%arg0: !stream.binding, %arg1: index, %arg2: index, %arg3: !stream.binding) {
+        %c0 = arith.constant 0 : index
+        %0 = flow.dispatch.workload.ordinal %arg1, 0 : index
+        %1 = flow.dispatch.workload.ordinal %arg2, 1 : index
+        %2 = stream.binding.subspan %arg0[%c0] : !stream.binding -> !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%0, %1}
+        %3 = stream.binding.subspan %arg3[%c0] : !stream.binding -> !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #encoding>>{%0, %1}
+        %4 = flow.dispatch.tensor.load %2, offsets = [0, 0], sizes = [%0, %1], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%0, %1} -> tensor<?x?xf32>
+        %5 = iree_encoding.set_encoding %4 : tensor<?x?xf32> -> tensor<?x?xf32, #encoding>
+        flow.dispatch.tensor.store %5, %3, offsets = [0, 0], sizes = [%0, %1], strides = [1, 1] : tensor<?x?xf32, #encoding> -> !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #encoding>>{%0, %1}
+        return
+      }
+    }
+  }
+  util.func public @multi_device_set_encoding(%arg0: !stream.resource<external>, %arg1: !stream.resource<external>, %N : index, %K : index) {
+    %c16 = arith.constant 16 : index
+    %c0 = arith.constant 0 : index
+    %0 = stream.async.transfer %arg0 : !stream.resource<external>{%c16} from(#hal.device.affinity<@device_a>) -> to(#hal.device.affinity<@device_a>) !stream.resource<*>{%c16}
+    %1 = stream.tensor.dispatch on(#hal.device.affinity<@device_a>) @ex::@set_encoding(%0, %N, %K) : (tensor<?x?xf32>{%N, %K} in !stream.resource<*>{%c16}, index, index) -> (tensor<?x?xf32, #encoding>{%N, %K} in !stream.resource<*>{%c16})
+    %2 = util.optimization_barrier %1 : !stream.resource<*>
+    %3 = stream.async.transfer %arg1 : !stream.resource<external>{%c16} from(#hal.device.affinity<@device_b>) -> to(#hal.device.affinity<@device_b>) !stream.resource<*>{%c16}
+    %4 = stream.tensor.dispatch on(#hal.device.affinity<@device_b>) @ex::@set_encoding(%3, %N, %K) : (tensor<?x?xf32>{%N, %K} in !stream.resource<*>{%c16}, index, index) -> (tensor<?x?xf32, #encoding>{%N, %K} in !stream.resource<*>{%c16})
+    %5 = util.optimization_barrier %4 : !stream.resource<*>
+    util.return
+  }
+}
+
+// CHECK-DAG:   #[[DEVICE_A_ENCODING:.+]] = #iree_encoding.encoding{{.+}} layouts = [#iree_cpu.vmvx_encoding_layout
+// CHECK-DAG:   #[[DEVICE_B_ENCODING:.+]] = #iree_encoding.encoding{{.+}} layouts = [#iree_cpu.cpu_encoding_layout
+// CHECK-DAG:   #[[MAP0:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
+// CHECK-DAG:   #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
+// CHECK-DAG:   #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+//
+// Explicitly capture the last `>` symbol because it makes sure that the
+// `layouts` is not attached in the ORIG_ENCODING.
+//
+// CHECK-DAG:   #[[ORIG_ENCODING:.+]] = #iree_encoding.encoding<{{.+}} user_indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]]>
+// CHECK-DAG:   #[[DEVICE_LOCAL_0:.+]] = #hal.device.target
+// CHECK-DAG:   #[[DEVICE_LOCAL_1:.+]] = #hal.device.target
+// CHECK:       util.global private @[[$DEVICE_A:.+]] = #[[DEVICE_LOCAL_0]]
+// CHECK:       util.global private @[[$DEVICE_B:.+]] = #[[DEVICE_LOCAL_1]]
+// CHECK:       stream.executable private @[[$EX0:.+]] {
+// CHECK:         func.func @set_encoding(
+// CHECK-SAME:        %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK-SAME:        %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK-SAME:        %[[ARG2:[a-zA-Z0-9]+]]
+// CHECK-SAME:        %[[ARG3:[a-zA-Z0-9]+]]
+// CHECK:           %[[SRC_BINDING:.+]] = stream.binding.subspan %[[ARG0]]
+// CHECK-SAME:        !flow.dispatch.tensor<readonly:tensor<?x?xf32>>
+// CHECK:           %[[DEST_BINDING:.+]] = stream.binding.subspan %[[ARG3]]
+// CHECK-SAME:        !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #[[DEVICE_A_ENCODING]]>
+// CHECK:           %[[SRC:.+]] = flow.dispatch.tensor.load %[[SRC_BINDING]]
+// CHECK:           %[[SET_ENCODING:.+]] = iree_encoding.set_encoding %[[SRC]]
+// CHECK-SAME:         tensor<?x?xf32> -> tensor<?x?xf32, #[[ORIG_ENCODING]]>
+// CHECK:           flow.dispatch.tensor.store %[[SET_ENCODING]], %[[DEST_BINDING]]
+// CHECK:       stream.executable private @[[$EX1:.+]] {
+// CHECK:         func.func @set_encoding(
+// CHECK-SAME:        %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK-SAME:        %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK-SAME:        %[[ARG2:[a-zA-Z0-9]+]]
+// CHECK-SAME:        %[[ARG3:[a-zA-Z0-9]+]]
+// CHECK:           %[[SRC_BINDING:.+]] = stream.binding.subspan %[[ARG0]]
+// CHECK-SAME:        !flow.dispatch.tensor<readonly:tensor<?x?xf32>>
+// CHECK:           %[[DEST_BINDING:.+]] = stream.binding.subspan %[[ARG3]]
+// CHECK-SAME:        !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #[[DEVICE_B_ENCODING]]>
+// CHECK:           %[[SRC:.+]] = flow.dispatch.tensor.load %[[SRC_BINDING]]
+// CHECK:           %[[SET_ENCODING:.+]] = iree_encoding.set_encoding %[[SRC]]
+// CHECK-SAME:         tensor<?x?xf32> -> tensor<?x?xf32, #[[ORIG_ENCODING]]>
+// CHECK:           flow.dispatch.tensor.store %[[SET_ENCODING]], %[[DEST_BINDING]]
+// CHECK-LABEL: util.func public @multi_device_set_encoding
+// CHECK:         stream.tensor.dispatch on(#hal.device.affinity<@[[$DEVICE_A]]>) @[[$EX0]]::@set_encoding
+// CHECK:         stream.tensor.dispatch on(#hal.device.affinity<@[[$DEVICE_B]]>) @[[$EX1]]::@set_encoding
+
+// -----
+
+// This test is simliar to the set_encoding test, but with unset_encoding ops.
+
+#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {encoding = #iree_cpu.vmvx_encoding_layout<>}>
+#executable_target_x86_64_ = #hal.executable.target<"llvm-cpu", "x86_64", {cpu_features = "+avx512f", encoding = #iree_cpu.cpu_encoding_layout<>, target_triple = "x86_64-xyz-xyz"}>
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
+#device_target_local_1_ = #hal.device.target<"local", {ordinal = 1 : index}, [#executable_target_x86_64_]> : !hal.device
+#encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2]>
+module attributes {stream.affinity.default = #hal.device.affinity<@device_a>} {
+  util.global private @device_a = #device_target_local_0_
+  util.global private @device_b = #device_target_local_1_
+  stream.executable private @ex {
+    stream.executable.export public @unset_encoding
+    builtin.module {
+      func.func @unset_encoding(%arg0: !stream.binding, %arg1: index, %arg2: index, %arg3: !stream.binding) {
+        %c0 = arith.constant 0 : index
+        %0 = flow.dispatch.workload.ordinal %arg1, 0 : index
+        %1 = flow.dispatch.workload.ordinal %arg2, 1 : index
+        %2 = stream.binding.subspan %arg0[%c0] : !stream.binding -> !flow.dispatch.tensor<readonly:tensor<?x?xf32, #encoding>>{%0, %1}
+        %3 = stream.binding.subspan %arg3[%c0] : !stream.binding -> !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>{%0, %1}
+        %4 = flow.dispatch.tensor.load %2, offsets = [0, 0], sizes = [%0, %1], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<?x?xf32, #encoding>>{%0, %1} -> tensor<?x?xf32, #encoding>
+        %5 = iree_encoding.unset_encoding %4 : tensor<?x?xf32, #encoding> -> tensor<?x?xf32>{%0, %1}
+        flow.dispatch.tensor.store %5, %3, offsets = [0, 0], sizes = [%0, %1], strides = [1, 1] : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>{%0, %1}
+        return
+      }
+    }
+  }
+  util.func public @multi_device_unset_encoding(%arg0: !stream.resource<external>, %arg1: !stream.resource<external>, %M: index, %N: index) {
+    %c16 = arith.constant 16 : index
+    %c0 = arith.constant 0 : index
+    %0 = stream.async.transfer %arg0 : !stream.resource<external>{%c16} from(#hal.device.affinity<@device_a>) -> to(#hal.device.affinity<@device_a>) !stream.resource<*>{%c16}
+    %1 = stream.tensor.dispatch on(#hal.device.affinity<@device_a>) @ex::@unset_encoding(%0, %M, %N) : (tensor<?x?xf32, #encoding>{%M, %N} in !stream.resource<*>{%c16}, index, index) -> (tensor<?x?xf32>{%M, %N} in !stream.resource<*>{%c16})
+    %2 = util.optimization_barrier %1 : !stream.resource<*>
+    %3 = stream.async.transfer %arg1 : !stream.resource<external>{%c16} from(#hal.device.affinity<@device_b>) -> to(#hal.device.affinity<@device_b>) !stream.resource<*>{%c16}
+    %4 = stream.tensor.dispatch on(#hal.device.affinity<@device_b>) @ex::@unset_encoding(%3, %M, %N) : (tensor<?x?xf32, #encoding>{%M, %N} in !stream.resource<*>{%c16}, index, index) -> (tensor<?x?xf32>{%M, %N} in !stream.resource<*>{%c16})
+    %5 = util.optimization_barrier %4 : !stream.resource<*>
+    util.return
+  }
+}
+// CHECK-DAG:   #[[DEVICE_A_ENCODING:.+]] = #iree_encoding.encoding{{.+}} layouts = [#iree_cpu.vmvx_encoding_layout
+// CHECK-DAG:   #[[DEVICE_B_ENCODING:.+]] = #iree_encoding.encoding{{.+}} layouts = [#iree_cpu.cpu_encoding_layout
+// CHECK-DAG:   #[[MAP0:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
+// CHECK-DAG:   #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
+// CHECK-DAG:   #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+// CHECK-DAG:   #[[ORIG_ENCODING:.+]] = #iree_encoding.encoding<{{.+}} user_indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]]>
+// CHECK-DAG:   #[[DEVICE_LOCAL_0:.+]] = #hal.device.target
+// CHECK-DAG:   #[[DEVICE_LOCAL_1:.+]] = #hal.device.target
+// CHECK:       util.global private @[[$DEVICE_A:.+]] = #[[DEVICE_LOCAL_0]]
+// CHECK:       util.global private @[[$DEVICE_B:.+]] = #[[DEVICE_LOCAL_1]]
+// CHECK:       stream.executable private @[[$EX0:.+]] {
+// CHECK:         func.func @unset_encoding(
+// CHECK-SAME:        %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK-SAME:        %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK-SAME:        %[[ARG2:[a-zA-Z0-9]+]]
+// CHECK-SAME:        %[[ARG3:[a-zA-Z0-9]+]]
+// CHECK:           %[[SRC_BINDING:.+]] = stream.binding.subspan %[[ARG0]]
+// CHECK-SAME:        !flow.dispatch.tensor<readonly:tensor<?x?xf32, #[[DEVICE_A_ENCODING]]>>
+// CHECK:           %[[DEST_BINDING:.+]] = stream.binding.subspan %[[ARG3]]
+// CHECK-SAME:        !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>
+// CHECK:           %[[SRC:.+]] = flow.dispatch.tensor.load %[[SRC_BINDING]]
+// CHECK-SAME:        !flow.dispatch.tensor<readonly:tensor<?x?xf32, #[[DEVICE_A_ENCODING]]>>
+// CHECK-SAME:        -> tensor<?x?xf32, #[[ORIG_ENCODING]]>
+// CHECK:           %[[UNSET_ENCODING:.+]] = iree_encoding.unset_encoding %[[SRC]]
+// CHECK-SAME:         tensor<?x?xf32, #[[ORIG_ENCODING]]> -> tensor<?x?xf32>
+// CHECK:           flow.dispatch.tensor.store %[[UNSET_ENCODING]], %[[DEST_BINDING]]
+// CHECK:       stream.executable private @[[$EX1:.+]] {
+// CHECK:         func.func @unset_encoding(
+// CHECK-SAME:        %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK-SAME:        %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK-SAME:        %[[ARG2:[a-zA-Z0-9]+]]
+// CHECK-SAME:        %[[ARG3:[a-zA-Z0-9]+]]
+// CHECK:           %[[SRC_BINDING:.+]] = stream.binding.subspan %[[ARG0]]
+// CHECK-SAME:        !flow.dispatch.tensor<readonly:tensor<?x?xf32, #[[DEVICE_B_ENCODING]]>>
+// CHECK:           %[[DEST_BINDING:.+]] = stream.binding.subspan %[[ARG3]]
+// CHECK-SAME:        !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>
+// CHECK:           %[[SRC:.+]] = flow.dispatch.tensor.load %[[SRC_BINDING]]
+// CHECK-SAME:        !flow.dispatch.tensor<readonly:tensor<?x?xf32, #[[DEVICE_B_ENCODING]]>>
+// CHECK-SAME:        -> tensor<?x?xf32, #[[ORIG_ENCODING]]>
+// CHECK:           %[[UNSET_ENCODING:.+]] = iree_encoding.unset_encoding %[[SRC]]
+// CHECK-SAME:         tensor<?x?xf32, #[[ORIG_ENCODING]]> -> tensor<?x?xf32>
+// CHECK:           flow.dispatch.tensor.store %[[UNSET_ENCODING]], %[[DEST_BINDING]]
+// CHECK-LABEL: util.func public @multi_device_unset_encoding
+// CHECK:         stream.tensor.dispatch on(#hal.device.affinity<@[[$DEVICE_A]]>) @[[$EX0]]::@unset_encoding
+// CHECK:         stream.tensor.dispatch on(#hal.device.affinity<@[[$DEVICE_B]]>) @[[$EX1]]::@unset_encoding
+
+// -----
+
+// This tests the computation ops on tensor encodings, where all the tensor
+// types are encoded. The computation body is fill + matmul.
+
+#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {encoding = #iree_cpu.vmvx_encoding_layout<>}>
+#executable_target_x86_64_ = #hal.executable.target<"llvm-cpu", "x86_64", {cpu_features = "+avx512f", encoding = #iree_cpu.cpu_encoding_layout<>, target_triple = "x86_64-xyz-xyz"}>
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
+#device_target_local_1_ = #hal.device.target<"local", {ordinal = 1 : index}, [#executable_target_x86_64_]> : !hal.device
+#encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2]>
+#encoding1 = #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2]>
+#encoding2 = #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2]>
+module attributes {stream.affinity.default = #hal.device.affinity<@device_a>} {
+  util.global private @device_a = #device_target_local_0_
+  util.global private @device_b = #device_target_local_1_
+  stream.executable private @ex {
+    stream.executable.export public @gemm
+    builtin.module {
+      func.func @gemm(%arg0: !stream.binding, %arg1: !stream.binding, %arg2: index, %arg3: index, %arg4: index, %arg5: index, %arg6: !stream.binding) {
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0.000000e+00 : f32
+        %0 = flow.dispatch.workload.ordinal %arg2, 0 : index
+        %1 = flow.dispatch.workload.ordinal %arg3, 1 : index
+        %2 = flow.dispatch.workload.ordinal %arg4, 2 : index
+        %3 = flow.dispatch.workload.ordinal %arg5, 3 : index
+        %4 = stream.binding.subspan %arg0[%c0] : !stream.binding -> !flow.dispatch.tensor<readonly:tensor<?x?xf32, #encoding>>{%2, %0}
+        %5 = stream.binding.subspan %arg1[%c0] : !stream.binding -> !flow.dispatch.tensor<readonly:tensor<?x?xf32, #encoding1>>{%1, %3}
+        %6 = stream.binding.subspan %arg6[%c0] : !stream.binding -> !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #encoding2>>{%2, %3}
+        %7 = flow.dispatch.tensor.load %4, offsets = [0, 0], sizes = [%2, %0], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<?x?xf32, #encoding>>{%2, %0} -> tensor<?x?xf32, #encoding>
+        %8 = flow.dispatch.tensor.load %5, offsets = [0, 0], sizes = [%1, %3], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<?x?xf32, #encoding1>>{%1, %3} -> tensor<?x?xf32, #encoding1>
+        %9 = tensor.empty(%2, %3) : tensor<?x?xf32, #encoding2>
+        %10 = linalg.fill ins(%cst : f32) outs(%9 : tensor<?x?xf32, #encoding2>) -> tensor<?x?xf32, #encoding2>
+        %11 = linalg.matmul ins(%7, %8 : tensor<?x?xf32, #encoding>, tensor<?x?xf32, #encoding1>) outs(%10 : tensor<?x?xf32, #encoding2>) -> tensor<?x?xf32, #encoding2>
+        flow.dispatch.tensor.store %11, %6, offsets = [0, 0], sizes = [%2, %3], strides = [1, 1] : tensor<?x?xf32, #encoding2> -> !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #encoding2>>{%2, %3}
+        return
+      }
+    }
+  }
+  util.func public @multi_device_gemm(%arg0: !stream.resource<external>, %arg1: !stream.resource<external>, %arg2: !stream.resource<external>, %arg3: !stream.resource<external>) {
+    %c0 = arith.constant 0 : index
+    %c16 = arith.constant 16 : index
+    %cst_M = arith.constant 1024 : index
+    %cst_N = arith.constant 2048 : index
+    %cst_K = arith.constant 512 : index
+    %cst_MK = arith.muli %cst_M, %cst_K : index
+    %cst_NK = arith.muli %cst_N, %cst_K : index
+    %cst_MN = arith.muli %cst_M, %cst_N : index
+    %M = util.optimization_barrier %cst_M : index
+    %N = util.optimization_barrier %cst_N : index
+    %K = util.optimization_barrier %cst_K : index
+    %MK = util.optimization_barrier %cst_MK : index
+    %NK = util.optimization_barrier %cst_NK : index
+    %MN = util.optimization_barrier %cst_MN : index
+    %LHS_A = stream.async.transfer %arg0 : !stream.resource<external>{%MK} from(#hal.device.affinity<@device_a>) -> to(#hal.device.affinity<@device_a>) !stream.resource<*>{%MK}
+    %RHS_A = stream.async.transfer %arg1 : !stream.resource<external>{%NK} from(#hal.device.affinity<@device_a>) -> to(#hal.device.affinity<@device_a>) !stream.resource<*>{%NK}
+    %RES_A = stream.tensor.dispatch on(#hal.device.affinity<@device_a>)
+      @ex::@gemm(%LHS_A, %RHS_A, %K, %K, %M, %N)
+      : (tensor<?x?xf32, #encoding>{%M, %K} in !stream.resource<*>{%MK}, tensor<?x?xf32, #encoding1>{%N, %K} in !stream.resource<*>{%NK}, index, index, index, index)
+      -> (tensor<?x?xf32, #encoding2>{%M, %N} in !stream.resource<*>{%MN})
+    %barrier_0 = util.optimization_barrier %RES_A : !stream.resource<*>
+    %LHS_B = stream.async.transfer %arg2 : !stream.resource<external>{%MK} from(#hal.device.affinity<@device_b>) -> to(#hal.device.affinity<@device_b>) !stream.resource<*>{%MK}
+    %RHS_B = stream.async.transfer %arg3 : !stream.resource<external>{%NK} from(#hal.device.affinity<@device_b>) -> to(#hal.device.affinity<@device_b>) !stream.resource<*>{%NK}
+    %RES_B = stream.tensor.dispatch on(#hal.device.affinity<@device_b>)
+      @ex::@gemm(%LHS_B, %RHS_B, %K, %K, %M, %N)
+      : (tensor<?x?xf32, #encoding>{%M, %K} in !stream.resource<*>{%MK}, tensor<?x?xf32, #encoding1>{%N, %K} in !stream.resource<*>{%NK}, index, index, index, index)
+      -> (tensor<?x?xf32, #encoding2>{%M, %N} in !stream.resource<*>{%MN})
+    %barrier_1 = util.optimization_barrier %RES_B : !stream.resource<*>
+    util.return
+  }
+}
+
+// CHECK-DAG:   #[[DEVICE_A_LHS_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 0{{.+}} layouts = [#iree_cpu.vmvx_encoding_layout
+// CHECK-DAG:   #[[DEVICE_A_RHS_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 1{{.+}} layouts = [#iree_cpu.vmvx_encoding_layout
+// CHECK-DAG:   #[[DEVICE_A_OUT_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 2{{.+}} layouts = [#iree_cpu.vmvx_encoding_layout
+// CHECK-DAG:   #[[DEVICE_B_LHS_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 0{{.+}} layouts = [#iree_cpu.cpu_encoding_layout
+// CHECK-DAG:   #[[DEVICE_B_RHS_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 1{{.+}} layouts = [#iree_cpu.cpu_encoding_layout
+// CHECK-DAG:   #[[DEVICE_B_OUT_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 2{{.+}} layouts = [#iree_cpu.cpu_encoding_layout
+// CHECK-DAG:   #[[MAP0:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
+// CHECK-DAG:   #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
+// CHECK-DAG:   #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+// CHECK-DAG:   #[[ORIG_LHS_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 0{{.+}} user_indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]]>
+// CHECK-DAG:   #[[ORIG_RHS_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 1{{.+}} user_indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]]>
+// CHECK-DAG:   #[[ORIG_OUT_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 2{{.+}} user_indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]]>
+// CHECK-DAG:   #[[DEVICE_LOCAL_0:.+]] = #hal.device.target
+// CHECK-DAG:   #[[DEVICE_LOCAL_1:.+]] = #hal.device.target
+// CHECK:       util.global private @[[$DEVICE_A:.+]] = #[[DEVICE_LOCAL_0]]
+// CHECK:       util.global private @[[$DEVICE_B:.+]] = #[[DEVICE_LOCAL_1]]
+// CHECK:       stream.executable private @[[$EX0:.+]] {
+// CHECK:         func.func @gemm(
+// CHECK-SAME:        %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK-SAME:        %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK-SAME:        %[[ARG2:[a-zA-Z0-9]+]]
+// CHECK-SAME:        %[[ARG3:[a-zA-Z0-9]+]]
+// CHECK-SAME:        %[[ARG4:[a-zA-Z0-9]+]]
+// CHECK-SAME:        %[[ARG5:[a-zA-Z0-9]+]]
+// CHECK-SAME:        %[[ARG6:[a-zA-Z0-9]+]]
+// CHECK:           %[[LHS_BINDING:.+]] = stream.binding.subspan %[[ARG0]]
+// CHECK-SAME:        !flow.dispatch.tensor<readonly:tensor<?x?xf32, #[[DEVICE_A_LHS_ENCODING]]>>
+// CHECK:           %[[RHS_BINDING:.+]] = stream.binding.subspan %[[ARG1]]
+// CHECK-SAME:        !flow.dispatch.tensor<readonly:tensor<?x?xf32, #[[DEVICE_A_RHS_ENCODING]]>>
+// CHECK:           %[[OUT_BINDING:.+]] = stream.binding.subspan %[[ARG6]]
+// CHECK-SAME:        !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #[[DEVICE_A_OUT_ENCODING]]>>
+// CHECK:           %[[LHS:.+]] = flow.dispatch.tensor.load %[[LHS_BINDING]]
+// CHECK-SAME:        !flow.dispatch.tensor<readonly:tensor<?x?xf32, #[[DEVICE_A_LHS_ENCODING]]>>
+// CHECK-SAME:        -> tensor<?x?xf32, #[[ORIG_LHS_ENCODING]]>
+// CHECK:           %[[RHS:.+]] = flow.dispatch.tensor.load %[[RHS_BINDING]]
+// CHECK-SAME:        !flow.dispatch.tensor<readonly:tensor<?x?xf32, #[[DEVICE_A_RHS_ENCODING]]>>
+// CHECK-SAME:        -> tensor<?x?xf32, #[[ORIG_RHS_ENCODING]]>
+// CHECK:           %[[INIT:.+]] = tensor.empty({{.+}}) : tensor<?x?xf32, #[[ORIG_OUT_ENCODING]]>
+// CHECK:           %[[FILL:.+]] = linalg.fill ins({{.+}}) outs(%[[INIT]]
+// CHECK:           %[[MATMUL:.+]] = linalg.matmul
+// CHECK-SAME:        ins(%[[LHS]], %[[RHS]]
+// CHECK-SAME:        outs(%[[FILL]]
+// CHECK:           flow.dispatch.tensor.store %[[MATMUL]], %[[OUT_BINDING]]
+// CHECK:       stream.executable private @[[$EX1:.+]] {
+// CHECK:         func.func @gemm(
+// CHECK-SAME:        %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK-SAME:        %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK-SAME:        %[[ARG2:[a-zA-Z0-9]+]]
+// CHECK-SAME:        %[[ARG3:[a-zA-Z0-9]+]]
+// CHECK-SAME:        %[[ARG4:[a-zA-Z0-9]+]]
+// CHECK-SAME:        %[[ARG5:[a-zA-Z0-9]+]]
+// CHECK-SAME:        %[[ARG6:[a-zA-Z0-9]+]]
+// CHECK:           %[[LHS_BINDING:.+]] = stream.binding.subspan %[[ARG0]]
+// CHECK-SAME:        !flow.dispatch.tensor<readonly:tensor<?x?xf32, #[[DEVICE_B_LHS_ENCODING]]>>
+// CHECK:           %[[RHS_BINDING:.+]] = stream.binding.subspan %[[ARG1]]
+// CHECK-SAME:        !flow.dispatch.tensor<readonly:tensor<?x?xf32, #[[DEVICE_B_RHS_ENCODING]]>>
+// CHECK:           %[[OUT_BINDING:.+]] = stream.binding.subspan %[[ARG6]]
+// CHECK-SAME:        !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #[[DEVICE_B_OUT_ENCODING]]>>
+// CHECK:           %[[LHS:.+]] = flow.dispatch.tensor.load %[[LHS_BINDING]]
+// CHECK-SAME:        !flow.dispatch.tensor<readonly:tensor<?x?xf32, #[[DEVICE_B_LHS_ENCODING]]>>
+// CHECK-SAME:        -> tensor<?x?xf32, #[[ORIG_LHS_ENCODING]]>
+// CHECK:           %[[RHS:.+]] = flow.dispatch.tensor.load %[[RHS_BINDING]]
+// CHECK-SAME:        !flow.dispatch.tensor<readonly:tensor<?x?xf32, #[[DEVICE_B_RHS_ENCODING]]>>
+// CHECK-SAME:        -> tensor<?x?xf32, #[[ORIG_RHS_ENCODING]]>
+// CHECK:           %[[INIT:.+]] = tensor.empty({{.+}}) : tensor<?x?xf32, #[[ORIG_OUT_ENCODING]]>
+// CHECK:           %[[FILL:.+]] = linalg.fill ins({{.+}}) outs(%[[INIT]]
+// CHECK:           %[[MATMUL:.+]] = linalg.matmul
+// CHECK-SAME:        ins(%[[LHS]], %[[RHS]]
+// CHECK-SAME:        outs(%[[FILL]]
+// CHECK:           flow.dispatch.tensor.store %[[MATMUL]], %[[OUT_BINDING]]
+// CHECK-LABEL: util.func public @multi_device_gemm
+// CHECK:         stream.tensor.dispatch on(#hal.device.affinity<@[[$DEVICE_A]]>) @[[$EX0]]::@gemm
+// CHECK:         stream.tensor.dispatch on(#hal.device.affinity<@[[$DEVICE_B]]>) @[[$EX1]]::@gemm


### PR DESCRIPTION
For the stream bindings, the encoding types of duplicated executables need to be updated with resolved layouts. In the revision, it is done by type interface. The revision introduces `EncodingTypeInterface` in the IREE::Encoding dialect. There are two interface methods:

- getEncodingType: returns the tensor type with the encoding. E.g., the bounded type is returned in the Flow::DispatchTensorType implementation.
- updateEncoding: returns the same type but with the new encoding. E.g., the encoding in the bounded type is updated to the new encoding in the Flow::DispatchTensorType implementation.

The revision implements the interface methods for
Flow::DispatchTensorType and uses them to update the bindings.

Codegen already looks at flow.dispatch.tensor.load/store and will have the incoming layout information available. If there is a layout transferring need, codegen should be able to generate relayout ops when they materialize the encodings. E.g., the incoming layout is attached and codegen knows the target layout. It can generate relayout ops to bring the incoming layout to the target layout.

```
#encoding3 =  ...operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32],
  layouts = [#iree_cpu.cpu_encoding_layout<configuration = {
    encoding_info = {innerDimsPos = [0, 1],
                     innerTileSizes = [16, 1],
                     outerDimsPerm = [0, 1]}}>]
>
#encoding6 =  ...operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32],
  user_indexing_maps = [#map, #map1, #map2]
>
%7 = flow.dispatch.tensor.load %4,
  offsets = [0, 0], sizes = [%2, %0], strides = [1, 1]
  : !flow.dispatch.tensor<readonly:tensor<?x?xf32, #encoding3>>{%2, %0}
  -> tensor<?x?xf32, #encoding6>
```