### PR TITLE
[AMDGPU] Do not rewrite or approximate math functions on ROCm

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/MathTransformPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MathTransformPass.cpp
@@ -63,12 +63,15 @@ static void populateMathFunctionsRewritePatterns(
 
 static bool predicateRewrite(StringRef name,
                              IREE::HAL::ExecutableTargetAttr target) {
-  (void)target;                // Currently unused.
   if (clNativeMathPrecision) { // Legacy.
     if (name == math::Exp2Op::getOperationName() ||
         name == math::RoundEvenOp::getOperationName()) {
       return false;
     }
+  }
+  if (isROCMBackend(target)) {
+    // On ROCm, we want to use device library functions.
+    return false;
   }
   // Currently enable all non-approximative rewrites.
   return true;
@@ -109,6 +112,10 @@ static bool predicateApprox(StringRef name,
     }
     return false;
   }
+  if (isROCMBackend(target)) {
+    // On ROCm, we want to use device library functions.
+    return false;
+  }
   StringRef acos = math::AcosOp::getOperationName();
   StringRef asin = math::AsinOp::getOperationName();
   StringRef atan = math::AtanOp::getOperationName();
@@ -123,9 +130,6 @@ static bool predicateApprox(StringRef name,
   StringRef expm1 = math::ExpM1Op::getOperationName();
   StringRef cbrt = math::CbrtOp::getOperationName();
   StringRef erf = math::ErfOp::getOperationName();
-  if (isROCMBackend(target) && name == erf) {
-    return false;
-  }
   return llvm::is_contained({atan, atan2, tanh, log, log2, log1p, erf, asin,
                              acos, exp, expm1, cbrt, sin, cos},
                             name);

--- a/compiler/src/iree/compiler/Codegen/Common/test/math_transform.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/math_transform.mlir
@@ -58,17 +58,36 @@ func.func @rewrite_erf(%arg0: f16) -> f16 attributes {
 
 // -----
 
-// CHECK-LABEL: @no_approx_erf_on_rocm
-func.func @no_approx_erf_on_rocm(%arg0: f16) -> f16 attributes {
+// CHECK-LABEL: @no_approx_on_rocm
+func.func @no_approx_on_rocm(%arg0: f16) -> f16 attributes {
   hal.executable.target =  #hal.executable.target<"rocm", "rocm-hsaco-fb", {}>
 } {
-  // On ROCm, we want to use the native device library function, so math.erf
-  // should not get rewritten. It's OK for f16 to still get casted to f32, as
-  // the device library function for f16 is casting to f32 anyway.
+  // On ROCm, we want to use the native device library functions.
+  // It's OK for f16 to still get casted to f32, as
+  // the device library functions for f16 are casting to f32 anyway.
+  // CHECK:         math.acos
+  // CHECK:         math.atan
+  // CHECK:         math.sin
+  // CHECK:         math.tanh
+  // CHECK:         math.log
+  // CHECK:         math.log2
+  // CHECK:         math.log1p
+  // CHECK:         math.exp
+  // CHECK:         math.exp2
+  // CHECK:         math.expm1
+  // CHECK:         math.cbrt
   // CHECK:         math.erf
-  // CHECK-NOT:     math.exp
-  // CHECK-NOT:     math.log
-  // CHECK-NOT:     math.fma
-  %0 = math.erf %arg0 : f16
-  return %0 : f16
+  %0 = math.acos %arg0 : f16
+  %1 = math.atan %0 : f16
+  %2 = math.sin %1 : f16
+  %3 = math.tanh %2 : f16
+  %4 = math.log %3 : f16
+  %5 = math.log2 %4 : f16
+  %6 = math.log1p %5 : f16
+  %7 = math.exp %6 : f16
+  %8 = math.exp2 %7 : f16
+  %9 = math.expm1 %8 : f16
+  %10 = math.cbrt %9 : f16
+  %11 = math.erf %10 : f16
+  return %11 : f16
 }

--- a/tests/e2e/math/math_ops_llvm-cpu.json
+++ b/tests/e2e/math/math_ops_llvm-cpu.json
@@ -2,8 +2,8 @@
   {
     "op": "acos",
     "type": "f32",
-    "atol": 1.0e-06,
-    "rtol": 1.0e-06
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
   },
   {
     "op": "acos",
@@ -14,8 +14,8 @@
   {
     "op": "acosh",
     "type": "f32",
-    "atol": 1.0e-06,
-    "rtol": 1.0e-06
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
   },
   {
     "op": "acosh",
@@ -26,8 +26,8 @@
   {
     "op": "asin",
     "type": "f32",
-    "atol": 1.0e-06,
-    "rtol": 1.0e-06
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
   },
   {
     "op": "asin",
@@ -50,20 +50,20 @@
   {
     "op": "atan",
     "type": "f32",
-    "atol": 1.0e-06,
-    "rtol": 1.0e-06
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
   },
   {
     "op": "atan",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03
+    "atol": 1.0e-04,
+    "rtol": 1.0e-04
   },
   {
     "op": "atanh",
     "type": "f32",
-    "atol": 1.0e-06,
-    "rtol": 1.0e-06
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
   },
   {
     "op": "atanh",
@@ -80,8 +80,8 @@
   {
     "op": "cbrt",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03
+    "atol": 1.0e-04,
+    "rtol": 1.0e-04
   },
   {
     "op": "ceil",
@@ -104,8 +104,8 @@
   {
     "op": "cos",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03
+    "atol": 1.0e-04,
+    "rtol": 1.0e-04
   },
   {
     "op": "cosh",
@@ -125,14 +125,14 @@
   {
     "op": "erf",
     "type": "f32",
-    "atol": 1.0e-06,
-    "rtol": 1.0e-06
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
   },
   {
     "op": "erf",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03
+    "atol": 1.0e-04,
+    "rtol": 1.0e-04
   },
   {
     "op": "exp",
@@ -143,8 +143,8 @@
   {
     "op": "exp",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03
+    "atol": 1.0e-04,
+    "rtol": 1.0e-04
   },
   {
     "op": "exp2",
@@ -168,8 +168,8 @@
   {
     "op": "expm1",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03
+    "atol": 1.0e-04,
+    "rtol": 1.0e-04
   },
   {
     "op": "floor",
@@ -186,38 +186,38 @@
   {
     "op": "log",
     "type": "f32",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03
+    "atol": 1.0e-04,
+    "rtol": 1.0e-04
   },
   {
     "op": "log",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03
+    "atol": 1.0e-04,
+    "rtol": 1.0e-04
   },
   {
     "op": "log1p",
     "type": "f32",
-    "atol": 1.0e-06,
-    "rtol": 1.0e-06
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
   },
   {
     "op": "log1p",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03
+    "atol": 1.0e-04,
+    "rtol": 1.0e-04
   },
   {
     "op": "log2",
     "type": "f32",
-    "atol": 1.0e-06,
-    "rtol": 1.0e-06
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
   },
   {
     "op": "log2",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03
+    "atol": 1.0e-04,
+    "rtol": 1.0e-04
   },
   {
     "op": "round",
@@ -246,8 +246,8 @@
   {
     "op": "rsqrt",
     "type": "f32",
-    "atol": 1.0e-06,
-    "rtol": 1.0e-06
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
   },
   {
     "op": "rsqrt",
@@ -264,8 +264,8 @@
   {
     "op": "sin",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03
+    "atol": 1.0e-04,
+    "rtol": 1.0e-04
   },
   {
     "op": "sinh",
@@ -285,14 +285,14 @@
   {
     "op": "sqrt",
     "type": "f32",
-    "atol": 1.0e-06,
-    "rtol": 1.0e-06
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
   },
   {
     "op": "sqrt",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03
+    "atol": 1.0e-04,
+    "rtol": 1.0e-04
   },
   {
     "op": "tan",
@@ -315,8 +315,8 @@
   {
     "op": "tanh",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03
+    "atol": 1.0e-04,
+    "rtol": 1.0e-04
   },
   {
     "op": "atan2",
@@ -327,8 +327,8 @@
   {
     "op": "atan2",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03
+    "atol": 1.0e-04,
+    "rtol": 1.0e-04
   },
   {
     "op": "powf",

--- a/tests/e2e/math/math_ops_rocm.json
+++ b/tests/e2e/math/math_ops_rocm.json
@@ -2,32 +2,32 @@
   {
     "op": "acos",
     "type": "f32",
-    "atol": 1.0e-06,
-    "rtol": 1.0e-06
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
   },
   {
     "op": "acos",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03
+    "atol": 0,
+    "rtol": 0
   },
   {
     "op": "acosh",
     "type": "f32",
-    "atol": 1.0e-06,
-    "rtol": 1.0e-06
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
   },
   {
     "op": "acosh",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03
+    "atol": 0,
+    "rtol": 0
   },
   {
     "op": "asin",
     "type": "f32",
-    "atol": 1.0e-06,
-    "rtol": 1.0e-06
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
   },
   {
     "op": "asin",
@@ -38,50 +38,50 @@
   {
     "op": "asinh",
     "type": "f32",
-    "atol": 1.0e-05,
-    "rtol": 1.0e-05
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
   },
   {
     "op": "asinh",
     "type": "f16",
-    "atol": 5.0e-02,
-    "rtol": 5.0e-02
+    "atol": 0,
+    "rtol": 0
   },
   {
     "op": "atan",
     "type": "f32",
-    "atol": 1.0e-06,
-    "rtol": 1.0e-06
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
   },
   {
     "op": "atan",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03
+    "atol": 0,
+    "rtol": 0
   },
   {
     "op": "atanh",
     "type": "f32",
-    "atol": 1.0e-06,
-    "rtol": 1.0e-06
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
   },
   {
     "op": "atanh",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03
+    "atol": 0,
+    "rtol": 0
   },
   {
     "op": "cbrt",
     "type": "f32",
-    "atol": 1.0e-06,
-    "rtol": 1.0e-06
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
   },
   {
     "op": "cbrt",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03
+    "atol": 0,
+    "rtol": 0
   },
   {
     "op": "ceil",
@@ -98,41 +98,38 @@
   {
     "op": "cos",
     "type": "f32",
-    "atol": 1.0e-06,
-    "rtol": 1.0e-06
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
   },
   {
     "op": "cos",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03
+    "atol": 0,
+    "rtol": 0
   },
   {
     "op": "cosh",
     "type": "f32",
-    "atol": 1.0e-06,
-    "rtol": 1.0e-06
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
   },
   {
     "op": "cosh",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03,
-    "xmin": -8,
-    "xmax": 8,
-    "comment": "discrepancy at switch between large-finite and infinite values"
+    "atol": 0,
+    "rtol": 0
   },
   {
     "op": "erf",
     "type": "f32",
-    "atol": 1.0e-06,
-    "rtol": 1.0e-06
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
   },
   {
     "op": "erf",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03
+    "atol": 0,
+    "rtol": 0
   },
   {
     "op": "exp",
@@ -143,20 +140,20 @@
   {
     "op": "exp",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03
+    "atol": 0,
+    "rtol": 0
   },
   {
     "op": "exp2",
     "type": "f32",
-    "atol": 1.0e-06,
-    "rtol": 1.0e-06
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
   },
   {
     "op": "exp2",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-02
+    "atol": 0,
+    "rtol": 0
   },
   {
     "op": "expm1",
@@ -167,8 +164,8 @@
   {
     "op": "expm1",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03
+    "atol": 0,
+    "rtol": 0
   },
   {
     "op": "floor",
@@ -185,38 +182,38 @@
   {
     "op": "log",
     "type": "f32",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
   },
   {
     "op": "log",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03
+    "atol": 0,
+    "rtol": 0
   },
   {
     "op": "log1p",
     "type": "f32",
-    "atol": 1.0e-06,
-    "rtol": 1.0e-06
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
   },
   {
     "op": "log1p",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03
+    "atol": 0,
+    "rtol": 0
   },
   {
     "op": "log2",
     "type": "f32",
-    "atol": 1.0e-06,
-    "rtol": 1.0e-06
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
   },
   {
     "op": "log2",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03
+    "atol": 0,
+    "rtol": 0
   },
   {
     "op": "round",
@@ -245,8 +242,8 @@
   {
     "op": "rsqrt",
     "type": "f32",
-    "atol": 1.0e-06,
-    "rtol": 1.0e-06
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
   },
   {
     "op": "rsqrt",
@@ -257,47 +254,44 @@
   {
     "op": "sin",
     "type": "f32",
-    "atol": 1.0e-06,
-    "rtol": 1.0e-06
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
   },
   {
     "op": "sin",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03
+    "atol": 0,
+    "rtol": 0
   },
   {
     "op": "sinh",
     "type": "f32",
-    "atol": 1.0e-06,
-    "rtol": 1.0e-06
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
   },
   {
     "op": "sinh",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03,
-    "xmin": -8,
-    "xmax": 8,
-    "comment": "discrepancy at switch between large-finite and infinite values"
+    "atol": 0,
+    "rtol": 0
   },
   {
     "op": "sqrt",
     "type": "f32",
-    "atol": 1.0e-06,
-    "rtol": 1.0e-06
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
   },
   {
     "op": "sqrt",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03
+    "atol": 0,
+    "rtol": 0
   },
   {
     "op": "tan",
     "type": "f32",
-    "atol": 1.0e-05,
-    "rtol": 1.0e-03
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
   },
   {
     "op": "tan",
@@ -308,26 +302,26 @@
   {
     "op": "tanh",
     "type": "f32",
-    "atol": 1.0e-06,
-    "rtol": 1.0e-06
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
   },
   {
     "op": "tanh",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03
+    "atol": 0,
+    "rtol": 0
   },
   {
     "op": "atan2",
     "type": "f32",
-    "atol": 1.0e-05,
-    "rtol": 1.0e-05
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
   },
   {
     "op": "atan2",
     "type": "f16",
-    "atol": 1.0e-03,
-    "rtol": 1.0e-03
+    "atol": 0,
+    "rtol": 0
   },
   {
     "op": "powf",
@@ -339,6 +333,6 @@
     "op": "powf",
     "type": "f16",
     "atol": 1.0e-03,
-    "rtol": 1.0e-02
+    "rtol": 1.0e-03
   }
 ]


### PR DESCRIPTION
On ROCm, we want to use the device library for all math functions.

This expands on https://github.com/iree-org/iree/pull/19969, which only concerned `math.erf`.

We only leave one category of rewrites enabled: the operand casts to f32. The ROCm device library internally performs the same for many math functions, so dropping the casts on our side would not necessarily make any difference.

The effect on accuracy is reflected in the updates to the JSON files in this PR, controlling the tolerances in the e2e accuracy tests for math ops. The tolerances are tightened also for LLVM-CPU to provide an accurate basis for comparison. The resulting diff between the two JSON files shows how the ROCm device library functions are much more accurate than the MLIR polynomial approximation which we are using on LLVM-CPU:
https://gist.github.com/bjacob/98549902957e8171373ffceed5611411#file-a-diff

Note that the tolerances 0 on many f16 testcases on ROCm, effectively requesting exactness, are explained by the fact that since we upcast from f16 to f32, the loss of precision in the math approximation happens in f32 and is typically small enough to not result in a change of the final f16 value after rounding.