### PR TITLE
Disable `misc-use-anonymous-namespace`

### DIFF
--- a/compiler/src/.clang-tidy
+++ b/compiler/src/.clang-tidy
@@ -7,6 +7,7 @@ Checks: >
         -misc-non-private-member-variables-in-classes,
         -misc-no-recursion,
         -misc-unused-using-decls,
+        -misc-use-anonymous-namespace,
         -llvm-else-after-return,
         -llvm-include-order,
         -llvm-qualified-auto


### PR DESCRIPTION
[misc-use-anonymous-namespace](https://clang.llvm.org/extra/clang-tidy/checks/misc/use-anonymous-namespace.html) suggests moving static variables and functions into anonymous namespaces (doesn't appear to effect classes). This conflicts with https://llvm.org/docs/CodingStandards.html#anonymous-namespaces (see https://github.com/iree-org/iree/pull/18764#discussion_r1931657913):

>Because of this, we have a simple guideline: make anonymous namespaces as small as possible, and only use them for class declarations.

It also clutters LSP warnings/errors.