### PR TITLE
Adding CloneToConsumersPass and ElideAsyncTransfersPass.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
@@ -162,7 +162,7 @@ struct ResourceDeallocaOpPattern
     Value signalFence = getOrCreateSignalFence(
         loc, device, deallocaOp.getResultTimepoint(), rewriter);
 
-    // Queue allocation.
+    // Queue deallocation.
     rewriter.create<IREE::HAL::DeviceQueueDeallocaOp>(
         loc, device, queueAffinity, waitFence, signalFence,
         adaptor.getOperand());

--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
@@ -939,4 +939,6 @@ LogicalResult ResourceUsageAnalysis::run() {
   return solver.run();
 }
 
+void ResourceUsageAnalysis::print(llvm::raw_ostream &os) { solver.print(os); }
+
 } // namespace mlir::iree_compiler::IREE::Stream

--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.h
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.h
@@ -70,6 +70,9 @@ public:
   // May fail if analysis cannot be completed due to unsupported or unknown IR.
   LogicalResult run();
 
+  // Prints the analysis results to |os|.
+  void print(llvm::raw_ostream &os);
+
   // Returns the analyzed resource usage of the |value| resource.
   // May return `Unknown` if analysis failed for the given value due to usage
   // that lead to indeterminate results (such as indirect access).

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -1961,6 +1961,8 @@ LogicalResult TensorCloneOp::verify() {
   return success();
 }
 
+bool TensorCloneOp::preferCloneToConsumers() { return true; }
+
 //===----------------------------------------------------------------------===//
 // stream.tensor.slice
 //===----------------------------------------------------------------------===//
@@ -2773,6 +2775,16 @@ void AsyncDispatchOp::getAsyncAccessRanges(
     ranges.push_back({ResourceAccessBitfield::Write, result, Value{},
                       resultSize, resultSize});
   }
+}
+
+bool AsyncDispatchOp::preferCloneToConsumers() {
+  // If the dispatch does not consume any resources then it is effectively a
+  // slow splat and should be treated like one.
+  const bool consumesAny = llvm::any_of(
+      getResourceOperands(), +[](Value operand) {
+        return isa<IREE::Stream::AffinityTypeInterface>(operand.getType());
+      });
+  return !consumesAny;
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -1379,7 +1379,9 @@ def Stream_TensorSplatOp : Stream_PureOp<"tensor.splat", [
 def Stream_TensorCloneOp : Stream_PureOp<"tensor.clone", [
   AttrSizedOperandSegments,
   Stream_AffinityOp,
-  Stream_StreamableOp,
+  DeclareOpInterfaceMethods<Stream_StreamableOp, [
+    "preferCloneToConsumers",
+  ]>,
   Stream_TensorPhaseOp,
   Util_ShapeAwareOp,
   Util_SizeAwareOp,
@@ -2491,7 +2493,9 @@ def Stream_AsyncDispatchOp : Stream_Op<"async.dispatch", [
   DeclareOpInterfaceMethods<SymbolUserOpInterface>,
   Stream_AffinityOp,
   Stream_AsyncPhaseOp,
-  Stream_StreamableOp,
+  DeclareOpInterfaceMethods<Stream_StreamableOp, [
+    "preferCloneToConsumers",
+  ]>,
   DeclareOpInterfaceMethods<Stream_AsyncAccessOp, [
     "getAsyncAccessRanges",
   ]>,

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/async_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/async_folding.mlir
@@ -125,8 +125,8 @@ util.func private @SplatAlreadyAtSinkLocation(
 
 // -----
 
-// CHECK-LABEL: @PropagateClonableOps
-util.func private @PropagateClonableOps(%arg0: index) -> !stream.resource<*> {
+// CHECK-LABEL: @PropagateCloneableOps
+util.func private @PropagateCloneableOps(%arg0: index) -> !stream.resource<*> {
   %c0 = arith.constant 0 : index
   %c128 = arith.constant 128 : index
   %c123_i32 = arith.constant 123 : i32
@@ -136,6 +136,21 @@ util.func private @PropagateClonableOps(%arg0: index) -> !stream.resource<*> {
   %1 = stream.async.clone %0 : !stream.resource<*>{%arg0} -> !stream.resource<*>{%arg0}
   // CHECK: util.return %[[T]]
   util.return %1 : !stream.resource<*>
+}
+
+// -----
+
+// CHECK-LABEL: @PropagateTypeChangeCloneableOps
+util.func private @PropagateTypeChangeCloneableOps(%arg0: index) -> !stream.resource<variable> {
+  %c0 = arith.constant 0 : index
+  %c128 = arith.constant 128 : index
+  %c123_i32 = arith.constant 123 : i32
+  // CHECK: %[[T:.+]] = stream.async.splat %c123_i32 : i32 -> !stream.resource<variable>{%arg0}
+  %0 = stream.async.splat %c123_i32 : i32 -> !stream.resource<transient>{%arg0}
+  // CHECK-NOT: stream.async.clone
+  %1 = stream.async.clone %0 : !stream.resource<transient>{%arg0} -> !stream.resource<variable>{%arg0}
+  // CHECK: util.return %[[T]]
+  util.return %1 : !stream.resource<variable>
 }
 
 // -----

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/BUILD.bazel
@@ -18,6 +18,7 @@ iree_compiler_cc_library(
         "AnnotateAffinities.cpp",
         "AnnotateDispatchArguments.cpp",
         "AnnotateDispatchAssumptions.cpp",
+        "CloneToConsumers.cpp",
         "ConvertToStream.cpp",
         "DumpStatistics.cpp",
         "ElideAsyncCopies.cpp",

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/BUILD.bazel
@@ -21,6 +21,7 @@ iree_compiler_cc_library(
         "ConvertToStream.cpp",
         "DumpStatistics.cpp",
         "ElideAsyncCopies.cpp",
+        "ElideAsyncTransfers.cpp",
         "ElideTimepoints.cpp",
         "EmplaceAllocations.cpp",
         "EncodeTensors.cpp",

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_cc_library(
     "AnnotateAffinities.cpp"
     "AnnotateDispatchArguments.cpp"
     "AnnotateDispatchAssumptions.cpp"
+    "CloneToConsumers.cpp"
     "ConvertToStream.cpp"
     "DumpStatistics.cpp"
     "ElideAsyncCopies.cpp"

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/CMakeLists.txt
@@ -22,6 +22,7 @@ iree_cc_library(
     "ConvertToStream.cpp"
     "DumpStatistics.cpp"
     "ElideAsyncCopies.cpp"
+    "ElideAsyncTransfers.cpp"
     "ElideTimepoints.cpp"
     "EmplaceAllocations.cpp"
     "EncodeTensors.cpp"

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/CloneToConsumers.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/CloneToConsumers.cpp
@@ -1,0 +1,197 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <utility>
+
+#include "iree/compiler/Dialect/Stream/Analysis/Affinity.h"
+#include "iree/compiler/Dialect/Stream/IR/StreamDialect.h"
+#include "iree/compiler/Dialect/Stream/IR/StreamOps.h"
+#include "iree/compiler/Dialect/Stream/Transforms/Passes.h"
+#include "llvm/Support/Debug.h"
+#include "mlir/IR/AsmState.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "iree-stream-clone-to-consumers"
+
+namespace mlir::iree_compiler::IREE::Stream {
+
+#define GEN_PASS_DEF_CLONETOCONSUMERSPASS
+#include "iree/compiler/Dialect/Stream/Transforms/Passes.h.inc"
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// --iree-stream-clone-to-consumers
+//===----------------------------------------------------------------------===//
+
+// Returns true if the given |op| can be cloned as part of this pass.
+static bool canCloneOp(Operation *op) {
+  if (!op) {
+    return false;
+  } else if (auto streamableOp =
+                 dyn_cast<IREE::Stream::StreamableOpInterface>(op)) {
+    return streamableOp.preferCloneToConsumers();
+  } else if (mlir::isPure(op)) {
+    return true;
+  }
+  return false;
+}
+
+// TODO(benvanik): swap this with a full analysis to find values that are on
+// edges that should be cloned. For example, a solver given
+// `A -> B -> C -> device0|device1 -> D` could mark A, B, and C as needing
+// clones for device 0 and 1. If ops that consume values but are still cloneable
+// are added we may need that to clone entire trees in one shot instead of
+// needing the fixed-point iteration. It would also let us clone across branch
+// and function boundaries: this simple local analysis only works in a single
+// basic block.
+static bool tryCloneToConsumersInRegion(Region &region,
+                                        AffinityAnalysis &analysis) {
+  bool didChange = false;
+  SmallVector<IREE::Stream::AffinityAttr> affinities; // cached, cleared in for
+  DenseMap<Operation *, Operation *> clonedOps;       // cached, cleared in for
+  for (auto &block : region.getBlocks()) {
+    for (auto &op : block.getOperations()) {
+      // Since we aren't using affinities here and just cloning the entire
+      // use-def chain we can't share cloned ops across other ops. It's possible
+      // to use analysis to determine if the op we cloned for shares the same
+      // affinity but the outer fixed point iteration takes care of that by
+      // running analysis again with the mutated IR.
+      clonedOps.clear();
+      for (auto &operand : op.getOpOperands()) {
+        // This simple analysis is block local and is not be able to look across
+        // branches or function calls.
+        auto *definingOp = operand.get().getDefiningOp();
+        if (!canCloneOp(definingOp)) {
+          continue;
+        }
+
+        // If we already cloned the defining op for this operand we can reuse
+        // it. Note that we can only reuse ops we cloned *for this op* as other
+        // ops may have different affinities.
+        auto result = cast<OpResult>(operand.get());
+        auto clonedIt = clonedOps.find(definingOp);
+        if (clonedIt != clonedOps.end()) {
+          operand.set(clonedIt->second->getResult(result.getResultNumber()));
+          didChange = true;
+          continue;
+        }
+
+        // Get the affinities the operand is potentially produced for.
+        // This will fail if analysis failed or may return the default affinity.
+        affinities.clear();
+        analysis.tryLookupResourceAffinity(result, affinities);
+
+        // Clone the producer of the operand if it has multiple affinities and
+        // replace our use with it.
+        if (affinities.size() > 1) {
+          OpBuilder builder(&op);
+          auto *clonedOp = builder.clone(*definingOp);
+          clonedOps.insert(std::make_pair(definingOp, clonedOp));
+          operand.set(clonedOp->getResult(result.getResultNumber()));
+          didChange = true;
+          continue;
+        }
+      }
+    }
+  }
+  return didChange;
+}
+
+// Clones ops that request cloning to consumers when their affinity is
+// ambiguous.
+struct CloneToConsumersPass
+    : public IREE::Stream::impl::CloneToConsumersPassBase<
+          CloneToConsumersPass> {
+  GreedyRewriteConfig config;
+  std::shared_ptr<const FrozenRewritePatternSet> patterns;
+
+  LogicalResult initialize(MLIRContext *context) override {
+    // Inherit the same config defaults from the upstream canonicalizer pass.
+    config.useTopDownTraversal = true;
+    config.enableRegionSimplification = mlir::GreedySimplifyRegionLevel::Normal;
+
+    RewritePatternSet owningPatterns(context);
+    for (auto *dialect : context->getLoadedDialects()) {
+      dialect->getCanonicalizationPatterns(owningPatterns);
+    }
+    for (RegisteredOperationName op : context->getRegisteredOperations()) {
+      op.getCanonicalizationPatterns(owningPatterns, context);
+    }
+    patterns =
+        std::make_shared<FrozenRewritePatternSet>(std::move(owningPatterns));
+
+    return success();
+  }
+
+  void runOnOperation() override {
+    auto moduleOp = getOperation();
+    if (moduleOp.getBody()->empty()) {
+      return;
+    }
+
+    // NOTE: we currently run this only once because all current inputs only
+    // need that. If we end up with more complex programs that have transfers
+    // that break analysis we may need multiple runs.
+    unsigned maxIterationCount = 32;
+
+    // Try analyzing the program and cloning operations until all are used on
+    // a single affinity.
+    unsigned iterationCount = 0;
+    for (; iterationCount < maxIterationCount; ++iterationCount) {
+      // Perform whole-program analysis.
+      // TODO(benvanik): reuse allocator across iterations.
+      AffinityAnalysis analysis(moduleOp);
+      if (failed(analysis.run())) {
+        moduleOp.emitError() << "failed to solve for affinity analysis";
+        return signalPassFailure();
+      }
+
+      // Apply analysis by cloning all ops we can with ambiguous affinities.
+      // If we can't clone any we'll consider the iteration complete and exit.
+      bool didChange = false;
+      for (auto funcOp : moduleOp.getOps<CallableOpInterface>()) {
+        bool funcDidChange = false;
+        if (auto *region = funcOp.getCallableRegion()) {
+          funcDidChange = tryCloneToConsumersInRegion(*region, analysis);
+        }
+        if (funcDidChange) {
+          if (failed(
+                  applyPatternsGreedily(getOperation(), *patterns, config))) {
+            llvm::errs()
+                << "canonicalization failed to converge; bad IR was produced\n";
+            return signalPassFailure();
+          }
+        }
+        didChange |= funcDidChange;
+      }
+      if (!didChange) {
+        break;
+      }
+    }
+    if (iterationCount == maxIterationCount) {
+      // If you find yourself hitting this we can evaluate increasing the
+      // iteration count (if it would eventually converge) or whether we allow
+      // this to happen without remarking. For now all our programs converge in
+      // just one or two iterations and this needs to be tuned with more complex
+      // control flow.
+      moduleOp.emitRemark()
+          << "clone to consumers pass failed to reach a fixed point after "
+          << maxIterationCount
+          << " iterations; ambiguous affinity may be present";
+      return;
+    }
+  }
+};
+
+} // namespace
+
+} // namespace mlir::iree_compiler::IREE::Stream

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ElideAsyncCopies.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ElideAsyncCopies.cpp
@@ -680,8 +680,9 @@ struct ElideAsyncCopiesPass
           ElideAsyncCopiesPass> {
   void runOnOperation() override {
     auto moduleOp = getOperation();
-    if (moduleOp.getBody()->empty())
+    if (moduleOp.getBody()->empty()) {
       return;
+    }
 
     // Try analyzing the program and eliding the unneeded copies until we reach
     // a fixed point (no more copies can be elided).
@@ -692,7 +693,7 @@ struct ElideAsyncCopiesPass
       // TODO(benvanik): reuse allocator across iterations.
       ElisionAnalysis analysis(moduleOp);
       if (failed(analysis.run())) {
-        moduleOp.emitError() << "failed to solve for last users";
+        moduleOp.emitError() << "failed to solve for elision analysis";
         return signalPassFailure();
       }
 
@@ -711,7 +712,7 @@ struct ElideAsyncCopiesPass
     if (iterationCount == maxIterationCount) {
       // If you find yourself hitting this we can evaluate increasing the
       // iteration count (if it would eventually converge) or whether we allow
-      // this to happen without remarking. For now all our programs coverge in
+      // this to happen without remarking. For now all our programs converge in
       // just one or two iterations and this needs to be tuned with more complex
       // control flow.
       moduleOp.emitRemark()

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ElideAsyncTransfers.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ElideAsyncTransfers.cpp
@@ -1,0 +1,159 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <utility>
+
+#include "iree/compiler/Dialect/Stream/Analysis/Affinity.h"
+#include "iree/compiler/Dialect/Stream/IR/StreamDialect.h"
+#include "iree/compiler/Dialect/Stream/IR/StreamOps.h"
+#include "iree/compiler/Dialect/Stream/Transforms/Passes.h"
+#include "llvm/Support/Debug.h"
+#include "mlir/IR/AsmState.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Pass/Pass.h"
+
+#define DEBUG_TYPE "iree-stream-elide-async-transfers"
+
+namespace mlir::iree_compiler::IREE::Stream {
+
+#define GEN_PASS_DEF_ELIDEASYNCTRANSFERSPASS
+#include "iree/compiler/Dialect/Stream/Transforms/Passes.h.inc"
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// --iree-stream-elide-async-transfers
+//===----------------------------------------------------------------------===//
+
+static bool tryElideTransferOp(IREE::Stream::AsyncTransferOp transferOp,
+                               AffinityAnalysis &analysis) {
+  // Only operate on transfers that are from/to the same affinity.
+  auto sourceAffinityAttr =
+      analysis.lookupResourceAffinity(transferOp.getSource());
+  auto targetAffinityAttr =
+      analysis.lookupResourceAffinity(transferOp.getResult());
+  if (sourceAffinityAttr != targetAffinityAttr) {
+    return false;
+  }
+
+  // If the transfer is from/to staging we need to preserve it even if the
+  // affinities are redundant.
+  auto sourceType =
+      cast<IREE::Stream::ResourceType>(transferOp.getSource().getType());
+  auto targetType =
+      cast<IREE::Stream::ResourceType>(transferOp.getResult().getType());
+  if (sourceType.getLifetime() == IREE::Stream::Lifetime::Staging ||
+      targetType.getLifetime() == IREE::Stream::Lifetime::Staging) {
+    LLVM_DEBUG({
+      llvm::dbgs() << "[elide-transfers] skipping staging transfer (";
+      llvm::dbgs() << sourceType;
+      llvm::dbgs() << " -> ";
+      llvm::dbgs() << targetType;
+      llvm::dbgs() << ")\n";
+    });
+    return false;
+  }
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "[elide-transfers] converting self transfer to clone (";
+    llvm::dbgs() << sourceType;
+    llvm::dbgs() << " -> ";
+    llvm::dbgs() << targetType;
+    llvm::dbgs() << ")\n";
+  });
+
+  OpBuilder builder(transferOp);
+  auto cloneOp = builder.create<IREE::Stream::AsyncCloneOp>(
+      transferOp.getLoc(), targetType, transferOp.getSource(),
+      transferOp.getSourceSize(), transferOp.getResultSize(),
+      targetAffinityAttr ? targetAffinityAttr : sourceAffinityAttr);
+  cloneOp->setDialectAttrs(transferOp->getDialectAttrs());
+
+  transferOp.getResult().replaceAllUsesWith(cloneOp.getResult());
+  transferOp.erase();
+
+  return true;
+}
+
+// Tries to elide copies nested within |region| when safe.
+// Returns true if any ops were elided.
+static bool tryElideAsyncTransfersInRegion(Region &region,
+                                           AffinityAnalysis &analysis) {
+  bool didChange = false;
+  for (auto &block : region) {
+    block.walk([&](Operation *op) {
+      return TypeSwitch<Operation *, WalkResult>(op)
+          .Case<IREE::Stream::AsyncTransferOp>([&](auto transferOp) {
+            didChange = tryElideTransferOp(transferOp, analysis) || didChange;
+            return WalkResult::advance();
+          })
+          .Default([&](auto *op) { return WalkResult::advance(); });
+    });
+  }
+  return didChange;
+}
+
+// Elides async transfers that are not required based on analysis.
+struct ElideAsyncTransfersPass
+    : public IREE::Stream::impl::ElideAsyncTransfersPassBase<
+          ElideAsyncTransfersPass> {
+  void runOnOperation() override {
+    auto moduleOp = getOperation();
+    if (moduleOp.getBody()->empty()) {
+      return;
+    }
+
+    // NOTE: we currently run this only once because all current inputs only
+    // need that. If we end up with more complex programs that have transfers
+    // that break analysis we may need multiple runs.
+    unsigned maxIterationCount = 2;
+
+    // Try analyzing the program and eliding the unneeded copies until we reach
+    // a fixed point (no more copies can be elided).
+    unsigned iterationCount = 0;
+    for (; iterationCount < maxIterationCount; ++iterationCount) {
+      // Perform whole-program analysis.
+      // TODO(benvanik): reuse allocator across iterations.
+      AffinityAnalysis analysis(moduleOp);
+      if (failed(analysis.run())) {
+        moduleOp.emitError() << "failed to solve for affinity analysis";
+        return signalPassFailure();
+      }
+
+      // Apply analysis by eliding all transfers that are safe to elide.
+      // If we can't elide any we'll consider the iteration complete and exit.
+      bool didChange = false;
+      for (auto funcOp : moduleOp.getOps<CallableOpInterface>()) {
+        if (auto *region = funcOp.getCallableRegion()) {
+          didChange =
+              tryElideAsyncTransfersInRegion(*region, analysis) || didChange;
+        }
+      }
+      if (!didChange) {
+        break; // quiesced
+      }
+    }
+    if (iterationCount == maxIterationCount) {
+      // If you find yourself hitting this we can evaluate increasing the
+      // iteration count (if it would eventually converge) or whether we allow
+      // this to happen without remarking. For now all our programs converge in
+      // just one or two iterations and this needs to be tuned with more complex
+      // control flow.
+      moduleOp.emitRemark()
+          << "transfer elision pass failed to reach a fixed point after "
+          << maxIterationCount
+          << " iterations; unneeded transfers may be present";
+      return;
+    }
+  }
+};
+
+} // namespace
+
+} // namespace mlir::iree_compiler::IREE::Stream

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
@@ -127,7 +127,15 @@ void buildStreamTensorPassPipeline(OpPassManager &passManager,
 
   // Elide any redundant transfers now that affinities are baked out and we know
   // where resources are located.
-  passManager.addPass(IREE::Stream::createElideAsyncTransfersPass());
+  //
+  // TODO(benvanik): enable this pass after updating usage refinement: today
+  // the clones are not handled correctly and will result in usage analysis
+  // failing. This seems to be caused by transfers having some non-trivial logic
+  // during analysis that clone does not have and just applying the same logic
+  // to clones results in other errors around lifetime changes. The resource
+  // analysis and refinement logic likely needs a larger reworking.
+  //
+  // passManager.addPass(IREE::Stream::createElideAsyncTransfersPass());
 
   // Cleanup globals that were created during conversion.
   buildStreamCleanupPassPipeline(passManager, transformOptions);

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
@@ -115,6 +115,10 @@ void buildStreamTensorPassPipeline(OpPassManager &passManager,
   // Run inlining after having baked out affinities.
   passManager.addPass(mlir::createInlinerPass());
 
+  // Elide any redundant transfers now that affinities are baked out and we know
+  // where resources are located.
+  passManager.addPass(IREE::Stream::createElideAsyncTransfersPass());
+
   // Cleanup globals that were created during conversion.
   buildStreamCleanupPassPipeline(passManager, transformOptions);
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
@@ -92,6 +92,16 @@ void buildStreamTensorPassPipeline(OpPassManager &passManager,
   // Conversion
   //----------------------------------------------------------------------------
 
+  // TODO(benvanik): cache the affinity analysis - if this pass does nothing (or
+  // once it converges) the analysis will be usable by AnnotateAffinities and
+  // ConvertToStream.
+  //
+  // Clone operations to consumers when the operations opt-in to such behavior.
+  //
+  // NOTE: CSE must not be run between this and ConvertToStream - doing so will
+  // undo the clones.
+  passManager.addPass(IREE::Stream::createCloneToConsumersPass());
+
   // Annotate all ops/resources with the analyzed affinities.
   // This should have no behavioral changes during conversion but allows for
   // debugging of analysis errors in end-user tooling.

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
@@ -45,18 +45,6 @@ def ConvertToStreamPass :
   ];
 }
 
-def ElideAsyncTransfersPass :
-    Pass<"iree-stream-elide-async-transfers", "mlir::ModuleOp"> {
-  let summary = "Elides transfers when they are not performing meaningful work.";
-  let description = [{
-    Performs whole-program analysis to identify transfers that are not required
-    for program correctness (transfers to/from the same device, etc).
-  }];
-  let dependentDialects = [
-    "IREE::Stream::StreamDialect",
-  ];
-}
-
 def EncodeHostTensorsPass :
     Pass<"iree-stream-encode-host-tensors", ""> {
   let summary = "Encodes tensors into storage formats based on affinity and target support.";
@@ -177,6 +165,20 @@ def MaterializeCopyOnWritePass :
   ];
 }
 
+def CloneToConsumersPass :
+    Pass<"iree-stream-clone-to-consumers", "mlir::ModuleOp"> {
+  let summary = "Clones operations that opt-in to consumer affinities.";
+  let description = [{
+    Performs whole-program analysis to identify operations that are used on
+    multiple affinities that can be cloned per-affinity. The `StreamableOp`
+    interface's `preferCloneToConsumers` query is used and any ops implementing
+    the interface may opt-in to the cloning.
+  }];
+  let dependentDialects = [
+    "IREE::Stream::StreamDialect",
+  ];
+}
+
 def ElideAsyncCopiesPass :
     Pass<"iree-stream-elide-async-copies", "mlir::ModuleOp"> {
   let summary = "Elides copies when they are not performing meaningful work.";
@@ -186,6 +188,18 @@ def ElideAsyncCopiesPass :
     of a value. This eliminates copies both from input programs and those
     materialized by the `iree-stream-materialize-copy-on-write` pass.
   }];
+}
+
+def ElideAsyncTransfersPass :
+    Pass<"iree-stream-elide-async-transfers", "mlir::ModuleOp"> {
+  let summary = "Elides transfers when they are not performing meaningful work.";
+  let description = [{
+    Performs whole-program analysis to identify transfers that are not required
+    for program correctness (transfers to/from the same device, etc).
+  }];
+  let dependentDialects = [
+    "IREE::Stream::StreamDialect",
+  ];
 }
 
 def EmplaceAllocationsPass :

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
@@ -45,6 +45,18 @@ def ConvertToStreamPass :
   ];
 }
 
+def ElideAsyncTransfersPass :
+    Pass<"iree-stream-elide-async-transfers", "mlir::ModuleOp"> {
+  let summary = "Elides transfers when they are not performing meaningful work.";
+  let description = [{
+    Performs whole-program analysis to identify transfers that are not required
+    for program correctness (transfers to/from the same device, etc).
+  }];
+  let dependentDialects = [
+    "IREE::Stream::StreamDialect",
+  ];
+}
+
 def EncodeHostTensorsPass :
     Pass<"iree-stream-encode-host-tensors", ""> {
   let summary = "Encodes tensors into storage formats based on affinity and target support.";

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/RefineUsage.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/RefineUsage.cpp
@@ -468,6 +468,8 @@ struct RefineUsagePass
       return signalPassFailure();
     }
 
+    analysis.print(llvm::errs());
+
     // Query and apply analysis results to all resources in the program.
     RewritePatternSet patterns(&getContext());
     insertUsageRefinementPatterns(&getContext(), analysis, patterns);

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/BUILD.bazel
@@ -22,6 +22,7 @@ iree_lit_test_suite(
             "convert_to_stream.mlir",
             "dump_statistics.mlir",
             "elide_async_copies.mlir",
+            "elide_async_transfers.mlir",
             "elide_timepoints_coverage.mlir",
             "elide_timepoints_immediate.mlir",
             "emplace_allocations.mlir",

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/BUILD.bazel
@@ -19,6 +19,7 @@ iree_lit_test_suite(
             "annotate_affinities.mlir",
             "annotate_dispatch_arguments.mlir",
             "annotate_dispatch_assumptions.mlir",
+            "clone_to_consumers.mlir",
             "convert_to_stream.mlir",
             "dump_statistics.mlir",
             "elide_async_copies.mlir",

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/CMakeLists.txt
@@ -17,6 +17,7 @@ iree_lit_test_suite(
     "annotate_affinities.mlir"
     "annotate_dispatch_arguments.mlir"
     "annotate_dispatch_assumptions.mlir"
+    "clone_to_consumers.mlir"
     "convert_to_stream.mlir"
     "dump_statistics.mlir"
     "elide_async_copies.mlir"

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/CMakeLists.txt
@@ -20,6 +20,7 @@ iree_lit_test_suite(
     "convert_to_stream.mlir"
     "dump_statistics.mlir"
     "elide_async_copies.mlir"
+    "elide_async_transfers.mlir"
     "elide_timepoints_coverage.mlir"
     "elide_timepoints_immediate.mlir"
     "emplace_allocations.mlir"

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/annotate_affinities.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/annotate_affinities.mlir
@@ -71,7 +71,7 @@ util.func private @constant_op() -> (tensor<1xi32>, tensor<1xi32>) {
 
 // Tests that splats (not constant-like but no consumed values) are placed with
 // their consumer(s). These are always best to rematerialize where they are
-// consumed to avoid allocating/transfering a bunch of repeated values.
+// consumed to avoid allocating/transferring a bunch of repeated values.
 
 // CHECK-LABEL: @splat_op
 util.func private @splat_op() -> tensor<1xi32> {

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/clone_to_consumers.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/clone_to_consumers.mlir
@@ -1,0 +1,152 @@
+// RUN: iree-opt --split-input-file --iree-stream-clone-to-consumers %s | FileCheck %s
+
+// Tests that splats (which are cloneable ops) are cloned for every user.
+
+// CHECK-LABEL: @splatOp
+util.func private @splatOp() -> (tensor<1xi32>, tensor<1xi32>) {
+  %splat_value = arith.constant 123 : i32
+  //      CHECK: %[[SPLAT_A:.+]] = flow.tensor.splat
+  %splat = flow.tensor.splat %splat_value : tensor<1xi32>
+  // CHECK-NEXT: %[[TRANSFER_A:.+]] = flow.tensor.transfer %[[SPLAT_A]]
+  %transfer_a = flow.tensor.transfer %splat : tensor<1xi32> to #hal.device.promise<@dev_a>
+  // CHECK-NEXT: %[[SPLAT_B:.+]] = flow.tensor.splat
+  // CHECK-NEXT: %[[TRANSFER_B:.+]] = flow.tensor.transfer %[[SPLAT_B]]
+  %transfer_b = flow.tensor.transfer %splat : tensor<1xi32> to #hal.device.promise<@dev_b>
+  // CHECK-NEXT: util.return %[[TRANSFER_A]], %[[TRANSFER_B]]
+  util.return %transfer_a, %transfer_b : tensor<1xi32>, tensor<1xi32>
+}
+
+// -----
+
+// Tests that a cloneable op with an explicit affinity assigned is not cloned.
+// This allows users to avoid the clones when they know they want a transfer.
+
+// CHECK-LABEL: @pinnedSplatOp
+util.func private @pinnedSplatOp() -> (tensor<1xi32>, tensor<1xi32>) {
+  %splat_value = arith.constant 123 : i32
+  //      CHECK: %[[SPLAT_A:.+]] = flow.tensor.splat
+  %splat_a = flow.tensor.splat %splat_value : tensor<1xi32> attributes {stream.affinity = #hal.device.promise<@dev_a>}
+  // CHECK-NEXT: %[[TRANSFER_A:.+]] = flow.tensor.transfer %[[SPLAT_A]]
+  %transfer_a = flow.tensor.transfer %splat_a : tensor<1xi32> to #hal.device.promise<@dev_a>
+  // CHECK-NEXT: %[[TRANSFER_B:.+]] = flow.tensor.transfer %[[SPLAT_A]]
+  %transfer_b = flow.tensor.transfer %splat_a : tensor<1xi32> to #hal.device.promise<@dev_b>
+  // CHECK-NEXT: util.return %[[TRANSFER_A]], %[[TRANSFER_B]]
+  util.return %transfer_a, %transfer_b : tensor<1xi32>, tensor<1xi32>
+}
+
+// -----
+
+// Tests that pure ops (here arith.select) also get cloned. Note that we clone
+// the entire use-def chain up to the root splat.
+
+// CHECK-LABEL: @selectOp
+util.func private @selectOp(%cond: i1) -> (tensor<1xi32>, tensor<1xi32>) {
+  // CHECK-DAG: %[[SPLAT0_VALUE:.+]] = arith.constant 123
+  %splat0_value = arith.constant 123 : i32
+  // CHECK-DAG: %[[SPLAT1_VALUE:.+]] = arith.constant 456
+  %splat1_value = arith.constant 456 : i32
+  // CHECK-DAG: %[[SPLAT0_A:.+]] = flow.tensor.splat %[[SPLAT0_VALUE]]
+  %splat0 = flow.tensor.splat %splat0_value : tensor<1xi32>
+  // CHECK-DAG: %[[SPLAT1_A:.+]] = flow.tensor.splat %[[SPLAT1_VALUE]]
+  %splat1 = flow.tensor.splat %splat1_value : tensor<1xi32>
+  // CHECK-DAG: %[[SELECT_A:.+]] = arith.select {{.+}}, %[[SPLAT0_A]], %[[SPLAT1_A]]
+  %select = arith.select %cond, %splat0, %splat1 : tensor<1xi32>
+  // CHECK-NEXT: %[[TRANSFER_A:.+]] = flow.tensor.transfer %[[SELECT_A]]
+  %transfer_a = flow.tensor.transfer %select : tensor<1xi32> to #hal.device.promise<@dev_a>
+  // CHECK-DAG: %[[SPLAT0_B:.+]] = flow.tensor.splat %[[SPLAT0_VALUE]]
+  // CHECK-DAG: %[[SPLAT1_B:.+]] = flow.tensor.splat %[[SPLAT1_VALUE]]
+  // CHECK-DAG: %[[SELECT_B:.+]] = arith.select {{.+}}, %[[SPLAT0_B]], %[[SPLAT1_B]]
+  // CHECK-NEXT: %[[TRANSFER_B:.+]] = flow.tensor.transfer %[[SELECT_B]]
+  %transfer_b = flow.tensor.transfer %select : tensor<1xi32> to #hal.device.promise<@dev_b>
+  // CHECK-NEXT: util.return %[[TRANSFER_A]], %[[TRANSFER_B]]
+  util.return %transfer_a, %transfer_b : tensor<1xi32>, tensor<1xi32>
+}
+
+// -----
+
+// Tests that a dispatch that consumes nothing is cloned for every user.
+// This is a special case where a dispatch is acting like a fancy splat that can
+// arise when generating masks, random numbers, etc.
+
+// CHECK-LABEL: @splatLikeDispatchOp
+util.func private @splatLikeDispatchOp() -> (tensor<1xi32>, tensor<1xi32>) {
+  %splat_value = arith.constant 123 : i32
+  //      CHECK: %[[DISPATCH_A:.+]] = flow.dispatch
+  %dispatch = flow.dispatch @some::@splat_like(%splat_value) : (i32) -> tensor<1xi32>
+  // CHECK-NEXT: %[[TRANSFER_A:.+]] = flow.tensor.transfer %[[DISPATCH_A]]
+  %transfer_a = flow.tensor.transfer %dispatch : tensor<1xi32> to #hal.device.promise<@dev_a>
+  // CHECK-NEXT: %[[DISPATCH_B:.+]] = flow.dispatch
+  // CHECK-NEXT: %[[TRANSFER_B:.+]] = flow.tensor.transfer %[[DISPATCH_B]]
+  %transfer_b = flow.tensor.transfer %dispatch : tensor<1xi32> to #hal.device.promise<@dev_b>
+  // CHECK-NEXT: util.return %[[TRANSFER_A]], %[[TRANSFER_B]]
+  util.return %transfer_a, %transfer_b : tensor<1xi32>, tensor<1xi32>
+}
+
+// -----
+
+// Tests that tied ops that do not have affinity of their own are cloned in
+// order to fully flatten out the dependency chain. Here we expect both the
+// splat dispatch and the reshape to be cloned for each target.
+
+// CHECK-LABEL: @reshapedDispatchOp
+util.func private @reshapedDispatchOp() -> (tensor<1x4xi32>, tensor<1x4xi32>) {
+  %splat_value = arith.constant 123 : i32
+  //      CHECK: %[[DISPATCH_A:.+]] = flow.dispatch
+  %splat = flow.dispatch @some::@splat_like(%splat_value) : (i32) -> tensor<4x1xi32>
+  // CHECK-NEXT: %[[RESHAPE_A:.+]] = flow.tensor.reshape %[[DISPATCH_A]]
+  %reshape = flow.tensor.reshape %splat : tensor<4x1xi32> -> tensor<1x4xi32>
+  // CHECK-NEXT: %[[TRANSFER_A:.+]] = flow.tensor.transfer %[[RESHAPE_A]]
+  %transfer_a = flow.tensor.transfer %reshape : tensor<1x4xi32> to #hal.device.promise<@dev_a>
+  // CHECK-NEXT: %[[DISPATCH_B:.+]] = flow.dispatch
+  // CHECK-NEXT: %[[RESHAPE_B:.+]] = flow.tensor.reshape %[[DISPATCH_B]]
+  // CHECK-NEXT: %[[TRANSFER_B:.+]] = flow.tensor.transfer %[[RESHAPE_B]]
+  %transfer_b = flow.tensor.transfer %reshape : tensor<1x4xi32> to #hal.device.promise<@dev_b>
+  // CHECK-NEXT: util.return %[[TRANSFER_A]], %[[TRANSFER_B]]
+  util.return %transfer_a, %transfer_b : tensor<1x4xi32>, tensor<1x4xi32>
+}
+
+// -----
+
+// Tests that a dispatch with multiple results is cloned even if some results
+// are not used on all devices - they'll end up unused and that's (probably) ok.
+// At this level of the stack there's not much we can do to elide the unneeded
+// results. We should only produce one clone per affinity instead of one per use
+// but the analysis required is expensive.
+
+// CHECK-LABEL: @uniformMultiResultDispatchOp
+util.func private @uniformMultiResultDispatchOp() -> (tensor<1xi32>, tensor<1xi32>, tensor<1xi32>) {
+  %dispatch_value = arith.constant 123 : i32
+  //      CHECK: %[[DISPATCH_A:.+]]:2 = flow.dispatch
+  %dispatch:2 = flow.dispatch @some::@multi_splat_like(%dispatch_value) : (i32) -> (tensor<1xi32>, tensor<1xi32>)
+  // CHECK-NEXT: %[[TRANSFER0_A:.+]] = flow.tensor.transfer %[[DISPATCH_A]]#0
+  %transfer0_a = flow.tensor.transfer %dispatch#0 : tensor<1xi32> to #hal.device.promise<@dev_a>
+  // CHECK-NEXT: %[[DISPATCH0_B:.+]]:2 = flow.dispatch
+  // CHECK-NEXT: %[[TRANSFER0_B:.+]] = flow.tensor.transfer %[[DISPATCH0_B]]#0
+  %transfer0_b = flow.tensor.transfer %dispatch#0 : tensor<1xi32> to #hal.device.promise<@dev_b>
+  // CHECK-NEXT: %[[DISPATCH1_B:.+]]:2 = flow.dispatch
+  // CHECK-NEXT: %[[TRANSFER1_B:.+]] = flow.tensor.transfer %[[DISPATCH1_B]]#1
+  %transfer1_b = flow.tensor.transfer %dispatch#1 : tensor<1xi32> to #hal.device.promise<@dev_b>
+  // CHECK-NEXT: util.return %[[TRANSFER0_A]], %[[TRANSFER0_B]], %[[TRANSFER1_B]]
+  util.return %transfer0_a, %transfer0_b, %transfer1_b : tensor<1xi32>, tensor<1xi32>, tensor<1xi32>
+}
+
+// -----
+
+// Tests that takes the same value multiple times does not clone the producers
+// more than once.
+
+// CHECK-LABEL: @multipleUses
+util.func private @multipleUses() -> (tensor<1xi32>, tensor<1xi32>) {
+  %splat_value = arith.constant 123 : i32
+  //      CHECK: %[[SPLAT_A:.+]] = flow.tensor.splat
+  %splat = flow.tensor.splat %splat_value : tensor<1xi32>
+  // CHECK-NEXT: %[[DISPATCH_A:.+]] = flow.dispatch @ex::@a(%[[SPLAT_A]], %[[SPLAT_A]])
+  %dispatch = flow.dispatch @ex::@a(%splat, %splat) {stream.affinity = #hal.device.promise<@dev_a>} : (tensor<1xi32>, tensor<1xi32>) -> tensor<1xi32>
+  // CHECK-NEXT: %[[TRANSFER_A:.+]] = flow.tensor.transfer %[[DISPATCH_A]]
+  %transfer_a = flow.tensor.transfer %dispatch : tensor<1xi32> to #hal.device.promise<@dev_a>
+  // CHECK-NEXT: %[[SPLAT_B:.+]] = flow.tensor.splat
+  // CHECK-NEXT: %[[TRANSFER_B:.+]] = flow.tensor.transfer %[[SPLAT_B]]
+  %transfer_b = flow.tensor.transfer %splat : tensor<1xi32> to #hal.device.promise<@dev_b>
+  // CHECK-NEXT: util.return %[[TRANSFER_A]], %[[TRANSFER_B]]
+  util.return %transfer_a, %transfer_b : tensor<1xi32>, tensor<1xi32>
+}

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/elide_async_transfers.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/elide_async_transfers.mlir
@@ -1,0 +1,72 @@
+// RUN: iree-opt --split-input-file --iree-stream-elide-async-transfers %s | FileCheck %s
+
+// Tests that a transfer with no source/target is turned into a clone.
+
+// CHECK-LABEL: @unassignedTransfers
+// CHECK-SAME: (%[[RESOURCE:.+]]: !stream.resource<*>, %[[SIZE:.+]]: index)
+util.func public @unassignedTransfers(%resource: !stream.resource<*>, %size: index) -> !stream.resource<*> {
+  // CHECK-NOT: stream.async.transfer
+  // CHECK: %[[TRANSFER:.+]] = stream.async.clone %[[RESOURCE]] : !stream.resource<*>{%[[SIZE]]} -> !stream.resource<*>{%[[SIZE]]}
+  %transfer = stream.async.transfer %resource : !stream.resource<*>{%size} -> !stream.resource<*>{%size}
+  // CHECK: util.return %[[TRANSFER]]
+  util.return %transfer : !stream.resource<*>
+}
+
+// -----
+
+// Tests that an elided transfer which changes lifetime has the proper types on
+// the resulting clone op.
+
+// CHECK-LABEL: @unassignedLifetimeTransfers
+// CHECK-SAME: (%[[RESOURCE:.+]]: !stream.resource<transient>, %[[SIZE:.+]]: index)
+util.func public @unassignedLifetimeTransfers(%resource: !stream.resource<transient>, %size: index) -> !stream.resource<external> {
+  // CHECK-NOT: stream.async.transfer
+  // CHECK: %[[TRANSFER:.+]] = stream.async.clone %[[RESOURCE]] : !stream.resource<transient>{%[[SIZE]]} -> !stream.resource<external>{%[[SIZE]]}
+  %transfer = stream.async.transfer %resource : !stream.resource<transient>{%size} -> !stream.resource<external>{%size}
+  // CHECK: util.return %[[TRANSFER]]
+  util.return %transfer : !stream.resource<external>
+}
+
+// -----
+
+// Tests that transfers to/from staging are not converted to clones.
+
+// CHECK-LABEL: @ignoreStagingTransfers
+// CHECK-SAME: (%[[RESOURCE:.+]]: !stream.resource<staging>, %[[SIZE:.+]]: index)
+util.func public @ignoreStagingTransfers(%resource: !stream.resource<staging>, %size: index) -> !stream.resource<external> {
+  // CHECK: stream.async.transfer
+  %transfer = stream.async.transfer %resource : !stream.resource<staging>{%size} -> !stream.resource<external>{%size}
+  util.return %transfer : !stream.resource<external>
+}
+
+// -----
+
+// Tests that missing source affinities from the target are elided.
+
+// CHECK-LABEL: @omittedSourceAffinity
+util.func public @omittedSourceAffinity(%size: index) -> !stream.resource<*> {
+  %c123_i32 = arith.constant 123 : i32
+  // CHECK: %[[SPLAT:.+]] = stream.async.splat
+  %splat = stream.async.splat %c123_i32 : i32 -> !stream.resource<*>{%size}
+  // CHECK-NOT: stream.async.transfer
+  // CHECK: %[[TRANSFER:.+]] = stream.async.clone %[[SPLAT]]
+  %transfer = stream.async.transfer %splat : !stream.resource<*>{%size} -> to(#hal.device.promise<@dev_a>) !stream.resource<*>{%size}
+  // CHECK: util.return %[[TRANSFER]]
+  util.return %transfer : !stream.resource<*>
+}
+
+// -----
+
+// Tests that missing target affinities from the source are elided.
+
+// CHECK-LABEL: @omittedTargetAffinity
+util.func public @omittedTargetAffinity(%size: index) -> !stream.resource<*> {
+  %c123_i32 = arith.constant 123 : i32
+  // CHECK: %[[SPLAT:.+]] = stream.async.splat
+  %splat = stream.async.splat %c123_i32 : i32 -> !stream.resource<*>{%size}
+  // CHECK-NOT: stream.async.transfer
+  // CHECK: %[[TRANSFER:.+]] = stream.async.clone on(#hal.device.promise<@dev_a>) %[[SPLAT]]
+  %transfer = stream.async.transfer %splat : !stream.resource<*>{%size} from(#hal.device.promise<@dev_a>) -> !stream.resource<*>{%size}
+  // CHECK: util.return %[[TRANSFER]]
+  util.return %transfer : !stream.resource<*>
+}

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/schedule_execution.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/schedule_execution.mlir
@@ -221,35 +221,35 @@ util.func public @partitioningWithConcurrentAffinities(%arg0: !stream.resource<e
 //    ↓    ↓
 // P2 4    5 P3
 //
-// CHECK-LABEL: @partitionWithInterdependentInterleavedDeviceAffinites
-util.func public @partitionWithInterdependentInterleavedDeviceAffinites(
-// CHECK-SAME: (%[[ARG0:.+]]: !stream.resource<external>,
+// CHECK-LABEL: @partitionWithInterdependentInterleavedDeviceAffinities
+util.func public @partitionWithInterdependentInterleavedDeviceAffinities(
+  // CHECK-SAME: (%[[ARG0:.+]]: !stream.resource<external>,
   %arg0: !stream.resource<external>,
-// CHECK-SAME: %[[ARG1:.+]]: !stream.resource<external>)
+  // CHECK-SAME: %[[ARG1:.+]]: !stream.resource<external>)
   %arg1: !stream.resource<external>) -> (!stream.resource<external>, !stream.resource<external>) {
   // CHECK: %[[C1:.+]] = arith.constant 1 : index
   %c1 = arith.constant 1 : index
 
   %0 = stream.async.dispatch on(#hal.device.affinity<@device_0>) @ex::@e00[%c1](
     %arg0[%c1 to %c1 for %c1]
-    ) : (!stream.resource<external>{%c1}) -> !stream.resource<transient>{%c1}
+  ) : (!stream.resource<external>{%c1}) -> !stream.resource<transient>{%c1}
   %1 = stream.async.dispatch on(#hal.device.affinity<@device_1>) @ex::@e01[%c1](
     %arg1[%c1 to %c1 for %c1]
-    ) : (!stream.resource<external>{%c1}) -> !stream.resource<transient>{%c1}
+  ) : (!stream.resource<external>{%c1}) -> !stream.resource<transient>{%c1}
 
   %2 = stream.async.dispatch on(#hal.device.affinity<@device_0>) @ex::@e10[%c1](
     %0[%c1 to %c1 for %c1], %1[%c1 to %c1 for %c1]
-    ) : (!stream.resource<transient>{%c1}, !stream.resource<transient>{%c1}) -> !stream.resource<transient>{%c1}
+  ) : (!stream.resource<transient>{%c1}, !stream.resource<transient>{%c1}) -> !stream.resource<transient>{%c1}
   %3 = stream.async.dispatch on(#hal.device.affinity<@device_1>) @ex::@e11[%c1](
     %0[%c1 to %c1 for %c1], %1[%c1 to %c1 for %c1]
-    ) : (!stream.resource<transient>{%c1}, !stream.resource<transient>{%c1}) -> !stream.resource<transient>{%c1}
+  ) : (!stream.resource<transient>{%c1}, !stream.resource<transient>{%c1}) -> !stream.resource<transient>{%c1}
 
   %4 = stream.async.dispatch on(#hal.device.affinity<@device_0>) @ex::@e20[%c1](
     %2[%c1 to %c1 for %c1], %3[%c1 to %c1 for %c1]
-    ) : (!stream.resource<transient>{%c1}, !stream.resource<transient>{%c1}) -> !stream.resource<external>{%c1}
+  ) : (!stream.resource<transient>{%c1}, !stream.resource<transient>{%c1}) -> !stream.resource<external>{%c1}
   %5 = stream.async.dispatch on(#hal.device.affinity<@device_1>) @ex::@e21[%c1](
     %2[%c1 to %c1 for %c1], %3[%c1 to %c1 for %c1]
-    ) : (!stream.resource<transient>{%c1}, !stream.resource<transient>{%c1}) -> !stream.resource<external>{%c1}
+  ) : (!stream.resource<transient>{%c1}, !stream.resource<transient>{%c1}) -> !stream.resource<external>{%c1}
 
   // Partition 0
   // CHECK: %[[RESULTS:.+]], %[[RESULT_TIMEPOINT:.+]] = stream.async.execute on(#hal.device.affinity<@device_0>)


### PR DESCRIPTION
CloneToConsumersPass performs affinity analysis and clones any clonable producer that is used by multiple affinities per-user. It's effectively the inverse of a CSE step and is intended to undo CSE that created the affinity ambiguity.

ElideAsyncTransfersPass does a global analysis to try to find transfers that are redundant and elides them. Unfortunately resource usage refinement is somewhat broken when transfers are turned into clones so the pass is currently disabled. The pass on its own is fine and shows a large reduction in transfers when applied.

The primary case where this arises today is CSE collapsing a splat or splat-like dispatch that is consumed by transfers or dispatches on different affinities.