### PR TITLE
Change transfers to do pulls on multi transfer

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/Partitioning/ReferencePartitioning.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/Partitioning/ReferencePartitioning.cpp
@@ -153,7 +153,8 @@ partitionStreamableOpsReference(IREE::Stream::PartitioningConfigAttr config,
       // region - we must still block on loads though.
       LLVM_DEBUG(llvm::dbgs() << "(ignoring global store)\n");
       continue;
-    } else if (!isa<IREE::Stream::StreamableOpInterface>(op)) {
+    } else if (!isa<IREE::Stream::StreamableOpInterface>(op) &&
+               !isa<IREE::Stream::AsyncBarrierOp>(op)) {
       // Not a streamable op. If it has side-effects then we force a hazard on
       // all builders so that we don't move ops across it.
       if (!mlir::wouldOpBeTriviallyDead(&op)) {

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
@@ -249,7 +249,7 @@ struct ConvertTensorBarrierOp
     auto barrierOp = rewriter.create<IREE::Stream::AsyncBarrierOp>(
         op.getLoc(), operand.resource.getType(), operand.resource,
         operand.resourceSize,
-        /*affinity=*/executionAffinityAttr);
+        /*affinity=*/cast<IREE::Stream::AffinityAttr>(op.getTargetAttr()));
     rewriter.replaceOpWithMultiple(op, {{barrierOp, operand.resourceSize}});
     return success();
   }
@@ -272,7 +272,8 @@ struct ConvertTensorTransferOp
         op.getLoc(), unknownType, operand.resource, operand.resourceSize,
         operand.resourceSize,
         /*source_affinity=*/operand.affinity,
-        /*result_affinity=*/executionAffinityAttr);
+        /*result_affinity=*/
+        cast<IREE::Stream::AffinityAttr>(op.getTargetAttr()));
     rewriter.replaceOpWithMultiple(op, {{transferOp, operand.resourceSize}});
     return success();
   }

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -2500,8 +2500,6 @@ void AsyncCollectiveOp::getAsyncAccessRanges(
 // stream.async.barrier
 //===----------------------------------------------------------------------===//
 
-bool AsyncBarrierOp::isMetadata() { return true; }
-
 LogicalResult AsyncBarrierOp::verify() { return success(); }
 
 Value AsyncBarrierOp::getTiedResult(unsigned resultIndex) {
@@ -2530,60 +2528,12 @@ LogicalResult AsyncTransferOp::verify() {
   return success();
 }
 
-IREE::Stream::AffinityAttr AsyncTransferOp::getAffinityAttr() {
-  auto sourceType = cast<IREE::Stream::ResourceType>(getSource().getType());
-  auto resultType = cast<IREE::Stream::ResourceType>(getResult().getType());
-  if (sourceType.getLifetime() == IREE::Stream::Lifetime::Staging &&
-      resultType.getLifetime() == IREE::Stream::Lifetime::Staging) {
-    // TODO(multi-device): figure out how to model staging->staging transfers.
-    return getSourceAffinityAttr();
-  } else if (sourceType.getLifetime() == IREE::Stream::Lifetime::External ||
-             sourceType.getLifetime() == IREE::Stream::Lifetime::Staging) {
-    // If source is staging then the op should execute on the consumer.
-    return getResultAffinityAttr();
-  } else if (resultType.getLifetime() == IREE::Stream::Lifetime::External ||
-             resultType.getLifetime() == IREE::Stream::Lifetime::Staging) {
-    // If result is staging then the op should execute on the producer.
-    return getSourceAffinityAttr();
-  } else {
-    // Default to result affinity.
-    return getSourceAffinityAttr();
-  }
-}
-
-void AsyncTransferOp::setAffinityAttr(IREE::Stream::AffinityAttr value) {
-  auto sourceType = cast<IREE::Stream::ResourceType>(getSource().getType());
-  auto resultType = cast<IREE::Stream::ResourceType>(getResult().getType());
-  if (sourceType.getLifetime() == IREE::Stream::Lifetime::Staging &&
-      resultType.getLifetime() == IREE::Stream::Lifetime::Staging) {
-    // TODO(multi-device): figure out how to model staging->staging transfers.
-    if (value) {
-      setSourceAffinityAttr(value);
-    } else {
-      removeSourceAffinityAttr();
-    }
-  } else if (sourceType.getLifetime() == IREE::Stream::Lifetime::Staging) {
-    // If source is staging then the op should execute on the consumer.
-    if (value) {
-      setResultAffinityAttr(value);
-    } else {
-      removeResultAffinityAttr();
-    }
-  } else if (resultType.getLifetime() == IREE::Stream::Lifetime::Staging) {
-    // If result is staging then the op should execute on the producer.
-    if (value) {
-      setSourceAffinityAttr(value);
-    } else {
-      removeSourceAffinityAttr();
-    }
-  } else {
-    // Default to result affinity.
-    if (value) {
-      setResultAffinityAttr(value);
-    } else {
-      removeResultAffinityAttr();
-    }
-  }
+void AsyncTransferOp::build(OpBuilder &builder, OperationState &state,
+                            Type type, Value source, Value source_size,
+                            Value result_size, AffinityAttr source_attr,
+                            AffinityAttr result_attr) {
+  build(builder, state, type, source, source_size, result_size, source_attr,
+        result_attr, nullptr);
 }
 
 void AsyncTransferOp::getAsyncAccessRanges(

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -2294,9 +2294,6 @@ def Stream_AsyncBarrierOp : Stream_Op<"async.barrier", [
   AllTypesMatch<["source", "result"]>,
   Stream_AffinityOp,
   Stream_AsyncPhaseOp,
-  DeclareOpInterfaceMethods<Stream_StreamableOp, [
-    "isMetadata",
-  ]>,
   Util_SizeAwareOp,
   DeclareOpInterfaceMethods<Util_TiedOpInterface, [
     "getTiedResult",
@@ -2344,10 +2341,7 @@ def Stream_AsyncBarrierOp : Stream_Op<"async.barrier", [
 }
 
 def Stream_AsyncTransferOp : Stream_Op<"async.transfer", [
-  DeclareOpInterfaceMethods<Stream_AffinityOp, [
-    "getAffinityAttr",
-    "setAffinityAttr",
-  ]>,
+  DeclareOpInterfaceMethods<Stream_AffinityOp>,
   Stream_AsyncPhaseOp,
   Stream_StreamableOp,
   DeclareOpInterfaceMethods<Stream_AsyncAccessOp, [
@@ -2371,7 +2365,8 @@ def Stream_AsyncTransferOp : Stream_Op<"async.transfer", [
     Stream_Size:$source_size,
     Stream_Size:$result_size,
     OptionalAttr<Stream_AffinityAttr>:$source_affinity,
-    OptionalAttr<Stream_AffinityAttr>:$result_affinity
+    OptionalAttr<Stream_AffinityAttr>:$result_affinity,
+    OptionalAttr<Stream_AffinityAttr>:$affinity
   );
   let results = (outs
     AnyTypeOf<[
@@ -2383,6 +2378,7 @@ def Stream_AsyncTransferOp : Stream_Op<"async.transfer", [
   let assemblyFormat = [{
     $source `:` type($source)
     `` `{` $source_size `}`
+    (`on` `(` $affinity^ `)`)?
     (`from` `(` $source_affinity^ `)`)?
     `->`
     (`to` `(` $result_affinity^ `)`)?
@@ -2399,6 +2395,16 @@ def Stream_AsyncTransferOp : Stream_Op<"async.transfer", [
 
   let hasCanonicalizer = 1;
   let hasFolder = 1;
+
+  let builders = [
+    OpBuilder<(ins
+      "Type":$type,
+      "Value":$source,
+      "Value":$source_size,
+      "Value":$result_size,
+      "AffinityAttr":$source_affinity,
+      "AffinityAttr":$result_affinity)>,
+  ];
 }
 
 def Stream_AsyncLoadOp : Stream_PureOp<"async.load", [

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/BUILD.bazel
@@ -24,6 +24,7 @@ iree_compiler_cc_library(
         "ElideTimepoints.cpp",
         "EmplaceAllocations.cpp",
         "EncodeTensors.cpp",
+        "ExecutionPlacement.cpp",
         "FoldUniformOperands.cpp",
         "FuseDispatchBindings.cpp",
         "LayoutSlices.cpp",

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_cc_library(
     "ElideTimepoints.cpp"
     "EmplaceAllocations.cpp"
     "EncodeTensors.cpp"
+    "ExecutionPlacement.cpp"
     "FoldUniformOperands.cpp"
     "FuseDispatchBindings.cpp"
     "LayoutSlices.cpp"

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ExecutionPlacement.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ExecutionPlacement.cpp
@@ -1,0 +1,79 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Stream/Analysis/Partitioning.h"
+#include "iree/compiler/Dialect/Stream/IR/StreamDialect.h"
+#include "iree/compiler/Dialect/Stream/IR/StreamOps.h"
+#include "iree/compiler/Dialect/Stream/IR/StreamTypes.h"
+#include "iree/compiler/Dialect/Stream/Transforms/Passes.h"
+#include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
+#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
+#include "llvm/ADT/EquivalenceClasses.h"
+#include "llvm/Support/Debug.h"
+#include "mlir/Analysis/TopologicalSortUtils.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassRegistry.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "iree-stream-execution-placement"
+
+namespace mlir::iree_compiler::IREE::Stream {
+
+#define GEN_PASS_DEF_EXECUTIONPLACEMENTPASS
+#include "iree/compiler/Dialect/Stream/Transforms/Passes.h.inc"
+
+namespace {
+
+struct ExecutionPlacementPass
+    : public IREE::Stream::impl::ExecutionPlacementPassBase<
+          ExecutionPlacementPass> {
+  void runOnOperation() override {
+
+    getOperation()->walk([](IREE::Stream::AsyncTransferOp transfer) {
+      if (transfer.getAffinityAttr())
+        return;
+
+      auto operand = transfer.getSource();
+      auto producer = operand.getDefiningOp();
+      auto streamable =
+          dyn_cast_or_null<IREE::Stream::StreamableOpInterface>(producer);
+      auto srcAffinity =
+          dyn_cast_or_null<IREE::Stream::AffinityOpInterface>(producer);
+
+      bool hasOneUse = operand.hasOneUse();
+      if (hasOneUse && streamable && srcAffinity &&
+          srcAffinity.getAffinityAttr()) {
+        transfer.setAffinityAttr(srcAffinity.getAffinityAttr());
+        return;
+      }
+
+      if (transfer.getResultAffinityAttr()) {
+        transfer.setAffinityAttr(transfer.getResultAffinityAttr());
+        return;
+      }
+
+      if (transfer.getSourceAffinityAttr()) {
+        transfer.setAffinityAttr(transfer.getSourceAffinityAttr());
+        return;
+      }
+
+      transfer->emitOpError("Unknown src/dest affinity");
+    });
+  }
+};
+
+} // namespace
+} // namespace mlir::iree_compiler::IREE::Stream

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
@@ -204,6 +204,8 @@ void buildStreamAsyncPassPipeline(OpPassManager &passManager,
   //----------------------------------------------------------------------------
 
   FunctionLikeNest(passManager)
+      // Analyze and assign execution placement.
+      .addPass(IREE::Stream::createExecutionPlacementPass)
       // Combine async work into execution regions.
       .addPass(IREE::Stream::createScheduleExecutionPass)
       // Group concurrently executable work into waves.

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
@@ -214,6 +214,19 @@ def RefineUsagePass :
 // Stream formation and scheduling
 //===----------------------------------------------------------------------===//
 
+def ExecutionPlacementPass :
+    InterfacePass<"iree-stream-execution-placement", "mlir::CallableOpInterface"> {
+  let summary = "Runs an analysis and placement for stream executions.";
+  let description = [{
+    Handles placement analysis for `stream.async` operators that have a preferable
+    placement. This is so that more complex analsysis can be separated from the
+    execution scheduling pass.
+  }];
+  let dependentDialects = [
+    "IREE::Stream::StreamDialect",
+  ];
+}
+
 def ScheduleExecutionPass :
     InterfacePass<"iree-stream-schedule-execution", "mlir::CallableOpInterface"> {
   let summary = "Identifies and groups asynchronous operations into executable regions within function-like regions.";

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
@@ -668,19 +668,8 @@ applyAsyncCollectiveOp(IREE::Stream::AsyncCollectiveOp asyncOp,
 static LogicalResult applyAsyncBarrierOp(IREE::Stream::AsyncBarrierOp barrierOp,
                                          AllocationScope &scope,
                                          OpBuilder builder) {
-  // TODO: barriers are being treated as copies, they should just be metadata
-  // operations but currently it's causing failures to be removed.
-  auto sourceRange = scope.lookupResourceRange(barrierOp.getSource());
-  auto targetRange = scope.lookupResourceRange(barrierOp.getResult());
-
-  // Perform the copy.
-  builder.create<IREE::Stream::CmdCopyOp>(
-      barrierOp.getLoc(), sourceRange.resource, sourceRange.resourceSize,
-      sourceRange.offset, targetRange.resource, targetRange.resourceSize,
-      targetRange.offset, sourceRange.length);
-
-  barrierOp.erase();
-  return success();
+  barrierOp->emitError("Async barrier should not longer exist");
+  return failure();
 }
 
 static LogicalResult applyAsyncTransferOp(IREE::Stream::AsyncTransferOp asyncOp,

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/BUILD.bazel
@@ -31,6 +31,7 @@ iree_lit_test_suite(
             "encode_host_tensors_encoding.mlir",
             "encode_host_tensors_packing.mlir",
             "encode_host_tensors_packing_i1_experimental_clopt.mlir",
+            "execution_placement.mlir",
             "fold_globals.mlir",
             "fold_uniform_operands.mlir",
             "fuse_dispatch_bindings.mlir",

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/CMakeLists.txt
@@ -29,6 +29,7 @@ iree_lit_test_suite(
     "encode_host_tensors_encoding.mlir"
     "encode_host_tensors_packing.mlir"
     "encode_host_tensors_packing_i1_experimental_clopt.mlir"
+    "execution_placement.mlir"
     "fold_globals.mlir"
     "fold_uniform_operands.mlir"
     "fuse_dispatch_bindings.mlir"

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/execution_placement.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/execution_placement.mlir
@@ -1,0 +1,81 @@
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(util.func(iree-stream-execution-placement))" %s | FileCheck %s
+
+// Tests partitioning multi-device execution with barriers and transfers.
+// It validates that multi-stream commands are created and run in parallel.
+
+// CHECK-LABEL: util.func public @deviceMultiDeviceSync
+util.func public @deviceMultiDeviceSync(%arg0: i1) -> !stream.resource<transient> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c128 = arith.constant 128 : index
+  %c255_i32 = arith.constant 255 : i32
+
+  %0 = stream.async.splat %c255_i32 : i32 -> !stream.resource<transient>{%c128}
+  // CHECK: stream.async.dispatch
+  %1 = stream.async.dispatch on(#hal.device.affinity<@device0>) @ex::@dispatch0[%c1, %c1, %c1](%0[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+  %3 = stream.async.barrier %1 : !stream.resource<transient>{%c128}
+
+  // CHECK: stream.async.transfer
+  // CHECK-SAME: on(#hal.device.affinity<@device1>)
+  %4 = stream.async.transfer %1 : !stream.resource<transient>{%c128} from(#hal.device.affinity<@device0>) -> to(#hal.device.affinity<@device1>) !stream.resource<transient>{%c128}
+  // CHECK: stream.async.dispatch
+  %2 = stream.async.dispatch on(#hal.device.affinity<@device1>) @ex::@dispatch1[%c1, %c1, %c1](%0[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+  %5 = stream.async.barrier %2 : !stream.resource<transient>{%c128}
+
+  // CHECK: stream.async.transfer
+  // CHECK-SAME: on(#hal.device.affinity<@device0>)
+  %6 = stream.async.transfer %2 : !stream.resource<transient>{%c128} from(#hal.device.affinity<@device1>) -> to(#hal.device.affinity<@device0>) !stream.resource<transient>{%c128}
+  // CHECK: stream.async.dispatch
+  %7 = stream.async.dispatch on(#hal.device.affinity<@device0>) @ex::@dispatch2[%c1, %c1, %c1](%3[%c0 to %c128 for %c128], %6[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}, !stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+  %8 = stream.async.barrier %7 : !stream.resource<transient>{%c128}
+  %9 = stream.async.dispatch on(#hal.device.affinity<@device1>) @ex::@dispatch2[%c1, %c1, %c1](%4[%c0 to %c128 for %c128], %5[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}, !stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+
+  // CHECK: stream.async.transfer
+  // CHECK-SAME: on(#hal.device.affinity<@device1>)
+  %10 = stream.async.transfer %9 : !stream.resource<transient>{%c128} from(#hal.device.affinity<@device1>) -> to(#hal.device.affinity<@device0>) !stream.resource<transient>{%c128}
+  // CHECK: stream.async.dispatch
+  %11 = stream.async.dispatch on(#hal.device.affinity<@device0>) @ex::@dispatch2[%c1, %c1, %c1](%8[%c0 to %c128 for %c128], %10[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}, !stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+  util.return %11 : !stream.resource<transient>
+}
+
+// -----
+
+// This one simulates how to do multi-device synchronization between
+// more than two devices.
+
+// CHECK-LABEL: @deviceTripleSync
+util.func public @deviceTripleSync(%arg0: i1) -> (!stream.resource<transient>, !stream.resource<transient>, !stream.resource<transient>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c128 = arith.constant 128 : index
+  %c255_i32 = arith.constant 255 : i32
+
+  %0 = stream.async.splat %c255_i32 : i32 -> !stream.resource<transient>{%c128}
+  %1 = stream.async.dispatch on(#hal.device.affinity<@device0>) @ex::@dispatch0[%c1, %c1, %c1](%0[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+  %2 = stream.async.barrier %1 : !stream.resource<transient>{%c128}
+
+  %3 = stream.async.dispatch on(#hal.device.affinity<@device1>) @ex::@dispatch0[%c1, %c1, %c1](%0[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+
+  // CHECK: stream.async.transfer
+  // CHECK-SAME: on(#hal.device.affinity<@device1>)
+  %4 = stream.async.transfer %3 : !stream.resource<transient>{%c128} from(#hal.device.affinity<@device1>) -> to(#hal.device.affinity<@device0>) !stream.resource<transient>{%c128}
+  %5 = stream.async.dispatch on(#hal.device.affinity<@device2>) @ex::@dispatch0[%c1, %c1, %c1](%0[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+
+  // CHECK: stream.async.transfer
+  // CHECK-SAME: on(#hal.device.affinity<@device2>)
+  %6 = stream.async.transfer %5 : !stream.resource<transient>{%c128} from(#hal.device.affinity<@device2>) -> to(#hal.device.affinity<@device0>) !stream.resource<transient>{%c128}
+  %7 = stream.async.dispatch on(#hal.device.affinity<@device0>) @ex::@dispatch2[%c1, %c1, %c1](%2[%c0 to %c128 for %c128], %4[%c0 to %c128 for %c128], %6[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}, !stream.resource<transient>{%c128}, !stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+  %8 = stream.async.barrier %7 : !stream.resource<transient>{%c128}
+  %11 = stream.async.dispatch on(#hal.device.affinity<@device0>) @ex::@dispatch0[%c1, %c1, %c1](%8[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+
+  // CHECK: stream.async.transfer
+  // CHECK-SAME: on(#hal.device.affinity<@device1>)
+  %9 = stream.async.transfer %7 : !stream.resource<transient>{%c128} from(#hal.device.affinity<@device0>) -> to(#hal.device.affinity<@device1>) !stream.resource<transient>{%c128}
+  %12 = stream.async.dispatch on(#hal.device.affinity<@device1>) @ex::@dispatch0[%c1, %c1, %c1](%9[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+
+  // CHECK: stream.async.transfer
+  // CHECK-SAME: on(#hal.device.affinity<@device2>)
+  %10 = stream.async.transfer %7 : !stream.resource<transient>{%c128} from(#hal.device.affinity<@device0>) -> to(#hal.device.affinity<@device2>) !stream.resource<transient>{%c128}
+  %13 = stream.async.dispatch on(#hal.device.affinity<@device2>) @ex::@dispatch0[%c1, %c1, %c1](%10[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+  util.return %11, %12, %13 : !stream.resource<transient>, !stream.resource<transient>, !stream.resource<transient>
+}

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/schedule_execution.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/schedule_execution.mlir
@@ -81,6 +81,60 @@ util.func public @deviceMultiDeviceSync(%arg0: i1) -> !stream.resource<transient
 
 // -----
 
+// CHECK-LABEL: @deviceTripleSync
+util.func public @deviceTripleSync(%arg0: i1) -> (!stream.resource<transient>, !stream.resource<transient>, !stream.resource<transient>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c128 = arith.constant 128 : index
+  %c255_i32 = arith.constant 255 : i32
+
+  // CHECK: stream.async.execute
+  // CHECK: stream.async.splat
+  // CHECK: stream.async.dispatch
+  %0 = stream.async.splat %c255_i32 : i32 -> !stream.resource<transient>{%c128}
+  %1 = stream.async.dispatch on(#hal.device.affinity<@device0>) @ex::@dispatch0[%c1, %c1, %c1](%0[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+  %2 = stream.async.barrier %1 : !stream.resource<transient>{%c128}
+
+  // CHECK: stream.async.execute
+  // CHECK: stream.async.splat
+  // CHECK: stream.async.dispatch
+  // CHECK: stream.async.transfer
+  %3 = stream.async.dispatch on(#hal.device.affinity<@device1>) @ex::@dispatch0[%c1, %c1, %c1](%0[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+  %4 = stream.async.transfer %3 : !stream.resource<transient>{%c128} on(#hal.device.affinity<@device1>) from(#hal.device.affinity<@device1>) -> to(#hal.device.affinity<@device0>) !stream.resource<transient>{%c128}
+
+  // CHECK: stream.async.execute
+  // CHECK: stream.async.splat
+  // CHECK: stream.async.dispatch
+  // CHECK: stream.async.transfer
+  %5 = stream.async.dispatch on(#hal.device.affinity<@device2>) @ex::@dispatch0[%c1, %c1, %c1](%0[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+  %6 = stream.async.transfer %5 : !stream.resource<transient>{%c128} on(#hal.device.affinity<@device2>) from(#hal.device.affinity<@device2>) -> to(#hal.device.affinity<@device0>) !stream.resource<transient>{%c128}
+
+  // CHECK: stream.async.execute
+  // CHECK: stream.async.dispatch
+  %7 = stream.async.dispatch on(#hal.device.affinity<@device0>) @ex::@dispatch2[%c1, %c1, %c1](%2[%c0 to %c128 for %c128], %4[%c0 to %c128 for %c128], %6[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}, !stream.resource<transient>{%c128}, !stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+  %8 = stream.async.barrier %7 : !stream.resource<transient>{%c128}
+
+  // CHECK: stream.async.execute
+  // CHECK: stream.async.dispatch
+  %11 = stream.async.dispatch on(#hal.device.affinity<@device0>) @ex::@dispatch0[%c1, %c1, %c1](%8[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+
+  // CHECK: stream.async.execute
+  // CHECK: stream.async.transfer
+  // CHECK: stream.async.dispatch
+  %9 = stream.async.transfer %7 : !stream.resource<transient>{%c128} on(#hal.device.affinity<@device1>) from(#hal.device.affinity<@device0>) -> to(#hal.device.affinity<@device1>) !stream.resource<transient>{%c128}
+  %12 = stream.async.dispatch on(#hal.device.affinity<@device1>) @ex::@dispatch0[%c1, %c1, %c1](%9[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+
+  // CHECK: stream.async.execute
+  // CHECK: stream.async.transfer
+  // CHECK: stream.async.dispatch
+  %10 = stream.async.transfer %7 : !stream.resource<transient>{%c128} on(#hal.device.affinity<@device2>) from(#hal.device.affinity<@device0>) -> to(#hal.device.affinity<@device2>) !stream.resource<transient>{%c128}
+  %13 = stream.async.dispatch on(#hal.device.affinity<@device2>) @ex::@dispatch0[%c1, %c1, %c1](%10[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+
+  util.return %11, %12, %13 : !stream.resource<transient>, !stream.resource<transient>, !stream.resource<transient>
+}
+
+// -----
+
 // Tests basic partitioning of sequential dispatches with differing affinities.
 // Dispatches with the same affinities should be placed into the same execution
 // regions.

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
@@ -281,14 +281,14 @@ util.func public @multi_device_with_same_executable_targets(%arg0: !hal.buffer_v
   %0 = stream.tensor.import on(#hal.device.affinity<@device_a>) %arg0 : !hal.buffer_view -> tensor<4xf32> in !stream.resource<external>{%c16}
   %1 = stream.timepoint.import on(#hal.device.affinity<@device_a>) %arg1 : (!hal.fence) => !stream.timepoint
   %2 = stream.timepoint.await %1 => %0 : !stream.resource<external>{%c16}
-  %3 = stream.async.transfer %2 : !stream.resource<external>{%c16} from(#hal.device.affinity<@device_a>) -> to(#hal.device.affinity<@device_a>) !stream.resource<*>{%c16}
+  %3 = stream.async.transfer %2 : !stream.resource<external>{%c16} on(#hal.device.affinity<@device_a>) from(#hal.device.affinity<@device_a>) -> to(#hal.device.affinity<@device_a>) !stream.resource<*>{%c16}
   %4 = stream.tensor.dispatch on(#hal.device.affinity<@device_a>) @ex::@dispatch(%3) : (tensor<16xf32, #encoding> in !stream.resource<*>{%c16}) -> tensor<16xf32, #encoding> in !stream.resource<*>{%c16}
-  %5 = stream.async.transfer %4 : !stream.resource<*>{%c16} from(#hal.device.affinity<@device_a>) -> to(#hal.device.affinity<@device_b>) !stream.resource<*>{%c16}
+  %5 = stream.async.transfer %4 : !stream.resource<*>{%c16} on(#hal.device.affinity<@device_a>) from(#hal.device.affinity<@device_a>) -> to(#hal.device.affinity<@device_b>) !stream.resource<*>{%c16}
   %6 = stream.tensor.dispatch on(#hal.device.affinity<@device_b>) @ex::@dispatch(%5) : (tensor<16xf32, #encoding> in !stream.resource<*>{%c16}) -> tensor<16xf32, #encoding> in !stream.resource<*>{%c16}
-  %7 = stream.async.transfer %6 : !stream.resource<*>{%c16} from(#hal.device.affinity<@device_b>) -> to(#hal.device.affinity<@device_a>) !stream.resource<*>{%c16}
+  %7 = stream.async.transfer %6 : !stream.resource<*>{%c16} on(#hal.device.affinity<@device_a>) from(#hal.device.affinity<@device_b>) -> to(#hal.device.affinity<@device_a>) !stream.resource<*>{%c16}
   %result, %result_timepoint = stream.timepoint.barrier on(#hal.device.affinity<@device_a>) %7 : !stream.resource<*>{%c16} => !stream.timepoint
   stream.timepoint.chain_external on(#hal.device.affinity<@device_a>) %result_timepoint => (%arg2 : !hal.fence)
-  %8 = stream.async.transfer %result : !stream.resource<*>{%c16} from(#hal.device.affinity<@device_a>) -> to(#hal.device.affinity<@device_a>) !stream.resource<external>{%c16}
+  %8 = stream.async.transfer %result : !stream.resource<*>{%c16} on(#hal.device.affinity<@device_a>) from(#hal.device.affinity<@device_a>) -> to(#hal.device.affinity<@device_a>) !stream.resource<external>{%c16}
   %9 = stream.tensor.export on(#hal.device.affinity<@device_a>) %8 : tensor<4xf32> in !stream.resource<external>{%c16} -> !hal.buffer_view
   util.return %9 : !hal.buffer_view
 }
@@ -342,11 +342,11 @@ util.func public @multi_device_with_different_executable_targets(%arg0: !hal.buf
   %0 = stream.tensor.import on(#hal.device.affinity<@device_a>) %arg0 : !hal.buffer_view -> tensor<4xf32> in !stream.resource<external>{%c16}
   %1 = stream.timepoint.import on(#hal.device.affinity<@device_a>) %arg1 : (!hal.fence) => !stream.timepoint
   %2 = stream.timepoint.await %1 => %0 : !stream.resource<external>{%c16}
-  %3 = stream.async.transfer %2 : !stream.resource<external>{%c16} from(#hal.device.affinity<@device_a>) -> to(#hal.device.affinity<@device_a>) !stream.resource<*>{%c16}
+  %3 = stream.async.transfer %2 : !stream.resource<external>{%c16} on(#hal.device.affinity<@device_a>) from(#hal.device.affinity<@device_a>) -> to(#hal.device.affinity<@device_a>) !stream.resource<*>{%c16}
   %4 = stream.tensor.dispatch on(#hal.device.affinity<@device_a>) @ex::@dispatch(%3) : (tensor<16xf32, #encoding> in !stream.resource<*>{%c16}) -> tensor<16xf32, #encoding> in !stream.resource<*>{%c16}
-  %5 = stream.async.transfer %4 : !stream.resource<*>{%c16} from(#hal.device.affinity<@device_a>) -> to(#hal.device.affinity<@device_b>) !stream.resource<*>{%c16}
+  %5 = stream.async.transfer %4 : !stream.resource<*>{%c16} on(#hal.device.affinity<@device_b>) from(#hal.device.affinity<@device_a>) -> to(#hal.device.affinity<@device_b>) !stream.resource<*>{%c16}
   %6 = stream.tensor.dispatch on(#hal.device.affinity<@device_b>) @ex::@dispatch(%5) : (tensor<16xf32, #encoding> in !stream.resource<*>{%c16}) -> tensor<16xf32, #encoding> in !stream.resource<*>{%c16}
-  %7 = stream.async.transfer %6 : !stream.resource<*>{%c16} from(#hal.device.affinity<@device_b>) -> to(#hal.device.affinity<@device_a>) !stream.resource<*>{%c16}
+  %7 = stream.async.transfer %6 : !stream.resource<*>{%c16} on(#hal.device.affinity<@device_a>) from(#hal.device.affinity<@device_b>) -> to(#hal.device.affinity<@device_a>) !stream.resource<*>{%c16}
   %result, %result_timepoint = stream.timepoint.barrier on(#hal.device.affinity<@device_a>) %7 : !stream.resource<*>{%c16} => !stream.timepoint
   stream.timepoint.chain_external on(#hal.device.affinity<@device_a>) %result_timepoint => (%arg2 : !hal.fence)
   %8 = stream.async.transfer %result : !stream.resource<*>{%c16} from(#hal.device.affinity<@device_a>) -> to(#hal.device.affinity<@device_a>) !stream.resource<external>{%c16}
@@ -408,10 +408,10 @@ stream.executable private @ex {
 util.func public @multi_device_set_encoding(%arg0: !stream.resource<external>, %arg1: !stream.resource<external>, %N : index, %K : index) {
   %c16 = arith.constant 16 : index
   %c0 = arith.constant 0 : index
-  %0 = stream.async.transfer %arg0 : !stream.resource<external>{%c16} from(#hal.device.affinity<@device_a>) -> to(#hal.device.affinity<@device_a>) !stream.resource<*>{%c16}
+  %0 = stream.async.transfer %arg0 : !stream.resource<external>{%c16} on(#hal.device.affinity<@device_a>) from(#hal.device.affinity<@device_a>) -> to(#hal.device.affinity<@device_a>) !stream.resource<*>{%c16}
   %1 = stream.tensor.dispatch on(#hal.device.affinity<@device_a>) @ex::@set_encoding(%0, %N, %K) : (tensor<?x?xf32>{%N, %K} in !stream.resource<*>{%c16}, index, index) -> (tensor<?x?xf32, #encoding>{%N, %K} in !stream.resource<*>{%c16})
   %2 = util.optimization_barrier %1 : !stream.resource<*>
-  %3 = stream.async.transfer %arg1 : !stream.resource<external>{%c16} from(#hal.device.affinity<@device_b>) -> to(#hal.device.affinity<@device_b>) !stream.resource<*>{%c16}
+  %3 = stream.async.transfer %arg1 : !stream.resource<external>{%c16} on(#hal.device.affinity<@device_b>) from(#hal.device.affinity<@device_b>) -> to(#hal.device.affinity<@device_b>) !stream.resource<*>{%c16}
   %4 = stream.tensor.dispatch on(#hal.device.affinity<@device_b>) @ex::@set_encoding(%3, %N, %K) : (tensor<?x?xf32>{%N, %K} in !stream.resource<*>{%c16}, index, index) -> (tensor<?x?xf32, #encoding>{%N, %K} in !stream.resource<*>{%c16})
   %5 = util.optimization_barrier %4 : !stream.resource<*>
   util.return
@@ -487,10 +487,10 @@ stream.executable private @ex {
 util.func public @multi_device_unset_encoding(%arg0: !stream.resource<external>, %arg1: !stream.resource<external>, %M: index, %N: index) {
   %c16 = arith.constant 16 : index
   %c0 = arith.constant 0 : index
-  %0 = stream.async.transfer %arg0 : !stream.resource<external>{%c16} from(#hal.device.affinity<@device_a>) -> to(#hal.device.affinity<@device_a>) !stream.resource<*>{%c16}
+  %0 = stream.async.transfer %arg0 : !stream.resource<external>{%c16} on(#hal.device.affinity<@device_a>) from(#hal.device.affinity<@device_a>) -> to(#hal.device.affinity<@device_a>) !stream.resource<*>{%c16}
   %1 = stream.tensor.dispatch on(#hal.device.affinity<@device_a>) @ex::@unset_encoding(%0, %M, %N) : (tensor<?x?xf32, #encoding>{%M, %N} in !stream.resource<*>{%c16}, index, index) -> (tensor<?x?xf32>{%M, %N} in !stream.resource<*>{%c16})
   %2 = util.optimization_barrier %1 : !stream.resource<*>
-  %3 = stream.async.transfer %arg1 : !stream.resource<external>{%c16} from(#hal.device.affinity<@device_b>) -> to(#hal.device.affinity<@device_b>) !stream.resource<*>{%c16}
+  %3 = stream.async.transfer %arg1 : !stream.resource<external>{%c16} on(#hal.device.affinity<@device_b>) from(#hal.device.affinity<@device_b>) -> to(#hal.device.affinity<@device_b>) !stream.resource<*>{%c16}
   %4 = stream.tensor.dispatch on(#hal.device.affinity<@device_b>) @ex::@unset_encoding(%3, %M, %N) : (tensor<?x?xf32, #encoding>{%M, %N} in !stream.resource<*>{%c16}, index, index) -> (tensor<?x?xf32>{%M, %N} in !stream.resource<*>{%c16})
   %5 = util.optimization_barrier %4 : !stream.resource<*>
   util.return
@@ -594,15 +594,15 @@ util.func public @multi_device_gemm(%arg0: !stream.resource<external>, %arg1: !s
   %MK = util.optimization_barrier %cst_MK : index
   %NK = util.optimization_barrier %cst_NK : index
   %MN = util.optimization_barrier %cst_MN : index
-  %LHS_A = stream.async.transfer %arg0 : !stream.resource<external>{%MK} from(#hal.device.affinity<@device_a>) -> to(#hal.device.affinity<@device_a>) !stream.resource<*>{%MK}
-  %RHS_A = stream.async.transfer %arg1 : !stream.resource<external>{%NK} from(#hal.device.affinity<@device_a>) -> to(#hal.device.affinity<@device_a>) !stream.resource<*>{%NK}
+  %LHS_A = stream.async.transfer %arg0 : !stream.resource<external>{%MK} on(#hal.device.affinity<@device_a>) from(#hal.device.affinity<@device_a>) -> to(#hal.device.affinity<@device_a>) !stream.resource<*>{%MK}
+  %RHS_A = stream.async.transfer %arg1 : !stream.resource<external>{%NK} on(#hal.device.affinity<@device_a>) from(#hal.device.affinity<@device_a>) -> to(#hal.device.affinity<@device_a>) !stream.resource<*>{%NK}
   %RES_A = stream.tensor.dispatch on(#hal.device.affinity<@device_a>)
     @ex::@gemm(%LHS_A, %RHS_A, %K, %K, %M, %N)
     : (tensor<?x?xf32, #encoding>{%M, %K} in !stream.resource<*>{%MK}, tensor<?x?xf32, #encoding1>{%N, %K} in !stream.resource<*>{%NK}, index, index, index, index)
     -> (tensor<?x?xf32, #encoding2>{%M, %N} in !stream.resource<*>{%MN})
   %barrier_0 = util.optimization_barrier %RES_A : !stream.resource<*>
-  %LHS_B = stream.async.transfer %arg2 : !stream.resource<external>{%MK} from(#hal.device.affinity<@device_b>) -> to(#hal.device.affinity<@device_b>) !stream.resource<*>{%MK}
-  %RHS_B = stream.async.transfer %arg3 : !stream.resource<external>{%NK} from(#hal.device.affinity<@device_b>) -> to(#hal.device.affinity<@device_b>) !stream.resource<*>{%NK}
+  %LHS_B = stream.async.transfer %arg2 : !stream.resource<external>{%MK} on(#hal.device.affinity<@device_b>) from(#hal.device.affinity<@device_b>) -> to(#hal.device.affinity<@device_b>) !stream.resource<*>{%MK}
+  %RHS_B = stream.async.transfer %arg3 : !stream.resource<external>{%NK} on(#hal.device.affinity<@device_b>) from(#hal.device.affinity<@device_b>) -> to(#hal.device.affinity<@device_b>) !stream.resource<*>{%NK}
   %RES_B = stream.tensor.dispatch on(#hal.device.affinity<@device_b>)
     @ex::@gemm(%LHS_B, %RHS_B, %K, %K, %M, %N)
     : (tensor<?x?xf32, #encoding>{%M, %K} in !stream.resource<*>{%MK}, tensor<?x?xf32, #encoding1>{%N, %K} in !stream.resource<*>{%NK}, index, index, index, index)

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
@@ -236,7 +236,7 @@ util.func public @tensor_dispatch_with_tied_operands(%arg0: !stream.resource<ext
   %c2 = arith.constant 2 : index
   %c3 = arith.constant 3 : index
   %c4 = arith.constant 4 : index
-  %0 = stream.async.transfer %arg0 : !stream.resource<external>{%arg2} from(#hal.device.affinity<@device_a>) -> to(#hal.device.affinity<@device_a>) !stream.resource<*>{%arg2}
+  %0 = stream.async.transfer %arg0 : !stream.resource<external>{%arg2} on(#hal.device.affinity<@device_a>) from(#hal.device.affinity<@device_a>) -> to(#hal.device.affinity<@device_a>) !stream.resource<*>{%arg2}
   %1 = stream.tensor.dispatch on(#hal.device.affinity<@device_a>) @executable::@dispatch[%c1, %c2, %c3](%0, %c4) : (tensor<4x?xf32, #encoding>{%arg2} in !stream.resource<*>{%arg1}, index) -> tensor<4x?xf32, #encoding>{%arg2} in %0{%arg1}
   util.return %1 : !stream.resource<*>
 }


### PR DESCRIPTION
Scatter-gather reduction operations are preferable due to non-parallel data transfers. To adjust for this we should only push tensors when they are mono-transfers. When distributing to multiple devices it is preferable to have the device fetch as the case of 1...8 -> 1 -> 1...8 we would prefer each device to handle its own data transfers.