### PR TITLE
[Encoding][NFC] Add builders for PadEncodingLayoutAttr.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -415,9 +415,8 @@ struct GPUPadEncodingLayoutResolverAttrInterface final
     auto encodingAttr = cast<Encoding::EncodingAttr>(type.getEncoding());
 
     const int64_t rank = type.getRank();
-    SmallVector<int32_t> padValues(rank, 0);
-    auto noPaddingAttr = Encoding::PadEncodingLayoutAttr::get(
-        ctx, DenseI32ArrayAttr::get(ctx, padValues));
+    auto noPaddingAttr =
+        Encoding::PadEncodingLayoutAttr::getIdentityAttr(ctx, rank);
     if (encodingAttr.getOpType().getValue() !=
         IREE::Encoding::EncodingOpType::matmul) {
       // We only support simple matmuls for now.
@@ -485,9 +484,9 @@ struct GPUPadEncodingLayoutResolverAttrInterface final
            "Incorrect pad amount");
     assert(padBytes < cacheSetSpanBytes && "Incorrect pad amount");
     const int64_t numPadElements = (padBytes * 8) / elementBits;
+    SmallVector<int32_t> padValues(rank, 0);
     padValues[*padDimensionIndex] = numPadElements;
-    auto padLayout = Encoding::PadEncodingLayoutAttr::get(
-        ctx, DenseI32ArrayAttr::get(ctx, padValues));
+    auto padLayout = Encoding::PadEncodingLayoutAttr::get(ctx, padValues);
     return padLayout;
   }
 };

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
@@ -322,6 +322,17 @@ Value EncodingAttr::calculateStorageSizeInBytes(Location loc,
 // encoding.pad_encoding_layout
 //===---------------------------------------------------------------------===//
 
+PadEncodingLayoutAttr PadEncodingLayoutAttr::get(MLIRContext *ctx,
+                                                 ArrayRef<int32_t> padding) {
+  return get(ctx, DenseI32ArrayAttr::get(ctx, padding));
+}
+
+PadEncodingLayoutAttr PadEncodingLayoutAttr::getIdentityAttr(MLIRContext *ctx,
+                                                             int rank) {
+  SmallVector<int32_t> zeros(rank, 0);
+  return get(ctx, zeros);
+}
+
 Value PadEncodingLayoutAttr::calculateStorageSizeInBytes(
     Location loc, OpBuilder &builder, RankedTensorType type,
     ValueRange dynamicDims) const {

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -171,6 +171,15 @@ def PadEncodingLayoutAttr : IREEEncoding_Attr<"PadEncodingLayout", [
     // How many padding elements to add along each tensor dimension.
     "DenseI32ArrayAttr":$padding
   );
+
+  let builders = [
+    AttrBuilder<(ins "ArrayRef<int32_t>":$padding)>
+  ];
+
+  let extraClassDeclaration = [{
+    /// Returns a PadEncodingLayoutAttr attribute that pads zero elements.
+    static PadEncodingLayoutAttr getIdentityAttr(MLIRContext *ctx, int rank);
+  }];
 }
 
 //===---------------------------------------------------------------------===//


### PR DESCRIPTION
It switches the existing code to use the new builders.