### PR TITLE
[Stream] Do not specialize encodings that is either unrecognized or already serialized

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -210,6 +210,17 @@ def TestingEncodingAttr :
   let genVerifyDecl = 0;
 }
 
+def UnknownEncodingAttr : IREEEncoding_Attr<"UnknownEncoding"> {
+  let mnemonic = "unknown_encoding";
+  let summary = "A pure encoding attribute for testing purpose";
+
+  let description = [{
+    An attribute for testing purpose. It is intended to be attached on
+    RankedTensorType as an encoding.
+  }];
+  let genVerifyDecl = 0;
+}
+
 def UnspecializedEncodingAttr :
     IREEEncoding_Attr<"UnspecializedEncoding", [
       DeclareAttrInterfaceMethods<IREEEncoding_EncodingLayoutResolverAttrInterface, [

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingDialect.cpp
@@ -36,7 +36,8 @@ struct EncodingOpAsmInterface : public OpAsmDialectInterface {
   /// `.` or end with a numeric digit([0-9]+). Returns success if an alias was
   /// provided, failure otherwise.
   AliasResult getAlias(Attribute attr, raw_ostream &os) const override {
-    if (llvm::isa<EncodingAttr, TestingEncodingAttr>(attr)) {
+    if (llvm::isa<EncodingAttr, TestingEncodingAttr, UnknownEncodingAttr>(
+            attr)) {
       os << "encoding";
       return AliasResult::OverridableAlias;
     }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
@@ -13,6 +13,7 @@
 #include "iree/compiler/Dialect/Stream/IR/StreamTypes.h"
 #include "iree/compiler/Dialect/Stream/Transforms/Passes.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVectorExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
@@ -68,11 +69,24 @@ static RankedTensorType cloneWithEncoding(RankedTensorType type,
                                encodingAttr);
 }
 
+/// Returns true iff the type is a RankedTensorType and it has an encoding that
+/// implements SerializableEncodingAttrInterface.
+static bool isRecognizedEncodingType(Type type) {
+  auto rankedTensorType = dyn_cast<RankedTensorType>(type);
+  if (!rankedTensorType) {
+    return false;
+  }
+  auto encoding = rankedTensorType.getEncoding();
+  if (!encoding) {
+    return false;
+  }
+  return isa<IREE::Encoding::SerializableEncodingAttrInterface>(encoding);
+}
+
 /// Returns the type with updated encoding, if any. Returns the original type if
-/// the type is not a RankedTensorType. If it is a RankedTensorType with an
-/// unknown encoding, returns the type without the encoding. The method uses
-/// `layoutResolvers` to resolve the layouts of the given `type`; returns the
-/// new encoding with the resolved layouts.
+/// the the encoding type is not recognized or it is already serialized.
+/// The method uses `layoutResolvers` to resolve the layouts of the given
+/// `type`; returns the new encoding with the resolved layouts.
 ///
 /// There are requirements to get the resolved layouts. Otherwise, the encodings
 /// are dropped unconditionally.
@@ -84,15 +98,12 @@ static RankedTensorType cloneWithEncoding(RankedTensorType type,
 ///     encodings.
 static Type getTypeWithResolvedEncodingLayouts(
     Type type, const SetVector<Attribute> &layoutResolvers) {
-  auto rankedTensorType = dyn_cast<RankedTensorType>(type);
-  if (!rankedTensorType) {
+  if (!isRecognizedEncodingType(type)) {
     return type;
   }
+  auto rankedTensorType = dyn_cast<RankedTensorType>(type);
   auto encodingAttr =
       IREE::Encoding::getSerializableEncodingAttrInterface(rankedTensorType);
-  if (!encodingAttr) {
-    return IREE::Encoding::dropEncoding(rankedTensorType);
-  }
   if (encodingAttr.isSerialized()) {
     return type;
   }
@@ -108,6 +119,9 @@ static Type getTypeWithResolvedEncodingLayouts(
     Attribute layout = encodingLayoutAttr.getLayout(rankedTensorType);
     if (!layout) {
       // Drop the encoding if the layout is not resolved.
+      // TODO(hanchung): return a failure if we can't convert it to serialized
+      // encoding. We need to replace the `UnsupportedEncoding` resolver with
+      // `DiscardEncoding` resolver.
       return IREE::Encoding::dropEncoding(rankedTensorType);
     }
     layouts.push_back(layout);
@@ -151,19 +165,9 @@ updateBindingEncodings(FunctionOpInterface funcOp,
       continue;
     }
     for (auto user : arg.getUsers()) {
-      auto subspanOp = dyn_cast<IREE::Stream::BindingSubspanOp>(user);
-      if (!subspanOp) {
-        return failure();
-      }
-
+      auto subspanOp = cast<IREE::Stream::BindingSubspanOp>(user);
       auto encodingTypeInterface =
-          dyn_cast<IREE::Encoding::EncodingTypeInterface>(subspanOp.getType());
-      if (!encodingTypeInterface) {
-        LLVM_DEBUG(llvm::dbgs()
-                   << "Can not update the binding type because the type does "
-                      "not implement EncodingTypeInterface.\n");
-        return failure();
-      }
+          cast<IREE::Encoding::EncodingTypeInterface>(subspanOp.getType());
       subspanOp.getResult().setType(
           encodingTypeInterface.updateEncoding(encodingAttr));
     }
@@ -230,27 +234,11 @@ getBindingLayoutAttrs(IREE::Stream::TensorDispatchOp dispatchOp) {
 /// this case, we have to duplicate the executable with updated encoding, and
 /// modify the dispatch to launch proper executable based on resolved encoding
 /// layouts.
-static LogicalResult
-duplicateExecutablesPerLayoutVariant(ModuleOp moduleOp, SymbolTable symbolTable,
-                                     FunctionOpInterface funcOp) {
+static LogicalResult duplicateExecutablesPerLayoutVariant(
+    ModuleOp moduleOp, SymbolTable symbolTable,
+    ArrayRef<IREE::Stream::TensorDispatchOp> candidates) {
   MLIRContext *ctx = moduleOp.getContext();
   IRRewriter rewriter(ctx);
-
-  SmallVector<IREE::Stream::TensorDispatchOp> candidates;
-  funcOp.walk([&](IREE::Stream::TensorDispatchOp op) {
-    // Filter out the cases that are not from the normal pipeline. E.g., custom
-    // dispatch could embed hal.executables.
-    bool recognizedInput = true;
-    op.forEachEntryPointAttr([&](SymbolRefAttr entryPoint) {
-      if (!isa<IREE::Stream::ExecutableExportOp>(
-              symbolTable.lookupSymbolIn(moduleOp, entryPoint))) {
-        recognizedInput = false;
-      }
-    });
-    if (recognizedInput) {
-      candidates.push_back(op);
-    }
-  });
 
   //===--------------------------------------------------------------------===//
   // Gather per-export [binding layouts] map. A function in an executable can be
@@ -315,12 +303,11 @@ duplicateExecutablesPerLayoutVariant(ModuleOp moduleOp, SymbolTable symbolTable,
       }
 
       // Update the binding encodings within the cloned executable op.
-      auto innerFuncOp =
-          cast<mlir::FunctionOpInterface>(symbolTable.lookupSymbolIn(
-              dupOp.getInnerModule(), exportOp.getSymName()));
-      if (failed(updateBindingEncodings(innerFuncOp,
+      auto funcOp = cast<mlir::FunctionOpInterface>(symbolTable.lookupSymbolIn(
+          dupOp.getInnerModule(), exportOp.getSymName()));
+      if (failed(updateBindingEncodings(funcOp,
                                         bindingLayoutTypeAttrs.getValue()))) {
-        return failure();
+        return funcOp->emitOpError("failed to update encodings for bindings");
       }
       dispatchSiteToExecutableOp[ExportAndBindingLayouts(
           exportOp, bindingLayoutTypeAttrs)] = dupOp;
@@ -357,11 +344,102 @@ duplicateExecutablesPerLayoutVariant(ModuleOp moduleOp, SymbolTable symbolTable,
   return success();
 }
 
+/// Returns true iff all the entry points are recognized by the pass:
+///   - The corresponding executable is a stream.executable op.
+///   - The function arguments, where the types are !stream.binding_type, are
+///     only used by stream.binding.subspan ops. Furthermore, the result type of
+///     subspan ops have to implement IREE::Encoding::EncodingTypeInterface.
+static bool recognizeEntryPoints(ModuleOp moduleOp, SymbolTable symbolTable,
+                                 IREE::Stream::TensorDispatchOp dispatchOp) {
+  bool result = true;
+  dispatchOp.forEachEntryPointAttr([&](SymbolRefAttr entryPoint) {
+    if (!result) {
+      return;
+    }
+    auto exportOp = cast<IREE::Stream::ExecutableExportOp>(
+        symbolTable.lookupSymbolIn(moduleOp, entryPoint));
+    auto executableOp = exportOp->getParentOfType<IREE::Stream::ExecutableOp>();
+    if (!executableOp) {
+      result = false;
+      return;
+    }
+
+    auto funcOp = cast<mlir::FunctionOpInterface>(symbolTable.lookupSymbolIn(
+        executableOp.getInnerModule(), exportOp.getSymName()));
+    for (auto arg : funcOp.getArguments()) {
+      if (!isa<IREE::Stream::BindingType>(arg.getType())) {
+        continue;
+      }
+      for (auto user : arg.getUsers()) {
+        auto subspanOp = dyn_cast<IREE::Stream::BindingSubspanOp>(user);
+        if (!subspanOp) {
+          result = false;
+          return;
+        }
+        auto encodingTypeInterface =
+            dyn_cast<IREE::Encoding::EncodingTypeInterface>(
+                subspanOp.getType());
+        if (!encodingTypeInterface) {
+          result = false;
+          return;
+        }
+      }
+    }
+  });
+  return result;
+}
+
+/// Returns true if any of encoding types is a recognized encoding. See
+/// `isRecognizedEncodingType` method for the definition.
+static bool hasRecognizedEncoding(ModuleOp moduleOp, SymbolTable symbolTable,
+                                  Operation *op) {
+  return TypeSwitch<Operation *, bool>(op)
+      .Case<IREE::Stream::TensorDispatchOp>([&](auto op) {
+        if (!recognizeEntryPoints(moduleOp, symbolTable, op)) {
+          return false;
+        }
+        for (TypeAttr typeAttr : llvm::concat<TypeAttr>(
+                 op.getOperandEncodings().template getAsRange<TypeAttr>(),
+                 op.getResultEncodings().template getAsRange<TypeAttr>())) {
+          if (isRecognizedEncodingType(typeAttr.getValue())) {
+            return true;
+          }
+        }
+        return false;
+      })
+      .Case<IREE::Stream::TensorSizeOfOp>(
+          [&](auto op) { return isRecognizedEncodingType(op.getEncoding()); })
+      .Case<IREE::Stream::TensorEmptyOp, IREE::Stream::TensorSplatOp>(
+          [&](auto op) {
+            return isRecognizedEncodingType(op.getResultEncoding());
+          })
+      .Case<IREE::Stream::TensorConstantOp>([&](auto op) {
+        return isRecognizedEncodingType(op.getResultEncoding());
+      })
+      .Case<IREE::Stream::TensorFillOp>([&](auto op) {
+        return isRecognizedEncodingType(op.getTargetEncoding());
+      })
+      .Case<IREE::Stream::TensorCloneOp>([&](auto op) {
+        return isRecognizedEncodingType(op.getSourceEncoding()) ||
+               isRecognizedEncodingType(op.getResultEncoding());
+      })
+      .Case<IREE::Stream::TensorSliceOp>([&](auto op) {
+        return isRecognizedEncodingType(op.getSourceEncoding()) ||
+               isRecognizedEncodingType(op.getResultEncoding());
+      })
+      .Case<IREE::Stream::TensorUpdateOp>([&](auto op) {
+        return isRecognizedEncodingType(op.getTargetEncoding()) ||
+               isRecognizedEncodingType(op.getUpdateEncoding());
+      })
+      .Default([](Operation *op) { return false; });
+}
+
 /// Returns all the stream tensor ops that implement AffinityOpInterface, where
 /// a stream affinity indicates the kind of enviroment the ops are expected run
 /// in.
 static SmallVector<IREE::Stream::AffinityOpInterface>
-collectStreamTensorOps(FunctionOpInterface funcOp) {
+collectStreamTensorOps(ModuleOp moduleOp, SymbolTable symbolTable,
+                       FunctionOpInterface funcOp) {
   SmallVector<IREE::Stream::AffinityOpInterface> result;
   funcOp.walk([&](IREE::Stream::AffinityOpInterface affinityOp) {
     // Only need to update encoding types for ops that have TensorPhaseOp trait.
@@ -374,6 +452,11 @@ collectStreamTensorOps(FunctionOpInterface funcOp) {
     if (!affinityAttr) {
       return;
     }
+
+    if (!hasRecognizedEncoding(moduleOp, symbolTable, affinityOp)) {
+      return;
+    }
+
     result.push_back(affinityOp);
   });
   return result;
@@ -404,6 +487,13 @@ public:
   // Adds the resolved layouts to all tensor types of `streamOps`, if encodings
   // are present.
   LogicalResult run();
+
+  SmallVector<IREE::Stream::TensorDispatchOp> getTensorDispatchOps() {
+    return llvm::map_to_vector(
+        llvm::filter_to_vector(streamOps,
+                               llvm::IsaPred<IREE::Stream::TensorDispatchOp>),
+        [](Operation *op) { return cast<IREE::Stream::TensorDispatchOp>(op); });
+  }
 
 private:
   // Appends the query from the `affinityOp` to `queries`. Note that most of
@@ -442,13 +532,15 @@ LogicalResult StreamTensorOpUpdater::init() {
   auto usedDialects = gatherUsedDialectInterfaces<
       IREE::Stream::AffinityAnalysisDialectInterface>(moduleOp);
   if (usedDialects.size() != 1) {
-    return moduleOp.emitError("expected only one dialect implementing "
-                              "AffinityAnalysisDialectInterface");
+    LLVM_DEBUG(llvm::dbgs() << "expected only one dialect implementing "
+                               "AffinityAnalysisDialectInterface\n");
+    return failure();
   }
   resolveLayoutAttr = usedDialects[0]->makeLayoutAttrResolver(moduleOp);
 
+  SymbolTable symbolTable(moduleOp);
   for (auto funcOp : moduleOp.getOps<FunctionOpInterface>()) {
-    streamOps.append(collectStreamTensorOps(funcOp));
+    streamOps.append(collectStreamTensorOps(moduleOp, symbolTable, funcOp));
   }
 
   return success();
@@ -471,7 +563,7 @@ LogicalResult StreamTensorOpUpdater::addQuery(
       }
       SmallVector<IREE::Stream::AffinityAttr> affinityAttrs;
       if (!affinityAnalysis.tryLookupResourceAffinity(operand, affinityAttrs)) {
-        return dispatchOp.emitError(
+        return dispatchOp.emitOpError(
                    "failed to determine resource affinity for operand ")
                << operand;
       }
@@ -505,10 +597,8 @@ static LogicalResult updateTensorDispatchOp(
     }
     SmallVector<IREE::Stream::AffinityAttr> affinityAttrs;
     if (!affinityAnalysis.tryLookupResourceAffinity(operand, affinityAttrs)) {
-      return failure();
-    }
-    if (affinityAttrs.size() != 1) {
-      return failure();
+      return dispatchOp->emitOpError(
+          "failed to look up operand resource affinity");
     }
 
     IREE::Stream::AffinityAndOpPair key(affinityAttrs[0], dispatchOp);
@@ -554,6 +644,15 @@ updateTensorSizeOfOp(RewriterBase &rewriter,
   return success();
 }
 
+static bool isUnrecognizedOrSerializedEncodingType(Type type) {
+  if (!isRecognizedEncodingType(type)) {
+    return true;
+  }
+  auto rankedTensorType = cast<RankedTensorType>(type);
+  return IREE::Encoding::getSerializableEncodingAttrInterface(rankedTensorType)
+      .isSerialized();
+}
+
 /// Updates the target encoding of `op` with resolved layouts.
 static LogicalResult
 updateTensorFillOp(RewriterBase &rewriter, IREE::Stream::TensorFillOp op,
@@ -565,79 +664,41 @@ updateTensorFillOp(RewriterBase &rewriter, IREE::Stream::TensorFillOp op,
   return success();
 }
 
-/// Returns failure if `op` has encoding. The EncodingAttr has padding
-/// semantic, a constant op with such  encoding can not be resolved at this
-/// moment.
+/// Returns success iff all the encodings are either unrecognized encoding or
+/// serialized encoding.
 static LogicalResult
 updateTensorConstantOp(RewriterBase &rewriter,
                        IREE::Stream::TensorConstantOp op,
                        const SetVector<Attribute> &layoutResolvers) {
-  auto encodingType = dyn_cast<RankedTensorType>(op.getResultEncoding());
-  if (!encodingType) {
-    return success();
-  }
-  if (encodingType.getEncoding()) {
-    return failure();
-  }
-  return success();
+  return success(
+      isUnrecognizedOrSerializedEncodingType(op.getResultEncoding()));
 }
 
-/// Returns a failure if there are encodings in target encoding type or update
-/// encoding type.
+/// Returns success iff all the encodings are either unrecognized encoding or
+/// serialized encoding.
 static LogicalResult updateTensorUpdateOp(RewriterBase &rewriter,
                                           IREE::Stream::TensorUpdateOp op) {
-  auto targetEncodingType = dyn_cast<RankedTensorType>(op.getTargetEncoding());
-  if (targetEncodingType && targetEncodingType.getEncoding()) {
-    return failure();
-  }
-  auto updateEncodingType = dyn_cast<RankedTensorType>(op.getUpdateEncoding());
-  if (updateEncodingType && updateEncodingType.getEncoding()) {
-    return failure();
-  }
-  return success();
+  return success(
+      isUnrecognizedOrSerializedEncodingType(op.getTargetEncoding()) &&
+      isUnrecognizedOrSerializedEncodingType(op.getUpdateEncoding()));
 }
 
-/// Returns a failure if there are encodings in source encoding type or result
-/// encoding type.
+/// Returns success iff all the encodings are either unrecognized encoding or
+/// serialized encoding.
 static LogicalResult updateTensorCloneOp(RewriterBase &rewriter,
                                          IREE::Stream::TensorCloneOp op) {
-  auto sourceEncodingType = dyn_cast<RankedTensorType>(op.getSourceEncoding());
-  if (sourceEncodingType && sourceEncodingType.getEncoding()) {
-    return failure();
-  }
-  auto resultEncodingType = dyn_cast<RankedTensorType>(op.getResultEncoding());
-  if (resultEncodingType && resultEncodingType.getEncoding()) {
-    return failure();
-  }
-  return success();
+  return success(
+      isUnrecognizedOrSerializedEncodingType(op.getSourceEncoding()) &&
+      isUnrecognizedOrSerializedEncodingType(op.getResultEncoding()));
 }
 
-/// Returns a failure if there are encodings in source encoding type or result
-/// encoding type.
+/// Returns success iff all the encodings are either unrecognized encoding or
+/// serialized encoding.
 static LogicalResult updateTensorSliceOp(RewriterBase &rewriter,
                                          IREE::Stream::TensorSliceOp op) {
-  auto sourceEncodingType = dyn_cast<RankedTensorType>(op.getSourceEncoding());
-  if (sourceEncodingType && sourceEncodingType.getEncoding()) {
-    return failure();
-  }
-  auto resultEncodingType = dyn_cast<RankedTensorType>(op.getResultEncoding());
-  if (resultEncodingType && resultEncodingType.getEncoding()) {
-    return failure();
-  }
-  return success();
-}
-
-/// Updates the source_encoding for `op`. The op has to define a
-/// `source_encoding` parameter.
-template <typename OpTy>
-static LogicalResult
-updateSourceEncoding(RewriterBase &rewriter, OpTy op,
-                     const SetVector<Attribute> &layoutResolvers) {
-  auto encodingType = dyn_cast<RankedTensorType>(op.getSourceEncoding());
-  Type newEncodingType =
-      getTypeWithResolvedEncodingLayouts(encodingType, layoutResolvers);
-  rewriter.modifyOpInPlace(op, [&] { op.setSourceEncoding(newEncodingType); });
-  return success();
+  return success(
+      isUnrecognizedOrSerializedEncodingType(op.getSourceEncoding()) &&
+      isUnrecognizedOrSerializedEncodingType(op.getResultEncoding()));
 }
 
 /// Updates the result_encoding for `op`. The op has to define a
@@ -661,12 +722,14 @@ LogicalResult StreamTensorOpUpdater::run() {
 
   for (auto op : streamOps) {
     if (failed(addQuery(affinityAnalysis, op))) {
-      return failure();
+      return moduleOp->emitError(
+          "failed to cache all the queris, it usually means that there are "
+          "failures in affinity analysis");
     }
   }
 
   if (failed(resolveLayoutAttr(queries, cachedLayoutAttrs))) {
-    return failure();
+    return moduleOp->emitError("failed to resolve layouts for an query");
   }
 
   IRRewriter rewriter(moduleOp.getContext());
@@ -701,12 +764,11 @@ LogicalResult StreamTensorOpUpdater::run() {
                 [&](auto op) { return updateTensorSliceOp(rewriter, op); })
             .Case<IREE::Stream::TensorUpdateOp>(
                 [&](auto op) { return updateTensorUpdateOp(rewriter, op); })
-            .Default([](Operation *op) {
-              return op->emitOpError("Unhandled stream op");
-            });
+            .Default([](Operation *op) { return failure(); });
 
     if (failed(result)) {
-      return failure();
+      return affinityOp->emitOpError(
+          "failed to convert unserialized encoding to serialized encoding");
     }
   }
   return success();
@@ -720,9 +782,15 @@ struct SpecializeEncodingsPass
 
     StreamTensorOpUpdater streamTensorOpUpdater(moduleOp);
     if (failed(streamTensorOpUpdater.init())) {
-      moduleOp.emitError("failed to initialize StreamTensorOpUpdater");
-      return signalPassFailure();
+      LLVM_DEBUG(
+          llvm::dbgs()
+          << "failed to initialize StreamTensorOpUpdater, skip the pass.");
+      return;
     }
+
+    // Signal a pass failure if any of following steps is failed. At this point,
+    // we recognize that all the unserialized encodings can be handled by the
+    // pass.
     if (failed(streamTensorOpUpdater.run())) {
       moduleOp.emitError(
           "failed to add layouts to Stream::TensorPhaseOp with encodings");
@@ -731,8 +799,9 @@ struct SpecializeEncodingsPass
 
     SymbolTable symbolTable(moduleOp);
     for (auto funcOp : moduleOp.getOps<FunctionOpInterface>()) {
-      if (failed(duplicateExecutablesPerLayoutVariant(moduleOp, symbolTable,
-                                                      funcOp))) {
+      if (failed(duplicateExecutablesPerLayoutVariant(
+              moduleOp, symbolTable,
+              streamTensorOpUpdater.getTensorDispatchOps()))) {
         funcOp.emitError("failed on executable duplication");
         return signalPassFailure();
       }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
@@ -76,7 +76,7 @@ static bool isRecognizedEncodingType(Type type) {
   if (!rankedTensorType) {
     return false;
   }
-  auto encoding = rankedTensorType.getEncoding();
+  Attribute encoding = rankedTensorType.getEncoding();
   if (!encoding) {
     return false;
   }
@@ -723,7 +723,7 @@ LogicalResult StreamTensorOpUpdater::run() {
   for (auto op : streamOps) {
     if (failed(addQuery(affinityAnalysis, op))) {
       return moduleOp->emitError(
-          "failed to cache all the queris, it usually means that there are "
+          "failed to cache all the queries, it usually means that there are "
           "failures in affinity analysis");
     }
   }
@@ -788,7 +788,7 @@ struct SpecializeEncodingsPass
       return;
     }
 
-    // Signal a pass failure if any of following steps is failed. At this point,
+    // Signal a pass failure if any of following steps fails. At this point,
     // we recognize that all the unserialized encodings can be handled by the
     // pass.
     if (failed(streamTensorOpUpdater.run())) {

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
@@ -884,7 +884,7 @@ util.func public @tensor_dispatch_with_unknown_and_serialized_encodings(%arg0: !
 
 #unknown_encoding = #iree_encoding.unknown_encoding
 #encoding = #iree_encoding.testing_encoding<>
-#executable_target_a = #hal.executable.target<"target_a", "abc", {encoding = #iree_encoding.unspecialized_encoding<123>}>
+#executable_target_a = #hal.executable.target<"target_a", "abc", {iree.encoding.resolver = #iree_encoding.unspecialized_encoding<123>}>
 #device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_a]> : !hal.device
 util.global private @device_a = #device_target_local_0_
 stream.executable private @executable {

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
@@ -942,7 +942,6 @@ util.func public @dispatch_hal_executable(%arg0: !stream.resource<*>, %arg1: ind
 
 // It does not fail because the executable does not match the requirements.
 
-
 #encoding = #iree_encoding.unknown_encoding
 hal.executable.source public @executable {
   hal.executable.export public @dispatch ordinal(0) layout(#hal.pipeline.layout<constants = 0, bindings = [
@@ -953,5 +952,4 @@ util.func public @dispatch_hal_executable_with_encodings(%arg0: !stream.resource
   %0 = stream.tensor.dispatch @executable::@dispatch(%arg0) : (tensor<4x?xf32, #encoding>{%arg2} in !stream.resource<*>{%arg1}) -> tensor<4x?xf32, #encoding>{%arg2} in !stream.resource<*>{%arg1}
   util.return %0 : !stream.resource<*>
 }
-
 // CHECK-LABEL: util.func public @dispatch_hal_executable_with_encodings(

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
@@ -182,7 +182,8 @@ util.func public @tensor_fill_op(%arg0: f32, %arg1: !stream.resource<*>, %arg2: 
 
 // -----
 
-// Checks that the stream.tensor.constant op with encoding is not supported.
+// Checks that the stream.tensor.constant op with unserialized encoding is not
+// supported.
 
 #executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.unspecialized_encoding<123>}>
 #device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
@@ -191,7 +192,8 @@ util.func public @tensor_fill_op(%arg0: f32, %arg1: !stream.resource<*>, %arg2: 
 // expected-error @+1 {{failed to add layouts to Stream::TensorPhaseOp with encodings}}
 module {
   util.global private @device_a = #device_target_local_0_
-  util.func public @ops_with_result_encoding_only(%arg0: index) {
+  util.func public @tensor_constant_op_with_unserialized_encoding(%arg0: index) {
+    // expected-error @+1 {{failed to convert unserialized encoding to serialized encoding}}
     %0 = stream.tensor.constant on(#hal.device.affinity<@device_a>) : tensor<?x5x64xf32, #encoding>{%arg0} in !stream.resource<constant> = dense<0.000000e+00> : tensor<1x5x64xf32>
     util.return
   }
@@ -199,7 +201,34 @@ module {
 
 // -----
 
-// Checks that the stream.tensor.clone op with encoding is not supported.
+#encoding = #iree_encoding.testing_encoding<[#iree_encoding.specialized_encoding<123>]>
+util.global private @device_a : !hal.device
+util.func public @tensor_constant_op_with_serialized_encoding(%arg0: index) {
+  %0 = stream.tensor.constant on(#hal.device.affinity<@device_a>) : tensor<?x5x64xf32, #encoding>{%arg0} in !stream.resource<constant> = dense<0.000000e+00> : tensor<1x5x64xf32>
+  util.return
+}
+// CHECK:       #[[$SERIALIZED_ENCODING:.+]] = #iree_encoding.testing_encoding<[#iree_encoding.specialized_encoding<123>]>
+// CHECK-LABEL: util.func public @tensor_constant_op_with_serialized_encoding(
+// CHECK:         stream.tensor.constant
+// CHECK-SAME:      tensor<?x5x64xf32, #[[$SERIALIZED_ENCODING]]>
+
+// -----
+
+#encoding = #iree_encoding.unknown_encoding
+util.global private @device_a : !hal.device
+util.func public @tensor_constant_op_with_unknown_encoding(%arg0: index) {
+  %0 = stream.tensor.constant on(#hal.device.affinity<@device_a>) : tensor<?x5x64xf32, #encoding>{%arg0} in !stream.resource<constant> = dense<0.000000e+00> : tensor<1x5x64xf32>
+  util.return
+}
+// CHECK:       #[[$UNKNOWN_ENCODING:.+]] = #iree_encoding.unknown_encoding
+// CHECK-LABEL: util.func public @tensor_constant_op_with_unknown_encoding(
+// CHECK:         stream.tensor.constant
+// CHECK-SAME:      tensor<?x5x64xf32, #[[$UNKNOWN_ENCODING]]>
+
+// -----
+
+// Checks that the stream.tensor.clone op with unserialized encoding is not
+// supported.
 
 #executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.unspecialized_encoding<123>}>
 #device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
@@ -208,7 +237,8 @@ module {
 // expected-error @+1 {{failed to add layouts to Stream::TensorPhaseOp with encodings}}
 module {
   util.global private @device_a = #device_target_local_0_
-  util.func public @tensor_clone_op(%arg0: !stream.resource<*>, %arg1: index, %arg2: index, %arg3: index, %arg4: index) {
+  util.func public @tensor_clone_op_with_unserialized_encoding(%arg0: !stream.resource<*>, %arg1: index, %arg2: index, %arg3: index, %arg4: index) {
+    // expected-error @+1 {{failed to convert unserialized encoding to serialized encoding}}
     %0 = stream.tensor.clone on(#hal.device.affinity<@device_a>)
       %arg0 : tensor<?x4xf32, #encoding>{%arg1} in !stream.resource<*>{%arg2}
       -> tensor<?x4xf32, #encoding>{%arg1} in !stream.resource<*>{%arg2}
@@ -218,7 +248,41 @@ module {
 
 // -----
 
-// Checks that the stream.tensor.slice op with encoding is not supported.
+#unknown_encoding = #iree_encoding.unknown_encoding
+util.global private @device_a : !hal.device
+util.func public @tensor_clone_op_with_unknown_encodings(%arg0: !stream.resource<*>, %arg1: index, %arg2: index, %arg3: index, %arg4: index) {
+  %0 = stream.tensor.clone on(#hal.device.affinity<@device_a>)
+    %arg0 : tensor<?x4xf32, #unknown_encoding>{%arg1} in !stream.resource<*>{%arg2}
+    -> tensor<?x4xf32, #unknown_encoding>{%arg1} in !stream.resource<*>{%arg2}
+  util.return
+}
+// CHECK-DAG:   #[[$UNKNOWN_ENCODING:.+]] = #iree_encoding.unknown_encoding
+// CHECK-LABEL: util.func public @tensor_clone_op_with_unknown_encodings(
+// CHECK:         stream.tensor.clone
+// CHECK-SAME:      tensor<?x4xf32, #[[$UNKNOWN_ENCODING]]>
+// CHECK-SAME:      tensor<?x4xf32, #[[$UNKNOWN_ENCODING]]>
+
+
+// -----
+
+#serialized_encoding = #iree_encoding.testing_encoding<[#iree_encoding.specialized_encoding<123>]>
+util.global private @device_a : !hal.device
+util.func public @tensor_clone_op_with_serialized_encodings(%arg0: !stream.resource<*>, %arg1: index, %arg2: index, %arg3: index, %arg4: index) {
+  %0 = stream.tensor.clone on(#hal.device.affinity<@device_a>)
+    %arg0 : tensor<?x4xf32, #serialized_encoding>{%arg1} in !stream.resource<*>{%arg2}
+    -> tensor<?x4xf32, #serialized_encoding>{%arg1} in !stream.resource<*>{%arg2}
+  util.return
+}
+// CHECK-DAG:   #[[$SERIALIZED_ENCODING:.+]] = #iree_encoding.testing_encoding<[#iree_encoding.specialized_encoding<123>]>
+// CHECK-LABEL: util.func public @tensor_clone_op_with_serialized_encodings(
+// CHECK:         stream.tensor.clone
+// CHECK-SAME:      tensor<?x4xf32, #[[$SERIALIZED_ENCODING]]>
+// CHECK-SAME:      tensor<?x4xf32, #[[$SERIALIZED_ENCODING]]>
+
+// -----
+
+// Checks that the stream.tensor.slice op with unserialized encoding is not
+// supported.
 
 #executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.unspecialized_encoding<123>}>
 #device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
@@ -230,6 +294,7 @@ module {
   util.func public @tensor_slice_op_with_encoding(%arg0: !stream.resource<*>, %arg1: index, %arg2: index, %arg3: index, %arg4: index) {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
+    // expected-error @+1 {{failed to convert unserialized encoding to serialized encoding}}
     %1 = stream.tensor.slice on(#hal.device.affinity<@device_a>)
       %arg0[%c0, %c1 for %arg3, %c1] : tensor<?x4xf32, #encoding>{%arg1} in !stream.resource<*>{%arg2}
       -> tensor<?x1xf32, #encoding>{%arg3} in !stream.resource<*>{%arg4}
@@ -239,7 +304,28 @@ module {
 
 // -----
 
-// Checks that the stream.tensor.update op with encoding is not supported.
+#unknown_encoding = #iree_encoding.unknown_encoding
+#serialized_encoding = #iree_encoding.testing_encoding<[#iree_encoding.specialized_encoding<123>]>
+util.global private @device_a : !hal.device
+util.func public @tensor_slice_op_with_unknown_or_serialized_encodings(%arg0: !stream.resource<*>, %arg1: index, %arg2: index, %arg3: index, %arg4: index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %1 = stream.tensor.slice on(#hal.device.affinity<@device_a>)
+    %arg0[%c0, %c1 for %arg3, %c1] : tensor<?x4xf32, #unknown_encoding>{%arg1} in !stream.resource<*>{%arg2}
+    -> tensor<?x1xf32, #serialized_encoding>{%arg3} in !stream.resource<*>{%arg4}
+  util.return
+}
+// CHECK:       #[[$UNKNOWN_ENCODING:.+]] = #iree_encoding.unknown_encoding
+// CHECK:       #[[$SERIALIZED_ENCODING:.+]] = #iree_encoding.testing_encoding<[#iree_encoding.specialized_encoding<123>]>
+// CHECK-LABEL: util.func public @tensor_slice_op_with_unknown_or_serialized_encodings(
+// CHECK:         stream.tensor.slice
+// CHECK-SAME:      tensor<?x4xf32, #[[$UNKNOWN_ENCODING]]>
+// CHECK-SAME:      tensor<?x1xf32, #[[$SERIALIZED_ENCODING]]>
+
+// -----
+
+// Checks that the stream.tensor.update op with unserialized encoding is not
+// supported.
 
 #executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.unspecialized_encoding<123>}>
 #device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
@@ -247,10 +333,11 @@ module {
 
 // expected-error @+1 {{failed to add layouts to Stream::TensorPhaseOp with encodings}}
 module {
-util.global private @device_a = #device_target_local_0_
-  util.func public @tensor_update_op(%arg0: !stream.resource<*>, %arg1: index, %arg2: !stream.resource<*>, %arg3: index, %arg4: index) {
+  util.global private @device_a = #device_target_local_0_
+  util.func public @tensor_update_op_with_unserialized_encodings(%arg0: !stream.resource<*>, %arg1: index, %arg2: !stream.resource<*>, %arg3: index, %arg4: index) {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
+    // expected-error @+1 {{failed to convert unserialized encoding to serialized encoding}}
     %0 = stream.tensor.update on(#hal.device.affinity<@device_a>)
       %arg0, %arg2[%c0, %c0] : tensor<2x2xf32, #encoding> in !stream.resource<*>{%arg1}
       -> tensor<?x4xf32, #encoding>{%arg3} in %arg2 as !stream.resource<*>{%arg4}
@@ -260,12 +347,33 @@ util.global private @device_a = #device_target_local_0_
 
 // -----
 
+#unknown_encoding = #iree_encoding.unknown_encoding
+#serialized_encoding = #iree_encoding.testing_encoding<[#iree_encoding.specialized_encoding<123>]>
+util.global private @device_a : !hal.device
+util.func public @tensor_update_op_with_unknown_or_serialized_encodings(%arg0: !stream.resource<*>, %arg1: index, %arg2: !stream.resource<*>, %arg3: index, %arg4: index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %0 = stream.tensor.update on(#hal.device.affinity<@device_a>)
+    %arg0, %arg2[%c0, %c0] : tensor<2x2xf32, #unknown_encoding> in !stream.resource<*>{%arg1}
+    -> tensor<?x4xf32, #serialized_encoding>{%arg3} in %arg2 as !stream.resource<*>{%arg4}
+  util.return
+}
+// CHECK:       #[[$UNKNOWN_ENCODING:.+]] = #iree_encoding.unknown_encoding
+// CHECK:       #[[$SERIALIZED_ENCODING:.+]] = #iree_encoding.testing_encoding<[#iree_encoding.specialized_encoding<123>]>
+// CHECK-LABEL: util.func public @tensor_update_op_with_unknown_or_serialized_encodings(
+// CHECK:         stream.tensor.update
+// CHECK-SAME:      tensor<2x2xf32, #[[$UNKNOWN_ENCODING]]>
+// CHECK-SAME:      tensor<?x4xf32, #[[$SERIALIZED_ENCODING]]>
+
+// -----
+
 // Drop encodings if encoding attribute is not available in the target
 // configuration.
 
 #executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {}>
 #device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
 #encoding = #iree_encoding.testing_encoding<>
+
 util.global private @device_a = #device_target_local_0_
 util.func public @drop_encoding(%arg0: index, %arg1: index, %scalar_f32 : f32) {
   %0 = stream.tensor.empty on(#hal.device.affinity<@device_a>) : tensor<?x0xf32, #encoding>{%arg0} in !stream.resource<*>{%arg1}
@@ -281,6 +389,7 @@ util.func public @drop_encoding(%arg0: index, %arg1: index, %scalar_f32 : f32) {
 #executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", { iree.encoding.resolver = #iree_encoding.unsupported_encoding }>
 #device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
 #encoding = #iree_encoding.testing_encoding<>
+
 util.global private @device_a = #device_target_local_0_
 util.func public @drop_encoding_by_unsupported_encoding(%arg0: index, %arg1: index, %scalar_f32 : f32) {
   %0 = stream.tensor.empty on(#hal.device.affinity<@device_a>) : tensor<?x0xf32, #encoding>{%arg0} in !stream.resource<*>{%arg1}
@@ -732,9 +841,91 @@ util.func public @multi_device_gemm(%arg0: !stream.resource<external>, %arg1: !s
 
 // -----
 
+// A test for unknown encodings and already serialized encodings. It does
+// nothing if the encoding is not recognized. It updates the subspan binding, if
+// the encoding is already serialized.
+
+#unknown_encoding = #iree_encoding.unknown_encoding
+#serialized_encoding = #iree_encoding.testing_encoding<[#iree_encoding.specialized_encoding<123>]>
+util.global private @device_a : !hal.device
+stream.executable private @executable {
+  stream.executable.export public @dispatch
+  builtin.module {
+    func.func @dispatch(%arg0: !stream.binding, %arg1: index, %arg2: !stream.binding) {
+      %c0 = arith.constant 0 : index
+      %0 = stream.binding.subspan %arg0[%c0] : !stream.binding -> !flow.dispatch.tensor<readonly:tensor<4x?xf32>>{%arg1}
+      %1 = stream.binding.subspan %arg2[%c0] : !stream.binding -> !flow.dispatch.tensor<writeonly:tensor<4x?xf32>>{%arg1}
+      return
+    }
+  }
+}
+util.func public @tensor_dispatch_with_unknown_and_serialized_encodings(%arg0: !stream.resource<external>, %arg1: index, %arg2: index, %arg3: index) -> !stream.resource<*> {
+  %0 = stream.async.transfer %arg0 : !stream.resource<external>{%arg2} on(#hal.device.affinity<@device_a>) from(#hal.device.affinity<@device_a>) -> to(#hal.device.affinity<@device_a>) !stream.resource<*>{%arg2}
+  %1 = stream.tensor.dispatch on(#hal.device.affinity<@device_a>) @executable::@dispatch(%0, %arg3) : (tensor<4x?xf32, #unknown_encoding>{%arg2} in !stream.resource<*>{%arg1}, index) -> tensor<4x?xf32, #serialized_encoding>{%arg2} in !stream.resource<*>{%arg1}
+  util.return %1 : !stream.resource<*>
+}
+// CHECK-DAG:   #[[$UNKNOWN_ENCODING:.+]] = #iree_encoding.unknown_encoding
+// CHECK-DAG:   #[[$SERIALIZED_ENCODING:.+]] = #iree_encoding.testing_encoding<[#iree_encoding.specialized_encoding<123>]>
+// CHECK:       stream.executable
+// CHECK:         func.func
+// CHECK-SAME:      %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK-SAME:      %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK-SAME:      %[[ARG2:[a-zA-Z0-9]+]]
+// CHECK-DAG:       stream.binding.subspan %[[ARG0]]{{.+}} !flow.dispatch.tensor<readonly:tensor<4x?xf32>>
+// CHECK-DAG:       stream.binding.subspan %[[ARG2]]{{.+}} !flow.dispatch.tensor<writeonly:tensor<4x?xf32, #[[$SERIALIZED_ENCODING]]>>
+// CHECK-LABEL: util.func public @tensor_dispatch_with_unknown_and_serialized_encodings(
+// CHECK:         stream.tensor.dispatch
+// CHECK:           tensor<4x?xf32, #[[$UNKNOWN_ENCODING]]>
+// CHECK:           tensor<4x?xf32, #[[$SERIALIZED_ENCODING]]>
+
+// -----
+
+// Test that the unserialized encoding is serialized, and the unknown encoding
+// is the same.
+
+#unknown_encoding = #iree_encoding.unknown_encoding
+#encoding = #iree_encoding.testing_encoding<>
+#executable_target_a = #hal.executable.target<"target_a", "abc", {encoding = #iree_encoding.unspecialized_encoding<123>}>
+#device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_a]> : !hal.device
+util.global private @device_a = #device_target_local_0_
+stream.executable private @executable {
+  stream.executable.export public @dispatch
+  builtin.module {
+    func.func @dispatch(%arg0: !stream.binding, %arg1: index, %arg2: !stream.binding) {
+      %c0 = arith.constant 0 : index
+      %0 = stream.binding.subspan %arg0[%c0] : !stream.binding -> !flow.dispatch.tensor<readonly:tensor<4x?xf32>>{%arg1}
+      %1 = stream.binding.subspan %arg2[%c0] : !stream.binding -> !flow.dispatch.tensor<writeonly:tensor<4x?xf32>>{%arg1}
+      return
+    }
+  }
+}
+util.func public @tensor_dispatch_with_unknown_and_unserialized_encodings(%arg0: !stream.resource<external>, %arg1: index, %arg2: index, %arg3: index) -> !stream.resource<*> {
+  %0 = stream.async.transfer %arg0 : !stream.resource<external>{%arg2} on(#hal.device.affinity<@device_a>) from(#hal.device.affinity<@device_a>) -> to(#hal.device.affinity<@device_a>) !stream.resource<*>{%arg2}
+  %1 = stream.tensor.dispatch on(#hal.device.affinity<@device_a>) @executable::@dispatch(%0, %arg3) : (tensor<4x?xf32, #unknown_encoding>{%arg2} in !stream.resource<*>{%arg1}, index) -> tensor<4x?xf32, #encoding>{%arg2} in !stream.resource<*>{%arg1}
+  util.return %1 : !stream.resource<*>
+}
+// CHECK-DAG:   #[[$UNKNOWN_ENCODING:.+]] = #iree_encoding.unknown_encoding
+// CHECK-DAG:   #[[$SERIALIZED_ENCODING:.+]] = #iree_encoding.testing_encoding<[#iree_encoding.specialized_encoding<123, tensor<4x?xf32>>]>
+// CHECK:       stream.executable
+// CHECK:         func.func
+// CHECK-SAME:      %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK-SAME:      %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK-SAME:      %[[ARG2:[a-zA-Z0-9]+]]
+// CHECK-DAG:       stream.binding.subspan %[[ARG0]]{{.+}} !flow.dispatch.tensor<readonly:tensor<4x?xf32>>
+// CHECK-DAG:       stream.binding.subspan %[[ARG2]]{{.+}} !flow.dispatch.tensor<writeonly:tensor<4x?xf32, #[[$SERIALIZED_ENCODING]]>>
+// CHECK-LABEL: util.func public @tensor_dispatch_with_unknown_and_unserialized_encodings(
+// CHECK:         stream.tensor.dispatch
+// CHECK:           tensor<4x?xf32, #[[$UNKNOWN_ENCODING]]>
+// CHECK:           tensor<4x?xf32, #[[$SERIALIZED_ENCODING]]>
+
+// -----
+
 //------------------------------------------------------------------------------
 // Negative tests. The pass should do nothing for the cases.
 //------------------------------------------------------------------------------
+
+// It does not fail because there are no encodings on stream.tensor.dispatch
+// ops.
 
 hal.executable.source public @executable {
   hal.executable.export public @dispatch ordinal(0) layout(#hal.pipeline.layout<constants = 0, bindings = [
@@ -745,4 +936,22 @@ util.func public @dispatch_hal_executable(%arg0: !stream.resource<*>, %arg1: ind
   %0 = stream.tensor.dispatch @executable::@dispatch(%arg0) : (tensor<4x?xf32>{%arg2} in !stream.resource<*>{%arg1}) -> tensor<4x?xf32>{%arg2} in !stream.resource<*>{%arg1}
   util.return %0 : !stream.resource<*>
 }
-// CHECK-LABEL: util.func public @dispatch_hal_executable
+// CHECK-LABEL: util.func public @dispatch_hal_executable(
+
+// -----
+
+// It does not fail because the executable does not match the requirements.
+
+
+#encoding = #iree_encoding.unknown_encoding
+hal.executable.source public @executable {
+  hal.executable.export public @dispatch ordinal(0) layout(#hal.pipeline.layout<constants = 0, bindings = [
+    #hal.pipeline.binding<storage_buffer>
+  ]>)
+}
+util.func public @dispatch_hal_executable_with_encodings(%arg0: !stream.resource<*>, %arg1: index, %arg2: index) -> !stream.resource<*> {
+  %0 = stream.tensor.dispatch @executable::@dispatch(%arg0) : (tensor<4x?xf32, #encoding>{%arg2} in !stream.resource<*>{%arg1}) -> tensor<4x?xf32, #encoding>{%arg2} in !stream.resource<*>{%arg1}
+  util.return %0 : !stream.resource<*>
+}
+
+// CHECK-LABEL: util.func public @dispatch_hal_executable_with_encodings(

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
@@ -262,7 +262,6 @@ util.func public @tensor_clone_op_with_unknown_encodings(%arg0: !stream.resource
 // CHECK-SAME:      tensor<?x4xf32, #[[$UNKNOWN_ENCODING]]>
 // CHECK-SAME:      tensor<?x4xf32, #[[$UNKNOWN_ENCODING]]>
 
-
 // -----
 
 #serialized_encoding = #iree_encoding.testing_encoding<[#iree_encoding.specialized_encoding<123>]>


### PR DESCRIPTION
A recognized encoding indicates an attribute that implements SerializableEncodingAttrInterface. If an encoding does not implement the interface, it is an unknown/unrecognized encoding.

The revision makes the SpecializeEncoding pass more robust. It filters all the ops that need the specialization. I.e., it filters out the ops that do not have any recognized encoding. For DispatchTensorOp, it also checks if the corresponding executables/functions match the assumptions or not. In the pass, the specializable cases must match:

- The corresponding executable is a stream.executable op.
- The function arguments, where the types are !stream.binding_type, are only used by stream.binding.subspan ops. Furthermore, the result type of subspan ops have to implement IREE::Encoding::EncodingTypeInterface.

If one of the requirements does not meet, the op won't be updated. If the encoding is unrecognized, the pass does nothing. If the encoding is recognized and it is already serialized, the pass updates the bindings with the serialized encodings.

To test unrecognized encoding, the revision introduces `UnknownEncodingAttr` and uses it for testing.