### PR TITLE
[Codegen] Swap to IREE's extract_strided_subview patterns

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -159,6 +159,7 @@ iree_compiler_cc_library(
         "TypePropagationPass.cpp",
         "UnrollAnnotatedLoops.cpp",
         "UserConfig.cpp",
+        "VectorTransferLowering.cpp",
         "VectorizeMemrefCopy.cpp",
         "VerifyWorkgroupDistribution.cpp",
     ],

--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -248,6 +248,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:Transforms",
         "@llvm-project//mlir:ValueBoundsOpInterface",
         "@llvm-project//mlir:VectorDialect",
+        "@llvm-project//mlir:VectorToSCF",
         "@llvm-project//mlir:VectorTransforms",
         "@llvm-project//mlir:ViewLikeInterface",
     ],

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -205,6 +205,7 @@ iree_cc_library(
     MLIRTransforms
     MLIRValueBoundsOpInterface
     MLIRVectorDialect
+    MLIRVectorToSCF
     MLIRVectorTransforms
     MLIRViewLikeInterface
     iree::compiler::Codegen::Common::FoldTensorExtractOpIncGen

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -151,6 +151,7 @@ iree_cc_library(
     "TypePropagationPass.cpp"
     "UnrollAnnotatedLoops.cpp"
     "UserConfig.cpp"
+    "VectorTransferLowering.cpp"
     "VectorizeMemrefCopy.cpp"
     "VerifyWorkgroupDistribution.cpp"
   DEPS

--- a/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EmulateNarrowType.cpp
@@ -135,7 +135,7 @@ struct EmulateNarrowTypePass final
     RewritePatternSet patterns(ctx);
     arith::populateArithNarrowTypeEmulationPatterns(typeConverter, patterns);
     memref::populateMemRefNarrowTypeEmulationPatterns(typeConverter, patterns);
-    populateIREEResolveExtractStridedMetadataPatterns(ctx, patterns);
+    populateIREEResolveExtractStridedMetadataPatterns(patterns);
     vector::populateVectorNarrowTypeEmulationPatterns(typeConverter, patterns);
     populateIreeNarrowTypeEmulationPatterns(typeConverter, patterns);
 

--- a/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Codegen/Common/Passes.h"
+#include "iree/compiler/Codegen/Common/Transforms.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/UKernelOps.h"
@@ -138,8 +139,6 @@ struct ResolveExtractMetadataFromHalInterfaceBindingSubspan
     if (!binding)
       return failure();
     auto memRefType = llvm::cast<MemRefType>(binding.getResult().getType());
-    if (memRefType.getRank() < 1)
-      return failure();
 
     auto loc = op.getLoc();
     OpBuilder::InsertionGuard g(rewriter);
@@ -195,21 +194,20 @@ struct ResolveExtractMetadataFromHalInterfaceBindingSubspan
         staticLinearShape, memRefType.getElementType(),
         MemRefLayoutAttrInterface(), memRefType.getMemorySpace());
     Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    auto linearInterfaceBinding =
-        rewriter.create<IREE::HAL::InterfaceBindingSubspanOp>(
-            loc, newBufferType, binding.getLayoutAttr(),
-            binding.getBindingAttr(), zero, dynamicLinearShape,
-            binding.getAlignmentAttr(), binding.getDescriptorFlagsAttr());
+    auto newBinding = rewriter.create<IREE::HAL::InterfaceBindingSubspanOp>(
+        loc, newBufferType, binding.getLayoutAttr(), binding.getBindingAttr(),
+        zero, dynamicLinearShape, binding.getAlignmentAttr(),
+        binding.getDescriptorFlagsAttr());
 
     SmallVector<Value> results;
     results.reserve(memRefType.getRank() + 2);
     auto baseBufferType = llvm::cast<MemRefType>(op.getBaseBuffer().getType());
     if (!op.getBaseBuffer().use_empty()) {
       if (newBufferType == baseBufferType) {
-        results.push_back(linearInterfaceBinding);
+        results.push_back(newBinding);
       } else {
         Value reinterpretCast = rewriter.create<memref::ReinterpretCastOp>(
-            loc, baseBufferType, linearInterfaceBinding, /*offset=*/0,
+            loc, baseBufferType, newBinding, /*offset=*/0,
             /*sizes=*/ArrayRef<int64_t>(),
             /*strides=*/ArrayRef<int64_t>());
         results.push_back(reinterpretCast);
@@ -259,17 +257,18 @@ struct IREEExpandStridedMetadataPass final
 } // namespace
 
 void populateIREEResolveExtractStridedMetadataPatterns(
-    MLIRContext *context, RewritePatternSet &patterns) {
+    RewritePatternSet &patterns) {
   memref::populateResolveExtractStridedMetadataPatterns(patterns);
   patterns.insert<ResolveExtractMetadataFromHalInterfaceBindingSubspan>(
-      context);
-  patterns.insert<ConvertCodegenIREEExtractMetadataToMemRef>(context);
+      patterns.getContext());
+  patterns.insert<ConvertCodegenIREEExtractMetadataToMemRef>(
+      patterns.getContext());
 }
 
 void IREEExpandStridedMetadataPass::runOnOperation() {
   MLIRContext *context = &getContext();
   RewritePatternSet patterns(context);
-  populateIREEResolveExtractStridedMetadataPatterns(context, patterns);
+  populateIREEResolveExtractStridedMetadataPatterns(patterns);
   populateRemoveDeadMemAllocPatterns(patterns);
   if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
     return signalPassFailure();

--- a/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
@@ -150,6 +150,8 @@ struct ResolveExtractMetadataFromHalInterfaceBindingSubspan
           op, "failed to resolve descriptor with source being binding op");
     }
 
+    bool bindsBasePointer =
+        memRefType.getRank() == 0 && memRefType.getLayout().isIdentity();
     // For the base buffer of the `hal.interface.binding.subspan` create a 1D
     // buffer with zero offset. For example, if the
     // `hal.interface.binding.subspan` is
@@ -190,17 +192,23 @@ struct ResolveExtractMetadataFromHalInterfaceBindingSubspan
     dispatchIndexOpFoldResult(linearizedMemrefSize, dynamicLinearShape,
                               staticLinearShape);
 
-    auto newBufferType = MemRefType::get(
-        staticLinearShape, memRefType.getElementType(),
-        MemRefLayoutAttrInterface(), memRefType.getMemorySpace());
-    Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    auto newBinding = rewriter.create<IREE::HAL::InterfaceBindingSubspanOp>(
-        loc, newBufferType, binding.getLayoutAttr(), binding.getBindingAttr(),
-        zero, dynamicLinearShape, binding.getAlignmentAttr(),
-        binding.getDescriptorFlagsAttr());
-
+    MemRefType newBufferType;
+    IREE::HAL::InterfaceBindingSubspanOp newBinding;
+    if (bindsBasePointer) {
+      newBufferType = memRefType;
+      newBinding = binding;
+    } else {
+      newBufferType = MemRefType::get(
+          staticLinearShape, memRefType.getElementType(),
+          MemRefLayoutAttrInterface(), memRefType.getMemorySpace());
+      Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+      newBinding = rewriter.create<IREE::HAL::InterfaceBindingSubspanOp>(
+          loc, newBufferType, binding.getLayoutAttr(), binding.getBindingAttr(),
+          zero, dynamicLinearShape, binding.getAlignmentAttr(),
+          binding.getDescriptorFlagsAttr());
+    }
     SmallVector<Value> results;
-    results.reserve(memRefType.getRank() + 2);
+    results.reserve(memRefType.getRank() * 2 + 2);
     auto baseBufferType = llvm::cast<MemRefType>(op.getBaseBuffer().getType());
     if (!op.getBaseBuffer().use_empty()) {
       if (newBufferType == baseBufferType) {

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -698,6 +698,16 @@ def VectorizeMemrefCopyPass :
   let summary = "Vectorizes memref copy operations.";
 }
 
+def VectorTransferLoweringPass :
+    InterfacePass<"iree-codegen-vector-transfer-lowering", "mlir::FunctionOpInterface"> {
+  let summary = "Pass to lower transfer ops to simpler ops like `vector.load`, `vector.store`, `vector.broadcast`, and a set of scf ops.";
+  let options = [
+    Option<"enableScalableLowerings", "enable-scalable-lowerings", "bool",
+      /*default=*/"false",
+      "Enables scalable vector specific transfer lowerings">,
+  ];
+}
+
 def VerifyWorkgroupDistributionPass :
     InterfacePass<"iree-codegen-verify-workgroup-distribution", "mlir::FunctionOpInterface"> {
   let summary = "Pass to verify proper distribution to workgroups.";

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.h
@@ -84,7 +84,7 @@ void populateTileAndDistributeToWorkgroupsCleanupPatterns(
 /// Populate IREE patterns related to resolving
 /// `memref.extract_strided_metadata`.
 void populateIREEResolveExtractStridedMetadataPatterns(
-    MLIRContext *context, RewritePatternSet &patterns);
+    RewritePatternSet &patterns);
 
 /// Populate patterns that replaces maximumf/minimumf with minumf/maxnumf ops.
 /// This is supposed to be used for targets which have faulty codegen

--- a/compiler/src/iree/compiler/Codegen/Common/VectorTransferLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorTransferLowering.cpp
@@ -4,29 +4,29 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "iree/compiler/Codegen/LLVMCPU/Passes.h"
+#include "iree/compiler/Codegen/Common/Passes.h"
 #include "mlir/Conversion/VectorToSCF/VectorToSCF.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Vector/Transforms/LoweringPatterns.h"
+#include "mlir/Dialect/Vector/Transforms/VectorRewritePatterns.h"
 #include "mlir/Dialect/Vector/Transforms/VectorTransforms.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
-#define DEBUG_TYPE "iree-llvmcpu-vector-transfer-lowering"
+#define DEBUG_TYPE "iree-codegen-vector-transfer-lowering"
 
 namespace mlir::iree_compiler {
 
-#define GEN_PASS_DEF_LLVMCPUVECTORTRANSFERLOWERINGPASS
-#include "iree/compiler/Codegen/LLVMCPU/Passes.h.inc"
+#define GEN_PASS_DEF_VECTORTRANSFERLOWERINGPASS
+#include "iree/compiler/Codegen/Common/Passes.h.inc"
 
 namespace {
-class LLVMCPUVectorTransferLoweringPass
-    : public impl::LLVMCPUVectorTransferLoweringPassBase<
-          LLVMCPUVectorTransferLoweringPass> {
+class VectorTransferLoweringPass
+    : public impl::VectorTransferLoweringPassBase<VectorTransferLoweringPass> {
 public:
-  using impl::LLVMCPUVectorTransferLoweringPassBase<
-      LLVMCPUVectorTransferLoweringPass>::LLVMCPUVectorTransferLoweringPassBase;
+  using impl::VectorTransferLoweringPassBase<
+      VectorTransferLoweringPass>::VectorTransferLoweringPassBase;
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<affine::AffineDialect, scf::SCFDialect,
@@ -35,11 +35,15 @@ public:
   void runOnOperation() override;
 };
 
-void LLVMCPUVectorTransferLoweringPass::runOnOperation() {
+void VectorTransferLoweringPass::runOnOperation() {
   MLIRContext *ctx = &getContext();
   auto funcOp = getOperation();
 
   RewritePatternSet patterns(ctx);
+  // Explicitly materialize the mask on transfer_read/transfer_write.
+  // Assume we don't have 4 GB vectors.
+  vector::populateVectorMaskMaterializationPatterns(
+      patterns, /*force32BitVectorIndices=*/true);
   vector::populateVectorTransferLoweringPatterns(patterns,
                                                  /*maxTransferRank=*/1);
   auto vectorTransferToSCFOptions =

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD.bazel
@@ -68,7 +68,6 @@ iree_compiler_cc_library(
         "LLVMCPUTileRootAndFuseProducerConsumer.cpp",
         "LLVMCPUUnfuseFMAOps.cpp",
         "LLVMCPUVectorShapeCastLowering.cpp",
-        "LLVMCPUVectorTransferLowering.cpp",
         "LLVMCPUVectorTransposeLowering.cpp",
         "LLVMCPUVerifyVectorSizeLegality.cpp",
         "LLVMCPUVirtualVectorLowering.cpp",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
@@ -69,7 +69,6 @@ iree_cc_library(
     "LLVMCPUTileRootAndFuseProducerConsumer.cpp"
     "LLVMCPUUnfuseFMAOps.cpp"
     "LLVMCPUVectorShapeCastLowering.cpp"
-    "LLVMCPUVectorTransferLowering.cpp"
     "LLVMCPUVectorTransposeLowering.cpp"
     "LLVMCPUVerifyVectorSizeLegality.cpp"
     "LLVMCPUVirtualVectorLowering.cpp"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -1040,6 +1040,8 @@ void ConvertToLLVMPass::runOnOperation() {
 
   populateComplexToLLVMConversionPatterns(typeConverter, patterns);
   populateMathToLLVMConversionPatterns(typeConverter, patterns);
+  // Note: workaround needed due to `memref.subview` returnd from an `if`.
+  memref::populateExpandStridedMetadataPatterns(patterns);
   iree_compiler::populateIREEResolveExtractStridedMetadataPatterns(patterns);
   populateFinalizeMemRefToLLVMConversionPatterns(typeConverter, patterns);
   populateFuncToLLVMConversionPatterns(typeConverter, patterns);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Codegen/Common/PassUtils.h"
+#include "iree/compiler/Codegen/Common/Transforms.h"
 #include "iree/compiler/Codegen/LLVMCPU/DispatchABI.h"
 #include "iree/compiler/Codegen/LLVMCPU/Passes.h"
 #include "iree/compiler/Codegen/LLVMCPU/Utils.h"
@@ -1039,7 +1040,7 @@ void ConvertToLLVMPass::runOnOperation() {
 
   populateComplexToLLVMConversionPatterns(typeConverter, patterns);
   populateMathToLLVMConversionPatterns(typeConverter, patterns);
-  memref::populateExpandStridedMetadataPatterns(patterns);
+  iree_compiler::populateIREEResolveExtractStridedMetadataPatterns(patterns);
   populateFinalizeMemRefToLLVMConversionPatterns(typeConverter, patterns);
   populateFuncToLLVMConversionPatterns(typeConverter, patterns);
   arith::populateArithToLLVMConversionPatterns(typeConverter, patterns);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -320,7 +320,7 @@ void buildLLVMCPUVectorLoweringPipeline(
   // lower them and can't be optimized away anymore.
   funcPassManager.addPass(createCanonicalizerPass());
 
-  LLVMCPUVectorTransferLoweringPassOptions transferLoweringOptions{};
+  VectorTransferLoweringPassOptions transferLoweringOptions{};
   if (!options.enableArmSME) {
     // The ArmSME dialect has its own (more specific) lowerings for scalable
     // vectors that occur later in the pipeline, so only enable the general
@@ -328,7 +328,7 @@ void buildLLVMCPUVectorLoweringPipeline(
     transferLoweringOptions.enableScalableLowerings = true;
   }
   funcPassManager.addPass(
-      createLLVMCPUVectorTransferLoweringPass(transferLoweringOptions));
+      createVectorTransferLoweringPass(transferLoweringOptions));
   funcPassManager.addPass(createLLVMCPUVectorTransposeLoweringPass(
       LLVMCPUVectorTransposeLoweringPassOptions{
           options.lowerVectorTransposeToAVX2}));
@@ -734,9 +734,24 @@ static void addLowerToLLVMPasses(OpPassManager &modulePassManager,
         .addPass(mlir::createConvertArmSMEToSCFPass);
   }
 
+  VectorTransferLoweringPassOptions transferLoweringOptions;
+  if (!enableAArch64SME) {
+    // The ArmSME dialect has its own (more specific) lowerings for scalable
+    // vectors that occur later in the pipeline, so only enable the general
+    // lowerings if SME is not available.
+    transferLoweringOptions.enableScalableLowerings = true;
+  }
+
   FunctionLikeNest(modulePassManager)
-      // Resolve get_buffer_descriptor ops. All structural buffer manipulations
-      // must conclude before this point.
+      // All structural buffer manipulations must conclude before this point.
+
+      // The subview folding doesn't like potentially-out-of-bounds
+      // vector.transfer_read and vector.transfer_write, lower them to loads and
+      // stores here.
+      .addPass([&]() {
+        return createVectorTransferLoweringPass(transferLoweringOptions);
+      })
+      .addPass(memref::createFoldMemRefAliasOpsPass)
       .addPass(createIREEExpandStridedMetadataPass)
       .addPass(createCleanupBufferAllocViewPass)
       // Checking stack allocation before converting to CF dialect is easier.

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
@@ -212,16 +212,6 @@ def LLVMCPUVirtualVectorLoweringPass :
   ];
 }
 
-def LLVMCPUVectorTransferLoweringPass :
-    InterfacePass<"iree-llvmcpu-vector-transfer-lowering", "mlir::FunctionOpInterface"> {
-  let summary = "Pass to lower transfer ops to simpler ops like `vector.load`, `vector.store`, `vector.broadcast`, and a set of scf ops.";
-  let options = [
-    Option<"enableScalableLowerings", "enable-scalable-lowerings", "bool",
-      /*default=*/"false",
-      "Enables scalable vector specific transfer lowerings">,
-  ];
-}
-
 def LLVMCPUVectorTransposeLoweringPass :
     InterfacePass<"iree-llvmcpu-vector-transpose-lowering", "mlir::FunctionOpInterface"> {
   let summary = "Pass to lower vector.transpose ops.";

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
@@ -145,7 +145,8 @@ struct ConvertToNVVMPass final
       populateLLVMConversionPatterns(&getContext(), llvmPatterns, converter);
       populateComplexToLLVMConversionPatterns(converter, llvmPatterns);
       populateMathToLLVMConversionPatterns(converter, llvmPatterns);
-      memref::populateExpandStridedMetadataPatterns(llvmPatterns);
+      iree_compiler::populateIREEResolveExtractStridedMetadataPatterns(
+          llvmPatterns);
       populateFinalizeMemRefToLLVMConversionPatterns(converter, llvmPatterns);
       populateFuncToLLVMConversionPatterns(converter, llvmPatterns);
       cf::populateControlFlowToLLVMConversionPatterns(converter, llvmPatterns);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -216,7 +216,8 @@ struct ConvertToROCDLPass final
       populateLLVMConversionPatterns(&getContext(), llvmPatterns, converter);
       populateComplexToLLVMConversionPatterns(converter, llvmPatterns);
       populateMathToLLVMConversionPatterns(converter, llvmPatterns);
-      memref::populateExpandStridedMetadataPatterns(llvmPatterns);
+      iree_compiler::populateIREEResolveExtractStridedMetadataPatterns(
+          llvmPatterns);
       populateFinalizeMemRefToLLVMConversionPatterns(converter, llvmPatterns);
       populateFuncToLLVMConversionPatterns(converter, llvmPatterns);
       cf::populateControlFlowToLLVMConversionPatterns(converter, llvmPatterns);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1026,8 +1026,12 @@ static void
 addLowerAndOptimizeAddressComputationPasses(FunctionLikeNest &funcPassManager) {
   funcPassManager.addPass(createExtractAddressComputationGPUPass)
       .addPass(memref::createExpandOpsPass)
+      // Lower any remaining vector.transfer_read and vector.transfer_write ops,
+      // since some of the following patterns have trouble dealing with their
+      // full complexity.
+      .addPass(createVectorTransferLoweringPass)
       .addPass(memref::createFoldMemRefAliasOpsPass)
-      .addPass(memref::createExpandStridedMetadataPass)
+      .addPass(createIREEExpandStridedMetadataPass)
       .addPass(createPropagateDispatchSizeBoundsPass)
       // Hoist loop invariant variables to give affine decomposition pass the
       // right loop dependencies.
@@ -1109,7 +1113,7 @@ static void addLowerToLLVMGPUPasses(OpPassManager &modulePassManager,
       .addPass(createPolynomialApproximationPass)
       .addPass(memref::createExpandOpsPass)
       .addPass(memref::createFoldMemRefAliasOpsPass)
-      .addPass(memref::createExpandStridedMetadataPass)
+      .addPass(createIREEExpandStridedMetadataPass)
       .addPass(createEmulateNarrowTypePass)
       .addPass(affine::createAffineExpandIndexOpsPass)
       .addPass(createLowerAffinePass);

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
@@ -92,6 +92,7 @@ buildVectorVMVXTransformPassPipeline(OpPassManager &variantPassManager) {
 
       // Resolve get_buffer_descriptor ops. All structural buffer manipulations
       // must conclude before this point.
+      .addPass(memref::createFoldMemRefAliasOpsPass)
       .addPass(createIREEExpandStridedMetadataPass)
       .addPass(createResolveBufferDescriptorsPass)
       .addPass(createCleanupBufferAllocViewPass)


### PR DESCRIPTION
Overall, the cole point of this is to swap from upstream memref::ExpandStridedMetadata to IREEExpandStridedMetadata.

Notably, the swapped version doesn't include the subview => reinterpret_cast folder. This means that our lowerings now correctly reveal subviews that aren't handled by FoldMemRefAliasOps, thus allowing us to maintain the invariant we thought we had where subviews are rewritten away before lowering to LLVM.

As a consequence, this commit moves the pass that rewrites vector.transfer_{read,write} to vector.[masked_]{load,store} and adds the patterns for non-out-of-bounds transfer ops. We now run this pass before FoldMemRefAliasOps to make sure that thas pass can run correctly.