### PR TITLE
Adding mimalloc v3 as an optional system allocator.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,7 @@ option(IREE_VISIBILITY_HIDDEN "Builds all C/C++ libraries with hidden visibility
 #
 # Built-in allocators available:
 # - `libc`: whatever `malloc`/`free` are defined as.
+# - `mimalloc`: https://github.com/microsoft/mimalloc (v3)
 #
 # Users adding their own allocators out of tree may define any of the following
 # CMake variables to control behavior:
@@ -953,6 +954,41 @@ endif()
 
 # This defines the iree-flatcc-cli target, so we don't use EXCLUDE_FROM_ALL.
 add_subdirectory(build_tools/third_party/flatcc)
+
+if(IREE_ALLOCATOR_SYSTEM STREQUAL "mimalloc")
+  set(IREE_ALLOCATOR_MIMALLOC_SRCS "allocator_mimalloc.c")
+  if(IREE_USE_SYSTEM_DEPS)
+    # NOTE: we don't know exactly what the user wants here and guess.
+    message(STATUS "iree_allocator_system using system mimalloc v3.*...")
+    set(MI_BUILD_STATIC ON)
+    find_package(mimalloc 3 REQUIRED)
+    set(IREE_ALLOCATOR_MIMALLOC_DEPS "mimalloc-static")
+  else()
+    # mimalloc is currently using the `dev3` branch (v3.*).
+    # Releases: https://github.com/microsoft/mimalloc/tags
+    #
+    # We directly inline the source into iree/base/allocator_mimalloc.c when
+    # fetching it ourselves and otherwise link against the static library. We
+    # do not want to override the global malloc/free implementations.
+    message(STATUS "Using fetched mimalloc v3.*...")
+    set(MI_OVERRIDE OFF)
+    set(MI_BUILD_STATIC OFF)
+    set(MI_BUILD_SHARED OFF)
+    set(MI_BUILD_OBJECT OFF)
+    set(MI_BUILD_TESTS OFF)
+    include(FetchContent)
+    FetchContent_Declare(
+      mimalloc
+      GIT_REPOSITORY https://github.com/microsoft/mimalloc.git
+      GIT_TAG        51c09e7b6a0ac5feeba998710f00c7dd7aa67bbf # v3.0.3
+    )
+    FetchContent_MakeAvailable(mimalloc)
+    list(APPEND IREE_ALLOCATOR_MIMALLOC_COPTS
+      "-I${mimalloc_SOURCE_DIR}/include"
+      "-DIREE_ALLOCATOR_MIMALLOC_STATIC_SRC=\"${mimalloc_SOURCE_DIR}/src/static.c\""
+    )
+  endif()
+endif()
 
 if(IREE_HAL_DRIVER_CUDA)
   add_subdirectory(build_tools/third_party/nccl EXCLUDE_FROM_ALL)

--- a/runtime/src/iree/base/CMakeLists.txt
+++ b/runtime/src/iree/base/CMakeLists.txt
@@ -23,6 +23,7 @@ iree_cc_library(
 # Note that with out of tree sources they must be absolute paths in order to be
 # found in this directory.
 set(IREE_ALLOCATOR_LIBC_SRCS "allocator_libc.c")
+set(IREE_ALLOCATOR_MIMALLOC_SRCS "allocator_mimalloc.c")
 
 # IREE_ALLOCATOR_SYSTEM -> variable expansion.
 string(TOUPPER ${IREE_ALLOCATOR_SYSTEM} _IREE_ALLOCATOR_SYSTEM)

--- a/runtime/src/iree/base/allocator_mimalloc.c
+++ b/runtime/src/iree/base/allocator_mimalloc.c
@@ -1,0 +1,154 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/base/api.h"
+
+//===----------------------------------------------------------------------===//
+// mimalloc dependency
+//===----------------------------------------------------------------------===//
+
+// Optionally include the entire library statically. The define should point to
+// `"mimalloc/src/static.c"` in the source distribution. If not defined we
+// assume mimalloc is being linked as a dynamic library or statically as part of
+// the hosting framework/application.
+#if defined(IREE_ALLOCATOR_MIMALLOC_STATIC_SRC)
+
+// Since we're including mimalloc inline we will potentially get warnings that
+// we enable that they do not. Ideally these would be fixed upstream as they are
+// easy to fix and help readability (most are implicit type casts).
+#if defined(IREE_COMPILER_MSVC)
+#pragma warning(push)
+#pragma warning(disable : 4024 4047 4133)
+#endif  // IREE_COMPILER_MSVC
+
+#include IREE_ALLOCATOR_MIMALLOC_STATIC_SRC
+
+#if defined(IREE_COMPILER_MSVC)
+#pragma warning(pop)
+#endif  // IREE_COMPILER_MSVC
+
+#else
+#include <mimalloc.h>
+#endif  // IREE_ALLOCATOR_MIMALLOC_STATIC_SRC
+
+//===----------------------------------------------------------------------===//
+// mimalloc allocator implementation
+//===----------------------------------------------------------------------===//
+// NOTE: currently we only use the default heap. Since the heap is just a void*
+// we could treat our allocator `self` param as the heap instead to allow the
+// user to specify a custom heap (via `iree_allocator_system_self`).
+
+static iree_status_t iree_allocator_mimalloc_malloc(
+    const iree_allocator_alloc_params_t* params, void** inout_ptr) {
+  IREE_ASSERT_ARGUMENT(params);
+  IREE_ASSERT_ARGUMENT(inout_ptr);
+  iree_host_size_t byte_length = params->byte_length;
+  if (IREE_UNLIKELY(byte_length == 0)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "allocations must be >0 bytes");
+  }
+
+  IREE_TRACE_ZONE_BEGIN(z0);
+  void* new_ptr = mi_heap_malloc(mi_prim_get_default_heap(), byte_length);
+  iree_status_t status = iree_ok_status();
+  if (new_ptr) {
+    *inout_ptr = new_ptr;
+  } else {
+    status = iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                              "mimalloc allocator failed the request");
+  }
+  IREE_TRACE_ALLOC(new_ptr, byte_length);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+static iree_status_t iree_allocator_mimalloc_realloc(
+    const iree_allocator_alloc_params_t* params, void** inout_ptr) {
+  IREE_ASSERT_ARGUMENT(params);
+  // Note that this will only be called by the control function if *inout_ptr
+  // is not NULL.
+  iree_host_size_t byte_length = params->byte_length;
+  if (IREE_UNLIKELY(byte_length == 0)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "allocations must be >0 bytes");
+  }
+
+  IREE_TRACE_ZONE_BEGIN(z0);
+  void* existing_ptr = *inout_ptr;
+  void* existing_ptr_value = iree_tracing_obscure_ptr(existing_ptr);
+  (void)existing_ptr_value;
+  void* new_ptr =
+      mi_heap_realloc(mi_prim_get_default_heap(), existing_ptr, byte_length);
+  iree_status_t status = iree_ok_status();
+  if (new_ptr) {
+    *inout_ptr = new_ptr;
+  } else {
+    status = iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                              "mimalloc allocator failed the request");
+  }
+  IREE_TRACE_FREE(existing_ptr_value);
+  IREE_TRACE_ALLOC(new_ptr, byte_length);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+static iree_status_t iree_allocator_mimalloc_calloc(
+    const iree_allocator_alloc_params_t* params, void** inout_ptr) {
+  IREE_ASSERT_ARGUMENT(params);
+  iree_host_size_t byte_length = params->byte_length;
+  if (IREE_UNLIKELY(byte_length == 0)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "allocations must be >0 bytes");
+  }
+
+  IREE_TRACE_ZONE_BEGIN(z0);
+  void* new_ptr = mi_heap_calloc(mi_prim_get_default_heap(), 1, byte_length);
+  iree_status_t status = iree_ok_status();
+  if (new_ptr) {
+    *inout_ptr = new_ptr;
+  } else {
+    status = iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                              "mimalloc allocator failed the request");
+  }
+  IREE_TRACE_ALLOC(new_ptr, byte_length);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+static iree_status_t iree_allocator_mimalloc_free(void** inout_ptr) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  void* ptr = *inout_ptr;
+  if (IREE_LIKELY(ptr != NULL)) {
+    IREE_TRACE_FREE(ptr);
+    mi_heap_free(mi_prim_get_default_heap(), ptr);
+    *inout_ptr = NULL;
+  }
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+IREE_API_EXPORT iree_status_t
+iree_allocator_mimalloc_ctl(void* self, iree_allocator_command_t command,
+                            const void* params, void** inout_ptr) {
+  IREE_ASSERT_ARGUMENT(inout_ptr);
+  switch (command) {
+    case IREE_ALLOCATOR_COMMAND_MALLOC:
+      return iree_allocator_mimalloc_malloc(params, inout_ptr);
+    case IREE_ALLOCATOR_COMMAND_CALLOC:
+      return iree_allocator_mimalloc_calloc(params, inout_ptr);
+    case IREE_ALLOCATOR_COMMAND_REALLOC:
+      if (!*inout_ptr) {
+        return iree_allocator_mimalloc_malloc(params, inout_ptr);
+      } else {
+        return iree_allocator_mimalloc_realloc(params, inout_ptr);
+      }
+    case IREE_ALLOCATOR_COMMAND_FREE:
+      return iree_allocator_mimalloc_free(inout_ptr);
+    default:
+      return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                              "unsupported mimalloc allocator command");
+  }
+}


### PR DESCRIPTION
Setting `-DIREE_ALLOCATOR_SYSTEM=mimalloc` will fetch v3 of mimalloc and switch the default system allocator to using it by statically linking it into iree::base. v3 was chosen because people seem to say it's significantly better in serving environments (or anywhere with a lot of threads) and that's what IREE is designed for.

If users bring their own and set `IREE_USE_SYSTEM_DEPS` they'll get what they have installed. Alternatively, a user can decide how they want to integrate mimalloc themselves, have it replace malloc/free globally, and not bother with any IREE-specific settings. That's the only way to make mimalloc work as an allocator in the compiler (outside of consteval) as well, if we wanted to do that.

This is not enabled by default as mimalloc is not supported in all configurations. Release builds could set it as default for the configurations where it is supported if they want.

Fixes #16812.