### PR TITLE
[DispatchCreation] Modify the generated fused op to not use concats.

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/FuseHorizontalContractions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FuseHorizontalContractions.cpp
@@ -208,9 +208,6 @@ static std::optional<SmallVector<Operation *>> getHorizontalFusionGroupMembers(
     if (!dominanceInfo.properlyDominates(seedOp, linalgOp)) {
       return false;
     }
-    if (!isHorizontalToGroup(linalgOp, allOps, dominanceInfo, seedOp)) {
-      return false;
-    }
     return true;
   };
 
@@ -237,6 +234,10 @@ static std::optional<SmallVector<Operation *>> getHorizontalFusionGroupMembers(
   for (Operation *lhsUser : lhsUsers) {
     auto linalgUser = dyn_cast<linalg::LinalgOp>(lhsUser);
     if (!linalgUser) {
+      continue;
+    }
+
+    if (!isHorizontalToGroup(linalgUser, allOps, dominanceInfo, seedOp)) {
       continue;
     }
 

--- a/compiler/src/iree/compiler/DispatchCreation/FuseHorizontalContractions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FuseHorizontalContractions.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
+#include "iree/compiler/DispatchCreation/FusionUtils.h"
 #include "iree/compiler/DispatchCreation/Passes.h"
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Analysis/TopologicalSortUtils.h"
@@ -47,62 +48,69 @@ struct FuseHorizontalContractionsPass final
 
 } // namespace
 
-/// Structs that captures the ops that are to be fused
-struct HorizontalFusionGroup {
-  // Contractions op that are to be fused.
-  SmallVector<linalg::LinalgOp> contractionOps;
-  // Optional truncate operations that could be following the contraction op.
-  std::optional<SmallVector<linalg::GenericOp>> truncateOps;
-};
-
 /// Helper method to check operations equivalence
-static bool checkOperationEquivalence(Operation *lhsOp, Operation *rhsOp) {
-  // During equivalence check, it would have been easier if `checkEquivalence`
-  // would just use `OpOperands *`. Since it takes `Value`s for now, just
-  // check that the values are the same as operands. This is potentially
-  // making the match too broad, but is an OK work-around for now.
-  // TODO(MaheshRavishankar): Fix upstream `checkEquivalence` signater in
-  // `OperationEquivalence::isEquivalentTo`.
-  llvm::SmallDenseSet<Value, 8> operands;
-  operands.insert(lhsOp->operand_begin(), lhsOp->operand_end());
-  operands.insert(rhsOp->operand_begin(), rhsOp->operand_end());
+static bool checkOperationEquivalence(Operation *aOp, Operation *bOp) {
+  auto aLinalgOp = dyn_cast<linalg::LinalgOp>(aOp);
+  auto bLinalgOp = dyn_cast<linalg::LinalgOp>(bOp);
 
-  llvm::DenseMap<Value, Value> equivalentValues;
-  auto checkEquivalent = [&](Value lhsValue, Value rhsValue) {
-    if (operands.contains(lhsValue) && operands.contains(rhsValue)) {
-      return success();
-    }
-    return success(equivalentValues.lookup(lhsValue) == rhsValue ||
-                   equivalentValues.lookup(rhsValue) == lhsValue);
+  if (!aLinalgOp || !bLinalgOp) {
+    return false;
+  }
+  // Contraction ops verifies that there are two operands and one result.
+  assert(linalg::isaContractionOpInterface(aLinalgOp) &&
+         linalg::isaContractionOpInterface(bLinalgOp) &&
+         "expected lhs and rhs to be contraction ops");
+
+  // CHeck that the LHS operand is the same. Can be relaxed in the future.
+  if (aLinalgOp.getDpsInputOperand(0)->get() !=
+      bLinalgOp.getDpsInputOperand(0)->get()) {
+    return false;
+  }
+
+  auto checkSameRankAndElementType = [](Value aVal, Value bVal) {
+    auto aType = dyn_cast<ShapedType>(aVal.getType());
+    auto bType = dyn_cast<ShapedType>(bVal.getType());
+    return aType && bType && aType.getRank() == bType.getRank() &&
+           aType.getElementType() == bType.getElementType();
   };
-  auto markEquivalent = [&](Value v1, Value v2) { equivalentValues[v1] = v2; };
-  return OperationEquivalence::isEquivalentTo(
-      lhsOp, rhsOp, checkEquivalent, markEquivalent,
-      /*flags=*/OperationEquivalence::IgnoreLocations);
+  // Check that the RHS rank and element type are the same. We dont check the
+  // type cause we allow RHS to be transposes.
+  if (!checkSameRankAndElementType(aLinalgOp.getDpsInputOperand(1)->get(),
+                                   bLinalgOp.getDpsInputOperand(1)->get())) {
+    return false;
+  }
+
+  // Check that the output rank and element type are the same. We dont check the
+  // type cause we allow RHS to be transposes.
+  if (!checkSameRankAndElementType(aLinalgOp.getDpsInitOperand(0)->get(),
+                                   bLinalgOp.getDpsInitOperand(0)->get())) {
+    return false;
+  }
+
+  // Check that the iterator types are the same.
+  if (aLinalgOp.getIteratorTypesArray() != bLinalgOp.getIteratorTypesArray()) {
+    return false;
+  }
+
+  // Check region equivalence.
+  if (!OperationEquivalence::isRegionEquivalentTo(
+          &aLinalgOp->getRegion(0), &bLinalgOp->getRegion(0),
+          OperationEquivalence::IgnoreLocations)) {
+    return false;
+  }
+
+  return true;
 }
 
 /// Check that an operation is a `empty -> fill -> contraction`
-static bool isEmptyFillContractionDAGRootOp(
+static bool isEquivalentContractionOp(
     linalg::LinalgOp linalgOp,
     std::optional<linalg::LinalgOp> seedContractionOp = std::nullopt) {
   if (!linalg::isaContractionOpInterface(linalgOp)) {
     return false;
   }
-  auto fillOp = linalgOp.getDpsInits()[0].getDefiningOp<linalg::FillOp>();
-  if (!fillOp) {
-    return false;
-  }
-  // For convenience check that the fill value is 0. This is not
-  // a necessity, but easier to handle the rewrite this way.
-  if (!matchPattern(fillOp.getDpsInputOperand(0)->get(), m_AnyZeroFloat()) &&
-      !matchPattern(fillOp.getDpsInputOperand(0)->get(), m_Zero())) {
-    return false;
-  }
-  if (!fillOp.getDpsInitOperand(0)->get().getDefiningOp<tensor::EmptyOp>()) {
-    return false;
-  }
   if (seedContractionOp) {
-    return checkOperationEquivalence(linalgOp, seedContractionOp.value());
+    return checkOperationEquivalence(seedContractionOp.value(), linalgOp);
   }
   return true;
 }
@@ -127,37 +135,6 @@ static bool isHorizontalToGroup(Operation *op,
   });
 }
 
-/// Get user of operation that is a truncate operation.
-static std::optional<linalg::GenericOp>
-getTruncateOp(Operation *op,
-              const llvm::SetVector<Operation *> &groupedOperations,
-              const DominanceInfo &dominanceInfo,
-              std::optional<linalg::GenericOp> seedTruncateOp = std::nullopt) {
-  if (!op->hasOneUse()) {
-    return std::nullopt;
-  }
-  Operation *user = *op->user_begin();
-  // TODO: This test should not be really needed. We should be able to check
-  // for ANY elementwise operation.
-  if (!IREE::LinalgExt::isBitTruncateOp(user)) {
-    return std::nullopt;
-  }
-  auto genericOp = dyn_cast<linalg::GenericOp>(user);
-  if (!genericOp) {
-    return std::nullopt;
-  }
-  if (seedTruncateOp) {
-    if (!checkOperationEquivalence(genericOp, seedTruncateOp.value())) {
-      return std::nullopt;
-    }
-    if (!isHorizontalToGroup(genericOp, groupedOperations, dominanceInfo,
-                             seedTruncateOp.value())) {
-      return std::nullopt;
-    }
-  }
-  return genericOp;
-}
-
 /// Find all candidates that can be used for horizontal fusion. For example
 /// ```
 /// %0 = linalg.matmul ins(%arg0, %arg1)
@@ -171,39 +148,17 @@ getTruncateOp(Operation *op,
 /// %4 = linalg.matmul ins(%arg0, concat(%arg1, %arg2, %arg3))
 /// ```
 ///
-/// This method recognizes such patterns. It also accounts for the quantized
-/// case where individual operations might be have lower-precision operands and
-/// accumulate in higher precision, followed by a `linalg.generic` that performs
-/// the `truncf` on the result.
-static std::optional<HorizontalFusionGroup> getHorizontalFusionGroupMembers(
+/// Note: The actual operation generated does not concat the RHS
+static std::optional<SmallVector<Operation *>> getHorizontalFusionGroupMembers(
     linalg::LinalgOp seedOp,
-    const llvm::SmallDenseSet<linalg::LinalgOp> &groupedOperations,
+    const llvm::SmallDenseSet<Operation *> &groupedOperations,
     const DominanceInfo &dominanceInfo, int fusionLimit) {
 
   Value lhs = seedOp->getOperand(0);
-  auto lhsType = cast<RankedTensorType>(lhs.getType());
-  Value rhs = seedOp->getOperand(1);
-  auto rhsType = cast<RankedTensorType>(rhs.getType());
-  Value out = seedOp->getOperand(2);
-  auto outType = cast<RankedTensorType>(out.getType());
-
-  if (!lhsType.hasStaticShape() || !rhsType.hasStaticShape() ||
-      !outType.hasStaticShape()) {
-    return std::nullopt;
-  }
 
   SetVector<Operation *> allOps;
-  SmallVector<linalg::LinalgOp> contractionOps = {seedOp};
-  std::optional<linalg::GenericOp> seedTruncOp =
-      getTruncateOp(seedOp, allOps, dominanceInfo);
-  std::optional<SmallVector<linalg::GenericOp>> truncateOps;
-  if (seedTruncOp) {
-    truncateOps = {seedTruncOp.value()};
-  }
+  SmallVector<Operation *> contractionOps = {seedOp};
   allOps.insert(seedOp);
-  if (seedTruncOp) {
-    allOps.insert(seedTruncOp.value());
-  }
 
   auto canBeGrouped = [&](linalg::LinalgOp linalgOp) -> bool {
     if (linalgOp->getParentOp() != seedOp->getParentOp()) {
@@ -211,12 +166,7 @@ static std::optional<HorizontalFusionGroup> getHorizontalFusionGroupMembers(
     }
 
     // Constraints of the operation itself.
-    if (!isEmptyFillContractionDAGRootOp(linalgOp, seedOp)) {
-      return false;
-    }
-    if (linalgOp->getOperand(0).getType() != lhsType ||
-        linalgOp->getOperand(1).getType() != rhsType ||
-        linalgOp->getOperand(2).getType() != outType) {
+    if (!isEquivalentContractionOp(linalgOp, seedOp)) {
       return false;
     }
     if (groupedOperations.contains(linalgOp)) {
@@ -248,8 +198,8 @@ static std::optional<HorizontalFusionGroup> getHorizontalFusionGroupMembers(
   }
 
   // Sort the users so that the order is deterministic
-  llvm::sort(lhsUsers, [&](Operation *lhs, Operation *rhs) {
-    return dominanceInfo.properlyDominates(lhs, rhs);
+  llvm::sort(lhsUsers, [&](Operation *a, Operation *b) {
+    return dominanceInfo.properlyDominates(a, b);
   });
 
   // Collect all contraction op users of lhs.
@@ -259,21 +209,8 @@ static std::optional<HorizontalFusionGroup> getHorizontalFusionGroupMembers(
       continue;
     }
 
-    std::optional<linalg::GenericOp> userTruncOp =
-        getTruncateOp(linalgUser, allOps, dominanceInfo, seedTruncOp);
-    // If there are truncate ops to fuse and current contraction op
-    // does not have a compatible truncate op to fuse as well, ignore
-    // the op for horizontal fusion.
-    if (truncateOps && !userTruncOp) {
-      continue;
-    }
-
     contractionOps.push_back(linalgUser);
     allOps.insert(linalgUser);
-    if (truncateOps) {
-      truncateOps.value().push_back(userTruncOp.value());
-      allOps.insert(userTruncOp.value());
-    }
     if (contractionOps.size() >= fusionLimit) {
       break;
     }
@@ -283,328 +220,239 @@ static std::optional<HorizontalFusionGroup> getHorizontalFusionGroupMembers(
     return std::nullopt;
   }
 
-  return HorizontalFusionGroup{contractionOps, truncateOps};
+  return contractionOps;
 }
 
-/// Concatenate the given tensor `values`. The assumption here
-/// is that all the `values` are the same type. These are concatanted
-/// by adding a extra outer dimension to each value and concatenating
-/// along the outer-most dim.
-static Value concatenateValues(RewriterBase &rewriter, Location loc,
-                               ArrayRef<Value> values) {
-  assert((values.size() >= 2) && "Invalid number of operands to concatenate");
-  auto valueType = cast<RankedTensorType>(values[0].getType());
+template <typename V, typename R>
+static void appendRange(V &vector, R &&range) {
+  vector.append(range.begin(), range.end());
+}
 
-  SmallVector<Value> concatOperands;
-  for (auto v : values) {
-    auto t = cast<RankedTensorType>(v.getType());
-    SmallVector<int64_t> expandedTypeShape = {1};
-    expandedTypeShape.append(t.getShape().begin(), t.getShape().end());
-    auto expandedType =
-        RankedTensorType::get(expandedTypeShape, t.getElementType());
-    SmallVector<OpFoldResult> expandedShape = {rewriter.getIndexAttr(1)};
-    auto mixedSizes = tensor::getMixedSizes(rewriter, loc, v);
-    expandedShape.append(mixedSizes.begin(), mixedSizes.end());
-
-    SmallVector<ReassociationIndices> reassoc;
-    if (t.getRank() != 0) {
-      reassoc.push_back({0, 1});
-      for (int i = 0, e = valueType.getRank() - 1; i < e; ++i) {
-        reassoc.push_back({i + 2});
-      }
-    }
-
-    Value expanded = rewriter.create<tensor::ExpandShapeOp>(
-        loc, expandedType, v, reassoc, expandedShape);
-    concatOperands.push_back(expanded);
+/// Permute the indexing maps of the operation marked for horizontal
+/// fusion to make sure all the LHS operands of the horizontally fused
+/// ops have the same indexing map.
+LogicalResult
+permuteIndexingMapsToMatchSeedLhs(RewriterBase &rewriter,
+                                  AffineMap seedLhsIndexingMap,
+                                  ArrayRef<utils::IteratorType> iteratorTypes,
+                                  SmallVector<AffineMap> &indexingMaps) {
+  if (indexingMaps.empty()) {
+    return failure();
+  }
+  AffineMap lhsIndexingMap = indexingMaps[0];
+  if (seedLhsIndexingMap == lhsIndexingMap) {
+    return success();
   }
 
-  Value concatedVal =
-      rewriter.create<tensor::ConcatOp>(loc, /*dim=*/0, concatOperands);
-  return concatedVal;
-}
-
-/// Compute the indexing map used in the concatenated operation.
-/// The indexing map is either
-/// 1) when shiftOnly = false, adds an extra outermost dimension to the indexing
-///    map and adding that dimension as the outermost dimension in the range.
-///    This is used for case where the original operands of the operations are
-///    concatanated as well to get the operand for the horizontally-fused
-///    operation.
-/// 2) when shiftOnly = true,  adds an extra outermost dimension to the indexing
-///    map without adding that dimension as the outermost dimension in the
-///    range. This is used for case where the same value is used as an operand
-///    for all the concatenated operations. In such cases the original operand
-///    can just be broadcasted along the concatenated dimension in the
-///    horizontally-fused operation.
-static AffineMap getConcatenatedIndexingMap(RewriterBase &rewriter,
-                                            AffineMap origIndexingMap,
-                                            bool shiftOnly = false) {
-  AffineMap newIndexingMap = origIndexingMap.shiftDims(1);
-  if (shiftOnly) {
-    return newIndexingMap;
+  assert(lhsIndexingMap.getNumDims() == seedLhsIndexingMap.getNumDims());
+  if (!lhsIndexingMap.isProjectedPermutation() ||
+      !seedLhsIndexingMap.isProjectedPermutation() ||
+      lhsIndexingMap.getNumResults() != seedLhsIndexingMap.getNumResults()) {
+    return failure();
   }
-  return newIndexingMap.insertResult(rewriter.getAffineDimExpr(0), 0);
-}
 
-/// During horizontal fusion, there might be operands of the fused operations
-/// whose definitions are interspersed between the fused operations. For groups
-/// chosen to fuse horizontally, such operations can be moved before the
-/// seed contraction operation (where the fused operation is generated).
-template <typename T>
-static LogicalResult
-moveOperandDefs(RewriterBase &rewriter, ArrayRef<T> operations,
-                Operation *insertionPoint, DominanceInfo &dominanceInfo,
-                ArrayRef<linalg::LinalgOp> ignoreOperations = {}) {
-  BackwardSliceOptions options;
-  llvm::DenseSet<Operation *> ignoreOperationsSet;
-  ignoreOperationsSet.insert(ignoreOperations.begin(), ignoreOperations.end());
-  options.filter = [&](Operation *op) {
-    return !dominanceInfo.properlyDominates(op, insertionPoint) &&
-           !ignoreOperationsSet.contains(op);
+  auto getResultDimsRange = [](ArrayRef<AffineExpr> exprs) {
+    return llvm::map_range(exprs, [](AffineExpr expr) {
+      return cast<AffineDimExpr>(expr).getPosition();
+    });
   };
-  // Set inclusive to true cause the slice is computed from the operand, and
-  // we want to include the defining op (which is the point here)
-  options.inclusive = true;
+  auto seedLhsResultDimsRange =
+      getResultDimsRange(seedLhsIndexingMap.getResults());
+  auto lhsResultDimsRange = getResultDimsRange(lhsIndexingMap.getResults());
 
-  llvm::SetVector<Operation *> slice;
-  for (auto op : operations) {
-    for (auto operand : op->getOperands()) {
-      getBackwardSlice(operand, &slice, options);
+  // Start with a identity permutations. For now try to only swap dimensions
+  // which is not a general solution.
+  SmallVector<unsigned> interchangeVector =
+      llvm::to_vector(llvm::seq<unsigned>(0, lhsIndexingMap.getNumDims()));
+  for (auto [seedDimPos, lhsDimPos] :
+       llvm::zip_equal(seedLhsResultDimsRange, lhsResultDimsRange)) {
+    if (seedDimPos == lhsDimPos) {
+      continue;
+    }
+    // If the current positions are what we started with, swap the positions.
+    if (interchangeVector[lhsDimPos] == lhsDimPos &&
+        interchangeVector[seedDimPos] == seedDimPos) {
+      interchangeVector[lhsDimPos] = seedDimPos;
+      interchangeVector[seedDimPos] = lhsDimPos;
+      continue;
+    }
+    // If this was a changed dimension, check that it is consistent.
+    if (interchangeVector[lhsDimPos] != seedDimPos ||
+        interchangeVector[seedDimPos] != lhsDimPos) {
+      return failure();
     }
   }
 
-  mlir::topologicalSort(slice);
-  for (auto op : slice) {
-    rewriter.moveOpBefore(op, insertionPoint);
+  // Check that the iterator types remain the same
+  SmallVector<utils::IteratorType> permutedIteratorTypes =
+      llvm::to_vector(iteratorTypes);
+  if (permutedIteratorTypes != iteratorTypes) {
+    return failure();
+  }
+
+  AffineMap interchangeMap =
+      AffineMap::getPermutationMap(interchangeVector, rewriter.getContext());
+  for (auto &map : indexingMaps) {
+    if (!map.isEmpty()) {
+      map = map.compose(interchangeMap);
+    }
   }
   return success();
 }
 
-/// On finding this pattern
-/// ```
-/// %0 = linalg.matmul ins(%arg0, %arg1)
-/// %1 = linalg.matmul ins(%arg0, %arg2)
-/// %2 = linalg.matmul ins(%arg0, %arg3)
-/// ```
-///
-/// where all matmul share an operand can be combined into
-/// rewrite to
-///
-/// ```
-/// %arg1_r = tensor.expand_shape %arg1 [[0, 1], ...] : tensor<?x?xf32> to
-///     tensor<1x?x?xf32>
-/// %arg2_r = tensor.expand_shape %arg2 [[0, 1], ...] : tensor<?x?xf32> to
-///     tensor<1x?x?xf32>
-/// %arg3_r = tensor.expand_shape %arg3 [[0, 1], ...] : tensor<?x?xf32> to
-///     tensor<1x?x?xf32>
-/// %rhs = tensor.concat(%arg1_r, %arg2_r, %arg3_r)
-/// %fused = linalg.generic {
-///     indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d1, d3)>,
-///                      affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>,
-///                      affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>}],
-///     iterator_types = ["parallel", "parallel", "parallel", "reduction"]}
-///   ins(%arg0, %rhs) ... { ... }
-/// %0 = tensor.extract_slice %fused [0, 0, 0] ... : tensor<1x?x?xf32> to
-///     tensor<?x?xf32>
-/// %1 = tensor.extract_slice %fused [1, 0, 0] ... : tensor<1x?x?xf32> to
-///     tensor<?x?xf32>
-/// %2 = tensor.extract_slice %fused [2, 0, 0] ... : tensor<1x?x?xf32> to
-///     tensor<?x?xf32>
-/// ```
-///
-/// Also accounts for quantized cases where inputs are at lower precision and
-/// accumulate is in higher-precision with truncate getting back to the
-/// quantized sizes.
-static LogicalResult fuseGroup(RewriterBase &rewriter,
-                               HorizontalFusionGroup &fusionGroup,
-                               DominanceInfo &dominanceInfo) {
-  linalg::LinalgOp baseContractOp = fusionGroup.contractionOps.front();
+/// Generate the horizontally fused operation as an operation with multiple
+/// results, corresponding to the results of the fused operations. It is assumed
+/// that the LHS of the contraction operations fused horizontally is the same
+/// and have the same indexing map for all the operations. The RHS/outputs of
+/// the operations can be different.
+static std::optional<linalg::GenericOp>
+fuseContractionsHorizontally(RewriterBase &rewriter, Location loc,
+                             MutableArrayRef<Operation *> linalgOps) {
+  if (linalgOps.empty()) {
+    return std::nullopt;
+  }
+
+  SmallVector<Value> fusedIns;
+  SmallVector<Value> fusedOuts;
+  SmallVector<Type> fusedResultTypes;
+  SmallVector<AffineMap> fusedInsIndexingMaps;
+  SmallVector<AffineMap> fusedOutsIndexingMaps;
+
+  linalg::LinalgOp seedOp = cast<linalg::LinalgOp>(linalgOps.front());
+  SmallVector<utils::IteratorType> fusedIteratorTypes =
+      cast<linalg::LinalgOp>(linalgOps.front()).getIteratorTypesArray();
+
+  OpOperand *seedOpLhs = seedOp.getDpsInputOperand(0);
+  AffineMap seedOpLhsIndexingMap = seedOp.getMatchingIndexingMap(seedOpLhs);
+  fusedIns.push_back(seedOpLhs->get());
+  fusedInsIndexingMaps.push_back(seedOpLhsIndexingMap);
+
+  llvm::SmallDenseSet<Operation *> droppedOps;
+  for (auto op : linalgOps) {
+    auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
+    if (!linalgOp ||
+        linalgOp.getDpsInputOperand(0)->get() != seedOpLhs->get()) {
+      droppedOps.insert(op);
+      continue;
+    }
+
+    SmallVector<AffineMap> opIndexingMaps = linalgOp.getIndexingMapsArray();
+    if (failed(permuteIndexingMapsToMatchSeedLhs(rewriter, seedOpLhsIndexingMap,
+                                                 fusedIteratorTypes,
+                                                 opIndexingMaps))) {
+      droppedOps.insert(op);
+      continue;
+    }
+
+    // Append the RHS operands;
+    SmallVector<OpOperand *> ins = linalgOp.getDpsInputOperands();
+    appendRange(
+        fusedIns,
+        llvm::map_range(ArrayRef<OpOperand *>(ins).drop_front(),
+                        [](OpOperand *operand) { return operand->get(); }));
+
+    // Append the Outs operands.
+    appendRange(fusedOuts, llvm::map_range(linalgOp.getDpsInitsMutable(),
+                                           [](OpOperand &operand) {
+                                             return operand.get();
+                                           }));
+
+    // Append the result types.
+    fusedResultTypes.append(linalgOp->result_type_begin(),
+                            linalgOp->result_type_end());
+
+    // Append the rhs indexing maps.
+    appendRange(fusedInsIndexingMaps,
+                ArrayRef<AffineMap>(opIndexingMaps)
+                    .slice(1, linalgOp.getNumDpsInputs() - 1));
+
+    // Append the outs indexing maps.
+    appendRange(fusedOutsIndexingMaps,
+                ArrayRef<AffineMap>(opIndexingMaps)
+                    .drop_front(linalgOp.getNumDpsInputs()));
+  }
+
+  SmallVector<AffineMap> fusedIndexingMaps = std::move(fusedInsIndexingMaps);
+  fusedIndexingMaps.append(fusedOutsIndexingMaps);
+  auto fusedOp = rewriter.create<linalg::GenericOp>(
+      loc, fusedResultTypes, fusedIns, fusedOuts, fusedIndexingMaps,
+      fusedIteratorTypes, [](OpBuilder &, Location, ValueRange) {});
+
+  Block *fusedBody = fusedOp.getBlock();
+  auto rhsIndex = 0;
+  auto outsIndex = fusedOp.getNumDpsInputs();
+  SmallVector<Value> yieldVals;
+  for (auto op : linalgOps) {
+    if (droppedOps.contains(op)) {
+      continue;
+    }
+    auto linalgOp = cast<linalg::LinalgOp>(op);
+    Block *body = linalgOp.getBlock();
+    SmallVector<Value> replacements = {fusedBody->getArgument(0)};
+    appendRange(
+        replacements,
+        llvm::map_range(fusedBody->getArguments().slice(
+                            rhsIndex + 1, linalgOp.getNumDpsInputs() - 1),
+                        [](BlockArgument arg) -> Value { return arg; }));
+
+    appendRange(
+        replacements,
+        llvm::map_range(fusedBody->getArguments().slice(
+                            outsIndex, linalgOp.getNumDpsInits()),
+                        [](BlockArgument arg) -> Value { return arg; }));
+
+    rewriter.mergeBlocks(body, fusedBody, replacements);
+    rhsIndex += linalgOp.getNumDpsInputs() - 1;
+    outsIndex += linalgOp.getNumDpsInits();
+
+    auto yieldOp = cast<linalg::YieldOp>(fusedBody->getTerminator());
+    yieldVals.append(yieldOp->operand_begin(), yieldOp->operand_end());
+    rewriter.eraseOp(yieldOp);
+  }
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPointToEnd(fusedBody);
+  rewriter.create<linalg::YieldOp>(loc, yieldVals);
+
+  auto resultsIndex = 0;
+  for (auto linalgOp : linalgOps) {
+    rewriter.replaceOp(linalgOp, fusedOp->getResults().slice(
+                                     resultsIndex, linalgOp->getNumResults()));
+    resultsIndex += linalgOp->getNumResults();
+  }
+
+  return fusedOp;
+}
+
+static void fuseGroup(RewriterBase &rewriter,
+                      MutableArrayRef<Operation *> fusionGroup,
+                      DominanceInfo &dominanceInfo) {
+  if (!llvm::all_of(fusionGroup, [](Operation *op) {
+        return isa_and_nonnull<linalg::LinalgOp>(op);
+      })) {
+    return;
+  }
+  linalg::LinalgOp baseContractOp = cast<linalg::LinalgOp>(fusionGroup.front());
   Location loc = baseContractOp.getLoc();
   OpBuilder::InsertionGuard g(rewriter);
   rewriter.setInsertionPoint(baseContractOp);
 
-  if (failed(moveOperandDefs(
-          rewriter, ArrayRef<linalg::LinalgOp>(fusionGroup.contractionOps),
-          baseContractOp, dominanceInfo))) {
-    return baseContractOp.emitOpError("failed to re-order operand definitions");
+  if (failed(moveOperandDefs(rewriter, fusionGroup, baseContractOp,
+                             dominanceInfo))) {
+    return;
   }
 
-  SmallVector<Value> rhsValues;
-  SmallVector<Value> initValues;
-  for (auto op : fusionGroup.contractionOps) {
-    Value rhs = op.getDpsInputOperand(1)->get();
-    Value init = op.getDpsInitOperand(0)->get();
-    rhsValues.push_back(rhs);
-    initValues.push_back(init);
-  }
-  Value newContractRhs = concatenateValues(rewriter, loc, rhsValues);
-  Value newContractInit = concatenateValues(rewriter, loc, initValues);
-
-  auto baseContractResultType =
-      cast<RankedTensorType>(baseContractOp->getResult(0).getType());
-  SmallVector<int64_t> newContractResultShape = {
-      static_cast<int64_t>(rhsValues.size())};
-  newContractResultShape.append(baseContractResultType.getShape().begin(),
-                                baseContractResultType.getShape().end());
-  auto newContractResultType = RankedTensorType::get(
-      newContractResultShape, baseContractResultType.getElementType());
-
-  Value lhs = baseContractOp->getOperand(0);
-
-  SmallVector<utils::IteratorType> newContractIteratorTypes = {
-      utils::IteratorType::parallel};
-  newContractIteratorTypes.append(baseContractOp.getIteratorTypesArray());
-
-  SmallVector<AffineMap> newContractIndexingMaps =
-      baseContractOp.getIndexingMapsArray();
-  newContractIndexingMaps[0] = getConcatenatedIndexingMap(
-      rewriter, newContractIndexingMaps[0], /*shiftOnly=*/true);
-  newContractIndexingMaps[1] =
-      getConcatenatedIndexingMap(rewriter, newContractIndexingMaps[1]);
-  newContractIndexingMaps[2] =
-      getConcatenatedIndexingMap(rewriter, newContractIndexingMaps[2]);
-
-  linalg::GenericOp newContractOp = rewriter.create<linalg::GenericOp>(
-      loc, newContractResultType, ValueRange{lhs, newContractRhs},
-      newContractInit, newContractIndexingMaps, newContractIteratorTypes);
-  rewriter.cloneRegionBefore(baseContractOp->getRegion(0),
-                             newContractOp.getRegion(),
-                             newContractOp.getRegion().begin());
-
-  linalg::LinalgOp concatResultOp = newContractOp;
-  if (fusionGroup.truncateOps) {
-    SmallVector<Value> newTruncOperands;
-    SmallVector<AffineMap> newTruncIndexingMaps;
-    linalg::GenericOp baseTruncOp = fusionGroup.truncateOps->front();
-    SmallVector<AffineMap> baseTruncOpIndexingMaps =
-        baseTruncOp.getIndexingMapsArray();
-
-    rewriter.setInsertionPoint(baseTruncOp);
-    if (failed(moveOperandDefs(
-            rewriter,
-            ArrayRef<linalg::GenericOp>(fusionGroup.truncateOps.value()),
-            baseTruncOp, dominanceInfo, fusionGroup.contractionOps))) {
-      return baseTruncOp.emitOpError(
-          "failed to move operand defs for truncate operations");
-    }
-
-    for (auto [operandIndex, baseTruncOperand, baseIndexingMap] :
-         llvm::enumerate(baseTruncOp->getOperands(), baseTruncOpIndexingMaps)) {
-      // Collect all the operands for the trunc operation.
-      SmallVector<Value> truncOperands;
-      for (auto truncOp : fusionGroup.truncateOps.value()) {
-        truncOperands.push_back(truncOp.getOperand(operandIndex));
-      }
-
-      // Three cases to handle here.
-      // Case 1. the operand is the contraction op.
-      if (llvm::all_of(llvm::zip(truncOperands, fusionGroup.contractionOps),
-                       [](auto it) {
-                         Value operand = std::get<0>(it);
-                         return operand.getDefiningOp<linalg::LinalgOp>() ==
-                                std::get<1>(it);
-                       })) {
-        // Use the result of the concatanted generic op
-        newTruncOperands.push_back(newContractOp.getResult(0));
-        newTruncIndexingMaps.push_back(
-            getConcatenatedIndexingMap(rewriter, baseIndexingMap));
-        continue;
-      }
-
-      // Case 2. all the operands are the same.
-      if (operandIndex < baseTruncOp.getNumDpsInputs() &&
-          llvm::all_equal(truncOperands)) {
-        newTruncOperands.push_back(truncOperands.front());
-        newTruncIndexingMaps.push_back(getConcatenatedIndexingMap(
-            rewriter, baseIndexingMap, /*shiftOnly=*/true));
-        continue;
-      }
-
-      // Case 3. Concatenate all the operands.
-      newTruncOperands.push_back(
-          concatenateValues(rewriter, loc, truncOperands));
-      newTruncIndexingMaps.push_back(
-          getConcatenatedIndexingMap(rewriter, baseIndexingMap));
-    }
-
-    // Insert truncate operator.
-    auto baseTruncType =
-        cast<RankedTensorType>(baseTruncOp.getResult(0).getType());
-    SmallVector<int64_t> newTruncShape = {
-        static_cast<int64_t>(rhsValues.size())};
-    newTruncShape.append(baseTruncType.getShape().begin(),
-                         baseTruncType.getShape().end());
-    auto newTruncType =
-        RankedTensorType::get(newTruncShape, baseTruncType.getElementType());
-    SmallVector<utils::IteratorType> newTruncIteratorTypes = {
-        utils::IteratorType::parallel};
-    newTruncIteratorTypes.append(baseTruncOp.getIteratorTypesArray());
-
-    ArrayRef newTruncOperandsRef(newTruncOperands);
-    linalg::GenericOp newTruncOp = rewriter.create<linalg::GenericOp>(
-        loc, newTruncType,
-        newTruncOperandsRef.take_front(baseTruncOp.getNumDpsInputs()),
-        newTruncOperandsRef.take_back(baseTruncOp.getNumDpsInits()),
-        newTruncIndexingMaps, newTruncIteratorTypes);
-
-    rewriter.cloneRegionBefore(baseTruncOp->getRegion(0),
-                               newTruncOp.getRegion(),
-                               newTruncOp.getRegion().begin());
-
-    concatResultOp = cast<linalg::LinalgOp>(newTruncOp.getOperation());
-  }
-
-  SmallVector<SmallVector<OpFoldResult>> concatResultShape;
-  if (failed(concatResultOp.reifyResultShapes(rewriter, concatResultShape))) {
-    return baseContractOp.emitOpError(
-        "failed to get shape of concatenated result op");
-  }
-  Value concatResult = concatResultOp->getResult(0);
-  MutableArrayRef<OpFoldResult> extractSizes(concatResultShape[0]);
-  extractSizes[0] = rewriter.getIndexAttr(1);
-  auto concatResultType = cast<RankedTensorType>(concatResult.getType());
-
-  SmallVector<OpFoldResult> extractOffsets(extractSizes.size(),
-                                           rewriter.getIndexAttr(0));
-  SmallVector<OpFoldResult> extractStrides(extractSizes.size(),
-                                           rewriter.getIndexAttr(1));
-
-  auto concatResultTypeShape =
-      llvm::map_to_vector(concatResultType.getShape(),
-                          [](size_t s) { return static_cast<int64_t>(s); });
-  auto resultOutType =
-      RankedTensorType::get(ArrayRef(concatResultTypeShape).drop_front(),
-                            concatResultType.getElementType());
-
-  SmallVector<Value> replacements;
-  for (auto i : llvm::seq<size_t>(0, rhsValues.size())) {
-    extractOffsets[0] = rewriter.getIndexAttr(static_cast<int64_t>(i));
-    replacements.push_back(rewriter.create<tensor::ExtractSliceOp>(
-        loc, resultOutType, concatResult, extractOffsets, extractSizes,
-        extractStrides));
-  }
-
-  for (auto [index, op, replacement] :
-       llvm::enumerate(fusionGroup.contractionOps, replacements)) {
-    Operation *replacedOp = op;
-    if (fusionGroup.truncateOps) {
-      replacedOp = fusionGroup.truncateOps.value()[index];
-    }
-    rewriter.replaceOp(replacedOp, replacement);
-  }
-  return success();
+  fuseContractionsHorizontally(rewriter, loc, fusionGroup);
 }
 
 void FuseHorizontalContractionsPass::runOnOperation() {
   MLIRContext *context = &getContext();
   DominanceInfo dominanceInfo(getOperation());
 
-  SmallVector<HorizontalFusionGroup> horizontalFusionGroups;
-  llvm::SmallDenseSet<linalg::LinalgOp> groupedOperations;
+  SmallVector<SmallVector<Operation *>> horizontalFusionGroups;
+  llvm::SmallDenseSet<Operation *> groupedOperations;
 
   getOperation()->walk([&](linalg::LinalgOp linalgOp) {
-    if (!isEmptyFillContractionDAGRootOp(linalgOp)) {
+    if (!isEquivalentContractionOp(linalgOp)) {
       return;
     }
     // Avoid already grouped operations;
@@ -612,7 +460,7 @@ void FuseHorizontalContractionsPass::runOnOperation() {
       return;
     }
 
-    std::optional<HorizontalFusionGroup> fusionGroup =
+    std::optional<SmallVector<Operation *>> fusionGroup =
         getHorizontalFusionGroupMembers(linalgOp, groupedOperations,
                                         dominanceInfo, fusionLimit);
 
@@ -622,7 +470,7 @@ void FuseHorizontalContractionsPass::runOnOperation() {
 
     // Update statistics.
     numFusionGroups++;
-    switch (fusionGroup->contractionOps.size()) {
+    switch (fusionGroup->size()) {
     case 2:
       numSize2FusionGroups++;
       break;
@@ -633,8 +481,7 @@ void FuseHorizontalContractionsPass::runOnOperation() {
       break;
     }
 
-    groupedOperations.insert(fusionGroup->contractionOps.begin(),
-                             fusionGroup->contractionOps.end());
+    groupedOperations.insert(fusionGroup->begin(), fusionGroup->end());
     horizontalFusionGroups.emplace_back(std::move(fusionGroup.value()));
   });
 
@@ -644,38 +491,7 @@ void FuseHorizontalContractionsPass::runOnOperation() {
 
   IRRewriter rewriter(context);
   for (auto &fusionGroup : horizontalFusionGroups) {
-    if (failed(fuseGroup(rewriter, fusionGroup, dominanceInfo))) {
-      return signalPassFailure();
-    }
-  }
-
-  {
-    RewritePatternSet foldReshapePatterns(context);
-    tensor::populateFoldTensorEmptyPatterns(foldReshapePatterns);
-    linalg::FillOp::getCanonicalizationPatterns(foldReshapePatterns, context);
-    if (failed(applyPatternsGreedily(getOperation(),
-                                     std::move(foldReshapePatterns)))) {
-      getOperation()->emitOpError("failed during reshape folding patterns");
-      return signalPassFailure();
-    }
-
-    RewritePatternSet foldPatterns(context);
-    tensor::populateFoldTensorEmptyPatterns(foldPatterns);
-    linalg::FillOp::getCanonicalizationPatterns(foldPatterns, context);
-    if (failed(
-            applyPatternsGreedily(getOperation(), std::move(foldPatterns)))) {
-      getOperation()->emitOpError("failed to fold empty/fill with concats");
-      return signalPassFailure();
-    }
-  }
-
-  // Note: Currently these patterns are required due to early lowering of
-  // tensor.concat. When we choose  to move the lowering of tensor.concat later,
-  // these patterns should be dropped.
-  RewritePatternSet patterns(context);
-  tensor::populateDecomposeTensorConcatPatterns(patterns);
-  if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
-    return signalPassFailure();
+    fuseGroup(rewriter, fusionGroup, dominanceInfo);
   }
 }
 } // namespace mlir::iree_compiler::DispatchCreation

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -67,7 +67,31 @@ def FoldUnitExtentDimsPass :
 
 def FuseHorizontalContractionsPass:
     InterfacePass<"iree-dispatch-creation-fuse-horizontal-contractions", "mlir::FunctionOpInterface"> {
-  let summary = "Fuses horizontal contraction ops without fusions";
+  let summary = "Fuses horizontal contraction ops";
+  let description = [{
+    For cases where multiple contractions
+    - that dont have a direct dependence
+    - that have the same LHS operand
+    - all the N dimensions of the RHS operands used are the same
+    Such contractions can be executed as a single contraction, i.e.
+
+    A = matmul(lhs, rhs0);
+    B = matmul(lhs, rhs1);
+    C = matmul(lhs, rhs2);
+
+    can be combined into
+    result = matmul(lhs, concat_along_N(rhs0, rhs1, rhs2));
+    A = slice0(result)
+    B = slice1(result)
+    C = slice2(result)
+
+    Instead of doing an actual concat of the RHS operands,
+    and extracting slices of the result, the pass generates a single
+    operation with
+    - the lhs operands
+    - all the rhs operands
+    - multiple results representing the individual matmuls
+  }];
   let dependentDialects = [
     "mlir::arith::ArithDialect",
     "mlir::tensor::TensorDialect",

--- a/compiler/src/iree/compiler/DispatchCreation/test/fuse_horizontal_contractions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/fuse_horizontal_contractions.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-fuse-horizontal-contractions))" --split-input-file %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-fuse-horizontal-contractions, cse))" --mlir-print-local-scope --split-input-file %s | FileCheck %s
 
 #map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4)>
 #map1 = affine_map<(d0, d1, d2, d3, d4) -> (d1, d3, d4)>
@@ -51,38 +51,55 @@ util.func public @test_horizontal_fuse(%arg0 : tensor<2x4096x640xf16>, %arg1: te
   util.return %6, %8, %10 : tensor<2x10x4096x64xf16>, tensor<2x10x4096x64xf16>, tensor<2x10x4096x64xf16>
 }
 
-//  CHECK-DAG: #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d3, d5)>
-//  CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d4, d5)>
-//  CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d4)>
-//  CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>
 //      CHECK: util.func public @test_horizontal_fuse
 // CHECK-SAME:     %[[ARG0:.+]]: tensor<2x4096x640xf16>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<10x64x640xf16>
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<10x64x640xf16>
 // CHECK-SAME:     %[[ARG3:[a-zA-Z0-9]+]]: tensor<10x64x640xf16>
-//  CHECK-DAG:    %[[CST:.+]] = arith.constant 0.0
-//  CHECK-DAG:    %[[EXP:.+]] = tensor.expand_shape %[[ARG1]] {{\[}}[0, 1], [2], [3]] output_shape {{.*}} : tensor<10x64x640xf16> into tensor<1x10x64x640xf16>
-//  CHECK-DAG:    %[[EXP1:.+]] = tensor.expand_shape %[[ARG2]] {{\[}}[0, 1], [2], [3]] output_shape {{.*}} : tensor<10x64x640xf16> into tensor<1x10x64x640xf16>
-//  CHECK-DAG:    %[[EXP2:.+]] = tensor.expand_shape %[[ARG3]] {{\[}}[0, 1], [2], [3]] output_shape {{.*}} : tensor<10x64x640xf16> into tensor<1x10x64x640xf16>
-//      CHECK:    %[[INP:.+]] = tensor.empty() : tensor<3x10x64x640xf16>
-//      CHECK:    %[[SLC:.+]] = tensor.insert_slice %[[EXP]] into %[[INP]][0, 0, 0, 0] [1, 10, 64, 640] [1, 1, 1, 1] : tensor<1x10x64x640xf16> into tensor<3x10x64x640xf16>
-//      CHECK:    %[[SLC1:.+]] = tensor.insert_slice %[[EXP1]] into %[[SLC]][1, 0, 0, 0] [1, 10, 64, 640] [1, 1, 1, 1] : tensor<1x10x64x640xf16> into tensor<3x10x64x640xf16>
-//      CHECK:    %[[SLC2:.+]] = tensor.insert_slice %[[EXP2]] into %[[SLC1]][2, 0, 0, 0] [1, 10, 64, 640] [1, 1, 1, 1] : tensor<1x10x64x640xf16> into tensor<3x10x64x640xf16>
-//      CHECK:    %[[OUT:.+]] = tensor.empty() : tensor<3x2x10x4096x64xf32>
-//      CHECK:    %[[FILL:.+]] = linalg.fill
-// CHECK-SAME:        ins(%[[CST]]
-// CHECK-SAME:        outs(%[[OUT]]
-//      CHECK:    %[[GEN1:.+]] = linalg.generic {indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "reduction"]} ins(%[[ARG0]], %[[SLC2]] : tensor<2x4096x640xf16>, tensor<3x10x64x640xf16>) outs(%[[FILL]] : tensor<3x2x10x4096x64xf32>)
-//      CHECK:    %[[EMPTY:.+]] = tensor.empty() : tensor<3x2x10x4096x64xf16>
-//      CHECK:    %[[GEN2:.+]] = linalg.generic {indexing_maps = [#[[MAP3]], #[[MAP3]]], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]} ins(%[[GEN1]] : tensor<3x2x10x4096x64xf32>) outs(%[[EMPTY]] : tensor<3x2x10x4096x64xf16>) {
-//      CHECK:    %[[R1:.+]] = tensor.extract_slice %[[GEN2]][0, 0, 0, 0, 0] [1, 2, 10, 4096, 64] [1, 1, 1, 1, 1] : tensor<3x2x10x4096x64xf16> to tensor<2x10x4096x64xf16>
-//      CHECK:    %[[R2:.+]] = tensor.extract_slice %[[GEN2]][1, 0, 0, 0, 0] [1, 2, 10, 4096, 64] [1, 1, 1, 1, 1] : tensor<3x2x10x4096x64xf16> to tensor<2x10x4096x64xf16>
-//      CHECK:    %[[R3:.+]] = tensor.extract_slice %[[GEN2]][2, 0, 0, 0, 0] [1, 2, 10, 4096, 64] [1, 1, 1, 1, 1] : tensor<3x2x10x4096x64xf16> to tensor<2x10x4096x64xf16>
-//      CHECK:    util.return %[[R1]], %[[R2]], %[[R3]]
+//      CHECK:   %[[FILL:.+]] = linalg.fill
+//      CHECK:   %[[FUSED_OP:.+]]:3 = linalg.generic
+// CHECK-SAME:       indexing_maps
+// CHECK-SAME:           affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4)>
+// CHECK-SAME:           affine_map<(d0, d1, d2, d3, d4) -> (d1, d3, d4)>
+// CHECK-SAME:           affine_map<(d0, d1, d2, d3, d4) -> (d1, d3, d4)>
+// CHECK-SAME:           affine_map<(d0, d1, d2, d3, d4) -> (d1, d3, d4)>
+// CHECK-SAME:           affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
+// CHECK-SAME:           affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
+// CHECK-SAME:           affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
+// CHECK-SAME:       iterator_types =
+// CHECK-SAME:           ["parallel", "parallel", "parallel", "parallel", "reduction"]
+// CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]], %[[ARG2]], %[[ARG3]] :
+// CHECK-SAME:       outs(%[[FILL]], %[[FILL]], %[[FILL]] :
+// CHECK-NEXT:     ^bb0(
+// CHECK-SAME:         %[[IN0:[a-zA-Z0-9_]+]]: f16
+// CHECK-SAME:         %[[IN1:[a-zA-Z0-9_]+]]: f16
+// CHECK-SAME:         %[[IN2:[a-zA-Z0-9_]+]]: f16
+// CHECK-SAME:         %[[IN3:[a-zA-Z0-9_]+]]: f16
+// CHECK-SAME:         %[[OUT0:[a-zA-Z0-9_]+]]: f32
+// CHECK-SAME:         %[[OUT1:[a-zA-Z0-9_]+]]: f32
+// CHECK-SAME:         %[[OUT2:[a-zA-Z0-9_]+]]: f32
+//  CHECK-DAG:       %[[EXT_IN0:.+]] = arith.extf %[[IN0]]
+//  CHECK-DAG:       %[[EXT_IN1:.+]] = arith.extf %[[IN1]]
+//  CHECK-DAG:       %[[MULF0:.+]] = arith.mulf %[[EXT_IN0]], %[[EXT_IN1]]
+//  CHECK-DAG:       %[[ADDF0:.+]] = arith.addf %[[OUT0]], %[[MULF0]]
+//  CHECK-DAG:       %[[EXT_IN2:.+]] = arith.extf %[[IN2]]
+//  CHECK-DAG:       %[[MULF1:.+]] = arith.mulf %[[EXT_IN0]], %[[EXT_IN2]]
+//  CHECK-DAG:       %[[ADDF1:.+]] = arith.addf %[[OUT1]], %[[MULF1]]
+//  CHECK-DAG:       %[[EXT_IN3:.+]] = arith.extf %[[IN3]]
+//  CHECK-DAG:       %[[MULF2:.+]] = arith.mulf %[[EXT_IN0]], %[[EXT_IN3]]
+//  CHECK-DAG:       %[[ADDF2:.+]] = arith.addf %[[OUT2]], %[[MULF2]]
+//      CHECK:       linalg.yield %[[ADDF0]], %[[ADDF1]], %[[ADDF2]]
+//      CHECK:   %[[TRUNCF1:.+]] = linalg.generic
+// CHECK-SAME:       ins(%[[FUSED_OP]]#0 :
+//      CHECK:   %[[TRUNCF2:.+]] = linalg.generic
+// CHECK-SAME:       ins(%[[FUSED_OP]]#1 :
+//      CHECK:   %[[TRUNCF3:.+]] = linalg.generic
+// CHECK-SAME:       ins(%[[FUSED_OP]]#2 :
+//      CHECK:   util.return %[[TRUNCF1]], %[[TRUNCF2]], %[[TRUNCF3]]
 
 // -----
 
-util.func public @test_horizontal_fuse(%arg0 : tensor<4096x640xf32>, %arg1: tensor<640x640xf32>, %arg2: tensor<640x640xf32>, %arg3: tensor<640x640xf32>) -> (tensor<4096x640xf32>, tensor<4096x640xf32>, tensor<4096x640xf32>) {
+util.func public @test_horizontal_fuse1(%arg0 : tensor<4096x640xf32>, %arg1: tensor<640x640xf32>, %arg2: tensor<640x640xf32>, %arg3: tensor<640x640xf32>) -> (tensor<4096x640xf32>, tensor<4096x640xf32>, tensor<4096x640xf32>) {
   %cst = arith.constant 0.000000e+00 : f32
   %2 = tensor.empty() : tensor<4096x640xf32>
   %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<4096x640xf32>) -> tensor<4096x640xf32>
@@ -91,32 +108,16 @@ util.func public @test_horizontal_fuse(%arg0 : tensor<4096x640xf32>, %arg1: tens
   %9 = linalg.matmul ins(%arg0, %arg3 : tensor<4096x640xf32>, tensor<640x640xf32>) outs(%3 : tensor<4096x640xf32>) -> tensor<4096x640xf32>
   util.return %4, %7, %9 : tensor<4096x640xf32>, tensor<4096x640xf32>, tensor<4096x640xf32>
 }
-
-// CHECK-DAG: #[[MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
-// CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
-// CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
-//     CHECK: util.func public @test_horizontal_fuse
+//      CHECK: util.func public @test_horizontal_fuse1
 // CHECK-SAME:     %[[ARG0:.+]]: tensor<4096x640xf32>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<640x640xf32>
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<640x640xf32>
 // CHECK-SAME:     %[[ARG3:[a-zA-Z0-9]+]]: tensor<640x640xf32>
-// CHECK-DAG:    %[[CST:.+]] = arith.constant 0.0
-// CHECK-DAG:    %[[EXP:.+]] = tensor.expand_shape %[[ARG1]] {{\[}}[0, 1], [2]] output_shape {{.*}} : tensor<640x640xf32> into tensor<1x640x640xf32>
-// CHECK-DAG:    %[[EXP1:.+]] = tensor.expand_shape %[[ARG2]] {{\[}}[0, 1], [2]] output_shape {{.*}} : tensor<640x640xf32> into tensor<1x640x640xf32>
-// CHECK-DAG:    %[[EXP2:.+]] = tensor.expand_shape %[[ARG3]] {{\[}}[0, 1], [2]] output_shape {{.*}} : tensor<640x640xf32> into tensor<1x640x640xf32>
-//     CHECK:    %[[INP:.+]] = tensor.empty() : tensor<3x640x640xf32>
-//     CHECK:    %[[SLC:.+]] = tensor.insert_slice %[[EXP]] into %[[INP]][0, 0, 0] [1, 640, 640] [1, 1, 1] : tensor<1x640x640xf32> into tensor<3x640x640xf32>
-//     CHECK:    %[[SLC1:.+]] = tensor.insert_slice %[[EXP1]] into %[[SLC]][1, 0, 0] [1, 640, 640] [1, 1, 1] : tensor<1x640x640xf32> into tensor<3x640x640xf32>
-//     CHECK:    %[[SLC2:.+]] = tensor.insert_slice %[[EXP2]] into %[[SLC1]][2, 0, 0] [1, 640, 640] [1, 1, 1] : tensor<1x640x640xf32> into tensor<3x640x640xf32>
-//     CHECK:    %[[OUT:.+]] = tensor.empty() : tensor<3x4096x640xf32>
-//     CHECK:    %[[FILL:.+]] = linalg.fill
-// CHECK-SAME:       ins(%[[CST]] :
-// CHECK-SAME:       outs(%[[OUT]] :
-//     CHECK:    %[[GEN1:.+]] = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "reduction"]} ins(%[[ARG0]], %[[SLC2]] : tensor<4096x640xf32>, tensor<3x640x640xf32>) outs(%[[FILL]] : tensor<3x4096x640xf32>)
-//     CHECK:    %[[R1:.+]] = tensor.extract_slice %[[GEN1]][0, 0, 0] [1, 4096, 640] [1, 1, 1] : tensor<3x4096x640xf32> to tensor<4096x640xf32>
-//     CHECK:    %[[R2:.+]] = tensor.extract_slice %[[GEN1]][1, 0, 0] [1, 4096, 640] [1, 1, 1] : tensor<3x4096x640xf32> to tensor<4096x640xf32>
-//     CHECK:    %[[R3:.+]] = tensor.extract_slice %[[GEN1]][2, 0, 0] [1, 4096, 640] [1, 1, 1] : tensor<3x4096x640xf32> to tensor<4096x640xf32>
-//     CHECK:    util.return %[[R1]], %[[R2]], %[[R3]]
+//      CHECK:   %[[FILL:.+]] = linalg.fill
+//      CHECK:   %[[FUSED_OP:.+]]:3 = linalg.generic
+// CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]], %[[ARG2]], %[[ARG3]] :
+// CHECK-SAME:       outs(%[[FILL]], %[[FILL]], %[[FILL]] :
+//      CHECK:   util.return %[[FUSED_OP]]#0, %[[FUSED_OP]]#1, %[[FUSED_OP]]#2
 
 // -----
 
@@ -204,79 +205,31 @@ util.func @horizontal_fusion_i8(%arg0: tensor<2x4096x640xi8>,
   } -> tensor<2x4096x640xf16>
   util.return %7, %9 : tensor<2x4096x640xf16>, tensor<2x4096x640xf16>
 }
-//  CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1, d2) -> (d1, d2)>
-//  CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
-//  CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d1, d2, d4)>
-//  CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d3, d4)>
-//  CHECK-DAG: #[[MAP4:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
-//  CHECK-DAG: #[[MAP5:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
-//  CHECK-DAG: #[[MAP6:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
-//  CHECK-DAG: #[[MAP7:.+]] = affine_map<(d0, d1, d2, d3) -> (d1, d2)>
-//  CHECK-DAG: #[[MAP8:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d3)>
-//  CHECK-DAG: #[[MAP9:.+]] = affine_map<(d0, d1, d2, d3) -> (d0)>
-//      CHECK: util.func public @horizontal_fusion_i8
-// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<2x4096x640xi8>
-// CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<640x640xi8>
-// CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<640xi8>
-// CHECK-SAME:     %[[ARG3:[a-zA-Z0-9]+]]: tensor<f32>
-// CHECK-SAME:     %[[ARG4:[a-zA-Z0-9]+]]: tensor<640x640xi8>
-// CHECK-SAME:     %[[ARG5:[a-zA-Z0-9]+]]: tensor<640xi8>
-// CHECK-SAME:     %[[ARG6:[a-zA-Z0-9]+]]: tensor<f32>
-
-// First check the hoisted operand definitions.
-//      CHECK:   %[[RHS0:.+]] = linalg.generic
-// CHECK-SAME:       ins(%[[ARG1]] :
-//      CHECK:   %[[RHS1:.+]] = linalg.generic
-// CHECK-SAME:       ins(%[[ARG4]] :
-
-// Concatanetion of the RHS
-//  CHECK-DAG:   %[[EXPANDED_RHS0:.+]] = tensor.expand_shape %[[RHS0]] {{\[}}[0, 1], [2], [3]{{\]}}
-//  CHECK-DAG:   %[[EXPANDED_RHS1:.+]] = tensor.expand_shape %[[RHS1]] {{\[}}[0, 1], [2], [3]{{\]}}
-//      CHECK:   %[[INSERT_RHS0:.+]] = tensor.insert_slice %[[EXPANDED_RHS0]]
-//      CHECK:   %[[INSERT_RHS1:.+]] = tensor.insert_slice %[[EXPANDED_RHS1]] into %[[INSERT_RHS0]]
-
-// Check empty and fill for the concatenated contraction
-//      CHECK:   %[[CONTRACT_EMPTY:.+]] = tensor.empty()
-//      CHECK:   %[[CONTRACT_FILL:.+]] = linalg.fill
-// CHECK-SAME:       outs(%[[CONTRACT_EMPTY]] :
-//      CHECK:   %[[CONTRACT:.+]] = linalg.generic
-// CHECK-SAME:       indexing_maps = [#[[MAP2]], #[[MAP3]], #[[MAP4]]]
-// CHECK-SAME:       iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]
-// CHECK-SAME:       ins(%[[ARG0]], %[[INSERT_RHS1]] :
-// CHECK-SAME:       outs(%[[CONTRACT_FILL]] :
-
-// The reduction that is adjacent to matmuls does not need to be hoisted. Is kept as is
-//      CHECK:   %[[UNTOUCHED_REDUCTION:.+]] = linalg.generic
-// CHECK-SAME:       ins(%[[ARG0]] :
-
-// Concatenation of non-common truncation operation operand
-//  CHECK-DAG:   %[[EXPANDED_OPERAND1_1:.+]] = tensor.expand_shape %[[ARG2]] {{\[}}[0, 1]{{\]}}
-//  CHECK-DAG:   %[[EXPANDED_OPERAND1_2:.+]] = tensor.expand_shape %[[ARG5]] {{\[}}[0, 1]{{\]}}
-//      CHECK:   %[[INSERT_OPERAND1_1:.+]] = tensor.insert_slice %[[EXPANDED_OPERAND1_1]]
-//      CHECK:   %[[INSERT_OPERAND1_2:.+]] = tensor.insert_slice %[[EXPANDED_OPERAND1_2]] into %[[INSERT_OPERAND1_1]]
-
-// Concatenation of non-common truncation operation zero-rank tensor operand
-//  CHECK-DAG:   %[[EXPANDED_OPERAND2_1:.+]] = tensor.expand_shape %[[ARG3]] []
-//  CHECK-DAG:   %[[EXPANDED_OPERAND2_2:.+]] = tensor.expand_shape %[[ARG6]] []
-//      CHECK:   %[[INSERT_OPERAND2_1:.+]] = tensor.insert_slice %[[EXPANDED_OPERAND2_1]]
-//      CHECK:   %[[INSERT_OPERAND2_2:.+]] = tensor.insert_slice %[[EXPANDED_OPERAND2_2]] into %[[INSERT_OPERAND2_1]]
-
-// Concatanated truncate operation
-//      CHECK:   %[[TRUNC_EMPTY:.+]] = tensor.empty()
-//      CHECK:   %[[TRUNCATE:.+]] = linalg.generic
-// CHECK-SAME:       indexing_maps = [#[[MAP6]], #[[MAP7]], #[[MAP8]], #[[MAP9]], #[[MAP6]]]
-// CHECK-SAME:       iterator_types = ["parallel", "parallel", "parallel", "parallel"]
-// CHECK-SAME:       ins(%[[CONTRACT]], %[[UNTOUCHED_REDUCTION]], %[[INSERT_OPERAND1_2]], %[[INSERT_OPERAND2_2]] :
-// CHECK-SAME:       outs(%[[TRUNC_EMPTY]] :
-
-// Extract the slices for replacement
-//  CHECK-DAG:   %[[SLICE1:.+]] = tensor.extract_slice %[[TRUNCATE]][0, 0, 0, 0]
-//  CHECK-DAG:   %[[SLICE2:.+]] = tensor.extract_slice %[[TRUNCATE]][1, 0, 0, 0]
-//      CHECK:   util.return %[[SLICE1]], %[[SLICE2]]
+// CHECK-LABEL: func public @horizontal_fusion_i8
+//  CHECK-SAME:     %[[ARG0:.+]]: tensor<2x4096x640xi8>
+//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<640x640xi8>
+//  CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<640xi8>
+//  CHECK-SAME:     %[[ARG3:[a-zA-Z0-9]+]]: tensor<f32>
+//  CHECK-SAME:     %[[ARG4:[a-zA-Z0-9]+]]: tensor<640x640xi8>
+//  CHECK-SAME:     %[[ARG5:[a-zA-Z0-9]+]]: tensor<640xi8>
+//  CHECK-SAME:     %[[ARG6:[a-zA-Z0-9]+]]: tensor<f32>
+//       CHECK:   %[[GENERIC1:.+]] = linalg.generic
+//  CHECK-SAME:       ins(%[[ARG1]] :
+//       CHECK:   %[[GENERIC2:.+]] = linalg.generic
+//  CHECK-SAME:       ins(%[[ARG4]] :
+//       CHECK:   %[[FUSED_OP:.+]]:2 = linalg.generic
+//  CHECK-SAME:       ins(%[[ARG0]], %[[GENERIC1]], %[[GENERIC2]] :
+//       CHECK:   %[[REDUCTION:.+]] = linalg.generic
+//  CHECK-SAME:       ins(%[[ARG0]] :
+//       CHECK:   %[[GENERIC3:.+]] = linalg.generic
+//  CHECK-SAME:       ins(%[[FUSED_OP]]#0, %[[REDUCTION]], %[[ARG2]], %[[ARG3]] :
+//       CHECK:   %[[GENERIC4:.+]] = linalg.generic
+//  CHECK-SAME:       ins(%[[FUSED_OP]]#1, %[[REDUCTION]], %[[ARG5]], %[[ARG6]] :
+//       CHECK:   util.return %[[GENERIC3]], %[[GENERIC4]]
 
 // -----
 
-util.func public @dont_fuse_when_same_trunc_op(%arg0: tensor<2x4096x640xi8>, %arg1: tensor<2x640x640xi8>, %arg2: tensor<640xi8>, %arg3: tensor<f32>, %arg4: tensor<2x640x640xi8>, %arg5: tensor<640xi8>, %arg6: tensor<f32>) -> tensor<2x4096x640xf16> {
+util.func public @fusion_same_trunc_op(%arg0: tensor<2x4096x640xi8>, %arg1: tensor<2x640x640xi8>, %arg2: tensor<640xi8>, %arg3: tensor<f32>, %arg4: tensor<2x640x640xi8>, %arg5: tensor<640xi8>, %arg6: tensor<f32>) -> tensor<2x4096x640xf16> {
   %c0_i32 = arith.constant 0 : i32
   %0 = tensor.empty() : tensor<2x4096x640xf16>
   %1 = tensor.empty() : tensor<2x4096x640xi32>
@@ -294,11 +247,95 @@ util.func public @dont_fuse_when_same_trunc_op(%arg0: tensor<2x4096x640xi8>, %ar
   } -> tensor<2x4096x640xf16>
   util.return %5 : tensor<2x4096x640xf16>
 }
+// CHECK-LABEL: func public @fusion_same_trunc_op
+//  CHECK-SAME:     %[[ARG0:.+]]: tensor<2x4096x640xi8>
+//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<2x640x640xi8>
+//  CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<640xi8>
+//  CHECK-SAME:     %[[ARG3:[a-zA-Z0-9]+]]: tensor<f32>
+//  CHECK-SAME:     %[[ARG4:[a-zA-Z0-9]+]]: tensor<2x640x640xi8>
+//  CHECK-SAME:     %[[ARG5:[a-zA-Z0-9]+]]: tensor<640xi8>
+//  CHECK-SAME:     %[[ARG6:[a-zA-Z0-9]+]]: tensor<f32>
+//       CHECK:   %[[FILL:.+]] = linalg.fill
+//       CHECK:   %[[FUSED_OP:.+]]:2 = linalg.generic
+//  CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]], %[[ARG4]] :
+//       CHECK:       outs(%[[FILL]], %[[FILL]] :
+//       CHECK:   %[[TRUNCF:.+]] = linalg.generic
+//  CHECK-SAME:       ins(%[[FUSED_OP]]#1, %[[FUSED_OP]]#0 :
 
-// Don't support multiple operands of the trunc being from different matmuls.
-//      CHECK: util.func public @dont_fuse_when_same_trunc_op
-//      CHECK:   %[[CONTRACT1:.+]] = linalg.batch_matmul_transpose_b
-//      CHECK:   %[[CONTRACT2:.+]] = linalg.batch_matmul_transpose_b
-//      CHECK:   %[[GENERIC:.+]] = linalg.generic
-// CHECK-SAME:       ins(%[[CONTRACT2]], %[[CONTRACT1]]
-//      CHECK:   util.return %[[GENERIC]]
+// -----
+
+#map = affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4)>
+#map1 = affine_map<(d0, d1, d2, d3, d4) -> (d1, d3, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+#map4 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d3, d2)>
+util.func public @test_horizontal_fuse_with_transpose(%arg0 : tensor<2x4096x640xf16>, %arg1: tensor<10x64x640xf16>, %arg2: tensor<10x64x640xf16>, %arg3: tensor<10x64x640xf16>) -> (tensor<2x10x4096x64xf16>, tensor<2x10x4096x64xf16>, tensor<2x10x64x4096xf16>) {
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = tensor.empty() : tensor<2x10x64x4096xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<2x10x64x4096xf32>) -> tensor<2x10x64x4096xf32>
+  %2 = tensor.empty() : tensor<2x10x4096x64xf32>
+  %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<2x10x4096x64xf32>) -> tensor<2x10x4096x64xf32>
+  %4 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<2x4096x640xf16>, tensor<10x64x640xf16>) outs(%3 : tensor<2x10x4096x64xf32>) {
+  ^bb0(%in: f16, %in_5: f16, %out: f32):
+    %11 = arith.extf %in : f16 to f32
+    %12 = arith.extf %in_5 : f16 to f32
+    %13 = arith.mulf %11, %12 : f32
+    %14 = arith.addf %out, %13 : f32
+    linalg.yield %14 : f32
+  } -> tensor<2x10x4096x64xf32>
+  %5 = tensor.empty() : tensor<2x10x4096x64xf16>
+  %6 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%4 : tensor<2x10x4096x64xf32>) outs(%5 : tensor<2x10x4096x64xf16>) {
+  ^bb0(%in: f32, %out: f16):
+    %11 = arith.truncf %in : f32 to f16
+    linalg.yield %11 : f16
+  } -> tensor<2x10x4096x64xf16>
+  %7 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]} ins(%arg0, %arg2 : tensor<2x4096x640xf16>, tensor<10x64x640xf16>) outs(%3 : tensor<2x10x4096x64xf32>) {
+  ^bb0(%in: f16, %in_5: f16, %out: f32):
+    %11 = arith.extf %in : f16 to f32
+    %12 = arith.extf %in_5 : f16 to f32
+    %13 = arith.mulf %11, %12 : f32
+    %14 = arith.addf %out, %13 : f32
+    linalg.yield %14 : f32
+  } -> tensor<2x10x4096x64xf32>
+  %8 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%7 : tensor<2x10x4096x64xf32>) outs(%5 : tensor<2x10x4096x64xf16>) {
+  ^bb0(%in: f32, %out: f16):
+    %11 = arith.truncf %in : f32 to f16
+    linalg.yield %11 : f16
+  } -> tensor<2x10x4096x64xf16>
+  %9 = linalg.generic {indexing_maps = [#map, #map1, #map4], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]} ins(%arg0, %arg3 : tensor<2x4096x640xf16>, tensor<10x64x640xf16>) outs(%1 : tensor<2x10x64x4096xf32>) {
+  ^bb0(%in: f16, %in_5: f16, %out: f32):
+    %11 = arith.extf %in : f16 to f32
+    %12 = arith.extf %in_5 : f16 to f32
+    %13 = arith.mulf %11, %12 : f32
+    %14 = arith.addf %out, %13 : f32
+    linalg.yield %14 : f32
+  } -> tensor<2x10x64x4096xf32>
+  %11 = tensor.empty() : tensor<2x10x64x4096xf16>
+  %10 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%9 : tensor<2x10x64x4096xf32>) outs(%11 : tensor<2x10x64x4096xf16>) {
+  ^bb0(%in: f32, %out: f16):
+    %12 = arith.truncf %in : f32 to f16
+    linalg.yield %12 : f16
+  } -> tensor<2x10x64x4096xf16>
+  util.return %6, %8, %10 : tensor<2x10x4096x64xf16>, tensor<2x10x4096x64xf16>, tensor<2x10x64x4096xf16>
+}
+//      CHECK: util.func public @test_horizontal_fuse_with_transpose
+// CHECK-SAME:     %[[ARG0:.+]]: tensor<2x4096x640xf16>
+// CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<10x64x640xf16>
+// CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<10x64x640xf16>
+// CHECK-SAME:     %[[ARG3:[a-zA-Z0-9]+]]: tensor<10x64x640xf16>
+//      CHECK:   %[[EMPTY0:.+]] = tensor.empty() : tensor<2x10x64x4096xf32>
+//      CHECK:   %[[FILL0:.+]] = linalg.fill
+// CHECK-SAME:       outs(%[[EMPTY0]] :
+//      CHECK:   %[[EMPTY1:.+]] = tensor.empty() : tensor<2x10x4096x64xf32>
+//      CHECK:   %[[FILL1:.+]] = linalg.fill
+// CHECK-SAME:       outs(%[[EMPTY1]] :
+//      CHECK:   %[[FUSED_OP:.+]]:3 = linalg.generic
+// CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]], %[[ARG2]], %[[ARG3]] :
+// CHECK-SAME:       outs(%[[FILL1]], %[[FILL1]], %[[FILL0]] :
+//      CHECK:   %[[TRUNCF1:.+]] = linalg.generic
+// CHECK-SAME:       ins(%[[FUSED_OP]]#0 :
+//      CHECK:   %[[TRUNCF2:.+]] = linalg.generic
+// CHECK-SAME:       ins(%[[FUSED_OP]]#1 :
+//      CHECK:   %[[TRUNCF3:.+]] = linalg.generic
+// CHECK-SAME:       ins(%[[FUSED_OP]]#2 :
+//      CHECK:   util.return %[[TRUNCF1]], %[[TRUNCF2]], %[[TRUNCF3]]

--- a/experimental/regression_suite/shark-test-suite-models/sd3/test_clip.py
+++ b/experimental/regression_suite/shark-test-suite-models/sd3/test_clip.py
@@ -111,7 +111,6 @@ ROCM_COMPILE_FLAGS = [
     "--iree-hip-waves-per-eu=2",
     "--iree-llvmgpu-enable-prefetch",
     "--iree-dispatch-creation-enable-aggressive-fusion",
-    "--iree-dispatch-creation-enable-fuse-horizontal-contractions=true",
     "--iree-opt-aggressively-propagate-transposes=true",
     "--iree-codegen-llvmgpu-use-vector-distribution=true",
     "--iree-execution-model=async-external",

--- a/experimental/regression_suite/shark-test-suite-models/sd3/test_mmdit.py
+++ b/experimental/regression_suite/shark-test-suite-models/sd3/test_mmdit.py
@@ -85,7 +85,6 @@ ROCM_COMPILE_FLAGS = [
     f"--iree-hip-target={rocm_chip}",
     "--iree-opt-const-eval=false",
     "--iree-global-opt-propagate-transposes=true",
-    "--iree-dispatch-creation-enable-fuse-horizontal-contractions=true",
     "--iree-dispatch-creation-enable-aggressive-fusion=true",
     "--iree-opt-aggressively-propagate-transposes=true",
     "--iree-opt-outer-dim-concat=true",


### PR DESCRIPTION
This is an almost complete rewrite of the  pass to fuse contractions horizontally which instead of concatenating operands to map to a GEMM, followed by slices to extract the individual matmul results; the pass now just creates a new operation with the operands being the common LHS, the RHS of each of the gemms, and the output of each of the gemms. The generated op yields the result of each constituent matmul.
This also allows for the RHS/output indexing maps of the gemms to be mismatched, since only the LHS operand and indexing maps need to match. The change also permutes the iteration space of the gemms to ensure that the same indexing maps are used for the LHS across all the fused matmuls.

The rest of the compiler stack has already been fixed up to handle such operations.