### PR TITLE
[hip] Handle when devices cannot access peers, such as on Windows.

### DIFF
--- a/runtime/src/iree/hal/drivers/hip/dynamic_symbol_tables.h
+++ b/runtime/src/iree/hal/drivers/hip/dynamic_symbol_tables.h
@@ -12,6 +12,7 @@ IREE_HAL_HIP_REQUIRED_PFN_DECL(hipCtxSetCurrent, hipCtx_t)
 IREE_HAL_HIP_REQUIRED_PFN_DECL(hipCtxGetCurrent, hipCtx_t *)
 IREE_HAL_HIP_REQUIRED_PFN_DECL(hipCtxPushCurrent, hipCtx_t)
 IREE_HAL_HIP_REQUIRED_PFN_DECL(hipCtxPopCurrent, hipCtx_t *)
+IREE_HAL_HIP_REQUIRED_PFN_DECL(hipDeviceCanAccessPeer, int *, int, int)
 IREE_HAL_HIP_REQUIRED_PFN_DECL(hipDeviceEnablePeerAccess, int, unsigned int)
 IREE_HAL_HIP_REQUIRED_PFN_DECL(hipDeviceGet, hipDevice_t *, int)
 IREE_HAL_HIP_REQUIRED_PFN_DECL(hipDeviceGetAttribute, int *,


### PR DESCRIPTION
With this change, I am able to now follow our ROCm instructions at https://iree.dev/guides/deployment-configurations/gpu-rocm/ on Windows, running MobileNet and getting the expected outputs 🎉

This does two things:

1. Only try to enable peering between devices if more than 1 device is going to be used
2. Check `hipDeviceCanAccessPeer` before calling `hipDeviceEnablePeerAccess` so there is a chance to log a better error message

### More information

On Windows 11 with 2x w7900 and the 6.2 HIP SDK, the previous code returned `hipErrorInvalidDevice` when calling `hipDeviceEnablePeerAccess`. On the same system under Linux (unknown HIP/ROCm version but pretty similar), the code works without errors. In both cases, I only requested a single device, so this peering code did not need to run at all. See also [this discussion on Discord](https://discord.com/channels/689900678990135345/1282818085153407038/1344105197353570377).

See documentation for these APIs at https://rocm.docs.amd.com/projects/HIP/en/latest/doxygen/html/group___peer_to_peer.html.

### Testing

> [!WARNING]
> I've only tested on the machines I have easy access to. I think we still need CI coverage for multi-device (e.g. https://github.com/iree-org/iree/issues/19995)