### PR TITLE
[Dispatch] Don't fuse when trunc is used by multiple contractions #19779

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/FuseHorizontalContractions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FuseHorizontalContractions.cpp
@@ -146,6 +146,10 @@ getTruncateOp(Operation *op,
     return std::nullopt;
   }
   if (seedTruncateOp) {
+    // TODO: support multiple contractions being used by the same truncate op.
+    if (seedTruncateOp == genericOp) {
+      return std::nullopt;
+    }
     if (!checkOperationEquivalence(genericOp, seedTruncateOp.value())) {
       return std::nullopt;
     }

--- a/compiler/src/iree/compiler/DispatchCreation/FuseHorizontalContractions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FuseHorizontalContractions.cpp
@@ -115,6 +115,7 @@ static bool isHorizontalToGroup(Operation *op,
                                 const DominanceInfo &dominanceInfo,
                                 Operation *seedOp) {
   BackwardSliceOptions options;
+  options.inclusive = true;
   // Limit the slice to the seed to make sure the slice is small.
   options.filter = [&](Operation *op) {
     return !dominanceInfo.properlyDominates(op, seedOp);
@@ -146,10 +147,6 @@ getTruncateOp(Operation *op,
     return std::nullopt;
   }
   if (seedTruncateOp) {
-    // TODO: support multiple contractions being used by the same truncate op.
-    if (seedTruncateOp == genericOp) {
-      return std::nullopt;
-    }
     if (!checkOperationEquivalence(genericOp, seedTruncateOp.value())) {
       return std::nullopt;
     }

--- a/experimental/regression_suite/shark-test-suite-models/sd3/test_clip.py
+++ b/experimental/regression_suite/shark-test-suite-models/sd3/test_clip.py
@@ -152,10 +152,6 @@ def test_run_clip_cpu(SD3_CLIP_COMMON_RUN_FLAGS, sd3_clip_real_weights):
 ###############################################################################
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Expected compilation to fail",
-)
 def test_compile_clip_rocm(sd3_clip_mlir):
     VmfbManager.sd3_clip_rocm_vmfb = iree_compile(
         sd3_clip_mlir,

--- a/experimental/regression_suite/shark-test-suite-models/sd3/test_clip.py
+++ b/experimental/regression_suite/shark-test-suite-models/sd3/test_clip.py
@@ -168,6 +168,9 @@ def test_run_clip_rocm(SD3_CLIP_COMMON_RUN_FLAGS, sd3_clip_real_weights):
         VmfbManager.sd3_clip_rocm_vmfb,
         device="hip",
         function="encode_tokens",
-        args=[f"--parameters=model={sd3_clip_real_weights.path}"]
+        args=[
+            f"--parameters=model={sd3_clip_real_weights.path}",
+            "--expected_f32_threshold=0.15f",
+        ]
         + SD3_CLIP_COMMON_RUN_FLAGS,
     )


### PR DESCRIPTION
Fixes a crash in horizontal fusion when the linalg truncate op is the consumer of multiple contractions. The crash was caused by the truncate op being replaced and then attempting to be replaced again.