### PR TITLE
[LLVMGPUVectorDistribute] VectorDistribution support for unaligned shapes

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUDistributionPatterns.cpp
@@ -161,6 +161,14 @@ struct DistributeScfFor final : OpDistributionPattern<scf::ForOp> {
     newForOp->setAttrs(forOp->getAttrs());
     Block *loopBody = newForOp.getBody();
 
+    // If there are no iterator arguments, the scf.for builder creates a
+    // terminator... This is really inconsistent and should be ideally fixed
+    // upstream. Erase the terminator, since we will merge a new terminator from
+    // the old block anyway.
+    if (forOp.getInitArgs().empty()) {
+      rewriter.eraseOp(loopBody->getTerminator());
+    }
+
     // Set up new iter_args. The loop body uses SIMD, so wrap the SIMD iter_args
     // of the new loop op into ToSIMDOps.
     rewriter.setInsertionPointToStart(loopBody);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -249,6 +249,7 @@ static void addGPUVectorizationPasses(OpPassManager &funcPassManager,
   options.enableVectorMasking = enableMasking;
   funcPassManager.addPass(createGenericVectorizationPass(options));
   funcPassManager.addPass(createCanonicalizerPass());
+  funcPassManager.addPass(memref::createResolveShapedTypeResultDimsPass());
   funcPassManager.addPass(createCSEPass());
   // Run subset hoisting to convert iter_args to vectors.
   funcPassManager.addPass(createOptimizeTensorInsertExtractSlicesPass());
@@ -899,7 +900,8 @@ void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createOptimizeTensorInsertExtractSlicesPass());
 
   // Linalg -> Vector
-  addGPUVectorizationPasses(funcPassManager);
+  addGPUVectorizationPasses(funcPassManager, /*vectorizeCopies=*/true,
+                            /*enableMasking=*/true);
 
   // Allocate tensors for copies to shared memory.
   funcPassManager.addPass(createGPUVectorAllocPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_reduction_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_reduction_gfx942.mlir
@@ -368,7 +368,6 @@ hal.executable private @attention_20x1x64x4096x64 {
 // CHECK:           vector.multi_reduction <add>
 // CHECK-COUNT-8:   gpu.subgroup_reduce  add
 
-
 // -----
 
 #config = #iree_gpu.lowering_config< {workgroup = [0, 4, 0],
@@ -415,6 +414,7 @@ hal.executable private @matvec_fp16 {
     }
   }
 }
+
 //     CHECK-LABEL: func.func @matvec_fp16_subgroup_reduction
 //          CHECK:    scf.for {{.*}} = %c0 to %c4096 step %c128
 //          CHECK:      %[[OUT:.+]] = vector.contract
@@ -426,3 +426,91 @@ hal.executable private @matvec_fp16 {
 //          CHECK:      gpu.subgroup_reduce add {{.*}} cluster(size = 2)
 //          CHECK:      scf.yield
 //          CHECK:    vector.transfer_write
+
+// -----
+
+// Tile Sizes:
+// workgroup         = [1, 1,  0,   0, 32]
+// partial_reduction = [0, 0,  0, 128,  0]
+// subgroup          = [0, 0,  0,   0,  8]
+// thread            = [0, 0, 32,   4,  4]
+
+// Counts:
+// subgroup          = [1, 1,  1,   1,  4]
+// threads           = [1, 1,  2,  32,  1]
+
+#config = #iree_gpu.lowering_config<{workgroup = [1, 1, 0, 0, 32],
+                                     partial_reduction = [0, 0, 0, 128, 0],
+                                     promote_operands = [1, 2]}>
+
+#qk_config = #iree_gpu.lowering_config<{subgroup_basis = [[1, 1, 1, 1, 4], [0, 1, 2, 3]],
+                                        thread_basis   = [[1, 1, 2, 32, 1], [0, 1, 2, 3]],
+                                        thread         = [0, 0, 32, 4],
+                                        promote_operands = [1]}>
+
+#pv_config = #iree_gpu.lowering_config<{subgroup_basis = [[1, 1, 1, 1, 4], [0, 1, 3, 4]],
+                                        thread_basis   = [[1, 1, 2, 32, 1], [0, 1, 3, 4]],
+                                        thread         = [0, 0, 4, 4],
+                                        promote_operands = [1]}>
+
+#translation = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute
+                                              workgroup_size = [256, 1, 1]
+                                              subgroup_size = 64>
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+hal.executable private @attention_20x1x64x4096x64_dynamic {
+  hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
+    hal.executable.export public @attention_20x1x64x4096x64 ordinal(0) layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_slice
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @attention_20x1x64x4096x64() attributes {translation_info = #translation} {
+        %cst = arith.constant 1.250000e-01 : f16
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<20x1x64xf16>>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<20x4096x64xf16>>
+        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(3) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<20x1x64xf16>>
+        %4 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [20, 1, 64], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<20x1x64xf16>> -> tensor<20x1x64xf16>
+        %5 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
+        %6 = flow.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<20x4096x64xf16>> -> tensor<20x4096x64xf16>
+        %7 = tensor.empty() : tensor<20x1x64xf16>
+        %8 = iree_linalg_ext.attention  {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d2)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
+                     affine_map<(d0, d1, d2, d3, d4) -> ()>,
+                     affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d4)>],
+                     lowering_config = #config,
+                     decomposition_config = {
+                      qk_attrs = {lowering_config = #qk_config},
+                      pv_attrs = {lowering_config = #pv_config}
+                     }}
+                     ins(%4, %5, %6, %cst : tensor<20x1x64xf16>, tensor<20x4096x64xf16>, tensor<20x4096x64xf16>, f16) outs(%7 : tensor<20x1x64xf16>) {
+                      ^bb0(%score: f32):
+                        iree_linalg_ext.yield %score : f32
+                     } -> tensor<20x1x64xf16>
+        flow.dispatch.tensor.store %8, %3, offsets = [0, 0, 0], sizes = [20, 1, 64], strides = [1, 1, 1] : tensor<20x1x64xf16> -> !flow.dispatch.tensor<writeonly:tensor<20x1x64xf16>>
+        return
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: func.func @attention_20x1x64x4096x64
+// CHECK:         scf.for %{{.*}} = %c0 to %c4096 step %c128
+// QK Matmul
+// CHECK:           vector.contract
+// CHECK-SAME:      vector<1x1x32xf16>, vector<1x1x1x1x4x32xf16> into vector<1x1x4xf32>
+// CHECK-COUNT-4:   gpu.subgroup_reduce  add
+
+// No subgroup reduction in the loop other than QK reductions
+// CHECK-NOT: gpu.subgroup_reduce
+
+// CHECK:           scf.yield


### PR DESCRIPTION
This PR adds support to perform statically tiled codegen on dynamic shapes in vector distribute pipeline.
Basically, it could honor lowering configs on dynamic shapes using masking.

Some side-effect changes: 
* Currently block dynamic dimension pass, change the dimensionality of the generics without performing a projection of the lowering config that was provided higher up in the pipeline. Moreover, the requirement to do this becomes less now as we can tile generally on the dynamic dimension with the changes here -- unless Im missing something here.

This builds on the following PRs -- hence putting to draft:
* https://github.com/iree-org/iree/pull/19830
* https://github.com/iree-org/iree/pull/19880
* https://github.com/iree-org/iree/pull/19899
* https://github.com/iree-org/iree/pull/19973

future work:
* (near future) Enable intrinsic distribution with selects.
* (near future) Once https://github.com/llvm/llvm-project/pull/126722 is merged and integrated, we can enable masking post-distribution.
* [AMDGPU] once buffer descriptor based pointers are properly introduced, we could rewrite the masked loads to be just loads followed by selects. (This works with the prototype : https://github.com/iree-org/iree/pull/19918)

Original Author: @manupak 