### PR TITLE
[Util][Hoisting] Make variable name better if encoding is present.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/BUILD.bazel
@@ -43,6 +43,7 @@ iree_compiler_cc_library(
     ],
     deps = [
         ":PassesIncGen",
+        "//compiler/src/iree/compiler/Dialect/Encoding/IR",
         "//compiler/src/iree/compiler/Dialect/Util/Analysis",
         "//compiler/src/iree/compiler/Dialect/Util/Analysis/Attributes",
         "//compiler/src/iree/compiler/Dialect/Util/Analysis/Constant",

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/CMakeLists.txt
@@ -61,6 +61,7 @@ iree_cc_library(
     MLIRTransformUtils
     MLIRTransforms
     MLIRVectorDialect
+    iree::compiler::Dialect::Encoding::IR
     iree::compiler::Dialect::Util::Analysis
     iree::compiler::Dialect::Util::Analysis::Attributes
     iree::compiler::Dialect::Util::Analysis::Constant

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals.mlir
@@ -99,6 +99,24 @@ module @hoist_sub_byte_aligned_scalar_transitive {
 
 // -----
 
+// Checks that the name of global op is readable when encoding is present.
+
+// CHECK: #[[$ENCODING:.+]] = #iree_encoding.testing_encoding<>
+#encoding = #iree_encoding.testing_encoding<>
+// CHECK-LABEL: @hoist_encoded_const_expr_with_simpler_name
+module @hoist_encoded_const_expr_with_simpler_name {
+  // CHECK: util.global private @__hoisted_tensor_64xi8__encoded : tensor<64xi8, #[[$ENCODING]]>
+  util.func public @main() -> (tensor<64xi8, #encoding>) {
+    %0 = arith.constant dense<0> : tensor<32xi8>
+    %1 = arith.constant dense<0> : tensor<32xi8>
+    %2 = "iree_unregistered.const_expr"(%0, %1)
+        : (tensor<32xi8>, tensor<32xi8>) -> tensor<64xi8, #encoding>
+    util.return %2 : tensor<64xi8, #encoding>
+  }
+}
+
+// -----
+
 // We presently expand i1 -> i8 for legacy reasons. As such, we support
 // it, even though we don't generally support sub-byte constexprs.
 


### PR DESCRIPTION
The revision simplifies the encoding content with `encoded` because encoding can have complicated parameters. E.g., they can have arbitrary dictionary attribute, and naming the variable with such information is making readability worse.

Fixes https://github.com/iree-org/iree/issues/20090