### PR TITLE
[LLVMGPUVectorDistribute] add support for inferred dynamic shapes in LLVMGPUConfigureTensorLayouts

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrs.cpp
@@ -147,7 +147,7 @@ LogicalResult NestedLayoutAttr::isValidLayout(ShapedType shapeTy,
     int64_t expectedShape = getSubgroupTile()[i] * getBatchTile()[i] *
                             getOuterTile()[i] * getThreadTile()[i] *
                             getElementTile()[i];
-    if (expectedShape != shape[i]) {
+    if (!ShapedType::isDynamic(shape[i]) && expectedShape != shape[i]) {
       std::string shapeStr;
       llvm::raw_string_ostream shapeOs(shapeStr);
       llvm::interleaveComma(shape, shapeOs);


### PR DESCRIPTION
Currently, LLVMGPUConfigureTensorLayouts relies on tensor shape
to obtain derived thread configs.

This commit adds vector size inference if the shapes are dynamic
but could be inferred via tracing the bounds.

depends/builds upon : https://github.com/iree-org/iree/pull/19768