### PR TITLE
Drop manual bf16 handling (currently just in LLVMGPU)

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1102,9 +1102,6 @@ static void addLowerToLLVMGPUPasses(OpPassManager &modulePassManager,
       .addPass(createCSEPass)
       // Handle complex operation conversion.
       .addPass(createConvertComplexToStandardPass)
-      // Convert BF16 operations to occur as F32.
-      .addPass(createConvertBf16ArithToF32Pass)
-      .addPass(createConvertBf16ToUInt16BuffersPass)
       // Math dialect ops rewrites, approximations, casts.
       .addPass(createMathTransformPass)
       .addPass(memref::createExpandOpsPass)


### PR DESCRIPTION
Get rid of the manual bfloat expansion pass because LLVM has a bfloat16 type and the AMDGU backend supports it.

The pass remains in the LLVMCPU pipeline (since not having it causes linker errors that aren't worth fixing) and in the SPIR-V backend, where there's no official bf16 type.

This PR seems to generate the CUDA tests fine, but since we haven't run them, it may cause issues.