### PR TITLE
[Encoding] Introduce matmul_k encoding.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -163,7 +163,6 @@ def MatmulKAttr : IREEEncoding_Attr<"MatmulK"> {
 
   let parameters = (ins
     "DenseI32ArrayAttr":$k_dims,
-    OptionalParameter<"ArrayAttr", "the serialized layouts, if present">:$layouts
   );
 }
 

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -143,6 +143,31 @@ def EncodingAttr :
 }
 
 //===---------------------------------------------------------------------===//
+// encoding.matmul_k
+//===---------------------------------------------------------------------===//
+
+def MatmulKAttr : IREEEncoding_Attr<"MatmulK"> {
+  let mnemonic = "matmul_k";
+  let summary = [{An attribute that tracks reduction dimensions for matmul}];
+  let description = [{
+    The attribute is specialized for tracking the matmul reduction dimensions
+    only. The encoded dimensions are the reduction dimensions that will be
+    further used in a matmul.
+
+    Any encoding propagation that transforms reduction dimensions could result
+    in undefined behavior. Because it does not encode the transformations. The
+    information is missing in this context.
+  }];
+
+  let assemblyFormat = "`<` struct(params) `>`";
+
+  let parameters = (ins
+    "DenseI32ArrayAttr":$k_dims,
+    OptionalParameter<"ArrayAttr", "the serialized layouts, if present">:$layouts
+  );
+}
+
+//===---------------------------------------------------------------------===//
 // encoding.pad_encoding_layout
 //===---------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -154,8 +154,33 @@ def MatmulKAttr : IREEEncoding_Attr<"MatmulK"> {
     only. The encoded dimensions are the reduction dimensions that will be
     further used in a matmul.
 
+    Example: linalg.matmul ins(%lhs, %rhs) outs(%acc), where the indexing maps
+             are:
+
+      lhs: (M, N, K) -> (M, K)
+      rhs: (M, N, K) -> (K, N)
+      acc: (M, N, K) -> (M, N)
+
+    The encoding for the lhs is iree_encoding.matmul_k<k_dims = [1]>.
+    The encoding for the rhs is iree_encoding.matmul_k<k_dims = [0]>.
+    The encoding for the acc is iree_encoding.matmul_k<k_dims = []>.
+
+    Example: linalg.matmul_transpose_b ins(%lhs, %rhs) outs(%acc), where the
+             indexing maps are:
+
+      lhs: (M, N, K) -> (M, K)
+      rhs: (M, N, K) -> (N, K)
+      acc: (M, N, K) -> (M, N)
+
+    The encoding for the lhs is iree_encoding.matmul_k<k_dims = [1]>.
+    The encoding for the rhs is iree_encoding.matmul_k<k_dims = [1]>.
+    The encoding for the acc is iree_encoding.matmul_k<k_dims = []>.
+
+    There is no difference between static cases and dynamic cases because the
+    dimension sizes are not encoded.
+
     Any encoding propagation that transforms reduction dimensions could result
-    in undefined behavior. Because it does not encode the transformations. The
+    in undefined behavior, because it does not encode the transformations. The
     information is missing in this context.
   }];
 

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -187,7 +187,7 @@ def MatmulKAttr : IREEEncoding_Attr<"MatmulK"> {
   let assemblyFormat = "`<` struct(params) `>`";
 
   let parameters = (ins
-    "DenseI32ArrayAttr":$k_dims,
+    "DenseI32ArrayAttr":$k_dims
   );
 }
 

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingDialect.cpp
@@ -30,14 +30,14 @@ namespace {
 // Used for custom printing support.
 struct EncodingOpAsmInterface : public OpAsmDialectInterface {
   using OpAsmDialectInterface::OpAsmDialectInterface;
-  /// Hooks for getting an alias identifier alias for a given symbol, that is
-  /// not necessarily a part of this dialect. The identifier is used in place
-  /// of the symbol when printing textual IR. These aliases must not contain
-  /// `.` or end with a numeric digit([0-9]+). Returns success if an alias was
-  /// provided, failure otherwise.
+  // Hooks for getting an alias identifier alias for a given symbol, that is
+  // not necessarily a part of this dialect. The identifier is used in place
+  // of the symbol when printing textual IR. These aliases must not contain
+  // `.` or end with a numeric digit([0-9]+). Returns success if an alias was
+  // provided, failure otherwise.
   AliasResult getAlias(Attribute attr, raw_ostream &os) const override {
-    if (llvm::isa<EncodingAttr, TestingEncodingAttr, UnknownEncodingAttr>(
-            attr)) {
+    if (llvm::isa<EncodingAttr, MatmulKAttr, TestingEncodingAttr,
+                  UnknownEncodingAttr>(attr)) {
       os << "encoding";
       return AliasResult::OverridableAlias;
     }

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/test/roundtrip.mlir
@@ -221,3 +221,25 @@ func.func @testing_encoding_with_layouts(%arg0: tensor<?x?xf32, #encoding>) -> t
 // CHECK:      func.func @testing_encoding_with_layouts(
 // CHECK-SAME:   %[[ARG0:.+]]: tensor<?x?xf32, #[[ENCODING]]>
 // CHECK         return %[[ARG0]]
+
+// -----
+
+#encoding = #iree_encoding.matmul_k<k_dims = [1]>
+func.func @matmul_k_encoding_without_layouts(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf32, #encoding> {
+  return %arg0 : tensor<?x?xf32, #encoding>
+}
+// CHECK:     #[[ENCODING:.+]] = #iree_encoding.matmul_k<k_dims = [1]>
+// CHECK:      func.func @matmul_k_encoding_without_layouts(
+// CHECK-SAME:   %[[ARG0:.+]]: tensor<?x?xf32, #[[ENCODING]]>
+// CHECK         return %[[ARG0]]
+
+// -----
+
+#encoding = #iree_encoding.matmul_k<k_dims = [1], layouts = [#iree_encoding.specialized_encoding<123, tensor<?x?xf32>>]>
+func.func @matmul_k_encoding_with_layouts(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf32, #encoding> {
+  return %arg0 : tensor<?x?xf32, #encoding>
+}
+// CHECK:     #[[ENCODING:.+]] = #iree_encoding.matmul_k<k_dims = [1], layouts = [#iree_encoding.specialized_encoding<123, tensor<?x?xf32>>]>
+// CHECK:      func.func @matmul_k_encoding_with_layouts(
+// CHECK-SAME:   %[[ARG0:.+]]: tensor<?x?xf32, #[[ENCODING]]>
+// CHECK         return %[[ARG0]]

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/test/roundtrip.mlir
@@ -232,14 +232,3 @@ func.func @matmul_k_encoding_without_layouts(%arg0: tensor<?x?xf32, #encoding>) 
 // CHECK:      func.func @matmul_k_encoding_without_layouts(
 // CHECK-SAME:   %[[ARG0:.+]]: tensor<?x?xf32, #[[ENCODING]]>
 // CHECK         return %[[ARG0]]
-
-// -----
-
-#encoding = #iree_encoding.matmul_k<k_dims = [1], layouts = [#iree_encoding.specialized_encoding<123, tensor<?x?xf32>>]>
-func.func @matmul_k_encoding_with_layouts(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf32, #encoding> {
-  return %arg0 : tensor<?x?xf32, #encoding>
-}
-// CHECK:     #[[ENCODING:.+]] = #iree_encoding.matmul_k<k_dims = [1], layouts = [#iree_encoding.specialized_encoding<123, tensor<?x?xf32>>]>
-// CHECK:      func.func @matmul_k_encoding_with_layouts(
-// CHECK-SAME:   %[[ARG0:.+]]: tensor<?x?xf32, #[[ENCODING]]>
-// CHECK         return %[[ARG0]]

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/test/roundtrip.mlir
@@ -225,10 +225,10 @@ func.func @testing_encoding_with_layouts(%arg0: tensor<?x?xf32, #encoding>) -> t
 // -----
 
 #encoding = #iree_encoding.matmul_k<k_dims = [1]>
-func.func @matmul_k_encoding_without_layouts(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf32, #encoding> {
+func.func @matmul_k_encoding(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf32, #encoding> {
   return %arg0 : tensor<?x?xf32, #encoding>
 }
 // CHECK:     #[[ENCODING:.+]] = #iree_encoding.matmul_k<k_dims = [1]>
-// CHECK:      func.func @matmul_k_encoding_without_layouts(
+// CHECK:      func.func @matmul_k_encoding(
 // CHECK-SAME:   %[[ARG0:.+]]: tensor<?x?xf32, #[[ENCODING]]>
 // CHECK         return %[[ARG0]]


### PR DESCRIPTION
The attribute is specialized for tracking the matmul reduction dimensions only. The encoded dimensions are the reduction dimensions that will be used by matmuls.

The below message will be removed before we land the PR.

Please check https://github.com/iree-org/iree/pull/20485, if you want to get the full picture about how the new encoding is set up.