### PR TITLE
Do not wrap single unset_encoding op into dispatch region.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -832,7 +832,7 @@ bool isClonableIntoDispatchOp(Operation *op,
   // with bufferization. Make them clonable when fixed.
   if (isa<affine::AffineApplyOp, arith::IndexCastOp, linalg::FillOp,
           tensor::EmptyOp, tensor::ExtractOp, tensor::ExtractSliceOp,
-          complex::CreateOp>(op)) {
+          complex::CreateOp, IREE::Encoding::UnsetEncodingOp>(op)) {
     return true;
   }
   if (LinalgExt::isBitExtendOp(op)) {

--- a/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
@@ -176,7 +176,7 @@ static bool isRootOp(Operation *op) {
   if (isa<TilingInterface>(op)) {
     return !isa<tensor::PadOp, linalg::PackOp>(op);
   }
-  return isa<IREE::Encoding::UnsetEncodingOp, linalg::UnPackOp>(op);
+  return isa<linalg::UnPackOp>(op);
 }
 
 /// Returns true if the operation is a `pack` op or a `set_encoding` op that

--- a/compiler/src/iree/compiler/DispatchCreation/test/convert_encoding_to_flow.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/convert_encoding_to_flow.mlir
@@ -40,3 +40,44 @@ util.func public @set_encoding_in_flow_region(%arg0: tensor<123x456xf32>) -> ten
 }
 // CHECK-LABEL: @set_encoding_in_flow_region(
 // CHECK-NOT:     flow.tensor.encode
+
+// -----
+
+#encoding = #iree_encoding.testing_encoding<>
+util.func public @unset_encoding_static(%arg0: tensor<123x456xf32, #encoding>) -> tensor<123x456xf32> {
+  %0 = iree_encoding.unset_encoding %arg0 : tensor<123x456xf32, #encoding> -> tensor<123x456xf32>
+  util.return %0 : tensor<123x456xf32>
+}
+// CHECK-DAG:    #[[$ENC:.+]] = #iree_encoding.testing_encoding<>
+// CHECK-LABEL:  @unset_encoding_static(
+// CHECK-SAME:     %[[SRC:[a-zA-Z0-9]+]]
+// CHECK:          %[[RES:.+]] = flow.tensor.encode %[[SRC]]
+// CHECK-SAME:       tensor<123x456xf32, #[[$ENC]]> -> tensor<123x456xf32>
+
+// -----
+
+#encoding = #iree_encoding.testing_encoding<>
+util.func public @unset_encoding_dynamic(%arg0: tensor<?x?xf32, #encoding>, %d0: index, %d1: index) -> tensor<?x?xf32> {
+  %0 = iree_encoding.unset_encoding %arg0 : tensor<?x?xf32, #encoding> -> tensor<?x?xf32>{%d0, %d1}
+  util.return %0 : tensor<?x?xf32>
+}
+// CHECK-DAG:    #[[$ENC:.+]] = #iree_encoding.testing_encoding<>
+// CHECK-LABEL:  @unset_encoding_dynamic(
+// CHECK-SAME:     %[[SRC:[a-zA-Z0-9]+]]
+// CHECK-SAME:     %[[D0:[a-zA-Z0-9]+]]
+// CHECK-SAME:     %[[D1:[a-zA-Z0-9]+]]
+// CHECK:          %[[RES:.+]] = flow.tensor.encode %[[SRC]]
+// CHECK-SAME:       tensor<?x?xf32, #[[$ENC]]>{%[[D0]], %[[D1]]} -> tensor<?x?xf32>{%[[D0]], %[[D1]]}
+
+// -----
+
+#encoding = #iree_encoding.testing_encoding<>
+util.func public @unset_encoding_in_flow_region(%arg0: tensor<123x456xf32, #encoding>) -> tensor<123x456xf32> {
+  %0 = flow.dispatch.region -> (tensor<123x456xf32>) {
+    %1 = iree_encoding.unset_encoding %arg0 : tensor<123x456xf32, #encoding> -> tensor<123x456xf32>
+    flow.return %1 : tensor<123x456xf32>
+  }
+  util.return %0 : tensor<123x456xf32>
+}
+// CHECK-LABEL: @unset_encoding_in_flow_region(
+// CHECK-NOT:     flow.tensor.encode

--- a/compiler/src/iree/compiler/DispatchCreation/test/form_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/form_dispatch_regions.mlir
@@ -255,8 +255,8 @@ util.func public @unset_encoding_elementwise_fusion(
 // CHECK-LABEL: util.func public @unset_encoding_elementwise_fusion(
 //  CHECK-SAME:     %[[ARG0:.+]]: tensor<?x?xf32, #[[$ENCODING]]>
 //  CHECK-SAME:     %[[ARG1:.+]]: tensor<?xf32>
+//       CHECK:   %[[UNSET_ENCODING:.+]] = iree_encoding.unset_encoding %[[ARG0]]
 //       CHECK:   %[[RESULT:.+]] = flow.dispatch.region
-//       CHECK:     %[[UNSET_ENCODING:.+]] = iree_encoding.unset_encoding %[[ARG0]]
 //       CHECK:     %[[GENERIC:.+]] = linalg.generic
 //  CHECK-SAME:         ins(%[[UNSET_ENCODING]], %[[ARG1]]
 //       CHECK:     flow.return %[[GENERIC]]
@@ -290,8 +290,8 @@ util.func public @unset_encoding_elementwise_fusion(
 // CHECK-LABEL: util.func public @unset_encoding_elementwise_fusion(
 //  CHECK-SAME:     %[[ARG0:.+]]: tensor<?x?xf32, #[[$ENCODING]]>
 //  CHECK-SAME:     %[[ARG1:.+]]: tensor<?xf32>
+//       CHECK:   %[[UNSET_ENCODING:.+]] = iree_encoding.unset_encoding %[[ARG0]]
 //       CHECK:   %[[RESULT0:.+]] = flow.dispatch.region
-//       CHECK:     %[[UNSET_ENCODING:.+]] = iree_encoding.unset_encoding %[[ARG0]]
 //       CHECK:     %[[GENERIC:.+]] = linalg.generic {{.*}} ins(%[[UNSET_ENCODING]]
 //       CHECK:     flow.return %[[GENERIC]]
 //       CHECK:   util.return %[[RESULT0]]
@@ -347,10 +347,8 @@ util.func public @unset_encoding_slice(%arg0: tensor<1x50x384xf32, #encoding>) -
 }
 // CHECK-LABEL: util.func public @unset_encoding_slice
 // CHECK-SAME:      %[[ARG0:[a-zA-Z0-9]+]]
-// CHECK:         %[[RESULT:.+]] = flow.dispatch.region
-// CHECK:           %[[UNSET_ENCODING:.+]] = iree_encoding.unset_encoding
-// CHECK:           flow.return %[[UNSET_ENCODING]]
-// CHECK:         %[[SLICE:.+]] = tensor.extract_slice %[[RESULT]]
+// CHECK:         %[[UNSET_ENCODING:.+]] = iree_encoding.unset_encoding
+// CHECK:         %[[SLICE:.+]] = tensor.extract_slice %[[UNSET_ENCODING]]
 // CHECK:         util.return %[[SLICE]]
 
 // -----

--- a/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests.mlir
@@ -281,3 +281,19 @@ util.func public @set_encoding_op(%arg0 : tensor<?x?xf32>)
 // CHECK-DAG:     %[[D1:.+]] = tensor.dim %[[SRC]], %[[C1]]
 // CHECK:         %[[RES:.+]] = flow.tensor.encode %[[SRC]] : tensor<?x?xf32>{%[[D0]], %[[D1]]} -> tensor<?x?xf32, #iree_encoding.testing_encoding<>>{%[[D0]], %[[D1]]}
 // CHECK:         util.return %[[RES]]
+
+// -----
+
+#encoding = #iree_encoding.testing_encoding<>
+util.func public @unset_encoding_op(%arg0 : tensor<?x?xf32, #encoding>, %d0: index, %d1: index)
+    -> tensor<?x?xf32> {
+  %0 = iree_encoding.unset_encoding %arg0
+      : tensor<?x?xf32, #encoding> -> tensor<?x?xf32>{%d0, %d1}
+  util.return %0 : tensor<?x?xf32>
+}
+// CHECK-LABEL: util.func public @unset_encoding_op
+// CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[D0:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[D1:[a-zA-Z0-9]+]]
+// CHECK:         %[[RES:.+]] = flow.tensor.encode %[[SRC]] : tensor<?x?xf32, #iree_encoding.testing_encoding<>>{%[[D0]], %[[D1]]} -> tensor<?x?xf32>{%[[D0]], %[[D1]]}
+// CHECK:         util.return %[[RES]]


### PR DESCRIPTION
There are few pieces to plumb it through the software stack. What the revision does is:

- Do not treat unset_encoding op as a root op, so it won't get fused into dispatches.
- Add the unset_encoding ops to clonable list, so the CloneProducersIntoDispatchRegions pass can pull it into the consumer dispatch.
- If there is no consumer dispatch, the unset_encoding op is converted to flow.tensor.encode op.
- Similar to other tensor encode op, the op is folded away if an identity layout is recognized. Otherwise, the MaterializeEncodingsPass materializes unique executables for `stream.tensor.encode` ops and replaces them with dispatches to those executables.

The [IR dump](https://gist.github.com/hanhanW/581d4ae9cd8ce26e47c723a27192f7d9) shows that there are no additional dispatches when the backend does not support encoding.

To repro, run

```bash
iree-compile \
  --output-format=vm-bytecode \
  --iree-hal-target-backends=vulkan-spirv \
  --iree-global-opt-enable-early-materialization=false \
  --mlir-print-ir-after=iree-stream-materialize-encodings \
  --mlir-print-ir-before=iree-stream-materialize-encodings \
  --mlir-disable-threading \
  matmul_f32.mlir -o /tmp/matmul_f32.vmfb
```

MLIR Source:

```mlir
func.func @main(%lhs: tensor<?x?xf32>, %rhs: tensor<?x?xf32>) -> tensor<?x?xf32> {
  %c0 = arith.constant 0 : index
  %c1 = arith.constant 1 : index
  %M = tensor.dim %lhs, %c0 : tensor<?x?xf32>
  %N = tensor.dim %rhs, %c1 : tensor<?x?xf32>
  %cst = arith.constant 0.0 : f32
  %init = tensor.empty(%M, %N) : tensor<?x?xf32>
  %fill = linalg.fill ins(%cst : f32) outs(%init : tensor<?x?xf32>) -> tensor<?x?xf32>
  %op = linalg.matmul
      ins(%lhs, %rhs : tensor<?x?xf32>, tensor<?x?xf32>)
      outs(%fill : tensor<?x?xf32>) -> tensor<?x?xf32>
  return %op : tensor<?x?xf32>
}
```

The revision deletes two old tests from `dispatch_linalg_on_tensors.mlir` because the functionality is tested in each pass and the pipeline tests.

Fixes https://github.com/iree-org/iree/issues/20187