### PR TITLE
[hip] Move alloc operations off the main stream

### DIFF
--- a/runtime/src/iree/hal/drivers/hip/per_device_information.h
+++ b/runtime/src/iree/hal/drivers/hip/per_device_information.h
@@ -20,6 +20,7 @@ typedef struct iree_hal_hip_per_device_info_t {
   hipCtx_t hip_context;
   hipDevice_t hip_device;
   hipStream_t hip_dispatch_stream;
+  hipStream_t hip_async_memory_stream;
 
   iree_hal_stream_tracing_context_t* tracing_context;
 


### PR DESCRIPTION
This gives us a secondary stream for hip async allocations. For sharded models, this means if device_0 is ahead of device_1 but device_1 requests an allocation on device_0, it will not be stalled until device_0 completes any existing work, as the allocation does not depend on that work.