### PR TITLE
[GPU] Add canonicalize and cse after im2col decomposition

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -232,6 +232,8 @@ static void addGPUVectorizationPasses(OpPassManager &funcPassManager,
                                       bool vectorizeCopies = true) {
   funcPassManager.addPass(createDecomposeConvolutionToLowerDimOpsPass());
   funcPassManager.addPass(IREE::LinalgExt::createDecomposeIm2colPass());
+  funcPassManager.addPass(createCanonicalizerPass());
+  funcPassManager.addPass(createCSEPass());
   funcPassManager.addPass(
       IREE::VectorExt::createVectorizeIREEVectorExtOpsPass());
   // Vectorize.

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_im2col.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_im2col.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-linalg-ext-decompose-im2col{unroll=false}))" --split-input-file %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-linalg-ext-decompose-im2col{unroll=false}, canonicalize, cse))" --split-input-file %s | FileCheck %s
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-linalg-ext-decompose-im2col{unroll=true}))" --split-input-file %s | FileCheck %s --check-prefix=CHECK-UNROLL
 
 #map = affine_map<(d0) -> (d0 * 4)>
@@ -257,3 +257,6 @@ module {
 //  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9_]+]]
 //       CHECK: %[[T1:.+]] = tensor.extract_slice %[[ARG0]]
 //       CHECK: %[[T2:.+]] = tensor.pad %[[T1]]
+//  CHECK-NEXT: ^bb0
+//  CHECK-NEXT:   tensor.yield
+//  CHECK-NEXT: } : tensor<1x?x?x?xf32> to tensor<1x1x1x1xf32>


### PR DESCRIPTION
The reason to do this is that we have swap extract slice with pad pattern after im2col decomposition in the pass and this can lead to tensor.pad + tensor.cast which would get folded after canonicalization. However, we run vectorization passes before canonicalizing and this will cause tensor pad to not vectorize as the output dimensions will be dynamic.