### PR TITLE
[DispatchCreation] Remove k2 attention constraint from BubbleUpExpandShapes

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
@@ -162,47 +162,8 @@ void BubbleUpExpandShapesPass::runOnOperation() {
   linalg::populateFoldReshapeOpsByExpansionPatterns(bubbleExpandShapePatterns,
                                                     bubbleUpExpansionControlFn);
 
-  // TODO(#19263): Temporary fix to prevent compilation failures when the
-  // reduction dims get expanded. This adds the constraint to
-  // `bubbleUpExpansionControlFn` that the reduction dimensions cannot be
-  // expanded by the reshape fusion.
-  linalg::ControlFusionFn linalgExtExpansionFn = [&](OpOperand *fusedOperand) {
-    if (!bubbleUpExpansionControlFn(fusedOperand)) {
-      return false;
-    }
-
-    // There is no need to handle `expand_shape` ops because they would be the
-    // producer and therefore are unable to expand the reduction dims.
-    auto collapseOp =
-        dyn_cast<tensor::CollapseShapeOp>(fusedOperand->get().getDefiningOp());
-    auto attentionOp =
-        dyn_cast<IREE::LinalgExt::AttentionOp>(fusedOperand->getOwner());
-    if (!collapseOp || !attentionOp) {
-      return true;
-    }
-
-    SmallVector<ReassociationIndices> reassoc =
-        collapseOp.getReassociationIndices();
-    auto opDetail = IREE::LinalgExt::AttentionOpDetail::get(
-        attentionOp.getQueryMap(), attentionOp.getKeyMap(),
-        attentionOp.getValueMap(), attentionOp.getOutputMap());
-
-    // Don't sink the `collapse_shape` op if it is collapsing into any of the
-    // reduction dimensions.
-    AffineMap operandMap = attentionOp.getMatchingIndexingMap(fusedOperand);
-    for (auto dim : llvm::concat<const int64_t>(opDetail->getK2Dims(),
-                                                opDetail->getK1Dims())) {
-      auto dimExpr = getAffineDimExpr(dim, operandMap.getContext());
-      if (std::optional<int64_t> maybeDim =
-              operandMap.getResultPosition(dimExpr);
-          maybeDim && reassoc[maybeDim.value()].size() > 1) {
-        return false;
-      }
-    }
-    return true;
-  };
   IREE::LinalgExt::populateFoldReshapeOpsByExpansionPatterns(
-      bubbleExpandShapePatterns, linalgExtExpansionFn);
+      bubbleExpandShapePatterns, bubbleUpExpansionControlFn);
 
   // Add patterns to do some additional cleanup (on top of canonicalizations
   // that can be done later) of reshape ops.
@@ -210,6 +171,10 @@ void BubbleUpExpandShapesPass::runOnOperation() {
   bubbleExpandShapePatterns.insert<BubbleExpandThroughExtract>(context);
   tensor::ExpandShapeOp::getCanonicalizationPatterns(bubbleExpandShapePatterns,
                                                      context);
+  tensor::CollapseShapeOp::getCanonicalizationPatterns(
+      bubbleExpandShapePatterns, context);
+  tensor::populateReassociativeReshapeFoldingPatterns(
+      bubbleExpandShapePatterns);
 
   GreedyRewriteConfig rewriteConfig;
   rewriteConfig.maxIterations = GreedyRewriteConfig::kNoLimit;

--- a/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
@@ -173,8 +173,6 @@ void BubbleUpExpandShapesPass::runOnOperation() {
                                                      context);
   tensor::CollapseShapeOp::getCanonicalizationPatterns(
       bubbleExpandShapePatterns, context);
-  tensor::populateReassociativeReshapeFoldingPatterns(
-      bubbleExpandShapePatterns);
 
   GreedyRewriteConfig rewriteConfig;
   rewriteConfig.maxIterations = GreedyRewriteConfig::kNoLimit;

--- a/compiler/src/iree/compiler/DispatchCreation/test/attention_fuse_by_expansion.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/attention_fuse_by_expansion.mlir
@@ -453,7 +453,7 @@ util.func public @sink_single_collapse_masked(%0 : tensor<4x32x64x128xf16>, %1 :
 #map3 = affine_map<(d0, d1, d2, d3, d4) -> ()>
 #map4 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>
 
-util.func public @dont_sink_through_k2(%0 : tensor<128x64x1x1x128xf16>, %1 : tensor<128x64x128xf16>, %2 : tensor<128x64x128xf16>, %cst : f16) -> (tensor<128x64x128xf16>) {
+util.func public @sink_through_k2(%0 : tensor<128x64x1x1x128xf16>, %1 : tensor<128x64x128xf16>, %2 : tensor<128x64x128xf16>, %cst : f16) -> (tensor<128x64x128xf16>) {
   %13 = tensor.empty() : tensor<4x32x64x128xf16>
   %collapsed_12 = tensor.collapse_shape %0 [[0], [1, 2, 3], [4]] : tensor<128x64x1x1x128xf16> into tensor<128x64x128xf16>
   %17 = tensor.empty() : tensor<128x64x128xf16>
@@ -464,20 +464,20 @@ util.func public @dont_sink_through_k2(%0 : tensor<128x64x1x1x128xf16>, %1 : ten
   util.return %18 : tensor<128x64x128xf16>
 }
 
-// CHECK-LABEL: util.func public @dont_sink_through_k2
+// CHECK-LABEL: util.func public @sink_through_k2
 //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]:
 //  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]:
 //  CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]:
 //  CHECK-SAME:     %[[ARG3:.+]]: f16
-//   CHECK-DAG:   %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG0]]
+//   CHECK-DAG:   %[[EXPANDED:.+]] = tensor.expand_shape %[[ARG1]]
 //       CHECK:   %[[ATTENTION:.+]] = iree_linalg_ext.attention
 //  CHECK-SAME:       indexing_maps =
-//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
-//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>
-//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>
-//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4) -> ()>
-//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>
-//  CHECK-SAME:       ins(%[[ARG2]], %[[ARG1]], %[[COLLAPSED]], %[[ARG3]] :
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2)>
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d3, d4, d5, d2)>
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d3, d4, d5, d6)>
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4, d5, d6) -> ()>
+//  CHECK-SAME:       affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d6)>
+//  CHECK-SAME:       ins(%[[ARG2]], %[[EXPANDED]], %[[ARG0]], %[[ARG3]] :
 //       CHECK:   util.return %[[ATTENTION]]
 
 // -----


### PR DESCRIPTION
This can be removed after https://github.com/iree-org/iree/pull/19654 landed and these dims can be collapsed. Also, I added some missing canonicalization patterns to fold away reshapes.