### PR TITLE
Raise an error in demotion passes if illegal extern funcs are present.

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/Common/test/demote_i64_to_i32.mlir
+++ b/compiler/src/iree/compiler/InputConversion/Common/test/demote_i64_to_i32.mlir
@@ -165,7 +165,10 @@ util.initializer {
   util.return
 }
 // CHECK: util.func private @initializer() -> tensor<4xi32>
-util.func private @initializer() -> tensor<4xi64>
+util.func private @initializer() -> tensor<4xi64> {
+  %0 = arith.constant dense<123> : tensor<4xi64>
+  util.return %0 : tensor<4xi64>
+}
 
 // -----
 


### PR DESCRIPTION
This avoids inscrutable dialect conversion errors if external functions that use a type being demoted exist in the module on input.

Fixes #12987.