### PR TITLE
Support `TRACY_MANUAL_LIFETIME=ON`

### DIFF
--- a/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
+++ b/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
@@ -1033,10 +1033,8 @@ bool Invocation::runPipeline(enum iree_compiler_pipeline_t pipeline) {
   if (failed(passManager->run(parsedModule))) {
     return false;
   }
-#if IREE_ENABLE_COMPILER_TRACING
   // Done with the pipeline, mark the start of a new 'frame'.
-  IREE_TRACE_FRAME_MARK();
-#endif
+  IREE_COMPILER_TRACE_FRAME_MARK();
   return true;
 }
 

--- a/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
+++ b/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
@@ -1033,8 +1033,10 @@ bool Invocation::runPipeline(enum iree_compiler_pipeline_t pipeline) {
   if (failed(passManager->run(parsedModule))) {
     return false;
   }
+#if IREE_ENABLE_COMPILER_TRACING
   // Done with the pipeline, mark the start of a new 'frame'.
   IREE_TRACE_FRAME_MARK();
+#endif
   return true;
 }
 

--- a/compiler/src/iree/compiler/Utils/TracingUtils.h
+++ b/compiler/src/iree/compiler/Utils/TracingUtils.h
@@ -44,6 +44,9 @@ enum {
 // Fork of IREE_TRACE_SCOPE.
 #define IREE_COMPILER_TRACE_SCOPE() ZoneScoped
 
+// Fork of IREE_TRACE_FRAME_MARK.
+#define IREE_COMPILER_TRACE_FRAME_MARK() ___tracy_emit_frame_mark(NULL)
+
 // Fork of IREE_TRACE_MESSAGE_DYNAMIC, taking std::string (or llvm::StringRef).
 #define IREE_COMPILER_TRACE_MESSAGE_DYNAMIC(level, value_string)               \
   ___tracy_emit_messageC(value_string.data(), value_string.size(),             \
@@ -71,6 +74,7 @@ createTraceFrameMarkEndPass(llvm::StringRef name = "");
 #else
 #define IREE_COMPILER_TRACE_SCOPE()
 #define IREE_COMPILER_TRACE_MESSAGE_DYNAMIC(level, value_string)
+#define IREE_COMPILER_TRACE_FRAME_MARK()
 #define IREE_TRACE_ADD_BEGIN_FRAME_PASS(passManager, frameName)
 #define IREE_TRACE_ADD_END_FRAME_PASS(passManager, frameName)
 #endif // IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION

--- a/runtime/src/iree/base/tracing/tracy.cc
+++ b/runtime/src/iree/base/tracing/tracy.cc
@@ -92,6 +92,9 @@ static char* iree_tracing_tracy_source_file_callback(void* user_data,
 }
 
 void iree_tracing_tracy_initialize() {
+#ifdef TRACY_MANUAL_LIFETIME
+  tracy::StartupProfiler();
+#endif  // TRACY_MANUAL_LIFETIME
   // Register a single source provider callback with Tracy. Tracy only supports
   // one at a time and the callback must remain valid until program exit.
   tracy::Profiler::SourceCallbackRegister(
@@ -111,6 +114,9 @@ void iree_tracing_tracy_deinitialize() {
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
 #endif  // IREE_PLATFORM_*
+#ifdef TRACY_MANUAL_LIFETIME
+  tracy::ShutdownProfiler();
+#endif  // TRACY_MANUAL_LIFETIME
 }
 
 void iree_tracing_publish_source_file(const void* filename,


### PR DESCRIPTION
This adds support for `TRACY_MANUAL_LIFETIME` by inserting startup/shutdown calls into the `iree_tracing_tracy_initialize`/`iree_tracing_tracy_deinitialize` functions. 

`TRACY_MANUAL_LIFETIME` is described in the tracy docs:
> _2.1.8  Setup for multi-DLL projects_
...
`TRACY_DELAYED_INIT` enables a path where profiler data is gathered into one structure and initialized on
the first request rather than statically at the DLL load at the expense of atomic load on each request to the
profiler data. `TRACY_MANUAL_LIFETIME` flag augments this behavior to provide manual `StartupProfiler`
and `ShutdownProfiler` functions that allow you to create and destroy the profiler data manually. This
manual management removes the need to do an atomic load on each call and lets you define an appropriate
place to free the resources.