### PR TITLE
Reduce verbosity of HAL translation failure errors

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCheckResourceUsage.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCheckResourceUsage.cpp
@@ -82,9 +82,10 @@ static LogicalResult checkGPUAllocationSize(
     cumSize += allocSize / 8;
   }
   if (cumSize > limit) {
-    return funcOp.emitOpError("uses ")
-           << cumSize << " bytes of shared memory; exceeded the limit of "
-           << limit << " bytes";
+    return emitError(funcOp->getLoc())
+           << "function '" << funcOp.getName() << "' uses " << cumSize
+           << " bytes of shared memory; exceeded the limit of " << limit
+           << " bytes";
   }
   return success();
 }

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/TranslateExecutables.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/TranslateExecutables.cpp
@@ -66,9 +66,10 @@ struct TranslateTargetExecutableVariantsPass
     targetBackend->buildTranslationPassPipeline(variantOp.getTargetAttr(),
                                                 passManager);
     if (failed(runPipeline(passManager, variantOp))) {
-      variantOp.emitError() << "failed to run translation of source "
-                               "executable to target executable for backend "
-                            << variantOp.getTarget();
+      emitError(variantOp->getLoc())
+          << "failed to run translation of source executable to target "
+             "executable for backend "
+          << variantOp.getTarget();
       return signalPassFailure();
     }
   }
@@ -106,7 +107,6 @@ struct TranslateAllExecutablesPass
     IREE_COMPILER_TRACE_MESSAGE_DYNAMIC(INFO, executableOp.getSymName().str());
 
     if (failed(runPipeline(passManager, executableOp))) {
-      llvm::errs() << "failed to translate executables\n";
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/TranslateExecutables.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/TranslateExecutables.cpp
@@ -58,7 +58,8 @@ struct TranslateTargetExecutableVariantsPass
 
     auto targetBackend = targetRegistry->getTargetBackend(target);
     if (!targetBackend) {
-      variantOp.emitError() << "unregistered target backend '" << target << "'";
+      emitError(variantOp->getLoc())
+          << "unregistered target backend '" << target << "'";
       return signalPassFailure();
     }
 


### PR DESCRIPTION
Some failure messages here are currently dumping entire functions, making it difficult to see the actual error. This removes the IR from the diagnostics.

To see the failing IR when debugging, you can pass `--mlir-print-ir-after-failure` to `iree-compile`/`iree-opt`; this approach also has the advantage of printing the IR in it's pretty form when possible, instead of the generic form that error diagnostics use.