### PR TITLE
Refresh compile/run examples in deployment configuration guides.

### DIFF
--- a/docs/website/docs/guides/deployment-configurations/cpu.md
+++ b/docs/website/docs/guides/deployment-configurations/cpu.md
@@ -13,27 +13,32 @@ IREE supports efficient program execution on CPU devices by using
 highly optimized CPU native instruction streams, which are embedded in one of
 IREE's deployable formats.
 
-To compile a program for CPU execution, pick one of IREE's supported executable
-formats:
+To compile a program for CPU execution:
 
-| Executable Format | Description                                           |
-| ----------------- | ----------------------------------------------------- |
-| embedded ELF      | portable, high performance dynamic library            |
-| system library    | platform-specific dynamic library (.so, .dll, etc.)   |
-| VMVX              | reference target                                      |
+1. Pick a CPU target supported by LLVM. By default, IREE includes these LLVM
+   targets:
 
-At runtime, CPU executables can be loaded using one of IREE's CPU HAL drivers:
+    * X86
+    * ARM
+    * AArch64
+    * RISCV
 
-* `local-task`: asynchronous, multithreaded driver built on IREE's "task"
+    Other targets may work, but in-tree test coverage and performance work is
+    focused on that list.
+
+2. Pick one of IREE's supported executable formats:
+
+    | Executable Format | Description                                           |
+    | ----------------- | ----------------------------------------------------- |
+    | Embedded ELF      | (Default) Portable, high performance dynamic library  |
+    | System library    | Platform-specific dynamic library (.so, .dll, etc.)   |
+    | VMVX              | Reference target                                      |
+
+At runtime, CPU executables can be loaded using one of IREE's CPU HAL devices:
+
+* `local-task`: asynchronous, multithreaded device built on IREE's "task"
    system
-* `local-sync`: synchronous, single-threaded driver that executes work inline
-
-!!! todo
-
-    Add IREE's CPU support matrix: what architectures are supported; what
-    architectures are well optimized; etc.
-
-<!-- TODO(??): when to use CPU vs GPU vs other backends -->
+* `local-sync`: synchronous, single-threaded devices that executes work inline
 
 ## :octicons-download-16: Prerequisites
 
@@ -44,7 +49,7 @@ At runtime, CPU executables can be loaded using one of IREE's CPU HAL drivers:
 Python packages are distributed through multiple channels. See the
 [Python Bindings](../../reference/bindings/python.md) page for more details.
 The core [`iree-base-compiler`](https://pypi.org/project/iree-base-compiler/)
-package includes the LLVM-based CPU compiler:
+package includes the compiler tools:
 
 --8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-compiler-from-release.md"
 
@@ -52,14 +57,9 @@ package includes the LLVM-based CPU compiler:
 
 Please make sure you have followed the
 [Getting started](../../building-from-source/getting-started.md) page to build
-IREE for your host platform and the
-[Android cross-compilation](../../building-from-source/android.md) or
-[iOS cross-compilation](../../building-from-source/ios.md) page if you are cross
-compiling for a mobile device. The `llvm-cpu` compiler backend is compiled in by
-default on all platforms.
-
-Ensure that the `IREE_TARGET_BACKEND_LLVM_CPU` CMake option is `ON` when
-configuring for the host.
+IREE for your host platform. The `llvm-cpu` compiler backend is compiled in by
+default on all platforms, though you should ensure that the
+`IREE_TARGET_BACKEND_LLVM_CPU` CMake option is `ON` when configuring.
 
 !!! tip
     `iree-compile` will be built under the `iree-build/tools/` directory. You
@@ -71,10 +71,14 @@ You will need to get an IREE runtime that supports the local CPU HAL driver,
 along with the appropriate executable loaders for your application.
 
 You can check for CPU support by looking for the `local-sync` and `local-task`
-drivers:
+drivers and devices:
 
-```console hl_lines="5 6"
+```console hl_lines="10-11"
 --8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-driver-list.md"
+```
+
+```console hl_lines="4-5"
+--8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-device-list-amd.md"
 ```
 
 #### :octicons-download-16: Download the runtime from a release
@@ -88,16 +92,12 @@ package includes the local CPU HAL drivers:
 
 #### :material-hammer-wrench: Build the runtime from source
 
-Please make sure you have followed the
-[Getting started](../../building-from-source/getting-started.md) page to build
-IREE for your host platform and the
-[Android cross-compilation](../../building-from-source/android.md) page if you
-are cross compiling for Android. The local CPU HAL drivers are compiled in by
-default on all platforms.
-
-Ensure that the `IREE_HAL_DRIVER_LOCAL_TASK` and
-`IREE_HAL_EXECUTABLE_LOADER_EMBEDDED_ELF` (or other executable loader) CMake
-options are `ON` when configuring for the target.
+Please make sure you have followed one of the
+[Building from source](../../building-from-source/index.md) pages to build
+IREE for your target platform. The local CPU HAL drivers and devices are
+compiled in by default on all platforms, though you should ensure that the
+`IREE_HAL_DRIVER_LOCAL_TASK` and `IREE_HAL_EXECUTABLE_LOADER_EMBEDDED_ELF`
+(or other executable loader) CMake options are `ON` when configuring.
 
 ## Compile and run a program
 
@@ -105,30 +105,36 @@ With the requirements out of the way, we can now compile a model and run it.
 
 ### :octicons-file-code-16: Compile a program
 
-The IREE compiler transforms a model into its final deployable format in many
-sequential steps. A model authored with Python in an ML framework should use the
-corresponding framework's import tool to convert into a format (i.e.,
-[MLIR](https://mlir.llvm.org/)) expected by the IREE compiler first.
+--8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-import-onnx-mobilenet.md"
 
-Using MobileNet v2 as an example, you can download the SavedModel with trained
-weights from
-[TensorFlow Hub](https://tfhub.dev/google/tf2-preview/mobilenet_v2/classification)
-and convert it using IREE's
-[TensorFlow importer](../ml-frameworks/tensorflow.md). Then run the following
-command to compile with the `llvm-cpu` target:
+Then run the following command to compile with the `llvm-cpu` target:
 
-``` shell hl_lines="2"
+``` shell hl_lines="2-3"
 iree-compile \
     --iree-hal-target-backends=llvm-cpu \
-    mobilenet_iree_input.mlir -o mobilenet_cpu.vmfb
+    --iree-llvmcpu-target-cpu=host \
+    mobilenetv2.mlir -o mobilenet_cpu.vmfb
 ```
 
-!!! tip "Tip - CPU targets"
+???+ tip "Tip - Target CPUs and CPU features"
+
+    By default, the compiler will use a generic CPU target which will result in
+    poor performance. A target CPU or target CPU feature set should be selected
+    using one of these options:
+
+    * `--iree-llvmcpu-target-cpu=...`
+    * `--iree-llvmcpu-target-cpu-features=...`
+
+    When not cross compiling, passing `--iree-llvmcpu-target-cpu=host` is
+    usually sufficient on most devices.
+
+???+ tip "Tip - CPU targets"
 
     The `--iree-llvmcpu-target-triple` flag tells the compiler to generate code
     for a specific type of CPU. You can see the list of supported targets with
-    `iree-compile --iree-llvmcpu-list-targets`, or pass "host" to let LLVM
-    infer the triple from your host machine (e.g. `x86_64-linux-gnu`).
+    `iree-compile --iree-llvmcpu-list-targets`, or use the default value of
+    "host" to let LLVM infer the triple from your host machine
+    (e.g. `x86_64-linux-gnu`).
 
     ```console
     $ iree-compile --iree-llvmcpu-list-targets
@@ -149,28 +155,21 @@ iree-compile \
         x86-64     - 64-bit X86: EM64T and AMD64
     ```
 
-!!! tip "Tip - CPU features"
-
-    The `--iree-llvmcpu-target-cpu-features` flag tells the compiler to generate
-    code using certain CPU "features", like SIMD instruction sets. Like the
-    target triple, you can pass "host" to this flag to let LLVM infer the
-    features supported by your host machine.
-
 ### :octicons-terminal-16: Run a compiled program
 
-In the build directory, run the following command:
+To run the compiled program:
 
 ``` shell hl_lines="2"
-tools/iree-run-module \
+iree-run-module \
     --device=local-task \
     --module=mobilenet_cpu.vmfb \
-    --function=predict \
-    --input="1x224x224x3xf32=0"
+    --function=torch-jit-export \
+    --input="1x3x224x224xf32=0"
 ```
 
-The above assumes the exported function in the model is named as `predict` and
-it expects one 224x224 RGB image. We are feeding in an image with all 0 values
-here for brevity, see `iree-run-module --help` for the format to specify
+The above assumes the exported function in the model is named `torch-jit-export`
+and it expects one 224x224 RGB image. We are feeding in an image with all 0
+values here for brevity, see `iree-run-module --help` for the format to specify
 concrete values.
 
 <!-- TODO(??): measuring performance -->

--- a/docs/website/docs/guides/deployment-configurations/cpu.md
+++ b/docs/website/docs/guides/deployment-configurations/cpu.md
@@ -74,7 +74,7 @@ You can check for CPU support by looking for the `local-sync` and `local-task`
 drivers and devices:
 
 ```console hl_lines="10-11"
---8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-driver-list.md"
+--8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-driver-list.md:1"
 ```
 
 ```console hl_lines="4-5"

--- a/docs/website/docs/guides/deployment-configurations/gpu-cuda.md
+++ b/docs/website/docs/guides/deployment-configurations/gpu-cuda.md
@@ -53,7 +53,7 @@ Next you will need to get an IREE runtime that includes the CUDA HAL driver.
 You can check for CUDA support by looking for a matching driver and device:
 
 ```console hl_lines="8"
---8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-driver-list.md"
+--8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-driver-list.md:1"
 ```
 
 ```console hl_lines="3"

--- a/docs/website/docs/guides/deployment-configurations/gpu-cuda.md
+++ b/docs/website/docs/guides/deployment-configurations/gpu-cuda.md
@@ -52,16 +52,12 @@ Next you will need to get an IREE runtime that includes the CUDA HAL driver.
 
 You can check for CUDA support by looking for a matching driver and device:
 
-```console hl_lines="3"
+```console hl_lines="8"
 --8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-driver-list.md"
 ```
 
 ```console hl_lines="3"
-$ iree-run-module --list_devices
-
-  cuda://GPU-00000000-1111-2222-3333-444444444444
-  local-sync://
-  local-task://
+--8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-device-list-nvidia.md"
 ```
 
 #### :octicons-download-16: Download the runtime from a release
@@ -82,69 +78,63 @@ IREE from source, then enable the CUDA HAL driver with the
 
 ## Compile and run a program model
 
-With the compiler and runtime ready, we can now compile programs and run them
-on GPUs.
+With the requirements out of the way, we can now compile a model and run it.
 
 ### :octicons-file-code-16: Compile a program
 
-The IREE compiler transforms a model into its final deployable format in many
-sequential steps. A model authored with Python in an ML framework should use the
-corresponding framework's import tool to convert into a format (i.e.,
-[MLIR](https://mlir.llvm.org/)) expected by the IREE compiler first.
+--8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-import-onnx-mobilenet.md"
 
-Using MobileNet v2 as an example, you can download the SavedModel with trained
-weights from
-[TensorFlow Hub](https://tfhub.dev/google/tf2-preview/mobilenet_v2/classification)
-and convert it using IREE's
-[TensorFlow importer](../ml-frameworks/tensorflow.md). Then run one of the
-following commands to compile:
+Then run the following command to compile with the `cuda` target:
 
 ```shell hl_lines="2-3"
 iree-compile \
     --iree-hal-target-backends=cuda \
     --iree-cuda-target=<...> \
-    mobilenet_iree_input.mlir -o mobilenet_cuda.vmfb
+    mobilenetv2.mlir -o mobilenet_cuda.vmfb
 ```
 
-Canonically a CUDA target (`iree-cuda-target`) matching the LLVM NVPTX backend
-of the form `sm_<arch_number>` is needed to compile towards each GPU
-architecture. If no architecture is specified then we will default to `sm_60`.
+???+ tip "Tip - CUDA targets"
 
-Here is a table of commonly used architectures:
+    Canonically a CUDA target (`iree-cuda-target`) matching the LLVM NVPTX
+    backend of the form `sm_<arch_number>` is needed to compile towards each GPU
+    architecture. If no architecture is specified then we will default to
+    `sm_60`.
 
-| CUDA GPU            | Target Architecture | Architecture Code Name
-| ------------------- | ------------------- | ----------------------
-| NVIDIA P100         | `sm_60`             | `pascal`
-| NVIDIA V100         | `sm_70`             | `volta`
-| NVIDIA A100         | `sm_80`             | `ampere`
-| NVIDIA H100         | `sm_90`             | `hopper`
-| NVIDIA RTX20 series | `sm_75`             | `turing`
-| NVIDIA RTX30 series | `sm_86`             | `ampere`
-| NVIDIA RTX40 series | `sm_89`             | `ada`
+    Here is a table of commonly used architectures:
 
-In addition to the canonical `sm_<arch_number>` scheme, `iree-cuda-target` also
-supports two additonal schemes to make a better developer experience:
+    | CUDA GPU            | Target Architecture | Architecture Code Name
+    | ------------------- | ------------------- | ----------------------
+    | NVIDIA P100         | `sm_60`             | `pascal`
+    | NVIDIA V100         | `sm_70`             | `volta`
+    | NVIDIA A100         | `sm_80`             | `ampere`
+    | NVIDIA H100         | `sm_90`             | `hopper`
+    | NVIDIA RTX20 series | `sm_75`             | `turing`
+    | NVIDIA RTX30 series | `sm_86`             | `ampere`
+    | NVIDIA RTX40 series | `sm_89`             | `ada`
 
-* Architecture code names like `volta` or `ampere`
-* GPU product names like `a100` or `rtx3090`
+    In addition to the canonical `sm_<arch_number>` scheme, `iree-cuda-target`
+    also supports two additonal schemes to make a better developer experience:
 
-These two schemes are translated into the canonical form under the hood.
-We add support for common code/product names without aiming to be exhaustive.
-If the ones you want are missing, please use the canonical form.
+    * Architecture code names like `volta` or `ampere`
+    * GPU product names like `a100` or `rtx3090`
+
+    These two schemes are translated into the canonical form under the hood.
+    We add support for common code/product names without aiming to be exhaustive.
+    If the ones you want are missing, please use the canonical form.
 
 ### :octicons-terminal-16: Run a compiled program
 
-Run the following command:
+To run the compiled program:
 
 ``` shell hl_lines="2"
 iree-run-module \
     --device=cuda \
     --module=mobilenet_cuda.vmfb \
-    --function=predict \
-    --input="1x224x224x3xf32=0"
+    --function=torch-jit-export \
+    --input="1x3x224x224xf32=0"
 ```
 
-The above assumes the exported function in the model is named as `predict` and
-it expects one 224x224 RGB image. We are feeding in an image with all 0 values
-here for brevity, see `iree-run-module --help` for the format to specify
+The above assumes the exported function in the model is named `torch-jit-export`
+and it expects one 224x224 RGB image. We are feeding in an image with all 0
+values here for brevity, see `iree-run-module --help` for the format to specify
 concrete values.

--- a/docs/website/docs/guides/deployment-configurations/gpu-rocm.md
+++ b/docs/website/docs/guides/deployment-configurations/gpu-rocm.md
@@ -116,8 +116,6 @@ iree-compile \
     | AMD MI100                | `mi100`     | `gfx908`            | `cdna1`                |
     | AMD MI210                | `mi210`     | `gfx90a`            | `cdna2`                |
     | AMD MI250                | `mi250`     | `gfx90a`            | `cdna2`                |
-    | AMD MI300X (early units) | N/A         | `gfx940`            | `cdna3`                |
-    | AMD MI300A (early units) | N/A         | `gfx941`            | `cdna3`                |
     | AMD MI300A               | `mi300a`    | `gfx942`            | `cdna3`                |
     | AMD MI300X               | `mi300x`    | `gfx942`            | `cdna3`                |
     | AMD MI308X               | `mi308x`    | `gfx942`            | `cdna3`                |

--- a/docs/website/docs/guides/deployment-configurations/gpu-rocm.md
+++ b/docs/website/docs/guides/deployment-configurations/gpu-rocm.md
@@ -55,7 +55,7 @@ Next you will need to get an IREE runtime that includes the HIP HAL driver.
 You can check for HIP support by looking for a matching driver and device:
 
 ```console hl_lines="9"
---8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-driver-list.md"
+--8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-driver-list.md:1"
 ```
 
 ```console hl_lines="3"

--- a/docs/website/docs/guides/deployment-configurations/gpu-rocm.md
+++ b/docs/website/docs/guides/deployment-configurations/gpu-rocm.md
@@ -54,16 +54,12 @@ Next you will need to get an IREE runtime that includes the HIP HAL driver.
 
 You can check for HIP support by looking for a matching driver and device:
 
-```console hl_lines="4"
+```console hl_lines="9"
 --8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-driver-list.md"
 ```
 
 ```console hl_lines="3"
-$ iree-run-module --list_devices
-
-  hip://GPU-00000000-1111-2222-3333-444444444444
-  local-sync://
-  local-task://
+--8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-device-list-amd.md"
 ```
 
 #### :octicons-download-16: Download the runtime from a release
@@ -89,88 +85,85 @@ on GPUs.
 
 ### :octicons-file-code-16: Compile a program
 
-The IREE compiler transforms a model into its final deployable format in many
-sequential steps. A model authored with Python in an ML framework should use the
-corresponding framework's import tool to convert into a format (i.e.,
-[MLIR](https://mlir.llvm.org/)) expected by the IREE compiler first.
+--8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-import-onnx-mobilenet.md"
 
-Using MobileNet v2 as an example, you can download the SavedModel with trained
-weights from
-[TensorFlow Hub](https://tfhub.dev/google/tf2-preview/mobilenet_v2/classification)
-and convert it using IREE's
-[TensorFlow importer](../ml-frameworks/tensorflow.md). Then run one of the
-following commands to compile:
+Then run the following command to compile with the `rocm` target:
 
 ```shell hl_lines="2-5"
 iree-compile \
     --iree-hal-target-backends=rocm \
     --iree-hip-target=<...> \
-    mobilenet_iree_input.mlir -o mobilenet_rocm.vmfb
+    mobilenetv2.mlir -o mobilenet_rocm.vmfb
 ```
 
-Note that IREE comes with bundled bitcode files, which are used for linking
-certain intrinsics on AMD GPUs. These will be used automatically or if the
-`--iree-hip-bc-dir` is empty. As additional support may be needed for
-different chips, users can use this flag to point to an explicit directory.
-For example, in ROCm installations on Linux, this is often found under
-`/opt/rocm/amdgcn/bitcode`.
+???+ tip "Tip - HIP bitcode files"
 
-A HIP target (`iree-hip-target`) matching the LLVM AMDGPU backend is needed to
-compile towards each GPU chip. Here is a table of commonly used architectures:
+    That IREE comes with bundled bitcode files, which are used for linking
+    certain intrinsics on AMD GPUs. These will be used automatically or if the
+    `--iree-hip-bc-dir` is empty. As additional support may be needed for
+    different chips, users can use this flag to point to an explicit directory.
+    For example, in ROCm installations on Linux, this is often found under
+    `/opt/rocm/amdgcn/bitcode`.
 
-| AMD GPU                  | SKU Name    | Target Architecture | Architecture Code Name |
-| ------------------------ | ----------- | ------------------- | ---------------------- |
-| AMD MI100                | `mi100`     | `gfx908`            | `cdna1`                |
-| AMD MI210                | `mi210`     | `gfx90a`            | `cdna2`                |
-| AMD MI250                | `mi250`     | `gfx90a`            | `cdna2`                |
-| AMD MI300X (early units) | N/A         | `gfx940`            | `cdna3`                |
-| AMD MI300A (early units) | N/A         | `gfx941`            | `cdna3`                |
-| AMD MI300A               | `mi300a`    | `gfx942`            | `cdna3`                |
-| AMD MI300X               | `mi300x`    | `gfx942`            | `cdna3`                |
-| AMD MI308X               | `mi308x`    | `gfx942`            | `cdna3`                |
-| AMD MI325X               | `mi325x`    | `gfx942`            | `cdna3`                |
-| AMD RX7900XTX            | `rx7900xtx` | `gfx1100`           | `rdna3`                |
-| AMD RX7900XT             | `rx7900xt`  | `gfx1100`           | `rdna3`                |
-| AMD PRO W7900            | `w7900`     | `gfx1100`           | `rdna3`                |
-| AMD PRO W7800            | `w7800`     | `gfx1100`           | `rdna3`                |
-| AMD RX7800XT             | `rx7800xt`  | `gfx1101`           | `rdna3`                |
-| AMD RX7700XT             | `rx7700xt`  | `gfx1101`           | `rdna3`                |
-| AMD PRO V710             | `v710`      | `gfx1101`           | `rdna3`                |
-| AMD PRO W7700            | `w7700`     | `gfx1101`           | `rdna3`                |
+???+ tip "Tip - HIP targets"
 
-For a more comprehensive list of prior GPU generations, you can refer to the
-[LLVM AMDGPU backend](https://llvm.org/docs/AMDGPUUsage.html#processors).
+    A HIP target (`iree-hip-target`) matching the LLVM AMDGPU backend is needed
+    to compile towards each GPU chip. Here is a table of commonly used
+    architectures:
 
-The `iree-hip-target` option support three schemes:
+    | AMD GPU                  | SKU Name    | Target Architecture | Architecture Code Name |
+    | ------------------------ | ----------- | ------------------- | ---------------------- |
+    | AMD MI100                | `mi100`     | `gfx908`            | `cdna1`                |
+    | AMD MI210                | `mi210`     | `gfx90a`            | `cdna2`                |
+    | AMD MI250                | `mi250`     | `gfx90a`            | `cdna2`                |
+    | AMD MI300X (early units) | N/A         | `gfx940`            | `cdna3`                |
+    | AMD MI300A (early units) | N/A         | `gfx941`            | `cdna3`                |
+    | AMD MI300A               | `mi300a`    | `gfx942`            | `cdna3`                |
+    | AMD MI300X               | `mi300x`    | `gfx942`            | `cdna3`                |
+    | AMD MI308X               | `mi308x`    | `gfx942`            | `cdna3`                |
+    | AMD MI325X               | `mi325x`    | `gfx942`            | `cdna3`                |
+    | AMD RX7900XTX            | `rx7900xtx` | `gfx1100`           | `rdna3`                |
+    | AMD RX7900XT             | `rx7900xt`  | `gfx1100`           | `rdna3`                |
+    | AMD PRO W7900            | `w7900`     | `gfx1100`           | `rdna3`                |
+    | AMD PRO W7800            | `w7800`     | `gfx1100`           | `rdna3`                |
+    | AMD RX7800XT             | `rx7800xt`  | `gfx1101`           | `rdna3`                |
+    | AMD RX7700XT             | `rx7700xt`  | `gfx1101`           | `rdna3`                |
+    | AMD PRO V710             | `v710`      | `gfx1101`           | `rdna3`                |
+    | AMD PRO W7700            | `w7700`     | `gfx1101`           | `rdna3`                |
 
-1. The exact GPU product (SKU), e.g., `--iree-hip-target=mi300x`. This allows
-  the compiler to know about both the target architecture and about additional
-  hardware details like the number of compute units. This extra information
-  guides some compiler heuristics and allows for SKU-specific [tuning
-  specs](../../reference/tuning.md).
-2. The GPU architecture, as defined by LLVM, e.g., `--iree-hip-target=gfx942`.
-  This scheme allows for architecture-specific [tuning
-  specs](../../reference/tuning.md) only.
-3. The architecture code name, e.g., `--iree-hip-target=cdna3`. This scheme gets
-  translated to closes matching GPU architecture under the hood.
+    For a more comprehensive list of prior GPU generations, you can refer to the
+    [LLVM AMDGPU backend](https://llvm.org/docs/AMDGPUUsage.html#processors).
 
-We support for common code/SKU names without aiming to be exhaustive. If the
-ones you want are missing, please use the GPU architecture scheme (2.) as it is
-the most general.
+    The `iree-hip-target` option support three schemes:
+
+    1. The exact GPU product (SKU), e.g., `--iree-hip-target=mi300x`. This
+       allows the compiler to know about both the target architecture and about
+       additional hardware details like the number of compute units. This extra
+       information guides some compiler heuristics and allows for SKU-specific
+       [tuning specs](../../reference/tuning.md).
+    2. The GPU architecture, as defined by LLVM, e.g.,
+       `--iree-hip-target=gfx942`. This scheme allows for architecture-specific
+       [tuning specs](../../reference/tuning.md) only.
+    3. The architecture code name, e.g., `--iree-hip-target=cdna3`. This scheme
+       gets translated to closes matching GPU architecture under the hood.
+
+    We support for common code/SKU names without aiming to be exhaustive. If the
+    ones you want are missing, please use the GPU architecture scheme (2.) as it
+    is the most general.
 
 ### :octicons-terminal-16: Run a compiled program
 
-Run the following command:
+To run the compiled program:
 
 ``` shell hl_lines="2"
 iree-run-module \
     --device=hip \
     --module=mobilenet_rocm.vmfb \
-    --function=predict \
-    --input="1x224x224x3xf32=0"
+    --function=torch-jit-export \
+    --input="1x3x224x224xf32=0"
 ```
 
-The above assumes the exported function in the model is named as `predict` and
-it expects one 224x224 RGB image. We are feeding in an image with all 0 values
-here for brevity, see `iree-run-module --help` for the format to specify
+The above assumes the exported function in the model is named `torch-jit-export`
+and it expects one 224x224 RGB image. We are feeding in an image with all 0
+values here for brevity, see `iree-run-module --help` for the format to specify
 concrete values.

--- a/docs/website/docs/guides/deployment-configurations/gpu-vulkan.md
+++ b/docs/website/docs/guides/deployment-configurations/gpu-vulkan.md
@@ -104,7 +104,7 @@ Next you will need to get an IREE runtime that supports the Vulkan HAL driver.
 You can check for Vulkan support by looking for a matching driver and device:
 
 ```console hl_lines="12"
---8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-driver-list.md"
+--8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-driver-list.md:1"
 ```
 
 ```console hl_lines="6"

--- a/docs/website/docs/guides/deployment-configurations/gpu-vulkan.md
+++ b/docs/website/docs/guides/deployment-configurations/gpu-vulkan.md
@@ -89,13 +89,9 @@ package includes the SPIR-V compiler:
 
 Please make sure you have followed the
 [Getting started](../../building-from-source/getting-started.md) page to build
-IREE for your host platform and the
-[Android cross-compilation](../../building-from-source/android.md) page if you
-are cross compiling for Android. The SPIR-V compiler backend is compiled in by
-default on all platforms.
-
-Ensure that the `IREE_TARGET_BACKEND_VULKAN_SPIRV` CMake option is `ON` when
-configuring for the host.
+IREE for your host platform. The SPIR-V compiler backend is compiled in by
+default on all platforms, though you should ensure that the
+`IREE_TARGET_BACKEND_VULKAN_SPIRV` CMake option is `ON` when configuring.
 
 !!! tip
     `iree-compile` will be built under the `iree-build/tools/` directory. You
@@ -107,17 +103,12 @@ Next you will need to get an IREE runtime that supports the Vulkan HAL driver.
 
 You can check for Vulkan support by looking for a matching driver and device:
 
-```console hl_lines="7"
+```console hl_lines="12"
 --8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-driver-list.md"
 ```
 
 ```console hl_lines="6"
-$ iree-run-module --list_devices
-
-  cuda://GPU-00000000-1111-2222-3333-444444444444
-  local-sync://
-  local-task://
-  vulkan://00000000-1111-2222-3333-444444444444
+--8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-device-list-amd.md"
 ```
 
 #### :octicons-download-16: Download the runtime from a release
@@ -131,97 +122,83 @@ package includes the Vulkan HAL driver:
 
 #### :material-hammer-wrench: Build the runtime from source
 
-Please make sure you have followed the
-[Getting started](../../building-from-source/getting-started.md) page to build
-IREE for Linux/Windows and the
-[Android cross-compilation](../../building-from-source/android.md) page for
-Android. The Vulkan HAL driver is compiled in by default on non-Apple platforms.
-
-Ensure that the `IREE_HAL_DRIVER_VULKAN` CMake option is `ON` when configuring
-for the target.
+Please make sure you have followed one of the
+[Building from source](../../building-from-source/index.md) pages to build
+IREE for your target platform. The Vulkan HAL driver is compiled in by default
+on supported platforms, though you should ensure that the
+`IREE_HAL_DRIVER_VULKAN` CMake option is `ON` when configuring.
 
 ## Compile and run a program
 
-With the SPIR-V compiler and Vulkan runtime, we can now compile programs and run
-them on GPUs.
+With the requirements out of the way, we can now compile a model and run it.
 
 ### :octicons-file-code-16: Compile a program
 
-The IREE compiler transforms a model into its final deployable format in many
-sequential steps. A model authored with Python in an ML framework should use the
-corresponding framework's import tool to convert into a format (i.e.,
-[MLIR](https://mlir.llvm.org/)) expected by the IREE compiler first.
+--8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-import-onnx-mobilenet.md"
 
-Using MobileNet v2 as an example, you can download the SavedModel with trained
-weights from
-[TensorFlow Hub](https://tfhub.dev/google/tf2-preview/mobilenet_v2/classification)
-and convert it using IREE's
-[TensorFlow importer](../ml-frameworks/tensorflow.md). Then run the following
-command to compile with the `vulkan-spirv` target:
+Then run the following command to compile with the `vulkan-spirv` target:
 
 ``` shell hl_lines="2 3"
 iree-compile \
     --iree-hal-target-backends=vulkan-spirv \
     --iree-vulkan-target=<...> \
-    mobilenet_iree_input.mlir -o mobilenet_vulkan.vmfb
+    mobilenetv2.mlir -o mobilenet_vulkan.vmfb
 ```
 
-`iree-vulkan-target` specifies the GPU architecture to target. It accepts a few
-schemes:
+???+ tip "Tip - Vulkan targets"
 
-* LLVM CodeGen backend style: this is using LLVM AMDGPU/NVPTX CodeGen targets
-  like `gfx1100` for AMD RX 7900XTX and `sm_86` for NVIDIA RTX 3090 GPUs.
-* Architecture code name style: e.g., using `rdna3`/`valhall4`/`ampere`/`adreno`
-  for AMD/ARM/NVIDIA/Qualcomm GPUs.
-* Product name style(1): e.g., using `rx7900xtx`/`a100` for corresponding GPUs.
+    The `--iree-vulkan-target` specifies the GPU architecture to target. It
+    accepts a few schemes:
 
-Here are a few examples showing how you can target various recent common GPUs:
+    * LLVM CodeGen backend style: this is using LLVM AMDGPU/NVPTX CodeGen targets
+      like `gfx1100` for AMD RX 7900XTX and `sm_86` for NVIDIA RTX 3090 GPUs.
+    * Architecture code name style like `rdna3`/`valhall4`/`ampere`/`adreno`
+      for AMD/ARM/NVIDIA/Qualcomm GPUs.
+    * Product name style: e.g., using `rx7900xtx`/`a100` for corresponding GPUs.
 
-| GPU                 | Target Architecture | Architecture Code Name | Product Name
-| ------------------- | ------------------- | ---------------------- | ------------
-| AMD RX7900XTX       | `gfx1100`           | `rdna3`                | `rx7900xtx`
-| AMD RX7900XT        | `gfx1100`           | `rdna3`                | `rx7900xt`
-| AMD RX7800XT        | `gfx1101`           | `rdna3`                | `rx7800xt`
-| AMD RX7700XT        | `gfx1101`           | `rdna3`                | `rx7700xt`
-| AMD RX6000 series   |                     | `rdna2`                |
-| AMD RX5000 series   |                     | `rdna1`                |
-| ARM Mali G715       |                     | `valhall4`             | e.g., `mali-g715`
-| ARM Mali G510       |                     | `valhall3`             | e.g., `mali-g510`
-| ARM GPUs            |                     | `valhall`              |
-| NVIDIA RTX40 series | `sm_89`             | `ada`                  | e.g., `rtx4090`
-| NVIDIA RTX30 series | `sm_86`             | `ampere`               | e.g., `rtx3080ti`
-| NVIDIA RTX20 series | `sm_75`             | `turing`               | e.g., `rtx2070super`
-| Qualcomm GPUs       |                     | `adreno`               |
+    Here are a few examples showing how you can target various recent common GPUs:
 
-If no target is specified, then a safe but more limited default will be used.
+    | GPU                 | Target Architecture | Architecture Code Name | Product Name
+    | ------------------- | ------------------- | ---------------------- | ------------
+    | AMD RX7900XTX       | `gfx1100`           | `rdna3`                | `rx7900xtx`
+    | AMD RX7900XT        | `gfx1100`           | `rdna3`                | `rx7900xt`
+    | AMD RX7800XT        | `gfx1101`           | `rdna3`                | `rx7800xt`
+    | AMD RX7700XT        | `gfx1101`           | `rdna3`                | `rx7700xt`
+    | AMD RX6000 series   |                     | `rdna2`                |
+    | AMD RX5000 series   |                     | `rdna1`                |
+    | ARM Mali G715       |                     | `valhall4`             | e.g., `mali-g715`
+    | ARM Mali G510       |                     | `valhall3`             | e.g., `mali-g510`
+    | ARM GPUs            |                     | `valhall`              |
+    | NVIDIA RTX40 series | `sm_89`             | `ada`                  | e.g., `rtx4090`
+    | NVIDIA RTX30 series | `sm_86`             | `ampere`               | e.g., `rtx3080ti`
+    | NVIDIA RTX20 series | `sm_75`             | `turing`               | e.g., `rtx2070super`
+    | Qualcomm GPUs       |                     | `adreno`               |
 
-!!! note annotate
-    Note that We don't support the full spectrum of GPUs here(2).
-    This is more of a mechanism to help us develop IREE itself--in the long term
-    we want to perform multiple targetting to generate to multiple architectures
-    if no target is given.
+    If no target is specified, then a safe but more limited default will be used.
 
-1. Note that we only support very limited GPUs that we are actively developing
-   against in this category, particularly for desktops.
-2. It's also impossible to capture all details of a Vulkan implementation
-   with a target triple, given the allowed variances on extensions, properties,
-   limits, etc. So the target triple is just an approximation for usage.
+    Note that we don't support the full spectrum of GPUs here and it is
+    impossible to capture all details of a Vulkan implementation with a target
+    triple, given the allowed variances on extensions, properties, limits, etc.
+    So the target triple is just an approximation for usage. This is more of a
+    mechanism to help us develop IREE itself--in the long term we want to
+    perform multiple targetting to generate to multiple architectures if no
+    target is given.
 
 ### :octicons-terminal-16: Run a compiled program
 
-In the build directory, run the following command:
+To run the compiled program:
 
 ``` shell hl_lines="2"
-tools/iree-run-module \
+iree-run-module \
     --device=vulkan \
     --module=mobilenet_vulkan.vmfb \
-    --function=predict \
-    --input="1x224x224x3xf32=0"
+    --function=torch-jit-export \
+    --input="1x3x224x224xf32=0"
 ```
 
-The above assumes the exported function in the model is named as `predict` and
-it expects one 224x224 RGB image. We are feeding in an image with all 0 values
-here for brevity, see `iree-run-module --help` for the format to specify
+The above assumes the exported function in the model is named `torch-jit-export`
+and it expects one 224x224 RGB image. We are feeding in an image with all 0
+values here for brevity, see `iree-run-module --help` for the format to specify
 concrete values.
 
 <!-- TODO(??): Vulkan profiles / API versions / extensions -->

--- a/docs/website/docs/guides/deployment-configurations/snippets/_iree-compiler-from-release.md
+++ b/docs/website/docs/guides/deployment-configurations/snippets/_iree-compiler-from-release.md
@@ -22,7 +22,7 @@
 !!! tip
     `iree-compile` and other tools are installed to your python module
     installation path. If you pip install with the user mode, it is under
-    `${HOME}/.local/bin`, or `%APPDATA%Python` on Windows. You may want to
+    `${HOME}/.local/bin`, or `%APPDATA%\Python` on Windows. You may want to
     include the path in your system's `PATH` environment variable:
 
     ```shell

--- a/docs/website/docs/guides/deployment-configurations/snippets/_iree-import-onnx-mobilenet.md
+++ b/docs/website/docs/guides/deployment-configurations/snippets/_iree-import-onnx-mobilenet.md
@@ -1,0 +1,17 @@
+The IREE compiler transforms a model into its final deployable format in several
+sequential steps. A model authored with Python in an ML framework should use the
+corresponding framework's import tool to convert into a format (i.e.,
+[MLIR](https://mlir.llvm.org/)) expected by the IREE compiler first.
+
+Using a
+[MobileNet model](https://github.com/onnx/models/tree/main/validated/vision/classification/mobilenet)
+as an example, import using IREE's [ONNX importer](../ml-frameworks/onnx.md):
+
+```bash
+# Download the model you want to compile and run.
+wget https://github.com/onnx/models/raw/refs/heads/main/validated/vision/classification/mobilenet/model/mobilenetv2-10.onnx
+
+# Import to MLIR using IREE's ONNX importer.
+pip install iree-base-compiler[onnx]
+iree-import-onnx mobilenetv2-10.onnx --opset-version 17 -o mobilenetv2.mlir
+```

--- a/docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-device-list-amd.md
+++ b/docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-device-list-amd.md
@@ -1,0 +1,6 @@
+$ iree-run-module --list_devices
+
+  hip://GPU-00000000-1111-2222-3333-444444444444
+  local-sync://
+  local-task://
+  vulkan://00000000-1111-2222-3333-444444444444

--- a/docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-device-list-nvidia.md
+++ b/docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-device-list-nvidia.md
@@ -1,0 +1,6 @@
+$ iree-run-module --list_devices
+
+  cuda://GPU-00000000-1111-2222-3333-444444444444
+  local-sync://
+  local-task://
+  vulkan://00000000-1111-2222-3333-444444444444

--- a/docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-driver-list.md
+++ b/docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-driver-list.md
@@ -1,4 +1,10 @@
+<!-- markdownlint-disable -->
 $ iree-run-module --list_drivers
+
+# ============================================================================
+# Available HAL drivers
+# ============================================================================
+# Use --list_devices={driver name} to enumerate available devices.
 
         cuda: NVIDIA CUDA HAL driver (via dylib)
          hip: HIP HAL driver (via dylib)

--- a/docs/website/docs/guides/ml-frameworks/onnx.md
+++ b/docs/website/docs/guides/ml-frameworks/onnx.md
@@ -10,14 +10,6 @@ icon: simple/onnx
 
 # ONNX support
 
-!!! caution "Caution - under development"
-
-    Support for a broad set of [ONNX operators](https://onnx.ai/onnx/operators/)
-    and [data types](https://onnx.ai/onnx/intro/concepts.html#supported-types)
-    is an active investment area. See the
-    [ONNX Op Support tracking issue](https://github.com/nod-ai/SHARK-ModelDev/issues/215)
-    for the latest status.
-
 ## :octicons-book-16: Overview
 
 Machine learning models using the
@@ -46,39 +38,33 @@ graph LR
 
 ## :octicons-download-16: Prerequisites
 
-1. Install ONNX:
+Install IREE packages, either by
+[building from source](../../building-from-source/getting-started.md#python-bindings)
+or from pip:
+
+=== ":octicons-package-16: Stable releases"
+
+    Stable release packages are [published to PyPI](https://pypi.org/).
 
     ``` shell
-    python -m pip install onnx
+    python -m pip install \
+      iree-base-compiler[onnx] \
+      iree-base-runtime
     ```
 
-2. Install IREE packages, either by
-    [building from source](../../building-from-source/getting-started.md#python-bindings)
-    or from pip:
+=== ":octicons-beaker-16: Nightly releases"
 
-    === ":octicons-package-16: Stable releases"
+    Nightly pre-releases are published on
+    [GitHub releases](https://github.com/iree-org/iree/releases).
 
-        Stable release packages are [published to PyPI](https://pypi.org/).
-
-        ``` shell
-        python -m pip install \
-          iree-base-compiler[onnx] \
-          iree-base-runtime
-        ```
-
-    === ":octicons-beaker-16: Nightly releases"
-
-        Nightly pre-releases are published on
-        [GitHub releases](https://github.com/iree-org/iree/releases).
-
-        ``` shell
-        python -m pip install \
-          --find-links https://iree.dev/pip-release-links.html \
-          --upgrade \
-          --pre \
-          iree-base-compiler[onnx] \
-          iree-base-runtime
-        ```
+    ``` shell
+    python -m pip install \
+      --find-links https://iree.dev/pip-release-links.html \
+      --upgrade \
+      --pre \
+      iree-base-compiler[onnx] \
+      iree-base-runtime
+    ```
 
 ## :octicons-rocket-16: Quickstart
 
@@ -88,11 +74,15 @@ graph LR
 2. Convert the `.onnx` file into MLIR using the `iree-import-onnx` tool:
 
     ```shell
-    iree-import-onnx [model.onnx] -o [model.mlir]
+    iree-import-onnx \
+      [model.onnx] \
+      --opset-version 17 \
+      -o [model.mlir]
     ```
 
     This tool produces a MLIR file with the help of the
-    [torch-mlir](https://github.com/llvm/torch-mlir) project.
+    [torch-mlir](https://github.com/llvm/torch-mlir) project. Run
+    `iree-import-onnx --help` for a full list of options.
 
 3. Once imported, the standard set of tools and APIs available for any of
    IREE's [deployment configurations](../deployment-configurations/index.md) and
@@ -102,6 +92,7 @@ graph LR
     iree-compile \
       model.mlir \
       --iree-hal-target-backends=llvm-cpu \
+      --iree-llvmcpu-target-cpu=host \
       -o model_cpu.vmfb
 
     iree-run-module \
@@ -122,6 +113,12 @@ Curated op and model tests | SHARK-TestSuite [`e2eshark/onnx`](https://github.co
 Importer tests | [torch-mlir `test/python/onnx_importer`](https://github.com/llvm/torch-mlir/tree/main/test/python/onnx_importer)
 
 ## :octicons-question-16: Troubleshooting
+
+Support for a broad set of [ONNX operators](https://onnx.ai/onnx/operators/)
+and [data types](https://onnx.ai/onnx/intro/concepts.html#supported-types)
+is an active investment area. See the
+[ONNX Op Support tracking issue](https://github.com/nod-ai/SHARK-ModelDev/issues/215)
+for the latest status.
 
 ### Failed to legalize operation that was explicitly marked illegal
 


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree/issues/18174, updating some stale documentation.

> [!NOTE]
> Demo here: https://scotttodd.github.io/iree/guides/deployment-configurations/cpu/

Changes included:

* Switch examples to use ONNX instead of TensorFlow given that users are trying to use TensorFlow and failing: https://github.com/iree-org/iree/issues/19852
* Add more documentation for CPU targets and features for https://github.com/iree-org/iree/issues/18561
* Standardize some formatting across CPU/CUDA/ROCm/Vulkan pages
* Adjust some parts of the ONNX guide now that support is more mature