### PR TITLE
Clean up named attribute construction. NFC.

### DIFF
--- a/compiler/plugins/target/CUDA/CUDATarget.cpp
+++ b/compiler/plugins/target/CUDA/CUDATarget.cpp
@@ -385,12 +385,8 @@ public:
   getDefaultDeviceTarget(MLIRContext *context,
                          const TargetRegistry &targetRegistry) const override {
     Builder b(context);
-
-    SmallVector<NamedAttribute> deviceConfigAttrs;
-    auto deviceConfigAttr = b.getDictionaryAttr(deviceConfigAttrs);
-
-    SmallVector<NamedAttribute> executableConfigAttrs;
-    auto executableConfigAttr = b.getDictionaryAttr(executableConfigAttrs);
+    auto deviceConfigAttr = b.getDictionaryAttr({});
+    auto executableConfigAttr = b.getDictionaryAttr({});
 
     // If we had multiple target environments we would generate one target attr
     // per environment, with each setting its own environment attribute.
@@ -424,16 +420,13 @@ public:
   getExecutableTarget(MLIRContext *context) const {
     Builder b(context);
     SmallVector<NamedAttribute> configItems;
-    auto addConfig = [&](StringRef name, Attribute value) {
-      configItems.emplace_back(b.getStringAttr(name), value);
-    };
-
     if (failed(options.verify(b)))
       return nullptr;
 
     if (auto target = GPU::getCUDATargetDetails(
-            options.clTarget, options.clTargetFeatures, context))
-      addConfig("iree.gpu.target", target);
+            options.clTarget, options.clTargetFeatures, context)) {
+      configItems.emplace_back("iree.gpu.target", target);
+    }
 
     return b.getAttr<IREE::HAL::ExecutableTargetAttr>(
         b.getStringAttr("cuda"), b.getStringAttr("cuda-nvptx-fb"),

--- a/compiler/plugins/target/MetalSPIRV/MetalSPIRVTarget.cpp
+++ b/compiler/plugins/target/MetalSPIRV/MetalSPIRVTarget.cpp
@@ -61,9 +61,7 @@ public:
   getDefaultDeviceTarget(MLIRContext *context,
                          const TargetRegistry &targetRegistry) const override {
     Builder b(context);
-    SmallVector<NamedAttribute> configItems;
-
-    auto configAttr = b.getDictionaryAttr(configItems);
+    auto configAttr = b.getDictionaryAttr({});
 
     // If we had multiple target environments we would generate one target attr
     // per environment, with each setting its own environment attribute.
@@ -97,13 +95,9 @@ public:
   IREE::HAL::ExecutableTargetAttr
   getExecutableTarget(MLIRContext *context) const {
     Builder b(context);
-    SmallVector<NamedAttribute> configItems;
-    auto addConfig = [&](StringRef name, Attribute value) {
-      configItems.emplace_back(b.getStringAttr(name), value);
-    };
-
+    SmallVector<NamedAttribute, 1> configItems;
     if (auto target = GPU::getMetalTargetDetails(context)) {
-      addConfig("iree.gpu.target", target);
+      configItems.emplace_back("iree.gpu.target", target);
     }
 
     return b.getAttr<IREE::HAL::ExecutableTargetAttr>(

--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -228,9 +228,9 @@ public:
   IREE::HAL::ExecutableTargetAttr
   getExecutableTarget(StringRef deviceID, MLIRContext *context) const {
     Builder b(context);
-    SmallVector<NamedAttribute> configItems;
+    SmallVector<NamedAttribute, 4> configItems;
     auto addConfig = [&](StringRef name, Attribute value) {
-      configItems.emplace_back(b.getStringAttr(name), value);
+      configItems.emplace_back(name, value);
     };
 
     if (failed(options.verify(b))) {
@@ -840,12 +840,8 @@ public:
   getDefaultDeviceTarget(MLIRContext *context,
                          const TargetRegistry &targetRegistry) const override {
     Builder b(context);
-
-    SmallVector<NamedAttribute> deviceConfigAttrs;
-    auto deviceConfigAttr = b.getDictionaryAttr(deviceConfigAttrs);
-
-    SmallVector<NamedAttribute> executableConfigAttrs;
-    auto executableConfigAttr = b.getDictionaryAttr(executableConfigAttrs);
+    auto deviceConfigAttr = b.getDictionaryAttr({});
+    auto executableConfigAttr = b.getDictionaryAttr({});
 
     // If we had multiple target environments we would generate one target attr
     // per environment, with each setting its own environment attribute.
@@ -870,12 +866,8 @@ public:
   getDefaultDeviceTarget(MLIRContext *context,
                          const TargetRegistry &targetRegistry) const override {
     Builder b(context);
-
-    SmallVector<NamedAttribute> deviceConfigAttrs;
-    auto deviceConfigAttr = b.getDictionaryAttr(deviceConfigAttrs);
-
-    SmallVector<NamedAttribute> executableConfigAttrs;
-    auto executableConfigAttr = b.getDictionaryAttr(executableConfigAttrs);
+    auto deviceConfigAttr = b.getDictionaryAttr({});
+    auto executableConfigAttr = b.getDictionaryAttr({});
 
     // If we had multiple target environments we would generate one target attr
     // per environment, with each setting its own environment attribute.

--- a/compiler/plugins/target/VMVX/VMVXTarget.cpp
+++ b/compiler/plugins/target/VMVX/VMVXTarget.cpp
@@ -44,15 +44,12 @@ static IREE::HAL::ExecutableTargetAttr
 getVMVXExecutableTarget(bool enableMicrokernels, MLIRContext *context,
                         StringRef backend, StringRef format) {
   Builder b(context);
-  SmallVector<NamedAttribute> configItems;
-
-  configItems.emplace_back(
-      b.getStringAttr("ukernels"),
-      b.getStringAttr(enableMicrokernels ? "all" : "none"));
+  NamedAttribute configItem(
+      "ukernels", b.getStringAttr(enableMicrokernels ? "all" : "none"));
 
   return b.getAttr<IREE::HAL::ExecutableTargetAttr>(
       b.getStringAttr(backend), b.getStringAttr(format),
-      b.getDictionaryAttr(configItems));
+      b.getDictionaryAttr(configItem));
 }
 
 class VMVXTargetBackend final : public TargetBackend {
@@ -200,9 +197,7 @@ public:
   getDefaultDeviceTarget(MLIRContext *context,
                          const TargetRegistry &targetRegistry) const override {
     Builder b(context);
-    SmallVector<NamedAttribute> configItems;
-
-    auto configAttr = b.getDictionaryAttr(configItems);
+    auto configAttr = b.getDictionaryAttr({});
 
     // If we had multiple target environments we would generate one target attr
     // per environment, with each setting its own environment attribute.

--- a/compiler/plugins/target/VulkanSPIRV/VulkanSPIRVTarget.cpp
+++ b/compiler/plugins/target/VulkanSPIRV/VulkanSPIRVTarget.cpp
@@ -160,12 +160,8 @@ public:
   getDefaultDeviceTarget(MLIRContext *context,
                          const TargetRegistry &targetRegistry) const override {
     Builder b(context);
-
-    SmallVector<NamedAttribute> deviceConfigAttrs;
-    auto deviceConfigAttr = b.getDictionaryAttr(deviceConfigAttrs);
-
-    SmallVector<NamedAttribute> executableConfigAttrs;
-    auto executableConfigAttr = b.getDictionaryAttr(executableConfigAttrs);
+    auto deviceConfigAttr = b.getDictionaryAttr({});
+    auto executableConfigAttr = b.getDictionaryAttr({});
 
     SmallVector<IREE::HAL::ExecutableTargetAttr> executableTargetAttrs;
     targetRegistry.getTargetBackend("vulkan-spirv")
@@ -199,13 +195,9 @@ public:
   IREE::HAL::ExecutableTargetAttr
   getExecutableTarget(MLIRContext *context, bool indirectBindings) const {
     Builder b(context);
-    SmallVector<NamedAttribute> configItems;
-    auto addConfig = [&](StringRef name, Attribute value) {
-      configItems.emplace_back(b.getStringAttr(name), value);
-    };
-
+    SmallVector<NamedAttribute, 1> configItems;
     if (auto target = GPU::getVulkanTargetDetails(options_.target, context)) {
-      addConfig("iree.gpu.target", target);
+      configItems.emplace_back("iree.gpu.target", target);
     } else {
       emitError(b.getUnknownLoc(), "Unknown Vulkan target '")
           << options_.target << "'";

--- a/compiler/plugins/target/WebGPUSPIRV/WebGPUSPIRVTarget.cpp
+++ b/compiler/plugins/target/WebGPUSPIRV/WebGPUSPIRVTarget.cpp
@@ -51,9 +51,7 @@ public:
   getDefaultDeviceTarget(MLIRContext *context,
                          const TargetRegistry &targetRegistry) const override {
     Builder b(context);
-    SmallVector<NamedAttribute> configItems;
-
-    auto configAttr = b.getDictionaryAttr(configItems);
+    auto configAttr = b.getDictionaryAttr({});
 
     // If we had multiple target environments we would generate one target attr
     // per environment, with each setting its own environment attribute.
@@ -87,13 +85,9 @@ public:
   IREE::HAL::ExecutableTargetAttr
   getExecutableTarget(MLIRContext *context) const {
     Builder b(context);
-    SmallVector<NamedAttribute> configItems;
-    auto addConfig = [&](StringRef name, Attribute value) {
-      configItems.emplace_back(b.getStringAttr(name), value);
-    };
-
+    SmallVector<NamedAttribute, 1> configItems;
     if (auto target = GPU::getWebGPUTargetDetails(context)) {
-      addConfig("iree.gpu.target", target);
+      configItems.emplace_back("iree.gpu.target", target);
     }
 
     return b.getAttr<IREE::HAL::ExecutableTargetAttr>(

--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/WrapEntryPoints.cpp
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/WrapEntryPoints.cpp
@@ -462,12 +462,11 @@ static void populateReflectionAttrs(IREE::ABI::InvocationModel invocationModel,
 
   if (auto reflectionAttr =
           exportOp->getAttrOfType<DictionaryAttr>("iree.reflection")) {
-    attrs.append(reflectionAttr.getValue().begin(),
-                 reflectionAttr.getValue().end());
+    llvm::append_range(attrs, reflectionAttr.getValue());
   }
 
   if (auto abiAttr = exportOp->getAttr("iree.abi")) {
-    attrs.emplace_back(StringAttr::get(context, "iree.abi"), abiAttr);
+    attrs.emplace_back("iree.abi", abiAttr);
   }
 
   switch (invocationModel) {
@@ -475,7 +474,7 @@ static void populateReflectionAttrs(IREE::ABI::InvocationModel invocationModel,
   case IREE::ABI::InvocationModel::Sync:
     break;
   case IREE::ABI::InvocationModel::CoarseFences:
-    attrs.emplace_back(StringAttr::get(context, "iree.abi.model"),
+    attrs.emplace_back("iree.abi.model",
                        StringAttr::get(context, "coarse-fences"));
     break;
   }
@@ -484,10 +483,9 @@ static void populateReflectionAttrs(IREE::ABI::InvocationModel invocationModel,
   // Users in source frontends can override this with something more natural
   // (python/whatever).
   if (auto declAttr = exportOp->getAttr("iree.abi.declaration")) {
-    attrs.emplace_back(StringAttr::get(context, "iree.abi.declaration"),
-                       declAttr);
+    attrs.emplace_back("iree.abi.declaration", declAttr);
   } else {
-    attrs.emplace_back(StringAttr::get(context, "iree.abi.declaration"),
+    attrs.emplace_back("iree.abi.declaration",
                        formatSourceDeclaration(invocationModel, exportOp,
                                                wrapperOp.getName(),
                                                exportOp.getAllArgAttrs(),

--- a/compiler/src/iree/compiler/Bindings/TFLite/Transforms/WrapEntryPoints.cpp
+++ b/compiler/src/iree/compiler/Bindings/TFLite/Transforms/WrapEntryPoints.cpp
@@ -605,7 +605,7 @@ private:
   // IO tensor names and quantization information.
   void populateReflectionAttrs(IREE::Util::FuncOp entryFuncOp,
                                IREE::Util::FuncOp wrapperFuncOp) {
-    SmallVector<NamedAttribute> attrs;
+    SmallVector<NamedAttribute, 1> attrs;
     attrs.push_back(buildIONamesAttr(entryFuncOp));
     // TODO(#3972): tfl.io.quant: quantization information.
     // TODO(#3978): tfl.io.types: tensor types (complex/strings/etc).
@@ -636,7 +636,7 @@ private:
       }
     }
     return NamedAttribute{
-        StringAttr::get(&getContext(), "tfl.io.names"),
+        "tfl.io.names",
         StringAttr::get(&getContext(), llvm::join(pieces, ";"))};
   }
 };

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.cpp
@@ -96,10 +96,10 @@ DictionaryAttr getLayoutImpl(Attribute attr, RankedTensorType type) {
   MLIRContext *ctx = attr.getContext();
   auto deviceLayoutAttr = cast<IREE::Codegen::LayoutAttrInterface>(attr);
   const MaterializeEncodingInfo info = deviceLayoutAttr.getEncodingInfo(type);
-  auto strAttr = StringAttr::get(ctx, kEncodingInfoAttrName);
   Attribute encodingInfoAttr =
       IREE::Codegen::serializeEncodingInfo(attr.getContext(), info);
-  return DictionaryAttr::get(ctx, {NamedAttribute(strAttr, encodingInfoAttr)});
+  return DictionaryAttr::get(
+      ctx, NamedAttribute(kEncodingInfoAttrName, encodingInfoAttr));
 }
 
 } // namespace mlir::iree_compiler::IREE

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -35,6 +35,7 @@
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypeInterfaces.h"
 #include "mlir/IR/Matchers.h"
@@ -425,11 +426,9 @@ setConvolutionVectorDistributionConfig(IREE::GPU::TargetAttr target,
   }
 
   Builder b(context);
-  SmallVector<NamedAttribute, 2> attrs;
-  attrs.emplace_back(StringAttr::get(context, "workgroup"),
-                     b.getI64ArrayAttr(workgroupTileSizes));
-  attrs.emplace_back(StringAttr::get(context, "reduction"),
-                     b.getI64ArrayAttr(reductionTileSizes));
+  SmallVector<NamedAttribute, 2> attrs = {
+      NamedAttribute("workgroup", b.getI64ArrayAttr(workgroupTileSizes)),
+      NamedAttribute("reduction", b.getI64ArrayAttr(reductionTileSizes))};
   IREE::GPU::setPromotedOperandList(context, attrs, {0, 1});
   IREE::GPU::setMmaKind(context, attrs, mmaKinds[schedule->index]);
   IREE::GPU::setSubgroupMCount(context, attrs, schedule->mSubgroupCounts[0]);
@@ -448,9 +447,7 @@ setConvolutionVectorDistributionConfig(IREE::GPU::TargetAttr target,
         /*use_igemm_convolution=*/false,
         /*reorder_workgroups_strategy=*/std::nullopt);
     pipelineAttrs.emplace_back(
-        StringAttr::get(context,
-                        IREE::GPU::GPUPipelineOptionsAttr::getDictKeyName()),
-        pipelineOptions);
+        IREE::GPU::GPUPipelineOptionsAttr::getDictKeyName(), pipelineOptions);
   }
 
   auto pipelineConfig = DictionaryAttr::get(context, pipelineAttrs);
@@ -688,11 +685,9 @@ setMatmulVectorDistributionConfig(IREE::GPU::TargetAttr target,
                                        *contractionDims, reductionTileSizes));
 
   Builder b(context);
-  SmallVector<NamedAttribute, 2> attrs;
-  attrs.emplace_back(StringAttr::get(context, "workgroup"),
-                     b.getI64ArrayAttr(workgroupTileSizes));
-  attrs.emplace_back(StringAttr::get(context, "reduction"),
-                     b.getI64ArrayAttr(reductionTileSizes));
+  SmallVector<NamedAttribute, 2> attrs = {
+      NamedAttribute("workgroup", b.getI64ArrayAttr(workgroupTileSizes)),
+      NamedAttribute("reduction", b.getI64ArrayAttr(reductionTileSizes))};
   IREE::GPU::setPromotedOperandList(context, attrs, {0, 1});
   IREE::GPU::setMmaKind(context, attrs, mmaKinds[schedule->index]);
   IREE::GPU::setSubgroupMCount(context, attrs, schedule->mSubgroupCounts[0]);
@@ -904,11 +899,9 @@ static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
 
   reductionTileSizes[k2Dim] = schedule->kTileSizes[0] * schedule->kSize;
 
-  SmallVector<NamedAttribute, 2> attrs;
-  attrs.emplace_back(StringAttr::get(context, "workgroup"),
-                     b.getI64ArrayAttr(workgroupTileSizes));
-  attrs.emplace_back(StringAttr::get(context, "reduction"),
-                     b.getI64ArrayAttr(reductionTileSizes));
+  SmallVector<NamedAttribute, 2> attrs = {
+      NamedAttribute("workgroup", b.getI64ArrayAttr(workgroupTileSizes)),
+      NamedAttribute("reduction", b.getI64ArrayAttr(reductionTileSizes))};
   IREE::GPU::setPromotedOperandList(context, attrs, {0, 1, 2});
 
   SmallVector<NamedAttribute, 2> qkConfig;
@@ -937,9 +930,8 @@ static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
 
   SmallVector<NamedAttribute, 2> qkAttrs;
   SmallVector<NamedAttribute, 2> pvAttrs;
-
-  qkAttrs.emplace_back(b.getNamedAttr("attention_qk_matmul", b.getUnitAttr()));
-  pvAttrs.emplace_back(b.getNamedAttr("attention_pv_matmul", b.getUnitAttr()));
+  qkAttrs.emplace_back("attention_qk_matmul", b.getUnitAttr());
+  pvAttrs.emplace_back("attention_pv_matmul", b.getUnitAttr());
 
   auto qkConfigDict = b.getDictionaryAttr(qkConfig);
   auto pvConfigDict = b.getDictionaryAttr(pvConfig);
@@ -949,8 +941,8 @@ static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
   auto pvLoweringConfig =
       IREE::GPU::LoweringConfigAttr::get(context, pvConfigDict);
 
-  qkAttrs.emplace_back(b.getNamedAttr("lowering_config", qkLoweringConfig));
-  pvAttrs.emplace_back(b.getNamedAttr("lowering_config", pvLoweringConfig));
+  qkAttrs.emplace_back("lowering_config", qkLoweringConfig);
+  pvAttrs.emplace_back("lowering_config", pvLoweringConfig);
 
   auto qkAttrDict = b.getDictionaryAttr(qkAttrs);
   auto pvAttrDict = b.getDictionaryAttr(pvAttrs);
@@ -1132,11 +1124,9 @@ setAttentionVectorDistributionConfig(IREE::GPU::TargetAttr target,
 
   MLIRContext *context = op.getContext();
 
-  SmallVector<NamedAttribute, 2> attrs;
-  attrs.emplace_back(StringAttr::get(context, "workgroup"),
-                     b.getI64ArrayAttr(workgroupTileSizes));
-  attrs.emplace_back(StringAttr::get(context, "reduction"),
-                     b.getI64ArrayAttr(reductionTileSizes));
+  SmallVector<NamedAttribute, 2> attrs = {
+      NamedAttribute("workgroup", b.getI64ArrayAttr(workgroupTileSizes)),
+      NamedAttribute("reduction", b.getI64ArrayAttr(reductionTileSizes))};
 
   SmallVector<NamedAttribute> qkConfig;
   IREE::GPU::setBasis(context, qkConfig, IREE::GPU::TilingLevel::Subgroup,
@@ -1161,17 +1151,17 @@ setAttentionVectorDistributionConfig(IREE::GPU::TargetAttr target,
   auto pvLoweringConfig =
       IREE::GPU::LoweringConfigAttr::get(context, pvConfigDict);
 
-  qkAttrs.emplace_back(b.getNamedAttr("lowering_config", qkLoweringConfig));
-  pvAttrs.emplace_back(b.getNamedAttr("lowering_config", pvLoweringConfig));
+  qkAttrs.emplace_back("lowering_config", qkLoweringConfig);
+  pvAttrs.emplace_back("lowering_config", pvLoweringConfig);
 
   auto qkAttrDict = b.getDictionaryAttr(qkAttrs);
   auto pvAttrDict = b.getDictionaryAttr(pvAttrs);
 
   SmallVector<NamedAttribute, 2> decompositionConfig;
-  decompositionConfig.emplace_back(
-      b.getNamedAttr(IREE::LinalgExt::AttentionOp::getQKAttrStr(), qkAttrDict));
-  decompositionConfig.emplace_back(
-      b.getNamedAttr(IREE::LinalgExt::AttentionOp::getPVAttrStr(), pvAttrDict));
+  decompositionConfig.emplace_back(IREE::LinalgExt::AttentionOp::getQKAttrStr(),
+                                   qkAttrDict);
+  decompositionConfig.emplace_back(IREE::LinalgExt::AttentionOp::getPVAttrStr(),
+                                   pvAttrDict);
 
   // Set attention decomposition control config.
   op.setDecompositionConfigAttr(b.getDictionaryAttr(decompositionConfig));
@@ -1324,7 +1314,6 @@ static LogicalResult setContractConfig(IREE::GPU::TargetAttr target,
 
       auto context = op.getContext();
       Builder b(context);
-      SmallVector<NamedAttribute, 1> attrs;
 
       SmallVector<int64_t> threadTileSizes(numParallelLoops + numReductionLoops,
                                            0);
@@ -1340,12 +1329,10 @@ static LogicalResult setContractConfig(IREE::GPU::TargetAttr target,
           numParallelLoops + numReductionLoops, 0);
       reductionTileSizes[numParallelLoops + numReductionLoops - 1] = tileK;
 
-      attrs.emplace_back(b.getStringAttr("workgroup"),
-                         b.getI64ArrayAttr(workgroupTileSizes));
-      attrs.emplace_back(b.getStringAttr("thread"),
-                         b.getI64ArrayAttr(threadTileSizes));
-      attrs.emplace_back(b.getStringAttr("reduction"),
-                         b.getI64ArrayAttr(reductionTileSizes));
+      SmallVector<NamedAttribute, 3> attrs = {
+          NamedAttribute("workgroup", b.getI64ArrayAttr(workgroupTileSizes)),
+          NamedAttribute("thread", b.getI64ArrayAttr(threadTileSizes)),
+          NamedAttribute("reduction", b.getI64ArrayAttr(reductionTileSizes))};
 
       auto configDict = b.getDictionaryAttr(attrs);
       auto loweringConfig =
@@ -2146,12 +2133,10 @@ static LogicalResult setArgmaxUkernelConfig(
 
   MLIRContext *context = op->getContext();
   Builder b(context);
-  SmallVector<NamedAttribute, 2> attrs;
-  attrs.emplace_back(StringAttr::get(context, "workgroup"),
-                     b.getI64ArrayAttr(workgroupTileSizes));
-  attrs.emplace_back(StringAttr::get(context, "reduction"),
-                     b.getI64ArrayAttr(reductionTileSizes));
-  attrs.emplace_back(StringAttr::get(context, "ukernel"), ukernelConfig);
+  SmallVector<NamedAttribute, 3> attrs = {
+      NamedAttribute("workgroup", b.getI64ArrayAttr(workgroupTileSizes)),
+      NamedAttribute("reduction", b.getI64ArrayAttr(reductionTileSizes)),
+      NamedAttribute("ukernel", ukernelConfig)};
   IREE::GPU::setPromotedOperandList(context, attrs, {0, 1});
   auto configDict = DictionaryAttr::get(context, attrs);
   auto loweringConfig = IREE::GPU::LoweringConfigAttr::get(context, configDict);

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ExportBenchmarkFuncs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ExportBenchmarkFuncs.cpp
@@ -14,6 +14,7 @@
 #include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/IRMapping.h"
@@ -233,12 +234,10 @@ createEntryPointBenchmarkFunc(mlir::ModuleOp moduleOp,
       loc, funcName, moduleBuilder.getFunctionType({}, {}));
   funcOp.setPublic();
   funcOp->setAttr("iree.abi.stub", moduleBuilder.getUnitAttr());
-  SmallVector<NamedAttribute> reflectionAttrs = {
-      moduleBuilder.getNamedAttr("iree.benchmark",
-                                 moduleBuilder.getStringAttr("entry")),
-  };
+  NamedAttribute reflectionAttr("iree.benchmark",
+                                moduleBuilder.getStringAttr("entry"));
   funcOp->setAttr("iree.reflection",
-                  moduleBuilder.getDictionaryAttr(reflectionAttrs));
+                  moduleBuilder.getDictionaryAttr(reflectionAttr));
   Block *block = funcOp.addEntryBlock();
 
   // Call the existing function with dummy arguments.

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/Devices/LocalDevice.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/Devices/LocalDevice.cpp
@@ -36,12 +36,8 @@ LocalDevice::LocalDevice(const LocalDevice::Options options)
 IREE::HAL::DeviceTargetAttr LocalDevice::getDefaultDeviceTarget(
     MLIRContext *context, const TargetRegistry &targetRegistry) const {
   Builder b(context);
-
-  SmallVector<NamedAttribute> deviceConfigAttrs;
-  auto deviceConfigAttr = b.getDictionaryAttr(deviceConfigAttrs);
-
-  SmallVector<NamedAttribute> executableConfigAttrs;
-  auto executableConfigAttr = b.getDictionaryAttr(executableConfigAttrs);
+  auto deviceConfigAttr = b.getDictionaryAttr({});
+  auto executableConfigAttr = b.getDictionaryAttr({});
 
   SmallVector<IREE::HAL::ExecutableTargetAttr> executableTargetAttrs;
   for (auto backendName : options.defaultTargetBackends) {
@@ -64,12 +60,8 @@ std::optional<IREE::HAL::DeviceTargetAttr>
 LocalDevice::getHostDeviceTarget(MLIRContext *context,
                                  const TargetRegistry &targetRegistry) const {
   Builder b(context);
-
-  SmallVector<NamedAttribute> deviceConfigAttrs;
-  auto deviceConfigAttr = b.getDictionaryAttr(deviceConfigAttrs);
-
-  SmallVector<NamedAttribute> executableConfigAttrs;
-  auto executableConfigAttr = b.getDictionaryAttr(executableConfigAttrs);
+  auto deviceConfigAttr = b.getDictionaryAttr({});
+  auto executableConfigAttr = b.getDictionaryAttr({});
 
   SmallVector<IREE::HAL::ExecutableTargetAttr> executableTargetAttrs;
   for (auto backendName : options.defaultHostBackends) {

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
@@ -153,15 +153,15 @@ void FuncOp::setReflectionAttr(StringRef name, Attribute value) {
     llvm::append_range(attrs, existingAttr);
   }
   bool didFind = false;
-  for (size_t i = 0; i < attrs.size(); ++i) {
-    if (attrs[i].getName() == name) {
-      attrs[i].setValue(value);
+  for (NamedAttribute &attr : attrs) {
+    if (attr.getName() == name) {
+      attr.setValue(value);
       didFind = true;
       break;
     }
   }
   if (!didFind) {
-    attrs.push_back(NamedAttribute(StringAttr::get(getContext(), name), value));
+    attrs.emplace_back(name, value);
     DictionaryAttr::sortInPlace(attrs);
   }
   getOperation()->setAttr("iree.reflection",


### PR DESCRIPTION
With https://github.com/llvm/llvm-project/pull/123974, we no longer have to construct a StringAttr for the name and can simplify a bunch of code.

Also avoid some needless memory allocations and needless small vectors in related code.