### PR TITLE
[Codegen] Rename tuning application test flag

### DIFF
--- a/compiler/plugins/target/ROCM/builtins/tuning/test/spec_gfx942.mlir
+++ b/compiler/plugins/target/ROCM/builtins/tuning/test/spec_gfx942.mlir
@@ -1,13 +1,13 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 \
 // RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-configure-target-executable-variants{target=rocm})))" \
 // RUN:   --iree-codegen-enable-default-tuning-specs \
-// RUN:   --iree-codegen-notify-transform-strategy-application \
+// RUN:   --iree-codegen-test-notify-transform-strategy-application \
 // RUN:   --verify-diagnostics %s | FileCheck %s
 
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=mi300x@hip \
 // RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-configure-target-executable-variants{target=rocm})))" \
 // RUN:   --iree-codegen-enable-default-tuning-specs \
-// RUN:   --iree-codegen-notify-transform-strategy-application \
+// RUN:   --iree-codegen-test-notify-transform-strategy-application \
 // RUN:   --verify-diagnostics %s | FileCheck %s --check-prefix=MI300X
 
 // Check that the default configuration for mmt_2048x1280x5120_f16_f16_f32

--- a/compiler/plugins/target/ROCM/test/lowering_strategy_from_tuning_spec.mlir
+++ b/compiler/plugins/target/ROCM/test/lowering_strategy_from_tuning_spec.mlir
@@ -1,14 +1,14 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 \
 // RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-configure-target-executable-variants{target=rocm})))" \
 // RUN:   --iree-codegen-tuning-spec-path=%p/tuning_spec_mmt_tile_and_fuse.mlir \
-// RUN:   --iree-codegen-notify-transform-strategy-application \
+// RUN:   --iree-codegen-test-notify-transform-strategy-application \
 // RUN:   --verify-diagnostics %s | FileCheck %s
 
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 \
 // RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-configure-target-executable-variants{target=rocm})))" \
 // RUN:   --iree-codegen-tuning-spec-path=%p/tuning_spec_mmt_tile_and_fuse.mlir \
 // RUN:   --iree-codegen-enable-default-tuning-specs \
-// RUN:   --iree-codegen-notify-transform-strategy-application \
+// RUN:   --iree-codegen-test-notify-transform-strategy-application \
 // RUN:   --verify-diagnostics %s | FileCheck %s
 
 // Make sure we can apply the lowering strategy from the specified tuning spec.

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeUserConfigs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeUserConfigs.cpp
@@ -10,6 +10,7 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/CommandLine.h"
 #include "mlir/Dialect/Transform/Transforms/TransformInterpreterUtils.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"
@@ -33,11 +34,11 @@ llvm::cl::opt<std::string> clCodegenTransformDialectLibraryFileName(
     llvm::cl::init(""));
 
 llvm::cl::opt<bool> clCodegenNotifyTransformDialectLibraryApplication(
-    "iree-codegen-notify-transform-strategy-application",
+    "iree-codegen-test-notify-transform-strategy-application",
     llvm::cl::desc(
         "Emit a remark when a transform configuration strategy successfully "
         "applies on a function. This is intended for testing/debuging."),
-    llvm::cl::init(false));
+    llvm::cl::Hidden, llvm::cl::init(false));
 
 #define GEN_PASS_DEF_MATERIALIZEUSERCONFIGSPASS
 #include "iree/compiler/Codegen/Common/Passes.h.inc"

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_user_config_from_tuning_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_user_config_from_tuning_spec.mlir
@@ -1,11 +1,11 @@
 // RUN: iree-opt --pass-pipeline='builtin.module(builtin.module(iree-codegen-materialize-tuning-specs,iree-codegen-materialize-user-configs))' \
 // RUN:   --iree-codegen-tuning-spec-path=%p/tuning_spec.mlir \
-// RUN:   --iree-codegen-notify-transform-strategy-application \
+// RUN:   --iree-codegen-test-notify-transform-strategy-application \
 // RUN:   --no-implicit-module --verify-diagnostics %s | FileCheck %s
 
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-codegen-materialize-tuning-specs,builtin.module(iree-codegen-materialize-user-configs))' \
 // RUN:   --iree-codegen-tuning-spec-path=%p/tuning_spec.mlir \
-// RUN:   --iree-codegen-notify-transform-strategy-application \
+// RUN:   --iree-codegen-test-notify-transform-strategy-application \
 // RUN:   --no-implicit-module --verify-diagnostics %s | FileCheck %s --check-prefix=PARENT
 
 // (1) We start by running the `Materialize Tuning Specs` pass to embed the


### PR DESCRIPTION
This flag is intended for tests only. Rename it and mark as it as hidden.

Requested by @qedawkins in https://github.com/iree-org/iree/pull/19762#discussion_r1929024920.

Issue: https://github.com/iree-org/iree/issues/19720