### PR TITLE
[Im2col] Remain batch dimension untiled during decomposition when it is contiguous and innermost

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_im2col.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_im2col.mlir
@@ -323,20 +323,68 @@ module {
 //   CHECK-DAG: %[[C14:.+]] = arith.constant 14 : index
 //   CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
 //   CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
-//   CHECK: %[[OUT_TILE:.+]] = tensor.empty() : tensor<1x14x14x36xf32>
-//   CHECK: %[[MLOOP0:.+]] = scf.for %[[M1:.+]] = %[[C0]] to %[[C14]] step %[[C1]] iter_args(%[[OUT1:.+]] = %[[OUT_TILE]]) -> (tensor<1x14x14x36xf32>)
-//   CHECK:   %[[MLOOP1:.+]] = scf.for %[[M2:.+]] = %[[C0]] to %[[C14]] step %[[C1]] iter_args(%[[OUT2:.+]] = %[[OUT1]]) -> (tensor<1x14x14x36xf32>)
-//   CHECK:     %[[KLOOP:.+]] = scf.for %[[K:.+]] = %[[C0]] to %[[C36]] step %[[C1]] iter_args(%[[OUT3:.+]] = %[[OUT2]]) -> (tensor<1x14x14x36xf32>)
-//   CHECK-DAG:   %[[kParts:.+]]:3 = affine.delinearize_index %[[K]] into (4, 3, 3) : index, index, index
-//   CHECK-DAG:   %[[FLAT_M:.+]] = affine.apply #[[$MAP]](%[[M1]], %[[M2]])
-//   CHECK-DAG:   %[[mParts:.+]]:2 = affine.delinearize_index %[[FLAT_M]] into (14, 14) : index, index
-//   CHECK-DAG:   %[[hIDX:.+]] = affine.apply #[[$MAP1]](%[[mParts]]#0, %[[kParts]]#1)
-//   CHECK-DAG:   %[[wIDX:.+]] = affine.apply #[[$MAP1]](%[[mParts]]#1, %[[kParts]]#2)
-//   CHECK:       %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][0, %[[hIDX]], %[[wIDX]], %[[kParts]]#0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x16x16x4xf32> to tensor<1x1x1x1xf32>
-//   CHECK:       %[[OUT_SLICE:.+]] = tensor.extract_slice %[[OUT3]][0, %[[M1]], %[[M2]], %[[K]]]
-//   CHECK:       %[[COPY:.+]] = linalg.copy ins(%[[IN_SLICE]] : tensor<1x1x1x1xf32>) outs(%[[OUT_SLICE]] : tensor<1x1x1x1xf32>)
-//   CHECK:       %[[INSERT:.+]] = tensor.insert_slice %[[COPY]] into %[[OUT3]][0, %[[M1]], %[[M2]], %[[K]]]
-//   CHECK:     scf.yield %[[INSERT]] : tensor<1x14x14x36xf32>
-//   CHECK:   scf.yield %[[KLOOP]] : tensor<1x14x14x36xf32>
-//   CHECK: scf.yield %[[MLOOP1]] : tensor<1x14x14x36xf32>
-//   CHECK: return %[[MLOOP0]] : tensor<1x14x14x36xf32>
+//       CHECK: %[[OUT_TILE:.+]] = tensor.empty() : tensor<1x14x14x36xf32>
+//       CHECK: %[[MLOOP0:.+]] = scf.for %[[M1:.+]] = %[[C0]] to %[[C14]] step %[[C1]] iter_args(%[[OUT1:.+]] = %[[OUT_TILE]]) -> (tensor<1x14x14x36xf32>)
+//       CHECK:   %[[MLOOP1:.+]] = scf.for %[[M2:.+]] = %[[C0]] to %[[C14]] step %[[C1]] iter_args(%[[OUT2:.+]] = %[[OUT1]]) -> (tensor<1x14x14x36xf32>)
+//       CHECK:     %[[KLOOP:.+]] = scf.for %[[K:.+]] = %[[C0]] to %[[C36]] step %[[C1]] iter_args(%[[OUT3:.+]] = %[[OUT2]]) -> (tensor<1x14x14x36xf32>)
+//   CHECK-DAG:       %[[kParts:.+]]:3 = affine.delinearize_index %[[K]] into (4, 3, 3) : index, index, index
+//   CHECK-DAG:       %[[FLAT_M:.+]] = affine.apply #[[$MAP]](%[[M1]], %[[M2]])
+//   CHECK-DAG:       %[[mParts:.+]]:2 = affine.delinearize_index %[[FLAT_M]] into (14, 14) : index, index
+//   CHECK-DAG:       %[[hIDX:.+]] = affine.apply #[[$MAP1]](%[[mParts]]#0, %[[kParts]]#1)
+//   CHECK-DAG:       %[[wIDX:.+]] = affine.apply #[[$MAP1]](%[[mParts]]#1, %[[kParts]]#2)
+//       CHECK:       %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][0, %[[hIDX]], %[[wIDX]], %[[kParts]]#0] [1, 1, 1, 1] [1, 1, 1, 1] : tensor<1x16x16x4xf32> to tensor<1x1x1x1xf32>
+//       CHECK:       %[[OUT_SLICE:.+]] = tensor.extract_slice %[[OUT3]][0, %[[M1]], %[[M2]], %[[K]]]
+//       CHECK:       %[[COPY:.+]] = linalg.copy ins(%[[IN_SLICE]] : tensor<1x1x1x1xf32>) outs(%[[OUT_SLICE]] : tensor<1x1x1x1xf32>)
+//       CHECK:       %[[INSERT:.+]] = tensor.insert_slice %[[COPY]] into %[[OUT3]][0, %[[M1]], %[[M2]], %[[K]]]
+//       CHECK:     scf.yield %[[INSERT]] : tensor<1x14x14x36xf32>
+//       CHECK:   scf.yield %[[KLOOP]] : tensor<1x14x14x36xf32>
+//       CHECK: scf.yield %[[MLOOP1]] : tensor<1x14x14x36xf32>
+//       CHECK: return %[[MLOOP0]] : tensor<1x14x14x36xf32>
+
+// -----
+
+module {
+  func.func @im2col_chwn(%arg0: tensor<16x26x18x4xf32>, %arg1: index, %arg2: index, %arg3: index) -> tensor<4x2x2x2xf32> {
+    %0 = tensor.empty() : tensor<4x2x2x2xf32>
+    %1 = iree_linalg_ext.im2col
+            strides = [1, 1] dilations = [1, 1] kernel_size = [24, 16]
+            m_offset = [%arg1, %arg2] * [3, 1] k_offset = [%arg3] * [1]
+            batch_pos = [3] m_pos = [1, 2] k_pos = [0]
+            input_k_perm = [0, 1, 2]
+            ins(%arg0 : tensor<16x26x18x4xf32>)
+            outs(%0 : tensor<4x2x2x2xf32>) -> tensor<4x2x2x2xf32>
+    return %1 : tensor<4x2x2x2xf32>
+  }
+}
+
+//   CHECK-DAG: #[[$MAP:.+]] = affine_map<(d0)[s0] -> (d0 + s0)>
+//   CHECK-DAG: #[[$MAP1:.+]] = affine_map<(d0, d1)[s0, s1] -> (d0 * 3 + d1 + s0 * 3 + s1)>
+//   CHECK-DAG: #[[$MAP2:.+]] = affine_map<(d0, d1) -> (d0 + d1)>
+// CHECK-LABEL: func.func @im2col_chwn
+//  CHECK-SAME: %[[ARG0:[a-zA-Z0-9_]+]]: tensor<16x26x18x4xf32>
+//  CHECK-SAME: %[[ARG1:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME: %[[ARG2:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME: %[[ARG3:[a-zA-Z0-9_]+]]: index
+//   CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG: %[[C2:.+]] = arith.constant 2 : index
+//       CHECK: %[[INIT:.+]] = tensor.empty() : tensor<4x2x2x2xf32>
+//       CHECK: %[[mLOOP0:.+]] = scf.for %[[M0:.+]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[OUT0:.+]] = %[[INIT]])
+//       CHECK:   %[[mLOOP1:.+]] = scf.for %[[M1:.+]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[OUT1:.+]] = %[[OUT0]])
+//       CHECK:     %[[kLOOP:.+]] = scf.for %[[K:.+]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[OUT2:.+]] = %[[OUT1]])
+//   CHECK-DAG:       %[[kIDX:.+]] = affine.apply #[[$MAP]](%[[K]])[%[[ARG3]]]
+//   CHECK-DAG:       %[[kParts:.+]]:3 = affine.delinearize_index %[[kIDX]] into (16, 24, 16)
+//   CHECK-DAG:       %[[mIDX:.+]] = affine.apply #[[$MAP1]](%[[M0]], %[[M1]])[%[[ARG1]], %[[ARG2]]]
+//   CHECK-DAG:       %[[mParts:.+]]:2 = affine.delinearize_index %[[mIDX]] into (3, 3)
+//   CHECK-DAG:       %[[hIDX:.+]] = affine.apply #[[$MAP2]](%[[mParts]]#0, %[[kParts]]#1)
+//   CHECK-DAG:       %[[wIDX:.+]] = affine.apply #[[$MAP2]](%[[mParts]]#1, %[[kParts]]#2)
+//       CHECK:       %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[kParts]]#0, %[[hIDX]], %[[wIDX]], 0] [1, 1, 1, 4] [1, 1, 1, 1]
+//       CHECK:       %[[EMPTY:.+]] = tensor.empty() : tensor<4x1x1x1xf32>
+//       CHECK:       %[[TRANS:.+]] = linalg.transpose ins(%[[IN_SLICE]] : tensor<1x1x1x4xf32>) outs(%[[EMPTY]] : tensor<4x1x1x1xf32>) permutation = [3, 1, 2, 0]
+//       CHECK:       %[[OUT_SLICE:.+]] = tensor.extract_slice %[[OUT2]][0, %[[M0]], %[[M1]], %[[K]]] [4, 1, 1, 1] [1, 1, 1, 1]
+//       CHECK:       %[[COPY:.+]] = linalg.copy ins(%[[TRANS]] : tensor<4x1x1x1xf32>) outs(%[[OUT_SLICE]] : tensor<4x1x1x1xf32>) -> tensor<4x1x1x1xf32>
+//       CHECK:       %[[INSERT:.+]] = tensor.insert_slice %[[COPY]] into %[[OUT2]][0, %[[M0]], %[[M1]], %[[K]]] [4, 1, 1, 1] [1, 1, 1, 1]
+//       CHECK:      scf.yield %[[INSERT]] : tensor<4x2x2x2xf32>
+//       CHECK:    scf.yield %[[kLOOP]] : tensor<4x2x2x2xf32>
+//       CHECK:  scf.yield %[[mLOOP1]] : tensor<4x2x2x2xf32>
+//       CHECK: return %[[MLOOP0:.+]] : tensor<4x2x2x2xf32>

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_im2col.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/decompose_im2col.mlir
@@ -381,9 +381,7 @@ module {
 //       CHECK:       %[[IN_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[kParts]]#0, %[[hIDX]], %[[wIDX]], 0] [1, 1, 1, 4] [1, 1, 1, 1]
 //       CHECK:       %[[EMPTY:.+]] = tensor.empty() : tensor<4x1x1x1xf32>
 //       CHECK:       %[[TRANS:.+]] = linalg.transpose ins(%[[IN_SLICE]] : tensor<1x1x1x4xf32>) outs(%[[EMPTY]] : tensor<4x1x1x1xf32>) permutation = [3, 1, 2, 0]
-//       CHECK:       %[[OUT_SLICE:.+]] = tensor.extract_slice %[[OUT2]][0, %[[M0]], %[[M1]], %[[K]]] [4, 1, 1, 1] [1, 1, 1, 1]
-//       CHECK:       %[[COPY:.+]] = linalg.copy ins(%[[TRANS]] : tensor<4x1x1x1xf32>) outs(%[[OUT_SLICE]] : tensor<4x1x1x1xf32>) -> tensor<4x1x1x1xf32>
-//       CHECK:       %[[INSERT:.+]] = tensor.insert_slice %[[COPY]] into %[[OUT2]][0, %[[M0]], %[[M1]], %[[K]]] [4, 1, 1, 1] [1, 1, 1, 1]
+//       CHECK:       %[[INSERT:.+]] = tensor.insert_slice %[[TRANS]] into %[[OUT2]][0, %[[M0]], %[[M1]], %[[K]]] [4, 1, 1, 1] [1, 1, 1, 1]
 //       CHECK:      scf.yield %[[INSERT]] : tensor<4x2x2x2xf32>
 //       CHECK:    scf.yield %[[kLOOP]] : tensor<4x2x2x2xf32>
 //       CHECK:  scf.yield %[[mLOOP1]] : tensor<4x2x2x2xf32>


### PR DESCRIPTION
This PR aims to improve the performance of backward convolutions `conv2d_chwn_chwf` by enabling vectorization along the batch dimension during im2col decomposition. The im2col op has an implicit transpose between the input and output tensor, for example,

```
%27 = iree_linalg_ext.im2col strides = [1, 1] dilations = [1, 1] kernel_size = [24, 16] m_offset = [%25, %26] * [3, 1] k_offset = [%24] * [1] batch_pos = [3] m_pos = [1, 2] k_pos = [0] input_k_perm = [0, 1, 2] ins(%extracted_slice_4 : tensor<16x26x18x4xbf16>) outs(%extracted_slice_5 : tensor<4x1x1x1xbf16>) -> tensor<4x1x1x1xbf16>
```

The batch dimension is transposed from the innermost to the outermost. During decomposition, the full batch dimension should be left untiled so it can be vectorized, and a transpose op is added to account for the dimension permutation. The detailed IR after decomposition can be referred to the new added test.

This should work together with the lowering config changes for im2col op which will be addressed in a separate PR.