### PR TITLE
[GPU] Use tile and fuse for matmul after vector distribute by default

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -50,8 +50,8 @@
 #define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 namespace mlir::iree_compiler {
 
-llvm::cl::opt<bool> clGPUTestTileAndFuseMatmul(
-    "iree-codegen-llvmgpu-test-tile-and-fuse-matmul",
+llvm::cl::opt<bool> clGPUEarlyTileAndFuseMatmul(
+    "iree-codegen-llvmgpu-early-tile-and-fuse-matmul",
     llvm::cl::desc("test the the tile and fuse pipeline for matmul"),
     llvm::cl::init(false));
 
@@ -2340,7 +2340,7 @@ static LogicalResult setRootConfig(IREE::GPU::TargetAttr target,
     LDBG("Tile and fuse data tiled multi_mma config");
     return success();
   }
-  if (clGPUTestTileAndFuseMatmul) {
+  if (clGPUEarlyTileAndFuseMatmul) {
     if (succeeded(IREE::GPU::setMatmulLoweringConfig(target, entryPointFn,
                                                      computeOp))) {
       LDBG("Tile and fuse matmul config");
@@ -2362,6 +2362,13 @@ static LogicalResult setRootConfig(IREE::GPU::TargetAttr target,
     }
   }
   if (succeeded(setVectorDistributionConfig(target, entryPointFn, computeOp))) {
+    return success();
+  }
+  // TODO : remove this when tile and fuse backend config becomes the default
+  // for matmul.
+  if (succeeded(IREE::GPU::setMatmulLoweringConfig(target, entryPointFn,
+                                                   computeOp))) {
+    LDBG("Tile and fuse matmul config after no vector distribute config");
     return success();
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -2364,8 +2364,8 @@ static LogicalResult setRootConfig(IREE::GPU::TargetAttr target,
   if (succeeded(setVectorDistributionConfig(target, entryPointFn, computeOp))) {
     return success();
   }
-  // TODO : remove this when tile and fuse backend config becomes the default
-  // for matmul.
+  // TODO (nirvedhmeshram, qedawkins) : remove this when tile and fuse backend
+  // config becomes the default for matmul.
   if (succeeded(IREE::GPU::setMatmulLoweringConfig(target, entryPointFn,
                                                    computeOp))) {
     LDBG("Tile and fuse matmul config after no vector distribute config");


### PR DESCRIPTION
Currently some efforts such as https://github.com/iree-org/iree/pull/19854 and https://github.com/iree-org/iree/pull/19520 are ongoing to make the Tile and Fuse matmul pipeline on by default. However, these efforts are still WIP in achieving exact parity with the current default of Vector Distribute in all use cases. 
This PR in the time being tries Tile and Fuse after Vector Distribute so that we can get the benefits of tile and fuse such as handling unaligned to intrinsic shape while leaving the shapes that vector distribute handles untouched.
Fixes :  https://github.com/iree-org/iree/issues/19864
Progress towards: https://github.com/iree-org/iree/issues/19855

Note the for https://github.com/iree-org/iree/issues/19855 we also need https://github.com/iree-org/iree/pull/19857