### PR TITLE
[Preprocessing] Clarify pre-processing preferences.

### DIFF
--- a/compiler/src/iree/compiler/Pipelines/Options.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Options.cpp
@@ -114,9 +114,9 @@ void PreprocessingOptions::bindOptions(OptionsBinder &binder) {
   static llvm::cl::OptionCategory category(
       "Preprocessing options",
       "IREE options for apply custom preprocessing before normal IREE "
-      "compilation flow. These options are exercised in the following order:"
-      " 1. `iree-preprocessing-pass-pipeline`,"
-      " 2. `iree-preprocessing-transform-spec-filename`,"
+      "compilation flow. These options are exercised in the following order:\n"
+      " 1. `iree-preprocessing-pass-pipeline`,\n"
+      " 2. `iree-preprocessing-transform-spec-filename`,\n"
       " 3. `iree-preprocessing-pdl-spec-filename`");
 
   binder.opt<std::string>(
@@ -132,8 +132,7 @@ void PreprocessingOptions::bindOptions(OptionsBinder &binder) {
       llvm::cl::cat(category));
   binder.opt<std::string>(
       "iree-preprocessing-pdl-spec-filename", preprocessingPDLSpecFilename,
-      llvm::cl::desc(
-          "File name of a transform dialect spec to use for preprocessing."),
+      llvm::cl::desc("File name of a PDL spec to use for preprocessing."),
       llvm::cl::cat(category));
 }
 

--- a/compiler/src/iree/compiler/Pipelines/Options.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Options.cpp
@@ -112,8 +112,12 @@ InputDialectOptions::Type InputDialectOptions::parseInputTypeMnemonic() {
 
 void PreprocessingOptions::bindOptions(OptionsBinder &binder) {
   static llvm::cl::OptionCategory category(
+      "Preprocessing options",
       "IREE options for apply custom preprocessing before normal IREE "
-      "compilation flow");
+      "compilation flow. These options are exercised in the following order:"
+      " 1. `iree-preprocessing-pass-pipeline`,"
+      " 2. `iree-preprocessing-transform-spec-filename`,"
+      " 3. `iree-preprocessing-pdl-spec-filename`");
 
   binder.opt<std::string>(
       "iree-preprocessing-pass-pipeline", preprocessingPassPipeline,

--- a/compiler/src/iree/compiler/Preprocessing/Passes.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Passes.cpp
@@ -75,7 +75,7 @@ static void buildPreprocessingPassPipelineFromCommandLine(
     extendWithTextPipeline(passManager, pipelineStr);
   }
   // Second preference is for transform spec file as a preprocessing recipe.
-  else if (!preprocessingOptions.preprocessingTransformSpecFilename.empty()) {
+  if (!preprocessingOptions.preprocessingTransformSpecFilename.empty()) {
     Preprocessing::InterpreterPassOptions interpreterOptions;
     interpreterOptions.transformSpecPath =
         preprocessingOptions.preprocessingTransformSpecFilename;
@@ -83,7 +83,7 @@ static void buildPreprocessingPassPipelineFromCommandLine(
         Preprocessing::createInterpreterPass(interpreterOptions));
   }
   // Third preference is for PDL spec file as a preprocessing recipe.
-  else if (!preprocessingOptions.preprocessingPDLSpecFilename.empty()) {
+  if (!preprocessingOptions.preprocessingPDLSpecFilename.empty()) {
     Preprocessing::ApplyPDLPatternsPassOptions applyPDLPatternsOptions;
     applyPDLPatternsOptions.patternsFile =
         preprocessingOptions.preprocessingPDLSpecFilename;

--- a/compiler/src/iree/compiler/Preprocessing/Passes.h
+++ b/compiler/src/iree/compiler/Preprocessing/Passes.h
@@ -19,12 +19,14 @@ namespace mlir::iree_compiler::Preprocessing {
 /// Placeholder struct for preprocessing pass pipeline options.
 struct TransformOptions : public PassPipelineOptions<TransformOptions> {};
 
-/// Adds a set of passes to the given pass manager that run preprocessing
-/// passes specified in textual pass-pipeline format using
-/// `iree-preprocessing-pass-pipeline`. This allows some user control
-/// on the sequence of preprocessing passes to run after conversion from input
-/// dialects like `stablehlo`/`tosa` before running the core IREE compilation
-/// pipelines (starting with the flow pipeline).
+/// Adds a set of passes to the given pass manager that are run after input
+/// conversion, but before any of the IREE compilation passes. There are many
+/// ways preprocessing passes can be added. These options are exercised in the
+/// following order
+/// 1. Using Command line options : See `PreprocessingOptions` to see the order
+///    of preference for different command line based preprocessing options.
+/// 2. Extensions specified by plugins : Plugins can specify a preprocessing
+///    pass pipeline to run.
 void buildPreprocessingPassPipeline(
     OpPassManager &passManager, const PreprocessingOptions &options,
     PipelineExtensions *pipelineExtensions = nullptr);


### PR DESCRIPTION
There are many ways today of running pre-processing passes. Clarify the preference of modes, and ensure only one path is taken. Current paths and preferences in decreasing order are

1. Command line options a. Textual pass pipeline description b. Transform dialect spec file c. PDL spec file

2. (default) Plugin defined pipeline extensions.

This change should be mostly NFC.