### PR TITLE
[Runtime][CUDA] Fix flag constant for cuEventCreate

### DIFF
--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.c
@@ -142,7 +142,7 @@ iree_hal_cuda_deferred_work_queue_device_interface_create_native_event(
       (iree_hal_cuda_deferred_work_queue_device_interface_t*)(base_device_interface);
   return IREE_CURESULT_TO_STATUS(
       device_interface->cuda_symbols,
-      cuEventCreate((CUevent*)out_event, CU_EVENT_WAIT_DEFAULT),
+      cuEventCreate((CUevent*)out_event, CU_EVENT_DEFAULT),
       "cuEventCreate");
 }
 

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.c
@@ -142,8 +142,7 @@ iree_hal_cuda_deferred_work_queue_device_interface_create_native_event(
       (iree_hal_cuda_deferred_work_queue_device_interface_t*)(base_device_interface);
   return IREE_CURESULT_TO_STATUS(
       device_interface->cuda_symbols,
-      cuEventCreate((CUevent*)out_event, CU_EVENT_DEFAULT),
-      "cuEventCreate");
+      cuEventCreate((CUevent*)out_event, CU_EVENT_DEFAULT), "cuEventCreate");
 }
 
 static iree_status_t


### PR DESCRIPTION
Refer to [CUDA documentation here](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__EVENT.html#group__CUDA__EVENT_1g450687e75f3ff992fe01662a43d9d3db), it seems that `CU_EVENT_WAIT_DEFAULT` cannot be used as a flag in `cuEventCreate`.

I think `CU_EVENT_WAIT_DEFAULT` is basically for some other CUDA APIs like `cuStreamWaitEvent` ([here](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__STREAM.html#group__CUDA__STREAM_1g6a898b652dfc6aa1d5c8d97062618b2f)).

It's interesting that currently these two constant is defined as the same value `0` in CUDA (so no functional change : ), but I believe it should be better if we can correct it.
