### PR TITLE
[GPU] fix bug in expand permutation calculation when concretizing MMA shapes

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -209,6 +209,9 @@ def IREEGPU_MultiMmaOp : Op<IREEGPU_Dialect, "multi_mma", [
     It does so semi-opaquely by including optional permutations of each MMA
     fragment with respect to the "canonical" MNK row major matrix multiply.
 
+    The permutations represents the permutation that takes the canonical
+    (row major) layout and converts it to the current layout.
+
     Since the canonical dimensionality of the inner dimensions are somewhat
     intrinsic specific, verification of this op requires only that element
     counts of the inner dimensions match the intrinsic.

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/ConcretizeMmaShapes.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/ConcretizeMmaShapes.cpp
@@ -171,6 +171,9 @@ struct ConcretizeMmaOperandShape final : OpRewritePattern<MultiMmaOp> {
           idx -= outerRank;
         }
       }
+      // |perm| represents the permutation that takes the canonical (row major)
+      // layout and converts it to the current layout. Take the inverse to
+      // update to the expanded permutation and then invert back
       SmallVector<int64_t> invertPerm = invertPermutationVector(perm.value());
       SmallVector<int64_t> expandedPerm;
       for (auto reInd : applyPermutation(innerReInds, invertPerm)) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/ConcretizeMmaShapes.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/ConcretizeMmaShapes.cpp
@@ -171,10 +171,12 @@ struct ConcretizeMmaOperandShape final : OpRewritePattern<MultiMmaOp> {
           idx -= outerRank;
         }
       }
+      SmallVector<int64_t> invertPerm = invertPermutationVector(perm.value());
       SmallVector<int64_t> expandedPerm;
-      for (auto reInd : applyPermutation(innerReInds, perm.value())) {
+      for (auto reInd : applyPermutation(innerReInds, invertPerm)) {
         expandedPerm.append(reInd);
       }
+      expandedPerm = invertPermutationVector(expandedPerm);
       return rewriter.getDenseI64ArrayAttr(expandedPerm);
     };
     std::optional<DenseI64ArrayAttr> lhsPerm = expandPerm(

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/concretize_mma_shapes.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/test/concretize_mma_shapes.mlir
@@ -190,7 +190,7 @@ func.func @concretize_multi_mma_F32_32x32x8_F16(%lhs: tensor<2x2x32x8xf16>, %rhs
 
 // CHECK-RESULT-DAG:    %[[EXPANDED_ACC:.+]] = tensor.expand_shape %[[ACC]] {{\[}}[0], [1], [2], [3, 4]] output_shape [2, 2, 32, 4, 8]
 // CHECK-RESULT:        %[[MMA:.+]] = iree_gpu.multi_mma %[[LHS]], %[[RHS]], %[[EXPANDED_ACC]]
-// CHECK-RESULT-SAME:     acc_permutation = array<i64: 1, 2, 0>
+// CHECK-RESULT-SAME:     acc_permutation = array<i64: 2, 0, 1>
 // CHECK-RESULT-SAME:     lowering_config = #iree_gpu.lowering_config
 // CHECK-RESULT-SAME:     : tensor<2x2x32x8xf16>, tensor<2x2x8x32xf16> into tensor<2x2x32x4x8xf32>
 // CHECK-RESULT:        %[[COLLAPSED:.+]] = tensor.collapse_shape %[[MMA]] {{\[}}[0], [1], [2], [3, 4]]


### PR DESCRIPTION
When expanding permutation during concretizing mma shapes. We want to first expand in the inverse domain and then take inverse of that.