### PR TITLE
[LLVMGPU] Set thread tile sizes to 1 when reshapes are present

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -621,6 +621,8 @@ LogicalResult setTileAndFuseLoweringConfig(IREE::GPU::TargetAttr target,
     return failure();
   }
 
+  // TODO(Max191): Drop this check for reshapes in the dispatch once we can
+  // codegen larger tile sizes with reshapes in the dispatch.
   bool hasReshapes = false;
   entryPoint->walk([&](Operation *opInEntryPoint) {
     if (isa<tensor::ExpandShapeOp, tensor::CollapseShapeOp>(opInEntryPoint)) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils/ConfigUtils.cpp
@@ -620,6 +620,16 @@ LogicalResult setTileAndFuseLoweringConfig(IREE::GPU::TargetAttr target,
   if (failed(maybeDistInfo)) {
     return failure();
   }
+
+  bool hasReshapes = false;
+  entryPoint->walk([&](Operation *opInEntryPoint) {
+    if (isa<tensor::ExpandShapeOp, tensor::CollapseShapeOp>(opInEntryPoint)) {
+      hasReshapes = true;
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+
   DistributionInfo distInfo = maybeDistInfo.value();
 
   const int subgroupSize = target.getPreferredSubgroupSize();
@@ -739,7 +749,7 @@ LogicalResult setTileAndFuseLoweringConfig(IREE::GPU::TargetAttr target,
         // TODO: Try to take into account element type bit width to get
         // 4xdword reads instead of 4x{elements}.
         if (distInfo.vectorizable && wgDim == 0 && !lossFactor &&
-            candidate % numVectorElements == 0) {
+            candidate % numVectorElements == 0 && !hasReshapes) {
           // Use size-1 vectors to increase parallelism if larger ones causes
           // idle threads in the subgroup.
           bool hasIdleThreads = distInfo.partitionableLoops.size() == 1 &&

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_tile_and_fuse.mlir
@@ -546,7 +546,7 @@ func.func @set_encoding_gpu(%0 : tensor<1234x567xi8>) -> tensor<10x9x8x4x4x4x2x8
 // CHECK-LABEL: func.func @set_encoding_gpu
 //  CHECK-SAME:   #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse workgroup_size = [64, 1, 1] subgroup_size = 64>
 //       CHECK:   linalg.generic {{.*}}lowering_config = #iree_gpu.lowering_config
-//  CHECK-SAME:     thread = [1, 1, 1, 1, 1, 1, 1, 4]
+//  CHECK-SAME:     thread = [1, 1, 1, 1, 1, 1, 1, 1]
 //  CHECK-SAME:     workgroup = [1, 1, 8, 4, 4, 4, 2, 8]
 
 // -----


### PR DESCRIPTION
Conservatively set thread tile sizes to 1 in the TileAndFuse pipeline when there are reshapes present in the dispatch. There are still some cases where the reshapes may not be fused into the thread loop when thread tile sizes are non unit, so we just always set sizes to 1 until we are able to better handle such cases.