### PR TITLE
[Stream][NFC] Move topological sort out of loop

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
@@ -282,14 +282,14 @@ LogicalResult processRegion(Location loc, MLIRContext *context, Region &region,
         toBeDeleted.replaceAllUsesWith(awaitOp.getResults().front());
         deadOps.insert(oldResult.getDefiningOp());
       }
-
-      // Sort the ops in the execution region. This is safe because we are
-      // still unaliased and SSA values imply ordering.
-      mlir::sortTopologically(block);
     }
     for (auto *deadOp : llvm::reverse(deadOps)) {
       deadOp->erase();
     }
+
+    // Sort the ops in the execution region. This is safe because we are
+    // still unaliased and SSA values imply ordering.
+    mlir::sortTopologically(block);
 
     LLVM_DEBUG({
       llvm::dbgs() << "\nPartitions constructed:\n";


### PR DESCRIPTION
There doesn't appear to be a need to re-sort for after each transformation with each partition builder (for 405b: `~5,000 iters` for several thousand ops). Also, I moved this after erasing dead ops since there is no reason to sort ops that will just be deleted.


On 405b sharded, this reduces compile time from 4.4min -> 8sec for this pass.