### PR TITLE
[GPU] Ignore deallocations in shared memory reuse pass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1073,6 +1073,8 @@ static void addLowerToLLVMGPUPasses(OpPassManager &modulePassManager,
   modulePassManager.addPass(createLowerUKernelOpsToCallsPass());
 
   FunctionLikeNest(modulePassManager)
+      // Pack non-overlapping memory allocations.
+      .addPass(createGPUReuseSharedMemoryAllocsPass)
       // LinalgExt -> SCF
       .addPass(IREE::LinalgExt::createLinalgExtToLoopsPass)
 


### PR DESCRIPTION
Deallocations don't affect the liveness range and can be ignored. Additionally adds the pass to LLVMGPU pipelines as this should be free to run everywhere.