### PR TITLE
[VectorExt] Add generic vectorization to iree_vector_ext.transfer_gather

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -191,6 +191,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/IR:IREEGPUDialect",
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils:KnownTargets",
         "//compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR:IREEVectorExtDialect",
+        "//compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms:VectorExtTransforms",
         "//compiler/src/iree/compiler/Codegen/Interfaces:BufferizationInterfaces",
         "//compiler/src/iree/compiler/Codegen/Interfaces:PartitionableLoopsInterface",
         "//compiler/src/iree/compiler/Codegen/Interfaces:UKernelOpInterface",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -226,6 +226,7 @@ iree_cc_library(
     iree::compiler::Codegen::Dialect::GPU::IR::IREEGPUDialect
     iree::compiler::Codegen::Dialect::GPU::TargetUtils::KnownTargets
     iree::compiler::Codegen::Dialect::VectorExt::IR::IREEVectorExtDialect
+    iree::compiler::Codegen::Dialect::VectorExt::Transforms::VectorExtTransforms
     iree::compiler::Codegen::Interfaces::BufferizationInterfaces
     iree::compiler::Codegen::Interfaces::PartitionableLoopsInterface
     iree::compiler::Codegen::Interfaces::UKernelOpInterface

--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -6,6 +6,8 @@
 
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Common/TileSizeSelection.h"
+#include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h"
+#include "iree/compiler/Codegen/Dialect/VectorExt/Transforms/Transforms.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "mlir/Dialect/Affine/LoopUtils.h"
 #include "mlir/Dialect/Linalg/Transforms/Hoisting.h"
@@ -99,8 +101,9 @@ public:
       GenericVectorizationPass>::GenericVectorizationPassBase;
 
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<tensor::TensorDialect, linalg::LinalgDialect,
-                    vector::VectorDialect>();
+    registry
+        .insert<tensor::TensorDialect, linalg::LinalgDialect,
+                vector::VectorDialect, IREE::VectorExt::IREEVectorExtDialect>();
   }
   void runOnOperation() override;
 };
@@ -156,6 +159,15 @@ void GenericVectorizationPass::runOnOperation() {
     }
     // Pad scalable dims with `false` to match the vector sizes.
     scalableVecDims.resize(vectorSizes.size());
+
+    // Try to vectorize to transfer_gather, if possible.
+    if (isa<linalg::GenericOp>(op) && vectorizeToTransferGather) {
+      if (succeeded(IREE::VectorExt::vectorizeGatherLikeGenericToTransferGather(
+              rewriter, cast<linalg::GenericOp>(op), vectorSizes,
+              scalableVecDims, vectorizeGatherAccesses))) {
+        continue;
+      }
+    }
     (void)linalg::vectorize(rewriter, op, vectorSizes, scalableVecDims,
                             vectorizeGatherAccesses);
   };

--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -162,14 +162,13 @@ void GenericVectorizationPass::runOnOperation() {
 
     // Try to vectorize to transfer_gather, if possible.
     if (isa<linalg::GenericOp>(op) && vectorizeToTransferGather) {
-      if (succeeded(IREE::VectorExt::vectorizeGatherLikeGenericToTransferGather(
-              rewriter, cast<linalg::GenericOp>(op), vectorSizes,
-              scalableVecDims, vectorizeGatherAccesses))) {
-        continue;
-      }
+      (void)IREE::VectorExt::vectorizeGatherLikeGenericToTransferGather(
+          rewriter, cast<linalg::GenericOp>(op), vectorSizes, scalableVecDims,
+          vectorizeGatherAccesses);
+    } else {
+      (void)linalg::vectorize(rewriter, op, vectorSizes, scalableVecDims,
+                              vectorizeGatherAccesses);
     }
-    (void)linalg::vectorize(rewriter, op, vectorSizes, scalableVecDims,
-                            vectorizeGatherAccesses);
   };
 
   {

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -352,6 +352,8 @@ def GenericVectorizationPass :
       "Rewrite all tensor.pad ops in the function to vector form.">,
     Option<"vectorizeGatherAccesses", "vectorize-gather-accesses", "bool", /*default=*/"false",
       "Enable vectorizaiton of operations that may generate vector.gather operations.">,
+    Option<"vectorizeToTransferGather", "vectorize-to-transfer-gather", "bool", /*default=*/"false",
+      "Enables vectorization of gather-like operations that may generate iree_vector_ext.transfer_gather">,
     Option<"enableCleanup", "enable-cleanup", "bool",/*default=*/"true",
       "Enable cleanups after vectorization. The patterns touch the structure"
       "generated from tiling so it affects later steps like bufferization and vector hoisting.">,

--- a/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization.mlir
@@ -579,7 +579,7 @@ func.func @paged_gather_read(%storage : !storage, %ind: !ind) -> !x {
     iterator_types = ["parallel", "parallel"]
 }
 
-func.func @contigious_gather_read(%storage : !storage) -> !x {
+func.func @contiguous_gather_read(%storage : !storage) -> !x {
   %x = tensor.empty() : !x
   %x_g = linalg.generic #gather
          outs(%x : !x) {
@@ -592,7 +592,7 @@ func.func @contigious_gather_read(%storage : !storage) -> !x {
   return %x_g : !x
 }
 
-// CHECK-GATHER-LABEL: @contigious_gather_read
+// CHECK-GATHER-LABEL: @contiguous_gather_read
 // CHECK-GATHER-SAME: %[[ARG0:.+]]: tensor<8192x8xf16>
 // CHECK-GATHER: %[[GATHER:.+]] = iree_vector_ext.transfer_gather %[[ARG0]]
 // CHECK-GATHER-SAME: [None, None]
@@ -630,3 +630,76 @@ func.func @negative_strided_paged_gather_read(%storage : !storage, %ind: !ind) -
 // from the iteration space to the memory space. This can be improved in future.
 // CHECK-GATHER-LABEL: @negative_strided_paged_gather_read
 // CHECK-GATHER: linalg.generic
+
+// -----
+
+!storage = tensor<8192x8xf16>
+!ind0     = tensor<128xi64>
+!ind1     = tensor<8xi64>
+!x       = tensor<128x8xf16>
+
+#gather = {
+    indexing_maps = [affine_map<(d0, d1) -> (d0)>,
+                     affine_map<(d0, d1) -> (d1)>,
+                     affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]
+}
+
+func.func @full_gather_read(%storage : !storage, %ind0: !ind0, %ind1 : !ind1) -> !x {
+  %x = tensor.empty() : !x
+  %x_g = linalg.generic #gather
+         ins(%ind0, %ind1 : !ind0, !ind1)
+         outs(%x : !x) {
+   ^bb0(%id0: i64, %id1 : i64, %out: f16):
+    %idx0 = arith.index_cast %id0 : i64 to index
+    %idx1 = arith.index_cast %id1 : i64 to index
+    %extracted = tensor.extract %storage[%idx0, %idx1] : !storage
+    linalg.yield %extracted : f16
+  } -> !x
+  return %x_g : !x
+}
+
+// CHECK-GATHER-LABEL: @full_gather_read
+// CHECK-GATHER-SAME: %[[ARG0:.+]]: tensor<8192x8xf16>, %[[ARG1:.+]]: tensor<128xi64>, %[[ARG2:.+]]: tensor<8xi64>
+// CHECK-GATHER-DAG: %[[IDX0:.+]] = vector.transfer_read %[[ARG1]]
+// CHECK-GATHER-DAG: %[[IDX1:.+]] = vector.transfer_read %[[ARG2]]
+// CHECK-GATHER-DAG: %[[CAST0:.+]] = arith.index_cast %[[IDX0]] : vector<128xi64> to vector<128xindex>
+// CHECK-GATHER-DAG: %[[CAST1:.+]] = arith.index_cast %[[IDX1]] : vector<8xi64> to vector<8xindex>
+// CHECK-GATHER-DAG: %[[GATHER:.+]] = iree_vector_ext.transfer_gather %[[ARG0]]
+// CHECK-GATHER-SAME: [%[[CAST0]]: vector<128xindex>, %[[CAST1]]: vector<8xindex>]
+// CHECK-GATHER: vector.transfer_write %[[GATHER]], %{{.*}}
+
+// -----
+
+!storage = tensor<8192x8xf16>
+!ind0     = tensor<128xi64>
+!ind1     = tensor<8xi64>
+!x       = tensor<128x8xf16>
+
+#gather = {
+    indexing_maps = [affine_map<(d0, d1) -> (d0)>,
+                     affine_map<(d0, d1) -> (d1)>,
+                     affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]
+}
+
+func.func @multi_extract(%storage : !storage, %storage2: !storage, %ind0: !ind0, %ind1 : !ind1) -> ( !x, !x ) {
+  %x = tensor.empty() : !x
+  %x_g, %x_g1 = linalg.generic #gather
+         ins(%ind0, %ind1 : !ind0, !ind1)
+         outs(%x, %x : !x, !x) {
+   ^bb0(%id0: i64, %id1 : i64, %out: f16, %out2: f16):
+    %idx0 = arith.index_cast %id0 : i64 to index
+    %idx1 = arith.index_cast %id1 : i64 to index
+    %extracted = tensor.extract %storage[%idx0, %idx1] : !storage
+    %idx2 = arith.index_cast %id0 : i64 to index
+    %idx3 = arith.index_cast %id1 : i64 to index
+    %extracted1 = tensor.extract %storage2[%idx2, %idx3] : !storage
+    linalg.yield %extracted, %extracted1 : f16, f16
+  } -> (!x, !x)
+  return %x_g, %x_g1 : !x, !x
+}
+
+// CHECK-GATHER-LABEL: @multi_extract
+// CHECK-GATHER-COUNT-2: transfer_gather

--- a/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization.mlir
@@ -1,6 +1,7 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-generic-vectorization))" --split-input-file %s | FileCheck %s
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-generic-vectorization{enable-vector-masking=true vectorize-padding=true}))" --split-input-file %s | FileCheck %s -check-prefix=CHECK-MASK
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-generic-vectorization{fold-cast-into-contract=true}))" --split-input-file %s | FileCheck %s -check-prefix=CHECK-FOLD
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-generic-vectorization{vectorize-to-transfer-gather=true}))" --split-input-file %s | FileCheck %s --check-prefix=CHECK-GATHER
 
 func.func @matmul(%lhs: tensor<3x4xf16>, %rhs: tensor<4x5xf16>, %acc: tensor<3x5xf32>) -> tensor<3x5xf32> {
   %result = linalg.matmul ins(%lhs, %rhs: tensor<3x4xf16>, tensor<4x5xf16>) outs(%acc: tensor<3x5xf32>) -> tensor<3x5xf32>
@@ -533,3 +534,99 @@ func.func @depthwise_conv_fold_away_masking(%arg0: tensor<1x68x120x96xf32>, %arg
 // CHECK-MASK:     vector.fma
 // CHECK-MASK-NOT: vector.create_mask
 // CHECK-MASK-NOT: vector.constant_mask
+
+// -----
+
+!storage = tensor<8192x8xf16>
+!ind     = tensor<128xi64>
+!x       = tensor<128x8xf16>
+
+#gather = {
+    indexing_maps = [affine_map<(page, vec) -> (page)>,
+                     affine_map<(page, vec) -> (page, vec)>],
+    iterator_types = ["parallel", "parallel"]
+}
+
+func.func @paged_gather_read(%storage : !storage, %ind: !ind) -> !x {
+  %x = tensor.empty() : !x
+  %x_g = linalg.generic #gather
+         ins(%ind : !ind)
+         outs(%x : !x) {
+  ^bb0(%page: i64, %out: f16):
+    %pageidx = arith.index_cast %page : i64 to index
+    %vec   = linalg.index 1 : index
+    %extracted = tensor.extract %storage[%pageidx, %vec] : !storage
+    linalg.yield %extracted : f16
+  } -> !x
+  return %x_g : !x
+}
+
+// CHECK-GATHER-LABEL: @paged_gather_read
+// CHECK-GATHER-SAME: %[[ARG0:.+]]: tensor<8192x8xf16>, %[[ARG1:.+]]: tensor<128xi64>
+// CHECK-GATHER: %[[INDEX_LOAD:.+]] = vector.transfer_read %[[ARG1]]
+// CHECK-GATHER: %[[INDEX_CAST:.+]] = arith.index_cast %[[INDEX_LOAD]] : vector<128xi64> to vector<128xindex>
+// CHECK-GATHER: %[[GATHER:.+]] = iree_vector_ext.transfer_gather %[[ARG0]]
+// CHECK-GATHER-SAME: [%[[INDEX_CAST]]: vector<128xindex>, None]
+// CHECK-GATHER: vector.transfer_write %[[GATHER]], %{{.*}}
+
+// -----
+
+!storage = tensor<8192x8xf16>
+!x       = tensor<128x8xf16>
+
+#gather = {
+    indexing_maps = [affine_map<(page, vec) -> (page, vec)>],
+    iterator_types = ["parallel", "parallel"]
+}
+
+func.func @contigious_gather_read(%storage : !storage) -> !x {
+  %x = tensor.empty() : !x
+  %x_g = linalg.generic #gather
+         outs(%x : !x) {
+  ^bb0(%out: f16):
+    %pageidx = linalg.index 0 : index
+    %vec   = linalg.index 1 : index
+    %extracted = tensor.extract %storage[%pageidx, %vec] : !storage
+    linalg.yield %extracted : f16
+  } -> !x
+  return %x_g : !x
+}
+
+// CHECK-GATHER-LABEL: @contigious_gather_read
+// CHECK-GATHER-SAME: %[[ARG0:.+]]: tensor<8192x8xf16>
+// CHECK-GATHER: %[[GATHER:.+]] = iree_vector_ext.transfer_gather %[[ARG0]]
+// CHECK-GATHER-SAME: [None, None]
+// CHECK-GATHER: vector.transfer_write %[[GATHER]], %{{.*}}
+
+// -----
+
+!storage = tensor<8192x8xf16>
+!ind     = tensor<128xi64>
+!x       = tensor<128x8xf16>
+
+#gather = {
+    indexing_maps = [affine_map<(page, vec) -> (page)>,
+                     affine_map<(page, vec) -> (page, vec)>],
+    iterator_types = ["parallel", "parallel"]
+}
+
+func.func @negative_strided_paged_gather_read(%storage : !storage, %ind: !ind) -> !x {
+  %x = tensor.empty() : !x
+  %c2 = arith.constant 2 : index
+  %x_g = linalg.generic #gather
+         ins(%ind : !ind)
+         outs(%x : !x) {
+  ^bb0(%page: i64, %out: f16):
+    %pageidx = arith.index_cast %page : i64 to index
+    %vec   = linalg.index 1 : index
+    %strided_vec = arith.muli %vec, %c2 : index
+    %extracted = tensor.extract %storage[%pageidx, %strided_vec] : !storage
+    linalg.yield %extracted : f16
+  } -> !x
+  return %x_g : !x
+}
+
+// For now, the vectorizer does not walk back on binary ops to find a mapping
+// from the iteration space to the memory space. This can be improved in future.
+// CHECK-GATHER-LABEL: @negative_strided_paged_gather_read
+// CHECK-GATHER: linalg.generic

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/BUILD.bazel
@@ -37,14 +37,18 @@ iree_compiler_cc_library(
     hdrs = [
         "Passes.h",
         "Passes.h.inc",
+        "Transforms.h",
     ],
     deps = [
         ":PassesIncGen",
         "//compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR:IREEVectorExtDialect",
+        "//compiler/src/iree/compiler/Dialect/LinalgExt/Utils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:FunctionInterfaces",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LinalgDialect",
+        "@llvm-project//mlir:LinalgTransforms",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_cc_library(
   HDRS
     "Passes.h"
     "Passes.h.inc"
+    "Transforms.h"
   SRCS
     "Passes.cpp"
     "VectorExtFoldUnitExtentDims.cpp"
@@ -35,6 +36,8 @@ iree_cc_library(
     MLIRArithDialect
     MLIRFunctionInterfaces
     MLIRIR
+    MLIRLinalgDialect
+    MLIRLinalgTransforms
     MLIRPass
     MLIRSupport
     MLIRTensorDialect
@@ -44,6 +47,7 @@ iree_cc_library(
     MLIRVectorTransforms
     MLIRVectorUtils
     iree::compiler::Codegen::Dialect::VectorExt::IR::IREEVectorExtDialect
+    iree::compiler::Dialect::LinalgExt::Utils
   PUBLIC
 )
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/Transforms.h
@@ -1,0 +1,25 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_DIALECT_VECTOR_EXT_TRANSFORMS_TRANSFORMS_H_
+#define IREE_COMPILER_CODEGEN_DIALECT_VECTOR_EXT_TRANSFORMS_TRANSFORMS_H_
+
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::iree_compiler::IREE::VectorExt {
+
+LogicalResult vectorizeGatherLikeGenericToTransferGather(
+    RewriterBase &rewriter, linalg::GenericOp linalgOp,
+    ArrayRef<int64_t> vectorSizes = {}, ArrayRef<bool> scalableVecDims = {},
+    bool vectorizeNDExtract = false);
+
+void populateVectorTransferGatherLoweringPatterns(RewritePatternSet &patterns);
+
+}; // namespace mlir::iree_compiler::IREE::VectorExt
+
+#endif // IREE_COMPILER_CODEGEN_DIALECT_VECTOR_EXT_TRANSFORMS_TRANSFORMS_H_

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorizeIREEVectorExtOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorizeIREEVectorExtOps.cpp
@@ -6,9 +6,13 @@
 
 #include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h"
 #include "iree/compiler/Codegen/Dialect/VectorExt/Transforms/Passes.h"
+#include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Dialect/Vector/Utils/VectorUtils.h"
 #include "mlir/IR/Builders.h"
+
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir::iree_compiler::IREE::VectorExt {
@@ -104,9 +108,6 @@ struct VectorizeToLayoutOpPattern final
   }
 };
 
-} // namespace
-
-namespace {
 struct VectorizeIREEVectorExtOpsPass final
     : impl::VectorizeIREEVectorExtOpsPassBase<VectorizeIREEVectorExtOpsPass> {
   void runOnOperation() override {
@@ -119,6 +120,362 @@ struct VectorizeIREEVectorExtOpsPass final
     }
   }
 };
+
+static linalg::GenericOp
+buildPartialGenericOp(RewriterBase &rewriter, linalg::GenericOp fullOp,
+                      ArrayRef<int64_t> vectorSizes,
+                      SmallVector<Operation *> partial,
+                      DenseMap<Value, std::pair<Value, AffineMap>> &tmap) {
+  // Each value used in the partial body is either outside the operation (use as
+  // is), or is defined inside the block (including block arguements). For
+  // values defined inside the block, the value will have a tensor and an
+  // AffineMap to access the tensor in tmap;
+
+  // Find all values used in partial that are defined inside the block.
+  SetVector<Value> newInputs;
+  SetVector<Value> newOutputs;
+  for (Operation *op : partial) {
+    for (Value operand : op->getOperands()) {
+      if (operand.getParentBlock() != fullOp.getBody()) {
+        continue;
+      }
+
+      if (tmap.contains(operand)) {
+        newInputs.insert(operand);
+      }
+    }
+
+    // If a user of the operation is not in partial, it needs to be a result.
+    for (Value result : op->getResults()) {
+      for (Operation *user : result.getUsers()) {
+        if (llvm::find(partial, user) == partial.end()) {
+          newOutputs.insert(result);
+        }
+      }
+    }
+  }
+
+  SmallVector<Value> ins, outs;
+  SmallVector<AffineMap> indexingMaps;
+  AffineMap ident = rewriter.getMultiDimIdentityMap(fullOp.getNumLoops());
+
+  for (Value val : newInputs) {
+    auto [in, map] = tmap[val];
+    ins.push_back(in);
+    indexingMaps.push_back(map);
+  }
+
+  for (Value val : newOutputs) {
+    Value out = rewriter.create<tensor::EmptyOp>(fullOp.getLoc(), vectorSizes,
+                                                 getElementTypeOrSelf(val));
+    outs.push_back(out);
+    indexingMaps.push_back(ident);
+  }
+
+  // If the last operation is a yield, add the out operands.
+  bool hasYield = !partial.empty() && isa<linalg::YieldOp>(partial.back());
+  if (hasYield) {
+    for (OpOperand &operand : fullOp.getDpsInitsMutable()) {
+      outs.push_back(operand.get());
+      indexingMaps.push_back(fullOp.getMatchingIndexingMap(&operand));
+    }
+  }
+
+  auto newOp = rewriter.create<linalg::GenericOp>(
+      fullOp.getLoc(), TypeRange(outs), ins, outs, indexingMaps,
+      fullOp.getIteratorTypesArray(),
+      [&](OpBuilder &b, Location loc, ValueRange blockArgs) {
+        IRMapping localMap;
+        for (auto [oldVal, newVal] : llvm::zip_equal(
+                 newInputs, blockArgs.take_front(newInputs.size()))) {
+          localMap.map(oldVal, newVal);
+        }
+
+        if (!hasYield) {
+          for (auto [oldVal, newVal] : llvm::zip_equal(
+                   newOutputs, blockArgs.take_back(newOutputs.size()))) {
+            localMap.map(oldVal, newVal);
+          }
+        }
+
+        // Clone partial into this region.
+        for (Operation *op : partial) {
+          b.clone(*op, localMap);
+        }
+
+        if (!hasYield) {
+          SmallVector<Value> yieldValues = llvm::map_to_vector(
+              newOutputs, [&](Value val) { return localMap.lookup(val); });
+          b.create<linalg::YieldOp>(loc, yieldValues);
+        }
+      });
+
+  // Add a entry in tmap for each value in newOutputs.
+  for (auto [index, val] : llvm::enumerate(newOutputs)) {
+    Value tensor = newOp.getResult(index);
+    AffineMap map = indexingMaps[newInputs.size() + index];
+    tmap[val] = {tensor, map};
+  }
+
+  return newOp;
+}
+
+/// Try to find a mapping from the memory space of tensor.extract to the loop
+/// iteration space, if possible.
+static AffineMap
+getIterationSpaceToMemorySpaceMap(linalg::GenericOp genericOp,
+                                  tensor::ExtractOp extractOp) {
+  // Try to find a mapping from the memory space to the input iteration space.
+  // Find backward slice for each index argument to tensor.extract.
+  MLIRContext *ctx = extractOp.getContext();
+  AffineMap map = AffineMap::get(genericOp.getNumLoops(), 0, ctx);
+  for (Value val : extractOp.getIndices()) {
+    Value trace = val;
+    bool found = false;
+    while (true) {
+      // If the index is a linalg.index op, this index maps to a loop iteration
+      // variable.
+      if (auto indexOp = trace.getDefiningOp<linalg::IndexOp>()) {
+        map = map.insertResult(getAffineDimExpr(indexOp.getDim(), ctx),
+                               map.getNumResults());
+        found = true;
+        break;
+      }
+
+      // If this index is a value defined outside the linalg.generic block, it
+      // is a constant value in the loop.
+      Operation *defOp = trace.getDefiningOp();
+      if (defOp && !genericOp.getBody()->findAncestorOpInBlock(*defOp)) {
+        map = map.insertResult(getAffineConstantExpr(0, ctx),
+                               map.getNumResults());
+        found = true;
+        break;
+      }
+
+      // If this index is a block argument, the index is a loop iterated
+      // variable, and the iteration space of the index is same as the loop
+      // iterated variable. However, we restrict to cases where the variable
+      // iteration space is 1-D or 0-D, otherwise the Memory -> Loop Iteration
+      // Space map will contain mods/floordivS.
+      if (auto blockArg = dyn_cast<BlockArgument>(trace)) {
+        // If this block argument isn't part of the linalg.generic body, then
+        // this is a constant value in the loop.
+        if (blockArg.getParentBlock() != genericOp.getBody()) {
+          map = map.insertResult(getAffineConstantExpr(0, ctx),
+                                 map.getNumResults());
+          found = true;
+        } else {
+          // Allow 0-D and 1-D maps.
+          AffineMap indexMap =
+              genericOp.getIndexingMapsArray()[blockArg.getArgNumber()];
+          if (indexMap.getNumResults() == 0) {
+            map = map.insertResult(getAffineConstantExpr(0, ctx),
+                                   map.getNumResults());
+            found = true;
+          } else if (indexMap.getNumResults() == 1) {
+            if (auto dimExpr = dyn_cast<AffineDimExpr>(indexMap.getResult(0))) {
+              map =
+                  map.insertResult(getAffineDimExpr(dimExpr.getPosition(), ctx),
+                                   map.getNumResults());
+              found = true;
+            }
+          }
+        }
+        break;
+      }
+
+      // Trace back arith.index_cast ops. This is a commonly occuring case,
+      // there may be other cases which we can trace back here (For example,
+      // addition with a loop invariant constant).
+      if (isa<arith::IndexCastOp>(defOp)) {
+        trace = defOp->getOperand(0);
+      } else {
+        break;
+      }
+    }
+
+    if (!found) {
+      return AffineMap();
+    }
+  }
+
+  return map;
+}
+
+static AffineMap inversePerm(AffineMap map) {
+  assert(map.isProjectedPermutation(/*allowZeroInResults=*/true) &&
+         "Expected projected permutation with zeros");
+  MLIRContext *context = map.getContext();
+  AffineExpr zero = mlir::getAffineConstantExpr(0, context);
+  // Start with all the results as 0.
+  SmallVector<AffineExpr, 4> exprs(map.getNumInputs(), zero);
+  for (unsigned i : llvm::seq(unsigned(0), map.getNumResults())) {
+    // Skip zeros from input map. 'exprs' is already initialized to zero.
+    if (isa<AffineConstantExpr>(map.getResult(i))) {
+      continue;
+    }
+
+    // Reverse each dimension existing in the original map result.
+    exprs[map.getDimPosition(i)] = getAffineDimExpr(i, context);
+  }
+  return AffineMap::get(map.getNumResults(), /*symbolCount=*/0, exprs, context);
+}
+
 } // namespace
+
+LogicalResult vectorizeGatherLikeGenericToTransferGather(
+    RewriterBase &rewriter, linalg::GenericOp linalgOp,
+    ArrayRef<int64_t> vectorSizes, ArrayRef<bool> scalableVecDims,
+    bool vectorizeNDExtract) {
+
+  Location loc = linalgOp->getLoc();
+  SmallVector<int64_t> canonicalVectorSizes(vectorSizes);
+  SmallVector<bool> canonicalScalableDims(scalableVecDims);
+
+  // If vector sizes are not provided, assume static vector sizes and use loop
+  // ranges.
+  if (vectorSizes.empty()) {
+    assert(canonicalScalableDims.empty() &&
+           "vector sizes not provided but scalable vector sizes provided");
+    canonicalVectorSizes = linalgOp.getStaticLoopRanges();
+    canonicalScalableDims.append(linalgOp.getNumLoops(), false);
+  }
+
+  // Since upstream vectorization does not support hooks to vectorize individual
+  // operations inside a linalg.generic, we take an alternate approach here,
+  // by splitting the generic into 3 operations, anchored around the first
+  // tensor.extract operation:
+  //
+  // 1. pre-extract-generic
+  // 2. extract-as-transfer-gather
+  // 3. post-extract-generic
+
+  // Find the first tensor.extract operation and use it as a cut-off point for
+  // gather vectorization.
+  SmallVector<Operation *> preExtract;
+  tensor::ExtractOp extractOp;
+  SmallVector<Operation *> postExtract;
+
+  for (Operation &op : linalgOp.getBody()->getOperations()) {
+    if (extractOp) {
+      // Already found extract, add to postExtract.
+      postExtract.push_back(&op);
+    } else {
+      if (auto candidate = dyn_cast<tensor::ExtractOp>(op)) {
+        extractOp = candidate;
+        continue;
+      }
+      preExtract.push_back(&op);
+    }
+  }
+
+  // If no extract op was found, call generic vectorization.
+  if (!extractOp) {
+    return linalg::vectorize(rewriter, linalgOp, canonicalVectorSizes,
+                             canonicalScalableDims, vectorizeNDExtract);
+  }
+
+  AffineMap itSpaceToExtract =
+      getIterationSpaceToMemorySpaceMap(linalgOp, extractOp);
+  if (!itSpaceToExtract) {
+    return failure();
+  }
+
+  // Create a mapping from values used inside the linalg body to newly created
+  // tensors.
+  DenseMap<Value, std::pair<Value, AffineMap>> tmap;
+  for (OpOperand &operand : linalgOp->getOpOperands()) {
+    AffineMap map = linalgOp.getMatchingIndexingMap(&operand);
+    Value blockArg = linalgOp.getMatchingBlockArgument(&operand);
+    tmap[blockArg] = {operand.get(), map};
+  }
+
+  rewriter.setInsertionPointAfter(linalgOp);
+
+  // Build the preExtract linalg.generic and vectorize it.
+  linalg::GenericOp preOp = buildPartialGenericOp(
+      rewriter, linalgOp, canonicalVectorSizes, preExtract, tmap);
+
+  // Build the iree_vector_ext.transfer_gather operation.
+  SmallVector<Value> baseIndices;
+  SmallVector<Value> indexVecs;
+  SmallVector<bool> indexed;
+  SmallVector<AffineMap> indexedMaps;
+
+  Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+
+  for (auto [i, index] : llvm::enumerate(extractOp.getIndices())) {
+    if (!tmap.contains(index)) {
+      baseIndices.push_back(index);
+      indexed.push_back(false);
+      continue;
+    }
+
+    auto [tensor, map] = tmap[index];
+
+    Type elemType = getElementTypeOrSelf(index);
+    AffineMap readMap = inverseAndBroadcastProjectedPermutation(map);
+    VectorType readType = VectorType::get(canonicalVectorSizes, elemType);
+
+    SmallVector<Value> operandIndices(map.getNumResults(), zero);
+
+    // TODO: Mask the operation here. It's really hard to do that here though
+    // because we don't have access to the vectorization infra, but maybe there
+    // are easier ways to do it here.
+    auto read = rewriter.create<vector::TransferReadOp>(
+        loc, readType, tensor, operandIndices, readMap);
+
+    baseIndices.push_back(zero);
+    indexed.push_back(true);
+    indexedMaps.push_back(inversePerm(itSpaceToExtract));
+    indexVecs.push_back(read.getResult());
+  }
+
+  auto gatherTy = VectorType::get(canonicalVectorSizes, extractOp.getType());
+  Value padding = rewriter.create<arith::ConstantOp>(
+      loc, rewriter.getZeroAttr(extractOp.getType()));
+  // tensor.extract always produces in-bounds accesses.
+  SmallVector<Attribute> inBounds(gatherTy.getRank(),
+                                  rewriter.getBoolAttr(true));
+
+  auto transferGatherOp = rewriter.create<IREE::VectorExt::TransferGatherOp>(
+      loc, gatherTy, extractOp.getTensor(), baseIndices, indexVecs,
+      rewriter.getBoolArrayAttr(indexed),
+      rewriter.getAffineMapArrayAttr(indexedMaps),
+      inversePerm(itSpaceToExtract), padding,
+      /*mask=*/Value(), rewriter.getArrayAttr(inBounds));
+
+  // Create a empty tensor to write to.
+  auto emptyOp = rewriter.create<tensor::EmptyOp>(loc, canonicalVectorSizes,
+                                                  gatherTy.getElementType());
+  SmallVector<Value> writeIndices(canonicalVectorSizes.size(), zero);
+
+  auto writeOp = rewriter.create<vector::TransferWriteOp>(
+      loc, transferGatherOp.getResult(), emptyOp, writeIndices);
+
+  tmap[extractOp.getResult()] = {
+      writeOp.getResult(),
+      rewriter.getMultiDimIdentityMap(canonicalVectorSizes.size())};
+
+  // Build the postExtract linalg.generic.
+  linalg::GenericOp postOp = buildPartialGenericOp(
+      rewriter, linalgOp, canonicalVectorSizes, postExtract, tmap);
+
+  rewriter.replaceOp(linalgOp, postOp);
+
+  if (failed(vectorizeGatherLikeGenericToTransferGather(
+          rewriter, preOp, canonicalVectorSizes, canonicalScalableDims,
+          vectorizeNDExtract))) {
+    return failure();
+  };
+
+  if (failed(vectorizeGatherLikeGenericToTransferGather(
+          rewriter, postOp, canonicalVectorSizes, canonicalScalableDims,
+          vectorizeNDExtract))) {
+    return failure();
+  }
+
+  return success();
+}
 
 } // namespace mlir::iree_compiler::IREE::VectorExt


### PR DESCRIPTION
This patch adds support to GenericVectorization to vectorize some special gather-like generic operations to transfer_gather. This support is added behind a flag and should not affect any existing pipelines.