### PR TITLE
[DispatchCreation] Bubble expand_shape for multi use producers

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
@@ -134,11 +134,9 @@ void BubbleUpExpandShapesPass::runOnOperation() {
           return false;
         }
 
-        // Do not fuse producer generic op if it has more than one user
-        // or any reduction iterators.
+        // Do not fuse producer generic op if it has any reduction iterators.
         if (auto producerGenericOp = dyn_cast<linalg::GenericOp>(producer)) {
-          return producerGenericOp->hasOneUse() &&
-                 llvm::all_of(producerGenericOp.getIteratorTypesArray(),
+          return llvm::all_of(producerGenericOp.getIteratorTypesArray(),
                               linalg::isParallelIterator);
         }
 
@@ -206,6 +204,10 @@ void BubbleUpExpandShapesPass::runOnOperation() {
   bubbleExpandShapePatterns.insert<BubbleExpandThroughExtract>(context);
   tensor::ExpandShapeOp::getCanonicalizationPatterns(bubbleExpandShapePatterns,
                                                      context);
+  tensor::DimOp::getCanonicalizationPatterns(bubbleExpandShapePatterns,
+                                             context);
+  tensor::EmptyOp::getCanonicalizationPatterns(bubbleExpandShapePatterns,
+                                               context);
 
   GreedyRewriteConfig rewriteConfig;
   rewriteConfig.maxIterations = GreedyRewriteConfig::kNoLimit;


### PR DESCRIPTION
This pr enables bubbling up expand_shape's through producers with multiple users. This allows propagation of expand_shape through a diamond like graph:

```
A = op1(in)
B = op2(A)
C = op2(A)
D = op3(B, C)
out = expand_shape D
```

This can get stuck at multiple expand_shape users

```
A = op1(in)
A1 = expand_shape A
A2 = expand_shape A
B = op2(A1)
C = op2(A2)
D = op3(B, C)
```

This PR enables the expand_shape to be propagated completly:

```
in_A = expand_shape A
A = op1(in_A)
B = op2(A)
C = op2(A)
D = op3(B, C)
```

This PR also adds a check when the diamond like expand_shape can cause cycles when expanding unit dimensions.