### PR TITLE
[DT][GPU] Implement EncodingLayoutResolverAttrInterface for GPUEncodingLayoutAttr.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
@@ -80,13 +80,18 @@ materializeFuncOpEncodings(FunctionOpInterface funcOp,
     } else if (isROCMBackend(targetAttr)) {
       LDBG("Select GPUEncodingLayoutAttr attribute as the layout attribute.");
       layoutAttr = cast<IREE::Codegen::LayoutAttrInterface>(
-          IREE::GPU::GPUEncodingLayoutAttr::get(ctx,
-                                                getGPUTargetAttr(targetAttr)));
+          IREE::GPU::GPUEncodingLayoutAttr::get(
+              ctx, DictionaryAttr::get(
+                       ctx, NamedAttribute(kGPUTargetAttrName,
+                                           getGPUTargetAttr(targetAttr)))));
     } else if (testCLGPUTarget) {
       LDBG("Select GPUEncodingLayoutAttr attribute as the layout attribute. "
            "(testCLGPUTarget)");
       layoutAttr = cast<IREE::Codegen::LayoutAttrInterface>(
-          IREE::GPU::GPUEncodingLayoutAttr::get(ctx, getCLGPUTarget(ctx)));
+          IREE::GPU::GPUEncodingLayoutAttr::get(
+              ctx,
+              DictionaryAttr::get(ctx, NamedAttribute(kGPUTargetAttrName,
+                                                      getCLGPUTarget(ctx)))));
     } else {
       LDBG("Select EncodingNopLayoutAttr attribute as the layout attribute.");
       layoutAttr = IREE::Codegen::EncodingNopLayoutAttr::get(ctx);

--- a/compiler/src/iree/compiler/Codegen/Common/test/llvmcpu_materialize_encoding.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/llvmcpu_materialize_encoding.mlir
@@ -2959,7 +2959,7 @@ func.func @broadcast_K() attributes {
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-#executable_target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz", cpu_features = "+avx512f", encoding = #iree_cpu.cpu_encoding_layout<>}>
+#executable_target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz", cpu_features = "+avx512f"}>
 #encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], layouts = [#iree_cpu.cpu_encoding_layout<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [1, 1], outerDimsPerm = [0, 1]}}>]>
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
@@ -2990,7 +2990,7 @@ func.func @set_encoding_LHS_with_layout() attributes {
 // -----
 
 #encoding = #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f32, f32, f32], layouts = [#iree_cpu.cpu_encoding_layout<configuration = {encoding_info = {innerDimsPos = [1, 0], innerTileSizes = [16, 1], outerDimsPerm = [1, 0]}}>]>
-#executable_target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz", cpu_features = "+avx512f", encoding = #iree_cpu.cpu_encoding_layout<>}>
+#executable_target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz", cpu_features = "+avx512f"}>
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
@@ -3023,7 +3023,7 @@ func.func @set_encoding_RHS_with_layout() attributes {
 // -----
 
 #encoding = #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f32, f32, f32], layouts = [#iree_cpu.cpu_encoding_layout<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [1, 16], outerDimsPerm = [0, 1]}}>]>
-#executable_target = #hal.executable.target<"llvm-cpu", "xyz", {cpu_features = "+avx512f", encoding = #iree_cpu.cpu_encoding_layout<>, target_triple = "x86_64-xyz-xyz"}>
+#executable_target = #hal.executable.target<"llvm-cpu", "xyz", {cpu_features = "+avx512f", target_triple = "x86_64-xyz-xyz"}>
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.cpp
@@ -283,7 +283,11 @@ getExpandedTileShape(const TileSwizzle::ExpandShapeType &expandShape) {
 MaterializeEncodingInfo
 getEncodingInfoForMatmul(Encoding::EncodingAttr encoding, TileMxNxK tileMxNxK) {
   MaterializeEncodingInfo encodingInfo;
-  auto cDims = getEncodingContractionDims(encoding);
+  FailureOr<linalg::ContractionDimensions> cDims =
+      getEncodingContractionDims(encoding);
+  if (failed(cDims)) {
+    return encodingInfo;
+  }
   // The following expects M, N, K, and Batch sizes of at most 1 for now
   assert(cDims->m.size() <= 1 && cDims->n.size() <= 1 && cDims->k.size() == 1 &&
          cDims->batch.size() <= 1 &&

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -295,9 +295,8 @@ def IREEGPU_GPUEncodingLayoutAttr :
   let assemblyFormat = "`<` struct(params) `>`";
 
   let parameters = (ins
-    OptionalParameter<"::mlir::iree_compiler::IREE::GPU::TargetAttr",
-     "IREE GPU target attribute. It is expected to be used in a pass scope, "
-     "but not the final IR output.">:$targetAttr
+    OptionalParameter<"DictionaryAttr", "Executable target configuration. It is "
+     "expected to be used in a pass scope, but not the final IR output.">:$configuration
   );
 }
 

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -54,17 +54,6 @@ namespace {
 // Utilities.
 //===----------------------------------------------------------------------===//
 
-/// Appends the NamedAttribute into `config` if there is a `name` NamedAttribute
-/// in the `dictAttr`.
-static void storeNamedAttrIfPresent(SmallVectorImpl<NamedAttribute> &config,
-                                    DictionaryAttr dictAttr, StringRef name) {
-  auto attr = dictAttr.getNamed(name);
-  if (!attr) {
-    return;
-  }
-  config.push_back(attr.value());
-}
-
 static void transposeInPlace(MaterializeEncodingInfo &info) {
   // Vector cases: nothing to do.
   if (info.innerTileSizes.size() < 2) {

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.cpp
@@ -102,4 +102,13 @@ DictionaryAttr getLayoutImpl(Attribute attr, RankedTensorType type) {
       ctx, NamedAttribute(kEncodingInfoAttrName, encodingInfoAttr));
 }
 
+void storeNamedAttrIfPresent(SmallVectorImpl<NamedAttribute> &config,
+                             DictionaryAttr dictAttr, StringRef name) {
+  auto attr = dictAttr.getNamed(name);
+  if (!attr) {
+    return;
+  }
+  config.push_back(attr.value());
+}
+
 } // namespace mlir::iree_compiler::IREE

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.h
@@ -25,6 +25,11 @@ Value calculateStorageSizeInBytesImpl(Attribute attr, Location loc,
 /// Requirement: `attr` must implement IREE::Codegen::LayoutAttrInterface.
 DictionaryAttr getLayoutImpl(Attribute attr, RankedTensorType type);
 
+/// Appends the NamedAttribute into `config` if there is a `name` NamedAttribute
+/// in the `dictAttr`.
+void storeNamedAttrIfPresent(SmallVectorImpl<NamedAttribute> &config,
+                             DictionaryAttr dictAttr, StringRef name);
+
 } // namespace mlir::iree_compiler::IREE
 
 #endif // IREE_COMPILER_CODEGEN_EXTERNALINTERFACES_UTILSS_H_

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -183,14 +183,15 @@ FailureOr<ArrayAttr> getSupportedMmaTypes(DictionaryAttr config);
 FailureOr<ArrayAttr> getSupportedMmaTypes(mlir::FunctionOpInterface entryPoint);
 
 /// Returns the GPU target attribute from `iree-gpu-test-target` if provided.
-/// Returns null TargetAttr othersise.
+/// Returns null TargetAttr otherwise.
 IREE::GPU::TargetAttr getCLGPUTarget(MLIRContext *context);
 
-/// Returns the GPU target attribute from executable |target| if found.
-/// Returns null TargetAttr othersise.
-IREE::GPU::TargetAttr getGPUTargetAttr(IREE::HAL::ExecutableTargetAttr target);
+/// Returns the GPU target attribute from attribute `attr` if found. The `attr`
+/// can be either IREE::HAL::ExecutableTargetAttr or DictionaryAttr.
+/// Returns null TargetAttr otherwise.
+IREE::GPU::TargetAttr getGPUTargetAttr(Attribute attr);
 /// Returns the GPU target attribute from the executable target wrapping |op|
-/// if found. Returns null TargetAttr othersise.
+/// if found. Returns null TargetAttr otherwise.
 IREE::GPU::TargetAttr getGPUTargetAttr(Operation *op);
 
 /// Returns the GPU subgroup size chosen for the current CodeGen pipeline if


### PR DESCRIPTION
Implements the EncodingLayoutAttrInterface (`cloneWithSimplifiedConfig` and `getLayout` methods) for GPU.

This replaces the `targetAttr` field in `GPUEncodingLayoutAttr` with a dictionary for storing the serialized encoding info.

This PR also removes an unused /unneeded `encoding = #iree_cpu.cpu_encoding_layout<>` attribute from the llvmcpu encoding materialization tests which leads to confusion on what this does. 

I will implement the SerializedEncodingLayoutAttrInterface in a separate PR.