### PR TITLE
[DT] Split out iree_encoding.layout from EncodingAttr.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/BUILD.bazel
@@ -55,6 +55,7 @@ iree_compiler_cc_library(
         ":PassHeaders",
         ":PassesIncGen",
         "//compiler/src/iree/compiler/Codegen/Common",
+        "//compiler/src/iree/compiler/Codegen/Dialect/CPU/IR:IREECPUDialect",
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils",
         "//compiler/src/iree/compiler/Codegen/Interfaces:UKernelOpInterface",

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/CMakeLists.txt
@@ -77,6 +77,7 @@ iree_cc_library(
     MLIRVectorTransforms
     iree::builtins::ukernel::exported_bits
     iree::compiler::Codegen::Common
+    iree::compiler::Codegen::Dialect::CPU::IR::IREECPUDialect
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
     iree::compiler::Codegen::Dialect::Codegen::Utils
     iree::compiler::Codegen::Interfaces::UKernelOpInterface

--- a/compiler/src/iree/compiler/Codegen/Common/CPU/test/lower_to_ukernel_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/CPU/test/lower_to_ukernel_ops.mlir
@@ -554,7 +554,8 @@ func.func @query_tile_sizes_2d() -> (index, index)  attributes {
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
-#encoding = #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f32, f32, f32], layouts = [#iree_cpu.vmvx_encoding_layout<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [-9223372036854775808, -9223372036854775808], outerDimsPerm = [0, 1]}}>]>
+#encoding_attr = #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f32, f32, f32]>
+#encoding = #iree_encoding.layout<[#iree_cpu.vmvx_encoding_layout<configuration = {encoding_attr = #encoding_attr, encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [-9223372036854775808, -9223372036854775808], outerDimsPerm = [0, 1]}}>]>
 func.func @query_tile_sizes_2d_with_layouts() -> (index, index)  attributes {
   hal.executable.target = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {ukernels = "all"}>
 } {

--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
@@ -76,10 +76,7 @@ MaterializeEncodingConversionTarget::MaterializeEncodingConversionTarget(
   markUnknownOpDynamicallyLegal([](Operation *op) {
     auto typeHasDataTilingEncoding = [](Type t) -> bool {
       auto tensorType = dyn_cast<RankedTensorType>(t);
-      if (!tensorType) {
-        return false;
-      }
-      if (!tensorType.getEncoding()) {
+      if (!tensorType || !tensorType.getEncoding()) {
         return false;
       }
       return isa<IREE::Encoding::EncodingAttr, IREE::Encoding::LayoutAttr>(

--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
@@ -76,9 +76,14 @@ MaterializeEncodingConversionTarget::MaterializeEncodingConversionTarget(
   markUnknownOpDynamicallyLegal([](Operation *op) {
     auto typeHasDataTilingEncoding = [](Type t) -> bool {
       auto tensorType = dyn_cast<RankedTensorType>(t);
-      if (!tensorType)
+      if (!tensorType) {
         return false;
-      return getEncodingAttr(tensorType) != nullptr;
+      }
+      if (!tensorType.getEncoding()) {
+        return false;
+      }
+      return isa<IREE::Encoding::EncodingAttr, IREE::Encoding::LayoutAttr>(
+          tensorType.getEncoding());
     };
     auto valueHasDataTilingEncoding = [=](Value v) -> bool {
       return typeHasDataTilingEncoding(v.getType());
@@ -103,15 +108,12 @@ MaterializeEncodingTypeConverter::getEncodingInfo(RankedTensorType type) const {
 
 std::optional<IREE::Codegen::MaterializeEncodingInfo>
 getEncodingInfoFromLayouts(RankedTensorType type) {
-  auto encodingAttr = IREE::Encoding::getEncodingAttr(type);
-  if (!encodingAttr) {
+  auto layoutAttr =
+      dyn_cast_or_null<IREE::Encoding::LayoutAttr>(type.getEncoding());
+  if (!layoutAttr) {
     return std::nullopt;
   }
-  ArrayAttr layoutsAttr = encodingAttr.getLayouts();
-  if (!layoutsAttr) {
-    return std::nullopt;
-  }
-  ArrayRef<Attribute> layouts = layoutsAttr.getValue();
+  ArrayRef<Attribute> layouts = layoutAttr.getLayouts().getValue();
   assert(layouts.size() == 1 && "only single layout is supported");
   if (auto layout = dyn_cast<IREE::Codegen::LayoutAttrInterface>(layouts[0])) {
     return layout.getEncodingInfo(type);

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
@@ -36,7 +36,7 @@ namespace {
 // if there's no encoding at all.
 static PadEncodingLayoutAttr getPadLayout(RankedTensorType type) {
   auto encoding =
-      dyn_cast_or_null<IREE::Encoding::EncodingAttr>(type.getEncoding());
+      dyn_cast_or_null<IREE::Encoding::LayoutAttr>(type.getEncoding());
   if (!encoding) {
     return nullptr;
   }

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPatterns.cpp
@@ -119,11 +119,6 @@ FailureOr<Value> lowerSetEncodingOpToPackOp(
     return source;
   }
 
-  auto encoding = IREE::Encoding::getEncodingAttr(resultType);
-  if (!encoding) {
-    return failure();
-  }
-
   // Create `tensor.empty` operation for the result of the pack operation.
   Location loc = encodingOp.getLoc();
   FailureOr<SmallVector<OpFoldResult>> innerTileSizesOfr = getInnerTileSizesOfr(

--- a/compiler/src/iree/compiler/Codegen/Common/test/gpu_materialize_encoding_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/gpu_materialize_encoding_gfx942.mlir
@@ -1204,7 +1204,7 @@ func.func @batch_matmul_lowering_MFMA_F32_16x16x16_BF16() {
 //----------------------------------------------------------------------------//
 
 #executable_target_rocm_hsaco_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree.encoding.resolver = #iree_gpu.gpu_encoding_layout<>}>
-#encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], layouts = [#iree_gpu.gpu_encoding_layout<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [128, 16], outerDimsPerm = [0, 1]}}>]>
+#encoding = #iree_encoding.layout<[#iree_gpu.gpu_encoding_layout<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [128, 16], outerDimsPerm = [0, 1]}}>]>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>

--- a/compiler/src/iree/compiler/Codegen/Common/test/llvmcpu_materialize_encoding.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/llvmcpu_materialize_encoding.mlir
@@ -2991,7 +2991,7 @@ func.func @broadcast_K() attributes {
   #hal.pipeline.binding<storage_buffer>
 ]>
 #executable_target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz", cpu_features = "+avx512f", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
-#encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type =  matmul, element_types = [f32, f32, f32], layouts = [#iree_cpu.cpu_encoding_layout<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [1, 1], outerDimsPerm = [0, 1]}}>]>
+#encoding = #iree_encoding.layout<[#iree_cpu.cpu_encoding_layout<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [1, 1], outerDimsPerm = [0, 1]}}>]>
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
@@ -3020,7 +3020,7 @@ func.func @set_encoding_LHS_with_layout() attributes {
 
 // -----
 
-#encoding = #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f32, f32, f32], layouts = [#iree_cpu.cpu_encoding_layout<configuration = {encoding_info = {innerDimsPos = [1, 0], innerTileSizes = [16, 1], outerDimsPerm = [1, 0]}}>]>
+#encoding = #iree_encoding.layout<[#iree_cpu.cpu_encoding_layout<configuration = {encoding_info = {innerDimsPos = [1, 0], innerTileSizes = [16, 1], outerDimsPerm = [1, 0]}}>]>
 #executable_target = #hal.executable.target<"llvm-cpu", "xyz", {target_triple = "x86_64-xyz-xyz", cpu_features = "+avx512f", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
@@ -3053,7 +3053,7 @@ func.func @set_encoding_RHS_with_layout() attributes {
 
 // -----
 
-#encoding = #iree_encoding.encoding<operand_index = 2 : index, op_type =  matmul, element_types = [f32, f32, f32], layouts = [#iree_cpu.cpu_encoding_layout<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [1, 16], outerDimsPerm = [0, 1]}}>]>
+#encoding = #iree_encoding.layout<[#iree_cpu.cpu_encoding_layout<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [1, 16], outerDimsPerm = [0, 1]}}>]>
 #executable_target = #hal.executable.target<"llvm-cpu", "xyz", {cpu_features = "+avx512f", target_triple = "x86_64-xyz-xyz", iree.encoding.resolver = #iree_cpu.cpu_encoding_layout<>}>
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map1 = affine_map<(d0, d1, d2) -> (d2, d1)>

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_into_padding.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_into_padding.mlir
@@ -4,8 +4,7 @@
 #binding_ro = #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">
 #binding = #hal.pipeline.binding<storage_buffer, Indirect>
 #encoding_mmt = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f16, f16, f16]>
-#pad_encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f16, f16, f16],
-                                        layouts = [#iree_encoding.pad_encoding_layout<[0, 64]>]>
+#pad_encoding = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 64]>]>
 func.func @set_pad_encoding_and_store() {
   %c0 = arith.constant 0 : index
   %0 = hal.interface.constant.load layout(<constants = 1, bindings = [#binding_ro, #binding], flags = Indirect>) ordinal(0) : i32
@@ -37,8 +36,7 @@ func.func @set_pad_encoding_and_store() {
 #binding_ro = #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">
 #binding = #hal.pipeline.binding<storage_buffer, Indirect>
 #encoding_mmt = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f16, f16, f16]>
-#pad_encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f16, f16, f16],
-                                        layouts = [#iree_encoding.pad_encoding_layout<[0, 0]>]>
+#pad_encoding = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 0]>]>
 func.func @set_zero_pad_encoding_and_store() {
   %c0 = arith.constant 0 : index
   %0 = hal.interface.constant.load layout(<constants = 1, bindings = [#binding_ro, #binding], flags = Indirect>) ordinal(0) : i32
@@ -70,8 +68,7 @@ func.func @set_zero_pad_encoding_and_store() {
 #binding_ro = #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">
 #binding = #hal.pipeline.binding<storage_buffer, Indirect>
 #encoding_mmt = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f16, f16, f16]>
-#pad_encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f16, f16, f16],
-                                        layouts = [#iree_encoding.pad_encoding_layout<[0, 64]>]>
+#pad_encoding = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 64]>]>
 func.func @dynamic_set_zero_pad_encoding_and_store() {
   %c0 = arith.constant 0 : index
   %0 = hal.interface.constant.load layout(<constants = 2, bindings = [#binding_ro, #binding], flags = Indirect>) ordinal(0) : i32
@@ -107,11 +104,9 @@ func.func @dynamic_set_zero_pad_encoding_and_store() {
 #binding_ro = #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">
 #binding = #hal.pipeline.binding<storage_buffer, Indirect>
 #encoding_mmt_lhs = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f16, f16, f16]>
-#pad_encoding_lhs = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f16, f16, f16],
-                                            layouts = [#iree_encoding.pad_encoding_layout<[0, 64]>]>
+#pad_encoding_lhs = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 64]>]>
 #encoding_mmt_rhs = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f16, f16, f16]>
-#pad_encoding_rhs = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f16, f16, f16],
-                                            layouts = [#iree_encoding.pad_encoding_layout<[0, 128]>]>
+#pad_encoding_rhs = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 128]>]>
 #encoding_mmt_out = #iree_encoding.encoding<operand_index = 2 : index, op_type = matmul, element_types = [f16, f16, f16]>
 func.func @load_from_padded_and_mmt() {
   %c0 = arith.constant 0 : index
@@ -172,8 +167,7 @@ func.func @load_from_padded_and_mmt() {
 
 #binding_ro = #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">
 #binding = #hal.pipeline.binding<storage_buffer, Indirect>
-#pad_encoding = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f16, f16, f16],
-                                        layouts = [#iree_encoding.pad_encoding_layout<[0, 64]>]>
+#pad_encoding = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 64]>]>
 func.func @set_pad_encoding_and_store_with_resolved_layout() {
   %c0 = arith.constant 0 : index
   %0 = hal.interface.constant.load layout(<constants = 1, bindings = [#binding_ro, #binding], flags = Indirect>) ordinal(0) : i32

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -758,7 +758,8 @@ struct VMVXHostEncodingLayoutResolverAttrInterface final
 
   Attribute getLayout(Attribute attr, RankedTensorType type) const {
     MLIRContext *ctx = attr.getContext();
-    return VMVXEncodingLayoutAttr::get(ctx, getLayoutImpl(attr, type));
+    return VMVXEncodingLayoutAttr::get(
+        ctx, getLayoutImpl(attr, type, /*addEncodingAttr=*/true));
   }
 };
 

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.h
@@ -55,9 +55,15 @@ Value calculateStorageSizeInBytesImpl(Attribute attr, Location loc,
                                       ValueRange dynamicDims);
 
 /// Returns a dictionary attribute that contains the materialized encoding info,
-/// i.e., serialized MaterializeEncodingInfo struct.
+/// i.e., serialized MaterializeEncodingInfo struct. The EncodingAttr attribute
+/// is attached to the dictionary, if it is present in `type` and
+/// `addEncodingAttr` is true.
+/// The `addEncodingAttr` is mainly for VMVX ukernel path because the ukernel
+/// ops lowering requires all the information. There are no direct mappings from
+/// layouts to ukernels.
 /// Requirement: `attr` must implement IREE::Codegen::LayoutAttrInterface.
-DictionaryAttr getLayoutImpl(Attribute attr, RankedTensorType type);
+DictionaryAttr getLayoutImpl(Attribute attr, RankedTensorType type,
+                             bool addEncodingAttr = false);
 
 /// Appends the NamedAttribute into `config` if there is a `name` NamedAttribute
 /// in the `dictAttr`.

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.h
@@ -58,8 +58,9 @@ Value calculateStorageSizeInBytesImpl(Attribute attr, Location loc,
 /// i.e., serialized MaterializeEncodingInfo struct. The EncodingAttr attribute
 /// is attached to the dictionary, if it is present in `type` and
 /// `addEncodingAttr` is true.
-/// The `addEncodingAttr` is mainly for VMVX ukernel path because the ukernel
-/// ops lowering requires all the information. There are no direct mappings from
+/// TODO(hanchung): only attach needed information to the configuration. The
+/// `addEncodingAttr` is mainly for VMVX ukernel path because the ukernel ops
+/// lowering requires all the information. There are no direct mappings from
 /// layouts to ukernels.
 /// Requirement: `attr` must implement IREE::Codegen::LayoutAttrInterface.
 DictionaryAttr getLayoutImpl(Attribute attr, RankedTensorType type,

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
@@ -66,28 +66,6 @@ LayoutAttr::verify(function_ref<mlir::InFlightDiagnostic()> emitError,
   return success();
 }
 
-Attribute LayoutAttr::parse(AsmParser &p, Type type) {
-  SMLoc loc = p.getCurrentLocation();
-  if (failed(p.parseLess())) {
-    return {};
-  }
-  ArrayAttr layouts;
-  if (failed(p.parseAttribute(layouts))) {
-    return {};
-  }
-  if (failed(p.parseGreater())) {
-    return {};
-  }
-  return p.getChecked<LayoutAttr>(loc, p.getContext(), layouts);
-}
-
-void LayoutAttr::print(AsmPrinter &p) const {
-  auto &os = p.getStream();
-  os << "<";
-  p.printAttribute(getLayouts());
-  os << ">";
-}
-
 bool LayoutAttr::isSerialized() const { return true; }
 
 bool LayoutAttr::isIdentityLayout() const {

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -67,6 +67,13 @@ def LayoutAttr :
     AttrParameter<"ArrayAttr", "Serialized layouts">:$layouts
   );
 
+  // Implement custom builders to bypass the verification assertion in Base::get
+  // method, i.e., `assert(succeeded(ConcreteT::verifyInvariants(...)))`.
+  let skipDefaultBuilders = 1;
+  let builders = [
+    AttrBuilder<(ins "ArrayAttr":$layouts)>,
+  ];
+
   let hasCustomAssemblyFormat = 1;
   let genVerifyDecl = 1;
 }
@@ -95,7 +102,6 @@ def EncodingAttr :
         "isSerialized",
         "isIdentityLayout",
         "cloneWithLayouts",
-        "calculateStorageSizeInBytes",
       ]>
     ]> {
   let mnemonic = "encoding";
@@ -377,7 +383,8 @@ def SpecializedEncodingAttr :
     IREEEncoding_Attr<"SpecializedEncoding", [
       DeclareAttrInterfaceMethods<IREEEncoding_EncodingLayoutResolverAttrInterface, [
         "getLayout",
-      ]>
+      ]>,
+      IREEEncoding_SerializableEncodingAttrInterface
     ]> {
   let mnemonic = "specialized_encoding";
 

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -45,6 +45,30 @@ def EncodingOpTypeAttr:
 // iree_encoding.packed_storage
 //===---------------------------------------------------------------------===//
 
+def LayoutAttr :
+    IREEEncoding_Attr<"Layout"> {
+  let mnemonic = "layout";
+  let summary = [{Indicates potential serialized layouts}];
+  let description = [{
+    This attribute describes the potential layouts of the encoding. It is an
+    array because a device could have multiple target device.
+
+    It has a verifier that will ensure that all the attributes in layouts
+    implement SerializableEncodingAttrInterface.
+  }];
+
+  let parameters = (ins
+    AttrParameter<"ArrayAttr", "Serialized layouts">:$layouts
+  );
+
+  let hasCustomAssemblyFormat = 1;
+  let genVerifyDecl = 1;
+}
+
+//===---------------------------------------------------------------------===//
+// iree_encoding.packed_storage
+//===---------------------------------------------------------------------===//
+
 def PackedStorageAttr : IREEEncoding_Attr<"PackedStorage"> {
   let mnemonic = "packed_storage";
   let summary = [{Indicates packed storage data type.}];

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -46,7 +46,13 @@ def EncodingOpTypeAttr:
 //===---------------------------------------------------------------------===//
 
 def LayoutAttr :
-    IREEEncoding_Attr<"Layout"> {
+    IREEEncoding_Attr<"Layout", [
+      DeclareAttrInterfaceMethods<IREEEncoding_SerializableEncodingAttrInterface, [
+        "isSerialized",
+        "isIdentityLayout",
+        "calculateStorageSizeInBytes",
+      ]>
+    ]> {
   let mnemonic = "layout";
   let summary = [{Indicates potential serialized layouts}];
   let description = [{

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -100,7 +100,6 @@ def EncodingAttr :
     IREEEncoding_Attr<"Encoding", [
       DeclareAttrInterfaceMethods<IREEEncoding_SerializableEncodingAttrInterface, [
         "isSerialized",
-        "isIdentityLayout",
         "cloneWithLayouts",
       ]>
     ]> {
@@ -130,11 +129,7 @@ def EncodingAttr :
     AttrParameter<"ArrayAttr", "element types of the user's operands">:$element_types,
     OptionalParameter<"ArrayAttr", "Indexing maps of the operation using this tensor">:$user_indexing_maps,
     OptionalParameter<"ArrayAttr", "The original operation's iteration sizes. "
-    "This is useful for handling skinny dimension sizes">:$iteration_sizes,
-    OptionalParameter<"ArrayAttr", "An array of attributes that describes the "
-    "layouts of the encoding. It is an array because a device could have "
-    "multiple target device. Note that it can be any attribute that "
-    "implements SerializableEncodingAttrInterface.">:$layouts
+    "This is useful for handling skinny dimension sizes">:$iteration_sizes
   );
 
   let builders = [
@@ -142,8 +137,7 @@ def EncodingAttr :
         "EncodingOpType":$opType,
         "ArrayRef<Type>":$elemTypes,
         CArg<"ArrayRef<AffineMap>", "{}">:$maps,
-        CArg<"ArrayRef<int64_t>", "{}">:$iterationSizes,
-        CArg<"ArrayRef<Attribute>", "{}">:$layouts)>
+        CArg<"ArrayRef<int64_t>", "{}">:$iterationSizes)>
   ];
 
   let extraClassDeclaration = [{

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -54,10 +54,12 @@ def LayoutAttr :
       ]>
     ]> {
   let mnemonic = "layout";
+  let assemblyFormat = "`<` $layouts `>`";
+
   let summary = [{Indicates potential serialized layouts}];
   let description = [{
     This attribute describes the potential layouts of the encoding. It is an
-    array because a device could have multiple target device.
+    array because a device could have multiple target layouts.
 
     It has a verifier that will ensure that all the attributes in layouts
     implement SerializableEncodingAttrInterface.
@@ -74,7 +76,6 @@ def LayoutAttr :
     AttrBuilder<(ins "ArrayAttr":$layouts)>,
   ];
 
-  let hasCustomAssemblyFormat = 1;
   let genVerifyDecl = 1;
 }
 

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingBase.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingBase.td
@@ -23,6 +23,9 @@ def IREEEncoding_Dialect : Dialect {
     A dialect defining IREE tensor encoding attributes and related ops, used to
     implement data-tiling.
   }];
+  let extraClassDeclaration = [{
+    void registerAttributes();
+  }];
   let useDefaultAttributePrinterParser = 1;
 }
 

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingDialect.cpp
@@ -18,7 +18,6 @@
 #include "mlir/Transforms/InliningUtils.h"
 
 #define GET_ATTRDEF_CLASSES
-#include "iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp.inc"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingEnums.cpp.inc"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.cpp.inc"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingTypeInterfaces.cpp.inc"
@@ -71,10 +70,7 @@ struct EncodingInlinerInterface : public DialectInlinerInterface {
 void IREEEncodingDialect::initialize() {
   addInterfaces<EncodingOpAsmInterface, EncodingInlinerInterface>();
 
-  addAttributes<
-#define GET_ATTRDEF_LIST
-#include "iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp.inc"
-      >();
+  registerAttributes();
 
 #define GET_OP_LIST
   addOperations<

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingDialect.cpp
@@ -36,7 +36,7 @@ struct EncodingOpAsmInterface : public OpAsmDialectInterface {
   // `.` or end with a numeric digit([0-9]+). Returns success if an alias was
   // provided, failure otherwise.
   AliasResult getAlias(Attribute attr, raw_ostream &os) const override {
-    if (llvm::isa<EncodingAttr, MatmulKAttr, TestingEncodingAttr,
+    if (llvm::isa<EncodingAttr, MatmulKAttr, LayoutAttr, TestingEncodingAttr,
                   UnknownEncodingAttr>(attr)) {
       os << "encoding";
       return AliasResult::OverridableAlias;

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/test/invalid.mlir
@@ -183,11 +183,3 @@ func.func @illegal_layout_encoding_without_any_layout(%arg0: tensor<?x?xf32, #en
 func.func @illegal_layout_encoding_with_invalid_layouts(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf32, #encoding> {
   return %arg0 : tensor<?x?xf32, #encoding>
 }
-
-// -----
-
-// expected-error @+1 {{invalid kind of attribute specified}}
-#encoding = #iree_encoding.layout<123>
-func.func @illegal_layout_encoding_with_invalid_attr(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf32, #encoding> {
-  return %arg0 : tensor<?x?xf32, #encoding>
-}

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/test/invalid.mlir
@@ -167,3 +167,27 @@ func.func @illegal_unset_encoding_op_with_shape_change(%arg0 : tensor<20x30xf32,
   %0 = iree_encoding.unset_encoding %arg0: tensor<20x30xf32, #encoding> -> tensor<10x20xf32>
   return %0 : tensor<10x20xf32>
 }
+
+// -----
+
+// expected-error @+1 {{expected non-empty layouts}}
+#encoding = #iree_encoding.layout<[]>
+func.func @illegal_layout_encoding_without_any_layout(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf32, #encoding> {
+  return %arg0 : tensor<?x?xf32, #encoding>
+}
+
+// -----
+
+// expected-error @+1 {{expected all the layout attributes to implement SerializableEncodingAttrInterface}}
+#encoding = #iree_encoding.layout<[#iree_encoding.unknown_encoding]>
+func.func @illegal_layout_encoding_with_invalid_layouts(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf32, #encoding> {
+  return %arg0 : tensor<?x?xf32, #encoding>
+}
+
+// -----
+
+// expected-error @+1 {{invalid kind of attribute specified}}
+#encoding = #iree_encoding.layout<123>
+func.func @illegal_layout_encoding_with_invalid_attr(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf32, #encoding> {
+  return %arg0 : tensor<?x?xf32, #encoding>
+}

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/test/roundtrip.mlir
@@ -254,3 +254,14 @@ func.func @matmul_k_encoding(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf3
 // CHECK:      func.func @matmul_k_encoding(
 // CHECK-SAME:   %[[ARG0:.+]]: tensor<?x?xf32, #[[ENCODING]]>
 // CHECK         return %[[ARG0]]
+
+// -----
+
+#encoding = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 64]>]>
+func.func @layout_encoding(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf32, #encoding> {
+  return %arg0 : tensor<?x?xf32, #encoding>
+}
+// CHECK:     #[[ENCODING:.+]] = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 64]>]>
+// CHECK:      func.func @layout_encoding(
+// CHECK-SAME:   %[[ARG0:.+]]: tensor<?x?xf32, #[[ENCODING]]>
+// CHECK         return %[[ARG0]]

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/test/roundtrip.mlir
@@ -182,18 +182,6 @@ func.func @set_encoding_ops_with_iteration_sizes(%arg0: tensor<?x?xf32>) {
 
 // -----
 
-#encoding = #iree_encoding.encoding<operand_index = 0 : i64, op_type =  matmul, element_types = [f32, f32, f32], layouts = [{}]>
-func.func @set_encoding_ops_with_layouts(%arg0: tensor<?x?xf32>) -> tensor<?x?xf32, #encoding> {
-  %0 = iree_encoding.set_encoding %arg0 : tensor<?x?xf32> -> tensor<?x?xf32, #encoding>
-  return %0 : tensor<?x?xf32, #encoding>
-}
-// CHECK-DAG:   #[[ENCODING:.+]] = #iree_encoding.encoding<operand_index = 0 : i64, op_type =  matmul, element_types = [f32, f32, f32], layouts = [{}]>
-// CHECK:       func.func @set_encoding_ops_with_layouts(
-// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]:
-// CHECK:         iree_encoding.set_encoding %[[ARG0]] : tensor<?x?xf32> -> tensor<?x?xf32, #[[ENCODING]]>
-
-// -----
-
 #encoding = #iree_encoding.unspecialized_encoding<123>
 func.func @unspecialized_encoding(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf32, #encoding> {
   return %arg0 : tensor<?x?xf32, #encoding>

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/encode_host_tensors_encoding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/encode_host_tensors_encoding.mlir
@@ -21,7 +21,7 @@ util.func public @tensorSizeOfAlignedPackedI1() -> index {
 // -----
 
 #encoding_layout = #iree_cpu.vmvx_encoding_layout<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [4, 16], outerDimsPerm = [0, 1]}}>
-#encoding = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f32, f32, f32], layouts = [#encoding_layout]>
+#encoding = #iree_encoding.layout<[#encoding_layout]>
 util.func public @sizeof_lhs_encoding_dynamic_using_layouts(%arg0: index, %arg1: index) -> index {
   %0 = stream.tensor.sizeof tensor<?x?xf32, #encoding>{%arg0, %arg1} : index
   util.return %0 : index
@@ -40,7 +40,7 @@ util.func public @sizeof_lhs_encoding_dynamic_using_layouts(%arg0: index, %arg1:
 // -----
 
 #encoding_layout = #iree_cpu.vmvx_encoding_layout<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [4, 16], outerDimsPerm = [0, 1]}}>
-#encoding = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f32, f32, f32], layouts = [#encoding_layout]>
+#encoding = #iree_encoding.layout<[#encoding_layout]>
 util.func public @sizeof_lhs_encoding_partially_dynamic_using_layouts(%arg0: index) -> index {
   %0 = stream.tensor.sizeof tensor<10x?xf32, #encoding>{%arg0} : index
   util.return %0 : index
@@ -59,7 +59,7 @@ util.func public @sizeof_lhs_encoding_partially_dynamic_using_layouts(%arg0: ind
 // (i.e., [8, 16]) are for [dim_1, dim_0] in the encoding_info, where dim_1 is
 // N-dimension and dim_0 is K-dimension.
 #encoding_layout = #iree_cpu.vmvx_encoding_layout<configuration = {encoding_info = {innerDimsPos = [1, 0], innerTileSizes = [8, 16], outerDimsPerm = [1, 0]}}>
-#encoding = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f32, f32, f32], layouts = [#encoding_layout]>
+#encoding = #iree_encoding.layout<[#encoding_layout]>
 util.func public @sizeof_rhs_encoding_dynamic_using_layouts(%arg0: index, %arg1: index) -> index {
   %0 = stream.tensor.sizeof tensor<?x?xf32, #encoding>{%arg0, %arg1} : index
   util.return %0 : index
@@ -79,7 +79,7 @@ util.func public @sizeof_rhs_encoding_dynamic_using_layouts(%arg0: index, %arg1:
 // -----
 
 #encoding_layout = #iree_cpu.vmvx_encoding_layout<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [4, 8], outerDimsPerm = [0, 1]}}>
-#encoding = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f32, f32, f32], layouts = [#encoding_layout]>
+#encoding = #iree_encoding.layout<[#encoding_layout]>
 util.func public @sizeof_result_encoding_dynamic_using_layouts(%arg0: index, %arg1: index) -> index {
   %0 = stream.tensor.sizeof tensor<?x?xf32, #encoding>{%arg0, %arg1} : index
   util.return %0 : index
@@ -100,7 +100,7 @@ util.func public @sizeof_result_encoding_dynamic_using_layouts(%arg0: index, %ar
 // The M-dimension inner tile is not present because it broadcasts across the
 // M-dimension. We do not need to pack the M-dimension in this case.
 #encoding_layout = #iree_cpu.vmvx_encoding_layout<configuration = {encoding_info = {innerDimsPos = [1], innerTileSizes = [16], outerDimsPerm = [0, 1]}}>
-#encoding = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f32, f32, f32], layouts = [#encoding_layout]>
+#encoding = #iree_encoding.layout<[#encoding_layout]>
 util.func public @sizeof_lhs_encoding_with_bcast_across_m_dim_dynamic_using_layouts(%arg0: index, %arg1: index) -> index {
   %0 = stream.tensor.sizeof tensor<?x?xf32, #encoding>{%arg0, %arg1} : index
   util.return %0 : index
@@ -123,11 +123,11 @@ util.func public @sizeof_lhs_encoding_with_bcast_across_m_dim_dynamic_using_layo
 #map1 = affine_map<(d0, d1, d2) -> (d1, d2)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
 #no_pad_layout = #iree_encoding.pad_encoding_layout<[0, 0]>
-#no_pad_encoding = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], layouts = [#no_pad_layout]>
+#no_pad_encoding = #iree_encoding.layout<[#no_pad_layout]>
 #pad_layout_a = #iree_encoding.pad_encoding_layout<[0, 64]>
-#pad_encoding_a = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], layouts = [#pad_layout_a]>
+#pad_encoding_a = #iree_encoding.layout<[#pad_layout_a]>
 #pad_layout_b = #iree_encoding.pad_encoding_layout<[64, 0]>
-#pad_encoding_b = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], layouts = [#pad_layout_b]>
+#pad_encoding_b = #iree_encoding.layout<[#pad_layout_b]>
 util.func public @sizeof_lhs_pad_encoding_static() -> index, index, index {
   %0 = stream.tensor.sizeof tensor<2048x4096xf16, #no_pad_encoding>{} : index
   %1 = stream.tensor.sizeof tensor<2048x4096xf16, #pad_encoding_a>{} : index
@@ -149,11 +149,11 @@ util.func public @sizeof_lhs_pad_encoding_static() -> index, index, index {
 #map1 = affine_map<(d0, d1, d2) -> (d1, d2)>
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
 #no_pad_layout = #iree_encoding.pad_encoding_layout<[0, 0]>
-#no_pad_encoding = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], layouts = [#no_pad_layout]>
+#no_pad_encoding = #iree_encoding.layout<[#no_pad_layout]>
 #pad_layout_a = #iree_encoding.pad_encoding_layout<[0, 64]>
-#pad_encoding_a = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], layouts = [#pad_layout_a]>
+#pad_encoding_a = #iree_encoding.layout<[#pad_layout_a]>
 #pad_layout_b = #iree_encoding.pad_encoding_layout<[64, 0]>
-#pad_encoding_b = #iree_encoding.encoding<operand_index = 1, op_type = matmul, element_types = [f16, f16, f32], user_indexing_maps = [#map, #map1, #map2], layouts = [#pad_layout_b]>
+#pad_encoding_b = #iree_encoding.layout<[#pad_layout_b]>
 util.func public @sizeof_rhs_pad_encoding_dynamic(%arg0 : index, %arg1 : index) -> index, index, index, index {
   %0 = stream.tensor.sizeof tensor<2048x?xf16, #no_pad_encoding>{%arg0} : index
   %1 = stream.tensor.sizeof tensor<?x4096xf16, #pad_encoding_a>{%arg0} : index
@@ -182,7 +182,7 @@ util.func public @sizeof_rhs_pad_encoding_dynamic(%arg0 : index, %arg1 : index) 
 #encoding_layout_0 = #iree_cpu.cpu_encoding_layout<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [4, 8], outerDimsPerm = [0, 1]}}>
 #encoding_layout_1 = #iree_cpu.vmvx_encoding_layout<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [2, 16], outerDimsPerm = [0, 1]}}>
 #encoding_layout_2 = #iree_gpu.gpu_encoding_layout<configuration = {encoding_info = {innerDimsPos = [0, 1], innerTileSizes = [128, 16], outerDimsPerm = [0, 1]}}>
-#encoding = #iree_encoding.encoding<operand_index = 0, op_type = matmul, element_types = [f32, f32, f32], layouts = [#encoding_layout_0, #encoding_layout_1, #encoding_layout_2]>
+#encoding = #iree_encoding.layout<[#encoding_layout_0, #encoding_layout_1, #encoding_layout_2]>
 util.func public @sizeof_multi_encoding_layouts(%arg0: index, %arg1: index) -> index {
   %0 = stream.tensor.sizeof tensor<?x?xf32, #encoding>{%arg0, %arg1} : index
   util.return %0 : index

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
@@ -21,10 +21,10 @@ util.func public @tensor_sizeof(%d0: index, %d1: index) -> (index, index) {
   %size1 = stream.tensor.sizeof on(#hal.device.affinity<@device_b>) tensor<?x?xf32, #encoding>{%d0, %d1} : index
   util.return %size0, %size1 : index, index
 }
-// CHECK:       #[[$ENCODING0:.+]] = #iree_encoding.encoding
+// CHECK:       #[[$ENCODING0:.+]] = #iree_encoding.layout
 // CHECK-SAME:    #iree_cpu.vmvx_encoding_layout
 // CHECK-SAME:    encoding_info = {innerDimsPos = [{{.+}}], innerTileSizes = [{{.+}}], outerDimsPerm = [{{.+}}]}
-// CHECK:       #[[$ENCODING1:.+]] = #iree_encoding.encoding
+// CHECK:       #[[$ENCODING1:.+]] = #iree_encoding.layout
 // CHECK-SAME:    #iree_cpu.cpu_encoding_layout
 // CHECK-SAME:    encoding_info = {innerDimsPos = [{{.+}}], innerTileSizes = [{{.+}}], outerDimsPerm = [{{.+}}]}
 // CHECK-LABEL: util.func public @tensor_sizeof
@@ -70,7 +70,7 @@ util.func public @gpu_with_encoding_layout(%d0: index, %d1: index) -> index {
   %size0 = stream.tensor.sizeof on(#hal.device.affinity<@device_a>) tensor<?x?xf32, #encoding>{%d0, %d1} : index
   util.return %size0 : index
 }
-// CHECK:       #[[$ENCODING:.+]] = #iree_encoding.encoding
+// CHECK:       #[[$ENCODING:.+]] = #iree_encoding.layout
 // CHECK-SAME:    #iree_gpu.gpu_encoding_layout
 // CHECK-SAME:    encoding_info = {innerDimsPos = [{{.+}}], innerTileSizes = [{{.+}}], outerDimsPerm = [{{.+}}]}
 // CHECK-LABEL: util.func public @gpu_with_encoding_layout
@@ -125,28 +125,25 @@ util.func public @with_pad_encoding(%arg0: index, %arg1: index, %scalar_f32 : f3
   util.return
 }
 
-// CHECK-DAG: #[[$NO_PAD_LHS:.+]] = #iree_encoding.encoding<operand_index = 0 : index, {{.*}}, layouts = [#iree_encoding.pad_encoding_layout<[0, 0]>]
-// CHECK-DAG: #[[$NO_PAD_RHS:.+]] = #iree_encoding.encoding<operand_index = 1 : index, {{.*}}, layouts = [#iree_encoding.pad_encoding_layout<[0, 0]>]
-// CHECK-DAG: #[[$NO_PAD_OUT:.+]] = #iree_encoding.encoding<operand_index = 2 : index, {{.*}}, layouts = [#iree_encoding.pad_encoding_layout<[0, 0]>]
-// CHECK-DAG: #[[$PAD_LHS_0:.+]] =  #iree_encoding.encoding<operand_index = 0 : index, {{.*}}, layouts = [#iree_encoding.pad_encoding_layout<[0, 64]>]
-// CHECK-DAG: #[[$PAD_LHS_1:.+]] =  #iree_encoding.encoding<operand_index = 0 : index, {{.*}}, layouts = [#iree_encoding.pad_encoding_layout<[0, 7]>]
-// CHECK-DAG: #[[$PAD_LHS_2:.+]] =  #iree_encoding.encoding<operand_index = 0 : index, {{.*}}, layouts = [#iree_encoding.pad_encoding_layout<[0, 65]>]
-// CHECK-DAG: #[[$PAD_RHS:.+]] =    #iree_encoding.encoding<operand_index = 1 : index, {{.*}}, layouts = [#iree_encoding.pad_encoding_layout<[0, 64]>]
+// CHECK-DAG: #[[$NO_PAD:.+]] = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 0]>]
+// CHECK-DAG: #[[$PAD_DIM1_64:.+]] =  #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 64]>]
+// CHECK-DAG: #[[$PAD_LHS_1:.+]] =  #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 7]>]
+// CHECK-DAG: #[[$PAD_LHS_2:.+]] =  #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 65]>]
 
 // CHECK-LABEL: util.func public @with_pad_encoding
 //
-// CHECK: stream.tensor.empty {{.*}} : tensor<4096x4096xf16, #[[$PAD_LHS_0]]>
-// CHECK: stream.tensor.empty {{.*}} : tensor<4096x4160xf16, #[[$NO_PAD_LHS]]>
+// CHECK: stream.tensor.empty {{.*}} : tensor<4096x4096xf16, #[[$PAD_DIM1_64]]>
+// CHECK: stream.tensor.empty {{.*}} : tensor<4096x4160xf16, #[[$NO_PAD]]>
 // CHECK: stream.tensor.empty {{.*}} : tensor<4096x1337xf16, #[[$PAD_LHS_1]]>
 // CHECK: stream.tensor.empty {{.*}} : tensor<4096x4095xf16, #[[$PAD_LHS_2]]>
-// CHECK: stream.tensor.empty {{.*}} : tensor<4096x250xf16, #[[$NO_PAD_LHS]]>
-// CHECK: stream.tensor.empty {{.*}} : tensor<60x4096xf16, #[[$NO_PAD_LHS]]>
-// CHECK: stream.tensor.empty {{.*}} : tensor<1x4096xf16, #[[$NO_PAD_RHS]]>
-// CHECK: stream.tensor.empty {{.*}} : tensor<?x4096xf16, #[[$PAD_LHS_0]]>
-// CHECK: stream.tensor.empty {{.*}} : tensor<?x?xf16, #[[$NO_PAD_LHS]]>
-// CHECK: stream.tensor.empty {{.*}} : tensor<4096x4096xf16, #[[$PAD_RHS]]>
-// CHECK: stream.tensor.empty {{.*}} : tensor<4096x4096xf16, #[[$NO_PAD_OUT]]>
-// CHECK: stream.tensor.empty {{.*}} : tensor<4096x4096xf16, #[[$PAD_RHS]]>
+// CHECK: stream.tensor.empty {{.*}} : tensor<4096x250xf16, #[[$NO_PAD]]>
+// CHECK: stream.tensor.empty {{.*}} : tensor<60x4096xf16, #[[$NO_PAD]]>
+// CHECK: stream.tensor.empty {{.*}} : tensor<1x4096xf16, #[[$NO_PAD]]>
+// CHECK: stream.tensor.empty {{.*}} : tensor<?x4096xf16, #[[$PAD_DIM1_64]]>
+// CHECK: stream.tensor.empty {{.*}} : tensor<?x?xf16, #[[$NO_PAD]]>
+// CHECK: stream.tensor.empty {{.*}} : tensor<4096x4096xf16, #[[$PAD_DIM1_64]]>
+// CHECK: stream.tensor.empty {{.*}} : tensor<4096x4096xf16, #[[$NO_PAD]]>
+// CHECK: stream.tensor.empty {{.*}} : tensor<4096x4096xf16, #[[$PAD_DIM1_64]]>
 //
 // CHECK-NEXT: util.return
 
@@ -849,12 +846,8 @@ util.func public @multi_device_gemm(%arg0: !stream.resource<external>, %arg1: !s
   util.return
 }
 
-// CHECK-DAG:   #[[DEVICE_A_LHS_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 0{{.+}} layouts = [#iree_encoding.specialized_encoding<123, tensor<?x?xf32>>]
-// CHECK-DAG:   #[[DEVICE_A_RHS_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 1{{.+}} layouts = [#iree_encoding.specialized_encoding<123, tensor<?x?xf32>>]
-// CHECK-DAG:   #[[DEVICE_A_OUT_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 2{{.+}} layouts = [#iree_encoding.specialized_encoding<123, tensor<?x?xf32>>]
-// CHECK-DAG:   #[[DEVICE_B_LHS_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 0{{.+}} layouts = [#iree_encoding.specialized_encoding<456, tensor<?x?xf32>>]
-// CHECK-DAG:   #[[DEVICE_B_RHS_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 1{{.+}} layouts = [#iree_encoding.specialized_encoding<456, tensor<?x?xf32>>]
-// CHECK-DAG:   #[[DEVICE_B_OUT_ENCODING:.+]] = #iree_encoding.encoding<operand_index = 2{{.+}} layouts = [#iree_encoding.specialized_encoding<456, tensor<?x?xf32>>]
+// CHECK-DAG:   #[[ENCODING_123:.+]] = #iree_encoding.layout<[#iree_encoding.specialized_encoding<123, tensor<?x?xf32>>]
+// CHECK-DAG:   #[[ENCODING_456:.+]] = #iree_encoding.layout<[#iree_encoding.specialized_encoding<456, tensor<?x?xf32>>]
 // CHECK-DAG:   #[[MAP0:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
 // CHECK-DAG:   #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d2, d1)>
 // CHECK-DAG:   #[[MAP2:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
@@ -875,16 +868,16 @@ util.func public @multi_device_gemm(%arg0: !stream.resource<external>, %arg1: !s
 // CHECK-SAME:        %[[ARG5:[a-zA-Z0-9]+]]
 // CHECK-SAME:        %[[ARG6:[a-zA-Z0-9]+]]
 // CHECK:           %[[LHS_BINDING:.+]] = stream.binding.subspan %[[ARG0]]
-// CHECK-SAME:        !flow.dispatch.tensor<readonly:tensor<?x?xf32, #[[DEVICE_A_LHS_ENCODING]]>>
+// CHECK-SAME:        !flow.dispatch.tensor<readonly:tensor<?x?xf32, #[[ENCODING_123]]>>
 // CHECK:           %[[RHS_BINDING:.+]] = stream.binding.subspan %[[ARG1]]
-// CHECK-SAME:        !flow.dispatch.tensor<readonly:tensor<?x?xf32, #[[DEVICE_A_RHS_ENCODING]]>>
+// CHECK-SAME:        !flow.dispatch.tensor<readonly:tensor<?x?xf32, #[[ENCODING_123]]>>
 // CHECK:           %[[OUT_BINDING:.+]] = stream.binding.subspan %[[ARG6]]
-// CHECK-SAME:        !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #[[DEVICE_A_OUT_ENCODING]]>>
+// CHECK-SAME:        !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #[[ENCODING_123]]>>
 // CHECK:           %[[LHS:.+]] = flow.dispatch.tensor.load %[[LHS_BINDING]]
-// CHECK-SAME:        !flow.dispatch.tensor<readonly:tensor<?x?xf32, #[[DEVICE_A_LHS_ENCODING]]>>
+// CHECK-SAME:        !flow.dispatch.tensor<readonly:tensor<?x?xf32, #[[ENCODING_123]]>>
 // CHECK-SAME:        -> tensor<?x?xf32, #[[ORIG_LHS_ENCODING]]>
 // CHECK:           %[[RHS:.+]] = flow.dispatch.tensor.load %[[RHS_BINDING]]
-// CHECK-SAME:        !flow.dispatch.tensor<readonly:tensor<?x?xf32, #[[DEVICE_A_RHS_ENCODING]]>>
+// CHECK-SAME:        !flow.dispatch.tensor<readonly:tensor<?x?xf32, #[[ENCODING_123]]>>
 // CHECK-SAME:        -> tensor<?x?xf32, #[[ORIG_RHS_ENCODING]]>
 // CHECK:           %[[INIT:.+]] = tensor.empty({{.+}}) : tensor<?x?xf32, #[[ORIG_OUT_ENCODING]]>
 // CHECK:           %[[FILL:.+]] = linalg.fill ins({{.+}}) outs(%[[INIT]]
@@ -902,16 +895,16 @@ util.func public @multi_device_gemm(%arg0: !stream.resource<external>, %arg1: !s
 // CHECK-SAME:        %[[ARG5:[a-zA-Z0-9]+]]
 // CHECK-SAME:        %[[ARG6:[a-zA-Z0-9]+]]
 // CHECK:           %[[LHS_BINDING:.+]] = stream.binding.subspan %[[ARG0]]
-// CHECK-SAME:        !flow.dispatch.tensor<readonly:tensor<?x?xf32, #[[DEVICE_B_LHS_ENCODING]]>>
+// CHECK-SAME:        !flow.dispatch.tensor<readonly:tensor<?x?xf32, #[[ENCODING_456]]>>
 // CHECK:           %[[RHS_BINDING:.+]] = stream.binding.subspan %[[ARG1]]
-// CHECK-SAME:        !flow.dispatch.tensor<readonly:tensor<?x?xf32, #[[DEVICE_B_RHS_ENCODING]]>>
+// CHECK-SAME:        !flow.dispatch.tensor<readonly:tensor<?x?xf32, #[[ENCODING_456]]>>
 // CHECK:           %[[OUT_BINDING:.+]] = stream.binding.subspan %[[ARG6]]
-// CHECK-SAME:        !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #[[DEVICE_B_OUT_ENCODING]]>>
+// CHECK-SAME:        !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #[[ENCODING_456]]>>
 // CHECK:           %[[LHS:.+]] = flow.dispatch.tensor.load %[[LHS_BINDING]]
-// CHECK-SAME:        !flow.dispatch.tensor<readonly:tensor<?x?xf32, #[[DEVICE_B_LHS_ENCODING]]>>
+// CHECK-SAME:        !flow.dispatch.tensor<readonly:tensor<?x?xf32, #[[ENCODING_456]]>>
 // CHECK-SAME:        -> tensor<?x?xf32, #[[ORIG_LHS_ENCODING]]>
 // CHECK:           %[[RHS:.+]] = flow.dispatch.tensor.load %[[RHS_BINDING]]
-// CHECK-SAME:        !flow.dispatch.tensor<readonly:tensor<?x?xf32, #[[DEVICE_B_RHS_ENCODING]]>>
+// CHECK-SAME:        !flow.dispatch.tensor<readonly:tensor<?x?xf32, #[[ENCODING_456]]>>
 // CHECK-SAME:        -> tensor<?x?xf32, #[[ORIG_RHS_ENCODING]]>
 // CHECK:           %[[INIT:.+]] = tensor.empty({{.+}}) : tensor<?x?xf32, #[[ORIG_OUT_ENCODING]]>
 // CHECK:           %[[FILL:.+]] = linalg.fill ins({{.+}}) outs(%[[INIT]]

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
@@ -21,12 +21,8 @@ util.func public @tensor_sizeof(%d0: index, %d1: index) -> (index, index) {
   %size1 = stream.tensor.sizeof on(#hal.device.affinity<@device_b>) tensor<?x?xf32, #encoding>{%d0, %d1} : index
   util.return %size0, %size1 : index, index
 }
-// CHECK:       #[[$ENCODING0:.+]] = #iree_encoding.layout
-// CHECK-SAME:    #iree_cpu.vmvx_encoding_layout
-// CHECK-SAME:    encoding_info = {innerDimsPos = [{{.+}}], innerTileSizes = [{{.+}}], outerDimsPerm = [{{.+}}]}
-// CHECK:       #[[$ENCODING1:.+]] = #iree_encoding.layout
-// CHECK-SAME:    #iree_cpu.cpu_encoding_layout
-// CHECK-SAME:    encoding_info = {innerDimsPos = [{{.+}}], innerTileSizes = [{{.+}}], outerDimsPerm = [{{.+}}]}
+// CHECK-DAG:   #[[$ENCODING0:.+]] = #iree_encoding.layout<[#iree_cpu.vmvx_encoding_layout{{.+}}encoding_info = {innerDimsPos = [{{.+}}], innerTileSizes = [{{.+}}], outerDimsPerm = [{{.+}}]}
+// CHECK-DAG:   #[[$ENCODING1:.+]] = #iree_encoding.layout<[#iree_cpu.cpu_encoding_layout{{.+}}encoding_info = {innerDimsPos = [{{.+}}], innerTileSizes = [{{.+}}], outerDimsPerm = [{{.+}}]}
 // CHECK-LABEL: util.func public @tensor_sizeof
 // CHECK:         %[[D0_RES:.+]] = stream.tensor.sizeof {{.+}} tensor<?x?xf32, #[[$ENCODING0]]>
 // CHECK:         %[[D1_RES:.+]] = stream.tensor.sizeof {{.+}} tensor<?x?xf32, #[[$ENCODING1]]>


### PR DESCRIPTION
The revision implements `IREE::Encoding::LayoutAttr` and retires the `layouts` field from EncodingAttr, as it encodes much more information than needed.

It is not easy to do incremental because many layers are involved, including
- Encoding specialization.
- Encoding materialization.
- Lower `iree_codegen.query_tile_size` op for VMVX ukernel path.

To make review easier, there are five commits in the PR:
- Introduce iree_encoding.layout encoding attribute: https://github.com/iree-org/iree/commit/85d919941ebc9ea1fa17de77e2716d3f332236f4
- Implement SerializableEncodingInterface for Encoding::LayoutAttr: https://github.com/iree-org/iree/commit/a49a7263b471f8f8112e083b53e97540a6cf70b3
- Use iree_encoding.layout when the layouts are resolved: https://github.com/iree-org/iree/commit/1dc9007118a27ec32508277944acad373760a96c
- Retire the layouts field from EncodingAttr: https://github.com/iree-org/iree/commit/b2f0329047c4c819dd9c0fa85581a933c99969b3
- Fix the ukernel ops lowering for VMVX: https://github.com/iree-org/iree/commit/0a51344b21512329c3b82ba74ff696241ce0cf6f

In the third commit, we need to move `registerAttributes` to `EncodingAttr.cpp` because we want to skip default builders. 
 It is very tricky when the verifier is implemented, because an assertion is triggered. However, it should just return nullptr in this context. To bypass the crash in get method, we need to implement our own get methods.

Note: the root cause of `reigsterAtrributes` is that the full definition of the storage class needs to be visible whenever we register the attribute. 

Fixes https://github.com/iree-org/iree/issues/20489