### PR TITLE
Enable ukernels on remaining aarch64 targets

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -186,10 +186,6 @@ static const char *getDefaultEnabledUkernels(Attribute attr) {
     return "mmt4d";
   }
   if (isAArch64(targetAttr)) {
-    if (hasFeature(targetAttr, "+sve") || hasFeature(targetAttr, "+sve2") ||
-        hasFeature(targetAttr, "+sme")) {
-      return kNone;
-    }
     return "mmt4d";
   }
   return kNone;


### PR DESCRIPTION
As newer aarch64 targets increasingly support SVE and SME, this clause was preventing ukernels from being used in cases where they do speed things up.  The reason why this logic was out of place here is that what it controls here is the enablement of ukernels, which are a detail of lowering an already tiled workload. If we wanted to use SVE with a variable vector length, or with a fixed vector length different from NEON's 128bit, that decision needed to be made earlier; conversely, if the workload at this point already has the right shaped to be matched to a NEON ukernel, then SVE is not relevant to it anymore.

FYI @ziereis , this results in substantially faster code in your test case from #19873.