### PR TITLE
[LLVMGPU] Pass to decompose horizontally fused GEMMs before layout configuration.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
@@ -50,6 +50,7 @@ iree_compiler_cc_library(
     name = "CommonGPUPasses",
     srcs = [
         "AMDGPUDistributeContract.cpp",
+        "DecomposeHorizontallyFusedGemms.cpp",
         "ExpandGPUOps.cpp",
         "GPUApplyTilingLevel.cpp",
         "GPUCheckResourceUsage.cpp",
@@ -107,6 +108,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Utils",
         "//compiler/src/iree/compiler/Codegen/Utils:VectorOpUtils",
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
+        "//compiler/src/iree/compiler/Dialect/LinalgExt/Utils",
         "//compiler/src/iree/compiler/Utils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AMDGPUDialect",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
@@ -48,6 +48,7 @@ iree_cc_library(
     "Passes.h"
   SRCS
     "AMDGPUDistributeContract.cpp"
+    "DecomposeHorizontallyFusedGemms.cpp"
     "ExpandGPUOps.cpp"
     "GPUApplyTilingLevel.cpp"
     "GPUCheckResourceUsage.cpp"
@@ -141,6 +142,7 @@ iree_cc_library(
     iree::compiler::Codegen::Utils
     iree::compiler::Codegen::Utils::VectorOpUtils
     iree::compiler::Dialect::HAL::IR
+    iree::compiler::Dialect::LinalgExt::Utils
     iree::compiler::Utils
   PUBLIC
 )

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/DecomposeHorizontallyFusedGemms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/DecomposeHorizontallyFusedGemms.cpp
@@ -1,0 +1,245 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/GPU/Passes.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.h"
+#include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_DECOMPOSEHORIZONTALLYFUSEDGEMMSPASS
+#include "iree/compiler/Codegen/Common/GPU/Passes.h.inc"
+
+namespace {
+
+struct DecomposeHorizontallyFusedGemmsPass final
+    : impl::DecomposeHorizontallyFusedGemmsPassBase<
+          DecomposeHorizontallyFusedGemmsPass> {
+  void runOnOperation() override;
+};
+} // namespace
+
+//===---------------------------------------------------------------------===//
+// Decompose horizontally fused gemm operations
+// TODO: Eventually drop this if we end up creating an operation for the
+// horizontally fused contractions.
+//===---------------------------------------------------------------------===//
+
+static LogicalResult captureUsedOperationsAndBlockArguements(
+    linalg::LinalgOp linalgOp, SetVector<int64_t> &usedInputs,
+    SetVector<Operation *> &usedOperations, int64_t resultNumber) {
+  BackwardSliceOptions options;
+  options.inclusive = true;
+  options.filter = [&](Operation *op) -> bool {
+    return op->getBlock() == linalgOp.getBlock();
+  };
+
+  auto yieldOp = cast<linalg::YieldOp>(linalgOp.getBlock()->getTerminator());
+  Value result = yieldOp.getOperand(resultNumber);
+
+  getBackwardSlice(result, &usedOperations, options);
+
+  // Get all block arguments used by the operations. If any of the arguments
+  // used is a dpsInit argument other than resultNumber, return failure.
+  for (Operation *op : usedOperations) {
+    for (Value operand : op->getOperands()) {
+      if (auto blockArg = dyn_cast<BlockArgument>(operand)) {
+        if (blockArg.getOwner() != linalgOp.getBlock()) {
+          continue;
+        }
+
+        int64_t argNumber = blockArg.getArgNumber();
+        if (argNumber >= linalgOp.getNumDpsInputs() &&
+            argNumber - linalgOp.getNumDpsInputs() != resultNumber) {
+          return failure();
+        }
+
+        if (argNumber < linalgOp.getNumDpsInputs()) {
+          usedInputs.insert(argNumber);
+        }
+      }
+    }
+  }
+
+  return success();
+}
+
+// Since the `promotedOperands` changes that needs to be modified
+// and transfered over to the decomposed ops.
+static IREE::GPU::LoweringConfigAttr
+getModifiedLoweringConfigForDecomposedGemmOp(
+    RewriterBase &rewriter, IREE::GPU::LoweringConfigAttr origAttr,
+    ArrayRef<unsigned> keptOperands) {
+  std::optional<SmallVector<int64_t>> promotedOperandsList =
+      IREE::GPU::getPromotedOperandList(origAttr);
+  if (!promotedOperandsList) {
+    return origAttr;
+  }
+
+  llvm::SmallDenseSet<int64_t> promotedOperandsSet(
+      promotedOperandsList->begin(), promotedOperandsList->end());
+  SmallVector<NamedAttribute> attrs;
+  auto promotedOperandsListName = IREE::GPU::getPromotedOperandListAttrName();
+  for (auto origAttr : origAttr.getAttributes().getValue()) {
+    if (origAttr.getName().getValue() != promotedOperandsListName) {
+      attrs.push_back(origAttr);
+      continue;
+    }
+    SmallVector<int64_t> newPromotedOperands;
+    for (auto [index, origOperandNum] : llvm::enumerate(keptOperands)) {
+      if (promotedOperandsSet.contains(origOperandNum)) {
+        newPromotedOperands.push_back(index);
+      }
+    }
+
+    attrs.emplace_back(
+        NamedAttribute{promotedOperandsListName,
+                       rewriter.getI64ArrayAttr(newPromotedOperands)});
+  }
+
+  return IREE::GPU::LoweringConfigAttr::get(rewriter.getContext(),
+                                            rewriter.getDictionaryAttr(attrs));
+}
+
+static LogicalResult
+decomposeHorizontallyFusedGemmOperations(RewriterBase &rewriter,
+                                         linalg::LinalgOp linalgOp) {
+  assert(IREE::LinalgExt::isaHorizontallyFusedContraction(linalgOp) &&
+         "expected op that is a horizontally fused contraction");
+
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(linalgOp);
+  // Create num_results linalg.generics, each producing a single result (and
+  // relying on canonicalizations to simplify).
+  for (int64_t resultNumber : llvm::seq<int64_t>(linalgOp->getNumResults())) {
+    rewriter.setInsertionPoint(linalgOp);
+
+    auto yieldOp = cast<linalg::YieldOp>(linalgOp.getBlock()->getTerminator());
+    Value result = yieldOp.getOperand(resultNumber);
+
+    // Get all operations required to produce this result.
+    SetVector<Operation *> usedOperations;
+    SetVector<int64_t> usedInputs;
+    if (failed(captureUsedOperationsAndBlockArguements(
+            linalgOp, usedInputs, usedOperations, resultNumber))) {
+      return failure();
+    }
+
+    // Create a new linalg.generic operation for this result.
+    SmallVector<OpOperand *> inputs = llvm::map_to_vector(
+        usedInputs, [&](int64_t x) { return linalgOp.getDpsInputOperand(x); });
+    SmallVector<OpOperand *> inits = {linalgOp.getDpsInitOperand(resultNumber)};
+
+    SmallVector<AffineMap> indexingMaps =
+        llvm::map_to_vector(usedInputs, [&](int64_t x) {
+          return linalgOp.getIndexingMapsArray()[x];
+        });
+    indexingMaps.push_back(linalgOp.getIndexingMapMatchingResult(
+        linalgOp->getOpResult(resultNumber)));
+    llvm::SmallBitVector unusedDims = getUnusedDimsBitVector(indexingMaps);
+    indexingMaps = compressUnusedDims(indexingMaps);
+
+    SmallVector<utils::IteratorType> iteratorTypes;
+    for (int64_t i : llvm::seq<int64_t>(linalgOp.getNumLoops())) {
+      if (!unusedDims.test(i)) {
+        iteratorTypes.push_back(linalgOp.getIteratorTypesArray()[i]);
+      }
+    }
+
+    SmallVector<Value> inputVals = llvm::map_to_vector(
+        inputs, [](OpOperand *operand) { return operand->get(); });
+    SmallVector<Value> initVals = llvm::map_to_vector(
+        inits, [](OpOperand *operand) { return operand->get(); });
+    auto newOp = rewriter.create<linalg::GenericOp>(
+        linalgOp.getLoc(), TypeRange{inits[0]->get().getType()}, inputVals,
+        initVals, indexingMaps, iteratorTypes,
+        [&](OpBuilder &b, Location loc, ValueRange blockArgs) {
+          Block *oldBody = linalgOp.getBlock();
+          usedInputs.insert(resultNumber + linalgOp.getNumDpsInputs());
+
+          IRMapping regionMapping;
+
+          for (auto [oldBlockArgNum, newBlockArg] :
+               llvm::zip_equal(usedInputs, blockArgs)) {
+            regionMapping.map(oldBody->getArgument(oldBlockArgNum),
+                              newBlockArg);
+          }
+
+          for (Operation *usedOperation : usedOperations) {
+            b.clone(*usedOperation, regionMapping);
+          }
+
+          b.create<linalg::YieldOp>(loc, regionMapping.lookup(result));
+        });
+
+    if (unusedDims.none()) {
+      DictionaryAttr origDictAttr = linalgOp->getDiscardableAttrDictionary();
+      auto loweringConfigAttr = dyn_cast_or_null<IREE::GPU::LoweringConfigAttr>(
+          origDictAttr.get(IREE::GPU::LoweringConfigAttr::getMnemonic()));
+      DictionaryAttr newDictAttr;
+      if (loweringConfigAttr &&
+          loweringConfigAttr.getAttributes().get(
+              IREE::GPU::getPromotedOperandListAttrName())) {
+        SmallVector<NamedAttribute> newAttrList;
+        for (auto origAttr : origDictAttr.getValue()) {
+          if (origAttr.getName() !=
+              IREE::GPU::LoweringConfigAttr::getMnemonic()) {
+            newAttrList.push_back(origAttr);
+            continue;
+          }
+          SmallVector<unsigned> operandNums =
+              llvm::map_to_vector(inputs, [](OpOperand *operand) {
+                return operand->getOperandNumber();
+              });
+          auto range = llvm::map_range(inits, [](OpOperand *operand) {
+            return operand->getOperandNumber();
+          });
+          operandNums.append(range.begin(), range.end());
+          auto origGPUAttr =
+              cast<IREE::GPU::LoweringConfigAttr>(origAttr.getValue());
+          IREE::GPU::LoweringConfigAttr newGPUAttr =
+              getModifiedLoweringConfigForDecomposedGemmOp(
+                  rewriter, origGPUAttr, operandNums);
+          newAttrList.emplace_back(
+              NamedAttribute{origAttr.getName(), newGPUAttr});
+        }
+        newDictAttr = DictionaryAttr::get(rewriter.getContext(), newAttrList);
+      } else {
+        newDictAttr = origDictAttr;
+      }
+      newOp->setDiscardableAttrs(newDictAttr);
+    }
+
+    rewriter.replaceAllUsesWith(linalgOp->getResult(resultNumber),
+                                newOp.getResult(0));
+  }
+
+  rewriter.eraseOp(linalgOp);
+  return success();
+}
+
+void DecomposeHorizontallyFusedGemmsPass::runOnOperation() {
+  auto funcOp = getOperation();
+  IRRewriter rewriter(&getContext());
+  SmallVector<linalg::LinalgOp> horizontallyFusedOps;
+  funcOp.walk([&](linalg::LinalgOp linalgOp) {
+    if (IREE::LinalgExt::isaHorizontallyFusedContraction(linalgOp)) {
+      horizontallyFusedOps.push_back(linalgOp);
+    }
+  });
+
+  for (auto linalgOp : llvm::make_early_inc_range(horizontallyFusedOps)) {
+    if (failed(decomposeHorizontallyFusedGemmOperations(rewriter, linalgOp))) {
+      return signalPassFailure();
+    }
+  }
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -13,6 +13,18 @@ include "mlir/Pass/PassBase.td"
 // Common Passes used for GPU-like backends (keep alphabetical)
 //===---------------------------------------------------------------------===//
 
+def DecomposeHorizontallyFusedGemmsPass :
+    InterfacePass<"iree-codegen-gpu-decompose-horizontally-fused-gemms",
+                  "mlir::FunctionOpInterface"> {
+  let summary =
+      "Decomposes a horizontally fused GEMM back into its constituent GEMMs";
+  let dependentDialects = [
+    "::mlir::iree_compiler::IREE::GPU::IREEGPUDialect",
+    "::mlir::linalg::LinalgDialect",
+  ];
+}
+
+
 def GPUCheckResourceUsagePass :
     InterfacePass<"iree-codegen-gpu-check-resource-usage", "mlir::FunctionOpInterface"> {
   let summary = "Checks GPU specific resource usage constraints like shared memory limits";

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "decompose_horizontally_fused_gemms.mlir",
             "gpu_apply_derived_thread_config.mlir",
             "gpu_apply_tiling_level.mlir",
             "gpu_check_resource_usage.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "decompose_horizontally_fused_gemms.mlir"
     "gpu_apply_derived_thread_config.mlir"
     "gpu_apply_tiling_level.mlir"
     "gpu_check_resource_usage.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/decompose_horizontally_fused_gemms.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/decompose_horizontally_fused_gemms.mlir
@@ -1,0 +1,166 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-decompose-horizontally-fused-gemms))" --split-input-file --mlir-print-local-scope %s | FileCheck %s
+
+func.func @fused_contraction_1(%arg0: tensor<2x4096x640xf16>,
+    %arg1: tensor<10x64x640xf16>, %arg2: tensor<10x64x640xf16>,
+    %arg3: tensor<10x64x640xf16>)
+    -> (tensor<2x10x4096x64xf32>, tensor<2x10x4096x64xf32>, tensor<2x10x4096x64xf32>) {
+    %0 = tensor.empty() : tensor<2x10x4096x64xf16>
+    %1 = tensor.empty() : tensor<2x10x4096x64xf32>
+    %cst = arith.constant 0.000000e+00 : f32
+    %2 = linalg.fill ins(%cst : f32) outs(%1 : tensor<2x10x4096x64xf32>) -> tensor<2x10x4096x64xf32>
+    %3:3 = linalg.generic {
+        indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4)>,
+                         affine_map<(d0, d1, d2, d3, d4) -> (d1, d3, d4)>,
+                         affine_map<(d0, d1, d2, d3, d4) -> (d1, d3, d4)>,
+                         affine_map<(d0, d1, d2, d3, d4) -> (d1, d3, d4)>,
+                         affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>,
+                         affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>,
+                         affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>],
+        iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]}
+        ins(%arg0, %arg1, %arg2, %arg3 : tensor<2x4096x640xf16>, tensor<10x64x640xf16>, tensor<10x64x640xf16>, tensor<10x64x640xf16>)
+        outs(%2, %2, %2 : tensor<2x10x4096x64xf32>, tensor<2x10x4096x64xf32>, tensor<2x10x4096x64xf32>)
+        attrs = {
+            lowering_config = #iree_gpu.lowering_config<{
+                mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16>, promote_operands = [0, 1, 2, 3],
+                reduction = [0, 0, 0, 0, 128], subgroup_m_count = 2 : i64, subgroup_n_count = 2 : i64,
+                workgroup = [1, 1, 32, 32, 0]}>} {
+    ^bb0(%in: f16, %in_0: f16, %in_1: f16, %in_2: f16, %out: f32, %out_3: f32, %out_4: f32):
+      %7 = arith.extf %in : f16 to f32
+      %8 = arith.extf %in_0 : f16 to f32
+      %9 = arith.mulf %7, %8 : f32
+      %10 = arith.addf %out, %9 : f32
+      %11 = arith.extf %in_1 : f16 to f32
+      %12 = arith.mulf %7, %11 : f32
+      %13 = arith.addf %out_3, %12 : f32
+      %14 = arith.extf %in_2 : f16 to f32
+      %15 = arith.mulf %7, %14 : f32
+      %16 = arith.addf %out_4, %15 : f32
+      linalg.yield %10, %13, %16 : f32, f32, f32
+  } -> (tensor<2x10x4096x64xf32>, tensor<2x10x4096x64xf32>, tensor<2x10x4096x64xf32>)
+  return %3#0, %3#1, %3#2 : tensor<2x10x4096x64xf32>, tensor<2x10x4096x64xf32>, tensor<2x10x4096x64xf32>
+}
+// CHECK-LABEL: func @fused_contraction_1
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<2x4096x640xf16>
+//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<10x64x640xf16>
+//  CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<10x64x640xf16>
+//  CHECK-SAME:     %[[ARG3:[a-zA-Z0-9]+]]: tensor<10x64x640xf16>
+//       CHECK:   %[[FILL:.+]] = linalg.fill
+//       CHECK:   %[[GENERIC0:.+]] = linalg.generic
+//  CHECK-SAME:       indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4)>
+//  CHECK-SAME:                        affine_map<(d0, d1, d2, d3, d4) -> (d1, d3, d4)>
+//  CHECK-SAME:                        affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
+//  CHECK-SAME:       iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]
+//  CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
+//  CHECK-SAME:       outs(%[[FILL]] :
+//  CHECK-SAME:       iree_gpu.lowering_config
+//  CHECK-SAME:           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16
+//  CHECK-SAME:           promote_operands = [0, 1]
+//  CHECK-SAME:           reduction = [0, 0, 0, 0, 128]
+//  CHECK-SAME:           subgroup_m_count = 2
+//  CHECK-SAME:           subgroup_n_count = 2
+//  CHECK-SAME:           workgroup = [1, 1, 32, 32, 0]
+//       CHECK:     ^bb0(%[[B0_0:[a-zA-Z0-9_]+]]: f16, %[[B1_0:[a-zA-Z0-9_]+]]: f16, %[[B2_0:[a-zA-Z0-9_]+]]: f32
+//   CHECK-DAG:       %[[LHS_0:.+]] = arith.extf %[[B0_0]]
+//   CHECK-DAG:       %[[RHS_0:.+]] = arith.extf %[[B1_0]]
+//   CHECK-DAG:       %[[MUL_0:.+]] = arith.mulf %[[LHS_0]], %[[RHS_0]]
+//   CHECK-DAG:       %[[ADD_0:.+]] = arith.addf %[[B2_0]], %[[MUL_0]]
+//   CHECK-DAG:       linalg.yield %[[ADD_0]]
+//       CHECK:   %[[GENERIC1:.+]] = linalg.generic
+//  CHECK-SAME:       indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4)>
+//  CHECK-SAME:                        affine_map<(d0, d1, d2, d3, d4) -> (d1, d3, d4)>
+//  CHECK-SAME:                        affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
+//  CHECK-SAME:       iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]
+//  CHECK-SAME:       ins(%[[ARG0]], %[[ARG2]] :
+//  CHECK-SAME:       outs(%[[FILL]] :
+//  CHECK-SAME:       iree_gpu.lowering_config
+//  CHECK-SAME:           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16
+//  CHECK-SAME:           promote_operands = [0, 1]
+//  CHECK-SAME:           reduction = [0, 0, 0, 0, 128]
+//  CHECK-SAME:           subgroup_m_count = 2
+//  CHECK-SAME:           subgroup_n_count = 2
+//  CHECK-SAME:           workgroup = [1, 1, 32, 32, 0]
+//       CHECK:     ^bb0(%[[B0_1:[a-zA-Z0-9_]+]]: f16, %[[B1_1:[a-zA-Z0-9_]+]]: f16, %[[B2_1:[a-zA-Z0-9_]+]]: f32
+//   CHECK-DAG:       %[[LHS_1:.+]] = arith.extf %[[B0_1]]
+//   CHECK-DAG:       %[[RHS_1:.+]] = arith.extf %[[B1_1]]
+//   CHECK-DAG:       %[[MUL_1:.+]] = arith.mulf %[[LHS_1]], %[[RHS_1]]
+//   CHECK-DAG:       %[[ADD_1:.+]] = arith.addf %[[B2_1]], %[[MUL_1]]
+//   CHECK-DAG:       linalg.yield %[[ADD_1]]
+//       CHECK:   %[[GENERIC2:.+]] = linalg.generic
+//  CHECK-SAME:       indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4)>
+//  CHECK-SAME:                        affine_map<(d0, d1, d2, d3, d4) -> (d1, d3, d4)>
+//  CHECK-SAME:                        affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
+//  CHECK-SAME:       iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]
+//  CHECK-SAME:       ins(%[[ARG0]], %[[ARG3]] :
+//  CHECK-SAME:       outs(%[[FILL]] :
+//  CHECK-SAME:       iree_gpu.lowering_config
+//  CHECK-SAME:           mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_F16
+//  CHECK-SAME:           promote_operands = [0, 1]
+//  CHECK-SAME:           reduction = [0, 0, 0, 0, 128]
+//  CHECK-SAME:           subgroup_m_count = 2
+//  CHECK-SAME:           subgroup_n_count = 2
+//  CHECK-SAME:           workgroup = [1, 1, 32, 32, 0]
+//       CHECK:     ^bb0(%[[B0_2:[a-zA-Z0-9_]+]]: f16, %[[B1_2:[a-zA-Z0-9_]+]]: f16, %[[B2_2:[a-zA-Z0-9_]+]]: f32
+//   CHECK-DAG:       %[[LHS_2:.+]] = arith.extf %[[B0_2]]
+//   CHECK-DAG:       %[[RHS_2:.+]] = arith.extf %[[B1_2]]
+//   CHECK-DAG:       %[[MUL_2:.+]] = arith.mulf %[[LHS_2]], %[[RHS_2]]
+//   CHECK-DAG:       %[[ADD_2:.+]] = arith.addf %[[B2_2]], %[[MUL_2]]
+//   CHECK-DAG:       linalg.yield %[[ADD_2]]
+//       CHECK:   return %[[GENERIC0]], %[[GENERIC1]], %[[GENERIC2]]
+
+// -----
+
+func.func @fused_contraction_2(%arg0: tensor<4096x640xf32>,
+    %arg1: tensor<640x640xf32>, %arg2: tensor<640x640xf32>, %arg3: tensor<640x640xf32>)
+    -> (tensor<4096x640xf32>, tensor<4096x640xf32>, tensor<4096x640xf32>) {
+    %0 = tensor.empty() : tensor<4096x640xf32>
+    %1 = tensor.empty() : tensor<4096x640xf32>
+    %cst = arith.constant 0.000000e+00 : f32
+    %2 = linalg.fill ins(%cst : f32) outs(%1 : tensor<4096x640xf32>) -> tensor<4096x640xf32>
+    %3:3 = linalg.generic {
+        indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
+                         affine_map<(d0, d1, d2) -> (d2, d1)>,
+                         affine_map<(d0, d1, d2) -> (d2, d1)>,
+                         affine_map<(d0, d1, d2) -> (d2, d1)>,
+                         affine_map<(d0, d1, d2) -> (d0, d1)>,
+                         affine_map<(d0, d1, d2) -> (d0, d1)>,
+                         affine_map<(d0, d1, d2) -> (d0, d1)>],
+        iterator_types = ["parallel", "parallel", "reduction"]}
+        ins(%arg0, %arg1, %arg2, %arg3 : tensor<4096x640xf32>, tensor<640x640xf32>, tensor<640x640xf32>, tensor<640x640xf32>)
+        outs(%2, %2, %2 : tensor<4096x640xf32>, tensor<4096x640xf32>, tensor<4096x640xf32>)
+        attrs = {
+            lowering_config = #iree_gpu.lowering_config<{
+                mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x4_F32>, promote_operands = [0, 1, 2, 3],
+                reduction = [0, 0, 16], subgroup_m_count = 2 : i64, subgroup_n_count = 2 : i64, workgroup = [32, 64, 0]}>} {
+    ^bb0(%in: f32, %in_0: f32, %in_1: f32, %in_2: f32, %out: f32, %out_3: f32, %out_4: f32):
+      %4 = arith.mulf %in, %in_0 : f32
+      %5 = arith.addf %out, %4 : f32
+      %6 = arith.mulf %in, %in_1 : f32
+      %7 = arith.addf %out_3, %6 : f32
+      %8 = arith.mulf %in, %in_2 : f32
+      %9 = arith.addf %out_4, %8 : f32
+      linalg.yield %5, %7, %9 : f32, f32, f32
+  } -> (tensor<4096x640xf32>, tensor<4096x640xf32>, tensor<4096x640xf32>)
+  return %3#0, %3#1, %3#2 : tensor<4096x640xf32>, tensor<4096x640xf32>, tensor<4096x640xf32>
+}
+// CHECK-LABEL: func @fused_contraction_2
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<4096x640xf32>
+//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<640x640xf32>
+//  CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<640x640xf32>
+//  CHECK-SAME:     %[[ARG3:[a-zA-Z0-9]+]]: tensor<640x640xf32>
+//       CHECK:   %[[FILL:.+]] = linalg.fill
+//       CHECK:   %[[GENERIC0:.+]] = linalg.generic
+//       CHECK:     ^bb0(%[[B0_0:[a-zA-Z0-9_]+]]: f32, %[[B1_0:[a-zA-Z0-9_]+]]: f32, %[[B2_0:[a-zA-Z0-9_]+]]: f32
+//   CHECK-DAG:       %[[MUL_0:.+]] = arith.mulf %[[B0_0]], %[[B1_0]]
+//   CHECK-DAG:       %[[ADD_0:.+]] = arith.addf %[[B2_0]], %[[MUL_0]]
+//   CHECK-DAG:       linalg.yield %[[ADD_0]]
+//       CHECK:   %[[GENERIC1:.+]] = linalg.generic
+//       CHECK:     ^bb0(%[[B0_1:[a-zA-Z0-9_]+]]: f32, %[[B1_1:[a-zA-Z0-9_]+]]: f32, %[[B2_1:[a-zA-Z0-9_]+]]: f32
+//   CHECK-DAG:       %[[MUL_1:.+]] = arith.mulf %[[B0_1]], %[[B1_1]]
+//   CHECK-DAG:       %[[ADD_1:.+]] = arith.addf %[[B2_1]], %[[MUL_1]]
+//   CHECK-DAG:       linalg.yield %[[ADD_1]]
+//       CHECK:   %[[GENERIC2:.+]] = linalg.generic
+//       CHECK:     ^bb0(%[[B0_2:[a-zA-Z0-9_]+]]: f32, %[[B1_2:[a-zA-Z0-9_]+]]: f32, %[[B2_2:[a-zA-Z0-9_]+]]: f32
+//   CHECK-DAG:       %[[MUL_2:.+]] = arith.mulf %[[B0_2]], %[[B1_2]]
+//   CHECK-DAG:       %[[ADD_2:.+]] = arith.addf %[[B2_2]], %[[MUL_2]]
+//   CHECK-DAG:       linalg.yield %[[ADD_2]]
+//       CHECK:   return %[[GENERIC0]], %[[GENERIC1]], %[[GENERIC2]]

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.cpp
@@ -118,6 +118,8 @@ FailureOr<Basis> getBasis(IREE::GPU::LoweringConfigAttr config,
 
 constexpr StringLiteral kPromoteOperandsName = "promote_operands";
 
+StringRef getPromotedOperandListAttrName() { return kPromoteOperandsName; }
+
 std::optional<SmallVector<int64_t>>
 getPromotedOperandList(LoweringConfigAttr config) {
   auto array = config.getAttributes().getAs<ArrayAttr>(kPromoteOperandsName);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.h
@@ -50,6 +50,7 @@ void setBasis(MLIRContext *context, SmallVector<NamedAttribute> &attrs,
               IREE::GPU::TilingLevel level, const Basis &basis);
 
 /// Helper to retrieve/set a list of operand indices to promote.
+StringRef getPromotedOperandListAttrName();
 std::optional<SmallVector<int64_t>>
 getPromotedOperandList(LoweringConfigAttr config);
 void setPromotedOperandList(MLIRContext *context,

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/GPULoweringConfigUtils.h
@@ -50,12 +50,18 @@ void setBasis(MLIRContext *context, SmallVector<NamedAttribute> &attrs,
               IREE::GPU::TilingLevel level, const Basis &basis);
 
 /// Helper to retrieve/set a list of operand indices to promote.
-StringRef getPromotedOperandListAttrName();
 std::optional<SmallVector<int64_t>>
 getPromotedOperandList(LoweringConfigAttr config);
-void setPromotedOperandList(MLIRContext *context,
-                            SmallVectorImpl<NamedAttribute> &attrs,
-                            ArrayRef<int64_t> operands);
+/// Append to `attrs` an `ArrayAttr` for `promotedOperands`.
+void appendPromotedOperandsList(MLIRContext *context,
+                                SmallVectorImpl<NamedAttribute> &attrs,
+                                ArrayRef<int64_t> operands);
+/// Create a new `LoweringConfigAttr` from `currAttr` with the promoted operands
+/// list modified/set to `operands`.
+IREE::GPU::LoweringConfigAttr
+setPromotedOperandsList(MLIRContext *context,
+                        IREE::GPU::LoweringConfigAttr currAttr,
+                        ArrayRef<int64_t> operands);
 
 /// Helper to retrieve  list of operand to pad.
 std::optional<SmallVector<int64_t>> getPaddingList(LoweringConfigAttr config);

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -95,7 +95,7 @@ LogicalResult setDataTiledMultiMmaLoweringConfig(
     // large to fit in shared memory, so they just want global memory and they
     // will take care of moving small chunks at a time into a shared memory
     // operand that will be created together with the ukernel op.
-    GPU::setPromotedOperandList(context, attrs, {0, 1});
+    GPU::appendPromotedOperandsList(context, attrs, {0, 1});
   }
   auto configDict = b.getDictionaryAttr(attrs);
   auto loweringConfig = IREE::GPU::LoweringConfigAttr::get(context, configDict);
@@ -346,11 +346,11 @@ getMatmulLoweringConfigAndWorkgroupSize(SmallVector<int64_t> bounds,
                      b.getI64ArrayAttr(subgroupTileSizes));
   attrs.emplace_back(StringAttr::get(context, "mma_kind"), mmaKind);
   if (mustBeAligned) {
-    GPU::setPromotedOperandList(context, attrs, {0, 1});
+    GPU::appendPromotedOperandsList(context, attrs, {0, 1});
   } else {
     // TODO (nirvedhmeshram, Max191, jerryyin) : Add support so that unaligned
     // shapes do not require c promotion.
-    GPU::setPromotedOperandList(context, attrs, {0, 1, 2});
+    GPU::appendPromotedOperandsList(context, attrs, {0, 1, 2});
     SmallVector<int64_t> paddingTileSizes = workgroupTileSizes;
 
     // Initialize inner and outer padding sizes from reductionTileSizes.
@@ -763,7 +763,7 @@ LogicalResult setTileAndFuseLoweringConfig(IREE::GPU::TargetAttr target,
                      b.getI64ArrayAttr(threadTileSizes));
 
   if (isNonMatvecContraction(linalgOp)) {
-    GPU::setPromotedOperandList(context, attrs, {0, 1});
+    GPU::appendPromotedOperandsList(context, attrs, {0, 1});
   }
 
   if (llvm::any_of(loopTileSizes, [](int64_t s) { return s != 0; })) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -429,7 +429,7 @@ setConvolutionVectorDistributionConfig(IREE::GPU::TargetAttr target,
   SmallVector<NamedAttribute, 2> attrs = {
       NamedAttribute("workgroup", b.getI64ArrayAttr(workgroupTileSizes)),
       NamedAttribute("reduction", b.getI64ArrayAttr(reductionTileSizes))};
-  IREE::GPU::setPromotedOperandList(context, attrs, {0, 1});
+  IREE::GPU::appendPromotedOperandsList(context, attrs, {0, 1});
   IREE::GPU::setMmaKind(context, attrs, mmaKinds[schedule->index]);
   IREE::GPU::setSubgroupMCount(context, attrs, schedule->mSubgroupCounts[0]);
   IREE::GPU::setSubgroupNCount(context, attrs, schedule->nSubgroupCounts[0]);
@@ -712,7 +712,7 @@ setMatmulVectorDistributionConfig(IREE::GPU::TargetAttr target,
       NamedAttribute("reduction", b.getI64ArrayAttr(reductionTileSizes))};
   auto promotedOperands =
       llvm::to_vector(llvm::seq<int64_t>(op.getNumDpsInputs()));
-  IREE::GPU::setPromotedOperandList(context, attrs, promotedOperands);
+  IREE::GPU::appendPromotedOperandsList(context, attrs, promotedOperands);
   IREE::GPU::setMmaKind(context, attrs, mmaKinds[schedule->index]);
   IREE::GPU::setSubgroupMCount(context, attrs, schedule->mSubgroupCounts[0]);
   IREE::GPU::setSubgroupNCount(context, attrs, schedule->nSubgroupCounts[0]);
@@ -926,7 +926,7 @@ static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
   SmallVector<NamedAttribute, 2> attrs = {
       NamedAttribute("workgroup", b.getI64ArrayAttr(workgroupTileSizes)),
       NamedAttribute("reduction", b.getI64ArrayAttr(reductionTileSizes))};
-  IREE::GPU::setPromotedOperandList(context, attrs, {0, 1, 2});
+  IREE::GPU::appendPromotedOperandsList(context, attrs, {0, 1, 2});
 
   SmallVector<NamedAttribute, 2> qkConfig;
   SmallVector<NamedAttribute, 2> pvConfig;
@@ -941,13 +941,13 @@ static LogicalResult setAttentionIntrinsicBasedVectorDistributionConfig(
 
   // Configuring for qk matmul.
   // subgroup_n count for qk matmul is always 1, since we do not tile K1.
-  IREE::GPU::setPromotedOperandList(context, qkConfig, {0, 1});
+  IREE::GPU::appendPromotedOperandsList(context, qkConfig, {0, 1});
   IREE::GPU::setMmaKind(context, qkConfig, mmaKinds[schedule->index]);
   IREE::GPU::setSubgroupMCount(context, qkConfig, schedule->mSubgroupCounts[0]);
   IREE::GPU::setSubgroupNCount(context, qkConfig, 1);
 
   // Configuring for pv matmul.
-  IREE::GPU::setPromotedOperandList(context, pvConfig, {1});
+  IREE::GPU::appendPromotedOperandsList(context, pvConfig, {1});
   IREE::GPU::setMmaKind(context, pvConfig, mmaKinds[schedule->index]);
   IREE::GPU::setSubgroupMCount(context, pvConfig, schedule->mSubgroupCounts[0]);
   IREE::GPU::setSubgroupNCount(context, pvConfig, schedule->nSubgroupCounts[0]);
@@ -2164,7 +2164,7 @@ static LogicalResult setArgmaxUkernelConfig(
       NamedAttribute("workgroup", b.getI64ArrayAttr(workgroupTileSizes)),
       NamedAttribute("reduction", b.getI64ArrayAttr(reductionTileSizes)),
       NamedAttribute("ukernel", ukernelConfig)};
-  IREE::GPU::setPromotedOperandList(context, attrs, {0, 1});
+  IREE::GPU::appendPromotedOperandsList(context, attrs, {0, 1});
   auto configDict = DictionaryAttr::get(context, attrs);
   auto loweringConfig = IREE::GPU::LoweringConfigAttr::get(context, configDict);
   if (failed(setOpConfigAndEntryPointFnTranslation(


### PR DESCRIPTION
Currently this is done using a pass that uses a recognizer. It might
be more ergnomic to just add an operation for the horizontally fused
gemm operation.

Signed-off-by: MaheshRavishankar <mahesh.ravishankar@gmail.com>