### PR TITLE
[DT][GPU] Retire experimental AMDGPU data-tiling flag.

### DIFF
--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -1619,8 +1619,6 @@ iree_generated_e2e_runner_test(
   COMPILER_FLAGS
     ${IREE_HIP_TEST_COMPILER_FLAGS}
     "--iree-opt-data-tiling"
-    "--iree-global-opt-experimental-rocm-data-tiling"
-    "--iree-global-opt-enable-early-materialization=true"
     "--iree-hip-enable-ukernels=multi_mma"
     "--iree-hip-encoding-layout-resolver=data-tiling"
   LABELS


### PR DESCRIPTION
In the matmul level input, i.e., not the model level, we are able to run set_encoding/unset_encoding on AMD GPU now. We are able to enable ukernels for `fill+multi_mma`. Thus, we no longer need the experimental flag.

This revision could impact performance because I did not verify the performance for a matmul. The e2e could get improved because we have less number of kernel launches, though. It is a reasonable switch because the test is mainly for correctness today.