### PR TITLE
Properly set the upper bound of gpu.lane_id when rewriteForallToLanes.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_distribute_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_distribute_forall.mlir
@@ -60,7 +60,7 @@ func.func @distribute_lane_forall(%out : memref<?xi32>)
 }
 
 // CHECK-LABEL: func @distribute_lane_forall
-//       CHECK:   %[[LANEID:.+]] = gpu.lane_id
+//       CHECK:   %[[LANEID:.+]] = gpu.lane_id upper_bound 32
 //       CHECK:   memref.store {{.*}}[%[[LANEID]]]
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/distribute_lane_forall.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/TransformExtensions/test/distribute_lane_forall.mlir
@@ -28,7 +28,7 @@ module attributes { transform.with_named_sequence } {
 // CHECK: #[[$MAP1:.+]] = affine_map<(d0) -> (d0 * 16)>
 
 // CHECK-LABEL: func @distribute_lane_forall
-//       CHECK:   %[[LANE_ID:.+]] = gpu.lane_id
+//       CHECK:   %[[LANE_ID:.+]] = gpu.lane_id upper_bound 64
 //   CHECK-NOT:   scf.forall
 //       CHECK:   affine.delinearize_index %[[LANE_ID]] into (4, 16) : index, index
 //       CHECK:   linalg.copy


### PR DESCRIPTION
If subgroup size is available, properly sets the upper bound of gpu.lane_id when it's created.

Fixes: #20385