### PR TITLE
[Codegen][Tuner] add support for attention op in the StripCompilationInfoPass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/StripCompilationInfoPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/StripCompilationInfoPass.cpp
@@ -56,8 +56,8 @@ struct StripLinalgOpCompilationInfo final
   }
 };
 
-struct StripAttentionOpCompilationInfo
-    : public OpRewritePattern<IREE::LinalgExt::AttentionOp> {
+struct StripAttentionOpCompilationInfo final
+    : OpRewritePattern<IREE::LinalgExt::AttentionOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(IREE::LinalgExt::AttentionOp attentionOp,
                                 PatternRewriter &rewriter) const override {
@@ -81,9 +81,8 @@ struct StripCompilationInfoPass final
   void runOnOperation() override {
     MLIRContext *ctx = &getContext();
     RewritePatternSet patterns(ctx);
-    patterns.add<StripFuncOpTranslationInfo>(ctx);
-    patterns.add<StripLinalgOpCompilationInfo>(ctx);
-    patterns.add<StripAttentionOpCompilationInfo>(ctx);
+    patterns.add<StripFuncOpTranslationInfo, StripLinalgOpCompilationInfo,
+                 StripAttentionOpCompilationInfo>(ctx);
     walkAndApplyPatterns(getOperation(), std::move(patterns));
   }
 };

--- a/compiler/src/iree/compiler/Codegen/Common/test/strip_compilation_info.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/strip_compilation_info.mlir
@@ -83,6 +83,8 @@ func.func @attention(%arg0: tensor<2x10x6x4xf16>, %arg1 : tensor<2x10x4x4xf16>, 
 // CHECK-LABEL: func.func @attention
 // CHECK-NOT:   iree_codegen.translation_info
 // CHECK-NOT:   iree_codegen.lowering_config
+// CHECK-NOT:   translation_info =
+// CHECK-NOT:   lowering_config =
 // CHECK-NOT:   decomposition_config =
 
 
@@ -109,6 +111,9 @@ func.func @attention_1(%arg0: tensor<2x10x6x4xf16>, %arg1 : tensor<2x10x4x4xf16>
 
 // CHECK-LABEL: func.func @attention_1
 // CHECK-NOT:   iree_codegen.compilation_info
-// CHECK-NOT:   iree_codegen.translation_info
 // CHECK-NOT:   iree_codegen.lowering_config
+// CHECK-NOT:   iree_codegen.translation_info
+// CHECK-NOT:   compilation_info =
+// CHECK-NOT:   translation_info =
+// CHECK-NOT:   lowering_config =
 // CHECK-NOT:   decomposition_config =

--- a/compiler/src/iree/compiler/Codegen/Common/test/strip_compilation_info.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/strip_compilation_info.mlir
@@ -60,3 +60,27 @@ func.func @matmul_128x1024x256_1(%lhs : tensor<128x256xf32>, %rhs: tensor<256x10
 
 // CHECK-LABEL: func.func @matmul_128x1024x256_1
 // CHECK-NOT:   iree_codegen.lowering_config
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d4)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d5, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d5)>
+#map3 = affine_map<(d0, d1, d2, d3, d4, d5) -> ()>
+#map4 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>
+#map5 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+#map6 = affine_map<(d0, d1, d2, d3) -> (d0, d2, d1, d3)>
+#config = #iree_codegen.lowering_config<tile_sizes = [[128, 256], [16, 16]]>
+func.func @attention(%arg0: tensor<2x10x6x4xf16>, %arg1 : tensor<2x10x4x4xf16>, %arg2 : tensor<2x10x4x4xf16>, %arg3 : f16) -> tensor<2x10x6x4xf16> attributes {translation_info = #iree_codegen.translation_info<pipeline = None subgroup_size = 32>} {
+  %init = tensor.empty() : tensor<2x10x6x4xf16>
+  %result = iree_linalg_ext.attention {decomposition_config = {x}, indexing_maps = [#map, #map1, #map2, #map3, #map4], lowering_config = #config} ins(%arg0, %arg1, %arg2, %arg3 : tensor<2x10x6x4xf16>, tensor<2x10x4x4xf16>, tensor<2x10x4x4xf16>, f16) outs(%init : tensor<2x10x6x4xf16>) {
+        ^bb0(%arg: f32):
+          iree_linalg_ext.yield %arg : f32
+        } -> tensor<2x10x6x4xf16>
+  return %result : tensor<2x10x6x4xf16>
+}
+
+// CHECK-LABEL: func.func @attention
+// CHECK-NOT:   iree_codegen.translation_info
+// CHECK-NOT:   decomposition_config =
+// CHECK-NOT:   iree_codegen.lowering_config

--- a/compiler/src/iree/compiler/Codegen/Common/test/strip_compilation_info.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/strip_compilation_info.mlir
@@ -81,6 +81,7 @@ func.func @attention(%arg0: tensor<2x10x6x4xf16>, %arg1 : tensor<2x10x4x4xf16>, 
 }
 
 // CHECK-LABEL: func.func @attention
+// CHECK:       iree_linalg_ext.attention
 // CHECK-NOT:   iree_codegen.translation_info
 // CHECK-NOT:   iree_codegen.lowering_config
 // CHECK-NOT:   translation_info =
@@ -110,6 +111,7 @@ func.func @attention_1(%arg0: tensor<2x10x6x4xf16>, %arg1 : tensor<2x10x4x4xf16>
 }
 
 // CHECK-LABEL: func.func @attention_1
+// CHECK:       iree_linalg_ext.attention
 // CHECK-NOT:   iree_codegen.compilation_info
 // CHECK-NOT:   iree_codegen.lowering_config
 // CHECK-NOT:   iree_codegen.translation_info

--- a/compiler/src/iree/compiler/Codegen/Common/test/strip_compilation_info.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/strip_compilation_info.mlir
@@ -82,5 +82,33 @@ func.func @attention(%arg0: tensor<2x10x6x4xf16>, %arg1 : tensor<2x10x4x4xf16>, 
 
 // CHECK-LABEL: func.func @attention
 // CHECK-NOT:   iree_codegen.translation_info
-// CHECK-NOT:   decomposition_config =
 // CHECK-NOT:   iree_codegen.lowering_config
+// CHECK-NOT:   decomposition_config =
+
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d4)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d5, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d5)>
+#map3 = affine_map<(d0, d1, d2, d3, d4, d5) -> ()>
+#map4 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3)>
+#map5 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+#map6 = affine_map<(d0, d1, d2, d3) -> (d0, d2, d1, d3)>
+#config = #iree_codegen.lowering_config<tile_sizes = [[128, 256], [16, 16]]>
+#translation = #iree_codegen.translation_info<pipeline = None workgroup_size = [16, 8, 1] subgroup_size = 64>
+#compilation = #iree_codegen.compilation_info<lowering_config = #config, translation_info = #translation>
+func.func @attention_1(%arg0: tensor<2x10x6x4xf16>, %arg1 : tensor<2x10x4x4xf16>, %arg2 : tensor<2x10x4x4xf16>, %arg3 : f16) -> tensor<2x10x6x4xf16> attributes {translation_info = #iree_codegen.translation_info<pipeline = None subgroup_size = 32>} {
+  %init = tensor.empty() : tensor<2x10x6x4xf16>
+  %result = iree_linalg_ext.attention {decomposition_config = {x}, indexing_maps = [#map, #map1, #map2, #map3, #map4], compilation_info = #compilation} ins(%arg0, %arg1, %arg2, %arg3 : tensor<2x10x6x4xf16>, tensor<2x10x4x4xf16>, tensor<2x10x4x4xf16>, f16) outs(%init : tensor<2x10x6x4xf16>) {
+        ^bb0(%arg: f32):
+          iree_linalg_ext.yield %arg : f32
+        } -> tensor<2x10x6x4xf16>
+  return %result : tensor<2x10x6x4xf16>
+}
+
+// CHECK-LABEL: func.func @attention_1
+// CHECK-NOT:   iree_codegen.compilation_info
+// CHECK-NOT:   iree_codegen.translation_info
+// CHECK-NOT:   iree_codegen.lowering_config
+// CHECK-NOT:   decomposition_config =


### PR DESCRIPTION
This PR adds the pattern rewriter for attention op and removes the configs from attention op in the StripCompilationInfoPass. 

Fixes #20053 