### PR TITLE
[GPU] Preserve lowering_config after tiling in GPUApplyTilingLevel

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyTilingLevel.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyTilingLevel.cpp
@@ -363,7 +363,9 @@ static LogicalResult applyTileAndFuseToEachRoot(
 
     if (IREE::Codegen::LoweringConfigAttrInterface originalConfig =
             getLoweringConfig(tilingInterfaceOp)) {
-      setLoweringConfig(tiledResults->tiledAndFusedOps[0], originalConfig);
+      if (!tiledResults->tiledAndFusedOps.empty()) {
+        setLoweringConfig(tiledResults->tiledAndFusedOps[0], originalConfig);
+      }
     }
 
     // Perform the replacement of tiled and fused values.

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyTilingLevel.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUApplyTilingLevel.cpp
@@ -361,6 +361,11 @@ static LogicalResult applyTileAndFuseToEachRoot(
       return failure();
     }
 
+    if (IREE::Codegen::LoweringConfigAttrInterface originalConfig =
+            getLoweringConfig(tilingInterfaceOp)) {
+      setLoweringConfig(tiledResults->tiledAndFusedOps[0], originalConfig);
+    }
+
     // Perform the replacement of tiled and fused values.
     SmallVector<Operation *> opsToReplace{tilingInterfaceOp};
     llvm::append_range(opsToReplace, tiledResults->fusedProducers);

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_tiling_level.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_apply_tiling_level.mlir
@@ -530,6 +530,7 @@ func.func @partial_reduction(%3: tensor<?x?xf32>) -> tensor<?xf32> {
 //       PARTRED:     linalg.generic
 //  PARTRED-SAME:       iterator_types = ["parallel", "parallel"]
 //  PARTRED-SAME:       ins(%{{.*}}  : tensor<?x?xf32>) outs(%{{.*}} : tensor<?x?xf32>)
+//  PARTRED-SAME:       attrs = {lowering_config =
 //       PARTRED:   scf.yield
 //       PARTRED:   linalg.reduce ins(%[[OUT]] : tensor<?x8xf32>)
 //  PARTRED-SAME:                 outs(%[[FULL]] : tensor<?xf32>)


### PR DESCRIPTION
PartialReductionOpInterface implementation of linalg ops upstream doesn't preserve attributes. Instead, we set the lowering config on the newly tiled op right before we replace it.