### PR TITLE
Integrate llvm/llvm-project@1c8e5e2

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -314,10 +314,10 @@ struct ConvertToROCDLPass final
       populateFuncToLLVMConversionPatterns(converter, llvmPatterns);
       cf::populateControlFlowToLLVMConversionPatterns(converter, llvmPatterns);
       arith::populateArithToLLVMConversionPatterns(converter, llvmPatterns);
-      StringRef chipset = getGPUTargetAttr(m).getArch();
-      FailureOr<amdgpu::Chipset> maybeChipset = amdgpu::Chipset::parse(chipset);
-      populateAMDGPUToROCDLConversionPatterns(
-          converter, llvmPatterns, maybeChipset.value_or(amdgpu::Chipset()));
+      StringRef targetArch = getGPUTargetAttr(m).getArch();
+      amdgpu::Chipset chipset =
+          amdgpu::Chipset::parse(targetArch).value_or(amdgpu::Chipset());
+      populateAMDGPUToROCDLConversionPatterns(converter, llvmPatterns, chipset);
       vector::populateVectorRankReducingFMAPattern(llvmPatterns);
       vector::populateVectorInsertExtractStridedSliceTransforms(llvmPatterns);
       vector::populateVectorStepLoweringPatterns(llvmPatterns);
@@ -325,9 +325,8 @@ struct ConvertToROCDLPass final
       populateVectorToLLVMConversionPatterns(converter, llvmPatterns);
       vector::populateVectorTransferLoweringPatterns(llvmPatterns,
                                                      /*maxTransferRank=*/1);
-      populateGpuToROCDLConversionPatterns(
-          converter, llvmPatterns, gpu::amd::Runtime::Unknown,
-          maybeChipset.value_or(amdgpu::Chipset()));
+      populateGpuToROCDLConversionPatterns(converter, llvmPatterns,
+                                           gpu::amd::Runtime::Unknown, chipset);
       LLVMConversionTarget target(getContext());
       populateFuncToLLVMFuncOpConversionPattern(converter, llvmPatterns);
       configureGpuToROCDLConversionLegality(target);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -325,8 +325,9 @@ struct ConvertToROCDLPass final
       populateVectorToLLVMConversionPatterns(converter, llvmPatterns);
       vector::populateVectorTransferLoweringPatterns(llvmPatterns,
                                                      /*maxTransferRank=*/1);
-      populateGpuToROCDLConversionPatterns(converter, llvmPatterns,
-                                           gpu::amd::Runtime::Unknown);
+      populateGpuToROCDLConversionPatterns(
+          converter, llvmPatterns, gpu::amd::Runtime::Unknown,
+          maybeChipset.value_or(amdgpu::Chipset()));
       LLVMConversionTarget target(getContext());
       populateFuncToLLVMFuncOpConversionPattern(converter, llvmPatterns);
       configureGpuToROCDLConversionLegality(target);

--- a/compiler/src/iree/compiler/GlobalOptimization/test/raise_special_ops.mlir
+++ b/compiler/src/iree/compiler/GlobalOptimization/test/raise_special_ops.mlir
@@ -341,18 +341,17 @@ util.func public @test_slice_negate_cat_peephole(%arg0: tensor<1x32x1x128xf16>) 
 
 // CHECK-LABEL: util.func public @test_slice_negate_cat_peephole
 //  CHECK-SAME:     %[[ARG0:.+]]: tensor<1x32x1x128xf16>
+//       CHECK:   %[[C0:.+]] = arith.constant 0 : index
 //       CHECK:   %[[C1:.+]] = arith.constant 1 : index
 //       CHECK:   %[[EXPIN:.+]] = tensor.expand_shape %[[ARG0]] {{\[\[}}0], [1], [2], [3, 4]] output_shape [1, 32, 1, 2, 64] : tensor<1x32x1x128xf16> into tensor<1x32x1x2x64xf16>
 //       CHECK:   %[[NREV:.+]] = linalg.generic
 //  CHECK-SAME:       iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]
 
-//       CHECK:      %[[I0:.+]] = linalg.index 0 : index
 //       CHECK:      %[[I1:.+]] = linalg.index 1 : index
-//       CHECK:      %[[I2:.+]] = linalg.index 2 : index
 //       CHECK:      %[[I3:.+]] = linalg.index 3 : index
 //       CHECK:      %[[I4:.+]] = linalg.index 4 : index
 //       CHECK:      %[[R3:.+]] = arith.subi %[[C1]], %[[I3]] : index
-//       CHECK:      %[[EXTR:.+]] = tensor.extract %expanded[%[[I0]], %[[I1]], %[[I2]], %[[R3]], %[[I4]]] : tensor<1x32x1x2x64xf16>
+//       CHECK:      %[[EXTR:.+]] = tensor.extract %expanded[%[[C0]], %[[I1]], %[[C0]], %[[R3]], %[[I4]]] : tensor<1x32x1x2x64xf16>
 //       CHECK:      %[[NEGF:.+]] = arith.negf %[[EXTR]] : f16
 //       CHECK:      %[[CMP:.+]] = arith.cmpi eq, %[[R3]], %[[C1]] : index
 //       CHECK:      %[[SEL:.+]] = arith.select %[[CMP]], %[[NEGF]], %[[EXTR]] : f16


### PR DESCRIPTION
Updated LIT test from landing llvm/llvm-project#136640 which folds linalg.index when size is unit dim (1).

Added chipSet argument into populateGpuToROCDLConversionPatterns based on changes in llvm/llvm-project#137360

This patch carries revert of

llvm/llvm-project#133231. This PR breaks fp_to_subbytes and emulation_subbyte_types on llvm-cpu tests. iree-test-deps. tracker issue in #20645.

llvm/llvm-project#137122. StableHLO and Torch-mlir needs to update their usage of GreedyRewriteConfig to use fluent API. i.e enableRegionSimplification = VS setRegionSimplificationLevel

llvm/llvm-project#135970. StableHLO has issue with VHLO_IntegerAttr and APInt not being updated. StableHLO needs to be updated with that PR's change for us to be able to integrate.

llvm/llvm-project#121389. Torch-MLIR needs to be
updated with that PR's change for us to be able to integrate.