### PR TITLE
Fix im2col conversion for no batch case

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv_to_im2col.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv_to_im2col.mlir
@@ -341,5 +341,21 @@ util.func public @conv_nhwc_hwfc_nobatch(%arg0: tensor<16x16x4xf32>, %arg1: tens
   util.return %0 : tensor<14x14x16xf32>
 }
 
-// CHECK:  util.func public @conv_nhwc_hwfc_nobatch(
-// CHECK:    iree_linalg_ext.im2col {{.*}} batch_pos = []
+// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d3, d4)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d3, d2, d4)>
+// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2)>
+// CHECK:      util.func public @conv_nhwc_hwfc_nobatch(
+// CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<16x16x4xf32>
+// CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: tensor<3x3x16x4xf32>
+// CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: tensor<14x14x16xf32>
+// CHECK:      %[[EMPTY:.+]] = tensor.empty() : tensor<14x14x9x4xf32>
+// CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
+// CHECK-SAME:   m_offset = [0, 0] * [14, 1] k_offset = [0, 0] * [4, 1] batch_pos = []
+// CHECK-SAME:   ins(%[[ARG0]] : tensor<16x16x4xf32>)
+// CHECK-SAME:   outs(%[[EMPTY]] : tensor<14x14x9x4xf32>) -> tensor<14x14x9x4xf32>
+// CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[ARG1]] {{\[}}[0, 1], [2], [3]] : tensor<3x3x16x4xf32> into tensor<9x16x4xf32>
+// CHECK:      %[[MATMUL:.+]] = linalg.generic
+// CHECK-SAME:   indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP2]]]
+// CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction"]
+// CHECK-SAME:   ins(%[[IM2COL]], %[[COLLAPSED]] : tensor<14x14x9x4xf32>, tensor<9x16x4xf32>)
+// CHECK:      util.return %[[MATMUL]] : tensor<14x14x16xf32>

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -470,11 +470,13 @@ getIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
     isOutputChannelFirst = true;
 
   bool isBatchDimLast = false;
-  std::optional<int64_t> batchFirstDim = outputMap.getResultPosition(
-      getAffineDimExpr(convDims.batch[0], outputMap.getContext()));
-  if (batchFirstDim && outputChannelLastDim.value() < batchFirstDim.value())
-    isBatchDimLast = true;
-
+  int64_t numBDims = (convDims.batch).size();
+  if (numBDims != 0) {
+    std::optional<int64_t> batchFirstDim = outputMap.getResultPosition(
+        getAffineDimExpr(convDims.batch[0], outputMap.getContext()));
+    if (batchFirstDim && outputChannelLastDim.value() < batchFirstDim.value())
+      isBatchDimLast = true;
+  }
   SmallVector<int64_t> filterkPos;
   for (auto reductionDim : reductionDims) {
     std::optional<int64_t> maybeDim = filterMap.getResultPosition(
@@ -537,7 +539,6 @@ getIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
     }
   }
 
-  int64_t numBDims = (convDims.batch).size();
   int64_t numMDims = (convDims.outputImage).size();
   int64_t numNDims = (convDims.outputChannel).size();
   int64_t numParallelDims = numBDims + numMDims + numNDims;


### PR DESCRIPTION
Add a missing guard to check batch dims for when there are no batch dims.
Fixes: https://github.com/iree-org/iree/issues/20461