### PR TITLE
[NFC][Encoding] Move materializeEncodingValueFn to type converter

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
@@ -121,11 +121,11 @@ materializeFuncOpEncodings(FunctionOpInterface funcOp,
     LDBG("Selected LayoutAttrInterface with target configuration: "
          << layoutAttrWithTargetInfo);
 
-    MaterializeEncodingTypeConverter typeConverter(layoutAttrWithTargetInfo);
-    MaterializeEncodingConversionTarget target(*ctx);
     auto materializeEncodingValueFn = getMaterializeEncodingValueFn(targetAttr);
-    populateMaterializeEncodingPatterns(patterns, target, typeConverter,
-                                        materializeEncodingValueFn);
+    MaterializeEncodingTypeConverter typeConverter(layoutAttrWithTargetInfo,
+                                                   materializeEncodingValueFn);
+    MaterializeEncodingConversionTarget target(*ctx);
+    populateMaterializeEncodingPatterns(patterns, target, typeConverter);
 
     if (failed(applyPartialConversion(funcOp, target, std::move(patterns)))) {
       funcOp.emitOpError("materialization failed");

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoNop.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoNop.cpp
@@ -44,11 +44,11 @@ struct MaterializeEncodingIntoNopPass final
 
     RewritePatternSet materializeEncodingPattern(context);
     MaterializeEncodingTypeConverter typeConverter(
-        IREE::Codegen::EncodingNopLayoutAttr::get(context));
+        IREE::Codegen::EncodingNopLayoutAttr::get(context),
+        materializeEncodingValueFn);
     MaterializeEncodingConversionTarget target(*context);
     populateMaterializeEncodingPatterns(materializeEncodingPattern, target,
-                                        typeConverter,
-                                        materializeEncodingValueFn);
+                                        typeConverter);
 
     if (failed(applyPartialConversion(operation, target,
                                       std::move(materializeEncodingPattern)))) {


### PR DESCRIPTION
This PR performs some refactoring as part of collapsing MaterializeEncodingIntoPadding into MaterializeEncoding (https://github.com/iree-org/iree/issues/20160) and moves the `materializeEncodingValueFn` parameter from OpMaterializeEncodingPattern to the MaterializeEncodingTypeConverter, together with the `getInnerTileSizesOfr` implementation, for following reasons:
- The `typeConverter` and `materializeEncodingValueFn` objects are typically passed around together, so now only `typeConverter` needs to be passed around and this simplifies the code.
- As part of https://github.com/iree-org/iree/issues/20160, I am creating a `getOffsetsSizesStrides` method in the MaterializeEncodingTypeConverter and SerializableEncodingAttrInterface and all encoding specific logic should be moved there. I would specifically like to avoid the need for passing a `MaterializeEncodingValueFn` to `getOffsetsSizesStrides`. This PR moves us in that direction. 