### PR TITLE
[stream] Dedeplicate `stream.yield` values from `stream.async.execute`

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
@@ -2319,9 +2319,7 @@ struct DeduplicateYieldCmdExecuteOp : public OpRewritePattern<AsyncExecuteOp> {
     auto newExecuteOp = rewriter.create<IREE::Stream::AsyncExecuteOp>(
         op.getLoc(), newTypes, newResultSizes, op.getAwaitTimepoint(),
         op.getResourceOperands(), op.getResourceOperandSizes(),
-        llvm::map_to_vector(op.getTiedOperandsAttr(), [](Attribute intAttr) {
-          return llvm::cast<IntegerAttr>(intAttr).getInt();
-        }));
+        llvm::SmallVector<int64_t>());
 
     newExecuteOp.setAffinityAttr(op.getAffinityAttr());
 


### PR DESCRIPTION
If during cleanup values are replicated in `stream.async.execute` cases it can result in double allocation of those blocks (this occurs as ScheduleAllocation assumes all returns are unique). This double allocation also results in bad numerical behavior as the separate returns may be used by different dispatches and fetch incorrect values.