### PR TITLE
[DT] Don't materialize encodings in case of missing information

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.cpp
@@ -280,13 +280,13 @@ getExpandedTileShape(const TileSwizzle::ExpandShapeType &expandShape) {
   return result;
 }
 
-MaterializeEncodingInfo
+FailureOr<MaterializeEncodingInfo>
 getEncodingInfoForMatmul(Encoding::EncodingAttr encoding, TileMxNxK tileMxNxK) {
   MaterializeEncodingInfo encodingInfo;
   FailureOr<linalg::ContractionDimensions> cDims =
       getEncodingContractionDims(encoding);
   if (failed(cDims)) {
-    return encodingInfo;
+    return failure();
   }
   // The following expects M, N, K, and Batch sizes of at most 1 for now
   assert(cDims->m.size() <= 1 && cDims->n.size() <= 1 && cDims->k.size() == 1 &&

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.h
@@ -74,7 +74,7 @@ struct TileMxNxK {
   int64_t K = 1;
 };
 
-MaterializeEncodingInfo
+FailureOr<MaterializeEncodingInfo>
 getEncodingInfoForMatmul(Encoding::EncodingAttr encoding, TileMxNxK tileMxNxK);
 
 } // namespace mlir::iree_compiler::IREE::Codegen

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -635,7 +635,12 @@ struct CPUDeviceEncodingLayoutResolverAttrInterface
     // taking narrow dimensions into account.
     TileMxNxK chosenTileMxNxK = chooseMatmulTile(
         enumeratedTileMxNxK, narrowDim, encoding.getRoundDimsToArray());
-    info = getEncodingInfoForMatmul(encoding, chosenTileMxNxK);
+    FailureOr<MaterializeEncodingInfo> maybeEncodingInfo =
+        getEncodingInfoForMatmul(encoding, chosenTileMxNxK);
+    if (failed(maybeEncodingInfo)) {
+      return info;
+    }
+    info = std::move(maybeEncodingInfo.value());
     if (Encoding::isNarrowNResult(encoding)) {
       transposeInPlace(info);
     }
@@ -767,7 +772,12 @@ struct VMVXDeviceEncodingLayoutResolverAttrInterface final
     // taking narrow dimensions into account.
     TileMxNxK chosenTileMxNxK = chooseMatmulTile(
         enumeratedTileMxNxK, narrowDim, encoding.getRoundDimsToArray());
-    info = getEncodingInfoForMatmul(encoding, chosenTileMxNxK);
+    FailureOr<MaterializeEncodingInfo> maybeEncodingInfo =
+        getEncodingInfoForMatmul(encoding, chosenTileMxNxK);
+    if (failed(maybeEncodingInfo)) {
+      return info;
+    }
+    info = std::move(maybeEncodingInfo.value());
     if (Encoding::isNarrowNResult(encoding)) {
       transposeInPlace(info);
     }

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -341,7 +341,12 @@ struct GPUDeviceEncodingLayoutResolverAttrInterface
     // based on its operand index in the matmul.
     TileMxNxK innerTile;
     std::tie(innerTile.M, innerTile.N, innerTile.K) = mma.getMNKShape();
-    info = getEncodingInfoForMatmul(encoding, innerTile);
+    FailureOr<MaterializeEncodingInfo> maybeEncodingInfo =
+        getEncodingInfoForMatmul(encoding, innerTile);
+    if (failed(maybeEncodingInfo)) {
+      return info;
+    }
+    info = std::move(maybeEncodingInfo.value());
     auto fragment = static_cast<IREE::GPU::MMAFragment>(
         encoding.getOperandIndex().getInt());
     info.swizzle = getSwizzle(mma, fragment);


### PR DESCRIPTION
This PR adds failure catches to fix an error being thrown when not enough information is provided to calculate matmul encoding materialization info. 

Note the `info.swizzle = getSwizzle(mma, fragment);` after a potentially empty `MaterializeEncodingInfo` was being returned. This would effectively return a `MaterializeEncodingInfo` object with just swizzle information to  `MaterializeEncodings`, which would result in a seemingly unrelated error somewhere inside.