### PR TITLE
Integrates/llvm 20250310: Bump to llvm/llvm-project@967ab7e

### DIFF
--- a/compiler/plugins/input/TOSA/InputConversion/test/apply_pdl_patterns_tosa.mlir
+++ b/compiler/plugins/input/TOSA/InputConversion/test/apply_pdl_patterns_tosa.mlir
@@ -41,16 +41,18 @@
 //       CHECK:       tosa.negate %[[RESULT]]
 
 func.func @mlp_invocation(%lhs: tensor<2x4xf32>, %rhs : tensor<4x8xf32>) -> tensor<2x8xf32> {
-  %lhs_shape = tosa.const_shape {value = dense<[1, 2, 4]> : tensor<3xindex>} : () -> !tosa.shape<3>
-  %rhs_shape = tosa.const_shape {value = dense<[1, 4, 8]> : tensor<3xindex>} : () -> !tosa.shape<3>
+  %lhs_shape = tosa.const_shape {values = dense<[1, 2, 4]> : tensor<3xindex>} : () -> !tosa.shape<3>
+  %rhs_shape = tosa.const_shape {values = dense<[1, 4, 8]> : tensor<3xindex>} : () -> !tosa.shape<3>
   %lhs_3D = tosa.reshape %lhs, %lhs_shape : (tensor<2x4xf32>, !tosa.shape<3>) -> tensor<1x2x4xf32>
   %rhs_3D = tosa.reshape %rhs, %rhs_shape : (tensor<4x8xf32>, !tosa.shape<3>) -> tensor<1x4x8xf32>
-  %0 = tosa.matmul %lhs_3D, %rhs_3D : (tensor<1x2x4xf32>, tensor<1x4x8xf32>) -> tensor<1x2x8xf32>
+  %azp0 = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
+  %bzp0 = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
+  %0 = tosa.matmul %lhs_3D, %rhs_3D, %azp0, %bzp0 : (tensor<1x2x4xf32>, tensor<1x4x8xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x2x8xf32>
   %1 = tosa.clamp %0 {
       min_val = 0.0 : f32, max_val = 3.4028235e+38 : f32}
       : (tensor<1x2x8xf32>) -> tensor<1x2x8xf32>
   %2 = tosa.negate %1 : (tensor<1x2x8xf32>) -> tensor<1x2x8xf32>
-  %result_shape = tosa.const_shape {value = dense<[2, 8]> : tensor<2xindex>} : () -> !tosa.shape<2>
+  %result_shape = tosa.const_shape {values = dense<[2, 8]> : tensor<2xindex>} : () -> !tosa.shape<2>
   %3 = tosa.reshape %2, %result_shape : (tensor<1x2x8xf32>, !tosa.shape<2>) -> tensor<2x8xf32>
   return %3 : tensor<2x8xf32>
 }

--- a/compiler/plugins/input/TOSA/InputConversion/test/convert_i48_to_i64.mlir
+++ b/compiler/plugins/input/TOSA/InputConversion/test/convert_i48_to_i64.mlir
@@ -23,9 +23,9 @@ func.func @test_other_types_not_converted(%arg0: tensor<2x2xi32>) -> tensor<2x2x
 // CHECK-LABEL: @test_attrs_converted
 func.func @test_attrs_converted() -> (i48, tensor<2xi48>) {
   // CHECK: %[[ARITH_C:.+]] = arith.constant 0 : i64
-  // CHECK: %[[TOSA_C:.+]] = "tosa.const"() <{value = dense<0> : tensor<2xi64>}> : () -> tensor<2xi64>
+  // CHECK: %[[TOSA_C:.+]] = "tosa.const"() <{values = dense<0> : tensor<2xi64>}> : () -> tensor<2xi64>
   // CHECK: return %[[ARITH_C]], %[[TOSA_C]] : i64, tensor<2xi64>
   %0 = "arith.constant"() {value = 0 : i48} : () -> i48
-  %1 = "tosa.const"() <{value = dense<0> : tensor<2xi48>}> : () -> tensor<2xi48>
+  %1 = "tosa.const"() <{values = dense<0> : tensor<2xi48>}> : () -> tensor<2xi48>
   return %0, %1 : i48, tensor<2xi48>
 }

--- a/compiler/plugins/input/TOSA/InputConversion/test/tosa.pdl.mlir
+++ b/compiler/plugins/input/TOSA/InputConversion/test/tosa.pdl.mlir
@@ -48,15 +48,19 @@ pdl.pattern @mlp : benefit(1) {
   %lhs = pdl.operand : %lhs_type
   %rhs_type = pdl.type
   %rhs = pdl.operand : %rhs_type
+  %zp_type = pdl.type
+  %azp0 = pdl.operand : %zp_type
+  %bzp0 = pdl.operand : %zp_type
   %matmul_type = pdl.type
   %min_fp = pdl.attribute = 0.0 : f32
   %max_fp = pdl.attribute
-  %matmul = pdl.operation "tosa.matmul"(%lhs, %rhs : !pdl.value, !pdl.value)
+  %matmul = pdl.operation "tosa.matmul"(%lhs, %rhs, %azp0, %bzp0 : !pdl.value, !pdl.value, !pdl.value, !pdl.value)
       -> (%matmul_type : !pdl.type)
   %element_type = pdl.type : f32
   pdl.apply_native_constraint "checkTensorElementType"(%lhs_type, %element_type : !pdl.type, !pdl.type)
   pdl.apply_native_constraint "checkTensorElementType"(%rhs_type, %element_type : !pdl.type, !pdl.type)
   pdl.apply_native_constraint "checkTensorElementType"(%matmul_type, %element_type : !pdl.type, !pdl.type)
+  pdl.apply_native_constraint "checkTensorElementType"(%zp_type, %element_type: !pdl.type, !pdl.type)
 
   %matmul_result = pdl.result 0 of %matmul
   %relu_type = pdl.type

--- a/compiler/plugins/target/CUDA/CUDATarget.cpp
+++ b/compiler/plugins/target/CUDA/CUDATarget.cpp
@@ -290,7 +290,7 @@ static LogicalResult linkObjects(Location loc, llvm::Module &module,
   // Ensure consistent target information.
   const llvm::Triple &targetTriple = targetMachine.getTargetTriple();
   module.setDataLayout(targetMachine.createDataLayout());
-  module.setTargetTriple(targetTriple.str());
+  module.setTargetTriple(targetTriple);
 
   auto specializationCallback = [&](llvm::Module &userModule) {
     // TODO(thomasraoux): inject __nvvm_reflect-style functions/globals for

--- a/compiler/plugins/target/LLVMCPU/LLVMCPUTarget.cpp
+++ b/compiler/plugins/target/LLVMCPU/LLVMCPUTarget.cpp
@@ -494,7 +494,7 @@ public:
 
     // Specialize the module to our target machine.
     llvmModule->setDataLayout(targetMachine->createDataLayout());
-    llvmModule->setTargetTriple(targetMachine->getTargetTriple().str());
+    llvmModule->setTargetTriple(targetMachine->getTargetTriple());
 
     // Dump just the codegen bitcode before linking and optimization.
     if (!options.dumpIntermediatesPath.empty()) {

--- a/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
@@ -276,10 +276,13 @@ void addIREEComprehensiveBufferizePasses(
 }
 
 void addConstantBufferizePasses(OpPassManager &funcPassManager) {
-  OneShotBufferizationOptions options;
+  bufferization::OneShotBufferizePassOptions options;
   options.copyBeforeWrite = true;
-  options.enforceAliasingInvariants = false;
-  options.opFilter.allowOperation(arith::ConstantOp::getOperationName());
+  options.bufferizeFunctionBoundaries = true;
+  // options.enforceAliasingInvariants = false;
+  // options.opFilter.allowOperation(arith::ConstantOp::getOperationName());
+  options.noAnalysisFuncFilter.push_back(
+      arith::ConstantOp::getOperationName().str());
   funcPassManager.addPass(bufferization::createOneShotBufferizePass(options));
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
@@ -276,13 +276,10 @@ void addIREEComprehensiveBufferizePasses(
 }
 
 void addConstantBufferizePasses(OpPassManager &funcPassManager) {
-  bufferization::OneShotBufferizePassOptions options;
+  OneShotBufferizationOptions options;
   options.copyBeforeWrite = true;
-  options.bufferizeFunctionBoundaries = true;
-  // options.enforceAliasingInvariants = false;
-  // options.opFilter.allowOperation(arith::ConstantOp::getOperationName());
-  options.noAnalysisFuncFilter.push_back(
-      arith::ConstantOp::getOperationName().str());
+  options.enforceAliasingInvariants = false;
+  options.opFilter.allowOperation(arith::ConstantOp::getOperationName());
   funcPassManager.addPass(bufferization::createOneShotBufferizePass(options));
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -975,7 +975,7 @@ void ConvertToLLVMPass::runOnOperation() {
     // TODO: doubtful that the "default" does what one want here, it is likely
     // better to use outerproduct.
     vector::populateVectorContractLoweringPatterns(
-        patterns, vector::VectorTransformsOptions());
+        patterns, vector::VectorContractLowering::Dot);
     vector::populateVectorMaskMaterializationPatterns(
         patterns, /*force32BitVectorIndices=*/false);
     vector::populateVectorMaskOpLoweringPatterns(patterns);
@@ -983,7 +983,7 @@ void ConvertToLLVMPass::runOnOperation() {
     // TODO: doubtful that the "default" does what one want here, it is likely
     // better to use shuffle.
     vector::populateVectorTransposeLoweringPatterns(
-        patterns, vector::VectorTransformsOptions());
+        patterns, vector::VectorTransposeLowering::EltWise);
     populateConvertArmNeon2dToIntrPatterns(patterns);
     if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -974,8 +974,9 @@ void ConvertToLLVMPass::runOnOperation() {
     vector::populateVectorInterleaveLoweringPatterns(patterns);
     // TODO: doubtful that the "default" does what one want here, it is likely
     // better to use outerproduct.
+    vector::VectorTransformsOptions defaultOptions;
     vector::populateVectorContractLoweringPatterns(
-        patterns, vector::VectorContractLowering::Dot);
+        patterns, defaultOptions.vectorContractLowering);
     vector::populateVectorMaskMaterializationPatterns(
         patterns, /*force32BitVectorIndices=*/false);
     vector::populateVectorMaskOpLoweringPatterns(patterns);
@@ -983,7 +984,7 @@ void ConvertToLLVMPass::runOnOperation() {
     // TODO: doubtful that the "default" does what one want here, it is likely
     // better to use shuffle.
     vector::populateVectorTransposeLoweringPatterns(
-        patterns, vector::VectorTransposeLowering::EltWise);
+        patterns, defaultOptions.vectorTransposeLowering);
     populateConvertArmNeon2dToIntrPatterns(patterns);
     if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       return signalPassFailure();

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVectorTransposeLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVectorTransposeLowering.cpp
@@ -68,8 +68,8 @@ void LLVMCPUVectorTransposeLoweringPass::runOnOperation() {
 
   RewritePatternSet patterns(ctx);
   vector::populateVectorToVectorCanonicalizationPatterns(patterns);
-  vector::populateVectorTransposeLoweringPatterns(patterns,
-                                                  vectorTransformOptions);
+  vector::populateVectorTransposeLoweringPatterns(
+      patterns, vectorTransformOptions.vectorTransposeLowering);
   vector::populateVectorTransposeNarrowTypeRewritePatterns(
       patterns, kNarrowTypeEmulationBenefit);
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVirtualVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUVirtualVectorLowering.cpp
@@ -70,7 +70,7 @@ void LLVMCPUVirtualVectorLoweringPass::runOnOperation() {
     vector::populateVectorToVectorCanonicalizationPatterns(patterns);
     vector::populateVectorGatherLoweringPatterns(patterns);
     vector::populateVectorContractLoweringPatterns(
-        patterns, vectorTransformOptions,
+        patterns, vectorTransformOptions.vectorContractLowering,
         /*benefit=*/1,
         /*disableOuterProductLowering=*/false);
     // This pattern will transform vector loads whose elements are used in a

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
@@ -1904,7 +1904,7 @@ module {
 
 // CHECK: #translation = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert, {enable_loop_peeling}>
 // CHECK-LABEL: @test_mod_vectorizing_strategy_peeling
-// CHECK-SAME: attributes {hal.executable.target = #executable_target_system_elf_x86_64_, translation_info = #translation}
+// CHECK-SAME: attributes {hal.executable.target = #executable_target_system_elf_x86_64, translation_info = #translation}
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
@@ -93,6 +93,9 @@ struct ConvertToNVVMPass final
     // Run Vector -> Vector transformations ahead of conversion to LLVM.
     {
       RewritePatternSet patterns(&getContext());
+      auto options =
+          vector::VectorTransformsOptions().setVectorTransformsOptions(
+              vector::VectorContractLowering::OuterProduct);
       populateVectorToSCFConversionPatterns(
           patterns, VectorTransferToSCFOptions().enableFullUnroll());
       populateDropSharedMemoryDeallocOpPatterns(patterns);
@@ -101,7 +104,7 @@ struct ConvertToNVVMPass final
       vector::populateVectorToVectorCanonicalizationPatterns(patterns);
       vector::populateVectorBroadcastLoweringPatterns(patterns);
       vector::populateVectorContractLoweringPatterns(
-          patterns, vector::VectorContractLowering::OuterProduct);
+          patterns, options.vectorContractLowering);
       vector::populateVectorMaskOpLoweringPatterns(patterns);
       // We currently always use 64 bit indices, thus ensure the bit width of
       // the mask compare is consistent.
@@ -111,7 +114,7 @@ struct ConvertToNVVMPass final
       // TODO: doubtful that the "default" does what one want here, it is likely
       // better to use something else.
       vector::populateVectorTransposeLoweringPatterns(
-          patterns, vector::VectorTransposeLowering::EltWise);
+          patterns, options.vectorTransposeLowering);
       vector::populateVectorTransferLoweringPatterns(patterns);
       arith::populateExpandBFloat16Patterns(patterns);
       if (failed(applyPatternsGreedily(m, std::move(patterns)))) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
@@ -101,9 +101,7 @@ struct ConvertToNVVMPass final
       vector::populateVectorToVectorCanonicalizationPatterns(patterns);
       vector::populateVectorBroadcastLoweringPatterns(patterns);
       vector::populateVectorContractLoweringPatterns(
-          patterns,
-          vector::VectorTransformsOptions().setVectorTransformsOptions(
-              vector::VectorContractLowering::OuterProduct));
+          patterns, vector::VectorContractLowering::OuterProduct);
       vector::populateVectorMaskOpLoweringPatterns(patterns);
       // We currently always use 64 bit indices, thus ensure the bit width of
       // the mask compare is consistent.
@@ -113,7 +111,7 @@ struct ConvertToNVVMPass final
       // TODO: doubtful that the "default" does what one want here, it is likely
       // better to use something else.
       vector::populateVectorTransposeLoweringPatterns(
-          patterns, vector::VectorTransformsOptions());
+          patterns, vector::VectorTransposeLowering::EltWise);
       vector::populateVectorTransferLoweringPatterns(patterns);
       arith::populateExpandBFloat16Patterns(patterns);
       if (failed(applyPatternsGreedily(m, std::move(patterns)))) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -159,6 +159,9 @@ struct ConvertToROCDLPass final
     // Run Vector -> Vector transformations ahead of conversion to LLVM.
     {
       RewritePatternSet patterns(&getContext());
+      auto options =
+          vector::VectorTransformsOptions().setVectorTransformsOptions(
+              vector::VectorContractLowering::OuterProduct);
       // These patterns only convert a subset of arith that target specific
       // rocdl intrinsics (e.g. fp8 conversions).
       StringRef chipset = getGPUTargetAttr(m).getArch();
@@ -191,7 +194,7 @@ struct ConvertToROCDLPass final
       vector::populateVectorInterleaveLoweringPatterns(patterns);
       vector::populateVectorInterleaveToShufflePatterns(patterns);
       vector::populateVectorContractLoweringPatterns(
-          patterns, vector::VectorContractLowering::OuterProduct);
+          patterns, options.vectorContractLowering);
       vector::populateVectorMaskOpLoweringPatterns(patterns);
       // We currently always use 64 bit indices, thus ensure the bit width of
       // the mask compare is consistent.
@@ -201,7 +204,7 @@ struct ConvertToROCDLPass final
       // TODO: doubtful that the "default" does what one want here, it is likely
       // better to use something else.
       vector::populateVectorTransposeLoweringPatterns(
-          patterns, vector::VectorTransposeLowering::EltWise);
+          patterns, options.vectorTransposeLowering);
       vector::populateVectorTransferLoweringPatterns(patterns);
       arith::populateExpandBFloat16Patterns(patterns);
       if (failed(applyPatternsGreedily(m, std::move(patterns)))) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -191,9 +191,7 @@ struct ConvertToROCDLPass final
       vector::populateVectorInterleaveLoweringPatterns(patterns);
       vector::populateVectorInterleaveToShufflePatterns(patterns);
       vector::populateVectorContractLoweringPatterns(
-          patterns,
-          vector::VectorTransformsOptions().setVectorTransformsOptions(
-              vector::VectorContractLowering::OuterProduct));
+          patterns, vector::VectorContractLowering::OuterProduct);
       vector::populateVectorMaskOpLoweringPatterns(patterns);
       // We currently always use 64 bit indices, thus ensure the bit width of
       // the mask compare is consistent.
@@ -203,7 +201,7 @@ struct ConvertToROCDLPass final
       // TODO: doubtful that the "default" does what one want here, it is likely
       // better to use something else.
       vector::populateVectorTransposeLoweringPatterns(
-          patterns, vector::VectorTransformsOptions());
+          patterns, vector::VectorTransposeLowering::EltWise);
       vector::populateVectorTransferLoweringPatterns(patterns);
       arith::populateExpandBFloat16Patterns(patterns);
       if (failed(applyPatternsGreedily(m, std::move(patterns)))) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
@@ -96,14 +96,16 @@ struct LLVMGPUVectorLoweringPass final
       // Lower high level vector operations like contract or multidim reduce ops
       // to lower level vector ops.
       RewritePatternSet contractLoweringPatterns(funcOp.getContext());
+      auto options =
+          vector::VectorTransformsOptions().setVectorTransformsOptions(
+              vector::VectorContractLowering::OuterProduct);
       vector::populateVectorTransferPermutationMapLoweringPatterns(
           contractLoweringPatterns);
       vector::TransposeOp::getCanonicalizationPatterns(contractLoweringPatterns,
                                                        funcOp.getContext());
       vector::populateVectorBroadcastLoweringPatterns(contractLoweringPatterns);
       vector::populateVectorContractLoweringPatterns(
-          contractLoweringPatterns,
-          vector::VectorContractLowering::OuterProduct);
+          contractLoweringPatterns, options.vectorContractLowering);
       contractLoweringPatterns.add<PromoteContractOperands>(
           funcOp->getContext());
       vector::populateVectorMaskOpLoweringPatterns(contractLoweringPatterns);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
@@ -103,8 +103,7 @@ struct LLVMGPUVectorLoweringPass final
       vector::populateVectorBroadcastLoweringPatterns(contractLoweringPatterns);
       vector::populateVectorContractLoweringPatterns(
           contractLoweringPatterns,
-          vector::VectorTransformsOptions().setVectorTransformsOptions(
-              vector::VectorContractLowering::OuterProduct));
+          vector::VectorContractLowering::OuterProduct);
       contractLoweringPatterns.add<PromoteContractOperands>(
           funcOp->getContext());
       vector::populateVectorMaskOpLoweringPatterns(contractLoweringPatterns);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVFinalVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVFinalVectorLowering.cpp
@@ -78,10 +78,12 @@ public:
                          .setVectorTransposeLowering(
                              vector::VectorTransposeLowering::EltWise);
       vector::populateVectorBroadcastLoweringPatterns(patterns);
-      vector::populateVectorContractLoweringPatterns(patterns, options);
+      vector::populateVectorContractLoweringPatterns(
+          patterns, options.vectorContractLowering);
       vector::populateVectorMultiReductionLoweringPatterns(
           patterns, vector::VectorMultiReductionLowering::InnerParallel);
-      vector::populateVectorTransposeLoweringPatterns(patterns, options);
+      vector::populateVectorTransposeLoweringPatterns(
+          patterns, options.vectorTransposeLowering);
       vector::populateVectorGatherLoweringPatterns(patterns);
       vector::populateVectorMaskOpLoweringPatterns(patterns);
       vector::CreateMaskOp::getCanonicalizationPatterns(patterns, context);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVInitialVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVInitialVectorLowering.cpp
@@ -420,10 +420,8 @@ public:
     // elementwise ops.
     {
       RewritePatternSet patterns(context);
-      auto options =
-          vector::VectorTransformsOptions().setVectorTransformsOptions(
-              vector::VectorContractLowering::ParallelArith);
-      vector::populateVectorContractLoweringPatterns(patterns, options);
+      vector::populateVectorContractLoweringPatterns(
+          patterns, vector::VectorContractLowering::ParallelArith);
       // The pattern can generate transpose ops. Try to fold it if possible to
       // avoid lowering them into extract/insert later.
       vector::TransposeOp::getCanonicalizationPatterns(patterns, context);
@@ -443,10 +441,8 @@ public:
     // to canonicalize/cancel.
     {
       RewritePatternSet patterns(context);
-      auto options =
-          vector::VectorTransformsOptions().setVectorTransposeLowering(
-              vector::VectorTransposeLowering::EltWise);
-      vector::populateVectorTransposeLoweringPatterns(patterns, options);
+      vector::populateVectorTransposeLoweringPatterns(
+          patterns, vector::VectorTransposeLowering::EltWise);
       vector::populateVectorShapeCastLoweringPatterns(patterns);
       if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
         return signalPassFailure();

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVInitialVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVInitialVectorLowering.cpp
@@ -420,8 +420,11 @@ public:
     // elementwise ops.
     {
       RewritePatternSet patterns(context);
+      auto options =
+          vector::VectorTransformsOptions().setVectorTransformsOptions(
+              vector::VectorContractLowering::ParallelArith);
       vector::populateVectorContractLoweringPatterns(
-          patterns, vector::VectorContractLowering::ParallelArith);
+          patterns, options.vectorContractLowering);
       // The pattern can generate transpose ops. Try to fold it if possible to
       // avoid lowering them into extract/insert later.
       vector::TransposeOp::getCanonicalizationPatterns(patterns, context);
@@ -441,8 +444,11 @@ public:
     // to canonicalize/cancel.
     {
       RewritePatternSet patterns(context);
+      auto options =
+          vector::VectorTransformsOptions().setVectorTransposeLowering(
+              vector::VectorTransposeLowering::EltWise);
       vector::populateVectorTransposeLoweringPatterns(
-          patterns, vector::VectorTransposeLowering::EltWise);
+          patterns, options.vectorTransposeLowering);
       vector::populateVectorShapeCastLoweringPatterns(patterns);
       if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
         return signalPassFailure();

--- a/compiler/src/iree/compiler/Dialect/HAL/Utils/LLVMLinkerUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Utils/LLVMLinkerUtils.cpp
@@ -51,7 +51,7 @@ LogicalResult linkBitcodeModule(
   // target attributes they won't be modified.
   auto bitcodeModule = std::move(bitcodeModuleValue.get());
   bitcodeModule->setDataLayout(targetMachine.createDataLayout());
-  bitcodeModule->setTargetTriple(targetMachine.getTargetTriple().str());
+  bitcodeModule->setTargetTriple(targetMachine.getTargetTriple());
 
   // Inject target-specific flags to specialize the bitcode prior to linking.
   if (specializationCallback) {

--- a/samples/custom_dispatch/cpu/mlp_plugin/mlp_tosa.mlir
+++ b/samples/custom_dispatch/cpu/mlp_plugin/mlp_tosa.mlir
@@ -46,16 +46,18 @@
 
 module @example attributes {hal.device.targets = [#cpu_target]} {
   func.func @mlp_invocation(%lhs: tensor<2x4xf32>, %rhs : tensor<4x8xf32>) -> tensor<2x8xf32> {
-    %lhs_shape = tosa.const_shape {value = dense<[1, 2, 4]> : tensor<3xindex>} : () -> !tosa.shape<3>
-    %rhs_shape = tosa.const_shape {value = dense<[1, 4, 8]> : tensor<3xindex>} : () -> !tosa.shape<3>
+    %lhs_shape = tosa.const_shape {values = dense<[1, 2, 4]> : tensor<3xindex>} : () -> !tosa.shape<3>
+    %rhs_shape = tosa.const_shape {values = dense<[1, 4, 8]> : tensor<3xindex>} : () -> !tosa.shape<3>
     %lhs_3D = tosa.reshape %lhs, %lhs_shape : (tensor<2x4xf32>, !tosa.shape<3>) -> tensor<1x2x4xf32>
     %rhs_3D = tosa.reshape %rhs, %rhs_shape : (tensor<4x8xf32>, !tosa.shape<3>) -> tensor<1x4x8xf32>
-    %0 = tosa.matmul %lhs_3D, %rhs_3D : (tensor<1x2x4xf32>, tensor<1x4x8xf32>) -> tensor<1x2x8xf32>
+    %azp0 = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
+    %bzp0 = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
+    %0 = tosa.matmul %lhs_3D, %rhs_3D, %azp0, %bzp0 : (tensor<1x2x4xf32>, tensor<1x4x8xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x2x8xf32>
     %1 = tosa.clamp %0 {
         min_val = 0.0 : f32, max_val = 3.4028235e+38 : f32}
         : (tensor<1x2x8xf32>) -> tensor<1x2x8xf32>
     %2 = tosa.negate %1 : (tensor<1x2x8xf32>) -> tensor<1x2x8xf32>
-    %result_shape = tosa.const_shape {value = dense<[2, 8]> : tensor<2xindex>} : () -> !tosa.shape<2>
+    %result_shape = tosa.const_shape {values = dense<[2, 8]> : tensor<2xindex>} : () -> !tosa.shape<2>
     %3 = tosa.reshape %2, %result_shape : (tensor<1x2x8xf32>, !tosa.shape<2>) -> tensor<2x8xf32>
     return %3 : tensor<2x8xf32>
   }

--- a/samples/custom_dispatch/cpu/mlp_plugin/mlp_tosa_spec.pdl.mlir
+++ b/samples/custom_dispatch/cpu/mlp_plugin/mlp_tosa_spec.pdl.mlir
@@ -49,15 +49,19 @@ pdl.pattern @mlp : benefit(1) {
   %rhs_type = pdl.type
   %lhs = pdl.operand : %lhs_type
   %rhs = pdl.operand : %rhs_type
+  %zp_type = pdl.type
+  %azp0 = pdl.operand : %zp_type
+  %bzp0 = pdl.operand : %zp_type
   %matmul_type = pdl.type
   %min_fp = pdl.attribute = 0.0 : f32
   %max_fp = pdl.attribute
-  %matmul = pdl.operation "tosa.matmul"(%lhs, %rhs : !pdl.value, !pdl.value)
+  %matmul = pdl.operation "tosa.matmul"(%lhs, %rhs, %azp0, %bzp0 : !pdl.value, !pdl.value, !pdl.value, !pdl.value)
       -> (%matmul_type : !pdl.type)
   %element_type = pdl.type : f32
   pdl.apply_native_constraint "checkTensorElementType"(%lhs_type, %element_type : !pdl.type, !pdl.type)
   pdl.apply_native_constraint "checkTensorElementType"(%rhs_type, %element_type : !pdl.type, !pdl.type)
   pdl.apply_native_constraint "checkTensorElementType"(%matmul_type, %element_type : !pdl.type, !pdl.type)
+  pdl.apply_native_constraint "checkTensorElementType"(%zp_type, %element_type: !pdl.type, !pdl.type)
   %matmul_result = pdl.result 0 of %matmul
   %relu_type = pdl.type
   %relu = pdl.operation "tosa.clamp"(%matmul_result : !pdl.value) {

--- a/tests/e2e/tosa_ops/const.mlir
+++ b/tests/e2e/tosa_ops/const.mlir
@@ -1,5 +1,5 @@
 func.func @tensor_float() {
-  %result = "tosa.const"() {value = dense<[-1.0, -0.5, 0.0, 1.0]> : tensor<4xf32>} : () -> tensor<4xf32>
+  %result = "tosa.const"() {values = dense<[-1.0, -0.5, 0.0, 1.0]> : tensor<4xf32>} : () -> tensor<4xf32>
   check.expect_almost_eq_const(%result, dense<[-1.0, -0.5, 0.0, 1.0]> : tensor<4xf32>) : tensor<4xf32>
   return
 }

--- a/tests/e2e/tosa_ops/gather.mlir
+++ b/tests/e2e/tosa_ops/gather.mlir
@@ -1,6 +1,6 @@
 func.func @gather_float() {
   %0 = arith.constant dense<[[[1.0, 2.0], [3.0, 4.0]]]> : tensor<1x2x2xf32>
-  %1 = "tosa.const"() { value = dense<[[1, 0]]> : tensor<1x2xi32> } : ()  -> (tensor<1x2xi32>)
+  %1 = "tosa.const"() { values = dense<[[1, 0]]> : tensor<1x2xi32> } : ()  -> (tensor<1x2xi32>)
   %2 = tosa.gather %0, %1 : (tensor<1x2x2xf32>, tensor<1x2xi32>) -> tensor<1x2x2xf32>
   check.expect_eq_const(%2, dense<[[[3.0, 4.0], [1.0, 2.0]]]> : tensor<1x2x2xf32>) : tensor<1x2x2xf32>
   return
@@ -8,7 +8,7 @@ func.func @gather_float() {
 
 func.func @gather_int() {
   %0 = arith.constant dense<[[[1, 2], [3, 4]]]> : tensor<1x2x2xi32>
-  %1 = "tosa.const"() { value = dense<[[1, 0]]> : tensor<1x2xi32> } : ()  -> (tensor<1x2xi32>)
+  %1 = "tosa.const"() { values = dense<[[1, 0]]> : tensor<1x2xi32> } : ()  -> (tensor<1x2xi32>)
   %2 = tosa.gather %0, %1 : (tensor<1x2x2xi32>, tensor<1x2xi32>) -> tensor<1x2x2xi32>
   check.expect_eq_const(%2, dense<[[[3, 4], [1, 2]]]> : tensor<1x2x2xi32>) : tensor<1x2x2xi32>
   return

--- a/tests/e2e/tosa_ops/matmul.mlir
+++ b/tests/e2e/tosa_ops/matmul.mlir
@@ -1,7 +1,9 @@
 func.func @tensor_float() {
   %0 = util.unfoldable_constant dense<[[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]]> : tensor<2x2x3xf32>
   %1 = util.unfoldable_constant dense<[[[7.0], [8.0], [9.0]], [[7.0], [8.0], [9.0]]]> : tensor<2x3x1xf32>
-  %result = tosa.matmul %0, %1 : (tensor<2x2x3xf32>, tensor<2x3x1xf32>) -> tensor<2x2x1xf32>
+  %azp0 = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
+  %bzp0 = "tosa.const"() <{values = dense<0.0> : tensor<1xf32>}> : () -> tensor<1xf32>
+  %result = tosa.matmul %0, %1, %azp0, %bzp0 : (tensor<2x2x3xf32>, tensor<2x3x1xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<2x2x1xf32>
   check.expect_eq_const(%result, dense<[[[50.0], [122.0]], [[50.0], [122.0]]]> : tensor<2x2x1xf32>) : tensor<2x2x1xf32>
   return
 }
@@ -9,7 +11,9 @@ func.func @tensor_float() {
 func.func @tensor_int() {
   %0 = util.unfoldable_constant dense<[[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]]> : tensor<2x2x3xi32>
   %1 = util.unfoldable_constant dense<[[[7], [8], [9]], [[7], [8], [9]]]> : tensor<2x3x1xi32>
-  %result = tosa.matmul %0, %1 : (tensor<2x2x3xi32>, tensor<2x3x1xi32>) -> tensor<2x2x1xi32>
+  %azp0 = "tosa.const"() <{values = dense<0> : tensor<1xi32>}> : () -> tensor<1xi32>
+  %bzp0 = "tosa.const"() <{values = dense<0> : tensor<1xi32>}> : () -> tensor<1xi32>
+  %result = tosa.matmul %0, %1, %azp0, %bzp0 : (tensor<2x2x3xi32>, tensor<2x3x1xi32>, tensor<1xi32>, tensor<1xi32>) -> tensor<2x2x1xi32>
   check.expect_eq_const(%result, dense<[[[50], [122]], [[50], [122]]]> : tensor<2x2x1xi32>) : tensor<2x2x1xi32>
   return
 }

--- a/tests/e2e/tosa_ops/mul.mlir
+++ b/tests/e2e/tosa_ops/mul.mlir
@@ -1,7 +1,7 @@
 func.func @tensor_float() {
   %0 = util.unfoldable_constant dense<[1.0, 0.0, 3.0, 4.0]> : tensor<4xf32>
   %1 = util.unfoldable_constant dense<[5.0, 6.0, -3.0, 8.0]> : tensor<4xf32>
-  %shift = "tosa.const"() {value = dense<0> : tensor<1xi8>} : () -> tensor<1xi8>
+  %shift = "tosa.const"() {values = dense<0> : tensor<1xi8>} : () -> tensor<1xi8>
   %result = tosa.mul %0, %1, %shift : (tensor<4xf32>, tensor<4xf32>, tensor<1xi8>) -> tensor<4xf32>
   check.expect_almost_eq_const(%result, dense<[5.0, 0.0, -9.0, 32.0]> : tensor<4xf32>) : tensor<4xf32>
   return
@@ -10,7 +10,7 @@ func.func @tensor_float() {
 func.func @tensor_int() {
   %0 = util.unfoldable_constant dense<[1, 0, 3, 4]> : tensor<4xi32>
   %1 = util.unfoldable_constant dense<[5, 6, -3, 8]> : tensor<4xi32>
-  %shift = "tosa.const"() {value = dense<0> : tensor<1xi8>} : () -> tensor<1xi8>
+  %shift = "tosa.const"() {values = dense<0> : tensor<1xi8>} : () -> tensor<1xi8>
   %result = tosa.mul %0, %1, %shift : (tensor<4xi32>, tensor<4xi32>, tensor<1xi8>) -> tensor<4xi32>
   check.expect_eq_const(%result, dense<[5, 0, -9, 32]> : tensor<4xi32>) : tensor<4xi32>
   return

--- a/tests/e2e/tosa_ops/mul_shift.mlir
+++ b/tests/e2e/tosa_ops/mul_shift.mlir
@@ -5,7 +5,7 @@
 func.func @tensor_int_shifted() {
   %0 = util.unfoldable_constant dense<[1, 0, 3, 4, 4]> : tensor<5xi32>
   %1 = util.unfoldable_constant dense<[5, 6, -3, 8, 8]> : tensor<5xi32>
-  %shift = "tosa.const"() {value = dense<1> : tensor<1xi8>} : () -> tensor<1xi8>
+  %shift = "tosa.const"() {values = dense<1> : tensor<1xi8>} : () -> tensor<1xi8>
   %result = tosa.mul %0, %1, %shift : (tensor<5xi32>, tensor<5xi32>, tensor<1xi8>) -> tensor<5xi32>
   check.expect_eq_const(%result, dense<[3, 0, -4, 16, 16]> : tensor<5xi32>) : tensor<5xi32>
   return

--- a/tests/e2e/tosa_ops/pad.mlir
+++ b/tests/e2e/tosa_ops/pad.mlir
@@ -1,23 +1,26 @@
 func.func @pad_1D_test() {
     %0 = util.unfoldable_constant dense<42> : tensor<2xi32>
-    %1 = tosa.const_shape { value = dense<[3, 2]> : tensor<2xindex> } : ()  -> !tosa.shape<2>
-    %result = tosa.pad %0, %1 : (tensor<2xi32>, !tosa.shape<2>) -> (tensor<7xi32>)
+    %1 = tosa.const_shape { values = dense<[3, 2]> : tensor<2xindex> } : ()  -> !tosa.shape<2>
+    %cst = "tosa.const"() { values = dense<0> : tensor<1xi32> } : () -> tensor<1xi32>
+    %result = tosa.pad %0, %1, %cst : (tensor<2xi32>, !tosa.shape<2>, tensor<1xi32>) -> (tensor<7xi32>)
     check.expect_eq_const(%result, dense<[0, 0, 0, 42, 42, 0, 0]> : tensor<7xi32>) : tensor<7xi32>
     return
 }
 
 func.func @pad_2D_test() {
     %0 = util.unfoldable_constant dense<42> : tensor<2x2xi32>
-    %1 = tosa.const_shape { value = dense<[1, 1, 1, 1]> : tensor<4xindex> } : ()  -> !tosa.shape<4>
-    %result = tosa.pad %0, %1 : (tensor<2x2xi32>, !tosa.shape<4>) -> (tensor<4x4xi32>)
+    %1 = tosa.const_shape { values = dense<[1, 1, 1, 1]> : tensor<4xindex> } : ()  -> !tosa.shape<4>
+    %cst = "tosa.const"() { values = dense<0> : tensor<1xi32> } : () -> tensor<1xi32>
+    %result = tosa.pad %0, %1, %cst : (tensor<2x2xi32>, !tosa.shape<4>, tensor<1xi32>) -> (tensor<4x4xi32>)
     check.expect_eq_const(%result, dense<[[0, 0, 0, 0], [0, 42, 42, 0], [0, 42, 42, 0], [0, 0, 0, 0]]> : tensor<4x4xi32>) : tensor<4x4xi32>
     return
 }
 
 func.func @pad_3D_test() {
     %0 = util.unfoldable_constant dense<42> : tensor<1x1x2xi32>
-    %1 = tosa.const_shape { value = dense<[0, 1, 1, 0, 0, 0]> : tensor<6xindex> } : ()  -> !tosa.shape<6>
-    %result = tosa.pad %0, %1 : (tensor<1x1x2xi32>, !tosa.shape<6>) -> (tensor<2x2x2xi32>)
+    %1 = tosa.const_shape { values = dense<[0, 1, 1, 0, 0, 0]> : tensor<6xindex> } : ()  -> !tosa.shape<6>
+    %cst = "tosa.const"() { values = dense<0> : tensor<1xi32> } : () -> tensor<1xi32>
+    %result = tosa.pad %0, %1, %cst : (tensor<1x1x2xi32>, !tosa.shape<6>, tensor<1xi32>) -> (tensor<2x2x2xi32>)
     check.expect_eq_const(%result, dense<[[[0, 0], [42, 42]], [[0, 0], [0, 0]]]> : tensor<2x2x2xi32>) : tensor<2x2x2xi32>
     return
 }

--- a/tests/e2e/tosa_ops/reshape.mlir
+++ b/tests/e2e/tosa_ops/reshape.mlir
@@ -1,6 +1,6 @@
 func.func @tensor_downrank() {
   %0 = util.unfoldable_constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi32>
-  %1 = tosa.const_shape {value = dense<[4]> : tensor<1xindex>} : () -> !tosa.shape<1>
+  %1 = tosa.const_shape {values = dense<[4]> : tensor<1xindex>} : () -> !tosa.shape<1>
   %result = tosa.reshape %0, %1 : (tensor<2x2xi32>, !tosa.shape<1>) -> tensor<4xi32>
   check.expect_eq_const(%result, dense<[1, 2, 3, 4]> : tensor<4xi32>) : tensor<4xi32>
   return
@@ -8,7 +8,7 @@ func.func @tensor_downrank() {
 
 func.func @tensor_uprank() {
   %0 = util.unfoldable_constant dense<[1, 2, 3, 4]> : tensor<4xi32>
-  %1 = tosa.const_shape {value = dense<[2, 2]> : tensor<2xindex>} : () -> !tosa.shape<2>
+  %1 = tosa.const_shape {values = dense<[2, 2]> : tensor<2xindex>} : () -> !tosa.shape<2>
   %result = tosa.reshape %0, %1 : (tensor<4xi32>, !tosa.shape<2>) -> tensor<2x2xi32>
   check.expect_eq_const(%result, dense<[[1, 2], [3, 4]]> : tensor<2x2xi32>) : tensor<2x2xi32>
   return
@@ -16,7 +16,7 @@ func.func @tensor_uprank() {
 
 func.func @tensor_crossrank() {
   %0 = util.unfoldable_constant dense<[[1, 2, 3], [4, 5, 6]]> : tensor<2x3xi32>
-  %1 = tosa.const_shape {value = dense<[3, 2]> : tensor<2xindex>} : () -> !tosa.shape<2>
+  %1 = tosa.const_shape {values = dense<[3, 2]> : tensor<2xindex>} : () -> !tosa.shape<2>
   %result = tosa.reshape %0, %1 : (tensor<2x3xi32>, !tosa.shape<2>) -> tensor<3x2xi32>
   check.expect_eq_const(%result, dense<[[1, 2], [3, 4], [5, 6]]> : tensor<3x2xi32>) : tensor<3x2xi32>
   return

--- a/tests/e2e/tosa_ops/while.mlir
+++ b/tests/e2e/tosa_ops/while.mlir
@@ -10,12 +10,12 @@
 func.func @while_test_iter0() {
   %0 = util.unfoldable_constant dense<4> : tensor<i32>
   %1 = tosa.while_loop (%arg0 = %0) : (tensor<i32>) -> tensor<i32> {
-    %2 = "tosa.const"() <{value = dense<3> : tensor<i32>}> : () -> tensor<i32>
+    %2 = "tosa.const"() <{values = dense<3> : tensor<i32>}> : () -> tensor<i32>
     %3 = tosa.greater_equal %2, %arg0 : (tensor<i32>, tensor<i32>) -> tensor<i1>
     tosa.yield %3 : tensor<i1>
   } do {
   ^bb0(%arg0: tensor<i32>):
-    %2 = "tosa.const"() <{value = dense<2> : tensor<i32>}> : () -> tensor<i32>
+    %2 = "tosa.const"() <{values = dense<2> : tensor<i32>}> : () -> tensor<i32>
     %3 = tosa.add %arg0, %2 : (tensor<i32>, tensor<i32>) -> tensor<i32>
     tosa.yield %3 : tensor<i32>
   }
@@ -27,12 +27,12 @@ func.func @while_test_iter0() {
 func.func @while_test_iter1() {
   %0 = util.unfoldable_constant dense<2> : tensor<i32>
   %1 = tosa.while_loop (%arg0 = %0) : (tensor<i32>) -> tensor<i32> {
-    %2 = "tosa.const"() <{value = dense<3> : tensor<i32>}> : () -> tensor<i32>
+    %2 = "tosa.const"() <{values = dense<3> : tensor<i32>}> : () -> tensor<i32>
     %3 = tosa.greater_equal %2, %arg0 : (tensor<i32>, tensor<i32>) -> tensor<i1>
     tosa.yield %3 : tensor<i1>
   } do {
   ^bb0(%arg0: tensor<i32>):
-    %2 = "tosa.const"() <{value = dense<2> : tensor<i32>}> : () -> tensor<i32>
+    %2 = "tosa.const"() <{values = dense<2> : tensor<i32>}> : () -> tensor<i32>
     %3 = tosa.add %arg0, %2 : (tensor<i32>, tensor<i32>) -> tensor<i32>
     tosa.yield %3 : tensor<i32>
   }
@@ -44,12 +44,12 @@ func.func @while_test_iter1() {
 func.func @while_test_iter2() {
   %0 = util.unfoldable_constant dense<0> : tensor<i32>
   %1 = tosa.while_loop (%arg0 = %0) : (tensor<i32>) -> tensor<i32> {
-    %2 = "tosa.const"() <{value = dense<3> : tensor<i32>}> : () -> tensor<i32>
+    %2 = "tosa.const"() <{values = dense<3> : tensor<i32>}> : () -> tensor<i32>
     %3 = tosa.greater_equal %2, %arg0 : (tensor<i32>, tensor<i32>) -> tensor<i1>
     tosa.yield %3 : tensor<i1>
   } do {
   ^bb0(%arg0: tensor<i32>):
-    %2 = "tosa.const"() <{value = dense<2> : tensor<i32>}> : () -> tensor<i32>
+    %2 = "tosa.const"() <{values = dense<2> : tensor<i32>}> : () -> tensor<i32>
     %3 = tosa.add %arg0, %2 : (tensor<i32>, tensor<i32>) -> tensor<i32>
     tosa.yield %3 : tensor<i32>
   }
@@ -61,12 +61,12 @@ func.func @while_test_iter2() {
 func.func @while_test_iter4() {
   %0 = util.unfoldable_constant dense<0> : tensor<i32>
   %1 = tosa.while_loop (%arg0 = %0) : (tensor<i32>) -> tensor<i32> {
-    %2 = "tosa.const"() <{value = dense<3> : tensor<i32>}> : () -> tensor<i32>
+    %2 = "tosa.const"() <{values = dense<3> : tensor<i32>}> : () -> tensor<i32>
     %3 = tosa.greater_equal %2, %arg0 : (tensor<i32>, tensor<i32>) -> tensor<i1>
     tosa.yield %3 : tensor<i1>
   } do {
   ^bb0(%arg0: tensor<i32>):
-    %2 = "tosa.const"() <{value = dense<1> : tensor<i32>}> : () -> tensor<i32>
+    %2 = "tosa.const"() <{values = dense<1> : tensor<i32>}> : () -> tensor<i32>
     %3 = tosa.add %arg0, %2 : (tensor<i32>, tensor<i32>) -> tensor<i32>
     tosa.yield %3 : tensor<i32>
   }


### PR DESCRIPTION
bump to  llvm@[967ab7e08e62a35cc65f34e21fbeb00abf3eb83f](https://github.com/iree-org/llvm-project/commit/967ab7e08e62a35cc65f34e21fbeb00abf3eb83f)
create one revert commit@[c190c8d](https://github.com/iree-org/llvm-project/commit/c190c8df3a501b21f7f018ec3dd4293651736560)  to this PR https://github.com/llvm/llvm-project/pull/129850.
add the commit [@d80a859](https://github.com/iree-org/llvm-project/commit/d80a85942af26ebfa883054136eb664d13f2714b) to fix bazel test error. 


PR #129850 attempted to use TableGen to define OneShotBufferizePassOption for controlling the bufferization of all operations. However, it appears that the TableGen implementation does not yet fully support all the options available in the manually defined OneShotBufferizationOptions struct. 

For the usage of all the vector transformation options,  follow Jakub's suggestion below to  pick up the default values instead of setting them manually.

```c++
    VectorTransformsOptions defaultOptions;
    ...
    vector::populateVectorTransposeLoweringPatterns(
        patterns, defaultOptions.vectorTransposeLowering);
 ```