### PR TITLE
[Util] Allow inlining on cast_and_call

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/TransformOps/UtilTransformOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/TransformOps/UtilTransformOps.cpp
@@ -12,6 +12,7 @@
 #include "mlir/Dialect/Transform/IR/TransformOps.h"
 #include "mlir/Dialect/Transform/Interfaces/TransformInterfaces.h"
 #include "mlir/IR/Dominance.h"
+#include "mlir/IR/IRMapping.h"
 #include "mlir/Transforms/DialectConversion.h"
 
 namespace mlir::iree_compiler::IREE::Util {
@@ -264,15 +265,56 @@ DiagnosedSilenceableFailure IREE::Util::transform_dialect::CastAndCallOp::apply(
     }
   }
 
-  auto callOp = rewriter.create<IREE::Util::CallOp>(
-      insertionPoint->getLoc(), targetFunction.getResultTypes(),
-      targetFunction.getName(), inputs, /*tied_operands=*/ArrayAttr{},
-      /*arg_attrs=*/nullptr, /*res_attrs=*/nullptr);
+  SmallVector<Value> replacements;
+  Operation *exceptedUser = nullptr;
+  if (getInlineCall()) {
+    // TODO: Support inlining multi-block functions using `scf.execute_region`
+    // (needed in case the callsite parent requires a single block region).
+    if (!targetFunction.getBody().hasOneBlock()) {
+      return emitDefiniteFailure()
+             << "Expected single block function, got "
+             << targetFunction.getBody().getBlocks().size() << " blocks.";
+    }
+
+    Region *targetRegion = rewriter.getInsertionBlock()->getParent();
+
+    // Temporarily clone the function body into the region containing the
+    // insertion point. This will never cross pass nesting scopes unless the
+    // insertion point itself does, which would be a misuse of this transform.
+    //
+    // We do this instead of cloning the function to avoid the possibility of
+    // a nested pass manager picking up the temporary function and processing
+    // it. (this likely isn't actually possible per the implementation of the
+    // pass manager, but skipping cloning the symbol is 100% safe).
+    //
+    // Note that this means the function being called is assumed to also not
+    // be undergoing modification (again no way to verify this, only specify
+    // it as misuse).
+    mlir::IRMapping mapper;
+    targetFunction.getFunctionBody().cloneInto(targetRegion, mapper);
+
+    Block *body = &targetRegion->getBlocks().back();
+    Operation *terminator = body->getTerminator();
+
+    // Inlining the block removes it from the parent region.
+    rewriter.inlineBlockBefore(body, &*rewriter.getInsertionPoint(), inputs);
+    replacements = terminator->getOperands();
+    rewriter.eraseOp(terminator);
+  } else {
+    auto callOp = rewriter.create<IREE::Util::CallOp>(
+        insertionPoint->getLoc(), targetFunction.getResultTypes(),
+        targetFunction.getName(), inputs, /*tied_operands=*/ArrayAttr{},
+        /*arg_attrs=*/nullptr, /*res_attrs=*/nullptr);
+    exceptedUser = callOp;
+    replacements = callOp->getOpResults();
+    if (getResults().size() != 0) {
+      results.set(cast<OpResult>(getResults()[0]), {callOp});
+    }
+  }
 
   // Cast the call results back to the expected types. If any conversions fail
   // this is a definite failure as the call has been constructed at this point.
-  for (auto [output, newOutput] :
-       llvm::zip_equal(outputs, callOp.getResults())) {
+  for (auto [output, newOutput] : llvm::zip_equal(outputs, replacements)) {
     Value convertedOutput = newOutput;
     if (output.getType() != newOutput.getType()) {
       convertedOutput = converter.materializeTargetConversion(
@@ -283,9 +325,12 @@ DiagnosedSilenceableFailure IREE::Util::transform_dialect::CastAndCallOp::apply(
                << " to type " << output.getType();
       }
     }
-    rewriter.replaceAllUsesExcept(output, convertedOutput, callOp);
+    if (exceptedUser) {
+      rewriter.replaceAllUsesExcept(output, convertedOutput, exceptedUser);
+    } else {
+      rewriter.replaceAllUsesWith(output, convertedOutput);
+    }
   }
-  results.set(cast<OpResult>(getResult()), {callOp});
   return DiagnosedSilenceableFailure::success();
 }
 
@@ -306,6 +351,13 @@ LogicalResult IREE::Util::transform_dialect::CastAndCallOp::verify() {
   }
   if (getFunction() && getFunctionName()) {
     return emitOpError() << "function handle and name are mutually exclusive";
+  }
+  if (getNumResults() > 1) {
+    return emitOpError()
+           << "produces at most one result as a handle to the call";
+  }
+  if (getInlineCall() && getNumResults() != 0) {
+    return emitOpError() << "inlining mode does not produce a result";
   }
   return success();
 }

--- a/compiler/src/iree/compiler/Dialect/Util/TransformOps/UtilTransformOps.td
+++ b/compiler/src/iree/compiler/Dialect/Util/TransformOps/UtilTransformOps.td
@@ -119,6 +119,10 @@ def CastAndCallOp : Op<Transform_Dialect, "util.cast_and_call", [
     The target function can be specified by a symbol name or by a handle to the
     operation.
 
+    If |inline_call| is set, the function body will be inlined at the insertion
+    point instead of called. This will lead to a definite failure if the
+    function exists but does not contain a single basic block (0 or > 1).
+
     This transform only reads the operand handles and only replaces the users of
     the outputs with the results of the call. No handles are consumed and no
     operations are removed. Users are expected to run cleanup separately if
@@ -147,19 +151,21 @@ def CastAndCallOp : Op<Transform_Dialect, "util.cast_and_call", [
   let arguments = (ins
     TransformHandleTypeInterface:$insertion_point,
     UnitAttr:$insert_after,
+    UnitAttr:$inline_call,
     Optional<TransformValueHandleTypeInterface>:$inputs,
     Optional<TransformValueHandleTypeInterface>:$outputs,
     OptionalAttr<SymbolRefAttr>:$function_name,
     Optional<TransformHandleTypeInterface>:$function
   );
   let results = (outs
-    TransformHandleTypeInterface:$result
+    Variadic<TransformHandleTypeInterface>:$result
   );
   let regions = (region
     MaxSizedRegion<1>:$conversions
   );
 
   let assemblyFormat = [{
+    (`inline_call` $inline_call^)?
     ($function_name^)? ($function^)?
     ( `(` $inputs^ `)` )?
     ( `->` $outputs^ )?

--- a/compiler/src/iree/compiler/Dialect/Util/TransformOps/test/symbol_transforms.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/TransformOps/test/symbol_transforms.mlir
@@ -21,3 +21,76 @@ module attributes {transform.with_named_sequence} {
     transform.yield
   }
 }
+
+// -----
+
+util.func public @times_two(%in: i32) -> i32 {
+  %c2 = arith.constant 2 : i32
+  %0 = arith.muli %in, %c2 : i32
+  util.return %0 : i32
+}
+
+module attributes {transform.with_named_sequence} {
+  util.func public @double_func(%arg0: i32) -> i32 {
+    %0 = arith.addi %arg0, %arg0 : i32
+    util.return %0 : i32
+  }
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+    %func = transform.util.get_sibling_symbol @double_func : !transform.any_op
+    %mul = transform.structured.match ops{["arith.muli"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %in = transform.get_operand %mul[0] : (!transform.any_op) -> !transform.any_value
+    %out = transform.get_result %mul[0] : (!transform.any_op) -> !transform.any_value
+    transform.util.cast_and_call inline_call %func(%in) -> %out after %mul {}
+      : (!transform.any_op, !transform.any_value, !transform.any_value, !transform.any_op) -> ()
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: util.func public @times_two
+//  CHECK-SAME:   %[[IN:.+]]: i32
+//       CHECK:   %[[ADD:.+]] = arith.addi %[[IN]], %[[IN]]
+//       CHECK:   util.return %[[ADD]]
+
+// Verify that the original function wasn't mangled by the call.
+//       CHECK: module attributes {transform.with_named_sequence}
+//       CHECK:   util.func public @double_func
+//  CHECK-NEXT:     arith.addi
+
+// -----
+
+util.func public @pow_two(%in: i32) -> i32 {
+  %c2 = arith.constant 2 : i32
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  // An example with scf.for that requires a single block body.
+  %pow2 = scf.for %i = %c0 to %in step %c1 iter_args(%iter = %c1) -> i32 : i32 {
+    %0 = arith.muli %iter, %c2 : i32
+    scf.yield %0 : i32
+  }
+  util.return %pow2 : i32
+}
+
+module attributes {transform.with_named_sequence} {
+  util.func public @double_func(%arg0: i32) -> i32 {
+    %0 = arith.addi %arg0, %arg0 : i32
+    util.return %0 : i32
+  }
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+    %func = transform.util.get_sibling_symbol @double_func : !transform.any_op
+    %mul = transform.structured.match ops{["arith.muli"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %in = transform.get_operand %mul[0] : (!transform.any_op) -> !transform.any_value
+    %out = transform.get_result %mul[0] : (!transform.any_op) -> !transform.any_value
+    transform.util.cast_and_call inline_call %func(%in) -> %out after %mul {}
+      : (!transform.any_op, !transform.any_value, !transform.any_value, !transform.any_op) -> ()
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: util.func public @pow_two
+//       CHECK:   scf.for {{.*}} iter_args(%[[ITER:.+]] =
+//       CHECK:     %[[ADD:.+]] = arith.addi %[[ITER]], %[[ITER]]
+//       CHECK:     scf.yield %[[ADD]]
+
+//       CHECK: module attributes {transform.with_named_sequence}
+//       CHECK:   util.func public @double_func
+//  CHECK-NEXT:     arith.addi

--- a/compiler/src/iree/compiler/Dialect/Util/TransformOps/test/symbol_transforms.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/TransformOps/test/symbol_transforms.mlir
@@ -36,7 +36,7 @@ module attributes {transform.with_named_sequence} {
     util.return %0 : i32
   }
   transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
-    %func = transform.util.get_sibling_symbol @double_func : !transform.any_op
+    %func = transform.util.lookup_nearest_symbol_from_self @double_func : !transform.any_op
     %mul = transform.structured.match ops{["arith.muli"]} in %arg1 : (!transform.any_op) -> !transform.any_op
     %in = transform.get_operand %mul[0] : (!transform.any_op) -> !transform.any_value
     %out = transform.get_result %mul[0] : (!transform.any_op) -> !transform.any_value
@@ -76,7 +76,7 @@ module attributes {transform.with_named_sequence} {
     util.return %0 : i32
   }
   transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
-    %func = transform.util.get_sibling_symbol @double_func : !transform.any_op
+    %func = transform.util.lookup_nearest_symbol_from_self @double_func : !transform.any_op
     %mul = transform.structured.match ops{["arith.muli"]} in %arg1 : (!transform.any_op) -> !transform.any_op
     %in = transform.get_operand %mul[0] : (!transform.any_op) -> !transform.any_value
     %out = transform.get_result %mul[0] : (!transform.any_op) -> !transform.any_value


### PR DESCRIPTION
This makes it possible to inline an external function call directly from the source instead of first needing to import it. This is required when the pass applying transformations is parallelized across functions, meaning we can't create a new function in the middle of the pass.