### PR TITLE
Introduce compatibility for encodings and update stream.tensor.clone op.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
@@ -140,6 +140,31 @@ def IREEEncoding_SerializableEncodingAttrInterface :
     >,
     InterfaceMethod<
       /*desc=*/[{
+        Returns true if the encoding is compatible with `other`. By default,
+        they are always compatible if any attribute is not serialized. If they
+        are both serialized, the method checks if they are identical or not.
+        We could do a less fuzzier match by overriding the implementation.
+      }],
+      /*retTy=*/"bool",
+      /*methodName=*/"isCompatibleWith",
+      /*args=*/(ins
+        "IREE::Encoding::SerializableEncodingAttrInterface":$other
+      ),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        auto attr =
+          llvm::dyn_cast_or_null<SerializableEncodingAttrInterface>($_attr);
+        if (!attr) {
+          return false;
+        }
+        if (attr.isSerialized() && other.isSerialized()) {
+          return $_attr == other;
+        }
+        return true;
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
         Returns the storage size (in bytes) for the tensor types with an
         optional encoding. Returns Value() if the size is unknown, i.e., it can
         not be inferred with existing information.
@@ -159,6 +184,13 @@ def IREEEncoding_SerializableEncodingAttrInterface :
       }]
     >
   ];
+
+  let extraClassDeclaration = [{
+    /// Returns true if they are the same attribute. Otherwise, returns true if
+    /// both attributes implement SerializableEncodingAttrInterface interface
+    /// and they are compatible with each other.
+    static bool areCompatible(Attribute lhs, Attribute rhs);
+  }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.cpp
@@ -23,6 +23,23 @@ getSerializableEncodingAttrInterface(RankedTensorType type) {
       type.getEncoding());
 }
 
+// static
+bool SerializableEncodingAttrInterface::areCompatible(Attribute lhs,
+                                                      Attribute rhs) {
+  if (lhs == rhs) {
+    return true;
+  }
+  auto lhsEncoding =
+      llvm::dyn_cast_or_null<SerializableEncodingAttrInterface>(lhs);
+  auto rhsEncoding =
+      llvm::dyn_cast_or_null<SerializableEncodingAttrInterface>(rhs);
+  if (!lhsEncoding || !rhsEncoding) {
+    return false;
+  }
+  return lhsEncoding.isCompatibleWith(rhsEncoding) &&
+         rhsEncoding.isCompatibleWith(lhsEncoding);
+}
+
 EncodingAttr getEncodingAttr(RankedTensorType type) {
   return dyn_cast_or_null<EncodingAttr>(type.getEncoding());
 }

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/BUILD.bazel
@@ -64,6 +64,7 @@ iree_compiler_cc_library(
         ":StreamInterfacesGen",
         ":StreamOpsGen",
         ":StreamTypesGen",
+        "//compiler/src/iree/compiler/Dialect/Encoding/IR",
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "//compiler/src/iree/compiler/Utils",
         "@llvm-project//llvm:Support",

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/CMakeLists.txt
@@ -54,6 +54,7 @@ iree_cc_library(
     MLIRTensorDialect
     MLIRTransformUtils
     MLIRViewLikeInterface
+    iree::compiler::Dialect::Encoding::IR
     iree::compiler::Dialect::Util::IR
     iree::compiler::Utils
   PUBLIC

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Dialect/Stream/IR/StreamOps.h"
 
+#include "iree/compiler/Dialect/Encoding/IR/EncodingTypes.h"
 #include "iree/compiler/Dialect/Util/IR/ClosureOpUtils.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
@@ -1943,7 +1944,8 @@ LogicalResult TensorCloneOp::verify() {
   // information.
   auto sourceEncoding = llvm::cast<RankedTensorType>(op.getSourceEncoding());
   auto resultEncoding = llvm::cast<RankedTensorType>(op.getResultEncoding());
-  if (sourceEncoding.getEncoding() != resultEncoding.getEncoding()) {
+  if (!IREE::Encoding::SerializableEncodingAttrInterface::areCompatible(
+          sourceEncoding.getEncoding(), resultEncoding.getEncoding())) {
     return op.emitOpError() << "clones changing tensor encoding from "
                             << sourceEncoding.getEncoding() << " to "
                             << resultEncoding.getEncoding() << "; not allowed";

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/tensor_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/tensor_ops.mlir
@@ -65,6 +65,19 @@ util.func private @tensorClone(%arg0: !stream.resource<*>, %arg1: index, %arg2: 
 
 // -----
 
+#unserialized_encoding = #iree_encoding.testing_encoding<>
+#serialized_encoding = #iree_encoding.testing_encoding<[#iree_encoding.specialized_encoding<123>]>
+// CHECK-DAG:   #[[$ENC_0:.+]] = #iree_encoding.testing_encoding<>
+// CHECK-DAG:   #[[$ENC_1:.+]] = #iree_encoding.testing_encoding<[#iree_encoding.specialized_encoding<123>]>
+// CHECK-LABEL: @tensorCloneWithEncoding(
+util.func private @tensorCloneWithEncoding(%arg0: !stream.resource<*>, %arg1: index, %arg2: index) -> !stream.resource<*> {
+  // CHECK: = stream.tensor.clone %arg0 : tensor<?x4xf32, #[[$ENC_0]]>{%arg1} in !stream.resource<*>{%arg2} -> tensor<?x4xf32, #[[$ENC_1]]>{%arg1} in !stream.resource<*>{%arg2}
+  %0 = stream.tensor.clone %arg0 : tensor<?x4xf32, #unserialized_encoding>{%arg1} in !stream.resource<*>{%arg2} -> tensor<?x4xf32, #serialized_encoding>{%arg1} in !stream.resource<*>{%arg2}
+  util.return %0 : !stream.resource<*>
+}
+
+// -----
+
 // CHECK-LABEL: @tensorSlice
 util.func private @tensorSlice(%arg0: !stream.resource<*>, %arg1: index, %arg2: index, %arg3: index, %arg4: index) -> !stream.resource<*> {
   %c0 = arith.constant 0 : index


### PR DESCRIPTION
The encoding content could be vague because the attribute could be descriptive. However, we realized that some encodings with different content could result in the same encoding layout. E.g., a matmul encoding can encode indexing maps for B/M/N/K dimension, while an encoding attribute only cares about `K` dimension. One of the examples is `IREE::GPU::GPUPadLayoutAttr`.

The revision introduces encoding compatibility in SerializableEncodingAttrInterface and relax the verifier of `stream.tensor.clone` op. If any encoding is not serialized, they are compatible. If both encodings are serialized, it checks if they are identical or not.

Note that it defers the real check after encoding specialization. If they end up with different layouts, a failure is detected.