### PR TITLE
[Encoding] Add getOffsetSizesStrides interface for load/store materialization

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingUtils.h
@@ -9,23 +9,11 @@
 
 #include "iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.h"
 #include "iree/compiler/Dialect/Encoding/IR/EncodingOps.h"
-#include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtTypes.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Transforms/DialectConversion.h"
 
 namespace mlir::iree_compiler {
-
-using MaterializeEncodingFn =
-    std::function<FailureOr<IREE::Codegen::MaterializeEncodingInfo>(
-        RankedTensorType, IREE::HAL::ExecutableTargetAttr targetAttr)>;
-
-struct MaterializeEncodingValueInfo {
-  SmallVector<Value> innerTileSizes;
-};
-
-using MaterializeEncodingValueFn =
-    std::function<FailureOr<MaterializeEncodingValueInfo>(
-        RankedTensorType, OpBuilder &, Location)>;
 
 //===---------------------------------------------------------------------===//
 // TypeConverter
@@ -35,8 +23,7 @@ using MaterializeEncodingValueFn =
 class MaterializeEncodingTypeConverter : public TypeConverter {
 public:
   MaterializeEncodingTypeConverter(
-      IREE::Encoding::LayoutAttrInterface layoutAttr,
-      MaterializeEncodingValueFn materializeEncodingValueFn);
+      IREE::Encoding::LayoutAttrInterface layoutAttr);
 
   const IREE::Encoding::LayoutAttrInterface &getLayoutAttr() const {
     return layoutAttr;
@@ -45,14 +32,35 @@ public:
   IREE::Codegen::MaterializeEncodingInfo
   getEncodingInfo(RankedTensorType type) const;
 
+  /// Returns the inner tile sizes to be used for the given tensor type.
   FailureOr<SmallVector<OpFoldResult>> getInnerTileSizesOfr(
       OpBuilder &rewriter, Location loc, RankedTensorType tensorType,
       const IREE::Codegen::MaterializeEncodingInfo &materializeEncodingInfo)
       const;
 
+  /// Returns the materialized packed and swizzled shape for a
+  /// `dispatchTensorType` that binds a `RankedTensorType` with encoding. The
+  /// dynamic dimension sizes of the `dispatchTensorType` are provided in
+  /// `dynamicDims`.
+  FailureOr<SmallVector<OpFoldResult>> getPackedDimsForDispatchTensor(
+      OpBuilder &builder, Location loc,
+      IREE::TensorExt::DispatchTensorType dispatchTensorType,
+      ValueRange dynamicDims) const;
+
+  /// Returns success if materialized `newOffsets`, `newSizes` and `newStrides`
+  /// can be calculated and set for the slice specified by `offsets`, `sizes`
+  /// and `strides` on the dispatch tensor `type` with potential `dynamicDims`
+  /// sizes.
+  LogicalResult getOffsetsSizesStrides(
+      OpBuilder &builder, Location loc,
+      IREE::TensorExt::DispatchTensorType type, ValueRange dynamicDims,
+      ArrayRef<OpFoldResult> offsets, ArrayRef<OpFoldResult> sizes,
+      ArrayRef<OpFoldResult> strides, SmallVectorImpl<OpFoldResult> &newOffsets,
+      SmallVectorImpl<OpFoldResult> &newSizes,
+      SmallVectorImpl<OpFoldResult> &newStrides) const;
+
 private:
   const IREE::Encoding::LayoutAttrInterface layoutAttr;
-  const MaterializeEncodingValueFn materializeEncodingValueFn;
 };
 
 /// Conversion target to use for for materializing the encoding.
@@ -85,6 +93,10 @@ FailureOr<Value> lowerUnsetEncodingToUnpackOp(
 /// Populates the set of patterns that lowers operations with encoding types to
 /// operations without encodings.
 void populateMaterializeEncodingPatterns(
+    RewritePatternSet &patterns, MaterializeEncodingConversionTarget &target,
+    MaterializeEncodingTypeConverter &typeConverter);
+
+void populateLoadStoreMaterializeEncodingPatterns(
     RewritePatternSet &patterns, MaterializeEncodingConversionTarget &target,
     MaterializeEncodingTypeConverter &typeConverter);
 

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoNop.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoNop.cpp
@@ -36,17 +36,10 @@ struct MaterializeEncodingIntoNopPass final
     MLIRContext *context = &getContext();
     FunctionOpInterface operation = getOperation();
 
-    auto materializeEncodingValueFn =
-        [](RankedTensorType, OpBuilder &,
-           Location) -> FailureOr<MaterializeEncodingValueInfo> {
-      return failure();
-    };
-
     RewritePatternSet materializeEncodingPattern(context);
     auto layoutAttr = cast<IREE::Encoding::LayoutAttrInterface>(
         IREE::Codegen::EncodingNopLayoutAttr::get(context));
-    MaterializeEncodingTypeConverter typeConverter(layoutAttr,
-                                                   materializeEncodingValueFn);
+    MaterializeEncodingTypeConverter typeConverter(layoutAttr);
     MaterializeEncodingConversionTarget target(*context);
     populateMaterializeEncodingPatterns(materializeEncodingPattern, target,
                                         typeConverter);

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPadding.cpp
@@ -88,10 +88,8 @@ static RankedTensorType getPaddedType(Attribute layoutAttr,
 struct MaterializePadEncodingTypeConverter final
     : MaterializeEncodingTypeConverter {
   MaterializePadEncodingTypeConverter(
-      IREE::Encoding::LayoutAttrInterface layoutAttr,
-      MaterializeEncodingValueFn materializeEncodingValueFn)
-      : MaterializeEncodingTypeConverter(layoutAttr,
-                                         materializeEncodingValueFn) {
+      IREE::Encoding::LayoutAttrInterface layoutAttr)
+      : MaterializeEncodingTypeConverter(layoutAttr) {
     addConversion([](RankedTensorType type) -> std::optional<RankedTensorType> {
       // The type converter is designed for `pad_encoding_layout` encoding
       // attribute. By the definition, the final converted type is the same
@@ -279,12 +277,6 @@ struct MaterializeEncodingIntoPaddingPass final
     MLIRContext *context = &getContext();
     FunctionOpInterface operation = getOperation();
 
-    auto materializeEncodingValueFn =
-        [](RankedTensorType, OpBuilder &,
-           Location) -> FailureOr<MaterializeEncodingValueInfo> {
-      return failure();
-    };
-
     // Retrieve the config from executable target attribute, if any. Otherwise,
     // retrieve the config from CLI GPU target and construct a virtual
     // configuration.
@@ -321,8 +313,7 @@ struct MaterializeEncodingIntoPaddingPass final
     }
 
     RewritePatternSet materializeEncodingPattern(context);
-    MaterializePadEncodingTypeConverter typeConverter(
-        layoutAttr, materializeEncodingValueFn);
+    MaterializePadEncodingTypeConverter typeConverter(layoutAttr);
     MaterializeEncodingConversionTarget target(*context);
     populateMaterializeEncodingPatterns(materializeEncodingPattern, target,
                                         typeConverter);

--- a/compiler/src/iree/compiler/Codegen/Utils/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Utils/BUILD.bazel
@@ -18,6 +18,7 @@ iree_compiler_cc_library(
     name = "Utils",
     srcs = [
         "CPUUtils.cpp",
+        "EncodingUtils.cpp",
         "GPUUtils.cpp",
         "LinalgOpInfo.cpp",
         "LinkingUtils.cpp",
@@ -26,6 +27,7 @@ iree_compiler_cc_library(
     ],
     hdrs = [
         "CPUUtils.h",
+        "EncodingUtils.h",
         "GPUUtils.h",
         "LinalgOpInfo.h",
         "LinkingUtils.h",
@@ -33,7 +35,9 @@ iree_compiler_cc_library(
         "Utils.h",
     ],
     deps = [
+        "//compiler/src/iree/compiler/Codegen/Dialect/CPU/IR:IREECPUDialect",
         "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR:IREECodegenDialect",
+        "//compiler/src/iree/compiler/Codegen/Dialect/Codegen/Utils",
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/IR:IREEGPUDialect",
         "//compiler/src/iree/compiler/Codegen/Dialect/GPU/TargetUtils:KnownTargets",
         "//compiler/src/iree/compiler/Codegen/Interfaces:PartitionableLoopsInterface",
@@ -51,6 +55,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:ArithUtils",
+        "@llvm-project//mlir:DialectUtils",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:FunctionInterfaces",
         "@llvm-project//mlir:GPUDialect",

--- a/compiler/src/iree/compiler/Codegen/Utils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Utils/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_cc_library(
     Utils
   HDRS
     "CPUUtils.h"
+    "EncodingUtils.h"
     "GPUUtils.h"
     "LinalgOpInfo.h"
     "LinkingUtils.h"
@@ -22,6 +23,7 @@ iree_cc_library(
     "Utils.h"
   SRCS
     "CPUUtils.cpp"
+    "EncodingUtils.cpp"
     "GPUUtils.cpp"
     "LinalgOpInfo.cpp"
     "LinkingUtils.cpp"
@@ -56,7 +58,9 @@ iree_cc_library(
     MLIRVectorDialect
     MLIRVectorTransforms
     MLIRViewLikeInterface
+    iree::compiler::Codegen::Dialect::CPU::IR::IREECPUDialect
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
+    iree::compiler::Codegen::Dialect::Codegen::Utils
     iree::compiler::Codegen::Dialect::GPU::IR::IREEGPUDialect
     iree::compiler::Codegen::Dialect::GPU::TargetUtils::KnownTargets
     iree::compiler::Codegen::Interfaces::PartitionableLoopsInterface

--- a/compiler/src/iree/compiler/Codegen/Utils/EncodingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/EncodingUtils.cpp
@@ -1,0 +1,122 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Utils/EncodingUtils.h"
+
+#include "iree/compiler/Codegen/Dialect/CPU/IR/IREECPUTypes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/Utils/Utils.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
+#include "mlir/Dialect/Utils/IndexingUtils.h"
+
+namespace mlir::iree_compiler {
+
+std::optional<IREE::Codegen::MaterializeEncodingInfo>
+getEncodingInfoFromLayouts(RankedTensorType type) {
+  auto layoutAttr =
+      dyn_cast_or_null<IREE::Encoding::LayoutAttr>(type.getEncoding());
+  if (!layoutAttr) {
+    return std::nullopt;
+  }
+  ArrayRef<Attribute> layouts = layoutAttr.getLayouts().getValue();
+  assert(layouts.size() == 1 && "only single layout is supported");
+  if (auto layout =
+          dyn_cast<IREE::Codegen::PackedLayoutAttrInterface>(layouts[0])) {
+    return layout.getEncodingInfo(type);
+  }
+  return std::nullopt;
+}
+
+FailureOr<SmallVector<OpFoldResult>> getInnerTileSizesOfrImpl(
+    OpBuilder &rewriter, Location loc, RankedTensorType tensorType,
+    IREE::Encoding::LayoutAttrInterface layoutAttr,
+    const IREE::Codegen::MaterializeEncodingInfo &materializeEncodingInfo) {
+  ArrayRef<int64_t> staticTileSizes = materializeEncodingInfo.innerTileSizes;
+  if (!ShapedType::isDynamicShape(staticTileSizes)) {
+    return getAsOpFoldResult(rewriter.getI64ArrayAttr(staticTileSizes));
+  }
+
+  // Only VMVX with ukernel config supports dynamic inner tile sizes.
+  auto vmvxLayoutAttr = dyn_cast<IREE::CPU::VMVXEncodingLayoutAttr>(layoutAttr);
+  if (!vmvxLayoutAttr || !hasUkernel(vmvxLayoutAttr.getConfiguration())) {
+    return failure();
+  }
+  SmallVector<Type> resultTypes(tensorType.getRank(), rewriter.getIndexType());
+  auto op = rewriter.create<IREE::Codegen::QueryTileSizesOp>(
+      loc, resultTypes, TypeAttr::get(tensorType));
+  SmallVector<Value> innerTileSizeValues = op.getResults();
+
+  SmallVector<OpFoldResult> result(staticTileSizes.size());
+  for (size_t i = 0; i < result.size(); ++i) {
+    if (ShapedType::isDynamic(staticTileSizes[i])) {
+      result[i] = innerTileSizeValues[i];
+    } else if (tensorType.isDynamicDim(i)) {
+      result[i] =
+          rewriter.create<arith::ConstantIndexOp>(loc, staticTileSizes[i])
+              .getResult();
+    } else {
+      result[i] = rewriter.getI64IntegerAttr(staticTileSizes[i]);
+    }
+  }
+  return result;
+}
+
+FailureOr<SmallVector<OpFoldResult>> getPackedDimsForDispatchTensorImpl(
+    OpBuilder &builder, Location loc,
+    IREE::TensorExt::DispatchTensorType dispatchTensorType,
+    ValueRange dynamicDims, IREE::Encoding::LayoutAttrInterface layoutAttr,
+    IREE::Codegen::MaterializeEncodingInfo encodingInfo) {
+  auto boundTensorType =
+      llvm::dyn_cast<RankedTensorType>(dispatchTensorType.getBoundType());
+  if (!boundTensorType) {
+    return failure();
+  }
+
+  if (IREE::Codegen::isIdentityLayout(encodingInfo)) {
+    return failure();
+  }
+
+  SmallVector<OpFoldResult> targetShape =
+      getMixedValues(boundTensorType.getShape(), dynamicDims, builder);
+  auto innerTileSizes = getInnerTileSizesOfrImpl(builder, loc, boundTensorType,
+                                                 layoutAttr, encodingInfo);
+  if (failed(innerTileSizes)) {
+    return failure();
+  }
+  SmallVector<OpFoldResult> convertedTargetShape =
+      linalg::PackOp::getResultShape(builder, loc, targetShape, *innerTileSizes,
+                                     encodingInfo.innerDimsPos,
+                                     encodingInfo.outerDimsPerm);
+  return getSwizzledShape(convertedTargetShape, encodingInfo);
+}
+
+SmallVector<OpFoldResult>
+getSwizzledShape(ArrayRef<OpFoldResult> packedShape,
+                 IREE::Codegen::MaterializeEncodingInfo encodingInfo) {
+  if (packedShape.empty() || !encodingInfo.swizzle) {
+    return SmallVector<OpFoldResult>(packedShape);
+  }
+
+  int64_t srcRank = packedShape.size() - encodingInfo.innerTileSizes.size();
+  SmallVector<int64_t> perm = llvm::to_vector(llvm::seq<int64_t>(0, srcRank));
+  for (auto i : encodingInfo.swizzle->permutation) {
+    perm.push_back(i + srcRank);
+  }
+
+  SmallVector<OpFoldResult> newShape(packedShape.take_front(srcRank));
+  SmallVector<int64_t> expandedTileShape =
+      IREE::Codegen::getExpandedTileShape(encodingInfo.swizzle->expandShape);
+  MLIRContext *ctx = packedShape[0].getContext();
+  Builder b(ctx);
+  for (int64_t d : expandedTileShape) {
+    newShape.push_back(b.getIndexAttr(d));
+  }
+  applyPermutationToVector(newShape, perm);
+
+  return newShape;
+}
+
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Utils/EncodingUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/EncodingUtils.h
@@ -1,0 +1,47 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_UTILS_ENCODINGUTILS_H_
+#define IREE_COMPILER_CODEGEN_UTILS_ENCODINGUTILS_H_
+
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenTypes.h"
+#include "iree/compiler/Dialect/Encoding/IR/EncodingTypes.h"
+#include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtTypes.h"
+#include "llvm/ADT/SmallVector.h"
+#include "mlir/IR/OpDefinition.h"
+
+namespace mlir::iree_compiler {
+
+/// Extracts encoding info for materialization from the layout attribute of a
+/// tensor type.
+std::optional<IREE::Codegen::MaterializeEncodingInfo>
+getEncodingInfoFromLayouts(RankedTensorType type);
+
+/// Returns the inner tile sizes to be used for the given tensor type.
+FailureOr<SmallVector<OpFoldResult>> getInnerTileSizesOfrImpl(
+    OpBuilder &rewriter, Location loc, RankedTensorType tensorType,
+    IREE::Encoding::LayoutAttrInterface layoutAttr,
+    const IREE::Codegen::MaterializeEncodingInfo &materializeEncodingInfo);
+
+/// Returns the materialized packed and swizzled shape for a
+/// `dispatchTensorType` that binds a `RankedTensorType` with encoding. The
+/// dynamic dimension sizes of the `dispatchTensorType` are provided in
+/// `dynamicDims`.
+FailureOr<SmallVector<OpFoldResult>> getPackedDimsForDispatchTensorImpl(
+    OpBuilder &builder, Location loc,
+    IREE::TensorExt::DispatchTensorType dispatchTensorType,
+    ValueRange dynamicDims, IREE::Encoding::LayoutAttrInterface layoutAttr,
+    IREE::Codegen::MaterializeEncodingInfo encodingInfo);
+
+/// Applies an returns a tile-swizzling permutation to a packed shape.
+SmallVector<OpFoldResult>
+getSwizzledShape(ArrayRef<OpFoldResult> packedShape,
+                 IREE::Codegen::MaterializeEncodingInfo encodingInfo);
+
+} // namespace mlir::iree_compiler
+
+#endif // IREE_COMPILER_CODEGEN_UTILS_ENCODINGUTILS_H_

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/BUILD.bazel
@@ -67,6 +67,7 @@ iree_compiler_cc_library(
         ":EncodingInterfacesGen",
         ":EncodingOpsIncGen",
         ":EncodingTypesGen",
+        "//compiler/src/iree/compiler/Dialect/TensorExt/IR",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:DialectUtils",

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/CMakeLists.txt
@@ -52,6 +52,7 @@ iree_cc_library(
     MLIRSupport
     MLIRTensorDialect
     MLIRTensorUtils
+    iree::compiler::Dialect::TensorExt::IR
   PUBLIC
 )
 

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
@@ -215,6 +215,8 @@ def IREEEncoding_LayoutAttrInterface :
 
     These are the core methods:
     - `convertType`: converts a type to its materialized form.
+    - `getOffsetsSizesStrides`: to retrieve the materialized new
+      offsets, sizes and strides for load/store type operations.
     - `lowerOp`: converts an operation to its materialized form.
   }];
 
@@ -232,6 +234,33 @@ def IREEEncoding_LayoutAttrInterface :
       /*defaultImplementation=*/[{
         assert(false && "unimplemented interface method");
         return type;
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns success if materialized `newOffsets`, `newSizes` and
+        `newStrides` can be calculated and set for the slice specified by
+        `offsets`, `sizes` and `strides` on the dispatch tensor `type` with
+        potential `dynamicDims` sizes.
+      }],
+      /*retTy=*/"::mlir::LogicalResult",
+      /*methodName=*/"getOffsetsSizesStrides",
+      /*args=*/(ins
+        "::mlir::OpBuilder &":$builder,
+        "::mlir::Location":$loc,
+        "IREE::TensorExt::DispatchTensorType":$type,
+        "::mlir::ValueRange":$dynamicDims,
+        "ArrayRef<OpFoldResult>":$offsets,
+        "ArrayRef<OpFoldResult>":$sizes,
+        "ArrayRef<OpFoldResult>":$strides,
+        "::llvm::SmallVectorImpl<OpFoldResult> &":$newOffsets,
+        "::llvm::SmallVectorImpl<OpFoldResult> &":$newSizes,
+        "::llvm::SmallVectorImpl<OpFoldResult> &":$newStrides
+      ),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        assert(false && "unimplemented interface method");
+        return failure();
       }]
     >,
     InterfaceMethod<

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.h
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingTypes.h
@@ -7,6 +7,7 @@
 #ifndef IREE_COMPILER_DIALECT_ENCODING_IR_ENCODINGTYPES_H_
 #define IREE_COMPILER_DIALECT_ENCODING_IR_ENCODINGTYPES_H_
 
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtTypes.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -14,6 +15,7 @@
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Support/LogicalResult.h"
 
 namespace mlir::iree_compiler::IREE::Encoding {
 

--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtTypes.h
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtTypes.h
@@ -11,6 +11,7 @@
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringSwitch.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/OpImplementation.h"
@@ -124,6 +125,13 @@ public:
     }
     return llvm::cast<RankedTensorType>(boundType);
   }
+
+  /// Returns `true` if the slice (described by the `offset`, `sizes` and
+  /// `strides`) spans the dispatch tensor type.
+  bool doesSliceSpanWholeTensor(ValueRange dispatchTypeDims,
+                                ArrayRef<OpFoldResult> offsets,
+                                ArrayRef<OpFoldResult> sizes,
+                                ArrayRef<OpFoldResult> strides) const;
 };
 
 void printType(DispatchTensorType &type, DialectAsmPrinter &p);


### PR DESCRIPTION
This PR adds the `getOffsetSizesStrides` interface method as part of the effort to collapse MaterializeEncodingIntoPadding into MaterializeEncoding: https://github.com/iree-org/iree/issues/20160. 

This should enable the collapsing of the padding materialization patterns for `dispatch.tensor.load` and `dispatch.tensor.store` into the generic one, however,  this is intentionally left out of the PR as @MaheshRavishankar is looking at adjusting the MaterializeEncodingIntoPadding pass for dynamic padding. 

The declaration looks like this:
```cpp
/// Returns success if materialized `newOffsets`, `newSizes` and
/// `newStrides` can be calculated and set for the slice specified by
/// `offsets`, `sizes` and `strides` on the dispatch tensor `type` with
/// potential `dynamicDims` sizes.
LogicalResult
getOffsetsSizesStrides(OpBuilder &builder, Location loc,
                         IREE::TensorExt::DispatchTensorType type,
                         IREE::Codegen::LayoutAttrInterface layoutAttr,
                         ValueRange dynamicDims,
                         ArrayRef<OpFoldResult> offsets,
                         ArrayRef<OpFoldResult> sizes,
                         ArrayRef<OpFoldResult> strides,
                         SmallVectorImpl<OpFoldResult> &newOffsets,
                         SmallVectorImpl<OpFoldResult> &newSizes,
                         SmallVectorImpl<OpFoldResult> &newStrides);
```
Two notes on this:
- ~~In general, the old offsets, sizes and strides should be passed as well, but the current materialization patterns assumes whole loads/stores (`isLoadOfWholeSource`, `isStoreToWholeTarget`). Imo this could be left to future work/a follow up.~~ The old offsets, sizes and strides are passed, but internally the implementations check for and only implement whole slices. Support for partial slices if left for future work to avoid changing the functionality (and adding corresponding tests) in this PR.
- ~~The `targetAttr` is passed as an `Attribute` instead of `IREE::HAL::ExecutableTargetAttr` to avoid a circular dependency between the HAL and Encoding dialects. This might need a better solution though longer term, i.e. avoiding the need to pass this attribute as it's only needed to check for a ukernel in the VMVX backend or by removing the HAL dependency on Encoding?~~ The VMVX ukernel information is retrieved from the layoutAttr (IREE::Codegen::LayoutAttrInterface).