### PR TITLE
[GPU][Codegen] Setting padding size of external reduction dimensions

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -335,9 +335,16 @@ getMatmulLoweringConfigAndWorkgroupSize(SmallVector<int64_t> bounds,
     // shapes do not require c promotion.
     GPU::setPromotedOperandList(context, attrs, {0, 1, 2});
     SmallVector<int64_t> paddingTileSizes = workgroupTileSizes;
+
+    // Initialize inner and outer padding sizes for K dimensions.
     int64_t innerKDim = contractionDims.k.back();
     int64_t kPackFactor = std::get<2>(mmaKind.getMNKShape());
     paddingTileSizes[innerKDim] = reductionTileSizes[innerKDim] * kPackFactor;
+
+    for (int64_t k : llvm::drop_end(contractionDims.k)) {
+      paddingTileSizes[k] = 1;
+    }
+
     attrs.emplace_back(StringAttr::get(context, "padding"),
                        b.getI64ArrayAttr(paddingTileSizes));
   }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -336,14 +336,14 @@ getMatmulLoweringConfigAndWorkgroupSize(SmallVector<int64_t> bounds,
     GPU::setPromotedOperandList(context, attrs, {0, 1, 2});
     SmallVector<int64_t> paddingTileSizes = workgroupTileSizes;
 
-    // Initialize inner and outer padding sizes for K dimensions.
+    // Initialize inner and outer padding sizes from reductionTileSizes.
+    for (int64_t kDim : kDims) {
+      paddingTileSizes[kDim] = reductionTileSizes[kDim];
+    }
+
     int64_t innerKDim = contractionDims.k.back();
     int64_t kPackFactor = std::get<2>(mmaKind.getMNKShape());
-    paddingTileSizes[innerKDim] = reductionTileSizes[innerKDim] * kPackFactor;
-
-    for (int64_t k : llvm::drop_end(contractionDims.k)) {
-      paddingTileSizes[k] = 1;
-    }
+    paddingTileSizes[innerKDim] *= kPackFactor;
 
     attrs.emplace_back(StringAttr::get(context, "padding"),
                        b.getI64ArrayAttr(paddingTileSizes));

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
@@ -288,6 +288,33 @@ func.func @unaligned_to_intrinsic_batched_matmul(%lhs : tensor<12x577x577xf32>, 
 // -----
 
 module {
+func.func @unaligned_matmul_with_two_reduce_dim(%arg0: tensor<196x9x4xf32>, %arg1: tensor<9x16x4xf32>) -> tensor<196x16xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = tensor.empty() : tensor<196x16xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<196x16xf32>) -> tensor<196x16xf32>
+  %2 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>, affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d2)>], iterator_types = ["parallel", "reduction", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<196x9x4xf32>, tensor<9x16x4xf32>) outs(%1 : tensor<196x16xf32>) {
+  ^bb0(%in: f32, %in_0: f32, %out: f32):
+    %3 = arith.mulf %in, %in_0 : f32
+    %4 = arith.addf %out, %3 : f32
+    linalg.yield %4 : f32
+  } -> tensor<196x16xf32>
+  return %2 : tensor<196x16xf32>
+}
+}
+
+// CHECK-LABEL: func.func @unaligned_matmul_with_two_reduce_dim
+// CHECK-SAME:  {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64
+// CHECK:       linalg.generic
+// CHECK-SAME:  {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>
+// CHECK-SAME:  padding = [16, 1, 16, 4]
+// CHECK-SAME:  promote_operands = [0, 1, 2]
+// CHECK-SAME:  reduction = [0, 1, 0, 1],
+// CHECK-SAME:  subgroup = [1, 0, 1, 0],
+// CHECK-SAME:  workgroup = [16, 0, 16, 0]}
+
+// -----
+
+module {
 func.func @unaligned_to_intrinsic_batched_matmul_tiling_check(%lhs : tensor<12x577x577xf32>, %rhs : tensor<12x577x1024xf32>) -> tensor<12x577x1024xf32> {
     %c0 = arith.constant 0.0 : f32
     %empty = tensor.empty() : tensor<12x577x1024xf32>


### PR DESCRIPTION
The padding tile sizes were previously ignored and initialized to 0. This will result in a crash at [here](https://github.com/llvm/llvm-project/blob/a4d17c44f14984f8f031d0715ea4d1387e96b741/mlir/lib/Dialect/Linalg/Transforms/Padding.cpp#L51) below.

```cpp
} else if (dimSize % shapeDimToMultiple[en.index()] != 0) {
```

This scenario will happen where 1) There are more than 1 reduction dimension 2) The outer reduction dimension padding is set to zero. This PR fixed this by initializing the reduction dimension tile size to be at least reduction tile size, so at minimal pad to a multiple of "1" in unaligned intrinsic sizes. 

Credit to @nirvedhmeshram who originally found and debugged this issue.