### PR TITLE
Revert "Fixing execution region result placement. (#19872)"

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
@@ -150,15 +150,8 @@ struct ExecutePartitionBuilder {
     // If the op has the same affinity as the partition region we can strip it.
     // Note that some ops may have affinities that are more specific and we
     // want to preserve those as long as possible.
-    if (auto transferOp = dyn_cast<IREE::Stream::AsyncTransferOp>(clonedOp)) {
-      if (transferOp.getSourceAffinityAttr() == partition->affinity) {
-        transferOp.setSourceAffinityAttr(nullptr);
-      }
-      if (transferOp.getResultAffinityAttr() == partition->affinity) {
-        transferOp.setResultAffinityAttr(nullptr);
-      }
-    } else if (auto affinityOp =
-                   dyn_cast<IREE::Stream::AffinityOpInterface>(clonedOp)) {
+    if (auto affinityOp =
+            dyn_cast<IREE::Stream::AffinityOpInterface>(clonedOp)) {
       if (affinityOp.getAffinityAttr() == partition->affinity) {
         affinityOp.setAffinityAttr(nullptr);
       }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/schedule_execution.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/schedule_execution.mlir
@@ -34,8 +34,8 @@ util.func public @partitioning(%arg0: !stream.resource<external>, %arg1: !stream
 
 // -----
 
-// Tests partitioning multi device execution with barriers and transfers.
-// It validates that multi stream commands are created and run in parallel:
+// Tests partitioning multi-device execution with barriers and transfers.
+// It validates that multi-stream commands are created and run in parallel.
 
 // CHECK-LABEL: util.func public @deviceMultiDeviceSync
 util.func public @deviceMultiDeviceSync(%arg0: i1) -> !stream.resource<transient> {
@@ -43,37 +43,38 @@ util.func public @deviceMultiDeviceSync(%arg0: i1) -> !stream.resource<transient
   %c1 = arith.constant 1 : index
   %c128 = arith.constant 128 : index
   %c255_i32 = arith.constant 255 : i32
+
+  // CHECK: stream.async.execute on(#hal.device.affinity<@device0>)
+  // CHECK: stream.async.splat
+  // CHECK: stream.async.dispatch
+  // CHECK: stream.async.transfer
   %0 = stream.async.splat %c255_i32 : i32 -> !stream.resource<transient>{%c128}
-  %1 = stream.async.dispatch on(#hal.device.affinity<@__device_0>) @ex::@dispatch0[%c1, %c1, %c1](%0[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
-  %3 = stream.async.barrier %1 : !stream.resource<transient>{%c128} -> !stream.resource<transient>
-  %4 = stream.async.transfer %1 : !stream.resource<transient>{%c128} from(#hal.device.affinity<@__device_0>) -> to(#hal.device.affinity<@__device_1>) !stream.resource<transient>{%c128}
-  // CHECK: stream.async.execute on(#hal.device.affinity<@__device_0>)
+  %1 = stream.async.dispatch on(#hal.device.affinity<@device0>) @ex::@dispatch0[%c1, %c1, %c1](%0[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+  %3 = stream.async.barrier %1 : !stream.resource<transient>{%c128}
+  %4 = stream.async.transfer %1 : !stream.resource<transient>{%c128} from(#hal.device.affinity<@device0>) -> to(#hal.device.affinity<@device1>) !stream.resource<transient>{%c128}
+
+  // CHECK: stream.async.execute on(#hal.device.affinity<@device1>)
   // CHECK: stream.async.splat
   // CHECK: stream.async.dispatch
   // CHECK: stream.async.transfer
+  %2 = stream.async.dispatch on(#hal.device.affinity<@device1>) @ex::@dispatch1[%c1, %c1, %c1](%0[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+  %5 = stream.async.barrier %2 : !stream.resource<transient>{%c128}
+  %6 = stream.async.transfer %2 : !stream.resource<transient>{%c128} from(#hal.device.affinity<@device1>) -> to(#hal.device.affinity<@device0>) !stream.resource<transient>{%c128}
 
-  %2 = stream.async.dispatch on(#hal.device.affinity<@__device_1>) @ex::@dispatch1[%c1, %c1, %c1](%0[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
-  %5 = stream.async.barrier %2 : !stream.resource<transient>{%c128} -> !stream.resource<transient>
-  %6 = stream.async.transfer %2 : !stream.resource<transient>{%c128} from(#hal.device.affinity<@__device_1>) -> to(#hal.device.affinity<@__device_0>) !stream.resource<transient>{%c128}
-  // CHECK: stream.async.execute on(#hal.device.affinity<@__device_1>)
-  // CHECK: stream.async.splat
+  // CHECK: stream.async.execute on(#hal.device.affinity<@device0>)
+  // CHECK: stream.async.dispatch
+  %7 = stream.async.dispatch on(#hal.device.affinity<@device0>) @ex::@dispatch2[%c1, %c1, %c1](%3[%c0 to %c128 for %c128], %6[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}, !stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+  %8 = stream.async.barrier %7 : !stream.resource<transient>{%c128}
+
+  // CHECK: stream.async.execute on(#hal.device.affinity<@device1>)
   // CHECK: stream.async.dispatch
   // CHECK: stream.async.transfer
+  %9 = stream.async.dispatch on(#hal.device.affinity<@device1>) @ex::@dispatch2[%c1, %c1, %c1](%4[%c0 to %c128 for %c128], %5[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}, !stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+  %10 = stream.async.transfer %9 : !stream.resource<transient>{%c128} from(#hal.device.affinity<@device1>) -> to(#hal.device.affinity<@device0>) !stream.resource<transient>{%c128}
 
-  %7 = stream.async.dispatch on(#hal.device.affinity<@__device_0>) @ex::@dispatch2[%c1, %c1, %c1](%3[%c0 to %c128 for %c128], %6[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}, !stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
-  %9 = stream.async.barrier %7 : !stream.resource<transient>{%c128} -> !stream.resource<transient>
-  // CHECK: stream.async.execute on(#hal.device.affinity<@__device_0>)
+  // CHECK: stream.async.execute on(#hal.device.affinity<@device0>)
   // CHECK: stream.async.dispatch
-
-  %8 = stream.async.dispatch on(#hal.device.affinity<@__device_1>) @ex::@dispatch2[%c1, %c1, %c1](%4[%c0 to %c128 for %c128], %5[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}, !stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
-  %10 = stream.async.transfer %8 : !stream.resource<transient>{%c128} from(#hal.device.affinity<@__device_1>) -> to(#hal.device.affinity<@__device_0>) !stream.resource<transient>{%c128}
-  // CHECK: stream.async.execute on(#hal.device.affinity<@__device_1>)
-  // CHECK: stream.async.dispatch
-  // CHECK: stream.async.transfer
-
-  %11 = stream.async.dispatch on(#hal.device.affinity<@__device_0>) @ex::@dispatch2[%c1, %c1, %c1](%9[%c0 to %c128 for %c128], %10[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}, !stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
-  // CHECK: stream.async.execute on(#hal.device.affinity<@__device_0>)
-  // CHECK: stream.async.dispatch
+  %11 = stream.async.dispatch on(#hal.device.affinity<@device0>) @ex::@dispatch2[%c1, %c1, %c1](%8[%c0 to %c128 for %c128], %10[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}, !stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
 
   util.return %11 : !stream.resource<transient>
 }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/schedule_execution.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/schedule_execution.mlir
@@ -34,8 +34,8 @@ util.func public @partitioning(%arg0: !stream.resource<external>, %arg1: !stream
 
 // -----
 
-// Tests partitioning multi-device execution with barriers and transfers.
-// It validates that multi-stream commands are created and run in parallel.
+// Tests partitioning multi device execution with barriers and transfers.
+// It validates that multi stream commands are created and run in parallel:
 
 // CHECK-LABEL: util.func public @deviceMultiDeviceSync
 util.func public @deviceMultiDeviceSync(%arg0: i1) -> !stream.resource<transient> {
@@ -43,38 +43,37 @@ util.func public @deviceMultiDeviceSync(%arg0: i1) -> !stream.resource<transient
   %c1 = arith.constant 1 : index
   %c128 = arith.constant 128 : index
   %c255_i32 = arith.constant 255 : i32
-
-  // CHECK: stream.async.execute on(#hal.device.affinity<@device0>)
-  // CHECK: stream.async.splat
-  // CHECK: stream.async.dispatch
-  // CHECK: stream.async.transfer
   %0 = stream.async.splat %c255_i32 : i32 -> !stream.resource<transient>{%c128}
-  %1 = stream.async.dispatch on(#hal.device.affinity<@device0>) @ex::@dispatch0[%c1, %c1, %c1](%0[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
-  %3 = stream.async.barrier %1 : !stream.resource<transient>{%c128}
-  %4 = stream.async.transfer %1 : !stream.resource<transient>{%c128} from(#hal.device.affinity<@device0>) -> to(#hal.device.affinity<@device1>) !stream.resource<transient>{%c128}
-
-  // CHECK: stream.async.execute on(#hal.device.affinity<@device1>)
+  %1 = stream.async.dispatch on(#hal.device.affinity<@__device_0>) @ex::@dispatch0[%c1, %c1, %c1](%0[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+  %3 = stream.async.barrier %1 : !stream.resource<transient>{%c128} -> !stream.resource<transient>
+  %4 = stream.async.transfer %1 : !stream.resource<transient>{%c128} from(#hal.device.affinity<@__device_0>) -> to(#hal.device.affinity<@__device_1>) !stream.resource<transient>{%c128}
+  // CHECK: stream.async.execute on(#hal.device.affinity<@__device_0>)
   // CHECK: stream.async.splat
   // CHECK: stream.async.dispatch
   // CHECK: stream.async.transfer
-  %2 = stream.async.dispatch on(#hal.device.affinity<@device1>) @ex::@dispatch1[%c1, %c1, %c1](%0[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
-  %5 = stream.async.barrier %2 : !stream.resource<transient>{%c128}
-  %6 = stream.async.transfer %2 : !stream.resource<transient>{%c128} from(#hal.device.affinity<@device1>) -> to(#hal.device.affinity<@device0>) !stream.resource<transient>{%c128}
 
-  // CHECK: stream.async.execute on(#hal.device.affinity<@device0>)
-  // CHECK: stream.async.dispatch
-  %7 = stream.async.dispatch on(#hal.device.affinity<@device0>) @ex::@dispatch2[%c1, %c1, %c1](%3[%c0 to %c128 for %c128], %6[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}, !stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
-  %8 = stream.async.barrier %7 : !stream.resource<transient>{%c128}
-
-  // CHECK: stream.async.execute on(#hal.device.affinity<@device1>)
+  %2 = stream.async.dispatch on(#hal.device.affinity<@__device_1>) @ex::@dispatch1[%c1, %c1, %c1](%0[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+  %5 = stream.async.barrier %2 : !stream.resource<transient>{%c128} -> !stream.resource<transient>
+  %6 = stream.async.transfer %2 : !stream.resource<transient>{%c128} from(#hal.device.affinity<@__device_1>) -> to(#hal.device.affinity<@__device_0>) !stream.resource<transient>{%c128}
+  // CHECK: stream.async.execute on(#hal.device.affinity<@__device_1>)
+  // CHECK: stream.async.splat
   // CHECK: stream.async.dispatch
   // CHECK: stream.async.transfer
-  %9 = stream.async.dispatch on(#hal.device.affinity<@device1>) @ex::@dispatch2[%c1, %c1, %c1](%4[%c0 to %c128 for %c128], %5[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}, !stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
-  %10 = stream.async.transfer %9 : !stream.resource<transient>{%c128} from(#hal.device.affinity<@device1>) -> to(#hal.device.affinity<@device0>) !stream.resource<transient>{%c128}
 
-  // CHECK: stream.async.execute on(#hal.device.affinity<@device0>)
+  %7 = stream.async.dispatch on(#hal.device.affinity<@__device_0>) @ex::@dispatch2[%c1, %c1, %c1](%3[%c0 to %c128 for %c128], %6[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}, !stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+  %9 = stream.async.barrier %7 : !stream.resource<transient>{%c128} -> !stream.resource<transient>
+  // CHECK: stream.async.execute on(#hal.device.affinity<@__device_0>)
   // CHECK: stream.async.dispatch
-  %11 = stream.async.dispatch on(#hal.device.affinity<@device0>) @ex::@dispatch2[%c1, %c1, %c1](%8[%c0 to %c128 for %c128], %10[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}, !stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+
+  %8 = stream.async.dispatch on(#hal.device.affinity<@__device_1>) @ex::@dispatch2[%c1, %c1, %c1](%4[%c0 to %c128 for %c128], %5[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}, !stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+  %10 = stream.async.transfer %8 : !stream.resource<transient>{%c128} from(#hal.device.affinity<@__device_1>) -> to(#hal.device.affinity<@__device_0>) !stream.resource<transient>{%c128}
+  // CHECK: stream.async.execute on(#hal.device.affinity<@__device_1>)
+  // CHECK: stream.async.dispatch
+  // CHECK: stream.async.transfer
+
+  %11 = stream.async.dispatch on(#hal.device.affinity<@__device_0>) @ex::@dispatch2[%c1, %c1, %c1](%9[%c0 to %c128 for %c128], %10[%c0 to %c128 for %c128]) : (!stream.resource<transient>{%c128}, !stream.resource<transient>{%c128}) -> !stream.resource<transient>{%c128}
+  // CHECK: stream.async.execute on(#hal.device.affinity<@__device_0>)
+  // CHECK: stream.async.dispatch
 
   util.return %11 : !stream.resource<transient>
 }


### PR DESCRIPTION
This reverts the changes to `SchedulingExecution.cpp` from commit 4fffb0ebff3f85147e7a991cda352da324e8761b.

This change caused corrupt tokens to be outputted from sharded llama models (#19948).

After bisecting, I was able to get good outputs again after reverting the specific changes to `ScheduleExecution.cpp`.