### PR TITLE
[Encoding] Remove padFactor in set encoding pass

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -41,14 +41,6 @@ static llvm::cl::opt<bool> clEnableFusePaddingIntoLinalgProducerOps(
     llvm::cl::desc("Enable fusing tensor.pad ops into Linalg consumer ops."),
     llvm::cl::init(false));
 
-static llvm::cl::opt<int> clPadFactor(
-    "iree-dispatch-creation-pad-factor",
-    llvm::cl::desc("Provides padding size hints that will be attached to "
-                   "encodings. This only affects the experimental data tiling "
-                   "path in DispatchCreation with "
-                   "iree-dispatch-creation-experimental-data-tiling."),
-    llvm::cl::init(32));
-
 static llvm::cl::opt<bool> clEnablePadHandling(
     "iree-flow-enable-pad-handling",
     llvm::cl::desc("Enable native handling of tensor.pad operations."),
@@ -252,9 +244,7 @@ addDispatchRegionCreationPasses(OpPassManager &passManager,
         // Set encodings on all eligible ops. All ops should be in compiler
         // formed dispatch regions, so encodings will be placed inside of the
         // dispatch regions with the data-tiled op.
-        .addPass([] {
-          return createSetEncodingPass(SetEncodingPassOptions{clPadFactor});
-        })
+        .addPass(createSetEncodingPass)
         // SetEncodingOps should not be in the same dispatch as the data-tiled
         // op, so hoist them out of their current dispatch regions. Also, bubble
         // SetEncodingOps through special operations like bit-extending ops and

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -306,10 +306,6 @@ def SetEncodingPass :
     "IREE::Flow::FlowDialect",
     "IREE::Encoding::IREEEncodingDialect",
   ];
-  let options = [
-    Option<"padFactor", "pad-factor", "int64_t", /*default=*/"32",
-           "provides padding size hints that will be attached to encodings.">,
-  ];
 }
 
 def ConvertEncodingToFlowPass :

--- a/compiler/src/iree/compiler/DispatchCreation/SetEncoding.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SetEncoding.cpp
@@ -163,8 +163,8 @@ class SetContractionOpEncoding final
     : public OpInterfaceRewritePattern<linalg::LinalgOp> {
 public:
   using OpInterfaceRewritePattern::OpInterfaceRewritePattern;
-  explicit SetContractionOpEncoding(MLIRContext *ctx, int64_t factor)
-      : OpInterfaceRewritePattern<linalg::LinalgOp>(ctx), padFactor(factor) {}
+  explicit SetContractionOpEncoding(MLIRContext *ctx)
+      : OpInterfaceRewritePattern<linalg::LinalgOp>(ctx) {}
 
   LogicalResult matchAndRewrite(linalg::LinalgOp linalgOp,
                                 PatternRewriter &rewriter) const override {
@@ -248,9 +248,6 @@ public:
     rewriter.replaceOp(linalgOp, result);
     return success();
   }
-
-private:
-  int64_t padFactor = 32;
 };
 
 /// Pattern to fold a `linalg.fill` -> `iree_encoding.set_encoding`
@@ -284,7 +281,7 @@ struct SetEncodingPass final : impl::SetEncodingPassBase<SetEncodingPass> {
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     RewritePatternSet patterns(context);
-    patterns.add<SetContractionOpEncoding>(context, padFactor);
+    patterns.add<SetContractionOpEncoding>(context);
     linalg::FillOp::getCanonicalizationPatterns(patterns, context);
     patterns.add<FoldFillWithSetEncoding>(context);
     memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
@@ -61,12 +61,6 @@ static llvm::cl::opt<DemotionOption> clDemoteContractionInputsToBF16Strategy(
         clEnumValN(DemotionOption::None, "none", "Demote no contraction ops.")),
     llvm::cl::init(DemotionOption::None));
 
-static llvm::cl::opt<int> clPadFactor(
-    "iree-global-opt-pad-factor",
-    llvm::cl::desc("provides padding size hints that will be attached to "
-                   "encodings."),
-    llvm::cl::init(32));
-
 static llvm::cl::opt<bool> clWarnOnUninitializedValues(
     "iree-global-opt-enable-warn-on-uninitialized-values",
     llvm::cl::desc("Warn on some classes of uses of uninitialized values."),
@@ -181,10 +175,8 @@ void buildGlobalOptimizationPassPipeline(
 
   // Enable data tiling after they are in a canonical form.
   if (transformOptions.options.dataTiling) {
-    FunctionLikeNest(mainPassManager).addPass([&]() {
-      return DispatchCreation::createSetEncodingPass(
-          DispatchCreation::SetEncodingPassOptions{clPadFactor});
-    });
+    FunctionLikeNest(mainPassManager)
+        .addPass(DispatchCreation::createSetEncodingPass);
     // TODO(hanchung): Make data-tiling passes be FunctionOpInterface pass, so
     // we can use `FunctionLikNest` here.
     if (clEnableEarlyMaterialization) {


### PR DESCRIPTION
Since we no longer need round_dims_to attribute  we can remove the pad-factor attribute. The encoding specialization handles the allocation.