### PR TITLE
[DT] Carefully cleanup the IRs before and after the encoding fusion.

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/FuseEncodingOpsIntoDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FuseEncodingOpsIntoDispatchRegions.cpp
@@ -70,8 +70,7 @@ struct FuseEncodingOpsIntoDispatchRegionsPass
     MLIRContext *context = &getContext();
     IRRewriter rewriter(context);
 
-    // Run CSE to eliminate common encoding ops, and run the canonicalization
-    // patterns to remove redundantly returned results.
+    // Run CSE to eliminate common encoding ops.
     DominanceInfo domInfo;
     mlir::eliminateCommonSubExpressions(rewriter, domInfo, funcOp);
 
@@ -114,7 +113,8 @@ struct FuseEncodingOpsIntoDispatchRegionsPass
     }
 
     // Dynamic dims may have dominance issues after pulling encoding ops into
-    // producer dispatch regions, so we need to resolve tensor.dim ops.
+    // producer dispatch regions, so we need to resolve tensor.dim ops., Also
+    // run the canonicalization patterns to remove redundantly returned results.
     GreedyRewriteConfig config;
     config.cseConstants = false;
     RewritePatternSet patterns(context);

--- a/compiler/src/iree/compiler/DispatchCreation/test/fuse_encoding_ops_into_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/fuse_encoding_ops_into_dispatch_regions.mlir
@@ -1,26 +1,24 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-fuse-encoding-ops-into-dispatch-regions-pass),canonicalize)" --split-input-file %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-fuse-encoding-ops-into-dispatch-regions-pass))" --split-input-file %s | FileCheck %s
 
 #map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 #encoding = #iree_encoding.testing_encoding<>
-module {
-  util.func public @parallel_fusion(%arg0: tensor<2x11008x128xf32>) -> tensor<2x11008x128xf32, #encoding> {
-    %cst = arith.constant 0.000000e+00 : f32
-    %0 = tensor.empty() : tensor<2x11008x128xf32>
-    %1 = flow.dispatch.region -> (tensor<2x11008x128xf32>) {
-      %3 = linalg.generic {
-          indexing_maps = [#map, #map, #map],
-          iterator_types = ["parallel", "parallel", "parallel"]}
-          ins(%arg0, %arg0 : tensor<2x11008x128xf32>, tensor<2x11008x128xf32>)
-          outs(%0 : tensor<2x11008x128xf32>) {
-      ^bb0(%in: f32, %in_0: f32, %out: f32):
-        %4 = arith.addf %in, %in_0 : f32
-        linalg.yield %4 : f32
-      } -> tensor<2x11008x128xf32>
-      flow.return %3 : tensor<2x11008x128xf32>
-    }
-    %2 = iree_encoding.set_encoding %1 : tensor<2x11008x128xf32> -> tensor<2x11008x128xf32, #encoding>
-    util.return %2 : tensor<2x11008x128xf32, #encoding>
+util.func public @parallel_fusion(%arg0: tensor<2x11008x128xf32>) -> tensor<2x11008x128xf32, #encoding> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = tensor.empty() : tensor<2x11008x128xf32>
+  %1 = flow.dispatch.region -> (tensor<2x11008x128xf32>) {
+    %3 = linalg.generic {
+        indexing_maps = [#map, #map, #map],
+        iterator_types = ["parallel", "parallel", "parallel"]}
+        ins(%arg0, %arg0 : tensor<2x11008x128xf32>, tensor<2x11008x128xf32>)
+        outs(%0 : tensor<2x11008x128xf32>) {
+    ^bb0(%in: f32, %in_0: f32, %out: f32):
+      %4 = arith.addf %in, %in_0 : f32
+      linalg.yield %4 : f32
+    } -> tensor<2x11008x128xf32>
+    flow.return %3 : tensor<2x11008x128xf32>
   }
+  %2 = iree_encoding.set_encoding %1 : tensor<2x11008x128xf32> -> tensor<2x11008x128xf32, #encoding>
+  util.return %2 : tensor<2x11008x128xf32, #encoding>
 }
 // CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.testing_encoding<>
 // CHECK-LABEL: @parallel_fusion
@@ -36,26 +34,23 @@ module {
 #map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 #map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
 #encoding = #iree_encoding.testing_encoding<>
-module {
-  util.func public @reduction_fusion(%arg0: tensor<2x11008x128x16xf32>) -> tensor<2x11008x128xf32, #encoding> {
-    %0 = tensor.empty() : tensor<2x11008x128xf32>
-    %1 = flow.dispatch.region -> (tensor<2x11008x128xf32>) {
-      %5 = linalg.generic {
-          indexing_maps = [#map, #map1],
-          iterator_types = ["parallel", "parallel", "parallel", "reduction"]}
-          ins(%arg0 : tensor<2x11008x128x16xf32>)
-          outs(%0 : tensor<2x11008x128xf32>) {
-      ^bb0(%in: f32, %out: f32):
-        %6 = arith.addf %in, %out : f32
-        linalg.yield %6 : f32
-      } -> tensor<2x11008x128xf32>
-      flow.return %5 : tensor<2x11008x128xf32>
-    }
-    %2 = iree_encoding.set_encoding %1 : tensor<2x11008x128xf32> -> tensor<2x11008x128xf32, #encoding>
-    util.return %2 : tensor<2x11008x128xf32, #encoding>
+util.func public @reduction_fusion(%arg0: tensor<2x11008x128x16xf32>) -> tensor<2x11008x128xf32, #encoding> {
+  %0 = tensor.empty() : tensor<2x11008x128xf32>
+  %1 = flow.dispatch.region -> (tensor<2x11008x128xf32>) {
+    %5 = linalg.generic {
+        indexing_maps = [#map, #map1],
+        iterator_types = ["parallel", "parallel", "parallel", "reduction"]}
+        ins(%arg0 : tensor<2x11008x128x16xf32>)
+        outs(%0 : tensor<2x11008x128xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %6 = arith.addf %in, %out : f32
+      linalg.yield %6 : f32
+    } -> tensor<2x11008x128xf32>
+    flow.return %5 : tensor<2x11008x128xf32>
   }
+  %2 = iree_encoding.set_encoding %1 : tensor<2x11008x128xf32> -> tensor<2x11008x128xf32, #encoding>
+  util.return %2 : tensor<2x11008x128xf32, #encoding>
 }
-
 // CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.testing_encoding<>
 // CHECK-LABEL: @reduction_fusion
 // CHECK:       %[[DISPATCH:.+]] = flow.dispatch.region -> (tensor<2x11008x128xf32>)
@@ -70,25 +65,22 @@ module {
 #map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d0, d2, d1)>
 #encoding = #iree_encoding.testing_encoding<>
-module {
-  util.func public @transpose_fusion(%arg0: tensor<2x128x11008xf32>) -> tensor<2x11008x128xf32, #encoding> {
-    %0 = tensor.empty() : tensor<2x11008x128xf32>
-    %1 = flow.dispatch.region -> (tensor<2x11008x128xf32>) {
-      %5 = linalg.generic {
-          indexing_maps = [#map, #map1],
-          iterator_types = ["parallel", "parallel", "parallel"]}
-          ins(%arg0 : tensor<2x128x11008xf32>)
-          outs(%0 : tensor<2x11008x128xf32>) {
-      ^bb0(%in: f32, %out: f32):
-        linalg.yield %in : f32
-      } -> tensor<2x11008x128xf32>
-      flow.return %5 : tensor<2x11008x128xf32>
-    }
-    %2 = iree_encoding.set_encoding %1 : tensor<2x11008x128xf32> -> tensor<2x11008x128xf32, #encoding>
-    util.return %2 : tensor<2x11008x128xf32, #encoding>
+util.func public @transpose_fusion(%arg0: tensor<2x128x11008xf32>) -> tensor<2x11008x128xf32, #encoding> {
+  %0 = tensor.empty() : tensor<2x11008x128xf32>
+  %1 = flow.dispatch.region -> (tensor<2x11008x128xf32>) {
+    %5 = linalg.generic {
+        indexing_maps = [#map, #map1],
+        iterator_types = ["parallel", "parallel", "parallel"]}
+        ins(%arg0 : tensor<2x128x11008xf32>)
+        outs(%0 : tensor<2x11008x128xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<2x11008x128xf32>
+    flow.return %5 : tensor<2x11008x128xf32>
   }
+  %2 = iree_encoding.set_encoding %1 : tensor<2x11008x128xf32> -> tensor<2x11008x128xf32, #encoding>
+  util.return %2 : tensor<2x11008x128xf32, #encoding>
 }
-
 // CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.testing_encoding<>
 // CHECK-LABEL: @transpose_fusion
 // CHECK:       %[[DISPATCH:.+]] = flow.dispatch.region -> (tensor<2x11008x128xf32, #[[$ENCODING]]>
@@ -102,27 +94,24 @@ module {
 
 #map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 #encoding = #iree_encoding.testing_encoding<>
-module {
-  util.func public @fusion_dynamic(%arg0: tensor<?x?x?xf32>, %d0: index, %d1: index, %d2: index) -> tensor<?x?x?xf32, #encoding> {
-    %cst = arith.constant 0.000000e+00 : f32
-    %0 = tensor.empty(%d0, %d1, %d2) : tensor<?x?x?xf32>
-    %1 = flow.dispatch.region -> (tensor<?x?x?xf32>{%d0, %d1, %d2}) {
-      %3 = linalg.generic {
-          indexing_maps = [#map, #map, #map],
-          iterator_types = ["parallel", "parallel", "parallel"]}
-          ins(%arg0, %arg0 : tensor<?x?x?xf32>, tensor<?x?x?xf32>)
-          outs(%0 : tensor<?x?x?xf32>) {
-      ^bb0(%in: f32, %in_0: f32, %out: f32):
-        %4 = arith.addf %in, %in_0 : f32
-        linalg.yield %4 : f32
-      } -> tensor<?x?x?xf32>
-      flow.return %3 : tensor<?x?x?xf32>
-    }
-    %2 = iree_encoding.set_encoding %1 : tensor<?x?x?xf32> -> tensor<?x?x?xf32, #encoding>
-    util.return %2 : tensor<?x?x?xf32, #encoding>
+util.func public @fusion_dynamic(%arg0: tensor<?x?x?xf32>, %d0: index, %d1: index, %d2: index) -> tensor<?x?x?xf32, #encoding> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = tensor.empty(%d0, %d1, %d2) : tensor<?x?x?xf32>
+  %1 = flow.dispatch.region -> (tensor<?x?x?xf32>{%d0, %d1, %d2}) {
+    %3 = linalg.generic {
+        indexing_maps = [#map, #map, #map],
+        iterator_types = ["parallel", "parallel", "parallel"]}
+        ins(%arg0, %arg0 : tensor<?x?x?xf32>, tensor<?x?x?xf32>)
+        outs(%0 : tensor<?x?x?xf32>) {
+    ^bb0(%in: f32, %in_0: f32, %out: f32):
+      %4 = arith.addf %in, %in_0 : f32
+      linalg.yield %4 : f32
+    } -> tensor<?x?x?xf32>
+    flow.return %3 : tensor<?x?x?xf32>
   }
+  %2 = iree_encoding.set_encoding %1 : tensor<?x?x?xf32> -> tensor<?x?x?xf32, #encoding>
+  util.return %2 : tensor<?x?x?xf32, #encoding>
 }
-
 // CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.testing_encoding<>
 // CHECK-LABEL: @fusion_dynamic
 // CHECK-SAME:    {{.+}}: tensor<?x?x?xf32>, %[[D0:.+]]: index, %[[D1:.+]]: index, %[[D2:.+]]: index)
@@ -133,3 +122,62 @@ module {
 // CHECK:         flow.return %[[SET_ENCODING]] :
 // CHECK:       }
 // CHECK:       util.return %[[DISPATCH0]] : tensor<?x?x?xf32, #[[$ENCODING]]>
+
+// -----
+
+#map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#encoding = #iree_encoding.testing_encoding<>
+util.func public @multi_encoding_fusion_dynamic(%arg0: tensor<?x?x?xf32>, %d0: index, %d1: index, %d2: index) -> (tensor<?x?x?xf32, #encoding>, tensor<?x?x?xf32, #encoding>) {
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = tensor.empty(%d0, %d1, %d2) : tensor<?x?x?xf32>
+  %1 = flow.dispatch.region -> (tensor<?x?x?xf32>{%d0, %d1, %d2}) {
+    %3 = linalg.generic {
+        indexing_maps = [#map, #map, #map],
+        iterator_types = ["parallel", "parallel", "parallel"]}
+        ins(%arg0, %arg0 : tensor<?x?x?xf32>, tensor<?x?x?xf32>)
+        outs(%0 : tensor<?x?x?xf32>) {
+    ^bb0(%in: f32, %in_0: f32, %out: f32):
+      %4 = arith.addf %in, %in_0 : f32
+      linalg.yield %4 : f32
+    } -> tensor<?x?x?xf32>
+    flow.return %3 : tensor<?x?x?xf32>
+  }
+  %2 = iree_encoding.set_encoding %1 : tensor<?x?x?xf32> -> tensor<?x?x?xf32, #encoding>
+  %3 = iree_encoding.set_encoding %1 : tensor<?x?x?xf32> -> tensor<?x?x?xf32, #encoding>
+  util.return %2, %3 : tensor<?x?x?xf32, #encoding>, tensor<?x?x?xf32, #encoding>
+}
+// CHECK-DAG:   #[[$ENCODING:.+]] = #iree_encoding.testing_encoding<>
+// CHECK-LABEL: @multi_encoding_fusion_dynamic
+// CHECK-SAME:    {{.+}}: tensor<?x?x?xf32>, %[[D0:.+]]: index, %[[D1:.+]]: index, %[[D2:.+]]: index)
+// CHECK:       %[[DISPATCH:.+]] = flow.dispatch.region -> (tensor<?x?x?xf32, #[[$ENCODING]]>
+// CHECK-SAME:      {%[[D0]], %[[D1]], %[[D2]]}
+// CHECK:         %[[ADD:.+]] = linalg.generic
+// CHECK:         %[[SET_ENCODING:.+]] = iree_encoding.set_encoding
+// CHECK:         flow.return %[[SET_ENCODING]] :
+// CHECK:       }
+// CHECK:       util.return %[[DISPATCH]], %[[DISPATCH]]
+
+// -----
+
+#encoding0 = #iree_encoding.testing_encoding<>
+#encoding1 = #iree_encoding.testing_encoding<[#iree_encoding.pad_encoding_layout<[0, 0]>]>
+util.func public @encoding_fusion(%arg0: tensor<?x?xf32, #encoding0>, %d0: index, %d1: index) -> tensor<?x?xf32, #encoding1> {
+  %0 = flow.dispatch.region -> (tensor<?x?xf32>{%d0, %d1}) {
+    %1 = iree_encoding.unset_encoding %arg0 : tensor<?x?xf32, #encoding0> -> tensor<?x?xf32>{%d0, %d1}
+    flow.return %1 : tensor<?x?xf32>
+  }
+  %2 = iree_encoding.set_encoding %0 : tensor<?x?xf32> -> tensor<?x?xf32, #encoding1>
+  util.return %2 : tensor<?x?xf32, #encoding1>
+}
+
+// CHECK-DAG:   #[[$ENCODING0:.+]] = #iree_encoding.testing_encoding<>
+// CHECK-DAG:   #[[$ENCODING1:.+]] = #iree_encoding.testing_encoding<[#iree_encoding.pad_encoding_layout<[0, 0]>]>
+// CHECK-LABEL: @encoding_fusion
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK-SAME:     %[[D0:[a-zA-Z0-9]+]]
+// CHECK-SAME:     %[[D1:[a-zA-Z0-9]+]]
+// CHECK:          %[[DISPATCH:.+]] =  flow.dispatch.region -> (tensor<?x?xf32, #[[$ENCODING1]]>{%[[D0]], %[[D1]]}
+// CHECK-NEXT:       %[[UNSET_ENCODING:.+]] = iree_encoding.unset_encoding %[[ARG0]]
+// CHECK-NEXT:       %[[SET_ENCODING:.+]] = iree_encoding.set_encoding %[[UNSET_ENCODING]] : tensor<?x?xf32> -> tensor<?x?xf32, #[[$ENCODING1]]>
+// CHECK-NEXT:       flow.return %[[SET_ENCODING]]
+// CHECK:          util.return %[[DISPATCH]]

--- a/compiler/src/iree/compiler/DispatchCreation/test/fuse_encoding_ops_into_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/fuse_encoding_ops_into_dispatch_regions.mlir
@@ -156,28 +156,3 @@ util.func public @multi_encoding_fusion_dynamic(%arg0: tensor<?x?x?xf32>, %d0: i
 // CHECK:         flow.return %[[SET_ENCODING]] :
 // CHECK:       }
 // CHECK:       util.return %[[DISPATCH]], %[[DISPATCH]]
-
-// -----
-
-#encoding0 = #iree_encoding.testing_encoding<>
-#encoding1 = #iree_encoding.testing_encoding<[#iree_encoding.pad_encoding_layout<[0, 0]>]>
-util.func public @encoding_fusion(%arg0: tensor<?x?xf32, #encoding0>, %d0: index, %d1: index) -> tensor<?x?xf32, #encoding1> {
-  %0 = flow.dispatch.region -> (tensor<?x?xf32>{%d0, %d1}) {
-    %1 = iree_encoding.unset_encoding %arg0 : tensor<?x?xf32, #encoding0> -> tensor<?x?xf32>{%d0, %d1}
-    flow.return %1 : tensor<?x?xf32>
-  }
-  %2 = iree_encoding.set_encoding %0 : tensor<?x?xf32> -> tensor<?x?xf32, #encoding1>
-  util.return %2 : tensor<?x?xf32, #encoding1>
-}
-
-// CHECK-DAG:   #[[$ENCODING0:.+]] = #iree_encoding.testing_encoding<>
-// CHECK-DAG:   #[[$ENCODING1:.+]] = #iree_encoding.testing_encoding<[#iree_encoding.pad_encoding_layout<[0, 0]>]>
-// CHECK-LABEL: @encoding_fusion
-// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]
-// CHECK-SAME:     %[[D0:[a-zA-Z0-9]+]]
-// CHECK-SAME:     %[[D1:[a-zA-Z0-9]+]]
-// CHECK:          %[[DISPATCH:.+]] =  flow.dispatch.region -> (tensor<?x?xf32, #[[$ENCODING1]]>{%[[D0]], %[[D1]]}
-// CHECK-NEXT:       %[[UNSET_ENCODING:.+]] = iree_encoding.unset_encoding %[[ARG0]]
-// CHECK-NEXT:       %[[SET_ENCODING:.+]] = iree_encoding.set_encoding %[[UNSET_ENCODING]] : tensor<?x?xf32> -> tensor<?x?xf32, #[[$ENCODING1]]>
-// CHECK-NEXT:       flow.return %[[SET_ENCODING]]
-// CHECK:          util.return %[[DISPATCH]]


### PR DESCRIPTION
The revision runs CSE at the start of the pass, which eliminates common encodings, and adds the canonicalization patterns of Flow::DispatchRegionOp to the end of cleanup patterns. The outcome is to remove the redundantly returned results. We do not run full canonicalization because it could hoist out the small constants.

The revision deletes `canonicalize` from the lit tests to ensure that the output IR is expected without running full canonicalization. It also removes redundant `module{}` from lit tests.