### PR TITLE
[runtime][hip] Cast IREE_[HOST|DEVICE]_MAX_SIZE to iree_host_size_t type

### DIFF
--- a/runtime/src/iree/base/config.h
+++ b/runtime/src/iree/base/config.h
@@ -80,7 +80,7 @@ typedef IREE_HOST_SIZE_T iree_host_size_t;
 
 // Maximum representable value in iree_host_size_t.
 #define IREE_HOST_SIZE_MAX \
-  (sizeof(iree_host_size_t) == 4 ? UINT32_MAX : UINT64_MAX)
+  ((iree_host_size_t)(sizeof(iree_host_size_t) == 4 ? UINT32_MAX : UINT64_MAX))
 
 #if !defined(IREE_DEVICE_SIZE_T)
 #define IREE_DEVICE_SIZE_T size_t
@@ -91,8 +91,9 @@ typedef IREE_HOST_SIZE_T iree_host_size_t;
 typedef IREE_DEVICE_SIZE_T iree_device_size_t;
 
 // Maximum representable value in iree_device_size_t.
-#define IREE_DEVICE_SIZE_MAX \
-  (sizeof(iree_device_size_t) == 4 ? UINT32_MAX : UINT64_MAX)
+#define IREE_DEVICE_SIZE_MAX                                         \
+  ((iree_device_size_t)(sizeof(iree_device_size_t) == 4 ? UINT32_MAX \
+                                                        : UINT64_MAX))
 
 //===----------------------------------------------------------------------===//
 // iree_status_t configuration


### PR DESCRIPTION
The revision fixes the `-Wformat` errors on platforms that treat `size_t` as `unsigned long long`. See below error log:

```
error: format specifies type 'size_t' (aka 'unsigned long') but the argument has type 'unsigned long long' [-Werror,-Wformat]
                            IREE_HOST_SIZE_MAX);
```

The error is introduced by https://github.com/iree-org/iree/pull/19667
