### PR TITLE
[Util][ConstExpr] Avoid hoisting of encoding operations when it could result in different layouts.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Constant/ConstExpr.h
@@ -20,6 +20,8 @@
 
 namespace mlir::iree_compiler::IREE::Util {
 
+class GlobalLoadOpInterface;
+
 // Analyzes an entire module to determine all operations/values that are
 // purely derived from constants or immutable data and builds a
 // dependency tree.
@@ -163,6 +165,13 @@ private:
   // as `definingOp`.
   void tryExpandToUseOrUseParent(Operation *definingOp, Operation *useOp);
 
+  // Check layout of leaves reachable from a root op. If the layout differs
+  // then drop leaves from the hoisting map, till the layout of the leaves
+  // agrees. The order in which the leaves are drop are arbitrary (but
+  // deterministic)
+  void dropLeavesWithLayoutConflicts(
+      ArrayRef<IREE::Util::GlobalLoadOpInterface> roots);
+
   // Add a new info record for a value to analyze for const-ness.
   ConstValueInfo *addInfo(Value constValue);
 
@@ -174,7 +183,7 @@ private:
   //   LoadGlobalOp.result -> GlobalOp
   //   ConstantOp.result -> ConstantOp
   // Entries can come from the whole program.
-  llvm::DenseMap<Value, Operation *> constantRoots;
+  llvm::MapVector<Value, Operation *> constantRoots;
 
   // Map of analyzed value to corresponding info struct.
   llvm::DenseMap<Value, ConstValueInfo *> constInfoMap;

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilInterfaces.td
@@ -1299,6 +1299,26 @@ def Util_HoistableOpInterface : OpInterface<"HoistableOpInterface"> {
         return true;
       }]
     >,
+    InterfaceMethod<      
+      /*desc=*/[{
+        Get the layout of the result if available.
+
+        If the op provides layout information this can be used
+        to determine if a sequence of ops rooted at a constant
+        has different layouts at all the leaves in the const expr
+        tree for a given root. This can be used to check if
+        const expr needs to be dropped due to increase in memory
+        usage. If a leaf result provides no layout information, then
+        that result is ignored.
+      }],
+      /*retTy=*/"std::optional<::mlir::iree_compiler::IREE::Util::LayoutInfo>",
+      /*methodName=*/"getResultLayout",
+      /*args=*/(ins "unsigned":$resultNum),
+      /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{
+        return std::nullopt;
+      }]
+    >
   ];
 }
 

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.cpp
@@ -2083,6 +2083,13 @@ LogicalResult GlobalStoreIndirectOp::verify() {
   return success();
 }
 
+std::optional<LayoutInfo> GlobalLoadOp::getResultLayout(unsigned resultNum) {
+  if (resultNum != 0) {
+    return std::nullopt;
+  }
+  return LayoutInfo{getResult().getType()};
+}
+
 //===----------------------------------------------------------------------===//
 // !util.list<T>
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
@@ -972,6 +972,7 @@ def Util_GlobalLoadOp : Util_Op<"global.load", [
   DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
   SymbolUserOpInterface,
   Util_GlobalLoadOpInterface,
+  DeclareOpInterfaceMethods<Util_HoistableOpInterface, ["getResultLayout"]>,
 ]> {
   let summary = [{loads a value from a global variable}];
   let description = [{

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.cpp
@@ -8,6 +8,7 @@
 #include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "llvm/ADT/BitVector.h"
+#include "llvm/ADT/DenseMapInfo.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Attributes.h"

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.h
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.h
@@ -398,7 +398,42 @@ static inline int64_t getRoundedPhysicalStorageSize(ShapedType type) {
                                        type.getElementType());
 }
 
+// Struct providing layout information for a value.
+// For now it is assumed that the type is enough to provide the
+// layout information.
+struct LayoutInfo {
+  ::mlir::Type type;
+};
+inline bool operator==(const LayoutInfo &lhs, const LayoutInfo &rhs) {
+  return lhs.type == rhs.type;
+}
+inline bool operator!=(const LayoutInfo &lhs, const LayoutInfo &rhs) {
+  return !(lhs == rhs);
+}
 } // namespace mlir::iree_compiler::IREE::Util
+
+namespace llvm {
+template <>
+struct DenseMapInfo<mlir::iree_compiler::IREE::Util::LayoutInfo> {
+  static inline mlir::iree_compiler::IREE::Util::LayoutInfo getEmptyKey() {
+    ::mlir::Type emptyType = llvm::DenseMapInfo<::mlir::Type>::getEmptyKey();
+    return mlir::iree_compiler::IREE::Util::LayoutInfo{emptyType};
+  }
+  static inline mlir::iree_compiler::IREE::Util::LayoutInfo getTombstoneKey() {
+    ::mlir::Type tombstoneType =
+        llvm::DenseMapInfo<::mlir::Type>::getTombstoneKey();
+    return mlir::iree_compiler::IREE::Util::LayoutInfo{tombstoneType};
+  }
+  static unsigned
+  getHashValue(mlir::iree_compiler::IREE::Util::LayoutInfo layout) {
+    return llvm::DenseMapInfo<::mlir::Type>::getHashValue(layout.type);
+  }
+  static bool isEqual(mlir::iree_compiler::IREE::Util::LayoutInfo lhs,
+                      mlir::iree_compiler::IREE::Util::LayoutInfo rhs) {
+    return lhs == rhs;
+  }
+};
+} // namespace llvm
 
 #include "iree/compiler/Dialect/Util/IR/UtilAttrInterfaces.h.inc" // IWYU pragma: export
 #include "iree/compiler/Dialect/Util/IR/UtilOpInterfaces.h.inc" // IWYU pragma: export

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals.mlir
@@ -463,3 +463,36 @@ module @partially_analyzed_op {
     util.return %barrier1#0, %barrier1#1 : i32, i32
   }
 }
+
+// -----
+
+// Check that computations on globals that end up with different layouts dont get hoisted.
+
+util.global private @"weights" : tensor<4096x4096xf8E4M3FNUZ>
+util.func public @func1() -> (tensor<4096x4096xf8E4M3FNUZ, #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], round_dims_to = array<i64: 32, 32, 32>>>) {
+  %0 = util.global.load immutable @"weights" : tensor<4096x4096xf8E4M3FNUZ>
+  %1 = flow.tensor.encode %0 : tensor<4096x4096xf8E4M3FNUZ> -> tensor<4096x4096xf8E4M3FNUZ, #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], round_dims_to = array<i64: 32, 32, 32>>>
+  util.return %1 : tensor<4096x4096xf8E4M3FNUZ, #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], round_dims_to = array<i64: 32, 32, 32>>>
+}
+util.func public @func2() -> (tensor<4096x4096xf8E4M3FNUZ, #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], round_dims_to = array<i64: 4, 32, 32>>>) {
+  %0 = util.global.load immutable @"weights" : tensor<4096x4096xf8E4M3FNUZ>
+  %1 = flow.tensor.encode %0 : tensor<4096x4096xf8E4M3FNUZ> -> tensor<4096x4096xf8E4M3FNUZ, #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], round_dims_to = array<i64: 4, 32, 32>>>
+  util.return %1 : tensor<4096x4096xf8E4M3FNUZ, #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], round_dims_to = array<i64: 4, 32, 32>>>
+}
+
+// -----
+
+
+// Check that computations on globals that end up with different layouts do get hoisted
+
+util.global private @"weights" : tensor<4096x4096xf8E4M3FNUZ>
+util.func public @func1() -> (tensor<4096x4096xf8E4M3FNUZ, #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], round_dims_to = array<i64: 32, 32, 32>>>) {
+  %0 = util.global.load immutable @"weights" : tensor<4096x4096xf8E4M3FNUZ>
+  %1 = flow.tensor.encode %0 : tensor<4096x4096xf8E4M3FNUZ> -> tensor<4096x4096xf8E4M3FNUZ, #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], round_dims_to = array<i64: 32, 32, 32>>>
+  util.return %1 : tensor<4096x4096xf8E4M3FNUZ, #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], round_dims_to = array<i64: 32, 32, 32>>>
+}
+util.func public @func2() -> (tensor<4096x4096xf8E4M3FNUZ, #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], round_dims_to = array<i64: 32, 32, 32>>>) {
+  %0 = util.global.load immutable @"weights" : tensor<4096x4096xf8E4M3FNUZ>
+  %1 = flow.tensor.encode %0 : tensor<4096x4096xf8E4M3FNUZ> -> tensor<4096x4096xf8E4M3FNUZ, #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], round_dims_to = array<i64: 32, 32, 32>>>
+  util.return %1 : tensor<4096x4096xf8E4M3FNUZ, #iree_encoding.encoding<operand_index = 1 : index, op_type =  matmul, element_types = [f8E4M3FNUZ, f8E4M3FNUZ, f32], user_indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], round_dims_to = array<i64: 32, 32, 32>>>
+}


### PR DESCRIPTION
When hoisting encoding operations which encode global tensors (like weights), if all the encodings do not agree in their layout, this could result in repeated duplication of the global tensors for different layouts. To avoid this

- A new interface method is added to `HoistableOpInterface` that allows an op to return information about layouts of its results

- Starting from each global (that is constant), forward slices of all its uses are computed. The layout at the leaves of all the slices are evaluated. If they disagree on the layout to be used, then the leaves are dropped. This could be done repeatedly, but is done only once in this PR.