### PR TITLE
Avoid nested fashion traversal in ModuleOp when possible.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -1027,10 +1027,14 @@ std::optional<int> getGPUSubgroupSize(mlir::FunctionOpInterface func) {
 
 SmallVector<IREE::HAL::ExecutableVariantOp>
 getExecutableVariantOps(mlir::ModuleOp moduleOp) {
+  // The variant ops must have a ExecutableOp parent. Thus we iterate on the
+  // ExecutableOp using `getOps()` for efficiency. We do not need to walk
+  // through all the ops in the `moduleOp` in a nested fashion.
   SmallVector<IREE::HAL::ExecutableVariantOp> executableVariantOps;
-  moduleOp.walk([&](IREE::HAL::ExecutableVariantOp executableOp) {
-    executableVariantOps.push_back(executableOp);
-  });
+  for (auto executableOp : moduleOp.getOps<IREE::HAL::ExecutableOp>()) {
+    auto iter = executableOp.getOps<IREE::HAL::ExecutableVariantOp>();
+    executableVariantOps.append(iter.begin(), iter.end());
+  }
   return executableVariantOps;
 }
 

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -204,9 +204,8 @@ IREE::GPU::TargetAttr getGPUTargetAttr(Operation *op);
 /// Returns std::nullopt if none found.
 std::optional<int> getGPUSubgroupSize(mlir::FunctionOpInterface func);
 
-/// Returns all `IREE::HAL::ExecutableVariantOp` operations from the
-/// given `mlir::ModuleOp`, ensuring they are returned in their original IR
-/// order.
+/// Returns the top-level `IREE::HAL::ExecutableVariantOp` operations from the
+/// given `moduleOp`, ensuring they are returned in their original IR order.
 SmallVector<IREE::HAL::ExecutableVariantOp>
 getExecutableVariantOps(mlir::ModuleOp moduleOp);
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
@@ -20,12 +20,12 @@ SmallVector<std::string>
 gatherExecutableTargetNames(IREE::HAL::ExecutableOp executableOp) {
   SmallVector<std::string> targetNames;
   llvm::SmallDenseSet<StringRef> targets;
-  executableOp.walk([&](IREE::HAL::ExecutableVariantOp variantOp) {
+  for (auto variantOp : executableOp.getOps<IREE::HAL::ExecutableVariantOp>()) {
     auto targetName = variantOp.getTarget().getBackend().getValue();
     if (targets.insert(targetName).second) {
       targetNames.push_back(targetName.str());
     }
-  });
+  }
   llvm::stable_sort(targetNames);
   return targetNames;
 }
@@ -34,14 +34,15 @@ SmallVector<std::string> gatherExecutableTargetNames(mlir::ModuleOp moduleOp) {
   SmallVector<std::string> targetNames;
   llvm::stable_sort(targetNames);
   llvm::SmallDenseSet<StringRef> targets;
-  moduleOp.walk([&](IREE::HAL::ExecutableOp executableOp) {
-    executableOp.walk([&](IREE::HAL::ExecutableVariantOp variantOp) {
+  for (auto executableOp : moduleOp.getOps<IREE::HAL::ExecutableOp>()) {
+    for (auto variantOp :
+         executableOp.getOps<IREE::HAL::ExecutableVariantOp>()) {
       auto targetName = variantOp.getTarget().getBackend().getValue();
       if (targets.insert(targetName).second) {
         targetNames.push_back(targetName.str());
       }
-    });
-  });
+    }
+  }
   return targetNames;
 }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/OutlineMemoizeRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/OutlineMemoizeRegions.cpp
@@ -583,9 +583,11 @@ struct OutlineMemoizeRegionsPass
     // Gather all memoize ops in the module. We are changing the module during
     // processing and need to complete the walk before modification.
     SmallVector<IREE::HAL::DeviceMemoizeOp> memoizeOps;
-    moduleOp.walk([&](IREE::HAL::DeviceMemoizeOp memoizeOp) {
-      memoizeOps.push_back(memoizeOp);
-    });
+    for (auto funcOp : moduleOp.getOps<FunctionOpInterface>()) {
+      funcOp.walk([&](IREE::HAL::DeviceMemoizeOp memoizeOp) {
+        memoizeOps.push_back(memoizeOp);
+      });
+    }
 
     // Try to outline all memoize ops. Some may fail analysis and be inlined.
     auto &moduleSymbolTable =

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/StripAndSplatConstants.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/StripAndSplatConstants.cpp
@@ -36,15 +36,17 @@ public:
                                               replaceIndex++);
     };
 
-    moduleOp.walk([&](Operation *op) {
-      if (auto globalOp = dyn_cast<Util::GlobalOp>(op)) {
-        if (auto initialValue = globalOp.getInitialValueAttr()) {
-          if (auto shapedType = dyn_cast<ShapedType>(initialValue.getType())) {
-            globalOp.setInitialValueAttr(getSplatAttr(shapedType));
-          }
-        }
+    for (auto globalOp : moduleOp.getOps<Util::GlobalOp>()) {
+      auto initialValue = globalOp.getInitialValueAttr();
+      if (!initialValue) {
+        continue;
       }
-    });
+      auto shapedType = dyn_cast<ShapedType>(initialValue.getType());
+      if (!shapedType) {
+        continue;
+      }
+      globalOp.setInitialValueAttr(getSplatAttr(shapedType));
+    }
   }
 };
 

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/MaterializeConstants.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/MaterializeConstants.cpp
@@ -15,6 +15,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassRegistry.h"
 
@@ -46,10 +47,12 @@ public:
     llvm::MapVector<Attribute, SmallVector<IREE::HAL::ExecutableConstantLoadOp>>
         allLoadOps;
     SmallVector<Location> allLoadLocs;
-    moduleOp.walk([&](IREE::HAL::ExecutableConstantLoadOp loadOp) {
-      allLoadOps[loadOp.getKeyAttr()].push_back(loadOp);
-      allLoadLocs.push_back(loadOp.getLoc());
-    });
+    for (auto funcOp : moduleOp.getOps<FunctionOpInterface>()) {
+      funcOp.walk([&](IREE::HAL::ExecutableConstantLoadOp loadOp) {
+        allLoadOps[loadOp.getKeyAttr()].push_back(loadOp);
+        allLoadLocs.push_back(loadOp.getLoc());
+      });
+    }
 
     // No constants found; omit the constant block entirely.
     if (allLoadOps.empty())


### PR DESCRIPTION
There are three cases in the revision:

1. Gather `ExecutableVariantOp` ops. The assumption is that we always have `module{executable{variant}}}` structrue. I.e., there are no nested executables variants. In the context, we can always use getOps from the module ops and executable ops to gather the variant ops.
2. Gather the HAL ops like `ExecutableConstantLoadOp` and `DeviceMemoizeOp`. They are always in the host code function, so it iterates over the top-level callables and walk on them.
3. Update global ops. The global ops are always the top-level ops in modules.