### PR TITLE
[LinalgExt] Add `iree_linalg_ext.gather` op

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
@@ -653,6 +653,8 @@ void registerBufferizationInterfaces(DialectRegistry &registry) {
         LinalgExtOpInterface<IREE::LinalgExt::ScanOp>>(*ctx);
     IREE::LinalgExt::ScatterOp::attachInterface<
         LinalgExtOpInterface<IREE::LinalgExt::ScatterOp>>(*ctx);
+    IREE::LinalgExt::GatherOp::attachInterface<
+        LinalgExtOpInterface<IREE::LinalgExt::GatherOp>>(*ctx);
     IREE::LinalgExt::SortOp::attachInterface<
         LinalgExtOpInterface<IREE::LinalgExt::SortOp>>(*ctx);
     IREE::LinalgExt::TopkOp::attachInterface<

--- a/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.cpp
@@ -245,6 +245,8 @@ void registerPartitionableLoopsInterfaceModels(DialectRegistry &registry) {
         AllParallelAsPartitionableLoops<IREE::LinalgExt::ScanOp>>(*ctx);
     IREE::LinalgExt::ScatterOp::attachInterface<
         OuterParallelAsPartitionableLoops<IREE::LinalgExt::ScatterOp>>(*ctx);
+    IREE::LinalgExt::GatherOp::attachInterface<
+        AllParallelAsPartitionableLoops<IREE::LinalgExt::GatherOp>>(*ctx);
     IREE::LinalgExt::SortOp::attachInterface<
         AllParallelAsPartitionableLoops<IREE::LinalgExt::SortOp>>(*ctx);
     IREE::LinalgExt::TopkOp::attachInterface<

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -133,29 +133,28 @@ static bool isSmallerThan(ArrayRef<int64_t> sourceShape,
                       });
 }
 
-//===----------------------------------------------------------------------===//
-// ScatterOp
-//===----------------------------------------------------------------------===//
-
-LogicalResult ScatterOp::verify() {
-  Operation *op = getOperation();
-  if (getInputs().size() != 2) {
-    return op->emitOpError("expected two input operands");
+template <typename OpTy>
+static LogicalResult
+verifyGatherScatter(OpTy op, int64_t sliceRank, ShapedType originalType,
+                    ShapedType updateType, StringRef originalName,
+                    StringRef updateName) {
+  if (op.getInputs().size() != 2) {
+    return op.emitOpError("expected two input operands");
   }
-  if (getOutputs().size() != 1) {
-    return op->emitOpError("expected one output operand");
+  if (op.getOutputs().size() != 1) {
+    return op.emitOpError("expected one output operand");
   }
 
-  auto indicesType = getIndicesType();
+  auto indicesType = op.getIndicesType();
   if (indicesType.getRank() < 1 ||
       !isa<IntegerType>(indicesType.getElementType())) {
     return op->emitOpError("expected indices to be of rank 1 or greater and of "
                            "integer element type");
   }
 
-  ArrayRef<int64_t> dimMap = getDimensionMap();
+  ArrayRef<int64_t> dimMap = op.getDimensionMap();
   if (failed(isPermSequence(
-          [&]() { return this->emitOpError("dimension map is invalid."); },
+          [&]() { return op->emitOpError("dimension map is invalid."); },
           dimMap))) {
     return failure();
   }
@@ -164,23 +163,24 @@ LogicalResult ScatterOp::verify() {
     return op->emitOpError("dimension map must have at least one element");
   }
 
-  const size_t indexDepth = getIndexDepth();
-  auto originalType = getOriginalType();
-  auto updateType = getUpdateType();
+  const size_t indexDepth = op.getIndexDepth();
   const auto originalSliceRank = originalType.getRank() - indexDepth;
   if (originalSliceRank < 0) {
-    return op->emitOpError(
-        "expected original rank to be greater or equal to index depth");
+    return op->emitOpError("expected " + originalName +
+                           " rank to be greater or equal to index depth");
   }
   if (updateType.getRank() < originalSliceRank) {
-    return op->emitOpError(
-        "expected update to be at least the rank of non indexed original dims");
+    return op->emitOpError("expected " + updateName +
+                           " to be at least the rank of non indexed " +
+                           originalName + " dims");
   }
   const size_t batchRank = updateType.getRank() - originalSliceRank;
 
   if (updateType.getRank() - batchRank != originalSliceRank) {
-    return op->emitOpError("expected rank of update value - batch rank to be "
-                           "equal to rank of original value - index depth");
+    return op->emitOpError("expected rank of " + updateName +
+                           " value - batch rank to be "
+                           "equal to rank of " +
+                           originalName + " value - index depth");
   }
 
   if ((indicesType.getRank() != batchRank || indexDepth != 1) &&
@@ -196,8 +196,8 @@ LogicalResult ScatterOp::verify() {
         llvm::mismatch(indicesType.getShape().take_front(batchRank),
                        updateType.getShape().take_front(batchRank));
     if (indicesIt != indicesType.getShape().take_front(batchRank).end()) {
-      return op->emitOpError(
-                 "mismatch in shape of indices and update value at dim#")
+      return op->emitOpError("mismatch in shape of indices and " + updateName +
+                             " value at dim#")
              << (indicesIt - indicesType.getShape().begin());
     }
   }
@@ -208,7 +208,7 @@ LogicalResult ScatterOp::verify() {
   }
 
   {
-    for (auto idx : llvm::seq<int64_t>(0, getUpdateSliceRank())) {
+    for (auto idx : llvm::seq<int64_t>(0, sliceRank)) {
       int64_t updateDim = idx + batchRank;
       int64_t origDim = idx + indexDepth;
       if (originalType.isDynamicDim(origDim) ||
@@ -217,14 +217,14 @@ LogicalResult ScatterOp::verify() {
       }
       if (originalType.getDimSize(origDim) !=
           updateType.getDimSize(updateDim)) {
-        return op->emitOpError("shape of update value dim#")
-               << (updateDim) << " must match original value at dim#"
-               << (origDim);
+        return op->emitOpError("shape of " + updateName + " value dim#")
+               << (updateDim)
+               << " must match " + originalName + " value at dim#" << (origDim);
       }
     }
   }
 
-  Region &region = this->getRegion();
+  Region &region = op.getRegion();
   Block *body = &region.front();
   if (body->getNumArguments() != 2) {
     return op->emitOpError("expected region to have two arguments");
@@ -238,12 +238,12 @@ LogicalResult ScatterOp::verify() {
   }
   if (arg0Type != updateType.getElementType()) {
     return op->emitOpError("mismatch in argument 0 of region ")
-           << arg0Type << " and element type of update value "
+           << arg0Type << " and element type of " + updateName + " value "
            << updateType.getElementType();
   }
   if (arg1Type != originalType.getElementType()) {
     return op->emitOpError("mismatch in argument 1 of region ")
-           << arg1Type << " and element type of original value "
+           << arg1Type << " and element type of " + originalName + " value "
            << originalType.getElementType();
   }
   if (arg0Type != arg1Type) {
@@ -260,6 +260,15 @@ LogicalResult ScatterOp::verify() {
            << yieldedType << " and argument of the region " << arg0Type;
   }
   return success();
+}
+
+//===----------------------------------------------------------------------===//
+// ScatterOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult ScatterOp::verify() {
+  return verifyGatherScatter(*this, getUpdateSliceRank(), getOriginalType(),
+                             getUpdateType(), "original", "update");
 }
 
 LogicalResult
@@ -283,6 +292,37 @@ SmallVector<AffineMap> ScatterOp::getIndexingMapsForOperands() {
 
 SmallVector<AffineMap> ScatterOp::getIndexingMapsForResults() {
   return {AffineMap(nullptr)};
+}
+
+//===----------------------------------------------------------------------===//
+// Gather Op
+//===----------------------------------------------------------------------===//
+
+LogicalResult GatherOp::verify() {
+  return verifyGatherScatter(*this, getResultSliceRank(), getSourceType(),
+                             getResultType(), "source", "result");
+}
+
+LogicalResult
+GatherOp::reifyResultShapes(OpBuilder &b,
+                            ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
+  return cast<LinalgExtOp>(getOperation())
+      .reifyResultShapes(b, reifiedReturnShapes);
+}
+
+FailureOr<SmallVector<int64_t>> GatherOp::getStaticLoopRanges() {
+  return SmallVector<int64_t>(getResultType().getRank());
+}
+
+SmallVector<AffineMap> GatherOp::getIndexingMapsForOperands() {
+  Builder builder(getContext());
+  return {AffineMap(nullptr), AffineMap(nullptr),
+          builder.getMultiDimIdentityMap(getResultType().getRank())};
+}
+
+SmallVector<AffineMap> GatherOp::getIndexingMapsForResults() {
+  Builder builder(getContext());
+  return {builder.getMultiDimIdentityMap(getResultType().getRank())};
 }
 
 //===----------------------------------------------------------------------===//
@@ -1950,6 +1990,7 @@ LogicalResult IREE::LinalgExt::IndexOp::verify() {
   }
 
 DEFINE_OP_GET_EFFECTS(ScatterOp)
+DEFINE_OP_GET_EFFECTS(GatherOp)
 DEFINE_OP_GET_EFFECTS(SortOp)
 DEFINE_OP_GET_EFFECTS(FftOp)
 DEFINE_OP_GET_EFFECTS(ScanOp)

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -299,8 +299,8 @@ SmallVector<AffineMap> ScatterOp::getIndexingMapsForResults() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult GatherOp::verify() {
-  return verifyGatherScatter(*this, getResultSliceRank(), getSourceType(),
-                             getResultType(), "source", "result");
+  return verifyGatherScatter(*this, getOutputSliceRank(), getSourceType(),
+                             getOutputType(), "source", "output");
 }
 
 LogicalResult
@@ -311,18 +311,18 @@ GatherOp::reifyResultShapes(OpBuilder &b,
 }
 
 FailureOr<SmallVector<int64_t>> GatherOp::getStaticLoopRanges() {
-  return SmallVector<int64_t>(getResultType().getRank());
+  return SmallVector<int64_t>(getOutputType().getRank());
 }
 
 SmallVector<AffineMap> GatherOp::getIndexingMapsForOperands() {
   Builder builder(getContext());
   return {AffineMap(nullptr), AffineMap(nullptr),
-          builder.getMultiDimIdentityMap(getResultType().getRank())};
+          builder.getMultiDimIdentityMap(getOutputType().getRank())};
 }
 
 SmallVector<AffineMap> GatherOp::getIndexingMapsForResults() {
   Builder builder(getContext());
-  return {builder.getMultiDimIdentityMap(getResultType().getRank())};
+  return {builder.getMultiDimIdentityMap(getOutputType().getRank())};
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -133,6 +133,11 @@ static bool isSmallerThan(ArrayRef<int64_t> sourceShape,
                       });
 }
 
+/// Helper function to verify both `scatter` and `gather`. Since both ops share
+/// the same sementics, we can use the same function to verify them. Note: this
+/// is written from the perspective of `scatter` op. For gather, `updateType`
+/// maps to the type of the output and `originalType` maps to the type of the
+/// `source`.
 template <typename OpTy>
 static LogicalResult
 verifyGatherScatter(OpTy op, int64_t sliceRank, ShapedType originalType,

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -289,12 +289,12 @@ def IREELinalgExt_GatherOp : IREELinalgExt_Op<"gather",
       return getDimensionMap().size();
     }
 
-    int64_t getResultSliceRank() {
+    int64_t getOutputSliceRank() {
       return getSourceType().getRank() - getIndexDepth();
     }
 
     int64_t getBatchRank() {
-      return getResultType().getRank() - getResultSliceRank();
+      return getOutputType().getRank() - getOutputSliceRank();
     }
 
     Value getSource(){
@@ -313,12 +313,12 @@ def IREELinalgExt_GatherOp : IREELinalgExt_Op<"gather",
       return cast<ShapedType>(getIndices().getType());
     }
 
-    Value getResult(){
+    Value getOutput(){
       return getDpsInitOperand(0)->get();
     }
 
-    ShapedType getResultType(){
-      return cast<ShapedType>(getResult().getType());
+    ShapedType getOutputType(){
+      return cast<ShapedType>(getOutput().getType());
     }
 
     MutableOperandRange getDpsInitsMutable() {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -282,6 +282,10 @@ def IREELinalgExt_GatherOp : IREELinalgExt_Op<"gather",
   }];
 
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
+    static constexpr unsigned kSourceOpNum = 0;
+    static constexpr unsigned kIndicesOpNum = 1;
+    static constexpr unsigned kResultOpNum = 2;
+
     int64_t getIndexDepth() {
       return getDimensionMap().size();
     }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -265,7 +265,26 @@ def IREELinalgExt_GatherOp : IREELinalgExt_Op<"gather",
          "getTiledImplementation",
          "generateResultTileValue"]>]> {
   let summary = "Gather operator";
-  let description = [{ TODO }];
+  let description = [{
+    Takes two inputs (`source` and `indices`) and outputs value (`output`).
+    The operation returns the value at the slices specified by `indices` by
+    combining the gathered value from `source` with the value in `output`
+    using the computation specified in `region`. The `region` specifies a binary
+    operation of signature `(T, T) -> T`, where `T` is the element-type of
+    `source` & `output`. The first argument is from `source` and the second is
+    from `output`.
+
+    The size of the `dimension_map` attribute is used to determine how many
+    indices are used to index into `source`, i.e. `index_depth`. The
+    `dimension_map` attribute describes which index value maps to which dimension
+    in the destination.
+
+    This operation preforms the opposite operation of `iree_linalg_ext.scatter`.
+    Instead of scattering `updates` into `original`, it gathers the values from
+    `source` into `output` using the indices in `indices`. See the documentation
+    on `iree_linalg_ext.scatter` for more details regarding the indexing/shape
+    semantics.
+  }];
   let arguments = (ins
       Variadic<AnyRankedTensorOrMemRefType>:$inputs,
       Variadic<AnyRankedTensorOrMemRefType>:$outputs,
@@ -285,20 +304,24 @@ def IREELinalgExt_GatherOp : IREELinalgExt_Op<"gather",
     static constexpr unsigned kIndicesOpNum = 1;
     static constexpr unsigned kResultOpNum = 2;
 
+    /// Utility to get the number of indices used to index into `source`.
     int64_t getIndexDepth() {
       return getDimensionMap().size();
     }
 
+    /// Utility to get rank of the portion of `output` that is contiguous.
     int64_t getOutputSliceRank() {
       return getSourceType().getRank() - getIndexDepth();
     }
 
+    /// Utility to get the rank of the portion of `indices` that represents the
+    /// batch dimensions.
     int64_t getBatchRank() {
       return getOutputType().getRank() - getOutputSliceRank();
     }
 
     Value getSource(){
-      return getDpsInputOperand(0)->get();
+      return getOperand(kSourceOpNum);
     }
 
     ShapedType getSourceType(){
@@ -306,7 +329,7 @@ def IREELinalgExt_GatherOp : IREELinalgExt_Op<"gather",
     }
 
     Value getIndices(){
-      return getDpsInputOperand(1)->get();
+      return getOperand(kIndicesOpNum);
     }
 
     ShapedType getIndicesType(){
@@ -314,13 +337,14 @@ def IREELinalgExt_GatherOp : IREELinalgExt_Op<"gather",
     }
 
     Value getOutput(){
-      return getDpsInitOperand(0)->get();
+      return getOperand(kResultOpNum);
     }
 
     ShapedType getOutputType(){
       return cast<ShapedType>(getOutput().getType());
     }
 
+    /// For DPS interface.
     MutableOperandRange getDpsInitsMutable() {
       return getOutputsMutable();
     }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -252,6 +252,78 @@ def IREELinalgExt_ScatterOp : IREELinalgExt_Op<"scatter",
   }];
 }
 
+def IREELinalgExt_GatherOp : IREELinalgExt_Op<"gather",
+    [DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
+     DeclareOpInterfaceMethods<LinalgFusionInterface,
+      ["getIndexingMapsForResults", "getIndexingMapsForOperands",
+       "getStaticLoopRanges"]>,
+     DeclareOpInterfaceMethods<TilingInterface,
+        ["generateScalarImplementation",
+         "getIterationDomain",
+         "getLoopIteratorTypes",
+         "getResultTilePosition",
+         "getTiledImplementation",
+         "getIterationDomainTileFromOperandTile",
+         "getTiledImplementationFromOperandTile"]>]> {
+  let summary = "Gather operator";
+  let description = [{ TODO }];
+  let arguments = (ins
+      Variadic<AnyRankedTensorOrMemRefType>:$inputs,
+      Variadic<AnyRankedTensorOrMemRefType>:$outputs,
+      DenseI64ArrayAttr:$dimension_map
+  );
+  let results = (outs Variadic<AnyRankedTensor>:$results);
+  let regions = (region AnyRegion:$region);
+  let assemblyFormat = [{
+    attr-dict `dimension_map` `=` $dimension_map
+    (`ins` `(` $inputs^ `:` type($inputs) `)`)?
+    `outs` `(` $outputs `:` type($outputs) `)`
+    $region (`->` type($results)^)?
+  }];
+
+  let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
+    int64_t getIndexDepth() {
+      return getDimensionMap().size();
+    }
+
+    int64_t getResultSliceRank() {
+      return getSourceType().getRank() - getIndexDepth();
+    }
+
+    int64_t getBatchRank() {
+      return getResultType().getRank() - getResultSliceRank();
+    }
+
+    Value getSource(){
+      return getDpsInputOperand(0)->get();
+    }
+
+    ShapedType getSourceType(){
+      return cast<ShapedType>(getSource().getType());
+    }
+
+    Value getIndices(){
+      return getDpsInputOperand(1)->get();
+    }
+
+    ShapedType getIndicesType(){
+      return cast<ShapedType>(getIndices().getType());
+    }
+
+    Value getResult(){
+      return getDpsInitOperand(0)->get();
+    }
+
+    ShapedType getResultType(){
+      return cast<ShapedType>(getResult().getType());
+    }
+
+    MutableOperandRange getDpsInitsMutable() {
+      return getOutputsMutable();
+    }
+  }];
+}
+
 def IREELinalgExt_SortOp : IREELinalgExt_Op<"sort",
     [DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
      DeclareOpInterfaceMethods<TilingInterface,

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -263,8 +263,7 @@ def IREELinalgExt_GatherOp : IREELinalgExt_Op<"gather",
          "getLoopIteratorTypes",
          "getResultTilePosition",
          "getTiledImplementation",
-         "getIterationDomainTileFromOperandTile",
-         "getTiledImplementationFromOperandTile"]>]> {
+         "generateResultTileValue"]>]> {
   let summary = "Gather operator";
   let description = [{ TODO }];
   let arguments = (ins

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -382,28 +382,11 @@ LogicalResult GatherOp::getResultTilePosition(
   return success();
 }
 
-LogicalResult GatherOp::getIterationDomainTileFromOperandTile(
-    OpBuilder &b, unsigned operandNumber, ArrayRef<OpFoldResult> offsets,
-    ArrayRef<OpFoldResult> sizes,
-    SmallVectorImpl<OpFoldResult> &iterDomainOffsets,
-    SmallVectorImpl<OpFoldResult> &iterDomainSizes) {
-  if (getInputs().getBeginOperandIndex() != operandNumber) {
-    return failure();
-  }
-
-  // TODO: implement
-  return failure();
-}
-
-FailureOr<TilingResult> GatherOp::getTiledImplementationFromOperandTile(
-    OpBuilder &b, unsigned operandNumber, ArrayRef<OpFoldResult> offsets,
-    ArrayRef<OpFoldResult> sizes) {
-  SmallVector<OpFoldResult> mappedOffsets, mappedSizes;
-  if (failed(getIterationDomainTileFromOperandTile(
-          b, operandNumber, offsets, sizes, mappedOffsets, mappedSizes))) {
-    return failure();
-  }
-  return getTiledImplementation(b, mappedOffsets, mappedSizes);
+FailureOr<TilingResult>
+GatherOp::generateResultTileValue(OpBuilder &builder, unsigned resultNumber,
+                                  ArrayRef<OpFoldResult> offsets,
+                                  ArrayRef<OpFoldResult> sizes) {
+  return getTiledImplementation(builder, offsets, sizes);
 }
 
 LogicalResult GatherOp::generateScalarImplementation(OpBuilder &b, Location loc,

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -336,15 +336,11 @@ GatherOp::getTiledImplementation(OpBuilder &builder,
   Value tiledIndices = indicesSlice->getResult(0);
 
   // Slice of the source.
-  SmallVector<OpFoldResult> sourceOffsets, sourceSizes;
-  // if (failed(getResultTilePosition(builder, 0, offsets, sizes,
-  // originalOffsets,
-  //                                  originalSizes))) {
-  //   return {};
-  // }
   auto sourceRank = getSourceType().getRank();
   auto indexDepth = getIndexDepth();
+
   // The first `indexDepth` dims are not tiled
+  SmallVector<OpFoldResult> sourceOffsets, sourceSizes;
   for (auto dim : llvm::seq<int64_t>(0, indexDepth)) {
     sourceOffsets.push_back(zeroAttr);
     sourceSizes.push_back(getDim(builder, loc, getSource(), dim));
@@ -384,23 +380,6 @@ LogicalResult GatherOp::getResultTilePosition(
   resultOffsets.assign(offsets.begin(), offsets.end());
   resultSizes.assign(sizes.begin(), sizes.end());
   return success();
-  // auto zeroAttr = builder.getI64IntegerAttr(0);
-  // // Slice of the source.
-  // auto resultRank = getResultType().getRank();
-  // resultOffsets.resize(resultRank, zeroAttr);
-  // resultSizes.resize(resultRank);
-  //
-  // auto sourceRank = getSourceType().getRank();
-  // Location loc = getLoc();
-  // for (auto dim : llvm::seq<int64_t>(0, sourceRank - getResultSliceRank())) {
-  //   resultSizes[dim] = getDim(builder, loc, getResult(), dim);
-  // }
-  // for (auto dim :
-  //      llvm::seq<int64_t>(sourceRank - getResultSliceRank(), sourceRank)) {
-  //   resultOffsets[dim] = offsets[dim - (sourceRank - resultRank)];
-  //   resultSizes[dim] = sizes[dim - (sourceRank - resultRank)];
-  // }
-  // return success();
 }
 
 LogicalResult GatherOp::getIterationDomainTileFromOperandTile(
@@ -408,20 +387,12 @@ LogicalResult GatherOp::getIterationDomainTileFromOperandTile(
     ArrayRef<OpFoldResult> sizes,
     SmallVectorImpl<OpFoldResult> &iterDomainOffsets,
     SmallVectorImpl<OpFoldResult> &iterDomainSizes) {
-  // TODO: Support fusion along the index operand. For the index operand, the
-  // offset + size must be the full size for the inner most dim.
   if (getInputs().getBeginOperandIndex() != operandNumber) {
     return failure();
   }
 
   // TODO: implement
   return failure();
-
-  // The iteration domain is defined in terms of the |input|, so simply
-  // use the given offsets/sizes.
-  iterDomainOffsets.assign(offsets.begin(), offsets.end());
-  iterDomainSizes.assign(sizes.begin(), sizes.end());
-  return success();
 }
 
 FailureOr<TilingResult> GatherOp::getTiledImplementationFromOperandTile(

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -421,14 +421,14 @@ func.func @scatter_index_depth_too_small(
 
 // -----
 
-func.func @gather_result_too_large(
+func.func @gather_output_too_large(
     %source : tensor<10xf32>, %idx : tensor<1xi32>,
-    %result : tensor<2xf32>) -> tensor<2xf32> {
-  // expected-error @below {{'iree_linalg_ext.gather' op mismatch in shape of indices and result value at dim#0}}
+    %output : tensor<2xf32>) -> tensor<2xf32> {
+  // expected-error @below {{'iree_linalg_ext.gather' op mismatch in shape of indices and output value at dim#0}}
   %0 = iree_linalg_ext.gather
     dimension_map = [0]
     ins(%source, %idx : tensor<10xf32>, tensor<1xi32>)
-    outs(%result : tensor<2xf32>) {
+    outs(%output : tensor<2xf32>) {
     ^bb0(%arg0: f32, %arg1: f32):
       iree_linalg_ext.yield %arg0 : f32
   } -> tensor<2xf32>
@@ -437,14 +437,14 @@ func.func @gather_result_too_large(
 
 // -----
 
-func.func @gather_mismatch_result_and_source(
+func.func @gather_mismatch_output_and_source(
     %source : tensor<10x10xf32>, %idx : tensor<2xi32>,
-    %result : tensor<1xf32>) -> tensor<1xf32> {
-  // expected-error @below {{'iree_linalg_ext.gather' op shape of result value dim#0 must match source value at dim#1}}
+    %output : tensor<1xf32>) -> tensor<1xf32> {
+  // expected-error @below {{'iree_linalg_ext.gather' op shape of output value dim#0 must match source value at dim#1}}
   %0 = iree_linalg_ext.gather
     dimension_map = [0]
     ins(%source, %idx : tensor<10x10xf32>, tensor<2xi32>)
-    outs(%result : tensor<1xf32>) {
+    outs(%output : tensor<1xf32>) {
     ^bb0(%arg0: f32, %arg1: f32):
       iree_linalg_ext.yield %arg0 : f32
   } -> tensor<1xf32>
@@ -455,12 +455,12 @@ func.func @gather_mismatch_result_and_source(
 
 func.func @gather_indices_batch_rank_too_large(
     %source : tensor<10x10xf32>, %idx : tensor<1x2xi32>,
-    %result : tensor<10xf32>) -> tensor<10xf32> {
+    %output : tensor<10xf32>) -> tensor<10xf32> {
   // expected-error @below {{'iree_linalg_ext.gather' op expected indices to be equal to batch rank or batch rank + 1}}
   %0 = iree_linalg_ext.gather
     dimension_map = [0]
     ins(%source, %idx : tensor<10x10xf32>, tensor<1x2xi32>)
-    outs(%result : tensor<10xf32>) {
+    outs(%output : tensor<10xf32>) {
     ^bb0(%arg0: f32, %arg1: f32):
       iree_linalg_ext.yield %arg0 : f32
   } -> tensor<10xf32>
@@ -471,12 +471,12 @@ func.func @gather_indices_batch_rank_too_large(
 
 func.func @gather_dim_map_mismatch(
     %source : tensor<2xf32>, %idx : tensor<1xi32>,
-    %result : tensor<1xf32>) -> tensor<1xf32> {
-  // expected-error @below {{'iree_linalg_ext.gather' op expected result to be at least the rank of non indexed source dims}}
+    %output : tensor<1xf32>) -> tensor<1xf32> {
+  // expected-error @below {{'iree_linalg_ext.gather' op expected output to be at least the rank of non indexed source dims}}
   %0 = iree_linalg_ext.gather
     dimension_map = [0, 1]
     ins(%source, %idx : tensor<2xf32>, tensor<1xi32>)
-    outs(%result : tensor<1xf32>) {
+    outs(%output : tensor<1xf32>) {
     ^bb0(%arg0: f32, %arg1: f32):
       iree_linalg_ext.yield %arg0 : f32
   } -> tensor<1xf32>

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -421,6 +421,70 @@ func.func @scatter_index_depth_too_small(
 
 // -----
 
+func.func @gather_result_too_large(
+    %source : tensor<10xf32>, %idx : tensor<1xi32>,
+    %result : tensor<2xf32>) -> tensor<2xf32> {
+  // expected-error @below {{'iree_linalg_ext.gather' op mismatch in shape of indices and result value at dim#0}}
+  %0 = iree_linalg_ext.gather
+    dimension_map = [0]
+    ins(%source, %idx : tensor<10xf32>, tensor<1xi32>)
+    outs(%result : tensor<2xf32>) {
+    ^bb0(%arg0: f32, %arg1: f32):
+      iree_linalg_ext.yield %arg0 : f32
+  } -> tensor<2xf32>
+  return %0 : tensor<2xf32>
+}
+
+// -----
+
+func.func @gather_mismatch_result_and_source(
+    %source : tensor<10x10xf32>, %idx : tensor<2xi32>,
+    %result : tensor<1xf32>) -> tensor<1xf32> {
+  // expected-error @below {{'iree_linalg_ext.gather' op shape of result value dim#0 must match source value at dim#1}}
+  %0 = iree_linalg_ext.gather
+    dimension_map = [0]
+    ins(%source, %idx : tensor<10x10xf32>, tensor<2xi32>)
+    outs(%result : tensor<1xf32>) {
+    ^bb0(%arg0: f32, %arg1: f32):
+      iree_linalg_ext.yield %arg0 : f32
+  } -> tensor<1xf32>
+  return %0 : tensor<1xf32>
+}
+
+// -----
+
+func.func @gather_indices_batch_rank_too_large(
+    %source : tensor<10x10xf32>, %idx : tensor<1x2xi32>,
+    %result : tensor<10xf32>) -> tensor<10xf32> {
+  // expected-error @below {{'iree_linalg_ext.gather' op expected indices to be equal to batch rank or batch rank + 1}}
+  %0 = iree_linalg_ext.gather
+    dimension_map = [0]
+    ins(%source, %idx : tensor<10x10xf32>, tensor<1x2xi32>)
+    outs(%result : tensor<10xf32>) {
+    ^bb0(%arg0: f32, %arg1: f32):
+      iree_linalg_ext.yield %arg0 : f32
+  } -> tensor<10xf32>
+  return %0 : tensor<10xf32>
+}
+
+// -----
+
+func.func @gather_dim_map_mismatch(
+    %source : tensor<2xf32>, %idx : tensor<1xi32>,
+    %result : tensor<1xf32>) -> tensor<1xf32> {
+  // expected-error @below {{'iree_linalg_ext.gather' op expected result to be at least the rank of non indexed source dims}}
+  %0 = iree_linalg_ext.gather
+    dimension_map = [0, 1]
+    ins(%source, %idx : tensor<2xf32>, tensor<1xi32>)
+    outs(%result : tensor<1xf32>) {
+    ^bb0(%arg0: f32, %arg1: f32):
+      iree_linalg_ext.yield %arg0 : f32
+  } -> tensor<1xf32>
+  return %0 : tensor<1xf32>
+}
+
+// -----
+
 func.func @topk_invalid(%input_values: tensor<2x10xf32>, %input_indices: tensor<2x10xi32>, %out_values : tensor<2x3xf32>, %out_indices: tensor<2x3xi32>) -> (tensor<2x3xf32>, tensor<2x3xi32>) {
   // expected-error@+1 {{expected one or two input operands}}
   %0:2 = iree_linalg_ext.topk

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
@@ -592,6 +592,56 @@ func.func @scatter_update_slice_2D(
 
 // -----
 
+func.func @gather_static(
+    %source : tensor<10xf32>, %idx : tensor<1xi32>,
+    %result : tensor<1xf32>) -> tensor<1xf32> {
+  %0 = iree_linalg_ext.gather
+    dimension_map = [0]
+    ins(%source, %idx : tensor<10xf32>, tensor<1xi32>)
+    outs(%result : tensor<1xf32>) {
+    ^bb0(%arg0: f32, %arg1: f32):
+      iree_linalg_ext.yield %arg0 : f32
+  } -> tensor<1xf32>
+  return %0 : tensor<1xf32>
+}
+// CHECK-LABEL: func.func @gather_static(
+// CHECK-SAME:   %[[SOURCE:[a-zA-Z0-9_]+]]
+// CHECK-SAME:   %[[IDX:[a-zA-Z0-9_]+]]
+// CHECK-SAME:   %[[RESULT:[a-zA-Z0-9_]+]]
+//     CHECK:   %[[VAL:.+]] = iree_linalg_ext.gather
+// CHECK-SAME:     dimension_map = [0]
+// CHECK-SAME:     ins(%[[SOURCE]], %[[IDX]]
+// CHECK-SAME:     outs(%[[RESULT]]
+//     CHECK:     iree_linalg_ext.yield %{{.+}} : f32
+//     CHECK:   return %[[VAL]]
+
+// -----
+
+func.func @gather_static_2D(
+    %source : tensor<4x3xf32>, %idx : tensor<1x1xi32>,
+    %result : tensor<1xf32>) -> tensor<1xf32> {
+  %0 = iree_linalg_ext.gather
+    dimension_map = [0, 1]
+    ins(%source, %idx : tensor<4x3xf32>, tensor<1x1xi32>)
+    outs(%result : tensor<1xf32>) {
+    ^bb0(%arg0: f32, %arg1: f32):
+      iree_linalg_ext.yield %arg0 : f32
+  } -> tensor<1xf32>
+  return %0 : tensor<1xf32>
+}
+// CHECK-LABEL: func.func @gather_static_2D(
+// CHECK-SAME:   %[[SOURCE:[a-zA-Z0-9_]+]]
+// CHECK-SAME:   %[[IDX:[a-zA-Z0-9_]+]]
+// CHECK-SAME:   %[[RESULT:[a-zA-Z0-9_]+]]
+//     CHECK:   %[[VAL:.+]] = iree_linalg_ext.gather
+// CHECK-SAME:     dimension_map = [0, 1]
+// CHECK-SAME:     ins(%[[SOURCE]], %[[IDX]]
+// CHECK-SAME:     outs(%[[RESULT]]
+//     CHECK:     iree_linalg_ext.yield %{{.+}} : f32
+//     CHECK:   return %[[VAL]]
+
+// -----
+
 func.func @fft_tensor(%arg0: tensor<1024xf32>, %arg1: tensor<1024xf32>)
     -> (tensor<1024xf32>, tensor<1024xf32>) {
   %cst1 = arith.constant 1 : index

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
@@ -2584,3 +2584,87 @@ module attributes { transform.with_named_sequence } {
 //      CHECK:       %[[INDEX:.+]] = affine.apply #[[MAP]](%[[IV]])[%[[NEW_INDEX]]]
 //      CHECK:       linalg.generic
 // CHECK-SAME:           ins(%{{.+}}, %[[INDEX]] :
+
+// -----
+
+func.func @gather_1d_indices(%arg0 : memref<?x?xi32>, %arg1 : memref<?xi32>, %arg2 : memref<?x?xi32>) {
+  iree_linalg_ext.gather
+    dimension_map = [0]
+    ins(%arg0, %arg1: memref<?x?xi32>, memref<?xi32>)
+    outs(%arg2: memref<?x?xi32>) {
+    ^bb0(%bb0: i32, %bb1: i32):
+      iree_linalg_ext.yield %bb0 : i32
+  }
+  return
+}
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["iree_linalg_ext.gather"]} in %module_op : (!transform.any_op) -> !transform.any_op
+    %1, %loops:2 = transform.structured.tile_using_for %0 tile_sizes [10, 20] : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+    transform.yield
+  }
+}
+//  CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0)[s0] -> (-d0 + s0, 10)>
+//  CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0)[s0] -> (-d0 + s0, 20)>
+//      CHECK: func @gather_1d_indices
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]
+//  CHECK-DAG:   %[[C20:.+]] = arith.constant 20
+//  CHECK-DAG:   %[[C10:.+]] = arith.constant 10
+//  CHECK-DAG:   %[[C0:.+]] = arith.constant 0
+//  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
+//  CHECK-DAG:   %[[D0:.+]] = memref.dim %[[ARG2]], %[[C0]]
+//  CHECK-DAG:   %[[D1:.+]] = memref.dim %[[ARG2]], %[[C1]]
+//      CHECK:   scf.for %[[I:.+]] = %[[C0]] to %[[D0]] step %[[C10]]
+//      CHECK:     scf.for %[[J:.+]] = %[[C0]] to %[[D1]] step %[[C20]]
+//  CHECK-DAG:       %[[MIN0:.+]] = affine.min #[[MAP0]](%[[I]])[%[[D0]]]
+//  CHECK-DAG:       %[[MIN1:.+]] = affine.min #[[MAP1]](%[[J]])[%[[D1]]]
+//  CHECK-DAG:       %[[RESULT:.+]] = memref.subview %[[ARG2]][%[[I]], %[[J]]] [%[[MIN0]], %[[MIN1]]] [1, 1]
+//  CHECK-DAG:       %[[INDEX:.+]] = memref.subview %[[ARG1]][%[[I]]] [%[[MIN0]]] [1]
+//  CHECK-DAG:       %[[D2:.+]] = memref.dim %[[ARG0]], %[[C0]]
+//  CHECK-DAG:       %[[SOURCE:.+]] = memref.subview %[[ARG0]][0, %[[J]]] [%[[D2]], %[[MIN1]]] [1, 1]
+//      CHECK:       iree_linalg_ext.gather
+// CHECK-SAME:           ins(%[[SOURCE]], %[[INDEX]]
+// CHECK-SAME:           outs(%[[RESULT]]
+
+
+
+// -----
+
+func.func @gather_2d_indices(%arg0 : memref<?x?xi32>, %arg1 : memref<?x2xi32>, %arg2 : memref<?xi32>) {
+  iree_linalg_ext.gather
+    dimension_map = [0, 1]
+    ins(%arg0, %arg1: memref<?x?xi32>, memref<?x2xi32>)
+    outs(%arg2: memref<?xi32>) {
+    ^bb0(%bb0: i32, %bb1: i32):
+      iree_linalg_ext.yield %bb0 : i32
+  }
+  return
+}
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%module_op: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["iree_linalg_ext.gather"]} in %module_op : (!transform.any_op) -> !transform.any_op
+    %1, %loops = transform.structured.tile_using_for %0 tile_sizes [13] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+    transform.yield
+  }
+}
+//      CHECK: #[[MAP0:.+]] = affine_map<(d0)[s0] -> (-d0 + s0, 13)>
+//      CHECK: func @gather_2d_indices
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]
+//  CHECK-DAG:   %[[C13:.+]] = arith.constant 13
+//  CHECK-DAG:   %[[C0:.+]] = arith.constant 0
+//  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
+//  CHECK-DAG:   %[[D0:.+]] = memref.dim %[[ARG2]], %[[C0]]
+//      CHECK:   scf.for %[[I:.+]] = %[[C0]] to %[[D0]] step %[[C13]]
+//  CHECK-DAG:     %[[MIN:.+]] = affine.min #[[MAP0]](%[[I]])[%[[D0]]]
+//  CHECK-DAG:     %[[RESULT:.+]] = memref.subview %[[ARG2]][%[[I]]] [%[[MIN]]] [1]
+//  CHECK-DAG:     %[[INDEX:.+]] = memref.subview %[[ARG1]][%[[I]], 0] [%[[MIN]], 2] [1, 1]
+//  CHECK-DAG:     %[[D1:.+]] = memref.dim %[[ARG0]], %[[C0]]
+//  CHECK-DAG:     %[[D2:.+]] = memref.dim %[[ARG0]], %[[C1]]
+//  CHECK-DAG:     %[[SOURCE:.+]] = memref.subview %[[ARG0]][0, 0] [%[[D1]], %[[D2]]] [1, 1]
+//      CHECK:     iree_linalg_ext.gather
+// CHECK-SAME:         ins(%[[SOURCE]], %[[INDEX]]
+// CHECK-SAME:         outs(%[[RESULT]]

--- a/tests/e2e/linalg_ext_ops/BUILD.bazel
+++ b/tests/e2e/linalg_ext_ops/BUILD.bazel
@@ -16,6 +16,7 @@ ALL_SRCS = enforce_glob(
     # keep sorted
     [
         "attention.mlir",
+        "gather.mlir",
         "scan.mlir",
         "scatter.mlir",
         "sort.mlir",

--- a/tests/e2e/linalg_ext_ops/BUILD.bazel
+++ b/tests/e2e/linalg_ext_ops/BUILD.bazel
@@ -64,6 +64,7 @@ iree_check_single_backend_test_suite(
 VMVX_SRCS = enforce_glob(
     # keep sorted
     [
+        "gather.mlir",
         "scan.mlir",
         "scatter.mlir",
         "sort.mlir",
@@ -88,6 +89,7 @@ iree_check_single_backend_test_suite(
 LLVM_GPU_SRCS = enforce_glob(
     # keep sorted
     [
+        "gather.mlir",
         "scan.mlir",
         "scatter.mlir",
         "sort.mlir",
@@ -121,6 +123,7 @@ iree_check_single_backend_test_suite(
 ROCM_HIP_SRCS = enforce_glob(
     # keep sorted
     [
+        "gather.mlir",
         "scan.mlir",
         "scatter.mlir",
         "sort.mlir",
@@ -147,6 +150,7 @@ iree_check_single_backend_test_suite(
     srcs = enforce_glob(
         # keep sorted
         [
+            "gather.mlir",
             "scan.mlir",
             "scatter.mlir",
             "sort.mlir",
@@ -169,6 +173,7 @@ iree_check_single_backend_test_suite(
     srcs = enforce_glob(
         # keep sorted
         [
+            "gather.mlir",
             "scan.mlir",
             "scatter.mlir",
             "sort.mlir",

--- a/tests/e2e/linalg_ext_ops/CMakeLists.txt
+++ b/tests/e2e/linalg_ext_ops/CMakeLists.txt
@@ -52,6 +52,7 @@ iree_check_single_backend_test_suite(
   NAME
     check_vmvx_local-task
   SRCS
+    "gather.mlir"
     "scan.mlir"
     "scatter.mlir"
     "sort.mlir"
@@ -68,6 +69,7 @@ iree_check_single_backend_test_suite(
   NAME
     check_cuda
   SRCS
+    "gather.mlir"
     "scan.mlir"
     "scatter.mlir"
     "sort.mlir"
@@ -90,6 +92,7 @@ iree_check_single_backend_test_suite(
   NAME
     check_rocm_hip
   SRCS
+    "gather.mlir"
     "scan.mlir"
     "scatter.mlir"
     "sort.mlir"
@@ -105,6 +108,7 @@ iree_check_single_backend_test_suite(
   NAME
     check_metal-spirv_vulkan
   SRCS
+    "gather.mlir"
     "scan.mlir"
     "scatter.mlir"
     "sort.mlir"
@@ -120,6 +124,7 @@ iree_check_single_backend_test_suite(
   NAME
     check_vulkan-spirv_vulkan
   SRCS
+    "gather.mlir"
     "scan.mlir"
     "scatter.mlir"
     "sort.mlir"

--- a/tests/e2e/linalg_ext_ops/CMakeLists.txt
+++ b/tests/e2e/linalg_ext_ops/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_check_single_backend_test_suite(
     check_llvm-cpu_local-task
   SRCS
     "attention.mlir"
+    "gather.mlir"
     "scan.mlir"
     "scatter.mlir"
     "sort.mlir"

--- a/tests/e2e/linalg_ext_ops/gather.mlir
+++ b/tests/e2e/linalg_ext_ops/gather.mlir
@@ -55,3 +55,33 @@ func.func @gather3() {
   check.expect_eq_const(%result, dense<[2, 3]> : tensor<2xi32>) : tensor<2xi32>
   return
 }
+
+func.func @gather_muli_in_region() {
+  %cst = arith.constant 2 : i32
+  %source = util.unfoldable_constant dense<[[0, 1], [2, 3]]> : tensor<2x2xi32>
+  %empty = tensor.empty() : tensor<2xi32>
+  %indices = util.unfoldable_constant dense<[1]> : tensor<1xi32>
+  %result = iree_linalg_ext.gather dimension_map = [0]
+                          ins(%source, %indices : tensor<2x2xi32>, tensor<1xi32>)
+                          outs(%empty: tensor<2xi32>) {
+                    ^bb0(%arg0: i32, %arg1: i32):
+                      %0 = arith.muli %arg0, %cst : i32
+                      iree_linalg_ext.yield %0 : i32
+  } -> tensor<2xi32>
+  check.expect_eq_const(%result, dense<[4, 6]> : tensor<2xi32>) : tensor<2xi32>
+  return
+}
+
+func.func @gather_perm_map() {
+  %source = util.unfoldable_constant dense<[[[0], [1]], [[2], [3]]]> : tensor<2x2x1xi32>
+  %empty = tensor.empty() : tensor<1xi32>
+  %indices = util.unfoldable_constant dense<[0, 1]> : tensor<2xi32>
+  %result = iree_linalg_ext.gather dimension_map = [1, 0]
+                          ins(%source, %indices : tensor<2x2x1xi32>, tensor<2xi32>)
+                          outs(%empty: tensor<1xi32>) {
+                    ^bb0(%arg0: i32, %arg1: i32):
+                      iree_linalg_ext.yield %arg0 : i32
+  } -> tensor<1xi32>
+  check.expect_eq_const(%result, dense<[2]> : tensor<1xi32>) : tensor<1xi32>
+  return
+}

--- a/tests/e2e/linalg_ext_ops/gather.mlir
+++ b/tests/e2e/linalg_ext_ops/gather.mlir
@@ -1,0 +1,29 @@
+func.func @gather0() {
+  %source = util.unfoldable_constant dense<0> : tensor<10x10xi32>
+  %empty = tensor.empty() : tensor<1x10xi32>
+  %indices = util.unfoldable_constant dense<0> : tensor<1xi32>
+  %result = iree_linalg_ext.gather dimension_map = [0]
+                          ins(%source, %indices : tensor<10x10xi32>, tensor<1xi32>)
+                          outs(%empty : tensor<1x10xi32>) {
+                    ^bb0(%arg0: i32, %arg1: i32):
+                      iree_linalg_ext.yield %arg0 : i32
+  } -> tensor<1x10xi32>
+
+  check.expect_eq_const(%result, dense<[[0, 0, 0, 0, 0, 0, 0, 0, 0, 0]]> : tensor<1x10xi32>)
+            : tensor<1x10xi32>
+  return
+}
+
+func.func @gather1() {
+  %source = util.unfoldable_constant dense<[[[0], [1]], [[1], [0]]]> : tensor<2x2x1xi32>
+  %empty = tensor.empty() : tensor<2x1xi32>
+  %indices = util.unfoldable_constant dense<[[0, 1], [1, 0]]> : tensor<2x2xi32>
+  %result = iree_linalg_ext.gather dimension_map = [0, 1]
+                          ins(%source, %indices : tensor<2x2x1xi32>, tensor<2x2xi32>)
+                          outs(%empty: tensor<2x1xi32>) {
+                    ^bb0(%arg0: i32, %arg1: i32):
+                      iree_linalg_ext.yield %arg0 : i32
+  } -> tensor<2x1xi32>
+  check.expect_eq_const(%result, dense<[[1], [1]]> : tensor<2x1xi32>) : tensor<2x1xi32>
+  return
+}

--- a/tests/e2e/linalg_ext_ops/gather.mlir
+++ b/tests/e2e/linalg_ext_ops/gather.mlir
@@ -15,15 +15,43 @@ func.func @gather0() {
 }
 
 func.func @gather1() {
-  %source = util.unfoldable_constant dense<[[[0], [1]], [[1], [0]]]> : tensor<2x2x1xi32>
-  %empty = tensor.empty() : tensor<2x1xi32>
+  %source = util.unfoldable_constant dense<[[0, 1], [2, 3]]> : tensor<2x2xi32>
+  %empty = tensor.empty() : tensor<2xi32>
   %indices = util.unfoldable_constant dense<[[0, 1], [1, 0]]> : tensor<2x2xi32>
   %result = iree_linalg_ext.gather dimension_map = [0, 1]
-                          ins(%source, %indices : tensor<2x2x1xi32>, tensor<2x2xi32>)
-                          outs(%empty: tensor<2x1xi32>) {
+                          ins(%source, %indices : tensor<2x2xi32>, tensor<2x2xi32>)
+                          outs(%empty: tensor<2xi32>) {
                     ^bb0(%arg0: i32, %arg1: i32):
                       iree_linalg_ext.yield %arg0 : i32
-  } -> tensor<2x1xi32>
-  check.expect_eq_const(%result, dense<[[1], [1]]> : tensor<2x1xi32>) : tensor<2x1xi32>
+  } -> tensor<2xi32>
+  check.expect_eq_const(%result, dense<[1, 2]> : tensor<2xi32>) : tensor<2xi32>
+  return
+}
+
+func.func @gather2() {
+  %source = util.unfoldable_constant dense<[[[0], [1]], [[0], [0]]]> : tensor<2x2x1xi32>
+  %empty = tensor.empty() : tensor<1xi32>
+  %indices = util.unfoldable_constant dense<[0, 1]> : tensor<2xi32>
+  %result = iree_linalg_ext.gather dimension_map = [0, 1]
+                          ins(%source, %indices : tensor<2x2x1xi32>, tensor<2xi32>)
+                          outs(%empty: tensor<1xi32>) {
+                    ^bb0(%arg0: i32, %arg1: i32):
+                      iree_linalg_ext.yield %arg0 : i32
+  } -> tensor<1xi32>
+  check.expect_eq_const(%result, dense<[1]> : tensor<1xi32>) : tensor<1xi32>
+  return
+}
+
+func.func @gather3() {
+  %source = util.unfoldable_constant dense<[[0, 1], [2, 3]]> : tensor<2x2xi32>
+  %empty = tensor.empty() : tensor<2xi32>
+  %indices = util.unfoldable_constant dense<[1]> : tensor<1xi32>
+  %result = iree_linalg_ext.gather dimension_map = [0]
+                          ins(%source, %indices : tensor<2x2xi32>, tensor<1xi32>)
+                          outs(%empty: tensor<2xi32>) {
+                    ^bb0(%arg0: i32, %arg1: i32):
+                      iree_linalg_ext.yield %arg0 : i32
+  } -> tensor<2xi32>
+  check.expect_eq_const(%result, dense<[2, 3]> : tensor<2xi32>) : tensor<2xi32>
   return
 }


### PR DESCRIPTION
Adds `iree_linalg_ext.gather` operation which is the converse of `iree_linalg_ext.scatter`. Both operations share similar semantics, but while scatter writes values into `original`, gather reads values from `source` based on `indices`.