### PR TITLE
[GlobalOptimization] Do not hoist fill-like operations

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/BUILD.bazel
@@ -38,5 +38,6 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TensorUtils",
+        "@llvm-project//mlir:TransformUtils",
     ],
 )

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/CMakeLists.txt
@@ -34,6 +34,7 @@ iree_cc_library(
     MLIRSupport
     MLIRTensorDialect
     MLIRTensorUtils
+    MLIRTransformUtils
   PUBLIC
 )
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -921,22 +921,23 @@ bool isArgmaxOp(linalg::GenericOp genericOp) {
   return true;
 }
 
-bool isFillLikeOp(linalg::GenericOp linalgOp) {
+bool hasOnlyScalarInputs(linalg::GenericOp linalgOp) {
   // Check if there are any non-scalar inputs or non-scalar captures in the
   // region.
   for (Value input : linalgOp.getDpsInputs()) {
     if (isa<ShapedType>(input.getType())) {
-      bool foundNonScalar = false;
-      visitUsedValuesDefinedAbove(
-          linalgOp.getRegion(), [&](OpOperand *operand) {
-            if (isa<ShapedType>(operand->get().getType())) {
-              foundNonScalar = true;
-            }
-          });
-
-      return !foundNonScalar;
+      return false;
     }
   }
+
+  bool foundNonScalar = false;
+  visitUsedValuesDefinedAbove(linalgOp.getRegion(), [&](OpOperand *operand) {
+    if (isa<ShapedType>(operand->get().getType())) {
+      foundNonScalar = true;
+    }
+  });
+
+  return !foundNonScalar;
 }
 
 } // namespace mlir::iree_compiler::IREE::LinalgExt

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
@@ -229,7 +229,7 @@ bool isArgmaxOp(linalg::GenericOp genericOp);
 
 /// Returns true if the operation is a GenericOp that has no tensor inputs,
 /// either as inputs or as implicit captures.
-bool isFillLikeOp(linalg::GenericOp op);
+bool hasOnlyScalarInputs(linalg::GenericOp op);
 
 } // namespace mlir::iree_compiler::IREE::LinalgExt
 #endif // IREE_COMPILER_DIALECT_LINALGEXT_UTILS_UTILS_H_

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
@@ -227,5 +227,9 @@ bool isaHorizontallyFusedContraction(Operation *op);
 /// Check if a linalg.generic is representing an argmax operation.
 bool isArgmaxOp(linalg::GenericOp genericOp);
 
+/// Returns true if the operation is a GenericOp that has no tensor inputs,
+/// either as inputs or as implicit captures.
+bool isFillLikeOp(linalg::GenericOp op);
+
 } // namespace mlir::iree_compiler::IREE::LinalgExt
 #endif // IREE_COMPILER_DIALECT_LINALGEXT_UTILS_UTILS_H_

--- a/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
@@ -371,12 +371,9 @@ struct HoistableLinalgOpInterface
       return !isa<linalg::FillOp>(op);
     }
 
-    // Don't hoist ops with no inputs, their result is defined by `linalg.index`
-    // ops and should be fused with their consumers.
-    if (genericOp.getNumDpsInputs() == 0) {
-      return false;
-    }
-
+    // Don't hoist ops with no tensor inputs, they can be fused with their
+    // consumers. Additionally, fusing these operations preserves information
+    // (e.g. contiguous indexing).
     if (IREE::LinalgExt::isFillLikeOp(genericOp)) {
       return false;
     }

--- a/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
@@ -377,7 +377,7 @@ struct HoistableLinalgOpInterface
       return false;
     }
 
-    if (linalg::isaFillOpInterface(genericOp).has_value()) {
+    if (IREE::LinalgExt::isFillLikeOp(genericOp)) {
       return false;
     }
 

--- a/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
@@ -371,10 +371,10 @@ struct HoistableLinalgOpInterface
       return !isa<linalg::FillOp>(op);
     }
 
-    // Don't hoist ops with no tensor inputs, they can be fused with their
-    // consumers. Additionally, fusing these operations preserves information
-    // (e.g. contiguous indexing).
-    if (IREE::LinalgExt::isFillLikeOp(genericOp)) {
+    // Don't hoist ops with no tensor inputs. They are likely to be fill-like
+    // or sequences (from `linalg.index`) which can be fused with their
+    // consumers.
+    if (IREE::LinalgExt::hasOnlyScalarInputs(genericOp)) {
       return false;
     }
 


### PR DESCRIPTION
Changes hoisting logic to look for and not hoist linalg ops without any tensor inputs. Before this change, we would hoist a fill-like op if it had a scalar input. Also, this change adds some missing hoisting tests for bit-extend/truncate ops.