### PR TITLE
[Codegen][GPU] Prevent overflows in GPUReduceBankConflicts

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/reduce_bank_conflicts.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/reduce_bank_conflicts.mlir
@@ -129,3 +129,30 @@ func.func @pad_alloc_rank_zero() {
   vector.transfer_write %cst, %0[] : vector<f32>, memref<f32, #gpu.address_space<workgroup>>
   return
 }
+
+// -----
+
+// CHECK-LABEL: func.func @no_padding_when_close_to_limit
+// CHECK: memref.alloc() : memref<4x32x127xf32, #gpu.address_space<workgroup>>
+func.func @no_padding_when_close_to_limit(%a: memref<1024x1024xf32>) {
+  %0 = memref.alloc() : memref<4x32x127xf32, #gpu.address_space<workgroup>>
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @no_padding_if_at_limit
+// CHECK: memref.alloc() : memref<4x32x128xf32, #gpu.address_space<workgroup>>
+func.func @no_padding_if_at_limit(%a: memref<1024x1024xf32>) {
+  %0 = memref.alloc() : memref<4x32x128xf32, #gpu.address_space<workgroup>>
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @pad_if_below_limit
+// CHECK: memref.alloc() : memref<4x32x128xf32, #gpu.address_space<workgroup>>
+func.func @pad_if_below_limit(%a: memref<1024x1024xf32>) {
+  %0 = memref.alloc() : memref<4x32x126xf32, #gpu.address_space<workgroup>>
+  return
+}


### PR DESCRIPTION
### Notes:
- Adds `computeSharedMemoryUsage` to fetch the used shared memory (without padding)
- Adds `computeEffectiveExtraBytes` to compute the extra bytes that the padding operation would add
- Modifies `runOnOperation` to query for the target GPU and check if an overflow would exist if `reduceSharedMemoryBankConflicts` were to run

### Tests:
- Adds test for checking if `paddingBits` would be set to 0 if an overflow would occur when the allocated memory before padding would be **close** to the available shared memory limit
- Adds test for checking if `paddingBits` would be set to 0 if an overflow would occur when the allocated memory before padding would be **equal** to the available shared memory limit
- Adds test for checking if `paddingBits` would **not** be set to 0 if adding the padding would fill up the available shared memory (this is useful to make sure that there are no off-by-one errors)

### Important:
Currently this implementation manually sets the index `bitWidth` to `64`, in the future it may be beneficial to make use of `GPUCheckResourceUsage` (https://github.com/iree-org/iree/blob/main/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCheckResourceUsage.cpp#L21-L25) instead of hard-coding the values.

See issue #19675 for additional context.