### PR TITLE
Convert all Conv2Ds to Winograd when no coop matrices available.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/BUILD.bazel
@@ -55,6 +55,7 @@ iree_compiler_cc_library(
         "MaliConfig.cpp",
         "NVIDIAConfig.cpp",
         "Passes.cpp",
+        "SPIRVAnnotateEligibleForWinograd.cpp",
         "SPIRVAnnotateWinogradLoops.cpp",
         "SPIRVBreakDownLargeVector.cpp",
         "SPIRVConvertGPUTarget.cpp",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/CMakeLists.txt
@@ -54,6 +54,7 @@ iree_cc_library(
     "MaliConfig.cpp"
     "NVIDIAConfig.cpp"
     "Passes.cpp"
+    "SPIRVAnnotateEligibleForWinograd.cpp"
     "SPIRVAnnotateWinogradLoops.cpp"
     "SPIRVBreakDownLargeVector.cpp"
     "SPIRVConvertGPUTarget.cpp"

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -621,6 +621,14 @@ static void buildSPIRVCodegenConfigurationPassPipelineImpl(
     OpPassManager &modulePassManager) {
   {
     FunctionLikeNest funcPassManager(modulePassManager);
+    // Transform Conv2D ops to Winograd ops if heuristically convenient for the
+    // target GPU.
+    {
+      funcPassManager.addPass(createSPIRVAnnotateEligibleForWinogradPass);
+      funcPassManager.addPass(
+          IREE::LinalgExt::createConvertConv2DToWinogradPass);
+    }
+
     funcPassManager.addPass(createGPUGeneralizeNamedOpsPass);
     addCommonTargetExecutablePreprocessingPasses(funcPassManager);
     addEncodingToNopPasses(funcPassManager);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.td
@@ -21,6 +21,10 @@ def ConvertToSPIRVPass : Pass<"iree-convert-to-spirv", "ModuleOp"> {
   ];
 }
 
+def SPIRVAnnotateEligibleForWinogradPass : InterfacePass<"iree-spirv-annotate-eligible-for-winograd", "mlir::FunctionOpInterface"> {
+  let summary = "Annotate Conv2D ops that are eligible for conversion to Winograd with the `__winograd_conv` annotation, if Winograd is heuristically convenient";
+}
+
 def SPIRVAnnotateWinogradLoopsPass : InterfacePass<"iree-spirv-annotate-winograd-loops", "mlir::FunctionOpInterface"> {
   let summary = "Annotate innermost Winograd loops with spirv distribute attribute";
 }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVAnnotateEligibleForWinograd.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVAnnotateEligibleForWinograd.cpp
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGpuAttrs.h"
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.h"
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVAnnotateEligibleForWinograd.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVAnnotateEligibleForWinograd.cpp
@@ -1,0 +1,57 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Dialect/GPU/IR/IREEGpuAttrs.h"
+#include "iree/compiler/Codegen/Utils/GPUUtils.h"
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
+
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_SPIRVANNOTATEELIGIBLEFORWINOGRADPASS
+#include "iree/compiler/Codegen/SPIRV/Passes.h.inc"
+
+namespace {
+
+static const char kWinogradAttr[] = "__winograd_conv";
+
+template <typename ConvOp>
+void annotateConvOps(FunctionOpInterface funcOp, MLIRContext *context) {
+  Attribute attr = UnitAttr::get(context);
+  funcOp.walk([&](ConvOp convOp) { convOp->setAttr(kWinogradAttr, attr); });
+}
+
+class SPIRVAnnotateEligibleForWinogradPass final
+    : public impl::SPIRVAnnotateEligibleForWinogradPassBase<
+          SPIRVAnnotateEligibleForWinogradPass> {
+public:
+  using impl::SPIRVAnnotateEligibleForWinogradPassBase<
+      SPIRVAnnotateEligibleForWinogradPass>::
+      SPIRVAnnotateEligibleForWinogradPassBase;
+
+  void runOnOperation() override {
+    FunctionOpInterface funcOp = getOperation();
+    IREE::GPU::TargetAttr target = getGPUTargetAttr(funcOp);
+    if (!target) {
+      funcOp.emitError("missing GPU target in #hal.executable.target");
+      return signalPassFailure();
+    }
+
+    // For now only annotate if cooperative matrices are absent
+    if (!target.getWgp().getMma().empty())
+      return;
+
+    MLIRContext *context = &getContext();
+    annotateConvOps<linalg::Conv2DNhwcHwcfOp>(funcOp, context);
+    annotateConvOps<linalg::Conv2DNchwFchwOp>(funcOp, context);
+  }
+};
+} // namespace
+} // namespace mlir::iree_compiler


### PR DESCRIPTION
Draft to discuss whether this is the right way to introduce conversion to Winograd of Conv2Ds for cases where it should perform better than other Convolution algorithms.