### PR TITLE
[Encoding] Clarify IREE::Encoding interfaces.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -313,10 +313,10 @@ def IREEGPU_GPUPadLayoutAttr : AttrDef<IREEGPU_Dialect, "GPUPadLayout"> {
   let description = [{
     Describes padding preferences for a given GPU target.
     This attribute can implement any encoding interface for data-tiling,
-    e.g., Encoding::EncodingLayoutAttrInterface, etc. They should be implemented
-    through external model mechanism because we do not want to relocate
-    domain-specific logic to the dialect implementation, and we can have better
-    code structure. See the implementation in
+    e.g., Encoding::EncodingLayoutResolverAttrInterface, etc. They should be
+    implemented through external model mechanism because we do not want to
+    relocate domain-specific logic to the dialect implementation, and we can
+    have better code structure. See the implementation in
     compiler/Codegen/ExternalInterfaces/*.
   }];
 

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -689,9 +689,9 @@ struct CPUHostEncodingLayoutAttrInterface final
   }
 };
 
-struct CPUHostSerializedEncodingLayoutAttrInterface final
-    : IREE::Encoding::SerializedEncodingLayoutAttrInterface::ExternalModel<
-          CPUHostSerializedEncodingLayoutAttrInterface, CPUEncodingLayoutAttr> {
+struct CPUHostSerializableEncodingAttrInterface final
+    : IREE::Encoding::SerializableEncodingAttrInterface::ExternalModel<
+          CPUHostSerializableEncodingAttrInterface, CPUEncodingLayoutAttr> {
 
   Value calculateStorageSizeInBytes(Attribute attr, Location loc,
                                     OpBuilder &builder, RankedTensorType type,
@@ -819,10 +819,9 @@ struct VMVXHostEncodingLayoutAttrInterface final
   }
 };
 
-struct VMVXHostSerializedEncodingLayoutAttrInterface final
-    : IREE::Encoding::SerializedEncodingLayoutAttrInterface::ExternalModel<
-          VMVXHostSerializedEncodingLayoutAttrInterface,
-          VMVXEncodingLayoutAttr> {
+struct VMVXHostSerializableEncodingAttrInterface final
+    : IREE::Encoding::SerializableEncodingAttrInterface::ExternalModel<
+          VMVXHostSerializableEncodingAttrInterface, VMVXEncodingLayoutAttr> {
   Value calculateStorageSizeInBytes(Attribute attr, Location loc,
                                     OpBuilder &builder, RankedTensorType type,
                                     ValueRange dynamicDims) const {
@@ -839,11 +838,11 @@ void registerCPUEncodingExternalModels(DialectRegistry &registry) {
         IREE::CPU::CPUEncodingLayoutAttr::attachInterface<
             CPUDeviceEncodingLayoutAttrInterface,
             CPUHostEncodingLayoutAttrInterface,
-            CPUHostSerializedEncodingLayoutAttrInterface>(*ctx);
+            CPUHostSerializableEncodingAttrInterface>(*ctx);
         IREE::CPU::VMVXEncodingLayoutAttr::attachInterface<
             VMVXDeviceEncodingLayoutAttrInterface,
             VMVXHostEncodingLayoutAttrInterface,
-            VMVXHostSerializedEncodingLayoutAttrInterface>(*ctx);
+            VMVXHostSerializableEncodingAttrInterface>(*ctx);
       });
 }
 

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -604,9 +604,9 @@ enumerateCPUMatmulTiles(IREE::Encoding::EncodingAttr encoding,
   return {};
 }
 
-struct CPUDeviceEncodingLayoutAttrInterface
+struct CPUDeviceEncodingLayoutResolverAttrInterface
     : public Codegen::LayoutAttrInterface::ExternalModel<
-          CPUDeviceEncodingLayoutAttrInterface, CPUEncodingLayoutAttr> {
+          CPUDeviceEncodingLayoutResolverAttrInterface, CPUEncodingLayoutAttr> {
   MaterializeEncodingInfo getEncodingInfo(Attribute attr,
                                           RankedTensorType type) const {
     auto layoutAttr = cast<CPUEncodingLayoutAttr>(attr);
@@ -670,9 +670,9 @@ struct CPUDeviceEncodingLayoutAttrInterface
   }
 };
 
-struct CPUHostEncodingLayoutAttrInterface final
-    : IREE::Encoding::EncodingLayoutAttrInterface::ExternalModel<
-          CPUHostEncodingLayoutAttrInterface, CPUEncodingLayoutAttr> {
+struct CPUHostEncodingLayoutResolverAttrInterface final
+    : IREE::Encoding::EncodingLayoutResolverAttrInterface::ExternalModel<
+          CPUHostEncodingLayoutResolverAttrInterface, CPUEncodingLayoutAttr> {
   Attribute cloneWithSimplifiedConfig(Attribute attr,
                                       DictionaryAttr config) const {
     MLIRContext *ctx = attr.getContext();
@@ -735,9 +735,10 @@ enumerateVMVXMatmulTiles(linalg::ContractionDimensions cDims,
   };
 }
 
-struct VMVXDeviceEncodingLayoutAttrInterface final
+struct VMVXDeviceEncodingLayoutResolverAttrInterface final
     : Codegen::LayoutAttrInterface::ExternalModel<
-          VMVXDeviceEncodingLayoutAttrInterface, VMVXEncodingLayoutAttr> {
+          VMVXDeviceEncodingLayoutResolverAttrInterface,
+          VMVXEncodingLayoutAttr> {
   MaterializeEncodingInfo getEncodingInfo(Attribute attr,
                                           RankedTensorType type) const {
     auto layoutAttr = cast<VMVXEncodingLayoutAttr>(attr);
@@ -801,9 +802,9 @@ struct VMVXDeviceEncodingLayoutAttrInterface final
   }
 };
 
-struct VMVXHostEncodingLayoutAttrInterface final
-    : IREE::Encoding::EncodingLayoutAttrInterface::ExternalModel<
-          VMVXHostEncodingLayoutAttrInterface, VMVXEncodingLayoutAttr> {
+struct VMVXHostEncodingLayoutResolverAttrInterface final
+    : IREE::Encoding::EncodingLayoutResolverAttrInterface::ExternalModel<
+          VMVXHostEncodingLayoutResolverAttrInterface, VMVXEncodingLayoutAttr> {
   Attribute cloneWithSimplifiedConfig(Attribute attr,
                                       DictionaryAttr config) const {
     MLIRContext *ctx = attr.getContext();
@@ -836,12 +837,12 @@ void registerCPUEncodingExternalModels(DialectRegistry &registry) {
   registry.addExtension(
       +[](MLIRContext *ctx, IREE::CPU::IREECPUDialect *dialect) {
         IREE::CPU::CPUEncodingLayoutAttr::attachInterface<
-            CPUDeviceEncodingLayoutAttrInterface,
-            CPUHostEncodingLayoutAttrInterface,
+            CPUDeviceEncodingLayoutResolverAttrInterface,
+            CPUHostEncodingLayoutResolverAttrInterface,
             CPUHostSerializableEncodingAttrInterface>(*ctx);
         IREE::CPU::VMVXEncodingLayoutAttr::attachInterface<
-            VMVXDeviceEncodingLayoutAttrInterface,
-            VMVXHostEncodingLayoutAttrInterface,
+            VMVXDeviceEncodingLayoutResolverAttrInterface,
+            VMVXHostEncodingLayoutResolverAttrInterface,
             VMVXHostSerializableEncodingAttrInterface>(*ctx);
       });
 }

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -6,7 +6,7 @@
 //===- GPUEncodingExternalModels.cpp --------------------------------------===//
 //
 // This file implements the IREE::Codegen::LayoutAttrInterface and
-// IREE::Encoding::EncodingLayoutAttrInterface for GPU backends.
+// IREE::Encoding::EncodingLayoutResolverAttrInterface for GPU backends.
 // Different from CPU backends, we do not transpose narrow-N to narrow-M for a
 // combination of reasons:
 //
@@ -298,9 +298,9 @@ static Operation *lowerContractionOpToMultiMmaOp(OpBuilder &builder,
   return mmaOp;
 }
 
-struct GPUDeviceEncodingLayoutAttrInterface
+struct GPUDeviceEncodingLayoutResolverAttrInterface
     : public Codegen::LayoutAttrInterface::ExternalModel<
-          GPUDeviceEncodingLayoutAttrInterface, GPUEncodingLayoutAttr> {
+          GPUDeviceEncodingLayoutResolverAttrInterface, GPUEncodingLayoutAttr> {
   MaterializeEncodingInfo getEncodingInfo(Attribute attr,
                                           RankedTensorType type) const {
     auto layoutAttr = cast<GPUEncodingLayoutAttr>(attr);
@@ -342,9 +342,9 @@ struct GPUDeviceEncodingLayoutAttrInterface
   }
 };
 
-struct GPUPadEncodingLayoutAttrInterface final
-    : Encoding::EncodingLayoutAttrInterface::ExternalModel<
-          GPUPadEncodingLayoutAttrInterface, GPUPadLayoutAttr> {
+struct GPUPadEncodingLayoutResolverAttrInterface final
+    : Encoding::EncodingLayoutResolverAttrInterface::ExternalModel<
+          GPUPadEncodingLayoutResolverAttrInterface, GPUPadLayoutAttr> {
   Attribute cloneWithSimplifiedConfig(Attribute attr,
                                       DictionaryAttr /*config*/) const {
     // This attribute is self-contained and does not need to look anything up
@@ -436,9 +436,9 @@ void registerGPUEncodingExternalModels(DialectRegistry &registry) {
   registry.addExtension(
       +[](MLIRContext *ctx, IREE::GPU::IREEGPUDialect *dialect) {
         IREE::GPU::GPUEncodingLayoutAttr::attachInterface<
-            GPUDeviceEncodingLayoutAttrInterface>(*ctx);
+            GPUDeviceEncodingLayoutResolverAttrInterface>(*ctx);
         IREE::GPU::GPUPadLayoutAttr::attachInterface<
-            GPUPadEncodingLayoutAttrInterface>(*ctx);
+            GPUPadEncodingLayoutResolverAttrInterface>(*ctx);
       });
 }
 

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -91,7 +91,7 @@ def EncodingAttr :
     OptionalParameter<"ArrayAttr", "An array of attributes that describes the "
     "potential layouts on the device. It is an array because a device could "
     "have several executable targets. Note that it can be any attribute that "
-    "implements EncodingLayoutAttrInterface. The expectation of the field "
+    "implements EncodingLayoutResolverAttrInterface. The expectation of the field "
     "is to bridge the logics between host codes and device codes. If an "
     "attribute does not implement the interface, it could be discarded anytime.">:$layouts
   );
@@ -148,7 +148,7 @@ def PadEncodingLayoutAttr : IREEEncoding_Attr<"PadEncodingLayout", [
     The logical dimensions of the tensors do not change, and the elements in the
     padded regions are left uninitialized.
 
-    This attribute implements `Encoding::SerializedEncodingLayoutAttrInterface`,
+    This attribute implements `Encoding::SerializedEncodingLayoutResolverAttrInterface`,
     to provide a hook for tensor sizeof lowering. The implementation of this
     interface is backend-agnostic, but the emission of the pad encoding attribute
     itself can be target- or domain-specific.
@@ -166,7 +166,7 @@ def PadEncodingLayoutAttr : IREEEncoding_Attr<"PadEncodingLayout", [
 
 def UnsupportedEncodingAttr :
     IREEEncoding_Attr<"UnsupportedEncoding", [
-      DeclareAttrInterfaceMethods<IREEEncoding_EncodingLayoutAttrInterface, [
+      DeclareAttrInterfaceMethods<IREEEncoding_EncodingLayoutResolverAttrInterface, [
         "cloneWithSimplifiedConfig",
         "getLayout",
       ]>
@@ -212,7 +212,7 @@ def TestingEncodingAttr :
 
 def UnspecializedEncodingAttr :
     IREEEncoding_Attr<"UnspecializedEncoding", [
-      DeclareAttrInterfaceMethods<IREEEncoding_EncodingLayoutAttrInterface, [
+      DeclareAttrInterfaceMethods<IREEEncoding_EncodingLayoutResolverAttrInterface, [
         "cloneWithSimplifiedConfig",
       ]>
     ]> {
@@ -222,7 +222,7 @@ def UnspecializedEncodingAttr :
 
   let description = [{
     This attribute indicates this is an unspecialized encoding. It implements
-    very basic interface methods of EncodingLayoutAttrInterface that converts
+    very basic interface methods of EncodingLayoutResolverAttrInterface that converts
     it to the SpecializeEncodingAttr during encoding specialization. It is
     mainly for testing purpose as some transformations do not depend on actual
     dialects that implement the attribute interface.
@@ -239,7 +239,7 @@ def UnspecializedEncodingAttr :
 
 def SpecializedEncodingAttr :
     IREEEncoding_Attr<"SpecializedEncoding", [
-      DeclareAttrInterfaceMethods<IREEEncoding_EncodingLayoutAttrInterface, [
+      DeclareAttrInterfaceMethods<IREEEncoding_EncodingLayoutResolverAttrInterface, [
         "getLayout",
       ]>
     ]> {

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -54,10 +54,9 @@ def PackedStorageAttr : IREEEncoding_Attr<"PackedStorage"> {
 
 def EncodingAttr :
     IREEEncoding_Attr<"Encoding", [
-      DeclareAttrInterfaceMethods<IREEEncoding_EncodingLayoutAttrInterface , [
+      DeclareAttrInterfaceMethods<IREEEncoding_SerializableEncodingAttrInterface, [
+        "isSerialized",
         "cloneWithLayouts",
-      ]>,
-      DeclareAttrInterfaceMethods<IREEEncoding_SerializedEncodingAttrInterface , [
         "calculateStorageSizeInBytes",
       ]>
     ]> {
@@ -137,7 +136,7 @@ def EncodingAttr :
 //===---------------------------------------------------------------------===//
 
 def PadEncodingLayoutAttr : IREEEncoding_Attr<"PadEncodingLayout", [
-      DeclareAttrInterfaceMethods<IREEEncoding_SerializedEncodingAttrInterface,
+      DeclareAttrInterfaceMethods<IREEEncoding_SerializableEncodingAttrInterface,
         ["calculateStorageSizeInBytes"]>
     ]> {
   let mnemonic = "pad_encoding_layout";
@@ -189,10 +188,10 @@ def UnsupportedEncodingAttr :
 
 def TestingEncodingAttr :
     IREEEncoding_Attr<"TestingEncoding", [
-      DeclareAttrInterfaceMethods<IREEEncoding_EncodingLayoutAttrInterface, [
+      DeclareAttrInterfaceMethods<IREEEncoding_SerializableEncodingAttrInterface, [
+        "isSerialized",
         "cloneWithLayouts",
-      ]>,
-      DeclareAttrInterfaceMethods<IREEEncoding_SerializedEncodingAttrInterface>
+      ]>
     ]> {
   let mnemonic = "testing_encoding";
   let summary = "An encoding attribute for testing purpose";

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
@@ -55,7 +55,7 @@ def IREEEncoding_EncodingLayoutAttrInterface :
       /*desc=*/[{
         Returns the an attribute implementing the  which is either common format
         or wrapped by an attribute that implements the
-        `SerializedEncodingLayoutAttrInterface` interface.
+        `SerializableEncodingAttrInterface` interface.
         If it is in common format (e.g., a regular tensor type), we can easily
         calculate the storage size. Otherwise, we will need a hook from
         external, and the hook can come from an attribute that implements the
@@ -72,12 +72,61 @@ def IREEEncoding_EncodingLayoutAttrInterface :
         assert(false && "unimplemented interface method");
         return {};
       }]
+    >
+  ];
+}
+
+def IREEEncoding_SerializableEncodingAttrInterface :
+  AttrInterface<"SerializableEncodingAttrInterface"> {
+  let cppNamespace = "::mlir::iree_compiler::IREE::Encoding";
+  let description = [{
+    Interface for encoding attributes that can be attached on a tensor type. An
+    encoding has two states, serialized and unserialized. An encoding can be set
+    with high level encoded information, e.g., operation type, element types of
+    operands, etc. During the lowering, the virtual encodings are progressively
+    lowered to physical encodings/operations. At some point, an encoding could
+    in the middle state, where the serialized data is encoded in the attribute.
+    I.e., the high level information is replaced with serialized information,
+    and they are no longer needed. The interface methods are intended to help
+    the lowering.
+
+    There are few core methods:
+
+    - isSerialized: checks if the encoding is serialized or not.
+    - cloneWithLayouts: creates a serializable encoding with the layouts
+      information.
+    - The rest of methods that interpret the encodings. E.g.,
+      calculateStorageSizeInBytes is the method to parse layouts and produce the
+      storage size in bytes.
+
+    The attributes implementing this interface may be target-specific or general
+    enough to be shared across backends, depending on the layouts used.
+
+    TBD: The serialization does not need to tie to layouts. It is the only use
+         case today, and could be relaxed in the future.
+  }];
+
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns true if the attribute already has the serialized information.
+        Otherwise, returns false.
+      }],
+      /*retTy=*/"bool",
+      /*methodName=*/"isSerialized",
+      /*args=*/(ins
+      ),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        assert(false && "unimplemented interface method");
+        return true;
+      }]
     >,
     InterfaceMethod<
       /*desc=*/[{
-        Clones an encoding with a new layout list. It is valid to drop any other
-        optional parameters used in layout resolving, because they are already
-        resolved and being attached to the encoding attribute.
+        Creates an encoding with a new layout list. It is valid to drop any
+        other optional parameters used in layout resolving, because they are
+        already resolved and being attached to the encoding attribute.
       }],
       /*retTy=*/"::mlir::Attribute",
       /*methodName=*/"cloneWithLayouts",
@@ -89,22 +138,7 @@ def IREEEncoding_EncodingLayoutAttrInterface :
         assert(false && "unimplemented interface method");
         return {};
       }]
-    >
-  ];
-}
-
-def IREEEncoding_SerializedEncodingAttrInterface :
-  AttrInterface<"SerializedEncodingLayoutAttrInterface"> {
-  let cppNamespace = "::mlir::iree_compiler::IREE::Encoding";
-  let description = [{
-    Interface used to query serialized layout information needed to materialize
-    encoding attributes.
-
-    The attributes implementing this interface may be target-specific or general
-    enough to be shared across backends, depending on the layouts used.
-  }];
-
-  let methods = [
+    >,
     InterfaceMethod<
       /*desc=*/[{
         Returns the storage size (in bytes) for the tensor types with an
@@ -139,7 +173,6 @@ def IREEEncoding_EncodingTypeInterface :
   let description = [{
     Interface used to access/update tensor types with encodings.
   }];
-
 
   let methods = [
     InterfaceMethod<

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
@@ -14,8 +14,8 @@ include "mlir/IR/BuiltinAttributeInterfaces.td"
 // Attribute Interfaces
 //===----------------------------------------------------------------------===//
 
-def IREEEncoding_EncodingLayoutAttrInterface :
-  AttrInterface<"EncodingLayoutAttrInterface"> {
+def IREEEncoding_EncodingLayoutResolverAttrInterface :
+  AttrInterface<"EncodingLayoutResolverAttrInterface"> {
   let cppNamespace = "::mlir::iree_compiler::IREE::Encoding";
   let description = [{
     Interface used to query layout information needed to materialize encoding

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
@@ -85,19 +85,19 @@ def IREEEncoding_SerializableEncodingAttrInterface :
     with high level encoded information, e.g., operation type, element types of
     operands, etc. During the lowering, the virtual encodings are progressively
     lowered to physical encodings/operations. At some point, an encoding could
-    in the middle state, where the serialized data is encoded in the attribute.
-    I.e., the high level information is replaced with serialized information,
-    and they are no longer needed. The interface methods are intended to help
-    the lowering.
+    in the middle state, where the final serialized data is encoded in the
+    attribute. I.e., the high level information is replaced with serialized
+    information, and they are no longer needed. The interface methods are
+    intended to help the lowering.
 
     There are few core methods:
 
-    - isSerialized: checks if the encoding is serialized or not.
-    - cloneWithLayouts: creates a serializable encoding with the layouts
+    - `isSerialized`: checks if the encoding is serialized or not.
+    - `cloneWithLayouts`: creates a serializable encoding with the layouts
       information.
     - The rest of methods that interpret the encodings. E.g.,
-      calculateStorageSizeInBytes is the method to parse layouts and produce the
-      storage size in bytes.
+      `calculateStorageSizeInBytes` is the method to parse layouts and produce
+      the storage size in bytes.
 
     The attributes implementing this interface may be target-specific or general
     enough to be shared across backends, depending on the layouts used.
@@ -109,8 +109,7 @@ def IREEEncoding_SerializableEncodingAttrInterface :
   let methods = [
     InterfaceMethod<
       /*desc=*/[{
-        Returns true if the attribute already has the serialized information.
-        Otherwise, returns false.
+        Returns true iff the attribute already has the serialized information.
       }],
       /*retTy=*/"bool",
       /*methodName=*/"isSerialized",

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Dialect/Encoding/IR/EncodingOps.h"
 
+#include "iree/compiler/Dialect/Encoding/IR/EncodingTypes.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
@@ -29,7 +30,7 @@ LogicalResult SetEncodingOp::verify() {
     return emitOpError(
         "source of set_encoding op cannot have a tensor encoding");
   }
-  if (!isa_and_nonnull<EncodingLayoutAttrInterface>(
+  if (!isa_and_nonnull<SerializableEncodingAttrInterface>(
           getResultType().getEncoding())) {
     return emitOpError(
         "result of set_encoding op expected to have a valid tensor encoding");
@@ -63,7 +64,7 @@ LogicalResult UnsetEncodingOp::verify() {
     return emitOpError(
         "result of unset_encoding op cannot have a tensor encoding");
   }
-  if (!isa_and_nonnull<EncodingLayoutAttrInterface>(
+  if (!isa_and_nonnull<SerializableEncodingAttrInterface>(
           getSourceType().getEncoding())) {
     return emitOpError(
         "source of unset_encoding op expected to have a valid tensor encoding");

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.td
@@ -30,8 +30,8 @@ def IREEEncoding_SetEncodingOp : IREEEncoding_PureOp<"set_encoding",[
   let description = [{
     Operation to assign an encoding to a tensor. The operation does not change
     the rank or extent of a tensor. Instead it adds an
-    EncodingLayoutAttrInterface attribute to the tensor type to represent a
-    change in layout.
+    EncodingLayoutResolverAttrInterface attribute to the tensor type to
+    represent a change in layout.
   }];
 
   let arguments = (ins AnyRankedTensor:$source);
@@ -62,8 +62,8 @@ def IREEEncoding_UnsetEncodingOp : IREEEncoding_PureOp<"unset_encoding", [
   ]> {
   let summary = "perfom unpack and extract operation on source";
   let description = [{
-    Operation to convert an tensor with EncodingLayoutAttrInterface encoding
-    that represents its data layout into a tensor with default layout
+    Operation to convert an tensor with EncodingLayoutResolverAttrInterface
+    encoding that represents its data layout into a tensor with default layout
     (i.e. no encoding). For now in IREE the default layout is row-major.
   }];
   let arguments = (ins

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.h
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.h
@@ -39,9 +39,9 @@
 namespace mlir::iree_compiler::IREE::Encoding {
 
 /// Returns the encoding attribute from the type if there is an encoding that
-/// implements EncodingLayoutAttrInterface. Otherwise, returns null.
-EncodingLayoutAttrInterface
-getEncodingLayoutAttrInterface(RankedTensorType type);
+/// implements SerializableEncodingAttrInterface. Otherwise, returns null.
+SerializableEncodingAttrInterface
+getSerializableEncodingAttrInterface(RankedTensorType type);
 
 /// Returns the encoding attribute from the type if there is an encoding.
 /// Otherwise, returns null.

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALDialect.cpp
@@ -125,7 +125,7 @@ public:
   using AffinityAnalysisDialectInterface::AffinityAnalysisDialectInterface;
 
   // Returns a function that gathers the corresponding
-  // EncodingLayoutAttrInterface attributes for each
+  // EncodingLayoutResolverAttrInterface attributes for each
   // (IREE::Stream::Affinity, Operation) query. The attribute is extracted from
   // the `encoding` field in the HAL::ExecutableTargetAttr configuration. If the
   // `encoding` is not present, UnsupportedEncodingAttr is returned.
@@ -162,7 +162,7 @@ public:
           }
           auto encodingLayoutAttr =
               targetAttr.getConfiguration()
-                  .getAs<IREE::Encoding::EncodingLayoutAttrInterface>(
+                  .getAs<IREE::Encoding::EncodingLayoutResolverAttrInterface>(
                       "encoding");
           if (!encodingLayoutAttr) {
             layoutAttrs[key].insert(getDefaultAttr());

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALDialect.cpp
@@ -142,22 +142,38 @@ public:
       }
 
       MLIRContext *ctx = getContext();
+      std::optional<IREE::Encoding::UnsupportedEncodingAttr> defaultAttr;
+      auto getDefaultAttr = [&]() {
+        if (defaultAttr) {
+          return defaultAttr.value();
+        }
+        defaultAttr = IREE::Encoding::UnsupportedEncodingAttr::get(ctx);
+        return defaultAttr.value();
+      };
       for (IREE::Stream::AffinityAndOpPair key : batchQueries) {
         auto [affinityAttr, op] = key;
         SetVector<IREE::HAL::ExecutableTargetAttr> resultSet;
         deviceAnalysis.gatherRequiredExecutableTargets(affinityAttr, op,
                                                        resultSet);
         for (auto targetAttr : resultSet) {
-          Attribute result = IREE::Encoding::UnsupportedEncodingAttr::get(ctx);
-          if (auto attr = targetAttr.getConfiguration().getNamed("encoding")) {
-            if (auto encodingLayoutAttr =
-                    dyn_cast<IREE::Encoding::EncodingLayoutAttrInterface>(
-                        attr->getValue())) {
-              result = encodingLayoutAttr.cloneWithSimplifiedConfig(
-                  targetAttr.getConfiguration());
-            }
+          if (!targetAttr.hasConfigurationAttr("encoding")) {
+            layoutAttrs[key].insert(getDefaultAttr());
+            continue;
           }
-          layoutAttrs[key].insert(result);
+          auto attr = targetAttr.getConfiguration().getNamed("encoding");
+          if (!attr) {
+            layoutAttrs[key].insert(getDefaultAttr());
+            continue;
+          }
+          auto encodingLayoutAttr =
+              dyn_cast<IREE::Encoding::EncodingLayoutAttrInterface>(
+                  attr->getValue());
+          if (!encodingLayoutAttr) {
+            layoutAttrs[key].insert(getDefaultAttr());
+            continue;
+          }
+          layoutAttrs[key].insert(encodingLayoutAttr.cloneWithSimplifiedConfig(
+              targetAttr.getConfiguration()));
         }
       }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALDialect.cpp
@@ -160,14 +160,10 @@ public:
             layoutAttrs[key].insert(getDefaultAttr());
             continue;
           }
-          auto attr = targetAttr.getConfiguration().getNamed("encoding");
-          if (!attr) {
-            layoutAttrs[key].insert(getDefaultAttr());
-            continue;
-          }
           auto encodingLayoutAttr =
-              dyn_cast<IREE::Encoding::EncodingLayoutAttrInterface>(
-                  attr->getValue());
+              targetAttr.getConfiguration()
+                  .getAs<IREE::Encoding::EncodingLayoutAttrInterface>(
+                      "encoding");
           if (!encodingLayoutAttr) {
             layoutAttrs[key].insert(getDefaultAttr());
             continue;

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
@@ -450,7 +450,7 @@ def SpecializeDispatchesPass :
 
 def SpecializeEncodingsPass :
     Pass<"iree-stream-specialize-encodings", "mlir::ModuleOp"> {
-  let summary = "Specializes data-tiling encodings based on layout analysis.";
+  let summary = "Specializes serializable encodings based on layout analysis.";
   let description = [{
     Attaches layouts to encodings and duplicates executables based on the
     encoding layout analysis.
@@ -472,11 +472,15 @@ def SpecializeEncodingsPass :
     executables based on the set of incoming layouts and result layouts, and
     updates bindings with resolved layouts.
 
-    It requires at least one of the dialect implements
-    AffinityAnalysisDialectInterface dialect interface, because Stream does not
-    need to know any dialect other than itself. It also requires the binding
-    types to implement EncodingTypeInterface, so it can updates the types
-    without accessing any other dialects.
+    Requirements:
+    - At least one of the dialect implements AffinityAnalysisDialectInterface
+      dialect interface, because Stream does not need to know any dialect other
+      than itself.
+    - The binding types have to implement IREE::EncodingEncodingTypeInterface,
+      so it can updates the types without accessing any other dialects.
+    - All the encodings attached on the types have to implement
+      SerializableEncodingAttrInterface. Because the pass updates the encodings
+      using interfaces.
   }];
   let dependentDialects = [
     "IREE::Encoding::IREEEncodingDialect"

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
@@ -476,7 +476,7 @@ def SpecializeEncodingsPass :
     - At least one of the dialect implements AffinityAnalysisDialectInterface
       dialect interface, because Stream does not need to know any dialect other
       than itself.
-    - The binding types have to implement IREE::EncodingEncodingTypeInterface,
+    - The binding types have to implement IREE::Encoding::EncodingTypeInterface,
       so it can updates the types without accessing any other dialects.
     - All the encodings attached on the types have to implement
       SerializableEncodingAttrInterface. Because the pass updates the encodings

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
@@ -77,7 +77,7 @@ static RankedTensorType cloneWithEncoding(RankedTensorType type,
 /// There are requirements to get the resolved layouts. Otherwise, the encodings
 /// are dropped unconditionally.
 ///   - All attributes in the `layoutResolvers` must implement
-///     EncodingLayoutAttrInterface. Otherwise, there is no way to query
+///     EncodingLayoutResolverAttrInterface. Otherwise, there is no way to query
 ///     layouts.
 ///   - The encoding on the type must implement
 ///     SerializableEncodingAttrInterface. Otherwise, there is no way to update
@@ -98,13 +98,13 @@ static Type getTypeWithResolvedEncodingLayouts(
   }
   if (!llvm::all_of(
           layoutResolvers,
-          llvm::IsaPred<IREE::Encoding::EncodingLayoutAttrInterface>)) {
+          llvm::IsaPred<IREE::Encoding::EncodingLayoutResolverAttrInterface>)) {
     return IREE::Encoding::dropEncoding(rankedTensorType);
   }
   SmallVector<Attribute> layouts;
   for (auto attr : layoutResolvers) {
     auto encodingLayoutAttr =
-        cast<IREE::Encoding::EncodingLayoutAttrInterface>(attr);
+        cast<IREE::Encoding::EncodingLayoutResolverAttrInterface>(attr);
     Attribute layout = encodingLayoutAttr.getLayout(rankedTensorType);
     if (!layout) {
       // Drop the encoding if the layout is not resolved.

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
@@ -68,14 +68,20 @@ static RankedTensorType cloneWithEncoding(RankedTensorType type,
                                encodingAttr);
 }
 
-// Returns the type with updated encoding, if any. Returns the original type if
-// the type is not a RankedTensorType. If it is a RankedTensorType with an
-// unknown encoding, returns the type without the encoding. The method uses
-// `layoutResolvers` to resolve the layouts of the given `type`; returns the new
-// encoding with the resolved layouts.
-// Note: The new encoding has to implement
-// SerializedEncodingLayoutAttrInterface. Otherwise, the specialization is
-// failed. Because the stream tensor ops still can not process encodings.
+/// Returns the type with updated encoding, if any. Returns the original type if
+/// the type is not a RankedTensorType. If it is a RankedTensorType with an
+/// unknown encoding, returns the type without the encoding. The method uses
+/// `layoutResolvers` to resolve the layouts of the given `type`; returns the
+/// new encoding with the resolved layouts.
+///
+/// There are requirements to get the resolved layouts. Otherwise, the encodings
+/// are dropped unconditionally.
+///   - All attributes in the `layoutResolvers` must implement
+///     EncodingLayoutAttrInterface. Otherwise, there is no way to query
+///     layouts.
+///   - The encoding on the type must implement
+///     SerializableEncodingAttrInterface. Otherwise, there is no way to update
+///     encodings.
 static Type getTypeWithResolvedEncodingLayouts(
     Type type, const SetVector<Attribute> &layoutResolvers) {
   auto rankedTensorType = dyn_cast<RankedTensorType>(type);
@@ -83,15 +89,16 @@ static Type getTypeWithResolvedEncodingLayouts(
     return type;
   }
   auto encodingAttr =
-      IREE::Encoding::getEncodingLayoutAttrInterface(rankedTensorType);
+      IREE::Encoding::getSerializableEncodingAttrInterface(rankedTensorType);
   if (!encodingAttr) {
     return IREE::Encoding::dropEncoding(rankedTensorType);
+  }
+  if (encodingAttr.isSerialized()) {
+    return type;
   }
   if (!llvm::all_of(
           layoutResolvers,
           llvm::IsaPred<IREE::Encoding::EncodingLayoutAttrInterface>)) {
-    // Drop the encoding if any attribute does not implement the interface.
-    // Because there is no way to query the layout.
     return IREE::Encoding::dropEncoding(rankedTensorType);
   }
   SmallVector<Attribute> layouts;
@@ -106,8 +113,7 @@ static Type getTypeWithResolvedEncodingLayouts(
     layouts.push_back(layout);
   }
   Attribute newEncoding = encodingAttr.cloneWithLayouts(layouts);
-  assert(
-      isa<IREE::Encoding::SerializedEncodingLayoutAttrInterface>(newEncoding));
+  assert(isa<IREE::Encoding::SerializableEncodingAttrInterface>(newEncoding));
   return cloneWithEncoding(rankedTensorType, newEncoding);
 };
 
@@ -134,12 +140,14 @@ updateBindingEncodings(FunctionOpInterface funcOp,
                  << "Skip, the new type is not RankedTensorType.\n");
       continue;
     }
-    auto encodingAttr = IREE::Encoding::getEncodingLayoutAttrInterface(newType);
+    auto encodingAttr =
+        IREE::Encoding::getSerializableEncodingAttrInterface(newType);
     if (!encodingAttr) {
-      LLVM_DEBUG(llvm::dbgs()
-                 << "Skip, the binding layout attribute is not "
-                    "EncodingLayoutAttrInterface, which means that the type "
-                    "does not have a valid encoding.\n");
+      LLVM_DEBUG(
+          llvm::dbgs()
+          << "Skip, the binding layout attribute is not "
+             "SerializableEncodingAttrInterface, which means that the type "
+             "does not have a valid encoding.\n");
       continue;
     }
     for (auto user : arg.getUsers()) {

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
@@ -246,6 +246,22 @@ util.func public @drop_encoding_by_unsupported_encoding(%arg0: index, %arg1: ind
 
 // -----
 
+// Do not drop encodings if they are already serialized.
+
+#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb">
+#device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
+#encoding = #iree_encoding.testing_encoding<[#iree_encoding.specialized_encoding<123>]>
+util.global private @device_a = #device_target_local_0_
+util.func public @keep_encoding_if_serialized(%arg0: index, %arg1: index, %scalar_f32 : f32) {
+  %0 = stream.tensor.empty on(#hal.device.affinity<@device_a>) : tensor<?x0xf32, #encoding>{%arg0} in !stream.resource<*>{%arg1}
+  util.return
+}
+// CHECK:       #[[$ENCODING:.+]] = #iree_encoding.testing_encoding<[#iree_encoding.specialized_encoding<123>]>
+// CHECK-LABEL: util.func public @keep_encoding_if_serialized
+// CHECK:         stream.tensor.empty {{.+}} : tensor<?x0xf32, #[[$ENCODING]]>
+
+// -----
+
 //------------------------------------------------------------------------------
 // This test suite tests the executable duplication logic.
 //------------------------------------------------------------------------------

--- a/compiler/src/iree/compiler/Utils/ElementPackingUtils.cpp
+++ b/compiler/src/iree/compiler/Utils/ElementPackingUtils.cpp
@@ -90,8 +90,9 @@ Value calculateStorageElementCountInBytes(Location loc,
                                           ValueRange dynamicDims,
                                           OpBuilder &builder) {
   Attribute encoding = shapedType.getEncoding();
-  if (auto encodingLayoutAttr = dyn_cast_or_null<
-          IREE::Encoding::SerializedEncodingLayoutAttrInterface>(encoding)) {
+  if (auto encodingLayoutAttr =
+          dyn_cast_or_null<IREE::Encoding::SerializableEncodingAttrInterface>(
+              encoding)) {
     return encodingLayoutAttr.calculateStorageSizeInBytes(
         loc, builder, shapedType, dynamicDims);
   }


### PR DESCRIPTION
Based on the learning from prototype, there are two kinds of encodings:

1. An encoding that is attached to the types, which is an encoding attribute.
2. An encoding that can query layouts from backends' perspective, which is an encoding layout resolver.

The former implements SerializeableEncodingAttrInterface, and the latter implements the EncodingLayoutResolverAttrInterface.

The revision moves the `cloneWithLayouts` method to the former interface, because it is used to update the former attributes.

The revision introduces `isSerialized` interface method to SerializeableEncodingAttrInterface, implements the method for existing encoding attributes, and makes the SpecializeEncoding pass skip the update if it is already serialized.

We don't use `isSpecialized` because specialization has larger scope. It does not only serialize the encodings, but also contains the analysis on affinities and executable duplication.

The revision also fixes a bug when the HAL device does not have configuration.