### PR TITLE
Adding IREE_ALLOCATOR_DEFAULT_CTL support and iree_allocator_default.

### DIFF
--- a/build_tools/cmake/static_linker_test.c.in
+++ b/build_tools/cmake/static_linker_test.c.in
@@ -103,13 +103,13 @@ iree_status_t Run() {
 
   if (iree_status_is_ok(status)) {
     status = iree_runtime_instance_create(&instance_options,
-                                          iree_allocator_system(), &instance);
+                                          iree_allocator_default(), &instance);
   }
 
   // Create local device with static loader.
   iree_hal_device_t* device = NULL;
   if (iree_status_is_ok(status)) {
-    status = create_device_with_static_loader(iree_allocator_system(), &device);
+    status = create_device_with_static_loader(iree_allocator_default(), &device);
   }
 
   // Session configuration (one per loaded module to hold module state).

--- a/compiler/src/iree/compiler/ConstEval/Runtime.cpp
+++ b/compiler/src/iree/compiler/ConstEval/Runtime.cpp
@@ -152,12 +152,12 @@ LogicalResult FunctionCall::initialize(Location loc) {
   iree_status_t status = iree_ok_status();
   if (iree_status_is_ok(status)) {
     status = iree_vm_list_create(iree_vm_make_undefined_type_def(), argCapacity,
-                                 iree_allocator_system(), &inputs);
+                                 iree_allocator_default(), &inputs);
   }
   if (iree_status_is_ok(status)) {
     status =
         iree_vm_list_create(iree_vm_make_undefined_type_def(), resultCapacity,
-                            iree_allocator_system(), &outputs);
+                            iree_allocator_default(), &outputs);
   }
   return handleRuntimeError(loc, status);
 }
@@ -246,7 +246,7 @@ LogicalResult FunctionCall::addBufferViewArgumentAttr(
           loc,
           iree_hal_buffer_view_create(buffer->get(), rank, shape, elementType,
                                       IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
-                                      iree_allocator_system(), &bufferView))))
+                                      iree_allocator_default(), &bufferView))))
     return failure();
 
   return handleRuntimeError(
@@ -345,7 +345,7 @@ LogicalResult FunctionCall::invoke(Location loc, StringRef name) {
                                                 IREE_VM_INVOCATION_FLAG_NONE,
                                                 /*policy=*/nullptr,
                                                 inputs.get(), outputs.get(),
-                                                iree_allocator_system()));
+                                                iree_allocator_default()));
 }
 
 LogicalResult FunctionCall::getResultAsAttr(Location loc, size_t index,
@@ -457,12 +457,12 @@ LogicalResult CompiledBinary::initialize(Location loc, void *data,
   if (iree_status_is_ok(status)) {
     status = iree_hal_driver_registry_try_create(
         runtime.registry, iree_make_cstring_view("local-task"),
-        iree_allocator_system(), &driver);
+        iree_allocator_default(), &driver);
   }
 
   if (iree_status_is_ok(status)) {
     status = iree_hal_driver_create_default_device(
-        driver, iree_allocator_system(), &device);
+        driver, iree_allocator_default(), &device);
   }
   iree_hal_driver_release(driver);
 
@@ -472,14 +472,14 @@ LogicalResult CompiledBinary::initialize(Location loc, void *data,
     status = iree_hal_module_create(runtime.instance.get(), devices.size(),
                                     devices.data(), IREE_HAL_MODULE_FLAG_NONE,
                                     iree_hal_module_debug_sink_stdio(stderr),
-                                    iree_allocator_system(), &hal_module);
+                                    iree_allocator_default(), &hal_module);
   }
 
   // Bytecode module.
   if (iree_status_is_ok(status)) {
     status = iree_vm_bytecode_module_create(
         runtime.instance.get(), iree_make_const_byte_span(data, length),
-        iree_allocator_null(), iree_allocator_system(), &main_module);
+        iree_allocator_null(), iree_allocator_default(), &main_module);
   }
 
   // Create context.
@@ -490,7 +490,7 @@ LogicalResult CompiledBinary::initialize(Location loc, void *data,
     };
     status = iree_vm_context_create_with_modules(
         runtime.instance.get(), IREE_VM_CONTEXT_FLAG_NONE, modules.size(),
-        modules.data(), iree_allocator_system(), &context);
+        modules.data(), iree_allocator_default(), &context);
   }
 
   return handleRuntimeError(loc, status);
@@ -514,14 +514,14 @@ InMemoryCompiledBinary::translateFromModule(mlir::ModuleOp moduleOp) {
 Runtime::Runtime() {
   if (iree_status_is_ok(initStatus)) {
     initStatus =
-        iree_hal_driver_registry_allocate(iree_allocator_system(), &registry);
+        iree_hal_driver_registry_allocate(iree_allocator_default(), &registry);
   }
   if (iree_status_is_ok(initStatus)) {
     initStatus = iree_hal_local_task_driver_module_register(registry);
   }
   if (iree_status_is_ok(initStatus)) {
     initStatus = iree_vm_instance_create(IREE_VM_TYPE_CAPACITY_DEFAULT,
-                                         iree_allocator_system(), &instance);
+                                         iree_allocator_default(), &instance);
   }
   if (iree_status_is_ok(initStatus)) {
     initStatus = iree_hal_module_register_all_types(instance.get());

--- a/compiler/src/iree/compiler/Modules/IO/Parameters/Transforms/ArchiveUtils.cpp
+++ b/compiler/src/iree/compiler/Modules/IO/Parameters/Transforms/ArchiveUtils.cpp
@@ -29,7 +29,7 @@ LogicalResult handleRuntimeError(Operation *op, iree_status_t status,
 }
 
 FailureOr<ArchiveBuilder> createArchiveBuilder(Operation *op) {
-  iree_allocator_t hostAllocator = iree_allocator_system();
+  iree_allocator_t hostAllocator = iree_allocator_default();
   iree_io_parameter_archive_builder_t *builderPtr = NULL;
   if (failed(handleRuntimeError(op,
                                 iree_allocator_malloc(hostAllocator,

--- a/compiler/src/iree/compiler/Modules/IO/Parameters/Transforms/ImportParameters.cpp
+++ b/compiler/src/iree/compiler/Modules/IO/Parameters/Transforms/ImportParameters.cpp
@@ -33,7 +33,7 @@ namespace {
 
 static FailureOr<FileHandle> openArchiveFile(ModuleOp moduleOp,
                                              StringRef archivePath) {
-  iree_allocator_t hostAllocator = iree_allocator_system();
+  iree_allocator_t hostAllocator = iree_allocator_default();
 
   // Open the archive (hopefully mapped).
   auto fileOrErr = llvm::MemoryBuffer::getFile(
@@ -80,7 +80,7 @@ loadParameterIndex(ModuleOp moduleOp, StringRef path,
     return failure();
 
   // Parse the archive as a particular format.
-  iree_allocator_t hostAllocator = iree_allocator_system();
+  iree_allocator_t hostAllocator = iree_allocator_default();
   return handleRuntimeError(
       moduleOp,
       iree_io_parse_file_index(iree_make_string_view(path.data(), path.size()),
@@ -102,7 +102,7 @@ public:
 
   iree_io_parameter_index_t *lookupOrCreate(ModuleOp moduleOp,
                                             StringRef scope) {
-    iree_allocator_t hostAllocator = iree_allocator_system();
+    iree_allocator_t hostAllocator = iree_allocator_default();
     if (iree_io_parameter_index_t *existing = lookup(scope))
       return existing;
     iree_io_parameter_index_t *parameterIndexPtr = nullptr;

--- a/experimental/web/sample_dynamic/main.c
+++ b/experimental/web/sample_dynamic/main.c
@@ -78,7 +78,7 @@ extern iree_status_t create_device_with_loaders(iree_allocator_t host_allocator,
 iree_sample_state_t* setup_sample() {
   iree_sample_state_t* sample_state = NULL;
   iree_status_t status =
-      iree_allocator_malloc(iree_allocator_system(),
+      iree_allocator_malloc(iree_allocator_default(),
                             sizeof(iree_sample_state_t), (void**)&sample_state);
 
   iree_runtime_instance_options_t instance_options;
@@ -87,11 +87,11 @@ iree_sample_state_t* setup_sample() {
 
   if (iree_status_is_ok(status)) {
     status = iree_runtime_instance_create(
-        &instance_options, iree_allocator_system(), &sample_state->instance);
+        &instance_options, iree_allocator_default(), &sample_state->instance);
   }
 
   if (iree_status_is_ok(status)) {
-    status = create_device_with_loaders(iree_allocator_system(),
+    status = create_device_with_loaders(iree_allocator_default(),
                                         &sample_state->device);
   }
 
@@ -114,7 +114,7 @@ void cleanup_sample(iree_sample_state_t* sample_state) {
 iree_program_state_t* load_program(iree_sample_state_t* sample_state,
                                    uint8_t* vmfb_data, size_t length) {
   iree_program_state_t* program_state = NULL;
-  iree_status_t status = iree_allocator_malloc(iree_allocator_system(),
+  iree_status_t status = iree_allocator_malloc(iree_allocator_default(),
                                                sizeof(iree_program_state_t),
                                                (void**)&program_state);
 
@@ -133,11 +133,11 @@ iree_program_state_t* load_program(iree_sample_state_t* sample_state,
     status = iree_vm_bytecode_module_create(
         iree_runtime_instance_vm_instance(sample_state->instance),
         iree_make_const_byte_span(vmfb_data, length),
-        /*flatbuffer_allocator=*/iree_allocator_system(),
-        iree_allocator_system(), &program_state->module);
+        /*flatbuffer_allocator=*/iree_allocator_default(),
+        iree_allocator_default(), &program_state->module);
   } else {
     // Must clean up the FlatBuffer data directly.
-    iree_allocator_free(iree_allocator_system(), (void*)vmfb_data);
+    iree_allocator_free(iree_allocator_default(), (void*)vmfb_data);
   }
 
   if (iree_status_is_ok(status)) {
@@ -341,13 +341,13 @@ static iree_status_t print_outputs_from_call(
         // Allocate scratch heap memory for the result and format into it.
         char* result_str = NULL;
         IREE_RETURN_IF_ERROR(iree_allocator_malloc(
-            iree_allocator_system(), result_length, (void**)&result_str));
+            iree_allocator_default(), result_length, (void**)&result_str));
         IREE_RETURN_IF_ERROR(iree_hal_buffer_view_format(
             buffer_view, IREE_HOST_SIZE_MAX, result_length, result_str,
             &result_length));
         IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
             outputs_builder, "%.*s", (int)result_length, result_str));
-        iree_allocator_free(iree_allocator_system(), result_str);
+        iree_allocator_free(iree_allocator_default(), result_str);
       } else {
         IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(
             outputs_builder, "(no printer)"));
@@ -376,7 +376,7 @@ const char* call_function(iree_program_state_t* program_state,
   // Fully qualify the function name. This sample only supports loading one
   // module (i.e. 'program') per session, so we can do this.
   iree_string_builder_t name_builder;
-  iree_string_builder_initialize(iree_allocator_system(), &name_builder);
+  iree_string_builder_initialize(iree_allocator_default(), &name_builder);
   if (iree_status_is_ok(status)) {
     iree_string_view_t module_name = iree_vm_module_name(program_state->module);
     status = iree_string_builder_append_format(&name_builder, "%.*s.%s",
@@ -411,7 +411,7 @@ const char* call_function(iree_program_state_t* program_state,
   iree_time_t time_elapsed = end_time - start_time;
 
   iree_string_builder_t outputs_builder;
-  iree_string_builder_initialize(iree_allocator_system(), &outputs_builder);
+  iree_string_builder_initialize(iree_allocator_default(), &outputs_builder);
 
   // Output a JSON object as a string:
   // {

--- a/experimental/web/sample_static/main.c
+++ b/experimental/web/sample_static/main.c
@@ -47,13 +47,13 @@ iree_status_t create_bytecode_module(iree_vm_instance_t* instance,
       iree_make_const_byte_span(module_file_toc->data, module_file_toc->size);
   return iree_vm_bytecode_module_create(instance, module_data,
                                         iree_allocator_null(),
-                                        iree_allocator_system(), out_module);
+                                        iree_allocator_default(), out_module);
 }
 
 iree_sample_state_t* setup_sample() {
   iree_sample_state_t* state = NULL;
   iree_status_t status = iree_allocator_malloc(
-      iree_allocator_system(), sizeof(iree_sample_state_t), (void**)&state);
+      iree_allocator_default(), sizeof(iree_sample_state_t), (void**)&state);
 
   iree_runtime_instance_options_t instance_options;
   iree_runtime_instance_options_initialize(&instance_options);
@@ -61,11 +61,11 @@ iree_sample_state_t* setup_sample() {
 
   if (iree_status_is_ok(status)) {
     status = iree_runtime_instance_create(
-        &instance_options, iree_allocator_system(), &state->instance);
+        &instance_options, iree_allocator_default(), &state->instance);
   }
 
   if (iree_status_is_ok(status)) {
-    status = create_device_with_static_loader(iree_allocator_system(),
+    status = create_device_with_static_loader(iree_allocator_default(),
                                               &state->device);
   }
 

--- a/integrations/pjrt/src/iree_pjrt/common/api_impl.cc
+++ b/integrations/pjrt/src/iree_pjrt/common/api_impl.cc
@@ -1261,7 +1261,7 @@ iree_status_t DeviceInstance::GetHalDevice(iree_hal_device_t** out_device) {
 
 ClientInstance::ClientInstance(std::unique_ptr<Platform> platform)
     : platform_(std::move(platform)) {
-  host_allocator_ = iree_allocator_system();
+  host_allocator_ = iree_allocator_default();
   IREE_CHECK_OK(
       iree_hal_driver_registry_allocate(host_allocator_, &driver_registry_));
   cached_platform_version_ = "git";  // TODO: Plumb through version info.
@@ -1974,7 +1974,7 @@ iree_status_t LoadedExecutableInstance::LoadAll() {
 
     IREE_CHECK_OK(iree_vm_context_create_with_modules(
         client_.vm_instance(), IREE_VM_CONTEXT_FLAG_NONE, module_ptrs.size(),
-        module_ptrs.data(), iree_allocator_system(), &loaded.vm_context));
+        module_ptrs.data(), iree_allocator_default(), &loaded.vm_context));
   }
 
   new_list.swap(resident_executables_);

--- a/integrations/pjrt/src/iree_pjrt/common/dylib_platform.cc
+++ b/integrations/pjrt/src/iree_pjrt/common/dylib_platform.cc
@@ -180,11 +180,11 @@ std::optional<std::string> DylibPlatform::GetBinaryDir() {
     char* path;
     auto status = iree_file_path_join(
         iree_make_string_view(home_dir->data(), home_dir->size()),
-        iree_make_cstring_view(local_name), iree_allocator_system(), &path);
+        iree_make_cstring_view(local_name), iree_allocator_default(), &path);
     if (!iree_status_is_ok(status)) continue;
 
     std::string existing_path(path);
-    iree_allocator_free(iree_allocator_system(), path);
+    iree_allocator_free(iree_allocator_default(), path);
     status = iree_file_exists(path);
     if (iree_status_is_ok(status)) return existing_path;
   }
@@ -207,11 +207,11 @@ std::optional<std::string> DylibPlatform::GetLibraryDir() {
     char* path;
     auto status = iree_file_path_join(
         iree_make_string_view(home_dir->data(), home_dir->size()),
-        iree_make_cstring_view(local_name), iree_allocator_system(), &path);
+        iree_make_cstring_view(local_name), iree_allocator_default(), &path);
     if (!iree_status_is_ok(status)) continue;
 
     std::string existing_path(path);
-    iree_allocator_free(iree_allocator_system(), path);
+    iree_allocator_free(iree_allocator_default(), path);
     status = iree_file_exists(path);
     if (iree_status_is_ok(status)) return existing_path;
   }
@@ -232,12 +232,12 @@ std::optional<std::string> DylibPlatform::GetCompilerLibraryPath() {
   char* path;
   auto status = iree_file_path_join(
       iree_make_string_view(lib_dir->data(), lib_dir->size()),
-      iree_make_cstring_view("libIREECompiler.so"), iree_allocator_system(),
+      iree_make_cstring_view("libIREECompiler.so"), iree_allocator_default(),
       &path);
   if (!iree_status_is_ok(status)) return {};
 
   std::string joined_path(path);
-  iree_allocator_free(iree_allocator_system(), path);
+  iree_allocator_free(iree_allocator_default(), path);
   return joined_path;
 }
 
@@ -255,11 +255,11 @@ std::optional<std::string> DylibPlatform::GetPartitionerLibraryPath() {
   auto status = iree_file_path_join(
       iree_make_string_view(lib_dir->data(), lib_dir->size()),
       iree_make_cstring_view("libOpenXLAPartitioner.so"),
-      iree_allocator_system(), &path);
+      iree_allocator_default(), &path);
   if (!iree_status_is_ok(status)) return {};
 
   std::string joined_path(path);
-  iree_allocator_free(iree_allocator_system(), path);
+  iree_allocator_free(iree_allocator_default(), path);
   return joined_path;
 }
 

--- a/runtime/bindings/python/hal.cc
+++ b/runtime/bindings/python/hal.cc
@@ -155,7 +155,7 @@ py::dict HalAllocator::QueryStatistics() {
 py::str HalAllocator::FormattedStatistics() {
   // Perform all allocating string manipulation without early exit.
   iree_string_builder_t builder;
-  iree_string_builder_initialize(iree_allocator_system(), &builder);
+  iree_string_builder_initialize(iree_allocator_default(), &builder);
   iree_hal_allocator_statistics_t stats;
   iree_hal_allocator_query_statistics(raw_ptr(), &stats);
   auto status = iree_hal_allocator_statistics_format(&stats, &builder);
@@ -887,7 +887,7 @@ HalBufferView HalDevice::FromDLPackCapsule(py::object input_capsule) {
   iree_status_t status =
       iree_hal_buffer_view_create(imported_buffer, dlt->ndim, dims, et,
                                   IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
-                                  iree_allocator_system(), &buffer_view);
+                                  iree_allocator_default(), &buffer_view);
 
   if (!iree_status_is_ok(status)) {
     iree_hal_buffer_release(imported_buffer);
@@ -906,7 +906,7 @@ std::vector<std::string> HalDriver::Query() {
   iree_hal_driver_info_t* driver_infos = NULL;
   CheckApiStatus(
       iree_hal_driver_registry_enumerate(iree_hal_driver_registry_default(),
-                                         iree_allocator_system(),
+                                         iree_allocator_default(),
                                          &driver_info_count, &driver_infos),
       "Error enumerating HAL drivers");
   std::vector<std::string> driver_names(driver_info_count);
@@ -914,7 +914,7 @@ std::vector<std::string> HalDriver::Query() {
     driver_names[i] = std::string(driver_infos[i].driver_name.data,
                                   driver_infos[i].driver_name.size);
   }
-  iree_allocator_free(iree_allocator_system(), driver_infos);
+  iree_allocator_free(iree_allocator_default(), driver_infos);
   return driver_names;
 }
 
@@ -928,7 +928,7 @@ py::object HalDriver::Create(const DeviceUri& device_uri) {
   iree_hal_driver_t* driver;
   CheckApiStatus(iree_hal_driver_registry_try_create(
                      iree_hal_driver_registry_default(), device_uri.driver_name,
-                     iree_allocator_system(), &driver),
+                     iree_allocator_default(), &driver),
                  "Error creating driver");
 
   py::object driver_obj = py::cast(HalDriver::StealFromRawPtr(driver));
@@ -959,9 +959,10 @@ py::object HalDriver::Create(const std::string& device_uri,
 py::list HalDriver::QueryAvailableDevices() {
   iree_hal_device_info_t* device_infos;
   iree_host_size_t count;
-  CheckApiStatus(iree_hal_driver_query_available_devices(
-                     raw_ptr(), iree_allocator_system(), &count, &device_infos),
-                 "Error querying devices");
+  CheckApiStatus(
+      iree_hal_driver_query_available_devices(
+          raw_ptr(), iree_allocator_default(), &count, &device_infos),
+      "Error querying devices");
   py::list results;
   for (iree_host_size_t i = 0; i < count; ++i) {
     py::dict device_data;
@@ -973,7 +974,7 @@ py::list HalDriver::QueryAvailableDevices() {
     results.append(device_data);
   }
 
-  iree_allocator_free(iree_allocator_system(), device_infos);
+  iree_allocator_free(iree_allocator_default(), device_infos);
   return results;
 }
 
@@ -1013,7 +1014,7 @@ static iree_status_t ConfigureDevice(iree_hal_device_t* device,
 HalDevice HalDriver::CreateDefaultDevice(std::optional<py::list> allocators) {
   iree_hal_device_t* device;
   CheckApiStatus(iree_hal_driver_create_default_device(
-                     raw_ptr(), iree_allocator_system(), &device),
+                     raw_ptr(), iree_allocator_default(), &device),
                  "Error creating default device");
   CheckApiStatus(ConfigureDevice(device, allocators),
                  "Error configuring the device");
@@ -1052,7 +1053,7 @@ HalDevice HalDriver::CreateDevice(iree_hal_device_id_t device_id,
   CheckApiStatus(iree_hal_driver_create_device_by_id(
                      raw_ptr(), device_id, params.size(),
                      (params.empty() ? nullptr : &params.front()),
-                     iree_allocator_system(), &device),
+                     iree_allocator_default(), &device),
                  "Error creating default device");
   CheckApiStatus(ConfigureDevice(device, allocators),
                  "Error configuring the device");
@@ -1066,7 +1067,7 @@ HalDevice HalDriver::CreateDeviceByURI(std::string& device_uri,
       device_uri.data(), static_cast<iree_host_size_t>(device_uri.size())};
   CheckApiStatus(
       iree_hal_driver_create_device_by_uri(raw_ptr(), device_uri_sv,
-                                           iree_allocator_system(), &device),
+                                           iree_allocator_default(), &device),
       "Error creating device");
   CheckApiStatus(ConfigureDevice(device, allocators),
                  "Error configuring the device");
@@ -1115,7 +1116,7 @@ VmModule CreateHalModule(
   CheckApiStatus(iree_hal_module_create(instance->raw_ptr(), device_count,
                                         devices_ptr, IREE_HAL_MODULE_FLAG_NONE,
                                         iree_hal_module_debug_sink,
-                                        iree_allocator_system(), &module),
+                                        iree_allocator_default(), &module),
                  "Error creating hal module");
   VmModule vm_module = VmModule::StealFromRawPtr(module);
   if (debug_sink) {
@@ -1469,7 +1470,7 @@ void SetupHalBindings(nanobind::module_ m) {
       .def("dump_device_info",
            [](HalDriver& self, iree_hal_device_id_t device_id) {
              iree_string_builder_t builder;
-             iree_string_builder_initialize(iree_allocator_system(), &builder);
+             iree_string_builder_initialize(iree_allocator_default(), &builder);
              CheckApiStatus(iree_hal_driver_dump_device_info(
                                 self.raw_ptr(), device_id, &builder),
                             "Querying device info");
@@ -1588,7 +1589,7 @@ void SetupHalBindings(nanobind::module_ m) {
         CheckApiStatus(iree_hal_buffer_view_create(
                            buffer.raw_ptr(), rank, dims, element_type,
                            IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
-                           iree_allocator_system(), &out_bv),
+                           iree_allocator_default(), &out_bv),
                        "creating buffer view");
         new (new_self) HalBufferView();
         *new_self = HalBufferView::StealFromRawPtr(out_bv);
@@ -1721,7 +1722,7 @@ void SetupHalBindings(nanobind::module_ m) {
           [](HalFence* new_fence, iree_host_size_t capacity) {
             iree_hal_fence_t* out_fence;
             CheckApiStatus(iree_hal_fence_create(
-                               capacity, iree_allocator_system(), &out_fence),
+                               capacity, iree_allocator_default(), &out_fence),
                            "creating fence");
             new (new_fence) HalFence();
             (*new_fence) = HalFence::StealFromRawPtr(out_fence);
@@ -1733,7 +1734,7 @@ void SetupHalBindings(nanobind::module_ m) {
             iree_hal_fence_t* out_fence;
             CheckApiStatus(
                 iree_hal_fence_create_at(sem.raw_ptr(), value,
-                                         iree_allocator_system(), &out_fence),
+                                         iree_allocator_default(), &out_fence),
                 "creating fence");
             return HalFence::StealFromRawPtr(out_fence);
           },
@@ -1749,7 +1750,7 @@ void SetupHalBindings(nanobind::module_ m) {
             }
             iree_hal_fence_t* out_fence;
             CheckApiStatus(
-                iree_hal_fence_join(count, fence_ptrs, iree_allocator_system(),
+                iree_hal_fence_join(count, fence_ptrs, iree_allocator_default(),
                                     &out_fence),
                 "joining fences");
             return HalFence::StealFromRawPtr(out_fence);

--- a/runtime/bindings/python/hal.h
+++ b/runtime/bindings/python/hal.h
@@ -225,7 +225,7 @@ class HalBuffer : public ApiRefCounted<HalBuffer, iree_hal_buffer_t> {
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR;
     CheckApiStatus(iree_hal_buffer_view_create(
                        raw_ptr(), shape.s.size(), shape.s.data(), element_type,
-                       encoding_type, iree_allocator_system(), &bv),
+                       encoding_type, iree_allocator_default(), &bv),
                    "Error creating buffer view");
     return HalBufferView::StealFromRawPtr(bv);
   }

--- a/runtime/bindings/python/io.cc
+++ b/runtime/bindings/python/io.cc
@@ -35,7 +35,7 @@ VmModule CreateIoParametersModule(VmInstance &instance, py::args providers) {
   }
   CheckApiStatus(iree_io_parameters_module_create(
                      instance.raw_ptr(), size, c_providers.data(),
-                     iree_allocator_system(), &module),
+                     iree_allocator_default(), &module),
                  "Error creating io_parameters module");
   return VmModule::StealFromRawPtr(module);
 }
@@ -70,7 +70,7 @@ FileHandle FileHandleWrapMemory(py::object host_buffer, bool readable,
               },
               (void *)outer_retained.get(),
           },
-          iree_allocator_system(), &created_handle),
+          iree_allocator_default(), &created_handle),
       "Could not wrap host memory into a file handle");
   outer_retained.release();
   return FileHandle::StealFromRawPtr(created_handle);
@@ -101,7 +101,7 @@ void ParameterIndexParseFileHandle(ParameterIndex &self,
   CheckApiStatus(
       iree_io_parse_file_index(
           iree_make_string_view(format.data(), format.size()),
-          file_handle.raw_ptr(), self.raw_ptr(), iree_allocator_system()),
+          file_handle.raw_ptr(), self.raw_ptr(), iree_allocator_default()),
       "Could not parse parameter file index");
 }
 
@@ -125,7 +125,7 @@ void ParameterIndexLoadFile(ParameterIndex &self, std::string &file_path,
   iree_file_contents_t *file_contents = nullptr;
   CheckApiStatus(
       iree_file_read_contents(file_path.c_str(), read_flags,
-                              iree_allocator_system(), &file_contents),
+                              iree_allocator_default(), &file_contents),
       "Error opening parameter file");
   iree_io_file_handle_release_callback_t release_callback = {
       +[](void *user_data, iree_io_file_handle_primitive_t handle_primitive) {
@@ -139,7 +139,7 @@ void ParameterIndexLoadFile(ParameterIndex &self, std::string &file_path,
   iree_io_file_handle_t *raw_file_handle = nullptr;
   iree_status_t status = iree_io_file_handle_wrap_host_allocation(
       IREE_IO_FILE_ACCESS_READ, file_contents->buffer, release_callback,
-      iree_allocator_system(), &raw_file_handle);
+      iree_allocator_default(), &raw_file_handle);
   if (!iree_status_is_ok(status)) {
     iree_file_contents_free(file_contents);
     CheckApiStatus(status, "Error accessing parameter memory");
@@ -299,7 +299,7 @@ void SetupIoBindings(py::module_ &m) {
            [](ParameterIndex *new_self) {
              iree_io_parameter_index_t *created;
              CheckApiStatus(iree_io_parameter_index_create(
-                                iree_allocator_system(), &created),
+                                iree_allocator_default(), &created),
                             "Could not create IO parameter index");
              new (new_self) ParameterIndex();
              *new_self = ParameterIndex::StealFromRawPtr(created);
@@ -337,7 +337,7 @@ void SetupIoBindings(py::module_ &m) {
       .def("__repr__",
            [](ParameterIndex &self) {
              iree_string_builder_t b;
-             iree_string_builder_initialize(iree_allocator_system(), &b);
+             iree_string_builder_initialize(iree_allocator_default(), &b);
              iree_status_t status = iree_io_parameter_index_dump(
                  iree_string_view_empty(), self.raw_ptr(), &b);
              iree_string_view_t sv = iree_string_builder_view(&b);
@@ -416,7 +416,7 @@ void SetupIoBindings(py::module_ &m) {
                 iree_io_parameter_index_provider_create(
                     iree_make_string_view(scope.data(), scope.size()),
                     self.raw_ptr(), *max_concurrent_operations,
-                    iree_allocator_system(), &created),
+                    iree_allocator_default(), &created),
                 "Could not create parameter provider from index");
             return ParameterProvider::StealFromRawPtr(created);
           },
@@ -435,7 +435,7 @@ void SetupIoBindings(py::module_ &m) {
             } else {
               iree_io_parameter_index_t *created;
               CheckApiStatus(iree_io_parameter_index_create(
-                                 iree_allocator_system(), &created),
+                                 iree_allocator_default(), &created),
                              "Could not create IO parameter index");
               default_target_index = ParameterIndex::StealFromRawPtr(created);
               target_index = default_target_index.raw_ptr();
@@ -454,7 +454,7 @@ void SetupIoBindings(py::module_ &m) {
               iree_file_contents_t *file_contents = NULL;
               IREE_RETURN_IF_ERROR(iree_file_create_mapped(
                   params->path, archive_offset + archive_length, archive_offset,
-                  (iree_host_size_t)archive_length, iree_allocator_system(),
+                  (iree_host_size_t)archive_length, iree_allocator_default(),
                   &file_contents));
               iree_io_file_handle_release_callback_t release_callback;
               memset(&release_callback, 0, sizeof(release_callback));
@@ -467,7 +467,7 @@ void SetupIoBindings(py::module_ &m) {
               release_callback.user_data = file_contents;
               iree_status_t status = iree_io_file_handle_wrap_host_allocation(
                   IREE_IO_FILE_ACCESS_WRITE, file_contents->buffer,
-                  release_callback, iree_allocator_system(), out_file_handle);
+                  release_callback, iree_allocator_default(), out_file_handle);
               if (!iree_status_is_ok(status)) {
                 iree_file_contents_free(file_contents);
               }
@@ -481,7 +481,7 @@ void SetupIoBindings(py::module_ &m) {
                                    file_open_callback,
                                    &file_open_user_data,
                                },
-                               file_offset, iree_allocator_system()),
+                               file_offset, iree_allocator_default()),
                            "Error building parameter archive");
 
             // Return the target index.

--- a/runtime/bindings/python/vm.cc
+++ b/runtime/bindings/python/vm.cc
@@ -158,7 +158,7 @@ VmInstance VmInstance::Create() {
 
   iree_vm_instance_t* instance = NULL;
   auto status = iree_vm_instance_create(IREE_VM_TYPE_CAPACITY_DEFAULT,
-                                        iree_allocator_system(), &instance);
+                                        iree_allocator_default(), &instance);
   CheckApiStatus(status, "Error creating instance");
 
   // The python bindings assume the HAL is always available for use.
@@ -182,7 +182,7 @@ VmContext VmContext::Create(VmInstance* instance,
     // Simple create with open allowed modules.
     auto status =
         iree_vm_context_create(instance->raw_ptr(), IREE_VM_CONTEXT_FLAG_NONE,
-                               iree_allocator_system(), &context);
+                               iree_allocator_default(), &context);
     CheckApiStatus(status, "Error creating vm context");
   } else {
     // Closed set of modules.
@@ -193,7 +193,7 @@ VmContext VmContext::Create(VmInstance* instance,
     }
     auto status = iree_vm_context_create_with_modules(
         instance->raw_ptr(), IREE_VM_CONTEXT_FLAG_NONE, module_handles.size(),
-        module_handles.data(), iree_allocator_system(), &context);
+        module_handles.data(), iree_allocator_default(), &context);
     CheckApiStatus(status, "Error creating vm context with modules");
   }
 
@@ -219,7 +219,7 @@ void VmContext::Invoke(iree_vm_function_t f, VmVariantList& inputs,
     py::gil_scoped_release release;
     status = iree_vm_invoke(raw_ptr(), f, IREE_VM_INVOCATION_FLAG_NONE, nullptr,
                             inputs.raw_ptr(), outputs.raw_ptr(),
-                            iree_allocator_system());
+                            iree_allocator_default());
   }
   CheckApiStatus(status, "Error invoking function");
 }
@@ -239,7 +239,7 @@ VmModule VmModule::ResolveModuleDependency(VmInstance* instance,
       IREE_VM_MODULE_DEPENDENCY_FLAG_REQUIRED};
 
   auto status = iree_tooling_resolve_module_dependency(
-      instance->raw_ptr(), &dependency, iree_allocator_system(), &module);
+      instance->raw_ptr(), &dependency, iree_allocator_default(), &module);
 
   assert(module != nullptr);
 
@@ -374,7 +374,7 @@ VmModule VmModule::WrapBuffer(VmInstance* instance, py::object buffer_obj,
       instance->raw_ptr(),
       {static_cast<const uint8_t*>(buffer_info.view().buf),
        static_cast<iree_host_size_t>(buffer_info.view().len)},
-      deallocator, iree_allocator_system(), &module);
+      deallocator, iree_allocator_default(), &module);
   if (!iree_status_is_ok(status)) {
     delete state;
   }
@@ -840,7 +840,7 @@ void SetupVmBindings(nanobind::module_ m) {
             iree_vm_buffer_t* raw_buffer;
             CheckApiStatus(
                 iree_vm_buffer_create(access, length, alignment,
-                                      iree_allocator_system(), &raw_buffer),
+                                      iree_allocator_default(), &raw_buffer),
                 "Error creating buffer");
 
             new (self) VmBuffer();

--- a/runtime/bindings/python/vm.h
+++ b/runtime/bindings/python/vm.h
@@ -92,7 +92,7 @@ class VmVariantList : public ApiRefCounted<VmVariantList, iree_vm_list_t> {
     iree_vm_list_t* list;
     CheckApiStatus(
         iree_vm_list_create(iree_vm_make_undefined_type_def(), capacity,
-                            iree_allocator_system(), &list),
+                            iree_allocator_default(), &list),
         "Error allocating variant list");
     return VmVariantList::StealFromRawPtr(list);
   }

--- a/runtime/bindings/tflite/model.c
+++ b/runtime/bindings/tflite/model.c
@@ -100,7 +100,7 @@ static iree_status_t _TfLiteModelInitializeModule(const void* flatbuffer_data,
 
 TFL_CAPI_EXPORT extern TfLiteModel* TfLiteModelCreate(const void* model_data,
                                                       size_t model_size) {
-  iree_allocator_t allocator = iree_allocator_system();
+  iree_allocator_t allocator = iree_allocator_default();
   IREE_TRACE_ZONE_BEGIN(z0);
 
   TfLiteModel* model = NULL;
@@ -131,7 +131,7 @@ TFL_CAPI_EXPORT extern TfLiteModel* TfLiteModelCreate(const void* model_data,
 
 TFL_CAPI_EXPORT extern TfLiteModel* TfLiteModelCreateFromFile(
     const char* model_path) {
-  iree_allocator_t allocator = iree_allocator_system();
+  iree_allocator_t allocator = iree_allocator_default();
   IREE_TRACE_ZONE_BEGIN(z0);
 
   // TODO(#3909): use file mapping C API.

--- a/runtime/bindings/tflite/options.c
+++ b/runtime/bindings/tflite/options.c
@@ -14,7 +14,7 @@ void _TfLiteInterpreterOptionsSetDefaults(TfLiteInterpreterOptions* options) {
 
 TFL_CAPI_EXPORT extern TfLiteInterpreterOptions*
 TfLiteInterpreterOptionsCreate() {
-  iree_allocator_t allocator = iree_allocator_system();
+  iree_allocator_t allocator = iree_allocator_default();
   IREE_TRACE_ZONE_BEGIN(z0);
 
   TfLiteInterpreterOptions* options = NULL;

--- a/runtime/src/iree/base/allocator.h
+++ b/runtime/src/iree/base/allocator.h
@@ -362,6 +362,21 @@ extern void* IREE_ALLOCATOR_DEFAULT_SELF;
 // `IREE_ALLOCATOR_DEFAULT_SELF` global `void*` variable can be defined if the
 // allocator requires state and otherwise `NULL` will be passed as the `self`
 // parameter to the control function.
+//
+// Any number of allocators can be linked into a program so long as they have
+// unique control functions. Since (nearly) all IREE APIs that allocate take an
+// `iree_allocator_t` as an argument frameworks and applications using IREE need
+// not modify IREE at all in order to use their own. Any code internal to IREE
+// that uses an allocator not taken as an argument (such as `iree_status_t`)
+// will use `iree_allocator_default()` to get its allocator. By default this
+// allocator is an alias for `iree_allocator_system()` using whatever C's malloc
+// and free are implemented with. If the user wishes to override this default
+// they can do so by either changing malloc/free at the global level or
+// specifically telling IREE to use a different default allocator.
+//
+// To make it easier to link in new allocators as part of build configuration
+// the CMake `IREE_ALLOCATOR_DEFAULT` value can be set to a named allocator
+// either provided by the user or by the IREE source.
 static inline iree_allocator_t iree_allocator_default(void) {
   iree_allocator_t v = {
 #if defined(IREE_ALLOCATOR_DEFAULT_SELF)

--- a/runtime/src/iree/base/internal/file_io_test.cc
+++ b/runtime/src/iree/base/internal/file_io_test.cc
@@ -87,7 +87,7 @@ TEST(FileIO, ReadWriteContentsPreload) {
   iree_file_contents_t* read_contents = NULL;
   IREE_ASSERT_OK(
       iree_file_read_contents(path.c_str(), IREE_FILE_READ_FLAG_PRELOAD,
-                              iree_allocator_system(), &read_contents));
+                              iree_allocator_default(), &read_contents));
 
   // Expect the contents are equal.
   EXPECT_EQ(write_contents.size(), read_contents->const_buffer.data_length);
@@ -118,7 +118,7 @@ TEST(FileIO, ReadWriteContentsMmap) {
   // Read the contents from disk.
   iree_file_contents_t* read_contents = NULL;
   IREE_ASSERT_OK(iree_file_read_contents(path.c_str(), IREE_FILE_READ_FLAG_MMAP,
-                                         iree_allocator_system(),
+                                         iree_allocator_default(),
                                          &read_contents));
 
   // Expect the contents are equal.

--- a/runtime/src/iree/base/internal/flags.c
+++ b/runtime/src/iree/base/internal/flags.c
@@ -27,8 +27,9 @@ static iree_status_t iree_flags_leaky_allocator_ctl(
     void* self, iree_allocator_command_t command, const void* params,
     void** inout_ptr) {
   IREE_LEAK_CHECK_DISABLE_PUSH();
+  iree_allocator_t allocator = iree_allocator_default();
   iree_status_t status =
-      iree_allocator_system_ctl(/*self=*/NULL, command, params, inout_ptr);
+      allocator.ctl(allocator.self, command, params, inout_ptr);
   IREE_LEAK_CHECK_DISABLE_POP();
   return status;
 }

--- a/runtime/src/iree/base/internal/path_test.cc
+++ b/runtime/src/iree/base/internal/path_test.cc
@@ -73,11 +73,11 @@ static std::string JoinPaths(std::string lhs, std::string rhs) {
   IREE_IGNORE_ERROR(
       iree_file_path_join(iree_make_string_view(lhs.data(), lhs.size()),
                           iree_make_string_view(rhs.data(), rhs.size()),
-                          iree_allocator_system(), &result_str));
+                          iree_allocator_default(), &result_str));
   std::string result;
   result.resize(strlen(result_str));
   memcpy((char*)result.data(), result_str, result.size());
-  iree_allocator_free(iree_allocator_system(), result_str);
+  iree_allocator_free(iree_allocator_default(), result_str);
   return result;
 }
 

--- a/runtime/src/iree/base/internal/threading_test.cc
+++ b/runtime/src/iree/base/internal/threading_test.cc
@@ -46,7 +46,7 @@ TEST(ThreadTest, Lifetime) {
   // Create the thread and immediately begin running it.
   iree_thread_t* thread = nullptr;
   IREE_ASSERT_OK(iree_thread_create(entry_fn, &entry_data, params,
-                                    iree_allocator_system(), &thread));
+                                    iree_allocator_default(), &thread));
   EXPECT_NE(0, iree_thread_id(thread));
 
   // Wait for the thread to finish.
@@ -86,7 +86,7 @@ TEST(ThreadTest, CreateSuspended) {
 
   iree_thread_t* thread = nullptr;
   IREE_ASSERT_OK(iree_thread_create(entry_fn, &entry_data, params,
-                                    iree_allocator_system(), &thread));
+                                    iree_allocator_default(), &thread));
   EXPECT_NE(0, iree_thread_id(thread));
 
   // NOTE: the thread will not be running and we should not expect a change in
@@ -133,7 +133,7 @@ TEST(ThreadTest, PriorityOverride) {
 
   iree_thread_t* thread = nullptr;
   IREE_ASSERT_OK(iree_thread_create(entry_fn, &entry_data, params,
-                                    iree_allocator_system(), &thread));
+                                    iree_allocator_default(), &thread));
   EXPECT_NE(0, iree_thread_id(thread));
 
   // Push a few overrides.
@@ -177,7 +177,7 @@ TEST(ThreadOverrideListTest, PriorityClass) {
         EXPECT_NE(current_priority_class, priority_class);
         current_priority_class = priority_class;
       },
-      current_priority_class, iree_allocator_system(), &list);
+      current_priority_class, iree_allocator_default(), &list);
 
   // (NORMAL) -> HIGH -> [ignored LOW] -> HIGHEST
   ASSERT_EQ(IREE_THREAD_PRIORITY_CLASS_NORMAL, current_priority_class);

--- a/runtime/src/iree/base/internal/wait_handle_inproc.c
+++ b/runtime/src/iree/base/internal/wait_handle_inproc.c
@@ -55,7 +55,7 @@ void iree_wait_handle_close(iree_wait_handle_t* handle) {
       iree_futex_handle_t* futex =
           (iree_futex_handle_t*)handle->value.local_futex;
       iree_notification_deinitialize(&futex->notification);
-      iree_allocator_free(iree_allocator_system(), futex);
+      iree_allocator_free(iree_allocator_default(), futex);
       break;
     }
 #endif  // IREE_HAVE_WAIT_TYPE_LOCAL_FUTEX
@@ -330,7 +330,7 @@ iree_status_t iree_event_initialize(bool initial_state,
   memset(out_event, 0, sizeof(*out_event));
 
   iree_futex_handle_t* futex = NULL;
-  iree_status_t status = iree_allocator_malloc(iree_allocator_system(),
+  iree_status_t status = iree_allocator_malloc(iree_allocator_default(),
                                                sizeof(*futex), (void**)&futex);
   if (iree_status_is_ok(status)) {
     out_event->type = IREE_WAIT_PRIMITIVE_TYPE_LOCAL_FUTEX;

--- a/runtime/src/iree/base/internal/wait_handle_test.cc
+++ b/runtime/src/iree/base/internal/wait_handle_test.cc
@@ -237,7 +237,7 @@ TEST(WaitSet, Lifetime) {
 
   iree_wait_set_t* wait_set = NULL;
   IREE_ASSERT_OK(
-      iree_wait_set_allocate(128, iree_allocator_system(), &wait_set));
+      iree_wait_set_allocate(128, iree_allocator_default(), &wait_set));
   IREE_ASSERT_OK(iree_wait_set_insert(wait_set, event));
   IREE_ASSERT_OK(iree_wait_set_insert(wait_set, event));
   iree_wait_set_erase(wait_set, event);
@@ -250,7 +250,7 @@ TEST(WaitSet, Lifetime) {
 TEST(WaitSet, UnreasonableCapacity) {
   iree_wait_set_t* wait_set = NULL;
   iree_status_t status = iree_wait_set_allocate(
-      1 * 1024 * 1024, iree_allocator_system(), &wait_set);
+      1 * 1024 * 1024, iree_allocator_default(), &wait_set);
   IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT, status);
   iree_status_free(status);
 }
@@ -262,7 +262,7 @@ TEST(WaitSet, Deduplication) {
   IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/true, &ev_dupe));
   iree_wait_set_t* wait_set = NULL;
   IREE_ASSERT_OK(
-      iree_wait_set_allocate(128, iree_allocator_system(), &wait_set));
+      iree_wait_set_allocate(128, iree_allocator_default(), &wait_set));
 
   // We want to test for duplication on ev_dupe here so ensure it's added.
   IREE_ASSERT_OK(iree_wait_set_insert(wait_set, ev_unset));
@@ -310,7 +310,7 @@ TEST(WaitSet, Clear) {
   IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/true, &ev_dupe));
   iree_wait_set_t* wait_set = NULL;
   IREE_ASSERT_OK(
-      iree_wait_set_allocate(128, iree_allocator_system(), &wait_set));
+      iree_wait_set_allocate(128, iree_allocator_default(), &wait_set));
 
   // We want to test for duplication o n ev_dupe here.
   IREE_ASSERT_OK(iree_wait_set_insert(wait_set, ev_unset));
@@ -349,7 +349,7 @@ TEST(WaitSet, WaitAllPolling) {
   IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/true, &ev_set_1));
   iree_wait_set_t* wait_set = NULL;
   IREE_ASSERT_OK(
-      iree_wait_set_allocate(128, iree_allocator_system(), &wait_set));
+      iree_wait_set_allocate(128, iree_allocator_default(), &wait_set));
 
   // Polls when empty should never block.
   iree_wait_set_clear(wait_set);
@@ -394,7 +394,7 @@ TEST(WaitSet, WaitAllTimeout) {
   IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/true, &ev_set_1));
   iree_wait_set_t* wait_set = NULL;
   IREE_ASSERT_OK(
-      iree_wait_set_allocate(128, iree_allocator_system(), &wait_set));
+      iree_wait_set_allocate(128, iree_allocator_default(), &wait_set));
 
   // Timeouts when empty should never block.
   iree_wait_set_clear(wait_set);
@@ -442,7 +442,7 @@ TEST(WaitSet, WaitAllBlocking) {
   IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/true, &ev_set_1));
   iree_wait_set_t* wait_set = NULL;
   IREE_ASSERT_OK(
-      iree_wait_set_allocate(128, iree_allocator_system(), &wait_set));
+      iree_wait_set_allocate(128, iree_allocator_default(), &wait_set));
 
   // Throw in some other set handles so that we are multi-waiting for just the
   // thread_to_main event to be set.
@@ -474,7 +474,7 @@ TEST(WaitSet, WaitAllDuplicates) {
   IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/true, &ev_set));
   iree_wait_set_t* wait_set = NULL;
   IREE_ASSERT_OK(
-      iree_wait_set_allocate(128, iree_allocator_system(), &wait_set));
+      iree_wait_set_allocate(128, iree_allocator_default(), &wait_set));
 
   IREE_ASSERT_OK(iree_wait_set_insert(wait_set, ev_set));
   IREE_ASSERT_OK(iree_wait_set_insert(wait_set, ev_set));
@@ -497,7 +497,7 @@ TEST(WaitSet, WaitAny) {
   IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/true, &ev_set));
   iree_wait_set_t* wait_set = NULL;
   IREE_ASSERT_OK(
-      iree_wait_set_allocate(128, iree_allocator_system(), &wait_set));
+      iree_wait_set_allocate(128, iree_allocator_default(), &wait_set));
 
   IREE_ASSERT_OK(iree_wait_set_insert(wait_set, ev_unset));
   IREE_ASSERT_OK(iree_wait_set_insert(wait_set, ev_set));
@@ -524,7 +524,7 @@ TEST(WaitSet, WaitAnyPolling) {
   IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/true, &ev_set_1));
   iree_wait_set_t* wait_set = NULL;
   IREE_ASSERT_OK(
-      iree_wait_set_allocate(128, iree_allocator_system(), &wait_set));
+      iree_wait_set_allocate(128, iree_allocator_default(), &wait_set));
 
   iree_wait_handle_t empty_handle;
   memset(&empty_handle, 0, sizeof(empty_handle));
@@ -591,7 +591,7 @@ TEST(WaitSet, WaitAnyTimeout) {
   IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/true, &ev_set_1));
   iree_wait_set_t* wait_set = NULL;
   IREE_ASSERT_OK(
-      iree_wait_set_allocate(128, iree_allocator_system(), &wait_set));
+      iree_wait_set_allocate(128, iree_allocator_default(), &wait_set));
 
   iree_wait_handle_t empty_handle;
   memset(&empty_handle, 0, sizeof(empty_handle));
@@ -656,7 +656,7 @@ TEST(WaitSet, WaitAnyBlocking) {
   IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/false, &ev_unset_1));
   iree_wait_set_t* wait_set = NULL;
   IREE_ASSERT_OK(
-      iree_wait_set_allocate(128, iree_allocator_system(), &wait_set));
+      iree_wait_set_allocate(128, iree_allocator_default(), &wait_set));
 
   // Throw in some unset handles so that we are multi-waiting for just the
   // thread_to_main event to be set.
@@ -696,7 +696,7 @@ TEST(WaitSet, WaitAnyErase) {
   IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/true, &ev_set));
   iree_wait_set_t* wait_set = NULL;
   IREE_ASSERT_OK(
-      iree_wait_set_allocate(128, iree_allocator_system(), &wait_set));
+      iree_wait_set_allocate(128, iree_allocator_default(), &wait_set));
 
   IREE_ASSERT_OK(iree_wait_set_insert(wait_set, ev_unset_0));
   IREE_ASSERT_OK(iree_wait_set_insert(wait_set, ev_set));
@@ -734,7 +734,7 @@ TEST(WaitSet, WaitAnyEraseTail) {
   IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/true, &ev_set));
   iree_wait_set_t* wait_set = NULL;
   IREE_ASSERT_OK(
-      iree_wait_set_allocate(128, iree_allocator_system(), &wait_set));
+      iree_wait_set_allocate(128, iree_allocator_default(), &wait_set));
 
   IREE_ASSERT_OK(iree_wait_set_insert(wait_set, ev_unset));
   IREE_ASSERT_OK(iree_wait_set_insert(wait_set, ev_set));
@@ -770,7 +770,7 @@ TEST(WaitSet, WaitAnyEraseSplit) {
   IREE_ASSERT_OK(iree_event_initialize(/*initial_state=*/true, &ev_set));
   iree_wait_set_t* wait_set = NULL;
   IREE_ASSERT_OK(
-      iree_wait_set_allocate(128, iree_allocator_system(), &wait_set));
+      iree_wait_set_allocate(128, iree_allocator_default(), &wait_set));
 
   IREE_ASSERT_OK(iree_wait_set_insert(wait_set, ev_unset));
   IREE_ASSERT_OK(iree_wait_set_insert(wait_set, ev_set));

--- a/runtime/src/iree/base/loop_test.h
+++ b/runtime/src/iree/base/loop_test.h
@@ -23,7 +23,7 @@ namespace iree {
 namespace testing {
 
 struct LoopTest : public ::testing::Test {
-  iree_allocator_t allocator = iree_allocator_system();
+  iree_allocator_t allocator = iree_allocator_default();
   iree_loop_t loop;
   iree_status_t loop_status = iree_ok_status();
 

--- a/runtime/src/iree/base/status.c
+++ b/runtime/src/iree/base/status.c
@@ -580,7 +580,7 @@ iree_status_annotate(iree_status_t base_status, iree_string_view_t message) {
     return base_status;
   }
 
-  iree_allocator_t allocator = iree_allocator_system();
+  iree_allocator_t allocator = iree_allocator_default();
   iree_status_payload_message_t* payload = NULL;
   iree_status_ignore(
       iree_allocator_malloc(allocator, sizeof(*payload), (void**)&payload));
@@ -617,7 +617,7 @@ IREE_MUST_USE_RESULT static iree_status_t iree_status_annotate_vf(
   // Allocate storage with the additional room to store the formatted message.
   // This avoids additional allocations for the common case of a message coming
   // only from the original status error site.
-  iree_allocator_t allocator = iree_allocator_system();
+  iree_allocator_t allocator = iree_allocator_default();
   iree_status_payload_message_t* payload = NULL;
   iree_status_ignore(iree_allocator_malloc(
       allocator, sizeof(*payload) + message_size, (void**)&payload));
@@ -905,7 +905,7 @@ IREE_API_EXPORT bool iree_status_to_string(
 IREE_API_EXPORT void iree_status_fprint(FILE* file, iree_status_t status) {
   // TODO(benvanik): better support for colors/etc - possibly move to logging.
   // TODO(benvanik): do this without allocation by streaming the status.
-  iree_allocator_t allocator = iree_allocator_system();
+  iree_allocator_t allocator = iree_allocator_default();
   char* status_buffer = NULL;
   iree_host_size_t status_buffer_length = 0;
   if (iree_status_to_string(status, &allocator, &status_buffer,

--- a/runtime/src/iree/base/status.h
+++ b/runtime/src/iree/base/status.h
@@ -533,7 +533,7 @@ IREE_API_EXPORT bool iree_status_format(iree_status_t status,
 // it) and must be non-NULL.
 //
 // Example:
-//  iree_allocator_t allocator = iree_allocator_system();
+//  iree_allocator_t allocator = iree_allocator_default();
 //  char* buffer = NULL;
 //  iree_host_size_t length = 0;
 //  if (iree_status_to_string(status, &allocator, &buffer, &length)) {

--- a/runtime/src/iree/base/status_stack_trace.c
+++ b/runtime/src/iree/base/status_stack_trace.c
@@ -341,7 +341,7 @@ iree_status_t iree_status_attach_stack_trace(iree_status_t status,
       sizeof(*payload) +
       sizeof(payload->addresses[0]) * IREE_STATUS_MAX_STACK_TRACE_FRAMES;
 
-  iree_allocator_t allocator = iree_allocator_system();
+  iree_allocator_t allocator = iree_allocator_default();
   iree_status_ignore(
       iree_allocator_malloc(allocator, total_size, (void**)&payload));
   if (IREE_UNLIKELY(!payload)) return status;

--- a/runtime/src/iree/base/string_builder.h
+++ b/runtime/src/iree/base/string_builder.h
@@ -24,7 +24,7 @@ extern "C" {
 //
 // Usage:
 //  iree_string_builder_t builder;
-//  iree_string_builder_initialize(iree_allocator_system(), &builder);
+//  iree_string_builder_initialize(iree_allocator_default(), &builder);
 //  IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(&builder, "hel"));
 //  IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(&builder, "lo"));
 //  fprintf(stream, "%.*s", (int)iree_string_builder_size(&builder),
@@ -92,13 +92,13 @@ iree_string_builder_view(const iree_string_builder_t* builder);
 //
 // Usage:
 //  iree_string_builder_t builder;
-//  iree_string_builder_initialize(iree_allocator_system(), &builder);
+//  iree_string_builder_initialize(iree_allocator_default(), &builder);
 //  ...
 //  char* buffer = iree_string_builder_take_storage(&builder);
 //  iree_host_size_t buffer_size = iree_string_builder_size(&builder);
 //  iree_string_builder_deinitialize(&builder);
 //  ...
-//  iree_allocator_free(iree_allocator_system(), buffer);
+//  iree_allocator_free(iree_allocator_default(), buffer);
 IREE_API_EXPORT IREE_MUST_USE_RESULT char* iree_string_builder_take_storage(
     iree_string_builder_t* builder);
 

--- a/runtime/src/iree/base/string_builder_test.cc
+++ b/runtime/src/iree/base/string_builder_test.cc
@@ -19,7 +19,7 @@ using iree::testing::status::StatusIs;
 struct StringBuilder {
   static StringBuilder MakeSystem() {
     iree_string_builder_t builder;
-    iree_string_builder_initialize(iree_allocator_system(), &builder);
+    iree_string_builder_initialize(iree_allocator_default(), &builder);
     return StringBuilder(builder);
   }
 
@@ -58,7 +58,7 @@ struct InlineStringBuilder : public StringBuilder {
 struct StringPairBuilder {
   static StringPairBuilder MakeSystem() {
     iree_string_pair_builder_t builder;
-    iree_string_pair_builder_initialize(iree_allocator_system(), &builder);
+    iree_string_pair_builder_initialize(iree_allocator_default(), &builder);
     return StringPairBuilder(builder);
   }
 

--- a/runtime/src/iree/base/testing/dynamic_library_test.cc
+++ b/runtime/src/iree/base/testing/dynamic_library_test.cc
@@ -79,14 +79,14 @@ TEST_F(DynamicLibraryTest, LoadLibrarySuccess) {
   iree_dynamic_library_t* library = NULL;
   IREE_ASSERT_OK(iree_dynamic_library_load_from_file(
       library_temp_path_.c_str(), IREE_DYNAMIC_LIBRARY_FLAG_NONE,
-      iree_allocator_system(), &library));
+      iree_allocator_default(), &library));
   iree_dynamic_library_release(library);
 }
 
 TEST_F(DynamicLibraryTest, LoadLibraryFailure) {
   iree_dynamic_library_t* library = NULL;
   iree_status_t status = iree_dynamic_library_load_from_file(
-      kUnknownName, IREE_DYNAMIC_LIBRARY_FLAG_NONE, iree_allocator_system(),
+      kUnknownName, IREE_DYNAMIC_LIBRARY_FLAG_NONE, iree_allocator_default(),
       &library);
   IREE_EXPECT_STATUS_IS(IREE_STATUS_NOT_FOUND, status);
   iree_status_free(status);
@@ -97,10 +97,10 @@ TEST_F(DynamicLibraryTest, LoadLibraryTwice) {
   iree_dynamic_library_t* library2 = NULL;
   IREE_ASSERT_OK(iree_dynamic_library_load_from_file(
       library_temp_path_.c_str(), IREE_DYNAMIC_LIBRARY_FLAG_NONE,
-      iree_allocator_system(), &library1));
+      iree_allocator_default(), &library1));
   IREE_ASSERT_OK(iree_dynamic_library_load_from_file(
       library_temp_path_.c_str(), IREE_DYNAMIC_LIBRARY_FLAG_NONE,
-      iree_allocator_system(), &library2));
+      iree_allocator_default(), &library2));
   iree_dynamic_library_release(library1);
   iree_dynamic_library_release(library2);
 }
@@ -109,7 +109,7 @@ TEST_F(DynamicLibraryTest, GetSymbolSuccess) {
   iree_dynamic_library_t* library = NULL;
   IREE_ASSERT_OK(iree_dynamic_library_load_from_file(
       library_temp_path_.c_str(), IREE_DYNAMIC_LIBRARY_FLAG_NONE,
-      iree_allocator_system(), &library));
+      iree_allocator_default(), &library));
 
   int (*fn_ptr)(int);
   IREE_ASSERT_OK(iree_dynamic_library_lookup_symbol(library, "times_two",
@@ -124,7 +124,7 @@ TEST_F(DynamicLibraryTest, GetSymbolFailure) {
   iree_dynamic_library_t* library = NULL;
   IREE_ASSERT_OK(iree_dynamic_library_load_from_file(
       library_temp_path_.c_str(), IREE_DYNAMIC_LIBRARY_FLAG_NONE,
-      iree_allocator_system(), &library));
+      iree_allocator_default(), &library));
 
   int (*fn_ptr)(int);
   iree_status_t status =

--- a/runtime/src/iree/builtins/ukernel/tools/benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/benchmark.c
@@ -100,7 +100,7 @@ void iree_uk_benchmark_register(
       .user_data = user_data,
   };
   iree_string_builder_t full_name;
-  iree_string_builder_initialize(iree_allocator_system(), &full_name);
+  iree_string_builder_initialize(iree_allocator_default(), &full_name);
   IREE_CHECK_OK(iree_string_builder_append_cstring(&full_name, name));
   if (strlen(cpu_features)) {
     IREE_CHECK_OK(iree_string_builder_append_cstring(&full_name, "_"));

--- a/runtime/src/iree/builtins/ukernel/tools/util.c
+++ b/runtime/src/iree/builtins/ukernel/tools/util.c
@@ -297,7 +297,7 @@ void iree_uk_make_cpu_data_for_features(const char* cpu_features,
 }
 
 static void iree_uk_initialize_cpu_expensive(void) {
-  iree_cpu_initialize(iree_allocator_system());
+  iree_cpu_initialize(iree_allocator_default());
 }
 
 void iree_uk_initialize_cpu_once(void) {

--- a/runtime/src/iree/hal/cts/buffer_mapping_test.h
+++ b/runtime/src/iree/hal/cts/buffer_mapping_test.h
@@ -142,7 +142,7 @@ TEST_F(BufferMappingTest, ZeroSubspan) {
   iree_hal_buffer_t* buffer_subspan = NULL;
   IREE_ASSERT_OK(
       iree_hal_buffer_subspan(buffer, /*byte_offset=*/4, subspan_length,
-                              iree_allocator_system(), &buffer_subspan));
+                              iree_allocator_default(), &buffer_subspan));
 
   // Zero part of the subspan.
   IREE_ASSERT_OK(iree_hal_buffer_map_zero(buffer_subspan, /*byte_offset=*/4,
@@ -256,7 +256,7 @@ TEST_F(BufferMappingTest, FillSubspan) {
   iree_hal_buffer_t* buffer_subspan = NULL;
   IREE_ASSERT_OK(
       iree_hal_buffer_subspan(buffer, /*byte_offset=*/4, subspan_length,
-                              iree_allocator_system(), &buffer_subspan));
+                              iree_allocator_default(), &buffer_subspan));
 
   // Fill part of the subspan.
   uint8_t fill_value = 0xFF;
@@ -346,7 +346,7 @@ TEST_F(BufferMappingTest, ReadDataSubspan) {
   iree_hal_buffer_t* buffer_subspan = NULL;
   IREE_ASSERT_OK(
       iree_hal_buffer_subspan(buffer, /*byte_offset=*/4, subspan_length,
-                              iree_allocator_system(), &buffer_subspan));
+                              iree_allocator_default(), &buffer_subspan));
 
   // Read the entire buffer subspan.
   std::vector<uint8_t> actual_data(subspan_length);
@@ -431,7 +431,7 @@ TEST_F(BufferMappingTest, WriteDataSubspan) {
   iree_hal_buffer_t* buffer_subspan = NULL;
   IREE_ASSERT_OK(
       iree_hal_buffer_subspan(buffer, /*byte_offset=*/4, subspan_length,
-                              iree_allocator_system(), &buffer_subspan));
+                              iree_allocator_default(), &buffer_subspan));
 
   // Write over part of the subspan.
   std::vector<uint8_t> fill_buffer{0x11, 0x22, 0x33, 0x44};

--- a/runtime/src/iree/hal/cts/command_buffer_update_buffer_test.h
+++ b/runtime/src/iree/hal/cts/command_buffer_update_buffer_test.h
@@ -118,7 +118,7 @@ TEST_F(CommandBufferUpdateBufferTest, UpdateBufferSubspan) {
   iree_hal_buffer_t* buffer_subspan;
   IREE_ASSERT_OK(
       iree_hal_buffer_subspan(device_buffer, /*byte_offset=*/4, subspan_length,
-                              iree_allocator_system(), &buffer_subspan));
+                              iree_allocator_default(), &buffer_subspan));
 
   iree_hal_command_buffer_t* command_buffer = NULL;
   IREE_CHECK_OK(iree_hal_command_buffer_create(

--- a/runtime/src/iree/hal/cts/cts_test_base.h
+++ b/runtime/src/iree/hal/cts/cts_test_base.h
@@ -73,7 +73,7 @@ static iree_status_t TryGetDriver(const std::string& driver_name,
   iree_status_t status = iree_hal_driver_registry_try_create(
       iree_hal_driver_registry_default(),
       iree_make_string_view(driver_name.data(), driver_name.size()),
-      iree_allocator_system(), &driver);
+      iree_allocator_default(), &driver);
   if (iree_status_is_unavailable(status)) {
     unavailable_driver_names.insert(driver_name);
   }
@@ -121,7 +121,7 @@ class CTSTestBase : public BaseType, public CTSTestResources {
 
     iree_hal_device_t* device = NULL;
     status = iree_hal_driver_create_default_device(
-        driver_, iree_allocator_system(), &device);
+        driver_, iree_allocator_default(), &device);
     if (iree_status_is_unavailable(status)) {
       iree_status_ignore(status);
       return;
@@ -277,7 +277,7 @@ class CTSTestBase : public BaseType, public CTSTestResources {
   // in the message of a.
   void CheckStatusContains(iree_status_t a, iree_status_t b) {
     EXPECT_EQ(iree_status_code(a), iree_status_code(b));
-    iree_allocator_t allocator = iree_allocator_system();
+    iree_allocator_t allocator = iree_allocator_default();
     char* a_str = NULL;
     iree_host_size_t a_str_length = 0;
     EXPECT_TRUE(iree_status_to_string(a, &allocator, &a_str, &a_str_length));

--- a/runtime/src/iree/hal/cts/driver_test.h
+++ b/runtime/src/iree/hal/cts/driver_test.h
@@ -54,7 +54,7 @@ class DriverTest : public ::testing::Test {
     iree_hal_device_t* device = NULL;
     iree_status_t status = iree_hal_driver_create_device_by_path(
         driver.get(), name, path, /*param_count=*/0, /*params=*/NULL,
-        iree_allocator_system(), &device);
+        iree_allocator_default(), &device);
 
     // Creation via path is HAL driver specific. Allow unimplemented cases.
     if (iree_status_is_not_found(status)) {
@@ -77,7 +77,7 @@ TEST_F(DriverTest, QueryAndCreateAvailableDevicesByID) {
   iree_host_size_t device_info_count = 0;
   iree_hal_device_info_t* device_infos = NULL;
   IREE_ASSERT_OK(iree_hal_driver_query_available_devices(
-      driver.get(), iree_allocator_system(), &device_info_count,
+      driver.get(), iree_allocator_default(), &device_info_count,
       &device_infos));
 
   std::cout << "Driver has " << device_info_count << " device(s)\n";
@@ -89,14 +89,14 @@ TEST_F(DriverTest, QueryAndCreateAvailableDevicesByID) {
     iree_hal_device_t* device = NULL;
     IREE_ASSERT_OK(iree_hal_driver_create_device_by_id(
         driver.get(), device_infos[i].device_id, /*param_count=*/0,
-        /*params=*/NULL, iree_allocator_system(), &device));
+        /*params=*/NULL, iree_allocator_default(), &device));
     iree_string_view_t device_id = iree_hal_device_id(device);
     std::cout << "    Created device with id: '"
               << std::string(device_id.data, device_id.size) << "'\n";
     iree_hal_device_release(device);
   }
 
-  iree_allocator_free(iree_allocator_system(), device_infos);
+  iree_allocator_free(iree_allocator_default(), device_infos);
 }
 
 TEST_F(DriverTest, QueryAndCreateAvailableDevicesByOrdinal) {
@@ -105,7 +105,7 @@ TEST_F(DriverTest, QueryAndCreateAvailableDevicesByOrdinal) {
   iree_host_size_t device_info_count = 0;
   iree_hal_device_info_t* device_infos = NULL;
   IREE_ASSERT_OK(iree_hal_driver_query_available_devices(
-      driver.get(), iree_allocator_system(), &device_info_count,
+      driver.get(), iree_allocator_default(), &device_info_count,
       &device_infos));
 
   std::cout << "Driver has " << device_info_count << " device(s)\n";
@@ -117,14 +117,14 @@ TEST_F(DriverTest, QueryAndCreateAvailableDevicesByOrdinal) {
     iree_hal_device_t* device = NULL;
     IREE_ASSERT_OK(iree_hal_driver_create_device_by_ordinal(
         driver.get(), i, /*param_count=*/0, /*params=*/NULL,
-        iree_allocator_system(), &device));
+        iree_allocator_default(), &device));
     iree_string_view_t device_id = iree_hal_device_id(device);
     std::cout << "    Created device with id: '"
               << std::string(device_id.data, device_id.size) << "'\n";
     iree_hal_device_release(device);
   }
 
-  iree_allocator_free(iree_allocator_system(), device_infos);
+  iree_allocator_free(iree_allocator_default(), device_infos);
 }
 
 TEST_F(DriverTest, QueryAndCreateAvailableDevicesByPath) {
@@ -133,7 +133,7 @@ TEST_F(DriverTest, QueryAndCreateAvailableDevicesByPath) {
   iree_host_size_t device_info_count = 0;
   iree_hal_device_info_t* device_infos = NULL;
   IREE_ASSERT_OK(iree_hal_driver_query_available_devices(
-      driver.get(), iree_allocator_system(), &device_info_count,
+      driver.get(), iree_allocator_default(), &device_info_count,
       &device_infos));
 
   std::cout << "Driver has " << device_info_count << " device(s)\n";
@@ -152,7 +152,7 @@ TEST_F(DriverTest, QueryAndCreateAvailableDevicesByPath) {
     CheckCreateDeviceViaPath(device_infos[0].name, iree_string_view_empty());
   }
 
-  iree_allocator_free(iree_allocator_system(), device_infos);
+  iree_allocator_free(iree_allocator_default(), device_infos);
 }
 
 }  // namespace iree::hal::cts

--- a/runtime/src/iree/hal/cts/file_test.h
+++ b/runtime/src/iree/hal/cts/file_test.h
@@ -60,14 +60,14 @@ class FileTest : public CTSTestBase<> {
                                  iree_device_size_t file_size, uint8_t pattern,
                                  iree_hal_file_t** out_file) {
     void* file_contents = NULL;
-    IREE_CHECK_OK(iree_allocator_malloc_aligned(iree_allocator_system(),
+    IREE_CHECK_OK(iree_allocator_malloc_aligned(iree_allocator_default(),
                                                 file_size, kMinimumAlignment, 0,
                                                 (void**)&file_contents));
     memset(file_contents, pattern, file_size);
 
     iree_io_file_handle_release_callback_t release_callback = {
         +[](void* user_data, iree_io_file_handle_primitive_t handle_primitive) {
-          iree_allocator_free_aligned(iree_allocator_system(), user_data);
+          iree_allocator_free_aligned(iree_allocator_default(), user_data);
         },
         file_contents,
     };
@@ -75,7 +75,7 @@ class FileTest : public CTSTestBase<> {
     IREE_CHECK_OK(iree_io_file_handle_wrap_host_allocation(
         IREE_IO_FILE_ACCESS_READ | IREE_IO_FILE_ACCESS_WRITE,
         iree_make_byte_span(file_contents, file_size), release_callback,
-        iree_allocator_system(), &handle));
+        iree_allocator_default(), &handle));
     IREE_CHECK_OK(iree_hal_file_import(
         device_, IREE_HAL_QUEUE_AFFINITY_ANY, access, handle,
         IREE_HAL_EXTERNAL_FILE_FLAG_NONE, out_file));
@@ -97,10 +97,10 @@ TEST_F(FileTest, ReadEntireFile) {
       device_, 0ull, IREE_HAL_SEMAPHORE_FLAG_NONE, &semaphore));
   iree_hal_fence_t* wait_fence = NULL;
   IREE_ASSERT_OK(iree_hal_fence_create_at(
-      semaphore, 1ull, iree_allocator_system(), &wait_fence));
+      semaphore, 1ull, iree_allocator_default(), &wait_fence));
   iree_hal_fence_t* signal_fence = NULL;
   IREE_ASSERT_OK(iree_hal_fence_create_at(
-      semaphore, 2ull, iree_allocator_system(), &signal_fence));
+      semaphore, 2ull, iree_allocator_default(), &signal_fence));
 
   // NOTE: synchronously executing here so start with the wait signaled.
   // We should be able to make this async in the future.

--- a/runtime/src/iree/hal/drivers/cuda/dynamic_symbols_test.cc
+++ b/runtime/src/iree/hal/drivers/cuda/dynamic_symbols_test.cc
@@ -25,7 +25,7 @@ namespace {
 TEST(DynamicSymbolsTest, CreateFromSystemLoader) {
   iree_hal_cuda_dynamic_symbols_t symbols;
   iree_status_t status = iree_hal_cuda_dynamic_symbols_initialize(
-      iree_allocator_system(), &symbols);
+      iree_allocator_default(), &symbols);
   if (!iree_status_is_ok(status)) {
     iree_status_fprint(stderr, status);
     iree_status_ignore(status);
@@ -52,7 +52,7 @@ TEST(DynamicSymbolsTest, CreateFromSystemLoader) {
 TEST(NCCLDynamicSymbolsTest, CreateFromSystemLoader) {
   iree_hal_cuda_dynamic_symbols_t cuda_symbols;
   iree_status_t status = iree_hal_cuda_dynamic_symbols_initialize(
-      iree_allocator_system(), &cuda_symbols);
+      iree_allocator_default(), &cuda_symbols);
   if (!iree_status_is_ok(status)) {
     iree_status_fprint(stderr, status);
     iree_status_ignore(status);
@@ -61,7 +61,7 @@ TEST(NCCLDynamicSymbolsTest, CreateFromSystemLoader) {
 
   iree_hal_cuda_nccl_dynamic_symbols_t nccl_symbols;
   status = iree_hal_cuda_nccl_dynamic_symbols_initialize(
-      iree_allocator_system(), &cuda_symbols, &nccl_symbols);
+      iree_allocator_default(), &cuda_symbols, &nccl_symbols);
   if (!iree_status_is_ok(status)) {
     iree_status_fprint(stderr, status);
     iree_status_ignore(status);

--- a/runtime/src/iree/hal/drivers/hip/cts/multi_queue_device_creation.h
+++ b/runtime/src/iree/hal/drivers/hip/cts/multi_queue_device_creation.h
@@ -21,7 +21,7 @@ inline iree_status_t iree_hal_drivers_hip_cts_default_multi_queue_create(
   iree_host_size_t device_info_count = 0;
   iree_hal_device_info_t* device_infos = NULL;
   IREE_RETURN_IF_ERROR(iree_hal_driver_query_available_devices(
-      driver, iree_allocator_system(), &device_info_count, &device_infos));
+      driver, iree_allocator_default(), &device_info_count, &device_infos));
 
   for (iree_host_size_t i = 0; i < device_info_count; ++i) {
     const char* nm = device_infos[i].name.data;
@@ -58,7 +58,7 @@ inline iree_status_t iree_hal_drivers_hip_cts_default_multi_queue_create(
     max_valid_devices = device_count;
   }
 
-  iree_allocator_free(iree_allocator_system(), device_infos);
+  iree_allocator_free(iree_allocator_default(), device_infos);
 
   if (!max_valid_devices) {
     return iree_make_status(IREE_STATUS_NOT_FOUND,
@@ -66,7 +66,7 @@ inline iree_status_t iree_hal_drivers_hip_cts_default_multi_queue_create(
   }
   return iree_hal_driver_create_device_by_path(
       driver, IREE_SV("hip"), IREE_SV(path.c_str()), /*param_count=*/0,
-      /*params=*/NULL, iree_allocator_system(), out_device);
+      /*params=*/NULL, iree_allocator_default(), out_device);
 }
 
 #endif  // IREE_HAL_DRIVERS_HIP_REGISTRATION_MULTI_QUEUE_H_

--- a/runtime/src/iree/hal/drivers/hip/dynamic_symbols.c
+++ b/runtime/src/iree/hal/drivers/hip/dynamic_symbols.c
@@ -87,7 +87,7 @@ iree_status_t iree_hal_hip_dynamic_symbols_initialize(
   bool loaded_one = false;
   iree_status_t status = iree_ok_status();
   iree_string_builder_t error_builder;
-  iree_string_builder_initialize(iree_allocator_system(), &error_builder);
+  iree_string_builder_initialize(iree_allocator_default(), &error_builder);
 
   if (hip_lib_search_path_count == 0) {
     // If no explicit search path, then have the system try to find the library

--- a/runtime/src/iree/hal/drivers/hip/dynamic_symbols_test.cc
+++ b/runtime/src/iree/hal/drivers/hip/dynamic_symbols_test.cc
@@ -26,7 +26,7 @@ namespace {
 TEST(DynamicSymbolsTest, CreateFromSystemLoader) {
   iree_hal_hip_dynamic_symbols_t symbols;
   iree_status_t status = iree_hal_hip_dynamic_symbols_initialize(
-      iree_allocator_system(), /*hip_lib_search_path_count=*/0,
+      iree_allocator_default(), /*hip_lib_search_path_count=*/0,
       /*hip_lib_search_paths=*/NULL, &symbols);
   if (!iree_status_is_ok(status)) {
     iree_status_fprint(stderr, status);
@@ -54,7 +54,7 @@ static const iree_string_view_t non_existing_search_paths[] = {
 TEST(DynamicSymbolsTest, SearchPathsFail) {
   iree_hal_hip_dynamic_symbols_t symbols;
   iree_status_t status = iree_hal_hip_dynamic_symbols_initialize(
-      iree_allocator_system(),
+      iree_allocator_default(),
       /*hip_lib_search_path_count=*/IREE_ARRAYSIZE(non_existing_search_paths),
       non_existing_search_paths, &symbols);
 
@@ -70,7 +70,7 @@ TEST(DynamicSymbolsTest, SearchPathsFail) {
 TEST(NCCLDynamicSymbolsTest, CreateFromSystemLoader) {
   iree_hal_hip_dynamic_symbols_t hip_symbols;
   iree_status_t status = iree_hal_hip_dynamic_symbols_initialize(
-      iree_allocator_system(), /*hip_lib_search_path_count=*/0,
+      iree_allocator_default(), /*hip_lib_search_path_count=*/0,
       /*hip_lib_search_paths=*/NULL, &hip_symbols);
   if (!iree_status_is_ok(status)) {
     iree_status_fprint(stderr, status);
@@ -80,7 +80,7 @@ TEST(NCCLDynamicSymbolsTest, CreateFromSystemLoader) {
 
   iree_hal_hip_nccl_dynamic_symbols_t nccl_symbols;
   status = iree_hal_hip_nccl_dynamic_symbols_initialize(
-      iree_allocator_system(), &hip_symbols, &nccl_symbols);
+      iree_allocator_default(), &hip_symbols, &nccl_symbols);
   if (!iree_status_is_ok(status)) {
     iree_status_fprint(stderr, status);
     iree_status_ignore(status);

--- a/runtime/src/iree/hal/drivers/hip/util/queue_test.cc
+++ b/runtime/src/iree/hal/drivers/hip/util/queue_test.cc
@@ -14,7 +14,7 @@ IREE_HAL_HIP_UTIL_TYPED_QUEUE_WRAPPER(test_queue, int32_t, 4);
 class QueueTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    test_queue_initialize(iree_allocator_system(), &queue_);
+    test_queue_initialize(iree_allocator_default(), &queue_);
   }
 
   void TearDown() override { test_queue_deinitialize(&queue_); }

--- a/runtime/src/iree/hal/drivers/hip/util/tree_test.cc
+++ b/runtime/src/iree/hal/drivers/hip/util/tree_test.cc
@@ -11,7 +11,7 @@
 class RedBlackTreeTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    iree_allocator_t allocator = iree_allocator_system();
+    iree_allocator_t allocator = iree_allocator_default();
     iree_hal_hip_util_tree_initialize(allocator, sizeof(int), initial_cache,
                                       1024, &tree_);
   }

--- a/runtime/src/iree/hal/drivers/vulkan/dynamic_symbols_test.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/dynamic_symbols_test.cc
@@ -43,7 +43,7 @@ VkInstanceCreateInfo GetInstanceCreateInfo(VkApplicationInfo* app_info) {
 TEST(DynamicSymbolsTest, CreateFromSystemLoader) {
   iree::ref_ptr<iree::hal::vulkan::DynamicSymbols> syms;
   IREE_ASSERT_OK(
-      DynamicSymbols::CreateFromSystemLoader(iree_allocator_system(), &syms));
+      DynamicSymbols::CreateFromSystemLoader(iree_allocator_default(), &syms));
 
   // Create and destroy a VkInstance using the symbols. This is mainly testing
   // that the symbols were loaded successfully and are actually able to be used.

--- a/runtime/src/iree/hal/local/elf/elf_module_test_main.c
+++ b/runtime/src/iree/hal/local/elf/elf_module_test_main.c
@@ -59,10 +59,10 @@ static iree_status_t run_test() {
   memset(&import_table, 0, sizeof(import_table));
   iree_elf_module_t module;
   IREE_RETURN_IF_ERROR(iree_elf_module_initialize_from_memory(
-      file_data, &import_table, iree_allocator_system(), &module));
+      file_data, &import_table, iree_allocator_default(), &module));
 
   iree_hal_executable_environment_v0_t environment;
-  iree_hal_executable_environment_initialize(iree_allocator_system(),
+  iree_hal_executable_environment_initialize(iree_allocator_default(),
                                              &environment);
 
   void* query_fn_ptr = NULL;

--- a/runtime/src/iree/hal/local/executable_library_benchmark.c
+++ b/runtime/src/iree/hal/local/executable_library_benchmark.c
@@ -295,7 +295,7 @@ int main(int argc, char** argv) {
 
   iree_hal_executable_plugin_manager_t* plugin_manager = NULL;
   IREE_CHECK_OK(iree_hal_executable_plugin_manager_create_from_flags(
-      iree_allocator_system(), &plugin_manager));
+      iree_allocator_default(), &plugin_manager));
 
   // TODO(benvanik): override these with our own flags.
   iree_benchmark_def_t benchmark_def = {

--- a/runtime/src/iree/hal/local/executable_library_test.c
+++ b/runtime/src/iree/hal/local/executable_library_test.c
@@ -31,7 +31,7 @@
 int main(int argc, char** argv) {
   // Default environment.
   iree_hal_executable_environment_v0_t environment;
-  iree_hal_executable_environment_initialize(iree_allocator_system(),
+  iree_hal_executable_environment_initialize(iree_allocator_default(),
                                              &environment);
 
   // Query the library header at the requested version.

--- a/runtime/src/iree/hal/string_util_test.cc
+++ b/runtime/src/iree/hal/string_util_test.cc
@@ -434,8 +434,8 @@ struct Allocator final
   static StatusOr<Allocator> CreateHostLocal() {
     Allocator allocator;
     iree_status_t status = iree_hal_allocator_create_heap(
-        iree_make_cstring_view("host_local"), iree_allocator_system(),
-        iree_allocator_system(), &allocator);
+        iree_make_cstring_view("host_local"), iree_allocator_default(),
+        iree_allocator_default(), &allocator);
     IREE_RETURN_IF_ERROR(std::move(status));
     return std::move(allocator);
   }
@@ -479,7 +479,7 @@ struct BufferView final
     BufferView buffer_view;
     iree_status_t status = iree_hal_buffer_view_create(
         buffer, shape.size(), shape.data(), element_type, encoding_type,
-        iree_allocator_system(), &buffer_view);
+        iree_allocator_default(), &buffer_view);
     IREE_RETURN_IF_ERROR(std::move(status));
     return std::move(buffer_view);
   }

--- a/runtime/src/iree/hal/utils/libmpi_test.cc
+++ b/runtime/src/iree/hal/utils/libmpi_test.cc
@@ -22,7 +22,7 @@ class LibmpiTest : public ::testing::Test {
  protected:
   static void SetUpTestSuite() {
     iree_status_t status =
-        iree_hal_mpi_library_load(iree_allocator_system(), &library, &symbols);
+        iree_hal_mpi_library_load(iree_allocator_default(), &library, &symbols);
 
     if (!iree_status_is_ok(status)) {
       iree_status_fprint(stderr, status);

--- a/runtime/src/iree/hal/utils/resource_set_test.cc
+++ b/runtime/src/iree/hal/utils/resource_set_test.cc
@@ -67,7 +67,7 @@ const iree_hal_test_resource_vtable_t iree_hal_test_resource_vtable = {
 struct ResourceSetTest : public ::testing::Test {
   // We could check the allocator to ensure all memory is freed if we wanted to
   // reduce the reliance on asan.
-  iree_allocator_t host_allocator = iree_allocator_system();
+  iree_allocator_t host_allocator = iree_allocator_default();
   iree_arena_block_pool_t block_pool;
 
   void SetUp() override {

--- a/runtime/src/iree/hal/utils/semaphore_base_test.cc
+++ b/runtime/src/iree/hal/utils/semaphore_base_test.cc
@@ -159,7 +159,7 @@ static iree_hal_semaphore_callback_t MakeCallback(CallbackState* state) {
 struct TrackingSemaphoreTest : public ::testing::Test {
   // We could check the allocator to ensure all memory is freed if we wanted to
   // reduce the reliance on asan.
-  iree_allocator_t host_allocator = iree_allocator_system();
+  iree_allocator_t host_allocator = iree_allocator_default();
 
   void SetUp() override {}
 

--- a/runtime/src/iree/io/formats/gguf/gguf_parser_test.cc
+++ b/runtime/src/iree/io/formats/gguf/gguf_parser_test.cc
@@ -21,7 +21,7 @@ static iree_io_file_handle_t* OpenTestFile(const char* name) {
       IREE_CHECK_OK(iree_io_file_handle_wrap_host_allocation(
           IREE_IO_FILE_ACCESS_READ,
           iree_make_byte_span((void*)file_toc[i].data, file_toc[i].size),
-          iree_io_file_handle_release_callback_null(), iree_allocator_system(),
+          iree_io_file_handle_release_callback_null(), iree_allocator_default(),
           &file_handle));
       return file_handle;
     }
@@ -35,11 +35,11 @@ static iree_io_file_handle_t* OpenTestFile(const char* name) {
 TEST(GgufFormatTest, Empty) {
   iree_io_parameter_index_t* index = NULL;
   IREE_ASSERT_OK(
-      iree_io_parameter_index_create(iree_allocator_system(), &index));
+      iree_io_parameter_index_create(iree_allocator_default(), &index));
 
   iree_io_file_handle_t* file_handle = OpenTestFile("empty.gguf");
   IREE_ASSERT_OK(
-      iree_io_parse_gguf_index(file_handle, index, iree_allocator_system()));
+      iree_io_parse_gguf_index(file_handle, index, iree_allocator_default()));
   iree_io_file_handle_release(file_handle);
 
   iree_io_parameter_index_release(index);
@@ -48,11 +48,11 @@ TEST(GgufFormatTest, Empty) {
 TEST(GgufFormatTest, SingleTensor) {
   iree_io_parameter_index_t* index = NULL;
   IREE_ASSERT_OK(
-      iree_io_parameter_index_create(iree_allocator_system(), &index));
+      iree_io_parameter_index_create(iree_allocator_default(), &index));
 
   iree_io_file_handle_t* file_handle = OpenTestFile("single.gguf");
   IREE_ASSERT_OK(
-      iree_io_parse_gguf_index(file_handle, index, iree_allocator_system()));
+      iree_io_parse_gguf_index(file_handle, index, iree_allocator_default()));
   iree_io_file_handle_release(file_handle);
 
   const iree_io_parameter_index_entry_t* entry0 = NULL;
@@ -70,11 +70,11 @@ TEST(GgufFormatTest, SingleTensor) {
 TEST(GgufFormatTest, SingleTensorV2) {
   iree_io_parameter_index_t* index = NULL;
   IREE_ASSERT_OK(
-      iree_io_parameter_index_create(iree_allocator_system(), &index));
+      iree_io_parameter_index_create(iree_allocator_default(), &index));
 
   iree_io_file_handle_t* file_handle = OpenTestFile("single_v2.gguf");
   IREE_ASSERT_OK(
-      iree_io_parse_gguf_index(file_handle, index, iree_allocator_system()));
+      iree_io_parse_gguf_index(file_handle, index, iree_allocator_default()));
   iree_io_file_handle_release(file_handle);
 
   const iree_io_parameter_index_entry_t* entry0 = NULL;
@@ -91,11 +91,11 @@ TEST(GgufFormatTest, SingleTensorV2) {
 TEST(GgufFormatTest, MultipleTensors) {
   iree_io_parameter_index_t* index = NULL;
   IREE_ASSERT_OK(
-      iree_io_parameter_index_create(iree_allocator_system(), &index));
+      iree_io_parameter_index_create(iree_allocator_default(), &index));
 
   iree_io_file_handle_t* file_handle = OpenTestFile("multiple.gguf");
   IREE_ASSERT_OK(
-      iree_io_parse_gguf_index(file_handle, index, iree_allocator_system()));
+      iree_io_parse_gguf_index(file_handle, index, iree_allocator_default()));
   iree_io_file_handle_release(file_handle);
 
   const iree_io_parameter_index_entry_t* entry0 = NULL;

--- a/runtime/src/iree/io/formats/irpa/irpa_parser_test.cc
+++ b/runtime/src/iree/io/formats/irpa/irpa_parser_test.cc
@@ -21,7 +21,7 @@ static iree_io_file_handle_t* OpenTestFile(const char* name) {
       IREE_CHECK_OK(iree_io_file_handle_wrap_host_allocation(
           IREE_IO_FILE_ACCESS_READ,
           iree_make_byte_span((void*)file_toc[i].data, file_toc[i].size),
-          iree_io_file_handle_release_callback_null(), iree_allocator_system(),
+          iree_io_file_handle_release_callback_null(), iree_allocator_default(),
           &file_handle));
       return file_handle;
     }
@@ -35,11 +35,11 @@ static iree_io_file_handle_t* OpenTestFile(const char* name) {
 TEST(IrpaFormatTest, Empty) {
   iree_io_parameter_index_t* index = NULL;
   IREE_ASSERT_OK(
-      iree_io_parameter_index_create(iree_allocator_system(), &index));
+      iree_io_parameter_index_create(iree_allocator_default(), &index));
 
   iree_io_file_handle_t* file_handle = OpenTestFile("empty.irpa");
   IREE_ASSERT_OK(
-      iree_io_parse_irpa_index(file_handle, index, iree_allocator_system()));
+      iree_io_parse_irpa_index(file_handle, index, iree_allocator_default()));
   EXPECT_EQ(0, iree_io_parameter_index_count(index));
   iree_io_file_handle_release(file_handle);
 
@@ -49,11 +49,11 @@ TEST(IrpaFormatTest, Empty) {
 TEST(IrpaFormatTest, SingleParameters) {
   iree_io_parameter_index_t* index = NULL;
   IREE_ASSERT_OK(
-      iree_io_parameter_index_create(iree_allocator_system(), &index));
+      iree_io_parameter_index_create(iree_allocator_default(), &index));
 
   iree_io_file_handle_t* file_handle = OpenTestFile("single.irpa");
   IREE_ASSERT_OK(
-      iree_io_parse_irpa_index(file_handle, index, iree_allocator_system()));
+      iree_io_parse_irpa_index(file_handle, index, iree_allocator_default()));
   EXPECT_EQ(1, iree_io_parameter_index_count(index));
   iree_io_file_handle_release(file_handle);
 
@@ -72,11 +72,11 @@ TEST(IrpaFormatTest, SingleParameters) {
 TEST(IrpaFormatTest, MultipleParameters) {
   iree_io_parameter_index_t* index = NULL;
   IREE_ASSERT_OK(
-      iree_io_parameter_index_create(iree_allocator_system(), &index));
+      iree_io_parameter_index_create(iree_allocator_default(), &index));
 
   iree_io_file_handle_t* file_handle = OpenTestFile("multiple.irpa");
   IREE_ASSERT_OK(
-      iree_io_parse_irpa_index(file_handle, index, iree_allocator_system()));
+      iree_io_parse_irpa_index(file_handle, index, iree_allocator_default()));
   EXPECT_EQ(2, iree_io_parameter_index_count(index));
   iree_io_file_handle_release(file_handle);
 
@@ -104,11 +104,11 @@ TEST(IrpaFormatTest, MultipleParameters) {
 TEST(IrpaFormatTest, MixedDataAndSplats) {
   iree_io_parameter_index_t* index = NULL;
   IREE_ASSERT_OK(
-      iree_io_parameter_index_create(iree_allocator_system(), &index));
+      iree_io_parameter_index_create(iree_allocator_default(), &index));
 
   iree_io_file_handle_t* file_handle = OpenTestFile("mixed.irpa");
   IREE_ASSERT_OK(
-      iree_io_parse_irpa_index(file_handle, index, iree_allocator_system()));
+      iree_io_parse_irpa_index(file_handle, index, iree_allocator_default()));
   EXPECT_EQ(4, iree_io_parameter_index_count(index));
   iree_io_file_handle_release(file_handle);
 

--- a/runtime/src/iree/io/formats/safetensors/safetensors_parser_test.cc
+++ b/runtime/src/iree/io/formats/safetensors/safetensors_parser_test.cc
@@ -21,7 +21,7 @@ static iree_io_file_handle_t* OpenTestFile(const char* name) {
       IREE_CHECK_OK(iree_io_file_handle_wrap_host_allocation(
           IREE_IO_FILE_ACCESS_READ,
           iree_make_byte_span((void*)file_toc[i].data, file_toc[i].size),
-          iree_io_file_handle_release_callback_null(), iree_allocator_system(),
+          iree_io_file_handle_release_callback_null(), iree_allocator_default(),
           &file_handle));
       return file_handle;
     }
@@ -35,11 +35,11 @@ static iree_io_file_handle_t* OpenTestFile(const char* name) {
 TEST(SafetensorsFormatTest, Empty) {
   iree_io_parameter_index_t* index = NULL;
   IREE_ASSERT_OK(
-      iree_io_parameter_index_create(iree_allocator_system(), &index));
+      iree_io_parameter_index_create(iree_allocator_default(), &index));
 
   iree_io_file_handle_t* file_handle = OpenTestFile("empty.safetensors");
   IREE_ASSERT_OK(iree_io_parse_safetensors_index(file_handle, index,
-                                                 iree_allocator_system()));
+                                                 iree_allocator_default()));
   iree_io_file_handle_release(file_handle);
 
   iree_io_parameter_index_release(index);
@@ -48,11 +48,11 @@ TEST(SafetensorsFormatTest, Empty) {
 TEST(SafetensorsFormatTest, SingleTensor) {
   iree_io_parameter_index_t* index = NULL;
   IREE_ASSERT_OK(
-      iree_io_parameter_index_create(iree_allocator_system(), &index));
+      iree_io_parameter_index_create(iree_allocator_default(), &index));
 
   iree_io_file_handle_t* file_handle = OpenTestFile("single.safetensors");
   IREE_ASSERT_OK(iree_io_parse_safetensors_index(file_handle, index,
-                                                 iree_allocator_system()));
+                                                 iree_allocator_default()));
   iree_io_file_handle_release(file_handle);
 
   const iree_io_parameter_index_entry_t* entry0 = NULL;
@@ -69,11 +69,11 @@ TEST(SafetensorsFormatTest, SingleTensor) {
 TEST(SafetensorsFormatTest, MultipleTensors) {
   iree_io_parameter_index_t* index = NULL;
   IREE_ASSERT_OK(
-      iree_io_parameter_index_create(iree_allocator_system(), &index));
+      iree_io_parameter_index_create(iree_allocator_default(), &index));
 
   iree_io_file_handle_t* file_handle = OpenTestFile("multiple.safetensors");
   IREE_ASSERT_OK(iree_io_parse_safetensors_index(file_handle, index,
-                                                 iree_allocator_system()));
+                                                 iree_allocator_default()));
   iree_io_file_handle_release(file_handle);
 
   const iree_io_parameter_index_entry_t* entry0 = NULL;

--- a/runtime/src/iree/io/memory_stream_test.cc
+++ b/runtime/src/iree/io/memory_stream_test.cc
@@ -28,7 +28,7 @@ TEST(MemoryStreamTest, Wrap) {
   iree_io_stream_t* stream = NULL;
   IREE_ASSERT_OK(iree_io_memory_stream_wrap(
       IREE_IO_STREAM_MODE_READABLE, iree_make_byte_span(data, sizeof(data)),
-      iree_io_stream_release_callback_null(), iree_allocator_system(),
+      iree_io_stream_release_callback_null(), iree_allocator_default(),
       &stream));
 
   EXPECT_EQ(iree_io_stream_mode(stream), IREE_IO_STREAM_MODE_READABLE);
@@ -44,7 +44,7 @@ TEST(MemoryStreamTest, WrapEmpty) {
   iree_io_stream_t* stream = NULL;
   IREE_ASSERT_OK(iree_io_memory_stream_wrap(
       IREE_IO_STREAM_MODE_READABLE, iree_make_byte_span(data, 0),
-      iree_io_stream_release_callback_null(), iree_allocator_system(),
+      iree_io_stream_release_callback_null(), iree_allocator_default(),
       &stream));
 
   EXPECT_EQ(iree_io_stream_mode(stream), IREE_IO_STREAM_MODE_READABLE);
@@ -71,7 +71,7 @@ TEST(MemoryStreamTest, WrapReleaseCallback) {
   iree_io_stream_t* stream = NULL;
   IREE_ASSERT_OK(iree_io_memory_stream_wrap(
       IREE_IO_STREAM_MODE_READABLE, iree_make_byte_span(data, sizeof(data)),
-      release_callback, iree_allocator_system(), &stream));
+      release_callback, iree_allocator_default(), &stream));
   ASSERT_EQ(callback_count, 0);
 
   iree_io_stream_release(stream);
@@ -83,7 +83,7 @@ TEST(MemoryStreamTest, SeekSet) {
   iree_io_stream_t* stream = NULL;
   IREE_ASSERT_OK(iree_io_memory_stream_wrap(
       IREE_IO_STREAM_MODE_READABLE, iree_make_byte_span(data, sizeof(data)),
-      iree_io_stream_release_callback_null(), iree_allocator_system(),
+      iree_io_stream_release_callback_null(), iree_allocator_default(),
       &stream));
 
   // Streams start at origin 0.
@@ -126,7 +126,7 @@ TEST(MemoryStreamTest, SeekFromCurrent) {
   iree_io_stream_t* stream = NULL;
   IREE_ASSERT_OK(iree_io_memory_stream_wrap(
       IREE_IO_STREAM_MODE_READABLE, iree_make_byte_span(data, sizeof(data)),
-      iree_io_stream_release_callback_null(), iree_allocator_system(),
+      iree_io_stream_release_callback_null(), iree_allocator_default(),
       &stream));
 
   // Streams start at origin 0.
@@ -188,7 +188,7 @@ TEST(MemoryStreamTest, SeekFromEnd) {
   iree_io_stream_t* stream = NULL;
   IREE_ASSERT_OK(iree_io_memory_stream_wrap(
       IREE_IO_STREAM_MODE_READABLE, iree_make_byte_span(data, sizeof(data)),
-      iree_io_stream_release_callback_null(), iree_allocator_system(),
+      iree_io_stream_release_callback_null(), iree_allocator_default(),
       &stream));
 
   // Streams start at origin 0.
@@ -231,7 +231,7 @@ TEST(MemoryStreamTest, SeekToAlignment) {
   iree_io_stream_t* stream = NULL;
   IREE_ASSERT_OK(iree_io_memory_stream_wrap(
       IREE_IO_STREAM_MODE_READABLE, iree_make_byte_span(data, sizeof(data)),
-      iree_io_stream_release_callback_null(), iree_allocator_system(),
+      iree_io_stream_release_callback_null(), iree_allocator_default(),
       &stream));
 
   // Streams start at origin 0.
@@ -283,7 +283,7 @@ TEST(MemoryStreamTest, ReadUpTo) {
   iree_io_stream_t* stream = NULL;
   IREE_ASSERT_OK(iree_io_memory_stream_wrap(
       IREE_IO_STREAM_MODE_READABLE, iree_make_byte_span(data, sizeof(data)),
-      iree_io_stream_release_callback_null(), iree_allocator_system(),
+      iree_io_stream_release_callback_null(), iree_allocator_default(),
       &stream));
 
   // Streams start at origin 0.
@@ -344,7 +344,7 @@ TEST(MemoryStreamTest, ReadExact) {
   iree_io_stream_t* stream = NULL;
   IREE_ASSERT_OK(iree_io_memory_stream_wrap(
       IREE_IO_STREAM_MODE_READABLE, iree_make_byte_span(data, sizeof(data)),
-      iree_io_stream_release_callback_null(), iree_allocator_system(),
+      iree_io_stream_release_callback_null(), iree_allocator_default(),
       &stream));
 
   // Streams start at origin 0.
@@ -403,7 +403,7 @@ TEST(MemoryStreamTest, Write) {
   iree_io_stream_t* stream = NULL;
   IREE_ASSERT_OK(iree_io_memory_stream_wrap(
       IREE_IO_STREAM_MODE_WRITABLE, iree_make_byte_span(data, sizeof(data)),
-      iree_io_stream_release_callback_null(), iree_allocator_system(),
+      iree_io_stream_release_callback_null(), iree_allocator_default(),
       &stream));
 
   const uint8_t write_buffer[8] = {0, 1, 2, 3, 4, 5, 6, 7};
@@ -460,7 +460,7 @@ TEST(MemoryStreamTest, Fill) {
   iree_io_stream_t* stream = NULL;
   IREE_ASSERT_OK(iree_io_memory_stream_wrap(
       IREE_IO_STREAM_MODE_WRITABLE, iree_make_byte_span(data, sizeof(data)),
-      iree_io_stream_release_callback_null(), iree_allocator_system(),
+      iree_io_stream_release_callback_null(), iree_allocator_default(),
       &stream));
 
   uint8_t pattern[] = {0x80, 0x90, 0xA0, 0xB0, 0xC0, 0xD0, 0xE0, 0xF0};
@@ -534,7 +534,7 @@ TEST(MemoryStreamTest, MapRead) {
   IREE_ASSERT_OK(iree_io_memory_stream_wrap(
       IREE_IO_STREAM_MODE_READABLE | IREE_IO_STREAM_MODE_MAPPABLE,
       iree_make_byte_span(data, sizeof(data)),
-      iree_io_stream_release_callback_null(), iree_allocator_system(),
+      iree_io_stream_release_callback_null(), iree_allocator_default(),
       &stream));
 
   iree_const_byte_span_t span = iree_const_byte_span_empty();
@@ -565,7 +565,7 @@ TEST(MemoryStreamTest, MapWrite) {
   IREE_ASSERT_OK(iree_io_memory_stream_wrap(
       IREE_IO_STREAM_MODE_WRITABLE | IREE_IO_STREAM_MODE_MAPPABLE,
       iree_make_byte_span(data, sizeof(data)),
-      iree_io_stream_release_callback_null(), iree_allocator_system(),
+      iree_io_stream_release_callback_null(), iree_allocator_default(),
       &stream));
 
   iree_byte_span_t span = iree_byte_span_empty();
@@ -597,7 +597,7 @@ TEST(MemoryStreamTest, Copy) {
   IREE_ASSERT_OK(iree_io_memory_stream_wrap(
       IREE_IO_STREAM_MODE_READABLE,
       iree_make_byte_span(source_data, sizeof(source_data)),
-      iree_io_stream_release_callback_null(), iree_allocator_system(),
+      iree_io_stream_release_callback_null(), iree_allocator_default(),
       &source_stream));
 
   uint8_t target_data[5] = {0xDD};
@@ -605,7 +605,7 @@ TEST(MemoryStreamTest, Copy) {
   IREE_ASSERT_OK(iree_io_memory_stream_wrap(
       IREE_IO_STREAM_MODE_WRITABLE,
       iree_make_byte_span(target_data, sizeof(target_data)),
-      iree_io_stream_release_callback_null(), iree_allocator_system(),
+      iree_io_stream_release_callback_null(), iree_allocator_default(),
       &target_stream));
 
   // Bounds checks length.
@@ -670,7 +670,7 @@ TEST(MemoryStreamTest, CopyLarge) {
   IREE_ASSERT_OK(iree_io_memory_stream_wrap(
       IREE_IO_STREAM_MODE_READABLE,
       iree_make_byte_span(source_data.data(), source_data.size()),
-      iree_io_stream_release_callback_null(), iree_allocator_system(),
+      iree_io_stream_release_callback_null(), iree_allocator_default(),
       &source_stream));
 
   std::vector<uint8_t> target_data(1 * 1024 * 1024);
@@ -678,7 +678,7 @@ TEST(MemoryStreamTest, CopyLarge) {
   IREE_ASSERT_OK(iree_io_memory_stream_wrap(
       IREE_IO_STREAM_MODE_WRITABLE,
       iree_make_byte_span(target_data.data(), target_data.size()),
-      iree_io_stream_release_callback_null(), iree_allocator_system(),
+      iree_io_stream_release_callback_null(), iree_allocator_default(),
       &target_stream));
 
   // Copy an interior subrange.

--- a/runtime/src/iree/io/vec_stream_test.cc
+++ b/runtime/src/iree/io/vec_stream_test.cc
@@ -30,7 +30,7 @@ static StreamPtr CreateStream(iree_io_stream_mode_t mode,
                               size_t block_size = 1 * 1024) {
   iree_io_stream_t* stream = NULL;
   IREE_CHECK_OK(iree_io_vec_stream_create(mode, block_size,
-                                          iree_allocator_system(), &stream));
+                                          iree_allocator_default(), &stream));
   return StreamPtr(stream, iree_io_stream_release);
 }
 
@@ -40,7 +40,7 @@ static StreamPtr CreateStreamWithContents(iree_io_stream_mode_t mode,
                                           size_t block_size = 1 * 1024) {
   iree_io_stream_t* stream = NULL;
   IREE_CHECK_OK(iree_io_vec_stream_create(mode | IREE_IO_STREAM_MODE_WRITABLE,
-                                          block_size, iree_allocator_system(),
+                                          block_size, iree_allocator_default(),
                                           &stream));
   IREE_CHECK_OK(iree_io_stream_write(stream, sizeof(T) * N, elements));
   IREE_CHECK_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_SET, 0));

--- a/runtime/src/iree/modules/check/module.cc
+++ b/runtime/src/iree/modules/check/module.cc
@@ -579,7 +579,7 @@ class CheckModuleState final {
  private:
   // Allocator that the caller requested we use for any allocations we need to
   // perform during operation.
-  iree_allocator_t allocator_ = iree_allocator_system();
+  iree_allocator_t allocator_ = iree_allocator_default();
 };
 
 // Function table mapping imported function names to their implementation.

--- a/runtime/src/iree/runtime/demo/hello_world_explained.c
+++ b/runtime/src/iree/runtime/demo/hello_world_explained.c
@@ -81,7 +81,7 @@ static int iree_runtime_demo_main(void) {
   iree_runtime_instance_options_use_all_available_drivers(&instance_options);
   iree_runtime_instance_t* instance = NULL;
   iree_status_t status = iree_runtime_instance_create(
-      &instance_options, iree_allocator_system(), &instance);
+      &instance_options, iree_allocator_default(), &instance);
 
   // Run the demo.
   // A real application would load its models (at startup, on-demand, etc) and

--- a/runtime/src/iree/runtime/demo/hello_world_terse.c
+++ b/runtime/src/iree/runtime/demo/hello_world_terse.c
@@ -23,7 +23,7 @@ int main(int argc, char** argv) {
   iree_runtime_instance_options_use_all_available_drivers(&instance_options);
   iree_runtime_instance_t* instance = NULL;
   IREE_CHECK_OK(iree_runtime_instance_create(
-      &instance_options, iree_allocator_system(), &instance));
+      &instance_options, iree_allocator_default(), &instance));
 
   // All sessions should share the same instance.
   iree_runtime_demo_run_session(instance);

--- a/runtime/src/iree/task/executor_demo.cc
+++ b/runtime/src/iree/task/executor_demo.cc
@@ -43,7 +43,7 @@ int main(int argc, char* argv[]) {
   IREE_TRACE_APP_ENTER();
   IREE_TRACE_SCOPE_NAMED("ExecutorTest::Any");
 
-  iree_allocator_t allocator = iree_allocator_system();
+  iree_allocator_t allocator = iree_allocator_default();
 
   iree_task_topology_t topology;
 #if 1

--- a/runtime/src/iree/task/executor_test.cc
+++ b/runtime/src/iree/task/executor_test.cc
@@ -27,7 +27,7 @@ TEST(ExecutorTest, Lifetime) {
     options.worker_local_memory_size = 64 * 1024;
     iree_task_executor_t* executor = NULL;
     IREE_ASSERT_OK(iree_task_executor_create(
-        options, &topology, iree_allocator_system(), &executor));
+        options, &topology, iree_allocator_default(), &executor));
     // -- idle --
     iree_task_executor_release(executor);
   }
@@ -47,7 +47,7 @@ TEST(ExecutorTest, LifetimeStress) {
     options.worker_local_memory_size = 64 * 1024;
     iree_task_executor_t* executor = NULL;
     IREE_ASSERT_OK(iree_task_executor_create(
-        options, &topology, iree_allocator_system(), &executor));
+        options, &topology, iree_allocator_default(), &executor));
     iree_task_scope_t scope;
     iree_task_scope_initialize(iree_make_cstring_view("scope"),
                                IREE_TASK_SCOPE_FLAG_NONE, &scope);
@@ -95,8 +95,8 @@ TEST(ExecutorTest, SubmissionStress) {
   iree_task_topology_t topology;
   iree_task_topology_initialize_from_group_count(/*group_count=*/4, &topology);
   iree_task_executor_t* executor = NULL;
-  IREE_ASSERT_OK(iree_task_executor_create(options, &topology,
-                                           iree_allocator_system(), &executor));
+  IREE_ASSERT_OK(iree_task_executor_create(
+      options, &topology, iree_allocator_default(), &executor));
   iree_task_scope_t scope;
   iree_task_scope_initialize(iree_make_cstring_view("scope"),
                              IREE_TASK_SCOPE_FLAG_NONE, &scope);

--- a/runtime/src/iree/task/pool_test.cc
+++ b/runtime/src/iree/task/pool_test.cc
@@ -21,7 +21,7 @@ typedef struct iree_test_task_t {
 TEST(PoolTest, Lifetime) {
   iree_task_pool_t pool;
   IREE_ASSERT_OK(iree_task_pool_initialize(
-      iree_allocator_system(), sizeof(iree_test_task_t), 32, &pool));
+      iree_allocator_default(), sizeof(iree_test_task_t), 32, &pool));
   iree_task_pool_deinitialize(&pool);
 }
 
@@ -29,7 +29,7 @@ TEST(PoolTest, AcquireRelease) {
   // Start with 2 preallocated tasks so we can test both acquiring existing and
   // growing to allocate new tasks.
   iree_task_pool_t pool;
-  IREE_ASSERT_OK(iree_task_pool_initialize(iree_allocator_system(),
+  IREE_ASSERT_OK(iree_task_pool_initialize(iree_allocator_default(),
                                            sizeof(iree_test_task_t), 2, &pool));
 
   // Acquire 4 tasks (so we test both the initial size and allocated tasks).
@@ -60,7 +60,7 @@ TEST(PoolTest, Trim) {
   // Start with 2 preallocated tasks so we can test both acquiring existing and
   // growing to allocate new tasks.
   iree_task_pool_t pool;
-  IREE_ASSERT_OK(iree_task_pool_initialize(iree_allocator_system(),
+  IREE_ASSERT_OK(iree_task_pool_initialize(iree_allocator_default(),
                                            sizeof(iree_test_task_t), 2, &pool));
 
   // Acquire and release some tasks.

--- a/runtime/src/iree/task/testing/task_test.h
+++ b/runtime/src/iree/task/testing/task_test.h
@@ -28,7 +28,7 @@ class TaskTest : public ::testing::Test {
     iree_task_topology_t topology;
     iree_task_topology_initialize_from_group_count(8, &topology);
     IREE_ASSERT_OK(iree_task_executor_create(
-        options, &topology, iree_allocator_system(), &executor_));
+        options, &topology, iree_allocator_default(), &executor_));
     iree_task_topology_deinitialize(&topology);
 
     iree_task_scope_initialize(iree_make_cstring_view("scope"),

--- a/runtime/src/iree/task/testing/test_util.h
+++ b/runtime/src/iree/task/testing/test_util.h
@@ -22,7 +22,7 @@ using TaskPoolPtr =
     std::unique_ptr<iree_task_pool_t, void (*)(iree_task_pool_t*)>;
 static inline TaskPoolPtr AllocateNopPool() {
   iree_task_pool_t* pool = new iree_task_pool_t();
-  IREE_CHECK_OK(iree_task_pool_initialize(iree_allocator_system(),
+  IREE_CHECK_OK(iree_task_pool_initialize(iree_allocator_default(),
                                           sizeof(iree_task_nop_t), 1024, pool));
   return {pool, [](iree_task_pool_t* pool) {
             iree_task_pool_deinitialize(pool);

--- a/runtime/src/iree/testing/benchmark_full.cc
+++ b/runtime/src/iree/testing/benchmark_full.cc
@@ -109,7 +109,7 @@ static void iree_benchmark_run(const char* benchmark_name,
   iree_benchmark_state_t state;
   memset(&state, 0, sizeof(state));
   state.impl = &benchmark_state;
-  state.host_allocator = iree_allocator_system();
+  state.host_allocator = iree_allocator_default();
 
   iree_status_t status = benchmark_def->run(benchmark_def, &state);
   if (!iree_status_is_ok(status)) {

--- a/runtime/src/iree/tooling/buffer_view_matchers_test.cc
+++ b/runtime/src/iree/tooling/buffer_view_matchers_test.cc
@@ -23,7 +23,7 @@ using ::testing::HasSubstr;
 struct StringBuilder {
   static StringBuilder MakeSystem() {
     iree_string_builder_t builder;
-    iree_string_builder_initialize(iree_allocator_system(), &builder);
+    iree_string_builder_initialize(iree_allocator_default(), &builder);
     return StringBuilder(builder);
   }
   static StringBuilder MakeEmpty() {
@@ -183,7 +183,7 @@ class BufferViewMatchersTest : public ::testing::Test {
   iree_hal_allocator_t* device_allocator_ = nullptr;
   virtual void SetUp() {
     IREE_CHECK_OK(iree_hal_allocator_create_heap(
-        IREE_SV("heap"), iree_allocator_system(), iree_allocator_system(),
+        IREE_SV("heap"), iree_allocator_default(), iree_allocator_default(),
         &device_allocator_));
   }
   virtual void TearDown() { iree_hal_allocator_release(device_allocator_); }
@@ -207,7 +207,7 @@ class BufferViewMatchersTest : public ::testing::Test {
     BufferView buffer_view;
     IREE_RETURN_IF_ERROR(iree_hal_buffer_view_create(
         buffer, shape.size(), shape.data(), element_type,
-        IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR, iree_allocator_system(),
+        IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR, iree_allocator_default(),
         &buffer_view));
     return std::move(buffer_view);
   }

--- a/runtime/src/iree/tooling/comparison_test.cc
+++ b/runtime/src/iree/tooling/comparison_test.cc
@@ -76,7 +76,7 @@ class ComparisonTest : public ::testing::Test {
   }
 
   iree_vm_instance_t* instance_ = nullptr;
-  iree_allocator_t host_allocator_ = iree_allocator_system();
+  iree_allocator_t host_allocator_ = iree_allocator_default();
   iree_hal_allocator_t* device_allocator_ = nullptr;
 };
 

--- a/runtime/src/iree/tooling/device_util.c
+++ b/runtime/src/iree/tooling/device_util.c
@@ -61,7 +61,7 @@ static void iree_hal_flags_print_action_flag(iree_string_view_t flag_name,
 static iree_status_t iree_hal_flags_list_drivers(iree_string_view_t flag_name,
                                                  void* storage,
                                                  iree_string_view_t value) {
-  iree_allocator_t host_allocator = iree_allocator_system();
+  iree_allocator_t host_allocator = iree_allocator_default();
 
   iree_hal_flags_print_action_header();
   fprintf(stdout, "# Available HAL drivers\n");
@@ -138,7 +138,7 @@ static iree_status_t iree_hal_flags_list_driver_devices(
 static iree_status_t iree_hal_flags_list_devices(iree_string_view_t flag_name,
                                                  void* storage,
                                                  iree_string_view_t value) {
-  iree_allocator_t host_allocator = iree_allocator_system();
+  iree_allocator_t host_allocator = iree_allocator_default();
   iree_hal_driver_registry_t* driver_registry =
       iree_hal_available_driver_registry();
 
@@ -243,7 +243,7 @@ static iree_status_t iree_hal_flags_dump_driver_devices(
 static iree_status_t iree_hal_flags_dump_devices(iree_string_view_t flag_name,
                                                  void* storage,
                                                  iree_string_view_t value) {
-  iree_allocator_t host_allocator = iree_allocator_system();
+  iree_allocator_t host_allocator = iree_allocator_default();
   iree_hal_driver_registry_t* driver_registry =
       iree_hal_available_driver_registry();
 

--- a/runtime/src/iree/tooling/function_io_test.cc
+++ b/runtime/src/iree/tooling/function_io_test.cc
@@ -19,7 +19,7 @@ namespace {
 
 struct FunctionIOTest : public ::testing::Test {
   virtual void SetUp() {
-    host_allocator = iree_allocator_system();
+    host_allocator = iree_allocator_default();
     IREE_ASSERT_OK(iree_vm_instance_create(IREE_VM_TYPE_CAPACITY_DEFAULT,
                                            host_allocator, &instance));
     IREE_ASSERT_OK(iree_hal_module_register_all_types(instance));

--- a/runtime/src/iree/tooling/numpy_io_test.cc
+++ b/runtime/src/iree/tooling/numpy_io_test.cc
@@ -28,7 +28,7 @@ class NumpyIOTest : public ::testing::Test {
   virtual void SetUp() {
     iree_status_t status = iree_hal_create_device(
         iree_hal_available_driver_registry(), IREE_SV("local-sync"),
-        iree_allocator_system(), &device_);
+        iree_allocator_default(), &device_);
     if (iree_status_is_not_found(status)) {
       fprintf(stderr, "Skipping test as 'local-sync' driver was not found:\n");
       iree_status_fprint(stderr, status);
@@ -48,7 +48,7 @@ class NumpyIOTest : public ::testing::Test {
       IREE_CHECK_OK(iree_io_memory_stream_wrap(
           IREE_IO_STREAM_MODE_READABLE | IREE_IO_STREAM_MODE_SEEKABLE,
           iree_make_byte_span((void*)file_toc[i].data, file_toc[i].size),
-          iree_io_stream_release_callback_null(), iree_allocator_system(),
+          iree_io_stream_release_callback_null(), iree_allocator_default(),
           &stream));
       return StreamPtr(stream, iree_io_stream_release);
     }
@@ -61,7 +61,7 @@ class NumpyIOTest : public ::testing::Test {
         IREE_IO_STREAM_MODE_READABLE | IREE_IO_STREAM_MODE_WRITABLE |
             IREE_IO_STREAM_MODE_SEEKABLE,
         // /*block_size=*/32 * 1024,
-        /*block_size=*/64, iree_allocator_system(), &stream));
+        /*block_size=*/64, iree_allocator_default(), &stream));
     return StreamPtr(stream, iree_io_stream_release);
   }
 

--- a/runtime/src/iree/vm/buffer_test.cc
+++ b/runtime/src/iree/vm/buffer_test.cc
@@ -18,7 +18,7 @@ static iree_vm_instance_t* instance = NULL;
 struct VMBufferTest : public ::testing::Test {
   static void SetUpTestSuite() {
     IREE_CHECK_OK(iree_vm_instance_create(IREE_VM_TYPE_CAPACITY_DEFAULT,
-                                          iree_allocator_system(), &instance));
+                                          iree_allocator_default(), &instance));
   }
   static void TearDownTestSuite() { iree_vm_instance_release(instance); }
 };

--- a/runtime/src/iree/vm/bytecode/dispatch_async_test.cc
+++ b/runtime/src/iree/vm/bytecode/dispatch_async_test.cc
@@ -30,19 +30,19 @@ class VMBytecodeDispatchAsyncTest : public ::testing::Test {
     IREE_TRACE_SCOPE();
     const iree_file_toc_t* file = async_bytecode_modules_c_create();
 
-    IREE_CHECK_OK(iree_vm_instance_create(IREE_VM_TYPE_CAPACITY_DEFAULT,
-                                          iree_allocator_system(), &instance_));
+    IREE_CHECK_OK(iree_vm_instance_create(
+        IREE_VM_TYPE_CAPACITY_DEFAULT, iree_allocator_default(), &instance_));
 
     IREE_CHECK_OK(iree_vm_bytecode_module_create(
         instance_,
         iree_const_byte_span_t{reinterpret_cast<const uint8_t*>(file->data),
                                static_cast<iree_host_size_t>(file->size)},
-        iree_allocator_null(), iree_allocator_system(), &bytecode_module_));
+        iree_allocator_null(), iree_allocator_default(), &bytecode_module_));
 
     std::vector<iree_vm_module_t*> modules = {bytecode_module_};
     IREE_CHECK_OK(iree_vm_context_create_with_modules(
         instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.size(), modules.data(),
-        iree_allocator_system(), &context_));
+        iree_allocator_default(), &context_));
   }
 
   void TearDown() override {
@@ -68,7 +68,7 @@ TEST_F(VMBytecodeDispatchAsyncTest, YieldSequence) {
       IREE_SV("yield_sequence"), &function));
   IREE_VM_INLINE_STACK_INITIALIZE(stack, IREE_VM_CONTEXT_FLAG_NONE,
                                   iree_vm_context_state_resolver(context_),
-                                  iree_allocator_system());
+                                  iree_allocator_default());
 
   uint32_t arg_value = 97;
   uint32_t ret_value = 0;
@@ -114,7 +114,7 @@ TEST_F(VMBytecodeDispatchAsyncTest, YieldDivergent) {
       IREE_SV("yield_divergent"), &function));
   IREE_VM_INLINE_STACK_INITIALIZE(stack, IREE_VM_CONTEXT_FLAG_NONE,
                                   iree_vm_context_state_resolver(context_),
-                                  iree_allocator_system());
+                                  iree_allocator_default());
 
   // result = %arg0 ? %arg1 : %arg2
   struct {

--- a/runtime/src/iree/vm/bytecode/dispatch_test.cc
+++ b/runtime/src/iree/vm/bytecode/dispatch_test.cc
@@ -38,7 +38,7 @@ std::vector<TestParams> GetModuleTestParams() {
 
   iree_vm_instance_t* instance = NULL;
   IREE_CHECK_OK(iree_vm_instance_create(IREE_VM_TYPE_CAPACITY_DEFAULT,
-                                        iree_allocator_system(), &instance));
+                                        iree_allocator_default(), &instance));
 
   const struct iree_file_toc_t* module_file_toc =
       all_bytecode_modules_c_create();
@@ -50,7 +50,7 @@ std::vector<TestParams> GetModuleTestParams() {
         iree_const_byte_span_t{
             reinterpret_cast<const uint8_t*>(module_file.data),
             static_cast<iree_host_size_t>(module_file.size)},
-        iree_allocator_null(), iree_allocator_system(), &module));
+        iree_allocator_null(), iree_allocator_default(), &module));
     iree_vm_module_signature_t signature = iree_vm_module_signature(module);
     test_params.reserve(test_params.size() + signature.export_function_count);
     for (int i = 0; i < signature.export_function_count; ++i) {
@@ -76,20 +76,20 @@ class VMBytecodeDispatchTest
   virtual void SetUp() {
     const auto& test_params = GetParam();
 
-    IREE_CHECK_OK(iree_vm_instance_create(IREE_VM_TYPE_CAPACITY_DEFAULT,
-                                          iree_allocator_system(), &instance_));
+    IREE_CHECK_OK(iree_vm_instance_create(
+        IREE_VM_TYPE_CAPACITY_DEFAULT, iree_allocator_default(), &instance_));
 
     IREE_CHECK_OK(iree_vm_bytecode_module_create(
         instance_,
         iree_const_byte_span_t{
             reinterpret_cast<const uint8_t*>(test_params.module_file.data),
             static_cast<iree_host_size_t>(test_params.module_file.size)},
-        iree_allocator_null(), iree_allocator_system(), &bytecode_module_));
+        iree_allocator_null(), iree_allocator_default(), &bytecode_module_));
 
     std::vector<iree_vm_module_t*> modules = {bytecode_module_};
     IREE_CHECK_OK(iree_vm_context_create_with_modules(
         instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.size(), modules.data(),
-        iree_allocator_system(), &context_));
+        iree_allocator_default(), &context_));
   }
 
   virtual void TearDown() {
@@ -109,7 +109,7 @@ class VMBytecodeDispatchTest
     // flags |= IREE_VM_INVOCATION_FLAG_TRACE_EXECUTION;
     return iree_vm_invoke(context_, function, flags,
                           /*policy=*/nullptr, /*inputs=*/nullptr,
-                          /*outputs=*/nullptr, iree_allocator_system());
+                          /*outputs=*/nullptr, iree_allocator_default());
   }
 
   iree_vm_instance_t* instance_ = nullptr;

--- a/runtime/src/iree/vm/bytecode/module_benchmark.cc
+++ b/runtime/src/iree/vm/bytecode/module_benchmark.cc
@@ -77,10 +77,10 @@ static iree_status_t RunFunction(iree_benchmark_state_t* benchmark_state,
                                  int result_count, int64_t batch_size = 1) {
   iree_vm_instance_t* instance = NULL;
   IREE_CHECK_OK(iree_vm_instance_create(IREE_VM_TYPE_CAPACITY_DEFAULT,
-                                        iree_allocator_system(), &instance));
+                                        iree_allocator_default(), &instance));
 
   iree_vm_module_t* import_module = NULL;
-  IREE_CHECK_OK(native_import_module_create(instance, iree_allocator_system(),
+  IREE_CHECK_OK(native_import_module_create(instance, iree_allocator_default(),
                                             &import_module));
 
   const auto* module_file_toc =
@@ -91,13 +91,13 @@ static iree_status_t RunFunction(iree_benchmark_state_t* benchmark_state,
       iree_const_byte_span_t{
           reinterpret_cast<const uint8_t*>(module_file_toc->data),
           static_cast<iree_host_size_t>(module_file_toc->size)},
-      iree_allocator_null(), iree_allocator_system(), &bytecode_module));
+      iree_allocator_null(), iree_allocator_default(), &bytecode_module));
 
   std::array<iree_vm_module_t*, 2> modules = {import_module, bytecode_module};
   iree_vm_context_t* context = NULL;
   IREE_CHECK_OK(iree_vm_context_create_with_modules(
       instance, IREE_VM_CONTEXT_FLAG_NONE, modules.size(), modules.data(),
-      iree_allocator_system(), &context));
+      iree_allocator_default(), &context));
 
   iree_vm_function_t function;
   IREE_CHECK_OK(
@@ -115,7 +115,7 @@ static iree_status_t RunFunction(iree_benchmark_state_t* benchmark_state,
 
   IREE_VM_INLINE_STACK_INITIALIZE(stack, IREE_VM_INVOCATION_FLAG_NONE,
                                   iree_vm_context_state_resolver(context),
-                                  iree_allocator_system());
+                                  iree_allocator_default());
   while (iree_benchmark_keep_running(benchmark_state, batch_size)) {
     for (iree_host_size_t i = 0; i < i32_args.size(); ++i) {
       reinterpret_cast<int32_t*>(call.arguments.data)[i] = i32_args[i];
@@ -136,7 +136,7 @@ static iree_status_t RunFunction(iree_benchmark_state_t* benchmark_state,
 IREE_BENCHMARK_FN(BM_ModuleCreate) {
   iree_vm_instance_t* instance = NULL;
   IREE_CHECK_OK(iree_vm_instance_create(IREE_VM_TYPE_CAPACITY_DEFAULT,
-                                        iree_allocator_system(), &instance));
+                                        iree_allocator_default(), &instance));
 
   while (iree_benchmark_keep_running(benchmark_state, 1)) {
     const auto* module_file_toc =
@@ -147,7 +147,7 @@ IREE_BENCHMARK_FN(BM_ModuleCreate) {
         iree_const_byte_span_t{
             reinterpret_cast<const uint8_t*>(module_file_toc->data),
             static_cast<iree_host_size_t>(module_file_toc->size)},
-        iree_allocator_null(), iree_allocator_system(), &module));
+        iree_allocator_null(), iree_allocator_default(), &module));
 
     // Just testing creation and verification here!
     iree_optimization_barrier(module);
@@ -163,7 +163,7 @@ IREE_BENCHMARK_REGISTER(BM_ModuleCreate);
 IREE_BENCHMARK_FN(BM_ModuleCreateState) {
   iree_vm_instance_t* instance = NULL;
   IREE_CHECK_OK(iree_vm_instance_create(IREE_VM_TYPE_CAPACITY_DEFAULT,
-                                        iree_allocator_system(), &instance));
+                                        iree_allocator_default(), &instance));
 
   const auto* module_file_toc =
       iree_vm_bytecode_module_benchmark_module_create();
@@ -173,11 +173,11 @@ IREE_BENCHMARK_FN(BM_ModuleCreateState) {
       iree_const_byte_span_t{
           reinterpret_cast<const uint8_t*>(module_file_toc->data),
           static_cast<iree_host_size_t>(module_file_toc->size)},
-      iree_allocator_null(), iree_allocator_system(), &module));
+      iree_allocator_null(), iree_allocator_default(), &module));
 
   while (iree_benchmark_keep_running(benchmark_state, 1)) {
     iree_vm_module_state_t* module_state;
-    module->alloc_state(module->self, iree_allocator_system(), &module_state);
+    module->alloc_state(module->self, iree_allocator_default(), &module_state);
 
     // Really just testing malloc overhead, though it'll be module-dependent
     // and if we do anything heavyweight on state init it'll show here.
@@ -195,7 +195,7 @@ IREE_BENCHMARK_REGISTER(BM_ModuleCreateState);
 IREE_BENCHMARK_FN(BM_FullModuleInit) {
   iree_vm_instance_t* instance = NULL;
   IREE_CHECK_OK(iree_vm_instance_create(IREE_VM_TYPE_CAPACITY_DEFAULT,
-                                        iree_allocator_system(), &instance));
+                                        iree_allocator_default(), &instance));
 
   while (iree_benchmark_keep_running(benchmark_state, 1)) {
     const auto* module_file_toc =
@@ -206,10 +206,10 @@ IREE_BENCHMARK_FN(BM_FullModuleInit) {
         iree_const_byte_span_t{
             reinterpret_cast<const uint8_t*>(module_file_toc->data),
             static_cast<iree_host_size_t>(module_file_toc->size)},
-        iree_allocator_null(), iree_allocator_system(), &module));
+        iree_allocator_null(), iree_allocator_default(), &module));
 
     iree_vm_module_state_t* module_state;
-    module->alloc_state(module->self, iree_allocator_system(), &module_state);
+    module->alloc_state(module->self, iree_allocator_default(), &module_state);
 
     iree_optimization_barrier(module_state);
 

--- a/runtime/src/iree/vm/bytecode/module_size_benchmark.cc
+++ b/runtime/src/iree/vm/bytecode/module_size_benchmark.cc
@@ -12,7 +12,7 @@
 int main(int argc, char** argv) {
   iree_vm_instance_t* instance = nullptr;
   iree_vm_instance_create(IREE_VM_TYPE_CAPACITY_DEFAULT,
-                          iree_allocator_system(), &instance);
+                          iree_allocator_default(), &instance);
 
   const auto* module_file_toc =
       iree_vm_bytecode_module_size_benchmark_module_create();
@@ -22,12 +22,12 @@ int main(int argc, char** argv) {
       iree_const_byte_span_t{
           reinterpret_cast<const uint8_t*>(module_file_toc->data),
           static_cast<iree_host_size_t>(module_file_toc->size)},
-      iree_allocator_null(), iree_allocator_system(), &module);
+      iree_allocator_null(), iree_allocator_default(), &module);
 
   iree_vm_context_t* context = nullptr;
   iree_vm_context_create_with_modules(instance, IREE_VM_CONTEXT_FLAG_NONE,
                                       /*module_count=*/1, &module,
-                                      iree_allocator_system(), &context);
+                                      iree_allocator_default(), &context);
 
   iree_vm_function_t function;
   iree_vm_module_lookup_function_by_name(
@@ -36,7 +36,7 @@ int main(int argc, char** argv) {
 
   iree_vm_invoke(context, function, IREE_VM_INVOCATION_FLAG_NONE,
                  /*policy=*/nullptr, /*inputs=*/nullptr,
-                 /*outputs=*/nullptr, iree_allocator_system());
+                 /*outputs=*/nullptr, iree_allocator_default());
 
   iree_vm_module_release(module);
   iree_vm_context_release(context);

--- a/runtime/src/iree/vm/bytecode/module_test.cc
+++ b/runtime/src/iree/vm/bytecode/module_test.cc
@@ -110,8 +110,8 @@ using testing::Eq;
 class VMBytecodeModuleTest : public ::testing::Test {
  protected:
   virtual void SetUp() {
-    IREE_CHECK_OK(iree_vm_instance_create(IREE_VM_TYPE_CAPACITY_DEFAULT,
-                                          iree_allocator_system(), &instance_));
+    IREE_CHECK_OK(iree_vm_instance_create(
+        IREE_VM_TYPE_CAPACITY_DEFAULT, iree_allocator_default(), &instance_));
 
     const auto* module_file_toc = iree_vm_bytecode_module_test_module_create();
     IREE_CHECK_OK(iree_vm_bytecode_module_create(
@@ -119,12 +119,12 @@ class VMBytecodeModuleTest : public ::testing::Test {
         iree_const_byte_span_t{
             reinterpret_cast<const uint8_t*>(module_file_toc->data),
             static_cast<iree_host_size_t>(module_file_toc->size)},
-        iree_allocator_null(), iree_allocator_system(), &bytecode_module_));
+        iree_allocator_null(), iree_allocator_default(), &bytecode_module_));
 
     std::vector<iree_vm_module_t*> modules = {bytecode_module_};
     IREE_CHECK_OK(iree_vm_context_create_with_modules(
         instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.size(), modules.data(),
-        iree_allocator_system(), &context_));
+        iree_allocator_default(), &context_));
   }
 
   virtual void TearDown() {
@@ -138,7 +138,7 @@ class VMBytecodeModuleTest : public ::testing::Test {
     ref<iree_vm_list_t> input_list;
     IREE_RETURN_IF_ERROR(
         iree_vm_list_create(iree_vm_make_undefined_type_def(), inputs.size(),
-                            iree_allocator_system(), &input_list));
+                            iree_allocator_default(), &input_list));
     IREE_RETURN_IF_ERROR(iree_vm_list_resize(input_list.get(), inputs.size()));
     for (iree_host_size_t i = 0; i < inputs.size(); ++i) {
       IREE_RETURN_IF_ERROR(
@@ -147,7 +147,7 @@ class VMBytecodeModuleTest : public ::testing::Test {
 
     ref<iree_vm_list_t> output_list;
     IREE_RETURN_IF_ERROR(iree_vm_list_create(iree_vm_make_undefined_type_def(),
-                                             8, iree_allocator_system(),
+                                             8, iree_allocator_default(),
                                              &output_list));
 
     iree_vm_function_t function;
@@ -157,7 +157,7 @@ class VMBytecodeModuleTest : public ::testing::Test {
     IREE_RETURN_IF_ERROR(
         iree_vm_invoke(context_, function, IREE_VM_INVOCATION_FLAG_NONE,
                        /*policy=*/nullptr, input_list.get(), output_list.get(),
-                       iree_allocator_system()));
+                       iree_allocator_default()));
 
     std::vector<iree_vm_value_t> outputs;
     outputs.resize(iree_vm_list_size(output_list.get()));
@@ -173,7 +173,7 @@ class VMBytecodeModuleTest : public ::testing::Test {
     ref<iree_vm_list_t> input_list;
     IREE_RETURN_IF_ERROR(
         iree_vm_list_create(iree_vm_make_undefined_type_def(), inputs.size(),
-                            iree_allocator_system(), &input_list));
+                            iree_allocator_default(), &input_list));
     IREE_RETURN_IF_ERROR(iree_vm_list_resize(input_list.get(), inputs.size()));
     for (iree_host_size_t i = 0; i < inputs.size(); ++i) {
       IREE_RETURN_IF_ERROR(
@@ -182,7 +182,7 @@ class VMBytecodeModuleTest : public ::testing::Test {
 
     ref<iree_vm_list_t> output_list;
     IREE_RETURN_IF_ERROR(iree_vm_list_create(iree_vm_make_undefined_type_def(),
-                                             8, iree_allocator_system(),
+                                             8, iree_allocator_default(),
                                              &output_list));
 
     iree_vm_function_t function;
@@ -192,7 +192,7 @@ class VMBytecodeModuleTest : public ::testing::Test {
     IREE_RETURN_IF_ERROR(
         iree_vm_invoke(context_, function, IREE_VM_INVOCATION_FLAG_NONE,
                        /*policy=*/nullptr, input_list.get(), output_list.get(),
-                       iree_allocator_system()));
+                       iree_allocator_default()));
 
     std::vector<iree_vm_ref_t> outputs;
     outputs.resize(iree_vm_list_size(output_list.get()));

--- a/runtime/src/iree/vm/bytecode/utils/block_list_test.cc
+++ b/runtime/src/iree/vm/bytecode/utils/block_list_test.cc
@@ -21,7 +21,7 @@ using testing::Eq;
 
 // Tests usage on empty lists.
 TEST(BlockListTest, Empty) {
-  iree_allocator_t allocator = iree_allocator_system();
+  iree_allocator_t allocator = iree_allocator_default();
   iree_vm_bytecode_block_list_t block_list;
   IREE_ASSERT_OK(
       iree_vm_bytecode_block_list_initialize(0u, allocator, &block_list));
@@ -48,7 +48,7 @@ TEST(BlockListTest, Empty) {
 // Valid IR usage for 3 blocks. Note that we insert them out of order: 1 2 0.
 // These should be stored inline in the block list struct.
 TEST(BlockListTest, Valid) {
-  iree_allocator_t allocator = iree_allocator_system();
+  iree_allocator_t allocator = iree_allocator_default();
   iree_vm_bytecode_block_list_t block_list;
   IREE_ASSERT_OK(
       iree_vm_bytecode_block_list_initialize(3u, allocator, &block_list));
@@ -119,7 +119,7 @@ TEST(BlockListTest, Valid) {
 
 // Tests that a declared block that was never defined errors on verification.
 TEST(BlockListTest, Undefined) {
-  iree_allocator_t allocator = iree_allocator_system();
+  iree_allocator_t allocator = iree_allocator_default();
   iree_vm_bytecode_block_list_t block_list;
   IREE_ASSERT_OK(
       iree_vm_bytecode_block_list_initialize(1u, allocator, &block_list));
@@ -143,7 +143,7 @@ TEST(BlockListTest, Undefined) {
 
 // Tests adding fewer blocks than expected by the capacity.
 TEST(BlockListTest, Underflow) {
-  iree_allocator_t allocator = iree_allocator_system();
+  iree_allocator_t allocator = iree_allocator_default();
   iree_vm_bytecode_block_list_t block_list;
   IREE_ASSERT_OK(
       iree_vm_bytecode_block_list_initialize(2u, allocator, &block_list));
@@ -172,7 +172,7 @@ TEST(BlockListTest, Underflow) {
 
 // Tests adding more blocks than allowed by the capacity.
 TEST(BlockListTest, Overflow) {
-  iree_allocator_t allocator = iree_allocator_system();
+  iree_allocator_t allocator = iree_allocator_default();
   iree_vm_bytecode_block_list_t block_list;
   IREE_ASSERT_OK(
       iree_vm_bytecode_block_list_initialize(1u, allocator, &block_list));
@@ -197,7 +197,7 @@ TEST(BlockListTest, Overflow) {
 
 // Tests adding any blocks to an expected-empty list.
 TEST(BlockListTest, OverflowEmpty) {
-  iree_allocator_t allocator = iree_allocator_system();
+  iree_allocator_t allocator = iree_allocator_default();
   iree_vm_bytecode_block_list_t block_list;
   IREE_ASSERT_OK(
       iree_vm_bytecode_block_list_initialize(0u, allocator, &block_list));
@@ -214,7 +214,7 @@ TEST(BlockListTest, OverflowEmpty) {
 
 // Tests a block that is missing its marker in the bytecode.
 TEST(BlockListTest, MissingMarker) {
-  iree_allocator_t allocator = iree_allocator_system();
+  iree_allocator_t allocator = iree_allocator_default();
   iree_vm_bytecode_block_list_t block_list;
   IREE_ASSERT_OK(
       iree_vm_bytecode_block_list_initialize(1u, allocator, &block_list));
@@ -237,7 +237,7 @@ TEST(BlockListTest, MissingMarker) {
 
 // Tests a block with a pc outside of the bytecode range.
 TEST(BlockListTest, OutOfBoundsPC) {
-  iree_allocator_t allocator = iree_allocator_system();
+  iree_allocator_t allocator = iree_allocator_default();
   iree_vm_bytecode_block_list_t block_list;
   IREE_ASSERT_OK(
       iree_vm_bytecode_block_list_initialize(1u, allocator, &block_list));
@@ -261,7 +261,7 @@ TEST(BlockListTest, OutOfBoundsPC) {
 // Tests inserting a block with a PC outside of what we can track. This should
 // be really rare in practice.
 TEST(BlockListTest, OverMaxPC) {
-  iree_allocator_t allocator = iree_allocator_system();
+  iree_allocator_t allocator = iree_allocator_default();
   iree_vm_bytecode_block_list_t block_list;
   IREE_ASSERT_OK(
       iree_vm_bytecode_block_list_initialize(1u, allocator, &block_list));
@@ -277,7 +277,7 @@ TEST(BlockListTest, OverMaxPC) {
 // Tests adding a lot of blocks such that we trigger a heap storage allocation.
 TEST(BlockListTest, HeapStorage) {
   uint32_t count = IREE_VM_BYTECODE_INLINE_BLOCK_LIST_CAPACITY * 8;
-  iree_allocator_t allocator = iree_allocator_system();
+  iree_allocator_t allocator = iree_allocator_default();
   iree_vm_bytecode_block_list_t block_list;
   IREE_ASSERT_OK(
       iree_vm_bytecode_block_list_initialize(count, allocator, &block_list));

--- a/runtime/src/iree/vm/list_test.cc
+++ b/runtime/src/iree/vm/list_test.cc
@@ -159,7 +159,7 @@ struct VMListTest : public ::testing::Test {
     // Note: VM instance creation registers list types, which is required before
     // using the list APIs.
     IREE_CHECK_OK(iree_vm_instance_create(IREE_VM_TYPE_CAPACITY_DEFAULT,
-                                          iree_allocator_system(), &instance));
+                                          iree_allocator_default(), &instance));
     RegisterRefTypes(instance);
   }
   static void TearDownTestSuite() { iree_vm_instance_release(instance); }
@@ -173,7 +173,7 @@ TEST_F(VMListTest, UsageI32) {
   iree_host_size_t initial_capacity = 123;
   iree_vm_list_t* list = nullptr;
   IREE_ASSERT_OK(iree_vm_list_create(element_type, initial_capacity,
-                                     iree_allocator_system(), &list));
+                                     iree_allocator_default(), &list));
 
   iree_vm_type_def_t queried_element_type = iree_vm_list_element_type(list);
   EXPECT_TRUE(iree_vm_type_def_is_value(queried_element_type));
@@ -207,7 +207,7 @@ TEST_F(VMListTest, UsageRef) {
   iree_host_size_t initial_capacity = 123;
   iree_vm_list_t* list = nullptr;
   IREE_ASSERT_OK(iree_vm_list_create(element_type, initial_capacity,
-                                     iree_allocator_system(), &list));
+                                     iree_allocator_default(), &list));
 
   iree_vm_type_def_t queried_element_type = iree_vm_list_element_type(list);
   EXPECT_TRUE(iree_vm_type_def_is_ref(queried_element_type));
@@ -242,7 +242,7 @@ TEST_F(VMListTest, UsageVariant) {
   iree_host_size_t initial_capacity = 123;
   iree_vm_list_t* list = nullptr;
   IREE_ASSERT_OK(iree_vm_list_create(element_type, initial_capacity,
-                                     iree_allocator_system(), &list));
+                                     iree_allocator_default(), &list));
 
   iree_vm_type_def_t queried_element_type = iree_vm_list_element_type(list);
   EXPECT_TRUE(iree_vm_type_def_is_variant(queried_element_type));
@@ -288,12 +288,12 @@ TEST_F(VMListTest, CloneValuesEmpty) {
   iree_host_size_t initial_capacity = 123;
   iree_vm_list_t* source_list = nullptr;
   IREE_ASSERT_OK(iree_vm_list_create(element_type, initial_capacity,
-                                     iree_allocator_system(), &source_list));
+                                     iree_allocator_default(), &source_list));
 
   // Clone list.
   iree_vm_list_t* target_list = nullptr;
   IREE_ASSERT_OK(
-      iree_vm_list_clone(source_list, iree_allocator_system(), &target_list));
+      iree_vm_list_clone(source_list, iree_allocator_default(), &target_list));
 
   // Verify the target list matches source parameters.
   iree_vm_type_def_t queried_element_type =
@@ -314,7 +314,7 @@ TEST_F(VMListTest, CloneValues) {
   iree_host_size_t initial_capacity = 123;
   iree_vm_list_t* source_list = nullptr;
   IREE_ASSERT_OK(iree_vm_list_create(element_type, initial_capacity,
-                                     iree_allocator_system(), &source_list));
+                                     iree_allocator_default(), &source_list));
   IREE_ASSERT_OK(iree_vm_list_resize(source_list, 5));
   EXPECT_EQ(5, iree_vm_list_size(source_list));
   for (iree_host_size_t i = 0; i < 5; ++i) {
@@ -325,7 +325,7 @@ TEST_F(VMListTest, CloneValues) {
   // Clone list.
   iree_vm_list_t* target_list = nullptr;
   IREE_ASSERT_OK(
-      iree_vm_list_clone(source_list, iree_allocator_system(), &target_list));
+      iree_vm_list_clone(source_list, iree_allocator_default(), &target_list));
 
   // Verify the contents match.
   EXPECT_EQ(iree_vm_list_size(target_list), iree_vm_list_size(source_list));
@@ -345,13 +345,13 @@ TEST_F(VMListTest, CloneValues) {
 TEST_F(VMListTest, CloneRefsEmpty) {
   iree_vm_type_def_t element_type = iree_vm_make_ref_type_def(test_a_type());
   iree_vm_list_t* source_list = nullptr;
-  IREE_ASSERT_OK(iree_vm_list_create(element_type, 8, iree_allocator_system(),
+  IREE_ASSERT_OK(iree_vm_list_create(element_type, 8, iree_allocator_default(),
                                      &source_list));
 
   // Clone list.
   iree_vm_list_t* target_list = nullptr;
   IREE_ASSERT_OK(
-      iree_vm_list_clone(source_list, iree_allocator_system(), &target_list));
+      iree_vm_list_clone(source_list, iree_allocator_default(), &target_list));
 
   // Verify the target list matches source parameters.
   iree_vm_type_def_t queried_element_type =
@@ -368,7 +368,7 @@ TEST_F(VMListTest, CloneRefsEmpty) {
 TEST_F(VMListTest, CloneRefs) {
   iree_vm_type_def_t element_type = iree_vm_make_ref_type_def(test_a_type());
   iree_vm_list_t* source_list = nullptr;
-  IREE_ASSERT_OK(iree_vm_list_create(element_type, 8, iree_allocator_system(),
+  IREE_ASSERT_OK(iree_vm_list_create(element_type, 8, iree_allocator_default(),
                                      &source_list));
   IREE_ASSERT_OK(iree_vm_list_resize(source_list, 5));
   EXPECT_EQ(5, iree_vm_list_size(source_list));
@@ -380,7 +380,7 @@ TEST_F(VMListTest, CloneRefs) {
   // Clone list.
   iree_vm_list_t* target_list = nullptr;
   IREE_ASSERT_OK(
-      iree_vm_list_clone(source_list, iree_allocator_system(), &target_list));
+      iree_vm_list_clone(source_list, iree_allocator_default(), &target_list));
 
   // Verify the contents match. Since they are refs we compare pointer equality
   // to ensure they were shallowly cloned.
@@ -405,13 +405,13 @@ TEST_F(VMListTest, CloneRefs) {
 TEST_F(VMListTest, CloneVariantsEmpty) {
   iree_vm_type_def_t element_type = iree_vm_make_undefined_type_def();
   iree_vm_list_t* source_list = nullptr;
-  IREE_ASSERT_OK(iree_vm_list_create(element_type, 10, iree_allocator_system(),
+  IREE_ASSERT_OK(iree_vm_list_create(element_type, 10, iree_allocator_default(),
                                      &source_list));
 
   // Clone list.
   iree_vm_list_t* target_list = nullptr;
   IREE_ASSERT_OK(
-      iree_vm_list_clone(source_list, iree_allocator_system(), &target_list));
+      iree_vm_list_clone(source_list, iree_allocator_default(), &target_list));
 
   // Verify the target list matches source parameters.
   iree_vm_type_def_t queried_element_type =
@@ -428,7 +428,7 @@ TEST_F(VMListTest, CloneVariantsEmpty) {
 TEST_F(VMListTest, CloneVariants) {
   iree_vm_type_def_t element_type = iree_vm_make_undefined_type_def();
   iree_vm_list_t* source_list = nullptr;
-  IREE_ASSERT_OK(iree_vm_list_create(element_type, 10, iree_allocator_system(),
+  IREE_ASSERT_OK(iree_vm_list_create(element_type, 10, iree_allocator_default(),
                                      &source_list));
   IREE_ASSERT_OK(iree_vm_list_resize(source_list, 10));
   EXPECT_EQ(10, iree_vm_list_size(source_list));
@@ -444,7 +444,7 @@ TEST_F(VMListTest, CloneVariants) {
   // Clone list.
   iree_vm_list_t* target_list = nullptr;
   IREE_ASSERT_OK(
-      iree_vm_list_clone(source_list, iree_allocator_system(), &target_list));
+      iree_vm_list_clone(source_list, iree_allocator_default(), &target_list));
 
   // Verify the contents match. Since they are refs we compare pointer equality
   // to ensure they were shallowly cloned.
@@ -478,7 +478,7 @@ TEST_F(VMListTest, Reserve) {
   iree_host_size_t initial_capacity = 0;
   iree_vm_list_t* list = nullptr;
   IREE_ASSERT_OK(iree_vm_list_create(element_type, initial_capacity,
-                                     iree_allocator_system(), &list));
+                                     iree_allocator_default(), &list));
   EXPECT_LE(initial_capacity, iree_vm_list_capacity(list));
   EXPECT_EQ(0, iree_vm_list_size(list));
 
@@ -506,7 +506,7 @@ TEST_F(VMListTest, ResizeI32) {
   iree_host_size_t initial_capacity = 4;
   iree_vm_list_t* list = nullptr;
   IREE_ASSERT_OK(iree_vm_list_create(element_type, initial_capacity,
-                                     iree_allocator_system(), &list));
+                                     iree_allocator_default(), &list));
   EXPECT_LE(initial_capacity, iree_vm_list_capacity(list));
   EXPECT_EQ(0, iree_vm_list_size(list));
 
@@ -556,7 +556,7 @@ TEST_F(VMListTest, ResizeRef) {
   iree_host_size_t initial_capacity = 4;
   iree_vm_list_t* list = nullptr;
   IREE_ASSERT_OK(iree_vm_list_create(element_type, initial_capacity,
-                                     iree_allocator_system(), &list));
+                                     iree_allocator_default(), &list));
   EXPECT_LE(initial_capacity, iree_vm_list_capacity(list));
   EXPECT_EQ(0, iree_vm_list_size(list));
 
@@ -606,7 +606,7 @@ TEST_F(VMListTest, ResizeVariant) {
   iree_host_size_t initial_capacity = 4;
   iree_vm_list_t* list = nullptr;
   IREE_ASSERT_OK(iree_vm_list_create(element_type, initial_capacity,
-                                     iree_allocator_system(), &list));
+                                     iree_allocator_default(), &list));
   EXPECT_LE(initial_capacity, iree_vm_list_capacity(list));
   EXPECT_EQ(0, iree_vm_list_size(list));
 
@@ -659,7 +659,7 @@ TEST_F(VMListTest, SwapStorageSelf) {
   iree_vm_type_def_t element_type = iree_vm_make_ref_type_def(test_a_type());
   iree_vm_list_t* list = nullptr;
   IREE_ASSERT_OK(iree_vm_list_create(element_type, /*initial_capacity=*/8,
-                                     iree_allocator_system(), &list));
+                                     iree_allocator_default(), &list));
   for (iree_host_size_t i = 0; i < 5; ++i) {
     iree_vm_ref_t ref_a = MakeRef<A>((float)i);
     IREE_ASSERT_OK(iree_vm_list_push_ref_move(list, &ref_a));
@@ -685,7 +685,7 @@ TEST_F(VMListTest, SwapStorage) {
   iree_vm_type_def_t element_type_a = iree_vm_make_ref_type_def(test_a_type());
   iree_vm_list_t* list_a = nullptr;
   IREE_ASSERT_OK(iree_vm_list_create(element_type_a, /*initial_capacity=*/8,
-                                     iree_allocator_system(), &list_a));
+                                     iree_allocator_default(), &list_a));
   iree_host_size_t list_a_size = 4;
   for (iree_host_size_t i = 0; i < list_a_size; ++i) {
     iree_vm_ref_t ref_a = MakeRef<A>((float)i);
@@ -695,7 +695,7 @@ TEST_F(VMListTest, SwapStorage) {
   iree_vm_type_def_t element_type_b = iree_vm_make_ref_type_def(test_b_type());
   iree_vm_list_t* list_b = nullptr;
   IREE_ASSERT_OK(iree_vm_list_create(element_type_b, /*initial_capacity=*/8,
-                                     iree_allocator_system(), &list_b));
+                                     iree_allocator_default(), &list_b));
   iree_host_size_t list_b_size = 3;
   for (iree_host_size_t i = 0; i < list_b_size; ++i) {
     iree_vm_ref_t ref_b = MakeRef<B>((float)i);
@@ -741,10 +741,10 @@ TEST_F(VMListTest, CopyOutOfRange) {
       iree_vm_make_value_type_def(IREE_VM_VALUE_TYPE_I32);
   iree_vm_list_t* src_list = nullptr;
   IREE_ASSERT_OK(iree_vm_list_create(element_type, /*initial_capacity=*/8,
-                                     iree_allocator_system(), &src_list));
+                                     iree_allocator_default(), &src_list));
   iree_vm_list_t* dst_list = nullptr;
   IREE_ASSERT_OK(iree_vm_list_create(element_type, /*initial_capacity=*/8,
-                                     iree_allocator_system(), &dst_list));
+                                     iree_allocator_default(), &dst_list));
 
   // Lists are both empty - everything should fail.
   IREE_ASSERT_OK(iree_vm_list_resize(src_list, 0));
@@ -814,7 +814,7 @@ TEST_F(VMListTest, CopyValues) {
   // src: [0, 1, 2, 3]
   iree_vm_list_t* src_list = nullptr;
   IREE_ASSERT_OK(iree_vm_list_create(element_type, /*initial_capacity=*/8,
-                                     iree_allocator_system(), &src_list));
+                                     iree_allocator_default(), &src_list));
   IREE_ASSERT_OK(iree_vm_list_resize(src_list, 4));
   for (iree_host_size_t i = 0; i < 4; ++i) {
     iree_vm_value_t value = iree_vm_value_make_i32(i);
@@ -824,7 +824,7 @@ TEST_F(VMListTest, CopyValues) {
   // dst: [4, 5, 6, 7]
   iree_vm_list_t* dst_list = nullptr;
   IREE_ASSERT_OK(iree_vm_list_create(element_type, /*initial_capacity=*/8,
-                                     iree_allocator_system(), &dst_list));
+                                     iree_allocator_default(), &dst_list));
   IREE_ASSERT_OK(iree_vm_list_resize(dst_list, 4));
   for (iree_host_size_t i = 0; i < 4; ++i) {
     iree_vm_value_t value = iree_vm_value_make_i32(4 + i);
@@ -872,7 +872,7 @@ TEST_F(VMListTest, CopyWrongValues) {
       iree_vm_make_value_type_def(IREE_VM_VALUE_TYPE_I32);
   iree_vm_list_t* src_list = nullptr;
   IREE_ASSERT_OK(iree_vm_list_create(src_element_type, /*initial_capacity=*/8,
-                                     iree_allocator_system(), &src_list));
+                                     iree_allocator_default(), &src_list));
   IREE_ASSERT_OK(iree_vm_list_resize(src_list, 4));
   for (iree_host_size_t i = 0; i < 4; ++i) {
     iree_vm_value_t value = iree_vm_value_make_i32(i);
@@ -884,7 +884,7 @@ TEST_F(VMListTest, CopyWrongValues) {
       iree_vm_make_value_type_def(IREE_VM_VALUE_TYPE_F32);
   iree_vm_list_t* dst_list = nullptr;
   IREE_ASSERT_OK(iree_vm_list_create(dst_element_type, /*initial_capacity=*/8,
-                                     iree_allocator_system(), &dst_list));
+                                     iree_allocator_default(), &dst_list));
   IREE_ASSERT_OK(iree_vm_list_resize(dst_list, 4));
   for (iree_host_size_t i = 0; i < 4; ++i) {
     iree_vm_value_t value = iree_vm_value_make_f32(4 + i);
@@ -906,7 +906,7 @@ TEST_F(VMListTest, CopyRefs) {
   // src: [0, 1, 2, 3]
   iree_vm_list_t* src_list = nullptr;
   IREE_ASSERT_OK(iree_vm_list_create(element_type, /*initial_capacity=*/8,
-                                     iree_allocator_system(), &src_list));
+                                     iree_allocator_default(), &src_list));
   iree_host_size_t src_list_size = 4;
   for (iree_host_size_t i = 0; i < src_list_size; ++i) {
     iree_vm_ref_t ref = MakeRef<B>(i);
@@ -916,7 +916,7 @@ TEST_F(VMListTest, CopyRefs) {
   // dst: [4, 5, 6, 7]
   iree_vm_list_t* dst_list = nullptr;
   IREE_ASSERT_OK(iree_vm_list_create(element_type, /*initial_capacity=*/8,
-                                     iree_allocator_system(), &dst_list));
+                                     iree_allocator_default(), &dst_list));
   iree_host_size_t dst_list_size = 4;
   for (iree_host_size_t i = 0; i < dst_list_size; ++i) {
     iree_vm_ref_t ref = MakeRef<B>(4 + i);
@@ -962,7 +962,7 @@ TEST_F(VMListTest, CopyWrongRefs) {
       iree_vm_make_ref_type_def(test_a_type());
   iree_vm_list_t* src_list = nullptr;
   IREE_ASSERT_OK(iree_vm_list_create(src_element_type, /*initial_capacity=*/8,
-                                     iree_allocator_system(), &src_list));
+                                     iree_allocator_default(), &src_list));
   iree_host_size_t src_list_size = 4;
   for (iree_host_size_t i = 0; i < src_list_size; ++i) {
     iree_vm_ref_t ref = MakeRef<A>(i);
@@ -974,7 +974,7 @@ TEST_F(VMListTest, CopyWrongRefs) {
       iree_vm_make_ref_type_def(test_b_type());
   iree_vm_list_t* dst_list = nullptr;
   IREE_ASSERT_OK(iree_vm_list_create(dst_element_type, /*initial_capacity=*/8,
-                                     iree_allocator_system(), &dst_list));
+                                     iree_allocator_default(), &dst_list));
   iree_host_size_t dst_list_size = 4;
   for (iree_host_size_t i = 0; i < dst_list_size; ++i) {
     iree_vm_ref_t ref = MakeRef<B>(4 + i);
@@ -1000,7 +1000,7 @@ TEST_F(VMListTest, CopyVariants) {
   iree_vm_list_t* src_list = nullptr;
   IREE_ASSERT_OK(iree_vm_list_create(iree_vm_make_undefined_type_def(),
                                      /*initial_capacity=*/8,
-                                     iree_allocator_system(), &src_list));
+                                     iree_allocator_default(), &src_list));
   IREE_ASSERT_OK(iree_vm_list_resize(src_list, 4));
   for (iree_host_size_t i = 0; i < 2; ++i) {
     iree_vm_value_t value = iree_vm_value_make_i32(i);
@@ -1015,7 +1015,7 @@ TEST_F(VMListTest, CopyVariants) {
   iree_vm_list_t* dst_list = nullptr;
   IREE_ASSERT_OK(iree_vm_list_create(iree_vm_make_undefined_type_def(),
                                      /*initial_capacity=*/8,
-                                     iree_allocator_system(), &dst_list));
+                                     iree_allocator_default(), &dst_list));
   IREE_ASSERT_OK(iree_vm_list_resize(dst_list, 4));
   for (iree_host_size_t i = 0; i < 2; ++i) {
     iree_vm_value_t value = iree_vm_value_make_i32(4 + i);
@@ -1064,7 +1064,7 @@ TEST_F(VMListTest, CopyFromVariants) {
   iree_vm_list_t* src_list = nullptr;
   IREE_ASSERT_OK(iree_vm_list_create(iree_vm_make_undefined_type_def(),
                                      /*initial_capacity=*/8,
-                                     iree_allocator_system(), &src_list));
+                                     iree_allocator_default(), &src_list));
   IREE_ASSERT_OK(iree_vm_list_resize(src_list, 4));
   for (iree_host_size_t i = 0; i < 2; ++i) {
     iree_vm_value_t value = iree_vm_value_make_i32(i);
@@ -1080,7 +1080,7 @@ TEST_F(VMListTest, CopyFromVariants) {
       iree_vm_make_value_type_def(IREE_VM_VALUE_TYPE_I32);
   iree_vm_list_t* dst_list = nullptr;
   IREE_ASSERT_OK(iree_vm_list_create(dst_element_type, /*initial_capacity=*/8,
-                                     iree_allocator_system(), &dst_list));
+                                     iree_allocator_default(), &dst_list));
   IREE_ASSERT_OK(iree_vm_list_resize(dst_list, 4));
   for (iree_host_size_t i = 0; i < 4; ++i) {
     iree_vm_value_t value = iree_vm_value_make_i32(4 + i);
@@ -1130,7 +1130,7 @@ TEST_F(VMListTest, CopyToVariants) {
       iree_vm_make_value_type_def(IREE_VM_VALUE_TYPE_I32);
   iree_vm_list_t* src_list = nullptr;
   IREE_ASSERT_OK(iree_vm_list_create(src_element_type, /*initial_capacity=*/8,
-                                     iree_allocator_system(), &src_list));
+                                     iree_allocator_default(), &src_list));
   IREE_ASSERT_OK(iree_vm_list_resize(src_list, 4));
   for (iree_host_size_t i = 0; i < 4; ++i) {
     iree_vm_value_t value = iree_vm_value_make_i32(i);
@@ -1141,7 +1141,7 @@ TEST_F(VMListTest, CopyToVariants) {
   iree_vm_list_t* dst_list = nullptr;
   IREE_ASSERT_OK(iree_vm_list_create(iree_vm_make_undefined_type_def(),
                                      /*initial_capacity=*/8,
-                                     iree_allocator_system(), &dst_list));
+                                     iree_allocator_default(), &dst_list));
   IREE_ASSERT_OK(iree_vm_list_resize(dst_list, 4));
   for (iree_host_size_t i = 0; i < 2; ++i) {
     iree_vm_value_t value = iree_vm_value_make_i32(4 + i);
@@ -1196,7 +1196,7 @@ TEST_F(VMListTest, PushPopRef) {
   iree_host_size_t initial_capacity = 4;
   iree_vm_list_t* list = nullptr;
   IREE_ASSERT_OK(iree_vm_list_create(element_type, initial_capacity,
-                                     iree_allocator_system(), &list));
+                                     iree_allocator_default(), &list));
   EXPECT_LE(initial_capacity, iree_vm_list_capacity(list));
   EXPECT_EQ(0, iree_vm_list_size(list));
 

--- a/runtime/src/iree/vm/native_module_test.cc
+++ b/runtime/src/iree/vm/native_module_test.cc
@@ -27,8 +27,8 @@ namespace {
 class VMNativeModuleTest : public ::testing::Test {
  protected:
   virtual void SetUp() {
-    IREE_CHECK_OK(iree_vm_instance_create(IREE_VM_TYPE_CAPACITY_DEFAULT,
-                                          iree_allocator_system(), &instance_));
+    IREE_CHECK_OK(iree_vm_instance_create(
+        IREE_VM_TYPE_CAPACITY_DEFAULT, iree_allocator_default(), &instance_));
   }
 
   virtual void TearDown() { iree_vm_instance_release(instance_); }
@@ -38,10 +38,10 @@ class VMNativeModuleTest : public ::testing::Test {
     // can be shared by multiple contexts.
     iree_vm_module_t* module_a = nullptr;
     IREE_CHECK_OK(
-        module_a_create(instance_, iree_allocator_system(), &module_a));
+        module_a_create(instance_, iree_allocator_default(), &module_a));
     iree_vm_module_t* module_b = nullptr;
     IREE_CHECK_OK(
-        module_b_create(instance_, iree_allocator_system(), &module_b));
+        module_b_create(instance_, iree_allocator_default(), &module_b));
 
     // Create the context with both modules and perform runtime linkage.
     // Imports from module_a -> module_b will be resolved and per-context state
@@ -50,7 +50,7 @@ class VMNativeModuleTest : public ::testing::Test {
     std::vector<iree_vm_module_t*> modules = {module_a, module_b};
     IREE_CHECK_OK(iree_vm_context_create_with_modules(
         instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.size(), modules.data(),
-        iree_allocator_system(), &context));
+        iree_allocator_default(), &context));
 
     // No longer need the modules as the context retains them.
     iree_vm_module_release(module_a);
@@ -74,21 +74,21 @@ class VMNativeModuleTest : public ::testing::Test {
     // populated upon return.
     vm::ref<iree_vm_list_t> input_list;
     IREE_RETURN_IF_ERROR(iree_vm_list_create(iree_vm_make_undefined_type_def(),
-                                             1, iree_allocator_system(),
+                                             1, iree_allocator_default(),
                                              &input_list));
     auto arg0_value = iree_vm_value_make_i32(arg0);
     IREE_RETURN_IF_ERROR(
         iree_vm_list_push_value(input_list.get(), &arg0_value));
     vm::ref<iree_vm_list_t> output_list;
     IREE_RETURN_IF_ERROR(iree_vm_list_create(iree_vm_make_undefined_type_def(),
-                                             1, iree_allocator_system(),
+                                             1, iree_allocator_default(),
                                              &output_list));
 
     // Invoke the entry function to do our work. Runs synchronously.
     IREE_RETURN_IF_ERROR(
         iree_vm_invoke(context, function, IREE_VM_INVOCATION_FLAG_NONE,
                        /*policy=*/nullptr, input_list.get(), output_list.get(),
-                       iree_allocator_system()));
+                       iree_allocator_default()));
 
     // Load the output result.
     iree_vm_value_t ret0_value;
@@ -131,7 +131,7 @@ TEST_F(VMNativeModuleTest, Fork) {
 
   // Fork the parent context, preserving its state.
   iree_vm_context_t* child_context = NULL;
-  IREE_ASSERT_OK(iree_vm_context_fork(parent_context, iree_allocator_system(),
+  IREE_ASSERT_OK(iree_vm_context_fork(parent_context, iree_allocator_default(),
                                       &child_context));
 
   // Run a tick in both the parent and child contexts; the values should match

--- a/runtime/src/iree/vm/ref_test.cc
+++ b/runtime/src/iree/vm/ref_test.cc
@@ -21,7 +21,7 @@ using InstancePtr =
 static InstancePtr MakeInstance() {
   iree_vm_instance_t* instance = NULL;
   IREE_CHECK_OK(iree_vm_instance_create(IREE_VM_TYPE_CAPACITY_DEFAULT,
-                                        iree_allocator_system(), &instance));
+                                        iree_allocator_default(), &instance));
   return InstancePtr(instance, iree_vm_instance_release);
 }
 

--- a/runtime/src/iree/vm/stack.h
+++ b/runtime/src/iree/vm/stack.h
@@ -175,7 +175,7 @@ typedef struct iree_vm_stack_t iree_vm_stack_t;
 //      stack,
 //      IREE_VM_INVOCATION_FLAG_NONE,
 //      iree_vm_context_state_resolver(context),
-//      iree_allocator_system());
+//      iree_allocator_default());
 //  ...
 //  iree_vm_stack_deinitialize(stack);
 #define IREE_VM_INLINE_STACK_INITIALIZE(stack, flags, state_resolver, \
@@ -229,7 +229,7 @@ IREE_API_EXPORT void iree_vm_stack_deinitialize(iree_vm_stack_t* stack);
 //
 // Example:
 //  iree_vm_stack_t* stack = NULL;
-//  iree_vm_stack_allocate(..., iree_allocator_system(), &stack);
+//  iree_vm_stack_allocate(..., iree_allocator_default(), &stack);
 //  ...
 //  iree_vm_stack_free(stack);
 IREE_API_EXPORT iree_status_t iree_vm_stack_allocate(

--- a/runtime/src/iree/vm/stack_test.cc
+++ b/runtime/src/iree/vm/stack_test.cc
@@ -38,7 +38,7 @@ static iree_status_t SentinelStateResolver(
 TEST(VMStackTest, Usage) {
   iree_vm_state_resolver_t state_resolver = {nullptr, SentinelStateResolver};
   IREE_VM_INLINE_STACK_INITIALIZE(stack, IREE_VM_INVOCATION_FLAG_NONE,
-                                  state_resolver, iree_allocator_system());
+                                  state_resolver, iree_allocator_default());
 
   EXPECT_EQ(nullptr, iree_vm_stack_current_frame(stack));
   EXPECT_EQ(nullptr, iree_vm_stack_parent_frame(stack));
@@ -75,7 +75,7 @@ TEST(VMStackTest, Usage) {
 TEST(VMStackTest, DeinitWithRemainingFrames) {
   iree_vm_state_resolver_t state_resolver = {nullptr, SentinelStateResolver};
   IREE_VM_INLINE_STACK_INITIALIZE(stack, IREE_VM_INVOCATION_FLAG_NONE,
-                                  state_resolver, iree_allocator_system());
+                                  state_resolver, iree_allocator_default());
 
   iree_vm_function_t function_a = {MODULE_A_SENTINEL,
                                    IREE_VM_FUNCTION_LINKAGE_INTERNAL, 0};
@@ -94,7 +94,7 @@ TEST(VMStackTest, DeinitWithRemainingFrames) {
 TEST(VMStackTest, StackOverflow) {
   iree_vm_state_resolver_t state_resolver = {nullptr, SentinelStateResolver};
   IREE_VM_INLINE_STACK_INITIALIZE(stack, IREE_VM_INVOCATION_FLAG_NONE,
-                                  state_resolver, iree_allocator_system());
+                                  state_resolver, iree_allocator_default());
 
   EXPECT_EQ(nullptr, iree_vm_stack_current_frame(stack));
   EXPECT_EQ(nullptr, iree_vm_stack_parent_frame(stack));
@@ -124,7 +124,7 @@ TEST(VMStackTest, StackOverflow) {
 TEST(VMStackTest, UnbalancedPop) {
   iree_vm_state_resolver_t state_resolver = {nullptr, SentinelStateResolver};
   IREE_VM_INLINE_STACK_INITIALIZE(stack, IREE_VM_INVOCATION_FLAG_NONE,
-                                  state_resolver, iree_allocator_system());
+                                  state_resolver, iree_allocator_default());
 
   iree_status_t status = iree_vm_stack_function_leave(stack);
   IREE_EXPECT_STATUS_IS(IREE_STATUS_FAILED_PRECONDITION, status);
@@ -137,7 +137,7 @@ TEST(VMStackTest, UnbalancedPop) {
 TEST(VMStackTest, ModuleStateQueries) {
   iree_vm_state_resolver_t state_resolver = {nullptr, SentinelStateResolver};
   IREE_VM_INLINE_STACK_INITIALIZE(stack, IREE_VM_INVOCATION_FLAG_NONE,
-                                  state_resolver, iree_allocator_system());
+                                  state_resolver, iree_allocator_default());
 
   EXPECT_EQ(nullptr, iree_vm_stack_current_frame(stack));
   EXPECT_EQ(nullptr, iree_vm_stack_parent_frame(stack));
@@ -186,7 +186,7 @@ TEST(VMStackTest, ModuleStateQueryFailure) {
         return iree_make_status(IREE_STATUS_INTERNAL);
       }};
   IREE_VM_INLINE_STACK_INITIALIZE(stack, IREE_VM_INVOCATION_FLAG_NONE,
-                                  state_resolver, iree_allocator_system());
+                                  state_resolver, iree_allocator_default());
 
   // Push should fail if we can't query state, status should propagate.
   iree_vm_function_t function_a = {MODULE_A_SENTINEL,

--- a/runtime/src/iree/vm/test/emitc/module_test.cc
+++ b/runtime/src/iree/vm/test/emitc/module_test.cc
@@ -119,17 +119,17 @@ class VMCModuleTest : public ::testing::Test,
   virtual void SetUp() {
     const auto& test_params = GetParam();
 
-    IREE_CHECK_OK(iree_vm_instance_create(IREE_VM_TYPE_CAPACITY_DEFAULT,
-                                          iree_allocator_system(), &instance_));
+    IREE_CHECK_OK(iree_vm_instance_create(
+        IREE_VM_TYPE_CAPACITY_DEFAULT, iree_allocator_default(), &instance_));
 
     iree_vm_module_t* module_ = nullptr;
     IREE_CHECK_OK(test_params.create_function(
-        instance_, iree_allocator_system(), &module_));
+        instance_, iree_allocator_default(), &module_));
 
     std::vector<iree_vm_module_t*> modules = {module_};
     IREE_CHECK_OK(iree_vm_context_create_with_modules(
         instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.size(), modules.data(),
-        iree_allocator_system(), &context_));
+        iree_allocator_default(), &context_));
 
     iree_vm_module_release(module_);
   }
@@ -150,7 +150,7 @@ class VMCModuleTest : public ::testing::Test,
 
     return iree_vm_invoke(context_, function, IREE_VM_INVOCATION_FLAG_NONE,
                           /*policy=*/nullptr, /*inputs=*/nullptr,
-                          /*outputs=*/nullptr, iree_allocator_system());
+                          /*outputs=*/nullptr, iree_allocator_default());
   }
 
   iree_vm_instance_t* instance_ = nullptr;

--- a/samples/custom_module/async/main.c
+++ b/samples/custom_module/async/main.c
@@ -33,7 +33,7 @@ int main(int argc, char** argv) {
   // Internally IREE does not (in general) use malloc and instead uses the
   // provided allocator to allocate and free memory. Applications can integrate
   // their own allocator as-needed.
-  iree_allocator_t host_allocator = iree_allocator_system();
+  iree_allocator_t host_allocator = iree_allocator_default();
 
   // Create and configure the instance shared across all sessions.
   iree_runtime_instance_options_t instance_options;

--- a/samples/custom_module/basic/main.c
+++ b/samples/custom_module/basic/main.c
@@ -41,7 +41,7 @@ int main(int argc, char** argv) {
   // Internally IREE does not (in general) use malloc and instead uses the
   // provided allocator to allocate and free memory. Applications can integrate
   // their own allocator as-needed.
-  iree_allocator_t allocator = iree_allocator_system();
+  iree_allocator_t allocator = iree_allocator_default();
 
   // Create the root isolated VM instance that we can create contexts within.
   iree_vm_instance_t* instance = NULL;

--- a/samples/custom_module/sync/main.c
+++ b/samples/custom_module/sync/main.c
@@ -33,7 +33,7 @@ int main(int argc, char** argv) {
   // Internally IREE does not (in general) use malloc and instead uses the
   // provided allocator to allocate and free memory. Applications can integrate
   // their own allocator as-needed.
-  iree_allocator_t host_allocator = iree_allocator_system();
+  iree_allocator_t host_allocator = iree_allocator_default();
 
   // Create and configure the instance shared across all sessions.
   iree_runtime_instance_options_t instance_options;

--- a/samples/dynamic_shapes/main.c
+++ b/samples/dynamic_shapes/main.c
@@ -153,7 +153,7 @@ iree_status_t run_sample(iree_string_view_t bytecode_module_path,
   iree_runtime_instance_t* instance = NULL;
   if (iree_status_is_ok(status)) {
     status = iree_runtime_instance_create(&instance_options,
-                                          iree_allocator_system(), &instance);
+                                          iree_allocator_default(), &instance);
   }
   // TODO(#5724): move device selection into the compiled modules.
   iree_hal_device_t* device = NULL;

--- a/samples/emitc_modules/add_module_test.cc
+++ b/samples/emitc_modules/add_module_test.cc
@@ -17,17 +17,17 @@ namespace {
 class VMAddModuleTest : public ::testing::Test {
  protected:
   virtual void SetUp() {
-    IREE_CHECK_OK(iree_vm_instance_create(IREE_VM_TYPE_CAPACITY_DEFAULT,
-                                          iree_allocator_system(), &instance_));
+    IREE_CHECK_OK(iree_vm_instance_create(
+        IREE_VM_TYPE_CAPACITY_DEFAULT, iree_allocator_default(), &instance_));
 
     iree_vm_module_t* add_module = nullptr;
     IREE_CHECK_OK(
-        add_module_create(instance_, iree_allocator_system(), &add_module));
+        add_module_create(instance_, iree_allocator_default(), &add_module));
 
     std::vector<iree_vm_module_t*> modules = {add_module};
     IREE_CHECK_OK(iree_vm_context_create_with_modules(
         instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.size(), modules.data(),
-        iree_allocator_system(), &context_));
+        iree_allocator_default(), &context_));
 
     iree_vm_module_release(add_module);
   }
@@ -49,20 +49,20 @@ class VMAddModuleTest : public ::testing::Test {
     // populated upon return.
     vm::ref<iree_vm_list_t> input_list;
     IREE_RETURN_IF_ERROR(iree_vm_list_create(iree_vm_make_undefined_type_def(),
-                                             1, iree_allocator_system(),
+                                             1, iree_allocator_default(),
                                              &input_list));
     auto arg_value = iree_vm_value_make_i32(arg);
     IREE_RETURN_IF_ERROR(iree_vm_list_push_value(input_list.get(), &arg_value));
     vm::ref<iree_vm_list_t> output_list;
     IREE_RETURN_IF_ERROR(iree_vm_list_create(iree_vm_make_undefined_type_def(),
-                                             1, iree_allocator_system(),
+                                             1, iree_allocator_default(),
                                              &output_list));
 
     // Invoke the entry function to do our work. Runs synchronously.
     IREE_RETURN_IF_ERROR(
         iree_vm_invoke(context_, function, IREE_VM_INVOCATION_FLAG_NONE,
                        /*policy=*/nullptr, input_list.get(), output_list.get(),
-                       iree_allocator_system()));
+                       iree_allocator_default()));
 
     // Load the output result.
     iree_vm_value_t ret_value;
@@ -84,7 +84,7 @@ class VMAddModuleTest : public ::testing::Test {
     // populated upon return.
     vm::ref<iree_vm_list_t> input_list;
     IREE_RETURN_IF_ERROR(iree_vm_list_create(iree_vm_make_undefined_type_def(),
-                                             1, iree_allocator_system(),
+                                             1, iree_allocator_default(),
                                              &input_list));
     auto arg0_value = iree_vm_value_make_i32(arg0);
     auto arg1_value = iree_vm_value_make_i32(arg1);
@@ -94,14 +94,14 @@ class VMAddModuleTest : public ::testing::Test {
         iree_vm_list_push_value(input_list.get(), &arg1_value));
     vm::ref<iree_vm_list_t> output_list;
     IREE_RETURN_IF_ERROR(iree_vm_list_create(iree_vm_make_undefined_type_def(),
-                                             1, iree_allocator_system(),
+                                             1, iree_allocator_default(),
                                              &output_list));
 
     // Invoke the entry function to do our work. Runs synchronously.
     IREE_RETURN_IF_ERROR(
         iree_vm_invoke(context_, function, IREE_VM_INVOCATION_FLAG_NONE,
                        /*policy=*/nullptr, input_list.get(), output_list.get(),
-                       iree_allocator_system()));
+                       iree_allocator_default()));
 
     // Load the output result.
     iree_vm_value_t ret_value;

--- a/samples/emitc_modules/import_module_test.cc
+++ b/samples/emitc_modules/import_module_test.cc
@@ -17,22 +17,22 @@ namespace {
 class VMImportModuleTest : public ::testing::Test {
  protected:
   virtual void SetUp() {
-    IREE_CHECK_OK(iree_vm_instance_create(IREE_VM_TYPE_CAPACITY_DEFAULT,
-                                          iree_allocator_system(), &instance_));
+    IREE_CHECK_OK(iree_vm_instance_create(
+        IREE_VM_TYPE_CAPACITY_DEFAULT, iree_allocator_default(), &instance_));
 
     iree_vm_module_t* module_a = nullptr;
     IREE_CHECK_OK(
-        module_a_create(instance_, iree_allocator_system(), &module_a));
+        module_a_create(instance_, iree_allocator_default(), &module_a));
 
     iree_vm_module_t* module_b = nullptr;
     IREE_CHECK_OK(
-        module_b_create(instance_, iree_allocator_system(), &module_b));
+        module_b_create(instance_, iree_allocator_default(), &module_b));
 
     // Note: order matters as module_a imports from module_b
     std::vector<iree_vm_module_t*> modules = {module_b, module_a};
     IREE_CHECK_OK(iree_vm_context_create_with_modules(
         instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.size(), modules.data(),
-        iree_allocator_system(), &context_));
+        iree_allocator_default(), &context_));
 
     iree_vm_module_release(module_a);
     iree_vm_module_release(module_b);
@@ -55,20 +55,20 @@ class VMImportModuleTest : public ::testing::Test {
     // populated upon return.
     vm::ref<iree_vm_list_t> input_list;
     IREE_RETURN_IF_ERROR(iree_vm_list_create(iree_vm_make_undefined_type_def(),
-                                             1, iree_allocator_system(),
+                                             1, iree_allocator_default(),
                                              &input_list));
     auto arg_value = iree_vm_value_make_i32(arg);
     IREE_RETURN_IF_ERROR(iree_vm_list_push_value(input_list.get(), &arg_value));
     vm::ref<iree_vm_list_t> output_list;
     IREE_RETURN_IF_ERROR(iree_vm_list_create(iree_vm_make_undefined_type_def(),
-                                             1, iree_allocator_system(),
+                                             1, iree_allocator_default(),
                                              &output_list));
 
     // Invoke the entry function to do our work. Runs synchronously.
     IREE_RETURN_IF_ERROR(
         iree_vm_invoke(context_, function, IREE_VM_INVOCATION_FLAG_NONE,
                        /*policy=*/nullptr, input_list.get(), output_list.get(),
-                       iree_allocator_system()));
+                       iree_allocator_default()));
 
     // Load the output result.
     iree_vm_value_t ret_value;

--- a/samples/simple_embedding/README.md
+++ b/samples/simple_embedding/README.md
@@ -22,6 +22,7 @@ bytecode with various target backends.
 Set up the CMake configuration with `-DIREE_BUILD_SAMPLES=ON` (default on)
 
 Then run
+
 ```sh
 cmake --build <build dir> --target samples/simple_embedding/all
 ```
@@ -69,14 +70,14 @@ iree_hal_sync_device_params_t params;
 iree_hal_sync_device_params_initialize(&params);
 iree_hal_executable_loader_t* loader = NULL;
   IREE_RETURN_IF_ERROR(iree_hal_embedded_elf_loader_create(
-      /*plugin_manager=*/NULL, iree_allocator_system(),
+      /*plugin_manager=*/NULL, iree_allocator_default(),
       &loader));
 
 iree_string_view_t identifier = iree_make_cstring_view("local-sync");
 
 iree_status_t status =
     iree_hal_sync_device_create(identifier, &params, /*loader_count=*/1,
-                                &loader, iree_allocator_system(), device);
+                                &loader, iree_allocator_default(), device);
 ```
 
 Whereas for [device_embedded.c](./device_embedded.c), the "sync device" is
@@ -87,7 +88,7 @@ replaced with the multithreaded "task device", which uses a "task executor":
 iree_task_executor_t* executor = NULL;
 iree_host_size_t executor_count = 0;
 iree_status_t status =
-    iree_task_executors_create_from_flags(iree_allocator_system(),
+    iree_task_executors_create_from_flags(iree_allocator_default(),
                                           1, &executor, &executor_count);
 IREE_ASSERT_EQ(count, 1, "NUMA unsupported");
 
@@ -97,8 +98,9 @@ if (iree_status_is_ok(status)) {
   status = iree_hal_task_device_create(identifier, &params,
                                        /*queue_count=*/1, &executor,
                                        /*loader_count=*/1, &loader,
-                                       iree_allocator_system(), device);
+                                       iree_allocator_default(), device);
 ```
+
 An example that utilizes a higher-level driver registry is in
 [device_vulkan.c](./device_vulkan.c)
 

--- a/samples/simple_embedding/simple_embedding.c
+++ b/samples/simple_embedding/simple_embedding.c
@@ -33,16 +33,16 @@ extern const iree_const_byte_span_t load_bytecode_module_data();
 iree_status_t Run() {
   iree_vm_instance_t* instance = NULL;
   IREE_RETURN_IF_ERROR(iree_vm_instance_create(
-      IREE_VM_TYPE_CAPACITY_DEFAULT, iree_allocator_system(), &instance));
+      IREE_VM_TYPE_CAPACITY_DEFAULT, iree_allocator_default(), &instance));
   IREE_RETURN_IF_ERROR(iree_hal_module_register_all_types(instance));
 
   iree_hal_device_t* device = NULL;
-  IREE_RETURN_IF_ERROR(create_sample_device(iree_allocator_system(), &device),
+  IREE_RETURN_IF_ERROR(create_sample_device(iree_allocator_default(), &device),
                        "create device");
   iree_vm_module_t* hal_module = NULL;
   IREE_RETURN_IF_ERROR(iree_hal_module_create(
       instance, /*device_count=*/1, &device, IREE_HAL_MODULE_FLAG_SYNCHRONOUS,
-      iree_hal_module_debug_sink_stdio(stderr), iree_allocator_system(),
+      iree_hal_module_debug_sink_stdio(stderr), iree_allocator_default(),
       &hal_module));
 
   // Load bytecode module from the embedded data.
@@ -50,7 +50,7 @@ iree_status_t Run() {
 
   iree_vm_module_t* bytecode_module = NULL;
   IREE_RETURN_IF_ERROR(iree_vm_bytecode_module_create(
-      instance, module_data, iree_allocator_null(), iree_allocator_system(),
+      instance, module_data, iree_allocator_null(), iree_allocator_default(),
       &bytecode_module));
 
   // Allocate a context that will hold the module state across invocations.
@@ -58,7 +58,7 @@ iree_status_t Run() {
   iree_vm_module_t* modules[] = {hal_module, bytecode_module};
   IREE_RETURN_IF_ERROR(iree_vm_context_create_with_modules(
       instance, IREE_VM_CONTEXT_FLAG_NONE, IREE_ARRAYSIZE(modules), &modules[0],
-      iree_allocator_system(), &context));
+      iree_allocator_default(), &context));
   iree_vm_module_release(hal_module);
   iree_vm_module_release(bytecode_module);
 
@@ -100,7 +100,7 @@ iree_status_t Run() {
   iree_vm_list_t* inputs = NULL;
   IREE_RETURN_IF_ERROR(
       iree_vm_list_create(iree_vm_make_undefined_type_def(),
-                          /*capacity=*/2, iree_allocator_system(), &inputs),
+                          /*capacity=*/2, iree_allocator_default(), &inputs),
       "can't allocate input vm list");
 
   iree_vm_ref_t arg0_buffer_view_ref =
@@ -117,13 +117,13 @@ iree_status_t Run() {
   iree_vm_list_t* outputs = NULL;
   IREE_RETURN_IF_ERROR(
       iree_vm_list_create(iree_vm_make_undefined_type_def(),
-                          /*capacity=*/1, iree_allocator_system(), &outputs),
+                          /*capacity=*/1, iree_allocator_default(), &outputs),
       "can't allocate output vm list");
 
   // Synchronously invoke the function.
   IREE_RETURN_IF_ERROR(iree_vm_invoke(
       context, main_function, IREE_VM_INVOCATION_FLAG_NONE,
-      /*policy=*/NULL, inputs, outputs, iree_allocator_system()));
+      /*policy=*/NULL, inputs, outputs, iree_allocator_default()));
 
   // Get the result buffers from the invocation.
   iree_hal_buffer_view_t* ret_buffer_view =

--- a/samples/static_library/static_library_demo.c
+++ b/samples/static_library/static_library_demo.c
@@ -72,13 +72,14 @@ iree_status_t Run() {
 
   if (iree_status_is_ok(status)) {
     status = iree_runtime_instance_create(&instance_options,
-                                          iree_allocator_system(), &instance);
+                                          iree_allocator_default(), &instance);
   }
 
   // Create local device with static loader.
   iree_hal_device_t* device = NULL;
   if (iree_status_is_ok(status)) {
-    status = create_device_with_static_loader(iree_allocator_system(), &device);
+    status =
+        create_device_with_static_loader(iree_allocator_default(), &device);
   }
 
   // Session configuration (one per loaded module to hold module state).

--- a/samples/variables_and_state/main.c
+++ b/samples/variables_and_state/main.c
@@ -128,7 +128,7 @@ iree_status_t run_sample(iree_string_view_t bytecode_module_path,
   iree_runtime_instance_t* instance = NULL;
   if (iree_status_is_ok(status)) {
     status = iree_runtime_instance_create(&instance_options,
-                                          iree_allocator_system(), &instance);
+                                          iree_allocator_default(), &instance);
   }
   // TODO(#5724): move device selection into the compiled modules.
   iree_hal_device_t* device = NULL;

--- a/tools/iree-benchmark-executable-main.c
+++ b/tools/iree-benchmark-executable-main.c
@@ -455,7 +455,7 @@ int main(int argc, char** argv) {
   IREE_TRACE_APP_ENTER();
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  iree_allocator_t host_allocator = iree_allocator_system();
+  iree_allocator_t host_allocator = iree_allocator_default();
   int exit_code = EXIT_SUCCESS;
 
   iree_flags_set_usage(

--- a/tools/iree-benchmark-module-main.cc
+++ b/tools/iree-benchmark-module-main.cc
@@ -169,7 +169,7 @@ static void BenchmarkGenericFunction(const std::string& benchmark_name,
 
   vm::ref<iree_vm_list_t> outputs;
   IREE_CHECK_OK(iree_vm_list_create(iree_vm_make_undefined_type_def(), 16,
-                                    iree_allocator_system(), &outputs));
+                                    iree_allocator_default(), &outputs));
 
   // Benchmarking loop.
   while (state.KeepRunningBatch(batch_size)) {
@@ -177,7 +177,7 @@ static void BenchmarkGenericFunction(const std::string& benchmark_name,
     IREE_TRACE_FRAME_MARK_NAMED("Iteration");
     IREE_CHECK_OK(iree_vm_invoke(
         context, function, IREE_VM_INVOCATION_FLAG_NONE, /*policy=*/nullptr,
-        inputs, outputs.get(), iree_allocator_system()));
+        inputs, outputs.get(), iree_allocator_default()));
     IREE_CHECK_OK(iree_vm_list_resize(outputs.get(), 0));
     IREE_TRACE_ZONE_END(z1);
     if (device) {
@@ -235,7 +235,7 @@ static void BenchmarkAsyncFunction(
   IREE_TRACE_ZONE_BEGIN_NAMED_DYNAMIC(z0, benchmark_name.data(),
                                       benchmark_name.size());
   IREE_TRACE_FRAME_MARK();
-  iree_allocator_t host_allocator = iree_allocator_system();
+  iree_allocator_t host_allocator = iree_allocator_default();
 
   // Round up batch size to some multiple of concurrency.
   batch_size = (int32_t)iree_host_align(batch_size, batch_concurrency);
@@ -380,13 +380,13 @@ static void BenchmarkDispatchFunction(const std::string& benchmark_name,
 
   vm::ref<iree_vm_list_t> inputs;
   IREE_CHECK_OK(iree_vm_list_create(iree_vm_make_undefined_type_def(), 16,
-                                    iree_allocator_system(), &inputs));
+                                    iree_allocator_default(), &inputs));
   iree_vm_value_t batch_size = iree_vm_value_make_i32(FLAG_batch_size);
   IREE_CHECK_OK(iree_vm_list_push_value(inputs.get(), &batch_size));
 
   vm::ref<iree_vm_list_t> outputs;
   IREE_CHECK_OK(iree_vm_list_create(iree_vm_make_undefined_type_def(), 16,
-                                    iree_allocator_system(), &outputs));
+                                    iree_allocator_default(), &outputs));
 
   // Benchmarking loop.
   while (state.KeepRunningBatch(FLAG_batch_size)) {
@@ -394,7 +394,7 @@ static void BenchmarkDispatchFunction(const std::string& benchmark_name,
     IREE_TRACE_FRAME_MARK_NAMED("Iteration");
     IREE_CHECK_OK(iree_vm_invoke(
         context, function, IREE_VM_INVOCATION_FLAG_NONE, /*policy=*/nullptr,
-        inputs.get(), outputs.get(), iree_allocator_system()));
+        inputs.get(), outputs.get(), iree_allocator_default()));
     IREE_CHECK_OK(iree_vm_list_resize(outputs.get(), 0));
     IREE_TRACE_ZONE_END(z1);
   }
@@ -471,7 +471,7 @@ class IREEBenchmark {
     IREE_TRACE_SCOPE_NAMED("IREEBenchmark::Init");
     IREE_TRACE_FRAME_MARK_BEGIN_NAMED("init");
 
-    iree_allocator_t host_allocator = iree_allocator_system();
+    iree_allocator_t host_allocator = iree_allocator_default();
     IREE_RETURN_IF_ERROR(
         iree_tooling_create_instance(host_allocator, &instance_));
 

--- a/tools/iree-check-module-main.cc
+++ b/tools/iree-check-module-main.cc
@@ -158,7 +158,7 @@ static int main(int argc, char** argv) {
 
   IREE_TRACE_ZONE_BEGIN_NAMED(z0, "iree-check-module");
   int exit_code = 1;
-  iree_status_t status = Run(iree_allocator_system(), &exit_code);
+  iree_status_t status = Run(iree_allocator_default(), &exit_code);
   exit_code = iree_status_is_ok(status) ? exit_code : EXIT_FAILURE;
   IREE_TRACE_ZONE_END(z0);
 

--- a/tools/iree-convert-parameters-main.c
+++ b/tools/iree-convert-parameters-main.c
@@ -200,7 +200,7 @@ int main(int argc, char** argv) {
   IREE_TRACE_APP_ENTER();
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  iree_allocator_t host_allocator = iree_allocator_system();
+  iree_allocator_t host_allocator = iree_allocator_default();
   int exit_code = EXIT_SUCCESS;
 
   // Parse command line flags.

--- a/tools/iree-cpuinfo.c
+++ b/tools/iree-cpuinfo.c
@@ -10,7 +10,7 @@
 #include "iree/base/internal/cpu.h"
 
 int main(int argc, char* argv[]) {
-  iree_cpu_initialize(iree_allocator_system());
+  iree_cpu_initialize(iree_allocator_default());
   const uint64_t* cpu_data = iree_cpu_data_fields();
 
 #define IREE_CPU_FEATURE_BIT(arch, field_index, bit_pos, bit_name, llvm_name) \

--- a/tools/iree-create-parameters-main.c
+++ b/tools/iree-create-parameters-main.c
@@ -222,7 +222,7 @@ int main(int argc, char** argv) {
   IREE_TRACE_APP_ENTER();
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  iree_allocator_t host_allocator = iree_allocator_system();
+  iree_allocator_t host_allocator = iree_allocator_default();
   int exit_code = EXIT_SUCCESS;
 
   // Parse command line flags.

--- a/tools/iree-dump-instruments-main.c
+++ b/tools/iree-dump-instruments-main.c
@@ -284,7 +284,7 @@ int main(int argc, char** argv) {
   iree_file_contents_t* file_contents = NULL;
   iree_status_t status =
       iree_file_read_contents(argv[1], IREE_FILE_READ_FLAG_DEFAULT,
-                              iree_allocator_system(), &file_contents);
+                              iree_allocator_default(), &file_contents);
   if (iree_status_is_ok(status)) {
     status =
         iree_tooling_dump_instrument_file(file_contents->const_buffer, stdout);

--- a/tools/iree-dump-module-main.c
+++ b/tools/iree-dump-module-main.c
@@ -551,7 +551,7 @@ IREE_FLAG(string, output, "metadata",
 int main(int argc, char** argv) {
   IREE_TRACE_APP_ENTER();
 
-  iree_allocator_t host_allocator = iree_allocator_system();
+  iree_allocator_t host_allocator = iree_allocator_default();
   int exit_code = EXIT_SUCCESS;
 
   // Parse command line flags.

--- a/tools/iree-dump-parameters-main.c
+++ b/tools/iree-dump-parameters-main.c
@@ -113,7 +113,7 @@ int main(int argc, char** argv) {
   IREE_TRACE_APP_ENTER();
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  iree_allocator_t host_allocator = iree_allocator_system();
+  iree_allocator_t host_allocator = iree_allocator_default();
   int exit_code = EXIT_SUCCESS;
 
   // Parse command line flags.

--- a/tools/iree-fatelf.c
+++ b/tools/iree-fatelf.c
@@ -99,7 +99,7 @@ static iree_status_t fatelf_parse(iree_const_byte_span_t file_data,
   // Allocate storage for the parsed header and records.
   iree_fatelf_header_t* header = NULL;
   IREE_RETURN_IF_ERROR(iree_allocator_malloc(
-      iree_allocator_system(),
+      iree_allocator_default(),
       sizeof(iree_fatelf_header_t) +
           host_header.record_count * sizeof(iree_fatelf_record_t),
       (void**)&header));
@@ -194,9 +194,9 @@ static iree_status_t fatelf_join(int argc, char** argv) {
       (fatelf_entry_t*)iree_alloca(entry_count * sizeof(fatelf_entry_t));
   memset(entries, 0, entry_count * sizeof(*entries));
   for (iree_elf64_byte_t i = 0; i < entry_count; ++i) {
-    IREE_RETURN_IF_ERROR(
-        iree_file_read_contents(argv[i], IREE_FILE_READ_FLAG_DEFAULT,
-                                iree_allocator_system(), &entries[i].contents));
+    IREE_RETURN_IF_ERROR(iree_file_read_contents(
+        argv[i], IREE_FILE_READ_FLAG_DEFAULT, iree_allocator_default(),
+        &entries[i].contents));
     entries[i].elf_data = entries[i].contents->const_buffer;
   }
 
@@ -330,7 +330,7 @@ static iree_status_t fatelf_split(int argc, char** argv) {
   iree_file_contents_t* fatelf_contents = NULL;
   IREE_RETURN_IF_ERROR(
       iree_file_read_contents(argv[0], IREE_FILE_READ_FLAG_DEFAULT,
-                              iree_allocator_system(), &fatelf_contents));
+                              iree_allocator_default(), &fatelf_contents));
   iree_fatelf_header_t* header = NULL;
   IREE_RETURN_IF_ERROR(fatelf_parse(fatelf_contents->const_buffer, &header));
 
@@ -366,7 +366,7 @@ static iree_status_t fatelf_split(int argc, char** argv) {
 
   fprintf(stdout, "Wrote %d records to %.*s!\n", header->record_count,
           (int)dirname.size, dirname.data);
-  iree_allocator_free(iree_allocator_system(), header);
+  iree_allocator_free(iree_allocator_default(), header);
   iree_file_contents_free(fatelf_contents);
   return iree_ok_status();
 }
@@ -378,7 +378,7 @@ static iree_status_t fatelf_select(int argc, char** argv) {
   iree_file_contents_t* fatelf_contents = NULL;
   IREE_RETURN_IF_ERROR(
       iree_file_read_contents(argv[0], IREE_FILE_READ_FLAG_DEFAULT,
-                              iree_allocator_system(), &fatelf_contents));
+                              iree_allocator_default(), &fatelf_contents));
   iree_const_byte_span_t elf_data = iree_const_byte_span_empty();
   IREE_RETURN_IF_ERROR(
       iree_fatelf_select(fatelf_contents->const_buffer, &elf_data));
@@ -414,7 +414,7 @@ static iree_status_t fatelf_dump(int argc, char** argv) {
   iree_file_contents_t* fatelf_contents = NULL;
   IREE_RETURN_IF_ERROR(
       iree_file_read_contents(argv[0], IREE_FILE_READ_FLAG_DEFAULT,
-                              iree_allocator_system(), &fatelf_contents));
+                              iree_allocator_default(), &fatelf_contents));
   iree_fatelf_header_t* header = NULL;
   IREE_RETURN_IF_ERROR(fatelf_parse(fatelf_contents->const_buffer, &header));
 
@@ -449,7 +449,7 @@ static iree_status_t fatelf_dump(int argc, char** argv) {
     fprintf(stdout, "\n");
   }
 
-  iree_allocator_free(iree_allocator_system(), header);
+  iree_allocator_free(iree_allocator_default(), header);
   iree_file_contents_free(fatelf_contents);
   return iree_ok_status();
 }

--- a/tools/iree-run-mlir-main.cc
+++ b/tools/iree-run-mlir-main.cc
@@ -334,7 +334,7 @@ StatusOr<int> CompileAndRunFile(iree_compiler_session_t* session,
   // Hosting libraries can route all runtime allocations to their own allocator
   // for statistics, isolation, or efficiency. Here we use the system
   // malloc/free.
-  iree_allocator_t host_allocator = iree_allocator_system();
+  iree_allocator_t host_allocator = iree_allocator_default();
 
   // The same VM instance should be shared across many contexts. Here we only
   // use this once but a library would want to retain this and the devices it

--- a/tools/iree-run-module-main.c
+++ b/tools/iree-run-module-main.c
@@ -26,7 +26,7 @@ int main(int argc, char** argv) {
 
   // Hosting applications can provide their own allocators to pool resources or
   // track allocation statistics related to IREE code.
-  iree_allocator_t host_allocator = iree_allocator_system();
+  iree_allocator_t host_allocator = iree_allocator_default();
   // Hosting applications should reuse instances across multiple contexts that
   // have similar composition (similar types/modules/etc). Most applications can
   // get by with a single shared instance.

--- a/tools/testing/e2e/iree-e2e-attention-test.cc
+++ b/tools/testing/e2e/iree-e2e-attention-test.cc
@@ -477,7 +477,7 @@ int main(int argc, char** argv) {
   }
 
   iree_status_t status = iree_test_utils_load_and_run_e2e_tests(
-      iree_allocator_system(), attention_test_module_create);
+      iree_allocator_default(), attention_test_module_create);
   int exit_code = EXIT_SUCCESS;
   if (!iree_status_is_ok(status)) {
     iree_status_fprint(stderr, status);

--- a/tools/testing/e2e/iree-e2e-conv2d-test.cc
+++ b/tools/testing/e2e/iree-e2e-conv2d-test.cc
@@ -558,7 +558,7 @@ int main(int argc, char** argv) {
   // and not have the required architectures for execution within them - to keep
   // the test runner dumber we gracefully fail those cases by returning success.
   iree_status_t status = iree_test_utils_load_and_run_e2e_tests(
-      iree_allocator_system(), conv2d_test_module_create);
+      iree_allocator_default(), conv2d_test_module_create);
   int exit_code = EXIT_SUCCESS;
   if (!iree_status_is_ok(status)) {
     iree_status_fprint(stderr, status);

--- a/tools/testing/e2e/iree-e2e-matmul-test.cc
+++ b/tools/testing/e2e/iree-e2e-matmul-test.cc
@@ -781,7 +781,7 @@ int main(int argc, char** argv) {
   // and not have the required architectures for execution within them - to keep
   // the test runner dumber we gracefully fail those cases by returning success.
   iree_status_t status = iree_test_utils_load_and_run_e2e_tests(
-      iree_allocator_system(), matmul_test_module_create);
+      iree_allocator_default(), matmul_test_module_create);
   int exit_code = EXIT_SUCCESS;
   if (!iree_status_is_ok(status)) {
     iree_status_fprint(stderr, status);


### PR DESCRIPTION
This allows for overriding the allocator control function (and its self) externally. By default (heh) if no default allocator is specified the system allocator (malloc/free, likely libc) will be used. Since many allocators allow for replacing malloc/free that's still the easiest path but giving explicit control over the allocator used by IREE allows for more options during composition in larger projects.

All usage of `iree_allocator_system` has been swapped to `iree_allocator_default`. This is an NFC in the default compiler configuration as default redirects to system.

Future changes will add mimalloc and cmake variables for controlling the default allocator (similar to what was done in #16812).