### PR TITLE
[codegen][gpu] Adding conv filter layout fhwc to preprocessing pipeline

### DIFF
--- a/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvFilterToChannelsLast.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/ConvertConvFilterToChannelsLast.cpp
@@ -128,8 +128,6 @@ public:
       LDBG("convert-filter-to-channels-last pass didn't apply since an "
            "unsupported layout is given. Please use hwfc or fhwc as pass "
            "filter-layout option.");
-      // TODO add default fallback to filter layout once we have more data
-      // about models with the two layouts
       return signalPassFailure();
     }
 

--- a/compiler/src/iree/compiler/Preprocessing/Common/Passes.td
+++ b/compiler/src/iree/compiler/Preprocessing/Common/Passes.td
@@ -41,7 +41,7 @@ def ConvertConvFilterToChannelsLastPass:
   let summary = "Convert linalg convolutions filter from hwcf to channel last layout.";
   let options = [
     Option<"filterLayout", "filter-layout", "std::string",
-      /*default=*/"", "Filter layout of convolution.">,
+      /*default=*/"\"fhwc\"", "Filter layout of convolution.">,
   ];
   let dependentDialects = [
     "mlir::linalg::LinalgDialect",

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/conv_filter_to_channels_last.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/conv_filter_to_channels_last.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(util.func(iree-preprocessing-convert-conv-filter-to-channels-last{filter-layout=hwfc}))" %s | FileCheck --check-prefixes=CHECK-HWFC,CHECK-ALL %s
-// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(util.func(iree-preprocessing-convert-conv-filter-to-channels-last{filter-layout=fhwc}))" %s | FileCheck --check-prefixes=CHECK-FHWC,CHECK-ALL %s
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(util.func(iree-preprocessing-convert-conv-filter-to-channels-last))" %s | FileCheck --check-prefixes=CHECK-FHWC,CHECK-ALL %s
 
 // CHECK-HWFC: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d3, d6)>
 // CHECK-FHWC: #[[$MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d3, d4, d5, d6)>

--- a/compiler/src/iree/compiler/Preprocessing/Passes.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Passes.cpp
@@ -103,7 +103,8 @@ buildTransposeConvolutionPassPipeline(OpPassManager &passManager,
       .addPass(GlobalOptimization::createDetachElementwiseFromNamedOpsPass)
       .addPass(mlir::createLinalgNamedOpConversionPass)
       .addPass(GlobalOptimization::createConvert1X1FilterConv2DToMatmulPass)
-      .addPass(createConvertConvToChannelsLastPass);
+      .addPass(createConvertConvToChannelsLastPass)
+      .addPass(createConvertConvFilterToChannelsLastPass);
   passManager.addPass(DispatchCreation::createFoldUnitExtentDimsPass());
   passManager.addPass(createCanonicalizerPass());
   passManager.addPass(createCSEPass());


### PR DESCRIPTION
This PR is follow-up to #19739 and #19798. In previous PRs, we allowed convolution filter to be converted according to pipeline options and lower through igemm lowering pipeline. As @Max191's tuning on convolution demonstrated the performance benefit of this pass, we decide to plumb the pass by default in this follow-up PR.

In this PR, we turn this pass on by default sdxl inference pipeline `iree-preprocessing-transpose-convolution-pipeline`. This will allow the pass to turn on in convolution related inferencing workloads. It will also pick `fhwc` layout by default if no option is explicitly set for `filter-layout`. 

Credit to discussion from @Max191 and @nirvedhmeshram that we don't always want to turn this pass on because transpose on filter can still be an overhead in training workloads. This pass matches the location where `ConvertConvToChannelsLast` is.