### PR TITLE
Extend IGEMM utils to support conv2d_chwn_chwf ops

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv_to_im2col.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv_to_im2col.mlir
@@ -285,3 +285,43 @@ util.func public @conv_2d_chwn_chwf(%arg0: tensor<16x26x18x288xf32>, %arg1: tens
 // CHECK:          arith.addf
 // CHECK:      } -> tensor<288x3x3x288xf32>
 // CHECK:      util.return %[[MATMUL]] : tensor<288x3x3x288xf32>
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0 + d4, d1 + d5, d6, d3)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d2)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+util.func public @conv_2d_hwcn_hwcf(%arg0: tensor<26x18x16x288xf32>, %arg1: tensor<24x16x16x288xf32>, %arg2: tensor<3x3x288x288xf32>) -> tensor<3x3x288x288xf32> {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<26x18x16x288xf32>, tensor<24x16x16x288xf32>) outs(%arg2 : tensor<3x3x288x288xf32>) {
+  ^bb0(%in: f32, %in_3: f32, %out: f32):
+    %12 = arith.mulf %in, %in_3 : f32
+    %13 = arith.addf %out, %12 : f32
+    linalg.yield %13 : f32
+  } -> tensor<3x3x288x288xf32>
+  util.return %0 : tensor<3x3x288x288xf32>
+}
+
+// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d2, d0, d1, d4)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d4, d2)>
+// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
+// CHECK:      util.func public @conv_2d_hwcn_hwcf(
+// CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<26x18x16x288xf32>
+// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<24x16x16x288xf32>
+// CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<3x3x288x288xf32>
+// CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<288x3x3x6144xf32>
+// CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
+// CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [24, 16]
+// CHECK-SAME:   m_offset = [0, 0] * [3, 1] k_offset = [0] * [1]
+// CHECK-SAME:   batch_pos = [3] m_pos = [0, 1] k_pos = [2]
+// CHECK-SAME:   ins(%[[ARG0]] : tensor<26x18x16x288xf32>)
+// CHECK-SAME:   outs(%[[EMPTY]] : tensor<288x3x3x6144xf32>) -> tensor<288x3x3x6144xf32>
+// CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0, 1, 2], [3]] : tensor<24x16x16x288xf32> into tensor<6144x288xf32>
+// CHECK:      %[[MATMUL:.+]] = linalg.generic
+// CHECK-SAME:   indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
+// CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]
+// CHECK-SAME:   ins(%[[IM2COL]], %[[COLLAPSED]] : tensor<288x3x3x6144xf32>,  tensor<6144x288xf32>)
+// CHECK-SAME:   outs(%[[ARG2]] : tensor<3x3x288x288xf32>) {
+// CHECK:          arith.mulf
+// CHECK:          arith.addf
+// CHECK:      } -> tensor<3x3x288x288xf32>
+// CHECK:      util.return %[[MATMUL]] : tensor<3x3x288x288xf32>

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv_to_im2col.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv_to_im2col.mlir
@@ -245,3 +245,43 @@ util.func public @conv_1d_ncw_fcw_transpose_maps(%arg0: tensor<1x8x130xf32>, %ar
 // CHECK:          arith.addf
 // CHECK:      } -> tensor<1x16x128xf32>
 // CHECK:      util.return %[[MATMUL]] : tensor<1x16x128xf32>
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d1 + d5, d2 + d6, d3)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d0)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+util.func public @conv_2d_chwn_chwf(%arg0: tensor<16x26x18x288xf32>, %arg1: tensor<16x24x16x288xf32>, %arg2: tensor<288x3x3x288xf32>) -> tensor<288x3x3x288xf32> {
+  %0 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<16x26x18x288xf32>, tensor<16x24x16x288xf32>) outs(%arg2 : tensor<288x3x3x288xf32>) {
+  ^bb0(%in: f32, %in_3: f32, %out: f32):
+    %12 = arith.mulf %in, %in_3 : f32
+    %13 = arith.addf %out, %12 : f32
+    linalg.yield %13 : f32
+  } -> tensor<288x3x3x288xf32>
+  util.return %0 : tensor<288x3x3x288xf32>
+}
+
+// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d4, d0)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d3, d1, d2, d4)>
+// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
+// CHECK:      util.func public @conv_2d_chwn_chwf(
+// CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<16x26x18x288xf32>
+// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<16x24x16x288xf32>
+// CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<288x3x3x288xf32>
+// CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<288x3x3x6144xf32>
+// CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
+// CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [24, 16]
+// CHECK-SAME:   m_offset = [0, 0] * [3, 1] k_offset = [0] * [1]
+// CHECK-SAME:   batch_pos = [3] m_pos = [1, 2] k_pos = [0]
+// CHECK-SAME:   ins(%[[ARG0]] : tensor<16x26x18x288xf32>)
+// CHECK-SAME:   outs(%[[EMPTY]] : tensor<288x3x3x6144xf32>) -> tensor<288x3x3x6144xf32>
+// CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0, 1, 2], [3]] : tensor<16x24x16x288xf32> into tensor<6144x288xf32>
+// CHECK:      %[[MATMUL:.+]] = linalg.generic
+// CHECK-SAME:   indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
+// CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]
+// CHECK-SAME:   ins(%[[COLLAPSED]], %[[IM2COL]] : tensor<6144x288xf32>, tensor<288x3x3x6144xf32>)
+// CHECK-SAME:   outs(%[[ARG2]] : tensor<288x3x3x288xf32>) {
+// CHECK:          arith.mulf
+// CHECK:          arith.addf
+// CHECK:      } -> tensor<288x3x3x288xf32>
+// CHECK:      util.return %[[MATMUL]] : tensor<288x3x3x288xf32>

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -481,7 +481,7 @@ getIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
         getAffineDimExpr(reductionDim, filterMap.getContext()));
     filterkPos.push_back(maybeDim.value());
   }
-  // group together adjacent reduction dimensions in the filter.
+  // Group together adjacent reduction dimensions in the filter.
   // First we want to sort the dims as the look up from the filterMap
   // can place the dims in arbitarty order.
   std::sort(filterkPos.begin(), filterkPos.end());
@@ -525,7 +525,7 @@ getIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
     filterIterators.push_back(reduction);
     filterReassocIndices.push_back(collapsedDim);
   }
-  // insert any leftover parallel dims in the end.
+  // Insert any leftover parallel dims in the end.
   for (int i = filterNdimPos; i < filterNdims.size(); i++) {
     filterReassocIndices.push_back({filterNdims[i]});
     filterIterators.push_back(parallel);
@@ -552,45 +552,34 @@ getIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
       SmallVector<AffineExpr>(dims.begin(), dims.begin() + numParallelDims),
       ctx);
 
-  // prepare the input map.
+  // Prepare the input map.
+  int64_t numBDimsInFront = isBatchDimLast ? 0 : numBDims;
+  int64_t startingMPos =
+      isOutputChannelFirst ? numNDims + numBDimsInFront : numBDimsInFront;
+  int64_t startingBPos = isBatchDimLast ? startingMPos + numMDims : 0;
   SmallVector<AffineExpr> inputDims;
   // Add the batch dimensions.
-  int64_t starting_m_pos;
-  if (isBatchDimLast && isOutputChannelFirst) {
-    starting_m_pos = numNDims;
-  } else if (isOutputChannelFirst) {
-    starting_m_pos = numBDims + numNDims;
-  } else {
-    starting_m_pos = numBDims;
-  }
-  int64_t starting_b_pos = isBatchDimLast ? starting_m_pos + numMDims : 0;
-  inputDims.insert(inputDims.end(), dims.begin() + starting_b_pos,
-                   dims.begin() + starting_b_pos + numBDims);
+  inputDims.insert(inputDims.end(), dims.begin() + startingBPos,
+                   dims.begin() + startingBPos + numBDims);
   // Add the M dims.
-  inputDims.insert(inputDims.end(), dims.begin() + starting_m_pos,
-                   dims.begin() + starting_m_pos + numMDims);
+  inputDims.insert(inputDims.end(), dims.begin() + startingMPos,
+                   dims.begin() + startingMPos + numMDims);
   // Add the reduction dims.
   inputDims.insert(inputDims.end(), dims.begin() + numParallelDims, dims.end());
   auto inputMapGEMM =
       AffineMap::get(numParallelDims + numKDims, 0, inputDims, ctx);
 
-  // prepare filter map.
+  // Prepare filter map.
+  int64_t currNPos =
+      isOutputChannelFirst ? numBDimsInFront : numBDimsInFront + numMDims;
+  int64_t currKPos = numBDims + numMDims + numNDims;
   SmallVector<AffineExpr> filterDims;
-  int64_t curr_n_pos;
-  if (isBatchDimLast && isOutputChannelFirst) {
-    curr_n_pos = 0;
-  } else if (isOutputChannelFirst) {
-    curr_n_pos = numBDims;
-  } else {
-    curr_n_pos = numBDims + numMDims;
-  }
-  int64_t curr_k_pos = numBDims + numMDims + numNDims;
 
   for (auto iter : filterIterators) {
     if (iter == parallel) {
-      filterDims.push_back(dims[curr_n_pos++]);
+      filterDims.push_back(dims[currNPos++]);
     } else if (iter == reduction) {
-      filterDims.push_back(dims[curr_k_pos++]);
+      filterDims.push_back(dims[currKPos++]);
     }
   }
   auto filterMapGEMM =


### PR DESCRIPTION
The previous implementation of IGEMM indexing map only considers the batch dimension that is at first. This PR extends the utility to support batch dimension at last for ops such as `conv2d_chwn_chwf`. We are interested in supporting this new layout since it shows up in the training workloads as `weight_backward` convolution.