### PR TITLE
[Tool] `--show-dialects`, `--list-passes` needed to take input

### DIFF
--- a/compiler/src/iree/compiler/API/Internal/IREEOptToolEntryPoint.cpp
+++ b/compiler/src/iree/compiler/API/Internal/IREEOptToolEntryPoint.cpp
@@ -110,6 +110,19 @@ static LogicalResult ireeOptMainFromCL(int argc, char **argv,
   const_cast<TargetRegistry &>(TargetRegistry::getGlobal())
       .mergeFrom(pluginTargetBackendList);
 
+  // brought from mlir-opt MlirOptMain.cpp
+  // printRegisteredDialects and printRegisteredPassesAndReturn
+  if (config.shouldShowDialects()) {
+    llvm::outs() << "Available Dialects: ";
+    interleave(registry.getDialectNames(), llvm::outs(), ",");
+    llvm::outs() << "\n";
+    return success();
+  }
+  if (config.shouldListPasses()) {
+    mlir::printRegisteredPasses();
+    return success();
+  }
+
   // When reading from stdin and the input is a tty, it is often a user mistake
   // and the process "appears to be stuck". Print a message to let the user know
   // about it!


### PR DESCRIPTION
ASIS:
`iree-opt --show-dialects`, and `iree-opt --list-passes`  requires dummy input, if it's not given, it expects to read input from stdin.

TOBE:
it directly works without passing dummy input.
```
> iree-opt --show-dialects

Available Dialects: affine,amdgpu,arith,arm_neon,arm_sme,arm_sve,bufferization,builtin,cf,check,chlo,complex,emitc,flow,func,gpu,hal,hal_inline,hal_loader,io_parameters,iree_codegen,iree_cpu,iree_encoding,iree_gpu,iree_input,iree_linalg_ext,iree_vector_ext,linalg,llvm,math,memref,mesh,ml_program,nvgpu,nvvm,pdl,pdl_interp,quant,rocdl,scf,shape,spirv,stablehlo,stream,tensor,tm_tensor,torch,torch_c,tosa,transform,util,vector,vhlo,vm,vmvx
```