### PR TITLE
Update regression mi300 test to use new runner cluster

### DIFF
--- a/.github/workflows/pkgci_regression_test.yml
+++ b/.github/workflows/pkgci_regression_test.yml
@@ -46,7 +46,7 @@ jobs:
           - name: amdgpu_rocm_mi300_gfx942
             rocm-chip: gfx942
             backend: rocm
-            runs-on: nodai-amdgpu-mi300-x86-64
+            runs-on: linux-mi300-gpu-1
     env:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
       IREE_TEST_PATH_EXTENSION: ${{ github.workspace }}/build_tools/pkgci/external_test_suite

--- a/.github/workflows/pkgci_regression_test.yml
+++ b/.github/workflows/pkgci_regression_test.yml
@@ -52,6 +52,7 @@ jobs:
       IREE_TEST_PATH_EXTENSION: ${{ github.workspace }}/build_tools/pkgci/external_test_suite
       VENV_DIR: ${{ github.workspace }}/venv
       TEST_OUTPUT_ARTIFACTS: ${{ github.workspace }}/model_output_artifacts
+      IREE_TEST_FILES: /mnt_k8s/iree_tests_cache
     steps:
       - name: Checking out IREE repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
This PR updated pkgci_regression_test to use a new runner by updating the label to linux-mi300-gpu-1.
