### PR TITLE
[hip] Add async allocations to the list of exportable buffer types.

### DIFF
--- a/runtime/src/iree/hal/drivers/hip/hip_allocator.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_allocator.c
@@ -772,6 +772,7 @@ static iree_status_t iree_hal_hip_allocator_export_buffer(
       switch (buffer_type) {
         case IREE_HAL_HIP_BUFFER_TYPE_DEVICE:
         case IREE_HAL_HIP_BUFFER_TYPE_EXTERNAL:
+        case IREE_HAL_HIP_BUFFER_TYPE_ASYNC:
           out_external_buffer->flags = requested_flags;
           out_external_buffer->type = requested_type;
           out_external_buffer->handle.device_allocation.ptr =


### PR DESCRIPTION
Async allocations are allocated the same way as normal device allocations, albeit in a different place. So this is equally valid.