### PR TITLE
Fix asm parsing for `Util_PreprocessingPipelineAttr`

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.td
@@ -222,7 +222,7 @@ def Util_PreprocessingPipelineAttr : AttrDef<Util_Dialect,
         "iree-preprocessing-transpose-convolution-pipeline">```
   }];
   let parameters = (ins
-    AttrParameter<"std::string", "">:$pipelineString
+    AttrParameter<"StringAttr", "">:$pipelineString
   );
 
   let assemblyFormat = [{

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/attributes.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/attributes.mlir
@@ -72,7 +72,6 @@ builtin.module @uninitialized attributes {
   util.tensor = #util.uninitialized : tensor<4xf32>
 } {}
 
-
 // -----
 
 // CHECK-LABEL: @preprocessing_pipeline

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/attributes.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/attributes.mlir
@@ -71,3 +71,14 @@ builtin.module @uninitialized attributes {
   // CHECK: util.tensor = #util.uninitialized : tensor<4xf32>
   util.tensor = #util.uninitialized : tensor<4xf32>
 } {}
+
+
+// -----
+
+// CHECK-LABEL: @preprocessing_pipeline
+builtin.module @preprocessing_pipeline {
+  // CHECK: util.func public @main() attributes {preprocessing_pipeline = #util.preprocessing_pipeline<"some-iree-preprocessing-pass-pipeline">}
+  util.func public @main() attributes {preprocessing_pipeline = #util.preprocessing_pipeline<"some-iree-preprocessing-pass-pipeline">} {
+    util.return
+  }
+}

--- a/compiler/src/iree/compiler/Preprocessing/Common/AttrBasedPipelinePass.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/AttrBasedPipelinePass.cpp
@@ -72,7 +72,8 @@ void AttrBasedPipelinePass::runOnOperation() {
       continue;
     }
 
-    std::string pipelineStr = passPipelineAttr.getPipelineString();
+    std::string pipelineStr =
+        passPipelineAttr.getPipelineString().getValue().str();
     if (failed(parsePassPipeline(pipelineStr, *passManager))) {
       funcLikeOp->emitOpError("failed to populate pass manager specified by : ")
           << pipelineStr;


### PR DESCRIPTION
This changes the contained `pipelineStr` to a `StringAttr`, since parsing the assembly format of this attribute would drop the quotes on `pipelineStr`, and then would fail on `AttrBasedPipelinePass`.