### PR TITLE
[Stream] Enable batch affinity queries in SpecializeEncoding pass.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamInterfaces.h
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamInterfaces.h
@@ -16,8 +16,13 @@
 
 namespace mlir::iree_compiler::IREE::Stream {
 
+using AffinityAndOpPair = std::pair<AffinityAttr, Operation *>;
+
+// The function could be slow, if any data flow analysis is involved. Thus, the
+// API provides the batch mode.
 using ResolveLayoutAttrFn = std::function<LogicalResult(
-    AffinityAttr, Operation *, SetVector<Attribute> &)>;
+    ArrayRef<AffinityAndOpPair>,
+    llvm::DenseMap<AffinityAndOpPair, SetVector<Attribute>> &)>;
 
 class AffinityAnalysisDialectInterface
     : public DialectInterface::Base<AffinityAnalysisDialectInterface> {

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamInterfaces.h
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamInterfaces.h
@@ -21,8 +21,8 @@ using AffinityAndOpPair = std::pair<AffinityAttr, Operation *>;
 // The function could be slow, if any data flow analysis is involved. Thus, the
 // API provides the batch mode.
 using ResolveLayoutAttrFn = std::function<LogicalResult(
-    ArrayRef<AffinityAndOpPair>,
-    llvm::DenseMap<AffinityAndOpPair, SetVector<Attribute>> &)>;
+    ArrayRef<AffinityAndOpPair> batchQueries,
+    llvm::DenseMap<AffinityAndOpPair, SetVector<Attribute>> &layoutAttrs)>;
 
 class AffinityAnalysisDialectInterface
     : public DialectInterface::Base<AffinityAnalysisDialectInterface> {

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
@@ -58,6 +58,8 @@ SmallVector<const T *> gatherUsedDialectInterfaces(mlir::ModuleOp moduleOp) {
   return results;
 }
 
+} // namespace
+
 // Returns an updated encoding attribute if the type is a RankedTensorType
 // and an EncodingAttr is present. Otherwise, returns std::nullopt. The
 // method uses the EncodingLayoutAttrInterface from the EncodingAttr to
@@ -311,8 +313,7 @@ namespace {
 // will be needed in the work.
 class StreamTensorOpUpdater {
 public:
-  StreamTensorOpUpdater();
-  StreamTensorOpUpdater(ModuleOp moduleOp);
+  explicit StreamTensorOpUpdater(ModuleOp moduleOp) : moduleOp(moduleOp){};
   ~StreamTensorOpUpdater() {}
 
   // Collects the stream tensor op candidates, and prepares all the needed
@@ -354,10 +355,8 @@ private:
   // encodings. See StreamInterfaces.h for more details.
   IREE::Stream::ResolveLayoutAttrFn resolveLayoutAttr;
 };
-} // namespace
 
-StreamTensorOpUpdater::StreamTensorOpUpdater(ModuleOp moduleOp)
-    : moduleOp(moduleOp) {}
+} // namespace
 
 LogicalResult StreamTensorOpUpdater::init() {
   auto usedDialects = gatherUsedDialectInterfaces<
@@ -659,8 +658,8 @@ LogicalResult StreamTensorOpUpdater::run() {
   }
   return success();
 }
-} // namespace
 
+namespace {
 struct SpecializeEncodingsPass
     : public impl::SpecializeEncodingsPassBase<SpecializeEncodingsPass> {
   void runOnOperation() override {
@@ -687,5 +686,6 @@ struct SpecializeEncodingsPass
     }
   }
 };
+} // namespace
 
 } // namespace mlir::iree_compiler::IREE::Stream

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
@@ -17,6 +17,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/LogicalResult.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/SymbolTable.h"
@@ -274,14 +275,143 @@ static RankedTensorType cloneWithEncoding(RankedTensorType type,
                                encodingAttr);
 }
 
+/// Returns all the stream tensor ops that implement AffinityOpInterface, where
+/// a stream affinity indicates the kind of enviroment the ops are expected run
+/// in.
+static SmallVector<IREE::Stream::AffinityOpInterface>
+collectStreamTensorOps(FunctionOpInterface funcOp) {
+  SmallVector<IREE::Stream::AffinityOpInterface> result;
+  funcOp.walk([&](IREE::Stream::AffinityOpInterface affinityOp) {
+    // Only need to update encoding types for ops that have TensorPhaseOp trait.
+    if (!affinityOp->hasTrait<OpTrait::IREE::Stream::TensorPhaseOp>()) {
+      return;
+    }
+
+    // Bail out if the operation does not have an affinity attribute.
+    auto affinityAttr = affinityOp.getAffinityAttr();
+    if (!affinityAttr) {
+      return;
+    }
+    result.push_back(affinityOp);
+  });
+  return result;
+}
+
+namespace {
+
+// Adds the resolved layouts to all tensor types on stream tensor ops, if
+// encodings are present. Most of stream tensor ops implement
+// AffinityOpInterface, where a stream affinity indicates the kind of
+// enviroment the ops are expected run in. When an encoding is present in the
+// tensor type, the method resolves the layouts, strips outdated information,
+// and adds the resolved layouts to the encodings. The updated encodings should
+// have enough information for other lowering transformations.
+// TODO(hanchung): Add support for stream.tensor.load ops and
+// stream.tensor.store ops. They are not affinity ops, so additional analysis
+// will be needed in the work.
+class StreamTensorOpUpdater {
+public:
+  StreamTensorOpUpdater();
+  StreamTensorOpUpdater(ModuleOp moduleOp);
+  ~StreamTensorOpUpdater() {}
+
+  // Collects the stream tensor op candidates, and prepares all the needed
+  // information for the update. This must be called once before calling `run`.
+  // Note that all the ops are unmodified after the execution.
+  LogicalResult init();
+
+  // Adds the resolved layouts to all tensor types of `streamOps`, if encodings
+  // are present.
+  LogicalResult run();
+
+private:
+  // Appends the query from the `affinityOp` to `queries`. Note that most of
+  // operations only care the execution affinity. There are outliers (e.g.,
+  // tensor dispatch op, etc.) that need to resolve affinities for
+  // operand resources.
+  LogicalResult addQuery(IREE::Stream::AffinityAnalysis &affinityAnalysis,
+                         IREE::Stream::AffinityOpInterface affinityOp);
+
+  // The list of the queries that can be used for batch affinity queries. The
+  // analysis could be very expensive because it could apply the whole program
+  // data flow analysis.
+  SmallVector<IREE::Stream::AffinityAndOpPair> queries;
+
+  // The layout resolvers for each query.
+  llvm::DenseMap<IREE::Stream::AffinityAndOpPair, SetVector<Attribute>>
+      cachedLayoutAttrs;
+
+  // Input moduleOp. The op is not expected to be updated during the query.
+  // Because data flow analaysis can be involved. Modifying the IR invalidates
+  // the state and may lead to crashes as pointer references into the IR
+  // structure are retained.
+  ModuleOp moduleOp;
+
+  // The ops that need to be updated.
+  SmallVector<IREE::Stream::AffinityOpInterface> streamOps;
+
+  // The layout resolver function, which is used to resolve layouts for
+  // encodings. See StreamInterfaces.h for more details.
+  IREE::Stream::ResolveLayoutAttrFn resolveLayoutAttr;
+};
+} // namespace
+
+StreamTensorOpUpdater::StreamTensorOpUpdater(ModuleOp moduleOp)
+    : moduleOp(moduleOp) {}
+
+LogicalResult StreamTensorOpUpdater::init() {
+  auto usedDialects = gatherUsedDialectInterfaces<
+      IREE::Stream::AffinityAnalysisDialectInterface>(moduleOp);
+  if (usedDialects.size() != 1) {
+    return moduleOp.emitError("expected only one dialect implementing "
+                              "AffinityAnalysisDialectInterface");
+  }
+  resolveLayoutAttr = usedDialects[0]->makeLayoutAttrResolver(moduleOp);
+
+  for (auto funcOp : moduleOp.getOps<FunctionOpInterface>()) {
+    streamOps.append(collectStreamTensorOps(funcOp));
+  }
+
+  return success();
+}
+
+LogicalResult StreamTensorOpUpdater::addQuery(
+    IREE::Stream::AffinityAnalysis &affinityAnalysis,
+    IREE::Stream::AffinityOpInterface affinityOp) {
+  queries.emplace_back(affinityOp.getAffinityAttr(), affinityOp);
+
+  if (auto dispatchOp =
+          dyn_cast<IREE::Stream::TensorDispatchOp>(affinityOp.getOperation())) {
+    for (auto [operand, typeAttr] :
+         llvm::zip_equal(dispatchOp.getMixedOperands(),
+                         dispatchOp.getOperandEncodings().getValue())) {
+      auto type = cast<TypeAttr>(typeAttr).getValue();
+      // Skip if the operand type is not AffinityType.
+      if (!isa<IREE::Stream::AffinityTypeInterface>(type)) {
+        continue;
+      }
+      SmallVector<IREE::Stream::AffinityAttr> affinityAttrs;
+      if (!affinityAnalysis.tryLookupResourceAffinity(operand, affinityAttrs)) {
+        return failure();
+      }
+      for (auto affinity : affinityAttrs) {
+        queries.emplace_back(affinity, affinityOp);
+      }
+    }
+  }
+
+  return success();
+}
+
 /// Updates the operand encondings and result encodings for the `dispatchOp`
 /// with resolved layouts.
-static LogicalResult
-updateTensorDispatchOp(RewriterBase &rewriter, ModuleOp moduleOp,
-                       IREE::Stream::AffinityAnalysis &affinityAnalysis,
-                       IREE::Stream::TensorDispatchOp dispatchOp,
-                       const SetVector<Attribute> &resLayoutResolvers,
-                       IREE::Stream::ResolveLayoutAttrFn resolveLayoutAttr) {
+static LogicalResult updateTensorDispatchOp(
+    RewriterBase &rewriter, ModuleOp moduleOp,
+    IREE::Stream::AffinityAnalysis &affinityAnalysis,
+    IREE::Stream::TensorDispatchOp dispatchOp,
+    const SetVector<Attribute> &resLayoutResolvers,
+    llvm::DenseMap<IREE::Stream::AffinityAndOpPair, SetVector<Attribute>>
+        &cachedLayoutAttrs) {
   SmallVector<Type> newOperandEncodings;
   for (auto [operand, typeAttr] :
        llvm::zip_equal(dispatchOp.getMixedOperands(),
@@ -299,11 +429,11 @@ updateTensorDispatchOp(RewriterBase &rewriter, ModuleOp moduleOp,
     if (affinityAttrs.size() != 1) {
       return failure();
     }
-    SetVector<Attribute> layoutResolvers;
-    if (failed(
-            resolveLayoutAttr(affinityAttrs[0], moduleOp, layoutResolvers))) {
-      return dispatchOp.emitError("failed on making layout resolvers");
-    }
+
+    IREE::Stream::AffinityAndOpPair key(affinityAttrs[0], dispatchOp);
+    assert(cachedLayoutAttrs.contains(key) &&
+           "the (affinity, dispatchOp) query is invalid");
+    const SetVector<Attribute> &layoutResolvers = cachedLayoutAttrs[key];
 
     std::optional<IREE::Encoding::EncodingAttr> encodingAttr =
         getEncodingWithNewLayouts(type, layoutResolvers);
@@ -325,7 +455,6 @@ updateTensorDispatchOp(RewriterBase &rewriter, ModuleOp moduleOp,
       newResultEncodings.push_back(type);
       continue;
     }
-
     std::optional<IREE::Encoding::EncodingAttr> encodingAttr =
         getEncodingWithNewLayouts(type, resLayoutResolvers);
     if (!encodingAttr) {
@@ -472,53 +601,34 @@ updateResultEncoding(RewriterBase &rewriter, OpTy op,
   return success();
 }
 
-/// Adds the resolved layouts to all tensor types on stream tensor ops, if
-/// encodings are present. Most of stream tensor ops implement
-/// AffinityOpInterface, where a stream affinity indicates the kind of
-/// enviroment the ops are expected run in. When an encoding is present in the
-/// tensor type, the method resolves the layouts, strips outdated information,
-/// and adds the resolved layouts to the encodings. The updated encodings should
-/// have enough information for other lowering transformations.
-/// TODO(hanchung): Add support for stream.tensor.load ops and
-/// stream.tensor.store ops. They are not affinity ops, so additional analysis
-/// will be needed in the work.
-static LogicalResult addLayoutsToTensorPhaseOps(
-    ModuleOp moduleOp, IREE::Stream::AffinityAnalysis &affinityAnalysis,
-    FunctionOpInterface funcOp,
-    IREE::Stream::ResolveLayoutAttrFn resolveLayoutAttr) {
-  SmallVector<IREE::Stream::AffinityOpInterface> candidates;
-  funcOp.walk([&](IREE::Stream::AffinityOpInterface affinityOp) {
-    // Only need to update encoding types for ops that have TensorPhaseOp trait.
-    if (!affinityOp->hasTrait<OpTrait::IREE::Stream::TensorPhaseOp>()) {
-      return;
-    }
-
-    // Bail out if the operation does not have an affinity attribute.
-    auto affinityAttr = affinityOp.getAffinityAttr();
-    if (!affinityAttr) {
-      return;
-    }
-    candidates.push_back(affinityOp);
-  });
-
-  if (candidates.empty()) {
-    return success();
+LogicalResult StreamTensorOpUpdater::run() {
+  IREE::Stream::AffinityAnalysis affinityAnalysis(moduleOp);
+  if (failed(affinityAnalysis.run())) {
+    return moduleOp.emitError("failed on running affinity analysis");
   }
 
-  IRRewriter rewriter(funcOp.getContext());
-  for (auto affinityOp : candidates) {
-    auto affinityAttr = affinityOp.getAffinityAttr();
-    SetVector<Attribute> layoutResolvers;
-    if (failed(resolveLayoutAttr(affinityAttr, moduleOp, layoutResolvers))) {
-      return affinityOp.emitError("failed on making layout resolvers");
+  for (auto op : streamOps) {
+    if (failed(addQuery(affinityAnalysis, op))) {
+      return failure();
     }
+  }
+
+  if (failed(resolveLayoutAttr(queries, cachedLayoutAttrs))) {
+    return failure();
+  }
+
+  IRRewriter rewriter(moduleOp.getContext());
+  for (auto affinityOp : streamOps) {
+    const SetVector<Attribute> &layoutResolvers =
+        cachedLayoutAttrs[IREE::Stream::AffinityAndOpPair(
+            affinityOp.getAffinityAttr(), affinityOp)];
 
     LogicalResult result =
         TypeSwitch<Operation *, LogicalResult>(affinityOp)
             .Case<IREE::Stream::TensorDispatchOp>([&](auto op) {
               return updateTensorDispatchOp(rewriter, moduleOp,
                                             affinityAnalysis, op,
-                                            layoutResolvers, resolveLayoutAttr);
+                                            layoutResolvers, cachedLayoutAttrs);
             })
             .Case<IREE::Stream::TensorSizeOfOp>([&](auto op) {
               return updateTensorSizeOfOp(rewriter, op, layoutResolvers);
@@ -555,30 +665,20 @@ struct SpecializeEncodingsPass
     : public impl::SpecializeEncodingsPassBase<SpecializeEncodingsPass> {
   void runOnOperation() override {
     ModuleOp moduleOp = getOperation();
-    auto usedDialects = gatherUsedDialectInterfaces<
-        IREE::Stream::AffinityAnalysisDialectInterface>(moduleOp);
-    if (usedDialects.size() != 1) {
-      moduleOp.emitError("expected only one dialect implementing "
-                         "AffinityAnalysisDialectInterface");
+
+    StreamTensorOpUpdater streamTensorOpUpdater(moduleOp);
+    if (failed(streamTensorOpUpdater.init())) {
+      moduleOp.emitError("failed to initialize StreamTensorOpUpdater");
       return signalPassFailure();
     }
-
-    IREE::Stream::AffinityAnalysis affinityAnalysis(moduleOp);
-    if (failed(affinityAnalysis.run())) {
-      moduleOp.emitError("failed on running affinity analysis");
+    if (failed(streamTensorOpUpdater.run())) {
+      moduleOp.emitError(
+          "failed to add layouts to Stream::TensorPhaseOp with encodings");
       return signalPassFailure();
     }
 
     SymbolTable symbolTable(moduleOp);
-    IREE::Stream::ResolveLayoutAttrFn resolveLayoutAttr =
-        usedDialects[0]->makeLayoutAttrResolver(moduleOp);
     for (auto funcOp : moduleOp.getOps<FunctionOpInterface>()) {
-      if (failed(addLayoutsToTensorPhaseOps(moduleOp, affinityAnalysis, funcOp,
-                                            resolveLayoutAttr))) {
-        funcOp.emitError(
-            "failed on adding layouts to Stream::TensorPhaseOp with encodings");
-        return signalPassFailure();
-      }
       if (failed(duplicateExecutablesPerLayoutVariant(moduleOp, symbolTable,
                                                       funcOp))) {
         funcOp.emitError("failed on executable duplication");

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --iree-stream-specialize-encodings --verify-diagnostics %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-stream-specialize-encodings)' --verify-diagnostics %s | FileCheck %s
 
 //------------------------------------------------------------------------------
 // IREE::CPU encoding layout specialization tests.
@@ -153,11 +153,13 @@ util.func public @tensor_fill_op(%arg0: f32, %arg1: !stream.resource<*>, %arg2: 
 #device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
 #encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map0, #map1, #map2]>
 
-util.global private @device_a = #device_target_local_0_
-// expected-error @+1 {{failed on adding layouts to Stream::TensorPhaseOp with encodings}}
-util.func public @ops_with_result_encoding_only(%arg0: index) {
-  %0 = stream.tensor.constant on(#hal.device.affinity<@device_a>) : tensor<?x5x64xf32, #encoding>{%arg0} in !stream.resource<constant> = dense<0.000000e+00> : tensor<1x5x64xf32>
-  util.return
+// expected-error @+1 {{failed to add layouts to Stream::TensorPhaseOp with encodings}}
+module {
+  util.global private @device_a = #device_target_local_0_
+  util.func public @ops_with_result_encoding_only(%arg0: index) {
+    %0 = stream.tensor.constant on(#hal.device.affinity<@device_a>) : tensor<?x5x64xf32, #encoding>{%arg0} in !stream.resource<constant> = dense<0.000000e+00> : tensor<1x5x64xf32>
+    util.return
+  }
 }
 
 // -----
@@ -171,13 +173,15 @@ util.func public @ops_with_result_encoding_only(%arg0: index) {
 #device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
 #encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map0, #map1, #map2]>
 
-util.global private @device_a = #device_target_local_0_
-// expected-error @+1 {{failed on adding layouts to Stream::TensorPhaseOp with encodings}}
-util.func public @tensor_clone_op(%arg0: !stream.resource<*>, %arg1: index, %arg2: index, %arg3: index, %arg4: index) {
-  %0 = stream.tensor.clone on(#hal.device.affinity<@device_a>)
-    %arg0 : tensor<?x4xf32, #encoding>{%arg1} in !stream.resource<*>{%arg2}
-    -> tensor<?x4xf32, #encoding>{%arg1} in !stream.resource<*>{%arg2}
-  util.return
+// expected-error @+1 {{failed to add layouts to Stream::TensorPhaseOp with encodings}}
+module {
+  util.global private @device_a = #device_target_local_0_
+  util.func public @tensor_clone_op(%arg0: !stream.resource<*>, %arg1: index, %arg2: index, %arg3: index, %arg4: index) {
+    %0 = stream.tensor.clone on(#hal.device.affinity<@device_a>)
+      %arg0 : tensor<?x4xf32, #encoding>{%arg1} in !stream.resource<*>{%arg2}
+      -> tensor<?x4xf32, #encoding>{%arg1} in !stream.resource<*>{%arg2}
+    util.return
+  }
 }
 
 // -----
@@ -191,15 +195,17 @@ util.func public @tensor_clone_op(%arg0: !stream.resource<*>, %arg1: index, %arg
 #device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
 #encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map0, #map1, #map2]>
 
+// expected-error @+1 {{failed to add layouts to Stream::TensorPhaseOp with encodings}}
+module {
   util.global private @device_a = #device_target_local_0_
-// expected-error @+1 {{failed on adding layouts to Stream::TensorPhaseOp with encodings}}
-util.func public @tensor_slice_op_with_encoding(%arg0: !stream.resource<*>, %arg1: index, %arg2: index, %arg3: index, %arg4: index) {
-  %c0 = arith.constant 0 : index
-  %c1 = arith.constant 1 : index
-  %1 = stream.tensor.slice on(#hal.device.affinity<@device_a>)
-    %arg0[%c0, %c1 for %arg3, %c1] : tensor<?x4xf32, #encoding>{%arg1} in !stream.resource<*>{%arg2}
-    -> tensor<?x1xf32, #encoding>{%arg3} in !stream.resource<*>{%arg4}
-  util.return
+  util.func public @tensor_slice_op_with_encoding(%arg0: !stream.resource<*>, %arg1: index, %arg2: index, %arg3: index, %arg4: index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %1 = stream.tensor.slice on(#hal.device.affinity<@device_a>)
+      %arg0[%c0, %c1 for %arg3, %c1] : tensor<?x4xf32, #encoding>{%arg1} in !stream.resource<*>{%arg2}
+      -> tensor<?x1xf32, #encoding>{%arg3} in !stream.resource<*>{%arg4}
+    util.return
+  }
 }
 
 // -----
@@ -213,15 +219,17 @@ util.func public @tensor_slice_op_with_encoding(%arg0: !stream.resource<*>, %arg
 #device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
 #encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map0, #map1, #map2]>
 
+// expected-error @+1 {{failed to add layouts to Stream::TensorPhaseOp with encodings}}
+module {
 util.global private @device_a = #device_target_local_0_
-// expected-error @+1 {{failed on adding layouts to Stream::TensorPhaseOp with encodings}}
-util.func public @tensor_update_op(%arg0: !stream.resource<*>, %arg1: index, %arg2: !stream.resource<*>, %arg3: index, %arg4: index) {
-  %c0 = arith.constant 0 : index
-  %c1 = arith.constant 1 : index
-  %0 = stream.tensor.update on(#hal.device.affinity<@device_a>)
-    %arg0, %arg2[%c0, %c0] : tensor<2x2xf32, #encoding> in !stream.resource<*>{%arg1}
-    -> tensor<?x4xf32, #encoding>{%arg3} in %arg2 as !stream.resource<*>{%arg4}
-  util.return
+  util.func public @tensor_update_op(%arg0: !stream.resource<*>, %arg1: index, %arg2: !stream.resource<*>, %arg3: index, %arg4: index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %0 = stream.tensor.update on(#hal.device.affinity<@device_a>)
+      %arg0, %arg2[%c0, %c0] : tensor<2x2xf32, #encoding> in !stream.resource<*>{%arg1}
+      -> tensor<?x4xf32, #encoding>{%arg3} in %arg2 as !stream.resource<*>{%arg4}
+    util.return
+  }
 }
 
 // -----


### PR DESCRIPTION
The returned function (i.e., `ResolveLayoutAttrFn`) can be very inefficient because there could be other data-flow analysis in a run. The revision updates the `ResolveLayoutAttrFn` API. Now it accepts a list of query, and it stores the results to the map of `SetVector<Attribute>`.

In the encoding specialization pass, it introduces `StreamTensorOpUpdater` class. There are two phases in the updater.  The class caches all the queries in `init()`, and updates all the encodings in `run()`. The `init` method is introduced because there could be a failure in the initialization. In this context, we do not put them to the constructor because we can not signal the error in constructors. See https://google.github.io/styleguide/cppguide.html#Doing_Work_in_Constructors

The pass gets 440x speed-up for one of SDXL compilation.

The lit test configuration change (i.e., `--pass-pipeline='builtin.module(iree-stream-specialize-encodings)'`) is needed because we want to validate failures for unsupported encodings.