### PR TITLE
Structuring hal.executable.export workgroup count region.

### DIFF
--- a/compiler/plugins/input/StableHLO/Conversion/test/stablehlo_to_linalg_ext.mlir
+++ b/compiler/plugins/input/StableHLO/Conversion/test/stablehlo_to_linalg_ext.mlir
@@ -28,7 +28,7 @@ func.func @sort_1d(%arg0: tensor<128xi32>) -> (tensor<128xi32>) {
 // CHECK-SAME:  )
 func.func @sort_1d_ui(%arg0: tensor<128xui32>) -> (tensor<128xui32>) {
   %0 = "stablehlo.sort"(%arg0) ( {
-  ^bb0(%arg2: tensor<ui32>, %arg3: tensor<ui32>):  // no predecessors
+  ^bb0(%arg2: tensor<ui32>, %arg3: tensor<ui32>):
     %1 = "stablehlo.compare"(%arg2, %arg3) {comparison_direction = #stablehlo<comparison_direction GT>} : (tensor<ui32>, tensor<ui32>) -> tensor<i1>
     "stablehlo.return"(%1) : (tensor<i1>) -> ()
   }) {dimension = 0 : i64, is_stable = false} : (tensor<128xui32>) -> (tensor<128xui32>)

--- a/compiler/plugins/input/Torch/InputConversion/test/scatter.mlir
+++ b/compiler/plugins/input/Torch/InputConversion/test/scatter.mlir
@@ -6,7 +6,7 @@ func.func @scatter_update(
   %0 = tm_tensor.scatter {dimension_map = array<i64: 0>} unique_indices(true)
     ins(%updates, %indices : tensor<3xi32>, tensor<3x1xi32>)
     outs(%original : tensor<8xi32>)  {
-  ^bb0(%update: i32, %orig: i32):  // no predecessors
+  ^bb0(%update: i32, %orig: i32):
     tm_tensor.yield %update: i32
   } -> tensor<8xi32>
   return %0 : tensor<8xi32>
@@ -32,7 +32,7 @@ func.func @scatter_add(
   %0 = tm_tensor.scatter {dimension_map = array<i64: 0>} unique_indices(true)
     ins(%updates, %indices : tensor<3xi32>, tensor<3x1xi32>)
     outs(%original : tensor<8xi32>)  {
-  ^bb0(%update: i32, %orig: i32):  // no predecessors
+  ^bb0(%update: i32, %orig: i32):
     %add = arith.addi %orig, %update: i32
     tm_tensor.yield %add: i32
   } -> tensor<8xi32>

--- a/compiler/plugins/target/LLVMCPU/test/smoketest_embedded.mlir
+++ b/compiler/plugins/target/LLVMCPU/test/smoketest_embedded.mlir
@@ -26,7 +26,7 @@ stream.executable public @add_dispatch_0 {
       %1 = iree_tensor_ext.dispatch.tensor.load %arg0, offsets=[0], sizes=[16], strides=[1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xf32>> -> tensor<16xf32>
       %2 = iree_tensor_ext.dispatch.tensor.load %arg1, offsets=[0], sizes=[16], strides=[1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xf32>> -> tensor<16xf32>
       %3 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%1, %2 : tensor<16xf32>, tensor<16xf32>) outs(%0 : tensor<16xf32>) {
-      ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):  // no predecessors
+      ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):
         %4 = arith.addf %arg3, %arg4 : f32
         linalg.yield %4 : f32
       } -> tensor<16xf32>

--- a/compiler/plugins/target/LLVMCPU/test/smoketest_system.mlir
+++ b/compiler/plugins/target/LLVMCPU/test/smoketest_system.mlir
@@ -28,7 +28,7 @@ stream.executable public @add_dispatch_0 {
       %1 = iree_tensor_ext.dispatch.tensor.load %arg0, offsets=[0], sizes=[16], strides=[1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xf32>> -> tensor<16xf32>
       %2 = iree_tensor_ext.dispatch.tensor.load %arg1, offsets=[0], sizes=[16], strides=[1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xf32>> -> tensor<16xf32>
       %3 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%1, %2 : tensor<16xf32>, tensor<16xf32>) outs(%0 : tensor<16xf32>) {
-      ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):  // no predecessors
+      ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):
         %4 = arith.addf %arg3, %arg4 : f32
         linalg.yield %4 : f32
       } -> tensor<16xf32>

--- a/compiler/plugins/target/ROCM/builtins/tuning/test/spec_gfx942.mlir
+++ b/compiler/plugins/target/ROCM/builtins/tuning/test/spec_gfx942.mlir
@@ -28,8 +28,7 @@
 ]>
 hal.executable public @main {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @matmul_transpose_b ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @matmul_transpose_b ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -78,8 +77,7 @@ hal.executable public @main {
 ]>
 hal.executable public @main {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @attention ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @attention ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -133,8 +131,7 @@ hal.executable public @main {
 ]>
 hal.executable public @main {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @attention ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @attention ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }

--- a/compiler/plugins/target/ROCM/test/external_function_validation.mlir
+++ b/compiler/plugins/target/ROCM/test/external_function_validation.mlir
@@ -21,14 +21,12 @@ builtin.module {
     // expected-error @+2 {{found an unresolved external function 'external_func' in the final bitcode}}
     // expected-error @+1 {{failed to serialize executable for target backend rocm}}
     hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
-      hal.executable.export public @test ordinal(0) layout(#pipeline_layout)
-        attributes {subgroup_size = 64 : index, workgroup_size = [128 : index, 2 : index, 1 : index]} {
-      ^bb0(%arg0: !hal.device):
+      hal.executable.export public @test ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
         %c128 = arith.constant 128 : index
         %c2 = arith.constant 2 : index
         %c1 = arith.constant 1 : index
         hal.return %c128, %c2, %c1 : index, index, index
-      }
+      } attributes {subgroup_size = 64 : index, workgroup_size = [128 : index, 2 : index, 1 : index]}
       builtin.module {
         llvm.func @external_func() attributes {sym_visibility = "private"}
         llvm.func @test() attributes { rocdl.kernel } {

--- a/compiler/plugins/target/ROCM/test/lowering_strategy_from_tuning_spec.mlir
+++ b/compiler/plugins/target/ROCM/test/lowering_strategy_from_tuning_spec.mlir
@@ -27,8 +27,7 @@
 ]>
 hal.executable public @main {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @matmul_transpose_b ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @matmul_transpose_b ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }

--- a/compiler/plugins/target/ROCM/test/opt_pass_plugin/gpu_hello.mlir
+++ b/compiler/plugins/target/ROCM/test/opt_pass_plugin/gpu_hello.mlir
@@ -24,7 +24,7 @@ stream.executable public @add_dispatch_0 {
       %1 = iree_tensor_ext.dispatch.tensor.load %arg0, offsets=[0], sizes=[16], strides=[1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xf32>> -> tensor<16xf32>
       %2 = iree_tensor_ext.dispatch.tensor.load %arg1, offsets=[0], sizes=[16], strides=[1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xf32>> -> tensor<16xf32>
       %3 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%1, %2 : tensor<16xf32>, tensor<16xf32>) outs(%0 : tensor<16xf32>) {
-      ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):  // no predecessors
+      ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):
         %4 = arith.addf %arg3, %arg4 : f32
         linalg.yield %4 : f32
       } -> tensor<16xf32>

--- a/compiler/plugins/target/VMVX/test/smoketest.mlir
+++ b/compiler/plugins/target/VMVX/test/smoketest.mlir
@@ -23,7 +23,7 @@ stream.executable public @add_dispatch_0 {
       %1 = iree_tensor_ext.dispatch.tensor.load %arg0, offsets=[0], sizes=[128], strides=[1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128xf32>> -> tensor<128xf32>
       %2 = iree_tensor_ext.dispatch.tensor.load %arg1, offsets=[0], sizes=[128], strides=[1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<128xf32>> -> tensor<128xf32>
       %3 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%1, %2 : tensor<128xf32>, tensor<128xf32>) outs(%0 : tensor<128xf32>) {
-      ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):  // no predecessors
+      ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):
         %4 = arith.addf %arg3, %arg4 : f32
         linalg.yield %4 : f32
       } -> tensor<128xf32>

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_distribute_shared_memory.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_distribute_shared_memory.mlir
@@ -23,7 +23,7 @@ module {
       ins(%m0 : memref<64x16xf32>)
       outs(%sm0 : memref<64x16xf32, 3>)
       attrs= {__internal_linalg_transform__ = "copy_to_workgroup_memory"} {
-      ^bb0(%arg4: f32, %s: f32):  // no predecessors
+      ^bb0(%arg4: f32, %s: f32):
         linalg.yield %arg4 : f32
     }
 
@@ -32,7 +32,7 @@ module {
       ins(%m1 : memref<256x4xf32>)
       outs(%sm1 : memref<256x4xf32, 3>)
       attrs= {__internal_linalg_transform__ = "copy_to_workgroup_memory"} {
-      ^bb0(%arg4: f32, %s: f32):  // no predecessors
+      ^bb0(%arg4: f32, %s: f32):
         linalg.yield %arg4 : f32
     }
 
@@ -41,7 +41,7 @@ module {
       ins(%m2 : memref<3x512xf32>)
       outs(%sm2 : memref<3x512xf32, 3>)
       attrs= {__internal_linalg_transform__ = "copy_to_workgroup_memory"} {
-      ^bb0(%arg4: f32, %s: f32):  // no predecessors
+      ^bb0(%arg4: f32, %s: f32):
         linalg.yield %arg4 : f32
     }
     gpu.barrier

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_reorder_workgroups_static.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_reorder_workgroups_static.mlir
@@ -25,13 +25,12 @@
 ]>
 hal.executable private @main_dispatch_0 {
 hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-  hal.executable.export public @main_dispatch_0_matmul_transpose_b_32000x32000x4096_f16 ordinal(0) layout(#pipeline_layout) attributes {subgroup_size = 64 : index, translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse, {pipeline_depth = 0 : i64, store_stage = 1 : i64}>, workgroup_size = [64 : index, 16 : index, 1 : index]} {
-  ^bb0(%arg0: !hal.device):
+  hal.executable.export public @main_dispatch_0_matmul_transpose_b_32000x32000x4096_f16 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
     %c250 = arith.constant 250 : index
     %c500 = arith.constant 500 : index
     %c1 = arith.constant 1 : index
     hal.return %c250, %c500, %c1 : index, index, index
-  }
+  } attributes {subgroup_size = 64 : index, translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUTileAndFuse, {pipeline_depth = 0 : i64, store_stage = 1 : i64}>, workgroup_size = [64 : index, 16 : index, 1 : index]}
   builtin.module {
     func.func @main_dispatch_0_matmul_transpose_b_32000x32000x4096_f16() {
       %c128 = arith.constant 128 : index

--- a/compiler/src/iree/compiler/Codegen/Common/test/convert_to_destination_passing_style.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/convert_to_destination_passing_style.mlir
@@ -459,7 +459,7 @@ func.func @multi_result() {
       %22:2 = linalg.generic {indexing_maps = [#map, #map, #map, #map], iterator_types = ["parallel", "parallel"]}
         ins(%20, %21 : tensor<?x?xf32>, tensor<?x?xf32>)
         outs(%shape, %shape : tensor<?x?xf32>, tensor<?x?xf32>) {
-        ^bb0(%arg2: f32, %arg3 : f32, %arg4 : f32, %arg5 : f32):  // no predecessors
+        ^bb0(%arg2: f32, %arg3 : f32, %arg4 : f32, %arg5 : f32):
           %23 = arith.mulf %arg2, %arg3 : f32
           %24 = arith.addf %arg2, %arg3 : f32
           linalg.yield %23, %24 : f32, f32
@@ -536,7 +536,7 @@ func.func @unused_ins_operand() {
         %26 = tensor.empty(%22, %23) : tensor<?x?xi32>
         %27 = tensor.empty(%22, %23, %24) : tensor<?x?x?xi32>
         %28 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%25, %26 : tensor<?x?x?xi32>, tensor<?x?xi32>) outs(%27 : tensor<?x?x?xi32>) attrs =  {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[], [1, 4, 4]]>} {
-        ^bb0(%arg3: i32, %arg4: i32, %arg5: i32):  // no predecessors
+        ^bb0(%arg3: i32, %arg4: i32, %arg5: i32):
           %29 = arith.index_cast %arg3 : i32 to index
           %30 = linalg.index 0 : index
           %31 = affine.apply affine_map<(d0, d1) -> (d0 + d1)>(%30, %arg0)

--- a/compiler/src/iree/compiler/Codegen/Common/test/fold_affine_min_of_block_id.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/fold_affine_min_of_block_id.mlir
@@ -6,8 +6,7 @@
 ]>
 hal.executable public @generic_static {
   hal.executable.variant public @cuda_nvptx_fb target(<"cuda", "cuda-nvptx-fb">) {
-    hal.executable.export public @generic_static ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+    hal.executable.export public @generic_static ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index) -> (index, index, index) {
       %c128 = arith.constant 128 : index
       %c1 = arith.constant 1 : index
       hal.return %c128, %c128, %c1 : index, index, index

--- a/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
@@ -2399,7 +2399,7 @@ func.func @topk() {
         dimension(1)
         ins(%input_values, %input_indices : tensor<200x8xf32> , tensor<200x8xi32>)
         outs(%out_values, %out_indices : tensor<200x3xf32>, tensor<200x3xi32>) {
-        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+        ^bb0(%arg0: f32, %arg1: f32):
           %2 = arith.cmpf ogt, %arg0, %arg1 : f32
           iree_linalg_ext.yield %2 : i1
         } -> tensor<200x3xf32>, tensor<200x3xi32>

--- a/compiler/src/iree/compiler/Codegen/Common/test/propagate_dispatch_size_bounds.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/propagate_dispatch_size_bounds.mlir
@@ -17,13 +17,12 @@
 
 hal.executable private @static {
   hal.executable.variant public @rocm_hsaco_fb target(#executable_target) {
-    hal.executable.export public @static ordinal(0) layout(#pipeline_layout) attributes {workgroup_size = [64 : index, 2 : index, 1 : index]} {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @static ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c32 = arith.constant 32 : index
       %c8 = arith.constant 8 : index
       %c1 = arith.constant 1 : index
       hal.return %c32, %c8, %c1 : index, index, index
-    }
+    } attributes {workgroup_size = [64 : index, 2 : index, 1 : index]}
     builtin.module {
 // CHECK-LABEL: func.func @static()
       func.func @static() {
@@ -88,13 +87,12 @@ hal.executable private @static {
 
 hal.executable private @manual_subgroup_size {
   hal.executable.variant public @rocm_hsaco_fb target(#executable_target) {
-    hal.executable.export public @manual_subgroup_size ordinal(0) layout(#pipeline_layout) attributes {subgroup_size = 64 : index} {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @manual_subgroup_size ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c32 = arith.constant 32 : index
       %c8 = arith.constant 8 : index
       %c1 = arith.constant 1 : index
       hal.return %c32, %c8, %c1 : index, index, index
-    }
+    } attributes {subgroup_size = 64 : index}
     builtin.module {
 // CHECK-LABEL: func.func @manual_subgroup_size()
       func.func @manual_subgroup_size() {
@@ -124,8 +122,7 @@ hal.executable private @manual_subgroup_size {
 
 hal.executable private @dynamic {
   hal.executable.variant public @rocm_hsaco_fb target(#executable_target) {
-    hal.executable.export public @dynamic ordinal(0) layout(#pipeline_layout) {
-      ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+    hal.executable.export public @dynamic ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index) -> (index, index, index) {
       %count_x = affine.apply affine_map<()[s0] -> (s0 ceildiv 32)>()[%arg1]
       %count_y = affine.apply affine_map<()[s0] -> (s0 ceildiv 8)>()[%arg2]
       %count_z = arith.constant 1 : index
@@ -182,13 +179,12 @@ hal.executable private @dynamic {
 
 hal.executable private @static_cpu {
   hal.executable.variant public @embedded_elf_x86_64 target(#executable_target) {
-    hal.executable.export public @static_cpu ordinal(0) layout(#pipeline_layout) attributes {workgroup_size = [64 : index, 2 : index, 1 : index]} {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @static_cpu ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c32 = arith.constant 32 : index
       %c8 = arith.constant 8 : index
       %c1 = arith.constant 1 : index
       hal.return %c32, %c8, %c1 : index, index, index
-    }
+    } attributes {workgroup_size = [64 : index, 2 : index, 1 : index]}
     builtin.module {
 // CHECK-LABEL: func.func @static_cpu()
       func.func @static_cpu() {
@@ -219,8 +215,7 @@ hal.executable private @static_cpu {
 
 hal.executable private @dynamic_cpu {
   hal.executable.variant public @embedded_elf_x86_64 target(#executable_target) {
-    hal.executable.export public @dynamic_cpu ordinal(0) layout(#pipeline_layout) {
-      ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+    hal.executable.export public @dynamic_cpu ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index) -> (index, index, index) {
       %count_x = affine.apply affine_map<()[s0] -> (s0 ceildiv 32)>()[%arg1]
       %count_y = affine.apply affine_map<()[s0] -> (s0 ceildiv 8)>()[%arg2]
       %count_z = arith.constant 1 : index

--- a/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info.mlir
@@ -154,8 +154,7 @@ hal.executable private @llvm_func_attrs {
     #hal.pipeline.binding<storage_buffer>]>
 hal.executable private @scf_forall_2D {
   hal.executable.variant public @scf_forall_2D target(#hal.executable.target<"", "", {}>) {
-    hal.executable.export public @scf_forall_2D layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+    hal.executable.export public @scf_forall_2D layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
@@ -181,7 +180,7 @@ hal.executable private @scf_forall_2D {
 //  CHECK-DAG: #[[MAP2:.+]] = affine_map<()[s0] -> (s0 * 64)>
 //  CHECK-DAG: #[[MAP3:.+]] = affine_map<()[s0] -> (s0 * 32)>
 //      CHECK: hal.executable.export public @scf_forall_2D layout
-// CHECK-NEXT:     %[[ARG1:[a-zA-z0-9]+]]: index
+// CHECK-SAME:     %[[ARG1:[a-zA-z0-9]+]]: index
 // CHECK-SAME:     %[[ARG2:[a-zA-z0-9]+]]: index
 // CHECK-SAME:     %[[ARG3:[a-zA-z0-9]+]]: index
 //  CHECK-DAG:   %[[WG_Y:.+]] = affine.apply #[[MAP0]]()[%[[ARG1]]]
@@ -202,8 +201,7 @@ hal.executable private @scf_forall_2D {
     #hal.pipeline.binding<storage_buffer>]>
 hal.executable private @scf_forall_2D_dynamic_tile_size {
   hal.executable.variant public @scf_forall_2D_dynamic_tile_size target(#hal.executable.target<"", "", {}>) {
-    hal.executable.export public @scf_forall_2D_dynamic_tile_size layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index):
+    hal.executable.export public @scf_forall_2D_dynamic_tile_size layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2, %arg3, %arg4
       hal.return %x, %y, %z : index, index, index
     }
@@ -229,7 +227,7 @@ hal.executable private @scf_forall_2D_dynamic_tile_size {
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0, s1] -> (s0 ceildiv s1)
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0, s1] -> (s1 * s0)>
 //      CHECK: hal.executable.export public @scf_forall_2D_dynamic_tile_size layout
-// CHECK-NEXT:     %[[ARG1:[a-zA-z0-9]+]]: index
+// CHECK-SAME:     %[[ARG1:[a-zA-z0-9]+]]: index
 // CHECK-SAME:     %[[ARG2:[a-zA-z0-9]+]]: index
 // CHECK-SAME:     %[[ARG3:[a-zA-z0-9]+]]: index
 // CHECK-SAME:     %[[ARG4:[a-zA-z0-9]+]]: index
@@ -253,10 +251,9 @@ hal.executable private @scf_forall_2D_dynamic_tile_size {
     #hal.pipeline.binding<storage_buffer>]>
 hal.executable private @scf_forall_4D {
   hal.executable.variant public @scf_forall_4D target(#hal.executable.target<"", "", {}>) {
-    hal.executable.export public @scf_forall_4D layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index,
-         %arg5 : index, %arg6 : index, %arg7 : index, %arg8 : index,
-         %arg9 : index, %arg10 : index, %arg11 : index, %arg12 : index):
+    hal.executable.export public @scf_forall_4D layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4: index,
+                                                                               %arg5: index, %arg6: index, %arg7: index, %arg8: index,
+                                                                               %arg9: index, %arg10: index, %arg11: index, %arg12: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2, %arg3,
           %arg4, %arg5, %arg6, %arg7, %arg8, %arg9, %arg10, %arg11, %arg12
       hal.return %x, %y, %z : index, index, index
@@ -303,7 +300,7 @@ hal.executable private @scf_forall_4D {
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0, s1, s2, s3, s4, s5] -> (((-s0 + s1) ceildiv s2) * ((-s3 + s4) ceildiv s5))>
 //  CHECK-DAG: #[[MAP2:.+]] = affine_map<()[s0, s1] -> (s1 * s0)>
 //      CHECK: hal.executable.export public @scf_forall_4D layout
-// CHECK-NEXT:     %[[ARG1:[a-zA-z0-9]+]]: index
+// CHECK-SAME:     %[[ARG1:[a-zA-z0-9]+]]: index
 // CHECK-SAME:     %[[ARG2:[a-zA-z0-9]+]]: index
 // CHECK-SAME:     %[[ARG3:[a-zA-z0-9]+]]: index
 // CHECK-SAME:     %[[ARG4:[a-zA-z0-9]+]]: index
@@ -347,8 +344,7 @@ hal.executable private @scf_forall_4D {
     #hal.pipeline.binding<storage_buffer>]>
 hal.executable private @scf_forall_4D_static_interchange {
   hal.executable.variant public @scf_forall_4D_static_interchange target(#hal.executable.target<"", "", {}>) {
-    hal.executable.export public @scf_forall_4D_static_interchange layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @scf_forall_4D_static_interchange layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -394,8 +390,7 @@ hal.executable private @scf_forall_4D_static_interchange {
     #hal.pipeline.binding<storage_buffer>]>
 hal.executable private @no_loop_do_nothing {
   hal.executable.variant public @no_loop_do_nothing target(#hal.executable.target<"", "", {}>) {
-    hal.executable.export public @no_loop_do_nothing layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @no_loop_do_nothing layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1: index
       %c2 = arith.constant 2: index
       hal.return %c1, %c2, %c1 : index, index, index
@@ -420,8 +415,7 @@ hal.executable private @no_loop_do_nothing {
     #hal.pipeline.binding<storage_buffer>]>
 hal.executable private @no_loop_default_workgroup_count {
   hal.executable.variant public @no_loop_default_workgroup_count target(#hal.executable.target<"", "", {}>) {
-    hal.executable.export public @no_loop_default_workgroup_count layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+    hal.executable.export public @no_loop_default_workgroup_count layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
       %0:3 = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2
       hal.return %0#1, %0#2, %0#0 : index, index, index
     }

--- a/compiler/src/iree/compiler/Codegen/Common/test/remove_trivial_loops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/remove_trivial_loops.mlir
@@ -8,8 +8,7 @@
 // CHECK-LABEL: func.func @dispatch_0()
 hal.executable private @dispatch_0  {
   hal.executable.variant @cuda target(#hal.executable.target<"cuda", "cuda-nvptx-fb">) {
-    hal.executable.export @dispatch_0 layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device) :
+    hal.executable.export public @dispatch_0 layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }
@@ -55,8 +54,7 @@ hal.executable private @dispatch_0  {
 #translation = #iree_codegen.translation_info<pipeline = LLVMGPUDistribute workgroup_size = [32, 1, 1]>
 hal.executable private @workgroup_tile_loop  {
   hal.executable.variant @cuda target(#hal.executable.target<"cuda", "cuda-nvptx-fb">) {
-    hal.executable.export @workgroup_tile_loop layout(#pipeline_layout) {
-    ^bb0(%arg0 : !hal.device, %arg1 : index):
+    hal.executable.export public @workgroup_tile_loop layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       %c64 = arith.constant 64 : index
       hal.return %c64, %c1, %c1 : index, index, index
@@ -90,8 +88,7 @@ hal.executable private @workgroup_tile_loop  {
 #translation = #iree_codegen.translation_info<pipeline = LLVMGPUDistribute>
 hal.executable private @workgroup_tile_loop_negative  {
   hal.executable.variant @cuda target(#hal.executable.target<"cuda", "cuda-nvptx-fb">) {
-    hal.executable.export @workgroup_tile_loop_negative layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1 : index):
+    hal.executable.export public @workgroup_tile_loop_negative layout(#pipeline_layout) count(%arg0: !hal.device, %arg1 : index) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       %0 = affine.apply affine_map<(d0) -> (d0 ceildiv 16)>(%arg1)
       hal.return %0, %c1, %c1 : index, index, index
@@ -127,8 +124,7 @@ hal.executable private @workgroup_tile_loop_negative  {
 #translation = #iree_codegen.translation_info<pipeline = LLVMGPUDistribute workgroup_size = [8, 2, 1]>
 hal.executable private @both_workgroup_and_workitem  {
   hal.executable.variant @cuda target(#hal.executable.target<"cuda", "cuda-nvptx-fb">) {
-    hal.executable.export @both_workgroup_and_workitem layout(#pipeline_layout) {
-    ^bb0(%arg0 : !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+    hal.executable.export public @both_workgroup_and_workitem layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       %c14 = arith.constant 14 : index
       %c112 = arith.constant 112: index
@@ -194,8 +190,7 @@ hal.executable private @both_workgroup_and_workitem  {
 #map3 = affine_map<(d0)[s0] -> (d0 + s0)>
 hal.executable private @simple_mul {
   hal.executable.variant public @variant target(#hal.executable.target<"cuda", "cuda-nvptx-fb">) {
-    hal.executable.export public @simple_mul ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
+    hal.executable.export public @simple_mul ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       %0 = affine.apply #map0()[%arg1]
       hal.return %0, %c1, %c1 : index, index, index
@@ -254,8 +249,7 @@ hal.executable private @simple_mul {
 // CHECK-LABEL: func.func @delinearize_linearize()
 hal.executable private @delinearize_linearize {
   hal.executable.variant @rocm_hsaco_fb target(#hal.executable.target<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export @delinearize_linearize layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device) :
+    hal.executable.export public @delinearize_linearize layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }
@@ -312,8 +306,7 @@ hal.executable private @delinearize_linearize {
 // CHECK-LABEL: func.func @workgroup_id
 hal.executable private @workgroup_id {
   hal.executable.variant @rocm_hsaco_fb target(#hal.executable.target<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export @workgroup_id layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device) :
+    hal.executable.export public @workgroup_id layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c8 = arith.constant 8 : index
       hal.return %c8, %c8, %c8 : index, index, index
     }
@@ -343,8 +336,7 @@ hal.executable private @workgroup_id {
 // CHECK-LABEL: func.func @argument_with_assume
 hal.executable private @argument_with_assume {
   hal.executable.variant @rocm_hsaco_fb target(#hal.executable.target<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export @workgroup_id layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device) :
+    hal.executable.export public @workgroup_id layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }

--- a/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
@@ -16,8 +16,7 @@
 #translation = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 hal.executable private @matmul_tensors {
   hal.executable.variant public @llvm target(#executable_target_embedded_elf_arm_64_) {
-    hal.executable.export public @matmul_tensors layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+    hal.executable.export public @matmul_tensors layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
@@ -57,7 +56,7 @@ hal.executable private @matmul_tensors {
 //  CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0)[s0] -> (-d0 + s0, 64)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 //      CHECK: hal.executable.export public @matmul_tensors
-// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_M:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[WORKLOAD_N:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[WORKLOAD_K:[a-zA-Z0-9_]+]]: index)
@@ -113,8 +112,7 @@ hal.executable private @matmul_tensors {
 #translation = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 hal.executable private @add {
   hal.executable.variant public @llvm target(#executable_target_embedded_elf_x86_64_) {
-    hal.executable.export public @add layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+    hal.executable.export public @add layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
@@ -154,7 +152,7 @@ hal.executable private @add {
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 //      CHECK: hal.executable private @add
 //      CHECK: hal.executable.export public @add
-// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[WORKLOAD_1:[a-zA-Z0-9_]+]]: index)
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
@@ -184,8 +182,7 @@ hal.executable private @add {
 #translation = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 hal.executable private @add4D {
   hal.executable.variant public @llvm target(#executable_target_embedded_elf_x86_64_) {
-    hal.executable.export public @add4D layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 :index):
+    hal.executable.export public @add4D layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 :index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2, %arg3, %arg4
       hal.return %x, %y, %z : index, index, index
     }
@@ -227,7 +224,7 @@ hal.executable private @add4D {
 //  CHECK-DAG: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 //      CHECK: hal.executable.export public @add4D
-// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[WORKLOAD_1:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[WORKLOAD_2:[a-zA-Z0-9_]+]]: index
@@ -261,8 +258,7 @@ hal.executable private @add4D {
 #translation = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 hal.executable private @add_distribute4D {
   hal.executable.variant public @llvm target(#executable_target_embedded_elf_x86_64_) {
-    hal.executable.export public @add_distribute4D layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 :index):
+    hal.executable.export public @add_distribute4D layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 :index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2, %arg3, %arg4
       hal.return %x, %y, %z : index, index, index
     }
@@ -314,7 +310,7 @@ hal.executable private @add_distribute4D {
 
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 //      CHECK: hal.executable.export public @add_distribute4D
-// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[WORKLOAD_1:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[WORKLOAD_2:[a-zA-Z0-9_]+]]: index
@@ -382,8 +378,7 @@ hal.executable private @add_distribute4D {
 #translation = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 hal.executable private @add_distribute4D_zero_tile_size {
   hal.executable.variant public @llvm target(#executable_target_embedded_elf_x86_64_) {
-    hal.executable.export public @add_distribute4D_zero_tile_size layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 :index):
+    hal.executable.export public @add_distribute4D_zero_tile_size layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 :index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2, %arg3, %arg4
       hal.return %x, %y, %z : index, index, index
     }
@@ -427,7 +422,7 @@ hal.executable private @add_distribute4D_zero_tile_size {
 
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 //      CHECK: hal.executable.export public @add_distribute4D_zero_tile_size
-// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[WORKLOAD_1:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[WORKLOAD_2:[a-zA-Z0-9_]+]]: index
@@ -454,8 +449,7 @@ hal.executable private @add_distribute4D_zero_tile_size {
 #translation = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 hal.executable private @batch_matmul_tensors {
   hal.executable.variant public @llvm target(#executable_target_embedded_elf_arm_64_) {
-    hal.executable.export public @batch_matmul_tensors layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index):
+    hal.executable.export public @batch_matmul_tensors layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2, %arg3, %arg4
       hal.return %x, %y, %z : index, index, index
     }
@@ -494,7 +488,7 @@ hal.executable private @batch_matmul_tensors {
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 //      CHECK: hal.executable.export public @batch_matmul_tensors
-// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[WORKLOAD_1:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[WORKLOAD_2:[a-zA-Z0-9_]+]]: index
@@ -523,8 +517,7 @@ hal.executable private @batch_matmul_tensors {
 #translation = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 hal.executable private @preset_config_matmul_tensors {
   hal.executable.variant public @system_elf_x86_64 target(#executable_target_system_elf_x86_64_) {
-    hal.executable.export public @preset_config layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @preset_config layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -555,7 +548,7 @@ hal.executable private @preset_config_matmul_tensors {
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 * 32)>
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 * 16)>
 //      CHECK: hal.executable.export public @preset_config
-// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device)
+// CHECK-SAME:   (%[[DEVICE:.+]]: !hal.device)
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
 //  CHECK-DAG:   %[[C4:.+]] = arith.constant 4 : index
 //  CHECK-DAG:   %[[C32:.+]] = arith.constant 32 : index
@@ -584,8 +577,7 @@ hal.executable private @preset_config_matmul_tensors {
 #translation = #iree_codegen.translation_info<pipeline = CPUBufferOpsTileAndVectorize>
 hal.executable public @copy_op {
   hal.executable.variant public @system_elf_x86_64 target(#executable_target_system_elf_x86_64_) {
-    hal.executable.export public @copy_op layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3: index, %arg4 : index, %arg5: index, %arg6 : index, %arg7: index, %arg8 : index, %arg9: index, %arg10: index):
+    hal.executable.export public @copy_op layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3: index, %arg4 : index, %arg5: index, %arg6 : index, %arg7: index, %arg8 : index, %arg9: index, %arg10: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7, %arg8, %arg9, %arg10
       hal.return %x, %y, %z : index, index, index
     }
@@ -683,8 +675,7 @@ hal.executable public @copy_op {
 #translation = #iree_codegen.translation_info<pipeline = CPUDefault>
 hal.executable private @static_1d_fft_stage2 {
   hal.executable.variant public @system_elf_x86_64 target(#executable_target_system_elf_x86_64_) {
-    hal.executable.export public @static_1d_fft_stage2 layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @static_1d_fft_stage2 layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -736,8 +727,7 @@ hal.executable private @static_1d_fft_stage2 {
 #translation = #iree_codegen.translation_info<pipeline = CPUDefault>
 hal.executable private @static_3d_fft_stage3 {
   hal.executable.variant public @system_elf_x86_64 target(#executable_target_system_elf_x86_64_) {
-    hal.executable.export public @static_3d_fft_stage3 layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @static_3d_fft_stage3 layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -790,8 +780,7 @@ hal.executable private @static_3d_fft_stage3 {
 #translation = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 hal.executable private @outs_fusion {
   hal.executable.variant public @system_elf_x86_64 target(#executable_target_system_elf_x86_64_) {
-    hal.executable.export public @outs_fusion_fn layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+    hal.executable.export public @outs_fusion_fn layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
@@ -838,7 +827,7 @@ hal.executable private @outs_fusion {
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 //      CHECK: hal.executable private @outs_fusion
 //      CHECK: hal.executable.export public @outs_fusion_fn
-// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[WORKLOAD_1:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[WORKLOAD_2:[a-zA-Z0-9_]+]]: index)
@@ -872,8 +861,7 @@ hal.executable private @outs_fusion {
 #translation = #iree_codegen.translation_info<pipeline = CPUDefault>
 hal.executable private @conv {
   hal.executable.variant public @system_elf_x86_64 target(#executable_target_system_elf_x86_64_) {
-    hal.executable.export public @conv layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index, %arg5 : index, %arg6 : index, %arg7 : index, %arg8 : index, %arg9 : index):
+    hal.executable.export public @conv layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index, %arg5 : index, %arg6 : index, %arg7 : index, %arg8 : index, %arg9 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7, %arg8, %arg9
       hal.return %x, %y, %z : index, index, index
     }
@@ -922,7 +910,7 @@ hal.executable private @conv {
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDefault>
 //      CHECK: hal.executable private @conv
 //      CHECK: hal.executable.export public @conv
-// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[WORKLOAD_1:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[WORKLOAD_2:[a-zA-Z0-9_]+]]: index
@@ -960,8 +948,7 @@ hal.executable private @conv {
 #translation = #iree_codegen.translation_info<pipeline = CPUDefault>
 hal.executable private @conv_static {
   hal.executable.variant public @system_elf_x86_64 target(#executable_target_system_elf_x86_64_) {
-    hal.executable.export public @conv_static layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index, %arg5 : index, %arg6 : index):
+    hal.executable.export public @conv_static layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index, %arg5 : index, %arg6 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3, %arg4, %arg5, %arg6
       hal.return %x, %y, %z : index, index, index
     }
@@ -995,7 +982,7 @@ hal.executable private @conv_static {
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDefault>
 //      CHECK: hal.executable private @conv_static
 //      CHECK: hal.executable.export public @conv_static
-// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[WORKLOAD_1:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[WORKLOAD_2:[a-zA-Z0-9_]+]]: index
@@ -1033,8 +1020,7 @@ hal.executable private @conv_static {
 #translation = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 hal.executable private @generic_static {
   hal.executable.variant public @system_elf_x86_64 target(#executable_target_system_elf_x86_64_) {
-    hal.executable.export public @generic_static layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @generic_static layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -1097,8 +1083,7 @@ hal.executable private @generic_static {
 #translation = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 hal.executable private @matmul_static {
   hal.executable.variant public @system_elf_arm_64 target(#executable_target_system_elf_arm_64_) {
-    hal.executable.export public @matmul_static layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @matmul_static layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -1150,8 +1135,7 @@ hal.executable private @matmul_static {
 #translation = #iree_codegen.translation_info<pipeline = CPUDefault>
 hal.executable private @restrict_num_workgroups {
   hal.executable.variant public @system_elf_arm_64 target(#executable_target_system_elf_arm_64_) {
-    hal.executable.export public @restrict_num_workgroups layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @restrict_num_workgroups layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -1205,11 +1189,10 @@ hal.executable private @restrict_num_workgroups {
 #translation = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 hal.executable private @reduction {
   hal.executable.variant public @reduction target(#executable_target_embedded_elf_x86_64_) {
-    hal.executable.export public @reduction ordinal(0) layout(#pipeline_layout) attributes {translation_info = #translation} {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @reduction ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
-    }
+    } attributes {translation_info = #translation}
     builtin.module {
       func.func @reduction(%arg0 : !iree_tensor_ext.dispatch.tensor<readonly:tensor<7x7x2048xf32>>,
           %arg1 : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<7xf32>>) attributes {translation_info = #translation} {
@@ -1273,8 +1256,7 @@ hal.executable private @reduction {
 #translation = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 hal.executable private @gemm_unit_N {
   hal.executable.variant public @embedded_elf_x86_64 target(#executable_target_embedded_elf_x86_64_) {
-    hal.executable.export public @gemm_unit_N ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+    hal.executable.export public @gemm_unit_N ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
@@ -1310,7 +1292,7 @@ hal.executable private @gemm_unit_N {
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 //      CHECK: hal.executable private @gemm_unit_N
 //      CHECK: hal.executable.export public @gemm_unit_N
-// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_0:[a-zA-Z0-9_]+]]: index,
 // CHECK-SAME:    %[[WORKLOAD_1:[a-zA-Z0-9_]+]]: index)
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
@@ -1343,8 +1325,7 @@ hal.executable private @gemm_unit_N {
 #translation = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 hal.executable private @gemm_unit_M_unit_N {
   hal.executable.variant public @embedded_elf_x86_64 target(#executable_target_embedded_elf_x86_64_) {
-    hal.executable.export public @gemm_unit_M_unit_N ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @gemm_unit_M_unit_N ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -1376,7 +1357,7 @@ hal.executable private @gemm_unit_M_unit_N {
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 //      CHECK: hal.executable private @gemm_unit_M_unit_N
 //      CHECK: hal.executable.export public @gemm_unit_M_unit_N
-// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device)
+// CHECK-SAME:   (%[[DEVICE:.+]]: !hal.device)
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
 //      CHECK:   hal.return %[[C1]], %[[C1]], %[[C1]] : index, index, index
 //      CHECK: func.func @gemm_unit_M_unit_N()
@@ -1400,8 +1381,7 @@ hal.executable private @gemm_unit_M_unit_N {
 #translation = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 hal.executable private @generic_unit_dims {
   hal.executable.variant public @llvm target(#executable_target_embedded_elf_x86_64_) {
-    hal.executable.export public @generic_unit_dims layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index):
+    hal.executable.export public @generic_unit_dims layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2, %arg3, %arg4
       hal.return %x, %y, %z : index, index, index
     }
@@ -1440,7 +1420,7 @@ hal.executable private @generic_unit_dims {
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 //      CHECK: hal.executable private @generic_unit_dims
 //      CHECK: hal.executable.export public @generic_unit_dims
-// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[WORKLOAD_1:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[WORKLOAD_2:[a-zA-Z0-9_]+]]: index
@@ -1473,8 +1453,7 @@ hal.executable private @generic_unit_dims {
 #translation = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 hal.executable private @reduce_to_scalar {
   hal.executable.variant public @llvm target(#executable_target_embedded_elf_x86_64_) {
-    hal.executable.export public @reduce_to_scalar layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index):
+    hal.executable.export public @reduce_to_scalar layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1
       hal.return %x, %y, %z : index, index, index
     }
@@ -1507,7 +1486,7 @@ hal.executable private @reduce_to_scalar {
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 //      CHECK: hal.executable private @reduce_to_scalar
 //      CHECK: hal.executable.export public @reduce_to_scalar
-// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_0:[a-zA-Z0-9_]+]]: index)
 //      CHECK:   %[[C1:.+]] = arith.constant 1 : index
 //      CHECK:   hal.return %[[C1]], %[[C1]], %[[C1]] : index, index, index
@@ -1530,8 +1509,7 @@ hal.executable private @reduce_to_scalar {
 #translation = #iree_codegen.translation_info<pipeline = CPUDefault>
 hal.executable private @scalar {
   hal.executable.variant public @llvm target(#executable_target_embedded_elf_x86_64_) {
-    hal.executable.export public @scalar layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @scalar layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -1563,7 +1541,7 @@ hal.executable private @scalar {
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDefault>
 //      CHECK: hal.executable private @scalar
 //      CHECK: hal.executable.export public @scalar
-// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device)
+// CHECK-SAME:   (%[[DEVICE:.+]]: !hal.device)
 //      CHECK:   %[[C1:.+]] = arith.constant 1 : index
 //      CHECK:   hal.return %[[C1]], %[[C1]], %[[C1]] : index, index, index
 //      CHECK: func.func @scalar()
@@ -1585,8 +1563,7 @@ hal.executable private @scalar {
 #translation = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 hal.executable private @rank_reduced_slice {
   hal.executable.variant public @llvm target(#executable_target_embedded_elf_arm_64_) {
-    hal.executable.export public @rank_reduced_slice layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index):
+    hal.executable.export public @rank_reduced_slice layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1
       hal.return %x, %y, %z : index, index, index
     }
@@ -1618,7 +1595,7 @@ hal.executable private @rank_reduced_slice {
 //  CHECK-DAG: #[[MAP:.+]] = affine_map<()[s0] -> (s0 + 10)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 //      CHECK: hal.executable.export public @rank_reduced_slice
-// CHECK-NEXT:   %[[WORKLOAD:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:   %[[WORKLOAD:[a-zA-Z0-9]+]]: index
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //  CHECK-DAG:   %[[C5:.+]] = arith.constant 5
 //      CHECK:   hal.return %[[C5]], %[[C1]], %[[C1]]
@@ -1651,8 +1628,7 @@ hal.executable private @rank_reduced_slice {
 #translation = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 hal.executable private @matmul_interchange {
   hal.executable.variant public @llvm target(#executable_target_embedded_elf_x86_64_) {
-    hal.executable.export public @matmul_interchange layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+    hal.executable.export public @matmul_interchange layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
@@ -1691,7 +1667,7 @@ hal.executable private @matmul_interchange {
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 //      CHECK: hal.executable.export public @matmul_interchange
-// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[WORKLOAD_1:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[WORKLOAD_2:[a-zA-Z0-9_]+]]: index)
@@ -1714,8 +1690,7 @@ hal.executable private @matmul_interchange {
 ]>
 hal.executable private @no_compute {
   hal.executable.variant public @embedded_elf_x86_64 target(<"llvm-cpu", "embedded-elf-x86_64", {}>) {
-    hal.executable.export public @no_compute ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4 : index, %arg5 : index):
+    hal.executable.export public @no_compute ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4 : index, %arg5 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2, %arg3, %arg4, %arg5
       hal.return %x, %y, %z : index, index, index
     }
@@ -1747,7 +1722,6 @@ hal.executable private @no_compute {
   }
 }
 //      CHECK: hal.executable.export public @no_compute
-// CHECK-NEXT: ^bb0
 // CHECK-NEXT:   %[[C1:.+]] = arith.constant 1 : index
 // CHECK-NEXT:   hal.return %[[C1]], %[[C1]], %[[C1]]
 
@@ -1761,8 +1735,7 @@ hal.executable private @no_compute {
 ]>
 hal.executable private @tile_multiuse_producer {
   hal.executable.variant public @embedded_elf_x86_64 target(<"llvm-cpu", "embedded-elf_x86_64", {}>) {
-    hal.executable.export public @tile_multiuse_producer ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @tile_multiuse_producer ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -1861,8 +1834,7 @@ hal.executable private @tile_multiuse_producer {
 ]>
 hal.executable private @no_tile {
   hal.executable.variant public @embedded_elf_x86_64 target(<"llvm-cpu", "embedded-elf-x86_64", {}>) {
-    hal.executable.export public @no_tile ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @no_tile ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -1902,8 +1874,7 @@ hal.executable private @no_tile {
 ]>
 hal.executable private @pack_lowering {
   hal.executable.variant public @embedded_elf_x86_64 target(<"llvm-cpu", "embedded-elf-x86_64", {}>) {
-    hal.executable.export public @gemm_lhs_pack ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @gemm_lhs_pack ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -1929,7 +1900,6 @@ hal.executable private @pack_lowering {
   }
 }
 //      CHECK: hal.executable.export public @gemm_lhs_pack
-// CHECK-NEXT:   %[[ARG0:.+]]: !hal.device
 //  CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : index
 //  CHECK-DAG:   %[[C6:.+]] = arith.constant 6 : index
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
@@ -1943,8 +1913,7 @@ hal.executable private @pack_lowering {
 ]>
 hal.executable private @pack_lowering {
   hal.executable.variant public @embedded_elf_x86_64 target(<"llvm-cpu", "embedded-elf-x86_64", {}>) {
-    hal.executable.export public @gemm_rhs_transpose_pack ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @gemm_rhs_transpose_pack ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -1984,8 +1953,7 @@ hal.executable private @pack_lowering {
 ]>
 hal.executable private @clone_index_computations {
   hal.executable.variant public @embedded_elf_x86_64 target(<"llvm-cpu", "embedded-elf-x86_64", {}>) {
-    hal.executable.export public @clone_index_computations ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3 : index, %arg4 : index):
+    hal.executable.export public @clone_index_computations ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3 : index, %arg4 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2, %arg3, %arg4
       hal.return %x, %y, %z : index, index, index
     }
@@ -2050,8 +2018,7 @@ hal.executable private @clone_index_computations {
 ]>
 hal.executable private @dynamic_unpack {
   hal.executable.variant public @embedded_elf_x86_64 target(<"llvm-cpu", "embedded-elf-x86_64", {}>) {
-    hal.executable.export public @dynamic_unpack ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4: index):
+    hal.executable.export public @dynamic_unpack ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2, %arg3, %arg4
       hal.return %x, %y, %z : index, index, index
     }
@@ -2097,8 +2064,7 @@ hal.executable private @dynamic_unpack {
 ]>
 hal.executable private @dynamic_unpack_dynamic_tile {
   hal.executable.variant public @embedded_elf_x86_64 target(<"llvm-cpu", "embedded-elf-x86_64", {}>) {
-    hal.executable.export public @dynamic_unpack_dynamic_tile ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4: index):
+    hal.executable.export public @dynamic_unpack_dynamic_tile ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2, %arg3, %arg4
       hal.return %x, %y, %z : index, index, index
     }
@@ -2150,8 +2116,7 @@ hal.executable private @dynamic_unpack_dynamic_tile {
 ]>
 hal.executable private @unpack_elem {
   hal.executable.variant public @embedded_elf_arm_64 target(<"llvm-cpu", "embedded-elf-arm_64", {}>) {
-    hal.executable.export public @unpack_elem ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @unpack_elem ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -2192,8 +2157,7 @@ hal.executable private @unpack_elem {
 #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
 hal.executable private @dynamic_unpack_fusion {
   hal.executable.variant public @vmvx_bytecode_fb target(<"vmvx", "vmvx-bytecode-fb", {ukernels = true}>) {
-    hal.executable.export public @dynamic_unpack_fusion ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @dynamic_unpack_fusion ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -2256,8 +2220,7 @@ hal.executable private @dynamic_unpack_fusion {
 ]>
 hal.executable private @elem_pack {
   hal.executable.variant public @embedded_elf_arm_64 target(<"llvm-cpu", "embedded-elf-arm_64", {cpu = "generic", cpu_features = "", data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-elf"}>) {
-    hal.executable.export public @elem_pack ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @elem_pack ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -2329,8 +2292,7 @@ hal.executable private @scatter {
       #hal.pipeline.binding<storage_buffer, ReadOnly>,
       #hal.pipeline.binding<storage_buffer>
     ]>)
-    {
-    ^bb0(%arg0: !hal.device):
+    count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -2369,8 +2331,7 @@ hal.executable private @scatter {
 ]>
 hal.executable private @collapse_workgroups_dispatch_dispatch_0 {
   hal.executable.variant public @cuda_nvptx_fb target(<"cuda", "cuda-nvptx-fb">) {
-    hal.executable.export public @collapse_workgroups_dispatch_dispatch_0_generic_1024x128x16x64 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @collapse_workgroups_dispatch_dispatch_0_generic_1024x128x16x64 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -2393,13 +2354,12 @@ hal.executable private @collapse_workgroups_dispatch_dispatch_0 {
 }
 
 // CHECKW-LABEL:   hal.executable private @collapse_workgroups_dispatch_dispatch_0 {
-//       CHECKW:           hal.executable.variant public @cuda_nvptx_fb
-//       CHECKW:             hal.executable.export public @collapse_workgroups_dispatch_dispatch_0_generic_1024x128x16x64 ordinal(0) layout({{.+}}) {
-//       CHECKW:             ^bb0(%[[ARG0:.*]]: !hal.device):
-//   CHECKW-DAG:               %[[C2097152:.*]] = arith.constant 2097152 : index
-//   CHECKW-DAG:               %[[C1:.*]] = arith.constant 1 : index
-//       CHECKW:               hal.return %[[C2097152]], %[[C1]], %[[C1]] : index, index, index
-//       CHECKW:             }
+//       CHECKW:     hal.executable.variant public @cuda_nvptx_fb
+//       CHECKW:       hal.executable.export public @collapse_workgroups_dispatch_dispatch_0_generic_1024x128x16x64 ordinal(0) layout({{.+}})
+//   CHECKW-DAG:         %[[C2097152:.*]] = arith.constant 2097152 : index
+//   CHECKW-DAG:         %[[C1:.*]] = arith.constant 1 : index
+//       CHECKW:         hal.return %[[C2097152]], %[[C1]], %[[C1]] : index, index, index
+//       CHECKW:       }
 
 // -----
 
@@ -2418,8 +2378,7 @@ hal.executable private @collapse_workgroups_dispatch_dispatch_0 {
 #translation = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 hal.executable private @matmul_tensors {
   hal.executable.variant public @llvm target(#executable_target_embedded_elf_arm_64_) {
-    hal.executable.export public @matmul_tensor_count_from_dag_root layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+    hal.executable.export public @matmul_tensor_count_from_dag_root layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
@@ -2455,7 +2414,7 @@ hal.executable private @matmul_tensors {
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 * 64)>
 //  CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0)[s0] -> (-d0 + s0, 64)>
 //      CHECK: hal.executable.export public @matmul_tensor_count_from_dag_root
-// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:   (%[[DEVICE:.+]]: !hal.device,
 // CHECK-SAME:    %[[WORKLOAD_M:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[WORKLOAD_N:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:    %[[WORKLOAD_K:[a-zA-Z0-9_]+]]: index)
@@ -2479,8 +2438,7 @@ hal.executable private @matmul_tensors {
 module {
   hal.executable private @matmul_tensors {
     hal.executable.variant public @llvm target(#executable_target_embedded_elf_arm_64_) {
-      hal.executable.export public @matmul_already_distributed layout(#pipeline_layout) {
-      ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
+      hal.executable.export public @matmul_already_distributed layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index) -> (index, index, index) {
         %c1 = arith.constant 1 : index
         %0 = affine.apply #map()[%arg1]
         %1 = affine.apply #map()[%arg2]
@@ -2531,11 +2489,10 @@ module {
 ]>
 hal.executable private @avoid_unit_range_distribute {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @avoid_unit_range_distribute ordinal(0) layout(#pipeline_layout) attributes {subgroup_size = 32 : index, translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute>, workgroup_size = [32 : index, 1 : index, 1 : index]} {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+    hal.executable.export public @avoid_unit_range_distribute ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
-    }
+    } attributes {subgroup_size = 32 : index, translation_info = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute>, workgroup_size = [32 : index, 1 : index, 1 : index]}
     builtin.module {
       func.func @avoid_unit_range_distribute() {
         %c0 = arith.constant 0 : index
@@ -2607,8 +2564,7 @@ hal.executable private @avoid_unit_range_distribute {
 ]>
 hal.executable private @set_size_to_tilesize_when_divisible {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @set_size_to_tilesize_when_divisible ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
+    hal.executable.export public @set_size_to_tilesize_when_divisible ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
@@ -2684,8 +2640,7 @@ hal.executable private @set_size_to_tilesize_when_divisible {
 #translation = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 hal.executable private @reshape_matmul_tensors {
   hal.executable.variant public @system_elf_x86_64 target(#executable_target_system_elf_x86_64_) {
-    hal.executable.export public @reshape_matmul layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @reshape_matmul layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -2717,7 +2672,7 @@ hal.executable private @reshape_matmul_tensors {
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 * 32)>
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 * 16)>
 //      CHECK: hal.executable.export public @reshape_matmul
-// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device)
+// CHECK-SAME:   (%[[DEVICE:.+]]: !hal.device)
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
 //  CHECK-DAG:   %[[C4:.+]] = arith.constant 4 : index
 //  CHECK-DAG:   %[[C32:.+]] = arith.constant 32 : index

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/apply_scale_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/apply_scale_lowering.mlir
@@ -14,12 +14,11 @@
 #translation = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 hal.executable private @apply_scale_no_vector_feature {
   hal.executable.variant public @embedded_elf_riscv_64 target(#executable_target_embedded_elf_riscv_64_) {
-    hal.executable.export public @apply_scale_no_vector_feature ordinal(0) layout(#pipeline_layout) attributes {translation_info = #translation} {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
+    hal.executable.export public @apply_scale_no_vector_feature ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       %0 = affine.apply #map()[%arg1]
       hal.return %0, %c1, %c1 : index, index, index
-    }
+    } attributes {translation_info = #translation}
     builtin.module {
       func.func @apply_scale_no_vector_feature() {
         %cst = arith.constant dense<19689> : vector<2xi32>
@@ -60,12 +59,11 @@ hal.executable private @apply_scale_no_vector_feature {
 #translation = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 hal.executable private @apply_scale_v {
   hal.executable.variant public @embedded_elf_riscv_64 target(#executable_target_embedded_elf_riscv_64_) {
-    hal.executable.export public @apply_scale_v ordinal(0) layout(#pipeline_layout) attributes {translation_info = #translation} {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
+    hal.executable.export public @apply_scale_v ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       %0 = affine.apply #map()[%arg1]
       hal.return %0, %c1, %c1 : index, index, index
-    }
+    } attributes {translation_info = #translation}
     builtin.module {
       func.func @apply_scale_v() {
         %cst = arith.constant dense<19689> : vector<2xi32>
@@ -104,12 +102,11 @@ hal.executable private @apply_scale_v {
 #translation = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 hal.executable private @apply_scale_zve64x {
   hal.executable.variant public @embedded_elf_riscv_64 target(#executable_target_embedded_elf_riscv_64_) {
-    hal.executable.export public @apply_scale_zve64x ordinal(0) layout(#pipeline_layout) attributes {translation_info = #translation} {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
+    hal.executable.export public @apply_scale_zve64x ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       %0 = affine.apply #map()[%arg1]
       hal.return %0, %c1, %c1 : index, index, index
-    }
+    } attributes {translation_info = #translation}
     builtin.module {
       func.func @apply_scale_zve64x() {
         %cst = arith.constant dense<19689> : vector<2xi32>
@@ -148,12 +145,11 @@ hal.executable private @apply_scale_zve64x {
 #translation = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 hal.executable private @apply_scale_zve32x {
   hal.executable.variant public @embedded_elf_riscv_64 target(#executable_target_embedded_elf_riscv_64_) {
-    hal.executable.export public @apply_scale_zve32x ordinal(0) layout(#pipeline_layout) attributes {translation_info = #translation} {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
+    hal.executable.export public @apply_scale_zve32x ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       %0 = affine.apply #map()[%arg1]
       hal.return %0, %c1, %c1 : index, index, index
-    }
+    } attributes {translation_info = #translation}
     builtin.module {
       func.func @apply_scale_zve32x() {
         %cst = arith.constant dense<19689> : vector<2xi32>
@@ -199,12 +195,11 @@ hal.executable private @apply_scale_zve32x {
 #translation = #iree_codegen.translation_info<pipeline = CPUDoubleTilingExpert>
 hal.executable private @apply_scale_zve32f {
   hal.executable.variant public @embedded_elf_riscv_64 target(#executable_target_embedded_elf_riscv_64_) {
-    hal.executable.export public @apply_scale_zve32f ordinal(0) layout(#pipeline_layout) attributes {translation_info = #translation} {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
+    hal.executable.export public @apply_scale_zve32f ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       %0 = affine.apply #map()[%arg1]
       hal.return %0, %c1, %c1 : index, index, index
-    }
+    } attributes {translation_info = #translation}
     builtin.module {
       func.func @apply_scale_zve32f() {
         %cst = arith.constant dense<19689> : vector<2xi32>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/annotate_kernel_for_translation.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/annotate_kernel_for_translation.mlir
@@ -16,14 +16,12 @@
 builtin.module {
   hal.executable public @test {
     hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
-      hal.executable.export public @test ordinal(0) layout(#pipeline_layout)
-        attributes {subgroup_size = 64 : index, workgroup_size = [128 : index, 2 : index, 1 : index]} {
-      ^bb0(%arg0: !hal.device):
+      hal.executable.export public @test ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
         %c128 = arith.constant 128 : index
         %c2 = arith.constant 2 : index
         %c1 = arith.constant 1 : index
         hal.return %c128, %c2, %c1 : index, index, index
-      }
+      } attributes {subgroup_size = 64 : index, workgroup_size = [128 : index, 2 : index, 1 : index]}
       builtin.module {
         llvm.func @test() {
           llvm.return
@@ -62,14 +60,12 @@ builtin.module {
 builtin.module {
   hal.executable public @test_kern_arg {
     hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
-      hal.executable.export public @test_kern_arg ordinal(0) layout(#pipeline_layout)
-        attributes {subgroup_size = 64 : index, workgroup_size = [128 : index, 2 : index, 1 : index]} {
-      ^bb0(%arg0: !hal.device):
+      hal.executable.export public @test_kern_arg ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
         %c128 = arith.constant 128 : index
         %c2 = arith.constant 2 : index
         %c1 = arith.constant 1 : index
         hal.return %c128, %c2, %c1 : index, index, index
-      }
+      } attributes {subgroup_size = 64 : index, workgroup_size = [128 : index, 2 : index, 1 : index]}
       builtin.module {
         llvm.func @test_kern_arg(%arg0: i32) {
           llvm.return
@@ -101,14 +97,12 @@ builtin.module {
 builtin.module {
   hal.executable public @test_no_kern_arg {
     hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
-      hal.executable.export public @test_no_kern_arg ordinal(0) layout(#pipeline_layout)
-        attributes {subgroup_size = 64 : index, workgroup_size = [128 : index, 2 : index, 1 : index]} {
-      ^bb0(%arg0: !hal.device):
+      hal.executable.export public @test_no_kern_arg ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
         %c128 = arith.constant 128 : index
         %c2 = arith.constant 2 : index
         %c1 = arith.constant 1 : index
         hal.return %c128, %c2, %c1 : index, index, index
-      }
+      } attributes {subgroup_size = 64 : index, workgroup_size = [128 : index, 2 : index, 1 : index]}
       builtin.module {
         llvm.func @test_no_kern_arg(%arg0: i32) {
           llvm.return

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_user_vector_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/config_user_vector_distribute.mlir
@@ -24,8 +24,7 @@
 ]>
 hal.executable public @main_0_dispatch_0 {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @main_0_dispatch_0_matmul_transpose_b_2048x10240x1280_f16xf16xf32 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @main_0_dispatch_0_matmul_transpose_b_2048x10240x1280_f16xf16xf32 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -97,8 +96,7 @@ hal.executable public @main_0_dispatch_0 {
 ]>
 hal.executable public @main_0_dispatch_0 {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @main_0_dispatch_0_matmul_transpose_b_2048x10240x1280_f16xf16xf32 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @main_0_dispatch_0_matmul_transpose_b_2048x10240x1280_f16xf16xf32 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -165,8 +163,7 @@ hal.executable public @main_0_dispatch_0 {
 ]>
 hal.executable public @main_0_dispatch_0 {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @main_0_dispatch_0_matmul_transpose_b_2048x10240x1280_f16xf16xf32 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @main_0_dispatch_0_matmul_transpose_b_2048x10240x1280_f16xf16xf32 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/lowering_scalar_dispatch.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/lowering_scalar_dispatch.mlir
@@ -9,8 +9,7 @@
 
 hal.executable @scalar_dispatch {
   hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
-    hal.executable.export public @scalar_dispatch ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @scalar_dispatch ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_elementwise_f8fnuz.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_elementwise_f8fnuz.mlir
@@ -10,8 +10,7 @@
 ]>
 hal.executable @ext_fp8_dispatch {
   hal.executable.variant @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export @ext_fp8_dispatch layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+    hal.executable.export public @ext_fp8_dispatch layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_elementwise_f8ocp.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_elementwise_f8ocp.mlir
@@ -10,8 +10,7 @@
 ]>
 hal.executable @ext_fp8_dispatch {
   hal.executable.variant @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export @ext_fp8_dispatch layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+    hal.executable.export public @ext_fp8_dispatch layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_igemm_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_igemm_tile_and_fuse.mlir
@@ -25,8 +25,7 @@
 }>
 hal.executable private @main {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @conv_igemm_im2col ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @conv_igemm_im2col ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -109,8 +108,7 @@ hal.executable private @main {
 }>
 hal.executable private @main {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @conv_dispatch_0_conv_2d_nhwc_hwcf_2x17x17x1281x3x3x1281_f16xf16xf32 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @conv_dispatch_0_conv_2d_nhwc_hwcf_2x17x17x1281x3x3x1281_f16xf16xf32 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_tile_and_fuse.mlir
@@ -14,8 +14,7 @@
 }>
 hal.executable public @main {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @matmul_transpose_b ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @matmul_transpose_b ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -84,8 +83,7 @@ hal.executable public @main {
 }>
 hal.executable public @main {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @matmul_transpose_b_mfma ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @matmul_transpose_b_mfma ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -154,8 +152,7 @@ hal.executable public @main {
 }>
 hal.executable public @main {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @matmul_transpose_b_wmmar3 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @matmul_transpose_b_wmmar3 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -228,8 +225,7 @@ hal.executable public @main {
 
 hal.executable public @main {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @matmul_transpose_b_mfma_16x16x4 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @matmul_transpose_b_mfma_16x16x4 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -284,8 +280,7 @@ hal.executable public @main {
 
 hal.executable public @main {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @matmul_transpose_b_mfma_16x16x32_f8 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @matmul_transpose_b_mfma_16x16x32_f8 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -340,8 +335,7 @@ hal.executable public @main {
 
 hal.executable public @main {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @matmul_transpose_b_mfma_32x32x16_i8 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @matmul_transpose_b_mfma_32x32x16_i8 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -396,8 +390,7 @@ hal.executable public @main {
 
 hal.executable public @main {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @matmul_transpose_b_wmmar3_f16_16x16x16_f16 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @matmul_transpose_b_wmmar3_f16_16x16x16_f16 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -450,8 +443,7 @@ hal.executable public @main {
 
 hal.executable public @main {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @conv_nchw_fused ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @conv_nchw_fused ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -514,8 +506,7 @@ hal.executable public @main {
 
 hal.executable public @main {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @skinny_matmul_config ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @skinny_matmul_config ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -589,8 +580,7 @@ hal.executable public @main {
 
 hal.executable public @main {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @matmul_fused_multi_result ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @matmul_fused_multi_result ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -654,8 +644,7 @@ hal.executable public @main {
 
 hal.executable public @main {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @small_elementwise ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @small_elementwise ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -712,8 +701,7 @@ hal.executable public @main {
 }>
 hal.executable public @main {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @matmul_transpose_b_mfma ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @matmul_transpose_b_mfma ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -829,8 +817,7 @@ hal.executable public @main {
 
 hal.executable public @main {
   hal.executable.variant public @cuda_nvptx_fb target(<"cuda", "cuda-nvptx-fb">) {
-    hal.executable.export public @small_m_matmul ordinal(0) layout(#layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @small_m_matmul ordinal(0) layout(#layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -888,8 +875,7 @@ hal.executable public @main {
 }>
 hal.executable public @main {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @small_matvec ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @small_matvec ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -939,8 +925,7 @@ hal.executable public @main {
 
 hal.executable public @main {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @elemwise_reduction_elemwise ordinal(0) layout(#layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @elemwise_reduction_elemwise ordinal(0) layout(#layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -1050,8 +1035,7 @@ hal.executable public @main {
 }>
 hal.executable public @main {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @matmul_transpose_b_promote_result ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @matmul_transpose_b_promote_result ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -1137,8 +1121,7 @@ hal.executable public @main {
 >
 hal.executable public @main {
   hal.executable.variant public @rocm_hsaco_fb target(#hal.executable.target<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @unaligned_to_intrinsic_batched_matmul_dispatch_0_batch_matmul_12x577x577x577_f32 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @unaligned_to_intrinsic_batched_matmul_dispatch_0_batch_matmul_12x577x577x577_f32 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -1197,8 +1180,7 @@ hal.executable public @main {
 
 hal.executable public @main {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @small_elementwise ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @small_elementwise ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx1100.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx1100.mlir
@@ -13,8 +13,7 @@
 ]>
 hal.executable @matmul_256x256x256_f16_f32 {
 hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
-  hal.executable.export @matmul_256x256x256_f16_f32 layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+  hal.executable.export public @matmul_256x256x256_f16_f32 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
@@ -60,8 +59,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 ]>
 hal.executable @matmul_256x256x256_f16_f16 {
 hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
-  hal.executable.export @matmul_256x256x256_f16_f16 layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+  hal.executable.export public @matmul_256x256x256_f16_f16 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_gfx942.mlir
@@ -18,8 +18,7 @@
 ]>
 hal.executable @matmul_256x256x256_f16_f32 {
 hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
-  hal.executable.export @matmul_256x256x256_f16_f32 layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+  hal.executable.export public @matmul_256x256x256_f16_f32 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
@@ -64,8 +63,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 ]>
 hal.executable @matmul_256x256x256_f16_f16 {
 hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
-  hal.executable.export @matmul_256x256x256_f16_f16 layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+  hal.executable.export public @matmul_256x256x256_f16_f16 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
@@ -108,8 +106,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 ]>
 hal.executable @expanded_matmul_transpose_b_executable {
 hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
-  hal.executable.export @expanded_matmul_transpose_b layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+  hal.executable.export public @expanded_matmul_transpose_b layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -174,8 +171,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 
 hal.executable @matmul_multiple_k {
   hal.executable.variant public @rocm target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @matmul_multiple_k layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @matmul_multiple_k layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -227,8 +223,7 @@ hal.executable @matmul_multiple_k {
 ]>
 hal.executable @matmul_256x256x256_16x16x32_f8_f32 {
 hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
-  hal.executable.export @matmul_256x256x256_16x16x32_f8_f32 layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+  hal.executable.export public @matmul_256x256x256_16x16x32_f8_f32 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
@@ -273,8 +268,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 ]>
 hal.executable @matmul_256x256x256_i8_i32 {
 hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
-  hal.executable.export @matmul_256x256x256_i8_i32 layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+  hal.executable.export public @matmul_256x256x256_i8_i32 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
@@ -319,8 +313,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 ]>
 hal.executable @matmul_256x256x256_32x32x16_f8_f32 {
 hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
-  hal.executable.export @matmul_256x256x256_32x32x16_f8_f32 layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+  hal.executable.export public @matmul_256x256x256_32x32x16_f8_f32 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
@@ -365,8 +358,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 ]>
 hal.executable @matmul_transpose_b_256x256x256_i8_i32 {
 hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
-  hal.executable.export @matmul_transpose_b_256x256x256_i8_i32 layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+  hal.executable.export public @matmul_transpose_b_256x256x256_i8_i32 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
@@ -409,8 +401,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 ]>
 hal.executable @conv_nhwc_dispatch_0 {
 hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
-  hal.executable.export @conv_nhwc layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+  hal.executable.export public @conv_nhwc layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -456,8 +447,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 #map2 = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3)>
 hal.executable public @main_dispatch_expanded_matmul {
   hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
-    hal.executable.export public @generic_2x1024x20x64x1280_f16 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @generic_2x1024x20x64x1280_f16 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -518,8 +508,7 @@ hal.executable public @main_dispatch_expanded_matmul {
 ]>
 hal.executable @unaligned_mk_batch_matmul_64x978x1281x1281_f16_f16 {
 hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
-  hal.executable.export @unaligned_mk_batch_matmul_64x978x1281x1281_f16_f16 layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+  hal.executable.export public @unaligned_mk_batch_matmul_64x978x1281x1281_f16_f16 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
@@ -593,8 +582,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 
 hal.executable public @pad_batch_matmul {
   hal.executable.variant public @rocm_hsaco_fb target(#hal.executable.target<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @pad_batch_matmul ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @pad_batch_matmul ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -660,8 +648,7 @@ hal.executable public @pad_batch_matmul {
 ]>
 hal.executable public @contract_schedule_considering_read_layout {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @contract_schedule_considering_read_layout ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @contract_schedule_considering_read_layout ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -715,8 +702,7 @@ hal.executable public @contract_schedule_considering_read_layout {
 ]>
 hal.executable @virtual_intrinsic_256x256x256_16x16x32xf8E4M3FNUZ_f32 {
 hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
-  hal.executable.export @virtual_intrinsic_256x256x256_16x16x32xf8E4M3FNUZ_f32 layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+  hal.executable.export public @virtual_intrinsic_256x256x256_16x16x32xf8E4M3FNUZ_f32 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
@@ -779,8 +765,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 ]>
 hal.executable @virtual_intrinsic_256x256x256_32x32x16_f8E4M3FNUZ_f32 {
 hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
-  hal.executable.export @virtual_intrinsic_256x256x256_32x32x16_f8E4M3FNUZ_f32 layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+  hal.executable.export public @virtual_intrinsic_256x256x256_32x32x16_f8E4M3FNUZ_f32 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
@@ -827,8 +812,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 ]>
 hal.executable @virtual_intrinsic_256x256x256_16x16x32xf8E4M3FNUZ_f32 {
 hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
-  hal.executable.export @virtual_intrinsic_256x256x256_16x16x32xf8E4M3FNUZ_f32 layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+  hal.executable.export public @virtual_intrinsic_256x256x256_16x16x32xf8E4M3FNUZ_f32 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
@@ -899,8 +883,7 @@ hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
 
 hal.executable public @matmul_gather_rhs {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @matmul_gather_rhs ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @matmul_gather_rhs ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -967,8 +950,7 @@ hal.executable public @matmul_gather_rhs {
 ]>
 hal.executable private @attention_20x4096x64x4096x64 {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @attention_20x4096x64x4096x64 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @attention_20x4096x64x4096x64 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -1040,8 +1022,7 @@ hal.executable private @attention_20x4096x64x4096x64 {
 ]>
 hal.executable private @attention_multiple_m_transpose {
   hal.executable.variant public @rocm target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @attention_multiple_m_transpose ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @attention_multiple_m_transpose ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -1108,8 +1089,7 @@ hal.executable private @attention_multiple_m_transpose {
 ]>
 hal.executable private @attention_mfma_32x32x8 {
   hal.executable.variant public @rocm target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @attention_mfma_32x32x8 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @attention_mfma_32x32x8 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -1184,8 +1164,7 @@ hal.executable private @attention_mfma_32x32x8 {
 ]>
 hal.executable private @online_attention_split_k2 {
   hal.executable.variant public @rocm target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @online_attention_split_k2 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @online_attention_split_k2 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -1261,8 +1240,7 @@ hal.executable private @online_attention_split_k2 {
 module {
   hal.executable public @attention_gather_k {
     hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
-      hal.executable.export public @attention_gather_k ordinal(0) layout(#pipeline_layout) {
-      ^bb0(%arg0: !hal.device):
+      hal.executable.export public @attention_gather_k ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
         %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
         hal.return %x, %y, %z : index, index, index
       }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_reduction_gfx942.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_vector_distribute_reduction_gfx942.mlir
@@ -20,8 +20,7 @@
 ]>
 hal.executable private @matvec_fp16 {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @matvec_fp16 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @matvec_fp16 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -78,8 +77,7 @@ hal.executable private @matvec_fp16 {
 ]>
 hal.executable private @matvec_fp16_parallel_subgroup {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @matvec_fp16_parallel_subgroup ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @matvec_fp16_parallel_subgroup ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -137,8 +135,7 @@ hal.executable private @matvec_fp16_parallel_subgroup {
 ]>
 hal.executable private @matvec_fp16_promote_rhs {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @matvec_fp16_promote_rhs ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @matvec_fp16_promote_rhs ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -217,8 +214,7 @@ hal.executable private @matvec_fp16_promote_rhs {
 ]>
 hal.executable private @attention_20x1x64x4096x64 {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @attention_20x1x64x4096x64 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @attention_20x1x64x4096x64 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -312,8 +308,7 @@ hal.executable private @attention_20x1x64x4096x64 {
 ]>
 hal.executable private @attention_20x1x64x4096x64 {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @attention_20x1x64x4096x64 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @attention_20x1x64x4096x64 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_warp_reduction.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_warp_reduction.mlir
@@ -6,8 +6,7 @@
 ]>
 hal.executable private @warp_reduction {
   hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @warp_reduction ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+    hal.executable.export public @warp_reduction ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
@@ -47,8 +46,7 @@ hal.executable private @warp_reduction {
 ]>
 hal.executable public @main_dispatch_517 {
   hal.executable.variant public @rocm target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @warp_reduction_large_vector ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @warp_reduction_large_vector ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/conv_pipeline_test_cuda.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/conv_pipeline_test_cuda.mlir
@@ -10,8 +10,7 @@
 ]>
 hal.executable private @conv2d_1x230x230x3_7x7x3x64_dispatch_0 {
   hal.executable.variant public @cuda_nvptx_fb target(#executable_target_cuda_nvptx_fb) {
-    hal.executable.export public @conv2d_1x230x230x3_7x7x3x64 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4: index, %arg5: index, %arg6: index, %arg7: index):
+    hal.executable.export public @conv2d_1x230x230x3_7x7x3x64 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4: index, %arg5: index, %arg6: index, %arg7: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7
       hal.return %x, %y, %z : index, index, index
     }
@@ -55,8 +54,7 @@ hal.executable private @conv2d_1x230x230x3_7x7x3x64_dispatch_0 {
 ]>
 hal.executable private @conv_nchw_dispatch_0 {
   hal.executable.variant public @cuda_nvptx_fb target(#executable_target_cuda_nvptx_fb) {
-    hal.executable.export public @conv_nchw ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4: index, %arg5: index, %arg6: index, %arg7: index):
+    hal.executable.export public @conv_nchw ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4: index, %arg5: index, %arg6: index, %arg7: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7
       hal.return %x, %y, %z : index, index, index
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_nvvm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_nvvm.mlir
@@ -8,7 +8,7 @@
 ]>
 hal.executable @abs_ex_dispatch_0 {
   hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-    hal.executable.export @abs_ex_dispatch_0 layout(#pipeline_layout)
+    hal.executable.export public @abs_ex_dispatch_0 layout(#pipeline_layout)
     builtin.module {
       func.func @abs_ex_dispatch_0() {
         %c0 = arith.constant 0 : index
@@ -47,7 +47,7 @@ hal.executable @abs_ex_dispatch_0 {
 ]>
 hal.executable @abs_dynamic {
   hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-    hal.executable.export @abs_dynamic layout(#pipeline_layout)
+    hal.executable.export public @abs_dynamic layout(#pipeline_layout)
     builtin.module {
       func.func @abs_dynamic() {
         %c0 = arith.constant 0 : index
@@ -104,7 +104,7 @@ hal.executable @abs_dynamic {
 ]>
 hal.executable @dead_symbol {
   hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-    hal.executable.export @dead_symbol layout(#pipeline_layout)
+    hal.executable.export public @dead_symbol layout(#pipeline_layout)
     builtin.module {
       func.func @dead_symbol() {
         %c0 = arith.constant 0 : index
@@ -140,7 +140,7 @@ hal.executable @dead_symbol {
 ]>
 hal.executable @mixed_type {
   hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-    hal.executable.export @mixed_type layout(#pipeline_layout)
+    hal.executable.export public @mixed_type layout(#pipeline_layout)
     builtin.module {
       func.func @mixed_type() {
         %c0 = arith.constant 0 : index
@@ -183,7 +183,7 @@ hal.executable @mixed_type {
 ]>
 hal.executable @shared_memory_lowering {
   hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-    hal.executable.export @shared_memory_lowering layout(#pipeline_layout)
+    hal.executable.export public @shared_memory_lowering layout(#pipeline_layout)
     builtin.module {
       func.func @shared_memory_lowering() {
         %c0 = arith.constant 0 : index
@@ -221,7 +221,7 @@ hal.executable @shared_memory_lowering {
 ]>
 hal.executable @shared_memory_dealloc_elision {
   hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-    hal.executable.export @shared_memory_dealloc_elision layout(#pipeline_layout)
+    hal.executable.export public @shared_memory_dealloc_elision layout(#pipeline_layout)
     builtin.module {
 // CHECK-LABEL: llvm.func @shared_memory_dealloc_elision() {
       func.func @shared_memory_dealloc_elision() {
@@ -245,7 +245,7 @@ hal.executable @shared_memory_dealloc_elision {
 ]>
 hal.executable @shared_memory_lowering_aligned_alloc {
   hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-    hal.executable.export @shared_memory_lowering_aligned_alloc layout(#pipeline_layout)
+    hal.executable.export public @shared_memory_lowering_aligned_alloc layout(#pipeline_layout)
     builtin.module {
       func.func @shared_memory_lowering_aligned_alloc() {
         %c0 = arith.constant 0 : index
@@ -281,7 +281,7 @@ hal.executable @shared_memory_lowering_aligned_alloc {
 ]>
 hal.executable @check_not_readonly {
   hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-    hal.executable.export @check_not_readonly layout(#pipeline_layout)
+    hal.executable.export public @check_not_readonly layout(#pipeline_layout)
     builtin.module {
       func.func @check_not_readonly() {
         %c0 = arith.constant 0 : index
@@ -319,7 +319,7 @@ hal.executable @check_not_readonly {
 ]>
 hal.executable @complex {
   hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-    hal.executable.export @complex layout(#pipeline_layout)
+    hal.executable.export public @complex layout(#pipeline_layout)
     builtin.module {
       func.func @complex() {
         %c0 = arith.constant 0 : index
@@ -353,7 +353,7 @@ hal.executable @complex {
 ]>
 hal.executable @shared_memory_lowering_index {
   hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-    hal.executable.export @shared_memory_lowering_index layout(#pipeline_layout)
+    hal.executable.export public @shared_memory_lowering_index layout(#pipeline_layout)
     builtin.module {
       func.func @shared_memory_lowering_index() {
         %c0 = arith.constant 0 : index
@@ -379,7 +379,7 @@ hal.executable @shared_memory_lowering_index {
 ]>
 hal.executable @masked_load_store {
   hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-    hal.executable.export @masked_load_store layout(#pipeline_layout)
+    hal.executable.export public @masked_load_store layout(#pipeline_layout)
     builtin.module {
       func.func @masked_load_store() {
         %c0 = arith.constant 0 : index
@@ -409,7 +409,7 @@ hal.executable @masked_load_store {
 ]>
 hal.executable private @interface_wg_size {
   hal.executable.variant @rocm target(<"cuda", "cuda-nvptx-fb">) {
-    hal.executable.export @interface_wg_size layout(#pipeline_layout) attributes {
+    hal.executable.export public @interface_wg_size layout(#pipeline_layout) attributes {
       workgroup_size = [32: index, 1: index, 1: index]
     }
     builtin.module attributes {} {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/gpu_pipeline_data_tiling.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/gpu_pipeline_data_tiling.mlir
@@ -12,8 +12,7 @@
 module attributes {stream.affinity.default = #hal.device.affinity<@__device_0>} {
   hal.executable private @executable {
     hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm_hsaco_fb) {
-      hal.executable.export public @export ordinal(0) layout(#pipeline_layout) {
-      ^bb0(%arg0: !hal.device):
+      hal.executable.export public @export ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
         %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
         hal.return %x, %y, %z : index, index, index
       }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/link_executables.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/link_executables.mlir
@@ -24,8 +24,7 @@
 
 hal.executable private @executable0 {
   hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm) {
-    hal.executable.export public @export0 ordinal(0) layout(#hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @export0 ordinal(0) layout(#hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }
@@ -42,8 +41,7 @@ hal.executable private @executable0 {
 }
 hal.executable private @executable1 {
   hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm) {
-    hal.executable.export public @export1 ordinal(0) layout(#hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @export1 ordinal(0) layout(#hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }
@@ -88,8 +86,7 @@ hal.executable private @executable1 {
 
 hal.executable private @executable0 {
   hal.executable.variant public @cuda_nvptx_fb target(#executable_target_cuda) {
-    hal.executable.export public @export0 ordinal(0) layout(#hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @export0 ordinal(0) layout(#hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }
@@ -100,8 +97,7 @@ hal.executable private @executable0 {
     }
   }
   hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm) {
-    hal.executable.export public @export0 ordinal(0) layout(#hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @export0 ordinal(0) layout(#hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }
@@ -114,8 +110,7 @@ hal.executable private @executable0 {
 }
 hal.executable private @executable1 {
   hal.executable.variant public @cuda_nvptx_fb target(#executable_target_cuda) {
-    hal.executable.export public @export1 ordinal(0) layout(#hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @export1 ordinal(0) layout(#hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }
@@ -126,8 +121,7 @@ hal.executable private @executable1 {
     }
   }
   hal.executable.variant public @rocm_hsaco_fb target(#executable_target_rocm) {
-    hal.executable.export public @export1 ordinal(0) layout(#hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @export1 ordinal(0) layout(#hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer>]>) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_extract_address_computation.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_extract_address_computation.mlir
@@ -83,8 +83,7 @@
 ]>
 hal.executable private @matmul_dispatch_0 {
   hal.executable.variant public @cuda_nvptx_fb target(#executable_target_cuda_nvptx_fb) {
-    hal.executable.export public @matmul_dispatch_0_matmul_2560x2560x2560 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
+    hal.executable.export public @matmul_dispatch_0_matmul_2560x2560x2560 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_mma_sync_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_mma_sync_pipeline_test.mlir
@@ -12,8 +12,7 @@
 ]>
 hal.executable @mma_fused_fp16 {
   hal.executable.variant public @cuda_nvptx_fb target(<"cuda", "cuda-nvptx-fb">) {
-  hal.executable.export public @_large_aligned_dispatch_0 ordinal(0) layout(#pipeline_layout) {
-  ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+  hal.executable.export public @_large_aligned_dispatch_0 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
     %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
     hal.return %x, %y, %z : index, index, index
   }
@@ -41,7 +40,7 @@ hal.executable @mma_fused_fp16 {
           indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
           iterator_types = ["parallel", "parallel"]}
           ins(%m, %d : tensor<2048x512xf16>, tensor<2048x512xf16>) outs(%init2 : tensor<2048x512xf16>) {
-        ^bb0(%arg3: f16, %arg4: f16, %arg5: f16):  // no predecessors
+        ^bb0(%arg3: f16, %arg4: f16, %arg5: f16):
           %19 = arith.addf %arg3, %arg4 : f16
           linalg.yield %19 : f16
         } -> (tensor<2048x512xf16>)
@@ -57,8 +56,8 @@ hal.executable @mma_fused_fp16 {
 //    CHECK-LABEL: hal.executable public @mma_fused_fp16
 //          CHECK:   hal.executable.variant public @cuda
 //    CHECK-LABEL:     hal.executable.export public @_large_aligned_dispatch_0
-//     CHECK-SAME:       subgroup_size = 32
-//     CHECK-SAME:       workgroup_size = [64 : index, 2 : index, 1 : index]
+//          CHECK:       subgroup_size = 32
+//          CHECK:       workgroup_size = [64 : index, 2 : index, 1 : index]
 //      CHECK-NOT:   llvm.store
 //  CHECK-COUNT-2:   nvvm.cp.async.shared.global {{.*}}, {{.*}}, 16
 //          CHECK:   nvvm.cp.async.commit.group
@@ -92,8 +91,7 @@ hal.executable @mma_fused_fp16 {
 ]>
 hal.executable @mma_fused_f32 {
   hal.executable.variant public @cuda_nvptx_fb target(<"cuda", "cuda-nvptx-fb">) {
-  hal.executable.export public @_large_aligned_dispatch_0 ordinal(0) layout(#pipeline_layout) {
-  ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+  hal.executable.export public @_large_aligned_dispatch_0 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
     %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
     hal.return %x, %y, %z : index, index, index
   }
@@ -121,7 +119,7 @@ hal.executable @mma_fused_f32 {
           indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
           iterator_types = ["parallel", "parallel"]}
           ins(%m, %d : tensor<2048x512xf32>, tensor<2048x512xf32>) outs(%init2 : tensor<2048x512xf32>) {
-        ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):  // no predecessors
+        ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):
           %19 = arith.addf %arg3, %arg4 : f32
           linalg.yield %19 : f32
         } -> (tensor<2048x512xf32>)

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
@@ -11,8 +11,7 @@
 ]>
 hal.executable @simpleMath_ex_dispatch_0 {
   hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-  hal.executable.export @add_dispatch_0 layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index):
+  hal.executable.export public @add_dispatch_0 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1
       hal.return %x, %y, %z : index, index, index
     }
@@ -26,7 +25,7 @@ hal.executable @simpleMath_ex_dispatch_0 {
       %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets=[0], sizes=[16], strides=[1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xf32>> -> tensor<16xf32>
       %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets=[0], sizes=[16], strides=[1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xf32>> -> tensor<16xf32>
       %6 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%4, %5 : tensor<16xf32>, tensor<16xf32>) outs(%3 : tensor<16xf32>) {
-      ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):  // no predecessors
+      ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
           %7 = arith.addf %arg0, %arg1 : f32
           linalg.yield %7 : f32
         } -> tensor<16xf32>
@@ -53,8 +52,7 @@ hal.executable @simpleMath_ex_dispatch_0 {
 ]>
 hal.executable @dot_dispatch_0 {
   hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-    hal.executable.export @dot_dispatch_0 layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+    hal.executable.export public @dot_dispatch_0 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
@@ -116,8 +114,7 @@ hal.executable @dot_dispatch_0 {
 ]>
 hal.executable @dot_dispatch_0 {
   hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-    hal.executable.export @dot_dispatch_0 layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+    hal.executable.export public @dot_dispatch_0 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
@@ -166,8 +163,7 @@ hal.executable @dot_dispatch_0 {
 ]>
 hal.executable @conv2d_dispatch_0 {
 hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-  hal.executable.export @conv2d_dispatch_0 layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index, %arg5 : index, %arg6 : index, %arg7 : index):
+  hal.executable.export public @conv2d_dispatch_0 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index, %arg5 : index, %arg6 : index, %arg7 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7
       hal.return %x, %y, %z : index, index, index
     }
@@ -212,8 +208,7 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 ]>
 hal.executable @simpleMath_ex_dispatch_0 {
 hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-  hal.executable.export @add_dispatch_0 layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index):
+  hal.executable.export public @add_dispatch_0 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1
       hal.return %x, %y, %z : index, index, index
     }
@@ -226,7 +221,7 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
       %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets=[0], sizes=[16], strides=[1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xf32>> -> tensor<16xf32>
       %5 = arith.constant dense<[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0]> : tensor<16xf32>
       %6 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%4, %5 : tensor<16xf32>, tensor<16xf32>) outs(%3 : tensor<16xf32>) {
-      ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):  // no predecessors
+      ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
           %7 = arith.addf %arg0, %arg1 : f32
           linalg.yield %7 : f32
       } -> tensor<16xf32>
@@ -250,8 +245,7 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 ]>
 hal.executable @reduction_dispatch {
 hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-  hal.executable.export @reduction layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+  hal.executable.export public @reduction layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
@@ -270,7 +264,7 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
             indexing_maps = [affine_map<(d0, d1, d2) -> (d1, d2, d0)>, affine_map<(d0, d1, d2) -> (d0)>],
             iterator_types = ["parallel", "reduction", "reduction"]}
             ins(%5 : tensor<14x14x96xf32>) outs(%9 : tensor<96xf32>) {
-        ^bb0(%arg1: f32, %arg2: f32):  // no predecessors
+        ^bb0(%arg1: f32, %arg2: f32):
           %11 = arith.addf %arg1, %arg2 : f32
           linalg.yield %11 : f32
         } -> tensor<96xf32>
@@ -295,8 +289,7 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 ]>
 hal.executable @vector_add_dispatch {
 hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-  hal.executable.export @vector_add_dispatch layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index):
+  hal.executable.export public @vector_add_dispatch layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1
       hal.return %x, %y, %z : index, index, index
     }
@@ -316,7 +309,7 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
           indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
           iterator_types = ["parallel"]}
           ins(%6, %8 : tensor<16384xf32>, tensor<16384xf32>) outs(%10 : tensor<16384xf32>) {
-        ^bb0(%arg1: f32, %arg2: f32, %arg3: f32):  // no predecessors
+        ^bb0(%arg1: f32, %arg2: f32, %arg3: f32):
           %12 = arith.addf %arg1, %arg2 : f32
           linalg.yield %12 : f32
         } -> tensor<16384xf32>
@@ -346,8 +339,7 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 ]>
 hal.executable @vector_reduction_dispatch {
 hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-  hal.executable.export @vector_reduction_dispatch layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+  hal.executable.export public @vector_reduction_dispatch layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
@@ -365,7 +357,7 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
       %10 = linalg.generic {
           indexing_maps = [#map3, #map4], iterator_types = ["parallel", "reduction"]}
           ins(%5 : tensor<512x16384xf32>) outs(%9 : tensor<16384xf32>) {
-        ^bb0(%arg1: f32, %arg2: f32):  // no predecessors
+        ^bb0(%arg1: f32, %arg2: f32):
           %11 = arith.addf %arg1, %arg2 : f32
           linalg.yield %11 : f32
         } -> tensor<16384xf32>
@@ -394,8 +386,7 @@ hal.executable @mma_fused {
     #hal.pipeline.binding<storage_buffer>,
     #hal.pipeline.binding<storage_buffer>,
     #hal.pipeline.binding<storage_buffer>
-  ]>) {
-  ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+  ]>) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
     %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
     hal.return %x, %y, %z : index, index, index
   }
@@ -423,7 +414,7 @@ hal.executable @mma_fused {
           indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
           iterator_types = ["parallel", "parallel"]}
           ins(%m, %d : tensor<2048x512xf32>, tensor<2048x512xf32>) outs(%init2 : tensor<2048x512xf32>) {
-        ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):  // no predecessors
+        ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):
           %19 = arith.addf %arg3, %arg4 : f32
           linalg.yield %19 : f32
         } -> (tensor<2048x512xf32>)
@@ -472,8 +463,7 @@ hal.executable @mma_fused_fp16 {
     #hal.pipeline.binding<storage_buffer>,
     #hal.pipeline.binding<storage_buffer>,
     #hal.pipeline.binding<storage_buffer>
-  ]>) {
-  ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+  ]>) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
     %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
     hal.return %x, %y, %z : index, index, index
   }
@@ -501,7 +491,7 @@ hal.executable @mma_fused_fp16 {
           indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
           iterator_types = ["parallel", "parallel"]}
           ins(%m, %d : tensor<2048x512xf16>, tensor<2048x512xf16>) outs(%init2 : tensor<2048x512xf16>) {
-        ^bb0(%arg3: f16, %arg4: f16, %arg5: f16):  // no predecessors
+        ^bb0(%arg3: f16, %arg4: f16, %arg5: f16):
           %19 = arith.addf %arg3, %arg4 : f16
           linalg.yield %19 : f16
         } -> (tensor<2048x512xf16>)
@@ -552,8 +542,7 @@ hal.executable @mma_fused_fp16 {
 #map6 = affine_map<(d0)[s0] -> (-d0 + 64, s0)>
   hal.executable @large_dot_general_dispatch_0 {
     hal.executable.variant public @cuda target(#executable_target_cuda_nvptx_fb) {
-      hal.executable.export @large_dot_general_dispatch_0 layout(#pipeline_layout) {
-      ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 :index):
+      hal.executable.export public @large_dot_general_dispatch_0 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 :index) -> (index, index, index) {
         %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3, %arg4
         hal.return %x, %y, %z : index, index, index
       }
@@ -630,8 +619,7 @@ hal.executable @mma_fused_fp16 {
 #map6 = affine_map<(d0, d1, d2) -> (d2, d0, d1)>
   hal.executable public @split_k_gemm {
     hal.executable.variant public @cuda_nvptx_fb target(#executable_target_cuda_nvptx_fb) {
-      hal.executable.export public @split_k_gemm ordinal(0) layout(#pipeline_layout) {
-      ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index):
+      hal.executable.export public @split_k_gemm ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index) -> (index, index, index) {
         %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3, %arg4
         hal.return %x, %y, %z : index, index, index
       }
@@ -691,8 +679,7 @@ hal.executable @mma_fused_fp16 {
 #executable_target_cuda_nvptx_fb = #hal.executable.target<"cuda", "cuda-nvptx-fb">
   hal.executable public @pooling_dynamic {
     hal.executable.variant public @cuda_nvptx_fb target(#executable_target_cuda_nvptx_fb) {
-      hal.executable.export public @pooling_dynamic ordinal(0) layout(#pipeline_layout) {
-      ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 :index, %arg4 : index, %arg5 : index, %arg6 : index):
+      hal.executable.export public @pooling_dynamic ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 :index, %arg4 : index, %arg5 : index, %arg6 : index) -> (index, index, index) {
         %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3, %arg4, %arg5, %arg6
         hal.return %x, %y, %z : index, index, index
       }
@@ -734,8 +721,7 @@ hal.executable @mma_fused_fp16 {
 ]>
 hal.executable @warp_reduction_dispatch {
 hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-  hal.executable.export @warp_reduction_dispatch layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+  hal.executable.export public @warp_reduction_dispatch layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
@@ -753,7 +739,7 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
       %10 = linalg.generic {
           indexing_maps = [#map3, #map4], iterator_types = ["parallel", "reduction"]}
           ins(%5 : tensor<512x1024xf32>) outs(%9 : tensor<512xf32>) {
-        ^bb0(%arg1: f32, %arg2: f32):  // no predecessors
+        ^bb0(%arg1: f32, %arg2: f32):
           %11 = arith.addf %arg1, %arg2 : f32
           linalg.yield %11 : f32
         } -> tensor<512xf32>
@@ -785,8 +771,7 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 ]>
 hal.executable @warp_reduction_broadcast_dispatch {
 hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-  hal.executable.export @warp_reduction_broadcast_dispatch layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+  hal.executable.export public @warp_reduction_broadcast_dispatch layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
@@ -805,7 +790,7 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
       %10 = linalg.generic {
           indexing_maps = [#map3, #map4], iterator_types = ["parallel", "reduction"]}
           ins(%5 : tensor<512x1024xf32>) outs(%9 : tensor<512xf32>) {
-        ^bb0(%arg1: f32, %arg2: f32):  // no predecessors
+        ^bb0(%arg1: f32, %arg2: f32):
           %11 = arith.addf %arg1, %arg2 : f32
           linalg.yield %11 : f32
         } -> tensor<512xf32>
@@ -844,8 +829,7 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 ]>
 hal.executable private @generalized_pool {
   hal.executable.variant public @cuda_nvptx_fb target(<"cuda", "cuda-nvptx-fb">) {
-    hal.executable.export public @generalized_pool ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4: index, %arg5: index):
+    hal.executable.export public @generalized_pool ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4: index, %arg5: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3, %arg4, %arg5
       hal.return %x, %y, %z : index, index, index
     }
@@ -890,8 +874,7 @@ hal.executable private @generalized_pool {
 #map1 = affine_map<(d0, d1) -> (d0, d1)>
 hal.executable private @shared_mem_transpose  {
   hal.executable.variant @cuda target(#executable_target_cuda_nvptx_fb) {
-    hal.executable.export @shared_mem_transpose layout(#pipeline_layout) {
-      ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+    hal.executable.export public @shared_mem_transpose layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index) -> (index, index, index) {
         %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
         hal.return %x, %y, %z : index, index, index
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_cuda.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_cuda.mlir
@@ -6,8 +6,7 @@
 ]>
 hal.executable @warp_reduction_dispatch {
 hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-  hal.executable.export @warp_reduction_dispatch layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+  hal.executable.export public @warp_reduction_dispatch layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
@@ -25,7 +24,7 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
       %10 = linalg.generic {
           indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]}
           ins(%5 : tensor<512x10240xf32>) outs(%9 : tensor<512xf32>) {
-        ^bb0(%arg1: f32, %arg2: f32):  // no predecessors
+        ^bb0(%arg1: f32, %arg2: f32):
           %11 = arith.addf %arg1, %arg2 : f32
           linalg.yield %11 : f32
         } -> tensor<512xf32>
@@ -68,8 +67,7 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 ]>
 hal.executable @warp_reduction_broadcast_dispatch {
 hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-  hal.executable.export @warp_reduction_broadcast_dispatch layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+  hal.executable.export public @warp_reduction_broadcast_dispatch layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
@@ -89,7 +87,7 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
           indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>],
           iterator_types = ["parallel", "reduction"]}
           ins(%5 : tensor<512x10240xf32>) outs(%9 : tensor<512xf32>) {
-        ^bb0(%arg1: f32, %arg2: f32):  // no predecessors
+        ^bb0(%arg1: f32, %arg2: f32):
           %11 = arith.addf %arg1, %arg2 : f32
           linalg.yield %11 : f32
         } -> tensor<512xf32>
@@ -137,8 +135,7 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 ]>
 hal.executable @softmax {
 hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
-  hal.executable.export @softmax layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+  hal.executable.export public @softmax layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
@@ -247,8 +244,7 @@ hal.executable.variant @cuda target(<"cuda", "cuda-nvptx-fb">) {
 ]>
 hal.executable @small_reduction {
 hal.executable.variant public @cuda_nvptx_fb target(<"cuda", "cuda-nvptx-fb">) {
-  hal.executable.export public @small_reduction ordinal(0) layout(#pipeline_layout) {
-  ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+  hal.executable.export public @small_reduction ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index) -> (index, index, index) {
     %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
     hal.return %x, %y, %z : index, index, index
   }
@@ -286,8 +282,7 @@ hal.executable.variant public @cuda_nvptx_fb target(<"cuda", "cuda-nvptx-fb">) {
 ]>
 hal.executable @group_reduction {
 hal.executable.variant public @cuda_nvptx_fb target(<"cuda", "cuda-nvptx-fb">) {
-  hal.executable.export public @group_reduction ordinal(0) layout(#pipeline_layout) {
-  ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+  hal.executable.export public @group_reduction ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index) -> (index, index, index) {
     %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
     hal.return %x, %y, %z : index, index, index
   }
@@ -328,8 +323,7 @@ hal.executable.variant public @cuda_nvptx_fb target(<"cuda", "cuda-nvptx-fb">) {
 ]>
 hal.executable @group_elementwise_reduction_elementwise {
 hal.executable.variant public @cuda_nvptx_fb target(<"cuda", "cuda-nvptx-fb">) {
-  hal.executable.export public @group_elementwise_reduction_elementwise ordinal(0) layout(#pipeline_layout) {
-  ^bb0(%arg0: !hal.device, %arg1: index):
+  hal.executable.export public @group_elementwise_reduction_elementwise ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index) -> (index, index, index) {
     %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1
     hal.return %x, %y, %z : index, index, index
   }
@@ -379,8 +373,7 @@ hal.executable.variant public @cuda_nvptx_fb target(<"cuda", "cuda-nvptx-fb">) {
 ]>
 hal.executable @group_reduction_larger {
 hal.executable.variant public @cuda_nvptx_fb target(<"cuda", "cuda-nvptx-fb">) {
-  hal.executable.export public @group_reduction_larger ordinal(0) layout(#pipeline_layout) {
-  ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+  hal.executable.export public @group_reduction_larger ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index) -> (index, index, index) {
     %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
     hal.return %x, %y, %z : index, index, index
   }
@@ -427,8 +420,7 @@ hal.executable.variant public @cuda_nvptx_fb target(<"cuda", "cuda-nvptx-fb">) {
 ]>
 hal.executable @group_reduction_1d {
 hal.executable.variant public @cuda_nvptx_fb target(<"cuda", "cuda-nvptx-fb">) {
-  hal.executable.export public @group_reduction_1d ordinal(0) layout(#pipeline_layout) {
-  ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+  hal.executable.export public @group_reduction_1d ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index) -> (index, index, index) {
     %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
     hal.return %x, %y, %z : index, index, index
   }
@@ -464,8 +456,7 @@ hal.executable.variant public @cuda_nvptx_fb target(<"cuda", "cuda-nvptx-fb">) {
 ]>
 hal.executable @group_elementwise_reduction_elementwise_4d {
 hal.executable.variant public @cuda_nvptx_fb target(<"cuda", "cuda-nvptx-fb">) {
-  hal.executable.export public @group_elementwise_reduction_elementwise_4d ordinal(0) layout(#pipeline_layout) {
-  ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
+  hal.executable.export public @group_elementwise_reduction_elementwise_4d ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index) -> (index, index, index) {
     %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3
     hal.return %x, %y, %z : index, index, index
   }
@@ -513,8 +504,7 @@ hal.executable.variant public @cuda_nvptx_fb target(<"cuda", "cuda-nvptx-fb">) {
 ]>
 hal.executable private @i4_dequant_matvec {
   hal.executable.variant public @cuda_nvptx_fb target(<"cuda", "cuda-nvptx-fb">) {
-    hal.executable.export public @i4_dequant_matvec ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @i4_dequant_matvec ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_rocm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_rocm.mlir
@@ -11,8 +11,7 @@
 ]>
 hal.executable @group_reduction_1d {
 hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-  hal.executable.export public @group_reduction_1d ordinal(0) layout(#pipeline_layout) {
-  ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+  hal.executable.export public @group_reduction_1d ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index) -> (index, index, index) {
     %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
     hal.return %x, %y, %z : index, index, index
   }
@@ -50,8 +49,7 @@ hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
 ]>
 hal.executable @group_reduction_1d {
 hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-  hal.executable.export public @group_reduction_1d ordinal(0) layout(#pipeline_layout) {
-  ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+  hal.executable.export public @group_reduction_1d ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index) -> (index, index, index) {
     %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
     hal.return %x, %y, %z : index, index, index
   }
@@ -93,8 +91,7 @@ hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
 ]>
 hal.executable private @i4_dequant_matvec {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @i4_dequant_matvec ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @i4_dequant_matvec ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -168,8 +165,7 @@ hal.executable private @i4_dequant_matvec {
 ]>
 hal.executable private @i4_dequant_matvec {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @i4_dequant_matvec ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @i4_dequant_matvec ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -223,8 +219,7 @@ hal.executable private @i4_dequant_matvec {
 ]>
 hal.executable private @matvec_fp16 {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @matvec_fp16 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @matvec_fp16 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -284,8 +279,7 @@ hal.executable private @matvec_fp16 {
 ]>
 hal.executable private @matvec_fp16 {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @matvec_fp16 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @matvec_fp16 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -342,8 +336,7 @@ hal.executable private @matvec_fp16 {
 ]>
 hal.executable public @multi_reduction {
   hal.executable.variant public @rocm_hsaco_fb target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export public @multi_reduction ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @multi_reduction ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_pipeline_test.mlir
@@ -12,8 +12,7 @@
 ]>
 hal.executable @simpleMath_ex_dispatch_0 {
   hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
-  hal.executable.export @add_dispatch_0 layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index):
+  hal.executable.export public @add_dispatch_0 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1
       hal.return %x, %y, %z : index, index, index
     }
@@ -27,7 +26,7 @@ hal.executable @simpleMath_ex_dispatch_0 {
       %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets=[0], sizes=[16], strides=[1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xf32>> -> tensor<16xf32>
       %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets=[0], sizes=[16], strides=[1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xf32>> -> tensor<16xf32>
       %6 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%4, %5 : tensor<16xf32>, tensor<16xf32>) outs(%3 : tensor<16xf32>) {
-      ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):  // no predecessors
+      ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
           %7 = arith.addf %arg0, %arg1 : f32
           linalg.yield %7 : f32
         } -> tensor<16xf32>
@@ -54,8 +53,7 @@ hal.executable @simpleMath_ex_dispatch_0 {
 ]>
 hal.executable @dot_dispatch_0 {
   hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
-    hal.executable.export @dot_dispatch_0 layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+    hal.executable.export public @dot_dispatch_0 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
@@ -106,8 +104,7 @@ hal.executable @dot_dispatch_0 {
 ]>
 hal.executable @ceildiv_expand_dispatch {
   hal.executable.variant @rocm target(<"rocm", "rocm-hsaco-fb">) {
-  hal.executable.export @ceildiv_expand layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index):
+  hal.executable.export public @ceildiv_expand layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1
       hal.return %x, %y, %z : index, index, index
     }
@@ -121,7 +118,7 @@ hal.executable @ceildiv_expand_dispatch {
       %4 = iree_tensor_ext.dispatch.tensor.load %0, offsets=[0], sizes=[16], strides=[1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xi32>> -> tensor<16xi32>
       %5 = iree_tensor_ext.dispatch.tensor.load %1, offsets=[0], sizes=[16], strides=[1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<16xi32>> -> tensor<16xi32>
       %6 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%4, %5 : tensor<16xi32>, tensor<16xi32>) outs(%3 : tensor<16xi32>) {
-      ^bb0(%arg0: i32, %arg1: i32, %arg2: i32):  // no predecessors
+      ^bb0(%arg0: i32, %arg1: i32, %arg2: i32):
           %7 = arith.ceildivsi %arg0, %arg1 : i32
           linalg.yield %7 : i32
         } -> tensor<16xi32>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transpose_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transpose_pipeline_test.mlir
@@ -8,8 +8,7 @@
 #executable_target_cuda_nvptx_fb = #hal.executable.target<"cuda", "cuda-nvptx-fb">
 hal.executable @transpose_dispatch_0 {
   hal.executable.variant public @cuda_nvptx_fb target(#executable_target_cuda_nvptx_fb) {
-    hal.executable.export public @transpose_dispatch_0_generic_4096x4096 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+    hal.executable.export public @transpose_dispatch_0_generic_4096x4096 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
@@ -64,8 +63,7 @@ hal.executable @transpose_dispatch_0 {
 #executable_target_cuda_nvptx_fb = #hal.executable.target<"cuda", "cuda-nvptx-fb">
 hal.executable @transpose_single_operand_dispatch_0_generic_768x2048 {
   hal.executable.variant public @cuda_nvptx_fb target(#executable_target_cuda_nvptx_fb) {
-    hal.executable.export public @transpose_single_operand_dispatch_0_generic_768x2048 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+    hal.executable.export public @transpose_single_operand_dispatch_0_generic_768x2048 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
@@ -129,8 +127,7 @@ hal.executable @transpose_single_operand_dispatch_0_generic_768x2048 {
 #executable_target_cuda_nvptx_fb = #hal.executable.target<"cuda", "cuda-nvptx-fb">
 hal.executable @transpose_3d_no_dispatch_0_generic_768x2048x1024 {
   hal.executable.variant public @cuda_nvptx_fb target(#executable_target_cuda_nvptx_fb) {
-    hal.executable.export public @transpose_3d_no_dispatch_0_generic_768x2048x1024 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
+    hal.executable.export public @transpose_3d_no_dispatch_0_generic_768x2048x1024 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
@@ -170,8 +167,7 @@ hal.executable @transpose_3d_no_dispatch_0_generic_768x2048x1024 {
 #executable_target_cuda_nvptx_fb = #hal.executable.target<"cuda", "cuda-nvptx-fb">
 hal.executable @transpose_3d_yes_dispatch_0_generic_10x768x2048 {
   hal.executable.variant public @cuda_nvptx_fb target(#executable_target_cuda_nvptx_fb) {
-    hal.executable.export public @transpose_3d_yes_dispatch_0_generic_10x768x2048 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
+    hal.executable.export public @transpose_3d_yes_dispatch_0_generic_10x768x2048 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
@@ -235,8 +231,7 @@ hal.executable @transpose_3d_yes_dispatch_0_generic_10x768x2048 {
 #executable_target_cuda_nvptx_fb = #hal.executable.target<"cuda", "cuda-nvptx-fb">
 hal.executable @transpose_3d_trans_out_dispatch_0_generic_10x2048x768 {
   hal.executable.variant public @cuda_nvptx_fb target(#executable_target_cuda_nvptx_fb) {
-    hal.executable.export public @transpose_3d_trans_out_dispatch_0_generic_10x2048x768 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
+    hal.executable.export public @transpose_3d_trans_out_dispatch_0_generic_10x2048x768 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
@@ -301,8 +296,7 @@ hal.executable @transpose_3d_trans_out_dispatch_0_generic_10x2048x768 {
 #executable_target_cuda_nvptx_fb = #hal.executable.target<"cuda", "cuda-nvptx-fb">
 hal.executable @transpose_3d_diff_dispatch_0_generic_10x768x2048 {
   hal.executable.variant public @cuda_nvptx_fb target(#executable_target_cuda_nvptx_fb) {
-    hal.executable.export public @transpose_3d_diff_dispatch_0_generic_10x768x2048 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
+    hal.executable.export public @transpose_3d_diff_dispatch_0_generic_10x768x2048 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/convert_gpu_target.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/convert_gpu_target.mlir
@@ -8,8 +8,7 @@ hal.executable.variant public @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-s
       max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>}>) {
   hal.executable.export public @dispatch ordinal(0) layout(#hal.pipeline.layout<bindings = [
     #hal.pipeline.binding<storage_buffer>]>
-  ) {
-  ^bb0(%arg0: !hal.device):
+  ) count(%arg0: !hal.device) -> (index, index, index) {
     %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
     hal.return %x, %y, %z : index, index, index
   }
@@ -55,8 +54,7 @@ hal.executable.variant public @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-s
       max_workgroup_counts = [2147483647, 2147483647, 2147483647]>>}>) {
   hal.executable.export public @dispatch ordinal(0) layout(#hal.pipeline.layout<bindings = [
     #hal.pipeline.binding<storage_buffer>]>
-  ) {
-  ^bb0(%arg0: !hal.device):
+  ) count(%arg0: !hal.device) -> (index, index, index) {
     %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
     hal.return %x, %y, %z : index, index, index
   }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/convert_to_spirv.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/convert_to_spirv.mlir
@@ -7,7 +7,7 @@
 ]>
 hal.executable private @push_constant {
   hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export @push_constant layout(#pipeline_layout) attributes {
+    hal.executable.export public @push_constant layout(#pipeline_layout) attributes {
       workgroup_size = [32: index, 1: index, 1: index]
     }
     builtin.module attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.3, [Int64, Shader], []>, #spirv.resource_limits<>>} {
@@ -43,7 +43,7 @@ hal.executable private @push_constant {
 ]>
 hal.executable private @resource_bindings_in_same_func {
   hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export @resource_bindings_in_same_func layout(#pipeline_layout) attributes {
+    hal.executable.export public @resource_bindings_in_same_func layout(#pipeline_layout) attributes {
       workgroup_size = [32: index, 1: index, 1: index]
     }
     builtin.module attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.3, [Int64, Shader], []>, #spirv.resource_limits<>>} {
@@ -99,10 +99,10 @@ hal.executable private @resource_bindings_in_same_func {
 ]>
 hal.executable private @resource_bindings_in_multi_entry_func {
   hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export @resource_bindings_in_entry_func1 layout(#pipeline_layout) attributes {
+    hal.executable.export public @resource_bindings_in_entry_func1 layout(#pipeline_layout) attributes {
       workgroup_size = [32: index, 1: index, 1: index]
     }
-    hal.executable.export @resource_bindings_in_entry_func2 layout(#pipeline_layout) attributes {
+    hal.executable.export public @resource_bindings_in_entry_func2 layout(#pipeline_layout) attributes {
       workgroup_size = [32: index, 1: index, 1: index]
     }
     builtin.module attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.3, [Int64, Shader], []>, #spirv.resource_limits<>>} {
@@ -157,7 +157,7 @@ hal.executable private @resource_bindings_in_multi_entry_func {
 ]>
 hal.executable private @interface_binding {
   hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export @interface_binding layout(#pipeline_layout) attributes {
+    hal.executable.export public @interface_binding layout(#pipeline_layout) attributes {
       workgroup_size = [32: index, 1: index, 1: index]
     }
     builtin.module attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.3, [Int64, Shader], []>, #spirv.resource_limits<>>} {
@@ -200,7 +200,7 @@ hal.executable private @interface_binding {
 ]>
 hal.executable private @interface_wg_id {
   hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export @interface_wg_id layout(#pipeline_layout) attributes {
+    hal.executable.export public @interface_wg_id layout(#pipeline_layout) attributes {
       workgroup_size = [32: index, 1: index, 1: index]
     }
     builtin.module attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.3, [Int64, Shader], []>, #spirv.resource_limits<>>} {
@@ -233,7 +233,7 @@ hal.executable private @interface_wg_id {
 ]>
 hal.executable private @interface_wg_size {
   hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export @interface_wg_size layout(#pipeline_layout) attributes {
+    hal.executable.export public @interface_wg_size layout(#pipeline_layout) attributes {
       workgroup_size = [32: index, 1: index, 1: index]
     }
     builtin.module attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.3, [Int64, Shader], []>, #spirv.resource_limits<>>} {
@@ -269,7 +269,7 @@ hal.executable private @interface_wg_size {
 ]>
 hal.executable private @interface_wg_count {
   hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export @interface_wg_count layout(#pipeline_layout) attributes {
+    hal.executable.export public @interface_wg_count layout(#pipeline_layout) attributes {
       workgroup_size = [32: index, 1: index, 1: index]
     }
     builtin.module attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.3, [Int64, Shader], []>, #spirv.resource_limits<>>} {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/link_executables.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/link_executables.mlir
@@ -19,8 +19,7 @@ hal.executable private @dispatch_0 {
       %c1 = arith.constant 1 : i32
       hal.return %c1 : i32
     }
-    hal.executable.export @dispatch_0 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device) :
+    hal.executable.export public @dispatch_0 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }
@@ -39,12 +38,11 @@ hal.executable private @dispatch_1 {
       %c2 = arith.constant 2 : i32
       hal.return %c2 : i32
     }
-    hal.executable.export @dispatch_1 ordinal(0) layout(#pipeline_layout) attributes {
-      workgroup_size = [64: index, 1: index, 1: index], subgroup_size = 64: index
-    } {
-    ^bb0(%arg0: !hal.device) :
+    hal.executable.export public @dispatch_1 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
+    } attributes {
+      workgroup_size = [64: index, 1: index, 1: index], subgroup_size = 64: index
     }
     builtin.module {
       spirv.module Logical GLSL450 requires #spirv.vce<v1.3, [Shader], []> {
@@ -57,8 +55,7 @@ hal.executable private @dispatch_1 {
 }
 hal.executable private @dispatch_2 {
   hal.executable.variant @spirv target(#vulkan_target) {
-    hal.executable.export @dispatch_2 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device) :
+    hal.executable.export public @dispatch_2 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       %c4 = arith.constant 4 : index
       hal.return %c4, %c4, %c1 : index, index, index
@@ -128,8 +125,8 @@ util.initializer {
 //      CHECK:     hal.executable.constant.block(%arg0: !hal.device) -> i32 as "baz"
 // CHECK-NEXT:       = arith.constant 2
 //      CHECK:     hal.executable.export public @dispatch_1 ordinal(1)
-// CHECK-SAME:       {subgroup_size = 64 : index, workgroup_size = [64 : index, 1 : index, 1 : index]}
 //      CHECK:       hal.return %c1, %c1, %c1
+//      CHECK:       attributes {subgroup_size = 64 : index, workgroup_size = [64 : index, 1 : index, 1 : index]}
 //      CHECK:     hal.executable.export public @dispatch_2 ordinal(2)
 //      CHECK:       hal.return %c4, %c4, %c1
 //      CHECK:     builtin.module {
@@ -202,8 +199,7 @@ hal.executable private @dispatch_0 {
       %c1 = arith.constant 1 : i32
       hal.return %c1 : i32
     }
-    hal.executable.export @dispatch_0 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device) :
+    hal.executable.export public @dispatch_0 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }
@@ -231,8 +227,7 @@ hal.executable private @dispatch_1 {
       %c2 = arith.constant 2 : i32
       hal.return %c2 : i32
     }
-    hal.executable.export @dispatch_1 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device) :
+    hal.executable.export public @dispatch_1 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }
@@ -247,8 +242,7 @@ hal.executable private @dispatch_1 {
 }
 hal.executable private @dispatch_2 {
   hal.executable.variant @spirv target(#vulkan_target_0) {
-    hal.executable.export @dispatch_2 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device) :
+    hal.executable.export public @dispatch_2 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }
@@ -272,8 +266,7 @@ hal.executable private @dispatch_3 {
       %2 = arith.andi %ok, %1 : i1
       hal.return %2 : i1
     }
-    hal.executable.export @dispatch_3 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device) :
+    hal.executable.export public @dispatch_3 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }
@@ -394,8 +387,7 @@ hal.executable private @dispatch_0 {
       %c1 = arith.constant 1 : i32
       hal.return %c1 : i32
     }
-    hal.executable.export @dispatch_0 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device) :
+    hal.executable.export public @dispatch_0 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }
@@ -421,8 +413,7 @@ hal.executable private @dispatch_0 {
       %c2 = arith.constant 2 : i32
       hal.return %c2 : i32
     }
-    hal.executable.export @dispatch_0 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device) :
+    hal.executable.export public @dispatch_0 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c2 = arith.constant 2 : index
       hal.return %c2, %c2, %c2 : index, index, index
     }
@@ -443,8 +434,7 @@ hal.executable private @dispatch_1 {
       %c3 = arith.constant 3 : i32
       hal.return %c3 : i32
     }
-    hal.executable.export @dispatch_1 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device) :
+    hal.executable.export public @dispatch_1 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c3 = arith.constant 3 : index
       hal.return %c3, %c3, %c3 : index, index, index
     }
@@ -470,8 +460,7 @@ hal.executable private @dispatch_1 {
       %c4 = arith.constant 4 : i32
       hal.return %c4 : i32
     }
-    hal.executable.export @dispatch_1 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device) :
+    hal.executable.export public @dispatch_1 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c4 = arith.constant 4 : index
       hal.return %c4, %c4, %c4 : index, index, index
     }
@@ -488,8 +477,7 @@ hal.executable private @dispatch_1 {
 // dispatch_1, so it can link with neither.
 hal.executable private @dispatch_2 {
   hal.executable.variant @spirv target(#vulkan_target_0) {
-    hal.executable.export @dispatch_2 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device) :
+    hal.executable.export public @dispatch_2 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }
@@ -506,8 +494,7 @@ hal.executable private @dispatch_2 {
 // requirement. So cannot link either.
 hal.executable private @dispatch_3 {
   hal.executable.variant @spirv_0 target(#vulkan_target_0) {
-    hal.executable.export @dispatch_3 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device) :
+    hal.executable.export public @dispatch_3 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }
@@ -529,8 +516,7 @@ hal.executable private @dispatch_3 {
       %2 = arith.andi %ok, %1 : i1
       hal.return %2 : i1
     }
-    hal.executable.export @dispatch_3 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device) :
+    hal.executable.export public @dispatch_3 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matmul_promotion.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matmul_promotion.mlir
@@ -18,8 +18,7 @@
 #map = affine_map<(d0, d1) -> (d0, d1)>
 hal.executable @matmul_f32_128x256x64 {
   hal.executable.variant public @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export public @matmul_f32_128x256x64 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+    hal.executable.export public @matmul_f32_128x256x64 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
@@ -104,8 +103,7 @@ hal.executable @matmul_f32_128x256x64 {
 #map = affine_map<(d0, d1) -> (d0, d1)>
 hal.executable @matmul_f32_128x256x64 {
   hal.executable.variant public @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export public @matmul_f32_128x256x64 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+    hal.executable.export public @matmul_f32_128x256x64 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
@@ -202,8 +200,7 @@ hal.executable @matmul_f32_128x256x64 {
     translation_info = #iree_codegen.translation_info<pipeline = SPIRVMatmulPromoteVectorize workgroup_size = [32, 8, 1], {pipeline_depth = 1, store_stage = 1}>>
 hal.executable @matmul_f16_4096x512x512 {
   hal.executable.variant public @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export public @matmul_f16_4096x512x512 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+    hal.executable.export public @matmul_f16_4096x512x512 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_scalar_dispatch.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_scalar_dispatch.mlir
@@ -6,8 +6,7 @@
 ]>
 hal.executable @scalar_dispatch {
   hal.executable.variant public @vulkan_spirv_fb target(#hal.executable.target<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export public @scalar_dispatch ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @scalar_dispatch ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/materialize_executable_conditions.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/materialize_executable_conditions.mlir
@@ -21,8 +21,7 @@ hal.executable private @dispatch_executable {
       spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Shader, GroupNonUniform], []>, #spirv.resource_limits<>>
     }>
   ) {
-    hal.executable.export public @test_assumed_capabilities ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @test_assumed_capabilities ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }
@@ -54,8 +53,7 @@ hal.executable private @dispatch_executable {
       spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [GroupNonUniformShuffle, GroupNonUniformArithmetic], []>, #spirv.resource_limits<>>
     }>
   ) {
-    hal.executable.export public @test_subgroup_capabilities ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @test_subgroup_capabilities ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }
@@ -87,8 +85,7 @@ hal.executable private @dispatch_executable {
       spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [UniformAndStorageBuffer8BitAccess, StorageBuffer8BitAccess], []>, #spirv.resource_limits<>>
     }>
   ) {
-    hal.executable.export public @test_8bit_storage_capabilities ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @test_8bit_storage_capabilities ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }
@@ -121,8 +118,7 @@ hal.executable private @dispatch_executable {
       spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [StorageBuffer16BitAccess, StorageUniform16], []>, #spirv.resource_limits<>>
     }>
   ) {
-    hal.executable.export public @test_16bit_storage_capabilities ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @test_16bit_storage_capabilities ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }
@@ -147,8 +143,7 @@ hal.executable private @dispatch_executable {
       spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Int64, Int16, Int8], []>, #spirv.resource_limits<>>
     }>
   ) {
-    hal.executable.export public @test_int_compute_capabilities ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @test_int_compute_capabilities ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }
@@ -172,8 +167,7 @@ hal.executable private @dispatch_executable {
       spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Float16, Float64], []>, #spirv.resource_limits<>>
     }>
   ) {
-    hal.executable.export public @test_float_compute_capabilities ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @test_float_compute_capabilities ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }
@@ -197,8 +191,7 @@ hal.executable private @dispatch_executable {
       spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [DotProduct, DotProductInput4x8Bit], []>, #spirv.resource_limits<>>
     }>
   ) {
-    hal.executable.export public @test_dot_product_capabilities ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @test_dot_product_capabilities ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }
@@ -222,12 +215,11 @@ hal.executable private @dispatch_executable {
       spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [CooperativeMatrixKHR], []>, #spirv.resource_limits<>>
     }>
   ) {
-    hal.executable.export public @test_cooperative_matrix_capabilities ordinal(0) layout(#pipeline_layout) attributes {
-      iree.spirv.coopmatrix.shape = array<i64: 16, 16, 16>, iree.spirv.coopmatrix.type = [f16, f16]
-    } {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @test_cooperative_matrix_capabilities ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
+    } attributes {
+      iree.spirv.coopmatrix.shape = array<i64: 16, 16, 16>, iree.spirv.coopmatrix.type = [f16, f16]
     }
     builtin.module {
       spirv.module Logical GLSL450 requires #spirv.vce<v1.0, [CooperativeMatrixKHR], []> {
@@ -257,8 +249,7 @@ hal.executable private @dispatch_executable {
                                             #spirv.resource_limits<>>
     }>
   ) {
-    hal.executable.export public @test_address_capabilities ordinal(0) layout(#indirect_pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @test_address_capabilities ordinal(0) layout(#indirect_pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/physical_storage_buffer_addresses.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/physical_storage_buffer_addresses.mlir
@@ -9,7 +9,7 @@
 ]>
 hal.executable private @interface_binding {
   hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb-ptr">) {
-    hal.executable.export @interface_binding layout(#pipeline_layout) attributes {
+    hal.executable.export public @interface_binding layout(#pipeline_layout) attributes {
       workgroup_size = [32: index, 1: index, 1: index]
     }
     builtin.module attributes {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_ops.mlir
@@ -20,8 +20,7 @@
 
 hal.executable public @matmul_256x1024x128_div_exp {
   hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export public @matmul_256x1024x128_div_exp layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+    hal.executable.export public @matmul_256x1024x128_div_exp layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
@@ -211,8 +210,7 @@ hal.executable public @matmul_256x1024x128_div_exp {
 ]>
 hal.executable public @batch_matmul_16x128x256x512_div {
   hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export public @batch_matmul_16x128x256x512_div layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
+    hal.executable.export public @batch_matmul_16x128x256x512_div layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
@@ -320,8 +318,7 @@ hal.executable public @batch_matmul_16x128x256x512_div {
 
 hal.executable public @matmul_32x32x32_div {
   hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export public @matmul_32x32x32_div layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+    hal.executable.export public @matmul_32x32x32_div layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
@@ -371,8 +368,7 @@ hal.executable public @matmul_32x32x32_div {
 
 hal.executable public @generic_batch_matmul_32x128x512x64 {
   hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export public @generic_batch_matmul_32x128x512x64 layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4: index):
+    hal.executable.export public @generic_batch_matmul_32x128x512x64 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3, %arg4
       hal.return %x, %y, %z : index, index, index
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_promotion.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_promotion.mlir
@@ -10,8 +10,7 @@
 
 hal.executable @matmul_f32_128x256x64 {
   hal.executable.variant public @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export public @matmul_f32_128x256x64 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+    hal.executable.export public @matmul_f32_128x256x64 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
@@ -83,8 +82,7 @@ hal.executable @matmul_f32_128x256x64 {
 
 hal.executable @matmul_f16_128x256x64 {
   hal.executable.variant public @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export public @matmul_f16_128x256x64 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+    hal.executable.export public @matmul_f16_128x256x64 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
@@ -161,8 +159,7 @@ hal.executable @matmul_f16_128x256x64 {
 
 hal.executable @matmul_f16_32x1280x1280 {
   hal.executable.variant public @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export public @matmul_f16_32x1280x1280 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
+    hal.executable.export public @matmul_f16_32x1280x1280 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_vectorization.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_vectorization.mlir
@@ -7,8 +7,7 @@
 ]>
 hal.executable private @fuse_and_vectorize_fill_matmul {
   hal.executable.variant @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export @fuse_and_vectorize_fill_matmul layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+    hal.executable.export public @fuse_and_vectorize_fill_matmul layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
@@ -50,8 +49,7 @@ hal.executable private @fuse_and_vectorize_fill_matmul {
 ]>
 hal.executable private @fuse_and_vectorize_matmul_add {
   hal.executable.variant @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export @fuse_and_vectorize_matmul_add layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+    hal.executable.export public @fuse_and_vectorize_matmul_add layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matvec.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matvec.mlir
@@ -17,8 +17,7 @@ hal.executable @i4_dequant_unit_matmul_f16 {
       max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536,
       max_workgroup_counts = [65535, 65535, 65535]>>
     }>) {
-    hal.executable.export @i4_dequant_unit_matmul_f16 layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @i4_dequant_unit_matmul_f16 layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }
@@ -125,8 +124,7 @@ hal.executable @i4_dequant_matvec_f16_subgroup_64 {
       max_thread_count_per_workgroup = 1024, max_workgroup_memory_bytes = 65536,
       max_workgroup_counts = [65535, 65535, 65535]>>
   }>) {
-    hal.executable.export @i4_dequant_matvec_f16_subgroup_64 layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @i4_dequant_matvec_f16_subgroup_64 layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_reduction_subgroup.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_reduction_subgroup.mlir
@@ -7,8 +7,7 @@
 ]>
 hal.executable private @subgroup_reduce {
   hal.executable.variant @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export public @subgroup_reduce ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+    hal.executable.export public @subgroup_reduce ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
@@ -98,8 +97,7 @@ hal.executable private @subgroup_reduce {
 ]>
 hal.executable public @softmax{
   hal.executable.variant @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export public @softmax ordinal(0) layout(#hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @softmax ordinal(0) layout(#hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_sub_byte_dequant.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_sub_byte_dequant.mlir
@@ -8,8 +8,7 @@
 ]>
 hal.executable @i4_dequant {
   hal.executable.variant @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export @i4_dequant layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @i4_dequant layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
       hal.return %x, %y, %z : index, index, index
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute.mlir
@@ -17,7 +17,7 @@
 ]>
 hal.executable private @matmul {
   hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export @matmul layout(#pipeline_layout) attributes {
+    hal.executable.export public @matmul layout(#pipeline_layout) attributes {
       workgroup_size = [16: index, 8: index, 1: index],
       translation_info = #translation
     }
@@ -85,7 +85,7 @@ hal.executable private @matmul {
 ]>
 hal.executable private @conv_1d {
   hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export @conv_1d layout(#pipeline_layout) attributes {
+    hal.executable.export public @conv_1d layout(#pipeline_layout) attributes {
       workgroup_size = [32: index, 4: index, 1: index],
       translation_info = #translation
     }
@@ -160,7 +160,7 @@ hal.executable private @conv_1d {
 ]>
 hal.executable private @conv_2d {
   hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export @conv_2d layout(#pipeline_layout) attributes {
+    hal.executable.export public @conv_2d layout(#pipeline_layout) attributes {
       workgroup_size = [32: index, 4: index, 1: index],
       translation_info = #translation
     }
@@ -273,7 +273,7 @@ hal.executable private @conv_2d {
 ]>
 hal.executable private @conv_3d {
   hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export @conv_3d layout(#pipeline_layout) attributes {
+    hal.executable.export public @conv_3d layout(#pipeline_layout) attributes {
       workgroup_size = [32: index, 4: index, 1: index],
       translation_info = #translation
     }
@@ -339,34 +339,32 @@ hal.executable private @conv_3d {
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-module  {
-  hal.executable private @pooling_nhwc_max {
-    hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-      hal.executable.export @pooling_nhwc_max layout(#pipeline_layout) attributes {
-        workgroup_size = [32: index, 4: index, 1: index],
-        translation_info = #translation
-      }
-      builtin.module {
-        func.func @pooling_nhwc_max() {
-          %c0 = arith.constant 0 : index
-          %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : memref<2x16x16x6xf32>
-          %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : memref<3x4xf32>
-          %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : memref<2x14x13x6xf32>
-          %3 = gpu.block_id x
-          %4 = gpu.block_id y
-          %5 = affine.apply #map0()[%4]
-          %6 = affine.min #map1()[%4]
-          %7 = affine.apply #map2()[%3]
-          %8 = affine.min #map3()[%3]
-          %9 = memref.subview %0[0, %5, %7, 0] [2, %6, %8, 6] [1, 1, 1, 1] : memref<2x16x16x6xf32> to memref<2x?x?x6xf32, #map4>
-          %10 = affine.min #map5()[%4]
-          %11 = affine.min #map6()[%3]
-          %12 = memref.subview %2[0, %5, %7, 0] [2, %10, %11, 6] [1, 1, 1, 1] : memref<2x14x13x6xf32> to memref<2x?x?x6xf32, #map7>
-          linalg.pooling_nhwc_max {lowering_config = #config, dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>}
-            ins(%9, %1 : memref<2x?x?x6xf32, #map4>, memref<3x4xf32>)
-            outs(%12 : memref<2x?x?x6xf32, #map7>)
-          return
-        }
+hal.executable private @pooling_nhwc_max {
+  hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
+    hal.executable.export public @pooling_nhwc_max layout(#pipeline_layout) attributes {
+      workgroup_size = [32: index, 4: index, 1: index],
+      translation_info = #translation
+    }
+    builtin.module {
+      func.func @pooling_nhwc_max() {
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) : memref<2x16x16x6xf32>
+        %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) : memref<3x4xf32>
+        %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) : memref<2x14x13x6xf32>
+        %3 = gpu.block_id x
+        %4 = gpu.block_id y
+        %5 = affine.apply #map0()[%4]
+        %6 = affine.min #map1()[%4]
+        %7 = affine.apply #map2()[%3]
+        %8 = affine.min #map3()[%3]
+        %9 = memref.subview %0[0, %5, %7, 0] [2, %6, %8, 6] [1, 1, 1, 1] : memref<2x16x16x6xf32> to memref<2x?x?x6xf32, #map4>
+        %10 = affine.min #map5()[%4]
+        %11 = affine.min #map6()[%3]
+        %12 = memref.subview %2[0, %5, %7, 0] [2, %10, %11, 6] [1, 1, 1, 1] : memref<2x14x13x6xf32> to memref<2x?x?x6xf32, #map7>
+        linalg.pooling_nhwc_max {lowering_config = #config, dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>}
+          ins(%9, %1 : memref<2x?x?x6xf32, #map4>, memref<3x4xf32>)
+          outs(%12 : memref<2x?x?x6xf32, #map7>)
+        return
       }
     }
   }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_scatter.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_scatter.mlir
@@ -9,7 +9,7 @@
 ]>
 hal.executable private @static_scatter_update_slice  {
   hal.executable.variant @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export @static_scatter_update_slice layout(#pipeline_layout) attributes {
+    hal.executable.export public @static_scatter_update_slice layout(#pipeline_layout) attributes {
       translation_info = #translation,
       workgroup_size = [16 : index, 1 : index, 1 : index]
     }
@@ -36,7 +36,7 @@ hal.executable private @static_scatter_update_slice  {
             %9 = memref.cast %8 : memref<1x1xi32, affine_map<(d0, d1)[s0] -> (d0 + s0 + d1)>> to memref<?x1xi32, affine_map<(d0, d1)[s0] -> (d0 + s0 + d1)>>
             %10 = memref.subview %2[0, %arg1] [100, %5] [1, 1] : memref<100x500xi32> to memref<100x?xi32, affine_map<(d0, d1)[s0] -> (d0 * 500 + s0 + d1)>>
             iree_linalg_ext.scatter {lowering_config = #config} dimension_map = [0] unique_indices(true) ins(%7, %9 : memref<?x?xi32, affine_map<(d0, d1)[s0] -> (d0 * 500 + s0 + d1)>>, memref<?x1xi32, affine_map<(d0, d1)[s0] -> (d0 + s0 + d1)>>) outs(%10 : memref<100x?xi32, affine_map<(d0, d1)[s0] -> (d0 * 500 + s0 + d1)>>)  {
-            ^bb0(%arg2: i32, %arg3: i32):  // no predecessors
+            ^bb0(%arg2: i32, %arg3: i32):
               iree_linalg_ext.yield %arg2 : i32
             }
           }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_sort.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_sort.mlir
@@ -7,7 +7,7 @@
 ]>
 hal.executable private @static_3d_sort  {
   hal.executable.variant @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export @static_3d_sort layout(#pipeline_layout) attributes {
+    hal.executable.export public @static_3d_sort layout(#pipeline_layout) attributes {
       translation_info = #translation,
       workgroup_size = [16 : index, 1 : index, 1 : index]
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_batch_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_batch_matmul.mlir
@@ -11,7 +11,7 @@
 ]>
 hal.executable private @fused_fill_batch_matmul {
   hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export @fused_fill_batch_matmul layout(#pipeline_layout) attributes {
+    hal.executable.export public @fused_fill_batch_matmul layout(#pipeline_layout) attributes {
       workgroup_size = [16: index, 1: index, 1: index],
       translation_info = #translation
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_conv.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_conv.mlir
@@ -11,7 +11,7 @@
 ]>
 hal.executable private @nhwc_conv_static_shape_f32 {
   hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export @nhwc_conv_static_shape_f32 layout(#pipeline_layout) attributes {
+    hal.executable.export public @nhwc_conv_static_shape_f32 layout(#pipeline_layout) attributes {
       workgroup_size = [4: index, 4: index, 1: index],
       translation_info = #translation
     }
@@ -83,7 +83,7 @@ hal.executable private @nhwc_conv_static_shape_f32 {
 ]>
 hal.executable private @nhwc_nhwc_depthwise_conv_static_shape_f32 {
   hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export @nhwc_nhwc_depthwise_conv_static_shape_f32 layout(#pipeline_layout) attributes {
+    hal.executable.export public @nhwc_nhwc_depthwise_conv_static_shape_f32 layout(#pipeline_layout) attributes {
       workgroup_size = [4: index, 4: index, 4: index],
       translation_info = #translation
     }
@@ -153,17 +153,15 @@ hal.executable private @nhwc_nhwc_depthwise_conv_static_shape_f32 {
 
 hal.executable private @low_padded_conv {
   hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export @low_padded_conv layout(#pipeline_layout) attributes {
-      workgroup_size = [8: index, 2: index, 1: index],
-      translation_info = #translation
-    } {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4: index, %arg5: index, %arg6: index, %arg7: index):
+    hal.executable.export public @low_padded_conv layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4: index, %arg5: index, %arg6: index, %arg7: index) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       %c28 = arith.constant 28 : index
       %c112 = arith.constant 112 : index
       hal.return %c1, %c28, %c112 : index, index, index
+    } attributes {
+      workgroup_size = [8: index, 2: index, 1: index],
+      translation_info = #translation
     }
-
     builtin.module {
       func.func @low_padded_conv() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -269,17 +267,15 @@ hal.executable private @low_padded_conv {
 
 hal.executable private @low_high_padded_nhwc_depthwise_conv {
   hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export @low_high_padded_nhwc_depthwise_conv layout(#pipeline_layout) attributes {
-      workgroup_size = [8: index, 2: index, 1: index],
-      translation_info = #translation
-    } {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4: index, %arg5: index, %arg6: index, %arg7: index):
+    hal.executable.export public @low_high_padded_nhwc_depthwise_conv layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4: index, %arg5: index, %arg6: index, %arg7: index) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       %c28 = arith.constant 28 : index
       %c112 = arith.constant 112 : index
       hal.return %c1, %c28, %c112 : index, index, index
+    } attributes {
+      workgroup_size = [8: index, 2: index, 1: index],
+      translation_info = #translation
     }
-
     builtin.module {
       func.func @low_high_padded_nhwc_depthwise_conv() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -388,7 +384,7 @@ hal.executable private @low_high_padded_nhwc_depthwise_conv {
 
 hal.executable private @nchw_conv_static_shape_f32 {
   hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export @nchw_conv_static_shape_f32 layout(#pipeline_layout) attributes {
+    hal.executable.export public @nchw_conv_static_shape_f32 layout(#pipeline_layout) attributes {
       workgroup_size = [4: index, 4: index, 1: index],
       translation_info = #translation
     }
@@ -461,7 +457,7 @@ hal.executable private @nchw_conv_static_shape_f32 {
 
 hal.executable private @nhwc_conv_static_shape_f16_batch2 {
   hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export @nhwc_conv_static_shape_f16_batch2 layout(#pipeline_layout) attributes {
+    hal.executable.export public @nhwc_conv_static_shape_f16_batch2 layout(#pipeline_layout) attributes {
       workgroup_size = [8: index, 8: index, 1: index],
       translation_info = #translation
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_matmul.mlir
@@ -10,7 +10,7 @@
 ]>
 hal.executable private @matmul_static_shape_f16 {
   hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export @matmul_static_shape_f16 layout(#pipeline_layout) attributes {
+    hal.executable.export public @matmul_static_shape_f16 layout(#pipeline_layout) attributes {
       workgroup_size = [16: index, 1: index, 1: index],
       translation_info = #translation
     }
@@ -70,7 +70,7 @@ hal.executable private @matmul_static_shape_f16 {
 ]>
 hal.executable private @matmul_static_shape_f32 {
   hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export @matmul_static_shape_f32 layout(#pipeline_layout) attributes {
+    hal.executable.export public @matmul_static_shape_f32 layout(#pipeline_layout) attributes {
       workgroup_size = [16: index, 1: index, 1: index],
       translation_info = #translation
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_pooling.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_pooling.mlir
@@ -11,13 +11,12 @@
 
 hal.executable private @pooling_nhwc_sum_f32 {
   hal.executable.variant @vulkan target(<"vulkan-spirv", "vulkan-spirv-fb">) {
-    hal.executable.export @pooling_nhwc_sum_f32 layout(#pipeline_layout) attributes {
-      workgroup_size = [2: index, 2: index, 2: index],
-      translation_info = #translation
-    } {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4: index, %arg5: index, %arg6: index):
+    hal.executable.export public @pooling_nhwc_sum_f32 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4: index, %arg5: index, %arg6: index) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
+    } attributes {
+      workgroup_size = [2: index, 2: index, 2: index],
+      translation_info = #translation
     }
     builtin.module  {
       func.func @pooling_nhwc_sum_f32() {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/trim_executable_target_env.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/trim_executable_target_env.mlir
@@ -19,8 +19,7 @@ hal.executable private @predict_dispatch_0 {
   // CHECK-LABEL: hal.executable.variant public @vulkan_spirv_fb0
   //  CHECK-SAME: target(#[[$TARGET0]])
   hal.executable.variant public @vulkan_spirv_fb0 target(#executable_target_vulkan_spirv_fb) {
-    hal.executable.export public @predict_dispatch_0_vecmat_128x784_f32 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @predict_dispatch_0_vecmat_128x784_f32 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c2 = arith.constant 2 : index
       %c1 = arith.constant 1 : index
       hal.return %c2, %c1, %c1 : index, index, index
@@ -47,8 +46,7 @@ hal.executable private @predict_dispatch_1 {
   // CHECK-LABEL: hal.executable.variant public @vulkan_spirv_fb1
   //  CHECK-SAME: target(#[[$TARGET1]])
   hal.executable.variant public @vulkan_spirv_fb1 target(#executable_target_vulkan_spirv_fb) {
-    hal.executable.export public @predict_dispatch_1_vecmat_10x128_f32 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+    hal.executable.export public @predict_dispatch_1_vecmat_10x128_f32 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c10 = arith.constant 10 : index
       %c1 = arith.constant 1 : index
       hal.return %c10, %c1, %c1 : index, index, index

--- a/compiler/src/iree/compiler/Codegen/VMVX/test/link_executables.mlir
+++ b/compiler/src/iree/compiler/Codegen/VMVX/test/link_executables.mlir
@@ -12,8 +12,7 @@ hal.executable private @dispatch_0 {
       %c1 = arith.constant 1 : i32
       hal.return %c1 : i32
     }
-    hal.executable.export @dispatch_0 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device) :
+    hal.executable.export public @dispatch_0 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }
@@ -33,8 +32,7 @@ hal.executable private @dispatch_1 {
       %c2 = arith.constant 2 : i32
       hal.return %c2 : i32
     }
-    hal.executable.export @dispatch_1 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device) :
+    hal.executable.export public @dispatch_1 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }
@@ -50,8 +48,7 @@ hal.executable private @dispatch_1 {
 }
 hal.executable private @dispatch_2 {
   hal.executable.variant @vmvx target(#vmvx_target) {
-    hal.executable.export @dispatch_2 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device) :
+    hal.executable.export public @dispatch_2 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }
@@ -180,8 +177,7 @@ util.initializer {
 
 hal.executable private @dispatch_0 {
   hal.executable.variant @vmvx target(#vmvx_target) {
-    hal.executable.export @dispatch_0 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device) :
+    hal.executable.export public @dispatch_0 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }
@@ -208,8 +204,7 @@ hal.executable private @dispatch_0 {
 }
 hal.executable private @dispatch_1 {
   hal.executable.variant @vmvx target(#vmvx_target) {
-    hal.executable.export @dispatch_1 ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device) :
+    hal.executable.export public @dispatch_1 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/deduplicate_executables.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/deduplicate_executables.mlir
@@ -196,7 +196,7 @@ flow.executable @nested_ops_ex_0 {
     func.func @nested_ops_entry_0(%input0: tensor<5x6xf32>, %input1: tensor<5x6xf32>) -> tensor<5x6xf32> {
       %init = tensor.empty() : tensor<5x6xf32>
       %max = linalg.generic {indexing_maps = [#map0, #map0, #map0], iterator_types = ["parallel", "parallel"]} ins(%input0, %input1 : tensor<5x6xf32>, tensor<5x6xf32>) outs(%init : tensor<5x6xf32>) {
-      ^bb0(%arg1: f32, %arg2: f32, %arg3: f32):  // no predecessors
+      ^bb0(%arg1: f32, %arg2: f32, %arg3: f32):
         %27 = arith.maximumf %arg1, %arg2 : f32
         linalg.yield %27 : f32
       } -> tensor<5x6xf32>
@@ -211,7 +211,7 @@ flow.executable @nested_ops_ex_1 {
     func.func @nested_ops_entry_1(%input0: tensor<5x6xf32>, %input1: tensor<5x6xf32>) -> tensor<5x6xf32> {
       %init = tensor.empty() : tensor<5x6xf32>
       %max = linalg.generic {indexing_maps = [#map0, #map0, #map0], iterator_types = ["parallel", "parallel"]} ins(%input0, %input1 : tensor<5x6xf32>, tensor<5x6xf32>) outs(%init : tensor<5x6xf32>) {
-      ^bb0(%arg1: f32, %arg2: f32, %arg3: f32):  // no predecessors
+      ^bb0(%arg1: f32, %arg2: f32, %arg3: f32):
         %27 = arith.maximumf %arg1, %arg2 : f32
         linalg.yield %27 : f32
       } -> tensor<5x6xf32>
@@ -226,7 +226,7 @@ flow.executable @nested_ops_ex_2 {
     func.func @nested_ops_entry_2(%input0: tensor<5x6xf32>, %input1: tensor<5x6xf32>) -> tensor<5x6xf32> {
       %init = tensor.empty() : tensor<5x6xf32>
       %min = linalg.generic {indexing_maps = [#map0, #map0, #map0], iterator_types = ["parallel", "parallel"]} ins(%input0, %input1 : tensor<5x6xf32>, tensor<5x6xf32>) outs(%init : tensor<5x6xf32>) {
-      ^bb0(%arg1: f32, %arg2: f32, %arg3: f32):  // no predecessors
+      ^bb0(%arg1: f32, %arg2: f32, %arg3: f32):
         %27 = arith.minimumf %arg1, %arg2 : f32
         linalg.yield %27 : f32
       } -> tensor<5x6xf32>
@@ -258,7 +258,7 @@ flow.executable @attributes_ex_0 {
     func.func @attributes_entry_0(%input0: tensor<5x6xf32>, %input1: tensor<5x6xf32>) -> tensor<5x6xf32> {
       %init = tensor.empty() : tensor<5x6xf32>
       %max = linalg.generic {indexing_maps = [#map0, #map0, #map0], iterator_types = ["parallel", "parallel"]} ins(%input0, %input1 : tensor<5x6xf32>, tensor<5x6xf32>) outs(%init : tensor<5x6xf32>) {
-      ^bb0(%arg1: f32, %arg2: f32, %arg3: f32):  // no predecessors
+      ^bb0(%arg1: f32, %arg2: f32, %arg3: f32):
         %27 = arith.maximumf %arg1, %arg2 : f32
         linalg.yield %27 : f32
       } -> tensor<5x6xf32>
@@ -274,7 +274,7 @@ flow.executable @attributes_ex_1 {
       %init = tensor.empty() : tensor<5x6xf32>
       // map1 instead of map0
       %max = linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%input0, %input1 : tensor<5x6xf32>, tensor<5x6xf32>) outs(%init : tensor<5x6xf32>) {
-      ^bb0(%arg1: f32, %arg2: f32, %arg3: f32):  // no predecessors
+      ^bb0(%arg1: f32, %arg2: f32, %arg3: f32):
         %27 = arith.maximumf %arg1, %arg2 : f32
         linalg.yield %27 : f32
       } -> tensor<5x6xf32>
@@ -290,7 +290,7 @@ flow.executable @attributes_ex_2 {
     func.func @attributes_entry_2(%input0: tensor<5x6xf32>, %input1: tensor<5x6xf32>) -> tensor<5x6xf32> {
       %init = tensor.empty() : tensor<5x6xf32>
       %max = linalg.generic {indexing_maps = [#map0, #map0, #map0], iterator_types = ["parallel", "parallel"]} ins(%input0, %input1 : tensor<5x6xf32>, tensor<5x6xf32>) outs(%init : tensor<5x6xf32>) {
-      ^bb0(%arg1: f32, %arg2: f32, %arg3: f32):  // no predecessors
+      ^bb0(%arg1: f32, %arg2: f32, %arg3: f32):
         %27 = arith.maximumf %arg1, %arg2 : f32
         linalg.yield %27 : f32
       } -> tensor<5x6xf32>
@@ -389,8 +389,7 @@ hal.executable private @ex0 {
         layout(#hal.pipeline.layout<bindings = [
           #hal.pipeline.binding<storage_buffer, ReadOnly>,
           #hal.pipeline.binding<storage_buffer>
-        ]>) {
-    ^bb0(%device: !hal.device, %workload: index):
+        ]>) count(%device: !hal.device, %workload: index) -> (index, index, index) {
       hal.return %workload, %workload, %workload : index, index, index
     }
   }
@@ -406,8 +405,7 @@ hal.executable private @ex1 {
         layout(#hal.pipeline.layout<bindings = [
           #hal.pipeline.binding<storage_buffer, ReadOnly>,
           #hal.pipeline.binding<storage_buffer>
-        ]>) {
-    ^bb0(%device: !hal.device, %workload: index):
+        ]>) count(%device: !hal.device, %workload: index) -> (index, index, index) {
       hal.return %workload, %workload, %workload : index, index, index
     }
   }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/outline_dispatch_externs.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/outline_dispatch_externs.mlir
@@ -5,7 +5,7 @@
 // CHECK-SAME:       objects([#hal.executable.object<{path = "a.o"}>])
 // CHECK-NEXT:     hal.executable.export public @main ordinal(100)
 // CHECK-SAME:         layout(#hal.pipeline.layout<constants = 1, bindings = [#hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer>]>)
-// CHECK-NEXT:     ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+// CHECK-SAME:         count(%arg0: !hal.device, %arg1: index, %arg2: index)
 // CHECK-NEXT:       %ok, %value = hal.device.query<%arg0 : !hal.device> key("some" :: "value") : i1, i32
 // CHECK-NEXT:       %0 = arith.index_cast %value : i32 to index
 // CHECK-NEXT:       hal.return %arg1, %arg2, %0 : index, index, index
@@ -16,7 +16,7 @@
 // CHECK-NEXT:       hal.return %ok : i1
 //      CHECK:     hal.executable.export public @main ordinal(200)
 // CHECK-SAME:         layout(#hal.pipeline.layout<constants = 1, bindings = [#hal.pipeline.binding<storage_buffer, ReadOnly>, #hal.pipeline.binding<storage_buffer>]>)
-// CHECK-NEXT:     ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+// CHECK-SAME:         count(%arg0: !hal.device, %arg1: index, %arg2: index)
 
 // Demonstrates the full functionality of an extern dispatch op.
 // Note that some fields are optional.

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/top_level_scf_to_cfg.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/top_level_scf_to_cfg.mlir
@@ -19,7 +19,7 @@ util.func public @generic_nested_for(%arg0: tensor<?x?x?x?xi32>, %arg1: tensor<?
   // CHECK: linalg.yield
   %0 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
     ins(%arg0, %arg1 : tensor<?x?x?x?xi32>, tensor<?x?x?x?xi32>) outs(%out0 : tensor<?x?x?x?xi32>) {
-  ^bb0(%arg2: i32, %arg3: i32, %arg4: i32):  // no predecessors
+  ^bb0(%arg2: i32, %arg3: i32, %arg4: i32):
     %18:3 = scf.for %arg5 = %c0 to %c6 step %c1 iter_args(%arg6 = %c1_i32, %arg7 = %arg2, %arg8 = %arg3) -> (i32, i32, i32) {
       %28 = arith.andi %arg8, %c1_i32 : i32
       %29 = arith.cmpi eq, %28, %c1_i32 : i32

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToHAL/test/pseudo_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToHAL/test/pseudo_ops.mlir
@@ -5,8 +5,7 @@
 ]>
 hal.executable private @ex {
   hal.executable.variant public @variant target(#hal.executable.target<"llvm-cpu", "embedded-elf-x86_64">) {
-    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):
+    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout) count(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       %0 = affine.apply affine_map<()[s0] -> (s0 ceildiv 4)>()[%arg0]
       hal.return %0, %c1, %c1 : index, index, index

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/test/cmd_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/test/cmd_ops.mlir
@@ -256,26 +256,24 @@ hal.executable private @ex {
       %ok, %selected = hal.device.query<%device : !hal.device> key("some" :: "feature") : i1, i1
       hal.return %selected : i1
     }
-    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout) attributes {
-      translation_info = #iree_codegen.translation_info<pipeline = CPUDefault>
-    } {
-    ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):  // no predecessors
+    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout) count(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       %0 = affine.apply affine_map<()[s0] -> (s0 ceildiv 4)>()[%arg0]
       hal.return %0, %c1, %c1 : index, index, index
+    } attributes {
+      translation_info = #iree_codegen.translation_info<pipeline = CPUDefault>
     }
     builtin.module {
       // Opaque at this point (in some target-specific dialects).
     }
   }
   hal.executable.variant public @x86_64 target(#executable_target_x86_64) {
-    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout) attributes {
-      translation_info = #iree_codegen.translation_info<pipeline = CPUDefault>
-    } {
-    ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):  // no predecessors
+    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout) count(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       %0 = affine.apply affine_map<()[s0] -> (s0 ceildiv 4)>()[%arg0]
       hal.return %0, %c1, %c1 : index, index, index
+    } attributes {
+      translation_info = #iree_codegen.translation_info<pipeline = CPUDefault>
     }
     builtin.module {
       // Opaque at this point (in some target-specific dialects).

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -2560,7 +2560,18 @@ def HAL_ExecutableExportOp : HAL_Op<"executable.export", [
     OptionalAttr<DictionaryAttr>:$source_locs
   );
 
-  let regions = (region AnyRegion:$workgroup_count);
+  let regions = (region
+    AnyRegion:$workgroup_count
+  );
+
+  let assemblyFormat = [{
+    custom<SymbolVisibility>($sym_visibility)
+    $sym_name
+    (`ordinal` `(` $ordinal^ `)`)?
+    `layout` `(` qualified($layout) `)`
+    custom<OptionalWorkgroupCountRegion>($workgroup_count)
+    attr-dict-with-keyword
+  }];
 
   let builders = [
     OpBuilder<(ins

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/command_buffer_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/command_buffer_ops.mlir
@@ -223,7 +223,7 @@ util.func public @command_buffer_collective(
 
 hal.executable @ex {
   hal.executable.variant @backend target(<"backend", "format">) {
-    hal.executable.export @entry0 ordinal(0) layout(#hal.pipeline.layout<bindings = [
+    hal.executable.export public @entry0 ordinal(0) layout(#hal.pipeline.layout<bindings = [
       #hal.pipeline.binding<storage_buffer>,
       #hal.pipeline.binding<storage_buffer>
     ]>)
@@ -269,7 +269,7 @@ util.func public @command_buffer_dispatch(
 
 hal.executable @ex {
   hal.executable.variant @backend target(<"backend", "format">) {
-    hal.executable.export @entry0 ordinal(0) layout(#hal.pipeline.layout<bindings = [
+    hal.executable.export public @entry0 ordinal(0) layout(#hal.pipeline.layout<bindings = [
       #hal.pipeline.binding<storage_buffer>,
       #hal.pipeline.binding<storage_buffer>
     ]>)
@@ -304,7 +304,7 @@ util.func public @command_buffer_dispatch_indirect(
 
 hal.executable @ex {
   hal.executable.variant @backend target(<"backend", "format">) {
-    hal.executable.export @entry0 ordinal(0) layout(#hal.pipeline.layout<bindings = [
+    hal.executable.export public @entry0 ordinal(0) layout(#hal.pipeline.layout<bindings = [
       #hal.pipeline.binding<storage_buffer>,
       #hal.pipeline.binding<storage_buffer>
     ]>)

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/executable_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/executable_ops.mlir
@@ -11,9 +11,9 @@ hal.executable @ex {
     #hal.executable.object<{path = "foo.bin"}>,
     #hal.executable.object<{path = "bar.bin"}>
   ]) {
-    // CHECK-DAG: hal.executable.export public @entry0 ordinal(0) layout(#pipeline_layout) attributes {
-    // CHECK-SAME:     workgroup_size = [4 : index, 1 : index, 1 : index]
-    hal.executable.export @entry0 ordinal(0) layout(#hal.pipeline.layout<bindings = [
+    // CHECK-DAG: hal.executable.export public @entry0 ordinal(0) layout(#pipeline_layout)
+    // CHECK:     workgroup_size = [4 : index, 1 : index, 1 : index]
+    hal.executable.export public @entry0 ordinal(0) layout(#hal.pipeline.layout<bindings = [
       #hal.pipeline.binding<storage_buffer>,
       #hal.pipeline.binding<storage_buffer>
     ]>) attributes {
@@ -37,18 +37,17 @@ hal.executable @ex {
 hal.executable @ex_with_workgroup_count_region {
   // CHECK: hal.executable.variant public @backend target(#executable_target_format
   hal.executable.variant @backend target(#executable_target_format) {
-    // CHECK-DAG: hal.executable.export public @entry0 ordinal(0) layout(#pipeline_layout) attributes {
-    // CHECK-SAME:     subgroup_size = 64 : index
-    // CHECK-SAME:     workgroup_size = [4 : index, 1 : index, 1 : index]
-    hal.executable.export @entry0 ordinal(0) layout(#hal.pipeline.layout<bindings = [
+    // CHECK-DAG: hal.executable.export public @entry0 ordinal(0) layout(#pipeline_layout)
+    // CHECK:     subgroup_size = 64 : index
+    // CHECK:     workgroup_size = [4 : index, 1 : index, 1 : index]
+    hal.executable.export public @entry0 ordinal(0) layout(#hal.pipeline.layout<bindings = [
       #hal.pipeline.binding<storage_buffer>,
       #hal.pipeline.binding<storage_buffer>
-    ]>) attributes {
+    ]>) count(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index) -> (index, index, index) {
+      hal.return %arg0, %arg1, %arg2 : index, index, index
+    } attributes {
       subgroup_size = 64 : index,
       workgroup_size = [4 : index, 1 : index, 1 : index]
-    } {
-    ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):
-      hal.return %arg0, %arg1, %arg2 : index, index, index
     }
   }
   // CHECK: hal.executable.binary
@@ -76,18 +75,17 @@ hal.executable @ex_with_condition {
       hal.return %ok : i1
     }
 
-    // CHECK-DAG: hal.executable.export public @entry0 ordinal(0) layout(#pipeline_layout) attributes {
-    // CHECK-SAME:     subgroup_size = 64 : index
-    // CHECK-SAME:     workgroup_size = [4 : index, 1 : index, 1 : index]
-    hal.executable.export @entry0 ordinal(0) layout(#hal.pipeline.layout<bindings = [
+    // CHECK-DAG: hal.executable.export public @entry0 ordinal(0) layout(#pipeline_layout)
+    // CHECK:     subgroup_size = 64 : index
+    // CHECK:     workgroup_size = [4 : index, 1 : index, 1 : index]
+    hal.executable.export public @entry0 ordinal(0) layout(#hal.pipeline.layout<bindings = [
       #hal.pipeline.binding<storage_buffer>,
       #hal.pipeline.binding<storage_buffer>
-    ]>) attributes {
+    ]>) count(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index) -> (index, index, index) {
+      hal.return %arg0, %arg1, %arg2 : index, index, index
+    } attributes {
       subgroup_size = 64 : index,
       workgroup_size = [4 : index, 1 : index, 1 : index]
-    } {
-    ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):
-      hal.return %arg0, %arg1, %arg2 : index, index, index
     }
   }
   // CHECK: hal.executable.binary
@@ -158,8 +156,7 @@ hal.executable @unresolved_workload_ex {
     hal.executable.export public @entry0 ordinal(0) layout(#hal.pipeline.layout<bindings = [
       #hal.pipeline.binding<storage_buffer>,
       #hal.pipeline.binding<storage_buffer>
-    ]>) {
-    ^bb0(%device: !hal.device, %arg0: index):
+    ]>) count(%device: !hal.device, %arg0: index) -> (index, index, index) {
       hal.return %arg0, %arg0, %arg0 : index, index, index
     }
   }

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.h
@@ -41,30 +41,30 @@ namespace mlir::iree_compiler::IREE::HAL {
 //   [[-iree-hal-materialize-interfaces]]
 //   -> hal.executable @my_exe
 //      + hal.executable.variant @spirv-v1.1-mobile filter="spirv-v1.1-mobile*"
-//          hal.executable.export @my_entry
+//          hal.executable.export public @my_entry
 //          module { ... }
 //      + hal.executable.variant @spirv-v1.1-desktop
 //      filter="spirv-v1.1-desktop*"
-//          hal.executable.export @my_entry
+//          hal.executable.export public @my_entry
 //          module { ... }
 //      + hal.executable.variant @spirv-v1.2-desktop
 //      filter="spirv-v1.2-desktop*"
-//          hal.executable.export @my_entry
+//          hal.executable.export public @my_entry
 //          module { ... }
 //   [[-iree-hal-translate-all-executables]]
 //   -> hal.executable @my_exe
 //      + hal.executable.variant @spirv-v1.1-mobile filter="spirv-v1.1-mobile*"
-//          hal.executable.export @my_entry_1
-//          hal.executable.export @my_entry_2
-//          hal.executable.export @my_entry_3
+//          hal.executable.export public @my_entry_1
+//          hal.executable.export public @my_entry_2
+//          hal.executable.export public @my_entry_3
 //          module { spirv.module { ... } }
 //      + hal.executable.variant @spirv-v1.1-desktop
 //      filter="spirv-v1.1-desktop*"
-//          hal.executable.export @my_entry
+//          hal.executable.export public @my_entry
 //          module { spirv.module { ... } }
 //      + hal.executable.variant @spirv-v1.2-desktop
 //      filter="spirv-v1.2-desktop*"
-//          hal.executable.export @my_entry
+//          hal.executable.export public @my_entry
 //          module { spirv.module { ... } }
 //   [[-iree-hal-link-all-executables]]
 //   -> TODO(benvanik): linkage rules.
@@ -160,7 +160,7 @@ public:
   //       hal.interface.binding @arg1, set=0, binding=1, ...
   //     }
   //     hal.executable.variant @target, target="target-backend" {
-  //       hal.executable.export @main interface(@main_io) {
+  //       hal.executable.export public @main interface(@main_io) {
   //         ordinal = 0 : index
   //       }
   //       module {
@@ -176,7 +176,7 @@ public:
   //       hal.interface.binding @arg1, set=0, binding=1, ...
   //     }
   //     hal.executable.variant @target, target="target-backend" {
-  //       hal.executable.export @main interface(@main_io)
+  //       hal.executable.export public @main interface(@main_io)
   //         {attrs = #target_specific_translation_attr<...>} {
   //         ordinal = 0 : index
   //       }
@@ -205,7 +205,7 @@ public:
   //       hal.interface.binding @arg1, set=0, binding=1, ...
   //     }
   //     hal.executable.variant @target, target="target-backend" {
-  //       hal.executable.export @main interface(@main_io) {
+  //       hal.executable.export public @main interface(@main_io) {
   //         ordinal = 0 : index
   //       }
   //       module { ... (annotated for translation) }
@@ -216,7 +216,7 @@ public:
   //   hal.executable @some_executable {
   //     hal.interface @main_io ...
   //     hal.executable.variant @target, target="target-backend" {
-  //       hal.executable.export @main ...
+  //       hal.executable.export public @main ...
   //       module { spirv.module { ... } }
   //     }
   //   }

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/capture_executable_sources.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/capture_executable_sources.mlir
@@ -16,13 +16,12 @@ hal.executable private @ex0 {
   // CHECK-SAME: sources({module_ex0_variant0.configured.mlir = dense_resource<module_ex0_variant0.configured.mlir
   hal.executable.variant public @variant0 target(#executable_target) {
     // CHECK: hal.executable.export public @dispatch0
-    // CHECK-SAME: source_locs = {configured = #[[EX0_VARIANT0_LOC]]}
-    hal.executable.export public @dispatch0 ordinal(0) layout(#pipeline_layout) attributes {
-      translation_info = #iree_codegen.translation_info<pipeline = CPUDefault>
-    } {
-    ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):  // no predecessors
+    // CHECK: source_locs = {configured = #[[EX0_VARIANT0_LOC]]}
+    hal.executable.export public @dispatch0 ordinal(0) layout(#pipeline_layout) count(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
+    } attributes {
+      translation_info = #iree_codegen.translation_info<pipeline = CPUDefault>
     }
     builtin.module {
       func.func @dispatch0() {
@@ -38,13 +37,12 @@ hal.executable private @ex1 {
   // CHECK-SAME: sources({module_ex1_variant1.configured.mlir = dense_resource<module_ex1_variant1.configured.mlir
   hal.executable.variant public @variant1 target(#executable_target) {
     // CHECK: hal.executable.export public @dispatch1
-    // CHECK-SAME: source_locs = {configured = #[[EX1_VARIANT1_LOC]]}
-    hal.executable.export public @dispatch1 ordinal(0) layout(#pipeline_layout) attributes {
-      translation_info = #iree_codegen.translation_info<pipeline = CPUDefault>
-    } {
-    ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):  // no predecessors
+    // CHECK: source_locs = {configured = #[[EX1_VARIANT1_LOC]]}
+    hal.executable.export public @dispatch1 ordinal(0) layout(#pipeline_layout) count(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
+    } attributes {
+      translation_info = #iree_codegen.translation_info<pipeline = CPUDefault>
     }
     builtin.module {
       func.func @dispatch1() {

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/convert_to_hal.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/convert_to_hal.mlir
@@ -20,8 +20,7 @@ util.global private @device : !hal.device
 // CHECK: hal.executable private @ex
 hal.executable private @ex {
   hal.executable.variant public @embedded_elf_aarch64 target(#executable_target_embedded_elf_aarch64) {
-    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):  // no predecessors
+    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout) count(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       %0 = affine.apply affine_map<()[s0] -> (s0 ceildiv 4)>()[%arg0]
       hal.return %0, %c1, %c1 : index, index, index
@@ -31,8 +30,7 @@ hal.executable private @ex {
     }
   }
   hal.executable.variant public @embedded_elf_x86_64 target(#executable_target_embedded_elf_x86_64) {
-    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout) {
-    ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):  // no predecessors
+    hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout) count(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       %0 = affine.apply affine_map<()[s0] -> (s0 ceildiv 4)>()[%arg0]
       hal.return %0, %c1, %c1 : index, index, index

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/dump_executable_benchmarks.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/dump_executable_benchmarks.mlir
@@ -24,12 +24,11 @@ util.global private @device = #hal.device.target<"local", [
 // CHECK: hal.executable private @ex0
 hal.executable private @ex0 {
   hal.executable.variant public @embedded_elf_x86_64 target(#executable_target_embedded_elf_x86_64) {
-    hal.executable.export public @dispatch0 ordinal(0) layout(#pipeline_layout_0) attributes {
-      translation_info = #iree_codegen.translation_info<pipeline = CPUDefault>
-    } {
-    ^bb0(%device: !hal.device, %arg0: index):
+    hal.executable.export public @dispatch0 ordinal(0) layout(#pipeline_layout_0) count(%device: !hal.device, %arg0: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg0
       hal.return %x, %y, %z : index, index, index
+    } attributes {
+      translation_info = #iree_codegen.translation_info<pipeline = CPUDefault>
     }
     builtin.module {
       func.func @dispatch0() {
@@ -37,14 +36,13 @@ hal.executable private @ex0 {
       }
     }
 
-    hal.executable.export public @dispatch1 ordinal(1) layout(#pipeline_layout_1) attributes {
-      translation_info = #iree_codegen.translation_info<pipeline = CPUDefault>
-    } {
-    ^bb0(%device: !hal.device, %arg0: index, %arg1: index):
+    hal.executable.export public @dispatch1 ordinal(1) layout(#pipeline_layout_1) count(%device: !hal.device, %arg0: index, %arg1: index) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       %0 = affine.apply affine_map<()[s0] -> (s0 ceildiv 4)>()[%arg0]
       %1 = arith.addi %0, %arg1 : index
       hal.return %1, %c1, %c1 : index, index, index
+    } attributes {
+      translation_info = #iree_codegen.translation_info<pipeline = CPUDefault>
     }
     builtin.module {
       func.func @dispatch1() {
@@ -184,24 +182,22 @@ util.global private @device_b = #hal.device.target<"local", [
 
 hal.executable private @ex_0 {
   hal.executable.variant public @variant_a target(#executable_target_embedded_elf_aarch64) {
-    hal.executable.export public @dispatch0 ordinal(0) layout(#pipeline_layout) attributes {
-      translation_info = #iree_codegen.translation_info<pipeline = CPUDefault>
-    } {
-    ^bb0(%device: !hal.device, %arg0: index):
+    hal.executable.export public @dispatch0 ordinal(0) layout(#pipeline_layout) count(%device: !hal.device, %arg0: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg0
       hal.return %x, %y, %z : index, index, index
+    } attributes {
+      translation_info = #iree_codegen.translation_info<pipeline = CPUDefault>
     }
     builtin.module {
       func.func @dispatch0() {
         func.return
       }
     }
-    hal.executable.export public @dispatch1 ordinal(1) layout(#pipeline_layout) attributes {
-      translation_info = #iree_codegen.translation_info<pipeline = CPUDefault>
-    } {
-    ^bb0(%device: !hal.device, %arg0: index, %arg1: index):
+    hal.executable.export public @dispatch1 ordinal(1) layout(#pipeline_layout) count(%device: !hal.device, %arg0: index, %arg1: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg0
       hal.return %x, %y, %z : index, index, index
+    } attributes {
+      translation_info = #iree_codegen.translation_info<pipeline = CPUDefault>
     }
     builtin.module {
       func.func @dispatch1() {
@@ -210,24 +206,22 @@ hal.executable private @ex_0 {
     }
   }
   hal.executable.variant public @variant_b target(#executable_target_embedded_elf_x86_64) {
-    hal.executable.export public @dispatch0 ordinal(0) layout(#pipeline_layout) attributes {
-      translation_info = #iree_codegen.translation_info<pipeline = CPUDefault>
-    } {
-    ^bb0(%device: !hal.device, %arg0: index):
+    hal.executable.export public @dispatch0 ordinal(0) layout(#pipeline_layout) count(%device: !hal.device, %arg0: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg0
       hal.return %x, %y, %z : index, index, index
+    } attributes {
+      translation_info = #iree_codegen.translation_info<pipeline = CPUDefault>
     }
     builtin.module {
       func.func @dispatch0() {
         func.return
       }
     }
-    hal.executable.export public @dispatch1 ordinal(1) layout(#pipeline_layout) attributes {
-      translation_info = #iree_codegen.translation_info<pipeline = CPUDefault>
-    } {
-    ^bb0(%device: !hal.device, %arg0: index, %arg1: index):
+    hal.executable.export public @dispatch1 ordinal(1) layout(#pipeline_layout) count(%device: !hal.device, %arg0: index, %arg1: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg0
       hal.return %x, %y, %z : index, index, index
+    } attributes {
+      translation_info = #iree_codegen.translation_info<pipeline = CPUDefault>
     }
     builtin.module {
       func.func @dispatch1() {
@@ -238,12 +232,11 @@ hal.executable private @ex_0 {
 }
 hal.executable private @ex_1 {
   hal.executable.variant public @variant_b target(#executable_target_embedded_elf_x86_64) {
-    hal.executable.export public @dispatch0 ordinal(0) layout(#pipeline_layout) attributes {
-      translation_info = #iree_codegen.translation_info<pipeline = CPUDefault>
-    } {
-    ^bb0(%device: !hal.device, %arg0: index):
+    hal.executable.export public @dispatch0 ordinal(0) layout(#pipeline_layout) count(%device: !hal.device, %arg0: index) -> (index, index, index) {
       %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root %arg0
       hal.return %x, %y, %z : index, index, index
+    } attributes {
+      translation_info = #iree_codegen.translation_info<pipeline = CPUDefault>
     }
     builtin.module {
       func.func @dispatch0() {

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/dump_executable_sources.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/dump_executable_sources.mlir
@@ -15,13 +15,12 @@ hal.executable private @ex0 {
   // We expect local outputs with attributes inlined:
   // CHECK-NEXT: hal.executable.variant {{.+}} target(<"llvm-cpu"
   hal.executable.variant public @embedded_elf_x86_64 target(#executable_target_embedded_elf_x86_64) {
-    hal.executable.export public @dispatch0 ordinal(0) layout(#pipeline_layout) attributes {
-      translation_info = #iree_codegen.translation_info<pipeline = CPUDefault>
-    } {
-    ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):  // no predecessors
+    hal.executable.export public @dispatch0 ordinal(0) layout(#pipeline_layout) count(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       %0 = affine.apply affine_map<()[s0] -> (s0 ceildiv 4)>()[%arg0]
       hal.return %0, %c1, %c1 : index, index, index
+    } attributes {
+      translation_info = #iree_codegen.translation_info<pipeline = CPUDefault>
     }
     builtin.module {
       func.func @dispatch0() {
@@ -34,13 +33,12 @@ hal.executable private @ex0 {
 // CHECK: hal.executable private @ex1
 hal.executable private @ex1 {
   hal.executable.variant public @embedded_elf_x86_64 target(#executable_target_embedded_elf_x86_64) {
-    hal.executable.export public @dispatch1 ordinal(0) layout(#pipeline_layout) attributes {
-      translation_info = #iree_codegen.translation_info<pipeline = CPUDefault>
-    } {
-    ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):  // no predecessors
+    hal.executable.export public @dispatch1 ordinal(0) layout(#pipeline_layout) count(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       %0 = affine.apply affine_map<()[s0] -> (s0 ceildiv 4)>()[%arg0]
       hal.return %0, %c1, %c1 : index, index, index
+    } attributes {
+      translation_info = #iree_codegen.translation_info<pipeline = CPUDefault>
     }
     builtin.module {
       func.func @dispatch1() {

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/hoist_executable_objects.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/hoist_executable_objects.mlir
@@ -17,7 +17,7 @@ hal.executable public @executable {
   hal.executable.variant public @backend target(#hal.executable.target<"backend", "format">) objects([
     #hal.executable.object<{path = "existing_variant.obj"}>
   ]) {
-    hal.executable.export @entry0 ordinal(0) layout(#hal.pipeline.layout<bindings = [
+    hal.executable.export public @entry0 ordinal(0) layout(#hal.pipeline.layout<bindings = [
       #hal.pipeline.binding<storage_buffer>
     ]>)
     builtin.module {

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_interfaces.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_interfaces.mlir
@@ -19,7 +19,7 @@ util.global private @default_device = #hal.device.target<"cpu", [
 // CHECK: hal.executable private @ex
 // CHECK:   hal.executable.variant public @arm_64 target(#executable_target_arm_64
 // CHECK:     hal.executable.export public @entry ordinal(0) layout(#pipeline_layout)
-// CHECK-NEXT: ^bb0(%[[DEVICE:.+]]: !hal.device, %[[ARG0:.+]]: index, %[[ARG1:.+]]: index):
+// CHECK-SAME: count(%[[DEVICE:.+]]: !hal.device, %[[ARG0:.+]]: index, %[[ARG1:.+]]: index) -> (index, index, index) {
 // CHECK-NEXT:   hal.return %[[ARG0]], %[[ARG1]], %[[ARG0]] : index, index, index
 // CHECK-NEXT: }
 // CHECK:     builtin.module
@@ -27,7 +27,7 @@ util.global private @default_device = #hal.device.target<"cpu", [
 // CHECK-NEXT:  func.func @entry
 // CHECK:   hal.executable.variant public @x86_64 target(#executable_target_x86_64
 // CHECK:     hal.executable.export public @entry ordinal(0) layout(#pipeline_layout)
-// CHECK-NEXT: ^bb0(%[[DEVICE:.+]]: !hal.device, %[[ARG0:.+]]: index, %[[ARG1:.+]]: index):
+// CHECK-SAME: count(%[[DEVICE:.+]]: !hal.device, %[[ARG0:.+]]: index, %[[ARG1:.+]]: index) -> (index, index, index) {
 // CHECK-NEXT:   hal.return %[[ARG0]], %[[ARG1]], %[[ARG0]] : index, index, index
 // CHECK-NEXT: }
 // CHECK:     builtin.module

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_resource_caches.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_resource_caches.mlir
@@ -19,9 +19,9 @@ hal.executable private @exe {
       %ok, %selected = hal.device.query<%device : !hal.device> key("some" :: "feature") : i1, i1
       hal.return %selected : i1
     }
-    hal.executable.export @entry0 ordinal(0) layout(#pipeline_layout_0)
-    hal.executable.export @entry0_alias ordinal(0) layout(#pipeline_layout_0)
-    hal.executable.export @entry1 ordinal(1) layout(#pipeline_layout_1)
+    hal.executable.export public @entry0 ordinal(0) layout(#pipeline_layout_0)
+    hal.executable.export public @entry0_alias ordinal(0) layout(#pipeline_layout_0)
+    hal.executable.export public @entry1 ordinal(1) layout(#pipeline_layout_1)
     // CHECK-NOT: hal.executable.constant.block
     hal.executable.constant.block() -> (i32, i32) as ("foo", "bar") {
       %c123 = arith.constant 123 : i32
@@ -123,7 +123,7 @@ hal.executable private @exe {
       %ok, %selected = hal.device.query<%device : !hal.device> key("some" :: "feature") : i1, i1
       hal.return %selected : i1
     }
-    hal.executable.export @entry0 ordinal(0) layout(#hal.pipeline.layout<bindings = [
+    hal.executable.export public @entry0 ordinal(0) layout(#hal.pipeline.layout<bindings = [
       #hal.pipeline.binding<storage_buffer>,
       #hal.pipeline.binding<storage_buffer>
     ]>)
@@ -187,7 +187,7 @@ util.func public @fallbackLookup() -> (!hal.executable, !hal.executable) {
 
 hal.executable private @exe {
   hal.executable.variant @vmvx target(<"vmvx", "vmvx-bytecode-fb">) {
-    hal.executable.export @entry0 ordinal(0) layout(#hal.pipeline.layout<bindings = [
+    hal.executable.export public @entry0 ordinal(0) layout(#hal.pipeline.layout<bindings = [
       #hal.pipeline.binding<storage_buffer>
     ]>)
   }
@@ -279,7 +279,7 @@ util.initializer {
 
 hal.executable @exe {
   hal.executable.variant @vmvx target(<"vmvx", "vmvx-bytecode-fb">) {
-    hal.executable.export @entry ordinal(0) layout(#pipeline_layout_0) attributes {
+    hal.executable.export public @entry ordinal(0) layout(#pipeline_layout_0) attributes {
       workgroup_size = [32 : index, 1 : index, 1 : index]
     }
   }

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/preprocess_executables.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/preprocess_executables.mlir
@@ -23,8 +23,7 @@ hal.executable private @executable_a {
   hal.executable.variant public @variant_a target(#hal.executable.target<"cuda", "cuda-nvptx-fb", {replace_i64 = 123 : i64}>) {
     hal.executable.export public @dispatch_a ordinal(0) layout(#hal.pipeline.layout<bindings = [
       #hal.pipeline.binding<storage_buffer>
-    ]>) {
-    ^bb0(%arg0: !hal.device, %arg1: index):
+    ]>) count(%arg0: !hal.device, %arg1: index) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }
@@ -41,8 +40,7 @@ hal.executable private @executable_a {
   hal.executable.variant public @variant_unmodified target(#hal.executable.target<"cuda", "cuda-nvptx-fb", {}>) {
     hal.executable.export public @dispatch_unmodified ordinal(0) layout(#hal.pipeline.layout<bindings = [
       #hal.pipeline.binding<storage_buffer>
-    ]>) {
-    ^bb0(%arg0: !hal.device, %arg1: index):
+    ]>) count(%arg0: !hal.device, %arg1: index) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }
@@ -63,8 +61,7 @@ hal.executable private @executable_b {
   hal.executable.variant public @variant_b target(#hal.executable.target<"cuda", "cuda-nvptx-fb", {replace_i64 = 456 : i64}>) {
     hal.executable.export public @dispatch_b ordinal(0) layout(#hal.pipeline.layout<bindings = [
       #hal.pipeline.binding<storage_buffer>
-    ]>) {
-    ^bb0(%arg0: !hal.device):
+    ]>) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
     }

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/resolve_export_ordinals.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/resolve_export_ordinals.mlir
@@ -2,14 +2,14 @@
 
 hal.executable @exe0 {
   hal.executable.variant @target target(<"vmvx", "vmvx-bytecode-fb">) {
-    hal.executable.export @entry123 ordinal(123) layout(#hal.pipeline.layout<bindings = [
+    hal.executable.export public @entry123 ordinal(123) layout(#hal.pipeline.layout<bindings = [
       #hal.pipeline.binding<storage_buffer>
     ]>)
   }
 }
 hal.executable @exe1 {
   hal.executable.variant @target target(<"vmvx", "vmvx-bytecode-fb">) {
-    hal.executable.export @entry456 ordinal(456) layout(#hal.pipeline.layout<bindings = [
+    hal.executable.export public @entry456 ordinal(456) layout(#hal.pipeline.layout<bindings = [
       #hal.pipeline.binding<storage_buffer>
     ]>)
   }

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/strip_executable_contents.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/strip_executable_contents.mlir
@@ -5,7 +5,7 @@ hal.executable @ex {
   // CHECK: hal.executable.variant public @backend
   hal.executable.variant @backend target(#hal.executable.target<"backend", "format">) {
     // CHECK: hal.executable.export public @entry0
-    hal.executable.export @entry0 ordinal(0) layout(#hal.pipeline.layout<bindings = [
+    hal.executable.export public @entry0 ordinal(0) layout(#hal.pipeline.layout<bindings = [
       #hal.pipeline.binding<storage_buffer>,
       #hal.pipeline.binding<storage_buffer>
     ]>)

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/substitute_executables.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/substitute_executables.mlir
@@ -9,8 +9,7 @@ hal.executable private @executable0 {
   hal.executable.variant public @variant target(<"cuda", "cuda-nvptx-fb">) {
     hal.executable.export public @dispatch0 ordinal(0) layout(#hal.pipeline.layout<bindings = [
       #hal.pipeline.binding<storage_buffer>
-    ]>) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+    ]>) count(%arg0: !hal.device, %arg1: index, %arg2: index) -> (index, index, index) {
       // CHECK: arith.constant 123
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
@@ -38,8 +37,7 @@ hal.executable private @executable1 {
   hal.executable.variant public @variant target(<"cuda", "cuda-nvptx-fb">) {
     hal.executable.export public @dispatch1 ordinal(0) layout(#hal.pipeline.layout<bindings = [
       #hal.pipeline.binding<storage_buffer>
-    ]>) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+    ]>) count(%arg0: !hal.device, %arg1: index, %arg2: index) -> (index, index, index) {
       // CHECK: arith.constant 100 : index
       %c100 = arith.constant 100 : index
       hal.return %c100, %c100, %c100 : index, index, index

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/substitute_executables_replacement.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/substitute_executables_replacement.mlir
@@ -3,8 +3,7 @@ hal.executable private @executable0 {
   hal.executable.variant public @variant target(<"cuda", "cuda-nvptx-fb">) {
     hal.executable.export public @dispatch0 ordinal(0) layout(#hal.pipeline.layout<bindings = [
       #hal.pipeline.binding<storage_buffer>
-    ]>) {
-    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+    ]>) count(%arg0: !hal.device, %arg1: index, %arg2: index) -> (index, index, index) {
       %c123 = arith.constant 123 : index
       hal.return %c123, %c123, %c123 : index, index, index
     }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -4,7 +4,7 @@ func.func @sort_invalid_dimension(%arg0: tensor<128xi32>) -> tensor<128xi32> {
   // expected-error @+1 {{dimension must be within (0, 1]}}
   %0 = iree_linalg_ext.sort dimension(1)
     outs(%arg0 : tensor<128xi32>) {
-  ^bb0(%arg1: i32, %arg2: i32):  // no predecessors
+  ^bb0(%arg1: i32, %arg2: i32):
     %1 = arith.cmpi sgt, %arg1, %arg2 : i32
     iree_linalg_ext.yield %1 : i1
   } -> tensor<128xi32>
@@ -18,7 +18,7 @@ func.func @sort_mismatch_rank(%arg0: tensor<?x?xi32>, %arg1: tensor<?xf32>)
   // expected-error @+1 {{expected operand 1 to be rank 2, same as other operands}}
   %0:2 = iree_linalg_ext.sort dimension(0)
       outs(%arg0, %arg1 : tensor<?x?xi32>, tensor<?xf32>) {
-      ^bb0(%arg2: i32, %arg3: i32, %arg4 : f32, %arg5 : f32):  // no predecessors
+      ^bb0(%arg2: i32, %arg3: i32, %arg4 : f32, %arg5 : f32):
         %1 = arith.cmpf ogt, %arg4, %arg5 : f32
         iree_linalg_ext.yield %1 : i1
       } -> tensor<?x?xi32>, tensor<?xf32>
@@ -32,7 +32,7 @@ func.func @sort_mismatch_shape(%arg0: tensor<?xi32>, %arg1: tensor<42xf32>)
   // expected-error @+1 {{expected operand 1 to have same shape as other operands}}
   %0:2 = iree_linalg_ext.sort dimension(0)
       outs(%arg0, %arg1 : tensor<?xi32>, tensor<42xf32>) {
-      ^bb0(%arg2: i32, %arg3: i32, %arg4 : f32, %arg5 : f32):  // no predecessors
+      ^bb0(%arg2: i32, %arg3: i32, %arg4 : f32, %arg5 : f32):
         %1 = arith.cmpf ogt, %arg4, %arg5 : f32
         iree_linalg_ext.yield %1 : i1
       } -> tensor<?xi32>, tensor<42xf32>
@@ -491,7 +491,7 @@ func.func @topk_invalid(%input_values: tensor<2x10xf32>, %input_indices: tensor<
         dimension(1)
         ins(%input_indices, %input_indices, %input_indices : tensor<2x10xi32>, tensor<2x10xi32>, tensor<2x10xi32>)
         outs(%out_values, %out_indices : tensor<2x3xf32>, tensor<2x3xi32>) {
-        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+        ^bb0(%arg0: f32, %arg1: f32):
           %0 = arith.cmpf ogt, %arg0, %arg1 : f32
           iree_linalg_ext.yield %0 : i1
         } -> tensor<2x3xf32>, tensor<2x3xi32>
@@ -506,7 +506,7 @@ func.func @topk_invalid(%input_values: tensor<2x10xi32>, %input_indices: tensor<
         dimension(1)
         ins(%input_values, %input_indices : tensor<2x10xi32> , tensor<2x10xi32>)
         outs(%out_values, %out_indices : tensor<2x3xf32>, tensor<2x3xi32>) {
-        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+        ^bb0(%arg0: f32, %arg1: f32):
           %0 = arith.cmpf ogt, %arg0, %arg1 : f32
           iree_linalg_ext.yield %0 : i1
         } -> tensor<2x3xf32>, tensor<2x3xi32>
@@ -521,7 +521,7 @@ func.func @topk_invalid(%input_values: tensor<2x10xf32>, %input_indices: tensor<
         dimension(1)
         ins(%input_values, %input_indices : tensor<2x10xf32> , tensor<2x10xf32>)
         outs(%out_values, %out_indices : tensor<2x3xf32>, tensor<2x3xi32>) {
-        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+        ^bb0(%arg0: f32, %arg1: f32):
           %0 = arith.cmpf ogt, %arg0, %arg1 : f32
           iree_linalg_ext.yield %0 : i1
         } -> tensor<2x3xf32>, tensor<2x3xi32>
@@ -536,7 +536,7 @@ func.func @topk_invalid(%input_values: tensor<10x2x10xf32>, %input_indices: tens
         dimension(1)
         ins(%input_values, %input_indices : tensor<10x2x10xf32> , tensor<10x2x10xi32>)
         outs(%out_values, %out_indices : tensor<2x3xf32>, tensor<2x3xi32>) {
-        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+        ^bb0(%arg0: f32, %arg1: f32):
           %0 = arith.cmpf ogt, %arg0, %arg1 : f32
           iree_linalg_ext.yield %0 : i1
         } -> tensor<2x3xf32>, tensor<2x3xi32>
@@ -551,7 +551,7 @@ func.func @topk_invalid(%input_values: tensor<3x10xf32>, %input_indices: tensor<
         dimension(1)
         ins(%input_values, %input_indices : tensor<3x10xf32> , tensor<2x10xi32>)
         outs(%out_values, %out_indices : tensor<2x3xf32>, tensor<2x3xi32>) {
-        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+        ^bb0(%arg0: f32, %arg1: f32):
           %0 = arith.cmpf ogt, %arg0, %arg1 : f32
           iree_linalg_ext.yield %0 : i1
         } -> tensor<2x3xf32>, tensor<2x3xi32>
@@ -566,7 +566,7 @@ func.func @topk_invalid(%input_values: tensor<2x10xf32>, %input_indices: tensor<
         dimension(1)
         ins(%input_values, %input_indices : tensor<2x10xf32> , tensor<2x10xi32>)
         outs(%out_values, %out_indices : tensor<3x3xf32>, tensor<2x3xi32>) {
-        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+        ^bb0(%arg0: f32, %arg1: f32):
           %0 = arith.cmpf ogt, %arg0, %arg1 : f32
           iree_linalg_ext.yield %0 : i1
         } -> tensor<3x3xf32>, tensor<2x3xi32>
@@ -581,7 +581,7 @@ func.func @topk_invalid(%input_values: tensor<3x10xf32>, %input_indices: tensor<
         dimension(1)
         ins(%input_values, %input_indices  : tensor<3x10xf32> , tensor<3x10xi32>)
         outs(%out_values, %out_indices : tensor<2x3xf32>, tensor<2x3xi32>) {
-        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+        ^bb0(%arg0: f32, %arg1: f32):
           %0 = arith.cmpf ogt, %arg0, %arg1 : f32
           iree_linalg_ext.yield %0 : i1
         } -> tensor<2x3xf32>, tensor<2x3xi32>

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
@@ -4,7 +4,7 @@ func.func @sort_tensor(%arg0: tensor<128xi32>) -> tensor<128xi32> {
   %0 = iree_linalg_ext.sort
     dimension(0)
     outs(%arg0 : tensor<128xi32>) {
-  ^bb0(%arg1: i32, %arg2: i32):  // no predecessors
+  ^bb0(%arg1: i32, %arg2: i32):
     %1 = arith.cmpi sgt, %arg1, %arg2 : i32
     iree_linalg_ext.yield %1 : i1
   } -> tensor<128xi32>
@@ -21,7 +21,7 @@ func.func @sort_tensor(%arg0: tensor<128xi32>) -> tensor<128xi32> {
 func.func @sort_memref(%arg0: memref<128xi32>) {
   iree_linalg_ext.sort dimension(0)
     outs(%arg0 : memref<128xi32>) {
-  ^bb0(%arg1: i32, %arg2: i32):  // no predecessors
+  ^bb0(%arg1: i32, %arg2: i32):
     %0 = arith.cmpi sgt, %arg1, %arg2 : i32
     iree_linalg_ext.yield %0 : i1
   }
@@ -40,7 +40,7 @@ func.func @sort_multi_result_tensor(
     -> (tensor<?x?xi32>, tensor<?x?xf32>) {
   %0:2 = iree_linalg_ext.sort dimension(0)
       outs(%arg0, %arg1 : tensor<?x?xi32>, tensor<?x?xf32>) {
-      ^bb0(%arg2: i32, %arg3: i32, %arg4 : f32, %arg5 : f32):  // no predecessors
+      ^bb0(%arg2: i32, %arg3: i32, %arg4 : f32, %arg5 : f32):
         %1 = arith.cmpf ogt, %arg4, %arg5 : f32
         iree_linalg_ext.yield %1 : i1
       } -> tensor<?x?xi32>, tensor<?x?xf32>
@@ -59,7 +59,7 @@ func.func @sort_multi_result_memref(
     %arg0: memref<?x?xi32>, %arg1: memref<?x?xf32>) {
   iree_linalg_ext.sort dimension(0)
      outs(%arg0, %arg1 : memref<?x?xi32>, memref<?x?xf32>) {
-     ^bb0(%arg2: i32, %arg3: i32, %arg4 : f32, %arg5 : f32):  // no predecessors
+     ^bb0(%arg2: i32, %arg3: i32, %arg4 : f32, %arg5 : f32):
        %1 = arith.cmpf ogt, %arg4, %arg5 : f32
        iree_linalg_ext.yield %1 : i1
      }
@@ -361,7 +361,7 @@ func.func @scatter_update_scalar_1D(
     unique_indices(true)
     ins(%updates, %indices : tensor<3xi32>, tensor<3xi32>)
     outs(%original : tensor<8xi32>)  {
-    ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
+    ^bb0(%arg0: i32, %arg1: i32):
       iree_linalg_ext.yield %arg0 : i32
     } -> tensor<8xi32>
   return %0 : tensor<8xi32>
@@ -388,7 +388,7 @@ func.func @scatter_update_i64_scalar_1D(
     unique_indices(true)
     ins(%updates, %indices : tensor<3xi32>, tensor<3x1xi64>)
     outs(%original : tensor<8xi32>)  {
-    ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
+    ^bb0(%arg0: i32, %arg1: i32):
       iree_linalg_ext.yield %arg0 : i32
     } -> tensor<8xi32>
   return %0 : tensor<8xi32>
@@ -415,7 +415,7 @@ func.func @scatter_update_scalar_2D(
     unique_indices(true)
     ins(%updates, %indices : tensor<3xi32>, tensor<3x2xi32>)
     outs(%original : tensor<4x3xi32>)  {
-    ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
+    ^bb0(%arg0: i32, %arg1: i32):
       iree_linalg_ext.yield %arg0 : i32
     } -> tensor<4x3xi32>
   return %0 : tensor<4x3xi32>
@@ -442,7 +442,7 @@ func.func @scatter_update_slice_2D(
     unique_indices(true)
     ins(%updates, %indices : tensor<1x3xi32>, tensor<1x1xi32>)
     outs(%original : tensor<4x3xi32>)  {
-    ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
+    ^bb0(%arg0: i32, %arg1: i32):
       iree_linalg_ext.yield %arg0 : i32
     } -> tensor<4x3xi32>
   return %0 : tensor<4x3xi32>
@@ -573,7 +573,7 @@ func.func @scatter_update_slice_2D(
     unique_indices(true)
     ins(%updates, %indices : tensor<1x?xi32>, tensor<1x1xi32>)
     outs(%original : tensor<4x?xi32>)  {
-    ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
+    ^bb0(%arg0: i32, %arg1: i32):
       iree_linalg_ext.yield %arg0 : i32
     } -> tensor<4x?xi32>
   return %0 : tensor<4x?xi32>
@@ -807,7 +807,7 @@ func.func @topk_tensor(%input_values: tensor<20x10x8x4xf32>, %input_indices: ten
         dimension(2)
         ins(%input_values, %input_indices : tensor<20x10x8x4xf32> , tensor<20x10x8x4xi32>)
         outs(%out_values, %out_indices : tensor<20x10x3x4xf32>, tensor<20x10x3x4xi32>) {
-        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+        ^bb0(%arg0: f32, %arg1: f32):
           %0 = arith.cmpf ogt, %arg0, %arg1 : f32
           iree_linalg_ext.yield %0 : i1
         } -> tensor<20x10x3x4xf32>, tensor<20x10x3x4xi32>
@@ -832,7 +832,7 @@ func.func @topk_memref(%input_values: memref<4x10xf32>, %input_indices: memref<4
         dimension(1)
         ins(%input_values, %input_indices : memref<4x10xf32> , memref<4x10xi32>)
         outs(%out_values, %out_indices : memref<4x3xf32>, memref<4x3xi32>) {
-        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+        ^bb0(%arg0: f32, %arg1: f32):
           %0 = arith.cmpf ogt, %arg0, %arg1 : f32
           iree_linalg_ext.yield %0 : i1
         }
@@ -856,7 +856,7 @@ func.func @topk_dynamic_tensor(%input_values: tensor<?x?xf32>, %input_indices: t
         dimension(1)
         ins(%input_values, %input_indices : tensor<?x?xf32> , tensor<?x?xi32>)
         outs(%out_values, %out_indices : tensor<?x?xf32>, tensor<?x?xi32>) {
-        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+        ^bb0(%arg0: f32, %arg1: f32):
           %0 = arith.cmpf ogt, %arg0, %arg1 : f32
           iree_linalg_ext.yield %0 : i1
         } -> tensor<?x?xf32>, tensor<?x?xi32>
@@ -883,7 +883,7 @@ func.func @topk_tensor_optional(%input_values: tensor<20x10x8x4xf32>) -> (tensor
         dimension(2)
         ins(%input_values : tensor<20x10x8x4xf32>)
         outs(%out_values, %out_indices : tensor<20x10x3x4xf32>, tensor<20x10x3x4xi32>) {
-        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+        ^bb0(%arg0: f32, %arg1: f32):
           %0 = arith.cmpf ogt, %arg0, %arg1 : f32
           iree_linalg_ext.yield %0 : i1
         } -> tensor<20x10x3x4xf32>, tensor<20x10x3x4xi32>

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
@@ -3,7 +3,7 @@
 func.func @sort_1d(%arg0: memref<128xi32>) {
   iree_linalg_ext.sort dimension(0)
     outs(%arg0 : memref<128xi32>) {
-  ^bb0(%arg2: i32, %arg3: i32):  // no predecessors
+  ^bb0(%arg2: i32, %arg3: i32):
     %0 = arith.cmpi sgt, %arg2, %arg3 : i32
     iree_linalg_ext.yield %0 : i1
   }
@@ -33,7 +33,7 @@ func.func @sort_1d(%arg0: memref<128xi32>) {
 func.func @sort_2d(%arg0: memref<16x32xi32>) {
   iree_linalg_ext.sort dimension(0)
     outs(%arg0 : memref<16x32xi32>) {
-  ^bb0(%arg2: i32, %arg3: i32):  // no predecessors
+  ^bb0(%arg2: i32, %arg3: i32):
     %0 = arith.cmpi sgt, %arg2, %arg3 : i32
     iree_linalg_ext.yield %0 : i1
   }
@@ -66,7 +66,7 @@ func.func @sort_multi(%arg0: memref<128xf32>, %arg1: memref<128xi32>) {
   iree_linalg_ext.sort
     dimension(0)
     outs(%arg0, %arg1 : memref<128xf32>, memref<128xi32>) {
-  ^bb0(%arg2: f32, %arg3: f32, %arg4: i32, %arg5: i32):  // no predecessors
+  ^bb0(%arg2: f32, %arg3: f32, %arg4: i32, %arg5: i32):
     %0 = arith.cmpf ogt, %arg2, %arg3 : f32
     iree_linalg_ext.yield %0 : i1
   }
@@ -104,7 +104,7 @@ func.func @scatter_update_scalar_1D(
   iree_linalg_ext.scatter dimension_map = [0] unique_indices(true)
     ins(%updates, %indices : memref<3xi32>, memref<3x1xi32>)
     outs(%original : memref<8xi32>)  {
-  ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
+  ^bb0(%arg0: i32, %arg1: i32):
     iree_linalg_ext.yield %arg0 : i32
   }
   return
@@ -130,7 +130,7 @@ func.func @scatter_batch_2D(
   iree_linalg_ext.scatter dimension_map = [0] unique_indices(true)
     ins(%updates, %indices : memref<1x3xi32>, memref<1x3x1xi32>)
     outs(%original : memref<8xi32>)  {
-  ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
+  ^bb0(%arg0: i32, %arg1: i32):
     iree_linalg_ext.yield %arg0 : i32
   }
   return
@@ -157,7 +157,7 @@ func.func @scatter_add_scalar_2D(
   iree_linalg_ext.scatter dimension_map = [0, 1] unique_indices(true)
     ins(%updates, %indices : memref<3xi32>, memref<3x2xi32>)
     outs(%original : memref<4x3xi32>)  {
-  ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
+  ^bb0(%arg0: i32, %arg1: i32):
     %0 = arith.addi %arg1, %arg0 : i32
     iree_linalg_ext.yield %0 : i32
   }
@@ -188,7 +188,7 @@ func.func @scatter_update_slice_2D(
   iree_linalg_ext.scatter dimension_map = [0] unique_indices(true)
     ins(%updates, %indices : memref<2x3xi32>, memref<2x1xi32>)
     outs(%original : memref<4x3xi32>)  {
-  ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
+  ^bb0(%arg0: i32, %arg1: i32):
     iree_linalg_ext.yield %arg0 : i32
   }
   return
@@ -218,7 +218,7 @@ func.func @scatter_add_scalar_1D(
   iree_linalg_ext.scatter dimension_map = [0] unique_indices(true)
     ins(%updates, %indices : memref<3xi32>, memref<3x1xi32>)
     outs(%original : memref<8xi32>)  {
-  ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
+  ^bb0(%arg0: i32, %arg1: i32):
     %0 = arith.addi %arg1, %arg0 : i32
     iree_linalg_ext.yield %0 : i32
   }
@@ -247,7 +247,7 @@ func.func @scatter_add_slice_2D(
   iree_linalg_ext.scatter dimension_map = [0] unique_indices(true)
     ins(%updates, %indices : memref<2x3xi32>, memref<2x1xi32>)
     outs(%original : memref<4x3xi32>)  {
-  ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
+  ^bb0(%arg0: i32, %arg1: i32):
     %0 = arith.addi %arg1, %arg0 : i32
     iree_linalg_ext.yield %0 : i32
   }
@@ -277,7 +277,7 @@ func.func @scatter_update_scalar_dynamic_1D(
   iree_linalg_ext.scatter dimension_map = [0] unique_indices(true)
     ins(%updates, %indices : memref<?xi32>, memref<?x1xi32>)
     outs(%original : memref<?xi32>)  {
-  ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
+  ^bb0(%arg0: i32, %arg1: i32):
     iree_linalg_ext.yield %arg0 : i32
   }
   return
@@ -303,7 +303,7 @@ func.func @scatter_add_scalar_dynamic_2D(
   iree_linalg_ext.scatter dimension_map = [0, 1] unique_indices(true)
     ins(%updates, %indices : memref<?xi32>, memref<?x2xi32>)
     outs(%original : memref<?x?xi32>)  {
-  ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
+  ^bb0(%arg0: i32, %arg1: i32):
     %0 = arith.addi %arg1, %arg0 : i32
     iree_linalg_ext.yield %0 : i32
   }
@@ -334,7 +334,7 @@ func.func @scatter_update_slice_dynamic_2D(
   iree_linalg_ext.scatter dimension_map = [0] unique_indices(true)
     ins(%updates, %indices : memref<?x?xi32>, memref<?x1xi32>)
     outs(%original : memref<?x?xi32>)  {
-  ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
+  ^bb0(%arg0: i32, %arg1: i32):
     iree_linalg_ext.yield %arg0 : i32
   }
   return
@@ -604,7 +604,7 @@ func.func @topk_memref(%input_values: memref<2x10xf32>, %input_indices: memref<2
         dimension(1)
         ins(%input_values, %input_indices : memref<2x10xf32> , memref<2x10xi32>)
         outs(%out_values, %out_indices : memref<2x3xf32>, memref<2x3xi32>) {
-        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+        ^bb0(%arg0: f32, %arg1: f32):
           %0 = arith.cmpf ogt, %arg0, %arg1 : f32
           iree_linalg_ext.yield %0 : i1
         }
@@ -649,7 +649,7 @@ func.func @topk_memref_dynamic(%input_values: memref<?x?xf32>, %input_indices: m
         dimension(1)
         ins(%input_values, %input_indices : memref<?x?xf32> , memref<?x?xi32>)
         outs(%out_values, %out_indices : memref<?x3xf32>, memref<?x3xi32>) {
-        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+        ^bb0(%arg0: f32, %arg1: f32):
           %0 = arith.cmpf ogt, %arg0, %arg1 : f32
           iree_linalg_ext.yield %0 : i1
         }
@@ -694,7 +694,7 @@ func.func @topk_memref_optional(%input_values: memref<2x10xf32>, %out_values: me
         dimension(1)
         ins(%input_values : memref<2x10xf32>)
         outs(%out_values, %out_indices : memref<2x3xf32>, memref<2x3xi32>) {
-        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+        ^bb0(%arg0: f32, %arg1: f32):
           %0 = arith.cmpf ogt, %arg0, %arg1 : f32
           iree_linalg_ext.yield %0 : i1
         }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/distribution.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/distribution.mlir
@@ -69,7 +69,7 @@ func.func @sort_3d_multi_result_distribute(
   %0, %1 = iree_linalg_ext.sort
       dimension(2)
       outs(%arg0, %arg1 : tensor<?x?x?xi32>, tensor<?x?x?xf32>) {
-      ^bb0(%arg2: i32, %arg3: i32, %arg4 : f32, %arg5 : f32):  // no predecessors
+      ^bb0(%arg2: i32, %arg3: i32, %arg4 : f32, %arg5 : f32):
         %2 = arith.cmpf ogt, %arg4, %arg5 : f32
         iree_linalg_ext.yield %2 : i1
       } -> tensor<?x?x?xi32>, tensor<?x?x?xf32>
@@ -127,7 +127,7 @@ func.func @sort_3d_multi_result_distribute_memref(
   iree_linalg_ext.sort
       dimension(2)
       outs(%arg0, %arg1 : memref<?x?x?xi32>, memref<?x?x?xf32>) {
-      ^bb0(%arg2: i32, %arg3: i32, %arg4 : f32, %arg5 : f32):  // no predecessors
+      ^bb0(%arg2: i32, %arg3: i32, %arg4 : f32, %arg5 : f32):
         %0 = arith.cmpf ogt, %arg4, %arg5 : f32
         iree_linalg_ext.yield %0 : i1
       }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/split_reduction.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/split_reduction.mlir
@@ -7,7 +7,7 @@ func.func @topk_split_reduction_1d(%input_values: tensor<30xf32>, %out_values: t
         dimension(0)
         ins(%input_values: tensor<30xf32>)
         outs(%out_values, %out_indices : tensor<3xf32>, tensor<3xi32>) {
-        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+        ^bb0(%arg0: f32, %arg1: f32):
           %0 = arith.cmpf ogt, %arg0, %arg1 : f32
           iree_linalg_ext.yield %0 : i1
         } -> tensor<3xf32>, tensor<3xi32>
@@ -57,7 +57,7 @@ func.func @topk_split_reduction_nd(%input_values: tensor<3x10x40x8xf32>, %out_va
         dimension(2)
         ins(%input_values : tensor<3x10x40x8xf32>)
         outs(%out_values, %out_indices : tensor<3x10x4x8xf32>, tensor<3x10x4x8xi32>) {
-        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+        ^bb0(%arg0: f32, %arg1: f32):
           %0 = arith.cmpf ogt, %arg0, %arg1 : f32
           iree_linalg_ext.yield %0 : i1
         } -> tensor<3x10x4x8xf32>, tensor<3x10x4x8xi32>
@@ -107,7 +107,7 @@ func.func @topk_split_reduction_double(%input_values: tensor<400xf32>, %out_valu
         dimension(0)
         ins(%input_values: tensor<400xf32>)
         outs(%out_values, %out_indices : tensor<3xf32>, tensor<3xi32>) {
-        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+        ^bb0(%arg0: f32, %arg1: f32):
           %0 = arith.cmpf ogt, %arg0, %arg1 : f32
           iree_linalg_ext.yield %0 : i1
         } -> tensor<3xf32>, tensor<3xi32>

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
@@ -202,7 +202,7 @@ func.func @scatter_batch_2D(
   iree_linalg_ext.scatter dimension_map = [0] unique_indices(true)
     ins(%updates, %indices : memref<?x?xi32>, memref<?x?x1xi32>)
     outs(%original : memref<?xi32>)  {
-  ^bb0(%arg0: i32, %arg1: i32):  // no predecessors
+  ^bb0(%arg0: i32, %arg1: i32):
     iree_linalg_ext.yield %arg0 : i32
   }
   return
@@ -246,7 +246,7 @@ func.func @sort_1d(%arg0: tensor<?xi32>) -> tensor<?xi32> {
   %0 = iree_linalg_ext.sort
        dimension(0)
        outs(%arg0 : tensor<?xi32>) {
-       ^bb0(%arg2: i32, %arg3: i32):  // no predecessors
+       ^bb0(%arg2: i32, %arg3: i32):
          %0 = arith.cmpi sgt, %arg2, %arg3 : i32
          iree_linalg_ext.yield %0 : i1
        } -> tensor<?xi32>
@@ -271,7 +271,7 @@ func.func @sort_2d(%arg0: tensor<?x?xi32>) -> tensor<?x?xi32> {
   %0 = iree_linalg_ext.sort
        dimension(1)
        outs(%arg0 : tensor<?x?xi32>) {
-       ^bb0(%arg2: i32, %arg3: i32):  // no predecessors
+       ^bb0(%arg2: i32, %arg3: i32):
          %0 = arith.cmpi sgt, %arg2, %arg3 : i32
          iree_linalg_ext.yield %0 : i1
        } -> tensor<?x?xi32>
@@ -310,7 +310,7 @@ func.func @sort_2d_inner_parallel(%arg0: tensor<?x?xi32>) -> tensor<?x?xi32> {
   %0 = iree_linalg_ext.sort
        dimension(0)
        outs(%arg0 : tensor<?x?xi32>) {
-       ^bb0(%arg2: i32, %arg3: i32):  // no predecessors
+       ^bb0(%arg2: i32, %arg3: i32):
          %0 = arith.cmpi sgt, %arg2, %arg3 : i32
          iree_linalg_ext.yield %0 : i1
        } -> tensor<?x?xi32>
@@ -351,7 +351,7 @@ func.func @sort_2d_multi_result(
   %0:2 = iree_linalg_ext.sort
        dimension(1)
        outs(%arg0, %arg1 : tensor<?x?xi32>, tensor<?x?xf32>) {
-       ^bb0(%arg2: i32, %arg3: i32, %arg4 : f32, %arg5 : f32):  // no predecessors
+       ^bb0(%arg2: i32, %arg3: i32, %arg4 : f32, %arg5 : f32):
          %1 = arith.cmpf ogt, %arg4, %arg5 : f32
          iree_linalg_ext.yield %1 : i1
        } -> tensor<?x?xi32>, tensor<?x?xf32>
@@ -396,7 +396,7 @@ func.func @sort_2d_multi_result_memref(
   iree_linalg_ext.sort
      dimension(0)
      outs(%arg0, %arg1 : memref<?x?xi32>, memref<?x?xf32>) {
-     ^bb0(%arg2: i32, %arg3: i32, %arg4 : f32, %arg5 : f32):  // no predecessors
+     ^bb0(%arg2: i32, %arg3: i32, %arg4 : f32, %arg5 : f32):
        %0 = arith.cmpf ogt, %arg4, %arg5 : f32
        iree_linalg_ext.yield %0 : i1
      }
@@ -661,7 +661,7 @@ func.func @topk_tile_tensor(%input_values: tensor<?x?xf32>, %input_indices: tens
         dimension(1)
         ins(%input_values, %input_indices : tensor<?x?xf32> , tensor<?x?xi32>)
         outs(%out_values, %out_indices : tensor<?x3xf32>, tensor<?x3xi32>) {
-        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+        ^bb0(%arg0: f32, %arg1: f32):
           %0 = arith.cmpf ogt, %arg0, %arg1 : f32
           iree_linalg_ext.yield %0 : i1
         } -> tensor<?x3xf32>, tensor<?x3xi32>
@@ -709,7 +709,7 @@ func.func @topk_tile_memref(%input_values: memref<?x?xf32>, %input_indices: memr
         dimension(1)
         ins(%input_values, %input_indices : memref<?x?xf32> , memref<?x?xi32>)
         outs(%out_values, %out_indices : memref<?x3xf32>, memref<?x3xi32>) {
-        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+        ^bb0(%arg0: f32, %arg1: f32):
           %0 = arith.cmpf ogt, %arg0, %arg1 : f32
           iree_linalg_ext.yield %0 : i1
         }
@@ -753,7 +753,7 @@ func.func @topk_tile_tensor_optional(%input_values: tensor<20x10xf32>, %out_valu
         dimension(1)
         ins(%input_values : tensor<20x10xf32>)
         outs(%out_values, %out_indices : tensor<20x3xf32>, tensor<20x3xi32>) {
-        ^bb0(%arg0: f32, %arg1: f32):  // no predecessors
+        ^bb0(%arg0: f32, %arg1: f32):
           %0 = arith.cmpf ogt, %arg0, %arg1 : f32
           iree_linalg_ext.yield %0 : i1
         } -> tensor<20x3xf32>, tensor<20x3xi32>

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/dump_statistics.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/dump_statistics.mlir
@@ -66,7 +66,7 @@ stream.executable private @func_a_ex_0 {
         %7 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [%arg3], sizes = [%5], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<4xi32>> -> tensor<?xi32>
         %8 = tensor.empty(%5) : tensor<?xi32>
         %9 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%6, %7 : tensor<?xi32>, tensor<?xi32>) outs(%8 : tensor<?xi32>) {
-        ^bb0(%arg4: i32, %arg5: i32, %arg6: i32):  // no predecessors
+        ^bb0(%arg4: i32, %arg5: i32, %arg6: i32):
           %10 = arith.maxsi %arg4, %arg5 : i32
           linalg.yield %10 : i32
         } -> tensor<?xi32>
@@ -97,7 +97,7 @@ stream.executable private @func_a_ex_1 {
         %7 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [%arg3], sizes = [%5], strides = [1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<3xi32>> -> tensor<?xi32>
         %8 = tensor.empty(%5) : tensor<?xi32>
         %9 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%6, %7 : tensor<?xi32>, tensor<?xi32>) outs(%8 : tensor<?xi32>) {
-        ^bb0(%arg4: i32, %arg5: i32, %arg6: i32):  // no predecessors
+        ^bb0(%arg4: i32, %arg5: i32, %arg6: i32):
           %10 = arith.maxsi %arg4, %arg5 : i32
           linalg.yield %10 : i32
         } -> tensor<?xi32>

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals_linalg.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/hoist_into_globals_linalg.mlir
@@ -15,14 +15,14 @@ module @compute_hoisted {
     // A non-leaf broadcast.
     %0 = tensor.empty() : tensor<5x6xf32>
     %1 = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel"]} ins(%cst_0 : tensor<f32>) outs(%0 : tensor<5x6xf32>) {
-    ^bb0(%arg1: f32, %arg2: f32):  // no predecessors
+    ^bb0(%arg1: f32, %arg2: f32):
       linalg.yield %arg1 : f32
     } -> tensor<5x6xf32>
 
     // A leaf-compute.
     %2 = tensor.empty() : tensor<5x6xf32>
     %3 = linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%1, %1 : tensor<5x6xf32>, tensor<5x6xf32>) outs(%2 : tensor<5x6xf32>) {
-    ^bb0(%arg1: f32, %arg2: f32, %arg3: f32):  // no predecessors
+    ^bb0(%arg1: f32, %arg2: f32, %arg3: f32):
       %42 = arith.mulf %arg1, %arg2 : f32
       linalg.yield %42 : f32
     } -> tensor<5x6xf32>
@@ -53,7 +53,7 @@ module @broadcast_treated_as_leaf {
     // A broadcast.
     // CHECK: linalg.generic
     %1 = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel"]} ins(%cst_0 : tensor<f32>) outs(%0 : tensor<5x6xf32>) {
-    ^bb0(%arg1: f32, %arg2: f32):  // no predecessors
+    ^bb0(%arg1: f32, %arg2: f32):
       linalg.yield %arg1 : f32
     } -> tensor<5x6xf32>
     // CHECK: util.return

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/test_float_range_analysis_linalg.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/test_float_range_analysis_linalg.mlir
@@ -8,26 +8,26 @@ util.func @linalg_generic_traversal(%arg0 : tensor<5x6xf32>) -> (tensor<5x6xf32>
   %init = tensor.empty() : tensor<5x6xf32>
 
   %broadcast_min = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel"]} ins(%cst_min : tensor<f32>) outs(%init : tensor<5x6xf32>) {
-  ^bb0(%arg1: f32, %arg2: f32):  // no predecessors
+  ^bb0(%arg1: f32, %arg2: f32):
     linalg.yield %arg1 : f32
   } -> tensor<5x6xf32>
   %broadcast_max = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel"]} ins(%cst_max : tensor<f32>) outs(%init : tensor<5x6xf32>) {
-  ^bb0(%arg1: f32, %arg2: f32):  // no predecessors
+  ^bb0(%arg1: f32, %arg2: f32):
     linalg.yield %arg1 : f32
   } -> tensor<5x6xf32>
 
   %floor = linalg.generic {indexing_maps = [#map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%arg0 : tensor<5x6xf32>) outs(%init : tensor<5x6xf32>) {
-  ^bb0(%arg1: f32, %arg2: f32):  // no predecessors
+  ^bb0(%arg1: f32, %arg2: f32):
     %27 = math.floor %arg1 : f32
     linalg.yield %27 : f32
   } -> tensor<5x6xf32>
   %max = linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%floor, %broadcast_min : tensor<5x6xf32>, tensor<5x6xf32>) outs(%init : tensor<5x6xf32>) {
-  ^bb0(%arg1: f32, %arg2: f32, %arg3: f32):  // no predecessors
+  ^bb0(%arg1: f32, %arg2: f32, %arg3: f32):
     %27 = arith.maximumf %arg1, %arg2 : f32
     linalg.yield %27 : f32
   } -> tensor<5x6xf32>
   %min = linalg.generic {indexing_maps = [#map1, #map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%max, %broadcast_max : tensor<5x6xf32>, tensor<5x6xf32>) outs(%init : tensor<5x6xf32>) {
-  ^bb0(%arg1: f32, %arg2: f32, %arg3: f32):  // no predecessors
+  ^bb0(%arg1: f32, %arg2: f32, %arg3: f32):
     %27 = arith.minimumf %arg1, %arg2 : f32
     linalg.yield %27 : f32
   } -> tensor<5x6xf32>

--- a/compiler/src/iree/compiler/DispatchCreation/test/dispatch_linalg_on_tensors.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/dispatch_linalg_on_tensors.mlir
@@ -559,7 +559,7 @@ util.func public @inline_dag_3(%240 : tensor<9xi32>, %244 : tensor<18xi32>, %247
       indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
       iterator_types = ["parallel"]}
       ins(%254 : tensor<9xi32>) outs(%255 : tensor<9xi1>) {
-        ^bb0(%arg20: i32, %arg21: i1):  // no predecessors
+        ^bb0(%arg20: i32, %arg21: i1):
           %849 = arith.cmpi eq, %arg20, %c5_i32 : i32
           linalg.yield %849 : i1
       } -> tensor<9xi1>
@@ -608,7 +608,7 @@ util.func public @inline_dag_4(%arg0: tensor<4xi32>, %arg1: tensor<i32>) -> tens
 ^bb1:  // pred: ^bb0
   %7 = tensor.empty() : tensor<i16>
   %8 = linalg.generic {indexing_maps = [#map, #map], iterator_types = []} ins(%6 : tensor<i32>) outs(%7 : tensor<i16>) {
-  ^bb0(%arg2: i32, %arg3: i16):  // no predecessors
+  ^bb0(%arg2: i32, %arg3: i16):
     %9 = arith.trunci %arg2 : i32 to i16
     linalg.yield %9 : i16
   } -> tensor<i16>
@@ -660,7 +660,7 @@ util.func public @multi_result(%arg0: tensor<?x?xi32>, %arg1: tensor<?x?xi32>) -
       iterator_types = ["parallel", "reduction"]}
       ins(%arg0, %arg1 : tensor<?x?xi32>, tensor<?x?xi32>)
       outs(%1, %2 : tensor<?xi32>, tensor<?xi32>) {
-  ^bb0(%arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32):  // no predecessors
+  ^bb0(%arg2: i32, %arg3: i32, %arg4: i32, %arg5: i32):
     %5 = arith.cmpi sge, %arg2, %arg4 : i32
     %6 = arith.select %5, %arg2, %arg4 : i32
     %7 = arith.cmpi eq, %arg2, %arg4 : i32
@@ -809,7 +809,7 @@ util.func public @sort_3d(%arg0: tensor<?x?x?xi32>, %arg1 : tensor<?x?x?xf32>)
     -> (tensor<?x?x?xi32>, tensor<?x?x?xf32>) {
   %0, %1 = iree_linalg_ext.sort dimension(0)
       outs(%arg0, %arg1 : tensor<?x?x?xi32>, tensor<?x?x?xf32>) {
-      ^bb0(%arg2: i32, %arg3: i32, %arg4 : f32, %arg5 : f32):  // no predecessors
+      ^bb0(%arg2: i32, %arg3: i32, %arg4 : f32, %arg5 : f32):
         %2 = arith.cmpf ogt, %arg4, %arg5 : f32
         iree_linalg_ext.yield %2 : i1
       } -> tensor<?x?x?xi32>, tensor<?x?x?xf32>
@@ -867,7 +867,7 @@ util.func public @scatter_static(%arg0 : tensor<4xi32>, %arg1 : tensor<4x1xi32>,
       unique_indices(true)
       ins(%arg0, %arg1 : tensor<4xi32>, tensor<4x1xi32>)
       outs(%arg2 : tensor<8xi32>)  {
-    ^bb0(%arg3: i32, %arg4: i32):  // no predecessors
+    ^bb0(%arg3: i32, %arg4: i32):
       iree_linalg_ext.yield %arg3 : i32
     } -> tensor<8xi32>
   util.return %0 : tensor<8xi32>

--- a/compiler/src/iree/compiler/DispatchCreation/test/transpose_generic_ops.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/transpose_generic_ops.mlir
@@ -72,7 +72,7 @@ util.func public @interchange(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>
     iterator_types = ["reduction", "parallel", "parallel", "parallel"]}
   ins(%arg0, %arg1 : tensor<?x?x?xf32>, tensor<?x?x?xf32>)
   outs(%arg2 : tensor<?x?x?xf32>) {
-  ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):  // no predecessors
+  ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):
     %m = arith.mulf %arg3, %arg4 : f32
     %a = arith.addf %arg5, %m : f32
     linalg.yield %a : f32

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Transforms/test/inline_executables.mlir
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Transforms/test/inline_executables.mlir
@@ -12,8 +12,7 @@ hal.executable private @ex {
         #hal.pipeline.binding<storage_buffer>,
         #hal.pipeline.binding<storage_buffer>,
         #hal.pipeline.binding<storage_buffer>
-      ]>) {
-    ^bb0(%arg0: !hal.device, %workload_x: index, %workload_y: index):
+      ]>) count(%arg0: !hal.device, %workload_x: index, %workload_y: index) -> (index, index, index) {
       %count_x = affine.apply affine_map<()[s0] -> (s0 ceildiv 4)>()[%workload_x]
       %count_y = affine.apply affine_map<()[s0] -> (s0 ceildiv 4)>()[%workload_y]
       %count_z = arith.constant 1 : index

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/test/cmd_ops.mlir
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/StreamToHALLoader/test/cmd_ops.mlir
@@ -9,8 +9,7 @@
 ]>
 hal.executable private @ex {
   hal.executable.variant public @variant target(#hal.executable.target<"llvm", "embedded-elf-x86_64">) {
-    hal.executable.export public @dispatch ordinal(16) layout(#pipeline_layout) {
-    ^bb0(%device: !hal.device, %workload_x: index, %workload_y: index):
+    hal.executable.export public @dispatch ordinal(16) layout(#pipeline_layout) count(%device: !hal.device, %workload_x: index, %workload_y: index) -> (index, index, index) {
       %count_x = affine.apply affine_map<()[s0] -> (s0 ceildiv 4)>()[%workload_x]
       %count_y = affine.apply affine_map<()[s0] -> (s0 ceildiv 4)>()[%workload_y]
       %count_z = arith.constant 1 : index

--- a/docs/website/docs/community/blog/posts/cuda-backend.md
+++ b/docs/website/docs/community/blog/posts/cuda-backend.md
@@ -171,7 +171,7 @@ At this stage the IR looks like the following:
           memref<4xf32, affine_map<(d0)[s0] -> (d0 + s0)>>,
           memref<4xf32, affine_map<(d0)[s0] -> (d0 + s0)>>)
       outs(%12 : memref<4xf32, affine_map<(d0)[s0] -> (d0 + s0)>>) {
-    ^bb0(%arg1: f32, %arg2: f32, %arg3: f32):  // no predecessors
+    ^bb0(%arg1: f32, %arg2: f32, %arg3: f32):
       %13 = addf %arg1, %arg2 : f32
       linalg.yield %13 : f32
     }

--- a/runtime/src/iree/hal/cts/testdata/command_buffer_dispatch_constants_test.mlir
+++ b/runtime/src/iree/hal/cts/testdata/command_buffer_dispatch_constants_test.mlir
@@ -5,11 +5,10 @@
 ]>
 
 hal.executable.source public @executable {
-  hal.executable.export public @write_constants ordinal(0) layout(#pipeline_layout) attributes {workgroup_size = [1 : index, 1 : index, 1 : index]} {
-  ^bb0(%arg0: !hal.device):
+  hal.executable.export public @write_constants ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
     %c1 = arith.constant 1 : index
     hal.return %c1, %c1, %c1 : index, index, index
-  }
+  } attributes {workgroup_size = [1 : index, 1 : index, 1 : index]}
   builtin.module {
     func.func @write_constants() {
       %input_0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32

--- a/runtime/src/iree/hal/cts/testdata/command_buffer_dispatch_test.mlir
+++ b/runtime/src/iree/hal/cts/testdata/command_buffer_dispatch_test.mlir
@@ -11,8 +11,7 @@
 ]>
 
 hal.executable.source public @executable {
-  hal.executable.export public @abs ordinal(0) layout(#pipeline_layout) {
-  ^bb0(%arg0: !hal.device):
+  hal.executable.export public @abs ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
     %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root
     hal.return %x, %y, %z : index, index, index
   }

--- a/runtime/src/iree/hal/cts/testdata/executable_cache_test.mlir
+++ b/runtime/src/iree/hal/cts/testdata/executable_cache_test.mlir
@@ -11,8 +11,7 @@
 ]>
 
 hal.executable.source public @executable {
-  hal.executable.export public @abs ordinal(0) layout(#pipeline_layout) {
-  ^bb0(%arg0: !hal.device):
+  hal.executable.export public @abs ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
     %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_dag_root
     hal.return %x, %y, %z : index, index, index
   }

--- a/runtime/src/iree/hal/local/elf/testdata/elementwise_mul.mlir
+++ b/runtime/src/iree/hal/local/elf/testdata/elementwise_mul.mlir
@@ -34,8 +34,7 @@ hal.executable.source public @ex {
   //
   // The ordinal is used to specify the entry point on command line tools and
   // must be unique across all entry points within the same executable.
-  hal.executable.export public @elementwise_mul ordinal(0) layout(#pipeline_layout) {
-  ^bb0(%arg0: !hal.device):
+  hal.executable.export public @elementwise_mul ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
     %c1 = arith.constant 1 : index
     hal.return %c1, %c1, %c1 : index, index, index
   }

--- a/samples/custom_dispatch/cpu/embedded/example_hal.mlir
+++ b/samples/custom_dispatch/cpu/embedded/example_hal.mlir
@@ -92,8 +92,7 @@ module @example attributes {hal.device.targets = [#cpu_target]} {
       // The ordinal must be assigned by the user and unique for the executable.
       // The layout defines the required bindings and push constants and can be
       // thought of as the function signature.
-      hal.executable.export public @simple_mul ordinal(0) layout(#pipeline_layout_0) {
-      ^bb0(%device: !hal.device, %workload: index):
+      hal.executable.export public @simple_mul ordinal(0) layout(#pipeline_layout_0) count(%device: !hal.device, %workload: index) -> (index, index, index) {
         // This host function is used to compute the XYZ workgroup count
         // dispatched at runtime. It can query the %device for capabilities
         // and limits (last-level cache sizes, etc). The other arguments are the
@@ -105,8 +104,7 @@ module @example attributes {hal.device.targets = [#cpu_target]} {
       }
 
       // Similar to the above but in-place by using a read/write binding.
-      hal.executable.export public @simple_mul_inplace ordinal(1) layout(#pipeline_layout_1) {
-      ^bb0(%device: !hal.device, %workload: index):
+      hal.executable.export public @simple_mul_inplace ordinal(1) layout(#pipeline_layout_1) count(%device: !hal.device, %workload: index) -> (index, index, index) {
         %x = affine.apply affine_map<()[s0] -> (s0 ceildiv 64)>()[%workload]
         %c1 = arith.constant 1 : index
         hal.return %x, %c1, %c1 : index, index, index

--- a/samples/custom_dispatch/cpu/embedded/example_transform_spec.mlir
+++ b/samples/custom_dispatch/cpu/embedded/example_transform_spec.mlir
@@ -37,8 +37,7 @@ module attributes {transform.with_named_sequence} {
         path = "samples/custom_dispatch/cpu/embedded/functions_x86_64.o"
       }>
     ]) {
-      hal.executable.export public @simple_mul_abs_negate ordinal(0) layout(#pipeline_layout) {
-      ^bb0(%device: !hal.device, %workload: index):
+      hal.executable.export public @simple_mul_abs_negate ordinal(0) layout(#pipeline_layout) count(%device: !hal.device, %workload: index) -> (index, index, index) {
         %x = affine.apply affine_map<()[s0] -> (s0 ceildiv 64)>()[%workload]
         %c1 = arith.constant 1 : index
         hal.return %x, %c1, %c1 : index, index, index

--- a/samples/custom_dispatch/cuda/kernels/README.md
+++ b/samples/custom_dispatch/cuda/kernels/README.md
@@ -75,8 +75,7 @@ nvcc ... (TODO, see CMakeLists.txt) -o kernels_sm_80.ptx
           #hal.pipeline.binding<storage_buffer, ReadOnly>,
           #hal.pipeline.binding<storage_buffer, ReadOnly>,
           #hal.pipeline.binding<storage_buffer>
-        ]>) attributes {workgroup_size = [64 : index, 1 : index, 1 : index]} {
-    ^bb0(%device: !hal.device, %workload: index):
+        ]>) attributes {workgroup_size = [64 : index, 1 : index, 1 : index]} count(%device: !hal.device, %workload: index) -> (index, index, index) {
       %x = affine.apply affine_map<()[s0] -> (s0 ceildiv 64)>()[%workload]
       %c1 = arith.constant 1 : index
       hal.return %x, %c1, %c1 : index, index, index

--- a/samples/custom_dispatch/cuda/kernels/example.mlir
+++ b/samples/custom_dispatch/cuda/kernels/example.mlir
@@ -83,8 +83,7 @@ module @example attributes {hal.device.targets = [#cuda_target]} {
       // Certain backends (like CUDA) require a workgroup size (aka block
       // size) to be defined ahead of time.
       workgroup_size = [64 : index, 1 : index, 1 : index]
-    } {
-    ^bb0(%device: !hal.device, %workload: index):
+    } count(%device: !hal.device, %workload: index) -> (index, index, index) {
       // This host function is used to compute the XYZ workgroup count
       // dispatched at runtime. It can query the %device for capabilities
       // and limits (shared memory size, etc). The other arguments are the
@@ -102,8 +101,7 @@ module @example attributes {hal.device.targets = [#cuda_target]} {
           #hal.pipeline.binding<storage_buffer>
         ]>) attributes {
       workgroup_size = [64 : index, 1 : index, 1 : index]
-    } {
-    ^bb0(%device: !hal.device, %workload: index):
+    } count(%device: !hal.device, %workload: index) -> (index, index, index) {
       %x = affine.apply affine_map<()[s0] -> (s0 ceildiv 64)>()[%workload]
       %c1 = arith.constant 1 : index
       hal.return %x, %c1, %c1 : index, index, index

--- a/samples/custom_dispatch/hip/kernels/example.mlir
+++ b/samples/custom_dispatch/hip/kernels/example.mlir
@@ -74,8 +74,7 @@ module @example attributes {hal.device.targets = [#rocm_target]} {
       // Certain backends (like ROCM) require a workgroup size (aka block
       // size) to be defined ahead of time.
       workgroup_size = [64 : index, 1 : index, 1 : index]
-    } {
-    ^bb0(%device: !hal.device, %workload: index):
+    } count(%device: !hal.device, %workload: index) -> (index, index, index) {
       // This host function is used to compute the XYZ workgroup count
       // dispatched at runtime. It can query the %device for capabilities
       // and limits (shared memory size, etc). The other arguments are the
@@ -93,8 +92,7 @@ module @example attributes {hal.device.targets = [#rocm_target]} {
           #hal.pipeline.binding<storage_buffer>
         ]>) attributes {
       workgroup_size = [64 : index, 1 : index, 1 : index]
-    } {
-    ^bb0(%device: !hal.device, %workload: index):
+    } count(%device: !hal.device, %workload: index) -> (index, index, index) {
       %x = affine.apply affine_map<()[s0] -> (s0 ceildiv 64)>()[%workload]
       %c1 = arith.constant 1 : index
       hal.return %x, %c1, %c1 : index, index, index

--- a/samples/custom_dispatch/vulkan/shaders/README.md
+++ b/samples/custom_dispatch/vulkan/shaders/README.md
@@ -79,8 +79,7 @@ glslc -fshader-stage=compute simple_mul.glsl -o simple_mul.spv
           #hal.pipeline.binding<storage_buffer, ReadOnly>,
           #hal.pipeline.binding<storage_buffer, ReadOnly>,
           #hal.pipeline.binding<storage_buffer>
-        ]>) {
-    ^bb0(%device: !hal.device, %workload: index):
+        ]>) count(%device: !hal.device, %workload: index) -> (index, index, index) {
       %x = affine.apply affine_map<()[s0] -> (s0 ceildiv 64)>()[%workload]
       %c1 = arith.constant 1 : index
       hal.return %x, %c1, %c1 : index, index, index

--- a/samples/custom_dispatch/vulkan/shaders/example.mlir
+++ b/samples/custom_dispatch/vulkan/shaders/example.mlir
@@ -80,8 +80,7 @@ module @example attributes {hal.device.targets = [#vulkan_target]} {
           #hal.pipeline.binding<storage_buffer, ReadOnly>,
           #hal.pipeline.binding<storage_buffer, ReadOnly>,
           #hal.pipeline.binding<storage_buffer>
-        ]>) {
-    ^bb0(%device: !hal.device, %workload: index):
+        ]>) count(%device: !hal.device, %workload: index) -> (index, index, index) {
       // This host function is used to compute the XYZ workgroup count
       // dispatched at runtime. It can query the %device for capabilities
       // and limits (shared memory size, etc). The other arguments are the
@@ -108,8 +107,7 @@ module @example attributes {hal.device.targets = [#vulkan_target]} {
         layout(#hal.pipeline.layout<constants = 1, bindings = [
           #hal.pipeline.binding<storage_buffer, ReadOnly>,
           #hal.pipeline.binding<storage_buffer>
-        ]>) {
-    ^bb0(%device: !hal.device, %workload: index):
+        ]>) count(%device: !hal.device, %workload: index) -> (index, index, index) {
       %x = affine.apply affine_map<()[s0] -> (s0 ceildiv 64)>()[%workload]
       %c1 = arith.constant 1 : index
       hal.return %x, %c1, %c1 : index, index, index

--- a/samples/transform_dialect/example_module.mlir
+++ b/samples/transform_dialect/example_module.mlir
@@ -54,8 +54,7 @@ module attributes {
 } {
   hal.executable private @example_module_dispatch_0 {
     hal.executable.variant public @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb", {iree.gpu.target = #target}>) {
-      hal.executable.export public @example_module_dispatch_0_generic_80_f32 ordinal(0) layout(#pipeline_layout_0) {
-      ^bb0(%arg0: !hal.device):
+      hal.executable.export public @example_module_dispatch_0_generic_80_f32 ordinal(0) layout(#pipeline_layout_0) count(%arg0: !hal.device) -> (index, index, index) {
         %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
         hal.return %x, %y, %z : index, index, index
       }
@@ -79,8 +78,7 @@ module attributes {
   }
   hal.executable private @example_module_dispatch_1 {
     hal.executable.variant public @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb", {iree.gpu.target = #target}>) {
-      hal.executable.export public @example_module_dispatch_1_matmul_16x16x5_f32 ordinal(0) layout(#pipeline_layout_1) {
-      ^bb0(%arg0: !hal.device):
+      hal.executable.export public @example_module_dispatch_1_matmul_16x16x5_f32 ordinal(0) layout(#pipeline_layout_1) count(%arg0: !hal.device) -> (index, index, index) {
         %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
         hal.return %x, %y, %z : index, index, index
       }
@@ -102,8 +100,7 @@ module attributes {
   }
   hal.executable private @example_module_dispatch_2 {
     hal.executable.variant public @vulkan_spirv_fb target(<"vulkan-spirv", "vulkan-spirv-fb", {iree.gpu.target = #target}>) {
-      hal.executable.export public @example_module_dispatch_2_generic_16x16_f32 ordinal(0) layout(#pipeline_layout_2) {
-      ^bb0(%arg0: !hal.device):
+      hal.executable.export public @example_module_dispatch_2_generic_16x16_f32 ordinal(0) layout(#pipeline_layout_2) count(%arg0: !hal.device) -> (index, index, index) {
         %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
         hal.return %x, %y, %z : index, index, index
       }

--- a/tests/compiler_driver/hal_executable.mlir
+++ b/tests/compiler_driver/hal_executable.mlir
@@ -21,8 +21,7 @@ hal.executable.source public @executable {
   // Exported functions are declared with the layout they use and may optionally
   // contain other information - though when hand-authoring that's usually
   // omitted.
-  hal.executable.export public @mul layout(#pipeline_layout) {
-    ^bb0(%arg0: !hal.device):
+  hal.executable.export public @mul layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       hal.return %c1, %c1, %c1 : index, index, index
   }

--- a/tests/e2e/linalg_ext_ops/sort.mlir
+++ b/tests/e2e/linalg_ext_ops/sort.mlir
@@ -1,7 +1,7 @@
 func.func @sort2D() {
   %input = util.unfoldable_constant dense<[[5, 6], [3, 7]]> : tensor<2x2xi32>
   %0 = iree_linalg_ext.sort dimension(0) outs(%input : tensor<2x2xi32>) {
-    ^bb0(%arg2: i32, %arg3: i32):  // no predecessors
+    ^bb0(%arg2: i32, %arg3: i32):
       %1 = arith.cmpi slt, %arg2, %arg3 : i32
       iree_linalg_ext.yield %1 : i1
     } -> tensor<2x2xi32>

--- a/tests/e2e/regression/large_reduction.mlir
+++ b/tests/e2e/regression/large_reduction.mlir
@@ -7,7 +7,7 @@ func.func @reduction_aligned() {
     affine_map<(d0, d1) -> (d0, d1)>,affine_map<(d0, d1) -> (d0)>],
     iterator_types = ["parallel", "reduction"]}
     ins(%in : tensor<128x384xf32>) outs(%fill : tensor<128xf32>) {
-    ^bb0(%arg3: f32, %arg4: f32):  // no predecessors
+    ^bb0(%arg3: f32, %arg4: f32):
       %2 = arith.addf %arg3, %arg4 : f32
       linalg.yield %2 : f32
     } -> tensor<128xf32>
@@ -24,7 +24,7 @@ func.func @reduction_unaligned() {
     affine_map<(d0, d1) -> (d0, d1)>,affine_map<(d0, d1) -> (d0)>],
     iterator_types = ["parallel", "reduction"]}
     ins(%in : tensor<129x384xf32>) outs(%fill : tensor<129xf32>) {
-    ^bb0(%arg3: f32, %arg4: f32):  // no predecessors
+    ^bb0(%arg3: f32, %arg4: f32):
       %2 = arith.addf %arg3, %arg4 : f32
       linalg.yield %2 : f32
     } -> tensor<129xf32>
@@ -42,7 +42,7 @@ func.func @reduction_aligned_larger() {
     affine_map<(d0, d1) -> (d0, d1)>,affine_map<(d0, d1) -> (d0)>],
     iterator_types = ["parallel", "reduction"]}
     ins(%in : tensor<2x40960xf32>) outs(%fill : tensor<2xf32>) {
-    ^bb0(%arg3: f32, %arg4: f32):  // no predecessors
+    ^bb0(%arg3: f32, %arg4: f32):
       %2 = arith.addf %arg3, %arg4 : f32
       linalg.yield %2 : f32
     } -> tensor<2xf32>
@@ -59,7 +59,7 @@ func.func @half_reduction_aligned() {
     affine_map<(d0, d1) -> (d0, d1)>,affine_map<(d0, d1) -> (d0)>],
     iterator_types = ["parallel", "reduction"]}
     ins(%in : tensor<2x4096xf16>) outs(%fill : tensor<2xf16>) {
-    ^bb0(%arg3: f16, %arg4: f16):  // no predecessors
+    ^bb0(%arg3: f16, %arg4: f16):
       %2 = arith.addf %arg3, %arg4 : f16
       linalg.yield %2 : f16
     } -> tensor<2xf16>
@@ -76,7 +76,7 @@ func.func @quarter_reduction_aligned_smaller() {
     affine_map<(d0, d1) -> (d0, d1)>,affine_map<(d0, d1) -> (d0)>],
     iterator_types = ["parallel", "reduction"]}
     ins(%in : tensor<128x128xi8>) outs(%fill : tensor<128xi8>) {
-    ^bb0(%arg3: i8, %arg4: i8):  // no predecessors
+    ^bb0(%arg3: i8, %arg4: i8):
       %2 = arith.addi %arg3, %arg4 : i8
       linalg.yield %2 : i8
     } -> tensor<128xi8>

--- a/tests/e2e/stablehlo_ops/reduce.mlir
+++ b/tests/e2e/stablehlo_ops/reduce.mlir
@@ -3,7 +3,7 @@ func.func @reduce_sum_1x10xi32() {
   %0 = util.unfoldable_constant dense<[[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]]> : tensor<1x10xi32>
   %1 = util.unfoldable_constant dense<0> : tensor<i32>
   %res = "stablehlo.reduce"(%0, %1) ( {
-  ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):   // no predecessors
+  ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):
     %3 = "stablehlo.add"(%arg0, %arg1) : (tensor<i32>, tensor<i32>) -> tensor<i32>
     "stablehlo.return"(%3) : (tensor<i32>) -> ()
   }) {dimensions = array<i64: 1>} : (tensor<1x10xi32>, tensor<i32>) -> tensor<1xi32>
@@ -16,7 +16,7 @@ func.func @reduce_max_1x10xi32() {
   %0 = util.unfoldable_constant dense<[[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]]> : tensor<1x10xi32>
   %1 = util.unfoldable_constant dense<0> : tensor<i32>
   %res = "stablehlo.reduce"(%0, %1) ( {
-  ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):   // no predecessors
+  ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):
     %3 = "stablehlo.maximum"(%arg0, %arg1) : (tensor<i32>, tensor<i32>) -> tensor<i32>
     "stablehlo.return"(%3) : (tensor<i32>) -> ()
   }) {dimensions = array<i64: 1>} : (tensor<1x10xi32>, tensor<i32>) -> tensor<1xi32>
@@ -29,7 +29,7 @@ func.func @reduce_min_5x1x1xi32() {
   %0 = util.unfoldable_constant dense<[[[1]],[[2]],[[3]],[[4]],[[5]]]> : tensor<5x1x1xi32>
   %1 = util.unfoldable_constant dense<999> : tensor<i32>
   %res = "stablehlo.reduce"(%0, %1) ( {
-  ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):   // no predecessors
+  ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):
     %3 = "stablehlo.minimum"(%arg0, %arg1) : (tensor<i32>, tensor<i32>) -> tensor<i32>
     "stablehlo.return"(%3) : (tensor<i32>) -> ()
   }) {dimensions = array<i64: 1, 2>} : (tensor<5x1x1xi32>, tensor<i32>) -> tensor<5xi32>
@@ -47,7 +47,7 @@ func.func @reduce_sum_2x3xi32_dim0() {
       [4, 5, 6]]> : tensor<2x3xi32>
   %1 = util.unfoldable_constant dense<0> : tensor<i32>
   %res = "stablehlo.reduce"(%0, %1) ( {
-  ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):   // no predecessors
+  ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):
     %3 = "stablehlo.add"(%arg0, %arg1) : (tensor<i32>, tensor<i32>) -> tensor<i32>
     "stablehlo.return"(%3) : (tensor<i32>) -> ()
   }) {dimensions = array<i64: 0>} : (tensor<2x3xi32>, tensor<i32>) -> tensor<3xi32>
@@ -61,7 +61,7 @@ func.func @reduce_sum_2x3xi32_dim1() {
       [4, 5, 6]]> : tensor<2x3xi32>
   %1 = util.unfoldable_constant dense<0> : tensor<i32>
   %res = "stablehlo.reduce"(%0, %1) ( {
-  ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):   // no predecessors
+  ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):
     %3 = "stablehlo.add"(%arg0, %arg1) : (tensor<i32>, tensor<i32>) -> tensor<i32>
     "stablehlo.return"(%3) : (tensor<i32>) -> ()
   }) {dimensions = array<i64: 1>} : (tensor<2x3xi32>, tensor<i32>) -> tensor<2xi32>
@@ -77,7 +77,7 @@ func.func @reduce_sum_4x2x3xi32_dim0() {
       [[1, 2, 3], [4, 5, 6]]]> : tensor<4x2x3xi32>
   %1 = util.unfoldable_constant dense<0> : tensor<i32>
   %res = "stablehlo.reduce"(%0, %1) ( {
-  ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):   // no predecessors
+  ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):
     %3 = "stablehlo.add"(%arg0, %arg1) : (tensor<i32>, tensor<i32>) -> tensor<i32>
     "stablehlo.return"(%3) : (tensor<i32>) -> ()
   }) {dimensions = array<i64: 0>} : (tensor<4x2x3xi32>, tensor<i32>) -> tensor<2x3xi32>
@@ -93,7 +93,7 @@ func.func @reduce_sum_4x2x3xi32_dim2() {
     [[1, 2, 3], [4, 5, 6]]]> : tensor<4x2x3xi32>
   %1 = util.unfoldable_constant dense<0> : tensor<i32>
   %res = "stablehlo.reduce"(%0, %1) ( {
-  ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):   // no predecessors
+  ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):
     %3 = "stablehlo.add"(%arg0, %arg1) : (tensor<i32>, tensor<i32>) -> tensor<i32>
     "stablehlo.return"(%3) : (tensor<i32>) -> ()
   }) {dimensions = array<i64: 2>} : (tensor<4x2x3xi32>, tensor<i32>) -> tensor<4x2xi32>
@@ -109,7 +109,7 @@ func.func @reduce_sum_4x2x3xi32_dims_0_1() {
       [[1, 2, 3], [4, 5, 6]]]> : tensor<4x2x3xi32>
   %1 = util.unfoldable_constant dense<0> : tensor<i32>
   %res = "stablehlo.reduce"(%0, %1) ( {
-  ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):   // no predecessors
+  ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):
     %3 = "stablehlo.add"(%arg0, %arg1) : (tensor<i32>, tensor<i32>) -> tensor<i32>
     "stablehlo.return"(%3) : (tensor<i32>) -> ()
   }) {dimensions = array<i64: 0, 1>} : (tensor<4x2x3xi32>, tensor<i32>) -> tensor<3xi32>
@@ -125,7 +125,7 @@ func.func @reduce_sum_4x2x3xi32_dims_0_1_2() {
       [[1, 2, 3], [4, 5, 6]]]> : tensor<4x2x3xi32>
   %1 = util.unfoldable_constant dense<0> : tensor<i32>
   %res = "stablehlo.reduce"(%0, %1) ( {
-  ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):   // no predecessors
+  ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):
     %3 = "stablehlo.add"(%arg0, %arg1) : (tensor<i32>, tensor<i32>) -> tensor<i32>
     "stablehlo.return"(%3) : (tensor<i32>) -> ()
   }) {dimensions = array<i64: 0, 1, 2>} : (tensor<4x2x3xi32>, tensor<i32>) -> tensor<i32>
@@ -138,7 +138,7 @@ func.func @reduce_sum_1x10xf32() {
   %0 = util.unfoldable_constant dense<[[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]]> : tensor<1x10xf32>
   %1 = util.unfoldable_constant dense<0.0> : tensor<f32>
   %res = "stablehlo.reduce"(%0, %1) ( {
-  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):   // no predecessors
+  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
     %3 = "stablehlo.add"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     "stablehlo.return"(%3) : (tensor<f32>) -> ()
   }) {dimensions = array<i64: 1>} : (tensor<1x10xf32>, tensor<f32>) -> tensor<1xf32>
@@ -152,7 +152,7 @@ func.func @reduce_max_1x10xf32() {
   %1 = util.unfoldable_constant dense<0.0> : tensor<f32>
   %res = "stablehlo.reduce"(%0, %1)
   ( {
-  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):   // no predecessors
+  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
       %3 = "stablehlo.maximum"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
       "stablehlo.return"(%3) : (tensor<f32>) -> ()
   })
@@ -166,7 +166,7 @@ func.func @reduce_min_5x1x1xf32() {
   %0 = util.unfoldable_constant dense<[[[1.0]],[[2.0]],[[3.0]],[[4.0]],[[5.0]]]> : tensor<5x1x1xf32>
   %1 = util.unfoldable_constant dense<999.0> : tensor<f32>
   %res = "stablehlo.reduce"(%0, %1) ( {
-  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):   // no predecessors
+  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
       %3 = "stablehlo.minimum"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
       "stablehlo.return"(%3) : (tensor<f32>) -> ()
   }) {dimensions = array<i64: 1, 2>} : (tensor<5x1x1xf32>, tensor<f32>) -> tensor<5xf32>
@@ -181,7 +181,7 @@ func.func @reduce_sum_2x3xf32_dim0() {
   %0 = util.unfoldable_constant dense<[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]> : tensor<2x3xf32>
   %1 = util.unfoldable_constant dense<0.0> : tensor<f32>
   %res = "stablehlo.reduce"(%0, %1) ( {
-  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):   // no predecessors
+  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
     %3 = "stablehlo.add"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     "stablehlo.return"(%3) : (tensor<f32>) -> ()
   }) {dimensions = array<i64: 0>} : (tensor<2x3xf32>, tensor<f32>) -> tensor<3xf32>
@@ -193,7 +193,7 @@ func.func @reduce_sum_2x3xf32_dim1() {
   %0 = util.unfoldable_constant dense<[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]> : tensor<2x3xf32>
   %1 = util.unfoldable_constant dense<0.0> : tensor<f32>
   %res = "stablehlo.reduce"(%0, %1) ( {
-  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):   // no predecessors
+  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
     %3 = "stablehlo.add"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     "stablehlo.return"(%3) : (tensor<f32>) -> ()
   }) {dimensions = array<i64: 1>} : (tensor<2x3xf32>, tensor<f32>) -> tensor<2xf32>
@@ -209,7 +209,7 @@ func.func @reduce_sum_4x2x3xf32_dim0() {
       [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]]> : tensor<4x2x3xf32>
   %1 = util.unfoldable_constant dense<0.0> : tensor<f32>
   %res = "stablehlo.reduce"(%0, %1) ( {
-  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):   // no predecessors
+  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
     %3 = "stablehlo.add"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     "stablehlo.return"(%3) : (tensor<f32>) -> ()
   }) {dimensions = array<i64: 0>} : (tensor<4x2x3xf32>, tensor<f32>) -> tensor<2x3xf32>
@@ -225,7 +225,7 @@ func.func @reduce_sum_4x2x3xf32_dim1() {
       [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]]> : tensor<4x2x3xf32>
   %1 = util.unfoldable_constant dense<0.0> : tensor<f32>
   %res = "stablehlo.reduce"(%0, %1) ( {
-  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):   // no predecessors
+  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
     %3 = "stablehlo.add"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     "stablehlo.return"(%3) : (tensor<f32>) -> ()
   }) {dimensions = array<i64: 1>} : (tensor<4x2x3xf32>, tensor<f32>) -> tensor<4x3xf32>
@@ -245,7 +245,7 @@ func.func @reduce_sum_4x2x3xf32_dim2() {
       [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]]> : tensor<4x2x3xf32>
   %1 = util.unfoldable_constant dense<0.0> : tensor<f32>
   %res = "stablehlo.reduce"(%0, %1) ( {
-  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):   // no predecessors
+  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
     %3 = "stablehlo.add"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     "stablehlo.return"(%3) : (tensor<f32>) -> ()
   }) {dimensions = array<i64: 2>} : (tensor<4x2x3xf32>, tensor<f32>) -> tensor<4x2xf32>
@@ -265,7 +265,7 @@ func.func @reduce_sum_4x2x3xf32_dims_0_1() {
       [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]]> : tensor<4x2x3xf32>
   %1 = util.unfoldable_constant dense<0.0> : tensor<f32>
   %res = "stablehlo.reduce"(%0, %1) ( {
-  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):   // no predecessors
+  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
     %3 = "stablehlo.add"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     "stablehlo.return"(%3) : (tensor<f32>) -> ()
   }) {dimensions = array<i64: 0, 1>} : (tensor<4x2x3xf32>, tensor<f32>) -> tensor<3xf32>
@@ -281,7 +281,7 @@ func.func @reduce_sum_4x2x3xf32_dims_0_1_2() {
       [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]]> : tensor<4x2x3xf32>
   %1 = util.unfoldable_constant dense<0.0> : tensor<f32>
   %res = "stablehlo.reduce"(%0, %1) ( {
-  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):   // no predecessors
+  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
     %3 = "stablehlo.add"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     "stablehlo.return"(%3) : (tensor<f32>) -> ()
   }) {dimensions = array<i64: 0, 1, 2>} : (tensor<4x2x3xf32>, tensor<f32>) -> tensor<f32>
@@ -295,7 +295,7 @@ func.func @reducemulti_result() {
   %arg0 = util.unfoldable_constant dense<[[1, 2], [3, 4], [5, 6], [7, 8], [9, 10], [11, 12], [13, 14], [15, 16], [17, 18]]> : tensor<9x2xi32>
   %arg1 = util.unfoldable_constant dense<[[0, 1], [2, 3], [4, 5], [6, 7], [8, 9], [10, 11], [12, 13], [14, 15], [16, 17]]> : tensor<9x2xi32>
   %res0, %res1 = "stablehlo.reduce"(%arg0, %arg1, %cst0, %cst1) ( {
-  ^bb0(%arg2: tensor<i32>, %arg3: tensor<i32>, %arg4: tensor<i32>, %arg5: tensor<i32>):  // no predecessors
+  ^bb0(%arg2: tensor<i32>, %arg3: tensor<i32>, %arg4: tensor<i32>, %arg5: tensor<i32>):
     %0 = "stablehlo.compare"(%arg2, %arg4) {comparison_direction = #stablehlo<comparison_direction GE>} : (tensor<i32>, tensor<i32>) -> tensor<i1>
     %1 = "stablehlo.select"(%0, %arg2, %arg4) : (tensor<i1>, tensor<i32>, tensor<i32>) -> tensor<i32>
     %2 = "stablehlo.compare"(%arg2, %arg4) {comparison_direction = #stablehlo<comparison_direction EQ>} : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/tests/e2e/stablehlo_ops/reduce_window.mlir
+++ b/tests/e2e/stablehlo_ops/reduce_window.mlir
@@ -5,7 +5,7 @@ func.func @reduce_window_nonoverlapping_1x4x6x1xf32() {
                                         [[19.0], [20.0], [21.0], [22.0], [23.0], [24.0]]]]> : tensor<1x4x6x1xf32>
   %1 = util.unfoldable_constant dense<0.0> : tensor<f32>
   %res = "stablehlo.reduce_window"(%0, %1) ( {
-  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):   // no predecessors
+  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
     %3 = "stablehlo.add"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     "stablehlo.return"(%3) : (tensor<f32>) -> ()
   }) {window_dimensions = array<i64: 1, 2, 3, 1>,
@@ -21,7 +21,7 @@ func.func @reduce_window_overlapping_4x6xf32() {
                                         [[19.0], [20.0], [21.0], [22.0], [23.0], [24.0]]]]> : tensor<1x4x6x1xf32>
   %1 = util.unfoldable_constant dense<0.0> : tensor<f32>
   %res = "stablehlo.reduce_window"(%0, %1) ( {
-  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):   // no predecessors
+  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
     %3 = "stablehlo.add"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     "stablehlo.return"(%3) : (tensor<f32>) -> ()
   }) {window_dimensions = array<i64: 1, 2, 3, 1>,
@@ -40,7 +40,7 @@ func.func @reduce_window_max_4x6xf32() {
                                         [[19.0], [20.0], [21.0], [22.0], [23.0], [24.0]]]]> : tensor<1x4x6x1xf32>
   %1 = util.unfoldable_constant dense<0.0> : tensor<f32>
   %res = "stablehlo.reduce_window"(%0, %1) ( {
-  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):   // no predecessors
+  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
     %3 = "stablehlo.maximum"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     "stablehlo.return"(%3) : (tensor<f32>) -> ()
   }) {window_dimensions = array<i64: 1, 2, 3, 1>,
@@ -56,7 +56,7 @@ func.func @reduce_window_min_4x6xf32() {
                                         [[19.0], [20.0], [21.0], [22.0], [23.0], [24.0]]]]> : tensor<1x4x6x1xf32>
   %1 = util.unfoldable_constant dense<14.0> : tensor<f32>
   %res = "stablehlo.reduce_window"(%0, %1) ( {
-  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):   // no predecessors
+  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
     %3 = "stablehlo.minimum"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     "stablehlo.return"(%3) : (tensor<f32>) -> ()
   }) {window_dimensions = array<i64: 1, 2, 3, 1>,
@@ -72,7 +72,7 @@ func.func @reduce_window_max_with_padding_4x6xf32() {
                                         [[19.0], [20.0], [21.0], [22.0], [23.0], [24.0]]]]> : tensor<1x4x6x1xf32>
   %1 = util.unfoldable_constant dense<0.0> : tensor<f32>
   %res = "stablehlo.reduce_window"(%0, %1) ( {
-  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):   // no predecessors
+  ^bb0(%arg0: tensor<f32>, %arg1: tensor<f32>):
     %3 = "stablehlo.maximum"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     "stablehlo.return"(%3) : (tensor<f32>) -> ()
   }) {window_dimensions = array<i64: 1, 2, 3, 1>,

--- a/tests/e2e/stablehlo_ops/scatter.mlir
+++ b/tests/e2e/stablehlo_ops/scatter.mlir
@@ -3,7 +3,7 @@ func.func @scatter_update_scalar_1D() {
   %arg1 = util.unfoldable_constant dense<[[1], [3], [4], [7]]> : tensor<4x1xi32>
   %arg2 = util.unfoldable_constant dense<[9, 10, 11, 12]> : tensor<4xi32>
   %0 = "stablehlo.scatter"(%arg0, %arg1, %arg2) ( {
-  ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>):  // no predecessors
+  ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>):
     "stablehlo.return"(%arg4) : (tensor<i32>) -> ()
   }) {
     indices_are_sorted = false,
@@ -23,7 +23,7 @@ func.func @scatter_repeated_update_scalar_1D() {
   %arg1 = util.unfoldable_constant dense<[[1], [1], [7], [7]]> : tensor<4x1xi32>
   %arg2 = util.unfoldable_constant dense<[9, 10, 11, 12]> : tensor<4xi32>
   %0 = "stablehlo.scatter"(%arg0, %arg1, %arg2) ( {
-  ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>):  // no predecessors
+  ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>):
     "stablehlo.return"(%arg4) : (tensor<i32>) -> ()
   }) {
     indices_are_sorted = false,
@@ -43,7 +43,7 @@ func.func @scatter_update_scalar_2D() {
   %arg1 = util.unfoldable_constant dense<[[0, 0], [1, 1], [2, 2]]> : tensor<3x2xi32>
   %arg2 = util.unfoldable_constant dense<[1, 2, 3]> : tensor<3xi32>
   %0 = "stablehlo.scatter"(%arg0, %arg1, %arg2) ( {
-  ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>):  // no predecessors
+  ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>):
     "stablehlo.return"(%arg4) : (tensor<i32>) -> ()
   }) {indices_are_sorted = false,
       scatter_dimension_numbers = #stablehlo.scatter<
@@ -66,7 +66,7 @@ func.func @scatter_update_slice_2D() {
   %arg2 = util.unfoldable_constant dense<[[1, 2, 3],
                                           [4, 5, 6]]> : tensor<2x3xi32>
   %0 = "stablehlo.scatter"(%arg0, %arg1, %arg2) ( {
-  ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>):  // no predecessors
+  ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>):
     "stablehlo.return"(%arg4) : (tensor<i32>) -> ()
   }) {
     indices_are_sorted = false,
@@ -93,7 +93,7 @@ func.func @scatter_add_slice_2D() {
   %arg2 = util.unfoldable_constant dense<[[1, 2, 3],
                                           [4, 5, 6]]> : tensor<2x3xi32>
   %0 = "stablehlo.scatter"(%arg0, %arg1, %arg2) ( {
-  ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>):  // no predecessors
+  ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>):
     %1 = stablehlo.add %arg3, %arg4 : tensor<i32>
     "stablehlo.return"(%1) : (tensor<i32>) -> ()
   }) {

--- a/tests/e2e/stablehlo_ops/scatter_dynamic.mlir
+++ b/tests/e2e/stablehlo_ops/scatter_dynamic.mlir
@@ -4,7 +4,7 @@ func.func @scatter_add_slice_2D_dynamic_num_updates() {
   %arg2 = flow.tensor.dynamic_constant dense<[[1, 2, 3],
                                              [4, 5, 6]]> : tensor<2x3xi32> -> tensor<?x3xi32>
   %0 = "stablehlo.scatter"(%arg0, %arg1, %arg2) ( {
-  ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>):  // no predecessors
+  ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>):
     %1 = stablehlo.add %arg3, %arg4 : tensor<i32>
     "stablehlo.return"(%1) : (tensor<i32>) -> ()
   }) {

--- a/tests/e2e/stablehlo_ops/sort.mlir
+++ b/tests/e2e/stablehlo_ops/sort.mlir
@@ -2,7 +2,7 @@ func.func @sort1D() {
   %input = util.unfoldable_constant dense<[3, 2, 1, 4]> : tensor<4xi32>
 
   %sort = "stablehlo.sort"(%input) ( {
-  ^bb0(%arg1: tensor<i32>, %arg2: tensor<i32>):  // no predecessors
+  ^bb0(%arg1: tensor<i32>, %arg2: tensor<i32>):
     %compare = "stablehlo.compare"(%arg1, %arg2) {comparison_direction = #stablehlo<comparison_direction LT>} : (tensor<i32>, tensor<i32>) -> tensor<i1>
     "stablehlo.return"(%compare) : (tensor<i1>) -> ()
   }) {dimension = 0 : i64, is_stable = false} : (tensor<4xi32>) -> tensor<4xi32>
@@ -16,7 +16,7 @@ func.func @sort2D() {
                                            [4, 3, 2, 1]]> : tensor<2x4xi32>
 
   %sort = "stablehlo.sort"(%input) ( {
-  ^bb0(%arg1: tensor<i32>, %arg2: tensor<i32>):  // no predecessors
+  ^bb0(%arg1: tensor<i32>, %arg2: tensor<i32>):
     %compare = "stablehlo.compare"(%arg1, %arg2) {comparison_direction = #stablehlo<comparison_direction LT>} : (tensor<i32>, tensor<i32>) -> tensor<i1>
     "stablehlo.return"(%compare) : (tensor<i1>) -> ()
   }) {dimension = 1 : i64, is_stable = false} : (tensor<2x4xi32>) -> tensor<2x4xi32>
@@ -30,7 +30,7 @@ func.func @sort3D() {
                                             [4, 3, 2, 1]]]> : tensor<1x2x4xi32>
 
   %sort = "stablehlo.sort"(%input) ( {
-  ^bb0(%arg1: tensor<i32>, %arg2: tensor<i32>):  // no predecessors
+  ^bb0(%arg1: tensor<i32>, %arg2: tensor<i32>):
     %compare = "stablehlo.compare"(%arg1, %arg2) {comparison_direction = #stablehlo<comparison_direction LT>} : (tensor<i32>, tensor<i32>) -> tensor<i1>
     "stablehlo.return"(%compare) : (tensor<i1>) -> ()
   }) {dimension = 2 : i64, is_stable = false} : (tensor<1x2x4xi32>) -> tensor<1x2x4xi32>
@@ -43,7 +43,7 @@ func.func @sort_to_decreasing_seq() {
   %input = util.unfoldable_constant dense<[3, 2, 1, 4]> : tensor<4xi32>
 
   %sort = "stablehlo.sort"(%input) ( {
-  ^bb0(%arg1: tensor<i32>, %arg2: tensor<i32>):  // no predecessors
+  ^bb0(%arg1: tensor<i32>, %arg2: tensor<i32>):
     %compare = "stablehlo.compare"(%arg1, %arg2) {comparison_direction = #stablehlo<comparison_direction GT>} : (tensor<i32>, tensor<i32>) -> tensor<i1>
     "stablehlo.return"(%compare) : (tensor<i1>) -> ()
   }) {dimension = 0 : i64, is_stable = false} : (tensor<4xi32>) -> tensor<4xi32>

--- a/tools/test/iree-benchmark-executable.mlir
+++ b/tools/test/iree-benchmark-executable.mlir
@@ -43,13 +43,12 @@
   #hal.pipeline.binding<storage_buffer>
 ]>
 hal.executable.source public @executable {
-  hal.executable.export public @elementwise_mul ordinal(0) layout(#pipeline_layout) attributes {
-    workgroup_size = [1 : index, 1 : index, 1 : index]
-  } {
-  ^bb0(%device: !hal.device):
+  hal.executable.export public @elementwise_mul ordinal(0) layout(#pipeline_layout) count(%device: !hal.device) -> (index, index, index) {
     // Unused - the workgroup count is provided to the tool.
     %c1 = arith.constant 1 : index
     hal.return %c1, %c1, %c1 : index, index, index
+  } attributes {
+    workgroup_size = [1 : index, 1 : index, 1 : index]
   }
   builtin.module {
     func.func @elementwise_mul() {


### PR DESCRIPTION
Previously the region was optional and had no indicator that could be used to disambiguate it. By adding an explicit `count` keyword new optional regions can be added to the export ops without conflict. This aligns the op with `hal.dispatch.extern` that already specifies the workgroup count region this way. Attributes were also moved to the end of the op for consistency.

Enables #20660.