### PR TITLE
[ROCM] Add radeon pro workstation cards to known targets

### DIFF
--- a/compiler/plugins/target/ROCM/test/target_device_features.mlir
+++ b/compiler/plugins/target/ROCM/test/target_device_features.mlir
@@ -13,6 +13,15 @@
 //
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
 // RUN:   --iree-hip-target=rx7900xtx %s | FileCheck %s --check-prefix=GFX1100
+//
+// RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
+// RUN:   --iree-hip-target=w7900 %s | FileCheck %s --check-prefix=GFX1100
+//
+// RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
+// RUN:   --iree-hip-target=v710 %s | FileCheck %s --check-prefix=GFX1101
+//
+// RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
+// RUN:   --iree-hip-target=w7700 %s | FileCheck %s --check-prefix=GFX1101
 
 // GFX942: target = #iree_gpu.target<arch = "gfx942",
 // GFX942-SAME: wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8,
@@ -34,6 +43,10 @@
 // GFX1100: target = #iree_gpu.target<arch = "gfx1100",
 // GFX1100-SAME:        mma = [<WMMA_F32_16x16x16_F16>, <WMMA_F16_16x16x16_F16>, <WMMA_I32_16x16x16_I8>, <WMMA_I32_16x16x16_I8>, <WMMA_I32_16x16x16_I8>]
 // GFX1100-SAME:        subgroup_size_choices = [32, 64]
+
+// GFX1101: target = #iree_gpu.target<arch = "gfx1101",
+// GFX1101-SAME:        mma = [<WMMA_F32_16x16x16_F16>, <WMMA_F16_16x16x16_F16>, <WMMA_I32_16x16x16_I8>, <WMMA_I32_16x16x16_I8>, <WMMA_I32_16x16x16_I8>]
+// GFX1101-SAME:        subgroup_size_choices = [32, 64]
 
 stream.executable public @reduce_dispatch {
   stream.executable.export @reduce_dispatch workgroups(%arg0: index) -> (index, index, index) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
@@ -302,6 +302,10 @@ std::optional<TargetDetails> getAMDGPUTargetDetails(StringRef target) {
   static const ChipDetails rx7900xtChip = {84, "rx7900xt"};
   static const ChipDetails rx7800xtChip = {60, "rx7800xt"};
   static const ChipDetails rx7700xtChip = {54, "rx7700xt"};
+  static const ChipDetails v710Chip = {54, "v710"};
+  static const ChipDetails w7900Chip = {96, "w7900"};
+  static const ChipDetails w7800Chip = {70, "w7800"};
+  static const ChipDetails w7700Chip = {48, "w7700"};
 
   // See https://llvm.org/docs/AMDGPUUsage.html#processors for gfxN to
   // cdnaN/rdnaN mapping.
@@ -325,6 +329,14 @@ std::optional<TargetDetails> getAMDGPUTargetDetails(StringRef target) {
       .Case("rx7800xt", TargetDetails{rdna3Wgp, &rx7800xtChip})
       // https://www.techpowerup.com/gpu-specs/radeon-rx-7700-xt.c3911
       .Case("rx7700xt", TargetDetails{rdna3Wgp, &rx7700xtChip})
+      // https://www.techpowerup.com/gpu-specs/radeon-pro-v710.c4234
+      .Case("v710", TargetDetails{rdna3Wgp, &v710Chip})
+      // https://www.techpowerup.com/gpu-specs/radeon-pro-w7900.c4147
+      .Case("w7900", TargetDetails{rdna3Wgp, &w7900Chip})
+      // https://www.techpowerup.com/gpu-specs/radeon-pro-w7800.c4148
+      .Case("w7800", TargetDetails{rdna3Wgp, &w7800Chip})
+      // https://www.techpowerup.com/gpu-specs/radeon-pro-w7700.c4184
+      .Case("w7700", TargetDetails{rdna3Wgp, &w7700Chip})
       .Cases("rdna3", "gfx1100", "gfx1101", "gfx1102", "gfx1103", "gfx1150",
              "gfx1151", TargetDetails{rdna3Wgp, nullptr})
       .Cases("rdna2", "gfx1030", "gfx1031", "gfx1032", "gfx1033", "gfx1034",
@@ -347,8 +359,8 @@ StringRef normalizeAMDGPUTarget(StringRef target) {
       .Cases("mi300a", "mi300x", "mi308x", "gfx942")
       .Cases("mi250x", "mi250", "mi210", "cdna2", "gfx90a")
       .Cases("mi100", "cdna1", "gfx908")
-      .Cases("rx7900xtx", "rx7900xt", "gfx1100")
-      .Cases("rx7800xt", "rx7700xt", "gfx1101")
+      .Cases("rx7900xtx", "rx7900xt", "w7900", "w7800", "gfx1100")
+      .Cases("rx7800xt", "rx7700xt", "v710", "w7700", "gfx1101")
       .Default("");
 }
 


### PR DESCRIPTION
This covers the most popular rdna3 card: w7900, w7800, w7700, and v710. Add these to known targets, as these pro cards are currently some of the most popular hw for local GPU dev work in IREE.

These don't match the consumer cards 1:1. For instance, I don't see a consumer card with 70 CUs like w7800.