### PR TITLE
[DT] Switching to use encoding attributes for late materialization path

### DIFF
--- a/compiler/plugins/target/LLVMCPU/LLVMCPUTarget.cpp
+++ b/compiler/plugins/target/LLVMCPU/LLVMCPUTarget.cpp
@@ -16,6 +16,7 @@
 #include "compiler/plugins/target/LLVMCPU/LinkerTool.h"
 #include "compiler/plugins/target/LLVMCPU/StaticLibraryGenerator.h"
 #include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUDialect.h"
+#include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
 #include "iree/compiler/Codegen/LLVMCPU/Passes.h"
 #include "iree/compiler/Codegen/LLVMCPU/Utils.h"
@@ -170,6 +171,9 @@ public:
     Builder b(context);
     SmallVector<NamedAttribute> configItems;
     target.storeToConfigAttrs(context, configItems);
+    configItems.emplace_back(
+        b.getStringAttr("encoding"),
+        IREE::CPU::CPUEncodingLayoutAttr::get(context, {}));
 
     // Compute the format used at runtime to select the executable loader.
     std::string format;

--- a/compiler/plugins/target/VMVX/VMVXTarget.cpp
+++ b/compiler/plugins/target/VMVX/VMVXTarget.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUDialect.h"
+#include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
 #include "iree/compiler/Codegen/VMVX/Passes.h"
 #include "iree/compiler/Dialect/HAL/Target/Devices/LocalDevice.h"
@@ -44,12 +45,15 @@ static IREE::HAL::ExecutableTargetAttr
 getVMVXExecutableTarget(bool enableMicrokernels, MLIRContext *context,
                         StringRef backend, StringRef format) {
   Builder b(context);
-  NamedAttribute configItem(
-      "ukernels", b.getStringAttr(enableMicrokernels ? "all" : "none"));
-
+  SmallVector<NamedAttribute> configItems;
+  configItems.emplace_back(
+      b.getStringAttr("ukernels"),
+      b.getStringAttr(enableMicrokernels ? "all" : "none"));
+  configItems.emplace_back(b.getStringAttr("encoding"),
+                           IREE::CPU::VMVXEncodingLayoutAttr::get(context, {}));
   return b.getAttr<IREE::HAL::ExecutableTargetAttr>(
       b.getStringAttr(backend), b.getStringAttr(format),
-      b.getDictionaryAttr(configItem));
+      b.getDictionaryAttr(configItems));
 }
 
 class VMVXTargetBackend final : public TargetBackend {

--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -208,6 +208,7 @@ X86_64_AVX512_BF16 = X86_64_AVX512 + [
     compiler_flags = [
         "--iree-opt-data-tiling",
         "--iree-global-opt-enable-early-materialization=false",
+        "--iree-stream-experimental-specialize-encodings",
     ] + ["--iree-llvmcpu-enable-ukernels=%s" % ("all" if use_uk else "none")],
     generator = ":generate_e2e_matmul_tests",
     generator_args = [
@@ -274,6 +275,7 @@ X86_64_AVX512_BF16 = X86_64_AVX512 + [
     compiler_flags = [
         "--iree-opt-data-tiling",
         "--iree-global-opt-enable-early-materialization=false",
+        "--iree-stream-experimental-specialize-encodings",
     ],
     generator = ":generate_e2e_matmul_tests",
     generator_args = [
@@ -304,6 +306,7 @@ X86_64_AVX512_BF16 = X86_64_AVX512 + [
     compiler_flags = [
         "--iree-opt-data-tiling",
         "--iree-global-opt-enable-early-materialization=false",
+        "--iree-stream-experimental-specialize-encodings",
     ],
     generator = ":generate_e2e_matmul_tests",
     generator_args = [
@@ -331,6 +334,7 @@ X86_64_AVX512_BF16 = X86_64_AVX512 + [
     compiler_flags = [
         "--iree-opt-data-tiling",
         "--iree-global-opt-enable-early-materialization=false",
+        "--iree-stream-experimental-specialize-encodings",
     ],
     generator = ":generate_e2e_matmul_tests",
     generator_args = [

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -537,6 +537,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     "--iree-opt-data-tiling"
     "--iree-global-opt-enable-early-materialization=false"
+    "--iree-stream-experimental-specialize-encodings"
     "--iree-llvmcpu-enable-ukernels=none"
   LABELS
 
@@ -566,6 +567,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     "--iree-opt-data-tiling"
     "--iree-global-opt-enable-early-materialization=false"
+    "--iree-stream-experimental-specialize-encodings"
     "--iree-llvmcpu-enable-ukernels=none"
   LABELS
 
@@ -594,6 +596,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     "--iree-opt-data-tiling"
     "--iree-global-opt-enable-early-materialization=false"
+    "--iree-stream-experimental-specialize-encodings"
     "--iree-llvmcpu-enable-ukernels=none"
   LABELS
     "noriscv"
@@ -624,6 +627,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     "--iree-opt-data-tiling"
     "--iree-global-opt-enable-early-materialization=false"
+    "--iree-stream-experimental-specialize-encodings"
     "--iree-llvmcpu-enable-ukernels=none"
   LABELS
     "noriscv"
@@ -654,6 +658,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     "--iree-opt-data-tiling"
     "--iree-global-opt-enable-early-materialization=false"
+    "--iree-stream-experimental-specialize-encodings"
     "--iree-llvmcpu-enable-ukernels=none"
   LABELS
     "noriscv"
@@ -685,6 +690,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     "--iree-opt-data-tiling"
     "--iree-global-opt-enable-early-materialization=false"
+    "--iree-stream-experimental-specialize-encodings"
     "--iree-llvmcpu-enable-ukernels=none"
   LABELS
     "noriscv"
@@ -716,6 +722,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     "--iree-opt-data-tiling"
     "--iree-global-opt-enable-early-materialization=false"
+    "--iree-stream-experimental-specialize-encodings"
     "--iree-llvmcpu-enable-ukernels=all"
   LABELS
 
@@ -745,6 +752,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     "--iree-opt-data-tiling"
     "--iree-global-opt-enable-early-materialization=false"
+    "--iree-stream-experimental-specialize-encodings"
     "--iree-llvmcpu-enable-ukernels=all"
   LABELS
 
@@ -773,6 +781,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     "--iree-opt-data-tiling"
     "--iree-global-opt-enable-early-materialization=false"
+    "--iree-stream-experimental-specialize-encodings"
     "--iree-llvmcpu-enable-ukernels=all"
   LABELS
     "noriscv"
@@ -803,6 +812,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     "--iree-opt-data-tiling"
     "--iree-global-opt-enable-early-materialization=false"
+    "--iree-stream-experimental-specialize-encodings"
     "--iree-llvmcpu-enable-ukernels=all"
   LABELS
     "noriscv"
@@ -833,6 +843,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     "--iree-opt-data-tiling"
     "--iree-global-opt-enable-early-materialization=false"
+    "--iree-stream-experimental-specialize-encodings"
     "--iree-llvmcpu-enable-ukernels=all"
   LABELS
     "noriscv"
@@ -864,6 +875,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     "--iree-opt-data-tiling"
     "--iree-global-opt-enable-early-materialization=false"
+    "--iree-stream-experimental-specialize-encodings"
     "--iree-llvmcpu-enable-ukernels=all"
   LABELS
     "noriscv"
@@ -896,6 +908,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     "--iree-opt-data-tiling"
     "--iree-global-opt-enable-early-materialization=false"
+    "--iree-stream-experimental-specialize-encodings"
   LABELS
 
 )
@@ -920,6 +933,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     "--iree-opt-data-tiling"
     "--iree-global-opt-enable-early-materialization=false"
+    "--iree-stream-experimental-specialize-encodings"
   LABELS
 
 )
@@ -944,6 +958,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     "--iree-opt-data-tiling"
     "--iree-global-opt-enable-early-materialization=false"
+    "--iree-stream-experimental-specialize-encodings"
   LABELS
 
 )
@@ -968,6 +983,7 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     "--iree-opt-data-tiling"
     "--iree-global-opt-enable-early-materialization=false"
+    "--iree-stream-experimental-specialize-encodings"
   LABELS
 
 )


### PR DESCRIPTION
The revision adds the encoding attributes to CPU and VMVX configurations, and switch late materialization path to use the attributes. I.e., the encoding specialization pass is enabled in the test suite.

The pass is still experimental. It is close to be ready for default, but there are still some remaining work. The revision enables an e2e test for the pass, which also can prevent post-failures of affinity analysis in advance.

If the encodings are present (e.g., like CPU/VMVX backends), they are used to specialize the encodings. If not (e.g., like vulkan/cuda/amdgpu/etc), they drop the encodings in the specialization.