### PR TITLE
e2e matmul tests: log early the presence of a numerical error

### DIFF
--- a/tools/testing/e2e/iree-e2e-matmul-test.cc
+++ b/tools/testing/e2e/iree-e2e-matmul-test.cc
@@ -630,6 +630,10 @@ static iree_status_t check_matmul_results(FILE* file,
     // numerical summary, as most of the reference matrix entries hadn't been
     // computed. Rerun now with check_every=1 to get that numerical logging.
     iree_status_ignore(status);
+    fprintf(file,
+            "Incorrect numerical results detected! Now computing the whole "
+            "reference matrix to log more detailed numerical error "
+            "diagnostics. This may take a while for larger matrices...\n");
     status = check_matmul_results_impl(file, results, 1);
   }
   IREE_TRACE_ZONE_END(z0);


### PR DESCRIPTION
On numerical error, e2e matmul tests rerun the reference matmul on ALL elements (instead of computing only 1 every N elements) to print the detailed numerical diagnostic. That can take a minute on huge matrices, as the reference code is so slow. Logging early what is going on allows the user to know it's a numerical error and not a hang.