### PR TITLE
[DataTiling] Don't set encodings in dispatch.region ops with workgroup counts

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/SetEncoding.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SetEncoding.cpp
@@ -20,6 +20,7 @@
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -152,6 +153,20 @@ static LogicalResult isSupportedContractionOp(PatternRewriter &rewriter,
   return success();
 }
 
+static bool isInScalarDispatch(Operation *op) {
+  auto parentDispatchOp = op->getParentOfType<IREE::Flow::DispatchRegionOp>();
+  if (!parentDispatchOp) {
+    return false;
+  }
+  Region &workgroupCountRegion = parentDispatchOp.getWorkgroupCount();
+  if (workgroupCountRegion.empty()) {
+    return false;
+  }
+  SmallVector<OpFoldResult> workgroupCounts =
+        workgroupCountRegion.getBlocks().front().getTerminator()->getOperands();
+  return areAllConstantIntValue(workgroupCounts, 1);
+}
+
 namespace {
 
 class SetContractionOpEncoding final
@@ -169,6 +184,10 @@ public:
     if (getCompilationInfo(linalgOp)) {
       return rewriter.notifyMatchFailure(
           linalgOp, "the op has preset compilation strategy, skip SetEncoding");
+    }
+    if (isInScalarDispatch(linalgOp.getOperation())) {
+      return rewriter.notifyMatchFailure(
+          linalgOp, "the op is in a scalar dispatch, skip SetEncoding");
     }
     if (failed(isSupportedContractionOp(rewriter, linalgOp))) {
       return failure();


### PR DESCRIPTION
Dispatch regions with workgroup counts have already decided some part of their compilation strategy, and if encodings are materialized during codegen, then the existing workgroup counts may not be valid anymore. This PR avoids setting encodings within dispatch regions that already contain workgroup counts.