### PR TITLE
[Integrate] Add arg/res_attrs to ops that implement CallOpInterface.

### DIFF
--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/ConvertStreamableOps.cpp
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/ConvertStreamableOps.cpp
@@ -269,7 +269,8 @@ static LogicalResult convertStreamableCall(StreamableFunc &streamableFunc,
     auto calculateCallOp = builder.create<IREE::Util::CallOp>(
         callOp.getLoc(), resultDimTypes,
         streamableFunc.resultDimsFunc.getLeafReference().getValue(),
-        callOp.getOperands(), ArrayAttr{});
+        callOp.getOperands(), /*tied_operands=*/ArrayAttr{},
+        callOp.getArgAttrsAttr(), callOp.getResAttrsAttr());
     llvm::append_range(resultDims, calculateCallOp.getResults());
   } else {
     // Get the shape dimensions from existing call arguments or tied operands.

--- a/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
@@ -121,7 +121,8 @@ emitLinkedTuningSpec(ModuleOp module, ArrayRef<NamedSequenceOp> specsToLink) {
     operand = builder
                   .create<transform::IncludeOp>(
                       loc, anyOpType, symbol,
-                      transform::FailurePropagationMode::Suppress, operand)
+                      transform::FailurePropagationMode::Suppress, operand,
+                      /*arg_attrs=*/nullptr, /*res_attrs=*/nullptr)
                   .getResults()
                   .front();
   }

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -1566,7 +1566,7 @@ void FuncOp::build(OpBuilder &builder, OperationState &state, StringRef name,
   if (!argAttrs.empty() || !resAttrs.empty()) {
     assert(type.getNumInputs() == argAttrs.size());
     assert(type.getNumResults() == resAttrs.size());
-    function_interface_impl::addArgAndResultAttrs(
+    call_interface_impl::addArgAndResultAttrs(
         builder, state, argAttrs, resAttrs, builder.getStringAttr("arg_attrs"),
         builder.getStringAttr("res_attrs"));
   }

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -964,7 +964,9 @@ def FLOW_CallOp : FLOW_Op<"call", [
     Variadic<AnyType>:$arguments,
     FLOW_ShapeDynamicDims:$argument_dims,
     FLOW_ShapeDynamicDims:$result_dims,
-    OptionalAttr<Util_TiedOpStorageAttr>:$tied_operands
+    OptionalAttr<Util_TiedOpStorageAttr>:$tied_operands,
+    OptionalAttr<DictArrayAttr>:$arg_attrs,
+    OptionalAttr<DictArrayAttr>:$res_attrs
   );
   let results = (outs
     Variadic<AnyType>:$results

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
@@ -924,7 +924,8 @@ struct CmdCallOpPattern
 
     rewriter.replaceOpWithNewOp<IREE::Util::CallOp>(
         callOp, resultTypes, callOp.getCallee(), operands,
-        /*tied_operands=*/ArrayAttr{});
+        /*tied_operands=*/ArrayAttr{}, callOp.getArgAttrsAttr(),
+        callOp.getResAttrsAttr());
     return success();
   }
 };

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -1778,7 +1778,7 @@ ParseResult ExecutableConstantBlockOp::parse(OpAsmParser &parser,
   bool isVariadic = false;
   SmallVector<DictionaryAttr> resultAttrs;
   SmallVector<Type> resultTypes;
-  if (mlir::function_interface_impl::parseFunctionSignature(
+  if (mlir::function_interface_impl::parseFunctionSignatureWithArguments(
           parser, /*allowVariadic=*/false, entryArgs, isVariadic, resultTypes,
           resultAttrs)) {
     return failure();
@@ -1826,7 +1826,7 @@ ParseResult ExecutableConstantBlockOp::parse(OpAsmParser &parser,
 
   // Add the attributes to the function arguments.
   assert(resultAttrs.size() == resultTypes.size());
-  mlir::function_interface_impl::addArgAndResultAttrs(
+  mlir::call_interface_impl::addArgAndResultAttrs(
       builder, result, entryArgs, resultAttrs, getArgAttrsAttrName(result.name),
       getResAttrsAttrName(result.name));
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
@@ -960,7 +960,7 @@ struct ConvertCallOp : public AffinityOpConversionPattern<IREE::Flow::CallOp> {
         op.getLoc(), resultTypes, adaptor.getCalleeAttr(), callOperands,
         callOperandSizes, callOperandOffsets, callOperandEnds,
         callOperandLengths, resultSizes, adaptor.getTiedOperandsAttr(),
-        executionAffinityAttr);
+        op.getArgAttrsAttr(), op.getResAttrsAttr(), executionAffinityAttr);
     newOp->setDialectAttrs(op->getDialectAttrs());
     replaceOpWithMultiple(op, newOp->getResults(), resultSizes, rewriter);
     return success();

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -2764,7 +2764,7 @@ void AsyncFuncOp::build(OpBuilder &builder, OperationState &state,
   if (!argAttrs.empty() || !resAttrs.empty()) {
     assert(type.getNumInputs() == argAttrs.size());
     assert(type.getNumResults() == resAttrs.size());
-    function_interface_impl::addArgAndResultAttrs(
+    call_interface_impl::addArgAndResultAttrs(
         builder, state, argAttrs, resAttrs, builder.getStringAttr("arg_attrs"),
         builder.getStringAttr("res_attrs"));
   }
@@ -3555,7 +3555,7 @@ void CmdFuncOp::build(OpBuilder &builder, OperationState &state, StringRef name,
   if (!argAttrs.empty() || !resAttrs.empty()) {
     assert(type.getNumInputs() == argAttrs.size());
     assert(type.getNumResults() == resAttrs.size());
-    function_interface_impl::addArgAndResultAttrs(
+    call_interface_impl::addArgAndResultAttrs(
         builder, state, argAttrs, resAttrs, builder.getStringAttr("arg_attrs"),
         builder.getStringAttr("res_attrs"));
   }

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -2684,6 +2684,8 @@ def Stream_AsyncCallOp : Stream_Op<"async.call", [
     Variadic<Stream_Size>:$resource_operand_lengths,
     Variadic<Stream_Size>:$result_sizes,
     OptionalAttr<Util_TiedOpStorageAttr>:$tied_operands,
+    OptionalAttr<DictArrayAttr>:$arg_attrs,
+    OptionalAttr<DictArrayAttr>:$res_attrs,
     OptionalAttr<Stream_AffinityAttr>:$affinity
   );
   let results = (outs
@@ -3368,6 +3370,8 @@ def Stream_CmdCallOp : Stream_Op<"cmd.call", [
     Variadic<Stream_Size>:$resource_operand_lengths,
     Variadic<Stream_Size>:$result_sizes,
     OptionalAttr<Util_TiedOpStorageAttr>:$tied_operands,
+    OptionalAttr<DictArrayAttr>:$arg_attrs,
+    OptionalAttr<DictArrayAttr>:$res_attrs,
     Stream_ResourceAccessArrayAttr:$resource_operand_accesses
   );
   let results = (outs

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
@@ -927,7 +927,8 @@ static LogicalResult applyAsyncCallOp(IREE::Stream::AsyncCallOp asyncOp,
       newResourceOperands, newResourceSizes, newResourceOffsets,
       newResourceLengths,
       /*result_sizes=*/ValueRange{},
-      /*tied_operands=*/nullptr, builder.getArrayAttr(newResourceAccesses));
+      /*tied_operands=*/nullptr, asyncOp.getArgAttrsAttr(),
+      asyncOp.getResAttrsAttr(), builder.getArrayAttr(newResourceAccesses));
   newOp->setDialectAttrs(asyncOp->getDialectAttrs());
   asyncOp.erase();
   return success();

--- a/compiler/src/iree/compiler/Dialect/Util/Conversion/ConversionPatterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Conversion/ConversionPatterns.cpp
@@ -151,7 +151,8 @@ struct ConvertCallOp : public OpConversionPattern<IREE::Util::CallOp> {
     }
     auto newOp = rewriter.replaceOpWithNewOp<IREE::Util::CallOp>(
         op, resultTypes, op.getCallee(), adaptor.getOperands(),
-        adaptor.getTiedOperandsAttr());
+        adaptor.getTiedOperandsAttr(), adaptor.getArgAttrsAttr(),
+        adaptor.getResAttrsAttr());
     newOp->setDialectAttrs(op->getDialectAttrs());
     return success();
   }

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.cpp
@@ -1624,7 +1624,7 @@ void FuncOp::build(OpBuilder &builder, OperationState &state, StringRef name,
   if (!argAttrs.empty() || !resAttrs.empty()) {
     assert(type.getNumInputs() == argAttrs.size());
     assert(type.getNumResults() == resAttrs.size());
-    function_interface_impl::addArgAndResultAttrs(
+    call_interface_impl::addArgAndResultAttrs(
         builder, state, argAttrs, resAttrs, builder.getStringAttr("arg_attrs"),
         builder.getStringAttr("res_attrs"));
   }
@@ -1716,7 +1716,7 @@ ParseResult FuncOp::parse(OpAsmParser &parser, OperationState &result) {
   result.attributes.append(parsedAttributes);
 
   assert(resultAttrs.size() == resultTypes.size());
-  function_interface_impl::addArgAndResultAttrs(
+  call_interface_impl::addArgAndResultAttrs(
       builder, result, arguments, resultAttrs,
       builder.getStringAttr("arg_attrs"), builder.getStringAttr("res_attrs"));
 
@@ -1913,7 +1913,8 @@ IREE::Util::CallOp IREE::Util::CallOp::cloneAndExpand(
 
   return builder.create<IREE::Util::CallOp>(
       getLoc(), newResultTypes, getCallee(), newOperands,
-      builder.getIndexArrayAttr(newTiedOperands));
+      builder.getIndexArrayAttr(newTiedOperands), getArgAttrsAttr(),
+      getResAttrsAttr());
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
@@ -778,7 +778,9 @@ def Util_CallOp : Util_Op<"call", [
   let arguments = (ins
     FlatSymbolRefAttr:$callee,
     Variadic<AnyType>:$operands,
-    OptionalAttr<Util_TiedOpStorageAttr>:$tied_operands
+    OptionalAttr<Util_TiedOpStorageAttr>:$tied_operands,
+    OptionalAttr<DictArrayAttr>:$arg_attrs,
+    OptionalAttr<DictArrayAttr>:$res_attrs
   );
   let results = (outs
     Variadic<AnyType>:$results
@@ -792,7 +794,7 @@ def Util_CallOp : Util_Op<"call", [
       CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs
     ), [{
       build($_builder, $_state, callee.getResultTypes(), callee.getName(),
-            operands, tied_operands);
+            operands, tied_operands, /*arg_attrs=*/nullptr, /*res_attrs=*/nullptr);
       $_state.addAttributes(attrs);
     }]>,
   ];

--- a/compiler/src/iree/compiler/Dialect/Util/TransformOps/UtilTransformOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/TransformOps/UtilTransformOps.cpp
@@ -243,7 +243,8 @@ DiagnosedSilenceableFailure IREE::Util::transform_dialect::CastAndCallOp::apply(
 
   auto callOp = rewriter.create<IREE::Util::CallOp>(
       insertionPoint->getLoc(), targetFunction.getResultTypes(),
-      targetFunction.getName(), inputs, /*tied_operands=*/ArrayAttr{});
+      targetFunction.getName(), inputs, /*tied_operands=*/ArrayAttr{},
+      /*arg_attrs=*/nullptr, /*res_attrs=*/nullptr);
 
   // Cast the call results back to the expected types. If any conversions fail
   // this is a definite failure as the call has been constructed at this point.

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/IPO.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/IPO.cpp
@@ -610,10 +610,11 @@ static bool applyCallChanges(FuncAnalysis &analysis,
     return false;
 
   // Fully replace call op because we may have changed result count.
-  // TODO(benvanik): update tied operands.
+  // TODO(benvanik): update tied operands, arg_attrs, and res_attrs.
   auto newCallOp = OpBuilder(callOp).create<IREE::Util::CallOp>(
       callOp.getLoc(), newResultTypes, callOp.getCalleeAttr(), newOperands,
-      /*tied_operands=*/ArrayAttr{});
+      /*tied_operands=*/ArrayAttr{},
+      /*arg_attrs=*/nullptr, /*res_attrs=*/nullptr);
   newCallOp->setDialectAttrs(callOp->getDialectAttrs());
 
   // Remap live old results -> new results.

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
@@ -120,10 +120,10 @@ void FuncOp::build(OpBuilder &builder, OperationState &result, StringRef name,
 
   assert(type.getNumInputs() == argAttrs.size() &&
          "expected as many argument attribute lists as arguments");
-  call_interface_impl::addArgAndResultAttrs(
-      builder, result, argAttrs,
-      /*resultAttrs=*/std::nullopt, getArgAttrsAttrName(result.name),
-      getResAttrsAttrName(result.name));
+  call_interface_impl::addArgAndResultAttrs(builder, result, argAttrs,
+                                            /*resultAttrs=*/std::nullopt,
+                                            getArgAttrsAttrName(result.name),
+                                            getResAttrsAttrName(result.name));
 }
 
 Block *FuncOp::addEntryBlock() {
@@ -289,10 +289,10 @@ ParseResult ImportOp::parse(OpAsmParser &parser, OperationState &result) {
     return parser.emitError(parser.getCurrentLocation())
            << "invalid result type list";
   }
-  call_interface_impl::addArgAndResultAttrs(
-      builder, result, argAttrs,
-      /*resultAttrs=*/std::nullopt, getArgAttrsAttrName(result.name),
-      getResAttrsAttrName(result.name));
+  call_interface_impl::addArgAndResultAttrs(builder, result, argAttrs,
+                                            /*resultAttrs=*/std::nullopt,
+                                            getArgAttrsAttrName(result.name),
+                                            getResAttrsAttrName(result.name));
   if (failed(parser.parseOptionalAttrDictWithKeyword(result.attributes))) {
     return failure();
   }
@@ -358,10 +358,10 @@ void ImportOp::build(OpBuilder &builder, OperationState &result, StringRef name,
   if (!argAttrs.empty()) {
     assert(type.getNumInputs() == argAttrs.size() &&
            "expected as many argument attribute lists as arguments");
-    call_interface_impl::addArgAndResultAttrs(
-        builder, result, argAttrs,
-        /*resultAttrs=*/std::nullopt, getArgAttrsAttrName(result.name),
-        getResAttrsAttrName(result.name));
+    call_interface_impl::addArgAndResultAttrs(builder, result, argAttrs,
+                                              /*resultAttrs=*/std::nullopt,
+                                              getArgAttrsAttrName(result.name),
+                                              getResAttrsAttrName(result.name));
   }
 
   result.addRegion();

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
@@ -120,7 +120,7 @@ void FuncOp::build(OpBuilder &builder, OperationState &result, StringRef name,
 
   assert(type.getNumInputs() == argAttrs.size() &&
          "expected as many argument attribute lists as arguments");
-  function_interface_impl::addArgAndResultAttrs(
+  call_interface_impl::addArgAndResultAttrs(
       builder, result, argAttrs,
       /*resultAttrs=*/std::nullopt, getArgAttrsAttrName(result.name),
       getResAttrsAttrName(result.name));
@@ -289,7 +289,7 @@ ParseResult ImportOp::parse(OpAsmParser &parser, OperationState &result) {
     return parser.emitError(parser.getCurrentLocation())
            << "invalid result type list";
   }
-  function_interface_impl::addArgAndResultAttrs(
+  call_interface_impl::addArgAndResultAttrs(
       builder, result, argAttrs,
       /*resultAttrs=*/std::nullopt, getArgAttrsAttrName(result.name),
       getResAttrsAttrName(result.name));
@@ -358,7 +358,7 @@ void ImportOp::build(OpBuilder &builder, OperationState &result, StringRef name,
   if (!argAttrs.empty()) {
     assert(type.getNumInputs() == argAttrs.size() &&
            "expected as many argument attribute lists as arguments");
-    function_interface_impl::addArgAndResultAttrs(
+    call_interface_impl::addArgAndResultAttrs(
         builder, result, argAttrs,
         /*resultAttrs=*/std::nullopt, getArgAttrsAttrName(result.name),
         getResAttrsAttrName(result.name));

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -4242,7 +4242,9 @@ def VM_CallOp : VM_CallBaseOp<"call"> {
 
   let arguments = (ins
     VM_FuncRefAttr:$callee,
-    Variadic<VM_AnyType>:$operands
+    Variadic<VM_AnyType>:$operands,
+    OptionalAttr<DictArrayAttr>:$arg_attrs,
+    OptionalAttr<DictArrayAttr>:$res_attrs
   );
   let results = (outs
     Variadic<VM_AnyType>:$results
@@ -4301,7 +4303,9 @@ def VM_CallVariadicOp : VM_CallBaseOp<"call.variadic"> {
     VM_FuncRefAttr:$callee,
     SignlessIntElementsAttr<16>:$segment_sizes,
     TypeArrayAttr:$segment_types,
-    Variadic<VM_AnyType>:$operands
+    Variadic<VM_AnyType>:$operands,
+    OptionalAttr<DictArrayAttr>:$arg_attrs,
+    OptionalAttr<DictArrayAttr>:$res_attrs
   );
   let results = (outs
     Variadic<VM_AnyType>:$results

--- a/compiler/src/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/IREEImportPublic.cpp
@@ -396,7 +396,7 @@ class FuncCallOpPattern : public OpConversionPattern<func::CallOp> {
         srcOp->getAttrOfType<ArrayAttr>("iree.abi.tied_operands");
     rewriter.replaceOpWithNewOp<IREE::Util::CallOp>(
         srcOp, resultTypes, srcOp.getCallee(), adaptor.getOperands(),
-        tiedOperandsAttr);
+        tiedOperandsAttr, srcOp.getArgAttrsAttr(), srcOp.getResAttrsAttr());
     return success();
   }
 };

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/StreamToHALInline/Patterns.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/StreamToHALInline/Patterns.cpp
@@ -498,7 +498,8 @@ struct CmdDispatchOpPattern
     llvm::append_range(callArgs, adaptor.getResourceLengths());
     rewriter.replaceOpWithNewOp<IREE::Util::CallOp>(
         dispatchOp, TypeRange{}, callee.getLeafReference(), callArgs,
-        /*tied_operands=*/ArrayAttr{});
+        /*tied_operands=*/ArrayAttr{},
+        /*arg_attrs=*/nullptr, /*res_attrs=*/nullptr);
     return success();
   }
 };
@@ -564,7 +565,8 @@ struct CmdCallOpPattern : public OpConversionPattern<IREE::Stream::CmdCallOp> {
 
     rewriter.replaceOpWithNewOp<IREE::Util::CallOp>(
         callOp, resultTypes, callOp.getCallee(), operands,
-        /*tied_operands=*/ArrayAttr{});
+        /*tied_operands=*/ArrayAttr{},
+        /*arg_attrs=*/nullptr, /*res_attrs=*/nullptr);
     return success();
   }
 };


### PR DESCRIPTION
It drops the revert of https://github.com/llvm/llvm-project/commit/327d627066e6452b081365b595657d17f2690a3b