### PR TITLE
[WIP] Fix transpose prop on generic contractions

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/SinkReshapes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SinkReshapes.cpp
@@ -169,6 +169,10 @@ void SinkReshapesPass::runOnOperation() {
                                                      shouldSinkExpandShapeOp);
   // Add patterns to fold `tensor.empty` and reshape ops.
   tensor::populateFoldTensorEmptyPatterns(sinkReshapePatterns);
+  tensor::CollapseShapeOp::getCanonicalizationPatterns(sinkReshapePatterns,
+                                                       context);
+  tensor::ExpandShapeOp::getCanonicalizationPatterns(sinkReshapePatterns,
+                                                     context);
   if (failed(applyPatternsGreedily(getOperation(),
                                    std::move(sinkReshapePatterns)))) {
     getOperation()->emitOpError("failed to sink reshape ops");

--- a/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/PropagateLinalgTranspose.cpp
@@ -508,12 +508,9 @@ public:
     }
     Value source = expandOp.getSrc();
     auto transposeOp = source.getDefiningOp<linalg::TransposeOp>();
-    // Do not propagate through reshapes if the transpose has multiple users, as
-    // this could end up duplicating the transposes. We should only propagate
-    // through reshape when it is free to do so.
-    if (!transposeOp || !transposeOp->hasOneUse()) {
+    if (!transposeOp) {
       return rewriter.notifyMatchFailure(
-          expandOp, "expand shape input is not a single-use transpose");
+          expandOp, "expand shape input is not a transpose");
     }
 
     auto invPerm = invertPermutationVector(transposeOp.getPermutation());
@@ -604,7 +601,7 @@ public:
     linalg::TransposeOp transposeOp;
     for (OpOperand *input : linalgOp.getDpsInputOperands()) {
       auto maybeTransposeOp = input->get().getDefiningOp<linalg::TransposeOp>();
-      if (maybeTransposeOp && maybeTransposeOp->hasOneUse()) {
+      if (maybeTransposeOp) {
         transposeOp = maybeTransposeOp;
         transposeOperand = input;
         break;

--- a/experimental/regression_suite/shark-test-suite-models/sdxl/test_clip.py
+++ b/experimental/regression_suite/shark-test-suite-models/sdxl/test_clip.py
@@ -92,7 +92,6 @@ ROCM_COMPILE_FLAGS = [
     "--iree-hal-target-backends=rocm",
     f"--iree-hip-target={rocm_chip}",
     "--iree-opt-level=O3",
-    "--iree-opt-generalize-matmul=false",
     "--iree-input-type=torch",
     "--iree-opt-const-eval=false",
     "--iree-hip-waves-per-eu=2",


### PR DESCRIPTION
Testing changes to transpose propagation to prevent regressions when generalizing matmuls

Dispatch formation changes are to get https://gist.github.com/IanWood1/671227ea27eee7f86b7635f55d2e8abe to fuse


There appears to be a ~2ms improvement for fp16 punet and ~1ms for f8 punet. 