### PR TITLE
[Codegen] Block dyn dims of parallel linalg.generic ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BlockDynamicDimensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BlockDynamicDimensions.cpp
@@ -265,6 +265,10 @@ static LogicalResult
 blockDynamicDimensions(RewriterBase &rewriter,
                        const TensorDynamicDimAnalysis &dynamicDimAnalysis,
                        linalg::LinalgOp linalgOp) {
+  if (isa<linalg::GenericOp>(linalgOp)) {
+    return blockDynamicDimensionsOfAllTensorOperandsAndResults(
+        rewriter, dynamicDimAnalysis, linalgOp);
+  }
   if (linalg::isaContractionOpInterface(linalgOp)) {
     return blockDynamicDimensionsOfAllTensorOperandsAndResults(
         rewriter, dynamicDimAnalysis, linalgOp);

--- a/compiler/src/iree/compiler/Codegen/Common/BlockDynamicDimensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BlockDynamicDimensions.cpp
@@ -265,7 +265,7 @@ static LogicalResult
 blockDynamicDimensions(RewriterBase &rewriter,
                        const TensorDynamicDimAnalysis &dynamicDimAnalysis,
                        linalg::LinalgOp linalgOp) {
-  if (isa<linalg::GenericOp>(linalgOp)) {
+  if (isa<linalg::GenericOp>(linalgOp) && linalgOp.isAllParallelLoops()) {
     return blockDynamicDimensionsOfAllTensorOperandsAndResults(
         rewriter, dynamicDimAnalysis, linalgOp);
   }


### PR DESCRIPTION
Fixes performance issues with dispatches with a single dynamic elementwise op.