### PR TITLE
[GPU] Update reshape propagation patterns to preserve fill and transpose

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.h
@@ -256,6 +256,17 @@ distributeLinalgOpsWithFilter(mlir::FunctionOpInterface funcOp,
                               linalg::LinalgTilingOptions tilingOptions,
                               LinalgTransformationFilter filter);
 
+using ControlFnTy = std::function<bool(Operation *)>;
+
+/// Patterns to propagate linalg tranpose ops through reshapes.
+void populateLinalgTransposeThroughCollapseShapePattern(
+    RewritePatternSet &patterns,
+    std::optional<ControlFnTy> controlFn = std::nullopt);
+
+void populateLinalgTransposeThroughExpandShapePattern(
+    RewritePatternSet &patterns,
+    std::optional<ControlFnTy> controlFn = std::nullopt);
+
 } // namespace mlir::iree_compiler
 
 #endif // IREE_COMPILER_CODEGEN_TRANSFORMS_TRANSFORMS_H_

--- a/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
+++ b/compiler/src/iree/compiler/GlobalOptimization/BUILD.bazel
@@ -77,6 +77,7 @@ iree_compiler_cc_library(
         ":PassesIncGen",
         "//compiler/src/iree/compiler/Codegen/Common",
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
+        "//compiler/src/iree/compiler/Codegen/Transforms",
         "//compiler/src/iree/compiler/Dialect/Encoding/IR",
         "//compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow",
         "//compiler/src/iree/compiler/Dialect/Flow/IR",

--- a/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
+++ b/compiler/src/iree/compiler/GlobalOptimization/CMakeLists.txt
@@ -92,6 +92,7 @@ iree_cc_library(
     MLIRTransforms
     iree::compiler::Codegen::Common
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
+    iree::compiler::Codegen::Transforms
     iree::compiler::Dialect::Encoding::IR
     iree::compiler::Dialect::Flow::Conversion::TensorToFlow
     iree::compiler::Dialect::Flow::IR


### PR DESCRIPTION
This PR uses existing patterns to do propagation through transposes and updates the control function to not use the upstream propagation patterns for fill and transpose as that causes them to generalize the fill/transpose ops.