### PR TITLE
Fixing typo in schedule allocation alias tracking.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
@@ -440,7 +440,7 @@ struct AllocationScope {
       ResourceRange aliasRange = resourceRange;
       if (auto subviewOp =
               IREE::Stream::ResourceSubviewOp::findSubviewOp(alias)) {
-        aliasRange.resourceSize = subviewOp.getSubrangeResource();
+        aliasRange.resource = subviewOp.getSubrangeResource();
         aliasRange.resourceSize = subviewOp.getSubrangeResourceSize();
         aliasRange.offset = subviewOp.getSubrangeOffset();
         aliasRange.length = subviewOp.getSubrangeLength();


### PR DESCRIPTION
I think it was ok before (later analysis covered for the failure) but certainly produced bad debug output.