### PR TITLE
[Dispatch] Enable fusing producers with scatter

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
@@ -267,14 +267,14 @@ matchIteratorTypes(const llvm::SmallBitVector &rootOuterParallelLoop,
 
   // If the candidate is all parallel, then it should be at least as parallel as
   // the root.
-  for (int pos : llvm::seq<int>(0, rootOuterParallelLoop.size())) {
+  for (int pos : llvm::seq<int>(0, std::min(candidateOuterParallelLoop.size(),
+                                            rootOuterParallelLoop.size()))) {
     // If we reach the end of the outer loops of the root, break out of the
     // loop.
     if (!rootOuterParallelLoop.test(pos))
       break;
     // If the root loop is parallel, the candidate loop should also be parallel.
-    if (pos >= candidateOuterParallelLoop.size() ||
-        !candidateOuterParallelLoop.test(pos))
+    if (!candidateOuterParallelLoop.test(pos))
       return false;
   }
   return true;

--- a/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
@@ -633,11 +633,6 @@ isFusableWithProducer(OpOperand &operand,
     return true;
   }
 
-  // TODO: Enable scatter fusion when supported by backends.
-  if (isa<IREE::LinalgExt::ScatterOp>(consumer)) {
-    return false;
-  }
-
   if (auto attentionOp = dyn_cast<IREE::LinalgExt::AttentionOp>(consumer)) {
     // Fuse with the rope computation if it is a gather operation.
     if (IREE::LinalgExt::isGatherlikeOp(producer)) {

--- a/compiler/src/iree/compiler/DispatchCreation/test/dispatch_linalg_ext_fusion.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/dispatch_linalg_ext_fusion.mlir
@@ -37,9 +37,9 @@ util.func public @linalgext_scatter_dispatch() -> tensor<8192x16x8x128xf32> {
 }
 
 // CHECK-LABEL:     util.func public @linalgext_scatter_dispatch
-//   CHECK-DAG:       %[[INDICES:.+]] = flow.dispatch.region
-//   CHECK-DAG:       %[[UPDATE:.+]] = flow.dispatch.region
 //       CHECK:       %[[RESULT:.+]] = flow.dispatch.region
+//       CHECK:         %[[INDICES:.+]] = linalg.generic
+//       CHECK:         %[[UPDATE:.+]] = linalg.generic
 //       CHECK:         %[[SCATTER_RESULT:.+]] = iree_linalg_ext.scatter
 //  CHECK-SAME:           ins(%[[UPDATE]], %[[INDICES]] : tensor<4x1x16x8x128xf32>, tensor<4x1xi32>)
 //       CHECK:         flow.return %[[SCATTER_RESULT]]

--- a/compiler/src/iree/compiler/DispatchCreation/test/form_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/form_dispatch_regions.mlir
@@ -976,3 +976,35 @@ util.func @attention_clone_mask(%Q : tensor<?x?xf16>, %K : tensor<?x?xf16>, %V: 
 // CHECK:     flow.dispatch.region
 // CHECK:       iree_linalg_ext.attention
 // CHECK:       flow.return
+
+// -----
+
+util.func @scatter_index_producer_fusion(%arg0 : tensor<?x1xi64>,
+    %arg1 : index, %arg2 : tensor<?x1x32x8x128xf16>,
+    %arg3 : tensor<?x32x8x128xf16>) -> tensor<?x32x8x128xf16> {
+  %empty = tensor.empty(%arg1) : tensor<?x1xi32>
+  %0 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                       affine_map<(d0, d1) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel"]}
+      ins(%arg0 : tensor<?x1xi64>) outs(%empty : tensor<?x1xi32>) {
+  ^bb0(%in: i64, %out: i32):
+    %1 = arith.trunci %in : i64 to i32
+    linalg.yield %1 : i32
+  } -> tensor<?x1xi32>
+  %1 = iree_linalg_ext.scatter
+      dimension_map = [0] unique_indices(true)
+      ins(%arg2, %0 : tensor<?x1x32x8x128xf16>, tensor<?x1xi32>)
+      outs(%arg3 : tensor<?x32x8x128xf16>) {
+  ^bb0(%arg6: f16, %arg7: f16):
+    iree_linalg_ext.yield %arg6 : f16
+  } -> tensor<?x32x8x128xf16>
+  util.return %1 : tensor<?x32x8x128xf16>
+}
+// CHECK-LABEL: func public @scatter_index_producer_fusion
+//       CHECK:   %[[DISPATCH:.+]] = flow.dispatch.region
+//       CHECK:     %[[GENERIC:.+]] = linalg.generic
+//       CHECK:     %[[SCATTER:.+]] = iree_linalg_ext.scatter
+//  CHECK-SAME:         ins(%{{.+}}, %[[GENERIC]] :
+//       CHECK:     flow.return %[[SCATTER]]
+//       CHECK:   util.return %[[DISPATCH]]


### PR DESCRIPTION
These changes enable fusion of scatter with its producers.~Ignore the first commit as it is from @jerryyin's PR.~

- **Commit 1:** reland https://github.com/iree-org/iree/pull/19198 which fixes logic to allow fusing scatter with `indices`
- **Commit 2:** fully enables fusion with scatter as a producer.

Testing with 8b unsharded, these changes result in [fused rope + index computation](https://gist.github.com/IanWood1/5b0b0d73f0d76dabd7669b714f066b3c) as well as [fused index computation](https://gist.github.com/IanWood1/d62452d2a2940784ff6ada711483c981). In the second case, the `updates` operand was unable to fuse because work is needed to bubble reshapes through contractions (see first bullet in this issue https://github.com/iree-org/iree/issues/19752).