### PR TITLE
[Codegen][bufferize] Change global space mem allocs to private space

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -299,12 +299,12 @@ static FailureOr<Value> gpuRequireMemSpaceAllocationFn(OpBuilder &builder,
                                                        ValueRange dynamicSizes,
                                                        unsigned alignment) {
   Attribute memorySpace = memRefType.getMemorySpace();
-  // Bail out if the memref type specifies a nonnull memory space that is not
-  // #gpu.address_space.
+  // Default to private space if the memref type specifies a nonnull memory
+  // space that is not #gpu.address_space.
   if (memorySpace &&
       !llvm::isa<gpu::AddressSpaceAttr, amdgpu::AddressSpaceAttr>(
           memorySpace)) {
-    return failure();
+    memorySpace = Attribute();
   }
 
   MemRefType allocType = memRefType;


### PR DESCRIPTION
Bufferization doesn't handle well unused results that come from global memory space. This is one suggested fix. 

See: https://github.com/iree-org/iree/issues/20699#issuecomment-2855132456