### PR TITLE
[Vulkan] Add initial support for rdna4 targets

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
@@ -378,6 +378,7 @@ std::optional<TargetDetails> getAMDGPUTargetDetails(StringRef target) {
       .Case("w7800", TargetDetails{rdna3Wgp, &w7800Chip})
       // https://www.techpowerup.com/gpu-specs/radeon-pro-w7700.c4184
       .Case("w7700", TargetDetails{rdna3Wgp, &w7700Chip})
+      .Cases("rdna4", "gfx1200", "gfx1201", TargetDetails{rdna4Wgp, nullptr})
       .Cases("rdna3", "gfx1100", "gfx1101", "gfx1102", "gfx1103", "gfx1150",
              "gfx1151", TargetDetails{rdna3Wgp, nullptr})
       .Cases("rdna2", "gfx1030", "gfx1031", "gfx1032", "gfx1033", "gfx1034",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_amd_matmul_cooperative_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_amd_matmul_cooperative_ops.mlir
@@ -1,4 +1,5 @@
 // RUN: iree-opt --split-input-file --iree-gpu-test-target=rdna3@vulkan --pass-pipeline='builtin.module(iree-spirv-select-lowering-strategy-pass)' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=rdna4@vulkan --pass-pipeline='builtin.module(iree-spirv-select-lowering-strategy-pass)' %s | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/convert_gpu_target.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/convert_gpu_target.mlir
@@ -38,3 +38,46 @@ hal.executable.variant public @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-s
 // CHECK-SAME:       #spirv.coop_matrix_props_khr<m_size = 16, n_size = 16, k_size = 16, a_type = f16, b_type = f16, c_type = f32, result_type = f32, acc_sat = false, scope = <Subgroup>>,
 // CHECK-SAME:       #spirv.coop_matrix_props_khr<m_size = 16, n_size = 16, k_size = 16, a_type = f16, b_type = f16, c_type = f16, result_type = f16, acc_sat = false, scope = <Subgroup>>
 // CHECK-SAME: ]>>
+
+
+// -----
+
+// Check that we filter out types not supported by VK_KHR_cooperative_matrix,
+// e.g., bf16 and various versions of f8.
+
+hal.executable @dispatch_with_unsupported_types {
+hal.executable.variant public @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb", {
+    iree.gpu.target = #iree_gpu.target<arch = "rdna4", features = "spirv:v1.6,cap:Shader",
+      wgp = <compute = fp64|fp32|fp16|int64|int32|int16|int8, storage = b32, subgroup = none, dot = none,
+             mma = [<WMMAR4_F32_16x16x16_F16>, <WMMAR4_F16_16x16x16_F16>, <WMMAR4_BF16_16x16x16_BF16>, <WMMAR4_F32_16x16x16_BF16>,
+                    <WMMAR4_F32_16x16x16_F8E5M2>, <WMMAR4_F32_16x16x16_F8E4M3FN_F8E5M2>, <WMMAR4_I32_16x16x16_I8>],
+      subgroup_size_choices = [32, 64], max_workgroup_sizes = [1024, 1024, 1024], max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536,
+      max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>}>) {
+  hal.executable.export public @dispatch ordinal(0) layout(#hal.pipeline.layout<bindings = [
+    #hal.pipeline.binding<storage_buffer>]>
+  ) {
+  ^bb0(%arg0: !hal.device):
+    %x, %y, %z = flow.dispatch.workgroup_count_from_slice
+    hal.return %x, %y, %z : index, index, index
+  }
+  builtin.module {
+    func.func @dispatch() {
+      return
+    }
+  }
+}
+}
+
+//      CHECK: builtin.module attributes
+// CHECK-SAME: spirv.target_env = #spirv.target_env<#spirv.vce<v1.6,
+// CHECK-SAME:   [Shader, Float64, Float16, Int64, Int16, Int8, CooperativeMatrixKHR],
+// CHECK-SAME:   [SPV_KHR_cooperative_matrix]>,
+// CHECK-SAME:   AMD,
+// CHECK-SAME:   #spirv.resource_limits<max_compute_shared_memory_size = 65536,
+// CHECK-SAME:     max_compute_workgroup_invocations = 1024, max_compute_workgroup_size = [1024 : i32, 1024 : i32, 1024 : i32],
+// CHECK-SAME:     min_subgroup_size = 32, max_subgroup_size = 64,
+// CHECK-SAME:     cooperative_matrix_properties_khr = [
+// CHECK-SAME:       #spirv.coop_matrix_props_khr<m_size = 16, n_size = 16, k_size = 16, a_type = f16, b_type = f16, c_type = f32, result_type = f32, acc_sat = false, scope = <Subgroup>>,
+// CHECK-SAME:       #spirv.coop_matrix_props_khr<m_size = 16, n_size = 16, k_size = 16, a_type = f16, b_type = f16, c_type = f16, result_type = f16, acc_sat = false, scope = <Subgroup>>,
+// CHECK-SAME:       #spirv.coop_matrix_props_khr<m_size = 16, n_size = 16, k_size = 16, a_type = i8, b_type = i8, c_type = i32, result_type = i32, acc_sat = false, scope = <Subgroup>>
+// CHECK-SAME: ]>>

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_ops.mlir
@@ -6,6 +6,10 @@
 // RUN:   --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-spirv-configuration-pipeline), iree-codegen-linalg-to-spirv-pipeline, canonicalize, cse)))' \
 // RUN:   %s | FileCheck %s --check-prefix=RDNA3
 
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=rdna4@vulkan \
+// RUN:   --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-codegen-spirv-configuration-pipeline), iree-codegen-linalg-to-spirv-pipeline, canonicalize, cse)))' \
+// RUN:   %s | FileCheck %s --check-prefix=RDNA4
+
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>,
@@ -192,6 +196,12 @@ hal.executable public @matmul_256x1024x128_div_exp {
 //     RDNA3-DAG:   spirv.GlobalVariable @[[C_MEM:.+]] : !spirv.ptr<!spirv.struct<(!spirv.array<1088 x vector<4xf32>>)>, Workgroup>
 //         RDNA3:   spirv.func @matmul_256x1024x128_div_exp
 
+//   RDNA4-LABEL: spirv.module Logical GLSL450
+//     RDNA4-DAG:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<1088 x vector<4xf32>>)>, Workgroup>
+//     RDNA4-DAG:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<640 x vector<4xf32>>)>, Workgroup>
+//     RDNA4-DAG:   spirv.GlobalVariable @[[C_MEM:.+]] : !spirv.ptr<!spirv.struct<(!spirv.array<1088 x vector<4xf32>>)>, Workgroup>
+//         RDNA4:   spirv.func @matmul_256x1024x128_div_exp
+
 // -----
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
@@ -292,6 +302,11 @@ hal.executable public @batch_matmul_16x128x256x512_div {
 //     RDNA3-DAG:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<1088 x vector<4xf32>>)>, Workgroup>
 //     RDNA3-DAG:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<640 x vector<4xf32>>)>, Workgroup>
 //         RDNA3:   spirv.func @batch_matmul_16x128x256x512_div
+
+//   RDNA4-LABEL: spirv.module Logical GLSL450
+//     RDNA4-DAG:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<1088 x vector<4xf32>>)>, Workgroup>
+//     RDNA4-DAG:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<640 x vector<4xf32>>)>, Workgroup>
+//         RDNA4:   spirv.func @batch_matmul_16x128x256x512_div
 
 // -----
 
@@ -440,3 +455,8 @@ hal.executable public @generic_batch_matmul_32x128x512x64 {
 //     RDNA3-DAG:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<1088 x vector<4xf32>>)>, Workgroup>
 //     RDNA3-DAG:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<640 x vector<4xf32>>)>, Workgroup>
 //         RDNA3:   spirv.func @generic_batch_matmul_32x128x512x64
+
+//   RDNA4-LABEL: spirv.module Logical GLSL450
+//     RDNA4-DAG:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<1088 x vector<4xf32>>)>, Workgroup>
+//     RDNA4-DAG:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<640 x vector<4xf32>>)>, Workgroup>
+//         RDNA4:   spirv.func @generic_batch_matmul_32x128x512x64


### PR DESCRIPTION
Make sure `rdna4@vulkan` is recognized as a Vulkan target. Handle wmma shapes not supported by the cooperative matrix extension.