### PR TITLE
Fix floating point type conversions when the result is in the denormal range

### DIFF
--- a/runtime/src/iree/base/internal/math.h
+++ b/runtime/src/iree/base/internal/math.h
@@ -396,7 +396,7 @@ static inline uint32_t iree_math_truncate_f32_to_bits_rounding_to_nearest_even(
         // Generate NaN.
         generate_nan = true;
       }
-    } else if (arithmetic_exp < -(1 << (dst_exp_bits - 1))) {
+    } else if (arithmetic_exp + dst_exp_bias <= 0) {
       // Underflow. Generate zero. Leave zero mantissa.
       dst_exp = 0;
     } else {

--- a/runtime/src/iree/base/internal/math_test.cc
+++ b/runtime/src/iree/base/internal/math_test.cc
@@ -192,6 +192,11 @@ TEST(F16ConversionTest, F32ToF16) {
   // Underflow
   EXPECT_EQ(0, iree_math_f32_to_f16(FLT_MIN));
   EXPECT_EQ(0x8000, iree_math_f32_to_f16(-FLT_MIN));
+  EXPECT_EQ(0, iree_math_f32_to_f16(1.0e-05));
+  EXPECT_EQ(0x8000, iree_math_f32_to_f16(-1.0e-05));
+  EXPECT_EQ(0, iree_math_f32_to_f16(6.1e-05));  // Near largest denormal
+  EXPECT_EQ(0x8000, iree_math_f32_to_f16(-6.1e-05));
+
   // Denormals may or may not get flushed to zero. Accept both ways.
   uint16_t positive_denormal = iree_math_f32_to_f16(kF16Min / 2);
   EXPECT_TRUE(positive_denormal == 0 || positive_denormal == 0x0200);
@@ -357,6 +362,11 @@ TEST(F8E5M2ConversionTest, F32ToF8E5M2) {
   // Underflow
   EXPECT_EQ(0, iree_math_f32_to_f8e5m2(FLT_MIN));
   EXPECT_EQ(0x80, iree_math_f32_to_f8e5m2(-FLT_MIN));
+  EXPECT_EQ(0, iree_math_f32_to_f8e5m2(kF8E5M2Min * 0.5f));
+  EXPECT_EQ(0x80, iree_math_f32_to_f8e5m2(-kF8E5M2Min * 0.5f));
+  EXPECT_EQ(0, iree_math_f32_to_f8e5m2(kF8E5M2Min * 0.75f));
+  EXPECT_EQ(0x80, iree_math_f32_to_f8e5m2(-kF8E5M2Min * 0.75f));
+
   // Denormals may or may not get flushed to zero. Accept both ways.
   uint16_t positive_denormal = iree_math_f32_to_f8e5m2(kF8E5M2Min / 2);
   EXPECT_TRUE(positive_denormal == 0 || positive_denormal == 0x02);


### PR DESCRIPTION
The condition for generating a denormal (which we just flush to zero) was incorrect. The new condition is very simple, checks that the biased converted exponent would be <= 0 which is the definition of a denormal. The added testcases show what is being fixed here. Prior to the fix, these cases converted to some large values as the exponent wrapped around!