### PR TITLE
[LLVMGPU] Fix lowering of functions that don't use all bindings

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl.mlir
@@ -30,7 +30,8 @@ builtin.module {
 // INDEX32-LABEL: llvm.func @abs_ex_dispatch_0
 //    CHECK-SAME: (%{{[a-zA-Z0-9]*}}: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef, llvm.readonly},
 //    CHECK-SAME:  %{{[a-zA-Z0-9]*}}: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef},
-//    CHECK-SAME:  %{{[a-zA-Z0-9]*}}: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef})
+//    CHECK-SAME:  %{{[a-zA-Z0-9]*}}: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef},
+//    CHECK-SAME:  %{{[a-zA-Z0-9]*}}: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef, llvm.readnone})
 //         CHECK:    rocdl.workgroup.dim.x
 //         CHECK:    llvm.getelementptr %{{.*}} : (!llvm.ptr, i64) -> !llvm.ptr, f32
 //       INDEX32:    llvm.getelementptr %{{.*}} : (!llvm.ptr, i32) -> !llvm.ptr, f32
@@ -230,3 +231,31 @@ module {
 }
 // CHECK-LABEL: llvm.func @emulation_lowering(
 //   CHECK-NOT:   builtin.unrealized_conversion_cast
+
+// -----
+// Test that an unused binding still appears in the kernargs
+#pipeline_layout = #hal.pipeline.layout<constants = 1, bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+builtin.module {
+  func.func @missing_ptr_dispatch_copy_idx_0() {
+    %c0 = arith.constant 0 : index
+    %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
+    %1 = arith.index_castui %0 : i32 to index
+    %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) offset(%1) flags(ReadOnly) : memref<16xf32, strided<[1], offset : ?>, #gpu.address_space<global>>
+    %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : memref<16xf32, #gpu.address_space<global>>
+    %4 = memref.load %2[%c0] : memref<16xf32, strided<[1], offset : ?>, #gpu.address_space<global>>
+    memref.store %4, %3[%c0] : memref<16xf32, #gpu.address_space<global>>
+    return
+  }
+}
+//   CHECK-LABEL: llvm.func @missing_ptr_dispatch_copy_idx_0
+//    CHECK-SAME: (%[[arg0:.+]]: !llvm.ptr<1> {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef, llvm.readonly},
+//    CHECK-SAME:  %[[arg1:.+]]: !llvm.ptr {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef, llvm.readnone},
+//    CHECK-SAME:  %[[arg2:.+]]: !llvm.ptr<1> {llvm.align = 16 : i32, llvm.noalias, llvm.nonnull, llvm.noundef},
+//    CHECK-SAME:  %[[arg3:.+]]: i32 {llvm.noundef})
+//         CHECK:   llvm.zext %[[arg3]] : i32 to i64
+//         CHECK:   llvm.insertvalue %[[arg0]]
+//         CHECK:   llvm.insertvalue %[[arg2]]


### PR DESCRIPTION
Runtime changes in [some previous PR, ask Ben] mean that now, GPU kernels are passed one pointer for each binding in the pipeline layout, whether or not they are used. When the previous behavior, which was to only pass in the needed pointers one after another, was removed, the GPU code was not updated to mach.

This PR updates the conversion from func.func to llvm.func to use one pointer per binding. It also moves the setting of attributes like noundef or nonnull into the function conversion, instead of making the lowerigs for hal.interface.binding.subspan and
hal.interface.constant.load reduntantly add those attributes.