### PR TITLE
[compiler] Fix reproducer generation/run

### DIFF
--- a/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
+++ b/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
@@ -53,6 +53,7 @@
 #include "iree/compiler/Utils/TracingUtils.h"
 #include "iree/compiler/embedding_api.h"
 #include "iree/compiler/mlir_interop.h"
+#include "llvm/Passes/PassBuilder.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ManagedStatic.h"
@@ -1005,6 +1006,9 @@ bool Invocation::runPipeline(enum iree_compiler_pipeline_t pipeline) {
     return false;
   }
 
+  if (llvm::PrintPipelinePasses) {
+    passManager->dump();
+  }
   if (failed(passManager->run(parsedModule))) {
     return false;
   }
@@ -1018,6 +1022,10 @@ bool Invocation::runTextualPassPipeline(const char *textPassPipeline) {
   if (failed(mlir::parsePassPipeline(textPassPipeline, *passManager,
                                      llvm::errs())))
     return false;
+
+  if (llvm::PrintPipelinePasses) {
+    passManager->dump();
+  }
   if (failed(passManager->run(parsedModule))) {
     return false;
   }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -221,9 +221,12 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
 
   // Cleanup executable contents.
   {
-    auto executablePassManager = passManager.nest<IREE::Flow::ExecutableOp>();
-    executablePassManager.addPass(IREE::Flow::createCanonicalizerPass());
-    executablePassManager.addPass(mlir::createCSEPass());
+    // Creating a new pass manager and adding that to the top-level manager
+    // breaks the pipeline string generation for reproducers.
+    // So we add these passes directly to the top-level manager.
+    passManager.addNestedPass<IREE::Flow::ExecutableOp>(
+        IREE::Flow::createCanonicalizerPass());
+    passManager.addNestedPass<IREE::Flow::ExecutableOp>(mlir::createCSEPass());
   }
 
   // Symbol DCE any remaining variables/functions that are now no longer

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetRegistry.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetRegistry.cpp
@@ -148,6 +148,14 @@ template class basic_parser<TargetRegistryRef>;
 
 using TargetRegistryRef = llvm::cl::TargetRegistryRef;
 
+void llvm::cl::parser<TargetRegistryRef>::print(
+    raw_ostream &os, const TargetRegistryRef &value) {
+  if (value.isGlobal())
+    os << "global";
+  else
+    os << "unknown";
+}
+
 // Return true on error.
 bool llvm::cl::parser<TargetRegistryRef>::parse(Option &O, StringRef ArgName,
                                                 StringRef Arg,
@@ -156,7 +164,8 @@ bool llvm::cl::parser<TargetRegistryRef>::parse(Option &O, StringRef ArgName,
   // of target backends and create a new registry with just that subset but
   // ownership gets tricky.
   if (Arg != "global")
-    return true;
+    llvm::errs() << "Cannot parse target registery: " << Arg
+                 << ". Defaulting to global.\n";
   Val.value = &mlir::iree_compiler::IREE::HAL::TargetRegistry::getGlobal();
   return false;
 }

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetRegistry.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetRegistry.h
@@ -17,6 +17,7 @@
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/raw_ostream.h"
 
 namespace mlir::iree_compiler::IREE::HAL {
 
@@ -127,13 +128,17 @@ struct TargetRegistryRef {
       : value(&value) {}
   TargetRegistryRef(const mlir::iree_compiler::IREE::HAL::TargetRegistry *value)
       : value(value) {}
-  operator bool() const noexcept {
+  explicit operator bool() const noexcept {
     return value->getRegisteredTargetDevices() !=
                mlir::iree_compiler::IREE::HAL::TargetRegistry::getGlobal()
                    .getRegisteredTargetDevices() &&
            value->getRegisteredTargetBackends() !=
                mlir::iree_compiler::IREE::HAL::TargetRegistry::getGlobal()
                    .getRegisteredTargetBackends();
+  }
+  bool isGlobal() const {
+    return value ==
+           &mlir::iree_compiler::IREE::HAL::TargetRegistry::getGlobal();
   }
   const mlir::iree_compiler::IREE::HAL::TargetRegistry *operator->() const {
     return value;
@@ -152,6 +157,7 @@ public:
   void printOptionDiff(const Option &O, TargetRegistryRef V,
                        const OptVal &Default, size_t GlobalWidth) const;
   void anchor() override;
+  static void print(raw_ostream &os, const TargetRegistryRef &value);
 };
 
 } // namespace llvm::cl

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/assign_legacy_target_devices.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/assign_legacy_target_devices.mlir
@@ -2,6 +2,8 @@
 // RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-hal-assign-legacy-target-devices{targetBackends=vmvx})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-1
 // RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-hal-assign-legacy-target-devices{targetBackends=vmvx,vmvx-inline})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-2
 // RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-hal-assign-legacy-target-devices{targetBackends=vmvx,vmvx})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-EQ
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-hal-assign-legacy-target-devices{target-registry=xyz targetBackends=vmvx,vmvx})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-EQ
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-hal-assign-legacy-target-devices{target-registry=global targetBackends=vmvx,vmvx})' %s | FileCheck %s --check-prefix=CHECK --check-prefix=TARGET-EQ
 
 // TARGET-1: #device_target_local = #hal.device.target<"local"
 

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/Passes.td
@@ -48,7 +48,7 @@ def FixedPointIteratorPass : Pass<"iree-util-fixed-point-iterator", ""> {
   let summary = "Iterates a sub-pipeline to a fixed point.";
   let constructor = [{
     mlir::iree_compiler::IREE::Util::createFixedPointIteratorPass(
-        mlir::OpPassManager("dummy_op"))
+        mlir::OpPassManager())
   }];
 }
 

--- a/compiler/src/iree/compiler/Tools/init_mlir_passes.h
+++ b/compiler/src/iree/compiler/Tools/init_mlir_passes.h
@@ -16,6 +16,7 @@
 
 #include "mlir/Conversion/Passes.h"
 #include "mlir/Dialect/Affine/Passes.h"
+#include "mlir/Dialect/Arith/Transforms/Passes.h"
 #include "mlir/Dialect/ArmSME/Transforms/Passes.h"
 #include "mlir/Dialect/Bufferization/Transforms/Passes.h"
 #include "mlir/Dialect/GPU/Transforms/Passes.h"
@@ -24,6 +25,7 @@
 #include "mlir/Dialect/SCF/Transforms/Passes.h"
 #include "mlir/Dialect/SPIRV/Transforms/Passes.h"
 #include "mlir/Dialect/Shape/Transforms/Passes.h"
+#include "mlir/Dialect/Tosa/Transforms/Passes.h"
 #include "mlir/Dialect/Transform/Transforms/Passes.h"
 #include "mlir/Transforms/Passes.h"
 
@@ -64,6 +66,22 @@ inline void registerMlirPasses() {
 
   // Linalg
   registerLinalgPasses();
+
+  // Tosa
+  registerTosaToMLProgram();
+  registerTosaToSCF();
+  registerTosaToLinalgNamed();
+  registerTosaToTensor();
+  registerTosaToArith();
+  tosa::registerTosaValidationPass();
+  tosa::registerTosaLayerwiseConstantFoldPass();
+  tosa::registerTosaInferShapesPass();
+  tosa::registerTosaOptionalDecompositionsPass();
+  tosa::registerTosaMakeBroadcastablePass();
+  registerSCFForLoopCanonicalization();
+
+  // Arith
+  arith::registerArithUnsignedWhenEquivalentPass();
 
   // LLVM
   registerConvertArmNeon2dToIntrPass();


### PR DESCRIPTION
- Fix/workaround for TargetRegistry de/serialization: Serialize the global registry to "global" & always fall-back to the global registry.
- Fix FixedPointIteratorPass constructor. 
- Add Flow::ExecutablOp with `addNestedPass` instead of `passManager.nest` and `addPass`.
- Aded Tosa and Arith Passes (possibly still some missing) to `registerMlirPasses`
- Also added -print-pipeline-passes support

Let me know if there are better ways to fix reproducers :)