### PR TITLE
Use caching_allocator for async allocation/deallocation in HIP

### DIFF
--- a/runtime/src/iree/hal/drivers/hip/hip_allocator.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_allocator.c
@@ -415,6 +415,10 @@ static void iree_hal_hip_buffer_free(
       IREE_TRACE_ZONE_APPEND_TEXT(z0, "(ignored; external)");
       break;
     }
+    case IREE_HAL_HIP_BUFFER_TYPE_WRAPPER: {
+      IREE_TRACE_ZONE_APPEND_TEXT(z0, "(ignored; wrapper)");
+      break;
+    }
   }
   IREE_TRACE_ZONE_END(z0);
 }
@@ -773,6 +777,7 @@ static iree_status_t iree_hal_hip_allocator_export_buffer(
         case IREE_HAL_HIP_BUFFER_TYPE_DEVICE:
         case IREE_HAL_HIP_BUFFER_TYPE_EXTERNAL:
         case IREE_HAL_HIP_BUFFER_TYPE_ASYNC:
+        case IREE_HAL_HIP_BUFFER_TYPE_WRAPPER:
           out_external_buffer->flags = requested_flags;
           out_external_buffer->type = requested_type;
           out_external_buffer->handle.device_allocation.ptr =

--- a/runtime/src/iree/hal/drivers/hip/hip_buffer.h
+++ b/runtime/src/iree/hal/drivers/hip/hip_buffer.h
@@ -26,6 +26,9 @@ typedef enum iree_hal_hip_buffer_type_e {
   // Externally registered buffer whose providence is unknown.
   // Must be freed by the user.
   IREE_HAL_HIP_BUFFER_TYPE_EXTERNAL,
+  // Wrapper of a device local buffer, allocated with
+  // hipMalloc/hipMallocManaged, freed with hipFree.
+  IREE_HAL_HIP_BUFFER_TYPE_WRAPPER,
 } iree_hal_hip_buffer_type_t;
 
 // Wraps a HIP allocation in an iree_hal_buffer_t.
@@ -64,5 +67,15 @@ void* iree_hal_hip_buffer_host_pointer(const iree_hal_buffer_t* buffer);
 // holding an allocation and the earliest the buffer could be destroyed is after
 // this call returns and the caller has released its reference.
 void iree_hal_hip_buffer_drop_release_callback(iree_hal_buffer_t* buffer);
+
+// Returns the HIP buffer wrapped by the given |base_buffer|, if the given
+// |base_buffer| is a wrapper.
+void iree_hal_hip_buffer_get_wrapped_buffer(iree_hal_buffer_t* base_buffer,
+                                            iree_hal_buffer_t** out_buffer);
+
+// Sets a HIP buffer to the given |base_buffer|, if the given |base_buffer|
+// is a hip buffer that wraps around another HIP buffer.
+void iree_hal_hip_buffer_set_wrapped_buffer(iree_hal_buffer_t* base_buffer,
+                                            iree_hal_buffer_t* wrapped_buffer);
 
 #endif  // IREE_HAL_DRIVERS_HIP_BUFFER_H_

--- a/runtime/src/iree/hal/drivers/hip/hip_buffer.h
+++ b/runtime/src/iree/hal/drivers/hip/hip_buffer.h
@@ -68,11 +68,6 @@ void* iree_hal_hip_buffer_host_pointer(const iree_hal_buffer_t* buffer);
 // this call returns and the caller has released its reference.
 void iree_hal_hip_buffer_drop_release_callback(iree_hal_buffer_t* buffer);
 
-// Returns the HIP buffer wrapped by the given |base_buffer|, if the given
-// |base_buffer| is a wrapper.
-void iree_hal_hip_buffer_get_wrapped_buffer(iree_hal_buffer_t* base_buffer,
-                                            iree_hal_buffer_t** out_buffer);
-
 // Sets a HIP buffer to the given |base_buffer|, if the given |base_buffer|
 // is a hip buffer that wraps around another HIP buffer.
 void iree_hal_hip_buffer_set_wrapped_buffer(iree_hal_buffer_t* base_buffer,

--- a/runtime/src/iree/hal/drivers/hip/hip_device.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_device.c
@@ -981,7 +981,7 @@ void iree_hal_hip_async_buffer_release(void* user_data,
                                        struct iree_hal_buffer_t* buffer) {
   iree_hal_hip_device_t* device = (iree_hal_hip_device_t*)user_data;
   void* ptr = iree_hal_hip_buffer_device_pointer(buffer);
-  if (ptr) {
+  if (ptr && iree_hal_hip_allocator_isa(device->device_allocator)) {
     iree_hal_hip_allocator_free_async(device->device_allocator, buffer);
   }
 }
@@ -1008,7 +1008,11 @@ static iree_status_t iree_hal_hip_device_prepare_async_alloc(
   iree_status_t status = iree_hal_hip_buffer_wrap(
       placement, params.type, params.access, params.usage, allocation_size,
       /*byte_offset=*/0,
-      /*byte_length=*/allocation_size, IREE_HAL_HIP_BUFFER_TYPE_ASYNC,
+      /*byte_length=*/allocation_size,
+      iree_hal_hip_allocator_isa(
+          iree_hal_device_allocator((iree_hal_device_t*)device))
+          ? IREE_HAL_HIP_BUFFER_TYPE_ASYNC
+          : IREE_HAL_HIP_BUFFER_TYPE_WRAPPER,
       /*device_ptr=*/NULL, /*host_ptr=*/NULL, callback, device->host_allocator,
       &buffer);
 
@@ -1301,6 +1305,7 @@ static iree_status_t iree_hal_hip_device_semaphore_callback(
 typedef struct iree_hal_hip_device_semaphore_buffer_operation_callback_data_t {
   iree_hal_hip_semaphore_callback_data_t base;
   iree_hal_buffer_t* buffer;
+  iree_hal_buffer_params_t params;
   iree_hal_hip_device_semaphore_buffer_operation_type_t type;
 } iree_hal_hip_device_semaphore_buffer_operation_callback_data_t;
 
@@ -1333,15 +1338,27 @@ static iree_status_t iree_hal_hip_device_complete_buffer_operation(
 
   if (data->buffer &&
       data->type == IREE_HAL_HIP_DEVICE_SEMAPHORE_OPERATION_ASYNC_DEALLOC) {
-    int device_ordinal =
-        iree_math_count_trailing_zeros_u64(data->base.queue_affinity);
-    if (data->base.device->supports_memory_pools) {
-      status = iree_status_join(
-          status,
-          iree_hal_hip_memory_pools_deallocate(
-              &data->base.device->devices[device_ordinal].memory_pools,
-              data->base.device->devices[device_ordinal].hip_dispatch_stream,
-              data->buffer));
+    iree_hal_allocator_t* device_allocator =
+        iree_hal_device_allocator((iree_hal_device_t*)data->base.device);
+    bool is_hip_allocator = iree_hal_hip_allocator_isa(device_allocator);
+    if (is_hip_allocator) {
+      int device_ordinal =
+          iree_math_count_trailing_zeros_u64(data->base.queue_affinity);
+      if (data->base.device->supports_memory_pools) {
+        status = iree_status_join(
+            status,
+            iree_hal_hip_memory_pools_deallocate(
+                &data->base.device->devices[device_ordinal].memory_pools,
+                data->base.device->devices[device_ordinal].hip_dispatch_stream,
+                data->buffer));
+      }
+    } else {
+      iree_hal_buffer_t* buffer = NULL;
+      iree_hal_hip_buffer_get_wrapped_buffer(data->buffer, &buffer);
+      if (buffer != NULL) {
+        iree_hal_allocator_deallocate_buffer(device_allocator, buffer);
+        iree_hal_hip_buffer_set_wrapped_buffer(data->buffer, NULL);
+      }
     }
   }
 
@@ -1401,6 +1418,8 @@ static iree_status_t iree_hal_hip_device_perform_buffer_operation_now(
   IREE_TRACE_ZONE_BEGIN_NAMED(
       z3, "iree_hal_hip_device_perform_buffer_operation_now_launch_operation");
   if (iree_status_is_ok(status)) {
+    bool is_hip_allocator = iree_hal_hip_allocator_isa(
+        iree_hal_device_allocator((iree_hal_device_t*)device));
     switch (data->type) {
       case IREE_HAL_HIP_DEVICE_SEMAPHORE_OPERATION_ASYNC_ALLOC:
         if (device->supports_memory_pools) {
@@ -1409,12 +1428,26 @@ static iree_status_t iree_hal_hip_device_perform_buffer_operation_now(
               stream, iree_hal_buffer_allocation_size(data->buffer));
           break;
         }
-        status = iree_hal_hip_allocator_alloc_async(
+        if (is_hip_allocator) {
+          status = iree_hal_hip_allocator_alloc_async(
+              iree_hal_device_allocator((iree_hal_device_t*)device),
+              data->buffer);
+          break;
+        }
+        iree_hal_buffer_t* buffer = NULL;
+        iree_device_size_t allocation_size =
+            iree_hal_buffer_allocation_size(data->buffer);
+        iree_hal_buffer_params_t buffer_params = data->params;
+        status = iree_hal_allocator_allocate_buffer(
             iree_hal_device_allocator((iree_hal_device_t*)device),
-            data->buffer);
+            buffer_params, allocation_size, &buffer);
+        if (iree_status_is_ok(status)) {
+          iree_hal_hip_buffer_set_wrapped_buffer(data->buffer, buffer);
+        }
         break;
       case IREE_HAL_HIP_DEVICE_SEMAPHORE_OPERATION_ASYNC_DEALLOC: {
-        if (!data->base.device->supports_memory_pools && data->buffer) {
+        if (!data->base.device->supports_memory_pools && data->buffer &&
+            is_hip_allocator) {
           // If we support memory pools this free is done on the cleanup thread.
           status = iree_status_join(
               status, iree_hal_hip_allocator_free_async(
@@ -1513,9 +1546,7 @@ static iree_status_t iree_hal_hip_device_queue_alloca(
   queue_affinity = (uint64_t)1 << device_ordinal;
 
   iree_status_t status = iree_ok_status();
-  if (!iree_all_bits_set(params.type, IREE_HAL_MEMORY_TYPE_HOST_VISIBLE) &&
-      (device->supports_memory_pools ||
-       iree_hal_hip_allocator_isa(iree_hal_device_allocator(base_device)))) {
+  if (!iree_all_bits_set(params.type, IREE_HAL_MEMORY_TYPE_HOST_VISIBLE)) {
     iree_hal_buffer_t* buffer = NULL;
 
     status = iree_hal_hip_device_prepare_async_alloc(


### PR DESCRIPTION
Previously hip allocator maintains its own async allocation and free operation. This patch moves the calls to use allocation/deallocation in caching_allocator instead.

This patch creates a wrapped_buffer structure, where it captures the real underlying hal_buffer, which will be allocated and deallocated via caching_allocator. When using the buffer, instead of assuming it's a hip_buffer, we should check whether it's a wrapped_buffer and acquire the underlying buffer instead before any operation.

BUG: #20134