### PR TITLE
[Encoding] Add convertType interface to generalize type conversion

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
@@ -7,13 +7,19 @@
 #include "iree/compiler/Codegen/Common/EncodingUtils.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingTypes.h"
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtTypes.h"
+#include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/IR/BuiltinAttributes.h"
 
 #include <optional>
+
+#define DEBUG_TYPE "iree-codegen-encoding-utils"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
 namespace mlir::iree_compiler {
 
@@ -21,6 +27,36 @@ using IREE::Codegen::MaterializeEncodingInfo;
 using IREE::Encoding::EncodingAttr;
 using IREE::Encoding::getEncodingAttr;
 using IREE::Encoding::getEncodingContractionDims;
+using IREE::Encoding::PadEncodingLayoutAttr;
+using IREE::Encoding::SerializableEncodingAttrInterface;
+
+// Returns the layout as a SerializableEncodingAttrInterface, or nullptr if this
+// is not the only layout or if there's no encoding at all.
+static SerializableEncodingAttrInterface
+getSerializableEncodingAttr(IREE::Codegen::LayoutAttrInterface layoutAttr,
+                            RankedTensorType type) {
+  if (!type.getEncoding()) {
+    return nullptr;
+  }
+  auto encoding = dyn_cast<IREE::Encoding::LayoutAttr>(type.getEncoding());
+  if (encoding) {
+    ArrayAttr layouts = encoding.getLayouts();
+    if (layouts.size() != 1) {
+      return nullptr;
+    }
+    return dyn_cast<SerializableEncodingAttrInterface>(*layouts.begin());
+  }
+  auto encodingResolver =
+      dyn_cast<IREE::Encoding::EncodingLayoutResolverAttrInterface>(layoutAttr);
+  if (!encodingResolver) {
+    return nullptr;
+  }
+  Attribute resolvedEncoding = encodingResolver.getLayout(type);
+  LDBG("Unresolved type: " << type);
+  LDBG("layoutAttr: " << layoutAttr);
+  LDBG("Resolved into: " << resolvedEncoding);
+  return dyn_cast<SerializableEncodingAttrInterface>(resolvedEncoding);
+}
 
 MaterializeEncodingTypeConverter::MaterializeEncodingTypeConverter(
     IREE::Codegen::LayoutAttrInterface layoutAttr)
@@ -29,40 +65,37 @@ MaterializeEncodingTypeConverter::MaterializeEncodingTypeConverter(
   addConversion([](IndexType indexType) { return indexType; });
   addConversion([](FloatType floatType) { return floatType; });
   addConversion([](MemRefType memrefType) { return memrefType; });
-  addConversion([=](RankedTensorType type) -> RankedTensorType {
-    // For a given tensor type with an encoding, return the materialized
-    // type to use for it. If no encoding is set, then return the tensor type
-    // itself.
-    MaterializeEncodingInfo encodingInfo = getEncodingInfo(type);
-    if (IREE::Codegen::isIdentityLayout(encodingInfo)) {
-      return type.dropEncoding();
+  addConversion([=](RankedTensorType type) {
+    SerializableEncodingAttrInterface serializableEncodingAttr =
+        getSerializableEncodingAttr(getLayoutAttr(), type);
+    // TODO(jornt): The isa<IREE::Encoding::PadEncodingLayoutAttr> check is
+    // needed because PadEncodingLayoutAttr is a serializable attribute, but it
+    // relies on its own type conversion for now. Once PadEncodingLayoutAttr
+    // implements `convertType`, this can be removed.
+    if (serializableEncodingAttr &&
+        !isa<IREE::Encoding::PadEncodingLayoutAttr>(serializableEncodingAttr)) {
+      return cast<RankedTensorType>(serializableEncodingAttr.convertType(type));
     }
-    auto packedType = cast<RankedTensorType>(linalg::PackOp::inferPackedType(
-        type, encodingInfo.innerTileSizes, encodingInfo.innerDimsPos,
-        encodingInfo.outerDimsPerm));
-
-    // There is no swizzle, we are already done. Typically the case on CPU.
-    if (!encodingInfo.swizzle) {
-      return packedType;
-    }
-
-    // There is a swizzle, we need to handle it. Typically the case on GPU.
-    auto swizzle = *encodingInfo.swizzle;
-    SmallVector<int64_t> newShape(
-        packedType.getShape().drop_back(encodingInfo.innerTileSizes.size()));
-    SmallVector<int64_t> swizzledTileShape =
-        IREE::Codegen::getExpandedTileShape(swizzle.expandShape);
-    applyPermutationToVector(swizzledTileShape, swizzle.permutation);
-    newShape.append(swizzledTileShape);
-    return RankedTensorType::get(newShape, packedType.getElementType());
+    return type.dropEncoding();
   });
-  addConversion([&](IREE::TensorExt::DispatchTensorType dispatchTensorType)
-                    -> IREE::TensorExt::DispatchTensorType {
-    Type boundType = dispatchTensorType.getBoundType();
-    Type convertedBoundType = convertType(boundType);
-    if (convertedBoundType == boundType) {
+  addConversion([&](IREE::TensorExt::DispatchTensorType dispatchTensorType) {
+    auto boundType =
+        dyn_cast<RankedTensorType>(dispatchTensorType.getBoundType());
+    if (!boundType || !boundType.getEncoding()) {
       return dispatchTensorType;
     }
+    SerializableEncodingAttrInterface serializableEncodingAttr =
+        getSerializableEncodingAttr(getLayoutAttr(), boundType);
+    // TODO(jornt): The isa<IREE::Encoding::PadEncodingLayoutAttr> check is
+    // needed because PadEncodingLayoutAttr is a serializable attribute, but it
+    // relies on its own type conversion for now. Once PadEncodingLayoutAttr
+    // implements `convertType`, this can be removed.
+    if (serializableEncodingAttr &&
+        !isa<IREE::Encoding::PadEncodingLayoutAttr>(serializableEncodingAttr)) {
+      return cast<IREE::TensorExt::DispatchTensorType>(
+          serializableEncodingAttr.convertType(dispatchTensorType));
+    }
+    Type convertedBoundType = convertType(boundType);
     return IREE::TensorExt::DispatchTensorType::get(
         dispatchTensorType.getAccess(), convertedBoundType);
   });

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/BUILD.bazel
@@ -16,12 +16,14 @@ iree_compiler_cc_library(
     name = "ExternalModels",
     srcs = [
         "CPUEncodingExternalModels.cpp",
+        "CodegenExternalModels.cpp",
         "GPUEncodingExternalModels.cpp",
         "Interfaces.cpp",
         "Utils.cpp",
     ],
     hdrs = [
         "CPUEncodingExternalModels.h",
+        "CodegenExternalModels.h",
         "GPUEncodingExternalModels.h",
         "Interfaces.h",
         "Utils.h",
@@ -34,6 +36,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils:KnownTargets",
         "//compiler/src/iree/compiler/Codegen/Utils",
         "//compiler/src/iree/compiler/Dialect/Encoding/IR",
+        "//compiler/src/iree/compiler/Dialect/TensorExt/IR",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:IR",

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CMakeLists.txt
@@ -15,11 +15,13 @@ iree_cc_library(
     ExternalModels
   HDRS
     "CPUEncodingExternalModels.h"
+    "CodegenExternalModels.h"
     "GPUEncodingExternalModels.h"
     "Interfaces.h"
     "Utils.h"
   SRCS
     "CPUEncodingExternalModels.cpp"
+    "CodegenExternalModels.cpp"
     "GPUEncodingExternalModels.cpp"
     "Interfaces.cpp"
     "Utils.cpp"
@@ -36,6 +38,7 @@ iree_cc_library(
     iree::compiler::Codegen::Dialect::GPU::TargetUtils::KnownTargets
     iree::compiler::Codegen::Utils
     iree::compiler::Dialect::Encoding::IR
+    iree::compiler::Dialect::TensorExt::IR
   PUBLIC
 )
 

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -638,7 +638,7 @@ struct CPUHostEncodingLayoutResolverAttrInterface final
 };
 
 struct CPUHostSerializableEncodingAttrInterface final
-    : IREE::Encoding::SerializableEncodingAttrInterface::ExternalModel<
+    : HostSerializableEncodingAttrInterfaceExternalModelBase<
           CPUHostSerializableEncodingAttrInterface, CPUEncodingLayoutAttr> {
 
   Value calculateStorageSizeInBytes(Attribute attr, Location loc,
@@ -769,7 +769,7 @@ struct VMVXHostEncodingLayoutResolverAttrInterface final
 };
 
 struct VMVXHostSerializableEncodingAttrInterface final
-    : IREE::Encoding::SerializableEncodingAttrInterface::ExternalModel<
+    : HostSerializableEncodingAttrInterfaceExternalModelBase<
           VMVXHostSerializableEncodingAttrInterface, VMVXEncodingLayoutAttr> {
   Value calculateStorageSizeInBytes(Attribute attr, Location loc,
                                     OpBuilder &builder, RankedTensorType type,

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CodegenExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CodegenExternalModels.cpp
@@ -1,0 +1,65 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/ExternalInterfaces/CodegenExternalModels.h"
+
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
+#include "iree/compiler/Dialect/Encoding/IR/EncodingTypes.h"
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtTypes.h"
+
+namespace mlir::iree_compiler::IREE::Codegen {
+
+using IREE::TensorExt::DispatchTensorType;
+
+struct EncodingNopHostEncodingLayoutResolverAttrInterface final
+    : IREE::Encoding::EncodingLayoutResolverAttrInterface::ExternalModel<
+          EncodingNopHostEncodingLayoutResolverAttrInterface,
+          EncodingNopLayoutAttr> {
+  Attribute cloneWithSimplifiedConfig(Attribute attr,
+                                      DictionaryAttr config) const {
+    return attr;
+  }
+
+  Attribute getLayout(Attribute attr, RankedTensorType type) const {
+    return attr;
+  }
+};
+
+struct EncodingNopHostSerializableEncodingAttrInterface final
+    : IREE::Encoding::SerializableEncodingAttrInterface::ExternalModel<
+          EncodingNopHostSerializableEncodingAttrInterface,
+          EncodingNopLayoutAttr> {
+public:
+  Type convertType(Attribute attr, Type type) const {
+    return TypeSwitch<Type, Type>(type)
+        .Case<RankedTensorType>([&](auto rankedTensorType) {
+          return rankedTensorType.dropEncoding();
+        })
+        .Case<DispatchTensorType>([&](auto dispatchTensorType) {
+          auto boundType =
+              dyn_cast<RankedTensorType>(dispatchTensorType.getBoundType());
+          if (!boundType || !boundType.getEncoding()) {
+            return dispatchTensorType;
+          }
+          Type convertedBoundType = convertType(attr, boundType);
+          return DispatchTensorType::get(dispatchTensorType.getAccess(),
+                                         convertedBoundType);
+        })
+        .Default([&](auto concreteType) { return concreteType; });
+  }
+};
+
+void registerCodegenExternalModels(DialectRegistry &registry) {
+  registry.addExtension(
+      +[](MLIRContext *ctx, IREE::Codegen::IREECodegenDialect *dialect) {
+        EncodingNopLayoutAttr::attachInterface<
+            EncodingNopHostEncodingLayoutResolverAttrInterface,
+            EncodingNopHostSerializableEncodingAttrInterface>(*ctx);
+      });
+}
+
+} // namespace mlir::iree_compiler::IREE::Codegen

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CodegenExternalModels.h
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CodegenExternalModels.h
@@ -1,0 +1,20 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_EXTERNALINTERFACES_CODEGENEXTERNALMODELS_H_
+#define IREE_COMPILER_CODEGEN_EXTERNALINTERFACES_CODEGENEXTERNALMODELS_H_
+
+namespace mlir {
+class DialectRegistry;
+} // namespace mlir
+
+namespace mlir::iree_compiler::IREE::Codegen {
+
+void registerCodegenExternalModels(DialectRegistry &registry);
+
+} // namespace mlir::iree_compiler::IREE::Codegen
+
+#endif // IREE_COMPILER_CODEGEN_EXTERNALINTERFACES_CODEGENEXTERNALMODELS_H_

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -371,7 +371,7 @@ struct GPUDeviceEncodingLayoutResolverAttrInterface
 };
 
 struct GPUHostSerializableEncodingAttrInterface final
-    : IREE::Encoding::SerializableEncodingAttrInterface::ExternalModel<
+    : HostSerializableEncodingAttrInterfaceExternalModelBase<
           GPUHostSerializableEncodingAttrInterface, GPUEncodingLayoutAttr> {
 
   Value calculateStorageSizeInBytes(Attribute attr, Location loc,

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Interfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Interfaces.cpp
@@ -7,11 +7,13 @@
 #include "iree/compiler/Codegen/ExternalInterfaces/Interfaces.h"
 
 #include "iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.h"
+#include "iree/compiler/Codegen/ExternalInterfaces/CodegenExternalModels.h"
 #include "iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.h"
 
 namespace mlir::iree_compiler {
 
 void registerCodegenExternalInterfaces(DialectRegistry &registry) {
+  IREE::Codegen::registerCodegenExternalModels(registry);
   IREE::CPU::registerCPUEncodingExternalModels(registry);
   IREE::GPU::registerGPUEncodingExternalModels(registry);
 }

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.h
@@ -9,12 +9,18 @@
 
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.h"
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtTypes.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/ValueRange.h"
 
 namespace mlir::iree_compiler::IREE {
+
+using IREE::Codegen::MaterializeEncodingInfo;
+using IREE::TensorExt::DispatchTensorType;
 
 static const char kEncodingInfoAttrName[] = "encoding_info";
 
@@ -44,6 +50,87 @@ public:
       }
     }
     return impl->getEncodingInfoImpl(attr, type);
+  }
+};
+
+static std::optional<MaterializeEncodingInfo>
+getEncodingInfoFromLayouts(RankedTensorType type) {
+  auto layoutAttr =
+      dyn_cast_or_null<IREE::Encoding::LayoutAttr>(type.getEncoding());
+  if (!layoutAttr) {
+    return std::nullopt;
+  }
+  ArrayRef<Attribute> layouts = layoutAttr.getLayouts().getValue();
+  assert(layouts.size() == 1 && "only single layout is supported");
+  if (auto layout = dyn_cast<IREE::Codegen::LayoutAttrInterface>(layouts[0])) {
+    return layout.getEncodingInfo(type);
+  }
+  return std::nullopt;
+}
+
+template <typename DeviceSerializableEncodingAttrInterface,
+          typename EncodingLayoutAttr>
+struct HostSerializableEncodingAttrInterfaceExternalModelBase
+    : public IREE::Encoding::SerializableEncodingAttrInterface::ExternalModel<
+          DeviceSerializableEncodingAttrInterface, EncodingLayoutAttr> {
+public:
+  MaterializeEncodingInfo getEncodingInfo(EncodingLayoutAttr layoutAttr,
+                                          RankedTensorType type) const {
+    // If the layout is present in the encoding, use it directly. It means that
+    // the layout is already resolved and some information could be dropped
+    // during the lowering. Thus, we prioritize the resolved layout.
+    if (std::optional<MaterializeEncodingInfo> maybeEncodingInfo =
+            getEncodingInfoFromLayouts(type)) {
+      return maybeEncodingInfo.value();
+    }
+    return cast<IREE::Codegen::LayoutAttrInterface>(layoutAttr)
+        .getEncodingInfo(type);
+  }
+
+  Type convertType(Attribute attr, Type type) const {
+    EncodingLayoutAttr layoutAttr = cast<EncodingLayoutAttr>(attr);
+    return TypeSwitch<Type, Type>(type)
+        .template Case<RankedTensorType>([&](auto type) {
+          // For a given tensor type with an encoding, return the materialized
+          // type to use for it. If no encoding is set, then return the tensor
+          // type itself.
+          MaterializeEncodingInfo encodingInfo =
+              getEncodingInfo(layoutAttr, type);
+          if (IREE::Codegen::isIdentityLayout(encodingInfo)) {
+            return type.dropEncoding();
+          }
+          auto packedType =
+              cast<RankedTensorType>(linalg::PackOp::inferPackedType(
+                  type, encodingInfo.innerTileSizes, encodingInfo.innerDimsPos,
+                  encodingInfo.outerDimsPerm));
+
+          // There is no swizzle, we are already done. Typically the case on
+          // CPU.
+          if (!encodingInfo.swizzle) {
+            return packedType;
+          }
+
+          // There is a swizzle, we need to handle it. Typically the case on
+          // GPU.
+          auto swizzle = *encodingInfo.swizzle;
+          SmallVector<int64_t> newShape(packedType.getShape().drop_back(
+              encodingInfo.innerTileSizes.size()));
+          SmallVector<int64_t> swizzledTileShape =
+              IREE::Codegen::getExpandedTileShape(swizzle.expandShape);
+          applyPermutationToVector(swizzledTileShape, swizzle.permutation);
+          newShape.append(swizzledTileShape);
+          return RankedTensorType::get(newShape, packedType.getElementType());
+        })
+        .template Case<DispatchTensorType>([&](auto dispatchTensorType) {
+          Type boundType = dispatchTensorType.getBoundType();
+          Type convertedBoundType = convertType(attr, boundType);
+          if (convertedBoundType == boundType) {
+            return dispatchTensorType;
+          }
+          return DispatchTensorType::get(dispatchTensorType.getAccess(),
+                                         convertedBoundType);
+        })
+        .Default([&](auto concreteType) { return concreteType; });
   }
 };
 

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
@@ -95,6 +95,7 @@ def IREEEncoding_SerializableEncodingAttrInterface :
     - `isSerialized`: checks if the encoding is serialized or not.
     - `cloneWithLayouts`: creates a serializable encoding with the layouts
       information.
+    - `convertType`: converts a type to materialized form.
     - The rest of methods that interpret the encodings. E.g.,
       `calculateStorageSizeInBytes` is the method to parse layouts and produce
       the storage size in bytes.
@@ -196,7 +197,22 @@ def IREEEncoding_SerializableEncodingAttrInterface :
         assert(false && "unimplemented interface method");
         return {};
       }]
-    >
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns the materialized form for the provided type.
+      }],
+      /*retTy=*/"::mlir::Type",
+      /*methodName=*/"convertType",
+      /*args=*/(ins
+        "::mlir::Type":$type
+      ),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        assert(false && "unimplemented interface method");
+        return type;
+      }]
+    >,
   ];
 
   let extraClassDeclaration = [{


### PR DESCRIPTION
Adds the `convertType` interface method to `SerializableEncodingAttrInterface`. This is the first stage for collapsing MaterializeEncodingIntoPadding into MaterializeEncoding, see https://github.com/iree-org/iree/issues/20160.

Note that this removes the need for MaterializePadEncodingTypeConverter if the `convertType` method is implemented for `PadEncodingLayoutAttr`, however, this is intentionally left out of the PR as @MaheshRavishankar is looking at adjusting the MaterializeEncodingIntoPadding for dynamic padding. To check what it looks like with MaterializePadEncodingTypeConverter  collapsed into MaterializeEncodingTypeConverter you can view this branch instead: https://github.com/iree-org/iree/compare/main...jtuyls:materialize-encoding-into-padding-convert-type?expand=1.

Second note that while the type conversion for `EncodingNopLayoutAttr` was previously combined with the common implementation for `CPUEncodingLayoutAttr`, `VMVXEncodingLayoutAttr` and `GPUEncodingLayoutAttr`, this PR provides a minimal standalone implementation for clarity on what's going on. `CPUEncodingLayoutAttr`, `VMVXEncodingLayoutAttr` and `GPUEncodingLayoutAttr`  still share the same implementation as they did previously through the `convertType` implementation in HostSerializableEncodingAttrInterfaceExternalModelBase. `EncodingNopLayoutAttr` now implements both IREE::Encoding::EncodingLayoutResolverAttrInterface and IREE::Encoding::SerializableEncodingAttrInterface to go down the same path as the above attributes, but provides its own implementation.