### PR TITLE
[Dispatch] Extend gather fusion pattern

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/ElementwiseOpFusion.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/ElementwiseOpFusion.cpp
@@ -63,8 +63,7 @@ struct GatherFusionPattern final : public OpRewritePattern<tensor::ExtractOp> {
     }
 
     // Check if the producerOp is fusible
-    if (producerOp.getNumDpsInputs() != 1 || producerOp.getNumResults() != 1 ||
-        !isElementwise(producerOp) ||
+    if (producerOp.getNumResults() != 1 || !isElementwise(producerOp) ||
         !IREE::LinalgExt::isBitExtendOp(producerOp)) {
       return rewriter.notifyMatchFailure(producerOp,
                                          "producer op is not fusible");
@@ -73,21 +72,29 @@ struct GatherFusionPattern final : public OpRewritePattern<tensor::ExtractOp> {
     OpBuilder::InsertionGuard g(rewriter);
     rewriter.setInsertionPoint(extractOp);
 
-    // Create a new extract op that extracts from the original tensor
-    // (after the original extract). Clone the producerOp's body into the
-    // consumerOp, inline the cloned block (erases the block) after the new
-    // extract, and clean up.
-    auto newExtractOp = rewriter.create<tensor::ExtractOp>(
-        extractOp.getLoc(), producerOp.getDpsInputOperand(0)->get(),
-        extractOp.getIndices());
+    auto result = cast<OpResult>(extractOp.getTensor());
+    auto resultMap = producerOp.getIndexingMapMatchingResult(result);
+    SmallVector<Value> extractOps;
+    for (OpOperand &operand : producerOp->getOpOperands()) {
+      auto inputMap = producerOp.getMatchingIndexingMap(&operand);
+      auto composedMap = inputMap.compose(inversePermutation(resultMap));
+      auto perm = llvm::map_to_vector<4>(
+          composedMap.getResults(), [](AffineExpr expr) -> int64_t {
+            return cast<AffineDimExpr>(expr).getPosition();
+          });
+      SmallVector<Value, 4> indices = extractOp.getIndices();
+      indices = applyPermutation(indices, perm);
+      auto newExtract = rewriter.create<tensor::ExtractOp>(
+          extractOp.getLoc(), operand.get(), indices);
+      extractOps.push_back(newExtract);
+    }
     rewriter.cloneRegionBefore(producerOp.getRegion(), consumerOp.getRegion(),
                                consumerOp.getRegion().begin());
     Block &clonedBlock = consumerOp.getRegion().front();
     auto producerTermOp = clonedBlock.getTerminator();
 
-    rewriter.inlineBlockBefore(
-        &clonedBlock, extractOp->getNextNode(),
-        {newExtractOp.getResult(), newExtractOp.getResult()});
+    rewriter.inlineBlockBefore(&clonedBlock, extractOp->getNextNode(),
+                               extractOps);
 
     // Replace the the all references to the original extract result with the
     // result from the inlined producerOp.


### PR DESCRIPTION
This extends `GatherFusionPattern` to support any bit-extend op, instead of just ones that have a single truncate. Needed for https://github.com/iree-org/iree/pull/19847 to fix codegen failures. 

This also improves VAE performance by ~%15