### PR TITLE
Replicate unplaced dispatches accross devices

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/PatternUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/PatternUtils.cpp
@@ -66,7 +66,8 @@ ConvertedTensor transferTensorOperands(
   auto affinityAttr = affinityAnalysis->lookupResourceAffinity(originalOperand);
   bool isBarrier = resource.getDefiningOp() &&
                    isa<IREE::Stream::AsyncBarrierOp>(resource.getDefiningOp());
-  if (affinityAttr != requiredAffinityAttr && !isBarrier) {
+  if (requiredAffinityAttr && affinityAttr != requiredAffinityAttr &&
+      !isBarrier) {
     resource = builder.create<IREE::Stream::AsyncTransferOp>(
         loc, resource.getType(), resource, resourceSize, resourceSize,
         affinityAttr, requiredAffinityAttr);

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -2644,6 +2644,15 @@ static void printDispatchOperands(OpAsmPrinter &p, Operation *op,
   p << ")";
 }
 
+bool AsyncDispatchOp::preferCloneToConsumers() {
+  for (auto operand : getResourceOperands()) {
+    if (isa<Stream::ResourceType>(operand.getType())) {
+      return false;
+    }
+  }
+  return true;
+}
+
 LogicalResult AsyncDispatchOp::verify() {
   AsyncDispatchOp op = *this;
   if (failed(verifyOpValueSizes(op, op.getResourceOperands(),

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -2493,7 +2493,9 @@ def Stream_AsyncDispatchOp : Stream_Op<"async.dispatch", [
   DeclareOpInterfaceMethods<SymbolUserOpInterface>,
   Stream_AffinityOp,
   Stream_AsyncPhaseOp,
-  Stream_StreamableOp,
+  DeclareOpInterfaceMethods<Stream_StreamableOp, [
+    "preferCloneToConsumers",
+  ]>,
   DeclareOpInterfaceMethods<Stream_AsyncAccessOp, [
     "getAsyncAccessRanges",
   ]>,

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ExecutionPlacement.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ExecutionPlacement.cpp
@@ -37,41 +37,167 @@ namespace mlir::iree_compiler::IREE::Stream {
 
 namespace {
 
+LogicalResult handleAsyncTransferOp(IREE::Stream::AsyncTransferOp transfer) {
+  if (transfer.getAffinityAttr())
+    return success();
+
+  auto operand = transfer.getSource();
+  auto producer = operand.getDefiningOp();
+  auto streamable =
+      dyn_cast_or_null<IREE::Stream::StreamableOpInterface>(producer);
+  auto srcAffinity =
+      dyn_cast_or_null<IREE::Stream::AffinityOpInterface>(producer);
+
+  bool hasOneUse = operand.hasOneUse();
+  if (hasOneUse && streamable && srcAffinity && srcAffinity.getAffinityAttr()) {
+    transfer.setAffinityAttr(srcAffinity.getAffinityAttr());
+    return success();
+  }
+
+  if (transfer.getResultAffinityAttr()) {
+    transfer.setAffinityAttr(transfer.getResultAffinityAttr());
+    return success();
+  }
+
+  if (transfer.getSourceAffinityAttr()) {
+    transfer.setAffinityAttr(transfer.getSourceAffinityAttr());
+    return success();
+  }
+
+  transfer->emitOpError("Unknown src/dest affinity");
+  return failure();
+}
+
+LogicalResult handleAsyncDispatchOp(IREE::Stream::AsyncDispatchOp dispatch) {
+  if (dispatch.getAffinityAttr() || dispatch.preferCloneToConsumers()) {
+    return success();
+  }
+
+  llvm::SetVector<AffinityAttr> affinities;
+  for (auto operand : dispatch.getResourceOperands()) {
+    auto affinityOp =
+        dyn_cast_or_null<AffinityOpInterface>(operand.getDefiningOp());
+    if (!affinityOp) {
+      continue;
+    }
+
+    if (auto transfer = dyn_cast_or_null<IREE::Stream::AsyncTransferOp>(
+            operand.getDefiningOp())) {
+      affinities.insert(transfer.getResultAffinityAttr());
+      continue;
+    }
+
+    if (auto stream =
+            dyn_cast_or_null<StreamableOpInterface>(operand.getDefiningOp())) {
+      if (stream.preferCloneToConsumers()) {
+        continue;
+      }
+
+      affinities.insert(affinityOp.getAffinityAttr());
+    }
+  }
+
+  if (affinities.size() == 0) {
+    dispatch->emitOpError("No affinities found");
+    return failure();
+  }
+
+  if (affinities.size() != 1) {
+    dispatch->emitOpError("Multiple affinities found");
+    return failure();
+  }
+
+  if (affinities[0] == nullptr) {
+    dispatch->emitOpError("Null affinity selected");
+    return failure();
+  }
+
+  dispatch.setAffinityAttr(affinities[0]);
+  return success();
+}
+
 struct ExecutionPlacementPass
     : public IREE::Stream::impl::ExecutionPlacementPassBase<
           ExecutionPlacementPass> {
   void runOnOperation() override {
 
-    getOperation()->walk([](IREE::Stream::AsyncTransferOp transfer) {
-      if (transfer.getAffinityAttr())
-        return;
-
-      auto operand = transfer.getSource();
-      auto producer = operand.getDefiningOp();
-      auto streamable =
-          dyn_cast_or_null<IREE::Stream::StreamableOpInterface>(producer);
-      auto srcAffinity =
-          dyn_cast_or_null<IREE::Stream::AffinityOpInterface>(producer);
-
-      bool hasOneUse = operand.hasOneUse();
-      if (hasOneUse && streamable && srcAffinity &&
-          srcAffinity.getAffinityAttr()) {
-        transfer.setAffinityAttr(srcAffinity.getAffinityAttr());
-        return;
+    auto result = getOperation()->walk([](Operation *op) -> WalkResult {
+      if (auto transfer = dyn_cast_or_null<IREE::Stream::AsyncTransferOp>(op)) {
+        if (failed(handleAsyncTransferOp(transfer))) {
+          return WalkResult::interrupt();
+        }
+      }
+      if (auto dispatch = dyn_cast_or_null<IREE::Stream::AsyncDispatchOp>(op)) {
+        if (failed(handleAsyncDispatchOp(dispatch))) {
+          return WalkResult::interrupt();
+        }
       }
 
-      if (transfer.getResultAffinityAttr()) {
-        transfer.setAffinityAttr(transfer.getResultAffinityAttr());
-        return;
-      }
-
-      if (transfer.getSourceAffinityAttr()) {
-        transfer.setAffinityAttr(transfer.getSourceAffinityAttr());
-        return;
-      }
-
-      transfer->emitOpError("Unknown src/dest affinity");
+      return WalkResult::advance();
     });
+
+    if (result.wasInterrupted()) {
+      return signalPassFailure();
+    }
+
+    // It is possible for the results of a dispatch to be used across multiple
+    // devices. This occurs when the output of the dispatch is constant. Cloning
+    // with all required affinities and remapping provides a separate
+    // implementation per device.
+    llvm::SmallVector<IREE::Stream::AsyncDispatchOp> cloneDispatches;
+    getOperation()->walk([&cloneDispatches](IREE::Stream::AsyncDispatchOp op) {
+      if (op.preferCloneToConsumers() && !op.getAffinityAttr()) {
+        cloneDispatches.push_back(op);
+      }
+    });
+
+    for (auto dispatch : llvm::reverse(cloneDispatches)) {
+      llvm::SetVector<AffinityAttr> affinities;
+      for (auto &use : dispatch->getUses()) {
+        if (auto affinity = dyn_cast<AffinityOpInterface>(use.getOwner())) {
+          affinities.insert(affinity.getAffinityAttr());
+        }
+      }
+
+      OpBuilder builder(dispatch.getOperation());
+      for (auto affinity : affinities) {
+        auto clone = builder.clone(*dispatch);
+        auto cloneDispatch = dyn_cast<IREE::Stream::AsyncDispatchOp>(clone);
+        cloneDispatch.setAffinityAttr(affinity);
+
+        for (int i = 0, s = dispatch.getNumResults(); i < s; ++i) {
+          Value result = dispatch.getResult(i);
+          result.replaceUsesWithIf(
+              cloneDispatch.getResult(i),
+              [affinity](OpOperand &operand) -> bool {
+                if (auto affinityOp =
+                        dyn_cast<AffinityOpInterface>(operand.getOwner())) {
+                  return affinityOp.getAffinityAttr() == affinity;
+                }
+
+                return false;
+              });
+        }
+      }
+
+      dispatch.erase();
+    }
+
+    // Cleanup the dead ops.
+    auto *context = &getContext();
+    RewritePatternSet patterns(context);
+    for (auto *dialect : context->getLoadedDialects()) {
+      dialect->getCanonicalizationPatterns(patterns);
+    }
+
+    for (auto op : context->getRegisteredOperations()) {
+      op.getCanonicalizationPatterns(patterns, context);
+    }
+
+    FrozenRewritePatternSet frozenPatterns(std::move(patterns));
+    if (failed(applyPatternsGreedily(getOperation(), frozenPatterns))) {
+      return signalPassFailure();
+    }
   }
 };
 

--- a/compiler/src/iree/compiler/ExternalInterfaces/StreamExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/StreamExternalModels.cpp
@@ -76,7 +76,7 @@ struct FlowTransferTargetAffinityAttrExternalModel
         FlowTransferTargetAffinityAttrExternalModel>(*context);
   }
 
-  bool requiresAffinity(Operation *op) const { return false; }
+  bool requiresAffinity(Operation *op) const { return true; }
 
   IREE::Stream::AffinityAttr getAffinityAttr(Operation *op) const {
     return op->getAttrOfType<IREE::Stream::AffinityAttr>("target");

--- a/compiler/src/iree/compiler/ExternalInterfaces/StreamExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/StreamExternalModels.cpp
@@ -76,7 +76,7 @@ struct FlowTransferTargetAffinityAttrExternalModel
         FlowTransferTargetAffinityAttrExternalModel>(*context);
   }
 
-  bool requiresAffinity(Operation *op) const { return true; }
+  bool requiresAffinity(Operation *op) const { return false; }
 
   IREE::Stream::AffinityAttr getAffinityAttr(Operation *op) const {
     return op->getAttrOfType<IREE::Stream::AffinityAttr>("target");


### PR DESCRIPTION
It is possible for producing dispatches to use no known buffers while being used across multiple pieces of hardware. E.g. the attention mask is often required across all tensor parallel devices. Rather than executing then transfering it is more efficient to replicate the dispatch across all devices.