### PR TITLE
Integrate llvm/llvm-project@15f7c6e

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_mask.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution_mask.mlir
@@ -223,10 +223,9 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK: %[[RED_IDENTITY:.+]] = arith.constant dense<0.000000e+00> : vector<2x1x2x1x2x8xf16>
 
 // CHECK: %[[MASK:.+]] = vector.create_mask
-// CHECK: %[[MASK_PCK:.+]] = vector.shape_cast %[[MASK]] : vector<8x8xi1> to vector<2x2x2x1x1x8xi1>
-// CHECK: %[[MASK_ITL_PCK:.+]] = vector.transpose %[[MASK_PCK]], [0, 3, 1, 4, 2, 5] : vector<2x2x2x1x1x8xi1> to vector<2x1x2x1x2x8xi1>
+// CHECK: %[[MASK_PCK:.+]] = vector.shape_cast %[[MASK]] : vector<8x8xi1> to vector<2x1x2x1x2x8xi1>
 
-// CHECK: %[[SELECT:.+]] = arith.select %[[MASK_ITL_PCK]], {{.*}}, %[[RED_IDENTITY]] : vector<2x1x2x1x2x8xi1>, vector<2x1x2x1x2x8xf16>
+// CHECK: %[[SELECT:.+]] = arith.select %[[MASK_PCK]], {{.*}}, %[[RED_IDENTITY]] : vector<2x1x2x1x2x8xi1>, vector<2x1x2x1x2x8xf16>
 // CHECK: vector.multi_reduction <add>, %[[SELECT]], {{.*}} [0, 2, 4] : vector<2x1x2x1x2x8xf16> to vector<1x1x8xf16>
 
 // -----
@@ -308,8 +307,7 @@ builtin.module attributes { transform.with_named_sequence } {
 // Currently, it does not fold away.
 // CHECK-DAG: %[[MASK_OP_1D:.+]] = vector.extract %[[MASK_OP]][0] : vector<2xi1> from vector<2x2xi1>
 // CHECK-DAG: %[[MASK_OP_1D_PACKED:.+]] = vector.shape_cast %[[MASK_OP_1D]] : vector<2xi1> to vector<1x1x2xi1>
-// CHECK-DAG: %[[MASK_OP_PACKED:.+]] = vector.shape_cast %[[MASK_OP]] : vector<2x2xi1> to vector<1x1x2x1x1x2xi1>
-// CHECK-DAG: %[[MASK_OP_INTERLEAVED:.+]] = vector.transpose %[[MASK_OP_PACKED]], [0, 3, 1, 4, 2, 5] : vector<1x1x2x1x1x2xi1> to vector<1x1x1x1x2x2xi1>
+// CHECK-DAG: %[[MASK_OP_PACKED:.+]] = vector.shape_cast %[[MASK_OP]] : vector<2x2xi1> to vector<1x1x1x1x2x2xi1>
 // CHECK-DAG: %[[MASK_OUT:.+]] = vector.create_mask {{.*}} : vector<2xi1>
 
 // CHECK-DAG: %[[LHS_READ:.+]] = vector.transfer_read %arg0{{.*}} %[[MASK_LHS]] {in_bounds = [true]} : memref<?xf16>, vector<2xf16>
@@ -318,6 +316,6 @@ builtin.module attributes { transform.with_named_sequence } {
 // CHECK-DAG: %[[RHS:.+]] = vector.insert_strided_slice %[[RHS_READ]]
 
 // CHECK-DAG: %[[LHS_SELECT:.+]] = arith.select %[[MASK_OP_1D_PACKED]], %[[LHS]], %[[RED_IDENTITY_LHS]] : vector<1x1x2xi1>, vector<1x1x2xf16>
-// CHECK-DAG: %[[RHS_SELECT:.+]] = arith.select %[[MASK_OP_INTERLEAVED]], %[[RHS]], %[[RED_IDENTITY_RHS]] : vector<1x1x1x1x2x2xi1>, vector<1x1x1x1x2x2xf16>
+// CHECK-DAG: %[[RHS_SELECT:.+]] = arith.select %[[MASK_OP_PACKED]], %[[RHS]], %[[RED_IDENTITY_RHS]] : vector<1x1x1x1x2x2xi1>, vector<1x1x1x1x2x2xf16>
 
 // CHECK: vector.contract {{.*}} %[[LHS_SELECT]], %[[RHS_SELECT]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -349,9 +349,9 @@ acquireInstrumentationEntry(Location loc, Value buffer, Value bufferPtr,
   Value offsetIndex =
       builder.create<LLVM::ConstantOp>(loc, i64Type, headOffset);
   auto i8Type = builder.getI8Type();
-  Value offsetPtr = builder.create<LLVM::GEPOp>(loc, basePtr.getType(), i8Type,
-                                                basePtr, offsetIndex,
-                                                /*inbounds=*/true);
+  Value offsetPtr = builder.create<LLVM::GEPOp>(
+      loc, basePtr.getType(), i8Type, basePtr, offsetIndex,
+      /*noWrapFlags =*/LLVM::GEPNoWrapFlags::inbounds);
   Value rawOffset = builder.create<LLVM::AtomicRMWOp>(
       loc, LLVM::AtomicBinOp::add, offsetPtr, entrySize,
       LLVM::AtomicOrdering::monotonic);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.cpp
@@ -952,11 +952,12 @@ Value HALDispatchABI::updateProcessorDataFromTargetAttr(
   for (int64_t i = 1, e = ProcessorDataCapacity; i < e; ++i) {
     Value loadPtr = builder.create<LLVM::GEPOp>(
         loc, processorDataPtrValue.getType(), i64Ty, processorDataPtrValue,
-        LLVM::GEPArg(int32_t(i)), /*inbounds =*/true);
+        LLVM::GEPArg(int32_t(i)),
+        /*noWrapFlags =*/LLVM::GEPNoWrapFlags::inbounds);
     Value loadVal = builder.create<LLVM::LoadOp>(loc, i64Ty, loadPtr);
     Value storePtr = builder.create<LLVM::GEPOp>(
         loc, alloca.getType(), i64Ty, alloca, LLVM::GEPArg(int32_t(i)),
-        /*inbounds =*/true);
+        /*noWrapFlags =*/LLVM::GEPNoWrapFlags::inbounds);
     builder.create<LLVM::StoreOp>(loc, loadVal, storePtr);
   }
   return alloca;
@@ -978,12 +979,12 @@ Value HALDispatchABI::loadProcessorData(Operation *forOp, OpBuilder &builder) {
       loc, LLVM::LLVMPointerType::get(context),
       LLVM::LLVMPointerType::get(context), environmentPtrValue,
       LLVM::GEPArg(int32_t(EnvironmentField::processor)),
-      /*inbounds=*/true);
+      /*noWrapFlags =*/LLVM::GEPNoWrapFlags::inbounds);
   Value processorDataPtrValue = builder.create<LLVM::GEPOp>(
       loc, LLVM::LLVMPointerType::get(context),
       LLVM::LLVMPointerType::get(context), processorPtrValue,
       LLVM::GEPArg(int32_t(ProcessorField::data)),
-      /*inbounds=*/true);
+      /*noWrapFlags =*/LLVM::GEPNoWrapFlags::inbounds);
   Value updatedProcessorData =
       updateProcessorDataFromTargetAttr(forOp, processorDataPtrValue, builder);
   return buildValueDI(forOp, updatedProcessorData, "processor_data",


### PR DESCRIPTION
- Carries the same 4 reverts from https://github.com/iree-org/iree/pull/20674.
- Uses enum when building `LLVM::GEPOp` (llvm/llvm-project#137272)
- Reverts https://github.com/llvm/llvm-project/commit/7318074168e324097b7f6ec93e34915463bf70f1 which can be undone after torch-mlir and stablehlo have been updated.
- Reverts https://github.com/llvm/llvm-project/pull/137930 and https://github.com/llvm/llvm-project/commit/e1cff21f65fc876f7a9d0531a4b4d2aa3f0b4f21 to fix correctness failure of e2e_matmul_cdna3_pad_i8_rocm_hip.
