### PR TITLE
Move sharktank and regression-test MI300 jobs to the ossci cluster.

### DIFF
--- a/.github/workflows/pkgci_regression_test.yml
+++ b/.github/workflows/pkgci_regression_test.yml
@@ -91,10 +91,10 @@ jobs:
       #       -rA -s -m "plat_host_cpu and presubmit" \
       #       experimental/regression_suite
 
-      - name: "Set IREE_TEST_FILES variable" 
+      - name: "Set IREE_TEST_FILES variable"
         run: |
           case "${{ matrix.name }}" in
-            "amdgpu_rocm_mi300_gfx942") IREE_TEST_FILES="/shark-cache/data/iree-regression-cache" >> $GITHUB_ENV;;
+            "amdgpu_rocm_mi300_gfx942") echo IREE_TEST_FILES="/shark-cache/data/iree-regression-cache" >> $GITHUB_ENV ;;
             *) echo "No cache directory assigned for ${{ matrix.name }}" ;;
           esac
 

--- a/.github/workflows/pkgci_regression_test.yml
+++ b/.github/workflows/pkgci_regression_test.yml
@@ -95,7 +95,6 @@ jobs:
         if: "!cancelled()"
         run: |
           source ${VENV_DIR}/bin/activate
-                    # Set IREE_TEST_FILES based on matrix.name
           case "${{ matrix.name }}" in
             "amdgpu_rocm_mi300_gfx942") IREE_TEST_FILES="/shark-cache/data/iree-regression-cache" ;;
             *) echo "No cache directory assigned for ${{ matrix.name }}" ;;
@@ -118,7 +117,6 @@ jobs:
         if: "!cancelled()"
         run: |
           source ${VENV_DIR}/bin/activate
-                    # Set IREE_TEST_FILES based on matrix.name
           case "${{ matrix.name }}" in
             "amdgpu_rocm_mi300_gfx942") IREE_TEST_FILES="/shark-cache/data/iree-regression-cache" ;;
             *) echo "No cache directory assigned for ${{ matrix.name }}" ;;
@@ -168,7 +166,6 @@ jobs:
         if: contains(matrix.name, 'rocm_mi300_gfx942')
         run: |
           source ${VENV_DIR}/bin/activate
-                    # Set IREE_TEST_FILES based on matrix.name
           case "${{ matrix.name }}" in
             "amdgpu_rocm_mi300_gfx942") IREE_TEST_FILES="/shark-cache/data/iree-regression-cache" ;;
             *) echo "No cache directory assigned for ${{ matrix.name }}" ;;

--- a/.github/workflows/pkgci_regression_test.yml
+++ b/.github/workflows/pkgci_regression_test.yml
@@ -48,7 +48,7 @@ jobs:
             rocm-chip: gfx942
             backend: rocm
             sku: mi300
-            runs-on: nodai-amdgpu-mi300-x86-64
+            runs-on: linux-mi300-1gpu-ossci-iree-org
           - name: amdgpu_rocm_mi308_gfx942
             rocm-chip: gfx942
             backend: rocm
@@ -95,6 +95,14 @@ jobs:
         if: "!cancelled()"
         run: |
           source ${VENV_DIR}/bin/activate
+                    # Set IREE_TEST_FILES based on matrix.name
+          case "${{ matrix.name }}" in
+            "amdgpu_rocm_mi300_gfx942") IREE_TEST_FILES="/shark-cache/data/iree-regression-cache" ;;
+            *) echo "No cache directory assigned for ${{ matrix.name }}" ;;
+          esac
+          if [[ -n "$IREE_TEST_FILES" ]]; then
+            export IREE_TEST_FILES
+          fi
           pytest ./experimental/regression_suite/shark-test-suite-models/sdxl \
             -k ${{ matrix.backend }} \
             -rpfE \
@@ -110,6 +118,14 @@ jobs:
         if: "!cancelled()"
         run: |
           source ${VENV_DIR}/bin/activate
+                    # Set IREE_TEST_FILES based on matrix.name
+          case "${{ matrix.name }}" in
+            "amdgpu_rocm_mi300_gfx942") IREE_TEST_FILES="/shark-cache/data/iree-regression-cache" ;;
+            *) echo "No cache directory assigned for ${{ matrix.name }}" ;;
+          esac
+          if [[ -n "$IREE_TEST_FILES" ]]; then
+            export IREE_TEST_FILES
+          fi
           pytest ./experimental/regression_suite/shark-test-suite-models/sd3 \
             -k ${{ matrix.backend }} \
             -rpfE \
@@ -152,6 +168,14 @@ jobs:
         if: contains(matrix.name, 'rocm_mi300_gfx942')
         run: |
           source ${VENV_DIR}/bin/activate
+                    # Set IREE_TEST_FILES based on matrix.name
+          case "${{ matrix.name }}" in
+            "amdgpu_rocm_mi300_gfx942") IREE_TEST_FILES="/shark-cache/data/iree-regression-cache" ;;
+            *) echo "No cache directory assigned for ${{ matrix.name }}" ;;
+          esac
+          if [[ -n "$IREE_TEST_FILES" ]]; then
+            export IREE_TEST_FILES
+          fi
           pytest ./experimental/benchmarks/sdxl/benchmark_sdxl_rocm.py \
             --goldentime-tolerance-multiplier 1.1 \
             --goldentime-rocm-e2e-ms 305.0 \

--- a/.github/workflows/pkgci_regression_test.yml
+++ b/.github/workflows/pkgci_regression_test.yml
@@ -91,17 +91,17 @@ jobs:
       #       -rA -s -m "plat_host_cpu and presubmit" \
       #       experimental/regression_suite
 
+      - name: "Set IREE_TEST_FILES variable" 
+        run: |
+          case "${{ matrix.name }}" in
+            "amdgpu_rocm_mi300_gfx942") IREE_TEST_FILES="/shark-cache/data/iree-regression-cache" >> $GITHUB_ENV;;
+            *) echo "No cache directory assigned for ${{ matrix.name }}" ;;
+          esac
+
       - name: "Running SDXL special model tests"
         if: "!cancelled()"
         run: |
           source ${VENV_DIR}/bin/activate
-          case "${{ matrix.name }}" in
-            "amdgpu_rocm_mi300_gfx942") IREE_TEST_FILES="/shark-cache/data/iree-regression-cache" ;;
-            *) echo "No cache directory assigned for ${{ matrix.name }}" ;;
-          esac
-          if [[ -n "$IREE_TEST_FILES" ]]; then
-            export IREE_TEST_FILES
-          fi
           pytest ./experimental/regression_suite/shark-test-suite-models/sdxl \
             -k ${{ matrix.backend }} \
             -rpfE \
@@ -117,13 +117,6 @@ jobs:
         if: "!cancelled()"
         run: |
           source ${VENV_DIR}/bin/activate
-          case "${{ matrix.name }}" in
-            "amdgpu_rocm_mi300_gfx942") IREE_TEST_FILES="/shark-cache/data/iree-regression-cache" ;;
-            *) echo "No cache directory assigned for ${{ matrix.name }}" ;;
-          esac
-          if [[ -n "$IREE_TEST_FILES" ]]; then
-            export IREE_TEST_FILES
-          fi
           pytest ./experimental/regression_suite/shark-test-suite-models/sd3 \
             -k ${{ matrix.backend }} \
             -rpfE \
@@ -166,13 +159,6 @@ jobs:
         if: contains(matrix.name, 'rocm_mi300_gfx942')
         run: |
           source ${VENV_DIR}/bin/activate
-          case "${{ matrix.name }}" in
-            "amdgpu_rocm_mi300_gfx942") IREE_TEST_FILES="/shark-cache/data/iree-regression-cache" ;;
-            *) echo "No cache directory assigned for ${{ matrix.name }}" ;;
-          esac
-          if [[ -n "$IREE_TEST_FILES" ]]; then
-            export IREE_TEST_FILES
-          fi
           pytest ./experimental/benchmarks/sdxl/benchmark_sdxl_rocm.py \
             --goldentime-tolerance-multiplier 1.1 \
             --goldentime-rocm-e2e-ms 305.0 \

--- a/.github/workflows/pkgci_test_sharktank.yml
+++ b/.github/workflows/pkgci_test_sharktank.yml
@@ -30,10 +30,15 @@ jobs:
             gpu: none
             runs-on: ubuntu-24.04
 
-          - name: rocm_hip
+          - name: rocm_hip_w7900
             target: target_hip
             gpu: gfx1100
             runs-on: nodai-amdgpu-w7900-x86-64
+
+          - name: rocm_hip_mi300
+            target: target_hip
+            gpu: gfx942
+            runs-on: linux-mi300-2gpu-ossci-iree-org
 
     env:
       VENV_DIR: ${{ github.workspace }}/venv


### PR DESCRIPTION
Progress on https://github.com/nod-ai/shark-ai/issues/793.

This moves the sharktank and regression-test workflow jobs using MI300 runners to the ossci cluster.

ci-exactly: build_packages,regression_test,test_sharktank