### PR TITLE
[VectorExt] make fold unit dims work with dynamic shape

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorExtFoldUnitExtentDims.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorExtFoldUnitExtentDims.cpp
@@ -64,10 +64,9 @@ struct DropToLayoutUnitDims final
         toLayoutOp.getSharedMemoryConversion(), toLayoutOp.getMmaKindAttr());
 
     // Expand to preserve output shape using insert_slice.
-    // Here, since the shape comes from the result of a to_layout op, it will
-    // always be static.
-    Value dest =
-        rewriter.create<tensor::EmptyOp>(loc, shape, inputTy.getElementType());
+    Value dest = rewriter.create<tensor::EmptyOp>(
+        loc, tensor::getMixedSizes(rewriter, loc, toLayoutOp.getInput()),
+        inputTy.getElementType());
 
     int64_t rank = inputTy.getRank();
     SmallVector<OpFoldResult> offsets(rank, rewriter.getIndexAttr(0));

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/test/BUILD.bazel
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "vector_ext_fold_unit_extent_dims.mlir",
             "vectorize_vector_ext_ops.mlir",
         ],
         include = ["*.mlir"],

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "vector_ext_fold_unit_extent_dims.mlir"
     "vectorize_vector_ext_ops.mlir"
   TOOLS
     FileCheck

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/test/vector_ext_fold_unit_extent_dims.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/test/vector_ext_fold_unit_extent_dims.mlir
@@ -1,0 +1,24 @@
+// RUN: iree-opt -pass-pipeline='builtin.module(func.func(iree-vector-ext-fold-unit-extent-dims,canonicalize,cse))' %s | FileCheck %s
+
+#layout = #iree_vector_ext.nested_layout<
+    subgroup_tile = [1, 1, 1, 1],
+    batch_tile = [1, 1, 64, 1],
+    outer_tile = [1, 1, 1, 1],
+    thread_tile = [1, 1, 2, 128],
+    element_tile = [1, 1, 1, 8],
+
+    subgroup_strides = [0, 0, 0, 0],
+    thread_strides = [0, 0, 128, 1]
+>
+
+func.func @dynamic_shape(%arg0: tensor<1x1x128x?xf16>) -> tensor<1x1x128x?xf16> {
+    %to_layout = iree_vector_ext.to_layout %arg0 to layout(#layout) : tensor<1x1x128x?xf16>
+    return %to_layout : tensor<1x1x128x?xf16>
+}
+
+// CHECK-LABEL: func.func @dynamic_shape
+// CHECK-DAG: %[[DIM:.+]] = tensor.dim %arg0, %c3 : tensor<1x1x128x?xf16>
+// CHECK-DAG: %[[SLICE:.+]] = tensor.extract_slice %arg0[0, 0, 0, 0] [1, 1, 128, %[[DIM]]] [1, 1, 1, 1] : tensor<1x1x128x?xf16> to tensor<128x?xf16>
+// CHECK-DAG: %[[LAYOUT:.+]] = iree_vector_ext.to_layout %[[SLICE]]
+// CHECK-DAG: %[[EMPTY:.+]] = tensor.empty(%[[DIM]]) : tensor<1x1x128x?xf16>
+// CHECK-DAG: %[[INSERT_SLICE:.+]] = tensor.insert_slice %[[LAYOUT]] into %[[EMPTY]][0, 0, 0, 0] [1, 1, 128, %dim] [1, 1, 1, 1] : tensor<128x?xf16> into tensor<1x1x128x?xf16>


### PR DESCRIPTION
This commit adds a one liner to make the empty destination be compatible with dynamic shapes (if any).