### PR TITLE
Fixing missing Metal HAL allocator parent device reference.

### DIFF
--- a/runtime/src/iree/hal/drivers/metal/direct_allocator.m
+++ b/runtime/src/iree/hal/drivers/metal/direct_allocator.m
@@ -69,6 +69,7 @@ iree_status_t iree_hal_metal_allocator_create(
 
   if (iree_status_is_ok(status)) {
     iree_hal_resource_initialize(&iree_hal_metal_allocator_vtable, &allocator->resource);
+    allocator->parent_device = parent_device;
     allocator->device = [device retain];  // +1
     allocator->is_unified_memory = [device hasUnifiedMemory];
     allocator->resource_tracking_mode = resource_tracking_mode;


### PR DESCRIPTION
I wanted to try out the metal backend, however i always got a runtime assert here:

https://github.com/iree-org/iree/blob/e33829c94027458267a47074f642cf559826bbd6/runtime/src/iree/hal/drivers/metal/metal_buffer.m#L52

This resolved the issue for me. 