### PR TITLE
[NFC][GPU] Simplify definitions of MMA attributes

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPUTileSwizzleUtils.cpp
@@ -319,7 +319,7 @@ static TileSwizzle
 getSwizzleBeforeMovingCrossThreadOutermost(IREE::GPU::DataTiledMMAAttr mma,
                                            IREE::GPU::MMAFragment fragment) {
   auto swizzle = getIntrinsicSwizzleBeforeMovingCrossThreadOutermost(
-      mma.getIntrinsic().getValue(), fragment);
+      mma.getIntrinsic(), fragment);
   switch (fragment) {
   case IREE::GPU::MMAFragment::Lhs:
     // A-matrix (LHS). Source dimensions are M (index 0) and K (index 1).

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -318,6 +318,16 @@ getMNKShapeFromIntrinsic(MMAIntrinsic intrinsic) {
   return getUnsupportedMNKShape(intrinsic);
 }
 
+int64_t getMSize(MMAIntrinsic intrinsic) {
+  return std::get<0>(getMNKShapeFromIntrinsic(intrinsic));
+}
+int64_t getNSize(MMAIntrinsic intrinsic) {
+  return std::get<1>(getMNKShapeFromIntrinsic(intrinsic));
+}
+int64_t getKSize(MMAIntrinsic intrinsic) {
+  return std::get<2>(getMNKShapeFromIntrinsic(intrinsic));
+}
+
 static OpaqueMmaLayout getOpaqueMMALayout(MLIRContext *context,
                                           MMAIntrinsic intrinsic) {
   OpaqueMmaLayout o;

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.cpp
@@ -306,30 +306,33 @@ struct OpaqueMmaLayout {
   Type cType;
 };
 
+static std::tuple<int64_t, int64_t, int64_t>
+getMNKShapeFromIntrinsic(MMAIntrinsic intrinsic) {
+  if (is_AMD(intrinsic)) {
+    auto lhs = getSingleSubgroupLayout(intrinsic, MMAFragment::Lhs);
+    auto rhs = getSingleSubgroupLayout(intrinsic, MMAFragment::Rhs);
+    return {lhs.outer[0] * lhs.thread[0] * lhs.element[0],
+            rhs.outer[1] * rhs.thread[1] * rhs.element[1],
+            lhs.outer[1] * lhs.thread[1] * lhs.element[1]};
+  }
+  return getUnsupportedMNKShape(intrinsic);
+}
+
 static OpaqueMmaLayout getOpaqueMMALayout(MLIRContext *context,
                                           MMAIntrinsic intrinsic) {
   OpaqueMmaLayout o;
   std::tie(o.aType, o.bType, o.cType) = getABCElementTypes(context, intrinsic);
-  if (is_AMD(intrinsic)) {
-    auto lhs = getSingleSubgroupLayout(intrinsic, MMAFragment::Lhs);
-    auto rhs = getSingleSubgroupLayout(intrinsic, MMAFragment::Rhs);
-    o.mSize = lhs.outer[0] * lhs.thread[0] * lhs.element[0];
-    o.kSize = lhs.outer[1] * lhs.thread[1] * lhs.element[1];
-    o.nSize = rhs.outer[1] * rhs.thread[1] * rhs.element[1];
-  } else {
-    std::tie(o.mSize, o.nSize, o.kSize) = getUnsupportedMNKShape(intrinsic);
-  }
+  std::tie(o.mSize, o.nSize, o.kSize) = getMNKShapeFromIntrinsic(intrinsic);
   return o;
 }
 
 MMASingleSubgroupLayout getSingleSubgroupLayout(MmaInterfaceAttr mmaKind,
                                                 MMAFragment fragment) {
   if (auto mmaAttr = dyn_cast<MMAAttr>(mmaKind)) {
-    return getSingleSubgroupLayout(mmaAttr.getIntrinsic().getValue(), fragment);
+    return getSingleSubgroupLayout(mmaAttr.getIntrinsic(), fragment);
   }
   if (auto vmmaAttr = dyn_cast<VirtualMMAAttr>(mmaKind)) {
-    return getSingleSubgroupLayout(vmmaAttr.getIntrinsic().getValue(),
-                                   fragment);
+    return getSingleSubgroupLayout(vmmaAttr.getIntrinsic(), fragment);
   }
   assert(false && "unhandled MMA Interface type.");
   return {};
@@ -339,43 +342,12 @@ MMASingleSubgroupLayout getSingleSubgroupLayout(MmaInterfaceAttr mmaKind,
 // MMA Attributes
 //===----------------------------------------------------------------------===//
 
-Attribute MMAAttr::parse(AsmParser &p, Type type) {
-  if (failed(p.parseLess()))
-    return {};
-
-  FailureOr<MMAIntrinsicAttr> mmaIntrinsic =
-      FieldParser<MMAIntrinsicAttr>::parse(p);
-  if (failed(mmaIntrinsic)) {
-    p.emitError(p.getCurrentLocation(), "failed to parse mfma type identifier");
-    return {};
-  }
-
-  if (failed(p.parseGreater()))
-    return {};
-
-  return get(p.getContext(), mmaIntrinsic->getValue());
-}
-
-void MMAAttr::print(AsmPrinter &p) const {
-  auto &os = p.getStream();
-  os << "<";
-  os << stringifyMMAIntrinsic(getIntrinsic().getValue());
-  os << ">";
-}
-
-MMAAttr MMAAttr::get(MLIRContext *context, MMAIntrinsic type) {
-  auto layout = getOpaqueMMALayout(context, type);
-  return Base::get(context, MMAIntrinsicAttr::get(context, type), layout.mSize,
-                   layout.nSize, layout.kSize, layout.aType, layout.bType,
-                   layout.cType);
-}
-
 std::tuple<Type, Type, Type> MMAAttr::getABCElementTypes() const {
-  return {getAType(), getBType(), getCType()};
+  return IREE::GPU::getABCElementTypes(getContext(), getIntrinsic());
 }
 
 std::tuple<int64_t, int64_t, int64_t> MMAAttr::getMNKShape() const {
-  return {getMSize(), getNSize(), getKSize()};
+  return getMNKShapeFromIntrinsic(getIntrinsic());
 }
 
 template <typename MMAIntrinsicType>
@@ -394,7 +366,7 @@ static VectorType getVectorType(MLIRContext *context,
 std::tuple<VectorType, VectorType, VectorType>
 MMAAttr::getABCVectorTypes() const {
   MLIRContext *context = getContext();
-  MMAIntrinsic intrinsic = getIntrinsic().getValue();
+  MMAIntrinsic intrinsic = getIntrinsic();
   VectorType aVecType = getVectorType(context, intrinsic, MMAFragment::Lhs);
   VectorType bVecType = getVectorType(context, intrinsic, MMAFragment::Rhs);
   VectorType cVecType = getVectorType(context, intrinsic, MMAFragment::Acc);
@@ -402,16 +374,16 @@ MMAAttr::getABCVectorTypes() const {
 }
 
 int64_t MMAAttr::getBlockSize() const {
-  return IREE::GPU::getBlockSize(getIntrinsic().getValue());
+  return IREE::GPU::getBlockSize(getIntrinsic());
 }
 
 int64_t MMAAttr::getSubgroupSize() const {
-  return getIntrinsicSubgroupSize(getIntrinsic().getValue());
+  return getIntrinsicSubgroupSize(getIntrinsic());
 }
 
 FailureOr<IREE::GPU::MMAScope> MMAAttr::getMmaScope() const {
   // Explicit distribution currently unsupported for NV intrinsics.
-  MMAIntrinsic intrinsic = getIntrinsic().getValue();
+  MMAIntrinsic intrinsic = getIntrinsic();
   if (intrinsic == MMAIntrinsic::NV_WMMA_F16_16x16x16_F16 ||
       intrinsic == MMAIntrinsic::NV_WMMA_F32_16x16x16_F16) {
     return failure();
@@ -421,7 +393,7 @@ FailureOr<IREE::GPU::MMAScope> MMAAttr::getMmaScope() const {
 
 // Get virtual intrinsics that is composed/based on queried op.
 SmallVector<VirtualMMAIntrinsic> MMAAttr::getVirtualIntrinsics() const {
-  switch (getIntrinsic().getValue()) {
+  switch (getIntrinsic()) {
   case MMAIntrinsic::MFMA_F32_16x16x16_F16:
     return {VirtualMMAIntrinsic::VMFMA_F32_16x16x32_F16};
   case MMAIntrinsic::MFMA_F32_32x32x8_F16:
@@ -475,8 +447,8 @@ FailureOr<Value> MMAAttr::buildMmaOperation(OpBuilder &builder, Location loc,
   if (cType != resultType) {
     return failure();
   }
-  if (Value value = createMmaOp(builder, loc, getIntrinsic().getValue(),
-                                resultType, lhs, rhs, acc)) {
+  if (Value value = createMmaOp(builder, loc, getIntrinsic(), resultType, lhs,
+                                rhs, acc)) {
     return value;
   }
   return failure();
@@ -562,7 +534,7 @@ LogicalResult MMAAttr::populateOperandOffsetsSizesStrides(
     SmallVector<OpFoldResult> &strides) const {
 
   MMASingleSubgroupLayout subgroupLayout =
-      getSingleSubgroupLayout(getIntrinsic().getValue(), fragment);
+      getSingleSubgroupLayout(getIntrinsic(), fragment);
   SmallVector<OpFoldResult> canonicalOffsets;
   SmallVector<OpFoldResult> canonicalSizes;
   if (failed(populateCanonicalOffsetsSizesAndStrides(
@@ -597,13 +569,13 @@ sliceSwizzledShape(const TileSwizzle &swizzle,
 
 std::tuple<Type, Type, Type> DataTiledMMAAttr::getABCElementTypes() const {
   MLIRContext *ctx = getContext();
-  auto opaqueLayout = getOpaqueMMALayout(ctx, getIntrinsic().getValue());
+  auto opaqueLayout = getOpaqueMMALayout(ctx, getIntrinsic());
   return {opaqueLayout.aType, opaqueLayout.bType, opaqueLayout.cType};
 }
 
 std::tuple<int64_t, int64_t, int64_t> DataTiledMMAAttr::getMNKShape() const {
   MLIRContext *ctx = getContext();
-  auto opaqueLayout = getOpaqueMMALayout(ctx, getIntrinsic().getValue());
+  auto opaqueLayout = getOpaqueMMALayout(ctx, getIntrinsic());
   return {opaqueLayout.mSize * getIntrinsicsM() * getSubgroupsM(),
           opaqueLayout.nSize * getIntrinsicsN() * getSubgroupsN(),
           opaqueLayout.kSize * getIntrinsicsK()};
@@ -624,7 +596,7 @@ DataTiledMMAAttr::getABCVectorTypes() const {
 }
 
 int64_t DataTiledMMAAttr::getSubgroupSize() const {
-  return getIntrinsicSubgroupSize(getIntrinsic().getValue());
+  return getIntrinsicSubgroupSize(getIntrinsic());
 }
 
 FailureOr<IREE::GPU::MMAScope> DataTiledMMAAttr::getMmaScope() const {
@@ -672,8 +644,7 @@ LogicalResult DataTiledMMAAttr::populateOperandOffsetsSizesStrides(
   // In layoutThreadSizes, intrinsic level dimensions are mixed with expansion
   // to multiple subgroups, so in order to tell if there are additional
   // distribution-only thread dimensions, we need to get back to the intrinsic.
-  TileSwizzle intrinsicSwizzle =
-      getIntrinsicSwizzle(getIntrinsic().getValue(), fragment);
+  TileSwizzle intrinsicSwizzle = getIntrinsicSwizzle(getIntrinsic(), fragment);
 
   SmallVector<int64_t> intrinsicLayoutThreadSizes =
       sliceSwizzledShape(intrinsicSwizzle, [](TileSwizzle::Dim d) {
@@ -826,7 +797,7 @@ FailureOr<Value> DataTiledMMAAttr::buildMmaOperation(OpBuilder &builder,
   SmallVector<Value> intrinsicsAcc =
       distributeMmaFragmentToIntrinsics(builder, loc, acc, accSwizzle);
 
-  MMAIntrinsic intrinsic = getIntrinsic().getValue();
+  MMAIntrinsic intrinsic = getIntrinsic();
   VectorType intrinCType =
       getVectorType(builder.getContext(), intrinsic, MMAFragment::Acc);
 
@@ -877,12 +848,6 @@ FailureOr<Value> DataTiledMMAAttr::buildMmaOperation(OpBuilder &builder,
 //===----------------------------------------------------------------------===//
 // VirtualMMA Attributes
 //===----------------------------------------------------------------------===//
-
-VirtualMMAAttr VirtualMMAAttr::get(MLIRContext *context,
-                                   VirtualMMAIntrinsic type) {
-  auto intrinsicAttr = VirtualMMAIntrinsicAttr::get(context, type);
-  return VirtualMMAAttr::get(context, intrinsicAttr);
-}
 
 static std::tuple<int64_t, int64_t, int64_t>
 getMNKShape(VirtualMMAIntrinsic type) {
@@ -936,14 +901,14 @@ static OpaqueMmaLayout getOpaqueMMALayout(MLIRContext *context,
 
 std::tuple<Type, Type, Type> VirtualMMAAttr::getABCElementTypes() const {
   MLIRContext *ctx = getContext();
-  auto opaqueLayout = getOpaqueMMALayout(ctx, getIntrinsic().getValue());
+  auto opaqueLayout = getOpaqueMMALayout(ctx, getIntrinsic());
   return {opaqueLayout.aType, opaqueLayout.bType, opaqueLayout.cType};
 }
 
 std::tuple<VectorType, VectorType, VectorType>
 VirtualMMAAttr::getABCVectorTypes() const {
   MLIRContext *context = getContext();
-  VirtualMMAIntrinsic intrinsic = getIntrinsic().getValue();
+  VirtualMMAIntrinsic intrinsic = getIntrinsic();
   VectorType aVecType = getVectorType(context, intrinsic, MMAFragment::Lhs);
   VectorType bVecType = getVectorType(context, intrinsic, MMAFragment::Rhs);
   VectorType cVecType = getVectorType(context, intrinsic, MMAFragment::Acc);
@@ -952,12 +917,12 @@ VirtualMMAAttr::getABCVectorTypes() const {
 
 std::tuple<int64_t, int64_t, int64_t> VirtualMMAAttr::getMNKShape() const {
   MLIRContext *ctx = getContext();
-  auto opaqueLayout = getOpaqueMMALayout(ctx, getIntrinsic().getValue());
+  auto opaqueLayout = getOpaqueMMALayout(ctx, getIntrinsic());
   return {opaqueLayout.mSize, opaqueLayout.nSize, opaqueLayout.kSize};
 }
 
 int64_t VirtualMMAAttr::getSubgroupSize() const {
-  switch (getIntrinsic().getValue()) {
+  switch (getIntrinsic()) {
   case VirtualMMAIntrinsic::VMFMA_F32_16x16x32_F8E4M3FNUZ:
   case VirtualMMAIntrinsic::VMFMA_F32_16x16x32_F16:
   case VirtualMMAIntrinsic::VMFMA_F32_32x32x16_F8E4M3FNUZ:
@@ -980,7 +945,7 @@ LogicalResult VirtualMMAAttr::populateOperandOffsetsSizesStrides(
     SmallVector<OpFoldResult> &strides) const {
 
   MMASingleSubgroupLayout subgroupLayout =
-      getSingleSubgroupLayout(getIntrinsic().getValue(), fragment);
+      getSingleSubgroupLayout(getIntrinsic(), fragment);
   SmallVector<OpFoldResult> canonicalOffsets;
   SmallVector<OpFoldResult> canonicalSizes;
   if (failed(populateCanonicalOffsetsSizesAndStrides(
@@ -995,7 +960,7 @@ LogicalResult VirtualMMAAttr::populateOperandOffsetsSizesStrides(
 }
 
 int64_t VirtualMMAAttr::getIntrinsicsK() const {
-  switch (getIntrinsic().getValue()) {
+  switch (getIntrinsic()) {
   case VirtualMMAIntrinsic::VMFMA_F32_16x16x32_F16:
   case VirtualMMAIntrinsic::VMFMA_F32_32x32x16_F16: {
     return 2;
@@ -1025,7 +990,7 @@ FailureOr<Value> VirtualMMAAttr::buildMmaOperation(OpBuilder &builder,
   if (cType != resultType) {
     return failure();
   }
-  switch (getIntrinsic().getValue()) {
+  switch (getIntrinsic()) {
   case VirtualMMAIntrinsic::VMFMA_F32_16x16x32_F8E4M3FNUZ:
   case VirtualMMAIntrinsic::VMFMA_F32_16x16x32_F16:
   case VirtualMMAIntrinsic::VMFMA_F32_32x32x16_F8E4M3FNUZ:
@@ -1064,7 +1029,7 @@ FailureOr<Value> VirtualMMAAttr::buildMmaOperation(OpBuilder &builder,
 }
 
 int64_t VirtualMMAAttr::getBlockSize() const {
-  switch (getIntrinsic().getValue()) {
+  switch (getIntrinsic()) {
   case VirtualMMAIntrinsic::VMFMA_F32_16x16x32_F8E4M3FNUZ:
   case VirtualMMAIntrinsic::VMFMA_F32_16x16x32_F16:
   case VirtualMMAIntrinsic::VMFMA_F32_32x32x16_F8E4M3FNUZ:

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h
@@ -59,6 +59,10 @@ struct MMASingleSubgroupLayout {
   SmallVector<int64_t, 2> element;
 };
 
+int64_t getMSize(MMAIntrinsic intrinsic);
+int64_t getNSize(MMAIntrinsic intrinsic);
+int64_t getKSize(MMAIntrinsic intrinsic);
+
 MMASingleSubgroupLayout getSingleSubgroupLayout(MMAIntrinsic intrinsic,
                                                 MMAFragment fragment);
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -115,52 +115,6 @@ def IREEGPU_DotProductOpsAttr : EnumAttr<
 }
 
 //===----------------------------------------------------------------------===//
-// Base MMA vector layout
-//===----------------------------------------------------------------------===//
-
-class IREEGPU_MmaVectorLayoutAttr<string attrname, string mmaintrinsic> :
-    AttrDef<IREEGPU_Dialect, attrname, [
-  DeclareAttrInterfaceMethods<IREEGPU_MmaInterfaceAttr, [
-    "getABCElementTypes",
-    "getABCVectorTypes",
-    "getMNKShape",
-    "getSubgroupSize",
-    "getMmaScope",
-    "buildMmaOperation",
-    "populateOperandOffsetsSizesStrides",
-  ]>
-]> {
-  let cppNamespace = "::mlir::iree_compiler::IREE::GPU";
-
-  string baseDescription = [{
-    Attribute describing a particular shape of matrix-multiply and accumulate
-    instruction. Abstractly, all attributes of this type represent the following
-    unit of arithmetic for matrices A, B, and C.
-
-    ```
-      C += A x B
-    ```
-
-    Where the shape of matrix `A` is `[m, k]`, `B` is `[k, n]`, and
-    `C` is `[m, n]`. This intentionally leaves the layout information abstract
-    and uses interface methods to materialize layout information only when
-    needed. The shape of the mma intrinsic is stored explicitly here as that
-    information is queried frequently.
-
-    The element types for this particular mma intrinsic are |aType|, |bType|,
-    and |cType| for matrices `A`, `B`, and `C` respectively.
-
-    ######
-
-  }];
-
-
-  let parameters = (ins
-    mmaintrinsic:$intrinsic
-  );
-}
-
-//===----------------------------------------------------------------------===//
 // MMA intrinsic
 //===----------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -207,16 +207,6 @@ def IREEGPU_MMAAttr : AttrDef<IREEGPU_Dialect, "MMA", [
   let extraClassDeclaration = [{
     int64_t getBlockSize() const;
 
-    int64_t getMSize() const {
-      return std::get<0>(getMNKShape());
-    }
-    int64_t getNSize() const {
-      return std::get<1>(getMNKShape());
-    }
-    int64_t getKSize() const {
-      return std::get<2>(getMNKShape());
-    }
-
     SmallVector<VirtualMMAIntrinsic> getVirtualIntrinsics() const;
   }];
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -156,13 +156,7 @@ class IREEGPU_MmaVectorLayoutAttr<string attrname, string mmaintrinsic> :
 
 
   let parameters = (ins
-    mmaintrinsic:$intrinsic,
-    "int64_t":$mSize,
-    "int64_t":$nSize,
-    "int64_t":$kSize,
-    "::mlir::Type":$aType,
-    "::mlir::Type":$bType,
-    "::mlir::Type":$cType
+    mmaintrinsic:$intrinsic
   );
 }
 
@@ -176,26 +170,52 @@ class IREEGPU_MmaEnumAttr<EnumAttrInfo enumInfo, string name = "">
 def IREEGPU_MMAIntrinsicAttr
   : IREEGPU_MmaEnumAttr<IREEGPU_MMAIntrinsic, "mma_intrinsic">;
 
-def IREEGPU_MMAAttr : IREEGPU_MmaVectorLayoutAttr<"MMA", "MMAIntrinsicAttr"> {
+def IREEGPU_MMAAttr : AttrDef<IREEGPU_Dialect, "MMA", [
+  DeclareAttrInterfaceMethods<IREEGPU_MmaInterfaceAttr, [
+    "getABCElementTypes",
+    "getABCVectorTypes",
+    "getMNKShape",
+    "getSubgroupSize",
+    "getMmaScope",
+    "buildMmaOperation",
+    "populateOperandOffsetsSizesStrides",
+  ]>
+]> {
   let mnemonic = "mma_layout";
   let cppNamespace = "::mlir::iree_compiler::IREE::GPU";
 
-  let description = !strconcat(baseDescription, [{
-    This mma variant describes configurations for MMA ops. The |intrinsic|
-    field specifies which particular MMA intrinsic this refers to, with each
-    intrinsic implicating a specific MNK shape and operand types.
+  let description = [{
+    Attribute describing a particular shape of matrix-multiply and accumulate
+    instruction. Abstractly, all attributes of this type represent the following
+    unit of arithmetic for matrices A, B, and C.
+
+    ```
+      C += A x B
+    ```
+
+    The |intrinsic| field specifies which particular MMA intrinsic this refers
+    to, with each intrinsic implicating a specific MNK shape and operand types.
     See IREEGPUEnums.td for the definition of the intrinsics.
-  }]);
+  }];
 
-  let hasCustomAssemblyFormat = 1;
+  let parameters = (ins
+    EnumParameter<IREEGPU_MMAIntrinsic>:$intrinsic
+  );
 
-  let skipDefaultBuilders = 1;
-  let builders = [
-    AttrBuilder<(ins "MMAIntrinsic":$intrinsic)>
-  ];
+  let assemblyFormat = "`<` params `>`";
 
   let extraClassDeclaration = [{
     int64_t getBlockSize() const;
+
+    int64_t getMSize() const {
+      return std::get<0>(getMNKShape());
+    }
+    int64_t getNSize() const {
+      return std::get<1>(getMNKShape());
+    }
+    int64_t getKSize() const {
+      return std::get<2>(getMNKShape());
+    }
 
     SmallVector<VirtualMMAIntrinsic> getVirtualIntrinsics() const;
   }];
@@ -231,7 +251,7 @@ def IREEGPU_DataTiledMMAAttr :
   let assemblyFormat = "`<` struct(params) `>`";
 
   let parameters = (ins
-    "::mlir::iree_compiler::IREE::GPU::MMAIntrinsicAttr":$intrinsic,
+    EnumParameter<IREEGPU_MMAIntrinsic>:$intrinsic,
     DefaultValuedParameter<"int64_t", "1", "Intrinsic count along the M dimension.">:$intrinsics_m,
     DefaultValuedParameter<"int64_t", "1", "Subgroup count along the M dimension.">:$subgroups_m,
     DefaultValuedParameter<"int64_t", "1", "Intrinsic count along the N dimension.">:$intrinsics_n,
@@ -269,12 +289,9 @@ def IREEGPU_VirtualMMAAttr :
   }];
 
   let assemblyFormat = "`<` struct(params) `>`";
-  let builders = [
-    AttrBuilder<(ins "VirtualMMAIntrinsic":$intrinsic)>
-  ];
 
   let parameters = (ins
-    "::mlir::iree_compiler::IREE::GPU::VirtualMMAIntrinsicAttr":$intrinsic
+    EnumParameter<IREEGPU_VirtualMMAIntrinsic>:$intrinsic
   );
 
   let extraClassDeclaration = [{

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -62,7 +62,8 @@ static MMAAttr chooseIntrinsicMMAAttr(TypeRange eTypes, TargetWgpAttr wgp) {
     // which would optimize performance when power is not the bottleneck.
     // Currently we just choose the intrinsic maximizing K, but that can be
     // revisited later.
-    if (candidateMma && candidateMma.getKSize() > mma.getKSize()) {
+    if (candidateMma &&
+        getKSize(candidateMma.getIntrinsic()) > getKSize(mma.getIntrinsic())) {
       continue;
     }
     candidateMma = mma;
@@ -202,16 +203,18 @@ chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
       IREE::Encoding::getMatmulNarrowDim(encoding);
   if (narrowDim.isM()) {
     intrinsicsM =
-        std::min(intrinsicsM, static_cast<int>(llvm::divideCeil(
-                                  narrowDim.size, intrinsicMma.getMSize())));
+        std::min(intrinsicsM,
+                 static_cast<int>(llvm::divideCeil(
+                     narrowDim.size, getMSize(intrinsicMma.getIntrinsic()))));
   }
   if (narrowDim.isN()) {
     std::swap(intrinsicsM, intrinsicsN);
     std::swap(subgroupsM, subgroupsN);
     assert(subgroupsN == 1);
     intrinsicsN =
-        std::min(intrinsicsN, static_cast<int>(llvm::divideCeil(
-                                  narrowDim.size, intrinsicMma.getNSize())));
+        std::min(intrinsicsN,
+                 static_cast<int>(llvm::divideCeil(
+                     narrowDim.size, getNSize(intrinsicMma.getIntrinsic()))));
   }
 
   return DataTiledMMAAttr::get(ctx, intrinsicMma.getIntrinsic(), intrinsicsM,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUSelectUKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUSelectUKernels.cpp
@@ -46,8 +46,7 @@ getUKernelNameAndSuffixForMultiMma(IREE::GPU::MultiMmaOp op) {
   if (!mma) {
     return {}; // Only handling DataTiledMMAAttr for now.
   }
-  return {"multi_mma",
-          stringifyMMAIntrinsic(mma.getIntrinsic().getValue()).lower()};
+  return {"multi_mma", stringifyMMAIntrinsic(mma.getIntrinsic()).lower()};
 }
 
 // Returns ukernel name and suffix for any op. Empty name = no ukernel.

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -1008,7 +1008,7 @@ queryMMAIntrinsics(IREE::HAL::ExecutableVariantOp executableOp) {
   if (IREE::GPU::TargetAttr target = getGPUTargetAttr(executableOp)) {
     mmaIntrinsics = llvm::map_to_vector(
         target.getWgp().getMma(),
-        [](IREE::GPU::MMAAttr attr) { return attr.getIntrinsic().getValue(); });
+        [](IREE::GPU::MMAAttr attr) { return attr.getIntrinsic(); });
   }
   return mmaIntrinsics;
 }


### PR DESCRIPTION
The tablegen had some strange auto-generated polymorphism with implicit parsing of certain fields. None of it provided any benefit and is simplified down to just the MMA enum. Also replaces the enum with an enum parameter removing the extra `.getValue()` indirection when accessing the enum.