### PR TITLE
[LLVMGPU] Switch to alloca for shared memory

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -867,7 +867,7 @@ struct DistributeMultiReduction final
     MemRefType allocType = MemRefType::get(
         partialReductionShape, srcVector.getType().getElementType(),
         AffineMap(), workgroupMemoryAddressSpace);
-    auto alloc = rewriter.create<memref::AllocOp>(loc, allocType);
+    auto alloc = rewriter.create<memref::AllocaOp>(loc, allocType);
     VectorType unDistributedType = VectorType::get(
         partialReductionShape, srcVector.getType().getElementType());
     Value undistrWrite = rewriter.create<IREE::VectorExt::ToSIMDOp>(

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_multi_reduce.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_multi_reduce.mlir
@@ -161,7 +161,7 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK: %[[THREAD_RED3:.+]] = vector.insert %[[THREAD_RED2]], %[[THREAD_RED1]] [1] : f32 into vector<2xf32>
 // CHECK: %[[THREAD_RED4:.+]] = vector.shape_cast %[[THREAD_RED3]] : vector<2xf32> to vector<2x1x1xf32>
 // Subgroup reduction
-// CHECK-DAG: %[[ALLOC:.+]] = memref.alloc() : memref<32x2xf32, #gpu.address_space<workgroup>>
+// CHECK-DAG: %[[ALLOC:.+]] = memref.alloca() : memref<32x2xf32, #gpu.address_space<workgroup>>
 // CHECK: gpu.barrier
 // CHECK-DAG: %[[SGID:.+]]:3 = affine.delinearize_index %thread_id_x into (2, 64)
 // CHECK-DAG: %[[TIDX:.+]]:2 = affine.delinearize_index %thread_id_x into (16)
@@ -171,9 +171,9 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK-DAG: vector.transfer_write %[[EXTRACT0]], %[[ALLOC]][%[[TIDX]]#1, %[[SGID]]#1]
 // CHECK-DAG: vector.transfer_write %[[EXTRACT1]], %[[ALLOC]][%[[TIDX1]], %[[SGID]]#1]
 // CHECK: gpu.barrier
-// CHECK-DAG: %[[READ0:.+]] = vector.transfer_read %alloc[%[[TIDX]]#1, %c0], {{.*}} {in_bounds = [true, true]} : memref<32x2xf32, #gpu.address_space<workgroup>>, vector<1x2xf32>
+// CHECK-DAG: %[[READ0:.+]] = vector.transfer_read %[[ALLOC]][%[[TIDX]]#1, %c0], {{.*}} {in_bounds = [true, true]} : memref<32x2xf32, #gpu.address_space<workgroup>>, vector<1x2xf32>
 // CHECK-DAG: %[[GATHER0:.+]] = vector.insert_strided_slice %[[READ0]], %[[CST]] {offsets = [0, 0, 0, 0, 0, 0], strides = [1, 1]} : vector<1x2xf32> into vector<2x1x1x1x1x2xf32>
-// CHECK-DAG: %[[READ1:.+]] = vector.transfer_read %alloc[%[[TIDX1]], %c0], %cst_0 {in_bounds = [true, true]} : memref<32x2xf32, #gpu.address_space<workgroup>>, vector<1x2xf32>
+// CHECK-DAG: %[[READ1:.+]] = vector.transfer_read %[[ALLOC]][%[[TIDX1]], %c0], %cst_0 {in_bounds = [true, true]} : memref<32x2xf32, #gpu.address_space<workgroup>>, vector<1x2xf32>
 // CHECK-DAG: %[[GATHER1:.+]] = vector.insert_strided_slice %[[READ1]], %[[GATHER0]] {offsets = [1, 0, 0, 0, 0, 0], strides = [1, 1]} : vector<1x2xf32> into vector<2x1x1x1x1x2xf32>
 // CHECK-DAG: %[[ACC:.+]] = iree_vector_ext.to_simt %arg1 : vector<32xf32> -> vector<2x1x1xf32>
 // CHECK-DAG: %[[SGRED:.+]] = vector.multi_reduction <maximumf>, %[[GATHER1]], {{.*}} [1, 3, 5] : vector<2x1x1x1x1x2xf32> to vector<2x1x1xf32>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_reuse_shared_memory_allocs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_reuse_shared_memory_allocs.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-reuse-shared-memory-allocs),canonicalize,cse)" %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-reuse-shared-memory-allocs),cse)" %s | FileCheck %s
 
 
 func.func @shared_memory_disjoint() {
@@ -6,9 +6,9 @@ func.func @shared_memory_disjoint() {
   %c1 = arith.constant 1 : index
   %c128 = arith.constant 128 : index
   %cst_f32 = arith.constant 0.000000e+00 : f32
-  %a = memref.alloc() : memref<128xf32, #gpu.address_space<workgroup>>
-  %b = memref.alloc() : memref<256xf32, #gpu.address_space<workgroup>>
-  %c = memref.alloc() : memref<32xf32, #gpu.address_space<workgroup>>
+  %a = memref.alloca() : memref<128xf32, #gpu.address_space<workgroup>>
+  %b = memref.alloca() : memref<256xf32, #gpu.address_space<workgroup>>
+  %c = memref.alloca() : memref<32xf32, #gpu.address_space<workgroup>>
   scf.for %arg0 = %c0 to %c128 step %c1 {
     memref.store %cst_f32, %a[%arg0] : memref<128xf32, #gpu.address_space<workgroup>>
     memref.store %cst_f32, %b[%arg0] : memref<256xf32, #gpu.address_space<workgroup>>
@@ -20,7 +20,7 @@ func.func @shared_memory_disjoint() {
 // CHECK-LABEL: func.func @shared_memory_disjoint
 //   CHECK-DAG:   %[[C512:.+]] = arith.constant 512 : index
 //   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
-//       CHECK:   %[[ALLOC:.+]] = memref.alloc() : memref<1536xi8, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   %[[ALLOC:.+]] = memref.alloca() : memref<1536xi8, #gpu.address_space<workgroup>>
 //   CHECK-DAG:   %[[VIEW_A:.+]] = memref.view %[[ALLOC]][%[[C0]]][] : memref<1536xi8, #gpu.address_space<workgroup>> to memref<128xf32, #gpu.address_space<workgroup>>
 //   CHECK-DAG:   %[[VIEW_B:.+]] = memref.view %[[ALLOC]][%[[C512]]][] : memref<1536xi8, #gpu.address_space<workgroup>> to memref<256xf32, #gpu.address_space<workgroup>>
 //   CHECK-DAG:   %[[VIEW_C:.+]] = memref.view %[[ALLOC]][%[[C0]]][] : memref<1536xi8, #gpu.address_space<workgroup>> to memref<32xf32, #gpu.address_space<workgroup>>
@@ -39,9 +39,9 @@ func.func @shared_memory_disjoint_subview() {
   %c1 = arith.constant 1 : index
   %c64 = arith.constant 64 : index
   %cst_f32 = arith.constant 0.000000e+00 : f32
-  %a = memref.alloc() : memref<128xf32, #gpu.address_space<workgroup>>
-  %b = memref.alloc() : memref<256xf32, #gpu.address_space<workgroup>>
-  %c = memref.alloc() : memref<32xf32, #gpu.address_space<workgroup>>
+  %a = memref.alloca() : memref<128xf32, #gpu.address_space<workgroup>>
+  %b = memref.alloca() : memref<256xf32, #gpu.address_space<workgroup>>
+  %c = memref.alloca() : memref<32xf32, #gpu.address_space<workgroup>>
   %a_subview = memref.subview %a[0] [64] [1] : memref<128xf32, #gpu.address_space<workgroup>> to memref<64xf32, #gpu.address_space<workgroup>>
   %b_subview = memref.subview %b[0] [64] [1] : memref<256xf32, #gpu.address_space<workgroup>> to memref<64xf32, #gpu.address_space<workgroup>>
   %c_subview = memref.subview %c[0] [16] [1] : memref<32xf32, #gpu.address_space<workgroup>> to memref<16xf32, #gpu.address_space<workgroup>>
@@ -55,7 +55,7 @@ func.func @shared_memory_disjoint_subview() {
 // CHECK-LABEL: func.func @shared_memory_disjoint_subview
 //   CHECK-DAG:   %[[C512:.+]] = arith.constant 512 : index
 //   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
-//       CHECK:   %[[ALLOC:.+]] = memref.alloc() : memref<1536xi8, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   %[[ALLOC:.+]] = memref.alloca() : memref<1536xi8, #gpu.address_space<workgroup>>
 //   CHECK-DAG:   %[[VIEW_A:.+]] = memref.view %[[ALLOC]][%[[C0]]][] : memref<1536xi8, #gpu.address_space<workgroup>> to memref<128xf32, #gpu.address_space<workgroup>>
 //   CHECK-DAG:   %[[SUBVIEW_A:.+]] = memref.subview %[[VIEW_A]][0] [64] [1] : memref<128xf32, #gpu.address_space<workgroup>> to memref<64xf32, #gpu.address_space<workgroup>>
 //   CHECK-DAG:   %[[VIEW_B:.+]] = memref.view %[[ALLOC]][%[[C512]]][] : memref<1536xi8, #gpu.address_space<workgroup>> to memref<256xf32, #gpu.address_space<workgroup>>
@@ -78,9 +78,9 @@ func.func @shared_memory_joint_subview() {
   %c64 = arith.constant 64 : index
   %cst_f32 = arith.constant 0.000000e+00 : f32
   %cst_i8 = arith.constant 0 : i8
-  %a = memref.alloc() : memref<128xf32, #gpu.address_space<workgroup>>
-  %b = memref.alloc() : memref<256xf32, #gpu.address_space<workgroup>>
-  %c = memref.alloc() : memref<32xf32, #gpu.address_space<workgroup>>
+  %a = memref.alloca() : memref<128xf32, #gpu.address_space<workgroup>>
+  %b = memref.alloca() : memref<256xf32, #gpu.address_space<workgroup>>
+  %c = memref.alloca() : memref<32xf32, #gpu.address_space<workgroup>>
   %a_subview = memref.subview %a[0] [64] [1] : memref<128xf32, #gpu.address_space<workgroup>> to memref<64xf32, #gpu.address_space<workgroup>>
   %b_subview_0 = memref.subview %b[0] [64] [1] : memref<256xf32, #gpu.address_space<workgroup>> to memref<64xf32, #gpu.address_space<workgroup>>
   %b_subview_1 = memref.subview %b_subview_0[0] [32] [1] : memref<64xf32, #gpu.address_space<workgroup>> to memref<32xf32, #gpu.address_space<workgroup>>
@@ -95,11 +95,11 @@ func.func @shared_memory_joint_subview() {
 }
 // CHECK-LABEL: func.func @shared_memory_joint_subview
 //   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
-//   CHECK-DAG:   %[[ALLOC_A:.+]] = memref.alloc() : memref<128xf32, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   %[[ALLOC_A:.+]] = memref.alloca() : memref<128xf32, #gpu.address_space<workgroup>>
 //   CHECK-DAG:   %[[SUBVIEW_A:.+]] = memref.subview %[[ALLOC_A]][0] [64] [1] : memref<128xf32, #gpu.address_space<workgroup>> to memref<64xf32, #gpu.address_space<workgroup>>
-//   CHECK-DAG:   %[[ALLOC_B:.+]] = memref.alloc() : memref<256xf32, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   %[[ALLOC_B:.+]] = memref.alloca() : memref<256xf32, #gpu.address_space<workgroup>>
 //   CHECK-DAG:   %[[SUBVIEW_B:.+]] = memref.subview %[[ALLOC_B]][0] [64] [1] : memref<256xf32, #gpu.address_space<workgroup>> to memref<64xf32, #gpu.address_space<workgroup>>
-//   CHECK-DAG:   %[[ALLOC_C:.+]] = memref.alloc() : memref<32xf32, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   %[[ALLOC_C:.+]] = memref.alloca() : memref<32xf32, #gpu.address_space<workgroup>>
 //   CHECK-DAG:   %[[SUBVIEW_C:.+]] = memref.subview %[[ALLOC_C]][0] [16] [1] : memref<32xf32, #gpu.address_space<workgroup>> to memref<16xf32, #gpu.address_space<workgroup>>
 //       CHECK:   scf.for
 //       CHECK:     memref.store {{.*}} %[[SUBVIEW_A]]{{.*}} : memref<64xf32, #gpu.address_space<workgroup>>
@@ -115,12 +115,12 @@ func.func @view_like_ops() {
   %c1 = arith.constant 1 : index
   %c64 = arith.constant 64 : index
   %cst_f32 = arith.constant 0.000000e+00 : f32
-  %a = memref.alloc() : memref<128xf32, #gpu.address_space<workgroup>>
-  %b = memref.alloc() : memref<128xf32, #gpu.address_space<workgroup>>
-  %c = memref.alloc() : memref<2x64xf32, #gpu.address_space<workgroup>>
-  %d = memref.alloc() : memref<512xi8, #gpu.address_space<workgroup>>
-  %e = memref.alloc() : memref<128xf32, #gpu.address_space<workgroup>>
-  %f = memref.alloc() : memref<128xf32, #gpu.address_space<workgroup>>
+  %a = memref.alloca() : memref<128xf32, #gpu.address_space<workgroup>>
+  %b = memref.alloca() : memref<128xf32, #gpu.address_space<workgroup>>
+  %c = memref.alloca() : memref<2x64xf32, #gpu.address_space<workgroup>>
+  %d = memref.alloca() : memref<512xi8, #gpu.address_space<workgroup>>
+  %e = memref.alloca() : memref<128xf32, #gpu.address_space<workgroup>>
+  %f = memref.alloca() : memref<128xf32, #gpu.address_space<workgroup>>
   %a_subview = memref.subview %a[0] [64] [1] : memref<128xf32, #gpu.address_space<workgroup>> to memref<64xf32, #gpu.address_space<workgroup>>
   %b_expand_shape = memref.expand_shape %b[[0, 1]] output_shape [2, 64] : memref<128xf32, #gpu.address_space<workgroup>> into memref<2x64xf32, #gpu.address_space<workgroup>>
   %c_collapse_shape = memref.collapse_shape %c[[0, 1]] : memref<2x64xf32, #gpu.address_space<workgroup>> into memref<128xf32, #gpu.address_space<workgroup>>
@@ -136,8 +136,8 @@ func.func @view_like_ops() {
   return
 }
 // CHECK-LABEL: func.func @view_like_ops
-//       CHECK:   memref.alloc() : memref<512xi8, #gpu.address_space<workgroup>>
-//   CHECK-NOT:   memref.alloc
+//       CHECK:   memref.alloca() : memref<512xi8, #gpu.address_space<workgroup>>
+//   CHECK-NOT:   memref.alloca
 
 // -----
 
@@ -146,9 +146,9 @@ func.func @select_alloc(%val : index) {
   %c1 = arith.constant 1 : index
   %c128 = arith.constant 128 : index
   %cst_f32 = arith.constant 0.000000e+00 : f32
-  %a = memref.alloc() : memref<128xf32, #gpu.address_space<workgroup>>
-  %b = memref.alloc() : memref<128xf32, #gpu.address_space<workgroup>>
-  %c = memref.alloc() : memref<32xf32, #gpu.address_space<workgroup>>
+  %a = memref.alloca() : memref<128xf32, #gpu.address_space<workgroup>>
+  %b = memref.alloca() : memref<128xf32, #gpu.address_space<workgroup>>
+  %c = memref.alloca() : memref<32xf32, #gpu.address_space<workgroup>>
   %cmp = arith.cmpi eq, %val, %c1 : index
   %a_or_b = arith.select %cmp, %a, %b : memref<128xf32, #gpu.address_space<workgroup>>
   memref.store %cst_f32, %a_or_b[%c0] : memref<128xf32, #gpu.address_space<workgroup>>
@@ -158,7 +158,7 @@ func.func @select_alloc(%val : index) {
 // CHECK-LABEL: func.func @select_alloc
 //   CHECK-DAG:   %[[C512:.+]] = arith.constant 512 : index
 //   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
-//   CHECK-DAG:   %[[ALLOC:.+]] = memref.alloc() : memref<1024xi8, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   %[[ALLOC:.+]] = memref.alloca() : memref<1024xi8, #gpu.address_space<workgroup>>
 //   CHECK-DAG:   %[[VIEW_A:.+]] = memref.view %[[ALLOC]][%[[C0]]][] : memref<1024xi8, #gpu.address_space<workgroup>> to memref<128xf32, #gpu.address_space<workgroup>>
 //   CHECK-DAG:   %[[VIEW_B:.+]] = memref.view %[[ALLOC]][%[[C512]]][] : memref<1024xi8, #gpu.address_space<workgroup>> to memref<128xf32, #gpu.address_space<workgroup>>
 //   CHECK-DAG:   %[[VIEW_C:.+]] = memref.view %[[ALLOC]][%[[C0]]][] : memref<1024xi8, #gpu.address_space<workgroup>> to memref<32xf32, #gpu.address_space<workgroup>>
@@ -170,9 +170,9 @@ func.func @select_alloc_with_if(%val : index) {
   %c1 = arith.constant 1 : index
   %c128 = arith.constant 128 : index
   %cst_f32 = arith.constant 0.000000e+00 : f32
-  %a = memref.alloc() : memref<128xf32, #gpu.address_space<workgroup>>
-  %b = memref.alloc() : memref<128xf32, #gpu.address_space<workgroup>>
-  %c = memref.alloc() : memref<32xf32, #gpu.address_space<workgroup>>
+  %a = memref.alloca() : memref<128xf32, #gpu.address_space<workgroup>>
+  %b = memref.alloca() : memref<128xf32, #gpu.address_space<workgroup>>
+  %c = memref.alloca() : memref<32xf32, #gpu.address_space<workgroup>>
   %cmp = arith.cmpi eq, %val, %c1 : index
   %a_or_b = scf.if %cmp -> (memref<128xf32, #gpu.address_space<workgroup>>) {
     scf.yield %a : memref<128xf32, #gpu.address_space<workgroup>>
@@ -186,7 +186,7 @@ func.func @select_alloc_with_if(%val : index) {
 // CHECK-LABEL: func.func @select_alloc_with_if
 //   CHECK-DAG:   %[[C512:.+]] = arith.constant 512 : index
 //   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
-//   CHECK-DAG:   %[[ALLOC:.+]] = memref.alloc() : memref<1024xi8, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   %[[ALLOC:.+]] = memref.alloca() : memref<1024xi8, #gpu.address_space<workgroup>>
 //   CHECK-DAG:   %[[VIEW_A:.+]] = memref.view %[[ALLOC]][%[[C0]]][] : memref<1024xi8, #gpu.address_space<workgroup>> to memref<128xf32, #gpu.address_space<workgroup>>
 //   CHECK-DAG:   %[[VIEW_B:.+]] = memref.view %[[ALLOC]][%[[C512]]][] : memref<1024xi8, #gpu.address_space<workgroup>> to memref<128xf32, #gpu.address_space<workgroup>>
 //   CHECK-DAG:   %[[VIEW_C:.+]] = memref.view %[[ALLOC]][%[[C0]]][] : memref<1024xi8, #gpu.address_space<workgroup>> to memref<32xf32, #gpu.address_space<workgroup>>
@@ -198,9 +198,9 @@ func.func @alloc_with_if(%val : index) {
   %c1 = arith.constant 1 : index
   %c128 = arith.constant 128 : index
   %cst_f32 = arith.constant 0.000000e+00 : f32
-  %a = memref.alloc() : memref<128xf32, #gpu.address_space<workgroup>>
-  %b = memref.alloc() : memref<128xf32, #gpu.address_space<workgroup>>
-  %c = memref.alloc() : memref<32xf32, #gpu.address_space<workgroup>>
+  %a = memref.alloca() : memref<128xf32, #gpu.address_space<workgroup>>
+  %b = memref.alloca() : memref<128xf32, #gpu.address_space<workgroup>>
+  %c = memref.alloca() : memref<32xf32, #gpu.address_space<workgroup>>
   %cmp = arith.cmpi eq, %val, %c1 : index
   scf.if %cmp {
     memref.store %cst_f32, %a[%c0] : memref<128xf32, #gpu.address_space<workgroup>>
@@ -213,7 +213,7 @@ func.func @alloc_with_if(%val : index) {
 // CHECK-LABEL: func.func @alloc_with_if
 //   CHECK-DAG:   %[[C512:.+]] = arith.constant 512 : index
 //   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
-//   CHECK-DAG:   %[[ALLOC:.+]] = memref.alloc() : memref<1024xi8, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   %[[ALLOC:.+]] = memref.alloca() : memref<1024xi8, #gpu.address_space<workgroup>>
 //   CHECK-DAG:   %[[VIEW_A:.+]] = memref.view %[[ALLOC]][%[[C0]]][] : memref<1024xi8, #gpu.address_space<workgroup>> to memref<128xf32, #gpu.address_space<workgroup>>
 //   CHECK-DAG:   %[[VIEW_B:.+]] = memref.view %[[ALLOC]][%[[C512]]][] : memref<1024xi8, #gpu.address_space<workgroup>> to memref<128xf32, #gpu.address_space<workgroup>>
 //   CHECK-DAG:   %[[VIEW_C:.+]] = memref.view %[[ALLOC]][%[[C0]]][] : memref<1024xi8, #gpu.address_space<workgroup>> to memref<32xf32, #gpu.address_space<workgroup>>

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -637,6 +637,8 @@ DiagnosedSilenceableFailure transform_dialect::HoistStaticAllocOp::applyToOne(
     transform::TransformState &state) {
   mlir::iree_compiler::hoistStaticallyBoundAllocationsInFunc<memref::AllocOp>(
       rewriter, target);
+  mlir::iree_compiler::hoistStaticallyBoundAllocationsInFunc<memref::AllocaOp>(
+      rewriter, target);
   return DiagnosedSilenceableFailure::success();
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.cpp
@@ -363,7 +363,8 @@ void addBarrier(mlir::FunctionOpInterface funcOp, Operation *alloc,
         needBarrier = true;
         break;
       }
-      if (isa<memref::AllocOp>(&op) && !llvm::is_contained(aliasGroup, &op)) {
+      if (isa<memref::AllocOp, memref::AllocaOp>(&op) &&
+          !llvm::is_contained(aliasGroup, &op)) {
         needBarrier = true;
         break;
       }
@@ -387,6 +388,11 @@ void packSharedMemoryAlloc(mlir::FunctionOpInterface funcOp) {
   DominanceInfo dominators(funcOp);
   SmallVector<Operation *> allocs;
   funcOp.walk([&](memref::AllocOp alloc) {
+    if (hasSharedMemoryAddressSpace(alloc.getType())) {
+      allocs.push_back(alloc);
+    }
+  });
+  funcOp.walk([&](memref::AllocaOp alloc) {
     if (hasSharedMemoryAddressSpace(alloc.getType())) {
       allocs.push_back(alloc);
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_user_vector_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_user_vector_distribute.mlir
@@ -31,15 +31,15 @@ hal.executable public @main_0_dispatch_0 {
     }
     builtin.module {
       // OPT-OUT-LABEL: func.func @main_0_dispatch_0_matmul_transpose_b
-      // OPT-OUT:         memref.alloc() : memref<128x32xf16, #gpu.address_space<workgroup>>
-      // OPT-OUT:         memref.alloc() : memref<128x32xf16, #gpu.address_space<workgroup>>
+      // OPT-OUT:         memref.alloca() : memref<128x32xf16, #gpu.address_space<workgroup>>
+      // OPT-OUT:         memref.alloca() : memref<128x32xf16, #gpu.address_space<workgroup>>
       // OPT-OUT:         scf.forall
       // OPT-OUT:          scf.for
       // OPT-OUT:         } {mapping = [#iree_codegen.workgroup_mapping<x>, #iree_codegen.workgroup_mapping<y>]}
 
       // OPT-IN-LABEL: func.func @main_0_dispatch_0_matmul_transpose_b
-      // OPT-IN:         memref.alloc() : memref<128x32xf16, #gpu.address_space<workgroup>>
-      // OPT-IN:         memref.alloc() : memref<128x32xf16, #gpu.address_space<workgroup>>
+      // OPT-IN:         memref.alloca() : memref<128x32xf16, #gpu.address_space<workgroup>>
+      // OPT-IN:         memref.alloca() : memref<128x32xf16, #gpu.address_space<workgroup>>
       // OPT-IN:         scf.forall
       // OPT-IN:          scf.for
       // OPT-IN:         } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
@@ -104,15 +104,15 @@ hal.executable public @main_0_dispatch_0 {
     }
     builtin.module {
       // OPT-OUT-LABEL: func.func @main_0_dispatch_0_matmul_transpose_b
-      // OPT-OUT:         memref.alloc() : memref<128x36xf16, #gpu.address_space<workgroup>>
-      // OPT-OUT:         memref.alloc() : memref<128x36xf16, #gpu.address_space<workgroup>>
+      // OPT-OUT:         memref.alloca() : memref<128x36xf16, #gpu.address_space<workgroup>>
+      // OPT-OUT:         memref.alloca() : memref<128x36xf16, #gpu.address_space<workgroup>>
       // OPT-OUT:         scf.forall
       // OPT-OUT:          scf.for
       // OPT-OUT:         } {mapping = [#iree_codegen.workgroup_mapping<x>, #iree_codegen.workgroup_mapping<y>]}
 
       // OPT-IN-LABEL: func.func @main_0_dispatch_0_matmul_transpose_b
-      // OPT-IN:         memref.alloc() : memref<128x36xf16, #gpu.address_space<workgroup>>
-      // OPT-IN:         memref.alloc() : memref<128x36xf16, #gpu.address_space<workgroup>>
+      // OPT-IN:         memref.alloca() : memref<128x36xf16, #gpu.address_space<workgroup>>
+      // OPT-IN:         memref.alloca() : memref<128x36xf16, #gpu.address_space<workgroup>>
       // OPT-IN:         scf.forall
       // OPT-IN:          scf.for
       // OPT-IN:         } {mapping = [#iree_codegen.workgroup_mapping<x>, #iree_codegen.workgroup_mapping<y>]}
@@ -172,8 +172,8 @@ hal.executable public @main_0_dispatch_0 {
     }
     builtin.module {
       // OPT-OUT-LABEL: func.func @main_0_dispatch_0_matmul_transpose_b
-      // OPT-OUT:         memref.alloc() : memref<128x36xf16, #gpu.address_space<workgroup>>
-      // OPT-OUT:         memref.alloc() : memref<128x36xf16, #gpu.address_space<workgroup>>
+      // OPT-OUT:         memref.alloca() : memref<128x36xf16, #gpu.address_space<workgroup>>
+      // OPT-OUT:         memref.alloca() : memref<128x36xf16, #gpu.address_space<workgroup>>
       // OPT-OUT:         scf.forall
       // OPT-OUT:          scf.for
       // OPT-OUT:         } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_igemm_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_igemm_tile_and_fuse.mlir
@@ -53,8 +53,8 @@ hal.executable private @main {
 //      CHECK-DAG:   %[[B0:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)
 //      CHECK-DAG:   %[[B1:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)
 //      CHECK-DAG:   %[[B2:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(2)
-//      CHECK-DAG:   memref.alloc() : memref<1x4x16x36xf16, #gpu.address_space<workgroup>>
-//      CHECK-DAG:   memref.alloc() : memref<32x260xf16, #gpu.address_space<workgroup>>
+//      CHECK-DAG:   memref.alloca() : memref<1x4x16x36xf16, #gpu.address_space<workgroup>>
+//      CHECK-DAG:   memref.alloca() : memref<32x260xf16, #gpu.address_space<workgroup>>
 //      CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //      CHECK-DAG:   %[[C720:.+]] = arith.constant 720 : index
 //      CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : index
@@ -133,9 +133,9 @@ hal.executable private @main {
 //      CHECK-DAG:   %[[B0:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)
 //      CHECK-DAG:   %[[B1:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)
 //      CHECK-DAG:   %[[B2:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(2)
-//      CHECK-DAG:   memref.alloc() : memref<2x1x32x18xf32, #gpu.address_space<workgroup>>
-//      CHECK-DAG:   memref.alloc() : memref<16x20xf16, #gpu.address_space<workgroup>>
-//      CHECK-DAG:   memref.alloc() : memref<2x1x32x20xf16, #gpu.address_space<workgroup>>
+//      CHECK-DAG:   memref.alloca() : memref<2x1x32x18xf32, #gpu.address_space<workgroup>>
+//      CHECK-DAG:   memref.alloca() : memref<16x20xf16, #gpu.address_space<workgroup>>
+//      CHECK-DAG:   memref.alloca() : memref<2x1x32x20xf16, #gpu.address_space<workgroup>>
 //      CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //      CHECK-DAG:   %[[C721:.+]] = arith.constant 721 : index
 //      CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
@@ -48,8 +48,8 @@ hal.executable public @main {
 //   CHECK-DAG:   %[[B0:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)
 //   CHECK-DAG:   %[[B1:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)
 //   CHECK-DAG:   %[[B2:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(2)
-//   CHECK-DAG:   memref.alloc() : memref<64x8xf16, #gpu.address_space<workgroup>>
-//   CHECK-DAG:   memref.alloc() : memref<64x8xf16, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   memref.alloca() : memref<64x8xf16, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   memref.alloca() : memref<64x8xf16, #gpu.address_space<workgroup>>
 //       CHECK:   scf.forall ({{.*}}) in (32, 160) {
 //       CHECK:     %[[LOOP:.+]] = scf.for %[[IV:.+]] = %c0 to %c1280 step %c4 {{.*}} -> (vector<8x4xf32>)
 //       CHECK:       gpu.barrier
@@ -112,8 +112,8 @@ hal.executable public @main {
 //   CHECK-DAG:   %[[B0:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)
 //   CHECK-DAG:   %[[B1:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)
 //   CHECK-DAG:   %[[B2:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(2)
-//   CHECK-DAG:   memref.alloc() : memref<64x36xf16, #gpu.address_space<workgroup>>
-//   CHECK-DAG:   memref.alloc() : memref<64x36xf16, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   memref.alloca() : memref<64x36xf16, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   memref.alloca() : memref<64x36xf16, #gpu.address_space<workgroup>>
 //       CHECK:   scf.forall ({{.*}}) in (32, 160) {
 //       CHECK:     %[[LOOP:.+]] = scf.for %[[IV:.+]] = %c0 to %c80 step %c2 {{.*}} -> (vector<2x2x4x1xf32>)
 //       CHECK:       gpu.barrier
@@ -179,8 +179,8 @@ hal.executable public @main {
 //   CHECK-DAG:   %[[B0:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)
 //   CHECK-DAG:   %[[B1:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)
 //   CHECK-DAG:   %[[B2:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(2)
-//   CHECK-DAG:   memref.alloc() : memref<64x36xf16, #gpu.address_space<workgroup>>
-//   CHECK-DAG:   memref.alloc() : memref<64x36xf16, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   memref.alloca() : memref<64x36xf16, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   memref.alloca() : memref<64x36xf16, #gpu.address_space<workgroup>>
 //       CHECK:   scf.forall ({{.*}}) in (32, 160) {
 //       CHECK:     %[[LOOP:.+]] = scf.for %[[IV:.+]] = %c0 to %c80 step %c2 {{.*}} -> (vector<2x2x8x1x1xf32>)
 //       CHECK:       gpu.barrier
@@ -247,8 +247,8 @@ hal.executable public @main {
 }
 
 // CHECK-LABEL: func @matmul_transpose_b_mfma_16x16x4
-//   CHECK-DAG:   memref.alloc() : memref<64x10xf32, #gpu.address_space<workgroup>>
-//   CHECK-DAG:   memref.alloc() : memref<64x10xf32, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   memref.alloca() : memref<64x10xf32, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   memref.alloca() : memref<64x10xf32, #gpu.address_space<workgroup>>
 //       CHECK:   scf.forall ({{.*}}) in (32, 160) {
 //       CHECK:     scf.for %{{.*}} = %c0 to %c320 step %c2 {{.*}} -> (vector<2x2x4x1xf32>)
 // CHECK-COUNT-8:     amdgpu.mfma {{.*}}blocks = 1 : i32, k = 4 : i32, m = 16 : i32, n = 16 : i32
@@ -303,8 +303,8 @@ hal.executable public @main {
 }
 
 // CHECK-LABEL: func @matmul_transpose_b_mfma_16x16x32_f8
-//   CHECK-DAG:   memref.alloc() : memref<64x72xf8E4M3FNUZ, #gpu.address_space<workgroup>>
-//   CHECK-DAG:   memref.alloc() : memref<64x72xf8E4M3FNUZ, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   memref.alloca() : memref<64x72xf8E4M3FNUZ, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   memref.alloca() : memref<64x72xf8E4M3FNUZ, #gpu.address_space<workgroup>>
 //       CHECK:   scf.forall ({{.*}}) in (32, 160) {
 //       CHECK:     scf.for %{{.*}} = %c0 to %c40 step %c2 {{.*}} -> (vector<2x2x4x1xf32>)
 // CHECK-COUNT-8:     amdgpu.mfma {{.*}}blocks = 1 : i32, k = 32 : i32, m = 16 : i32, n = 16 : i32
@@ -359,8 +359,8 @@ hal.executable public @main {
 }
 
 // CHECK-LABEL: func @matmul_transpose_b_mfma_32x32x16_i8
-//   CHECK-DAG:   memref.alloc() : memref<64x40xi8, #gpu.address_space<workgroup>>
-//   CHECK-DAG:   memref.alloc() : memref<64x40xi8, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   memref.alloca() : memref<64x40xi8, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   memref.alloca() : memref<64x40xi8, #gpu.address_space<workgroup>>
 //       CHECK:   scf.forall ({{.*}}) in (32, 160) {
 //       CHECK:     scf.for %{{.*}} = %c0 to %c80 step %c2 {{.*}} -> (vector<1x1x4x4x1xi32>)
 // CHECK-COUNT-2:     amdgpu.mfma {{.*}}blocks = 1 : i32, k = 16 : i32, m = 32 : i32, n = 32 : i32
@@ -415,8 +415,8 @@ hal.executable public @main {
 }
 
 // CHECK-LABEL: func @matmul_transpose_b_wmmar3_f16_16x16x16_f16
-//   CHECK-DAG:   memref.alloc() : memref<64x36xf16, #gpu.address_space<workgroup>>
-//   CHECK-DAG:   memref.alloc() : memref<64x36xf16, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   memref.alloca() : memref<64x36xf16, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   memref.alloca() : memref<64x36xf16, #gpu.address_space<workgroup>>
 //       CHECK:   scf.forall ({{.*}}) in (32, 160) {
 //       CHECK:     scf.for %{{.*}} = %c0 to %c80 step %c2 {{.*}} -> (vector<2x2x16x1x1xf16>)
 // CHECK-COUNT-8:     amdgpu.wmma {{.*}} : vector<16xf16>, vector<16xf16>, vector<16xf16>
@@ -623,8 +623,8 @@ hal.executable public @main {
 }
 
 // CHECK-LABEL: func @matmul_fused_multi_result
-// CHECK-DAG:      memref.alloc() : memref<64x72xi8, #gpu.address_space<workgroup>>
-// CHECK-DAG:      memref.alloc() : memref<64x136xi8, #gpu.address_space<workgroup>>
+// CHECK-DAG:      memref.alloca() : memref<64x72xi8, #gpu.address_space<workgroup>>
+// CHECK-DAG:      memref.alloca() : memref<64x136xi8, #gpu.address_space<workgroup>>
 // CHECK-COUNT-32: amdgpu.wmma {{.*}} : vector<16xi8>, vector<16xi8>, vector<8xi32>
 // CHECK:          vector.transfer_write {{.*}} : vector<4x1x2x8x1xi8>, memref<16x16x196x8x2xi8, #hal.descriptor_type<storage_buffer>>
 // CHECK:          vector.transfer_write {{.*}} : vector<2x8x1x4x1xi8>, memref<196x8x2x16x16xi8, #hal.descriptor_type<storage_buffer>>
@@ -745,8 +745,8 @@ hal.executable public @main {
 // CHECK-DAG:  %[[BINDING_A:.+]] = hal.interface.binding.subspan {{.*}} binding(0)
 // CHECK-DAG:  %[[BINDING_B:.+]] = hal.interface.binding.subspan {{.*}} binding(1)
 // CHECK-DAG:  %[[BINDING_C:.+]] = hal.interface.binding.subspan {{.*}} binding(2)
-// CHECK-DAG:  %[[A_ALLOC:.+]] = memref.alloc() : memref<1x1x8x4x4x4x4xf32, #gpu.address_space<workgroup>>
-// CHECK-DAG:  %[[B_ALLOC:.+]] = memref.alloc() : memref<1x1x4x2x4x16x4xf32, #gpu.address_space<workgroup>>
+// CHECK-DAG:  %[[A_ALLOC:.+]] = memref.alloca() : memref<1x1x8x4x4x4x4xf32, #gpu.address_space<workgroup>>
+// CHECK-DAG:  %[[B_ALLOC:.+]] = memref.alloca() : memref<1x1x4x2x4x16x4xf32, #gpu.address_space<workgroup>>
 // CHECK:      gpu.barrier
 // CHECK-DAG:  %[[A_GLOBAL_LOAD:.+]] = vector.transfer_read %[[BINDING_A]]{{.*}} vector<4xf32>
 // CHECK-DAG:  %[[B_GLOBAL_LOAD:.+]] = vector.transfer_read %[[BINDING_B]]{{.*}} vector<4xf32>
@@ -846,8 +846,8 @@ hal.executable public @main {
 //   CHECK-DAG:   %[[B0:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)
 //   CHECK-DAG:   %[[B1:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)
 //   CHECK-DAG:   %[[B2:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(2)
-//   CHECK-DAG:   %[[LHS_ALLOC:.+]] = memref.alloc() : memref<1x6xf32, #gpu.address_space<workgroup>>
-//   CHECK-DAG:   %[[RHS_ALLOC:.+]] = memref.alloc() : memref<4x130xf32, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   %[[LHS_ALLOC:.+]] = memref.alloca() : memref<1x6xf32, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   %[[RHS_ALLOC:.+]] = memref.alloca() : memref<4x130xf32, #gpu.address_space<workgroup>>
 //       CHECK:   %[[LOOP:.+]] = scf.for %[[IV:.+]] = %c0 to %c1000 step %c4 {{.*}} -> (vector<1x4xf32>)
 //       CHECK:     gpu.barrier
 //       CHECK:     scf.for %{{.*}} = %{{.*}} to %c1 step %c32
@@ -1064,9 +1064,9 @@ hal.executable public @main {
 //   CHECK-DAG:   %[[B0:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)
 //   CHECK-DAG:   %[[B1:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)
 //   CHECK-DAG:   %[[B2:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(2)
-//   CHECK-DAG:   memref.alloc() : memref<64x36xf16, #gpu.address_space<workgroup>>
-//   CHECK-DAG:   memref.alloc() : memref<64x36xf16, #gpu.address_space<workgroup>>
-//   CHECK-DAG:   memref.alloc() : memref<64x66xf32, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   memref.alloca() : memref<64x36xf16, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   memref.alloca() : memref<64x36xf16, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   memref.alloca() : memref<64x66xf32, #gpu.address_space<workgroup>>
 //       CHECK:   scf.forall ({{.*}}) in (32, 160) {
 //       CHECK:     %[[LOOP:.+]] = scf.for %[[IV:.+]] = %c0 to %c80 step %c2 {{.*}} -> (vector<2x2x4x1xf32>)
 //       CHECK:       gpu.barrier
@@ -1145,9 +1145,9 @@ hal.executable public @main {
 //   CHECK-DAG:   %[[B0:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)
 //   CHECK-DAG:   %[[B1:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)
 //   CHECK-DAG:   %[[B2:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(2)
-//   CHECK-DAG:   memref.alloc() : memref<1x4x66xf32, #gpu.address_space<workgroup>>
-//   CHECK-DAG:   memref.alloc() : memref<1x16x6xf32, #gpu.address_space<workgroup>>
-//   CHECK-DAG:   memref.alloc() : memref<1x16x66xf32, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   memref.alloca() : memref<1x4x66xf32, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   memref.alloca() : memref<1x16x6xf32, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   memref.alloca() : memref<1x16x66xf32, #gpu.address_space<workgroup>>
 //       CHECK:   scf.forall ({{.*}}) in (12, 37, 10) {
 //       CHECK:     %[[LOOP:.+]] = scf.for %[[IV:.+]] = %c0 to %c145 step %c1 {{.*}} -> (vector<1x1x1x4x1xf32>)
 //       CHECK:       gpu.barrier

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx942.mlir
@@ -544,10 +544,8 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 // Basic pipeline test to make sure it generates the instructions we expect.
 
 // CHECK-LABEL: func.func @unaligned_nk_batch_matmul()
-// CHECK-DAG:     %[[RHS_SHARED:.+]] = memref.alloc() : memref<1x16x20xf16, #gpu.address_space<workgroup>>
-// CHECK-DAG:     %[[RHS_SHARED_SUB:.+]] =  memref.subview %[[RHS_SHARED]][0, 0, 0] [1, 16, 16] [1, 1, 1]
-// CHECK-DAG:     %[[LHS_SHARED:.+]] = memref.alloc() : memref<1x16x20xf16, #gpu.address_space<workgroup>>
-// CHECK-DAG:     %[[LHS_SHARED_SUB:.+]] =  memref.subview %[[LHS_SHARED]][0, 0, 0] [1, 16, 16] [1, 1, 1]
+// CHECK-DAG:     %[[RHS_SHARED:.+]] = memref.alloca() : memref<1x16x20xf16, #gpu.address_space<workgroup>>
+// CHECK-DAG:     %[[LHS_SHARED:.+]] = memref.alloca() : memref<1x16x20xf16, #gpu.address_space<workgroup>>
 // CHECK-DAG:     %[[LHS_GLOBAL:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : memref<64x968x1281xf16, #hal.descriptor_type<storage_buffer>>
 // CHECK-DAG:     %[[RHS_GLOBAL:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : memref<64x1281x1281xf16, #hal.descriptor_type<storage_buffer>>
 // CHECK-DAG:     %[[OUT_GLOBAL:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(2) alignment(64) offset(%c0) : memref<64x968x1281xf16, #hal.descriptor_type<storage_buffer>>
@@ -690,10 +688,8 @@ hal.executable public @contract_schedule_considering_read_layout {
 // Basic pipeline test to make sure it generates the instructions we expect.
 
 // CHECK-LABEL: func.func @contract_schedule_considering_read_layout()
-// CHECK-DAG:     %[[RHS_SHARED:.+]] = memref.alloc() : memref<128x132xf16, #gpu.address_space<workgroup>>
-// CHECK-DAG:     %[[RHS_SHARED_SUB:.+]] =  memref.subview %[[RHS_SHARED]][0, 0] [128, 128] [1, 1]
-// CHECK-DAG:     %[[LHS_SHARED:.+]] = memref.alloc() : memref<16x132xf16, #gpu.address_space<workgroup>>
-// CHECK-DAG:     %[[LHS_SHARED_SUB:.+]] =  memref.subview %[[LHS_SHARED]][0, 0] [16, 128] [1, 1]
+// CHECK-DAG:     %[[RHS_SHARED:.+]] = memref.alloca() : memref<128x132xf16, #gpu.address_space<workgroup>>
+// CHECK-DAG:     %[[LHS_SHARED:.+]] = memref.alloca() : memref<16x132xf16, #gpu.address_space<workgroup>>
 // CHECK:   scf.for {{.*}} = %c0 to %c1408 step %c128 iter_args(%[[ARG:.+]] = {{.*}}) -> (vector<1x2x1x1x4x1xf16>)
 // CHECK-COUNT-16:     amdgpu.mfma {{.*}} {blocks = 1 : i32, k = 16 : i32, m = 16 : i32, n = 16 : i32} blgp =  none : vector<4xf16>, vector<4xf16>, vector<4xf32>
 // CHECK:     scf.yield
@@ -851,8 +847,8 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 }
 
 // CHECK-LABEL: func @virtual_intrinsic_256x256x256_16x16x32xf8E4M3FNUZ_f32
-// CHECK-DAG:     %[[ALLOC_LHS:.+]] = memref.alloc() : memref<32x136xf8E4M3FNUZ, #gpu.address_space<workgroup>>
-// CHECK-DAG:     %[[ALLOC_RHS:.+]] = memref.alloc() : memref<128x40xf8E4M3FNUZ, #gpu.address_space<workgroup>>
+// CHECK-DAG:     %[[ALLOC_LHS:.+]] = memref.alloca() : memref<32x136xf8E4M3FNUZ, #gpu.address_space<workgroup>>
+// CHECK-DAG:     %[[ALLOC_RHS:.+]] = memref.alloca() : memref<128x40xf8E4M3FNUZ, #gpu.address_space<workgroup>>
 // CHECK:   scf.for {{.*}} = %c0 to %c256 step %c128 iter_args(%[[ARG:.+]] = {{.*}}) -> (vector<1x1x1x1x4x1xf32>)
 
 // Validate that VMFMA do 2 interleaved reads, combine them for every MFMA:
@@ -1023,8 +1019,8 @@ hal.executable private @attention_20x4096x64x4096x64 {
 // Check that we only use alloc for Q, K, and V. No shared memory for S is
 // needed because the intrinsic layout mathes.
 // MEMORY-LABEL: func.func @attention_20x4096x64x4096x64()
-// MEMORY-COUNT-3: memref.alloc
-// MEMORY-NOT: memref.alloc
+// MEMORY-COUNT-3: memref.alloca
+// MEMORY-NOT: memref.alloca
 
 // -----
 
@@ -1091,8 +1087,8 @@ hal.executable private @attention_multiple_m_transpose {
 // Check that we only use alloc for Q, K, and V. No shared memory for S is
 // needed because the intrinsic layout mathes.
 // MEMORY-LABEL: func.func @attention_multiple_m_transpose()
-// MEMORY-COUNT-3: memref.alloc
-// MEMORY-NOT: memref.alloc
+// MEMORY-COUNT-3: memref.alloca
+// MEMORY-NOT: memref.alloca
 
 // -----
 
@@ -1159,8 +1155,8 @@ hal.executable private @attention_mfma_32x32x8 {
 // Check that we only use alloc for Q, K, and V. No shared memory for S is
 // needed because the intrinsic layout mathes.
 // MEMORY-LABEL: func.func @attention_mfma_32x32x8()
-// MEMORY-COUNT-3: memref.alloc
-// MEMORY-NOT: memref.alloc
+// MEMORY-COUNT-3: memref.alloca
+// MEMORY-NOT: memref.alloca
 
 // -----
 
@@ -1238,8 +1234,8 @@ hal.executable private @online_attention_split_k2 {
 // Check that we only use alloc for Q, K, and V. No shared memory for S is
 // needed because the intrinsic layout mathes.
 // MEMORY-LABEL: func.func @online_attention_split_k2()
-// MEMORY-COUNT-3: memref.alloc
-// MEMORY-NOT: memref.alloc
+// MEMORY-COUNT-3: memref.alloca
+// MEMORY-NOT: memref.alloca
 
 // -----
 
@@ -1310,5 +1306,5 @@ module {
 // CHECK: scf.yield
 
 // MEMORY-LABEL: func.func @attention_gather_k
-// MEMORY-COUNT-3: memref.alloc
-// MEMORY-NOT:     memref.alloc
+// MEMORY-COUNT-3: memref.alloca
+// MEMORY-NOT:     memref.alloca

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_reduction_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_reduction_gfx942.mlir
@@ -167,7 +167,7 @@ hal.executable private @matvec_fp16_promote_rhs {
 }
 
 //     CHECK-LABEL: func.func @matvec_fp16_promote_rhs
-//          CHECK:    %[[ALLOC:.+]] = memref.alloc() : memref<4x516xf16, #gpu.address_space<workgroup>>
+//          CHECK:    %[[ALLOC:.+]] = memref.alloca() : memref<4x516xf16, #gpu.address_space<workgroup>>
 //          CHECK:    scf.for {{.*}} = %c0 to %c4096 step %c512
 //          CHECK:      %[[RHS_SHARED_READ:.+]] = vector.transfer_read %alloc
 //          CHECK:      %[[RHS_INSERT:.+]] = vector.insert_strided_slice %[[RHS_SHARED_READ]]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reuse_shared_memory_allocs.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reuse_shared_memory_allocs.mlir
@@ -3,10 +3,10 @@
 func.func @trivial_reuse() {
     %c0 = arith.constant 0 : index
     %cst = arith.constant 0.000000e+00 : f16
-    %alloc0 = memref.alloc() : memref<64x128xf16, #gpu.address_space<workgroup>>
-    %alloc1 = memref.alloc() : memref<64x128xf16, #gpu.address_space<workgroup>>
-    %alloc2 = memref.alloc() : memref<64x128xf16, #gpu.address_space<workgroup>>
-    %alloc3 = memref.alloc() : memref<64x128xf16, #gpu.address_space<workgroup>>
+    %alloc0 = memref.alloca() : memref<64x128xf16, #gpu.address_space<workgroup>>
+    %alloc1 = memref.alloca() : memref<64x128xf16, #gpu.address_space<workgroup>>
+    %alloc2 = memref.alloca() : memref<64x128xf16, #gpu.address_space<workgroup>>
+    %alloc3 = memref.alloca() : memref<64x128xf16, #gpu.address_space<workgroup>>
 
     %r0 = vector.transfer_read %alloc0[%c0, %c0], %cst {in_bounds = [true, true]} : memref<64x128xf16, #gpu.address_space<workgroup>>, vector<64x128xf16>
     vector.transfer_write %r0, %alloc1[%c0, %c0] {in_bounds = [true, true]} : vector<64x128xf16>, memref<64x128xf16, #gpu.address_space<workgroup>>
@@ -18,7 +18,7 @@ func.func @trivial_reuse() {
 }
 
 // CHECK-LABEL: @trivial_reuse
-// CHECK: %[[ALLOC:.+]] = memref.alloc() : memref<16384xi8, #gpu.address_space<workgroup>>
+// CHECK: %[[ALLOC:.+]] = memref.alloca() : memref<16384xi8, #gpu.address_space<workgroup>>
 // CHECK-COUNT-4: memref.view %[[ALLOC]][%c0{{.*}}]
 
 // -----
@@ -26,10 +26,10 @@ func.func @trivial_reuse() {
 func.func @trivial_non_reuse() {
     %c0 = arith.constant 0 : index
     %cst = arith.constant 0.000000e+00 : f16
-    %alloc0 = memref.alloc() : memref<64x128xf16, #gpu.address_space<workgroup>>
-    %alloc1 = memref.alloc() : memref<64x128xf16, #gpu.address_space<workgroup>>
-    %alloc2 = memref.alloc() : memref<64x128xf16, #gpu.address_space<workgroup>>
-    %alloc3 = memref.alloc() : memref<64x128xf16, #gpu.address_space<workgroup>>
+    %alloc0 = memref.alloca() : memref<64x128xf16, #gpu.address_space<workgroup>>
+    %alloc1 = memref.alloca() : memref<64x128xf16, #gpu.address_space<workgroup>>
+    %alloc2 = memref.alloca() : memref<64x128xf16, #gpu.address_space<workgroup>>
+    %alloc3 = memref.alloca() : memref<64x128xf16, #gpu.address_space<workgroup>>
 
     %r0 = vector.transfer_read %alloc0[%c0, %c0], %cst {in_bounds = [true, true]} : memref<64x128xf16, #gpu.address_space<workgroup>>, vector<64x128xf16>
     vector.transfer_write %r0, %alloc1[%c0, %c0] {in_bounds = [true, true]} : vector<64x128xf16>, memref<64x128xf16, #gpu.address_space<workgroup>>
@@ -47,7 +47,7 @@ func.func @trivial_non_reuse() {
 }
 
 // CHECK-LABEL: @trivial_non_reuse
-// CHECK-COUNT-4: memref.alloc() : memref<64x128xf16, #gpu.address_space<workgroup>>
+// CHECK-COUNT-4: memref.alloca() : memref<64x128xf16, #gpu.address_space<workgroup>>
 
 // -----
 
@@ -62,7 +62,7 @@ func.func @shared_reuse_scf_for(%in0: memref<128x128xf16>, %in1: memref<1x4096x1
     %workgroup_id_x = hal.interface.workgroup.id[0] : index
     %4 = affine.apply affine_map<()[s0] -> (s0 * 128)>()[%workgroup_id_x]
     %5 = vector.transfer_read %in0[%c0, %c0], %cst {in_bounds = [true, true]} : memref<128x128xf16>, vector<128x128xf16>
-    %alloc = memref.alloc() : memref<128x128xf16, #gpu.address_space<workgroup>>
+    %alloc = memref.alloca() : memref<128x128xf16, #gpu.address_space<workgroup>>
     vector.transfer_write %5, %alloc[%c0, %c0] {in_bounds = [true, true]} : vector<128x128xf16>, memref<128x128xf16, #gpu.address_space<workgroup>>
     gpu.barrier
     %8 = vector.transfer_read %alloc[%c0, %c0], %cst {in_bounds = [true, true]} : memref<128x128xf16, #gpu.address_space<workgroup>>, vector<128x128xf16>
@@ -70,9 +70,9 @@ func.func @shared_reuse_scf_for(%in0: memref<128x128xf16>, %in1: memref<1x4096x1
     %11 = scf.for %arg0 = %c0 to %c4096 step %c64 iter_args(%arg1 = %cst_0) -> vector<64x128xf16> {
         %17 = vector.transfer_read %in1[%c0, %arg0, %c0], %cst {in_bounds = [true, true]} : memref<1x4096x128xf16>, vector<64x128xf16>
         %19 = vector.transfer_read %in2[%c0, %arg0, %c0], %cst {in_bounds = [true, true]} : memref<1x4096x128xf16>, vector<64x128xf16>
-        %alloc_10 = memref.alloc() : memref<64x128xf16, #gpu.address_space<workgroup>>
+        %alloc_10 = memref.alloca() : memref<64x128xf16, #gpu.address_space<workgroup>>
         vector.transfer_write %17, %alloc_10[%c0, %c0] {in_bounds = [true, true]} : vector<64x128xf16>, memref<64x128xf16, #gpu.address_space<workgroup>>
-        %alloc_11 = memref.alloc() : memref<64x128xf16, #gpu.address_space<workgroup>>
+        %alloc_11 = memref.alloca() : memref<64x128xf16, #gpu.address_space<workgroup>>
         vector.transfer_write %19, %alloc_11[%c0, %c0] {in_bounds = [true, true]} : vector<64x128xf16>, memref<64x128xf16, #gpu.address_space<workgroup>>
 
         %21 = vector.transfer_read %alloc_10[%c0, %c0], %cst {in_bounds = [true, true]} : memref<64x128xf16, #gpu.address_space<workgroup>>, vector<64x128xf16>
@@ -85,7 +85,7 @@ func.func @shared_reuse_scf_for(%in0: memref<128x128xf16>, %in1: memref<1x4096x1
 }
 
 // CHECK-LABEL: @shared_reuse_scf_for
-// CHECK: %[[ALLOC:.+]] = memref.alloc() : memref<32768xi8, #gpu.address_space<workgroup>>
+// CHECK: %[[ALLOC:.+]] = memref.alloca() : memref<32768xi8, #gpu.address_space<workgroup>>
 // CHECK-DAG: memref.view %[[ALLOC]][%c0{{.*}}][] : memref<32768xi8, #gpu.address_space<workgroup>> to memref<128x128xf16, #gpu.address_space<workgroup>>
 // CHECK-DAG: memref.view %[[ALLOC]][%c0{{.*}}][] : memref<32768xi8, #gpu.address_space<workgroup>> to memref<64x128xf16, #gpu.address_space<workgroup>>
 // CHECK-DAG: memref.view %[[ALLOC]][%c16384][] : memref<32768xi8, #gpu.address_space<workgroup>> to memref<64x128xf16, #gpu.address_space<workgroup>>
@@ -107,9 +107,9 @@ func.func @shared_no_reuse_scf_for(%in0: memref<128x128xf16>, %in1: memref<1x409
     %11 = scf.for %arg0 = %c0 to %c4096 step %c64 iter_args(%arg1 = %cst_0) -> vector<64x128xf16> {
         %17 = vector.transfer_read %in1[%c0, %arg0, %c0], %cst {in_bounds = [true, true]} : memref<1x4096x128xf16>, vector<64x128xf16>
         %19 = vector.transfer_read %in2[%c0, %arg0, %c0], %cst {in_bounds = [true, true]} : memref<1x4096x128xf16>, vector<64x128xf16>
-        %alloc_10 = memref.alloc() : memref<64x128xf16, #gpu.address_space<workgroup>>
+        %alloc_10 = memref.alloca() : memref<64x128xf16, #gpu.address_space<workgroup>>
         vector.transfer_write %17, %alloc_10[%c0, %c0] {in_bounds = [true, true]} : vector<64x128xf16>, memref<64x128xf16, #gpu.address_space<workgroup>>
-        %alloc_11 = memref.alloc() : memref<64x128xf16, #gpu.address_space<workgroup>>
+        %alloc_11 = memref.alloca() : memref<64x128xf16, #gpu.address_space<workgroup>>
         vector.transfer_write %19, %alloc_11[%c0, %c0] {in_bounds = [true, true]} : vector<64x128xf16>, memref<64x128xf16, #gpu.address_space<workgroup>>
 
         %21 = vector.transfer_read %alloc_10[%c0, %c0], %cst {in_bounds = [true, true]} : memref<64x128xf16, #gpu.address_space<workgroup>>, vector<64x128xf16>
@@ -124,4 +124,4 @@ func.func @shared_no_reuse_scf_for(%in0: memref<128x128xf16>, %in1: memref<1x409
 // The IR is expected not to be modified if there is no opportunities
 // for reuse.
 // CHECK-LABEL: @shared_no_reuse_scf_for
-// CHECK-COUNT-2: memref.alloc() : memref<64x128xf16, #gpu.address_space<workgroup>>
+// CHECK-COUNT-2: memref.alloca() : memref<64x128xf16, #gpu.address_space<workgroup>>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transpose_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transpose_pipeline_test.mlir
@@ -157,7 +157,7 @@ hal.executable @transpose_3d_no_dispatch_0_generic_768x2048x1024 {
 
 // CHECK-LABEL:   hal.executable public @transpose_3d_no_dispatch_0_generic_768x2048x1024 {
 //   CHECK-NOT:   gpu.barrier
-//   CHECK-NOT:   memref.alloc
+//   CHECK-NOT:   memref.alloc{{.*}}#gpu.address_space<workgroup>
 //       CHECK:   return
 
 // -----
@@ -350,5 +350,5 @@ hal.executable @transpose_3d_diff_dispatch_0_generic_10x768x2048 {
 
 // CHECK-LABEL:   hal.executable public @transpose_3d_diff_dispatch_0_generic_10x768x2048 {
 //   CHECK-NOT:   gpu.barrier
-//   CHECK-NOT:   memref.alloc
+//   CHECK-NOT:   memref.alloc{{.*}}#gpu.address_space<workgroup>
 //       CHECK:   return

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.h
@@ -121,10 +121,12 @@ void analyseAllocsForPacking(mlir::FunctionOpInterface funcOp,
                              SmallVector<AliasGroup> &aliasGroups);
 
 /// Pack groups of allocations into a unique large i8 allocation and use
-/// memref.view to separate the indivudual allocations. This allows re-using
+/// memref.view to separate the individual allocations. This allows re-using
 /// memory across alias groups.
 void packAllocs(OpBuilder &builder, mlir::FunctionOpInterface funcOp,
                 ArrayRef<AliasGroup> aliasGroups);
+void packAllocas(OpBuilder &builder, mlir::FunctionOpInterface funcOp,
+                 ArrayRef<AliasGroup> aliasGroups);
 
 /// Lower the workgroup count region for the default code-generation path in
 /// IREE. Given the list `workgroupCount` (fastest varying dimension innermost)


### PR DESCRIPTION
The inability to deallocate shared memory, as well as the fact that we can't generate escaping allocations makes shared memory closer to an alloca. This switches to alloca for LLVMGPUTileAndFuse and LLVMGPUVectorDistribute. Other pipelines are left alone due to reliance on upstream functions/passes that only work for `memref.alloc` (e.g. memref::multiBuffer).