### PR TITLE
Introduce Flow/Stream tensor encode op and the conversion.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -1873,8 +1873,9 @@ LogicalResult TensorEncodeOp::verify() {
     return emitOpError("the source operand type has encoding; not allowed");
   }
   auto resultType = cast<RankedTensorType>(getResult().getType());
-  if (operandType.dropEncoding() != resultType.dropEncoding()) {
-    return failure();
+  if (operandType != resultType.dropEncoding()) {
+    return emitOpError(
+        "the result type is not compatible with the source operand type");
   }
   return success();
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -1858,6 +1858,28 @@ LogicalResult TensorCloneOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// flow.tensor.encode
+//===----------------------------------------------------------------------===//
+
+LogicalResult TensorEncodeOp::verify() {
+  if (failed(verifyOpDynamicDims(getOperation(), {getOperand()},
+                                 getOperandDims())) ||
+      failed(verifyOpDynamicDims(getOperation(), {getResult()},
+                                 getOperandDims()))) {
+    return failure();
+  }
+  auto operandType = cast<RankedTensorType>(getOperand().getType());
+  if (operandType.getEncoding()) {
+    return emitOpError("the source operand type has encoding; not allowed");
+  }
+  auto resultType = cast<RankedTensorType>(getResult().getType());
+  if (operandType.dropEncoding() != resultType.dropEncoding()) {
+    return failure();
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // flow.tensor.barrier
 //===----------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -1865,17 +1865,14 @@ LogicalResult TensorEncodeOp::verify() {
   if (failed(verifyOpDynamicDims(getOperation(), {getOperand()},
                                  getOperandDims())) ||
       failed(verifyOpDynamicDims(getOperation(), {getResult()},
-                                 getOperandDims()))) {
+                                 getResultDims()))) {
     return failure();
   }
   auto operandType = cast<RankedTensorType>(getOperand().getType());
-  if (operandType.getEncoding()) {
-    return emitOpError("the source operand type has encoding; not allowed");
-  }
   auto resultType = cast<RankedTensorType>(getResult().getType());
-  if (operandType != resultType.dropEncoding()) {
-    return emitOpError(
-        "the result type is not compatible with the source operand type");
+  if (failed(mlir::verifyCompatibleShape(operandType.getShape(),
+                                         resultType.getShape()))) {
+    return emitOpError("the operand shape and result shape are not compatible");
   }
   return success();
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -1508,6 +1508,39 @@ def FLOW_TensorCloneOp : FLOW_PureOp<"tensor.clone", [
   let hasFolder = 1;
 }
 
+// TODO(hanchung): Add folders.
+def FLOW_TensorEncodeOp : FLOW_PureOp<"tensor.encode", [
+  DeclareOpInterfaceMethods<Util_HoistableOpInterface>,
+  Util_ShapeAwareOp,
+]> {
+  let summary = [{performs a full tensor encode operation}];
+  let description = [{
+    Encode the input tensor into an encoded output tensor.
+  }];
+
+  let arguments = (ins
+    FLOW_Tensor:$operand,
+    FLOW_ShapeDynamicDims:$operand_dims
+  );
+  let results = (outs
+    FLOW_Tensor:$result
+  );
+
+  let assemblyFormat = [{
+    $operand `:` type($operand) (`{` $operand_dims^ `}`)? `->` type($result)
+    attr-dict-with-keyword
+  }];
+
+  let extraClassDeclaration = [{
+    bool isHoistableLeafOp() { return false; }
+
+    ValueRange getOperandDynamicDims(unsigned idx) { return getOperandDims(); }
+    ValueRange getResultDynamicDims(unsigned idx) { return getOperandDims(); }
+  }];
+
+  let hasVerifier = 1;
+}
+
 def FLOW_TensorBarrierOp : FLOW_PureOp<"tensor.barrier", [
   AllTypesMatch<["operand", "result"]>,
   DeclareOpInterfaceMethods<Util_HoistableOpInterface>,

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -1509,7 +1509,10 @@ def FLOW_TensorCloneOp : FLOW_PureOp<"tensor.clone", [
 }
 
 def FLOW_TensorEncodeOp : FLOW_PureOp<"tensor.encode", [
+  AllRanksMatch<["operand", "result"]>,
+  AllElementTypesMatch<["operand", "result"]>,
   DeclareOpInterfaceMethods<Util_HoistableOpInterface>,
+  AttrSizedOperandSegments,
   Util_ShapeAwareOp,
 ]> {
   let summary = [{performs a full tensor encode operation}];
@@ -1519,14 +1522,17 @@ def FLOW_TensorEncodeOp : FLOW_PureOp<"tensor.encode", [
 
   let arguments = (ins
     FLOW_Tensor:$operand,
-    FLOW_ShapeDynamicDims:$operand_dims
+    FLOW_ShapeDynamicDims:$operand_dims,
+    FLOW_ShapeDynamicDims:$result_dims
   );
   let results = (outs
     FLOW_Tensor:$result
   );
 
   let assemblyFormat = [{
-    $operand `:` type($operand) (`{` $operand_dims^ `}`)? `->` type($result)
+    $operand `:`
+    type($operand) (`{` $operand_dims^ `}`)? `->`
+    type($result) (`{` $result_dims^ `}`)?
     attr-dict-with-keyword
   }];
 
@@ -1534,7 +1540,7 @@ def FLOW_TensorEncodeOp : FLOW_PureOp<"tensor.encode", [
     bool isHoistableLeafOp() { return false; }
 
     ValueRange getOperandDynamicDims(unsigned idx) { return getOperandDims(); }
-    ValueRange getResultDynamicDims(unsigned idx) { return getOperandDims(); }
+    ValueRange getResultDynamicDims(unsigned idx) { return getResultDims(); }
   }];
 
   let hasVerifier = 1;

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -1508,7 +1508,6 @@ def FLOW_TensorCloneOp : FLOW_PureOp<"tensor.clone", [
   let hasFolder = 1;
 }
 
-// TODO(hanchung): Add folders.
 def FLOW_TensorEncodeOp : FLOW_PureOp<"tensor.encode", [
   DeclareOpInterfaceMethods<Util_HoistableOpInterface>,
   Util_ShapeAwareOp,

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_ops.mlir
@@ -209,7 +209,6 @@ util.func public @tensorEncodeDynamic(%arg0 : tensor<?x4xf32>, %arg1 : index) ->
   util.return %0 : tensor<?x4xf32, #encoding>
 }
 
-
 // -----
 
 // CHECK-LABEL: @tensorSlice

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_ops.mlir
@@ -186,10 +186,10 @@ util.func public @tensorCloneDynamic(%arg0 : tensor<?x4xf32>) -> tensor<?x4xf32>
 
 // -----
 
-#encoding = #iree_encoding.testing_encoding<>
 // CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.testing_encoding<>
 // CHECK-LABEL: @tensorEncodeStatic
 // CHECK-SAME:    %[[ARG0:.[a-zA-Z0-9]+]]
+#encoding = #iree_encoding.testing_encoding<>
 util.func public @tensorEncodeStatic(%arg0 : tensor<4x4xf32>) -> tensor<4x4xf32, #encoding> {
   // CHECK: %[[RES:.+]] = flow.tensor.encode %[[ARG0]] : tensor<4x4xf32> -> tensor<4x4xf32, #[[$ENCODING]]>
   %0 = flow.tensor.encode %arg0 : tensor<4x4xf32> -> tensor<4x4xf32, #encoding>
@@ -198,15 +198,31 @@ util.func public @tensorEncodeStatic(%arg0 : tensor<4x4xf32>) -> tensor<4x4xf32,
 
 // -----
 
-#encoding = #iree_encoding.testing_encoding<>
 // CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.testing_encoding<>
 // CHECK-LABEL: @tensorEncodeDynamic
 // CHECK-SAME:    %[[ARG0:.[a-zA-Z0-9]+]]
 // CHECK-SAME:    %[[ARG1:.[a-zA-Z0-9]+]]
-util.func public @tensorEncodeDynamic(%arg0 : tensor<?x4xf32>, %arg1 : index) -> tensor<?x4xf32, #encoding> {
-  // CHECK: %[[RES:.+]] = flow.tensor.encode %[[ARG0]] : tensor<?x4xf32>{%[[ARG1]]} -> tensor<?x4xf32, #[[$ENCODING]]>
-  %0 = flow.tensor.encode %arg0 : tensor<?x4xf32>{%arg1} -> tensor<?x4xf32, #encoding>
-  util.return %0 : tensor<?x4xf32, #encoding>
+// CHECK-SAME:    %[[ARG2:.[a-zA-Z0-9]+]]
+#encoding = #iree_encoding.testing_encoding<>
+util.func public @tensorEncodeDynamic(%arg0 : tensor<?x4xf32>, %arg1 : index, %arg2: index) -> tensor<5x?xf32, #encoding> {
+  // CHECK: %[[RES:.+]] = flow.tensor.encode %[[ARG0]] : tensor<?x4xf32>{%[[ARG1]]} -> tensor<5x?xf32, #[[$ENCODING]]>{%[[ARG2]]}
+  %0 = flow.tensor.encode %arg0 : tensor<?x4xf32>{%arg1} -> tensor<5x?xf32, #encoding>{%arg2}
+  util.return %0 : tensor<5x?xf32, #encoding>
+}
+
+// -----
+
+// CHECK-LABEL: @tensorEncodeChangeEncoding
+// CHECK-SAME:    %[[ARG0:.[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG1:.[a-zA-Z0-9]+]]
+#encoding = #iree_encoding.unspecialized_encoding<123>
+#encoding1 = #iree_encoding.unspecialized_encoding<456>
+util.func public @tensorEncodeChangeEncoding(%arg0 : tensor<?x4xf32, #encoding>, %arg1 : index) -> tensor<?x4xf32, #encoding1> {
+  // CHECK:      %[[RES:.+]] = flow.tensor.encode %[[ARG0]]
+  // CHECK-SAME:   : tensor<?x4xf32, #iree_encoding.unspecialized_encoding<123>>{%[[ARG1]]}
+  // CHECK-SAME:   -> tensor<?x4xf32, #iree_encoding.unspecialized_encoding<456>>{%[[ARG1]]}
+  %0 = flow.tensor.encode %arg0 : tensor<?x4xf32, #encoding>{%arg1} -> tensor<?x4xf32, #encoding1>{%arg1}
+  util.return %0 : tensor<?x4xf32, #encoding1>
 }
 
 // -----

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_ops.mlir
@@ -186,6 +186,32 @@ util.func public @tensorCloneDynamic(%arg0 : tensor<?x4xf32>) -> tensor<?x4xf32>
 
 // -----
 
+#encoding = #iree_encoding.testing_encoding<>
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.testing_encoding<>
+// CHECK-LABEL: @tensorEncodeStatic
+// CHECK-SAME:    %[[ARG0:.[a-zA-Z0-9]+]]
+util.func public @tensorEncodeStatic(%arg0 : tensor<4x4xf32>) -> tensor<4x4xf32, #encoding> {
+  // CHECK: %[[RES:.+]] = flow.tensor.encode %[[ARG0]] : tensor<4x4xf32> -> tensor<4x4xf32, #[[$ENCODING]]>
+  %0 = flow.tensor.encode %arg0 : tensor<4x4xf32> -> tensor<4x4xf32, #encoding>
+  util.return %0 : tensor<4x4xf32, #encoding>
+}
+
+// -----
+
+#encoding = #iree_encoding.testing_encoding<>
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.testing_encoding<>
+// CHECK-LABEL: @tensorEncodeDynamic
+// CHECK-SAME:    %[[ARG0:.[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG1:.[a-zA-Z0-9]+]]
+util.func public @tensorEncodeDynamic(%arg0 : tensor<?x4xf32>, %arg1 : index) -> tensor<?x4xf32, #encoding> {
+  // CHECK: %[[RES:.+]] = flow.tensor.encode %[[ARG0]] : tensor<?x4xf32>{%[[ARG1]]} -> tensor<?x4xf32, #[[$ENCODING]]>
+  %0 = flow.tensor.encode %arg0 : tensor<?x4xf32>{%arg1} -> tensor<?x4xf32, #encoding>
+  util.return %0 : tensor<?x4xf32, #encoding>
+}
+
+
+// -----
+
 // CHECK-LABEL: @tensorSlice
 util.func public @tensorSlice(%arg0 : tensor<4x4xf32>, %arg1 : index, %arg2 : index) -> tensor<2x2xf32> {
   // CHECK-NEXT: %0 = flow.tensor.slice %arg0[%arg1, %arg2 for %arg2, %arg1] : tensor<4x4xf32> -> tensor<2x2xf32>

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
@@ -254,9 +254,9 @@ struct ConvertTensorEncodeOp
     auto encodeOp = rewriter.create<IREE::Stream::TensorEncodeOp>(
         op.getLoc(), unknownType, operand.resource, op.getOperand().getType(),
         op.getOperandDims(), operand.resourceSize, op.getResult().getType(),
-        flattenValues(adaptor.getOperandDims()), resultSize,
+        flattenValues(adaptor.getResultDims()), resultSize,
         executionAffinityAttr);
-    rewriter.replaceOpWithMultiple(op, {{encodeOp, operand.resourceSize}});
+    rewriter.replaceOpWithMultiple(op, {{encodeOp, resultSize}});
     return success();
   }
 };

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
@@ -237,6 +237,30 @@ struct ConvertTensorCloneOp
   }
 };
 
+struct ConvertTensorEncodeOp
+    : public AffinityOpConversionPattern<IREE::Flow::TensorEncodeOp> {
+  using AffinityOpConversionPattern::AffinityOpConversionPattern;
+  LogicalResult matchAndRewriteOnAffinity(
+      IREE::Flow::TensorEncodeOp op, OneToNOpAdaptor adaptor,
+      IREE::Stream::AffinityAttr executionAffinityAttr,
+      ConversionPatternRewriter &rewriter) const override {
+    auto operand = transferTensorOperands(op.getLoc(), op.getOperand(),
+                                          adaptor.getOperand(),
+                                          executionAffinityAttr, rewriter);
+    auto unknownType = rewriter.getType<IREE::Stream::ResourceType>();
+    auto resultSize =
+        buildResultSizeOf(op.getLoc(), op.getResult(), op.getOperandDims(),
+                          executionAffinityAttr, rewriter);
+    auto encodeOp = rewriter.create<IREE::Stream::TensorEncodeOp>(
+        op.getLoc(), unknownType, operand.resource, op.getOperand().getType(),
+        op.getOperandDims(), operand.resourceSize, op.getResult().getType(),
+        flattenValues(adaptor.getOperandDims()), resultSize,
+        executionAffinityAttr);
+    rewriter.replaceOpWithMultiple(op, {{encodeOp, operand.resourceSize}});
+    return success();
+  }
+};
+
 struct ConvertTensorBarrierOp
     : public AffinityOpConversionPattern<IREE::Flow::TensorBarrierOp> {
   using AffinityOpConversionPattern::AffinityOpConversionPattern;
@@ -1187,10 +1211,10 @@ void populateFlowToStreamConversionPatterns(
       ConvertTensorCastLikeOp<IREE::Flow::TensorReshapeOp>,
       ConvertTensorCastLikeOp<IREE::Flow::TensorBitCastOp>,
       ConvertTensorAllocaOp, ConvertTensorEmptyOp, ConvertTensorSplatOp,
-      ConvertTensorCloneOp, ConvertTensorBarrierOp, ConvertTensorTransferOp,
-      ConvertTensorSliceOp, ConvertTensorUpdateOp, ConvertTensorLoadOp,
-      ConvertTensorStoreOp, ConvertTensorTraceOp>(typeConverter, context,
-                                                  affinityAnalysis);
+      ConvertTensorCloneOp, ConvertTensorEncodeOp, ConvertTensorBarrierOp,
+      ConvertTensorTransferOp, ConvertTensorSliceOp, ConvertTensorUpdateOp,
+      ConvertTensorLoadOp, ConvertTensorStoreOp, ConvertTensorTraceOp>(
+      typeConverter, context, affinityAnalysis);
   patterns.insert<ConvertChannelDefaultOp>(typeConverter, context,
                                            affinityAnalysis);
   patterns.insert<ConvertChannelSplitOp, ConvertChannelRankOp,

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/tensor_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/tensor_ops.mlir
@@ -100,36 +100,86 @@ util.func public @tensorBitCastWithSingleUse(%input: tensor<5x24x48xi8>) -> tens
 
 // -----
 
-// CHECK-DAG:   #[[$ENC:.+]] = #iree_encoding.testing_encoding<>
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.testing_encoding<>
 // CHECK-LABEL: @tensorEncodeStatic
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
 // CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
 #encoding = #iree_encoding.testing_encoding<>
 util.func public @tensorEncodeStatic(%input: tensor<30x2x96xf32>) -> tensor<30x2x96xf32, #encoding> {
-  // CHECK: %[[SIZE:.+]] = stream.tensor.sizeof tensor<30x2x96xf32, #[[$ENC]]> : index
-  // CHECK: %[[RESULT:.+]] = stream.tensor.encode %[[ARG0]] : tensor<30x2x96xf32> in !stream.resource<*>{%[[ARG1]]} -> tensor<30x2x96xf32, #[[$ENC]]> in !stream.resource<*>{%[[SIZE]]}
+  // CHECK: %[[SIZE:.+]] = stream.tensor.sizeof tensor<30x2x96xf32, #[[$ENCODING]]> : index
+  // CHECK: %[[RESULT:.+]] = stream.tensor.encode %[[ARG0]] : tensor<30x2x96xf32> in !stream.resource<*>{%[[ARG1]]} -> tensor<30x2x96xf32, #[[$ENCODING]]> in !stream.resource<*>{%[[SIZE]]}
   %0 = flow.tensor.encode %input : tensor<30x2x96xf32> -> tensor<30x2x96xf32, #encoding>
-  // CHECK: util.return %[[RESULT]], %[[ARG1]] : !stream.resource<*>, index
+  // CHECK: util.return %[[RESULT]], %[[SIZE]] : !stream.resource<*>, index
   util.return %0 : tensor<30x2x96xf32, #encoding>
 }
 
 // -----
 
-// CHECK-DAG:   #[[$ENC:.+]] = #iree_encoding.testing_encoding<>
-// CHECK-LABEL: @tensorEncodeDynamic
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.testing_encoding<>
+// CHECK-LABEL: @tensorEncodeStatic
+// CHECK-SAME:    %[[ARG0:.[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG1:.[a-zA-Z0-9]+]]
+#encoding = #iree_encoding.testing_encoding<>
+util.func public @tensorEncodeStatic(%arg0 : tensor<4x4xf32>) -> tensor<4x4xf32, #encoding> {
+  // CHECK: %[[SIZE:.+]] = stream.tensor.sizeof tensor<4x4xf32, #[[$ENCODING]]> : index
+  // CHECK: %[[RESULT:.+]] = stream.tensor.encode %[[ARG0]] : tensor<4x4xf32> in !stream.resource<*>{%[[ARG1]]} -> tensor<4x4xf32, #[[$ENCODING]]> in !stream.resource<*>{%[[SIZE]]}
+  %0 = flow.tensor.encode %arg0 : tensor<4x4xf32> -> tensor<4x4xf32, #encoding>
+  // CHECK: util.return %[[RESULT]], %[[SIZE]] : !stream.resource<*>, index
+  util.return %0 : tensor<4x4xf32, #encoding>
+}
+
+// -----
+
+// Note: `ARG1` is the size of `ARG0` after the conversion.
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.testing_encoding<>
+// CHECK-LABEL: @tensorEncodePartialDynamic
+// CHECK-SAME:    %[[ARG0:.[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG1:.[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG2:.[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG3:.[a-zA-Z0-9]+]]
+#encoding = #iree_encoding.testing_encoding<>
+util.func public @tensorEncodePartialDynamic(%arg0 : tensor<?x4xf32>, %arg1 : index, %arg2: index) -> tensor<5x?xf32, #encoding> {
+  // CHECK: %[[SIZE:.+]] = stream.tensor.sizeof tensor<5x?xf32, #[[$ENCODING]]>{%[[ARG2]]} : index
+  // CHECK: %[[RESULT:.+]] = stream.tensor.encode %[[ARG0]] : tensor<?x4xf32>{%[[ARG2]]} in !stream.resource<*>{%[[ARG1]]} -> tensor<5x?xf32, #[[$ENCODING]]>{%[[ARG3]]} in !stream.resource<*>{%[[SIZE]]}
+  %0 = flow.tensor.encode %arg0 : tensor<?x4xf32>{%arg1} -> tensor<5x?xf32, #encoding>{%arg2}
+  // CHECK: util.return %[[RESULT]], %[[SIZE]] : !stream.resource<*>, index
+  util.return %0 : tensor<5x?xf32, #encoding>
+}
+
+// -----
+
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.testing_encoding<>
+// CHECK-LABEL: @tensorEncodeFullyDynamic
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
 // CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
 // CHECK-SAME:    %[[D0:[a-zA-Z0-9]+]]
 // CHECK-SAME:    %[[D1:[a-zA-Z0-9]+]]
 #encoding = #iree_encoding.testing_encoding<>
-util.func public @tensorEncodeDynamic(%input: tensor<?x?xf32>, %d0: index, %d1: index) -> tensor<?x?xf32, #encoding> {
-  // CHECK: %[[SIZE:.+]] = stream.tensor.sizeof tensor<?x?xf32, #[[$ENC]]>{%[[D0]], %[[D1]]} : index
-  // CHECK: %[[RESULT:.+]] = stream.tensor.encode %[[ARG0]] : tensor<?x?xf32>{%[[D0]], %[[D1]]} in !stream.resource<*>{%[[ARG1]]} -> tensor<?x?xf32, #[[$ENC]]>{%[[D0]], %[[D1]]} in !stream.resource<*>{%[[SIZE]]}
-  %0 = flow.tensor.encode %input : tensor<?x?xf32>{%d0, %d1} -> tensor<?x?xf32, #encoding>
-  // CHECK: util.return %[[RESULT]], %[[ARG1]] : !stream.resource<*>, index
+util.func public @tensorEncodeFullyDynamic(%input: tensor<?x?xf32>, %d0: index, %d1: index) -> tensor<?x?xf32, #encoding> {
+  // CHECK: %[[SIZE:.+]] = stream.tensor.sizeof tensor<?x?xf32, #[[$ENCODING]]>{%[[D0]], %[[D1]]} : index
+  // CHECK: %[[RESULT:.+]] = stream.tensor.encode %[[ARG0]] : tensor<?x?xf32>{%[[D0]], %[[D1]]} in !stream.resource<*>{%[[ARG1]]} -> tensor<?x?xf32, #[[$ENCODING]]>{%[[D0]], %[[D1]]} in !stream.resource<*>{%[[SIZE]]}
+  %0 = flow.tensor.encode %input : tensor<?x?xf32>{%d0, %d1} -> tensor<?x?xf32, #encoding>{%d0, %d1}
+  // CHECK: util.return %[[RESULT]], %[[SIZE]] : !stream.resource<*>, index
   util.return %0 : tensor<?x?xf32, #encoding>
 }
 
+// -----
+
+// CHECK-LABEL: @tensorEncodeChangeEncoding
+// CHECK-SAME:    %[[ARG0:.[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG1:.[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG2:.[a-zA-Z0-9]+]]
+#encoding = #iree_encoding.unspecialized_encoding<123>
+#encoding1 = #iree_encoding.unspecialized_encoding<456>
+util.func public @tensorEncodeChangeEncoding(%arg0 : tensor<?x4xf32, #encoding>, %arg1 : index) -> tensor<?x4xf32, #encoding1> {
+  // CHECK:      %[[SIZE:.+]] = stream.tensor.sizeof tensor<?x4xf32, #iree_encoding.unspecialized_encoding<456>>{%[[ARG2]]} : index
+  // CHECK:      %[[RESULT:.+]] = stream.tensor.encode %[[ARG0]]
+  // CHECK-SAME:   : tensor<?x4xf32, #iree_encoding.unspecialized_encoding<123>>{%[[ARG2]]} in !stream.resource<*>{%[[ARG1]]}
+  // CHECK-SAME:   -> tensor<?x4xf32, #iree_encoding.unspecialized_encoding<456>>{%[[ARG2]]} in !stream.resource<*>{%[[SIZE]]}
+  %0 = flow.tensor.encode %arg0 : tensor<?x4xf32, #encoding>{%arg1} -> tensor<?x4xf32, #encoding1>{%arg1}
+  // CHECK:      util.return %[[RESULT]], %[[SIZE]] : !stream.resource<*>, index
+  util.return %0 : tensor<?x4xf32, #encoding1>
+}
 // -----
 
 // CHECK-LABEL: @tensorAlloca

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -1967,14 +1967,6 @@ LogicalResult TensorCloneOp::verify() {
 
 LogicalResult TensorEncodeOp::verify() {
   TensorEncodeOp op = *this;
-  auto sourceEncoding = llvm::cast<RankedTensorType>(op.getSourceEncoding());
-  if (sourceEncoding.getEncoding()) {
-    return op.emitOpError("expects no encodings on the source tensor");
-  }
-  auto resultEncoding = llvm::cast<RankedTensorType>(op.getResultEncoding());
-  if (!resultEncoding.getEncoding()) {
-    return op.emitOpError() << "expects an encoding on the result tensor";
-  }
   if (failed(verifyOpDynamicDims(op, op.getSourceEncoding(),
                                  op.getSourceEncodingDims())) ||
       failed(verifyOpDynamicDims(op, op.getResultEncoding(),

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -1962,6 +1962,31 @@ LogicalResult TensorCloneOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// stream.tensor.encode
+//===----------------------------------------------------------------------===//
+
+LogicalResult TensorEncodeOp::verify() {
+  TensorEncodeOp op = *this;
+  auto sourceEncoding = llvm::cast<RankedTensorType>(op.getSourceEncoding());
+  if (sourceEncoding.getEncoding()) {
+    return op.emitOpError("expects no encodings on the source tensor");
+  }
+  auto resultEncoding = llvm::cast<RankedTensorType>(op.getResultEncoding());
+  if (!resultEncoding.getEncoding()) {
+    return op.emitOpError() << "expects an encoding on the result tensor";
+  }
+  if (failed(verifyOpDynamicDims(op, op.getSourceEncoding(),
+                                 op.getSourceEncodingDims())) ||
+      failed(verifyOpDynamicDims(op, op.getResultEncoding(),
+                                 op.getResultEncodingDims())) ||
+      failed(verifyOpValueSizes(op, op.getSource(), op.getSourceSize())) ||
+      failed(verifyOpValueSizes(op, op.getResult(), op.getResultSize()))) {
+    return failure();
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // stream.tensor.slice
 //===----------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -1430,6 +1430,60 @@ def Stream_TensorCloneOp : Stream_PureOp<"tensor.clone", [
   let hasFolder = 1;
 }
 
+// TODO(hanchung): Add folders.
+def Stream_TensorEncodeOp : Stream_PureOp<"tensor.encode", [
+  AttrSizedOperandSegments,
+  Stream_AffinityOp,
+  Stream_StreamableOp,
+  Stream_TensorPhaseOp,
+  Util_ShapeAwareOp,
+  Util_SizeAwareOp,
+]> {
+  let summary = [{Encodes the contents of a value}];
+  let description = [{
+    Elones the contents of a value at a snapshot in time. Future changes to the
+    identity encoding will not effect the result. Acts as a copy-on-write
+    operation. Otherwise, an executable for encoding the value is generated
+    during lowering.
+  }];
+
+  let arguments = (ins
+    Stream_AnyStreamResource:$source,
+    TypeAttr:$source_encoding,
+    Stream_ShapeDynamicDims:$source_encoding_dims,
+    Stream_Size:$source_size,
+    TypeAttr:$result_encoding,
+    Stream_ShapeDynamicDims:$result_encoding_dims,
+    Stream_Size:$result_size,
+    OptionalAttr<Stream_AffinityAttr>:$affinity
+  );
+  let results = (outs
+    Stream_AnyStreamResource:$result
+  );
+
+  let assemblyFormat = [{
+    (`on` `(` $affinity^ `)`)?
+    $source `:`
+    $source_encoding (`` `{` $source_encoding_dims^ `}`)?
+    `in`
+    type($source) `` `{` $source_size `}`
+    `->`
+    $result_encoding (`` `{` $result_encoding_dims^ `}`)?
+    `in`
+    type($result) `` `{` $result_size `}`
+    attr-dict-with-keyword
+  }];
+
+  let extraClassDeclaration = [{
+    ValueRange getOperandDynamicDims(unsigned idx) { return getSourceEncodingDims(); }
+    ValueRange getResultDynamicDims(unsigned idx) { return getResultEncodingDims(); }
+    Value getOperandSize(unsigned idx) { return getSourceSize(); }
+    Value getResultSize(unsigned idx) { return getResultSize(); }
+  }];
+
+  let hasVerifier = 1;
+}
+
 def Stream_TensorSliceOp : Stream_PureOp<"tensor.slice", [
   AttrSizedOperandSegments,
   Stream_AffinityOp,

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/tensor_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/tensor_ops.mlir
@@ -78,6 +78,17 @@ util.func private @tensorCloneWithEncoding(%arg0: !stream.resource<*>, %arg1: in
 
 // -----
 
+#encoding = #iree_encoding.testing_encoding<>
+// CHECK-DAG:   #[[$ENC:.+]] = #iree_encoding.testing_encoding<>
+// CHECK-LABEL: @tensorEncode
+util.func private @tensorEncode(%arg0: !stream.resource<*>, %arg1: index, %arg2: index) -> !stream.resource<*> {
+  // CHECK: = stream.tensor.encode %arg0 : tensor<?x4xf32>{%arg1} in !stream.resource<*>{%arg2} -> tensor<?x4xf32, #[[$ENC]]>{%arg1} in !stream.resource<*>{%arg2}
+  %0 = stream.tensor.encode %arg0 : tensor<?x4xf32>{%arg1} in !stream.resource<*>{%arg2} -> tensor<?x4xf32, #encoding>{%arg1} in !stream.resource<*>{%arg2}
+  util.return %0 : !stream.resource<*>
+}
+
+// -----
+
 // CHECK-LABEL: @tensorSlice
 util.func private @tensorSlice(%arg0: !stream.resource<*>, %arg1: index, %arg2: index, %arg3: index, %arg4: index) -> !stream.resource<*> {
   %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/tensor_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/tensor_ops.mlir
@@ -81,9 +81,9 @@ util.func private @tensorCloneWithEncoding(%arg0: !stream.resource<*>, %arg1: in
 #encoding = #iree_encoding.testing_encoding<>
 // CHECK-DAG:   #[[$ENC:.+]] = #iree_encoding.testing_encoding<>
 // CHECK-LABEL: @tensorEncode
-util.func private @tensorEncode(%arg0: !stream.resource<*>, %arg1: index, %arg2: index) -> !stream.resource<*> {
-  // CHECK: = stream.tensor.encode %arg0 : tensor<?x4xf32>{%arg1} in !stream.resource<*>{%arg2} -> tensor<?x4xf32, #[[$ENC]]>{%arg1} in !stream.resource<*>{%arg2}
-  %0 = stream.tensor.encode %arg0 : tensor<?x4xf32>{%arg1} in !stream.resource<*>{%arg2} -> tensor<?x4xf32, #encoding>{%arg1} in !stream.resource<*>{%arg2}
+util.func private @tensorEncode(%arg0: !stream.resource<*>, %arg1: index, %arg2: index, %arg3: index) -> !stream.resource<*> {
+  // CHECK: = stream.tensor.encode %arg0 : tensor<?x4xf32>{%arg1} in !stream.resource<*>{%arg2} -> tensor<?x4xf32, #[[$ENC]]>{%arg1} in !stream.resource<*>{%arg3}
+  %0 = stream.tensor.encode %arg0 : tensor<?x4xf32>{%arg1} in !stream.resource<*>{%arg2} -> tensor<?x4xf32, #encoding>{%arg1} in !stream.resource<*>{%arg3}
   util.return %0 : !stream.resource<*>
 }
 

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/tensor_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/tensor_ops.mlir
@@ -81,9 +81,9 @@ util.func private @tensorCloneWithEncoding(%arg0: !stream.resource<*>, %arg1: in
 #encoding = #iree_encoding.testing_encoding<>
 // CHECK-DAG:   #[[$ENC:.+]] = #iree_encoding.testing_encoding<>
 // CHECK-LABEL: @tensorEncode
-util.func private @tensorEncode(%arg0: !stream.resource<*>, %arg1: index, %arg2: index, %arg3: index) -> !stream.resource<*> {
-  // CHECK: = stream.tensor.encode %arg0 : tensor<?x4xf32>{%arg1} in !stream.resource<*>{%arg2} -> tensor<?x4xf32, #[[$ENC]]>{%arg1} in !stream.resource<*>{%arg3}
-  %0 = stream.tensor.encode %arg0 : tensor<?x4xf32>{%arg1} in !stream.resource<*>{%arg2} -> tensor<?x4xf32, #encoding>{%arg1} in !stream.resource<*>{%arg3}
+util.func private @tensorEncode(%arg0: !stream.resource<*>, %arg1: index, %arg2: index, %arg3: index, %arg4: index) -> !stream.resource<*> {
+  // CHECK: = stream.tensor.encode %arg0 : tensor<?x4xf32>{%arg1} in !stream.resource<*>{%arg2} -> tensor<?x4xf32, #[[$ENC]]>{%arg3} in !stream.resource<*>{%arg4}
+  %0 = stream.tensor.encode %arg0 : tensor<?x4xf32>{%arg1} in !stream.resource<*>{%arg2} -> tensor<?x4xf32, #encoding>{%arg3} in !stream.resource<*>{%arg4}
   util.return %0 : !stream.resource<*>
 }
 

--- a/compiler/src/iree/compiler/ExternalInterfaces/StreamExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/StreamExternalModels.cpp
@@ -206,6 +206,7 @@ void registerStreamExternalModels(DialectRegistry &registry) {
     AffinityOpAttrExternalModel<IREE::Flow::TensorEmptyOp>::add(context);
     AffinityOpAttrExternalModel<IREE::Flow::TensorSplatOp>::add(context);
     AffinityOpAttrExternalModel<IREE::Flow::TensorCloneOp>::add(context);
+    AffinityOpAttrExternalModel<IREE::Flow::TensorEncodeOp>::add(context);
     AffinityOpAttrExternalModel<IREE::Flow::TensorSliceOp>::add(context);
     AffinityOpAttrExternalModel<IREE::Flow::TensorUpdateOp>::add(context);
     AffinityOpAttrExternalModel<IREE::Flow::ChannelDefaultOp>::add(context);


### PR DESCRIPTION
The revision introduces `flow.tensor.encode` op and `stream.tensor.encode` op, and the conversion from Flow to Stream.

It is a step towards https://github.com/iree-org/iree/issues/20187