### PR TITLE
Do not unconditionally build runtime demo

### DIFF
--- a/runtime/src/iree/runtime/demo/CMakeLists.txt
+++ b/runtime/src/iree/runtime/demo/CMakeLists.txt
@@ -1,6 +1,10 @@
 # NOTE: not using bazel-to-cmake here because of the runtime unified rule.
 # We should figure out how to make bazel/cmake consistent with that.
 
+if(NOT IREE_BUILD_SAMPLES)
+  return()
+endif()
+
 iree_cc_binary(
   NAME
     hello_world_file


### PR DESCRIPTION
I want to build IREE runtime without any demo, sample, test. I know this commit cannot pass `bazel_to_cmake` check. However, I don't know how to make both of them happy.