### PR TITLE
[Encoding][Stream] Extend encoding specialization to handle interface.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -54,6 +54,9 @@ def PackedStorageAttr : IREEEncoding_Attr<"PackedStorage"> {
 
 def EncodingAttr :
     IREEEncoding_Attr<"Encoding", [
+      DeclareAttrInterfaceMethods<IREEEncoding_EncodingLayoutAttrInterface , [
+        "cloneWithLayouts",
+      ]>,
       DeclareAttrInterfaceMethods<IREEEncoding_SerializedEncodingAttrInterface , [
         "calculateStorageSizeInBytes",
       ]>
@@ -124,10 +127,6 @@ def EncodingAttr :
 
     /// Clones an encoding with a new bcast_map
     EncodingAttr clone(AffineMap bcastMap);
-
-    /// Clones an encoding with a new layout list and drops other optional
-    /// parameters (because they are resolved).
-    EncodingAttr cloneWithLayouts(ArrayRef<Attribute> layouts);
   }];
 
   let genVerifyDecl = 0;
@@ -165,6 +164,30 @@ def PadEncodingLayoutAttr : IREEEncoding_Attr<"PadEncodingLayout", [
 //===---------------------------------------------------------------------===//
 // Encoding specialization attributes, which are mainly for testing purpose.
 //===---------------------------------------------------------------------===//
+
+def TestingEncodingAttr :
+    IREEEncoding_Attr<"TestingEncoding", [
+      DeclareAttrInterfaceMethods<IREEEncoding_EncodingLayoutAttrInterface, [
+        "cloneWithLayouts",
+      ]>,
+      DeclareAttrInterfaceMethods<IREEEncoding_SerializedEncodingAttrInterface>
+    ]> {
+  let mnemonic = "testing_encoding";
+  let summary = "An encoding attribute for testing purpose";
+
+  let description = [{
+    An attribute for testing purpose. It is intended to be attached on
+    RankedTensorType as an encoding.
+  }];
+
+  let parameters = (ins
+    OptionalParameter<"ArrayAttr", "An array of attributes that describes the "
+    "layouts.">:$layouts
+  );
+
+  let hasCustomAssemblyFormat = 1;
+  let genVerifyDecl = 0;
+}
 
 def UnspecializedEncodingAttr :
     IREEEncoding_Attr<"UnspecializedEncoding", [

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingDialect.cpp
@@ -36,7 +36,7 @@ struct EncodingOpAsmInterface : public OpAsmDialectInterface {
   /// `.` or end with a numeric digit([0-9]+). Returns success if an alias was
   /// provided, failure otherwise.
   AliasResult getAlias(Attribute attr, raw_ostream &os) const override {
-    if (llvm::isa<EncodingAttr>(attr)) {
+    if (llvm::isa<EncodingAttr, TestingEncodingAttr>(attr)) {
       os << "encoding";
       return AliasResult::OverridableAlias;
     }

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
@@ -71,6 +71,23 @@ def IREEEncoding_EncodingLayoutAttrInterface :
         assert(false && "unimplemented interface method");
         return {};
       }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Clones an encoding with a new layout list. It is valid to drop any other
+        optional parameters used in layout resolving, because they are already
+        resolved and being attached to the encoding attribute.
+      }],
+      /*retTy=*/"::mlir::Attribute",
+      /*methodName=*/"cloneWithLayouts",
+      /*args=*/(ins
+        "ArrayRef<::mlir::Attribute>":$layoutAttr
+      ),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        assert(false && "unimplemented interface method");
+        return {};
+      }]
     >
   ];
 }
@@ -139,7 +156,7 @@ def IREEEncoding_EncodingTypeInterface :
       /*retTy=*/"::mlir::Type",
       /*methodName=*/"updateEncoding",
       /*args=*/(ins
-        "::mlir::iree_compiler::IREE::Encoding::EncodingAttr":$encoding)
+        "::mlir::Attribute":$encoding)
     >,
   ];
 }

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.cpp
@@ -29,7 +29,8 @@ LogicalResult SetEncodingOp::verify() {
     return emitOpError(
         "source of set_encoding op cannot have a tensor encoding");
   }
-  if (!isa_and_nonnull<EncodingAttr>(getResultType().getEncoding())) {
+  if (!isa_and_nonnull<EncodingLayoutAttrInterface>(
+          getResultType().getEncoding())) {
     return emitOpError(
         "result of set_encoding op expected to have a valid tensor encoding");
   }
@@ -62,7 +63,8 @@ LogicalResult UnsetEncodingOp::verify() {
     return emitOpError(
         "result of unset_encoding op cannot have a tensor encoding");
   }
-  if (!isa_and_nonnull<EncodingAttr>(getSourceType().getEncoding())) {
+  if (!isa_and_nonnull<EncodingLayoutAttrInterface>(
+          getSourceType().getEncoding())) {
     return emitOpError(
         "source of unset_encoding op expected to have a valid tensor encoding");
   }

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.td
@@ -28,10 +28,10 @@ def IREEEncoding_SetEncodingOp : IREEEncoding_PureOp<"set_encoding",[
   ]> {
   let summary = "perform pack and pad operation on source";
   let description = [{
-    Operation to assign an encoding to a tensor. The operation
-    does not change the rank or extent of a tensor. Instead it
-    adds an encoding attribute to the tensor type to represent
-    a change in layout.
+    Operation to assign an encoding to a tensor. The operation does not change
+    the rank or extent of a tensor. Instead it adds an
+    EncodingLayoutAttrInterface attribute to the tensor type to represent a
+    change in layout.
   }];
 
   let arguments = (ins AnyRankedTensor:$source);
@@ -62,9 +62,9 @@ def IREEEncoding_UnsetEncodingOp : IREEEncoding_PureOp<"unset_encoding", [
   ]> {
   let summary = "perfom unpack and extract operation on source";
   let description = [{
-    Operation to convert an tensor with encoding that represents
-    its data layout into a tensor with default layout (i.e. no encoding).
-    For now in IREE the default layout is row-major.
+    Operation to convert an tensor with EncodingLayoutAttrInterface encoding
+    that represents its data layout into a tensor with default layout
+    (i.e. no encoding). For now in IREE the default layout is row-major.
   }];
   let arguments = (ins
     AnyRankedTensor:$source,

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.h
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.h
@@ -38,6 +38,11 @@
 
 namespace mlir::iree_compiler::IREE::Encoding {
 
+/// Returns the encoding attribute from the type if there is an encoding that
+/// implements EncodingLayoutAttrInterface. Otherwise, returns null.
+EncodingLayoutAttrInterface
+getEncodingLayoutAttrInterface(RankedTensorType type);
+
 /// Returns the encoding attribute from the type if there is an encoding.
 /// Otherwise, returns null.
 EncodingAttr getEncodingAttr(RankedTensorType type);

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/test/roundtrip.mlir
@@ -199,3 +199,25 @@ func.func @specialized_encoding_with_type(%arg0: tensor<?x?xf32, #encoding>) -> 
 // CHECK:      func.func @specialized_encoding_with_type(
 // CHECK-SAME:   %[[ARG0:.+]]: tensor<?x?xf32, #iree_encoding.specialized_encoding<123, tensor<?x?xf32>>>
 // CHECK         return %[[ARG0]]
+
+// -----
+
+#encoding = #iree_encoding.testing_encoding<>
+func.func @testing_encoding_without_layouts(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf32, #encoding> {
+  return %arg0 : tensor<?x?xf32, #encoding>
+}
+// CHECK:     #[[ENCODING:.+]] = #iree_encoding.testing_encoding<>
+// CHECK:      func.func @testing_encoding_without_layouts(
+// CHECK-SAME:   %[[ARG0:.+]]: tensor<?x?xf32, #[[ENCODING]]>
+// CHECK         return %[[ARG0]]
+
+// -----
+
+#encoding = #iree_encoding.testing_encoding<[#iree_encoding.unspecialized_encoding<123>]>
+func.func @testing_encoding_with_layouts(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf32, #encoding> {
+  return %arg0 : tensor<?x?xf32, #encoding>
+}
+// CHECK:     #[[ENCODING:.+]] = #iree_encoding.testing_encoding<[#iree_encoding.unspecialized_encoding<123>]>
+// CHECK:      func.func @testing_encoding_with_layouts(
+// CHECK-SAME:   %[[ARG0:.+]]: tensor<?x?xf32, #[[ENCODING]]>
+// CHECK         return %[[ARG0]]

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowTypes.cpp
@@ -119,8 +119,7 @@ bool DispatchTensorType::hasStaticShape(ArrayRef<int64_t> shape) const {
 
 Type DispatchTensorType::getEncodingType() const { return getBoundType(); }
 
-Type DispatchTensorType::updateEncoding(
-    IREE::Encoding::EncodingAttr encoding) const {
+Type DispatchTensorType::updateEncoding(Attribute encoding) const {
   return DispatchTensorType::get(getAccess(), getShape(), getBoundElementType(),
                                  encoding);
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowTypes.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowTypes.h
@@ -136,7 +136,7 @@ public:
   }
 
   Type getEncodingType() const;
-  Type updateEncoding(IREE::Encoding::EncodingAttr encoding) const;
+  Type updateEncoding(Attribute encoding) const;
 };
 
 void printType(DispatchTensorType &type, DialectAsmPrinter &p);

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
@@ -93,12 +93,9 @@ util.func public @with_pad_encoding(%arg0: index, %arg1: index, %scalar_f32 : f3
 // encoding is updated that carries resolved layouts.
 //------------------------------------------------------------------------------
 
-#map0 = affine_map<(m, n, k) -> (m, k)>
-#map1 = affine_map<(m, n, k) -> (k, n)>
-#map2 = affine_map<(m, n, k) -> (m, n)>
 #executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {encoding = #iree_encoding.unspecialized_encoding<123>}>
 #device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
-#encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map0, #map1, #map2]>
+#encoding = #iree_encoding.testing_encoding<>
 
 util.global private @device_a = #device_target_local_0_
 util.func public @ops_with_result_encoding_only(%arg0: index, %arg1: index, %scalar_f32 : f32) {
@@ -107,8 +104,8 @@ util.func public @ops_with_result_encoding_only(%arg0: index, %arg1: index, %sca
   %2 = stream.tensor.splat on(#hal.device.affinity<@device_a>) %scalar_f32 : f32 -> tensor<?x1x10xf32, #encoding>{%arg0} in !stream.resource<*>{%arg1}
   util.return
 }
-// CHECK-DAG:   #[[$ENCODING0:.+]] = #iree_encoding.encoding<{{.+}} layouts = [#iree_encoding.specialized_encoding<123, tensor<?x0xf32>>]
-// CHECK-DAG:   #[[$ENCODING1:.+]] = #iree_encoding.encoding<{{.+}} layouts = [#iree_encoding.specialized_encoding<123, tensor<?x1x10xf32>>]
+// CHECK-DAG:   #[[$ENCODING0:.+]] = #iree_encoding.testing_encoding<[#iree_encoding.specialized_encoding<123, tensor<?x0xf32>>]>
+// CHECK-DAG:   #[[$ENCODING1:.+]] = #iree_encoding.testing_encoding<[#iree_encoding.specialized_encoding<123, tensor<?x1x10xf32>>]>
 // CHECK:       #[[TARGET:.+]] = #hal.device.target
 // CHECK:       util.global private @[[$DEVICE:.+]] = #[[TARGET]]
 // CHECK-LABEL: util.func public @ops_with_result_encoding_only
@@ -119,13 +116,9 @@ util.func public @ops_with_result_encoding_only(%arg0: index, %arg1: index, %sca
 
 // -----
 
-#map0 = affine_map<(m, n, k) -> (m, k)>
-#map1 = affine_map<(m, n, k) -> (k, n)>
-#map2 = affine_map<(m, n, k) -> (m, n)>
 #executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {encoding = #iree_encoding.unspecialized_encoding<123>}>
 #device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
-#encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map0, #map1, #map2]>
-
+#encoding = #iree_encoding.testing_encoding<>
 util.global private @device_a = #device_target_local_0_
 util.func public @tensor_fill_op(%arg0: f32, %arg1: !stream.resource<*>, %arg2: index, %arg3: index) {
   %c0 = arith.constant 0 : index
@@ -135,7 +128,7 @@ util.func public @tensor_fill_op(%arg0: f32, %arg1: !stream.resource<*>, %arg2: 
     -> tensor<?x4xf32, #encoding>{%arg2} in %arg1 as !stream.resource<*>{%arg3}
   util.return
 }
-// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.encoding<{{.+}} layouts = [#iree_encoding.specialized_encoding<123, tensor<?x4xf32>>]
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.testing_encoding<[#iree_encoding.specialized_encoding<123, tensor<?x4xf32>>]>
 // CHECK:       #[[TARGET:.+]] = #hal.device.target
 // CHECK:       util.global private @[[$DEVICE:.+]] = #[[TARGET]]
 // CHECK-LABEL: util.func public @tensor_fill_op
@@ -146,12 +139,9 @@ util.func public @tensor_fill_op(%arg0: f32, %arg1: !stream.resource<*>, %arg2: 
 
 // Checks that the stream.tensor.constant op with encoding is not supported.
 
-#map0 = affine_map<(m, n, k) -> (m, k)>
-#map1 = affine_map<(m, n, k) -> (k, n)>
-#map2 = affine_map<(m, n, k) -> (m, n)>
 #executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {encoding = #iree_encoding.unspecialized_encoding<123>}>
 #device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
-#encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map0, #map1, #map2]>
+#encoding = #iree_encoding.testing_encoding<>
 
 // expected-error @+1 {{failed to add layouts to Stream::TensorPhaseOp with encodings}}
 module {
@@ -166,12 +156,9 @@ module {
 
 // Checks that the stream.tensor.clone op with encoding is not supported.
 
-#map0 = affine_map<(m, n, k) -> (m, k)>
-#map1 = affine_map<(m, n, k) -> (k, n)>
-#map2 = affine_map<(m, n, k) -> (m, n)>
 #executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {encoding = #iree_encoding.unspecialized_encoding<123>}>
 #device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
-#encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map0, #map1, #map2]>
+#encoding = #iree_encoding.testing_encoding<>
 
 // expected-error @+1 {{failed to add layouts to Stream::TensorPhaseOp with encodings}}
 module {
@@ -188,12 +175,9 @@ module {
 
 // Checks that the stream.tensor.slice op with encoding is not supported.
 
-#map0 = affine_map<(m, n, k) -> (m, k)>
-#map1 = affine_map<(m, n, k) -> (k, n)>
-#map2 = affine_map<(m, n, k) -> (m, n)>
 #executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {encoding = #iree_encoding.unspecialized_encoding<123>}>
 #device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
-#encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map0, #map1, #map2]>
+#encoding = #iree_encoding.testing_encoding<>
 
 // expected-error @+1 {{failed to add layouts to Stream::TensorPhaseOp with encodings}}
 module {
@@ -212,12 +196,9 @@ module {
 
 // Checks that the stream.tensor.update op with encoding is not supported.
 
-#map0 = affine_map<(m, n, k) -> (m, k)>
-#map1 = affine_map<(m, n, k) -> (k, n)>
-#map2 = affine_map<(m, n, k) -> (m, n)>
 #executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {encoding = #iree_encoding.unspecialized_encoding<123>}>
 #device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
-#encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map0, #map1, #map2]>
+#encoding = #iree_encoding.testing_encoding<>
 
 // expected-error @+1 {{failed to add layouts to Stream::TensorPhaseOp with encodings}}
 module {
@@ -235,13 +216,9 @@ util.global private @device_a = #device_target_local_0_
 // -----
 
 #executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {encoding = #iree_encoding.unspecialized_encoding<123>}>
-#map = affine_map<(d0) -> (d0)>
-#map0 = affine_map<(m, n, k) -> (m, k)>
-#map1 = affine_map<(m, n, k) -> (k, n)>
-#map2 = affine_map<(m, n, k) -> (m, n)>
 #device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
 #device_target_local_1_ = #hal.device.target<"local", {ordinal = 1 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
-#encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map0, #map1, #map2]>
+#encoding = #iree_encoding.testing_encoding<>
 
 util.global private @device_a = #device_target_local_0_
 util.global private @device_b = #device_target_local_1_
@@ -279,7 +256,7 @@ util.func public @multi_device_with_same_executable_targets(%arg0: !hal.buffer_v
 }
 // CHECK-DAG:   #[[DEVICE_LOCAL_0:.+]] = #hal.device.target
 // CHECK-DAG:   #[[DEVICE_LOCAL_1:.+]] = #hal.device.target
-// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.encoding<{{.+}} layouts = [#iree_encoding.specialized_encoding<123, tensor<16xf32>>]
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.testing_encoding<[#iree_encoding.specialized_encoding<123, tensor<16xf32>>]>
 // CHECK:       util.global private @[[$DEVICE_A:.+]] = #[[DEVICE_LOCAL_0]]
 // CHECK:       util.global private @[[$DEVICE_B:.+]] = #[[DEVICE_LOCAL_1]]
 // CHECK:       stream.executable private @[[$EX0:.+]] {
@@ -302,11 +279,7 @@ util.func public @multi_device_with_same_executable_targets(%arg0: !hal.buffer_v
 #executable_target_b = #hal.executable.target<"target_b", "xyz", {encoding = #iree_encoding.unspecialized_encoding<456>}>
 #device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_a]> : !hal.device
 #device_target_local_1_ = #hal.device.target<"local", {ordinal = 1 : index}, [#executable_target_b]> : !hal.device
-#map = affine_map<(d0) -> (d0)>
-#map0 = affine_map<(m, n, k) -> (m, k)>
-#map1 = affine_map<(m, n, k) -> (k, n)>
-#map2 = affine_map<(m, n, k) -> (m, n)>
-#encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map0, #map1, #map2]>
+#encoding = #iree_encoding.testing_encoding<>
 
 util.global private @device_a = #device_target_local_0_
 util.global private @device_b = #device_target_local_1_
@@ -344,8 +317,8 @@ util.func public @multi_device_with_different_executable_targets(%arg0: !hal.buf
 }
 // CHECK-DAG:   #[[DEVICE_LOCAL_0:.+]] = #hal.device.target
 // CHECK-DAG:   #[[DEVICE_LOCAL_1:.+]] = #hal.device.target
-// CHECK-DAG:   #[[$DEVICE_A_ENCODING:.+]] = #iree_encoding.encoding{{.+}} layouts = [#iree_encoding.specialized_encoding<123, tensor<16xf32>>
-// CHECK-DAG:   #[[$DEVICE_B_ENCODING:.+]] = #iree_encoding.encoding{{.+}} layouts = [#iree_encoding.specialized_encoding<456, tensor<16xf32>>
+// CHECK-DAG:   #[[$DEVICE_A_ENCODING:.+]] = #iree_encoding.testing_encoding<[#iree_encoding.specialized_encoding<123, tensor<16xf32>>]>
+// CHECK-DAG:   #[[$DEVICE_B_ENCODING:.+]] = #iree_encoding.testing_encoding<[#iree_encoding.specialized_encoding<456, tensor<16xf32>>]>
 // CHECK:       util.global private @[[$DEVICE_A:.+]] = #[[DEVICE_LOCAL_0]]
 // CHECK:       util.global private @[[$DEVICE_B:.+]] = #[[DEVICE_LOCAL_1]]
 // CHECK:       stream.executable private @[[$EX0:.+]] {
@@ -372,12 +345,9 @@ util.func public @multi_device_with_different_executable_targets(%arg0: !hal.buf
 
 #executable_target_a = #hal.executable.target<"target_a", "abc", {encoding = #iree_encoding.unspecialized_encoding<123>}>
 #executable_target_b = #hal.executable.target<"target_b", "xyz", {encoding = #iree_encoding.unspecialized_encoding<456>}>
-#map = affine_map<(d0, d1, d2) -> (d0, d2)>
-#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
-#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
 #device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_a]> : !hal.device
 #device_target_local_1_ = #hal.device.target<"local", {ordinal = 1 : index}, [#executable_target_b]> : !hal.device
-#encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2]>
+#encoding = #iree_encoding.testing_encoding<>
 
 util.global private @device_a = #device_target_local_0_
 util.global private @device_b = #device_target_local_1_
@@ -409,16 +379,9 @@ util.func public @multi_device_set_encoding(%arg0: !stream.resource<external>, %
   util.return
 }
 
-// CHECK-DAG:   #[[DEVICE_A_ENCODING:.+]] = #iree_encoding.encoding{{.+}} layouts = [#iree_encoding.specialized_encoding<123, tensor<?x?xf32>>]
-// CHECK-DAG:   #[[DEVICE_B_ENCODING:.+]] = #iree_encoding.encoding{{.+}} layouts = [#iree_encoding.specialized_encoding<456, tensor<?x?xf32>>]
-// CHECK-DAG:   #[[MAP0:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
-// CHECK-DAG:   #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
-// CHECK-DAG:   #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
-//
-// Explicitly capture the last `>` symbol because it makes sure that the
-// `layouts` is not attached in the ORIG_ENCODING.
-//
-// CHECK-DAG:   #[[ORIG_ENCODING:.+]] = #iree_encoding.encoding<{{.+}} user_indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]]>
+// CHECK-DAG:   #[[DEVICE_A_ENCODING:.+]] = #iree_encoding.testing_encoding<[#iree_encoding.specialized_encoding<123, tensor<?x?xf32>>]>
+// CHECK-DAG:   #[[DEVICE_B_ENCODING:.+]] = #iree_encoding.testing_encoding<[#iree_encoding.specialized_encoding<456, tensor<?x?xf32>>]>
+// CHECK-DAG:   #[[ORIG_ENCODING:.+]] = #iree_encoding.testing_encoding<>
 // CHECK-DAG:   #[[DEVICE_LOCAL_0:.+]] = #hal.device.target
 // CHECK-DAG:   #[[DEVICE_LOCAL_1:.+]] = #hal.device.target
 // CHECK:       util.global private @[[$DEVICE_A:.+]] = #[[DEVICE_LOCAL_0]]
@@ -461,12 +424,9 @@ util.func public @multi_device_set_encoding(%arg0: !stream.resource<external>, %
 
 #executable_target_a = #hal.executable.target<"target_a", "abc", {encoding = #iree_encoding.unspecialized_encoding<123>}>
 #executable_target_b = #hal.executable.target<"target_b", "xyz", {encoding = #iree_encoding.unspecialized_encoding<456>}>
-#map = affine_map<(d0, d1, d2) -> (d0, d2)>
-#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
-#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
 #device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_a]> : !hal.device
 #device_target_local_1_ = #hal.device.target<"local", {ordinal = 1 : index}, [#executable_target_b]> : !hal.device
-#encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#map, #map1, #map2]>
+#encoding = #iree_encoding.testing_encoding<>
 
 util.global private @device_a = #device_target_local_0_
 util.global private @device_b = #device_target_local_1_
@@ -497,12 +457,9 @@ util.func public @multi_device_unset_encoding(%arg0: !stream.resource<external>,
   %5 = util.optimization_barrier %4 : !stream.resource<*>
   util.return
 }
-// CHECK-DAG:   #[[DEVICE_A_ENCODING:.+]] = #iree_encoding.encoding{{.+}} layouts = [#iree_encoding.specialized_encoding<123, tensor<?x?xf32>>]
-// CHECK-DAG:   #[[DEVICE_B_ENCODING:.+]] = #iree_encoding.encoding{{.+}} layouts = [#iree_encoding.specialized_encoding<456, tensor<?x?xf32>>]
-// CHECK-DAG:   #[[MAP0:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
-// CHECK-DAG:   #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
-// CHECK-DAG:   #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
-// CHECK-DAG:   #[[ORIG_ENCODING:.+]] = #iree_encoding.encoding<{{.+}} user_indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]]>
+// CHECK-DAG:   #[[DEVICE_A_ENCODING:.+]] = #iree_encoding.testing_encoding<[#iree_encoding.specialized_encoding<123, tensor<?x?xf32>>]>
+// CHECK-DAG:   #[[DEVICE_B_ENCODING:.+]] = #iree_encoding.testing_encoding<[#iree_encoding.specialized_encoding<456, tensor<?x?xf32>>]>
+// CHECK-DAG:   #[[ORIG_ENCODING:.+]] = #iree_encoding.testing_encoding<>
 // CHECK-DAG:   #[[DEVICE_LOCAL_0:.+]] = #hal.device.target
 // CHECK-DAG:   #[[DEVICE_LOCAL_1:.+]] = #hal.device.target
 // CHECK:       util.global private @[[$DEVICE_A:.+]] = #[[DEVICE_LOCAL_0]]


### PR DESCRIPTION
The revision adds the `cloneWithLayouts` method to EncodingLayoutAttrInterface. With the change, the specialization no longer stick to EncodingAttr attribute. Any encoding that implements `EncodingLayoutAttrInterface` can be specialized with the change.

The revision relax SetEncoding ops and UnsetEncoding ops to allow EncodingLayoutAttrInterface. Because there could be other encodings that implement the interface, but not use EncodingAttr.

E.g., the revision introduces a TestingEncodingAttr, and use it in the SpecializeEncoding tests. Only `sizeof` and `multi_device_gemm` test suites keep using `EncodingAttr`. Others are switching to TestingEncodingAttr to decouple dependencies between backend attributes and the SpecializeEncoding pass.