### PR TITLE
[DT][GPU] Implement  SerializableEncodingAttrInterface

### DIFF
--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -366,6 +366,18 @@ struct GPUDeviceEncodingLayoutResolverAttrInterface
   }
 };
 
+struct GPUHostSerializableEncodingAttrInterface final
+    : IREE::Encoding::SerializableEncodingAttrInterface::ExternalModel<
+          GPUHostSerializableEncodingAttrInterface, GPUEncodingLayoutAttr> {
+
+  Value calculateStorageSizeInBytes(Attribute attr, Location loc,
+                                    OpBuilder &builder, RankedTensorType type,
+                                    ValueRange dynamicDims) const {
+    return calculateStorageSizeInBytesImpl(attr, loc, builder, type,
+                                           dynamicDims);
+  }
+};
+
 struct GPUHostEncodingLayoutResolverAttrInterface final
     : IREE::Encoding::EncodingLayoutResolverAttrInterface::ExternalModel<
           GPUHostEncodingLayoutResolverAttrInterface, GPUEncodingLayoutAttr> {
@@ -485,7 +497,8 @@ void registerGPUEncodingExternalModels(DialectRegistry &registry) {
       +[](MLIRContext *ctx, IREE::GPU::IREEGPUDialect *dialect) {
         IREE::GPU::GPUEncodingLayoutAttr::attachInterface<
             GPUDeviceEncodingLayoutResolverAttrInterface,
-            GPUHostEncodingLayoutResolverAttrInterface>(*ctx);
+            GPUHostEncodingLayoutResolverAttrInterface,
+            GPUHostSerializableEncodingAttrInterface>(*ctx);
         IREE::GPU::GPUPadLayoutAttr::attachInterface<
             GPUPadEncodingLayoutResolverAttrInterface>(*ctx);
       });

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.h
@@ -16,6 +16,9 @@ namespace mlir::iree_compiler::IREE {
 
 static const char kEncodingInfoAttrName[] = "encoding_info";
 
+/// Calculates the storage size in bytes for the given `type` with a layout
+/// encoding `attr`.
+/// Requirement: `attr` must implement IREE::Codegen::LayoutAttrInterface.
 Value calculateStorageSizeInBytesImpl(Attribute attr, Location loc,
                                       OpBuilder &builder, RankedTensorType type,
                                       ValueRange dynamicDims);


### PR DESCRIPTION
Implements the SerializableEncodingAttrInterface's `calculateStorageSizeInBytes` method for GPU. Note that this implementation is  exactly the same as the CPU one as the GPU's swizzle field can be ignored for storage calculation purposes as it describes the layout of the inner tile: https://github.com/iree-org/iree/issues/20021

Resolves #20021