### PR TITLE
[ConstEval] Expand to parents of nested immediate root uses

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.cpp
@@ -56,6 +56,19 @@ bool ConstExprAnalysis::ConstValueInfo::hasNonAnalyzedConsumer() const {
   return false;
 }
 
+void ConstExprAnalysis::tryExpandToUseOrUseParent(Operation *definingOp,
+                                                  Operation *useOp) {
+  if (definingOp->getParentOp() != useOp->getParentOp()) {
+    auto parentOp = useOp->getParentOp();
+    if (parentOp && definingOp->getParentOp() == parentOp->getParentOp()) {
+      // expandToOp(useOp);
+      expandToOp(parentOp);
+    }
+    return;
+  }
+  expandToOp(useOp);
+}
+
 ConstExprAnalysis::ConstExprAnalysis(Operation *rootOp)
     : asmState(rootOp,
                OpPrintingFlags().elideLargeElementsAttrs().skipRegions()) {
@@ -111,12 +124,8 @@ ConstExprAnalysis::ConstExprAnalysis(Operation *rootOp)
   // its consumers.
   for (auto it : constantRoots) {
     Operation *constOp = it.second;
-    for (auto &use : constOp->getUses()) {
-      Operation *useOp = use.getOwner();
-      // For now ignore operations that are not in the same scope.
-      if (constOp->getParentOp() != useOp->getParentOp())
-        continue;
-      expandToOp(useOp);
+    for (Operation *user : constOp->getUsers()) {
+      tryExpandToUseOrUseParent(constOp, user);
     }
   }
 
@@ -173,19 +182,8 @@ ConstExprAnalysis::ConstExprAnalysis(Operation *rootOp)
         // And expand the frontier.
         Operation *definingOp = info->constValue.getDefiningOp();
         assert(definingOp && "const values should have defining op");
-        for (auto &use : definingOp->getUses()) {
-          Operation *useOp = use.getOwner();
-          // Skip expanding of ops within dispatch or nested regions.
-          if (definingOp->getParentOp() != useOp->getParentOp()) {
-            // check if we can expand to the parent op instead
-            if (auto parentOp = useOp->getParentOp()) {
-              if (definingOp->getParentOp() == parentOp->getParentOp()) {
-                expandToOp(parentOp);
-              }
-            }
-            continue;
-          }
-          expandToOp(useOp);
+        for (Operation *user : definingOp->getUsers()) {
+          tryExpandToUseOrUseParent(definingOp, user);
         }
       }
     }

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.cpp
@@ -61,7 +61,6 @@ void ConstExprAnalysis::tryExpandToUseOrUseParent(Operation *definingOp,
   if (definingOp->getParentOp() != useOp->getParentOp()) {
     auto parentOp = useOp->getParentOp();
     if (parentOp && definingOp->getParentOp() == parentOp->getParentOp()) {
-      // expandToOp(useOp);
       expandToOp(parentOp);
     }
     return;

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.h
@@ -153,6 +153,11 @@ private:
   void expandToOpStep(Operation *op,
                       SmallVectorImpl<Operation *> &expandWorklist);
 
+  // Try to expand to `useOp` if it is in the same scope as `definingOp`.
+  // Otherwise, expand to the parent of `useOp` if it is in the same scope
+  // as `definingOp`.
+  void tryExpandToUseOrUseParent(Operation *definingOp, Operation *useOp);
+
   // Add a new info record for a value to analyze for const-ness.
   ConstValueInfo *addInfo(Value constValue);
 

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals.mlir
@@ -336,15 +336,18 @@ module @do_not_hoist_non_value_type_results {
 
 // -----
 
-// CHECK-LABEL: @do_not_hoist_uses_within_dispatches
-module @do_not_hoist_uses_within_dispatches {
+// CHECK-LABEL: @hoist_root_consumer_dispatch
+module @hoist_root_consumer_dispatch {
+  // CHECK: util.global private @[[HOISTED_SYM:.+]] : tensor<i32>
+  // CHECK: util.initializer {
+  // CHECK:       flow.dispatch.region -> (tensor<i32>)
+  // CHECK:       util.return
+  // CHECK: }
+  // CHECK: util.func public @main
   util.func public @main() -> (tensor<i32>) {
-    // CHECK:   %[[CST:.+]] = arith.constant
-    // CHECK:   %[[RESULT:.+]] = flow.dispatch.region
-    // CHECK:     %[[SLICE:.+]] = tensor.extract_slice %[[CST]]
-    // CHECK:     flow.return %[[SLICE]]
-    // CHECK:   util.return %[[RESULT]]
     %cst = arith.constant dense<[2, 3]>: tensor<2xi32>
+    // CHECK: %[[VAL:.*]] = util.global.load immutable @[[HOISTED_SYM]] : tensor<i32>
+    // CHECK: util.return %[[VAL]]
     %result = flow.dispatch.region -> (tensor<i32>) {
       %slice = tensor.extract_slice %cst[0] [1] [1] : tensor<2xi32> to tensor<i32>
       flow.return %slice : tensor<i32>


### PR DESCRIPTION
This was done during worklist processing in https://github.com/iree-org/iree/pull/19062, but not for the immediate consumers of constant roots.

Also move the logic from worklist processing and root creation into a shared private function. Git blame shows that this logic has been mistakenly updated in only one of the two places twice now, so this will hopefully prevent this from happening in the future.