### PR TITLE
[CUDA][Integrate] Switch CUDATarget to ptx_kernel cc.

### DIFF
--- a/compiler/plugins/target/CUDA/CUDATarget.cpp
+++ b/compiler/plugins/target/CUDA/CUDATarget.cpp
@@ -545,7 +545,7 @@ public:
         };
 
         // Mark the entry point as a kernel.
-        setMetadataValueI32("kernel", 1);
+        llvmFunc->setCallingConv(llvm::CallingConv::PTX_Kernel);
 
         // Set the maximum number of threads in the thread block (CTA).
         auto exportOp = exportOpMap[funcOp.getName()];


### PR DESCRIPTION
This drops the local LLVM revert: https://github.com/llvm/llvm-project/commit/de7438e472839df63e1f10478436c2f15b8e4184