### PR TITLE
[docs] Mention TRACY_PORT in tracy profiling docs

### DIFF
--- a/docs/website/docs/developers/performance/profiling-with-tracy.md
+++ b/docs/website/docs/developers/performance/profiling-with-tracy.md
@@ -266,7 +266,7 @@ client application. For example, to run `iree-benchmark-module` on port 1234:
 TRACY_PORT=1234 iree-benchmark-module \
   --device=local-task \
   --module=out.vmfb \
-
+  ...
 ```
 
 ## :octicons-graph-16: Touring the Tracy profiler UI

--- a/docs/website/docs/developers/performance/profiling-with-tracy.md
+++ b/docs/website/docs/developers/performance/profiling-with-tracy.md
@@ -259,6 +259,16 @@ adb forward tcp:8086 tcp:8086
 You can also pass `-p <port>` to the capture tool to override the default port
 to connect to, or use the Tracy GUI which scans other ports too.
 
+The `TRACY_PORT` environment variable can be used to change the port used by the
+client application. For example, to run `iree-benchmark-module` on port 1234:
+
+```shell
+TRACY_PORT=1234 iree-benchmark-module \
+  --device=local-task \
+  --module=out.vmfb \
+
+```
+
 ## :octicons-graph-16: Touring the Tracy profiler UI
 
 The initial view should look like this:


### PR DESCRIPTION
I was looking for a way to change the port used by the `iree-*` runtime tools but I wasn't able to find a mention to `TRACY_PORT` in the docs. This adds a small mention below the section that discusses changing the port of the capture tool.