### PR TITLE
Bump llvm-project to llvm/llvm-project@4c4fd6b

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/propagate_reshapes_by_expansion.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/propagate_reshapes_by_expansion.mlir
@@ -10,7 +10,7 @@ func.func @reshape_and_lowering_config(%src: tensor<3x4xf16>, %dest: tensor<12xf
 
 // CHECK-LABEL: func @reshape_and_lowering_config
 //  CHECK-SAME:   %[[SRC:[A-Za-z0-9]+]]: tensor<3x4xf16>
-//       CHECK:   %[[COPY1:.+]] = linalg.generic {{.*}} ins(%[[SRC]]
+//       CHECK:   %[[COPY1:.+]] = linalg.copy{{.*}} ins(%[[SRC]]
 //       CHECK:   %[[COLLAPSE:.+]] = tensor.collapse_shape %[[COPY1]]
 //       CHECK:   linalg.copy
 //  CHECK-SAME:     lowering_config = #iree_gpu.derived_thread_config

--- a/tests/e2e/regression/BUILD.bazel
+++ b/tests/e2e/regression/BUILD.bazel
@@ -193,7 +193,6 @@ iree_check_single_backend_test_suite(
     name = "check_regression_compilation_only_vmvx_ukernels",
     srcs = [
         "dynamic_matmuls_on_same_accumulator_issue_12060.mlir",
-        "dynamic_tosa_clamp.mlir",
     ],
     compiler_flags = [
         "--iree-vmvx-enable-microkernels",

--- a/tests/e2e/regression/CMakeLists.txt
+++ b/tests/e2e/regression/CMakeLists.txt
@@ -237,7 +237,6 @@ iree_check_single_backend_test_suite(
     check_regression_compilation_only_vmvx_ukernels
   SRCS
     "dynamic_matmuls_on_same_accumulator_issue_12060.mlir"
-    "dynamic_tosa_clamp.mlir"
   TARGET_BACKEND
     "vmvx"
   COMPILER_FLAGS

--- a/tests/e2e/regression/dynamic_tosa_clamp.mlir
+++ b/tests/e2e/regression/dynamic_tosa_clamp.mlir
@@ -1,6 +1,0 @@
-// Minimized from dynamic_tosa_quantized_fully_connected_issue_10859.mlir
-
-func.func @clamp(%arg0: tensor<?xi8>) ->tensor<?xi8>{
-  %1 = tosa.clamp %arg0 {max_val = 127 : i8, min_val = -128 : i8} : (tensor<?xi8>) -> tensor<?xi8>
-  return %1 : tensor<?xi8>
-}


### PR DESCRIPTION
Drops a test in LLVMGPU/test/rocdl_pipeline_test.mlir according to changes in https://github.com/iree-org/iree/pull/20152