### PR TITLE
[Flow] Improve DumpDispatchGraph pass for programs at model level.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -133,7 +133,11 @@ def DumpDispatchGraphPass : Pass<"iree-flow-dump-dispatch-graph-pass"> {
     Option<"printDataFlowEdges", "print-data-flow-edges", "bool",
            /*default=*/"true", "Print data flow edges">,
     Option<"printResultTypes", "print-result-types", "bool",
-            /*default=*/"true", "Print result types of operations">
+            /*default=*/"true", "Print result types of operations">,
+    Option<"emitDispatchBody", "emit-dispatch-body", "bool",
+            /*default=*/"false", "Emit dispatch body in label">,
+    Option<"emitInitializers", "emit-initializers", "bool",
+            /*default=*/"false", "Emit initializers">
   ];
 }
 


### PR DESCRIPTION
The dispatch names are meaningful enough, so it turns off the dispatch body print by default. It also skips operations that have index result type and expose the global load ops.

The output can be used by https://github.com/hanhanW/iree-dispatch-dump-viewer, which is a toy viewer that generates a HTML for a browser.

No tests are added, because they don't exist. The examples, which are generated with the revision, can be found in the iree-dispatch-dump-viewer repo.