### PR TITLE
[LLVMGPU] Set full workgroup tile sizes to 0

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -803,6 +803,13 @@ LogicalResult setTileAndFuseLoweringConfig(IREE::GPU::TargetAttr target,
     }
   }
 
+  // Set full workgroup tiles to 0 to avoid generating loops when tiling.
+  for (auto [size, bound] : llvm::zip_equal(workgroupTileSizes, loopBounds)) {
+    if (size == bound) {
+      size = 0;
+    }
+  }
+
   // Attach the MMA schedule as an attribute to the entry point export function
   // for later access in the pipeline.
   MLIRContext *context = linalgOp.getContext();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
@@ -194,7 +194,7 @@ module {
 //  CHECK-SAME:     promote_operands = [0, 1]
 //  CHECK-SAME:     reduction = [0, 0, 4]
 //  CHECK-SAME:     thread = [1, 4, 0]
-//  CHECK-SAME:     workgroup = [1, 256, 0]
+//  CHECK-SAME:     workgroup = [1, 0, 0]
 
 //        LATE:  LLVMGPUWarpReduction
 
@@ -215,7 +215,7 @@ module {
 //  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
 //       CHECK:   linalg.add {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     thread = [1, 4]
-//  CHECK-SAME:     workgroup = [1, 256]
+//  CHECK-SAME:     workgroup = [1, 0]
 
 // -----
 
@@ -547,7 +547,7 @@ func.func @set_encoding_gpu(%0 : tensor<1234x567xi8>) -> tensor<10x9x8x4x4x4x2x8
 //  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     thread = [1, 1, 1, 1, 1, 1, 1, 4]
-//  CHECK-SAME:     workgroup = [1, 1, 8, 4, 4, 4, 2, 8]
+//  CHECK-SAME:     workgroup = [1, 1, 0, 0, 0, 0, 0, 0]
 
 // -----
 
@@ -575,7 +575,7 @@ func.func @unset_encoding_gpu(%arg0: tensor<10x5x4x8x2x4x16x4xi32>) -> tensor<12
 //  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     thread = [1, 1, 1, 1, 1, 1, 1, 1]
-//  CHECK-SAME:     workgroup = [1, 1, 4, 8, 4, 4, 16, 2]
+//  CHECK-SAME:     workgroup = [1, 1, 0, 0, 0, 0, 0, 0]
 
 // -----
 
@@ -627,7 +627,7 @@ func.func @pack_full_tile(%arg0: tensor<32x32xi8>) -> tensor<1x1x32x32xi8> {
 //  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     thread = [1, 4]
-//  CHECK-SAME:     workgroup = [32, 32]
+//  CHECK-SAME:     workgroup = [0, 0]
 
 // -----
 
@@ -653,7 +653,7 @@ func.func @pack_dynamic_tile(%arg0: tensor<32x32xi8>, %d0: index, %d1: index, %t
 //  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
 //  CHECK-SAME:     thread = [1, 4]
-//  CHECK-SAME:     workgroup = [8, 32]
+//  CHECK-SAME:     workgroup = [8, 0]
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
@@ -559,7 +559,7 @@ func.func @inner_unit_dim() {
 //      CHECK: func.func @inner_unit_dim()
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.generic
-// CHECK-SAME:       lowering_config = #iree_gpu.lowering_config<{thread = [1, 1], workgroup = [32, 1]}>
+// CHECK-SAME:       lowering_config = #iree_gpu.lowering_config<{thread = [1, 1], workgroup = [32, 0]}>
 
 // -----
 


### PR DESCRIPTION
In the TileAndFuse lowering config selection, set workgroup tile sizes to zero when would be equal to the full iteration space bounds. This does the exact same tiling, and TileAndDistributeToWorkgroupsUsingForall will produce the same output before and after this change for a single operation.

The purpose of setting tile sizes to zero is to avoid creating single trip loops during tiling. These loops will be canonicalized away, but they can sometimes block the cleanup patterns that happen between tiling and fusion within tileConsumerAndFuseProducersUsingSCF. The cleanup patterns only listen for slice operations, so we cannot apply any canonicalizations to the loop between tiling and fusion, and it is simpler to avoid creating these single trip loops to begin with.