### PR TITLE
[linalgExt::Attention] Move `scale` out of `AttentionOp`

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/AggregatedOpInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/AggregatedOpInterfaceImpl.cpp
@@ -306,38 +306,17 @@ static bool willBeContiguousSlice(OpFoldResult inputSize, OpFoldResult tileSize,
 //===----------------------------------------------------------------------===//
 
 Value computeQKAndElementwise(Location loc, OpBuilder &b, Value query,
-                              Value key, Value scale, std::optional<Value> mask,
+                              Value key, std::optional<Value> mask,
                               AffineMap qMap, AffineMap kMap, AffineMap sMap,
                               std::optional<AffineMap> maskMap,
                               SmallVector<OpFoldResult> iterationDomain,
                               Type sElementType, Region &elementwiseRegion,
                               DictionaryAttr qkAttrs, bool lowPrecision) {
   MLIRContext *ctx = b.getContext();
-  // Since we use exp2 for attention instead of the original exp, we have to
-  // multiply the scale by log2(e). We use exp2 instead of exp as most platforms
-  // have better support for exp2 (we verified that we gain some speedup on
-  // some GPUs).
-  Value log2e = b.create<arith::ConstantOp>(
-      loc, b.getFloatAttr(scale.getType(), M_LOG2E));
-  scale = b.create<arith::MulFOp>(loc, scale, log2e);
-
   auto qETy = getElementTypeOrSelf(query.getType());
 
   AffineMap scaleMap = AffineMap::get(/*dimCount=*/qMap.getNumInputs(),
                                       /*symbolCount=*/0, ctx);
-
-  // In the original algorithm, the scaling is done after the softmax:
-  //        softmax(Q @ K.T * scale) @ V
-  //
-  // But, it is mathematically equivalent to do it on Q first and then multiply
-  // it by K.T. This just allows us to do the scaling once, instead of each
-  // iteration of the loop. This is only valid for f16 or f32 types as f8
-  // is extremely limited on its dynamic range therefore this would
-  // significantly affect numerics.
-  if (!lowPrecision) {
-    query = elementwiseValueInPlace<arith::MulFOp>(b, loc, qMap, scaleMap,
-                                                   query, scale);
-  }
 
   // ---- QK Matmul ----
 
@@ -366,10 +345,6 @@ Value computeQKAndElementwise(Location loc, OpBuilder &b, Value query,
     // losing numerical precision due to the low dynamic range of fp8 types when
     // pre applying the sclaing.
     AffineMap sMap = b.getMultiDimIdentityMap(sSizes.size());
-    AffineMap scaleMap = AffineMap::get(/*dimCount=*/sMap.getNumInputs(),
-                                        /*symbolCount=*/0, ctx);
-    s = elementwiseValueInPlace<arith::MulFOp>(b, loc, sMap, scaleMap, s,
-                                               scale);
 
     // If we need to truncate to fp8 post softmax we apply a scaling to use the
     // full fp8 range. We can do this with a offset as post `exp2` this equates
@@ -431,9 +406,9 @@ FailureOr<SmallVector<Value>> AttentionOp::decomposeOperation(OpBuilder &b) {
   Type f32Type = b.getF32Type();
 
   // ---- QK Matmul + elementwise math ----
-  Value s = computeQKAndElementwise(loc, b, query, key, getScale(), mask, qMap,
-                                    kMap, sMap, getMaskMap(), sizes, f32Type,
-                                    getRegion(), qkAttrs, lowPrecision);
+  Value s = computeQKAndElementwise(loc, b, query, key, mask, qMap, kMap, sMap,
+                                    getMaskMap(), sizes, f32Type, getRegion(),
+                                    qkAttrs, lowPrecision);
 
   // ---- Softmax ----
 
@@ -546,9 +521,9 @@ OnlineAttentionOp::decomposeOperation(OpBuilder &b) {
   bool lowPrecision = qETy.getIntOrFloatBitWidth() <= 8;
 
   // ---- QK Matmul + elementwise math ----
-  Value s = computeQKAndElementwise(
-      loc, b, query, key, getScale(), mask, qMap, kMap, sMap, getMaskMap(),
-      sizes, elementType, getRegion(), qkAttrs, lowPrecision);
+  Value s = computeQKAndElementwise(loc, b, query, key, mask, qMap, kMap, sMap,
+                                    getMaskMap(), sizes, elementType,
+                                    getRegion(), qkAttrs, lowPrecision);
 
   // TODO: This decomposition should be in a seperate op called
   // "online softmax".

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1239,10 +1239,10 @@ LogicalResult WinogradOutputTransformOp::reifyResultShapes(
 
 void AttentionOp::build(OpBuilder &odsBuilder, OperationState &odsState,
                         TypeRange results, Value query, Value key, Value value,
-                        Value scale, Value output, ArrayAttr indexingMaps,
+                        Value output, ArrayAttr indexingMaps,
                         std::optional<Value> mask) {
   Value maskIn = mask.value_or(Value());
-  build(odsBuilder, odsState, results, query, key, value, scale, maskIn, output,
+  build(odsBuilder, odsState, results, query, key, value, maskIn, output,
         indexingMaps, DictionaryAttr());
 }
 
@@ -1258,11 +1258,6 @@ LogicalResult AttentionOp::verify() {
       getQueryMap(), getKeyMap(), getValueMap(), getOutputMap());
   if (failed(maybeOpInfo)) {
     return attnOp->emitOpError("failed to verify op's indexing maps");
-  }
-
-  FloatType scaleElementType = dyn_cast<FloatType>(getScale().getType());
-  if (!scaleElementType) {
-    return attnOp->emitOpError("expected scale to be of floating point type");
   }
 
   // Check shape compatibility based on indexing maps.
@@ -1326,7 +1321,6 @@ LogicalResult AttentionOp::verify() {
   if (failed(checkDomain("Query", getQueryMap())) ||
       failed(checkDomain("Key", getKeyMap())) ||
       failed(checkDomain("Value", getValueMap())) ||
-      failed(checkDomain("Scale", getScaleMap())) ||
       failed(checkDomain("Output", getOutputMap()))) {
     return failure();
   }
@@ -1355,7 +1349,7 @@ LogicalResult AttentionOp::verify() {
 }
 
 MutableOperandRange AttentionOp::getDpsInitsMutable() {
-  return MutableOperandRange(*this, /*numInputs=*/getMask() ? 5 : 4,
+  return MutableOperandRange(*this, /*numInputs=*/getMask() ? 4 : 3,
                              /*numInits=*/1);
 }
 
@@ -1413,12 +1407,12 @@ SmallVector<AffineMap> AttentionOp::getIndexingMapsForResults() {
 
 void OnlineAttentionOp::build(OpBuilder &odsBuilder, OperationState &odsState,
                               TypeRange results, Value query, Value key,
-                              Value value, Value scale, Value output, Value max,
-                              Value sum, ArrayAttr indexingMaps,
+                              Value value, Value output, Value max, Value sum,
+                              ArrayAttr indexingMaps,
                               std::optional<Value> mask) {
   Value maskIn = mask.value_or(Value());
-  build(odsBuilder, odsState, results, query, key, value, maskIn, scale, output,
-        max, sum, indexingMaps, DictionaryAttr());
+  build(odsBuilder, odsState, results, query, key, value, maskIn, output, max,
+        sum, indexingMaps, DictionaryAttr());
 }
 
 LogicalResult OnlineAttentionOp::verify() {
@@ -1493,7 +1487,6 @@ LogicalResult OnlineAttentionOp::verify() {
   if (failed(checkDomain("Query", getQueryMap())) ||
       failed(checkDomain("Key", getKeyMap())) ||
       failed(checkDomain("Value", getValueMap())) ||
-      failed(checkDomain("Scale", getScaleMap())) ||
       failed(checkDomain("Output", getOutputMap())) ||
       failed(checkDomain("Max", getMaxMap())) ||
       failed(checkDomain("Sum", getSumMap()))) {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -550,12 +550,13 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_PureOp<"attention",
        "generateResultTileValue"]>]> {
   let summary = "Attention operator";
   let description = [{
-    Computes the scaled dot product attention function:
+    Computes the dot product attention function:
 
-    attention(Q, K, V, scale) = softmax(Q @ K.T * scale) @ V
+    attention(Q, K, V) = softmax(Q @ K.T) @ V
 
-    Here Q, K, V are given tensors and scale is a scalar value specifying
-    the scale to use.
+    Here Q, K, V are given tensors. The operation does not take scale,
+
+    If scaling is required, it should be applied to Q or K before calling this op.
 
     If an additional mask argument M is included, the result of the first matmul is modified according to:
 
@@ -565,7 +566,6 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_PureOp<"attention",
   let arguments = (ins AnyShaped:$query,
                        AnyShaped:$key,
                        AnyShaped:$value,
-                       AnyFloat:$scale,
                        Optional<AnyShaped>:$mask,
                        AnyShaped:$output,
                        AffineMapArrayAttr:$indexing_maps,
@@ -578,7 +578,7 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_PureOp<"attention",
   let hasCustomAssemblyFormat = 1;
   let assemblyFormat = [{
     attr-dict
-    `ins` `(` $query `,` $key `,` $value `,` $scale (`,` $mask^)?  `:` type($query) `,` type($key) `,` type($value) `,` type($scale) (`,` type($mask)^ )?`)`
+    `ins` `(` $query `,` $key `,` $value `,` (`,` $mask^)?  `:` type($query) `,` type($key) `,` type($value) (`,` type($mask)^ )?`)`
     `outs` `(` $output `:` type($output) `)`
     $region
     (`->` type($results)^)?
@@ -589,7 +589,6 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_PureOp<"attention",
     "Value":$query,
     "Value":$key,
     "Value":$value,
-    "Value":$scale,
     "Value":$output,
     "ArrayAttr":$indexing_maps,
     CArg<"std::optional<Value>", "std::nullopt">:$mask)>
@@ -611,12 +610,9 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_PureOp<"attention",
     AffineMap getValueMap() {
       return cast<AffineMap>(getIndexingMapsArray()[2]);
     }
-    AffineMap getScaleMap() {
-      return cast<AffineMap>(getIndexingMapsArray()[3]);
-    }
     std::optional<AffineMap> getMaskMap() {
       if (getMask()) {
-        return cast<AffineMap>(getIndexingMapsArray()[4]);
+        return cast<AffineMap>(getIndexingMapsArray()[3]);
       }
       return std::nullopt;
     }
@@ -659,13 +655,13 @@ def IREELinalgExt_OnlineAttentionOp : IREELinalgExt_PureOp<"online_attention",
   let description = [{
     Traditional scaled dot product attention computes:
 
-    attention(Q, K, V, scale) = softmax(Q @ K.T * scale) @ V
+    attention(Q, K, V) = softmax(Q @ K.T) @ V
 
     Online Attention on the other hand, uses an online normalizer instead of
     softmax:
 
-    online_attention(Q, K, V, scale, running_max, running_sum)
-      = online_normalizer(Q @ K.T * scale, running_max, running_sum) @ V
+    online_attention(Q, K, V, running_max, running_sum)
+      = online_normalizer(Q @ K.T, running_max, running_sum) @ V
 
     If an additional mask argument M is included, the result of the first matmul is modified according to:
 
@@ -686,7 +682,6 @@ def IREELinalgExt_OnlineAttentionOp : IREELinalgExt_PureOp<"online_attention",
   let arguments = (ins AnyShaped:$query,
                        AnyShaped:$key,
                        AnyShaped:$value,
-                       AnyFloat:$scale,
                        Optional<AnyShaped>:$mask,
                        AnyShaped:$output,
                        AnyShaped:$max,
@@ -701,7 +696,7 @@ def IREELinalgExt_OnlineAttentionOp : IREELinalgExt_PureOp<"online_attention",
   let hasCustomAssemblyFormat = 1;
   let assemblyFormat = [{
     attr-dict
-    `ins` `(` $query `,` $key `,` $value `,` $scale (`,` $mask^)?  `:` type($query) `,` type($key) `,` type($value) `,` type($scale) (`,` type($mask)^ )?`)`
+    `ins` `(` $query `,` $key `,` $value `,` (`,` $mask^)?  `:` type($query) `,` type($key) `,` type($value) `,` (`,` type($mask)^ )?`)`
     `outs` `(` $output `,` $max `,` $sum `:` type($output) `,` type($max) `,` type($sum) `)`
     $region
     (`->` type($results)^)?
@@ -712,7 +707,6 @@ def IREELinalgExt_OnlineAttentionOp : IREELinalgExt_PureOp<"online_attention",
     "Value":$query,
     "Value":$key,
     "Value":$value,
-    "Value":$scale,
     "Value":$output,
     "Value":$max,
     "Value":$sum,
@@ -737,12 +731,9 @@ def IREELinalgExt_OnlineAttentionOp : IREELinalgExt_PureOp<"online_attention",
     AffineMap getValueMap() {
       return getIndexingMapsArray()[2];
     }
-    AffineMap getScaleMap() {
-      return getIndexingMapsArray()[3];
-    }
     std::optional<AffineMap> getMaskMap() {
       if (getMask()) {
-        return cast<AffineMap>(getIndexingMapsArray()[4]);
+        return cast<AffineMap>(getIndexingMapsArray()[3]);
       }
       return std::nullopt;
     }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -1906,8 +1906,6 @@ AttentionOp::getTiledImplementation(OpBuilder &builder,
   SmallVector<Range> outputSlice =
       getPermutedRange(getOutputMap(), offsets, sizes);
 
-  Value scale = getScale();
-
   SmallVector<Value> tiledOperands;
   SmallVector<Operation *> slices;
 
@@ -1940,9 +1938,6 @@ AttentionOp::getTiledImplementation(OpBuilder &builder,
     tiledOperands.emplace_back(valueSliceOp->getResult(0));
     slices.push_back(valueSliceOp);
   }
-
-  // Scale
-  tiledOperands.emplace_back(scale);
 
   // Mask
   Value attnMask = getMask();
@@ -2066,8 +2061,6 @@ OnlineAttentionOp::getTiledImplementation(OpBuilder &builder,
   SmallVector<Range> maxSlice = getPermutedRange(getMaxMap(), offsets, sizes);
   SmallVector<Range> sumSlice = getPermutedRange(getSumMap(), offsets, sizes);
 
-  Value scale = getScale();
-
   SmallVector<Value> tiledOperands;
   SmallVector<Operation *> slices;
   /// Query
@@ -2099,8 +2092,6 @@ OnlineAttentionOp::getTiledImplementation(OpBuilder &builder,
     tiledOperands.emplace_back(valueSliceOp->getResult(0));
     slices.push_back(valueSliceOp);
   }
-
-  tiledOperands.emplace_back(scale);
 
   // Mask
   Value attnMask = getMask();
@@ -2292,8 +2283,6 @@ FailureOr<TilingResult> OnlineAttentionOp::tileToPartialReduction(
   if (failed(appendSlice(getValue(), getValueMap(), offsets))) {
     return failure();
   }
-
-  tiledOperands.emplace_back(getScale());
 
   if (Value mask = getMask()) {
     if (failed(appendSlice(mask, *getMaskMap(), offsets))) {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ReshapeFusion.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ReshapeFusion.cpp
@@ -450,9 +450,8 @@ static std::optional<SmallVector<Value>> fuseAttentionWithReshapeByExpansion(
   TypeRange resultTypes = ValueRange(output).getTypes();
   auto fusedOp = rewriter.create<AttentionOp>(
       attentionOp.getLoc(), resultTypes, expandedOpOperands[0],
-      expandedOpOperands[1], expandedOpOperands[2], expandedOpOperands[3],
-      output, rewriter.getAffineMapArrayAttr(expandedOpIndexingMaps),
-      maskOperand);
+      expandedOpOperands[1], expandedOpOperands[2], output,
+      rewriter.getAffineMapArrayAttr(expandedOpIndexingMaps), maskOperand);
 
   rewriter.inlineRegionBefore(attentionOp.getRegion(), fusedOp.getRegion(),
                               fusedOp.getRegion().begin());
@@ -915,7 +914,7 @@ static Operation *createCollapsedOp(AttentionOp origOp,
 
   auto collapsedOp = rewriter.create<AttentionOp>(
       origOp.getLoc(), resultTypes, inputOperands[0], inputOperands[1],
-      inputOperands[2], inputOperands[3], outputOperands[0],
+      inputOperands[2], outputOperands[0],
       rewriter.getAffineMapArrayAttr(indexingMaps), maskOperand);
   rewriter.inlineRegionBefore(origOp.getRegion(), collapsedOp.getRegion(),
                               collapsedOp.getRegion().begin());

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TileAttention.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/TileAttention.cpp
@@ -105,9 +105,8 @@ void convertToOnlineAttention(IREE::LinalgExt::AttentionOp attnOp,
 
   OnlineAttentionOp onlineAttn = rewriter.create<OnlineAttentionOp>(
       loc, TypeRange{accFill.getType(), maxFill.getType(), sumFill.getType()},
-      attnOp.getQuery(), attnOp.getKey(), attnOp.getValue(), attnOp.getScale(),
-      mask, accFill, maxFill, sumFill,
-      rewriter.getAffineMapArrayAttr(indexingMaps),
+      attnOp.getQuery(), attnOp.getKey(), attnOp.getValue(), mask, accFill,
+      maxFill, sumFill, rewriter.getAffineMapArrayAttr(indexingMaps),
       attnOp.getDecompositionConfigAttr());
 
   rewriter.cloneRegionBefore(attnOp.getRegion(), onlineAttn.getRegion(),

--- a/compiler/src/iree/compiler/Preprocessing/Common/FoldAttentionWithTranspose.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/FoldAttentionWithTranspose.cpp
@@ -174,8 +174,7 @@ struct FoldAttentionAndTranspose
         rewriter.getAffineMapArrayAttr(newIndexingMaps);
     auto newAttentionOp = rewriter.create<IREE::LinalgExt::AttentionOp>(
         attentionOp.getLoc(), expandedInit.getType(), expandedQuery,
-        expandedKey, expandedValue, attentionOp.getScale(), expandedInit,
-        newIndexingMapsAttr);
+        expandedKey, expandedValue, expandedInit, newIndexingMapsAttr);
     rewriter.replaceOp(transposeLikeOp, newAttentionOp);
     return success();
   }


### PR DESCRIPTION
#18932


- Move `scale` out of `linalgExt::AttentionOp`, and `linalgExt::OnlineAttentionOp`
- Add useExp attribute to use exp_e or exp_2

~~I'm first to this project so I'd like to proceed with some help,  is this direction okay or plausible?~~



cc @Groverkss 