### PR TITLE
IREE_BUILD_COMPILER doesn't require nanobind

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -774,7 +774,7 @@ endif()
 
 # Both the IREE and MLIR Python bindings require nanobind. We initialize it here
 # at the top level so that everything uses ours consistently.
-if(IREE_BUILD_PYTHON_BINDINGS OR IREE_BUILD_COMPILER)
+if(IREE_BUILD_PYTHON_BINDINGS)
   include(FetchContent)
   FetchContent_Declare(
     nanobind


### PR DESCRIPTION
I check it with `cmake -DIREE_ENABLE_LLD=ON -DIREE_BUILD_TESTS=OFF --fresh ..` and iree builds well.