### PR TITLE
[Codegen] Support bufferization for load_from/store_to_memref ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/eliminate_empty_tensors.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/eliminate_empty_tensors.mlir
@@ -31,3 +31,38 @@ func.func @eliminate_empty_tensors_with_store_op() {
 // CHECK:   %[[LOAD:.+]] = iree_tensor_ext.dispatch.tensor.load %[[SPAN]], offsets = [%[[ARG0]], 0]
 // CHECK:   %[[RES:.+]] = scf.for %{{.+}} = %[[C0]] to %[[C32]] step %[[C8]] iter_args(%{{.+}} = %[[LOAD]])
 // CHECK:   iree_tensor_ext.dispatch.tensor.store %[[RES]], %[[SPAN]]
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @eliminate_empty_tensors_with_store_to_memref_op() {
+  %c0 = arith.constant 0 : index
+  %c8 = arith.constant 8 : index
+  %c32 = arith.constant 32 : index
+  %c128 = arith.constant 128 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<128x384xf32, #hal.descriptor_type<storage_buffer>>
+  memref.assume_alignment %0, 64 : memref<128x384xf32, #hal.descriptor_type<storage_buffer>>
+  %1 = tensor.empty() : tensor<32x384xf32>
+  scf.for %arg0 = %c0 to %c128 step %c32 {
+    %subview = memref.subview %0[%arg0, 0] [32, 384] [1, 1] : memref<128x384xf32, #hal.descriptor_type<storage_buffer>> to memref<32x384xf32, strided<[384, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>
+    %2 = scf.for %arg1 = %c0 to %c32 step %c8 iter_args(%arg2 = %1) -> (tensor<32x384xf32>) {
+      scf.yield %arg2 : tensor<32x384xf32>
+    }
+    iree_codegen.store_to_memref %2, %subview : tensor<32x384xf32> into memref<32x384xf32, strided<[384, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>
+  }
+  return
+}
+
+// CHECK-LABEL: @eliminate_empty_tensors_with_store_to_memref_op
+// CHECK: %[[C0:.+]] = arith.constant 0 : index
+// CHECK: %[[C8:.+]] = arith.constant 8 : index
+// CHECK: %[[C32:.+]] = arith.constant 32 : index
+// CHECK: %[[C128:.+]] = arith.constant 128 : index
+// CHECK: %[[SPAN:.+]] = hal.interface.binding.subspan
+// CHECK: scf.for %[[ARG0:.+]] = %[[C0]] to %[[C128]] step %[[C32]]
+// CHECK:   %[[SUBVIEW:.+]] = memref.subview %[[SPAN]][%[[ARG0]], 0]
+// CHECK:   %[[LOAD:.+]] = iree_codegen.load_from_memref %[[SUBVIEW]]
+// CHECK:   %[[RES:.+]] = scf.for %{{.+}} = %[[C0]] to %[[C32]] step %[[C8]] iter_args(%{{.+}} = %[[LOAD]])
+// CHECK:   iree_codegen.store_to_memref %[[RES]], %[[SUBVIEW]]

--- a/compiler/src/iree/compiler/Codegen/Common/test/eliminate_empty_tensors.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/eliminate_empty_tensors.mlir
@@ -35,34 +35,24 @@ func.func @eliminate_empty_tensors_with_store_op() {
 // -----
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
 func.func @eliminate_empty_tensors_with_store_to_memref_op() {
   %c0 = arith.constant 0 : index
-  %c8 = arith.constant 8 : index
-  %c32 = arith.constant 32 : index
-  %c128 = arith.constant 128 : index
-  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<128x384xf32, #hal.descriptor_type<storage_buffer>>
-  memref.assume_alignment %0, 64 : memref<128x384xf32, #hal.descriptor_type<storage_buffer>>
-  %1 = tensor.empty() : tensor<32x384xf32>
-  scf.for %arg0 = %c0 to %c128 step %c32 {
-    %subview = memref.subview %0[%arg0, 0] [32, 384] [1, 1] : memref<128x384xf32, #hal.descriptor_type<storage_buffer>> to memref<32x384xf32, strided<[384, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>
-    %2 = scf.for %arg1 = %c0 to %c32 step %c8 iter_args(%arg2 = %1) -> (tensor<32x384xf32>) {
-      scf.yield %arg2 : tensor<32x384xf32>
-    }
-    iree_codegen.store_to_memref %2, %subview : tensor<32x384xf32> into memref<32x384xf32, strided<[384, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>
-  }
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<128xf32, #hal.descriptor_type<storage_buffer>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : memref<128xf32, #hal.descriptor_type<storage_buffer>>
+  %2 = iree_codegen.load_from_memref %0 : memref<128xf32, #hal.descriptor_type<storage_buffer>> -> tensor<128xf32>
+  %3 = tensor.empty() : tensor<128xf32>
+  %copy = linalg.copy ins(%2 : tensor<128xf32>) outs(%3 : tensor<128xf32>) -> tensor<128xf32>
+  iree_codegen.store_to_memref %copy, %1 : tensor<128xf32> into memref<128xf32, #hal.descriptor_type<storage_buffer>>
   return
 }
 
 // CHECK-LABEL: @eliminate_empty_tensors_with_store_to_memref_op
-// CHECK: %[[C0:.+]] = arith.constant 0 : index
-// CHECK: %[[C8:.+]] = arith.constant 8 : index
-// CHECK: %[[C32:.+]] = arith.constant 32 : index
-// CHECK: %[[C128:.+]] = arith.constant 128 : index
-// CHECK: %[[SPAN:.+]] = hal.interface.binding.subspan
-// CHECK: scf.for %[[ARG0:.+]] = %[[C0]] to %[[C128]] step %[[C32]]
-// CHECK:   %[[SUBVIEW:.+]] = memref.subview %[[SPAN]][%[[ARG0]], 0]
-// CHECK:   %[[LOAD:.+]] = iree_codegen.load_from_memref %[[SUBVIEW]]
-// CHECK:   %[[RES:.+]] = scf.for %{{.+}} = %[[C0]] to %[[C32]] step %[[C8]] iter_args(%{{.+}} = %[[LOAD]])
-// CHECK:   iree_codegen.store_to_memref %[[RES]], %[[SUBVIEW]]
+//     CHECK: %[[INPUT_SPAN:.+]] = hal.interface.binding.subspan{{.*}}binding(0)
+//     CHECK: %[[RESULT_SPAN:.+]] = hal.interface.binding.subspan{{.*}}binding(1)
+// CHECK-DAG: %[[INPUT:.+]] = iree_codegen.load_from_memref %[[INPUT_SPAN]]
+// CHECK-DAG: %[[INIT:.+]] = iree_codegen.load_from_memref %[[RESULT_SPAN]]
+//     CHECK: %[[COPY:.+]] = linalg.copy ins(%[[INPUT]] : tensor<128xf32>) outs(%[[INIT]] : tensor<128xf32>)
+//     CHECK: iree_codegen.store_to_memref %[[COPY]], %[[RESULT_SPAN]]

--- a/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
@@ -2948,3 +2948,61 @@ func.func @check_no_alloc() {
 }
 // CHECK-LABEL: func @check_no_alloc
 //   CHECK-NOT:   memref.alloc
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @load_from_memref_store_to_memref() {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<128xf32, #hal.descriptor_type<storage_buffer>>
+  memref.assume_alignment %0, 64 : memref<128xf32, #hal.descriptor_type<storage_buffer>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : memref<128xf32, #hal.descriptor_type<storage_buffer>>
+  memref.assume_alignment %1, 64 : memref<128xf32, #hal.descriptor_type<storage_buffer>>
+  %2 = iree_codegen.load_from_memref %0 {read_only} : memref<128xf32, #hal.descriptor_type<storage_buffer>> -> tensor<128xf32>
+  iree_codegen.store_to_memref %2, %1 : tensor<128xf32> into memref<128xf32, #hal.descriptor_type<storage_buffer>>
+  return
+}
+
+// CHECK-LABEL: func.func @load_from_memref_store_to_memref()
+//   CHECK-DAG:   %[[INPUT:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)
+//   CHECK-DAG:   %[[OUTPUT:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)
+//       CHECK:   linalg.generic
+//  CHECK-SAME:       ins(%[[INPUT]] :
+//  CHECK-SAME:       outs(%[[OUTPUT]] :
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @load_from_memref_store_to_memref_in_place() {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<128x384xf32, #hal.descriptor_type<storage_buffer>>
+  memref.assume_alignment %0, 64 : memref<128x384xf32, #hal.descriptor_type<storage_buffer>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : memref<128x384xf32, #hal.descriptor_type<storage_buffer>>
+  memref.assume_alignment %1, 64 : memref<128x384xf32, #hal.descriptor_type<storage_buffer>>
+  %2 = iree_codegen.load_from_memref %0 {read_only} : memref<128x384xf32, #hal.descriptor_type<storage_buffer>> -> tensor<128x384xf32>
+  %3 = iree_codegen.load_from_memref %1 : memref<128x384xf32, #hal.descriptor_type<storage_buffer>> -> tensor<128x384xf32>
+  %forall = scf.forall (%arg0) in (128) shared_outs(%arg1 = %3) -> (tensor<128x384xf32>) {
+    %input = tensor.extract_slice %2[%arg0, 0] [1, 384] [1, 1] : tensor<128x384xf32> to tensor<384xf32>
+    %init = tensor.extract_slice %arg1[%arg0, 0] [1, 384] [1, 1] : tensor<128x384xf32> to tensor<384xf32>
+    %copy = linalg.copy ins(%input : tensor<384xf32>) outs(%init : tensor<384xf32>) -> tensor<384xf32>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %copy into %arg1[%arg0, 0] [1, 384] [1, 1] : tensor<384xf32> into tensor<128x384xf32>
+    }
+  } {mapping = [#iree_codegen.workgroup_mapping<x>]}
+  iree_codegen.store_to_memref %forall, %1 : tensor<128x384xf32> into memref<128x384xf32, #hal.descriptor_type<storage_buffer>>
+  return
+}
+
+// CHECK-LABEL: func.func @load_from_memref_store_to_memref_in_place()
+//   CHECK-DAG:   %[[INPUT:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)
+//   CHECK-DAG:   %[[OUTPUT:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)
+//       CHECK:   scf.forall (%[[ARG0:.+]]) in (128)
+//   CHECK-DAG:     %[[INPUT_TILE:.+]] = memref.subview %[[INPUT]][%[[ARG0]], 0] [1, 384] [1, 1]
+//   CHECK-DAG:     %[[OUTPUT_TILE:.+]] = memref.subview %[[OUTPUT]][%[[ARG0]], 0] [1, 384] [1, 1]
+//       CHECK:     linalg.copy ins(%[[INPUT_TILE]] {{.*}} outs(%[[OUTPUT_TILE]]

--- a/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
@@ -2958,9 +2958,7 @@ func.func @check_no_alloc() {
 func.func @load_from_memref_store_to_memref() {
   %c0 = arith.constant 0 : index
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<128xf32, #hal.descriptor_type<storage_buffer>>
-  memref.assume_alignment %0, 64 : memref<128xf32, #hal.descriptor_type<storage_buffer>>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : memref<128xf32, #hal.descriptor_type<storage_buffer>>
-  memref.assume_alignment %1, 64 : memref<128xf32, #hal.descriptor_type<storage_buffer>>
   %2 = iree_codegen.load_from_memref %0 {read_only} : memref<128xf32, #hal.descriptor_type<storage_buffer>> -> tensor<128xf32>
   iree_codegen.store_to_memref %2, %1 : tensor<128xf32> into memref<128xf32, #hal.descriptor_type<storage_buffer>>
   return
@@ -2982,10 +2980,8 @@ func.func @load_from_memref_store_to_memref() {
 func.func @load_from_memref_store_to_memref_in_place() {
   %c0 = arith.constant 0 : index
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<128x384xf32, #hal.descriptor_type<storage_buffer>>
-  memref.assume_alignment %0, 64 : memref<128x384xf32, #hal.descriptor_type<storage_buffer>>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : memref<128x384xf32, #hal.descriptor_type<storage_buffer>>
-  memref.assume_alignment %1, 64 : memref<128x384xf32, #hal.descriptor_type<storage_buffer>>
-  %2 = iree_codegen.load_from_memref %0 {read_only} : memref<128x384xf32, #hal.descriptor_type<storage_buffer>> -> tensor<128x384xf32>
+  %2 = iree_codegen.load_from_memref %0 : memref<128x384xf32, #hal.descriptor_type<storage_buffer>> -> tensor<128x384xf32>
   %3 = iree_codegen.load_from_memref %1 : memref<128x384xf32, #hal.descriptor_type<storage_buffer>> -> tensor<128x384xf32>
   %forall = scf.forall (%arg0) in (128) shared_outs(%arg1 = %3) -> (tensor<128x384xf32>) {
     %input = tensor.extract_slice %2[%arg0, 0] [1, 384] [1, 1] : tensor<128x384xf32> to tensor<384xf32>
@@ -3006,3 +3002,30 @@ func.func @load_from_memref_store_to_memref_in_place() {
 //   CHECK-DAG:     %[[INPUT_TILE:.+]] = memref.subview %[[INPUT]][%[[ARG0]], 0] [1, 384] [1, 1]
 //   CHECK-DAG:     %[[OUTPUT_TILE:.+]] = memref.subview %[[OUTPUT]][%[[ARG0]], 0] [1, 384] [1, 1]
 //       CHECK:     linalg.copy ins(%[[INPUT_TILE]] {{.*}} outs(%[[OUTPUT_TILE]]
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer>,
+  #hal.pipeline.binding<storage_buffer>
+]>
+func.func @load_from_memref_read_only_copy() {
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : memref<128xf32, #hal.descriptor_type<storage_buffer>>
+  %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : memref<128xf32, #hal.descriptor_type<storage_buffer>>
+  %2 = iree_codegen.load_from_memref %0 : memref<128xf32, #hal.descriptor_type<storage_buffer>> -> tensor<128xf32>
+  %copy = linalg.copy ins(%2 : tensor<128xf32>) outs(%2 : tensor<128xf32>) -> tensor<128xf32>
+  iree_codegen.store_to_memref %copy, %1 : tensor<128xf32> into memref<128xf32, #hal.descriptor_type<storage_buffer>>
+  return
+}
+
+// CHECK-LABEL: func.func @load_from_memref_read_only_copy()
+//   CHECK-DAG:   %[[READ_ONLY_BUFFER:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)
+//   CHECK-DAG:   %[[OUTPUT:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)
+//   CHECK-DAG:   %[[ALLOC:.+]] = memref.alloc() : memref<128xf32>
+//       CHECK:   linalg.copy
+//  CHECK-SAME:       ins(%[[READ_ONLY_BUFFER]] :
+//  CHECK-SAME:       outs(%[[ALLOC]] :
+//       CHECK:   linalg.generic
+//  CHECK-SAME:       ins(%[[ALLOC]] :
+//  CHECK-SAME:       outs(%[[OUTPUT]] :

--- a/compiler/src/iree/compiler/Codegen/Interfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BUILD.bazel
@@ -88,6 +88,7 @@ iree_compiler_cc_library(
         "BufferizationInterfaces.h",
     ],
     deps = [
+        "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/IR:IREEGPUDialect",
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms:BufferizationInterfaces",
         "//compiler/src/iree/compiler/Codegen/Utils",

--- a/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
@@ -6,6 +6,8 @@
 
 #include "iree/compiler/Codegen/Interfaces/BufferizationInterfaces.h"
 
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
 #include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUDialect.h"
 #include "iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
@@ -282,6 +284,62 @@ struct DispatchTensorStoreOpInterface
     // target buffer already. The copy folds away in that case.
     if (failed(options.createMemCpy(rewriter, storeOp->getLoc(), srcMemref,
                                     target)))
+      return failure();
+
+    rewriter.eraseOp(storeOp);
+    return success();
+  }
+};
+
+struct LoadFromMemrefOpInterface
+    : public BufferizableOpInterface::ExternalModel<
+          LoadFromMemrefOpInterface, IREE::Codegen::LoadFromMemrefOp> {
+  bool isWritable(Operation *op, Value value,
+                  const AnalysisState &state) const {
+    auto loadOp = cast<IREE::Codegen::LoadFromMemrefOp>(op);
+    return !loadOp.getReadOnly();
+  }
+
+  LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
+                          const BufferizationOptions &options) const {
+    auto loadOp = cast<IREE::Codegen::LoadFromMemrefOp>(op);
+    replaceOpWithBufferizedValues(rewriter, op, loadOp.getSource());
+    return success();
+  }
+};
+
+struct StoreToMemrefOpInterface
+    : public BufferizableOpInterface::ExternalModel<
+          StoreToMemrefOpInterface, IREE::Codegen::StoreToMemrefOp> {
+  bool bufferizesToMemoryRead(Operation *op, OpOperand &opOperand,
+                              const AnalysisState &state) const {
+    return true;
+  }
+
+  bool bufferizesToMemoryWrite(Operation *op, OpOperand &opOperand,
+                               const AnalysisState &state) const {
+    return false;
+  }
+
+  bufferization::AliasingValueList
+  getAliasingValues(Operation *op, OpOperand &opOperand,
+                    const AnalysisState &state) const {
+    return {};
+  }
+
+  LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
+                          const BufferizationOptions &options) const {
+    auto storeOp = cast<IREE::Codegen::StoreToMemrefOp>(op);
+    FailureOr<Value> maybeBuffer =
+        getBuffer(rewriter, storeOp.getValue(), options);
+    if (failed(maybeBuffer))
+      return failure();
+    Value srcMemref = *maybeBuffer;
+
+    // If everything bufferized inplace, no copy is needed. We wrote to the
+    // target buffer already. The copy folds away in that case.
+    if (failed(options.createMemCpy(rewriter, storeOp.getLoc(), srcMemref,
+                                    storeOp.getTarget())))
       return failure();
 
     rewriter.eraseOp(storeOp);
@@ -610,6 +668,87 @@ struct DispatchTensorStoreOpSubsetInsertionInterface
   }
 };
 
+struct LoadFromMemrefOpSubsetInterface
+    : public SubsetOpInterface::ExternalModel<LoadFromMemrefOpSubsetInterface,
+                                              IREE::Codegen::LoadFromMemrefOp> {
+  bool operatesOnEquivalentSubset(
+      Operation *op, SubsetOpInterface candidate,
+      function_ref<bool(Value, Value)> equivalenceFn) const {
+    auto loadOp = cast<IREE::Codegen::LoadFromMemrefOp>(op);
+    Operation *otherOp = candidate.getOperation();
+    if (auto storeOp = dyn_cast<IREE::Codegen::StoreToMemrefOp>(otherOp)) {
+      return equivalenceFn(loadOp.getSource(), storeOp.getTarget());
+    }
+    if (auto otherLoadOp = dyn_cast<IREE::Codegen::LoadFromMemrefOp>(otherOp)) {
+      return equivalenceFn(loadOp.getSource(), otherLoadOp.getSource());
+    }
+    return false;
+  }
+
+  bool operatesOnDisjointSubset(
+      Operation *op, SubsetOpInterface candidate,
+      function_ref<bool(Value, Value)> equivalenceFn) const {
+    // TODO: This is a new entry point and not clear it is correct.
+    return false;
+  }
+};
+
+struct StoreToMemrefOpSubsetInterface
+    : public SubsetOpInterface::ExternalModel<StoreToMemrefOpSubsetInterface,
+                                              IREE::Codegen::StoreToMemrefOp> {
+
+  bool operatesOnEquivalentSubset(
+      Operation *op, SubsetOpInterface candidate,
+      function_ref<bool(Value, Value)> equivalenceFn) const {
+    // Returns true if the value of a `storeOp` bufferizes to an equivalent
+    // DispatchTensorLoadOp result that bufferizes inplace.
+    auto storeOp = cast<IREE::Codegen::StoreToMemrefOp>(op);
+    Operation *otherOp = candidate.getOperation();
+    if (auto otherStoreOp = dyn_cast<IREE::Codegen::StoreToMemrefOp>(otherOp)) {
+      return equivalenceFn(storeOp.getTarget(), otherStoreOp.getTarget());
+    }
+    if (auto loadOp = dyn_cast<IREE::Codegen::LoadFromMemrefOp>(otherOp)) {
+      return equivalenceFn(storeOp.getTarget(), loadOp.getSource());
+    }
+    return false;
+  }
+
+  bool operatesOnDisjointSubset(
+      Operation *op, SubsetOpInterface candidate,
+      function_ref<bool(Value, Value)> equivalenceFn) const {
+    // TODO: This is a new entry point and not clear it is correct.
+    return false;
+  }
+};
+
+struct StoreToMemrefOpSubsetInsertionInterface
+    : public SubsetInsertionOpInterface::ExternalModel<
+          StoreToMemrefOpSubsetInsertionInterface,
+          IREE::Codegen::StoreToMemrefOp> {
+
+  OpOperand &getSourceOperand(Operation *op) const {
+    return cast<IREE::Codegen::StoreToMemrefOp>(op).getValueMutable();
+  }
+
+  OpOperand &getDestinationOperand(Operation *op) const {
+    return cast<IREE::Codegen::StoreToMemrefOp>(op).getTargetMutable();
+  }
+
+  Value buildSubsetExtraction(Operation *op, OpBuilder &builder,
+                              Location loc) const {
+    auto storeOp = cast<IREE::Codegen::StoreToMemrefOp>(op);
+    auto loadOp = builder.create<IREE::Codegen::LoadFromMemrefOp>(
+        loc, storeOp.getValue().getType(), storeOp.getTarget());
+    return loadOp.getResult();
+  }
+
+  SmallVector<Value>
+  getValuesNeededToBuildSubsetExtraction(Operation *op) const {
+    auto storeOp = cast<IREE::Codegen::StoreToMemrefOp>(op);
+    return {storeOp.getTarget()};
+  }
+};
+
 //===----------------------------------------------------------------------===//
 // IREE specific post analysis transformations.
 //===----------------------------------------------------------------------===//
@@ -639,6 +778,14 @@ void registerBufferizationInterfaces(DialectRegistry &registry) {
             DispatchTensorStoreOpSubsetInterface>(*ctx);
         IREE::TensorExt::DispatchTensorStoreOp::attachInterface<
             DispatchTensorStoreOpSubsetInsertionInterface>(*ctx);
+      });
+  registry.addExtension(
+      +[](MLIRContext *ctx, IREE::Codegen::IREECodegenDialect *dialect) {
+        IREE::Codegen::LoadFromMemrefOp::attachInterface<
+            LoadFromMemrefOpInterface, LoadFromMemrefOpSubsetInterface>(*ctx);
+        IREE::Codegen::StoreToMemrefOp::attachInterface<
+            StoreToMemrefOpInterface, StoreToMemrefOpSubsetInterface,
+            StoreToMemrefOpSubsetInsertionInterface>(*ctx);
       });
   registry.addExtension(+[](MLIRContext *ctx,
                             IREE::LinalgExt::IREELinalgExtDialect *dialect) {

--- a/compiler/src/iree/compiler/Codegen/Interfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/CMakeLists.txt
@@ -76,6 +76,7 @@ iree_cc_library(
     MLIRTensorDialect
     MLIRTensorTransforms
     MLIRVectorTransforms
+    iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
     iree::compiler::Codegen::Dialect::GPU::IR::IREEGPUDialect
     iree::compiler::Codegen::Dialect::GPU::Transforms::BufferizationInterfaces
     iree::compiler::Codegen::Utils


### PR DESCRIPTION
Implements the interfaces needed for bufferization of the `iree_codegen.load_from_memref` and `iree_codegen.store_to_memref` ops. The interface implementations follow what is done for iree_tensor_ext.dispatch.tensor.load/store, but without any logic for offsets, sizes, and strides, since the iree_codegen ops do not have slice semantics.

 - The `iree_codegen.load_from_memref` implements `BufferizableOpInterface` and `SubsetOpInterface`
 - The `iree_codegen.store_to_memref` implements `BufferizableOpInterface`, `SubsetOpInterface`, and `SubsetInsertionOpInterface`

The `iree_comprehensive_bufferize.mlir` lit tests are updated to use the new iree_codegen ops in place of iree_tensor_ext.dispatch.tensor.load/store. Future PRs will add a conversion of dispatch tensor load and store ops into the new iree_codegen ops early on in codegen, so this PR updates the tests to ensure bufferization can handle the new ops.