### PR TITLE
[python] Register `vector.transform` ops

### DIFF
--- a/compiler/bindings/python/CMakeLists.txt
+++ b/compiler/bindings/python/CMakeLists.txt
@@ -233,6 +233,7 @@ set(_SOURCE_COMPONENTS
   MLIRPythonSources.Dialects.transform.extras
   MLIRPythonSources.Dialects.transform.interpreter
   MLIRPythonSources.Dialects.vector
+  MLIRPythonSources.Dialects.vector_transform
 
   # iree-dialects project.
   IREEDialectsPythonSources

--- a/compiler/bindings/python/test/ir/dialects_test.py
+++ b/compiler/bindings/python/test/ir/dialects_test.py
@@ -6,6 +6,32 @@
 
 from iree.compiler import ir
 
+# Test upstream dialects import
+from iree.compiler.dialects import (
+    affine,
+    amdgpu,
+    arith,
+    builtin,
+    cf,
+    complex,
+    func,
+    gpu,
+    linalg,
+    llvm,
+    math,
+    memref,
+    pdl,
+    rocdl,
+    scf,
+    shape,
+    structured_transform,
+    tensor,
+    tosa,
+    transform,
+    vector,
+    vector_transform,
+)
+
 # Make sure that our dialects import.
 from iree.compiler.dialects import flow, hal, stream, vm, util, iree_codegen, iree_gpu
 

--- a/compiler/bindings/python/test/ir/dialects_test.py
+++ b/compiler/bindings/python/test/ir/dialects_test.py
@@ -24,7 +24,6 @@ from iree.compiler.dialects import (
     rocdl,
     scf,
     shape,
-    structured_transform,
     tensor,
     tosa,
     transform,

--- a/compiler/bindings/python/test/ir/dialects_test.py
+++ b/compiler/bindings/python/test/ir/dialects_test.py
@@ -28,8 +28,8 @@ from iree.compiler.dialects import (
     tosa,
     transform,
     vector,
-    vector_transform,
 )
+from iree.compiler.dialects.vector import transform
 
 # Make sure that our dialects import.
 from iree.compiler.dialects import flow, hal, stream, vm, util, iree_codegen, iree_gpu

--- a/compiler/bindings/python/test/ir/dialects_test.py
+++ b/compiler/bindings/python/test/ir/dialects_test.py
@@ -29,7 +29,11 @@ from iree.compiler.dialects import (
     transform,
     vector,
 )
-from iree.compiler.dialects.vector import transform
+
+# Smoke test for vector transforms
+from iree.compiler.dialects.transform import (
+    apply_conversion_patterns_vector_vector_to_llvm,
+)
 
 # Make sure that our dialects import.
 from iree.compiler.dialects import flow, hal, stream, vm, util, iree_codegen, iree_gpu

--- a/compiler/bindings/python/test/ir/dialects_test.py
+++ b/compiler/bindings/python/test/ir/dialects_test.py
@@ -6,6 +6,19 @@
 
 from iree.compiler import ir
 
+
+# Substitute `replace=True` so that colliding registration don't error.
+# TODO(makslevental): remove after https://github.com/llvm/llvm-project/pull/117918 is resolved.
+def register_attribute_builder(kind, replace=True):
+    def decorator_builder(func):
+        ir.AttrBuilder.insert(kind, func, replace=replace)
+        return func
+
+    return decorator_builder
+
+
+ir.register_attribute_builder = register_attribute_builder
+
 # Test upstream dialects import
 from iree.compiler.dialects import (
     affine,

--- a/compiler/bindings/python/test/ir/dialects_test.py
+++ b/compiler/bindings/python/test/ir/dialects_test.py
@@ -31,9 +31,7 @@ from iree.compiler.dialects import (
 )
 
 # Smoke test for vector transforms
-from iree.compiler.dialects.transform import (
-    apply_conversion_patterns_vector_vector_to_llvm,
-)
+from iree.compiler.dialects.transform import vector as vt
 
 # Make sure that our dialects import.
 from iree.compiler.dialects import flow, hal, stream, vm, util, iree_codegen, iree_gpu


### PR DESCRIPTION
Also, add a simple smoke test for upstream dialects import.