### PR TITLE
Bump tracy to wolfpld/tracy@5479a42 and update local build system.

### DIFF
--- a/build_tools/pkgci/build_linux_packages.sh
+++ b/build_tools/pkgci/build_linux_packages.sh
@@ -236,18 +236,15 @@ function install_native_deps() {
   # Get the output of uname -m
   uname_m=$(uname -m)
 
-  # Check if the output is aarch64
-
   if [[ "$uname_m" == "aarch64" ]]; then
     echo "The architecture is aarch64 and we use manylinux 2_28 so install deps"
     yum install -y epel-release
     yum update -y
     # Required for Tracy
-    yum install -y capstone-devel tbb-devel libzstd-devel
+    yum install -y libzstd-devel
     yum install -y clang lld
   elif [[ "$uname_m" == "x86_64" ]]; then
-    # Check if the output is x86_64
-    echo "Running on an architecture which has deps in docker image."
+    echo "The architecture is x86_64 so assume we are on a managed image with deps"
   else
     echo "The architecture is unknown. Exiting"
     exit 1

--- a/build_tools/python_deploy/build_linux_packages.sh
+++ b/build_tools/python_deploy/build_linux_packages.sh
@@ -206,16 +206,14 @@ function install_deps() {
   # Get the output of uname -m
   uname_m=$(uname -m)
 
-  # Check if the output is aarch64
   if [[ "$uname_m" == "aarch64" ]]; then
     echo "The architecture is aarch64 and we use manylinux 2_28 so install deps"
     yum install -y epel-release
     yum update -y
     # Required for Tracy
-    yum install -y capstone-devel tbb-devel libzstd-devel
+    yum install -y libzstd-devel
     yum install -y clang lld
   elif [[ "$uname_m" == "x86_64" ]]; then
-    # Check if the output is x86_64
     echo "The architecture is x86_64 so assume we are on a managed image with deps"
   else
     echo "The architecture is unknown. Exiting"

--- a/build_tools/third_party/tracy/CMakeLists.txt
+++ b/build_tools/third_party/tracy/CMakeLists.txt
@@ -27,29 +27,62 @@ else()
 
   # Deps slightly differ by platform but some are common.
   pkg_check_modules(TRACY_DEPS
-    tbb
     libzstd
-  )
-  pkg_check_modules(TRACY_CAPSTONE_DEPS
-    capstone
   )
 
   if(NOT TRACY_DEPS_FOUND)
     message(STATUS "Could not find Tracy dependencies (Tracy server will not be built).")
-    message(STATUS "To build Tracy, install packages libzstd, and tbb:")
-    message(STATUS "  Ubuntu/Debian: `apt install libcapstone-dev libtbb-dev libzstd-dev`")
-    message(STATUS "  MacOS: `brew install capstone tbb zstd`")
-    return()
-  endif()
-
-  if(NOT TRACY_CAPSTONE_DEPS_FOUND)
-    message(STATUS "Could not find capstone, a Tracy dependency (Tracy server will not be built).")
-    message(STATUS "To build Tracy, install capstone or build from source:")
-    message(STATUS "  Ubuntu/Debian: `apt install libcapstone-dev`")
-    message(STATUS "  MacOS: `brew install capstone`")
+    message(STATUS "To build Tracy, install libzstd:")
+    message(STATUS "  Ubuntu/Debian: `apt install libzstd-dev`")
+    message(STATUS "  MacOS: `brew install zstd`")
     return()
   endif()
 endif()
+
+#-------------------------------------------------------------------------------
+# Source dependencies
+# See https://github.com/wolfpld/tracy/blob/master/cmake/vendor.cmake
+#-------------------------------------------------------------------------------
+
+include(FetchContent)
+
+FetchContent_Declare(
+  capstone
+  GIT_REPOSITORY https://github.com/capstone-engine/capstone.git
+  GIT_TAG        97db712c91e964718f9cc300e81b9cf76b31a22e # 6.0.0-Alpha1
+  EXCLUDE_FROM_ALL
+)
+set(CAPSTONE_X86_ATT_DISABLE ON CACHE BOOL "" FORCE)
+set(CAPSTONE_ALPHA_SUPPORT OFF CACHE BOOL "" FORCE)
+set(CAPSTONE_HPPA_SUPPORT OFF CACHE BOOL "" FORCE)
+set(CAPSTONE_LOONGARCH_SUPPORT OFF CACHE BOOL "" FORCE)
+set(CAPSTONE_M680X_SUPPORT OFF CACHE BOOL "" FORCE)
+set(CAPSTONE_M68K_SUPPORT OFF CACHE BOOL "" FORCE)
+set(CAPSTONE_MIPS_SUPPORT OFF CACHE BOOL "" FORCE)
+set(CAPSTONE_MOS65XX_SUPPORT OFF CACHE BOOL "" FORCE)
+set(CAPSTONE_PPC_SUPPORT OFF CACHE BOOL "" FORCE)
+set(CAPSTONE_SPARC_SUPPORT OFF CACHE BOOL "" FORCE)
+set(CAPSTONE_SYSTEMZ_SUPPORT OFF CACHE BOOL "" FORCE)
+set(CAPSTONE_XCORE_SUPPORT OFF CACHE BOOL "" FORCE)
+set(CAPSTONE_TRICORE_SUPPORT OFF CACHE BOOL "" FORCE)
+set(CAPSTONE_TMS320C64X_SUPPORT OFF CACHE BOOL "" FORCE)
+set(CAPSTONE_M680X_SUPPORT OFF CACHE BOOL "" FORCE)
+set(CAPSTONE_EVM_SUPPORT OFF CACHE BOOL "" FORCE)
+set(CAPSTONE_WASM_SUPPORT OFF CACHE BOOL "" FORCE)
+set(CAPSTONE_BPF_SUPPORT OFF CACHE BOOL "" FORCE)
+set(CAPSTONE_RISCV_SUPPORT OFF CACHE BOOL "" FORCE)
+set(CAPSTONE_SH_SUPPORT OFF CACHE BOOL "" FORCE)
+set(CAPSTONE_XTENSA_SUPPORT OFF CACHE BOOL "" FORCE)
+set(CAPSTONE_BUILD_MACOS_THIN ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(capstone)
+
+FetchContent_Declare(
+  PPQSort
+  GIT_REPOSITORY https://github.com/GabTux/PPQSort.git
+  GIT_TAG        4b964020d67b435dae7ebac7b8f5ecea1f421c58 # v1.0.3
+  EXCLUDE_FROM_ALL
+)
+FetchContent_MakeAvailable(PPQSort)
 
 #-------------------------------------------------------------------------------
 # Configuration
@@ -58,7 +91,7 @@ endif()
 function(setup_cxx_options name)
   set_target_properties(${name}
     PROPERTIES
-      CXX_STANDARD 17
+      CXX_STANDARD 20
   )
   target_compile_options(${name}
     PRIVATE
@@ -68,22 +101,19 @@ function(setup_cxx_options name)
     PUBLIC
       ${TRACY_SOURCE_DIR}/imgui
       ${TRACY_DEPS_INCLUDE_DIRS}
-      ${TRACY_CAPSTONE_DEPS_INCLUDE_DIRS}
-      # capstone-next moved capstone.h to a capstone/ subdirectory, but the
-      # pkg-config isn't updated yet as of April 2022.
-      ${TRACY_CAPSTONE_DEPS_INCLUDE_DIRS}/capstone
+      ${capstone_SOURCE_DIR}/include/capstone
   )
   target_link_libraries(${name}
     PRIVATE
       ${TRACY_DEPS_LIBRARIES}
-      ${TRACY_CAPSTONE_DEPS_LIBRARIES}
       ${CMAKE_DL_LIBS}
       ${CMAKE_THREAD_LIBS_INIT}
+      capstone
+      PPQSort
   )
   target_link_directories(${name}
     PRIVATE
       ${TRACY_DEPS_LIBRARY_DIRS}
-      ${TRACY_CAPSTONE_DEPS_LIBRARY_DIRS}
   )
 endfunction()
 

--- a/docs/website/docs/developers/performance/profiling-with-tracy.md
+++ b/docs/website/docs/developers/performance/profiling-with-tracy.md
@@ -85,7 +85,7 @@ UI and CLI capture tool, is a PDF manual:
 
 You will need three things to capture a trace:
 
-1. The Tracy profiler UI (or CLI capture tool)
+1. The Tracy profiler UI or CLI capture tool
 2. A binary tool to trace, such as `iree-run-module`, built with tracing
     support enabled
 3. A program to profile, e.g. a `.vmfb` file with parameters and input values
@@ -398,7 +398,9 @@ First, refer to the upstream build instructions at either the
 <https://github.com/wolfpld/tracy/> repository itself or the
 [Tracy PDF manual](#the-tracy-manual).
 
-For example, to build the profiler GUI from an IREE checkout:
+#### Building the tracy-profiler GUI
+
+To build the profiler GUI from an IREE checkout:
 
 ```bash
 # Build using CMake:
@@ -410,60 +412,39 @@ cmake --build profiler/build --parallel --config Release
 ./profiler/build/tracy-profiler
 ```
 
-#### Additional Capstone dependencies for CPU code disassembly
+#### Building the tracy-capture CLI tool
 
-You can skip this section if you don't need disassembly of CPU code.
+To build `tracy-capture` from an IREE checkout:
 
-[Capstone](https://github.com/capstone-engine/capstone) is the disassembly
-framework used by Tracy. The default branch, which is what OS packages still
-distribute, is running a few years behind current CPU architectures.
+```bash
+# Build using CMake:
+cd third_party/tracy
+cmake -B capture/build -S capture -DCMAKE_BUILD_TYPE=Release
+cmake --build capture/build --parallel --config Release
 
-Newer CPU architectures such as RISC-V, or newer extensions of existing
-architectures (e.g. new SIMD instructions in the ARM architecture) are typically
-only supported in the
-[`next`](https://github.com/capstone-engine/capstone/tree/next) branch. If you
-need that support, check out and build that branch. Consider uninstalling any OS
-package for `capstone` or otherwise ensure that your IREE build will pick up
-your `next` branch build.
-
-##### Linux
-
-If you haven't opted to build `capstone-next` (see above section), install the
-OS package for `capstone` now (Debian-based distributions):
-
-```shell
-sudo apt install libcapstone-dev
+# Run the capture tool:
+./capture/build/tracy-capture --help
 ```
 
-Install other dependencies:
+IREE also maintains a downstream build for `tracy-capture`, renamed as
+`iree-tracy-capture`, that is bundled along with the `iree-base-runtime` Python
+package on Linux. To build this yourself, set the `-DIREE_BUILD_TRACY=ON` CMake
+option in your IREE CMake build or set the `IREE_RUNTIME_BUILD_TRACY_TOOLS=1`
+environment variable when building Python packages
+(see [`runtime/setup.py`](https://github.com/iree-org/iree/blob/main/runtime/setup.py)).
 
-```shell
-sudo apt install libtbb-dev libzstd-dev libglfw3-dev libfreetype6-dev libgtk-3-dev
-```
+#### Building the `tracy-csvexport` tool
 
-If you only build the command-line tool `iree-tracy-capture` and not the
-graphical `iree-tracy-profiler`, you can install only:
+To build `tracy-csvexport` from an IREE checkout:
 
-```shell
-sudo apt install libtbb-dev libzstd-dev
-```
+```bash
+# Build using CMake:
+cd third_party/tracy
+cmake -B csvexport/build -S csvexport -DCMAKE_BUILD_TYPE=Release
+cmake --build csvexport/build --parallel --config Release
 
-The zstd version on Ubuntu 18.04 is old. You will need to install it from source
-from <https://github.com/facebook/zstd.git>
-
-##### Mac
-
-If you haven't opted to build `capstone-next` (see above section), install the
-system `capstone` now:
-
-```shell
-brew install capstone
-```
-
-Install other dependencies:
-
-```shell
-brew install pkg-config glfw freetype tbb zstd
+# Run the csvexport tool:
+./csvexport/build/tracy-csvexport --help
 ```
 
 ### Android system settings required for Sampling and SysTrace


### PR DESCRIPTION
Closes https://github.com/iree-org/iree/pull/19801 (this is an alternate version of that PR).

This updates us from [Tracy v0.11.0](https://github.com/wolfpld/tracy/releases/tag/v0.11.0) (at https://github.com/wolfpld/tracy/commit/075395620a504c0cdcaf9bab3d196db16a043de7) to a development version of v0.11.2 at https://github.com/wolfpld/tracy/commit/5479a42ef9346b64e6d1b860ae58aa8abdb0c7f6.

The relevant sections of the upstream changelog [can be viewed here](https://github.com/wolfpld/tracy/blob/5479a42ef9346b64e6d1b860ae58aa8abdb0c7f6/NEWS#L5-L65). Notably for our usage:

* csvexport improvements, including support for exporting plots and GPU zones
* UI improvements, including a new flame graph feature
* More bundled dependencies, letting us prune some dockerfiles and build scripts
  * The dependency on TBB, installed at the system level, was replaced with a source dependency on https://github.com/GabTux/PPQSort
  * (From 0.11.0) Tracy supports using a known version of the capstone library, rather than a system install. We now use this, fixing https://github.com/iree-org/iree/issues/16777.