### PR TITLE
[Codegen] Add option to expand subview metadata

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEExpandStridedMetadata.cpp
@@ -266,8 +266,12 @@ struct IREEExpandStridedMetadataPass final
 } // namespace
 
 void populateIREEResolveExtractStridedMetadataPatterns(
-    RewritePatternSet &patterns) {
-  memref::populateResolveExtractStridedMetadataPatterns(patterns);
+    RewritePatternSet &patterns, bool allowSubviewExpansion) {
+  if (allowSubviewExpansion) {
+    memref::populateExpandStridedMetadataPatterns(patterns);
+  } else {
+    memref::populateResolveExtractStridedMetadataPatterns(patterns);
+  }
   amdgpu::populateAmdgpuResolveStridedMetadataPatterns(patterns);
   patterns.insert<ResolveExtractMetadataFromHalInterfaceBindingSubspan>(
       patterns.getContext());
@@ -278,7 +282,8 @@ void populateIREEResolveExtractStridedMetadataPatterns(
 void IREEExpandStridedMetadataPass::runOnOperation() {
   MLIRContext *context = &getContext();
   RewritePatternSet patterns(context);
-  populateIREEResolveExtractStridedMetadataPatterns(patterns);
+  populateIREEResolveExtractStridedMetadataPatterns(patterns,
+                                                    allowSubviewExpansion);
   populateRemoveDeadMemAllocPatterns(patterns);
   if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
     return signalPassFailure();

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -421,6 +421,8 @@ def IREEExpandStridedMetadataPass :
     Pass<"iree-codegen-expand-strided-metadata", ""> {
   let summary = "Resolve memref.extract_strided_metadata operations";
   let options = [
+    Option<"allowSubviewExpansion", "allow-subview-expansion", "bool", /*default=*/"false",
+           "Enables expansion of memref.subview ops">,
     Option<"allowUnresolved", "allow-unresolved", "bool", /*default=*/"false",
            "Allow unresolved strided metadata op (for testing)">,
   ];

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.h
@@ -84,7 +84,7 @@ void populateTileAndDistributeToWorkgroupsCleanupPatterns(
 /// Populate IREE patterns related to resolving
 /// `memref.extract_strided_metadata`.
 void populateIREEResolveExtractStridedMetadataPatterns(
-    RewritePatternSet &patterns);
+    RewritePatternSet &patterns, bool allowSubviewExpansion = false);
 
 /// Populate patterns that replaces maximumf/minimumf with minumf/maxnumf ops.
 /// This is supposed to be used for targets which have faulty codegen

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -58,6 +58,7 @@ iree_lit_test_suite(
             "hoist_statically_bound_allocations.mlir",
             "hoist_unrolled_vector_extract_insert_slice.mlir",
             "iree_comprehensive_bufferize.mlir",
+            "iree_expand_strided_metadata_with_subview_expansion.mlir",
             "iree_expand_strided_metadata.mlir",
             "iree_loop_invariant_code_motion.mlir",
             "link_tuning_specs.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -55,6 +55,7 @@ iree_lit_test_suite(
     "hoist_unrolled_vector_extract_insert_slice.mlir"
     "iree_comprehensive_bufferize.mlir"
     "iree_expand_strided_metadata.mlir"
+    "iree_expand_strided_metadata_with_subview_expansion.mlir"
     "iree_loop_invariant_code_motion.mlir"
     "link_tuning_specs.mlir"
     "llvmcpu_materialize_encoding.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/iree_expand_strided_metadata_with_subview_expansion.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/iree_expand_strided_metadata_with_subview_expansion.mlir
@@ -1,0 +1,22 @@
+// RUN: iree-opt %s --iree-codegen-expand-strided-metadata="allow-subview-expansion=true" --split-input-file | FileCheck %s
+
+#pipeline_layout = #hal.pipeline.layout<constants = 1, bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @expand_subview_into_resource_cast(%offset: index) -> memref<256x4096xf16, strided<[4096, 1]>, #amdgpu.address_space<fat_raw_buffer>> {
+  %c4096_i14 = arith.constant 4096 : i14
+  %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
+  %1 = arith.index_castui %0 : i32 to index
+  %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%1) flags(ReadOnly)
+    : memref<4096x4096xf16, #gpu.address_space<global>>
+  %subview = memref.subview %2[%offset, 0] [256, 4096] [1, 1]
+    : memref<4096x4096xf16, #gpu.address_space<global>> to memref<256x4096xf16, strided<[4096, 1], offset: ?>, #gpu.address_space<global>>
+  %38 = amdgpu.fat_raw_buffer_cast %subview cacheSwizzleStride(%c4096_i14) resetOffset
+    : memref<256x4096xf16, strided<[4096, 1], offset: ?>, #gpu.address_space<global>> to memref<256x4096xf16, strided<[4096, 1]>, #amdgpu.address_space<fat_raw_buffer>>
+  return %38 : memref<256x4096xf16, strided<[4096, 1]>, #amdgpu.address_space<fat_raw_buffer>>
+}
+
+// CHECK-LABEL: func.func @expand_subview_into_resource_cast
+//       CHECK:   %[[SUBSPAN:.+]] = hal.interface.binding.subspan
+//       CHECK:   %[[REINTERPRET:.+]] = memref.reinterpret_cast %[[SUBSPAN]]
+//       CHECK:   amdgpu.fat_raw_buffer_cast %[[REINTERPRET]]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1128,7 +1128,7 @@ static void addLowerToLLVMGPUPasses(OpPassManager &modulePassManager,
       .addPass(createMathTransformPass)
       .addPass(memref::createExpandOpsPass)
       .addPass(memref::createFoldMemRefAliasOpsPass)
-      .addPass([&]() {
+      .addPass([]() {
         IREEExpandStridedMetadataPassOptions options;
         options.allowSubviewExpansion = true;
         return createIREEExpandStridedMetadataPass(options);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1128,7 +1128,11 @@ static void addLowerToLLVMGPUPasses(OpPassManager &modulePassManager,
       .addPass(createMathTransformPass)
       .addPass(memref::createExpandOpsPass)
       .addPass(memref::createFoldMemRefAliasOpsPass)
-      .addPass(createIREEExpandStridedMetadataPass)
+      .addPass([&]() {
+        IREEExpandStridedMetadataPassOptions options;
+        options.allowSubviewExpansion = true;
+        return createIREEExpandStridedMetadataPass(options);
+      })
       .addPass(createEmulateNarrowTypePass)
       .addPass(affine::createAffineExpandIndexOpsPass)
       .addPass(createLowerAffinePass);


### PR DESCRIPTION
Excluding the metadata expansion patterns is based on the assumption that all view like operations should fold into their producers. In practice this isn't always possible around operations that generate fat pointers under the hood (e.g. amdgpu.fat_raw_buffer_cast). This adds an option to IREEExpandStridedMetadata that enables expansion so that we only expand at the last moment when we need to.