### PR TITLE
[DispatchCreation] Add support for hoisting Flow ops.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -1537,8 +1537,6 @@ def FLOW_TensorEncodeOp : FLOW_PureOp<"tensor.encode", [
   }];
 
   let extraClassDeclaration = [{
-    bool isHoistableLeafOp() { return false; }
-
     ValueRange getOperandDynamicDims(unsigned idx) { return getOperandDims(); }
     ValueRange getResultDynamicDims(unsigned idx) { return getResultDims(); }
   }];

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -1511,7 +1511,6 @@ def FLOW_TensorCloneOp : FLOW_PureOp<"tensor.clone", [
 def FLOW_TensorEncodeOp : FLOW_PureOp<"tensor.encode", [
   AllRanksMatch<["operand", "result"]>,
   AllElementTypesMatch<["operand", "result"]>,
-  DeclareOpInterfaceMethods<Util_HoistableOpInterface>,
   AttrSizedOperandSegments,
   Util_ShapeAwareOp,
 ]> {

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.cpp
@@ -9,8 +9,6 @@
 #include "iree/compiler/Dialect/Util/Analysis/Constant/OpOracle.h"
 #include "iree/compiler/Dialect/Util/Analysis/Explorer.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
-#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
-#include "llvm/Support/Casting.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/GraphWriter.h"
@@ -502,15 +500,6 @@ void ConstExprHoistingPolicy::makeDecision(
   if (!hasLegalEscape) {
     decision->disableHoist();
     return;
-  }
-
-  // If the op explicitly says no, we disable the hoisting.
-  if (auto hoistableOp =
-          dyn_cast<Util::HoistableOpInterface>(info->getOperation())) {
-    if (!hoistableOp.isHoistableOp()) {
-      decision->disableHoist();
-      return;
-    }
   }
 
   // Otherwise, we can conditionally enable hoisting (based on cost model, etc).

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.cpp
@@ -9,6 +9,8 @@
 #include "iree/compiler/Dialect/Util/Analysis/Constant/OpOracle.h"
 #include "iree/compiler/Dialect/Util/Analysis/Explorer.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
+#include "llvm/Support/Casting.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/GraphWriter.h"
@@ -500,6 +502,15 @@ void ConstExprHoistingPolicy::makeDecision(
   if (!hasLegalEscape) {
     decision->disableHoist();
     return;
+  }
+
+  // If the op explicitly says no, we disable the hoisting.
+  if (auto hoistableOp =
+          dyn_cast<Util::HoistableOpInterface>(info->getOperation())) {
+    if (!hoistableOp.isHoistableOp()) {
+      decision->disableHoist();
+      return;
+    }
   }
 
   // Otherwise, we can conditionally enable hoisting (based on cost model, etc).

--- a/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
@@ -198,6 +198,7 @@ void HoistEncodingOpsPass::runOnOperation() {
     // root op.
     Operation *src = setEncodingOp.getSource().getDefiningOp();
     if (src && src->hasTrait<OpTrait::ConstantLike>() &&
+        src->getParentOfType<IREE::Flow::DispatchRegionOp>() &&
         failed(IREE::Flow::hoistOutOfDispatch(rewriter, src))) {
       src->emitOpError("failed to hoist the source out of dispatch");
       return signalPassFailure();

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -260,6 +260,13 @@ addDispatchRegionCreationPasses(OpPassManager &passManager,
   }
   FunctionLikeNest(passManager)
       .addPass(DispatchCreation::createConvertEncodingToFlowPass);
+  // Hoist encoding operations into initializers when possible.
+  IREE::Util::ExprHoistingOptions hoistingOptions;
+  hoistingOptions.maxSizeIncreaseThreshold = 0;
+  hoistingOptions.registerDependentDialectsFn = [](DialectRegistry &registry) {
+    registry.insert<IREE::Flow::FlowDialect>();
+  };
+  passManager.addPass(IREE::Util::createHoistIntoGlobalsPass(hoistingOptions));
 }
 
 // Apply preprocessing and form dispatch regions

--- a/compiler/src/iree/compiler/DispatchCreation/test/set_encoding_pipeline.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/set_encoding_pipeline.mlir
@@ -102,7 +102,7 @@ util.func public @broadcast_rhs_batch_mmt(%arg0: tensor<16x1024x1280xi8>, %arg1:
 
 // -----
 
-// The below tests that the set_encoding(constant) is hoisted to util.initializer.
+// The below tests that the encoding ops are hoisted to util.initializer.
 
 util.func public @foo(%arg0: tensor<255x513xf32>) -> tensor<255x1023xf32> {
   %cst = arith.constant dense<1.000000e+00> : tensor<513x1023xf32>

--- a/compiler/src/iree/compiler/DispatchCreation/test/set_encoding_pipeline.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/set_encoding_pipeline.mlir
@@ -99,3 +99,27 @@ util.func public @broadcast_rhs_batch_mmt(%arg0: tensor<16x1024x1280xi8>, %arg1:
 //      CHECK:   linalg.generic
 // CHECK-SAME:      ins(%{{.*}}, %{{.*}} : tensor<16384x1280xi8, #[[ENCODING_LHS]]>, tensor<10240x1280xi8, #[[ENCODING_RHS]]>)
 // CHECK-SAME:      outs(%{{.*}} : tensor<16384x10240xi32, #[[ENCODING_OUT]]>)
+
+// -----
+
+// The below tests that the set_encoding(constant) is hoisted to util.initializer.
+
+util.func public @foo(%arg0: tensor<255x513xf32>) -> tensor<255x1023xf32> {
+  %cst = arith.constant dense<1.000000e+00> : tensor<513x1023xf32>
+  %cst_0 = arith.constant 0.000000e+00 : f32
+  %0 = tensor.empty() : tensor<255x1023xf32>
+  %1 = linalg.fill ins(%cst_0 : f32) outs(%0 : tensor<255x1023xf32>) -> tensor<255x1023xf32>
+  %2 = linalg.matmul ins(%arg0, %cst : tensor<255x513xf32>, tensor<513x1023xf32>) outs(%1 : tensor<255x1023xf32>) -> tensor<255x1023xf32>
+  util.return %2 : tensor<255x1023xf32>
+}
+// CHECK-DAG:  #[[MAP0:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
+// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+// CHECK-DAG:  #[[LHS_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]]
+// CHECK-DAG:  #[[RHS_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]]
+// CHECK-DAG:  #[[RES_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]]
+// CHECK:      util.global private @[[HOISTED:.+]] : tensor<513x1023xf32, #[[RHS_ENCODING]]>
+// CHECK:      util.initializer {
+// CHECK:        %[[CST:.+]] = arith.constant dense<1.000000e+00> : tensor<513x1023xf32>
+// CHECK:        %[[ENCODED_CST:.+]] = flow.tensor.encode %[[CST]] : tensor<513x1023xf32> -> tensor<513x1023xf32, #[[RHS_ENCODING]]>
+// CHECK:        util.global.store %[[ENCODED_CST]], @[[HOISTED]]

--- a/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/UtilExternalModels.cpp
@@ -10,6 +10,8 @@
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.h"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingDialect.h"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingOps.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
@@ -490,13 +492,24 @@ void registerUtilExternalModels(DialectRegistry &registry) {
 
   // Hoistable Op Interface registration.
 
-  // Register hoistable type interfaces for LinalgExt ops.
+  // Register hoistable op interfaces for Encoding ops.
   registry.addExtension(
       +[](MLIRContext *context, IREE::Encoding::IREEEncodingDialect *dialect) {
         UnhoistableOpInterfaceHelper<
             IREE::Encoding::SetEncodingOp>::registerOpInterface(context);
       });
-  // Register hoistable type interfaces for linalg ops.
+
+  // Register hoistable op interfaces for Flow ops.
+  registry.addExtension(
+      +[](MLIRContext *context, IREE::Flow::FlowDialect *dialect) {
+        UnhoistableOpInterfaceHelper<
+            IREE::Flow::DispatchWorkgroupCountOp>::registerOpInterface(context);
+
+        AlwaysHoistableOpInterfaceHelper<
+            IREE::Flow::TensorEncodeOp>::registerOpInterface(context);
+      });
+
+  // Register hoistable op interfaces for linalg ops.
   // We have a specific allow-list for Linalg ops because we want to consider
   // new additions carefully.
   registry.addExtension(
@@ -521,7 +534,7 @@ void registerUtilExternalModels(DialectRegistry &registry) {
         AlwaysHoistableOpInterfaceHelper<
             linalg::PackOp, linalg::UnPackOp>::registerOpInterface(context);
       });
-  // Register hoistable type interfaces for tensor ops.
+  // Register hoistable op interfaces for tensor ops.
   registry.addExtension(
       +[](MLIRContext *context, tensor::TensorDialect *dialect) {
         // Never hoist empty and other pure metadata ops as a leaf. It's fine to


### PR DESCRIPTION
The revision enables the hoisting of constants and weights for data-tiling. It also fixes a bug in hoisting the constants.

The DispatchWorkgroupCountOp is marked as unhoistable. It happens in custom_dispatch, which is not on regular path, so new tests are not added.