### PR TITLE
[Codegen] Drop read_only from LoadFromMemrefOp.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
@@ -180,15 +180,11 @@ def IREECodegen_LoadFromMemrefOp : Op<IREECodegen_Dialect, "load_from_memref",
   let summary = [{loads a tensor from a memref}];
   let description = [{
     Loads a tensor from a memref with a compatible shape and the same element
-    type. The read_only attribute indicates that the source buffer from which
-    the tensor is read is a read only buffer. This hint can be used by
-    bufferization to determine whether or not the buffer that this op reads
-    from may be written.
+    type.
   }];
 
   let arguments = (ins
-    AnyStridedMemRef:$source,
-    UnitAttr:$read_only
+    AnyStridedMemRef:$source
   );
   let results = (outs
     AnyRankedTensor:$result

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
@@ -11,17 +11,6 @@ func.func @load_from_memref(%arg0: memref<4xf32>) -> tensor<4xf32> {
 
 // -----
 
-func.func @load_from_memref_read_only(%arg0: memref<4xf32>) -> tensor<4xf32> {
-  %value = iree_codegen.load_from_memref %arg0 {read_only} : memref<4xf32> -> tensor<4xf32>
-  return %value : tensor<4xf32>
-}
-// CHECK-LABEL: func.func @load_from_memref_read_only(
-// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]
-// CHECK:         iree_codegen.load_from_memref %[[ARG0]] {read_only}
-// CHECK-SAME:      : memref<4xf32> -> tensor<4xf32>
-
-// -----
-
 func.func @load_from_memref_mixed_static_dynamic(%arg0: memref<?x4xf32>) -> tensor<4x?xf32> {
   %value = iree_codegen.load_from_memref %arg0 : memref<?x4xf32> -> tensor<4x?xf32>
   return %value : tensor<4x?xf32>


### PR DESCRIPTION
The operand was added for bufferization, which is not used in the implementation. The revision drops the unused argument.