### PR TITLE
Use static build path in local temp disk vs. shared

### DIFF
--- a/.github/workflows/ci_windows_x64_msvc.yml
+++ b/.github/workflows/ci_windows_x64_msvc.yml
@@ -24,7 +24,7 @@ jobs:
     if: ${{ github.repository_owner == 'iree-org' || github.event_name != 'schedule' }}
     runs-on: azure-windows-scale
     env:
-      BASE_BUILD_DIR_POWERSHELL: C:\mnt\azure\b
+      BASE_BUILD_DIR_POWERSHELL: B:\tmpbuild
       SCCACHE_AZURE_CONNECTION_STRING: "${{ secrets.AZURE_CCACHE_CONNECTION_STRING }}"
       SCCACHE_AZURE_BLOB_CONTAINER: ccache-container
       SCCACHE_CCACHE_ZSTD_LEVEL: 10
@@ -36,12 +36,11 @@ jobs:
           submodules: true
       - name: "Create build dir"
         run: |
-          $currentTime = (Get-Date).ToString('HHmmss')
-          $buildDir = "$env:BASE_BUILD_DIR_POWERSHELL\$currentTime"
+          $buildDir = "$env:BASE_BUILD_DIR_POWERSHELL\"
           echo "BUILD_DIR_POWERSHELL=$buildDir" >> $env:GITHUB_ENV
           mkdir "$buildDir"
           Write-Host "Generated Build Directory: $buildDir"
-          $bashBuildDir = $buildDir -replace '\\', '/' -replace '^C:', '/c'
+          $bashBuildDir = $buildDir -replace '\\', '/' -replace '^B:', '/b'
           echo  "BUILD_DIR_BASH=$bashBuildDir" >> $env:GITHUB_ENV
           Write-Host "Converted Build Directory For Bash: $bashBuildDir"
       - name: "Setting up Python"


### PR DESCRIPTION
- Use a static build path `B:\tmpbuild` rather than `C:\mnt\azure\b\$currentTime` as this has been causing ccache to miss 100%
- The `B:\` is mounted with `emptyDir` to use ephemeral storage, that is fast (NVMe on Dads_v6 series), and local to the VM rather than the shared PVC (backed by StandardSSD_ZRS) between all runners (potentially causing collisions/contention)
- This will also constrain each runner to their own file systems.

The following update has been made to the kubernetes scale-set configuration to coincide with these changes:
```yaml
      resources:
        limits:
          ephemeral-storage: 100Gi
          memory: 92Gi
        requests:
          ephemeral-storage: 10Gi
          memory: 92Gi
      volumeMounts:
      - name: tmpbuild-dir
        mountPath: "b:"
      - name: src-ccache-dir
        mountPath: /home/runner/_work
      - name: azure-disk
        mountPath: /mnt/azure
    tolerations:
    - effect: NoSchedule
      key: kubernetes.io/os
      operator: Equal
      value: windows
    - effect: NoSchedule
      key: kubernetes.azure.com/scalesetpriority
      operator: Equal
      value: spot
    volumes:
    - name: tmpbuild-dir
      emptyDir: {}
    - name: src-ccache-dir
      emptyDir: {}
    - name: azure-disk
      emptyDir: {}
```