### PR TITLE
[Dispatch] Fix error in FuseMultiUseElementwiseProducerPass

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/FuseMultiUseElementwiseProducer.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FuseMultiUseElementwiseProducer.cpp
@@ -54,7 +54,9 @@ static std::optional<OpOperand *> getFusableUse(Operation *op,
     bool dominatesAllUsers = true;
     for (OpOperand &target : uses) {
       Operation *targetOp = target.getOwner();
-      if (!dominanceInfo.dominates(sourceOp, targetOp)) {
+      if (sourceOp != targetOp &&
+          !dominanceInfo.properlyDominates(sourceOp, targetOp,
+                                           /*enclosingOpOk=*/false)) {
         dominatesAllUsers = false;
         break;
       }


### PR DESCRIPTION
Changes the logic that finds a fusable consumer to not fuse when there is another use in its body.

closes https://github.com/iree-org/iree/issues/19947