### PR TITLE
[Preprocessing] Adding conv filter to channel last pass in preprocessing

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
@@ -149,6 +149,17 @@ getGenericOpOrGeneralizeContraction(RewriterBase &rewriter, Operation *op,
       !(allowGeneralizing && linalg::isaContractionOpInterface(linalgOp))) {
     return failure();
   }
+
+  // If this is generic op but comply to convolution op interface, assume
+  // it is from ConvertConvToChannelsLast pass and skip.
+  // FuseTransposeWithProducerLinalgOp will fuse the transpose into successive
+  // convolution, negating the effect from the filter layout conversion from
+  // that pass.
+  if (isa<linalg::GenericOp>(linalgOp) &&
+      linalg::isaConvolutionOpInterface(linalgOp)) {
+    return failure();
+  }
+
   auto genericOp = dyn_cast<linalg::GenericOp>(op);
   if (genericOp) {
     return genericOp;

--- a/compiler/src/iree/compiler/Preprocessing/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Preprocessing/Common/BUILD.bazel
@@ -32,8 +32,8 @@ iree_compiler_cc_library(
     srcs = [
         "ApplyPDLPatterns.cpp",
         "ConvertConv2DToImg2Col.cpp",
-        "ConvertConvToChannelsLast.cpp",
         "ConvertConvFilterToChannelsLast.cpp",
+        "ConvertConvToChannelsLast.cpp",
         "FoldAttentionWithTranspose.cpp",
         "GeneralizeLinalgMatMul.cpp",
         "InterpreterPass.cpp",

--- a/compiler/src/iree/compiler/Preprocessing/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Preprocessing/Common/BUILD.bazel
@@ -33,6 +33,7 @@ iree_compiler_cc_library(
         "ApplyPDLPatterns.cpp",
         "ConvertConv2DToImg2Col.cpp",
         "ConvertConvToChannelsLast.cpp",
+        "ConvertConvFilterToChannelsLast.cpp",
         "FoldAttentionWithTranspose.cpp",
         "GeneralizeLinalgMatMul.cpp",
         "InterpreterPass.cpp",

--- a/compiler/src/iree/compiler/Preprocessing/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Preprocessing/Common/CMakeLists.txt
@@ -29,6 +29,7 @@ iree_cc_library(
     "ApplyPDLPatterns.cpp"
     "ConvertConv2DToImg2Col.cpp"
     "ConvertConvToChannelsLast.cpp"
+    "ConvertConvFilterToChannelsLast.cpp"
     "FoldAttentionWithTranspose.cpp"
     "GeneralizeLinalgMatMul.cpp"
     "InterpreterPass.cpp"

--- a/compiler/src/iree/compiler/Preprocessing/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Preprocessing/Common/CMakeLists.txt
@@ -28,8 +28,8 @@ iree_cc_library(
   SRCS
     "ApplyPDLPatterns.cpp"
     "ConvertConv2DToImg2Col.cpp"
-    "ConvertConvToChannelsLast.cpp"
     "ConvertConvFilterToChannelsLast.cpp"
+    "ConvertConvToChannelsLast.cpp"
     "FoldAttentionWithTranspose.cpp"
     "GeneralizeLinalgMatMul.cpp"
     "InterpreterPass.cpp"

--- a/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvFilterToChannelsLast.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvFilterToChannelsLast.cpp
@@ -1,0 +1,144 @@
+//===----------------------------------------------------------------------===//
+// ConvertConvFilterToChannelsLastPass
+//===----------------------------------------------------------------------===//
+
+#include "iree/compiler/Preprocessing/Common/Passes.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/LogicalResult.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "iree-preprocessing-convert-conv-filter-to-channels-last"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+namespace mlir::iree_compiler::Preprocessing {
+
+#define GEN_PASS_DEF_CONVERTCONVFILTERTOCHANNELSLASTPASS
+#include "iree/compiler/Preprocessing/Common/Passes.h.inc"
+
+// Utility function to swap the last two dimensions.
+static AffineMap constructFilterMap(AffineMap map, SmallVector<int64_t> &perm) {
+  unsigned numDims = map.getNumDims();
+  ArrayRef<AffineExpr> mapResults = map.getResults();
+  SmallVector<AffineExpr, 4> exprs;
+  for (int i = 0; i < perm.size(); ++i) {
+    exprs.push_back(mapResults[perm[i]]);
+  }
+  return AffineMap::get(numDims, map.getNumSymbols(), exprs, map.getContext());
+}
+
+// Utility function to create a transpose operation.
+static Value createTransposeOp(PatternRewriter &rewriter, Location loc,
+                               Value tensor, SmallVector<int64_t> &perm) {
+  SmallVector<OpFoldResult, 4> dimSizes =
+      tensor::getMixedSizes(rewriter, loc, tensor);
+  // Dim index of H, W, F, C
+  SmallVector<OpFoldResult, 4> transposeResultDims;
+  for (int i = 0; i < perm.size(); ++i) {
+    transposeResultDims.push_back(dimSizes[perm[i]]);
+  }
+
+  auto tensorType = cast<RankedTensorType>(tensor.getType());
+  auto emptyTensor = rewriter.create<tensor::EmptyOp>(
+      loc, transposeResultDims, tensorType.getElementType());
+  return rewriter.create<linalg::TransposeOp>(loc, tensor, emptyTensor, perm)
+      .getResult()[0];
+}
+
+llvm::LogicalResult
+convertConvFilterToTargetLayout(linalg::Conv2DNhwcHwcfOp convOp,
+                                PatternRewriter &rewriter,
+                                SmallVector<int64_t> &perm) {
+  Location loc = convOp.getLoc();
+
+  // Extract operands.
+  Value input = convOp.getInputs()[0];
+  Value filter = convOp.getInputs()[1];
+  Value output = convOp.getOutputs()[0];
+
+  // Extract indexing maps.
+  AffineMap inputMap = convOp.getIndexingMapsArray()[0];
+  AffineMap filterMap = convOp.getIndexingMapsArray()[1];
+  AffineMap outputMap = convOp.getIndexingMapsArray()[2];
+
+  AffineMap transposedFilterMap = constructFilterMap(filterMap, perm);
+  Value transposedFilter = createTransposeOp(rewriter, loc, filter, perm);
+
+  SmallVector<utils::IteratorType> iterators = convOp.getIteratorTypesArray();
+
+  auto genericOp = rewriter.create<linalg::GenericOp>(
+      loc, output.getType(), ValueRange{input, transposedFilter}, output,
+      ArrayRef<AffineMap>{inputMap, transposedFilterMap, outputMap}, iterators);
+
+  // Reuse the same payload as the original convolution op.
+  rewriter.inlineRegionBefore(convOp->getRegion(0), genericOp.getRegion(),
+                              genericOp.getRegion().begin());
+
+  rewriter.replaceOp(convOp, genericOp->getResults());
+  return success();
+}
+
+namespace {
+struct ConvertHwcfToHwfc : public OpRewritePattern<linalg::Conv2DNhwcHwcfOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::Conv2DNhwcHwcfOp convOp,
+                                PatternRewriter &rewriter) const override {
+    SmallVector<int64_t> perm = {0, 1, 3, 2};
+    return convertConvFilterToTargetLayout(convOp, rewriter, perm);
+  }
+};
+
+struct ConvertHwcfToFhwc : public OpRewritePattern<linalg::Conv2DNhwcHwcfOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::Conv2DNhwcHwcfOp convOp,
+                                PatternRewriter &rewriter) const override {
+    SmallVector<int64_t> perm = {3, 0, 1, 2};
+    return convertConvFilterToTargetLayout(convOp, rewriter, perm);
+  }
+};
+
+class ConvertConvFilterToChannelsLastPass
+    : public iree_compiler::Preprocessing::impl::
+          ConvertConvFilterToChannelsLastPassBase<
+              ConvertConvFilterToChannelsLastPass> {
+public:
+  using iree_compiler::Preprocessing::impl::
+      ConvertConvFilterToChannelsLastPassBase<
+          ConvertConvFilterToChannelsLastPass>::
+          ConvertConvFilterToChannelsLastPassBase;
+
+  void runOnOperation() override {
+    auto op = getOperation();
+    MLIRContext *context = &getContext();
+
+    RewritePatternSet patterns(context);
+    if (filterLayout == "hwfc") {
+      patterns.add<ConvertHwcfToHwfc>(context);
+    } else if (filterLayout == "fhwc") {
+      patterns.add<ConvertHwcfToFhwc>(context);
+    } else {
+      // TODO add default fallback to filter layout once we have more data
+      // about models with the two layouts
+      llvm_unreachable("Unsupported filter layout. Use hwfc or fhwc.");
+    }
+
+    if (failed(applyPatternsGreedily(op, std::move(patterns)))) {
+      return signalPassFailure();
+    }
+
+    LDBG("after converting convolutions to channels last\n" << *op);
+  }
+};
+
+} // namespace
+} // namespace mlir::iree_compiler::Preprocessing

--- a/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvFilterToChannelsLast.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvFilterToChannelsLast.cpp
@@ -31,8 +31,8 @@ static AffineMap applyPermutationToResults(AffineMap map,
                                            ArrayRef<int64_t> perm) {
   unsigned numDims = map.getNumDims();
   ArrayRef<AffineExpr> mapResults = map.getResults();
-  SmallVector<AffineExpr, 4> exprs;
-  for (int i = 0; i < perm.size(); ++i) {
+  SmallVector<AffineExpr> exprs;
+  for (int i = 0, e = perm.size(); i < e; ++i) {
     exprs.push_back(mapResults[perm[i]]);
   }
   return AffineMap::get(numDims, map.getNumSymbols(), exprs, map.getContext());
@@ -40,7 +40,7 @@ static AffineMap applyPermutationToResults(AffineMap map,
 
 static Value createTransposeOp(RewriterBase &rewriter, Location loc,
                                Value tensor, ArrayRef<int64_t> perm) {
-  SmallVector<OpFoldResult, 4> dimSizes =
+  SmallVector<OpFoldResult> dimSizes =
       tensor::getMixedSizes(rewriter, loc, tensor);
   applyPermutationToVector(dimSizes, perm);
 

--- a/compiler/src/iree/compiler/Preprocessing/Common/Passes.td
+++ b/compiler/src/iree/compiler/Preprocessing/Common/Passes.td
@@ -36,6 +36,19 @@ def ConvertConv2DToImg2ColPass :
   ];
 }
 
+def ConvertConvFilterToChannelsLastPass:
+    Pass<"iree-preprocessing-convert-conv-filter-to-channels-last", ""> {
+  let summary = "Convert linalg convolutions filter from hwcf to channel last layout.";
+  let options = [
+    Option<"filterLayout", "filter-layout", "std::string",
+      /*default=*/"", "Filter layout of convolution.">,
+  ];
+  let dependentDialects = [
+    "mlir::linalg::LinalgDialect",
+    "mlir::tensor::TensorDialect",
+  ];
+}
+
 def ConvertConvToChannelsLastPass :
     Pass<"iree-preprocessing-convert-conv-to-channels-last", ""> {
   let summary = "Convert linalg convolutions to channels last.";

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/BUILD.bazel
@@ -17,6 +17,7 @@ iree_lit_test_suite(
     srcs = enforce_glob(
         [
             "conv2d_to_img2col.mlir",
+            "conv_filter_to_channels_last.mlir",
             "conv_to_channels_last.mlir",
             "fold_attention_with_transpose.mlir",
             "generalize_linalg_matmul.mlir",

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "conv2d_to_img2col.mlir"
+    "conv_filter_to_channels_last.mlir"
     "conv_to_channels_last.mlir"
     "fold_attention_with_transpose.mlir"
     "generalize_linalg_matmul.mlir"

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/conv_filter_to_channels_last.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/conv_filter_to_channels_last.mlir
@@ -3,26 +3,26 @@
 
 // CHECK-HWFC: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d3, d6)>
 // CHECK-FHWC: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d3, d4, d5, d6)>
-// CHECK-ALL-LABEL: @conv_fp16
-util.func @conv_fp16(%arg0: tensor<2x130x130x16xf16>, %arg1: tensor<3x3x16x320xf16>,
-%arg2: tensor<2x128x128x320xf32>)
-    -> tensor<2x128x128x320xf32> {
+// CHECK-ALL-LABEL: @conv_i8
+util.func @conv_i8(%arg0: tensor<2x130x130x16xi8>, %arg1: tensor<3x3x16x320xi8>,
+%arg2: tensor<2x128x128x320xi32>)
+    -> tensor<2x128x128x320xi32> {
 
-// CHECK-HWFC:      %[[EMPTY:.*]] = tensor.empty() : tensor<3x3x320x16xf16>
-// CHECK-HWFC:      %[[TRANSPOSE:.*]] = linalg.transpose ins(%arg1 : tensor<3x3x16x320xf16>) outs(%[[EMPTY]] : tensor<3x3x320x16xf16>) permutation = [0, 1, 3, 2]
+// CHECK-HWFC:      %[[EMPTY:.*]] = tensor.empty() : tensor<3x3x320x16xi8>
+// CHECK-HWFC:      %[[TRANSPOSE:.*]] = linalg.transpose ins(%arg1 : tensor<3x3x16x320xi8>) outs(%[[EMPTY]] : tensor<3x3x320x16xi8>) permutation = [0, 1, 3, 2]
 // CHECK-HWFC:      %[[GENERIC:.*]] = linalg.generic
 // CHECK-HWFC-SAME: indexing_maps = [#map, #[[$MAP]], #map2],
-// CHECK-HWFC-SAME: ins(%arg0, %[[TRANSPOSE]] : tensor<2x130x130x16xf16>, tensor<3x3x320x16xf16>)
+// CHECK-HWFC-SAME: ins(%arg0, %[[TRANSPOSE]] : tensor<2x130x130x16xi8>, tensor<3x3x320x16xi8>)
 
-// CHECK-FHWC:      %[[EMPTY:.*]] = tensor.empty() : tensor<320x3x3x16xf16>
-// CHECK-FHWC:      %[[TRANSPOSE:.*]] = linalg.transpose ins(%arg1 : tensor<3x3x16x320xf16>) outs(%[[EMPTY]] : tensor<320x3x3x16xf16>) permutation = [3, 0, 1, 2]
+// CHECK-FHWC:      %[[EMPTY:.*]] = tensor.empty() : tensor<320x3x3x16xi8>
+// CHECK-FHWC:      %[[TRANSPOSE:.*]] = linalg.transpose ins(%arg1 : tensor<3x3x16x320xi8>) outs(%[[EMPTY]] : tensor<320x3x3x16xi8>) permutation = [3, 0, 1, 2]
 // CHECK-FHWC:      %[[GENERIC:.*]] = linalg.generic
 // CHECK-FHWC-SAME: indexing_maps = [#map, #[[$MAP]], #map2],
-// CHECK-FHWC-SAME: ins(%arg0, %[[TRANSPOSE]] : tensor<2x130x130x16xf16>, tensor<320x3x3x16xf16>)
+// CHECK-FHWC-SAME: ins(%arg0, %[[TRANSPOSE]] : tensor<2x130x130x16xi8>, tensor<320x3x3x16xi8>)
   %conv0 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>}
-             ins(%arg0, %arg1 : tensor<2x130x130x16xf16>, tensor<3x3x16x320xf16>)
-             outs(%arg2 : tensor<2x128x128x320xf32>) -> tensor<2x128x128x320xf32>
-  util.return %conv0 : tensor<2x128x128x320xf32>
+             ins(%arg0, %arg1 : tensor<2x130x130x16xi8>, tensor<3x3x16x320xi8>)
+             outs(%arg2 : tensor<2x128x128x320xi32>) -> tensor<2x128x128x320xi32>
+  util.return %conv0 : tensor<2x128x128x320xi32>
 }
 
 // -----
@@ -69,20 +69,4 @@ util.func @conv_dyn_filter(%arg0: tensor<2x130x130x16xf16>, %arg1: tensor<?x?x16
              ins(%arg0, %arg1 : tensor<2x130x130x16xf16>, tensor<?x?x16x320xf16>)
              outs(%arg2 : tensor<2x128x128x320xf32>) -> tensor<2x128x128x320xf32>
   util.return %conv0 : tensor<2x128x128x320xf32>
-}
-
-// -----
-
-// CHECK-ALL-LABEL: @conv_i8
-util.func @conv_i8(%arg0: tensor<2x130x130x16xi8>, %arg1: tensor<3x3x16x320xi8>,
-%arg2: tensor<2x128x128x320xi32>)
-    -> tensor<2x128x128x320xi32> {
-
-// CHECK-ALL:       linalg.generic
-// CHECK-HWFC-SAME: ins(%arg0, %{{.*}} : tensor<2x130x130x16xi8>, tensor<3x3x320x16xi8>) outs(%arg2 : tensor<2x128x128x320xi32>)
-// CHECK-FHWC-SAME: ins(%arg0, %{{.*}} : tensor<2x130x130x16xi8>, tensor<320x3x3x16xi8>) outs(%arg2 : tensor<2x128x128x320xi32>)
-  %conv0 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>}
-             ins(%arg0, %arg1 : tensor<2x130x130x16xi8>, tensor<3x3x16x320xi8>)
-             outs(%arg2 : tensor<2x128x128x320xi32>) -> tensor<2x128x128x320xi32>
-  util.return %conv0 : tensor<2x128x128x320xi32>
 }

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/conv_filter_to_channels_last.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/conv_filter_to_channels_last.mlir
@@ -1,0 +1,88 @@
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(util.func(iree-preprocessing-convert-conv-filter-to-channels-last{filter-layout=hwfc}))" %s | FileCheck --check-prefixes=CHECK-HWFC,CHECK-ALL %s
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(util.func(iree-preprocessing-convert-conv-filter-to-channels-last{filter-layout=fhwc}))" %s | FileCheck --check-prefixes=CHECK-FHWC,CHECK-ALL %s
+
+// CHECK-HWFC: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d3, d6)>
+// CHECK-FHWC: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d3, d4, d5, d6)>
+// CHECK-ALL-LABEL: @conv_fp16
+util.func @conv_fp16(%arg0: tensor<2x130x130x16xf16>, %arg1: tensor<3x3x16x320xf16>,
+%arg2: tensor<2x128x128x320xf32>)
+    -> tensor<2x128x128x320xf32> {
+
+// CHECK-HWFC:      %[[EMPTY:.*]] = tensor.empty() : tensor<3x3x320x16xf16>
+// CHECK-HWFC:      %[[TRANSPOSE:.*]] = linalg.transpose ins(%arg1 : tensor<3x3x16x320xf16>) outs(%[[EMPTY]] : tensor<3x3x320x16xf16>) permutation = [0, 1, 3, 2]
+// CHECK-HWFC:      %[[GENERIC:.*]] = linalg.generic
+// CHECK-HWFC-SAME: indexing_maps = [#map, #[[$MAP]], #map2],
+// CHECK-HWFC-SAME: ins(%arg0, %[[TRANSPOSE]] : tensor<2x130x130x16xf16>, tensor<3x3x320x16xf16>)
+
+// CHECK-FHWC:      %[[EMPTY:.*]] = tensor.empty() : tensor<320x3x3x16xf16>
+// CHECK-FHWC:      %[[TRANSPOSE:.*]] = linalg.transpose ins(%arg1 : tensor<3x3x16x320xf16>) outs(%[[EMPTY]] : tensor<320x3x3x16xf16>) permutation = [3, 0, 1, 2]
+// CHECK-FHWC:      %[[GENERIC:.*]] = linalg.generic
+// CHECK-FHWC-SAME: indexing_maps = [#map, #[[$MAP]], #map2],
+// CHECK-FHWC-SAME: ins(%arg0, %[[TRANSPOSE]] : tensor<2x130x130x16xf16>, tensor<320x3x3x16xf16>)
+  %conv0 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>}
+             ins(%arg0, %arg1 : tensor<2x130x130x16xf16>, tensor<3x3x16x320xf16>)
+             outs(%arg2 : tensor<2x128x128x320xf32>) -> tensor<2x128x128x320xf32>
+  util.return %conv0 : tensor<2x128x128x320xf32>
+}
+
+// -----
+
+// CHECK-ALL-LABEL: @conv_dyn_input
+util.func @conv_dyn_input(%arg0: tensor<?x?x?x16xf16>, %arg1: tensor<3x3x16x320xf16>,
+%arg2: tensor<?x?x?x320xf32>)
+    -> tensor<?x?x?x320xf32> {
+// CHECK-ALL:       %[[GENERIC:.*]] = linalg.generic
+
+// CHECK-HWFC-SAME: ins(%arg0, %[[TRANSPOSED:.*]]: tensor<?x?x?x16xf16>, tensor<3x3x320x16xf16>)
+// CHECK-FHWC-SAME: ins(%arg0, %[[TRANSPOSED:.*]]: tensor<?x?x?x16xf16>, tensor<320x3x3x16xf16>)
+
+// CHECK-ALL-SAME:  outs(%arg2 : tensor<?x?x?x320xf32>)
+// CHECK-ALL:       util.return %[[GENERIC]] : tensor<?x?x?x320xf32>
+  %conv0 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>}
+             ins(%arg0, %arg1 : tensor<?x?x?x16xf16>, tensor<3x3x16x320xf16>)
+             outs(%arg2 : tensor<?x?x?x320xf32>) -> tensor<?x?x?x320xf32>
+  util.return %conv0 : tensor<?x?x?x320xf32>
+}
+
+// -----
+
+// CHECK-ALL-LABEL: @conv_dyn_filter
+util.func @conv_dyn_filter(%arg0: tensor<2x130x130x16xf16>, %arg1: tensor<?x?x16x320xf16>,
+%arg2: tensor<2x128x128x320xf32>)
+    -> tensor<2x128x128x320xf32> {
+
+// CHECK-ALL-DAG:   %[[C1:.*]] = arith.constant 1 : index
+// CHECK-ALL-DAG:   %[[C0:.*]] = arith.constant 0 : index
+// CHECK-ALL-DAG:   %[[DIM0:.*]] = tensor.dim %arg1, %[[C0]]
+// CHECK-ALL-DAG:   %[[DIM1:.*]] = tensor.dim %arg1, %[[C1]]
+// CHECK-ALL:       %[[EMPTY:.*]] = tensor.empty(%[[DIM0]], %[[DIM1]])
+
+// CHECK-HWFC:      %[[TRANSPOSE:.*]] = linalg.transpose ins(%arg1 : tensor<?x?x16x320xf16>) outs(%[[EMPTY]] : tensor<?x?x320x16xf16>) permutation = [0, 1, 3, 2]
+// CHECK-FHWC:      %[[TRANSPOSE:.*]] = linalg.transpose ins(%arg1 : tensor<?x?x16x320xf16>) outs(%[[EMPTY]] : tensor<320x?x?x16xf16>) permutation = [3, 0, 1, 2]
+
+// CHECK-ALL:       linalg.generic
+
+// CHECK-HWFC-SAME: ins(%arg0, %[[TRANSPOSE]] : tensor<2x130x130x16xf16>, tensor<?x?x320x16xf16>) outs(%arg2 : tensor<2x128x128x320xf32>)
+// CHECK-FHWC-SAME: ins(%arg0, %[[TRANSPOSE]] : tensor<2x130x130x16xf16>, tensor<320x?x?x16xf16>) outs(%arg2 : tensor<2x128x128x320xf32>)
+
+  %conv0 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>}
+             ins(%arg0, %arg1 : tensor<2x130x130x16xf16>, tensor<?x?x16x320xf16>)
+             outs(%arg2 : tensor<2x128x128x320xf32>) -> tensor<2x128x128x320xf32>
+  util.return %conv0 : tensor<2x128x128x320xf32>
+}
+
+// -----
+
+// CHECK-ALL-LABEL: @conv_i8
+util.func @conv_i8(%arg0: tensor<2x130x130x16xi8>, %arg1: tensor<3x3x16x320xi8>,
+%arg2: tensor<2x128x128x320xi32>)
+    -> tensor<2x128x128x320xi32> {
+
+// CHECK-ALL:       linalg.generic
+// CHECK-HWFC-SAME: ins(%arg0, %{{.*}} : tensor<2x130x130x16xi8>, tensor<3x3x320x16xi8>) outs(%arg2 : tensor<2x128x128x320xi32>)
+// CHECK-FHWC-SAME: ins(%arg0, %{{.*}} : tensor<2x130x130x16xi8>, tensor<320x3x3x16xi8>) outs(%arg2 : tensor<2x128x128x320xi32>)
+  %conv0 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>}
+             ins(%arg0, %arg1 : tensor<2x130x130x16xi8>, tensor<3x3x16x320xi8>)
+             outs(%arg2 : tensor<2x128x128x320xi32>) -> tensor<2x128x128x320xi32>
+  util.return %conv0 : tensor<2x128x128x320xi32>
+}


### PR DESCRIPTION
- Created the new pass: convert-conv-filter-to-channels-last with below options
  - filter-layout=fhwc
  - filter-layout=hwfc
- Disabled FuseTransposeWithLinalgOpConsumer pass for linalg generic that are lowered from convolution
- Added corresponding unit tests
- Verified the pass via SDXL and confirmed filter transpose are const-folded

Note: This pass serve as an experimental option and not hooked into any pipeline yet. To invoke and test this pass, use: `iree-preprocessing-convert-conv-filter-to-channels-last{filter-layout=fhwc}`, for example.