### PR TITLE
[AMDGPU] Optimize masked transfer read in presence of fat raw buffers

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD.bazel
@@ -108,6 +108,7 @@ iree_compiler_cc_library(
         "LLVMGPUVectorToGPU.cpp",
         "Passes.cpp",
         "ROCDLAnnotateKernelForTranslation.cpp",
+        "ROCDLBufferInstructionsOptimization.cpp",
         "ROCDLConfigureBufferInstructions.cpp",
         "ROCDLKernelConfig.cpp",
         "ROCDLLowerExecutableTarget.cpp",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -93,6 +93,7 @@ iree_cc_library(
     "LLVMGPUVectorToGPU.cpp"
     "Passes.cpp"
     "ROCDLAnnotateKernelForTranslation.cpp"
+    "ROCDLBufferInstructionsOptimization.cpp"
     "ROCDLConfigureBufferInstructions.cpp"
     "ROCDLKernelConfig.cpp"
     "ROCDLLowerExecutableTarget.cpp"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -345,6 +345,8 @@ static void addGPUBufferizePasses(OpPassManager &funcPassManager) {
       createIREEComprehensiveBufferizePass(allocationFn, memcpyFn));
   addIREEPostBufferizationPasses(funcPassManager);
 
+  funcPassManager.addPass(createROCDLBufferInstructionsOptimizationPass());
+
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLBufferInstructionsOptimization.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLBufferInstructionsOptimization.cpp
@@ -49,7 +49,7 @@ struct SimplifyMaskVectorTransferRead final
 
   LogicalResult matchAndRewrite(vector::CreateMaskOp maskOp,
                                 PatternRewriter &rewriter) const override {
-    auto loc = maskOp.getLoc();
+    Location loc = maskOp.getLoc();
     auto readOp = dyn_cast<vector::TransferReadOp>(
         *(maskOp.getResult().getUsers().begin()));
     if (!readOp) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLBufferInstructionsOptimization.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLBufferInstructionsOptimization.cpp
@@ -20,10 +20,10 @@ namespace mlir::iree_compiler {
 
 namespace {
 
-Value createi1And(Location loc, ArrayRef<Value> values, OpBuilder &builder) {
+Value createI1And(Location loc, ArrayRef<Value> values, OpBuilder &builder) {
   Value base =
       builder.create<arith::IndexCastUIOp>(loc, builder.getI1Type(), values[0]);
-  for (auto value : values.drop_front()) {
+  for (Value value : values.drop_front()) {
     Value rhs =
         builder.create<arith::IndexCastUIOp>(loc, builder.getI1Type(), value);
     base = builder.create<arith::AndIOp>(loc, base, rhs);
@@ -106,7 +106,7 @@ struct SimplifyMaskVectorTransferRead final
     if (ValuesToAnd.empty()) {
       return rewriter.notifyMatchFailure(maskOp, "trivial mask not supported");
     }
-    Value selectValue = createi1And(loc, ValuesToAnd, rewriter);
+    Value selectValue = createI1And(loc, ValuesToAnd, rewriter);
     auto constantValue = rewriter.create<vector::SplatOp>(
         loc, readOp.getVectorType(), readOp.getPadding());
 
@@ -126,7 +126,6 @@ struct ROCDLBufferInstructionsOptimizationPass final
     : impl::ROCDLBufferInstructionsOptimizationPassBase<
           ROCDLBufferInstructionsOptimizationPass> {
   void runOnOperation() override {
-
     RewritePatternSet patterns(&getContext());
     patterns.add<SimplifyMaskVectorTransferRead>(&getContext());
     walkAndApplyPatterns(getOperation(), std::move(patterns));

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLBufferInstructionsOptimization.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLBufferInstructionsOptimization.cpp
@@ -1,0 +1,131 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/LLVMGPU/Passes.h"
+#include "iree/compiler/Codegen/Utils/GPUUtils.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
+#include "llvm/Support/Debug.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#define DEBUG_TYPE "iree-codegen-rocdl-buffer-instructions-optimization"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_ROCDLBUFFERINSTRUCTIONSOPTIMIZATIONPASS
+#include "iree/compiler/Codegen/LLVMGPU/ROCDLPasses.h.inc"
+
+namespace {
+
+Value createi1And(Location loc, ArrayRef<Value> values, OpBuilder &builder) {
+  Value base =
+      builder.create<arith::IndexCastUIOp>(loc, builder.getI1Type(), values[0]);
+  for (auto value : values.drop_front()) {
+    Value rhs =
+        builder.create<arith::IndexCastUIOp>(loc, builder.getI1Type(), value);
+    base = builder.create<arith::AndIOp>(loc, base, rhs);
+  }
+  return base;
+}
+// Determine if the mask vector is all ones or all zeros and if so, then replace
+// the masked transferReadOp with transferReadOp with no mask for when the mask
+// is all ones and the padding values when the mask is all zeros. The pattern
+// thus does the following optimization.
+// clang-format off
+// mask = vector.create_mask %0, ..., %n, %c8 : vector<1x ... x1x8xi1>
+// %read = vector.transfer_read %memref, %mask : memref<..., amdgpu.raw_fat_buffer>
+// becomes
+// %padding = arith.constant dense<0> : vector<1x ... x1x8xbf16>
+// %read = vector.transfer_read %memref : memref<..., amdgpu.raw_fat_buffer> // no mask!
+// %masked_read
+//   = arith.select %0 && ... && %n ? %read : %padding : index,vector<1x ... x1x8xbf16>
+// clang-format on
+class SimplifyMaskVectorTransferRead
+    : public OpRewritePattern<vector::CreateMaskOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(vector::CreateMaskOp maskOp,
+                                PatternRewriter &rewriter) const override {
+    auto loc = maskOp.getLoc();
+    auto readOp = dyn_cast<vector::TransferReadOp>(
+        *(maskOp.getResult().getUsers().begin()));
+    if (!readOp) {
+      return failure();
+    }
+
+    auto sourceType = dyn_cast<MemRefType>(readOp.getSource().getType());
+    if (!sourceType) {
+      return failure();
+    }
+    // This optimization only works on fat raw buffers.
+    if (!hasAMDGPUFatRawBufferAddressSpace(sourceType)) {
+      return failure();
+    }
+
+    SmallVector<bool> inBounds = readOp.getInBoundsValues();
+    if (inBounds.size() != sourceType.getRank()) {
+      return failure();
+    }
+
+    SmallVector<Value> maskIndices = maskOp.getOperands();
+    ArrayRef<int64_t> maskShape = maskOp.getResult().getType().getShape();
+    SmallVector<Value> ValuesToAnd;
+    for (auto [idx, i] : llvm::enumerate(maskIndices)) {
+      auto constantValue = getConstantIndex(i);
+      // We only support the pattern for reads that are in-bounds.
+      if (inBounds[idx] != true) {
+        return failure();
+      }
+      if (constantValue) {
+        // We bail-out if we can statically determine that a mask dim is not
+        // full.
+        if (maskShape[idx] != constantValue) {
+          return failure();
+        }
+      } else {
+        // The non-constant dimensions are only allowed to be unit to ensure
+        // an all ones or an all zeros mask.
+        if (maskShape[idx] != 1) {
+          return failure();
+        }
+        ValuesToAnd.push_back(i);
+      }
+    }
+    // There are no non-constant unit dimensions which means this is
+    // a always one mask, such masks should be folded by vector
+    // canonicalizations so we dont handle it.
+    if (ValuesToAnd.size() == 0) {
+      return failure();
+    }
+    auto selectValue = createi1And(loc, ValuesToAnd, rewriter);
+    auto constantValue = rewriter.create<vector::SplatOp>(
+        loc, readOp.getVectorType(), readOp.getPadding());
+
+    auto newReadOp = rewriter.create<vector::TransferReadOp>(
+        loc, readOp.getVectorType(), readOp.getSource(), readOp.getIndices(),
+        readOp.getPadding(), ArrayRef<bool>{inBounds});
+    rewriter.replaceOpWithNewOp<arith::SelectOp>(readOp, selectValue, newReadOp,
+                                                 constantValue);
+
+    return success();
+  }
+};
+
+struct ROCDLBufferInstructionsOptimizationPass final
+    : impl::ROCDLBufferInstructionsOptimizationPassBase<
+          ROCDLBufferInstructionsOptimizationPass> {
+  void runOnOperation() override {
+    FunctionOpInterface funcOp = getOperation();
+
+    RewritePatternSet patterns(funcOp.getContext());
+    patterns.add<SimplifyMaskVectorTransferRead>(funcOp.getContext());
+    (void)applyPatternsGreedily(funcOp, std::move(patterns));
+  }
+};
+
+} // namespace
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLPasses.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ROCDLPasses.td
@@ -19,6 +19,17 @@ def ROCDLAnnotateKernelForTranslationPass : Pass<
   let dependentDialects = ["ROCDL::ROCDLDialect"];
 }
 
+def ROCDLBufferInstructionsOptimizationPass :
+    InterfacePass<"iree-rocdl-buffer-instructions-optimization", "mlir::FunctionOpInterface"> {
+  let summary = "Optimizations possible with buffer fat pointers";
+  let description = [{
+    Buffer fat pointers support out of bound access so we can make use of this
+    feature for optimizations.
+
+    This pass is a no-op on non-ROCDL targets.
+  }];
+}
+
 def ROCDLConfigureBufferInstructionsPass :
     InterfacePass<"iree-rocdl-configure-buffer-instructions", "mlir::FunctionOpInterface"> {
   let summary = "Determine which subspans can be implemneted with buffer fat pointers";

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/PrefetchSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/PrefetchSharedMemoryCopy.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
 
 #include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
 #include "llvm/ADT/APInt.h"
@@ -33,18 +34,6 @@
 namespace mlir::iree_compiler {
 
 namespace {
-
-/// Returns the underlying index if the given value is a constant index.
-std::optional<int64_t> getConstantIndex(Value value) {
-  if (!isa<IndexType>(value.getType()))
-    return std::nullopt;
-
-  APInt val;
-  if (!matchPattern(value, m_ConstantInt(&val)))
-    return std::nullopt;
-
-  return val.getSExtValue();
-}
 
 class LoopPrefetcher {
 public:

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/BUILD.bazel
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     srcs = enforce_glob(
         [
             "annotate_kernel_for_translation.mlir",
+            "buffer_instructions_optimization.mlir",
             "config_igemm_tile_and_fuse.mlir",
             "config_tile_and_fuse.mlir",
             "config_vector_distribute_gfx1100.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "annotate_kernel_for_translation.mlir"
+    "buffer_instructions_optimization.mlir"
     "config_igemm_tile_and_fuse.mlir"
     "config_tile_and_fuse.mlir"
     "config_user_vector_distribute.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/buffer_instructions_optimization.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/buffer_instructions_optimization.mlir
@@ -1,0 +1,181 @@
+// RUN: iree-opt --split-input-file --iree-gpu-test-target=gfx942 \
+// RUN: --pass-pipeline="builtin.module(func.func(iree-rocdl-buffer-instructions-optimization))" %s \
+// RUN:  | FileCheck %s
+
+func.func @simplify_mask(%1 : memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, %index1 : index, %index2 : index) -> vector<1x1x1x8xbf16> {
+  %c0 = arith.constant 0 : index
+  %c8 = arith.constant 8 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 1.000000e+00 : bf16
+  %mask = vector.create_mask %c1, %index1, %index2, %c8 : vector<1x1x1x8xi1>
+  %read = vector.transfer_read %1[%c0, %c0, %c0, %c0], %cst, %mask {in_bounds = [true, true, true, true]} : memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, vector<1x1x1x8xbf16>
+  return %read : vector<1x1x1x8xbf16>
+}
+
+// CHECK-LABEL: @simplify_mask
+//  CHECK-SAME:   (%[[ARG0:.+]]: memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index)
+//   CHECK-DAG: %[[CST:.+]] = arith.constant dense<1.000000e+00> : vector<1x1x1x8xbf16>
+//       CHECK: %[[LHS:.+]] = arith.index_castui %[[ARG1]] : index to i1
+//       CHECK: %[[RHS:.+]] = arith.index_castui %[[ARG2]] : index to i1
+//       CHECK: %[[AND:.+]] = arith.andi %[[LHS]], %[[RHS]] : i1
+//       CHECK: %[[READ:.+]] = vector.transfer_read %[[ARG0]]
+//       CHECK: %[[SEL:.+]] = arith.select %[[AND]], %[[READ]], %[[CST]] : vector<1x1x1x8xbf16>
+//       CHECK: return %[[SEL]] : vector<1x1x1x8xbf16>
+
+// -----
+
+func.func @simplify_mask2(%1 : memref<?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, %index1 : index) -> vector<1x8xbf16> {
+  %c0 = arith.constant 0 : index
+  %c8 = arith.constant 8 : index
+  %cst = arith.constant 1.000000e+00 : bf16
+  %mask = vector.create_mask %index1, %c8 : vector<1x8xi1>
+  %read = vector.transfer_read %1[%c0, %c0], %cst, %mask {in_bounds = [true, true]} : memref<?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, vector<1x8xbf16>
+  return %read : vector<1x8xbf16>
+}
+
+// CHECK-LABEL: @simplify_mask2
+//  CHECK-SAME:   (%[[ARG0:.+]]: memref<?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, %[[ARG1:.+]]: index)
+//   CHECK-DAG: %[[CST:.+]] = arith.constant dense<1.000000e+00> : vector<1x8xbf16>
+//       CHECK: %[[COND:.+]] = arith.index_castui %[[ARG1]] : index to i1
+//       CHECK: %[[READ:.+]] = vector.transfer_read %[[ARG0]]
+//       CHECK: %[[SEL:.+]] = arith.select %[[COND]], %[[READ]], %[[CST]] : vector<1x8xbf16>
+//       CHECK: return %[[SEL]] : vector<1x8xbf16>
+
+// -----
+
+func.func @simplify_mask3(%1 : memref<?x?x1x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, %index1 : index, %index2 : index, %index3 : index) -> vector<1x1x1x1x8xbf16> {
+  %c0 = arith.constant 0 : index
+  %c8 = arith.constant 8 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 1.000000e+00 : bf16
+  %mask = vector.create_mask %index1, %index2, %c1, %index3, %c8 : vector<1x1x1x1x8xi1>
+  %read = vector.transfer_read %1[%c0, %c0, %c0, %c0, %c0], %cst, %mask {in_bounds = [true, true, true, true, true]} : memref<?x?x1x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, vector<1x1x1x1x8xbf16>
+  return %read : vector<1x1x1x1x8xbf16>
+}
+
+// CHECK-LABEL: @simplify_mask3
+//  CHECK-SAME:   (%[[ARG0:.+]]: memref<?x?x1x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index, %[[ARG3:.+]]: index)
+//   CHECK-DAG: %[[CST:.+]] = arith.constant dense<1.000000e+00> : vector<1x1x1x1x8xbf16>
+//   CHECK-DAG: %[[LHS:.+]] = arith.index_castui %[[ARG1]] : index to i1
+//   CHECK-DAG: %[[MID:.+]] = arith.index_castui %[[ARG2]] : index to i1
+//       CHECK: %[[AND1:.+]] = arith.andi %[[LHS]], %[[MID]] : i1
+//   CHECK-DAG: %[[RHS:.+]] = arith.index_castui %[[ARG3]] : index to i1
+//       CHECK: %[[AND2:.+]] = arith.andi %[[AND1]], %[[RHS]] : i1
+//       CHECK: %[[READ:.+]] = vector.transfer_read %[[ARG0]]
+//       CHECK: %[[SEL:.+]] = arith.select %[[AND2]], %[[READ]], %[[CST]] : vector<1x1x1x1x8xbf16>
+//       CHECK: return %[[SEL]] : vector<1x1x1x1x8xbf16>
+
+// -----
+
+func.func @no_simplify_mask_no_fat_raw_buffer(%1 : memref<1x?x?x8xbf16>, %index1 : index, %index2 : index) -> vector<1x1x1x8xbf16> {
+  %c0 = arith.constant 0 : index
+  %c8 = arith.constant 8 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 1.000000e+00 : bf16
+  %mask = vector.create_mask %c1, %index1, %index2, %c8 : vector<1x1x1x8xi1>
+  %read = vector.transfer_read %1[%c0, %c0, %c0, %c0], %cst, %mask {in_bounds = [true, true, true, true]} : memref<1x?x?x8xbf16>, vector<1x1x1x8xbf16>
+  return %read : vector<1x1x1x8xbf16>
+}
+
+// CHECK-LABEL: @no_simplify_mask_no_fat_raw_buffer
+//  CHECK-SAME:   (%[[ARG0:.+]]: memref<1x?x?x8xbf16>, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index)
+//   CHECK-DAG: %[[MASK:.+]] = vector.create_mask
+//       CHECK: %[[READ:.+]] = vector.transfer_read %[[ARG0]]
+//  CHECK-SAME: %[[MASK]]
+//       CHECK: return %[[READ]] : vector<1x1x1x8xbf16>
+
+// -----
+
+func.func @no_simplify_mask_tensor(%1 : tensor<1x?x?x8xbf16>, %index1 : index, %index2 : index) -> vector<1x1x1x8xbf16> {
+  %c0 = arith.constant 0 : index
+  %c8 = arith.constant 8 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 1.000000e+00 : bf16
+  %mask = vector.create_mask %c1, %index1, %index2, %c8 : vector<1x1x1x8xi1>
+  %read = vector.transfer_read %1[%c0, %c0, %c0, %c0], %cst, %mask {in_bounds = [true, true, true, true]} : tensor<1x?x?x8xbf16>, vector<1x1x1x8xbf16>
+  return %read : vector<1x1x1x8xbf16>
+}
+
+// CHECK-LABEL: @no_simplify_mask_tensor
+//  CHECK-SAME:   (%[[ARG0:.+]]: tensor<1x?x?x8xbf16>, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index)
+//   CHECK-DAG: %[[MASK:.+]] = vector.create_mask
+//       CHECK: %[[READ:.+]] = vector.transfer_read %[[ARG0]]
+//  CHECK-SAME: %[[MASK]]
+//       CHECK: return %[[READ]] : vector<1x1x1x8xbf16>
+
+// -----
+
+func.func @no_simplify_mask_outofbounds(%1 : memref<1x?x?x6xbf16, #amdgpu.address_space<fat_raw_buffer>>, %index1 : index, %index2 : index) -> vector<1x1x1x8xbf16> {
+  %c0 = arith.constant 0 : index
+  %c8 = arith.constant 8 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 1.000000e+00 : bf16
+  %mask = vector.create_mask %c1, %index1, %index2, %c8 : vector<1x1x1x8xi1>
+  %read = vector.transfer_read %1[%c0, %c0, %c0, %c0], %cst, %mask {in_bounds = [true, true, true, false]} : memref<1x?x?x6xbf16, #amdgpu.address_space<fat_raw_buffer>>, vector<1x1x1x8xbf16>
+  return %read : vector<1x1x1x8xbf16>
+}
+
+// CHECK-LABEL: @no_simplify_mask_outofbounds
+//  CHECK-SAME:   (%[[ARG0:.+]]: memref<1x?x?x6xbf16, #amdgpu.address_space<fat_raw_buffer>>, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index)
+//   CHECK-DAG: %[[MASK:.+]] = vector.create_mask
+//       CHECK: %[[READ:.+]] = vector.transfer_read %[[ARG0]]
+//  CHECK-SAME: %[[MASK]]
+//       CHECK: return %[[READ]] : vector<1x1x1x8xbf16>
+
+// -----
+
+func.func @no_simplify_partial_mask(%1 : memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, %index1 : index, %index2 : index) -> vector<1x1x1x8xbf16> {
+  %c0 = arith.constant 0 : index
+  %c6 = arith.constant 6 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 1.000000e+00 : bf16
+  %mask = vector.create_mask %c1, %index1, %index2, %c6 : vector<1x1x1x8xi1>
+  %read = vector.transfer_read %1[%c0, %c0, %c0, %c0], %cst, %mask {in_bounds = [true, true, true, true]} : memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, vector<1x1x1x8xbf16>
+  return %read : vector<1x1x1x8xbf16>
+}
+
+// CHECK-LABEL: @no_simplify_partial_mask
+//  CHECK-SAME:   (%[[ARG0:.+]]: memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index)
+//   CHECK-DAG: %[[MASK:.+]] = vector.create_mask
+//       CHECK: %[[READ:.+]] = vector.transfer_read %[[ARG0]]
+//  CHECK-SAME: %[[MASK]]
+//       CHECK: return %[[READ]] : vector<1x1x1x8xbf16>
+
+// -----
+
+func.func @no_simplify_mask_nonunit(%1 : memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, %index1 : index, %index2 : index) -> vector<1x1x2x8xbf16> {
+  %c0 = arith.constant 0 : index
+  %c8 = arith.constant 8 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 1.000000e+00 : bf16
+  %mask = vector.create_mask %c1, %index1, %index2, %c8 : vector<1x1x2x8xi1>
+  %read = vector.transfer_read %1[%c0, %c0, %c0, %c0], %cst, %mask {in_bounds = [true, true, true, true]} : memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, vector<1x1x2x8xbf16>
+  return %read : vector<1x1x2x8xbf16>
+}
+
+// CHECK-LABEL: @no_simplify_mask_nonunit
+//  CHECK-SAME:   (%[[ARG0:.+]]: memref<1x?x?x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index)
+//   CHECK-DAG: %[[MASK:.+]] = vector.create_mask
+//       CHECK: %[[READ:.+]] = vector.transfer_read %[[ARG0]]
+//  CHECK-SAME: %[[MASK]]
+//       CHECK: return %[[READ]] : vector<1x1x2x8xbf16>
+
+// -----
+
+// This type of simplification is supported by upstream vectorization canonicalization so we dont support it here.
+func.func @no_simplify_trivial(%1 : memref<1x8xbf16, #amdgpu.address_space<fat_raw_buffer>>) -> vector<1x8xbf16> {
+  %c0 = arith.constant 0 : index
+  %c8 = arith.constant 8 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 1.000000e+00 : bf16
+  %mask = vector.create_mask %c1, %c8 : vector<1x8xi1>
+  %read = vector.transfer_read %1[%c0, %c0], %cst, %mask {in_bounds = [true, true]} : memref<1x8xbf16, #amdgpu.address_space<fat_raw_buffer>>, vector<1x8xbf16>
+  return %read : vector<1x8xbf16>
+}
+
+// CHECK-LABEL: @no_simplify_trivial
+//  CHECK-SAME:   (%[[ARG0:.+]]: memref<1x8xbf16, #amdgpu.address_space<fat_raw_buffer>>)
+//   CHECK-DAG: %[[MASK:.+]] = vector.create_mask
+//       CHECK: %[[READ:.+]] = vector.transfer_read %[[ARG0]]
+//  CHECK-SAME: %[[MASK]]
+//       CHECK: return %[[READ]] : vector<1x8xbf16>

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -931,6 +931,19 @@ bool hasGlobalMemoryAddressSpace(MemRefType memrefType) {
   return llvm::isa<IREE::HAL::DescriptorTypeAttr>(addrSpace);
 }
 
+bool hasAMDGPUFatRawBufferAddressSpace(MemRefType memrefType) {
+  Attribute addrSpace = memrefType.getMemorySpace();
+  if (!addrSpace) {
+    return false;
+  }
+  auto amdgpuAttr = llvm::dyn_cast<amdgpu::AddressSpaceAttr>(addrSpace);
+  if (amdgpuAttr &&
+      amdgpuAttr.getValue() == amdgpu::AddressSpace::FatRawBuffer) {
+    return true;
+  }
+  return false;
+}
+
 bool hasSharedMemoryAddressSpace(MemRefType memrefType) {
   auto addrSpace = llvm::dyn_cast_if_present<gpu::AddressSpaceAttr>(
       memrefType.getMemorySpace());

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -936,7 +936,7 @@ bool hasAMDGPUFatRawBufferAddressSpace(MemRefType memrefType) {
   if (!addrSpace) {
     return false;
   }
-  auto amdgpuAttr = llvm::dyn_cast<amdgpu::AddressSpaceAttr>(addrSpace);
+  auto amdgpuAttr = dyn_cast<amdgpu::AddressSpaceAttr>(addrSpace);
   if (amdgpuAttr &&
       amdgpuAttr.getValue() == amdgpu::AddressSpace::FatRawBuffer) {
     return true;

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -147,6 +147,10 @@ std::optional<SmallVector<int64_t>> getWmmaNativeVectorSize(Operation *op);
 /// Helper function to return native size for MMA.SYNC-based operations.
 std::optional<SmallVector<int64_t>> getMmaNativeVectorSize(Operation *op);
 
+/// Rerutn true if memref has #amdgpu.address_space<fat_raw_buffer> address
+/// space.
+bool hasAMDGPUFatRawBufferAddressSpace(MemRefType memrefType);
+
 /// Return true if the given memref has one of the global address spaces - no
 /// adress space, explicit integer 0, #gpu.address_space<global>, or
 /// #amdgpu.address_space<fat_raw_buffer>

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -1809,4 +1809,15 @@ std::optional<VectorizationTileSizes> inferSizesFromIR(Value val) {
   return result;
 }
 
+std::optional<int64_t> getConstantIndex(Value value) {
+  if (!isa<IndexType>(value.getType()))
+    return std::nullopt;
+
+  APInt val;
+  if (!matchPattern(value, m_ConstantInt(&val)))
+    return std::nullopt;
+
+  return val.getSExtValue();
+}
+
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -289,6 +289,9 @@ std::optional<VectorizationTileSizes> inferSizesFromIR(linalg::PackOp op);
 std::optional<VectorizationTileSizes>
 inferSizesFromIR(linalg::LinalgOp linalgOp, std::optional<OpResult> opResult);
 
+/// Returns the underlying index if the given value is a constant index.
+std::optional<int64_t> getConstantIndex(Value value);
+
 } // namespace mlir::iree_compiler
 
 #endif // IREE_COMPILER_CODEGEN_UTILS_UTILS_H_


### PR DESCRIPTION
Adds a pattern that makes use of the out-of-bounds handling provided by raw fat buffers in cases of all ones or all zero masks. This pattern prevents elementwise selection code that otherwise gets generated when we lower the masked transfer read to load + (elementwise) select. Note that this pattern needs to run after bufferization but before optimizations such as `OptimizeVectorTransferPass` run as they add vector.extracts between the mask and the read making running such an optimization harder.