### PR TITLE
Emit an error message if a device alias is used but is missing targets.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/ResolveDeviceAliases.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/ResolveDeviceAliases.cpp
@@ -75,6 +75,13 @@ resolveAliasAttr(Operation *forOp, IREE::HAL::DeviceAliasAttr aliasAttr,
         defaultAttr.getExecutableTargets());
   }
 
+  if (defaultAttr.getExecutableTargets().empty()) {
+    return forOp->emitError()
+           << "device alias " << aliasAttr.getDeviceID()
+           << " does not provide any executable targets; ensure "
+              "device-specific compilation backends have been specified";
+  }
+
   return defaultAttr;
 }
 


### PR DESCRIPTION
Fixes #20283.