### PR TITLE
Added missing dependencies for the bazel build

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Utils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Utils/BUILD.bazel
@@ -64,6 +64,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:SCFTransforms",
         "@llvm-project//mlir:SideEffectInterfaces",
+        "@llvm-project//mlir:SubsetOpInterface",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TilingInterface",

--- a/compiler/src/iree/compiler/Codegen/Utils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Utils/CMakeLists.txt
@@ -48,6 +48,7 @@ iree_cc_library(
     MLIRSCFDialect
     MLIRSCFTransforms
     MLIRSideEffectInterfaces
+    MLIRSubsetOpInterface
     MLIRSupport
     MLIRTensorDialect
     MLIRTilingInterface

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/BUILD.bazel
@@ -57,6 +57,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:InferTypeOpInterface",
         "@llvm-project//mlir:InliningUtils",
+        "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",
     ],
 )

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/CMakeLists.txt
@@ -33,6 +33,7 @@ iree_cc_library(
     MLIRArithUtils
     MLIRIR
     MLIRInferTypeOpInterface
+    MLIRSupport
     MLIRTensorDialect
     iree::compiler::Dialect::Util::IR
   PUBLIC

--- a/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/BUILD.bazel
@@ -27,5 +27,6 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:AffineUtils",
         "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:TransformUtils",
     ],
 )

--- a/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/Transforms/CMakeLists.txt
@@ -22,6 +22,7 @@ iree_cc_library(
     MLIRAffineDialect
     MLIRAffineUtils
     MLIRTensorDialect
+    MLIRTransformUtils
     iree::compiler::Dialect::TensorExt::IR
   PUBLIC
 )


### PR DESCRIPTION
This resolves build errors like this:
```
In file included from compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtTypes.cpp:7:
In file included from compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtTypes.h:10:
compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtDialect.h:12:10: error: module //compiler/src/iree/compiler/Dialect/TensorExt/IR:IR does not depend on a module exporting 'mlir/Support/TypeID.h'
   12 | #include "mlir/Support/TypeID.h"
      |          ^
In file included from compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtTypes.cpp:7:
compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtTypes.h:20:10: error: module //compiler/src/iree/compiler/Dialect/TensorExt/IR:IR does not depend on a module exporting 'mlir/Support/LLVM.h'
   20 | #include "mlir/Support/LLVM.h"
```