### PR TITLE
[hip] Fix async read offsets.

### DIFF
--- a/runtime/src/iree/hal/drivers/hip/hip_device.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_device.c
@@ -1721,7 +1721,7 @@ bool iree_hal_hip_transfer_buffer_size_check_condition(void* user_data) {
   iree_hal_hip_transfer_buffer_size_check_data_t* data =
       (iree_hal_hip_transfer_buffer_size_check_data_t*)user_data;
   return iree_hal_hip_transfer_buffer_size_left(
-             data->device, &data->device->devices[data->device_ordinal]) >
+             data->device, &data->device->devices[data->device_ordinal]) >=
          data->num_bytes;
 }
 
@@ -1759,6 +1759,9 @@ void iree_hal_hip_transfer_buffer_reserve_chunks(
     out_chunks[1].size = 0;
     info->file_transfer_staging_buffer.head += size;
   }
+  info->file_transfer_staging_buffer.head %=
+      device->params.file_transfer_buffer_size;
+
   iree_slim_mutex_unlock(&info->file_transfer_staging_buffer.mutex);
 }
 


### PR DESCRIPTION
We were incorrectly missing the use of one byte of the file, which could cause unecessary stalls. We also could get into a case where we would accidently think a full buffer was empty.