### PR TITLE
[Codegen][Common] Add transform op to check for lowering configs when matching

### DIFF
--- a/compiler/plugins/target/ROCM/builtins/tuning/iree_default_tuning_spec_gfx942.mlir
+++ b/compiler/plugins/target/ROCM/builtins/tuning/iree_default_tuning_spec_gfx942.mlir
@@ -1370,6 +1370,7 @@ transform.named_sequence @match_attention_f16(%root: !transform.any_op {transfor
 transform.named_sequence
 @match_attention_2x10x4096x64x64x64_f16(%attention: !transform.any_op {transform.readonly})
   -> (!transform.any_op, !transform.any_param, !transform.any_param) {
+  transform.iree.match.has_no_lowering_config %attention : !transform.any_op
 
   %matched = transform.include @match_attention_f16 failures(propagate) (%attention)
     : (!transform.any_op) -> !transform.any_op
@@ -1443,6 +1444,8 @@ transform.named_sequence @match_mmt_f16_f16_f32(%root: !transform.any_op {transf
 transform.named_sequence
 @match_mmt_2048x1280x5120_f16_f16_f32(%matmul: !transform.any_op {transform.readonly})
   -> (!transform.any_op, !transform.any_param) {
+  transform.iree.match.has_no_lowering_config %matmul : !transform.any_op
+
   %mmt = transform.include @match_mmt_f16_f16_f32 failures(propagate) (%matmul)
     : (!transform.any_op) -> !transform.any_op
   %lhs = transform.get_operand %matmul[0] : (!transform.any_op) -> !transform.any_value

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -646,6 +646,21 @@ void transform_dialect::HoistStaticAllocOp::getEffects(
 }
 
 //===---------------------------------------------------------------------===//
+// MatchHasNoLoweringConfigOp
+//===---------------------------------------------------------------------===//
+
+DiagnosedSilenceableFailure
+IREE::transform_dialect::MatchHasNoLoweringConfigOp::matchOperation(
+    Operation *current, transform::TransformResults &results,
+    transform::TransformState &state) {
+  if (getLoweringConfig(current) || getCompilationInfo(current)) {
+    return emitSilenceableError()
+           << "payload has a lowering config or compilation info.";
+  }
+  return DiagnosedSilenceableFailure::success();
+}
+
+//===---------------------------------------------------------------------===//
 // PopulateWorkgroupCountRegionUsingNumThreadsSliceOp
 //===---------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.h
@@ -9,6 +9,7 @@
 
 #include "mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.h"
 #include "mlir/Dialect/Transform/IR/TransformDialect.h"
+#include "mlir/Dialect/Transform/Interfaces/MatchInterfaces.h"
 #include "mlir/Dialect/Transform/Interfaces/TransformInterfaces.h"
 
 namespace mlir {

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -7,6 +7,7 @@
 #ifndef IREE_COMPILER_CODEGEN_COMMON_TRANSFORMEXTENSIONS_COMMONEXTENSIONS
 #define IREE_COMPILER_CODEGEN_COMMON_TRANSFORMEXTENSIONS_COMMONEXTENSIONS
 
+include "mlir/Dialect/Transform/Interfaces/MatchInterfaces.td"
 include "mlir/Dialect/Transform/IR/TransformAttrs.td"
 include "mlir/Dialect/Transform/IR/TransformDialect.td"
 include "mlir/Dialect/Transform/IR/TransformTypes.td"
@@ -463,6 +464,32 @@ def IREEEliminateEmptyTensorsOp : Op<
         ::mlir::transform::ApplyToEachResultList &results,
         ::mlir::transform::TransformState &state);
   }];
+}
+
+def MatchHasNoLoweringConfigOp : Op<Transform_Dialect, "iree.match.has_no_lowering_config",
+    [MatchOpInterface,
+     SingleOpMatcher,
+     MemoryEffectsOpInterface]> {
+  let summary =
+      "Checks that the payload op does not carry a lowering config or compilation info";
+  let description = [{
+    Verifies that the payload does not have a "compilation_info" or
+    "lowering_config" attribute. This is a very common check needed for external
+    matchers to avoid overwriting already configured ops.
+
+    #### Return modes
+
+    Succeeds if the payload lacks a configuration. Produces a silenceable
+    failure otherwise. Produces a definite failure if the operand is not
+    associated with a single payload op.
+  }];
+
+  let arguments = (ins TransformHandleTypeInterface:$operand_handle);
+  let results = (outs);
+  let assemblyFormat = "$operand_handle attr-dict `:` type($operand_handle)";
+  let extraClassDeclaration = SingleOpMatcher.extraDeclaration;
+
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 }
 
 def PopulateWorkgroupCountRegionUsingNumThreadsSliceOp :

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -26,6 +26,7 @@ iree_lit_test_suite(
             "bufferize_copy_only_dispatches.mlir",
             "bufferize_dispatch_tensor_load_store.mlir",
             "canonicalize_interface_load_store.mlir",
+            "check_for_config.mlir",
             "convert_accgemm_to_gemm.mlir",
             "convert_bf16_to_uint16_buffers.mlir",
             "convert_bf16_arith_to_f32.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -22,6 +22,7 @@ iree_lit_test_suite(
     "bufferize_copy_only_dispatches.mlir"
     "bufferize_dispatch_tensor_load_store.mlir"
     "canonicalize_interface_load_store.mlir"
+    "check_for_config.mlir"
     "convert_accgemm_to_gemm.mlir"
     "convert_bf16_arith_to_f32.mlir"
     "convert_bf16_to_uint16_buffers.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/check_for_config.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/check_for_config.mlir
@@ -1,0 +1,50 @@
+// RUN: iree-opt %s -iree-transform-dialect-interpreter -transform-dialect-drop-schedule --split-input-file --verify-diagnostics | FileCheck %s
+
+func.func @no_lowering_config() -> index {
+  %0 = arith.constant 0 : index
+  return %0 : index
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["arith.constant"]} in %root : (!transform.any_op) -> !transform.any_op
+    transform.iree.match.has_no_lowering_config %0 : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: no_lowering_config
+
+// -----
+
+func.func @lowering_config() -> index {
+  %0 = arith.constant {lowering_config = #iree_codegen.lowering_config<tile_sizes = []>} 0 : index
+  return %0 : index
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["arith.constant"]} in %root : (!transform.any_op) -> !transform.any_op
+    // expected-error @+1 {{payload has a lowering config or compilation info.}}
+    transform.iree.match.has_no_lowering_config %0 : !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+func.func @compilation_info() -> index {
+  %0 = arith.constant {compilation_info = #iree_codegen.compilation_info<
+    lowering_config = #iree_codegen.lowering_config<tile_sizes = []>,
+    translation_info = #iree_codegen.translation_info<pipeline = CPUDefault>>} 0 : index
+  return %0 : index
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%root: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["arith.constant"]} in %root : (!transform.any_op) -> !transform.any_op
+    // expected-error @+1 {{payload has a lowering config or compilation info.}}
+    transform.iree.match.has_no_lowering_config %0 : !transform.any_op
+    transform.yield
+  }
+}

--- a/docs/website/docs/reference/tuning.md
+++ b/docs/website/docs/reference/tuning.md
@@ -81,6 +81,7 @@ transform.named_sequence
 transform.named_sequence
 @match_mmt_2048x1280x5120_f16_f16_f32(%matmul: !transform.any_op {transform.readonly})
   -> (!transform.any_op, !transform.any_param) {
+  transform.iree.match.has_no_lowering_config %matmul : !transform.any_op
   %mmt = transform.include @match_mmt_f16_f16_f32 failures(propagate) (%matmul)
     : (!transform.any_op) -> !transform.any_op
   %lhs = transform.get_operand %matmul[0] : (!transform.any_op) -> !transform.any_value

--- a/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_flux_mi300.mlir
+++ b/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_flux_mi300.mlir
@@ -16,6 +16,8 @@ module attributes {transform.with_named_sequence} {
 //===----------------------------------------------------------------------===//
 
   transform.named_sequence @match_contraction_4608x21504x3072_bf16xbf16xf32(%arg0: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+    transform.iree.match.has_no_lowering_config %arg0 : !transform.any_op
+
     %inputs, %outputs = transform.iree.match.cast_compatible_dag_from_root %arg0 {
     ^bb0(%arg1: tensor<4608x3072xbf16>, %arg2: tensor<21504x3072xbf16>, %arg3: tensor<4608x21504xf32>):
       %1 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg1, %arg2 : tensor<4608x3072xbf16>, tensor<21504x3072xbf16>) outs(%arg3 : tensor<4608x21504xf32>) {
@@ -32,6 +34,8 @@ module attributes {transform.with_named_sequence} {
   }
 
   transform.named_sequence @match_contraction_4608x3072x4608_bf16xbf16xf32(%arg0: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+    transform.iree.match.has_no_lowering_config %arg0 : !transform.any_op
+
     %inputs, %outputs = transform.iree.match.cast_compatible_dag_from_root %arg0 {
     ^bb0(%arg1: tensor<15360x4608xbf16>, %arg2: tensor<3072x15360xbf16>, %arg3: tensor<4608x3072xf32>):
       %1 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d2, d0)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg1, %arg2 : tensor<15360x4608xbf16>, tensor<3072x15360xbf16>) outs(%arg3 : tensor<4608x3072xf32>) {
@@ -48,6 +52,8 @@ module attributes {transform.with_named_sequence} {
   }
 
   transform.named_sequence @match_contraction_4096x12288x3072_bf16xbf16xf32(%arg0: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+    transform.iree.match.has_no_lowering_config %arg0 : !transform.any_op
+
     %inputs, %outputs = transform.iree.match.cast_compatible_dag_from_root %arg0 {
     ^bb0(%arg1: tensor<4096x3072xbf16>, %arg2: tensor<12288x3072xbf16>, %arg3: tensor<4096x12288xf32>):
       %1 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg1, %arg2 : tensor<4096x3072xbf16>, tensor<12288x3072xbf16>) outs(%arg3 : tensor<4096x12288xf32>) {
@@ -64,6 +70,8 @@ module attributes {transform.with_named_sequence} {
   }
 
   transform.named_sequence @match_contraction_4096x3072x12288_bf16xbf16xf32(%arg0: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+    transform.iree.match.has_no_lowering_config %arg0 : !transform.any_op
+
     %inputs, %outputs = transform.iree.match.cast_compatible_dag_from_root %arg0 {
     ^bb0(%arg1: tensor<4096x12288xbf16>, %arg2: tensor<3072x12288xbf16>, %arg3: tensor<4096x3072xf32>):
       %1 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg1, %arg2 : tensor<4096x12288xbf16>, tensor<3072x12288xbf16>) outs(%arg3 : tensor<4096x3072xf32>) {
@@ -80,6 +88,8 @@ module attributes {transform.with_named_sequence} {
   }
 
   transform.named_sequence @match_contraction_72x4096x3072_bf16xbf16xf32(%arg0: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+    transform.iree.match.has_no_lowering_config %arg0 : !transform.any_op
+
     %inputs, %outputs = transform.iree.match.cast_compatible_dag_from_root %arg0 {
     ^bb0(%arg1: tensor<4096x3072xbf16>, %arg2: tensor<72x128x3072xbf16>, %arg3: tensor<72x4096x128xf32>):
       %1 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d1, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel", "reduction"]} ins(%arg1, %arg2 : tensor<4096x3072xbf16>, tensor<72x128x3072xbf16>) outs(%arg3 : tensor<72x4096x128xf32>) {
@@ -96,6 +106,8 @@ module attributes {transform.with_named_sequence} {
   }
 
   transform.named_sequence @match_contraction_4096x3072x3072_bf16xbf16xf32(%arg0: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+    transform.iree.match.has_no_lowering_config %arg0 : !transform.any_op
+
     %inputs, %outputs = transform.iree.match.cast_compatible_dag_from_root %arg0 {
     ^bb0(%arg1: tensor<4096x3072xbf16>, %arg2: tensor<3072x3072xbf16>, %arg3: tensor<4096x3072xf32>):
       %1 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg1, %arg2 : tensor<4096x3072xbf16>, tensor<3072x3072xbf16>) outs(%arg3 : tensor<4096x3072xf32>) {
@@ -112,6 +124,8 @@ module attributes {transform.with_named_sequence} {
   }
 
   transform.named_sequence @match_contraction_512x12288x3072_bf16xbf16xf32(%arg0: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+    transform.iree.match.has_no_lowering_config %arg0 : !transform.any_op
+
     %inputs, %outputs = transform.iree.match.cast_compatible_dag_from_root %arg0 {
     ^bb0(%arg1: tensor<512x3072xbf16>, %arg2: tensor<12288x3072xbf16>, %arg3: tensor<512x12288xf32>):
       %1 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg1, %arg2 : tensor<512x3072xbf16>, tensor<12288x3072xbf16>) outs(%arg3 : tensor<512x12288xf32>) {
@@ -128,6 +142,8 @@ module attributes {transform.with_named_sequence} {
   }
 
   transform.named_sequence @match_contraction_512x3072x12288_bf16xbf16xf32(%arg0: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+    transform.iree.match.has_no_lowering_config %arg0 : !transform.any_op
+
     %inputs, %outputs = transform.iree.match.cast_compatible_dag_from_root %arg0 {
     ^bb0(%arg1: tensor<512x12288xbf16>, %arg2: tensor<3072x12288xbf16>, %arg3: tensor<512x3072xf32>):
       %1 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg1, %arg2 : tensor<512x12288xbf16>, tensor<3072x12288xbf16>) outs(%arg3 : tensor<512x3072xf32>) {

--- a/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_punet_mi300.mlir
+++ b/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_punet_mi300.mlir
@@ -46,6 +46,8 @@ module attributes { transform.with_named_sequence } {
 //===----------------------------------------------------------------------===//
 
 transform.named_sequence @match_attention_f16(%attention: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param, !transform.any_param) {
+    transform.iree.match.has_no_lowering_config %attention : !transform.any_op
+
     transform.match.operation_name %attention ["iree_linalg_ext.attention"] : !transform.any_op
     %in0 = transform.get_operand %attention[0] : (!transform.any_op) -> !transform.any_value
     transform.iree.match.cast_compatible_type %in0 = tensor<?x?x?x?xf16> : !transform.any_value
@@ -71,6 +73,8 @@ transform.named_sequence @match_attention_f16(%attention: !transform.any_op {tra
   }
 
 transform.named_sequence @match_attention_f8(%attention: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param, !transform.any_param) {
+    transform.iree.match.has_no_lowering_config %attention : !transform.any_op
+
     transform.match.operation_name %attention ["iree_linalg_ext.attention"] : !transform.any_op
     %in0 = transform.get_operand %attention[0] : (!transform.any_op) -> !transform.any_value
     transform.iree.match.cast_compatible_type %in0 = tensor<?x?x?x?xf8E4M3FNUZ> : !transform.any_value
@@ -123,6 +127,8 @@ transform.named_sequence @match_mmt_i8_i8_i32(%root: !transform.any_op {transfor
 }
 
 transform.named_sequence @match_mmt_2048x10240x1280(%matmul: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+  transform.iree.match.has_no_lowering_config %matmul : !transform.any_op
+
   %mmt = transform.include @match_mmt_i8_i8_i32 failures(propagate) (%matmul) : (!transform.any_op) -> !transform.any_op
   %lhs = transform.get_operand %matmul[0] : (!transform.any_op) -> !transform.any_value
   %rhs = transform.get_operand %matmul[1] : (!transform.any_op) -> !transform.any_value
@@ -142,6 +148,8 @@ transform.named_sequence @match_mmt_2048x10240x1280(%matmul: !transform.any_op {
 }
 
 transform.named_sequence @match_mmt_2048x1280x5120(%matmul: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+  transform.iree.match.has_no_lowering_config %matmul : !transform.any_op
+
   %mmt = transform.include @match_mmt_i8_i8_i32 failures(propagate) (%matmul) : (!transform.any_op) -> !transform.any_op
   %lhs = transform.get_operand %matmul[0] : (!transform.any_op) -> !transform.any_value
   %rhs = transform.get_operand %matmul[1] : (!transform.any_op) -> !transform.any_value
@@ -161,6 +169,8 @@ transform.named_sequence @match_mmt_2048x1280x5120(%matmul: !transform.any_op {t
 }
 
 transform.named_sequence @match_mmt_2048x1280x1280(%matmul: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+  transform.iree.match.has_no_lowering_config %matmul : !transform.any_op
+
   %mmt = transform.include @match_mmt_i8_i8_i32 failures(propagate) (%matmul) : (!transform.any_op) -> !transform.any_op
   %lhs = transform.get_operand %matmul[0] : (!transform.any_op) -> !transform.any_value
   %rhs = transform.get_operand %matmul[1] : (!transform.any_op) -> !transform.any_value
@@ -181,6 +191,8 @@ transform.named_sequence @match_mmt_2048x1280x1280(%matmul: !transform.any_op {t
 }
 
 transform.named_sequence @match_mmt_8192x640x640(%matmul: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+  transform.iree.match.has_no_lowering_config %matmul : !transform.any_op
+
   %mmt = transform.include @match_mmt_i8_i8_i32 failures(propagate) (%matmul) : (!transform.any_op) -> !transform.any_op
   %lhs = transform.get_operand %matmul[0] : (!transform.any_op) -> !transform.any_value
   %rhs = transform.get_operand %matmul[1] : (!transform.any_op) -> !transform.any_value
@@ -200,6 +212,8 @@ transform.named_sequence @match_mmt_8192x640x640(%matmul: !transform.any_op {tra
 }
 
 transform.named_sequence @match_mmt_8192x5120x640(%matmul: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+  transform.iree.match.has_no_lowering_config %matmul : !transform.any_op
+
   %mmt = transform.include @match_mmt_i8_i8_i32 failures(propagate) (%matmul) : (!transform.any_op) -> !transform.any_op
   %lhs = transform.get_operand %matmul[0] : (!transform.any_op) -> !transform.any_value
   %rhs = transform.get_operand %matmul[1] : (!transform.any_op) -> !transform.any_value
@@ -219,6 +233,8 @@ transform.named_sequence @match_mmt_8192x5120x640(%matmul: !transform.any_op {tr
 }
 
 transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+  transform.iree.match.has_no_lowering_config %matmul : !transform.any_op
+
   %mmt = transform.include @match_mmt_i8_i8_i32 failures(propagate) (%matmul) : (!transform.any_op) -> !transform.any_op
   %lhs = transform.get_operand %matmul[0] : (!transform.any_op) -> !transform.any_value
   %rhs = transform.get_operand %matmul[1] : (!transform.any_op) -> !transform.any_value
@@ -250,6 +266,8 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
 //===----------------------------------------------------------------------===//
 
   transform.named_sequence @match_broadcast_rhs_mmt_Bx1024x10240x1280(%generic: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+    transform.iree.match.has_no_lowering_config %generic : !transform.any_op
+
     %mmt = transform.include @match_broadcast_rhs_mmt_i8_i8_i32 failures(propagate) (%generic) : (!transform.any_op) -> !transform.any_op
     %lhs = transform.get_operand %generic[0] : (!transform.any_op) -> !transform.any_value
     %rhs = transform.get_operand %generic[1] : (!transform.any_op) -> !transform.any_value
@@ -269,6 +287,8 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
   }
 
   transform.named_sequence @match_broadcast_rhs_mmt_Bx1024x1280x1280(%generic: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+    transform.iree.match.has_no_lowering_config %generic : !transform.any_op
+
     %mmt = transform.include @match_broadcast_rhs_mmt_i8_i8_i32 failures(propagate) (%generic) : (!transform.any_op) -> !transform.any_op
     %lhs = transform.get_operand %generic[0] : (!transform.any_op) -> !transform.any_value
     %rhs = transform.get_operand %generic[1] : (!transform.any_op) -> !transform.any_value
@@ -289,6 +309,8 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
   }
 
   transform.named_sequence @match_broadcast_rhs_mmt_Bx64x1280x2480(%generic: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+    transform.iree.match.has_no_lowering_config %generic : !transform.any_op
+
     %mmt = transform.include @match_broadcast_rhs_mmt_i8_i8_i32 failures(propagate) (%generic) : (!transform.any_op) -> !transform.any_op
     %lhs = transform.get_operand %generic[0] : (!transform.any_op) -> !transform.any_value
     %rhs = transform.get_operand %generic[1] : (!transform.any_op) -> !transform.any_value
@@ -310,6 +332,8 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
   }
 
   transform.named_sequence @match_broadcast_rhs_mmt_Bx4960x640x640(%generic: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+    transform.iree.match.has_no_lowering_config %generic : !transform.any_op
+
     %mmt = transform.include @match_broadcast_rhs_mmt_i8_i8_i32 failures(propagate) (%generic) : (!transform.any_op) -> !transform.any_op
     %lhs = transform.get_operand %generic[0] : (!transform.any_op) -> !transform.any_value
     %rhs = transform.get_operand %generic[1] : (!transform.any_op) -> !transform.any_value
@@ -329,6 +353,8 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
   }
 
   transform.named_sequence @match_broadcast_rhs_mmt_Bx64x640x2480(%generic: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+    transform.iree.match.has_no_lowering_config %generic : !transform.any_op
+
     %mmt = transform.include @match_broadcast_rhs_mmt_i8_i8_i32 failures(propagate) (%generic) : (!transform.any_op) -> !transform.any_op
     %lhs = transform.get_operand %generic[0] : (!transform.any_op) -> !transform.any_value
     %rhs = transform.get_operand %generic[1] : (!transform.any_op) -> !transform.any_value
@@ -348,6 +374,8 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
   }
 
   transform.named_sequence @match_broadcast_rhs_mmt_Bx4096x5120x640(%generic: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+    transform.iree.match.has_no_lowering_config %generic : !transform.any_op
+
     %mmt = transform.include @match_broadcast_rhs_mmt_i8_i8_i32 failures(propagate) (%generic) : (!transform.any_op) -> !transform.any_op
     %lhs = transform.get_operand %generic[0] : (!transform.any_op) -> !transform.any_value
     %rhs = transform.get_operand %generic[1] : (!transform.any_op) -> !transform.any_value
@@ -372,6 +400,8 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
 
   transform.named_sequence @match_matmul_like_Bx20x1024x64x1280_i8xi8xi32(%cont: !transform.any_op {transform.readonly})
     -> (!transform.any_op, !transform.any_param) {
+    transform.iree.match.has_no_lowering_config %cont : !transform.any_op
+
     %ins, %outs = transform.iree.match.cast_compatible_dag_from_root %cont {
     ^bb0(%lhs: tensor<?x1024x1280xi8>, %rhs: tensor<20x64x1280xi8>, %out: tensor<?x20x1024x64xi32>):
       %16 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4)>,
@@ -407,6 +437,8 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
   // Variant of matmul_like_Bx20x1024x64x1280_i8xi8xi32 from Transposed-V.
   transform.named_sequence @match_matmul_like_Bx20x64x1024x1280_i8xi8xi32(%cont: !transform.any_op {transform.readonly})
     -> (!transform.any_op, !transform.any_param) {
+    transform.iree.match.has_no_lowering_config %cont : !transform.any_op
+
     %ins, %outs = transform.iree.match.cast_compatible_dag_from_root %cont {
     ^bb0(%lhs: tensor<?x1024x1280xi8>, %rhs: tensor<20x64x1280xi8>, %out: tensor<?x20x64x1024xi32>):
       %16 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
@@ -440,6 +472,8 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
 
   transform.named_sequence @match_matmul_like_Bx20x64x64x2048_i8xi8xi32(%cont: !transform.any_op {transform.readonly})
     -> (!transform.any_op, !transform.any_param) {
+    transform.iree.match.has_no_lowering_config %cont : !transform.any_op
+
     %ins, %outs = transform.iree.match.cast_compatible_dag_from_root %cont {
     ^bb0(%lhs: tensor<?x64x2048xi8>, %rhs: tensor<20x64x2048xi8>, %out: tensor<?x20x64x64xi32>):
       %16 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4)>,
@@ -472,6 +506,8 @@ transform.named_sequence @match_mmt_8192x640x2560 (%matmul: !transform.any_op {t
   // Variant of matmul_like_Bx20x64x64x2048_i8xi8xi32 from Transposed-V.
 transform.named_sequence @match_matmul_like_Bx20x64x64x2048_transposev_i8xi8xi32(%cont: !transform.any_op {transform.readonly})
     -> (!transform.any_op, !transform.any_param) {
+    transform.iree.match.has_no_lowering_config %cont : !transform.any_op
+
     %ins, %outs = transform.iree.match.cast_compatible_dag_from_root %cont {
     ^bb0(%lhs: tensor<?x64x2048xi8>, %rhs: tensor<20x64x2048xi8>, %out: tensor<?x20x64x64xi32>):
       %16 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d3, d4)>,
@@ -503,6 +539,8 @@ transform.named_sequence @match_matmul_like_Bx20x64x64x2048_transposev_i8xi8xi32
 
   transform.named_sequence @match_matmul_like_Bx10x4096x64x640_i8xi8xi32(%cont: !transform.any_op {transform.readonly})
     -> (!transform.any_op, !transform.any_param) {
+    transform.iree.match.has_no_lowering_config %cont : !transform.any_op
+
     %ins, %outs = transform.iree.match.cast_compatible_dag_from_root %cont {
     ^bb0(%lhs: tensor<?x4096x640xi8>, %rhs: tensor<10x64x640xi8>, %out: tensor<?x10x4096x64xi32>):
       %16 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d0, d2, d4)>,

--- a/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_unet_fp16_mi308.mlir
+++ b/tests/external/iree-test-suites/test_suite_files/attention_and_matmul_spec_unet_fp16_mi308.mlir
@@ -20,6 +20,8 @@ transform.named_sequence @apply_attn_op_config(%attention: !transform.any_op {tr
 }
 
 transform.named_sequence @match_attention_f16(%attention: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param, !transform.any_param) {
+  transform.iree.match.has_no_lowering_config %attention : !transform.any_op
+
   transform.match.operation_name %attention ["iree_linalg_ext.attention"] : !transform.any_op
   %in0 = transform.get_operand %attention[0] : (!transform.any_op) -> !transform.any_value
   transform.iree.match.cast_compatible_type %in0 = tensor<?x?x?x?xf16> : !transform.any_value
@@ -72,6 +74,8 @@ transform.named_sequence @match_mmt_f16_f16_f32(%root: !transform.any_op {transf
 //===----------------------------------------------------------------------===//
 
 transform.named_sequence @match_mmt_1920x10240x1280(%matmul: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+  transform.iree.match.has_no_lowering_config %matmul : !transform.any_op
+
   %mmt = transform.include @match_mmt_f16_f16_f32 failures(propagate) (%matmul) : (!transform.any_op) -> !transform.any_op
   %lhs = transform.get_operand %matmul[0] : (!transform.any_op) -> !transform.any_value
   %rhs = transform.get_operand %matmul[1] : (!transform.any_op) -> !transform.any_value
@@ -92,6 +96,8 @@ transform.named_sequence @match_mmt_1920x10240x1280(%matmul: !transform.any_op {
 }
 
 transform.named_sequence @match_mmt_1920x1280x1280(%matmul: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+  transform.iree.match.has_no_lowering_config %matmul : !transform.any_op
+
   %mmt = transform.include @match_mmt_f16_f16_f32 failures(propagate) (%matmul) : (!transform.any_op) -> !transform.any_op
   %lhs = transform.get_operand %matmul[0] : (!transform.any_op) -> !transform.any_value
   %rhs = transform.get_operand %matmul[1] : (!transform.any_op) -> !transform.any_value
@@ -112,6 +118,8 @@ transform.named_sequence @match_mmt_1920x1280x1280(%matmul: !transform.any_op {t
 }
 
 transform.named_sequence @match_mmt_1920x1280x5120(%matmul: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+  transform.iree.match.has_no_lowering_config %matmul : !transform.any_op
+
   %mmt = transform.include @match_mmt_f16_f16_f32 failures(propagate) (%matmul) : (!transform.any_op) -> !transform.any_op
   %lhs = transform.get_operand %matmul[0] : (!transform.any_op) -> !transform.any_value
   %rhs = transform.get_operand %matmul[1] : (!transform.any_op) -> !transform.any_value
@@ -132,6 +140,8 @@ transform.named_sequence @match_mmt_1920x1280x5120(%matmul: !transform.any_op {t
 }
 
 transform.named_sequence @match_mmt_7680x5120x640(%matmul: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+  transform.iree.match.has_no_lowering_config %matmul : !transform.any_op
+
   %mmt = transform.include @match_mmt_f16_f16_f32 failures(propagate) (%matmul) : (!transform.any_op) -> !transform.any_op
   %lhs = transform.get_operand %matmul[0] : (!transform.any_op) -> !transform.any_value
   %rhs = transform.get_operand %matmul[1] : (!transform.any_op) -> !transform.any_value
@@ -152,6 +162,8 @@ transform.named_sequence @match_mmt_7680x5120x640(%matmul: !transform.any_op {tr
 }
 
 transform.named_sequence @match_mmt_128x1280x2048(%matmul: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+  transform.iree.match.has_no_lowering_config %matmul : !transform.any_op
+
   %mmt = transform.include @match_mmt_f16_f16_f32 failures(propagate) (%matmul) : (!transform.any_op) -> !transform.any_op
   %lhs = transform.get_operand %matmul[0] : (!transform.any_op) -> !transform.any_value
   %rhs = transform.get_operand %matmul[1] : (!transform.any_op) -> !transform.any_value
@@ -172,6 +184,8 @@ transform.named_sequence @match_mmt_128x1280x2048(%matmul: !transform.any_op {tr
 }
 
 transform.named_sequence @match_mmt_7680x640x640(%matmul: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+  transform.iree.match.has_no_lowering_config %matmul : !transform.any_op
+
   %mmt = transform.include @match_mmt_f16_f16_f32 failures(propagate) (%matmul) : (!transform.any_op) -> !transform.any_op
   %lhs = transform.get_operand %matmul[0] : (!transform.any_op) -> !transform.any_value
   %rhs = transform.get_operand %matmul[1] : (!transform.any_op) -> !transform.any_value
@@ -192,6 +206,8 @@ transform.named_sequence @match_mmt_7680x640x640(%matmul: !transform.any_op {tra
 }
 
 transform.named_sequence @match_mmt_7680x640x2560(%matmul: !transform.any_op {transform.readonly}) -> (!transform.any_op, !transform.any_param) {
+  transform.iree.match.has_no_lowering_config %matmul : !transform.any_op
+
   %mmt = transform.include @match_mmt_f16_f16_f32 failures(propagate) (%matmul) : (!transform.any_op) -> !transform.any_op
   %lhs = transform.get_operand %matmul[0] : (!transform.any_op) -> !transform.any_value
   %rhs = transform.get_operand %matmul[1] : (!transform.any_op) -> !transform.any_value


### PR DESCRIPTION
Introduces `iree.match.has_no_lowering_config`.

This allows skipping already configured operations when matching in a transform spec. Additionally adds this op to all in-tree matchers.