### PR TITLE
Integrate LLVM at 94783a8199c5e589d8efd6d4530482d72bf98f4d

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_elementwise_f8fnuz.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_elementwise_f8fnuz.mlir
@@ -45,8 +45,8 @@ hal.executable @ext_fp8_dispatch {
 
 //   CDNA3-LABEL: hal.executable public @ext_fp8_dispatch
 //         CDNA3:   hal.executable.variant public @rocm
-// CDNA3-COUNT-16:     rocdl.cvt.f32.fp8 %{{.*}} : f32
-// CDNA3-COUNT-16:     rocdl.cvt.f32.bf8 %{{.*}} : f32
+// CDNA3-COUNT-8:     rocdl.cvt.pk.f32.fp8 %{{.*}} : vector<2xf32>
+// CDNA3-COUNT-8:     rocdl.cvt.pk.f32.bf8 %{{.*}} : vector<2xf32>
 //         CDNA3:     %[[ADD:.+]] = llvm.fadd %{{.*}}, %{{.*}} : vector<16xf32>
 //         CDNA3:     llvm.store %[[ADD]], %{{.*}} : vector<16xf32>, !llvm.ptr<7>
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_elementwise_f8ocp.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_elementwise_f8ocp.mlir
@@ -45,8 +45,8 @@ hal.executable @ext_fp8_dispatch {
 
 //   RDNA4-LABEL: hal.executable public @ext_fp8_dispatch
 //         RDNA4:   hal.executable.variant public @rocm
-// RDNA4-COUNT-16:     rocdl.cvt.f32.fp8 %{{.*}} : f32
-// RDNA4-COUNT-16:     rocdl.cvt.f32.bf8 %{{.*}} : f32
+// RDNA4-COUNT-8:     rocdl.cvt.pk.f32.fp8 %{{.*}} : vector<2xf32>
+// RDNA4-COUNT-8:     rocdl.cvt.pk.f32.bf8 %{{.*}} : vector<2xf32>
 //         RDNA4:     %[[ADD:.+]] = llvm.fadd %{{.*}}, %{{.*}} : vector<16xf32>
 //         RDNA4:     llvm.store %[[ADD]], %{{.*}} : vector<16xf32>, !llvm.ptr<7>
 


### PR DESCRIPTION
ROCDL tests are updated due to LLVM commit 0ea4fb92648b2aa7cbab486bb493e122b4dcc062.