### PR TITLE
[Preprocessing] Form single dispatch programs.

### DIFF
--- a/compiler/src/iree/compiler/Preprocessing/BUILD.bazel
+++ b/compiler/src/iree/compiler/Preprocessing/BUILD.bazel
@@ -21,6 +21,7 @@ iree_compiler_cc_library(
         "Passes.h",
     ],
     deps = [
+        "//compiler/src/iree/compiler/Dialect/LinalgExt/IR",
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "//compiler/src/iree/compiler/DispatchCreation",
         "//compiler/src/iree/compiler/GlobalOptimization",
@@ -29,9 +30,12 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Preprocessing/Common:Transforms",
         "//compiler/src/iree/compiler/Utils",
         "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LinalgTransforms",
         "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:Transforms",
     ],
 )

--- a/compiler/src/iree/compiler/Preprocessing/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Preprocessing/CMakeLists.txt
@@ -19,10 +19,14 @@ iree_cc_library(
     "Passes.cpp"
   DEPS
     LLVMSupport
+    MLIRAnalysis
     MLIRArithDialect
+    MLIRIR
     MLIRLinalgTransforms
     MLIRPass
+    MLIRTensorDialect
     MLIRTransforms
+    iree::compiler::Dialect::LinalgExt::IR
     iree::compiler::Dialect::Util::IR
     iree::compiler::DispatchCreation
     iree::compiler::GlobalOptimization

--- a/compiler/src/iree/compiler/Preprocessing/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Preprocessing/Common/BUILD.bazel
@@ -63,6 +63,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineDialect",
+        "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:DialectUtils",
         "@llvm-project//mlir:FuncDialect",

--- a/compiler/src/iree/compiler/Preprocessing/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Preprocessing/Common/CMakeLists.txt
@@ -42,6 +42,7 @@ iree_cc_library(
     ::PassesIncGen
     LLVMSupport
     MLIRAffineDialect
+    MLIRAnalysis
     MLIRArithDialect
     MLIRFuncDialect
     MLIRFunctionInterfaces

--- a/compiler/src/iree/compiler/Preprocessing/Common/MakeSingleDispatchForFunction.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/MakeSingleDispatchForFunction.cpp
@@ -66,7 +66,7 @@ void MakeSingleDispatchForFunctionPass::runOnOperation() {
   llvm::SetVector<Operation *> firstSlice;
   mlir::getBackwardSlice(block.getTerminator(), &firstSlice, firstSliceOptions);
 
-  // 2. Do the second slice starting form the first slice to remove any ABI
+  // 2. Do the second slice starting from the first slice to remove any ABI
   // related operations on the argument.
   BackwardSliceOptions secondSliceOptions;
   secondSliceOptions.omitUsesFromAbove = false;
@@ -133,7 +133,7 @@ void MakeSingleDispatchForFunctionPass::runOnOperation() {
   }
 
   auto resultTypes =
-      llvm::map_to_vector(results, [](Value v) { return v.getType(); });
+      llvm::map_to_vector(results, [](Value v) -> Type { return v.getType(); });
   auto dispatchRegionOp = rewriter.create<IREE::Flow::DispatchRegionOp>(
       funcOp.getLoc(), resultTypes,
       /*result_dims=*/ValueRange{}, /*workload=*/ValueRange{});

--- a/compiler/src/iree/compiler/Preprocessing/Common/MakeSingleDispatchForFunction.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/MakeSingleDispatchForFunction.cpp
@@ -5,11 +5,18 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
 #include "iree/compiler/Preprocessing/Common/Passes.h"
+#include "llvm/ADT/SetVector.h"
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Analysis/TopologicalSortUtils.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Transforms/RegionUtils.h"
 
 namespace mlir::iree_compiler::Preprocessing {
 
@@ -29,61 +36,120 @@ struct MakeSingleDispatchForFunctionPass
 void MakeSingleDispatchForFunctionPass::runOnOperation() {
   auto funcOp = getOperation();
 
-  // Abort if there are any operations that prevent moving all operations
-  // into a single dispatch.
-  auto walkResult = funcOp.walk([](mlir::CallOpInterface op) -> WalkResult {
-    return WalkResult::interrupt();
-  });
-  if (walkResult.wasInterrupted()) {
-    funcOp->emitOpError("unhandled operation in function body prevents moving "
-                        "body into a single dispatch");
-  }
-
-  // Currently this can only be done for static shapes cause
-  // there is no way of getting the tied dynamic shapes for
-  // a function.
-  auto resultTypes = funcOp.getResultTypes();
-  if (llvm::any_of(resultTypes, [&](Type t) {
-        auto shapedType = dyn_cast<ShapedType>(t);
-        return shapedType && !shapedType.hasStaticShape();
-      })) {
+  Region &body = funcOp.getFunctionBody();
+  if (!llvm::hasSingleElement(body)) {
+    // Do nothing.
     return;
   }
 
-  IRRewriter rewriter(&getContext());
-  Location loc = funcOp.getLoc();
-  Region &funcBody = funcOp.getFunctionBody();
+  Block &block = body.front();
+  auto whitelistedOps = [&](Operation *op) {
+    auto dialect = op->getDialect();
+    if (isa<IREE::LinalgExt::IREELinalgExtDialect, linalg::LinalgDialect,
+            tensor::TensorDialect>(dialect)) {
+      return true;
+    }
+    if (isa<arith::ArithDialect>(dialect)) {
+      return !isa<arith::ConstantOp>(op);
+    }
+    return false;
+  };
 
-  // Split the function entry block to create a new entry block into which the
-  // new operations will be added.
-  Block &entryBlock = funcBody.front();
-  Block *funcBodyStart = rewriter.splitBlock(&entryBlock, entryBlock.begin());
+  // Find the region to outline by doing two slices.
 
-  // Create an empty `flow.dispatch.region` operation with same result type as
-  // the function.
-  rewriter.setInsertionPointToEnd(&entryBlock);
-  auto dispatchRegionOp = rewriter.create<IREE::Flow::DispatchRegionOp>(
-      loc, resultTypes, /*result_dims=*/ValueRange{},
-      /*workload=*/ValueRange{});
+  // 1. The first slice removes any ABI related operations at the return.
+  BackwardSliceOptions firstSliceOptions;
+  firstSliceOptions.omitUsesFromAbove = false;
+  firstSliceOptions.inclusive = true;
+  // Filter returns true for any dialect not allowed.
+  firstSliceOptions.filter = [&](Operation *op) { return !whitelistedOps(op); };
+  llvm::SetVector<Operation *> firstSlice;
+  mlir::getBackwardSlice(block.getTerminator(), &firstSlice, firstSliceOptions);
 
-  // Move the body of the function into the region.
-  Region &region = dispatchRegionOp.getBody();
-  region.getBlocks().splice(region.begin(), funcBody.getBlocks(),
-                            Region::iterator(funcBodyStart), funcBody.end());
-
-  // Replace all `func.return` with `flow.return`.
-  SmallVector<func::ReturnOp> returnOps =
-      llvm::to_vector(region.getOps<func::ReturnOp>());
-  for (auto returnOp : returnOps) {
-    OpBuilder::InsertionGuard g(rewriter);
-    rewriter.setInsertionPoint(returnOp);
-    rewriter.replaceOpWithNewOp<IREE::Flow::ReturnOp>(returnOp,
-                                                      returnOp.getOperands());
+  // 2. Do the second slice starting form the first slice to remove any ABI
+  // related operations on the argument.
+  BackwardSliceOptions secondSliceOptions;
+  secondSliceOptions.omitUsesFromAbove = false;
+  secondSliceOptions.inclusive = true;
+  secondSliceOptions.filter = whitelistedOps;
+  llvm::SetVector<Operation *> secondSlice;
+  for (Operation *op : firstSlice) {
+    for (Value operand : op->getOperands()) {
+      mlir::getBackwardSlice(operand, &secondSlice, secondSliceOptions);
+    }
+  }
+  if (secondSlice.empty()) {
+    return;
   }
 
-  // Return the results of the `flow.dispatch.region`.
-  rewriter.setInsertionPointAfter(dispatchRegionOp);
-  rewriter.create<func::ReturnOp>(loc, dispatchRegionOp.getResults());
+  // 3. Sort  the operations.
+  mlir::topologicalSort(secondSlice);
+
+  // Move the second slice into a `flow.dispatch.region`.
+  MLIRContext *context = &getContext();
+  IRRewriter rewriter(context);
+  Operation *insertionPoint = secondSlice.front();
+  rewriter.setInsertionPoint(insertionPoint);
+
+  // Go over the slice and find the return values, i.e. values defined by ops in
+  // the slice and used outside of the slice.
+  SmallVector<Value> results;
+  for (Operation *op : secondSlice) {
+    for (OpOperand &use : op->getUses()) {
+      Operation *user = use.getOwner();
+      if (!secondSlice.contains(user)) {
+        results.push_back(use.get());
+      }
+    }
+  }
+
+  // Getting the dynamic dimensions of result values in terms of values passed
+  // into the slice should be possible, but is involved. Ignore this case for
+  // now.
+  for (auto result : results) {
+    auto shapedType = dyn_cast<ShapedType>(result.getType());
+    if (!shapedType.hasStaticShape()) {
+      emitError(result.getLoc())
+          << "unhandled dynamic dimensions for created dispatch region";
+      return signalPassFailure();
+    }
+  }
+
+  // Find the values captures by the slice.
+  SmallVector<Value> capturedValues;
+  for (Operation *op : secondSlice) {
+    for (OpOperand &use : op->getOpOperands()) {
+      Operation *definingOp = use.get().getDefiningOp();
+      if (!definingOp || secondSlice.contains(definingOp)) {
+        continue;
+      }
+      capturedValues.push_back(use.get());
+    }
+  }
+  if (failed(moveValueDefinitions(rewriter, capturedValues, insertionPoint))) {
+    funcOp.emitOpError(
+        "failed to move definitions of captured values before region op");
+    return signalPassFailure();
+  }
+
+  auto resultTypes =
+      llvm::map_to_vector(results, [](Value v) { return v.getType(); });
+  auto dispatchRegionOp = rewriter.create<IREE::Flow::DispatchRegionOp>(
+      funcOp.getLoc(), resultTypes,
+      /*result_dims=*/ValueRange{}, /*workload=*/ValueRange{});
+  Region &regionOpBody = dispatchRegionOp.getBody();
+  Block *newBlock = rewriter.createBlock(&regionOpBody, regionOpBody.begin());
+  for (Operation *op : secondSlice) {
+    rewriter.moveOpBefore(op, newBlock, newBlock->end());
+  }
+  rewriter.setInsertionPointToEnd(newBlock);
+  rewriter.create<IREE::Flow::ReturnOp>(dispatchRegionOp.getLoc(), results);
+  rewriter.replaceUsesWithIf(
+      results, dispatchRegionOp->getResults(), [&](OpOperand &use) {
+        Operation *user = use.getOwner();
+        return user->getParentOfType<IREE::Flow::DispatchRegionOp>() !=
+               dispatchRegionOp;
+      });
 }
 
 } // namespace mlir::iree_compiler::Preprocessing

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/make_single_dispatch_for_function.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/make_single_dispatch_for_function.mlir
@@ -1,10 +1,10 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-preprocessing-make-single-dispatch-for-function))" --split-input-file %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-preprocessing-make-single-dispatch-for-function))" --split-input-file --mlir-print-local-scope %s | FileCheck %s
 
-func.func @simple_test() -> tensor<10x20xf32> {
+util.func @simple_test() -> tensor<10x20xf32> {
   %0 = tensor.empty() : tensor<10x20xf32>
-  return %0 : tensor<10x20xf32>
+  util.return %0 : tensor<10x20xf32>
 }
-// CHECK-LABEL: func @simple_test() -> tensor<10x20xf32>
+// CHECK-LABEL: func public @simple_test() -> tensor<10x20xf32>
 //  CHECK-NEXT:   %[[DISPATCH:.+]] = flow.dispatch.region
 //       CHECK:     %[[EMPTY:.+]] = tensor.empty
 //       CHECK:     flow.return %[[EMPTY]]
@@ -12,24 +12,114 @@ func.func @simple_test() -> tensor<10x20xf32> {
 
 // -----
 
-func.func @simple_test_with_cfg(%arg0 : i1) -> tensor<10x20xf32> {
-    cf.cond_br %arg0, ^bb1, ^bb2
-  ^bb1:
-    %0 = tensor.empty() : tensor<10x20xf32>
-    return %0 : tensor<10x20xf32>
-  ^bb2:
-    %1 = arith.constant dense<1.0> : tensor<10x20xf32>
-    return %1 : tensor<10x20xf32>
+// Generic test excercising some basic use case.
+util.func public @conv_2d(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view,
+    %arg2: !hal.fence, %arg3: !hal.fence) -> !hal.buffer_view {
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = hal.tensor.import wait(%arg2) => %arg0 : !hal.buffer_view -> tensor<4x3x234x234xbf16>
+  %1 = hal.tensor.import wait(%arg2) => %arg1 : !hal.buffer_view -> tensor<10x3x3x3xbf16>
+  %2 = tensor.empty() : tensor<4x10x232x232xf32>
+  %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<4x10x232x232xf32>) -> tensor<4x10x232x232xf32>
+  %4 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%0, %1 : tensor<4x3x234x234xbf16>, tensor<10x3x3x3xbf16>) outs(%3 : tensor<4x10x232x232xf32>) -> tensor<4x10x232x232xf32>
+  %5 = tensor.empty() : tensor<4x10x232x232xbf16>
+  %6 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>,
+                       affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
+      iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+      ins(%4 : tensor<4x10x232x232xf32>) outs(%5 : tensor<4x10x232x232xbf16>) {
+  ^bb0(%in: f32, %out: bf16):
+    %9 = arith.truncf %in : f32 to bf16
+    linalg.yield %9 : bf16
+  } -> tensor<4x10x232x232xbf16>
+  %7 = hal.tensor.barrier join(%6 : tensor<4x10x232x232xbf16>) => %arg3 : !hal.fence
+  %8 = hal.tensor.export %7 : tensor<4x10x232x232xbf16> -> !hal.buffer_view
+  util.return %8 : !hal.buffer_view
 }
-// CHECK-LABEL: func @simple_test_with_cfg
-//  CHECK-SAME:     %[[ARG0:.+]]: i1
-//  CHECK-NEXT:   %[[DISPATCH:.+]] = flow.dispatch.region -> (tensor<10x20xf32>) {
-//       CHECK:       cf.cond_br %[[ARG0]], ^[[BB1:[a-zA-Z0-9]+]], ^[[BB2:[a-zA-Z0-9]+]]
-//       CHECK:     ^[[BB1]]:
-//       CHECK:       %[[EMPTY:.+]] = tensor.empty
-//       CHECK:       flow.return %[[EMPTY]]
-//       CHECK:     ^[[BB2]]:
-//       CHECK:       %[[CST:.+]] = arith.constant
-//       CHECK:       flow.return %[[CST]]
-//       CHECK:   }
-//       CHECK:   return %[[DISPATCH]]
+// CHECK-LABEL: func public @conv_2d
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: !hal.buffer_view
+//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: !hal.buffer_view
+//  CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: !hal.fence
+//  CHECK-SAME:     %[[ARG3:[a-zA-Z0-9]+]]: !hal.fence
+//   CHECK-DAG:   %[[CST:.+]] = arith.constant 0.0
+//   CHECK-DAG:   %[[IMPORT0:.+]] = hal.tensor.import wait(%[[ARG2]]) => %[[ARG0]]
+//   CHECK-DAG:   %[[IMPORT1:.+]] = hal.tensor.import wait(%[[ARG2]]) => %[[ARG1]]
+//       CHECK:   %[[DISPATCH:.+]] = flow.dispatch.region
+//       CHECK:     %[[EMPTY:.+]] = tensor.empty()
+//       CHECK:     %[[FILL:.+]] = linalg.fill
+//  CHECK-SAME:         ins(%[[CST]] :
+//  CHECK-SAME:         outs(%[[EMPTY]] :
+//       CHECK:     %[[CONV:.+]] = linalg.conv_2d_nchw_fchw
+//  CHECK-SAME:         ins(%[[IMPORT0]], %[[IMPORT1]] :
+//  CHECK-SAME:         outs(%[[FILL]] :
+//       CHECK:     %[[TRUNC:.+]] = linalg.generic
+//  CHECK-SAME:         ins(%[[CONV]] :
+//       CHECK:     flow.return %[[TRUNC]]
+//       CHECK:   %[[JOIN:.+]] = hal.tensor.barrier join(%[[DISPATCH]] :
+//       CHECK:   %[[EXPORT:.+]] = hal.tensor.export %[[JOIN]]
+//       CHECK:   util.return %[[EXPORT]]
+
+// -----
+
+// Check handling of interleaved ABI ops
+util.func @interleaved_import(%arg0 : !hal.buffer_view, %arg1 : !hal.fence,
+    %arg2 : !hal.buffer_view, %arg3 : !hal.fence,
+    %arg4 : !hal.buffer_view, %arg5 : !hal.fence) -> (tensor<10xf32>, tensor<10xf32>) {
+  %0 = hal.tensor.import wait(%arg1) => %arg0 : !hal.buffer_view -> tensor<10xf32>
+  %1 = hal.tensor.import wait(%arg3) => %arg2 : !hal.buffer_view -> tensor<10xf32>
+  %2 = tensor.empty() : tensor<10xf32>
+  %3 = linalg.add ins(%0, %1 : tensor<10xf32>, tensor<10xf32>)
+      outs(%2 : tensor<10xf32>) -> tensor<10xf32>
+  %4 = hal.tensor.import wait(%arg5) => %arg4 : !hal.buffer_view -> tensor<10xf32>
+  %5 = linalg.add ins(%3, %4 : tensor<10xf32>, tensor<10xf32>)
+      outs(%2 : tensor<10xf32>) -> tensor<10xf32>
+  util.return %3, %5 : tensor<10xf32>, tensor<10xf32>
+}
+// CHECK-LABEL: func public @interleaved_import(
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: !hal.buffer_view
+//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: !hal.fence
+//  CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: !hal.buffer_view
+//  CHECK-SAME:     %[[ARG3:[a-zA-Z0-9]+]]: !hal.fence
+//  CHECK-SAME:     %[[ARG4:[a-zA-Z0-9]+]]: !hal.buffer_view
+//  CHECK-SAME:     %[[ARG5:[a-zA-Z0-9]+]]: !hal.fence
+//   CHECK-DAG:   %[[IMPORT0:.+]] = hal.tensor.import wait(%[[ARG1]]) => %[[ARG0]]
+//   CHECK-DAG:   %[[IMPORT1:.+]] = hal.tensor.import wait(%[[ARG3]]) => %[[ARG2]]
+//   CHECK-DAG:   %[[IMPORT2:.+]] = hal.tensor.import wait(%[[ARG5]]) => %[[ARG4]]
+//       CHECK:   %[[DISPATCH:.+]]:2 = flow.dispatch.region
+//       CHECK:     %[[EMPTY:.+]] = tensor.empty()
+//       CHECK:     %[[ADD1:.+]] = linalg.add ins(%[[IMPORT0]], %[[IMPORT1]] :
+//       CHECK:     %[[ADD2:.+]] = linalg.add ins(%[[ADD1]], %[[IMPORT2]] :
+//       CHECK:     flow.return %[[ADD1]], %[[ADD2]]
+//       CHECK:   return %[[DISPATCH]]#0, %[[DISPATCH]]#1
+
+// -----
+
+// Check handling of interleaved result ABI ops
+util.func @interleaved_export(%arg0 : tensor<10xf32>, %arg1 : tensor<10xf32>,
+    %arg2 : tensor<10xf32>, %arg3 : !hal.fence)
+    -> (!hal.buffer_view, !hal.buffer_view) {
+  %0 = tensor.empty() : tensor<10xf32>
+  %1 = linalg.add ins(%arg0, %arg1 : tensor<10xf32>, tensor<10xf32>)
+      outs(%0 : tensor<10xf32>) -> tensor<10xf32>
+  %2 = hal.tensor.barrier join(%1 : tensor<10xf32>) => %arg3 : !hal.fence
+  %3 = hal.tensor.export %2 : tensor<10xf32> -> !hal.buffer_view
+  %4 = linalg.add ins(%arg2, %1 : tensor<10xf32>, tensor<10xf32>)
+      outs(%0 : tensor<10xf32>) -> tensor<10xf32>
+  %5 = hal.tensor.barrier join(%4 : tensor<10xf32>) => %arg3 : !hal.fence
+  %6 = hal.tensor.export %5 : tensor<10xf32> -> !hal.buffer_view
+  util.return %3, %6 : !hal.buffer_view, !hal.buffer_view
+}
+// CHECK-LABEL: func public @interleaved_export(
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<10xf32>
+//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<10xf32>
+//  CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<10xf32>
+//  CHECK-SAME:     %[[ARG3:[a-zA-Z0-9]+]]: !hal.fence
+//       CHECK:   %[[DISPATCH:.+]]:2 = flow.dispatch.region
+//       CHECK:     %[[EMPTY:.+]] = tensor.empty()
+//       CHECK:     %[[ADD1:.+]] = linalg.add ins(%[[ARG0]], %[[ARG1]] :
+//       CHECK:     %[[ADD2:.+]] = linalg.add ins(%[[ARG2]], %[[ADD1]] :
+//       CHECK:     flow.return %[[ADD1]], %[[ADD2]]
+//   CHECK-DAG:   %[[BARRIER0:.+]] = hal.tensor.barrier join(%[[DISPATCH]]#0 :
+//   CHECK-DAG:   %[[EXPORT0:.+]] = hal.tensor.export %[[BARRIER0]]
+//   CHECK-DAG:   %[[BARRIER1:.+]] = hal.tensor.barrier join(%[[DISPATCH]]#1 :
+//   CHECK-DAG:   %[[EXPORT1:.+]] = hal.tensor.export %[[BARRIER1]]
+//       CHECK:   return %[[EXPORT0]], %[[EXPORT1]]


### PR DESCRIPTION
The `MakeSingleDispatchForFunction` pass was an initial attempt to move the entire program into a single dispatch. It was fairly basic and didnt account for ABI etc. This PR changes the logic of the pass to find the core computation of the function using slices and ignores ABI related operations (and some additional ones).

The pass would previously handle multiple basic-blocks. We should be able to handle them with the new approach, but needs some iteration on how the upstream slicing utilities can be used in that context. Dropping support for that for now, and will be revisited later. This pass is not really used anywhere, so this "support" is not very meaningful.