### PR TITLE
[VectorExt] Add `iree_vector_ext.transfer_gather` operation

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/BUILD.bazel
@@ -36,6 +36,7 @@ iree_td_library(
         "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
         "@llvm-project//mlir:OpBaseTdFiles",
         "@llvm-project//mlir:SideEffectInterfacesTdFiles",
+        "@llvm-project//mlir:VectorInterfacesTdFiles",
     ],
 )
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h
@@ -13,6 +13,7 @@
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Interfaces/VectorInterfaces.h"
 
 // clang-format off: must be included after all LLVM/MLIR headers
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.h"
 #include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
 
 using namespace mlir;
 using namespace mlir::iree_compiler::IREE::VectorExt;
@@ -35,6 +36,407 @@ OpFoldResult ToSIMTOp::fold(FoldAdaptor) {
     return simdOp.getOperand();
   }
   return {};
+}
+
+//
+// TransferGatherOp
+//
+
+Speculation::Speculatability TransferGatherOp::getSpeculatability() {
+  if (isa<RankedTensorType>(getSource().getType())) {
+    return Speculation::Speculatable;
+  }
+  return Speculation::NotSpeculatable;
+}
+
+void TransferGatherOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  if (llvm::isa<MemRefType>(getSource().getType())) {
+    effects.emplace_back(MemoryEffects::Read::get(), &getSourceMutable(),
+                         SideEffects::DefaultResource::get());
+  }
+}
+
+const char *kNonIndexedSymbol = "None";
+
+ParseResult
+parseIndexVecs(OpAsmParser &parser,
+               SmallVectorImpl<OpAsmParser::UnresolvedOperand> &indexVecs,
+               SmallVectorImpl<Type> &indexVecTypes, ArrayAttr &indexed) {
+  if (parser.parseLSquare())
+    return failure();
+
+  SMLoc loc;
+  SmallVector<bool> indexedArr;
+  while (parser.parseOptionalRSquare()) {
+    // Check if this dimension is not indexed
+    if (!parser.parseOptionalKeyword(kNonIndexedSymbol)) {
+      indexedArr.push_back(false);
+      (void)parser.parseOptionalComma();
+      continue;
+    }
+
+    OpAsmParser::UnresolvedOperand indexVec;
+    Type indexVecType;
+    if (parser.getCurrentLocation(&loc) || parser.parseOperand(indexVec) ||
+        parser.parseColon() || parser.parseType(indexVecType)) {
+      return parser.emitError(loc, "Expected `none` or `operand : type`");
+    }
+
+    indexVecs.push_back(indexVec);
+    indexVecTypes.push_back(indexVecType);
+    indexedArr.push_back(true);
+
+    (void)parser.parseOptionalComma();
+  }
+
+  // OpBuilder is only used as a helper to build an BoolArrayAttr.
+  OpBuilder b(parser.getContext());
+  indexed = b.getBoolArrayAttr(indexedArr);
+  return success();
+}
+
+void printIndexVecs(OpAsmPrinter &p, Operation *op, OperandRange indexVecs,
+                    TypeRange indexVecTypes, ArrayAttr indexed) {
+  int64_t rank = indexed.size();
+  SmallVector<bool> indexedArr(indexed.getAsValueRange<BoolAttr>());
+
+  int64_t currIndexDim = 0;
+  p << "[";
+  for (int64_t i : llvm::seq<int64_t>(rank)) {
+    if (indexedArr[i]) {
+      p << indexVecs[currIndexDim] << ": " << indexVecTypes[currIndexDim];
+      ++currIndexDim;
+    } else {
+      p << kNonIndexedSymbol;
+    }
+
+    if (i != rank - 1) {
+      p << ", ";
+    }
+  }
+  p << "]";
+}
+
+static void printTransferAttrs(OpAsmPrinter &p, VectorTransferOpInterface op,
+                               SmallVector<StringRef, 3> elidedAttrs = {}) {
+  elidedAttrs.push_back(TransferGatherOp::getOperandSegmentSizeAttr());
+  if (op.getPermutationMap().isMinorIdentity())
+    elidedAttrs.push_back(op.getPermutationMapAttrName());
+  // Elide in_bounds attribute if all dims are out-of-bounds.
+  if (llvm::none_of(op.getInBoundsValues(), [](bool b) { return b; }))
+    elidedAttrs.push_back(op.getInBoundsAttrName());
+  p.printOptionalAttrDict(op->getAttrs(), elidedAttrs);
+}
+
+void TransferGatherOp::print(OpAsmPrinter &p) {
+  p << " " << getSource() << "[" << getIndices() << "]";
+  printIndexVecs(p, *this, getIndexVecs(), getIndexVecs().getTypes(),
+                 getIndexedAttr());
+  if (getMask())
+    p << ", " << getMask();
+  printTransferAttrs(p, *this, {"indexed"});
+  p << " : ";
+  p << getShapedType() << ", ";
+  llvm::interleaveComma(getIndexVecs().getType(), p);
+  p << ", " << getVectorType();
+}
+
+static LogicalResult
+verifyTransferOp(VectorTransferOpInterface op, ShapedType shapedType,
+                 VectorType vectorType, VectorType maskType,
+                 VectorType inferredMaskType, AffineMap permutationMap,
+                 ArrayAttr inBounds) {
+  if (op->hasAttr("masked")) {
+    return op->emitOpError("masked attribute has been removed. "
+                           "Use in_bounds instead.");
+  }
+
+  if (!llvm::isa<MemRefType, RankedTensorType>(shapedType))
+    return op->emitOpError(
+        "requires source to be a memref or ranked tensor type");
+
+  auto elementType = shapedType.getElementType();
+  DataLayout dataLayout = DataLayout::closest(op);
+  if (auto vectorElementType = llvm::dyn_cast<VectorType>(elementType)) {
+    // Memref or tensor has vector element type.
+    unsigned sourceVecSize =
+        dataLayout.getTypeSizeInBits(vectorElementType.getElementType()) *
+        vectorElementType.getShape().back();
+    unsigned resultVecSize =
+        dataLayout.getTypeSizeInBits(vectorType.getElementType()) *
+        vectorType.getShape().back();
+    if (resultVecSize % sourceVecSize != 0)
+      return op->emitOpError(
+          "requires the bitwidth of the minor 1-D vector to be an integral "
+          "multiple of the bitwidth of the minor 1-D vector of the source");
+
+    unsigned sourceVecEltRank = vectorElementType.getRank();
+    unsigned resultVecRank = vectorType.getRank();
+    if (sourceVecEltRank > resultVecRank)
+      return op->emitOpError(
+          "requires source vector element and vector result ranks to match.");
+    unsigned rankOffset = resultVecRank - sourceVecEltRank;
+    // Check that permutation map results match 'rankOffset' of vector type.
+    if (permutationMap.getNumResults() != rankOffset)
+      return op->emitOpError("requires a permutation_map with result dims of "
+                             "the same rank as the vector type");
+
+    if (maskType)
+      return op->emitOpError("does not support masks with vector element type");
+  } else {
+    // Memref or tensor has scalar element type.
+    unsigned minorSize =
+        vectorType.getRank() == 0 ? 1 : vectorType.getShape().back();
+    unsigned resultVecSize =
+        dataLayout.getTypeSizeInBits(vectorType.getElementType()) * minorSize;
+    if (resultVecSize % dataLayout.getTypeSizeInBits(elementType) != 0)
+      return op->emitOpError(
+          "requires the bitwidth of the minor 1-D vector to be an integral "
+          "multiple of the bitwidth of the source element type");
+
+    // Check that permutation map results match rank of vector type.
+    if (permutationMap.getNumResults() != vectorType.getRank())
+      return op->emitOpError("requires a permutation_map with result dims of "
+                             "the same rank as the vector type");
+  }
+
+  if (permutationMap.getNumSymbols() != 0)
+    return op->emitOpError("requires permutation_map without symbols");
+
+  if (permutationMap.getNumInputs() != shapedType.getRank())
+    return op->emitOpError("requires a permutation_map with input dims of the "
+                           "same rank as the source type");
+
+  if (maskType && maskType != inferredMaskType)
+    return op->emitOpError("inferred mask type (")
+           << inferredMaskType << ") and mask operand type (" << maskType
+           << ") don't match";
+
+  if (permutationMap.getNumResults() != static_cast<int64_t>(inBounds.size()))
+    return op->emitOpError("expects the in_bounds attr of same rank "
+                           "as permutation_map results: ")
+           << AffineMapAttr::get(permutationMap)
+           << " vs inBounds of size: " << inBounds.size();
+
+  return success();
+}
+
+template <typename EmitFun>
+static LogicalResult verifyPermutationMap(AffineMap permutationMap,
+                                          EmitFun emitOpError) {
+  SmallVector<bool, 8> seen(permutationMap.getNumInputs(), false);
+  for (auto expr : permutationMap.getResults()) {
+    auto dim = dyn_cast<AffineDimExpr>(expr);
+    auto zero = dyn_cast<AffineConstantExpr>(expr);
+    if (zero) {
+      if (zero.getValue() != 0) {
+        return emitOpError(
+            "requires a projected permutation_map (at most one dim or the zero "
+            "constant can appear in each result)");
+      }
+      continue;
+    }
+    if (!dim) {
+      return emitOpError("requires a projected permutation_map (at most one "
+                         "dim or the zero constant can appear in each result)");
+    }
+    if (seen[dim.getPosition()]) {
+      return emitOpError(
+          "requires a permutation_map that is a permutation (found one dim "
+          "used more than once)");
+    }
+    seen[dim.getPosition()] = true;
+  }
+  return success();
+}
+
+LogicalResult TransferGatherOp::verify() {
+  // Consistency of elemental types in source and vector.
+  ShapedType shapedType = getShapedType();
+  VectorType vectorType = getVectorType();
+  VectorType maskType = getMaskType();
+  auto paddingType = getPadding().getType();
+  auto permutationMap = getPermutationMap();
+  VectorType inferredMaskType =
+      maskType ? vector::inferTransferOpMaskType(vectorType, permutationMap)
+               : VectorType();
+  auto sourceElementType = shapedType.getElementType();
+
+  if (static_cast<int64_t>(getIndices().size()) != shapedType.getRank())
+    return emitOpError("requires ") << shapedType.getRank() << " indices";
+
+  if (failed(verifyTransferOp(cast<VectorTransferOpInterface>(getOperation()),
+                              shapedType, vectorType, maskType,
+                              inferredMaskType, permutationMap, getInBounds())))
+    return failure();
+
+  if (auto sourceVectorElementType =
+          llvm::dyn_cast<VectorType>(sourceElementType)) {
+    // Source has vector element type.
+    // Check that 'sourceVectorElementType' and 'paddingType' types match.
+    if (sourceVectorElementType != paddingType)
+      return emitOpError(
+          "requires source element type and padding type to match.");
+
+  } else {
+    // Check that 'paddingType' is valid to store in a vector type.
+    if (!VectorType::isValidElementType(paddingType))
+      return emitOpError("requires valid padding vector elemental type");
+
+    // Check that padding type and vector element types match.
+    if (paddingType != sourceElementType)
+      return emitOpError(
+          "requires formal padding and source of the same elemental type");
+  }
+
+  if (failed(verifyPermutationMap(permutationMap,
+                                  [&](Twine t) { return emitOpError(t); }))) {
+    return failure();
+  }
+
+  OperandRange indexVecs = getIndexVecs();
+  SmallVector<AffineMap> indexedMaps = getIndexedMapsArray();
+  SmallVector<bool> indexed(getIndexed().getAsValueRange<BoolAttr>());
+  if (indexed.size() != shapedType.getRank()) {
+    return emitOpError("requires indexed to have a value for each dimension of "
+                       "the shaped type");
+  }
+
+  int64_t numIndexed = llvm::count(indexed, true);
+  if (numIndexed != indexVecs.size()) {
+    return emitOpError("requires ") << numIndexed << " index vectors";
+  }
+  if (indexVecs.size() != indexedMaps.size()) {
+    return emitOpError("requires ") << numIndexed << " indexing map";
+  }
+
+  SmallVector<int64_t> sliceSize = getTransferChunkAccessed();
+  for (auto [i, indexVec, indexMap] : llvm::enumerate(indexVecs, indexedMaps)) {
+    auto indexVecTy = cast<VectorType>(indexVec.getType());
+    if (indexVecTy.getRank() != indexMap.getNumResults()) {
+      return emitOpError(
+                 "requires number of results for corressponding "
+                 "indexing map to match the rank of index vector at dim: ")
+             << i;
+    }
+
+    SmallVector<int64_t> expectedShape =
+        applyPermutationMap(indexMap, ArrayRef(sliceSize));
+    if (expectedShape != indexVecTy.getShape()) {
+      return emitOpError("Invalid index vector shape at dim: ")
+             << i << ", expected: " << expectedShape
+             << ", got: " << indexVecTy.getShape();
+    }
+  }
+
+  return success();
+}
+
+ParseResult TransferGatherOp::parse(OpAsmParser &parser,
+                                    OperationState &result) {
+  auto &builder = parser.getBuilder();
+  SMLoc typesLoc;
+  OpAsmParser::UnresolvedOperand sourceInfo;
+  SmallVector<OpAsmParser::UnresolvedOperand, 8> indexInfo;
+  SmallVector<OpAsmParser::UnresolvedOperand, 8> indexVecInfo;
+  OpAsmParser::UnresolvedOperand paddingInfo;
+  SmallVector<Type, 2> types;
+  OpAsmParser::UnresolvedOperand maskInfo;
+  // Parsing with support for paddingValue.
+  if (parser.parseOperand(sourceInfo) ||
+      parser.parseOperandList(indexInfo, OpAsmParser::Delimiter::Square))
+    return failure();
+
+  SmallVector<Type, 2> indexVecTypes;
+  ArrayAttr indexed;
+  if (parseIndexVecs(parser, indexVecInfo, indexVecTypes, indexed))
+    return failure();
+  result.addAttribute("indexed", indexed);
+
+  if (parser.parseComma() || parser.parseOperand(paddingInfo))
+    return failure();
+
+  ParseResult hasMask = parser.parseOptionalComma();
+  if (hasMask.succeeded()) {
+    if (parser.parseOperand(maskInfo))
+      return failure();
+  }
+
+  // Parse attributes and types.
+  if (parser.parseOptionalAttrDict(result.attributes) ||
+      parser.getCurrentLocation(&typesLoc) || parser.parseColonTypeList(types))
+    return failure();
+
+  // Check if number of types given are correct.
+  int64_t nRequiredTypes = 2;
+  if (types.size() != nRequiredTypes) {
+    return parser.emitError(typesLoc, "expected ")
+           << nRequiredTypes << " types";
+  }
+
+  // The types are arranged as:
+  // sourceTy, resultTy
+  auto shapedType = llvm::dyn_cast<ShapedType>(types[0]);
+  VectorType vectorType = llvm::dyn_cast<VectorType>(types[1]);
+  if (!shapedType || !llvm::isa<MemRefType, RankedTensorType>(shapedType))
+    return parser.emitError(typesLoc, "requires memref or ranked tensor type");
+  if (!vectorType)
+    return parser.emitError(typesLoc, "requires vector type");
+  auto permMapAttrName =
+      TransferGatherOp::getPermutationMapAttrName(result.name);
+  Attribute permMapAttr = result.attributes.get(permMapAttrName);
+  AffineMap permMap;
+  if (!permMapAttr) {
+    permMap = vector::getTransferMinorIdentityMap(shapedType, vectorType);
+    result.attributes.set(permMapAttrName, AffineMapAttr::get(permMap));
+  } else {
+    permMap = llvm::cast<AffineMapAttr>(permMapAttr).getValue();
+  }
+  auto inBoundsAttrName = TransferGatherOp::getInBoundsAttrName(result.name);
+  Attribute inBoundsAttr = result.attributes.get(inBoundsAttrName);
+  if (!inBoundsAttr) {
+    result.addAttribute(inBoundsAttrName,
+                        builder.getBoolArrayAttr(
+                            SmallVector<bool>(permMap.getNumResults(), false)));
+  }
+  if (parser.resolveOperand(sourceInfo, shapedType, result.operands) ||
+      parser.resolveOperands(indexInfo, builder.getIndexType(),
+                             result.operands) ||
+      parser.resolveOperands(indexVecInfo, indexVecTypes, typesLoc,
+                             result.operands) ||
+      parser.resolveOperand(paddingInfo, shapedType.getElementType(),
+                            result.operands))
+    return failure();
+  if (hasMask.succeeded()) {
+    if (llvm::dyn_cast<VectorType>(shapedType.getElementType()))
+      return parser.emitError(
+          maskInfo.location, "does not support masks with vector element type");
+    if (vectorType.getRank() != permMap.getNumResults()) {
+      return parser.emitError(typesLoc,
+                              "expected the same rank for the vector and the "
+                              "results of the permutation map");
+    }
+    // Instead of adding the mask type as an op type, compute it based on the
+    // vector type and the permutation map (to keep the type signature small).
+    auto maskType = vector::inferTransferOpMaskType(vectorType, permMap);
+    if (parser.resolveOperand(maskInfo, maskType, result.operands))
+      return failure();
+  }
+  result.addAttribute(TransferGatherOp::getOperandSegmentSizeAttr(),
+                      builder.getDenseI32ArrayAttr(
+                          {1, static_cast<int32_t>(indexInfo.size()),
+                           static_cast<int32_t>(indexVecInfo.size()), 1,
+                           static_cast<int32_t>(hasMask.succeeded())}));
+  return parser.addTypeToList(vectorType, result.types);
+}
+
+void TransferGatherOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                                   MLIRContext *ctx) {}
+
+OpFoldResult TransferGatherOp::fold(FoldAdaptor adaptor) {
+  return OpFoldResult();
 }
 
 // clang-format off

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.h
@@ -18,5 +18,6 @@
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Interfaces/VectorInterfaces.h"
 
 #endif // IREE_DIALECTS_DIALECT_VECTOREXT_IR_VECTOREXTOPS_H_

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
@@ -11,7 +11,6 @@ include "mlir/Interfaces/VectorInterfaces.td"
 include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtBase.td"
 include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrs.td"
 include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtInterfaces.td"
-include "mlir/Interfaces/DestinationStyleOpInterface.td"
 include "mlir/IR/OpBase.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
@@ -7,9 +7,11 @@
 #ifndef IREE_DIALECT_VECTOREXT_OPS
 #define IREE_DIALECT_VECTOREXT_OPS
 
+include "mlir/Interfaces/VectorInterfaces.td"
 include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtBase.td"
 include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrs.td"
 include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtInterfaces.td"
+include "mlir/Interfaces/DestinationStyleOpInterface.td"
 include "mlir/IR/OpBase.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
@@ -111,6 +113,132 @@ def IREEVectorExt_ToSIMTOp : IREEVectorExt_PureOp<"to_simt",
   let extraClassDeclaration = [{}];
   let assemblyFormat = "$input attr-dict `:` type($input) `->` type($output)";
   let hasFolder = 1;
+}
+
+def IREEVectorExt_TransferGatherOp : IREEVectorExt_PureOp<"transfer_gather", [
+    DeclareOpInterfaceMethods<VectorTransferOpInterface>,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+    DeclareOpInterfaceMethods<ConditionallySpeculatable>,
+    AttrSizedOperandSegments
+  ]>,
+  Arguments<(ins AnyShaped:$source,
+                 Variadic<Index>:$indices,
+                 Variadic<VectorOfAnyRankOf<[Index]>>:$index_vecs,
+                 BoolArrayAttr:$indexed,
+                 AffineMapArrayAttr:$indexed_maps,
+                 AffineMapAttr:$permutation_map,
+                 AnyType:$padding,
+                 Optional<VectorOfNonZeroRankOf<[I1]>>:$mask,
+                 BoolArrayAttr:$in_bounds)>,
+  Results<(outs AnyVectorOfAnyRank:$vector)> {
+
+  let summary = "Gathers a supervector from memory into an SSA vector value.";
+
+  let description = [{
+    The iree_vector_ext.transfer_gather operation provides a structured
+    abstraction for gathers, by preserving the iteration space mapping between
+    the result vector and the memory dimensions being indexed.
+
+    The operation is a generalization of `vector.transfer_read` op, where the
+    slice from which the read is performed is not guranteed to be contigious,
+    and instead how the slice is gathered is defined explicitly in the
+    operation.
+
+    The operation can be thought of as:
+      1. A contigious slice gathered from the source as described by the operation
+      2. A `vector.transfer_read` on the contigious slice
+
+    The operation defines `permutation_map`, `padding`, `mask`, `in_bounds` in
+    the same way as `vector.transfer_read` defines, but on the inferred
+    contigious slice.
+
+    The other parameters of the operation define how the contigious slice is
+    gathered from the source. `indices` define a base to offset the source by.
+    `indexed` defines for each dimension if the dimension is gathered or
+    contigious.
+
+    The `indices` contains a base to offset the source by. The `indexed` array
+    defines if a dimension is gathered or not. For example, for the following
+    gather:
+
+    ```
+    slice[i, j, k] = source[i + i_offset][j][indices[i][j][k]]
+    ```
+
+    The operation would represent this as:
+
+    ```
+    indices = %i_offset, 0, 0
+    indexed = [False, False, True]
+    ```
+
+    For every dimension that is gathered, the operation defines how it is
+    gathered. For each gathered dimension, the operation expects a vector of
+    indices in `index_vecs` to act as a source of indices for that dimension
+    and an AffineMap in `index_maps` describing how this source of indices is
+    indexed. For example, for the following gather:
+
+    ```
+    slice[i, j, k] = source[i][indices0[i] + offset][indices1[j, k]]
+    ```
+
+    The indexing would be described by:
+
+    ```
+    indices      = 0, %offset, 0
+    indexed      = [False, True, True]
+    index_vecs   = %index_vec1, %index_vec2
+    index_maps = [
+      affine_map<(i, j, k) -> (i),
+      affine_map<(i, j, k) -> (j, k)
+    ]
+    ```
+
+    With these additional parameters, the operation can define a supervector
+    read from a non-contigious slice. For example:
+
+    ```
+    source: memref<8192x8x16xf32>
+    indices0 : vector<2xindex>
+    indices1 : vector<4x8xindex>
+
+    slice[i, j, k] = source[indices0[k]][j][indices1[i, j]]
+    vector = read(slice) : memref<8192x8x16xf32> -> vector<16x8x2xf32>
+    ```
+
+    Can be represented by:
+
+    ```
+    %vector = vector.transfer_gather %source[0, 0, 0](%indices0, %indices1) {
+      gather_dims = [0, 2],
+      index_maps = [
+        affine_map<(i, j, k) -> (k)>,
+        affine_map<(i, j, k) -> (i, j)>
+      ],
+      in_bounds = [true, true, true],
+      permutation_map = affine_map<(i, j, k) -> (k, j, i)>
+    } : memref<8192x8x16xf32> -> vector<16x8x2xf32>
+    ```
+
+    The crucial structure of the operation relies on the index_vec and
+    the result vector's indexing being defined based on the dimensions of the
+    memory. This mapping can be exploited to simplify gathered dimensions
+    to contigious dimensions.
+  }];
+
+  let extraClassDeclaration = [{
+    // MaskableOpInterface methods.
+    bool supportsPassthru() { return true; }
+
+    SmallVector<AffineMap> getIndexedMapsArray() {
+      return llvm::to_vector(getIndexedMaps().getAsValueRange<AffineMapAttr>());
+    }
+  }];
+
+  let hasCanonicalizer = 1;
+  let hasCustomAssemblyFormat = 1;
+  let hasFolder = 1;
+  let hasVerifier = 1;
 }
 
 #endif  // IREE_DIALECT_VECTOREXT_OPS


### PR DESCRIPTION
This operation implementes the operation mentioned in https://discourse.llvm.org/t/rfc-improving-gather-codegen-for-vector-dialect/85011 . The plan is to implement support for it downstream, and slowly try to upstream it once things are working.