### PR TITLE
[AMDGPU] Test more math ops on ROCm: `erfc`, `log10`, `trunc`

### DIFF
--- a/tests/e2e/math/generate.py
+++ b/tests/e2e/math/generate.py
@@ -198,6 +198,10 @@ def get_math_op_info():
             kind=MathOpKind.UNARY_FLOAT,
             domain=lambda x: True,
         ),
+        "erfc": MathOpInfo(
+            kind=MathOpKind.UNARY_FLOAT,
+            domain=lambda x: True,
+        ),
         "exp": MathOpInfo(
             kind=MathOpKind.UNARY_FLOAT,
             domain=lambda x: True,
@@ -215,6 +219,10 @@ def get_math_op_info():
             domain=lambda x: True,
         ),
         "log": MathOpInfo(
+            kind=MathOpKind.UNARY_FLOAT,
+            domain=lambda x: x > 0,
+        ),
+        "log10": MathOpInfo(
             kind=MathOpKind.UNARY_FLOAT,
             domain=lambda x: x > 0,
         ),
@@ -262,6 +270,10 @@ def get_math_op_info():
             kind=MathOpKind.UNARY_FLOAT,
             domain=lambda x: True,
         ),
+        "trunc": MathOpInfo(
+            kind=MathOpKind.UNARY_FLOAT,
+            domain=lambda x: True,
+        ),
     }
 
 
@@ -275,6 +287,8 @@ def main(args):
     for testcase in testcases:
         op = testcase["op"]
         ops_not_yet_encountered.discard(op)
+        if "disabled" in testcase:
+            continue
         info = math_op_info[op]
         kind = info.kind
         type = testcase["type"]

--- a/tests/e2e/math/math_ops_llvm-cpu.json
+++ b/tests/e2e/math/math_ops_llvm-cpu.json
@@ -135,6 +135,11 @@
     "rtol": 1.0e-04
   },
   {
+    "op": "erfc",
+    "disabled": true,
+    "comment": "TODO(#20164): compilation failure"
+  },
+  {
     "op": "exp",
     "type": "f32",
     "atol": 1.0e-06,
@@ -193,6 +198,11 @@
     "type": "f16",
     "atol": 1.0e-04,
     "rtol": 1.0e-04
+  },
+  {
+    "op": "log10",
+    "disabled": true,
+    "comment": "TODO(#20165): linking failure"
   },
   {
     "op": "log1p",
@@ -340,5 +350,10 @@
     "type": "f16",
     "atol": 1.0e-03,
     "rtol": 1.0e-02
+  },
+  {
+    "op": "trunc",
+    "disabled": true,
+    "comment": "TODO(#20165): linking failure"
   }
 ]

--- a/tests/e2e/math/math_ops_rocm.json
+++ b/tests/e2e/math/math_ops_rocm.json
@@ -132,6 +132,18 @@
     "rtol": 0
   },
   {
+    "op": "erfc",
+    "type": "f32",
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
+  },
+  {
+    "op": "erfc",
+    "type": "f16",
+    "atol": 0,
+    "rtol": 0
+  },
+  {
     "op": "exp",
     "type": "f32",
     "atol": 1.0e-06,
@@ -187,6 +199,18 @@
   },
   {
     "op": "log",
+    "type": "f16",
+    "atol": 0,
+    "rtol": 0
+  },
+  {
+    "op": "log10",
+    "type": "f32",
+    "atol": 1.2e-07,
+    "rtol": 1.2e-07
+  },
+  {
+    "op": "log10",
     "type": "f16",
     "atol": 0,
     "rtol": 0
@@ -307,6 +331,18 @@
   },
   {
     "op": "tanh",
+    "type": "f16",
+    "atol": 0,
+    "rtol": 0
+  },
+  {
+    "op": "trunc",
+    "type": "f32",
+    "atol": 0,
+    "rtol": 0
+  },
+  {
+    "op": "trunc",
     "type": "f16",
     "atol": 0,
     "rtol": 0


### PR DESCRIPTION
These 3 math ops, `erfc`, `log10`, `trunc`, were initially left out because they fail to compile or to link on LLVM-CPU: https://github.com/iree-org/iree/issues/20164, https://github.com/iree-org/iree/issues/20165.

Thanks to the way that the e2e math tests are structured, it is now easy to test them on ROCm while leaving them out on CPU.