### PR TITLE
[hip] Re-enable peering for compatible devices.

### DIFF
--- a/runtime/src/iree/hal/drivers/hip/hip_device.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_device.c
@@ -432,9 +432,7 @@ static iree_status_t iree_hal_hip_device_enable_peering(
       return IREE_HIP_RESULT_TO_STATUS(symbols, hip_error);
     }
     if (canAccessPeer != 1) {
-      return iree_make_status(IREE_STATUS_PERMISSION_DENIED,
-                              "device %d is not able to access peer %d",
-                              device_id, j);
+      continue;
     }
 
     hip_error = symbols->hipDeviceEnablePeerAccess(j, 0);
@@ -504,7 +502,7 @@ iree_status_t iree_hal_hip_device_create(
     }
 
     // If there are multiple devices, enable peering between them all.
-    if (iree_status_is_ok(status) && device_count > 1) {
+    if (iree_status_is_ok(status)) {
       status = iree_hal_hip_device_enable_peering(symbols, device_id);
     }
   }


### PR DESCRIPTION
https://github.com/iree-org/iree/pull/20114 disabled all peering any time we only have a single physical device backing a logical device. This broke our current sharded models:
https://github.com/iree-org/iree/issues/20409

Our current sharded models are not set up this way, they have multiple logical devices backed by multiple physical devices, so every hip_device has only a single physical device, and peering is never enabled at all (see
https://github.com/iree-org/iree/pull/19555) for the original change to allow this.

This change enables peering for all devices with all devices that are compatible, which should fix our sharded models. Howewver we should at some point update our sharding method to correctly use single logical devices backed by multiple physical devices.