### PR TITLE
bump tracy to wolfpld/tracy@5479a42

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -970,16 +970,6 @@ if(IREE_ENABLE_CLANG_TIDY)
   set(CMAKE_CXX_CLANG_TIDY "")
 endif()
 
-if(IREE_BUILD_TRACY)
-  if(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin|Linux")
-    message(WARNING "Building Tracy (IREE_BUILD_TRACY) on non-Darwin/Linux is unsupported and may fail below.")
-  endif()
-  add_subdirectory(build_tools/third_party/tracy ${CMAKE_CURRENT_BINARY_DIR}/tracy)
-  if(NOT TARGET IREETracyCaptureServer)
-    message(SEND_ERROR "Could not build Tracy. Either unset IREE_BUILD_TRACY or look for missing dependencies above and install them.")
-  endif()
-endif()
-
 # Order constraint: The python bindings install tools targets from tools/
 # and tracy, and must come after it.
 if(IREE_BUILD_PYTHON_BINDINGS)

--- a/build_tools/third_party/tracy/CMakeLists.txt
+++ b/build_tools/third_party/tracy/CMakeLists.txt
@@ -1,41 +1,130 @@
-# Copyright 2025 The IREE Authors
+# Copyright 2021 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-cmake_minimum_required(VERSION 3.16)
-message(STATUS "Start building tracy capture tool")
 
-option(NO_ISA_EXTENSIONS "Disable ISA extensions (don't pass -march=native or -mcpu=native to the compiler)" OFF)
-option(NO_STATISTICS "Disable calculation of statistics" ON)
-option(NO_PARALLEL_STL "Disable parallel STL" OFF)
+cmake_minimum_required(VERSION 3.16.3)
+
+project(IREETracyServer C CXX)
 
 set(TRACY_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../third_party/tracy")
-include(${TRACY_SOURCE_DIR}/cmake/version.cmake)
 
+find_package(Threads REQUIRED)
 
-set(CMAKE_CXX_STANDARD 20)
+#-------------------------------------------------------------------------------
+# Detect package manager
+#-------------------------------------------------------------------------------
 
-project(
-    IREETracyCaptureServer
-    LANGUAGES C CXX
-    VERSION ${TRACY_VERSION_STRING}
+message(STATUS "Checking for Tracy dependencies...")
+find_program(PKGCONFIG pkg-config)
+if(NOT PKGCONFIG)
+  message(STATUS "Could not find pkg-config to get dependencies; you need to specify them manually or use pkg-config")
+  message(STATUS "  Ubuntu/Debian: `apt install pkg-config`")
+  message(STATUS "  MacOS: `brew install pkg-config`")
+else()
+  include(FindPkgConfig)
+
+  # Deps slightly differ by platform but some are common.
+  pkg_check_modules(TRACY_DEPS
+    tbb
+    libzstd
+  )
+  pkg_check_modules(TRACY_CAPSTONE_DEPS
+    capstone
+  )
+
+  if(NOT TRACY_DEPS_FOUND)
+    message(STATUS "Could not find Tracy dependencies (Tracy server will not be built).")
+    message(STATUS "To build Tracy, install packages libzstd, and tbb:")
+    message(STATUS "  Ubuntu/Debian: `apt install libcapstone-dev libtbb-dev libzstd-dev`")
+    message(STATUS "  MacOS: `brew install capstone tbb zstd`")
+    return()
+  endif()
+
+  if(NOT TRACY_CAPSTONE_DEPS_FOUND)
+    message(STATUS "Could not find capstone, a Tracy dependency (Tracy server will not be built).")
+    message(STATUS "To build Tracy, install capstone or build from source:")
+    message(STATUS "  Ubuntu/Debian: `apt install libcapstone-dev`")
+    message(STATUS "  MacOS: `brew install capstone`")
+    return()
+  endif()
+endif()
+
+#-------------------------------------------------------------------------------
+# Configuration
+#-------------------------------------------------------------------------------
+
+function(setup_cxx_options name)
+  set_target_properties(${name}
+    PROPERTIES
+      CXX_STANDARD 17
+  )
+  target_compile_options(${name}
+    PRIVATE
+      $<$<CXX_COMPILER_ID:GNU,Clang>:-Wno-unused-result>
+  )
+  target_include_directories(${name}
+    PUBLIC
+      ${TRACY_SOURCE_DIR}/imgui
+      ${TRACY_DEPS_INCLUDE_DIRS}
+      ${TRACY_CAPSTONE_DEPS_INCLUDE_DIRS}
+      # capstone-next moved capstone.h to a capstone/ subdirectory, but the
+      # pkg-config isn't updated yet as of April 2022.
+      ${TRACY_CAPSTONE_DEPS_INCLUDE_DIRS}/capstone
+  )
+  target_link_libraries(${name}
+    PRIVATE
+      ${TRACY_DEPS_LIBRARIES}
+      ${TRACY_CAPSTONE_DEPS_LIBRARIES}
+      ${CMAKE_DL_LIBS}
+      ${CMAKE_THREAD_LIBS_INIT}
+  )
+  target_link_directories(${name}
+    PRIVATE
+      ${TRACY_DEPS_LIBRARY_DIRS}
+      ${TRACY_CAPSTONE_DEPS_LIBRARY_DIRS}
+  )
+endfunction()
+
+#-------------------------------------------------------------------------------
+# Common library
+#-------------------------------------------------------------------------------
+
+file(GLOB COMMON_SRCS ${TRACY_SOURCE_DIR}/public/common/*.cpp)
+add_library(IREETracyCommon
+  ${COMMON_SRCS}
+)
+setup_cxx_options(IREETracyCommon)
+
+#-------------------------------------------------------------------------------
+# Server library
+#-------------------------------------------------------------------------------
+
+file(GLOB SERVER_SRCS ${TRACY_SOURCE_DIR}/server/*.cpp)
+add_library(IREETracyServer
+  ${SERVER_SRCS}
+)
+setup_cxx_options(IREETracyServer)
+target_link_libraries(IREETracyServer
+  PRIVATE
+    IREETracyCommon
 )
 
-include(${TRACY_SOURCE_DIR}/cmake/config.cmake)
-include(${TRACY_SOURCE_DIR}/cmake/vendor.cmake)
-include(${TRACY_SOURCE_DIR}/cmake/server.cmake)
+#-------------------------------------------------------------------------------
+# Standalone capture server
+#-------------------------------------------------------------------------------
 
-set(PROGRAM_FILES
-    ${TRACY_SOURCE_DIR}/capture/src/capture.cpp
+add_executable(IREETracyCaptureServer
+  ${TRACY_SOURCE_DIR}/capture/src/capture.cpp
 )
-
-add_executable(${PROJECT_NAME} ${PROGRAM_FILES} ${COMMON_FILES} ${SERVER_FILES})
-
-set_target_properties(${PROJECT_NAME}
+set_target_properties(IREETracyCaptureServer
   PROPERTIES
     OUTPUT_NAME "iree-tracy-capture"
 )
-
-target_link_libraries(${PROJECT_NAME} PRIVATE TracyServer TracyGetOpt)
-set_property(DIRECTORY ${CMAKE_CURRENT_LIST_DIR} PROPERTY VS_STARTUP_PROJECT ${PROJECT_NAME})
+setup_cxx_options(IREETracyCaptureServer)
+target_link_libraries(IREETracyCaptureServer
+  PRIVATE
+    IREETracyCommon
+    IREETracyServer
+)

--- a/build_tools/third_party/tracy/CMakeLists.txt
+++ b/build_tools/third_party/tracy/CMakeLists.txt
@@ -1,130 +1,41 @@
-# Copyright 2021 The IREE Authors
+# Copyright 2025 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+cmake_minimum_required(VERSION 3.16)
+message(STATUS "Start building tracy capture tool")
 
-cmake_minimum_required(VERSION 3.16.3)
-
-project(IREETracyServer C CXX)
+option(NO_ISA_EXTENSIONS "Disable ISA extensions (don't pass -march=native or -mcpu=native to the compiler)" OFF)
+option(NO_STATISTICS "Disable calculation of statistics" ON)
+option(NO_PARALLEL_STL "Disable parallel STL" OFF)
 
 set(TRACY_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../third_party/tracy")
+include(${TRACY_SOURCE_DIR}/cmake/version.cmake)
 
-find_package(Threads REQUIRED)
 
-#-------------------------------------------------------------------------------
-# Detect package manager
-#-------------------------------------------------------------------------------
+set(CMAKE_CXX_STANDARD 20)
 
-message(STATUS "Checking for Tracy dependencies...")
-find_program(PKGCONFIG pkg-config)
-if(NOT PKGCONFIG)
-  message(STATUS "Could not find pkg-config to get dependencies; you need to specify them manually or use pkg-config")
-  message(STATUS "  Ubuntu/Debian: `apt install pkg-config`")
-  message(STATUS "  MacOS: `brew install pkg-config`")
-else()
-  include(FindPkgConfig)
-
-  # Deps slightly differ by platform but some are common.
-  pkg_check_modules(TRACY_DEPS
-    tbb
-    libzstd
-  )
-  pkg_check_modules(TRACY_CAPSTONE_DEPS
-    capstone
-  )
-
-  if(NOT TRACY_DEPS_FOUND)
-    message(STATUS "Could not find Tracy dependencies (Tracy server will not be built).")
-    message(STATUS "To build Tracy, install packages libzstd, and tbb:")
-    message(STATUS "  Ubuntu/Debian: `apt install libcapstone-dev libtbb-dev libzstd-dev`")
-    message(STATUS "  MacOS: `brew install capstone tbb zstd`")
-    return()
-  endif()
-
-  if(NOT TRACY_CAPSTONE_DEPS_FOUND)
-    message(STATUS "Could not find capstone, a Tracy dependency (Tracy server will not be built).")
-    message(STATUS "To build Tracy, install capstone or build from source:")
-    message(STATUS "  Ubuntu/Debian: `apt install libcapstone-dev`")
-    message(STATUS "  MacOS: `brew install capstone`")
-    return()
-  endif()
-endif()
-
-#-------------------------------------------------------------------------------
-# Configuration
-#-------------------------------------------------------------------------------
-
-function(setup_cxx_options name)
-  set_target_properties(${name}
-    PROPERTIES
-      CXX_STANDARD 17
-  )
-  target_compile_options(${name}
-    PRIVATE
-      $<$<CXX_COMPILER_ID:GNU,Clang>:-Wno-unused-result>
-  )
-  target_include_directories(${name}
-    PUBLIC
-      ${TRACY_SOURCE_DIR}/imgui
-      ${TRACY_DEPS_INCLUDE_DIRS}
-      ${TRACY_CAPSTONE_DEPS_INCLUDE_DIRS}
-      # capstone-next moved capstone.h to a capstone/ subdirectory, but the
-      # pkg-config isn't updated yet as of April 2022.
-      ${TRACY_CAPSTONE_DEPS_INCLUDE_DIRS}/capstone
-  )
-  target_link_libraries(${name}
-    PRIVATE
-      ${TRACY_DEPS_LIBRARIES}
-      ${TRACY_CAPSTONE_DEPS_LIBRARIES}
-      ${CMAKE_DL_LIBS}
-      ${CMAKE_THREAD_LIBS_INIT}
-  )
-  target_link_directories(${name}
-    PRIVATE
-      ${TRACY_DEPS_LIBRARY_DIRS}
-      ${TRACY_CAPSTONE_DEPS_LIBRARY_DIRS}
-  )
-endfunction()
-
-#-------------------------------------------------------------------------------
-# Common library
-#-------------------------------------------------------------------------------
-
-file(GLOB COMMON_SRCS ${TRACY_SOURCE_DIR}/public/common/*.cpp)
-add_library(IREETracyCommon
-  ${COMMON_SRCS}
-)
-setup_cxx_options(IREETracyCommon)
-
-#-------------------------------------------------------------------------------
-# Server library
-#-------------------------------------------------------------------------------
-
-file(GLOB SERVER_SRCS ${TRACY_SOURCE_DIR}/server/*.cpp)
-add_library(IREETracyServer
-  ${SERVER_SRCS}
-)
-setup_cxx_options(IREETracyServer)
-target_link_libraries(IREETracyServer
-  PRIVATE
-    IREETracyCommon
+project(
+    IREETracyCaptureServer
+    LANGUAGES C CXX
+    VERSION ${TRACY_VERSION_STRING}
 )
 
-#-------------------------------------------------------------------------------
-# Standalone capture server
-#-------------------------------------------------------------------------------
+include(${TRACY_SOURCE_DIR}/cmake/config.cmake)
+include(${TRACY_SOURCE_DIR}/cmake/vendor.cmake)
+include(${TRACY_SOURCE_DIR}/cmake/server.cmake)
 
-add_executable(IREETracyCaptureServer
-  ${TRACY_SOURCE_DIR}/capture/src/capture.cpp
+set(PROGRAM_FILES
+    ${TRACY_SOURCE_DIR}/capture/src/capture.cpp
 )
-set_target_properties(IREETracyCaptureServer
+
+add_executable(${PROJECT_NAME} ${PROGRAM_FILES} ${COMMON_FILES} ${SERVER_FILES})
+
+set_target_properties(${PROJECT_NAME}
   PROPERTIES
     OUTPUT_NAME "iree-tracy-capture"
 )
-setup_cxx_options(IREETracyCaptureServer)
-target_link_libraries(IREETracyCaptureServer
-  PRIVATE
-    IREETracyCommon
-    IREETracyServer
-)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE TracyServer TracyGetOpt)
+set_property(DIRECTORY ${CMAKE_CURRENT_LIST_DIR} PROPERTY VS_STARTUP_PROJECT ${PROJECT_NAME})

--- a/runtime/bindings/python/CMakeLists.txt
+++ b/runtime/bindings/python/CMakeLists.txt
@@ -10,7 +10,6 @@ set(_TRACY_ENABLED OFF)
 if(IREE_BUILD_TRACY)
   message(STATUS "Bundling Tracy CLI tools with Python API")
   set(_TRACY_ENABLED ON)
-  list(APPEND _EXTRA_INSTALL_TOOL_TARGETS "IREETracyCaptureServer")
 endif()
 
 ################################################################################
@@ -196,14 +195,6 @@ iree_symlink_tool(
   FROM_TOOL_TARGET iree-run-module
   TO_EXE_NAME iree/_runtime_libs/iree-run-module
 )
-
-if(_TRACY_ENABLED)
-  iree_symlink_tool(
-    TARGET runtime
-    FROM_TOOL_TARGET IREETracyCaptureServer
-    TO_EXE_NAME iree/_runtime_libs/iree-tracy-capture
-  )
-endif()
 
 ################################################################################
 # Tests


### PR DESCRIPTION
1. [wolfpld/tracy@5479a42](https://github.com/iree-org/iree/pull/19801#top) replaced its dep on TBB (installed at the system level) with a dep PPQSort (a source dep on a git repo).  Its c++ standard is changed to c++20. This may lead to CI docker image change and the current [CMakeLists.txt ](https://github.com/iree-org/iree/blob/7e6c5ec26332c55d1912d3f7fd2cf2350a936768/build_tools/third_party/tracy/CMakeLists.txt) change. To void the complexity, the current PR totally skipped the custom build of capture tool in IREE.

2. Affter bump tracy to [wolfpld/tracy@5479a42](https://github.com/wolfpld/tracy/commit/5479a42ef9346b64e6d1b860ae58aa8abdb0c7f6), the trace captured must be opened by the profiler built from iree\\third_party\\tracy

Here is the instructions on how to build it on windows:

-     Copy python.exe to python3.exe (they should be in the same folder like c:\python312)

-     Go to iree\\third_party\\tracy, run below two commands

        cmake -B profiler/build -S profiler -DCMAKE_BUILD_TYPE=Release
        cmake --build profiler/build --parallel --config Release
After that your profiler version is 0.11.2

3. [Tracy-csvexport](https://github.com/wolfpld/tracy/pull/975) can export gpu-zones to csv file
-     Go to iree\\third_party\\tracy, run below two commands

        cmake -B csvexport/build -S profiler -DCMAKE_BUILD_TYPE=Release
        cmake --build csvexport/build --parallel --config Release
After that run tracy-csvexport like:
        **tracy-csvexport -g test.tracy > test.csv**