### PR TITLE
[Codegen] Add ops to translate between tensor and memref

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
@@ -73,8 +73,7 @@ void ExtractStridedMetadataOp::getAsmResultNames(
 LogicalResult LoadFromMemrefOp::verify() {
   RankedTensorType resultType = getResult().getType();
   MemRefType sourceType = getSource().getType();
-  if (failed(verifyCompatibleShape(resultType.getShape(),
-                                   sourceType.getShape())) ||
+  if (!llvm::equal(resultType.getShape(), sourceType.getShape()) ||
       resultType.getElementType() != sourceType.getElementType()) {
     return emitOpError("source and result shape and element type must match");
   }
@@ -95,8 +94,7 @@ void LoadFromMemrefOp::getEffects(
 LogicalResult StoreToMemrefOp::verify() {
   RankedTensorType valueType = getValue().getType();
   MemRefType targetType = getTarget().getType();
-  if (failed(
-          verifyCompatibleShape(valueType.getShape(), targetType.getShape())) ||
+  if (!llvm::equal(valueType.getShape(), targetType.getShape()) ||
       valueType.getElementType() != targetType.getElementType()) {
     return emitOpError("value and target shape and element type must match");
   }

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
@@ -73,9 +73,11 @@ void ExtractStridedMetadataOp::getAsmResultNames(
 LogicalResult LoadFromMemrefOp::verify() {
   RankedTensorType resultType = getResult().getType();
   MemRefType sourceType = getSource().getType();
-  if (!llvm::equal(resultType.getShape(), sourceType.getShape()) ||
+  if (failed(verifyCompatibleShape(resultType.getShape(),
+                                   sourceType.getShape())) ||
       resultType.getElementType() != sourceType.getElementType()) {
-    return emitOpError("source and result shape and element type must match");
+    return emitOpError("source and result shapes must be compatible and "
+                       "element types must match");
   }
   return success();
 }
@@ -94,9 +96,11 @@ void LoadFromMemrefOp::getEffects(
 LogicalResult StoreToMemrefOp::verify() {
   RankedTensorType valueType = getValue().getType();
   MemRefType targetType = getTarget().getType();
-  if (!llvm::equal(valueType.getShape(), targetType.getShape()) ||
+  if (failed(
+          verifyCompatibleShape(valueType.getShape(), targetType.getShape())) ||
       valueType.getElementType() != targetType.getElementType()) {
-    return emitOpError("value and target shape and element type must match");
+    return emitOpError("value and target shapes must be compatible and element "
+                       "types must match");
   }
   return success();
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
@@ -65,3 +65,47 @@ void ExtractStridedMetadataOp::getAsmResultNames(
     setNameFn(getStrides().front(), "strides");
   }
 }
+
+//===----------------------------------------------------------------------===//
+// LoadFromMemrefOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult LoadFromMemrefOp::verify() {
+  RankedTensorType resultType = getResult().getType();
+  MemRefType sourceType = getSource().getType();
+  if (failed(verifyCompatibleShape(resultType.getShape(),
+                                   sourceType.getShape())) ||
+      resultType.getElementType() != sourceType.getElementType()) {
+    return emitOpError("source and result shape and element type must match");
+  }
+  return success();
+}
+
+void LoadFromMemrefOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Read::get(), &getSourceMutable(),
+                       SideEffects::DefaultResource::get());
+}
+
+//===----------------------------------------------------------------------===//
+// StoreToMemrefOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult StoreToMemrefOp::verify() {
+  RankedTensorType valueType = getValue().getType();
+  MemRefType targetType = getTarget().getType();
+  if (failed(
+          verifyCompatibleShape(valueType.getShape(), targetType.getShape())) ||
+      valueType.getElementType() != targetType.getElementType()) {
+    return emitOpError("value and target shape and element type must match");
+  }
+  return success();
+}
+
+void StoreToMemrefOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), &getTargetMutable(),
+                       SideEffects::DefaultResource::get());
+}

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
@@ -171,5 +171,54 @@ def IREECodegen_NullPointerOp :
   let assemblyFormat = "attr-dict";
 }
 
+//===----------------------------------------------------------------------===//
+// LoadFrom/StoreToMemref Ops
+//===----------------------------------------------------------------------===//
+
+def IREECodegen_LoadFromMemrefOp : Op<IREECodegen_Dialect, "load_from_memref",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+  let summary = [{loads a tensor from a memref}];
+  let description = [{
+    Loads a tensor from a memref with the same shape and element type. The
+    read_only attribute indicates that the source buffer from which the tensor
+    is read is a read only buffer. This hint can be used by bufferization to
+    determine whether or not the buffer that this op reads from may be written.
+  }];
+
+  let arguments = (ins
+    AnyStridedMemRef:$source,
+    UnitAttr:$read_only
+  );
+  let results = (outs
+    AnyRankedTensor:$result
+  );
+
+  let assemblyFormat = [{
+    $source attr-dict `:` type($source) `->` type($result)
+  }];
+
+  let hasVerifier = 1;
+}
+
+def IREECodegen_StoreToMemrefOp : Op<IREECodegen_Dialect, "store_to_memref",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+  let summary = [{stores a tensor into a memref}];
+  let description = [{
+    Stores a tensor into a memref with the same shape and element type.
+  }];
+
+  let arguments = (ins
+    AnyRankedTensor:$value,
+    AnyStridedMemRef:$target
+  );
+  let results = (outs);
+
+  let assemblyFormat = [{
+    $value `,` $target
+    attr-dict `:` type($value) `into` type($target)
+  }];
+
+  let hasVerifier = 1;
+}
 
 #endif // IREE_CODEGEN_DIALECT_IREECODEGENOPS

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
@@ -179,10 +179,11 @@ def IREECodegen_LoadFromMemrefOp : Op<IREECodegen_Dialect, "load_from_memref",
     [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = [{loads a tensor from a memref}];
   let description = [{
-    Loads a tensor from a memref with the same shape and element type. The
-    read_only attribute indicates that the source buffer from which the tensor
-    is read is a read only buffer. This hint can be used by bufferization to
-    determine whether or not the buffer that this op reads from may be written.
+    Loads a tensor from a memref with a compatible shape and the same element
+    type. The read_only attribute indicates that the source buffer from which
+    the tensor is read is a read only buffer. This hint can be used by
+    bufferization to determine whether or not the buffer that this op reads
+    from may be written.
   }];
 
   let arguments = (ins
@@ -204,7 +205,8 @@ def IREECodegen_StoreToMemrefOp : Op<IREECodegen_Dialect, "store_to_memref",
     [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = [{stores a tensor into a memref}];
   let description = [{
-    Stores a tensor into a memref with the same shape and element type.
+    Stores a tensor into a memref with a compatible shape and the same element
+    type.
   }];
 
   let arguments = (ins

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/BUILD.bazel
@@ -20,6 +20,7 @@ iree_lit_test_suite(
         [
             "invalid.mlir",
             "lowering_config_attr.mlir",
+            "roundtrip.mlir",
             "ukernel_ops.mlir",
             "ukernel_ops_cse.mlir",
             "workgroup_mapping_attrs.mlir",

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_lit_test_suite(
   SRCS
     "invalid.mlir"
     "lowering_config_attr.mlir"
+    "roundtrip.mlir"
     "ukernel_ops.mlir"
     "ukernel_ops_cse.mlir"
     "workgroup_mapping_attrs.mlir"

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/invalid.mlir
@@ -21,14 +21,6 @@ func.func @load_from_memref_invalid_shape(%arg0: memref<5xf32>) -> tensor<4xf32>
 
 // -----
 
-func.func @load_from_memref_mixed_static_dynamic_shape(%arg0: memref<?xf32>) -> tensor<4xf32> {
-  // expected-error @+1 {{source and result shape and element type must match}}
-  %value = iree_codegen.load_from_memref %arg0 : memref<?xf32> -> tensor<4xf32>
-  return %value : tensor<4xf32>
-}
-
-// -----
-
 func.func @load_from_memref_invalid_element_type(%arg0: memref<4xf32>) -> tensor<4xf16> {
   // expected-error @+1 {{source and result shape and element type must match}}
   %value = iree_codegen.load_from_memref %arg0 : memref<4xf32> -> tensor<4xf16>
@@ -40,14 +32,6 @@ func.func @load_from_memref_invalid_element_type(%arg0: memref<4xf32>) -> tensor
 func.func @store_to_memref_invalid_shape(%arg0: tensor<4xf32>, %arg1: memref<5xf32>) {
   // expected-error @+1 {{value and target shape and element type must match}}
   iree_codegen.store_to_memref %arg0, %arg1 : tensor<4xf32> into memref<5xf32>
-  return
-}
-
-// -----
-
-func.func @store_to_memref_mixed_static_dynamic_shape(%arg0: tensor<?xf32>, %arg1: memref<4xf32>) {
-  // expected-error @+1 {{value and target shape and element type must match}}
-  iree_codegen.store_to_memref %arg0, %arg1 : tensor<?xf32> into memref<4xf32>
   return
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/invalid.mlir
@@ -10,3 +10,35 @@ module {
     return
   }
 }
+
+// -----
+
+func.func @load_from_memref_invalid_shape(%arg0: memref<5xf32>) -> tensor<4xf32> {
+  // expected-error @+1 {{source and result shape and element type must match}}
+  %value = iree_codegen.load_from_memref %arg0 : memref<5xf32> -> tensor<4xf32>
+  return %value : tensor<4xf32>
+}
+
+// -----
+
+func.func @load_from_memref_invalid_element_type(%arg0: memref<4xf32>) -> tensor<4xf16> {
+  // expected-error @+1 {{source and result shape and element type must match}}
+  %value = iree_codegen.load_from_memref %arg0 : memref<4xf32> -> tensor<4xf16>
+  return %value : tensor<4xf16>
+}
+
+// -----
+
+func.func @store_to_memref_invalid_shape(%arg0: tensor<4xf32>, %arg1: memref<5xf32>) {
+  // expected-error @+1 {{value and target shape and element type must match}}
+  iree_codegen.store_to_memref %arg0, %arg1 : tensor<4xf32> into memref<5xf32>
+  return
+}
+
+// -----
+
+func.func @store_to_memref_invalid_element_type(%arg0: tensor<4xf16>, %arg1: memref<4xf32>) {
+  // expected-error @+1 {{value and target shape and element type must match}}
+  iree_codegen.store_to_memref %arg0, %arg1 : tensor<4xf16> into memref<4xf32>
+  return
+}

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/invalid.mlir
@@ -14,7 +14,7 @@ module {
 // -----
 
 func.func @load_from_memref_invalid_shape(%arg0: memref<5xf32>) -> tensor<4xf32> {
-  // expected-error @+1 {{source and result shape and element type must match}}
+  // expected-error @+1 {{source and result shapes must be compatible and element types must match}}
   %value = iree_codegen.load_from_memref %arg0 : memref<5xf32> -> tensor<4xf32>
   return %value : tensor<4xf32>
 }
@@ -22,7 +22,7 @@ func.func @load_from_memref_invalid_shape(%arg0: memref<5xf32>) -> tensor<4xf32>
 // -----
 
 func.func @load_from_memref_invalid_element_type(%arg0: memref<4xf32>) -> tensor<4xf16> {
-  // expected-error @+1 {{source and result shape and element type must match}}
+  // expected-error @+1 {{source and result shapes must be compatible and element types must match}}
   %value = iree_codegen.load_from_memref %arg0 : memref<4xf32> -> tensor<4xf16>
   return %value : tensor<4xf16>
 }
@@ -30,7 +30,7 @@ func.func @load_from_memref_invalid_element_type(%arg0: memref<4xf32>) -> tensor
 // -----
 
 func.func @store_to_memref_invalid_shape(%arg0: tensor<4xf32>, %arg1: memref<5xf32>) {
-  // expected-error @+1 {{value and target shape and element type must match}}
+  // expected-error @+1 {{value and target shapes must be compatible and element types must match}}
   iree_codegen.store_to_memref %arg0, %arg1 : tensor<4xf32> into memref<5xf32>
   return
 }
@@ -38,7 +38,7 @@ func.func @store_to_memref_invalid_shape(%arg0: tensor<4xf32>, %arg1: memref<5xf
 // -----
 
 func.func @store_to_memref_invalid_element_type(%arg0: tensor<4xf16>, %arg1: memref<4xf32>) {
-  // expected-error @+1 {{value and target shape and element type must match}}
+  // expected-error @+1 {{value and target shapes must be compatible and element types must match}}
   iree_codegen.store_to_memref %arg0, %arg1 : tensor<4xf16> into memref<4xf32>
   return
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/invalid.mlir
@@ -21,6 +21,14 @@ func.func @load_from_memref_invalid_shape(%arg0: memref<5xf32>) -> tensor<4xf32>
 
 // -----
 
+func.func @load_from_memref_mixed_static_dynamic_shape(%arg0: memref<?xf32>) -> tensor<4xf32> {
+  // expected-error @+1 {{source and result shape and element type must match}}
+  %value = iree_codegen.load_from_memref %arg0 : memref<?xf32> -> tensor<4xf32>
+  return %value : tensor<4xf32>
+}
+
+// -----
+
 func.func @load_from_memref_invalid_element_type(%arg0: memref<4xf32>) -> tensor<4xf16> {
   // expected-error @+1 {{source and result shape and element type must match}}
   %value = iree_codegen.load_from_memref %arg0 : memref<4xf32> -> tensor<4xf16>
@@ -32,6 +40,14 @@ func.func @load_from_memref_invalid_element_type(%arg0: memref<4xf32>) -> tensor
 func.func @store_to_memref_invalid_shape(%arg0: tensor<4xf32>, %arg1: memref<5xf32>) {
   // expected-error @+1 {{value and target shape and element type must match}}
   iree_codegen.store_to_memref %arg0, %arg1 : tensor<4xf32> into memref<5xf32>
+  return
+}
+
+// -----
+
+func.func @store_to_memref_mixed_static_dynamic_shape(%arg0: tensor<?xf32>, %arg1: memref<4xf32>) {
+  // expected-error @+1 {{value and target shape and element type must match}}
+  iree_codegen.store_to_memref %arg0, %arg1 : tensor<?xf32> into memref<4xf32>
   return
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
@@ -1,0 +1,74 @@
+// RUN: iree-opt --split-input-file %s | FileCheck %s
+
+func.func @load_from_memref(%arg0: memref<4xf32>) -> tensor<4xf32> {
+  %value = iree_codegen.load_from_memref %arg0 : memref<4xf32> -> tensor<4xf32>
+  return %value : tensor<4xf32>
+}
+// CHECK-LABEL: func.func @load_from_memref(
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]
+// CHECK:         iree_codegen.load_from_memref %[[ARG0]]
+// CHECK-SAME:      : memref<4xf32> -> tensor<4xf32>
+
+// -----
+
+func.func @load_from_memref_mixed_static_dynamic(%arg0: memref<?x4xf32>) -> tensor<4x?xf32> {
+  %value = iree_codegen.load_from_memref %arg0 : memref<?x4xf32> -> tensor<4x?xf32>
+  return %value : tensor<4x?xf32>
+}
+// CHECK-LABEL: func.func @load_from_memref_mixed_static_dynamic(
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]
+// CHECK:         iree_codegen.load_from_memref %[[ARG0]]
+// CHECK-SAME:      : memref<?x4xf32> -> tensor<4x?xf32>
+
+// -----
+
+func.func @load_from_strided_memref(
+    %arg0: memref<?x?xf32, strided<[?, 1], offset: ?>>
+) -> tensor<?x?xf32> {
+  %value = iree_codegen.load_from_memref %arg0
+    : memref<?x?xf32, strided<[?, 1], offset: ?>> -> tensor<?x?xf32>
+  return %value : tensor<?x?xf32>
+}
+// CHECK-LABEL: func.func @load_from_strided_memref(
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]:
+// CHECK:         iree_codegen.load_from_memref %[[ARG0]]
+// CHECK-SAME:      : memref<?x?xf32, strided<[?, 1], offset: ?>> -> tensor<?x?xf32>
+
+// -----
+
+func.func @store_to_memref(%arg0: tensor<4xf32>, %arg1: memref<4xf32>) {
+  iree_codegen.store_to_memref %arg0, %arg1 : tensor<4xf32> into memref<4xf32>
+  return
+}
+// CHECK-LABEL: func.func @store_to_memref(
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]+]]
+// CHECK:         iree_codegen.store_to_memref %[[ARG0]], %[[ARG1]]
+// CHECK-SAME:      : tensor<4xf32> into memref<4xf32>
+
+// -----
+
+func.func @store_to_memref_mixed_static_dynamic(%arg0: tensor<4x?xf32>, %arg1: memref<?x4xf32>) {
+  iree_codegen.store_to_memref %arg0, %arg1 : tensor<4x?xf32> into memref<?x4xf32>
+  return
+}
+// CHECK-LABEL: func.func @store_to_memref_mixed_static_dynamic(
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]+]]
+// CHECK:         iree_codegen.store_to_memref %[[ARG0]], %[[ARG1]]
+// CHECK-SAME:      : tensor<4x?xf32> into memref<?x4xf32>
+
+// -----
+
+func.func @store_to_strided_memref(
+    %arg0: tensor<?x?xf32>, %arg1: memref<?x?xf32, strided<[?, 1], offset: ?>>
+) {
+  iree_codegen.store_to_memref %arg0, %arg1
+    : tensor<?x?xf32> into memref<?x?xf32, strided<[?, 1], offset: ?>>
+  return
+}
+// CHECK-LABEL: func.func @store_to_strided_memref(
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]:
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]+]]:
+// CHECK:         iree_codegen.store_to_memref %[[ARG0]], %[[ARG1]]
+// CHECK-SAME:      : tensor<?x?xf32> into memref<?x?xf32, strided<[?, 1], offset: ?>>

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
@@ -11,14 +11,14 @@ func.func @load_from_memref(%arg0: memref<4xf32>) -> tensor<4xf32> {
 
 // -----
 
-func.func @load_from_memref_mixed_static_dynamic(%arg0: memref<?x4xf32>) -> tensor<4x?xf32> {
-  %value = iree_codegen.load_from_memref %arg0 : memref<?x4xf32> -> tensor<4x?xf32>
-  return %value : tensor<4x?xf32>
+func.func @load_from_memref_read_only(%arg0: memref<4xf32>) -> tensor<4xf32> {
+  %value = iree_codegen.load_from_memref %arg0 {read_only} : memref<4xf32> -> tensor<4xf32>
+  return %value : tensor<4xf32>
 }
-// CHECK-LABEL: func.func @load_from_memref_mixed_static_dynamic(
+// CHECK-LABEL: func.func @load_from_memref_read_only(
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]
-// CHECK:         iree_codegen.load_from_memref %[[ARG0]]
-// CHECK-SAME:      : memref<?x4xf32> -> tensor<4x?xf32>
+// CHECK:         iree_codegen.load_from_memref %[[ARG0]] {read_only}
+// CHECK-SAME:      : memref<4xf32> -> tensor<4xf32>
 
 // -----
 
@@ -45,18 +45,6 @@ func.func @store_to_memref(%arg0: tensor<4xf32>, %arg1: memref<4xf32>) {
 // CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]+]]
 // CHECK:         iree_codegen.store_to_memref %[[ARG0]], %[[ARG1]]
 // CHECK-SAME:      : tensor<4xf32> into memref<4xf32>
-
-// -----
-
-func.func @store_to_memref_mixed_static_dynamic(%arg0: tensor<4x?xf32>, %arg1: memref<?x4xf32>) {
-  iree_codegen.store_to_memref %arg0, %arg1 : tensor<4x?xf32> into memref<?x4xf32>
-  return
-}
-// CHECK-LABEL: func.func @store_to_memref_mixed_static_dynamic(
-// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]
-// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]+]]
-// CHECK:         iree_codegen.store_to_memref %[[ARG0]], %[[ARG1]]
-// CHECK-SAME:      : tensor<4x?xf32> into memref<?x4xf32>
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
@@ -22,6 +22,17 @@ func.func @load_from_memref_read_only(%arg0: memref<4xf32>) -> tensor<4xf32> {
 
 // -----
 
+func.func @load_from_memref_mixed_static_dynamic(%arg0: memref<?x4xf32>) -> tensor<4x?xf32> {
+  %value = iree_codegen.load_from_memref %arg0 : memref<?x4xf32> -> tensor<4x?xf32>
+  return %value : tensor<4x?xf32>
+}
+// CHECK-LABEL: func.func @load_from_memref_mixed_static_dynamic(
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]
+// CHECK:         iree_codegen.load_from_memref %[[ARG0]]
+// CHECK-SAME:      : memref<?x4xf32> -> tensor<4x?xf32>
+
+// -----
+
 func.func @load_from_strided_memref(
     %arg0: memref<?x?xf32, strided<[?, 1], offset: ?>>
 ) -> tensor<?x?xf32> {
@@ -45,6 +56,18 @@ func.func @store_to_memref(%arg0: tensor<4xf32>, %arg1: memref<4xf32>) {
 // CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]+]]
 // CHECK:         iree_codegen.store_to_memref %[[ARG0]], %[[ARG1]]
 // CHECK-SAME:      : tensor<4xf32> into memref<4xf32>
+
+// -----
+
+func.func @store_to_memref_mixed_static_dynamic(%arg0: tensor<4x?xf32>, %arg1: memref<?x4xf32>) {
+  iree_codegen.store_to_memref %arg0, %arg1 : tensor<4x?xf32> into memref<?x4xf32>
+  return
+}
+// CHECK-LABEL: func.func @store_to_memref_mixed_static_dynamic(
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]+]]
+// CHECK:         iree_codegen.store_to_memref %[[ARG0]], %[[ARG1]]
+// CHECK-SAME:      : tensor<4x?xf32> into memref<?x4xf32>
 
 // -----
 


### PR DESCRIPTION
This PR adds 2 new ops to go from tensors to memrefs and memrefs to tensors. The new ops are:

 - `iree_codegen.load_from_memref` - Loads a tensor from a memref with the same shape and element type.
 - `iree_codegen.store_to_memref` - Stores a tensor to a memref with the same shape and element type.

These ops can be used to bufferize hal.interface.subspan and iree_tensor_ext.dispatch.tensor.store ops early on, which allows for certain transformations that are only possible with memref semantics to happen without needing to bufferize the entire dispatch.

This PR only adds the basic op definitions, and various op interface implementations (bufferization, subset insertion, etc.) will come as follow-ups.