### PR TITLE
Enable ccache for PJRT pkgci workflow

### DIFF
--- a/.github/workflows/pkgci.yml
+++ b/.github/workflows/pkgci.yml
@@ -121,6 +121,8 @@ jobs:
     needs: [setup, build_packages]
     if: contains(fromJson(needs.setup.outputs.enabled-jobs), 'test_pjrt')
     uses: ./.github/workflows/pkgci_test_pjrt.yml
+    with:
+      write-caches: ${{ needs.setup.outputs.write-caches }}
 
   ##############################################################################
 

--- a/.github/workflows/pkgci_test_pjrt.yml
+++ b/.github/workflows/pkgci_test_pjrt.yml
@@ -11,11 +11,17 @@ on:
       artifact_run_id:
         type: string
         default: ""
+      write-caches:
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       artifact_run_id:
         type: string
         default: ""
+      write-caches:
+        required: true
+        type: string
 
 jobs:
   build_and_test:
@@ -59,6 +65,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@a1209f81afb8c005c13b4296c32e363431bffea5 # v1.2.17
         with:
           key: ${{ github.job }}-${{ matrix.pjrt_platform }}
+          save: ${{ inputs.write-caches == 1 }}
       - name: Build and install
         run: |
           # install editable into venv

--- a/.github/workflows/pkgci_test_pjrt.yml
+++ b/.github/workflows/pkgci_test_pjrt.yml
@@ -55,10 +55,16 @@ jobs:
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
             --artifact-path=${PACKAGE_DOWNLOAD_DIR} \
             --fetch-gh-workflow=${{ inputs.artifact_run_id }}
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@a1209f81afb8c005c13b4296c32e363431bffea5 # v1.2.17
+        with:
+          key: ${{ github.job }}-${{ matrix.pjrt_platform }}
       - name: Build and install
         run: |
           # install editable into venv
           source ${VENV_DIR}/bin/activate
+          export CMAKE_C_COMPILER_LAUNCHER=ccache
+          export CMAKE_CXX_COMPILER_LAUNCHER=ccache
           python -m pip install -v --no-deps -e integrations/pjrt/python_packages/iree_${{ matrix.pjrt_platform }}_plugin
           # install
           python -m pip install jax==0.4.36

--- a/integrations/pjrt/python_packages/_setup_support/iree_pjrt_setup.py
+++ b/integrations/pjrt/python_packages/_setup_support/iree_pjrt_setup.py
@@ -197,6 +197,9 @@ class BaseCMakeBuildPy(_build_py):
             cmake_args, "MACOSX_DEPLOYMENT_TARGET", "CMAKE_OSX_DEPLOYMENT_TARGET"
         )
 
+        add_env_cmake_setting(cmake_args, "CMAKE_C_COMPILER_LAUNCHER")
+        add_env_cmake_setting(cmake_args, "CMAKE_CXX_COMPILER_LAUNCHER")
+
         # Only do a from-scratch configure if not already configured.
         cmake_cache_file = os.path.join(cmake_build_dir, "CMakeCache.txt")
         if not os.path.exists(cmake_cache_file):


### PR DESCRIPTION
Follow the comment in #19369 (https://github.com/iree-org/iree/pull/19369/files#discussion_r1871777205), we can make the PJRT workflow faster by enabling ccache in build phase.

Before, it took about 8min ~ 9min to complete the PJRT workflow (e.g. https://github.com/iree-org/iree/actions/runs/13242473906/job/36965747148).

Now, this workflow can be completed in about 4 minutes: https://github.com/iree-org/iree/actions/runs/13244742479/job/36968861178?pr=19944

ci-exactly: build_packages, test_pjrt