### PR TITLE
Add quick fix since uint is not portable

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Verifiers.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Verifiers.cpp
@@ -253,7 +253,7 @@ verifyGPUMatmulPipeline(Operation *op,
   }
 
   unsigned reduction = static_cast<uint32_t>(IREE::GPU::TilingLevel::Reduction);
-  uint numLoops = llvm::cast<linalg::LinalgOp>(op).getNumLoops();
+  unsigned numLoops = llvm::cast<linalg::LinalgOp>(op).getNumLoops();
   size_t size = 0;
 
   SmallVector<int64_t> reductionTileSizes =


### PR DESCRIPTION
Add quick fix since **uint** is not portable