### PR TITLE
Runtime float type conversion helpers: Fix handling of denormals.

### DIFF
--- a/runtime/src/iree/base/internal/math.h
+++ b/runtime/src/iree/base/internal/math.h
@@ -373,14 +373,13 @@ static inline float iree_math_make_f32_from_bits(uint32_t src, int exp_bits,
         int32_t unclamped_f32_mantissa =
             (src_mantissa << (f32_mantissa_bits - src_mantissa_bits + 1)) -
             (1 << f32_mantissa_bits);
-        // It's a bit hard to reason about the edge cases with that subtraction
-        // of 1 << f32_mantissa_bits... at least we know we don't want the
-        // f32_mantissa to run outside the range [0, 2^23 - 1]... we just clamp.
-        // This should be correct as long as we picked the correct f32_exp above
-        // and if that's not the case, that is if some rounding case requires
-        // incrementing/decrementing f32_exp, then we were already wrong above.
-        // Maybe it's OK to be slightly incorrect in a few denormal-only edge
-        // cases when the error is only a rounding error.
+        // We don't want the f32_mantissa to run outside the range [0, 2^23 - 1]
+        // so we just clamp. I *think* that is correct. The reasoning is that
+        // first, there is no question of rounding here since we are expanding
+        // from a narrow to a wider type, and so the only question really is:
+        // did we pick the correct exponent above? As long as f32_exp is correct
+        // it forces a range of representable values and that means that
+        // clamping to the mantissa range is the correct rounding to do.
         f32_mantissa = unclamped_f32_mantissa < 0
                            ? 0
                            : (unclamped_f32_mantissa & f32_mantissa_mask);

--- a/runtime/src/iree/base/internal/math.h
+++ b/runtime/src/iree/base/internal/math.h
@@ -368,8 +368,8 @@ static inline float iree_math_make_f32_from_bits(uint32_t src, int exp_bits,
         // "1 + " term. After some algebra isolating f32_mantissa on the left
         // hand side of the equantion:
         f32_mantissa =
-            (src_mantissa << -(-f32_mantissa_bits + src_mantissa_bits +
-                               f32_arithmetic_exp - src_arithmetic_exp)) -
+            (src_mantissa << (f32_mantissa_bits - src_mantissa_bits -
+                              f32_arithmetic_exp + src_arithmetic_exp)) -
             (1 << f32_mantissa_bits);
       }
     } else {

--- a/runtime/src/iree/base/internal/math.h
+++ b/runtime/src/iree/base/internal/math.h
@@ -7,6 +7,7 @@
 #ifndef IREE_BASE_INTERNAL_MATH_H_
 #define IREE_BASE_INTERNAL_MATH_H_
 
+#include <math.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -299,102 +300,38 @@ static inline float iree_math_make_f32_from_bits(uint32_t src, int exp_bits,
                                                  int bias_tweak,
                                                  bool nan_as_neg_zero) {
   IREE_MATH_FP_FORMAT_CONSTANTS(src_, exp_bits, mantissa_bits, bias_tweak)
-  IREE_MATH_FP_FORMAT_CONSTANTS(f32_, 8, 23, 0)
-  const uint32_t src_sign = src & src_sign_mask;
-  const uint32_t f32_sign = src_sign << (f32_sign_shift - src_sign_shift);
+  const float float_sign = (src & src_sign_mask) ? -1.f : 1.f;
   const uint32_t src_exp = src & src_exp_mask;
   const uint32_t src_mantissa = src & src_mantissa_mask;
-  uint32_t f32_exp = 0;
-  uint32_t f32_mantissa = 0;
   if (src_exp == src_exp_mask) {
     // Top exponent value normally means infinity or NaN.
     if (have_infinity) {
       // NaN or Inf case.
-      f32_exp = f32_exp_mask;
       if (src_mantissa) {
-        f32_mantissa = f32_mantissa_mask;  // Quiet NaN.
+        return NAN;
       } else {
-        f32_mantissa = 0;  // Inf.
+        return float_sign * INFINITY;
       }
     } else {
       // No infinities => more large finite values, unless this is a NaN.
-      bool is_finite = src_mantissa != src_mantissa_mask || nan_as_neg_zero;
-      if (is_finite) {
-        f32_exp = ((src_exp >> src_exp_shift) + f32_exp_bias - src_exp_bias)
-                  << f32_exp_shift;
-        f32_mantissa = src_mantissa << (f32_mantissa_bits - src_mantissa_bits);
-      } else {
-        // NaN. Generate a quiet NaN.
-        f32_exp = f32_exp_mask;
-        f32_mantissa = f32_mantissa_mask;
+      if (src_mantissa == src_mantissa_mask && !nan_as_neg_zero) {
+        return NAN;
       }
     }
   } else if (nan_as_neg_zero && src == src_sign_mask) {
-    // Source is NaN encoded as negative zero. Generate NaN.
-    f32_exp = f32_exp_mask;
-    f32_mantissa = f32_mantissa_mask;
-  } else if (src_exp == 0 && src_mantissa == 0) {
-    // Zero. Leave f32_exp and f32_mantissa as zero.
-  } else {
-    if (src_exp == 0) {
-      // Source is denormal, nonzero.
-
-      // Case when the source and destination types have the same exponent
-      // range (bfloat16/f32).
-      if (src_exp_bits == f32_exp_bits) {
-        f32_exp = src_exp << (f32_exp_shift - src_exp_shift);
-        f32_mantissa = src_mantissa << (f32_mantissa_bits - src_mantissa_bits);
-      } else {
-        // Source is denormal, destination is normal. Careful with the
-        // arithmetic exponents, as denormals are a special case:
-        // The source being denormal means that the arithmetic exponent is one
-        // plus what is normally encoded in the exponent bits. We won't need
-        // this, but we will refer to this in comments:
-        //     int src_arithmetic_exp = 1 - src_exp_bias;
-        // The f32 destination being normal means it doesn't have that
-        // adjustment by one.
-        int f32_arithmetic_exp = -src_exp_bias;
-        // Compute the final f32 exponent bits.
-        f32_exp = (f32_arithmetic_exp + f32_exp_bias) << f32_exp_shift;
-        // Now the hard part: compute the final f32 mantissa. Unlike the source,
-        // the f32 result is a normal value, which means that it is encoded as
-        //   (1 + mantissa_value) * 2^dst_arithmetic_exponent
-        // Where mantissa_value is a number in the half-open interval [0, 1).
-        // Scaling this to the actual integer encoded in the mantissa bits, that
-        // value is:
-        //    ((1 << f32_mantissa_bits) + f32_mantissa)
-        //                        * 2^(f32_arithmetic_exp - f32_mantissa_bits)
-        // Now we plug that into an equation of that value with the source
-        // value which is a denormal and hence does not have the corresponding
-        // "1 + " term. After some algebra isolating f32_mantissa on the left
-        // hand side of the equantion, and since per the above we have
-        //   -f32_arithmetic_exp + src_arithmetic_exp == 1
-        // we arrive at this:
-        int32_t unclamped_f32_mantissa =
-            (src_mantissa << (f32_mantissa_bits - src_mantissa_bits + 1)) -
-            (1 << f32_mantissa_bits);
-        // We don't want the f32_mantissa to run outside the range [0, 2^23 - 1]
-        // so we just clamp. I *think* that is correct. The reasoning is that
-        // first, there is no question of rounding here since we are expanding
-        // from a narrow to a wider type, and so the only question really is:
-        // did we pick the correct exponent above? As long as f32_exp is correct
-        // it forces a range of representable values and that means that
-        // clamping to the mantissa range is the correct rounding to do.
-        f32_mantissa = unclamped_f32_mantissa < 0
-                           ? 0
-                           : (unclamped_f32_mantissa & f32_mantissa_mask);
-      }
-    } else {
-      // Source is normal.
-      int src_arithmetic_exp = (src_exp >> src_exp_shift) - src_exp_bias;
-      f32_exp = (src_arithmetic_exp + f32_exp_bias) << f32_exp_shift;
-      f32_mantissa = src_mantissa << (f32_mantissa_bits - src_mantissa_bits);
-    }
+    // Case of small FP types using the negative-0 encoding for NaN.
+    return NAN;
+  } else if (src_exp == 0) {
+    // Denormals. In that case, the exponent is interpreted as 1 instead of the
+    // encoded 0, and the result is proportional to src_mantissa instead of
+    // having an implied leading 1.
+    return float_sign *
+           ldexpf(src_mantissa, 1 - src_exp_bias - src_mantissa_bits);
   }
-  const uint32_t u32_value = f32_sign | f32_exp | f32_mantissa;
-  float f32_value;
-  memcpy(&f32_value, &u32_value, sizeof f32_value);
-  return f32_value;
+  // Normal value.
+  return float_sign *
+         ldexpf(src_mantissa + (1 << src_mantissa_bits),
+                (src_exp >> src_exp_shift) - src_exp_bias - src_mantissa_bits);
 }
 
 // Generic conversion from f32 to any less-than-32-bit floating-point format,
@@ -459,7 +396,7 @@ static inline uint32_t iree_math_truncate_f32_to_bits_rounding_to_nearest_even(
       // by right-shifting the subnormal mantissa.
       int shift_amount = f32_mantissa_bits - dst_mantissa_bits -
                          arithmetic_exp + dst_arithmetic_exp;
-      if (shift_amount < 0 || shift_amount >= f32_mantissa_bits) {
+      if (shift_amount < 0 || shift_amount > f32_mantissa_bits) {
         dst_mantissa = 0;
       } else {
         // Source f32 value is normal so has an implied 1... leading bit.

--- a/runtime/src/iree/base/internal/math.h
+++ b/runtime/src/iree/base/internal/math.h
@@ -350,8 +350,8 @@ static inline float iree_math_make_f32_from_bits(uint32_t src, int exp_bits,
         // The source being denormal means that the arithmetic exponent is one
         // plus what is normally encoded in the exponent bits.
         int src_arithmetic_exp = 1 - src_exp_bias;
-        // The f32 destination being normal means it doesn't that adjustment by
-        // one.
+        // The f32 destination being normal means it doesn't have that
+        // adjustment by one.
         int f32_arithmetic_exp = -src_exp_bias;
         // Compute the final f32 exponent bits.
         f32_exp = (f32_arithmetic_exp + f32_exp_bias) << f32_exp_shift;
@@ -361,7 +361,8 @@ static inline float iree_math_make_f32_from_bits(uint32_t src, int exp_bits,
         // Where mantissa_value is a number in the half-open interval [0, 1).
         // Scaling this to the actual integer encoded in the mantissa bits, that
         // value is:
-        //    ((1 << f32_mantissa_bits) + f32_mantissa) * 2^f32_arithmetic_exp
+        //    ((1 << f32_mantissa_bits) + f32_mantissa)
+        //                        * 2^(f32_arithmetic_exp - f32_mantissa_bits)
         // Now we plug that into an equation of that value with the source
         // value which is a denormal and hence does not have the corresponding
         // "1 + " term. After some algebra isolating f32_mantissa on the left

--- a/runtime/src/iree/base/internal/math_test.cc
+++ b/runtime/src/iree/base/internal/math_test.cc
@@ -280,7 +280,9 @@ TEST(BF16ConversionTest, F32ToBF16) {
   EXPECT_EQ(0x7f80, iree_math_f32_to_bf16(FLT_MAX));
   EXPECT_EQ(0xff80, iree_math_f32_to_bf16(-FLT_MAX));
   // No underflow, as bfloat16 has the same smallest normal value as float32.
-  EXPECT_EQ(0x80, iree_math_f32_to_bf16(FLT_MIN));
+  EXPECT_EQ(0x007F, iree_math_f32_to_bf16(1.1663108e-38));  // Largest denormal.
+  EXPECT_EQ(0x0080, iree_math_f32_to_bf16(1.1754942e-38));  // Rounds to normal.
+  EXPECT_EQ(0x0080, iree_math_f32_to_bf16(FLT_MIN));
   EXPECT_EQ(0x8080, iree_math_f32_to_bf16(-FLT_MIN));
 }
 

--- a/runtime/src/iree/base/internal/math_test.cc
+++ b/runtime/src/iree/base/internal/math_test.cc
@@ -254,6 +254,7 @@ TEST(F16ConversionTest, F32ToF16ToF32) {
   // Denormals
   EXPECT_EQ(3.05175781e-05f,
             iree_math_f16_to_f32(iree_math_f32_to_f16(kF16Min / 2)));
+  EXPECT_EQ(3.05175781e-05f, iree_math_f16_to_f32(0x0001));
   // Inf and Nan
   EXPECT_EQ(INFINITY, iree_math_f16_to_f32(iree_math_f32_to_f16(INFINITY)));
   EXPECT_EQ(-INFINITY, iree_math_f16_to_f32(iree_math_f32_to_f16(-INFINITY)));
@@ -327,6 +328,8 @@ TEST(BF16ConversionTest, F32ToBF16ToF32) {
   // Denormals
   EXPECT_EQ(1.83670992e-40f,
             iree_math_bf16_to_f32(iree_math_f32_to_bf16(2.0e-40f)));
+  EXPECT_EQ(9.18354962e-41f, iree_math_bf16_to_f32(0x0001));
+
   // Inf and Nan
   EXPECT_EQ(INFINITY, iree_math_bf16_to_f32(iree_math_f32_to_bf16(INFINITY)));
   EXPECT_EQ(-INFINITY, iree_math_bf16_to_f32(iree_math_f32_to_bf16(-INFINITY)));
@@ -420,6 +423,7 @@ TEST(F8E5M2ConversionTest, F32ToF8E5M2ToF32) {
   // Denormals
   EXPECT_EQ(1.f / 32768.f,
             iree_math_f8e5m2_to_f32(iree_math_f32_to_f8e5m2(kF8E5M2Min / 2)));
+  EXPECT_EQ(3.05175781e-05f, iree_math_f8e5m2_to_f32(0x0001));
   // Inf and Nan
   EXPECT_EQ(INFINITY,
             iree_math_f8e5m2_to_f32(iree_math_f32_to_f8e5m2(INFINITY)));


### PR DESCRIPTION
As preparation for introducing support for FP6/FP4 types where denormals become essential, I wanted to make sure that we had robust support for denormals already for larger types. It was known to be incomplete in the sense that we were still flushing to zero in many cases, but it turned out to also be buggy in some cases. This PR should nail this for good.