### PR TITLE
[GlobalOpt] Add option to propagate transposes through conv

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.td
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.td
@@ -117,6 +117,8 @@ def PropagateLinalgTransposePass :
            "Flag used for lit-testing bubbling patterns only. Not for general usage">,
     Option<"enableAttentionVTranspose", "enable-attention-v-transpose", "bool",
             /*default=*/"true", "Enable transposition of attention v operand">,
+    Option<"enableConvolutionPropagation", "enable-aggressive-propagation-through-conv", "bool",
+            /*default=*/"false", "enable propagation through convolutions">,
   ];
 }
 


### PR DESCRIPTION
This option is off by default as propagating transposes through convs causes weight  constant folding issues with other preprocessing pipelines that might want to cancel them out.