### PR TITLE
[Im2Col] Support converting group convs to im2col

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConvToIm2ColOp.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConvToIm2ColOp.cpp
@@ -79,37 +79,36 @@ static void collectDimExprs(ArrayRef<AffineExpr> exprs,
 
 // Computes `inputKPerm` that maps the input spatial and channel dimension order
 // to filter's.
-static SmallVector<int64_t> computeInputKPerm(AffineMap inputMap,
-                                              AffineMap filterMap) {
-  DenseSet<AffineExpr> inputDimsSet;
-  DenseSet<AffineExpr> filterDimsSet;
-  collectDimExprs(inputMap.getResults(), inputDimsSet);
-  collectDimExprs(filterMap.getResults(), filterDimsSet);
+static SmallVector<int64_t>
+computeInputKPerm(AffineMap inputMap, AffineMap filterMap,
+                  const mlir::linalg::ConvolutionDimensions &convDims) {
+  // Get reduction dims from input and filter in order of appearance.
+  auto reductionDims =
+      llvm::concat<const unsigned>(convDims.inputChannel, convDims.filterLoop);
+  SmallVector<int64_t> inputReductionDims;
+  for (auto dimExpr : inputMap.getResults()) {
+    for (auto reductionDim : reductionDims) {
+      if (dimExpr.isFunctionOfDim(reductionDim)) {
+        inputReductionDims.push_back(reductionDim);
+      }
+    }
+  }
+  SmallVector<int64_t> filterReductionDims;
+  for (auto dimExpr : filterMap.getResults()) {
+    for (auto reductionDim : reductionDims) {
+      if (dimExpr.isFunctionOfDim(reductionDim)) {
+        filterReductionDims.push_back(reductionDim);
+      }
+    }
+  }
 
-  // Get shared dims from input and filter in order of appearance.
-  SmallVector<AffineExpr> inputSharedDims;
-  SmallVector<AffineExpr> filterSharedDims;
-  for (AffineExpr expr : inputMap.getResults()) {
-    expr.walk([&](AffineExpr dimExpr) {
-      if (filterDimsSet.contains(dimExpr)) {
-        inputSharedDims.push_back(dimExpr);
-      }
-    });
-  }
-  for (AffineExpr expr : filterMap.getResults()) {
-    expr.walk([&](AffineExpr dimExpr) {
-      if (inputDimsSet.contains(dimExpr)) {
-        filterSharedDims.push_back(dimExpr);
-      }
-    });
-  }
   // Compute the permutation that maps inputSharedDims to filterSharedDims.
   SmallVector<int64_t> inputKPerm;
-  for (AffineExpr filterExpr : filterSharedDims) {
-    auto it = llvm::find(inputSharedDims, filterExpr);
-    assert(it != inputSharedDims.end() &&
+  for (int64_t dim : filterReductionDims) {
+    auto it = llvm::find(inputReductionDims, dim);
+    assert(it != inputReductionDims.end() &&
            "Filter dimension not found in input shared dimensions");
-    inputKPerm.push_back(std::distance(inputSharedDims.begin(), it));
+    inputKPerm.push_back(std::distance(inputReductionDims.begin(), it));
   }
   return inputKPerm;
 }
@@ -211,18 +210,18 @@ public:
           rewriter.getIndexAttr(filterShape[maybeDim.value()]));
     }
 
-    // Shape of the resulting tensor from im2col.
-    SmallVector<int64_t> colTensorShape;
-    SmallVector<int64_t> batchPos;
-    for (auto batch : convDims.batch) {
-      std::optional<int64_t> maybeBatch = inputMap.getResultPosition(
-          getAffineDimExpr(batch, inputMap.getContext()));
-      if (!maybeBatch) {
-        return rewriter.notifyMatchFailure(linalgOp,
-                                           "Failed to infer batch shape.");
-      }
-      batchPos.push_back(maybeBatch.value());
-      colTensorShape.push_back(inputShape[maybeBatch.value()]);
+    // Batch dims for the im2col also include the depth/group dimensions of the
+    // conv.
+    auto im2colBatchIterDims =
+        llvm::to_vector(llvm::concat<unsigned>(convDims.depth, convDims.batch));
+    SmallVector<int64_t> batchPos(im2colBatchIterDims.size());
+    for (auto dim : im2colBatchIterDims) {
+      auto dimExpr = getAffineDimExpr(dim, inputMap.getContext());
+      int64_t im2colInputDim = inputMap.getResultPosition(dimExpr).value();
+      int64_t igemmInputDim = igemmConvDetails.getIgemmInputImageMap()
+                                  .getResultPosition(dimExpr)
+                                  .value();
+      batchPos[igemmInputDim] = im2colInputDim;
     }
 
     SmallVector<int64_t> mPos;
@@ -236,7 +235,6 @@ public:
       for (auto [idx, e] : llvm::enumerate(outputMap.getResults())) {
         if (e.isFunctionOfDim(outputImage)) {
           mShape.push_back(outputShape[idx]);
-          colTensorShape.push_back(outputShape[idx]);
         }
       }
     }
@@ -251,12 +249,11 @@ public:
     }
     // The index at which the reduction dimension bounds starts in
     // igemmLoopBounds.
-    int64_t reductionBoundIndex = convDims.batch.size() +
-                                  convDims.outputImage.size() +
-                                  convDims.outputChannel.size();
+    int64_t reductionBoundIndex =
+        convDims.batch.size() + convDims.depth.size() +
+        convDims.outputImage.size() + convDims.outputChannel.size();
     SmallVector<int64_t> kShape(igemmLoopBounds.begin() + reductionBoundIndex,
                                 igemmLoopBounds.end());
-    colTensorShape.insert(colTensorShape.end(), kShape.begin(), kShape.end());
 
     SmallVector<OpFoldResult> mBasis =
         getAsIndexOpFoldResult(getContext(), getBasisFromShape(mShape));
@@ -266,9 +263,17 @@ public:
     SmallVector<OpFoldResult> kOffset(kBasis.size(), rewriter.getIndexAttr(0));
     SmallVector<OpFoldResult> mOffset(mBasis.size(), rewriter.getIndexAttr(0));
 
-    SmallVector<int64_t> inputKPerm = computeInputKPerm(inputMap, filterMap);
+    SmallVector<int64_t> inputKPerm =
+        computeInputKPerm(inputMap, filterMap, convDims);
 
     auto loc = linalgOp.getLoc();
+    // Shape of the resulting tensor from im2col.
+    SmallVector<int64_t> colTensorShape;
+    for (int64_t dim : batchPos) {
+      colTensorShape.push_back(inputShape[dim]);
+    }
+    colTensorShape.append(mShape);
+    colTensorShape.append(kShape);
     Value colTensor = rewriter.create<tensor::EmptyOp>(
         loc, colTensorShape, inputType.getElementType());
     Value img2ColTensor =

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConvToIm2ColOp.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConvToIm2ColOp.cpp
@@ -200,11 +200,13 @@ public:
     auto im2colBatchIterDims =
         llvm::to_vector(llvm::concat<unsigned>(convDims.depth, convDims.batch));
     SmallVector<int64_t> batchPos(im2colBatchIterDims.size());
-    for (auto dim : im2colBatchIterDims) {
-      auto dimExpr = getAffineDimExpr(dim, inputMap.getContext());
-      int64_t im2colInputDim = inputMap.getResultPosition(dimExpr).value();
+    for (int64_t convDim : im2colBatchIterDims) {
+      AffineExpr convDimExpr = getAffineDimExpr(convDim, getContext());
+      int64_t im2colInputDim = inputMap.getResultPosition(convDimExpr).value();
+
+      AffineExpr igemmDimExpr = igemmConvDetails.convToIgemmDimMap.at(convDim);
       int64_t igemmInputDim = igemmConvDetails.getIgemmInputImageMap()
-                                  .getResultPosition(dimExpr)
+                                  .getResultPosition(igemmDimExpr)
                                   .value();
       batchPos[igemmInputDim] = im2colInputDim;
     }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv_to_im2col.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv_to_im2col.mlir
@@ -464,18 +464,18 @@ util.func public @conv_2d_nhwgc_gfhwc(%arg0: tensor<2x10x10x7x4xf32>, %arg1: ten
   util.return %0 : tensor<2x8x8x7x16xf32>
 }
 //                                            n   h   w   g   f   c
-// CHECK-DAG:  #[[LHS_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d0, d1, d2, d5)>
+// CHECK-DAG:  #[[LHS_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d3, d1, d2, d5)>
 // CHECK-DAG:  #[[RHS_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d4, d5)>
 // CHECK-DAG:  #[[OUT_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d4)>
 // CHECK:      util.func public @conv_2d_nhwgc_gfhwc(
 // CHECK-SAME:   %[[IMG:.+]]: [[IMG_T:tensor<2x10x10x7x4xf32>]]
 // CHECK-SAME:   %[[FIL:.+]]: [[FIL_T:tensor<7x16x3x3x4xf32>]]
 // CHECK-SAME:   %[[OUT:.+]]: [[OUT_T:tensor<2x8x8x7x16xf32>]]
-// CHECK:      %[[EMPTY:.+]] = tensor.empty() : [[LHS_T:tensor<7x2x8x8x36xf32>]]
+// CHECK:      %[[EMPTY:.+]] = tensor.empty() : [[LHS_T:tensor<2x7x8x8x36xf32>]]
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
 // CHECK-SAME:   m_offset = [0, 0] * [8, 1] k_offset = [0] * [1]
-// CHECK-SAME:   batch_pos = [3, 0] m_pos = [1, 2] k_pos = [4]
+// CHECK-SAME:   batch_pos = [0, 3] m_pos = [1, 2] k_pos = [4]
 // CHECK-SAME:   input_k_perm = [0, 1, 2]
 // CHECK-SAME:   ins(%[[IMG]] : [[IMG_T]])
 // CHECK-SAME:   outs(%[[EMPTY]] : [[LHS_T]])
@@ -499,17 +499,17 @@ util.func public @conv_2d_ngchw_fgchw(%arg0: tensor<2x7x4x10x10xf32>, %arg1: ten
 }
 //                                            n   g   f   h   w   c
 // CHECK-DAG:  #[[LHS_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d2, d1, d5)>
-// CHECK-DAG:  #[[RHS_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d0, d3, d4, d5)>
+// CHECK-DAG:  #[[RHS_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4, d5)>
 // CHECK-DAG:  #[[OUT_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d4)>
 // CHECK:      util.func public @conv_2d_ngchw_fgchw(
 // CHECK-SAME:   %[[IMG:.+]]: [[IMG_T:tensor<2x7x4x10x10xf32>]]
 // CHECK-SAME:   %[[FIL:.+]]: [[FIL_T:tensor<16x7x4x3x3xf32>]]
 // CHECK-SAME:   %[[OUT:.+]]: [[OUT_T:tensor<2x7x16x8x8xf32>]]
-// CHECK:      %[[EMPTY:.+]] = tensor.empty() : [[RHS_T:tensor<7x2x8x8x36xf32>]]
+// CHECK:      %[[EMPTY:.+]] = tensor.empty() : [[RHS_T:tensor<2x7x8x8x36xf32>]]
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
 // CHECK-SAME:   m_offset = [0, 0] * [8, 1] k_offset = [0] * [1]
-// CHECK-SAME:   batch_pos = [1, 0] m_pos = [3, 4] k_pos = [2]
+// CHECK-SAME:   batch_pos = [0, 1] m_pos = [3, 4] k_pos = [2]
 // CHECK-SAME:   input_k_perm = [0, 1, 2]
 // CHECK-SAME:   ins(%[[IMG]] : [[IMG_T]])
 // CHECK-SAME:   outs(%[[EMPTY]] : [[LHS_T]])

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv_to_im2col.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv_to_im2col.mlir
@@ -456,21 +456,22 @@ util.func public @conv_1d_nhc_chf(%arg0: tensor<1x3x2xf32>, %arg1: tensor<2x2x2x
 
 // -----
 
-util.func public @conv_2d_nhwgc_gfhwc(%arg0: tensor<1x10x10x7x4xf32>, %arg1: tensor<7x16x3x3x4xf32>, %arg2: tensor<1x8x8x7x16xf32>) -> tensor<1x8x8x7x16xf32> {
+util.func public @conv_2d_nhwgc_gfhwc(%arg0: tensor<2x10x10x7x4xf32>, %arg1: tensor<7x16x3x3x4xf32>, %arg2: tensor<2x8x8x7x16xf32>) -> tensor<2x8x8x7x16xf32> {
   %0 = linalg.conv_2d_nhwgc_gfhwc
     {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64> }
-     ins(%arg0, %arg1: tensor<1x10x10x7x4xf32>, tensor<7x16x3x3x4xf32>)
-    outs(%arg2: tensor<1x8x8x7x16xf32>) -> tensor<1x8x8x7x16xf32>
-  util.return %0 : tensor<1x8x8x7x16xf32>
+     ins(%arg0, %arg1: tensor<2x10x10x7x4xf32>, tensor<7x16x3x3x4xf32>)
+    outs(%arg2: tensor<2x8x8x7x16xf32>) -> tensor<2x8x8x7x16xf32>
+  util.return %0 : tensor<2x8x8x7x16xf32>
 }
+//                                            n   h   w   g   f   c
 // CHECK-DAG:  #[[LHS_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d0, d1, d2, d5)>
 // CHECK-DAG:  #[[RHS_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d4, d5)>
 // CHECK-DAG:  #[[OUT_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d4)>
 // CHECK:      util.func public @conv_2d_nhwgc_gfhwc(
-// CHECK-SAME:   %[[IMG:.+]]: [[IMG_T:tensor<1x10x10x7x4xf32>]]
+// CHECK-SAME:   %[[IMG:.+]]: [[IMG_T:tensor<2x10x10x7x4xf32>]]
 // CHECK-SAME:   %[[FIL:.+]]: [[FIL_T:tensor<7x16x3x3x4xf32>]]
-// CHECK-SAME:   %[[OUT:.+]]: [[OUT_T:tensor<1x8x8x7x16xf32>]]
-// CHECK:      %[[EMPTY:.+]] = tensor.empty() : [[LHS_T:tensor<7x1x8x8x36xf32>]]
+// CHECK-SAME:   %[[OUT:.+]]: [[OUT_T:tensor<2x8x8x7x16xf32>]]
+// CHECK:      %[[EMPTY:.+]] = tensor.empty() : [[LHS_T:tensor<7x2x8x8x36xf32>]]
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
 // CHECK-SAME:   m_offset = [0, 0] * [8, 1] k_offset = [0] * [1]
@@ -484,30 +485,27 @@ util.func public @conv_2d_nhwgc_gfhwc(%arg0: tensor<1x10x10x7x4xf32>, %arg1: ten
 // CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "reduction"]
 // CHECK-SAME:   ins(%[[IM2COL]], %[[COLLAPSED]] : [[LHS_T]], [[RHS_T]])
 // CHECK-SAME:   outs(%[[OUT]] : [[OUT_T]]) {
-// CHECK:          arith.mulf
-// CHECK:          arith.addf
 // CHECK:      }
 // CHECK:      util.return %[[MATMUL]]
 
 // -----
 
-util.func public @conv_2d_ngchw_fgchw(%arg0: tensor<1x7x4x10x10xf32>, %arg1: tensor<16x7x4x3x3xf32>, %arg2: tensor<1x7x16x8x8xf32>) -> tensor<1x7x16x8x8xf32> {
+util.func public @conv_2d_ngchw_fgchw(%arg0: tensor<2x7x4x10x10xf32>, %arg1: tensor<16x7x4x3x3xf32>, %arg2: tensor<2x7x16x8x8xf32>) -> tensor<2x7x16x8x8xf32> {
   %0 = linalg.conv_2d_ngchw_fgchw
     {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64> }
-     ins(%arg0, %arg1: tensor<1x7x4x10x10xf32>, tensor<16x7x4x3x3xf32>)
-    outs(%arg2: tensor<1x7x16x8x8xf32>) -> tensor<1x7x16x8x8xf32>
-  util.return %0 : tensor<1x7x16x8x8xf32>
+     ins(%arg0, %arg1: tensor<2x7x4x10x10xf32>, tensor<16x7x4x3x3xf32>)
+    outs(%arg2: tensor<2x7x16x8x8xf32>) -> tensor<2x7x16x8x8xf32>
+  util.return %0 : tensor<2x7x16x8x8xf32>
 }
-// og filter map (x0, x1, x2, x3, x4, x5) -> ()
 //                                            n   g   f   h   w   c
 // CHECK-DAG:  #[[LHS_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d2, d1, d5)>
 // CHECK-DAG:  #[[RHS_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d0, d3, d4, d5)>
 // CHECK-DAG:  #[[OUT_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d4)>
 // CHECK:      util.func public @conv_2d_ngchw_fgchw(
-// CHECK-SAME:   %[[IMG:.+]]: [[IMG_T:tensor<1x7x4x10x10xf32>]]
+// CHECK-SAME:   %[[IMG:.+]]: [[IMG_T:tensor<2x7x4x10x10xf32>]]
 // CHECK-SAME:   %[[FIL:.+]]: [[FIL_T:tensor<16x7x4x3x3xf32>]]
-// CHECK-SAME:   %[[OUT:.+]]: [[OUT_T:tensor<1x7x16x8x8xf32>]]
-// CHECK:      %[[EMPTY:.+]] = tensor.empty() : [[RHS_T:tensor<7x1x8x8x36xf32>]]
+// CHECK-SAME:   %[[OUT:.+]]: [[OUT_T:tensor<2x7x16x8x8xf32>]]
+// CHECK:      %[[EMPTY:.+]] = tensor.empty() : [[RHS_T:tensor<7x2x8x8x36xf32>]]
 // CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
 // CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
 // CHECK-SAME:   m_offset = [0, 0] * [8, 1] k_offset = [0] * [1]
@@ -521,7 +519,5 @@ util.func public @conv_2d_ngchw_fgchw(%arg0: tensor<1x7x4x10x10xf32>, %arg1: ten
 // CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "reduction"]
 // CHECK-SAME:   ins(%[[COLLAPSED]], %[[IM2COL]] : [[LHS_T]], [[RHS_T]])
 // CHECK-SAME:   outs(%[[OUT]] : [[OUT_T]]) {
-// CHECK:          arith.mulf
-// CHECK:          arith.addf
 // CHECK:      }
 // CHECK:      util.return %[[MATMUL]]

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv_to_im2col.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/conv_to_im2col.mlir
@@ -453,3 +453,75 @@ util.func public @conv_1d_nhc_chf(%arg0: tensor<1x3x2xf32>, %arg1: tensor<2x2x2x
 // CHECK-SAME:   input_k_perm = [1, 0]
 // CHECK-SAME:   ins({{.*}} : tensor<1x3x2xf32>)
 // CHECK-SAME:   outs({{.*}} : tensor<1x2x4xf32>) -> tensor<1x2x4xf32>
+
+// -----
+
+util.func public @conv_2d_nhwgc_gfhwc(%arg0: tensor<1x10x10x7x4xf32>, %arg1: tensor<7x16x3x3x4xf32>, %arg2: tensor<1x8x8x7x16xf32>) -> tensor<1x8x8x7x16xf32> {
+  %0 = linalg.conv_2d_nhwgc_gfhwc
+    {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64> }
+     ins(%arg0, %arg1: tensor<1x10x10x7x4xf32>, tensor<7x16x3x3x4xf32>)
+    outs(%arg2: tensor<1x8x8x7x16xf32>) -> tensor<1x8x8x7x16xf32>
+  util.return %0 : tensor<1x8x8x7x16xf32>
+}
+// CHECK-DAG:  #[[LHS_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d0, d1, d2, d5)>
+// CHECK-DAG:  #[[RHS_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d4, d5)>
+// CHECK-DAG:  #[[OUT_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d4)>
+// CHECK:      util.func public @conv_2d_nhwgc_gfhwc(
+// CHECK-SAME:   %[[IMG:.+]]: [[IMG_T:tensor<1x10x10x7x4xf32>]]
+// CHECK-SAME:   %[[FIL:.+]]: [[FIL_T:tensor<7x16x3x3x4xf32>]]
+// CHECK-SAME:   %[[OUT:.+]]: [[OUT_T:tensor<1x8x8x7x16xf32>]]
+// CHECK:      %[[EMPTY:.+]] = tensor.empty() : [[LHS_T:tensor<7x1x8x8x36xf32>]]
+// CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
+// CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
+// CHECK-SAME:   m_offset = [0, 0] * [8, 1] k_offset = [0] * [1]
+// CHECK-SAME:   batch_pos = [3, 0] m_pos = [1, 2] k_pos = [4]
+// CHECK-SAME:   input_k_perm = [0, 1, 2]
+// CHECK-SAME:   ins(%[[IMG]] : [[IMG_T]])
+// CHECK-SAME:   outs(%[[EMPTY]] : [[LHS_T]])
+// CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[FIL]] {{\[}}[0], [1], [2, 3, 4]] : [[FIL_T]] into [[RHS_T:tensor<7x16x36xf32>]]
+// CHECK:      %[[MATMUL:.+]] = linalg.generic
+// CHECK-SAME:   indexing_maps = [#[[LHS_MAP]], #[[RHS_MAP]], #[[OUT_MAP]]]
+// CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "reduction"]
+// CHECK-SAME:   ins(%[[IM2COL]], %[[COLLAPSED]] : [[LHS_T]], [[RHS_T]])
+// CHECK-SAME:   outs(%[[OUT]] : [[OUT_T]]) {
+// CHECK:          arith.mulf
+// CHECK:          arith.addf
+// CHECK:      }
+// CHECK:      util.return %[[MATMUL]]
+
+// -----
+
+util.func public @conv_2d_ngchw_fgchw(%arg0: tensor<1x7x4x10x10xf32>, %arg1: tensor<16x7x4x3x3xf32>, %arg2: tensor<1x7x16x8x8xf32>) -> tensor<1x7x16x8x8xf32> {
+  %0 = linalg.conv_2d_ngchw_fgchw
+    {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64> }
+     ins(%arg0, %arg1: tensor<1x7x4x10x10xf32>, tensor<16x7x4x3x3xf32>)
+    outs(%arg2: tensor<1x7x16x8x8xf32>) -> tensor<1x7x16x8x8xf32>
+  util.return %0 : tensor<1x7x16x8x8xf32>
+}
+// og filter map (x0, x1, x2, x3, x4, x5) -> ()
+//                                            n   g   f   h   w   c
+// CHECK-DAG:  #[[LHS_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d2, d1, d5)>
+// CHECK-DAG:  #[[RHS_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d0, d3, d4, d5)>
+// CHECK-DAG:  #[[OUT_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d4)>
+// CHECK:      util.func public @conv_2d_ngchw_fgchw(
+// CHECK-SAME:   %[[IMG:.+]]: [[IMG_T:tensor<1x7x4x10x10xf32>]]
+// CHECK-SAME:   %[[FIL:.+]]: [[FIL_T:tensor<16x7x4x3x3xf32>]]
+// CHECK-SAME:   %[[OUT:.+]]: [[OUT_T:tensor<1x7x16x8x8xf32>]]
+// CHECK:      %[[EMPTY:.+]] = tensor.empty() : [[RHS_T:tensor<7x1x8x8x36xf32>]]
+// CHECK:      %[[IM2COL:.+]] = iree_linalg_ext.im2col
+// CHECK-SAME:   strides = [1, 1] dilations = [1, 1] kernel_size = [3, 3]
+// CHECK-SAME:   m_offset = [0, 0] * [8, 1] k_offset = [0] * [1]
+// CHECK-SAME:   batch_pos = [1, 0] m_pos = [3, 4] k_pos = [2]
+// CHECK-SAME:   input_k_perm = [0, 1, 2]
+// CHECK-SAME:   ins(%[[IMG]] : [[IMG_T]])
+// CHECK-SAME:   outs(%[[EMPTY]] : [[LHS_T]])
+// CHECK-DAG:  %[[COLLAPSED:.+]] = tensor.collapse_shape %[[FIL]] {{\[}}[0], [1], [2, 3, 4]] : [[FIL_T]] into [[LHS_T:tensor<16x7x36xf32>]]
+// CHECK:      %[[MATMUL:.+]] = linalg.generic
+// CHECK-SAME:   indexing_maps = [#[[LHS_MAP]], #[[RHS_MAP]], #[[OUT_MAP]]]
+// CHECK-SAME:   iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "reduction"]
+// CHECK-SAME:   ins(%[[COLLAPSED]], %[[IM2COL]] : [[LHS_T]], [[RHS_T]])
+// CHECK-SAME:   outs(%[[OUT]] : [[OUT_T]]) {
+// CHECK:          arith.mulf
+// CHECK:          arith.addf
+// CHECK:      }
+// CHECK:      util.return %[[MATMUL]]

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -410,7 +410,7 @@ getIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
     llvm::interleaveComma(convDims.filterLoop, llvm::dbgs());
     llvm::dbgs() << "\nconv input channel dims: ";
     llvm::interleaveComma(convDims.inputChannel, llvm::dbgs());
-    llvm::dbgs() << "\nconv depth multiplier: ";
+    llvm::dbgs() << "\nconv depth dims: ";
     llvm::interleaveComma(convDims.depth, llvm::dbgs());
     llvm::dbgs() << "\n";
   });
@@ -431,11 +431,6 @@ getIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
   if (!hasAllOneValues(convDims.dilations)) {
     LDBG("[unimplemented] expected no dilations (expected dilations to all be "
          "one).");
-    return failure();
-  }
-  // TODO: Support depthwise.
-  if (!convDims.depth.empty()) {
-    LDBG("[unimplemented] expected no depth");
     return failure();
   }
 
@@ -473,14 +468,6 @@ getIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
   if (outputChannelLastDim.value() < outputImageFirstDim.value())
     isOutputChannelFirst = true;
 
-  bool isBatchDimLast = false;
-  int64_t numBDims = (convDims.batch).size();
-  if (numBDims != 0) {
-    std::optional<int64_t> batchFirstDim = outputMap.getResultPosition(
-        getAffineDimExpr(convDims.batch[0], outputMap.getContext()));
-    if (batchFirstDim && outputChannelLastDim.value() < batchFirstDim.value())
-      isBatchDimLast = true;
-  }
   SmallVector<int64_t> filterkPos;
   for (auto reductionDim : reductionDims) {
     std::optional<int64_t> maybeDim = filterMap.getResultPosition(
@@ -508,14 +495,19 @@ getIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
 
   auto parallel = utils::IteratorType::parallel;
   auto reduction = utils::IteratorType::reduction;
-  SmallVector<utils::IteratorType> filterIterators;
+
+  // Parallel filter dims, in order.
   SmallVector<int64_t> filterNdims;
-  for (auto outputChannel : convDims.outputChannel) {
+  for (auto iterDim :
+       llvm::concat<const unsigned>(convDims.depth, convDims.outputChannel)) {
     std::optional<int64_t> maybeDim = filterMap.getResultPosition(
-        getAffineDimExpr(outputChannel, filterMap.getContext()));
+        getAffineDimExpr(iterDim, filterMap.getContext()));
     filterNdims.push_back(maybeDim.value());
   }
+  std::sort(filterNdims.begin(), filterNdims.end());
+
   SmallVector<ReassociationIndices> filterReassocIndices;
+  SmallVector<utils::IteratorType> filterIterators;
   // Interleave the parallel dims with the reduction dims.
   int64_t filterNdimPos = 0;
   for (auto collapsedDim : collapsedFilterReductionDim) {
@@ -543,9 +535,9 @@ getIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
     }
   }
 
-  int64_t numMDims = (convDims.outputImage).size();
-  int64_t numNDims = (convDims.outputChannel).size();
-  int64_t numParallelDims = numBDims + numMDims + numNDims;
+  int64_t numParallelDims = convDims.depth.size() + convDims.batch.size() +
+                            convDims.outputImage.size() +
+                            convDims.outputChannel.size();
   int64_t numKDims = collapsedFilterReductionDim.size();
   SmallVector<utils::IteratorType> genericIterators(numParallelDims, parallel);
   genericIterators.insert(genericIterators.end(), numKDims, reduction);
@@ -582,6 +574,8 @@ getIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
       inputDims.push_back(dims[i]);
   };
 
+  // Add the depth (group) dims.
+  insertExprs(remapDims(convDims.depth));
   // Add the batch dims.
   insertExprs(remapDims(convDims.batch));
   // Add the M dims.
@@ -592,17 +586,19 @@ getIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
       AffineMap::get(numParallelDims + numKDims, 0, inputDims, ctx);
 
   // Prepare filter map.
-  int64_t numBDimsInFront = isBatchDimLast ? 0 : numBDims;
-  int64_t currNPos =
-      isOutputChannelFirst ? numBDimsInFront : numBDimsInFront + numMDims;
-  int64_t currKPos = numBDims + numMDims + numNDims;
+  int64_t currKPos = numParallelDims;
   SmallVector<AffineExpr> filterDims;
-
-  for (auto iter : filterIterators) {
-    if (iter == parallel) {
-      filterDims.push_back(dims[currNPos++]);
-    } else if (iter == reduction) {
+  for (const auto &[iter, indices] :
+       llvm::zip_equal(filterIterators, filterReassocIndices)) {
+    if (iter == reduction) {
       filterDims.push_back(dims[currKPos++]);
+    } else {
+      assert(iter == parallel && "expected a parallel dim");
+      assert(indices.size() == 1 && "expected a single reassociation index");
+      int64_t filterInputIdx = indices.front();
+      AffineExpr originalDim = filterMap.getResult(filterInputIdx);
+      int64_t canonicalDim = outputMap.getResultPosition(originalDim).value();
+      filterDims.push_back(dims[canonicalDim]);
     }
   }
   auto filterMapGEMM =

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -574,10 +574,10 @@ getIGEMMGenericConvDetails(linalg::LinalgOp linalgOp) {
       inputDims.push_back(dims[i]);
   };
 
-  // Add the depth (group) dims.
-  insertExprs(remapDims(convDims.depth));
   // Add the batch dims.
   insertExprs(remapDims(convDims.batch));
+  // Add the depth (group) dims.
+  insertExprs(remapDims(convDims.depth));
   // Add the M dims.
   insertExprs(remapDims(convDims.outputImage));
   // Add the reduction dims at the end.

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
@@ -170,6 +170,11 @@ struct IGEMMGenericConvDetails {
   /// Indicates if the OutputChannel is before the OutputImage in the output.
   /// This determines our lhs/rhs ordering.
   bool isOutputChannelFirst;
+
+  // Get the indexing map for the IGEMM image operand.
+  AffineMap getIgemmInputImageMap() {
+    return igemmContractionMaps[isOutputChannelFirst ? 1 : 0];
+  }
 };
 
 /// Populate `IGEMMGenericConvDetails` for a given convolution operation.

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.h
@@ -162,6 +162,9 @@ struct IGEMMGenericConvDetails {
   SmallVector<Value> igemmOperands;
   /// The inferred convolution dimensions.
   mlir::linalg::ConvolutionDimensions convDims;
+  /// Mapping from dimensions in 'convDims' to dimensions in
+  /// 'igemmContractionMaps'. This only includes parallel dimensions.
+  DenseMap<int64_t, AffineExpr> convToIgemmDimMap;
   /// The reassociation indices used to computer the collapse shape of the
   /// filter in IGEMM transformation.
   SmallVector<ReassociationIndices> filterReassocIndices;


### PR DESCRIPTION
This adds support for converting group convs to im2col, allowing them to go down the IGEMM path.

Group dimensions are parallel iterator dims that index into the image, filter, and output. For im2col they are treated as a batch dimension.

This also fixes #20498