### PR TITLE
Do not wrap a single set_encoding op into flow.dispatch.region. 

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
@@ -856,8 +856,7 @@ decideFusableLinalgOps(Region &region, DominanceInfo const &dominanceInfo,
       // to convert them to splats. Also avoid moving dequantization-like ops
       // into their own dispatch since it is better to clone these ops and avoid
       // materializing large tensors between dispatches.
-      if (!isa<linalg::LinalgOp, tensor::PadOp, linalg::PackOp,
-               IREE::Encoding::SetEncodingOp>(op) ||
+      if (!isa<linalg::LinalgOp, tensor::PadOp, linalg::PackOp>(op) ||
           IREE::Flow::isClonableIntoDispatchOp(&op, clonableOptions)) {
         continue;
       }

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -255,9 +255,11 @@ addDispatchRegionCreationPasses(OpPassManager &passManager,
         .addPass(DispatchCreation::createHoistEncodingOpsPass)
         // After SetEncodingOps are hoisted, try to fuse them with their
         // producer dispatches to try to hide packing costs.
-        .addPass(DispatchCreation::createFuseEncodingOpsIntoDispatchRegionsPass)
-        .addPass(DispatchCreation::createConvertEncodingToFlowPass);
+        .addPass(
+            DispatchCreation::createFuseEncodingOpsIntoDispatchRegionsPass);
   }
+  FunctionLikeNest(passManager)
+      .addPass(DispatchCreation::createConvertEncodingToFlowPass);
 }
 
 // Apply preprocessing and form dispatch regions

--- a/compiler/src/iree/compiler/DispatchCreation/test/dispatch_linalg_on_tensors.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/dispatch_linalg_on_tensors.mlir
@@ -1823,41 +1823,6 @@ util.func public @batchnorm_training(%arg0: tensor<12xf32>, %arg1: tensor<12x12x
 // -----
 
 #encoding = #iree_encoding.testing_encoding<>
-util.func public @set_encoding_op(%arg0 : tensor<?x?xf32>)
-    -> tensor<?x?xf32, #encoding> {
-  %0 = iree_encoding.set_encoding %arg0
-      : tensor<?x?xf32> -> tensor<?x?xf32, #encoding>
-  util.return %0 : tensor<?x?xf32, #encoding>
-}
-//      CHECK: #[[ENCODING:.+]] = #iree_encoding.testing_encoding<>
-//      CHECK: util.func public @set_encoding_op
-// CHECK-SAME:     %[[ARG0:.+]]: tensor<?x?xf32>
-//  CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
-//  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//  CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
-//  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG0]], %[[C1]]
-//      CHECK:   %[[DISPATCH:.+]] = flow.dispatch.workgroups[%[[D0]], %[[D1]]](%[[ARG0]], %[[D0]], %[[D1]])
-// CHECK-NEXT:     %[[INARG:.+]]: !flow.dispatch.tensor<readonly:tensor<?x?xf32>>
-// CHECK-SAME:     %[[INDEXARG0:[a-zA-Z0-9]+]]: index
-// CHECK-SAME:     %[[INDEXARG1:[a-zA-Z0-9]+]]: index
-// CHECK-SAME:     %[[OUTARG:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #[[ENCODING]]>>
-//  CHECK-DAG:     %[[W0:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG0]], 0
-//  CHECK-DAG:     %[[W1:.+]] = flow.dispatch.workload.ordinal %[[INDEXARG1]], 1
-//      CHECK:     %[[LOAD:.+]] = flow.dispatch.tensor.load %[[INARG]]
-// CHECK-SAME:         !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%[[W0]], %[[W1]]}
-//      CHECK:     %[[SET_ENCODING:.+]] = iree_encoding.set_encoding %[[LOAD]]
-//      CHECK:     flow.dispatch.tensor.store %[[SET_ENCODING]], %[[OUTARG]]
-// CHECK-SAME:         sizes = [%[[W0]], %[[W1]]]
-// CHECK-SAME:         !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #[[ENCODING]]>>{%[[W0]], %[[W1]]}
-//      CHECK:     flow.return
-//      CHECK:   count(%[[WL0:[a-zA-Z0-9]+]]: index, %[[WL1:[a-zA-Z0-9]+]]: index)
-//      CHECK:     %[[X:[a-zA-Z0-9]+]], %[[Y:[a-zA-Z0-9]+]], %[[Z:.+]] = flow.dispatch.workgroup_count_from_slice %[[WL0]], %[[WL1]]
-//      CHECK:     flow.return %[[X]], %[[Y]], %[[Z]]
-//      CHECK:   util.return %[[DISPATCH]]
-
-// -----
-
-#encoding = #iree_encoding.testing_encoding<>
 util.func public @unset_encoding_op(%arg0 : tensor<?x?xf32, #encoding>, %d0 : index, %d1 : index)
     -> tensor<?x?xf32> {
   %0 = iree_encoding.unset_encoding %arg0

--- a/compiler/src/iree/compiler/DispatchCreation/test/form_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/form_dispatch_regions.mlir
@@ -210,6 +210,23 @@ util.func public @set_encoding_pad_fusion(%arg0 : tensor<?x?xf32>,
 
 // -----
 
+
+#encoding = #iree_encoding.testing_encoding<>
+util.func public @set_encoding_op(%arg0 : tensor<?x?xf32>)
+    -> tensor<?x?xf32, #encoding> {
+  %encode = iree_encoding.set_encoding %arg0
+      : tensor<?x?xf32> -> tensor<?x?xf32, #encoding>
+  util.return %encode : tensor<?x?xf32, #encoding>
+}
+//      CHECK: #[[ENCODING:.+]] = #iree_encoding.testing_encoding
+//      CHECK: util.func public @set_encoding_op
+// CHECK-SAME:     %[[ARG0:.+]]: tensor<?x?xf32>
+//  CHECK-NOT:   flow.dispatch.region
+//      CHECK:   %[[ENCODE:.+]] = iree_encoding.set_encoding %[[ARG0]]  : tensor<?x?xf32> -> tensor<?x?xf32, #[[ENCODING]]>
+// CHECK: util.return %[[ENCODE]]
+
+// -----
+
 #encoding = #iree_encoding.testing_encoding<>
 util.func public @unset_encoding_elementwise_fusion(
     %arg0: tensor<?x?xf32, #encoding>,

--- a/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests.mlir
@@ -263,3 +263,21 @@ util.func public @verify_bubbling(%arg0: !hal.buffer_view, %arg2: !hal.fence) ->
 //       CHECK:     %[[GEN:.+]] = linalg.generic
 //       CHECK:      flow.dispatch.tensor.store %[[GEN]]
 //   CHECK-NOT:   linalg.generic
+
+// -----
+
+#encoding = #iree_encoding.testing_encoding<>
+util.func public @set_encoding_op(%arg0 : tensor<?x?xf32>)
+    -> tensor<?x?xf32, #encoding> {
+  %0 = iree_encoding.set_encoding %arg0
+      : tensor<?x?xf32> -> tensor<?x?xf32, #encoding>
+  util.return %0 : tensor<?x?xf32, #encoding>
+}
+// CHECK-LABEL: util.func public @set_encoding_op
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:     %[[D0:.+]] = tensor.dim %[[SRC]], %[[C0]]
+// CHECK-DAG:     %[[D1:.+]] = tensor.dim %[[SRC]], %[[C1]]
+// CHECK:         %[[RES:.+]] = flow.tensor.encode %[[SRC]] : tensor<?x?xf32>{%[[D0]], %[[D1]]} -> tensor<?x?xf32, #iree_encoding.testing_encoding<>>{%[[D0]], %[[D1]]}
+// CHECK:         util.return %[[RES]]


### PR DESCRIPTION
This makes the set_encoding dispatch become `flow.tensor.encode` op if the setting encoding happens before dispatch formation. The op is folded away if an identity layout is identified.

It deletes an outdated test from `dispatch_linalg_on_tensors.mlir`, and adds the set_encoding test case to both `form_dispatch_regions.mlir` and `pipeline_tests.mlir`.

It is a step towards https://github.com/iree-org/iree/issues/20187