### PR TITLE
[Stream][NFC] Iterate over blocks to find return op

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/RefineUsage.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/RefineUsage.cpp
@@ -72,7 +72,7 @@ static IREE::Stream::AffinityAttr getOpAffinity(Operation *op) {
 }
 
 // Returns a return op in `op`.
-static Util::ReturnOp getAnyReturnOp(IREE::Util::FuncOp op) {
+static IREE::Util::ReturnOp getAnyReturnOp(IREE::Util::FuncOp op) {
   for (auto &block : op.getCallableRegion()->getBlocks()) {
     if (auto retOp = dyn_cast<IREE::Util::ReturnOp>(block.getTerminator())) {
       return retOp;


### PR DESCRIPTION
`auto anyReturnOp = *op.getOps<IREE::Util::ReturnOp>().begin();` is expensive when `op` contains lots of ops to traverse before finding a return op. Instead, look at each contained block for a return op.

On 405b sharded, this reduces compile time from 2min -> 10sec for this pass