### PR TITLE
Fold iree_tensor_ext.dispatch.workload.ordinal on constants.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtBase.td
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtBase.td
@@ -25,7 +25,11 @@ def IREETensorExt_Dialect : Dialect {
     A dialect designed for experimenting with tensor operations
     beyond what is currently available in the Tensor Dialect.
   }];
+  let dependentDialects = [
+    "arith::ArithDialect" // For materializeConstant()
+  ];
   let useDefaultTypePrinterParser = 1;
+  let hasConstantMaterializer = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtDialect.cpp
@@ -8,6 +8,7 @@
 
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtOps.h"
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtTypes.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 
 namespace mlir::iree_compiler::IREE::TensorExt {
@@ -21,6 +22,15 @@ void IREETensorExtDialect::initialize() {
       >();
 
   getContext()->getOrLoadDialect<tensor::TensorDialect>();
+}
+
+Operation *IREETensorExtDialect::materializeConstant(OpBuilder &builder,
+                                                     Attribute value, Type type,
+                                                     Location loc) {
+  if (arith::ConstantOp::isBuildableWith(value, type)) {
+    return builder.create<arith::ConstantOp>(loc, type, cast<TypedAttr>(value));
+  }
+  return nullptr;
 }
 
 } // namespace mlir::iree_compiler::IREE::TensorExt

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpFolders.cpp
@@ -321,10 +321,10 @@ OpFoldResult DispatchWorkloadOrdinalOp::fold(FoldAdaptor operands) {
   }
 
   // Fold away following sequence ordinal ops:
-  // ```mlir
-  // %1 = iree_tensor_ext.dispatch.workload.ordinal %0, 2
-  // %2 = iree_tensor_ext.dispatch.workload.ordinal %1, 2
-  // ```
+  //
+  //   %1 = iree_tensor_ext.dispatch.workload.ordinal %0, 2
+  //   %2 = iree_tensor_ext.dispatch.workload.ordinal %1, 2
+  //
   // This can happen when the operands get deduped.
   if (auto producerOrdinalOp = dyn_cast_or_null<DispatchWorkloadOrdinalOp>(
           getOperand().getDefiningOp())) {

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpFolders.cpp
@@ -322,8 +322,8 @@ OpFoldResult DispatchWorkloadOrdinalOp::fold(FoldAdaptor operands) {
 
   // Fold away following sequence ordinal ops:
   // ```mlir
-  // %1 = iree_tensor_ext.dispatch.workload.ordinal %0 2
-  // %2 = iree_tensor_ext.dispatch.workload.ordinal %1 2
+  // %1 = iree_tensor_ext.dispatch.workload.ordinal %0, 2
+  // %2 = iree_tensor_ext.dispatch.workload.ordinal %1, 2
   // ```
   // This can happen when the operands get deduped.
   if (auto producerOrdinalOp = dyn_cast_or_null<DispatchWorkloadOrdinalOp>(

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOpFolders.cpp
@@ -313,21 +313,26 @@ struct BubbleUpOrdinalOp : public OpRewritePattern<DispatchWorkloadOrdinalOp> {
 
 } // namespace
 
-/// Fold away following sequence of `iree_tensor_ext.dispatch.workload.ordinal`.
-///
-/// ```mlir
-/// %1 = iree_tensor_ext.dispatch.workload.ordinal %0 2
-/// %2 = iree_tensor_ext.dispatch.workload.ordinal %1 2
-/// ```
-///
-/// This can happen when the operands get deduped.
 OpFoldResult DispatchWorkloadOrdinalOp::fold(FoldAdaptor operands) {
+  // If the operand being annotated is a constant then just fold to it as
+  // there's no longer any relation to the captured workload.
+  if (operands.getOperand()) {
+    return operands.getOperand();
+  }
+
+  // Fold away following sequence ordinal ops:
+  // ```mlir
+  // %1 = iree_tensor_ext.dispatch.workload.ordinal %0 2
+  // %2 = iree_tensor_ext.dispatch.workload.ordinal %1 2
+  // ```
+  // This can happen when the operands get deduped.
   if (auto producerOrdinalOp = dyn_cast_or_null<DispatchWorkloadOrdinalOp>(
           getOperand().getDefiningOp())) {
     if (producerOrdinalOp.getOrdinal() == getOrdinal()) {
       return producerOrdinalOp.getOperand();
     }
   }
+
   return {};
 }
 

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
@@ -325,7 +325,7 @@ def IREETensorExt_DispatchWorkloadOrdinalOp :
   }];
   let description = [{
     The arguments that represent the captured/returned values of the
-    `flow.dispatch.workgroups, i.e. the signature of the body of the op is not
+    `flow.dispatch.workgroups`, i.e. the signature of the body of the op is not
     preserved during IREEs compilation. Since the workloads are derived from
     the operands captured by the operation, this op denotes the values captured
     as workloads. This can be used in the backends to map back to the workload

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/dispatch_workload_ordinal_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/dispatch_workload_ordinal_folding.mlir
@@ -110,7 +110,7 @@ util.func public @dedup_workload(
 util.func public @constant_fold_workload_ordinal() -> (index) {
   // CHECK: %[[C2:.+]] = arith.constant 2 : index
   %c2 = arith.constant 2: index
-  // CHECK-NOT: flow.dispatch.workload.ordinal
+  // CHECK-NOT: iree_tensor_ext.dispatch.workload.ordinal
   %0 = iree_tensor_ext.dispatch.workload.ordinal %c2, 0 : index
   // CHECK: util.return %[[C2]]
   util.return %0 : index

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/dispatch_workload_ordinal_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/test/dispatch_workload_ordinal_folding.mlir
@@ -103,3 +103,15 @@ util.func public @dedup_workload(
   }
   util.return %result :tensor<?x?x?x?x?xf32>
 }
+
+// -----
+
+// CHECK-LABEL: util.func public @constant_fold_workload_ordinal()
+util.func public @constant_fold_workload_ordinal() -> (index) {
+  // CHECK: %[[C2:.+]] = arith.constant 2 : index
+  %c2 = arith.constant 2: index
+  // CHECK-NOT: flow.dispatch.workload.ordinal
+  %0 = iree_tensor_ext.dispatch.workload.ordinal %c2, 0 : index
+  // CHECK: util.return %[[C2]]
+  util.return %0 : index
+}


### PR DESCRIPTION
The TensorExt dialect now implements materializeConstant so this folder (and others in the future) can create constants.

Fixes #18383 (this is just that PR ported to the new dialect with required fixes).