### PR TITLE
Update resource placement and transfer for barrier operations

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
@@ -394,6 +394,12 @@ private:
               DFX::Resolution::REQUIRED);
           getState() ^= targetUsage.getState();
         })
+        .Case([&](IREE::Stream::AsyncBarrierOp op) {
+          auto &tiedUsage = solver.getElementFor<ValueResourceUsage>(
+              *this, Position::forValue(op.getOperand(0)),
+              DFX::Resolution::REQUIRED);
+          getState() ^= tiedUsage.getState();
+        })
         .Case([&](IREE::Stream::AsyncTransferOp op) {
           removeAssumedBits(NOT_TRANSFER_WRITE);
           auto &sourceUsage = solver.getElementFor<ValueResourceUsage>(
@@ -715,6 +721,12 @@ private:
                 DFX::Resolution::REQUIRED);
             getState() ^= resultUsage.getState();
           }
+        })
+        .Case([&](IREE::Stream::AsyncBarrierOp op) {
+          auto &resultUsage = solver.getElementFor<ValueResourceUsage>(
+              *this, Position::forValue(op.getResult()),
+              DFX::Resolution::OPTIONAL);
+          getState() ^= resultUsage.getState();
         })
         .Case([&](IREE::Stream::AsyncTransferOp op) {
           removeAssumedBits(NOT_TRANSFER_READ);

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/PatternUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/PatternUtils.cpp
@@ -64,7 +64,7 @@ ConvertedTensor transferTensorOperands(
   Value resource = convertedOperand[0];
   Value resourceSize = convertedOperand[1];
   auto affinityAttr = affinityAnalysis->lookupResourceAffinity(originalOperand);
-  auto isBarrier = isa<IREE::Stream::AsyncBarrierOp>(resource.getDefiningOp());
+  bool isBarrier = isa<IREE::Stream::AsyncBarrierOp>(resource.getDefiningOp());
   if (affinityAttr != requiredAffinityAttr && !isBarrier) {
     resource = builder.create<IREE::Stream::AsyncTransferOp>(
         loc, resource.getType(), resource, resourceSize, resourceSize,

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/PatternUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/PatternUtils.cpp
@@ -64,7 +64,8 @@ ConvertedTensor transferTensorOperands(
   Value resource = convertedOperand[0];
   Value resourceSize = convertedOperand[1];
   auto affinityAttr = affinityAnalysis->lookupResourceAffinity(originalOperand);
-  bool isBarrier = isa<IREE::Stream::AsyncBarrierOp>(resource.getDefiningOp());
+  bool isBarrier = resource.getDefiningOp() &&
+                   isa<IREE::Stream::AsyncBarrierOp>(resource.getDefiningOp());
   if (affinityAttr != requiredAffinityAttr && !isBarrier) {
     resource = builder.create<IREE::Stream::AsyncTransferOp>(
         loc, resource.getType(), resource, resourceSize, resourceSize,

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/PatternUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/PatternUtils.cpp
@@ -64,7 +64,8 @@ ConvertedTensor transferTensorOperands(
   Value resource = convertedOperand[0];
   Value resourceSize = convertedOperand[1];
   auto affinityAttr = affinityAnalysis->lookupResourceAffinity(originalOperand);
-  if (affinityAttr != requiredAffinityAttr) {
+  auto isBarrier = isa<IREE::Stream::AsyncBarrierOp>(resource.getDefiningOp());
+  if (affinityAttr != requiredAffinityAttr && !isBarrier) {
     resource = builder.create<IREE::Stream::AsyncTransferOp>(
         loc, resource.getType(), resource, resourceSize, resourceSize,
         affinityAttr, requiredAffinityAttr);


### PR DESCRIPTION
Barriers indicate within device blocking. The results of a barrier should not transfer to another location, otherwise there would be a transfer and not a barrier.