### PR TITLE
Support cloning operand-less dispatches

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/Affinity.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/Affinity.cpp
@@ -723,26 +723,11 @@ void OpAffinityPVS::initializeOperation(Operation *op, DFX::Solver &solver) {
 ChangeStatus OpAffinityPVS::updateOperation(Operation *op,
                                             DFX::Solver &solver) {
   StateType newState;
-
-  const bool consumesAny = llvm::any_of(
-      op->getOperandTypes(), +[](Type type) {
-        return isa<IREE::Stream::AffinityTypeInterface>(type);
-      });
-  if (consumesAny) {
-    for (auto operand : op->getOperands()) {
-      if (isa<IREE::Stream::AffinityTypeInterface>(operand.getType())) {
-        auto valuePVS = solver.getElementFor<ValueProducerAffinityPVS>(
-            *this, Position::forValue(operand), DFX::Resolution::REQUIRED);
-        newState ^= valuePVS;
-      }
-    }
-  } else {
-    for (auto result : op->getResults()) {
-      if (isa<IREE::Stream::AffinityTypeInterface>(result.getType())) {
-        auto valuePVS = solver.getElementFor<ValueConsumerAffinityPVS>(
-            *this, Position::forValue(result), DFX::Resolution::REQUIRED);
-        newState ^= valuePVS;
-      }
+  for (auto operand : op->getOperands()) {
+    if (isa<IREE::Stream::AffinityTypeInterface>(operand.getType())) {
+      auto valuePVS = solver.getElementFor<ValueProducerAffinityPVS>(
+          *this, Position::forValue(operand), DFX::Resolution::REQUIRED);
+      newState ^= valuePVS;
     }
   }
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/Partitioning/ReferencePartitioning.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/Partitioning/ReferencePartitioning.cpp
@@ -99,11 +99,11 @@ partitionStreamableOpsReference(IREE::Stream::PartitioningConfigAttr config,
     IREE::Stream::AffinityAttr affinityAttr;
     if (auto affinityOp = dyn_cast<IREE::Stream::AffinityOpInterface>(op))
       affinityAttr = affinityOp.getAffinityAttr();
-    if (!IREE::Stream::AffinityAttr::canExecuteTogether(
+    bool preferCloneToConsumers = streamableOp.preferCloneToConsumers();
+    if (!preferCloneToConsumers && !IREE::Stream::AffinityAttr::canExecuteTogether(
             affinityAttr, builders[partitionOrdinal]->affinity))
       return false;
 
-    bool preferCloneToConsumers = streamableOp.preferCloneToConsumers();
     llvm::BitVector *opHazards = nullptr;
     llvm::BitVector opHazardsInCandidatePartition;
     if (preferCloneToConsumers) {

--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/Partitioning/ReferencePartitioning.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/Partitioning/ReferencePartitioning.cpp
@@ -100,7 +100,8 @@ partitionStreamableOpsReference(IREE::Stream::PartitioningConfigAttr config,
     if (auto affinityOp = dyn_cast<IREE::Stream::AffinityOpInterface>(op))
       affinityAttr = affinityOp.getAffinityAttr();
     bool preferCloneToConsumers = streamableOp.preferCloneToConsumers();
-    if (!preferCloneToConsumers && !IREE::Stream::AffinityAttr::canExecuteTogether(
+    if (!preferCloneToConsumers &&
+        !IREE::Stream::AffinityAttr::canExecuteTogether(
             affinityAttr, builders[partitionOrdinal]->affinity))
       return false;
 

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -2189,6 +2189,15 @@ TensorDispatchOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
                                   getWorkload(), symbolTable);
 }
 
+bool TensorDispatchOp::preferCloneToConsumers() {
+  for (auto operand : getMixedOperands()) {
+    if (isa<Stream::ResourceType>(operand.getType())) {
+      return false;
+    }
+  }
+  return true;
+}
+
 std::pair<unsigned, unsigned>
 TensorDispatchOp::getTiedOperandsIndexAndLength() {
   return getODSOperandIndexAndLength(1); // $operands

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -2644,6 +2644,15 @@ static void printDispatchOperands(OpAsmPrinter &p, Operation *op,
   p << ")";
 }
 
+bool AsyncDispatchOp::preferCloneToConsumers() {
+  for (auto operand : getResourceOperands()) {
+    if (isa<Stream::ResourceType>(operand.getType())) {
+      return false;
+    }
+  }
+  return true;
+}
+
 LogicalResult AsyncDispatchOp::verify() {
   AsyncDispatchOp op = *this;
   if (failed(verifyOpValueSizes(op, op.getResourceOperands(),

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -1744,7 +1744,9 @@ def Stream_TensorDispatchOp : Stream_Op<"tensor.dispatch", [
   DeclareOpInterfaceMethods<SymbolUserOpInterface>,
   Stream_AffinityOp,
   Stream_TensorPhaseOp,
-  Stream_StreamableOp,
+  DeclareOpInterfaceMethods<Stream_StreamableOp, [
+    "preferCloneToConsumers",
+  ]>,
   Util_SizeAwareOp,
   DeclareOpInterfaceMethods<Util_TiedOpInterface, [
     "getTiedOperandsIndexAndLength",

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -2493,7 +2493,9 @@ def Stream_AsyncDispatchOp : Stream_Op<"async.dispatch", [
   DeclareOpInterfaceMethods<SymbolUserOpInterface>,
   Stream_AffinityOp,
   Stream_AsyncPhaseOp,
-  Stream_StreamableOp,
+  DeclareOpInterfaceMethods<Stream_StreamableOp, [
+    "preferCloneToConsumers",
+  ]>,
   DeclareOpInterfaceMethods<Stream_AsyncAccessOp, [
     "getAsyncAccessRanges",
   ]>,

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
@@ -163,6 +163,10 @@ struct ExecutePartitionBuilder {
         affinityOp.setAffinityAttr(nullptr);
       }
 
+      // Any op that prefers being cloned to consumers doesn't need to specify
+      // an affinity as it can be no more specialized than any valid consumer
+      // of it. Clearing the affinity here may allow the target a greater
+      // ability to optimize the operation.
       auto streamableOp =
           dyn_cast<IREE::Stream::StreamableOpInterface>(clonedOp);
       if (streamableOp && streamableOp.preferCloneToConsumers()) {

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
@@ -162,6 +162,12 @@ struct ExecutePartitionBuilder {
       if (affinityOp.getAffinityAttr() == partition->affinity) {
         affinityOp.setAffinityAttr(nullptr);
       }
+
+      auto streamableOp =
+          dyn_cast<IREE::Stream::StreamableOpInterface>(clonedOp);
+      if (streamableOp && streamableOp.preferCloneToConsumers()) {
+        affinityOp.setAffinityAttr(nullptr);
+      }
     }
 
     return true;


### PR DESCRIPTION
Any dispatch that does not consume a resource can be placed on any device. If so we can clone this to every device to avoid transferring or access across device memory.