### PR TITLE
[Dispatch] Bubble extract_slice through all parallel generics

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/BubbleUpExtractSlices.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/BubbleUpExtractSlices.cpp
@@ -40,7 +40,7 @@ struct BubbleUpExtract : OpRewritePattern<tensor::ExtractSliceOp> {
                    "single result");
     }
 
-    if (!genericOp.isAllParallelLoops() && !genericOp->hasOneUse()) {
+    if (!IREE::LinalgExt::isBitExtendOp(genericOp) && !genericOp->hasOneUse()) {
       return rewriter.notifyMatchFailure(
           sliceOp,
           "expected source to be dequantize-like op or have a single use");
@@ -143,7 +143,6 @@ struct BubbleUpExtractSlicesPass
       patterns.insert<BubbleUpExtract>(context);
       patterns.insert<SwapExtractSliceOfFill>(context);
       tensor::populateFoldTensorEmptyPatterns(patterns, false);
-      tensor::populateReassociativeReshapeFoldingPatterns(patterns);
       if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
         return signalPassFailure();
       }


### PR DESCRIPTION
Fixes llama fp8 perf regression introduced by https://github.com/iree-org/iree/pull/20106. The PR stopped the linalg.generic from getting hoisted. This was causing a broadcast to get fused and `tensor<1x1x131072x131072xi1>` to be recomputed on each prefill call.