### PR TITLE
[NFC] Switch to builtin dropEncoding and cloneWithEncoding methods.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
@@ -34,7 +34,7 @@ MaterializeEncodingTypeConverter::MaterializeEncodingTypeConverter(
     // itself.
     MaterializeEncodingInfo encodingInfo = getEncodingInfo(type);
     if (IREE::Codegen::isIdentityLayout(encodingInfo)) {
-      return IREE::Encoding::dropEncoding(type);
+      return type.dropEncoding();
     }
     auto packedType = cast<RankedTensorType>(linalg::PackOp::inferPackedType(
         type, encodingInfo.innerTileSizes, encodingInfo.innerDimsPos,
@@ -88,10 +88,6 @@ MaterializeEncodingTypeConverter::getEncodingInfo(RankedTensorType type) const {
     return maybeEncodingInfo.value();
   }
   return layoutAttr.getEncodingInfo(type);
-}
-
-RankedTensorType dropEncoding(RankedTensorType type) {
-  return RankedTensorType::get(type.getShape(), type.getElementType());
 }
 
 std::optional<IREE::Codegen::MaterializeEncodingInfo>

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
@@ -53,7 +53,7 @@ static PadEncodingLayoutAttr getPadLayout(RankedTensorType type) {
 static RankedTensorType getPaddedType(RankedTensorType type) {
   PadEncodingLayoutAttr layout = getPadLayout(type);
   if (!isNonZeroPadding(layout)) {
-    return dropEncoding(type);
+    return type.dropEncoding();
   }
 
   ArrayRef<int32_t> padding = layout.getPadding().asArrayRef();

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -70,10 +70,6 @@ static void transposeInPlace(MaterializeEncodingInfo &info) {
   transpose(info.outerDimsPerm);
 }
 
-static RankedTensorType dropEncoding(RankedTensorType type) {
-  return RankedTensorType::get(type.getShape(), type.getElementType());
-}
-
 static Operation *dropEncodingAndCloneOp(OpBuilder &builder, Operation *op,
                                          ValueRange convertedInputOperands,
                                          ValueRange convertedOutputOperands) {
@@ -81,10 +77,11 @@ static Operation *dropEncodingAndCloneOp(OpBuilder &builder, Operation *op,
   operands.append(convertedInputOperands.begin(), convertedInputOperands.end());
   operands.append(convertedOutputOperands.begin(),
                   convertedOutputOperands.end());
-  return mlir::clone(builder, op,
-                     {dropEncoding(cast<RankedTensorType>(
-                         convertedOutputOperands[0].getType()))},
-                     operands);
+  return mlir::clone(
+      builder, op,
+      {cast<RankedTensorType>(convertedOutputOperands[0].getType())
+           .dropEncoding()},
+      operands);
 }
 
 static RankedTensorType

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
@@ -382,7 +382,7 @@ void SpecializedEncodingAttr::print(AsmPrinter &p) const {
 
 Attribute SpecializedEncodingAttr::getLayout(RankedTensorType type) const {
   MLIRContext *ctx = getContext();
-  return get(ctx, getSeed(), TypeAttr::get(dropEncoding(type)));
+  return get(ctx, getSeed(), TypeAttr::get(type.dropEncoding()));
 }
 
 } // namespace mlir::iree_compiler::IREE::Encoding

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.cpp
@@ -113,8 +113,4 @@ bool isNarrowNResult(EncodingAttr encoding) {
   return IREE::Encoding::getMatmulNarrowDim(encoding).isN();
 }
 
-RankedTensorType dropEncoding(RankedTensorType type) {
-  return RankedTensorType::get(type.getShape(), type.getElementType());
-}
-
 } // namespace mlir::iree_compiler::IREE::Encoding

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.h
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.h
@@ -104,9 +104,6 @@ MatmulNarrowDim getMatmulNarrowDim(EncodingAttr encoding);
 /// result of a matvec.
 bool isNarrowNResult(EncodingAttr encoding);
 
-/// Returns the same RankedTensoType without the encoding.
-RankedTensorType dropEncoding(RankedTensorType type);
-
 } // namespace mlir::iree_compiler::IREE::Encoding
 
 #endif // IREE_COMPILER_DIALECT_ENCODING_IR_ENCODINGTYPES_H_

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
@@ -62,13 +62,6 @@ SmallVector<const T *> gatherUsedDialectInterfaces(mlir::ModuleOp moduleOp) {
 
 } // namespace
 
-// TODO(hanchung): Add "cloneWithEncoding" method to RankedTensorType.
-static RankedTensorType cloneWithEncoding(RankedTensorType type,
-                                          Attribute encodingAttr) {
-  return RankedTensorType::get(type.getShape(), type.getElementType(),
-                               encodingAttr);
-}
-
 /// Returns true iff the type is a RankedTensorType and it has an encoding that
 /// implements SerializableEncodingAttrInterface.
 static bool isRecognizedEncodingType(Type type) {
@@ -111,7 +104,7 @@ static Type getTypeWithResolvedEncodingLayouts(
   if (!llvm::all_of(
           layoutResolvers,
           llvm::IsaPred<IREE::Encoding::EncodingLayoutResolverAttrInterface>)) {
-    return IREE::Encoding::dropEncoding(rankedTensorType);
+    return rankedTensorType.dropEncoding();
   }
   SmallVector<Attribute> layouts;
   for (auto attr : layoutResolvers) {
@@ -125,7 +118,7 @@ static Type getTypeWithResolvedEncodingLayouts(
   }
   Attribute newEncoding = encodingAttr.cloneWithLayouts(layouts);
   assert(isa<IREE::Encoding::SerializableEncodingAttrInterface>(newEncoding));
-  return cloneWithEncoding(rankedTensorType, newEncoding);
+  return rankedTensorType.cloneWithEncoding(newEncoding);
 };
 
 /// Updates the bindings of function arguments with encoding layouts. It only

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/BUILD.bazel
@@ -43,7 +43,6 @@ iree_compiler_cc_library(
     ],
     deps = [
         ":PassesIncGen",
-        "//compiler/src/iree/compiler/Dialect/Encoding/IR",
         "//compiler/src/iree/compiler/Dialect/Util/Analysis",
         "//compiler/src/iree/compiler/Dialect/Util/Analysis/Attributes",
         "//compiler/src/iree/compiler/Dialect/Util/Analysis/Constant",

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/CMakeLists.txt
@@ -61,7 +61,6 @@ iree_cc_library(
     MLIRTransformUtils
     MLIRTransforms
     MLIRVectorDialect
-    iree::compiler::Dialect::Encoding::IR
     iree::compiler::Dialect::Util::Analysis
     iree::compiler::Dialect::Util::Analysis::Attributes
     iree::compiler::Dialect::Util::Analysis::Constant

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/HoistIntoGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/HoistIntoGlobals.cpp
@@ -4,9 +4,6 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// TODO(hanchung): Drop the Encoding dep once the `dropEncoding` method is
-// upstreamed to RankedTensorType.
-#include "iree/compiler/Dialect/Encoding/IR/EncodingTypes.h"
 #include "iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.h"
 #include "iree/compiler/Dialect/Util/Analysis/Constant/OpOracle.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
@@ -45,7 +42,7 @@ static std::string getHoistedName(Type type) {
   os << "__hoisted_";
   auto rankedTensorType = dyn_cast<RankedTensorType>(type);
   if (rankedTensorType && rankedTensorType.getEncoding()) {
-    IREE::Encoding::dropEncoding(rankedTensorType).print(os);
+    rankedTensorType.dropEncoding().print(os);
     os << "_encoded";
   } else {
     type.print(os);


### PR DESCRIPTION
The two methods were upstreamed to RankedTensorType's methods, so we can delete the methods from IREE codebase.