### PR TITLE
Clarify error message for missing module dependencies.

### DIFF
--- a/runtime/src/iree/tooling/modules/resolver.c
+++ b/runtime/src/iree/tooling/modules/resolver.c
@@ -64,7 +64,8 @@ iree_status_t iree_tooling_resolve_module_dependency(
                                    IREE_VM_MODULE_DEPENDENCY_FLAG_REQUIRED)) {
     // Required but not found; fail.
     return iree_make_status(IREE_STATUS_NOT_FOUND,
-                            "required module '%.*s' not available in the build",
+                            "required module '%.*s' not available in the build "
+                            "(note: module registration order matters)",
                             (int)dependency->name.size, dependency->name.data);
   }
   *out_module = module;

--- a/runtime/src/iree/tooling/modules/resolver.c
+++ b/runtime/src/iree/tooling/modules/resolver.c
@@ -63,10 +63,12 @@ iree_status_t iree_tooling_resolve_module_dependency(
   if (!module && iree_all_bits_set(dependency->flags,
                                    IREE_VM_MODULE_DEPENDENCY_FLAG_REQUIRED)) {
     // Required but not found; fail.
-    return iree_make_status(IREE_STATUS_NOT_FOUND,
-                            "required module '%.*s' not available in the build "
-                            "(note: module registration order matters)",
-                            (int)dependency->name.size, dependency->name.data);
+    return iree_make_status(
+        IREE_STATUS_NOT_FOUND,
+        "required module '%.*s' not available in the build "
+        "(modules must be registered in order with dependent modules following "
+        "those they depend upon)",
+        (int)dependency->name.size, dependency->name.data);
   }
   *out_module = module;
   return iree_ok_status();


### PR DESCRIPTION
For pipelines like https://github.com/iree-org/iree/blob/main/experimental/benchmarks/sdxl/sdxl_pipeline_bench_f16.mlir, the order that each .vmfb module is passed to tooling matters.

Running for example
```bash
iree-run-module \
  --module=sdxl_full_pipeline_fp16_rocm.vmfb \
  --module=sdxl_clip_vmfbs/model.rocm_gfx942.vmfb \
  --module=sdxl_unet_fp16_vmfbs/model.rocm_gfx942.vmfb \
  --module=sdxl_vae_vmfbs/model.rocm_gfx942.vmfb \
  ...
```

instead of 

```diff
iree-run-module \
- --module=sdxl_full_pipeline_fp16_rocm.vmfb \
  --module=sdxl_clip_vmfbs/model.rocm_gfx942.vmfb \
  --module=sdxl_unet_fp16_vmfbs/model.rocm_gfx942.vmfb \
  --module=sdxl_vae_vmfbs/model.rocm_gfx942.vmfb \
+ --module=sdxl_full_pipeline_fp16_rocm.vmfb \
  ...
```

will hit this error message.