### PR TITLE
fix(iree-opt): add missing passes and dialects for CUDA

### DIFF
--- a/compiler/src/iree/compiler/Tools/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Tools/CMakeLists.txt
@@ -121,6 +121,7 @@ iree_cc_library(
     MLIRTensorTransformOps
     MLIRVectorTransformOps
     MLIRTransformLoopExtension
+    MLIRComplexToStandard
   PUBLIC
 )
 

--- a/compiler/src/iree/compiler/Tools/init_mlir_dialects.h
+++ b/compiler/src/iree/compiler/Tools/init_mlir_dialects.h
@@ -29,6 +29,7 @@
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/GPU/TransformOps/GPUTransformOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/NVVMDialect.h"
 #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
 #include "mlir/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
@@ -79,6 +80,7 @@ inline void registerMlirDialects(DialectRegistry &registry) {
                   mesh::MeshDialect,
                   memref::MemRefDialect,
                   ml_program::MLProgramDialect,
+                  NVVM::NVVMDialect,
                   pdl::PDLDialect,
                   pdl_interp::PDLInterpDialect,
                   scf::SCFDialect,

--- a/compiler/src/iree/compiler/Tools/init_mlir_passes.h
+++ b/compiler/src/iree/compiler/Tools/init_mlir_passes.h
@@ -17,6 +17,7 @@
 #include "mlir/Conversion/Passes.h"
 #include "mlir/Dialect/Affine/Passes.h"
 #include "mlir/Dialect/ArmSME/Transforms/Passes.h"
+#include "mlir/Dialect/Bufferization/Transforms/Passes.h"
 #include "mlir/Dialect/GPU/Transforms/Passes.h"
 #include "mlir/Dialect/Linalg/Passes.h"
 #include "mlir/Dialect/MemRef/Transforms/Passes.h"
@@ -48,6 +49,8 @@ inline void registerMlirPasses() {
   registerViewOpGraphPass();
   registerStripDebugInfoPass();
   registerSymbolDCEPass();
+  bufferization::registerBufferizationPasses();
+  registerConvertComplexToStandard();
 
   // Generic conversions
   registerReconcileUnrealizedCastsPass();


### PR DESCRIPTION
While testing the GPU pipeline for CUDA, there are some differences between iree-compile and iree-opt. For instance the NVVMDialect was missing. This caused issues when parsing the executable-targets compilation IR.

And when executing a GPU pipeline argument from iree-opt the complex conversion pass was missing.

It seems the CUDA backend plugin registers this in the driver which is missing in opt.

