### PR TITLE
New flag: `iree-codegen-math-transform-tweaks`

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/MathTransformPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MathTransformPass.cpp
@@ -5,6 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Codegen/Common/Passes.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "mlir/Dialect/Math/Transforms/Approximation.h"
 #include "mlir/Dialect/Math/Transforms/Passes.h"
 #include "mlir/IR/PatternMatch.h"
@@ -12,6 +14,9 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_MATHTRANSFORMPASS
+#include "iree/compiler/Codegen/Common/Passes.h.inc"
 
 /// Deprecated! This flag had buggy/unintentional semantics.
 /// Its original comment said:
@@ -23,8 +28,92 @@ static llvm::cl::opt<bool> clNativeMathPrecision(
                    "for math op natively available on GPU.\""),
     llvm::cl::init(false));
 
-#define GEN_PASS_DEF_MATHTRANSFORMPASS
-#include "iree/compiler/Codegen/Common/Passes.h.inc"
+static llvm::cl::opt<std::string> clMathTransformTweaks(
+    "iree-codegen-math-transform-tweaks",
+    llvm::cl::desc(
+        "Comma-separated list of tweaks to apply to default math transforms. "
+        "Each entry has the form transform:+op or transform:-op to "
+        "enable/disable a transform on an op. Allowed values for `op` are the "
+        "math dialect ops, math.cos. Allowed values for `transform` "
+        "are: rewrite, approx, f32cast. Example: approx:-math.cos ."),
+    llvm::cl::init(""));
+
+struct MathTransformTweaks {
+  // Ops to enable "rewrite" transformations on. See `predicateRewrite`.
+  SmallVector<std::string> enableRewrite;
+  // Ops to disable "rewrite" transformations on. See `predicateRewrite`.
+  SmallVector<std::string> disableRewrite;
+  // Ops to enable "f32cast" transformations on. See `predicateF32Cast`.
+  SmallVector<std::string> enableF32Cast;
+  // Ops to disable "f32cast" transformations on. See `predicateF32Cast`.
+  SmallVector<std::string> disableF32Cast;
+  // Ops to enable "approx" transformations on. See `predicateApprox`.
+  SmallVector<std::string> enableApprox;
+  // Ops to disable "approx" transformations on. See `predicateApprox`.
+  SmallVector<std::string> disableApprox;
+};
+
+static llvm::Expected<MathTransformTweaks>
+getMathTransformTweaksFromString(StringRef tweaksString) {
+  auto error = [](auto... args) {
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   llvm::formatv(args...));
+  };
+  if (tweaksString.empty()) {
+    // Default case, no tweaks, return an default-constructed object.
+    return MathTransformTweaks{};
+  }
+  MathTransformTweaks tweaks;
+  SmallVector<StringRef> flags;
+  tweaksString.split(flags, ',');
+  for (StringRef flag : flags) {
+    if (flag.empty()) {
+      return error("Empty entry in comma-separated list");
+    }
+    auto [transform, plusMinusOp] = flag.split(':');
+    if (plusMinusOp.empty()) {
+      return error("No `:` separator found in `{}`", flag);
+    }
+    if (plusMinusOp.size() < 2) {
+      return error("Expected at least 2 characters to the right of `:` in `{}`",
+                   flag);
+    }
+    StringRef op = plusMinusOp.ltrim("-+");
+    if (op.size() + 1 != plusMinusOp.size()) {
+      // Check that exactly one left prefix char is '-' or '+'.
+      return error(
+          "Expected exactly one + or - character on the right of : in `{}`",
+          flag);
+    }
+    char plusMinus = plusMinusOp[0];
+    // User input already validated. This assert is just an internal check.
+    assert(plusMinus == '+' || plusMinus == '-');
+    SmallVector<std::string> *dstVecPtr =
+        llvm::StringSwitch<SmallVector<std::string> *>(transform)
+            .Case("rewrite", plusMinus == '+' ? &tweaks.enableRewrite
+                                              : &tweaks.disableRewrite)
+            .Case("f32cast", plusMinus == '+' ? &tweaks.enableF32Cast
+                                              : &tweaks.disableF32Cast)
+            .Case("approx", plusMinus == '+' ? &tweaks.enableApprox
+                                             : &tweaks.disableApprox)
+            .Default(nullptr);
+    if (!dstVecPtr) {
+      return error("Unknown key on left of the : separator in {}", flag);
+    }
+    dstVecPtr->emplace_back(op);
+  }
+  return tweaks;
+}
+
+static llvm::Expected<MathTransformTweaks>
+getMathTransformTweaksFromCLAndReportError() {
+  llvm::Expected<MathTransformTweaks> tweaks =
+      getMathTransformTweaksFromString(clMathTransformTweaks);
+  if (!tweaks) {
+    clMathTransformTweaks.error(llvm::toString(tweaks.takeError()));
+  }
+  return tweaks;
+}
 
 static void populateMathFunctionsRewritePatterns(
     RewritePatternSet &patterns,
@@ -62,7 +151,8 @@ static void populateMathFunctionsRewritePatterns(
 }
 
 static bool predicateRewrite(StringRef name,
-                             IREE::HAL::ExecutableTargetAttr target) {
+                             IREE::HAL::ExecutableTargetAttr target,
+                             const MathTransformTweaks &tweaks) {
   (void)target;                // Currently unused.
   if (clNativeMathPrecision) { // Legacy.
     if (name == math::Exp2Op::getOperationName() ||
@@ -70,14 +160,27 @@ static bool predicateRewrite(StringRef name,
       return false;
     }
   }
+  if (llvm::is_contained(tweaks.enableRewrite, name)) {
+    return true;
+  }
+  if (llvm::is_contained(tweaks.disableRewrite, name)) {
+    return false;
+  }
   // Currently enable all non-approximative rewrites.
   return true;
 }
 
 static bool predicateF32Cast(StringRef name,
-                             IREE::HAL::ExecutableTargetAttr target) {
+                             IREE::HAL::ExecutableTargetAttr target,
+                             const MathTransformTweaks &tweaks) {
   (void)target;                // Currently unused.
   if (clNativeMathPrecision) { // Legacy.
+    return false;
+  }
+  if (llvm::is_contained(tweaks.enableF32Cast, name)) {
+    return true;
+  }
+  if (llvm::is_contained(tweaks.disableF32Cast, name)) {
     return false;
   }
   StringRef atan = math::AtanOp::getOperationName();
@@ -98,7 +201,8 @@ static bool predicateF32Cast(StringRef name,
 }
 
 static bool predicateApprox(StringRef name,
-                            IREE::HAL::ExecutableTargetAttr target) {
+                            IREE::HAL::ExecutableTargetAttr target,
+                            const MathTransformTweaks &tweaks) {
   if (clNativeMathPrecision) { // Legacy.
     if (name == math::ErfOp::getOperationName()) {
       // The legacy implementation had a bug: it always applied polynomial
@@ -107,6 +211,12 @@ static bool predicateApprox(StringRef name,
       // clNativeMathPrecision but fail unless math.erf is approximated.
       return true;
     }
+    return false;
+  }
+  if (llvm::is_contained(tweaks.enableApprox, name)) {
+    return true;
+  }
+  if (llvm::is_contained(tweaks.disableApprox, name)) {
     return false;
   }
   StringRef acos = math::AcosOp::getOperationName();
@@ -139,23 +249,30 @@ public:
   using Base::Base;
 
   void runOnOperation() override {
+    // Parse tweaks from command-line flag. Static initializer is thread-safe
+    // and ensures that the parsing and any error-printing is done only once.
+    static llvm::Expected<MathTransformTweaks> tweaks =
+        getMathTransformTweaksFromCLAndReportError();
+    if (!tweaks) {
+      // Any error message has already been printed.
+      return signalPassFailure();
+    }
     RewritePatternSet patterns(&getContext());
     auto target = IREE::HAL::ExecutableTargetAttr::lookup(getOperation());
     if (!target) {
       return signalPassFailure();
     }
-    populateMathFunctionsRewritePatterns(patterns, [target](StringRef name) {
-      return predicateRewrite(name, target);
+    populateMathFunctionsRewritePatterns(patterns, [&](StringRef name) {
+      return predicateRewrite(name, target, *tweaks);
     });
 
-    populateMathF32ExpansionPatterns(patterns, [target](StringRef name) {
-      return predicateF32Cast(name, target);
+    populateMathF32ExpansionPatterns(patterns, [&](StringRef name) {
+      return predicateF32Cast(name, target, *tweaks);
     });
 
-    populateMathPolynomialApproximationPatterns(
-        patterns,
-        [target](StringRef name) { return predicateApprox(name, target); });
-
+    populateMathPolynomialApproximationPatterns(patterns, [&](StringRef name) {
+      return predicateApprox(name, target, *tweaks);
+    });
     if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();
     }

--- a/compiler/src/iree/compiler/Codegen/Common/test/math_transform.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/math_transform.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-codegen-math-transform))' --split-input-file %s | FileCheck %s
-// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-codegen-math-transform))' '--iree-codegen-math-transform-tweaks=approx:-math.tan,rewrite:-math.tan,f32cast:-math.tan' --split-input-file %s | FileCheck %s --check-prefix=FLAGS1
-// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-codegen-math-transform))' '--iree-codegen-math-transform-tweaks=approx:-math.tan,rewrite:-math.tan,f32cast:+math.tan' --split-input-file %s | FileCheck %s --check-prefix=FLAGS2
-// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-codegen-math-transform))' '--iree-codegen-math-transform-tweaks=approx:-math.tan,approx:-math.cos,approx:-math.sin,rewrite:+math.tan' --split-input-file %s | FileCheck %s --check-prefix=FLAGS3
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-codegen-math-transform))' '--iree-codegen-math-transform-tweaks=-approx:math.tan,-rewrite:math.tan,-f32cast:math.tan' --split-input-file %s | FileCheck %s --check-prefix=FLAGS1
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-codegen-math-transform))' '--iree-codegen-math-transform-tweaks=-approx:math.tan,-rewrite:math.tan,+f32cast:math.tan' --split-input-file %s | FileCheck %s --check-prefix=FLAGS2
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-codegen-math-transform))' '--iree-codegen-math-transform-tweaks=-approx:math.tan,-approx:math.cos,-approx:math.sin,+rewrite:math.tan' --split-input-file %s | FileCheck %s --check-prefix=FLAGS3
 
 // CHECK-ALL-LABEL: @rewrite_tan
 func.func @rewrite_tan(%arg0: f16) -> f16 attributes {


### PR DESCRIPTION
This flag allows finely controlling `MathTransformPass`.

It should supersede the deprecated `iree-codegen-gpu-native-math-precision` and give us a path to retiring it.

It should also enable future sprints to iterate more quickly than we have experienced this time around.