### PR TITLE
Remove barriers post execution scheduling

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
@@ -357,9 +357,10 @@ struct ScheduleExecutionPass
       op.getCanonicalizationPatterns(patterns, context);
     }
 
-    // Barriers are used only for analysis and can be removed as part of cleanup.
+    // Barriers are used only for analysis and can be removed as part of
+    // cleanup.
     patterns.insert<RemoveBarriers>(context);
-    
+
     FrozenRewritePatternSet frozenPatterns(std::move(patterns));
     if (failed(applyPatternsGreedily(getOperation(), frozenPatterns))) {
       return signalPassFailure();

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
@@ -315,6 +315,15 @@ LogicalResult processRegion(Location loc, MLIRContext *context, Region &region,
 // --iree-stream-schedule-execution
 //===----------------------------------------------------------------------===//
 
+struct RemoveBarriers : public OpRewritePattern<IREE::Stream::AsyncBarrierOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(IREE::Stream::AsyncBarrierOp op,
+                                PatternRewriter &rewriter) const override {
+    rewriter.replaceOp(op, op.getOperand(0));
+    return success();
+  }
+};
+
 struct ScheduleExecutionPass
     : public IREE::Stream::impl::ScheduleExecutionPassBase<
           ScheduleExecutionPass> {
@@ -347,6 +356,8 @@ struct ScheduleExecutionPass
     for (auto op : context->getRegisteredOperations()) {
       op.getCanonicalizationPatterns(patterns, context);
     }
+
+    patterns.insert<RemoveBarriers>(context);
     FrozenRewritePatternSet frozenPatterns(std::move(patterns));
     if (failed(applyPatternsGreedily(getOperation(), frozenPatterns))) {
       return signalPassFailure();

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
@@ -357,7 +357,9 @@ struct ScheduleExecutionPass
       op.getCanonicalizationPatterns(patterns, context);
     }
 
+    // Barriers are used only for analysis and can be removed as part of cleanup.
     patterns.insert<RemoveBarriers>(context);
+    
     FrozenRewritePatternSet frozenPatterns(std::move(patterns));
     if (failed(applyPatternsGreedily(getOperation(), frozenPatterns))) {
       return signalPassFailure();

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/schedule_execution.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/schedule_execution.mlir
@@ -50,7 +50,6 @@ util.func public @deviceMultiDeviceSync(%arg0: i1) -> !stream.resource<transient
   // CHECK: stream.async.execute on(#hal.device.affinity<@__device_0>)
   // CHECK: stream.async.splat
   // CHECK: stream.async.dispatch
-  // CHECK: stream.async.barrier
   // CHECK: stream.async.transfer
 
   %2 = stream.async.dispatch on(#hal.device.affinity<@__device_1>) @ex::@dispatch1[%c1, %c1, %c1](%0[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
@@ -59,14 +58,12 @@ util.func public @deviceMultiDeviceSync(%arg0: i1) -> !stream.resource<transient
   // CHECK: stream.async.execute on(#hal.device.affinity<@__device_1>)
   // CHECK: stream.async.splat
   // CHECK: stream.async.dispatch
-  // CHECK: stream.async.barrier
   // CHECK: stream.async.transfer
 
   %7 = stream.async.dispatch on(#hal.device.affinity<@__device_0>) @ex::@dispatch2[%c1, %c1, %c1](%3[%c0 to %c128 for %c128], %6[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}, !stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
   %9 = stream.async.barrier %7 : !stream.resource<transient>{%c128} -> !stream.resource<transient>
   // CHECK: stream.async.execute on(#hal.device.affinity<@__device_0>)
   // CHECK: stream.async.dispatch
-  // CHECK: stream.async.barrier
 
   %8 = stream.async.dispatch on(#hal.device.affinity<@__device_1>) @ex::@dispatch2[%c1, %c1, %c1](%4[%c0 to %c128 for %c128], %5[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}, !stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
   %10 = stream.async.transfer %8 : !stream.resource<transient>{%c128} from(#hal.device.affinity<@__device_1>) -> to(#hal.device.affinity<@__device_0>) !stream.resource<transient>{%c128}


### PR DESCRIPTION
Once scheduling is complete we will no longer need the barrier operators. Removing the operations now prevents the copy during allocation.