### PR TITLE
[ROCM] Don't reject RDNA4 targets, add them to wavesize32 list

### DIFF
--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -496,12 +496,14 @@ public:
         opt.GlobalISelAbort = options.globalISel
                                   ? llvm::GlobalISelAbortMode::Enable
                                   : llvm::GlobalISelAbortMode::Disable;
+        bool isWave64 = true;
         SmallVector<std::string> features;
         if (targetArch.starts_with("gfx10") ||
             targetArch.starts_with("gfx11") ||
             targetArch.starts_with("gfx12")) {
           switch (subgroupSize.value_or(64)) {
           case 32:
+            isWave64 = false;
             features.emplace_back("+wavefrontsize32");
             break;
           default:
@@ -581,8 +583,8 @@ public:
       }
 
       // Sets HIP platform globals based on the target architecture.
-      if (failed(setHIPGlobals(variantOp.getLoc(), llvmModule.get(),
-                               targetArch))) {
+      if (failed(setHIPGlobals(variantOp.getLoc(), llvmModule.get(), targetArch,
+                               isWave64))) {
         return failure();
       }
 

--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -46,6 +46,7 @@
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Transforms/Utils/Cloning.h"
+#include "mlir/Dialect/AMDGPU/Utils/Chipset.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -437,6 +438,12 @@ public:
                << "object file could not be loaded: " << objectAttr;
       }
     } else {
+      auto maybeChipset = amdgpu::Chipset::parse(targetArch);
+      if (failed(maybeChipset)) {
+        return variantOp.emitOpError()
+               << "could not parse AMDGPU chipset name '" << targetArch << "'";
+      }
+      amdgpu::Chipset chipset = *maybeChipset;
       // Perform the translation in a separate context to avoid any
       // multi-threading issues.
       llvm::LLVMContext context;
@@ -469,6 +476,7 @@ public:
       }
 
       std::unique_ptr<llvm::TargetMachine> targetMachine;
+      bool isWave64 = true;
       {
         llvm::Triple triple("amdgcn-amd-amdhsa");
         std::string error;
@@ -496,11 +504,8 @@ public:
         opt.GlobalISelAbort = options.globalISel
                                   ? llvm::GlobalISelAbortMode::Enable
                                   : llvm::GlobalISelAbortMode::Disable;
-        bool isWave64 = true;
         SmallVector<std::string> features;
-        if (targetArch.starts_with("gfx10") ||
-            targetArch.starts_with("gfx11") ||
-            targetArch.starts_with("gfx12")) {
+        if (chipset.majorVersion >= 10 && chipset.majorVersion <= 12) {
           switch (subgroupSize.value_or(64)) {
           case 32:
             isWave64 = false;
@@ -583,7 +588,7 @@ public:
       }
 
       // Sets HIP platform globals based on the target architecture.
-      if (failed(setHIPGlobals(variantOp.getLoc(), llvmModule.get(), targetArch,
+      if (failed(setHIPGlobals(variantOp.getLoc(), llvmModule.get(), chipset,
                                isWave64))) {
         return failure();
       }

--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -498,7 +498,8 @@ public:
                                   : llvm::GlobalISelAbortMode::Disable;
         SmallVector<std::string> features;
         if (targetArch.starts_with("gfx10") ||
-            targetArch.starts_with("gfx11")) {
+            targetArch.starts_with("gfx11") ||
+            targetArch.starts_with("gfx12")) {
           switch (subgroupSize.value_or(64)) {
           case 32:
             features.emplace_back("+wavefrontsize32");

--- a/compiler/plugins/target/ROCM/ROCMTargetUtils.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTargetUtils.cpp
@@ -130,8 +130,8 @@ LogicalResult setHIPGlobals(Location loc, llvm::Module *module,
   // Oldest GFX arch supported is gfx60x.
   if (major < 6)
     return failure();
-  // Latest GFX arch supported is gfx115x.
-  if (major > 11 || (major == 11 && minor > 0x5f))
+  // Latest GFX arch supported is gfx120x.
+  if (major > 12 || (major == 12 && minor > 0xf))
     return failure();
   int chipCode = major * 1000 + minor;
   auto *int32Type = llvm::Type::getInt32Ty(module->getContext());

--- a/compiler/plugins/target/ROCM/ROCMTargetUtils.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTargetUtils.cpp
@@ -124,11 +124,12 @@ LogicalResult setHIPGlobals(Location loc, llvm::Module *module,
   }
   // Latest GFX arch supported is gfx120x.
   if (chipset.majorVersion > 12 ||
-      (chipset.majorVersion == 12 && chipset.minorVersion > 0))
+      (chipset.majorVersion == 12 && chipset.minorVersion > 0)) {
     return emitError(loc)
            << "a chipset with major version = " << chipset.majorVersion
            << " and minor version = " << chipset.minorVersion
            << " was not known to exist at the time this IREE was built";
+  }
   int chipCode = chipset.majorVersion * 1000 + chipset.minorVersion * 16 +
                  chipset.steppingVersion;
   auto *int32Type = llvm::Type::getInt32Ty(module->getContext());

--- a/compiler/plugins/target/ROCM/ROCMTargetUtils.h
+++ b/compiler/plugins/target/ROCM/ROCMTargetUtils.h
@@ -11,11 +11,15 @@
 #include "llvm/IR/Module.h"
 #include "llvm/Target/TargetMachine.h"
 
+namespace mlir::amdgpu {
+struct Chipset;
+} // namespace mlir::amdgpu
+
 namespace mlir::iree_compiler::IREE::HAL {
 
 // Sets HIP platform globals based on the target architecture.
 LogicalResult setHIPGlobals(Location loc, llvm::Module *module,
-                            StringRef targetChip, bool isWave64);
+                            const amdgpu::Chipset &targetChip, bool isWave64);
 
 // Links HIP device bitcode if the module uses any symbols from it.
 LogicalResult linkHIPBitcodeIfNeeded(Location loc, llvm::Module *module,

--- a/compiler/plugins/target/ROCM/ROCMTargetUtils.h
+++ b/compiler/plugins/target/ROCM/ROCMTargetUtils.h
@@ -15,7 +15,7 @@ namespace mlir::iree_compiler::IREE::HAL {
 
 // Sets HIP platform globals based on the target architecture.
 LogicalResult setHIPGlobals(Location loc, llvm::Module *module,
-                            StringRef targetChip);
+                            StringRef targetChip, bool isWave64);
 
 // Links HIP device bitcode if the module uses any symbols from it.
 LogicalResult linkHIPBitcodeIfNeeded(Location loc, llvm::Module *module,


### PR DESCRIPTION
We have a check for not senting unknown targets
into LLVM that was causing silent failures in executable serialization. This patch adds gfx120x as supported and also makes it pass +wavesize32 like gfx11 and gfx10.

This also fixes a TODO about just using amdgpu::Chipset to parse the chipset version because I'm here already *and* fixes a bug in the device global setup that would cause the device libraries to think we're in wave64 mode when we're in wave32 mode