### PR TITLE
Enable iree-test-deps on macos-14

### DIFF
--- a/.github/workflows/ci_macos_arm64_clang.yml
+++ b/.github/workflows/ci_macos_arm64_clang.yml
@@ -55,8 +55,6 @@ jobs:
         run: brew install ninja ccache coreutils bash
       - name: "Building IREE"
         env:
-          # TODO(#19664): Enable building test deps when build errors are fixed.
-          IREE_BUILD_TEST_DEPS: 0
         run: bash ./build_tools/cmake/build_all.sh "${BUILD_DIR}"
 
       - name: Post to Discord on Failure

--- a/.github/workflows/ci_macos_arm64_clang.yml
+++ b/.github/workflows/ci_macos_arm64_clang.yml
@@ -54,7 +54,6 @@ jobs:
         # features we use in scripts.
         run: brew install ninja ccache coreutils bash
       - name: "Building IREE"
-        env:
         run: bash ./build_tools/cmake/build_all.sh "${BUILD_DIR}"
 
       - name: Post to Discord on Failure


### PR DESCRIPTION
The CI is green: https://github.com/iree-org/iree/actions/runs/13248061450

Fixes https://github.com/iree-org/iree/issues/19664