### PR TITLE
[ExternalInterfaces] Fix LinalgExtFusionInterface registeration

### DIFF
--- a/compiler/src/iree/compiler/ExternalInterfaces/LinalgExtExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/LinalgExtExternalModels.cpp
@@ -128,10 +128,6 @@ void registerLinalgExtExternalModels(DialectRegistry &registry) {
     registerOpsWithLinalgExtOpInterface<
 #include "mlir/Dialect/Linalg/IR/LinalgStructuredOps.cpp.inc"
         >(ctx);
-  });
-  registry.addExtension(+[](MLIRContext *ctx,
-                            IREE::LinalgExt::IREELinalgExtDialect *dialect) {
-    ctx->loadDialect<linalg::LinalgDialect>();
     linalg::SoftmaxOp::attachInterface<SoftmaxFusionOpInterfaceAdapter>(*ctx);
   });
 }

--- a/compiler/src/iree/compiler/ExternalInterfaces/LinalgExtExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/LinalgExtExternalModels.cpp
@@ -123,14 +123,14 @@ void registerOpsWithLinalgExtOpInterface(mlir::MLIRContext *context) {
 } // namespace
 
 void registerLinalgExtExternalModels(DialectRegistry &registry) {
-  registry.addExtension(+[](MLIRContext *ctx,
-                            IREE::LinalgExt::IREELinalgExtDialect *dialect) {
-    ctx->loadDialect<mlir::linalg::LinalgDialect>();
-
+  registry.addExtension(+[](MLIRContext *ctx, linalg::LinalgDialect *dialect) {
 #define GET_OP_LIST
     registerOpsWithLinalgExtOpInterface<
 #include "mlir/Dialect/Linalg/IR/LinalgStructuredOps.cpp.inc"
         >(ctx);
+  });
+  registry.addExtension(+[](MLIRContext *ctx,
+                            IREE::LinalgExt::IREELinalgExtDialect *dialect) {
     linalg::SoftmaxOp::attachInterface<SoftmaxFusionOpInterfaceAdapter>(*ctx);
   });
 }

--- a/compiler/src/iree/compiler/ExternalInterfaces/LinalgExtExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/LinalgExtExternalModels.cpp
@@ -131,6 +131,7 @@ void registerLinalgExtExternalModels(DialectRegistry &registry) {
   });
   registry.addExtension(+[](MLIRContext *ctx,
                             IREE::LinalgExt::IREELinalgExtDialect *dialect) {
+    ctx->loadDialect<linalg::LinalgDialect>();
     linalg::SoftmaxOp::attachInterface<SoftmaxFusionOpInterfaceAdapter>(*ctx);
   });
 }


### PR DESCRIPTION
addExtension adds a dialect dependency on the dialect passed as an argument. If LinalgExtDialect is never registered, we would never register LinalgExtFusionInterface for linalg ops.