### PR TITLE
[DispatchCreation] Add pass to move non-fused encodings into dispatches.

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/BUILD.bazel
+++ b/compiler/src/iree/compiler/DispatchCreation/BUILD.bazel
@@ -39,6 +39,7 @@ iree_compiler_cc_library(
         "SplitReduction.cpp",
         "TensorPadToTensorInsertSlice.cpp",
         "TransposeGenericOps.cpp",
+        "WrapEncodingOpInDispatchRegion.cpp",
     ],
     hdrs = [
         "FusionUtils.h",

--- a/compiler/src/iree/compiler/DispatchCreation/CMakeLists.txt
+++ b/compiler/src/iree/compiler/DispatchCreation/CMakeLists.txt
@@ -41,6 +41,7 @@ iree_cc_library(
     "SplitReduction.cpp"
     "TensorPadToTensorInsertSlice.cpp"
     "TransposeGenericOps.cpp"
+    "WrapEncodingOpInDispatchRegion.cpp"
   DEPS
     ::PassHeaders
     ::PassesIncGen

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -259,8 +259,8 @@ static void addDispatchRegionCreationPasses(OpPassManager &passManager) {
         .addPass(DispatchCreation::createHoistEncodingOpsPass)
         // After SetEncodingOps are hoisted, try to fuse them with their
         // producer dispatches to try to hide packing costs.
-        .addPass(
-            DispatchCreation::createFuseEncodingOpsIntoDispatchRegionsPass);
+        .addPass(DispatchCreation::createFuseEncodingOpsIntoDispatchRegionsPass)
+        .addPass(DispatchCreation::createWrapEncodingOpInDispatchRegionPass);
   }
 }
 

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -290,6 +290,20 @@ def SetEncodingPass :
   ];
 }
 
+def WrapEncodingOpInDispatchRegionPass :
+    InterfacePass<"iree-dispatch-creation-wrap-encoding-op-in-dispatch-region",
+                  "mlir::FunctionOpInterface"> {
+  let summary = "Wrap encoding ops not in dispatches into a dispatch";
+  let description = [{
+    This pass is a clean up pass that runs after hoisting + fusion of encoding
+    ops. It moves any hoisted + non-fused encodings into their own dispatch".
+  }];
+  let dependentDialects = [
+    "IREE::Flow::FlowDialect",
+    "IREE::Encoding::IREEEncodingDialect",
+  ];
+}
+
 //===---------------------------------------------------------------------===//
 // Dispatch region to workgroups passes
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/DispatchCreation/WrapEncodingOpInDispatchRegion.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/WrapEncodingOpInDispatchRegion.cpp
@@ -10,6 +10,7 @@
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h"
 #include "iree/compiler/DispatchCreation/Passes.h"
+
 namespace mlir::iree_compiler::DispatchCreation {
 
 #define GEN_PASS_DEF_WRAPENCODINGOPINDISPATCHREGIONPASS

--- a/compiler/src/iree/compiler/DispatchCreation/WrapEncodingOpInDispatchRegion.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/WrapEncodingOpInDispatchRegion.cpp
@@ -1,0 +1,49 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Encoding/IR/EncodingDialect.h"
+#include "iree/compiler/Dialect/Encoding/IR/EncodingOps.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h"
+#include "iree/compiler/DispatchCreation/Passes.h"
+namespace mlir::iree_compiler::DispatchCreation {
+
+#define GEN_PASS_DEF_WRAPENCODINGOPINDISPATCHREGIONPASS
+#include "iree/compiler/DispatchCreation/Passes.h.inc"
+
+namespace {
+
+struct WrapEncodingOpInDispatchRegionPass
+    : public impl::WrapEncodingOpInDispatchRegionPassBase<
+          WrapEncodingOpInDispatchRegionPass> {
+
+  void runOnOperation() override;
+};
+
+} // namespace
+
+void WrapEncodingOpInDispatchRegionPass::runOnOperation() {
+  MLIRContext *context = &getContext();
+  mlir::FunctionOpInterface funcOp = getOperation();
+
+  SmallVector<IREE::Encoding::SetEncodingOp> encodingOps;
+  funcOp->walk([&](IREE::Encoding::SetEncodingOp encodingOp) {
+    if (IREE::Flow::isNonNullAndOutsideDispatch(encodingOp)) {
+      encodingOps.push_back(encodingOp);
+    }
+  });
+
+  IRRewriter rewriter(context);
+  for (auto encodingOp : encodingOps) {
+    if (failed(IREE::Flow::wrapOpInDispatchRegion(rewriter, encodingOp))) {
+      funcOp.emitOpError("failed to move encoding op into dispatch region");
+      return signalPassFailure();
+    }
+  }
+}
+
+} // namespace mlir::iree_compiler::DispatchCreation

--- a/compiler/src/iree/compiler/DispatchCreation/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/DispatchCreation/test/BUILD.bazel
@@ -48,6 +48,7 @@ iree_lit_test_suite(
             "split_reduction.mlir",
             "tensor_pad_to_tensor_insert_slice.mlir",
             "transpose_generic_ops.mlir",
+            "wrap_encoding_op_in_dispatch_region.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/compiler/src/iree/compiler/DispatchCreation/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/DispatchCreation/test/CMakeLists.txt
@@ -46,6 +46,7 @@ iree_lit_test_suite(
     "split_reduction.mlir"
     "tensor_pad_to_tensor_insert_slice.mlir"
     "transpose_generic_ops.mlir"
+    "wrap_encoding_op_in_dispatch_region.mlir"
   TOOLS
     FileCheck
     iree-opt

--- a/compiler/src/iree/compiler/DispatchCreation/test/fuse_encoding_ops_into_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/fuse_encoding_ops_into_dispatch_regions.mlir
@@ -73,11 +73,8 @@ module {
 // CHECK:         %[[REDUCTION:.+]] = linalg.generic
 // CHECK:         flow.return %[[REDUCTION]] :
 // CHECK:       }
-// CHECK:       %[[DISPATCH_SE:.+]] = flow.dispatch.region -> (tensor<2x11008x128xf32, #[[$ENCODING]]>)
-// CHECK:         %[[SET_ENCODING:.+]] = iree_encoding.set_encoding %[[DISPATCH]]
-// CHECK:         flow.return %[[SET_ENCODING]] :
-// CHECK:       }
-// CHECK:       util.return %[[DISPATCH_SE]] : tensor<2x11008x128xf32, #[[$ENCODING]]>
+// CHECK:       %[[SET_ENCODING:.+]] = iree_encoding.set_encoding %[[DISPATCH]]
+// CHECK:       util.return %[[SET_ENCODING]] : tensor<2x11008x128xf32, #[[$ENCODING]]>
 
 // -----
 

--- a/compiler/src/iree/compiler/DispatchCreation/test/wrap_encoding_op_in_dispatch_region.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/wrap_encoding_op_in_dispatch_region.mlir
@@ -1,0 +1,36 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-wrap-encoding-op-in-dispatch-region))" --split-input-file --mlir-print-local-scope %s | FileCheck %s
+
+util.func @wrap_encoding_op(%arg0 : tensor<?x?xf32>)
+    -> tensor<?x?xf32, #iree_encoding.testing_encoding<>> {
+  %0 = iree_encoding.set_encoding %arg0 :
+      tensor<?x?xf32> -> tensor<?x?xf32, #iree_encoding.testing_encoding<>>
+  util.return %0 : tensor<?x?xf32, #iree_encoding.testing_encoding<>>
+}
+// CHECK-LABEL: func public @wrap_encoding_op
+//  CHECK-SAME:     %[[ARG0:.+]]: tensor<?x?xf32>
+//       CHECK:   %[[DISPATCH:.+]] = flow.dispatch.region
+//       CHECK:     %[[ENCODING:.+]] = iree_encoding.set_encoding %[[ARG0]]
+//       CHECK:     flow.return %[[ENCODING]]
+//       CHECK:   return %[[DISPATCH]]
+
+// -----
+
+util.func @do_not_wrap_encoding_op(%arg0 : tensor<?x?xf32>)
+    -> tensor<?x?xf32, #iree_encoding.testing_encoding<>> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
+  %d1 = tensor.dim %arg0, %c1 : tensor<?x?xf32>
+  %0 = flow.dispatch.region -> (tensor<?x?xf32, #iree_encoding.testing_encoding<>>{%d0, %d1}) {
+    %1 = iree_encoding.set_encoding %arg0 :
+        tensor<?x?xf32> -> tensor<?x?xf32, #iree_encoding.testing_encoding<>>
+    flow.return %1 : tensor<?x?xf32, #iree_encoding.testing_encoding<>>
+  }
+  util.return %0 : tensor<?x?xf32, #iree_encoding.testing_encoding<>>
+}
+// CHECK-LABEL: func public @do_not_wrap_encoding_op
+//  CHECK-SAME:     %[[ARG0:.+]]: tensor<?x?xf32>
+//       CHECK:   %[[DISPATCH:.+]] = flow.dispatch.region
+//       CHECK:     %[[ENCODING:.+]] = iree_encoding.set_encoding %[[ARG0]]
+//       CHECK:     flow.return %[[ENCODING]]
+//       CHECK:   return %[[DISPATCH]]


### PR DESCRIPTION
From the pass that fuses encodings into producers, removes the
fallback of moving encodings into their own dispatch in favor of
having a separate pass that does this all at once.

Signed-off-by: MaheshRavishankar <mahesh.ravishankar@gmail.com>