### PR TITLE
Properly handle unaligned refs in VM ABI marshaling.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/Analysis/RegisterAllocation.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Analysis/RegisterAllocation.cpp
@@ -97,6 +97,7 @@ struct RegisterUsage {
     maxRefRegisterOrdinal = -1;
   }
 
+  // Returns the index
   std::optional<int> findFirstUnsetIntOrdinalSpan(size_t byteWidth) {
     unsigned int requiredAlignment = byteWidth / 4;
     unsigned int ordinalStart = intRegisters.find_first_unset();
@@ -122,28 +123,55 @@ struct RegisterUsage {
     return std::nullopt;
   }
 
+  std::optional<int> findLastUnsetIntOrdinalSpan(size_t byteWidth) {
+    unsigned int requiredAlignment = byteWidth / 4;
+    unsigned int ordinalStart =
+        llvm::alignTo(intRegisters.find_last() + 1, requiredAlignment);
+    unsigned int ordinalEnd = ordinalStart + (byteWidth / 4) - 1;
+    if (ordinalEnd >= Register::kInt32RegisterCount) {
+      return std::nullopt;
+    }
+    return static_cast<int>(ordinalStart);
+  }
+
+  // Allocates a register of the given |type|.
+  // The register will be marked as used.
   std::optional<Register> allocateRegister(Type type) {
+    Register reg;
     if (type.isIntOrFloat()) {
       size_t byteWidth = IREE::Util::getRoundedElementByteWidth(type);
       auto ordinalStartOr = findFirstUnsetIntOrdinalSpan(byteWidth);
       if (!ordinalStartOr.has_value()) {
         return std::nullopt;
       }
-      int ordinalStart = ordinalStartOr.value();
-      unsigned int ordinalEnd = ordinalStart + (byteWidth / 4) - 1;
-      intRegisters.set(ordinalStart, ordinalEnd + 1);
-      maxI32RegisterOrdinal =
-          std::max(static_cast<int>(ordinalEnd), maxI32RegisterOrdinal);
-      return Register::getValue(type, ordinalStart);
+      reg = Register::getValue(type, ordinalStartOr.value());
     } else {
       int ordinal = refRegisters.find_first_unset();
       if (ordinal >= Register::kRefRegisterCount || ordinal == -1) {
         return std::nullopt;
       }
-      refRegisters.set(ordinal);
-      maxRefRegisterOrdinal = std::max(ordinal, maxRefRegisterOrdinal);
-      return Register::getRef(type, ordinal, /*isMove=*/false);
+      reg = Register::getRef(type, ordinal, /*isMove=*/false);
     }
+    markRegisterUsed(reg);
+    return reg;
+  }
+
+  // Allocates a |block| argument register of the given |type|.
+  // Entry block registers are allocated as monotonically increasing while all
+  // internal blocks are assigned as dense as possible.
+  std::optional<Register> allocateBlockArgRegister(Block *block, Type type) {
+    if (!block->isEntryBlock() || !type.isIntOrFloat()) {
+      return allocateRegister(type);
+    }
+    assert(type.isIntOrFloat()); // special handling only for primitives
+    size_t byteWidth = IREE::Util::getRoundedElementByteWidth(type);
+    auto ordinalStartOr = findLastUnsetIntOrdinalSpan(byteWidth);
+    if (!ordinalStartOr.has_value()) {
+      return std::nullopt;
+    }
+    auto reg = Register::getValue(type, ordinalStartOr.value());
+    markRegisterUsed(reg);
+    return reg;
   }
 
   void markRegisterUsed(Register reg) {
@@ -240,7 +268,8 @@ LogicalResult RegisterAllocation::recalculate(IREE::VM::FuncOp funcOp) {
 
     // Allocate arguments first from left-to-right.
     for (auto blockArg : block->getArguments()) {
-      auto reg = registerUsage.allocateRegister(blockArg.getType());
+      auto reg =
+          registerUsage.allocateBlockArgRegister(block, blockArg.getType());
       if (!reg.has_value()) {
         return funcOp.emitError() << "register allocation failed for block arg "
                                   << blockArg.getArgNumber();

--- a/compiler/src/iree/compiler/Dialect/VM/Analysis/RegisterAllocation.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Analysis/RegisterAllocation.cpp
@@ -97,7 +97,6 @@ struct RegisterUsage {
     maxRefRegisterOrdinal = -1;
   }
 
-  // Returns the index
   std::optional<int> findFirstUnsetIntOrdinalSpan(size_t byteWidth) {
     unsigned int requiredAlignment = byteWidth / 4;
     unsigned int ordinalStart = intRegisters.find_first_unset();

--- a/compiler/src/iree/compiler/Dialect/VM/Analysis/test/register_allocation.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Analysis/test/register_allocation.mlir
@@ -23,6 +23,16 @@ vm.module @module {
     vm.return %zero : i32
   }
 
+  // Note that arguments are special and must be assigned monotonically
+  // increasing registers even if that leaves gaps. Here %arg2 must get i4
+  // and not the unused i1.
+  // CHECK-LABEL: @func_args
+  vm.func @func_args(%arg0: i32, %arg1: i64, %arg2: i32) -> (i32, i64, i32) {
+    // CHECK: vm.return
+    // CHECK-SAME: block_registers = ["i0", "i2+3", "i4"]
+    vm.return %arg0, %arg1, %arg2 : i32, i64, i32
+  }
+
   // CHECK-LABEL: @dominating_values
   vm.func @dominating_values(%arg0 : i32, %arg1 : i32) -> (i32, i32) {
     // CHECK: vm.const.i32 5

--- a/runtime/src/iree/base/alignment.h
+++ b/runtime/src/iree/base/alignment.h
@@ -120,6 +120,10 @@ static inline bool iree_is_power_of_two_uint64(uint64_t value) {
   return (value != 0) && ((value & (value - 1)) == 0);
 }
 
+// TODO(benvanik): when C23 is fully adopted we can make a single generic
+// version of the alignment functions that uses typeof to cast back to the
+// expected result. For now we explicitly spell out the variants we want.
+
 // Aligns |value| up to the given power-of-two |alignment| if required.
 // https://en.wikipedia.org/wiki/Data_structure_alignment#Computing_padding
 static inline uint64_t iree_align_uint64(uint64_t value, uint64_t alignment) {

--- a/runtime/src/iree/vm/BUILD.bazel
+++ b/runtime/src/iree/vm/BUILD.bazel
@@ -108,6 +108,18 @@ iree_runtime_cc_test(
 )
 
 iree_runtime_cc_test(
+    name = "module_test",
+    srcs = ["module_test.cc"],
+    deps = [
+        ":cc",
+        ":impl",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+iree_runtime_cc_test(
     name = "native_module_test",
     srcs = ["native_module_test.cc"],
     deps = [

--- a/runtime/src/iree/vm/CMakeLists.txt
+++ b/runtime/src/iree/vm/CMakeLists.txt
@@ -98,6 +98,19 @@ iree_cc_test(
 
 iree_cc_test(
   NAME
+    module_test
+  SRCS
+    "module_test.cc"
+  DEPS
+    ::cc
+    ::impl
+    iree::base
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
+iree_cc_test(
+  NAME
     native_module_test
   SRCS
     "native_module_test.cc"

--- a/runtime/src/iree/vm/bytecode/module.c
+++ b/runtime/src/iree/vm/bytecode/module.c
@@ -14,6 +14,10 @@
 #include "iree/vm/bytecode/module_impl.h"
 #include "iree/vm/bytecode/verifier.h"
 
+// Maximum size of an argument or result buffer used when marshaling ABI
+// arguments in bytes.
+#define IREE_VM_FUNCTION_MAX_ABI_BUFFER_SIZE (16 * 1024)
+
 // Perform an strcmp between a FlatBuffers string and an IREE string view.
 static bool iree_vm_flatbuffer_strcmp(flatbuffers_string_t lhs,
                                       iree_string_view_t rhs) {
@@ -784,7 +788,8 @@ static iree_status_t iree_vm_bytecode_module_resolve_import(
   }
   IREE_RETURN_IF_ERROR(iree_vm_function_call_compute_cconv_fragment_size(
       import->results, /*segment_size_list=*/NULL, &result_buffer_size));
-  if (argument_buffer_size > 16 * 1024 || result_buffer_size > 16 * 1024) {
+  if (argument_buffer_size > IREE_VM_FUNCTION_MAX_ABI_BUFFER_SIZE ||
+      result_buffer_size > IREE_VM_FUNCTION_MAX_ABI_BUFFER_SIZE) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                             "ABI marshaling buffer overflow on import %" PRIhsz,
                             ordinal);

--- a/runtime/src/iree/vm/module_test.cc
+++ b/runtime/src/iree/vm/module_test.cc
@@ -1,0 +1,199 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/vm/module.h"
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include "iree/base/api.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+bool operator==(const iree_string_view_t lhs, const iree_string_view_t rhs) {
+  return iree_string_view_equal(lhs, rhs);
+}
+
+std::ostream& operator<<(std::ostream& stream, iree_string_view_t const& str) {
+  stream << '`';
+  stream.write(str.data, str.size);
+  stream << '`';
+  return stream;
+}
+
+namespace {
+
+using ::iree::Status;
+using ::iree::StatusCode;
+using ::iree::StatusOr;
+using ::iree::testing::status::IsOkAndHolds;
+using ::iree::testing::status::StatusIs;
+
+iree_vm_function_signature_t MakeSignature(const char* cconv) {
+  iree_vm_function_signature_t signature = {
+      /*.calling_convention=*/iree_make_cstring_view(cconv),
+  };
+  return signature;
+}
+
+static StatusOr<std::pair<iree_string_view_t, iree_string_view_t>>
+GetCconvFragments(const char* cconv) {
+  auto signature = MakeSignature(cconv);
+  iree_string_view_t arguments = iree_string_view_empty();
+  iree_string_view_t results = iree_string_view_empty();
+  iree_status_t status = iree_vm_function_call_get_cconv_fragments(
+      &signature, &arguments, &results);
+  if (iree_status_is_ok(status)) {
+    return std::make_pair(arguments, results);
+  }
+  return status;
+}
+
+TEST(FunctionCallTest, GetCconvFragments) {
+  // Empty cconv strings are treated as `()->()`.
+  EXPECT_THAT(GetCconvFragments(""),
+              IsOkAndHolds(std::make_pair(IREE_SV(""), IREE_SV(""))));
+
+  // Only version 0 is supported and all others should fail.
+  EXPECT_THAT(GetCconvFragments("1"), StatusIs(StatusCode::kUnimplemented));
+
+  EXPECT_THAT(GetCconvFragments("0v"),
+              IsOkAndHolds(std::make_pair(IREE_SV(""), IREE_SV(""))));
+  EXPECT_THAT(GetCconvFragments("0v_v"),
+              IsOkAndHolds(std::make_pair(IREE_SV(""), IREE_SV(""))));
+  EXPECT_THAT(GetCconvFragments("0i"),
+              IsOkAndHolds(std::make_pair(IREE_SV("i"), IREE_SV(""))));
+  EXPECT_THAT(GetCconvFragments("0_i"),
+              IsOkAndHolds(std::make_pair(IREE_SV(""), IREE_SV("i"))));
+  EXPECT_THAT(GetCconvFragments("0v_i"),
+              IsOkAndHolds(std::make_pair(IREE_SV(""), IREE_SV("i"))));
+  EXPECT_THAT(GetCconvFragments("0i_f"),
+              IsOkAndHolds(std::make_pair(IREE_SV("i"), IREE_SV("f"))));
+  EXPECT_THAT(GetCconvFragments("0iIi_fFf"),
+              IsOkAndHolds(std::make_pair(IREE_SV("iIi"), IREE_SV("fFf"))));
+}
+
+TEST(FunctionCallTest, IsVariadicCconv) {
+  EXPECT_FALSE(iree_vm_function_call_is_variadic_cconv(IREE_SV("")));
+  EXPECT_FALSE(iree_vm_function_call_is_variadic_cconv(IREE_SV("0i")));
+  EXPECT_TRUE(iree_vm_function_call_is_variadic_cconv(IREE_SV("0CiD")));
+}
+
+static StatusOr<std::pair<iree_host_size_t, iree_host_size_t>>
+CountArgumentsAndResults(const char* cconv) {
+  auto signature = MakeSignature(cconv);
+  iree_host_size_t argument_count = 0;
+  iree_host_size_t result_count = 0;
+  iree_status_t status = iree_vm_function_call_count_arguments_and_results(
+      &signature, &argument_count, &result_count);
+  if (iree_status_is_ok(status)) {
+    return std::make_pair(argument_count, result_count);
+  }
+  return status;
+}
+
+TEST(FunctionCallTest, CountArgumentsAndResults) {
+  // Variadic functions cannot be counted.
+  EXPECT_THAT(CountArgumentsAndResults("0CiD"),
+              StatusIs(StatusCode::kInvalidArgument));
+
+  EXPECT_THAT(CountArgumentsAndResults(""), IsOkAndHolds(std::make_pair(0, 0)));
+  EXPECT_THAT(CountArgumentsAndResults("0v"),
+              IsOkAndHolds(std::make_pair(0, 0)));
+  EXPECT_THAT(CountArgumentsAndResults("0v_v"),
+              IsOkAndHolds(std::make_pair(0, 0)));
+  EXPECT_THAT(CountArgumentsAndResults("0i"),
+              IsOkAndHolds(std::make_pair(1, 0)));
+  EXPECT_THAT(CountArgumentsAndResults("0i_v"),
+              IsOkAndHolds(std::make_pair(1, 0)));
+  EXPECT_THAT(CountArgumentsAndResults("0i_i"),
+              IsOkAndHolds(std::make_pair(1, 1)));
+  EXPECT_THAT(CountArgumentsAndResults("0iIfFr_iIfFr"),
+              IsOkAndHolds(std::make_pair(5, 5)));
+}
+
+static StatusOr<iree_host_size_t> ComputeCconvFragmentSize(
+    const char* cconv, std::vector<uint16_t> segment_sizes = {}) {
+  // Convert the dynamically-sized segment size list to the VM size-prefixed
+  // format.
+  iree_vm_register_list_t* segment_size_list = nullptr;
+  if (!segment_sizes.empty()) {
+    segment_size_list = (iree_vm_register_list_t*)iree_alloca(
+        sizeof(uint16_t) + sizeof(uint16_t) * segment_sizes.size());
+    segment_size_list->size = (uint16_t)segment_sizes.size();
+    memcpy(&segment_size_list->registers[0], segment_sizes.data(),
+           sizeof(uint16_t) * segment_sizes.size());
+  }
+
+  iree_host_size_t required_size = 0;
+  iree_status_t status = iree_vm_function_call_compute_cconv_fragment_size(
+      iree_make_cstring_view(cconv), segment_size_list, &required_size);
+
+  if (iree_status_is_ok(status)) {
+    return required_size;
+  }
+  return status;
+}
+
+TEST(FunctionCallTest, ComputeCconvFragmentSize) {
+  EXPECT_THAT(ComputeCconvFragmentSize(""), IsOkAndHolds(0));
+  EXPECT_THAT(ComputeCconvFragmentSize("i"), IsOkAndHolds(sizeof(int32_t)));
+  EXPECT_THAT(ComputeCconvFragmentSize("I"), IsOkAndHolds(sizeof(int64_t)));
+  EXPECT_THAT(ComputeCconvFragmentSize("f"), IsOkAndHolds(sizeof(float)));
+  EXPECT_THAT(ComputeCconvFragmentSize("F"), IsOkAndHolds(sizeof(double)));
+  EXPECT_THAT(ComputeCconvFragmentSize("r"),
+              IsOkAndHolds(sizeof(iree_vm_ref_t)));
+
+  // No external trailing padding (to min alignment of int64_t) expected.
+  EXPECT_THAT(ComputeCconvFragmentSize("Ii"),
+              IsOkAndHolds(sizeof(int64_t) + sizeof(int32_t)));
+
+  // No internal padding (to align the int64_t) expected.
+  EXPECT_THAT(ComputeCconvFragmentSize("iI"),
+              IsOkAndHolds(sizeof(int32_t) + sizeof(int64_t)));
+
+  // No internal padding for the ref and external padding to min alignment of
+  // ref. We bake out the logic here for readability: this is what the function
+  // does internally (generically).
+  iree_host_size_t iri_size = 0;
+  iri_size += sizeof(int32_t);        // `i`
+  iri_size += sizeof(iree_vm_ref_t);  // `r`
+  iri_size += sizeof(int32_t);        // `i`
+  EXPECT_THAT(ComputeCconvFragmentSize("iri"), IsOkAndHolds(iri_size));
+}
+
+TEST(FunctionCallTest, ComputeVariadicCconvFragmentSize) {
+  // Require a segment size list of the appropriate size is provided if there
+  // are any variadic segments.
+  EXPECT_THAT(ComputeCconvFragmentSize("CiD", {}),
+              StatusIs(StatusCode::kInvalidArgument));
+  EXPECT_THAT(ComputeCconvFragmentSize("CiDCID", {0}),
+              StatusIs(StatusCode::kInvalidArgument));
+
+  // There's always an int32_t used for the span count that is embedded in the
+  // ABI storage. Though we have the information in the segment size list used
+  // in this test not all callers/callees have the list and hermeticity of the
+  // storage is required.
+  EXPECT_THAT(ComputeCconvFragmentSize("CfD", {0}),
+              IsOkAndHolds(sizeof(int32_t)));
+  EXPECT_THAT(ComputeCconvFragmentSize("CfD", {1}),
+              IsOkAndHolds(sizeof(int32_t) + 1 * sizeof(float)));
+  EXPECT_THAT(ComputeCconvFragmentSize("CfD", {2}),
+              IsOkAndHolds(sizeof(int32_t) + 2 * sizeof(float)));
+
+  // Spans have no padding.
+  iree_host_size_t iri_size = 0;
+  iri_size += sizeof(int32_t);  // span count
+  for (iree_host_size_t i = 0; i < 2; ++i) {
+    iri_size += sizeof(int32_t);        // `i`
+    iri_size += sizeof(iree_vm_ref_t);  // `r`
+    iri_size += sizeof(int32_t);        // `i`
+  }
+  EXPECT_THAT(ComputeCconvFragmentSize("CiriD", {2}), IsOkAndHolds(iri_size));
+}
+
+}  // namespace

--- a/runtime/src/iree/vm/ref.h
+++ b/runtime/src/iree/vm/ref.h
@@ -200,47 +200,57 @@ static inline iree_status_t iree_vm_ref_check(const iree_vm_ref_t ref,
 }
 
 // Retains the reference-counted pointer |ref|.
+// Unsafe to call on unaligned refs.
 IREE_API_EXPORT void iree_vm_ref_retain_inplace(iree_vm_ref_t* ref);
 
 // Retains the reference-counted pointer |ref|.
 // |out_ref| will be released if it already contains a reference.
+// Safe to call on unaligned refs.
 IREE_API_EXPORT void iree_vm_ref_retain(iree_vm_ref_t* ref,
                                         iree_vm_ref_t* out_ref);
 
 // Retains the reference-counted pointer |ref| and checks that it is of |type|.
 // |out_ref| will be released if it already contains a reference.
+// Safe to call on unaligned refs.
 IREE_API_EXPORT iree_status_t iree_vm_ref_retain_checked(
     iree_vm_ref_t* ref, iree_vm_ref_type_t type, iree_vm_ref_t* out_ref);
 
 // Retains or moves |ref| to |out_ref|.
 // |out_ref| will be released if it already contains a reference.
+// Safe to call on unaligned refs.
 IREE_API_EXPORT void iree_vm_ref_retain_or_move(int is_move, iree_vm_ref_t* ref,
                                                 iree_vm_ref_t* out_ref);
 
 // Retains or moves |ref| to |out_ref| and checks that |ref| is of |type|.
 // |out_ref| will be released if it already contains a reference.
+// Safe to call on unaligned refs.
 IREE_API_EXPORT iree_status_t iree_vm_ref_retain_or_move_checked(
     int is_move, iree_vm_ref_t* ref, iree_vm_ref_type_t type,
     iree_vm_ref_t* out_ref);
 
 // Releases the reference-counted pointer |ref|, possibly freeing it.
+// Safe to call on unaligned refs.
 IREE_API_EXPORT void iree_vm_ref_release(iree_vm_ref_t* ref);
 
 // Assigns the reference-counted pointer |ref| without incrementing the count.
 // |out_ref| will be released if it already contains a reference.
+// Safe to call on unaligned refs.
 IREE_API_EXPORT void iree_vm_ref_assign(iree_vm_ref_t* ref,
                                         iree_vm_ref_t* out_ref);
 
 // Moves one reference to another without changing the reference count.
 // |out_ref| will be released if it already contains a reference.
+// Safe to call on unaligned refs.
 IREE_API_EXPORT void iree_vm_ref_move(iree_vm_ref_t* ref,
                                       iree_vm_ref_t* out_ref);
 
 // Returns true if the given |ref| is NULL.
+// Safe to call on unaligned refs.
 IREE_API_EXPORT bool iree_vm_ref_is_null(const iree_vm_ref_t* ref);
 
 // Returns true if the two references point at the same value (or are both
 // null).
+// Safe to call on unaligned refs.
 IREE_API_EXPORT bool iree_vm_ref_equal(const iree_vm_ref_t* lhs,
                                        const iree_vm_ref_t* rhs);
 

--- a/tools/test/iree-run-module-inputs.mlir
+++ b/tools/test/iree-run-module-inputs.mlir
@@ -1,8 +1,7 @@
 // Passing no inputs is okay.
 
-// RUN: (iree-compile --iree-hal-target-device=local \
-// RUN:               --iree-hal-local-target-device-backends=vmvx %s | \
-// RUN:  iree-run-module --device=local-sync --module=- --function=no_input) | \
+// RUN: (iree-compile %s | \
+// RUN:  iree-run-module --module=- --function=no_input) | \
 // RUN: FileCheck --check-prefix=NO-INPUT %s
 // NO-INPUT-LABEL: EXEC @no_input
 func.func @no_input() {
@@ -14,10 +13,8 @@ func.func @no_input() {
 // Scalars use the form `--input=value`. Type (float/int) should be omitted.
 //   * The VM does not use i1/i8 types, so i32 VM types are returned instead.
 
-// RUN: (iree-compile --iree-hal-target-device=local \
-// RUN:               --iree-hal-local-target-device-backends=vmvx %s | \
-// RUN:  iree-run-module --device=local-sync \
-// RUN:                  --module=- \
+// RUN: (iree-compile %s | \
+// RUN:  iree-run-module --module=- \
 // RUN:                  --function=scalars \
 // RUN:                  --input=1 \
 // RUN:                  --input=5 \
@@ -25,12 +22,12 @@ func.func @no_input() {
 // RUN:                  --input=-3.14) | \
 // RUN: FileCheck --check-prefix=INPUT-SCALARS %s
 // INPUT-SCALARS-LABEL: EXEC @scalars
-func.func @scalars(%arg0: i1, %arg1: i8, %arg2 : i32, %arg3 : f32) -> (i1, i8, i32, f32) {
+func.func @scalars(%arg0: i1, %arg1: i64, %arg2: i32, %arg3: f32) -> (i1, i64, i32, f32) {
   // INPUT-SCALARS: result[0]: i32=1
-  // INPUT-SCALARS: result[1]: i32=5
+  // INPUT-SCALARS: result[1]: i64=5
   // INPUT-SCALARS: result[2]: i32=1234
   // INPUT-SCALARS: result[3]: f32=-3.14
-  return %arg0, %arg1, %arg2, %arg3 : i1, i8, i32, f32
+  return %arg0, %arg1, %arg2, %arg3 : i1, i64, i32, f32
 }
 
 // -----


### PR DESCRIPTION
`iree_vm_ref_*` functions have been updated to handle unaligned ref pointers. The changes do not significantly change the code and allow for the ABI marshaling to remain simple.

Tests were added to verify the ABI size calculations match expectations.
A bug was fixed in padding of i64/f64 argument registers on external calls both in the compiler and runtime.

Fixes #20663.