### PR TITLE
Workaround network issues on GPU cluster with new dockerfile.

### DIFF
--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -21,8 +21,7 @@ jobs:
   test_mi300:
     runs-on: linux-mi300-gpu-1
     container:
-      # TODO(#19955): switch from 'main' to a version hash once the first image is published
-      image: ghcr.io/iree-org/rocm_ubuntu_jammy@main
+      image: ghcr.io/iree-org/rocm_ubuntu_jammy@sha256:54aaf6cb8913a4c33c9504e19c393569e0eb64a8638659992c756a06275bf961
       options: --user root --device=/dev/kfd --device=/dev/dri --ipc=host --group-add video --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
     env:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -21,7 +21,8 @@ jobs:
   test_mi300:
     runs-on: linux-mi300-gpu-1
     container:
-      image: rocm/dev-ubuntu-22.04:6.3
+      # TODO(#19955): switch from 'main' to a version hash once the first image is published
+      image: ghcr.io/iree-org/rocm_ubuntu_jammy@main
       options: --user root --device=/dev/kfd --device=/dev/dri --ipc=host --group-add video --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
     env:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
@@ -35,16 +36,10 @@ jobs:
       IREE_HIP_ENABLE: 1
       IREE_HIP_TEST_TARGET_CHIP: "gfx942"
     steps:
-      - name: "Install dependencies"
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake ninja-build clang lld git
       - name: Check out repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: false
-      - name: "Mark git safe.directory"
-        run: git config --global --add safe.directory '*'
       - name: Check out runtime submodules
         run: ./build_tools/scripts/git/update_runtime_submodules.sh
       - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -39,6 +39,8 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: false
+      - name: "Mark git safe.directory"
+        run: git config --global --add safe.directory '*'
       - name: Check out runtime submodules
         run: ./build_tools/scripts/git/update_runtime_submodules.sh
       - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0


### PR DESCRIPTION
Fixes https://github.com/iree-org/iree/issues/19955.

This dockerfile extends the `rocm/dev-ubuntu-22.04:6.3` dockerfile with cmake, ninja, etc. (see https://github.com/iree-org/base-docker-images/pull/28). The base dockerfile includes much more than we needand this workflow should be able to run `apt get`, so I consider this version of the dockerfile a temporary workaround.

Test runs:
* https://github.com/iree-org/iree/actions/runs/13708926290/attempts/1?pr=20178 (success)
* https://github.com/iree-org/iree/actions/runs/13708926290/attempts/2?pr=20178 (flakes tracked at https://github.com/iree-org/iree/issues/20061)
* https://github.com/iree-org/iree/actions/runs/13708926290/attempts/3?pr=20178 (success)

ci-exactly: build_packages, test_amd_mi300