### PR TITLE
Only pin affinity during analysis if an affinity is specified.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -1812,7 +1812,7 @@ LogicalResult TensorImportOp::verify() {
   return success();
 }
 
-bool TensorImportOp::pinsValueAffinity() { return true; }
+bool TensorImportOp::pinsValueAffinity() { return getAffinity().has_value(); }
 
 Value TensorImportOp::getTiedResult(unsigned resultIndex) {
   return IREE::Util::TiedOpInterface::findTiedBaseValue(getSource());
@@ -1841,7 +1841,7 @@ LogicalResult TensorExportOp::verify() {
   return success();
 }
 
-bool TensorExportOp::pinsValueAffinity() { return true; }
+bool TensorExportOp::pinsValueAffinity() { return getAffinity().has_value(); }
 
 Value TensorExportOp::getTiedResult(unsigned resultIndex) {
   return IREE::Util::TiedOpInterface::findTiedBaseValue(getSource());

--- a/compiler/src/iree/compiler/ExternalInterfaces/StreamExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/StreamExternalModels.cpp
@@ -129,7 +129,9 @@ struct HALTensorAffinityAttrExternalModel
 
   bool requiresAffinity(Operation *op) const { return false; }
 
-  bool pinsValueAffinity(Operation *op) const { return true; }
+  bool pinsValueAffinity(Operation *op) const {
+    return op->hasAttrOfType<IREE::Stream::AffinityAttr>("affinity");
+  }
 
   IREE::Stream::AffinityAttr getAffinityAttr(Operation *op) const {
     return op->getAttrOfType<IREE::Stream::AffinityAttr>("affinity");


### PR DESCRIPTION
We still expect for affinity to be specified, but this does make it easier (if non-deterministic) to preserve the correct metadata.

Fixes #20381.