### PR TITLE
[NFC] Use ShapedType::isDynamicShape when possible.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.cpp
@@ -144,8 +144,7 @@ MaterializeEncodingTypeConverter::getInnerTileSizesOfr(
     const IREE::Codegen::MaterializeEncodingInfo &materializeEncodingInfo)
     const {
   ArrayRef<int64_t> staticTileSizes = materializeEncodingInfo.innerTileSizes;
-  if (llvm::all_of(staticTileSizes,
-                   [](int64_t i) { return !ShapedType::isDynamic(i); })) {
+  if (!ShapedType::isDynamicShape(staticTileSizes)) {
     return getAsOpFoldResult(rewriter.getI64ArrayAttr(staticTileSizes));
   }
   assert(materializeEncodingValueFn &&

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/WorkgroupReordering.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/WorkgroupReordering.cpp
@@ -48,7 +48,7 @@ getWorkgroupCountsXY(OpBuilder &builder, FunctionOpInterface funcOp,
                      std::optional<APInt> xBound, std::optional<APInt> yBound) {
   Location loc = funcOp.getLoc();
   SmallVector<int64_t> workgroupCounts = getStaticNumWorkgroups(funcOp);
-  bool isStaticWgCount = llvm::none_of(workgroupCounts, ShapedType::isDynamic);
+  bool isStaticWgCount = !ShapedType::isDynamicShape(workgroupCounts);
   // Check if we can rely on a static grid.
   if (isStaticWgCount && workgroupCounts.size() >= 2) {
     LLVM_DEBUG(llvm::dbgs()

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorizeIREEVectorExtOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorizeIREEVectorExtOps.cpp
@@ -381,9 +381,7 @@ LogicalResult vectorizeGatherLikeGenericToTransferGather(
     canonicalScalableDims.append(linalgOp.getNumLoops(), false);
 
     // loop ranges must be static to infer vector sizes.
-    if (llvm::any_of(canonicalVectorSizes, [](int64_t size) {
-          return ShapedType::isDynamic(size);
-        })) {
+    if (ShapedType::isDynamicShape(canonicalVectorSizes)) {
       return failure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -2704,8 +2704,7 @@ adjustTileSizesForPackOp(mlir::FunctionOpInterface entryPointFn,
   ArrayRef<int64_t> innerDimsPos = packOp.getInnerDimsPos();
   ArrayRef<int64_t> innerTiles = packOp.getStaticInnerTiles();
   // Currently we only handle pack op with static inner tile sizes.
-  if (llvm::any_of(innerTiles,
-                   [](int64_t size) { return ShapedType::isDynamic(size); })) {
+  if (ShapedType::isDynamicShape(innerTiles)) {
     return failure();
   }
   // Pack op requires special vector tile sizes to achieve good performance.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
@@ -142,8 +142,7 @@ struct ConvertSharedMemAllocOp : public OpRewritePattern<memref::AllocOp> {
     if (!hasSharedMemoryAddressSpace(allocOp.getType()))
       return failure();
     ArrayRef<int64_t> shape = allocOp.getType().getShape();
-    if (llvm::any_of(shape,
-                     [](int64_t dim) { return ShapedType::isDynamic(dim); })) {
+    if (ShapedType::isDynamicShape(shape)) {
       return failure();
     }
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConv2DToWinograd.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ConvertConv2DToWinograd.cpp
@@ -230,10 +230,10 @@ public:
     if (!inputType) {
       return failure();
     }
-    SmallVector<int64_t> inputShape(inputType.getShape());
-    if (llvm::any_of(inputShape, ShapedType::isDynamic)) {
+    if (!inputType.hasStaticShape()) {
       return rewriter.notifyMatchFailure(convOp, "Input shape is not static");
     }
+    SmallVector<int64_t> inputShape(inputType.getShape());
     assert(inputShape.size() == 4);
     if (isNchwFchw) {
       permute<IREE::LinalgExt::Permutation::NCHW_TO_NHWC>(inputShape);


### PR DESCRIPTION
The revision avoids additional lambdas, any_of, and none_of, which improves the readability.