### PR TITLE
[LLVMGPUVectorDistribute] Infer sizes for dynamic shapes from lowering config

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUConfigureTensorLayouts.cpp
@@ -903,6 +903,13 @@ static LogicalResult setGPULoweringConfigLayout(
   Location loc = candidate.getLoc();
 
   SmallVector<int64_t> bounds = candidate.getStaticLoopRanges();
+  std::optional<VectorizationTileSizes> sizes =
+      inferSizesFromIR(candidate, std::nullopt);
+  // Even though the opShape could be dynamic, we could potentially
+  // infer the vector shape
+  if (sizes.has_value()) {
+    bounds = sizes.value().vectorSizes;
+  }
 
   // Subgroup distribution layouts.
   SmallVector<int64_t> subgroupSizes, subgroupStrides;


### PR DESCRIPTION
Currently, we only infer static tiling sizes when we use derived thread config.
This commit adds the same support when tiling sizes are derived from lowering config.