### PR TITLE
Silence false-positive warnings about implicit CPU fallback.

### DIFF
--- a/compiler/plugins/target/LLVMCPU/LLVMTargetOptions.cpp
+++ b/compiler/plugins/target/LLVMCPU/LLVMTargetOptions.cpp
@@ -607,7 +607,13 @@ LLVMTargetOptions LLVMCPUTargetCLOptions::getTargetOptions() {
   ResolveCPUAndCPUFeaturesStatus status;
   std::optional<LLVMTarget> maybeTarget = LLVMTarget::create(
       targetTriple, targetCPU, targetCPUFeatures, linkEmbedded, status);
-  if (status != ResolveCPUAndCPUFeaturesStatus::OK) {
+  // Only report serious errors here, not potentially verbose warnings such as
+  // ImplicitGenericFallback, which has false positives at this point as it
+  // triggers on default-constructed targets that we might not actually use.
+  // If the targets are used, they will trigger the warning again in
+  // LLVMTarget::loadFromConfigAttr.
+  if (status != ResolveCPUAndCPUFeaturesStatus::OK &&
+      status != ResolveCPUAndCPUFeaturesStatus::ImplicitGenericFallback) {
     llvm::errs() << getMessage(status, targetTriple);
   }
   if (maybeTarget) {


### PR DESCRIPTION
In https://github.com/iree-org/iree/pull/19902 we added reporting of errors in `LLVMCPUTargetCLOptions::getTargetOptions` which allows reporting things like an unknown CPU before that causes assertion failures in LLVM. But we mistakenly also reported there the warning about the implicit CPU fallback, which is a false positive in this case as it triggers on default targets that we may not actually use.