### PR TITLE
[DispatchCreation] Hoist leaf expand_shapes out before collapsing dimensions

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/CollapseDimensions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/CollapseDimensions.cpp
@@ -622,9 +622,9 @@ findRootOp(IREE::Flow::DispatchRegionOp regionOp) {
 // Reshape Hoisting
 //===---------------------------------------------------------------------===//
 
-/// Hoist `tensor.collapse_shape` ops at the beginning of the `dispatchOp`
-/// and `tensor.expand_shape` ops at the end of the `dispatchOp`, out of the
-/// dispatch.
+/// Hoist `tensor.collapse_shape` and `tensor.expand_shape` ops at the beginning
+/// of the `dispatchOp` and `tensor.expand_shape` ops at the end of the
+/// `dispatchOp`, out of the dispatch.
 static FailureOr<IREE::Flow::DispatchRegionOp>
 hoistTensorReshapesOutOfDispatchRegion(
     RewriterBase &rewriter, IREE::Flow::DispatchRegionOp dispatchOp) {
@@ -641,26 +641,27 @@ hoistTensorReshapesOutOfDispatchRegion(
   SetVector<Operation *> slice;
   getBackwardSlice(returnOp, &slice, sliceOptions);
 
-  // 2. Get the leaf operations that are tensor.collapse_shape ops.
-  SmallVector<tensor::CollapseShapeOp> leafs;
+  // 2. Get the leaf operations that are `tensor.collapse_shape` and
+  // `tensor_expand_shape` ops.
+  SmallVector<Operation *> reshapeLeafs;
   for (Operation *op : slice) {
-    auto collapseShapeOp = dyn_cast<tensor::CollapseShapeOp>(op);
-    if (!collapseShapeOp) {
+    if (!isa<tensor::CollapseShapeOp, tensor::ExpandShapeOp>(op)) {
       continue;
     }
     if (llvm::all_of(op->getOperands(), [&](Value operand) {
           Operation *definingOp = operand.getDefiningOp();
           return !definingOp || slice.count(definingOp) == 0;
         })) {
-      leafs.push_back(collapseShapeOp);
+      reshapeLeafs.push_back(op);
     }
   }
 
-  // 3. Clone the leaf `tensor.collapse_shape` ops outside the dispatch.
+  // 3. Clone the leaf `tensor.collapse_shape` and `tensor_expand_shape`  ops
+  // outside the dispatch.
   OpBuilder::InsertionGuard g(rewriter);
   rewriter.setInsertionPoint(dispatchOp);
-  for (auto reshapeOp : leafs) {
-    Operation *clonedOp = rewriter.clone(*reshapeOp.getOperation());
+  for (auto reshapeOp : reshapeLeafs) {
+    Operation *clonedOp = rewriter.clone(*reshapeOp);
     rewriter.replaceOp(reshapeOp, clonedOp->getResults());
   }
 
@@ -1017,8 +1018,16 @@ void CollapseDimensionsPass::runOnOperation() {
 
   SmallVector<IREE::Flow::DispatchRegionOp> modifiedDispatchOps;
   funcOp->walk([&](IREE::Flow::DispatchRegionOp dispatchOp) {
-    if (collapseDimensionsForDispatch(rewriter, dispatchOp, maxIterations)) {
-      modifiedDispatchOps.push_back(dispatchOp);
+    FailureOr<IREE::Flow::DispatchRegionOp> newDispatchOp =
+        hoistTensorReshapesOutOfDispatchRegion(
+            rewriter, cast<IREE::Flow::DispatchRegionOp>(dispatchOp));
+    if (failed(newDispatchOp)) {
+      dispatchOp->emitOpError("failed to hoist reshapes out of dispatch");
+      return signalPassFailure();
+    }
+    if (collapseDimensionsForDispatch(rewriter, newDispatchOp.value(),
+                                      maxIterations)) {
+      modifiedDispatchOps.push_back(newDispatchOp.value());
     }
   });
 

--- a/compiler/src/iree/compiler/DispatchCreation/CollapseDimensions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/CollapseDimensions.cpp
@@ -1022,6 +1022,7 @@ void CollapseDimensionsPass::runOnOperation() {
         hoistTensorReshapesOutOfDispatchRegion(
             rewriter, cast<IREE::Flow::DispatchRegionOp>(dispatchOp));
     if (failed(newDispatchOp)) {
+      dispatchOp->emitOpError("failed to hoist reshapes out of dispatch");
       return WalkResult::interrupt();
     }
     if (collapseDimensionsForDispatch(rewriter, newDispatchOp.value(),

--- a/compiler/src/iree/compiler/DispatchCreation/test/collapse_dimensions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/collapse_dimensions.mlir
@@ -588,7 +588,9 @@ util.func public @collapse_attention_with_truncf(%arg0: tensor<20x4096x16xf32>, 
 //       CHECK:   flow.return %[[TRUNC]] : tensor<20x4096x64xf16>
 
 // -----
-
+// The expand_shape within the dispatch.region is hoisted out as
+// its a leaf node i.e the defining op of the source operand
+// is outside the dispatch.region.
 util.func public @collapse(%10: tensor<64x32x1280xi8>, %11 : tensor<10240x1280xi8>, %12 : tensor<10240xi32>, %13 : tensor<10240xf32>) -> (tensor<2x32x32x10240xf16>) {
   %c0_i32 = arith.constant 0 : i32
   %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/DispatchCreation/test/collapse_dimensions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/collapse_dimensions.mlir
@@ -589,14 +589,15 @@ util.func public @collapse_attention_with_truncf(%arg0: tensor<20x4096x16xf32>, 
 
 // -----
 
-util.func public @collapse(%10: tensor<2x32x32x1280xi8>, %11 : tensor<10240x1280xi8>, %12 : tensor<10240xi32>, %13 : tensor<10240xf32>) -> (tensor<2x32x32x10240xf16>) {
+util.func public @collapse(%10: tensor<64x32x1280xi8>, %11 : tensor<10240x1280xi8>, %12 : tensor<10240xi32>, %13 : tensor<10240xf32>) -> (tensor<2x32x32x10240xf16>) {
   %c0_i32 = arith.constant 0 : i32
   %c0 = arith.constant 0 : index
   %14 = tensor.empty() : tensor<2x32x32x10240xf16>
   %15 = tensor.empty() : tensor<2x32x32x10240xi32>
   %16 = linalg.fill ins(%c0_i32 : i32) outs(%15 : tensor<2x32x32x10240xi32>) -> tensor<2x32x32x10240xi32>
   %dispatch = flow.dispatch.region -> (tensor<2x32x32x10240xf16>) {
-    %17 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d4)>, affine_map<(d0, d1, d2, d3, d4) -> (d3, d4)>, affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]} ins(%10, %11 : tensor<2x32x32x1280xi8>, tensor<10240x1280xi8>) outs(%16 : tensor<2x32x32x10240xi32>) {
+    %expand = tensor.expand_shape %10 [[0, 1], [2], [3]] output_shape [2, 32, 32, 1280] : tensor<64x32x1280xi8> into tensor<2x32x32x1280xi8>
+    %17 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d4)>, affine_map<(d0, d1, d2, d3, d4) -> (d3, d4)>, affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction"]} ins(%expand, %11 : tensor<2x32x32x1280xi8>, tensor<10240x1280xi8>) outs(%16 : tensor<2x32x32x10240xi32>) {
     ^bb0(%in: i8, %in_0: i8, %out: i32):
       %19 = arith.extsi %in : i8 to i32
       %20 = arith.extsi %in_0 : i8 to i32

--- a/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(iree-dispatch-creation-fold-unit-extent-dims, iree-dispatch-creation-pipeline)" --split-input-file --mlir-print-local-scope %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline="builtin.module(iree-preprocessing-attr-based-pipeline, iree-dispatch-creation-fold-unit-extent-dims, iree-dispatch-creation-pipeline)" --split-input-file --mlir-print-local-scope %s | FileCheck %s
 
 #map = affine_map<(d0, d1) -> (d0)>
 #map1 = affine_map<(d0, d1) -> (d1)>
@@ -297,3 +297,32 @@ util.func public @unset_encoding_op(%arg0 : tensor<?x?xf32, #encoding>, %d0: ind
 // CHECK-SAME:    %[[D1:[a-zA-Z0-9]+]]
 // CHECK:         %[[RES:.+]] = flow.tensor.encode %[[SRC]] : tensor<?x?xf32, #iree_encoding.testing_encoding<>>{%[[D0]], %[[D1]]} -> tensor<?x?xf32>{%[[D0]], %[[D1]]}
 // CHECK:         util.return %[[RES]]
+
+
+// -----
+
+// Check that we are able to collapse in presence of unit dims in the make single dispatch pipeline
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d1 + d5, d2 + d6, d3)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d0)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>
+util.func public @make_single_dispatch(%arg0: tensor<16x8x32x2048xbf16>, %arg1: tensor<16x8x32x4096xbf16>) -> tensor<4096x1x1x2048xf32>
+ attributes {preprocessing_pipeline = #util.preprocessing_pipeline<"iree-preprocessing-make-single-dispatch">} {
+    %cst = arith.constant 0.000000e+00 : f32
+    %2 = tensor.empty() : tensor<4096x1x1x2048xf32>
+    %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<4096x1x1x2048xf32>) -> tensor<4096x1x1x2048xf32>
+    %4 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<16x8x32x2048xbf16>, tensor<16x8x32x4096xbf16>) outs(%3 : tensor<4096x1x1x2048xf32>) {
+    ^bb0(%in: bf16, %in_0: bf16, %out: f32):
+      %9 = arith.extf %in : bf16 to f32
+      %10 = arith.extf %in_0 : bf16 to f32
+      %11 = arith.mulf %9, %10 : f32
+      %12 = arith.addf %out, %11 : f32
+      linalg.yield %12 : f32
+    } -> tensor<4096x1x1x2048xf32>
+    util.return %4 : tensor<4096x1x1x2048xf32>
+  }
+
+// CHECK-LABEL: util.func public @make_single_dispatch
+//       CHECK: linalg.generic
+//  CHECK-SAME: ins(%{{.*}}, %{{.*}} : tensor<4096x2048xbf16>, tensor<4096x4096xbf16>)
+//  CHECK-SAME: outs(%{{.*}} :  tensor<4096x2048xf32>)


### PR DESCRIPTION
This allows for collapsing dimensions that would otherwise be blocked.