### PR TITLE
[Python] Enable building Python bindings as editable wheels, document it

### DIFF
--- a/compiler/setup.py
+++ b/compiler/setup.py
@@ -21,6 +21,10 @@
 #
 # Select CMake options are available from environment variables:
 #   IREE_ENABLE_CPUINFO
+#
+# If building from a development tree and aiming to get an "editable" install,
+# use the environment option CMAKE_INSTALL_MODE=ABS_SYMLINK on your
+# `pip install -e .` invocation.
 
 from gettext import install
 import json
@@ -337,7 +341,7 @@ class CMakeBuildPy(_build_py):
         shutil.copytree(
             os.path.join(CMAKE_INSTALL_DIR_ABS, "python_packages", "iree_compiler"),
             target_dir,
-            symlinks=False,
+            symlinks=self.editable_mode,
         )
         print("Target populated.", file=sys.stderr)
 

--- a/docs/website/docs/building-from-source/getting-started.md
+++ b/docs/website/docs/building-from-source/getting-started.md
@@ -396,6 +396,43 @@ cmake --build ../iree-build/
 
 ### Using the Python bindings
 
+There are two available methods for installing the Python bindings, either
+through creating an editable wheel or through extending `PYTHONPATH`.
+
+#### Installing the bindings as editable wheels
+
+This method links the files in your build tree into your Python package directory
+as an editable wheel.
+
+=== ":fontawesome-brands-linux: Linux"
+
+    ``` shell
+    CMAKE_INSTALL_METHOD=ABS_SYMLINK python -m pip install -e ../iree-build/compiler
+    CMAKE_INSTALL_METHOD=ABS_SYMLINK python -m pip install -e ../iree-build/runtime
+    ```
+
+=== ":fontawesome-brands-apple: macOS"
+
+    ``` shell
+    CMAKE_INSTALL_METHOD=ABS_SYMLINK python -m pip install -e ../iree-build/compiler
+    CMAKE_INSTALL_METHOD=ABS_SYMLINK python -m pip install -e ../iree-build/runtime
+    ```
+
+=== ":fontawesome-brands-windows: Windows"
+
+    ``` powershell
+    $env:CMAKE_INSTALL_MODE="ABS_SYMLINK"
+    python -m pip install -e ..\iree-build\compiler
+    python -m pip install -e ..\iree-build\runtime
+    $env:CMAKE_INSTALL_MODE=null
+    ```
+
+#### Extending PYTHONPATH
+
+This method more effectively captures the state of your build directory,
+but is prone to errors arising from forgetting to source the environment
+variables.
+
 Extend your `PYTHONPATH` with IREE's `bindings/python` paths and try importing:
 
 === ":fontawesome-brands-linux: Linux"
@@ -431,6 +468,8 @@ Extend your `PYTHONPATH` with IREE's `bindings/python` paths and try importing:
     python -c "import iree.runtime; help(iree.runtime)"
     ```
 
+#### Tensorflow/TFLite bindings
+
 Using IREE's TensorFlow/TFLite importers requires a few extra steps:
 
 ``` shell
@@ -438,6 +477,7 @@ Using IREE's TensorFlow/TFLite importers requires a few extra steps:
 python -m pip install -r integrations/tensorflow/test/requirements.txt
 
 # Install pure Python packages (no build required)
+# You may use `pip install -e` here to create an editable wheel.
 python -m pip install integrations/tensorflow/python_projects/iree_tf
 python -m pip install integrations/tensorflow/python_projects/iree_tflite
 

--- a/docs/website/docs/building-from-source/getting-started.md
+++ b/docs/website/docs/building-from-source/getting-started.md
@@ -399,7 +399,7 @@ cmake --build ../iree-build/
 There are two available methods for installing the Python bindings, either
 through creating an editable wheel or through extending `PYTHONPATH`.
 
-#### Installing the bindings as editable wheels
+#### Option A: Installing the bindings as editable wheels
 
 This method links the files in your build tree into your Python package directory
 as an editable wheel.
@@ -427,7 +427,7 @@ as an editable wheel.
     $env:CMAKE_INSTALL_MODE=null
     ```
 
-#### Extending PYTHONPATH
+#### Option B: Extending PYTHONPATH
 
 This method more effectively captures the state of your build directory,
 but is prone to errors arising from forgetting to source the environment

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -34,5 +34,7 @@ iree_include_cmake_plugin_dirs(
 add_subdirectory(src)
 
 if(IREE_BUILD_PYTHON_BINDINGS)
+  configure_file(pyproject.toml pyproject.toml COPYONLY)
+  configure_file(setup.py setup.py @ONLY)
   add_subdirectory(bindings/python)
 endif()


### PR DESCRIPTION
In order to not need to constantly source PYTHONPATH, and to run the rink of potentially having it set wrong when dealing with multiple IREE builds, and to allow packages like the kernel bunchmarking suite to use a local build without needing to edit requirements.txt, add the ability to build these packages as editableble wheels.

This method, newly added to the build documentation, tells CMake to use symbolic links when "installing" the Python packages from the build directroy into a different build directory. In combination with telling copytree to preserve symlinks, this creates Python packages that link back to the build or source directory when the `-e` flag is used on pip.

This means that an automated virtual environment switcher, like `pyenv`, will pick up the correct Python bindings automatically and will direct `iree-compiler` and `iree-runtime` shims to the correct build.