### PR TITLE
Increase size of the PotentialValuesState.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/DFX/State.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/DFX/State.h
@@ -433,7 +433,7 @@ struct PotentialValuesState : AbstractState {
   }
 
   // Maximum number of potential values to be tracked.
-  static constexpr unsigned maxPotentialValues = 256;
+  static constexpr unsigned maxPotentialValues = 8192;
 
   // Returns empty set as the best state of potential values.
   static PotentialValuesState getBestState() {


### PR DESCRIPTION
When running the ElideTimepoints pass on a large program (llama 8b for example) we exhaust our state, and fail to elide timepoints.

This significantly reduces the number of timepoints that end up in the waiting set in those cases.

The number of timepoint waits in the stream output are as follows.
```
23765 << State Size 256
8801 << State Size 8192
```