### PR TITLE
[GPU] Replace the skip condition for TileLargeTensors to be more general

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileLargeTensors.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileLargeTensors.cpp
@@ -184,7 +184,11 @@ static void processRegion(RewriterBase &rewriter, Region *region,
         // significant computation anyway. Equivalent generics are still tiled
         // as they typically arise organically. Fills in particular are almost
         // never found on their own and will be fused when tiling if need be.
-        if (isa<linalg::TransposeOp, linalg::CopyOp, linalg::FillOp>(op)) {
+        // Additonally, if linalg.yeild is the only op in the linalg payload
+        // then it is a reshape/ broadcast type op and same expectations of them
+        // being carefully introduced holds. E.g, they could be transpose ops
+        // which got generalized by a reshape fusion pattern.
+        if (linalgOp.getBlock()->getOperations().size() == 1) {
           continue;
         }
         tileToMaxVectorSize(rewriter, linalgOp, maxVectorSize);

--- a/compiler/src/iree/compiler/Codegen/Common/test/tile_large_tensors.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tile_large_tensors.mlir
@@ -128,3 +128,18 @@ func.func @no_tile_fill(%arg0: f32) -> tensor<64x256xf32> {
 //   CHECK-NOT:   scf.for
 //       CHECK:   %[[FILL:.+]] = linalg.fill
 //       CHECK:   return %[[FILL]]
+
+
+func.func @no_tile_reshape(%arg0: tensor<1x4x4x1x4x4xi32>) -> tensor<1x4x1x4x4x4xi32> {
+  %empty = tensor.empty() : tensor<1x4x1x4x4x4xi32>
+  %0 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d2, d4, d5)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d4, d5)>], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "parallel"]} ins(%arg0 : tensor<1x4x4x1x4x4xi32>) outs(%empty : tensor<1x4x1x4x4x4xi32>) {
+        ^bb0(%in: i32, %out: i32):
+          linalg.yield %in : i32
+    } -> tensor<1x4x1x4x4x4xi32>
+    return %0 : tensor<1x4x1x4x4x4xi32>
+}
+
+// CHECK-LABEL: func.func @no_tile_reshape
+//   CHECK-NOT:   scf.for
+//       CHECK:   %[[RESHAPE:.+]] = linalg.generic
+//       CHECK:   return %[[RESHAPE]]


### PR DESCRIPTION
This PR turns TileLargeTensors pass off for lianlg.generic with empty body (except a linalg.yeild) along with exisitng cases in which we dont want it (which also meet the new condition). The reason this is and should be needed is that some patterns such as reshape fusion will generalize to a generic op, see here for example consider the `fuseWithReshapeByExpansion` upstream, it will convert a transpose (or any expandable linalg op for that matter) to a generic op. We dont want to use this pass for such carefully introduced ops.
https://github.com/llvm/llvm-project/blob/main/mlir/lib/Dialect/Linalg/Transforms/ElementwiseOpFusion.cpp#L930-L933 