### PR TITLE
Fixes for CMake 3.31 policy changes.

### DIFF
--- a/build_tools/cmake/iree_macros.cmake
+++ b/build_tools/cmake/iree_macros.cmake
@@ -596,6 +596,7 @@ function(iree_symlink_tool)
 
   add_custom_command(
     TARGET "${_TARGET}"
+    POST_BUILD
     BYPRODUCTS
       "${CMAKE_CURRENT_BINARY_DIR}/${_RULE_TO_EXE_NAME}${CMAKE_EXECUTABLE_SUFFIX}"
     COMMAND

--- a/build_tools/cmake/iree_python.cmake
+++ b/build_tools/cmake/iree_python.cmake
@@ -47,6 +47,7 @@ function(iree_py_library)
     set(_SRC_BIN_PATH "${CMAKE_CURRENT_BINARY_DIR}/${_SRC_FILE}")
     get_filename_component(_SRC_BIN_DIR "${_SRC_BIN_PATH}" DIRECTORY)
     add_custom_command(
+      POST_BUILD
       TARGET ${_NAME}
       COMMAND
         ${CMAKE_COMMAND} -E make_directory "${_SRC_BIN_DIR}"

--- a/compiler/bindings/python/CMakeLists.txt
+++ b/compiler/bindings/python/CMakeLists.txt
@@ -376,8 +376,7 @@ endforeach()
 add_custom_command(
   OUTPUT ${_dylib_target_files}
   DEPENDS ${_dylib_src_files}
-  POST_BUILD
-    ${_dylib_copy_commands}
+  COMMAND ${_dylib_copy_commands}
 )
 
 add_custom_target(IREECompilerPythonDylibFiles

--- a/compiler/plugins/target/ROCM/CMakeLists.txt
+++ b/compiler/plugins/target/ROCM/CMakeLists.txt
@@ -152,8 +152,7 @@ endforeach()
 add_custom_command(
   OUTPUT ${_all_device_bc_files}
   DEPENDS ${_all_device_bc_deps}
-  POST_BUILD
-    ${_all_device_bc_copy_commands}
+  COMMAND ${_all_device_bc_copy_commands}
 )
 add_custom_target(iree_compiler_plugins_target_ROCM_GenDeviceLibs
   DEPENDS


### PR DESCRIPTION
The policy https://cmake.org/cmake/help/latest/policy/CMP0175.html says

> The `OUTPUT` form does not accept `PRE_BUILD`, `PRE_LINK`, or `POST_BUILD` keywords.

> The `TARGET` form requires exactly one of `PRE_BUILD`, `PRE_LINK`, or `POST_BUILD` to be given. Previously, if none were given, `POST_BUILD` was assumed, or if multiple keywords were given, the last one was used.

## Remaining warnings

We have a warning for https://cmake.org/cmake/help/latest/policy/CMP0177.html

```
CMake Warning (dev) at compiler/plugins/target/ROCM/CMakeLists.txt:167 (install):
  Policy CMP0177 is not set: install() DESTINATION paths are normalized.  Run
  "cmake --help-policy CMP0177" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

and this:

```
CMake Warning (dev) at build_tools/cmake/iree_install_support.cmake:62 (install):
  Target cpuinfo has PUBLIC_HEADER files but no PUBLIC_HEADER DESTINATION.
Call Stack (most recent call first):
  CMakeLists.txt:925 (iree_install_targets)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

(but we want to drop our cpuinfo dep anyways)