### PR TITLE
Don't hoist sequence like ops

### DIFF
--- a/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
@@ -350,6 +350,13 @@ struct HoistableLinalgOpInterface
     if (!genericOp) {
       return !isa<linalg::FillOp>(op);
     }
+
+    // Don't hoist ops with no inputs, their result is defined by `linalg.index`
+    // ops and should be fused with their consumers.
+    if (genericOp.getNumDpsInputs() == 0) {
+      return false;
+    }
+
     if (linalg::isaFillOpInterface(genericOp).has_value()) {
       return false;
     }


### PR DESCRIPTION
We should not be hoisting `vector.step`-like `linalg.generic` ops. They should be fused into their consumers since this preserves information about how the tensor is indexed. 


This is affecting both VAE and llama, and there was a marginal improvement to their dispatch counts. The operation originates from torch-mlir's decomposition of `aten.index.Tensor`, which creates this sequence tensor for dimensions that are fully indexed.