### PR TITLE
[Codegen] Use affine.delinearize_index in workgroup distribution

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups_func_scope.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups_func_scope.mlir
@@ -32,14 +32,12 @@ func.func @multiple_dim_distribute(%s0 : index, %s1 : index, %s2 : index, %s3 : 
 //   CHECK-DAG:   %[[WG_ID_X:.+]] = hal.interface.workgroup.id[0]
 //   CHECK-DAG:   %[[WG_ID_Y:.+]] = hal.interface.workgroup.id[1]
 //   CHECK-DAG:   %[[WG_ID_Z:.+]] = hal.interface.workgroup.id[2]
+//   CHECK-DAG:   %[[WG_IDS_Z:.+]]:3 = affine.delinearize_index %[[WG_ID_Z]] into (%[[S0]], %[[S1]], %[[S2]])
 //   CHECK-DAG:   %[[EMPTY:.+]] = tensor.empty() : tensor<1x2x1x3x1x4x1x1xf32>
 //   CHECK-DAG:   %[[IN_SLICE:.+]] = tensor.extract_slice %[[INPUT]][0, 0, 0, %[[WG_ID_X]]] [2, 3, 4, 1]
 //       CHECK:   %[[GENERIC:.+]] = linalg.generic
 //  CHECK-SAME:       ins(%[[IN_SLICE]] :
 //  CHECK-SAME:       outs(%[[EMPTY]] :
-//   CHECK-DAG:   %[[WG_ID_Z_0:.+]] = affine.apply affine_map<()[s0, s1, s2] -> ((s1 floordiv s2) floordiv s0)>()[%[[S1]], %[[WG_ID_Z]], %[[S2]]]
-//   CHECK-DAG:   %[[WG_ID_Z_1:.+]] = affine.apply affine_map<()[s0, s1, s2] -> ((s1 floordiv s2) mod s0)>()[%[[S1]], %[[WG_ID_Z]], %[[S2]]]
-//   CHECK-DAG:   %[[WG_ID_Z_2:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 mod s1)>()[%[[WG_ID_Z]], %[[S2]]]
 //       CHECK:   flow.dispatch.tensor.store %[[GENERIC]],
-//  CHECK-SAME:       offsets = [%[[WG_ID_Z_0]], 0, %[[WG_ID_Z_1]], 0, %[[WG_ID_Z_2]], 0, %[[WG_ID_Y]], %[[WG_ID_X]]]
+//  CHECK-SAME:       offsets = [%[[WG_IDS_Z]]#0, 0, %[[WG_IDS_Z]]#1, 0, %[[WG_IDS_Z]]#2, 0, %[[WG_ID_Y]], %[[WG_ID_X]]]
 //  CHECK-SAME:       sizes = [1, 2, 1, 3, 1, 4, 1, 1]

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -1013,7 +1013,8 @@ linalg::LinalgLoopDistributionOptions getIREELinalgLoopDistributionOptions(
     auto numParallelDims = parallelLoopRanges.size();
 
     SmallVector<linalg::ProcInfo, 3> procInfo(numParallelDims);
-    std::optional<OpFoldResult> splitDim;
+    std::optional<Value> splitDim;
+    SmallVector<OpFoldResult> splitNumTiles;
     for (size_t dim = 0; dim < numParallelDims; ++dim) {
       if (numParallelDims > maxWorkgroupParallelDims &&
           dim >= maxWorkgroupParallelDims - 1) {
@@ -1030,19 +1031,7 @@ linalg::LinalgLoopDistributionOptions getIREELinalgLoopDistributionOptions(
         bindSymbols(builder.getContext(), d0, d1, d2);
         OpFoldResult numTiles = affine::makeComposedFoldedAffineApply(
             builder, loc, (d1 - d0).ceilDiv(d2), {offset, size, step});
-        OpFoldResult dimValue;
-        if (dim == numParallelDims - 1)
-          dimValue = splitDim.value();
-        else {
-          dimValue = affine::makeComposedFoldedAffineApply(
-              builder, loc, (d0 % d1), {splitDim.value(), numTiles});
-          splitDim = affine::makeComposedFoldedAffineApply(
-              builder, loc, (d0).floorDiv(d1), {splitDim.value(), numTiles});
-        }
-        procInfo[numParallelDims - dim - 1] = {
-            getValueOrCreateConstantIndexOp(builder, loc, dimValue),
-            getValueOrCreateConstantIndexOp(builder, loc, numTiles),
-            distributionMethod};
+        splitNumTiles.push_back(numTiles);
         continue;
       }
       procInfo[numParallelDims - dim - 1] = {
@@ -1051,6 +1040,20 @@ linalg::LinalgLoopDistributionOptions getIREELinalgLoopDistributionOptions(
           buildHALWorkgroupInfoOp<IREE::HAL::InterfaceWorkgroupCountOp>(builder,
                                                                         dim),
           distributionMethod};
+    }
+    if (splitDim) {
+      std::reverse(splitNumTiles.begin(), splitNumTiles.end());
+      auto delinearized = builder.create<affine::AffineDelinearizeIndexOp>(
+          loc, *splitDim, splitNumTiles, /*hasOuterBound=*/true);
+      for (auto [i, id, numTiles] :
+           llvm::enumerate(delinearized.getResults(), splitNumTiles)) {
+        // We iterate the delinearize results from slowest up to fastest, and
+        // we know that these are all the highest values of `dim. Tha tis,
+        // `i = 0` corresponds to `dim = numParallelDims - 1`.
+        procInfo[i] = {id,
+                       getValueOrCreateConstantIndexOp(builder, loc, numTiles),
+                       distributionMethod};
+      }
     }
     return procInfo;
   }};

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -1048,8 +1048,8 @@ linalg::LinalgLoopDistributionOptions getIREELinalgLoopDistributionOptions(
       for (auto [i, id, numTiles] :
            llvm::enumerate(delinearized.getResults(), splitNumTiles)) {
         // We iterate the delinearize results from slowest up to fastest, and
-        // we know that these are all the highest values of `dim. Tha tis,
-        // `i = 0` corresponds to `dim = numParallelDims - 1`.
+        // we know that these are all the highest values of dimension. That is,
+        // `i = 0` corresponds to the `numParallelDims - 1`-th dimension.
         procInfo[i] = {id,
                        getValueOrCreateConstantIndexOp(builder, loc, numTiles),
                        distributionMethod};


### PR DESCRIPTION
In the interests of getting rid of needless substractions from affine composition, get rid of one of the last remaining manual calls to floorDiv()

The other ProcInfo generators have been converted to delinearize_index by earlier PRs - this one finishes the job.

This should not impact the behavior of generated programs.