### PR TITLE
[LLVMGPUVectorDistribute] Support vector.mask + vector.multi_reduce

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -587,17 +587,19 @@ static int64_t getShuffleWidth(NestedLayoutAttr layout, int64_t dim) {
 ///      to shared memory and will be reloaded into a layout where partial
 ///      reductions will be placed inside threads.
 struct DistributeMultiReduction final
-    : OpDistributionPattern<vector::MultiDimReductionOp> {
-  using OpDistributionPattern::OpDistributionPattern;
+    : MaskedOpDistributionPattern<vector::MultiDimReductionOp> {
+  using MaskedOpDistributionPattern::MaskedOpDistributionPattern;
 
   DistributeMultiReduction(MLIRContext *context, int64_t subgroupSize,
                            int64_t maxBitsPerShuffle, int64_t benefit = 1)
-      : OpDistributionPattern(context, benefit), subgroupSize(subgroupSize),
-        maxBitsPerShuffle(maxBitsPerShuffle) {}
+      : MaskedOpDistributionPattern(context, benefit),
+        subgroupSize(subgroupSize), maxBitsPerShuffle(maxBitsPerShuffle) {}
 
-  LogicalResult matchAndRewrite(vector::MultiDimReductionOp multiReduceOp,
-                                DistributionSignature &signature,
-                                PatternRewriter &rewriter) const override {
+  LogicalResult
+  matchAndRewrite(vector::MultiDimReductionOp multiReduceOp,
+                  DistributionSignature &signature, vector::MaskOp maskOp,
+                  std::optional<DistributionSignature> &maskSignature,
+                  PatternRewriter &rewriter) const {
     Location loc = multiReduceOp.getLoc();
     VectorValue srcVector = multiReduceOp.getSource();
     Value acc = multiReduceOp.getAcc();
@@ -632,11 +634,9 @@ struct DistributeMultiReduction final
     }
 
     VectorValue mask = nullptr;
-    if (auto maskOp = multiReduceOp->getParentOfType<vector::MaskOp>()) {
-      std::optional<DistributionSignature> signatureMask =
-          getOpSignature(maskOp);
+    if (maskOp) {
       auto maskLayout = dyn_cast_or_null<NestedLayoutAttr>(
-          signatureMask.value()[maskOp.getMask()]);
+          maskSignature.value()[maskOp.getMask()]);
       if (!maskLayout) {
         return rewriter.notifyMatchFailure(maskOp,
                                            "expected nested layout attr");
@@ -1680,33 +1680,6 @@ struct DistributeCreateMask final
   int64_t subgroupSize;
 };
 
-struct DistributeMask final : OpDistributionPattern<vector::MaskOp> {
-  using OpDistributionPattern::OpDistributionPattern;
-
-  LogicalResult matchAndRewrite(vector::MaskOp maskOp,
-                                DistributionSignature &signature,
-                                PatternRewriter &rewriter) const override {
-    SmallVector<Value> returns =
-        maskOp.getBody()->getTerminator()->getOperands();
-    for (auto [idx, ret] : llvm::enumerate(returns)) {
-      if (VectorValue vectorRet = dyn_cast<VectorValue>(ret)) {
-        VectorValue maskRet = cast<VectorValue>(maskOp.getResult(idx));
-        VectorLayoutInterface layout =
-            dyn_cast<NestedLayoutAttr>(signature[maskRet]);
-        if (!layout) {
-          return rewriter.notifyMatchFailure(maskOp,
-                                             "layout must be NestedLayoutAttr");
-        }
-        ret = getDistributed(rewriter, vectorRet, layout);
-      }
-    }
-    rewriter.eraseOp(maskOp.getBody()->getTerminator());
-    rewriter.inlineBlockBefore(maskOp.getBody(), maskOp);
-    replaceOpWithDistributedValues(rewriter, maskOp, returns);
-    return success();
-  }
-};
-
 } // namespace
 
 void populateGPUDistributeNestedLayoutAttrPatterns(RewritePatternSet &patterns,
@@ -1723,7 +1696,6 @@ void populateGPUDistributeNestedLayoutAttrPatterns(RewritePatternSet &patterns,
   patterns.add<DistributeStep>(patterns.getContext(), threadId, subgroupSize);
   patterns.add<DistributeCreateMask>(patterns.getContext(), threadId,
                                      subgroupSize);
-  patterns.add<DistributeMask>(patterns.getContext());
 }
 
 }; // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -598,6 +598,7 @@ struct DistributeMultiReduction final
   LogicalResult matchAndRewrite(vector::MultiDimReductionOp multiReduceOp,
                                 DistributionSignature &signature,
                                 PatternRewriter &rewriter) const override {
+    Location loc = multiReduceOp.getLoc();
     VectorValue srcVector = multiReduceOp.getSource();
     Value acc = multiReduceOp.getAcc();
     Value res = multiReduceOp.getResult();
@@ -630,7 +631,24 @@ struct DistributeMultiReduction final
       disAcc = multiReduceOp.getAcc();
     }
 
-    Location loc = multiReduceOp.getLoc();
+    VectorValue mask = nullptr;
+    if (auto maskOp = multiReduceOp->getParentOfType<vector::MaskOp>()) {
+      std::optional<DistributionSignature> signatureMask =
+          getOpSignature(maskOp);
+      auto maskLayout = dyn_cast_or_null<NestedLayoutAttr>(
+          signatureMask.value()[maskOp.getMask()]);
+      if (!maskLayout) {
+        return rewriter.notifyMatchFailure(maskOp,
+                                           "expected nested layout attr");
+      }
+      mask = getDistributed(rewriter, maskOp.getMask(), maskLayout);
+      Value passThruSrc = getCombiningIdentityValue(
+          loc, rewriter, multiReduceOp.getKind(), disSrc.getType());
+      disSrc = cast<VectorValue>(
+          rewriter.create<arith::SelectOp>(loc, mask, disSrc, passThruSrc)
+              .getResult());
+    }
+
     SmallVector<bool> reducedDims = multiReduceOp.getReductionMask();
     int64_t rank = srcVector.getType().getRank();
 
@@ -645,18 +663,23 @@ struct DistributeMultiReduction final
     }
     Value localInit = getCombiningIdentityValue(
         loc, rewriter, multiReduceOp.getKind(), disAcc.getType());
-    auto localReduction = rewriter.create<vector::MultiDimReductionOp>(
+    Value localReduction = rewriter.create<vector::MultiDimReductionOp>(
         loc, disSrc, localInit, distributedReductionMask,
         multiReduceOp.getKind());
+    if (mask) {
+      localReduction =
+          vector::maskOperation(rewriter, localReduction.getDefiningOp(), mask)
+              ->getResult(0);
+    }
 
     VectorValue locallyReduced;
     if (accVector) {
-      locallyReduced = dyn_cast<VectorValue>(localReduction.getResult());
+      locallyReduced = dyn_cast<VectorValue>(localReduction);
     } else {
       // Broadcast scalar accumulator to vector.
       VectorType vecType = VectorType::get(ArrayRef{int64_t(1)}, elemTy);
-      locallyReduced = rewriter.create<vector::BroadcastOp>(
-          loc, vecType, localReduction.getResult());
+      locallyReduced =
+          rewriter.create<vector::BroadcastOp>(loc, vecType, localReduction);
     }
 
     assert(locallyReduced && "result should have been a vector");
@@ -739,7 +762,6 @@ struct DistributeMultiReduction final
 
     for (unsigned i = 0; i < numElements; ++i) {
       Value extracted = rewriter.create<vector::ExtractOp>(loc, flat, i);
-
       // Reduce across all reduction dimensions 1-by-1.
       for (unsigned i = 0, e = reductionMask.size(); i != e; ++i) {
         if (reductionMask[i]) {
@@ -1658,6 +1680,33 @@ struct DistributeCreateMask final
   int64_t subgroupSize;
 };
 
+struct DistributeMask final : OpDistributionPattern<vector::MaskOp> {
+  using OpDistributionPattern::OpDistributionPattern;
+
+  LogicalResult matchAndRewrite(vector::MaskOp maskOp,
+                                DistributionSignature &signature,
+                                PatternRewriter &rewriter) const override {
+    SmallVector<Value> returns =
+        maskOp.getBody()->getTerminator()->getOperands();
+    for (auto [idx, ret] : llvm::enumerate(returns)) {
+      if (VectorValue vectorRet = dyn_cast<VectorValue>(ret)) {
+        VectorValue maskRet = cast<VectorValue>(maskOp.getResult(idx));
+        VectorLayoutInterface layout =
+            dyn_cast<NestedLayoutAttr>(signature[maskRet]);
+        if (!layout) {
+          return rewriter.notifyMatchFailure(maskOp,
+                                             "layout must be NestedLayoutAttr");
+        }
+        ret = getDistributed(rewriter, vectorRet, layout);
+      }
+    }
+    rewriter.eraseOp(maskOp.getBody()->getTerminator());
+    rewriter.inlineBlockBefore(maskOp.getBody(), maskOp);
+    replaceOpWithDistributedValues(rewriter, maskOp, returns);
+    return success();
+  }
+};
+
 } // namespace
 
 void populateGPUDistributeNestedLayoutAttrPatterns(RewritePatternSet &patterns,
@@ -1674,6 +1723,7 @@ void populateGPUDistributeNestedLayoutAttrPatterns(RewritePatternSet &patterns,
   patterns.add<DistributeStep>(patterns.getContext(), threadId, subgroupSize);
   patterns.add<DistributeCreateMask>(patterns.getContext(), threadId,
                                      subgroupSize);
+  patterns.add<DistributeMask>(patterns.getContext());
 }
 
 }; // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_mask.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_mask.mlir
@@ -181,3 +181,50 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK: %[[DISTR_MASK:.+]] = vector.create_mask {{.*}} : vector<8xi1>
 // CHECK: %[[DISTR_MASK_0:.+]] = vector.extract_strided_slice %16 {offsets = [0], sizes = [2], strides = [1]} : vector<8xi1> to vector<2xi1>
 // CHECK: vector.transfer_read %arg0{{.*}} %[[DISTR_MASK_0]]
+
+// -----
+
+#nested = #iree_vector_ext.nested_layout<
+  subgroup_tile = [2, 1],
+  batch_tile = [2, 1],
+  outer_tile = [2, 1],
+  thread_tile = [16, 16],
+  element_tile = [2, 8],
+
+  subgroup_strides = [1, 0],
+  thread_strides = [16, 1]
+>
+
+func.func @masked_read_write_reduce(%arg0 : memref<?x128xf16>, %arg1 : memref<128xf16>) {
+  %c0 = arith.constant 0 : index
+  %c128 = arith.constant 128 : index
+  %cst_6 = arith.constant 0.000000e+00 : f16
+  %cst_1 = arith.constant dense<0.000000e+00> : vector<128xf16>
+
+  %dyn = memref.dim %arg0, %c0 : memref<?x128xf16>
+  %41 = vector.create_mask %dyn, %c128 : vector<256x128xi1>
+  %42 = vector.transfer_read %arg0[%c0, %c0], %cst_6, %41 {in_bounds = [true, true]} : memref<?x128xf16>, vector<256x128xf16>
+  %43 = iree_vector_ext.to_layout %42 to layout(#nested) : vector<256x128xf16>
+  %44 = vector.mask %41 { vector.multi_reduction <add>, %43, %cst_1 [0] : vector<256x128xf16> to vector<128xf16> } : vector<256x128xi1> -> vector<128xf16>
+  vector.transfer_write %44, %arg1[%c0] {in_bounds = [true]} : vector<128xf16>, memref<128xf16>
+  return
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: func @masked_read_write_reduce
+
+// CHECK: %[[RED_IDENTITY:.+]] = arith.constant dense<0.000000e+00> : vector<2x1x2x1x2x8xf16>
+
+// CHECK: %[[MASK:.+]] = vector.create_mask
+// CHECK: %[[MASK_PCK:.+]] = vector.shape_cast %[[MASK]] : vector<8x8xi1> to vector<2x2x2x1x1x8xi1>
+// CHECK: %[[MASK_ITL_PCK:.+]] = vector.transpose %[[MASK_PCK]], [0, 3, 1, 4, 2, 5] : vector<2x2x2x1x1x8xi1> to vector<2x1x2x1x2x8xi1>
+
+// CHECK: %[[SELECT:.+]] = arith.select %[[MASK_ITL_PCK]], {{.*}}, %[[RED_IDENTITY]] : vector<2x1x2x1x2x8xi1>, vector<2x1x2x1x2x8xf16>
+// CHECK: vector.mask %[[MASK_ITL_PCK]] { vector.multi_reduction <add>, %[[SELECT]], {{.*}} [0, 2, 4] : vector<2x1x2x1x2x8xf16> to vector<1x1x8xf16> } : vector<2x1x2x1x2x8xi1> -> vector<1x1x8xf16>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_mask.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_mask.mlir
@@ -227,4 +227,4 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK: %[[MASK_ITL_PCK:.+]] = vector.transpose %[[MASK_PCK]], [0, 3, 1, 4, 2, 5] : vector<2x2x2x1x1x8xi1> to vector<2x1x2x1x2x8xi1>
 
 // CHECK: %[[SELECT:.+]] = arith.select %[[MASK_ITL_PCK]], {{.*}}, %[[RED_IDENTITY]] : vector<2x1x2x1x2x8xi1>, vector<2x1x2x1x2x8xf16>
-// CHECK: vector.mask %[[MASK_ITL_PCK]] { vector.multi_reduction <add>, %[[SELECT]], {{.*}} [0, 2, 4] : vector<2x1x2x1x2x8xf16> to vector<1x1x8xf16> } : vector<2x1x2x1x2x8xi1> -> vector<1x1x8xf16>
+// CHECK: vector.multi_reduction <add>, %[[SELECT]], {{.*}} [0, 2, 4] : vector<2x1x2x1x2x8xf16> to vector<1x1x8xf16>

--- a/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
@@ -984,7 +984,7 @@ void PropagateLayout::visitMaskOp(
     std::function<void(DistributionLayout *, mlir::ChangeResult)> update) {
   mask.getBody()->walk(
       [&](Operation *traversed) { visitOperation(traversed); });
-  // Propogate from body to results
+  // Propagate from body to results.
   SmallVector<OpResult> vectorResults =
       llvm::filter_to_vector(mask.getResults(), [](OpResult result) {
         return isa<VectorType>(result.getType());

--- a/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorLayoutAnalysis.cpp
@@ -136,6 +136,10 @@ private:
                              RegionBranchPoint branchPoint,
                              MutableArrayRef<OpOperand> operands);
 
+  void visitMaskOp(
+      vector::MaskOp maskOp,
+      std::function<void(DistributionLayout *, mlir::ChangeResult)> update);
+
   DistributionLayout *getLatticeElement(Value val);
 
   MLIRContext *ctx;
@@ -163,6 +167,10 @@ private:
   void visitRegionSuccessors(RegionBranchOpInterface branch,
                              RegionBranchPoint branchPoint,
                              OperandRange operands);
+
+  void visitMaskOp(
+      vector::MaskOp maskOp,
+      std::function<void(DistributionLayout *, mlir::ChangeResult)> update);
 
   DistributionLayout *getLatticeElement(Value val);
 
@@ -971,6 +979,35 @@ LogicalResult PropagateLayout::visit(ProgramPoint *point) {
   return failure();
 }
 
+void PropagateLayout::visitMaskOp(
+    vector::MaskOp mask,
+    std::function<void(DistributionLayout *, mlir::ChangeResult)> update) {
+  mask.getBody()->walk(
+      [&](Operation *traversed) { visitOperation(traversed); });
+  // Propogate from body to results
+  SmallVector<OpResult> vectorResults =
+      llvm::filter_to_vector(mask.getResults(), [](OpResult result) {
+        return isa<VectorType>(result.getType());
+      });
+  SmallVector<DistributionLayout *> resultLayouts = llvm::map_to_vector(
+      vectorResults, [&](Value result) -> DistributionLayout * {
+        return getLatticeElement(result);
+      });
+  SmallVector<Value> vectorYieldResults = llvm::filter_to_vector(
+      mask.getBody()->getTerminator()->getOperands(),
+      [](Value result) { return isa<VectorType>(result.getType()); });
+  SmallVector<DistributionLayout *> yieldLayouts = llvm::map_to_vector(
+      vectorYieldResults, [&](Value yieldResult) -> DistributionLayout * {
+        return getLatticeElement(yieldResult);
+      });
+  for (auto [result, yieldResult] : llvm::zip(resultLayouts, yieldLayouts)) {
+    if (!result->hasLayout() && !yieldResult->isUninitialized()) {
+      ChangeResult changed = result->resolve(yieldResult);
+      update(result, changed);
+    }
+  }
+}
+
 void PropagateLayout::visitOperation(Operation *op) {
   // Handle region branching control flow.
   // TODO: Write more about what we are doing here.
@@ -986,6 +1023,15 @@ void PropagateLayout::visitOperation(Operation *op) {
                             yield->getOperands());
       return;
     }
+  }
+
+  auto changeFunc = [&](DistributionLayout *lattice, ChangeResult changed) {
+    this->propagateIfChanged(lattice, changed);
+  };
+
+  if (auto mask = dyn_cast<vector::MaskOp>(op)) {
+    visitMaskOp(mask, changeFunc);
+    return;
   }
 
   // TODO: Handle BranchOpInterface also.
@@ -1017,10 +1063,6 @@ void PropagateLayout::visitOperation(Operation *op) {
   if (resultLattices.empty()) {
     return;
   }
-
-  auto changeFunc = [&](DistributionLayout *lattice, ChangeResult changed) {
-    this->propagateIfChanged(lattice, changed);
-  };
 
   propagationTransferFunction(op, operandLattices, resultLattices, changeFunc);
 }
@@ -1094,6 +1136,34 @@ LogicalResult EnforceLayout::visit(ProgramPoint *point) {
   return failure();
 }
 
+void EnforceLayout::visitMaskOp(
+    vector::MaskOp mask,
+    std::function<void(DistributionLayout *, mlir::ChangeResult)> update) {
+  mask.getBody()->walk(
+      [&](Operation *traversed) { visitOperation(traversed); });
+  SmallVector<OpResult> vectorResults =
+      llvm::filter_to_vector(mask.getResults(), [](OpResult result) {
+        return isa<VectorType>(result.getType());
+      });
+  SmallVector<DistributionLayout *> resultLayouts = llvm::map_to_vector(
+      vectorResults, [&](Value result) -> DistributionLayout * {
+        return getLatticeElement(result);
+      });
+  SmallVector<Value> vectorYieldResults = llvm::filter_to_vector(
+      mask.getBody()->getTerminator()->getOperands(),
+      [](Value result) { return isa<VectorType>(result.getType()); });
+  SmallVector<DistributionLayout *> yieldLayouts = llvm::map_to_vector(
+      vectorYieldResults, [&](Value yieldResult) -> DistributionLayout * {
+        return getLatticeElement(yieldResult);
+      });
+  for (auto [result, yieldResult] : llvm::zip(resultLayouts, yieldLayouts)) {
+    if (!yieldResult->hasLayout() && !result->isUninitialized()) {
+      ChangeResult changed = yieldResult->resolve(result);
+      update(yieldResult, changed);
+    }
+  }
+}
+
 void EnforceLayout::visitOperation(Operation *op) {
   // Handle region branching control flow.
   // TODO: Write more about what we are doing here.
@@ -1109,6 +1179,15 @@ void EnforceLayout::visitOperation(Operation *op) {
                             yield->getOpOperands());
       return;
     }
+  }
+
+  auto changeFunc = [&](DistributionLayout *lattice, ChangeResult changed) {
+    this->propagateIfChanged(lattice, changed);
+  };
+
+  if (auto mask = dyn_cast<vector::MaskOp>(op)) {
+    visitMaskOp(mask, changeFunc);
+    return;
   }
 
   // TODO: Handle BranchOpInterface also.
@@ -1141,10 +1220,6 @@ void EnforceLayout::visitOperation(Operation *op) {
     DistributionLayout *resultLattice = getLatticeElement(result);
     resultLattices.push_back(resultLattice);
   }
-
-  auto changeFunc = [&](DistributionLayout *lattice, ChangeResult changed) {
-    this->propagateIfChanged(lattice, changed);
-  };
 
   enforcementTransferFunction(op, operandLattices, resultLattices, changeFunc);
 }


### PR DESCRIPTION
This commit enables vector layout propogation
into and out of vector.mask and its body.

Moreover, it enables the distribution of vector.multi_reduce
that is wrapped in a vector.mask.
The way that is done is :
* The distributed mask is applied to thread-local reduce
* The distributed operand is selected between the
  reduction identity and the provided operand using
  the distributed mask.

depends on : https://github.com/iree-org/iree/pull/19830 (hence putting to draft until thats merged)