### PR TITLE
[NFC] Trim redundant `iree-opt` from lit tests.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/dispatch_workgroups_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/dispatch_workgroups_folding.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --allow-unregistered-dialect --split-input-file --canonicalize --cse %s | iree-opt --allow-unregistered-dialect --split-input-file | FileCheck %s
+// RUN: iree-opt --allow-unregistered-dialect --split-input-file --canonicalize --cse %s | FileCheck %s
 
 // CHECK-LABEL: util.func public @dontInlineReadWrite
 // CHECK-SAME: (%[[ARG0:.+]]: tensor<1x4xf32>)

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/buffer_view_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/buffer_view_folding.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --canonicalize -cse %s | iree-opt --split-input-file | FileCheck %s
+// RUN: iree-opt --split-input-file --canonicalize -cse %s | FileCheck %s
 
 // CHECK-LABEL: @FoldBufferViewCreateSubspan
 // CHECK-SAME: (%[[BASE_BUFFER:.+]]: !hal.buffer, %[[SUBSPAN_OFFSET:.+]]: index, %[[SUBSPAN_LENGTH:.+]]: index)

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/command_buffer_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/command_buffer_folding.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --canonicalize %s | iree-opt --split-input-file | FileCheck %s
+// RUN: iree-opt --split-input-file --canonicalize %s | FileCheck %s
 
 // CHECK-LABEL: @skip_command_buffer_device
 // CHECK-SAME: (%[[DEVICE:.+]]: !hal.device, %[[AFFINITY:.+]]: i64)

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/device_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/device_folding.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --canonicalize %s | iree-opt --split-input-file | FileCheck %s
+// RUN: iree-opt --split-input-file --canonicalize %s | FileCheck %s
 
 // CHECK-LABEL: @ImmediatelyResolveDeviceQueueBarrier
 // CHECK-SAME: (%[[DEVICE:.+]]: !hal.device, %[[SIGNAL_FENCE:.+]]: !hal.fence)

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/executable_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/executable_folding.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --canonicalize %s | iree-opt --split-input-file | FileCheck %s
+// RUN: iree-opt --split-input-file --canonicalize %s | FileCheck %s
 
 // Tests that multiple constant blocks get merged into one.
 

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/fence_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/fence_folding.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --canonicalize %s | iree-opt --split-input-file | FileCheck %s
+// RUN: iree-opt --split-input-file --canonicalize %s | FileCheck %s
 
 // Tests that a fence with no timepoints gets turned into a null value.
 // This avoids the allocation and lets the null propagate through the rest of

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/tensor_op_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/tensor_op_folding.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --canonicalize -cse %s | iree-opt --split-input-file | FileCheck %s
+// RUN: iree-opt --split-input-file --canonicalize -cse %s | FileCheck %s
 
 // CHECK-LABEL: @foldTensorImportExport
 util.func public @foldTensorImportExport(%arg0: !hal.buffer_view) -> !hal.buffer_view {

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/async_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/async_folding.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --canonicalize=test-convergence=true %s | iree-opt --split-input-file | FileCheck %s
+// RUN: iree-opt --split-input-file --canonicalize=test-convergence=true %s | FileCheck %s
 
 // Ensures that the splat moves to the first common dominator of bb2/bb3.
 // We likely want to clone instead to reduce lifetime of the splats.

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/channel_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/channel_folding.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --canonicalize=test-convergence=true %s | iree-opt --split-input-file | FileCheck %s
+// RUN: iree-opt --split-input-file --canonicalize=test-convergence=true %s | FileCheck %s
 
 // CHECK-LABEL: @FoldChannelRankOp
 //  CHECK-SAME: (%[[RANK:.+]]: index)

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/cmd_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/cmd_folding.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --canonicalize %s | iree-opt --split-input-file | FileCheck %s
+// RUN: iree-opt --split-input-file --canonicalize %s | FileCheck %s
 
 // CHECK-LABEL: @FoldSubviewsIntoCmdTOp
 util.func private @FoldSubviewsIntoCmdTOp(%arg0: !stream.resource<transient>, %arg1: index) -> !stream.timepoint {

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/parameter_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/parameter_folding.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --canonicalize %s | iree-opt --split-input-file | FileCheck %s
+// RUN: iree-opt --split-input-file --canonicalize %s | FileCheck %s
 
 // CHECK-LABEL: @FoldParameterLoadTargetSubview
 // CHECK-SAME: (%[[WAIT:.+]]: !stream.timepoint, %[[OFFSET0:.+]]: index, %[[LENGTH0:.+]]: index, %[[OFFSET1:.+]]: index, %[[LENGTH1:.+]]: index)

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/resource_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/resource_folding.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --canonicalize %s | iree-opt --split-input-file | FileCheck %s
+// RUN: iree-opt --split-input-file --canonicalize %s | FileCheck %s
 
 // CHECK-LABEL: @FoldResourceSizeOp
 util.func private @FoldResourceSizeOp(%arg0: !stream.resource<staging>, %arg1: index) -> (index, i32) {

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/tensor_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/tensor_folding.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --canonicalize %s | iree-opt --split-input-file | FileCheck %s
+// RUN: iree-opt --split-input-file --canonicalize %s | FileCheck %s
 
 // CHECK-LABEL: @FoldTensorImportOp
 util.func private @FoldTensorImportOp(%arg0: !stream.resource<external>, %arg1: index) -> !stream.resource<external> {

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/alignment_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/alignment_folding.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --canonicalize --mlir-print-local-scope %s | iree-opt --split-input-file --mlir-print-local-scope | FileCheck %s
+// RUN: iree-opt --split-input-file --canonicalize --mlir-print-local-scope %s | FileCheck %s
 
 // CHECK-LABEL: @foldSameAlignment
 // CHECK-SAME: (%[[VALUE:.+]]: index, %[[ALIGNMENT:.+]]: index)

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/assignment_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/assignment_folding.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --canonicalize %s | iree-opt --split-input-file | FileCheck %s
+// RUN: iree-opt --split-input-file --canonicalize %s | FileCheck %s
 
 // CHECK-LABEL: @foldSwitchI32Nop
 util.func public @foldSwitchI32Nop(%arg0 : index) -> i32 {

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/assume_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/assume_folding.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --canonicalize %s | iree-opt --split-input-file | FileCheck %s
+// RUN: iree-opt --split-input-file --canonicalize %s | FileCheck %s
 
 // CHECK-LABEL: @already_canonical
 util.func public @already_canonical(%arg0 : index) -> index  {

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/buffer_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/buffer_folding.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --canonicalize %s | iree-opt --split-input-file | FileCheck %s
+// RUN: iree-opt --split-input-file --canonicalize %s | FileCheck %s
 
 // CHECK-LABEL: @FoldSubspansIntoSliceOp
 util.func public @FoldSubspansIntoSliceOp(%arg0: !util.buffer, %arg1: index, %arg2: index, %arg3: index) -> !util.buffer {

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/comparison_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/comparison_folding.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --canonicalize %s | iree-opt --split-input-file | FileCheck %s
+// RUN: iree-opt --split-input-file --canonicalize %s | FileCheck %s
 
 // CHECK-LABEL: @cmp_eq_same
 util.func @cmp_eq_same(%value: !util.buffer) -> i1 {

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/global_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/global_folding.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --canonicalize %s | iree-opt --split-input-file | FileCheck %s
+// RUN: iree-opt --split-input-file --canonicalize %s | FileCheck %s
 
 // CHECK: util.global private @v_initialized = dense<4> : tensor<4xi32>
 util.global private @v_initialized : tensor<4xi32>

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/range_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/range_folding.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --canonicalize %s | iree-opt --split-input-file | FileCheck %s
+// RUN: iree-opt --split-input-file --canonicalize %s | FileCheck %s
 
 // NOTE: util.range.min and util.range.max share their code so we just test min.
 

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/structural_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/structural_folding.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --canonicalize %s | iree-opt --split-input-file | FileCheck %s
+// RUN: iree-opt --split-input-file --canonicalize %s | FileCheck %s
 
 // CHECK-NOT: util.initializer
 util.initializer {

--- a/compiler/src/iree/compiler/Dialect/VM/IR/test/conversion_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/test/conversion_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file %s | iree-opt --split-input-file | FileCheck %s
+// RUN: iree-opt --split-input-file %s | FileCheck %s
 
 // CHECK-LABEL: @trunc
 vm.module @my_module {

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/test/ordinal_allocation.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/test/ordinal_allocation.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(vm.module(iree-vm-ordinal-allocation))" %s | FileCheck %s
 // check the parser for vm.module.ordinal_counts
-// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(vm.module(iree-vm-ordinal-allocation))" %s | iree-opt | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(vm.module(iree-vm-ordinal-allocation))" %s | FileCheck %s
 
 // CHECK-LABEL: @global_address_propagation
   // CHECK-SAME: attributes {ordinal_counts = #vm.ordinal_counts<

--- a/compiler/src/iree/compiler/Modules/Check/test/ops.mlir
+++ b/compiler/src/iree/compiler/Modules/Check/test/ops.mlir
@@ -1,6 +1,6 @@
 // Tests the printing/parsing of the Check dialect ops.
 
-// RUN: iree-opt --split-input-file %s | iree-opt --split-input-file | FileCheck %s
+// RUN: iree-opt --split-input-file %s | FileCheck %s
 
 // CHECK-LABEL: @expect_true
 // CHECK-SAME: %[[ARG:[a-zA-Z0-9$._-]+]]

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/IR/test/buffer_folding.mlir
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/IR/test/buffer_folding.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --canonicalize -cse %s | iree-opt --split-input-file | FileCheck %s
+// RUN: iree-opt --split-input-file --canonicalize -cse %s | FileCheck %s
 
 // CHECK-LABEL: @FoldBufferLengthOp
 // CHECK-SAME: (%[[LENGTH:.+]]: index)

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/IR/test/dispatch_folding.mlir
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/IR/test/dispatch_folding.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --canonicalize -cse %s | iree-opt --split-input-file | FileCheck %s
+// RUN: iree-opt --split-input-file --canonicalize -cse %s | FileCheck %s
 
 // CHECK-LABEL: @fold_binding_subspans_into_dispatch
 util.func public @fold_binding_subspans_into_dispatch(


### PR DESCRIPTION
The revision deletes the second `iree-opt` pipeline from the testing commands. It is generated by the following commands:

```bash
cd compiler/src/iree/compiler
sed -i -E 's/(iree-opt[^|]*\|)[^|]*\|/\1/' **/*_folding.mlir

cd Dialect/VM
sed -i -E 's/(iree-opt[^|]*\|)[^|]*\|/\1/' **/*.mlir

cd ../../Modules
sed -i -E 's/(iree-opt[^|]*\|)[^|]*\|/\1/' **/*.mlir
```