### PR TITLE
Don't hoist bit-extend op as a leaf

### DIFF
--- a/.github/workflows/pkgci_regression_test.yml
+++ b/.github/workflows/pkgci_regression_test.yml
@@ -131,9 +131,9 @@ jobs:
             --goldentime-rocm-unet-ms 255.0 \
             --goldentime-rocm-clip-ms 14.5 \
             --goldentime-rocm-vae-ms 310.0 \
-            --goldendispatch-rocm-unet 1602 \
-            --goldendispatch-rocm-clip 1139 \
-            --goldendispatch-rocm-vae 246 \
+            --goldendispatch-rocm-unet 1236 \
+            --goldendispatch-rocm-clip 967 \
+            --goldendispatch-rocm-vae 208 \
             --goldensize-rocm-unet-bytes 2280000  \
             --goldensize-rocm-clip-bytes 860000 \
             --goldensize-rocm-vae-bytes 840000 \
@@ -156,16 +156,16 @@ jobs:
             --goldentime-rocm-unet-ms 80.0 \
             --goldentime-rocm-clip-ms 15.0 \
             --goldentime-rocm-vae-ms 75.0 \
-            --goldendispatch-rocm-unet 1602 \
-            --goldendispatch-rocm-clip 1139 \
-            --goldendispatch-rocm-vae 246 \
+            --goldendispatch-rocm-unet 1236 \
+            --goldendispatch-rocm-clip 967 \
+            --goldendispatch-rocm-vae 208 \
             --goldensize-rocm-unet-bytes 2270000 \
             --goldensize-rocm-clip-bytes 860000  \
             --goldensize-rocm-vae-bytes 840000 \
             --goldentime-rocm-punet-int8-fp16-ms 50.0 \
             --goldentime-rocm-punet-int8-fp8-ms 52.0 \
-            --goldendispatch-rocm-punet-int8-fp16 1424 \
-            --goldendispatch-rocm-punet-int8-fp8 1704 \
+            --goldendispatch-rocm-punet-int8-fp16 1419 \
+            --goldendispatch-rocm-punet-int8-fp8 1699 \
             --goldensize-rocm-punet-int8-fp8-bytes 2800000 \
             --goldensize-rocm-punet-int8-fp16-bytes 2560000 \
             --rocm-chip gfx942 \
@@ -185,16 +185,16 @@ jobs:
             --goldentime-rocm-unet-ms 195.0 \
             --goldentime-rocm-clip-ms 15.0 \
             --goldentime-rocm-vae-ms 190.0 \
-            --goldendispatch-rocm-unet 1602 \
-            --goldendispatch-rocm-clip 1139 \
-            --goldendispatch-rocm-vae 246 \
+            --goldendispatch-rocm-unet 1236 \
+            --goldendispatch-rocm-clip 967 \
+            --goldendispatch-rocm-vae 208 \
             --goldensize-rocm-unet-bytes 2270000 \
             --goldensize-rocm-clip-bytes 860000 \
             --goldensize-rocm-vae-bytes 840000 \
             --goldentime-rocm-punet-int8-fp16-ms 140.0 \
             --goldentime-rocm-punet-int8-fp8-ms 150 \
-            --goldendispatch-rocm-punet-int8-fp16 1424 \
-            --goldendispatch-rocm-punet-int8-fp8 1704 \
+            --goldendispatch-rocm-punet-int8-fp16 1419 \
+            --goldendispatch-rocm-punet-int8-fp8 1699 \
             --goldensize-rocm-punet-int8-fp8-bytes 2800000 \
             --goldensize-rocm-punet-int8-fp16-bytes 2560000 \
             --rocm-chip gfx942 \

--- a/compiler/src/iree/compiler/ExternalInterfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/ExternalInterfaces/BUILD.bazel
@@ -36,6 +36,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/Flow/IR",
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
         "//compiler/src/iree/compiler/Dialect/LinalgExt/IR",
+        "//compiler/src/iree/compiler/Dialect/LinalgExt/Utils",
         "//compiler/src/iree/compiler/Dialect/Stream/IR",
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "@llvm-project//mlir:ArithDialect",

--- a/compiler/src/iree/compiler/ExternalInterfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/ExternalInterfaces/CMakeLists.txt
@@ -42,6 +42,7 @@ iree_cc_library(
     iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::LinalgExt::IR
+    iree::compiler::Dialect::LinalgExt::Utils
     iree::compiler::Dialect::Stream::IR
     iree::compiler::Dialect::Util::IR
   PUBLIC

--- a/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
@@ -12,6 +12,7 @@
 #include "iree/compiler/Dialect/Encoding/IR/EncodingOps.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
 #include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
@@ -340,6 +341,9 @@ struct HoistableLinalgOpInterface
     auto genericOp = llvm::dyn_cast<linalg::GenericOp>(op);
     if (!genericOp)
       return !isa<linalg::FillOp>(op);
+    if (IREE::LinalgExt::isBitExtendOp(op)) {
+      return false;
+    }
     // Generally, we prefer to not hoist broadcasts.
     // Detect op that only broadcast input as fusing them makes the new
     // op cheaper.


### PR DESCRIPTION
There are a ton bit extend ops that are getting hoisted which simply convert the weights from f16 to f32 (these ops are fairly small so they don't trigger the max size increase threshold i.e. 1024 elems). Instead, we want these ops to be fused with their consumers to prevent materializing the high bit-width tensors.

Originally from https://github.com/iree-org/iree/pull/19847 but this can be reviewed separately so I moved it out.