### PR TITLE
[GPU] Skip tiling large transposes and copies

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileLargeTensors.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileLargeTensors.cpp
@@ -178,6 +178,14 @@ static void processRegion(RewriterBase &rewriter, Region *region,
 
       // Try to greedily tile + fuse linalg ops.
       if (auto linalgOp = dyn_cast<linalg::LinalgOp>(op)) {
+
+        // Skip copies and transposes. This is based on an expectation that such
+        // ops are introduced carefully and don't represent significant
+        // computation anyway. Equivalent generics are still tiled as they
+        // typically arise organically.
+        if (isa<linalg::TransposeOp, linalg::CopyOp>(op)) {
+          continue;
+        }
         tileToMaxVectorSize(rewriter, linalgOp, maxVectorSize);
         continue;
       }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_igemm_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_igemm_tile_and_fuse.mlir
@@ -148,5 +148,5 @@ hal.executable private @main {
 //          CHECK:     %[[LOOP_T:.+]] = vector.shape_cast %[[LOOP]] : vector<1x1x1x1x4x1xf32> to vector<4xf32>
 //          CHECK:     vector.transfer_write %[[LOOP_T]]
 // Note there is a writeback loop here that is skipped to simplify the test.
-//          CHECK:     vector.transfer_write {{.*}}, %[[B2]]
+//       CHECK:        memref.copy {{.*}}#gpu.address_space<workgroup>> to {{.*}}#hal.descriptor_type<storage_buffer>
 //          CHECK:   } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
@@ -1158,7 +1158,6 @@ hal.executable public @main {
 //       CHECK:     %[[LOOP_T:.+]] = vector.shape_cast %[[LOOP]] : vector<1x1x1x4x1xf32> to vector<4xf32>
 //       CHECK:     vector.transfer_write %[[LOOP_T]]
 //       CHECK:     scf.for {{.*}} {
-//       CHECK:       %[[SHARED_READ:.+]] = vector.transfer_read {{.*}} #gpu.address_space<workgroup>>, vector<1xf32>
-//       CHECK:       vector.transfer_write %[[SHARED_READ]], %[[B2]]
+//       CHECK:       memref.copy {{.*}}#gpu.address_space<workgroup>> to {{.*}}#hal.descriptor_type<storage_buffer>
 //       CHECK:    }
 //       CHECK:   } {mapping = [#iree_codegen.workgroup_mapping<z>, #iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}


### PR DESCRIPTION
`linalg.transpose` and `linalg.copy` are typically only introduced in carefully controlled situations and can sometimes exceed the "large vector" tiling threshold. To avoid unexpected loops in critical places, this patch disables large vector tiling of these ops.

This is somewhat of a WaR for a lack of good analysis of when "large tensors" cause the code to blow up vs when they are carefully chosen/intended sizes. A few possible future directions:

1. Propagation based pre-vectorization of ops we know are expected to vectorize (per the lowering configuration)
2. Region or annotation based exclusion from the TileLargeTensors pass
3. Improve this pass to consider bitwidths and compute regions