### PR TITLE
[DispatchCreation] Address missed horizontal fusion case with transposes 

### DIFF
--- a/.github/workflows/pkgci_regression_test.yml
+++ b/.github/workflows/pkgci_regression_test.yml
@@ -128,10 +128,10 @@ jobs:
           pytest ./experimental/benchmarks/sdxl/benchmark_sdxl_rocm.py \
             --goldentime-tolerance-multiplier 1.3 \
             --goldentime-rocm-e2e-ms 1100.0 \
-            --goldentime-rocm-unet-ms 255.0 \
+            --goldentime-rocm-unet-ms 258.0 \
             --goldentime-rocm-clip-ms 12.0 \
             --goldentime-rocm-vae-ms 260.0 \
-            --goldendispatch-rocm-unet 1220 \
+            --goldendispatch-rocm-unet 1149 \
             --goldendispatch-rocm-clip 794 \
             --goldendispatch-rocm-vae 176 \
             --goldensize-rocm-unet-bytes 1370000  \
@@ -156,7 +156,7 @@ jobs:
             --goldentime-rocm-unet-ms 78.0 \
             --goldentime-rocm-clip-ms 9.0 \
             --goldentime-rocm-vae-ms 62.0 \
-            --goldendispatch-rocm-unet 1220 \
+            --goldendispatch-rocm-unet 1149 \
             --goldendispatch-rocm-clip 794 \
             --goldendispatch-rocm-vae 176 \
             --goldensize-rocm-unet-bytes 1400000 \
@@ -164,8 +164,8 @@ jobs:
             --goldensize-rocm-vae-bytes 430000 \
             --goldentime-rocm-punet-int8-fp16-ms 45.0 \
             --goldentime-rocm-punet-int8-fp8-ms 46.0 \
-            --goldendispatch-rocm-punet-int8-fp16 1415 \
-            --goldendispatch-rocm-punet-int8-fp8 1695 \
+            --goldendispatch-rocm-punet-int8-fp16 1275 \
+            --goldendispatch-rocm-punet-int8-fp8 1555 \
             --goldensize-rocm-punet-int8-fp8-bytes 2200000 \
             --goldensize-rocm-punet-int8-fp16-bytes 2000000 \
             --rocm-chip gfx942 \
@@ -182,19 +182,19 @@ jobs:
           pytest ./experimental/benchmarks/sdxl/benchmark_sdxl_rocm.py \
             --goldentime-tolerance-multiplier 1.1 \
             --goldentime-rocm-e2e-ms 740.0 \
-            --goldentime-rocm-unet-ms 191.0 \
+            --goldentime-rocm-unet-ms 198.0 \
             --goldentime-rocm-clip-ms 12.0 \
             --goldentime-rocm-vae-ms 146.0 \
-            --goldendispatch-rocm-unet 1220 \
+            --goldendispatch-rocm-unet 1149 \
             --goldendispatch-rocm-clip 794 \
             --goldendispatch-rocm-vae 176 \
             --goldensize-rocm-unet-bytes 1400000 \
             --goldensize-rocm-clip-bytes 460000 \
             --goldensize-rocm-vae-bytes 430000 \
-            --goldentime-rocm-punet-int8-fp16-ms 115.0 \
-            --goldentime-rocm-punet-int8-fp8-ms 115.0 \
-            --goldendispatch-rocm-punet-int8-fp16 1415 \
-            --goldendispatch-rocm-punet-int8-fp8 1695 \
+            --goldentime-rocm-punet-int8-fp16-ms 118.0 \
+            --goldentime-rocm-punet-int8-fp8-ms 119.0 \
+            --goldendispatch-rocm-punet-int8-fp16 1275 \
+            --goldendispatch-rocm-punet-int8-fp8 1555 \
             --goldensize-rocm-punet-int8-fp8-bytes 2200000 \
             --goldensize-rocm-punet-int8-fp16-bytes 2000000 \
             --rocm-chip gfx942 \

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -705,11 +705,10 @@ isContractionOpSequence(Value yielded) {
 /// TODO: The logic below is quite convoluted. Might be better
 /// off having a dedicated operation for this.
 bool isaHorizontallyFusedContraction(Operation *op) {
-  auto linalgOp = dyn_cast_or_null<linalg::GenericOp>(op);
+  auto linalgOp = dyn_cast_or_null<linalg::LinalgOp>(op);
   if (!linalgOp) {
     return false;
   }
-
   if (linalgOp->getNumResults() == 1) {
     return false;
   }

--- a/compiler/src/iree/compiler/DispatchCreation/test/form_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/form_dispatch_regions.mlir
@@ -1286,14 +1286,16 @@ util.func @horizontal_fusion3(%lhs : tensor<2x4096x640xf16>,
   } -> tensor<2x10x64x4096xf16>
   util.return %8, %9, %10 : tensor<2x10x4096x64xf16>, tensor<2x10x4096x64xf16>, tensor<2x10x64x4096xf16>
 }
-// CHECK-LABEL: func public @horizontal_fusion3
-//       CHECK:   %[[DISPATCH:.+]]:3 = flow.dispatch.region
-//       CHECK:     %[[GENERIC:.+]]:3 = linalg.generic
-//       CHECK:     %[[TRUNC0:.+]] = linalg.generic
-//  CHECK-SAME:         ins(%[[GENERIC]]#0 :
-//       CHECK:     %[[TRUNC1:.+]] = linalg.generic
-//  CHECK-SAME:         ins(%[[GENERIC]]#1 :
-//       CHECK:     %[[TRUNC2:.+]] = linalg.generic
-//  CHECK-SAME:         ins(%[[GENERIC]]#2 :
-//       CHECK:     flow.return %[[TRUNC0]], %[[TRUNC1]], %[[TRUNC2]]
-//       CHECK:   util.return %[[DISPATCH]]#0, %[[DISPATCH]]#1, %[[DISPATCH]]#2
+//      CHECK: #[[INTERCHANGED_MAP:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3, d2)>
+//      CHECK: func public @horizontal_fusion3
+//      CHECK:   %[[DISPATCH:.+]]:3 = flow.dispatch.region
+//      CHECK:     %[[GENERIC:.+]]:3 = linalg.generic
+//      CHECK:     %[[TRUNC0:.+]] = linalg.generic
+// CHECK-SAME:         ins(%[[GENERIC]]#0 :
+//      CHECK:     %[[TRUNC1:.+]] = linalg.generic
+// CHECK-SAME:         ins(%[[GENERIC]]#1 :
+//      CHECK:     %[[TRUNC2:.+]] = linalg.generic
+// CHECK-SANE:         indexing_maps = [#[[INTERCHANGED_MAP]], #[[INTERCHANGED_MAP]]]
+// CHECK-SAME:         ins(%[[GENERIC]]#2 :
+//      CHECK:     flow.return %[[TRUNC0]], %[[TRUNC1]], %[[TRUNC2]]
+//      CHECK:   util.return %[[DISPATCH]]#0, %[[DISPATCH]]#1, %[[DISPATCH]]#2

--- a/compiler/src/iree/compiler/DispatchCreation/test/form_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/form_dispatch_regions.mlir
@@ -1213,3 +1213,87 @@ util.func @avoid_use_def_violation_on_consumer_fusion(%arg0 : tensor<?xf32>,
 //  CHECK-SAME:         ins(%[[DISPATCH1]], %[[BARRIER]] :
 //       CHECK:     flow.return %[[GENERIC2]]
 //       CHECK:   util.return %[[DISPATCH2]]
+
+// -----
+
+util.func @horizontal_fusion3(%lhs : tensor<2x4096x640xf16>,
+    %rhs0 : tensor<10x64x640xf16>, %rhs1 : tensor<10x64x640xf16>,
+    %rhs2 : tensor<10x64x640xf16>) ->
+    (tensor<2x10x4096x64xf16>, tensor<2x10x4096x64xf16>,
+     tensor<2x10x64x4096xf16>) {
+  %0 = tensor.empty() : tensor<2x10x64x4096xf32>
+  %4 = tensor.empty() : tensor<2x10x4096x64xf32>
+  %cst = arith.constant 0.0 : f32
+  %1 = linalg.fill ins(%cst : f32)
+      outs(%0 : tensor<2x10x64x4096xf32>) -> tensor<2x10x64x4096xf32>
+  %5 = linalg.fill ins(%cst : f32)
+      outs(%4 : tensor<2x10x4096x64xf32>) -> tensor<2x10x4096x64xf32>
+  %6:3 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4)>,
+                       affine_map<(d0, d1, d2, d3, d4) -> (d1, d3, d4)>,
+                       affine_map<(d0, d1, d2, d3, d4) -> (d1, d3, d4)>,
+                       affine_map<(d0, d1, d2, d3, d4) -> (d1, d3, d4)>,
+                       affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>,
+                       affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>,
+                       affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d3, d2)>],
+      iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]}
+      ins(%lhs, %rhs0, %rhs1, %rhs2
+          : tensor<2x4096x640xf16>, tensor<10x64x640xf16>, tensor<10x64x640xf16>,
+            tensor<10x64x640xf16>)
+      outs(%5, %5, %1
+          : tensor<2x10x4096x64xf32>, tensor<2x10x4096x64xf32>, tensor<2x10x64x4096xf32>) {
+  ^bb0(%in: f16, %in_0: f16, %in_1: f16, %in_2: f16, %out: f32, %out_3: f32, %out_4: f32):
+    %14 = arith.extf %in : f16 to f32
+    %15 = arith.extf %in_0 : f16 to f32
+    %16 = arith.mulf %14, %15 : f32
+    %17 = arith.addf %out, %16 : f32
+    %18 = arith.extf %in_1 : f16 to f32
+    %19 = arith.mulf %14, %18 : f32
+    %20 = arith.addf %out_3, %19 : f32
+    %21 = arith.extf %in_2 : f16 to f32
+    %22 = arith.mulf %14, %21 : f32
+    %23 = arith.addf %out_4, %22 : f32
+    linalg.yield %17, %20, %23 : f32, f32, f32
+  } -> (tensor<2x10x4096x64xf32>, tensor<2x10x4096x64xf32>, tensor<2x10x64x4096xf32>)
+  %7 = tensor.empty() : tensor<2x10x4096x64xf16>
+  %8 = linalg.generic {
+        indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>,
+                         affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
+        iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+        ins(%6#0 : tensor<2x10x4096x64xf32>) outs(%7 : tensor<2x10x4096x64xf16>) {
+  ^bb0(%in: f32, %out: f16):
+    %14 = arith.truncf %in : f32 to f16
+    linalg.yield %14 : f16
+  } -> tensor<2x10x4096x64xf16>
+  %9 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>,
+                       affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
+      iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+      ins(%6#1 : tensor<2x10x4096x64xf32>) outs(%7 : tensor<2x10x4096x64xf16>) {
+  ^bb0(%in: f32, %out: f16):
+    %14 = arith.truncf %in : f32 to f16
+    linalg.yield %14 : f16
+  } -> tensor<2x10x4096x64xf16>
+  %2 = tensor.empty() : tensor<2x10x64x4096xf16>
+  %10 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>,
+                       affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
+      iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+      ins(%6#2 : tensor<2x10x64x4096xf32>) outs(%2 : tensor<2x10x64x4096xf16>) {
+  ^bb0(%in: f32, %out: f16):
+    %14 = arith.truncf %in : f32 to f16
+    linalg.yield %14 : f16
+  } -> tensor<2x10x64x4096xf16>
+  util.return %8, %9, %10 : tensor<2x10x4096x64xf16>, tensor<2x10x4096x64xf16>, tensor<2x10x64x4096xf16>
+}
+// CHECK-LABEL: func public @horizontal_fusion3
+//       CHECK:   %[[DISPATCH:.+]]:3 = flow.dispatch.region
+//       CHECK:     %[[GENERIC:.+]]:3 = linalg.generic
+//       CHECK:     %[[TRUNC0:.+]] = linalg.generic
+//  CHECK-SAME:         ins(%[[GENERIC]]#0 :
+//       CHECK:     %[[TRUNC1:.+]] = linalg.generic
+//  CHECK-SAME:         ins(%[[GENERIC]]#1 :
+//       CHECK:     %[[TRUNC2:.+]] = linalg.generic
+//  CHECK-SAME:         ins(%[[GENERIC]]#2 :
+//       CHECK:     flow.return %[[TRUNC0]], %[[TRUNC1]], %[[TRUNC2]]
+//       CHECK:   util.return %[[DISPATCH]]#0, %[[DISPATCH]]#1, %[[DISPATCH]]#2


### PR DESCRIPTION
The check for finding valid gemms to fuse with did not permute the
indices of the LHS if required and use the permuted op to make the
decision. This change fixes this.

This change also actually triggers the horizontal fusions that were
missed earlier. For mi300 this keeps the existing performance, but
there is a slight slowdown for other AMD cards that we arent really
tracking at bleeding edge of performance. So adjust all the dispatch
counts and runtimes as seen with this PR.

Signed-off-by: MaheshRavishankar <mahesh.ravishankar@gmail.com>