### PR TITLE
Fix or work around gcc-14 warnings/errors.

### DIFF
--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -248,6 +248,8 @@ iree_select_compiler_opts(IREE_DEFAULT_COPTS
     "-Wno-unknown-pragmas"
     "-Wno-unused-but-set-variable"
     "-Wno-misleading-indentation"
+    # False positives? Not useful? https://stackoverflow.com/a/78760067
+    $<$<COMPILE_LANGUAGE:CXX>:-Wno-dangling-reference>
 
   MSVC_OR_CLANG_CL
     # Default warning level (severe + significant + production quality).

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUVectorDistribution.h
@@ -53,8 +53,7 @@ protected:
 
 template <typename SourceOp>
 struct OpDistributionPattern : DistributionPattern {
-  OpDistributionPattern<SourceOp>(MLIRContext *context,
-                                  PatternBenefit benefit = 1)
+  OpDistributionPattern(MLIRContext *context, PatternBenefit benefit = 1)
       : DistributionPattern(SourceOp::getOperationName(), benefit, context) {}
 
   virtual LogicalResult matchAndRewrite(SourceOp op,

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
@@ -281,8 +281,8 @@ void MemRefUsageAnalysis::analyzeMemRefValue(Value value) {
 template <typename OpTy>
 class MemRefConversionPattern : public OpConversionPattern<OpTy> {
 public:
-  MemRefConversionPattern<OpTy>(MLIRContext *context,
-                                const MemRefUsageAnalysis &memrefUsageAnalysis)
+  MemRefConversionPattern(MLIRContext *context,
+                          const MemRefUsageAnalysis &memrefUsageAnalysis)
       : OpConversionPattern<OpTy>::OpConversionPattern(context),
         memrefUsageAnalysis(memrefUsageAnalysis) {}
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConv2DToWinograd.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConv2DToWinograd.cpp
@@ -156,8 +156,8 @@ template <typename ConvOp>
 class ConvertConvToWinograd final : public OpRewritePattern<ConvOp> {
 public:
   using OpRewritePattern<ConvOp>::OpRewritePattern;
-  ConvertConvToWinograd<ConvOp>(MLIRContext *context, bool replaceAllConvs,
-                                PatternBenefit benefit = 1)
+  ConvertConvToWinograd(MLIRContext *context, bool replaceAllConvs,
+                        PatternBenefit benefit = 1)
       : OpRewritePattern<ConvOp>(context, benefit),
         replaceAllConvs(replaceAllConvs) {}
 


### PR DESCRIPTION
Fixing or working around a few "warnings as errors" on gcc-14 (released May 2024). These are also causing the aarch64 nightly distribution builds to fail. Note that we also have some new warnings as errors coming in clang-20 (not yet released): https://clang.llvm.org/docs/ReleaseNotes.html#improvements-to-clang-s-diagnostics.

### dangling-reference

Not sure how we want to handle these. We have a bunch of code in IREE and torch-mlir that uses temporaries in loop headers, which this warning does not like. For now just disabling the warning.

```
/iree/compiler/src/iree/compiler/API/Internal/Diagnostics.cpp: In function 'std::optional<mlir::CallSiteLoc> mlir::iree_compiler::embed::{anonymous}::getCallSiteLoc(mlir::Location)':
/iree/compiler/src/iree/compiler/API/Internal/Diagnostics.cpp:30:57: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
   30 |     for (auto subLoc : cast<FusedLoc>(loc).getLocations()) {
      |                                                         ^
/iree/compiler/src/iree/compiler/API/Internal/Diagnostics.cpp:30:56: note: the temporary was destroyed at the end of the full expression 'llvm::cast<mlir::FusedLoc, mlir::Location>(loc).mlir::FusedLoc::getLocations()'
   30 |     for (auto subLoc : cast<FusedLoc>(loc).getLocations()) {
      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
```

### template-id-cdtor

These looked legit and were easy enough to fix.

```
/iree/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConv2DToWinograd.cpp:159:33: error: template-id not allowed for constructor in C++20 [-Werror=template-id-cdtor]
  159 |   ConvertConvToWinograd<ConvOp>(MLIRContext *context, bool replaceAllConvs,
      |                                 ^~~~~~~~~~~
/iree/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConv2DToWinograd.cpp:159:33: note: remove the '< >'
```