### PR TITLE
DNS - Eliminate encode tensor if the layout is identity.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -56,6 +56,7 @@ def EncodingAttr :
     IREEEncoding_Attr<"Encoding", [
       DeclareAttrInterfaceMethods<IREEEncoding_SerializableEncodingAttrInterface, [
         "isSerialized",
+        "isIdentityLayout",
         "cloneWithLayouts",
         "calculateStorageSizeInBytes",
       ]>
@@ -136,8 +137,10 @@ def EncodingAttr :
 //===---------------------------------------------------------------------===//
 
 def PadEncodingLayoutAttr : IREEEncoding_Attr<"PadEncodingLayout", [
-      DeclareAttrInterfaceMethods<IREEEncoding_SerializableEncodingAttrInterface,
-        ["calculateStorageSizeInBytes"]>
+      DeclareAttrInterfaceMethods<IREEEncoding_SerializableEncodingAttrInterface, [
+         "calculateStorageSizeInBytes",
+         "isIdentityLayout",
+        ]>
     ]> {
   let mnemonic = "pad_encoding_layout";
   let assemblyFormat = "`<` $padding `>`";

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
@@ -131,7 +131,6 @@ def IREEEncoding_SerializableEncodingAttrInterface :
       ),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
-        assert(false && "unimplemented interface method");
         return false;
       }]
     >,

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
@@ -123,6 +123,20 @@ def IREEEncoding_SerializableEncodingAttrInterface :
     >,
     InterfaceMethod<
       /*desc=*/[{
+        Returns true iff the layout is identity.
+      }],
+      /*retTy=*/"bool",
+      /*methodName=*/"isIdentityLayout",
+      /*args=*/(ins
+      ),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        assert(false && "unimplemented interface method");
+        return false;
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
         Creates an encoding with a new layout list. It is valid to drop any
         other optional parameters used in layout resolving, because they are
         already resolved and being attached to the encoding attribute.

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -1858,6 +1858,28 @@ LogicalResult TensorCloneOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// flow.tensor.encode
+//===----------------------------------------------------------------------===//
+
+LogicalResult TensorEncodeOp::verify() {
+  if (failed(verifyOpDynamicDims(getOperation(), {getOperand()},
+                                 getOperandDims())) ||
+      failed(verifyOpDynamicDims(getOperation(), {getResult()},
+                                 getOperandDims()))) {
+    return failure();
+  }
+  auto operandType = cast<RankedTensorType>(getOperand().getType());
+  if (operandType.getEncoding()) {
+    return emitOpError("the source operand type has encoding; not allowed");
+  }
+  auto resultType = cast<RankedTensorType>(getResult().getType());
+  if (operandType.dropEncoding() != resultType.dropEncoding()) {
+    return failure();
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // flow.tensor.barrier
 //===----------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -1508,6 +1508,39 @@ def FLOW_TensorCloneOp : FLOW_PureOp<"tensor.clone", [
   let hasFolder = 1;
 }
 
+// TODO(hanchung): Add folders.
+def FLOW_TensorEncodeOp : FLOW_PureOp<"tensor.encode", [
+  DeclareOpInterfaceMethods<Util_HoistableOpInterface>,
+  Util_ShapeAwareOp,
+]> {
+  let summary = [{performs a full tensor encode operation}];
+  let description = [{
+    Encode the input tensor into an encoded output tensor.
+  }];
+
+  let arguments = (ins
+    FLOW_Tensor:$operand,
+    FLOW_ShapeDynamicDims:$operand_dims
+  );
+  let results = (outs
+    FLOW_Tensor:$result
+  );
+
+  let assemblyFormat = [{
+    $operand `:` type($operand) (`{` $operand_dims^ `}`)? `->` type($result)
+    attr-dict-with-keyword
+  }];
+
+  let extraClassDeclaration = [{
+    bool isHoistableLeafOp() { return false; }
+
+    ValueRange getOperandDynamicDims(unsigned idx) { return getOperandDims(); }
+    ValueRange getResultDynamicDims(unsigned idx) { return getOperandDims(); }
+  }];
+
+  let hasVerifier = 1;
+}
+
 def FLOW_TensorBarrierOp : FLOW_PureOp<"tensor.barrier", [
   AllTypesMatch<["operand", "result"]>,
   DeclareOpInterfaceMethods<Util_HoistableOpInterface>,

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_ops.mlir
@@ -186,6 +186,32 @@ util.func public @tensorCloneDynamic(%arg0 : tensor<?x4xf32>) -> tensor<?x4xf32>
 
 // -----
 
+#encoding = #iree_encoding.testing_encoding<>
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.testing_encoding<>
+// CHECK-LABEL: @tensorEncodeStatic
+// CHECK-SAME:    %[[ARG0:.[a-zA-Z0-9]+]]
+util.func public @tensorEncodeStatic(%arg0 : tensor<4x4xf32>) -> tensor<4x4xf32, #encoding> {
+  // CHECK: %[[RES:.+]] = flow.tensor.encode %[[ARG0]] : tensor<4x4xf32> -> tensor<4x4xf32, #[[$ENCODING]]>
+  %0 = flow.tensor.encode %arg0 : tensor<4x4xf32> -> tensor<4x4xf32, #encoding>
+  util.return %0 : tensor<4x4xf32, #encoding>
+}
+
+// -----
+
+#encoding = #iree_encoding.testing_encoding<>
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.testing_encoding<>
+// CHECK-LABEL: @tensorEncodeDynamic
+// CHECK-SAME:    %[[ARG0:.[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG1:.[a-zA-Z0-9]+]]
+util.func public @tensorEncodeDynamic(%arg0 : tensor<?x4xf32>, %arg1 : index) -> tensor<?x4xf32, #encoding> {
+  // CHECK: %[[RES:.+]] = flow.tensor.encode %[[ARG0]] : tensor<?x4xf32>{%[[ARG1]]} -> tensor<?x4xf32, #[[$ENCODING]]>
+  %0 = flow.tensor.encode %arg0 : tensor<?x4xf32>{%arg1} -> tensor<?x4xf32, #encoding>
+  util.return %0 : tensor<?x4xf32, #encoding>
+}
+
+
+// -----
+
 // CHECK-LABEL: @tensorSlice
 util.func public @tensorSlice(%arg0 : tensor<4x4xf32>, %arg1 : index, %arg2 : index) -> tensor<2x2xf32> {
   // CHECK-NEXT: %0 = flow.tensor.slice %arg0[%arg1, %arg2 for %arg2, %arg1] : tensor<4x4xf32> -> tensor<2x2xf32>

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
@@ -237,6 +237,30 @@ struct ConvertTensorCloneOp
   }
 };
 
+struct ConvertTensorEncodeOp
+    : public AffinityOpConversionPattern<IREE::Flow::TensorEncodeOp> {
+  using AffinityOpConversionPattern::AffinityOpConversionPattern;
+  LogicalResult matchAndRewriteOnAffinity(
+      IREE::Flow::TensorEncodeOp op, OneToNOpAdaptor adaptor,
+      IREE::Stream::AffinityAttr executionAffinityAttr,
+      ConversionPatternRewriter &rewriter) const override {
+    auto operand = transferTensorOperands(op.getLoc(), op.getOperand(),
+                                          adaptor.getOperand(),
+                                          executionAffinityAttr, rewriter);
+    auto unknownType = rewriter.getType<IREE::Stream::ResourceType>();
+    auto resultSize =
+        buildResultSizeOf(op.getLoc(), op.getResult(), op.getOperandDims(),
+                          executionAffinityAttr, rewriter);
+    auto encodeOp = rewriter.create<IREE::Stream::TensorEncodeOp>(
+        op.getLoc(), unknownType, operand.resource, op.getOperand().getType(),
+        op.getOperandDims(), operand.resourceSize, op.getResult().getType(),
+        flattenValues(adaptor.getOperandDims()), resultSize,
+        executionAffinityAttr);
+    rewriter.replaceOpWithMultiple(op, {{encodeOp, operand.resourceSize}});
+    return success();
+  }
+};
+
 struct ConvertTensorBarrierOp
     : public AffinityOpConversionPattern<IREE::Flow::TensorBarrierOp> {
   using AffinityOpConversionPattern::AffinityOpConversionPattern;
@@ -1187,10 +1211,10 @@ void populateFlowToStreamConversionPatterns(
       ConvertTensorCastLikeOp<IREE::Flow::TensorReshapeOp>,
       ConvertTensorCastLikeOp<IREE::Flow::TensorBitCastOp>,
       ConvertTensorAllocaOp, ConvertTensorEmptyOp, ConvertTensorSplatOp,
-      ConvertTensorCloneOp, ConvertTensorBarrierOp, ConvertTensorTransferOp,
-      ConvertTensorSliceOp, ConvertTensorUpdateOp, ConvertTensorLoadOp,
-      ConvertTensorStoreOp, ConvertTensorTraceOp>(typeConverter, context,
-                                                  affinityAnalysis);
+      ConvertTensorCloneOp, ConvertTensorEncodeOp, ConvertTensorBarrierOp,
+      ConvertTensorTransferOp, ConvertTensorSliceOp, ConvertTensorUpdateOp,
+      ConvertTensorLoadOp, ConvertTensorStoreOp, ConvertTensorTraceOp>(
+      typeConverter, context, affinityAnalysis);
   patterns.insert<ConvertChannelDefaultOp>(typeConverter, context,
                                            affinityAnalysis);
   patterns.insert<ConvertChannelSplitOp, ConvertChannelRankOp,

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -1962,6 +1962,31 @@ LogicalResult TensorCloneOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// stream.tensor.encode
+//===----------------------------------------------------------------------===//
+
+LogicalResult TensorEncodeOp::verify() {
+  TensorEncodeOp op = *this;
+  auto sourceEncoding = llvm::cast<RankedTensorType>(op.getSourceEncoding());
+  if (sourceEncoding.getEncoding()) {
+    return op.emitOpError("expects no encodings on the source tensor");
+  }
+  auto resultEncoding = llvm::cast<RankedTensorType>(op.getResultEncoding());
+  if (!resultEncoding.getEncoding()) {
+    return op.emitOpError() << "expects an encoding on the result tensor";
+  }
+  if (failed(verifyOpDynamicDims(op, op.getSourceEncoding(),
+                                 op.getSourceEncodingDims())) ||
+      failed(verifyOpDynamicDims(op, op.getResultEncoding(),
+                                 op.getResultEncodingDims())) ||
+      failed(verifyOpValueSizes(op, op.getSource(), op.getSourceSize())) ||
+      failed(verifyOpValueSizes(op, op.getResult(), op.getResultSize()))) {
+    return failure();
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // stream.tensor.slice
 //===----------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -1430,6 +1430,60 @@ def Stream_TensorCloneOp : Stream_PureOp<"tensor.clone", [
   let hasFolder = 1;
 }
 
+// TODO(hanchung): Add folders.
+def Stream_TensorEncodeOp : Stream_PureOp<"tensor.encode", [
+  AttrSizedOperandSegments,
+  Stream_AffinityOp,
+  Stream_StreamableOp,
+  Stream_TensorPhaseOp,
+  Util_ShapeAwareOp,
+  Util_SizeAwareOp,
+]> {
+  let summary = [{Encodes the contents of a value}];
+  let description = [{
+    Elones the contents of a value at a snapshot in time. Future changes to the
+    identity encoding will not effect the result. Acts as a copy-on-write
+    operation. Otherwise, an executable for encoding the value is generated
+    during lowering.
+  }];
+
+  let arguments = (ins
+    Stream_AnyStreamResource:$source,
+    TypeAttr:$source_encoding,
+    Stream_ShapeDynamicDims:$source_encoding_dims,
+    Stream_Size:$source_size,
+    TypeAttr:$result_encoding,
+    Stream_ShapeDynamicDims:$result_encoding_dims,
+    Stream_Size:$result_size,
+    OptionalAttr<Stream_AffinityAttr>:$affinity
+  );
+  let results = (outs
+    Stream_AnyStreamResource:$result
+  );
+
+  let assemblyFormat = [{
+    (`on` `(` $affinity^ `)`)?
+    $source `:`
+    $source_encoding (`` `{` $source_encoding_dims^ `}`)?
+    `in`
+    type($source) `` `{` $source_size `}`
+    `->`
+    $result_encoding (`` `{` $result_encoding_dims^ `}`)?
+    `in`
+    type($result) `` `{` $result_size `}`
+    attr-dict-with-keyword
+  }];
+
+  let extraClassDeclaration = [{
+    ValueRange getOperandDynamicDims(unsigned idx) { return getSourceEncodingDims(); }
+    ValueRange getResultDynamicDims(unsigned idx) { return getResultEncodingDims(); }
+    Value getOperandSize(unsigned idx) { return getSourceSize(); }
+    Value getResultSize(unsigned idx) { return getResultSize(); }
+  }];
+
+  let hasVerifier = 1;
+}
+
 def Stream_TensorSliceOp : Stream_PureOp<"tensor.slice", [
   AttrSizedOperandSegments,
   Stream_AffinityOp,

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -1482,6 +1482,7 @@ def Stream_TensorEncodeOp : Stream_PureOp<"tensor.encode", [
   }];
 
   let hasVerifier = 1;
+  let hasFolder = 1;
 }
 
 def Stream_TensorSliceOp : Stream_PureOp<"tensor.slice", [

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/tensor_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/tensor_folding.mlir
@@ -206,3 +206,14 @@ util.func private @ElideUnneededTensorClones(%arg0: !stream.resource<*>, %arg1: 
   // CHECK: util.return %[[T1]]
   util.return %2 : f32
 }
+
+// -----
+
+#encoding = #iree_encoding.pad_encoding_layout<[0, 0]>
+// CHECK-LABEL: @FoldTensorEncodeOp
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]
+util.func private @FoldTensorEncodeOp(%arg0: !stream.resource<*>, %arg1: index) -> !stream.resource<*> {
+  %0 = stream.tensor.encode %arg0 : tensor<2x2xf32> in !stream.resource<*>{%arg1} -> tensor<2x2xf32, #encoding> in !stream.resource<*>{%arg1}
+  // CHECK:         util.return %[[SRC]]
+  util.return %0 : !stream.resource<*>
+}

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/tensor_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/tensor_ops.mlir
@@ -78,6 +78,17 @@ util.func private @tensorCloneWithEncoding(%arg0: !stream.resource<*>, %arg1: in
 
 // -----
 
+#encoding = #iree_encoding.testing_encoding<>
+// CHECK-DAG:   #[[$ENC:.+]] = #iree_encoding.testing_encoding<>
+// CHECK-LABEL: @tensorEncode
+util.func private @tensorEncode(%arg0: !stream.resource<*>, %arg1: index, %arg2: index) -> !stream.resource<*> {
+  // CHECK: = stream.tensor.encode %arg0 : tensor<?x4xf32>{%arg1} in !stream.resource<*>{%arg2} -> tensor<?x4xf32, #[[$ENC]]>{%arg1} in !stream.resource<*>{%arg2}
+  %0 = stream.tensor.encode %arg0 : tensor<?x4xf32>{%arg1} in !stream.resource<*>{%arg2} -> tensor<?x4xf32, #encoding>{%arg1} in !stream.resource<*>{%arg2}
+  util.return %0 : !stream.resource<*>
+}
+
+// -----
+
 // CHECK-LABEL: @tensorSlice
 util.func private @tensorSlice(%arg0: !stream.resource<*>, %arg1: index, %arg2: index, %arg3: index, %arg4: index) -> !stream.resource<*> {
   %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/BUILD.bazel
@@ -29,6 +29,7 @@ iree_compiler_cc_library(
         "LayoutSlices.cpp",
         "MaterializeBuiltins.cpp",
         "MaterializeCopyOnWrite.cpp",
+        "MaterializeEncodings.cpp",
         "PackConstants.cpp",
         "PackDispatchOperands.cpp",
         "Passes.cpp",

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/CMakeLists.txt
@@ -30,6 +30,7 @@ iree_cc_library(
     "LayoutSlices.cpp"
     "MaterializeBuiltins.cpp"
     "MaterializeCopyOnWrite.cpp"
+    "MaterializeEncodings.cpp"
     "PackConstants.cpp"
     "PackDispatchOperands.cpp"
     "Passes.cpp"

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeEncodings.cpp
@@ -1,0 +1,233 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Encoding/IR/EncodingOps.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowTypes.h"
+#include "iree/compiler/Dialect/Stream/IR/StreamOps.h"
+#include "iree/compiler/Dialect/Stream/IR/StreamTypes.h"
+#include "iree/compiler/Dialect/Stream/Transforms/Passes.h"
+#include "iree/compiler/Utils/StringUtils.h"
+#include "llvm/Support/Debug.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Arith/Utils/Utils.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/PatternMatch.h"
+
+namespace mlir::iree_compiler::IREE::Stream {
+
+#define GEN_PASS_DEF_MATERIALIZEENCODINGSPASS
+#include "iree/compiler/Dialect/Stream/Transforms/Passes.h.inc"
+
+namespace {
+struct MaterializeEncodingsPass
+    : public IREE::Stream::impl::MaterializeEncodingsPassBase<
+          MaterializeEncodingsPass> {
+  void runOnOperation() override;
+};
+
+} // namespace
+
+static std::string getDispatchFuncName(IREE::Stream::TensorEncodeOp encodeOp) {
+  std::string str;
+  llvm::raw_string_ostream os(str);
+  os << "encode_";
+  auto resultType = dyn_cast<RankedTensorType>(encodeOp.getResultEncoding());
+  for (auto dimSize : resultType.getShape()) {
+    if (ShapedType::isDynamic(dimSize)) {
+      os << "D";
+    } else {
+      os << std::to_string(dimSize);
+    }
+    os << "x";
+  }
+  resultType.getElementType().print(os);
+  return str;
+}
+
+static func::FuncOp createWorkgroupFunc(IREE::Stream::TensorEncodeOp encodeOp,
+                                        StringRef functionName) {
+  Location loc = encodeOp.getLoc();
+  MLIRContext *ctx = encodeOp.getContext();
+  SmallVector<Type> argumentTypes;
+  SmallVector<Location> argumentLocs;
+  auto bindingType = IREE::Stream::BindingType::get(ctx);
+  // Source
+  argumentTypes.push_back(bindingType);
+  argumentLocs.push_back(loc);
+  for (auto argument : encodeOp.getSourceEncodingDims()) {
+    Type argumentType = argument.getType();
+    if (!llvm::isa<IndexType>(argumentType)) {
+      argumentTypes.push_back(bindingType);
+      argumentLocs.push_back(loc);
+    } else {
+      argumentTypes.push_back(argumentType);
+      argumentLocs.push_back(argument.getLoc());
+    }
+  }
+  // Destination
+  argumentTypes.push_back(bindingType);
+  argumentLocs.push_back(loc);
+
+  // Build function type matching the region signature.
+  auto functionType =
+      FunctionType::get(encodeOp.getContext(), argumentTypes, /*results=*/{});
+
+  // Clone region into the function body.
+  auto funcOp = mlir::func::FuncOp::create(loc, functionName, functionType);
+
+  Block &block = funcOp.getBody().emplaceBlock();
+  block.addArguments(argumentTypes, argumentLocs);
+  OpBuilder builder(funcOp.getBody());
+
+  auto zero = builder.create<arith::ConstantIndexOp>(loc, 0);
+  int ordinalCount = 0;
+  SmallVector<Value> dynamicDims;
+  for (auto argument : block.getArguments()) {
+    if (!llvm::isa<IndexType>(argument.getType())) {
+      continue;
+    }
+    dynamicDims.push_back(builder.create<IREE::Flow::DispatchWorkloadOrdinalOp>(
+        loc, argument, builder.getIndexAttr(ordinalCount++)));
+  }
+  auto sourceType = IREE::Flow::DispatchTensorType::get(
+      IREE::Flow::TensorAccess::ReadOnly, encodeOp.getSourceEncoding());
+  Value source = builder.create<IREE::Stream::BindingSubspanOp>(
+      loc, sourceType, block.getArgument(0), zero, dynamicDims);
+  auto destinationType = IREE::Flow::DispatchTensorType::get(
+      IREE::Flow::TensorAccess::WriteOnly, encodeOp.getResultEncoding());
+  Value destination = builder.create<IREE::Stream::BindingSubspanOp>(
+      loc, destinationType, block.getArguments().back(), zero, dynamicDims);
+  Value value = builder.create<IREE::Flow::DispatchTensorLoadOp>(
+      loc, sourceType.asRankedTensorType(), source, dynamicDims);
+  value = builder.create<IREE::Encoding::SetEncodingOp>(
+      loc, destinationType.asRankedTensorType(), value);
+  builder.create<IREE::Flow::DispatchTensorStoreOp>(loc, value, destination,
+                                                    dynamicDims);
+  builder.create<func::ReturnOp>(loc);
+
+  return funcOp;
+}
+
+// TODO(hanchung): Refactor the function for better readability.
+static IREE::Stream::ExecutableOp
+createExecutableAndEntry(RewriterBase &rewriter,
+                         IREE::Stream::TensorEncodeOp encodeOp,
+                         int executableId) {
+
+  auto parentFuncOp = encodeOp->getParentOfType<FunctionOpInterface>();
+  ModuleOp parentModuleOp = parentFuncOp->getParentOfType<ModuleOp>();
+  OpBuilder parentModuleBuilder(&parentModuleOp.getBody()->back());
+  Location loc = encodeOp.getLoc();
+  std::string executableName = "__encoding_" + std::to_string(executableId);
+  auto executableOp = parentModuleBuilder.create<IREE::Stream::ExecutableOp>(
+      loc, executableName);
+
+  SmallVector<Type> workloadTypes;
+  SmallVector<Location> workloadLocs;
+  for (auto argument : encodeOp.getSourceEncodingDims()) {
+    Type argumentType = argument.getType();
+    if (!llvm::isa<IndexType>(argumentType)) {
+      continue;
+    }
+    workloadTypes.push_back(argumentType);
+    workloadLocs.push_back(argument.getLoc());
+  }
+
+  // Build the inner module and func op.
+  std::string funcName = executableName + "$" + getDispatchFuncName(encodeOp);
+  auto funcOp = createWorkgroupFunc(encodeOp, funcName);
+  {
+    OpBuilder builder(executableOp.getBody());
+    auto innerModule = builder.create<mlir::ModuleOp>(loc);
+    innerModule.push_back(funcOp);
+  }
+
+  executableOp.getOperation()->moveBefore(parentFuncOp);
+  executableOp.setPrivate();
+
+  // Add an export pointing at the entry point function.
+  OpBuilder builder2(executableOp.getBody());
+  auto exportOp = builder2.create<IREE::Stream::ExecutableExportOp>(
+      loc, funcOp.getName(), SymbolRefAttr::get(funcOp));
+  Block *block = builder2.createBlock(&exportOp.getWorkgroupCount(),
+                                      exportOp.getWorkgroupCount().end(),
+                                      workloadTypes, workloadLocs);
+  builder2.setInsertionPointToStart(block);
+  auto defaultCountOp =
+      builder2.create<IREE::Flow::DispatchWorkgroupCountFromSliceOp>(
+          loc, block->getArguments());
+  builder2.create<IREE::Stream::ReturnOp>(loc, defaultCountOp.getResults());
+
+  rewriter.setInsertionPoint(encodeOp);
+  Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  SmallVector<Value> operandOffsets = {zero};
+  SmallVector<Value> operandEnds = {encodeOp.getSourceSize()};
+  SmallVector<Value> operandLengths = {encodeOp.getSourceSize()};
+  SmallVector<Value> operands = {encodeOp.getSource()};
+  for (auto argument : encodeOp.getSourceEncodingDims()) {
+    operands.push_back(argument);
+  }
+
+  // TODO(hanchung): Add the builder to Stream::DispatchTensorOp that takes
+  // export op.
+  StringRef executableOpSymName =
+      exportOp->getParentOp()
+          ->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName())
+          .getValue();
+  auto entryPoint =
+      SymbolRefAttr::get(rewriter.getContext(), executableOpSymName,
+                         {SymbolRefAttr::get(exportOp)});
+
+  SmallVector<int64_t> tiedArguments = {
+      IREE::Util::TiedOpInterface::kUntiedIndex};
+
+  SmallVector<Value> dynamicDims;
+  for (Value argument : encodeOp.getSourceEncodingDims()) {
+    dynamicDims.push_back(argument);
+  }
+  SmallVector<OpFoldResult> workload = getMixedValues(
+      cast<RankedTensorType>(encodeOp.getSourceEncoding()).getShape(),
+      dynamicDims, rewriter.getContext());
+
+  rewriter.replaceOpWithNewOp<IREE::Stream::AsyncDispatchOp>(
+      encodeOp, encodeOp.getResult().getType(),
+      /*workload=*/dynamicDims, rewriter.getArrayAttr({entryPoint}), operands,
+      encodeOp.getSourceSize(), operandOffsets, operandEnds, operandLengths,
+      encodeOp.getResultSize(),
+      /*tied_operands=*/
+      cast<ArrayAttr>(rewriter.getIndexArrayAttr(tiedArguments)),
+      encodeOp.getAffinityAttr());
+
+  return executableOp;
+}
+
+void MaterializeEncodingsPass::runOnOperation() {
+  ModuleOp moduleOp = getOperation();
+  SmallVector<IREE::Stream::TensorEncodeOp> encodeOps;
+  moduleOp.walk(
+      [&](IREE::Stream::TensorEncodeOp op) { encodeOps.push_back(op); });
+  if (encodeOps.empty()) {
+    return;
+  }
+
+  // TODO(hanchung): Cache the executables and reuse for the same encodings.
+  MLIRContext *ctx = &getContext();
+  IRRewriter rewriter(ctx);
+  int executableId = 0;
+  for (auto encodeOp : encodeOps) {
+    (void)createExecutableAndEntry(rewriter, encodeOp, executableId++);
+  }
+}
+
+} // namespace mlir::iree_compiler::IREE::Stream

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
@@ -163,6 +163,11 @@ void buildStreamAsyncPassPipeline(OpPassManager &passManager,
       IREE::Stream::createEncodeDeviceTensorsPass());
 
   buildStreamCleanupPassPipeline(passManager, transformOptions);
+  passManager.addPass(IREE::Stream::createMaterializeEncodingsPass());
+  FunctionLikeNest(passManager)
+      // Standard MLIR cleanup.
+      .addPass(mlir::createCanonicalizerPass)
+      .addPass(mlir::createCSEPass);
 
   // Everything must now be in stream.async.* form but we don't yet have
   // lifetime assigned.

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.h
@@ -7,6 +7,7 @@
 #ifndef IREE_COMPILER_DIALECT_STREAM_TRANSFORMS_PASSES_H_
 #define IREE_COMPILER_DIALECT_STREAM_TRANSFORMS_PASSES_H_
 
+#include "iree/compiler/Dialect/Encoding/IR/EncodingDialect.h"
 #include "iree/compiler/Dialect/Stream/IR/StreamOps.h"
 #include "llvm/ADT/StringMap.h"
 #include "mlir/IR/BuiltinOps.h"

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
@@ -165,6 +165,20 @@ def MaterializeCopyOnWritePass :
   ];
 }
 
+def MaterializeEncodingsPass :
+    Pass<"iree-stream-materialize-encodings", "mlir::ModuleOp"> {
+  let summary = "Materialize stream.tensor.encode .";
+  let description = [{
+    TBD.
+  }];
+  let dependentDialects = [
+    "mlir::func::FuncDialect",
+    "IREE::Encoding::IREEEncodingDialect",
+    "IREE::Flow::FlowDialect",
+    "IREE::Stream::StreamDialect",
+  ];
+}
+
 def ElideAsyncCopiesPass :
     Pass<"iree-stream-elide-async-copies", "mlir::ModuleOp"> {
   let summary = "Elides copies when they are not performing meaningful work.";

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeEncodings.cpp
@@ -425,6 +425,10 @@ static bool hasRecognizedEncoding(ModuleOp moduleOp, SymbolTable symbolTable,
         return isRecognizedEncodingType(op.getTargetEncoding()) ||
                isRecognizedEncodingType(op.getUpdateEncoding());
       })
+      .Case<IREE::Stream::TensorEncodeOp>([&](auto op) {
+        return isRecognizedEncodingType(op.getSourceEncoding()) ||
+               isRecognizedEncodingType(op.getResultEncoding());
+      })
       .Default([](Operation *op) { return false; });
 }
 
@@ -757,10 +761,10 @@ LogicalResult StreamTensorOpUpdater::run() {
             .Case<IREE::Stream::TensorSizeOfOp>([&](auto op) {
               return updateTensorSizeOfOp(rewriter, op, layoutResolvers);
             })
-            .Case<IREE::Stream::TensorEmptyOp, IREE::Stream::TensorSplatOp>(
-                [&](auto op) {
-                  return updateResultEncoding(rewriter, op, layoutResolvers);
-                })
+            .Case<IREE::Stream::TensorEmptyOp, IREE::Stream::TensorSplatOp,
+                  IREE::Stream::TensorEncodeOp>([&](auto op) {
+              return updateResultEncoding(rewriter, op, layoutResolvers);
+            })
             .Case<IREE::Stream::TensorConstantOp>([&](auto op) {
               return updateTensorConstantOp(rewriter, op, layoutResolvers);
             })

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
@@ -182,6 +182,27 @@ util.func public @tensor_fill_op(%arg0: f32, %arg1: !stream.resource<*>, %arg2: 
 
 // -----
 
+#executable_target_vmvx_bytecode_fb = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {iree.encoding.resolver = #iree_encoding.unspecialized_encoding<123>}>
+#device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_vmvx_bytecode_fb]> : !hal.device
+#encoding = #iree_encoding.testing_encoding<>
+util.global private @device_a = #device_target_local_0_
+util.func public @tensor_encode_op(%arg0: !stream.resource<*>, %arg1: index, %arg2: index, %arg3: index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %0 = stream.tensor.encode on(#hal.device.affinity<@device_a>)
+    %arg0 : tensor<?x?xf32>{%arg2, %arg3} in !stream.resource<*>{%arg1}
+    -> tensor<?x?xf32, #encoding>{%arg2, %arg3} in !stream.resource<*>{%arg1}
+  util.return
+}
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.testing_encoding<[#iree_encoding.specialized_encoding<123, tensor<?x?xf32>>]>
+// CHECK:       #[[TARGET:.+]] = #hal.device.target
+// CHECK:       util.global private @[[$DEVICE:.+]] = #[[TARGET]]
+// CHECK-LABEL: util.func public @tensor_encode_op
+// CHECK:         stream.tensor.encode on(#hal.device.affinity<@[[$DEVICE]]>)
+// CHECK-SAME:      -> tensor<?x?xf32, #[[$ENCODING]]>
+
+// -----
+
 // Checks that the stream.tensor.constant op with unserialized encoding is not
 // supported.
 

--- a/compiler/src/iree/compiler/DispatchCreation/BUILD.bazel
+++ b/compiler/src/iree/compiler/DispatchCreation/BUILD.bazel
@@ -20,6 +20,7 @@ iree_compiler_cc_library(
         "CloneProducersIntoDispatchRegions.cpp",
         "CollapseDimensions.cpp",
         "CollapseReductionDimensions.cpp",
+        "ConvertDispatchRegionsToFlowOps.cpp",
         "ConvertDispatchRegionsToWorkgroups.cpp",
         "ConvertTensorToFlow.cpp",
         "ElementwiseOpFusion.cpp",

--- a/compiler/src/iree/compiler/DispatchCreation/CMakeLists.txt
+++ b/compiler/src/iree/compiler/DispatchCreation/CMakeLists.txt
@@ -22,6 +22,7 @@ iree_cc_library(
     "CloneProducersIntoDispatchRegions.cpp"
     "CollapseDimensions.cpp"
     "CollapseReductionDimensions.cpp"
+    "ConvertDispatchRegionsToFlowOps.cpp"
     "ConvertDispatchRegionsToWorkgroups.cpp"
     "ConvertTensorToFlow.cpp"
     "ElementwiseOpFusion.cpp"

--- a/compiler/src/iree/compiler/DispatchCreation/ConvertDispatchRegionsToFlowOps.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/ConvertDispatchRegionsToFlowOps.cpp
@@ -1,0 +1,73 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Encoding/IR/EncodingOps.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/DispatchCreation/Passes.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/Debug.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
+
+#define DEBUG_TYPE "iree-dispatch-creation-convert-dispatch-regions-to-flow-ops"
+
+namespace mlir::iree_compiler::DispatchCreation {
+
+#define GEN_PASS_DEF_CONVERTDISPATCHREGIONSTOFLOWOPSPASS
+#include "iree/compiler/DispatchCreation/Passes.h.inc"
+
+namespace {
+struct ConvertDispatchRegionsToFlowOpsPass
+    : public impl::ConvertDispatchRegionsToFlowOpsPassBase<
+          ConvertDispatchRegionsToFlowOpsPass> {
+  using Base::Base;
+  void runOnOperation() override;
+};
+} // namespace
+
+static std::optional<IREE::Encoding::SetEncodingOp>
+getEncodingFromSetEncodingDispatchRegion(
+    IREE::Flow::DispatchRegionOp regionOp) {
+  Region &region = regionOp.getBody();
+  if (!region.hasOneBlock()) {
+    return std::nullopt;
+  }
+  Block &block = region.front();
+  if (!llvm::hasSingleElement(block.without_terminator())) {
+    return std::nullopt;
+  }
+  auto encoding = dyn_cast<IREE::Encoding::SetEncodingOp>(*block.begin());
+  if (!encoding) {
+    return std::nullopt;
+  }
+  return encoding;
+}
+
+// Creates a DispatchWorkgroupsOp for every DispatchRegionOp.
+void ConvertDispatchRegionsToFlowOpsPass::runOnOperation() {
+  FunctionOpInterface funcOp = getOperation();
+
+  IRRewriter rewriter(&getContext());
+  funcOp.walk([&](IREE::Flow::DispatchRegionOp op) {
+    std::optional<IREE::Encoding::SetEncodingOp> encodingOp =
+        getEncodingFromSetEncodingDispatchRegion(op);
+    if (!encodingOp) {
+      return;
+    }
+    rewriter.setInsertionPointAfter(op);
+    Value source = encodingOp->getSource();
+    SmallVector<OpFoldResult> mixedSizes =
+        tensor::getMixedSizes(rewriter, op.getLoc(), source);
+    SmallVector<Value> dynamicDimSizes;
+    std::tie(std::ignore, dynamicDimSizes) = decomposeMixedValues(mixedSizes);
+    rewriter.replaceOpWithNewOp<IREE::Flow::TensorEncodeOp>(
+        op, encodingOp->getResultType(), source, dynamicDimSizes);
+  });
+}
+} // namespace mlir::iree_compiler::DispatchCreation

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -90,7 +90,7 @@ static llvm::cl::opt<bool> clConvertToFlowEncodeOp(
     "iree-dispatch-creation-experimental-convert-to-flow-encode-op",
     llvm::cl::desc("Enable the conversion from set_encoding dispatch to "
                    "flow.tensor.encode op."),
-    llvm::cl::init(false));
+    llvm::cl::init(true));
 
 namespace mlir::iree_compiler::DispatchCreation {
 

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -86,6 +86,12 @@ static llvm::cl::opt<bool> clEnableDataTiling(
                    "path, --iree-opt-data-tiling=false must be set as wells"),
     llvm::cl::init(false));
 
+static llvm::cl::opt<bool> clConvertToFlowEncodeOp(
+    "iree-dispatch-creation-experimental-convert-to-flow-encode-op",
+    llvm::cl::desc("Enable the conversion from set_encoding dispatch to "
+                   "flow.tensor.encode op."),
+    llvm::cl::init(false));
+
 namespace mlir::iree_compiler::DispatchCreation {
 
 //===----------------------------------------------------------------------===//
@@ -309,6 +315,9 @@ void buildDispatchCreationPassPipeline(
   addDispatchRegionCreationPasses(passManager);
 
   FunctionLikeNest(passManager)
+      .addPredicatedPass(
+          clConvertToFlowEncodeOp,
+          DispatchCreation::createConvertDispatchRegionsToFlowOpsPass)
       .addPass(DispatchCreation::createConvertDispatchRegionsToWorkgroupsPass)
       // Convert tensor operations to flow.tensor ops.
       // - Convert extract/insert slice to flow update ops when the tensor op

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.h
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.h
@@ -9,6 +9,7 @@
 
 #include <functional>
 
+#include "iree/compiler/Dialect/Encoding/IR/EncodingDialect.h"
 #include "iree/compiler/Pipelines/Options.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -294,6 +294,19 @@ def SetEncodingPass :
 // Dispatch region to workgroups passes
 //===---------------------------------------------------------------------===//
 
+def ConvertDispatchRegionsToFlowOpsPass :
+    InterfacePass<"iree-dispatch-creation-convert-dispatch-regions-to-flow-ops", "mlir::FunctionOpInterface"> {
+  let summary = "Convert dispatch regions to Flow ops.";
+  let description = [{
+    Pass to convert dispatch regions to Flow ops. This pass is
+    intended to be used after dispatch regions have been formed.
+  }];
+  let dependentDialects = [
+    "IREE::Encoding::IREEEncodingDialect",
+    "IREE::Flow::FlowDialect",
+  ];
+}
+
 def ConvertDispatchRegionsToWorkgroupsPass :
     InterfacePass<"iree-dispatch-creation-convert-dispatch-regions-to-workgroups", "mlir::FunctionOpInterface"> {
   let summary = "Convert dispatch regions to dispatch workgroups.";

--- a/compiler/src/iree/compiler/DispatchCreation/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/DispatchCreation/test/BUILD.bazel
@@ -27,6 +27,7 @@ iree_lit_test_suite(
             "form_dispatch_regions.mlir",
             "dispatch_linalg_on_tensors.mlir",
             "convert_region_to_workgroups.mlir",
+            "convert_regions_to_flow_ops.mlir",
             "bubble_up_expand_shapes.mlir",
             "bubble_up_extract_slice.mlir",
             "form_dispatch_workgroups.mlir",

--- a/compiler/src/iree/compiler/DispatchCreation/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/DispatchCreation/test/CMakeLists.txt
@@ -22,6 +22,7 @@ iree_lit_test_suite(
     "collapse_linalg_generic_on_tensors.mlir"
     "collapse_reduction.mlir"
     "convert_region_to_workgroups.mlir"
+    "convert_regions_to_flow_ops.mlir"
     "dispatch_linalg_ext_fusion.mlir"
     "dispatch_linalg_on_tensors.mlir"
     "dispatch_linalg_on_tensors_default.mlir"

--- a/compiler/src/iree/compiler/DispatchCreation/test/convert_regions_to_flow_ops.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/convert_regions_to_flow_ops.mlir
@@ -1,0 +1,39 @@
+// RUN: iree-opt %s --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-convert-dispatch-regions-to-flow-ops,canonicalize))" -split-input-file | FileCheck %s
+
+#encoding = #iree_encoding.testing_encoding<>
+util.func public @set_encoding_static(%arg0: tensor<123x456xf32>) -> tensor<123x456xf32, #encoding> {
+  %0 = flow.dispatch.region -> (tensor<123x456xf32, #encoding>) {
+    %1 = iree_encoding.set_encoding %arg0 : tensor<123x456xf32> -> tensor<123x456xf32, #encoding>
+    flow.return %1 : tensor<123x456xf32, #encoding>
+  }
+  util.return %0 : tensor<123x456xf32, #encoding>
+}
+// CHECK-DAG:    #[[$ENC:.+]] = #iree_encoding.testing_encoding<>
+// CHECK-LABEL:  @set_encoding_static(
+// CHECK-SAME:     %[[SRC:[a-zA-Z0-9]+]]
+// CHECK:          %[[RES:.+]] = flow.tensor.encode %[[SRC]]
+// CHECK-SAME:       tensor<123x456xf32> -> tensor<123x456xf32, #[[$ENC]]>
+
+// -----
+
+#encoding = #iree_encoding.testing_encoding<>
+util.func public @set_encoding_dynamic(%arg0: tensor<?x?xf32>) -> tensor<?x?xf32, #encoding> {
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %dim = tensor.dim %arg0, %c0 : tensor<?x?xf32>
+  %dim_0 = tensor.dim %arg0, %c1 : tensor<?x?xf32>
+  %0 = flow.dispatch.region -> (tensor<?x?xf32, #encoding>{%dim, %dim_0}) {
+    %1 = iree_encoding.set_encoding %arg0 : tensor<?x?xf32> -> tensor<?x?xf32, #encoding>
+    flow.return %1 : tensor<?x?xf32, #encoding>
+  }
+  util.return %0 : tensor<?x?xf32, #encoding>
+}
+// CHECK-DAG:    #[[$ENC:.+]] = #iree_encoding.testing_encoding<>
+// CHECK-LABEL:  @set_encoding_dynamic(
+// CHECK-SAME:     %[[SRC:[a-zA-Z0-9]+]]
+// CHECK-DAG:      %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:      %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:      %[[D0:.+]] = tensor.dim %[[SRC]], %[[C0]]
+// CHECK-DAG:      %[[D1:.+]] = tensor.dim %[[SRC]], %[[C1]]
+// CHECK:          %[[RES:.+]] = flow.tensor.encode %[[SRC]]
+// CHECK-SAME:       tensor<?x?xf32>{%[[D0]], %[[D1]]} -> tensor<?x?xf32, #[[$ENC]]>

--- a/compiler/src/iree/compiler/ExternalInterfaces/StreamExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/StreamExternalModels.cpp
@@ -206,6 +206,7 @@ void registerStreamExternalModels(DialectRegistry &registry) {
     AffinityOpAttrExternalModel<IREE::Flow::TensorEmptyOp>::add(context);
     AffinityOpAttrExternalModel<IREE::Flow::TensorSplatOp>::add(context);
     AffinityOpAttrExternalModel<IREE::Flow::TensorCloneOp>::add(context);
+    AffinityOpAttrExternalModel<IREE::Flow::TensorEncodeOp>::add(context);
     AffinityOpAttrExternalModel<IREE::Flow::TensorSliceOp>::add(context);
     AffinityOpAttrExternalModel<IREE::Flow::TensorUpdateOp>::add(context);
     AffinityOpAttrExternalModel<IREE::Flow::ChannelDefaultOp>::add(context);


### PR DESCRIPTION
Compile: `iree-compile --output-format=vm-bytecode --iree-hal-target-backends=rocm --iree-hip-target=gfx942 ~/matmul.mlir -o /tmp/z.vmfb --iree-global-opt-enable-early-materialization=false`

[Full log](https://gist.githubusercontent.com/hanhanW/362b09d0014aa21c301d7674ec2eb116/raw/fad76758d8ee545d63e3e1f2fef8aa1533708e3d/log)

```mlir
func.func @foo(%lhs: tensor<?x?xf32>, %rhs: tensor<?x?xf32>) -> tensor<?x?xf32> {
  %c0 = arith.constant 0 : index
  %c1 = arith.constant 1 : index
  %M = tensor.dim %lhs, %c0 : tensor<?x?xf32>
  %N = tensor.dim %rhs, %c1 : tensor<?x?xf32>
  %cst = arith.constant 0.0 : f32
  %init = tensor.empty(%M, %N) : tensor<?x?xf32>
  %fill = linalg.fill ins(%cst : f32) outs(%init : tensor<?x?xf32>) -> tensor<?x?xf32>
  %op = linalg.matmul
      ins(%lhs, %rhs : tensor<?x?xf32>, tensor<?x?xf32>)
      outs(%fill : tensor<?x?xf32>) -> tensor<?x?xf32>
  return %op : tensor<?x?xf32>
}
```