### PR TITLE
Adding a `hal.executable.export` condition region.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
@@ -855,7 +855,7 @@ struct CmdDispatchOpPattern
           loc, builder.getIndexType(), getExportRef(baseExportOp));
       auto workgroupCount =
           baseExportOp.calculateWorkgroupCount(loc, device, workload, builder);
-      return std::make_tuple(ordinal, workgroupCount);
+      return {ordinal, workgroupCount};
     }
     // Recursively build the selection decision tree.
     auto fallbackExportOp =
@@ -926,11 +926,12 @@ struct CmdDispatchOpPattern
                                               });
       }
     }
-    return std::make_tuple(ifOp.getResult(0), std::array<Value, 3>{
-                                                  ifOp.getResult(1),
-                                                  ifOp.getResult(2),
-                                                  ifOp.getResult(3),
-                                              });
+    return {ifOp.getResult(0),
+            {
+                ifOp.getResult(1),
+                ifOp.getResult(2),
+                ifOp.getResult(3),
+            }};
   }
 
   Operation *emitDispatchOp(

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
@@ -811,20 +811,141 @@ struct CmdDispatchOpPattern
     return success();
   }
 
+  // Returns the fully qualified export name (@executable::@variant::@export).
+  SymbolRefAttr getExportRef(IREE::HAL::ExecutableExportOp exportOp) const {
+    auto variantOp =
+        exportOp->getParentOfType<IREE::HAL::ExecutableVariantOp>();
+    auto executableOp = variantOp->getParentOfType<IREE::HAL::ExecutableOp>();
+    return SymbolRefAttr::get(executableOp.getSymNameAttr(),
+                              {
+                                  FlatSymbolRefAttr::get(variantOp),
+                                  FlatSymbolRefAttr::get(exportOp),
+                              });
+  }
+
+  // Selects the ordinal for the given |baseExportOp| and calculates its
+  // workgroup count. The ordinal may be different than the ordinal of the
+  // export itself if any fallbacks are specified. Each export condition will be
+  // evaluated and the first that matches will be returned.
+  //
+  // As an example, a fallback chain of @0 -> @1 -> @2 (with @0 being the
+  // highest priority) would result in a decision tree:
+  //   %ordinal, %workgroups = scf.if %cond0 {
+  //     %ordinal0 = hal.executable.export.ordinal @0
+  //     %workgroups0 = calculate for @0
+  //     scf.yield %ordinal0, %workgroups0
+  //   } else {
+  //     %ordinal12, %workgroups12 = scf.if %cond1 {
+  //       %ordinal1 = hal.executable.export.ordinal @1
+  //       %workgroups1 = calculate for @1
+  //       scf.yield %ordinal1, %workgroups1
+  //     } else {
+  //       %ordinal2 = hal.executable.export.ordinal @2
+  //       %workgroups2 = calculate for @2
+  //       scf.yield %ordinal2, %workgroups2
+  //     }
+  //     scf.yield %ordinal12, %workgroups12
+  //   }
+  std::tuple<Value, std::array<Value, 3>>
+  selectExport(Location loc, IREE::HAL::ExecutableExportOp baseExportOp,
+               Value device, ValueRange workload, OpBuilder &builder) const {
+    if (!baseExportOp.getConditionBody()) {
+      // No fallback - fast path to just the base export.
+      Value ordinal = builder.create<IREE::HAL::ExecutableExportOrdinalOp>(
+          loc, builder.getIndexType(), getExportRef(baseExportOp));
+      auto workgroupCount =
+          baseExportOp.calculateWorkgroupCount(loc, device, workload, builder);
+      return std::make_tuple(ordinal, workgroupCount);
+    }
+    // Recursively build the selection decision tree.
+    auto fallbackExportOp =
+        SymbolTable::lookupNearestSymbolFrom<IREE::HAL::ExecutableExportOp>(
+            baseExportOp, baseExportOp.getConditionFallbackAttr());
+    return buildExportSelection(loc, baseExportOp, fallbackExportOp, device,
+                                workload, builder);
+  }
+  std::tuple<Value, std::array<Value, 3>>
+  buildExportSelection(Location loc, IREE::HAL::ExecutableExportOp tryExportOp,
+                       IREE::HAL::ExecutableExportOp fallbackExportOp,
+                       Value device, ValueRange workload,
+                       OpBuilder &builder) const {
+    // Inline the condition logic.
+    Value tryCondition =
+        tryExportOp.calculateCondition(loc, device, workload, builder);
+
+    // Create an scf.if: the then region will simply return the
+    // ordinal (condition matches) and the else region will contain the rest of
+    // the decision tree.
+    Type indexType = builder.getIndexType();
+    auto ifOp = builder.create<scf::IfOp>(
+        loc, TypeRange{indexType, indexType, indexType, indexType},
+        tryCondition,
+        /*addThenBlock=*/true, /*addElseBlock=*/true);
+    {
+      auto thenBuilder = ifOp.getThenBodyBuilder();
+      Value tryOrdinal =
+          thenBuilder.create<IREE::HAL::ExecutableExportOrdinalOp>(
+              loc, thenBuilder.getIndexType(), getExportRef(tryExportOp));
+      auto tryWorkgroupCount = tryExportOp.calculateWorkgroupCount(
+          loc, device, workload, thenBuilder);
+      thenBuilder.create<scf::YieldOp>(loc, ValueRange{
+                                                tryOrdinal,
+                                                tryWorkgroupCount[0],
+                                                tryWorkgroupCount[1],
+                                                tryWorkgroupCount[2],
+                                            });
+    }
+    {
+      auto elseBuilder = ifOp.getElseBodyBuilder();
+      if (fallbackExportOp.getConditionBody()) {
+        // Recursively chain to the next fallback-enabled export.
+        auto chainExportOp =
+            SymbolTable::lookupNearestSymbolFrom<IREE::HAL::ExecutableExportOp>(
+                fallbackExportOp, fallbackExportOp.getConditionFallbackAttr());
+        auto [chainOrdinal, chainWorkgroupCount] =
+            buildExportSelection(loc, fallbackExportOp, chainExportOp, device,
+                                 workload, elseBuilder);
+        elseBuilder.create<scf::YieldOp>(loc, ValueRange{
+                                                  chainOrdinal,
+                                                  chainWorkgroupCount[0],
+                                                  chainWorkgroupCount[1],
+                                                  chainWorkgroupCount[2],
+                                              });
+      } else {
+        // Tail of recursion; fallback has no fallback.
+        Value fallbackOrdinal =
+            elseBuilder.create<IREE::HAL::ExecutableExportOrdinalOp>(
+                loc, indexType, getExportRef(fallbackExportOp));
+        auto fallbackWorkgroupCount = fallbackExportOp.calculateWorkgroupCount(
+            loc, device, workload, elseBuilder);
+        elseBuilder.create<scf::YieldOp>(loc, ValueRange{
+                                                  fallbackOrdinal,
+                                                  fallbackWorkgroupCount[0],
+                                                  fallbackWorkgroupCount[1],
+                                                  fallbackWorkgroupCount[2],
+                                              });
+      }
+    }
+    return std::make_tuple(ifOp.getResult(0), std::array<Value, 3>{
+                                                  ifOp.getResult(1),
+                                                  ifOp.getResult(2),
+                                                  ifOp.getResult(3),
+                                              });
+  }
+
   Operation *emitDispatchOp(
       Location loc, IREE::Stream::AffinityAttr affinityAttr, Value device,
       CommandBufferConversionMapping &commandBufferMapping,
       IREE::HAL::ExecutableExportOp exportOp, SymbolRefAttr entryPointAttr,
       IREE::Stream::CmdDispatchOp dispatchOp, OpAdaptor adaptor,
       OpBuilder &builder) const {
-    auto workgroupCount = exportOp.calculateWorkgroupCount(
-        loc, device, adaptor.getWorkload(), builder);
-
     Value executable = builder.create<IREE::HAL::ExecutableLookupOp>(
         loc, builder.getType<IREE::HAL::ExecutableType>(), device,
         entryPointAttr.getRootReference().getValue());
-    Value ordinal = builder.create<IREE::HAL::ExecutableExportOrdinalOp>(
-        loc, builder.getIndexType(), entryPointAttr);
+
+    // Select the export and calculate its workgroup count.
+    auto [ordinal, workgroupCount] =
+        selectExport(loc, exportOp, device, adaptor.getWorkload(), builder);
 
     auto layoutAttr = exportOp.getLayout();
     SmallVector<IREE::HAL::BindingValue> bindings;

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/test/cmd_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/test/cmd_ops.mlir
@@ -326,7 +326,7 @@ util.func public @cmdDispatch(%arg_resource: !stream.resource<external>) -> !str
     // CHECK-SAME:     target(@ex::@aarch64::@dispatch) : index
 
     // Inlined workgroup count calculation:
-    // CHECK: %[[X:.+]] = affine.apply #map()[%c1]
+    // CHECK: %[[X:.+]] = affine.apply #{{.*}}[%c1]
 
     // Dispatch:
     // CHECK: hal.command_buffer.dispatch<%[[CMD]]

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/test/cmd_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/test/cmd_ops.mlir
@@ -318,15 +318,15 @@ util.func public @cmdDispatch(%arg_resource: !stream.resource<external>) -> !str
     // CHECK: scf.index_switch %[[VARIANT0]]
     // CHECK-NEXT: case 0 {
 
-    // Inlined workgroup count calculation:
-    // CHECK: %[[X:.+]] = affine.apply #map()[%c1]
-
     // Target executable/export:
     //  CHECK-DAG: %[[EXECUTABLE_0:.+]] = hal.executable.lookup
     // CHECK-SAME:     device(%[[CMD_DEVICE]] : !hal.device)
     // CHECK-SAME:     executable(@ex) : !hal.executable
     //  CHECK-DAG: %[[ORDINAL_0:.+]] = hal.executable.export.ordinal
     // CHECK-SAME:     target(@ex::@aarch64::@dispatch) : index
+
+    // Inlined workgroup count calculation:
+    // CHECK: %[[X:.+]] = affine.apply #map()[%c1]
 
     // Dispatch:
     // CHECK: hal.command_buffer.dispatch<%[[CMD]]
@@ -352,6 +352,88 @@ util.func public @cmdDispatch(%arg_resource: !stream.resource<external>) -> !str
   //      CHECK: hal.device.queue.execute.indirect<%[[DEVICE]] : !hal.device> {{.+}} commands(%[[MEMOIZED_CMD]]) bindings([
   // CHECK-NEXT:   (%[[ARG_RESOURCE]] : !hal.buffer)[%c0, %[[ARG_SIZE]]]
   // CHECK-NEXT: ])
+  util.return %0 : !stream.timepoint
+}
+
+// -----
+
+// Tests export fallback logic.
+// Each dispatch will try to dispatch (@export0 -> @export1 -> @export2). Note
+// that the workgroup count region for each can vary and we must dispatch with
+// the workgroup count of the export selected.
+
+#pipeline_layout = #hal.pipeline.layout<bindings = [
+  #hal.pipeline.binding<storage_buffer, Indirect>
+]>
+hal.executable private @executable {
+  hal.executable.variant public @variant target(#hal.executable.target<"llvm-cpu", "embedded-elf-aarch64">) {
+    // Primary export to try. Fallback to @export1.
+    hal.executable.export public @export0 ordinal(0) layout(#pipeline_layout) condition(%device: !hal.device, %workload: index) -> i1 {
+      %c0 = arith.constant 0 : index
+      %cond = arith.cmpi eq, %workload, %c0 : index
+      hal.return %cond : i1
+    } fallback(@export1) count(%device: !hal.device, %workload: index) -> (index, index, index) {
+      %c100 = arith.constant 100 : index
+      hal.return %workload, %c100, %c100 : index, index, index
+    }
+    // Secondary export to try. Fallback to @export2.
+    hal.executable.export public @export1 ordinal(1) layout(#pipeline_layout) condition(%device: !hal.device, %workload: index) -> i1 {
+      %c1 = arith.constant 1 : index
+      %cond = arith.cmpi eq, %workload, %c1 : index
+      hal.return %cond : i1
+    } fallback(@export2) count(%device: !hal.device, %workload: index) -> (index, index, index) {
+      %c101 = arith.constant 101 : index
+      hal.return %workload, %c101, %c101 : index, index, index
+    }
+    // Fallback export, always selected if reached.
+    hal.executable.export public @export2 ordinal(2) layout(#pipeline_layout) count(%device: !hal.device, %workload: index) -> (index, index, index) {
+      %102 = arith.constant 102 : index
+      hal.return %workload, %102, %102 : index, index, index
+    }
+    builtin.module {
+      // Opaque at this point (in some target-specific dialects).
+    }
+  }
+}
+
+util.global private @device : !hal.device
+
+// CHECK-LABEL: @cmdDispatchFallback
+//  CHECK-SAME: (%[[WORKLOAD:.+]]: index, %[[ARG_RESOURCE:.+]]: !hal.buffer)
+util.func public @cmdDispatchFallback(%workload: index, %arg_resource: !stream.resource<external>) -> !stream.timepoint {
+  %c0 = arith.constant 0 : index
+  %arg_size = arith.constant 200 : index
+  // CHECK: hal.command_buffer.create
+  %0 = stream.cmd.execute on(#hal.device.affinity<@device>) with(%arg_resource as %arg_capture: !stream.resource<external>{%arg_size}) {
+    // Try @export0:
+    // CHECK: %[[EXPORT0_COND:.+]] = arith.cmpi eq, %[[WORKLOAD]], %c0
+    // CHECK: %[[ORDINAL_COUNT:.+]]:4 = scf.if %[[EXPORT0_COND]]
+    // CHECK-DAG: %[[EXPORT0_ORDINAL:.+]] = hal.executable.export.ordinal target(@executable::@variant::@export0)
+    // CHECK-DAG: %[[EXPORT0_YZ:.+]] = arith.constant 100
+    // CHECK-NEXT: scf.yield %[[EXPORT0_ORDINAL]], %[[WORKLOAD]], %[[EXPORT0_YZ]], %[[EXPORT0_YZ]]
+    // CHECK-NEXT: } else {
+
+    // Fallback and try @export1:
+    // CHECK: %[[EXPORT1_COND:.+]] = arith.cmpi eq, %[[WORKLOAD]], %c1
+    // CHECK: %[[ORDINAL_COUNT12:.+]]:4 = scf.if %[[EXPORT1_COND]]
+    // CHECK-DAG: %[[EXPORT1_ORDINAL:.+]] = hal.executable.export.ordinal target(@executable::@variant::@export1)
+    // CHECK-DAG: %[[EXPORT1_YZ:.+]] = arith.constant 101
+    // CHECK-NEXT: scf.yield %[[EXPORT1_ORDINAL]], %[[WORKLOAD]], %[[EXPORT1_YZ]], %[[EXPORT1_YZ]]
+    // CHECK-NEXT: } else {
+
+    // Finally fallback to @export2 unconditionally:
+    // CHECK-DAG: %[[EXPORT2_ORDINAL:.+]] = hal.executable.export.ordinal target(@executable::@variant::@export2)
+    // CHECK-DAG: %[[EXPORT2_YZ:.+]] = arith.constant 102
+    // CHECK-NEXT: scf.yield %[[EXPORT2_ORDINAL]], %[[WORKLOAD]], %[[EXPORT2_YZ]], %[[EXPORT2_YZ]]
+
+    // CHECK: scf.yield %[[ORDINAL_COUNT12]]#0, %[[ORDINAL_COUNT12]]#1, %[[ORDINAL_COUNT12]]#2, %[[ORDINAL_COUNT12]]#3
+
+    // CHECK: hal.command_buffer.dispatch{{.+}}[%[[ORDINAL_COUNT]]#0]
+    // CHECK-SAME: workgroups([%[[ORDINAL_COUNT]]#1, %[[ORDINAL_COUNT]]#2, %[[ORDINAL_COUNT]]#3])
+    stream.cmd.dispatch @executable::@variant::@export0[%workload] {
+      wo %arg_capture[%c0 for %arg_size] : !stream.resource<external>{%arg_size}
+    }
+  } => !stream.timepoint
   util.return %0 : !stream.timepoint
 }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -2532,6 +2532,7 @@ def HAL_ExecutableEndOp : HAL_Op<"executable_end", [
 
 def HAL_ExecutableExportOp : HAL_Op<"executable.export", [
   Symbol,
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>,
   ParentOneOf<[
     "IREE::HAL::ExecutableSourceOp",
     "IREE::HAL::ExecutableVariantOp",
@@ -2547,6 +2548,24 @@ def HAL_ExecutableExportOp : HAL_Op<"executable.export", [
     returns the number of workgroups to use in the 3D grid dispatch.
     The arguments to the region represents the workload as captured by each
     dispatch. It returns the number of workgroups along x, y, and z.
+
+    The optional `condition` region provides boolean logic determining whether
+    the export should be dispatched given the device and workload or if a
+    specified fallback export in the same executable should be dispatched
+    instead. Multiple exports can be chained together as fallbacks to allow for
+    arbitrarily complex decisions trees. Fallbacks for an export must match the
+    layout and workload exactly but may vary any other attribute (such as
+    workgroup size or translation configuration).
+
+    Workgroup count and condition regions that have dependencies on dynamic
+    workload information will be executed using indirect dispatch. If the
+    information is available on the host at the time a command buffer containing
+    the dispatch is available the indirect dispatch _may_ have lower overhead
+    by using `IREE_HAL_DISPATCH_FLAG_STATIC_INDIRECT_PARAMETERS`. If the
+    information required is data-dependent on work within the same command
+    buffer some backends will suffer a performance penalty. Condition regions
+    consuming dynamic workloads in particular may result in long chains of
+    indirect dispatches sent to the device or even host round-trips.
   }];
 
   let arguments = (ins
@@ -2554,6 +2573,7 @@ def HAL_ExecutableExportOp : HAL_Op<"executable.export", [
     SymbolNameAttr:$sym_name,
     OptionalAttr<HAL_OrdinalAttr>:$ordinal,
     HAL_PipelineLayoutAttr:$layout,
+    OptionalAttr<FlatSymbolRefAttr>:$condition_fallback,
     OptionalAttr<HAL_WorkgroupSizeAttr>:$workgroup_size,
     OptionalAttr<HAL_SubgroupSizeAttr>:$subgroup_size,
     OptionalAttr<IndexAttr>:$workgroup_local_memory,
@@ -2561,7 +2581,8 @@ def HAL_ExecutableExportOp : HAL_Op<"executable.export", [
   );
 
   let regions = (region
-    AnyRegion:$workgroup_count
+    AnyRegion:$workgroup_count,
+    AnyRegion:$condition
   );
 
   let assemblyFormat = [{
@@ -2569,7 +2590,9 @@ def HAL_ExecutableExportOp : HAL_Op<"executable.export", [
     $sym_name
     (`ordinal` `(` $ordinal^ `)`)?
     `layout` `(` qualified($layout) `)`
-    custom<OptionalWorkgroupCountRegion>($workgroup_count)
+    (`condition` `` custom<ExportConditionRegion>($condition)^)?
+    (`fallback` `(` $condition_fallback^ `)`)?
+    (`count` `` custom<WorkgroupCountRegion>($workgroup_count)^)?
     attr-dict-with-keyword
   }];
 
@@ -2583,14 +2606,26 @@ def HAL_ExecutableExportOp : HAL_Op<"executable.export", [
       "::mlir::IntegerAttr":$workgroup_local_memory
     ), [{
       build($_builder, $_state, nullptr, sym_name, ordinal, layout,
+            /*condition_fallback=*/FlatSymbolRefAttr{},
             workgroup_size, subgroup_size, workgroup_local_memory,
-            DictionaryAttr{});
+            /*source_locs=*/DictionaryAttr{});
     }]>,
   ];
 
+  let hasCanonicalizer = 1;
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
+    Block* getConditionBody() {
+      if (getCondition().empty()) return nullptr;
+      return &getCondition().front();
+    }
+
+    // Calculates whether the condition region (if any) evaluates to true for
+    // the export.
+    Value calculateCondition(
+        Location loc, Value device, ValueRange workload, OpBuilder &builder);
+
     /// For now assume that the workload is at max 3D.
     /// Arguments to the region are workload along x, y and z.
     // TODO: Propogate this and avoid magic constants.

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/ConvertToHAL.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/ConvertToHAL.cpp
@@ -45,6 +45,19 @@ namespace {
 // --iree-hal-conversion
 //===----------------------------------------------------------------------===//
 
+static void stripExportRegions(ModuleOp moduleOp) {
+  for (auto executableOp : moduleOp.getOps<IREE::HAL::ExecutableOp>()) {
+    for (auto variantOp :
+         executableOp.getOps<IREE::HAL::ExecutableVariantOp>()) {
+      for (auto exportOp : variantOp.getOps<IREE::HAL::ExecutableExportOp>()) {
+        exportOp.removeConditionFallbackAttr();
+        exportOp.getCondition().getBlocks().clear();
+        exportOp.getWorkgroupCount().getBlocks().clear();
+      }
+    }
+  }
+}
+
 struct ConvertToHALPass
     : public IREE::HAL::impl::ConvertToHALPassBase<ConvertToHALPass> {
   void runOnOperation() override {
@@ -88,6 +101,10 @@ struct ConvertToHALPass
                                       std::move(patterns)))) {
       return signalPassFailure();
     }
+
+    // Drop executable export regions we no longer need. This reduces the
+    // visible IR and prevents confusion as to when they are required.
+    stripExportRegions(moduleOp);
 
     // Cleanup conversion attributes used for spooky action at a distance.
     moduleOp->removeAttr("stream.affinity.default");

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
@@ -466,10 +466,12 @@ void buildHALTransformPassPipeline(OpPassManager &passManager,
     passManager.addPass(IREE::HAL::createOutlineMemoizeRegionsPass());
   }
 
-  // Prune unused executables and their contents.
-  passManager.addPass(IREE::HAL::createPruneExecutablesPass());
-
   addCleanupPatterns(passManager);
+
+  // Prune unused executables and their contents.
+  // After conversion any unused exports will be dropped allowing for
+  // serialization to drop their contents.
+  passManager.addPass(IREE::HAL::createPruneExecutablesPass());
 
   //----------------------------------------------------------------------------
   // Executable packing and runtime loading

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/PruneExecutables.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/PruneExecutables.cpp
@@ -69,10 +69,10 @@ static bool reachableAsFallback(ArrayRef<Attribute> users,
       // The user treating the given symbol as a fallback is used directly.
       return true;
     }
-    if (!reachableAsFallback(referenceMap[user].fallbackOf, referenceMap)) {
+    if (reachableAsFallback(referenceMap[user].fallbackOf, referenceMap)) {
       // The user treating the given symbol as a fallback itself is a fallback
       // that has uses.
-      return false;
+      return true;
     }
   }
   return false;

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/PruneExecutables.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/PruneExecutables.cpp
@@ -23,6 +23,7 @@ namespace {
 struct SymbolReferences {
   Operation *symbolOp;
   unsigned count = 0;
+  SmallVector<Attribute> fallbackOf;
 };
 using SymbolReferenceMap = DenseMap<Attribute, SymbolReferences>;
 
@@ -59,12 +60,32 @@ static void processOp(Operation *op, SymbolReferenceMap &referenceMap) {
   }
 }
 
+// Returns true if the users treating a symbol as a fallback are transitively
+// reachable directly or as fallbacks for reachable symbols.
+static bool reachableAsFallback(ArrayRef<Attribute> users,
+                                SymbolReferenceMap &referenceMap) {
+  for (auto user : users) {
+    if (referenceMap[user].count > 0) {
+      // The user treating the given symbol as a fallback is used directly.
+      return true;
+    }
+    if (!reachableAsFallback(referenceMap[user].fallbackOf, referenceMap)) {
+      // The user treating the given symbol as a fallback itself is a fallback
+      // that has uses.
+      return false;
+    }
+  }
+  return false;
+}
+
 static void eraseOps(ArrayRef<Attribute> symbolRefAttrs,
                      SymbolReferenceMap &referenceMap) {
   for (auto symbolRefAttr : symbolRefAttrs) {
     auto &symbolRefs = referenceMap[symbolRefAttr];
-    if (symbolRefs.count == 0)
+    if (symbolRefs.count == 0 &&
+        !reachableAsFallback(symbolRefs.fallbackOf, referenceMap)) {
       symbolRefs.symbolOp->erase();
+    }
   }
 }
 
@@ -83,7 +104,7 @@ struct PruneExecutablesPass
     SymbolReferenceMap referenceMap;
     SmallVector<Attribute> executableRefAttrs;
     SmallVector<Attribute> variantRefAttrs;
-    SmallVector<Attribute> exportRefAttrs;
+    SetVector<Attribute> exportRefAttrs;
     for (auto executableOp : moduleOp.getOps<IREE::HAL::ExecutableOp>()) {
       ignoredOps.insert(executableOp);
       if (!executableOp.isPrivate())
@@ -112,7 +133,21 @@ struct PruneExecutablesPass
                   FlatSymbolRefAttr::get(exportOp.getSymNameAttr()),
               });
           referenceMap[exportRefAttr].symbolOp = exportOp;
-          exportRefAttrs.push_back(exportRefAttr);
+          exportRefAttrs.insert(exportRefAttr);
+          if (auto localFallbackAttr = exportOp.getConditionFallbackAttr()) {
+            auto fallbackRefAttr = SymbolRefAttr::get(
+                executableOp.getSymNameAttr(),
+                {
+                    FlatSymbolRefAttr::get(variantOp.getSymNameAttr()),
+                    localFallbackAttr,
+                });
+            auto fallbackOp = SymbolTable::lookupNearestSymbolFrom(
+                exportOp, localFallbackAttr);
+            auto &fallbackRefs = referenceMap[fallbackRefAttr];
+            fallbackRefs.symbolOp = fallbackOp;
+            fallbackRefs.fallbackOf.push_back(exportRefAttr);
+            exportRefAttrs.insert(fallbackRefAttr);
+          }
         }
       }
     }
@@ -132,7 +167,7 @@ struct PruneExecutablesPass
     // Erase any executable-related op with no references.
     // We have to start with exports > variants > executables so that we don't
     // erase a container before the nested ops.
-    eraseOps(exportRefAttrs, referenceMap);
+    eraseOps(exportRefAttrs.getArrayRef(), referenceMap);
     eraseOps(variantRefAttrs, referenceMap);
     eraseOps(executableRefAttrs, referenceMap);
   }

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/convert_to_hal.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/convert_to_hal.mlir
@@ -20,6 +20,8 @@ util.global private @device : !hal.device
 // CHECK: hal.executable private @ex
 hal.executable private @ex {
   hal.executable.variant public @embedded_elf_aarch64 target(#executable_target_embedded_elf_aarch64) {
+    // CHECK: hal.executable.export public @dispatch
+    // CHECK-NOT: count
     hal.executable.export public @dispatch ordinal(0) layout(#pipeline_layout) count(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index) -> (index, index, index) {
       %c1 = arith.constant 1 : index
       %0 = affine.apply affine_map<()[s0] -> (s0 ceildiv 4)>()[%arg0]


### PR DESCRIPTION
The region will be evaluated at each dispatch site with the device and workload (same as with the count region). If the region returns true the particular export will be dispatched and otherwise a specified fallback export within the same executable will be attempted (which itself may have a condition region).

The intent is that executable translation can produce one or more fallbacks to a particular dispatch based on dynamic parameters (device capabilities/configuration like shared workgroup memory or workload like specializing for GEMM or GEMV based on dynamic dimensions). As a simple example:
```mlir
hal.executable @export_with_condition_region {
  hal.executable.variant @backend target(#executable_target_format) {
    // Dispatching @specialized_lt_1024 will first check whether the workload is
    // < 1024 - if it is then @specialized_lt_1024 will be executed and
    // otherwise @specialized_lt_2048 will be checked next.
    hal.executable.export public @specialized_lt_1024 ordinal(0) layout(#layout) condition(%device: !hal.device, %workload: index) -> i1 {
      %c1024 = arith.constant 1024 : index
      %use_me = arith.cmpi slt, %workload, %c1024 : index
      hal.return %use_me : i1
    } fallback(@specialized_lt_2048)
    // This can be dispatched directly if the workload is < 2048 and otherwise
    // chain on to @fallback_generic.
    hal.executable.export public @specialized_lt_2048 ordinal(1) layout(#layout) condition(%device: !hal.device, %workload: index) -> i1 {
      %c2048 = arith.constant 2048 : index
      %use_me = arith.cmpi slt, %workload, %c2048 : index
      hal.return %use_me : i1
    } fallback(@fallback_generic)
    // Not specifying a fallback ends the chain. This can still be dispatched
    // directly, and after optimizations may be (if we can prove with range
    // analysis that the workload is >= 2048, for example).
    hal.executable.export public @fallback_generic ordinal(2) layout(#layout)
  }
}
```

After the conditions are inlined at each dispatch site constant folding, value range analysis/propagation, and CSE/hoisting allow for simplification. Device queries will be memoized as in other contexts and hoisted up to the top of the command buffer and still allow for command buffer memoization. Dynamic workload parameters will currently prevent memoization but in the future the condition region will be used to perform device-side selection (CPU/AMDGPU). Condition regions using dynamic workload parameters without range information from frontends and ops that can be folded using it are considered performance hostile in general, though there may be some special cases the design of this chained condition enable with indirect dispatch that make it not _so_ bad (depending on if the target is able to cull).

This was designed to be compatible with hoisting for memoization but the lowering during stream->hal conversion will likely need some iteration. Executables containing the regions should not need to change and users can start producing executables with fallbacks today.

The final IR of the new test added for stream->hal lowering shows how the logic works at each dispatch site:
```mlir
#executable_target_embedded_elf_aarch64 = #hal.executable.target<"llvm-cpu", "embedded-elf-aarch64">
#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, Indirect>]>
module {
  hal.executable private @executable {
    hal.executable.variant public @variant target(#executable_target_embedded_elf_aarch64) {
      hal.executable.export public @export0 ordinal(0) layout(#pipeline_layout) condition(%arg0: !hal.device, %arg1: index) -> i1 {
        %c0 = arith.constant 0 : index
        %0 = arith.cmpi eq, %arg1, %c0 : index
        hal.return %0 : i1
      } fallback(@export1) count(%arg0: !hal.device, %arg1: index) -> (index, index, index) {
        %c100 = arith.constant 100 : index
        hal.return %arg1, %c100, %c100 : index, index, index
      }
      hal.executable.export public @export1 ordinal(1) layout(#pipeline_layout) condition(%arg0: !hal.device, %arg1: index) -> i1 {
        %c1 = arith.constant 1 : index
        %0 = arith.cmpi eq, %arg1, %c1 : index
        hal.return %0 : i1
      } fallback(@export2) count(%arg0: !hal.device, %arg1: index) -> (index, index, index) {
        %c101 = arith.constant 101 : index
        hal.return %arg1, %c101, %c101 : index, index, index
      } 
      hal.executable.export public @export2 ordinal(2) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index) -> (index, index, index) {
        %c102 = arith.constant 102 : index
        hal.return %arg1, %c102, %c102 : index, index, index
      }
      builtin.module {
      }
    }
  }
  util.global private @device : !hal.device
  util.func public @cmdDispatchFallback(%arg0: index, %arg1: !hal.buffer) -> !hal.fence {
    %c0 = arith.constant 0 : index
    %c200 = arith.constant 200 : index
    %device = util.global.load immutable @device : !hal.device
    %c-1_i64 = arith.constant -1 : i64
    %0 = hal.device.memoize<%device : !hal.device> affinity(%c-1_i64) -> !hal.command_buffer {
      %c1 = arith.constant 1 : index
      %cmd = hal.command_buffer.create device(%device : !hal.device) mode("None") categories("Transfer|Dispatch") affinity(%c-1_i64) bindings(%c1) : !hal.command_buffer
      %2 = hal.command_buffer.device<%cmd : !hal.command_buffer> : !hal.device
      %exe = hal.executable.lookup device(%2 : !hal.device) executable(@executable) : !hal.executable
      %3 = arith.cmpi eq, %arg0, %c0 : index
      %4:4 = scf.if %3 -> (index, index, index, index) {
        %ordinal = hal.executable.export.ordinal target(@executable::@variant::@export0) : index
        %c100 = arith.constant 100 : index
        scf.yield %ordinal, %arg0, %c100, %c100 : index, index, index, index
      } else {
        %5 = arith.cmpi eq, %arg0, %c1 : index
        %6:4 = scf.if %5 -> (index, index, index, index) {
          %ordinal = hal.executable.export.ordinal target(@executable::@variant::@export1) : index
          %c101 = arith.constant 101 : index
          scf.yield %ordinal, %arg0, %c101, %c101 : index, index, index, index
        } else {
          %ordinal = hal.executable.export.ordinal target(@executable::@variant::@export2) : index
          %c102 = arith.constant 102 : index
          scf.yield %ordinal, %arg0, %c102, %c102 : index, index, index, index
        }
        scf.yield %6#0, %6#1, %6#2, %6#3 : index, index, index, index
      }
      hal.command_buffer.dispatch<%cmd : !hal.command_buffer> target(%exe : !hal.executable)[%4#0] workgroups([%4#1, %4#2, %4#3]) bindings([
        (%c0 : index)[%c0, %c200]
      ]) flags("None")
      hal.command_buffer.execution_barrier<%cmd : !hal.command_buffer> source("Dispatch|Transfer|CommandRetire") target("CommandIssue|Dispatch|Transfer") flags("None")
      hal.command_buffer.finalize<%cmd : !hal.command_buffer>
      hal.return %cmd : !hal.command_buffer
    }
    %1 = util.null : !hal.fence
    %fence = hal.fence.create device(%device : !hal.device) flags("None") : !hal.fence
    hal.device.queue.execute.indirect<%device : !hal.device> affinity(%c-1_i64) wait(%1) signal(%fence) commands(%0) bindings([
      (%arg1 : !hal.buffer)[%c0, %c200]
    ]) flags("None")
    util.return %fence : !hal.fence
  }
}
```

Note that because the condition logic is inlined any device queries that can resolve to the device used have the opportunity to be folded and any arithmetic on the workload that results in the condition can use value range analysis to fold. The same export chain dispatched 100 times in a command buffer may reduce to a smaller set (or potentially a single selection) based on the workload for each. If any exports are never selected the PruneExecutablesPass will remove them prior to serializing executables. Codegen pipelines will need to perform their own DCE for functions not reachable from any export (they currently do not AFAIK).

Fixes #20660.