### PR TITLE
Fixes for parentheses warnings on gcc/clang.

### DIFF
--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -211,6 +211,7 @@ iree_select_compiler_opts(IREE_DEFAULT_COPTS
     "-Wimplicit-fallthrough"
     "-Winfinite-recursion"
     "-Wliteral-conversion"
+    "-Wlogical-op-parentheses"
     "-Wnon-virtual-dtor"
     "-Woverloaded-virtual"
     "-Wpointer-arith"

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
@@ -59,8 +59,8 @@ static RankedTensorType getPaddedType(RankedTensorType type) {
   ArrayRef<int32_t> padding = layout.getPadding().asArrayRef();
   auto newShape = llvm::to_vector_of<int64_t>(type.getShape());
   for (auto [newDim, padValue] : llvm::zip_equal(newShape, padding)) {
-    assert(padValue == 0 || !ShapedType::isDynamic(newDim) &&
-                                "Padding dynamic dims not supported");
+    assert((padValue == 0 || !ShapedType::isDynamic(newDim)) &&
+           "Padding dynamic dims not supported");
     newDim += padValue;
   }
 


### PR DESCRIPTION
Tentative fix for https://github.com/iree-org/iree/issues/19956.

Unfortunately the clang warning (https://clang.llvm.org/docs/DiagnosticsReference.html#wlogical-op-parentheses) does not flag the same code that gcc does. Might as well enable it just in case though.