### PR TITLE
[DispatchCreation] Set padding encodings on intermediate tensors.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Canonicalizer.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Canonicalizer.cpp
@@ -112,6 +112,7 @@ struct CanonicalizerPass
   }
   void runOnOperation() override {
     // Canonicalization is best-effort. Non-convergence is not a pass failure.
+    config.cseConstants = cseConstants;
     LogicalResult didConverge =
         applyPatternsGreedily(getOperation(), *patterns, config);
     if (this->testConvergence && failed(didConverge)) {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -26,6 +26,8 @@ def CanonicalizerPass :
     Pass<"iree-flow-canonicalize", ""> {
   let summary = "Flow specific canonicalization pass";
   let options = [
+    Option<"cseConstants", "cse-constants", "bool",
+            /*default=*/"true", "Do Not CSE constants on canonicalization">,
     Option<"testConvergence", "test-convergence", "bool",
            /*default=*/"false", "Fails if the patterns fail to converge">
   ];

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -251,6 +251,12 @@ addDispatchRegionCreationPasses(OpPassManager &passManager,
   // separated from compiler fusion decisions.
   if (clEnableDataTiling) {
     FunctionLikeNest(passManager)
+        // Run canonicalizer first to make propagation easier.
+        .addPass([&]() {
+          IREE::Flow::CanonicalizerPassOptions options;
+          options.cseConstants = false;
+          return IREE::Flow::createCanonicalizerPass(options);
+        })
         // Set encodings on all eligible ops. All ops should be in compiler
         // formed dispatch regions, so encodings will be placed inside of the
         // dispatch regions with the data-tiled op.

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.h
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.h
@@ -18,7 +18,7 @@
 
 namespace mlir::iree_compiler::DispatchCreation {
 
-enum class EncodingOptions { MatmulK, Generic };
+enum class EncodingOptions { Padding, MatmulK, Generic };
 
 //===----------------------------------------------------------------------===//
 // Pipelines

--- a/compiler/src/iree/compiler/DispatchCreation/Passes.td
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.td
@@ -324,6 +324,9 @@ def SetEncodingPass : InterfacePass<"iree-dispatch-creation-set-encoding",
         "Select the type of encoding options to add.",
         [{::llvm::cl::values(
             clEnumValN(
+                mlir::iree_compiler::DispatchCreation::EncodingOptions::Padding,
+                "padding", "Encode tensors that need to be padded."),
+            clEnumValN(
                 mlir::iree_compiler::DispatchCreation::EncodingOptions::MatmulK,
                 "matmulk", "Only encodes reduction dimensions in the encoding."),
             clEnumValN(

--- a/compiler/src/iree/compiler/DispatchCreation/SetEncoding.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/SetEncoding.cpp
@@ -306,10 +306,226 @@ struct FoldFillWithSetEncoding final
   }
 };
 
+//===---------------------------------------------------------------------===//
+// Set padding encodings
+//===---------------------------------------------------------------------===//
+
+struct PaddedValue {
+  Value paddedValue;
+  SmallVector<Value> dynamicDims;
+};
+
+// For a given `operand`, if its producer is a `flow.dispatch.region`,
+// generate a new value for `operand` that has the padding encoding.
+// The producer `flow.dispatch.region` need not be the immediate defining op
+// of `operand`. This method tracks through operations like
+// `tensor.expand_shape/tensor.collapse_shape` to get to the producer dispatch.
+// Once the producer dispatch is found, its result is modified to be of the same
+// type as `operand` but with the padding encodings. To keep things consistent,
+// the operations that are encountered before getting to the original producing
+// `flow.dispatch.region` are replicated into the producer dispatch.
+static std::optional<PaddedValue> padProducerOfValue(RewriterBase &rewriter,
+                                                     Value operand) {
+  auto operandType = dyn_cast<RankedTensorType>(operand.getType());
+  if (!operandType || operandType.getRank() == 0) {
+    return std::nullopt;
+  }
+
+  SmallVector<Operation *> opChain;
+  auto producerValue = dyn_cast<OpResult>(operand);
+  while (producerValue &&
+         !isa<IREE::Flow::DispatchRegionOp>(producerValue.getOwner())) {
+    if (!llvm::hasSingleElement(producerValue.getUses())) {
+      return std::nullopt;
+    }
+
+    // If it is an operation that we want to look past, add it to the chain
+    // and update the `producerValue`.
+    Operation *currOperation = producerValue.getOwner();
+    if (isa<tensor::CollapseShapeOp, tensor::ExpandShapeOp>(currOperation)) {
+      opChain.push_back(currOperation);
+      producerValue = dyn_cast<OpResult>(currOperation->getOperand(0));
+      continue;
+    }
+
+    // Conservative, bail out.
+    return std::nullopt;
+  }
+
+  if (!producerValue) {
+    return std::nullopt;
+  }
+
+  auto producerDispatch =
+      dyn_cast<IREE::Flow::DispatchRegionOp>(producerValue.getOwner());
+  // TODO(MaheshRavishankar): Multi-result producer dispatches can be supported.
+  // Will require to move the consumer dispatch immediately after the producer
+  // instead of what is done below and move other operands of the consumer
+  // dispatch before the producer dispatch.
+  if (!producerDispatch ||
+      !llvm::hasSingleElement(producerDispatch.getBody()) ||
+      producerDispatch->getNumResults() != 1) {
+    return std::nullopt;
+  }
+  if (!llvm::hasSingleElement(producerValue.getUses())) {
+    return std::nullopt;
+  }
+
+  Location loc = producerDispatch.getLoc();
+  unsigned resultNumber = producerValue.getResultNumber();
+  // Compute the padding encoding.  Set to dynamic for backend to pick the right
+  // value.
+  SmallVector<int64_t> paddingValue(operandType.getRank(), 0);
+  paddingValue.back() = ShapedType::kDynamic;
+  auto encoding = IREE::Encoding::PadEncodingLayoutAttr::get(
+      rewriter.getContext(), paddingValue);
+
+  // Compute the result types of the new dispatch.
+  auto newResultType = operandType.cloneWithEncoding(encoding);
+  auto newResultTypes = llvm::to_vector(producerDispatch->getResultTypes());
+  newResultTypes[resultNumber] = newResultType;
+
+  // Compute the result dynamic dims.
+  SmallVector<OpFoldResult> operandDims =
+      tensor::getMixedSizes(rewriter, loc, operand);
+  SmallVector<Value> operandDynamicDims;
+  std::tie(std::ignore, operandDynamicDims) = decomposeMixedValues(operandDims);
+
+  SmallVector<Value> newResultDynamicDims;
+  for (OpResult producerDispatchResult : producerDispatch.getResults()) {
+    if (producerDispatchResult != producerValue) {
+      llvm::append_range(newResultDynamicDims,
+                         producerDispatch.getResultDynamicDims(
+                             producerDispatchResult.getResultNumber()));
+      continue;
+    }
+    llvm::append_range(newResultDynamicDims, operandDynamicDims);
+  }
+
+  auto newDispatchOp = rewriter.create<IREE::Flow::DispatchRegionOp>(
+      producerDispatch->getLoc(), newResultTypes, newResultDynamicDims,
+      producerDispatch.getWorkload());
+
+  // Move over the body of the old dispatch.
+  Region &newBody = newDispatchOp.getBody();
+  Region &producerDispatchBody = producerDispatch.getBody();
+  rewriter.cloneRegionBefore(producerDispatchBody, newBody, newBody.begin());
+
+  // Move over the slice operations if needed.
+  Region &producerWorkgroupCountBody = producerDispatch.getWorkgroupCount();
+  if (!producerWorkgroupCountBody.empty()) {
+    Region &newWorkgroupCountBody = newDispatchOp.getWorkgroupCount();
+    rewriter.cloneRegionBefore(producerWorkgroupCountBody,
+                               newWorkgroupCountBody,
+                               newWorkgroupCountBody.begin());
+  }
+
+  // Clone the operation chain.
+  IRMapping map;
+  auto returnOp = cast<IREE::Flow::ReturnOp>(newBody.front().getTerminator());
+  Value yieldedVal = returnOp.getOperand(resultNumber);
+
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(returnOp);
+  map.map(producerValue, yieldedVal);
+
+  for (Operation *op : llvm::reverse(opChain)) {
+    rewriter.clone(*op, map);
+  }
+  // Find the new value to yield.
+  Value newYieldedVal = map.lookup(operand);
+  auto encodingOp = rewriter.create<IREE::Encoding::SetEncodingOp>(
+      returnOp->getLoc(), newResultType, newYieldedVal);
+  rewriter.modifyOpInPlace(
+      returnOp, [&]() { returnOp.setOperand(resultNumber, encodingOp); });
+
+  return PaddedValue{newDispatchOp->getResult(resultNumber),
+                     operandDynamicDims};
+}
+
+// For a given operation, pad the operands corresponding to `operandNums`.
+static SmallVector<unsigned> padOperandsOfOp(RewriterBase &rewriter,
+                                             Operation *op,
+                                             ArrayRef<unsigned> operandNums) {
+  // Do not pad the operands of operations not within dispatches.
+  auto dispatchOp = op->getParentOfType<IREE::Flow::DispatchRegionOp>();
+  if (!dispatchOp) {
+    return {};
+  }
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(dispatchOp);
+
+  SmallVector<unsigned> paddedOperands;
+  for (auto operandNum : operandNums) {
+    OpOperand &operand = op->getOpOperand(operandNum);
+    std::optional<PaddedValue> paddedVal =
+        padProducerOfValue(rewriter, operand.get());
+    if (!paddedVal) {
+      continue;
+    }
+    rewriter.modifyOpInPlace(op, [&]() {
+      OpBuilder::InsertionGuard g2(rewriter);
+      rewriter.setInsertionPoint(op);
+      Type operandType = operand.get().getType();
+      auto unsetEncodignOp = rewriter.create<IREE::Encoding::UnsetEncodingOp>(
+          op->getLoc(), operandType, paddedVal->paddedValue,
+          paddedVal->dynamicDims);
+      op->setOperand(operandNum, unsetEncodignOp.getResult());
+    });
+  }
+  return paddedOperands;
+}
+
+// Main driver method to add encodings to pad. Typically these are
+// intermediate values produced by `flow.dispatch.region`.
+static LogicalResult setPaddingEncodings(MLIRContext *context,
+                                         FunctionOpInterface funcOp) {
+  IRRewriter rewriter(context);
+
+  // Collect all operations whose operands can be padded.
+  SmallVector<Operation *> matmulOps;
+  funcOp.walk([&](linalg::LinalgOp linalgOp) {
+    if (linalg::isaContractionOpInterface(linalgOp)) {
+      matmulOps.push_back(linalgOp);
+    }
+  });
+  for (auto op : matmulOps) {
+    // Only pad LHS or RHS of matmul ops.
+    padOperandsOfOp(rewriter, op, {0, 1});
+  }
+
+  // Apply the dim resolution patterns.
+  RewritePatternSet dimResolutionPatterns(context);
+  memref::populateResolveRankedShapedTypeResultDimsPatterns(
+      dimResolutionPatterns);
+  GreedyRewriteConfig config;
+  config.fold = true;
+  config.maxIterations = GreedyRewriteConfig::kNoLimit;
+  if (failed(applyPatternsGreedily(funcOp, std::move(dimResolutionPatterns),
+                                   config))) {
+    return funcOp.emitOpError("failed to resolve tensor.dim operations");
+  }
+  return success();
+}
+
+//===---------------------------------------------------------------------===//
+// Pass definition
+//===---------------------------------------------------------------------===//
+
 struct SetEncodingPass final : impl::SetEncodingPassBase<SetEncodingPass> {
   using Base::Base;
   void runOnOperation() override {
+    auto funcOp = getOperation();
     MLIRContext *context = &getContext();
+
+    // Implement the padding encoding.
+    if (encodingOption == DispatchCreation::EncodingOptions::Padding) {
+      if (failed(setPaddingEncodings(context, funcOp))) {
+        return signalPassFailure();
+      }
+      return;
+    }
+
     RewritePatternSet patterns(context);
     patterns.add<SetContractionOpEncoding>(context, encodingOption.getValue());
     linalg::FillOp::getCanonicalizationPatterns(patterns, context);

--- a/compiler/src/iree/compiler/DispatchCreation/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/DispatchCreation/test/BUILD.bazel
@@ -45,6 +45,7 @@ iree_lit_test_suite(
             "pipeline_tests.mlir",
             "propagate_encodings.mlir",
             "set_encoding.mlir",
+            "set_encoding_padding.mlir",
             "set_encoding_pipeline.mlir",
             "sink_reshapes.mlir",
             "split_reduction.mlir",

--- a/compiler/src/iree/compiler/DispatchCreation/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/DispatchCreation/test/CMakeLists.txt
@@ -43,6 +43,7 @@ iree_lit_test_suite(
     "pipeline_tests.mlir"
     "propagate_encodings.mlir"
     "set_encoding.mlir"
+    "set_encoding_padding.mlir"
     "set_encoding_pipeline.mlir"
     "sink_reshapes.mlir"
     "split_reduction.mlir"

--- a/compiler/src/iree/compiler/DispatchCreation/test/set_encoding_padding.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/set_encoding_padding.mlir
@@ -1,0 +1,135 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(util.func(iree-dispatch-creation-set-encoding{encoding-option=padding}))" --split-input-file --mlir-print-local-scope %s | FileCheck %s
+
+util.func @simple_test(%lhs : tensor<?x?xf32>, %rhs0 : tensor<?x?xf32>,
+    %rhs1 : tensor<?x?xf32>, %M : index, %K1 : index, %K2 : index,
+    %N: index) -> tensor<?x?xf32> {
+  %c0 = arith.constant 0.0 : f32
+  %0 = flow.dispatch.region[%M, %K2, %K1] -> (tensor<?x?xf32>{%M, %K2}) {
+    %1 = tensor.empty(%M, %K2) : tensor<?x?xf32>
+    %2 = linalg.fill ins(%c0 : f32) outs(%1 : tensor<?x?xf32>) -> tensor<?x?xf32>
+    %3 = linalg.matmul ins(%lhs, %rhs0 : tensor<?x?xf32>, tensor<?x?xf32>)
+        outs(%2 : tensor<?x?xf32>) -> tensor<?x?xf32>
+    flow.return %3 : tensor<?x?xf32>
+  } count(%w0: index, %w1 : index, %w2 : index) -> (index, index, index) {
+    %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %w0, %w1, %w2
+    flow.return %x, %y, %z : index, index, index
+  }
+  %1 = flow.dispatch.region[%M, %N, %K2] -> (tensor<?x?xf32>{%M, %N}) {
+    %2 = tensor.empty(%M, %N) : tensor<?x?xf32>
+    %3 = linalg.fill ins(%c0 : f32) outs(%2 : tensor<?x?xf32>) -> tensor<?x?xf32>
+    %4 = linalg.matmul ins(%0, %rhs1 : tensor<?x?xf32>, tensor<?x?xf32>)
+        outs(%3 : tensor<?x?xf32>) -> tensor<?x?xf32>
+    flow.return %4 : tensor<?x?xf32>
+  } count(%w0: index, %w1 : index, %w2 : index) -> (index, index, index) {
+    %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %w0, %w1, %w2
+    flow.return %x, %y, %z : index, index, index
+  }
+  util.return %1 : tensor<?x?xf32>
+}
+// CHECK-LABEL: @simple_test(
+//  CHECK-SAME:     %[[LHS:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+//  CHECK-SAME:     %[[RHS0:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+//  CHECK-SAME:     %[[RHS1:[a-zA-Z0-9_]+]]: tensor<?x?xf32>
+//  CHECK-SAME:     %[[M:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:     %[[K1:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:     %[[K2:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:     %[[N:[a-zA-Z0-9_]+]]: index
+//       CHECK:   %[[DISPATCH0:.+]] = flow.dispatch.region
+//  CHECK-SAME:       [%[[M]], %[[K2]], %[[K1]]]
+//  CHECK-SAME:       -> (tensor<?x?xf32, #iree_encoding.pad_encoding_layout<[0, ?]>>{%[[M]], %[[K2]]})
+//       CHECK:     %[[OP0:.+]] = linalg.matmul
+//       CHECK:     %[[SET_ENCODING:.+]] = iree_encoding.set_encoding %[[OP0]]
+//       CHECK:     flow.return %[[SET_ENCODING]]
+//       CHECK:     count(%[[B0:[a-zA-Z0-9]+]]: index, %[[B1:[a-zA-Z0-9]+]]: index, %[[B2:[a-zA-Z0-9]+]]: index)
+//       CHECK:       %[[X:[a-zA-Z0-9_]+]], %[[Y:[a-zA-Z0-9_]+]], %[[Z:[a-zA-Z0-9_]+]] = iree_tensor_ext.dispatch.workgroup_count_from_slice %[[B0]], %[[B1]], %[[B2]]
+//       CHECK:       flow.return %[[X]], %[[Y]], %[[Z]]
+//       CHECK:   flow.dispatch.region
+//       CHECK:     %[[UNSET_ENCODING:.+]] = iree_encoding.unset_encoding %[[DISPATCH0]]
+//  CHECK-SAME:         tensor<?x?xf32>{%[[M]], %[[K2]]}
+//       CHECK:     linalg.matmul
+//  CHECK-SAME:         ins(%[[UNSET_ENCODING]],
+
+// -----
+
+// Check that padding encoding can be set across collapse_shape ops.
+util.func @encoding_across_collapse(%lhs : tensor<?x?xf32>, %rhs : tensor<?x?xf32>,
+    %M : index, %N : index, %K1 : index, %K2 : index) -> tensor<?x?xf32> {
+  %c0 = arith.constant 0.0 : f32
+  %0 = flow.dispatch.region[%M, %K1, %K2] -> (tensor<?x?x?xf32>{%M, %K1, %K2}) {
+    %1 = tensor.empty(%M, %K1, %K2) : tensor<?x?x?xf32>
+    flow.return %1 : tensor<?x?x?xf32>
+  } count(%w0: index, %w1 : index, %w2 : index) -> (index, index, index) {
+    %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %w0, %w1, %w2
+    flow.return %x, %y, %z : index, index, index
+  }
+  %1 = tensor.collapse_shape %0 [[0], [1, 2]] : tensor<?x?x?xf32> into tensor<?x?xf32>
+  %2 = arith.muli %K1, %K2 : index
+  %3 = flow.dispatch.region[%M, %N, %2] -> (tensor<?x?xf32>{%M, %N}) {
+    %4 = tensor.empty(%M, %N) : tensor<?x?xf32>
+    %5 = linalg.fill ins(%c0 : f32) outs(%4 : tensor<?x?xf32>) -> tensor<?x?xf32>
+    %6 = linalg.matmul ins(%1, %rhs : tensor<?x?xf32>, tensor<?x?xf32>)
+        outs(%5 : tensor<?x?xf32>) -> tensor<?x?xf32>
+    flow.return %6 : tensor<?x?xf32>
+  } count(%w0: index, %w1 : index, %w2 : index) -> (index, index, index) {
+    %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %w0, %w1, %w2
+    flow.return %x, %y, %z : index, index, index
+  }
+  util.return %3 : tensor<?x?xf32>
+}
+// CHECK-LABEL: @encoding_across_collapse
+//  CHECK-SAME:     %[[M:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:     %[[N:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:     %[[K1:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:     %[[K2:[a-zA-Z0-9_]+]]: index
+//       CHECK:   %[[K:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%[[K1]], %[[K2]]]
+//       CHECK:   %[[DISPATCH0:.+]] = flow.dispatch.region
+//  CHECK-SAME:       -> (tensor<?x?xf32, #iree_encoding.pad_encoding_layout<[0, ?]>>{%[[M]], %[[K]]}
+//       CHECK:     %[[EMPTY:.+]] = tensor.empty
+//       CHECK:     %[[COLLAPSE:.+]] = tensor.collapse_shape %[[EMPTY]]
+//       CHECK:     %[[SET_ENCODING:.+]] = iree_encoding.set_encoding %[[COLLAPSE]]
+//       CHECK:     flow.return %[[SET_ENCODING]]
+//       CHECK:   flow.dispatch.region
+//       CHECK:     %[[UNSET_ENCODING:.+]] = iree_encoding.unset_encoding
+//  CHECK-SAME:         -> tensor<?x?xf32>{%[[M]], %[[K]]}
+//       CHECK:     linalg.matmul ins(%[[UNSET_ENCODING]],
+
+// -----
+
+// Check that padding encoding can be set across sequence of operations.
+util.func @encoding_across_collapse(%lhs : tensor<?x?xf32>, %rhs : tensor<?x?xf32>,
+    %M : index, %N : index, %K1 : index, %K2 : index) -> tensor<?x?xf32> {
+  %c0 = arith.constant 0.0 : f32
+  %0 = flow.dispatch.region[%M, %K1] -> (tensor<?x?xf32>{%M, %K1}) {
+    %1 = tensor.empty(%M, %K1) : tensor<?x?xf32>
+    flow.return %1 : tensor<?x?xf32>
+  } count(%w0: index, %w1 : index) -> (index, index, index) {
+    %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %w0, %w1
+    flow.return %x, %y, %z : index, index, index
+  }
+  %1 = arith.divsi %K1, %K2 : index
+  %2 = tensor.expand_shape %0 [[0], [1, 2]] output_shape[%M, %1, %K2] : tensor<?x?xf32> into tensor<?x?x?xf32>
+  %3 = tensor.collapse_shape %2 [[0, 1], [2]] : tensor<?x?x?xf32> into tensor<?x?xf32>
+  %4 = arith.muli %M, %1 : index
+  %5 = flow.dispatch.region[%4, %N, %K2] -> (tensor<?x?xf32>{%4, %K2}) {
+    %6 = tensor.empty(%4, %N) : tensor<?x?xf32>
+    %7 = linalg.fill ins(%c0 : f32) outs(%6 : tensor<?x?xf32>) -> tensor<?x?xf32>
+    %8 = linalg.matmul ins(%3, %rhs : tensor<?x?xf32>, tensor<?x?xf32>)
+        outs(%7 : tensor<?x?xf32>) -> tensor<?x?xf32>
+    flow.return %8 : tensor<?x?xf32>
+  } count(%w0: index, %w1 : index, %w2 : index) -> (index, index, index) {
+    %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %w0, %w1, %w2
+    flow.return %x, %y, %z : index, index, index
+  }
+  util.return %5 : tensor<?x?xf32>
+}
+// CHECK-LABEL: @encoding_across_collapse
+//       CHECK:   %[[DISPATCH:.+]] = flow.dispatch.region
+//  CHECK-SAME:       #iree_encoding.pad_encoding_layout<[0, ?]>
+//       CHECK:     %[[EMPTY:.+]] = tensor.empty
+//       CHECK:     %[[EXPAND:.+]] = tensor.expand_shape %[[EMPTY]]
+//       CHECK:     %[[COLLAPSE:.+]] = tensor.collapse_shape %[[EXPAND]]
+//       CHECK:     %[[SET_ENCODING:.+]] = iree_encoding.set_encoding %[[COLLAPSE]]
+//       CHECK:     flow.return %[[SET_ENCODING]]
+//       CHECK:   flow.dispatch.region
+//       CHECK:     %[[UNSET_ENCODING:.+]] = iree_encoding.unset_encoding %[[DISPATCH]]
+//       CHECK:     linalg.matmul ins(%[[UNSET_ENCODING]],


### PR DESCRIPTION
This PR adds a new way to set encodings to suggest that certain intermediate tensors need to have a wider allocation than the logical shape of the tensor.

In this implementation, the lhs/rhs operands of contraction-like operations that are produced by other dispatches are targets for adding such encoding. This PR also accounts for having operations like `tensor.collapse_shape`/`tensor.expand_shape` in between the producing dispatch and its use. It doesnt do this through propagation, instead, the intervening operations are cloned into the producer dispatch, so that the result of the producer dispatch is directly usable in the operation. The result of the dispatch is then "encoded" to specify that padding is needed.

Depends on #20662 

Please review only last commit.