### PR TITLE
[Codegen] Add pass to combine layout transformations

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -98,6 +98,7 @@ iree_compiler_cc_library(
         "BufferizeCopyOnlyDispatchesPass.cpp",
         "BufferizeDispatchTensorLoadStore.cpp",
         "CleanupBufferAllocViewPass.cpp",
+        "CombineLayoutTransformation.cpp",
         "ConcretizePadResultShape.cpp",
         "ConfigTrackingCanonicalizer.cpp",
         "ConvertAccGEMMToGEMMPass.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -86,6 +86,7 @@ iree_cc_library(
     "BufferizeCopyOnlyDispatchesPass.cpp"
     "BufferizeDispatchTensorLoadStore.cpp"
     "CleanupBufferAllocViewPass.cpp"
+    "CombineLayoutTransformation.cpp"
     "ConcretizePadResultShape.cpp"
     "ConfigTrackingCanonicalizer.cpp"
     "ConvertAccGEMMToGEMMPass.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -1,0 +1,318 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/Passes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
+#include "iree/compiler/Dialect/LinalgExt/Transforms/Transforms.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/MemRef/Transforms/Transforms.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "iree-codegen-combine-layout-transformation"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_COMBINELAYOUTTRANSFORMATIONPASS
+#include "iree/compiler/Codegen/Common/Passes.h.inc"
+
+using IREE::LinalgExt::MapScatterOp;
+
+//===----------------------------------------------------------------------===//
+// Preprocessing Utilities
+//===----------------------------------------------------------------------===//
+
+/// Convert complex ops into simpler ops by decomposing or raising to a named
+/// op.
+///  - `PackOp`s and `UnPackOp`s are decomposed.
+///  - Transpose `linalg::GenericOp`s are raised to `linalg::TransposeOp`s.
+static void simplifyComplexRelayoutOps(RewriterBase &rewriter,
+                                       FunctionOpInterface funcOp) {
+  OpBuilder::InsertionGuard g(rewriter);
+  SmallVector<linalg::PackOp> packOps(
+      funcOp.getFunctionBody().getOps<linalg::PackOp>());
+  for (auto packOp : packOps) {
+    rewriter.setInsertionPoint(packOp);
+    (void)linalg::lowerPack(rewriter, packOp,
+                            /*lowerPadLikeWithInsertSlice=*/false);
+  }
+  SmallVector<linalg::UnPackOp> unPackOps(
+      funcOp.getFunctionBody().getOps<linalg::UnPackOp>());
+  for (auto unPackOp : unPackOps) {
+    rewriter.setInsertionPoint(unPackOp);
+    (void)linalg::lowerUnPack(rewriter, unPackOp,
+                              /*lowerUnpadLikeWithExtractSlice=*/false);
+  }
+  SmallVector<linalg::GenericOp> genericOps(
+      funcOp.getFunctionBody().getOps<linalg::GenericOp>());
+  for (auto genericOp : genericOps) {
+    if (linalg::isaTransposeOpInterface(genericOp)) {
+      rewriter.setInsertionPoint(genericOp);
+      (void)linalg::specializeGenericOp(rewriter, genericOp);
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Combining Layout Transformation Ops
+//===----------------------------------------------------------------------===//
+
+/// Folds an `op` that does not affect index computation into a `mapScatterOp`.
+/// This is used for ops like `linalg::CopyOp`.
+static MapScatterOp
+foldIdentityLikeOpIntoMapScatter(RewriterBase &rewriter, Operation *op,
+                                 MapScatterOp mapScatterOp) {
+  assert(mapScatterOp.getInput() == op->getResult(0) &&
+         "expected op to be the producer of mapScatterOp");
+  rewriter.modifyOpInPlace(mapScatterOp, [&]() {
+    mapScatterOp.getInputMutable().assign(op->getOperand(0));
+  });
+  return mapScatterOp;
+}
+
+/// Fold a `transposeOp` into a consumer `mapScatterOp`, by transposing the
+/// uses of the `mapScatterOp`s transformation_region block arguments.
+static MapScatterOp foldTransposeIntoMapScatter(RewriterBase &rewriter,
+                                                linalg::TransposeOp transposeOp,
+                                                MapScatterOp mapScatterOp) {
+  assert(mapScatterOp.getInput() == transposeOp->getResult(0) &&
+         "expected transposeOp to be the producer of mapScatterOp");
+
+  ArrayRef<int64_t> perm = transposeOp.getPermutation();
+  auto indexTransformBuilder =
+      [&](ArrayRef<BlockArgument> srcIndices) -> SmallVector<Value> {
+    SmallVector<Value> indexValues(srcIndices);
+    return applyPermutation(indexValues, perm);
+  };
+  rewriter.modifyOpInPlace(mapScatterOp, [&]() {
+    mapScatterOp.insertTransformationAtStart(rewriter, indexTransformBuilder,
+                                             perm.size());
+    mapScatterOp.getInputMutable().assign(transposeOp.getInput());
+  });
+  return mapScatterOp;
+}
+
+/// Fold a tensor::ExpandShapeOp or tensor::CollapseShapeOp into a consumer
+/// `mapScatterOp`, by linearizing and then delinearizing the source indices
+/// of the `mapScatterOp`s index transformation.
+template <typename ReshapeOpTy>
+static MapScatterOp foldReshapeIntoMapScatter(RewriterBase &rewriter,
+                                              ReshapeOpTy reshapeOp,
+                                              MapScatterOp mapScatterOp) {
+  assert(mapScatterOp.getInput() == reshapeOp->getResult(0) &&
+         "expected reshapeOp to be the producer of mapScatterOp");
+  Location loc = reshapeOp->getLoc();
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPointAfter(reshapeOp);
+  SmallVector<OpFoldResult> srcDims =
+      tensor::getMixedSizes(rewriter, loc, reshapeOp.getSrc());
+  // There can be leftover tensor.dim ops consuming the result of the reshape,
+  // but they will be folded into some affine.apply ops on the source sizes by
+  // later cleanup patterns.
+  SmallVector<OpFoldResult> resultDims =
+      tensor::getMixedSizes(rewriter, loc, reshapeOp.getResult());
+
+  auto indexTransformBuilder =
+      [&](ArrayRef<BlockArgument> srcIndices) -> SmallVector<Value> {
+    auto linearizeIndexOp = rewriter.create<affine::AffineLinearizeIndexOp>(
+        mapScatterOp->getLoc(), srcIndices, srcDims, /*disjoint=*/true);
+    auto delinearizeIndexOp = rewriter.create<affine::AffineDelinearizeIndexOp>(
+        mapScatterOp->getLoc(), linearizeIndexOp.getResult(), resultDims,
+        /*hasOuterBound=*/true);
+    return delinearizeIndexOp->getResults();
+  };
+  rewriter.modifyOpInPlace(mapScatterOp, [&]() {
+    mapScatterOp.insertTransformationAtStart(rewriter, indexTransformBuilder,
+                                             srcDims.size());
+    mapScatterOp.getInputMutable().assign(reshapeOp->getOperand(0));
+  });
+  return mapScatterOp;
+}
+
+/// Fold an `extractSliceOp` into a consumer `mapScatterOp` by applying a mask
+/// based on the bounds of the extractSliceOp. Currently, only zero offsets and
+/// unit strides are supported.
+///
+/// For a given `%mask` value, and slice sizes of `%size0`, `%size1`, ...,
+/// `%sizeN`, the `%new_mask` becomes:
+///
+///   %bound0 = arith.cmpi ult, %idx0, %size0 : index
+///   %mask0 = arith.andi %mask, %bound0 : i1
+///   %bound1 = arith.cmpi ult, %idx1, %size1 : index
+///   %mask1 = arith.andi %mask0, %bound1 : i1
+///   ...
+///   %boundN = arith.cmpi ult, %idxN, %sizeN : index
+///   %new_mask = arith.andi %maskN-1, %boundN : i1
+static FailureOr<MapScatterOp>
+foldExtractSliceIntoMapScatter(RewriterBase &rewriter,
+                               tensor::ExtractSliceOp extractSliceOp,
+                               MapScatterOp mapScatterOp) {
+  assert(mapScatterOp.getInput() == extractSliceOp->getResult(0) &&
+         "expected extractSliceOp to be the producer of mapScatterOp");
+  // TODO(Max191): Support rank-reducing slices.
+  if (extractSliceOp.getSourceType().getRank() !=
+      extractSliceOp.getResultType().getRank()) {
+    return rewriter.notifyMatchFailure(
+        extractSliceOp, "rank reducing extract_slice op is not supported");
+  }
+  // TODO(Max191): Support non-zero offsets.
+  if (!areAllConstantIntValue(extractSliceOp.getMixedOffsets(), 0)) {
+    return rewriter.notifyMatchFailure(extractSliceOp,
+                                       "non-zero offsets are not supported");
+  }
+  // TODO(Max191): Support non-unit strides.
+  if (!areAllConstantIntValue(extractSliceOp.getMixedStrides(), 1)) {
+    return rewriter.notifyMatchFailure(extractSliceOp,
+                                       "non-unit strides are not supported");
+  }
+  SmallVector<OpFoldResult> bounds(extractSliceOp.getMixedSizes());
+  Block &transformBody = mapScatterOp.getTransformationRegion().front();
+  auto yieldOp = cast<IREE::LinalgExt::YieldOp>(transformBody.getTerminator());
+  Value mask = yieldOp->getOperands().back();
+
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(yieldOp);
+  Location loc = mapScatterOp->getLoc();
+  ArrayRef<BlockArgument> srcIndices = transformBody.getArguments();
+  for (auto [bound, srcIdx] : llvm::zip_equal(bounds, srcIndices)) {
+    Value boundValue = getValueOrCreateConstantIndexOp(rewriter, loc, bound);
+    auto isOutOfBounds =
+        rewriter
+            .create<arith::CmpIOp>(loc, arith::CmpIPredicate::ult, srcIdx,
+                                   boundValue)
+            ->getResult(0);
+    mask = rewriter.create<arith::AndIOp>(loc, mask, isOutOfBounds);
+  }
+  rewriter.modifyOpInPlace(yieldOp, [&]() {
+    yieldOp->setOperand(yieldOp->getNumOperands() - 1, mask);
+  });
+  rewriter.modifyOpInPlace(mapScatterOp, [&]() {
+    mapScatterOp.getInputMutable().assign(extractSliceOp.getSource());
+  });
+  return mapScatterOp;
+}
+
+/// Fold the `op` into the `mapScatterOp`, if possible. The resulting
+/// map_scatter op is returned, if the `op` was folded. Otherwise, return
+/// failure.
+static FailureOr<MapScatterOp> foldIntoMapScatter(RewriterBase &rewriter,
+                                                  Operation *op,
+                                                  MapScatterOp mapScatterOp) {
+  return llvm::TypeSwitch<Operation *, FailureOr<MapScatterOp>>(op)
+      .Case<linalg::CopyOp>([&](linalg::CopyOp copyOp) {
+        return foldIdentityLikeOpIntoMapScatter(rewriter, copyOp, mapScatterOp);
+      })
+      .Case<linalg::TransposeOp>([&](linalg::TransposeOp transposeOp) {
+        return foldTransposeIntoMapScatter(rewriter, transposeOp, mapScatterOp);
+      })
+      .Case<tensor::ExpandShapeOp>([&](tensor::ExpandShapeOp expandOp) {
+        return foldReshapeIntoMapScatter(rewriter, expandOp, mapScatterOp);
+      })
+      .Case<tensor::CollapseShapeOp>([&](tensor::CollapseShapeOp collapseOp) {
+        return foldReshapeIntoMapScatter(rewriter, collapseOp, mapScatterOp);
+      })
+      .Case<tensor::ExtractSliceOp>([&](tensor::ExtractSliceOp extractSliceOp) {
+        return foldExtractSliceIntoMapScatter(rewriter, extractSliceOp,
+                                              mapScatterOp);
+      })
+      .Default([](Operation *) { return failure(); });
+}
+
+/// Starting from the `root`, iteratively combine any relayout op producers
+/// into a single iree_linalg_ext.map_scatter op. An identity map_scatter op
+/// is inserted before the root, and then the producers of the map_scatter op
+/// are folded into the map_scatter until an unsupported op is reached.
+static void combineRelayoutOpChain(RewriterBase &rewriter,
+                                   MapScatterOp mapScatterOp) {
+  Operation *relayoutOp = mapScatterOp.getInput().getDefiningOp();
+  if (!relayoutOp) {
+    return;
+  }
+  MapScatterOp combinedRelayoutOp = mapScatterOp;
+  while (relayoutOp) {
+    LDBG("Attempting to fold " << relayoutOp->getName()
+                               << " into map_scatter op:\n"
+                               << *relayoutOp);
+    FailureOr<MapScatterOp> maybeCombinedRelayoutOp =
+        foldIntoMapScatter(rewriter, relayoutOp, combinedRelayoutOp);
+    if (failed(maybeCombinedRelayoutOp)) {
+      LDBG("Failed to fold " << relayoutOp->getName()
+                             << " into map_scatter op");
+      break;
+    }
+    combinedRelayoutOp = maybeCombinedRelayoutOp.value();
+    LDBG("Successfully folded " << relayoutOp->getName()
+                                << " into map_scatter. New map_scatter op:\n"
+                                << combinedRelayoutOp);
+    relayoutOp = combinedRelayoutOp.getInput().getDefiningOp();
+  }
+  if (combinedRelayoutOp.isIdentity()) {
+    rewriter.replaceOp(combinedRelayoutOp, combinedRelayoutOp.getInput());
+  }
+}
+
+static MapScatterOp
+insertIdentityMapScatter(RewriterBase &rewriter,
+                         IREE::Codegen::StoreToMemrefOp storeOp) {
+  Location loc = storeOp->getLoc();
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(storeOp);
+  auto mapScatterDest =
+      rewriter
+          .create<tensor::EmptyOp>(
+              loc, memref::getMixedSizes(rewriter, loc, storeOp.getTarget()),
+              storeOp.getValue().getType().getElementType())
+          .getResult();
+  auto mapScatterOp = MapScatterOp::createIdentityMapScatter(
+      rewriter, loc, storeOp.getValue(), mapScatterDest);
+  rewriter.modifyOpInPlace(storeOp, [&]() {
+    storeOp.getValueMutable().assign(mapScatterOp.getResult(0));
+  });
+  LDBG("Created identity map_scatter:\n" << mapScatterOp);
+  return mapScatterOp;
+}
+
+namespace {
+
+struct CombineLayoutTransformationPass final
+    : impl::CombineLayoutTransformationPassBase<
+          CombineLayoutTransformationPass> {
+  using impl::CombineLayoutTransformationPassBase<
+      CombineLayoutTransformationPass>::CombineLayoutTransformationPassBase;
+
+  void runOnOperation() override {
+    auto funcOp = getOperation();
+
+    // Apply some preprocessing to convert complex layout transformation
+    // ops like pack and unpack into simpler supported ops.
+    IRRewriter rewriter(&getContext());
+    simplifyComplexRelayoutOps(rewriter, funcOp);
+
+    // Start from iree_codegen.store_to_memref ops, and combine producer
+    // relayout ops into a single map_scatter.
+    SmallVector<IREE::Codegen::StoreToMemrefOp> dispatchResults(
+        funcOp.getFunctionBody().getOps<IREE::Codegen::StoreToMemrefOp>());
+    for (IREE::Codegen::StoreToMemrefOp dispatchResult : dispatchResults) {
+      MapScatterOp mapScatterOp =
+          insertIdentityMapScatter(rewriter, dispatchResult);
+      combineRelayoutOpChain(rewriter, mapScatterOp);
+    }
+
+    // Cleanup any tensor.dim ops that may be present after relayout
+    // combination.
+    RewritePatternSet cleanupPatterns(&getContext());
+    memref::populateResolveRankedShapedTypeResultDimsPatterns(cleanupPatterns);
+    if (failed(applyPatternsGreedily(funcOp, std::move(cleanupPatterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+
+} // namespace
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -123,6 +123,16 @@ def ConvertToDestinationPassingStylePass :
   ];
 }
 
+def CombineLayoutTransformationPass :
+    InterfacePass<"iree-codegen-combine-layout-transformation", "mlir::FunctionOpInterface"> {
+  let summary =
+    "Combines layout transformation operations on the results of a dispatch into a single operation.";
+  let dependentDialects = [
+    "iree_compiler::IREE::LinalgExt::IREELinalgExtDialect",
+    "tensor::TensorDialect"
+  ];
+}
+
 def ConvolutionToIGEMMPass :
     InterfacePass<"iree-codegen-convolution-to-igemm", "mlir::FunctionOpInterface"> {
   let summary =

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -27,6 +27,7 @@ iree_lit_test_suite(
             "bufferize_dispatch_tensor_load_store.mlir",
             "canonicalize_interface_load_store.mlir",
             "check_for_config.mlir",
+            "combine_layout_transformation.mlir",
             "convert_accgemm_to_gemm.mlir",
             "convert_bf16_to_uint16_buffers.mlir",
             "convert_bf16_arith_to_f32.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -23,6 +23,7 @@ iree_lit_test_suite(
     "bufferize_dispatch_tensor_load_store.mlir"
     "canonicalize_interface_load_store.mlir"
     "check_for_config.mlir"
+    "combine_layout_transformation.mlir"
     "convert_accgemm_to_gemm.mlir"
     "convert_bf16_arith_to_f32.mlir"
     "convert_bf16_to_uint16_buffers.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/combine_layout_transformation.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/combine_layout_transformation.mlir
@@ -1,0 +1,173 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-combine-layout-transformation,canonicalize,cse))" -split-input-file %s | FileCheck %s
+
+func.func @fold_collapse_shape_op(%source : tensor<2x4x16xf32>, %result : memref<8x16xf32>) {
+  %collapse = tensor.collapse_shape %source [[0, 1], [2]] : tensor<2x4x16xf32> into tensor<8x16xf32>
+  iree_codegen.store_to_memref %collapse, %result : tensor<8x16xf32> into memref<8x16xf32>
+  return
+}
+// CHECK-LABEL: @fold_collapse_shape_op
+//  CHECK-SAME:   %[[SOURCE:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[RESULT:[a-zA-Z0-9_]+]]
+//   CHECK-DAG:   %[[TRUE:.+]] = arith.constant true
+//       CHECK:   %[[MAP_SCATTER_DEST:.+]] = tensor.empty() : tensor<8x16xf32>
+//       CHECK:   %[[MAP_SCATTER:.+]] = iree_linalg_ext.map_scatter
+//  CHECK-SAME:     %[[SOURCE]] into %[[MAP_SCATTER_DEST]] {
+//  CHECK-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index, %[[IDX2:.+]]: index):
+//       CHECK:     %[[LINEARIZE:.+]] = affine.linearize_index
+//  CHECK-SAME:       [%[[IDX0]], %[[IDX1]]] by (2, 4)
+//       CHECK:     iree_linalg_ext.yield %[[LINEARIZE]], %[[IDX2]], %[[TRUE]] : index, index, i1
+//       CHECK:   } : tensor<2x4x16xf32> into tensor<8x16xf32> -> tensor<8x16xf32>
+//       CHECK:   iree_codegen.store_to_memref %[[MAP_SCATTER]], %[[RESULT]] : tensor<8x16xf32> into memref<8x16xf32>
+
+// -----
+
+func.func @fold_expand_shape_op(%source : tensor<8x16xf32>, %result : memref<2x4x16xf32>) {
+  %expand = tensor.expand_shape %source [[0, 1], [2]] output_shape [2, 4, 16] : tensor<8x16xf32> into tensor<2x4x16xf32>
+  iree_codegen.store_to_memref %expand, %result : tensor<2x4x16xf32> into memref<2x4x16xf32>
+  return
+}
+// CHECK-LABEL: @fold_expand_shape_op
+//  CHECK-SAME:   %[[SOURCE:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[RESULT:[a-zA-Z0-9_]+]]
+//   CHECK-DAG:   %[[TRUE:.+]] = arith.constant true
+//       CHECK:   %[[MAP_SCATTER_DEST:.+]] = tensor.empty() : tensor<2x4x16xf32>
+//       CHECK:   %[[MAP_SCATTER:.+]] = iree_linalg_ext.map_scatter
+//  CHECK-SAME:     %[[SOURCE]] into %[[MAP_SCATTER_DEST]] {
+//  CHECK-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index):
+//       CHECK:     %[[DELINEARIZE:.+]]:2 = affine.delinearize_index
+//  CHECK-SAME:       %[[IDX0]] into (2, 4) : index, index
+//       CHECK:     iree_linalg_ext.yield %[[DELINEARIZE]]#0, %[[DELINEARIZE]]#1, %[[IDX1]], %[[TRUE]]
+//       CHECK:   } : tensor<8x16xf32> into tensor<2x4x16xf32> -> tensor<2x4x16xf32>
+//       CHECK:   iree_codegen.store_to_memref %[[MAP_SCATTER]], %[[RESULT]] : tensor<2x4x16xf32> into memref<2x4x16xf32>
+
+// -----
+
+func.func @fold_transpose_op(%source : tensor<2x4x16xf32>, %result : memref<4x16x2xf32>) {
+  %init = tensor.empty() : tensor<4x16x2xf32>
+  %transposed = linalg.transpose ins(%source : tensor<2x4x16xf32>) outs(%init : tensor<4x16x2xf32>) permutation = [1, 2, 0]
+  iree_codegen.store_to_memref %transposed, %result : tensor<4x16x2xf32> into memref<4x16x2xf32>
+  return
+}
+// CHECK-LABEL: @fold_transpose_op
+//  CHECK-SAME:   %[[SOURCE:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[RESULT:[a-zA-Z0-9_]+]]
+//   CHECK-DAG:   %[[TRUE:.+]] = arith.constant true
+//       CHECK:   %[[MAP_SCATTER_DEST:.+]] = tensor.empty() : tensor<4x16x2xf32>
+//       CHECK:   %[[MAP_SCATTER:.+]] = iree_linalg_ext.map_scatter
+//  CHECK-SAME:     %[[SOURCE]] into %[[MAP_SCATTER_DEST]] {
+//  CHECK-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index, %[[IDX2:.+]]: index):
+//       CHECK:     iree_linalg_ext.yield %[[IDX1]], %[[IDX2]], %[[IDX0]], %[[TRUE]]
+//       CHECK:   } : tensor<2x4x16xf32> into tensor<4x16x2xf32> -> tensor<4x16x2xf32>
+//       CHECK:   iree_codegen.store_to_memref %[[MAP_SCATTER]], %[[RESULT]] : tensor<4x16x2xf32> into memref<4x16x2xf32>
+
+// -----
+
+func.func @fold_extract_slice_op(%source : tensor<64xf32>, %result : memref<63xf32>) {
+  %slice = tensor.extract_slice %source[0] [63] [1] : tensor<64xf32> to tensor<63xf32>
+  iree_codegen.store_to_memref %slice, %result : tensor<63xf32> into memref<63xf32>
+  return
+}
+// CHECK-LABEL: @fold_extract_slice_op
+//  CHECK-SAME:   %[[SOURCE:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[RESULT:[a-zA-Z0-9_]+]]
+//   CHECK-DAG:   %[[C63:.+]] = arith.constant 63 : index
+//       CHECK:   %[[MAP_SCATTER_DEST:.+]] = tensor.empty() : tensor<63xf32>
+//       CHECK:   %[[MAP_SCATTER:.+]] = iree_linalg_ext.map_scatter
+//  CHECK-SAME:     %[[SOURCE]] into %[[MAP_SCATTER_DEST]] {
+//  CHECK-NEXT:   ^bb0(%[[IDX0:.+]]: index):
+//       CHECK:     %[[MASK:.+]] = arith.cmpi ult, %[[IDX0]], %[[C63]] : index
+//       CHECK:     iree_linalg_ext.yield %[[IDX0]], %[[MASK]]
+//       CHECK:   } : tensor<64xf32> into tensor<63xf32> -> tensor<63xf32>
+//       CHECK:   iree_codegen.store_to_memref %[[MAP_SCATTER]], %[[RESULT]] : tensor<63xf32> into memref<63xf32>
+
+// -----
+
+func.func @no_fold_offset_extract_slice_op(%source : tensor<64xf32>, %result : memref<4xf32>) {
+  %slice = tensor.extract_slice %source[42] [4] [1] : tensor<64xf32> to tensor<4xf32>
+  iree_codegen.store_to_memref %slice, %result : tensor<4xf32> into memref<4xf32>
+  return
+}
+// CHECK-LABEL: @no_fold_offset_extract_slice_op
+//       CHECK:   tensor.extract_slice
+//   CHECK-NOT:   iree_linalg_ext.map_scatter
+
+// -----
+
+func.func @no_fold_strided_extract_slice_op(%source : tensor<64xf32>, %result : memref<16xf32>) {
+  %slice = tensor.extract_slice %source[0] [16] [4] : tensor<64xf32> to tensor<16xf32>
+  iree_codegen.store_to_memref %slice, %result : tensor<16xf32> into memref<16xf32>
+  return
+}
+// CHECK-LABEL: @no_fold_strided_extract_slice_op
+//       CHECK:   tensor.extract_slice
+//   CHECK-NOT:   iree_linalg_ext.map_scatter
+
+// -----
+
+func.func @fold_unpack_op(%source : tensor<?x?x128x128xf32>, %result : memref<?x?xf32>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %d0 = memref.dim %result, %c0 : memref<?x?xf32>
+  %d1 = memref.dim %result, %c1 : memref<?x?xf32>
+  %dest = tensor.empty(%d0, %d1) : tensor<?x?xf32>
+  %unpack = linalg.unpack %source
+      outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [128, 128]
+      into %dest : tensor<?x?x128x128xf32> -> tensor<?x?xf32>
+  iree_codegen.store_to_memref %unpack, %result : tensor<?x?xf32> into memref<?x?xf32>
+  return
+}
+//       CHECK: #[[$MAP:.+]] = affine_map<()[s0] -> (s0 * 128)>
+// CHECK-LABEL: @fold_unpack_op
+//  CHECK-SAME:   %[[SOURCE:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[RESULT:[a-zA-Z0-9_]+]]
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG:   %[[RES_D0:.+]] = memref.dim %[[RESULT]], %[[C0]] : memref<?x?xf32>
+//   CHECK-DAG:   %[[RES_D1:.+]] = memref.dim %[[RESULT]], %[[C1]] : memref<?x?xf32>
+//   CHECK-DAG:   %[[SRC_D0:.+]] = tensor.dim %[[SOURCE]], %[[C0]] : tensor<?x?x128x128xf32>
+//   CHECK-DAG:   %[[SRC_D1:.+]] = tensor.dim %[[SOURCE]], %[[C1]] : tensor<?x?x128x128xf32>
+//   CHECK-DAG:   %[[COLLAPSE_SIZE0:.+]] = affine.apply #[[$MAP]]()[%[[SRC_D0]]]
+//   CHECK-DAG:   %[[COLLAPSE_SIZE1:.+]] = affine.apply #[[$MAP]]()[%[[SRC_D1]]]
+//       CHECK:   %[[MAP_SCATTER_DEST:.+]] = tensor.empty(%[[RES_D0]], %[[RES_D1]]) : tensor<?x?xf32>
+//       CHECK:   %[[MAP_SCATTER:.+]] = iree_linalg_ext.map_scatter
+//  CHECK-SAME:     %[[SOURCE]] into %[[MAP_SCATTER_DEST]] {
+//  CHECK-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index, %[[IDX2:.+]]: index, %[[IDX3:.+]]: index):
+//       CHECK:     %[[LINEARIZE:.+]] = affine.linearize_index
+//  CHECK-SAME:       [%[[IDX0]], %[[IDX2]], %[[IDX1]], %[[IDX3]]]
+//  CHECK-SAME:       by (%[[SRC_D0]], 128, %[[SRC_D1]], 128)
+//       CHECK:     %[[DELINEARIZE:.+]]:2 = affine.delinearize_index %[[LINEARIZE]]
+//  CHECK-SAME:       into (%[[COLLAPSE_SIZE0]], %[[COLLAPSE_SIZE1]]) : index, index
+//       CHECK:     %[[BOUND0:.+]] = arith.cmpi ult, %[[DELINEARIZE]]#0, %[[RES_D0]] : index
+//       CHECK:     %[[BOUND1:.+]] = arith.cmpi ult, %[[DELINEARIZE]]#1, %[[RES_D1]] : index
+//       CHECK:     %[[MASK:.+]] = arith.andi %[[BOUND0]], %[[BOUND1]] : i1
+//       CHECK:     iree_linalg_ext.yield %[[DELINEARIZE]]#0, %[[DELINEARIZE]]#1, %[[MASK]] : index, index, i1
+//       CHECK:   } : tensor<?x?x128x128xf32> into tensor<?x?xf32> -> tensor<?x?xf32>
+//       CHECK:   iree_codegen.store_to_memref %[[MAP_SCATTER]], %[[RESULT]] : tensor<?x?xf32> into memref<?x?xf32>
+
+// -----
+
+func.func @fold_pack_op(%source : tensor<250x250xf32>, %result : memref<2x2x128x128xf32>) {
+  %cst = arith.constant 0.0 : f32
+  %dest = tensor.empty() : tensor<2x2x128x128xf32>
+  %unpack = linalg.pack %source padding_value(%cst : f32)
+      outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [128, 128]
+      into %dest : tensor<250x250xf32> -> tensor<2x2x128x128xf32>
+  iree_codegen.store_to_memref %unpack, %result : tensor<2x2x128x128xf32> into memref<2x2x128x128xf32>
+  return
+}
+// CHECK-LABEL: @fold_pack_op
+//  CHECK-SAME:   %[[SOURCE:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[RESULT:[a-zA-Z0-9_]+]]
+//   CHECK-DAG:   %[[TRUE:.+]] = arith.constant true
+//       CHECK:   %[[PAD:.+]] = tensor.pad %[[SOURCE]] low[0, 0] high[6, 6]
+//       CHECK:   %[[MAP_SCATTER_DEST:.+]] = tensor.empty() : tensor<2x2x128x128xf32>
+//       CHECK:   %[[MAP_SCATTER:.+]] = iree_linalg_ext.map_scatter
+//  CHECK-SAME:     %[[PAD]] into %[[MAP_SCATTER_DEST]] {
+//  CHECK-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index):
+//       CHECK:     %[[DELINEARIZE0:.+]]:2 = affine.delinearize_index %[[IDX0]]
+//  CHECK-SAME:       into (2, 128) : index, index
+//       CHECK:     %[[DELINEARIZE1:.+]]:2 = affine.delinearize_index %[[IDX1]]
+//  CHECK-SAME:       into (2, 128) : index, index
+//       CHECK:     iree_linalg_ext.yield %[[DELINEARIZE0]]#0, %[[DELINEARIZE1]]#0, %[[DELINEARIZE0]]#1, %[[DELINEARIZE1]]#1, %[[TRUE]]
+//       CHECK:   } : tensor<256x256xf32> into tensor<2x2x128x128xf32> -> tensor<2x2x128x128xf32>
+//       CHECK:   iree_codegen.store_to_memref %[[MAP_SCATTER]], %[[RESULT]] : tensor<2x2x128x128xf32> into memref<2x2x128x128xf32>

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -388,6 +388,18 @@ def IREELinalgExt_MapScatterOp : IREELinalgExt_PureOp<"map_scatter",
             transformationBuilder,
         int64_t numSourceIndices);
 
+    // Return true if the mapScatterOp is an identity transformation, meaning
+    // it is just doing a copy from input to output. This is true if the mask
+    // always evaluates to true, and the mapping from input to output index is
+    // identity.
+    bool isIdentity();
+
+    // Creates a MapScatterOp with an identity mapping in the transforamtion
+    // body. Expects the types of `input` and `output` to be the same.
+    static MapScatterOp createIdentityMapScatter(OpBuilder &builder,
+                                                 Location loc, Value input,
+                                                 Value output);
+
     // Method to implement for specifying output range for
     // DestinationStyleOpInterface
     MutableOperandRange getDpsInitsMutable() {


### PR DESCRIPTION
Adds a pass called `CombineLayoutTransformation` that collapses any relayouting ops (e.g., transpose, reshape, etc) and slices into a single `iree_linalg_ext.map_scatter` operation, if they are directly consumed by an `iree_codegen.store_to_memref` op. The idea behind this pass is to collapse complex layout transformations like the ones we see from set_encoding materialization, into a single op that is fusable by consumer fusion at the end of dispatches. This simplifies the cases we need to handle in codegen, and allows for more flexibility in fusing layout transformations into producer dispatch regions.

The pass works by starting at `iree_codegen.store_to_memref` ops, and inserting an identity map_scatter op. Then any supported producer ops are iteratively folded into the map_scatter op, until an unsupported op is reached. The currently supported ops are `linalg.copy`, `linalg.transpose`, `tensor.expand_shape`, `tensor.collapse_shape`, and `tensor.extract_slice`.

This pass is expected to eventually handle padding as well, but it is not implemented yet in this PR for simplicity.