### PR TITLE
[python] Fix immediate mode scheduling of BuildActions in iree.build

### DIFF
--- a/compiler/bindings/python/iree/build/executor.py
+++ b/compiler/bindings/python/iree/build/executor.py
@@ -676,6 +676,8 @@ class Scheduler:
             self.reporter.start_dep(dep)
             if dep.concurrency == ActionConcurrency.NONE:
                 invoke()
+                dep.start(concurrent.futures.Future())
+                dep.finish()
             elif (
                 dep.concurrency == ActionConcurrency.THREAD
                 or dep.concurrency == ActionConcurrency.PROCESS


### PR DESCRIPTION
When running the build action in the same thread we must still do a start-finish to get an initialized completed future.