### PR TITLE
[Encoding] Implement ContractionEncodingAttrInterface.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
@@ -79,8 +79,8 @@ MaterializeEncodingConversionTarget::MaterializeEncodingConversionTarget(
       if (!tensorType || !tensorType.getEncoding()) {
         return false;
       }
-      return isa<IREE::Encoding::EncodingAttr, IREE::Encoding::LayoutAttr>(
-          tensorType.getEncoding());
+      return isa<IREE::Encoding::ContractionEncodingAttrInterface,
+                 IREE::Encoding::LayoutAttr>(tensorType.getEncoding());
     };
     auto valueHasDataTilingEncoding = [=](Value v) -> bool {
       return typeHasDataTilingEncoding(v.getType());

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_into_padding.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_into_padding.mlir
@@ -193,3 +193,70 @@ func.func @set_pad_encoding_and_store_with_resolved_layout() {
 // CHECK-SAME:                  !flow.dispatch.tensor<readonly:tensor<2048x2048xf16>> -> tensor<2048x2048xf16>
 // CHECK:         flow.dispatch.tensor.store %[[LD]], %[[B]], offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1]
 // CHECK-SAME:                  tensor<2048x2048xf16> -> !flow.dispatch.tensor<writeonly:tensor<2048x2112xf16>>
+
+// -----
+
+// We only have one matmul_k test because they are all going through interfaces.
+// Other logic is already tested above.
+
+#binding_ro = #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">
+#binding = #hal.pipeline.binding<storage_buffer, Indirect>
+#encoding_mmt_lhs = #iree_encoding.matmul_k<k_dims = [1]>
+#pad_encoding_lhs = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 64]>]>
+#encoding_mmt_rhs = #iree_encoding.matmul_k<k_dims = [1]>
+#pad_encoding_rhs = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 128]>]>
+#encoding_mmt_out = #iree_encoding.matmul_k<k_dims = []>
+func.func @load_from_padded_and_mmt_using_matmul_k() {
+  %c0 = arith.constant 0 : index
+  %c8650752 = arith.constant 8650752 : index
+  %c17301504 = arith.constant 17301504 : index
+  %cst = arith.constant 0.000000e+00 : f16
+  %0 = hal.interface.binding.subspan layout(<bindings = [#binding_ro, #binding], flags = Indirect>) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect")
+         : !flow.dispatch.tensor<readonly:tensor<2048x2048xf16, #pad_encoding_lhs>>
+  %1 = hal.interface.binding.subspan layout(<bindings = [#binding_ro, #binding], flags = Indirect>) binding(0) alignment(64) offset(%c8650752) flags("ReadOnly|Indirect")
+         : !flow.dispatch.tensor<readonly:tensor<2048x2048xf16, #pad_encoding_rhs>>
+  %2 = hal.interface.binding.subspan layout(<bindings = [#binding_ro, #binding], flags = Indirect>) binding(1) alignment(64) offset(%c17301504) flags(Indirect)
+         : !flow.dispatch.tensor<writeonly:tensor<2048x2048xf16>>
+  %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1]
+         : !flow.dispatch.tensor<readonly:tensor<2048x2048xf16, #pad_encoding_lhs>> -> tensor<2048x2048xf16, #encoding_mmt_lhs>
+  %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1]
+         : !flow.dispatch.tensor<readonly:tensor<2048x2048xf16, #pad_encoding_rhs>> -> tensor<2048x2048xf16, #encoding_mmt_rhs>
+  %5 = tensor.empty() : tensor<2048x2048xf16, #encoding_mmt_out>
+  %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<2048x2048xf16, #encoding_mmt_out>) -> tensor<2048x2048xf16, #encoding_mmt_out>
+  %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>,
+                                        affine_map<(d0, d1, d2) -> (d1, d2)>,
+                                        affine_map<(d0, d1, d2) -> (d0, d1)>],
+                       iterator_types = ["parallel", "parallel", "reduction"]}
+    ins(%3, %4 : tensor<2048x2048xf16, #encoding_mmt_lhs>, tensor<2048x2048xf16, #encoding_mmt_rhs>)
+    outs(%6 : tensor<2048x2048xf16, #encoding_mmt_out>) {
+  ^bb0(%in: f16, %in_0: f16, %out: f16):
+    %9 = arith.mulf %in, %in_0 : f16
+    %10 = arith.addf %out, %9 : f16
+    linalg.yield %10 : f16
+  } -> tensor<2048x2048xf16, #encoding_mmt_out>
+  %8 = iree_encoding.unset_encoding %7 : tensor<2048x2048xf16, #encoding_mmt_out> -> tensor<2048x2048xf16>
+  flow.dispatch.tensor.store %8, %2, offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1]
+    : tensor<2048x2048xf16> -> !flow.dispatch.tensor<writeonly:tensor<2048x2048xf16>>
+  return
+}
+
+// CHECK-LABEL: @load_from_padded_and_mmt_using_matmul_k
+// CHECK:         %[[A:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)
+// CHECK-SAME:                  !flow.dispatch.tensor<readonly:tensor<2048x2112xf16>>
+// CHECK:         %[[B:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)
+// CHECK-SAME:                  !flow.dispatch.tensor<readonly:tensor<2048x2176xf16>>
+// CHECK:         %[[C:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)
+// CHECK-SAME:                  !flow.dispatch.tensor<writeonly:tensor<2048x2048xf16>>
+// CHECK:         %[[LD_A:.+]] = flow.dispatch.tensor.load %[[A]], offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1]
+// CHECK-SAME:                    !flow.dispatch.tensor<readonly:tensor<2048x2112xf16>> -> tensor<2048x2048xf16>
+// CHECK:         %[[LD_B:.+]] = flow.dispatch.tensor.load %[[B]], offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1]
+// CHECK-SAME:                    !flow.dispatch.tensor<readonly:tensor<2048x2176xf16>> -> tensor<2048x2048xf16>
+//
+// CHECK:         tensor.empty() : tensor<2048x2048xf16>
+// CHECK:         %[[FILL:.+]] = linalg.fill {{.+}} : tensor<2048x2048xf16>
+// CHECK:         %[[MMT:.+]] = linalg.generic
+// CHECK-SAME:      ins(%[[LD_A]], %[[LD_B]] : tensor<2048x2048xf16>, tensor<2048x2048xf16>)
+// CHECK-SAME:      outs(%[[FILL]] : tensor<2048x2048xf16>)
+//
+// CHECK:         flow.dispatch.tensor.store %[[MMT]], %[[C]], offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1]
+// CHECK-SAME:                  tensor<2048x2048xf16> -> !flow.dispatch.tensor<writeonly:tensor<2048x2048xf16>>

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
@@ -480,12 +480,10 @@ std::optional<SmallVector<int32_t>> EncodingAttr::getReductionDims() const {
     return std::nullopt;
   }
   SmallVector<int32_t> result;
-  for (auto k : contractionDims->k) {
-    std::optional<unsigned> dimIdx = mapDimToOperandIndex(k);
-    if (!dimIdx) {
-      continue;
+  for (unsigned k : contractionDims->k) {
+    if (std::optional<unsigned> dimIdx = mapDimToOperandIndex(k)) {
+      result.push_back(dimIdx.value());
     }
-    result.push_back(dimIdx.value());
   }
   return result;
 }

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -102,6 +102,9 @@ def EncodingAttr :
       DeclareAttrInterfaceMethods<IREEEncoding_SerializableEncodingAttrInterface, [
         "isSerialized",
         "cloneWithLayouts",
+      ]>,
+      DeclareAttrInterfaceMethods<IREEEncoding_ContractionEncodingAttrInterface, [
+        "getReductionDims",
       ]>
     ]> {
   let mnemonic = "encoding";
@@ -180,7 +183,14 @@ def EncodingAttr :
 // iree_encoding.matmul_k
 //===---------------------------------------------------------------------===//
 
-def MatmulKAttr : IREEEncoding_Attr<"MatmulK"> {
+def MatmulKAttr : IREEEncoding_Attr<"MatmulK", [
+      // TODO(hanchung): Implement the interface method. It is required to make
+      // set/unset_encoding ops happy.
+      IREEEncoding_SerializableEncodingAttrInterface,
+      DeclareAttrInterfaceMethods<IREEEncoding_ContractionEncodingAttrInterface, [
+        "getReductionDims",
+      ]>
+    ]> {
   let mnemonic = "matmul_k";
   let summary = [{An attribute that tracks reduction dimensions for matmul}];
   let description = [{

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -184,7 +184,6 @@ def EncodingAttr :
 //===---------------------------------------------------------------------===//
 
 def MatmulKAttr : IREEEncoding_Attr<"MatmulK", [
-      IREEEncoding_SerializableEncodingAttrInterface,
       DeclareAttrInterfaceMethods<IREEEncoding_SerializableEncodingAttrInterface, [
         "isSerialized",
         "cloneWithLayouts",

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
@@ -207,6 +207,30 @@ def IREEEncoding_SerializableEncodingAttrInterface :
   }];
 }
 
+def IREEEncoding_ContractionEncodingAttrInterface :
+  AttrInterface<"ContractionEncodingAttrInterface"> {
+  let cppNamespace = "::mlir::iree_compiler::IREE::Encoding";
+  let description = [{
+    Interface used to query contraction information.
+  }];
+
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns the reduction dimensions. Returns std::nullopt on failure.
+      }],
+      /*retTy=*/"std::optional<llvm::SmallVector<int32_t>>",
+      /*methodName=*/"getReductionDims",
+      /*args=*/(ins
+      ),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return std::nullopt;
+      }]
+    >
+  ];
+}
+
 //===----------------------------------------------------------------------===//
 // Type Interfaces
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
There is a `getReductionDims()` method in the interface so far. The revision implements it for EncodingAttr and MatmulKAttr and adapts GPUPadLayoutAttr to use the interface.

It is a step towards https://github.com/iree-org/iree/issues/20493