### PR TITLE
Fix build failure on GCC

### DIFF
--- a/compiler/src/iree/compiler/Utils/OptionUtils.h
+++ b/compiler/src/iree/compiler/Utils/OptionUtils.h
@@ -55,8 +55,7 @@ private:
     os << val;
   }
 
-  template <>
-  void prettyPrint<bool>(llvm::raw_ostream &os, bool &val) {
+  void prettyPrint(llvm::raw_ostream &os, bool &val) {
     os << (val ? "true" : "false");
   }
 };


### PR DESCRIPTION
Use function overload instead of explicit specialization to fix GCC error:

```
/__w/iree/iree/compiler/src/iree/compiler/Utils/OptionUtils.h:58:13: error: explicit specialization in non-namespace scope 'struct mlir::iree_compiler::opt_initializer<Ty>'
   58 |   template <>
      |          
```