### PR TITLE
Disable ubuntu-24.04-arm workflows until the runners are stable.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,10 @@ jobs:
           - name: ubuntu-24.04
             runs-on: ubuntu-24.04
             driver-options: -DIREE_HAL_DRIVER_CUDA=ON -DIREE_HAL_DRIVER_HIP=ON -DIREE_HAL_DRIVER_VULKAN=ON
-          - name: ubuntu-24.04-arm
-            runs-on: ubuntu-24.04-arm
-            driver-options: -DIREE_HAL_DRIVER_CUDA=ON -DIREE_HAL_DRIVER_HIP=ON -DIREE_HAL_DRIVER_VULKAN=ON
+          # TODO(scotttodd): re-enable when GitHub-hosted Arm runners are stable and don't fail during actions/checkout
+          # - name: ubuntu-24.04-arm
+          #   runs-on: ubuntu-24.04-arm
+          #   driver-options: -DIREE_HAL_DRIVER_CUDA=ON -DIREE_HAL_DRIVER_HIP=ON -DIREE_HAL_DRIVER_VULKAN=ON
           - name: windows-2022
             runs-on: windows-2022
             driver-options: -DIREE_HAL_DRIVER_CUDA=ON -DIREE_HAL_DRIVER_HIP=ON -DIREE_HAL_DRIVER_VULKAN=ON
@@ -169,7 +170,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-24.04, ubuntu-24.04-arm, windows-2022, macos-14]
+        runs-on:
+          - ubuntu-24.0
+          # TODO(scotttodd): re-enable when GitHub-hosted Arm runners are stable and don't fail during actions/checkout
+          # - ubuntu-24.04-arm
+          - windows-2022
+          - macos-14
         provider: [tracy, console]
     env:
       BUILD_DIR: build-tracing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on:
-          - ubuntu-24.0
+          - ubuntu-24.04
           # TODO(scotttodd): re-enable when GitHub-hosted Arm runners are stable and don't fail during actions/checkout
           # - ubuntu-24.04-arm
           - windows-2022


### PR DESCRIPTION
See other reports at https://github.com/actions/partner-runner-images/issues/47. Sample failure here: https://github.com/iree-org/iree/actions/runs/13273573155/job/37060589352?pr=19964.

ci-exactly: runtime,runtime_tracing