### PR TITLE
Add `mi300` runner for toy_llama tests

### DIFF
--- a/.github/workflows/pkgci_test_sharktank.yml
+++ b/.github/workflows/pkgci_test_sharktank.yml
@@ -21,6 +21,8 @@ jobs:
   test_sharktank_models:
     name: "test_sharktank_models :: ${{ matrix.name }}"
     runs-on: ${{ matrix.runs-on }}
+    # Dynamically assign container for `linux-mi300-gpu-1`
+    container: ${{ fromJSON(toJSON(matrix.container || {})) }}
     strategy:
       fail-fast: false
       matrix:
@@ -39,6 +41,9 @@ jobs:
             target: target_hip
             gpu: gfx942
             runs-on: linux-mi300-gpu-1
+            container:
+              image: rocm/dev-ubuntu-22.04:6.3
+              options: --user root --device=/dev/kfd --device=/dev/dri --ipc=host --group-add video --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
 
     env:
       VENV_DIR: ${{ github.workspace }}/venv

--- a/.github/workflows/pkgci_test_sharktank.yml
+++ b/.github/workflows/pkgci_test_sharktank.yml
@@ -50,6 +50,12 @@ jobs:
     env:
       VENV_DIR: ${{ github.workspace }}/venv
     steps:
+      - name: "Install dependencies"
+        # Only run if a container is defined in the matrix (i.e., not null)
+        if: ${{ matrix.container != null }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build clang lld git
       - name: Checking out IREE repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/pkgci_test_sharktank.yml
+++ b/.github/workflows/pkgci_test_sharktank.yml
@@ -30,10 +30,15 @@ jobs:
             gpu: none
             runs-on: ubuntu-24.04
 
-          - name: hip_task
+          - name: hip_task_w7900
             target: target_hip
             gpu: gfx1100
             runs-on: nodai-amdgpu-w7900-x86-64
+
+          - name: hip_task_mi300
+            target: target_hip
+            gpu: gfx942
+            runs-on: linux-mi300-gpu-1
 
     env:
       VENV_DIR: ${{ github.workspace }}/venv

--- a/.github/workflows/pkgci_test_sharktank.yml
+++ b/.github/workflows/pkgci_test_sharktank.yml
@@ -22,7 +22,7 @@ jobs:
     name: "test_sharktank_models :: ${{ matrix.name }}"
     runs-on: ${{ matrix.runs-on }}
     # Dynamically assign container for `linux-mi300-gpu-1`
-    container: ${{ fromJSON(toJSON(matrix.container || {})) }}
+    container: ${{ fromJSON(toJSON(matrix.container)) }}
     strategy:
       fail-fast: false
       matrix:
@@ -31,11 +31,13 @@ jobs:
             target: target_cpu
             gpu: none
             runs-on: ubuntu-24.04
+            container: null
 
           - name: hip_task_w7900
             target: target_hip
             gpu: gfx1100
             runs-on: nodai-amdgpu-w7900-x86-64
+            container: null
 
           - name: hip_task_mi300
             target: target_hip


### PR DESCRIPTION
Currently, we only run on a `w7900` when we run the toy_llama tests. I recently bisected an issue due to sharding accuracy being broken for llama in shortfin, on mi300 (#19872), and when I run `iree-test-suites` locally, I get failures:

```bash
================================================= short test summary info ==================================================
PASSED sharktank_models/clip/test_clip.py::test_results_close[bf16-hip]
PASSED sharktank_models/clip/test_clip.py::test_results_close[f32-hip]
PASSED sharktank_models/llama3.1/test_llama.py::test_prefill[hip]
PASSED sharktank_models/llama3.1/test_llama.py::test_decode[hip]
PASSED sharktank_models/llama3.1/test_llama.py::test_prefill_decode[hip]
PASSED sharktank_models/llama3.1/test_llama.py::test_prefill[hip_tp2]
PASSED sharktank_models/llama3.1/test_llama.py::test_prefill_decode[hip_tp2]
FAILED sharktank_models/llama3.1/test_llama.py::test_decode[hip_tp2] - AssertionError: cross entropy outside of tolerance
================================== 1 failed, 7 passed, 8 deselected, 2 warnings in 17.84s ==================================
```

I suspect that this would have been able to catch the bug had it been enabled. If it didn't, then we can determine how to extend the tests to cover the case we saw.

Reference issues for sharded failure: https://github.com/iree-org/iree/issues/19948, https://github.com/nod-ai/shark-ai/issues/934

ci-exactly: build_packages,test_sharktank