### PR TITLE
Call IREE_TRACE_APP_ENTER/EXIT in compiler tool main functions.

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -14,6 +14,7 @@
 # Programs with a dependency on the compiler are not designed to run on device
 # platforms (e.g. Android), so they are tagged "hostonly".
 
+load("@rules_cc//cc:defs.bzl", "cc_binary")
 load("//build_tools/bazel:build_defs.oss.bzl", "iree_compiler_cc_binary", "iree_runtime_cc_binary")
 
 package(
@@ -171,6 +172,7 @@ iree_compiler_cc_binary(
     deps = [
         "//compiler/bindings/c:headers",
         "//compiler/src/iree/compiler/API:Impl",
+        "//runtime/src/iree/base",
     ],
 )
 
@@ -241,6 +243,7 @@ iree_compiler_cc_binary(
     deps = [
         "//compiler/bindings/c:headers",
         "//compiler/src/iree/compiler/API:Impl",
+        "//runtime/src/iree/base",
     ],
 )
 
@@ -251,5 +254,6 @@ iree_compiler_cc_binary(
     deps = [
         "//compiler/bindings/c:headers",
         "//compiler/src/iree/compiler/API:Impl",
+        "//runtime/src/iree/base",
     ],
 )

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -304,6 +304,7 @@ if(IREE_BUILD_COMPILER)
     SRCS
       "iree-compile-main.cc"
     DEPS
+      iree::base
       iree::compiler::bindings::c::headers
       iree::compiler::API::Impl
     DATA
@@ -319,6 +320,7 @@ if(IREE_BUILD_COMPILER)
     SRCS
       "iree-reduce.cc"
     DEPS
+      iree::base
       iree::compiler::bindings::c::headers
       iree::compiler::API::Impl
     DATA
@@ -352,6 +354,7 @@ if(IREE_BUILD_COMPILER)
     SRCS
       "iree-opt-main.cc"
     DEPS
+      iree::base
       iree::compiler::bindings::c::headers
       iree::compiler::API::Impl
     DATA

--- a/tools/iree-compile-main.cc
+++ b/tools/iree-compile-main.cc
@@ -4,6 +4,12 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree/base/api.h"
 #include "iree/compiler/tool_entry_points_api.h"
 
-int main(int argc, char **argv) { return ireeCompilerRunMain(argc, argv); }
+int main(int argc, char **argv) {
+  IREE_TRACE_APP_ENTER();
+  int exit_code = ireeCompilerRunMain(argc, argv);
+  IREE_TRACE_APP_EXIT(exit_code);
+  return exit_code;
+}

--- a/tools/iree-opt-main.cc
+++ b/tools/iree-opt-main.cc
@@ -8,6 +8,12 @@
 //
 // Based on mlir-opt but registers the passes and dialects we care about.
 
+#include "iree/base/api.h"
 #include "iree/compiler/tool_entry_points_api.h"
 
-int main(int argc, char **argv) { return ireeOptRunMain(argc, argv); }
+int main(int argc, char **argv) {
+  IREE_TRACE_APP_ENTER();
+  int exit_code = ireeOptRunMain(argc, argv);
+  IREE_TRACE_APP_EXIT(exit_code);
+  return exit_code;
+}

--- a/tools/iree-reduce.cc
+++ b/tools/iree-reduce.cc
@@ -14,6 +14,12 @@
 // the first arguement. The script should return 0 if the input file produces
 // the required error as the original file and 1 otherwise.
 
+#include "iree/base/api.h"
 #include "iree/compiler/tool_entry_points_api.h"
 
-int main(int argc, char **argv) { return ireeReduceRunMain(argc, argv); }
+int main(int argc, char **argv) {
+  IREE_TRACE_APP_ENTER();
+  int exit_code = ireeReduceRunMain(argc, argv);
+  IREE_TRACE_APP_EXIT(exit_code);
+  return exit_code;
+}


### PR DESCRIPTION
This ensures that if tracing is used in one of these tools it is valid. The dep on the runtime isn't fantastic, but consteval already takes the dep so this adds nothing over what the compiler library already pulls in.

Fixes #18502.