### PR TITLE
Install gh as needed on self-hosted runners.

### DIFF
--- a/.github/workflows/pkgci_regression_test.yml
+++ b/.github/workflows/pkgci_regression_test.yml
@@ -75,7 +75,7 @@ jobs:
           name: linux_x86_64_release_packages
           path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
       - name: Install gh
-        uses: actions4gh/setup-gh@44a12005484c53be5bf51bebe8c985b4be8ba8de # v1.0.2
+        uses: ksivamuthu/actions-setup-gh-cli@c78dbed4be2f8d6133a14a9a597ee12fd4ed5c93 # v3
         if: ${{ inputs.artifact_run_id != '' }}
       - name: Setup venv
         run: |

--- a/.github/workflows/pkgci_regression_test.yml
+++ b/.github/workflows/pkgci_regression_test.yml
@@ -74,6 +74,11 @@ jobs:
         with:
           name: linux_x86_64_release_packages
           path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
+      - name: Install dependencies
+        if: ${{ inputs.artifact_run_id != '' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install gh
       - name: Setup venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \

--- a/.github/workflows/pkgci_regression_test.yml
+++ b/.github/workflows/pkgci_regression_test.yml
@@ -77,6 +77,10 @@ jobs:
       - name: Install gh
         uses: ksivamuthu/actions-setup-gh-cli@c78dbed4be2f8d6133a14a9a597ee12fd4ed5c93 # v3
         if: ${{ inputs.artifact_run_id != '' }}
+      - name: Check gh
+        run: |
+          which gh
+          gh --version
       - name: Setup venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \

--- a/.github/workflows/pkgci_regression_test.yml
+++ b/.github/workflows/pkgci_regression_test.yml
@@ -74,11 +74,9 @@ jobs:
         with:
           name: linux_x86_64_release_packages
           path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
-      - name: Install dependencies
+      - name: Install gh
+        uses: actions4gh/setup-gh@44a12005484c53be5bf51bebe8c985b4be8ba8de # v1.0.2
         if: ${{ inputs.artifact_run_id != '' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install gh
       - name: Setup venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \

--- a/.github/workflows/pkgci_regression_test.yml
+++ b/.github/workflows/pkgci_regression_test.yml
@@ -77,8 +77,8 @@ jobs:
       - name: Install dependencies
         if: ${{ inputs.artifact_run_id != '' }}
         run: |
-          apt-get update
-          apt-get install gh
+          sudo apt-get update
+          sudo apt-get install gh
       - name: Setup venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \

--- a/.github/workflows/pkgci_regression_test.yml
+++ b/.github/workflows/pkgci_regression_test.yml
@@ -77,8 +77,8 @@ jobs:
       - name: Install dependencies
         if: ${{ inputs.artifact_run_id != '' }}
         run: |
-          sudo apt-get update
-          sudo apt-get install gh
+          apt-get update
+          apt-get install gh
       - name: Setup venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \

--- a/.github/workflows/pkgci_test_amd_mi250.yml
+++ b/.github/workflows/pkgci_test_amd_mi250.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Install dependencies
         if: ${{ inputs.artifact_run_id != '' }}
         run: |
-          sudo apt-get update
-          sudo apt-get install gh
+          apt-get update
+          apt-get install gh
       - name: Setup base venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \

--- a/.github/workflows/pkgci_test_amd_mi250.yml
+++ b/.github/workflows/pkgci_test_amd_mi250.yml
@@ -48,11 +48,9 @@ jobs:
         with:
           name: linux_x86_64_release_packages
           path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
-      - name: Install dependencies
+      - name: Install gh
+        uses: actions4gh/setup-gh@44a12005484c53be5bf51bebe8c985b4be8ba8de # v1.0.2
         if: ${{ inputs.artifact_run_id != '' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install gh
       - name: Setup base venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \

--- a/.github/workflows/pkgci_test_amd_mi250.yml
+++ b/.github/workflows/pkgci_test_amd_mi250.yml
@@ -48,6 +48,11 @@ jobs:
         with:
           name: linux_x86_64_release_packages
           path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
+      - name: Install dependencies
+        if: ${{ inputs.artifact_run_id != '' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install gh
       - name: Setup base venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \

--- a/.github/workflows/pkgci_test_amd_mi250.yml
+++ b/.github/workflows/pkgci_test_amd_mi250.yml
@@ -49,7 +49,7 @@ jobs:
           name: linux_x86_64_release_packages
           path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
       - name: Install gh
-        uses: actions4gh/setup-gh@44a12005484c53be5bf51bebe8c985b4be8ba8de # v1.0.2
+        uses: ksivamuthu/actions-setup-gh-cli@c78dbed4be2f8d6133a14a9a597ee12fd4ed5c93 # v3
         if: ${{ inputs.artifact_run_id != '' }}
       - name: Setup base venv
         run: |

--- a/.github/workflows/pkgci_test_amd_mi250.yml
+++ b/.github/workflows/pkgci_test_amd_mi250.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Install dependencies
         if: ${{ inputs.artifact_run_id != '' }}
         run: |
-          apt-get update
-          apt-get install gh
+          sudo apt-get update
+          sudo apt-get install gh
       - name: Setup base venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -56,8 +56,8 @@ jobs:
       - name: Install dependencies
         if: ${{ inputs.artifact_run_id != '' }}
         run: |
-          apt-get update
-          apt-get install gh
+          sudo apt-get update
+          sudo apt-get install gh
       - name: Setup base venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -48,11 +48,9 @@ jobs:
         with:
           name: linux_x86_64_release_packages
           path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
-      - name: Install dependencies
+      - name: Install gh
+        uses: actions4gh/setup-gh@44a12005484c53be5bf51bebe8c985b4be8ba8de # v1.0.2
         if: ${{ inputs.artifact_run_id != '' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install gh
       - name: Setup base venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -53,6 +53,11 @@ jobs:
         with:
           name: linux_x86_64_release_packages
           path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
+      - name: Install dependencies
+        if: ${{ inputs.artifact_run_id != '' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install gh
       - name: Setup base venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -43,11 +43,6 @@ jobs:
         with:
           # Must match the subset of versions built in pkgci_build_packages.
           python-version: "3.11"
-      - name: Install dependencies
-        if: ${{ inputs.artifact_run_id != '' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install gh
       - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         if: ${{ inputs.artifact_run_id == '' }}
         with:

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -49,7 +49,7 @@ jobs:
           name: linux_x86_64_release_packages
           path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
       - name: Install gh
-        uses: actions4gh/setup-gh@44a12005484c53be5bf51bebe8c985b4be8ba8de # v1.0.2
+        uses: ksivamuthu/actions-setup-gh-cli@c78dbed4be2f8d6133a14a9a597ee12fd4ed5c93 # v3
         if: ${{ inputs.artifact_run_id != '' }}
       - name: Setup base venv
         run: |

--- a/.github/workflows/pkgci_test_amd_mi300.yml
+++ b/.github/workflows/pkgci_test_amd_mi300.yml
@@ -56,8 +56,8 @@ jobs:
       - name: Install dependencies
         if: ${{ inputs.artifact_run_id != '' }}
         run: |
-          sudo apt-get update
-          sudo apt-get install gh
+          apt-get update
+          apt-get install gh
       - name: Setup base venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \

--- a/.github/workflows/pkgci_test_amd_w7900.yml
+++ b/.github/workflows/pkgci_test_amd_w7900.yml
@@ -46,6 +46,11 @@ jobs:
         with:
           name: linux_x86_64_release_packages
           path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
+      - name: Install dependencies
+        if: ${{ inputs.artifact_run_id != '' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install gh
       - name: Setup base venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \

--- a/.github/workflows/pkgci_test_amd_w7900.yml
+++ b/.github/workflows/pkgci_test_amd_w7900.yml
@@ -47,7 +47,7 @@ jobs:
           name: linux_x86_64_release_packages
           path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
       - name: Install gh
-        uses: actions4gh/setup-gh@44a12005484c53be5bf51bebe8c985b4be8ba8de # v1.0.2
+        uses: ksivamuthu/actions-setup-gh-cli@c78dbed4be2f8d6133a14a9a597ee12fd4ed5c93 # v3
         if: ${{ inputs.artifact_run_id != '' }}
       - name: Setup base venv
         run: |

--- a/.github/workflows/pkgci_test_amd_w7900.yml
+++ b/.github/workflows/pkgci_test_amd_w7900.yml
@@ -49,8 +49,8 @@ jobs:
       - name: Install dependencies
         if: ${{ inputs.artifact_run_id != '' }}
         run: |
-          sudo apt-get update
-          sudo apt-get install gh
+          apt-get update
+          apt-get install gh
       - name: Setup base venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \

--- a/.github/workflows/pkgci_test_amd_w7900.yml
+++ b/.github/workflows/pkgci_test_amd_w7900.yml
@@ -49,8 +49,8 @@ jobs:
       - name: Install dependencies
         if: ${{ inputs.artifact_run_id != '' }}
         run: |
-          apt-get update
-          apt-get install gh
+          sudo apt-get update
+          sudo apt-get install gh
       - name: Setup base venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \

--- a/.github/workflows/pkgci_test_amd_w7900.yml
+++ b/.github/workflows/pkgci_test_amd_w7900.yml
@@ -46,11 +46,9 @@ jobs:
         with:
           name: linux_x86_64_release_packages
           path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
-      - name: Install dependencies
+      - name: Install gh
+        uses: actions4gh/setup-gh@44a12005484c53be5bf51bebe8c985b4be8ba8de # v1.0.2
         if: ${{ inputs.artifact_run_id != '' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install gh
       - name: Setup base venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \

--- a/.github/workflows/pkgci_test_onnx.yml
+++ b/.github/workflows/pkgci_test_onnx.yml
@@ -85,8 +85,8 @@ jobs:
       - name: Install dependencies
         if: ${{ inputs.artifact_run_id != '' }}
         run: |
-          apt-get update
-          apt-get install gh
+          sudo apt-get update
+          sudo apt-get install gh
       - name: Setup venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
@@ -175,8 +175,8 @@ jobs:
       - name: Install dependencies
         if: ${{ inputs.artifact_run_id != '' }}
         run: |
-          apt-get update
-          apt-get install gh
+          sudo apt-get update
+          sudo apt-get install gh
       - name: Setup venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \

--- a/.github/workflows/pkgci_test_onnx.yml
+++ b/.github/workflows/pkgci_test_onnx.yml
@@ -151,6 +151,7 @@ jobs:
           # TODO(#18238): migrate to new runner cluster
     env:
       VENV_DIR: ${{ github.workspace }}/venv
+      GH_TOKEN: ${{ github.token }}
       CONFIG_FILE_PATH: tests/external/iree-test-suites/onnx_models/${{ matrix.config-file }}
     steps:
       - name: Checking out IREE repository
@@ -162,6 +163,7 @@ jobs:
           # Must match the subset of versions built in pkgci_build_packages.
           python-version: "3.11"
       - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        if: ${{ inputs.artifact_run_id == '' }}
         with:
           name: linux_x86_64_release_packages
           path: ${{ env.PACKAGE_DOWNLOAD_DIR }}

--- a/.github/workflows/pkgci_test_onnx.yml
+++ b/.github/workflows/pkgci_test_onnx.yml
@@ -77,11 +77,9 @@ jobs:
         with:
           # Must match the subset of versions built in pkgci_build_packages.
           python-version: "3.11"
-      - name: Install dependencies
+      - name: Install gh
+        uses: actions4gh/setup-gh@44a12005484c53be5bf51bebe8c985b4be8ba8de # v1.0.2
         if: ${{ inputs.artifact_run_id != '' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install gh
       - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         if: ${{ inputs.artifact_run_id == '' }}
         with:
@@ -172,11 +170,9 @@ jobs:
         with:
           name: linux_x86_64_release_packages
           path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
-      - name: Install dependencies
+      - name: Install gh
+        uses: actions4gh/setup-gh@44a12005484c53be5bf51bebe8c985b4be8ba8de # v1.0.2
         if: ${{ inputs.artifact_run_id != '' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install gh
       - name: Setup venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \

--- a/.github/workflows/pkgci_test_onnx.yml
+++ b/.github/workflows/pkgci_test_onnx.yml
@@ -77,6 +77,11 @@ jobs:
         with:
           # Must match the subset of versions built in pkgci_build_packages.
           python-version: "3.11"
+      - name: Install dependencies
+        if: ${{ inputs.artifact_run_id != '' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install gh
       - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         if: ${{ inputs.artifact_run_id == '' }}
         with:
@@ -167,6 +172,11 @@ jobs:
         with:
           name: linux_x86_64_release_packages
           path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
+      - name: Install dependencies
+        if: ${{ inputs.artifact_run_id != '' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install gh
       - name: Setup venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \

--- a/.github/workflows/pkgci_test_onnx.yml
+++ b/.github/workflows/pkgci_test_onnx.yml
@@ -85,8 +85,8 @@ jobs:
       - name: Install dependencies
         if: ${{ inputs.artifact_run_id != '' }}
         run: |
-          sudo apt-get update
-          sudo apt-get install gh
+          apt-get update
+          apt-get install gh
       - name: Setup venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
@@ -175,8 +175,8 @@ jobs:
       - name: Install dependencies
         if: ${{ inputs.artifact_run_id != '' }}
         run: |
-          sudo apt-get update
-          sudo apt-get install gh
+          apt-get update
+          apt-get install gh
       - name: Setup venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \

--- a/.github/workflows/pkgci_test_onnx.yml
+++ b/.github/workflows/pkgci_test_onnx.yml
@@ -82,6 +82,11 @@ jobs:
         with:
           name: linux_x86_64_release_packages
           path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
+      - name: Install dependencies
+        if: ${{ inputs.artifact_run_id != '' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install gh
       - name: Setup venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
@@ -167,6 +172,11 @@ jobs:
         with:
           name: linux_x86_64_release_packages
           path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
+      - name: Install dependencies
+        if: ${{ inputs.artifact_run_id != '' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install gh
       - name: Setup venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \

--- a/.github/workflows/pkgci_test_onnx.yml
+++ b/.github/workflows/pkgci_test_onnx.yml
@@ -78,7 +78,7 @@ jobs:
           # Must match the subset of versions built in pkgci_build_packages.
           python-version: "3.11"
       - name: Install gh
-        uses: actions4gh/setup-gh@44a12005484c53be5bf51bebe8c985b4be8ba8de # v1.0.2
+        uses: ksivamuthu/actions-setup-gh-cli@c78dbed4be2f8d6133a14a9a597ee12fd4ed5c93 # v3
         if: ${{ inputs.artifact_run_id != '' }}
       - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         if: ${{ inputs.artifact_run_id == '' }}
@@ -171,7 +171,7 @@ jobs:
           name: linux_x86_64_release_packages
           path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
       - name: Install gh
-        uses: actions4gh/setup-gh@44a12005484c53be5bf51bebe8c985b4be8ba8de # v1.0.2
+        uses: ksivamuthu/actions-setup-gh-cli@c78dbed4be2f8d6133a14a9a597ee12fd4ed5c93 # v3
         if: ${{ inputs.artifact_run_id != '' }}
       - name: Setup venv
         run: |

--- a/.github/workflows/pkgci_test_onnx.yml
+++ b/.github/workflows/pkgci_test_onnx.yml
@@ -167,11 +167,6 @@ jobs:
         with:
           name: linux_x86_64_release_packages
           path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
-      - name: Install dependencies
-        if: ${{ inputs.artifact_run_id != '' }} && contains(matrix.name, 'cpu_llvm_task')
-        run: |
-          apt-get update
-          apt-get install gh
       - name: Setup venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \

--- a/.github/workflows/pkgci_test_onnx.yml
+++ b/.github/workflows/pkgci_test_onnx.yml
@@ -82,11 +82,6 @@ jobs:
         with:
           name: linux_x86_64_release_packages
           path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
-      - name: Install dependencies
-        if: ${{ inputs.artifact_run_id != '' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install gh
       - name: Setup venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \
@@ -173,10 +168,10 @@ jobs:
           name: linux_x86_64_release_packages
           path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
       - name: Install dependencies
-        if: ${{ inputs.artifact_run_id != '' }}
+        if: ${{ inputs.artifact_run_id != '' }} && contains(matrix.name, 'cpu_llvm_task')
         run: |
-          sudo apt-get update
-          sudo apt-get install gh
+          apt-get update
+          apt-get install gh
       - name: Setup venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \

--- a/.github/workflows/pkgci_test_sharktank.yml
+++ b/.github/workflows/pkgci_test_sharktank.yml
@@ -52,6 +52,11 @@ jobs:
         with:
           name: linux_x86_64_release_packages
           path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
+      - name: Install dependencies
+        if: ${{ inputs.artifact_run_id != '' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install gh
       - name: Setup venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \

--- a/.github/workflows/pkgci_test_sharktank.yml
+++ b/.github/workflows/pkgci_test_sharktank.yml
@@ -55,8 +55,8 @@ jobs:
       - name: Install dependencies
         if: ${{ inputs.artifact_run_id != '' }}
         run: |
-          apt-get update
-          apt-get install gh
+          sudo apt-get update
+          sudo apt-get install gh
       - name: Setup venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \

--- a/.github/workflows/pkgci_test_sharktank.yml
+++ b/.github/workflows/pkgci_test_sharktank.yml
@@ -55,8 +55,8 @@ jobs:
       - name: Install dependencies
         if: ${{ inputs.artifact_run_id != '' }}
         run: |
-          sudo apt-get update
-          sudo apt-get install gh
+          apt-get update
+          apt-get install gh
       - name: Setup venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \

--- a/.github/workflows/pkgci_test_sharktank.yml
+++ b/.github/workflows/pkgci_test_sharktank.yml
@@ -52,11 +52,9 @@ jobs:
         with:
           name: linux_x86_64_release_packages
           path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
-      - name: Install dependencies
+      - name: Install gh
+        uses: actions4gh/setup-gh@44a12005484c53be5bf51bebe8c985b4be8ba8de # v1.0.2
         if: ${{ inputs.artifact_run_id != '' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install gh
       - name: Setup venv
         run: |
           ./build_tools/pkgci/setup_venv.py ${VENV_DIR} \

--- a/.github/workflows/pkgci_test_sharktank.yml
+++ b/.github/workflows/pkgci_test_sharktank.yml
@@ -53,7 +53,7 @@ jobs:
           name: linux_x86_64_release_packages
           path: ${{ env.PACKAGE_DOWNLOAD_DIR }}
       - name: Install gh
-        uses: actions4gh/setup-gh@44a12005484c53be5bf51bebe8c985b4be8ba8de # v1.0.2
+        uses: ksivamuthu/actions-setup-gh-cli@c78dbed4be2f8d6133a14a9a597ee12fd4ed5c93 # v3
         if: ${{ inputs.artifact_run_id != '' }}
       - name: Setup venv
         run: |


### PR DESCRIPTION
Follow-up to https://github.com/iree-org/iree/pull/20190#issuecomment-2707153232, making more workflows support this method of running. Docs: https://iree.dev/developers/general/github-actions/#faster-iteration-on-pkgci-workflows.

Install instructions: https://github.com/cli/cli/blob/trunk/docs/install_linux.md , or https://github.com/actions4gh/setup-gh / https://github.com/ksivamuthu/actions-setup-gh-cli.

Some tests:

workflow | logs | notes
-- | -- | --
mi250 | https://github.com/iree-org/iree/actions/runs/13727467224 | success
onnx | https://github.com/iree-org/iree/actions/runs/13727633290 | failures to install on cpu runner... but better than nothing
regression test | https://github.com/iree-org/iree/actions/runs/13727663282 | <ul><li>failures to install on cpu runner... but better than nothing</li><li>503 error running `sudo apt-get update` on MI300 `smc300x-ccs-aus-GPUCC5A` machine too</li><li>mi308 `sudo: you do not exist in the passwd database`</li></ul>

skip-ci: skip while testing