### PR TITLE
Integrate llvm-project@bb1f32ded0b7

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
@@ -616,8 +616,8 @@ struct LinearizeTransferWriteIndices final
     }
 
     rewriter.replaceOpWithNewOp<vector::TransferWriteOp>(
-        transferWriteOp, adaptor.getVector(), adaptor.getSource(), linearIndex,
-        AffineMapAttr::get(rewriter.getDimIdentityMap()),
+        transferWriteOp, adaptor.getValueToStore(), adaptor.getSource(),
+        linearIndex, AffineMapAttr::get(rewriter.getDimIdentityMap()),
         transferWriteOp.getInBoundsAttr());
     return success();
   }

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -403,7 +403,7 @@ struct DistributeTransferWrite final
                                 DistributionSignature &signature,
                                 PatternRewriter &rewriter) const override {
     NestedLayoutAttr vectorLayout =
-        dyn_cast<NestedLayoutAttr>(signature[writeOp.getVector()]);
+        dyn_cast<NestedLayoutAttr>(signature[writeOp.getValueToStore()]);
     if (!vectorLayout) {
       return rewriter.notifyMatchFailure(writeOp,
                                          "non-nested transfer_write layout");
@@ -439,7 +439,7 @@ struct DistributeTransferWrite final
     }
 
     Value distributedVector =
-        getDistributed(rewriter, writeOp.getVector(), vectorLayout);
+        getDistributed(rewriter, writeOp.getValueToStore(), vectorLayout);
 
     ValueRange indices = writeOp.getIndices();
     AffineMap permMap = writeOp.getPermutationMap();

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/VectorReductionToGPU.cpp
@@ -158,7 +158,7 @@ struct InsertToBroadcast final : OpRewritePattern<vector::InsertOp> {
     if (insertOp.getDestVectorType().getNumElements() != 1)
       return failure();
     rewriter.replaceOpWithNewOp<vector::BroadcastOp>(
-        insertOp, insertOp.getDestVectorType(), insertOp.getSource());
+        insertOp, insertOp.getDestVectorType(), insertOp.getValueToStore());
     return success();
   }
 };

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.cpp
@@ -43,6 +43,10 @@ OpFoldResult ToSIMTOp::fold(FoldAdaptor) {
 // TransferGatherOp
 //===----------------------------------------------------------------------===//
 
+VectorType TransferGatherOp::getVectorType() {
+  return getType();
+}
+
 Speculation::Speculatability TransferGatherOp::getSpeculatability() {
   if (isa<RankedTensorType>(getSource().getType())) {
     return Speculation::Speculatable;

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.cpp
@@ -43,9 +43,7 @@ OpFoldResult ToSIMTOp::fold(FoldAdaptor) {
 // TransferGatherOp
 //===----------------------------------------------------------------------===//
 
-VectorType TransferGatherOp::getVectorType() {
-  return getType();
-}
+VectorType TransferGatherOp::getVectorType() { return getType(); }
 
 Speculation::Speculatability TransferGatherOp::getSpeculatability() {
   if (isa<RankedTensorType>(getSource().getType())) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.cpp
@@ -5,7 +5,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.h"
-#include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
@@ -143,7 +142,7 @@ void TransferGatherOp::print(OpAsmPrinter &p) {
   p << " : ";
   p << getShapedType() << ", ";
   llvm::interleaveComma(getIndexVecs().getType(), p);
-  p << ", " << getVectorType();
+  p << ", " << getType();
 }
 
 static LogicalResult
@@ -263,7 +262,7 @@ static LogicalResult verifyPermutationMap(
 LogicalResult TransferGatherOp::verify() {
   // Consistency of elemental types in source and vector.
   ShapedType shapedType = getShapedType();
-  VectorType vectorType = getVectorType();
+  VectorType vectorType = getType();
   VectorType maskType = getMaskType();
   Type paddingType = getPadding().getType();
   AffineMap permutationMap = getPermutationMap();
@@ -642,7 +641,7 @@ struct FoldContigousGatherToTransferRead final
 
     // Canonicalize to vector.transfer_read.
     rewriter.replaceOpWithNewOp<vector::TransferReadOp>(
-        xferOp, xferOp.getVectorType(), xferOp.getSource(), xferOp.getIndices(),
+        xferOp, xferOp.getType(), xferOp.getSource(), xferOp.getIndices(),
         xferOp.getPermutationMap(), xferOp.getPadding(), xferOp.getMask(),
         xferOp.getInBounds());
     return success();

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
@@ -119,17 +119,17 @@ def IREEVectorExt_TransferGatherOp : IREEVectorExt_PureOp<"transfer_gather", [
     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
     DeclareOpInterfaceMethods<ConditionallySpeculatable>,
     AttrSizedOperandSegments
-  ]>,
-  Arguments<(ins AnyShaped:$source,
-                 Variadic<Index>:$indices,
-                 Variadic<VectorOfAnyRankOf<[Index]>>:$index_vecs,
-                 BoolArrayAttr:$indexed,
-                 AffineMapArrayAttr:$indexed_maps,
-                 AffineMapAttr:$permutation_map,
-                 AnyType:$padding,
-                 Optional<VectorOfNonZeroRankOf<[I1]>>:$mask,
-                 BoolArrayAttr:$in_bounds)>,
-  Results<(outs AnyVectorOfAnyRank:$vector)> {
+  ]> {
+  let arguments = (ins AnyShaped:$source,
+                       Variadic<Index>:$indices,
+                       Variadic<VectorOfAnyRankOf<[Index]>>:$index_vecs,
+                       BoolArrayAttr:$indexed,
+                       AffineMapArrayAttr:$indexed_maps,
+                       AffineMapAttr:$permutation_map,
+                       AnyType:$padding,
+                       Optional<VectorOfNonZeroRankOf<[I1]>>:$mask,
+                       BoolArrayAttr:$in_bounds);
+  let results = (outs AnyVectorOfAnyRank:$vector);
 
   let summary = "Gathers a supervector from memory into an SSA vector value.";
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVInitialVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVInitialVectorLowering.cpp
@@ -103,9 +103,11 @@ Operation *stripElementBitPatternPreservingParents(Value op) {
             .Case<vector::ExtractOp, vector::ExtractElementOp,
                   vector::ExtractStridedSliceOp>(
                 [](auto extract) { return extract.getVector(); })
-            .Case<vector::InsertOp, vector::InsertElementOp,
-                  vector::InsertStridedSliceOp>(
-                [](auto insert) { return insert.getSource(); })
+            .Case<vector::InsertElementOp>([](vector::InsertElementOp insert) {
+              return insert.getSource();
+            })
+            .Case<vector::InsertOp, vector::InsertStridedSliceOp>(
+                [](auto insert) { return insert.getValueToStore(); })
             .Case<vector::TransposeOp>([](vector::TransposeOp transpose) {
               return transpose.getVector();
             })

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
@@ -475,8 +475,8 @@ public:
     // If the transfer_write can be replaced by a store after vectorization cast
     // the original value and use StoreOp.
     if (*vectorMemrefElemSize == *writeVecSize) {
-      Value data = rewriter.create<vector::BitCastOp>(loc, memrefVectorType,
-                                                      adaptor.getVector());
+      Value data = rewriter.create<vector::BitCastOp>(
+          loc, memrefVectorType, adaptor.getValueToStore());
       rewriter.replaceOpWithNewOp<memref::StoreOp>(
           write, data, adaptor.getSource(), indices.value());
       return success();
@@ -506,7 +506,7 @@ public:
     for (int i = 0; i < vectorCount; ++i) {
       offsets.back() = i * memrefVectorType.getNumElements();
       auto slice = rewriter.create<vector::ExtractStridedSliceOp>(
-          loc, adaptor.getVector(), offsets, sizes, strides);
+          loc, adaptor.getValueToStore(), offsets, sizes, strides);
       auto component =
           rewriter.create<vector::BitCastOp>(loc, memrefVectorType, slice);
       Value iVal = rewriter.create<arith::ConstantIndexOp>(loc, i);


### PR DESCRIPTION
The changes are caused by:
* https://github.com/llvm/llvm-project/pull/134206

Reverts:
* https://github.com/llvm/llvm-project/pull/125883. This breaks the RISC-V test: `e2e/math/math_ops_llvm-cpu.mlir`.