### PR TITLE
BlockDynamicDimensions: Fold remaining reshapes with bindings

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BlockDynamicDimensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BlockDynamicDimensions.cpp
@@ -389,6 +389,9 @@ void BlockDynamicDimensionsPass::runOnOperation() {
                                                        context);
     tensor::CollapseShapeOp::getCanonicalizationPatterns(
         removeBarrierOpsPatterns, context);
+    // Add patterns to fold the remaining reshape operation with their interface
+    // bindings or `tensor.empty` operations.
+    populateReshapeToInterfaceTensorPatterns(removeBarrierOpsPatterns);
     tensor::populateFoldTensorEmptyPatterns(removeBarrierOpsPatterns);
     linalg::FillOp::getCanonicalizationPatterns(removeBarrierOpsPatterns,
                                                 context);


### PR DESCRIPTION
Adds pattern to the end of `BlockDynamicDimensions` to folds any leftover reshapes with `flow.dispatch.tensor.load` ops. This can occur when values are "blocked" but there user does not have projected permutation indexing maps.



Resolves compilation failure on https://github.com/nod-ai/shark-ai/pull/1254 ([failing dispatch](https://gist.github.com/IanWood1/0f2aa19865112828ffca9c9418d7d8c5)). I don't think this actually resolves the root of the problem with the dispatch (invalid IR generated during bufferization), but this seems like a good pattern to have anyways.