### PR TITLE
[Preprocessing] Fix bug in TD dag matching op

### DIFF
--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensions.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensions.cpp
@@ -177,7 +177,7 @@ IREE::transform_dialect::MatchCastCompatibleDagFromRootOp::matchOperation(
           return emitDefiniteFailure() << "Invalid block argument in target";
         }
         int64_t argIdx = targetBlockArg.getArgNumber();
-        if (inputs[argIdx] && inputs[argIdx] != targetOperand) {
+        if (inputs[argIdx] && inputs[argIdx] != payloadOperand) {
           return emitSilenceableError()
                  << "input operand with conflicting uses";
         }


### PR DESCRIPTION
Fixes a bug in the `transform.iree.match.cast_compatible_dag_from_root` op failing to match when there are repeated operands.