### PR TITLE
Deprecate `--iree-codegen-gpu-native-math-precision`

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -172,6 +172,10 @@ bool isROCMBackend(IREE::HAL::ExecutableTargetAttr targetAttr) {
   return targetAttr && targetAttr.getBackend().getValue().starts_with("rocm");
 }
 
+bool isWebGPUBackend(IREE::HAL::ExecutableTargetAttr targetAttr) {
+  return targetAttr && targetAttr.getBackend().getValue().starts_with("webgpu");
+}
+
 static const char *getDefaultEnabledUkernels(Attribute attr) {
   const char *kNone = "none";
   if (!attr) {

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -64,6 +64,7 @@ const char *getIreeArchNameForTargetTriple(llvm::Triple triple);
 bool isLLVMCPUBackend(IREE::HAL::ExecutableTargetAttr targetAttr);
 bool isVMVXBackend(IREE::HAL::ExecutableTargetAttr targetAttr);
 bool isROCMBackend(IREE::HAL::ExecutableTargetAttr targetAttr);
+bool isWebGPUBackend(IREE::HAL::ExecutableTargetAttr targetAttr);
 
 // Returns true if the ukernel with given `ukernelName` is enabled.
 // If `ukernelName` is empty (the default), returns true if any ukernel

--- a/experimental/web/sample_webgpu/build_sample.sh
+++ b/experimental/web/sample_webgpu/build_sample.sh
@@ -50,14 +50,11 @@ mkdir -p ${BINARY_DIR}
 ###############################################################################
 
 echo "=== Compiling sample MLIR files to VM FlatBuffer outputs (.vmfb) ==="
-
-# TODO(#11321): Enable iree-codegen-gpu-native-math-precision by default?
 compile_sample() {
   echo "  Compiling '$1' sample for WebGPU..."
   "${HOST_TOOLS_BINARY_DIR}/iree-compile" $3 \
     --iree-input-type=$2 \
     --iree-hal-target-backends=webgpu-spirv \
-    --iree-codegen-gpu-native-math-precision=true \
     --iree-stream-resource-alias-mutable-bindings=true \
     --o ${BINARY_DIR}/$1_webgpu.vmfb
 }

--- a/experimental/web/sample_webgpu/index.html
+++ b/experimental/web/sample_webgpu/index.html
@@ -181,7 +181,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     <textarea type="text" readonly spellcheck="false"
     class="form-control" style="width:610px; height:90px; resize:none; font-family: monospace;">
 --iree-hal-target-backends=webgpu-spirv \
---iree-codegen-gpu-native-math-precision=true \
 --iree-stream-resource-alias-mutable-bindings=true \</textarea>
 
   </div>

--- a/tests/e2e/stablehlo_ops/CMakeLists.txt
+++ b/tests/e2e/stablehlo_ops/CMakeLists.txt
@@ -676,7 +676,7 @@ iree_check_single_backend_test_suite(
     "negate.mlir"
     "pad.mlir"
     # "philox.mlir"  # TODO(#12509): WebGPU SPIR-V broken
-    "pow.mlir"
+    # "pow.mlir"  # TODO(#11321): error: value nan cannot be represented as 'f32'
     "reduce.mlir"
     "reduce_window.mlir"
     "remainder.mlir"
@@ -707,7 +707,6 @@ iree_check_single_backend_test_suite(
   #   "webgpu"
   COMPILER_FLAGS
     "--iree-input-type=stablehlo"
-    "--iree-codegen-gpu-native-math-precision=true"  # TODO(#11321): Infer/flip default
 )
 
 iree_check_single_backend_test_suite(

--- a/tests/e2e/tosa_ops/CMakeLists.txt
+++ b/tests/e2e/tosa_ops/CMakeLists.txt
@@ -499,7 +499,6 @@ iree_check_single_backend_test_suite(
   #   "webgpu"
   COMPILER_FLAGS
     "--iree-input-type=tosa"
-    "--iree-codegen-gpu-native-math-precision=true"  # TODO(#11321): Infer/flip default
 )
 
 iree_check_single_backend_test_suite(


### PR DESCRIPTION
This was mostly used on ROCm and WebGPU.

On ROCm, over the past month we have made this be essentially the default behavior, so the flag is essentially not needed anymore. The last thing required before we can drop usage of the flag on ROCm is https://github.com/iree-org/iree/pull/20074.

On WebGPU, this PR makes this be the default behavior like on ROCm, so this PR also drops the flag. The WGSL spec issue https://github.com/gpuweb/gpuweb/issues/5109 mentioned in the comment explains the problem. It has also been discussed in the past as https://github.com/iree-org/iree/issues/11321.