### PR TITLE
Use a better way to determine C11 support

### DIFF
--- a/runtime/src/iree/base/status.c
+++ b/runtime/src/iree/base/status.c
@@ -30,7 +30,7 @@
 // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/aligned-malloc
 #define iree_aligned_alloc(alignment, size) _aligned_malloc(size, alignment)
 #define iree_aligned_free(p) _aligned_free(p)
-#elif defined(_ISOC11_SOURCE)
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
 // https://en.cppreference.com/w/c/memory/aligned_alloc
 #define iree_aligned_alloc(alignment, size) aligned_alloc(alignment, size)
 #define iree_aligned_free(p) free(p)


### PR DESCRIPTION
Here we just want to check whether current compiler support C11 standard. `__STDC_VERSION__` is a predefined macro supported by [clang](https://clang.llvm.org/docs/UsersManual.html#differences-between-various-standard-modes), [gcc](https://gcc.gnu.org/onlinedocs/gcc-14.2.0/cpp/Standard-Predefined-Macros.html) and [MSVC](https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170), while `_ISOC11_SOURCE` is defined by glibc. If target is not glibc such as bare metal ELF, `_ISOC11_SOURCE` will not be defined. 