### PR TITLE
[DispatchCreation] Add pattern to fold expand shape into hal.tensor.export

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/BUILD.bazel
+++ b/compiler/src/iree/compiler/DispatchCreation/BUILD.bazel
@@ -53,6 +53,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow",
         "//compiler/src/iree/compiler/Dialect/Flow/IR",
         "//compiler/src/iree/compiler/Dialect/Flow/Transforms",
+        "//compiler/src/iree/compiler/Dialect/HAL/IR",
         "//compiler/src/iree/compiler/Dialect/LinalgExt/IR",
         "//compiler/src/iree/compiler/Dialect/LinalgExt/Transforms",
         "//compiler/src/iree/compiler/Dialect/LinalgExt/Utils",

--- a/compiler/src/iree/compiler/DispatchCreation/CMakeLists.txt
+++ b/compiler/src/iree/compiler/DispatchCreation/CMakeLists.txt
@@ -84,6 +84,7 @@ iree_cc_library(
     iree::compiler::Dialect::Flow::Conversion::TensorToFlow
     iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::Flow::Transforms
+    iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::LinalgExt::IR
     iree::compiler::Dialect::LinalgExt::Transforms
     iree::compiler::Dialect::LinalgExt::Utils

--- a/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
@@ -77,6 +77,7 @@ class FoldExpandIntoExport
     if (barrierOp) {
       SmallVector<Value> newSources = barrierOp.getSources();
       newSources[expandIdx] = expandOp.getSrc();
+      rewriter.setInsertionPoint(barrierOp);
       newResult = rewriter
                       .replaceOpWithNewOp<IREE::HAL::TensorBarrierOp>(
                           barrierOp, newSources, barrierOp.getSignalFence())
@@ -89,6 +90,7 @@ class FoldExpandIntoExport
                            : nullptr;
     Attribute newExportAffinity =
         exportOp.getAffinity() ? exportOp.getAffinity().value() : nullptr;
+    rewriter.setInsertionPoint(exportOp);
     rewriter.replaceOpWithNewOp<IREE::HAL::TensorExportOp>(
         exportOp, exportOp.getTarget().getType(), newResult,
         TypeAttr::get(exportOp.getSourceEncoding()), newExportName,

--- a/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FoldUnitExtentDims.cpp
@@ -45,7 +45,7 @@ namespace mlir::iree_compiler::DispatchCreation {
 // `hal.tensor.export` op if they are directly consumed by them or optionally
 // consumed by `hal.tensor.barrier` op that is then consumed by the export op.
 // This is useful becuase folding unit extent dims often results in expand
-// shapes that can then be bubbled up be other patterns blocking further
+// shapes that can then be bubbled up by other patterns blocking further
 // optimizations.
 
 class FoldExpandIntoExport
@@ -91,7 +91,7 @@ class FoldExpandIntoExport
         exportOp.getAffinity() ? exportOp.getAffinity().value() : nullptr;
     rewriter.replaceOpWithNewOp<IREE::HAL::TensorExportOp>(
         exportOp, exportOp.getTarget().getType(), newResult,
-        TypeAttr::get(expandOp.getResult().getType()), newExportName,
+        TypeAttr::get(exportOp.getSourceEncoding()), newExportName,
         newExportAffinity);
 
     return success();

--- a/compiler/src/iree/compiler/DispatchCreation/test/fold_unit_dims.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/fold_unit_dims.mlir
@@ -132,14 +132,14 @@ util.func public @scatter(%arg0 : tensor<4xi64>, %arg1 : tensor<4x1xi32>, %arg2 
 
 util.func public @no_barrier(%arg0 : tensor<4096x2048xf32>) -> !hal.buffer_view {
   %expanded = tensor.expand_shape %arg0 [[0, 1, 2], [3]] output_shape [4096, 1, 1, 2048] : tensor<4096x2048xf32> into tensor<4096x1x1x2048xf32>
-  %8 = hal.tensor.export on(#hal.device.promise<@dev_a>) %expanded "output" : tensor<4096x1x1x2048xf32> -> !hal.buffer_view
+  %8 = hal.tensor.export on(#hal.device.promise<@dev_a>) %expanded "output" : tensor<2048x2x1x2048xf32> as tensor<4096x1x1x2048xf32> -> !hal.buffer_view
   util.return %8 : !hal.buffer_view
 }
 // CHECK-LABEL: func public @no_barrier
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
 //  CHECK-NOT:    tensor.expand_shape
 //      CHECK:    %[[EXPORT:.+]] =  hal.tensor.export on(#hal.device.promise<@dev_a>) %[[ARG0]] "output"
-// CHECK-SAME:      : tensor<4096x1x1x2048xf32> as tensor<4096x2048xf32> -> !hal.buffer_view
+// CHECK-SAME:      : tensor<2048x2x1x2048xf32> as tensor<4096x2048xf32> -> !hal.buffer_view
 //      CHECK:    util.return %[[EXPORT]]
 
 // -----


### PR DESCRIPTION
Export op allows for providing a source encoding so when we have a expand shape that is only consumed by  export op (either directly of via a barrier) we can fold the expand shape into the export. This is useful as these expand shapes through later passes can block optimizations. This is more of a problem for the `makeSingleDispatch` preprocessing pipeline becuase the expand shapes can end up within the dispatch and block optmizations done by the `CollapseDimensionsPass`.