### PR TITLE
[Stream] Avoid clone on single user in CloneToConsumers

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.td
@@ -189,6 +189,15 @@ def CloneToConsumersPass :
     interface's `preferCloneToConsumers` query is used and any ops implementing
     the interface may opt-in to the cloning.
   }];
+  let options = [
+    Option<
+      "printIterations", "print-iterations",
+      "bool",
+      /*default=*/"false",
+      "Prints the number of analysis and cloning iterations run (for testing "
+      "purposes only)"
+    >,
+  ];
   let dependentDialects = [
     "IREE::Stream::StreamDialect",
   ];


### PR DESCRIPTION
There's a test case in CI that hits the maxIterationCount limit in `CloneToConsumers`, see following snippet from [link](https://productionresultssa18.blob.core.windows.net/actions-results/12feab86-0903-45f5-aa4d-bb9ce25e7a83/workflow-job-run-9a12b7d0-3d94-5577-bd10-45030e262b7b/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-04-29T09%3A18%3A36Z&sig=AqOWKb2LcvJwQ5TKwwkPsQXdUp2l8wBwMrGUAQ8Auu4%3D&ske=2025-04-29T18%3A02%3A25Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-04-29T06%3A02%3A25Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-01-05&sp=r&spr=https&sr=b&st=2025-04-29T09%3A08%3A31Z&sv=2025-01-05):
```
2025-04-28T22:30:40.8293436Z /home/esaimana/actions-runner-2/_work/iree/iree/iree-test-suites/sharktank_models/llama3.1/assets/toy_llama_tp2.mlir:3:1: remark: clone to consumers pass failed to reach a fixed point after 32 iterations; ambiguous affinity may be present
2025-04-28T22:30:40.8295022Z module @module {
2025-04-28T22:30:40.8295393Z ^
2025-04-28T22:30:40.8295873Z ------------------------------ Captured log setup ------------------------------
2025-04-28T22:30:40.8299532Z INFO     root:binaries.py:185 Invoke IREE Tool: /home/esaimana/actions-runner-2/_work/iree/iree/venv/lib/python3.11/site-packages/iree/compiler/tools/../_mlir_libs/iree-compile /home/esaimana/actions-runner-2/_work/iree/iree/iree-test-suites/sharktank_models/llama3.1/assets/toy_llama_tp2.mlir --iree-input-type=auto --iree-vm-bytecode-module-output-format=flatbuffer-binary --mlir-print-debuginfo --mlir-print-op-on-diagnostic=false '--iree-hal-target-device=hip[0]' '--iree-hal-target-device=hip[1]' --iree-hip-target=gfx1100
```
This can be reproduced by running the following command on [clone_to_consumers_remark.mlir.txt](https://github.com/user-attachments/files/19956123/clone_to_consumers_remark.mlir.txt):

```
iree-opt --iree-stream-clone-to-consumers clone_to_consumers_remark.mlir
```

I reduced this further to the following test case:

```
module {
  util.global private @param_dev0 {stream.affinity = #hal.device.affinity<@__device_0>} : tensor<1xi32>
  util.global private @param_dev1 {stream.affinity = #hal.device.affinity<@__device_1>} : tensor<1xi32>
  util.func private @single_user_multi_device() -> tensor<1xi32> {
    %weight1 = util.global.load immutable @param_dev0 : tensor<1xi32>
    %weight2 = util.global.load immutable @param_dev1 : tensor<1xi32>
    %splat_value = arith.constant 123 : i32
    %splat = flow.tensor.splat %splat_value : tensor<i32>
    %16 = flow.dispatch @test::@test(%weight1, %weight2, %splat) : (tensor<1xi32>, tensor<1xi32>, tensor<i32>) -> tensor<1xi32>
    util.return %16 : tensor<1xi32>
  }
}
```

I am actually not entirely sure whether a dispatch with params that have different affinity is correct or whether this should never happen? It seems from the remark message that it can happen:

>  clone to consumers pass failed to reach a fixed point after 32 iterations; ambiguous affinity may be present

If this is correct, adding a `hasOneUse` check should break up the indefinite cloning of the single producer. 