### PR TITLE
Enable CUDA and ROCm backends in ci_linux_x64_clang.yml.

### DIFF
--- a/.github/workflows/ci_linux_x64_clang.yml
+++ b/.github/workflows/ci_linux_x64_clang.yml
@@ -43,6 +43,8 @@ jobs:
             -DIREE_ENABLE_LLD=ON \
             -DIREE_ENABLE_ASSERTIONS=ON \
             -DIREE_BUILD_DOCS=ON \
+            -DIREE_TARGET_BACKEND_CUDA=ON \
+            -DIREE_TARGET_BACKEND_ROCM=ON \
             -DIREE_TARGET_BACKEND_WEBGPU_SPIRV=ON
       - name: CMake - build
         run: |


### PR DESCRIPTION
These backends default to disabled, so enable them on this CI config. The backends are already tested in other jobs too.

I hoped this might help spot issues like https://github.com/iree-org/iree/issues/19875, but it doesn't seem that way.

| | Before | After |
-- | -- | --
Logs | [logs here](https://github.com/iree-org/iree/actions/runs/13118302608/job/36597989009) | [logs here](https://github.com/iree-org/iree/actions/runs/13118149869/job/36597451528?pr=19883)
Number of build targets | 8442 | 8715
Number of `iree-test-deps` targets | 1067 | 1336
Number of tests | 1538 | 1552


ci-exactly: linux_x64_clang