### PR TITLE
Skip flaky iree-dump-parameters test on Windows.

### DIFF
--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -126,6 +126,7 @@ if [[ "${OSTYPE}" =~ ^msys ]]; then
     "iree/tests/e2e/tosa_ops/check_vmvx_local-sync_microkernels_matmul.mlir"
     # Flaky on CI for unknown reasons, skip.
     "iree/tools/test/iree-dump-parameters.txt.test"
+    "iree/tools/test/parameters_unscoped.mlir.test"
   )
 elif [[ "${OSTYPE}" =~ ^darwin ]]; then
   excluded_tests+=(

--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -124,6 +124,8 @@ if [[ "${OSTYPE}" =~ ^msys ]]; then
     # TODO(#11070): Fix argument/result signature mismatch
     "iree/tests/e2e/tosa_ops/check_vmvx_local-sync_microkernels_fully_connected.mlir"
     "iree/tests/e2e/tosa_ops/check_vmvx_local-sync_microkernels_matmul.mlir"
+    # Flaky on CI for unknown reasons, skip.
+    "iree/tools/test/iree-dump-parameters.txt.test"
   )
 elif [[ "${OSTYPE}" =~ ^darwin ]]; then
   excluded_tests+=(

--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -124,8 +124,10 @@ if [[ "${OSTYPE}" =~ ^msys ]]; then
     # TODO(#11070): Fix argument/result signature mismatch
     "iree/tests/e2e/tosa_ops/check_vmvx_local-sync_microkernels_fully_connected.mlir"
     "iree/tests/e2e/tosa_ops/check_vmvx_local-sync_microkernels_matmul.mlir"
-    # Flaky on CI for unknown reasons, skip.
+    # Flaky on CI opening the .safetensors testdata for unknown reasons, skip.
+    "iree/tools/test/iree-convert-parameters.txt.test"
     "iree/tools/test/iree-dump-parameters.txt.test"
+    "iree/tools/test/parameters_scoped.mlir.test"
     "iree/tools/test/parameters_unscoped.mlir.test"
   )
 elif [[ "${OSTYPE}" =~ ^darwin ]]; then


### PR DESCRIPTION
This test is flaky on CI. I can't reproduce the issue locally and I'm not sure why the file would not be found or would have errors being opened. Maybe due to too much ctest parallelism?

Sample logs:

* https://github.com/iree-org/iree/actions/runs/12926084982/job/36048365781#step:10:187
* https://github.com/iree-org/iree/actions/runs/13154155457/job/36707383211#step:10:157

```
  34/1546 Test   #12: iree/tools/test/iree-dump-parameters.txt.test ....................................................................***Failed    3.02 sec
-- Testing: 1 tests, 1 workers --
FAIL: IREE :: test/iree-dump-parameters.txt (1 of 1)
******************** TEST 'IREE :: test/iree-dump-parameters.txt' FAILED ********************
Exit Code: 2

Command Output (stderr):
--
RUN: at line 1: (iree-dump-parameters    --parameters=a=C:/home/runner/_work/iree/iree/tools/test/parameters_a.safetensors    --parameters=b=C:/home/runner/_work/iree/iree/tools/test/parameters_b.safetensors) |   FileCheck C:/home/runner/_work/iree/iree/tools/test/iree-dump-parameters.txt
+ iree-dump-parameters --parameters=a=C:/home/runner/_work/iree/iree/tools/test/parameters_a.safetensors --parameters=b=C:/home/runner/_work/iree/iree/tools/test/parameters_b.safetensors
+ FileCheck C:/home/runner/_work/iree/iree/tools/test/iree-dump-parameters.txt
C:\home\runner\_work\iree\iree\runtime\src\iree\io\file_handle.c:223: UNKNOWN; failed to open file 'C:/home/runner/_work/iree/iree/tools/test/parameters_a.safetensors'; stack:
  0x00007ff6326c6754 iree-dump-parameters <iree_io_file_handle_platform_open+0x1a4> (C:\home\runner\_work\iree\iree\runtime\src\iree\io\file_handle.c:221)
  0x00007ff6326c6283 iree-dump-parameters <iree_io_file_handle_create_or_open+0x83> (C:\home\runner\_work\iree\iree\runtime\src\iree\io\file_handle.c:367)
  0x00007ff6326c6528 iree-dump-parameters <iree_io_file_handle_open+0x78> (C:\home\runner\_work\iree\iree\runtime\src\iree\io\file_handle.c:419)
  0x00007ff6326ac3de iree-dump-parameters <iree_io_open_parameter_file+0x13e> (C:\home\runner\_work\iree\iree\runtime\src\iree\tooling\parameter_util.c:93)
  0x00007ff6326ac224 iree-dump-parameters <iree_io_append_parameter_file_to_index+0x64> (C:\home\runner\_work\iree\iree\runtime\src\iree\tooling\parameter_util.c:130)
  0x00007ff6326ac732 iree-dump-parameters <iree_tooling_build_parameter_indices_from_flags+0xd2> (C:\home\runner\_work\iree\iree\runtime\src\iree\tooling\parameter_util.c:166)
  0x00007ff6326a377a iree-dump-parameters <main+0xca> (C:\home\runner\_work\iree\iree\tools\iree-dump-parameters-main.c:138)
  0x00007ff6326d4f88 iree-dump-parameters <__scrt_common_main_seh+0x10c> (D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288)
  0x00007ff954d34cb0 ??? <BaseThreadInitThunk+0x10>
  0x00007ff95a21edcb ??? <RtlUserThreadStart+0x2b>

FileCheck error: '<stdin>' is empty.
FileCheck command line:  C:\mnt\azure\b\092750\llvm-project\bin\FileCheck.exe C:/home/runner/_work/iree/iree/tools/test/iree-dump-parameters.txt

--

********************
********************
Failed Tests (1):
  IREE :: test/iree-dump-parameters.txt
```

skip-ci: not tested by presubmit