### PR TITLE
setup release callback for cuda buffers

### DIFF
--- a/runtime/src/iree/hal/drivers/cuda/cuda_allocator.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_allocator.c
@@ -9,6 +9,7 @@
 #include <stddef.h>
 
 #include "iree/base/api.h"
+#include "iree/hal/drivers/cuda/cuda_allocator.h"
 #include "iree/hal/drivers/cuda/cuda_buffer.h"
 #include "iree/hal/drivers/cuda/cuda_dynamic_symbols.h"
 #include "iree/hal/drivers/cuda/cuda_status_util.h"
@@ -336,6 +337,9 @@ static void iree_hal_cuda_buffer_free(
   IREE_TRACE_ZONE_END(z0);
 }
 
+static void iree_hal_cuda_buffer_release_callback(void* user_data,
+                                                  iree_hal_buffer_t* buffer);
+
 static iree_status_t iree_hal_cuda_allocator_allocate_buffer(
     iree_hal_allocator_t* IREE_RESTRICT base_allocator,
     const iree_hal_buffer_params_t* IREE_RESTRICT params,
@@ -431,13 +435,15 @@ static iree_status_t iree_hal_cuda_allocator_allocate_buffer(
                                                  : IREE_HAL_QUEUE_AFFINITY_ANY,
         .flags = IREE_HAL_BUFFER_PLACEMENT_FLAG_NONE,
     };
+    iree_hal_buffer_release_callback_t callback = {
+        .fn = iree_hal_cuda_buffer_release_callback,
+        .user_data = (void*)base_allocator};
     status = iree_hal_cuda_buffer_wrap(
         placement, compat_params.type, compat_params.access,
         compat_params.usage, allocation_size,
         /*byte_offset=*/0,
         /*byte_length=*/allocation_size, buffer_type, device_ptr, host_ptr,
-        iree_hal_buffer_release_callback_null(),
-        iree_hal_allocator_host_allocator(base_allocator), &buffer);
+        callback, iree_hal_allocator_host_allocator(base_allocator), &buffer);
   }
 
   if (iree_status_is_ok(status)) {
@@ -504,6 +510,33 @@ static void iree_hal_cuda_allocator_deallocate_buffer(
   }
 
   iree_hal_buffer_destroy(base_buffer);
+}
+
+static void iree_hal_cuda_buffer_release_callback(void* user_data,
+                                                  iree_hal_buffer_t* buffer) {
+  iree_hal_cuda_allocator_t* allocator = (iree_hal_cuda_allocator_t*)user_data;
+
+  const iree_hal_cuda_buffer_type_t buffer_type =
+      iree_hal_cuda_buffer_type(buffer);
+
+  iree_hal_cuda_buffer_free(allocator->symbols, buffer_type,
+                            iree_hal_cuda_buffer_device_pointer(buffer),
+                            iree_hal_cuda_buffer_host_pointer(buffer));
+
+  switch (buffer_type) {
+    case IREE_HAL_CUDA_BUFFER_TYPE_DEVICE:
+    case IREE_HAL_CUDA_BUFFER_TYPE_HOST: {
+      IREE_TRACE_FREE_NAMED(IREE_HAL_CUDA_ALLOCATOR_ID,
+                            (void*)iree_hal_cuda_buffer_device_pointer(buffer));
+      IREE_STATISTICS(iree_hal_allocator_statistics_record_free(
+          &allocator->statistics, iree_hal_buffer_memory_type(buffer),
+          iree_hal_buffer_allocation_size(buffer)));
+      break;
+    }
+    default:
+      // Buffer type not tracked.
+      break;
+  }
 }
 
 static iree_status_t iree_hal_cuda_allocator_import_buffer(


### PR DESCRIPTION
This is a similar PR to #19787. The release callback for the CUDA allocator isn't set up correctly, so the CUDA memory isn't released, in fact. With the growth of module invocations, you can see an obvious growth in CUDA memory occupancy.

I'm working on Python bindings, so you can reproduce this issue with the following script easily
```python3
from iree import compiler as ireec
from iree import runtime as ireert
import numpy as np

# Compile a module.
INPUT_MLIR = """
func.func @matmul(%input : tensor<4096x4096xf32>, %weight : tensor<4096x4096xf32>) -> (tensor<4096x4096xf32>) {
    %0 = tensor.empty(): tensor<4096x4096xf32>
    %1 = linalg.matmul ins(%input, %weight: tensor<4096x4096xf32>, tensor<4096x4096xf32>) outs(%0: tensor<4096x4096xf32>) -> tensor<4096x4096xf32>
    func.return %1 : tensor<4096x4096xf32>
}
"""

compiled_flatbuffer = ireec.tools.compile_str(INPUT_MLIR, target_backends=["cuda"])

device = ireert.get_device("cuda")
config = ireert.Config(device=device)
ctx = ireert.SystemContext(config=config)
vm_module = ireert.VmModule.copy_buffer(ctx.instance, compiled_flatbuffer)
ctx.add_vm_module(vm_module)
arg0 = np.random.rand(4096, 4096).astype(np.float32)
arg1 = np.random.rand(4096, 4096).astype(np.float32)

for _ in range(1000):
    f = ctx.modules.module["matmul"]
    results = f(arg0, arg1).to_host()
```

When you open `nvtop`, you can see the growth of CUDA memory occupancy, and it'll lead to an OOM finally.

After applying this PR, the CUDA memory stays stable.