### PR TITLE
[DT] Hoist constant source out of dispatch in HoistEncodingOps pass.

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
@@ -204,10 +204,10 @@ void HoistEncodingOpsPass::runOnOperation() {
   });
   IRRewriter rewriter(ctx);
   for (auto setEncodingOp : candidates) {
-    Value src = setEncodingOp.getSource();
-    if (getConstantIntValue(src).has_value() &&
-        failed(IREE::Flow::hoistOutOfDispatch(rewriter, src.getDefiningOp()))) {
-      setEncodingOp->emitOpError("failed to hoist the source out of dispatch");
+    Operation *src = setEncodingOp.getSource().getDefiningOp();
+    if (src && src->hasTrait<OpTrait::ConstantLike>() &&
+        failed(IREE::Flow::hoistOutOfDispatch(rewriter, src))) {
+      src->emitOpError("failed to hoist the source out of dispatch");
       return signalPassFailure();
     }
     if (failed(IREE::Flow::hoistOutOfDispatch(rewriter, setEncodingOp))) {

--- a/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
@@ -204,6 +204,8 @@ void HoistEncodingOpsPass::runOnOperation() {
   });
   IRRewriter rewriter(ctx);
   for (auto setEncodingOp : candidates) {
+    // TODO: Hoist the entire slice of IR up to the root if there is a ConstExpr
+    // root op.
     Operation *src = setEncodingOp.getSource().getDefiningOp();
     if (src && src->hasTrait<OpTrait::ConstantLike>() &&
         failed(IREE::Flow::hoistOutOfDispatch(rewriter, src))) {

--- a/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
@@ -204,7 +204,14 @@ void HoistEncodingOpsPass::runOnOperation() {
   });
   IRRewriter rewriter(ctx);
   for (auto setEncodingOp : candidates) {
+    Value src = setEncodingOp.getSource();
+    if (getConstantIntValue(src).has_value() &&
+        failed(IREE::Flow::hoistOutOfDispatch(rewriter, src.getDefiningOp()))) {
+      setEncodingOp->emitOpError("failed to hoist the source out of dispatch");
+      return signalPassFailure();
+    }
     if (failed(IREE::Flow::hoistOutOfDispatch(rewriter, setEncodingOp))) {
+      setEncodingOp.emitOpError("failed to hoist the op out of dispatch");
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/DispatchCreation/test/hoist_encoding_ops.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/hoist_encoding_ops.mlir
@@ -212,15 +212,15 @@ module {
 // -----
 
 #encoding = #iree_encoding.testing_encoding<>
-util.func private @get_tensor(tensor<640x320xi8, #encoding>) -> tensor<640x320xi8>
-util.func public @hoist_both_src_and_encoding() -> tensor<640x320xi8> {
-  %0 = flow.dispatch.region -> (tensor<640x320xi8>) {
-    %cst = arith.constant dense<1> : tensor<640x320xi8>
-    %1 = iree_encoding.set_encoding %cst : tensor<640x320xi8> -> tensor<640x320xi8, #encoding>
-    %2 = util.call @get_tensor(%1) : (tensor<640x320xi8, #encoding>) -> tensor<640x320xi8>
-    flow.return %2 : tensor<640x320xi8>
+util.func private @get_tensor(tensor<640x320xf32, #encoding>) -> tensor<640x320xf32>
+util.func public @hoist_both_src_and_encoding() -> tensor<640x320xf32> {
+  %0 = flow.dispatch.region -> (tensor<640x320xf32>) {
+    %cst = arith.constant dense<1.0> : tensor<640x320xf32>
+    %1 = iree_encoding.set_encoding %cst : tensor<640x320xf32> -> tensor<640x320xf32, #encoding>
+    %2 = util.call @get_tensor(%1) : (tensor<640x320xf32, #encoding>) -> tensor<640x320xf32>
+    flow.return %2 : tensor<640x320xf32>
   }
-  util.return %0 : tensor<640x320xi8>
+  util.return %0 : tensor<640x320xf32>
 }
 // CHECK-LABEL: util.func public @hoist_both_src_and_encoding(
 // CHECK:         %[[CST:.+]] = arith.constant


### PR DESCRIPTION
The small constants can be inlined into dispatches, and they could become the source of `set_encoding` ops. The revision adds the support for hoisting both operations out if the source is a constant.