### PR TITLE
Integrate llvm-project@7af0bfe62

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
@@ -259,7 +259,6 @@ void IREEComprehensiveBufferizePass::runOnOperation() {
 void IREEBufferizeConstantsPass::runOnOperation() {
   mlir::bufferization::OneShotBufferizationOptions opt;
   opt.copyBeforeWrite = true;
-  opt.enforceAliasingInvariants = false;
   opt.opFilter.allowOperation(arith::ConstantOp::getOperationName());
   if (failed(
           mlir::bufferization::runOneShotBufferize(getOperation(), opt,


### PR DESCRIPTION
`enforceAliasingInvariants` was dropped upstream.