### PR TITLE
[NFC][LinalgExt] Remove unused scatter member fns

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -211,35 +211,6 @@ def IREELinalgExt_ScatterOp : IREELinalgExt_Op<"scatter",
       return getOriginalType().getRank() - getIndexDepth();
     }
 
-    /// Utility to get the shape of the portion of `updates` that
-    /// is scattered into `original`.
-    ArrayRef<int64_t> getUpdateSliceShape() {
-      return getUpdateType().getShape().slice(getBatchRank(),
-                                              getUpdateSliceRank());
-    }
-
-    /// Utility to get the dimension in `updates` the corresponds
-    /// to the given dimension in `original`
-    int64_t convertOriginalDimToUpdatesDim(uint64_t dim) {
-      assert(dim >= 0 && dim < getOriginalType().getRank() &&
-             "expected dimension to be within original rank");
-      int64_t updateDim =
-          getUpdateType().getRank() - getOriginalType().getRank() + dim;
-      assert(updateDim >= getBatchRank() &&
-             "dim doesn't map to a dim in updates");
-      return updateDim;
-    }
-
-    /// Get the dimension in `original` that corresponds to the given
-    /// dimension in `original`.
-    int64_t convertUpdatesDimToOriginalDim(uint64_t dim) {
-      assert(dim >= getBatchRank() &&
-             "update batch dim doesn't map to original");
-      assert(dim < getUpdateType().getRank() &&
-             "expected dimension to be within updates rank");
-      return getOriginalType().getRank() - getUpdateType().getRank() + dim;
-    }
-
     bool isScalarUpdate() {
       return getUpdateSliceRank() == 0;
     }


### PR DESCRIPTION
These were added by https://github.com/iree-org/iree/pull/19560 but were never actually needed or used.