### PR TITLE
Adding user-defined IREE_ALLOCATOR_SYSTEM support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,37 @@ set(IREE_LTO_MODE "full" CACHE STRING "LTO type, 'thin' or 'full'. Only consulte
 option(IREE_VISIBILITY_HIDDEN "Builds all C/C++ libraries with hidden visibility" ON)
 
 #-------------------------------------------------------------------------------
+# Custom runtime allocator configuration
+#-------------------------------------------------------------------------------
+# See iree/base/allocator.h for more information on `iree_allocator_system`.
+
+# A default allocator can be specified by C defines
+# (`IREE_ALLOCATOR_SYSTEM_CTL`) and linked in manually or by name with the
+# `IREE_ALLOCATOR_SYSTEM` option at the CMake level. If set in CMake additional
+# sources, copts, and dependencies can be added to iree::base in order to make
+# the allocator accessible.
+#
+# Built-in allocators available:
+# - `libc`: whatever `malloc`/`free` are defined as.
+#
+# Users adding their own allocators out of tree may define any of the following
+# CMake variables to control behavior:
+# - IREE_ALLOCATOR_{NAME}_SRCS:
+#       List of source files to add to iree::base. Must be an absolute/resolved
+#       path unless present in the iree/base/ directory. Defaults to empty.
+# - IREE_ALLOCATOR_{NAME}_COPTS:
+#       Compiler defines (`-DFOO`) private to iree::base. Defaults to empty.
+# - IREE_ALLOCATOR_{NAME}_DEPS:
+#       Dependencies (static/dynamic libraries) added to iree::base.
+#       Defaults to empty.
+# - IREE_ALLOCATOR_{NAME}_CTL:
+#       iree_allocator_ctl_fn_t name. Defaults to `iree_allocator_{NAME}_ctl`.
+# - IREE_ALLOCATOR_{NAME}_SELF:
+#       iree_allocator_t self void* name. Defaults to empty (NULL).
+set(IREE_ALLOCATOR_SYSTEM "libc" CACHE STRING
+    "Default named `iree_allocator_t` library and function base name.")
+
+#-------------------------------------------------------------------------------
 # IREE command-line tooling configuration
 #-------------------------------------------------------------------------------
 

--- a/runtime/src/iree/base/BUILD.bazel
+++ b/runtime/src/iree/base/BUILD.bazel
@@ -23,6 +23,7 @@ iree_runtime_cc_library(
     srcs = [
         "allocator.c",
         "allocator.h",
+        "allocator_libc.c",
         "assert.h",
         "bitfield.c",
         "bitfield.h",
@@ -44,6 +45,9 @@ iree_runtime_cc_library(
         "wait_source.h",
     ],
     hdrs = ["api.h"],
+    defines = [
+        "IREE_ALLOCATOR_SYSTEM_CTL=iree_allocator_libc_ctl",
+    ],
     deps = [
         ":core_headers",
         "//runtime/src/iree/base/internal:time",

--- a/runtime/src/iree/base/CMakeLists.txt
+++ b/runtime/src/iree/base/CMakeLists.txt
@@ -8,6 +8,48 @@ iree_add_all_subdirs()
 
 iree_cc_library(
   NAME
+    core_headers
+  HDRS
+    "alignment.h"
+    "attributes.h"
+    "config.h"
+    "target_platform.h"
+    "time.h"
+    "tracing.h"
+  PUBLIC
+)
+
+# Users providing their own allocators can have their sources live out-of-tree.
+# Note that with out of tree sources they must be absolute paths in order to be
+# found in this directory.
+set(IREE_ALLOCATOR_LIBC_SRCS "allocator_libc.c")
+
+# IREE_ALLOCATOR_SYSTEM -> variable expansion.
+string(TOUPPER ${IREE_ALLOCATOR_SYSTEM} _IREE_ALLOCATOR_SYSTEM)
+string(REGEX REPLACE "-" "_" _IREE_ALLOCATOR_SYSTEM ${_IREE_ALLOCATOR_SYSTEM})
+message(STATUS "iree_allocator_system() using `IREE_ALLOCATOR_${_IREE_ALLOCATOR_SYSTEM}_*`")
+get_property(_IREE_ALLOCATOR_SYSTEM_SRCS VARIABLE PROPERTY IREE_ALLOCATOR_${_IREE_ALLOCATOR_SYSTEM}_SRCS)
+get_property(_IREE_ALLOCATOR_SYSTEM_COPTS VARIABLE PROPERTY IREE_ALLOCATOR_${_IREE_ALLOCATOR_SYSTEM}_COPTS)
+get_property(_IREE_ALLOCATOR_SYSTEM_DEPS VARIABLE PROPERTY IREE_ALLOCATOR_${_IREE_ALLOCATOR_SYSTEM}_DEPS)
+get_property(_IREE_ALLOCATOR_SYSTEM_CTL VARIABLE PROPERTY IREE_ALLOCATOR_${_IREE_ALLOCATOR_SYSTEM}_CTL)
+get_property(_IREE_ALLOCATOR_SYSTEM_SELF VARIABLE PROPERTY IREE_ALLOCATOR_${_IREE_ALLOCATOR_SYSTEM}_SELF)
+if(IREE_ALLOCATOR_SYSTEM_CTL)
+  list(APPEND _IREE_ALLOCATOR_SYSTEM_DEFINES
+    "-DIREE_ALLOCATOR_SYSTEM_CTL=${_IREE_ALLOCATOR_SYSTEM_CTL}"
+  )
+else()
+  list(APPEND _IREE_ALLOCATOR_SYSTEM_DEFINES
+    "-DIREE_ALLOCATOR_SYSTEM_CTL=iree_allocator_${IREE_ALLOCATOR_SYSTEM}_ctl"
+  )
+endif()
+if(IREE_ALLOCATOR_SYSTEM_SELF)
+  list(APPEND _IREE_ALLOCATOR_SYSTEM_DEFINES
+    "-DIREE_ALLOCATOR_SYSTEM_SELF=${_IREE_ALLOCATOR_SYSTEM_SELF}"
+  )
+endif()
+
+iree_cc_library(
+  NAME
     base
   HDRS
     "api.h"
@@ -33,23 +75,16 @@ iree_cc_library(
     "time.c"
     "wait_source.c"
     "wait_source.h"
+    ${_IREE_ALLOCATOR_SYSTEM_SRCS}
+  COPTS
+    ${_IREE_ALLOCATOR_SYSTEM_COPTS}
+  DEFINES
+    ${_IREE_ALLOCATOR_SYSTEM_DEFINES}
   DEPS
     ::core_headers
     iree::base::internal::time
     iree::base::tracing::provider
-  PUBLIC
-)
-
-iree_cc_library(
-  NAME
-    core_headers
-  HDRS
-    "alignment.h"
-    "attributes.h"
-    "config.h"
-    "target_platform.h"
-    "time.h"
-    "tracing.h"
+    ${_IREE_ALLOCATOR_SYSTEM_DEPS}
   PUBLIC
 )
 

--- a/runtime/src/iree/base/allocator.c
+++ b/runtime/src/iree/base/allocator.c
@@ -8,7 +8,6 @@
 #include <string.h>
 
 #include "iree/base/api.h"
-#include "iree/base/tracing.h"
 
 //===----------------------------------------------------------------------===//
 // iree_allocator_t (std::allocator-like interface)
@@ -66,91 +65,6 @@ IREE_API_EXPORT void iree_allocator_free(iree_allocator_t allocator,
 //===----------------------------------------------------------------------===//
 // Built-in iree_allocator_t implementations
 //===----------------------------------------------------------------------===//
-
-static iree_status_t iree_allocator_system_alloc(
-    iree_allocator_command_t command,
-    const iree_allocator_alloc_params_t* params, void** inout_ptr) {
-  IREE_ASSERT_ARGUMENT(params);
-  IREE_ASSERT_ARGUMENT(inout_ptr);
-  iree_host_size_t byte_length = params->byte_length;
-  if (IREE_UNLIKELY(byte_length == 0)) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "allocations must be >0 bytes");
-  }
-
-  void* existing_ptr = *inout_ptr;
-
-  IREE_TRACE(iree_zone_id_t z0 = 0);
-  IREE_TRACE({
-    if (existing_ptr && command == IREE_ALLOCATOR_COMMAND_REALLOC) {
-      IREE_TRACE_ZONE_BEGIN_NAMED(z0_named, "iree_allocator_system_realloc");
-      z0 = z0_named;
-    } else if (command == IREE_ALLOCATOR_COMMAND_CALLOC) {
-      IREE_TRACE_ZONE_BEGIN_NAMED(z0_named, "iree_allocator_system_calloc");
-      z0 = z0_named;
-    } else {
-      IREE_TRACE_ZONE_BEGIN_NAMED(z0_named, "iree_allocator_system_malloc");
-      z0 = z0_named;
-    }
-  });
-
-  void* existing_ptr_value = NULL;
-  void* new_ptr = NULL;
-  if (existing_ptr && command == IREE_ALLOCATOR_COMMAND_REALLOC) {
-    existing_ptr_value = iree_tracing_obscure_ptr(existing_ptr);
-    new_ptr = realloc(existing_ptr, byte_length);
-  } else {
-    existing_ptr = NULL;
-    if (command == IREE_ALLOCATOR_COMMAND_CALLOC) {
-      new_ptr = calloc(1, byte_length);
-    } else {
-      new_ptr = malloc(byte_length);
-    }
-  }
-  if (!new_ptr) {
-    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
-                            "system allocator failed the request");
-  }
-
-  if (existing_ptr_value) {
-    IREE_TRACE_FREE(existing_ptr_value);
-  }
-  IREE_TRACE_ALLOC(new_ptr, byte_length);
-
-  *inout_ptr = new_ptr;
-  IREE_TRACE(IREE_TRACE_ZONE_END(z0));
-  return iree_ok_status();
-}
-
-static iree_status_t iree_allocator_system_free(void** inout_ptr) {
-  IREE_ASSERT_ARGUMENT(inout_ptr);
-  IREE_TRACE_ZONE_BEGIN(z0);
-  void* ptr = *inout_ptr;
-  if (IREE_LIKELY(ptr != NULL)) {
-    IREE_TRACE_FREE(ptr);
-    free(ptr);
-    *inout_ptr = NULL;
-  }
-  IREE_TRACE_ZONE_END(z0);
-  return iree_ok_status();
-}
-
-IREE_API_EXPORT iree_status_t
-iree_allocator_system_ctl(void* self, iree_allocator_command_t command,
-                          const void* params, void** inout_ptr) {
-  switch (command) {
-    case IREE_ALLOCATOR_COMMAND_MALLOC:
-    case IREE_ALLOCATOR_COMMAND_CALLOC:
-    case IREE_ALLOCATOR_COMMAND_REALLOC:
-      return iree_allocator_system_alloc(
-          command, (const iree_allocator_alloc_params_t*)params, inout_ptr);
-    case IREE_ALLOCATOR_COMMAND_FREE:
-      return iree_allocator_system_free(inout_ptr);
-    default:
-      return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
-                              "unsupported system allocator command");
-  }
-}
 
 static iree_status_t iree_allocator_inline_arena_alloc(
     iree_allocator_inline_storage_t* storage, iree_allocator_command_t command,

--- a/runtime/src/iree/base/allocator_libc.c
+++ b/runtime/src/iree/base/allocator_libc.c
@@ -1,0 +1,98 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <stdlib.h>
+
+#include "iree/base/api.h"
+
+//===----------------------------------------------------------------------===//
+// libc allocator implementation
+//===----------------------------------------------------------------------===//
+
+static iree_status_t iree_allocator_libc_alloc(
+    iree_allocator_command_t command,
+    const iree_allocator_alloc_params_t* params, void** inout_ptr) {
+  IREE_ASSERT_ARGUMENT(params);
+  IREE_ASSERT_ARGUMENT(inout_ptr);
+  iree_host_size_t byte_length = params->byte_length;
+  if (IREE_UNLIKELY(byte_length == 0)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "allocations must be >0 bytes");
+  }
+
+  void* existing_ptr = *inout_ptr;
+
+  IREE_TRACE(iree_zone_id_t z0 = 0);
+  IREE_TRACE({
+    if (existing_ptr && command == IREE_ALLOCATOR_COMMAND_REALLOC) {
+      IREE_TRACE_ZONE_BEGIN_NAMED(z0_named, "iree_allocator_libc_realloc");
+      z0 = z0_named;
+    } else if (command == IREE_ALLOCATOR_COMMAND_CALLOC) {
+      IREE_TRACE_ZONE_BEGIN_NAMED(z0_named, "iree_allocator_libc_calloc");
+      z0 = z0_named;
+    } else {
+      IREE_TRACE_ZONE_BEGIN_NAMED(z0_named, "iree_allocator_libc_malloc");
+      z0 = z0_named;
+    }
+  });
+
+  void* existing_ptr_value = NULL;
+  void* new_ptr = NULL;
+  if (existing_ptr && command == IREE_ALLOCATOR_COMMAND_REALLOC) {
+    existing_ptr_value = iree_tracing_obscure_ptr(existing_ptr);
+    new_ptr = realloc(existing_ptr, byte_length);
+  } else {
+    existing_ptr = NULL;
+    if (command == IREE_ALLOCATOR_COMMAND_CALLOC) {
+      new_ptr = calloc(1, byte_length);
+    } else {
+      new_ptr = malloc(byte_length);
+    }
+  }
+  if (!new_ptr) {
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "libc allocator failed the request");
+  }
+
+  if (existing_ptr_value) {
+    IREE_TRACE_FREE(existing_ptr_value);
+  }
+  IREE_TRACE_ALLOC(new_ptr, byte_length);
+
+  *inout_ptr = new_ptr;
+  IREE_TRACE(IREE_TRACE_ZONE_END(z0));
+  return iree_ok_status();
+}
+
+static iree_status_t iree_allocator_libc_free(void** inout_ptr) {
+  IREE_ASSERT_ARGUMENT(inout_ptr);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  void* ptr = *inout_ptr;
+  if (IREE_LIKELY(ptr != NULL)) {
+    IREE_TRACE_FREE(ptr);
+    free(ptr);
+    *inout_ptr = NULL;
+  }
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+IREE_API_EXPORT iree_status_t
+iree_allocator_libc_ctl(void* self, iree_allocator_command_t command,
+                        const void* params, void** inout_ptr) {
+  switch (command) {
+    case IREE_ALLOCATOR_COMMAND_MALLOC:
+    case IREE_ALLOCATOR_COMMAND_CALLOC:
+    case IREE_ALLOCATOR_COMMAND_REALLOC:
+      return iree_allocator_libc_alloc(
+          command, (const iree_allocator_alloc_params_t*)params, inout_ptr);
+    case IREE_ALLOCATOR_COMMAND_FREE:
+      return iree_allocator_libc_free(inout_ptr);
+    default:
+      return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                              "unsupported libc allocator command");
+  }
+}

--- a/runtime/src/iree/base/internal/flags.c
+++ b/runtime/src/iree/base/internal/flags.c
@@ -26,9 +26,10 @@
 static iree_status_t iree_flags_leaky_allocator_ctl(
     void* self, iree_allocator_command_t command, const void* params,
     void** inout_ptr) {
+  const iree_allocator_t allocator = iree_allocator_system();
   IREE_LEAK_CHECK_DISABLE_PUSH();
   iree_status_t status =
-      iree_allocator_system_ctl(/*self=*/NULL, command, params, inout_ptr);
+      allocator.ctl(allocator.self, command, params, inout_ptr);
   IREE_LEAK_CHECK_DISABLE_POP();
   return status;
 }


### PR DESCRIPTION
This allows for overriding the allocator control function (and its self) externally. If no system allocator is specified the libc allocator (malloc/free, likely libc but could be anything that overrides them) will be used. Since many allocators allow for replacing malloc/free that's still the easiest path but giving explicit control over the allocator used by IREE allows for more options during composition in larger projects.