### PR TITLE
Add passes to do more preprocessing when creating single dispatch

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
@@ -137,12 +137,6 @@ struct FoldUnitExtentDimsPass final
   void runOnOperation() override;
 };
 
-struct FoldUnitExtentDimsForFuncPass final
-    : public impl::FoldUnitExtentDimsForFuncPassBase<
-          FoldUnitExtentDimsForFuncPass> {
-  void runOnOperation() override;
-};
-
 void FoldUnitExtentDimsPass::runOnOperation() {
   auto moduleOp = getOperation();
   MLIRContext *context = &getContext();
@@ -180,6 +174,14 @@ void FoldUnitExtentDimsPass::runOnOperation() {
     return signalPassFailure();
   }
 }
+} // namespace
+
+namespace {
+struct FoldUnitExtentDimsForFuncPass final
+    : public impl::FoldUnitExtentDimsForFuncPassBase<
+          FoldUnitExtentDimsForFuncPass> {
+  void runOnOperation() override;
+};
 
 void FoldUnitExtentDimsForFuncPass::runOnOperation() {
   MLIRContext *context = &getContext();

--- a/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
@@ -142,7 +142,6 @@ struct FoldUnitExtentDimsForFuncPass final
           FoldUnitExtentDimsForFuncPass> {
   void runOnOperation() override;
 };
-} // namespace
 
 void FoldUnitExtentDimsPass::runOnOperation() {
   auto moduleOp = getOperation();
@@ -192,4 +191,5 @@ void FoldUnitExtentDimsForFuncPass::runOnOperation() {
   }
 }
 
+} // namespace
 } // namespace mlir::iree_compiler::DispatchCreation

--- a/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
@@ -32,11 +32,34 @@
 namespace mlir::iree_compiler::DispatchCreation {
 
 #define GEN_PASS_DEF_FOLDUNITEXTENTDIMSPASS
+#define GEN_PASS_DEF_FOLDUNITEXTENTDIMSFORFUNCPASS
 #include "iree/compiler/DispatchCreation/Passes.h.inc"
 
 //===----------------------------------------------------------------------===//
 // Pass helpers
 //===----------------------------------------------------------------------===//
+
+static void
+populatefoldUnitDimsPatterns(RewritePatternSet &foldUnitDimsPatterns) {
+  linalg::ControlDropUnitDims options;
+  auto defaultFn = options.controlFn;
+
+  options.controlFn = [&](Operation *op) {
+    // Ignore operations already in dispatches.
+    if (!IREE::Flow::isNonNullAndOutsideDispatch(op)) {
+      return SmallVector<unsigned>{};
+    }
+    if (isa<IREE::LinalgExt::LinalgExtOp>(op)) {
+      return IREE::LinalgExt::defaultControlDropUnitDims(op);
+    }
+    return defaultFn(op);
+  };
+
+  linalg::populateFoldUnitExtentDimsPatterns(foldUnitDimsPatterns, options);
+  IREE::LinalgExt::populateFoldUnitExtentDimsPatterns(foldUnitDimsPatterns,
+                                                      options);
+  linalg::populateMoveInitOperandsToInputPattern(foldUnitDimsPatterns);
+}
 
 static LogicalResult
 foldUnitDimsOnGlobal(IRRewriter &rewriter, IREE::Util::GlobalOpInterface global,
@@ -113,6 +136,12 @@ struct FoldUnitExtentDimsPass final
     : public impl::FoldUnitExtentDimsPassBase<FoldUnitExtentDimsPass> {
   void runOnOperation() override;
 };
+
+struct FoldUnitExtentDimsForFuncPass final
+    : public impl::FoldUnitExtentDimsForFuncPassBase<
+          FoldUnitExtentDimsForFuncPass> {
+  void runOnOperation() override;
+};
 } // namespace
 
 void FoldUnitExtentDimsPass::runOnOperation() {
@@ -146,24 +175,19 @@ void FoldUnitExtentDimsPass::runOnOperation() {
   });
 
   RewritePatternSet foldUnitDimsPatterns(context);
-  linalg::ControlDropUnitDims options;
-  auto defaultFn = options.controlFn;
-  options.controlFn = [&](Operation *op) {
-    // Ignore operations already in dispatches.
-    if (!IREE::Flow::isNonNullAndOutsideDispatch(op)) {
-      return SmallVector<unsigned>{};
-    }
-    if (isa<IREE::LinalgExt::LinalgExtOp>(op)) {
-      return IREE::LinalgExt::defaultControlDropUnitDims(op);
-    }
-    return defaultFn(op);
-  };
-  linalg::populateFoldUnitExtentDimsPatterns(foldUnitDimsPatterns, options);
-  IREE::LinalgExt::populateFoldUnitExtentDimsPatterns(foldUnitDimsPatterns,
-                                                      options);
-  linalg::populateMoveInitOperandsToInputPattern(foldUnitDimsPatterns);
+  populatefoldUnitDimsPatterns(foldUnitDimsPatterns);
   if (failed(
           applyPatternsGreedily(moduleOp, std::move(foldUnitDimsPatterns)))) {
+    return signalPassFailure();
+  }
+}
+
+void FoldUnitExtentDimsForFuncPass::runOnOperation() {
+  MLIRContext *context = &getContext();
+  RewritePatternSet foldUnitDimsPatterns(context);
+  populatefoldUnitDimsPatterns(foldUnitDimsPatterns);
+  if (failed(applyPatternsGreedily(getOperation(),
+                                   std::move(foldUnitDimsPatterns)))) {
     return signalPassFailure();
   }
 }

--- a/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
@@ -44,7 +44,7 @@ populatefoldUnitDimsPatterns(RewritePatternSet &foldUnitDimsPatterns) {
   linalg::ControlDropUnitDims options;
   auto defaultFn = options.controlFn;
 
-  options.controlFn = [&](Operation *op) {
+  options.controlFn = [=](Operation *op) {
     // Ignore operations already in dispatches.
     if (!IREE::Flow::isNonNullAndOutsideDispatch(op)) {
       return SmallVector<unsigned>{};
@@ -137,6 +137,14 @@ struct FoldUnitExtentDimsPass final
   void runOnOperation() override;
 };
 
+struct FoldUnitExtentDimsForFuncPass final
+    : public impl::FoldUnitExtentDimsForFuncPassBase<
+          FoldUnitExtentDimsForFuncPass> {
+  void runOnOperation() override;
+};
+
+} // namespace
+
 void FoldUnitExtentDimsPass::runOnOperation() {
   auto moduleOp = getOperation();
   MLIRContext *context = &getContext();
@@ -174,14 +182,6 @@ void FoldUnitExtentDimsPass::runOnOperation() {
     return signalPassFailure();
   }
 }
-} // namespace
-
-namespace {
-struct FoldUnitExtentDimsForFuncPass final
-    : public impl::FoldUnitExtentDimsForFuncPassBase<
-          FoldUnitExtentDimsForFuncPass> {
-  void runOnOperation() override;
-};
 
 void FoldUnitExtentDimsForFuncPass::runOnOperation() {
   MLIRContext *context = &getContext();
@@ -193,5 +193,4 @@ void FoldUnitExtentDimsForFuncPass::runOnOperation() {
   }
 }
 
-} // namespace
 } // namespace mlir::iree_compiler::DispatchCreation

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -65,6 +65,20 @@ def FoldUnitExtentDimsPass :
   ];
 }
 
+def FoldUnitExtentDimsForFuncPass :
+    Pass<"iree-dispatch-creation-fold-unit-extent-dims-for-func", ""> {
+  let summary = "Fold unit extent dimension of operations on a function.";
+  let description = [{
+    Imports upstream patterns to fold unit extent dims but with IREE control.
+  }];
+  let dependentDialects = [
+    "mlir::affine::AffineDialect",
+    "mlir::arith::ArithDialect",
+    "mlir::linalg::LinalgDialect",
+    "mlir::tensor::TensorDialect",
+  ];
+}
+
 def FuseHorizontalContractionsPass:
     InterfacePass<"iree-dispatch-creation-fuse-horizontal-contractions", "mlir::FunctionOpInterface"> {
   let summary = "Fuses horizontal contraction ops";

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/attr_based_pipeline.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/attr_based_pipeline.mlir
@@ -46,8 +46,10 @@ func.func @single_dispatch_fusion(%lhs : tensor<18x288xf32>, %rhs :  tensor<18x2
 
 // CHECK-LABEL: @single_dispatch_fusion
 //       CHECK:   %[[DISPATCH:.+]] = flow.dispatch.region
-//       CHECK:   %[[TRUNC:.+]] =  arith.truncf
-//       CHECK:   %[[ADD:.+]] = arith.addf %[[TRUNC]]
+//       CHECK:     linalg.generic
+//       CHECK:       %[[TRUNC:.+]] =  arith.truncf
+//       CHECK:       %[[ADD:.+]] = arith.addf %[[TRUNC]]
+//   CHECK-NOT:     linalg.generic
 
 // -----
 

--- a/compiler/src/iree/compiler/Preprocessing/Common/test/attr_based_pipeline.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/attr_based_pipeline.mlir
@@ -1,20 +1,53 @@
 // RUN: iree-opt --iree-preprocessing-attr-based-pipeline --mlir-print-local-scope --split-input-file --verify-diagnostics %s | FileCheck %s
 
-func.func @test(%lhs : tensor<16x26x18x288xbf16>, %rhs :  tensor<288x288x3x3xbf16>, %outs : tensor<16x288x26x18xbf16>,
-    %outs2 : tensor<16x288x24x16xf32>) -> tensor<16x288x24x16xf32> attributes {
+func.func @single_dispatch_dropunitdims(%lhs : tensor<1x26x18x288xbf16>, %rhs :  tensor<288x288x3x3xbf16>, %outs : tensor<1x288x26x18xbf16>,
+    %outs2 : tensor<1x288x24x16xf32>) -> tensor<1x288x24x16xf32> attributes {
     preprocessing_pipeline = #util.preprocessing_pipeline<"iree-preprocessing-make-single-dispatch">} {
-  %transposed = linalg.transpose ins(%lhs : tensor<16x26x18x288xbf16>) outs(%outs : tensor<16x288x26x18xbf16>) permutation = [0, 3, 1, 2]
+  %transposed = linalg.transpose ins(%lhs : tensor<1x26x18x288xbf16>) outs(%outs : tensor<1x288x26x18xbf16>) permutation = [0, 3, 1, 2]
   %conv = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>}
-    ins(%transposed, %rhs : tensor<16x288x26x18xbf16>, tensor<288x288x3x3xbf16>)
-    outs(%outs2 : tensor<16x288x24x16xf32>) -> tensor<16x288x24x16xf32>
-  return %conv : tensor<16x288x24x16xf32>
+    ins(%transposed, %rhs : tensor<1x288x26x18xbf16>, tensor<288x288x3x3xbf16>)
+    outs(%outs2 : tensor<1x288x24x16xf32>) -> tensor<1x288x24x16xf32>
+  return %conv : tensor<1x288x24x16xf32>
 }
-// CHECK-LABEL: test
-//  CHECK-SAME: %[[ARG0:[A-Za-z0-9]+]]: tensor<16x26x18x288xbf16>
+// CHECK-LABEL: @single_dispatch_dropunitdims
+//  CHECK-SAME: %[[ARG0:[A-Za-z0-9]+]]: tensor<1x26x18x288xbf16>
 //       CHECK:   %[[DISPATCH:.+]] = flow.dispatch.region
-//       CHECK:     %[[CONV:.+]] = linalg.generic {{.*}} ins(%[[ARG0]]
+//       CHECK:     %[[COLLAPSE:.+]] = tensor.collapse_shape %[[ARG0]]
+//       CHECK:     %[[EXPAND:.+]] = tensor.expand_shape %[[COLLAPSE]]
+//       CHECK:     %[[CONV:.+]] = linalg.generic {{.*}} ins(%[[EXPAND]]
 //       CHECK:     flow.return %[[CONV]]
 //       CHECK:   return %[[DISPATCH]]
+
+// -----
+func.func @single_dispatch_fusion(%lhs : tensor<18x288xf32>, %rhs :  tensor<18x288xbf16>, %outs : tensor<18x288xbf16>)
+    -> tensor<18x288xbf16> attributes {
+    preprocessing_pipeline = #util.preprocessing_pipeline<"iree-preprocessing-make-single-dispatch">} {
+  %first = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%lhs : tensor<18x288xf32>) outs(%outs : tensor<18x288xbf16>) {
+  ^bb0(%in: f32, %out: bf16):
+    %1 = arith.truncf %in : f32 to bf16
+    linalg.yield %1 : bf16
+  } -> tensor<18x288xbf16>
+  %final = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%first, %rhs : tensor<18x288xbf16>, tensor<18x288xbf16>) outs(%outs : tensor<18x288xbf16>) {
+  ^bb0(%in: bf16, %in_3: bf16, %out: bf16):
+    %2 = arith.addf %in, %in_3 : bf16
+    linalg.yield %2 : bf16
+  } -> tensor<18x288xbf16>
+  return %final : tensor<18x288xbf16>
+}
+
+// CHECK-LABEL: @single_dispatch_fusion
+//       CHECK:   %[[DISPATCH:.+]] = flow.dispatch.region
+//       CHECK:   %[[TRUNC:.+]] =  arith.truncf
+//       CHECK:   %[[ADD:.+]] = arith.addf %[[TRUNC]]
 
 // -----
 

--- a/compiler/src/iree/compiler/Preprocessing/Passes.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Passes.cpp
@@ -136,8 +136,7 @@ buildMakeSingleDispatchPassPipeline(OpPassManager &passManager,
                                     const TransformOptions &options) {
   // We generalize certain named ops immediately before folding unit extent
   // dims as the unit dim folding pass updates indexing maps and is better
-  // at working with generics. By this point we have already done any
-  // specialized raising and the op names are no longer useful.
+  // at working with generics.
   passManager.addPass(GlobalOptimization::createGeneralizeLinalgNamedOpsPass());
   passManager.addPass(DispatchCreation::createFoldUnitExtentDimsForFuncPass());
   GlobalOptimization::PropagateLinalgTransposePassOptions transposeOptions;
@@ -145,6 +144,8 @@ buildMakeSingleDispatchPassPipeline(OpPassManager &passManager,
   transposeOptions.enableAggressivePropagation = true;
   passManager.addPass(
       GlobalOptimization::createPropagateLinalgTransposePass(transposeOptions));
+  // Generalize transposes and any other remaining named linalg ops that can
+  // now be represented as generics.
   passManager.addPass(GlobalOptimization::createGeneralizeLinalgNamedOpsPass());
   passManager.addPass(DispatchCreation::createFusionPreprocessingPass());
   passManager.addPass(mlir::createCSEPass());


### PR DESCRIPTION
The single dispatch pass pipeline is on a function like pass manager, since `FoldUnitExtentDimsPass` is for module, we add a new pass that can be run on function manager, This PR introduces preprocessing so that we can fold unit dims, and fuse elementwise ops together. 