### PR TITLE
[Encoding] Allow `PadEncodingAttribute` to support dynamic padding.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
@@ -74,7 +74,7 @@ static RankedTensorType getPaddedType(Attribute layoutAttr,
     return type.dropEncoding();
   }
 
-  ArrayRef<int32_t> padding = layout.getPadding().asArrayRef();
+  ArrayRef<int64_t> padding = layout.getPadding().asArrayRef();
   auto newShape = llvm::to_vector_of<int64_t>(type.getShape());
   for (auto [newDim, padValue] : llvm::zip_equal(newShape, padding)) {
     assert((padValue == 0 || !ShapedType::isDynamic(newDim)) &&

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -539,7 +539,7 @@ struct GPUPadEncodingLayoutResolverAttrInterface final
            "Incorrect pad amount");
     assert(padBytes < cacheSetSpanBytes && "Incorrect pad amount");
     const int64_t numPadElements = (padBytes * 8) / elementBits;
-    SmallVector<int32_t> padValues(rank, 0);
+    SmallVector<int64_t> padValues(rank, 0);
     padValues[padDimensionIndex] = numPadElements;
     auto padLayout = Encoding::PadEncodingLayoutAttr::get(ctx, padValues);
     return padLayout;

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -251,13 +251,21 @@ def PadEncodingLayoutAttr : IREEEncoding_Attr<"PadEncodingLayout", [
         ]>
     ]> {
   let mnemonic = "pad_encoding_layout";
-  let assemblyFormat = "`<` $padding `>`";
+  let assemblyFormat = "`<` custom<Padding>($padding) `>`";
 
   let summary = "An attribute that encodes padding values of tensor dimensions";
   let description = [{
     Associates tensor dimensions with pad values (numbers of appended elements).
     The logical dimensions of the tensors do not change, and the elements in the
     padded regions are left uninitialized.
+
+    It is expected that the number of pad values specified is same as the rank of
+    the associated tensor.
+    - If the value is `0` no padding is done along that dimension
+    - If the value is positive static value, the tensor dimension is padded to that value
+    - If the value is `?`, the tensor dimension is padded to a value determined by the
+      backend, usually for better cache behavior.
+    Negative values for padding is illegal.
 
     This attribute implements `Encoding::SerializedEncodingLayoutResolverAttrInterface`,
     to provide a hook for tensor sizeof lowering. The implementation of this
@@ -267,17 +275,19 @@ def PadEncodingLayoutAttr : IREEEncoding_Attr<"PadEncodingLayout", [
 
   let parameters = (ins
     // How many padding elements to add along each tensor dimension.
-    "DenseI32ArrayAttr":$padding
+    "DenseI64ArrayAttr":$padding
   );
 
   let builders = [
-    AttrBuilder<(ins "ArrayRef<int32_t>":$padding)>
+    AttrBuilder<(ins "ArrayRef<int64_t>":$padding)>
   ];
 
   let extraClassDeclaration = [{
     /// Returns a PadEncodingLayoutAttr attribute that pads zero elements.
     static PadEncodingLayoutAttr getIdentityAttr(MLIRContext *ctx, int rank);
   }];
+
+  let genVerifyDecl = 1;
 }
 
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/test/invalid.mlir
@@ -183,3 +183,11 @@ func.func @illegal_layout_encoding_without_any_layout(%arg0: tensor<?x?xf32, #en
 func.func @illegal_layout_encoding_with_invalid_layouts(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf32, #encoding> {
   return %arg0 : tensor<?x?xf32, #encoding>
 }
+
+// -----
+
+// expected-error @+1 {{expected all padding values need to be non-negative or dynamic}}
+#encoding = #iree_encoding.pad_encoding_layout<[0, ?, -1]>
+func.func @negative_layout_encoding(%arg0: tensor<?x?x?xf32, #encoding>) -> tensor<?x?x?xf32, #encoding> {
+  return %arg0 : tensor<?x?x?xf32, #encoding>
+}

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/test/roundtrip.mlir
@@ -5,10 +5,10 @@ func.func @set_encoding_ops(%arg0: tensor<?x?xf32>) -> tensor<?x?xf32, #encoding
   %0 = iree_encoding.set_encoding %arg0 : tensor<?x?xf32> -> tensor<?x?xf32, #encoding>
   return %0 : tensor<?x?xf32, #encoding>
 }
-// CHECK:      #[[ENCODING:.+]] = #iree_encoding.testing_encoding<>
-// CHECK:      func.func @set_encoding_ops
+//      CHECK: #[[ENCODING:.+]] = #iree_encoding.testing_encoding<>
+//      CHECK: func.func @set_encoding_ops
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]
-// CHECK:        iree_encoding.set_encoding %[[ARG0]] : tensor<?x?xf32> -> tensor<?x?xf32, #[[ENCODING]]>
+//      CHECK:   iree_encoding.set_encoding %[[ARG0]] : tensor<?x?xf32> -> tensor<?x?xf32, #[[ENCODING]]>
 
 // -----
 
@@ -17,10 +17,10 @@ func.func @set_encoding_ops_mixed_dynamic_static(%arg0: tensor<?x10xf32>) -> ten
   %0 = iree_encoding.set_encoding %arg0 : tensor<?x10xf32> -> tensor<20x?xf32, #encoding>
   return %0 : tensor<20x?xf32, #encoding>
 }
-// CHECK:       #[[ENCODING:.+]] = #iree_encoding.testing_encoding<>
-// CHECK:       func.func @set_encoding_ops_mixed_dynamic_static
-// CHECK-SAME:      %[[ARG0:[a-zA-Z0-9]+]]
-// CHECK:         iree_encoding.set_encoding %[[ARG0]] : tensor<?x10xf32> -> tensor<20x?xf32, #[[ENCODING]]>
+//      CHECK: #[[ENCODING:.+]] = #iree_encoding.testing_encoding<>
+//      CHECK: func.func @set_encoding_ops_mixed_dynamic_static
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]
+//      CHECK:   iree_encoding.set_encoding %[[ARG0]] : tensor<?x10xf32> -> tensor<20x?xf32, #[[ENCODING]]>
 
 // -----
 
@@ -39,20 +39,20 @@ func.func @set_encoding_with_batch_matmul_user(%arg0: tensor<?x?x?xf32>) {
   iree_encoding.set_encoding %arg0 : tensor<?x?x?xf32> -> tensor<?x?x?xf32, #encoding5>
   return
 }
-// CHECK-DAG: #[[ENCODING0:.+]] = #iree_encoding.encoding<operand_index = 0 : i64, op_type =  matmul, element_types = [f32, f32, f32]>
-// CHECK-DAG: #[[ENCODING1:.+]] = #iree_encoding.encoding<operand_index = 0 : i64, op_type =  matmul, element_types = [i8, i8, i32]>
-// CHECK-DAG: #[[ENCODING2:.+]] = #iree_encoding.encoding<operand_index = 0 : i64, op_type =  matmul, element_types = [f16, f16, f32]>
-// CHECK-DAG: #[[ENCODING3:.+]] = #iree_encoding.encoding<operand_index = 0 : i64, op_type =  matmul, element_types = [f16, f16, f16]>
-// CHECK-DAG: #[[ENCODING4:.+]] = #iree_encoding.encoding<operand_index = 0 : i64, op_type =  matmul, element_types = [bf16, bf16, f32]>
-// CHECK-DAG: #[[ENCODING5:.+]] = #iree_encoding.encoding<operand_index = 0 : i64, op_type =  matmul, element_types = [bf16, bf16, bf16]>
-// CHECK:       func.func @set_encoding_with_batch_matmul_user
-// CHECK-SAME:      %[[ARG0:[a-zA-Z0-9]+]]
-// CHECK:         iree_encoding.set_encoding %[[ARG0]] : tensor<?x?x?xf32> -> tensor<?x?x?xf32, #[[ENCODING0]]>
-// CHECK:         iree_encoding.set_encoding %[[ARG0]] : tensor<?x?x?xf32> -> tensor<?x?x?xf32, #[[ENCODING1]]>
-// CHECK:         iree_encoding.set_encoding %[[ARG0]] : tensor<?x?x?xf32> -> tensor<?x?x?xf32, #[[ENCODING2]]>
-// CHECK:         iree_encoding.set_encoding %[[ARG0]] : tensor<?x?x?xf32> -> tensor<?x?x?xf32, #[[ENCODING3]]>
-// CHECK:         iree_encoding.set_encoding %[[ARG0]] : tensor<?x?x?xf32> -> tensor<?x?x?xf32, #[[ENCODING4]]>
-// CHECK:         iree_encoding.set_encoding %[[ARG0]] : tensor<?x?x?xf32> -> tensor<?x?x?xf32, #[[ENCODING5]]>
+//  CHECK-DAG: #[[ENCODING0:.+]] = #iree_encoding.encoding<operand_index = 0 : i64, op_type =  matmul, element_types = [f32, f32, f32]>
+//  CHECK-DAG: #[[ENCODING1:.+]] = #iree_encoding.encoding<operand_index = 0 : i64, op_type =  matmul, element_types = [i8, i8, i32]>
+//  CHECK-DAG: #[[ENCODING2:.+]] = #iree_encoding.encoding<operand_index = 0 : i64, op_type =  matmul, element_types = [f16, f16, f32]>
+//  CHECK-DAG: #[[ENCODING3:.+]] = #iree_encoding.encoding<operand_index = 0 : i64, op_type =  matmul, element_types = [f16, f16, f16]>
+//  CHECK-DAG: #[[ENCODING4:.+]] = #iree_encoding.encoding<operand_index = 0 : i64, op_type =  matmul, element_types = [bf16, bf16, f32]>
+//  CHECK-DAG: #[[ENCODING5:.+]] = #iree_encoding.encoding<operand_index = 0 : i64, op_type =  matmul, element_types = [bf16, bf16, bf16]>
+//      CHECK: func.func @set_encoding_with_batch_matmul_user
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]
+//      CHECK:   iree_encoding.set_encoding %[[ARG0]] : tensor<?x?x?xf32> -> tensor<?x?x?xf32, #[[ENCODING0]]>
+//      CHECK:   iree_encoding.set_encoding %[[ARG0]] : tensor<?x?x?xf32> -> tensor<?x?x?xf32, #[[ENCODING1]]>
+//      CHECK:   iree_encoding.set_encoding %[[ARG0]] : tensor<?x?x?xf32> -> tensor<?x?x?xf32, #[[ENCODING2]]>
+//      CHECK:   iree_encoding.set_encoding %[[ARG0]] : tensor<?x?x?xf32> -> tensor<?x?x?xf32, #[[ENCODING3]]>
+//      CHECK:   iree_encoding.set_encoding %[[ARG0]] : tensor<?x?x?xf32> -> tensor<?x?x?xf32, #[[ENCODING4]]>
+//      CHECK:   iree_encoding.set_encoding %[[ARG0]] : tensor<?x?x?xf32> -> tensor<?x?x?xf32, #[[ENCODING5]]>
 
 // -----
 
@@ -61,10 +61,10 @@ func.func @unset_encoding_fully_static(%arg0: tensor<3x5xf32, #encoding>) -> ten
   %0 = iree_encoding.unset_encoding %arg0 : tensor<3x5xf32, #encoding> -> tensor<3x5xf32>
   return %0 : tensor<3x5xf32>
 }
-// CHECK:       #[[ENCODING:.+]] = #iree_encoding.testing_encoding<>
-// CHECK:       func.func @unset_encoding_fully_static
-// CHECK-SAME:      %[[ARG0:[a-zA-Z0-9]+]]: tensor<3x5xf32, #[[ENCODING]]
-// CHECK:         iree_encoding.unset_encoding %[[ARG0]] : tensor<3x5xf32, #[[ENCODING]]> -> tensor<3x5xf32>
+//      CHECK: #[[ENCODING:.+]] = #iree_encoding.testing_encoding<>
+//      CHECK: func.func @unset_encoding_fully_static
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<3x5xf32, #[[ENCODING]]
+//      CHECK:   iree_encoding.unset_encoding %[[ARG0]] : tensor<3x5xf32, #[[ENCODING]]> -> tensor<3x5xf32>
 
 // -----
 
@@ -73,12 +73,12 @@ func.func @unset_encoding_fully_dynamic(%arg0: tensor<?x?xf32, #encoding>, %d0 :
   %0 = iree_encoding.unset_encoding %arg0 : tensor<?x?xf32, #encoding> -> tensor<?x?xf32>{%d0, %d1}
   return %0 : tensor<?x?xf32>
 }
-// CHECK:      #[[ENCODING:.+]] = #iree_encoding.testing_encoding<>
-// CHECK:      func.func @unset_encoding_fully_dynamic
+//      CHECK: #[[ENCODING:.+]] = #iree_encoding.testing_encoding<>
+//      CHECK: func.func @unset_encoding_fully_dynamic
 // CHECK-SAME:      %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32, #[[ENCODING]]
 // CHECK-SAME:      %[[D0:[a-zA-Z0-9]+]]
 // CHECK-SAME:      %[[D1:[a-zA-Z0-9]+]]
-// CHECK:        iree_encoding.unset_encoding %[[ARG0]] : tensor<?x?xf32, #[[ENCODING]]> -> tensor<?x?xf32>{%[[D0]], %[[D1]]}
+//      CHECK:   iree_encoding.unset_encoding %[[ARG0]] : tensor<?x?xf32, #[[ENCODING]]> -> tensor<?x?xf32>{%[[D0]], %[[D1]]}
 
 // -----
 
@@ -87,11 +87,11 @@ func.func @unset_encoding_ops_mixed_dynamic_static(%arg0: tensor<10x?xf32, #enco
   %0 = iree_encoding.unset_encoding %arg0 : tensor<10x?xf32, #encoding> -> tensor<?x20xf32>{%d0}
   return %0 : tensor<?x20xf32>
 }
-// CHECK:      #[[ENCODING:.+]] = #iree_encoding.testing_encoding<>
-// CHECK:      func.func @unset_encoding_ops_mixed_dynamic_static
+//      CHECK: #[[ENCODING:.+]] = #iree_encoding.testing_encoding<>
+//      CHECK: func.func @unset_encoding_ops_mixed_dynamic_static
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<10x?xf32, #[[ENCODING]]>
 // CHECK-SAME:     %[[D0:[a-zA-Z0-9]+]]
-// CHECK:        iree_encoding.unset_encoding %[[ARG0]] : tensor<10x?xf32, #[[ENCODING]]> -> tensor<?x20xf32>{%[[D0]]}
+//      CHECK:   iree_encoding.unset_encoding %[[ARG0]] : tensor<10x?xf32, #[[ENCODING]]> -> tensor<?x20xf32>{%[[D0]]}
 
 // -----
 
@@ -114,28 +114,28 @@ func.func @encoding_tensors_with_ops(%arg0 : tensor<?x?xf32>,
   %4 = iree_encoding.unset_encoding %3 : tensor<?x?xf32, #encoding2> -> tensor<?x?xf32>{%M, %N}
   return %4 : tensor<?x?xf32>
 }
-// CHECK-DAG:   #[[ENCODING0:.+]] = #iree_encoding.encoding<operand_index = 0 : i64, op_type =  matmul, element_types = [f32, f32, f32]>
-// CHECK-DAG:   #[[ENCODING1:.+]] = #iree_encoding.encoding<operand_index = 1 : i64, op_type =  matmul, element_types = [f32, f32, f32]>
-// CHECK-DAG:   #[[ENCODING2:.+]] = #iree_encoding.encoding<operand_index = 2 : i64, op_type =  matmul, element_types = [f32, f32, f32]>
-// CHECK:       func.func @encoding_tensors_with_ops
+//  CHECK-DAG: #[[ENCODING0:.+]] = #iree_encoding.encoding<operand_index = 0 : i64, op_type =  matmul, element_types = [f32, f32, f32]>
+//  CHECK-DAG: #[[ENCODING1:.+]] = #iree_encoding.encoding<operand_index = 1 : i64, op_type =  matmul, element_types = [f32, f32, f32]>
+//  CHECK-DAG: #[[ENCODING2:.+]] = #iree_encoding.encoding<operand_index = 2 : i64, op_type =  matmul, element_types = [f32, f32, f32]>
+//      CHECK:  func.func @encoding_tensors_with_ops
 // CHECK-SAME:      %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
 // CHECK-SAME:      %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?xf32>
 // CHECK-SAME:      %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?xf32>
-// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
-// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
-// CHECK-DAG:     %[[M:.+]] = tensor.dim %[[ARG0]], %[[C0]]
-// CHECK-DAG:     %[[N:.+]] = tensor.dim %[[ARG1]], %[[C1]]
-// CHECK:         %[[LHS:.+]] = iree_encoding.set_encoding %[[ARG0]]
+//  CHECK-DAG:    %[[C0:.+]] = arith.constant 0 : index
+//  CHECK-DAG:    %[[C1:.+]] = arith.constant 1 : index
+//  CHECK-DAG:    %[[M:.+]] = tensor.dim %[[ARG0]], %[[C0]]
+//  CHECK-DAG:    %[[N:.+]] = tensor.dim %[[ARG1]], %[[C1]]
+//      CHECK:    %[[LHS:.+]] = iree_encoding.set_encoding %[[ARG0]]
 // CHECK-SAME:        tensor<?x?xf32> -> tensor<?x?xf32, #[[ENCODING0]]>
-// CHECK:         %[[RHS:.+]] = iree_encoding.set_encoding %[[ARG1]]
+//      CHECK:    %[[RHS:.+]] = iree_encoding.set_encoding %[[ARG1]]
 // CHECK-SAME:        tensor<?x?xf32> -> tensor<?x?xf32, #[[ENCODING1]]>
-// CHECK:         %[[OUT:.+]] = iree_encoding.set_encoding %[[ARG2]]
+//      CHECK:    %[[OUT:.+]] = iree_encoding.set_encoding %[[ARG2]]
 // CHECK-SAME:        tensor<?x?xf32> -> tensor<?x?xf32, #[[ENCODING2]]>
-// CHECK:         %[[GEMM:.+]] = linalg.matmul
+//      CHECK:    %[[GEMM:.+]] = linalg.matmul
 // CHECK-SAME:        ins(%[[LHS]], %[[RHS]]
 // CHECK-SAME:        outs(%[[OUT]]
-// CHECK:         %[[RESULT:.+]] = iree_encoding.unset_encoding %[[GEMM]] : tensor<?x?xf32, #[[ENCODING2]]> -> tensor<?x?xf32>{%[[M]], %[[N]]}
-// CHECK:         return %[[RESULT]]
+//      CHECK:    %[[RESULT:.+]] = iree_encoding.unset_encoding %[[GEMM]] : tensor<?x?xf32, #[[ENCODING2]]> -> tensor<?x?xf32>{%[[M]], %[[N]]}
+//      CHECK:    return %[[RESULT]]
 
 // -----
 
@@ -148,15 +148,15 @@ func.func @set_encoding_ops_with_indexing_maps(%arg0: tensor<?x?xf32>) -> tensor
   %0 = iree_encoding.set_encoding %arg0 : tensor<?x?xf32> -> tensor<?x?xf32, #encoding>
   return %0 : tensor<?x?xf32, #encoding>
 }
-// CHECK-DAG:   #[[MAP0:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
-// CHECK-DAG:   #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
-// CHECK-DAG:   #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
-// CHECK-DAG:   #[[MAP3:.+]] = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
-// CHECK-DAG:   #[[ENCODING:.+]] = #iree_encoding.encoding<operand_index = 0 : i64, op_type =  matmul, element_types = [f32, f32, f32],
-// CHECK-SAME:    user_indexing_maps = {{\[}}[#[[MAP0]], #[[MAP3]]], #[[MAP1]], #[[MAP2]]{{\]}}
-// CHECK:       func.func @set_encoding_ops_with_indexing_maps(
-// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]:
-// CHECK:         iree_encoding.set_encoding %[[ARG0]] : tensor<?x?xf32> -> tensor<?x?xf32, #[[ENCODING]]>
+//  CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d3)>
+//  CHECK-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>
+//  CHECK-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+//  CHECK-DAG: #[[MAP3:.+]] = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+//  CHECK-DAG: #[[ENCODING:.+]] = #iree_encoding.encoding<operand_index = 0 : i64, op_type =  matmul, element_types = [f32, f32, f32],
+// CHECK-SAME:      user_indexing_maps = {{\[}}[#[[MAP0]], #[[MAP3]]], #[[MAP1]], #[[MAP2]]{{\]}}
+//      CHECK: func.func @set_encoding_ops_with_indexing_maps(
+// CHECK-SAME:   %[[ARG0:[a-zA-Z0-9]+]]:
+//      CHECK:   iree_encoding.set_encoding %[[ARG0]] : tensor<?x?xf32> -> tensor<?x?xf32, #[[ENCODING]]>
 
 // -----
 
@@ -170,15 +170,15 @@ func.func @set_encoding_ops_with_iteration_sizes(%arg0: tensor<?x?xf32>) {
   %2 = iree_encoding.set_encoding %arg0 : tensor<?x?xf32> -> tensor<?x?xf32, #encoding2>
   return
 }
-// CHECK-DAG:   #[[MAP:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
-// CHECK-DAG:   #[[ENCODING:.+]] = #iree_encoding.encoding<operand_index = 0 : i64, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#[[MAP]], #[[MAP]], #[[MAP]]], iteration_sizes = [1, 1, 1]>
-// CHECK-DAG:   #[[ENCODING1:.+]] = #iree_encoding.encoding<operand_index = 0 : i64, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#[[MAP]], #[[MAP]], #[[MAP]]], iteration_sizes = [?, ?, ?]>
-// CHECK-DAG:   #[[ENCODING2:.+]] = #iree_encoding.encoding<operand_index = 0 : i64, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#[[MAP]], #[[MAP]], #[[MAP]]], iteration_sizes = [?, 1, ?]>
-// CHECK:       func.func @set_encoding_ops_with_iteration_sizes(
-// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]:
-// CHECK:         iree_encoding.set_encoding %[[ARG0]] : tensor<?x?xf32> -> tensor<?x?xf32, #[[ENCODING]]>
-// CHECK:         iree_encoding.set_encoding %[[ARG0]] : tensor<?x?xf32> -> tensor<?x?xf32, #[[ENCODING1]]>
-// CHECK:         iree_encoding.set_encoding %[[ARG0]] : tensor<?x?xf32> -> tensor<?x?xf32, #[[ENCODING2]]>
+//  CHECK-DAG: #[[MAP:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+//  CHECK-DAG: #[[ENCODING:.+]] = #iree_encoding.encoding<operand_index = 0 : i64, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#[[MAP]], #[[MAP]], #[[MAP]]], iteration_sizes = [1, 1, 1]>
+//  CHECK-DAG: #[[ENCODING1:.+]] = #iree_encoding.encoding<operand_index = 0 : i64, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#[[MAP]], #[[MAP]], #[[MAP]]], iteration_sizes = [?, ?, ?]>
+//  CHECK-DAG: #[[ENCODING2:.+]] = #iree_encoding.encoding<operand_index = 0 : i64, op_type =  matmul, element_types = [f32, f32, f32], user_indexing_maps = [#[[MAP]], #[[MAP]], #[[MAP]]], iteration_sizes = [?, 1, ?]>
+//      CHECK:  func.func @set_encoding_ops_with_iteration_sizes(
+// CHECK-SAME:      %[[ARG0:[a-zA-Z0-9]+]]:
+//      CHECK:    iree_encoding.set_encoding %[[ARG0]] : tensor<?x?xf32> -> tensor<?x?xf32, #[[ENCODING]]>
+//      CHECK:    iree_encoding.set_encoding %[[ARG0]] : tensor<?x?xf32> -> tensor<?x?xf32, #[[ENCODING1]]>
+//      CHECK:    iree_encoding.set_encoding %[[ARG0]] : tensor<?x?xf32> -> tensor<?x?xf32, #[[ENCODING2]]>
 
 // -----
 
@@ -186,7 +186,7 @@ func.func @set_encoding_ops_with_iteration_sizes(%arg0: tensor<?x?xf32>) {
 func.func @unspecialized_encoding(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf32, #encoding> {
   return %arg0 : tensor<?x?xf32, #encoding>
 }
-// CHECK:      func.func @unspecialized_encoding(
+//      CHECK: func.func @unspecialized_encoding(
 // CHECK-SAME:   %[[ARG0:.+]]: tensor<?x?xf32, #iree_encoding.unspecialized_encoding<123>>
 // CHECK         return %[[ARG0]]
 
@@ -196,7 +196,7 @@ func.func @unspecialized_encoding(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?
 func.func @specialized_encoding_without_type(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf32, #encoding> {
   return %arg0 : tensor<?x?xf32, #encoding>
 }
-// CHECK:      func.func @specialized_encoding_without_type(
+//      CHECK: func.func @specialized_encoding_without_type(
 // CHECK-SAME:   %[[ARG0:.+]]: tensor<?x?xf32, #iree_encoding.specialized_encoding<123>>
 // CHECK         return %[[ARG0]]
 
@@ -206,7 +206,7 @@ func.func @specialized_encoding_without_type(%arg0: tensor<?x?xf32, #encoding>) 
 func.func @specialized_encoding_with_type(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf32, #encoding> {
   return %arg0 : tensor<?x?xf32, #encoding>
 }
-// CHECK:      func.func @specialized_encoding_with_type(
+//      CHECK: func.func @specialized_encoding_with_type(
 // CHECK-SAME:   %[[ARG0:.+]]: tensor<?x?xf32, #iree_encoding.specialized_encoding<123, tensor<?x?xf32>>>
 // CHECK         return %[[ARG0]]
 
@@ -216,8 +216,8 @@ func.func @specialized_encoding_with_type(%arg0: tensor<?x?xf32, #encoding>) -> 
 func.func @testing_encoding_without_layouts(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf32, #encoding> {
   return %arg0 : tensor<?x?xf32, #encoding>
 }
-// CHECK:     #[[ENCODING:.+]] = #iree_encoding.testing_encoding<>
-// CHECK:      func.func @testing_encoding_without_layouts(
+//      CHECK: #[[ENCODING:.+]] = #iree_encoding.testing_encoding<>
+//      CHECK: func.func @testing_encoding_without_layouts(
 // CHECK-SAME:   %[[ARG0:.+]]: tensor<?x?xf32, #[[ENCODING]]>
 // CHECK         return %[[ARG0]]
 
@@ -227,8 +227,8 @@ func.func @testing_encoding_without_layouts(%arg0: tensor<?x?xf32, #encoding>) -
 func.func @testing_encoding_with_layouts(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf32, #encoding> {
   return %arg0 : tensor<?x?xf32, #encoding>
 }
-// CHECK:     #[[ENCODING:.+]] = #iree_encoding.testing_encoding<[#iree_encoding.unspecialized_encoding<123>]>
-// CHECK:      func.func @testing_encoding_with_layouts(
+//      CHECK: #[[ENCODING:.+]] = #iree_encoding.testing_encoding<[#iree_encoding.unspecialized_encoding<123>]>
+//      CHECK: func.func @testing_encoding_with_layouts(
 // CHECK-SAME:   %[[ARG0:.+]]: tensor<?x?xf32, #[[ENCODING]]>
 // CHECK         return %[[ARG0]]
 
@@ -238,8 +238,8 @@ func.func @testing_encoding_with_layouts(%arg0: tensor<?x?xf32, #encoding>) -> t
 func.func @matmul_k_encoding(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf32, #encoding> {
   return %arg0 : tensor<?x?xf32, #encoding>
 }
-// CHECK:     #[[ENCODING:.+]] = #iree_encoding.matmul_k<k_dims = [1]>
-// CHECK:      func.func @matmul_k_encoding(
+//      CHECK: #[[ENCODING:.+]] = #iree_encoding.matmul_k<k_dims = [1]>
+//      CHECK: func.func @matmul_k_encoding(
 // CHECK-SAME:   %[[ARG0:.+]]: tensor<?x?xf32, #[[ENCODING]]>
 // CHECK         return %[[ARG0]]
 
@@ -249,7 +249,16 @@ func.func @matmul_k_encoding(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf3
 func.func @layout_encoding(%arg0: tensor<?x?xf32, #encoding>) -> tensor<?x?xf32, #encoding> {
   return %arg0 : tensor<?x?xf32, #encoding>
 }
-// CHECK:     #[[ENCODING:.+]] = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 64]>]>
-// CHECK:      func.func @layout_encoding(
+//      CHECK: #[[ENCODING:.+]] = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, 64]>]>
+//      CHECK: func.func @layout_encoding(
 // CHECK-SAME:   %[[ARG0:.+]]: tensor<?x?xf32, #[[ENCODING]]>
 // CHECK         return %[[ARG0]]
+
+// -----
+
+#encoding = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, ?, 64]>]>
+func.func @dynamic_layout_encoding(%arg0: tensor<?x?x?xf32, #encoding>) -> tensor<?x?x?xf32, #encoding> {
+  return %arg0 : tensor<?x?x?xf32, #encoding>
+}
+//      CHECK: #[[ENCODING:.+]] = #iree_encoding.layout<[#iree_encoding.pad_encoding_layout<[0, ?, 64]>]>
+//      CHECK: func.func @dynamic_layout_encoding(%[[ARG0:.+]]: tensor<?x?x?xf32, #[[ENCODING]]>)

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/unittests/EncodingAttrTest.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/unittests/EncodingAttrTest.cpp
@@ -61,7 +61,7 @@ TEST_F(EncodingAttrsTest, PadEncodingLayoutAttr) {
   EXPECT_TRUE(cast<SerializableEncodingAttrInterface>(zeroPaddingAttr)
                   .isIdentityLayout());
 
-  SmallVector<int32_t> paddings = {4, 2};
+  SmallVector<int64_t> paddings = {4, 2};
   auto nonZeroPaddingAttr = PadEncodingLayoutAttr::get(ctx, paddings);
   EXPECT_FALSE(cast<SerializableEncodingAttrInterface>(nonZeroPaddingAttr)
                    .isIdentityLayout());


### PR DESCRIPTION
The dynamic padding allows different backends to chose different padding values.

To be able to use `?` for representing dynamic values, the container is changed to be int64_t.