### PR TITLE
[ci] Clean up runner-env and runner-group tags.

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -152,7 +152,6 @@ jobs:
           # - runs-on:
           #     - ${{ github.repository == 'iree-org/iree' && 'self-hosted' || 'macos-14' }}
           #     - os-family=macOS
-          #     - runner-group=postsubmit
           - runs-on: macos-14
             build-family: macos
             build-package: py-compiler-pkg

--- a/.github/workflows/pkgci_build_packages.yml
+++ b/.github/workflows/pkgci_build_packages.yml
@@ -108,7 +108,6 @@ jobs:
 #   name: Linux Release Asserts (x86_64)
 #   runs-on:
 #     - self-hosted # must come first
-#     - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
 #     - environment=prod
 #     - cpu
 #     - os-family=Linux

--- a/.github/workflows/pkgci_test_nvidia_t4.yml
+++ b/.github/workflows/pkgci_test_nvidia_t4.yml
@@ -22,7 +22,6 @@ jobs:
     # TODO(#18238): migrate to new runner cluster
     runs-on:
       - self-hosted # must come first
-      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
       - environment=prod
       - gpu
       - os-family=Linux

--- a/.github/workflows/pkgci_test_onnx.yml
+++ b/.github/workflows/pkgci_test_onnx.yml
@@ -48,7 +48,6 @@ jobs:
           #   numprocesses: 4
           #   runs-on:
           #     - self-hosted # must come first
-          #     - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
           #     - environment=prod
           #     - gpu # TODO(scotttodd): qualify further with vendor/model
           #     - os-family=Linux
@@ -57,7 +56,6 @@ jobs:
           #   numprocesses: 4
           #   runs-on:
           #     - self-hosted # must come first
-          #     - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
           #     - environment=prod
           #     - gpu # TODO(scotttodd): qualify further with vendor/model
           #     - os-family=Linux

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -21,14 +21,6 @@ on:
         description: |
           Whether the workflow has been triggered by a pull request.
         value: ${{ jobs.setup.outputs.is-pr }}
-      runner-env:
-        description: |
-          The runner environment to use.
-        value: ${{ jobs.setup.outputs.runner-env }}
-      runner-group:
-        description: |
-          The runner group to use.
-        value: ${{ jobs.setup.outputs.runner-group }}
       write-caches:
         description: |
           Whether to write to caches.
@@ -47,8 +39,6 @@ jobs:
     outputs:
       enabled-jobs: ${{ steps.configure.outputs.enabled-jobs }}
       is-pr: ${{ steps.configure.outputs.is-pr }}
-      runner-env: ${{ steps.configure.outputs.runner-env }}
-      runner-group: ${{ steps.configure.outputs.runner-group }}
       write-caches: ${{ steps.configure.outputs.write-caches }}
     steps:
       - name: "Checking out repository"

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -62,7 +62,6 @@ class Trailer(str, enum.Enum):
     SKIP_JOBS = "ci-skip"
     EXTRA_JOBS = "ci-extra"
     EXACTLY_JOBS = "ci-exactly"
-    RUNNER_ENV = "runner-env"
 
     # Before Python 3.12, it the native __contains__ doesn't work for checking
     # member values like this and it's not possible to easily override this.
@@ -107,9 +106,6 @@ SKIP_PATH_PATTERNS = [
     "*AUTHORS",
     "*LICENSE",
 ]
-
-RUNNER_ENV_DEFAULT = "prod"
-RUNNER_ENV_OPTIONS = [RUNNER_ENV_DEFAULT, "testing"]
 
 CONTROL_JOB_REGEXES = frozenset(
     [
@@ -330,19 +326,6 @@ def modifies_non_skip_paths(paths: Optional[Iterable[str]]) -> bool:
     return any(not skip_path(p) for p in paths)
 
 
-def get_runner_env(trailers: Mapping[str, str]) -> str:
-    runner_env = trailers.get(Trailer.RUNNER_ENV)
-    if runner_env is None:
-        print(
-            f"Using '{RUNNER_ENV_DEFAULT}' runners because"
-            f" '{Trailer.RUNNER_ENV}' not found in {trailers}"
-        )
-        runner_env = RUNNER_ENV_DEFAULT
-    else:
-        print(f"Using runner environment '{runner_env}' from PR description trailers")
-    return runner_env
-
-
 def parse_jobs_trailer(
     trailers: Mapping[str, str], key: str, all_jobs: Set[str]
 ) -> Set[str]:
@@ -518,8 +501,6 @@ def main():
     output = {
         "enabled-jobs": json.dumps(sorted(enabled_jobs)),
         "is-pr": json.dumps(is_pr),
-        "runner-env": get_runner_env(trailers),
-        "runner-group": "presubmit" if is_pr else "postsubmit",
         "write-caches": "0" if is_pr else "1",
     }
 

--- a/docs/website/docs/developers/general/contributing.md
+++ b/docs/website/docs/developers/general/contributing.md
@@ -317,7 +317,6 @@ ci-skip: jobs,to,skip
 ci-extra: extra,jobs,to,run
 ci-exactly: exact,set,of,jobs,to,run
 skip-ci: free form reason
-runner-env: [testing|prod]
 ```
 
 ??? info - "Using `skip-ci`"
@@ -354,17 +353,6 @@ runner-env: [testing|prod]
     dependencies are satisfied. Thus, if you request skipping the
     `build_packages` job, all the jobs that depend on it will fail, not be
     skipped.
-
-??? info - "Using `runner-env`"
-
-    The `runner-env` option controls which runner environment to target for our
-    self-hosted runners. We maintain a test environment to allow testing out new
-    configurations prior to rolling them out. This trailer is for advanced users
-    who are working on the CI infrastructure itself.
-
-    ``` text
-    runner-env: [testing|prod]
-    ```
 
 ##### CI configuration recipes
 


### PR DESCRIPTION
These were used by the prior GCP runner cluster (https://github.com/iree-org/iree/issues/18238, https://github.com/iree-org/iree/issues/17893) but new self-hosted runners do not currently use them.