### PR TITLE
[Im2col] Fix bug when there is no batch dimension

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/AggregatedOpInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/AggregatedOpInterfaceImpl.cpp
@@ -879,8 +879,8 @@ FailureOr<SmallVector<Value>> Im2colOp::decomposeOperation(OpBuilder &b) {
 
   // Set the batch and K size for the input tensor.
   const int64_t kPos = getKPos().front();
-  const int64_t bPos = getBatchPos().front();
   if (contiguousAlongB) {
+    const int64_t bPos = getBatchPos().front();
     sliceSizes[bPos] = innerInputTileSize;
   } else {
     sliceSizes[kPos] = innerInputTileSize;


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/iree-org/iree/pull/20633, that when `getBatchPos()` is empty, `getBatchPos().front()` will cause a crash. Move it inside the condition of `contiguousAlongB`, since this condition guarantees the batch dimension is non-empty.