### PR TITLE
[ConstEval] Don't create ops with partially uninitialized ConstValueInfo

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.cpp
@@ -231,14 +231,27 @@ void ConstExprAnalysis::expandToOpStep(
       valueInfo = addInfo(result);
 
     // Update the producers first as we might early-return below.
-    for (auto producer : opInfo.producers) {
-      ConstValueInfo *producerInfo = constInfoMap.lookup(producer);
-      if (!producerInfo) {
-        // Create an unanalyzed value info as a placeholder. The info might be
-        // analyzed later if we are interested in it.
-        producerInfo = addInfo(producer);
+    for (Value producer : opInfo.producers) {
+      if (ConstValueInfo *producerInfo = constInfoMap.lookup(producer)) {
+        valueInfo->producers.insert(producerInfo);
+        continue;
       }
+      // Create an unanalyzed value info as a placeholder. The info might be
+      // analyzed later if we are interested in it.
+      ConstValueInfo *producerInfo = addInfo(producer);
       valueInfo->producers.insert(producerInfo);
+      // If the producer is a multi-result operation, then add ConstValueInfo
+      // for all of the op's results. This initialization ensures that no ops
+      // will have a mix of results with and without ConstValueInfo.
+      Operation *producerOp = producer.getDefiningOp();
+      if (!producerOp) {
+        continue;
+      }
+      for (Value producerOpResult : producerOp->getResults()) {
+        if (!constInfoMap.lookup(producerOpResult)) {
+          (void)addInfo(producer);
+        }
+      }
     }
 
     if (!opInfo.isEligible) {

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.cpp
@@ -249,7 +249,7 @@ void ConstExprAnalysis::expandToOpStep(
       }
       for (Value producerOpResult : producerOp->getResults()) {
         if (!constInfoMap.lookup(producerOpResult)) {
-          (void)addInfo(producer);
+          (void)addInfo(producerOpResult);
         }
       }
     }

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.h
@@ -40,8 +40,11 @@ public:
   }
 
   // Return const-expr info for an operation (or nullptr if unknown). Presently,
-  // an operation's results will either all be const-expr or not, so we just
-  // check the first. 0-result ops cannot be const-expr.
+  // an operation's results will either all be analyzed or not, but when they
+  // are not all analyzed, some of the operation's results may not have a
+  // ConstValueInfo. In this case, there is no real difference between having
+  // no ConstValueInfo and having an unanalyzed ConstValueInfo, so we just check
+  // the first result.
   const ConstValueInfo *lookup(Operation *queryOp) const {
     if (queryOp->getNumResults() == 0)
       return nullptr;

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/HoistIntoGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/HoistIntoGlobals.cpp
@@ -116,8 +116,9 @@ public:
           return WalkResult::advance();
         for (Value constExprResult : iterOp->getResults()) {
           auto *resultInfo = constExprs.lookup(constExprResult);
-          if (!resultInfo || policy.getDecision(resultInfo)->getOutcome() !=
-                                 ConstExprHoistingPolicy::ENABLE_HOIST) {
+          assert(resultInfo && "must have const-expr info");
+          if (policy.getDecision(resultInfo)->getOutcome() !=
+              ConstExprHoistingPolicy::ENABLE_HOIST) {
             continue;
           }
           if (failed(hoistConstExpr(constExprResult, hoistedMap, moduleSymbols,

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/HoistIntoGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/HoistIntoGlobals.cpp
@@ -116,9 +116,8 @@ public:
           return WalkResult::advance();
         for (Value constExprResult : iterOp->getResults()) {
           auto *resultInfo = constExprs.lookup(constExprResult);
-          assert(resultInfo && "must have const-expr info");
-          if (policy.getDecision(resultInfo)->getOutcome() !=
-              ConstExprHoistingPolicy::ENABLE_HOIST) {
+          if (!resultInfo || policy.getDecision(resultInfo)->getOutcome() !=
+                                 ConstExprHoistingPolicy::ENABLE_HOIST) {
             continue;
           }
           if (failed(hoistConstExpr(constExprResult, hoistedMap, moduleSymbols,

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals.mlir
@@ -445,3 +445,18 @@ module @nested_program_const_expr {
     }
   }
 }
+
+// -----
+
+// We may attach ConstValueInfo to some op results, but not others, in some
+// special cases. Ensure we do not crash on such cases.
+
+// CHECK-LABEL: @partially_analyzed_op
+module @partially_analyzed_op {
+  util.func public @main(%arg0: i32, %arg1: i32) -> (i32, i32) {
+    %cst = arith.constant 1 : i32
+    %barrier0:2 = util.optimization_barrier %arg0, %arg1 : i32, i32
+    %barrier1:2 = util.optimization_barrier %cst, %barrier0#0 : i32, i32
+    util.return %barrier1#0, %barrier1#1 : i32, i32
+  }
+}


### PR DESCRIPTION
HoistIntoGlobals asserted that any op with ConstValueInfo on one OpResult should have ConstValueInfo on all OpResults. This is was necessarily always true in some cases. For example:

```
util.func public @main(%arg0: i32, %arg1: i32) -> (i32, i32) {
  %cst = arith.constant 1 : i32
  %barrier0:2 = util.optimization_barrier %arg0, %arg1 : i32, i32
  %barrier1:2 = util.optimization_barrier %cst, %barrier0#0 : i32, i32
  util.return %barrier1#0, %barrier1#1 : i32, i32
}
```

In this case, we expand the analysis frontier to `%barrier1`, and we assign producers to each of its OpResults (`%cst` and `%barrier0#0`). However, since the op is known non-constant, we stop expanding the frontier for efficiency. This means that `%barrier0` will not be expanded, and its second OpResult will never be added to the analysis graph.

We don't want to sacrifice efficiency in cases where ops are known non-constant. We also need to attach producers to OpResults, even when its owner is known non-constant, because the information may be needed to find legal escapes of the producer.

This PR initializes ConstValueInfo on all results of producer operations when expending the analysis frontier, instead of just the consumed result. Initializing the ConstValueInfo does not affect the analysis, and protects against any op having a mix of initialized and uninitialized ConstValueInfo on its results.

fixes https://github.com/iree-org/iree/issues/20206