### PR TITLE
[ROCm] Do rewrite `math.fpowi`

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/MathTransformPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MathTransformPass.cpp
@@ -70,8 +70,11 @@ static bool predicateRewrite(StringRef name,
     }
   }
   if (isROCMBackend(target)) {
-    // On ROCm, we want to use device library functions.
-    return false;
+    // On ROCm, we do not need most rewrites as we can generally bottom out on
+    // either device library functions, or handling of intrinsics in AMDGPU.
+    // An important exception is math.fpowi, which needs to get rewritten to
+    // multiplications.
+    return llvm::is_contained({math::FPowIOp::getOperationName()}, name);
   }
   // Currently enable all non-approximative rewrites.
   return true;
@@ -113,7 +116,8 @@ static bool predicateApprox(StringRef name,
     return false;
   }
   if (isROCMBackend(target)) {
-    // On ROCm, we want to use device library functions.
+    // On ROCm, we do not need most rewrites as we can generally bottom out on
+    // either device library functions, or handling of intrinsics in AMDGPU.
     return false;
   }
   StringRef acos = math::AcosOp::getOperationName();


### PR DESCRIPTION
When in #20222 we dropped all math rewrites on ROCm, we lost an important rewrite of `math.fpowi` to multiplications. This caused the regression flagged by @AmosLewis in https://github.com/iree-org/iree/pull/20222#issuecomment-2727793538.