### PR TITLE
[Codegen][DerivedConfig] Add support to set outermost tile size as vector size

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.cpp
@@ -20,81 +20,92 @@ namespace mlir::iree_compiler::IREE::GPU {
 static constexpr int64_t kPreferredCopyNumBits = 128;
 
 // Helper to construct a list of tile sizes that simply uses the given vector
-// size or the innerDimSize as the inner most tile size, whichever is smaller.
-// All other dims are tiled to 1.
-static SmallVector<int64_t>
-getVectorSizeTileSizes(int64_t rank, int64_t innerDimSize, int64_t vectorSize) {
+// size or the `targetDimSize` as the inner/outer most tile size, whichever is
+// smaller. All other dims are tiled to 1.
+static SmallVector<int64_t> getVectorSizeTileSizes(int64_t rank,
+                                                   int64_t targetDim,
+                                                   int64_t targetDimSize,
+                                                   int64_t vectorSize) {
   SmallVector<int64_t> tileSizes(rank, 1);
-  if (ShapedType::isDynamic(innerDimSize) || innerDimSize >= vectorSize) {
-    tileSizes.back() = vectorSize;
-  } else {
-    tileSizes.back() = innerDimSize;
-  }
+  tileSizes[targetDim] =
+      ShapedType::isDynamic(targetDimSize) || targetDimSize >= vectorSize
+          ? vectorSize
+          : targetDimSize;
   return tileSizes;
 }
 
 /// Derives the tiles sizes to use based on loop ranges, the number of threads,
-/// and the optimal vector size. If |allowMultiDimCollapse| is true then this
+/// and the optimal vector size. If `vectorOutermost` is true, the vector tile
+/// size is set along the outermost loop dimension, instead of the default
+/// innermost dimension. If `allowMultiDimCollapse` is true then this
 /// will attempt to split the optimal vector size along multiple complete dims.
 ///
 /// For example, with a vector size of 8 and loop ranges of [64 x 2 x 4] this
-/// would return tile sizes of [1, 2, 4] if |allowMultiDimCollapse| is true and
+/// would return tile sizes of [1, 2, 4] if `allowMultiDimCollapse` is true and
 /// [1, 1, 4] otherwise. If the loop ranges were instead [64 x 4 x 4] this
 /// would give tile sizes of [1, 1, 4] no matter what because we won't be able
 /// to collapse the vector.transfer_read that results from this choice of tile
 /// size.
-static SmallVector<int64_t>
-getVectorTileSizesFromLoopRanges(SmallVector<int64_t> loopRanges,
-                                 int64_t numThreads, int64_t vectorSize,
-                                 bool allowMultiDimCollapse = true) {
+static SmallVector<int64_t> getVectorTileSizesFromLoopRanges(
+    SmallVector<int64_t> loopRanges, int64_t numThreads, int64_t vectorSize,
+    bool allowMultiDimCollapse = true, bool vectorizeOutermost = false) {
+  int64_t rank = loopRanges.size();
+  int64_t targetDim = vectorizeOutermost ? 0 : rank - 1;
+  int64_t targetRange = loopRanges[targetDim];
+
   // If any loop ranges are dynamic, default to a simple vector size based
   // tile size.
   if (llvm::any_of(loopRanges, &ShapedType::isDynamic)) {
-    return getVectorSizeTileSizes(loopRanges.size(), loopRanges.back(),
-                                  vectorSize);
+    return getVectorSizeTileSizes(rank, targetDim, targetRange, vectorSize);
   }
 
   // If the number of loop trips are indivisible by the number of threads then
-  // also default to just the vector size (i.e. [1, ..., 1, vector_size]).
+  // also default to just the vector size.
   int64_t flatNumTrips = std::accumulate(loopRanges.begin(), loopRanges.end(),
                                          1, std::multiplies<int64_t>());
   if (flatNumTrips % numThreads != 0) {
-    return getVectorSizeTileSizes(loopRanges.size(), loopRanges.back(),
-                                  vectorSize);
+    return getVectorSizeTileSizes(rank, targetDim, targetRange, vectorSize);
   }
-  SmallVector<int64_t> tileSizes(loopRanges.size(), 1);
+  SmallVector<int64_t> tileSizes(rank, 1);
 
   // Let the maximum possible vector size be the minimum between:
   //   - The requested vector size
   //   - The maximum vector size that avoids an exec mask
   int64_t maxVectorSize = std::min(vectorSize, flatNumTrips / numThreads);
 
-  // Bail out to unit vector sizes if the inner most loop range is not divisible
+  // Bail out to unit vector sizes if the target loop range is not divisible
   // by the vector size or vice-versa.
-  int64_t innerMostRange = loopRanges.back();
-  if (innerMostRange % maxVectorSize != 0 &&
-      maxVectorSize % innerMostRange != 0) {
+  if (targetRange % maxVectorSize != 0 && maxVectorSize % targetRange != 0) {
     return tileSizes;
   }
 
-  // Let the inner most tile size be the smaller of the target vector size
-  // and the inner most loop range. If |allowMultiDimCollapse| is false, return
-  // here.
-  tileSizes.back() = std::min(innerMostRange, maxVectorSize);
-  if (innerMostRange >= maxVectorSize || !allowMultiDimCollapse) {
+  // Let the tile size for the target (inner/outer most) dim be the smaller of
+  // the vector size and the target loop range. If `allowMultiDimCollapse` is
+  // false, return here.
+  tileSizes[targetDim] = std::min(targetRange, maxVectorSize);
+  if (targetRange >= maxVectorSize || !allowMultiDimCollapse) {
     return tileSizes;
   }
 
-  maxVectorSize = maxVectorSize / innerMostRange;
-  for (int64_t i = loopRanges.size() - 2, e = 0; i >= e; --i) {
-    // Only increase the tile size if the remaining vector size is divisible
-    // by the loop range (and thus range <= remaining vector size).
-    int64_t range = loopRanges[i];
-    if (maxVectorSize % range != 0) {
-      break;
+  // Only increase the tile size if the remaining vector size is divisible
+  // by the loop range (and thus range <= remaining vector size).
+  maxVectorSize /= targetRange;
+  if (vectorizeOutermost) {
+    for (int64_t i = 1; i < rank; ++i) {
+      int64_t range = loopRanges[i];
+      if (maxVectorSize % range != 0)
+        break;
+      tileSizes[i] = range;
+      maxVectorSize /= range;
     }
-    tileSizes[i] = range;
-    maxVectorSize = maxVectorSize / range;
+  } else {
+    for (int64_t i = rank - 2; i >= 0; --i) {
+      int64_t range = loopRanges[i];
+      if (maxVectorSize % range != 0)
+        break;
+      tileSizes[i] = range;
+      maxVectorSize /= range;
+    }
   }
 
   return tileSizes;
@@ -130,10 +141,21 @@ deriveIm2colOpThreadTileSizes(IREE::LinalgExt::Im2colOp im2colOp,
   int64_t vectorSize = kPreferredCopyNumBits /
                        getElementTypeOrSelf(im2colOp->getResultTypes()[0])
                            .getIntOrFloatBitWidth();
-  // Im2col cannot coalesce past the inner most dim so always default to only
-  // the inner most tile size being the vector size (or smaller).
+
+  // If the im2col input tensor has the batch dim at last, im2col output tensor
+  // has an implicit transpose to move the batch dim in front, and tiling should
+  // be along the batch dim. Currently only a single batch dim is supported for
+  // tiling along the batch dim.
+  unsigned innerDim = im2colOp.getInputRank() - 1;
+  bool singleBatchDimInnermost = im2colOp.getBatchPos().size() == 1 &&
+                                 im2colOp.getBatchPos().back() == innerDim;
+  bool vectorizeOutermost = singleBatchDimInnermost ? true : false;
+
+  // Im2col cannot coalesce past the inner/outer most dim so always default to
+  // only the inner/outer most tile size being the vector size (or smaller).
   return getVectorTileSizesFromLoopRanges(loopRanges, numThreads, vectorSize,
-                                          /*allowMultiDimCollapse=*/false);
+                                          /*allowMultiDimCollapse=*/false,
+                                          vectorizeOutermost);
 }
 
 SmallVector<int64_t> deriveThreadTileSizes(Operation *op) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/DerivedConfigUtils.cpp
@@ -81,8 +81,9 @@ static SmallVector<int64_t> getVectorTileSizesFromLoopRanges(
   }
 
   // Let the tile size for the target dim be the smaller of the vector size and
-  // the target loop range. If `allowMultiDimCollapse` is false, or
-  // `vectorizeOutermost` is true, return here.
+  // the target loop range. Return here, if `allowMultiDimCollapse` is false, or
+  // `vectorizeOutermost` is true, because we don't expect consecutive
+  // dimensions to be vectorizable contiguously for these cases.
   tileSizes[targetDim] = std::min(targetRange, maxVectorSize);
   if (targetRange >= maxVectorSize || !allowMultiDimCollapse ||
       vectorizeOutermost) {


### PR DESCRIPTION
In backward convolutions (e.g., `conv2d_chwn_chwf`), the im2col input tensor has the batch dim as innermost, whereas the output tensor implicitly transposes the batch dimension to the outermost. To enable efficient `vector.load` operations on the im2col input, we need to tile along the contiguous batch dimension and assign the vector size to the outermost tile dimension.

This PR together with https://github.com/iree-org/iree/pull/20633 will improve the performance of backward convolutions. For example, for the following conv
```
%7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d1 + d5, d2 + d6, d3)>, affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d4, d5, d6, d0)>, affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%3, %4 : tensor<16x26x18x288xbf16>, tensor<16x24x16x288xbf16>) outs(%6 : tensor<288x3x3x288xf32>) {
    ^bb0(%in: bf16, %in_0: bf16, %out: f32):
      %10 = arith.extf %in : bf16 to f32
      %11 = arith.extf %in_0 : bf16 to f32
      %12 = arith.mulf %10, %11 : f32
      %13 = arith.addf %out, %12 : f32
      linalg.yield %13 : f32
    } -> tensor<288x3x3x288xf32>
```
The runtime is reduced from 235us to 140us.