### PR TITLE
[GPU] Rework MaterializeEncodingIntoPadding pass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
@@ -42,9 +42,8 @@ namespace {
 
 // Returns the pad encoding layout, or nullptr if this is not the only layout or
 // if there's no encoding at all.
-static PadEncodingLayoutAttr
-getPadLayout(const IREE::Codegen::LayoutAttrInterface &layoutAttr,
-             RankedTensorType type) {
+static PadEncodingLayoutAttr getPadLayout(Attribute layoutAttr,
+                                          RankedTensorType type) {
   auto encoding =
       dyn_cast_or_null<IREE::Encoding::EncodingAttr>(type.getEncoding());
   if (!encoding) {
@@ -65,9 +64,8 @@ getPadLayout(const IREE::Codegen::LayoutAttrInterface &layoutAttr,
 
 // Returns a padded tensor type (without encoding) for tensor types with the pad
 // encoding layout, or the same type for all other tensors.
-static RankedTensorType
-getPaddedType(const IREE::Codegen::LayoutAttrInterface &layoutAttr,
-              RankedTensorType type) {
+static RankedTensorType getPaddedType(Attribute layoutAttr,
+                                      RankedTensorType type) {
   PadEncodingLayoutAttr layout = getPadLayout(layoutAttr, type);
   if (!isNonZeroPadding(layout)) {
     return type.dropEncoding();
@@ -84,9 +82,9 @@ getPaddedType(const IREE::Codegen::LayoutAttrInterface &layoutAttr,
   return RankedTensorType::get(newShape, type.getElementType());
 }
 
-static bool
-hasNonZeroPadding(const IREE::Codegen::LayoutAttrInterface &layoutAttr,
-                  RankedTensorType type) {
+// TODO(hanchung): Perhaps we can just check if the encoding is present and
+// query if it is an identity layout.
+static bool hasNonZeroPadding(Attribute layoutAttr, RankedTensorType type) {
   return isNonZeroPadding(getPadLayout(layoutAttr, type));
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
@@ -11,6 +11,7 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
+#include "iree/compiler/Codegen/Dialect/GPU/TargetUtils/KnownTargets.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingTypes.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
@@ -291,11 +292,9 @@ struct MaterializeEncodingIntoPaddingPass final
     } else {
       IREE::GPU::TargetAttr targetAttr = getCLGPUTarget(context);
       SmallVector<NamedAttribute> items;
-      items.emplace_back(IREE::Encoding::kEncodingResolverAttrName,
-                         IREE::GPU::GPUPadLayoutAttr::get(
-                             context, /*cacheLineBytes=*/std::nullopt,
-                             /*cacheSets=*/std::nullopt));
-      items.emplace_back(kGPUTargetAttrName, targetAttr);
+      items.emplace_back(
+          IREE::Encoding::kEncodingResolverAttrName,
+          IREE::GPU::getHIPTargetEncodingLayoutAttr(targetAttr, "pad"));
       targetConfig = DictionaryAttr::get(context, items);
     }
 

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
@@ -301,7 +301,8 @@ struct MaterializeEncodingIntoPaddingPass final
     //
     // Otherwise, fall back to the nop layout.
     IREE::Codegen::LayoutAttrInterface layoutAttr;
-    if (targetConfig.contains(IREE::Encoding::kEncodingResolverAttrName)) {
+    if (targetConfig &&
+        targetConfig.contains(IREE::Encoding::kEncodingResolverAttrName)) {
       layoutAttr = targetConfig.getAs<IREE::Codegen::LayoutAttrInterface>(
           IREE::Encoding::kEncodingResolverAttrName);
       auto resolverAttr =

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_into_padding.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_into_padding.mlir
@@ -1,4 +1,5 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-materialize-encoding-into-padding))" \
+// RUN:   --iree-gpu-test-target=gfx942 \
 // RUN:   --split-input-file %s | FileCheck %s
 
 #binding_ro = #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">
@@ -167,3 +168,35 @@ func.func @load_from_padded_and_mmt() {
 //
 // CHECK:         flow.dispatch.tensor.store %[[MMT]], %[[C]], offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1]
 // CHECK-SAME:                  tensor<2048x2048xf16> -> !flow.dispatch.tensor<writeonly:tensor<2048x2048xf16>>
+
+// -----
+
+#binding_ro = #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">
+#binding = #hal.pipeline.binding<storage_buffer, Indirect>
+#pad_encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f16, f16, f16],
+                                        layouts = [#iree_encoding.pad_encoding_layout<[0, 64]>]>
+func.func @set_pad_encoding_and_store_with_resolved_layout() {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.constant.load layout(<constants = 1, bindings = [#binding_ro, #binding], flags = Indirect>) ordinal(0) : i32
+  %1 = arith.index_castui %0 : i32 to index
+  %3 = hal.interface.binding.subspan layout(<constants = 1, bindings = [#binding_ro, #binding], flags = Indirect>) binding(0) alignment(64) offset(%1) flags("ReadOnly|Indirect")
+    : !flow.dispatch.tensor<readonly:tensor<2048x2048xf16>>
+  %4 = hal.interface.binding.subspan layout(<constants = 1, bindings = [#binding_ro, #binding], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags(Indirect)
+    : !flow.dispatch.tensor<writeonly:tensor<2048x2048xf16, #pad_encoding>>
+  %5 = flow.dispatch.tensor.load %3, offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1]
+    : !flow.dispatch.tensor<readonly:tensor<2048x2048xf16>> -> tensor<2048x2048xf16>
+  %6 = iree_encoding.set_encoding %5 : tensor<2048x2048xf16> -> tensor<2048x2048xf16, #pad_encoding>
+  flow.dispatch.tensor.store %6, %4, offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1]
+    : tensor<2048x2048xf16, #pad_encoding> -> !flow.dispatch.tensor<writeonly:tensor<2048x2048xf16, #pad_encoding>>
+  return
+}
+
+// CHECK-LABEL: @set_pad_encoding_and_store_with_resolved_layout
+// CHECK:         %[[A:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)
+// CHECK-SAME:                  !flow.dispatch.tensor<readonly:tensor<2048x2048xf16>>
+// CHECK:         %[[B:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)
+// CHECK-SAME:                  !flow.dispatch.tensor<writeonly:tensor<2048x2112xf16>>
+// CHECK:         %[[LD:.+]] = flow.dispatch.tensor.load %[[A]], offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1]
+// CHECK-SAME:                  !flow.dispatch.tensor<readonly:tensor<2048x2048xf16>> -> tensor<2048x2048xf16>
+// CHECK:         flow.dispatch.tensor.store %[[LD]], %[[B]], offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1]
+// CHECK-SAME:                  tensor<2048x2048xf16> -> !flow.dispatch.tensor<writeonly:tensor<2048x2112xf16>>

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -400,6 +400,27 @@ struct GPUHostEncodingLayoutResolverAttrInterface final
   }
 };
 
+struct GPUPadDeviceEncodingLayoutAttrInterface final
+    : Codegen::LayoutAttrInterface::ExternalModel<
+          GPUPadDeviceEncodingLayoutAttrInterface, GPUPadLayoutAttr> {
+
+  // TODO(#20160): Do not implement the interface method because it is
+  // data-tiling specific. It is a workaround to reuse encoding materialization
+  // patterns, because we query types from the method in the conversion. We
+  // should really move them to interface methods, then we can delete the
+  // workaround.
+  MaterializeEncodingInfo getEncodingInfo(Attribute attr,
+                                          RankedTensorType type) const {
+    return MaterializeEncodingInfo{};
+  }
+
+  Operation *lowerOp(Attribute attr, OpBuilder &b, Operation *op,
+                     TypeRange convertedResTypes,
+                     ValueRange convertedOperands) const {
+    return clone(b, op, convertedResTypes, convertedOperands);
+  }
+};
+
 struct GPUPadEncodingLayoutResolverAttrInterface final
     : Encoding::EncodingLayoutResolverAttrInterface::ExternalModel<
           GPUPadEncodingLayoutResolverAttrInterface, GPUPadLayoutAttr> {
@@ -528,6 +549,7 @@ void registerGPUEncodingExternalModels(DialectRegistry &registry) {
             GPUHostEncodingLayoutResolverAttrInterface,
             GPUHostSerializableEncodingAttrInterface>(*ctx);
         IREE::GPU::GPUPadLayoutAttr::attachInterface<
+            GPUPadDeviceEncodingLayoutAttrInterface,
             GPUPadEncodingLayoutResolverAttrInterface>(*ctx);
       });
 }

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -1755,6 +1755,35 @@ iree_generated_e2e_runner_test(
     "requires-gpu-cdna3"
 )
 
+iree_generated_e2e_runner_test(
+  NAME
+    e2e_matmul_cdna3_pad_f32
+  TEST_TYPE
+    matmul
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f32"
+    "--acc_type=f32"
+  TEST_RUNNER
+    iree_tools_testing_e2e_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "rocm"
+  DRIVERS
+    "hip"
+  COMPILER_FLAGS
+    ${IREE_HIP_TEST_COMPILER_FLAGS}
+    "--iree-opt-data-tiling=false"
+    "--iree-dispatch-creation-experimental-data-tiling=true"
+    "--iree-hip-encoding-layout-resolver=pad"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-cdna3"
+)
+
 endif()
 
 elseif(IREE_HIP_TEST_TARGET_CHIP MATCHES "^gfx11")


### PR DESCRIPTION
The revision reworks the pass to be compatible with recent flow/stream tensor encode changes. There is a step in encoding materialization that brings the global layout to preferred layout. The revision moves the logic to SetEncoding lowering because the `set_encoding` op is responsible for layout changes from global layout to target preferred layout.

The load/store should operate on the source/destination if the resolved layout matches. Otherwise, it applies layout transfer, which is not implemented for any targets at the moment.

The revision exposes a "hidden" dependency between padding layout resolver and nop layout resolver. Because the current type converter is not decoupled enough from data-tiling usage. To collapse two passes properly, we'll need to add more interface methods to `IREE::Codegen::LayoutAttrInterface`, e.g., `convertType(Type)`, `lowerToTargetLayout(...)`, `lowerToGlobalLayout(...)`, etc.

The revision adds e2e tests to padding approach, which ensures that other future changes won't break it. It was broken because of the recent flow/stream tensor encode work.

Fixes https://github.com/iree-org/iree/issues/20362