### PR TITLE
[Dispatch] Clone scatter indices

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/test/clone_producers_into_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/clone_producers_into_dispatch_regions.mlir
@@ -645,3 +645,41 @@ util.func public @dont_clone_flow_ops(%arg0: tensor<?x?xf16>, %arg1: tensor<?x?x
 //  CHECK-SAME:         ins({{.+}}, %[[MASK]] :
 //       CHECK:     flow.return %[[ATTENTION]]
 //       CHECK:   return %[[DISPATCH]]
+
+// -----
+
+util.func public @clone_scatter_indices(%arg0: tensor<1x?x32x8x128xf8E4M3FNUZ>, %arg1: tensor<1x?x32x8x128xbf16>, %arg2: tensor<1x?xi64>, %arg3: tensor<1x?xi64>, %arg4: tensor<1x?xi32>, %arg5: tensor<?x32x8x128xbf16>) -> (tensor<?x32x8x128xbf16>, tensor<1x?xi64>) {
+  %c1 = arith.constant 1 : index
+  %c10_i64 = arith.constant 10 : i64
+  %0 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>, affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]} ins(%arg0 : tensor<1x?x32x8x128xf8E4M3FNUZ>) outs(%arg1 : tensor<1x?x32x8x128xbf16>) {
+  ^bb0(%in: f8E4M3FNUZ, %out: bf16):
+    %3 = arith.extf %in : f8E4M3FNUZ to bf16
+    linalg.yield %3 : bf16
+  } -> tensor<1x?x32x8x128xbf16>
+  %1:2 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%arg2 : tensor<1x?xi64>) outs(%arg3, %arg4 : tensor<1x?xi64>, tensor<1x?xi32>) {
+  ^bb0(%in: i64, %out: i64, %out_0: i32):
+    %3 = arith.addi %in, %c10_i64 : i64
+    %4 = arith.trunci %3 : i64 to i32
+    linalg.yield %3, %4 : i64, i32
+  } -> (tensor<1x?xi64>, tensor<1x?xi32>)
+  %2 = flow.dispatch.region -> (tensor<?x32x8x128xbf16>{%c1}) {
+    %3 = iree_linalg_ext.scatter dimension_map = [0] unique_indices(true) ins(%0, %1#1 : tensor<1x?x32x8x128xbf16>, tensor<1x?xi32>) outs(%arg5 : tensor<?x32x8x128xbf16>) {
+    ^bb0(%arg6: bf16, %arg7: bf16):
+      iree_linalg_ext.yield %arg6 : bf16
+    } -> tensor<?x32x8x128xbf16>
+    flow.return %3 : tensor<?x32x8x128xbf16>
+  }
+  util.return %2, %1#0 : tensor<?x32x8x128xbf16>, tensor<1x?xi64>
+}
+
+// CHECK-LABEL: func public @clone_scatter_indices
+//       CHECK:   %[[DISPATCH0:.+]] = flow.dispatch.region
+//       CHECK:     %[[GEN0:.+]]:2 = linalg.generic
+//       CHECK:     flow.return %[[GEN0]]#0 : tensor<1x?xi64>
+//       CHECK:   %[[DISPATCH1:.+]] = flow.dispatch.region
+//       CHECK:     %[[GEN1:.+]] = linalg.generic
+//       CHECK:     %[[GEN2:.+]]:2 = linalg.generic
+//       CHECK:     %[[SCATTER:.+]] = iree_linalg_ext.scatter
+//  CHECK-SAME:       ins(%[[GEN1]], %[[GEN2]]#1
+//       CHECK:     flow.return %[[SCATTER]] : tensor<?x32x8x128xbf16>
+//       CHECK:   util.return %[[DISPATCH1]], %[[DISPATCH0]]

--- a/compiler/src/iree/compiler/DispatchCreation/test/dispatch_linalg_ext_fusion.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/dispatch_linalg_ext_fusion.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --verify-diagnostics --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-form-dispatch-regions{aggressive-fusion=true}, iree-dispatch-creation-clone-producers-into-dispatch-regions), cse, canonicalize, cse)" %s | FileCheck %s
+// RUN: iree-opt --split-input-file --verify-diagnostics --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-form-dispatch-regions{aggressive-fusion=true}, iree-dispatch-creation-clone-producers-into-dispatch-regions{aggressive=true}), cse, canonicalize, cse)" %s | FileCheck %s
 
 #map = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>

--- a/compiler/src/iree/compiler/DispatchCreation/test/form_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/form_dispatch_regions.mlir
@@ -979,7 +979,7 @@ util.func @attention_clone_mask(%Q : tensor<?x?xf16>, %K : tensor<?x?xf16>, %V: 
 
 // -----
 
-util.func @scatter_index_producer_fusion(%arg0 : tensor<?x1xi64>,
+util.func @scatter_no_index_producer_fusion(%arg0 : tensor<?x1xi64>,
     %arg1 : index, %arg2 : tensor<?x1x32x8x128xf16>,
     %arg3 : tensor<?x32x8x128xf16>) -> tensor<?x32x8x128xf16> {
   %empty = tensor.empty(%arg1) : tensor<?x1xi32>
@@ -1001,9 +1001,11 @@ util.func @scatter_index_producer_fusion(%arg0 : tensor<?x1xi64>,
   } -> tensor<?x32x8x128xf16>
   util.return %1 : tensor<?x32x8x128xf16>
 }
-// CHECK-LABEL: func public @scatter_index_producer_fusion
+// Indices operand should be cloned.
+//
+// CHECK-LABEL: func public @scatter_no_index_producer_fusion
+//       CHECK:   %[[GENERIC:.+]] = linalg.generic
 //       CHECK:   %[[DISPATCH:.+]] = flow.dispatch.region
-//       CHECK:     %[[GENERIC:.+]] = linalg.generic
 //       CHECK:     %[[SCATTER:.+]] = iree_linalg_ext.scatter
 //  CHECK-SAME:         ins(%{{.+}}, %[[GENERIC]] :
 //       CHECK:     flow.return %[[SCATTER]]


### PR DESCRIPTION
Clone `iree_linalg_ext.scatter`'s indices so that they are not also returned from the dispatch.



Fixes https://github.com/iree-org/iree/issues/20077