### PR TITLE
[DT] Teach MaterializeEncoding pass to use resolved layouts, if any.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
@@ -85,8 +85,7 @@ MaterializeEncodingTypeConverter::getEncodingInfo(RankedTensorType type) const {
   // If the layout is present in the encoding, use it directly. It means that
   // the layout is already resolved and some information could be dropped during
   // the lowering. Thus, we prioritize the resolved layout.
-  auto maybeEncodingInfo = getEncodingInfoFromLayouts(type);
-  if (maybeEncodingInfo) {
+  if (auto maybeEncodingInfo = getEncodingInfoFromLayouts(type)) {
     return maybeEncodingInfo.value();
   }
   return layoutAttr.getEncodingInfo(type);

--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Codegen/Common/EncodingUtils.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.h"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingTypes.h"
 #include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
@@ -79,8 +80,36 @@ MaterializeEncodingConversionTarget::MaterializeEncodingConversionTarget(
   });
 }
 
+IREE::Codegen::MaterializeEncodingInfo
+MaterializeEncodingTypeConverter::getEncodingInfo(RankedTensorType type) const {
+  // If the layout is present in the encoding, use it directly. It means that
+  // the layout is already resolved and some information could be dropped during
+  // the lowering. Thus, we prioritize the resolved layout.
+  auto maybeEncodingInfo = getEncodingInfoFromLayouts(type);
+  if (maybeEncodingInfo) {
+    return maybeEncodingInfo.value();
+  }
+  return layoutAttr.getEncodingInfo(type);
+}
+
 RankedTensorType dropEncoding(RankedTensorType type) {
   return RankedTensorType::get(type.getShape(), type.getElementType());
+}
+
+std::optional<IREE::Codegen::MaterializeEncodingInfo>
+getEncodingInfoFromLayouts(RankedTensorType type) {
+  auto encodingAttr = IREE::Encoding::getEncodingAttr(type);
+  if (!encodingAttr) {
+    return std::nullopt;
+  }
+  auto layoutsAttr = encodingAttr.getLayouts();
+  if (!layoutsAttr) {
+    return std::nullopt;
+  }
+  ArrayRef<Attribute> layouts = layoutsAttr.getValue();
+  assert(layouts.size() == 1 && "only single layout is supported");
+  return cast<IREE::Codegen::LayoutAttrInterface>(layouts[0])
+      .getEncodingInfo(type);
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.h
@@ -43,9 +43,7 @@ public:
   }
 
   IREE::Codegen::MaterializeEncodingInfo
-  getEncodingInfo(RankedTensorType type) const {
-    return layoutAttr.getEncodingInfo(type);
-  }
+  getEncodingInfo(RankedTensorType type) const;
 
 private:
   const IREE::Codegen::LayoutAttrInterface layoutAttr;
@@ -78,6 +76,12 @@ protected:
 
 /// Returns the RankedTensorType without encodings.
 RankedTensorType dropEncoding(RankedTensorType type);
+
+/// Returns the deserialized MaterializeEncodingInfo if the `layouts` field is
+/// present in encodings and it only has a single layout. Otherwise, returns
+/// std::nullopt.
+std::optional<IREE::Codegen::MaterializeEncodingInfo>
+getEncodingInfoFromLayouts(RankedTensorType type);
 
 /// Utility method to convert from `set_encoding` op to `pack` operation.
 /// NOTE: `source` could be returned when packing is not needed.

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
@@ -361,8 +361,13 @@ static FailureOr<SmallVector<OpFoldResult>> getPackedDimsForDispatchTensor(
     return failure();
   }
 
-  MaterializeEncodingInfo encodingInfo =
-      typeConverter.getEncodingInfo(boundTensorType);
+  MaterializeEncodingInfo encodingInfo;
+  if (auto maybeEncodingInfo = getEncodingInfoFromLayouts(boundTensorType)) {
+    encodingInfo = maybeEncodingInfo.value();
+  } else {
+    encodingInfo = typeConverter.getEncodingInfo(boundTensorType);
+  }
+
   if (IREE::Codegen::isIdentityLayout(encodingInfo)) {
     return failure();
   }


### PR DESCRIPTION
The layouts can be resolved in the encoding specialization pass, i.e., it could add the serialized encoding information to the EncodingAttr. The attached layout is an attribute that implements EncodingLayoutAttrInterface, which bridges the gap between host and device. When the layout shows up, it means that the layout is already resolved and only the layout attribute knows the details. Furthermore, some information could be dropped during the specialization. Thus, we have to use the attribute to parse the layout and use it directly during the materialization. This usually happens in bindings and flow.tensor.load/store lowering.