### PR TITLE
[Encoding] Implement SerializableEncodingAttrInterface for MatmulK.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
@@ -474,6 +474,21 @@ Attribute EncodingAttr::cloneWithLayouts(ArrayRef<Attribute> layouts) const {
 }
 
 //===---------------------------------------------------------------------===//
+// iree_encoding.matmul_k
+//===---------------------------------------------------------------------===//
+
+MatmulKAttr MatmulKAttr::get(MLIRContext *ctx, ArrayRef<int32_t> kDims) {
+  return get(ctx, DenseI32ArrayAttr::get(ctx, kDims));
+}
+
+bool MatmulKAttr::isSerialized() const { return false; }
+
+Attribute MatmulKAttr::cloneWithLayouts(ArrayRef<Attribute> layouts) const {
+  MLIRContext *ctx = getContext();
+  return LayoutAttr::get(ctx, ArrayAttr::get(ctx, layouts));
+}
+
+//===---------------------------------------------------------------------===//
 // iree_encoding.pad_encoding_layout
 //===---------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -180,7 +180,12 @@ def EncodingAttr :
 // iree_encoding.matmul_k
 //===---------------------------------------------------------------------===//
 
-def MatmulKAttr : IREEEncoding_Attr<"MatmulK"> {
+def MatmulKAttr : IREEEncoding_Attr<"MatmulK", [
+      DeclareAttrInterfaceMethods<IREEEncoding_SerializableEncodingAttrInterface, [
+        "isSerialized",
+        "cloneWithLayouts",
+      ]>
+    ]> {
   let mnemonic = "matmul_k";
   let summary = [{An attribute that tracks reduction dimensions for matmul}];
   let description = [{
@@ -223,6 +228,10 @@ def MatmulKAttr : IREEEncoding_Attr<"MatmulK"> {
   let parameters = (ins
     "DenseI32ArrayAttr":$k_dims
   );
+
+  let builders = [
+    AttrBuilder<(ins "ArrayRef<int32_t>":$k_dims)>
+  ];
 }
 
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/unittests/EncodingAttrTest.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/unittests/EncodingAttrTest.cpp
@@ -42,6 +42,18 @@ TEST_F(EncodingAttrsTest, EncodingAttr) {
   EXPECT_TRUE(attr.isIdentityLayout());
 }
 
+TEST_F(EncodingAttrsTest, MatulKAttr) {
+  MLIRContext *ctx = getContext();
+  Builder builder(ctx);
+  auto attr = cast<SerializableEncodingAttrInterface>(
+      MatmulKAttr::get(ctx, /*k_dims=*/{1}));
+  EXPECT_FALSE(attr.isIdentityLayout());
+
+  attr = cast<SerializableEncodingAttrInterface>(attr.cloneWithLayouts(
+      PadEncodingLayoutAttr::getIdentityAttr(ctx, /*rank=*/2)));
+  EXPECT_TRUE(attr.isIdentityLayout());
+}
+
 TEST_F(EncodingAttrsTest, PadEncodingLayoutAttr) {
   MLIRContext *ctx = getContext();
   auto zeroPaddingAttr =


### PR DESCRIPTION
It also adds a builder which takes `ArrayRef<int32_t>` as an input.

It is a step towards https://github.com/iree-org/iree/issues/20493