### PR TITLE
Add links to new iree-turbine documentation website.

### DIFF
--- a/docs/website/docs/guides/ml-frameworks/pytorch.md
+++ b/docs/website/docs/guides/ml-frameworks/pytorch.md
@@ -9,14 +9,6 @@ icon: simple/pytorch
 
 # PyTorch + IREE = :octicons-heart-16:
 
-!!! caution "Caution - under development"
-
-    We are still validating and fixing specific models. We don't expect that
-    you will be able to do a lot of advanced things without working with us.
-
-    Stay tuned and join the discussion in our
-    [Discord server](https://discord.gg/wEWh6Z9nMU)'s `#pytorch` channel.
-
 ## :octicons-book-16: Overview
 
 [iree-turbine](https://github.com/iree-org/iree-turbine) offers a tight
@@ -59,6 +51,11 @@ graph LR
   aot -.-> binary
 ```
 
+!!! info
+
+    Documentation for iree-turbine is available at
+    <https://iree-turbine.readthedocs.io/>.
+
 ## :octicons-download-16: Prerequisites
 
 1. First install a recent version of PyTorch by following
@@ -67,7 +64,7 @@ graph LR
     === ":fontawesome-brands-linux: Linux"
 
         ``` shell
-        python -m pip install torch --index-url https://download.pytorch.org/whl/test/cpu
+        python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
         ```
 
     === ":fontawesome-brands-apple: macOS"

--- a/docs/website/docs/reference/bindings/python.md
+++ b/docs/website/docs/reference/bindings/python.md
@@ -24,18 +24,17 @@ PIP package name | Description
 Collectively, these packages allow for importing from frontends, compiling
 towards various targets, and executing compiled code on IREE's backends.
 
-???+ Info "Note - `iree-compiler` and `iree-runtime` are deprecated"
+???+ Info "Note - deprecated package names"
     The Python packages
     [`iree-compiler`](https://pypi.org/project/iree-compiler/) and
-    [`iree-runtime`](https://pypi.org/project/iree-runtime/) have been
-    renamed to
+    [`iree-runtime`](https://pypi.org/project/iree-runtime/) are deprecated.
+    The packages were renamed to
     [`iree-base-compiler`](https://pypi.org/project/iree-base-compiler/) and
     [`iree-base-runtime`](https://pypi.org/project/iree-base-runtime/)
-    respectively, thus effectively deprecating the old packages.
-    This name change only affects the names of the packages but not
-    the modules. To make sure the new packages are used, run
-    `pip uninstall iree-compiler iree-runtime` before installing the
-    new packages.
+    respectively.
+
+    To clean old installed packages, run
+    `pip uninstall iree-compiler iree-runtime`.
 
 ## :octicons-download-16: Prerequisites
 
@@ -109,13 +108,13 @@ page for instructions for building from source.
 
 ## Usage
 
-!!! info "Info - API reference pages"
+### :material-file-document-multiple: API reference pages
 
-    API reference pages for IREE's runtime and compiler Python APIs are hosted on
-    [readthedocs](https://iree-python-api.readthedocs.io/en/latest/).
-
-    Documentation for the MLIR compiler Python APIs can be found at
-    [https://mlir.llvm.org/docs/Bindings/Python/](https://mlir.llvm.org/docs/Bindings/Python/).
+Description | URL
+-- | --
+IREE Python APIs | <https://iree-python-api.readthedocs.io/>
+IREE Turbine APIs | <https://iree-turbine.readthedocs.io/>
+MLIR Python APIs | <https://mlir.llvm.org/docs/Bindings/Python/>
 
 ### Compile a program
 


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree-turbine/issues/77.

* Drop warning about PyTorch support being unstable while under development. I think it is mature enough now.
* Add links to new documentation at https://iree-turbine.readthedocs.io/
* Make the link to https://iree-python-api.readthedocs.io/ more prominent