### PR TITLE
[Codegen][Tuner] default tuning spec available per-SKU

### DIFF
--- a/compiler/plugins/target/ROCM/builtins/tuning/BUILD.bazel
+++ b/compiler/plugins/target/ROCM/builtins/tuning/BUILD.bazel
@@ -26,6 +26,7 @@ endif()
 # Target archs for tuning specs. https://llvm.org/docs/AMDGPUUsage.html#processors
 gpu_archs = [
     "gfx942",
+    "mi308x",
 ]
 
 tuning_spec_mlir_files = [

--- a/compiler/plugins/target/ROCM/builtins/tuning/CMakeLists.txt
+++ b/compiler/plugins/target/ROCM/builtins/tuning/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_c_embed_data(
     iree_default_tuning_specs_amdgpu
   SRCS
     "iree_default_tuning_spec_gfx942.mlir"
+    "iree_default_tuning_spec_mi308x.mlir"
   C_FILE_OUTPUT
     "iree_default_tuning_specs_amdgpu.c"
   H_FILE_OUTPUT
@@ -32,6 +33,7 @@ iree_lit_test_suite(
     verify_default_tuning_specs_amdgpu
   SRCS
     "iree_default_tuning_spec_gfx942.mlir"
+    "iree_default_tuning_spec_mi308x.mlir"
   TOOLS
     iree-opt
 )

--- a/compiler/plugins/target/ROCM/builtins/tuning/iree_default_tuning_spec_mi308x.mlir
+++ b/compiler/plugins/target/ROCM/builtins/tuning/iree_default_tuning_spec_mi308x.mlir
@@ -13,7 +13,7 @@ module @iree_default_tuning_spec_mi308x attributes { transform.with_named_sequen
 transform.named_sequence @apply_op_config(%op: !transform.any_op {transform.readonly},
                                           %config: !transform.any_param {transform.readonly}) {
   transform.annotate %op "compilation_info" = %config : !transform.any_op, !transform.any_param
-  // transform.print %op {name = "Applied"} : !transform.any_op
+  transform.annotate %op "__tuning_spec_applied__" : !transform.any_op
   transform.yield
 }
 

--- a/compiler/plugins/target/ROCM/builtins/tuning/iree_default_tuning_spec_mi308x.mlir
+++ b/compiler/plugins/target/ROCM/builtins/tuning/iree_default_tuning_spec_mi308x.mlir
@@ -1,0 +1,263 @@
+// RUN: iree-opt %s
+
+// This is just an initial tuning spec for mi308x and is not intended for
+// production use.
+// TODO(https://github.com/iree-org/iree/issues/19214): Add missing
+// configurations to this spec.
+
+module @iree_default_tuning_spec_mi308x attributes { transform.with_named_sequence, iree_codegen.tuning_spec_with_default_entrypoint} {
+//===----------------------------------------------------------------------===//
+// Tuning infra
+//===----------------------------------------------------------------------===//
+
+transform.named_sequence @apply_op_config(%op: !transform.any_op {transform.readonly},
+                                          %config: !transform.any_param {transform.readonly}) {
+  transform.annotate %op "compilation_info" = %config : !transform.any_op, !transform.any_param
+  // transform.print %op {name = "Applied"} : !transform.any_op
+  transform.yield
+}
+
+transform.named_sequence @apply_attn_op_config(%attention: !transform.any_op {transform.readonly},
+                                                %config: !transform.any_param {transform.readonly},
+                                                %decomposition_config: !transform.any_param {transform.readonly}) {
+  transform.annotate %attention "compilation_info" = %config : !transform.any_op, !transform.any_param
+  transform.annotate %attention "decomposition_config" = %decomposition_config : !transform.any_op, !transform.any_param
+  // transform.print %attention {name = "Applied attention config"} : !transform.any_op
+  transform.yield
+}
+
+transform.named_sequence @match_attention_f16(%attention: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param, !transform.any_param) {
+  transform.match.operation_name %attention ["iree_linalg_ext.attention"] : !transform.any_op
+  %in0 = transform.get_operand %attention[0] : (!transform.any_op) -> !transform.any_value
+  transform.iree.match.cast_compatible_type %in0 = tensor<?x?x?x?xf16> : !transform.any_value
+
+  %config = transform.param.constant #iree_codegen.compilation_info<
+          lowering_config = #iree_gpu.lowering_config<{workgroup = [1, 1, 64, 0, 0, 0], reduction=[0, 0, 0, 0, 0, 64], promote_operands = [1, 2]}>,
+          translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+                                                            workgroup_size = [64, 4]
+                                                            subgroup_size = 64 ,
+            {llvm_func_attrs = { "amdgpu-waves-per-eu" = "2", "denormal-fp-math-f32" = "preserve-sign" }}>>
+  -> !transform.any_param
+
+  %decomposition_config = transform.param.constant {
+    qk_attrs = {attention_qk_matmul,
+                lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.virtual_mma_layout<intrinsic = VMFMA_F32_32x32x16_F16>,
+                                                              subgroup_m_count = 4, subgroup_n_count = 1, promote_operands = [1] }>},
+    pv_attrs = {attention_pv_matmul,
+                lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>,
+                                                              subgroup_m_count = 4, subgroup_n_count = 1, promote_operands = [1] }>}
+  } -> !transform.any_param
+
+  transform.yield %attention, %config, %decomposition_config : !transform.any_op, !transform.any_param, !transform.any_param
+}
+
+transform.named_sequence @match_mmt_f16_f16_f32(%root: !transform.any_op {transform.readonly}) -> (!transform.any_op) {
+  transform.match.operation_name %root ["linalg.generic"] : !transform.any_op
+  // transform.print %root {name = "Generic"} : !transform.any_op
+  %ins, %outs = transform.iree.match.cast_compatible_dag_from_root %root {
+    ^bb0(%lhs: tensor<?x?xf16>, %rhs: tensor<?x?xf16>, %out: tensor<?x?xf32>):
+    %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
+                                          affine_map<(d0, d1, d2) -> (d1, d2)>,
+                                          affine_map<(d0, d1, d2) -> (d0, d1)>],
+                         iterator_types = ["parallel", "parallel", "reduction"]}
+        ins(%lhs, %rhs : tensor<?x?xf16>, tensor<?x?xf16>) outs(%out : tensor<?x?xf32>) {
+      ^bb0(%in: f16, %in_0: f16, %acc: f32):
+        %18 = arith.extf %in : f16 to f32
+        %19 = arith.extf %in_0 : f16 to f32
+        %20 = arith.mulf %18, %19 : f32
+        %21 = arith.addf %acc, %20 : f32
+        linalg.yield %21 : f32
+      } -> tensor<?x?xf32>
+  } : (!transform.any_op) -> (!transform.any_value, !transform.any_value)
+  transform.yield %root : !transform.any_op
+}
+
+// TUNING_SPEC_BEGIN DO NOT REMOVE
+
+//===----------------------------------------------------------------------===//
+// Matmul tuning
+//===----------------------------------------------------------------------===//
+
+transform.named_sequence @match_mmt_1920x10240x1280(%matmul: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+  %mmt = transform.include @match_mmt_f16_f16_f32 failures(propagate) (%matmul) : (!transform.any_op) -> !transform.any_op
+  %lhs = transform.get_operand %matmul[0] : (!transform.any_op) -> !transform.any_value
+  %rhs = transform.get_operand %matmul[1] : (!transform.any_op) -> !transform.any_value
+  transform.iree.match.cast_compatible_type %lhs = tensor<1920x1280xf16> : !transform.any_value
+  transform.iree.match.cast_compatible_type %rhs = tensor<10240x1280xf16> : !transform.any_value
+  %config = transform.param.constant #iree_codegen.compilation_info<
+  lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
+                                                mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
+                                                subgroup_m_count = 4, subgroup_n_count = 2,
+                                                reduction = [0, 0, 32],
+                                                workgroup = [128, 128, 0]}>,
+  translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+    workgroup_size = [128, 4, 1] subgroup_size = 64,
+    {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true>,
+     llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}
+    }>> -> !transform.any_param
+  transform.yield %matmul, %config : !transform.any_op, !transform.any_param
+}
+
+transform.named_sequence @match_mmt_1920x1280x1280(%matmul: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+  %mmt = transform.include @match_mmt_f16_f16_f32 failures(propagate) (%matmul) : (!transform.any_op) -> !transform.any_op
+  %lhs = transform.get_operand %matmul[0] : (!transform.any_op) -> !transform.any_value
+  %rhs = transform.get_operand %matmul[1] : (!transform.any_op) -> !transform.any_value
+  transform.iree.match.cast_compatible_type %lhs = tensor<1920x1280xf16> : !transform.any_value
+  transform.iree.match.cast_compatible_type %rhs = tensor<1280x1280xf16> : !transform.any_value
+  %config = transform.param.constant #iree_codegen.compilation_info<
+  lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
+                                                mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
+                                                subgroup_m_count = 4, subgroup_n_count = 2,
+                                                reduction = [0, 0, 32],
+                                                workgroup = [128, 128, 0]}>,
+  translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+    workgroup_size = [128, 4, 1] subgroup_size = 64,
+    {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true>,
+     llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}
+    }>> -> !transform.any_param
+  transform.yield %matmul, %config : !transform.any_op, !transform.any_param
+}
+
+transform.named_sequence @match_mmt_1920x1280x5120(%matmul: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+  %mmt = transform.include @match_mmt_f16_f16_f32 failures(propagate) (%matmul) : (!transform.any_op) -> !transform.any_op
+  %lhs = transform.get_operand %matmul[0] : (!transform.any_op) -> !transform.any_value
+  %rhs = transform.get_operand %matmul[1] : (!transform.any_op) -> !transform.any_value
+  transform.iree.match.cast_compatible_type %lhs = tensor<1920x5120xf16> : !transform.any_value
+  transform.iree.match.cast_compatible_type %rhs = tensor<1280x5120xf16> : !transform.any_value
+  %config = transform.param.constant #iree_codegen.compilation_info<
+  lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
+                                                mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
+                                                subgroup_m_count = 4, subgroup_n_count = 2,
+                                                reduction = [0, 0, 32],
+                                                workgroup = [128, 128, 0]}>,
+  translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+    workgroup_size = [128, 4, 1] subgroup_size = 64,
+    {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true>,
+     llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}
+    }>> -> !transform.any_param
+  transform.yield %matmul, %config : !transform.any_op, !transform.any_param
+}
+
+transform.named_sequence @match_mmt_7680x5120x640(%matmul: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+  %mmt = transform.include @match_mmt_f16_f16_f32 failures(propagate) (%matmul) : (!transform.any_op) -> !transform.any_op
+  %lhs = transform.get_operand %matmul[0] : (!transform.any_op) -> !transform.any_value
+  %rhs = transform.get_operand %matmul[1] : (!transform.any_op) -> !transform.any_value
+  transform.iree.match.cast_compatible_type %lhs = tensor<7680x640xf16> : !transform.any_value
+  transform.iree.match.cast_compatible_type %rhs = tensor<5120x640xf16> : !transform.any_value
+  %config = transform.param.constant #iree_codegen.compilation_info<
+  lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
+                                                mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
+                                                subgroup_m_count = 2, subgroup_n_count = 4,
+                                                reduction = [0, 0, 32],
+                                                workgroup = [128, 256, 0]}>,
+  translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+    workgroup_size = [256, 2, 1] subgroup_size = 64,
+    {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true>,
+     llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}
+    }>> -> !transform.any_param
+  transform.yield %matmul, %config : !transform.any_op, !transform.any_param
+}
+
+transform.named_sequence @match_mmt_128x1280x2048(%matmul: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+  %mmt = transform.include @match_mmt_f16_f16_f32 failures(propagate) (%matmul) : (!transform.any_op) -> !transform.any_op
+  %lhs = transform.get_operand %matmul[0] : (!transform.any_op) -> !transform.any_value
+  %rhs = transform.get_operand %matmul[1] : (!transform.any_op) -> !transform.any_value
+  transform.iree.match.cast_compatible_type %lhs = tensor<1280x2048xf16> : !transform.any_value
+  transform.iree.match.cast_compatible_type %rhs = tensor<1280x2048xf16> : !transform.any_value
+  %config = transform.param.constant #iree_codegen.compilation_info<
+  lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
+                                                mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>,
+                                                subgroup_m_count = 2, subgroup_n_count = 1,
+                                                reduction = [0, 0, 128],
+                                                workgroup = [64, 16, 0]}>,
+  translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+    workgroup_size = [64, 2, 1] subgroup_size = 64,
+    {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true>,
+     llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}
+    }>> -> !transform.any_param
+  transform.yield %matmul, %config : !transform.any_op, !transform.any_param
+}
+
+transform.named_sequence @match_mmt_7680x640x640(%matmul: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+  %mmt = transform.include @match_mmt_f16_f16_f32 failures(propagate) (%matmul) : (!transform.any_op) -> !transform.any_op
+  %lhs = transform.get_operand %matmul[0] : (!transform.any_op) -> !transform.any_value
+  %rhs = transform.get_operand %matmul[1] : (!transform.any_op) -> !transform.any_value
+  transform.iree.match.cast_compatible_type %lhs = tensor<7680x640xf16> : !transform.any_value
+  transform.iree.match.cast_compatible_type %rhs = tensor<640x640xf16> : !transform.any_value
+  %config = transform.param.constant #iree_codegen.compilation_info<
+  lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
+                                                mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>,
+                                                subgroup_m_count = 1, subgroup_n_count = 4,
+                                                reduction = [0, 0, 32],
+                                                workgroup = [256, 128, 0]}>,
+  translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+    workgroup_size = [256, 1, 1] subgroup_size = 64,
+    {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true>,
+     llvm_func_attrs = {"amdgpu-waves-per-eu" = "1"}
+    }>> -> !transform.any_param
+  transform.yield %matmul, %config : !transform.any_op, !transform.any_param
+}
+
+transform.named_sequence @match_mmt_7680x640x2560(%matmul: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+  %mmt = transform.include @match_mmt_f16_f16_f32 failures(propagate) (%matmul) : (!transform.any_op) -> !transform.any_op
+  %lhs = transform.get_operand %matmul[0] : (!transform.any_op) -> !transform.any_value
+  %rhs = transform.get_operand %matmul[1] : (!transform.any_op) -> !transform.any_value
+  transform.iree.match.cast_compatible_type %lhs = tensor<7680x2560xf16> : !transform.any_value
+  transform.iree.match.cast_compatible_type %rhs = tensor<640x2560xf16> : !transform.any_value
+  %config = transform.param.constant #iree_codegen.compilation_info<
+  lowering_config = #iree_gpu.lowering_config<{promote_operands = [0, 1],
+                                                mma_kind = #iree_gpu.mma_layout<MFMA_F32_32x32x8_F16>,
+                                                subgroup_m_count = 4, subgroup_n_count = 2,
+                                                reduction = [0, 0, 32],
+                                                workgroup = [256, 128, 0]}>,
+  translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+    workgroup_size = [128, 4, 1] subgroup_size = 64,
+    {gpu_pipeline_options = #iree_gpu.pipeline_options<prefetch_shared_memory = true>,
+     llvm_func_attrs = {"amdgpu-waves-per-eu" = "4"}
+    }>> -> !transform.any_param
+  transform.yield %matmul, %config : !transform.any_op, !transform.any_param
+}
+
+//===----------------------------------------------------------------------===//
+// Convolution tuning
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// Batch matmul tuning
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// Broadcast rhs mmt tuning
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// Contraction tuning
+//===----------------------------------------------------------------------===//
+
+// TUNING_SPEC_END DO NOT REMOVE
+
+//===----------------------------------------------------------------------===//
+// Entry point
+//===----------------------------------------------------------------------===//
+
+  transform.named_sequence @__kernel_config(%variant_op: !transform.any_op {transform.consumed}) -> !transform.any_op
+  attributes { iree_codegen.tuning_spec_entrypoint } {
+    %result = transform.foreach_match in %variant_op
+        @match_attention_f16 -> @apply_attn_op_config
+
+        // TUNING_MATCH_BEGIN DO NOT REMOVE
+
+        // MMT.
+        , @match_mmt_1920x10240x1280 -> @apply_op_config
+        , @match_mmt_1920x1280x1280 -> @apply_op_config
+        , @match_mmt_1920x1280x5120 -> @apply_op_config
+        , @match_mmt_7680x5120x640 -> @apply_op_config
+        , @match_mmt_128x1280x2048 -> @apply_op_config
+        , @match_mmt_7680x640x640 -> @apply_op_config
+        , @match_mmt_7680x640x2560 -> @apply_op_config
+
+        // TUNING_MATCH_END DO NOT REMOVE
+      : (!transform.any_op) -> (!transform.any_op)
+    transform.yield %result : !transform.any_op
+  }
+} ////  module

--- a/compiler/plugins/target/ROCM/builtins/tuning/test/BUILD.bazel
+++ b/compiler/plugins/target/ROCM/builtins/tuning/test/BUILD.bazel
@@ -26,6 +26,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = [
         "spec_gfx942.mlir",
+        "spec_mi308x.mlir",
     ],
     cfg = "//compiler:lit.cfg.py",
     tools = [

--- a/compiler/plugins/target/ROCM/builtins/tuning/test/CMakeLists.txt
+++ b/compiler/plugins/target/ROCM/builtins/tuning/test/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "spec_gfx942.mlir"
+    "spec_mi308x.mlir"
   TOOLS
     FileCheck
     iree-opt

--- a/compiler/plugins/target/ROCM/builtins/tuning/test/spec_gfx942.mlir
+++ b/compiler/plugins/target/ROCM/builtins/tuning/test/spec_gfx942.mlir
@@ -4,12 +4,23 @@
 // RUN:   --iree-codegen-notify-transform-strategy-application \
 // RUN:   --verify-diagnostics %s | FileCheck %s
 
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=mi300x \
+// RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-configure-target-executable-variants{target=rocm})))" \
+// RUN:   --iree-codegen-enable-default-tuning-specs \
+// RUN:   --iree-codegen-notify-transform-strategy-application \
+// RUN:   --verify-diagnostics %s | FileCheck %s --check-prefix=MI300X
+
+
 // Check that the default configuration for mmt_2048x1280x5120_f16_f16_f32
 // applies to the `linalg.matmul_transpose_b` below.
 
 // CHECK-LABEL:  func.func @mmt_2048x1280x5120_f16_f16_f32
 // CHECK:          linalg.generic
 // CHECK-SAME:       __tuning_spec_applied__
+
+// MI300X-LABEL: func.func @mmt_2048x1280x5120_f16_f16_f32
+// MI300X:         linalg.generic
+// MI300X-SAME:      __tuning_spec_applied__
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,

--- a/compiler/plugins/target/ROCM/builtins/tuning/test/spec_mi308x.mlir
+++ b/compiler/plugins/target/ROCM/builtins/tuning/test/spec_mi308x.mlir
@@ -1,0 +1,46 @@
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=mi308x \
+// RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-configure-target-executable-variants{target=rocm})))" \
+// RUN:   --iree-codegen-enable-default-tuning-specs \
+// RUN:   --iree-codegen-notify-transform-strategy-application \
+// RUN:   --verify-diagnostics %s | FileCheck %s
+
+// Check that the default configuration for mmt_1920x10240x1280_f16_f16_f32
+// applies to the `linalg.matmul_transpose_b` below.
+
+// CHECK-LABEL:  func.func @mmt_1920x10240x1280_f16_f16_f32
+// CHECK:          linalg.generic
+// CHECK-SAME:       __tuning_spec_applied__
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable public @main {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @matmul_transpose_b ordinal(0) layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_slice
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      // expected-remark@+1 {{Applied transform configuration strategy @iree_default_tuning_spec_mi308x::@__kernel_config}}
+      func.func @mmt_1920x10240x1280_f16_f16_f32() {
+        %cst = arith.constant 0.000000e+00 : f16
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<1920x1280xf16>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<10240x1280xf16>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<1920x10240xf32>>
+        %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1920, 1280], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<1920x1280xf16>> -> tensor<1920x1280xf16>
+        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [10240, 1280], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<10240x1280xf16>> -> tensor<10240x1280xf16>
+        %5 = tensor.empty() : tensor<1920x10240xf32>
+        %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<1920x10240xf32>) -> tensor<1920x10240xf32>
+        %7 = linalg.matmul_transpose_b
+          ins(%3, %4 : tensor<1920x1280xf16>, tensor<10240x1280xf16>)
+          outs(%6 : tensor<1920x10240xf32>) -> tensor<1920x10240xf32>
+        flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [1920, 10240], strides = [1, 1] : tensor<1920x10240xf32> -> !flow.dispatch.tensor<writeonly:tensor<1920x10240xf32>>
+        return
+      }
+    }
+  }
+}

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
@@ -281,6 +281,7 @@ std::optional<TargetDetails> getAMDGPUTargetDetails(StringRef target) {
   // https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/white-papers/amd-cdna-3-white-paper.pdf
   static const ChipDetails mi300xChip = {304};
   static const ChipDetails mi300aChip = {228};
+  static const ChipDetails mi308xChip = {80};
 
   // "AMD Instinct MI200 Series Accelerator Product Offerings" in Page 14 of
   // https://www.amd.com/content/dam/amd/en/documents/instinct-business-docs/white-papers/amd-cdna2-white-paper.pdf
@@ -302,6 +303,7 @@ std::optional<TargetDetails> getAMDGPUTargetDetails(StringRef target) {
 
   return llvm::StringSwitch<std::optional<TargetDetails>>(target.lower())
       .Case("mi300x", TargetDetails{cdna3Wgp, &mi300xChip})
+      .Case("mi308x", TargetDetails{cdna3Wgp, &mi308xChip})
       .Case("mi300a", TargetDetails{cdna3Wgp, &mi300aChip})
       .Cases("cdna3", "gfx940", "gfx941", "gfx942",
              TargetDetails{cdna3Wgp, nullptr})
@@ -338,7 +340,7 @@ StringRef normalizeAMDGPUTarget(StringRef target) {
     return target;
 
   return llvm::StringSwitch<StringRef>(target.lower())
-      .Cases("mi300x", "mi300a", "gfx942")
+      .Cases("mi300x", "mi300a", "mi308x", "gfx942")
       .Cases("mi250x", "mi250", "mi210", "cdna2", "gfx90a")
       .Cases("mi100", "cdna1", "gfx908")
       .Cases("rx7900xtx", "rx7900xt", "gfx1100")

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -35,7 +35,7 @@
 
 static constexpr unsigned kShuffleBitWidth = 32;
 
-static llvm::cl::opt<std::string> clTestTarget(
+llvm::cl::opt<std::string> clTestTarget(
     "iree-gpu-test-target",
     llvm::cl::desc(
         "The target for IR LIT tests. Format is '<arch>:<feature>@<api>', "
@@ -953,6 +953,8 @@ IREE::GPU::TargetAttr getCLGPUTarget(MLIRContext *context) {
     if (StringRef(clTestTarget).starts_with("sm_"))
       backend = "cuda";
     else if (StringRef(clTestTarget).starts_with("gfx"))
+      backend = "hip";
+    else if (StringRef(clTestTarget).starts_with("mi"))
       backend = "hip";
     else if (StringRef(clTestTarget).starts_with("adreno"))
       backend = "vulkan";

--- a/docs/website/docs/guides/deployment-configurations/gpu-rocm.md
+++ b/docs/website/docs/guides/deployment-configurations/gpu-rocm.md
@@ -130,6 +130,7 @@ Here is a table of commonly used architectures:
 | AMD MI300A (early units) | `gfx941`    | `cdna3`
 | AMD MI300A               | `gfx942`    | `cdna3`
 | AMD MI300X               | `gfx942`    | `cdna3`
+| AMD MI308X               | `gfx942`    | `cdna3`
 | AMD RX7900XTX            | `gfx1100`   | `rdna3`
 | AMD RX7900XT             | `gfx1100`   | `rdna3`
 | AMD RX7800XT             | `gfx1101`   | `rdna3`


### PR DESCRIPTION
This PR addresses the tasks outlined in the following issues: [#19720](https://github.com/iree-org/iree/issues/19720) and [#19721](https://github.com/iree-org/iree/issues/19721).
- adds mi308x to the list of known HIP targets.
- Update the default tuning strategy to be to be per-SKU first, and then per-architecture as a fallback. start with MI300X and MI308X
     - Introduced a default tuning specification for MI308X.
     - For MI300x, the tuning will default to the existing gfx942 specification, as an MI300X-specific tuning spec has not been added yet.