### PR TITLE
Fix up polynomial approximation pass logic

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/PolynomialApproximationPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/PolynomialApproximationPass.cpp
@@ -27,13 +27,7 @@ static llvm::cl::opt<bool> clNativeMathPrecision(
 namespace {
 
 static void populateErfPattern(RewritePatternSet &patterns) {
-  if (clNativeMathPrecision) {
-    patterns.add<math::ErfPolynomialApproximation>(patterns.getContext());
-  } else {
-    populateExpandExp2FPattern(patterns);
-    populateMathPolynomialApproximationPatterns(patterns);
-    populateExpandRoundEvenPattern(patterns);
-  }
+  patterns.add<math::ErfPolynomialApproximation>(patterns.getContext());
 }
 
 /// math dialect elementry functions -> polynomial form.
@@ -62,7 +56,7 @@ public:
 
     for (const auto &[fnName, populateFn] : patternMap) {
       // Skip any ops in the "do not convert" list.
-      if (!llvm::is_contained(noApproxOps, fnName)) {
+      if (!llvm::is_contained(noApproxOps, fnName) && !clNativeMathPrecision) {
         populateFn(mathPatterns);
       }
     }


### PR DESCRIPTION
The `clNativeMathPrecision` option had no effect because both branches of the `if` had the same effect of adding the `math::ErfPolynomialApproximation` pattern. It seems a contradiction of the command line option that the pattern was being added in the `if` branch. The other things done in the `else` branch didn't seem to have an effect anyway.

Since that command-line option is a switch applying to all math functions, it was best handled one level up anyway.