### PR TITLE
Add HIP data-tiling resolver to e2e encoding.mlir tests.

### DIFF
--- a/tests/e2e/encoding/BUILD.bazel
+++ b/tests/e2e/encoding/BUILD.bazel
@@ -18,6 +18,7 @@ iree_check_single_backend_test_suite(
     srcs = ["encoding.mlir"],
     compiler_flags = [
         "--iree-global-opt-experimental-rocm-data-tiling",
+        "--iree-hip-encoding-layout-resolver=data-tiling",
     ],
     driver = "hip",
     target_backend = "rocm",

--- a/tests/e2e/encoding/CMakeLists.txt
+++ b/tests/e2e/encoding/CMakeLists.txt
@@ -21,6 +21,7 @@ iree_check_single_backend_test_suite(
     "hip"
   COMPILER_FLAGS
     "--iree-global-opt-experimental-rocm-data-tiling"
+    "--iree-hip-encoding-layout-resolver=data-tiling"
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###


### PR DESCRIPTION
Otherwise, the encodings are dropped because there are no resolvers.