### PR TITLE
Switch test_mi300 workflow to a different runner label and remove Docker.

### DIFF
--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -41,6 +41,10 @@ jobs:
         with:
           # Must match the subset of versions built in pkgci_build_packages.
           python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install gh
       - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         if: ${{ inputs.artifact_run_id == '' }}
         with:

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -20,16 +20,11 @@ on:
 jobs:
   test_mi300:
     runs-on: linux-mi300-gpu-1
-    container:
-      image: ghcr.io/iree-org/rocm_ubuntu_jammy@sha256:54aaf6cb8913a4c33c9504e19c393569e0eb64a8638659992c756a06275bf961
-      options: --user root --device=/dev/kfd --device=/dev/dri --ipc=host --group-add video --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
     env:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
       BUILD_DIR: build-tests
       VENV_DIR: ${{ github.workspace }}/.venv
       GH_TOKEN: ${{ github.token }}
-      CC: clang
-      CXX: clang++
       IREE_CPU_DISABLE: 1
       IREE_VULKAN_DISABLE: 1
       IREE_CUDA_ENABLE: 0
@@ -40,8 +35,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: false
-      - name: "Mark git safe.directory"
-        run: git config --global --add safe.directory '*'
       - name: Check out runtime submodules
         run: ./build_tools/scripts/git/update_runtime_submodules.sh
       - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -44,6 +44,7 @@ jobs:
           # Must match the subset of versions built in pkgci_build_packages.
           python-version: "3.11"
       - name: Install dependencies
+        if: ${{ inputs.artifact_run_id != '' }}
         run: |
           sudo apt-get update
           sudo apt-get install gh

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -31,6 +31,8 @@ jobs:
       IREE_HIP_ENABLE: 1
       IREE_HIP_TEST_TARGET_CHIP: "gfx942"
     steps:
+      - name: Run rocminfo
+        run: rocminfo
       - name: Check out repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   test_mi300:
-    runs-on: linux-mi300-gpu-1
+    runs-on: linux-mi300-1gpu-ossci-iree-org
     env:
       PACKAGE_DOWNLOAD_DIR: ${{ github.workspace }}/.packages
       BUILD_DIR: build-tests


### PR DESCRIPTION
Another tentative fix for https://github.com/iree-org/iree/issues/19955.

The previously used runner label did not have ROCm installed or GPUs visible so we were forced to get that from a Dockerfile. With this we no longer need Docker in the workflow at all, including the changes from https://github.com/iree-org/iree/pull/20178 and https://github.com/iree-org/base-docker-images/pull/28). I can delete that dockerfile if this sticks.

Test runs:
* https://github.com/iree-org/iree/actions/runs/13726740244/attempts/1
* https://github.com/iree-org/iree/actions/runs/13726740244/attempts/2 (flakes tracked at https://github.com/iree-org/iree/issues/20061)
* https://github.com/iree-org/iree/actions/runs/13726740244/attempts/3

ci-exactly: build_packages, test_amd_mi300