### PR TITLE
[GlobalOpt] Generalize 1x1 group convolutions

### DIFF
--- a/compiler/src/iree/compiler/GlobalOptimization/GeneralizeLinalgNamedOps.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/GeneralizeLinalgNamedOps.cpp
@@ -19,6 +19,7 @@
 
 #define DEBUG_TYPE "iree-global-opt-generalize-linalg-named-ops"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir::iree_compiler::GlobalOptimization {
 
@@ -44,16 +45,15 @@ static bool isConvFoldableToContraction(linalg::LinalgOp linalgOp) {
 
   if (!llvm::all_of(convDims.strides,
                     [](int64_t element) { return element == 1; })) {
-    LLVM_DEBUG(DBGS() << "conv not foldable: non-unit strides\n");
+    LDBG("conv not foldable: non-unit strides");
     return false;
   }
 
   // Dont generalize pooling operations or depthwise convolutions. For pooling
   // ops, the input/output channel size will be categorized as the additional
-  // batch dimension
+  // batch dimension.
   if (convDims.outputChannel.empty() || convDims.inputChannel.empty()) {
-    LLVM_DEBUG(
-        DBGS() << "conv not foldable: missing input or output channel dims\n");
+    LDBG("conv not foldable: missing input or output channel dims");
     return false;
   }
 
@@ -62,7 +62,7 @@ static bool isConvFoldableToContraction(linalg::LinalgOp linalgOp) {
   auto filterShapeType = llvm::dyn_cast<RankedTensorType>(
       linalgOp.getDpsInputOperand(kFilterInputIdx)->get().getType());
   if (!filterShapeType) {
-    LLVM_DEBUG(DBGS() << "conv not foldable: filter shape not ranked tensor\n");
+    LDBG("conv not foldable: filter shape not ranked tensor");
     return false;
   }
   auto filterShape = filterShapeType.getShape();
@@ -71,7 +71,7 @@ static bool isConvFoldableToContraction(linalg::LinalgOp linalgOp) {
     std::optional<int64_t> maybeDim = filterMap.getResultPosition(
         getAffineDimExpr(filterLoop, filterMap.getContext()));
     if (!maybeDim || filterShape[*maybeDim] != 1) {
-      LLVM_DEBUG(DBGS() << "conv not foldable: non-unit filter dim\n");
+      LDBG("conv not foldable: non-unit filter dim");
       return false;
     }
   }

--- a/compiler/src/iree/compiler/GlobalOptimization/GeneralizeLinalgNamedOps.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/GeneralizeLinalgNamedOps.cpp
@@ -17,6 +17,9 @@
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Pass/Pass.h"
 
+#define DEBUG_TYPE "iree-global-opt-generalize-linalg-named-ops"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+
 namespace mlir::iree_compiler::GlobalOptimization {
 
 #define GEN_PASS_DEF_GENERALIZELINALGNAMEDOPSPASS
@@ -41,17 +44,16 @@ static bool isConvFoldableToContraction(linalg::LinalgOp linalgOp) {
 
   if (!llvm::all_of(convDims.strides,
                     [](int64_t element) { return element == 1; })) {
+    LLVM_DEBUG(DBGS() << "conv not foldable: non-unit strides\n");
     return false;
   }
 
-  // Dont generalize depthwise convolutions.
-  if (!convDims.depth.empty()) {
-    return false;
-  }
-
-  // Dont generalize pooling operations. For pooling ops, the input/output
-  // channel size will be categorized as the additional batch dimension
+  // Dont generalize pooling operations or depthwise convolutions. For pooling
+  // ops, the input/output channel size will be categorized as the additional
+  // batch dimension
   if (convDims.outputChannel.empty() || convDims.inputChannel.empty()) {
+    LLVM_DEBUG(
+        DBGS() << "conv not foldable: missing input or output channel dims\n");
     return false;
   }
 
@@ -60,6 +62,7 @@ static bool isConvFoldableToContraction(linalg::LinalgOp linalgOp) {
   auto filterShapeType = llvm::dyn_cast<RankedTensorType>(
       linalgOp.getDpsInputOperand(kFilterInputIdx)->get().getType());
   if (!filterShapeType) {
+    LLVM_DEBUG(DBGS() << "conv not foldable: filter shape not ranked tensor\n");
     return false;
   }
   auto filterShape = filterShapeType.getShape();
@@ -68,6 +71,7 @@ static bool isConvFoldableToContraction(linalg::LinalgOp linalgOp) {
     std::optional<int64_t> maybeDim = filterMap.getResultPosition(
         getAffineDimExpr(filterLoop, filterMap.getContext()));
     if (!maybeDim || filterShape[*maybeDim] != 1) {
+      LLVM_DEBUG(DBGS() << "conv not foldable: non-unit filter dim\n");
       return false;
     }
   }


### PR DESCRIPTION
This allows 1x1 group convolutions to be generalized, since they are effectively loops around matmuls. On llvmgpu this allows them to go down the contraction/matmul lowering path.