### PR TITLE
Allow preferCloneToConsumer ops to ignore affinities.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
@@ -162,7 +162,7 @@ struct ResourceDeallocaOpPattern
     Value signalFence = getOrCreateSignalFence(
         loc, device, deallocaOp.getResultTimepoint(), rewriter);
 
-    // Queue allocation.
+    // Queue deallocation.
     rewriter.create<IREE::HAL::DeviceQueueDeallocaOp>(
         loc, device, queueAffinity, waitFence, signalFence,
         adaptor.getOperand());

--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/Partitioning/ReferencePartitioning.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/Partitioning/ReferencePartitioning.cpp
@@ -85,8 +85,9 @@ partitionStreamableOpsReference(IREE::Stream::PartitioningConfigAttr config,
     // If we are to make partition with ordinal targetOrdinal to
     // depend on partition with ordinal sourceOrdinal,
     // will this create a circular dependency.
-    if (sourceOrdinal == targetOrdinal)
+    if (sourceOrdinal == targetOrdinal) {
       return false;
+    }
     return builders[sourceOrdinal]->hazards.size() > targetOrdinal &&
            builders[sourceOrdinal]->hazards[targetOrdinal];
   };
@@ -94,16 +95,35 @@ partitionStreamableOpsReference(IREE::Stream::PartitioningConfigAttr config,
   auto canAddOpToPartition = [&](Operation &op, OpInfo &opInfo,
                                  unsigned partitionOrdinal) {
     auto streamableOp = dyn_cast<IREE::Stream::StreamableOpInterface>(op);
-    if (!streamableOp)
+    if (!streamableOp) {
       return false;
-    IREE::Stream::AffinityAttr affinityAttr;
-    if (auto affinityOp = dyn_cast<IREE::Stream::AffinityOpInterface>(op))
-      affinityAttr = affinityOp.getAffinityAttr();
-    if (!IREE::Stream::AffinityAttr::canExecuteTogether(
-            affinityAttr, builders[partitionOrdinal]->affinity))
-      return false;
+    }
 
-    bool preferCloneToConsumers = streamableOp.preferCloneToConsumers();
+    // Most ops should have affinity at this point. If they do not then we allow
+    // them to be placed anywhere (and whatever performance implications that
+    // has is on the higher layers for not explicitly saying).
+    IREE::Stream::AffinityAttr affinityAttr;
+    if (auto affinityOp = dyn_cast<IREE::Stream::AffinityOpInterface>(op)) {
+      affinityAttr = affinityOp.getAffinityAttr();
+    }
+
+    // If the op prefers to be cloned we can ignore its affinity to place it
+    // with its consumers in the current partition. This does risk increasing
+    // memory consumption, though, so we only do it in cases where the user has
+    // not told us to be careful.
+    const bool preferCloneToConsumers = streamableOp.preferCloneToConsumers();
+    const bool canCloneOp =
+        preferCloneToConsumers &&
+        config.getFavor().getValue() != IREE::Stream::Favor::MinPeakMemory;
+
+    // In order to add the op to the partition it must be either cloneable or
+    // able to execute together with the existing work in the partition.
+    if (!canCloneOp &&
+        !IREE::Stream::AffinityAttr::canExecuteTogether(
+            affinityAttr, builders[partitionOrdinal]->affinity)) {
+      return false;
+    }
+
     llvm::BitVector *opHazards = nullptr;
     llvm::BitVector opHazardsInCandidatePartition;
     if (preferCloneToConsumers) {
@@ -115,11 +135,13 @@ partitionStreamableOpsReference(IREE::Stream::PartitioningConfigAttr config,
       // it should not produce invalid partitioning.
       opHazards = &opHazardsInCandidatePartition;
       for (auto user : op.getUsers()) {
-        if (builders[partitionOrdinal]->ops.contains(user))
+        if (builders[partitionOrdinal]->ops.contains(user)) {
           opHazardsInCandidatePartition |= opInfos[user].hazards;
+        }
       }
-    } else
+    } else {
       opHazards = &opInfo.hazards;
+    }
 
     for (auto opHazardOrdinal : opHazards->set_bits()) {
       if (partitionOrdinal < opHazardOrdinal) {
@@ -132,8 +154,9 @@ partitionStreamableOpsReference(IREE::Stream::PartitioningConfigAttr config,
       }
       // Check for formation of circular dependency between partitions.
       if (willCreateCircularDependencyBetweenPartitions(opHazardOrdinal,
-                                                        partitionOrdinal))
+                                                        partitionOrdinal)) {
         return false;
+      }
     }
     return true;
   };
@@ -182,8 +205,9 @@ partitionStreamableOpsReference(IREE::Stream::PartitioningConfigAttr config,
       if (streamable && srcAffinity && srcAffinity.getAffinityAttr() &&
           IREE::Stream::AffinityAttr::canExecuteTogether(
               opAffinity.getAffinityAttr(), srcAffinity.getAffinityAttr())) {
-        if (!syncOps.contains(producer))
+        if (!syncOps.contains(producer)) {
           syncOps[producer] = llvm::SmallVector<Operation *>();
+        }
         syncOps[producer].push_back(&op);
         continue;
       }
@@ -210,8 +234,9 @@ partitionStreamableOpsReference(IREE::Stream::PartitioningConfigAttr config,
     llvm::BitVector consumers(builders.size(), /*t=*/false);
     for (auto user : op.getUsers()) {
       auto userInfoIt = opInfos.find(user);
-      if (userInfoIt == opInfos.end())
+      if (userInfoIt == opInfos.end()) {
         continue;
+      }
       auto &userInfo = userInfoIt->second;
       LLVM_DEBUG({
         llvm::dbgs() << "Testing user:\n";
@@ -232,8 +257,9 @@ partitionStreamableOpsReference(IREE::Stream::PartitioningConfigAttr config,
     for (auto syncOp : syncOps[&op]) {
       for (auto user : syncOp->getUsers()) {
         auto userInfoIt = opInfos.find(user);
-        if (userInfoIt == opInfos.end())
+        if (userInfoIt == opInfos.end()) {
           continue;
+        }
         auto &userInfo = userInfoIt->second;
         opInfo.hazards |= userInfo.membership;
         opInfo.hazards |= userInfo.hazards;
@@ -465,8 +491,9 @@ partitionRegionConcurrencyReference(IREE::Stream::PartitioningConfigAttr config,
     // dependency chain down the use-def chain to a wave.
     for (auto user : op.getUsers()) {
       auto userInfoIt = opInfos.find(user);
-      if (userInfoIt == opInfos.end())
+      if (userInfoIt == opInfos.end()) {
         continue;
+      }
       auto &userInfo = userInfoIt->second;
       LLVM_DEBUG({
         llvm::dbgs() << "Testing user:\n";
@@ -495,18 +522,22 @@ partitionRegionConcurrencyReference(IREE::Stream::PartitioningConfigAttr config,
     // For each resource operand of this op we scan back through previously
     // created waves to see if there are any partitioned ops that have a hazard.
     for (auto operand : op.getOperands()) {
-      if (!isa<IREE::Stream::ResourceType>(operand.getType()))
+      if (!isa<IREE::Stream::ResourceType>(operand.getType())) {
         continue;
+      }
       for (auto user : operand.getUsers()) {
         if (user == &op || user->getBlock() != block ||
-            user->isBeforeInBlock(&op))
+            user->isBeforeInBlock(&op)) {
           continue;
+        }
         auto tiedOp = dyn_cast<IREE::Util::TiedOpInterface>(user);
-        if (!tiedOp || !tiedOp.hasAnyTiedUses(operand))
+        if (!tiedOp || !tiedOp.hasAnyTiedUses(operand)) {
           continue;
+        }
         auto userInfoIt = opInfos.find(user);
-        if (userInfoIt == opInfos.end())
+        if (userInfoIt == opInfos.end()) {
           continue;
+        }
         auto &userInfo = userInfoIt->second;
         LLVM_DEBUG({
           llvm::dbgs() << "Testing tied user:\n";

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -2718,6 +2718,16 @@ void AsyncDispatchOp::getAsyncAccessRanges(
   }
 }
 
+bool AsyncDispatchOp::preferCloneToConsumers() {
+  // If the dispatch does not consume any resources then it is effectively a
+  // slow splat and should be treated like one.
+  const bool consumesAny = llvm::any_of(
+      getResourceOperands(), +[](Value operand) {
+        return isa<IREE::Stream::AffinityTypeInterface>(operand.getType());
+      });
+  return !consumesAny;
+}
+
 //===----------------------------------------------------------------------===//
 // stream.async.func
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -2497,7 +2497,9 @@ def Stream_AsyncDispatchOp : Stream_Op<"async.dispatch", [
   DeclareOpInterfaceMethods<SymbolUserOpInterface>,
   Stream_AffinityOp,
   Stream_AsyncPhaseOp,
-  Stream_StreamableOp,
+  DeclareOpInterfaceMethods<Stream_StreamableOp, [
+    "preferCloneToConsumers",
+  ]>,
   DeclareOpInterfaceMethods<Stream_AsyncAccessOp, [
     "getAsyncAccessRanges",
   ]>,

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/schedule_execution.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/schedule_execution.mlir
@@ -275,35 +275,35 @@ util.func public @partitioningWithConcurrentAffinities(%arg0: !stream.resource<e
 //    ↓    ↓
 // P2 4    5 P3
 //
-// CHECK-LABEL: @partitionWithInterdependentInterleavedDeviceAffinites
-util.func public @partitionWithInterdependentInterleavedDeviceAffinites(
-// CHECK-SAME: (%[[ARG0:.+]]: !stream.resource<external>,
+// CHECK-LABEL: @partitionWithInterdependentInterleavedDeviceAffinities
+util.func public @partitionWithInterdependentInterleavedDeviceAffinities(
+  // CHECK-SAME: (%[[ARG0:.+]]: !stream.resource<external>,
   %arg0: !stream.resource<external>,
-// CHECK-SAME: %[[ARG1:.+]]: !stream.resource<external>)
+  // CHECK-SAME: %[[ARG1:.+]]: !stream.resource<external>)
   %arg1: !stream.resource<external>) -> (!stream.resource<external>, !stream.resource<external>) {
   // CHECK: %[[C1:.+]] = arith.constant 1 : index
   %c1 = arith.constant 1 : index
 
   %0 = stream.async.dispatch on(#hal.device.affinity<@device_0>) @ex::@e00[%c1](
     %arg0[%c1 to %c1 for %c1]
-    ) : (!stream.resource<external>{%c1}) -> !stream.resource<transient>{%c1}
+  ) : (!stream.resource<external>{%c1}) -> !stream.resource<transient>{%c1}
   %1 = stream.async.dispatch on(#hal.device.affinity<@device_1>) @ex::@e01[%c1](
     %arg1[%c1 to %c1 for %c1]
-    ) : (!stream.resource<external>{%c1}) -> !stream.resource<transient>{%c1}
+  ) : (!stream.resource<external>{%c1}) -> !stream.resource<transient>{%c1}
 
   %2 = stream.async.dispatch on(#hal.device.affinity<@device_0>) @ex::@e10[%c1](
     %0[%c1 to %c1 for %c1], %1[%c1 to %c1 for %c1]
-    ) : (!stream.resource<transient>{%c1}, !stream.resource<transient>{%c1}) -> !stream.resource<transient>{%c1}
+  ) : (!stream.resource<transient>{%c1}, !stream.resource<transient>{%c1}) -> !stream.resource<transient>{%c1}
   %3 = stream.async.dispatch on(#hal.device.affinity<@device_1>) @ex::@e11[%c1](
     %0[%c1 to %c1 for %c1], %1[%c1 to %c1 for %c1]
-    ) : (!stream.resource<transient>{%c1}, !stream.resource<transient>{%c1}) -> !stream.resource<transient>{%c1}
+  ) : (!stream.resource<transient>{%c1}, !stream.resource<transient>{%c1}) -> !stream.resource<transient>{%c1}
 
   %4 = stream.async.dispatch on(#hal.device.affinity<@device_0>) @ex::@e20[%c1](
     %2[%c1 to %c1 for %c1], %3[%c1 to %c1 for %c1]
-    ) : (!stream.resource<transient>{%c1}, !stream.resource<transient>{%c1}) -> !stream.resource<external>{%c1}
+  ) : (!stream.resource<transient>{%c1}, !stream.resource<transient>{%c1}) -> !stream.resource<external>{%c1}
   %5 = stream.async.dispatch on(#hal.device.affinity<@device_1>) @ex::@e21[%c1](
     %2[%c1 to %c1 for %c1], %3[%c1 to %c1 for %c1]
-    ) : (!stream.resource<transient>{%c1}, !stream.resource<transient>{%c1}) -> !stream.resource<external>{%c1}
+  ) : (!stream.resource<transient>{%c1}, !stream.resource<transient>{%c1}) -> !stream.resource<external>{%c1}
 
   // Partition 0
   // CHECK: %[[RESULTS:.+]], %[[RESULT_TIMEPOINT:.+]] = stream.async.execute on(#hal.device.affinity<@device_0>)

--- a/compiler/src/iree/compiler/ExternalInterfaces/StreamExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/StreamExternalModels.cpp
@@ -19,6 +19,37 @@ namespace mlir::iree_compiler {
 namespace {
 
 template <typename OpT>
+struct PreferCloneToConsumersStreamableOpExternalModel
+    : public IREE::Stream::StreamableOpInterface::ExternalModel<
+          PreferCloneToConsumersStreamableOpExternalModel<OpT>, OpT> {
+  static void add(MLIRContext *context) {
+    OpT::template attachInterface<
+        PreferCloneToConsumersStreamableOpExternalModel<OpT>>(*context);
+  }
+
+  bool preferCloneToConsumers(Operation *op) const { return true; }
+};
+
+struct FlowDispatchStreamableOpExternalModel
+    : public IREE::Stream::StreamableOpInterface::ExternalModel<
+          FlowDispatchStreamableOpExternalModel, IREE::Flow::DispatchOp> {
+  static void add(MLIRContext *context) {
+    IREE::Flow::DispatchOp::attachInterface<
+        FlowDispatchStreamableOpExternalModel>(*context);
+  }
+
+  bool preferCloneToConsumers(Operation *op) const {
+    // If the dispatch does not consume any resources then it is effectively a
+    // slow splat and should be treated like one.
+    const bool consumesAny = llvm::any_of(
+        op->getOperandTypes(), +[](Type type) {
+          return isa<IREE::Stream::AffinityTypeInterface>(type);
+        });
+    return !consumesAny;
+  }
+};
+
+template <typename OpT>
 struct OptionalOpAffinityAttrExternalModel
     : public IREE::Stream::AffinityOpInterface::ExternalModel<
           OptionalOpAffinityAttrExternalModel<OpT>, OpT> {
@@ -193,8 +224,17 @@ void registerStreamExternalModels(DialectRegistry &registry) {
   registry.insert<IREE::Flow::FlowDialect>();
   registry.addExtension(+[](MLIRContext *context,
                             IREE::Flow::FlowDialect *dialect) {
+    PreferCloneToConsumersStreamableOpExternalModel<
+        IREE::Flow::TensorAllocaOp>::add(context);
+    PreferCloneToConsumersStreamableOpExternalModel<
+        IREE::Flow::TensorEmptyOp>::add(context);
+    PreferCloneToConsumersStreamableOpExternalModel<
+        IREE::Flow::TensorSplatOp>::add(context);
+    FlowDispatchStreamableOpExternalModel::add(context);
+
     FlowBarrierTargetAffinityAttrExternalModel::add(context);
     FlowTransferTargetAffinityAttrExternalModel::add(context);
+
     AffinityOpAttrExternalModel<IREE::Flow::DispatchRegionOp>::add(context);
     AffinityOpAttrExternalModel<IREE::Flow::DispatchWorkgroupsOp>::add(context);
     AffinityOpAttrExternalModel<IREE::Flow::DispatchOp>::add(context);


### PR DESCRIPTION
When favoring max-concurrency partitioning will now ignore affinities on ops with preferCloneToConsumers set. The common case where this is needed is splats, dispatches that take no operands (slow splats), and empty/allocs.

This will result in higher memory consumption as prior to this a splat pinned to a single affinity may end up being performed on one affinity and then used on other consumer affinities - now it'll be cloned to all consumers and each will need its own backing allocation. Because of this we limit this memory growth to only those cases where the user opts in. To opt-in the user can either pass `--iree-stream-partitioning-favor=max-concurrency` or add an attribute to their module (or function/etc scope): `stream.partitioning = #stream.partitioning_config<"max-concurrency">`.