### PR TITLE
Rename "hip_task" job to "rocm_hip".

### DIFF
--- a/.github/workflows/pkgci_test_sharktank.yml
+++ b/.github/workflows/pkgci_test_sharktank.yml
@@ -30,7 +30,7 @@ jobs:
             gpu: none
             runs-on: ubuntu-24.04
 
-          - name: hip_task
+          - name: rocm_hip
             target: target_hip
             gpu: gfx1100
             runs-on: nodai-amdgpu-w7900-x86-64


### PR DESCRIPTION
The convention is [compiler target, runtime HAL driver/device].

This was reported [here on Discord](https://discord.com/channels/689900678990135345/1166024193599615006/1341505000303759401).

ci-exactly: build_packages, test_sharktank