### PR TITLE
Fix mapping of CPU to CPU features on Arm64.

### DIFF
--- a/compiler/plugins/target/LLVMCPU/ResolveCPUAndCPUFeatures.h
+++ b/compiler/plugins/target/LLVMCPU/ResolveCPUAndCPUFeatures.h
@@ -14,6 +14,7 @@ namespace mlir::iree_compiler::IREE::HAL {
 
 enum class ResolveCPUAndCPUFeaturesStatus {
   OK,
+  UnknownCPU,
   InconsistentHost,
   UnimplementedMapping,
   ImplicitGenericFallback


### PR DESCRIPTION
The existing mapping only added the features that are default in the ARM architecture revision. For example, AppleM4 is ArmV8.7-a plus a bunch of additional features, and we were missing those additional features.