### PR TITLE
[LinalgExt] Clone iree_linalg_ext.gather (5/5)

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -45,12 +45,6 @@ static llvm::cl::opt<int> clInlineConstantByteLength(
                    "into a dispatch region or 0 to disable inlining."),
     llvm::cl::init(256));
 
-// TODO(#18457, #18447): Remove once backends support gather fusion.
-static llvm::cl::opt<bool>
-    clEnableGatherFusion("iree-flow-enable-gather-fusion",
-                         llvm::cl::desc("Fuse gather-like ops with consumer."),
-                         llvm::cl::init(false));
-
 namespace mlir::iree_compiler::IREE::Flow {
 
 //===----------------------------------------------------------------------===//
@@ -861,9 +855,7 @@ bool isClonableIntoDispatchOp(Operation *op,
   if (LinalgExt::isBitExtendOp(op)) {
     return true;
   }
-  if (clEnableGatherFusion && LinalgExt::isGatherlikeOp(op)) {
-    return true;
-  }
+
   // If the operation is used for masking an AttentionOp, then we always
   // clone it. The Attention mask is usually big, and is always generated
   // from a small tensor, so it's always good to clone it.

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -877,6 +877,10 @@ bool isClonableIntoDispatchOp(Operation *op,
     return true;
   }
 
+  if (isa<IREE::LinalgExt::GatherOp>(op)) {
+    return true;
+  }
+
   if (isa<arith::ConstantOp>(op) || isa<complex::ConstantOp>(op)) {
     if (clInlineConstantByteLength == 0)
       return false;

--- a/compiler/src/iree/compiler/DispatchCreation/CloneProducersIntoDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/CloneProducersIntoDispatchRegions.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h"
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree/compiler/DispatchCreation/Passes.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/IR/Iterators.h"
@@ -46,7 +47,7 @@ struct CloneProducersIntoDispatchRegionsPass final
 
     funcOp->walk([&](Operation *op) {
       if (!IREE::Flow::isNonNullAndOutsideDispatch(op) ||
-          !isa<linalg::GenericOp>(op)) {
+          !isa<linalg::GenericOp, IREE::LinalgExt::GatherOp>(op)) {
         return;
       }
       if (failed(IREE::Flow::wrapOpInDispatchRegion(rewriter, op))) {

--- a/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/FormDispatchRegions.cpp
@@ -174,7 +174,7 @@ static bool isRootOp(Operation *op) {
     return !isa<linalg::FillOp>(op);
   }
   if (isa<TilingInterface>(op)) {
-    return !isa<tensor::PadOp, linalg::PackOp>(op);
+    return !isa<IREE::LinalgExt::GatherOp, tensor::PadOp, linalg::PackOp>(op);
   }
   return isa<linalg::UnPackOp>(op);
 }

--- a/compiler/src/iree/compiler/DispatchCreation/test/clone_producers_into_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/clone_producers_into_dispatch_regions.mlir
@@ -793,10 +793,7 @@ util.func @clone_gather_elementwise(%source : tensor<2x2x2048xi32>,
     %empty = tensor.empty() : tensor<2048xi32>
     %result = iree_linalg_ext.gather dimension_map = [0, 1]
                             ins(%source, %indices : tensor<2x2x2048xi32>, tensor<2xi32>)
-                            outs(%empty: tensor<2048xi32>) {
-                      ^bb0(%arg0: i32, %arg1: i32):
-                        iree_linalg_ext.yield %arg0 : i32
-    } -> tensor<2048xi32>
+                            outs(%empty: tensor<2048xi32>) -> tensor<2048xi32>
     %generic = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%result : tensor<2048xi32>) outs(%empty: tensor<2048xi32>) {
       ^bb0(%arg0: i32, %arg1: i32):
         %0 = arith.muli %arg0, %cst : i32

--- a/compiler/src/iree/compiler/DispatchCreation/test/clone_producers_into_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/clone_producers_into_dispatch_regions.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --iree-flow-enable-gather-fusion --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-clone-producers-into-dispatch-regions{aggressive=true}))" %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-clone-producers-into-dispatch-regions{aggressive=true}))" %s | FileCheck %s
 
 util.func public @complex_element_type(%input: tensor<4xi32>, %table: tensor<8x2xcomplex<f32>>) -> tensor<4x2xcomplex<f32>> {
   %c4095 = arith.constant 4095 : i32
@@ -364,54 +364,6 @@ util.func public @dont_clone_index_type_op_2(%arg0: i64) -> tensor<?xf32> {
 
 // -----
 
-util.func public @clone_bit_ext_of_gather_like(%arg0: tensor<128256x4096xf16>, %arg1: tensor<4x?xi64>, %arg2: tensor<4096xf32>) -> tensor<4x?xf32> {
-  %c1 = arith.constant 1 : index
-  %cst = arith.constant 0.000000e+00 : f32
-  %cst_0 = arith.constant 1.000000e-01 : f32
-  %dim = tensor.dim %arg1, %c1 : tensor<4x?xi64>
-  %0 = tensor.empty(%dim) : tensor<4x?x4096xf16>
-  %1 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg1 : tensor<4x?xi64>) outs(%0 : tensor<4x?x4096xf16>) {
-  ^bb0(%in: i64, %out: f16):
-    %7 = arith.index_cast %in : i64 to index
-    %8 = linalg.index 2 : index
-    %extracted = tensor.extract %arg0[%7, %8] : tensor<128256x4096xf16>
-    linalg.yield %extracted : f16
-  } -> tensor<4x?x4096xf16>
-  %2 = tensor.empty(%dim) : tensor<4x?x4096xf32>
-  %3 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%1 : tensor<4x?x4096xf16>) outs(%2 : tensor<4x?x4096xf32>) {
-  ^bb0(%in: f16, %out: f32):
-    %7 = arith.extf %in : f16 to f32
-    linalg.yield %7 : f32
-  } -> tensor<4x?x4096xf32>
-  %4 = tensor.empty(%dim) : tensor<4x?xf32>
-  %5 = linalg.fill ins(%cst : f32) outs(%4 : tensor<4x?xf32>) -> tensor<4x?xf32>
-  %6 = flow.dispatch.region -> (tensor<4x?xf32>{%dim}) {
-    %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%3 : tensor<4x?x4096xf32>) outs(%5 : tensor<4x?xf32>) {
-    ^bb0(%in: f32, %out: f32):
-      %8 = math.powf %in, %cst_0 : f32
-      %9 = arith.addf %8, %out : f32
-      linalg.yield %9 : f32
-    } -> tensor<4x?xf32>
-    flow.return %7 : tensor<4x?xf32>
-  }
-  util.return %6 : tensor<4x?xf32>
-}
-
-// CHECK-LABEL:  util.func public @clone_bit_ext_of_gather_like
-//       CHECK:    %[[DISPATCH:.+]] = flow.dispatch.region
-//       CHECK:      %[[GATHER0:.+]] = linalg.generic
-//       CHECK:        %[[EXTRACT:.+]] = tensor.extract
-//       CHECK:        linalg.yield %[[EXTRACT]]
-//       CHECK:      %[[EXT:.+]] = linalg.generic
-//  CHECK-SAME:        ins(%[[GATHER0]] : tensor<4x?x4096xf16>)
-//       CHECK:        %[[EXTF:.+]] = arith.extf
-//       CHECK:        linalg.yield %[[EXTF]]
-//       CHECK:      %[[RES:.+]] = linalg.generic
-//  CHECK-SAME:        ins(%[[EXT]] : tensor<4x?x4096xf32>)
-//       CHECK:      flow.return %[[RES]]
-
-// -----
-
 util.func public @attention_clone_mask(%arg0: tensor<?x?xf16>,
     %arg1: tensor<?x?xf16>, %arg2: tensor<?x?xf16>) -> tensor<?x?xf16> {
   %c0 = arith.constant 0 : index
@@ -538,82 +490,6 @@ util.func public @clone_scatter_indices(%arg0: tensor<1x?x32x8x128xf8E4M3FNUZ>, 
 //  CHECK-SAME:       ins(%[[GEN1]], %[[GEN2]]#1
 //       CHECK:     flow.return %[[SCATTER]] : tensor<?x32x8x128xbf16>
 //       CHECK:   util.return %[[DISPATCH1]], %[[DISPATCH0]]
-
-// -----
-
-// Fuse rope computation only with query and not key/value
-util.func @attention_rope_fusion(%arg0: tensor<10x20x30x50xbf16>,
-    %arg1: tensor<10x20x40x50xbf16>, %arg2: tensor<10x20x40x50xbf16>,
-    %cst : bf16) -> tensor<10x20x30x40xbf16> {
-  %query_empty = tensor.empty() : tensor<10x20x30x50xbf16>
-  %query = linalg.generic {
-      indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
-      iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
-      outs(%query_empty : tensor<10x20x30x50xbf16>) {
-    ^bb0(%b0: bf16) :
-      %idx0 = linalg.index 0 : index
-      %idx1 = linalg.index 1 : index
-      %idx2 = linalg.index 2 : index
-      %idx3 = linalg.index 3 : index
-      %val = tensor.extract %arg0[%idx0, %idx1, %idx2, %idx3] : tensor<10x20x30x50xbf16>
-      linalg.yield %val : bf16
-  } -> tensor<10x20x30x50xbf16>
-  %key_empty = tensor.empty() : tensor<10x20x40x50xbf16>
-  %key = linalg.generic {
-      indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
-      iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
-      outs(%key_empty : tensor<10x20x40x50xbf16>) {
-    ^bb0(%b0: bf16) :
-      %idx0 = linalg.index 0 : index
-      %idx1 = linalg.index 1 : index
-      %idx2 = linalg.index 2 : index
-      %idx3 = linalg.index 3 : index
-      %val = tensor.extract %arg1[%idx0, %idx1, %idx2, %idx3] : tensor<10x20x40x50xbf16>
-      linalg.yield %val : bf16
-  } -> tensor<10x20x40x50xbf16>
-  %value_empty = tensor.empty() : tensor<10x20x40x50xbf16>
-  %value = linalg.generic {
-      indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
-      iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
-      outs(%value_empty : tensor<10x20x40x50xbf16>) {
-    ^bb0(%b0: bf16) :
-      %idx0 = linalg.index 0 : index
-      %idx1 = linalg.index 1 : index
-      %idx2 = linalg.index 2 : index
-      %idx3 = linalg.index 3 : index
-      %val = tensor.extract %arg2[%idx0, %idx1, %idx2, %idx3] : tensor<10x20x40x50xbf16>
-      linalg.yield %val : bf16
-  } -> tensor<10x20x40x50xbf16>
-  %empty = tensor.empty() : tensor<10x20x30x40xbf16>
-  %dispatch = flow.dispatch.region -> (tensor<10x20x30x40xbf16>) {
-    %attention = iree_linalg_ext.attention {
-        indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d4)>,
-                         affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d3, d4)>,
-                         affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d3, d4)>,
-                         affine_map<(d0, d1, d2, d3, d4, d5, d6) -> ()>,
-                         affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>]}
-        ins(%query, %key, %value, %cst
-            : tensor<10x20x30x50xbf16>, tensor<10x20x40x50xbf16>, tensor<10x20x40x50xbf16>, bf16)
-        outs(%empty : tensor<10x20x30x40xbf16>) {
-      ^bb0(%arg6: f32):
-        iree_linalg_ext.yield %arg6 : f32
-    } -> tensor<10x20x30x40xbf16>
-    flow.return %attention : tensor<10x20x30x40xbf16>
-  }
-  util.return %dispatch : tensor<10x20x30x40xbf16>
-}
-// CHECK-LABEL: func public @attention_rope_fusion
-//  CHECK-SAME:     %[[ARG0:.+]]: tensor<10x20x30x50xbf16>
-//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<10x20x40x50xbf16>
-//  CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<10x20x40x50xbf16>
-//       CHECK:   %[[DISPATCHK:.+]] = flow.dispatch.region
-//       CHECK:   %[[DISPATCHV:.+]] = flow.dispatch.region
-//       CHECK:   %[[DISPATCH:.+]] = flow.dispatch.region
-//       CHECK:     %[[Q:.+]] = linalg.generic
-//       CHECK:     %[[ATTENTION:.+]] = iree_linalg_ext.attention
-//  CHECK-SAME:         ins(%[[Q]], %[[DISPATCHK]], %[[DISPATCHV]]
-//       CHECK:     flow.return %[[ATTENTION]]
-//       CHECK:   util.return %[[DISPATCH]]
 
 // -----
 

--- a/compiler/src/iree/compiler/DispatchCreation/test/clone_producers_into_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/clone_producers_into_dispatch_regions.mlir
@@ -664,12 +664,12 @@ util.func @never_clone_insert_slice_ops(%arg0 : tensor<?xi32>, %arg1 : tensor<?x
 
 util.func @clone_gather_elementwise(%source : tensor<2x2x2048xi32>,
                                    %indices : tensor<2xi32>) -> tensor<2048xi32> {
+  %empty = tensor.empty() : tensor<2048xi32>
+  %result = iree_linalg_ext.gather dimension_map = [0, 1]
+                          ins(%source, %indices : tensor<2x2x2048xi32>, tensor<2xi32>)
+                          outs(%empty: tensor<2048xi32>) -> tensor<2048xi32>
   %dispatch = flow.dispatch.region -> (tensor<2048xi32>) {
     %cst = arith.constant 2 : i32
-    %empty = tensor.empty() : tensor<2048xi32>
-    %result = iree_linalg_ext.gather dimension_map = [0, 1]
-                            ins(%source, %indices : tensor<2x2x2048xi32>, tensor<2xi32>)
-                            outs(%empty: tensor<2048xi32>) -> tensor<2048xi32>
     %generic = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%result : tensor<2048xi32>) outs(%empty: tensor<2048xi32>) {
       ^bb0(%arg0: i32, %arg1: i32):
         %0 = arith.muli %arg0, %cst : i32

--- a/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests.mlir
@@ -329,10 +329,7 @@ util.func public @gather_matmul(%source : tensor<2x2x100x100xi32>, %indices : te
   %empty = tensor.empty() : tensor<100x100xi32>
   %result = iree_linalg_ext.gather dimension_map = [1, 0]
                           ins(%source, %indices : tensor<2x2x100x100xi32>, tensor<2xi32>)
-                          outs(%empty: tensor<100x100xi32>) {
-                    ^bb0(%arg0: i32, %arg1: i32):
-                      iree_linalg_ext.yield %arg0 : i32
-  } -> tensor<100x100xi32>
+                          outs(%empty: tensor<100x100xi32>) -> tensor<100x100xi32>
   %mm = linalg.matmul_transpose_b ins(%result, %arg2 : tensor<100x100xi32>, tensor<100x100xi32>) outs(%arg3 : tensor<100x100xi32>) -> tensor<100x100xi32>
   util.return %mm : tensor<100x100xi32>
 }
@@ -341,24 +338,21 @@ util.func public @gather_matmul(%source : tensor<2x2x100x100xi32>, %indices : te
 //       CHECK:     %[[GATHER:.+]] = iree_linalg_ext.gather
 //       CHECK:     %[[MATMUL:.+]] = linalg.matmul_transpose_b
 //  CHECK-SAME:       ins(%[[GATHER]]
-//       CHECK:     flow.dispatch.tensor.store %[[MATMUL]]
+//       CHECK:     iree_tensor_ext.dispatch.tensor.store %[[MATMUL]]
 //       CHECK:   util.return %[[DISPATCH]]
 
 // -----
 
-util.func public @gather_matmul(%source : tensor<2x2x100x100xi32>, %indices : tensor<2xi32>, %arg2 : tensor<100x100xi32>, %arg3 : tensor<100x100xi32>) -> tensor<100x100xi32> {
+util.func public @single_gather(%source : tensor<2x2x100x100xi32>, %indices : tensor<2xi32>, %arg2 : tensor<100x100xi32>, %arg3 : tensor<100x100xi32>) -> tensor<100x100xi32> {
   %empty = tensor.empty() : tensor<100x100xi32>
   %result = iree_linalg_ext.gather dimension_map = [1, 0]
                           ins(%source, %indices : tensor<2x2x100x100xi32>, tensor<2xi32>)
-                          outs(%empty: tensor<100x100xi32>) {
-                    ^bb0(%arg0: i32, %arg1: i32):
-                      iree_linalg_ext.yield %arg0 : i32
-  } -> tensor<100x100xi32>
+                          outs(%empty: tensor<100x100xi32>) -> tensor<100x100xi32>
   util.return %result : tensor<100x100xi32>
 }
 // Make sure single gather gets wrapped in dispatch.
-// CHECK-LABEL: util.func public @gather_matmul
+// CHECK-LABEL: util.func public @single_gather
 //       CHECK:   %[[DISPATCH:.+]] = flow.dispatch.workgroups
 //       CHECK:     %[[GATHER:.+]] = iree_linalg_ext.gather
-//       CHECK:     flow.dispatch.tensor.store %[[GATHER]]
+//       CHECK:     iree_tensor_ext.dispatch.tensor.store %[[GATHER]]
 //       CHECK:   util.return %[[DISPATCH]]

--- a/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests.mlir
@@ -295,7 +295,6 @@ util.func public @unset_encoding_op(%arg0 : tensor<?x?xf32, #encoding>, %d0: ind
 // CHECK:         %[[RES:.+]] = flow.tensor.encode %[[SRC]] : tensor<?x?xf32, #iree_encoding.testing_encoding<>>{%[[D0]], %[[D1]]} -> tensor<?x?xf32>{%[[D0]], %[[D1]]}
 // CHECK:         util.return %[[RES]]
 
-
 // -----
 
 // Check that we are able to collapse in presence of unit dims in the make single dispatch pipeline
@@ -323,3 +322,43 @@ util.func public @make_single_dispatch(%arg0: tensor<16x8x32x2048xbf16>, %arg1: 
 //       CHECK: linalg.generic
 //  CHECK-SAME: ins(%{{.*}}, %{{.*}} : tensor<4096x2048xbf16>, tensor<4096x4096xbf16>)
 //  CHECK-SAME: outs(%{{.*}} :  tensor<4096x2048xf32>)
+
+// -----
+
+util.func public @gather_matmul(%source : tensor<2x2x100x100xi32>, %indices : tensor<2xi32>, %arg2 : tensor<100x100xi32>, %arg3 : tensor<100x100xi32>) -> tensor<100x100xi32> {
+  %empty = tensor.empty() : tensor<100x100xi32>
+  %result = iree_linalg_ext.gather dimension_map = [1, 0]
+                          ins(%source, %indices : tensor<2x2x100x100xi32>, tensor<2xi32>)
+                          outs(%empty: tensor<100x100xi32>) {
+                    ^bb0(%arg0: i32, %arg1: i32):
+                      iree_linalg_ext.yield %arg0 : i32
+  } -> tensor<100x100xi32>
+  %mm = linalg.matmul_transpose_b ins(%result, %arg2 : tensor<100x100xi32>, tensor<100x100xi32>) outs(%arg3 : tensor<100x100xi32>) -> tensor<100x100xi32>
+  util.return %mm : tensor<100x100xi32>
+}
+// CHECK-LABEL: util.func public @gather_matmul
+//       CHECK:   %[[DISPATCH:.+]] = flow.dispatch.workgroups
+//       CHECK:     %[[GATHER:.+]] = iree_linalg_ext.gather
+//       CHECK:     %[[MATMUL:.+]] = linalg.matmul_transpose_b
+//  CHECK-SAME:       ins(%[[GATHER]]
+//       CHECK:     flow.dispatch.tensor.store %[[MATMUL]]
+//       CHECK:   util.return %[[DISPATCH]]
+
+// -----
+
+util.func public @gather_matmul(%source : tensor<2x2x100x100xi32>, %indices : tensor<2xi32>, %arg2 : tensor<100x100xi32>, %arg3 : tensor<100x100xi32>) -> tensor<100x100xi32> {
+  %empty = tensor.empty() : tensor<100x100xi32>
+  %result = iree_linalg_ext.gather dimension_map = [1, 0]
+                          ins(%source, %indices : tensor<2x2x100x100xi32>, tensor<2xi32>)
+                          outs(%empty: tensor<100x100xi32>) {
+                    ^bb0(%arg0: i32, %arg1: i32):
+                      iree_linalg_ext.yield %arg0 : i32
+  } -> tensor<100x100xi32>
+  util.return %result : tensor<100x100xi32>
+}
+// Make sure single gather gets wrapped in dispatch.
+// CHECK-LABEL: util.func public @gather_matmul
+//       CHECK:   %[[DISPATCH:.+]] = flow.dispatch.workgroups
+//       CHECK:     %[[GATHER:.+]] = iree_linalg_ext.gather
+//       CHECK:     flow.dispatch.tensor.store %[[GATHER]]
+//       CHECK:   util.return %[[DISPATCH]]

--- a/tests/e2e/linalg_ext_ops/gather.mlir
+++ b/tests/e2e/linalg_ext_ops/gather.mlir
@@ -62,10 +62,7 @@ func.func @gather_fuse_elementwise() {
   %indices = util.unfoldable_constant dense<[1]> : tensor<1xi32>
   %result = iree_linalg_ext.gather dimension_map = [0]
                           ins(%source, %indices : tensor<2x2xi32>, tensor<1xi32>)
-                          outs(%empty: tensor<2xi32>) {
-                    ^bb0(%arg0: i32, %arg1: i32):
-                      iree_linalg_ext.yield %arg0 : i32
-  } -> tensor<2xi32>
+                          outs(%empty: tensor<2xi32>) -> tensor<2xi32>
   %generic = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%result : tensor<2xi32>) outs(%empty: tensor<2xi32>) {
     ^bb0(%arg0: i32, %arg1: i32):
       %0 = arith.muli %arg0, %cst : i32

--- a/tests/e2e/linalg_ext_ops/gather.mlir
+++ b/tests/e2e/linalg_ext_ops/gather.mlir
@@ -54,3 +54,23 @@ func.func @gather_perm_map() {
   check.expect_eq_const(%result, dense<[2]> : tensor<1xi32>) : tensor<1xi32>
   return
 }
+
+func.func @gather_fuse_elementwise() {
+  %cst = arith.constant 2 : i32
+  %source = util.unfoldable_constant dense<[[0, 1], [2, 3]]> : tensor<2x2xi32>
+  %empty = tensor.empty() : tensor<2xi32>
+  %indices = util.unfoldable_constant dense<[1]> : tensor<1xi32>
+  %result = iree_linalg_ext.gather dimension_map = [0]
+                          ins(%source, %indices : tensor<2x2xi32>, tensor<1xi32>)
+                          outs(%empty: tensor<2xi32>) {
+                    ^bb0(%arg0: i32, %arg1: i32):
+                      iree_linalg_ext.yield %arg0 : i32
+  } -> tensor<2xi32>
+  %generic = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%result : tensor<2xi32>) outs(%empty: tensor<2xi32>) {
+    ^bb0(%arg0: i32, %arg1: i32):
+      %0 = arith.muli %arg0, %cst : i32
+      linalg.yield %0 : i32
+  } -> tensor<2xi32>
+  check.expect_eq_const(%generic, dense<[4, 6]> : tensor<2xi32>) : tensor<2xi32>
+  return
+}


### PR DESCRIPTION
Adds support to clone `iree_linalg_ext.gather` ops into dispatches.