### PR TITLE
[Codegen] Add op for swizzling memory accesses

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -148,6 +148,7 @@ iree_compiler_cc_library(
         "RematerializeParallelOps.cpp",
         "RemoveSingleIterationLoop.cpp",
         "ReplaceSlowMinMaxOps.cpp",
+        "ResolveSwizzleHints.cpp",
         "SplitFullPartialTransferPass.cpp",
         "StripCompilationInfoPass.cpp",
         "TensorDynamicDimAnalysis.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -141,6 +141,7 @@ iree_cc_library(
     "RematerializeParallelOps.cpp"
     "RemoveSingleIterationLoop.cpp"
     "ReplaceSlowMinMaxOps.cpp"
+    "ResolveSwizzleHints.cpp"
     "SplitFullPartialTransferPass.cpp"
     "StripCompilationInfoPass.cpp"
     "TensorDynamicDimAnalysis.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -597,6 +597,15 @@ def RemoveSingleIterationLoopPass :
   let summary = "Remove distributed loop with single iteration.";
 }
 
+def ResolveSwizzleHintsPass :
+    InterfacePass<"iree-codegen-resolve-swizzle-hints", "mlir::FunctionOpInterface"> {
+  let summary = "Resolves iree_codegen.swizzle_hint ops";
+  let dependentDialects = [
+    "affine::AffineDialect",
+    "arith::ArithDialect",
+  ];
+}
+
 def StripCompilationInfoPass :
     Pass<"iree-codegen-strip-compilation-info", "">{
    let summary = "Remove all the the lowering configuration and translation info attributes.";

--- a/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ResolveSwizzleHints.cpp
@@ -1,0 +1,196 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/Passes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Arith/Utils/Utils.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/AffineExpr.h"
+#include "mlir/IR/AffineMap.h"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_RESOLVESWIZZLEHINTSPASS
+#include "iree/compiler/Codegen/Common/Passes.h.inc"
+
+namespace {
+struct ResolveSwizzleHintsPass final
+    : public impl::ResolveSwizzleHintsPassBase<ResolveSwizzleHintsPass> {
+  using Base::Base;
+  void runOnOperation() override;
+};
+} // namespace
+
+/// Swizzles vector.load(iree_codegen.swizzle_hint, offset). The
+/// SwizzleInterfaceAttr exposes two methods:
+///   1. getAccessElementCount -> int64_t
+///        - Gives the number of contiguous elements in the swizzling pattern.
+///   2. swizzleOffset(src: memref<N x !eltype>, offset: index) -> index
+///        - Swizzles the |offset| into |src|, returning the new offset.
+///
+/// For a 1-d load of type `vector<C x !eltype>`, the load is unrolled into
+/// loads of size `k = getAccessElementCount()` and individually swizzled.
+///
+/// For example, if `C = 16` and `k = 4`, this produces:
+///
+/// %0 = vector.load %src[swizzleOffset(%src, %offset)] : vector<4>
+/// %1 = vector.load %src[swizzleOffset(%src, %offset + 4)] : vector<4>
+/// %2 = vector.load %src[swizzleOffset(%src, %offset + 8)] : vector<4>
+/// %3 = vector.load %src[swizzleOffset(%src, %offset + 12)] : vector<4>
+/// %load = concat[%0, %1, %2, %3] : vector<16>
+void swizzleLoad(RewriterBase &rewriter, vector::LoadOp load,
+                 IREE::Codegen::SwizzleHintOp hintOp) {
+  Location hintLoc = hintOp.getLoc();
+  int64_t accessWidth = hintOp.getSwizzle().getAccessElementCount();
+  VectorType type = load.getVectorType();
+  int64_t loadWidth = type.getShape()[0];
+  Value memrefOffset = load.getIndices()[0];
+  VectorType swizzledLoadType =
+      VectorType::get({accessWidth}, type.getElementType());
+
+  AffineExpr s0, s1;
+  bindSymbols(rewriter.getContext(), s0, s1);
+  AffineMap sum = AffineMap::get(0, 2, s0 + s1);
+
+  // ~ vector.undef, overwritten by unrolling.
+  Value replacement = rewriter.create<arith::ConstantOp>(
+      hintLoc, type, rewriter.getZeroAttr(type));
+
+  // Load type = vector<C>, k = accessWidth
+  // i = 0 -> C += k is the offset into the vector of a contiguous group of
+  // swizzled elements.
+  for (int64_t i = 0; i < loadWidth; i += accessWidth) {
+    auto vecOffset = rewriter.getIndexAttr(i);
+    auto newBaseOffset = affine::makeComposedFoldedAffineApply(
+        rewriter, hintLoc, sum, {memrefOffset, vecOffset});
+
+    Value newOffset = getValueOrCreateConstantIndexOp(
+        rewriter, hintLoc,
+        hintOp.getSwizzle().swizzleOffset(rewriter, hintOp.getLoc(),
+                                          newBaseOffset, hintOp.getOperand()));
+    auto subLoad = rewriter.create<vector::LoadOp>(
+        load.getLoc(), swizzledLoadType, load.getBase(), newOffset);
+
+    replacement = rewriter.create<vector::InsertStridedSliceOp>(
+        load.getLoc(), subLoad, replacement, ArrayRef<int64_t>{i},
+        ArrayRef<int64_t>{1});
+  }
+  rewriter.replaceOp(load, replacement);
+}
+
+/// Swizzles vector.store(iree_codegen.swizzle_hint, offset).
+///
+/// For a 1-d store of type `vector<C x !eltype>`, the store is unrolled into
+/// stores of size `k = getAccessElementCount()` and individually swizzled.
+///
+/// For example, if `C = 16` and `k = 4`, this produces:
+///
+/// %0, %1, %2, %3 = split[%value_to_store] : vector<16>
+/// vector.store %0, %src[swizzleOffset(%src, %offset)] : vector<4>
+/// vector.store %1, %src[swizzleOffset(%src, %offset + 4)] : vector<4>
+/// vector.store %2, %src[swizzleOffset(%src, %offset + 8)] : vector<4>
+/// vector.store %3, %src[swizzleOffset(%src, %offset + 12)] : vector<4>
+void swizzleStore(RewriterBase &rewriter, vector::StoreOp store,
+                  IREE::Codegen::SwizzleHintOp hintOp) {
+  Location hintLoc = hintOp.getLoc();
+  int64_t accessWidth = hintOp.getSwizzle().getAccessElementCount();
+  VectorType type = store.getVectorType();
+  int64_t storeWidth = type.getShape()[0];
+  Value memrefOffset = store.getIndices()[0];
+
+  AffineExpr s0, s1;
+  bindSymbols(rewriter.getContext(), s0, s1);
+  AffineMap sum = AffineMap::get(0, 2, s0 + s1);
+
+  // Store type = vector<C>, k = accessWidth
+  // i = 0 -> C += k is the offset into the vector of a contiguous group of
+  // swizzled elements.
+  for (int64_t i = 0; i < storeWidth; i += accessWidth) {
+    Value subVec = rewriter.create<vector::ExtractStridedSliceOp>(
+        store.getLoc(), store.getValueToStore(), ArrayRef<int64_t>{i},
+        ArrayRef<int64_t>{accessWidth}, ArrayRef<int64_t>{1});
+    auto vecOffset = rewriter.getIndexAttr(i);
+    auto newBaseOffset = affine::makeComposedFoldedAffineApply(
+        rewriter, hintLoc, sum, {memrefOffset, vecOffset});
+
+    Value newOffset = getValueOrCreateConstantIndexOp(
+        rewriter, hintLoc,
+        hintOp.getSwizzle().swizzleOffset(rewriter, hintOp.getLoc(),
+                                          newBaseOffset, hintOp.getOperand()));
+    rewriter.create<vector::StoreOp>(store.getLoc(), subVec, store.getBase(),
+                                     newOffset);
+  }
+  rewriter.eraseOp(store);
+}
+
+/// Resolves all hints. Walks all direct users and splits them into loads and
+/// stores. If any user is not a swizzle-able load or store, bail out and
+/// silently drop the optimization hint.
+void resolveHintOp(RewriterBase &rewriter,
+                   IREE::Codegen::SwizzleHintOp hintOp) {
+  SmallVector<vector::LoadOp> loads;
+  SmallVector<vector::StoreOp> stores;
+  int64_t accessWidth = hintOp.getSwizzle().getAccessElementCount();
+  for (Operation *user : hintOp->getUsers()) {
+    if (auto load = dyn_cast<vector::LoadOp>(user)) {
+      VectorType loadType = load.getVectorType();
+      // Guard on zero rank loads and loads not divisible by the access width.
+      if (loadType.getRank() != 1 ||
+          loadType.getShape()[0] % accessWidth != 0) {
+        return;
+      }
+      loads.push_back(load);
+      continue;
+    }
+    if (auto store = dyn_cast<vector::StoreOp>(user)) {
+      VectorType storeType = store.getVectorType();
+      // Guard on zero rank stores and stores not divisible by the access width.
+      if (storeType.getRank() != 1 ||
+          storeType.getShape()[0] % accessWidth != 0) {
+        return;
+      }
+      stores.push_back(store);
+      continue;
+    }
+    // Bail out if we can't rewrite all users.
+    return;
+  }
+
+  for (auto load : loads) {
+    rewriter.setInsertionPoint(load);
+    swizzleLoad(rewriter, load, hintOp);
+  }
+  for (auto store : stores) {
+    rewriter.setInsertionPoint(store);
+    swizzleStore(rewriter, store, hintOp);
+  }
+}
+
+void ResolveSwizzleHintsPass::runOnOperation() {
+  auto funcOp = getOperation();
+
+  // Collect all hint ops.
+  SmallVector<IREE::Codegen::SwizzleHintOp> hintOps;
+  funcOp.walk(
+      [&](IREE::Codegen::SwizzleHintOp hint) { hintOps.push_back(hint); });
+
+  // Swizzle all load/store uses of the hint ops if possible. If we can't
+  // guarantee all accesses of a particular hint are swizzled, this will
+  // silently pass through for that hint.
+  IRRewriter rewriter(funcOp->getContext());
+  for (auto hintOp : hintOps) {
+    resolveHintOp(rewriter, hintOp);
+  }
+
+  // Drop all hints.
+  for (auto hintOp : hintOps) {
+    rewriter.replaceOp(hintOp, hintOp.getOperand());
+  }
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -82,6 +82,7 @@ iree_lit_test_suite(
             "rematerialize_parallel_ops.mlir",
             "remove_dead_allocs.mlir",
             "remove_trivial_loops.mlir",
+            "resolve_swizzle_hints.mlir",
             "repeated_matcher_use.mlir",
             "replace_slow_min_max_ops.mlir",
             "strip_compilation_info.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -80,6 +80,7 @@ iree_lit_test_suite(
     "remove_trivial_loops.mlir"
     "repeated_matcher_use.mlir"
     "replace_slow_min_max_ops.mlir"
+    "resolve_swizzle_hints.mlir"
     "strip_compilation_info.mlir"
     "test_partitionable_loops_interface.mlir"
     "tile_and_distribute_to_workgroups.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/resolve_swizzle_hints.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/resolve_swizzle_hints.mlir
@@ -1,0 +1,191 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-resolve-swizzle-hints, canonicalize, cse))" \
+// RUN:   --split-input-file --mlir-print-local-scope %s | FileCheck %s
+
+func.func @swizzle_load(%src: memref<?xf32>) -> vector<4xf32> {
+  %0 = iree_codegen.swizzle_hint %src[#iree_codegen.rotate_rows<64, 4>] : memref<?xf32>
+
+  // 68 = (1 x 64, 4) -> (1, 8) = 72
+  %offset = arith.constant 68 : index
+  %1 = vector.load %0[%offset] : memref<?xf32>, vector<4xf32>
+  return %1: vector<4xf32>
+}
+
+// CHECK-LABEL: func @swizzle_load
+//  CHECK-SAME:   %[[SRC:[A-Za-z0-9]+]]: memref<?xf32>
+//       CHECK:   %[[SWOFF:.+]] = arith.constant 72 : index
+//       CHECK:   %[[VECTOR:.+]] = vector.load %[[SRC]][%[[SWOFF]]]
+//       CHECK:   return %[[VECTOR]]
+
+// -----
+
+func.func @swizzle_store(%dst: memref<?xf32>, %src: vector<4xf32>) {
+  %0 = iree_codegen.swizzle_hint %dst[#iree_codegen.rotate_rows<64, 4>] : memref<?xf32>
+
+  // 124 = (1 x 64, 60) -> (1, 64 % 64) = 64
+  %offset = arith.constant 124 : index
+  vector.store %src, %0[%offset] : memref<?xf32>, vector<4xf32>
+  return
+}
+
+// CHECK-LABEL: func @swizzle_store
+//  CHECK-SAME:   %[[DST:[A-Za-z0-9]+]]: memref<?xf32>
+//  CHECK-SAME:   %[[SRC:[A-Za-z0-9]+]]: vector<4xf32>
+//       CHECK:   %[[SWOFF:.+]] = arith.constant 64 : index
+//       CHECK:   vector.store %[[SRC]], %[[DST]][%[[SWOFF]]]
+
+// -----
+
+func.func @swizzle_both(%src: memref<?xf32>) {
+  %0 = iree_codegen.swizzle_hint %src[#iree_codegen.rotate_rows<64, 4>] : memref<?xf32>
+  %c4 = arith.constant 4 : index
+  %c44 = arith.constant 44 : index
+  %c444 = arith.constant 444 : index
+  %c4444 = arith.constant 4444 : index
+  %1 = vector.load %0[%c4] : memref<?xf32>, vector<4xf32>
+  %2 = vector.load %0[%c44] : memref<?xf32>, vector<4xf32>
+  %3 = vector.load %0[%c444] : memref<?xf32>, vector<4xf32>
+  %4 = vector.load %0[%c4444] : memref<?xf32>, vector<4xf32>
+  vector.store %4, %0[%c4] : memref<?xf32>, vector<4xf32>
+  vector.store %3, %0[%c44] : memref<?xf32>, vector<4xf32>
+  vector.store %2, %0[%c444] : memref<?xf32>, vector<4xf32>
+  vector.store %1, %0[%c4444] : memref<?xf32>, vector<4xf32>
+  return
+}
+
+// CHECK-LABEL: func @swizzle_both
+//  CHECK-SAME:   %[[SRC:[A-Za-z0-9]+]]: memref<?xf32>
+//   CHECK-DAG:   %[[O0:.+]] = arith.constant 4 : index
+//   CHECK-DAG:   %[[O1:.+]] = arith.constant 44 : index
+//   CHECK-DAG:   %[[O2:.+]] = arith.constant 404 : index
+//   CHECK-DAG:   %[[O3:.+]] = arith.constant 4464 : index
+//       CHECK:   %[[V0:.+]] = vector.load %[[SRC]][%[[O0]]]
+//       CHECK:   %[[V1:.+]] = vector.load %[[SRC]][%[[O1]]]
+//       CHECK:   %[[V2:.+]] = vector.load %[[SRC]][%[[O2]]]
+//       CHECK:   %[[V3:.+]] = vector.load %[[SRC]][%[[O3]]]
+//       CHECK:   vector.store %[[V3]], %[[SRC]][%[[O0]]]
+//       CHECK:   vector.store %[[V2]], %[[SRC]][%[[O1]]]
+//       CHECK:   vector.store %[[V1]], %[[SRC]][%[[O2]]]
+//       CHECK:   vector.store %[[V0]], %[[SRC]][%[[O3]]]
+
+// -----
+
+func.func @drop_swizzle_non_access_user(%src: memref<?xf32>) -> (memref<?xf32>, vector<4xf32>) {
+  %0 = iree_codegen.swizzle_hint %src[#iree_codegen.rotate_rows<64, 4>] : memref<?xf32>
+  %offset = arith.constant 68 : index
+  %1 = vector.load %0[%offset] : memref<?xf32>, vector<4xf32>
+  return %0, %1: memref<?xf32>, vector<4xf32>
+}
+
+// CHECK-LABEL: func @drop_swizzle_non_access_user
+//  CHECK-SAME:   %[[SRC:[A-Za-z0-9]+]]: memref<?xf32>
+
+// Make sure the offset remains the same
+//       CHECK:   %[[SWOFF:.+]] = arith.constant 68 : index
+//       CHECK:   %[[VECTOR:.+]] = vector.load %[[SRC]][%[[SWOFF]]]
+//       CHECK:   return %[[SRC]], %[[VECTOR]]
+
+// -----
+
+func.func @swizzle_unroll_load(%src: memref<?xf32>) -> (vector<4xf32>, vector<4xf32>) {
+  %0 = iree_codegen.swizzle_hint %src[#iree_codegen.rotate_rows<64, 4>] : memref<?xf32>
+  %offset = arith.constant 60 : index
+  %1 = vector.load %0[%offset] : memref<?xf32>, vector<8xf32>
+  %2 = vector.extract_strided_slice %1 {offsets = [0], sizes = [4], strides = [1]} : vector<8xf32> to vector<4xf32>
+  %3 = vector.extract_strided_slice %1 {offsets = [4], sizes = [4], strides = [1]} : vector<8xf32> to vector<4xf32>
+  return %2, %3 : vector<4xf32>, vector<4xf32>
+}
+
+// CHECK-LABEL: func @swizzle_unroll_load
+//  CHECK-SAME:   %[[SRC:[A-Za-z0-9]+]]: memref<?xf32>
+//   CHECK-DAG:   %[[SWOFF0:.+]] = arith.constant 60 : index
+//   CHECK-DAG:   %[[SWOFF1:.+]] = arith.constant 68 : index
+//   CHECK-DAG:   %[[V0:.+]] = vector.load %[[SRC]][%[[SWOFF0]]]
+//   CHECK-DAG:   %[[V1:.+]] = vector.load %[[SRC]][%[[SWOFF1]]]
+//       CHECK:   return %[[V0]], %[[V1]]
+
+// -----
+
+func.func @swizzle_unroll_store(%dst: memref<?xf32>, %src0: vector<4xf32>, %src1: vector<4xf32>) {
+  %0 = iree_codegen.swizzle_hint %dst[#iree_codegen.rotate_rows<64, 4>] : memref<?xf32>
+  %offset = arith.constant 60 : index
+  %cst = arith.constant dense<0.0> : vector<8xf32>
+  %1 = vector.insert_strided_slice %src0, %cst {offsets = [0], strides = [1]} : vector<4xf32> into vector<8xf32>
+  %2 = vector.insert_strided_slice %src1, %1 {offsets = [4], strides = [1]} : vector<4xf32> into vector<8xf32>
+  vector.store %2, %0[%offset] : memref<?xf32>, vector<8xf32>
+  return
+}
+
+// CHECK-LABEL: func @swizzle_unroll_store
+//  CHECK-SAME:   %[[DST:[A-Za-z0-9]+]]: memref<?xf32>
+//  CHECK-SAME:   %[[SRC0:[A-Za-z0-9]+]]: vector<4xf32>
+//  CHECK-SAME:   %[[SRC1:[A-Za-z0-9]+]]: vector<4xf32>
+//   CHECK-DAG:   %[[SWOFF0:.+]] = arith.constant 60 : index
+//   CHECK-DAG:   %[[SWOFF1:.+]] = arith.constant 68 : index
+//   CHECK-DAG:   vector.store %[[SRC0]], %[[DST]][%[[SWOFF0]]]
+//   CHECK-DAG:   vector.store %[[SRC1]], %[[DST]][%[[SWOFF1]]]
+
+// -----
+
+func.func @swizzle_dynamic(%src: memref<?xf32>, %vec: vector<4xf32>, %offset: index) -> vector<4xf32> {
+  %0 = iree_codegen.swizzle_hint %src[#iree_codegen.rotate_rows<64, 4>] : memref<?xf32>
+  %1 = vector.load %0[%offset] : memref<?xf32>, vector<4xf32>
+  vector.store %vec, %0[%offset] : memref<?xf32>, vector<4xf32>
+  return %1: vector<4xf32>
+}
+
+// CHECK-LABEL: func @swizzle_dynamic
+//  CHECK-SAME:   %[[SRC:[A-Za-z0-9]+]]: memref<?xf32>
+//  CHECK-SAME:   %[[VEC:[A-Za-z0-9]+]]: vector<4xf32>
+//  CHECK-SAME:   %[[OFFSET:[A-Za-z0-9]+]]: index
+//   CHECK-DAG:   %[[ROW_WIDTH:.+]] = arith.constant 64 : index
+//   CHECK-DAG:   %[[GROUP_COUNT:.+]] = arith.constant 16 : index
+//   CHECK-DAG:   %[[GROUP_WIDTH:.+]] = arith.constant 4 : index
+//       CHECK:   %[[I:.+]] = arith.divui %[[OFFSET]], %[[ROW_WIDTH]] : index
+//       CHECK:   %[[JELEM:.+]] = arith.remui %[[OFFSET]], %[[ROW_WIDTH]] : index
+//       CHECK:   %[[J:.+]] = arith.divui %[[JELEM]], %[[GROUP_WIDTH]] : index
+//       CHECK:   %[[ADD:.+]] = arith.addi %[[I]], %[[J]] : index
+//       CHECK:   %[[ROTATEJ:.+]] = arith.remui %[[ADD]], %[[GROUP_COUNT]] : index
+//       CHECK:   %[[ROTATEJELEM:.+]] = arith.muli %[[ROTATEJ]], %[[GROUP_WIDTH]] : index
+//       CHECK:   %[[IELEM:.+]] = arith.muli %[[I]], %[[ROW_WIDTH]] : index
+//       CHECK:   %[[SWOFF:.+]] = arith.addi %[[ROTATEJELEM]], %[[IELEM]] : index
+
+// Make sure both the load and store get the same calculation.
+//       CHECK:   %[[VECTOR:.+]] = vector.load %[[SRC]][%[[SWOFF]]]
+//       CHECK:   vector.store %[[VEC]], %[[SRC]][%[[SWOFF]]]
+//       CHECK:   return %[[VECTOR]]
+
+// -----
+
+func.func @swizzle_adjust_affine_offset(%src: memref<?xf32>, %vec: vector<4xf32>, %offset_base: index) -> vector<4xf32> {
+  %0 = iree_codegen.swizzle_hint %src[#iree_codegen.rotate_rows<64, 4>] : memref<?xf32>
+  %load_offset = affine.apply affine_map<()[s0] -> (16 + s0)>()[%offset_base]
+  %1 = vector.load %0[%load_offset] : memref<?xf32>, vector<4xf32>
+  %store_offset = affine.apply affine_map<()[s0] -> (1040 + s0)>()[%offset_base]
+  vector.store %vec, %0[%store_offset] : memref<?xf32>, vector<4xf32>
+  return %1: vector<4xf32>
+}
+
+// CHECK-LABEL: func @swizzle_adjust_affine_offset
+//  CHECK-SAME:   %[[SRC:[A-Za-z0-9]+]]: memref<?xf32>
+//  CHECK-SAME:   %[[VEC:[A-Za-z0-9]+]]: vector<4xf32>
+//  CHECK-SAME:   %[[OFFSET:[A-Za-z0-9]+]]: index
+//   CHECK-DAG:   %[[ROW_WIDTH:.+]] = arith.constant 64 : index
+//   CHECK-DAG:   %[[GROUP_COUNT:.+]] = arith.constant 16 : index
+//   CHECK-DAG:   %[[GROUP_WIDTH:.+]] = arith.constant 4 : index
+//       CHECK:   %[[APPLY_BASE:.+]] = affine.apply affine_map<()[s0] -> (s0 + 16)>()[%[[OFFSET]]]
+//       CHECK:   %[[I:.+]] = arith.divui %[[APPLY_BASE]], %[[ROW_WIDTH]] : index
+//       CHECK:   %[[JELEM:.+]] = arith.remui %[[APPLY_BASE]], %[[ROW_WIDTH]] : index
+//       CHECK:   %[[J:.+]] = arith.divui %[[JELEM]], %[[GROUP_WIDTH]] : index
+//       CHECK:   %[[ADD:.+]] = arith.addi %[[I]], %[[J]] : index
+//       CHECK:   %[[ROTATEJ:.+]] = arith.remui %[[ADD]], %[[GROUP_COUNT]] : index
+//       CHECK:   %[[ROTATEJELEM:.+]] = arith.muli %[[ROTATEJ]], %[[GROUP_WIDTH]] : index
+//       CHECK:   %[[IELEM:.+]] = arith.muli %[[I]], %[[ROW_WIDTH]] : index
+//       CHECK:   %[[SWOFF:.+]] = arith.addi %[[ROTATEJELEM]], %[[IELEM]] : index
+
+//       CHECK:   %[[VECTOR:.+]] = vector.load %[[SRC]][%[[SWOFF]]]
+
+//       CHECK:   %[[STORE_BASE:.+]] = affine.apply affine_map<()[s0] -> (s0 + 1040)>()[%[[OFFSET]]]
+//       CHECK:   %[[OFFSET_DIFF:.+]] = arith.subi %[[SWOFF]], %[[APPLY_BASE]] : index
+//       CHECK:   %[[STORE_SWOFF:.+]] = arith.addi %[[STORE_BASE]], %[[OFFSET_DIFF]] : index
+//       CHECK:   vector.store %[[VEC]], %[[SRC]][%[[STORE_SWOFF]]]
+//       CHECK:   return %[[VECTOR]]

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/BUILD.bazel
@@ -91,6 +91,7 @@ iree_compiler_cc_library(
         ":UKernelOpsGen",
         "//compiler/src/iree/compiler/Codegen/Interfaces:UKernelOpInterface",
         "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:ArithUtils",
         "@llvm-project//mlir:BufferizationDialect",

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/CMakeLists.txt
@@ -52,6 +52,7 @@ iree_cc_library(
     ::LoweringConfigInterfaceGen
     ::UKernelOpsGen
     LLVMSupport
+    MLIRAffineDialect
     MLIRArithDialect
     MLIRArithUtils
     MLIRBufferizationDialect

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -434,4 +434,52 @@ def IREECodegen_EncodingNopLayoutAttr  :
   }];
 }
 
+//===---------------------------------------------------------------------===//
+// iree_codegen.rotate_rows
+//===---------------------------------------------------------------------===//
+
+def IREECodegen_RotateRowsAttr  :
+    AttrDef<IREECodegen_Dialect, "RotateRows", [
+    DeclareAttrInterfaceMethods<IREECodegen_SwizzleAttrInterface, [
+        "swizzleOffset",
+        "getAccessElementCount"
+      ]>
+    ]> {
+  let mnemonic = "rotate_rows";
+  let summary = "An attribute that describes a swizzling pattern for rotating rows.";
+  let description = [{
+    This attribute rotates accesses of |access_width| within rows of size
+    |row_width|. For any given access into logical memref of shape
+    `memref<...xNx|access_width|x!eltype>` where `N = row_width / access_width`
+    at position `(i, j, 0)` is rotated to `(i, (i + j) % N, 0)`. For example,
+
+    ```
+    row_width = 16, access_width = 4
+
+    0000 1111 2222 3333 /// 0 1 2 3
+    4444 5555 6666 7777 /// 0 1 2 3
+    8888 9999 AAAA BBBB /// 0 1 2 3
+    CCCC DDDD EEEE FFFF /// 0 1 2 3
+    ```
+
+    is swizzled to
+    ```
+    0000 1111 2222 3333 /// 0 1 2 3
+    7777 4444 5555 6666 /// 3 0 1 2
+    BBBB AAAA 8888 9999 /// 2 3 0 1
+    FFFF EEEE DDDD CCCC /// 1 2 3 0
+    ```
+
+    The pattern repeats for subsequent rows.
+  }];
+  let parameters = (ins
+    AttrParameter<"int64_t", "">:$row_width,
+    AttrParameter<"int64_t", "">:$access_width
+  );
+  let assemblyFormat = [{
+    `<` $row_width `,` $access_width `>`
+  }];
+  let genVerifyDecl = 1;
+}
+
 #endif // IREE_COMPILER_CODEGEN_DIALECT_IREECODEGENATTRS

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td
@@ -169,4 +169,52 @@ def IREECodegen_LayoutAttrInterface :
   ];
 }
 
+def IREECodegen_SwizzleAttrInterface :
+  AttrInterface<"SwizzleAttrInterface"> {
+  let cppNamespace = "::mlir::iree_compiler::IREE::Codegen";
+  let description = [{
+    An interface that describes 1D memref swizzling patterns.
+  }];
+
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/[{
+        Swizzles |offset| into memref |src|.
+      }],
+      /*retTy=*/"::mlir::OpFoldResult",
+      /*methodName=*/"swizzleOffset",
+      /*args=*/(ins "::mlir::OpBuilder&":$b,
+                    "::mlir::Location":$loc,
+                    "::mlir::OpFoldResult":$offset,
+                    "::mlir::Value":$src),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return offset;
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns the number of elements that remain contiguous with the swizzling
+        pattern. This unrolls all accesses to this element count.
+
+        Currently swizzling is only supported if all accesses are multiples of
+        this value.
+
+        TODO: Support non-width aligned swizzling.
+      }],
+      /*retTy=*/"int64_t",
+      /*methodName=*/"getAccessElementCount",
+      /*args=*/(ins)
+    >
+  ];
+}
+
+def IREECodegen_AnySwizzleAttr : Attr<Or<[
+  CPred<"isa<IREE::Codegen::SwizzleAttrInterface>($_self)">,
+]>, "swizzling descriptor attributes"> {
+  let storageType = [{ IREE::Codegen::SwizzleAttrInterface }];
+  let returnType = [{ IREE::Codegen::SwizzleAttrInterface }];
+  let convertFromStorage = "$_self";
+}
+
 #endif // IREE_COMPILER_CODEGEN_DIALECT_CODEGEN_IREECODEGENINTERFACES

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h
@@ -7,6 +7,7 @@
 #ifndef IREE_COMPILER_CODEGEN_DIALECT_IREECODEGENOPS_H_
 #define IREE_COMPILER_CODEGEN_DIALECT_IREECODEGENOPS_H_
 
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.h"
 #include "mlir/Bytecode/BytecodeOpInterface.h"
 #include "mlir/IR/Builders.h"

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
@@ -8,6 +8,7 @@
 #define IREE_CODEGEN_DIALECT_IREECODEGENOPS
 
 include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.td"
+include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td"
 include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.td"
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/OpBase.td"
@@ -101,6 +102,59 @@ def IREECodegen_ExtractStridedMetadataOp : Op<IREECodegen_Dialect, "extract_stri
     ::mlir::Value getViewSource() { return getSource(); }
   }];
 }
+
+//===----------------------------------------------------------------------===//
+// SwizzleHintOp
+//===----------------------------------------------------------------------===//
+
+def IREECodegen_SwizzleHintOp : Op<IREECodegen_Dialect, "swizzle_hint", [
+    SameOperandsAndResultType, Pure]> {
+  let summary = "Hint to swizzle accesses according to an access pattern";
+  let description = [{
+    Optimization hint to swizzle all accesses to the memref this takes a view
+    of. This only affects reads/writes immediately consuming this operation and
+    is best effort. If the desired swizzling is not apparently possible, this
+    op will no-op. As a result, it should not be relied on for correctness.
+
+    Note that this only rewrites direct users. If there are any aliased loads
+    or stores of the data from/to the |src| memref of a hintOp, those accesses
+    will not be swizzled. This allows reusing an allocation with different
+    swizzled access patterns as long as there is no data dependency between
+    memory with different layouts. For example:
+
+    ```
+    %0 = alloc()
+    %1 = iree_codegen.swizzle_hint %0, #layout_0
+    %2 = iree_codegen.swizzle_hint %0, #layout_1
+    {
+       vector.store %1
+       vector.load %1
+         ^
+         |
+        unrelated
+         |
+         v
+       vector.store %2
+       vector.load %2
+    }
+    ```
+
+    If there is a dependency between the accesses of %1 and %2, this is
+    undefined behavior.
+  }];
+
+  let arguments = (ins MemRefRankOf<[AnyType], [1]>:$operand,
+                       IREECodegen_AnySwizzleAttr:$swizzle);
+  let results = (outs MemRefRankOf<[AnyType], [1]>:$result);
+
+  let assemblyFormat = [{
+    $operand `[` $swizzle attr-dict `]` `:` type($result)
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// NullPointerOp
+//===----------------------------------------------------------------------===//
 
 def IREECodegen_NullPointerOp :
      Op<IREECodegen_Dialect, "null_pointer", [Pure]> {

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
@@ -115,6 +115,10 @@ def IREECodegen_SwizzleHintOp : Op<IREECodegen_Dialect, "swizzle_hint", [
     of. This only affects reads/writes immediately consuming this operation and
     is best effort. If the desired swizzling is not apparently possible, this
     op will no-op. As a result, it should not be relied on for correctness.
+    
+    Any subviews on this operation will cause swizzling to fail. The expectation
+    is for all view like operations to fold into the accessing ops
+    (loads/stores) before this op takes effect.
 
     Note that this only rewrites direct users. If there are any aliased loads
     or stores of the data from/to the |src| memref of a hintOp, those accesses
@@ -139,8 +143,9 @@ def IREECodegen_SwizzleHintOp : Op<IREECodegen_Dialect, "swizzle_hint", [
     }
     ```
 
-    If there is a dependency between the accesses of %1 and %2, this is
-    undefined behavior.
+    If there is a data dependency between the accesses of %1 and %2, for example
+    a value stored to %1 is loaded from %2, this is undefined behavior. Aliasing
+    is otherwise perfectly legal.
   }];
 
   let arguments = (ins MemRefRankOf<[AnyType], [1]>:$operand,

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
@@ -115,7 +115,7 @@ def IREECodegen_SwizzleHintOp : Op<IREECodegen_Dialect, "swizzle_hint", [
     of. This only affects reads/writes immediately consuming this operation and
     is best effort. If the desired swizzling is not apparently possible, this
     op will no-op. As a result, it should not be relied on for correctness.
-    
+
     Any subviews on this operation will cause swizzling to fail. The expectation
     is for all view like operations to fold into the accessing ops
     (loads/stores) before this op takes effect.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1098,7 +1098,10 @@ static void addLowerToLLVMGPUPasses(OpPassManager &modulePassManager,
   FunctionLikeNest funcPassManager(modulePassManager);
   funcPassManager.addPass(createFoldTensorExtractOpPass)
       .addPass(createLLVMGPUVectorLoweringPass)
-      .addPass(createExpandGPUOpsPass);
+      .addPass(createExpandGPUOpsPass)
+      .addPass(createResolveSwizzleHintsPass)
+      .addPass(createCanonicalizerPass)
+      .addPass(createCSEPass);
 
   // This pass needs to run before SCF -> CF.
   addLowerAndOptimizeAddressComputationPasses(funcPassManager);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1040,6 +1040,12 @@ addLowerAndOptimizeAddressComputationPasses(FunctionLikeNest &funcPassManager) {
       // full complexity.
       .addPass(createVectorTransferLoweringPass)
       .addPass(memref::createFoldMemRefAliasOpsPass)
+      // Resolve swizzling hints before lowering affine ops but after
+      // lowering vector (transfer) ops.
+      .addPass(createResolveSwizzleHintsPass)
+      // Canonicalize and CSE to attempt to deduplicate swizzle computation.
+      .addPass(createCanonicalizerPass)
+      .addPass(createCSEPass)
       .addPass(createIREEExpandStridedMetadataPass)
       .addPass(createPropagateDispatchSizeBoundsPass)
       // Hoist loop invariant variables to give affine decomposition pass the
@@ -1098,10 +1104,7 @@ static void addLowerToLLVMGPUPasses(OpPassManager &modulePassManager,
   FunctionLikeNest funcPassManager(modulePassManager);
   funcPassManager.addPass(createFoldTensorExtractOpPass)
       .addPass(createLLVMGPUVectorLoweringPass)
-      .addPass(createExpandGPUOpsPass)
-      .addPass(createResolveSwizzleHintsPass)
-      .addPass(createCanonicalizerPass)
-      .addPass(createCSEPass);
+      .addPass(createExpandGPUOpsPass);
 
   // This pass needs to run before SCF -> CF.
   addLowerAndOptimizeAddressComputationPasses(funcPassManager);


### PR DESCRIPTION
This patch introduces `iree_codegen.swizzle_hint` op which enables swizzling accesses to a 1-d memref for better access patterns that are difficult to represent at a higher level. The use case today is for rotating accesses to shared memory to avoid bank conflicts.

This is designed as a generic op that takes an attribute interface to make it easier to implement new swizzling strategies in the future for new/different hardware and/or codegen strategies. Also by operating like a view, this op still works with other transformations like packing/reusing shared memory.