### PR TITLE
[LinalgExt] Implement tiling interface for map_scatter

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -321,7 +321,15 @@ def IREELinalgExt_GatherOp : IREELinalgExt_Op<"gather",
 
 def IREELinalgExt_MapScatterOp : IREELinalgExt_PureOp<"map_scatter",
     [LinalgExtInterface, DestinationStyleOpInterface,
-     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     DeclareOpInterfaceMethods<TilingInterface,
+        ["getIterationDomain",
+         "getLoopIteratorTypes",
+         "getResultTilePosition",
+         "getTiledImplementation",
+         "getIterationDomainTileFromOperandTile",
+         "getTiledImplementationFromOperandTile",
+         "generateScalarImplementation"]>]> {
   let summary = "Scatter with a mapping from source indices to result indices";
   let description = [{
     Takes two inputs, `input` and `output`, and stores every element of `input`
@@ -365,6 +373,19 @@ def IREELinalgExt_MapScatterOp : IREELinalgExt_PureOp<"map_scatter",
     int64_t getOutputRank() {
       return getOutputType().getRank();
     }
+
+    // Helper to apply transformations to the source index block arguments of
+    // the transformation body, and replace the uses of the previous source
+    // indices with the values returned by the builder function. The argument
+    // to the `transformationBuilder` function will be an ArrayRef of the new
+    // block arguments, the number of which is determined by `numSourceIndices`.
+    // The `transformationBuilder` should return the replacements for the old
+    // block arguments.
+    void insertTransformationAtStart(
+        OpBuilder &builder,
+        function_ref<SmallVector<Value>(ArrayRef<BlockArgument>)>
+            transformationBuilder,
+        int64_t numSourceIndices);
 
     // Method to implement for specifying output range for
     // DestinationStyleOpInterface

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
@@ -1520,3 +1520,37 @@ func.func @gather_inline_region(%arg0 : memref<2x2xi32>, %arg1 : memref<2x2xi32>
 // CHECK:           %[[LOAD0:.+]] = memref.load %[[ARG0]][%[[CAST0]], %[[CAST1]]] : memref<2x2xi32>
 // CHECK:           %[[MUL:.+]] = arith.muli %[[LOAD0]], %[[C3]] : i32
 // CHECK:           memref.store %[[MUL]], %[[ARG2]][%[[I]]] : memref<2xi32>
+
+// -----
+
+func.func @map_scatter_memref(
+  %input: memref<?xf32>, %output: memref<?x?xf32>, %bound: index
+) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %dim0 = memref.dim %output, %c0 : memref<?x?xf32>
+  %dim1 = memref.dim %output, %c1 : memref<?x?xf32>
+  iree_linalg_ext.map_scatter %input into %output {
+    ^bb0(%idx0: index):
+      %mask = arith.cmpi uge, %idx0, %bound : index
+      %out_idx:2 = affine.delinearize_index %idx0 into (%dim0, %dim1) : index, index
+      iree_linalg_ext.yield %out_idx#0, %out_idx#1, %mask : index, index, i1
+  } : memref<?xf32> into memref<?x?xf32>
+  return
+}
+//      CHECK: func @map_scatter_memref
+// CHECK-SAME:    %[[INPUT:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[OUTPUT:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[BOUND:[a-zA-Z0-9]+]]
+//  CHECK-DAG:   %[[C0:.+]] = arith.constant 0
+//  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
+//  CHECK-DAG:   %[[IN_D0:.+]] = memref.dim %[[INPUT]], %[[C0]]
+//  CHECK-DAG:   %[[OUT_D0:.+]] = memref.dim %[[OUTPUT]], %[[C0]]
+//  CHECK-DAG:   %[[OUT_D1:.+]] = memref.dim %[[OUTPUT]], %[[C1]]
+//      CHECK:   scf.for %[[IV:.+]] = %[[C0]] to %[[IN_D0]] step %[[C1]]
+//  CHECK-DAG:     %[[MASK:.+]] = arith.cmpi uge, %[[IV]], %[[BOUND]] : index
+//  CHECK-DAG:     %[[OUT_IDX:.+]]:2 = affine.delinearize_index %[[IV]] into (%[[OUT_D0]], %[[OUT_D1]]) : index, index
+//      CHECK:     scf.if %[[MASK]] {
+//  CHECK-DAG:       %[[INPUT_ELEM:.+]] = memref.load %[[INPUT]][%[[IV]]]
+//  CHECK-DAG:       memref.store %[[INPUT_ELEM]], %[[OUTPUT]]
+// CHECK-SAME:         [%[[OUT_IDX]]#0, %[[OUT_IDX]]#1] : memref<?x?xf32>


### PR DESCRIPTION
Implements the TilingInterface for `iree_linalg_ext.map_scatter`. This PR implements basic tiling, the scalar implementation (`generateScalarImplementation`), and consumer fusion (`getTiledImplementationFromOperandTile`). Producer fusion is not implemented, because the output does not get tiled.