### PR TITLE
removes the check of large_model and opset_version

### DIFF
--- a/compiler/bindings/python/iree/compiler/tools/import_onnx/__main__.py
+++ b/compiler/bindings/python/iree/compiler/tools/import_onnx/__main__.py
@@ -86,12 +86,6 @@ def main(args: argparse.Namespace):
 def load_onnx_model(args: argparse.Namespace) -> onnx.ModelProto:
     input_dir = os.path.dirname(os.path.abspath(args.input_file))
 
-    # TODO: setup updating opset version without loading external weights.
-    if args.opset_version and args.large_model:
-        raise NotImplementedError(
-            "Updating the opset version for large models is currently unsupported."
-        )
-
     if not args.large_model:
         # Load the model, with possible external data coming from the default
         # location, or the location specified on the command line.


### PR DESCRIPTION
removes the check which is not needed anymore after handling opset_version issue using function added in PR: https://github.com/nod-ai/SHARK-TestSuite/pull/396