### PR TITLE
[Codegen][Tuner] improve verifier for the default attribute

### DIFF
--- a/compiler/plugins/target/ROCM/test/default_tuning_specs_amdgpu.mlir
+++ b/compiler/plugins/target/ROCM/test/default_tuning_specs_amdgpu.mlir
@@ -35,6 +35,9 @@
 // Check that both the user tuning spec and the default spec get linked and
 // materialized. The user spec should have precedence over the default one.
 
+// TODO: Re-add the check for iree_codegen.tuning_spec_with_default_entrypoint
+// once new linking is added and the output IR can pass verification for the default attribute.
+
 // BOTH-LABEL: module @iree_linked_tuning_spec
 // BOTH-SAME:    transform.with_named_sequence
 // BOTH-LABEL:   module @mmt_tile_and_fuse_spec_0 attributes {transform.with_named_sequence}

--- a/compiler/plugins/target/ROCM/test/default_tuning_specs_amdgpu.mlir
+++ b/compiler/plugins/target/ROCM/test/default_tuning_specs_amdgpu.mlir
@@ -36,7 +36,6 @@
 // materialized. The user spec should have precedence over the default one.
 
 // BOTH-LABEL: module @iree_linked_tuning_spec
-// BOTH-SAME:    iree_codegen.tuning_spec_with_default_entrypoint
 // BOTH-SAME:    transform.with_named_sequence
 // BOTH-LABEL:   module @mmt_tile_and_fuse_spec_0 attributes {transform.with_named_sequence}
 // BOTH-LABEL:     transform.named_sequence @main

--- a/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
@@ -83,7 +83,7 @@ emitLinkedTuningSpec(ModuleOp module, ArrayRef<NamedSequenceOp> specsToLink) {
       0, hasConsumedSequences ? kArgConsumedAttrName : kArgReadOnlyAttrName,
       builder.getUnitAttr());
   newSpec->setAttr(kTuningSpecEntrypointAttrName, builder.getUnitAttr());
-  // TODO: re-enable default attribute as below once new linking lands.
+  // TODO: Re-enable default attribute as below once new linking lands.
   // module->setAttr(kTuningSpecDefaultEntrypointAttrName,
   // builder.getUnitAttr());
 

--- a/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
@@ -83,6 +83,9 @@ emitLinkedTuningSpec(ModuleOp module, ArrayRef<NamedSequenceOp> specsToLink) {
       0, hasConsumedSequences ? kArgConsumedAttrName : kArgReadOnlyAttrName,
       builder.getUnitAttr());
   newSpec->setAttr(kTuningSpecEntrypointAttrName, builder.getUnitAttr());
+  // TODO: re-enable default attribute as below once new linking lands.
+  // module->setAttr(kTuningSpecDefaultEntrypointAttrName,
+  // builder.getUnitAttr());
 
   Region &region = newSpec.getRegion();
   Block *body = builder.createBlock(&region, region.begin(),

--- a/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LinkTuningSpecsPass.cpp
@@ -83,7 +83,6 @@ emitLinkedTuningSpec(ModuleOp module, ArrayRef<NamedSequenceOp> specsToLink) {
       0, hasConsumedSequences ? kArgConsumedAttrName : kArgReadOnlyAttrName,
       builder.getUnitAttr());
   newSpec->setAttr(kTuningSpecEntrypointAttrName, builder.getUnitAttr());
-  module->setAttr(kTuningSpecDefaultEntrypointAttrName, builder.getUnitAttr());
 
   Region &region = newSpec.getRegion();
   Block *body = builder.createBlock(&region, region.begin(),

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_tuning_specs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_tuning_specs.mlir
@@ -10,8 +10,8 @@
 
 // Check that the final tuning spec is as expected when the user tuning spec is provided.
 
-// TODO: Add the default attribute (`iree_codegen.tuning_spec_with_default_entrypoint`) here once
-//       the merging logic supports cases beyond a single `foreach_match` operation.
+// TODO: Add the check for default attribute (`iree_codegen.tuning_spec_with_default_entrypoint`) here
+//       once the merging logic supports cases beyond a single `foreach_match` operation.
 
 // CHECK-LABEL: module @iree_linked_tuning_spec
 // CHECK-SAME:    transform.with_named_sequence

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_tuning_specs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_tuning_specs.mlir
@@ -33,6 +33,7 @@
 // SKIPLINK-LABEL: module  @user_spec
 // SKIPLINK-SAME:    iree_codegen.tuning_spec_with_default_entrypoint
 // SKIPLINK-SAME:    transform.with_named_sequence
+// SKIPLINK:         transform.print  {name = "Hello Tuning Spec"}
 // SKIPLINK-NOT:    module @{{.+}}
 // SKIPLINK:        module attributes
 // SKIPLINK-SAME:     iree_codegen.tuning_spec_mlirbc = dense<{{.+}}> : vector<{{[0-9]+}}xi8>

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_tuning_specs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_tuning_specs.mlir
@@ -10,6 +10,9 @@
 
 // Check that the final tuning spec is as expected when the user tuning spec is provided.
 
+// TODO: Add the default attribute (`iree_codegen.tuning_spec_with_default_entrypoint`) here once
+//       the merging logic supports cases beyond a single `foreach_match` operation.
+
 // CHECK-LABEL: module @iree_linked_tuning_spec
 // CHECK-SAME:    transform.with_named_sequence
 // CHECK-LABEL:   module @user_spec_0 attributes {transform.with_named_sequence}

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_tuning_specs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_tuning_specs.mlir
@@ -11,7 +11,6 @@
 // Check that the final tuning spec is as expected when the user tuning spec is provided.
 
 // CHECK-LABEL: module @iree_linked_tuning_spec
-// CHECK-SAME:    iree_codegen.tuning_spec_with_default_entrypoint
 // CHECK-SAME:    transform.with_named_sequence
 // CHECK-LABEL:   module @user_spec_0 attributes {transform.with_named_sequence}
 // CHECK-LABEL:     transform.named_sequence @hello

--- a/compiler/src/iree/compiler/Codegen/Common/test/tuning_spec_default.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tuning_spec_default.mlir
@@ -1,9 +1,18 @@
 // RUN: iree-opt %s
 
 module @user_spec attributes { transform.with_named_sequence, iree_codegen.tuning_spec_with_default_entrypoint } {
-  transform.named_sequence @__kernel_config(%arg0: !transform.any_op {transform.readonly}) -> !transform.any_op
-    attributes { iree_codegen.tuning_spec_entrypoint } {
-    transform.print {name = "Hello Tuning Spec", skip_regions}
-    transform.yield %arg0 : !transform.any_op
+  transform.named_sequence @match(%arg: !transform.any_op {transform.readonly}) -> (!transform.any_op) {
+    transform.yield %arg : !transform.any_op
+  }
+
+  transform.named_sequence @apply_op_config(%op: !transform.any_op {transform.readonly}) {
+    transform.yield
+  }
+
+  transform.named_sequence @__kernel_config(%arg0: !transform.any_op {transform.consumed})
+      -> (!transform.any_op) attributes { iree_codegen.tuning_spec_entrypoint } {
+      %res = transform.foreach_match in %arg0 @match -> @apply_op_config
+        : (!transform.any_op) -> (!transform.any_op)
+      transform.yield %res : !transform.any_op
   }
 }

--- a/compiler/src/iree/compiler/Codegen/Common/test/tuning_spec_default.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tuning_spec_default.mlir
@@ -2,6 +2,7 @@
 
 module @user_spec attributes { transform.with_named_sequence, iree_codegen.tuning_spec_with_default_entrypoint } {
   transform.named_sequence @match(%arg: !transform.any_op {transform.readonly}) -> (!transform.any_op) {
+    transform.print {name = "Hello Tuning Spec"}
     transform.yield %arg : !transform.any_op
   }
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/tuning_spec_default.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tuning_spec_default.mlir
@@ -11,7 +11,8 @@ module @user_spec attributes { transform.with_named_sequence, iree_codegen.tunin
 
   transform.named_sequence @__kernel_config(%arg0: !transform.any_op {transform.consumed})
       -> (!transform.any_op) attributes { iree_codegen.tuning_spec_entrypoint } {
-      %res = transform.foreach_match in %arg0 @match -> @apply_op_config
+      %res = transform.foreach_match in %arg0
+        @match -> @apply_op_config
         : (!transform.any_op) -> (!transform.any_op)
       transform.yield %res : !transform.any_op
   }

--- a/compiler/src/iree/compiler/Codegen/Common/test/verify_tuning_specs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/verify_tuning_specs.mlir
@@ -108,25 +108,14 @@ module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_defa
 
 // expected-error @+1{{Expected exactly one NamedSequenceOp with the attribute 'iree_codegen.tuning_spec_entrypoint', but found 2}}
 module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_default_entrypoint } {
-  transform.named_sequence @match(%arg: !transform.any_op {transform.readonly}) -> (!transform.any_op) {
-      transform.yield %arg : !transform.any_op
-  }
-
-  transform.named_sequence @apply_op_config(%op: !transform.any_op {transform.readonly}) {
-      transform.yield
-  }
 
   transform.named_sequence @__kernel_config(%arg0: !transform.any_op {transform.consumed})
       -> (!transform.any_op) attributes { iree_codegen.tuning_spec_entrypoint } {
-
-      %res = transform.foreach_match in %arg0 @match -> @apply_op_config
-        : (!transform.any_op) -> (!transform.any_op)
-      transform.yield %res : !transform.any_op
+    transform.yield %arg0 : !transform.any_op
   }
 
-  transform.named_sequence @main(%arg0: !transform.any_op {transform.readonly}) -> !transform.any_op
-    attributes { iree_codegen.tuning_spec_entrypoint } {
-    transform.print {name = "Hello Tuning Spec", skip_regions}
+  transform.named_sequence @main(%arg0: !transform.any_op {transform.readonly})
+      -> !transform.any_op attributes { iree_codegen.tuning_spec_entrypoint } {
     transform.yield %arg0 : !transform.any_op
   }
 }

--- a/compiler/src/iree/compiler/Codegen/Common/test/verify_tuning_specs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/verify_tuning_specs.mlir
@@ -108,7 +108,6 @@ module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_defa
 
 // expected-error @+1{{Expected exactly one NamedSequenceOp with the attribute 'iree_codegen.tuning_spec_entrypoint', but found 2}}
 module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_default_entrypoint } {
-
   transform.named_sequence @__kernel_config(%arg0: !transform.any_op {transform.consumed})
       -> (!transform.any_op) attributes { iree_codegen.tuning_spec_entrypoint } {
     transform.yield %arg0 : !transform.any_op
@@ -117,5 +116,217 @@ module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_defa
   transform.named_sequence @main(%arg0: !transform.any_op {transform.readonly})
       -> !transform.any_op attributes { iree_codegen.tuning_spec_entrypoint } {
     transform.yield %arg0 : !transform.any_op
+  }
+}
+
+// -----
+
+module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_default_entrypoint } {
+    transform.named_sequence @match(%arg: !transform.any_op {transform.readonly}) -> (!transform.any_op) {
+      transform.yield %arg : !transform.any_op
+    }
+
+    transform.named_sequence @apply_op_config(%op: !transform.any_op {transform.readonly}) {
+        transform.yield
+    }
+
+    // expected-error @+1{{The named sequence '__kernel_config' must contain exactly one 'transform::YieldOp', but found 2}}
+    transform.named_sequence @__kernel_config(%arg0: !transform.any_op {transform.consumed})
+        -> (!transform.any_op) attributes { iree_codegen.tuning_spec_entrypoint } {
+        %res = transform.foreach_match in %arg0 @match -> @apply_op_config
+        : (!transform.any_op) -> (!transform.any_op)
+
+        transform.yield %res : !transform.any_op
+        transform.yield %res : !transform.any_op
+    }
+}
+
+// -----
+
+// expected-error @+1{{Expected exactly one NamedSequenceOp with the attribute 'iree_codegen.tuning_spec_entrypoint', but found 2}}
+module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_default_entrypoint } {
+  transform.named_sequence @__kernel_config(%arg0: !transform.any_op {transform.consumed})
+      -> (!transform.any_op) attributes { iree_codegen.tuning_spec_entrypoint } {
+    transform.yield %arg0 : !transform.any_op
+  }
+
+  module @extra_module attributes { iree_codegen.tuning_spec_entrypoint } {
+    transform.yield
+  }
+}
+
+// -----
+
+module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_default_entrypoint } {
+  transform.named_sequence private @dummy_func(!transform.any_op {transform.consumed}) -> !transform.any_op
+    transform.named_sequence @match(%arg: !transform.any_op {transform.readonly}) -> (!transform.any_op) {
+      transform.yield %arg : !transform.any_op
+    }
+
+    transform.named_sequence @apply_op_config(%op: !transform.any_op {transform.readonly}) {
+        transform.yield
+    }
+
+    // expected-error @+1{{The named sequence '__kernel_configbut found an unsupported operation: transform.include}}
+    transform.named_sequence @__kernel_config(%arg0: !transform.any_op {transform.consumed})
+        -> (!transform.any_op) attributes { iree_codegen.tuning_spec_entrypoint } {
+        %tmp = transform.include @dummy_func failures(suppress) (%arg0) : (!transform.any_op) -> (!transform.any_op)
+        %res = transform.foreach_match in %tmp @match -> @apply_op_config
+        : (!transform.any_op) -> (!transform.any_op)
+
+        transform.yield %res : !transform.any_op
+    }
+}
+
+// -----
+
+module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_default_entrypoint } {
+  transform.named_sequence private @dummy_func(!transform.any_op {transform.consumed}) -> !transform.any_op
+    transform.named_sequence @match(%arg: !transform.any_op {transform.readonly}) -> (!transform.any_op) {
+      transform.yield %arg : !transform.any_op
+    }
+
+    transform.named_sequence @apply_op_config(%op: !transform.any_op {transform.readonly}) {
+        transform.yield
+    }
+
+    // expected-error @+1{{The named sequence '__kernel_configbut found an unsupported operation: transform.print}}
+    transform.named_sequence @__kernel_config(%arg0: !transform.any_op {transform.consumed})
+        -> (!transform.any_op) attributes { iree_codegen.tuning_spec_entrypoint } {
+         transform.print {name = "Hello"}
+        %res = transform.foreach_match in %arg0 @match -> @apply_op_config
+        : (!transform.any_op) -> (!transform.any_op)
+
+        transform.yield %res : !transform.any_op
+    }
+}
+
+// -----
+
+module @iree_default_tuning_spec attributes { transform.with_named_sequence, iree_codegen.tuning_spec_with_default_entrypoint } {
+  transform.named_sequence @match(%arg: !transform.any_op {transform.readonly})
+    -> (!transform.any_op, !transform.any_op) {
+    transform.yield %arg, %arg : !transform.any_op, !transform.any_op
+  }
+
+  transform.named_sequence @apply_op_config(%op1: !transform.any_op {transform.readonly}, %op2: !transform.any_op {transform.readonly})
+    -> (!transform.any_op) {
+    transform.yield %op1 : !transform.any_op
+  }
+
+  transform.named_sequence @__kernel_config(%arg0: !transform.any_op {transform.consumed})
+    -> (!transform.any_op) attributes { iree_codegen.tuning_spec_entrypoint } {
+    // expected-error @+1 {{ForeachMatchOp must return exactly one any_op result}}
+    %res1, %res2 = transform.foreach_match in %arg0 @match -> @apply_op_config
+      : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+
+    transform.yield %res1 : !transform.any_op
+  }
+}
+
+// -----
+
+module @iree_default_tuning_spec attributes { transform.with_named_sequence, iree_codegen.tuning_spec_with_default_entrypoint } {
+  transform.named_sequence @match(%arg: !transform.any_op) -> (!transform.any_op) {
+    transform.yield %arg : !transform.any_op
+  }
+
+  transform.named_sequence @apply_op_config(%op: !transform.any_op) {
+    transform.yield
+  }
+
+  // expected-error @+1 {{Tuning spec entry point expected to return any_op}}
+  transform.named_sequence @__kernel_config(%arg0: !transform.any_op)
+      -> (f32) attributes { iree_codegen.tuning_spec_entrypoint } {
+     // expected-error @+1 {{ForeachMatchOp must return exactly one any_op result}}
+    %res = transform.foreach_match in %arg0 @match -> @apply_op_config
+      : (!transform.any_op) -> (f32)
+
+    transform.yield %res : f32
+  }
+}
+
+// -----
+
+module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_default_entrypoint } {
+  transform.named_sequence @match(%arg1: !transform.any_op {transform.readonly}, %arg2: !transform.any_op {transform.readonly})
+        -> (!transform.any_op) {
+        transform.yield %arg1 : !transform.any_op
+  }
+
+  transform.named_sequence @apply_op_config(%op: !transform.any_op {transform.readonly}) {
+        transform.yield
+  }
+
+  transform.named_sequence @__kernel_config(%arg0: !transform.any_op {transform.consumed})
+    -> (!transform.any_op) attributes { iree_codegen.tuning_spec_entrypoint } {
+    // expected-error @+1 {{ForeachMatchOp must take exactly one any_op argument}}
+    %res = transform.foreach_match in %arg0, %arg0 @match -> @apply_op_config
+    : (!transform.any_op, !transform.any_op) -> (!transform.any_op)
+
+    transform.yield %res : !transform.any_op
+  }
+}
+
+// -----
+
+module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_default_entrypoint } {
+  transform.named_sequence @match(%arg: index) -> (index) {
+    transform.yield %arg : index
+  }
+
+  transform.named_sequence @apply_op_config(%op: !transform.any_op) {
+    transform.yield
+  }
+
+  transform.named_sequence @__kernel_config(%arg0: index)
+      -> (!transform.any_op) attributes { iree_codegen.tuning_spec_entrypoint } {
+    // expected-error @+1 {{ForeachMatchOp must take exactly one any_op argument}}
+    %res = transform.foreach_match in %arg0 @match -> @apply_op_config
+      : (index) -> (!transform.any_op)
+
+    transform.yield %res : !transform.any_op
+  }
+}
+
+// -----
+
+module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_default_entrypoint } {
+  transform.named_sequence @match(%arg: !transform.any_op) -> (!transform.any_op) {
+    transform.yield %arg : !transform.any_op
+  }
+
+  transform.named_sequence @apply_op_config(%op: !transform.any_op) {
+    transform.yield
+  }
+
+  transform.named_sequence @__kernel_config(%arg0: !transform.any_op)
+      -> (!transform.any_op) attributes { iree_codegen.tuning_spec_entrypoint } {
+     // expected-error @+1{{ForeachMatchOp must not have the 'restrict_root' attribute}}
+    %res = transform.foreach_match restrict_root in %arg0 @match -> @apply_op_config
+      : (!transform.any_op) -> (!transform.any_op)
+
+    transform.yield %res : !transform.any_op
+  }
+}
+
+// -----
+
+module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_default_entrypoint } {
+  transform.named_sequence @match(%arg: !transform.any_op) -> (!transform.any_op) {
+    transform.yield %arg : !transform.any_op
+  }
+
+  transform.named_sequence @apply_op_config(%op: !transform.any_op) {
+    transform.yield
+  }
+
+  transform.named_sequence @__kernel_config(%arg0: !transform.any_op)
+      -> (!transform.any_op) attributes { iree_codegen.tuning_spec_entrypoint } {
+     // expected-error @+1{{ForeachMatchOp must not have the 'flatten_results' attribute}}
+    %res = transform.foreach_match flatten_results in %arg0 @match -> @apply_op_config
+      : (!transform.any_op) -> (!transform.any_op)
+
+    transform.yield %res : !transform.any_op
   }
 }

--- a/compiler/src/iree/compiler/Codegen/Common/test/verify_tuning_specs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/verify_tuning_specs.mlir
@@ -18,7 +18,7 @@ module @foo_module attributes { transform.with_named_sequence } {
 // -----
 
 module @foo_module attributes { transform.with_named_sequence } {
-  // expected-error @+1{{Tuning spec entry point expected to have a single any_op argument}}
+  // expected-error @+1{{Must take one 'any_op' (required by 'iree_codegen.tuning_spec_entrypoint')}}
   transform.named_sequence @foo(%arg0: !transform.any_op {transform.readonly}, %arg1: !transform.any_op {transform.readonly}) -> !transform.any_op
     attributes { iree_codegen.tuning_spec_entrypoint } {
     transform.yield %arg0 : !transform.any_op
@@ -28,7 +28,7 @@ module @foo_module attributes { transform.with_named_sequence } {
 // -----
 
 module @foo_module attributes { transform.with_named_sequence } {
-  // expected-error @+1{{Tuning spec entry point expected to have a single any_op argument}}
+  // expected-error @+1{{Must take one 'any_op' (required by 'iree_codegen.tuning_spec_entrypoint')}}
   transform.named_sequence @foo(%arg0: i32) -> !transform.any_op
     attributes { iree_codegen.tuning_spec_entrypoint } {}
 }
@@ -36,7 +36,7 @@ module @foo_module attributes { transform.with_named_sequence } {
 // -----
 
 module @foo_module attributes { transform.with_named_sequence } {
-  // expected-error @+1{{Tuning spec entry point expected to return any_op}}
+  // expected-error @+1{{Must return one 'any_op' (required by 'iree_codegen.tuning_spec_entrypoint')}}
   transform.named_sequence @foo(%arg0: !transform.any_op {transform.readonly}) -> i32
     attributes { iree_codegen.tuning_spec_entrypoint } {
     %0 = arith.constant 0 : i32
@@ -47,20 +47,20 @@ module @foo_module attributes { transform.with_named_sequence } {
 // -----
 
 module @foo_module attributes { transform.with_named_sequence } {
-  // expected-error @+1{{Tuning spec entry point expected to return any_op}}
+  // expected-error @+1{{Must return one 'any_op' (required by 'iree_codegen.tuning_spec_entrypoint')}}
   transform.named_sequence @foo(%arg0: !transform.any_op {transform.readonly})
     attributes { iree_codegen.tuning_spec_entrypoint } {}
 }
 
 // -----
 
-// expected-error @+1{{The tuning specification must include a named sequence with the symbol name '__kernel_config'}}
+// expected-error @+1{{Missing named sequence '__kernel_config' (required by 'iree_codegen.tuning_spec_with_default_entrypoint')}}
 module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_default_entrypoint } {
 }
 
 // -----
 
-// expected-error @+1{{The tuning specification must include a named sequence with the symbol name '__kernel_config'}}
+// expected-error @+1{{Missing named sequence '__kernel_config' (required by 'iree_codegen.tuning_spec_with_default_entrypoint')}}
 module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_default_entrypoint } {
   func.func @__kernel_config(%arg0: i32) -> () {
     return
@@ -70,7 +70,7 @@ module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_defa
 // -----
 
 module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_default_entrypoint } {
-  // expected-error @+1{{The named sequence '__kernel_config' must have the attribute 'iree_codegen.tuning_spec_entrypoint'}}
+  // expected-error @+1{{Missing attribute 'iree_codegen.tuning_spec_entrypoint' in named sequence '__kernel_config' (required by 'iree_codegen.tuning_spec_with_default_entrypoint')}}
   transform.named_sequence @__kernel_config(%arg0: !transform.any_op {transform.consumed})
       -> (!transform.any_op) {
       transform.yield %arg0 : !transform.any_op
@@ -80,11 +80,7 @@ module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_defa
 // -----
 
 module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_default_entrypoint } {
-  transform.named_sequence @match_a(%arg: !transform.any_op {transform.readonly}) -> (!transform.any_op) {
-      transform.yield %arg : !transform.any_op
-  }
-
-  transform.named_sequence @match_b(%arg: !transform.any_op {transform.readonly}) -> (!transform.any_op) {
+  transform.named_sequence @match(%arg: !transform.any_op {transform.readonly}) -> (!transform.any_op) {
       transform.yield %arg : !transform.any_op
   }
 
@@ -92,13 +88,15 @@ module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_defa
       transform.yield
   }
 
-  // expected-error @+1{{The named sequence '__kernel_config' must contain exactly one 'ForeachMatchOp', but found 2}}
+  // expected-error @+1{{'__kernel_config' must contain exactly one 'ForeachMatchOp' (required by 'iree_codegen.tuning_spec_with_default_entrypoint')}}
   transform.named_sequence @__kernel_config(%arg0: !transform.any_op {transform.consumed})
       -> (!transform.any_op) attributes { iree_codegen.tuning_spec_entrypoint } {
 
-      %res_a = transform.foreach_match in %arg0 @match_a -> @apply_op_config
+      %res_a = transform.foreach_match in %arg0
+        @match -> @apply_op_config
         : (!transform.any_op) -> (!transform.any_op)
-      %res_b = transform.foreach_match in %res_a @match_b -> @apply_op_config
+      %res_b = transform.foreach_match in %res_a
+        @match -> @apply_op_config
         : (!transform.any_op) -> (!transform.any_op)
       transform.yield %res_b : !transform.any_op
   }
@@ -106,7 +104,7 @@ module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_defa
 
 // -----
 
-// expected-error @+1{{Expected exactly one NamedSequenceOp with the attribute 'iree_codegen.tuning_spec_entrypoint', but found 2}}
+// expected-error @+1{{Expected one named sequence with 'iree_codegen.tuning_spec_entrypoint', but found 2 (required by 'iree_codegen.tuning_spec_with_default_entrypoint')}}
 module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_default_entrypoint } {
   transform.named_sequence @__kernel_config(%arg0: !transform.any_op {transform.consumed})
       -> (!transform.any_op) attributes { iree_codegen.tuning_spec_entrypoint } {
@@ -130,20 +128,21 @@ module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_defa
         transform.yield
     }
 
-    // expected-error @+1{{The named sequence '__kernel_config' must contain exactly one 'transform::YieldOp', but found 2}}
+    // expected-error @+1{{Unexpected op 'transform.print' in '__kernel_config' (required by 'iree_codegen.tuning_spec_with_default_entrypoint')}}
     transform.named_sequence @__kernel_config(%arg0: !transform.any_op {transform.consumed})
         -> (!transform.any_op) attributes { iree_codegen.tuning_spec_entrypoint } {
-        %res = transform.foreach_match in %arg0 @match -> @apply_op_config
-        : (!transform.any_op) -> (!transform.any_op)
+        %res = transform.foreach_match in %arg0
+          @match -> @apply_op_config
+          : (!transform.any_op) -> (!transform.any_op)
 
         transform.yield %res : !transform.any_op
-        transform.yield %res : !transform.any_op
+        transform.print {name = "Hello"}
     }
 }
 
 // -----
 
-// expected-error @+1{{Expected exactly one NamedSequenceOp with the attribute 'iree_codegen.tuning_spec_entrypoint', but found 2}}
+// expected-error @+1{{Expected one named sequence with 'iree_codegen.tuning_spec_entrypoint', but found 2 (required by 'iree_codegen.tuning_spec_with_default_entrypoint')}}
 module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_default_entrypoint } {
   transform.named_sequence @__kernel_config(%arg0: !transform.any_op {transform.consumed})
       -> (!transform.any_op) attributes { iree_codegen.tuning_spec_entrypoint } {
@@ -167,12 +166,13 @@ module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_defa
         transform.yield
     }
 
-    // expected-error @+1{{The named sequence '__kernel_configbut found an unsupported operation: transform.include}}
+    // expected-error @+1{{Unexpected op 'transform.include' in '__kernel_config' (required by 'iree_codegen.tuning_spec_with_default_entrypoint')}}
     transform.named_sequence @__kernel_config(%arg0: !transform.any_op {transform.consumed})
         -> (!transform.any_op) attributes { iree_codegen.tuning_spec_entrypoint } {
         %tmp = transform.include @dummy_func failures(suppress) (%arg0) : (!transform.any_op) -> (!transform.any_op)
-        %res = transform.foreach_match in %tmp @match -> @apply_op_config
-        : (!transform.any_op) -> (!transform.any_op)
+        %res = transform.foreach_match in %tmp
+          @match -> @apply_op_config
+          : (!transform.any_op) -> (!transform.any_op)
 
         transform.yield %res : !transform.any_op
     }
@@ -190,12 +190,13 @@ module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_defa
         transform.yield
     }
 
-    // expected-error @+1{{The named sequence '__kernel_configbut found an unsupported operation: transform.print}}
+    // expected-error @+1{{Unexpected op 'transform.print' in '__kernel_config' (required by 'iree_codegen.tuning_spec_with_default_entrypoint')}}
     transform.named_sequence @__kernel_config(%arg0: !transform.any_op {transform.consumed})
         -> (!transform.any_op) attributes { iree_codegen.tuning_spec_entrypoint } {
          transform.print {name = "Hello"}
-        %res = transform.foreach_match in %arg0 @match -> @apply_op_config
-        : (!transform.any_op) -> (!transform.any_op)
+        %res = transform.foreach_match in
+          %arg0 @match -> @apply_op_config
+          : (!transform.any_op) -> (!transform.any_op)
 
         transform.yield %res : !transform.any_op
     }
@@ -216,8 +217,9 @@ module @iree_default_tuning_spec attributes { transform.with_named_sequence, ire
 
   transform.named_sequence @__kernel_config(%arg0: !transform.any_op {transform.consumed})
     -> (!transform.any_op) attributes { iree_codegen.tuning_spec_entrypoint } {
-    // expected-error @+1 {{ForeachMatchOp must return exactly one any_op result}}
-    %res1, %res2 = transform.foreach_match in %arg0 @match -> @apply_op_config
+    // expected-error @+1 {{'ForeachMatchOp' must return exactly one 'any_op' result (required by 'iree_codegen.tuning_spec_with_default_entrypoint')}}
+    %res1, %res2 = transform.foreach_match in %arg0
+      @match -> @apply_op_config
       : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 
     transform.yield %res1 : !transform.any_op
@@ -235,11 +237,11 @@ module @iree_default_tuning_spec attributes { transform.with_named_sequence, ire
     transform.yield
   }
 
-  // expected-error @+1 {{Tuning spec entry point expected to return any_op}}
   transform.named_sequence @__kernel_config(%arg0: !transform.any_op)
       -> (f32) attributes { iree_codegen.tuning_spec_entrypoint } {
-     // expected-error @+1 {{ForeachMatchOp must return exactly one any_op result}}
-    %res = transform.foreach_match in %arg0 @match -> @apply_op_config
+     // expected-error @+1 {{'ForeachMatchOp' must return exactly one 'any_op' result (required by 'iree_codegen.tuning_spec_with_default_entrypoint')}}
+    %res = transform.foreach_match in %arg0
+      @match -> @apply_op_config
       : (!transform.any_op) -> (f32)
 
     transform.yield %res : f32
@@ -260,9 +262,10 @@ module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_defa
 
   transform.named_sequence @__kernel_config(%arg0: !transform.any_op {transform.consumed})
     -> (!transform.any_op) attributes { iree_codegen.tuning_spec_entrypoint } {
-    // expected-error @+1 {{ForeachMatchOp must take exactly one any_op argument}}
-    %res = transform.foreach_match in %arg0, %arg0 @match -> @apply_op_config
-    : (!transform.any_op, !transform.any_op) -> (!transform.any_op)
+    // expected-error @+1 {{'ForeachMatchOp' must take exactly one 'any_op' argument (required by 'iree_codegen.tuning_spec_with_default_entrypoint')}}
+    %res = transform.foreach_match in %arg0, %arg0
+      @match -> @apply_op_config
+      : (!transform.any_op, !transform.any_op) -> (!transform.any_op)
 
     transform.yield %res : !transform.any_op
   }
@@ -281,8 +284,9 @@ module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_defa
 
   transform.named_sequence @__kernel_config(%arg0: index)
       -> (!transform.any_op) attributes { iree_codegen.tuning_spec_entrypoint } {
-    // expected-error @+1 {{ForeachMatchOp must take exactly one any_op argument}}
-    %res = transform.foreach_match in %arg0 @match -> @apply_op_config
+    // expected-error @+1 {{'ForeachMatchOp' must take exactly one 'any_op' argument (required by 'iree_codegen.tuning_spec_with_default_entrypoint')}}
+    %res = transform.foreach_match in %arg0
+      @match -> @apply_op_config
       : (index) -> (!transform.any_op)
 
     transform.yield %res : !transform.any_op
@@ -302,8 +306,9 @@ module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_defa
 
   transform.named_sequence @__kernel_config(%arg0: !transform.any_op)
       -> (!transform.any_op) attributes { iree_codegen.tuning_spec_entrypoint } {
-     // expected-error @+1{{ForeachMatchOp must not have the 'restrict_root' attribute}}
-    %res = transform.foreach_match restrict_root in %arg0 @match -> @apply_op_config
+     // expected-error @+1{{'ForeachMatchOp' must not have 'restrict_root' attribute (required by 'iree_codegen.tuning_spec_with_default_entrypoint')}}
+    %res = transform.foreach_match restrict_root in %arg0
+      @match -> @apply_op_config
       : (!transform.any_op) -> (!transform.any_op)
 
     transform.yield %res : !transform.any_op
@@ -323,8 +328,9 @@ module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_defa
 
   transform.named_sequence @__kernel_config(%arg0: !transform.any_op)
       -> (!transform.any_op) attributes { iree_codegen.tuning_spec_entrypoint } {
-     // expected-error @+1{{ForeachMatchOp must not have the 'flatten_results' attribute}}
-    %res = transform.foreach_match flatten_results in %arg0 @match -> @apply_op_config
+     // expected-error @+1{{'ForeachMatchOp' must not have 'flatten_results' attribute (required by 'iree_codegen.tuning_spec_with_default_entrypoint')}}
+    %res = transform.foreach_match flatten_results in %arg0
+      @match -> @apply_op_config
       : (!transform.any_op) -> (!transform.any_op)
 
     transform.yield %res : !transform.any_op

--- a/compiler/src/iree/compiler/Codegen/Common/test/verify_tuning_specs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/verify_tuning_specs.mlir
@@ -103,3 +103,30 @@ module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_defa
       transform.yield %res_b : !transform.any_op
   }
 }
+
+// -----
+
+// expected-error @+1{{Expected exactly one NamedSequenceOp with the attribute 'iree_codegen.tuning_spec_entrypoint', but found 2}}
+module @iree_default_tuning_spec attributes { iree_codegen.tuning_spec_with_default_entrypoint } {
+  transform.named_sequence @match(%arg: !transform.any_op {transform.readonly}) -> (!transform.any_op) {
+      transform.yield %arg : !transform.any_op
+  }
+
+  transform.named_sequence @apply_op_config(%op: !transform.any_op {transform.readonly}) {
+      transform.yield
+  }
+
+  transform.named_sequence @__kernel_config(%arg0: !transform.any_op {transform.consumed})
+      -> (!transform.any_op) attributes { iree_codegen.tuning_spec_entrypoint } {
+
+      %res = transform.foreach_match in %arg0 @match -> @apply_op_config
+        : (!transform.any_op) -> (!transform.any_op)
+      transform.yield %res : !transform.any_op
+  }
+
+  transform.named_sequence @main(%arg0: !transform.any_op {transform.readonly}) -> !transform.any_op
+    attributes { iree_codegen.tuning_spec_entrypoint } {
+    transform.print {name = "Hello Tuning Spec", skip_regions}
+    transform.yield %arg0 : !transform.any_op
+  }
+}

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.cpp
@@ -74,9 +74,9 @@ IREECodegenDialect::verifyOperationAttribute(Operation *op,
   //   2. If the operation is a transform::NamedSequenceOp:
   //      - The operation's function signature must satisfy the following:
   //         a. It must have exactly one result type, and the result must be
-  //         of type `transform::AnyOpType`. b. It must have exactly one
-  //         argument type, and the argument must be of type
-  //         `transform::AnyOpType`.
+  //         of type `transform::AnyOpType`.
+  //         b. It must have exactly one argument type, and the argument must be
+  //         of type `transform::AnyOpType`.
 
   if (symbol == kTuningSpecDefaultEntrypointAttrName) {
     if (auto moduleOp = dyn_cast<ModuleOp>(op)) {

--- a/docs/website/docs/reference/tuning.md
+++ b/docs/website/docs/reference/tuning.md
@@ -124,7 +124,9 @@ that conform to the following format:
 * All entry points in the final tuning specs must either read
   (`transform.readonly`) or consume (`transform.consumed`) the argument.
 * The `iree_codegen.tuning_spec_with_default_entrypoint` attribute ensures that
-  the tuning spec includes a named sequence op with name `__kernel_config`.
+  the tuning spec includes a named sequence op with name `__kernel_config`, which
+  must contain exactly one `foreach_match` op. Furthermore, only one tuning spec
+  entry point is allowed, and it must be `__kernel_config` op.
 
 The tuning spec above attempts to match `linalg.generic` ops that correspond to the
 matmul operation with the RHS operand transposed (a.k.a. mmt) of shape

--- a/docs/website/docs/reference/tuning.md
+++ b/docs/website/docs/reference/tuning.md
@@ -125,8 +125,9 @@ that conform to the following format:
   (`transform.readonly`) or consume (`transform.consumed`) the argument.
 * The `iree_codegen.tuning_spec_with_default_entrypoint` attribute ensures that
   the tuning spec includes a named sequence op with name `__kernel_config`, which
-  must contain exactly one `foreach_match` op. Furthermore, only one tuning spec
-  entry point is allowed, and it must be `__kernel_config` op.
+  must contain exactly one `foreach_match` op. That `foreach_match` op must have
+  exactly one argument and one result of type any_op, and must not have
+  `flatten_results` and `restrict_root` attributes.
 
 The tuning spec above attempts to match `linalg.generic` ops that correspond to the
 matmul operation with the RHS operand transposed (a.k.a. mmt) of shape

--- a/docs/website/docs/reference/tuning.md
+++ b/docs/website/docs/reference/tuning.md
@@ -126,8 +126,7 @@ that conform to the following format:
 * The `iree_codegen.tuning_spec_with_default_entrypoint` attribute ensures that
   the tuning spec includes a named sequence op with name `__kernel_config`, which
   must contain exactly one `foreach_match` op. That `foreach_match` op must have
-  exactly one argument and one result of type any_op, and must not have
-  `flatten_results` and `restrict_root` attributes.
+  exactly one argument and one result of type any_op.
 
 The tuning spec above attempts to match `linalg.generic` ops that correspond to the
 matmul operation with the RHS operand transposed (a.k.a. mmt) of shape


### PR DESCRIPTION
This PR enhances the verification of the default attribute `iree_codegen.tuning_spec_with_default_entrypoint`.

- The `__kernel_config `named sequence operation must include the `iree_codegen.tuning_spec_entrypoint` attribute, on which the verification will be performed.

- The `__kernel_config` named sequence operation must contain only a single `foreach_match` operation.

