### PR TITLE
Skipping generic from root op when it computes slice indices

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -2544,14 +2544,10 @@ LogicalResult initGPULaunchConfig(FunctionOpInterface funcOp) {
               dyn_cast<linalg::GenericOp>(indices.getDefiningOp())) {
         genericToSkip.insert(genericOp);
       }
-      // If scatter's backward slices are generic ops, mark them as to skip too.
+      // Mark scatter's backward slices as to skip too.
       SetVector<Operation *> slices;
       getBackwardSlice(indices, &slices);
-      for (auto slice : slices) {
-        if (isa<linalg::GenericOp>(slice)) {
-          genericToSkip.insert(slice);
-        }
-      }
+      genericToSkip.insert(slices.begin(), slices.end());
     }
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -2535,8 +2535,8 @@ LogicalResult initGPULaunchConfig(FunctionOpInterface funcOp) {
     }
 
     if (auto scatterOp = dyn_cast<IREE::LinalgExt::ScatterOp>(op)) {
-      auto indices = scatterOp.getIndices();
-      if (indices.getDefiningOp() == nullptr) {
+      Value indices = scatterOp.getIndices();
+      if (!indices.getDefiningOp()) {
         continue;
       }
       // If scatter's indices is a generic op, mark it as to skip.
@@ -2554,7 +2554,7 @@ LogicalResult initGPULaunchConfig(FunctionOpInterface funcOp) {
   // Generic ops take priority over scatter and fill ops as the root op.
   if (!rootOperation) {
     for (Operation *op : llvm::reverse(computeOps)) {
-      if (isa<linalg::GenericOp>(op) && genericToSkip.count(op) == 0) {
+      if (isa<linalg::GenericOp>(op) && !genericToSkip.contains(op)) {
         rootOperation = op;
         break;
       }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -2539,14 +2539,12 @@ LogicalResult initGPULaunchConfig(FunctionOpInterface funcOp) {
       if (!indices.getDefiningOp()) {
         continue;
       }
-      // If scatter's indices is a generic op, mark it as to skip.
-      if (auto genericOp =
-              dyn_cast<linalg::GenericOp>(indices.getDefiningOp())) {
-        genericToSkip.insert(genericOp);
-      }
-      // Mark scatter's backward slices as to skip too.
+
+      // Mark scatter's backward slices(inclusive) as to skip.
+      BackwardSliceOptions options;
+      options.inclusive = true;
       SetVector<Operation *> slices;
-      getBackwardSlice(indices, &slices);
+      getBackwardSlice(indices, &slices, options);
       genericToSkip.insert(slices.begin(), slices.end());
     }
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
@@ -423,3 +423,35 @@ func.func @elementwise_scatter(%arg0: tensor<3x2048x2048xf32>,
 
 // Verify that the scatter does not get a lowering config
 //       CHECK:   linalg_ext.scatter dimension_map
+
+// -----
+
+func.func @scatter_as_root_op(%arg0: tensor<4x?xi64>,
+                              %arg1: tensor<4x?x32x8x128xf16>) -> tensor<?x32x8x128xf16> {
+  %i1 = arith.constant 1 : index
+  %0 = tensor.dim %arg0, %i1 : tensor<4x?xi64>
+  %1 = tensor.empty(%0) : tensor<4x?xi32>
+  %2 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%arg0 : tensor<4x?xi64>) outs(%1 : tensor<4x?xi32>) {
+  ^bb0(%in: i64, %out: i32):
+    %3 = arith.trunci %in : i64 to i32
+    linalg.yield %3 : i32
+  } -> tensor<4x?xi32>
+
+  %4 = tensor.dim %arg1, %i1 : tensor<4x?x32x8x128xf16>
+  %5 = tensor.empty(%4) : tensor<?x32x8x128xf16>
+  %6 = iree_linalg_ext.scatter dimension_map = [0] unique_indices(true) ins(%arg1, %2 : tensor<4x?x32x8x128xf16>, tensor<4x?xi32>) outs(%5 : tensor<?x32x8x128xf16>) {
+  ^bb0(%arg2: f16, %arg3: f16):
+    iree_linalg_ext.yield %arg2 : f16
+  } -> tensor<?x32x8x128xf16>
+  return %6 : tensor<?x32x8x128xf16>
+}
+
+// CHECK-LABEL: func.func @scatter_as_root_op
+
+// Verify that the linalg.generic does not get a lowering config
+// CHECK:      linalg.generic
+// CHECK-SAME: {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]}
+// CHECK-SAME: ins(%arg0 : tensor<4x?xi64>) outs({{.*}} : tensor<4x?xi32>) {
+
+// Verify that the scatter op gets a lowering config
+// CHECK:      iree_linalg_ext.scatter {{.*}}lowering_config =


### PR DESCRIPTION
This PR prevents the linalg.generic to become root op when it is used to compute slice indices. This PR fix https://github.com/iree-org/iree/issues/19746. @IanWood1 has help confirmed this will not cause performance degradation compared with another alternative: having scatter op take precedence over generics.

I'd like to thank @qedawkins for providing mentorship to this PR.

