### PR TITLE
[Stream][Encoding] Skip specialization if export op is not Stream op.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
@@ -353,8 +353,12 @@ static bool recognizeEntryPoints(ModuleOp moduleOp, SymbolTable symbolTable,
     if (!result) {
       return;
     }
-    auto exportOp = cast<IREE::Stream::ExecutableExportOp>(
+    auto exportOp = dyn_cast<IREE::Stream::ExecutableExportOp>(
         symbolTable.lookupSymbolIn(moduleOp, entryPoint));
+    if (!exportOp) {
+      result = false;
+      return;
+    }
     auto executableOp = exportOp->getParentOfType<IREE::Stream::ExecutableOp>();
     if (!executableOp) {
       result = false;

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
@@ -963,13 +963,14 @@ util.func public @dispatch_hal_executable(%arg0: !stream.resource<*>, %arg1: ind
 // It does not fail because the executable does not match the requirements.
 
 #encoding = #iree_encoding.unknown_encoding
+util.global private @device : !hal.device
 hal.executable.source public @executable {
   hal.executable.export public @dispatch ordinal(0) layout(#hal.pipeline.layout<constants = 0, bindings = [
     #hal.pipeline.binding<storage_buffer>
   ]>)
 }
 util.func public @dispatch_hal_executable_with_encodings(%arg0: !stream.resource<*>, %arg1: index, %arg2: index) -> !stream.resource<*> {
-  %0 = stream.tensor.dispatch @executable::@dispatch(%arg0) : (tensor<4x?xf32, #encoding>{%arg2} in !stream.resource<*>{%arg1}) -> tensor<4x?xf32, #encoding>{%arg2} in !stream.resource<*>{%arg1}
+  %0 = stream.tensor.dispatch on(#hal.device.affinity<@device>) @executable::@dispatch(%arg0) : (tensor<4x?xf32, #encoding>{%arg2} in !stream.resource<*>{%arg1}) -> tensor<4x?xf32, #encoding>{%arg2} in !stream.resource<*>{%arg1}
   util.return %0 : !stream.resource<*>
 }
 // CHECK-LABEL: util.func public @dispatch_hal_executable_with_encodings(


### PR DESCRIPTION
The previous test did not catch the case because it did not have an affinity. The revision adds the affinity to the test, which ensures it is tested.