### PR TITLE
[DT] Add a flag to not hoist encodings when the source is ConstExpr.

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -286,6 +286,10 @@ def FuseEncodingOpsIntoDispatchRegionsPass :
 def HoistEncodingOpsPass :
     InterfacePass<"iree-dispatch-creation-hoist-encoding-ops", "mlir::FunctionOpInterface"> {
   let summary = "Hoists tensor encoding ops out of flow dispatch regions.";
+  let options = [
+    Option<"hoistEncodingsForConstExpr", "hoist-encodings-for-constexpr", "bool", /*default=*/"true",
+           "Enable the hoisting when the source is a ConstExpr.">,
+  ];
   let dependentDialects = [
     "mlir::linalg::LinalgDialect",
     "IREE::Flow::FlowDialect",

--- a/compiler/src/iree/compiler/DispatchCreation/test/hoist_encoding_ops.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/hoist_encoding_ops.mlir
@@ -1,4 +1,5 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-hoist-encoding-ops))" --split-input-file %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-hoist-encoding-ops{hoist-encodings-for-constexpr=false}))" --split-input-file %s | FileCheck %s --check-prefix=NO-CONST
 
 #map1 = affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>
 #map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
@@ -247,3 +248,8 @@ util.func public @hoist_encoding_only() -> tensor<640x320xf32> {
 // CHECK:         %[[CST:.+]] = arith.constant
 // CHECK:         %[[SET_ENCODING:.+]] = iree_encoding.set_encoding %[[CST]]
 // CHECK:         flow.dispatch.region
+
+// NO-CONST-LABEL: util.func public @hoist_encoding_only(
+// NO-CONST:         %[[CST:.+]] = arith.constant
+// NO-CONST:         flow.dispatch.region
+// NO-CONST:           %[[SET_ENCODING:.+]] = iree_encoding.set_encoding %[[CST]]


### PR DESCRIPTION
The revision adds an option to not hoist encodings when the source is a global.load op or has ConstantLike trait.

It is a workaround for huge memory allocation because the ops are still in dispatch region. I.e., it stops hoisting globals to initializer.