### PR TITLE
[DT][NFC] Remove duplicated code for existing layout checks

### DIFF
--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -590,8 +590,8 @@ enumerateCPUMatmulTiles(IREE::Encoding::EncodingAttr encoding,
 }
 
 struct CPUDeviceEncodingLayoutResolverAttrInterface
-    : public WrappedExternalModel<CPUDeviceEncodingLayoutResolverAttrInterface,
-                                  CPUEncodingLayoutAttr> {
+    : public DeviceEncodingLayoutResolverExternalModelBase<
+          CPUDeviceEncodingLayoutResolverAttrInterface, CPUEncodingLayoutAttr> {
 
   MaterializeEncodingInfo getEncodingInfoImpl(Attribute attr,
                                               RankedTensorType type) const {
@@ -716,8 +716,9 @@ enumerateVMVXMatmulTiles(linalg::ContractionDimensions cDims,
 }
 
 struct VMVXDeviceEncodingLayoutResolverAttrInterface final
-    : WrappedExternalModel<VMVXDeviceEncodingLayoutResolverAttrInterface,
-                           VMVXEncodingLayoutAttr> {
+    : DeviceEncodingLayoutResolverExternalModelBase<
+          VMVXDeviceEncodingLayoutResolverAttrInterface,
+          VMVXEncodingLayoutAttr> {
 
   MaterializeEncodingInfo getEncodingInfoImpl(Attribute attr,
                                               RankedTensorType type) const {

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -590,22 +590,12 @@ enumerateCPUMatmulTiles(IREE::Encoding::EncodingAttr encoding,
 }
 
 struct CPUDeviceEncodingLayoutResolverAttrInterface
-    : public Codegen::LayoutAttrInterface::ExternalModel<
-          CPUDeviceEncodingLayoutResolverAttrInterface, CPUEncodingLayoutAttr> {
-  MaterializeEncodingInfo getEncodingInfo(Attribute attr,
-                                          RankedTensorType type) const {
-    auto layoutAttr = cast<CPUEncodingLayoutAttr>(attr);
+    : public WrappedExternalModel<CPUDeviceEncodingLayoutResolverAttrInterface,
+                                  CPUEncodingLayoutAttr> {
 
-    // If the layout is already resolved, use it directly.
-    if (auto config = layoutAttr.getConfiguration()) {
-      if (auto namedAttr = config.getNamed(kEncodingInfoAttrName)) {
-        std::optional<MaterializeEncodingInfo> info =
-            Codegen::deserializeEncodingInfo(
-                cast<DictionaryAttr>(namedAttr->getValue()));
-        assert(info && "encoding_info is invalid");
-        return info.value();
-      }
-    }
+  MaterializeEncodingInfo getEncodingInfoImpl(Attribute attr,
+                                              RankedTensorType type) const {
+    auto layoutAttr = cast<CPUEncodingLayoutAttr>(attr);
 
     auto encoding = llvm::dyn_cast_or_null<IREE::Encoding::EncodingAttr>(
         type.getEncoding());
@@ -726,23 +716,12 @@ enumerateVMVXMatmulTiles(linalg::ContractionDimensions cDims,
 }
 
 struct VMVXDeviceEncodingLayoutResolverAttrInterface final
-    : Codegen::LayoutAttrInterface::ExternalModel<
-          VMVXDeviceEncodingLayoutResolverAttrInterface,
-          VMVXEncodingLayoutAttr> {
-  MaterializeEncodingInfo getEncodingInfo(Attribute attr,
-                                          RankedTensorType type) const {
-    auto layoutAttr = cast<VMVXEncodingLayoutAttr>(attr);
+    : WrappedExternalModel<VMVXDeviceEncodingLayoutResolverAttrInterface,
+                           VMVXEncodingLayoutAttr> {
 
-    // If the layout is already resolved, use it directly.
-    if (auto config = layoutAttr.getConfiguration()) {
-      if (auto namedAttr = config.getNamed(kEncodingInfoAttrName)) {
-        std::optional<MaterializeEncodingInfo> info =
-            Codegen::deserializeEncodingInfo(
-                cast<DictionaryAttr>(namedAttr->getValue()));
-        assert(info && "encoding_info is invalid");
-        return info.value();
-      }
-    }
+  MaterializeEncodingInfo getEncodingInfoImpl(Attribute attr,
+                                              RankedTensorType type) const {
+    auto layoutAttr = cast<VMVXEncodingLayoutAttr>(attr);
 
     auto encoding = llvm::dyn_cast_or_null<IREE::Encoding::EncodingAttr>(
         type.getEncoding());

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -593,6 +593,10 @@ struct CPUDeviceEncodingLayoutResolverAttrInterface
     : public DeviceEncodingLayoutResolverExternalModelBase<
           CPUDeviceEncodingLayoutResolverAttrInterface, CPUEncodingLayoutAttr> {
 
+  DictionaryAttr getConfiguration(Attribute attr) const {
+    return cast<CPUEncodingLayoutAttr>(attr).getConfiguration();
+  }
+
   MaterializeEncodingInfo getEncodingInfoImpl(Attribute attr,
                                               RankedTensorType type) const {
     auto layoutAttr = cast<CPUEncodingLayoutAttr>(attr);
@@ -719,6 +723,10 @@ struct VMVXDeviceEncodingLayoutResolverAttrInterface final
     : DeviceEncodingLayoutResolverExternalModelBase<
           VMVXDeviceEncodingLayoutResolverAttrInterface,
           VMVXEncodingLayoutAttr> {
+
+  DictionaryAttr getConfiguration(Attribute attr) const {
+    return cast<VMVXEncodingLayoutAttr>(attr).getConfiguration();
+  }
 
   MaterializeEncodingInfo getEncodingInfoImpl(Attribute attr,
                                               RankedTensorType type) const {

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -300,8 +300,8 @@ static Operation *lowerContractionOpToMultiMmaOp(OpBuilder &builder,
 }
 
 struct GPUDeviceEncodingLayoutResolverAttrInterface
-    : public WrappedExternalModel<GPUDeviceEncodingLayoutResolverAttrInterface,
-                                  GPUEncodingLayoutAttr> {
+    : public DeviceEncodingLayoutResolverExternalModelBase<
+          GPUDeviceEncodingLayoutResolverAttrInterface, GPUEncodingLayoutAttr> {
   MaterializeEncodingInfo getEncodingInfoImpl(Attribute attr,
                                               RankedTensorType type) const {
     auto layoutAttr = cast<GPUEncodingLayoutAttr>(attr);

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -300,10 +300,10 @@ static Operation *lowerContractionOpToMultiMmaOp(OpBuilder &builder,
 }
 
 struct GPUDeviceEncodingLayoutResolverAttrInterface
-    : public Codegen::LayoutAttrInterface::ExternalModel<
-          GPUDeviceEncodingLayoutResolverAttrInterface, GPUEncodingLayoutAttr> {
-  MaterializeEncodingInfo getEncodingInfo(Attribute attr,
-                                          RankedTensorType type) const {
+    : public WrappedExternalModel<GPUDeviceEncodingLayoutResolverAttrInterface,
+                                  GPUEncodingLayoutAttr> {
+  MaterializeEncodingInfo getEncodingInfoImpl(Attribute attr,
+                                              RankedTensorType type) const {
     auto layoutAttr = cast<GPUEncodingLayoutAttr>(attr);
     DictionaryAttr config = layoutAttr.getConfiguration();
 
@@ -313,18 +313,6 @@ struct GPUDeviceEncodingLayoutResolverAttrInterface
     MaterializeEncodingInfo info;
     if (!encoding) {
       return info;
-    }
-
-    // If the layout is already resolved, use it directly.
-    if (config) {
-      if (std::optional<NamedAttribute> namedAttr =
-              config.getNamed(kEncodingInfoAttrName)) {
-        std::optional<MaterializeEncodingInfo> preresolvedInfo =
-            Codegen::deserializeEncodingInfo(
-                cast<DictionaryAttr>(namedAttr->getValue()));
-        assert(preresolvedInfo && "encoding_info is invalid");
-        return preresolvedInfo.value();
-      }
     }
 
     IREE::GPU::TargetAttr gpuAttr = getGPUTargetAttr(config);

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -302,6 +302,10 @@ static Operation *lowerContractionOpToMultiMmaOp(OpBuilder &builder,
 struct GPUDeviceEncodingLayoutResolverAttrInterface
     : public DeviceEncodingLayoutResolverExternalModelBase<
           GPUDeviceEncodingLayoutResolverAttrInterface, GPUEncodingLayoutAttr> {
+  DictionaryAttr getConfiguration(Attribute attr) const {
+    return cast<GPUEncodingLayoutAttr>(attr).getConfiguration();
+  }
+
   MaterializeEncodingInfo getEncodingInfoImpl(Attribute attr,
                                               RankedTensorType type) const {
     auto layoutAttr = cast<GPUEncodingLayoutAttr>(attr);

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.h
@@ -24,10 +24,6 @@ struct DeviceEncodingLayoutResolverExternalModelBase
     : public Codegen::LayoutAttrInterface::ExternalModel<
           DeviceEncodingLayoutResolverAttrInterface, EncodingLayoutAttr> {
 public:
-  DictionaryAttr getConfiguration(Attribute attr) const {
-    return cast<EncodingLayoutAttr>(attr).getConfiguration();
-  }
-
   Codegen::MaterializeEncodingInfo
   getEncodingInfo(Attribute attr, RankedTensorType type) const {
     const DeviceEncodingLayoutResolverAttrInterface *impl =

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.h
@@ -20,7 +20,7 @@ static const char kEncodingInfoAttrName[] = "encoding_info";
 
 template <typename DeviceEncodingLayoutResolverAttrInterface,
           typename EncodingLayoutAttr>
-struct WrappedExternalModel
+struct DeviceEncodingLayoutResolverExternalModelBase
     : public Codegen::LayoutAttrInterface::ExternalModel<
           DeviceEncodingLayoutResolverAttrInterface, EncodingLayoutAttr> {
 public:

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.h
@@ -18,6 +18,11 @@ namespace mlir::iree_compiler::IREE {
 
 static const char kEncodingInfoAttrName[] = "encoding_info";
 
+// This class is the base class for the external model of different encoding
+// resolver attributes. It provides a public method, `getEncodingInfo` to reduce
+// the duplicated implementations before. To inherit it, it requires the derived
+// class to implement the `getConfiguration` method and the
+// `getEncodingInfoImpl` method.
 template <typename DeviceEncodingLayoutResolverAttrInterface,
           typename EncodingLayoutAttr>
 struct DeviceEncodingLayoutResolverExternalModelBase


### PR DESCRIPTION
I removed the duplicated code in the implementation of `CPUDeviceEncodingLayoutResolverAttrInterface`, `VMVXDeviceEncodingLayoutResolverAttrInterface`, and `GPUDeviceEncodingLayoutResolverAttrInterface`. I provide a base class `WrappedExternalModel` to provide `getConfiguration` and `getEncodingInfo`, so the derived class only needs to implement their own `getEncodingInfoImpl` method.

Fixing https://github.com/iree-org/iree/issues/20050