### PR TITLE
[Flow] Fix cloning of `flow.tensor.transfer` into dispatch

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -807,6 +807,10 @@ static bool isAttentionMaskGenerator(Operation *op) {
 /// operations as roots.
 bool isClonableIntoDispatchOp(Operation *op,
                               ClonableIntoDispatchOptions options) {
+  if (isa<Flow::FlowDialect>(op->getDialect())) {
+    return false;
+  }
+
   // TODO(#8637): `tensor.collapse_shape` and `tensor.expand_shape` are
   // trivially clonable too, but they cause problems
   // with bufferization. Make them clonable when fixed.


### PR DESCRIPTION
Fixes case where `flow.tensor.transfer` was getting cloned into dispatches with an attention op by not cloning any `Flow` ops. This happens because `isAttentionMaskGenerator` returns true for all ops that are used by attention ops (including flow ops).
