### PR TITLE
[GPU] Enable vector distribute pipeline for Matvecs by default

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -521,11 +521,14 @@ static VectorValue broadcastToShape(RewriterBase &rewriter, Value source,
 
   VectorType broadcastedVecType =
       VectorType::get(leadingBroadcastShape, getElementTypeOrSelf(source));
-  Value broadcasted = rewriter.create<vector::BroadcastOp>(
+  VectorValue broadcasted = rewriter.create<vector::BroadcastOp>(
       source.getLoc(), broadcastedVecType, source);
 
   // Transpose the broadcasted dims to the right place.
   SmallVector<int64_t> inversePerm = invertPermutationVector(perm);
+  if (isIdentityPermutation(inversePerm)) {
+    return broadcasted;
+  }
   return rewriter.create<vector::TransposeOp>(source.getLoc(), broadcasted,
                                               inversePerm);
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -68,11 +68,6 @@ llvm::cl::opt<bool> clLLVMGPUVectorizePipeline(
     llvm::cl::desc("forces use of the legacy LLVMGPU vectorize pipeline"),
     llvm::cl::init(false));
 
-llvm::cl::opt<bool> clGPUTestVectorDistributeOnReduction(
-    "iree-codegen-llvmgpu-test-vector-distribution-on-reduction",
-    llvm::cl::desc("test vector distribute on reduction."),
-    llvm::cl::init(false));
-
 llvm::cl::opt<bool> clGPUEnableVectorDistribution(
     "iree-codegen-llvmgpu-use-vector-distribution",
     llvm::cl::desc("enable the usage of the vector distribution pipeline"),
@@ -139,6 +134,8 @@ struct TileWorkgroupSizePair {
 constexpr unsigned softwarePipelineDepthSimt = 0;
 
 } // namespace
+
+static bool isMatvecLike(linalg::LinalgOp linalgOp);
 
 bool isROCmBackend(IREE::GPU::TargetAttr target) {
   return target.getArch().starts_with("gfx");
@@ -433,6 +430,12 @@ getVectorDistributeReductionConfig(linalg::LinalgOp op,
     return linalg::isaContractionOpInterface(linalgOp) &&
            linalgOp.getNumParallelLoops() >= 2;
   };
+
+  // Currently, only the skinny matmul pass the numerics.
+  // TODO: Enable it for other reduction dispatches.
+  if (!isMatmulLike(op)) {
+    return failure();
+  }
 
   // TODO: This is enabled for matvec on ROCm for now. We should
   // validate this strategy and extend to more linalg generics and to CUDA.
@@ -2987,12 +2990,10 @@ static LogicalResult setRootConfig(IREE::GPU::TargetAttr target,
       LDBG("Contract Config");
       return success();
     }
-    if (clGPUTestVectorDistributeOnReduction) {
-      if (succeeded(setReductionVectorDistributionConfig(target, entryPointFn,
-                                                         linalgOp))) {
-        LDBG("Vector Distribution Subgroup Reduction Config");
-        return success();
-      }
+    if (succeeded(setReductionVectorDistributionConfig(target, entryPointFn,
+                                                       linalgOp))) {
+      LDBG("Vector Distribution Subgroup Reduction Config");
+      return success();
     }
     if (succeeded(setWarpReductionConfig(target, entryPointFn, linalgOp))) {
       LDBG("Warp Reduction Config");

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -272,6 +272,12 @@ static CodeGenPipeline getTensorCorePipeline(Type elementType) {
 //====---------------------------------------------------------------------===//
 // Vector Distribution Reduction Pipeline Configuration
 //====---------------------------------------------------------------------===//
+//
+
+static bool isMatmulLike(linalg::LinalgOp &linalgOp) {
+  return linalg::isaContractionOpInterface(linalgOp) &&
+         linalgOp.getNumParallelLoops() >= 1;
+};
 
 /// Check if `op` is a linalg.reduce or a linalg.generic that has at least one
 /// reduction iterator.
@@ -428,11 +434,6 @@ getVectorDistributeReductionConfig(linalg::LinalgOp op,
   // Setting the config for operation with atleast one reduction dimension.
   SmallVector<int64_t> partialReductionTileSizes(op.getNumLoops(), 0);
   int64_t lastReductionDim = reductionDims.back();
-
-  auto isMatmulLike = [](linalg::LinalgOp &linalgOp) -> bool {
-    return linalg::isaContractionOpInterface(linalgOp) &&
-           linalgOp.getNumParallelLoops() >= 2;
-  };
 
   // TODO: This is enabled for matvec on ROCm for now. We should
   // validate this strategy and extend to more linalg generics and to CUDA.
@@ -2987,11 +2988,7 @@ static LogicalResult setRootConfig(IREE::GPU::TargetAttr target,
       LDBG("Contract Config");
       return success();
     }
-    // TODO: Skinny matmuls go through the vectordistribute pipeline by default.
-    auto isMatmulLike = [](linalg::LinalgOp &linalgOp) -> bool {
-      return linalg::isaContractionOpInterface(linalgOp) &&
-             linalgOp.getNumParallelLoops() >= 1;
-    };
+    // Skinny matmuls go through the vectordistribute pipeline by default.
     if (clGPUTestVectorDistributeOnReduction || isMatmulLike(linalgOp)) {
       if (succeeded(setReductionVectorDistributionConfig(target, entryPointFn,
                                                          linalgOp))) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matvec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/config_matvec.mlir
@@ -73,12 +73,16 @@ func.func @vmt1() attributes {hal.executable.target = #executable_target_rocm_hs
   return
 }
 
-//   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 8], [0, 0, 512]{{\]}}>
-//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUWarpReduction workgroup_size = [64, 1, 1] subgroup_size = 64>
+//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
 // CHECK-LABEL: func.func @vmt1()
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
-//  CHECK-SAME:       lowering_config = #[[$CONFIG]]
+//  CHECK-SAME:    attrs =  {lowering_config = #iree_gpu.lowering_config<{
+//  CHECK-SAME:               partial_reduction = [0, 0, 512],
+//  CHECK-SAME:               subgroup_basis = {{\[}}[1, 1, 1], [0, 1, 2]],
+//  CHECK-SAME:               thread = [0, 0, 8], thread_basis = {{\[}}[1, 1, 64], [0, 1, 2]],
+//  CHECK-SAME:               workgroup = [1, 8, 0]
+
 
 // -----
 
@@ -111,12 +115,15 @@ func.func @matvec_like_no_m_dim() attributes {hal.executable.target = #executabl
   return
 }
 
-//   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[8], [0, 512]{{\]}}>
-//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUWarpReduction workgroup_size = [64, 1, 1] subgroup_size = 64>
+//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
 // CHECK-LABEL: func.func @matvec_like_no_m_dim()
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
-//  CHECK-SAME:       lowering_config = #[[$CONFIG]]
+//  CHECK-SAME:    attrs =  {lowering_config = #iree_gpu.lowering_config<{
+//  CHECK-SAME:               partial_reduction = [0, 512],
+//  CHECK-SAME:               subgroup_basis = {{\[}}[1, 1], [0, 1]],
+//  CHECK-SAME:               thread = [0, 8], thread_basis = {{\[}}[1, 64], [0, 1]],
+//  CHECK-SAME:               workgroup = [8, 0]
 
 // -----
 
@@ -149,12 +156,15 @@ func.func @matvec_unit_n_dim() attributes {hal.executable.target = #executable_t
   return
 }
 
-//   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[8, 1], [0, 0, 512]{{\]}}>
-//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUWarpReduction workgroup_size = [64, 1, 1] subgroup_size = 64>
+//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
 // CHECK-LABEL: func.func @matvec_unit_n_dim()
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
-//  CHECK-SAME:       lowering_config = #[[$CONFIG]]
+//  CHECK-SAME:    attrs =  {lowering_config = #iree_gpu.lowering_config<{
+//  CHECK-SAME:               partial_reduction = [0, 0, 512],
+//  CHECK-SAME:               subgroup_basis = {{\[}}[1, 1, 1], [0, 1, 2]],
+//  CHECK-SAME:               thread = [0, 0, 8], thread_basis = {{\[}}[1, 1, 64], [0, 1, 2]],
+//  CHECK-SAME:               workgroup = [8, 1, 0]
 
 // -----
 
@@ -189,12 +199,15 @@ func.func @vmt2() attributes {hal.executable.target = #executable_target_rocm_hs
   return
 }
 
-//   CDNA3-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 8], [0, 0, 512]{{\]}}>
-//   CDNA3-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUWarpReduction workgroup_size = [64, 1, 1] subgroup_size = 32>
+//   CDNA3-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 32
 // CDNA3-LABEL: func.func @vmt2()
 //  CDNA3-SAME:     translation_info = #[[$TRANSLATION]]
 //       CDNA3:   linalg.generic
-//  CDNA3-SAME:       lowering_config = #[[$CONFIG]]
+//  CDNA3-SAME:    attrs =  {lowering_config = #iree_gpu.lowering_config<{
+//  CDNA3-SAME:               partial_reduction = [0, 0, 512],
+//  CDNA3-SAME:               subgroup_basis = {{\[}}[1, 1, 2], [0, 1, 2]],
+//  CDNA3-SAME:               thread = [0, 0, 8], thread_basis = {{\[}}[1, 1, 32], [0, 1, 2]],
+//  CDNA3-SAME:               workgroup = [1, 8, 0]
 
 // -----
 
@@ -244,12 +257,16 @@ func.func @i4_dequant_matvec() {
 
 // TODO: We should process multiple rows per subgroup.
 
-//   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1], [0, 4, 128]{{\]}}>
-//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUWarpReduction workgroup_size = [64, 1, 1] subgroup_size = 64>
+//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 64
 //       CHECK: func.func @i4_dequant_matvec()
 //  CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
-//  CHECK-SAME:       lowering_config = #[[$CONFIG]]
+//       CHECK:   linalg.generic
+//  CHECK-SAME:    attrs =  {lowering_config = #iree_gpu.lowering_config<{
+//  CHECK-SAME:               partial_reduction = [0, 1, 128],
+//  CHECK-SAME:               subgroup_basis = {{\[}}[1, 1, 1], [0, 1, 2]],
+//  CHECK-SAME:               thread = [0, 1, 2], thread_basis = {{\[}}[1, 1, 64], [0, 1, 2]],
+//  CHECK-SAME:               workgroup = [8, 0, 0]
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
@@ -698,9 +698,13 @@ func.func @i4_dequant_matvec() {
   return
 }
 
-//   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 1], [0, 0, 32]{{\]}}>
-//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUWarpReduction workgroup_size = [32, 1, 1] subgroup_size = 32>
-// CHECK-LABEL: func.func @i4_dequant_matvec()
-//  CHECK-SAME:   translation_info = #[[$TRANSLATION]]
+//      CHECK: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<pipeline = LLVMGPUVectorDistribute workgroup_size = [64, 1, 1] subgroup_size = 32
+//      CHECK: func.func @i4_dequant_matvec()
+// CHECK-SAME:     translation_info = #[[$TRANSLATION]]
 //       CHECK:   linalg.generic
-//  CHECK-SAME:     lowering_config = #[[$CONFIG]]
+//       CHECK:   linalg.generic
+//  CHECK-SAME:    attrs =  {lowering_config = #iree_gpu.lowering_config<{
+//  CHECK-SAME:               partial_reduction = [0, 0, 256],
+//  CHECK-SAME:               subgroup_basis = {{\[}}[1, 1, 2], [0, 1, 2]],
+//  CHECK-SAME:               thread = [0, 0, 4], thread_basis = {{\[}}[1, 1, 32], [0, 1, 2]],
+//  CHECK-SAME:               workgroup = [1, 1, 0]


### PR DESCRIPTION
All the skinny matmuls and matvecs now go through vector distribute pipeline.