### PR TITLE
[Codegen][GPU] Allow pre-distributed multi_mma ops in distribution

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/DistributeMmaToLanes.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/DistributeMmaToLanes.cpp
@@ -82,7 +82,12 @@ void DistributeMmaToLanesPass::runOnOperation() {
 
   // Distribute multi_mma ops to lanes and greedily fuse producers.
   SmallVector<IREE::GPU::MultiMmaOp> mmaOps;
-  funcOp.walk([&](IREE::GPU::MultiMmaOp mmaOp) { mmaOps.push_back(mmaOp); });
+  funcOp.walk([&](IREE::GPU::MultiMmaOp mmaOp) {
+    if (!mmaOp.hasTensorSemantics()) {
+      return;
+    }
+    mmaOps.push_back(mmaOp);
+  });
   if (mmaOps.empty()) {
     return;
   }


### PR DESCRIPTION
This allows alternative flows that handle distribution on their own to pass through.