### PR TITLE
[DispatchCreation] Always clone attention mask generator

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h
@@ -133,7 +133,11 @@ FailureOr<Flow::DispatchRegionOp> wrapOpInDispatchRegion(RewriterBase &rewriter,
 ///
 /// Note: This function returns `false` for ops that should be tiled and fused
 /// into a dispatch region.
-bool isClonableIntoDispatchOp(Operation *op);
+struct ClonableIntoDispatchOptions {
+  bool aggressive = false;
+};
+bool isClonableIntoDispatchOp(Operation *op,
+                              ClonableIntoDispatchOptions options = {});
 
 /// Hoists an operation out of a dispatch region, as long as it does not have
 /// producers inside of the dispatch region, or all of its uses are part of
@@ -148,12 +152,15 @@ FailureOr<Operation *> hoistOutOfDispatch(RewriterBase &rewriter,
                                           Operation *op);
 
 /// Collect all ops that should be cloned into the given dispatch region op.
-SmallVector<Operation *> getCloneableOps(Flow::DispatchRegionOp regionOp);
+SmallVector<Operation *>
+getCloneableOps(Flow::DispatchRegionOp regionOp,
+                ClonableIntoDispatchOptions options = {});
 
 /// Clone into the region producers of those value used in the region but
 /// defined above, to prepare the dispatch region isolated from above.
 LogicalResult cloneProducersToRegion(RewriterBase &rewriter,
-                                     Flow::DispatchRegionOp regionOp);
+                                     Flow::DispatchRegionOp regionOp,
+                                     ClonableIntoDispatchOptions options = {});
 
 } // namespace mlir::iree_compiler::IREE::Flow
 

--- a/compiler/src/iree/compiler/DispatchCreation/CloneProducersIntoDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/CloneProducersIntoDispatchRegions.cpp
@@ -26,12 +26,15 @@ namespace {
 struct CloneProducersIntoDispatchRegionsPass final
     : public impl::CloneProducersIntoDispatchRegionsPassBase<
           CloneProducersIntoDispatchRegionsPass> {
+  using Base::Base;
   void runOnOperation() override {
     mlir::FunctionOpInterface funcOp = getOperation();
     IRRewriter rewriter(funcOp->getContext());
 
+    IREE::Flow::ClonableIntoDispatchOptions options;
+    options.aggressive = aggressive;
     funcOp->walk([&](IREE::Flow::DispatchRegionOp regionOp) {
-      if (failed(cloneProducersToRegion(rewriter, regionOp)))
+      if (failed(cloneProducersToRegion(rewriter, regionOp, options)))
         return signalPassFailure();
     });
 
@@ -54,7 +57,7 @@ struct CloneProducersIntoDispatchRegionsPass final
     // Rerun the cloning again to move still clonable operations into
     // dispatches.
     funcOp->walk([&](IREE::Flow::DispatchRegionOp regionOp) {
-      if (failed(cloneProducersToRegion(rewriter, regionOp)))
+      if (failed(cloneProducersToRegion(rewriter, regionOp, options)))
         return signalPassFailure();
     });
   }

--- a/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
@@ -720,18 +720,6 @@ fuseRootsWithProducers(MLIRContext *context, Operation *root, unsigned groupNum,
   }
 }
 
-static bool isAttentionMaskGenerator(Operation *op) {
-  for (OpOperand &use : op->getUses()) {
-    if (auto attention =
-            dyn_cast<IREE::LinalgExt::AttentionOp>(use.getOwner())) {
-      if (attention.getMask() == use.get()) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
 /// Some heuristic is needed to fuse a dispatchable op with root operations
 /// using tile + fuse. Using some heuristic, each root operation is tagged with
 /// an ID (using an IntegerAttr with name `kRootOpAttr`) and all dispatchable
@@ -783,12 +771,6 @@ decideFusableLinalgOps(Region &region, DominanceInfo const &dominanceInfo,
       // If it is part of a fusion group or root op, ignore it.
       if (hasFusionGroupsAttribute(&op) || hasRootOpAttribute(&op))
         continue;
-      // If the operation is used for masking an AttentionOp, then we always
-      // clone it. The Attention mask is usually big, and is always generated
-      // from a small tensor, so it's always good to clone it.
-      if (isAttentionMaskGenerator(&op)) {
-        continue;
-      }
       // Only look for Linalg ops here. Avoid moving `linalg.fill` that aren't
       // fused with anything else into their own dispatches since it is better
       // to convert them to splats. Also avoid moving dequantization-like ops

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -229,7 +229,11 @@ static void addDispatchRegionCreationPasses(OpPassManager &passManager) {
       // afterwards that would need the full dispatch content but don't want to
       // handle explicit captures as materialized as dispatch workgroup operands
       // and block arguments.
-      .addPass(DispatchCreation::createCloneProducersIntoDispatchRegionsPass);
+      .addPass([&]() {
+        return DispatchCreation::createCloneProducersIntoDispatchRegionsPass(
+            CloneProducersIntoDispatchRegionsPassOptions{
+                clEnableAggressiveFusion});
+      });
 
   // Experimental data tiling path. The intent of this path is to set encodings
   // after fusion decisions have already been made, so encodings can be

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -169,6 +169,11 @@ def CloneProducersIntoDispatchRegionsPass :
     regions but defined in the above. This prepares the dispatch regions for
     converting to dispatch workgroups with explicit captures.
   }];
+  let options = [
+    Option<"aggressive", "aggressive", "bool",
+    /*default=*/"false",
+    "Include operations that are cloned only under aggressive fusion mode">,
+  ];
 }
 
 def CollapseDimensionsPass :

--- a/compiler/src/iree/compiler/DispatchCreation/test/clone_producers_into_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/clone_producers_into_dispatch_regions.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --iree-flow-enable-gather-fusion --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-clone-producers-into-dispatch-regions))" %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-flow-enable-gather-fusion --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-clone-producers-into-dispatch-regions{aggressive=true}))" %s | FileCheck %s
 
 util.func public @complex_element_type(%input: tensor<4xi32>, %table: tensor<8x2xcomplex<f32>>) -> tensor<4x2xcomplex<f32>> {
   %c4095 = arith.constant 4095 : i32
@@ -554,3 +554,53 @@ util.func public @clone_bit_ext_of_gather_like(%arg0: tensor<128256x4096xf16>, %
 //       CHECK:      %[[RES:.+]] = linalg.generic
 //  CHECK-SAME:        ins(%[[EXT]] : tensor<4x?x4096xf32>)
 //       CHECK:      flow.return %[[RES]]
+
+// -----
+
+util.func public @attention_clone_mask(%arg0: tensor<?x?xf16>,
+    %arg1: tensor<?x?xf16>, %arg2: tensor<?x?xf16>) -> tensor<?x?xf16> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %dim = tensor.dim %arg0, %c0 : tensor<?x?xf16>
+  %dim_0 = tensor.dim %arg1, %c1 : tensor<?x?xf16>
+  %dim_1 = tensor.dim %arg2, %c1 : tensor<?x?xf16>
+  %false = arith.constant false
+  %true = arith.constant true
+  %cst = arith.constant 1.000000e+00 : f16
+  %0 = tensor.empty(%dim, %dim_0) : tensor<?x?xi1>
+  %1 = tensor.empty(%dim, %dim_1) : tensor<?x?xf16>
+  %2 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel"]}
+      outs(%0 : tensor<?x?xi1>) {
+  ^bb0(%out: i1):
+    %4 = linalg.index 0 : index
+    %5 = linalg.index 1 : index
+    %6 = arith.cmpi sge, %4, %5 : index
+    %7 = arith.select %6, %false, %true : i1
+    linalg.yield %7 : i1
+  } -> tensor<?x?xi1>
+  %3 = flow.dispatch.region -> (tensor<?x?xf16>{%dim, %dim_1}) {
+    %4 = iree_linalg_ext.attention {
+        indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d3)>,
+                         affine_map<(d0, d1, d2, d3) -> (d2, d3)>,
+                         affine_map<(d0, d1, d2, d3) -> (d2, d1)>,
+                         affine_map<(d0, d1, d2, d3) -> ()>,
+                         affine_map<(d0, d1, d2, d3) -> (d2, d3)>,
+                         affine_map<(d0, d1, d2, d3) -> (d0, d1)>]}
+        ins(%arg0, %arg1, %arg2, %cst, %2 : tensor<?x?xf16>, tensor<?x?xf16>,
+            tensor<?x?xf16>, f16, tensor<?x?xi1>) outs(%1 : tensor<?x?xf16>) {
+    ^bb0(%arg3: f32):
+      iree_linalg_ext.yield %arg3 : f32
+    } -> tensor<?x?xf16>
+    flow.return %4 : tensor<?x?xf16>
+  }
+  util.return %3 : tensor<?x?xf16>
+}
+// CHECK-LABEL: func public @attention_clone_mask
+//       CHECK:   %[[DISPATCH:.+]] = flow.dispatch.region
+//       CHECK:     %[[MASK:.+]] = linalg.generic
+//       CHECK:     %[[ATTENTION:.+]] = iree_linalg_ext.attention
+//  CHECK-SAME:         ins({{.+}}, %[[MASK]] :
+//       CHECK:     flow.return %[[ATTENTION]]
+//       CHECK:   return %[[DISPATCH]]

--- a/tests/e2e/linalg_ext_ops/attention_i1_mask.mlir
+++ b/tests/e2e/linalg_ext_ops/attention_i1_mask.mlir
@@ -14,8 +14,10 @@ func.func @attention1x4x4_i1_mask() {
                                             [0.9, 1.0, 1.1, 1.2],
                                             [1.3, 1.4, 1.5, 1.6]]]> : tensor<1x4x4xf32>
 
-  %i8mask = util.unfoldable_constant dense<[165, 165]> : tensor<2xi8>
-  %mask = flow.tensor.bitcast %i8mask : tensor<2xi8> -> tensor<1x4x4xi1>
+  %mask = util.unfoldable_constant dense<[[[1, 0, 1, 0],
+                                           [0, 1, 0, 1],
+                                           [1, 0, 1, 0],
+                                           [0, 1, 0, 1]]]> : tensor<1x4x4xi1>
 
   %scale = arith.constant 0.5 : f32
   %1 = iree_linalg_ext.attention  {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,
@@ -55,8 +57,10 @@ func.func @attention1x4x4_i1_mask_all_ones() {
                                             [0.9, 1.0, 1.1, 1.2],
                                             [1.3, 1.4, 1.5, 1.6]]]> : tensor<1x4x4xf32>
 
-  %i8mask = util.unfoldable_constant dense<[255, 255]> : tensor<2xi8>
-  %mask = flow.tensor.bitcast %i8mask : tensor<2xi8> -> tensor<1x4x4xi1>
+  %mask = util.unfoldable_constant dense<[[[1, 1, 1, 1],
+                                           [1, 1, 1, 1],
+                                           [1, 1, 1, 1],
+                                           [1, 1, 1, 1]]]> : tensor<1x4x4xi1>
 
   %scale = arith.constant 0.5 : f32
   %1 = iree_linalg_ext.attention  {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,
@@ -96,8 +100,10 @@ func.func @attention1x4x4_i1_mask_tril() {
                                             [0.9, 1.0, 1.1, 1.2],
                                             [1.3, 1.4, 1.5, 1.6]]]> : tensor<1x4x4xf32>
 
-  %i8mask = util.unfoldable_constant dense<[140, 239]> : tensor<2xi8>
-  %mask = flow.tensor.bitcast %i8mask : tensor<2xi8> -> tensor<1x4x4xi1>
+  %mask = util.unfoldable_constant dense<[[[1, 0, 0, 0],
+                                           [1, 1, 0, 0],
+                                           [1, 1, 1, 0],
+                                           [1, 1, 1, 1]]]> : tensor<1x4x4xi1>
 
   %scale = arith.constant 0.5 : f32
   %1 = iree_linalg_ext.attention  {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,

--- a/tests/e2e/linalg_ext_ops/attention_i1_mask.mlir
+++ b/tests/e2e/linalg_ext_ops/attention_i1_mask.mlir
@@ -14,10 +14,8 @@ func.func @attention1x4x4_i1_mask() {
                                             [0.9, 1.0, 1.1, 1.2],
                                             [1.3, 1.4, 1.5, 1.6]]]> : tensor<1x4x4xf32>
 
-  %mask = util.unfoldable_constant dense<[[[1, 0, 1, 0],
-                                           [0, 1, 0, 1],
-                                           [1, 0, 1, 0],
-                                           [0, 1, 0, 1]]]> : tensor<1x4x4xi1>
+  %i8mask = util.unfoldable_constant dense<[165, 165]> : tensor<2xi8>
+  %mask = flow.tensor.bitcast %i8mask : tensor<2xi8> -> tensor<1x4x4xi1>
 
   %scale = arith.constant 0.5 : f32
   %1 = iree_linalg_ext.attention  {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,
@@ -57,10 +55,8 @@ func.func @attention1x4x4_i1_mask_all_ones() {
                                             [0.9, 1.0, 1.1, 1.2],
                                             [1.3, 1.4, 1.5, 1.6]]]> : tensor<1x4x4xf32>
 
-  %mask = util.unfoldable_constant dense<[[[1, 1, 1, 1],
-                                           [1, 1, 1, 1],
-                                           [1, 1, 1, 1],
-                                           [1, 1, 1, 1]]]> : tensor<1x4x4xi1>
+  %i8mask = util.unfoldable_constant dense<[255, 255]> : tensor<2xi8>
+  %mask = flow.tensor.bitcast %i8mask : tensor<2xi8> -> tensor<1x4x4xi1>
 
   %scale = arith.constant 0.5 : f32
   %1 = iree_linalg_ext.attention  {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,
@@ -100,10 +96,8 @@ func.func @attention1x4x4_i1_mask_tril() {
                                             [0.9, 1.0, 1.1, 1.2],
                                             [1.3, 1.4, 1.5, 1.6]]]> : tensor<1x4x4xf32>
 
-  %mask = util.unfoldable_constant dense<[[[1, 0, 0, 0],
-                                           [1, 1, 0, 0],
-                                           [1, 1, 1, 0],
-                                           [1, 1, 1, 1]]]> : tensor<1x4x4xi1>
+  %i8mask = util.unfoldable_constant dense<[140, 239]> : tensor<2xi8>
+  %mask = flow.tensor.bitcast %i8mask : tensor<2xi8> -> tensor<1x4x4xi1>
 
   %scale = arith.constant 0.5 : f32
   %1 = iree_linalg_ext.attention  {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,


### PR DESCRIPTION
Attention mask is generally generated from a very small tensor and is broadcasted / filled to a larger tensor. This generated tensor is usually very large. It is almost always better to clone this mask generator into it's consumers dispatch.