### PR TITLE
 [Codegen][Tuner]: remove attrs inside decomposeConfig for attention op

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/StripCompilationInfoPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/StripCompilationInfoPass.cpp
@@ -69,19 +69,17 @@ struct StripAttentionOpCompilationInfo final
       eraseLoweringConfig(attentionOp);
     }
 
-    DictionaryAttr decompositionConfig =
-        attentionOp.getDecompositionConfigAttr();
-    if (decompositionConfig) {
-      decompositionConfig = DictionaryAttr::get(
+    if (DictionaryAttr decompositionConfig =
+            attentionOp.getDecompositionConfigAttr()) {
+      DictionaryAttr modifiedDecompositionConfig = DictionaryAttr::get(
           decompositionConfig.getContext(),
-          llvm::to_vector(llvm::make_filter_range(
-              decompositionConfig, [&](NamedAttribute attr) {
-                return attr.getName() !=
-                           IREE::LinalgExt::AttentionOp::getQKAttrStr() &&
-                       attr.getName() !=
-                           IREE::LinalgExt::AttentionOp::getPVAttrStr();
-              })));
-      attentionOp.setDecompositionConfigAttr(decompositionConfig);
+          llvm::filter_to_vector(decompositionConfig, [&](NamedAttribute attr) {
+            return attr.getName() !=
+                       IREE::LinalgExt::AttentionOp::getQKAttrStr() &&
+                   attr.getName() !=
+                       IREE::LinalgExt::AttentionOp::getPVAttrStr();
+          }));
+      attentionOp.setDecompositionConfigAttr(modifiedDecompositionConfig);
     }
     return success();
   }

--- a/compiler/src/iree/compiler/Codegen/Common/StripCompilationInfoPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/StripCompilationInfoPass.cpp
@@ -69,8 +69,19 @@ struct StripAttentionOpCompilationInfo final
       eraseLoweringConfig(attentionOp);
     }
 
-    if (attentionOp.getDecompositionConfigAttr()) {
-      attentionOp.removeDecompositionConfigAttr();
+    DictionaryAttr decompositionConfig =
+        attentionOp.getDecompositionConfigAttr();
+    if (decompositionConfig) {
+      decompositionConfig = DictionaryAttr::get(
+          decompositionConfig.getContext(),
+          llvm::to_vector(llvm::make_filter_range(
+              decompositionConfig, [&](NamedAttribute attr) {
+                return attr.getName() !=
+                           IREE::LinalgExt::AttentionOp::getQKAttrStr() &&
+                       attr.getName() !=
+                           IREE::LinalgExt::AttentionOp::getPVAttrStr();
+              })));
+      attentionOp.setDecompositionConfigAttr(decompositionConfig);
     }
     return success();
   }

--- a/compiler/src/iree/compiler/Codegen/Common/StripCompilationInfoPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/StripCompilationInfoPass.cpp
@@ -71,15 +71,15 @@ struct StripAttentionOpCompilationInfo final
 
     if (DictionaryAttr decompositionConfig =
             attentionOp.getDecompositionConfigAttr()) {
-      DictionaryAttr modifiedDecompositionConfig = DictionaryAttr::get(
+      DictionaryAttr newConfig = DictionaryAttr::get(
           decompositionConfig.getContext(),
-          llvm::filter_to_vector(decompositionConfig, [&](NamedAttribute attr) {
+          llvm::filter_to_vector(decompositionConfig, [](NamedAttribute attr) {
             return attr.getName() !=
                        IREE::LinalgExt::AttentionOp::getQKAttrStr() &&
                    attr.getName() !=
                        IREE::LinalgExt::AttentionOp::getPVAttrStr();
           }));
-      attentionOp.setDecompositionConfigAttr(modifiedDecompositionConfig);
+      attentionOp.setDecompositionConfigAttr(newConfig);
     }
     return success();
   }

--- a/compiler/src/iree/compiler/Codegen/Common/test/strip_compilation_info.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/strip_compilation_info.mlir
@@ -73,7 +73,7 @@ func.func @matmul_128x1024x256_1(%lhs : tensor<128x256xf32>, %rhs: tensor<256x10
 #config = #iree_codegen.lowering_config<tile_sizes = [[128, 256], [16, 16]]>
 func.func @attention(%arg0: tensor<2x10x6x4xf16>, %arg1 : tensor<2x10x4x4xf16>, %arg2 : tensor<2x10x4x4xf16>, %arg3 : f16) -> tensor<2x10x6x4xf16> attributes {translation_info = #iree_codegen.translation_info<pipeline = None subgroup_size = 32>} {
   %init = tensor.empty() : tensor<2x10x6x4xf16>
-  %result = iree_linalg_ext.attention {decomposition_config = {x}, indexing_maps = [#map, #map1, #map2, #map3, #map4], lowering_config = #config} ins(%arg0, %arg1, %arg2, %arg3 : tensor<2x10x6x4xf16>, tensor<2x10x4x4xf16>, tensor<2x10x4x4xf16>, f16) outs(%init : tensor<2x10x6x4xf16>) {
+  %result = iree_linalg_ext.attention {decomposition_config = {pv_attrs = {x}, qk_attrs = {y}, z}, indexing_maps = [#map, #map1, #map2, #map3, #map4], lowering_config = #config} ins(%arg0, %arg1, %arg2, %arg3 : tensor<2x10x6x4xf16>, tensor<2x10x4x4xf16>, tensor<2x10x4x4xf16>, f16) outs(%init : tensor<2x10x6x4xf16>) {
         ^bb0(%arg: f32):
           iree_linalg_ext.yield %arg : f32
         } -> tensor<2x10x6x4xf16>
@@ -82,12 +82,12 @@ func.func @attention(%arg0: tensor<2x10x6x4xf16>, %arg1 : tensor<2x10x4x4xf16>, 
 
 // CHECK-LABEL: func.func @attention
 // CHECK:       iree_linalg_ext.attention
+// CHECK-SAME:  decomposition_config = {z}
 // CHECK-NOT:   iree_codegen.translation_info
 // CHECK-NOT:   iree_codegen.lowering_config
 // CHECK-NOT:   translation_info =
 // CHECK-NOT:   lowering_config =
 // CHECK-NOT:   decomposition_config =
-
 
 // -----
 
@@ -103,7 +103,7 @@ func.func @attention(%arg0: tensor<2x10x6x4xf16>, %arg1 : tensor<2x10x4x4xf16>, 
 #compilation = #iree_codegen.compilation_info<lowering_config = #config, translation_info = #translation>
 func.func @attention_1(%arg0: tensor<2x10x6x4xf16>, %arg1 : tensor<2x10x4x4xf16>, %arg2 : tensor<2x10x4x4xf16>, %arg3 : f16) -> tensor<2x10x6x4xf16> attributes {translation_info = #iree_codegen.translation_info<pipeline = None subgroup_size = 32>} {
   %init = tensor.empty() : tensor<2x10x6x4xf16>
-  %result = iree_linalg_ext.attention {decomposition_config = {x}, indexing_maps = [#map, #map1, #map2, #map3, #map4], compilation_info = #compilation} ins(%arg0, %arg1, %arg2, %arg3 : tensor<2x10x6x4xf16>, tensor<2x10x4x4xf16>, tensor<2x10x4x4xf16>, f16) outs(%init : tensor<2x10x6x4xf16>) {
+  %result = iree_linalg_ext.attention {decomposition_config = {pv_attrs = {x}, qk_attrs = {y}}, indexing_maps = [#map, #map1, #map2, #map3, #map4], compilation_info = #compilation} ins(%arg0, %arg1, %arg2, %arg3 : tensor<2x10x6x4xf16>, tensor<2x10x4x4xf16>, tensor<2x10x4x4xf16>, f16) outs(%init : tensor<2x10x6x4xf16>) {
         ^bb0(%arg: f32):
           iree_linalg_ext.yield %arg : f32
         } -> tensor<2x10x6x4xf16>
@@ -112,6 +112,7 @@ func.func @attention_1(%arg0: tensor<2x10x6x4xf16>, %arg1 : tensor<2x10x4x4xf16>
 
 // CHECK-LABEL: func.func @attention_1
 // CHECK:       iree_linalg_ext.attention
+// CHECK-SAME:  decomposition_config = {}
 // CHECK-NOT:   iree_codegen.compilation_info
 // CHECK-NOT:   iree_codegen.lowering_config
 // CHECK-NOT:   iree_codegen.translation_info

--- a/compiler/src/iree/compiler/Codegen/Common/test/strip_compilation_info.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/strip_compilation_info.mlir
@@ -103,7 +103,7 @@ func.func @attention(%arg0: tensor<2x10x6x4xf16>, %arg1 : tensor<2x10x4x4xf16>, 
 #compilation = #iree_codegen.compilation_info<lowering_config = #config, translation_info = #translation>
 func.func @attention_1(%arg0: tensor<2x10x6x4xf16>, %arg1 : tensor<2x10x4x4xf16>, %arg2 : tensor<2x10x4x4xf16>, %arg3 : f16) -> tensor<2x10x6x4xf16> attributes {translation_info = #iree_codegen.translation_info<pipeline = None subgroup_size = 32>} {
   %init = tensor.empty() : tensor<2x10x6x4xf16>
-  %result = iree_linalg_ext.attention {decomposition_config = {pv_attrs = {x}, qk_attrs = {y}}, indexing_maps = [#map, #map1, #map2, #map3, #map4], compilation_info = #compilation} ins(%arg0, %arg1, %arg2, %arg3 : tensor<2x10x6x4xf16>, tensor<2x10x4x4xf16>, tensor<2x10x4x4xf16>, f16) outs(%init : tensor<2x10x6x4xf16>) {
+  %result = iree_linalg_ext.attention {decomposition_config = {pv_attrs = {x}, qk_attrs = {y}, use_exp2}, indexing_maps = [#map, #map1, #map2, #map3, #map4], compilation_info = #compilation} ins(%arg0, %arg1, %arg2, %arg3 : tensor<2x10x6x4xf16>, tensor<2x10x4x4xf16>, tensor<2x10x4x4xf16>, f16) outs(%init : tensor<2x10x6x4xf16>) {
         ^bb0(%arg: f32):
           iree_linalg_ext.yield %arg : f32
         } -> tensor<2x10x6x4xf16>
@@ -112,7 +112,7 @@ func.func @attention_1(%arg0: tensor<2x10x6x4xf16>, %arg1 : tensor<2x10x4x4xf16>
 
 // CHECK-LABEL: func.func @attention_1
 // CHECK:       iree_linalg_ext.attention
-// CHECK-SAME:  decomposition_config = {}
+// CHECK-SAME:  decomposition_config = {use_exp2}
 // CHECK-NOT:   iree_codegen.compilation_info
 // CHECK-NOT:   iree_codegen.lowering_config
 // CHECK-NOT:   iree_codegen.translation_info


### PR DESCRIPTION
This PR follows up on https://github.com/iree-org/iree/pull/20072 to remove drop `qk_attrs` and `pv_attrs` inside `DecompositionConfig`,   instead of completely removing `DecompositionConfig`.

Fixes https://github.com/iree-org/iree/issues/20053