### PR TITLE
[Encoding] Teach PadLayoutEncodingAttr about collapsing dimensions.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_into_padding.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding_into_padding.mlir
@@ -92,7 +92,7 @@ func.func @set_encoding_and_store_with_unresolved_encodings_from_executable() at
 #binding_ro = #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">
 #binding = #hal.pipeline.binding<storage_buffer, Indirect>
 #encoding_mmt = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f16, f16, f16]>
-#pad_encoding = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 64]>]>
+#pad_encoding = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<padding = [0, 64]>]>
 func.func @set_pad_encoding_and_store() {
   %c0 = arith.constant 0 : index
   %0 = hal.interface.constant.load layout(<constants = 1, bindings = [#binding_ro, #binding], flags = Indirect>) ordinal(0) : i32
@@ -124,7 +124,7 @@ func.func @set_pad_encoding_and_store() {
 #binding_ro = #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">
 #binding = #hal.pipeline.binding<storage_buffer, Indirect>
 #encoding_mmt = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f16, f16, f16]>
-#pad_encoding = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 0]>]>
+#pad_encoding = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<padding = [0, 0]>]>
 func.func @set_zero_pad_encoding_and_store() {
   %c0 = arith.constant 0 : index
   %0 = hal.interface.constant.load layout(<constants = 1, bindings = [#binding_ro, #binding], flags = Indirect>) ordinal(0) : i32
@@ -156,7 +156,7 @@ func.func @set_zero_pad_encoding_and_store() {
 #binding_ro = #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">
 #binding = #hal.pipeline.binding<storage_buffer, Indirect>
 #encoding_mmt = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f16, f16, f16]>
-#pad_encoding = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 64]>]>
+#pad_encoding = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<padding = [0, 64]>]>
 func.func @dynamic_set_zero_pad_encoding_and_store() {
   %c0 = arith.constant 0 : index
   %0 = hal.interface.constant.load layout(<constants = 2, bindings = [#binding_ro, #binding], flags = Indirect>) ordinal(0) : i32
@@ -192,9 +192,9 @@ func.func @dynamic_set_zero_pad_encoding_and_store() {
 #binding_ro = #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">
 #binding = #hal.pipeline.binding<storage_buffer, Indirect>
 #encoding_mmt_lhs = #iree_encoding.encoding<operand_index = 0 : index, op_type = matmul, element_types = [f16, f16, f16]>
-#pad_encoding_lhs = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 64]>]>
+#pad_encoding_lhs = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<padding = [0, 64]>]>
 #encoding_mmt_rhs = #iree_encoding.encoding<operand_index = 1 : index, op_type = matmul, element_types = [f16, f16, f16]>
-#pad_encoding_rhs = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 128]>]>
+#pad_encoding_rhs = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<padding = [0, 128]>]>
 #encoding_mmt_out = #iree_encoding.encoding<operand_index = 2 : index, op_type = matmul, element_types = [f16, f16, f16]>
 func.func @load_from_padded_and_mmt() {
   %c0 = arith.constant 0 : index
@@ -255,7 +255,7 @@ func.func @load_from_padded_and_mmt() {
 
 #binding_ro = #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">
 #binding = #hal.pipeline.binding<storage_buffer, Indirect>
-#pad_encoding = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 64]>]>
+#pad_encoding = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<padding = [0, 64]>]>
 func.func @set_pad_encoding_and_store_with_resolved_layout() {
   %c0 = arith.constant 0 : index
   %0 = hal.interface.constant.load layout(<constants = 1, bindings = [#binding_ro, #binding], flags = Indirect>) ordinal(0) : i32
@@ -290,9 +290,9 @@ func.func @set_pad_encoding_and_store_with_resolved_layout() {
 #binding_ro = #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">
 #binding = #hal.pipeline.binding<storage_buffer, Indirect>
 #encoding_mmt_lhs = #iree_encoding.matmul_k<k_dims = [1]>
-#pad_encoding_lhs = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 64]>]>
+#pad_encoding_lhs = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<padding = [0, 64]>]>
 #encoding_mmt_rhs = #iree_encoding.matmul_k<k_dims = [1]>
-#pad_encoding_rhs = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 128]>]>
+#pad_encoding_rhs = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<padding = [0, 128]>]>
 #encoding_mmt_out = #iree_encoding.matmul_k<k_dims = []>
 func.func @load_from_padded_and_mmt_using_matmul_k() {
   %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -251,13 +251,17 @@ def PadEncodingLayoutAttr : IREEEncoding_Attr<"PadEncodingLayout", [
         ]>
     ]> {
   let mnemonic = "pad_encoding_layout";
-  let assemblyFormat = "`<` $padding `>`";
+  let assemblyFormat = "`<` struct(params) `>`";
 
   let summary = "An attribute that encodes padding values of tensor dimensions";
   let description = [{
     Associates tensor dimensions with pad values (numbers of appended elements).
     The logical dimensions of the tensors do not change, and the elements in the
     padded regions are left uninitialized.
+
+    The `reassociation` map describes how to collapse the dimensions before
+    applying padding. The size of the map has to be as the same as the number of
+    elements in `padding`.
 
     This attribute implements `Encoding::SerializedEncodingLayoutResolverAttrInterface`,
     to provide a hook for tensor sizeof lowering. The implementation of this
@@ -266,15 +270,30 @@ def PadEncodingLayoutAttr : IREEEncoding_Attr<"PadEncodingLayout", [
   }];
 
   let parameters = (ins
-    // How many padding elements to add along each tensor dimension.
-    "DenseI32ArrayAttr":$padding
+    // How many padding elements to add along each tensor dimension after
+    // collapsing the tensor type with `reassociation` map.
+    "DenseI32ArrayAttr":$padding,
+    // The reassociation map for collapsing the shape before padding each
+    // dimension.
+    OptionalParameter<"ArrayAttr", "">:$reassociation
   );
 
   let builders = [
-    AttrBuilder<(ins "ArrayRef<int32_t>":$padding)>
+    AttrBuilder<(ins
+      "ArrayRef<int32_t>":$padding,
+      CArg<"ArrayRef<ReassociationIndices>", "{}">:$reassociation
+    )>
   ];
 
   let extraClassDeclaration = [{
+    /// Returns the reassociation indices in `reassociation`. Returns an
+    /// identity reassociation map, if `reassociation` does not exist.
+    SmallVector<ReassociationIndices> getReassociationIndices() const;
+
+    /// Returns the shape that collapses `shape` using the `reassociation`.
+    SmallVector<int64_t> getCollapsedShapeWithoutPadding(
+        ArrayRef<int64_t> shape) const;
+
     /// Returns a PadEncodingLayoutAttr attribute that pads zero elements.
     static PadEncodingLayoutAttr getIdentityAttr(MLIRContext *ctx, int rank);
   }];

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/test/roundtrip.mlir
@@ -245,11 +245,11 @@ func.func @matmul_k_encoding(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf3
 
 // -----
 
-#encoding = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 64]>]>
+#encoding = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<padding = [0, 64]>]>
 func.func @layout_encoding(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf32, #encoding> {
   return %arg0 : tensor<?x?xf32, #encoding>
 }
-// CHECK:     #[[ENCODING:.+]] = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 64]>]>
+// CHECK:     #[[ENCODING:.+]] = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<padding = [0, 64]>]>
 // CHECK:      func.func @layout_encoding(
 // CHECK-SAME:   %[[ARG0:.+]]: tensor<?x?xf32, #[[ENCODING]]>
 // CHECK         return %[[ARG0]]

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/tensor_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/tensor_folding.mlir
@@ -209,7 +209,7 @@ util.func private @ElideUnneededTensorClones(%arg0: !stream.resource<*>, %arg1: 
 
 // -----
 
-#encoding = #iree_encoding.pad_encoding_layout<[0, 0]>
+#encoding = #iree_encoding.pad_encoding_layout<padding = [0, 0]>
 // CHECK-LABEL: @FoldTensorEncodeOpWithIdentitySource(
 // CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]
 util.func private @FoldTensorEncodeOpWithIdentitySource(%arg0: !stream.resource<*>, %arg1: index) -> !stream.resource<*> {
@@ -220,7 +220,7 @@ util.func private @FoldTensorEncodeOpWithIdentitySource(%arg0: !stream.resource<
 
 // -----
 
-#encoding = #iree_encoding.pad_encoding_layout<[0, 0]>
+#encoding = #iree_encoding.pad_encoding_layout<padding = [0, 0]>
 // CHECK-LABEL: @FoldTensorEncodeOpWithIdentityResult(
 // CHECK-SAME:    %[[SRC:[a-zA-Z0-9]+]]
 util.func private @FoldTensorEncodeOpWithIdentityResult(%arg0: !stream.resource<*>, %arg1: index) -> !stream.resource<*> {

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
@@ -121,10 +121,10 @@ util.func public @with_pad_encoding(%arg0: index, %arg1: index, %scalar_f32 : f3
   util.return
 }
 
-// CHECK-DAG: #[[$NO_PAD:.+]] = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 0]>]
-// CHECK-DAG: #[[$PAD_DIM1_64:.+]] =  #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 64]>]
-// CHECK-DAG: #[[$PAD_LHS_1:.+]] =  #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 7]>]
-// CHECK-DAG: #[[$PAD_LHS_2:.+]] =  #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 65]>]
+// CHECK-DAG: #[[$NO_PAD:.+]] = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<padding = [0, 0]>]
+// CHECK-DAG: #[[$PAD_DIM1_64:.+]] =  #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<padding = [0, 64]>]
+// CHECK-DAG: #[[$PAD_LHS_1:.+]] =  #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<padding = [0, 7]>]
+// CHECK-DAG: #[[$PAD_LHS_2:.+]] =  #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<padding = [0, 65]>]
 
 // CHECK-LABEL: util.func public @with_pad_encoding
 //
@@ -435,7 +435,7 @@ util.func public @drop_encoding(%arg0: index, %arg1: index, %scalar_f32 : f32) {
   %0 = stream.tensor.empty on(#hal.device.affinity<@device_a>) : tensor<?x0xf32, #encoding>{%arg0} in !stream.resource<*>{%arg1}
   util.return
 }
-// CHECK-DAG:   #[[$IDENTITY_ENCODING:.+]] = #iree_encoding.testing_encoding<[#iree_encoding.pad_encoding_layout<[0, 0]>]>
+// CHECK-DAG:   #[[$IDENTITY_ENCODING:.+]] = #iree_encoding.testing_encoding<[#iree_encoding.pad_encoding_layout<padding = [0, 0]>]>
 // CHECK-LABEL: util.func public @drop_encoding
 // CHECK:         stream.tensor.empty {{.+}} : tensor<?x0xf32, #[[$IDENTITY_ENCODING]]>
 
@@ -452,7 +452,7 @@ util.func public @ignore_encoding_by_identity_encoding(%arg0: index, %arg1: inde
   %0 = stream.tensor.empty on(#hal.device.affinity<@device_a>) : tensor<?x0xf32, #encoding>{%arg0} in !stream.resource<*>{%arg1}
   util.return
 }
-// CHECK-DAG:   #[[$IDENTITY_ENCODING:.+]] = #iree_encoding.testing_encoding<[#iree_encoding.pad_encoding_layout<[0, 0]>]>
+// CHECK-DAG:   #[[$IDENTITY_ENCODING:.+]] = #iree_encoding.testing_encoding<[#iree_encoding.pad_encoding_layout<padding = [0, 0]>]>
 // CHECK-LABEL: util.func public @ignore_encoding_by_identity_encoding
 // CHECK:         stream.tensor.empty {{.+}} : tensor<?x0xf32, #[[$IDENTITY_ENCODING]]>
 


### PR DESCRIPTION
The dimensionality could change after encoding propagation. The revision teaches the PadLayoutEncodingAttr to carry the `reassociation` information.

It is needed for encoding propagation that could expand the padding dimension, otherwise the behaviors mismatch in different dispatches.