### PR TITLE
Add ubuntu-24.04-arm runtime and runtime_tracing CI jobs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,9 @@ jobs:
           - name: ubuntu-24.04
             runs-on: ubuntu-24.04
             driver-options: -DIREE_HAL_DRIVER_CUDA=ON -DIREE_HAL_DRIVER_HIP=ON -DIREE_HAL_DRIVER_VULKAN=ON
+          - name: ubuntu-24.04-arm
+            runs-on: ubuntu-24.04-arm
+            driver-options: -DIREE_HAL_DRIVER_CUDA=ON -DIREE_HAL_DRIVER_HIP=ON -DIREE_HAL_DRIVER_VULKAN=ON
           - name: windows-2022
             runs-on: windows-2022
             driver-options: -DIREE_HAL_DRIVER_CUDA=ON -DIREE_HAL_DRIVER_HIP=ON -DIREE_HAL_DRIVER_VULKAN=ON
@@ -166,7 +169,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-24.04, windows-2022, macos-14]
+        runs-on: [ubuntu-24.04, ubuntu-24.04-arm, windows-2022, macos-14]
         provider: [tracy, console]
     env:
       BUILD_DIR: build-tracing


### PR DESCRIPTION
These runners are now available for free in public repositories: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/.

Job timing from https://github.com/iree-org/iree/actions/runs/12819364861?pr=19724 (all with cold caches)

Job name / link | Time taken
-- | --
[runtime :: ubuntu-24.04-arm](https://github.com/iree-org/iree/actions/runs/12819364861/job/35889684739?pr=19724#logs) | 3m26s
[runtime_tracing :: ubuntu-24.04-arm :: tracy](https://github.com/iree-org/iree/actions/runs/12819364861/job/35889684253?pr=19724#logs) | 3m08s
[runtime_tracing :: ubuntu-24.04-arm :: console](https://github.com/iree-org/iree/actions/runs/12819364861/job/35889685123?pr=19724#logs) | 3m25s

ci-exactly: runtime, runtime_tracing