### PR TITLE
[Stream][Encoding] Filter out unrecognized dispatches in specialization.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
@@ -212,8 +212,20 @@ duplicateExecutablesPerLayoutVariant(ModuleOp moduleOp, SymbolTable symbolTable,
   IRRewriter rewriter(ctx);
 
   SmallVector<IREE::Stream::TensorDispatchOp> candidates;
-  funcOp.walk(
-      [&](IREE::Stream::TensorDispatchOp op) { candidates.push_back(op); });
+  funcOp.walk([&](IREE::Stream::TensorDispatchOp op) {
+    // Filter out the cases that are not from the normal pipeline. E.g., custom
+    // dispatch could embed hal.executables.
+    bool recognizedInput = true;
+    op.forEachEntryPointAttr([&](SymbolRefAttr entryPoint) {
+      if (!isa<IREE::Stream::ExecutableExportOp>(
+              symbolTable.lookupSymbolIn(moduleOp, entryPoint))) {
+        recognizedInput = false;
+      }
+    });
+    if (recognizedInput) {
+      candidates.push_back(op);
+    }
+  });
 
   //===--------------------------------------------------------------------===//
   // Gather per-export [binding layouts] map. A function in an executable can be

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
@@ -689,18 +689,14 @@ util.func public @multi_device_gemm(%arg0: !stream.resource<external>, %arg1: !s
 // Negative tests. The pass should do nothing for the cases.
 //------------------------------------------------------------------------------
 
+
 hal.executable.source public @executable {
   hal.executable.export public @dispatch ordinal(0) layout(#hal.pipeline.layout<constants = 0, bindings = [
     #hal.pipeline.binding<storage_buffer>
   ]>)
 }
 util.func public @dispatch_hal_executable(%arg0: !stream.resource<*>, %arg1: index, %arg2: index) -> !stream.resource<*> {
-  %c0 = arith.constant 0 : index
-  %c1 = arith.constant 1 : index
-  %c2 = arith.constant 2 : index
-  %c3 = arith.constant 3 : index
-  %c4 = arith.constant 4 : index
-  %1 = stream.tensor.dispatch @executable::@dispatch[%c1, %c2, %c3](%arg0, %c4) : (tensor<4x?xf32>{%arg2} in !stream.resource<*>{%arg1}, index) -> tensor<4x?xf32>{%arg2} in !stream.resource<*>{%arg1}
-  util.return %1 : !stream.resource<*>
+  %0 = stream.tensor.dispatch @executable::@dispatch(%arg0) : (tensor<4x?xf32>{%arg2} in !stream.resource<*>{%arg1}) -> tensor<4x?xf32>{%arg2} in !stream.resource<*>{%arg1}
+  util.return %0 : !stream.resource<*>
 }
 // CHECK-LABEL: util.func public @dispatch_hal_executable

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
@@ -684,3 +684,23 @@ util.func public @multi_device_gemm(%arg0: !stream.resource<external>, %arg1: !s
 // CHECK-LABEL: util.func public @multi_device_gemm
 // CHECK:         stream.tensor.dispatch on(#hal.device.affinity<@[[$DEVICE_A]]>) @[[$EX0]]::@gemm
 // CHECK:         stream.tensor.dispatch on(#hal.device.affinity<@[[$DEVICE_B]]>) @[[$EX1]]::@gemm
+
+//------------------------------------------------------------------------------
+// Negative tests. The pass should do nothing for the cases.
+//------------------------------------------------------------------------------
+
+hal.executable.source public @executable {
+  hal.executable.export public @dispatch ordinal(0) layout(#hal.pipeline.layout<constants = 0, bindings = [
+    #hal.pipeline.binding<storage_buffer>
+  ]>)
+}
+util.func public @dispatch_hal_executable(%arg0: !stream.resource<*>, %arg1: index, %arg2: index) -> !stream.resource<*> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
+  %1 = stream.tensor.dispatch @executable::@dispatch[%c1, %c2, %c3](%arg0, %c4) : (tensor<4x?xf32>{%arg2} in !stream.resource<*>{%arg1}, index) -> tensor<4x?xf32>{%arg2} in !stream.resource<*>{%arg1}
+  util.return %1 : !stream.resource<*>
+}
+// CHECK-LABEL: util.func public @dispatch_hal_executable

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
@@ -689,7 +689,6 @@ util.func public @multi_device_gemm(%arg0: !stream.resource<external>, %arg1: !s
 // Negative tests. The pass should do nothing for the cases.
 //------------------------------------------------------------------------------
 
-
 hal.executable.source public @executable {
   hal.executable.export public @dispatch ordinal(0) layout(#hal.pipeline.layout<constants = 0, bindings = [
     #hal.pipeline.binding<storage_buffer>

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
@@ -685,6 +685,8 @@ util.func public @multi_device_gemm(%arg0: !stream.resource<external>, %arg1: !s
 // CHECK:         stream.tensor.dispatch on(#hal.device.affinity<@[[$DEVICE_A]]>) @[[$EX0]]::@gemm
 // CHECK:         stream.tensor.dispatch on(#hal.device.affinity<@[[$DEVICE_B]]>) @[[$EX1]]::@gemm
 
+// -----
+
 //------------------------------------------------------------------------------
 // Negative tests. The pass should do nothing for the cases.
 //------------------------------------------------------------------------------


### PR DESCRIPTION
There are cases from non-default path that do not have stream.executable ops. E.g., there are embedded hal.executable in `samples/custom_dispatch/cpu/embedded/example_transform_spec.mlir`