### PR TITLE
Limit CTEST_PARALLEL_LEVEL in linux_x64_clang job.

### DIFF
--- a/.github/workflows/ci_linux_x64_clang.yml
+++ b/.github/workflows/ci_linux_x64_clang.yml
@@ -54,6 +54,8 @@ jobs:
           sccache --show-stats
       - name: Run CTest
         run: ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
+        env:
+          CTEST_PARALLEL_LEVEL: 32
       - name: Test iree-dialects
         run: ./build_tools/cmake/test_iree_dialects.sh "${BUILD_DIR}"
 

--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -186,6 +186,7 @@ if (( ${#excluded_tests[@]} )); then
 fi
 
 echo "*************** Running CTest ***************"
+echo "  Using CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL}"
 
 set -x
 ctest ${ctest_args[@]}


### PR DESCRIPTION
Checking if this helps with flaky timeouts like https://github.com/iree-org/iree/actions/runs/13865892809/job/38804796013.

This doesn't add much to total run time.

* Random sample took 32 seconds to run tests using max parallelism: https://github.com/iree-org/iree/actions/runs/13861707751/job/38791587212#step:7:12.
* This PR took 39 seconds to run tests using 32: https://github.com/iree-org/iree/actions/runs/13866660657/job/38807040519?pr=20259#step:7:13

ci-exactly: linux_x64_clang,