### PR TITLE
Move gcc dangling-reference check to GCC>=13.

### DIFF
--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -248,6 +248,8 @@ iree_select_compiler_opts(IREE_DEFAULT_COPTS
     "-Wno-unknown-pragmas"
     "-Wno-unused-but-set-variable"
     "-Wno-misleading-indentation"
+
+  GCC_GTE_13
     # False positives? Not useful? https://stackoverflow.com/a/78760067
     $<$<COMPILE_LANGUAGE:CXX>:-Wno-dangling-reference>
 

--- a/build_tools/cmake/iree_macros.cmake
+++ b/build_tools/cmake/iree_macros.cmake
@@ -390,7 +390,7 @@ function(iree_select_compiler_opts OPTS)
     _IREE_SELECTS
     ""
     ""
-    "ALL;CLANG;CLANG_GTE_10;CLANG_GTE_12;CLANG_CL;MSVC;GCC;CLANG_OR_GCC;MSVC_OR_CLANG_CL"
+    "ALL;CLANG;CLANG_GTE_10;CLANG_GTE_12;CLANG_CL;MSVC;GCC;GCC_GTE_13;CLANG_OR_GCC;MSVC_OR_CLANG_CL"
   )
   # OPTS is a variable containing the *name* of the variable being populated, so
   # we need to dereference it twice.
@@ -399,6 +399,9 @@ function(iree_select_compiler_opts OPTS)
   if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     list(APPEND _OPTS "${_IREE_SELECTS_GCC}")
     list(APPEND _OPTS "${_IREE_SELECTS_CLANG_OR_GCC}")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13)
+      list(APPEND _OPTS ${_IREE_SELECTS_GCC_GTE_13})
+    endif()
   elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
     if(MSVC)
       list(APPEND _OPTS ${_IREE_SELECTS_CLANG_CL})


### PR DESCRIPTION
This should fix the error reported at https://github.com/iree-org/iree/pull/19758#discussion_r1925623090 on older gcc versions: `cc1plus: error: unrecognized command line option '-Wno-dangling-reference' [-Werror]`