### PR TITLE
[Docs] Make op/attr/type summary styles consistent

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -470,8 +470,9 @@ def MatchHasNoLoweringConfigOp : Op<Transform_Dialect, "iree.match.has_no_loweri
     [MatchOpInterface,
      SingleOpMatcher,
      MemoryEffectsOpInterface]> {
-  let summary =
-      "Checks that the payload op does not carry a lowering config or compilation info";
+  let summary = [{
+    Checks that the payload op does not carry a lowering config or compilation info
+  }];
   let description = [{
     Verifies that the payload does not have a "compilation_info" or
     "lowering_config" attribute. This is a very common check needed for external

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -471,7 +471,7 @@ def MatchHasNoLoweringConfigOp : Op<Transform_Dialect, "iree.match.has_no_loweri
      SingleOpMatcher,
      MemoryEffectsOpInterface]> {
   let summary = [{
-    Checks that the payload op does not carry a lowering config or compilation info
+    Checks that the payload op does not carry a lowering config or compilation info.
   }];
   let description = [{
     Verifies that the payload does not have a "compilation_info" or

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -179,7 +179,7 @@ def CopyTensorOperandOp :  Op<Transform_Dialect, "iree.copy_tensor_operand",
      TransformEachOpTrait,
      TransformOpInterface,
      ReportTrackingListenerFailuresOpTrait]> {
-  let summary = "Hoist static allocations";
+  let summary = [{Create a linalg copy of a specified value.}];
   let description = [{
     Inserts a copy of the specified operand of the target operation.
 
@@ -214,7 +214,7 @@ def GpuDistributeSharedMemoryCopyOp :
   Op<Transform_Dialect, "iree.gpu_distribute_shared_memory_copy",
     [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
      TransformOpInterface, TransformEachOpTrait]> {
-  let summary = "Distribute shared memory copies";
+  let summary = [{Distribute shared memory copies.}];
   let description = [{
     Find copies to/from shared memory and distribute the copies based on the
     workgroup size.
@@ -244,7 +244,7 @@ def HoistStaticAllocOp :  Op<Transform_Dialect, "iree.hoist_static_alloc",
      TransformEachOpTrait,
      TransformOpInterface,
      ReportTrackingListenerFailuresOpTrait]> {
-  let summary = "Hoist static allocations";
+  let summary = [{Hoist static allocations.}];
   let description = [{
     Find static allocations and hoist them to the top level.
 
@@ -530,7 +530,7 @@ def ReduceSharedMemoryBankConflictsOp :  Op<Transform_Dialect, "iree.reduce_shar
      TransformEachOpTrait,
      TransformOpInterface,
      ReportTrackingListenerFailuresOpTrait]> {
-  let summary = "Add padding to 'memref.alloc' ops reduce shared memory bank conflicts";
+  let summary = [{Add padding to 'memref.alloc' ops reduce shared memory bank conflicts.}];
   let description = [{
     The `paddingSizeBits` argument should be picked based on the target
     architecture, striking balance between minimizing bank conflicts and keeping

--- a/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CPU/IR/IREECPUAttrs.td
@@ -18,7 +18,7 @@ include "mlir/IR/AttrTypeBase.td"
 def IREECPU_CPUEncodingLayoutAttr :
     AttrDef<IREECPU_Dialect, "CPUEncodingLayout"> {
   let mnemonic = "cpu_encoding_layout";
-  let summary = "The encoding layout attribute for CPU backends.";
+  let summary = [{The encoding layout attribute for CPU backends.}];
   let description = [{
     This attribute can implement any layout interface methods for data-tiling,
     e.g., Codegen::LayoutAttrInterface, etc. They are implemented through
@@ -37,7 +37,7 @@ def IREECPU_CPUEncodingLayoutAttr :
 def IREECPU_VMVXEncodingLayoutAttr :
     AttrDef<IREECPU_Dialect, "VMVXEncodingLayout"> {
   let mnemonic = "vmvx_encoding_layout";
-  let summary = "The encoding layout attribute for VMVX backend.";
+  let summary = [{The encoding layout attribute for VMVX backend.}];
   let description = [{
     This attribute can implement any layout interface methods for data-tiling,
     e.g., Codegen::LayoutAttrInterface, etc. They are implemented through

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -204,7 +204,7 @@ def WorkgroupMappingAttr :
 def IREECodegen_TranslationInfoAttr :
     AttrDef<IREECodegen_Dialect, "TranslationInfo", []> {
   let mnemonic = "translation_info";
-  let summary = [{drive dispatch entry point lowering}];
+  let summary = [{Drive dispatch entry point lowering.}];
   let description = [{
     Specifies the information that is used to drive the translation of
     an entry point function using Linalg based structured-op
@@ -294,7 +294,7 @@ def IREECodegen_LoweringConfigAttr :
       ]>
     ]> {
   let mnemonic = "lowering_config";
-  let summary = [{drive lowering of an operation within dispatch region}];
+  let summary = [{Drive lowering of an operation within dispatch region.}];
   let description = [{
     Default implementation of a lowering configuration attribute. It includes
     only tiling and optionally vectorization information. The interpretation of
@@ -364,7 +364,7 @@ def IREECodegen_LoweringConfigAttr :
 def IREECodegen_CompilationInfoAttr :
     AttrDef<IREECodegen_Dialect, "CompilationInfo", []> {
   let mnemonic = "compilation_info";
-  let summary = [{drive lowering of an operation from input dialect}];
+  let summary = [{Drive lowering of an operation from input dialect.}];
   let description = [{
     Specifies the information that allows controlling the compilation
     of operations like `linalg.matmul`/`linalg.*conv` within
@@ -398,7 +398,7 @@ def IREECodegen_CompilationInfoAttr :
 
 def IREECodegen_ExportConfig : AttrDef<IREECodegen_Dialect, "ExportConfig", []> {
   let mnemonic = "export_config";
-  let summary = "User defined workgroup size specification";
+  let summary = [{User defined workgroup size specification.}];
   let description = [{
     Allows setting workgroup size for pre-formed dispatches.
   }];
@@ -426,7 +426,7 @@ def IREECodegen_EncodingNopLayoutAttr  :
       ]>
     ]> {
   let mnemonic = "encoding_nop_layout";
-  let summary = "An attribute with implementation that treats encoding as nop.";
+  let summary = [{An attribute with implementation that treats encoding as nop.}];
   let description = [{
     An attribute that implements the interface methods that discards the
     encodings. It can be a default attribute when a backend does not implement
@@ -446,7 +446,7 @@ def IREECodegen_RotateRowsAttr  :
       ]>
     ]> {
   let mnemonic = "rotate_rows";
-  let summary = "An attribute that describes a swizzling pattern for rotating rows.";
+  let summary = [{An attribute that describes a swizzling pattern for rotating rows.}];
   let description = [{
     This attribute rotates accesses of |access_width| within rows of size
     |row_width|. For any given access into logical memref of shape

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
@@ -20,10 +20,12 @@ def TensorTypeAttr : TypeAttrBase<"TensorType", "Tensor type attribute">;
 
 def IREECodegen_QueryTileSizesOp :
     Op<IREECodegen_Dialect, "query_tile_sizes", [Pure]> {
-  let summary = "Query tile sizes";
+  let summary = [{Yields tile sizes for the specified tensor type.}];
 
   let description = [{
-    Query tile sizes
+    For targets where tile sizes can't be resolved at compile time, this
+    operation allows querying the sizes at runtime. Today this only applies
+    to VMVX.
   }];
 
   let arguments = (ins TensorTypeAttr:$tensor_type);
@@ -43,7 +45,7 @@ def IREECodegen_ExtractStridedMetadataOp : Op<IREECodegen_Dialect, "extract_stri
     SameVariadicResultSize,
     ViewLikeOpInterface,
     InferTypeOpAdaptor]> {
-  let summary = "Extracts a buffer base with offset and strides";
+  let summary = [{Extracts a buffer base with offset and strides.}];
   let description = [{
     This op is implemented similarly to the upstream MemRef::ExtractStridedMetadataOp
     with the following differences.
@@ -109,7 +111,7 @@ def IREECodegen_ExtractStridedMetadataOp : Op<IREECodegen_Dialect, "extract_stri
 
 def IREECodegen_SwizzleHintOp : Op<IREECodegen_Dialect, "swizzle_hint", [
     SameOperandsAndResultType, Pure]> {
-  let summary = "Hint to swizzle accesses according to an access pattern";
+  let summary = [{Hint to swizzle accesses according to an access pattern}];
   let description = [{
     Optimization hint to swizzle all accesses to the memref this takes a view
     of. This only affects reads/writes immediately consuming this operation and
@@ -163,7 +165,7 @@ def IREECodegen_SwizzleHintOp : Op<IREECodegen_Dialect, "swizzle_hint", [
 
 def IREECodegen_NullPointerOp :
      Op<IREECodegen_Dialect, "null_pointer", [Pure]> {
-  let summary = "Returns a null_pointer value.";
+  let summary = [{Returns a null_pointer value.}];
   let description = [{
     This is meant to be used only as arguments to microkernels.
   }];
@@ -177,7 +179,7 @@ def IREECodegen_NullPointerOp :
 
 def IREECodegen_LoadFromMemrefOp : Op<IREECodegen_Dialect, "load_from_memref",
     [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
-  let summary = [{loads a tensor from a memref}];
+  let summary = [{Loads a tensor from a memref.}];
   let description = [{
     Loads a tensor from a memref with a compatible shape and the same element
     type.
@@ -199,7 +201,7 @@ def IREECodegen_LoadFromMemrefOp : Op<IREECodegen_Dialect, "load_from_memref",
 
 def IREECodegen_StoreToMemrefOp : Op<IREECodegen_Dialect, "store_to_memref",
     [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
-  let summary = [{stores a tensor into a memref}];
+  let summary = [{Stores a tensor into a memref.}];
   let description = [{
     Stores a tensor into a memref with a compatible shape and the same element
     type.

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
@@ -111,7 +111,7 @@ def IREECodegen_ExtractStridedMetadataOp : Op<IREECodegen_Dialect, "extract_stri
 
 def IREECodegen_SwizzleHintOp : Op<IREECodegen_Dialect, "swizzle_hint", [
     SameOperandsAndResultType, Pure]> {
-  let summary = [{Hint to swizzle accesses according to an access pattern}];
+  let summary = [{Hint to swizzle accesses according to an access pattern.}];
   let description = [{
     Optimization hint to swizzle all accesses to the memref this takes a view
     of. This only affects reads/writes immediately consuming this operation and

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.td
@@ -11,7 +11,7 @@ include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.td"
 
 def NullPointer
   : TypeDef<IREECodegen_Dialect, "NullPointer", []> {
-  let summary = "Pseudo null-pointer type. Lowers to a null pointer.";
+  let summary = [{Pseudo null-pointer type. Lowers to a null pointer.}];
   let description = [{
     This is meant to be used only as arguments to microkernels.
   }];

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/UKernelOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/UKernelOps.td
@@ -22,7 +22,7 @@ class IREECodegen_UKernelOp<string mnemonic, list<Trait> traits = []> :
 def IREECodegen_UKernelGenericOp :
     IREECodegen_UKernelOp<"ukernel.generic", [
       AttrSizedOperandSegments]> {
-  let summary = "Generic Microkernel operator";
+  let summary = [{Generic Microkernel operator.}];
 
   let description = [{
     Operation to wrap a computation forwarded to a microkernel.

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td
@@ -44,7 +44,7 @@ def IREEGPU_LoweringConfigAttr :
       ]>
     ]> {
   let mnemonic = "lowering_config";
-  let summary = "drive lowering of an operation for gpu compilation.";
+  let summary = [{Drive lowering of an operation for gpu compilation.}];
   let description = [{
     GPU specific implementation of a lowering config. This carries just a
     dictionary attribute to store any relevant fields. This is the simplest
@@ -69,7 +69,7 @@ def IREEGPU_DerivedThreadConfig :
     ]> {
   let mnemonic = "derived_thread_config";
   let summary = [{
-    drive lowering of an operation by deriving thread distribution when needed.
+    Drive lowering of an operation by deriving thread distribution when needed.
   }];
   let description = [{
     Lowering config for a single thread tiling level that is inferred after
@@ -295,7 +295,7 @@ def IREEGPU_MmaScheduleAttr : AttrDef<IREEGPU_Dialect, "MMASchedule"> {
 def IREEGPU_GPUEncodingLayoutAttr :
     AttrDef<IREEGPU_Dialect, "GPUEncodingLayout"> {
   let mnemonic = "gpu_encoding_layout";
-  let summary = "The encoding layout attribute for GPU backend";
+  let summary = [{The encoding layout attribute for GPU backend.}];
   let description = [{
     This attribute can implement any layout interface methods for data-tiling,
     e.g., Codegen::LayoutAttrInterface, etc. They should be implemented
@@ -319,7 +319,7 @@ def IREEGPU_GPUEncodingLayoutAttr :
 
 def IREEGPU_GPUPadLayoutAttr : AttrDef<IREEGPU_Dialect, "GPUPadLayout"> {
   let mnemonic = "gpu_pad_layout";
-  let summary = "The padded encoding layout attribute for GPU targets.";
+  let summary = [{The padded encoding layout attribute for GPU targets.}];
   let assemblyFormat = "`<` struct(params) `>`";
 
   let description = [{
@@ -345,7 +345,7 @@ def IREEGPU_GPUPadLayoutAttr : AttrDef<IREEGPU_Dialect, "GPUPadLayout"> {
 //===----------------------------------------------------------------------===//
 
 def IREEGPU_TargetWgpAttr : AttrDef<IREEGPU_Dialect, "TargetWgp"> {
-  let summary = "Workgroup processor level target description";
+  let summary = [{Workgroup processor level target description.}];
   let description = [{
     This attribute contains hardware features/limits at a single GPU workgroup
     processor (WGP) level. Here a GPU workgroup processor means the basic
@@ -403,7 +403,7 @@ def IREEGPU_TargetWgpAttr : AttrDef<IREEGPU_Dialect, "TargetWgp"> {
 // AMD compute units or NVIDIA streaming multiprocessors; it's the final SKU.
 
 def IREEGPU_TargetChipAttr : AttrDef<IREEGPU_Dialect, "TargetChip"> {
-  let summary = "Chip level target description";
+  let summary = [{Chip level target description.}];
   let description = [{
     This attribute contains hardware features/limits at a single GPU chip level.
     Here a GPU chip means the hardware functionality scope where the whole
@@ -433,7 +433,7 @@ def IREEGPU_TargetChipAttr : AttrDef<IREEGPU_Dialect, "TargetChip"> {
 //===----------------------------------------------------------------------===//
 
 def IREEGPU_TargetAttr : AttrDef<IREEGPU_Dialect, "Target"> {
-  let summary = "Full GPU target attribute";
+  let summary = [{Full GPU target attribute.}];
   let description = [{
     This attributes describes a full GPU target. It contains a few fields:
     * The canonical target architecture for compilation, e.g., sm_80 for
@@ -530,7 +530,7 @@ def IREEGPU_LaneIdAttr : AttrDef<IREEGPU_Dialect, "LaneId", [
 def IREEGPU_UKernelConfigAttr  :
     AttrDef<IREEGPU_Dialect, "UKernelConfig", []> {
   let mnemonic = "ukernel_config";
-  let summary = "An attribute specifying a ukernel that an op can lower to.";
+  let summary = [{An attribute specifying a ukernel that an op can lower to.}];
   let description = [{
     An attribute that can be applied to any operation to specify that it has
     been matched with a ukernel that is a legal lowering for it.
@@ -554,7 +554,7 @@ def IREEGPU_ReorderWorkgroupsStrategyAttr :
 }
 
 def IREEGPU_GPUPipelineOptionsAttr : AttrDef<IREEGPU_Dialect, "GPUPipelineOptions"> {
-  let summary = "GPU pipeline options attribute.";
+  let summary = [{Options attribute for linalg + tensors -> vector + memref GPU pipelines.}];
   let description = [{
     This attributes describes lowering pipeline specific configuration options:
     * prefetch_shared_memory: Boolean option indicating whether or not to run

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUOps.td
@@ -26,7 +26,7 @@ def IREEGPU_BarrierRegionOp : Op<IREEGPU_Dialect, "barrier_region", [
     Pure,
     SingleBlockImplicitTerminator<"mlir::iree_compiler::IREE::GPU::YieldOp">
     ]> {
-  let summary = "Synchronizes uses of a shared tensor.";
+  let summary = [{Synchronizes workers on a region of shared code.}];
   let description = [{
     This op is designed to represent synchronization of workers on the operands
     and results of the given region. This operation naturally arises when combining
@@ -125,7 +125,7 @@ def IREEGPU_MultiMmaOp : Op<IREEGPU_Dialect, "multi_mma", [
         "getTiledImplementation",
         "getResultTilePosition"]>
     ]> {
-  let summary = "Models a contraction of multiple mma operations";
+  let summary = [{Models a contraction of multiple mma operations.}];
   let description = [{
     Computes the sum of inner MMA operations along a set of outer dimensions.
     Logically matches closely with a `vector.contraction` operation, however
@@ -391,7 +391,7 @@ def IREEGPU_MultiMmaOp : Op<IREEGPU_Dialect, "multi_mma", [
 def IREEGPU_ValueBarrierOp : Op<IREEGPU_Dialect, "value_barrier", [
   Pure,
   AllTypesMatch<["inputs", "results"]>]> {
-  let summary = "Synchronizes workers on a value semantic tensor or vector.";
+  let summary = [{Synchronizes workers on a value semantic tensor or vector.}];
   let description = [{
     This operation acts as a barrier on a value semantic SSA values (tensor or
     vector). It takes multiple operands and produces a value equivalent to each
@@ -444,7 +444,7 @@ def IREEGPU_ValueBarrierOp : Op<IREEGPU_Dialect, "value_barrier", [
 def IREEGPU_YieldOp : Op<IREEGPU_Dialect, "yield", [
     Pure, ReturnLike, Terminator,
     HasParent<"::mlir::iree_compiler::IREE::GPU::BarrierRegionOp">]> {
-  let summary = "Yield values from a region";
+  let summary = [{Yield values from a iree_gpu region.}];
   let description = [{
      This operation is used to yield values from a within a region.
   }];
@@ -469,7 +469,7 @@ def IREEGPU_YieldOp : Op<IREEGPU_Dialect, "yield", [
 def IREEGPU_BufferResourceCastOp : Op<IREEGPU_Dialect, "buffer_resource_cast", [
   Pure,
   AllTypesMatch<["input", "result"]>]> {
-  let summary = "Represents a cast to addr_space<7> (buffer resource) before bufferization";
+  let summary = [{Represents a cast to addr_space<7> (buffer resource) before bufferization.}];
   let description = [{
     Nominal cast of a tensor to AMDGPU buffer resource memory space before
     bufferization. This op takes the parameters with which to perform the cast

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtAttrs.td
@@ -16,7 +16,7 @@ include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtBase.td"
 def NestedLayoutAttr : IREEVectorExt_Attr<"NestedLayout",
       [ DeclareAttrInterfaceMethods<VectorLayoutInterface> ]> {
   let mnemonic = "nested_layout";
-  let summary = [{A layout representing a mapping from GPU thread hierarchy to a shape}];
+  let summary = [{A layout representing a mapping from GPU thread hierarchy to a shape.}];
   let description = [{
     This layout explicitly defines how the shape of the associated vector
     is mapped to a compute hierarchy.

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.td
@@ -30,7 +30,7 @@ def IREEVectorExt_ToLayoutOp : IREEVectorExt_PureOp<"to_layout", [
   Pure,
   AllTypesMatch<["input", "output"]>
   ]> {
-  let summary = "Layout conversion operator";
+  let summary = [{Layout conversion operator.}];
   let description = [{
     The layout conversion operator takes a shaped value and a layout and
     transforms the value to have that layout.
@@ -78,7 +78,7 @@ def IREEVectorExt_ToLayoutOp : IREEVectorExt_PureOp<"to_layout", [
 
 def IREEVectorExt_ToSIMDOp : IREEVectorExt_PureOp<"to_simd",
     [SameOperandsAndResultElementType, Pure]> {
-  let summary = "SIMT to SIMD conversion operation";
+  let summary = [{SIMT to SIMD conversion operation.}];
   let description = [{
     This operation is a temporary operation useful for source/target
     materializations when doing type conversions between distributed and not
@@ -97,7 +97,7 @@ def IREEVectorExt_ToSIMDOp : IREEVectorExt_PureOp<"to_simd",
 
 def IREEVectorExt_ToSIMTOp : IREEVectorExt_PureOp<"to_simt",
     [SameOperandsAndResultElementType, Pure]> {
-  let summary = "SIMD to SIMT conversion operation";
+  let summary = [{SIMD to SIMT conversion operation.}];
   let description = [{
     This operation is a temporary operation useful for source/target
     materializations when doing type conversions between distributed and not
@@ -131,7 +131,7 @@ def IREEVectorExt_TransferGatherOp : IREEVectorExt_PureOp<"transfer_gather", [
                        BoolArrayAttr:$in_bounds);
   let results = (outs AnyVectorOfAnyRank:$vector);
 
-  let summary = "Gathers a supervector from memory into an SSA vector value.";
+  let summary = [{Gathers a supervector from memory into an SSA vector value.}];
 
   let description = [{
     The iree_vector_ext.transfer_gather operation provides a structured

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
@@ -615,7 +615,7 @@ def PackSharedMemoryAllocOp :  Op<Transform_Dialect, "iree.pack_shared_memory_al
      TransformEachOpTrait,
      TransformOpInterface,
      ReportTrackingListenerFailuresOpTrait]> {
-  let summary = "Pack shared memory allocation to reduce memory usage";
+  let summary = [{Pack shared memory allocation to reduce memory usage.}];
   let description = [{
     Looks for allocs in shared memory space with overlapping liveness and
     groups them, then packs all the allocations in each group into one i8

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -56,7 +56,7 @@ def LayoutAttr :
   let mnemonic = "layout";
   let assemblyFormat = "`<` $layouts `>`";
 
-  let summary = [{Indicates potential serialized layouts}];
+  let summary = [{Indicates potential serialized layouts.}];
   let description = [{
     This attribute describes the potential layouts of the encoding. It is an
     array because a device could have multiple target layouts.
@@ -108,7 +108,7 @@ def EncodingAttr :
       ]>
     ]> {
   let mnemonic = "encoding";
-  let summary = [{information to decide how to data-tile a tensor}];
+  let summary = [{Information to decide how to data-tile a tensor.}];
   let description = [{
     This attribute describes the change in the layout for
     a given tensor to execute subsequent operations on
@@ -193,7 +193,7 @@ def MatmulKAttr : IREEEncoding_Attr<"MatmulK", [
       ]>,
     ]> {
   let mnemonic = "matmul_k";
-  let summary = [{An attribute that tracks reduction dimensions for matmul}];
+  let summary = [{An attribute that tracks reduction dimensions for matmul.}];
   let description = [{
     The attribute is specialized for tracking the matmul reduction dimensions
     only. The encoded dimensions are the reduction dimensions that will be
@@ -253,7 +253,7 @@ def PadEncodingLayoutAttr : IREEEncoding_Attr<"PadEncodingLayout", [
   let mnemonic = "pad_encoding_layout";
   let assemblyFormat = "`<` custom<Padding>($padding) `>`";
 
-  let summary = "An attribute that encodes padding values of tensor dimensions";
+  let summary = [{An attribute that encodes padding values of tensor dimensions.}];
   let description = [{
     Associates tensor dimensions with pad values (numbers of appended elements).
     The logical dimensions of the tensors do not change, and the elements in the
@@ -302,7 +302,7 @@ def IdentityEncodingAttr :
       ]>
     ]> {
   let mnemonic = "identity_encoding";
-  let summary = "A layout resolver that behaves like an identity function";
+  let summary = [{A layout resolver that behaves like an identity function.}];
   let description = [{
     A layout resolver that behaves like an identity function. I.e., it resolves
     the layout to the same layout without encodings.
@@ -323,7 +323,7 @@ def UnsupportedEncodingAttr :
       ]>
     ]> {
   let mnemonic = "unsupported_encoding";
-  let summary = "A layout resolver attribute that always fails to get layout";
+  let summary = [{A layout resolver attribute that always fails to get layout.}];
   let description = [{
     An layout resolver that never resolves the layout. I.e., it always fails on
     getting a layout. It can be used in testing or a default unknown attribute
@@ -345,7 +345,7 @@ def TestingEncodingAttr :
       ]>
     ]> {
   let mnemonic = "testing_encoding";
-  let summary = "An encoding attribute for testing purpose";
+  let summary = [{An encoding attribute for testing purposes.}];
 
   let description = [{
     An attribute for testing purpose. It is intended to be attached on
@@ -363,7 +363,7 @@ def TestingEncodingAttr :
 
 def UnknownEncodingAttr : IREEEncoding_Attr<"UnknownEncoding"> {
   let mnemonic = "unknown_encoding";
-  let summary = "A pure encoding attribute for testing purpose";
+  let summary = [{A pure encoding attribute for testing purpose.}];
 
   let description = [{
     An attribute for testing purpose. It is intended to be attached on
@@ -382,7 +382,7 @@ def UnspecializedEncodingAttr :
   let mnemonic = "unspecialized_encoding";
   let assemblyFormat = "`<` $seed `>`";
 
-  let summary = "An attribute that indicates the encoding is not yet specialized";
+  let summary = [{An attribute that indicates the encoding is not yet specialized.}];
 
   let description = [{
     This attribute indicates this is an unspecialized encoding. It implements
@@ -404,7 +404,7 @@ def SpecializedEncodingAttr :
   let mnemonic = "specialized_encoding";
   let assemblyFormat = "`<` $seed (`,` $type^)? `>`";
 
-  let summary = "An attribute that indicates the encoding is specialized";
+  let summary = [{An attribute that indicates the encoding is specialized.}];
 
   let description = [{
     This attribute is similar to UnspecializedEncodingAttr, but with an optional

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingOps.td
@@ -26,7 +26,7 @@ class IREEEncoding_PureOp<string mnemonic, list<Trait> traits = []> :
 def IREEEncoding_SetEncodingOp : IREEEncoding_PureOp<"set_encoding",[
    DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>, Pure
   ]> {
-  let summary = "perform pack and pad operation on source";
+  let summary = [{Perform pack and pad operation on source.}];
   let description = [{
     Operation to assign an encoding to a tensor. The operation does not change
     the rank or extent of a tensor. Instead it adds an
@@ -60,7 +60,7 @@ def IREEEncoding_SetEncodingOp : IREEEncoding_PureOp<"set_encoding",[
 def IREEEncoding_UnsetEncodingOp : IREEEncoding_PureOp<"unset_encoding", [
     DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>, Pure
   ]> {
-  let summary = "perfom unpack and extract operation on source";
+  let summary = [{Perform unpack and extract operation on source.}];
   let description = [{
     Operation to convert an tensor with EncodingLayoutResolverAttrInterface
     encoding that represents its data layout into a tensor with default layout

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowBase.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowBase.td
@@ -143,7 +143,7 @@ def FLOW_CollectiveElementTypeAttr :
 
 def FLOW_Channel : TypeDef<Flow_Dialect, "Channel", []> {
   let mnemonic = "channel";
-  let summary = [{a collecive communication channel}];
+  let summary = [{A collecive communication channel.}];
   let description = [{
     Represents a single participant in a collective clique. Multiple channels
     may exist within the same program to allow for partial operations or
@@ -193,7 +193,7 @@ def FLOW_NamedParameterAttr :
       ]>,
     ]> {
   let mnemonic = "parameter.named";
-  let summary = [{named parameter referenced an optional scope and key}];
+  let summary = [{Named parameter referenced an optional scope and key.}];
   let description = [{
     Species an externally-defined parameter that can be referenced by an
     optional scope defining a set of parameters and a key uniquely identifying

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -40,7 +40,7 @@ def FLOW_DispatchRegionOp : FLOW_PureOp<"dispatch.region", [
     DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
     Util_ShapeAwareOp,
     AttrSizedOperandSegments]> {
-  let summary = [{a group of ops}];
+  let summary = [{A grouping of ops with implicit capture.}];
   let description = [{
     This op is a container/grouping of ops. It represents a fusion group before
     being lowered to a dispatch region. Ops are collected inside of the region
@@ -89,7 +89,7 @@ def FLOW_DispatchWorkgroupsOp : FLOW_PureOp<"dispatch.workgroups", [
   ]>,
   Util_ShapeAwareOp,
 ]> {
-  let summary = [{a dispatch of workgroups across a 3-dimensional grid}];
+  let summary = [{A dispatch of workgroups across a 3-dimensional grid.}];
   let description = [{
     Dispatches some number of workgroups across a 3-dimensional grid. The
     body region will be invoked for each workgroup with a unique
@@ -240,7 +240,7 @@ def FLOW_DispatchWorkgroupsOp : FLOW_PureOp<"dispatch.workgroups", [
 def FLOW_DispatchWorkgroupIDOp : FLOW_PureOp<"dispatch.workgroup.id", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{returns the index of the current workgroup in the grid}];
+  let summary = [{Returns the index of the current workgroup in the grid.}];
   let description = [{
     The global workgroup ID of the current workgroup in the range of
     `[0, flow.dispatch.workgroup.count)` along each dimension.
@@ -277,7 +277,7 @@ def FLOW_DispatchWorkgroupIDOp : FLOW_PureOp<"dispatch.workgroup.id", [
 def FLOW_DispatchWorkgroupCountOp : FLOW_PureOp<"dispatch.workgroup.count", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{returns the total workgroup count of the grid}];
+  let summary = [{Returns the total workgroup count of the grid.}];
   let description = [{
     The total number of workgroups along each dimension in the dispatch grid.
 
@@ -313,7 +313,7 @@ def FLOW_DispatchWorkgroupCountOp : FLOW_PureOp<"dispatch.workgroup.count", [
 def FLOW_DispatchWorkgroupSizeOp : FLOW_PureOp<"dispatch.workgroup.size", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{returns the size of each workgroup in invocations}];
+  let summary = [{Returns the size of each workgroup in invocations.}];
   let description = [{
     The number of local invocations within the current workgroup along each
     dimension. Depending on backend this may map to the SIMT thread count or
@@ -359,7 +359,7 @@ def FLOW_DispatchTieShapeOp : FLOW_PureOp<"dispatch.tie_shape", [
   DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
   Util_ShapeAwareOp,
 ]> {
-  let summary = [{ties a runtime shape to a dispatch I/O argument}];
+  let summary = [{Ties a runtime shape to a dispatch I/O argument.}];
   let description = [{
     Metadata op used to tie a runtime-computed shape with dynamic dimensions to
     a dispatch input/output argument. All uses of the argument should use the
@@ -394,7 +394,7 @@ def FLOW_ReturnOp : FLOW_Op<"return", [
   ReturnLike,
   Terminator,
 ]> {
-  let summary = [{return from a flow.dispatch_region}];
+  let summary = [{Return from a flow.dispatch_region.}];
   let description = [{
     Returns the given values from the region and back to the host code.
   }];
@@ -433,7 +433,7 @@ def FLOW_ExecutableOp : FLOW_Op<"executable", [
   SymbolTable,
   Util_ObjectLike,
 ]> {
-  let summary = [{generic executable module}];
+  let summary = [{Generic executable module.}];
   let description = [{
     An executable module containing one or more public functions. The contents
     of the functions are safe to dispatch and can be lowered further to
@@ -476,7 +476,7 @@ def FLOW_ExecutableEndOp : FLOW_Op<"executable_end", [
   HasParent<"IREE::Flow::ExecutableOp">,
   Terminator,
 ]> {
-  let summary = [{terminator pseudo-op for the executable op}];
+  let summary = [{Terminator pseudo-op for the executable op.}];
   let assemblyFormat = "attr-dict";
 }
 
@@ -485,7 +485,7 @@ def FLOW_ExecutableExportOp : FLOW_Op<"executable.export", [
   Symbol,
   IsolatedFromAbove,
 ]> {
-  let summary = [{defines an executable entry point for dispatch operations}];
+  let summary = [{Defines an executable entry point for dispatch operations.}];
   let description = [{
     Specifies an exported function with an externally-visible alias. Multiple
     exports can reference the same internal function.
@@ -540,7 +540,7 @@ def FLOW_DispatchOp : FLOW_PureOp<"dispatch", [
   ]>,
   Util_ShapeAwareOp,
 ]> {
-  let summary = [{a dispatch of workgroups across a grid}];
+  let summary = [{A dispatch of workgroups across a grid.}];
   let description = [{
     Dispatches workgroups across an grid defined by the captured workload
     parameters carrying the information required to compute the workgroup count
@@ -654,7 +654,7 @@ def FLOW_FuncOp : FLOW_Op<"func", [
   FunctionOpInterface,
   IsolatedFromAbove,
 ]> {
-  let summary = [{streamable function declaration}];
+  let summary = [{Streamable function declaration.}];
   let description = [{
     Declares a function that can be called as an asynchronous streaming
     operation via `flow.call`. Today only external functions are allowed.
@@ -723,7 +723,7 @@ def FLOW_CallOp : FLOW_Op<"call", [
   ]>,
   Util_ShapeAwareOp,
 ]> {
-  let summary = [{calls a streamable external host function}];
+  let summary = [{Calls a streamable external host function.}];
   let description = [{
     Calls a function taking/returning tensor values with stream semantics.
     Tensors have their shapes captured and may be tied to denote in-place
@@ -830,7 +830,7 @@ def FLOW_TensorConstantOp : FLOW_PureOp<"tensor.constant", [
   ConstantLike,
   AllTypesMatch<["value", "result"]>,
 ]> {
-  let summary = [{tensor constant that can have dynamic dimensions}];
+  let summary = [{Tensor constant that can have dynamic dimensions.}];
   let description = [{
     Allows specifying a tensor constant of IREE-specific types/attributes.
 
@@ -855,7 +855,7 @@ def FLOW_TensorConstantOp : FLOW_PureOp<"tensor.constant", [
 }
 
 def FLOW_TensorDynamicConstantOp : FLOW_Op<"tensor.dynamic_constant"> {
-  let summary = [{tensor constant that can have dynamic dimensions}];
+  let summary = [{Tensor constant that can have dynamic dimensions.}];
   let description = [{
     Allows specifying a tensor constant of IREE-specific types/attributes with
     a dynamic shape that approximates a value as passed from the user. This
@@ -889,7 +889,7 @@ def FLOW_TensorTieShapeOp : FLOW_PureOp<"tensor.tie_shape", [
   DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
   Util_ShapeAwareOp,
 ]> {
-  let summary = [{ties a runtime shape to a tensor value}];
+  let summary = [{Ties a runtime shape to a tensor value.}];
   let description = [{
     Metadata op used to tie tensors with their runtime-computed dynamic
     dimensions. This only exists transiently in the IR as a witness to shape
@@ -931,9 +931,17 @@ def FLOW_TensorReshapeOp : FLOW_PureOp<"tensor.reshape", [
   ]>,
   Util_ShapeAwareOp,
 ]> {
-  let summary = [{reshapes a tensor}];
+  let summary = [{Reshapes a tensor without modifying the contents.}];
   let description = [{
-    Reshapes a tensor to a new shape without modifying the contents.
+    Reshapes a tensor |source| to the shape implied by this operations result
+    type interleaved with |result_dims|. For example,
+
+    ```
+    result_dims = {%0, %1}
+    result_type = tensor<1x?x2x?x3>
+    ```
+
+    produces a tensor of shape [1, %0, 2, %1, 3] and the same element type.
   }];
 
   let arguments = (ins
@@ -986,9 +994,19 @@ def FLOW_TensorBitCastOp : FLOW_PureOp<"tensor.bitcast", [
   ]>,
   Util_ShapeAwareOp,
 ]> {
-  let summary = [{bitcasts a tensor}];
+  let summary = [{Bitcasts a tensor without modifying the contents.}];
   let description = [{
-    Bitcasts a tensor to a new type without modifying the contents.
+    Bitcasts a tensor |source| to the shape implied by this operations result
+    type interleaved with |result_dims|, potentially with a different element
+    type. For example,
+
+    ```
+    result_dims = {%0, %1}
+    result_type = tensor<1x?x2x?x3 x!eltype>
+    ```
+
+    produces a tensor of shape [1, %0, 2, %1, 3] and element type `!eltype`.
+    Note that the source and result tensors must serialized to the same size.
   }];
 
   let arguments = (ins
@@ -1038,7 +1056,7 @@ def FLOW_TensorLoadOp : FLOW_PureOp<"tensor.load", [
   AttrSizedOperandSegments,
   Util_ShapeAwareOp,
 ]> {
-  let summary = [{loads a value from a tensor element}];
+  let summary = [{Loads a value from a tensor element.}];
   let description = [{
     Returns the element at the given location from within the tensor.
   }];
@@ -1089,7 +1107,7 @@ def FLOW_TensorStoreOp : FLOW_PureOp<"tensor.store", [
   AttrSizedOperandSegments,
   Util_ShapeAwareOp,
 ]> {
-  let summary = [{stores a value into a tensor element}];
+  let summary = [{Stores a value into a tensor element.}];
   let description = [{
     Returns a tensor with the element at the given index set to the given value.
   }];
@@ -1136,7 +1154,7 @@ def FLOW_TensorAllocaOp : FLOW_Op<"tensor.alloca", [
   Util_ShapeAwareOp,
   MemoryEffects<[MemAlloc]>,
 ]> {
-  let summary = [{an empty tensor allocation with undefined contents}];
+  let summary = [{An empty tensor allocation with undefined contents.}];
   let description = [{
     Returns a new transient tensor allocation with undefined contents.
     Subsequent writes must populate any ranges of the tensor that are later
@@ -1172,7 +1190,7 @@ def FLOW_TensorEmptyOp : FLOW_PureOp<"tensor.empty", [
   DeclareOpInterfaceMethods<Util_HoistableOpInterface>,
   Util_ShapeAwareOp,
 ]> {
-  let summary = [{an empty tensor carrying metadata but no contents}];
+  let summary = [{An empty tensor carrying metadata but no contents.}];
   let description = [{
     Returns a tensor with undefined contents. Subsequent writes must populate
     any ranges of the tensor that are later read.
@@ -1208,7 +1226,7 @@ def FLOW_TensorSplatOp : FLOW_PureOp<"tensor.splat", [
   DeclareOpInterfaceMethods<Util_HoistableOpInterface>,
   Util_ShapeAwareOp,
 ]> {
-  let summary = [{splats a value into a shaped tensor}];
+  let summary = [{Splats a value into a shaped tensor.}];
   let description = [{
     Returns a tensor initialized to the given primitive value.
   }];
@@ -1242,7 +1260,7 @@ def FLOW_TensorCloneOp : FLOW_PureOp<"tensor.clone", [
   DeclareOpInterfaceMethods<Util_HoistableOpInterface>,
   Util_ShapeAwareOp,
 ]> {
-  let summary = [{performs a full tensor clone operation}];
+  let summary = [{Performs a full tensor clone operation.}];
   let description = [{
     Clones the input tensor into an identical output tensor.
   }];
@@ -1288,7 +1306,7 @@ def FLOW_TensorEncodeOp : FLOW_PureOp<"tensor.encode", [
   AttrSizedOperandSegments,
   Util_ShapeAwareOp,
 ]> {
-  let summary = [{performs a full tensor encode operation}];
+  let summary = [{Performs a full tensor encode operation.}];
   let description = [{
     Encode the input tensor into an encoded output tensor.
   }];
@@ -1328,7 +1346,7 @@ def FLOW_TensorBarrierOp : FLOW_PureOp<"tensor.barrier", [
       "getTiedResultOperandIndices",
   ]>,
 ]> {
-  let summary = [{indicates a value that must have a specific affinity}];
+  let summary = [{Indicates a value that must have a specific affinity.}];
   let description = [{
     Prevents fusion and scheduling of a value across an affinity boundary.
     May introduce copy-on-write behavior if the operand value is used as well as
@@ -1378,7 +1396,7 @@ def FLOW_TensorTransferOp : FLOW_PureOp<"tensor.transfer", [
   DeclareOpInterfaceMethods<Util_HoistableOpInterface>,
   Util_ShapeAwareOp,
 ]> {
-  let summary = [{transfers a tensor to a target by copying if needed}];
+  let summary = [{Transfers a tensor to a target by copying if needed.}];
   let description = [{
     Transfers the tensor from whichever context it may be in to the specified
     target context. If the contexts are compatible and can access each others
@@ -1431,10 +1449,7 @@ def FLOW_TensorSliceOp : FLOW_PureOp<"tensor.slice", [
   AttrSizedOperandSegments,
   Util_ShapeAwareOp,
 ]> {
-  let summary = [{slices out a subregion of a tensor}];
-  let description = [{
-    Clones a subregion of a tensor.
-  }];
+  let summary = [{Clones a subregion of a tensor.}];
 
   let arguments = (ins
     FLOW_Tensor:$source,
@@ -1479,7 +1494,7 @@ def FLOW_TensorUpdateOp : FLOW_PureOp<"tensor.update", [
   ]>,
   Util_ShapeAwareOp,
 ]> {
-  let summary = [{updates a tensor with the contents of another tensor}];
+  let summary = [{Updates a tensor with the contents of another tensor.}];
   let description = [{
     Updates the target tensor with the contents of the update tensor at the
     given offset indices.
@@ -1529,7 +1544,7 @@ def FLOW_TensorTraceOp : FLOW_Op<"tensor.trace", [
   AttrSizedOperandSegments,
   DeclareOpInterfaceMethods<Util_ShapeAwareOp>,
 ]> {
-  let summary = [{traces one or more tensor values at runtime}];
+  let summary = [{Traces one or more tensor values at runtime.}];
   let description = [{
     Traces out to a runtime trace sink (console, log file, etc) the given
     tensors. The key is arbitrary and can be used for identifying the set of
@@ -1574,7 +1589,7 @@ let opDocGroup = OpGroupCollectiveCommunicationOps in {
 def FLOW_ChannelDefaultOp : FLOW_PureOp<"channel.default", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
 ]> {
-  let summary = [{returns a default collective communication channel}];
+  let summary = [{Returns a default collective communication channel.}];
   let description = [{
     Returns a channel initialized using the runtime environment.
   }];
@@ -1601,7 +1616,7 @@ def FLOW_ChannelDefaultOp : FLOW_PureOp<"channel.default", [
 def FLOW_ChannelSplitOp : FLOW_Op<"channel.split", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
 ]> {
-  let summary = [{splits a collective communication channel}];
+  let summary = [{Splits a collective communication channel.}];
   let description = [{
     Partitions the group associated with the given channel into disjoint
     subgroups for each unique value of color. Each new subgroup contains all
@@ -1632,7 +1647,7 @@ def FLOW_ChannelSplitOp : FLOW_Op<"channel.split", [
 def FLOW_ChannelRankOp : FLOW_PureOp<"channel.rank", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{returns the rank of the local participant in the group}];
+  let summary = [{Returns the rank of the local participant in the group.}];
   let description = [{
     Returns the rank the channel represents as a participant in a collective
     group in `[0, count)`.
@@ -1654,7 +1669,7 @@ def FLOW_ChannelRankOp : FLOW_PureOp<"channel.rank", [
 def FLOW_ChannelCountOp : FLOW_PureOp<"channel.count", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{returns the total number of participants in the group}];
+  let summary = [{Returns the total number of participants in the group.}];
   let description = [{
     Returns the total participant count in the collective communicator group.
   }];
@@ -1680,8 +1695,8 @@ def FLOW_CollectiveAllGatherOp : FLOW_Op<"collective.all_gather", [
     "getTiedResultOperandIndices",
   ]>,
 ]> {
-  let summary = [{performs all-gather operation}];
-  let description = [{It gathers data from all ranks and concatenates them on the 0-th dimension.}];
+  let summary = [{Performs all-gather operation.}];
+  let description = [{Gathers data from all ranks and concatenates them on the 0-th dimension.}];
 
   let arguments = (ins
     FLOW_CollectiveElementTypeAttr:$element_type,
@@ -1717,8 +1732,8 @@ def FLOW_CollectiveAllReduceOp : FLOW_Op<"collective.all_reduce", [
     "getTiedResultOperandIndices",
   ]>,
 ]> {
-  let summary = [{performs all-reduce operation}];
-  let description = [{The operation reduces data across all the ranks in the channel.}];
+  let summary = [{Performs all-reduce operation.}];
+  let description = [{Reduces data across all the ranks in the channel.}];
 
   let arguments = (ins
     FLOW_CollectiveReductionOpAttr:$reduction_op,
@@ -1756,7 +1771,7 @@ def FLOW_CollectiveAllToAllOp : FLOW_Op<"collective.all_to_all", [
     "getTiedResultOperandIndices",
   ]>,
 ]> {
-  let summary = [{performs all-to-all operation}];
+  let summary = [{Performs all-to-all operation.}];
   let description = [{This operation mutually exchanges data acrosss all of the ranks in the channel.}];
 
   let arguments = (ins
@@ -1793,7 +1808,7 @@ def FLOW_CollectiveReduceScatterOp : FLOW_Op<"collective.reduce_scatter", [
     "getTiedResultOperandIndices",
   ]>,
 ]> {
-  let summary = [{performs reduce and scatter operations}];
+  let summary = [{Performs reduce and scatter operations.}];
   let description = [{The operation reduces data across all the ranks in the channel and
     scatters the result to each rank.}];
 
@@ -1833,7 +1848,7 @@ def FLOW_CollectiveSendRecvOp : FLOW_Op<"collective.send_recv", [
     "getTiedResultOperandIndices",
   ]>,
 ]> {
-  let summary = [{performs a grouped send and receive operation}];
+  let summary = [{Performs a grouped send and receive operation.}];
   let description = [{The operation sends data to the rank specificied by send
     and receives data from the rank specified by recv. If send is -1, this rank
     will not send any data. If recv is -1, this rank will not receive any data

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALAttrs.td
@@ -445,7 +445,7 @@ def HAL_CollectiveElementTypeAttr :
 def HAL_CollectiveAttr :
     AttrDef<HAL_Dialect, "Collective", []> {
   let mnemonic = "collective";
-  let summary = [{collective operation and specification}];
+  let summary = [{Collective operation and specification.}];
   let description = [{
     Specifies the collective operation to perform and any mode bits required.
   }];
@@ -470,7 +470,7 @@ def HAL_CollectiveAttr :
 def HAL_PipelineBindingAttr :
     AttrDef<HAL_Dialect, "PipelineBinding", []> {
   let mnemonic = "pipeline.binding";
-  let summary = [{pipeline binding specification}];
+  let summary = [{Pipeline binding specification.}];
   let description = [{
     Specifies a single binding within a pipeline layout.
   }];
@@ -490,7 +490,7 @@ def HAL_PipelineBindingAttr :
 def HAL_PipelineLayoutAttr :
     AttrDef<HAL_Dialect, "PipelineLayout", []> {
   let mnemonic = "pipeline.layout";
-  let summary = [{executable entry point layout specification}];
+  let summary = [{Executable entry point layout specification.}];
   let description = [{
     Specifies the layout information used for interacting with executable
     functions. This allows host code to correctly map parameters to the
@@ -523,7 +523,7 @@ def HAL_PipelineLayoutAttr :
 def HAL_ExecutableTargetAttr :
     AttrDef<HAL_Dialect, "ExecutableTarget"> {
   let mnemonic = "executable.target";
-  let summary = [{generic executable target specification}];
+  let summary = [{Generic executable target specification.}];
   let description = [{
     Specifies how to compile an executable for a specific target backend.
     A backend is used to translate and serialize the executable into the final
@@ -589,7 +589,7 @@ def HAL_ExecutableTargetAttr :
 
 def HAL_ExecutableObjectAttr : AttrDef<HAL_Dialect, "ExecutableObject"> {
   let mnemonic = "executable.object";
-  let summary = [{object file reference}];
+  let summary = [{Object file reference.}];
   let description = [{
     Defines an object file that can be linked into executables.
     Today this is only supported for external file references with paths the
@@ -652,7 +652,7 @@ def HAL_ExecutableObjectArrayAttr :
 
 def HAL_ExecutableObjectsAttr : AttrDef<HAL_Dialect, "ExecutableObjects"> {
   let mnemonic = "executable.objects";
-  let summary = [{target-specific object file references}];
+  let summary = [{Target-specific object file references.}];
   let description = [{
     A dictionary mapping executable target specifications to a list of objects.
     This is used to allow layers of the stack that support multi-targeting to
@@ -701,7 +701,7 @@ def HAL_DeviceAliasAttr : AttrDef<HAL_Dialect, "DeviceAlias", [
   TypedAttrInterface,
 ]> {
   let mnemonic = "device.alias";
-  let summary = [{device target named alias}];
+  let summary = [{Device target named alias.}];
   let description = [{
     Specifies a device target by named alias whose configuration will be
     expanded based on compiler configuration and flags. Any configuration
@@ -752,7 +752,7 @@ def HAL_DeviceTargetAttr : AttrDef<HAL_Dialect, "DeviceTarget", [
   DeclareAttrInterfaceMethods<HAL_DeviceInitializationAttrInterface>,
 ]> {
   let mnemonic = "device.target";
-  let summary = [{generic device target specification}];
+  let summary = [{Generic device target specification.}];
   let description = [{
     Specifies the properties of a target runtime device.
     Target devices are specified with a canonical identifier matching those used
@@ -828,7 +828,7 @@ def HAL_DeviceOrdinalAttr : AttrDef<HAL_Dialect, "DeviceOrdinal", [
   DeclareAttrInterfaceMethods<HAL_DeviceInitializationAttrInterface>,
 ]> {
   let mnemonic = "device.ordinal";
-  let summary = [{specifies a device by runtime registration ordinal}];
+  let summary = [{Specifies a device by runtime registration ordinal.}];
   let description = [{
     Represents the device registered with the runtime in the order it was
     registered with ordinal 0 being the first registered. Returns null during
@@ -853,7 +853,7 @@ def HAL_DeviceFallbackAttr : AttrDef<HAL_Dialect, "DeviceFallback", [
   DeclareAttrInterfaceMethods<HAL_DeviceInitializationAttrInterface>,
 ]> {
   let mnemonic = "device.fallback";
-  let summary = [{specifies a reference to another device}];
+  let summary = [{Specifies a reference to another device.}];
   let description = [{
     Specifies by symbol a device that has already been initialized.
     Returns null during initialization if the device specified as a fallback is
@@ -878,7 +878,7 @@ def HAL_DeviceSelectAttr : AttrDef<HAL_Dialect, "DeviceSelect", [
   DeclareAttrInterfaceMethods<HAL_DeviceInitializationAttrInterface>,
 ]> {
   let mnemonic = "device.select";
-  let summary = [{selects a device from one or more options}];
+  let summary = [{Selects a device from one or more options.}];
   let description = [{
     Selects a HAL device at runtime by either enumerating and querying for
     target support or matching the given existing device by affinity.
@@ -941,7 +941,7 @@ def HAL_DeviceAffinityAttr : AttrDef<HAL_Dialect, "DeviceAffinity", [
   ]>,
 ]> {
   let mnemonic = "device.affinity";
-  let summary = [{specifies a named device and optional queue affinity}];
+  let summary = [{Specifies a named device and optional queue affinity.}];
   let description = [{
     Specifies that an annotated operation or scope is only allowed to execute on
     a specific device and optionally a set of queues (0-64) provided.
@@ -980,7 +980,7 @@ def HAL_DevicePromiseAttr : AttrDef<HAL_Dialect, "DevicePromise", [
   ]>,
 ]> {
   let mnemonic = "device.promise";
-  let summary = [{promises a named device and optional queue affinity}];
+  let summary = [{Promises a named device and optional queue affinity.}];
   let description = [{
     Specifies that an annotated operation or scope is only allowed to execute on
     a specific device that has not yet been declared and optionally a set of

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -44,7 +44,7 @@ let opDocGroup = OpGroupExperimentalOps in {
 def HAL_ExFileFromMemoryOp : HAL_Op<"ex.file.from_memory", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{creates a file mapped into a byte range of a host buffer}];
+  let summary = [{Creates a file mapped into a byte range of a host buffer.}];
   let description = [{
     Returns a file handle that is backed by the given `buffer` contents.
     Behavior is undefined if the buffer contents change while the accesses are
@@ -103,7 +103,7 @@ def HAL_TensorImportOp : HAL_PureOp<"tensor.import", [
   AttrSizedOperandSegments,
   Util_ShapeAwareOp,
 ]> {
-  let summary = [{imports a tensor from a HAL buffer view}];
+  let summary = [{Imports a tensor from a HAL buffer view.}];
   let description = [{
     Defines an import of an external HAL buffer view into a SSA-form tensor.
     An optional fence can be specified indicating when the buffer view is
@@ -180,7 +180,7 @@ def HAL_TensorImportOp : HAL_PureOp<"tensor.import", [
 def HAL_TensorExportOp : HAL_PureOp<"tensor.export", [
   Util_ShapeAwareOp,
 ]> {
-  let summary = [{exports a tensor to a HAL buffer view}];
+  let summary = [{Exports a tensor to a HAL buffer view.}];
   let description = [{
     Defines an export of an SSA-form tensor to an external HAL buffer view.
 
@@ -245,7 +245,7 @@ def HAL_TensorAliasOp : HAL_PureOp<"tensor.alias", [
   ]>,
   Util_ShapeAwareOp,
 ]> {
-  let summary = [{hints that tensor storage should alias a HAL buffer view}];
+  let summary = [{Hints that tensor storage should alias a HAL buffer view.}];
   let description = [{
     Hints that the backing storage of an entire tensor aliases the given storage
     buffer. There's no guarantee that the storage will alias and instead only
@@ -314,7 +314,7 @@ def HAL_TensorBarrierOp : HAL_Op<"tensor.barrier", [
     "getTiedResultOperandIndices",
   ]>,
 ]> {
-  let summary = [{signals a fence when all tensors are available}];
+  let summary = [{Signals a fence when all tensors are available.}];
   let description = [{
     Defines a barrier that is used to indicate availability of an entire set of
     tensors by signaling a fence. The source tensors are returned for chaining.
@@ -353,7 +353,7 @@ def HAL_DispatchExternOp : HAL_PureOp<"dispatch.extern", [
   ]>,
   Util_ShapeAwareOp,
 ]> {
-  let summary = [{a dispatch of workgroups across a 3-dimensional grid}];
+  let summary = [{A dispatch of workgroups across a 3-dimensional grid.}];
   let description = [{
     Dispatches some number of workgroups across a 3-dimensional grid using a
     function defined externally in one or more referenced objects. Objects are
@@ -511,7 +511,7 @@ def HAL_DeviceMemoizeOp : HAL_Op<"device.memoize", [
   DeclareOpInterfaceMethods<RegionBranchOpInterface>,
   SingleBlockImplicitTerminator<"IREE::HAL::ReturnOp">,
 ]> {
-  let summary = [{memoizes resources for a particular device and queue affinity}];
+  let summary = [{Memoizes resources for a particular device and queue affinity.}];
   let description = [{
     Executes the nested region once per device and affinity mask and memoizes
     the results such that future references return the previously memoized
@@ -574,7 +574,7 @@ def HAL_AllocatorAllocateOp : HAL_Op<"allocator.allocate", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
   DeclareOpInterfaceMethods<Util_SizeAwareOp>,
 ]> {
-  let summary = [{empty buffer allocation operation}];
+  let summary = [{Empty buffer allocation operation.}];
   let description = [{
     Allocates a buffer of the given size from the allocator.
     The size of the buffer returned may be larger than the requested size if the
@@ -607,7 +607,7 @@ def HAL_AllocatorImportOp : HAL_Op<"allocator.import", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
   DeclareOpInterfaceMethods<Util_SizeAwareOp>,
 ]> {
-  let summary = [{allocator-supported host buffer import operation}];
+  let summary = [{Allocator-supported host buffer import operation.}];
   let description = [{
     Tries importing host memory backed by the given byte buffer into a
     device accessible `!hal.buffer`. The returned buffer may be host-only and
@@ -657,7 +657,7 @@ def OpGroupBufferOps : OpDocGroup {
 let opDocGroup = OpGroupBufferOps in {
 
 def HAL_BufferAssertOp : HAL_Op<"buffer.assert"> {
-  let summary = [{buffer compatibility assertion}];
+  let summary = [{Buffer compatibility assertion.}];
   let description = [{
     Asserts that the buffer is compatible with the given allocator and usage.
     Program execution will abort as if `std.assert` had been used.
@@ -695,7 +695,7 @@ def HAL_BufferAssertOp : HAL_Op<"buffer.assert"> {
 }
 
 def HAL_BufferAllocationPreserveOp : HAL_Op<"buffer.allocation.preserve"> {
-  let summary = [{preserves the underlying buffer allocation for the caller}];
+  let summary = [{Preserves the underlying buffer allocation for the caller.}];
   let description = [{
     Preservation is a way to track lifetime of an asynchronously-allocated
     buffer on multiple device timelines. Incrementing the preserve count
@@ -738,7 +738,7 @@ def HAL_BufferAllocationPreserveOp : HAL_Op<"buffer.allocation.preserve"> {
 def HAL_BufferAllocationDiscardOp : HAL_Op<"buffer.allocation.discard", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{discards ownership of the underlying buffer allocation by the caller}];
+  let summary = [{Discards ownership of the underlying buffer allocation by the caller.}];
   let description = [{
     Decrementing the preserve count indicates that the owner is releasing its
     ownership. When the last owner discards their ownership it is safe to
@@ -775,7 +775,7 @@ def HAL_BufferAllocationDiscardOp : HAL_Op<"buffer.allocation.discard", [
 def HAL_BufferAllocationIsTerminalOp : HAL_Op<"buffer.allocation.is_terminal", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{returns true if the underlying buffer allocation has a single owner}];
+  let summary = [{Returns true if the underlying buffer allocation has a single owner.}];
   let description = [{
     This can be used to reuse a buffer that has no other owners.
 
@@ -808,7 +808,7 @@ def HAL_BufferSubspanOp : HAL_PureOp<"buffer.subspan", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
   DeclareOpInterfaceMethods<Util_SizeAwareOp>,
 ]> {
-  let summary = [{buffer subspan operation}];
+  let summary = [{Buffer subspan operation.}];
   let description = [{
     Returns a reference to a subspan of the buffer.
   }];
@@ -833,7 +833,7 @@ def HAL_BufferSubspanOp : HAL_PureOp<"buffer.subspan", [
 def HAL_BufferLengthOp : HAL_PureOp<"buffer.length", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{buffer byte length accessor}];
+  let summary = [{Buffer byte length accessor.}];
   let description = [{
     Returns the allocated size of a buffer in bytes.
     May be less than the underlying buffer allocation if this is a subspan or
@@ -855,7 +855,7 @@ def HAL_BufferLengthOp : HAL_PureOp<"buffer.length", [
 }
 
 def HAL_BufferLoadOp : HAL_PureOp<"buffer.load"> {
-  let summary = [{buffer element load operation}];
+  let summary = [{Buffer element load operation.}];
   let description = [{
     Loads a value from a buffer by mapping it.
   }];
@@ -877,7 +877,7 @@ def HAL_BufferLoadOp : HAL_PureOp<"buffer.load"> {
 }
 
 def HAL_BufferStoreOp : HAL_Op<"buffer.store"> {
-  let summary = [{buffer element store operation}];
+  let summary = [{Buffer element store operation.}];
   let description = [{
     Stores a value into a buffer by mapping it.
   }];
@@ -912,7 +912,7 @@ let opDocGroup = OpGroupBufferViewOps in {
 def HAL_ElementTypeOp : HAL_PureOp<"element_type", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{an iree_hal_element_type_t for the given MLIR type}];
+  let summary = [{An iree_hal_element_type_t for the given MLIR type.}];
   let description = [{
     Maps an MLIR type to a runtime `iree_hal_element_type_t` value for all types
     that are convertable.
@@ -943,7 +943,7 @@ def HAL_ElementTypeOp : HAL_PureOp<"element_type", [
 def HAL_EncodingTypeOp : HAL_PureOp<"encoding_type", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{an iree_hal_encoding_type_t for the given MLIR encoding}];
+  let summary = [{An iree_hal_encoding_type_t for the given MLIR encoding.}];
   let description = [{
     Maps an MLIR encoding to a runtime `iree_hal_encoding_type_t` value for all
     encodings that are convertable.
@@ -974,7 +974,7 @@ def HAL_EncodingTypeOp : HAL_PureOp<"encoding_type", [
 def HAL_BufferViewCreateOp : HAL_PureOp<"buffer_view.create", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{buffer view reference initializer}];
+  let summary = [{Buffer view reference initializer.}];
   let description = [{
     Creates a reference to a buffer with a particular shape and element type.
     The buffer is not copied and both the original and view references must be
@@ -1028,7 +1028,7 @@ def HAL_BufferViewCreateOp : HAL_PureOp<"buffer_view.create", [
 }
 
 def HAL_BufferViewAssertOp : HAL_Op<"buffer_view.assert"> {
-  let summary = [{buffer view contents assertion}];
+  let summary = [{Buffer view contents assertion.}];
   let description = [{
     Asserts that the buffer view contains a data compatible tensor with the
     given encoding. Program execution will abort as if `std.assert` had been
@@ -1060,7 +1060,7 @@ def HAL_BufferViewAssertOp : HAL_Op<"buffer_view.assert"> {
 def HAL_BufferViewBufferOp : HAL_PureOp<"buffer_view.buffer", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{buffer view buffer accessor}];
+  let summary = [{Buffer view buffer accessor.}];
   let description = [{
     Returns the buffer backing this view's contents.
   }];
@@ -1080,7 +1080,7 @@ def HAL_BufferViewBufferOp : HAL_PureOp<"buffer_view.buffer", [
 }
 
 def HAL_BufferViewElementTypeOp : HAL_PureOp<"buffer_view.element_type"> {
-  let summary = [{buffer view element type query}];
+  let summary = [{Buffer view element type query.}];
   let description = [{
     Returns the element type of the buffer view.
   }];
@@ -1100,7 +1100,7 @@ def HAL_BufferViewElementTypeOp : HAL_PureOp<"buffer_view.element_type"> {
 }
 
 def HAL_BufferViewEncodingTypeOp : HAL_PureOp<"buffer_view.encoding_type"> {
-  let summary = [{buffer view encoding type query}];
+  let summary = [{Buffer view encoding type query.}];
   let description = [{
     Returns the encoding type of the buffer view.
   }];
@@ -1123,7 +1123,7 @@ def HAL_BufferViewRankOp : HAL_PureOp<"buffer_view.rank", [
     DeclareOpInterfaceMethods<InferIntRangeInterface,
         ["inferResultRangesFromOptional"]>,
 ]> {
-  let summary = [{buffer view rank query}];
+  let summary = [{Buffer view rank query.}];
   let description = [{
     Returns the rank of the buffer view.
   }];
@@ -1146,7 +1146,7 @@ def HAL_BufferViewDimOp : HAL_PureOp<"buffer_view.dim", [
     DeclareOpInterfaceMethods<InferIntRangeInterface,
         ["inferResultRangesFromOptional"]>,
 ]> {
-  let summary = [{buffer view dimension value query}];
+  let summary = [{Buffer view dimension value query.}];
   let description = [{
     Returns the value of the given dimension.
   }];
@@ -1168,7 +1168,7 @@ def HAL_BufferViewDimOp : HAL_PureOp<"buffer_view.dim", [
 }
 
 def HAL_BufferViewTraceOp : HAL_Op<"buffer_view.trace", []> {
-  let summary = [{trace value(s) operation}];
+  let summary = [{Trace value(s) operation.}];
   let description = [{
     Traces out to a runtime trace sink (console, log file, etc) the given buffer
     views and titles them with the given key. The key is informational only and
@@ -1203,7 +1203,7 @@ let opDocGroup = OpGroupChannelOps in {
 def HAL_ChannelCreateOp : HAL_Op<"channel.create", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{creates a new channel for collective communication}];
+  let summary = [{Creates a new channel for collective communication.}];
   let description = [{
     Returns a new channel with the given rank associated with the given device
     queue. Collective operations using this channel must only be submitted on
@@ -1245,7 +1245,7 @@ def HAL_ChannelCreateOp : HAL_Op<"channel.create", [
 def HAL_ChannelSplitOp : HAL_Op<"channel.split", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{splits a collective communication channel}];
+  let summary = [{Splits a collective communication channel.}];
   let description = [{
     Partitions the group associated with the given channel into disjoint
     subgroups for each unique value of color. Each new subgroup contains all
@@ -1281,7 +1281,7 @@ def HAL_ChannelSplitOp : HAL_Op<"channel.split", [
 def HAL_ChannelRankAndCountOp : HAL_PureOp<"channel.rank_and_count", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{returns the rank of the local participant in the group}];
+  let summary = [{Returns the rank of the local participant in the group.}];
   let description = [{
     Returns the rank the channel represents as a participant in a collective
     group in `[0, count)` and the total participant count.
@@ -1318,7 +1318,7 @@ let opDocGroup = OpGroupCommandBufferOps in {
 def HAL_CommandBufferCreateOp : HAL_Op<"command_buffer.create", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{command buffer allocation operation}];
+  let summary = [{Command buffer allocation operation.}];
   let description = [{
     Returns a command buffer from the device pool ready to begin recording.
   }];
@@ -1346,7 +1346,7 @@ def HAL_CommandBufferCreateOp : HAL_Op<"command_buffer.create", [
 }
 
 def HAL_CommandBufferFinalizeOp : HAL_Op<"command_buffer.finalize"> {
-  let summary = [{finalizes command buffer recording}];
+  let summary = [{Finalizes command buffer recording.}];
   let description = [{
     Ends recording into the command buffer and prepares it for submission.
     No more commands may be recorded into the command buffer.
@@ -1363,7 +1363,7 @@ def HAL_CommandBufferFinalizeOp : HAL_Op<"command_buffer.finalize"> {
 }
 
 def HAL_CommandBufferDeviceOp : HAL_PureOp<"command_buffer.device"> {
-  let summary = [{command buffer device query operation}];
+  let summary = [{Command buffer device query operation.}];
   let description = [{
     Used during conversion to access the device used to create a command buffer.
   }];
@@ -1385,7 +1385,7 @@ def HAL_CommandBufferDeviceOp : HAL_PureOp<"command_buffer.device"> {
 }
 
 def HAL_CommandBufferBeginDebugGroupOp : HAL_Op<"command_buffer.begin_debug_group"> {
-  let summary = [{pushes a command buffer debug group label}];
+  let summary = [{Pushes a command buffer debug group label.}];
   let description = [{
     Pushes a new debug group with the given label.
     All commands between this and a mandatory matching call to
@@ -1406,7 +1406,7 @@ def HAL_CommandBufferBeginDebugGroupOp : HAL_Op<"command_buffer.begin_debug_grou
 }
 
 def HAL_CommandBufferEndDebugGroupOp : HAL_Op<"command_buffer.end_debug_group"> {
-  let summary = [{pops a command buffer debug group label}];
+  let summary = [{Pops a command buffer debug group label.}];
   let description = [{
     Pops a debug group from the stack.
   }];
@@ -1422,7 +1422,7 @@ def HAL_CommandBufferEndDebugGroupOp : HAL_Op<"command_buffer.end_debug_group"> 
 }
 
 def HAL_CommandBufferExecutionBarrierOp : HAL_Op<"command_buffer.execution_barrier"> {
-  let summary = [{command buffer execution barrier recording operation}];
+  let summary = [{Command buffer execution barrier recording operation.}];
   let description = [{
     Defines an execution dependency between all commands recorded before the
     barrier and all commands recorded after the barrier. Only the stages
@@ -1448,7 +1448,7 @@ def HAL_CommandBufferExecutionBarrierOp : HAL_Op<"command_buffer.execution_barri
 // TODO(benvanik): event ops.
 
 def HAL_CommandBufferFillBufferOp : HAL_Op<"command_buffer.fill_buffer"> {
-  let summary = [{command buffer buffer fill recording operation}];
+  let summary = [{Command buffer buffer fill recording operation.}];
   let description = [{
     Fills the target buffer with the given repeating value.
   }];
@@ -1483,7 +1483,7 @@ def HAL_CommandBufferUpdateBufferOp : HAL_Op<"command_buffer.update_buffer", [
   Util_SizeAwareOp,
   DeclareOpInterfaceMethods<Util_SubrangeOperandOpInterface>,
 ]> {
-  let summary = [{command buffer buffer update recording operation}];
+  let summary = [{Command buffer buffer update recording operation.}];
   let description = [{
     Copies a range of a host buffer into a device buffer. The host buffer
     contents will be captured at the time of the call and embedded in the
@@ -1521,7 +1521,7 @@ def HAL_CommandBufferUpdateBufferOp : HAL_Op<"command_buffer.update_buffer", [
 }
 
 def HAL_CommandBufferCopyBufferOp : HAL_Op<"command_buffer.copy_buffer"> {
-  let summary = [{command buffer buffer copy recording operation}];
+  let summary = [{Command buffer buffer copy recording operation.}];
   let description = [{
     Copies a range of one buffer to another.
   }];
@@ -1553,7 +1553,7 @@ def HAL_CommandBufferCopyBufferOp : HAL_Op<"command_buffer.copy_buffer"> {
 def HAL_CommandBufferCollectiveOp : HAL_Op<"command_buffer.collective", [
   AttrSizedOperandSegments,
 ]> {
-  let summary = [{command buffer collective dispatch recording operation}];
+  let summary = [{Command buffer collective dispatch recording operation.}];
   let description = [{
     Dispatches a collective operation defined by op using the given buffers.
   }];
@@ -1591,7 +1591,7 @@ def HAL_CommandBufferCollectiveOp : HAL_Op<"command_buffer.collective", [
 def HAL_CommandBufferDispatchOp : HAL_Op<"command_buffer.dispatch", [
   AttrSizedOperandSegments,
 ]> {
-  let summary = [{command buffer dispatch recording operation}];
+  let summary = [{Command buffer dispatch recording operation.}];
   let description = [{
     Dispatches an execution request.
     The request may execute overlapped with any other transfer operation or
@@ -1658,7 +1658,7 @@ def HAL_CommandBufferDispatchOp : HAL_Op<"command_buffer.dispatch", [
 def HAL_CommandBufferDispatchIndirectOp : HAL_Op<"command_buffer.dispatch.indirect", [
   AttrSizedOperandSegments,
 ]> {
-  let summary = [{command buffer indirect dispatch recording operation}];
+  let summary = [{Command buffer indirect dispatch recording operation.}];
   let description = [{
     Dispatches an execution request with a deferred workgroup count.
     This is the same as iree_hal_command_buffer_dispatch but the workgroup count
@@ -1739,7 +1739,7 @@ let opDocGroup = OpGroupDeviceOps in {
 def HAL_DeviceResolveOp : HAL_PureOp<"device.resolve", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{resolves device handles based on affinity}];
+  let summary = [{Resolves device handles based on affinity.}];
   let description = [{
     Examples:
     ```
@@ -1774,7 +1774,7 @@ def HAL_DeviceResolveOp : HAL_PureOp<"device.resolve", [
 def HAL_DeviceAllocatorOp : HAL_PureOp<"device.allocator", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{device allocator accessor operation}];
+  let summary = [{Device allocator accessor operation.}];
   let description = [{
     Returns the allocator that can be used to allocate buffers compatible with
     the device.
@@ -1804,7 +1804,7 @@ def HAL_DeviceAllocatorOp : HAL_PureOp<"device.allocator", [
 def HAL_ReturnOp : HAL_Op<"return", [
   Terminator,
 ]> {
-  let summary = [{return from a hal.* region}];
+  let summary = [{Return from a hal.* region.}];
   let description = [{
     Returns the given values from the region and back to the host code.
   }];
@@ -1828,7 +1828,7 @@ def HAL_ReturnOp : HAL_Op<"return", [
 }
 
 def HAL_DeviceQueryOp : HAL_PureOp<"device.query"> {
-  let summary = [{returns a runtime configuration parameter from the device}];
+  let summary = [{Returns a runtime configuration parameter from the device.}];
   let description = [{
     Queries a device configuration parameter with the given key.
     Returns a status indicating whether the pair was recognized/available and if
@@ -1901,7 +1901,7 @@ def HAL_DeviceQueueAllocaOp : HAL_Op<"device.queue.alloca", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
   DeclareOpInterfaceMethods<Util_SizeAwareOp>,
 ]> {
-  let summary = [{allocates a queue-ordered transient buffer}];
+  let summary = [{Allocates a queue-ordered transient buffer.}];
   let description = [{
     Returns a queue-ordered transient buffer that will be available for use when
     the signal fence is reached. The allocation will not be made until the
@@ -1950,7 +1950,7 @@ def HAL_DeviceQueueAllocaOp : HAL_Op<"device.queue.alloca", [
 def HAL_DeviceQueueDeallocaOp : HAL_Op<"device.queue.dealloca", [
   HAL_DeviceQueueOp,
 ]> {
-  let summary = [{deallocates a queue-ordered transient buffer}];
+  let summary = [{Deallocates a queue-ordered transient buffer.}];
   let description = [{
     Deallocates a queue-ordered transient buffer.
     The deallocation will not be made until the wait fence has been reached and
@@ -1986,7 +1986,7 @@ def HAL_DeviceQueueDeallocaOp : HAL_Op<"device.queue.dealloca", [
 def HAL_DeviceQueueFillOp : HAL_Op<"device.queue.fill", [
   HAL_DeviceQueueOp,
 ]> {
-  let summary = [{fills a buffer with a repeating pattern}];
+  let summary = [{Fills a buffer with a repeating pattern.}];
   let description = [{
     The target buffer must be visible to the device queue performing the update.
     In most cases the queue affinity should be set to where the target buffer
@@ -2028,7 +2028,7 @@ def HAL_DeviceQueueFillOp : HAL_Op<"device.queue.fill", [
 def HAL_DeviceQueueUpdateOp : HAL_Op<"device.queue.update", [
   HAL_DeviceQueueOp,
 ]> {
-  let summary = [{updates a buffer with the contents of a host buffer}];
+  let summary = [{Updates a buffer with the contents of a host buffer.}];
   let description = [{
     The provided host source buffer will be captured and need not remain live or
     unchanged while the operation is queued. The target buffer must be visible
@@ -2078,7 +2078,7 @@ def HAL_DeviceQueueUpdateOp : HAL_Op<"device.queue.update", [
 def HAL_DeviceQueueCopyOp : HAL_Op<"device.queue.copy", [
   HAL_DeviceQueueOp,
 ]> {
-  let summary = [{copies one device-visible buffer to another}];
+  let summary = [{Copies one device-visible buffer to another.}];
   let description = [{
     The source buffer and target buffer must both be visible to the device
     queue performing the copy. In most cases the queue affinity should be set to
@@ -2124,7 +2124,7 @@ def HAL_DeviceQueueCopyOp : HAL_Op<"device.queue.copy", [
 def HAL_DeviceQueueReadOp : HAL_Op<"device.queue.read", [
   HAL_DeviceQueueOp,
 ]> {
-  let summary = [{reads a segment from a file into a device buffer}];
+  let summary = [{Reads a segment from a file into a device buffer.}];
   let description = [{
     Enqueues a file read operation that streams a segment of the source file
     defined by the source offset and length into the target HAL buffer at the
@@ -2168,7 +2168,7 @@ def HAL_DeviceQueueReadOp : HAL_Op<"device.queue.read", [
 def HAL_DeviceQueueWriteOp : HAL_Op<"device.queue.write", [
   HAL_DeviceQueueOp,
 ]> {
-  let summary = [{writes a segment from a device buffer into a file}];
+  let summary = [{Writes a segment from a device buffer into a file.}];
   let description = [{
     Enqueues a file write operation that streams a segment of the source HAL
     buffer defined by the source offset and length into the target file at the
@@ -2212,7 +2212,7 @@ def HAL_DeviceQueueWriteOp : HAL_Op<"device.queue.write", [
 def HAL_DeviceQueueBarrierOp : HAL_Op<"device.queue.barrier", [
   HAL_DeviceQueueOp,
 ]> {
-  let summary = [{enqueues an execution barrier}];
+  let summary = [{Enqueues an execution barrier.}];
   let description = [{
     Signals the provided fence once the wait fence is reached.
   }];
@@ -2242,7 +2242,7 @@ def HAL_DeviceQueueBarrierOp : HAL_Op<"device.queue.barrier", [
 def HAL_DeviceQueueExecuteOp : HAL_Op<"device.queue.execute", [
   HAL_DeviceQueueOp,
 ]> {
-  let summary = [{enqueues command buffer execution}];
+  let summary = [{Enqueues command buffer execution.}];
   let description = [{
     Executes a command buffer on a device queue.
     No commands will execute until the wait fence has been reached and the
@@ -2276,7 +2276,7 @@ def HAL_DeviceQueueExecuteIndirectOp : HAL_Op<"device.queue.execute.indirect", [
   SameVariadicOperandSize,
   HAL_DeviceQueueOp,
 ]> {
-  let summary = [{enqueues command buffer execution}];
+  let summary = [{Enqueues command buffer execution.}];
   let description = [{
     Executes a command buffer on a device queue with the given binding table.
     No commands will execute until the wait fence has been reached and the
@@ -2329,7 +2329,7 @@ def HAL_DeviceQueueExecuteIndirectOp : HAL_Op<"device.queue.execute.indirect", [
 }
 
 def HAL_DeviceQueueFlushOp : HAL_Op<"device.queue.flush"> {
-  let summary = [{flushes locally-pending submissions to the queue}];
+  let summary = [{Flushes locally-pending submissions to the queue.}];
   let description = [{
     Flushes any locally-pending submissions in the queue.
     When submitting many queue operations this can be used to eagerly flush
@@ -2366,7 +2366,7 @@ let opDocGroup = OpGroupDeviceManagementOps in {
 def HAL_DevicesCountOp : HAL_PureOp<"devices.count", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{returns the number of available devices}];
+  let summary = [{Returns the number of available devices.}];
   let description = [{
     Returns the total number of available devices registered at runtime.
   }];
@@ -2383,7 +2383,7 @@ def HAL_DevicesCountOp : HAL_PureOp<"devices.count", [
 def HAL_DevicesGetOp : HAL_PureOp<"devices.get", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{returns the device with the given index}];
+  let summary = [{Returns the device with the given index.}];
   let description = [{
     Returns the device with the given index in the [0, hal.devices.count) range.
     Devices may be lazily initialized upon first use.
@@ -2420,7 +2420,7 @@ def HAL_ExecutableSourceOp : HAL_Op<"executable.source", [
   Symbol,
   SymbolTable,
 ]> {
-  let summary = [{generic source contents of an executable op}];
+  let summary = [{Generic source contents of an executable op.}];
   let description = [{
     This is an unspecialized source representation of an executable
     module without an assigned target. This is useful for hand-authoring
@@ -2478,7 +2478,7 @@ def HAL_ExecutableSourceEndOp : HAL_Op<"executable.source_end", [
   HasParent<"IREE::HAL::ExecutableSourceOp">,
   Terminator,
 ]> {
-  let summary = [{terminator pseudo-op for the executable source op}];
+  let summary = [{Terminator pseudo-op for the executable source op.}];
   let assemblyFormat = "attr-dict";
 }
 
@@ -2489,7 +2489,7 @@ def HAL_ExecutableOp : HAL_Op<"executable", [
   SymbolTable,
   Util_ObjectLike,
 ]> {
-  let summary = [{target-specific executable module}];
+  let summary = [{Target-specific executable module.}];
   let description = [{
     An executable module representing a target-specific compiled
     kernel/shader/etc.
@@ -2526,7 +2526,7 @@ def HAL_ExecutableEndOp : HAL_Op<"executable_end", [
   HasParent<"IREE::HAL::ExecutableOp">,
   Terminator,
 ]> {
-  let summary = [{terminator pseudo-op for the executable op}];
+  let summary = [{Terminator pseudo-op for the executable op.}];
   let assemblyFormat = "attr-dict";
 }
 
@@ -2538,7 +2538,7 @@ def HAL_ExecutableExportOp : HAL_Op<"executable.export", [
   ]>,
   IsolatedFromAbove,
 ]> {
-  let summary = [{executable entry point declaration}];
+  let summary = [{Executable entry point declaration.}];
   let description = [{
     An entry point exported by the executable with statically-available
     information describing the IO interface it uses and other dispatch metadata.
@@ -2627,7 +2627,7 @@ def HAL_ExecutableVariantOp : HAL_Op<"executable.variant", [
   Symbol,
   SymbolTable,
 ]> {
-  let summary = [{target-specific variant of an executable op}];
+  let summary = [{Target-specific variant of an executable op.}];
   let description = [{
     The target IR for the executable. This can be preserved for debugging but
     is usually removed during transformation.
@@ -2713,7 +2713,7 @@ def HAL_ExecutableVariantEndOp : HAL_Op<"executable.variant_end", [
   HasParent<"IREE::HAL::ExecutableVariantOp">,
   Terminator,
 ]> {
-  let summary = [{terminator pseudo-op for the executable variant op}];
+  let summary = [{Terminator pseudo-op for the executable variant op.}];
   let assemblyFormat = "attr-dict";
 }
 
@@ -2722,7 +2722,7 @@ def HAL_ExecutableConditionOp : HAL_Op<"executable.condition", [
   FunctionOpInterface,
   CallableOpInterface,
 ]> {
-  let summary = [{host code to determine if the executable is enabled}];
+  let summary = [{Host code to determine if the executable is enabled.}];
   let description = [{
     Variants are selected based on their target and this optional condition
     op that returns true if the variant is valid for use on the provided
@@ -2779,7 +2779,7 @@ def HAL_ExecutableConstantBlockOp : HAL_Op<"executable.constant.block", [
   CallableOpInterface,
   FunctionOpInterface,
 ]> {
-  let summary = [{executable constant block initializer}];
+  let summary = [{Executable constant block initializer.}];
   let description = [{
     Initializes one or more constants in the executable constant block by
     returning one value per identified constant. Each constant block is
@@ -2872,7 +2872,7 @@ def HAL_ExecutableConstantBlockOp : HAL_Op<"executable.constant.block", [
 }
 
 def HAL_ExecutableConstantLoadOp : HAL_PureOp<"executable.constant.load"> {
-  let summary = [{loads a constant value from the executable constant block}];
+  let summary = [{Loads a constant value from the executable constant block.}];
   let description = [{
     Loads a scalar constant value from the static executable constant block.
     The value provided by a constant block with the given key will be loaded and
@@ -2899,7 +2899,7 @@ def HAL_ExecutableBinaryOp : HAL_Op<"executable.binary", [
   HasParent<"IREE::HAL::ExecutableOp">,
   Symbol,
 ]> {
-  let summary = [{compiled executable binary data}];
+  let summary = [{Compiled executable binary data.}];
   let description = [{
     A compiled executable binary with an optional nested module containing the
     IR prior to serialization (for debugging).
@@ -2938,7 +2938,7 @@ def HAL_ExecutableBinaryOp : HAL_Op<"executable.binary", [
 def HAL_ExecutableCreateOp : HAL_PureOp<"executable.create", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{creates an executable}];
+  let summary = [{Creates an executable.}];
   let description = [{
     Creates a target-dependent executable cached on the provided device. Entry
     points contained within the executable can be dispatched using the resulting
@@ -2976,7 +2976,7 @@ def HAL_ExecutableCreateOp : HAL_PureOp<"executable.create", [
 def HAL_ExecutableLookupOp : HAL_PureOp<"executable.lookup", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{executable cache lookup pseudo-op}];
+  let summary = [{Executable cache lookup pseudo-op.}];
   let description = [{
     Used during conversion to provide a placeholder for a globally cached and
     possibly lazy-initialized executable.
@@ -3001,7 +3001,7 @@ def HAL_ExecutableLookupOp : HAL_PureOp<"executable.lookup", [
 def HAL_ExecutableExportOrdinalOp : HAL_PureOp<"executable.export.ordinal", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{executable export ordinal lookup pseudo-op}];
+  let summary = [{Executable export ordinal lookup pseudo-op.}];
   let description = [{
     Resolves an executable export ordinal to a value once ordinals have been
     assigned.
@@ -3022,7 +3022,7 @@ def HAL_ExecutableExportOrdinalOp : HAL_PureOp<"executable.export.ordinal", [
 }
 
 def HAL_ExecutableCalculateWorkgroupsOp : HAL_PureOp<"executable.calculate_workgroups"> {
-  let summary = [{calculates workgroup count from workload for an exported function}];
+  let summary = [{Calculates workgroup count from workload for an exported function.}];
   let description = [{
     Calculates the workgroup count (grid XYZ) based on the given workload using
     the workgroup count calculation region of the target
@@ -3063,7 +3063,7 @@ def OpGroupInstrumentOps : OpDocGroup {
 let opDocGroup = OpGroupInstrumentOps in {
 
 def HAL_InstrumentWorkgroupOp : HAL_Op<"instrument.workgroup"> {
-  let summary = [{emits a dispatch workgroup instrumentation event}];
+  let summary = [{Emits a dispatch workgroup instrumentation event.}];
   let description = [{
     Emits an `iree_instrument_dispatch_workgroup_t` event into the
     instrumentation stream. The workgroup event identifies the unique dispatch,
@@ -3097,7 +3097,7 @@ def HAL_InstrumentWorkgroupOp : HAL_Op<"instrument.workgroup"> {
 }
 
 def HAL_InstrumentPrintOp : HAL_Op<"instrument.print"> {
-  let summary = [{emits a human-readable printf-style string event}];
+  let summary = [{Emits a human-readable printf-style string event.}];
   let description = [{
     Formats a string using a limited subset of printf format specifiers and the
     provided values and then emits an `iree_instrument_dispatch_print_t` event. Final
@@ -3123,7 +3123,7 @@ def HAL_InstrumentPrintOp : HAL_Op<"instrument.print"> {
 def HAL_InstrumentValueOp : HAL_Op<"instrument.value", [
   AllTypesMatch<["operand", "result"]>,
 ]> {
-  let summary = [{emits a scalar value instrumentation event}];
+  let summary = [{Emits a scalar value instrumentation event.}];
   let description = [{
     Emits a workgroup-specific typed value with the given workgroup-relative
     ordinal.
@@ -3151,7 +3151,7 @@ def HAL_InstrumentValueOp : HAL_Op<"instrument.value", [
 def HAL_InstrumentMemoryLoadOp : HAL_PureOp<"instrument.memory.load", [
   AllTypesMatch<["loadValue", "result"]>,
 ]> {
-  let summary = [{emits a memory load instrumentation event}];
+  let summary = [{Emits a memory load instrumentation event.}];
   let description = [{
     Emits a workgroup-specific memory load event indicating that a number of
     bytes from the given resolved pointer have been loaded by the workgroup.
@@ -3178,7 +3178,7 @@ def HAL_InstrumentMemoryLoadOp : HAL_PureOp<"instrument.memory.load", [
 def HAL_InstrumentMemoryStoreOp : HAL_PureOp<"instrument.memory.store", [
   AllTypesMatch<["storeValue", "result"]>,
 ]> {
-  let summary = [{emits a memory store instrumentation event}];
+  let summary = [{Emits a memory store instrumentation event.}];
   let description = [{
     Emits a workgroup-specific memory store event indicating that a number of
     bytes have been stored to the given resolved pointer by the workgroup.
@@ -3238,7 +3238,7 @@ class HAL_InterfaceWorkgroupOp<string mnemonic, list<Trait> traits = []>
 }
 
 def HAL_InterfaceWorkgroupIDOp : HAL_InterfaceWorkgroupOp<"interface.workgroup.id"> {
-  let summary = [{returns the index of the current workgroup in the grid}];
+  let summary = [{Returns the index of the current workgroup in the grid.}];
   let description = [{
     The global workgroup ID of the current tile in the range of
     `[0, hal.interface.workgroup.count)` along each XYZ dimension.
@@ -3255,7 +3255,7 @@ def HAL_InterfaceWorkgroupIDOp : HAL_InterfaceWorkgroupOp<"interface.workgroup.i
 }
 
 def HAL_InterfaceWorkgroupCountOp : HAL_InterfaceWorkgroupOp<"interface.workgroup.count"> {
-  let summary = [{returns the total workgroup count of the grid}];
+  let summary = [{Returns the total workgroup count of the grid.}];
   let description = [{
     The total number of workgroups along each dimension in the dispatch grid.
     Matches what was passed to the `hal.command_buffer.dispatch` command (or
@@ -3274,7 +3274,7 @@ def HAL_InterfaceWorkgroupCountOp : HAL_InterfaceWorkgroupOp<"interface.workgrou
 }
 
 def HAL_InterfaceWorkgroupSizeOp : HAL_InterfaceWorkgroupOp<"interface.workgroup.size"> {
-  let summary = [{returns the size of each workgroup in invocations}];
+  let summary = [{Returns the size of each workgroup in invocations.}];
   let description = [{
     The number of local invocations within the current workgroup along each
     dimension. Depending on backend this may map to the SIMT thread count or
@@ -3292,7 +3292,7 @@ def HAL_InterfaceWorkgroupSizeOp : HAL_InterfaceWorkgroupOp<"interface.workgroup
 }
 
 def HAL_InterfaceConstantLoadOp : HAL_PureOp<"interface.constant.load"> {
-  let summary = [{loads a constant value from the interface constant block}];
+  let summary = [{Loads a constant value from the interface constant block.}];
   let description = [{
     Loads a scalar constant value from an executable IO push constant block.
     The value will be loaded from the given constant offset and will be
@@ -3336,7 +3336,7 @@ def HAL_InterfaceBindingSubspanOp : HAL_PureOp<"interface.binding.subspan", [
   DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
   Util_ShapeAwareOp,
 ]> {
-  let summary = [{returns an alias to a subspan of interface binding data}];
+  let summary = [{Returns an alias to a subspan of interface binding data.}];
   let description = [{
     Returns a subspan of an interface binding storage buffer in a generic type.
     The exact shape, type, and alignment of the returned type are defined by
@@ -3420,7 +3420,7 @@ def HAL_FenceCreateOp : HAL_Op<"fence.create", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
   MemoryEffects<[MemAlloc]>,
 ]> {
-  let summary = [{creates an unsignaled fence}];
+  let summary = [{Creates an unsignaled fence.}];
   let description = [{
     Returns a fence that defines a point in time. By default fences will remain
     unsignaled unless they are explicitly signaled with `hal.fence.signal` or
@@ -3449,7 +3449,7 @@ def HAL_FenceCreateOp : HAL_Op<"fence.create", [
 def HAL_FenceJoinOp : HAL_Op<"fence.join", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{creates a fence from the given timepoints}];
+  let summary = [{Creates a fence from the given timepoints.}];
   let description = [{
     Returns a fence that joins the input fences as a wait-all operation.
   }];
@@ -3474,7 +3474,7 @@ def HAL_FenceJoinOp : HAL_Op<"fence.join", [
 }
 
 def HAL_FenceQueryOp : HAL_Op<"fence.query"> {
-  let summary = [{fence query operation}];
+  let summary = [{Fence query operation.}];
   let description = [{
     Queries whether the fence has been reached and its status.
     Returns OK if the fence has been signaled successfully, DEFERRED if it is
@@ -3496,7 +3496,7 @@ def HAL_FenceQueryOp : HAL_Op<"fence.query"> {
 }
 
 def HAL_FenceSignalOp : HAL_Op<"fence.signal"> {
-  let summary = [{fence signal operation}];
+  let summary = [{Fence signal operation.}];
   let description = [{
     Signals the fence to indicate that the timepoints contained have been
     reached. Waiting work may begin immediately.
@@ -3515,7 +3515,7 @@ def HAL_FenceSignalOp : HAL_Op<"fence.signal"> {
 }
 
 def HAL_FenceFailOp : HAL_Op<"fence.fail"> {
-  let summary = [{fence failure operation}];
+  let summary = [{Fence failure operation.}];
   let description = [{
     Signals the fence with a failure. The `status` will be returned from
     each timepoint semaphores `hal.semaphore.query` and `hal.semaphore.signal`
@@ -3538,7 +3538,7 @@ def HAL_FenceAwaitOp : HAL_Op<"fence.await", [
   Util_YieldPoint,
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{asynchronous fence wait operation}];
+  let summary = [{Asynchronous fence wait operation.}];
   let description = [{
     Yields the caller until all fences is reached. Returns the `status` of the
     fence after the wait, with a non-zero value indicating failure.

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -51,7 +51,7 @@ let opDocGroup = OpGroupUtilityOps in {
 def IREELinalgExt_IndexOp : IREELinalgExt_PureOp<"index", [Pure]>,
     Arguments<(ins ConfinedAttr<I64Attr, [IntMinValue<0>]>:$dim)>,
     Results<(outs Index:$result)> {
-  let summary = "linalg_ext index operation";
+  let summary = [{LinalgExt index operation.}];
   let description = [{
     This operation is a mirror of `linalg.index` operation and has the same
     semantics, except that `linalg.index` enforces that the parent op is a
@@ -64,7 +64,7 @@ def IREELinalgExt_IndexOp : IREELinalgExt_PureOp<"index", [Pure]>,
 }
 
 def IREELinalgExt_YieldOp : IREELinalgExt_PureOp<"yield", [Pure, ReturnLike, Terminator]> {
-  let summary = "LinalgExt yield op";
+  let summary = [{LinalgExt yield op.}];
   let description = [{
     `iree_linalg_ext.yield` is a special terminator operation for blocks inside
     regions in `iree_linalg_ext` ops.
@@ -105,7 +105,7 @@ def IREELinalgExt_ScatterOp : IREELinalgExt_Op<"scatter",
          "getTiledImplementation",
          "getIterationDomainTileFromOperandTile",
          "getTiledImplementationFromOperandTile"]>]> {
-  let summary = "Scatter operator";
+  let summary = [{Scatters an input in slices based on a tensor of indices.}];
   let description = [{
     Takes two `inputs` (`update` and `indices`) and `outputs` value (`original`).
     The operation updates the value at the slices specified by `indices` by
@@ -232,7 +232,7 @@ def IREELinalgExt_GatherOp : IREELinalgExt_Op<"gather",
          "getResultTilePosition",
          "getTiledImplementation",
          "generateResultTileValue"]>]> {
-  let summary = "Gather operator";
+  let summary = [{Gathers slices from a source based on a tensor of indices.}];
   let description = [{
     Takes two inputs (`source` and `indices`) and outputs value (`output`).
     The operation returns the value at the slices specified by `indices` by
@@ -331,7 +331,7 @@ def IREELinalgExt_MapScatterOp : IREELinalgExt_PureOp<"map_scatter",
          "getTiledImplementationFromOperandTile",
          "generateScalarImplementation"]>,
      SingleBlockImplicitTerminator<"::mlir::iree_compiler::IREE::LinalgExt::YieldOp">]> {
-  let summary = "Scatter with a mapping from source indices to result indices";
+  let summary = [{Scatter with a mapping from source indices to result indices.}];
   let description = [{
     Takes two operands, `input` and `output`, and stores every element of
     `input` to a unique location in `output`. If the operands are tensors, the
@@ -404,7 +404,7 @@ def IREELinalgExt_SortOp : IREELinalgExt_Op<"sort",
          "getLoopIteratorTypes",
          "getResultTilePosition",
          "getTiledImplementation"]>]> {
-  let summary = "Sort operator";
+  let summary = [{Sorts a tensor a specified dimension.}];
   let description = [{
     Based on XLA operation semantics, sorts the given `operands` at the given
     `dimension` with the given `comparator`.
@@ -455,7 +455,7 @@ def IREELinalgExt_FftOp : IREELinalgExt_Op<"fft", [
        "getLoopIteratorTypes",
        "getResultTilePosition",
        "getTiledImplementation"]>]> {
-  let summary = "Fft operator";
+  let summary = [{Fft operator.}];
   let description = [{
     Apply 1D FFT to innermost dim. This is an iterative FFT, not recurrsive.
     Thus, the bit reversal is assumed applied on the input. The op carries an
@@ -525,7 +525,7 @@ def IREELinalgExt_ScanOp : IREELinalgExt_Op<"scan",
        "getLoopIteratorTypes",
        "getResultTilePosition",
        "getTiledImplementation"]>]> {
-  let summary = "Scan operator";
+  let summary = [{Scan operator.}];
   let description = [{
     Computes the inclusive/exclusive scan along a given dimension.
   }];
@@ -588,7 +588,7 @@ def IREELinalgExt_TopkOp : IREELinalgExt_Op<"topk",[
      "getResultTilePosition",
      "getTiledImplementation"]>
 ]>{
-  let summary = "Top-K operator";
+  let summary = [{Top-K operator.}];
   let description = [{
    A Top-K operation for N-D tensors. Reduces the target dimension from the input
    size N down to K elements based on the supplied binary region.
@@ -674,7 +674,7 @@ def IREELinalgExt_AttentionOp : IREELinalgExt_PureOp<"attention",
        "getResultTilePosition",
        "getTiledImplementation",
        "generateResultTileValue"]>]> {
-  let summary = "Attention operator";
+  let summary = [{Attention operator.}];
   let description = [{
     Computes the scaled dot product attention function:
 
@@ -781,7 +781,7 @@ def IREELinalgExt_OnlineAttentionOp : IREELinalgExt_PureOp<"online_attention",
        "tileToPartialReduction",
        "mergeReductions",
        "getPartialResultTilePosition"]>]> {
-  let summary = "Online Attention operator";
+  let summary = [{Online Attention operator.}];
   let description = [{
     Traditional scaled dot product attention computes:
 
@@ -906,7 +906,7 @@ def IREELinalgExt_Im2colOp : IREELinalgExt_Op<"im2col",
        "getResultTilePosition",
        "getTiledImplementation",
        "generateResultTileValue"]>]> {
-  let summary = "Im2col operation for convolutions";
+  let summary = [{Im2col operation for convolutions.}];
   let description = [{
     Im2col op for convolutions. The operation performs a transformation on the
     input to convert it from a convolution input to an equivalent gemm input.
@@ -1100,7 +1100,7 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack", [
      "generateScalarImplementation"]>,
   DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
 ]>{
-  let summary = "pack operation";
+  let summary = [{LinalgExt pack operation for both tensors and buffers.}];
   let description = [{
     The pack operation converts an `input` into a tiled and packed layout. The
     dimensions to be tiled are obtained from `inner_dims_pos` and the size of the
@@ -1263,7 +1263,7 @@ def IREELinalgExt_UnPackOp : IREELinalgExt_Op<"unpack", [
      "generateScalarImplementation"]>,
   DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
 ]>{
-  let summary = "unpack operation";
+  let summary = [{LinalgExt unpack operation for both tensors and buffers.}];
 
   let description = [{
     The unpack operation converts a tiled and packed input to an unpacked
@@ -1396,7 +1396,7 @@ def IREELinalgExt_WinogradInputTransformOp : IREELinalgExt_Op<"winograd.input_tr
        "getLoopIteratorTypes",
        "getResultTilePosition",
        "getTiledImplementation"]>]> {
-  let summary = "Winograd Input Transform operator";
+  let summary = [{Winograd Input Transform operator.}];
   let description = [{
     This operator is part of the first step in converting a convolution to
     its Winograd equivalent. Given a tile of an input image (I),
@@ -1507,7 +1507,7 @@ def IREELinalgExt_WinogradFilterTransformOp : IREELinalgExt_Op<"winograd.filter_
        "getLoopIteratorTypes",
        "getResultTilePosition",
        "getTiledImplementation"]>]> {
-  let summary = "Winograd Filter Transform operator";
+  let summary = [{Winograd Filter Transform operator.}];
   let description = [{
     This operator is part of the first step in converting a convolution to
     its Winograd equivalent. Given a tile of a convolution filter (F),
@@ -1623,7 +1623,7 @@ def IREELinalgExt_WinogradOutputTransformOp : IREELinalgExt_Op<"winograd.output_
        "getLoopIteratorTypes",
        "getResultTilePosition",
        "getTiledImplementation"]>]> {
-  let summary = "Winograd Output Transform operator";
+  let summary = [{Winograd Output Transform operator.}];
   let description = [{
     This operator is the last transform in converting a convolution to
     its Winograd equivalent. After convolution in the Winograd domain
@@ -1748,7 +1748,7 @@ def IREELinalgExt_CustomOp : IREELinalgExt_Op<"custom_op", [
      "getResultTilePosition",
      "getTiledImplementation"]>
   ]> {
-  let summary = "Custom operation for compiling with IREE";
+  let summary = [{Custom operation for compiling with IREE.}];
   let description = [{
     This operation is meant to allow computation sequences that are fused at
     tile level prescriptively. This is to account for cases where such fusion

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamBase.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamBase.td
@@ -231,7 +231,7 @@ def Stream_CollectiveElementTypeAttr :
 def Stream_CollectiveAttr :
     AttrDef<Stream_Dialect, "Collective", []> {
   let mnemonic = "collective";
-  let summary = [{collective operation and specification}];
+  let summary = [{Collective operation and specification.}];
   let description = [{
     Specifies the collective operation to perform and any mode bits required.
   }];
@@ -260,7 +260,7 @@ def Stream_FavorAttr :
 def Stream_PartitioningConfigAttr :
     AttrDef<Stream_Dialect, "PartitioningConfig"> {
   let mnemonic = "partitioning_config";
-  let summary = [{defines partitioning configuration}];
+  let summary = [{Defines partitioning configuration.}];
   let description = [{
     Configures the partitioning algorithm to use and its configuration.
     Partitioning is useful to adjust when scheduling behavior of targets is
@@ -306,7 +306,7 @@ def Stream_ResourceConfigAttr :
     AttrDef<Stream_Dialect, "ResourceConfig", []> {
   let mnemonic = "resource_config";
 
-  let summary = [{defines resource constraints configuration}];
+  let summary = [{Defines resource constraints configuration.}];
   let description = [{
     Defines resource storage constraints. These allow for packing and layout
     algorithms to ensure they are producing usable results on target devices.
@@ -388,7 +388,7 @@ def Stream_NamedParameterAttr :
       ]>,
     ]> {
   let mnemonic = "parameter.named";
-  let summary = [{named parameter referenced an optional scope and key}];
+  let summary = [{Named parameter referenced an optional scope and key.}];
   let description = [{
     Species an externally-defined parameter that can be referenced by an
     optional scope defining a set of parameters and a key uniquely identifying
@@ -417,7 +417,7 @@ def Stream_Timepoint : TypeDef<Stream_Dialect, "Timepoint", [
 ]> {
   let mnemonic = "timepoint";
 
-  let summary = [{a timepoint indicating execution availability}];
+  let summary = [{A timepoint indicating execution availability.}];
   let description = [{
     Represents a point in the execution timeline that when resolved indicates
     that all of the execution prior to this timepoint has completed and the
@@ -433,7 +433,7 @@ def Stream_Timepoint : TypeDef<Stream_Dialect, "Timepoint", [
 def Stream_TimepointAttr : AttrDef<Stream_Dialect, "Timepoint",
                              [TypedAttrInterface]> {
   let mnemonic = "timepoint";
-  let summary = [{an immediately-resolved timepoint}];
+  let summary = [{An immediately-resolved timepoint.}];
   let description = [{}];
   let parameters = (ins AttributeSelfTypeParameter<"">:$type);
   let valueType = Stream_Timepoint;
@@ -489,7 +489,7 @@ def Stream_Channel : TypeDef<Stream_Dialect, "Channel", [
 ]> {
   let mnemonic = "channel";
 
-  let summary = [{a collective communication channel}];
+  let summary = [{A collective communication channel.}];
   let description = [{
     Represents a single participant in a collective clique. Multiple channels
     may exist within the same program to allow for partial operations or
@@ -519,7 +519,7 @@ def Stream_Resource : TypeDef<Stream_Dialect, "Resource", [
 ]> {
   let mnemonic = "resource";
 
-  let summary = [{a managed resource}];
+  let summary = [{A managed resource.}];
   let description = [{
     Stream external values represent asynchronously-available and sequenced
     values that are owned and managed by external code - such as those passed in
@@ -670,7 +670,7 @@ def Stream_AnyStreamResource : AnyTypeOf<[
 def Stream_File : TypeDef<Stream_Dialect, "File", []> {
   let mnemonic = "file";
 
-  let summary = [{a file handle used for I/O operations}];
+  let summary = [{A file handle used for I/O operations.}];
   let description = [{
     A file handle that can be asynchronously read and written into/from
     stream resources.
@@ -692,7 +692,7 @@ def Stream_File : TypeDef<Stream_Dialect, "File", []> {
 def Stream_Binding : TypeDef<Stream_Dialect, "Binding", []> {
   let mnemonic = "binding";
 
-  let summary = [{a managed resource binding into an executable scope}];
+  let summary = [{A managed resource binding into an executable scope.}];
   let description = [{
     A resource binding available within an executable dispatch function.
     The bindings map 1:1 with the resources bound during dispatch operations.

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamInterfaces.td
@@ -16,7 +16,7 @@ include "iree/compiler/Dialect/Util/IR/UtilBase.td"
 def Stream_AffinityAttr : AttrInterface<"AffinityAttr"> {
   let cppNamespace = "::mlir::iree_compiler::IREE::Stream";
 
-  let summary = [{defines execution context affinity}];
+  let summary = [{Defines execution context affinity.}];
   let description = [{
     WIP; see [#10765](https://github.com/iree-org/iree/issues/10765).
 

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -40,7 +40,7 @@ let opDocGroup = OpGroupContextOps in {
 def Stream_ContextResolveOp : Stream_PureOp<"context.resolve", [
   Stream_AffinityOp,
 ]> {
-  let summary = [{resolves low-level context resources based on type}];
+  let summary = [{Resolves low-level context resources based on type.}];
   let description = [{
     WIP; allows for accessing the implementation details of lower-level dialects
     such as the HAL. This will likely be reworked in the future to either
@@ -91,7 +91,7 @@ def Stream_ResourceAllocOp : Stream_Op<"resource.alloc", [
   AlwaysSpeculatable,
   MemoryEffects<[MemAlloc]>,
 ]> {
-  let summary = [{allocates a persistent resource}];
+  let summary = [{Allocates a persistent resource.}];
   let description = [{
     Allocates a persistent value (one that is long-lived and possibly external
     to the program) with undefined contents. Consumers of the allocated
@@ -151,7 +151,7 @@ def Stream_ResourceAllocaOp : Stream_Op<"resource.alloca", [
   AlwaysSpeculatable,
   MemoryEffects<[MemAlloc]>,
 ]> {
-  let summary = [{allocates a transient value with undefined contents}];
+  let summary = [{Allocates a transient value with undefined contents.}];
   let description = [{
     Allocates a transient value (one that is short-lived and local to the
     current computation) with undefined contents. Consumers of the allocated
@@ -215,7 +215,7 @@ def Stream_ResourceDeallocaOp : Stream_Op<"resource.dealloca", [
   Util_SizeAwareOp,
   MemoryEffects<[MemFree]>,
 ]> {
-  let summary = [{frees a transient value when available}];
+  let summary = [{Frees a transient value when available.}];
   let description = [{
     Deallocates a transient value (one that is short-lived and local to the
     current computation) previously allocated using `stream.resource.alloca`.
@@ -265,7 +265,7 @@ def Stream_ResourceRetainOp : Stream_Op<"resource.retain", [
   Stream_CmdPhaseOp,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{retains ownership of the resource}];
+  let summary = [{Retains ownership of the resource.}];
   let description = [{
     Retains ownership of the resource for the parent code until a corresponding
     `stream.resource.release` is used to release the ownership claim. A
@@ -300,7 +300,7 @@ def Stream_ResourceReleaseOp : Stream_Op<"resource.release", [
   Util_SizeAwareOp,
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{releases an ownership claim on the resource}];
+  let summary = [{Releases an ownership claim on the resource.}];
   let description = [{
     A resource is allowed to be deallocated or reused once the last owner
     releases their ownership. Returns a boolean indicating whether the owner
@@ -331,7 +331,7 @@ def Stream_ResourceIsTerminalOp : Stream_Op<"resource.is_terminal", [
   Util_SizeAwareOp,
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{returns true if the resource has no other claims to ownership}];
+  let summary = [{Returns true if the resource has no other claims to ownership.}];
   let description = [{
     Resources may have multiple conceptual owners and are generally only safe to
     deallocate if the code performing the deallocation is the last owner. This
@@ -361,7 +361,7 @@ def Stream_ResourceIsTerminalOp : Stream_Op<"resource.is_terminal", [
 def Stream_ResourceSizeOp : Stream_PureOp<"resource.size", [
   Util_SizeAwareOp,
 ]> {
-  let summary = [{returns the size of the resource storage in bytes}];
+  let summary = [{Returns the size of the resource storage in bytes.}];
   let description = [{
     Returns a possibly runtime-dynamic byte size of the resource backing
     storage. This may differ from the logical storage size of a value based on
@@ -396,7 +396,7 @@ def Stream_ResourceTryMapOp : Stream_PureOp<"resource.try_map", [
   Util_SizeAwareOp,
   MemoryEffects<[MemAlloc]>,
 ]> {
-  let summary = [{maps read-only memory into a resource}];
+  let summary = [{Maps read-only memory into a resource.}];
   let description = [{
     Synchronously maps a host heap buffer into a stream-accessible resource
     with the requested lifetime. If the given source cannot be mapped the
@@ -438,7 +438,7 @@ def Stream_ResourceTryMapOp : Stream_PureOp<"resource.try_map", [
 def Stream_ResourceLoadOp : Stream_Op<"resource.load", [
   Util_SizeAwareOp,
 ]> {
-  let summary = [{loads a value from a staging resource}];
+  let summary = [{Loads a value from a staging resource.}];
   let description = [{
     Returns the element(s) at the given offset in the staging resource.
     The operation will complete synchronously against the resource though it may
@@ -476,7 +476,7 @@ def Stream_ResourceStoreOp : Stream_Op<"resource.store", [
   Util_SizeAwareOp,
   MemoryEffects<[MemWrite]>,
 ]> {
-  let summary = [{stores a value into a staging resource}];
+  let summary = [{Stores a value into a staging resource.}];
   let description = [{
     The operation will complete synchronously against the resource though it may
     introduce a yield point if the staging resource needs to be acquired.
@@ -513,7 +513,7 @@ def Stream_ResourcePackOp : Stream_PureOp<"resource.pack", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
   Stream_AffinityOp,
 ]> {
-  let summary = [{packs variable-sized slices into a single slab}];
+  let summary = [{Packs variable-sized slices into a single slab.}];
   let description = [{
     Performs a greedy packing of one or more sized slices with specified
     lifetimes and returns their relative offsets in an aliased linear space.
@@ -619,7 +619,7 @@ def Stream_ResourceConstantsOp : Stream_PureOp<"resource.constants", [
   Stream_TimelineOp,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{asynchronously uploads or maps constant values}];
+  let summary = [{Asynchronously uploads or maps constant values.}];
   let description = [{
     Represents an upload of constant resources that may be packed, suballocated,
     and mapped depending on the final lowering target.
@@ -688,7 +688,7 @@ def Stream_ResourceSubviewOp : Stream_PureOp<"resource.subview", [
     "getTiedResultOperandIndices",
   ]>,
 ]> {
-  let summary = [{slices out a subview of a value}];
+  let summary = [{Slices out a subview of a value.}];
   let description = [{
     Aliases a byte subrange of a resource.
   }];
@@ -752,7 +752,7 @@ def Stream_ParameterLoadOp : Stream_PureOp<"parameter.load", [
   Stream_TimelineOp,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{reads one or more resources from a parameter scope}];
+  let summary = [{Reads one or more resources from a parameter scope.}];
   let description = [{
     Asynchronously reads one or more resources from an external parameter
     provider and returns the resulting stream resources. Depending on the
@@ -806,7 +806,7 @@ def Stream_ParameterReadOp : Stream_Op<"parameter.read", [
   Stream_TimelineOp,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{reads a resource from a parameter scope}];
+  let summary = [{Reads a resource from a parameter scope.}];
   let description = [{
     Asynchronously reads a resource from an external parameter provider into the
     provided target resource range.
@@ -858,7 +858,7 @@ def Stream_ParameterWriteOp : Stream_Op<"parameter.write", [
   Stream_TimelineOp,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{writes a resource to a parameter scope}];
+  let summary = [{Writes a resource to a parameter scope.}];
   let description = [{
     Asynchronously writes a resource to an external parameter provider from
     the provided source resource range.
@@ -911,7 +911,7 @@ def Stream_ParameterGatherOp : Stream_Op<"parameter.gather", [
   Stream_TimelineOp,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{gathers multiple resources from a parameter scope}];
+  let summary = [{Gathers multiple resources from a parameter scope.}];
   let description = [{
     Asynchronously gathers one or more resources into a single target stream
     resource. This is equivalent to one `stream.parameter.read` per parameter
@@ -967,7 +967,7 @@ def Stream_ParameterScatterOp : Stream_Op<"parameter.scatter", [
   Stream_TimelineOp,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{scatters multiple resources to a parameter scope}];
+  let summary = [{Scatters multiple resources to a parameter scope.}];
   let description = [{
     Asynchronously scatters one or more resources from a single source resource
     into one or more parameters. This is equivalent to one
@@ -1036,7 +1036,7 @@ def Stream_FileConstantOp : Stream_PureOp<"file.constant", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
   DeclareOpInterfaceMethods<Util_SubrangeOperandOpInterface>,
 ]> {
-  let summary = [{creates a file backed by the provided constant host memory}];
+  let summary = [{Creates a file backed by the provided constant host memory.}];
   let description = [{
     Synchronously wraps a host heap buffer into a stream-accessible file handle.
     Changing the source buffer after definition has undefined behavior.
@@ -1074,7 +1074,7 @@ def Stream_FileReadOp : Stream_Op<"file.read", [
   Stream_TimelineOp,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{reads a segment of a file into a resource}];
+  let summary = [{Reads a segment of a file into a resource.}];
   let description = [{
     Asynchronously reads a segment of a file into a resource.
 
@@ -1129,7 +1129,7 @@ def Stream_FileWriteOp : Stream_Op<"file.write", [
   Stream_TimelineOp,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{writes a segment of a file from a resource}];
+  let summary = [{Writes a segment of a file from a resource.}];
   let description = [{
     Asynchronously writes a segment of a resource into a file.
     The file range must be valid within the file as this operation cannot
@@ -1205,7 +1205,7 @@ def Stream_TensorImportOp : Stream_PureOp<"tensor.import", [
     "getTiedResultOperandIndices",
   ]>,
 ]> {
-  let summary = [{conversion placeholder for other->stream type conversion}];
+  let summary = [{Conversion placeholder for other->stream type conversion.}];
   let description = [{
     Defines a conversion from a higher-level dialect type such as `tensor` that
     is resolved during lowering into the stream dialect. This can be used to
@@ -1267,7 +1267,7 @@ def Stream_TensorExportOp : Stream_PureOp<"tensor.export", [
     "getTiedResultOperandIndices",
   ]>,
 ]> {
-  let summary = [{conversion placeholder for stream->other type conversion}];
+  let summary = [{Conversion placeholder for stream->other type conversion.}];
   let description = [{
     Defines a conversion to a higher-level dialect type such as `tensor` that
     is resolved during lowering into the stream dialect. This can be used to
@@ -1327,7 +1327,7 @@ def Stream_TensorSizeOfOp : Stream_PureOp<"tensor.sizeof", [
   Stream_AffinityOp,
   Stream_TensorPhaseOp,
 ]> {
-  let summary = [{calculates the storage size of a given high-level type}];
+  let summary = [{Calculates the storage size of a given high-level type.}];
   let description = [{
     Target-dependent storage size calculation using a high-level annotated type.
     While within the stream dialect the storage size of a value is left as a
@@ -1365,7 +1365,7 @@ def Stream_TensorEmptyOp : Stream_PureOp<"tensor.empty", [
   Util_SizeAwareOp,
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{defines an empty tensor value}];
+  let summary = [{Defines an empty tensor value.}];
   let description = [{
     Returns a typed resource initialized with no contents. This still carries
     shape metadata and may encode to a non-empty resource such as in cases
@@ -1410,7 +1410,7 @@ def Stream_TensorConstantOp : Stream_PureOp<"tensor.constant", [
   Util_ShapeAwareOp,
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{defines a constant tensor value}];
+  let summary = [{Defines a constant tensor value.}];
   let description = [{
     Returns a typed resource initialized to the given constant value.
   }];
@@ -1455,7 +1455,7 @@ def Stream_TensorSplatOp : Stream_PureOp<"tensor.splat", [
   Util_ShapeAwareOp,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{splats a value into a shaped tensor}];
+  let summary = [{Splats a value into a shaped tensor.}];
   let description = [{
     Returns a typed resource initialized to the given primitive value.
   }];
@@ -1504,7 +1504,7 @@ def Stream_TensorCloneOp : Stream_PureOp<"tensor.clone", [
   Util_ShapeAwareOp,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{clones the contents of a value}];
+  let summary = [{Clones the contents of a value.}];
   let description = [{
     Clones the contents of a value at a snapshot in time. Future changes to the
     cloned value will not effect the result. Acts as a copy-on-write operation.
@@ -1558,7 +1558,7 @@ def Stream_TensorEncodeOp : Stream_PureOp<"tensor.encode", [
   Util_ShapeAwareOp,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{Encodes the contents of a value}];
+  let summary = [{Encodes the contents of a value.}];
   let description = [{
     Elones the contents of a value at a snapshot in time. Future changes to the
     identity encoding will not effect the result. Acts as a copy-on-write
@@ -1612,7 +1612,7 @@ def Stream_TensorSliceOp : Stream_PureOp<"tensor.slice", [
   Util_ShapeAwareOp,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{slices out a cloned subview of a value}];
+  let summary = [{Slices out a cloned subview of a value.}];
   let description = [{
     Slices a subrange of a stream resource based on a tensor encoding. Acts as a
     copy-on-write operation.
@@ -1674,7 +1674,7 @@ def Stream_TensorFillOp : Stream_Op<"tensor.fill", [
     "getTiedResultOperandIndices",
   ]>,
 ]> {
-  let summary = [{fills a subview of a stream resource with a value}];
+  let summary = [{Fills a subview of a stream resource with a value.}];
   let description = [{
     Splats a value into a subview of the given stream resource and returns the
     resource with the update applied.
@@ -1733,7 +1733,7 @@ def Stream_TensorUpdateOp : Stream_Op<"tensor.update", [
     "getTiedResultOperandIndices",
   ]>,
 ]> {
-  let summary = [{updates a slice of a subview of a resource in-place}];
+  let summary = [{Updates a slice of a subview of a resource in-place.}];
   let description = [{
     Copies a value into a resource based on tensor encodings. The returned value
     is the entire updated target value.
@@ -1791,7 +1791,7 @@ def Stream_TensorLoadOp : Stream_PureOp<"tensor.load", [
   Util_ShapeAwareOp,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{loads a value from a tensor element}];
+  let summary = [{Loads a value from a tensor element.}];
   let description = [{
     Returns the element at the given location from within the tensor.
   }];
@@ -1841,7 +1841,7 @@ def Stream_TensorStoreOp : Stream_PureOp<"tensor.store", [
     "getTiedResultOperandIndices",
   ]>,
 ]> {
-  let summary = [{stores a value into a tensor element}];
+  let summary = [{Stores a value into a tensor element.}];
   let description = [{
     Returns a tensor with the element at the given index set to the given value.
   }];
@@ -1886,7 +1886,7 @@ def Stream_TensorTraceOp : Stream_Op<"tensor.trace", [
   DeclareOpInterfaceMethods<Util_ShapeAwareOp>,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{traces one or more tensor values at runtime}];
+  let summary = [{Traces one or more tensor values at runtime.}];
   let description = [{
     Traces out to a runtime trace sink (console, log file, etc) the given
     tensors. The key is arbitrary and can be used for identifying the set of
@@ -1928,7 +1928,7 @@ def Stream_TensorDispatchOp : Stream_Op<"tensor.dispatch", [
     "getTiedOperandsIndexAndLength",
   ]>,
 ]> {
-  let summary = [{dispatches a parallelized grid of work}];
+  let summary = [{Dispatches a parallelized grid of work.}];
   let description = [{
     Calls the specified entry point function once for each element in the
     specified workgroup count. Each workgroup has access to the same operands
@@ -2015,7 +2015,7 @@ def Stream_AsyncAllocaOp : Stream_Op<"async.alloca", [
   AlwaysSpeculatable,
   MemoryEffects<[MemAlloc]>,
 ]> {
-  let summary = [{allocates a transient value with undefined contents}];
+  let summary = [{Allocates a transient value with undefined contents.}];
   let description = [{
     Allocates a transient value (one that is short-lived and local to the
     current computation) with undefined contents. Consumers of the allocated
@@ -2055,7 +2055,7 @@ def Stream_AsyncConstantOp : Stream_PureOp<"async.constant", [
   Util_SizeAwareOp,
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{defines a constant resource}];
+  let summary = [{Defines a constant resource.}];
   let description = [{
     Returns a new resource with the given constant value.
   }];
@@ -2099,7 +2099,7 @@ def Stream_AsyncSplatOp : Stream_Op<"async.splat", [
   ]>,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{splats a value into a resource}];
+  let summary = [{Splats a value into a resource.}];
   let description = [{
     Returns a new resource with the given primitive value splatted out to fill
     the entire contents.
@@ -2141,7 +2141,7 @@ def Stream_AsyncCloneOp : Stream_Op<"async.clone", [
   ]>,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{clones the contents of a value}];
+  let summary = [{Clones the contents of a value.}];
   let description = [{
     Clones the contents of a value at a snapshot in time. Future changes to the
     cloned value will not effect the result. Acts as a copy-on-write operation.
@@ -2186,7 +2186,7 @@ def Stream_AsyncSliceOp : Stream_PureOp<"async.slice", [
   ]>,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{slices out a cloned subview of a value}];
+  let summary = [{Slices out a cloned subview of a value.}];
   let description = [{
     Slices a subrange of a stream resource based on a byte range. Acts as a
     copy-on-write operation.
@@ -2238,7 +2238,7 @@ def Stream_AsyncFillOp : Stream_Op<"async.fill", [
     "getTiedResultOperandIndices",
   ]>,
 ]> {
-  let summary = [{fills a subview of a stream resource with a value}];
+  let summary = [{Fills a subview of a stream resource with a value.}];
   let description = [{
     Splats a value into a subview of the given stream resource and returns the
     resource with the update applied.
@@ -2293,7 +2293,7 @@ def Stream_AsyncUpdateOp : Stream_Op<"async.update", [
     "getTiedResultOperandIndices",
   ]>,
 ]> {
-  let summary = [{updates a slice of a subview of a resource in-place}];
+  let summary = [{Updates a slice of a subview of a resource in-place.}];
   let description = [{
     Copies a value into a resource based on a byte range. The returned value
     is the entire updated target value. Updates can be turned into placement
@@ -2350,7 +2350,7 @@ def Stream_AsyncCopyOp : Stream_Op<"async.copy", [
     "getTiedResultOperandIndices",
   ]>,
 ]> {
-  let summary = [{copies a subview of a stream resource to another}];
+  let summary = [{Copies a subview of a stream resource to another.}];
   let description = [{
     Copies a subview of a resource into a subview of another.
     As with memcpy this does not support overlapping updates into the same
@@ -2413,7 +2413,7 @@ def Stream_AsyncCollectiveOp : Stream_Op<"async.collective", [
     "getTiedResultOperandIndices",
   ]>,
 ]> {
-  let summary = [{performs a collective operation}];
+  let summary = [{Performs a collective operation.}];
   let description = [{
     TODO: document different usage. For now this should be considered a
     prototype and that modeling of collective operations may change in the
@@ -2482,7 +2482,7 @@ def Stream_AsyncBarrierOp : Stream_Op<"async.barrier", [
     "getTiedResultOperandIndices",
   ]>,
 ]> {
-  let summary = [{indicates a value that must have a specific affinity}];
+  let summary = [{Indicates a value that must have a specific affinity.}];
   let description = [{
     Prevents fusion and scheduling of a value across an affinity boundary.
     May introduce copy-on-write behavior if the operand value is used as well as
@@ -2533,7 +2533,7 @@ def Stream_AsyncTransferOp : Stream_Op<"async.transfer", [
   ]>,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{transfers a resource from one location/state to another}];
+  let summary = [{Transfers a resource from one location/state to another.}];
   let description = [{
     Transfers a resource between different states (such as a `staging` lifetime
     to a `local` lifetime) or different affinities. This is roughly equivalent
@@ -2583,7 +2583,7 @@ def Stream_AsyncLoadOp : Stream_PureOp<"async.load", [
   Stream_AsyncPhaseOp,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{loads a value from a resource}];
+  let summary = [{Loads a value from a resource.}];
   let description = [{
     Returns the element at the given location from within the resource.
   }];
@@ -2625,7 +2625,7 @@ def Stream_AsyncStoreOp : Stream_PureOp<"async.store", [
     "getTiedResultOperandIndices",
   ]>,
 ]> {
-  let summary = [{stores a value into a resource}];
+  let summary = [{Stores a value into a resource.}];
   let description = [{
     Returns a resource with the element at the given offset set to the given
     value.
@@ -2676,7 +2676,7 @@ def Stream_AsyncDispatchOp : Stream_Op<"async.dispatch", [
     "getTiedOperandsIndexAndLength",
   ]>,
 ]> {
-  let summary = [{dispatches a parallelized grid of work}];
+  let summary = [{Dispatches a parallelized grid of work.}];
   let description = [{
     Calls the specified entry point function once for each element in the
     specified workgroup count. Each workgroup has access to the same operands
@@ -2772,7 +2772,7 @@ def Stream_AsyncFuncOp : Stream_Op<"async.func", [
   IsolatedFromAbove,
   Stream_AsyncPhaseOp,
 ]> {
-  let summary = [{streamable function declaration}];
+  let summary = [{Streamable function declaration.}];
   let description = [{
     Declares a function that can be called as an asynchronous streaming
     operation via `stream.async.call`. Today only external functions are
@@ -2850,7 +2850,7 @@ def Stream_AsyncCallOp : Stream_Op<"async.call", [
     "getTiedOperandsIndexAndLength",
   ]>,
 ]> {
-  let summary = [{calls a streamable external host function}];
+  let summary = [{Calls a streamable external host function.}];
   let description = [{
     Calls a function taking/returning resource values with stream semantics.
     Asynchronous calls must have no side-effects.
@@ -2959,7 +2959,7 @@ def Stream_AsyncExecuteOp : Stream_Op<"async.execute", [
     "getTiedResultsIndexAndLength",
   ]>,
 ]> {
-  let summary = [{executes a dependency-aware sequence of streamable ops}];
+  let summary = [{Executes a dependency-aware sequence of streamable ops.}];
   let description = [{
     Evaluates the operations within the region by dependency order while obeying
     ties when present. Nested ops execute serially in block order and nested
@@ -3052,7 +3052,7 @@ def Stream_AsyncConcurrentOp : Stream_Op<"async.concurrent", [
   DeclareOpInterfaceMethods<Util_ClosureOpInterface>,
   DeclareOpInterfaceMethods<Util_TiedOpInterface>,
 ]> {
-  let summary = [{executes all ops concurrently}];
+  let summary = [{Executes all ops concurrently.}];
   let description = [{
     Represents a wave of work scheduled concurrently (each op executing at the
     same time). All resource inputs must be captured explicitly. All results are
@@ -3162,7 +3162,7 @@ def Stream_CmdFlushOp : Stream_Op<"cmd.flush", [
   Stream_SubviewEffectOp,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{flushes a subview of a resource}];
+  let summary = [{Flushes a subview of a resource.}];
   let description = [{
     Transfers a resource to an external target. The resource memory is made
     available to the target and can be made visible there using
@@ -3201,7 +3201,7 @@ def Stream_CmdInvalidateOp : Stream_Op<"cmd.invalidate", [
   Stream_SubviewEffectOp,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{invalidates a subview of a resource}];
+  let summary = [{Invalidates a subview of a resource.}];
   let description = [{
     Transfers a resource from an external source into the current target. The
     resource memory is assumed to have been made available at the source via
@@ -3240,7 +3240,7 @@ def Stream_CmdDiscardOp : Stream_Op<"cmd.discard", [
   Stream_SubviewEffectOp,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{discards a subview of a resource}];
+  let summary = [{Discards a subview of a resource.}];
   let description = [{
     Discards a subview of a resource, indicating that after this command the
     specified contents are no longer needed. This can be used to trim memory
@@ -3277,7 +3277,7 @@ def Stream_CmdFillOp : Stream_Op<"cmd.fill", [
   Stream_SubviewEffectOp,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{fills a subview of a stream resource with a value}];
+  let summary = [{Fills a subview of a stream resource with a value.}];
   let description = [{
     Splats a value into a subview of the given stream resource and returns the
     resource with the update applied.
@@ -3316,7 +3316,7 @@ def Stream_CmdCopyOp : Stream_Op<"cmd.copy", [
   Stream_SubviewEffectOp,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{copies a subview of a stream resource to another}];
+  let summary = [{Copies a subview of a stream resource to another.}];
   let description = [{
     Copies a subview of a resource into a subview of another.
     As with memcpy this does not support overlapping updates into the same
@@ -3362,7 +3362,7 @@ def Stream_CmdCollectiveOp : Stream_Op<"cmd.collective", [
   Stream_SubviewEffectOp,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{dispatches a collective operation}];
+  let summary = [{Dispatches a collective operation.}];
   let description = [{
     Dispatches a collective operation specified against the device. If grouped
     with other collectives in a `stream.cmd.concurrent` region the collective
@@ -3415,7 +3415,7 @@ def Stream_CmdDispatchOp : Stream_Op<"cmd.dispatch", [
   Stream_SubviewEffectOp,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{dispatches a parallelized grid of work}];
+  let summary = [{Dispatches a parallelized grid of work.}];
   let description = [{
     Calls the specified entry point function once for each element in the
     specified workgroup count. Each workgroup has access to the same operands
@@ -3477,7 +3477,7 @@ def Stream_CmdFuncOp : Stream_Op<"cmd.func", [
   IsolatedFromAbove,
   Stream_CmdPhaseOp,
 ]> {
-  let summary = [{streamable function declaration}];
+  let summary = [{Streamable function declaration.}];
   let description = [{
     Declares a function that can be called as an asynchronous streaming
     operation via `stream.cmd.call`. Today only external functions are
@@ -3541,7 +3541,7 @@ def Stream_CmdCallOp : Stream_Op<"cmd.call", [
   Stream_SubviewEffectOp,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{calls a streamable external host function}];
+  let summary = [{Calls a streamable external host function.}];
   let description = [{
     Calls a function operating on resource values with stream semantics.
     Asynchronous calls must have no side-effects.
@@ -3633,7 +3633,7 @@ def Stream_CmdExecuteOp : Stream_Op<"cmd.execute", [
   Util_SizeAwareOp,
   DeclareOpInterfaceMethods<Util_ClosureOpInterface>,
 ]> {
-  let summary = [{executes a dependency-aware sequence of streamable ops}];
+  let summary = [{Executes a dependency-aware sequence of streamable ops.}];
   let description = [{
     Evaluates the operations within the region by dependency order while obeying
     ties when present. Nested ops execute serially in block order and nested
@@ -3710,7 +3710,7 @@ def Stream_CmdSerialOp : Stream_Op<"cmd.serial", [
   Stream_CmdPhaseOp,
   Stream_StreamableOp,
 ]> {
-  let summary = [{executes all ops serially (in-order)}];
+  let summary = [{Executes all ops serially (in-order).}];
   let description = [{
     Represents a sequence of work scheduled serially (each op executing one
     after the other).
@@ -3776,7 +3776,7 @@ def Stream_CmdConcurrentOp : Stream_Op<"cmd.concurrent", [
   Stream_CmdPhaseOp,
   Stream_StreamableOp,
 ]> {
-  let summary = [{executes all ops concurrently}];
+  let summary = [{Executes all ops concurrently.}];
   let description = [{
     Represents a wave of work scheduled concurrently (each op executing at the
     same time).
@@ -3843,7 +3843,7 @@ def Stream_TimepointImmediateOp : Stream_PureOp<"timepoint.immediate", [
   ConstantLike,
   Stream_TimelineOp,
 ]> {
-  let summary = [{results an immediately-available timepoint}];
+  let summary = [{Results an immediately-available timepoint.}];
   let description = [{
     Timepoints indicate a point in the execution timeline and this op can be
     used to get a placeholder representing the start of the timeline. Any waits
@@ -3871,7 +3871,7 @@ def Stream_TimepointImmediateOp : Stream_PureOp<"timepoint.immediate", [
 def Stream_TimepointImportOp : Stream_PureOp<"timepoint.import", [
   Stream_AffinityOp,
 ]> {
-  let summary = [{imports a timepoint from an external dialect type}];
+  let summary = [{Imports a timepoint from an external dialect type.}];
   let description = [{
     Defines a conversion from an external dialect type such as `hal.semaphore`
     that is resolved during lowering into the stream dialect. This can be used
@@ -3899,7 +3899,7 @@ def Stream_TimepointImportOp : Stream_PureOp<"timepoint.import", [
 def Stream_TimepointExportOp : Stream_PureOp<"timepoint.export", [
   Stream_AffinityOp,
 ]> {
-  let summary = [{exports a timepoint to an external dialect type}];
+  let summary = [{Exports a timepoint to an external dialect type.}];
   let description = [{
     Defines a conversion to an external dialect type such as `hal.fence`
     that is resolved during lowering into the stream dialect. This can be used
@@ -3930,7 +3930,7 @@ def Stream_TimepointChainExternalOp :
     Stream_Op<"timepoint.chain_external", [
       Stream_AffinityOp,
     ]> {
-  let summary = [{exports a timepoint to an external dialect type}];
+  let summary = [{Exports a timepoint to an external dialect type.}];
   let description = [{
     Defines a conversion to an external dialect type such as `hal.fence`
     that is resolved during lowering into the stream dialect. This can be used
@@ -3958,7 +3958,7 @@ def Stream_TimepointChainExternalOp :
 def Stream_TimepointJoinOp : Stream_PureOp<"timepoint.join", [
   Stream_TimelineOp,
 ]> {
-  let summary = [{joins one or more timepoints into the max of all of them}];
+  let summary = [{Joins one or more timepoints into the max of all of them.}];
   let description = [{
     Returns a timepoint that indicates that all of the input timepoints have
     been reached.
@@ -4001,7 +4001,7 @@ def Stream_TimepointBarrierOp : Stream_PureOp<"timepoint.barrier", [
     "getTiedResultsIndexAndLength",
   ]>,
 ]> {
-  let summary = [{returns a timepoint indicating when a resource is available}];
+  let summary = [{Returns a timepoint indicating when a resource is available.}];
   let description = [{
     After asynchronous execution scheduling resources may exist in different
     states at different points in the execution timeline. This op enables
@@ -4055,7 +4055,7 @@ def Stream_TimepointAwaitOp : Stream_PureOp<"timepoint.await", [
     "getTiedResultOperandIndices",
   ]>,
 ]> {
-  let summary = [{awaits a timepoint before returning a set of resources}];
+  let summary = [{Awaits a timepoint before returning a set of resources.}];
   let description = [{
     After asynchronous execution scheduling resources may exist in different
     states at different points in the execution timeline. This op enables
@@ -4135,7 +4135,7 @@ def Stream_ChannelCreateOp : Stream_PureOp<"channel.create", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
   Stream_AffinityOp,
 ]> {
-  let summary = [{creates a new channel for collective communication}];
+  let summary = [{Creates a new channel for collective communication.}];
   let description = [{
     Returns a new channel with the given rank associated with the specified
     affinity. Collective operations using this channel must only be submitted on
@@ -4173,7 +4173,7 @@ def Stream_ChannelCreateOp : Stream_PureOp<"channel.create", [
 def Stream_ChannelSplitOp : Stream_PureOp<"channel.split", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
 ]> {
-  let summary = [{splits a collective communication channel}];
+  let summary = [{Splits a collective communication channel.}];
   let description = [{
     Partitions the group associated with the given channel into disjoint
     subgroups for each unique value of color. Each new subgroup contains all
@@ -4205,7 +4205,7 @@ def Stream_ChannelSplitOp : Stream_PureOp<"channel.split", [
 def Stream_ChannelRankOp : Stream_PureOp<"channel.rank", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{returns the rank of the local participant in the group}];
+  let summary = [{Returns the rank of the local participant in the group.}];
   let description = [{
     Returns the rank the channel represents as a participant in a collective
     group in `[0, count)`.
@@ -4229,7 +4229,7 @@ def Stream_ChannelRankOp : Stream_PureOp<"channel.rank", [
 def Stream_ChannelCountOp : Stream_PureOp<"channel.count", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{returns the total number of participants in the group}];
+  let summary = [{Returns the total number of participants in the group.}];
   let description = [{
     Returns the total participant count in the collective communicator group.
   }];
@@ -4269,7 +4269,7 @@ def Stream_ExecutableOp : Stream_Op<"executable", [
   SymbolTable,
   Util_ObjectLike,
 ]> {
-  let summary = [{generic executable module}];
+  let summary = [{Generic executable module.}];
   let description = [{
     An executable module containing one or more public functions. The contents
     of the functions are safe to dispatch and can be lowered further to
@@ -4311,7 +4311,7 @@ def Stream_ExecutableEndOp : Stream_Op<"executable.end", [
   HasParent<"IREE::Stream::ExecutableOp">,
   Terminator,
 ]> {
-  let summary = [{terminator pseudo-op for the executable op}];
+  let summary = [{Terminator pseudo-op for the executable op.}];
   let assemblyFormat = "attr-dict";
 }
 
@@ -4320,7 +4320,7 @@ def Stream_ExecutableExportOp : Stream_Op<"executable.export", [
   Symbol,
   IsolatedFromAbove,
 ]> {
-  let summary = [{defines an executable entry point for dispatch operations}];
+  let summary = [{Defines an executable entry point for dispatch operations.}];
   let description = [{
     Specifies an exported function with an externally-visible alias. Multiple
     exports can reference the same internal function.
@@ -4362,7 +4362,7 @@ def Stream_ExecutableExportOp : Stream_Op<"executable.export", [
 def Stream_BindingSubspanOp : Stream_PureOp<"binding.subspan", [
   Util_ShapeAwareOp,
 ]> {
-  let summary = [{returns an alias to a subspan of interface binding data}];
+  let summary = [{Returns an alias to a subspan of interface binding data.}];
   let description = [{
     Returns a subview to a tensor or memref-like type from a binding. The same
     binding may have multiple subviews at different byte offsets.
@@ -4393,7 +4393,7 @@ def Stream_BindingSubspanOp : Stream_PureOp<"binding.subspan", [
 def Stream_DispatchWorkgroupIDOp : Stream_PureOp<"dispatch.workgroup.id", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{returns the index of the current workgroup in the grid}];
+  let summary = [{Returns the index of the current workgroup in the grid.}];
   let description = [{
     The global workgroup ID of the current workgroup in the range of
     `[0, stream.dispatch.workgroup.count)` along each dimension.
@@ -4427,7 +4427,7 @@ def Stream_DispatchWorkgroupIDOp : Stream_PureOp<"dispatch.workgroup.id", [
 def Stream_DispatchWorkgroupCountOp : Stream_PureOp<"dispatch.workgroup.count", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{returns the total workgroup count of the grid}];
+  let summary = [{Returns the total workgroup count of the grid.}];
   let description = [{
     The total number of workgroups along each dimension in the dispatch grid.
 
@@ -4460,7 +4460,7 @@ def Stream_DispatchWorkgroupCountOp : Stream_PureOp<"dispatch.workgroup.count", 
 def Stream_DispatchWorkgroupSizeOp : Stream_PureOp<"dispatch.workgroup.size", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{returns the size of each workgroup in invocations}];
+  let summary = [{Returns the size of each workgroup in invocations.}];
   let description = [{
     The number of local invocations within the current workgroup along each
     dimension. Depending on backend this may map to the SIMT thread count or
@@ -4518,7 +4518,7 @@ def Stream_ReturnOp : Stream_Op<"return", [
   ReturnLike,
   Terminator,
 ]> {
-  let summary = [{returns results from a region}];
+  let summary = [{Returns results from a region.}];
   let description = [{
     The values returned are copied by-value.
   }];
@@ -4550,7 +4550,7 @@ def Stream_YieldOp : Stream_Op<"yield", [
   ]>,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{yields stream values from an execution region}];
+  let summary = [{Yields stream values from an execution region.}];
   let description = [{
     The values returned represent the asynchronous value at the point in time
     the SSA value is defined (or tied).

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
@@ -37,7 +37,7 @@ def IREETensorExt_DispatchTensorLoadOp : IREETensorExt_PureOp<"dispatch.tensor.l
   ]>,
   Util_ShapeAwareOp,
 ]> {
-  let summary = [{loads a tensor from a dispatch input placeholder}];
+  let summary = [{Loads a tensor from a dispatch input placeholder.}];
   let description = [{
     Loads an input tensor or subtensor from an input placeholder. As each
     workgroup executes concurrently all workgroups will receive identical loaded
@@ -155,7 +155,7 @@ def IREETensorExt_DispatchTensorStoreOp : IREETensorExt_Op<"dispatch.tensor.stor
   OffsetSizeAndStrideOpInterface,
   Util_ShapeAwareOp,
 ]> {
-  let summary = [{stores a tensor into a dispatch output placeholder}];
+  let summary = [{Stores a tensor into a dispatch output placeholder.}];
   let description = [{
     Stores a tensor or subtensor into an output tensor placeholder. As each
     workgroup executes concurrently behavior is undefined if more than one
@@ -270,7 +270,7 @@ class IREETensorExt_DispatchWorkgroupCountOp<string mnemonic, list<Trait> traits
 def IREETensorExt_DispatchWorkgroupCountFromDagRootOp :
     IREETensorExt_DispatchWorkgroupCountOp<"dispatch.workgroup_count_from_dag_root"> {
   let summary = [{
-    workgroup count computed based on iteration range of the root of the DAG
+    Workgroup count computed based on iteration range of the root of the DAG
     for ops within the dispatch.
   }];
   let description = [{

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.td
@@ -20,7 +20,7 @@ include "mlir/IR/OpBase.td"
 def Util_IntAssumptionAttr : AttrDef<Util_Dialect, "IntAssumption", []
 > {
   let mnemonic = "int.assumption";
-  let summary = [{specifies assumptions that can be made about an integer's value}];
+  let summary = [{Specifies assumptions that can be made about an integer's value.}];
   let description = [{
     This is typically used to memorialize the result of some integer analysis
     or outside knowledge. All components of the attribute are optional.
@@ -59,7 +59,7 @@ def Util_BytePatternAttr : AttrDef<Util_Dialect, "BytePattern", [
   ]>,
 ]> {
   let mnemonic = "byte_pattern";
-  let summary = [{an attribute containing a filled byte pattern}];
+  let summary = [{An attribute containing a filled byte pattern.}];
   let description = [{
     A dense serializable attribute with the given byte pattern.
   }];
@@ -80,7 +80,7 @@ def Util_BytePatternAttr : AttrDef<Util_Dialect, "BytePattern", [
 
 def Util_ByteRangeAttr : AttrDef<Util_Dialect, "ByteRange", []> {
   let mnemonic = "byte_range";
-  let summary = [{defines a range of bytes}];
+  let summary = [{Defines a range of bytes.}];
   let description = [{
     Specifies a starting offset and total length in bytes.
   }];
@@ -107,7 +107,7 @@ def Util_CompositeAttr : AttrDef<Util_Dialect, "Composite", [
   ]>,
 ]> {
   let mnemonic = "composite";
-  let summary = [{an attribute composed of a sequence of attributes}];
+  let summary = [{An attribute composed of a sequence of attributes.}];
   let description = [{
     Models a concatenated set of serializable attributes that when combined
     form a single sequence of i8 elements. As each value references the uniqued
@@ -149,7 +149,7 @@ def Util_InlineNeverAttr : AttrDef<Util_Dialect, "InlineNever", [
   Util_InliningPolicyAttrInterface,
 ]> {
   let mnemonic = "inline.never";
-  let summary = [{disables inlining on the associated function}];
+  let summary = [{Disables inlining on the associated function.}];
   let description = [{
     Disables inlining of the function the attribute is associated with into
     any call-site.
@@ -167,7 +167,7 @@ def Util_InlineAlwaysAttr : AttrDef<Util_Dialect, "InlineAlways", [
   Util_InliningPolicyAttrInterface,
 ]> {
   let mnemonic = "inline.always";
-  let summary = [{forces inlining on the associated function when possible}];
+  let summary = [{Forces inlining on the associated function when possible.}];
   let description = [{
     Skips any cost-model decisions as to whether a function should be inlined
     into call-sites and allows the inlining to happen. Any policies that prevent
@@ -191,7 +191,7 @@ def Util_NullAttr : AttrDef<Util_Dialect, "Null", [
   TypedAttrInterface,
 ]> {
   let mnemonic = "null";
-  let summary = [{an attribute specifying a null reference}];
+  let summary = [{An attribute specifying a null reference.}];
   let description = [{
     A null reference value.
   }];
@@ -210,7 +210,7 @@ def Util_NullAttr : AttrDef<Util_Dialect, "Null", [
 def Util_PreprocessingPipelineAttr : AttrDef<Util_Dialect,
     "PreprocessingPassPipeline"> {
   let mnemonic = "preprocessing_pipeline";
-  let summary = "[{preprocessing pass-pipeline to run on the function}]";
+  let summary = "[{Preprocessing pass-pipeline to run on the function.}]";
   let description = [{
     Textual description of the preprocessing pass-pipeline to run on the
     function-like object that the attribute is specified on. Note that the
@@ -241,7 +241,7 @@ def Util_UninitializedAttr : AttrDef<Util_Dialect, "Uninitialized", [
   ]>,
 ]> {
   let mnemonic = "uninitialized";
-  let summary = [{an attribute specifying uninitialized storage}];
+  let summary = [{An attribute specifying uninitialized storage.}];
   let description = [{
     The contents of the storage backing this attribute _may_ be uninitialized at
     runtime. This is a hint to implementations that if policy allows memory

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
@@ -49,7 +49,7 @@ let opDocGroup = OpGroupTypeManipulationOps in {
 def Util_NullOp : Util_PureOp<"null", [
   ConstantLike,
 ]> {
-  let summary = [{returns a null type value}];
+  let summary = [{Returns a null type value.}];
   let description = [{
     Defines an SSA value that is lowered into dialects supporting
     null/undefined/optional/etc values.
@@ -75,7 +75,7 @@ def Util_CastOp : Util_PureOp<"cast", [
     "getTiedResultOperandIndices",
   ]>,
 ]> {
-  let summary = [{casts one util type to another ala static_cast/dynamic_cast}];
+  let summary = [{Casts one util type to another ala static_cast/dynamic_cast.}];
   let description = [{
     Performs a type cast between object types known to the util dialect.
   }];
@@ -100,7 +100,7 @@ def Util_CmpEQOp : Util_PureOp<"cmp.eq", [
   AllTypesMatch<["lhs", "rhs"]>,
   Commutative,
 ]> {
-  let summary = [{compares two values for equality}];
+  let summary = [{Compares two values for equality.}];
   let description = [{
     Compares two operands for equality. This is intended for comparing IREE
     reference types (like !util.buffer) that cannot be used with std.cmpi.
@@ -125,7 +125,7 @@ def Util_CmpNEOp : Util_PureOp<"cmp.ne", [
   AllTypesMatch<["lhs", "rhs"]>,
   Commutative,
 ]> {
-  let summary = [{compares two values for inequality}];
+  let summary = [{Compares two values for inequality.}];
   let description = [{
     Compares two operands for inequality. This is intended for comparing IREE
     reference types (like !util.buffer) that cannot be used with std.cmpi.
@@ -162,7 +162,7 @@ let opDocGroup = OpGroupDataTypeConversionOps in {
 def Util_NumericOptionalNarrowOp : Util_PureOp<"numeric.optional_narrow", [
   SameOperandsAndResultType
 ]> {
-  let summary = "memorializes an optional numeric narrowing that is valid";
+  let summary = [{memorializes an optional numeric narrowing that is valid.}];
   let description = [{
     Serves as a placeholder for points in the computation where an optional
     numeric narrowing can be performed without loss of information. Such ops
@@ -247,7 +247,7 @@ def Util_RangeMinOp : Util_PureOp<"range.min", [
   SameOperandsAndResultType,
   SameVariadicOperandSize,
 ]> {
-  let summary = [{returns the min of all values}];
+  let summary = [{Returns the min of all values.}];
   let description = [{
     Computes the min of a variadic list of operands. Though it's possible to
     express this with standard arithmetic this op enables more semantically
@@ -273,7 +273,7 @@ def Util_RangeMaxOp : Util_PureOp<"range.max", [
   SameOperandsAndResultType,
   SameVariadicOperandSize,
 ]> {
-  let summary = [{returns the max of all values}];
+  let summary = [{Returns the max of all values.}];
   let description = [{
     Computes the max of a variadic list of operands. Though it's possible to
     express this with standard arithmetic this op enables more semantically
@@ -299,7 +299,7 @@ def Util_RangeExtentsOp : Util_PureOp<"range.extents", [
   SameOperandsAndResultType,
   SameVariadicOperandSize,
 ]> {
-  let summary = [{returns the min/max of a union of a set of ranges}];
+  let summary = [{Returns the min/max of a union of a set of ranges.}];
   let description = [{
     Computes min(offsets) and max(offsets + lengths). Though it's possible to
     express this with standard arithmetic this op enables more semantically
@@ -340,7 +340,7 @@ def Util_AlignOp : Util_PureOp<"align", [
     DeclareOpInterfaceMethods<InferIntRangeInterface, ["inferResultRanges"]>,
     DeclareOpInterfaceMethods<InferIntDivisibilityOpInterface, ["inferResultRanges"]>
 ]> {
-  let summary = "Aligns up to a power-of-two alignment if required";
+  let summary = [{Aligns up to a power-of-two alignment if required.}];
   let description = [{
      Aligns |value| up to the given power-of-two |alignment| if required.
   }];
@@ -373,7 +373,7 @@ def Util_AlignOp : Util_PureOp<"align", [
 }
 
 def Util_SizeOfOp : Util_PureOp<"sizeof"> {
-  let summary = [{returns the size in bytes of a datatype}];
+  let summary = [{Returns the size in bytes of a datatype.}];
   let description = [{
     Most datatypes have a static size at all layers of the compilation stack.
     However, those that only have a size for certain lowering flows can be
@@ -415,7 +415,7 @@ let opDocGroup = OpGroupValueUtilityOps in {
 def Util_SwitchOp : Util_PureOp<"switch", [
   AllTypesMatch<["default_value", "result"]>,
 ]> {
-  let summary = [{primitive switch operation}];
+  let summary = [{Primitive switch operation.}];
   let description = [{
     Returns the value with the given `index` in `values` or `default_value` if
     the index is out of bounds.
@@ -466,7 +466,7 @@ def Util_AssumeIntOp : Util_PureOp<"assume.int", [
     DeclareOpInterfaceMethods<InferIntDivisibilityOpInterface, ["inferResultRanges"]>,
     AllTypesMatch<["operands", "results"]>
 ]> {
-  let summary = "memorializes assumptions about index/integer values.";
+  let summary = [{Memorializes assumptions about index/integer values.}];
   let description = [{
     This op is used to memorialize the result of some integer analysis or
     outside knowledge across a boundary beyond which such information can
@@ -527,7 +527,7 @@ def Util_AssumeIntOp : Util_PureOp<"assume.int", [
 def Util_OptimizationBarrierOp : Util_Op<"optimization_barrier", [
   SameOperandsAndResultType,
 ]> {
-  let summary = "Prevents compiler optimizations across a value.";
+  let summary = [{Prevents compiler optimizations across a value.}];
   let description = [{
     Wraps any operands in an unoptimizable identity to prevent its results from
     being folded. It will be dropped during the final step in compilation and
@@ -552,7 +552,7 @@ def Util_OptimizationBarrierOp : Util_Op<"optimization_barrier", [
 }
 
 def Util_UnfoldableConstantOp : Util_Op<"unfoldable_constant"> {
-  let summary = "A constant that cannot be folded by the compiler.";
+  let summary = [{A constant that cannot be folded by the compiler.}];
   let description = [{
     Similar to a std.constant, but is declared as having a side effect and has
     no folder. This is really just syntactic sugar as it is canonicalized to a
@@ -574,7 +574,7 @@ def Util_UnreachableOp : Util_Op<"unreachable", [
   ReturnLike,
   Terminator
 ]> {
-  let summary = [{unreachable assertion op}];
+  let summary = [{Unreachable assertion op.}];
   let description = [{
     Signals to the compiler that the parent block should not be reachable.
     This may be converted into a runtime assertion, though ideally they are
@@ -617,7 +617,7 @@ def Util_InitializerOp : Util_Op<"initializer", [
   CallableOpInterface,
   Util_InitializerOpInterface,
 ]> {
-  let summary = [{global initialization function}];
+  let summary = [{Global initialization function.}];
   let description = [{
     A function that is called in definition order upon module initialization.
     Must not load any globals that are defined or initialized after it in the
@@ -682,7 +682,7 @@ def Util_FuncOp : Util_Op<"func", [
   IsolatedFromAbove,
   OpAsmOpInterface,
 ]> {
-  let summary = [{function operation containing a CFG region}];
+  let summary = [{Function operation containing a CFG region.}];
   let description = [{
     An operation declaring a callable function.
 
@@ -757,7 +757,7 @@ def Util_CallOp : Util_Op<"call", [
   Util_TiedOpInterface,
   DeclareOpInterfaceMethods<SymbolUserOpInterface>,
 ]> {
-  let summary = [{function call operation}];
+  let summary = [{Function call operation.}];
   let description = [{
     Represents a direct call to a function that is within the same symbol scope
     as the call. The operands and result types of the call must match the
@@ -845,7 +845,7 @@ def Util_ReturnOp : Util_Op<"return", [
   ReturnLike,
   Terminator,
 ]> {
-  let summary = [{return from a util.initializer}];
+  let summary = [{Return from a util.initializer.}];
   let description = [{
     Returns control from an initializer function.
   }];
@@ -885,7 +885,7 @@ def Util_GlobalOp : Util_Op<"global", [
   Symbol,
   Util_GlobalOpInterface,
 ]> {
-  let summary = [{stateful global variable declaration}];
+  let summary = [{Stateful global variable declaration.}];
   let description = [{
     Declares a global variable that maintains its value across invocations.
     The value is tied to the execution context of the module and different
@@ -940,7 +940,7 @@ def Util_GlobalAddressOp : Util_PureOp<"global.address", [
   SymbolUserOpInterface,
   Util_GlobalAddressOpInterface,
 ]> {
-  let summary = [{returns an address reference to a global}];
+  let summary = [{Returns an address reference to a global.}];
   let description = [{
     Returns the address of a global as a typed reference. Can be used with the
     global load and store indirect ops.
@@ -973,9 +973,11 @@ def Util_GlobalLoadOp : Util_Op<"global.load", [
   SymbolUserOpInterface,
   Util_GlobalLoadOpInterface,
 ]> {
-  let summary = [{loads a value from a global variable}];
+  let summary = [{Loads a value from a global variable.}];
   let description = [{
-    Returns a global variable value.
+    Returns a global variable value. |is_immutable| is a reflection of the
+    mutability of the loaded global to minimize the need to traverse symbol
+    tables.
   }];
 
   let arguments = (ins
@@ -1008,7 +1010,7 @@ def Util_GlobalLoadOp : Util_Op<"global.load", [
 def Util_GlobalLoadIndirectOp : Util_Op<"global.load.indirect", [
   Util_GlobalLoadIndirectOpInterface,
 ]> {
-  let summary = [{loads a value from a global variable}];
+  let summary = [{Loads a value from a global variable.}];
   let description = [{
     Returns a copy of the global variable value.
   }];
@@ -1035,7 +1037,7 @@ def Util_GlobalStoreOp : Util_Op<"global.store", [
   SymbolUserOpInterface,
   Util_GlobalStoreOpInterface,
 ]> {
-  let summary = [{stores a value into a global variable}];
+  let summary = [{Stores a value into a global variable.}];
   let description = [{
     Stores a copy of the value into a global variable.
   }];
@@ -1069,7 +1071,7 @@ def Util_GlobalStoreOp : Util_Op<"global.store", [
 def Util_GlobalStoreIndirectOp : Util_Op<"global.store.indirect", [
   Util_GlobalStoreIndirectOpInterface,
 ]> {
-  let summary = [{stores a value into a global variable}];
+  let summary = [{Stores a value into a global variable.}];
   let description = [{
     Stores a copy of the value into a global variable.
   }];
@@ -1110,7 +1112,7 @@ let opDocGroup = OpGroupListOps in {
 def Util_ListCreateOp : Util_PureOp<"list.create", [
   MemoryEffects<[MemAlloc]>,
 ]> {
-  let summary = [{creates a new empty list}];
+  let summary = [{Creates a new empty list.}];
   let description = [{
     Creates a new empty list with an optional initial capacity.
   }];
@@ -1128,7 +1130,7 @@ def Util_ListCreateOp : Util_PureOp<"list.create", [
 def Util_ListSizeOp : Util_Op<"list.size", [
   MemoryEffects<[MemRead]>,
 ]> {
-  let summary = [{the size of the list in elements}];
+  let summary = [{The size of the list in elements.}];
   let description = [{
     Returns the current size of the list in elements.
   }];
@@ -1146,7 +1148,7 @@ def Util_ListSizeOp : Util_Op<"list.size", [
 def Util_ListResizeOp : Util_Op<"list.resize", [
   MemoryEffects<[MemWrite]>,
 ]> {
-  let summary = [{resizes the list to a new count in elements}];
+  let summary = [{Resizes the list to a new count in elements.}];
   let description = [{
     Resizes the list to contain `new_size` elements. This will either truncate
     the list if the existing size is greater than `new_size` or extend the list
@@ -1164,7 +1166,7 @@ def Util_ListResizeOp : Util_Op<"list.resize", [
 def Util_ListGetOp : Util_Op<"list.get", [
   MemoryEffects<[MemRead]>,
 ]> {
-  let summary = [{element accessor}];
+  let summary = [{Element accessor.}];
   let description = [{
     Returns the value of the element at the given index. Note that the value
     may be null if the element is null or the type does not match.
@@ -1186,7 +1188,7 @@ def Util_ListGetOp : Util_Op<"list.get", [
 def Util_ListSetOp : Util_Op<"list.set", [
   MemoryEffects<[MemWrite]>,
 ]> {
-  let summary = [{element mutator}];
+  let summary = [{Element mutator.}];
   let description = [{
     Sets the element at the given index to the new value.
   }];
@@ -1218,7 +1220,7 @@ let opDocGroup = OpGroupBufferOps in {
 def Util_BufferConstantOp : Util_PureOp<"buffer.constant", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{constant host-side byte buffer}];
+  let summary = [{Constant host-side byte buffer.}];
   let description = [{
     Defines a compile-time byte buffer based on the given attribute value.
     The attribute will be serialized into the canonical IREE format for the
@@ -1247,7 +1249,7 @@ def Util_BufferAllocOp : Util_PureOp<"buffer.alloc", [
   MemoryEffects<[MemAlloc]>,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{allocates a buffer with undefined contents}];
+  let summary = [{Allocates a buffer with undefined contents.}];
   let description = [{
     Allocates a buffer with undefined contents. Consumers of the allocated
     result must assume nothing of the contents.
@@ -1281,7 +1283,7 @@ def Util_BufferDeallocOp : Util_PureOp<"buffer.dealloc", [
   MemoryEffects<[MemFree]>,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{deallocates a buffer}];
+  let summary = [{Deallocates a buffer.}];
   let description = [{
     Hints that the buffer contents can be discarded. Buffers are reference
     counted and other owners may keep it live beyond the dealloc.
@@ -1310,7 +1312,7 @@ def Util_BufferSliceOp : Util_PureOp<"buffer.slice", [
   Util_SizeAwareOp,
   DeclareOpInterfaceMethods<Util_SubrangeOperandOpInterface>,
 ]> {
-  let summary = [{clones a subregion of a buffer}];
+  let summary = [{Clones a subregion of a buffer.}];
   let description = [{
     Returns a copy of the contents from the source buffer.
   }];
@@ -1351,7 +1353,7 @@ def Util_BufferSubspanOp : Util_PureOp<"buffer.subspan", [
     "getTiedResultOperandIndices",
   ]>,
 ]> {
-  let summary = [{returns a reference to a subrange of a buffer}];
+  let summary = [{Returns a reference to a subrange of a buffer.}];
   let description = [{
     Returns a logical view into an underlying source buffer. This induces
     aliasing and multiple SSA values may allow access to the same underlying
@@ -1401,7 +1403,7 @@ def Util_BufferSizeOp : Util_PureOp<"buffer.size", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{returns the total buffer storage size in bytes}];
+  let summary = [{Returns the total buffer storage size in bytes.}];
   let description = [{
     Returns the total length of the buffer in bytes from its base offset.
   }];
@@ -1432,7 +1434,7 @@ def Util_BufferStorageOp : Util_PureOp<"buffer.storage", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{returns the underlying buffer storage range}];
+  let summary = [{Returns the underlying buffer storage range.}];
   let description = [{
     Returns the buffer storage as a memref that must be offset and restricted to
     the returned range. The memref may be of any type and the user is
@@ -1468,7 +1470,7 @@ def Util_BufferCopyOp : Util_Op<"buffer.copy", [
   Util_SizeAwareOp,
   DeclareOpInterfaceMethods<Util_SubrangeOperandOpInterface>,
 ]> {
-  let summary = [{copies a range of bytes between buffers}];
+  let summary = [{Copies a range of bytes between buffers.}];
   let description = [{
     Copies a range of bytes as with memcpy (no overlapping).
   }];
@@ -1503,7 +1505,7 @@ def Util_BufferCompareOp : Util_PureOp<"buffer.compare", [
   Util_SizeAwareOp,
   DeclareOpInterfaceMethods<Util_SubrangeOperandOpInterface>,
 ]> {
-  let summary = [{compares a range of two buffers}];
+  let summary = [{Compares a range of two buffers.}];
   let description = [{
     Returns true if the two ranges are bitwise equivalent, somewhat like memcmp.
   }];
@@ -1541,7 +1543,7 @@ def Util_BufferFillOp : Util_Op<"buffer.fill", [
   Util_SizeAwareOp,
   DeclareOpInterfaceMethods<Util_SubrangeOperandOpInterface>,
 ]> {
-  let summary = [{fills a range of bytes with a value}];
+  let summary = [{Fills a range of bytes with a value.}];
   let description = [{
     Fills the contents of the buffer in the given byte range with a pattern.
     The offset and length must match the natural alignment of the pattern type.
@@ -1574,7 +1576,7 @@ def Util_BufferLoadOp : Util_Op<"buffer.load", [
   Util_SizeAwareOp,
   DeclareOpInterfaceMethods<Util_SubrangeOperandOpInterface>,
 ]> {
-  let summary = [{loads a value from a buffer}];
+  let summary = [{Loads a value from a buffer.}];
   let description = [{
     Loads a value at a byte offset. Must be aligned to the natural size of the
     result type.
@@ -1609,7 +1611,7 @@ def Util_BufferStoreOp : Util_Op<"buffer.store", [
   Util_SizeAwareOp,
   DeclareOpInterfaceMethods<Util_SubrangeOperandOpInterface>,
 ]> {
-  let summary = [{stores a value into a buffer}];
+  let summary = [{Stores a value into a buffer.}];
   let description = [{
     Stores a value at a byte offset. Must be aligned to the natural size of the
     source type.
@@ -1641,7 +1643,7 @@ def Util_BufferHashOp : Util_Op<"buffer.hash", [
   Util_SizeAwareOp,
   DeclareOpInterfaceMethods<Util_SubrangeOperandOpInterface>,
 ]> {
-  let summary = [{computes the hash of a byte range of a buffer}];
+  let summary = [{Computes the hash of a byte range of a buffer.}];
   let description = [{
     Computes the SipHash-2-4 of a value at a byte offset with the given length.
     This always uses a seed of `0x0001020304...0e0f` and produces a single 64
@@ -1684,7 +1686,7 @@ def OpGroupStatusOps : OpDocGroup {
 let opDocGroup = OpGroupStatusOps in {
 
 def Util_StatusCheckOkOp : Util_Op<"status.check_ok"> {
-  let summary = [{raises a global failure if a status is not 'ok'}];
+  let summary = [{Raises a global failure if a status is not 'ok'.}];
   let description = [{
     When the status is not 'ok' this signals a runtime failure that causes the
     entire active invocation - and possibly *all* in-flight and pending

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.td
@@ -29,7 +29,7 @@ def Util_BufferType : TypeDef<Util_Dialect, "Buffer", [
 ]> {
   let mnemonic = "buffer";
 
-  let summary = [{A reference counted byte buffer..}];
+  let summary = [{A reference counted byte buffer.}];
   let description = [{
     A reference counted byte buffer that models a pointer, offset, and length.
   }];

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.td
@@ -29,7 +29,7 @@ def Util_BufferType : TypeDef<Util_Dialect, "Buffer", [
 ]> {
   let mnemonic = "buffer";
 
-  let summary = [{a reference counted byte buffer}];
+  let summary = [{A reference counted byte buffer..}];
   let description = [{
     A reference counted byte buffer that models a pointer, offset, and length.
   }];
@@ -48,7 +48,7 @@ def Util_BufferType : TypeDef<Util_Dialect, "Buffer", [
 def Util_ListType : TypeDef<Util_Dialect, "List"> {
   let mnemonic = "list";
 
-  let summary = [{dense list container type}];
+  let summary = [{Dense list container type.}];
   let description = [{
     Typed container supporting variant storage.
   }];
@@ -99,7 +99,7 @@ class Util_ListOf<Type type> :
 def Util_PtrType : TypeDef<Util_Dialect, "Ptr"> {
   let mnemonic = "ptr";
 
-  let summary = [{a pointer-like reference}];
+  let summary = [{A pointer-like reference.}];
   let description = [{
     A typed indirect reference to a value. These define a runtime addressable
     value that is strongly referenced.
@@ -165,7 +165,7 @@ class Util_GlobalPtrOf<list<Type> types> : TypeAlias<Util_AnyPtrType> {
 def Util_ObjectType : TypeDef<Util_Dialect, "Object"> {
   let mnemonic = "object";
 
-  let summary = [{a placeholder for an unspecified object type}];
+  let summary = [{A placeholder for an unspecified object type.}];
   let description = [{
     Describes a runtime object type. These may be reference counted or garbage
     collected at runtime.
@@ -190,7 +190,7 @@ def Util_ObjectType : TypeDef<Util_Dialect, "Object"> {
 def Util_UnusedType : TypeDef<Util_Dialect, "Unused"> {
   let mnemonic = "unused";
 
-  let summary = [{a placeholder for unused types}];
+  let summary = [{A placeholder for unused types.}];
   let description = [{
     An unused type placeholder used to satisfy verifiers that may require a
     type even if unused.
@@ -210,7 +210,7 @@ def Util_UnusedType : TypeDef<Util_Dialect, "Unused"> {
 def Util_VariantType : TypeDef<Util_Dialect, "Variant"> {
   let mnemonic = "variant";
 
-  let summary = [{a placeholder for a variant type (`?`)}];
+  let summary = [{A placeholder for a variant type (`?`).}];
   let description = [{
     Describes a runtime variant type. These may be primitives (i32, f32, etc) or
     object types.

--- a/compiler/src/iree/compiler/Dialect/Util/TransformOps/UtilTransformOps.td
+++ b/compiler/src/iree/compiler/Dialect/Util/TransformOps/UtilTransformOps.td
@@ -21,7 +21,7 @@ def CreateSerializedModuleOp : Op<Transform_Dialect, "util.create_serialized_mod
      ReportTrackingListenerFailuresOpTrait,
     ] # GraphRegionNoTerminator.traits> {
   let cppNamespace = "mlir::iree_compiler::IREE::Util::transform_dialect";
-  let summary = "Creates a serialized module op using the transform region";
+  let summary = [{Creates a serialized module op using the transform region.}];
   let description = [{
     This op creates an owning op reference to a module op and executes the
     transforms contained within this operations body on it. Then the serialized
@@ -151,8 +151,9 @@ def CastAndCallOp : Op<Transform_Dialect, "util.cast_and_call", [
 ] # GraphRegionNoTerminator.traits> {
   let cppNamespace = "mlir::iree_compiler::IREE::Util::transform_dialect";
 
-  let summary = "Casts values to the signature of a function and replaces them "
-                "with a call";
+  let summary = [{
+    Casts values to the signature of a function and replaces them with a call.
+  }];
   let description = [{
     This transform takes value handles to a set of `inputs` and `outputs` and
     attempts to cast them to the function signature of the attached function

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -49,7 +49,7 @@ def VM_ModuleOp : VM_Op<"module", [
     Symbol,
     SymbolTable,
   ]> {
-  let summary = [{module containing VM functions and variables}];
+  let summary = [{Module containing VM functions and variables.}];
   let description = [{
     Top-level container for VM functions.
   }];
@@ -98,7 +98,7 @@ def VM_ModuleTerminatorOp : VM_Op<"module_terminator", [
     HasParent<"IREE::VM::ModuleOp">,
     Terminator,
   ]> {
-  let summary = [{terminator pseudo-op for the module op}];
+  let summary = [{Terminator pseudo-op for the module op.}];
 
   let assemblyFormat = "attr-dict";
 }
@@ -112,7 +112,7 @@ def VM_FuncOp : VM_Op<"func", [
     CallableOpInterface,
     Symbol,
   ]> {
-  let summary = [{function defined with VM control flow ops}];
+  let summary = [{Function defined with VM control flow ops.}];
   let description = [{
     Represents a function containing VM ops and those of compatible dialects.
     All flow control is performed by VM ops.
@@ -185,7 +185,7 @@ def VM_ExportOp : VM_Op<"export", [
     // HasParent<"IREE::VM::ModuleOp">,
     DeclareOpInterfaceMethods<SymbolUserOpInterface>,
   ]> {
-  let summary = [{exports a function from the module}];
+  let summary = [{Exports a function from the module.}];
   let description = [{
     Specifies an exported function with an externally-visible alias. Multiple
     exports can reference the same internal functions.
@@ -213,7 +213,7 @@ def VM_ImportOp : VM_Op<"import", [
     FunctionOpInterface,
     CallableOpInterface,
   ]> {
-  let summary = [{imports a function from an external module}];
+  let summary = [{Imports a function from an external module.}];
   let description = [{
     Specifies a function that should be imported from either the runtime or
     an external VM module.
@@ -303,7 +303,7 @@ def VM_InitializerOp : VM_Op<"initializer", [
     CallableOpInterface,
     Util_InitializerOpInterface,
   ]> {
-  let summary = [{global initialization function}];
+  let summary = [{Global initialization function.}];
   let description = [{
     A function that is called in definition order upon module initialization.
     Must not load any globals that are defined or initialized after it in the
@@ -435,7 +435,7 @@ class VM_PrimitiveGlobalOp<string mnemonic, Attr attr_type, list<Trait> traits =
 
 def VM_GlobalI32Op : VM_PrimitiveGlobalOp<"global.i32",
                                           VM_ConstantIntegerValueAttr<I32>> {
-  let summary = [{32-bit integer global declaration}];
+  let summary = [{32-bit integer global declaration.}];
   let description = [{
     Defines a global value that is treated as a scalar literal at runtime.
     Initialized to zero unless an initial value is specified.
@@ -446,7 +446,7 @@ def VM_GlobalI32Op : VM_PrimitiveGlobalOp<"global.i32",
 
 def VM_GlobalI64Op : VM_PrimitiveGlobalOp<"global.i64",
                                           VM_ConstantIntegerValueAttr<I64>> {
-  let summary = [{64-bit integer global declaration}];
+  let summary = [{64-bit integer global declaration.}];
   let description = [{
     Defines a global value that is treated as a scalar literal at runtime.
     Initialized to zero unless an initial value is specified.
@@ -458,7 +458,7 @@ def VM_GlobalI64Op : VM_PrimitiveGlobalOp<"global.i64",
 def VM_GlobalF32Op : VM_PrimitiveGlobalOp<"global.f32",
                                           VM_ConstantFloatValueAttr<F32>,
                                           [VM_ExtF32]> {
-  let summary = [{32-bit floating-point global declaration}];
+  let summary = [{32-bit floating-point global declaration.}];
   let description = [{
     Defines a global value that is treated as a scalar literal at runtime.
     Initialized to zero unless an initial value is specified.
@@ -470,7 +470,7 @@ def VM_GlobalF32Op : VM_PrimitiveGlobalOp<"global.f32",
 def VM_GlobalF64Op : VM_PrimitiveGlobalOp<"global.f64",
                                           VM_ConstantFloatValueAttr<F64>,
                                           [VM_ExtF64]> {
-  let summary = [{64-bit floating-point global declaration}];
+  let summary = [{64-bit floating-point global declaration.}];
   let description = [{
     Defines a global value that is treated as a scalar literal at runtime.
     Initialized to zero unless an initial value is specified.
@@ -486,7 +486,7 @@ def VM_GlobalRefOp :
       Symbol,
       DeclareOpInterfaceMethods<Util_GlobalOpInterface>,
     ]> {
-  let summary = [{ref<T> global declaration}];
+  let summary = [{ref<T> global declaration.}];
   let description = [{
     Defines a global value that is a ref of a specific type. The global will
     retain the ref object for the lifetime of the context or until the value is
@@ -540,7 +540,7 @@ def VM_GlobalAddressOp : VM_PureOp<"global.address", [
       SymbolUserOpInterface,
       Util_GlobalAddressOpInterface,
     ]> {
-  let summary = [{returns an address reference to a global}];
+  let summary = [{Returns an address reference to a global.}];
   let description = [{
     Returns an indirect address reference to the given global. During export the
     address will be converted to the natural format of the global table (for
@@ -715,7 +715,7 @@ def VM_GlobalLoadI32Op :
     VM_GlobalLoadPrimitiveOp<I32, "global.load.i32", VM_OPC_GlobalLoadI32, [
       DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{global 32-bit integer load operation}];
+  let summary = [{Global 32-bit integer load operation.}];
   let hasCanonicalizer = 1;
 }
 
@@ -723,7 +723,7 @@ def VM_GlobalLoadI64Op :
     VM_GlobalLoadPrimitiveOp<I64, "global.load.i64", VM_OPC_GlobalLoadI64, [
       DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{global 64-bit integer load operation}];
+  let summary = [{Global 64-bit integer load operation.}];
   let hasCanonicalizer = 1;
 }
 
@@ -732,7 +732,7 @@ def VM_GlobalLoadF32Op :
       VM_ExtF32,
       DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{global 32-bit floating-point load operation}];
+  let summary = [{Global 32-bit floating-point load operation.}];
   let hasCanonicalizer = 1;
 }
 
@@ -741,43 +741,43 @@ def VM_GlobalLoadF64Op :
       VM_ExtF64,
       DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{global 64-bit floating-point load operation}];
+  let summary = [{Global 64-bit floating-point load operation.}];
   let hasCanonicalizer = 1;
 }
 
 def VM_GlobalStoreI32Op :
     VM_GlobalStorePrimitiveOp<I32, "global.store.i32", VM_OPC_GlobalStoreI32> {
-  let summary = [{global 32-bit integer store operation}];
+  let summary = [{Global 32-bit integer store operation.}];
 }
 
 def VM_GlobalStoreI64Op :
     VM_GlobalStorePrimitiveOp<I64, "global.store.i64", VM_OPC_GlobalStoreI64> {
-  let summary = [{global 64-bit integer store operation}];
+  let summary = [{Global 64-bit integer store operation.}];
 }
 
 def VM_GlobalStoreF32Op :
     VM_GlobalStorePrimitiveOp<F32, "global.store.f32", VM_OPC_GlobalStoreF32,
                               [VM_ExtF32]> {
-  let summary = [{global 32-bit floating-point store operation}];
+  let summary = [{Global 32-bit floating-point store operation.}];
 }
 
 def VM_GlobalStoreF64Op :
     VM_GlobalStorePrimitiveOp<F64, "global.store.f64", VM_OPC_GlobalStoreF64,
                               [VM_ExtF64]> {
-  let summary = [{global 64-bit floating-point store operation}];
+  let summary = [{Global 64-bit floating-point store operation.}];
 }
 
 def VM_GlobalLoadIndirectI32Op :
     VM_GlobalLoadIndirectPrimitiveOp<I32, "global.load.indirect.i32",
                                      VM_OPC_GlobalLoadIndirectI32> {
-  let summary = [{global 32-bit integer load operation}];
+  let summary = [{Global 32-bit integer load operation.}];
   let hasCanonicalizer = 1;
 }
 
 def VM_GlobalLoadIndirectI64Op :
     VM_GlobalLoadIndirectPrimitiveOp<I64, "global.load.indirect.i64",
                                      VM_OPC_GlobalLoadIndirectI64> {
-  let summary = [{global 64-bit integer load operation}];
+  let summary = [{Global 64-bit integer load operation.}];
   let hasCanonicalizer = 1;
 }
 
@@ -785,7 +785,7 @@ def VM_GlobalLoadIndirectF32Op :
     VM_GlobalLoadIndirectPrimitiveOp<F32, "global.load.indirect.f32",
                                      VM_OPC_GlobalLoadIndirectF32,
                                      [VM_ExtF64]> {
-  let summary = [{global 32-bit floating-point load operation}];
+  let summary = [{Global 32-bit floating-point load operation.}];
   let hasCanonicalizer = 1;
 }
 
@@ -793,21 +793,21 @@ def VM_GlobalLoadIndirectF64Op :
     VM_GlobalLoadIndirectPrimitiveOp<F64, "global.load.indirect.f64",
                                      VM_OPC_GlobalLoadIndirectF64,
                                      [VM_ExtF64]> {
-  let summary = [{global 64-bit floating-point load operation}];
+  let summary = [{Global 64-bit floating-point load operation.}];
   let hasCanonicalizer = 1;
 }
 
 def VM_GlobalStoreIndirectI32Op :
     VM_GlobalStoreIndirectPrimitiveOp<I32, "global.store.indirect.i32",
                                       VM_OPC_GlobalStoreIndirectI32> {
-  let summary = [{global 32-bit integer store operation}];
+  let summary = [{Global 32-bit integer store operation.}];
   let hasCanonicalizer = 1;
 }
 
 def VM_GlobalStoreIndirectI64Op :
     VM_GlobalStoreIndirectPrimitiveOp<I64, "global.store.indirect.i64",
                                       VM_OPC_GlobalStoreIndirectI64> {
-  let summary = [{global 64-bit integer store operation}];
+  let summary = [{Global 64-bit integer store operation.}];
   let hasCanonicalizer = 1;
 }
 
@@ -815,7 +815,7 @@ def VM_GlobalStoreIndirectF32Op :
     VM_GlobalStoreIndirectPrimitiveOp<F32, "global.store.indirect.f32",
                                       VM_OPC_GlobalStoreIndirectI32,
                                       [VM_ExtF32]> {
-  let summary = [{global 32-bit floating-point store operation}];
+  let summary = [{Global 32-bit floating-point store operation.}];
   let hasCanonicalizer = 1;
 }
 
@@ -823,14 +823,14 @@ def VM_GlobalStoreIndirectF64Op :
     VM_GlobalStoreIndirectPrimitiveOp<F64, "global.store.indirect.f64",
                                       VM_OPC_GlobalStoreIndirectF64,
                                       [VM_ExtF64]> {
-  let summary = [{global 64-bit floating-point store operation}];
+  let summary = [{Global 64-bit floating-point store operation.}];
   let hasCanonicalizer = 1;
 }
 
 def VM_GlobalLoadRefOp : VM_GlobalLoadOp<VM_AnyRef, "global.load.ref", [
       DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{global ref<T> load operation}];
+  let summary = [{Global ref<T> load operation.}];
   let description = [{
     Loads the value of a global containing a ref of the given type.
   }];
@@ -844,7 +844,7 @@ def VM_GlobalLoadRefOp : VM_GlobalLoadOp<VM_AnyRef, "global.load.ref", [
 }
 
 def VM_GlobalStoreRefOp : VM_GlobalStoreOp<VM_AnyRef, "global.store.ref"> {
-  let summary = [{global ref<T> stores operation}];
+  let summary = [{Global ref<T> stores operation.}];
   let description = [{
     Stores a ref<T> to a global, retaining it until the global is reset.
   }];
@@ -859,7 +859,7 @@ def VM_GlobalStoreRefOp : VM_GlobalStoreOp<VM_AnyRef, "global.store.ref"> {
 
 def VM_GlobalLoadIndirectRefOp :
     VM_GlobalLoadIndirectOp<VM_AnyRef, "global.load.indirect.ref"> {
-  let summary = [{global ref<T> load operation}];
+  let summary = [{Global ref<T> load operation.}];
   let description = [{
     Loads the value of a global containing a ref of the given type.
   }];
@@ -876,7 +876,7 @@ def VM_GlobalLoadIndirectRefOp :
 
 def VM_GlobalStoreIndirectRefOp :
     VM_GlobalStoreIndirectOp<VM_AnyRef, "global.store.indirect.ref"> {
-  let summary = [{global ref<T> stores operation}];
+  let summary = [{Global ref<T> stores operation.}];
   let description = [{
     Stores a ref<T> to a global, retaining it until the global is reset.
   }];
@@ -953,7 +953,7 @@ def VM_ConstI32Op :
                            "int32_t", [
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{32-bit integer constant operation}];
+  let summary = [{32-bit integer constant operation.}];
   let arguments = (ins
     VM_ConstantIntegerValueAttr<I32>:$value
   );
@@ -966,7 +966,7 @@ def VM_ConstI64Op :
                            "int64_t", [
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{64-bit integer constant operation}];
+  let summary = [{64-bit integer constant operation.}];
   let arguments = (ins
     VM_ConstantIntegerValueAttr<I64>:$value
   );
@@ -977,7 +977,7 @@ def VM_ConstI64Op :
 def VM_ConstF32Op :
     VM_ConstantPrimitiveOp<F32, 32, "const.f32", VM_OPC_ConstF32,
                            "float", [VM_ExtF32]> {
-  let summary = [{32-bit floating-point constant operation}];
+  let summary = [{32-bit floating-point constant operation.}];
   let arguments = (ins
     VM_ConstantFloatValueAttr<F32>:$value
   );
@@ -988,7 +988,7 @@ def VM_ConstF32Op :
 def VM_ConstF64Op :
     VM_ConstantPrimitiveOp<F64, 64, "const.f64", VM_OPC_ConstF64,
                            "double", [VM_ExtF64]> {
-  let summary = [{64-bit floating-point constant operation}];
+  let summary = [{64-bit floating-point constant operation.}];
   let arguments = (ins
     VM_ConstantFloatValueAttr<F64>:$value
   );
@@ -1027,7 +1027,7 @@ def VM_ConstI32ZeroOp :
                                "int32_t", [
       DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{32-bit integer constant zero operation}];
+  let summary = [{32-bit integer constant zero operation.}];
   let hasFolder = 1;
 }
 
@@ -1036,7 +1036,7 @@ def VM_ConstI64ZeroOp :
                                "int64_t", [
       DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{64-bit integer constant zero operation}];
+  let summary = [{64-bit integer constant zero operation.}];
   let hasFolder = 1;
 }
 
@@ -1046,7 +1046,7 @@ def VM_ConstF32ZeroOp :
       VM_ExtF32,
       DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{32-bit floating-point constant zero operation}];
+  let summary = [{32-bit floating-point constant zero operation.}];
   let hasFolder = 1;
 }
 
@@ -1056,7 +1056,7 @@ def VM_ConstF64ZeroOp :
       VM_ExtF64,
       DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{64-bit floating-point constant zero operation}];
+  let summary = [{64-bit floating-point constant zero operation.}];
   let hasFolder = 1;
 }
 
@@ -1065,7 +1065,7 @@ def VM_ConstRefZeroOp : VM_PureOp<"const.ref.zero", [
     DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
     DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
   ]> {
-  let summary = [{null ref constant operation}];
+  let summary = [{null ref constant operation.}];
   let description = [{
     Defines a constant null ref that can be used in comparisons and
     initialization.
@@ -1097,7 +1097,7 @@ def VM_RodataOp : VM_Op<"rodata", [
     HasParent<"IREE::VM::ModuleOp">,
     Symbol,
   ]> {
-  let summary = [{read-only data definition operation}];
+  let summary = [{Read-only data definition operation.}];
   let description = [{
     Defines a blob of read-only constant data that can be represented as a
     ref. This can be used to store arbitrary data within modules such as
@@ -1141,7 +1141,7 @@ def VM_ConstRefRodataOp : VM_PureOp<"const.ref.rodata", [
     DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
     DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
   ]> {
-  let summary = [{constant rodata access operation}];
+  let summary = [{Constant rodata access operation.}];
   let description = [{
     Returns a reference to a read-only buffer.
   }];
@@ -1176,7 +1176,7 @@ def VM_ConstRefRodataOp : VM_PureOp<"const.ref.rodata", [
 def VM_RodataInlineOp : VM_PureOp<"rodata.inline", [
     VM_PseudoOp,
   ]> {
-  let summary = [{inlined constant rodata}];
+  let summary = [{Inlined constant rodata.}];
   let description = [{
     vm.rodata that can be embedded inline in functions. See vm.rodata for more
     information.
@@ -1210,7 +1210,7 @@ def VM_RodataInlineOp : VM_PureOp<"rodata.inline", [
 def VM_RodataTableInlineOp : VM_PureOp<"rodata.table.inline", [
     VM_PseudoOp,
   ]> {
-  let summary = [{inlined constant rodata table}];
+  let summary = [{Inlined constant rodata table.}];
   let description = [{
     vm.rodata with another associated vm.rodata table specifying byte offsets
     and sizes as a subview into the flattened data. The table is a flat array
@@ -1268,7 +1268,7 @@ def VM_BufferAllocOp :
       MemoryEffects<[MemAlloc]>,
       AlwaysSpeculatable,
     ]> {
-  let summary = [{allocates a new zero-initialized buffer}];
+  let summary = [{Allocates a new zero-initialized buffer.}];
   let description = [{
     Allocates a new zero-initialized buffer with the given size in bytes.
   }];
@@ -1299,7 +1299,7 @@ def VM_BufferCloneOp :
       MemoryEffects<[MemAlloc, MemRead]>,
       AlwaysSpeculatable,
     ]> {
-  let summary = [{clones a buffer}];
+  let summary = [{Clones a buffer.}];
   let description = [{
     Clones a range of the source buffer to produce a mutable buffer with the
     same contents.
@@ -1333,7 +1333,7 @@ def VM_BufferLengthOp :
     VM_PureOp<"buffer.length", [
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
     ]> {
-  let summary = [{returns the byte length of a buffer}];
+  let summary = [{Returns the byte length of a buffer.}];
   let description = [{
     Returns the total byte length of the given buffer. This is the exact value
     as specified during buffer allocation though the underlying system buffer
@@ -1363,7 +1363,7 @@ def VM_BufferCopyOp :
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
       MemoryEffects<[MemRead, MemWrite]>,
     ]> {
-  let summary = [{copies a range of a buffer to another}];
+  let summary = [{Copies a range of a buffer to another.}];
   let description = [{
     Copies a range of one buffer to another, like memcpy.
   }];
@@ -1395,7 +1395,7 @@ def VM_BufferCompareOp :
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
       MemoryEffects<[MemRead, MemWrite]>,
     ]> {
-  let summary = [{compares a range of a buffer to another}];
+  let summary = [{Compares a range of a buffer to another.}];
   let description = [{
     Returns 1 if the two ranges are bitwise equivalent, somewhat like memcmp.
   }];
@@ -1459,29 +1459,29 @@ class VM_BufferFillOp<Type type, string mnemonic, VM_OPC opcode,
 
 def VM_BufferFillI8Op :
     VM_BufferFillOp<I8, "buffer.fill.i8", VM_OPC_BufferFillI8> {
-  let summary = [{fills the buffer with the given repeating 8-bit value}];
+  let summary = [{Fills the buffer with the given repeating 8-bit value.}];
 }
 def VM_BufferFillI16Op :
     VM_BufferFillOp<I16, "buffer.fill.i16", VM_OPC_BufferFillI16> {
-  let summary = [{fills the buffer with the given repeating 16-bit value}];
+  let summary = [{Fills the buffer with the given repeating 16-bit value.}];
 }
 def VM_BufferFillI32Op :
     VM_BufferFillOp<I32, "buffer.fill.i32", VM_OPC_BufferFillI32> {
-  let summary = [{fills the buffer with the given repeating 32-bit value}];
+  let summary = [{Fills the buffer with the given repeating 32-bit value.}];
 }
 def VM_BufferFillI64Op :
     VM_BufferFillOp<I64, "buffer.fill.i64", VM_OPC_BufferFillI64> {
-  let summary = [{fills the buffer with the given repeating 64-bit value}];
+  let summary = [{Fills the buffer with the given repeating 64-bit value.}];
 }
 def VM_BufferFillF32Op :
     VM_BufferFillOp<F32, "buffer.fill.f32", VM_OPC_BufferFillF32,
                     [VM_ExtF32]> {
-  let summary = [{fills the buffer with the given repeating 32-bit value}];
+  let summary = [{Fills the buffer with the given repeating 32-bit value.}];
 }
 def VM_BufferFillF64Op :
     VM_BufferFillOp<F64, "buffer.fill.f64", VM_OPC_BufferFillF64,
                     [VM_ExtF64]> {
-  let summary = [{fills the buffer with the given repeating 64-bit value}];
+  let summary = [{Fills the buffer with the given repeating 64-bit value.}];
 }
 
 class VM_BufferLoadOp<Type type, string mnemonic, VM_OPC opcode,
@@ -1546,66 +1546,66 @@ class VM_BufferStoreOp<Type type, string mnemonic, VM_OPC opcode,
 
 def VM_BufferLoadI8UOp :
     VM_BufferLoadOp<I32, "buffer.load.i8.u", VM_OPC_BufferLoadI8U, []> {
-  let summary = [{unsigned 8-bit integer load}];
+  let summary = [{Unsigned 8-bit integer load.}];
 }
 def VM_BufferLoadI8SOp :
     VM_BufferLoadOp<I32, "buffer.load.i8.s", VM_OPC_BufferLoadI8S, []> {
-  let summary = [{signed 8-bit integer load}];
+  let summary = [{Signed 8-bit integer load.}];
 }
 
 def VM_BufferLoadI16UOp :
     VM_BufferLoadOp<I32, "buffer.load.i16.u", VM_OPC_BufferLoadI16U, []> {
-  let summary = [{unsigned 16-bit integer load}];
+  let summary = [{Unsigned 16-bit integer load.}];
 }
 def VM_BufferLoadI16SOp :
     VM_BufferLoadOp<I32, "buffer.load.i16.s", VM_OPC_BufferLoadI16S, []> {
-  let summary = [{signed 16-bit integer load}];
+  let summary = [{Signed 16-bit integer load.}];
 }
 
 def VM_BufferLoadI32Op :
     VM_BufferLoadOp<I32, "buffer.load.i32", VM_OPC_BufferLoadI32, []> {
-  let summary = [{32-bit integer load}];
+  let summary = [{32-bit integer load.}];
 }
 def VM_BufferLoadI64Op :
     VM_BufferLoadOp<I64, "buffer.load.i64", VM_OPC_BufferLoadI64> {
-  let summary = [{64-bit integer load}];
+  let summary = [{64-bit integer load.}];
 }
 def VM_BufferLoadF32Op :
     VM_BufferLoadOp<F32, "buffer.load.f32", VM_OPC_BufferLoadF32,
                     [VM_ExtF32]> {
-  let summary = [{32-bit floating-point load}];
+  let summary = [{32-bit floating-point load.}];
 }
 def VM_BufferLoadF64Op :
     VM_BufferLoadOp<F64, "buffer.load.f64", VM_OPC_BufferLoadF64,
                     [VM_ExtF64]> {
-  let summary = [{64-bit floating-point load}];
+  let summary = [{64-bit floating-point load.}];
 }
 
 def VM_BufferStoreI8Op :
     VM_BufferStoreOp<I32, "buffer.store.i8", VM_OPC_BufferStoreI8, []> {
-  let summary = [{unsigned 8-bit integer store}];
+  let summary = [{Unsigned 8-bit integer store.}];
 }
 def VM_BufferStoreI16Op :
     VM_BufferStoreOp<I32, "buffer.store.i16", VM_OPC_BufferStoreI16, []> {
-  let summary = [{unsigned 16-bit integer store}];
+  let summary = [{Unsigned 16-bit integer store.}];
 }
 def VM_BufferStoreI32Op :
     VM_BufferStoreOp<I32, "buffer.store.i32", VM_OPC_BufferStoreI32, []> {
-  let summary = [{32-bit integer store}];
+  let summary = [{32-bit integer store.}];
 }
 def VM_BufferStoreI64Op :
     VM_BufferStoreOp<I64, "buffer.store.i64", VM_OPC_BufferStoreI64> {
-  let summary = [{64-bit integer store}];
+  let summary = [{64-bit integer store.}];
 }
 def VM_BufferStoreF32Op :
     VM_BufferStoreOp<F32, "buffer.store.f32", VM_OPC_BufferStoreF32,
                      [VM_ExtF32]> {
-  let summary = [{32-bit floating-point store}];
+  let summary = [{32-bit floating-point store.}];
 }
 def VM_BufferStoreF64Op :
     VM_BufferStoreOp<F64, "buffer.store.f64", VM_OPC_BufferStoreF64,
                      [VM_ExtF64]> {
-  let summary = [{64-bit floating-point store}];
+  let summary = [{64-bit floating-point store.}];
 }
 
 def VM_BufferHashOp : VM_Op<"buffer.hash", [
@@ -1663,7 +1663,7 @@ def VM_ListAllocOp :
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
       MemoryEffects<[MemAlloc]>,
     ]> {
-  let summary = [{allocates a new empty list}];
+  let summary = [{Allocates a new empty list.}];
   let description = [{
     Allocates a new typed list with a minimum initial_capacity.
   }];
@@ -1692,7 +1692,7 @@ def VM_ListReserveOp :
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
       MemoryEffects<[MemAlloc, MemRead, MemWrite]>,
     ]> {
-  let summary = [{reserves capacity for list growth}];
+  let summary = [{Reserves capacity for list growth.}];
   let description = [{
     Reserves storage for at least minimum_capacity elements. If the list already
     has at least the specified capacity the operation is ignored.
@@ -1719,7 +1719,7 @@ def VM_ListSizeOp :
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
       MemoryEffects<[MemRead]>,
     ]> {
-  let summary = [{the size of the list in elements}];
+  let summary = [{The size of the list in elements.}];
   let description = [{
     Returns the current size of the list in elements.
   }];
@@ -1747,7 +1747,7 @@ def VM_ListResizeOp :
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
       MemoryEffects<[MemWrite]>,
     ]> {
-  let summary = [{resizes the list to a new count in elements}];
+  let summary = [{Resizes the list to a new count in elements.}];
   let description = [{
     Resizes the list to contain new_size elements. This will either truncate
     the list if the existing size is greater than new_size or extend the list
@@ -1776,7 +1776,7 @@ class VM_ListGetPrimitiveOp<Type type, string mnemonic, VM_OPC opcode,
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
       MemoryEffects<[MemRead]>,
     ])> {
-  let summary = [{primitive type element accessor}];
+  let summary = [{Primitive type element accessor.}];
   let description = [{
     Returns the value of the element at the given index.
   }];
@@ -1807,7 +1807,7 @@ class VM_ListSetPrimitiveOp<Type type, string mnemonic, VM_OPC opcode,
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
       MemoryEffects<[MemWrite]>,
     ])> {
-  let summary = [{primitive type element mutator}];
+  let summary = [{Primitive type element mutator.}];
   let description = [{
     Sets the element at the given index to the new value.
   }];
@@ -1859,7 +1859,7 @@ def VM_ListGetRefOp :
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
       MemoryEffects<[MemRead]>,
     ]> {
-  let summary = [{ref type element accessor}];
+  let summary = [{ref type element accessor.}];
   let description = [{
     Returns the ref value of the element at the given index. Note that the value
     may be null if the element is null or the type does not match.
@@ -1893,7 +1893,7 @@ def VM_ListSetRefOp :
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
       MemoryEffects<[MemWrite]>,
     ]> {
-  let summary = [{ref type element mutator}];
+  let summary = [{ref type element mutator.}];
   let description = [{
     Sets the element at the given index to the new ref value (possibly null).
   }];
@@ -1973,24 +1973,24 @@ class VM_SelectPrimitiveOp<Type type, string mnemonic, VM_OPC opcode,
 }
 
 def VM_SelectI32Op : VM_SelectPrimitiveOp<I32, "select.i32", VM_OPC_SelectI32> {
-  let summary = [{integer select operation}];
+  let summary = [{Integer select operation.}];
   let hasFolder = 1;
 }
 
 def VM_SelectI64Op : VM_SelectPrimitiveOp<I64, "select.i64", VM_OPC_SelectI64> {
-  let summary = [{integer select operation}];
+  let summary = [{Integer select operation.}];
   let hasFolder = 1;
 }
 
 def VM_SelectF32Op : VM_SelectPrimitiveOp<F32, "select.f32", VM_OPC_SelectF32,
                                           [VM_ExtF32]> {
-  let summary = [{floating-point select operation}];
+  let summary = [{Floating-point select operation.}];
   let hasFolder = 1;
 }
 
 def VM_SelectF64Op : VM_SelectPrimitiveOp<F64, "select.f64", VM_OPC_SelectF64,
                                           [VM_ExtF64]> {
-  let summary = [{floating-point select operation}];
+  let summary = [{Floating-point select operation.}];
   let hasFolder = 1;
 }
 
@@ -1998,7 +1998,7 @@ def VM_SelectRefOp : VM_PureOp<"select.ref", [
     DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
     AllTypesMatch<["true_value", "false_value", "result"]>,
   ]> {
-  let summary = [{ref<T> select operation}];
+  let summary = [{ref<T> select operation.}];
   let description = [{
     Chooses one value based on a binary condition supplied as its first operand.
     If the value of the condition is true the `true_value` operand is chosen,
@@ -2109,24 +2109,24 @@ class VM_SwitchFloatOp<F type, string mnemonic, VM_OPC opcode,
 }
 
 def VM_SwitchI32Op : VM_SwitchIntegerOp<I32, "switch.i32", VM_OPC_SwitchI32> {
-  let summary = [{integer switch operation}];
+  let summary = [{Integer switch operation.}];
   let hasFolder = 1;
 }
 
 def VM_SwitchI64Op : VM_SwitchIntegerOp<I64, "switch.i64", VM_OPC_SwitchI64> {
-  let summary = [{integer switch operation}];
+  let summary = [{Integer switch operation.}];
   let hasFolder = 1;
 }
 
 def VM_SwitchF32Op : VM_SwitchFloatOp<F32, "switch.f32", VM_OPC_SwitchF32,
                                       [VM_ExtF32]> {
-  let summary = [{floating-point switch operation}];
+  let summary = [{Floating-point switch operation.}];
   let hasFolder = 1;
 }
 
 def VM_SwitchF64Op : VM_SwitchFloatOp<F64, "switch.f64", VM_OPC_SwitchF64,
                                       [VM_ExtF64]> {
-  let summary = [{floating-point switch operation}];
+  let summary = [{Floating-point switch operation.}];
   let hasFolder = 1;
 }
 
@@ -2134,7 +2134,7 @@ def VM_SwitchRefOp : VM_PureOp<"switch.ref", [
     DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
     AllTypesMatch<["default_value", "result"]>,
   ]> {
-  let summary = [{ref<T> switch operation}];
+  let summary = [{ref<T> switch operation.}];
   let description = [{
     Returns the value with the given `index` in `values` or `default_value` if
     the index is out of bounds.
@@ -2294,163 +2294,163 @@ let opDocGroup = OpGroupIntegerArithmeticOps in {
 
 def VM_AddI32Op :
     VM_BinaryArithmeticOp<I32, "add.i32", VM_OPC_AddI32, [Commutative]> {
-  let summary = [{integer add operation}];
+  let summary = [{Integer add operation.}];
   let hasFolder = 1;
   let hasCanonicalizer = 1;
 }
 
 def VM_AddI64Op :
     VM_BinaryArithmeticOp<I64, "add.i64", VM_OPC_AddI64, [Commutative]> {
-  let summary = [{integer add operation}];
+  let summary = [{Integer add operation.}];
   let hasFolder = 1;
   let hasCanonicalizer = 1;
 }
 
 def VM_SubI32Op :
     VM_BinaryArithmeticOp<I32, "sub.i32", VM_OPC_SubI32> {
-  let summary = [{integer subtract operation}];
+  let summary = [{Integer subtract operation.}];
   let hasFolder = 1;
 }
 
 def VM_SubI64Op :
     VM_BinaryArithmeticOp<I64, "sub.i64", VM_OPC_SubI64> {
-  let summary = [{integer subtract operation}];
+  let summary = [{Integer subtract operation.}];
   let hasFolder = 1;
 }
 
 def VM_MulI32Op :
     VM_BinaryArithmeticOp<I32, "mul.i32", VM_OPC_MulI32, [Commutative]> {
-  let summary = [{integer multiplication operation}];
+  let summary = [{Integer multiplication operation.}];
   let hasFolder = 1;
   let hasCanonicalizer = 1;
 }
 
 def VM_MulI64Op :
     VM_BinaryArithmeticOp<I64, "mul.i64", VM_OPC_MulI64, [Commutative]> {
-  let summary = [{integer multiplication operation}];
+  let summary = [{Integer multiplication operation.}];
   let hasFolder = 1;
   let hasCanonicalizer = 1;
 }
 
 def VM_DivI32SOp :
     VM_BinaryArithmeticOp<I32, "div.i32.s", VM_OPC_DivI32S> {
-  let summary = [{signed integer division operation}];
+  let summary = [{Signed integer division operation.}];
   let hasFolder = 1;
 }
 
 def VM_DivI64SOp :
     VM_BinaryArithmeticOp<I64, "div.i64.s", VM_OPC_DivI64S> {
-  let summary = [{signed integer division operation}];
+  let summary = [{Signed integer division operation.}];
   let hasFolder = 1;
 }
 
 def VM_DivI32UOp :
     VM_BinaryArithmeticOp<I32, "div.i32.u", VM_OPC_DivI32U> {
-  let summary = [{unsigned integer division operation}];
+  let summary = [{Unsigned integer division operation.}];
   let hasFolder = 1;
 }
 
 def VM_DivI64UOp :
     VM_BinaryArithmeticOp<I64, "div.i64.u", VM_OPC_DivI64U> {
-  let summary = [{unsigned integer division operation}];
+  let summary = [{Unsigned integer division operation.}];
   let hasFolder = 1;
 }
 
 def VM_RemI32SOp :
     VM_BinaryArithmeticOp<I32, "rem.i32.s", VM_OPC_RemI32S> {
-  let summary = [{signed integer division remainder operation}];
+  let summary = [{Signed integer division remainder operation.}];
   let hasFolder = 1;
 }
 
 def VM_RemI64SOp :
     VM_BinaryArithmeticOp<I64, "rem.i64.s", VM_OPC_RemI64S> {
-  let summary = [{signed integer division remainder operation}];
+  let summary = [{Signed integer division remainder operation.}];
   let hasFolder = 1;
 }
 
 def VM_RemI32UOp :
     VM_BinaryArithmeticOp<I32, "rem.i32.u", VM_OPC_RemI32U> {
-  let summary = [{unsigned integer division remainder operation}];
+  let summary = [{Unsigned integer division remainder operation.}];
   let hasFolder = 1;
 }
 
 def VM_RemI64UOp :
     VM_BinaryArithmeticOp<I64, "rem.i64.u", VM_OPC_RemI64U> {
-  let summary = [{unsigned integer division remainder operation}];
+  let summary = [{Unsigned integer division remainder operation.}];
   let hasFolder = 1;
 }
 
 def VM_FMAI32Op :
     VM_TernaryArithmeticOp<I32, "fma.i32", VM_OPC_FMAI32> {
-  let summary = [{integer fused-multiply add operation (a*b+c)}];
+  let summary = [{Integer fused-multiply add operation (a*b+c).}];
   let hasFolder = 1;
   let hasCanonicalizer = 1;
 }
 
 def VM_FMAI64Op :
     VM_TernaryArithmeticOp<I64, "fma.i64", VM_OPC_FMAI64> {
-  let summary = [{integer fused-multiply add operation (a*b+c)}];
+  let summary = [{Integer fused-multiply add operation (a*b+c).}];
   let hasFolder = 1;
   let hasCanonicalizer = 1;
 }
 
 def VM_AbsI32Op :
     VM_UnaryArithmeticOp<I32, "abs.i32", VM_OPC_AbsI32> {
-  let summary = [{integer absolute-value operation}];
+  let summary = [{Integer absolute-value operation.}];
   let hasFolder = 1;
 }
 
 def VM_AbsI64Op :
     VM_UnaryArithmeticOp<I64, "abs.i64", VM_OPC_AbsI64> {
-  let summary = [{integer absolute-value operation}];
+  let summary = [{Integer absolute-value operation.}];
   let hasFolder = 1;
 }
 
 def VM_MinI32SOp :
     VM_BinaryArithmeticOp<I32, "min.i32.s", VM_OPC_MinI32S, [Commutative]> {
-  let summary = [{signed integer minimum operation}];
+  let summary = [{Signed integer minimum operation.}];
   let hasFolder = 1;
 }
 
 def VM_MinI32UOp :
     VM_BinaryArithmeticOp<I32, "min.i32.u", VM_OPC_MinI32U, [Commutative]> {
-  let summary = [{unsigned integer minimum operation}];
+  let summary = [{Unsigned integer minimum operation.}];
   let hasFolder = 1;
 }
 
 def VM_MinI64SOp :
     VM_BinaryArithmeticOp<I64, "min.i64.s", VM_OPC_MinI64S, [Commutative]> {
-  let summary = [{signed integer minimum operation}];
+  let summary = [{Signed integer minimum operation.}];
   let hasFolder = 1;
 }
 
 def VM_MinI64UOp :
     VM_BinaryArithmeticOp<I64, "min.i64.u", VM_OPC_MinI64U, [Commutative]> {
-  let summary = [{unsigned integer minimum operation}];
+  let summary = [{Unsigned integer minimum operation.}];
   let hasFolder = 1;
 }
 
 def VM_MaxI32SOp :
     VM_BinaryArithmeticOp<I32, "max.i32.s", VM_OPC_MaxI32S, [Commutative]> {
-  let summary = [{signed integer maximum operation}];
+  let summary = [{Signed integer maximum operation.}];
   let hasFolder = 1;
 }
 
 def VM_MaxI32UOp :
     VM_BinaryArithmeticOp<I32, "max.i32.u", VM_OPC_MaxI32U, [Commutative]> {
-  let summary = [{unsigned integer maximum operation}];
+  let summary = [{Unsigned integer maximum operation.}];
   let hasFolder = 1;
 }
 
 def VM_MaxI64SOp :
     VM_BinaryArithmeticOp<I64, "max.i64.s", VM_OPC_MaxI64S, [Commutative]> {
-  let summary = [{signed integer maximum operation}];
+  let summary = [{Signed integer maximum operation.}];
   let hasFolder = 1;
 }
 
 def VM_MaxI64UOp :
     VM_BinaryArithmeticOp<I64, "max.i64.u", VM_OPC_MaxI64U, [Commutative]> {
-  let summary = [{unsigned integer maximum operation}];
+  let summary = [{Unsigned integer maximum operation.}];
   let hasFolder = 1;
 }
 
@@ -2470,7 +2470,7 @@ let opDocGroup = OpGroupFloatingPointArithmeticOps in {
 def VM_AddF32Op :
     VM_TotalBinaryArithmeticOp<F32, "add.f32", VM_OPC_AddF32,
                                [VM_ExtF32, Commutative]> {
-  let summary = [{floating-point add operation}];
+  let summary = [{Floating-point add operation.}];
   let hasFolder = 1;
   let hasCanonicalizer = 1;
 }
@@ -2478,7 +2478,7 @@ def VM_AddF32Op :
 def VM_AddF64Op :
     VM_TotalBinaryArithmeticOp<F64, "add.f64", VM_OPC_AddF64,
                                [VM_ExtF64, Commutative]> {
-  let summary = [{floating-point add operation}];
+  let summary = [{Floating-point add operation.}];
   let hasFolder = 1;
   let hasCanonicalizer = 1;
 }
@@ -2486,21 +2486,21 @@ def VM_AddF64Op :
 def VM_SubF32Op :
     VM_TotalBinaryArithmeticOp<F32, "sub.f32", VM_OPC_SubF32,
                               [VM_ExtF32]> {
-  let summary = [{floating point subtraction operation}];
+  let summary = [{Floating point subtraction operation.}];
   let hasFolder = 1;
 }
 
 def VM_SubF64Op :
     VM_TotalBinaryArithmeticOp<F64, "sub.f64", VM_OPC_SubF64,
                                [VM_ExtF64]> {
-  let summary = [{floating point subtraction operation}];
+  let summary = [{Floating point subtraction operation.}];
   let hasFolder = 1;
 }
 
 def VM_MulF32Op :
     VM_TotalBinaryArithmeticOp<F32, "mul.f32", VM_OPC_MulF32,
                                [VM_ExtF32, Commutative]> {
-  let summary = [{floating point multiplication operation}];
+  let summary = [{Floating point multiplication operation.}];
   let hasFolder = 1;
   let hasCanonicalizer = 1;
 }
@@ -2508,7 +2508,7 @@ def VM_MulF32Op :
 def VM_MulF64Op :
     VM_TotalBinaryArithmeticOp<F64, "mul.f64", VM_OPC_MulF64,
                                [VM_ExtF64, Commutative]> {
-  let summary = [{floating point multiplication operation}];
+  let summary = [{Floating point multiplication operation.}];
   let hasFolder = 1;
   let hasCanonicalizer = 1;
 }
@@ -2516,41 +2516,41 @@ def VM_MulF64Op :
 def VM_DivF32Op :
     VM_TotalBinaryArithmeticOp<F32, "div.f32", VM_OPC_DivF32,
                                [VM_ExtF32]> {
-  let summary = [{floating point division operation}];
+  let summary = [{Floating point division operation.}];
   let hasFolder = 1;
 }
 
 def VM_DivF64Op :
     VM_TotalBinaryArithmeticOp<F64, "div.f64", VM_OPC_DivF64,
                                [VM_ExtF64]> {
-  let summary = [{floating point division operation}];
+  let summary = [{Floating point division operation.}];
   let hasFolder = 1;
 }
 
 def VM_RemF32Op :
     VM_TotalBinaryArithmeticOp<F32, "rem.f32", VM_OPC_RemF32,
                                [VM_ExtF32]> {
-  let summary = [{floating point remainder operation}];
+  let summary = [{Floating point remainder operation.}];
   let hasFolder = 1;
 }
 
 def VM_RemF64Op :
     VM_TotalBinaryArithmeticOp<F64, "rem.f64", VM_OPC_RemF64,
                                [VM_ExtF64]> {
-  let summary = [{floating point remainder operation}];
+  let summary = [{Floating point remainder operation.}];
   let hasFolder = 1;
 }
 
 def VM_FMAF32Op :
     VM_TotalTernaryArithmeticOp<F32, "fma.f32", VM_OPC_FMAF32, [VM_ExtF32]> {
-  let summary = [{floating point fused multiply-add operation (a*b+c)}];
+  let summary = [{Floating point fused multiply-add operation (a*b+c).}];
   let hasFolder = 1;
   let hasCanonicalizer = 1;
 }
 
 def VM_FMAF64Op :
     VM_TotalTernaryArithmeticOp<F64, "fma.f64", VM_OPC_FMAF64, [VM_ExtF64]> {
-  let summary = [{floating point fused multiply-add operation (a*b+c)}];
+  let summary = [{Floating point fused multiply-add operation (a*b+c).}];
   let hasFolder = 1;
   let hasCanonicalizer = 1;
 }
@@ -2558,108 +2558,108 @@ def VM_FMAF64Op :
 def VM_AbsF32Op :
     VM_TotalUnaryArithmeticOp<F32, "abs.f32", VM_OPC_AbsF32,
                               [VM_ExtF32]> {
-  let summary = [{floating point absolute-value operation}];
+  let summary = [{Floating point absolute-value operation.}];
   let hasFolder = 1;
 }
 
 def VM_AbsF64Op :
     VM_TotalUnaryArithmeticOp<F64, "abs.f64", VM_OPC_AbsF64,
                               [VM_ExtF64]> {
-  let summary = [{floating point absolute-value operation}];
+  let summary = [{Floating point absolute-value operation.}];
   let hasFolder = 1;
 }
 
 def VM_NegF32Op :
     VM_TotalUnaryArithmeticOp<F32, "neg.f32", VM_OPC_NegF32,
                              [VM_ExtF32]> {
-  let summary = [{floating point negation operation}];
+  let summary = [{Floating point negation operation.}];
   let hasFolder = 1;
 }
 
 def VM_NegF64Op :
     VM_TotalUnaryArithmeticOp<F64, "neg.f64", VM_OPC_NegF64,
                               [VM_ExtF64]> {
-  let summary = [{floating point negation operation}];
+  let summary = [{Floating point negation operation.}];
   let hasFolder = 1;
 }
 
 def VM_CeilF32Op :
     VM_TotalUnaryArithmeticOp<F32, "ceil.f32", VM_OPC_CeilF32,
                               [VM_ExtF32]> {
-  let summary = [{floating point ceiling operation}];
+  let summary = [{Floating point ceiling operation.}];
   let hasFolder = 1;
 }
 
 def VM_CeilF64Op :
     VM_TotalUnaryArithmeticOp<F64, "ceil.f64", VM_OPC_CeilF64,
                               [VM_ExtF64]> {
-  let summary = [{floating point ceiling operation}];
+  let summary = [{Floating point ceiling operation.}];
   let hasFolder = 1;
 }
 
 def VM_FloorF32Op :
     VM_TotalUnaryArithmeticOp<F32, "floor.f32", VM_OPC_FloorF32,
                               [VM_ExtF32]> {
-  let summary = [{floating point floor operation}];
+  let summary = [{Floating point floor operation.}];
   let hasFolder = 1;
 }
 
 def VM_FloorF64Op :
     VM_TotalUnaryArithmeticOp<F64, "floor.f64", VM_OPC_FloorF64,
                               [VM_ExtF64]> {
-  let summary = [{floating point floor operation}];
+  let summary = [{Floating point floor operation.}];
   let hasFolder = 1;
 }
 
 def VM_RoundF32Op :
     VM_TotalUnaryArithmeticOp<F32, "round.f32", VM_OPC_RoundF32,
                               [VM_ExtF32]> {
-  let summary = [{rounds the value to the nearest integer away from zero}];
+  let summary = [{Rounds the value to the nearest integer away from zero.}];
 }
 
 def VM_RoundF64Op :
     VM_TotalUnaryArithmeticOp<F64, "round.f64", VM_OPC_RoundF64,
                               [VM_ExtF64]> {
-  let summary = [{rounds the value to the nearest integer away from zero}];
+  let summary = [{Rounds the value to the nearest integer away from zero.}];
 }
 
 def VM_RoundF32EvenOp :
     VM_TotalUnaryArithmeticOp<F32, "round.f32.even", VM_OPC_RoundF32Even,
                               [VM_ExtF32]> {
-  let summary = [{rounds the value to the nearest even integer}];
+  let summary = [{Rounds the value to the nearest even integer.}];
 }
 
 def VM_RoundF64EvenOp :
     VM_TotalUnaryArithmeticOp<F64, "round.f64.even", VM_OPC_RoundF64Even,
                               [VM_ExtF64]> {
-  let summary = [{rounds the value to the nearest even integer}];
+  let summary = [{Rounds the value to the nearest even integer.}];
 }
 
 def VM_MinF32Op :
     VM_TotalBinaryArithmeticOp<F32, "min.f32", VM_OPC_MinF32,
                                [VM_ExtF32, Commutative]> {
-  let summary = [{floating point minimum operation}];
+  let summary = [{Floating point minimum operation.}];
   let hasFolder = 1;
 }
 
 def VM_MinF64Op :
     VM_TotalBinaryArithmeticOp<F64, "min.f64", VM_OPC_MinF64,
                                [VM_ExtF64, Commutative]> {
-  let summary = [{floating point minimum operation}];
+  let summary = [{Floating point minimum operation.}];
   let hasFolder = 1;
 }
 
 def VM_MaxF32Op :
     VM_TotalBinaryArithmeticOp<F32, "max.f32", VM_OPC_MaxF32,
                                [VM_ExtF32, Commutative]> {
-  let summary = [{floating point maximum operation}];
+  let summary = [{Floating point maximum operation.}];
   let hasFolder = 1;
 }
 
 def VM_MaxF64Op :
     VM_TotalBinaryArithmeticOp<F64, "max.f64", VM_OPC_MaxF64,
                                [VM_ExtF64, Commutative]> {
-  let summary = [{floating point maximum operation}];
+  let summary = [{Floating point maximum operation.}];
   let hasFolder = 1;
 }
 
@@ -2679,162 +2679,162 @@ let opDocGroup = OpGroupFloatingPointMathOps in {
 
 def VM_AtanF32Op :
     VM_TotalUnaryArithmeticOp<F32, "atan.f32", VM_OPC_AtanF32, [VM_ExtF32]> {
-  let summary = [{arcus tangent of the given value}];
+  let summary = [{Arcus tangent of the given value.}];
 }
 
 def VM_AtanF64Op :
     VM_TotalUnaryArithmeticOp<F64, "atan.f64", VM_OPC_AtanF64, [VM_ExtF64]> {
-  let summary = [{arcus tangent of the given value}];
+  let summary = [{Arcus tangent of the given value.}];
 }
 
 def VM_Atan2F32Op :
     VM_TotalBinaryArithmeticOp<F32, "atan2.f32", VM_OPC_Atan2F32, [VM_ExtF32]> {
-  let summary = [{2-argument arcus tangent of the given values}];
+  let summary = [{2-argument arcus tangent of the given values.}];
 }
 
 def VM_Atan2F64Op :
     VM_TotalBinaryArithmeticOp<F64, "atan2.f64", VM_OPC_Atan2F64, [VM_ExtF64]> {
-  let summary = [{2-argument arcus tangent of the given values}];
+  let summary = [{2-argument arcus tangent of the given values.}];
 }
 
 def VM_CosF32Op :
     VM_TotalUnaryArithmeticOp<F32, "cos.f32", VM_OPC_CosF32, [VM_ExtF32]> {
-  let summary = [{cosine of the specified value}];
+  let summary = [{Cosine of the specified value.}];
 }
 
 def VM_CosF64Op :
     VM_TotalUnaryArithmeticOp<F64, "cos.f64", VM_OPC_CosF64, [VM_ExtF64]> {
-  let summary = [{cosine of the specified value}];
+  let summary = [{Cosine of the specified value.}];
 }
 
 def VM_SinF32Op :
     VM_TotalUnaryArithmeticOp<F32, "sin.f32", VM_OPC_SinF32, [VM_ExtF32]> {
-  let summary = [{sine of the specified value}];
+  let summary = [{Sine of the specified value.}];
 }
 def VM_SinF64Op :
     VM_TotalUnaryArithmeticOp<F64, "sin.f64", VM_OPC_SinF64, [VM_ExtF64]> {
-  let summary = [{sine of the specified value}];
+  let summary = [{Sine of the specified value.}];
 }
 
 def VM_ExpF32Op :
     VM_TotalUnaryArithmeticOp<F32, "exp.f32", VM_OPC_ExpF32, [VM_ExtF32]> {
-  let summary = [{base-e exponential of the specified value}];
+  let summary = [{Base-e exponential of the specified value.}];
 }
 
 def VM_ExpF64Op :
     VM_TotalUnaryArithmeticOp<F64, "exp.f64", VM_OPC_ExpF64, [VM_ExtF64]> {
-  let summary = [{base-e exponential of the specified value}];
+  let summary = [{Base-e exponential of the specified value.}];
 }
 
 def VM_Exp2F32Op :
     VM_TotalUnaryArithmeticOp<F32, "exp2.f32", VM_OPC_Exp2F32, [VM_ExtF32]> {
-  let summary = [{base-2 exponential of the specified value}];
+  let summary = [{Base-2 exponential of the specified value.}];
 }
 
 def VM_Exp2F64Op :
     VM_TotalUnaryArithmeticOp<F64, "exp2.f64", VM_OPC_Exp2F64, [VM_ExtF64]> {
-  let summary = [{base-2 exponential of the specified value}];
+  let summary = [{Base-2 exponential of the specified value.}];
 }
 
 def VM_ExpM1F32Op :
     VM_TotalUnaryArithmeticOp<F32, "expm1.f32", VM_OPC_ExpM1F32, [VM_ExtF32]> {
-  let summary = [{base-e exponential of the specified value minus 1}];
+  let summary = [{Base-e exponential of the specified value minus 1.}];
 }
 
 def VM_ExpM1F64Op :
     VM_TotalUnaryArithmeticOp<F64, "expm1.f64", VM_OPC_ExpM1F64, [VM_ExtF64]> {
-  let summary = [{base-e exponential of the specified value minus 1}];
+  let summary = [{Base-e exponential of the specified value minus 1.}];
 }
 
 def VM_LogF32Op :
     VM_TotalUnaryArithmeticOp<F32, "log.f32", VM_OPC_LogF32, [VM_ExtF32]> {
-  let summary = [{base-e logarithm of the specified value}];
+  let summary = [{Base-e logarithm of the specified value.}];
 }
 
 def VM_LogF64Op :
    VM_TotalUnaryArithmeticOp<F64, "log.f64", VM_OPC_LogF64, [VM_ExtF64]> {
-  let summary = [{base-e logarithm of the specified value}];
+  let summary = [{Base-e logarithm of the specified value.}];
 }
 
 def VM_Log10F32Op :
     VM_TotalUnaryArithmeticOp<F32, "log10.f32", VM_OPC_Log10F32, [VM_ExtF32]> {
-  let summary = [{base-10 logarithm of the specified value}];
+  let summary = [{Base-10 logarithm of the specified value.}];
 }
 def VM_Log10F64Op :
     VM_TotalUnaryArithmeticOp<F64, "log10.f64", VM_OPC_Log10F64, [VM_ExtF64]> {
-  let summary = [{base-10 logarithm of the specified value}];
+  let summary = [{Base-10 logarithm of the specified value.}];
 }
 
 def VM_Log1pF32Op :
     VM_TotalUnaryArithmeticOp<F32, "log1p.f32", VM_OPC_Log1pF32, [VM_ExtF32]> {
-  let summary = [{natural logarithm of one plus the given value}];
+  let summary = [{Natural logarithm of one plus the given value.}];
 }
 
 def VM_Log1pF64Op :
     VM_TotalUnaryArithmeticOp<F64, "log1p.f64", VM_OPC_Log1pF64, [VM_ExtF64]> {
-  let summary = [{natural logarithm of one plus the given value}];
+  let summary = [{Natural logarithm of one plus the given value.}];
 }
 
 def VM_Log2F32Op :
     VM_TotalUnaryArithmeticOp<F32, "log2.f32", VM_OPC_Log2F32, [VM_ExtF32]> {
-  let summary = [{base-2 logarithm of the specified value}];
+  let summary = [{Base-2 logarithm of the specified value.}];
 }
 
 def VM_Log2F64Op :
     VM_TotalUnaryArithmeticOp<F64, "log2.f64", VM_OPC_Log2F64, [VM_ExtF64]> {
-  let summary = [{base-2 logarithm of the specified value}];
+  let summary = [{Base-2 logarithm of the specified value.}];
 }
 
 def VM_PowF32Op :
     VM_TotalBinaryArithmeticOp<F32, "pow.f32", VM_OPC_PowF32, [VM_ExtF32]> {
-  let summary = [{floating point raised to the power of operation}];
+  let summary = [{Floating point raised to the power of operation.}];
 }
 
 def VM_PowF64Op :
     VM_TotalBinaryArithmeticOp<F64, "pow.f64", VM_OPC_PowF64, [VM_ExtF64]> {
-  let summary = [{floating point raised to the power of operation}];
+  let summary = [{Floating point raised to the power of operation.}];
 }
 
 def VM_RsqrtF32Op :
     VM_TotalUnaryArithmeticOp<F32, "rsqrt.f32", VM_OPC_RsqrtF32, [VM_ExtF32]> {
-  let summary = [{reciprocal of sqrt (1 / sqrt of the specified value)}];
+  let summary = [{Reciprocal of sqrt (1 / sqrt of the specified value).}];
 }
 
 def VM_RsqrtF64Op :
     VM_TotalUnaryArithmeticOp<F64, "rsqrt.f64", VM_OPC_RsqrtF64, [VM_ExtF64]> {
-  let summary = [{reciprocal of sqrt (1 / sqrt of the specified value)}];
+  let summary = [{Reciprocal of sqrt (1 / sqrt of the specified value).}];
 }
 
 def VM_SqrtF32Op :
     VM_TotalUnaryArithmeticOp<F32, "sqrt.f32", VM_OPC_SqrtF32, [VM_ExtF32]> {
-  let summary = [{sqrt of the specified value}];
+  let summary = [{Sqrt of the specified value.}];
   let hasFolder = 1;
 }
 
 def VM_SqrtF64Op :
     VM_TotalUnaryArithmeticOp<F64, "sqrt.f64", VM_OPC_SqrtF64, [VM_ExtF64]> {
-  let summary = [{sqrt of the specified value}];
+  let summary = [{Sqrt of the specified value.}];
   let hasFolder = 1;
 }
 
 def VM_TanhF32Op :
     VM_TotalUnaryArithmeticOp<F32, "tanh.f32", VM_OPC_TanhF32, [VM_ExtF32]> {
-  let summary = [{hyperbolic tangent of the specified value}];
+  let summary = [{Hyperbolic tangent of the specified value.}];
 }
 
 def VM_TanhF64Op :
     VM_TotalUnaryArithmeticOp<F64, "tanh.f64", VM_OPC_TanhF64, [VM_ExtF64]> {
-  let summary = [{hyperbolic tangent of the specified value}];
+  let summary = [{Hyperbolic tangent of the specified value.}];
 }
 
 def VM_ErfF32Op :
     VM_TotalUnaryArithmeticOp<F32, "erf.f32", VM_OPC_ErfF32, [VM_ExtF32]> {
-  let summary = [{computes the error function of the specified value}];
+  let summary = [{Computes the error function of the specified value.}];
 }
 
 def VM_ErfF64Op :
     VM_TotalUnaryArithmeticOp<F64, "erf.f64", VM_OPC_ErfF64, [VM_ExtF64]> {
-  let summary = [{computes the error function of the specified value}];
+  let summary = [{Computes the error function of the specified value.}];
 }
 
 } // OpGroupFloatingPointMathOps
@@ -2852,61 +2852,61 @@ let opDocGroup = OpGroupIntegerBitManipulationOps in {
 
 def VM_NotI32Op :
     VM_TotalUnaryArithmeticOp<I32, "not.i32", VM_OPC_NotI32> {
-  let summary = [{integer binary not operation}];
+  let summary = [{Integer binary not operation.}];
   let hasFolder = 1;
 }
 
 def VM_NotI64Op :
     VM_TotalUnaryArithmeticOp<I64, "not.i64", VM_OPC_NotI64> {
-  let summary = [{integer binary not operation}];
+  let summary = [{Integer binary not operation.}];
   let hasFolder = 1;
 }
 
 def VM_AndI32Op :
     VM_TotalBinaryArithmeticOp<I32, "and.i32", VM_OPC_AndI32, [Commutative]> {
-  let summary = [{integer binary and operation}];
+  let summary = [{Integer binary and operation.}];
   let hasFolder = 1;
 }
 
 def VM_AndI64Op :
     VM_TotalBinaryArithmeticOp<I64, "and.i64", VM_OPC_AndI64, [Commutative]> {
-  let summary = [{integer binary and operation}];
+  let summary = [{Integer binary and operation.}];
   let hasFolder = 1;
 }
 
 def VM_OrI32Op :
     VM_TotalBinaryArithmeticOp<I32, "or.i32", VM_OPC_OrI32, [Commutative]> {
-  let summary = [{integer binary or operation}];
+  let summary = [{Integer binary or operation.}];
   let hasFolder = 1;
 }
 
 def VM_OrI64Op :
     VM_TotalBinaryArithmeticOp<I64, "or.i64", VM_OPC_OrI64, [Commutative]> {
-  let summary = [{integer binary or operation}];
+  let summary = [{Integer binary or operation.}];
   let hasFolder = 1;
 }
 
 def VM_XorI32Op :
     VM_TotalBinaryArithmeticOp<I32, "xor.i32", VM_OPC_XorI32, [Commutative]> {
-  let summary = [{integer binary exclusive-or operation}];
+  let summary = [{Integer binary exclusive-or operation.}];
   let hasFolder = 1;
 }
 
 def VM_XorI64Op :
     VM_TotalBinaryArithmeticOp<I64, "xor.i64", VM_OPC_XorI64, [Commutative]> {
-  let summary = [{integer binary exclusive-or operation}];
+  let summary = [{Integer binary exclusive-or operation.}];
   let hasFolder = 1;
 }
 
 def VM_CtlzI32Op :
     VM_TotalUnaryArithmeticOp<I32, "ctlz.i32", VM_OPC_CtlzI32> {
-  let summary = [{counts the leading zeros in an integer value}];
+  let summary = [{Counts the leading zeros in an integer value.}];
   let hasFolder = 1;
 }
 
 def VM_CtlzI64Op :
     VM_TotalUnaryArithmeticOp<I64, "ctlz.i64", VM_OPC_CtlzI64> {
-  let summary = [{counts the leading zeros in an integer value}];
+  let summary = [{Counts the leading zeros in an integer value.}];
   let hasFolder = 1;
 }
 
@@ -2954,32 +2954,32 @@ class VM_ShiftArithmeticOp<I type, string mnemonic, VM_OPC opcode,
 }
 
 def VM_ShlI32Op : VM_ShiftArithmeticOp<I32, "shl.i32", VM_OPC_ShlI32> {
-  let summary = [{integer shift left operation}];
+  let summary = [{Integer shift left operation.}];
   let hasFolder = 1;
 }
 
 def VM_ShlI64Op : VM_ShiftArithmeticOp<I64, "shl.i64", VM_OPC_ShlI64> {
-  let summary = [{integer shift left operation}];
+  let summary = [{Integer shift left operation.}];
   let hasFolder = 1;
 }
 
 def VM_ShrI32SOp : VM_ShiftArithmeticOp<I32, "shr.i32.s", VM_OPC_ShrI32S> {
-  let summary = [{signed integer (arithmetic) shift right operation}];
+  let summary = [{Signed integer (arithmetic) shift right operation.}];
   let hasFolder = 1;
 }
 
 def VM_ShrI64SOp : VM_ShiftArithmeticOp<I64, "shr.i64.s", VM_OPC_ShrI64S> {
-  let summary = [{signed integer (arithmetic) shift right operation}];
+  let summary = [{Signed integer (arithmetic) shift right operation.}];
   let hasFolder = 1;
 }
 
 def VM_ShrI32UOp : VM_ShiftArithmeticOp<I32, "shr.i32.u", VM_OPC_ShrI32U> {
-  let summary = [{unsigned integer (logical) shift right operation}];
+  let summary = [{Unsigned integer (logical) shift right operation.}];
   let hasFolder = 1;
 }
 
 def VM_ShrI64UOp : VM_ShiftArithmeticOp<I64, "shr.i64.u", VM_OPC_ShrI64U> {
-  let summary = [{unsigned integer (logical) shift right operation}];
+  let summary = [{Unsigned integer (logical) shift right operation.}];
   let hasFolder = 1;
 }
 
@@ -3038,227 +3038,227 @@ class VM_ConversionPseudoOp<Type src_type, Type dst_type, string mnemonic,
 
 def VM_TruncI16I8Op :
     VM_ConversionPseudoOp<I32, I32, "trunc.i16.i8"> {
-  let summary = [{integer truncate to 8 bits}];
+  let summary = [{Integer truncate to 8 bits.}];
   let hasFolder = 1;
 }
 
 def VM_TruncI32I8Op :
     VM_ConversionOp<I32, I32, "trunc.i32.i8", VM_OPC_TruncI32I8> {
-  let summary = [{integer truncate to 8 bits}];
+  let summary = [{Integer truncate to 8 bits.}];
   let hasFolder = 1;
 }
 
 def VM_TruncI32I16Op :
     VM_ConversionOp<I32, I32, "trunc.i32.i16", VM_OPC_TruncI32I16> {
-  let summary = [{integer truncate to 16 bits}];
+  let summary = [{Integer truncate to 16 bits.}];
   let hasFolder = 1;
 }
 
 def VM_TruncI64I8Op :
     VM_ConversionPseudoOp<I64, I32, "trunc.i64.i8"> {
-  let summary = [{integer truncate to 8 bits}];
+  let summary = [{Integer truncate to 8 bits.}];
   let hasFolder = 1;
 }
 
 def VM_TruncI64I16Op :
     VM_ConversionPseudoOp<I64, I32, "trunc.i64.i16"> {
-  let summary = [{integer truncate to 16 bits}];
+  let summary = [{Integer truncate to 16 bits.}];
   let hasFolder = 1;
 }
 
 def VM_TruncI64I32Op :
     VM_ConversionOp<I64, I32, "trunc.i64.i32", VM_OPC_TruncI64I32> {
-  let summary = [{integer truncate to 32 bits}];
+  let summary = [{Integer truncate to 32 bits.}];
   let hasFolder = 1;
 }
 
 def VM_TruncF64F32Op :
     VM_ConversionOp<F64, F32, "trunc.f64.f32", VM_OPC_TruncF64F32,
                     [VM_ExtF64]> {
-  let summary = [{floating-point truncate to 32 bits}];
+  let summary = [{Floating-point truncate to 32 bits.}];
   let hasFolder = 1;
 }
 
 def VM_ExtI8I32SOp :
     VM_ConversionOp<I32, I32, "ext.i8.i32.s", VM_OPC_ExtI8I32S> {
-  let summary = [{integer sign extend 8 bits to 32 bits}];
+  let summary = [{Integer sign extend 8 bits to 32 bits.}];
   let hasFolder = 1;
 }
 
 def VM_ExtI8I32UOp :
     VM_ConversionOp<I32, I32, "ext.i8.i32.u", VM_OPC_ExtI8I32U> {
-  let summary = [{integer zero extend 8 bits to 32 bits}];
+  let summary = [{Integer zero extend 8 bits to 32 bits.}];
   let hasFolder = 1;
 }
 
 def VM_ExtI16I32SOp :
     VM_ConversionOp<I32, I32, "ext.i16.i32.s", VM_OPC_ExtI16I32S> {
-  let summary = [{integer sign extend 16 bits to 32 bits}];
+  let summary = [{Integer sign extend 16 bits to 32 bits.}];
   let hasFolder = 1;
 }
 
 def VM_ExtI16I32UOp :
     VM_ConversionOp<I32, I32, "ext.i16.i32.u", VM_OPC_ExtI16I32U> {
-  let summary = [{integer zero extend 16 bits to 32 bits}];
+  let summary = [{Integer zero extend 16 bits to 32 bits.}];
   let hasFolder = 1;
 }
 
 def VM_ExtI8I64SOp :
     VM_ConversionPseudoOp<I32, I64, "ext.i8.i64.s"> {
-  let summary = [{integer sign extend 8 bits to 64 bits}];
+  let summary = [{Integer sign extend 8 bits to 64 bits.}];
   let hasFolder = 1;
 }
 
 def VM_ExtI8I64UOp :
     VM_ConversionPseudoOp<I32, I64, "ext.i8.i64.u"> {
-  let summary = [{integer zero extend 8 bits to 64 bits}];
+  let summary = [{Integer zero extend 8 bits to 64 bits.}];
   let hasFolder = 1;
 }
 
 def VM_ExtI16I64SOp :
     VM_ConversionPseudoOp<I32, I64, "ext.i16.i64.s"> {
-  let summary = [{integer sign extend 16 bits to 64 bits}];
+  let summary = [{Integer sign extend 16 bits to 64 bits.}];
   let hasFolder = 1;
 }
 
 def VM_ExtI16I64UOp :
     VM_ConversionPseudoOp<I32, I64, "ext.i16.i64.u"> {
-  let summary = [{integer zero extend 16 bits to 64 bits}];
+  let summary = [{Integer zero extend 16 bits to 64 bits.}];
   let hasFolder = 1;
 }
 
 def VM_ExtI32I64SOp :
     VM_ConversionOp<I32, I64, "ext.i32.i64.s", VM_OPC_ExtI32I64S> {
-  let summary = [{integer sign extend 32 bits to 64 bits}];
+  let summary = [{Integer sign extend 32 bits to 64 bits.}];
   let hasFolder = 1;
 }
 
 def VM_ExtI32I64UOp :
     VM_ConversionOp<I32, I64, "ext.i32.i64.u", VM_OPC_ExtI32I64U> {
-  let summary = [{integer zero extend 32 bits to 64 bits}];
+  let summary = [{Integer zero extend 32 bits to 64 bits.}];
   let hasFolder = 1;
 }
 
 def VM_ExtF32F64Op :
     VM_ConversionOp<F32, F64, "ext.f32.f64", VM_OPC_ExtF32F64,
                     [VM_ExtF64]> {
-  let summary = [{floating-point zero extend 32 bits to 64 bits}];
+  let summary = [{Floating-point zero extend 32 bits to 64 bits.}];
   let hasFolder = 1;
 }
 
 def VM_CastSI32F32Op :
     VM_ConversionOp<I32, F32, "cast.si32.f32", VM_OPC_CastSI32F32,
                     [VM_ExtF32]> {
-  let summary = [{cast from a signed integer to a float-point value}];
+  let summary = [{Cast from a signed integer to a float-point value.}];
   let hasFolder = 1;
 }
 
 def VM_CastSI64F32Op :
     VM_ConversionOp<I64, F32, "cast.si64.f32", VM_OPC_CastSI64F32,
                     [VM_ExtF32]> {
-  let summary = [{cast from a signed integer to a float-point value}];
+  let summary = [{Cast from a signed integer to a float-point value.}];
   let hasFolder = 1;
 }
 
 def VM_CastSI64F64Op :
     VM_ConversionOp<I64, F64, "cast.si64.f64", VM_OPC_CastSI64F64,
                     [VM_ExtF64]> {
-  let summary = [{cast from a signed integer to a float-point value}];
+  let summary = [{Cast from a signed integer to a float-point value.}];
   let hasFolder = 1;
 }
 
 def VM_CastUI32F32Op :
     VM_ConversionOp<I32, F32, "cast.ui32.f32", VM_OPC_CastUI32F32,
                     [VM_ExtF32]> {
-  let summary = [{cast from an unsigned integer to a float-point value}];
+  let summary = [{Cast from an unsigned integer to a float-point value.}];
   let hasFolder = 1;
 }
 
 def VM_CastUI64F32Op :
     VM_ConversionOp<I64, F32, "cast.ui64.f32", VM_OPC_CastUI64F32,
                     [VM_ExtF32]> {
-  let summary = [{cast from an unsigned integer to a float-point value}];
+  let summary = [{Cast from an unsigned integer to a float-point value.}];
   let hasFolder = 1;
 }
 
 def VM_CastUI64F64Op :
     VM_ConversionOp<I64, F64, "cast.ui64.f64", VM_OPC_CastUI64F64,
                     [VM_ExtF64]> {
-  let summary = [{cast from an unsigned integer to a float-point value}];
+  let summary = [{Cast from an unsigned integer to a float-point value.}];
   let hasFolder = 1;
 }
 
 def VM_CastF32SI32Op :
     VM_ConversionOp<F32, I32, "cast.f32.si32", VM_OPC_CastF32SI32,
                     [VM_ExtF32]> {
-  let summary = [{cast from a float-point value to a signed 32-bit integer}];
+  let summary = [{Cast from a float-point value to a signed 32-bit integer.}];
   let hasFolder = 1;
 }
 
 def VM_CastF32SI64Op :
     VM_ConversionOp<F32, I64, "cast.f32.si64", VM_OPC_CastF32SI64,
                     [VM_ExtF32]> {
-  let summary = [{cast from a float-point value to a signed 64-bit integer}];
+  let summary = [{Cast from a float-point value to a signed 64-bit integer.}];
   let hasFolder = 1;
 }
 
 def VM_CastF32UI32Op :
     VM_ConversionOp<F32, I32, "cast.f32.ui32", VM_OPC_CastF32UI32,
                     [VM_ExtF32]> {
-  let summary = [{cast from an float-point value to an unsigned 32-bit integer}];
+  let summary = [{Cast from an float-point value to an unsigned 32-bit integer.}];
   let hasFolder = 1;
 }
 
 def VM_CastF32UI64Op :
     VM_ConversionOp<F32, I64, "cast.f32.ui64", VM_OPC_CastF32UI64,
                     [VM_ExtF32]> {
-  let summary = [{cast from an float-point value to an unsigned 64-bit integer}];
+  let summary = [{Cast from an float-point value to an unsigned 64-bit integer.}];
   let hasFolder = 1;
 }
 
 def VM_CastF64SI64Op :
     VM_ConversionOp<F64, I64, "cast.f64.si64", VM_OPC_CastF64SI64,
                     [VM_ExtF64]> {
-  let summary = [{cast from a float-point value to a signed integer}];
+  let summary = [{Cast from a float-point value to a signed integer.}];
   let hasFolder = 1;
 }
 
 def VM_CastF64UI64Op :
     VM_ConversionOp<F64, I64, "cast.f64.ui64", VM_OPC_CastF64UI64,
                     [VM_ExtF64]> {
-  let summary = [{cast from an float-point value to an unsigned integer}];
+  let summary = [{Cast from an float-point value to an unsigned integer.}];
   let hasFolder = 1;
 }
 
 def VM_BitcastI32F32Op :
     VM_ConversionOp<I32, F32, "bitcast.i32.f32", VM_OPC_BitcastI32F32,
                     [VM_ExtF32]> {
-  let summary = [{bitcast from a 32-bit integer to a 32-bit float-point value}];
+  let summary = [{Bitcast from a 32-bit integer to a 32-bit float-point value.}];
 }
 
 def VM_BitcastF32I32Op :
     VM_ConversionOp<F32, I32, "bitcast.f32.i32", VM_OPC_BitcastF32I32,
                     [VM_ExtF32]> {
-  let summary = [{bitcast from a 32-bit float-point value to a 32-bit integer}];
+  let summary = [{Bitcast from a 32-bit float-point value to a 32-bit integer.}];
 }
 
 def VM_BitcastI64F64Op :
     VM_ConversionOp<I64, F64, "bitcast.i64.f64", VM_OPC_BitcastI64F64,
                     [VM_ExtF64]> {
-  let summary = [{bitcast from a 64-bit integer to a 64-bit float-point value}];
+  let summary = [{Bitcast from a 64-bit integer to a 64-bit float-point value.}];
 }
 
 def VM_BitcastF64I64Op :
     VM_ConversionOp<F64, I64, "bitcast.f64.i64", VM_OPC_BitcastF64I64,
                     [VM_ExtF64]> {
-  let summary = [{bitcast from a 64-bit float-point value to a 64-bit integer}];
+  let summary = [{Bitcast from a 64-bit float-point value to a 64-bit integer.}];
 }
 
 def VM_CastAnyRefOp :
     VM_PureOp<"cast.any.ref", [
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
     ]> {
-  let summary = [{casts from any ref to a specific ref type}];
+  let summary = [{Casts from any ref to a specific ref type.}];
   let description = [{
     Performs a runtime cast of an opaque `!vm.ref<?>` to a specific `!vm.ref<T>`
     and raises an error if the operand does not match the expected type.
@@ -3289,7 +3289,7 @@ def VM_CastAnyRefOp :
 
 def VM_CastRefAnyOp :
     VM_PureOp<"cast.ref.any", [VM_AssignmentOp]> {
-  let summary = [{casts from a specific ref to any ref type}];
+  let summary = [{Casts from a specific ref to any ref type.}];
   let description = [{
     Performs a compile-time widening cast of a specific `!vm.ref<T>` to an
     opaque `!vm.ref<?>`.
@@ -3435,7 +3435,7 @@ def VM_CmpEQI32Op :
         Commutative,
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{integer equality comparison operation}];
+  let summary = [{Integer equality comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3445,7 +3445,7 @@ def VM_CmpEQI64Op :
         Commutative,
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{integer equality comparison operation}];
+  let summary = [{Integer equality comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3455,7 +3455,7 @@ def VM_CmpNEI32Op :
         Commutative,
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{integer inequality comparison operation}];
+  let summary = [{Integer inequality comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3465,7 +3465,7 @@ def VM_CmpNEI64Op :
         Commutative,
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{integer inequality comparison operation}];
+  let summary = [{Integer inequality comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3474,7 +3474,7 @@ def VM_CmpLTI32SOp :
     VM_BinaryComparisonOp<I32, "cmp.lt.i32.s", VM_OPC_CmpLTI32S, [
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{signed integer less-than comparison operation}];
+  let summary = [{Signed integer less-than comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3483,7 +3483,7 @@ def VM_CmpLTI64SOp :
     VM_BinaryComparisonOp<I64, "cmp.lt.i64.s", VM_OPC_CmpLTI64S, [
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{signed integer less-than comparison operation}];
+  let summary = [{Signed integer less-than comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3492,7 +3492,7 @@ def VM_CmpLTI32UOp :
     VM_BinaryComparisonOp<I32, "cmp.lt.i32.u", VM_OPC_CmpLTI32U, [
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{unsigned integer less-than comparison operation}];
+  let summary = [{Unsigned integer less-than comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3501,7 +3501,7 @@ def VM_CmpLTI64UOp :
     VM_BinaryComparisonOp<I64, "cmp.lt.i64.u", VM_OPC_CmpLTI64U, [
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{unsigned integer less-than comparison operation}];
+  let summary = [{Unsigned integer less-than comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3510,7 +3510,7 @@ def VM_CmpLTEI32SOp :
     VM_BinaryComparisonPseudoOp<I32, "cmp.lte.i32.s", [
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{signed integer less-than-or-equal comparison operation}];
+  let summary = [{Signed integer less-than-or-equal comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3519,7 +3519,7 @@ def VM_CmpLTEI64SOp :
     VM_BinaryComparisonPseudoOp<I64, "cmp.lte.i64.s", [
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{signed integer less-than-or-equal comparison operation}];
+  let summary = [{Signed integer less-than-or-equal comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3528,7 +3528,7 @@ def VM_CmpLTEI32UOp :
     VM_BinaryComparisonPseudoOp<I32, "cmp.lte.i32.u", [
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{unsigned integer less-than-or-equal comparison operation}];
+  let summary = [{Unsigned integer less-than-or-equal comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3537,7 +3537,7 @@ def VM_CmpLTEI64UOp :
     VM_BinaryComparisonPseudoOp<I64, "cmp.lte.i64.u", [
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{unsigned integer less-than-or-equal comparison operation}];
+  let summary = [{Unsigned integer less-than-or-equal comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3546,7 +3546,7 @@ def VM_CmpGTI32SOp :
     VM_BinaryComparisonPseudoOp<I32, "cmp.gt.i32.s", [
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{signed integer greater-than comparison operation}];
+  let summary = [{Signed integer greater-than comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3555,7 +3555,7 @@ def VM_CmpGTI64SOp :
     VM_BinaryComparisonPseudoOp<I64, "cmp.gt.i64.s", [
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{signed integer greater-than comparison operation}];
+  let summary = [{Signed integer greater-than comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3564,7 +3564,7 @@ def VM_CmpGTI32UOp :
     VM_BinaryComparisonPseudoOp<I32, "cmp.gt.i32.u", [
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{unsigned integer greater-than comparison operation}];
+  let summary = [{Unsigned integer greater-than comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3573,7 +3573,7 @@ def VM_CmpGTI64UOp :
     VM_BinaryComparisonPseudoOp<I64, "cmp.gt.i64.u", [
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{unsigned integer greater-than comparison operation}];
+  let summary = [{Unsigned integer greater-than comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3582,7 +3582,7 @@ def VM_CmpGTEI32SOp :
     VM_BinaryComparisonPseudoOp<I32, "cmp.gte.i32.s", [
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{signed integer greater-than-or-equal comparison operation}];
+  let summary = [{Signed integer greater-than-or-equal comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3591,7 +3591,7 @@ def VM_CmpGTEI64SOp :
     VM_BinaryComparisonPseudoOp<I64, "cmp.gte.i64.s", [
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{signed integer greater-than-or-equal comparison operation}];
+  let summary = [{Signed integer greater-than-or-equal comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3600,7 +3600,7 @@ def VM_CmpGTEI32UOp :
     VM_BinaryComparisonPseudoOp<I32, "cmp.gte.i32.u", [
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{unsigned integer greater-than-or-equal comparison operation}];
+  let summary = [{Unsigned integer greater-than-or-equal comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3609,7 +3609,7 @@ def VM_CmpGTEI64UOp :
     VM_BinaryComparisonPseudoOp<I64, "cmp.gte.i64.u", [
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{unsigned integer greater-than-or-equal comparison operation}];
+  let summary = [{Unsigned integer greater-than-or-equal comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3618,7 +3618,7 @@ def VM_CmpNZI32Op :
     VM_UnaryComparisonOp<I32, "cmp.nz.i32", VM_OPC_CmpNZI32, [
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{integer non-zero comparison operation}];
+  let summary = [{Integer non-zero comparison operation.}];
   let description = [{
     Compares the given integer operand for a non-zero value.
   }];
@@ -3629,7 +3629,7 @@ def VM_CmpNZI64Op :
     VM_UnaryComparisonOp<I64, "cmp.nz.i64", VM_OPC_CmpNZI64, [
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{integer non-zero comparison operation}];
+  let summary = [{Integer non-zero comparison operation.}];
   let description = [{
     Compares the given integer operand for a non-zero value.
   }];
@@ -3652,7 +3652,7 @@ let opDocGroup = OpGroupFloatingPointComparisonOps in {
 def VM_CmpEQF32OOp :
     VM_BinaryComparisonOp<F32, "cmp.eq.f32.o", VM_OPC_CmpEQF32O,
                           [VM_ExtF32, Commutative]> {
-  let summary = [{ordered floating-point equality comparison operation}];
+  let summary = [{Ordered floating-point equality comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3660,7 +3660,7 @@ def VM_CmpEQF32OOp :
 def VM_CmpEQF64OOp :
     VM_BinaryComparisonOp<F64, "cmp.eq.f64.o", VM_OPC_CmpEQF64O,
                           [VM_ExtF64, Commutative]> {
-  let summary = [{ordered floating-point equality comparison operation}];
+  let summary = [{Ordered floating-point equality comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3668,7 +3668,7 @@ def VM_CmpEQF64OOp :
 def VM_CmpEQF32UOp :
     VM_BinaryComparisonOp<F32, "cmp.eq.f32.u", VM_OPC_CmpEQF32U,
                           [VM_ExtF32, Commutative]> {
-  let summary = [{unordered floating-point equality comparison operation}];
+  let summary = [{Unordered floating-point equality comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3676,7 +3676,7 @@ def VM_CmpEQF32UOp :
 def VM_CmpEQF64UOp :
     VM_BinaryComparisonOp<F64, "cmp.eq.f64.u", VM_OPC_CmpEQF64U,
                           [VM_ExtF64, Commutative]> {
-  let summary = [{unordered floating-point equality comparison operation}];
+  let summary = [{Unordered floating-point equality comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3684,7 +3684,7 @@ def VM_CmpEQF64UOp :
 def VM_CmpEQF32NearOp :
     VM_BinaryComparisonPseudoOp<F32, "cmp.eq.f32.near",
                           [VM_ExtF32, Commutative]> {
-  let summary = [{near floating-point equality comparison operation}];
+  let summary = [{Near floating-point equality comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3692,7 +3692,7 @@ def VM_CmpEQF32NearOp :
 def VM_CmpEQF64NearOp :
     VM_BinaryComparisonPseudoOp<F64, "cmp.eq.f64.near",
                           [VM_ExtF64, Commutative]> {
-  let summary = [{near floating-point equality comparison operation}];
+  let summary = [{Near floating-point equality comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3700,7 +3700,7 @@ def VM_CmpEQF64NearOp :
 def VM_CmpNEF32OOp :
     VM_BinaryComparisonOp<F32, "cmp.ne.f32.o", VM_OPC_CmpNEF32O,
                           [VM_ExtF32, Commutative]> {
-  let summary = [{ordered floating-point inequality comparison operation}];
+  let summary = [{Ordered floating-point inequality comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3708,7 +3708,7 @@ def VM_CmpNEF32OOp :
 def VM_CmpNEF64OOp :
     VM_BinaryComparisonOp<F64, "cmp.ne.f64.o", VM_OPC_CmpNEF64O,
                           [VM_ExtF64, Commutative]> {
-  let summary = [{ordered floating-point inequality comparison operation}];
+  let summary = [{Ordered floating-point inequality comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3716,7 +3716,7 @@ def VM_CmpNEF64OOp :
 def VM_CmpNEF32UOp :
     VM_BinaryComparisonOp<F32, "cmp.ne.f32.u", VM_OPC_CmpNEF32U,
                           [VM_ExtF32, Commutative]> {
-  let summary = [{unordered floating-point inequality comparison operation}];
+  let summary = [{Unordered floating-point inequality comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3724,7 +3724,7 @@ def VM_CmpNEF32UOp :
 def VM_CmpNEF64UOp :
     VM_BinaryComparisonOp<F64, "cmp.ne.f64.u", VM_OPC_CmpNEF64U,
                           [VM_ExtF64, Commutative]> {
-  let summary = [{unordered floating-point inequality comparison operation}];
+  let summary = [{Unordered floating-point inequality comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3732,7 +3732,7 @@ def VM_CmpNEF64UOp :
 def VM_CmpLTF32OOp :
     VM_BinaryComparisonOp<F32, "cmp.lt.f32.o", VM_OPC_CmpLTF32O,
                           [VM_ExtF32]> {
-  let summary = [{ordered floating-point less-than comparison operation}];
+  let summary = [{Ordered floating-point less-than comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3740,7 +3740,7 @@ def VM_CmpLTF32OOp :
 def VM_CmpLTF64OOp :
     VM_BinaryComparisonOp<F64, "cmp.lt.f64.o", VM_OPC_CmpLTF64O,
                           [VM_ExtF64]> {
-  let summary = [{ordered floating-point less-than comparison operation}];
+  let summary = [{Ordered floating-point less-than comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3748,7 +3748,7 @@ def VM_CmpLTF64OOp :
 def VM_CmpLTF32UOp :
     VM_BinaryComparisonOp<F32, "cmp.lt.f32.u", VM_OPC_CmpLTF32U,
                           [VM_ExtF32]> {
-  let summary = [{unordered floating-point less-than comparison operation}];
+  let summary = [{Unordered floating-point less-than comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3756,7 +3756,7 @@ def VM_CmpLTF32UOp :
 def VM_CmpLTF64UOp :
     VM_BinaryComparisonOp<F64, "cmp.lt.f64.u", VM_OPC_CmpLTF64U,
                           [VM_ExtF64]> {
-  let summary = [{unordered floating-point less-than comparison operation}];
+  let summary = [{Unordered floating-point less-than comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3764,35 +3764,35 @@ def VM_CmpLTF64UOp :
 def VM_CmpLTEF32OOp :
     VM_BinaryComparisonOp<F32, "cmp.lte.f32.o", VM_OPC_CmpLTEF32O,
                                 [VM_ExtF32]> {
-  let summary = [{ordered floating-point less-than-or-equal comparison operation}];
+  let summary = [{Ordered floating-point less-than-or-equal comparison operation.}];
   let hasFolder = 1;
 }
 
 def VM_CmpLTEF64OOp :
     VM_BinaryComparisonOp<F64, "cmp.lte.f64.o", VM_OPC_CmpLTEF64O,
                           [VM_ExtF64]> {
-  let summary = [{ordered floating-point less-than-or-equal comparison operation}];
+  let summary = [{Ordered floating-point less-than-or-equal comparison operation.}];
   let hasFolder = 1;
 }
 
 def VM_CmpLTEF32UOp :
     VM_BinaryComparisonOp<F32, "cmp.lte.f32.u", VM_OPC_CmpLTEF32U,
                           [VM_ExtF32]> {
-  let summary = [{unordered floating-point less-than-or-equal comparison operation}];
+  let summary = [{Unordered floating-point less-than-or-equal comparison operation.}];
   let hasFolder = 1;
 }
 
 def VM_CmpLTEF64UOp :
     VM_BinaryComparisonOp<F64, "cmp.lte.f64.u", VM_OPC_CmpLTEF64U,
                           [VM_ExtF64]> {
-  let summary = [{unordered floating-point less-than-or-equal comparison operation}];
+  let summary = [{Unordered floating-point less-than-or-equal comparison operation.}];
   let hasFolder = 1;
 }
 
 def VM_CmpGTF32OOp :
     VM_BinaryComparisonPseudoOp<F32, "cmp.gt.f32.o",
                                 [VM_ExtF32]> {
-  let summary = [{ordered floating-point greater-than comparison operation}];
+  let summary = [{Ordered floating-point greater-than comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3800,7 +3800,7 @@ def VM_CmpGTF32OOp :
 def VM_CmpGTF64OOp :
     VM_BinaryComparisonPseudoOp<F64, "cmp.gt.f64.o",
                                 [VM_ExtF64]> {
-  let summary = [{ordered floating-point greater-than comparison operation}];
+  let summary = [{Ordered floating-point greater-than comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3808,7 +3808,7 @@ def VM_CmpGTF64OOp :
 def VM_CmpGTF32UOp :
     VM_BinaryComparisonPseudoOp<F32, "cmp.gt.f32.u",
                                 [VM_ExtF32]> {
-  let summary = [{unordered floating-point greater-than comparison operation}];
+  let summary = [{Unordered floating-point greater-than comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3816,7 +3816,7 @@ def VM_CmpGTF32UOp :
 def VM_CmpGTF64UOp :
     VM_BinaryComparisonPseudoOp<F64, "cmp.gt.f64.u",
                                 [VM_ExtF64]> {
-  let summary = [{unordered floating-point greater-than comparison operation}];
+  let summary = [{Unordered floating-point greater-than comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3824,7 +3824,7 @@ def VM_CmpGTF64UOp :
 def VM_CmpGTEF32OOp :
     VM_BinaryComparisonPseudoOp<F32, "cmp.gte.f32.o",
                                 [VM_ExtF32]> {
-  let summary = [{ordered floating-point greater-than-or-equal comparison operation}];
+  let summary = [{Ordered floating-point greater-than-or-equal comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3832,7 +3832,7 @@ def VM_CmpGTEF32OOp :
 def VM_CmpGTEF64OOp :
     VM_BinaryComparisonPseudoOp<F64, "cmp.gte.f64.o",
                                 [VM_ExtF64]> {
-  let summary = [{ordered floating-point greater-than-or-equal comparison operation}];
+  let summary = [{Ordered floating-point greater-than-or-equal comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3840,7 +3840,7 @@ def VM_CmpGTEF64OOp :
 def VM_CmpGTEF32UOp :
     VM_BinaryComparisonPseudoOp<F32, "cmp.gte.f32.u",
                                 [VM_ExtF32]> {
-  let summary = [{unordered floating-point greater-than-or-equal comparison operation}];
+  let summary = [{Unordered floating-point greater-than-or-equal comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3848,7 +3848,7 @@ def VM_CmpGTEF32UOp :
 def VM_CmpGTEF64UOp :
     VM_BinaryComparisonPseudoOp<F64, "cmp.gte.f64.u",
                                 [VM_ExtF64]> {
-  let summary = [{unordered floating-point greater-than-or-equal comparison operation}];
+  let summary = [{Unordered floating-point greater-than-or-equal comparison operation.}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3856,7 +3856,7 @@ def VM_CmpGTEF64UOp :
 def VM_CmpNZF32OOp :
     VM_UnaryComparisonPseudoOp<F32, "cmp.nz.f32.o",
                                [VM_ExtF32]> {
-  let summary = [{ordered floating-point non-zero comparison operation}];
+  let summary = [{Ordered floating-point non-zero comparison operation.}];
   let description = [{
     Compares the given floating-point operand for a non-zero value.
   }];
@@ -3867,7 +3867,7 @@ def VM_CmpNZF32OOp :
 def VM_CmpNZF64OOp :
     VM_UnaryComparisonPseudoOp<F64, "cmp.nz.f64.o",
                                [VM_ExtF64]> {
-  let summary = [{ordered floating-point non-zero comparison operation}];
+  let summary = [{Ordered floating-point non-zero comparison operation.}];
   let description = [{
     Compares the given floating-point operand for a non-zero value.
   }];
@@ -3878,7 +3878,7 @@ def VM_CmpNZF64OOp :
 def VM_CmpNZF32UOp :
     VM_UnaryComparisonPseudoOp<F32, "cmp.nz.f32.u",
                                [VM_ExtF32]> {
-  let summary = [{unordered floating-point non-zero comparison operation}];
+  let summary = [{Unordered floating-point non-zero comparison operation.}];
   let description = [{
     Compares the given floating-point operand for a non-zero value.
   }];
@@ -3889,7 +3889,7 @@ def VM_CmpNZF32UOp :
 def VM_CmpNZF64UOp :
     VM_UnaryComparisonPseudoOp<F64, "cmp.nz.f64.u",
                                [VM_ExtF64]> {
-  let summary = [{unordered floating-point non-zero comparison operation}];
+  let summary = [{Unordered floating-point non-zero comparison operation.}];
   let description = [{
     Compares the given floating-point operand for a non-zero value.
   }];
@@ -3900,7 +3900,7 @@ def VM_CmpNZF64UOp :
 def VM_CmpNaNF32Op :
     VM_UnaryComparisonOp<F32, "cmp.nan.f32", VM_OPC_CmpNaNF32,
                          [VM_ExtF32]> {
-  let summary = [{floating-point NaN comparison operation}];
+  let summary = [{Floating-point NaN comparison operation.}];
   let description = [{
     Returns 1 if the value is NaN.
   }];
@@ -3910,7 +3910,7 @@ def VM_CmpNaNF32Op :
 def VM_CmpNaNF64Op :
     VM_UnaryComparisonOp<F64, "cmp.nan.f64", VM_OPC_CmpNaNF64,
                          [VM_ExtF64]> {
-  let summary = [{floating-point NaN comparison operation}];
+  let summary = [{Floating-point NaN comparison operation.}];
   let description = [{
     Returns 1 if the value is NaN.
   }];
@@ -3935,7 +3935,7 @@ def VM_CmpEQRefOp :
         Commutative,
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{ref<T> equality comparison operation}];
+  let summary = [{ref<T> equality comparison operation.}];
   let hasFolder = 1;
   let hasCanonicalizer = 1;
 }
@@ -3946,7 +3946,7 @@ def VM_CmpNERefOp :
         Commutative,
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{ref<T> inequality comparison operation}];
+  let summary = [{ref<T> inequality comparison operation.}];
   let hasFolder = 1;
   let hasCanonicalizer = 1;
 }
@@ -3955,7 +3955,7 @@ def VM_CmpNZRefOp :
     VM_UnaryComparisonOp<VM_AnyRef, "cmp.nz.ref", VM_OPC_CmpNZRef, [
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
     ]> {
-  let summary = [{ref<T> non-zero comparison operation}];
+  let summary = [{ref<T> non-zero comparison operation.}];
   let description = [{
     Compares the given ref operand for a non-zero/null value.
   }];
@@ -3980,7 +3980,7 @@ def VM_BranchOp : VM_Op<"br", [
     DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
     Terminator,
   ]> {
-  let summary = [{unconditional branch operation}];
+  let summary = [{Unconditional branch operation.}];
   let description = [{
     Represents an unconditional branch operation that branches to a target block
     with the given set of arguments.
@@ -4034,7 +4034,7 @@ def VM_CondBranchOp : VM_Op<"cond_br", [
     DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
     Terminator,
   ]> {
-  let summary = [{conditional branch operation}];
+  let summary = [{Conditional branch operation.}];
   let description = [{
     Represents a conditional branch operation that branches to one of the two
     target blocks with the given set of arguments.
@@ -4152,7 +4152,7 @@ def VM_BranchTableOp : VM_PureOp<"br_table", [
     DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
     Terminator,
   ]> {
-  let summary = [{branch table operation}];
+  let summary = [{Branch table operation.}];
   let description = [{
     Represents a branch table instructing execution to branch to the block with
     the specified index. If the index is out of bounds then execution will
@@ -4242,7 +4242,7 @@ class VM_CallBaseOp<string mnemonic, list<Trait> traits = []> :
 }
 
 def VM_CallOp : VM_CallBaseOp<"call"> {
-  let summary = [{call operation}];
+  let summary = [{Call operation.}];
   let description = [{
     Calls an internal VM function with the given arguments.
   }];
@@ -4297,7 +4297,7 @@ def VM_CallOp : VM_CallBaseOp<"call"> {
 }
 
 def VM_CallVariadicOp : VM_CallBaseOp<"call.variadic"> {
-  let summary = [{call operation with variadic arguments}];
+  let summary = [{Call operation with variadic arguments.}];
   let description = [{
     Calls an internal VM function with the given arguments. One or more of the
     arguments may be variadic, encoded as segmented sized operand lists.
@@ -4358,7 +4358,7 @@ def VM_ReturnOp : VM_Op<"return", [
     ReturnLike,
     Terminator,
   ]> {
-  let summary = "return operation";
+  let summary = [{Return operation.}];
   let description = [{
     Represents a return operation within a function.
 
@@ -4394,7 +4394,7 @@ def VM_FailOp : VM_Op<"fail", [
     DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
     Terminator,
   ]> {
-  let summary = [{raises a global failure}];
+  let summary = [{Raises a global failure.}];
   let description = [{
     Signals a runtime failure that causes the entire active invocation - and
     possibly *all* in-flight and pending invocations - to fail with the given
@@ -4446,7 +4446,7 @@ def VM_FailOp : VM_Op<"fail", [
 def VM_CondFailOp : VM_Op<"cond_fail", [
     VM_PseudoOp,
   ]> {
-  let summary = [{raises a global failure if the condition is true}];
+  let summary = [{Raises a global failure if the condition is true.}];
   let description = [{
     When the condition is true this signals a runtime failure that causes the
     entire active invocation - and possibly *all* in-flight and pending
@@ -4502,7 +4502,7 @@ class VM_CheckOp<string mnemonic, list<Trait> traits = []> :
     VM_Op<mnemonic, !listconcat(traits, [
       VM_PseudoOp,
     ])> {
-  let summary = [{raises a global failure if the condition is true}];
+  let summary = [{Raises a global failure if the condition is true.}];
   let description = [{
     When the condition is true this signals a runtime failure that causes the
     entire active invocation - and possibly *all* in-flight and pending
@@ -4587,7 +4587,7 @@ def VM_ImportResolvedOp : VM_TrivialOp<"import.resolved", [
   DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
 ]> {
-  let summary = [{returns true if an optional import was resolved at runtime}];
+  let summary = [{Returns true if an optional import was resolved at runtime.}];
   let description = [{
     Allows for checking whether a optional import was resolved at runtime. If
     this returns false then attempting to call the imported function will result
@@ -4639,7 +4639,7 @@ def VM_YieldOp : VM_Op<"yield", [
     Terminator,
     Util_YieldPoint,
   ]> {
-  let summary = [{unconditional fiber yield operation}];
+  let summary = [{Unconditional fiber yield operation.}];
   let description = [{
     Yields the fiber for some (likely short) amount of time. This can be used to
     perform cooperative scheduling and ensure fair (enough) execution. Execution
@@ -4703,7 +4703,7 @@ def VM_TraceOp : VM_Op<"trace", [
     VM_FullBarrier,
     VM_DebugOnly,
   ]> {
-  let summary = [{trace value(s) operation}];
+  let summary = [{Trace value(s) operation.}];
   let description = [{
     Traces one or more values at the time the operation is executed.
     These values will be encoded into the active trace depending on the active
@@ -4733,7 +4733,7 @@ def VM_PrintOp : VM_Op<"print", [
     VM_FullBarrier,
     VM_DebugOnly,
   ]> {
-  let summary = [{message printing operation}];
+  let summary = [{Message printing operation.}];
   let description = [{
     Prints the given string message and zero or more values.
   }];
@@ -4764,7 +4764,7 @@ def VM_BreakOp : VM_Op<"break", [
     VM_FullBarrier,
     VM_DebugOnly,
   ]> {
-  let summary = [{unconditional debug break operation}];
+  let summary = [{Unconditional debug break operation.}];
   let description = [{
     Breaks into the attached debugger or asks for attaching a debugger. After
     resuming (or if a debugger is not attached) execution will continue at the
@@ -4814,7 +4814,7 @@ def VM_CondBreakOp : VM_Op<"cond_break", [
     VM_FullBarrier,
     VM_DebugOnly,
   ]> {
-  let summary = [{conditional debug break operation}];
+  let summary = [{Conditional debug break operation.}];
   let description = [{
     Breaks into the attached debugger or asks for attaching a debugger if the
     provided condition is true. After resuming (or if a debugger is not

--- a/compiler/src/iree/compiler/Dialect/VMVX/IR/VMVXOps.td
+++ b/compiler/src/iree/compiler/Dialect/VMVX/IR/VMVXOps.td
@@ -31,7 +31,7 @@ let opDocGroup = OpGroupUtilityOps in {
 def VMVX_GetBufferDescriptorOp : VMVX_PureOp<"get_buffer_descriptor", [
     SameVariadicResultSize
   ]> {
-  let summary = "Late binds a base buffer/offset/strides";
+  let summary = [{Late binds a base buffer/offset/strides.}];
   let description = [{
     Queries a base buffer, offset and strides. This op is late bound to its
     source (alloca, binding, etc), allowing additional layers of
@@ -60,7 +60,7 @@ def VMVX_GetBufferDescriptorOp : VMVX_PureOp<"get_buffer_descriptor", [
 
 def VMVX_GetRawInterfaceBindingBufferOp : VMVX_PureOp<
     "get_raw_interface_binding_buffer"> {
-  let summary = "Gets the raw buffer associated with a binding";
+  let summary = [{Gets the raw buffer associated with a binding.}];
   let description = [{
     Normally, a slice of a binding buffer is returned via
     hal.interface.binding.subspan. However, the normal VMVX lowering flow for
@@ -99,7 +99,7 @@ def OpGroupABIOps : OpDocGroup {
 let opDocGroup = OpGroupABIOps in {
 
 def VMVX_BinaryOp : VMVX_Op<"binary", [SameVariadicOperandSize]> {
-  let summary = "Performs a strided elementwise operation on two same-rank buffers";
+  let summary = [{Performs a strided elementwise operation on two same-rank buffers.}];
   let description = [{
     Performs the operation in-place as if:
     ```
@@ -142,7 +142,7 @@ def VMVX_BinaryOp : VMVX_Op<"binary", [SameVariadicOperandSize]> {
 }
 
 def VMVX_CopyOp : VMVX_Op<"copy", [SameVariadicOperandSize]> {
-  let summary = "Copy from one buffer to another";
+  let summary = [{Copy from one buffer to another.}];
   let arguments = (ins
     // LHS.
     VMVX_Buffer:$in_buffer,
@@ -169,7 +169,7 @@ def VMVX_CopyOp : VMVX_Op<"copy", [SameVariadicOperandSize]> {
 }
 
 def VMVX_Fill2DOp : VMVX_Op<"fill2d"> {
-  let summary = "Fill a tile with a scalar";
+  let summary = [{Fill a tile with a scalar.}];
   let description = [{
     Fills a tile with dimensions [m, n] with a scalar.
   }];
@@ -193,7 +193,7 @@ def VMVX_Fill2DOp : VMVX_Op<"fill2d"> {
 }
 
 def VMVX_UnaryOp : VMVX_Op<"unary", [SameVariadicOperandSize]> {
-  let summary = "Performs a strided elementwise unary operation";
+  let summary = [{Performs a strided elementwise unary operation.}];
   let description = [{
     Performs the operation in-place as if:
     ```

--- a/compiler/src/iree/compiler/Modules/Check/IR/CheckOps.td
+++ b/compiler/src/iree/compiler/Modules/Check/IR/CheckOps.td
@@ -19,7 +19,7 @@ def CHECK_Dialect : Dialect {
 }
 
 def CHECK_ExpectTrueOp : Op<CHECK_Dialect, "expect_true"> {
-  let summary = [{Checks that the operand is true}];
+  let summary = [{Checks that the operand is true.}];
   let description = [{
     Verifies that the operand contains a true value, which is represented by
     any non-zero integer.
@@ -37,7 +37,7 @@ def CHECK_ExpectTrueOp : Op<CHECK_Dialect, "expect_true"> {
 }
 
 def CHECK_ExpectFalseOp : Op<CHECK_Dialect, "expect_false"> {
-  let summary = [{Checks that the operand is false}];
+  let summary = [{Checks that the operand is false.}];
   let description = [{
     Verifies that the operand contains a false value, which is represented by
     zero.
@@ -55,7 +55,7 @@ def CHECK_ExpectFalseOp : Op<CHECK_Dialect, "expect_false"> {
 }
 
 def CHECK_ExpectAllTrueOp : Op<CHECK_Dialect, "expect_all_true"> {
-  let summary = [{Checks that the operand contains only values that are true}];
+  let summary = [{Checks that the operand contains only values that are true.}];
   let description = [{
     Verifies that the operand contains true values, which are represented by any
     non-zero integer.
@@ -81,7 +81,7 @@ def CHECK_ExpectAllTrueOp : Op<CHECK_Dialect, "expect_all_true"> {
 
 def CHECK_ExpectEqOp :
     Op<CHECK_Dialect, "expect_eq", [AllTypesMatch<["lhs", "rhs"]>]> {
-  let summary = [{Checks that the tensor or buffer view operands are equal}];
+  let summary = [{Checks that the tensor or buffer view operands are equal.}];
   let description = [{
     Verifies that the operands are exactly equal.
 
@@ -106,7 +106,7 @@ def CHECK_ExpectEqOp :
 
 def CHECK_ExpectEqConstOp :
     Op<CHECK_Dialect, "expect_eq_const", [AllTypesMatch<["lhs", "value"]>]> {
-  let summary = [{Checks that the tensor operand is equal to some constant}];
+  let summary = [{Checks that the tensor operand is equal to some constant.}];
   let description =  [{
     Verifies that the tensor operand is exactly equal to a constant attribute.
 
@@ -135,7 +135,7 @@ def CHECK_ExpectEqConstOp :
 
 def CHECK_ExpectAlmostEqOp :
     Op<CHECK_Dialect, "expect_almost_eq", [AllTypesMatch<["lhs", "rhs"]>]> {
-  let summary = [{Checks that the operands are almost equal}];
+  let summary = [{Checks that the operands are almost equal.}];
   let description = [{
     Verifies that the buffer view or tensor operands with float elements satisfy
     the Numpy-style fuzzy-comparision condition with parameters `atol`,
@@ -181,7 +181,7 @@ def CHECK_ExpectAlmostEqOp :
 def CHECK_ExpectAlmostEqConstOp :
     Op<CHECK_Dialect,
        "expect_almost_eq_const", [AllTypesMatch<["lhs", "value"]>]> {
-  let summary = [{Checks that the tensor operand is almost equal to some constant}];
+  let summary = [{Checks that the tensor operand is almost equal to some constant.}];
   let description =  [{
     This op is just a convenience wrapper around the expect_almost_eq op.
 

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/IR/HALInlineOps.td
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/IR/HALInlineOps.td
@@ -32,7 +32,7 @@ def HALInline_BufferAllocateOp : HALInline_Op<"buffer.allocate", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
   DeclareOpInterfaceMethods<Util_SizeAwareOp>,
 ]> {
-  let summary = [{empty buffer allocation operation}];
+  let summary = [{Empty buffer allocation operation.}];
   let description = [{
     Allocates a buffer of the given size.
     The size of the buffer returned may be larger than the requested size if the
@@ -59,7 +59,7 @@ def HALInline_BufferAllocateInitializedOp : HALInline_Op<"buffer.allocate.initia
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
   DeclareOpInterfaceMethods<Util_SizeAwareOp>,
 ]> {
-  let summary = [{buffer allocation with cloning}];
+  let summary = [{Buffer allocation with cloning.}];
   let description = [{
     Allocates a buffer with a copy of the provided contents.
   }];
@@ -87,7 +87,7 @@ def HALInline_BufferWrapOp : HALInline_Op<"buffer.wrap", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
   DeclareOpInterfaceMethods<Util_SizeAwareOp>,
 ]> {
-  let summary = [{host buffer wrapping operation}];
+  let summary = [{Host buffer wrapping operation.}];
   let description = [{
     Tries wrapping a !hal.buffer around host memory backed by the given byte
     buffer.
@@ -114,7 +114,7 @@ def HALInline_BufferSubspanOp : HALInline_PureOp<"buffer.subspan", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
   DeclareOpInterfaceMethods<Util_SizeAwareOp>,
 ]> {
-  let summary = [{buffer subspan operation}];
+  let summary = [{Buffer subspan operation.}];
   let description = [{
     Returns a reference to a subspan of the buffer.
   }];
@@ -141,7 +141,7 @@ def HALInline_BufferSubspanOp : HALInline_PureOp<"buffer.subspan", [
 def HALInline_BufferLengthOp : HALInline_PureOp<"buffer.length", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{buffer byte length accessor}];
+  let summary = [{Buffer byte length accessor.}];
   let description = [{
     Returns the allocated size of a buffer in bytes.
     May be less than the underlying buffer allocation if this is a subspan or
@@ -174,7 +174,7 @@ def HALInline_BufferLengthOp : HALInline_PureOp<"buffer.length", [
 def HALInline_BufferStorageOp : HALInline_PureOp<"buffer.storage", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{buffer backing storage accessor}];
+  let summary = [{Buffer backing storage accessor.}];
   let description = [{
     Returns the host backing storage of the HAL buffer as a subspan limited to
     to the buffer's logical range (meaning that byte 0 of the returned buffer is
@@ -220,7 +220,7 @@ let opDocGroup = OpGroupBufferViewOps in {
 def HALInline_BufferViewCreateOp : HALInline_PureOp<"buffer_view.create", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{buffer view reference initializer}];
+  let summary = [{Buffer view reference initializer.}];
   let description = [{
     Creates a reference to a buffer with a particular shape and element type.
     The buffer is not copied and both the original and view references must be
@@ -274,7 +274,7 @@ def HALInline_BufferViewCreateOp : HALInline_PureOp<"buffer_view.create", [
 }
 
 def HALInline_BufferViewAssertOp : HALInline_Op<"buffer_view.assert"> {
-  let summary = [{buffer view contents assertion}];
+  let summary = [{Buffer view contents assertion.}];
   let description = [{
     Asserts that the buffer view contains a data compatible tensor with the
     given encoding. Program execution will abort as if `std.assert` had been
@@ -306,7 +306,7 @@ def HALInline_BufferViewAssertOp : HALInline_Op<"buffer_view.assert"> {
 def HALInline_BufferViewBufferOp : HALInline_PureOp<"buffer_view.buffer", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = [{buffer view buffer accessor}];
+  let summary = [{Buffer view buffer accessor.}];
   let description = [{
     Returns the buffer backing this view's contents.
   }];
@@ -328,7 +328,7 @@ def HALInline_BufferViewBufferOp : HALInline_PureOp<"buffer_view.buffer", [
 }
 
 def HALInline_BufferViewElementTypeOp : HALInline_PureOp<"buffer_view.element_type"> {
-  let summary = [{buffer view element type query}];
+  let summary = [{Buffer view element type query.}];
   let description = [{
     Returns the element type of the buffer view.
   }];
@@ -348,7 +348,7 @@ def HALInline_BufferViewElementTypeOp : HALInline_PureOp<"buffer_view.element_ty
 }
 
 def HALInline_BufferViewEncodingTypeOp : HALInline_PureOp<"buffer_view.encoding_type"> {
-  let summary = [{buffer view encoding type query}];
+  let summary = [{Buffer view encoding type query.}];
   let description = [{
     Returns the encoding type of the buffer view.
   }];
@@ -368,7 +368,7 @@ def HALInline_BufferViewEncodingTypeOp : HALInline_PureOp<"buffer_view.encoding_
 }
 
 def HALInline_BufferViewRankOp : HALInline_PureOp<"buffer_view.rank"> {
-  let summary = [{buffer view rank query}];
+  let summary = [{Buffer view rank query.}];
   let description = [{
     Returns the rank of the buffer view.
   }];
@@ -388,7 +388,7 @@ def HALInline_BufferViewRankOp : HALInline_PureOp<"buffer_view.rank"> {
 }
 
 def HALInline_BufferViewDimOp : HALInline_PureOp<"buffer_view.dim"> {
-  let summary = [{buffer view dimension value query}];
+  let summary = [{Buffer view dimension value query.}];
   let description = [{
     Returns the value of the given dimension.
   }];
@@ -410,7 +410,7 @@ def HALInline_BufferViewDimOp : HALInline_PureOp<"buffer_view.dim"> {
 }
 
 def HALInline_BufferViewTraceOp : HALInline_Op<"buffer_view.trace", []> {
-  let summary = [{trace value(s) operation}];
+  let summary = [{Trace value(s) operation.}];
   let description = [{
     Traces out to a runtime trace sink (console, log file, etc) the given buffer
     views and titles them with the given key. The key is informational only and
@@ -444,7 +444,7 @@ let opDocGroup = OpGroupDeviceOps in {
 
 def HALInline_DeviceQueryOp :
     HALInline_PureOp<"device.query"> {
-  let summary = [{returns a runtime configuration parameter from the device}];
+  let summary = [{Returns a runtime configuration parameter from the device.}];
   let description = [{
     Queries a device configuration parameter with the given key.
     Returns a status indicating whether the pair was recognized/available and if

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/IR/HALLoaderOps.td
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/IR/HALLoaderOps.td
@@ -32,7 +32,7 @@ let opDocGroup = OpGroupExecutableOps in {
 def HALLoader_ExecutableQuerySupportOp : HALLoader_PureOp<"executable.query_support", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = "queries whether an executable format is supported";
+  let summary = [{Queries whether an executable format is supported.}];
   let description = [{
     Returns true if the given format is supported by the device loader. This
     does not guarantee that loading will succeed as the executable may require
@@ -56,7 +56,7 @@ def HALLoader_ExecutableQuerySupportOp : HALLoader_PureOp<"executable.query_supp
 def HALLoader_ExecutableLoadOp : HALLoader_PureOp<"executable.load", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
 ]> {
-  let summary = "dynamically loads an executable";
+  let summary = [{Dynamically loads an executable.}];
   let description = [{
     Creates, loads, and dynamically links an executable.
 
@@ -86,7 +86,7 @@ def HALLoader_ExecutableLookupOp : HALLoader_PureOp<"executable.lookup", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
   DeclareOpInterfaceMethods<SymbolUserOpInterface>,
 ]> {
-  let summary = [{executable cache lookup pseudo-op}];
+  let summary = [{Executable cache lookup pseudo-op.}];
   let description = [{
     Used during conversion to provide a placeholder for a globally cached and
     possibly lazy-initialized executable.
@@ -110,7 +110,7 @@ def HALLoader_ExecutableExportOrdinalOp : HALLoader_PureOp<"executable.export.or
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
   DeclareOpInterfaceMethods<SymbolUserOpInterface>,
 ]> {
-  let summary = [{executable export ordinal lookup pseudo-op}];
+  let summary = [{Executable export ordinal lookup pseudo-op.}];
   let description = [{
     Resolves an executable export ordinal to a value once ordinals have been
     assigned.
@@ -133,7 +133,7 @@ def HALLoader_ExecutableExportOrdinalOp : HALLoader_PureOp<"executable.export.or
 def HALLoader_ExecutableDispatchOp : HALLoader_Op<"executable.dispatch", [
   AttrSizedOperandSegments,
 ]> {
-  let summary = [{inline executable dispatch operation}];
+  let summary = [{Inline executable dispatch operation.}];
   let description = [{
     Dispatches execution to an executable entry point with the given parameters.
   }];

--- a/compiler/src/iree/compiler/Modules/IO/Parameters/IR/IOParametersOps.td
+++ b/compiler/src/iree/compiler/Modules/IO/Parameters/IR/IOParametersOps.td
@@ -33,7 +33,7 @@ def IOParameters_LoadOp : IOParameters_Op<"load", [
   AttrSizedOperandSegments,
   Util_SizeAwareOp,
 ]> {
-  let summary = [{reads one or more parameters from a parameter scope}];
+  let summary = [{Reads one or more parameters from a parameter scope.}];
   let description = [{
     Asynchronously reads one or more parameters from an external parameter
     provider and returns the resulting buffers. Depending on the parameter and
@@ -86,7 +86,7 @@ def IOParameters_LoadOp : IOParameters_Op<"load", [
 def IOParameters_GatherOp : IOParameters_Op<"gather", [
   AttrSizedOperandSegments,
 ]> {
-  let summary = [{gathers multiple parameters from a parameter scope}];
+  let summary = [{Gathers multiple parameters from a parameter scope.}];
   let description = [{
     Asynchronously gathers one or more parameters into a single target buffer.
     This is equivalent to one read per parameter but allows implementations that
@@ -127,7 +127,7 @@ def IOParameters_GatherOp : IOParameters_Op<"gather", [
 def IOParameters_ScatterOp : IOParameters_Op<"scatter", [
   AttrSizedOperandSegments,
 ]> {
-  let summary = [{scatters multiple parameters to a parameter scope}];
+  let summary = [{Scatters multiple parameters to a parameter scope.}];
   let description = [{
     Asynchronously scatters one or more parameters from a single source buffer
     into one or more parameters. This is equivalent to one write per parameter

--- a/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
+++ b/compiler/src/iree/compiler/Preprocessing/TransformExtensions/PreprocessingExtensionsOps.td
@@ -21,9 +21,10 @@ def MatchCastCompatibleDagFromRootOp : Op<Transform_Dialect, "iree.match.cast_co
      SingleOpMatcher,
      SingleBlockImplicitTerminator<"::mlir::transform::YieldOp">,
      MemoryEffectsOpInterface]> {
-  let summary =
-      "Checks if the body of the target op matches an operation dag starting "
-      "at the given root";
+  let summary = [{
+      Checks if the body of the target op matches an operation dag starting
+      at the given root.
+  }];
   let description = [{
     Checks whether the given root op matches an operation dag specified in the
     body of this op. Enforces cast compatibilty between types rather than a
@@ -62,8 +63,7 @@ def MatchCastCompatibleTypesOp : Op<Transform_Dialect, "iree.match.cast_compatib
      MatchOpInterface,
      SingleValueMatcher,
      MemoryEffectsOpInterface]> {
-  let summary =
-      "Checks if the body of the target op matches the body of the single contained op";
+  let summary = [{Checks if the payload value is cast compatible with a target type.}];
   let description = [{
     Checks whether the given value is cast-compatible with the given target
     type attribute.
@@ -91,8 +91,7 @@ def MatchDimBoundsOp : Op<Transform_Dialect, "iree.match.dim_bounds",
      MatchOpInterface,
      SingleValueMatcher,
      MemoryEffectsOpInterface]> {
-  let summary =
-      "Checks whether the size of a dim is within given bounds";
+  let summary = [{Checks whether the size of a dim is within given bounds.}];
   let description = [{
     Checks whether a dim is within a specified lower and upper bound.
 
@@ -124,8 +123,7 @@ def MatchDimIsMultipleOfOp : Op<Transform_Dialect, "iree.match.dim_is_multiple_o
      MatchOpInterface,
      SingleValueMatcher,
      MemoryEffectsOpInterface]> {
-  let summary =
-      "Checks the static size of a dim is divisible by a given value";
+  let summary = [{Checks the static size of a dim is divisible by a given value.}];
   let description = [{
     Checks whether the given dimension given shaped value is a multiple of the
     given size.
@@ -153,8 +151,7 @@ def MatchRegionsOp : Op<Transform_Dialect, "iree.match.regions",
      SingleOpMatcher,
      SingleBlockImplicitTerminator<"::mlir::transform::YieldOp">,
      MemoryEffectsOpInterface]> {
-  let summary =
-      "Checks if the body of the target op matches the body of the single contained op";
+  let summary = [{Checks if the body of the target op matches the body of the single contained op.}];
   let description = [{
     Does a structural comparison of the regions of the single op contained
     within the region of this op against the regions of the target operation.


### PR DESCRIPTION
We have been publishing dialect docs for some time and the summary fields across our dialects were inconsistently styled. This changes all summaries to read more like a sentence (capitalized w/ punctuation) and cleans up a few summaries/descriptions. Switches to use braces everywhere as they make multi-line descriptions easier.

- flow.reshape/bitcast descriptions are improved
- iree_codegen.query_tile_sizes description is improved
- util.global.load description and summary are slightly less redundant

There is still a lot of room for improvement on the contents of the docs, but this is a good first step.