### PR TITLE
[CPU] Improve Fusions and KernelConfig heuristics for Attention

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.td
@@ -168,14 +168,10 @@ def LLVMCPUVerifyVectorSizeLegalityPass :
   let summary =
       "Signals errors when there are large vectors in the IR. I.e., one of"
       "the vector sizes is greater than"
-      "maxAllowedNumberOfNativeVectors * native_vector_size. For scalable"
+      "clMaxAllowedNumberOfNativeVectors * native_vector_size. For scalable"
       "vectors, it assumes that the vscale value is always 1. It may be an"
       "underestimate if the runtime larger than 1, but it should still catch"
       "unreasonable vector sizes.";
-  let options = [
-    Option<"maxAllowedNumberOfNativeVectors", "max-allowed-number-of-native-vectors", "int64_t", /*default=*/"512",
-           "The ratio used in the computation of max vector size.">
-  ];
 }
 
 // Note: This pass is currently only required when targeting Arm SME (which is

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Utils.h
@@ -58,6 +58,9 @@ bool isLinalgGeneric2DTranspose(linalg::GenericOp genericOp);
 /// Returns true if the op could result in undefined behavior.
 bool mayHaveUndefinedBehaviorInMasking(Operation *op);
 
+int64_t
+getMaxVectorSizeForLargeVectorCheck(IREE::HAL::ExecutableTargetAttr targetAttr);
+
 } // namespace mlir::iree_compiler
 
 #endif // IREE_COMPILER_CODEGEN_LLVMCPU_UTILS_H_

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/select_x86_64_lowering_strategy.mlir
@@ -1757,7 +1757,7 @@ func.func @attention() attributes {hal.executable.target = #executable_target_em
   flow.dispatch.tensor.store %8, %3, offsets = [0, 0, 0], sizes = [20, 4096, 64], strides = [1, 1, 1] : tensor<20x4096x64xf16> -> !flow.dispatch.tensor<writeonly:tensor<20x4096x64xf16>>
   return
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 0, 0, 64], [1, 1, 0, 0, 32], [0, 0, 0, 32, 0]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 0, 0, 64], [1, 1, 0, 0, 32], [0, 0, 0, 2, 0]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPULinalgExtTileAndVectorize>
 //      CHECK: func.func @attention()
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -1829,7 +1829,7 @@ func.func @attention_transpose_distribute_4d() attributes {hal.executable.target
   return
 }
 
-// CHECK-DAG:  #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 1, 64, 64, 0, 0, 0, 0], [1, 1, 1, 32, 0, 0, 0, 0], [0, 0, 0, 0, 0, 32, 1, 1]]>
+// CHECK-DAG:  #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 1, 64, 64, 0, 0, 0, 0], [1, 1, 1, 2, 0, 0, 0, 0], [0, 0, 0, 0, 0, 1, 1, 1]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPULinalgExtTileAndVectorize>
 //      CHECK: func.func @attention_transpose_distribute_4d
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]


### PR DESCRIPTION
- Use newer TileAndFuse passes for LinalgExt TileAndVectorize pipeline
- Restrict QK and PV vector tile sizes based on register space available
- Restrict vector tile sizes based on the max allowed vector tile size verification check. This requires us to move the flat for setting max vector size to LLVMCPU/Utils.

This PR makes sure we never generate tile sizes that are too big to pass large vector verification check, i.e. attention will never fail to compile on CPU. The performance can be improved by selecting better heuristics, but that is a problem for another day.