### PR TITLE
[Dispatch] Fold attention with consumer transpose

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/ElementwiseOpFusion.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/ElementwiseOpFusion.cpp
@@ -150,10 +150,7 @@ void ElementwiseOpFusionPass::runOnOperation() {
 
   // Try fuse with linalgExt patterns.
   linalg::ControlFusionFn foldTransposeControlFn = [](OpOperand *fusedOperand) {
-    Operation *producer = fusedOperand->get().getDefiningOp();
-    Operation *consumer = fusedOperand->getOwner();
-
-    return IREE::Flow::isNonNullAndOutsideDispatch({producer, consumer});
+    return true;
   };
   RewritePatternSet linalgExtFusionPatterns(context);
   IREE::LinalgExt::populateFuseLinalgExtOpsWithTransposes(

--- a/compiler/src/iree/compiler/DispatchCreation/test/elementwise_op_fusion.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/elementwise_op_fusion.mlir
@@ -39,7 +39,7 @@ util.func public @transpose_attention(%arg0: tensor<4x64x32x128xf16>, %arg1: ten
 //  CHECK-SAME:     affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d4, d1, d3)>
 //  CHECK-SAME:     affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d4, d1, d5)>
 //  CHECK-SAME:     affine_map<(d0, d1, d2, d3, d4, d5) -> ()>
-//  CHECK-SAME:     affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d5)>
+//  CHECK-SAME:     affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d1, d5)>
 //  CHECK-SAME:     ins(%[[ARG0]], %[[ARG1]], %[[ARG2]], %[[ARG3]]
 
 // -----
@@ -90,7 +90,7 @@ util.func public @transposed_attention_masked(%arg0: tensor<4x64x32x128xf16>, %a
 //  CHECK-SAME:     affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d4, d1, d5)>
 //  CHECK-SAME:     affine_map<(d0, d1, d2, d3, d4, d5) -> ()>
 //  CHECK-SAME:     affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d1, d4)>
-//  CHECK-SAME:     affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d5)>
+//  CHECK-SAME:     affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d1, d5)>
 //  CHECK-SAME:     ins(%[[ARG0]], %[[ARG1]], %[[ARG2]], %[[ARG3]]
 
 // -----


### PR DESCRIPTION
When benching https://github.com/iree-org/iree/pull/19847, I saw some dispatches that had `attention -> transpose`. I thought this might have been causing problems (especially since transposes easily block fusion), but there seemed to be a negligible effect on the benchmarks.