### PR TITLE
[Dispatch] Fix issue with bubbling of extract/expand shape

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -137,6 +137,7 @@ void addDispatchRegionCreationPreprocessingPasses(OpPassManager &passManager) {
       // 2. Bubble up expand_shape ops (or sink collapse_shape ops) to get
       //    elementwise operation into higher dimensions for more fusion
       //    opportunities.
+      .addPass(DispatchCreation::createBubbleUpExtractSlicesPass)
       .addPass(DispatchCreation::createBubbleUpExpandShapesPass)
       .addPass(DispatchCreation::createBubbleUpExtractSlicesPass)
       .addPass(IREE::Flow::createCanonicalizerPass)


### PR DESCRIPTION
`tensor.extract_slice` and `tensor.expand_shape` ops can block each other during `BubbleUpExtractSlicesPass` and `BubbleUpExpandShapePass`, respectively. To solve the general case, these two passes could be combined to account for large chains of extract/expand slice ops. However, I have yet to see that be a problem. So, for now, just run `BubbleUpExtractSlicesPass` to clear the way for reshapes to be bubled.

Resolves some fusion issues in llama

https://github.com/iree-org/iree/issues/19752