### PR TITLE
[ROCm][Vulkan] Add initial rdna4 products to known targets and docs

### DIFF
--- a/compiler/plugins/target/ROCM/test/target_device_features.mlir
+++ b/compiler/plugins/target/ROCM/test/target_device_features.mlir
@@ -30,6 +30,12 @@
 //
 // RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
 // RUN:   --iree-hip-target=gfx1201 %s | FileCheck %s --check-prefix=GFX1201
+//
+// RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
+// RUN:   --iree-hip-target=rx9070xt %s | FileCheck %s --check-prefixes=GFX1201,RX9070XT
+//
+// RUN: iree-opt --pass-pipeline='builtin.module(iree-hal-assign-target-devices{targetDevices=hip},iree-hal-transformation-pipeline{serialize-executables=false})' \
+// RUN:   --iree-hip-target=rx9070 %s | FileCheck %s --check-prefixes=GFX1201,RX9070
 
 // GFX942: target = #iree_gpu.target<arch = "gfx942",
 // GFX942-SAME: wgp = <compute =  fp64|fp32|fp16|int64|int32|int16|int8, storage =  b64|b32|b16|b8,
@@ -64,6 +70,9 @@
 // GFX1201: target = #iree_gpu.target<arch = "gfx1201",
 // GFX1201-SAME:        mma = [<WMMAR4_F32_16x16x16_F16>, <WMMAR4_F16_16x16x16_F16>, <WMMAR4_F32_16x16x16_BF16>, <WMMAR4_BF16_16x16x16_BF16>, <WMMAR4_F32_16x16x16_F8E5M2>, <WMMAR4_F32_16x16x16_F8E5M2_F8E4M3FN>, <WMMAR4_F32_16x16x16_F8E4M3FN>, <WMMAR4_F32_16x16x16_F8E4M3FN_F8E5M2>,  <WMMAR4_I32_16x16x16_I8>]
 // GFX1201-SAME:        subgroup_size_choices = [32, 64]
+
+// RX9070XT: chip = <wgp_count = 64, sku = "rx9070xt">>
+// RX9070:   chip = <wgp_count = 56, sku = "rx9070">>
 
 stream.executable public @reduce_dispatch {
   stream.executable.export @reduce_dispatch workgroups(%arg0: index) -> (index, index, index) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.cpp
@@ -336,6 +336,12 @@ std::optional<TargetDetails> getAMDGPUTargetDetails(StringRef target) {
   // https://www.amd.com/content/dam/amd/en/documents/instinct-business-docs/white-papers/amd-cdna-white-paper.pdf
   static const ChipDetails mi100Chip = {120, "mi100"};
 
+  // AMD RDNA4 architecture:
+  // https://www.amd.com/en/newsroom/press-releases/2025-2-28-amd-unveils-next-generation-amd-rdna-4-architectu.html.
+  static const ChipDetails rx9070xtChip = {64, "rx9070xt"};
+  static const ChipDetails rx9070Chip = {56, "rx9070"};
+
+  // AMD RDNA3.
   static const ChipDetails rx7900xtxChip = {96, "rx7900xtx"};
   static const ChipDetails rx7900xtChip = {84, "rx7900xt"};
   static const ChipDetails rx7800xtChip = {60, "rx7800xt"};
@@ -360,8 +366,10 @@ std::optional<TargetDetails> getAMDGPUTargetDetails(StringRef target) {
       .Cases("cdna2", "gfx90a", TargetDetails{cdna2Wgp, nullptr})
       .Case("mi100", TargetDetails{cdna1Wgp, &mi100Chip})
       .Cases("cdna1", "gfx908", TargetDetails{cdna1Wgp, nullptr})
-      // Preliminary listing - chip details not available.
-      .Cases("gfx1200", "gfx1201", TargetDetails{rdna4Wgp, nullptr})
+      // https://www.techpowerup.com/gpu-specs/radeon-rx-9070-xt.c4229
+      .Case("rx9070xt", TargetDetails{rdna4Wgp, &rx9070xtChip})
+      // https://www.techpowerup.com/gpu-specs/radeon-rx-9070.c4250
+      .Case("rx9070", TargetDetails{rdna4Wgp, &rx9070Chip})
       // https://www.techpowerup.com/gpu-specs/radeon-rx-7900-xtx.c3941
       .Case("rx7900xtx", TargetDetails{rdna3Wgp, &rx7900xtxChip})
       // https://www.techpowerup.com/gpu-specs/radeon-rx-7900-xt.c3912
@@ -401,6 +409,7 @@ StringRef normalizeAMDGPUTarget(StringRef target) {
       .Cases("mi300a", "mi300x", "mi308x", "mi325x", "gfx942")
       .Cases("mi250x", "mi250", "mi210", "cdna2", "gfx90a")
       .Cases("mi100", "cdna1", "gfx908")
+      .Cases("rx9070xt", "rx9070", "gfx1201")
       .Cases("rx7900xtx", "rx7900xt", "w7900", "w7800", "gfx1100")
       .Cases("rx7800xt", "rx7700xt", "v710", "w7700", "gfx1101")
       .Default("");

--- a/docs/website/docs/guides/deployment-configurations/gpu-rocm.md
+++ b/docs/website/docs/guides/deployment-configurations/gpu-rocm.md
@@ -191,14 +191,16 @@ architectures:
 | AMD MI300X               | `mi300x`    | `gfx942`            | `cdna3`                |
 | AMD MI308X               | `mi308x`    | `gfx942`            | `cdna3`                |
 | AMD MI325X               | `mi325x`    | `gfx942`            | `cdna3`                |
-| AMD RX7900XTX            | `rx7900xtx` | `gfx1100`           | `rdna3`                |
-| AMD RX7900XT             | `rx7900xt`  | `gfx1100`           | `rdna3`                |
-| AMD PRO W7900            | `w7900`     | `gfx1100`           | `rdna3`                |
-| AMD PRO W7800            | `w7800`     | `gfx1100`           | `rdna3`                |
-| AMD RX7800XT             | `rx7800xt`  | `gfx1101`           | `rdna3`                |
-| AMD RX7700XT             | `rx7700xt`  | `gfx1101`           | `rdna3`                |
 | AMD PRO V710             | `v710`      | `gfx1101`           | `rdna3`                |
 | AMD PRO W7700            | `w7700`     | `gfx1101`           | `rdna3`                |
+| AMD PRO W7800            | `w7800`     | `gfx1100`           | `rdna3`                |
+| AMD PRO W7900            | `w7900`     | `gfx1100`           | `rdna3`                |
+| AMD RX 7700XT            | `rx7700xt`  | `gfx1101`           | `rdna3`                |
+| AMD RX 7800XT            | `rx7800xt`  | `gfx1101`           | `rdna3`                |
+| AMD RX 7900XT            | `rx7900xt`  | `gfx1100`           | `rdna3`                |
+| AMD RX 7900XTX           | `rx7900xtx` | `gfx1100`           | `rdna3`                |
+| AMD RX 9070              | `rx9070`    | `gfx1201`           | `rdna4`                |
+| AMD RX 9070XT            | `rx9070xt`  | `gfx1201`           | `rdna4`                |
 
 For a more comprehensive list of prior GPU generations, you can refer to the
 [LLVM AMDGPU backend](https://llvm.org/docs/AMDGPUUsage.html#processors).

--- a/docs/website/docs/guides/deployment-configurations/gpu-vulkan.md
+++ b/docs/website/docs/guides/deployment-configurations/gpu-vulkan.md
@@ -180,18 +180,20 @@ Here are a few examples showing how you can target various recent common GPUs:
 
 | GPU                 | Product Name   | Target Architecture | Architecture Code Name |
 | ------------------- | -------------- | ------------------- | ---------------------- |
-| AMD RX7900XTX       | `rx7900xtx`    | `gfx1100`           | `rdna3`                |
-| AMD RX7900XT        | `rx7900xt`     | `gfx1100`           | `rdna3`                |
-| AMD RX7800XT        | `rx7800xt`     | `gfx1101`           | `rdna3`                |
-| AMD RX7700XT        | `rx7700xt`     | `gfx1101`           | `rdna3`                |
-| AMD RX6000 series   |                |                     | `rdna2`                |
-| AMD RX5000 series   |                |                     | `rdna1`                |
-| ARM Mali G715       | `mali-g715`    |                     | `valhall4`             |
-| ARM Mali G510       | `mali-g510`    |                     | `valhall3`             |
+| AMD RX 5000 series  |                |                     | `rdna1`                |
+| AMD RX 6000 series  |                |                     | `rdna2`                |
+| AMD RX 7700XT       | `rx7700xt`     | `gfx1101`           | `rdna3`                |
+| AMD RX 7800XT       | `rx7800xt`     | `gfx1101`           | `rdna3`                |
+| AMD RX 7900XT       | `rx7900xt`     | `gfx1100`           | `rdna3`                |
+| AMD RX 7900XTX      | `rx7900xtx`    | `gfx1100`           | `rdna3`                |
+| AMD RX 9070         | `rx9070`       | `gfx1201`           | `rdna4`                |
+| AMD RX 9070XT       | `rx9070xt`     | `gfx1201`           | `rdna4`                |
 | ARM GPUs            |                |                     | `valhall`              |
-| NVIDIA RTX40 series | `rtx4090`      | `sm_89`             | `ada`                  |
-| NVIDIA RTX30 series | `rtx3080ti`    | `sm_86`             | `ampere`               |
+| ARM Mali G510       | `mali-g510`    |                     | `valhall3`             |
+| ARM Mali G715       | `mali-g715`    |                     | `valhall4`             |
 | NVIDIA RTX20 series | `rtx2070super` | `sm_75`             | `turing`               |
+| NVIDIA RTX30 series | `rtx3080ti`    | `sm_86`             | `ampere`               |
+| NVIDIA RTX40 series | `rtx4090`      | `sm_89`             | `ada`                  |
 | Qualcomm GPUs       |                |                     | `adreno`               |
 
 If no target is specified, then a safe but more limited default will be used.


### PR DESCRIPTION
Based on the announcement
https://www.amd.com/en/newsroom/press-releases/2025-2-28-amd-unveils-next-generation-amd-rdna-4-architectu.html.

Also sort the list of rocm and vulkan alphabetically, since any other order is hard to maintain by hand.