### PR TITLE
[Encoding][NFC] Refactor dropEncoding method to "EncodingTypes.h".

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
@@ -34,7 +34,7 @@ MaterializeEncodingTypeConverter::MaterializeEncodingTypeConverter(
     // itself.
     MaterializeEncodingInfo encodingInfo = getEncodingInfo(type);
     if (IREE::Codegen::isIdentityLayout(encodingInfo)) {
-      return dropEncoding(type);
+      return IREE::Encoding::dropEncoding(type);
     }
     auto packedType = cast<RankedTensorType>(tensor::PackOp::inferPackedType(
         type, encodingInfo.innerTileSizes, encodingInfo.innerDimsPos,

--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.h
@@ -74,9 +74,6 @@ protected:
 // Utility methods about Encoding.
 //===---------------------------------------------------------------------===//
 
-/// Returns the RankedTensorType without encodings.
-RankedTensorType dropEncoding(RankedTensorType type);
-
 /// Returns the deserialized MaterializeEncodingInfo if the `layouts` field is
 /// present in encodings and it only has a single layout. Otherwise, returns
 /// std::nullopt.

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
@@ -411,7 +411,7 @@ void SpecializedEncodingAttr::print(AsmPrinter &p) const {
   os << ">";
 }
 
-static RankedTensorType dropEncoding(RankedTensorType type) {
+RankedTensorType dropEncoding(RankedTensorType type) {
   return RankedTensorType::get(type.getShape(), type.getElementType());
 }
 

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.h
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.h
@@ -93,9 +93,12 @@ MatmulNarrowDim getMatmulNarrowDim(linalg::LinalgOp linalgOp,
 /// value.
 MatmulNarrowDim getMatmulNarrowDim(EncodingAttr encoding);
 
-// Returns true if `encoding` represents a narrow-N matmul RESULT, e.g. the
-// result of a matvec.
+/// Returns true if `encoding` represents a narrow-N matmul RESULT, e.g. the
+/// result of a matvec.
 bool isNarrowNResult(EncodingAttr encoding);
+
+/// Returns the same RankedTensoType without the encoding.
+RankedTensorType dropEncoding(RankedTensorType type);
 
 } // namespace mlir::iree_compiler::IREE::Encoding
 


### PR DESCRIPTION
Also fix a comment style for a method in the EncodingType.h.