### PR TITLE
Fix IREE_FILE_IO_ENABLE check

### DIFF
--- a/runtime/src/iree/modules/hal/debugging.c
+++ b/runtime/src/iree/modules/hal/debugging.c
@@ -16,7 +16,7 @@ iree_hal_module_debug_sink_null(void) {
   return sink;
 }
 
-#if defined(IREE_FILE_IO_ENABLE)
+#if IREE_FILE_IO_ENABLE
 
 #if IREE_HAL_MODULE_STRING_UTIL_ENABLE
 static iree_status_t iree_hal_module_buffer_view_trace_stdio(

--- a/runtime/src/iree/modules/hal/debugging.h
+++ b/runtime/src/iree/modules/hal/debugging.h
@@ -53,7 +53,7 @@ typedef struct iree_hal_module_debug_sink_t {
 IREE_API_EXPORT iree_hal_module_debug_sink_t
 iree_hal_module_debug_sink_null(void);
 
-#if defined(IREE_FILE_IO_ENABLE)
+#if IREE_FILE_IO_ENABLE
 
 // Returns a default debug sink that routes to an stdio stream in textual form.
 IREE_API_EXPORT iree_hal_module_debug_sink_t


### PR DESCRIPTION
According to https://iree.dev/guides/deployment-configurations/bare-metal/#define-iree-macros, users should define `IREE_FILE_IO_ENABLE=0	` to disable file io.