### PR TITLE
[Util] Update Utils.cpp to address compilation error (#17593)

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -1759,6 +1759,9 @@ std::optional<VectorizationTileSizes> inferSizesFromIR(tensor::UnPackOp op) {
 }
 
 std::optional<VectorizationTileSizes> inferSizesFromIR(Value val) {
+  if (!val.getDefiningOp())
+    return std::nullopt;
+
   std::optional<VectorizationTileSizes> result;
   TypeSwitch<Operation *, void>(val.getDefiningOp())
       .Case<linalg::LinalgOp>(


### PR DESCRIPTION
#17593

while reproducing this, I was caught by an error
`unpack.mlir`
```mlir
func.func @unpack(%arg0: tensor<1x5x2x64xf32>) -> tensor<2x320xf32> {
  %0 = tensor.empty() : tensor<2x320xf32>
  %unpack = tensor.unpack %arg0 outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [2, 64] into %0 : tensor<1x5x2x64xf32> -> tensor<2x320xf32>
  return %unpack : tensor<2x320xf32>
}
```
 
exec script:
```
iree-opt --mlir-print-ir-before-all --mlir-pretty-debuginfo \
--pass-pipeline="builtin.module(func.func(iree-codegen-generic-vectorization{enable-vector-masking=true}))" \
--split-input-file  unpack.mlir
```


Compilation error workaround
