### PR TITLE
Tentative E2E tests for gfx12, copying gfx11 with relevant sed, adding fp8

### DIFF
--- a/build_tools/bazel/build_test_all.sh
+++ b/build_tools/bazel/build_test_all.sh
@@ -18,6 +18,7 @@
 #   * IREE_VULKAN_DISABLE
 #   * IREE_NVIDIA_GPU_TESTS_DISABLE
 #   * IREE_AMD_RDNA3_GPU_TESTS_DISABLE
+#   * IREE_AMD_RDNA4_GPU_TESTS_DISABLE
 #   * IREE_ARM_SME_DISABLE
 #
 # Freeform filters can be appended using:
@@ -57,6 +58,9 @@ fi
 if ! [[ -v IREE_AMD_RDNA3_GPU_TESTS_DISABLE ]]; then
   IREE_AMD_RDNA3_GPU_TESTS_DISABLE=1
 fi
+if ! [[ -v IREE_AMD_RDNA4_GPU_TESTS_DISABLE ]]; then
+  IREE_AMD_RDNA4_GPU_TESTS_DISABLE=1
+fi
 if ! [[ -v IREE_ARM_SME_DISABLE ]]; then
   IREE_ARM_SME_DISABLE=1
 fi
@@ -69,6 +73,7 @@ declare -a test_env_args=(
   --test_env=IREE_VULKAN_DISABLE="${IREE_VULKAN_DISABLE}"
   --test_env=IREE_NVIDIA_GPU_TESTS_DISABLE="${IREE_NVIDIA_GPU_TESTS_DISABLE}"
   --test_env=IREE_AMD_RDNA3_GPU_TESTS_DISABLE="${IREE_AMD_RDNA3_GPU_TESTS_DISABLE}"
+  --test_env=IREE_AMD_RDNA4_GPU_TESTS_DISABLE="${IREE_AMD_RDNA4_GPU_TESTS_DISABLE}"
 )
 
 if ! [[ -n IREE_LLVM_SYSTEM_LINKER_PATH ]]; then
@@ -99,6 +104,9 @@ if (( IREE_NVIDIA_GPU_TESTS_DISABLE == 1 )); then
 fi
 if (( IREE_AMD_RDNA3_GPU_TESTS_DISABLE == 1 )); then
   default_test_tag_filters+=("-requires-gpu-rdna3")
+fi
+if (( IREE_AMD_RDNA4_GPU_TESTS_DISABLE == 1 )); then
+  default_test_tag_filters+=("-requires-gpu-rdna4")
 fi
 if (( IREE_ARM_SME_DISABLE == 1 )); then
   default_test_tag_filters+=("-requires-arm-sme")

--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -42,6 +42,8 @@ export IREE_NVIDIA_GPU_TESTS_DISABLE="${IREE_NVIDIA_GPU_TESTS_DISABLE:-1}"
 export IREE_NVIDIA_SM80_TESTS_DISABLE="${IREE_NVIDIA_SM80_TESTS_DISABLE:-1}"
 # Respect the user setting, but default to skipping tests that require RDNA3 AMD GPU.
 export IREE_AMD_RDNA3_TESTS_DISABLE="${IREE_AMD_RDNA3_TESTS_DISABLE:-1}"
+# Respect the user setting, but default to skipping tests that require RDNA4 AMD GPU.
+export IREE_AMD_RDNA4_TESTS_DISABLE="${IREE_AMD_RDNA4_TESTS_DISABLE:-1}"
 # Respect the user setting, but default to skipping tests that require more than one device(GPU).
 export IREE_MULTI_DEVICE_TESTS_DISABLE="${IREE_MULTI_DEVICE_TESTS_DISABLE:-1}"
 # Respect the user setting, default to no --repeat-until-fail.
@@ -95,6 +97,9 @@ if (( IREE_NVIDIA_SM80_TESTS_DISABLE == 1 )); then
   label_exclude_args+=("^requires-gpu-sm80$")
 fi
 if (( IREE_AMD_RDNA3_TESTS_DISABLE == 1 )); then
+  label_exclude_args+=("^requires-gpu-rdna3$")
+fi
+if (( IREE_AMD_RDNA4_TESTS_DISABLE == 1 )); then
   label_exclude_args+=("^requires-gpu-rdna3$")
 fi
 if (( IREE_MULTI_DEVICE_TESTS_DISABLE == 1 )); then

--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -100,7 +100,7 @@ if (( IREE_AMD_RDNA3_TESTS_DISABLE == 1 )); then
   label_exclude_args+=("^requires-gpu-rdna3$")
 fi
 if (( IREE_AMD_RDNA4_TESTS_DISABLE == 1 )); then
-  label_exclude_args+=("^requires-gpu-rdna3$")
+  label_exclude_args+=("^requires-gpu-rdna4$")
 fi
 if (( IREE_MULTI_DEVICE_TESTS_DISABLE == 1 )); then
   label_exclude_args+=("^requires-multiple-devices$")

--- a/tests/e2e/matmul/BUILD.bazel
+++ b/tests/e2e/matmul/BUILD.bazel
@@ -640,4 +640,4 @@ iree_generated_e2e_runner_test(
     ("f32", "f32"),
 ]]
 
-# TODO(#19465): add large matmul tests for rdna3.
+# TODO(#19465): add large matmul tests for rdna3 and rdna4.

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -1374,7 +1374,7 @@ iree_generated_e2e_runner_test(
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###
 
-# To distinguish between CDNA(gfx9) and RDNA3(gfx11)
+# To distinguish between CDNA(gfx9), RDNA3(gfx11), and RDNA4(gfx12)
 if(IREE_HIP_TEST_TARGET_CHIP MATCHES "^gfx9")
 
 unset(IREE_HIP_TEST_COMPILER_FLAGS)
@@ -1923,6 +1923,166 @@ iree_generated_e2e_runner_test(
     "notsan"
     "noubsan"
     "requires-gpu-rdna3"
+)
+
+elseif(IREE_HIP_TEST_TARGET_CHIP MATCHES "^gfx12")
+
+unset(IREE_HIP_TEST_COMPILER_FLAGS)
+list(APPEND IREE_HIP_TEST_COMPILER_FLAGS
+  "--iree-hip-target=${IREE_HIP_TEST_TARGET_CHIP}"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_matmul_rocm_f16_large_rdna4_wmma
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f16"
+    "--acc_type=f32"
+    "--compilation_info=LLVMGPUVectorDistributeWMMAR4"
+    "--shapes=easy_large_static"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+  RUNNER_ARGS
+    "--require_exact_results=false"
+    "--acceptable_fp_delta=1e-04"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-rdna4"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_matmul_rocm_f16_large_rdna4_wmma_tb
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f16"
+    "--acc_type=f32"
+    "--transpose_rhs"
+    "--compilation_info=LLVMGPUVectorDistributeWMMAR4"
+    "--shapes=easy_large_static"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+  RUNNER_ARGS
+    "--require_exact_results=false"
+    "--acceptable_fp_delta=1e-04"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-rdna4"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_matmul_rocm_i8_large_rdna4_wmma_tb
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=i8"
+    "--acc_type=i32"
+    "--transpose_rhs"
+    "--compilation_info=LLVMGPUVectorDistributeWMMAR4"
+    "--shapes=easy_large_static"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-rdna4"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_matmul_rdna4_dt_f16
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f16"
+    "--acc_type=f32"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+    "--iree-opt-data-tiling"
+    "--iree-global-opt-experimental-rocm-data-tiling"
+    "--iree-global-opt-enable-early-materialization=true"
+  RUNNER_ARGS
+    "--require_exact_results=false"
+    "--acceptable_fp_delta=1e-04"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-rdna4"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_matmul_rdna4_dt_i8
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=i8"
+    "--acc_type=i32"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+    "--iree-opt-data-tiling"
+    "--iree-global-opt-experimental-rocm-data-tiling"
+    "--iree-global-opt-enable-early-materialization=true"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-rdna4"
 )
 
 endif()

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -1997,6 +1997,69 @@ iree_generated_e2e_runner_test(
 
 iree_generated_e2e_runner_test(
   NAME
+    e2e_matmul_rocm_f8E4M3FN_large_rdna4_wmma
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f8E4M3FN"
+    "--acc_type=f32"
+    "--compilation_info=LLVMGPUVectorDistributeWMMAR4"
+    "--shapes=easy_large_static"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+  RUNNER_ARGS
+    "--require_exact_results=false"
+    "--acceptable_fp_delta=1e-04"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-rdna4"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_matmul_rocm_f8e4M3FN_large_rdna4_wmma_tb
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f8E4M3FN"
+    "--acc_type=f32"
+    "--transpose_rhs"
+    "--compilation_info=LLVMGPUVectorDistributeWMMAR4"
+    "--shapes=easy_large_static"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+  RUNNER_ARGS
+    "--require_exact_results=false"
+    "--acceptable_fp_delta=1e-04"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-rdna4"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
     e2e_matmul_rocm_i8_large_rdna4_wmma_tb
   TEST_TYPE
     matmul
@@ -2033,6 +2096,38 @@ iree_generated_e2e_runner_test(
     "generate_e2e_matmul_tests.py"
   GENERATOR_ARGS
     "--lhs_rhs_type=f16"
+    "--acc_type=f32"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+    "--iree-opt-data-tiling"
+    "--iree-global-opt-experimental-rocm-data-tiling"
+    "--iree-global-opt-enable-early-materialization=true"
+  RUNNER_ARGS
+    "--require_exact_results=false"
+    "--acceptable_fp_delta=1e-04"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-rdna4"
+)
+
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_matmul_rdna4_dt_f8E4M3FN
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f8E4M3FN"
     "--acc_type=f32"
   TEST_RUNNER
     iree_tools_testing_e2e_iree-e2e-matmul-test

--- a/tests/e2e/matmul/generate_e2e_matmul_tests.py
+++ b/tests/e2e/matmul/generate_e2e_matmul_tests.py
@@ -54,6 +54,7 @@ class CompilationInfoId(enum.Enum):
     LLVMGPUMatmulTensorCoreMmaSync = "LLVMGPUMatmulTensorCoreMmaSync"
     LLVMGPUVectorDistributeMFMA = "LLVMGPUVectorDistributeMFMA"
     LLVMGPUVectorDistributeWMMAR3 = "LLVMGPUVectorDistributeWMMAR3"
+    LLVMGPUVectorDistributeWMMAR4 = "LLVMGPUVectorDistributeWMMAR4"
     SPIRVCooperativeMatrixVectorize = "SPIRVCooperativeMatrixVectorize"
     SPIRVVectorizeMali = "SPIRVVectorizeMali"
     SPIRVVectorizeNVIDIA = "SPIRVVectorizeNVIDIA"
@@ -312,6 +313,8 @@ def get_rocm_test_compilation_infos(
         intrinsic = "MFMA"
     elif compilation_info_id == CompilationInfoId.LLVMGPUVectorDistributeWMMAR3:
         intrinsic = "WMMAR3"
+    elif compilation_info_id == CompilationInfoId.LLVMGPUVectorDistributeWMMAR4:
+        intrinsic = "WMMAR4"
     else:
         raise ValueError("Unknown pipeline for rocm")
 
@@ -374,6 +377,24 @@ def get_rocm_test_compilation_infos(
             MMASchedule("WMMAR3_I32_16x16x16_I8", 2, 4, 2, 1, 2),
             MMASchedule("WMMAR3_I32_16x16x16_I8", 4, 2, 4, 2, 2),
         ]
+    elif intrinsic == "WMMAR4":
+        # TODO(kdrewnia) FP8 intrinsics
+        schedules = [
+            MMASchedule("WMMAR4_F32_16x16x16_F16", 1, 1, 1, 1, 1),
+            MMASchedule("WMMAR4_F32_16x16x16_F16", 1, 1, 1, 1, 2),
+            MMASchedule("WMMAR4_F32_16x16x16_F16", 1, 1, 1, 2, 1),
+            MMASchedule("WMMAR4_F32_16x16x16_F16", 1, 1, 2, 1, 1),
+            MMASchedule("WMMAR4_F32_16x16x16_F16", 2, 2, 1, 1, 1),
+            MMASchedule("WMMAR4_F32_16x16x16_F16", 2, 4, 2, 1, 2),
+            MMASchedule("WMMAR4_F32_16x16x16_F16", 4, 2, 4, 2, 2),
+            MMASchedule("WMMAR4_I32_16x16x16_I8", 1, 1, 1, 1, 1),
+            MMASchedule("WMMAR4_I32_16x16x16_I8", 1, 1, 1, 1, 2),
+            MMASchedule("WMMAR4_I32_16x16x16_I8", 1, 1, 1, 2, 1),
+            MMASchedule("WMMAR4_I32_16x16x16_I8", 1, 1, 2, 1, 1),
+            MMASchedule("WMMAR4_I32_16x16x16_I8", 2, 2, 1, 1, 1),
+            MMASchedule("WMMAR4_I32_16x16x16_I8", 2, 4, 2, 1, 2),
+            MMASchedule("WMMAR4_I32_16x16x16_I8", 4, 2, 4, 2, 2),
+        ]
     else:
         raise NotImplementedError("unhandled intrinsic case")
 
@@ -418,11 +439,12 @@ def get_rocm_test_compilation_infos(
             wg_tile_m = schedule.m_count * schedule.m_tile_count * 32
             wg_tile_n = schedule.n_count * schedule.n_tile_count * 32
             wg_tile_k = schedule.k_tile_count * 16
-        elif schedule.intrinsic == "WMMAR3_F32_16x16x16_F16":
-            wg_tile_m = schedule.m_count * schedule.m_tile_count * 16
-            wg_tile_n = schedule.n_count * schedule.n_tile_count * 16
-            wg_tile_k = schedule.k_tile_count * 16
-        elif schedule.intrinsic == "WMMAR3_I32_16x16x16_I8":
+        elif (
+            schedule.intrinsic == "WMMAR3_F32_16x16x16_F16"
+            or schedule.intrinsic == "WMMAR3_I32_16x16x16_I8"
+            or schedule.intrinsic == "WMMAR4_F32_16x16x16_F16"
+            or schedule.intrinsic == "WMMAR4_I32_16x16x16_I8"
+        ):
             wg_tile_m = schedule.m_count * schedule.m_tile_count * 16
             wg_tile_n = schedule.n_count * schedule.n_tile_count * 16
             wg_tile_k = schedule.k_tile_count * 16
@@ -455,6 +477,7 @@ def get_test_compilation_infos(
     if compilation_info_id in [
         CompilationInfoId.LLVMGPUVectorDistributeMFMA,
         CompilationInfoId.LLVMGPUVectorDistributeWMMAR3,
+        CompilationInfoId.LLVMGPUVectorDistributeWMMAR4,
     ]:
         return get_rocm_test_compilation_infos(compilation_info_id, lhs_rhs_type)
 

--- a/tests/e2e/matmul/generate_e2e_matmul_tests.py
+++ b/tests/e2e/matmul/generate_e2e_matmul_tests.py
@@ -378,7 +378,6 @@ def get_rocm_test_compilation_infos(
             MMASchedule("WMMAR3_I32_16x16x16_I8", 4, 2, 4, 2, 2),
         ]
     elif intrinsic == "WMMAR4":
-        # TODO(kdrewnia) FP8 intrinsics
         schedules = [
             MMASchedule("WMMAR4_F32_16x16x16_F16", 1, 1, 1, 1, 1),
             MMASchedule("WMMAR4_F32_16x16x16_F16", 1, 1, 1, 1, 2),

--- a/tests/e2e/matmul/generate_e2e_matmul_tests.py
+++ b/tests/e2e/matmul/generate_e2e_matmul_tests.py
@@ -445,12 +445,12 @@ def get_rocm_test_compilation_infos(
             wg_tile_m = schedule.m_count * schedule.m_tile_count * 32
             wg_tile_n = schedule.n_count * schedule.n_tile_count * 32
             wg_tile_k = schedule.k_tile_count * 16
-        elif (
-            schedule.intrinsic == "WMMAR3_F32_16x16x16_F16"
-            or schedule.intrinsic == "WMMAR3_I32_16x16x16_I8"
-            or schedule.intrinsic == "WMMAR4_F32_16x16x16_F16"
-            or schedule.intrinsic == "WMMAR4_F32_16x16x16_F8E4M3FN"
-            or schedule.intrinsic == "WMMAR4_I32_16x16x16_I8"
+        elif schedule.intrinsic in (
+            "WMMAR3_F32_16x16x16_F16",
+            "WMMAR3_I32_16x16x16_I8",
+            "WMMAR4_F32_16x16x16_F16",
+            "WMMAR4_F32_16x16x16_F8E4M3FN",
+            "WMMAR4_I32_16x16x16_I8",
         ):
             wg_tile_m = schedule.m_count * schedule.m_tile_count * 16
             wg_tile_n = schedule.n_count * schedule.n_tile_count * 16

--- a/tests/e2e/matmul/generate_e2e_matmul_tests.py
+++ b/tests/e2e/matmul/generate_e2e_matmul_tests.py
@@ -30,7 +30,7 @@ class MatrixElemTypeId(enum.Enum):
     F16 = "f16"
     BF16 = "bf16"
     F8E5M2 = "f8E5M2"
-    F8E4M3 = "f8E4M3"
+    F8E4M3FN = "f8E4M3FN"
     F8E5M2FNUZ = "f8E5M2FNUZ"
     F8E4M3FNUZ = "f8E4M3FNUZ"
 
@@ -387,6 +387,13 @@ def get_rocm_test_compilation_infos(
             MMASchedule("WMMAR4_F32_16x16x16_F16", 2, 2, 1, 1, 1),
             MMASchedule("WMMAR4_F32_16x16x16_F16", 2, 4, 2, 1, 2),
             MMASchedule("WMMAR4_F32_16x16x16_F16", 4, 2, 4, 2, 2),
+            MMASchedule("WMMAR4_F32_16x16x16_F8E4M3FN", 1, 1, 1, 1, 1),
+            MMASchedule("WMMAR4_F32_16x16x16_F8E4M3FN", 1, 1, 1, 1, 2),
+            MMASchedule("WMMAR4_F32_16x16x16_F8E4M3FN", 1, 1, 1, 2, 1),
+            MMASchedule("WMMAR4_F32_16x16x16_F8E4M3FN", 1, 1, 2, 1, 1),
+            MMASchedule("WMMAR4_F32_16x16x16_F8E4M3FN", 2, 2, 1, 1, 1),
+            MMASchedule("WMMAR4_F32_16x16x16_F8E4M3FN", 2, 4, 2, 1, 2),
+            MMASchedule("WMMAR4_F32_16x16x16_F8E4M3FN", 4, 2, 4, 2, 2),
             MMASchedule("WMMAR4_I32_16x16x16_I8", 1, 1, 1, 1, 1),
             MMASchedule("WMMAR4_I32_16x16x16_I8", 1, 1, 1, 1, 2),
             MMASchedule("WMMAR4_I32_16x16x16_I8", 1, 1, 1, 2, 1),
@@ -443,6 +450,7 @@ def get_rocm_test_compilation_infos(
             schedule.intrinsic == "WMMAR3_F32_16x16x16_F16"
             or schedule.intrinsic == "WMMAR3_I32_16x16x16_I8"
             or schedule.intrinsic == "WMMAR4_F32_16x16x16_F16"
+            or schedule.intrinsic == "WMMAR4_F32_16x16x16_F8E4M3FN"
             or schedule.intrinsic == "WMMAR4_I32_16x16x16_I8"
         ):
             wg_tile_m = schedule.m_count * schedule.m_tile_count * 16
@@ -918,7 +926,7 @@ def parse_arguments():
             "f16",
             "bf16",
             "f8E5M2",
-            "f8E4M3",
+            "f8E4M3FN",
             "f8E5M2FNUZ",
             "f8E4M3FNUZ",
         ],


### PR DESCRIPTION
Add e2e matmul tests for gfx12 mirroring gfx11 with the addition of fp8 (f8E4M3) tests.

While there's currently no CI for these, I have ran them on the relevant machine and they pass.