### PR TITLE
[python] Remove linalg import from the test

### DIFF
--- a/compiler/bindings/python/test/ir/dialects_test.py
+++ b/compiler/bindings/python/test/ir/dialects_test.py
@@ -20,29 +20,30 @@ def register_attribute_builder(kind, replace=True):
 ir.register_attribute_builder = register_attribute_builder
 
 # Test upstream dialects import
-# TODO: importing linalg pulls yaml dependency, disable for now
-# from iree.compiler.dialects import (
-#     affine,
-#     amdgpu,
-#     arith,
-#     builtin,
-#     cf,
-#     complex,
-#     func,
-#     gpu,
-#     linalg,
-#     llvm,
-#     math,
-#     memref,
-#     pdl,
-#     rocdl,
-#     scf,
-#     shape,
-#     tensor,
-#     tosa,
-#     transform,
-#     vector,
-# )
+
+from iree.compiler.dialects import (
+    affine,
+    amdgpu,
+    arith,
+    builtin,
+    cf,
+    complex,
+    func,
+    gpu,
+    # TODO: importing linalg pulls yaml dependency, disable for now
+    # linalg, 
+    llvm,
+    math,
+    memref,
+    pdl,
+    rocdl,
+    scf,
+    shape,
+    tensor,
+    tosa,
+    transform,
+    vector,
+)
 
 # Smoke test for vector transforms
 from iree.compiler.dialects.transform import vector as vt

--- a/compiler/bindings/python/test/ir/dialects_test.py
+++ b/compiler/bindings/python/test/ir/dialects_test.py
@@ -20,28 +20,29 @@ def register_attribute_builder(kind, replace=True):
 ir.register_attribute_builder = register_attribute_builder
 
 # Test upstream dialects import
-from iree.compiler.dialects import (
-    affine,
-    amdgpu,
-    arith,
-    builtin,
-    cf,
-    complex,
-    func,
-    gpu,
-    linalg,
-    llvm,
-    math,
-    memref,
-    pdl,
-    rocdl,
-    scf,
-    shape,
-    tensor,
-    tosa,
-    transform,
-    vector,
-)
+# TODO: importing linalg pulls yaml dependency, disable for now
+# from iree.compiler.dialects import (
+#     affine,
+#     amdgpu,
+#     arith,
+#     builtin,
+#     cf,
+#     complex,
+#     func,
+#     gpu,
+#     linalg,
+#     llvm,
+#     math,
+#     memref,
+#     pdl,
+#     rocdl,
+#     scf,
+#     shape,
+#     tensor,
+#     tosa,
+#     transform,
+#     vector,
+# )
 
 # Smoke test for vector transforms
 from iree.compiler.dialects.transform import vector as vt

--- a/compiler/bindings/python/test/ir/dialects_test.py
+++ b/compiler/bindings/python/test/ir/dialects_test.py
@@ -20,7 +20,6 @@ def register_attribute_builder(kind, replace=True):
 ir.register_attribute_builder = register_attribute_builder
 
 # Test upstream dialects import
-
 from iree.compiler.dialects import (
     affine,
     amdgpu,
@@ -31,7 +30,7 @@ from iree.compiler.dialects import (
     func,
     gpu,
     # TODO: importing linalg pulls yaml dependency, disable for now
-    # linalg, 
+    # linalg,
     llvm,
     math,
     memref,


### PR DESCRIPTION
linalg dialect import pulls yaml dependency, which is not present on some CI runners.
