### PR TITLE
Typo Fix in hip-hal-driver.md

### DIFF
--- a/docs/website/docs/developers/design-docs/hip-hal-driver.md
+++ b/docs/website/docs/developers/design-docs/hip-hal-driver.md
@@ -8,7 +8,7 @@ tags:
 
 # HIP HAL driver
 
-This document lists technical details regarding the HIP implemenation of
+This document lists technical details regarding the HIP implementation of
 IREE's Hardware Abstraction Layer, called a HIP HAL driver.
 
 IREE provides a [Hardware Abstraction Layer (HAL)][iree-hal] as a common
@@ -46,7 +46,7 @@ and device enumeration and creation.
 `iree_hal_hip_device_t` implements [`iree_hal_device_t`][hal-device] to provide
 the interface to HIP GPU device by wrapping a `hipDevice_t`.
 For each device, right now we create two `hipStream_t`s--one for issuing commands
-for memory allocation and kernel lauches as instructed by the program; the other
+for memory allocation and kernel launches as instructed by the program; the other
 for issue host callback functions after dispatched command buffers completes.
 See synchronization section regarding the details.
 
@@ -197,7 +197,7 @@ Though, per the documentation of `hipLaunchHostFunc()`, "the host function must
 not make any HIP API calls." So we cannot do that directly inside
 `hipLaunchHostFunc()`; we need to notify another separate thread to call HIP
 APIs to push more work to the GPU. So the deferred/pending action queue should
-have an associcated thread.
+have an associated thread.
 
 For GPU waits, we can also leverage the same logic--using CPU signaling to
 unblock deferred GPU queue actions. Though this is performant, given that


### PR DESCRIPTION
There was 2 typos in the doc. 
* 'implemenation'-> 'implementation'
* 'lauches' -> 'launches'