### PR TITLE
Add news links to SDXL MLPerf blog using IREE.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ guides, and instructions on building from source.
 ## Project news
 
 * 2025-04-02:
-[IREE submits SDXL text-to-image MLPerf inference benchmarks using AMD Instinct™ MI325X](https://rocm.blogs.amd.com/artificial-intelligence/mi325x-accelerates-mlperf-inference/README.html#stable-diffusion-xl-sdxl-text-to-image-mlperf-inference-benchmark)
+[AMD submitted an IREE-based SDXL implementation to the MLPerf benchmark suite](https://rocm.blogs.amd.com/artificial-intelligence/mi325x-accelerates-mlperf-inference/README.html#stable-diffusion-xl-sdxl-text-to-image-mlperf-inference-benchmark)
 * 2024-05-23:
 [IREE joins the LF AI & Data Foundation as a sandbox-stage project](https://lfaidata.foundation/blog/2024/05/23/announcing-iree-a-new-initiative-for-machine-learning-deployment/)
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ guides, and instructions on building from source.
 
 ## Project news
 
-* 2025-04-02: [IREE submits SDXL text-to-image MLPerf inference benchmarks using AMD Instinct™ MI325X](https://rocm.blogs.amd.com/artificial-intelligence/mi325x-accelerates-mlperf-inference/README.html#stable-diffusion-xl-sdxl-text-to-image-mlperf-inference-benchmark)
-* 2024-05-23: [IREE joins the LF AI & Data Foundation as a sandbox-stage project](https://lfaidata.foundation/blog/2024/05/23/announcing-iree-a-new-initiative-for-machine-learning-deployment/)
+* 2025-04-02:
+[IREE submits SDXL text-to-image MLPerf inference benchmarks using AMD Instinct™ MI325X](https://rocm.blogs.amd.com/artificial-intelligence/mi325x-accelerates-mlperf-inference/README.html#stable-diffusion-xl-sdxl-text-to-image-mlperf-inference-benchmark)
+* 2024-05-23:
+[IREE joins the LF AI & Data Foundation as a sandbox-stage project](https://lfaidata.foundation/blog/2024/05/23/announcing-iree-a-new-initiative-for-machine-learning-deployment/)
 
 ## Project status
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ guides, and instructions on building from source.
 
 ## Project news
 
+* 2025-04-02: [IREE submits SDXL text-to-image MLPerf inference benchmarks using AMD Instinct™ MI325X](https://rocm.blogs.amd.com/artificial-intelligence/mi325x-accelerates-mlperf-inference/README.html#stable-diffusion-xl-sdxl-text-to-image-mlperf-inference-benchmark)
 * 2024-05-23: [IREE joins the LF AI & Data Foundation as a sandbox-stage project](https://lfaidata.foundation/blog/2024/05/23/announcing-iree-a-new-initiative-for-machine-learning-deployment/)
 
 ## Project status

--- a/docs/website/docs/index.md
+++ b/docs/website/docs/index.md
@@ -190,6 +190,7 @@ See how IREE is used:
 
 ### :material-newspaper: Project news
 
+* 2025-04-02: [IREE submits SDXL text-to-image MLPerf inference benchmarks using AMD Instinct™ MI325X](https://rocm.blogs.amd.com/artificial-intelligence/mi325x-accelerates-mlperf-inference/README.html#stable-diffusion-xl-sdxl-text-to-image-mlperf-inference-benchmark)
 * 2024-05-23: [IREE joins the LF AI & Data Foundation as a sandbox-stage project](https://lfaidata.foundation/blog/2024/05/23/announcing-iree-a-new-initiative-for-machine-learning-deployment/)
 
 ### :octicons-broadcast-24: Communication channels

--- a/docs/website/docs/index.md
+++ b/docs/website/docs/index.md
@@ -191,7 +191,7 @@ See how IREE is used:
 ### :material-newspaper: Project news
 
 * 2025-04-02:
-[IREE submits SDXL text-to-image MLPerf inference benchmarksusing AMD Instinct™ MI325X](https://rocm.blogs.amd.com/artificial-intelligence/mi325x-accelerates-mlperf-inference/README.html#stable-diffusion-xl-sdxl-text-to-image-mlperf-inference-benchmark)
+[AMD submitted an IREE-based SDXL implementation to the MLPerf benchmark suite](https://rocm.blogs.amd.com/artificial-intelligence/mi325x-accelerates-mlperf-inference/README.html#stable-diffusion-xl-sdxl-text-to-image-mlperf-inference-benchmark)
 * 2024-05-23:
 [IREE joins the LF AI & Data Foundation as a sandbox-stage project](https://lfaidata.foundation/blog/2024/05/23/announcing-iree-a-new-initiative-for-machine-learning-deployment/)
 

--- a/docs/website/docs/index.md
+++ b/docs/website/docs/index.md
@@ -190,8 +190,10 @@ See how IREE is used:
 
 ### :material-newspaper: Project news
 
-* 2025-04-02: [IREE submits SDXL text-to-image MLPerf inference benchmarks using AMD Instinct™ MI325X](https://rocm.blogs.amd.com/artificial-intelligence/mi325x-accelerates-mlperf-inference/README.html#stable-diffusion-xl-sdxl-text-to-image-mlperf-inference-benchmark)
-* 2024-05-23: [IREE joins the LF AI & Data Foundation as a sandbox-stage project](https://lfaidata.foundation/blog/2024/05/23/announcing-iree-a-new-initiative-for-machine-learning-deployment/)
+* 2025-04-02:
+[IREE submits SDXL text-to-image MLPerf inference benchmarksusing AMD Instinct™ MI325X](https://rocm.blogs.amd.com/artificial-intelligence/mi325x-accelerates-mlperf-inference/README.html#stable-diffusion-xl-sdxl-text-to-image-mlperf-inference-benchmark)
+* 2024-05-23:
+[IREE joins the LF AI & Data Foundation as a sandbox-stage project](https://lfaidata.foundation/blog/2024/05/23/announcing-iree-a-new-initiative-for-machine-learning-deployment/)
 
 ### :octicons-broadcast-24: Communication channels
 


### PR DESCRIPTION
The MLPerf submission announced at https://rocm.blogs.amd.com/artificial-intelligence/mi325x-accelerates-mlperf-inference/README.html#stable-diffusion-xl-sdxl-text-to-image-mlperf-inference-benchmark used [Torch-MLIR](https://github.com/llvm/torch-mlir), [MLIR](https://mlir.llvm.org/), [IREE](https://github.com/iree-org/iree), and [shark-ai](https://github.com/nod-ai/shark-ai).