### PR TITLE
Replace loop with more efficient memcmp

### DIFF
--- a/runtime/src/iree/base/string_view.c
+++ b/runtime/src/iree/base/string_view.c
@@ -32,10 +32,7 @@ static inline char iree_tolower(char c) {
 IREE_API_EXPORT bool iree_string_view_equal(iree_string_view_t lhs,
                                             iree_string_view_t rhs) {
   if (lhs.size != rhs.size) return false;
-  for (iree_host_size_t i = 0; i < lhs.size; ++i) {
-    if (lhs.data[i] != rhs.data[i]) return false;
-  }
-  return true;
+  return memcmp(lhs.data, rhs.data, lhs.size) == 0;
 }
 
 IREE_API_EXPORT bool iree_string_view_equal_case(iree_string_view_t lhs,


### PR DESCRIPTION
Instead of using loop to check for equality, more efficient memcmp() should be used which are optimized for comparing the memory content.