### PR TITLE
[Stream] Implement folders for stream.tensor.encode op.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -1432,7 +1432,6 @@ def Stream_TensorCloneOp : Stream_PureOp<"tensor.clone", [
   let hasFolder = 1;
 }
 
-// TODO(hanchung): Add folders.
 def Stream_TensorEncodeOp : Stream_PureOp<"tensor.encode", [
   AttrSizedOperandSegments,
   Stream_AffinityOp,
@@ -1484,6 +1483,7 @@ def Stream_TensorEncodeOp : Stream_PureOp<"tensor.encode", [
   }];
 
   let hasVerifier = 1;
+  let hasFolder = 1;
 }
 
 def Stream_TensorSliceOp : Stream_PureOp<"tensor.slice", [

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/tensor_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/tensor_folding.mlir
@@ -206,3 +206,36 @@ util.func private @ElideUnneededTensorClones(%arg0: !stream.resource<*>, %arg1: 
   // CHECK: util.return %[[T1]]
   util.return %2 : f32
 }
+
+// -----
+
+#encoding = #iree_encoding.pad_encoding_layout<[0, 0]>
+// CHECK-LABEL: @FoldTensorEncodeOpWithIdentitySource(
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]
+util.func private @FoldTensorEncodeOpWithIdentitySource(%arg0: !stream.resource<*>, %arg1: index) -> !stream.resource<*> {
+  %0 = stream.tensor.encode %arg0 : tensor<2x2xf32, #encoding> in !stream.resource<*>{%arg1} -> tensor<2x2xf32> in !stream.resource<*>{%arg1}
+  // CHECK:         util.return %[[SRC]]
+  util.return %0 : !stream.resource<*>
+}
+
+// -----
+
+#encoding = #iree_encoding.pad_encoding_layout<[0, 0]>
+// CHECK-LABEL: @FoldTensorEncodeOpWithIdentityResult(
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]
+util.func private @FoldTensorEncodeOpWithIdentityResult(%arg0: !stream.resource<*>, %arg1: index) -> !stream.resource<*> {
+  %0 = stream.tensor.encode %arg0 : tensor<2x2xf32> in !stream.resource<*>{%arg1} -> tensor<2x2xf32, #encoding> in !stream.resource<*>{%arg1}
+  // CHECK:         util.return %[[SRC]]
+  util.return %0 : !stream.resource<*>
+}
+
+// -----
+
+#encoding = #iree_encoding.unknown
+// CHECK-LABEL: @FoldTensorEncodeOpWithSameSourceResultEncodings(
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]
+util.func private @FoldTensorEncodeOpWithSameSourceResultEncodings(%arg0: !stream.resource<*>, %arg1: index) -> !stream.resource<*> {
+  %0 = stream.tensor.encode %arg0 : tensor<2x2xf32, #encoding> in !stream.resource<*>{%arg1} -> tensor<2x2xf32, #encoding> in !stream.resource<*>{%arg1}
+  // CHECK:         util.return %[[SRC]]
+  util.return %0 : !stream.resource<*>
+}

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/tensor_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/tensor_folding.mlir
@@ -231,11 +231,37 @@ util.func private @FoldTensorEncodeOpWithIdentityResult(%arg0: !stream.resource<
 
 // -----
 
-#encoding = #iree_encoding.unknown
+#encoding = #iree_encoding.unknown_encoding
 // CHECK-LABEL: @FoldTensorEncodeOpWithSameSourceResultEncodings(
 // CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]
 util.func private @FoldTensorEncodeOpWithSameSourceResultEncodings(%arg0: !stream.resource<*>, %arg1: index) -> !stream.resource<*> {
   %0 = stream.tensor.encode %arg0 : tensor<2x2xf32, #encoding> in !stream.resource<*>{%arg1} -> tensor<2x2xf32, #encoding> in !stream.resource<*>{%arg1}
   // CHECK:         util.return %[[SRC]]
+  util.return %0 : !stream.resource<*>
+}
+
+// -----
+
+#encoding = #iree_encoding.unknown_encoding
+// CHECK-LABEL:  @NofoldTensorEncodingOpWithUnknownSourceEncoding
+util.func public @NofoldTensorEncodingOpWithUnknownSourceEncoding(%arg0: !stream.resource<*>, %arg1: index, %arg2: index, %arg3: index) -> !stream.resource<*> {
+  // CHECK: %[[RESULT:.+]] = stream.tensor.encode
+  // CHECK: util.return %[[RESULT]]
+  %0 = stream.tensor.encode on(#hal.device.affinity<@device_a>)
+    %arg0 : tensor<?x?xf32, #encoding>{%arg2, %arg3} in !stream.resource<*>{%arg1}
+    -> tensor<?x?xf32>{%arg2, %arg3} in !stream.resource<*>{%arg1}
+  util.return %0 : !stream.resource<*>
+}
+
+// -----
+
+#encoding = #iree_encoding.unknown_encoding
+// CHECK-LABEL:  @NofoldTensorEncodingOpWithUnknownResultEncoding
+util.func public @NofoldTensorEncodingOpWithUnknownResultEncoding(%arg0: !stream.resource<*>, %arg1: index, %arg2: index, %arg3: index) -> !stream.resource<*> {
+  // CHECK: %[[RESULT:.+]] = stream.tensor.encode
+  // CHECK: util.return %[[RESULT]]
+  %0 = stream.tensor.encode on(#hal.device.affinity<@device_a>)
+    %arg0 : tensor<?x?xf32>{%arg2, %arg3} in !stream.resource<*>{%arg1}
+    -> tensor<?x?xf32, #encoding>{%arg2, %arg3} in !stream.resource<*>{%arg1}
   util.return %0 : !stream.resource<*>
 }


### PR DESCRIPTION
There are few folders available for `stream.tensor.encode` op, we can fold it into the source resource for the cases:
- The source encoding is as the same as the result encoding.
- If they are not identical, fold the op when the source layout and the result layout are identity layouts.

A tensor type without encodings is recognized as an identity layout. A tensor type with the encoding is an identity layout if the encoding attribute implements the `isIdentityLayout` interface method and it returns true.