### PR TITLE
Include missing dependency to @llvm-project//mlir:Support

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/BUILD.bazel
@@ -28,6 +28,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:DialectUtils",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LinalgDialect",
+        "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",
     ],
 )

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/CMakeLists.txt
@@ -22,6 +22,7 @@ iree_cc_library(
     MLIRArithDialect
     MLIRIR
     MLIRLinalgDialect
+    MLIRSupport
     MLIRTensorDialect
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
     iree::compiler::Dialect::Encoding::IR


### PR DESCRIPTION
Compiling on Linux Debian using Bazel fails due to this missing dependency

```
❯ bazel build tools/...

INFO: Analyzed 69 targets (0 packages loaded, 0 targets configured).
ERROR: $HOME/src/iree/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/BUILD.bazel:15:25: Compiling compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.cpp failed: (Exit 1): clang failed: error executing CppCompile command (from target //compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils:Utils) /usr/lib/llvm-16/bin/clang -U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -Wunused-but-set-parameter -Wno-free-nonheap-object -fcolor-diagnostics -fno-omit-frame-pointer -g0 ... (remaining 163 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
In file included from compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.cpp:7:
compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.h:16:10: error: module //compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils:Utils does not depend on a module exporting 'mlir/Support/LLVM.h'
#include "mlir/Support/LLVM.h"
         ^
1 error generated.
```


`compiler/Codegen/Dialect/Codegen/Utils` depends on `@llvm-project//llvm:Support` but not on `@llvm-project//mlir:Support`.

Discord conversation: https://discord.com/channels/689900678990135345/1331670426044207186