### PR TITLE
[Codegen] Replace upstream constant bufferization pass with our own

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
@@ -46,6 +46,7 @@ using mlir::bufferization::OneShotBufferizationOptions;
 namespace mlir::iree_compiler {
 
 #define GEN_PASS_DEF_ELIMINATEEMPTYTENSORSPASS
+#define GEN_PASS_DEF_IREEBUFFERIZECONSTANTSPASS
 #define GEN_PASS_DEF_IREECOMPREHENSIVEBUFFERIZEPASS
 #include "iree/compiler/Codegen/Common/Passes.h.inc"
 
@@ -119,6 +120,20 @@ public:
 private:
   const BufferizationOptions::AllocationFn allocationFn = defaultAllocationFn;
   const BufferizationOptions::MemCpyFn memCpyFn = defaultMemCpyFn;
+};
+
+/// Pass to convert from tensor based constants to memref.
+class IREEBufferizeConstantsPass final
+    : public impl::IREEBufferizeConstantsPassBase<IREEBufferizeConstantsPass> {
+public:
+  using impl::IREEBufferizeConstantsPassBase<
+      IREEBufferizeConstantsPass>::IREEBufferizeConstantsPassBase;
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<arith::ArithDialect, bufferization::BufferizationDialect,
+                    memref::MemRefDialect>();
+  }
+
+  void runOnOperation() override;
 };
 } // namespace
 
@@ -241,6 +256,19 @@ void IREEComprehensiveBufferizePass::runOnOperation() {
   }
 }
 
+void IREEBufferizeConstantsPass::runOnOperation() {
+  mlir::bufferization::OneShotBufferizationOptions opt;
+  opt.copyBeforeWrite = true;
+  opt.enforceAliasingInvariants = false;
+  opt.opFilter.allowOperation(arith::ConstantOp::getOperationName());
+  if (failed(
+          mlir::bufferization::runOneShotBufferize(getOperation(), opt,
+                                                   /*statistics=*/nullptr))) {
+    signalPassFailure();
+    return;
+  }
+}
+
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createIREEComprehensiveBufferizePass(
     std::optional<BufferizationOptions::AllocationFn> allocationFn,
@@ -273,14 +301,6 @@ void addIREEComprehensiveBufferizePasses(
   funcPassManager.addPass(
       createIREEComprehensiveBufferizePass(allocationFn, memCpyFn));
   addIREEPostBufferizationPasses(funcPassManager);
-}
-
-void addConstantBufferizePasses(OpPassManager &funcPassManager) {
-  OneShotBufferizationOptions options;
-  options.copyBeforeWrite = true;
-  options.enforceAliasingInvariants = false;
-  options.opFilter.allowOperation(arith::ConstantOp::getOperationName());
-  funcPassManager.addPass(bufferization::createOneShotBufferizePass(options));
 }
 
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.h
@@ -48,8 +48,6 @@ void addIREEComprehensiveBufferizePasses(
         std::nullopt,
     std::optional<BufferizationOptions::MemCpyFn> memCpyFn = std::nullopt);
 
-void addConstantBufferizePasses(OpPassManager &funcPassManager);
-
 /// Populate Encoding to Nop pass and canonicalizer pass to the pipeline.
 void addEncodingToNopPasses(FunctionLikeNest &passManager);
 

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -393,6 +393,11 @@ def HoistStaticallyBoundAllocationsPass :
   ];
 }
 
+def IREEBufferizeConstantsPass :
+    Pass<"iree-codegen-iree-bufferize-constants", ""> {
+  let summary = "Convert from arith.constant on tensors to buffers";
+}
+
 def IREEComprehensiveBufferizePass :
     InterfacePass<"iree-codegen-iree-comprehensive-bufferize", "mlir::FunctionOpInterface"> {
   let summary = "Convert from to Linalg ops on tensors to buffers";

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -706,7 +706,7 @@ static void addLowerToLLVMPasses(OpPassManager &modulePassManager,
       .addPass(createCSEPass);
 
   // Handled tensor-type constants.
-  addConstantBufferizePasses(modulePassManager);
+  modulePassManager.addPass(createIREEBufferizeConstantsPass());
 
   FunctionLikeNest(modulePassManager)
       .addPass(createFoldTensorExtractOpPass)

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1093,7 +1093,7 @@ static void addLowerToLLVMGPUPasses(OpPassManager &modulePassManager,
       .addPass(createCSEPass);
 
   // Handled tensor constants.
-  addConstantBufferizePasses(modulePassManager);
+  modulePassManager.addPass(createIREEBufferizeConstantsPass());
 
   FunctionLikeNest funcPassManager(modulePassManager);
   funcPassManager.addPass(createFoldTensorExtractOpPass)

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
@@ -86,7 +86,7 @@ buildVectorVMVXTransformPassPipeline(OpPassManager &variantPassManager) {
       .addPass(memref::createExpandOpsPass);
 
   // Handle tensor-type constants.
-  addConstantBufferizePasses(modulePassManager);
+  modulePassManager.addPass(createIREEBufferizeConstantsPass());
   FunctionLikeNest(modulePassManager)
       .addPass(createFoldTensorExtractOpPass)
 


### PR DESCRIPTION
Recently the upstream constructor for the OneShotBufferizePass was refactored and no longer supported some of the options we needed. Our use case for it was fairly specific so this replaces it with our own IREEBufferizeConstantsPass.

This also drops the revert getting us to a clean state with integrate.