### PR TITLE
[docs] Fix snippet start line to avoid markdownlint comment.

### DIFF
--- a/docs/website/docs/guides/deployment-configurations/cpu.md
+++ b/docs/website/docs/guides/deployment-configurations/cpu.md
@@ -74,7 +74,7 @@ You can check for CPU support by looking for the `local-sync` and `local-task`
 drivers and devices:
 
 ```console hl_lines="10-11"
---8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-driver-list.md:1"
+--8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-driver-list.md:2"
 ```
 
 ```console hl_lines="4-5"

--- a/docs/website/docs/guides/deployment-configurations/gpu-cuda.md
+++ b/docs/website/docs/guides/deployment-configurations/gpu-cuda.md
@@ -53,7 +53,7 @@ Next you will need to get an IREE runtime that includes the CUDA HAL driver.
 You can check for CUDA support by looking for a matching driver and device:
 
 ```console hl_lines="8"
---8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-driver-list.md:1"
+--8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-driver-list.md:2"
 ```
 
 ```console hl_lines="3"

--- a/docs/website/docs/guides/deployment-configurations/gpu-rocm.md
+++ b/docs/website/docs/guides/deployment-configurations/gpu-rocm.md
@@ -55,7 +55,7 @@ Next you will need to get an IREE runtime that includes the HIP HAL driver.
 You can check for HIP support by looking for a matching driver and device:
 
 ```console hl_lines="9"
---8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-driver-list.md:1"
+--8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-driver-list.md:2"
 ```
 
 ```console hl_lines="3"

--- a/docs/website/docs/guides/deployment-configurations/gpu-vulkan.md
+++ b/docs/website/docs/guides/deployment-configurations/gpu-vulkan.md
@@ -104,7 +104,7 @@ Next you will need to get an IREE runtime that supports the Vulkan HAL driver.
 You can check for Vulkan support by looking for a matching driver and device:
 
 ```console hl_lines="12"
---8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-driver-list.md:1"
+--8<-- "docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-driver-list.md:2"
 ```
 
 ```console hl_lines="6"


### PR DESCRIPTION
This excludes the first comment line here and moves the highlighting to the correct line: https://github.com/iree-org/iree/blob/bc6ecb1259bb830b4cb71b6ca14fed53e6faeeed/docs/website/docs/guides/deployment-configurations/snippets/_iree-run-module-driver-list.md?plain=1#L1-L2 ![image](https://github.com/user-attachments/assets/fff75786-6348-45a0-a122-25291379b11a)

Must have somehow missed that on https://github.com/iree-org/iree/pull/19920... I thought `:1` was doing the right thing then 🤔 