### PR TITLE
 Bump llvm to llvm/llvm-project@c06d0ff806b7

### DIFF
--- a/compiler/plugins/target/CUDA/test/smoketest.mlir
+++ b/compiler/plugins/target/CUDA/test/smoketest.mlir
@@ -61,12 +61,12 @@ stream.executable public @mul_dispatch_executable {
 
 }
 
-// PTX: .entry add_dispatch
-// PTX: .maxntid 32, 1, 1
+// PTX: .func add_dispatch
+// FAILPTX: .maxntid 32, 1, 1
 // PTX:   add.rn.f32
 
-// PTX: .entry mul_dispatch
-// PTX: .maxntid 32, 1, 1
+// PTX: .func mul_dispatch
+// FAILPTX: .maxntid 32, 1, 1
 // PTX:   mul.rn.f32
 
 //      CHECK: hal.executable public @smoketest_linked

--- a/compiler/plugins/target/CUDA/test/smoketest.mlir
+++ b/compiler/plugins/target/CUDA/test/smoketest.mlir
@@ -61,12 +61,12 @@ stream.executable public @mul_dispatch_executable {
 
 }
 
-// PTX: .func add_dispatch
-// FAILPTX: .maxntid 32, 1, 1
+// PTX: .entry add_dispatch
+// PTX: .maxntid 32, 1, 1
 // PTX:   add.rn.f32
 
-// PTX: .func mul_dispatch
-// FAILPTX: .maxntid 32, 1, 1
+// PTX: .entry mul_dispatch
+// PTX: .maxntid 32, 1, 1
 // PTX:   mul.rn.f32
 
 //      CHECK: hal.executable public @smoketest_linked

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -964,14 +964,6 @@ DiagnosedSilenceableFailure transform_dialect::IREEBufferizeOp::apply(
     return listener.checkAndResetError();
   }
 
-  //   3. Post-bufferization passes are fine.
-  PassManager pm(getContext());
-  addIREEPostBufferizationPasses(pm);
-  if (failed(pm.run(target))) {
-    return mlir::emitDefiniteFailure(target)
-           << "post-bufferization passes failed";
-  }
-
   results.set(getOperation()->getOpResult(0), {target});
   return listener.checkAndResetError();
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/transform_dialect_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/transform_dialect_bufferize.mlir
@@ -35,7 +35,10 @@ module attributes {transform.with_named_sequence} {
     transform.print %8 : !transform.any_op
     transform.iree.eliminate_empty_tensors %8 : (!transform.any_op) -> ()
     %9 = transform.iree.bufferize %8 : (!transform.any_op) -> !transform.any_op
-    // %9 = transform.structured.match ops{["func.func"]} in %8 : (!transform.any_op) -> !transform.any_op
+    %10 = transform.structured.match ops{["func.func"]} in %9 : (!transform.any_op) -> !transform.op<"func.func">
+    transform.apply_patterns to %10 {
+      transform.apply_patterns.canonicalization
+    } : !transform.op<"func.func">
     transform.yield
   }
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_bufferize_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_bufferize_spec.mlir
@@ -4,10 +4,14 @@ module attributes { transform.with_named_sequence } {
     %tensor_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
     transform.iree.eliminate_empty_tensors %tensor_func : (!transform.any_op) -> ()
     %memref_func = transform.iree.bufferize %tensor_func : (!transform.any_op) -> !transform.any_op
+    %func_op_bufferized = transform.structured.match ops{["func.func"]} in %memref_func : (!transform.any_op) -> !transform.op<"func.func">
+    transform.apply_patterns to %func_op_bufferized {
+      transform.apply_patterns.canonicalization
+    } : !transform.op<"func.func">
 
     // Annotate the exported function as already translated.
     %none = transform.param.constant #iree_codegen.translation_info<pipeline = None> -> !transform.any_param
-    transform.annotate %memref_func "translation_info" = %none : !transform.any_op, !transform.any_param
+    transform.annotate %func_op_bufferized "translation_info" = %none : !transform.op<"func.func">, !transform.any_param
     transform.yield
   }
 } // module


### PR DESCRIPTION
Add local fixes to torch-mlir because of https://github.com/llvm/llvm-project/commit/956c0707d9098499a2682297b71f46b0a562eed9

Local revert commits:
- https://github.com/llvm/llvm-project/commit/327d627066e6452b081365b595657d17f2690a3b
- https://github.com/llvm/llvm-project/commit/de7438e472839df63e1f10478436c2f15b8e4184
- https://github.com/llvm/llvm-project/commit/3a3377579f137a0a6e14b60d891a9736707e7e8d

Additional changes:

- Switch DumpExecutableBenchmarks to use eliminateCommonSubExpressions.
- Remove cleanups (dynamic pass manager) from IREEBufferizeOp::apply

Because the dynamic pass pipeline triggers the below error. The dialects either need to be loaded or we need to initialize the objects before running the pass. The transform op is not a pass, which makes it much tricker. We follow what upstream does, which separate the cleanups, i.e., users need to clean the IR themselves. Upstream example: https://github.com/llvm/llvm-project/blob/cf9806eb4da23b42702aa88784969520702dae00/mlir/test/Integration/Dialect/Linalg/CPU/unpack-dynamic-inner-tile.mlir#L96-L104

```
Assertion failed: (impl->multiThreadedExecutionContext == 0 && "appending to the MLIRContext dialect registry while in a " "multi-threaded execution context"), function ap
pendDialectRegistry, file MLIRContext.cpp, line 403.
Please report issues to https://github.com/iree-org/iree/issues and include the crash backtrace.
Stack dump:
0.      Program arguments: build/tools/iree-opt --iree-transform-dialect-interpreter --transform-dialect-drop-schedule compiler/src/iree/compiler/Codegen/LLVMCPU/test/tran
sform_dialect_bufferize.mlir --mlir-disable-threading
```
