### PR TITLE
[codegen] Unroll vector operations in LLVMGPUVectorLowering

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorLowering.cpp
@@ -9,7 +9,9 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Dialect/Vector/Transforms/LoweringPatterns.h"
+#include "mlir/Dialect/Vector/Transforms/VectorRewritePatterns.h"
 #include "mlir/Dialect/Vector/Transforms/VectorTransforms.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
@@ -81,8 +83,87 @@ struct PromoteContractOperands final
   }
 };
 
+SmallVector<int64_t> getWithLeadingOnes(VectorType vectorType) {
+  SmallVector<int64_t> nativeSize(vectorType.getRank(), 1);
+  if (vectorType.getRank() > 0) {
+    nativeSize.back() = vectorType.getShape().back();
+  }
+  return nativeSize;
+}
+
+// Example of unrolling with native shape chosen based on the result's final
+// dimension. In this case the result is a 4x2 vector, so the 'native shape' is
+// 1x2.
+//
+// clang-format off
+//   %transposed = vector.transpose %cst, [1,0] : vector<2x4xf32> to vector<4x2xf32>
+// clang-format on
+//
+//  becomes
+//
+// clang-format off
+//   %cst = arith.constant dense<0.000000e+00> : vector<4x2xf32>
+//   %0 = vector.extract_strided_slice %arg0 {offsets = [0, 0], sizes = [2, 1], strides = [1, 1]} : vector<2x4xf32> to vector<2x1xf32>
+//   %1 = vector.transpose %0, [1, 0] : vector<2x1xf32> to vector<1x2xf32>
+//   %2 = vector.insert_strided_slice %1, %cst {offsets = [0, 0], strides = [1, 1]} : vector<1x2xf32> into vector<4x2xf32>
+//   %3 = vector.extract_strided_slice %arg0 {offsets = [0, 1], sizes = [2, 1], strides = [1, 1]} : vector<2x4xf32> to vector<2x1xf32>
+//   %4 = vector.transpose %3, [1, 0] : vector<2x1xf32> to vector<1x2xf32>
+//   %5 = vector.insert_strided_slice %4, %2 {offsets = [1, 0], strides = [1, 1]} : vector<1x2xf32> into vector<4x2xf32>
+//   [...]
+// clang-format on
+//
+//
+// TODO(newling) Further analysis can improve this. For example flattening
+// out unit dimensions and canonicalizations might help. Example:
+//
+// clang-format off
+//   %t = vector.transpose %cst, [0,2,1] : vector<10x1x4xf32> to vector<10x4x1xf32>
+// clang-format on
+//
+// should ideally not result in 40 extract-insert pairs of single f32 elements.
+SmallVector<int64_t> getNativeVectorShapeImpl(vector::TransposeOp op) {
+  return getWithLeadingOnes(op.getResultVectorType());
+}
+
+SmallVector<int64_t> getNativeVectorShapeImpl(vector::GatherOp op) {
+  return getWithLeadingOnes(op.getVectorType());
+}
+
+SmallVector<int64_t> getNativeVectorShapeImpl(vector::ReductionOp op) {
+  return getWithLeadingOnes(op.getSourceVectorType());
+}
+
+// As we do unrolling after lowering vector operations, it's not necessary to
+// provide an unroll shape for most ops (as compared to SPIRV).
+//
+// Unrolling here assumes that the input has already been tiled such that the
+// inner-most dimensions of vectors are the optimal hardware vector size to
+// operate on.
+std::optional<SmallVector<int64_t>> getNativeVectorShape(Operation *op) {
+
+  // Unroll shape for elementwise operations. Example:
+  //
+  // clang-format off
+  //   %2 = arith.truncf %1 : vector<10x4xf32> to vector<10x4xf16>
+  // clang-format on
+  //
+  // will be unrolled to 10 arith.truncf operations on vectors of shape 1x4.
+  if (OpTrait::hasElementwiseMappableTraits(op) && op->getNumResults() == 1) {
+    if (auto vecType = llvm::dyn_cast<VectorType>(op->getResultTypes()[0])) {
+      return getWithLeadingOnes(vecType);
+    }
+  }
+
+  return TypeSwitch<Operation *, std::optional<SmallVector<int64_t>>>(op)
+      .Case<vector::ReductionOp, vector::TransposeOp, vector::GatherOp>(
+          [](auto typedOp) { return getNativeVectorShapeImpl(typedOp); })
+      .Default([](Operation *) { return std::nullopt; });
+}
+
 struct LLVMGPUVectorLoweringPass final
     : impl::LLVMGPUVectorLoweringPassBase<LLVMGPUVectorLoweringPass> {
+  using impl::LLVMGPUVectorLoweringPassBase<
+      LLVMGPUVectorLoweringPass>::LLVMGPUVectorLoweringPassBase;
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<affine::AffineDialect>();
     registry.insert<memref::MemRefDialect>();
@@ -92,22 +173,23 @@ struct LLVMGPUVectorLoweringPass final
   void runOnOperation() override {
     auto funcOp = getOperation();
 
+    MLIRContext *context = funcOp.getContext();
+
     {
       // Lower high level vector operations like contract or multidim reduce ops
       // to lower level vector ops.
-      RewritePatternSet contractLoweringPatterns(funcOp.getContext());
+      RewritePatternSet contractLoweringPatterns(context);
       auto options =
           vector::VectorTransformsOptions().setVectorTransformsOptions(
               vector::VectorContractLowering::OuterProduct);
       vector::populateVectorTransferPermutationMapLoweringPatterns(
           contractLoweringPatterns);
       vector::TransposeOp::getCanonicalizationPatterns(contractLoweringPatterns,
-                                                       funcOp.getContext());
+                                                       context);
       vector::populateVectorBroadcastLoweringPatterns(contractLoweringPatterns);
       vector::populateVectorContractLoweringPatterns(
           contractLoweringPatterns, options.vectorContractLowering);
-      contractLoweringPatterns.add<PromoteContractOperands>(
-          funcOp->getContext());
+      contractLoweringPatterns.add<PromoteContractOperands>(context);
       vector::populateVectorGatherLoweringPatterns(contractLoweringPatterns);
       vector::populateVectorMaskOpLoweringPatterns(contractLoweringPatterns);
       vector::populateVectorShapeCastLoweringPatterns(contractLoweringPatterns);
@@ -120,7 +202,7 @@ struct LLVMGPUVectorLoweringPass final
       }
     }
 
-    RewritePatternSet vectorToLoopsPatterns(&getContext());
+    RewritePatternSet vectorToLoopsPatterns(context);
     VectorTransferToSCFOptions vectorToSCFOptions;
     vectorToSCFOptions.enableFullUnroll();
     populateVectorToSCFConversionPatterns(vectorToLoopsPatterns,
@@ -130,6 +212,34 @@ struct LLVMGPUVectorLoweringPass final
     if (failed(
             applyPatternsGreedily(funcOp, std::move(vectorToLoopsPatterns)))) {
       return signalPassFailure();
+    }
+
+    if (!unroll) {
+      return;
+    }
+
+    // Canonicalize in preparation for unrolling.
+    {
+      RewritePatternSet patterns(context);
+      vector::InsertOp::getCanonicalizationPatterns(patterns, context);
+      vector::ExtractOp::getCanonicalizationPatterns(patterns, context);
+      vector::BroadcastOp::getCanonicalizationPatterns(patterns, context);
+      vector::ShapeCastOp::getCanonicalizationPatterns(patterns, context);
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
+        return signalPassFailure();
+      }
+    }
+
+    // Unroll vector operations to the optimal size for a single thread to
+    // operate on.
+    {
+      RewritePatternSet patterns(context);
+      auto opts = vector::UnrollVectorOptions().setNativeShapeFn(
+          [=](auto op) { return getNativeVectorShape(op); });
+      vector::populateVectorUnrollPatterns(patterns, opts);
+      if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
+        return signalPassFailure();
+      }
     }
   }
 };

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.td
@@ -119,6 +119,11 @@ def LLVMGPUVectorDistributePass :
 def LLVMGPUVectorLoweringPass :
     InterfacePass<"iree-llvmgpu-vector-lowering", "mlir::FunctionOpInterface"> {
   let summary = "Pass to lower Vector ops before conversion to LLVM.";
+  let options = [
+    Option<"unroll", "unroll", "bool", /*default=*/"true",
+           "Controls whether to perform unrolling after inital vector lowering.">,
+  ];
+
 }
 
 def LLVMGPUVectorToGPUPass :

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_mma_sync_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_mma_sync_pipeline_test.mlir
@@ -3,7 +3,6 @@
 // Verify that a simple element wise op gets lowered succefully all the way to
 // nvvm/llvm dialect via mma.sync path.
 
-// -----
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
@@ -147,13 +146,7 @@ hal.executable @mma_fused_f32 {
 //          CHECK:   nvvm.ldmatrix{{.*}} : (!llvm.ptr<3>) -> !llvm.struct<(i32, i32, i32, i32)>
 //  CHECK-COUNT-4:   llvm.extractvalue{{.*}} : !llvm.struct<(i32, i32, i32, i32)>
 //          CHECK:   llvm.load{{.*}} : !llvm.ptr<3> -> f32
-//          CHECK:   llvm.insertvalue{{.*}} : !llvm.array<2 x vector<1xf32>>
-//          CHECK:   llvm.load{{.*}} : !llvm.ptr<3> -> f32
-//          CHECK:   llvm.insertvalue{{.*}} : !llvm.array<2 x vector<1xf32>>
-//          CHECK:   llvm.load{{.*}} : !llvm.ptr<3> -> f32
-//          CHECK:   llvm.insertvalue{{.*}} : !llvm.array<2 x vector<1xf32>>
-//          CHECK:   llvm.load{{.*}} : !llvm.ptr<3> -> f32
-//          CHECK:   llvm.insertvalue{{.*}} : !llvm.array<2 x vector<1xf32>>
+//  CHECK-COUNT-4:   llvm.insertvalue{{.*}} : !llvm.array<2 x vector<1xf32>>
 //          CHECK:   llvm.br
 //          CHECK:   nvvm.ldmatrix{{.*}} : (!llvm.ptr<3>) -> !llvm.struct<(i32, i32, i32, i32)>
 //  CHECK-COUNT-4:   llvm.extractvalue{{.*}} : !llvm.struct<(i32, i32, i32, i32)>
@@ -164,13 +157,7 @@ hal.executable @mma_fused_f32 {
 //          CHECK:   nvvm.ldmatrix{{.*}} : (!llvm.ptr<3>) -> !llvm.struct<(i32, i32, i32, i32)>
 //  CHECK-COUNT-4:   llvm.extractvalue{{.*}} : !llvm.struct<(i32, i32, i32, i32)>
 //          CHECK:   llvm.load{{.*}} : !llvm.ptr<3> -> f32
-//          CHECK:   llvm.insertvalue{{.*}} : !llvm.array<2 x vector<1xf32>>
-//          CHECK:   llvm.load{{.*}} : !llvm.ptr<3> -> f32
-//          CHECK:   llvm.insertvalue{{.*}} : !llvm.array<2 x vector<1xf32>>
-//          CHECK:   llvm.load{{.*}} : !llvm.ptr<3> -> f32
-//          CHECK:   llvm.insertvalue{{.*}} : !llvm.array<2 x vector<1xf32>>
-//          CHECK:   llvm.load{{.*}} : !llvm.ptr<3> -> f32
-//          CHECK:   llvm.insertvalue{{.*}} : !llvm.array<2 x vector<1xf32>>
+//  CHECK-COUNT-4:   llvm.insertvalue{{.*}} : !llvm.array<2 x vector<1xf32>>
 //  CHECK-COUNT-2:   nvvm.mma.sync {{.*}} {layoutA = #nvvm.mma_layout<row>, layoutB = #nvvm.mma_layout<col>, multiplicandAPtxType = #nvvm.mma_type<tf32>, multiplicandBPtxType = #nvvm.mma_type<tf32>, shape = #nvvm.shape<m = 16, n = 8, k = 8>} : (i32, i32, f32) -> !llvm.struct<(f32, f32, f32, f32)>
 //          CHECK:   llvm.br
 //      CHECK-NOT:   nvvm.mma.sync

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_lowering.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-llvmgpu-vector-lowering{unroll=0},canonicalize,cse))" --split-input-file %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-llvmgpu-vector-lowering{unroll=0},canonicalize,cse))" --split-input-file %s | FileCheck %s --check-prefix=NOUNROLL
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-llvmgpu-vector-lowering{unroll=1},canonicalize,cse))" --split-input-file %s | FileCheck %s --check-prefix=UNROLL
 
 module {
@@ -10,13 +10,13 @@ module {
     return %broadcast_read : vector<1x8xf16>
   }
 }
-// CHECK-LABEL: func.func @broadcast_read_lowering
-//  CHECK-SAME: (%[[ARG0:.+]]: memref<4096x32xf16>)
-//  CHECK: %[[LOAD:.+]] = vector.load %[[ARG0]]{{.*}} : memref<4096x32xf16>
-//  CHECK: %[[ELEM:.+]] = vector.extract %[[LOAD]][0] : f16 from vector<1xf16>
-//  CHECK: %[[SPLAT:.+]] = vector.splat %[[ELEM]] : vector<8xf16>
-//  CHECK: %[[INSERT:.+]] = vector.broadcast %[[SPLAT]] : vector<8xf16> to vector<1x8xf16>
-//  CHECK: return %[[INSERT]]
+// NOUNROLL-LABEL: func.func @broadcast_read_lowering
+//  NOUNROLL-SAME: (%[[ARG0:.+]]: memref<4096x32xf16>)
+//       NOUNROLL:   %[[LOAD:.+]] = vector.load %[[ARG0]]{{.*}} : memref<4096x32xf16>
+//       NOUNROLL:   %[[ELEM:.+]] = vector.extract %[[LOAD]][0] : f16 from vector<1xf16>
+//       NOUNROLL:   %[[SPLAT:.+]] = vector.splat %[[ELEM]] : vector<8xf16>
+//       NOUNROLL:   %[[INSERT:.+]] = vector.broadcast %[[SPLAT]] : vector<8xf16> to vector<1x8xf16>
+//       NOUNROLL:   return %[[INSERT]]
 
 // -----
 
@@ -27,26 +27,53 @@ module {
   }
 }
 
-// CHECK-LABEL: func.func @contraction_masked
-// CHECK-SAME: %[[LHS:.+]]: vector<3xf16>, %[[RHS:.+]]: vector<2x3xf16>, %[[ACC:.+]]: vector<2xf32>, %[[MASK:.+]]: vector<3x2xi1>
-// CHECK: %[[TPRHS:.+]] = vector.transpose %[[RHS]], [1, 0] : vector<2x3xf16> to vector<3x2xf16>
-// CHECK: %[[RHS_EXTRACT:.+]] = vector.extract %[[TPRHS]][0] : vector<2xf16> from vector<3x2xf16>
-// CHECK: %[[LHS_EXTRACT:.+]] = vector.extract %[[LHS]][0] : f16 from vector<3xf16>
-// CHECK: %[[RHS_CAST:.+]] = arith.extf %[[RHS_EXTRACT]] : vector<2xf16> to vector<2xf32>
-// CHECK: %[[LHS_CAST:.+]] = arith.extf %[[LHS_EXTRACT]] : f16 to f32
-// CHECK: %[[MASK_EXTRACT:.+]] = vector.extract %[[MASK]][0] : vector<2xi1> from vector<3x2xi1>
-// CHECK: %[[LHS_SPLAT:.+]] = vector.splat %[[LHS_CAST]] : vector<2xf32>
-// CHECK: %[[FMA:.+]] = vector.fma %[[RHS_CAST]], %[[LHS_SPLAT]], %[[ACC]] : vector<2xf32>
-// CHECK: arith.select %[[MASK_EXTRACT]], %[[FMA]], %[[ACC]] : vector<2xi1>, vector<2xf32>
+// NOUNROLL-LABEL: func.func @contraction_masked
+//  NOUNROLL-SAME: %[[LHS:.+]]: vector<3xf16>, %[[RHS:.+]]: vector<2x3xf16>,
+//  NOUNROLL-SAME: %[[ACC:.+]]: vector<2xf32>, %[[MASK:.+]]: vector<3x2xi1>
+//       NOUNROLL:   %[[TPRHS:.+]] = vector.transpose %[[RHS]], [1, 0] : vector<2x3xf16> to vector<3x2xf16>
+//       NOUNROLL:   %[[RHS_EXTRACT:.+]] = vector.extract %[[TPRHS]][0] : vector<2xf16> from vector<3x2xf16>
+//       NOUNROLL:   %[[LHS_EXTRACT:.+]] = vector.extract %[[LHS]][0] : f16 from vector<3xf16>
+//       NOUNROLL:   %[[RHS_CAST:.+]] = arith.extf %[[RHS_EXTRACT]] : vector<2xf16> to vector<2xf32>
+//       NOUNROLL:   %[[LHS_CAST:.+]] = arith.extf %[[LHS_EXTRACT]] : f16 to f32
+//       NOUNROLL:   %[[MASK_EXTRACT:.+]] = vector.extract %[[MASK]][0] : vector<2xi1> from vector<3x2xi1>
+//       NOUNROLL:   %[[LHS_SPLAT:.+]] = vector.splat %[[LHS_CAST]] : vector<2xf32>
+//       NOUNROLL:   %[[FMA:.+]] = vector.fma %[[RHS_CAST]], %[[LHS_SPLAT]], %[[ACC]] : vector<2xf32>
+//       NOUNROLL:   arith.select %[[MASK_EXTRACT]], %[[FMA]], %[[ACC]] : vector<2xi1>, vector<2xf32>
 
-// With unrolling, the transpose gets decomposed into transposes on slices.
+// With unrolling, the transpose gets decomposed into transposes on slices in the final dimension of the result.
+//
 // UNROLL-LABEL: func.func @contraction_masked
-// UNROLL-SAME: %[[LHS:.+]]: vector<3xf16>, %[[RHS:.+]]: vector<2x3xf16>, %[[ACC:.+]]: vector<2xf32>, %[[MASK:.+]]: vector<3x2xi1>
-// UNROLL: %[[STRIDED_SLICE_0:.+]] = vector.extract_strided_slice %[[RHS]] {offsets = [0, 0], sizes = [2, 1], strides = [1, 1]} : vector<2x3xf16> to vector<2x1xf16>
-// UNROLL: %[[TRANSPOSE_0:.+]] = vector.transpose %[[STRIDED_SLICE_0]], [1, 0] : vector<2x1xf16> to vector<1x2xf16>
-// UNROLL: %[[STRIDED_SLICE_1:.+]] = vector.extract_strided_slice %[[RHS]] {offsets = [0, 1], sizes = [2, 1], strides = [1, 1]} : vector<2x3xf16> to vector<2x1xf16>
-// UNROLL: %[[TRANSPOSE_1:.+]] = vector.transpose %[[STRIDED_SLICE_1]], [1, 0] : vector<2x1xf16> to vector<1x2xf16>
-// UNROLL: %[[STRIDED_SLICE_2:.+]] = vector.extract_strided_slice %[[RHS]] {offsets = [0, 2], sizes = [2, 1], strides = [1, 1]} : vector<2x3xf16> to vector<2x1xf16>
-// UNROLL: %[[TRANSPOSE_2:.+]] = vector.transpose %[[STRIDED_SLICE_2]], [1, 0] : vector<2x1xf16> to vector<1x2xf16>
-// UNROLL: %[[LHS_EXTRACT_0:.+]] = vector.extract %[[TRANSPOSE_0]][0] : vector<2xf16> from vector<1x2xf16>
-// UNROLL: %[[CAST_0:.+]] = arith.extf %[[LHS_EXTRACT_0]] : vector<2xf16> to vector<2xf32>
+//  UNROLL-SAME: %[[LHS:.+]]: vector<3xf16>, %[[RHS:.+]]: vector<2x3xf16>, %[[ACC:.+]]: vector<2xf32>, %[[MASK:.+]]: vector<3x2xi1>
+//       UNROLL:   %[[STRIDED_SLICE_0:.+]] = vector.extract_strided_slice %[[RHS]] {offsets = [0, 0], sizes = [2, 1], strides = [1, 1]} : vector<2x3xf16> to vector<2x1xf16>
+//       UNROLL:   %[[TRANSPOSE_0:.+]] = vector.transpose %[[STRIDED_SLICE_0]], [1, 0] : vector<2x1xf16> to vector<1x2xf16>
+//       UNROLL:   %[[STRIDED_SLICE_1:.+]] = vector.extract_strided_slice %[[RHS]] {offsets = [0, 1], sizes = [2, 1], strides = [1, 1]} : vector<2x3xf16> to vector<2x1xf16>
+//       UNROLL:                         vector.transpose %[[STRIDED_SLICE_1]], [1, 0] : vector<2x1xf16> to vector<1x2xf16>
+//       UNROLL:   %[[STRIDED_SLICE_2:.+]] = vector.extract_strided_slice %[[RHS]] {offsets = [0, 2], sizes = [2, 1], strides = [1, 1]} : vector<2x3xf16> to vector<2x1xf16>
+//       UNROLL:                         vector.transpose %[[STRIDED_SLICE_2]], [1, 0] : vector<2x1xf16> to vector<1x2xf16>
+//       UNROLL:   %[[LHS_EXTRACT_0:.+]] = vector.extract %[[TRANSPOSE_0]][0] : vector<2xf16> from vector<1x2xf16>
+//       UNROLL:   %[[CAST_0:.+]] = arith.extf %[[LHS_EXTRACT_0]] : vector<2xf16> to vector<2xf32>
+
+
+// -----
+
+func.func @test_unroll(%arg0: vector<4x1x1x1x4xf32>, %arg1: vector<4x1x1x1x4xf32>) -> vector<2x1x1xf16> {
+  %cst = arith.constant dense<0.000000e+00> : vector<2x1x1xf16>
+  %cst_0 = arith.constant dense<0.000000e+00> : vector<2x4x1x1x1x4xf32>
+  %0 = vector.insert %arg0, %cst_0 [0] : vector<4x1x1x1x4xf32> into vector<2x4x1x1x1x4xf32>
+  %1 = vector.insert %arg1, %0 [1] : vector<4x1x1x1x4xf32> into vector<2x4x1x1x1x4xf32>
+  %2 = arith.truncf %1 : vector<2x4x1x1x1x4xf32> to vector<2x4x1x1x1x4xf16>
+  %3 = vector.multi_reduction <maximumf>, %2, %cst [1, 3, 5] : vector<2x4x1x1x1x4xf16> to vector<2x1x1xf16>
+  return %3 : vector<2x1x1xf16>
+}
+
+// The arith.tuncf gets unrolled to 8 truncf operations on 4 elements
+//    UNROLL-LABEL: func.func @test_unroll
+//     UNROLL-SAME: (%[[ARG0:.+]]: vector<4x1x1x1x4xf32>, %[[ARG1:.+]]: vector<4x1x1x1x4xf32>) -> vector<2x1x1xf16>
+//          UNROLL:   %[[EXTRACT_0:.+]] = vector.extract %[[ARG0]][0, 0, 0, 0] : vector<4xf32> from vector<4x1x1x1x4xf32>
+//          UNROLL:   %[[RESHAPE_0:.+]] = vector.shape_cast %[[EXTRACT_0]] : vector<4xf32> to vector<1x1x1x1x1x4xf32>
+//          UNROLL:     arith.truncf %[[RESHAPE_0]] : vector<1x1x1x1x1x4xf32> to vector<1x1x1x1x1x4xf16>
+//  UNROLL-COUNT-7:     arith.truncf {{.*}} : vector<1x1x1x1x1x4xf32> to vector<1x1x1x1x1x4xf16>
+//      UNROLL-NOT:     arith.truncf
+// UNROLL-COUNT-16:     arith.maximumf {{.*}} : vector<2xf16>
+//      UNROLL-NOT:     arith.maximumf
+//          UNROLL:     return {{.*}} : vector<2x1x1xf16>


### PR DESCRIPTION

Unroll vector operations, after lowering high-level ops like vector.multi_reduction and vector.contract to primitives. 

Code like
```
 %434 = arith.truncf %324 : vector<2x4x1x1x1x4xf32> to vector<2x4x1x1x1x4xf16>
 ```
 
 Gets unrolled to 8 `arith.truncf` ops on 4-element vectors of type vector<1x1x1x1x1x4xf16>. All but the inner-most dimension get fully unrolled. Basic idea from [SPIRV](https://github.com/iree-org/iree/blob/99c162ceeea17d3e7d124399a7658918fedad1d4/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVInitialVectorLowering.cpp#L9), however this PR does less analysis (it assumes that the inner-dimension is already the optimal vector size) and supports fewer ops (because it happens after, for example, vector.contract has been lowered, which doesn't seem to be the case for SPIRV). 
 
 This is the a sub-PR of https://github.com/iree-org/iree/pull/20451 (I'll probably close that one eventually). 
 
 #### Motivation: 
 
 avoid IR like 
 
```
  %1490 = llvm.extractvalue %1465[1, 1, 0, 0, 0] : !llvm.array<2 x array<4 x array<1 x array<1 x array<1 x vector<4xf32>>>>>>
```

being generated in `iree-convert-to-rocdl`, and allow us to perform better/more fine grained optimization before lowering to LLVM. 