### PR TITLE
Print opt flags to more accurately reproduce (.linked -> .optimized)

### DIFF
--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -612,17 +612,28 @@ public:
                          ".linked.ll", *llvmModule);
       }
 
+      // For example 'gfx942'
+      StringRef targetCPU = targetMachine->getTargetCPU();
+
+      // For example 'amdgcn-amd-amdhsa'
+      std::string targetTriple = targetMachine->getTargetTriple().str();
+
       // Run LLVM optimization passes.
       std::string passesString;
       optimizeModule(*llvmModule, *targetMachine, options.passPlugins,
                      options.slpVectorization, passesString);
       if (!serializationOptions.dumpIntermediatesPath.empty()) {
-        std::string header = llvm::formatv(R"TXT(
+
+        std::string header =
+            llvm::formatv(R"TXT(
 ; To reproduce the .optimized.ll from the .linked.ll, run:
-; opt --passes='{}'
+; opt -S -mtriple={} -mcpu={} --passes='{}'
+; The flag '-S' to emit LLVMIR.
+; The behavior of some passes depend on '-mtriple' and '-mcpu'.
 
 )TXT",
-                                           passesString);
+                          targetTriple, targetCPU, passesString);
+
         dumpModuleToPath(serializationOptions.dumpIntermediatesPath,
                          serializationOptions.dumpBaseName, variantOp.getName(),
                          ".optimized.ll", *llvmModule, header);

--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -624,12 +624,14 @@ public:
                      options.slpVectorization, passesString);
       if (!serializationOptions.dumpIntermediatesPath.empty()) {
 
+        // Additional context on '-mcpu' flag in PR comments, see for example:
+        // https://github.com/iree-org/iree/pull/20716#issuecomment-2851650421
         std::string header =
             llvm::formatv(R"TXT(
 ; To reproduce the .optimized.ll from the .linked.ll, run:
 ; opt -S -mtriple={} -mcpu={} --passes='{}'
 ; The flag '-S' to emit LLVMIR.
-; The behavior of some passes depend on '-mtriple' and '-mcpu'.
+; The behavior of some passes depends on '-mtriple' and '-mcpu'
 
 )TXT",
                           targetTriple, targetCPU, passesString);


### PR DESCRIPTION
The suggestion at the top of foo.optimized.ll on how to recreate from foo.linked.ll,

opt -passes='a,b,c' foo.linked.ll

is very useful (thank you @bjacob ) However it doesn't quite fully reproduce the .optimized.ll from .linked.ll. Indeed

opt -S -passes='a,b,c' foo.linked.ll

generates a near match of foo.optimized.ll, but with some significant differences. The example I had was producing 4 `call void @llvm.amdgcn.s.barrier()`s,  while the original .optimized.ll had 6.  So I dug deeper to figure out why, and it turns out that opt takes additional flags, mtriple and mcpu, that modify the behavior of passes. I assume that without these flags, some defaults (which are not amdgcn-amd-amdhsa/gfx942) are used. This PR adds these flags to comment at the top of .optimized.ll, to more accurately reproduce .optimized.ll