### PR TITLE
[VectorDistribution] Clone vector.step on layout conflict

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
@@ -204,7 +204,7 @@ ChangeResult DistributionLayout::resolveWithPossibleConflict(
   // Handle case where constantOp may have multiple consumers with different
   // layouts by creating a copy of constOp for other users.
   if (!opOperand.get().hasOneUse() && !vectorLayout &&
-      llvm::dyn_cast_or_null<arith::ConstantOp>(
+      llvm::isa_and_nonnull<arith::ConstantOp, vector::StepOp>(
           opOperand.get().getDefiningOp())) {
     builder.setInsertionPoint(opOperand.get().getDefiningOp());
     Operation *copiedConstOp = builder.clone(*opOperand.get().getDefiningOp());


### PR DESCRIPTION
vector.step, just like arith.constant should be cloned during vector distribution as it has no load cost. This usually occurs when duplicate vector.step's get csed away.