### PR TITLE
Integrate llvm/llvm-project@f0a59c4

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx942.mlir
@@ -630,11 +630,9 @@ hal.executable public @pad_batch_matmul {
 // CHECK-SAME:        memref<196x16x24xf32
 // CHECK-SAME:        vector<1x1x1xf32>
 // RHS
-// The dynamic dimension should be removed after:
-// https://github.com/llvm/llvm-project/pull/112236
 // CHECK:             vector.transfer_read
-// CHECK-SAME:        in_bounds = [true, false, false]
-// CHECK-SAME:        memref<1x?x24xf32
+// CHECK-SAME:        in_bounds = [true, true, false]
+// CHECK-SAME:        memref<1x8x24xf32
 // CHECK-SAME:        vector<1x1x2xf32>
 // CHECK:           scf.yield
 // OUTPUT

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_im2col.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_im2col.mlir
@@ -265,7 +265,7 @@ module {
 //       CHECK: %[[T2:.+]] = tensor.pad %[[T1]]
 //  CHECK-NEXT: ^bb0
 //  CHECK-NEXT:   tensor.yield
-//  CHECK-NEXT: } : tensor<1x?x?x?xf32> to tensor<1x1x1x1xf32>
+//  CHECK-NEXT: } : tensor<1x1x?x?xf32> to tensor<1x1x1x1xf32>
 
 // -----
 


### PR DESCRIPTION
Changes to LIT test is coming in from landing
https://github.com/llvm/llvm-project/commit/23020a8d01a3f58e4903c42eba4b803d5809653e which seem to improve/get better static information from TensorTilingInterface when there is no padding.

This patch carries revert of
llvm/llvm-project#121389. Torch-MLIR needs to be
updated with that PR's change for us to be able to integrate.