### PR TITLE
[DT][CodeGen] Use EncodingTypeInterface during the materialization.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
@@ -254,6 +254,23 @@ def IREEEncoding_EncodingTypeInterface :
     >,
     InterfaceMethod<
       [{
+        Returns the tensor type with the updated encoding type.
+      }],
+      /*retTy=*/"::mlir::Type",
+      /*methodName=*/"updateEncodingType",
+      /*args=*/(ins
+        "::mlir::Type":$type)
+    >,
+    InterfaceMethod<
+      [{
+        Returns the encoding.
+      }],
+      /*retTy=*/"::mlir::Attribute",
+      /*methodName=*/"getEncoding",
+      /*args=*/(ins)
+    >,
+    InterfaceMethod<
+      [{
         Returns the same type but with the updated encoding.
       }],
       /*retTy=*/"::mlir::Type",

--- a/compiler/src/iree/compiler/ExternalInterfaces/TensorExtExternalModels.cpp
+++ b/compiler/src/iree/compiler/ExternalInterfaces/TensorExtExternalModels.cpp
@@ -54,6 +54,17 @@ struct EncodingTypeExternalModel
     return dispatchTensorType.getBoundType();
   }
 
+  Type updateEncodingType(Type type, Type newEncodingType) const {
+    auto dispatchTensorType = cast<IREE::TensorExt::DispatchTensorType>(type);
+    return IREE::TensorExt::DispatchTensorType::get(
+        dispatchTensorType.getAccess(), newEncodingType);
+  }
+
+  Attribute getEncoding(Type type) const {
+    auto dispatchTensorType = cast<IREE::TensorExt::DispatchTensorType>(type);
+    return dispatchTensorType.asRankedTensorType().getEncoding();
+  }
+
   Type updateEncoding(Type type, Attribute encoding) const {
     auto dispatchTensorType = cast<IREE::TensorExt::DispatchTensorType>(type);
     return IREE::TensorExt::DispatchTensorType::get(


### PR DESCRIPTION
The revision cuts the FlowTypes dependency from the CodeGen encoding materialization pass. It no longer needs to understand what `IREE::Flow::DispatchTensorType` is and it can query the information from the type interface. To achieve it, the revision adds two type interface methods to update and access the encodings:

- `updateEncodingType(Type)`: Returns the tensor type with the updated encoding type.
- `getEncoding()`: Returns the encoding.