### PR TITLE
[codegen][wip] LLVMGPUVectorLowering : unroll and flatten to rank-1 vectors. 

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -112,6 +112,7 @@ iree_compiler_cc_library(
         "EraseHALDescriptorTypeFromMemRef.cpp",
         "ExtractAddressComputation.cpp",
         "FlattenMemRefSubspanPass.cpp",
+        "FlattenVectorExtractInsertPatterns.cpp",
         "FoldAffineMinInDistributedLoops.cpp",
         "FoldTensorExtractOpPass.cpp",
         "FoldTensorSubsetIntoVectorTransferOps.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -105,6 +105,7 @@ iree_cc_library(
     "EraseHALDescriptorTypeFromMemRef.cpp"
     "ExtractAddressComputation.cpp"
     "FlattenMemRefSubspanPass.cpp"
+    "FlattenVectorExtractInsertPatterns.cpp"
     "FoldAffineMinInDistributedLoops.cpp"
     "FoldTensorExtractOpPass.cpp"
     "FoldTensorSubsetIntoVectorTransferOps.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/FlattenVectorExtractInsertPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FlattenVectorExtractInsertPatterns.cpp
@@ -1,0 +1,229 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//===-- FlattenVectorExtractInsertPatterns.cpp --------------------===//
+//
+//===--------------------------------------------------------------===//
+
+#include "iree/compiler/Codegen/Common/Passes.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/Dialect/Vector/Transforms/LoweringPatterns.h"
+#include "mlir/Dialect/Vector/Transforms/VectorRewritePatterns.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_TESTFLATTENVECTOREXTRACTINSERTPASS
+#include "iree/compiler/Codegen/Common/Passes.h.inc"
+
+namespace {
+
+// Get the global offset/position of the extract op in a flat vector.
+FailureOr<int64_t> getGlobalOffset(PatternRewriter &rewriter,
+                                   SmallVector<OpFoldResult> positions,
+                                   VectorType largeType) {
+
+  // Ensure offsets/positions is of the same rank as the large vector
+  // by prepending zeros.
+  assert(positions.size() <= largeType.getRank() &&
+         "positions size should be less than or equal to large vector rank");
+  IntegerAttr zeroFoldResult = rewriter.getIndexAttr(0);
+  while (positions.size() < largeType.getRank()) {
+    positions.push_back(zeroFoldResult);
+  }
+
+  // Compute the global offset. This is essentially the offset of the element
+  // at index `positions` in the vector with row-major striding.
+  int64_t stride{1};
+  int64_t globalOffset{0};
+  for (int64_t i = largeType.getRank() - 1; i >= 0; i--) {
+    OpFoldResult positionFoldRes = positions[i];
+    Attribute positionAttr = dyn_cast<Attribute>(positionFoldRes);
+    if (!positionAttr) {
+      return failure();
+    }
+    int64_t position = cast<IntegerAttr>(positionAttr).getInt();
+    globalOffset += position * stride;
+    stride *= largeType.getDimSize(i);
+  }
+  return globalOffset;
+}
+
+FailureOr<int64_t> getNumberOfElements(Type type) {
+  if (type.isIntOrIndexOrFloat()) {
+    return 1;
+  } else if (auto shapedType = dyn_cast<ShapedType>(type)) {
+    return shapedType.getNumElements();
+  }
+  return failure();
+}
+
+// Convert vector.extract ops with inputs of rank > 1:
+//
+// If the result has a single element, convert to an extract op on
+// a vector of rank-1 with a scalar result.
+//
+// Otherwise, convert to an extract_strided_slice op on a vector of rank-1.
+//
+// In other words: create an extract or extract_strided_slice with the lowest
+// possible value of (rank input + rank output).
+class ConvertExtractOpToRankOneOp final
+    : public OpRewritePattern<vector::ExtractOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(vector::ExtractOp extractOp,
+                                PatternRewriter &rewriter) const override {
+
+    TypedValue<VectorType> large = extractOp.getVector();
+    VectorType largeType = large.getType();
+
+    SmallVector<OpFoldResult> positions = extractOp.getMixedPosition();
+    Location loc = extractOp.getLoc();
+
+    if (largeType.getRank() == 1) {
+      return failure();
+    }
+    VectorType flatLargeType = VectorType::get({largeType.getNumElements()},
+                                               largeType.getElementType());
+
+    Type smallType = extractOp.getType();
+    FailureOr<int64_t> maybeNumberElementsSmall =
+        getNumberOfElements(smallType);
+    if (failed(maybeNumberElementsSmall)) {
+      return failure();
+    }
+    int64_t numberElementsSmall = maybeNumberElementsSmall.value();
+
+    FailureOr<int64_t> maybeGlobalOffset =
+        getGlobalOffset(rewriter, positions, largeType);
+    if (failed(maybeGlobalOffset)) {
+      return failure();
+    }
+    int64_t globalOffset = maybeGlobalOffset.value();
+
+    auto replacement = [&]() -> Value {
+      Value flatLarge =
+          rewriter.createOrFold<vector::ShapeCastOp>(loc, flatLargeType, large);
+
+      // If the extract op's output is a scalar, create another extract to
+      // scalar.
+      if (smallType.isIntOrIndexOrFloat()) {
+        return rewriter.create<vector::ExtractOp>(
+            extractOp.getLoc(), flatLarge, SmallVector<int64_t>{globalOffset});
+      }
+
+      auto strided = rewriter.create<vector::ExtractStridedSliceOp>(
+          extractOp.getLoc(), flatLarge, SmallVector<int64_t>{globalOffset},
+          SmallVector<int64_t>{numberElementsSmall}, SmallVector<int64_t>{1});
+
+      return rewriter.createOrFold<vector::ShapeCastOp>(extractOp.getLoc(),
+                                                        smallType, strided);
+    }();
+
+    rewriter.replaceOp(extractOp, replacement);
+    return success();
+  }
+};
+
+// Convert vector.insert where the destination is rank > 1.
+//
+// If the source is a scalar, convert to a vector.insert op into a vector of
+// rank-1.
+//
+// Otherwise, convert to a vector.insert_strided_slice op into a vector of
+// rank-1.
+//
+// In other words: create an insert or insert_strided_slice with the lowest
+// possible value of (rank source + rank destination).
+class ConvertInsertOpToRankOneOp final
+    : public OpRewritePattern<vector::InsertOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(vector::InsertOp insertOp,
+                                PatternRewriter &rewriter) const override {
+
+    TypedValue<VectorType> large = insertOp.getDest();
+    VectorType largeType = large.getType();
+    if (largeType.getRank() == 1) {
+      return failure();
+    }
+
+    SmallVector<OpFoldResult> positions = insertOp.getMixedPosition();
+    Location loc = insertOp.getLoc();
+
+    Value small = insertOp.getSource();
+    Type smallType = insertOp.getSourceType();
+    auto maybeNumberElementsSmall = getNumberOfElements(smallType);
+    if (failed(maybeNumberElementsSmall)) {
+      return failure();
+    }
+    int64_t numberElementsSmall = maybeNumberElementsSmall.value();
+
+    auto maybeGlobalOffset = getGlobalOffset(rewriter, positions, largeType);
+    if (failed(maybeGlobalOffset)) {
+      return failure();
+    }
+    int64_t globalOffset = maybeGlobalOffset.value();
+
+    // Rank-1 source.
+    VectorType flatLargeType = VectorType::get({largeType.getNumElements()},
+                                               largeType.getElementType());
+    auto flatLarge =
+        rewriter.createOrFold<vector::ShapeCastOp>(loc, flatLargeType, large);
+
+    Value updated = [&]() -> Value {
+      if (smallType.isSignlessIntOrFloat()) {
+        return rewriter.create<vector::InsertOp>(
+            loc, small, flatLarge, SmallVector<int64_t>{globalOffset});
+      }
+      VectorType flatSmallType =
+          VectorType::get({numberElementsSmall}, largeType.getElementType());
+      auto flatSmall =
+          rewriter.createOrFold<vector::ShapeCastOp>(loc, flatSmallType, small);
+      return rewriter.create<vector::InsertStridedSliceOp>(
+          insertOp.getLoc(), flatSmall, flatLarge,
+          SmallVector<int64_t>{globalOffset}, SmallVector<int64_t>{1});
+    }();
+
+    Value replacement = rewriter.createOrFold<vector::ShapeCastOp>(
+        insertOp.getLoc(), largeType, updated);
+
+    rewriter.replaceOp(insertOp, replacement);
+    return success();
+  }
+};
+
+struct TestFlattenVectorExtractInsertPass final
+    : public impl::TestFlattenVectorExtractInsertPassBase<
+          TestFlattenVectorExtractInsertPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<vector::VectorDialect>();
+  }
+
+  void runOnOperation() override {
+    RewritePatternSet patterns(&getContext());
+    // Folding must be disable when applying these patterns, because the
+    // vector.extract op 'folds' extract(shape_cast(x)) -> extract(x), but
+    // the pattern ConvertExtractOpToRankOneOp converts
+    // extract(x) to extract(shape_cast(x)) in some cases.
+    GreedyRewriteConfig config;
+    config.fold = false;
+    populateFlattenVectorExtractInsertPatterns(patterns);
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns),
+                                     config))) {
+      return signalPassFailure();
+    }
+  }
+};
+
+} // namespace
+
+void populateFlattenVectorExtractInsertPatterns(RewritePatternSet &patterns,
+                                                PatternBenefit benefit) {
+  // TODO(newling) Consider adding patterns for maximally reducing the ranks of
+  // vector.insert_strided_slice and vector.extract_strided_slice ops.
+  patterns.insert<ConvertExtractOpToRankOneOp, ConvertInsertOpToRankOneOp>(
+      patterns.getContext(), benefit);
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/ForOpCanonicalizationPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ForOpCanonicalizationPass.cpp
@@ -21,64 +21,37 @@ namespace mlir::iree_compiler {
 
 namespace {
 
-/// Pattern to combine instructions across ForOp boundary. It is common when
-/// doing incremental lowering to generate transient ops that cancel each others
-/// out. Canonicalization usually clean up those operations. When the value is
-/// loop carried, MLIR canonicalization currently doesn't remove the redundant
-/// operations.
-///
-/// This pass allow to workaround MLIR limitation and does ad hoc clean up of
-/// instructions found in IREE. Once we have a more general mechanism in MLIR
-/// this pass can be completely removed.
-/// This pass does this kind of transformation:
-/// ```
-/// %21 = vector.shape_cast %20 : vector<4xf32> to vector<1x4xf32>
-/// %22 = scf.for %arg3 = %c0 to %c4096 step %c4 iter_args(%arg4 = %21)
-///    -> vector<1x4xf32> {
-///    [...]
-///    %100 = vector.shape_cast %arg4 : vector<1x4xf32> to vector<4xf32>
-///    [...]
-///    %109 = vector.shape_cast %108 : vector<4xf32> to vector<1x4xf32>
-///    scf.yield %109 : vector<1x4xf32>
-///  }
-///  %24 = vector.shape_cast %22 : vector<1x4xf32> to vector<4xf32>
-/// ```
-/// ->
-/// ```
-/// %22 = scf.for %arg3 = %c0 to %c4096 step %c4 iter_args(%arg4 = %20)
-///    -> vector<4xf32> {
-///    [...]
-///    scf.yield %108 : vector<4xf32>
-///  }
-/// ```
 struct CanonicalizeForOpInductionVarShape final
     : public OpRewritePattern<scf::ForOp> {
   using OpRewritePattern<scf::ForOp>::OpRewritePattern;
 
-  Value FoldCarryDep(scf::ForOp forOp, Operation *ivUser,
-                     Operation *ivDef) const {
-    if (auto shapeCast = dyn_cast<vector::ShapeCastOp>(ivUser)) {
-      if (auto souceOp = dyn_cast<vector::ShapeCastOp>(ivDef)) {
-        if (shapeCast.getType() == souceOp.getSource().getType()) {
-          return souceOp.getSource();
-        }
-      }
-    } else if (auto extractOp = dyn_cast<vector::ExtractOp>(ivUser)) {
-      if (auto broadcastOp = dyn_cast<vector::BroadcastOp>(ivDef)) {
-        if (extractOp.getType() == broadcastOp.getSourceType()) {
-          return broadcastOp.getSource();
-        }
-      }
-    } else if (auto targetOp = dyn_cast<UnrealizedConversionCastOp>(ivUser)) {
-      if (auto sourceOp = dyn_cast<UnrealizedConversionCastOp>(ivDef)) {
-        if (sourceOp->getNumOperands() == 1 && targetOp->getNumResults() == 1 &&
-            sourceOp->getOperandTypes().front() ==
-                targetOp.getResultTypes().front()) {
-          return sourceOp.getInputs().front();
-        }
-      }
+  // Return true if it might be possible to yield the operand of `op` instead of
+  // its result.
+  bool canFoldEnd(Operation *op) const {
+    if (!isa<vector::ShapeCastOp, vector::BroadcastOp,
+             UnrealizedConversionCastOp>(op)) {
+      return false;
     }
-    return Value();
+    if (op->getNumOperands() != 1) {
+      return false;
+    }
+    return true;
+  }
+
+  // Return true if `op` (user of induction variable) can be folded if the
+  // induction variable is changed to have type `type`.
+  bool canFoldStart(Operation *op, Type type) const {
+    if (op->getNumResults() != 1) {
+      return false;
+    }
+    if (!isa<vector::ShapeCastOp, vector::ExtractOp,
+             UnrealizedConversionCastOp>(op)) {
+      return false;
+    }
+    if (op->getResult(0).getType() != type) {
+      return false;
+    }
+    return true;
   }
 
   // Transfer the body of `source` into `dest` and update the terminator of
@@ -117,40 +90,80 @@ struct CanonicalizeForOpInductionVarShape final
 
   LogicalResult matchAndRewrite(scf::ForOp forOp,
                                 PatternRewriter &rewriter) const override {
+
     SmallVector<unsigned, 8> iteratorFolded;
     SmallVector<Operation *, 8> resultOps;
     auto terminator = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
     auto returnValues = llvm::to_vector<8>(terminator.getOperands());
     auto initArgs = llvm::to_vector<8>(forOp.getInitArgs());
-    for (auto [index, iterArg] : llvm::enumerate(forOp.getRegionIterArgs())) {
-      if (!iterArg.hasOneUse())
-        continue;
-      Operation *op = iterArg.use_begin()->getOwner();
-      if (!isa<vector::ShapeCastOp, vector::ExtractOp,
-               UnrealizedConversionCastOp>(op)) {
-        continue;
-      }
+    for (uint32_t index = 0; index < forOp.getNumRegionIterArgs(); ++index) {
+
       Operation *returnValDef = returnValues[index].getDefiningOp();
+
       // Currently we don't track usage through block arguments.
       if (!returnValDef) {
         continue;
       }
-      Value newReturn = FoldCarryDep(forOp, op, returnValDef);
-      if (!newReturn)
+
+      if (!canFoldEnd(returnValDef)) {
         continue;
+      }
+      Value newReturn = returnValDef->getOperand(0);
+
+      BlockArgument iterArg = forOp.getRegionIterArg(index);
+
+      // Check that all of the users of the induction variable can be folded,
+      // and if so return the final user of the induction variable.
+      Operation *finalIvUser = [&]() -> Operation * {
+        Operation *op{nullptr};
+        for (auto &use : iterArg.getUses()) {
+          op = use.getOwner();
+          if (!canFoldStart(op, newReturn.getType())) {
+            return nullptr;
+          }
+        }
+        return op;
+      }();
+
+      if (!finalIvUser) {
+        continue;
+      }
+
       iteratorFolded.push_back(index);
       resultOps.push_back(returnValDef);
       returnValues[index] = newReturn;
 
+      // Create a clone of the user of the induction variable. Clone will be
+      // used as induction variable in new scf.for.
+      //
+      // An example, where %new_clone is clone of %to_clone:
+      // ```
+      // %0 = scf.for %arg0 = %c1 to %c3 step %c1 iter_args(%arg1 = %cst) ->
+      // (vector<4xf32>) {
+      //   %to_clone = vector.extract %arg1[%arg0] : f32 from vector<4xf32>
+      //   ...
+      // }
+      // %new_clone = vector.extact %cst[%c1] : f32 from vector<4xf32>
+      // ```
       IRMapping mapping;
       mapping.map(iterArg, initArgs[index]);
-      initArgs[index] = rewriter.clone(*op, mapping)->getResult(0);
+
+      std::optional<SmallVector<Value>> loopIndVars =
+          forOp.getLoopInductionVars();
+      assert(loopIndVars.has_value() && loopIndVars.value().size() == 1 &&
+             "scf.for must have 1 loop induction variable");
+      Value loopIndVar = loopIndVars.value()[0];
+      Value start = forOp.getLowerBound();
+      mapping.map(loopIndVar, start);
+      initArgs[index] = rewriter.clone(*finalIvUser, mapping)->getResult(0);
     }
     if (iteratorFolded.empty())
       return failure();
+
     auto newLoop = rewriter.create<scf::ForOp>(
         forOp.getLoc(), forOp.getLowerBound(), forOp.getUpperBound(),
         forOp.getStep(), initArgs);
+
     SmallVector<Value> newReturnVals = transferBody(
         forOp.getBody(), newLoop.getBody(), returnValues, rewriter);
 
@@ -160,15 +173,18 @@ struct CanonicalizeForOpInductionVarShape final
     for (auto [index, iter] : llvm::enumerate(iteratorFolded)) {
       IRMapping mapping;
       mapping.map(newReturnVals[iter], newLoop.getResult(iter));
-      repResults[index] =
+      repResults[iter] =
           rewriter.clone(*resultOps[index], mapping)->getResult(0);
-      Operation *oldOp =
-          newLoop.getRegionIterArgs()[index].use_begin()->getOwner();
-      assert(oldOp->getNumResults() == 1 && "expected single result");
-      rewriter.replaceAllUsesWith(oldOp->getResult(0),
-                                  newLoop.getRegionIterArgs()[index]);
+
+      for (auto &use : newLoop.getRegionIterArgs()[iter].getUses()) {
+        Operation *oldOp = use.getOwner();
+        assert(oldOp->getNumResults() == 1 && "expected single result");
+        rewriter.replaceAllUsesWith(oldOp->getResult(0),
+                                    newLoop.getRegionIterArgs()[iter]);
+      }
     }
     rewriter.replaceOp(forOp, repResults);
+
     return success();
   }
 };
@@ -314,4 +330,10 @@ struct ForOpCanonicalizationPass final
 };
 
 } // namespace
+
+void populateForOpInductionVarShapePatterns(RewritePatternSet &patterns,
+                                            PatternBenefit benefit) {
+  patterns.insert<CanonicalizeForOpInductionVarShape>(patterns.getContext(),
+                                                      benefit);
+}
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -625,15 +625,6 @@ def TensorToVectorVectorizePadPass :
                 "control flows";
 }
 
-def TestExecutablePreprocessingPass :
-    Pass<"iree-codegen-test-executable-preprocessing", ""> {
-  let summary = "Tests iree-hal-preprocess-executables-with behavior.";
-}
-
-def TestPartitionableLoopsInterfacePass :
-    Pass<"iree-codegen-test-partitionable-loops-interface", ""> {
-  let summary = "Test the PartitionableLoopsInterface";
-}
 
 def TileAndDistributeToWorkgroupsPass :
     InterfacePass<"iree-codegen-tile-and-distribute-to-workgroups", "mlir::FunctionOpInterface"> {
@@ -744,5 +735,25 @@ def VerifyWorkgroupDistributionPass :
     side effects are contained within a workgroup distributed loop.
   }];
 }
+
+//------------------------------------------------------------------------------
+// Test Passes
+//------------------------------------------------------------------------------
+
+def TestExecutablePreprocessingPass :
+    Pass<"iree-codegen-test-executable-preprocessing", ""> {
+  let summary = "Tests iree-hal-preprocess-executables-with behavior.";
+}
+
+def TestPartitionableLoopsInterfacePass :
+    Pass<"iree-codegen-test-partitionable-loops-interface", ""> {
+  let summary = "Test the PartitionableLoopsInterface";
+}
+
+def TestFlattenVectorExtractInsertPass :
+ Pass<"iree-codegen-test-flatten-vector-extract-insert", ""> {
+  let summary = "Pass to test patterns that flatten vector dialect extract and insert ops";
+}
+
 
 #endif // IREE_CODEGEN_COMMON_PASSES

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -45,6 +45,7 @@ iree_lit_test_suite(
             "erase_hal_descriptor_type.mlir",
             "extract_address_computation.mlir",
             "flatten_memref_subspan.mlir",
+            "flatten_vector_extract_insert.mlir",
             "fold_affine_min_in_distributed_loops.mlir",
             "fold_affine_min_of_block_id.mlir",
             "fold_tensor_extract_op.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -41,6 +41,7 @@ iree_lit_test_suite(
     "erase_hal_descriptor_type.mlir"
     "extract_address_computation.mlir"
     "flatten_memref_subspan.mlir"
+    "flatten_vector_extract_insert.mlir"
     "fold_affine_min_in_distributed_loops.mlir"
     "fold_affine_min_of_block_id.mlir"
     "fold_tensor_extract_op.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/flatten_vector_extract_insert.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/flatten_vector_extract_insert.mlir
@@ -1,0 +1,122 @@
+// RUN: iree-opt --split-input-file --iree-codegen-test-flatten-vector-extract-insert %s | FileCheck %s
+
+
+// before : extract 3 -> 0
+// after  : extract 1 -> 0
+// CHECK: func.func @extract_to_rank_one_r0(%[[ARG0:.*]]: vector<6x5x4xf32>) -> f32
+// CHECK: %[[SHAPE_CAST:.*]] = vector.shape_cast %[[ARG0]] : vector<6x5x4xf32> to vector<120xf32>
+// CHECK: %[[EXTRACT:.*]] = vector.extract %[[SHAPE_CAST]][50] : f32 from vector<120xf32>
+// CHECK: return %[[EXTRACT]] : f32
+func.func @extract_to_rank_one_r0(%arg0: vector<6x5x4xf32>) -> f32 {
+  %0 = vector.extract %arg0[2, 2, 2] : f32 from vector<6x5x4xf32>
+  return %0 : f32
+}
+
+// -----
+
+// before  : extract 1 -> 0
+// after   : extract 1 -> 0
+// CHECK: func.func @extract_to_rank_one_r1_r0(%[[ARG0:.*]]: vector<1xf32>) -> f32
+// CHECK: %[[EXTRACT:.*]] = vector.extract %[[ARG0]][] : f32 from vector<1xf32>
+// CHECK: return %[[EXTRACT]] : f32
+func.func @extract_to_rank_one_r1_r0(%arg0: vector<1xf32>) -> f32 {
+  %0 = vector.extract %arg0[] : f32 from vector<1xf32>
+  return %0 : f32
+}
+
+// -----
+
+// before  : extract 3 -> 1
+// after   : extract_strided_slice 1 -> 1
+// CHECK: func.func @extract_to_rank_one_r1(%[[ARG0:.*]]: vector<6x5x4xf32>) -> vector<4xf32>
+// CHECK: %[[SHAPE_CAST:.*]] = vector.shape_cast %[[ARG0]] : vector<6x5x4xf32> to vector<120xf32>
+// CHECK: %[[EXTRACT:.*]] = vector.extract_strided_slice %[[SHAPE_CAST]] {offsets = [48], sizes = [4], strides = [1]} : vector<120xf32> to vector<4xf32>
+// CHECK: return %[[EXTRACT]] : vector<4xf32>
+func.func @extract_to_rank_one_r1(%arg0: vector<6x5x4xf32>) -> vector<4xf32> {
+  %0 = vector.extract %arg0[2, 2] : vector<4xf32> from vector<6x5x4xf32>
+  return %0 : vector<4xf32>
+}
+
+// -----
+
+// before  : extract 3 -> 2
+// after   : extract_strided_slice 1 -> 1
+// CHECK: func.func @extract_to_rank_one_r2(%[[ARG0:.*]]: vector<6x5x4xf32>) -> vector<5x4xf32>
+// CHECK: %[[SHAPE_CAST:.*]] = vector.shape_cast %[[ARG0]] : vector<6x5x4xf32> to vector<120xf32>
+// CHECK: %[[EXTRACT:.*]] = vector.extract_strided_slice %[[SHAPE_CAST]] {offsets = [40], sizes = [20], strides = [1]} : vector<120xf32> to vector<20xf32>
+// CHECK: %[[SHAPE_CAST1:.*]] = vector.shape_cast %[[EXTRACT]] : vector<20xf32> to vector<5x4xf32>
+func.func @extract_to_rank_one_r2(%arg0: vector<6x5x4xf32>) -> vector<5x4xf32> {
+  %0 = vector.extract %arg0[2] : vector<5x4xf32> from vector<6x5x4xf32>
+  return %0 : vector<5x4xf32>
+}
+
+// -----
+
+// before  : extract 3 -> 3
+// after   : extract_strided_slice 1 -> 1
+// CHECK: func.func @extract_to_rank_one_r3(%[[ARG0:.*]]: vector<6x5x4xf32>) -> vector<6x5x4xf32>
+// CHECK: %[[SHAPE_CAST:.*]] = vector.shape_cast %[[ARG0]] : vector<6x5x4xf32> to vector<120xf32>
+// CHECK: %[[EXTRACT:.*]] = vector.extract_strided_slice %[[SHAPE_CAST]] {offsets = [0], sizes = [120], strides = [1]} : vector<120xf32> to vector<120xf32>
+// CHECK: %[[SHAPE_CAST1:.*]] = vector.shape_cast %[[EXTRACT]] : vector<120xf32> to vector<6x5x4xf32>
+func.func @extract_to_rank_one_r3(%arg0: vector<6x5x4xf32>) -> vector<6x5x4xf32> {
+  %0 = vector.extract %arg0[] : vector<6x5x4xf32> from vector<6x5x4xf32>
+  return %0 : vector<6x5x4xf32>
+}
+
+
+
+// -----
+
+// before  :  insert 2 into 3
+// after   :  insert_strided_slice 1 into 1
+// CHECK: func.func @insert_to_rank_one_r2(%[[ARG0:.*]]: vector<6x5x4xf32>, %[[ARG1:.*]]: vector<5x4xf32>) -> vector<6x5x4xf32>
+// CHECK: %[[SHAPE_CAST:.*]] = vector.shape_cast %[[ARG0]] : vector<6x5x4xf32> to vector<120xf32>
+// CHECK: %[[SHAPE_CAST1:.*]] = vector.shape_cast %[[ARG1]] : vector<5x4xf32> to vector<20xf32>
+// CHECK: %[[INSERT:.*]] = vector.insert_strided_slice %[[SHAPE_CAST1]], %[[SHAPE_CAST]] {offsets = [40], strides = [1]} : vector<20xf32> into vector<120xf32>
+// CHECK: %[[SHAPE_CAST2:.*]] = vector.shape_cast %[[INSERT]] : vector<120xf32> to vector<6x5x4xf32>
+// CHECK: return %[[SHAPE_CAST2]] : vector<6x5x4xf32>
+func.func @insert_to_rank_one_r2(%arg0: vector<6x5x4xf32>, %arg1: vector<5x4xf32>) -> vector<6x5x4xf32> {
+  %0 = vector.insert %arg1, %arg0 [2] : vector<5x4xf32> into vector<6x5x4xf32>
+  return %0 : vector<6x5x4xf32>
+}
+
+// -----
+
+// before  : insert 1 into 3
+// after   : insert_strided_slice 1 into 1
+// CHECK: func.func @insert_to_rank_one_r1(%[[ARG0:.*]]: vector<6x5x4xf32>, %[[ARG1:.*]]: vector<4xf32>) -> vector<6x5x4xf32>
+// CHECK: %[[SHAPE_CAST:.*]] = vector.shape_cast %[[ARG0]] : vector<6x5x4xf32> to vector<120xf32>
+// CHECK: %[[INSERT:.*]] = vector.insert_strided_slice %[[ARG1]], %[[SHAPE_CAST]] {offsets = [48], strides = [1]} : vector<4xf32> into vector<120xf32>
+// CHECK: %[[SHAPE_CAST1:.*]] = vector.shape_cast %[[INSERT]] : vector<120xf32> to vector<6x5x4xf32>
+// CHECK: return %[[SHAPE_CAST1]] : vector<6x5x4xf32>
+func.func @insert_to_rank_one_r1(%arg0: vector<6x5x4xf32>, %arg1: vector<4xf32>) -> vector<6x5x4xf32> {
+  %0 = vector.insert %arg1, %arg0 [2, 2] : vector<4xf32> into vector<6x5x4xf32>
+  return %0 : vector<6x5x4xf32>
+}
+
+// -----
+
+
+// before  : insert 0 into 3
+// after   : insert 0 into 1
+// CHECK: func.func @insert_to_rank_one_r0(%[[ARG0:.*]]: vector<6x5x4xf32>, %[[ARG1:.*]]: f32) -> vector<6x5x4xf32>
+// CHECK: %[[SHAPE_CAST:.*]] = vector.shape_cast %[[ARG0]] : vector<6x5x4xf32> to vector<120xf32>
+// CHECK: %[[INSERT:.*]] = vector.insert %[[ARG1]], %[[SHAPE_CAST]] [50] : f32 into vector<120xf32>
+// CHECK: %[[SHAPE_CAST1:.*]] = vector.shape_cast %[[INSERT]] : vector<120xf32> to vector<6x5x4xf32>
+// CHECK: return %[[SHAPE_CAST1]] : vector<6x5x4xf32>
+func.func @insert_to_rank_one_r0(%arg0: vector<6x5x4xf32>, %arg1: f32) -> vector<6x5x4xf32> {
+  %0 = vector.insert %arg1, %arg0 [2, 2, 2] : f32 into vector<6x5x4xf32>
+  return %0 : vector<6x5x4xf32>
+}
+
+// -----
+
+// before  : insert 0 into 1
+// after   : insert 0 into 1
+// CHECK: func.func @insert_to_rank_one_r0_r1(%[[ARG0:.*]]: vector<4xf32>, %[[ARG1:.*]]: f32) -> vector<4xf32>
+// CHECK: %[[INSERT:.*]] = vector.insert %[[ARG1]], %[[ARG0]] [2] : f32 into vector<4xf32>
+// CHECK: return %[[INSERT]] : vector<4xf32>
+func.func @insert_to_rank_one_r0_r1(%arg0: vector<4xf32>, %arg1: f32) -> vector<4xf32> {
+  %0 = vector.insert %arg1, %arg0 [2] : f32 into vector<4xf32>
+  return %0 : vector<4xf32>
+}

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
@@ -4,12 +4,16 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/LLVMGPU/Passes.h"
 #include "mlir/Conversion/VectorToSCF/VectorToSCF.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Dialect/Vector/Transforms/LoweringPatterns.h"
+#include "mlir/Dialect/Vector/Transforms/VectorRewritePatterns.h"
 #include "mlir/Dialect/Vector/Transforms/VectorTransforms.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
@@ -81,8 +85,103 @@ struct PromoteContractOperands final
   }
 };
 
+SmallVector<int64_t> getWithLeadingOnes(VectorType vectorType) {
+  SmallVector<int64_t> nativeSize(vectorType.getRank(), 1);
+  if (vectorType.getRank() > 0) {
+    nativeSize.back() = vectorType.getShape().back();
+  }
+  return nativeSize;
+}
+
+// Example of unrolling with native shape chosen based on the result's final
+// dimension. In this case the result is a 4x2 vector, so the 'native shape' is
+// 1x2.
+//
+// clang-format off
+//   %transposed = vector.transpose %cst, [1,0] : vector<2x4xf32> to vector<4x2xf32>
+// clang-format on
+//
+//  becomes
+//
+// clang-format off
+//   %cst = arith.constant dense<0.000000e+00> : vector<4x2xf32>
+//   %0 = vector.extract_strided_slice %arg0 {offsets = [0, 0], sizes = [2, 1], strides = [1, 1]} : vector<2x4xf32> to vector<2x1xf32>
+//   %1 = vector.transpose %0, [1, 0] : vector<2x1xf32> to vector<1x2xf32>
+//   %2 = vector.insert_strided_slice %1, %cst {offsets = [0, 0], strides = [1, 1]} : vector<1x2xf32> into vector<4x2xf32>
+//   %3 = vector.extract_strided_slice %arg0 {offsets = [0, 1], sizes = [2, 1], strides = [1, 1]} : vector<2x4xf32> to vector<2x1xf32>
+//   %4 = vector.transpose %3, [1, 0] : vector<2x1xf32> to vector<1x2xf32>
+//   %5 = vector.insert_strided_slice %4, %2 {offsets = [1, 0], strides = [1, 1]} : vector<1x2xf32> into vector<4x2xf32>
+//   [...]
+// clang-format on
+//
+//
+// TODO(newling) Further analysis can improve this. For example flattening
+// out unit dimensions and canonicalizations might help. Example:
+//
+// clang-format off
+//   %t = vector.transpose %cst, [0,2,1] : vector<10x1x4xf32> to vector<10x4x1xf32>
+// clang-format on
+//
+// should ideally not result in 40 extract-insert pairs of single f32 elements.
+SmallVector<int64_t> getNativeVectorShapeImpl(vector::TransposeOp op) {
+  return getWithLeadingOnes(op.getResultVectorType());
+}
+
+SmallVector<int64_t> getNativeVectorShapeImpl(vector::GatherOp op) {
+  return getWithLeadingOnes(op.getVectorType());
+}
+
+SmallVector<int64_t> getNativeVectorShapeImpl(vector::ReductionOp op) {
+  return getWithLeadingOnes(op.getSourceVectorType());
+}
+
+// As we do unrolling after lowering vector operations, it's not necessary to
+// provide an unroll shape for most ops (as compared to SPIRV).
+//
+// Unrolling here assumes that the input has already been tiled such that the
+// inner-most dimensions of vectors are the optimal hardware vector size to
+// operate on.
+std::optional<SmallVector<int64_t>> getNativeVectorShape(Operation *op) {
+
+  // Unroll shape for elementwise operations. Example:
+  //
+  // clang-format off
+  //   %2 = arith.truncf %1 : vector<10x4xf32> to vector<10x4xf16>
+  // clang-format on
+  //
+  // will be unrolled to 10 arith.truncf operations on vectors of shape 1x4.
+  if (OpTrait::hasElementwiseMappableTraits(op) && op->getNumResults() == 1) {
+    if (auto vecType = llvm::dyn_cast<VectorType>(op->getResultTypes()[0])) {
+      return getWithLeadingOnes(vecType);
+    }
+  }
+
+  return TypeSwitch<Operation *, std::optional<SmallVector<int64_t>>>(op)
+      .Case<vector::ReductionOp, vector::TransposeOp, vector::GatherOp>(
+          [](auto typedOp) { return getNativeVectorShapeImpl(typedOp); })
+      .Default([](Operation *) { return std::nullopt; });
+}
+
+// Duplicate of
+// https://github.com/llvm/llvm-project/pull/133988
+// Pattern to rewrite a ShapeCast(PoisonOp) -> PoisonOp.
+class ShapeCastPoisonFolder final
+    : public OpRewritePattern<vector::ShapeCastOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(vector::ShapeCastOp cast,
+                                PatternRewriter &rewriter) const override {
+    if (!cast.getSource().getDefiningOp<ub::PoisonOp>())
+      return failure();
+    rewriter.replaceOpWithNewOp<ub::PoisonOp>(cast, cast.getType());
+    return success();
+  }
+};
+
 struct LLVMGPUVectorLoweringPass final
     : impl::LLVMGPUVectorLoweringPassBase<LLVMGPUVectorLoweringPass> {
+  using impl::LLVMGPUVectorLoweringPassBase<
+      LLVMGPUVectorLoweringPass>::LLVMGPUVectorLoweringPassBase;
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<affine::AffineDialect>();
     registry.insert<memref::MemRefDialect>();
@@ -92,22 +191,23 @@ struct LLVMGPUVectorLoweringPass final
   void runOnOperation() override {
     auto funcOp = getOperation();
 
+    MLIRContext *context = funcOp.getContext();
+
     {
       // Lower high level vector operations like contract or multidim reduce ops
       // to lower level vector ops.
-      RewritePatternSet contractLoweringPatterns(funcOp.getContext());
+      RewritePatternSet contractLoweringPatterns(context);
       auto options =
           vector::VectorTransformsOptions().setVectorTransformsOptions(
               vector::VectorContractLowering::OuterProduct);
       vector::populateVectorTransferPermutationMapLoweringPatterns(
           contractLoweringPatterns);
       vector::TransposeOp::getCanonicalizationPatterns(contractLoweringPatterns,
-                                                       funcOp.getContext());
+                                                       context);
       vector::populateVectorBroadcastLoweringPatterns(contractLoweringPatterns);
       vector::populateVectorContractLoweringPatterns(
           contractLoweringPatterns, options.vectorContractLowering);
-      contractLoweringPatterns.add<PromoteContractOperands>(
-          funcOp->getContext());
+      contractLoweringPatterns.add<PromoteContractOperands>(context);
       vector::populateVectorGatherLoweringPatterns(contractLoweringPatterns);
       vector::populateVectorMaskOpLoweringPatterns(contractLoweringPatterns);
       vector::populateVectorShapeCastLoweringPatterns(contractLoweringPatterns);
@@ -120,7 +220,7 @@ struct LLVMGPUVectorLoweringPass final
       }
     }
 
-    RewritePatternSet vectorToLoopsPatterns(&getContext());
+    RewritePatternSet vectorToLoopsPatterns(context);
     VectorTransferToSCFOptions vectorToSCFOptions;
     vectorToSCFOptions.enableFullUnroll();
     populateVectorToSCFConversionPatterns(vectorToLoopsPatterns,
@@ -130,6 +230,94 @@ struct LLVMGPUVectorLoweringPass final
     if (failed(
             applyPatternsGreedily(funcOp, std::move(vectorToLoopsPatterns)))) {
       return signalPassFailure();
+    }
+
+    if (!unroll && flatten) {
+      funcOp->emitOpError("can only flatten if unrolled, cannot have ")
+          << "unroll=false and flatten=true";
+      return signalPassFailure();
+    }
+
+    if (!unroll) {
+      return;
+    }
+
+    // Canonicalize in preparation for unrolling.
+    {
+      RewritePatternSet patterns(context);
+      vector::InsertOp::getCanonicalizationPatterns(patterns, context);
+      vector::ExtractOp::getCanonicalizationPatterns(patterns, context);
+      vector::BroadcastOp::getCanonicalizationPatterns(patterns, context);
+      vector::ShapeCastOp::getCanonicalizationPatterns(patterns, context);
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
+        return signalPassFailure();
+      }
+    }
+
+    // Unroll vector operations to the optimal size for a single thread to
+    // operate on.
+    {
+      RewritePatternSet patterns(context);
+      auto opts = vector::UnrollVectorOptions().setNativeShapeFn(
+          [=](auto op) { return getNativeVectorShape(op); });
+      vector::populateVectorUnrollPatterns(patterns, opts);
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
+        return signalPassFailure();
+      }
+    }
+
+    if (!flatten) {
+      return;
+    }
+
+    // Now lower vector transpose ops. TODO(newling) unify the approach
+    // of lowering transpose, there are 2 odd things about needing to
+    // do it here: 1) why not lowered with the other ops? 2) Why do we
+    // need to unroll it before lowering it?
+    //
+    // This converts transpose ops into extract and insert pairs, in preparation
+    // of further transformations to canonicalize/cancel.
+    {
+      RewritePatternSet patterns(context);
+      auto options =
+          vector::VectorTransformsOptions().setVectorTransposeLowering(
+              vector::VectorTransposeLowering::EltWise);
+      vector::populateVectorTransposeLoweringPatterns(
+          patterns, options.vectorTransposeLowering);
+      vector::populateVectorShapeCastLoweringPatterns(patterns);
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
+        return signalPassFailure();
+      }
+    }
+
+    // Cast away leading 1 dimensions, and related canonicalizers.
+    {
+      RewritePatternSet patterns(context);
+      vector::populateCastAwayVectorLeadingOneDimPatterns(patterns);
+      vector::populateVectorInsertExtractStridedSliceDecompositionPatterns(
+          patterns);
+      vector::ExtractOp::getCanonicalizationPatterns(patterns, context);
+      vector::BroadcastOp::getCanonicalizationPatterns(patterns, context);
+      vector::ShapeCastOp::getCanonicalizationPatterns(patterns, context);
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
+        return signalPassFailure();
+      }
+    }
+
+    // Reduce rank of ops with vector.shape_casts, and hope that they cancel
+    // with each other.
+    {
+      RewritePatternSet patterns(context);
+      // extract(shape_cast(x)) gets 'folded' to extract(x), which can prevent
+      // shape_cast cancelling, so disabling folding in this set of patterns.
+      GreedyRewriteConfig config;
+      config.fold = false;
+      populateFlattenVectorExtractInsertPatterns(patterns);
+      patterns.insert<ShapeCastPoisonFolder>(context);
+      populateForOpInductionVarShapePatterns(patterns);
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns), config))) {
+        return signalPassFailure();
+      }
     }
   }
 };

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
@@ -119,6 +119,20 @@ def LLVMGPUVectorDistributePass :
 def LLVMGPUVectorLoweringPass :
     InterfacePass<"iree-llvmgpu-vector-lowering", "mlir::FunctionOpInterface"> {
   let summary = "Pass to lower Vector ops before conversion to LLVM.";
+  let description = [{
+     This pass lowers, unrolls, and flattens higher-level vector operations with
+     rank>1 vector operand/results, to a smaller set of rank-1 vector operations
+     whose operand/result sizes correspond to HW vector instructions.
+  }];
+
+  let options = [
+    Option<"unroll", "unroll", "bool", /*default=*/"true",
+           "Controls whether to perform unrolling after inital vector lowering.">,
+    Option<"flatten", "flatten",
+           "bool", /*default=*/"true",
+           "Controls whether to perform flattening after vector unrolling.">,
+  ];
+
 }
 
 def LLVMGPUVectorToGPUPass :

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_mma_sync_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_mma_sync_pipeline_test.mlir
@@ -3,7 +3,6 @@
 // Verify that a simple element wise op gets lowered succefully all the way to
 // nvvm/llvm dialect via mma.sync path.
 
-// -----
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -147,13 +146,7 @@ hal.executable @mma_fused_f32 {
 //          CHECK:   nvvm.ldmatrix{{.*}} : (!llvm.ptr<3>) -> !llvm.struct<(i32, i32, i32, i32)>
 //  CHECK-COUNT-4:   llvm.extractvalue{{.*}} : !llvm.struct<(i32, i32, i32, i32)>
 //          CHECK:   llvm.load{{.*}} : !llvm.ptr<3> -> f32
-//          CHECK:   llvm.insertvalue{{.*}} : !llvm.array<2 x vector<1xf32>>
-//          CHECK:   llvm.load{{.*}} : !llvm.ptr<3> -> f32
-//          CHECK:   llvm.insertvalue{{.*}} : !llvm.array<2 x vector<1xf32>>
-//          CHECK:   llvm.load{{.*}} : !llvm.ptr<3> -> f32
-//          CHECK:   llvm.insertvalue{{.*}} : !llvm.array<2 x vector<1xf32>>
-//          CHECK:   llvm.load{{.*}} : !llvm.ptr<3> -> f32
-//          CHECK:   llvm.insertvalue{{.*}} : !llvm.array<2 x vector<1xf32>>
+//  CHECK-COUNT-4:   llvm.insertvalue{{.*}} : !llvm.array<2 x vector<1xf32>>
 //          CHECK:   llvm.br
 //          CHECK:   nvvm.ldmatrix{{.*}} : (!llvm.ptr<3>) -> !llvm.struct<(i32, i32, i32, i32)>
 //  CHECK-COUNT-4:   llvm.extractvalue{{.*}} : !llvm.struct<(i32, i32, i32, i32)>
@@ -164,13 +157,7 @@ hal.executable @mma_fused_f32 {
 //          CHECK:   nvvm.ldmatrix{{.*}} : (!llvm.ptr<3>) -> !llvm.struct<(i32, i32, i32, i32)>
 //  CHECK-COUNT-4:   llvm.extractvalue{{.*}} : !llvm.struct<(i32, i32, i32, i32)>
 //          CHECK:   llvm.load{{.*}} : !llvm.ptr<3> -> f32
-//          CHECK:   llvm.insertvalue{{.*}} : !llvm.array<2 x vector<1xf32>>
-//          CHECK:   llvm.load{{.*}} : !llvm.ptr<3> -> f32
-//          CHECK:   llvm.insertvalue{{.*}} : !llvm.array<2 x vector<1xf32>>
-//          CHECK:   llvm.load{{.*}} : !llvm.ptr<3> -> f32
-//          CHECK:   llvm.insertvalue{{.*}} : !llvm.array<2 x vector<1xf32>>
-//          CHECK:   llvm.load{{.*}} : !llvm.ptr<3> -> f32
-//          CHECK:   llvm.insertvalue{{.*}} : !llvm.array<2 x vector<1xf32>>
+//  CHECK-COUNT-4:   llvm.insertvalue{{.*}} : !llvm.array<2 x vector<1xf32>>
 //  CHECK-COUNT-2:   nvvm.mma.sync {{.*}} {layoutA = #nvvm.mma_layout<row>, layoutB = #nvvm.mma_layout<col>, multiplicandAPtxType = #nvvm.mma_type<tf32>, multiplicandBPtxType = #nvvm.mma_type<tf32>, shape = #nvvm.shape<m = 16, n = 8, k = 8>} : (i32, i32, f32) -> !llvm.struct<(f32, f32, f32, f32)>
 //          CHECK:   llvm.br
 //      CHECK-NOT:   nvvm.mma.sync

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-llvmgpu-vector-lowering,canonicalize,cse))" --split-input-file %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-llvmgpu-vector-lowering{unroll=0 flatten=0},canonicalize,cse))" --split-input-file %s | FileCheck %s
 
 module {
   func.func @broadcast_read_lowering(%arg0: memref<4096x32xf16>) -> vector<1x8xf16> {

--- a/compiler/src/iree/compiler/Tools/init_mlir_dialects.h
+++ b/compiler/src/iree/compiler/Tools/init_mlir_dialects.h
@@ -53,6 +53,7 @@
 #include "mlir/Dialect/Tensor/TransformOps/TensorTransformOps.h"
 #include "mlir/Dialect/Transform/IR/TransformDialect.h"
 #include "mlir/Dialect/Transform/LoopExtension/LoopExtension.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Dialect/Vector/TransformOps/VectorTransformOps.h"
 
@@ -92,6 +93,7 @@ inline void registerMlirDialects(DialectRegistry &registry) {
                   arm_sme::ArmSMEDialect,
                   func::FuncDialect,
                   mlir::arith::ArithDialect,
+                  mlir::ub::UBDialect,
                   vector::VectorDialect,
                   tensor::TensorDialect,
                   transform::TransformDialect,


### PR DESCRIPTION
This PR has a combination of commits that are being split out, so far: 
https://github.com/llvm/llvm-project/pull/133988
https://github.com/llvm/llvm-project/pull/134939
https://github.com/iree-org/iree/pull/20444
https://github.com/iree-org/iree/pull/20486

Currently after the `LLVMGPUVectorLowering` pass the IR looks like

```
 %315 = vector.insert %314, %309 [0, 1, 0, 0] : vector<4x1xf32> into vector<4x2x1x1x4x1xf32> 
[...]
 %434 = arith.truncf %324 : vector<2x4x1x1x1x4xf32> to vector<2x4x1x1x1x4xf16>
[...]
%453 = vector.transpose %452, [1, 0, 3, 2, 5, 4] : vector<4x2x1x1x4x1xf32> to vector<2x4x1x1x1x4xf32> 
```

My understanding is that these ops are supposed to be executed by a single-thread, and that in general only _innermost_ dimensions correspond to a HW vector width. All other dimensions are artefacts of distributing the workgroup computation to thread computations in `LLVMGPUVectorDistributePass`. For example, before the `'LLVMGPUVectorDistributePass` pass the `arith.truncf` looks like

```
 %42 = arith.truncf %40 : vector<64x64xf32> to vector<64x64xf16>
```

The goal of this PR is to unroll/flatten all the dimensions other than the innermost dimension. It takes inspiration from [SPIRV pass](https://github.com/iree-org/iree/blob/99c162ceeea17d3e7d124399a7658918fedad1d4/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVInitialVectorLowering.cpp#L9), and adds additional patterns to reduce the rank of unrolled vectors. 


Currently when lowering an attention op, I can see some IR changes/improvements:

~ all MLIR values of vector type are rank-1. 
~ IR after ConvertToROCDLPass contains 2319 lines, down from 3442 lines. 
~ final gcm asm is almost unchanged
~ arrays like ` !llvm.array<4 x array<1 x array<1 x array<1 x array<1 x vector<8xf16>>>>>> ` no longer appear

