### PR TITLE
Temporarily Disable MI250 workflow due to machine outage

### DIFF
--- a/.github/workflows/pkgci.yml
+++ b/.github/workflows/pkgci.yml
@@ -53,7 +53,7 @@ jobs:
   # Jobs that run unit tests on special hardware platforms or accelerators
   #############################################################################
 
-  # Temporarily disbling MI250 runs due to downed Cirruscale GPU 945D machine
+  # Disabled while no `nodai-amdgpu-mi250-x86-64` runners are online
   #test_amd_mi250:
   #  name: Test AMD MI250
   #  needs: [setup, build_packages]

--- a/.github/workflows/pkgci.yml
+++ b/.github/workflows/pkgci.yml
@@ -53,11 +53,12 @@ jobs:
   # Jobs that run unit tests on special hardware platforms or accelerators
   #############################################################################
 
-  test_amd_mi250:
-    name: Test AMD MI250
-    needs: [setup, build_packages]
-    if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_amd_mi250')
-    uses: ./.github/workflows/pkgci_test_amd_mi250.yml
+  # Temporarily disbling MI250 runs due to downed Cirruscale GPU 945D machine
+  #test_amd_mi250:
+  #  name: Test AMD MI250
+  #  needs: [setup, build_packages]
+  #  if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_amd_mi250')
+  #  uses: ./.github/workflows/pkgci_test_amd_mi250.yml
 
   test_amd_mi300:
     name: Test AMD MI300
@@ -132,7 +133,7 @@ jobs:
       - build_packages
       - unit_test
       - regression_test
-      - test_amd_mi250
+      # - test_amd_mi250
       - test_amd_mi300
       - test_amd_w7900
       # - test_nvidia_t4


### PR DESCRIPTION
Temporarily disabling MI250 workflow runs as the machine is currently down.

Changes:
- Commented out MI250 workflow to prevent job failures
- Added comments explaining the temporary nature of this change

Note: This is a temporary change and should be reverted once the MI250 machine is back online.

skip-ci: Disabling workflow due to known machine outage
