### PR TITLE
[LinalgExt] Add map_scatter op and verifier

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -318,6 +318,55 @@ GatherOp::reifyResultShapes(OpBuilder &b,
 }
 
 //===----------------------------------------------------------------------===//
+// MapScatterOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult MapScatterOp::verify() {
+  if (getInputType().getElementType() != getOutputType().getElementType()) {
+    return emitOpError("expected input and output element types to match");
+  }
+  if (!hasPureBufferSemantics() && !hasPureTensorSemantics()) {
+    return emitOpError("expected input and output to be both tensor or both "
+                       "memref");
+  }
+  if (hasPureBufferSemantics() && getNumResults() != 0) {
+    return emitOpError("expected no result for memref output");
+  }
+  if (hasPureTensorSemantics() && getNumResults() != 1) {
+    return emitOpError("expected one result for tensor output");
+  }
+  Region &transformRegion = getTransformationRegion();
+  if (!transformRegion.hasOneBlock()) {
+    return emitOpError("expected a single block in the transform_region");
+  }
+  Block &transformBody = transformRegion.getBlocks().front();
+  if (transformBody.getNumArguments() != getInputRank()) {
+    return emitOpError("expected number of block arguments to be equal "
+                       "to the input rank");
+  }
+  if (!llvm::all_of(transformBody.getArgumentTypes(),
+                    llvm::IsaPred<IndexType>)) {
+    return emitOpError("expected block arguments to be index types");
+  }
+  auto yieldOp = cast<IREE::LinalgExt::YieldOp>(transformBody.getTerminator());
+  if (yieldOp->getNumOperands() != getOutputRank() + 1) {
+    return yieldOp.emitOpError("expected transformation_region to yield a "
+                               "value for each output dimension and a mask");
+  }
+  for (int operandIdx = 0; operandIdx < getOutputRank(); ++operandIdx) {
+    if (!isa<IndexType>(yieldOp.getOperandTypes()[operandIdx])) {
+      return yieldOp.emitOpError("expected yielded indices to be index types");
+    }
+  }
+  auto maskType =
+      dyn_cast<IntegerType>(yieldOp.getOperandTypes()[getOutputRank()]);
+  if (!maskType || maskType.getIntOrFloatBitWidth() != 1) {
+    return yieldOp.emitOpError("expected yielded mask to be i1 type");
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // SortOp
 //===----------------------------------------------------------------------===//
 
@@ -2005,6 +2054,7 @@ LogicalResult IREE::LinalgExt::IndexOp::verify() {
 
 DEFINE_OP_GET_EFFECTS(ScatterOp)
 DEFINE_OP_GET_EFFECTS(GatherOp)
+DEFINE_OP_GET_EFFECTS(MapScatterOp)
 DEFINE_OP_GET_EFFECTS(SortOp)
 DEFINE_OP_GET_EFFECTS(FftOp)
 DEFINE_OP_GET_EFFECTS(ScanOp)

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -332,13 +332,7 @@ LogicalResult MapScatterOp::verify() {
   if (hasPureBufferSemantics() && getNumResults() != 0) {
     return emitOpError("expected no result for memref output");
   }
-  if (hasPureTensorSemantics() && getNumResults() != 1) {
-    return emitOpError("expected one result for tensor output");
-  }
   Region &transformRegion = getTransformationRegion();
-  if (!transformRegion.hasOneBlock()) {
-    return emitOpError("expected a single block in the transform_region");
-  }
   Block &transformBody = transformRegion.getBlocks().front();
   if (transformBody.getNumArguments() != getInputRank()) {
     return emitOpError("expected number of block arguments to be equal "

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -325,13 +325,6 @@ LogicalResult MapScatterOp::verify() {
   if (getInputType().getElementType() != getOutputType().getElementType()) {
     return emitOpError("expected input and output element types to match");
   }
-  if (!hasPureBufferSemantics() && !hasPureTensorSemantics()) {
-    return emitOpError("expected input and output to be both tensor or both "
-                       "memref");
-  }
-  if (hasPureBufferSemantics() && getNumResults() != 0) {
-    return emitOpError("expected no result for memref output");
-  }
   Region &transformRegion = getTransformationRegion();
   Block &transformBody = transformRegion.getBlocks().front();
   if (transformBody.getNumArguments() != getInputRank()) {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -319,6 +319,61 @@ def IREELinalgExt_GatherOp : IREELinalgExt_Op<"gather",
   }];
 }
 
+def IREELinalgExt_MapScatterOp : IREELinalgExt_PureOp<"map_scatter",
+    [LinalgExtInterface, DestinationStyleOpInterface,
+     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+  let summary = "Scatter with a mapping from source indices to result indices";
+  let description = [{
+    Takes two inputs, `input` and `output`, and stores every element of `input`
+    to a unique location in `output`. If the operands are tensors, the op will
+    also return a Value for the result. For an element of the `input`, the index
+    to store into the `output` is determined by index computation mapping the
+    index in the `input` value to an index in the `output` value. This
+    computation is contained in the `transformation_region`, which contains a
+    single block, with one argument for each dimension in the `input` value.
+    The block arguments represent the index of a given element along the
+    corresponding dimension (i.e., block arg `i` represents the index along
+    dimension `i` of the `input` value). The block is terminated by an
+    iree_linalg_ext.yield op, which yields one index for each dimension in
+    the `output`, and an additional `i1` Value, which represents a mask on
+    whether or not to write to the `output` at the yielded set of indices. Iff
+    the mask value is true, the input value will be written.
+  }];
+  let arguments = (ins
+      AnyRankedTensorOrMemRefType:$input,
+      AnyRankedTensorOrMemRefType:$output
+  );
+  let results = (outs Variadic<AnyRankedTensor>:$results);
+  let regions = (region AnyRegion:$transformation_region);
+  let hasVerifier = 1;
+  let assemblyFormat = [{
+    attr-dict $input `into` $output
+    $transformation_region
+    `:` type($input) `into` type($output) (`->` type($results)^)?
+  }];
+
+  let extraClassDeclaration = [{
+    ShapedType getInputType() {
+      return cast<ShapedType>(getInput().getType());
+    }
+    int64_t getInputRank() {
+      return getInputType().getRank();
+    }
+    ShapedType getOutputType() {
+      return cast<ShapedType>(getOutput().getType());
+    }
+    int64_t getOutputRank() {
+      return getOutputType().getRank();
+    }
+
+    // Method to implement for specifying output range for
+    // DestinationStyleOpInterface
+    MutableOperandRange getDpsInitsMutable() {
+      return getOutputMutable();
+    }
+  }];
+}
+
 def IREELinalgExt_SortOp : IREELinalgExt_Op<"sort",
     [DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
      DeclareOpInterfaceMethods<TilingInterface,

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -321,16 +321,17 @@ def IREELinalgExt_GatherOp : IREELinalgExt_Op<"gather",
 
 def IREELinalgExt_MapScatterOp : IREELinalgExt_PureOp<"map_scatter",
     [LinalgExtInterface, DestinationStyleOpInterface,
-     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     SingleBlockImplicitTerminator<"::mlir::iree_compiler::IREE::LinalgExt::YieldOp">]> {
   let summary = "Scatter with a mapping from source indices to result indices";
   let description = [{
-    Takes two inputs, `input` and `output`, and stores every element of `input`
-    to a unique location in `output`. If the operands are tensors, the op will
-    also return a Value for the result. For an element of the `input`, the index
-    to store into the `output` is determined by index computation mapping the
-    index in the `input` value to an index in the `output` value. This
-    computation is contained in the `transformation_region`, which contains a
-    single block, with one argument for each dimension in the `input` value.
+    Takes two operands, `input` and `output`, and stores every element of
+    `input` to a unique location in `output`. If the operands are tensors, the
+    op will also return a Value for the result. For an element of the `input`,
+    the index to store into the `output` is determined by index computation
+    mapping the index in the `input` value to an index in the `output` value.
+    This computation is contained in the `transformation_region`, which contains
+    a single block, with one argument for each dimension in the `input` value.
     The block arguments represent the index of a given element along the
     corresponding dimension (i.e., block arg `i` represents the index along
     dimension `i` of the `input` value). The block is terminated by an

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -495,34 +495,6 @@ func.func @gather_dim_map_mismatch(
 
 // -----
 
-func.func @map_scatter_mixed_tensor_memref(
-    %input: memref<4xf32>, %output: tensor<4xf32>
-) -> tensor<4xf32> {
-  // expected-error@+1 {{expected input and output to be both tensor or both memref}}
-  %0 = iree_linalg_ext.map_scatter %input into %output {
-    ^bb0(%idx0: index):
-      %mask = arith.constant true
-      iree_linalg_ext.yield %idx0, %mask : index, i1
-  } : memref<4xf32> into tensor<4xf32> -> tensor<4xf32>
-  return %0 : tensor<4xf32>
-}
-
-// -----
-
-func.func @map_scatter_memref_with_result(
-    %input: memref<4xf32>, %output: memref<4xf32>
-) -> tensor<4xf32> {
-  // expected-error@+1 {{expected no result for memref output}}
-  %0 = iree_linalg_ext.map_scatter %input into %output {
-    ^bb0(%idx0: index):
-      %mask = arith.constant true
-      iree_linalg_ext.yield %idx0, %mask : index, i1
-  } : memref<4xf32> into memref<4xf32> -> tensor<4xf32>
-  return %0 : tensor<4xf32>
-}
-
-// -----
-
 func.func @map_scatter_mixed_element_types(
     %input: memref<4xf16>, %output: memref<4xf32>
 ) {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -523,20 +523,6 @@ func.func @map_scatter_memref_with_result(
 
 // -----
 
-func.func @map_scatter_tensor_without_result(
-    %input: tensor<4xf32>, %output: tensor<4xf32>
-) {
-  // expected-error@+1 {{expected one result for tensor output}}
-  iree_linalg_ext.map_scatter %input into %output {
-    ^bb0(%idx0: index):
-      %mask = arith.constant true
-      iree_linalg_ext.yield %idx0, %mask : index, i1
-  } : tensor<4xf32> into tensor<4xf32>
-  return
-}
-
-// -----
-
 func.func @map_scatter_mixed_element_types(
     %input: memref<4xf16>, %output: memref<4xf32>
 ) {
@@ -546,22 +532,6 @@ func.func @map_scatter_mixed_element_types(
       %mask = arith.constant true
       iree_linalg_ext.yield %idx0, %mask : index, i1
   } : memref<4xf16> into memref<4xf32>
-  return
-}
-
-// -----
-
-func.func @map_scatter_multi_block_region(
-    %input: memref<4xf32>, %output: memref<4xf32>
-) {
-  // expected-error@+1 {{expected a single block in the transform_region}}
-  iree_linalg_ext.map_scatter %input into %output {
-    ^bb0(%idx0: index):
-      %mask = arith.constant true
-      iree_linalg_ext.yield %idx0, %mask : index, i1
-    ^bb1:
-      iree_linalg_ext.yield %idx0, %mask : index, i1
-  } : memref<4xf32> into memref<4xf32>
   return
 }
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -495,6 +495,149 @@ func.func @gather_dim_map_mismatch(
 
 // -----
 
+func.func @map_scatter_mixed_tensor_memref(
+    %input: memref<4xf32>, %output: tensor<4xf32>
+) -> tensor<4xf32> {
+  // expected-error@+1 {{expected input and output to be both tensor or both memref}}
+  %0 = iree_linalg_ext.map_scatter %input into %output {
+    ^bb0(%idx0: index):
+      %mask = arith.constant true
+      iree_linalg_ext.yield %idx0, %mask : index, i1
+  } : memref<4xf32> into tensor<4xf32> -> tensor<4xf32>
+  return %0 : tensor<4xf32>
+}
+
+// -----
+
+func.func @map_scatter_memref_with_result(
+    %input: memref<4xf32>, %output: memref<4xf32>
+) -> tensor<4xf32> {
+  // expected-error@+1 {{expected no result for memref output}}
+  %0 = iree_linalg_ext.map_scatter %input into %output {
+    ^bb0(%idx0: index):
+      %mask = arith.constant true
+      iree_linalg_ext.yield %idx0, %mask : index, i1
+  } : memref<4xf32> into memref<4xf32> -> tensor<4xf32>
+  return %0 : tensor<4xf32>
+}
+
+// -----
+
+func.func @map_scatter_tensor_without_result(
+    %input: tensor<4xf32>, %output: tensor<4xf32>
+) {
+  // expected-error@+1 {{expected one result for tensor output}}
+  iree_linalg_ext.map_scatter %input into %output {
+    ^bb0(%idx0: index):
+      %mask = arith.constant true
+      iree_linalg_ext.yield %idx0, %mask : index, i1
+  } : tensor<4xf32> into tensor<4xf32>
+  return
+}
+
+// -----
+
+func.func @map_scatter_mixed_element_types(
+    %input: memref<4xf16>, %output: memref<4xf32>
+) {
+  // expected-error@+1 {{expected input and output element types to match}}
+  iree_linalg_ext.map_scatter %input into %output {
+    ^bb0(%idx0: index):
+      %mask = arith.constant true
+      iree_linalg_ext.yield %idx0, %mask : index, i1
+  } : memref<4xf16> into memref<4xf32>
+  return
+}
+
+// -----
+
+func.func @map_scatter_multi_block_region(
+    %input: memref<4xf32>, %output: memref<4xf32>
+) {
+  // expected-error@+1 {{expected a single block in the transform_region}}
+  iree_linalg_ext.map_scatter %input into %output {
+    ^bb0(%idx0: index):
+      %mask = arith.constant true
+      iree_linalg_ext.yield %idx0, %mask : index, i1
+    ^bb1:
+      iree_linalg_ext.yield %idx0, %mask : index, i1
+  } : memref<4xf32> into memref<4xf32>
+  return
+}
+
+// -----
+
+func.func @map_scatter_wrong_num_arguments(
+    %input: memref<4xf32>, %output: memref<4xf32>
+) {
+  // expected-error@+1 {{expected number of block arguments to be equal to the input rank}}
+  iree_linalg_ext.map_scatter %input into %output {
+    ^bb0(%idx0: index, %idx1: index):
+      %mask = arith.constant true
+      iree_linalg_ext.yield %idx0, %mask : index, i1
+  } : memref<4xf32> into memref<4xf32>
+  return
+}
+
+// -----
+
+func.func @map_scatter_wrong_argument_types(
+    %input: memref<4xf32>, %output: memref<4xf32>
+) {
+  // expected-error@+1 {{expected block arguments to be index types}}
+  iree_linalg_ext.map_scatter %input into %output {
+    ^bb0(%idx0: i64):
+      %mask = arith.constant true
+      %idx_cast = arith.index_cast %idx0 : i64 to index
+      iree_linalg_ext.yield %idx_cast, %mask : index, i1
+  } : memref<4xf32> into memref<4xf32>
+  return
+}
+
+// -----
+
+func.func @map_scatter_wrong_yielded_types(
+    %input: memref<4xf32>, %output: memref<4xf32>
+) {
+  iree_linalg_ext.map_scatter %input into %output {
+    ^bb0(%idx0: index):
+      %mask = arith.constant true
+      %idx_cast = arith.index_cast %idx0 : index to i64
+      // expected-error@+1 {{expected yielded indices to be index types}}
+      iree_linalg_ext.yield %idx_cast, %mask : i64, i1
+  } : memref<4xf32> into memref<4xf32>
+  return
+}
+
+// -----
+
+func.func @map_scatter_wrong_mask_type(
+    %input: memref<4xf32>, %output: memref<4xf32>
+) {
+  iree_linalg_ext.map_scatter %input into %output {
+    ^bb0(%idx0: index):
+      %mask = arith.constant 1 : i32
+      // expected-error@+1 {{expected yielded mask to be i1 type}}
+      iree_linalg_ext.yield %idx0, %mask : index, i32
+  } : memref<4xf32> into memref<4xf32>
+  return
+}
+
+// -----
+
+func.func @map_scatter_wrong_num_yielded_values(
+    %input: memref<4xf32>, %output: memref<4xf32>
+) {
+  iree_linalg_ext.map_scatter %input into %output {
+    ^bb0(%idx0: index):
+      // expected-error@+1 {{expected transformation_region to yield a value for each output dimension and a mask}}
+      iree_linalg_ext.yield %idx0 : index
+  } : memref<4xf32> into memref<4xf32>
+  return
+}
+
+// -----
+
 func.func @topk_invalid(%input_values: tensor<2x10xf32>, %input_indices: tensor<2x10xi32>, %out_values : tensor<2x3xf32>, %out_indices: tensor<2x3xi32>) -> (tensor<2x3xf32>, tensor<2x3xi32>) {
   // expected-error@+1 {{expected one or two input operands}}
   %0:2 = iree_linalg_ext.topk


### PR DESCRIPTION
Adds a new op called `iree_linalg_ext.map_scatter`, which represents a scattering of an input tensor to an output tensor by a mapping from input indices to unique output indices. The index mapping is represented by a region containing index computation operations, yielding a set of output indices and a mask.

The new op is useful for representing long chains of index transformation in a single operation, and can greatly simplify the handling of complex sequences of index transformation ops, like we often see in data tiling layout transformations.

This PR adds the op definition and verifier for the new op.