### PR TITLE
[Encoding] Drop resolver interface implementation for SpecializedEncodingAttr

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.cpp
@@ -668,13 +668,13 @@ TestingEncodingAttr::cloneWithLayouts(ArrayRef<Attribute> layouts) const {
 
 Attribute
 UnspecializedEncodingAttr::cloneWithSimplifiedConfig(DictionaryAttr) const {
-  MLIRContext *ctx = getContext();
-  return SpecializedEncodingAttr::get(ctx, getSeed(), /*type=*/{});
+  return *this;
 }
 
-Attribute SpecializedEncodingAttr::getLayout(RankedTensorType type) const {
+Attribute UnspecializedEncodingAttr::getLayout(RankedTensorType type) const {
   MLIRContext *ctx = getContext();
-  return get(ctx, getSeed(), TypeAttr::get(type.dropEncoding()));
+  return SpecializedEncodingAttr::get(ctx, getSeed(),
+                                      TypeAttr::get(type.dropEncoding()));
 }
 
 } // namespace mlir::iree_compiler::IREE::Encoding

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -366,6 +366,7 @@ def UnspecializedEncodingAttr :
     IREEEncoding_Attr<"UnspecializedEncoding", [
       DeclareAttrInterfaceMethods<IREEEncoding_EncodingLayoutResolverAttrInterface, [
         "cloneWithSimplifiedConfig",
+        "getLayout",
       ]>
     ]> {
   let mnemonic = "unspecialized_encoding";
@@ -376,11 +377,11 @@ def UnspecializedEncodingAttr :
   let description = [{
     This attribute indicates this is an unspecialized encoding. It implements
     very basic interface methods of EncodingLayoutResolverAttrInterface that
-    converts it to the SpecializeEncodingAttr during encoding specialization.
+    returns the SpecializedEncodingAttr with the same seed as serialized layout
+    in encoding specialization. Different seed values indicate different layouts.
+
     It is mainly for testing purpose as some transformations do not depend on
     actual dialects that implement the attribute interface.
-
-    Different seed values indicate different layouts.
   }];
 
   let parameters = (ins "int32_t":$seed);
@@ -388,9 +389,6 @@ def UnspecializedEncodingAttr :
 
 def SpecializedEncodingAttr :
     IREEEncoding_Attr<"SpecializedEncoding", [
-      DeclareAttrInterfaceMethods<IREEEncoding_EncodingLayoutResolverAttrInterface, [
-        "getLayout",
-      ]>,
       IREEEncoding_SerializableEncodingAttrInterface
     ]> {
   let mnemonic = "specialized_encoding";
@@ -400,11 +398,10 @@ def SpecializedEncodingAttr :
 
   let description = [{
     This attribute is similar to UnspecializedEncodingAttr, but with an optional
-    type. The attribute denotes the layout of the type. Different seed values
-    indicate different layouts, which can be used to emulate different encoding
-    attributes.
+    type. The attribute denotes the layout of the type.
 
-    Different seed values indicate different layouts.
+    Different seed values indicate different layouts, which can be used to
+    emulate different encoding attributes.
   }];
 
   let parameters = (ins


### PR DESCRIPTION
The attributes were created for testing SpecializeEncoding pass when the ideas were rough. The specialized_encoding is NOT a resolver, so it does not implement the interface.

The revision moves the implementation to unspecialized encoding resolver, and make corresponding changes. It returns itself in the cloning methods. There are no new tests because the existing tests are robust and already cover it. E.g.,

https://github.com/iree-org/iree/blob/360288f1a4e7e177a24ca290aabc083bd6e26b4f/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir#L153-L163