### PR TITLE
Do more aggressive reshape propagation in single-dispatch pipeline

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
@@ -138,7 +138,7 @@ void BubbleUpExpandShapesPass::runOnOperation() {
         }
 
         if (auto producerGenericOp = dyn_cast<linalg::GenericOp>(producer)) {
-          if (enableAggressivePropagation)
+          if (enableBubbleUpExpandShapesAcrossReductionOps)
             return true;
           // Only bubble up if producer generic op is an elementwise op.
           return llvm::all_of(producerGenericOp.getIteratorTypesArray(),

--- a/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/BubbleUpExpandShapes.cpp
@@ -138,11 +138,12 @@ void BubbleUpExpandShapesPass::runOnOperation() {
         }
 
         if (auto producerGenericOp = dyn_cast<linalg::GenericOp>(producer)) {
-          if (enableBubbleUpExpandShapesAcrossReductionOps)
-            return true;
-          // Only bubble up if producer generic op is an elementwise op.
-          return llvm::all_of(producerGenericOp.getIteratorTypesArray(),
-                              linalg::isParallelIterator);
+          // If producer generic op is elementwise op, bubble up the expand
+          // shape past this operation.
+          // If bubbling across reduction ops is enabled, allow all generic ops.
+          return (enableBubbleUpExpandShapesAcrossReductionOps ||
+                  llvm::all_of(producerGenericOp.getIteratorTypesArray(),
+                               linalg::isParallelIterator));
         }
 
         // Do not bubble up expand shapes across named ops for now.

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -26,6 +26,10 @@ include "mlir/Pass/PassBase.td"
 def BubbleUpExpandShapesPass :
     Pass<"iree-dispatch-creation-bubble-up-expand-shapes"> {
   let summary = "Propagate expand_shapes up the program (and collapse_shapes down).";
+  let options = [
+    Option<"enableAggressivePropagation", "enable-aggressive-propagation", "bool",
+           /*default=*/"false", "Enable more aggressive propagation of reshapes">
+  ];
   let dependentDialects = [
     "mlir::affine::AffineDialect",
   ];

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -27,8 +27,8 @@ def BubbleUpExpandShapesPass :
     Pass<"iree-dispatch-creation-bubble-up-expand-shapes"> {
   let summary = "Propagate expand_shapes up the program (and collapse_shapes down).";
   let options = [
-    Option<"enableAggressivePropagation", "enable-aggressive-propagation", "bool",
-           /*default=*/"false", "Enable more aggressive propagation of reshapes">
+    Option<"enableBubbleUpExpandShapesAcrossReductionOps", "enable-bubble-up-expand-shapes-across-reduction-ops", "bool",
+           /*default=*/"false", "Enables propagation of 'expand_shape's through 'linalg.generic's with reductions">
   ];
   let dependentDialects = [
     "mlir::affine::AffineDialect",

--- a/compiler/src/iree/compiler/DispatchCreation/test/bubble_up_expand_shapes.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/bubble_up_expand_shapes.mlir
@@ -1,4 +1,5 @@
-// RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-bubble-up-expand-shapes))" %s | FileCheck %s
+// RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-bubble-up-expand-shapes))" %s | FileCheck %s --check-prefixes=CHECK,CHECK-DEFAULT
+// RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-bubble-up-expand-shapes{enable-aggressive-propagation}))" %s | FileCheck %s --check-prefixes=CHECK,CHECK-AGGRESSIVE
 
 util.func public @bubbble_expand_through_extract(%arg0 : tensor<2x4096x5120xf16>) -> (tensor<2x64x64x2560xf16>) {
   %extracted_slice_237 = tensor.extract_slice %arg0[0, 0, 0] [2, 4096, 2560] [1, 1, 1] : tensor<2x4096x5120xf16> to tensor<2x4096x2560xf16>
@@ -107,3 +108,29 @@ util.func @multiple_users(%arg0 : tensor<?x128xf16>,
 //       CHECK:   %[[EXPANDED_GENERIC:.+]] = linalg.generic
 //  CHECK-SAME:       ins(%[[EXPAND_SHAPE]] :
 //       CHECK:   return %[[EXPANDED_GENERIC]]
+
+// -----
+
+// Bubbling through reductions should apply when enabled via flag.
+util.func @bubble_up_through_reduction(%arg0: tensor<10x?xi64>) -> tensor<2x5xi64> {
+  %outs = tensor.empty() : tensor<10xi64>
+  %9 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]
+  } ins(%arg0 : tensor<10x?xi64>) outs(%outs : tensor<10xi64>) {
+  ^bb0(%in: i64, %out: i64):
+    %x = arith.addi %in, %out : i64
+    linalg.yield %x : i64
+  } -> tensor<10xi64>
+  %expanded = tensor.expand_shape %9 [[0, 1]] output_shape [2, 5] : tensor<10xi64> into tensor<2x5xi64>
+  util.return %expanded : tensor<2x5xi64>
+}
+//      CHECK-LABEL: func public @bubble_up_through_reduction
+//       CHECK-SAME:     %[[ARG0:.+]]: tensor
+//    CHECK-DEFAULT:   %[[GENERIC:.+]] = linalg.generic {{.+}} ins(%[[ARG0]]
+//    CHECK-DEFAULT:   %[[EXPANDED:.+]] = tensor.expand_shape %[[GENERIC]]
+//    CHECK-DEFAULT:   return %[[EXPANDED]]
+
+// CHECK-AGGRESSIVE:   %[[EXPANDED:.+]] = tensor.expand_shape %[[ARG0]]
+// CHECK-AGGRESSIVE:   %[[EXPANDED_GENERIC:.+]] = linalg.generic {{.+}} ins(%[[EXPANDED]]
+// CHECK-AGGRESSIVE:   return %[[EXPANDED_GENERIC]]

--- a/compiler/src/iree/compiler/DispatchCreation/test/bubble_up_expand_shapes.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/bubble_up_expand_shapes.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-bubble-up-expand-shapes))" %s | FileCheck %s --check-prefixes=CHECK,CHECK-DEFAULT
-// RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-bubble-up-expand-shapes{enable-aggressive-propagation}))" %s | FileCheck %s --check-prefixes=CHECK,CHECK-AGGRESSIVE
+// RUN: iree-opt --split-input-file --mlir-print-local-scope --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-bubble-up-expand-shapes{enable-bubble-up-expand-shapes-across-reduction-ops}))" %s | FileCheck %s --check-prefixes=CHECK,CHECK-AGGRESSIVE
 
 util.func public @bubbble_expand_through_extract(%arg0 : tensor<2x4096x5120xf16>) -> (tensor<2x64x64x2560xf16>) {
   %extracted_slice_237 = tensor.extract_slice %arg0[0, 0, 0] [2, 4096, 2560] [1, 1, 1] : tensor<2x4096x5120xf16> to tensor<2x4096x2560xf16>

--- a/compiler/src/iree/compiler/Preprocessing/Passes.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Passes.cpp
@@ -149,10 +149,10 @@ buildMakeSingleDispatchPassPipeline(OpPassManager &passManager,
   passManager.addPass(GlobalOptimization::createGeneralizeLinalgNamedOpsPass());
   passManager.addPass(DispatchCreation::createFusionPreprocessingPass());
   passManager.addPass(mlir::createCSEPass());
-  // TODO : createBubbleUpExpandShapesPass currently doesnt bubble up through
-  // producer generic ops that have reudction. We need to allow this in
-  // a single dispatch use case.
-  passManager.addPass(DispatchCreation::createBubbleUpExpandShapesPass());
+  DispatchCreation::BubbleUpExpandShapesPassOptions bubbleOptions;
+  bubbleOptions.enableAggressivePropagation = true;
+  passManager.addPass(
+      DispatchCreation::createBubbleUpExpandShapesPass(bubbleOptions));
   passManager.addPass(DispatchCreation::createElementwiseOpFusionPass(
       DispatchCreation::ElementwiseOpFusionPassOptions{
           /*enableElementWiseFuseMultiReduction=*/true}));

--- a/compiler/src/iree/compiler/Preprocessing/Passes.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Passes.cpp
@@ -150,7 +150,7 @@ buildMakeSingleDispatchPassPipeline(OpPassManager &passManager,
   passManager.addPass(DispatchCreation::createFusionPreprocessingPass());
   passManager.addPass(mlir::createCSEPass());
   DispatchCreation::BubbleUpExpandShapesPassOptions bubbleOptions;
-  bubbleOptions.enableAggressivePropagation = true;
+  bubbleOptions.enableBubbleUpExpandShapesAcrossReductionOps = true;
   passManager.addPass(
       DispatchCreation::createBubbleUpExpandShapesPass(bubbleOptions));
   passManager.addPass(DispatchCreation::createElementwiseOpFusionPass(


### PR DESCRIPTION
This adds an option to `BubbleUpExpandShapesPass` which enables propagation through producer `linalg.generic`s doing reductions, and enables it in the single-dispatch pipeline.

The motivating case here is convolutions with bias, where this enables more simplifications:
<details>

<summary>input IR</summary>

```mlir
#map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
#map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
module {
  func.func @conv_2d_bfloat16_forward_1x24x16x256_192x1x1x256_1x1s_0x0p_1x1d_1g(%arg0: tensor<1x24x16x256xbf16>, %arg1: tensor<192x1x1x256xbf16>,  %arg2: tensor<1x24x16x192xbf16>) -> tensor<1x24x16x192xbf16> {
    %cst = arith.constant 0.000000e+00 : f32
    %0 = tensor.empty() : tensor<1x256x24x16xbf16>
    %transposed = linalg.transpose ins(%arg0 : tensor<1x24x16x256xbf16>) outs(%0 : tensor<1x256x24x16xbf16>) permutation = [0, 3, 1, 2] 
    %1 = tensor.empty() : tensor<192x256x1x1xbf16>
    %transposed_0 = linalg.transpose ins(%arg1 : tensor<192x1x1x256xbf16>) outs(%1 : tensor<192x256x1x1xbf16>) permutation = [0, 3, 1, 2] 
    %2 = tensor.empty() : tensor<1x192x24x16xf32>
    %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<1x192x24x16xf32>) -> tensor<1x192x24x16xf32>
    %4 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%transposed, %transposed_0 : tensor<1x256x24x16xbf16>, tensor<192x256x1x1xbf16>) outs(%3 : tensor<1x192x24x16xf32>) -> tensor<1x192x24x16xf32>
    %5 = tensor.empty() : tensor<1x192x24x16xbf16>
    %6 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%4 : tensor<1x192x24x16xf32>) outs(%5 : tensor<1x192x24x16xbf16>) {
    ^bb0(%in: f32, %out: bf16):
      %9 = arith.truncf %in : f32 to bf16
      linalg.yield %9 : bf16
    } -> tensor<1x192x24x16xbf16>
    %empty = tensor.empty() : tensor<1x192x24x16xbf16>
    %8 = tensor.empty() : tensor<1x24x16x192xbf16>
    %transposed_1 = linalg.transpose ins(%6 : tensor<1x192x24x16xbf16>) outs(%8 : tensor<1x24x16x192xbf16>) permutation = [0, 2, 3, 1]
    %7 = linalg.generic {indexing_maps = [#map, #map, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%transposed_1, %arg2 : tensor<1x24x16x192xbf16>, tensor<1x24x16x192xbf16>) outs(%8 : tensor<1x24x16x192xbf16>) {
    ^bb0(%in_1: bf16, %in_2 : bf16, %out: bf16):
      %10 = arith.addf %in_1, %in_2 : bf16
      linalg.yield %10 : bf16
    } -> tensor<1x24x16x192xbf16>
    return %7 : tensor<1x24x16x192xbf16>
  }
}
```
</details>

Compiling with `iree-compile tmp/bias.mlir -mlir-print-ir-after=iree-llvmgpu-select-lowering-strategy --iree-hal-target-device=hip --iree-hip-target=gfx942 -o /dev/null '--iree-preprocessing-pass-pipeline=builtin.module(util.func(iree-preprocessing-make-single-dispatch))'`:
<details>
<summary>before change</summary>

```mlir
// -----// IR Dump After LLVMGPUSelectLoweringStrategyPass (iree-llvmgpu-select-lowering-strategy) //----- //
module {
  func.func @conv_2d_bfloat16_forward_1x24x16x256_192x1x1x256_1x1s_0x0p_1x1d_1g_dispatch_0_matmul_like_24x16x192x256_bf16xbf16xf32() attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {}>} {
    %cst = arith.constant 0.000000e+00 : f32
    %c0 = arith.constant 0 : index
    %0 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") {iree_gpu.use_rocdl_buffer_instructions} : !flow.dispatch.tensor<readonly:tensor<1x24x16x256xbf16>>
    %1 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") {iree_gpu.use_rocdl_buffer_instructions} : !flow.dispatch.tensor<readonly:tensor<192x256xbf16>>
    %2 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(2) alignment(64) offset(%c0) flags("ReadOnly|Indirect") {iree_gpu.use_rocdl_buffer_instructions} : !flow.dispatch.tensor<readonly:tensor<1x24x16x192xbf16>>
    %3 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(3) alignment(64) offset(%c0) flags(Indirect) {iree_gpu.use_rocdl_buffer_instructions} : !flow.dispatch.tensor<writeonly:tensor<1x24x16x192xbf16>>
    %4 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [1, 24, 16, 256], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<1x24x16x256xbf16>> -> tensor<1x24x16x256xbf16>
    %5 = flow.dispatch.tensor.load %2, offsets = [0, 0, 0, 0], sizes = [1, 24, 16, 192], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<1x24x16x192xbf16>> -> tensor<1x24x16x192xbf16>
    %6 = tensor.empty() : tensor<256x1x24x16xbf16>
    %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d3, d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%4 : tensor<1x24x16x256xbf16>) outs(%6 : tensor<256x1x24x16xbf16>) {
    ^bb0(%in: bf16, %out: bf16):
      linalg.yield %in : bf16
    } -> tensor<256x1x24x16xbf16>
    %8 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [192, 256], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<192x256xbf16>> -> tensor<192x256xbf16>
    %9 = tensor.empty() : tensor<1x24x16x192xf32>
    %10 = linalg.fill ins(%cst : f32) outs(%9 : tensor<1x24x16x192xf32>) -> tensor<1x24x16x192xf32>
    %11 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d4, d0, d1, d2)>, affine_map<(d0, d1, d2, d3, d4) -> (d3, d4)>, affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]} ins(%7, %8 : tensor<256x1x24x16xbf16>, tensor<192x256xbf16>) outs(%10 : tensor<1x24x16x192xf32>) attrs =  {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>, promote_operands = [0, 1], reduction = [0, 0, 0, 0, 128], subgroup_m_count = 1 : i64, subgroup_n_count = 4 : i64, workgroup = [1, 1, 16, 64, 0]}>} {
    ^bb0(%in: bf16, %in_0: bf16, %out: f32):
      %14 = arith.extf %in : bf16 to f32
      %15 = arith.extf %in_0 : bf16 to f32
      %16 = arith.mulf %14, %15 : f32
      %17 = arith.addf %out, %16 : f32
      linalg.yield %17 : f32
    } -> tensor<1x24x16x192xf32>
    %12 = tensor.empty() : tensor<1x24x16x192xbf16>
    %13 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%11, %5 : tensor<1x24x16x192xf32>, tensor<1x24x16x192xbf16>) outs(%12 : tensor<1x24x16x192xbf16>) {
    ^bb0(%in: f32, %in_0: bf16, %out: bf16):
      %14 = arith.truncf %in : f32 to bf16
      %15 = arith.addf %14, %in_0 : bf16
      linalg.yield %15 : bf16
    } -> tensor<1x24x16x192xbf16>
    flow.dispatch.tensor.store %13, %3, offsets = [0, 0, 0, 0], sizes = [1, 24, 16, 192], strides = [1, 1, 1, 1] : tensor<1x24x16x192xbf16> -> !flow.dispatch.tensor<writeonly:tensor<1x24x16x192xbf16>>
    return
  }
}
```
</details>

<details>
<summary>after change</summary>

```mlir
// -----// IR Dump After LLVMGPUSelectLoweringStrategyPass (iree-llvmgpu-select-lowering-strategy) //----- //
module {
  func.func @conv_2d_bfloat16_forward_1x24x16x256_192x1x1x256_1x1s_0x0p_1x1d_1g_dispatch_0_matmul_like_384x192x256_bf16xbf16xf32() attributes {translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [256, 1, 1] subgroup_size = 64, {}>} {
    %cst = arith.constant 0.000000e+00 : f32
    %c0 = arith.constant 0 : index
    %0 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") {iree_gpu.use_rocdl_buffer_instructions} : !flow.dispatch.tensor<readonly:tensor<384x256xbf16>>
    %1 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") {iree_gpu.use_rocdl_buffer_instructions} : !flow.dispatch.tensor<readonly:tensor<192x256xbf16>>
    %2 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(2) alignment(64) offset(%c0) flags("ReadOnly|Indirect") {iree_gpu.use_rocdl_buffer_instructions} : !flow.dispatch.tensor<readonly:tensor<384x192xbf16>>
    %3 = hal.interface.binding.subspan layout(<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) binding(3) alignment(64) offset(%c0) flags(Indirect) {iree_gpu.use_rocdl_buffer_instructions} : !flow.dispatch.tensor<writeonly:tensor<384x192xbf16>>
    %4 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [384, 256], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<384x256xbf16>> -> tensor<384x256xbf16>
    %5 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [192, 256], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<192x256xbf16>> -> tensor<192x256xbf16>
    %6 = flow.dispatch.tensor.load %2, offsets = [0, 0], sizes = [384, 192], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<384x192xbf16>> -> tensor<384x192xbf16>
    %7 = tensor.empty() : tensor<384x192xf32>
    %8 = linalg.fill ins(%cst : f32) outs(%7 : tensor<384x192xf32>) -> tensor<384x192xf32>
    %9 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%4, %5 : tensor<384x256xbf16>, tensor<192x256xbf16>) outs(%8 : tensor<384x192xf32>) attrs =  {lowering_config = #iree_gpu.lowering_config<{mma_kind = #iree_gpu.mma_layout<MFMA_F32_16x16x16_BF16>, promote_operands = [0, 1], reduction = [0, 0, 128], subgroup_m_count = 2 : i64, subgroup_n_count = 2 : i64, workgroup = [64, 64, 0]}>} {
    ^bb0(%in: bf16, %in_0: bf16, %out: f32):
      %12 = arith.extf %in : bf16 to f32
      %13 = arith.extf %in_0 : bf16 to f32
      %14 = arith.mulf %12, %13 : f32
      %15 = arith.addf %out, %14 : f32
      linalg.yield %15 : f32
    } -> tensor<384x192xf32>
    %10 = tensor.empty() : tensor<384x192xbf16>
    %11 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%9, %6 : tensor<384x192xf32>, tensor<384x192xbf16>) outs(%10 : tensor<384x192xbf16>) {
    ^bb0(%in: f32, %in_0: bf16, %out: bf16):
      %12 = arith.truncf %in : f32 to bf16
      %13 = arith.addf %12, %in_0 : bf16
      linalg.yield %13 : bf16
    } -> tensor<384x192xbf16>
    flow.dispatch.tensor.store %11, %3, offsets = [0, 0], sizes = [384, 192], strides = [1, 1] : tensor<384x192xbf16> -> !flow.dispatch.tensor<writeonly:tensor<384x192xbf16>>
    return
  }
}
```
</details>