### PR TITLE
[Encoding] Implement [Un]specialized encodings for testing purpose.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
@@ -15,7 +15,9 @@
 #include "mlir/Dialect/Utils/StructuredOpsUtils.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributeInterfaces.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Support/LLVM.h"
@@ -309,6 +311,78 @@ std::string stringifyOperandIndex(IntegerAttr valueAttr) {
     assert(false && "invalid index");
     return "";
   }
+}
+
+//===---------------------------------------------------------------------===//
+// Encoding specialization attributes, which are mainly for testing purpose.
+//===---------------------------------------------------------------------===//
+
+Attribute UnspecializedEncodingAttr::parse(AsmParser &p, Type type) {
+  if (failed(p.parseLess())) {
+    return {};
+  }
+  IntegerAttr seed;
+  if (failed(p.parseAttribute(seed))) {
+    return {};
+  }
+  if (failed(p.parseGreater())) {
+    return {};
+  }
+  return get(p.getContext(), seed);
+}
+
+void UnspecializedEncodingAttr::print(AsmPrinter &p) const {
+  auto &os = p.getStream();
+  os << "<";
+  p.printAttributeWithoutType(getSeed());
+  os << ">";
+}
+
+Attribute
+UnspecializedEncodingAttr::cloneWithSimplifiedConfig(DictionaryAttr) const {
+  MLIRContext *ctx = getContext();
+  return SpecializedEncodingAttr::get(ctx, getSeed(), /*type=*/{});
+}
+
+Attribute SpecializedEncodingAttr::parse(AsmParser &p, Type type) {
+  if (failed(p.parseLess())) {
+    return {};
+  }
+
+  IntegerAttr seed;
+  if (failed(p.parseAttribute(seed))) {
+    return {};
+  }
+
+  TypeAttr typeAttr;
+  if (succeeded(p.parseOptionalComma()) && failed(p.parseAttribute(typeAttr))) {
+    return {};
+  }
+
+  if (failed(p.parseGreater())) {
+    return {};
+  }
+  return get(p.getContext(), seed, typeAttr);
+}
+
+void SpecializedEncodingAttr::print(AsmPrinter &p) const {
+  auto &os = p.getStream();
+  os << "<";
+  p.printAttributeWithoutType(getSeed());
+  if (auto typeAttr = getType()) {
+    os << ", ";
+    p.printAttribute(typeAttr);
+  }
+  os << ">";
+}
+
+static RankedTensorType dropEncoding(RankedTensorType type) {
+  return RankedTensorType::get(type.getShape(), type.getElementType());
+}
+
+Attribute SpecializedEncodingAttr::getLayout(RankedTensorType type) const {
+  MLIRContext *ctx = getContext();
+  return get(ctx, getSeed(), TypeAttr::get(dropEncoding(type)));
 }
 
 } // namespace mlir::iree_compiler::IREE::Encoding

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -133,4 +133,62 @@ def EncodingAttr :
   let genVerifyDecl = 0;
 }
 
+//===---------------------------------------------------------------------===//
+// Encoding specialization attributes, which are mainly for testing purpose.
+//===---------------------------------------------------------------------===//
+
+def UnspecializedEncodingAttr :
+    IREEEncoding_Attr<"UnspecializedEncoding", [
+      DeclareAttrInterfaceMethods<IREEEncoding_EncodingLayoutAttrInterface, [
+        "cloneWithSimplifiedConfig",
+      ]>
+    ]> {
+  let mnemonic = "unspecialized_encoding";
+
+  let summary = "An attribute that indicates the encoding is not yet specialized";
+
+  let description = [{
+    This attribute indicates this is an unspecialized encoding. It implements
+    very basic interface methods of EncodingLayoutAttrInterface that converts
+    it to the SpecializeEncodingAttr during encoding specialization. It is
+    mainly for testing purpose as some transformations do not depend on actual
+    dialects that implement the attribute interface.
+  }];
+
+  let parameters = (ins
+    AttrParameter<"IntegerAttr", "The seed that attached on the attribute. "
+    "Different seed values indicate different layouts.">:$seed
+  );
+
+  let hasCustomAssemblyFormat = 1;
+  let genVerifyDecl = 0;
+}
+
+def SpecializedEncodingAttr :
+    IREEEncoding_Attr<"SpecializedEncoding", [
+      DeclareAttrInterfaceMethods<IREEEncoding_EncodingLayoutAttrInterface, [
+        "getLayout",
+      ]>
+    ]> {
+  let mnemonic = "specialized_encoding";
+
+  let summary = "An attribute that indicates the encoding is specialized";
+
+  let description = [{
+    This attribute is similar to UnspecializeEncodingAttr, but with an optional
+    type. The attribute denotes the layout of the type. Different seed values
+    indicate different layouts, which can be used to emulate different encoding
+    attributes.
+  }];
+
+  let parameters = (ins
+    AttrParameter<"IntegerAttr", "The seed that attached on the attribute. "
+    "Different seed values indicate different layouts.">:$seed,
+    AttrParameter<"TypeAttr", "">:$type
+  );
+
+  let hasCustomAssemblyFormat = 1;
+  let genVerifyDecl = 0;
+}
+
 #endif // IREE_DIALECT_ENCODING_ATTRS

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/test/roundtrip.mlir
@@ -169,3 +169,33 @@ func.func @set_encoding_ops_with_layouts(%arg0: tensor<?x?xf32>) -> tensor<?x?xf
 // CHECK:       func.func @set_encoding_ops_with_layouts(
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]:
 // CHECK:         iree_encoding.set_encoding %[[ARG0]] : tensor<?x?xf32> -> tensor<?x?xf32, #[[ENCODING]]>
+
+// -----
+
+#encoding = #iree_encoding.unspecialized_encoding<123>
+func.func @unspecialized_encoding(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf32, #encoding> {
+  return %arg0 : tensor<?x?xf32, #encoding>
+}
+// CHECK:      func.func @unspecialized_encoding(
+// CHECK-SAME:   %[[ARG0:.+]]: tensor<?x?xf32, #iree_encoding.unspecialized_encoding<123>>
+// CHECK         return %[[ARG0]]
+
+// -----
+
+#encoding = #iree_encoding.specialized_encoding<123>
+func.func @specialized_encoding_without_type(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf32, #encoding> {
+  return %arg0 : tensor<?x?xf32, #encoding>
+}
+// CHECK:      func.func @specialized_encoding_without_type(
+// CHECK-SAME:   %[[ARG0:.+]]: tensor<?x?xf32, #iree_encoding.specialized_encoding<123>>
+// CHECK         return %[[ARG0]]
+
+// -----
+
+#encoding = #iree_encoding.specialized_encoding<123, tensor<?x?xf32>>
+func.func @specialized_encoding_with_type(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf32, #encoding> {
+  return %arg0 : tensor<?x?xf32, #encoding>
+}
+// CHECK:      func.func @specialized_encoding_with_type(
+// CHECK-SAME:   %[[ARG0:.+]]: tensor<?x?xf32, #iree_encoding.specialized_encoding<123, tensor<?x?xf32>>>
+// CHECK         return %[[ARG0]]

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
@@ -85,7 +85,7 @@ module {
 
 // -----
 
-#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {encoding = #iree_cpu.vmvx_encoding_layout<>}>
+#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {encoding = #iree_encoding.unspecialized_encoding<123>}>
 #map = affine_map<(d0) -> (d0)>
 #map0 = affine_map<(m, n, k) -> (m, k)>
 #map1 = affine_map<(m, n, k) -> (k, n)>
@@ -145,10 +145,10 @@ module attributes {stream.affinity.default = #hal.device.affinity<@device_a>} {
 // launch it on device_b. Thus, the incoming layout of second tensor dispatch op
 // has device_a layout, and it produces device_b layout.
 
-#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {encoding = #iree_cpu.vmvx_encoding_layout<>}>
-#executable_target_x86_64 = #hal.executable.target<"llvm-cpu", "xyz", {encoding = #iree_cpu.cpu_encoding_layout<>, target_triple="x86_64-xyz-xyz", cpu_features="+avx512f"}>
-#device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
-#device_target_local_1_ = #hal.device.target<"local", {ordinal = 1 : index}, [#executable_target_x86_64]> : !hal.device
+#executable_target_a = #hal.executable.target<"target_a", "abc", {encoding = #iree_encoding.unspecialized_encoding<123>}>
+#executable_target_b = #hal.executable.target<"target_b", "xyz", {encoding = #iree_encoding.unspecialized_encoding<456>}>
+#device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_a]> : !hal.device
+#device_target_local_1_ = #hal.device.target<"local", {ordinal = 1 : index}, [#executable_target_b]> : !hal.device
 #map = affine_map<(d0) -> (d0)>
 #map0 = affine_map<(m, n, k) -> (m, k)>
 #map1 = affine_map<(m, n, k) -> (k, n)>
@@ -192,8 +192,8 @@ module attributes {stream.affinity.default = #hal.device.affinity<@device_a>} {
 }
 // CHECK-DAG:   #[[DEVICE_LOCAL_0:.+]] = #hal.device.target
 // CHECK-DAG:   #[[DEVICE_LOCAL_1:.+]] = #hal.device.target
-// CHECK-DAG:   #[[$DEVICE_A_ENCODING:.+]] = #iree_encoding.encoding{{.+}} layouts = [#iree_cpu.vmvx_encoding_layout
-// CHECK-DAG:   #[[$DEVICE_B_ENCODING:.+]] = #iree_encoding.encoding{{.+}} layouts = [#iree_cpu.cpu_encoding_layout
+// CHECK-DAG:   #[[$DEVICE_A_ENCODING:.+]] = #iree_encoding.encoding{{.+}} layouts = [#iree_encoding.specialized_encoding<123, tensor<16xf32>>
+// CHECK-DAG:   #[[$DEVICE_B_ENCODING:.+]] = #iree_encoding.encoding{{.+}} layouts = [#iree_encoding.specialized_encoding<456, tensor<16xf32>>
 // CHECK:       util.global private @[[$DEVICE_A:.+]] = #[[DEVICE_LOCAL_0]]
 // CHECK:       util.global private @[[$DEVICE_B:.+]] = #[[DEVICE_LOCAL_1]]
 // CHECK:       stream.executable private @[[$EX0:.+]] {


### PR DESCRIPTION
The revision implements the speialized_encoding attribute and the unspecialized_encoding attribute in `IREE::Encoding` dialect. They are mainly for testing purpose that decouple the transformation dependency.

Both encoding attributes take a seed, which can be used to emulate different attributes. The unspecialized_encoding is converted to speialized_encoding in the `cloneWithSimplifiedConfig` interface method. And the specialized_encoding implements the `getLayout` method that attaches the type (without encoding) to self.

In the specialize_encodings.mlir, only the duplication tests use the testing attributes. Because the duplication does not care about the serialized layouts in practice. It remains the Stream tensor ops with vmvx/cpu attributes because it is important to verify that they are connected.

The custom assembly format is implemented for better visualization. Otherwise, the type of the `seed` gets printed out, which is just a visual noise.

Without the custom assembly format:

```mlir
#iree_encoding.specialized_encoding<123 : i64>
```

With the custom assembly format:

```mlir
#iree_encoding.specialized_encoding<123>
```