### PR TITLE
[Encoding] Use struct directive for encodingAttr assembly format

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingAttrs.td
@@ -125,7 +125,12 @@ def EncodingAttr :
     - The maps in `user_indexing_maps` should be composable.
   }];
 
-  let hasCustomAssemblyFormat = 1;
+  let assemblyFormat = [{
+    `<`
+    struct($operand_index, $op_type, $element_types, $user_indexing_maps,
+           custom<DynamicI64ArrayAttr>($iteration_sizes))
+    `>`
+  }];
 
   let parameters = (ins
     AttrParameter<"IntegerAttr", "this tensor operand's index in the parameter list">:$operand_index,

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/test/invalid.mlir
@@ -1,6 +1,7 @@
 // RUN: iree-opt --split-input-file --verify-diagnostics %s
 
-// expected-error @+1 {{missing required parameter: `operand_index`}}
+// expected-error @+2 {{expected valid keyword}}
+// expected-error @+1 {{expected a parameter name in struct}}
 #encoding = #iree_encoding.encoding<>
 func.func @illegal_encoding_attr_missing_operand_index(%arg0: tensor<?x?xf32>) -> tensor<?x?xf32, #encoding> {
   %0 = iree_encoding.set_encoding %arg0 : tensor<?x?xf32> -> tensor<?x?xf32, #encoding>
@@ -9,7 +10,8 @@ func.func @illegal_encoding_attr_missing_operand_index(%arg0: tensor<?x?xf32>) -
 
 // -----
 
-// expected-error @+1 {{missing required parameter: `op_type`}}
+
+// expected-error @+1 {{struct is missing required parameter: op_type}}
 #encoding = #iree_encoding.encoding<operand_index = 0>
 func.func @illegal_encoding_attr_missing_operand_index(%arg0: tensor<?x?xf32>) -> tensor<?x?xf32, #encoding> {
   %0 = iree_encoding.set_encoding %arg0 : tensor<?x?xf32> -> tensor<?x?xf32, #encoding>
@@ -18,7 +20,7 @@ func.func @illegal_encoding_attr_missing_operand_index(%arg0: tensor<?x?xf32>) -
 
 // -----
 
-// expected-error @+1 {{missing required parameter: `element_types`}}
+// expected-error @+1 {{struct is missing required parameter: element_types}}
 #encoding = #iree_encoding.encoding<operand_index = 0, op_type = matmul>
 func.func @illegal_encoding_attr_missing_operand_index(%arg0: tensor<?x?xf32>) -> tensor<?x?xf32, #encoding> {
   %0 = iree_encoding.set_encoding %arg0 : tensor<?x?xf32> -> tensor<?x?xf32, #encoding>


### PR DESCRIPTION
With https://github.com/llvm/llvm-project/pull/133939 merged and integrated we can now use the struct directive with a nested custom directive to let tablegen generate the parser and printer for EncodingAttr.