### PR TITLE
Workaround for stack overflow in stream refine usage.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
@@ -813,8 +813,25 @@ private:
           removeAssumedBits(NOT_DISPATCH_READ);
           for (auto result : op.getOperandTiedResults(operandIdx)) {
             removeAssumedBits(NOT_MUTATED | NOT_DISPATCH_WRITE);
-            auto &resultUsage = solver.getElementFor<ValueResourceUsage>(
-                *this, Position::forValue(result), DFX::Resolution::REQUIRED);
+            // TODO(#20748): some programs do some very naughty things with
+            // in-place operations that may lead to 10000+ sequentially tied
+            // dispatches. Currently getElementFor will recursively perform an
+            // update on initialization and that easily leads to stack
+            // overflows. The correct solution is to either pre-seed during
+            // value initialization or find a way to short-circuit the walk and
+            // break the tied traversal. An alternative would be to add a solver
+            // getElementFor helper that takes a callback instead of returning
+            // a result to allow it to manage a worklist instead of using the
+            // native stack.
+            //
+            // Original code (that should be what happens):
+            //   auto &resultUsage = solver.getElementFor<ValueResourceUsage>(
+            //    *this, Position::forValue(result), DFX::Resolution::REQUIRED);
+            auto &resultUsage =
+                solver.getOrCreateElementFor<ValueResourceUsage>(
+                    Position::forValue(result), *this,
+                    DFX::Resolution::REQUIRED, /*forceUpdate=*/false,
+                    /*updateAfterInit=*/false);
             getState() ^= resultUsage.getState();
           }
         })


### PR DESCRIPTION
On certain models (like that in #19832) kvcache updates end up as massively long sequences of tied dispatches. The attributor-style analysis uses recursion to initialize elements on first use. Tied ops need to walk through the operand to the result and transitively to further uses. When their powers combine we get stack overflows.

There are a few ways around this but this change to avoid update is the simplest. It's not a great solution as it may lead to more iterations as values initialized during ValueResourceUsage update will require at least one iteration to perform their initial update and then one more to quiesce. The best solution would be to avoid recursion by changing the API for querying elements but that's a much larger bit of refactoring. If this does cause issues (like major regressions in compile times) there's probably some other ways that could be explored but here's to hoping no one notices anything.

(filed #20748 to track the history of reverts if one is required here).