### PR TITLE
Integrate llvm/llvm-project@0c61b24

### DIFF
--- a/compiler/src/iree/compiler/API/Internal/BUILD.bazel
+++ b/compiler/src/iree/compiler/API/Internal/BUILD.bazel
@@ -35,6 +35,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Tools:version",
         "//compiler/src/iree/compiler/Utils",
         "@llvm-project//llvm:Support",
+        "@llvm-project//llvm:TargetParser",
         "@llvm-project//mlir:BuiltinToLLVMIRTranslation",
         "@llvm-project//mlir:BytecodeWriter",
         "@llvm-project//mlir:CAPIIR",

--- a/compiler/src/iree/compiler/API/Internal/CMakeLists.txt
+++ b/compiler/src/iree/compiler/API/Internal/CMakeLists.txt
@@ -20,6 +20,7 @@ iree_cc_library(
     "Diagnostics.cpp"
   DEPS
     LLVMSupport
+    LLVMTargetParser
     MLIRBuiltinToLLVMIRTranslation
     MLIRBytecodeWriter
     MLIRCAPIIR

--- a/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
+++ b/compiler/src/iree/compiler/API/Internal/CompilerDriver.cpp
@@ -65,6 +65,7 @@
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/ThreadPool.h"
 #include "llvm/Support/ToolOutputFile.h"
+#include "llvm/TargetParser/Host.h"
 #include "mlir/Bytecode/BytecodeWriter.h"
 #include "mlir/CAPI/IR.h"
 #include "mlir/CAPI/Wrap.h"
@@ -1161,11 +1162,11 @@ void llvmVersionPrinter(llvm::raw_ostream &os) {
   os << " with assertions";
 #endif
 #if LLVM_VERSION_PRINTER_SHOW_HOST_TARGET_INFO
-  std::string CPU = std::string(sys::getHostCPUName());
+  std::string CPU = std::string(llvm::sys::getHostCPUName());
   if (CPU == "generic")
     CPU = "(unknown)";
   os << ".\n"
-     << "  Default target: " << sys::getDefaultTargetTriple() << '\n'
+     << "  Default target: " << llvm::sys::getDefaultTargetTriple() << '\n'
      << "  Host CPU: " << CPU;
 #endif
   os << '\n';

--- a/compiler/src/iree/compiler/GlobalOptimization/test/raise_special_ops.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/raise_special_ops.mlir
@@ -341,18 +341,17 @@ util.func public @test_slice_negate_cat_peephole(%arg0: tensor<1x32x1x128xf16>) 
 
 // CHECK-LABEL: util.func public @test_slice_negate_cat_peephole
 //  CHECK-SAME:     %[[ARG0:.+]]: tensor<1x32x1x128xf16>
+//       CHECK:   %[[C0:.+]] = arith.constant 0 : index
 //       CHECK:   %[[C1:.+]] = arith.constant 1 : index
 //       CHECK:   %[[EXPIN:.+]] = tensor.expand_shape %[[ARG0]] {{\[\[}}0], [1], [2], [3, 4]] output_shape [1, 32, 1, 2, 64] : tensor<1x32x1x128xf16> into tensor<1x32x1x2x64xf16>
 //       CHECK:   %[[NREV:.+]] = linalg.generic
 //  CHECK-SAME:       iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]
 
-//       CHECK:      %[[I0:.+]] = linalg.index 0 : index
 //       CHECK:      %[[I1:.+]] = linalg.index 1 : index
-//       CHECK:      %[[I2:.+]] = linalg.index 2 : index
 //       CHECK:      %[[I3:.+]] = linalg.index 3 : index
 //       CHECK:      %[[I4:.+]] = linalg.index 4 : index
 //       CHECK:      %[[R3:.+]] = arith.subi %[[C1]], %[[I3]] : index
-//       CHECK:      %[[EXTR:.+]] = tensor.extract %expanded[%[[I0]], %[[I1]], %[[I2]], %[[R3]], %[[I4]]] : tensor<1x32x1x2x64xf16>
+//       CHECK:      %[[EXTR:.+]] = tensor.extract %expanded[%[[C0]], %[[I1]], %[[C0]], %[[R3]], %[[I4]]] : tensor<1x32x1x2x64xf16>
 //       CHECK:      %[[NEGF:.+]] = arith.negf %[[EXTR]] : f16
 //       CHECK:      %[[CMP:.+]] = arith.cmpi eq, %[[R3]], %[[C1]] : index
 //       CHECK:      %[[SEL:.+]] = arith.select %[[CMP]], %[[NEGF]], %[[EXTR]] : f16

--- a/compiler/src/iree/compiler/GlobalOptimization/test/raise_special_ops.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/raise_special_ops.mlir
@@ -341,17 +341,18 @@ util.func public @test_slice_negate_cat_peephole(%arg0: tensor<1x32x1x128xf16>) 
 
 // CHECK-LABEL: util.func public @test_slice_negate_cat_peephole
 //  CHECK-SAME:     %[[ARG0:.+]]: tensor<1x32x1x128xf16>
-//       CHECK:   %[[C0:.+]] = arith.constant 0 : index
 //       CHECK:   %[[C1:.+]] = arith.constant 1 : index
 //       CHECK:   %[[EXPIN:.+]] = tensor.expand_shape %[[ARG0]] {{\[\[}}0], [1], [2], [3, 4]] output_shape [1, 32, 1, 2, 64] : tensor<1x32x1x128xf16> into tensor<1x32x1x2x64xf16>
 //       CHECK:   %[[NREV:.+]] = linalg.generic
 //  CHECK-SAME:       iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]
 
+//       CHECK:      %[[I0:.+]] = linalg.index 0 : index
 //       CHECK:      %[[I1:.+]] = linalg.index 1 : index
+//       CHECK:      %[[I2:.+]] = linalg.index 2 : index
 //       CHECK:      %[[I3:.+]] = linalg.index 3 : index
 //       CHECK:      %[[I4:.+]] = linalg.index 4 : index
 //       CHECK:      %[[R3:.+]] = arith.subi %[[C1]], %[[I3]] : index
-//       CHECK:      %[[EXTR:.+]] = tensor.extract %expanded[%[[C0]], %[[I1]], %[[C0]], %[[R3]], %[[I4]]] : tensor<1x32x1x2x64xf16>
+//       CHECK:      %[[EXTR:.+]] = tensor.extract %expanded[%[[I0]], %[[I1]], %[[I2]], %[[R3]], %[[I4]]] : tensor<1x32x1x2x64xf16>
 //       CHECK:      %[[NEGF:.+]] = arith.negf %[[EXTR]] : f16
 //       CHECK:      %[[CMP:.+]] = arith.cmpi eq, %[[R3]], %[[C1]] : index
 //       CHECK:      %[[SEL:.+]] = arith.select %[[CMP]], %[[NEGF]], %[[EXTR]] : f16


### PR DESCRIPTION
This patch carries revert of

llvm/llvm-project#136640 because linalg.index folder is segfaulting on inceptionv2 model

llvm/llvm-project#133231. This PR breaks fp_to_subbytes and emulation_subbyte_types on llvm-cpu tests. `iree-test-deps`.

llvm/llvm-project#137122. StableHLO and Torch-mlir needs to update their usage of GreedyRewriteConfig to use fluent API. i.e enableRegionSimplification = VS setRegionSimplificationLevel

llvm/llvm-project#135970. StableHLO has issue with VHLO_IntegerAttr and APInt not being updated. StableHLO needs to be updated with that PR's change for us to be able to integrate.

llvm/llvm-project#121389. Torch-MLIR needs to be
updated with that PR's change for us to be able to integrate.