### PR TITLE
[DispatchCreation] Avoid hoisting set encoding operations with padding encodings

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/HoistEncodingOps.cpp
@@ -192,6 +192,11 @@ void HoistEncodingOpsPass::runOnOperation() {
     if (!setEncodingOp->getParentOfType<IREE::Flow::DispatchRegionOp>()) {
       return;
     }
+    // Avoid hoisting set encodings that are using the padding encodings.
+    Attribute encoding = setEncodingOp.getResultType().getEncoding();
+    if (isa_and_nonnull<IREE::Encoding::PadEncodingLayoutAttr>(encoding)) {
+      return;
+    }
     Operation *src = setEncodingOp.getSource().getDefiningOp();
     if (!hoistEncodingsForConstExpr && src &&
         (isa<IREE::Util::GlobalLoadOp>(src) ||


### PR DESCRIPTION
For padding, the `set_encoding/unset_encoding` are already placed in the right dispatches. These shouldnt be hoisted out