### PR TITLE
Revert "Disable ubuntu-24.04-arm workflows until the runners are stable."

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,9 @@ jobs:
           - name: ubuntu-24.04
             runs-on: ubuntu-24.04
             driver-options: -DIREE_HAL_DRIVER_CUDA=ON -DIREE_HAL_DRIVER_HIP=ON -DIREE_HAL_DRIVER_VULKAN=ON
-          # TODO(scotttodd): re-enable when GitHub-hosted Arm runners are stable and don't fail during actions/checkout
-          # - name: ubuntu-24.04-arm
-          #   runs-on: ubuntu-24.04-arm
-          #   driver-options: -DIREE_HAL_DRIVER_CUDA=ON -DIREE_HAL_DRIVER_HIP=ON -DIREE_HAL_DRIVER_VULKAN=ON
+          - name: ubuntu-24.04-arm
+            runs-on: ubuntu-24.04-arm
+            driver-options: -DIREE_HAL_DRIVER_CUDA=ON -DIREE_HAL_DRIVER_HIP=ON -DIREE_HAL_DRIVER_VULKAN=ON
           - name: windows-2022
             runs-on: windows-2022
             driver-options: -DIREE_HAL_DRIVER_CUDA=ON -DIREE_HAL_DRIVER_HIP=ON -DIREE_HAL_DRIVER_VULKAN=ON
@@ -170,12 +169,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on:
-          - ubuntu-24.04
-          # TODO(scotttodd): re-enable when GitHub-hosted Arm runners are stable and don't fail during actions/checkout
-          # - ubuntu-24.04-arm
-          - windows-2022
-          - macos-14
+        runs-on: [ubuntu-24.04, ubuntu-24.04-arm, windows-2022, macos-14]
         provider: [tracy, console]
     env:
       BUILD_DIR: build-tracing


### PR DESCRIPTION
Reverts iree-org/iree#19968. The runners may be more stable now: https://github.com/orgs/community/discussions/148648#discussioncomment-12205917.

ci-exactly: runtime,runtime_tracing