### PR TITLE
[CPU][NFC] Refresh debugging log with LDBG.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUPeel.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUPeel.cpp
@@ -17,6 +17,7 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "iree-llvmcpu-peel"
+#define LDBG(X) LLVM_DEBUG(llvm::dbgs() << X << "\n")
 
 namespace mlir::iree_compiler {
 
@@ -46,7 +47,7 @@ void collectLoopsToPeel(Operation *op,
     if (!loop || iree_compiler::isTiledAndDistributedLoop(loop))
       break;
 
-    LLVM_DEBUG(llvm::dbgs() << "Loop to peel:\n" << *op << "\n");
+    LDBG("Loop to peel\n  " << *op);
     loopsToPeel.insert(loop);
   }
 }
@@ -67,13 +68,12 @@ void LLVMCPUPeelPass::runOnOperation() {
   llvm::SmallSetVector<scf::ForOp, 8> uniqueLoopsToPeel;
   funcOp.walk([&](Operation *op) {
     if (isa<linalg::LinalgOp, linalg::PackOp>(op)) {
-      LLVM_DEBUG(llvm::dbgs() << "Gather loops to peel from candidate op:\n"
-                              << *op << "\n");
+      LDBG("Gather loops to peel from candidate op\n  " << *op);
       collectLoopsToPeel(op, uniqueLoopsToPeel);
     }
   });
 
-  LLVM_DEBUG(llvm::dbgs() << "Peeling loops\n");
+  LDBG("Peeling loops");
   // Visiting the loops in outer-to-inner order will prevent loops nested in
   // partial iterations to be peeled again.
   SmallVector<scf::ForOp, 8> outerToInnerLoopsToPeel(uniqueLoopsToPeel.rbegin(),
@@ -81,7 +81,7 @@ void LLVMCPUPeelPass::runOnOperation() {
   IRRewriter rewriter(context);
   linalg::peelLoops(rewriter, outerToInnerLoopsToPeel);
 
-  LLVM_DEBUG(llvm::dbgs() << "Canonicalizing loops\n");
+  LDBG("Canonicalizing loops");
   RewritePatternSet patterns(context);
   linalg::populateLinalgTilingCanonicalizationPatterns(patterns);
   scf::populateSCFForLoopCanonicalizationPatterns(patterns);
@@ -89,7 +89,7 @@ void LLVMCPUPeelPass::runOnOperation() {
   context->getLoadedDialect<tensor::TensorDialect>()
       ->getCanonicalizationPatterns(patterns);
   if (failed(applyPatternsGreedily(funcOp, std::move(patterns)))) {
-    LLVM_DEBUG(llvm::dbgs() << "----- cleanup failed -----\n");
+    LDBG("----- cleanup failed -----");
     return signalPassFailure();
   }
 }


### PR DESCRIPTION
The revision refactors the debugging print with a new LDBG macro, which logs the print with a new line at the end. It also uses llvm::interleaved and llvm::interleaved_array for KernelDispatch.