### PR TITLE
[Codegen] Add expand slice swap pattern to TileAndDistributeToWorkgroups

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
@@ -478,6 +478,8 @@ void TileAndDistributeToWorkgroupsUsingForallOpPass::runOnOperation() {
   tensor::ExtractSliceOp::getCanonicalizationPatterns(cleanupPatterns, context);
   tensor::DimOp::getCanonicalizationPatterns(cleanupPatterns, context);
   tensor::populateMergeConsecutiveInsertExtractSlicePatterns(cleanupPatterns);
+  // TODO(Max191): Replace populateSwapExtractWithExpandPattern with upstream
+  // MLIR version once it is available (llvm-project/pull/126898).
   populateSwapExtractWithExpandPattern(cleanupPatterns);
   tileAndFuseOptions.cleanupPatterns =
       FrozenRewritePatternSet(std::move(cleanupPatterns));

--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingForall.cpp
@@ -474,6 +474,13 @@ void TileAndDistributeToWorkgroupsUsingForallOpPass::runOnOperation() {
 
   scf::SCFTileAndFuseOptions tileAndFuseOptions;
   tileAndFuseOptions.setTilingOptions(tilingOptions);
+  RewritePatternSet cleanupPatterns(context);
+  tensor::ExtractSliceOp::getCanonicalizationPatterns(cleanupPatterns, context);
+  tensor::DimOp::getCanonicalizationPatterns(cleanupPatterns, context);
+  tensor::populateMergeConsecutiveInsertExtractSlicePatterns(cleanupPatterns);
+  populateSwapExtractWithExpandPattern(cleanupPatterns);
+  tileAndFuseOptions.cleanupPatterns =
+      FrozenRewritePatternSet(std::move(cleanupPatterns));
 
   // The control function that determines whether a tiled producer should yield
   // its replacement.


### PR DESCRIPTION
Adds cleanup patterns to run during `tileConsumerAndFuseProducersUsingSCF` in TileandDistributeToWorkgroupsUsingForall. The PR adds the `SwapExtractWithExpandPattern`, and some extra cleanup patterns for slices.

This enables codegen for set_encoding ops on GPU, since the materialization of set_encoding contains an expand_shape that will block distribution tiling of the full dispatch.