### PR TITLE
[Util] Fix OptimizeIntArithmetic pattern failure condition

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/OptimizeIntArithmetic.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/OptimizeIntArithmetic.cpp
@@ -135,7 +135,7 @@ struct ConvertUnsignedI64IndexCastProducerToIndex
                                 PatternRewriter &rewriter) const override {
     Type inType = origIndexOp.getIn().getType();
     Type outType = origIndexOp.getOut().getType();
-    if (!inType.isSignlessInteger(64) && isa<IndexType>(outType))
+    if (!inType.isSignlessInteger(64) || !isa<IndexType>(outType))
       return failure();
 
     Operation *producer = origIndexOp.getIn().getDefiningOp();


### PR DESCRIPTION
The condition is wrong and leads to infinite loops if the input is i32 and output is index type.