### PR TITLE
[LLVMGPUVectorDistribute] Add support for distributing masked reads/writes

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -1608,8 +1608,12 @@ struct DistributeCreateMask final
           creatMaskOp, "missing nested layout for step op result");
     }
     SmallVector<Value> subgroupIndices, threadIndices;
-    populateWarpAndThreadIndices(rewriter, threadId, subgroupSize, resultLayout,
-                                 subgroupIndices, threadIndices);
+    if (failed(populateWarpAndThreadIndices(rewriter, threadId, subgroupSize,
+                                            resultLayout, subgroupIndices,
+                                            threadIndices))) {
+      return rewriter.notifyMatchFailure(
+          creatMaskOp, "warp or thread tiles have overlapping strides");
+    }
 
     SmallVector<Value> distributedBounds =
         createDistributedBounds(rewriter, loc, creatMaskOp.getOperands(),

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
@@ -37,6 +37,7 @@ iree_lit_test_suite(
             "gpu_lower_to_ukernels.mlir",
             "gpu_nested_layout_contract_amdgpu.mlir",
             "gpu_nested_layout_vector_distribution.mlir",
+            "gpu_nested_layout_vector_distribution_mask.mlir",
             "gpu_nested_layout_vector_distribution_multi_reduce.mlir",
             "gpu_nested_layout_vector_distribution_step.mlir",
             "gpu_pad_operands.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
@@ -32,6 +32,7 @@ iree_lit_test_suite(
     "gpu_lower_to_ukernels.mlir"
     "gpu_nested_layout_contract_amdgpu.mlir"
     "gpu_nested_layout_vector_distribution.mlir"
+    "gpu_nested_layout_vector_distribution_mask.mlir"
     "gpu_nested_layout_vector_distribution_multi_reduce.mlir"
     "gpu_nested_layout_vector_distribution_step.mlir"
     "gpu_pack_to_instrinsics.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_mask.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_mask.mlir
@@ -33,8 +33,8 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // CHECK-LABEL: func @masked_read_write
 // CHECK: %[[DIM:.+]] = memref.dim %arg0, %c0 : memref<?x128xf16>
-// CHECK: %[[VSID:.+]] = affine.apply affine_map<()[s0] -> ((s0 floordiv 64) mod 2)>()[%thread_id_x]
-// CHECK: %[[VTID:.+]] = affine.apply affine_map<()[s0] -> ((s0 floordiv 16) mod 16)>()[%thread_id_x]
+// CHECK: %[[VSID:.+]]:3 = affine.delinearize_index %thread_id_x into (2, 64) : index, index, index
+// CHECK: %[[VTID:.+]]:3 = affine.delinearize_index %thread_id_x into (16, 16) : index, index, index
 // CHECK: %[[LASTIDX:.+]] = arith.subi %[[DIM]], %c1 : index
 // CHECK: %[[PACKED_LASTIDX:.+]]:4 = affine.delinearize_index %[[LASTIDX]] into (2, 4, 16, 2) : index, index, index, index
 
@@ -45,10 +45,10 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK: %[[DISTR_LASTIDX:.+]] = affine.linearize_index [%[[PACKED_LASTIDX]]#1, %[[PACKED_LASTIDX]]#3] by (4, 2) : index
 // CHECK: %[[DISTR_BOUND:.+]] = arith.addi %[[DISTR_LASTIDX]], %c1 : index
 
-// CHECK: %[[EQ_BOUND_TID:.+]] = arith.cmpi eq, %[[VTID]], %[[PACKED_LASTIDX]]#2 : index
-// CHECK: %[[LT_BOUND_TID:.+]] = arith.cmpi slt, %[[VTID]], %[[PACKED_LASTIDX]]#2 : index
-// CHECK: %[[EQ_BOUND_SID:.+]] = arith.cmpi eq, %[[VSID]], %[[PACKED_LASTIDX]]#0 : index
-// CHECK: %[[LT_BOUND_SID:.+]] = arith.cmpi slt, %[[VSID]], %[[PACKED_LASTIDX]]#0 : index
+// CHECK: %[[EQ_BOUND_TID:.+]] = arith.cmpi eq, %[[VTID]]#1, %[[PACKED_LASTIDX]]#2 : index
+// CHECK: %[[LT_BOUND_TID:.+]] = arith.cmpi slt, %[[VTID]]#1, %[[PACKED_LASTIDX]]#2 : index
+// CHECK: %[[EQ_BOUND_SID:.+]] = arith.cmpi eq, %[[VSID]]#1, %[[PACKED_LASTIDX]]#0 : index
+// CHECK: %[[LT_BOUND_SID:.+]] = arith.cmpi slt, %[[VSID]]#1, %[[PACKED_LASTIDX]]#0 : index
 
 // CHECK: %[[SELTREE0:.+]] = arith.select %[[LT_BOUND_TID]], %[[ETILE_VALID_BOUND]], %[[ETILE_INVALID_BOUND]] : index
 // CHECK: %[[SELTREE1:.+]] = arith.select %[[EQ_BOUND_TID]], %[[DISTR_BOUND]], %[[SELTREE0]] : index

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_mask.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_mask.mlir
@@ -1,0 +1,61 @@
+// RUN: iree-opt --iree-transform-dialect-interpreter --split-input-file --canonicalize --cse --canonicalize --mlir-print-local-scope %s | FileCheck %s
+
+#nested = #iree_vector_ext.nested_layout<
+  subgroup_tile = [2, 1],
+  batch_tile = [2, 1],
+  outer_tile = [2, 1],
+  thread_tile = [16, 16],
+  element_tile = [2, 8],
+
+  subgroup_strides = [1, 0],
+  thread_strides = [16, 1]
+>
+
+func.func @masked_read_write(%arg0 : memref<?x128xf16>, %arg1 : memref<?x128xf16>) {
+  %c0 = arith.constant 0 : index
+  %c128 = arith.constant 128 : index
+  %cst_6 = arith.constant 0.000000e+00 : f16
+  %dyn = memref.dim %arg0, %c0 : memref<?x128xf16>
+  %41 = vector.create_mask %dyn, %c128 : vector<256x128xi1>
+  %42 = vector.transfer_read %arg0[%c0, %c0], %cst_6, %41 {in_bounds = [true, true]} : memref<?x128xf16>, vector<256x128xf16>
+  %43 = iree_vector_ext.to_layout %42 to layout(#nested) : vector<256x128xf16>
+  vector.transfer_write %43, %arg1[%c0, %c0], %41 {in_bounds = [true, true]} : vector<256x128xf16>, memref<?x128xf16>
+  return
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @masked_read_write
+// CHECK: %[[DIM:.+]] = memref.dim %arg0, %c0 : memref<?x128xf16>
+// CHECK: %[[VSID:.+]] = affine.apply affine_map<()[s0] -> ((s0 floordiv 64) mod 2)>()[%thread_id_x]
+// CHECK: %[[VTID:.+]] = affine.apply affine_map<()[s0] -> ((s0 floordiv 16) mod 16)>()[%thread_id_x]
+// CHECK: %[[LASTIDX:.+]] = arith.subi %[[DIM]], %c1 : index
+// CHECK: %[[PACKED_LASTIDX:.+]]:4 = affine.delinearize_index %[[LASTIDX]] into (2, 4, 16, 2) : index, index, index, index
+
+// CHECK: %[[ETILE_VALID:.+]] = affine.linearize_index [%[[PACKED_LASTIDX]]#1, %c1] by (4, 2) : index
+// CHECK: %[[ETILE_VALID_BOUND:.+]] = arith.addi %[[ETILE_VALID]], %c1 : index
+// CHECK: %[[ETILE_INVALID:.+]] = affine.linearize_index [%[[PACKED_LASTIDX]]#1, %c0] by (4, 2) : index
+// CHECK: %[[ETILE_INVALID_BOUND:.+]] = arith.addi %[[ETILE_INVALID]], %c1 : index
+// CHECK: %[[DISTR_LASTIDX:.+]] = affine.linearize_index [%[[PACKED_LASTIDX]]#1, %[[PACKED_LASTIDX]]#3] by (4, 2) : index
+// CHECK: %[[DISTR_BOUND:.+]] = arith.addi %[[DISTR_LASTIDX]], %c1 : index
+
+// CHECK: %[[EQ_BOUND_TID:.+]] = arith.cmpi eq, %[[VTID]], %[[PACKED_LASTIDX]]#2 : index
+// CHECK: %[[LT_BOUND_TID:.+]] = arith.cmpi slt, %[[VTID]], %[[PACKED_LASTIDX]]#2 : index
+// CHECK: %[[EQ_BOUND_SID:.+]] = arith.cmpi eq, %[[VSID]], %[[PACKED_LASTIDX]]#0 : index
+// CHECK: %[[LT_BOUND_SID:.+]] = arith.cmpi slt, %[[VSID]], %[[PACKED_LASTIDX]]#0 : index
+
+// CHECK: %[[SELTREE0:.+]] = arith.select %[[LT_BOUND_TID]], %[[ETILE_VALID_BOUND]], %[[ETILE_INVALID_BOUND]] : index
+// CHECK: %[[SELTREE1:.+]] = arith.select %[[EQ_BOUND_TID]], %[[DISTR_BOUND]], %[[SELTREE0]] : index
+// CHECK: %[[SELTREE2:.+]] = arith.select %[[LT_BOUND_SID]], %c7, %c0 : index
+// CHECK: %[[SELTREE3:.+]] = arith.select %[[EQ_BOUND_SID]], %[[SELTREE1]], %[[SELTREE2]] : index
+// CHECK: %[[MASK:.+]] = vector.create_mask %[[SELTREE3]], %c7 : vector<8x8xi1>
+
+// CHECK: %[[MASK_EXTR:.+]] = vector.extract_strided_slice %[[MASK]] {offsets = [0, 0], sizes = [2, 8], strides = [1, 1]} : vector<8x8xi1> to vector<2x8xi1>
+// CHECK: %[[READ:.+]] = vector.transfer_read %arg0{{.*}}, %[[MASK_EXTR]] {in_bounds = [true, true]} : memref<?x128xf16>, vector<2x8xf16>
+// CHECK: vector.transfer_write %[[READ]], %arg1{{.*}}, %[[MASK_EXTR]] {in_bounds = [true, true]} : vector<2x8xf16>, memref<?x128xf16>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_mask.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_mask.mlir
@@ -140,3 +140,44 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK: %[[DISTR_MASK:.+]] = vector.create_mask %c8, {{.*}} : vector<8x8xi1>
 // CHECK: %[[DISTR_MASK_0:.+]] = vector.extract_strided_slice %[[DISTR_MASK]] {offsets = [0, 0], sizes = [8, 2], strides = [1, 1]} : vector<8x8xi1> to vector<8x2xi1>
 // CHECK: vector.transfer_read %arg0{{.*}} %[[DISTR_MASK_0]]
+
+// -----
+
+#nested = #iree_vector_ext.nested_layout<
+  subgroup_tile = [2, 1],
+  batch_tile = [2, 1],
+  outer_tile = [2, 1],
+  thread_tile = [16, 16],
+  element_tile = [2, 8],
+
+  subgroup_strides = [1, 0],
+  thread_strides = [16, 1]
+>
+
+func.func @masked_read_write_perm_bcast(%arg0 : memref<128x?x1xf16>, %arg1 : memref<128x?x1xf16>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c128 = arith.constant 128 : index
+  %cst_6 = arith.constant 0.000000e+00 : f16
+  %dyn = memref.dim %arg0, %c1 : memref<128x?x1xf16>
+  %41 = vector.create_mask %dyn : vector<256xi1>
+  %42 = vector.transfer_read %arg0[%c0, %c0, %c0], %cst_6, %41 {in_bounds = [true, true], permutation_map = affine_map<(d0, d1, d2) -> (d1, 0)>} : memref<128x?x1xf16>, vector<256x128xf16>
+  %43 = iree_vector_ext.to_layout %42 to layout(#nested) : vector<256x128xf16>
+  %44 = vector.create_mask %dyn, %c128 : vector<256x128xi1>
+  vector.transfer_write %43, %arg1[%c0, %c0, %c0], %44 {in_bounds = [true, true], permutation_map = affine_map<(d0, d1, d2) -> (d1, d2)>} : vector<256x128xf16>, memref<128x?x1xf16>
+  return
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @masked_read_write_perm_bcast
+
+// CHECK: %[[DISTR_MASK:.+]] = vector.create_mask {{.*}} : vector<8xi1>
+// CHECK: %[[DISTR_MASK_0:.+]] = vector.extract_strided_slice %16 {offsets = [0], sizes = [2], strides = [1]} : vector<8xi1> to vector<2xi1>
+// CHECK: vector.transfer_read %arg0{{.*}} %[[DISTR_MASK_0]]

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_mask.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_mask.mlir
@@ -40,8 +40,6 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // CHECK: %[[ETILE_VALID:.+]] = affine.linearize_index [%[[PACKED_LASTIDX]]#1, %c1] by (4, 2) : index
 // CHECK: %[[ETILE_VALID_BOUND:.+]] = arith.addi %[[ETILE_VALID]], %c1 : index
-// CHECK: %[[ETILE_INVALID:.+]] = affine.linearize_index [%[[PACKED_LASTIDX]]#1, %c0] by (4, 2) : index
-// CHECK: %[[ETILE_INVALID_BOUND:.+]] = arith.addi %[[ETILE_INVALID]], %c1 : index
 // CHECK: %[[DISTR_LASTIDX:.+]] = affine.linearize_index [%[[PACKED_LASTIDX]]#1, %[[PACKED_LASTIDX]]#3] by (4, 2) : index
 // CHECK: %[[DISTR_BOUND:.+]] = arith.addi %[[DISTR_LASTIDX]], %c1 : index
 
@@ -50,12 +48,55 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK: %[[EQ_BOUND_SID:.+]] = arith.cmpi eq, %[[VSID]]#1, %[[PACKED_LASTIDX]]#0 : index
 // CHECK: %[[LT_BOUND_SID:.+]] = arith.cmpi slt, %[[VSID]]#1, %[[PACKED_LASTIDX]]#0 : index
 
-// CHECK: %[[SELTREE0:.+]] = arith.select %[[LT_BOUND_TID]], %[[ETILE_VALID_BOUND]], %[[ETILE_INVALID_BOUND]] : index
+// CHECK: %[[SELTREE0:.+]] = arith.select %[[LT_BOUND_TID]], %[[ETILE_VALID_BOUND]], %c0 : index
 // CHECK: %[[SELTREE1:.+]] = arith.select %[[EQ_BOUND_TID]], %[[DISTR_BOUND]], %[[SELTREE0]] : index
-// CHECK: %[[SELTREE2:.+]] = arith.select %[[LT_BOUND_SID]], %c7, %c0 : index
+// CHECK: %[[SELTREE2:.+]] = arith.select %[[LT_BOUND_SID]], %c8, %c0 : index
 // CHECK: %[[SELTREE3:.+]] = arith.select %[[EQ_BOUND_SID]], %[[SELTREE1]], %[[SELTREE2]] : index
-// CHECK: %[[MASK:.+]] = vector.create_mask %[[SELTREE3]], %c7 : vector<8x8xi1>
+// CHECK: %[[MASK:.+]] = vector.create_mask %[[SELTREE3]], %c8 : vector<8x8xi1>
 
 // CHECK: %[[MASK_EXTR:.+]] = vector.extract_strided_slice %[[MASK]] {offsets = [0, 0], sizes = [2, 8], strides = [1, 1]} : vector<8x8xi1> to vector<2x8xi1>
 // CHECK: %[[READ:.+]] = vector.transfer_read %arg0{{.*}}, %[[MASK_EXTR]] {in_bounds = [true, true]} : memref<?x128xf16>, vector<2x8xf16>
 // CHECK: vector.transfer_write %[[READ]], %arg1{{.*}}, %[[MASK_EXTR]] {in_bounds = [true, true]} : vector<2x8xf16>, memref<?x128xf16>
+
+// -----
+
+#nested = #iree_vector_ext.nested_layout<
+  subgroup_tile = [1, 2, 1],
+  batch_tile = [1, 2, 1],
+  outer_tile = [1, 2, 1],
+  thread_tile = [1, 16, 16],
+  element_tile = [1, 2, 8],
+
+  subgroup_strides = [1, 1, 0],
+  thread_strides = [1, 16, 1]
+>
+
+func.func @masked_read_write_perm(%arg0 : memref<128x?x1xf16>, %arg1 : memref<128x?x1xf16>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c128 = arith.constant 128 : index
+  %cst_6 = arith.constant 0.000000e+00 : f16
+  %dyn = memref.dim %arg0, %c1 : memref<128x?x1xf16>
+  %41 = vector.create_mask %c128, %dyn, %c1 : vector<128x256x1xi1>
+  %42 = vector.transfer_read %arg0[%c0, %c0, %c0], %cst_6, %41 {in_bounds = [true, true, true], permutation_map = affine_map<(d0, d1, d2) -> (d2, d1, d0)>} : memref<128x?x1xf16>, vector<1x256x128xf16>
+  %43 = iree_vector_ext.to_layout %42 to layout(#nested) : vector<1x256x128xf16>
+  vector.transfer_write %43, %arg1[%c0, %c0, %c0], %41 {in_bounds = [true, true, true], permutation_map = affine_map<(d0, d1, d2) -> (d2, d1, d0)>} : vector<1x256x128xf16>, memref<128x?x1xf16>
+  return
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @masked_read_write_perm
+
+// Here we check the layout enforcement was carried out
+// accounting for permutation
+
+// CHECK: %[[DISTR_MASK:.+]] = vector.create_mask %c8, %15, %c1 : vector<8x8x1xi1>
+// CHECK: %[[DISTR_MASK_0:.+]] = vector.extract_strided_slice %[[DISTR_MASK]] {offsets = [0, 0, 0], sizes = [8, 2, 1], strides = [1, 1, 1]} : vector<8x8x1xi1> to vector<8x2x1xi1>
+// CHECK: vector.transfer_read %arg0{{.*}} %[[DISTR_MASK_0]]

--- a/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
@@ -801,6 +801,55 @@ static void enforceLayoutToGatherOp(
   }
 }
 
+static void enforceLayoutToTransferReadOp(
+    vector::TransferReadOp read, ArrayRef<DistributionLayout *> operandLattices,
+    ArrayRef<const DistributionLayout *> resultLattices,
+    std::function<void(DistributionLayout *, ChangeResult)> update) {
+  if (resultLattices.empty()) {
+    return;
+  }
+  if (!read.getMask()) {
+    return;
+  }
+  // transfer_read has only one vector result.
+  const DistributionLayout *result = resultLattices[0];
+  // Cannot enforce layout if result is uninitialized.
+  if (result->isUninitialized()) {
+    return;
+  }
+  for (auto [index, operandLattice] : llvm::enumerate(operandLattices)) {
+    ChangeResult changed = operandLattice->resolveWithPossibleConflict(
+        result, getOpOperand(read, index));
+    update(operandLattice, changed);
+  }
+}
+
+static void enforceLayoutToTransferWriteOp(
+    vector::TransferWriteOp write,
+    ArrayRef<DistributionLayout *> operandLattices,
+    ArrayRef<const DistributionLayout *> resultLattices,
+    std::function<void(DistributionLayout *, ChangeResult)> update) {
+  if (operandLattices.empty()) {
+    return;
+  }
+  if (!write.getMask()) {
+    return;
+  }
+  // transfer_write may have layout set on the vector
+  // that is to be written
+  const DistributionLayout *writeOperand = operandLattices[0];
+  // Cannot enforce layout if writeOperand is uninitialized.
+  if (writeOperand->isUninitialized()) {
+    return;
+  }
+  for (auto [index, operandLattice] :
+       llvm::enumerate(operandLattices.slice(1))) {
+    ChangeResult changed = operandLattice->resolveWithPossibleConflict(
+        writeOperand, getOpOperand(write, index + 1));
+    update(operandLattice, changed);
+  }
+}
+
 void enforcementTransferFunction(
     Operation *op, ArrayRef<DistributionLayout *> operandLattices,
     ArrayRef<const DistributionLayout *> resultLattices,
@@ -842,6 +891,18 @@ void enforcementTransferFunction(
   if (auto contraction = dyn_cast<vector::ContractionOp>(op)) {
     enforceLayoutToContractionOp(contraction, operandLattices, resultLattices,
                                  update);
+    return;
+  }
+
+  if (auto read = dyn_cast<vector::TransferReadOp>(op)) {
+    enforceLayoutToTransferReadOp(read, operandLattices, resultLattices,
+                                  update);
+    return;
+  }
+
+  if (auto write = dyn_cast<vector::TransferWriteOp>(op)) {
+    enforceLayoutToTransferWriteOp(write, operandLattices, resultLattices,
+                                   update);
     return;
   }
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrs.cpp
@@ -126,6 +126,28 @@ SmallVector<int64_t> NestedLayoutAttr::getUndistributedShape() const {
   return shape;
 }
 
+SmallVector<int64_t>
+NestedLayoutAttr::getPackedShapeForUndistributedDim(int64_t dim) const {
+  SmallVector<int64_t> shape;
+  shape.reserve(5);
+  shape.push_back(getSubgroupTile()[dim]);
+  shape.push_back(getBatchTile()[dim]);
+  shape.push_back(getOuterTile()[dim]);
+  shape.push_back(getThreadTile()[dim]);
+  shape.push_back(getElementTile()[dim]);
+  return shape;
+}
+
+SmallVector<int64_t> NestedLayoutAttr::getDistributedUnpackedShape() const {
+  SmallVector<int64_t> shape;
+  shape.reserve(getRank());
+  for (auto [batch, outer, element] :
+       llvm::zip(getBatchTile(), getOuterTile(), getElementTile())) {
+    shape.push_back(batch * outer * element);
+  }
+  return shape;
+}
+
 // Gets the rank of the undistributed vector for this layout.
 int64_t NestedLayoutAttr::getRank() const {
   // The layout requires that all size lists are the same length and match

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrs.td
@@ -242,6 +242,12 @@ def NestedLayoutAttr : IREEVectorExt_Attr<"NestedLayout",
 
     // Get the undistributed shape that is subgroup x batch x outer x thread x element
     SmallVector<int64_t> getUndistributedPackedShape() const;
+
+    // Get the subgroup x batch x outer x thread x element shape for original dim
+    SmallVector<int64_t> getPackedShapeForUndistributedDim(int64_t dim) const;
+
+    // Get the distributed shape but has the same rank as the undistributed shape.
+    SmallVector<int64_t> getDistributedUnpackedShape() const;
   }];
 
   let genVerifyDecl = 1;


### PR DESCRIPTION
This commit adds support for distributing masked reads/writes that originates from `vector.create_mask` op.