### PR TITLE
[Codegen][ROCDL] Add hacky pattern to swap setprio with mfma

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -117,7 +117,7 @@ struct SwapSetPrioWithMFMA : public OpRewritePattern<ROCDL::SetPrioOp> {
 
     while (remainingToSwap > 0 && (current = current->getNextNode())) {
       if (isa<mlir::amdgpu::MFMAOp>(current)) {
-        remainingToSwap--;
+        --remainingToSwap;
         mfmaToSwap = current;
       }
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -73,6 +73,65 @@ static void populateConvertGPUToAMDGPUPatterns(RewritePatternSet &patterns) {
   patterns.add<ReplaceGPUBarrierWithLDSBarrier>(patterns.getContext());
 }
 
+/// Hacky pattern to swap `s_setprio` operations with `amdgpu.mfma` ops.
+/// This is needed for ping-pong scheduling patterns to prevent off
+/// waves from interrupting the MFMA region of the high priority wave.
+/// The IR is rewritten as follows:
+///
+/// rocdl.s.setprio {iree_gpu.swap_mfma = n}
+/// amdgpu.mfma // 1
+/// ...
+/// amdgpu.mfma // n
+/// amdgpu.mfma // n + 1
+///
+/// to
+///
+/// amdgpu.mfma // 1
+/// ...
+/// amdgpu.mfma // n
+/// rocdl.s.setprio
+/// amdgpu.mfma // n + 1
+///
+/// This only looks at successor mfmas within the same block and is best
+/// effort.
+constexpr StringLiteral kSwapName = "iree_gpu.swap_mfma";
+struct SwapSetPrioWithMFMA : public OpRewritePattern<ROCDL::SetPrioOp> {
+  using OpRewritePattern<ROCDL::SetPrioOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(ROCDL::SetPrioOp setPrio,
+                                PatternRewriter &rewriter) const override {
+    if (!setPrio->hasAttr(kSwapName)) {
+      return failure();
+    }
+
+    auto count = setPrio->getAttrOfType<IntegerAttr>(kSwapName);
+    if (!count) {
+      return failure();
+    }
+
+    int64_t remainingToSwap = count.getInt();
+    rewriter.startOpModification(setPrio);
+    setPrio->removeDiscardableAttr(kSwapName);
+
+    Operation *current = setPrio;
+    Operation *mfmaToSwap = nullptr;
+
+    while (remainingToSwap > 0 && (current = current->getNextNode())) {
+      if (isa<mlir::amdgpu::MFMAOp>(current)) {
+        remainingToSwap--;
+        mfmaToSwap = current;
+      }
+    }
+    if (mfmaToSwap) {
+      rewriter.moveOpAfter(setPrio, mfmaToSwap);
+    }
+    return success();
+  }
+};
+
+static void populateSwapSetPrioWithMFMAPatterns(RewritePatternSet &patterns) {
+  patterns.add<SwapSetPrioWithMFMA>(patterns.getContext());
+}
+
 } // namespace
 
 template <typename... Floats>
@@ -184,6 +243,7 @@ struct ConvertToROCDLPass final
           patterns, /*convertFP8Arithmetic=*/true, /*saturateFP8Truncf=*/false,
           /*allowPackedF16Rtz=*/false, /*chipset=*/*maybeChipset);
       arith::populateCeilFloorDivExpandOpsPatterns(patterns);
+      populateSwapSetPrioWithMFMAPatterns(patterns);
       populateConvertGPUToAMDGPUPatterns(patterns);
       populateConvertSharedMemoryAllocOps(patterns);
       populateDropSharedMemoryDeallocOpPatterns(patterns);


### PR DESCRIPTION
This is needed to achieve the right behavior for block pingpong schedules. The `iree_gpu.swap_mfma` discardable attribute can be added to indicate that the setprio op needs to swap with subsequent ops at a later step. The reason this hack is needed/useful is because the point at which we want to insert these setprio ops comes far before the point where we want to unroll composite mfma/contraction ops (iree_gpu.multi_mma or vector.contract).