### PR TITLE
Drop nanobind workaround

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -649,11 +649,6 @@ if(IREE_BUILD_PYTHON_BINDINGS)
   # can be troublesome. Note that nanobind requires FindPython.
   set(Python_EXECUTABLE "${Python3_EXECUTABLE}")
   find_package(Python 3.9 COMPONENTS Interpreter Development.Module NumPy REQUIRED)
-  if(APPLE)
-    # Workaround for upstream using PyClassMethod_New but nanobind not being aware
-    # see https://github.com/iree-org/iree/issues/19591
-    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-U -Wl,_PyClassMethod_New")
-  endif()
 elseif(IREE_BUILD_COMPILER OR IREE_BUILD_TESTS)
   find_package(Python3 COMPONENTS Interpreter REQUIRED)
   set(Python_EXECUTABLE "${Python3_EXECUTABLE}")


### PR DESCRIPTION
This drops the workaround to set linker flags to work around the issue when building the compiler Python bindings for macOS as this is fixed upstream as soon as llvm/llvm-project#125733 lands and was integrated into IREE's llvm fork.

Closes #19591