### PR TITLE
Verifying that vm.import ops have a module.func separator.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.cpp
@@ -330,7 +330,6 @@ buildFlatBufferModule(IREE::VM::TargetOptions vmOptions,
   importFuncOps.resize(ordinalCounts.getImportFuncs());
   exportFuncOps.resize(ordinalCounts.getExportFuncs());
   internalFuncOps.resize(ordinalCounts.getInternalFuncs());
-
   for (auto &op : moduleOp.getBlock().getOperations()) {
     if (auto funcOp = dyn_cast<IREE::VM::FuncOp>(op)) {
       internalFuncOps[funcOp.getOrdinal()->getLimitedValue()] = funcOp;
@@ -338,6 +337,11 @@ buildFlatBufferModule(IREE::VM::TargetOptions vmOptions,
       exportFuncOps[exportOp.getOrdinal()->getLimitedValue()] = exportOp;
     } else if (auto importOp = dyn_cast<IREE::VM::ImportOp>(op)) {
       importFuncOps[importOp.getOrdinal()->getLimitedValue()] = importOp;
+      if (!importOp.getName().contains('.')) {
+        return importOp.emitOpError("must reference a function in a module "
+                                    "(@module_name.func_name); got unscoped `@")
+               << importOp.getName() << "`";
+      }
     }
   }
 

--- a/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/test/dependencies.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/test/dependencies.mlir
@@ -1,5 +1,8 @@
-// RUN: iree-compile --split-input-file --compile-mode=vm \
-// RUN: --iree-vm-bytecode-module-output-format=flatbuffer-text %s | FileCheck %s
+// RUN: iree-compile \
+// RUN:   --split-input-file \
+// RUN:   --compile-mode=vm \
+// RUN:   --iree-vm-bytecode-module-output-format=flatbuffer-text %s | \
+// RUN: FileCheck %s
 
 // CHECK-LABEL: "main_module"
 // CHECK: "version": 100
@@ -29,4 +32,11 @@ vm.module @main_module attributes { version = 100 : i32 } {
   // CHECK: "flags": "OPTIONAL"
   vm.import private optional @optional.method1() attributes { minimum_version = 11 : i32 }
 
+}
+
+// -----
+
+vm.module @import_funcs_invalid {
+  // expected-error@+1 {{'vm.import' op must reference a function in a module}}
+  vm.import private @missing_module_name.fn()
 }


### PR DESCRIPTION
This was being verified on parsing but not on ops lowered into imports from other dialects (extern func.func ops, etc).