### PR TITLE
[GPU] Add transpose to set of generalized named ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUGeneralizeNamedOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUGeneralizeNamedOps.cpp
@@ -55,7 +55,7 @@ struct GPUGeneralizeNamedOpsPass final
     SmallVector<linalg::LinalgOp> namedOpCandidates;
     funcOp.walk([&](linalg::LinalgOp linalgOp) {
       if (isa<linalg::BatchMatmulTransposeBOp, linalg::MatmulTransposeBOp,
-              linalg::VecmatOp, linalg::MatvecOp>(linalgOp))
+              linalg::VecmatOp, linalg::MatvecOp, linalg::TransposeOp>(linalgOp))
         namedOpCandidates.push_back(linalgOp);
     });
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUGeneralizeNamedOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUGeneralizeNamedOps.cpp
@@ -55,7 +55,8 @@ struct GPUGeneralizeNamedOpsPass final
     SmallVector<linalg::LinalgOp> namedOpCandidates;
     funcOp.walk([&](linalg::LinalgOp linalgOp) {
       if (isa<linalg::BatchMatmulTransposeBOp, linalg::MatmulTransposeBOp,
-              linalg::VecmatOp, linalg::MatvecOp, linalg::TransposeOp>(linalgOp))
+              linalg::VecmatOp, linalg::MatvecOp, linalg::TransposeOp>(
+              linalgOp))
         namedOpCandidates.push_back(linalgOp);
     });
 

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_generalize_named_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_generalize_named_ops.mlir
@@ -111,3 +111,17 @@ func.func @lowering_config(%arg0: tensor<512x128xf16>, %arg1: tensor<512x128xf16
 // CHECK-LABEL: func.func @lowering_config
 //       CHECK:   linalg.generic
 //  CHECK-SAME:     lowering_config = #[[$CONFIG]]
+
+// -----
+
+func.func @transpose_op(%arg0: tensor<16x32xf16>) -> tensor<32x16xf16> {
+  %empty = tensor.empty() : tensor<32x16xf16>
+  %transpose = linalg.transpose
+      ins(%arg0 : tensor<16x32xf16>)
+      outs(%empty : tensor<32x16xf16>)
+      permutation = [1, 0]
+  return %transpose : tensor<32x16xf16>
+}
+
+// CHECK-LABEL: func.func @transpose_op
+//       CHECK:   linalg.generic


### PR DESCRIPTION
Adds linalg.transpose to the set of ops to generalize before GPU codegen. When GPU data tiling is used, encoding ops will materialize into a sequence that includes linalg.transpose ops, so we generalize to avoid requiring special lowering config logic for linalg.transpose ops.