### PR TITLE
Enable tensor.pad lowering via buffer load with bounds check

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/LLVMGPU/Passes.h"
 #include "mlir/Conversion/VectorToSCF/VectorToSCF.h"
+#include "mlir/Dialect/AMDGPU/Transforms/Passes.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -126,6 +127,7 @@ struct LLVMGPUVectorLoweringPass final
     populateVectorToSCFConversionPatterns(vectorToLoopsPatterns,
                                           vectorToSCFOptions);
     memref::populateFoldMemRefAliasOpPatterns(vectorToLoopsPatterns);
+    amdgpu::populateAmdgpuTransferReadToLoadPatterns(vectorToLoopsPatterns);
     vector::populateVectorTransferLoweringPatterns(vectorToLoopsPatterns);
     if (failed(
             applyPatternsGreedily(funcOp, std::move(vectorToLoopsPatterns)))) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -229,7 +229,8 @@ static void tileAndBufferize(OpPassManager &funcPassManager) {
 }
 
 static void addGPUVectorizationPasses(OpPassManager &funcPassManager,
-                                      bool vectorizeCopies = true) {
+                                      bool vectorizeCopies = true,
+                                      bool enableMasking = false) {
   funcPassManager.addPass(createDecomposeConvolutionToLowerDimOpsPass());
   funcPassManager.addPass(IREE::LinalgExt::createDecomposeIm2colPass());
   funcPassManager.addPass(createCanonicalizerPass());
@@ -243,6 +244,7 @@ static void addGPUVectorizationPasses(OpPassManager &funcPassManager,
   options.vectorizeGatherAccesses = true;
   options.enableCleanup = false;
   options.foldCastIntoContract = true;
+  options.enableVectorMasking = enableMasking;
   funcPassManager.addPass(createGenericVectorizationPass(options));
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
@@ -476,7 +478,7 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
 
   // Step 6. Lower special ops and vectorize.
   funcPassManager.addPass(IREE::GPU::createVectorizeIREEGPUOpsPass());
-  addGPUVectorizationPasses(funcPassManager, /*vectorizeCopies=*/false);
+  addGPUVectorizationPasses(funcPassManager, /*vectorizeCopies=*/false, true);
   funcPassManager.addPass(createCleanupBufferAllocViewPass());
   funcPassManager.addPass(createGPUCombineValueBarriersPass());
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -478,7 +478,8 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
 
   // Step 6. Lower special ops and vectorize.
   funcPassManager.addPass(IREE::GPU::createVectorizeIREEGPUOpsPass());
-  addGPUVectorizationPasses(funcPassManager, /*vectorizeCopies=*/false, true);
+  addGPUVectorizationPasses(funcPassManager, /*vectorizeCopies=*/false,
+                            /*enableMasking=*/true);
   funcPassManager.addPass(createCleanupBufferAllocViewPass());
   funcPassManager.addPass(createGPUCombineValueBarriersPass());
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
@@ -1223,9 +1223,8 @@ hal.executable public @main {
 // CHECK-DAG:     %[[C42:.+]] = arith.constant 42 : i32
 // CHECK:         scf.forall {{.*}} in (16, 4) {
 // CHECK:           scf.for
-// CHECK-DAG:         linalg.fill ins(%[[C42]] : i32) outs(%[[ALLOCA]] : memref<4x1xi32, #gpu.address_space<private>>)
-// CHECK-DAG:         %[[INPUT_SUBVIEW:.+]] = memref.subview {{.*}} : memref<100x250xi32, #amdgpu.address_space<fat_raw_buffer>> to memref<?x?xi32, strided<[250, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>>
-// CHECK-DAG:         %[[ALLOCA_SUBVIEW:.+]] = memref.subview %[[ALLOCA]]{{.*}} : memref<4x1xi32, #gpu.address_space<private>> to memref<?x?xi32, strided<[1, 1]>, #gpu.address_space<private>>
-// CHECK-DAG:         memref.copy %[[INPUT_SUBVIEW]], %[[ALLOCA_SUBVIEW]] : memref<?x?xi32, strided<[250, 1], offset: ?>, #amdgpu.address_space<fat_raw_buffer>> to memref<?x?xi32, strided<[1, 1]>, #gpu.address_space<private>>
+// CHECK:             %[[MASK:.+]] = vector.create_mask
+// CHECK:             %[[READ0:.+]] = vector.transfer_read{{.*}} %[[MASK]]
+// CHECK-DAG:         %[[ALLOCA_SUBVIEW:.+]] = memref.subview %[[ALLOCA]]{{.*}} : memref<4x1xi32, #gpu.address_space<private>> to memref<4xi32, strided<[1]>, #gpu.address_space<private>>
 // CHECK-DAG:         %[[READ:.+]] = vector.transfer_read{{.*}}: memref<1x4xi32, strided<[4, 1]>, #gpu.address_space<private>>, vector<4xi32>
 // CHECK-DAG:         vector.transfer_write %[[READ]]{{.*}}: vector<4xi32>, memref<16x4x16x32xi32, #amdgpu.address_space<fat_raw_buffer>>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
@@ -38,7 +38,6 @@ module {
 // CHECK: %[[FMA:.+]] = vector.fma %[[RHS_CAST]], %[[LHS_SPLAT]], %[[ACC]] : vector<2xf32>
 // CHECK: arith.select %[[MASK_EXTRACT]], %[[FMA]], %[[ACC]] : vector<2xi1>, vector<2xf32>
 
-
 // -----
 
 module {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
@@ -37,3 +37,23 @@ module {
 // CHECK: %[[LHS_SPLAT:.+]] = vector.splat %[[LHS_CAST]] : vector<2xf32>
 // CHECK: %[[FMA:.+]] = vector.fma %[[RHS_CAST]], %[[LHS_SPLAT]], %[[ACC]] : vector<2xf32>
 // CHECK: arith.select %[[MASK_EXTRACT]], %[[FMA]], %[[ACC]] : vector<2xi1>, vector<2xf32>
+
+
+// -----
+
+module {
+  func.func @transfer_read_lowering(%arg0: memref<8x8xf32, #amdgpu.address_space<fat_raw_buffer>>, %idx : index, %mask: vector<4xi1>) -> vector<4xf32> {
+    %cst_0 = arith.constant 0.000000e+00 : f32
+    %v = vector.transfer_read %arg0[%idx, %idx], %cst_0, %mask {in_bounds = [true]} : memref<8x8xf32, #amdgpu.address_space<fat_raw_buffer>>, vector<4xf32>
+    return %v : vector<4xf32>
+  }
+}
+
+// CHECK-LABEL: func.func @transfer_read_lowering(
+// CHECK-SAME: %[[ARG0:.+]]: memref<8x8xf32, #amdgpu.address_space<fat_raw_buffer>>,
+// CHECK-SAME: %[[ARG1:.+]]: index,
+// CHECK-SAME: %[[MASK:.+]]: vector<4xi1>
+// CHECK: %[[CST:.+]] = arith.constant dense<0.000000e+00>
+// CHECK: %[[LOAD:.+]] = vector.load %[[ARG0]][%[[ARG1]], %[[ARG1]]]
+// CHECK: %[[SELECT:.+]] = arith.select %[[MASK]], %[[LOAD]], %[[CST]]
+// CHECK: return %[[SELECT]]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
@@ -55,4 +55,3 @@ module {
 // CHECK: %[[CST:.+]] = arith.constant dense<0.000000e+00>
 // CHECK: %[[LOAD:.+]] = vector.load %[[ARG0]][%[[ARG1]], %[[ARG1]]]
 // CHECK: %[[SELECT:.+]] = arith.select %[[MASK]], %[[LOAD]], %[[CST]]
-// CHECK: return %[[SELECT]]


### PR DESCRIPTION
This PR enables tensor.pad op to be lowered as buffer load with bounds check. It achieved this with the following steps:
 - Step 1: turn on `enable-masking` option for vectorization pass, which allowed tensor.pad to be lowered as `tensor.create_maks` + `tensor.transfer_read` with mask
 - Step 2: Use `populateAmdgpuTransferReadToLoadPatterns` from upstream so that `tensor.transfer_read` will be lowered towards `vector.load` + `arith.select` 
 - Step 3: eventually, in LLVM, vector.load lowers to buffer load with bounds check

The performance impact has been verified via a set of convolution configs. In summary, this PR either have no perf impact or positive impact on the convolutions tested below.

conv configs  | buffer_load enabled (us) | baseline (us) | improvement
-- | -- | -- | --
convbfp16 -n 8 -c 112 -H 1 -W 1 -k 448 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 | 6.287 | 6.371 | 0.013184743
convbfp16 -n 8 -c 112 -H 1 -W 1 -k 896 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 | 6.225 | 6.195 | -0.004842615
convbfp16 -n 8 -c 2016 -H 1 -W 1 -k 224 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 | 17.952 | 34.057 | 0.472883695
convbfp16 -n 8 -c 2016 -H 30 -W 46 -k 2016 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 | 542.48 | 541.596 | -0.001632213
convbfp16 -n 8 -c 2016 -H 30 -W 46 -k 768 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 | 125.335 | 125.366 | 0.000247276
convbfp16 -n 8 -c 224 -H 1 -W 1 -k 2016 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 | 6.394 | 6.699 | 0.045529183
convbfp16 -n 8 -c 224 -H 1 -W 1 -k 56 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 | 6.195 | 9.46 | 0.345137421
convbfp16 -n 8 -c 224 -H 1 -W 1 -k 8 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 | 6.248 | 12.589 | 0.503693701
convbfp16 -n 8 -c 224 -H 1 -W 1 -k 896 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 | 6.347 | 6.408 | 0.009519351
convbfp16 -n 8 -c 224 -H 235 -W 363 -k 224 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 | 605.285 | 1095.52 | 0.447490689
convbfp16 -n 8 -c 224 -H 235 -W 363 -k 448 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 | 1212.707 | 1414.581 | 0.142709396
convbfp16 -n 8 -c 224 -H 235 -W 363 -k 448 -y 1 -x 1 -p 0 -q 0 -u 2 -v 2 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 | 708.679 | 709.045 | 0.000516187
convbfp16 -n 8 -c 3 -H 940 -W 1450 -k 32 -y 3 -x 3 -p 1 -q 1 -u 2 -v 2 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 | 558.838 | 568.68 | 0.017306745
convbfp16 -n 8 -c 32 -H 470 -W 725 -k 224 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 | 848.511 | 846.817 | -0.002000432
convbfp16 -n 8 -c 32 -H 470 -W 725 -k 224 -y 1 -x 1 -p 0 -q 0 -u 2 -v 2 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 | 520.813 | 520.752 | -0.000117138
convbfp16 -n 8 -c 4 -H 940 -W 1450 -k 3 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 | 250.794 | 250.732 | -0.000247276
convbfp16 -n 8 -c 448 -H 1 -W 1 -k 112 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 | 6.286 | 9.537 | 0.340882877
convbfp16 -n 8 -c 448 -H 1 -W 1 -k 56 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 | 6.683 | 15.946 | 0.580898031
convbfp16 -n 8 -c 448 -H 118 -W 182 -k 448 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 | 286.163 | 286.224 | 0.00021312
convbfp16 -n 8 -c 448 -H 118 -W 182 -k 896 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 | 499.877 | 502.457 | 0.005134768
convbfp16 -n 8 -c 448 -H 118 -W 182 -k 896 -y 1 -x 1 -p 0 -q 0 -u 2 -v 2 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 | 441.192 | 440.857 | -0.000759884
convbfp16 -n 8 -c 56 -H 1 -W 1 -k 224 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 | 6.286 | 6.225 | -0.009799197
convbfp16 -n 8 -c 56 -H 1 -W 1 -k 448 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 | 6.286 | 6.287 | 0.000159058
convbfp16 -n 8 -c 8 -H 1 -W 1 -k 224 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 | 6.256 | 6.287 | 0.00493081
convbfp16 -n 8 -c 896 -H 1 -W 1 -k 112 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 | 7.607 | 16.052 | 0.526102666
convbfp16 -n 8 -c 896 -H 1 -W 1 -k 224 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 | 7.568 | 15.701 | 0.517992485
convbfp16 -n 8 -c 896 -H 59 -W 91 -k 2016 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 | 1130.554 | 2489.166 | 0.545810123
convbfp16 -n 8 -c 896 -H 59 -W 91 -k 2016 -y 1 -x 1 -p 0 -q 0 -u 2 -v 2 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 | 1326.783 | 1325.378 | -0.001060075
convbfp16 -n 8 -c 896 -H 59 -W 91 -k 896 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 | 319.427 | 457.245 | 0.301409529

























