### PR TITLE
Metal HAL: remove shadowed variable

### DIFF
--- a/runtime/src/iree/hal/drivers/metal/metal_device.m
+++ b/runtime/src/iree/hal/drivers/metal/metal_device.m
@@ -435,7 +435,6 @@ static iree_status_t iree_hal_metal_device_queue_execute(
   // inconsistent state.
   iree_hal_command_buffer_t* direct_command_buffer = NULL;
   if (iree_status_is_ok(status) && command_buffer) {
-    iree_hal_command_buffer_t* direct_command_buffer = NULL;
     if (iree_hal_deferred_command_buffer_isa(command_buffer)) {
       // Create a temporary command buffer and replay the deferred command buffer with the
       // binding table provided. Note that any resources used will be retained by the command


### PR DESCRIPTION
probably a typo from some refactor, should fix https://github.com/iree-org/iree/issues/19530. 

input: 
func.func @import(%arg: tensor<2x2xf32>) -> tensor<2x2xf32> {
  return %arg : tensor<2x2xf32>
}

before this change:
```
ziereis@Mac ~/p/iree (main)> ./build/tools/iree-run-module  --function=import --input=2x2xf32=2 --module=import.vmfb --device=metal --trace_execution=tr
ue
[module.__init+00000000]    <block>
[module.__init+00000001]    %i0 = vm.const.i32 527363  // 0x00080C03
[module.__init+00000008]    %i1 = vm.const.i32 48  // 0x00000030
[module.__init+0000000F]    %i2 = vm.const.i32 1  // 0x00000001
[module.__init+00000016]    %i3 = vm.const.i32 -1  // 0xFFFFFFFF
[module.__init+0000001D]    %i4 = vm.const.i32.zero
[module.__init+00000020]    %i6:7 = vm.const.i64 -1  // 0xFFFFFFFFFFFFFFFF
[module.__init+0000002B]    %i8:9 = vm.const.i64.zero
[module.__init+0000002E]    %i10:11 = vm.const.i64 64  // 0x0000000000000040
[module.__init+00000039]    %r0 = vm.const.ref.zero
[module.__init+0000003C]    %i5 = vm.const.i32 18  // 0x00000012
[module.__init+00000043]    %i12:13 = vm.const.i64 1  // 0x0000000000000001
[module.__init+0000004E]    %r1 = vm.const.ref.zero
[module.__init+00000051]    %i14 = vm.call @hal.devices.count()
[module.__init+0000005C]    %i14:15 = vm.ext.i32.i64.s %i14(1)
[module.__init+00000061]    vm.br ^0000007C(%r1(null)->%r2, %i8(0)->%i16, %i9(0)->%i17, %i8(0)->%i18, %i9(0)->%i19)
[module.__init+0000007D]    %i20 = vm.cmp.nz.ref %r2(null)
[module.__init+00000082]    %i20 = vm.xor.i32 %i20(0), %i2(1)
[module.__init+00000089]    %i21 = vm.cmp.lt.i64.s %i16:17(0), %i14:15(1)
[module.__init+00000090]    %i21 = vm.and.i32 %i20(1), %i21(1)
[module.__init+00000097]    vm.cond_br %i21(1), ^000000A6(), ^00000170()
[module.__init+000000A7]    %i20 = vm.trunc.i64.i32 %i16:17(0)
[module.__init+000000AC]    %r2 = vm.call @hal.devices.get(%i20(0))
[module.__init+000000BA]    %r3 = vm.const.ref.rodata 0  // 0x0x12f009a54 13b
[module.__init+000000C1]    %r4 = vm.const.ref.rodata 1  // 0x0x12f009a70 5b
[module.__init+000000C8]    %i20, %i22 = vm.call @hal.device.query.i64(%r2(!hal.device/0x0x12f806930), %r3(!vm.buffer/0x0x12e7041d0), %r4(!vm.buffer/0x0x12e7041f8))
[module.__init+000000DC]    %i21 = vm.cmp.nz.i64 %i22:23(1)
[module.__init+000000E1]    %i20 = vm.select.i32 %i20(1) ? %i21(1) : %i4(0)
[module.__init+000000EA]    vm.cond_br %i20(1), ^000000FE(), ^00000136(%i4(0)->%i20)
[module.__init+000000FF]    %r3 = vm.const.ref.rodata 2  // 0x0x12f009a84 21b
[module.__init+00000106]    %r4 = vm.const.ref.rodata 3  // 0x0x12f009aa8 12b
[module.__init+0000010D]    %i20, %i22 = vm.call @hal.device.query.i64(%r2(!hal.device/0x0x12f806930), %r3(!vm.buffer/0x0x12e704220), %r4(!vm.buffer/0x0x12e704248))
[module.__init+00000120]    %i21 = vm.cmp.nz.i64 %i22:23(1)
[module.__init+00000125]    %i20 = vm.select.i32 %i20(1) ? %i21(1) : %i4(0)
[module.__init+0000012E]    vm.br ^00000136()
[module.__init+00000137]    %i21 = vm.cmp.eq.i64 %i18:19(0), %i8:9(0)
[module.__init+0000013E]    %i22:23 = vm.select.i64 %i20(1) ? %i12:13(1) : %i8:9(0)
[module.__init+00000147]    %i18:19 = vm.add.i64 %i18:19(0), %i22:23(1)
[module.__init+0000014E]    %i20 = vm.and.i32 %i20(1), %i21(1)
[module.__init+00000155]    %r2 = vm.select.ref %i20(1) ? %r2(!hal.device/0x0x12f806930) : %r1(null) -> !hal.device
[module.__init+00000162]    %i16:17 = vm.add.i64 %i16:17(0), %i12:13(1)
[module.__init+00000169]    vm.br ^0000007C()
[module.__init+0000007D]    %i20 = vm.cmp.nz.ref %r2(!hal.device/0x0x12f806930)
[module.__init+00000082]    %i20 = vm.xor.i32 %i20(1), %i2(1)
[module.__init+00000089]    %i21 = vm.cmp.lt.i64.s %i16:17(1), %i14:15(1)
[module.__init+00000090]    %i21 = vm.and.i32 %i20(0), %i21(0)
[module.__init+00000097]    vm.cond_br %i21(0), ^000000A6(), ^00000170()
[module.__init+00000171]    vm.cond_br %i20(0), ^00000180(), ^000003B5()
[module.__init+000003B6]    %r1 = vm.const.ref.rodata 4  // 0x0x12f009ac0 64b
[module.__init+000003BD]    %r3 = vm.call @hal.device.allocator(%r2(!hal.device/0x0x12f806930))
[module.__init+000003CA]    %r4 = vm.call @hal.allocator.import(%r3(!hal.allocator/0x0x12f8202d0), %i2(1), %i6(4294967295), %i1(48), %i0(527363), %r1(!vm.buffer/0x0x12e704270), %i8(0), %i10(64))
[module.__init+000003E6]    %i5 = vm.cmp.nz.ref %r4(!hal.buffer/0x0x12e72cff0)
[module.__init+000003EB]    vm.global.store.ref %r2(!hal.device/0x0x12f806930), .refs[0] : !hal.device
[module.__init+000003F6]    vm.cond_br %i5(1), ^00000478(%r4(!hal.buffer/0x0x12e72cff0)->%r1), ^0000040A()
[module.__init+00000479]    %i0 = vm.call.varadic @hal.fence.await(%i3(4294967295), %i8(0), %r0(null))
[module.__init+00000492]    vm.cond_br %i0(0), ^000004B2(), ^000004A2()
[module.__init+000004A3]    vm.global.store.ref %r1(!hal.buffer/0x0x12e72cff0), .refs[1] : !hal.buffer
[module.__init+000004AE]    vm.return 
EXEC @import
[module.import+00000000]    <block>
[module.import+00000001]    vm.return %r0(!hal.buffer_view/0x0x12e72e8a0)
result[0]: hal.buffer_view
2x2xf32=[0 0][0 0]
```

After:

```
ziereis@Mac ~/p/iree (main)> ./build/tools/iree-run-module  --function=import --input=2x2xf32=2 --module=import.vmfb --device=metal --trace_execution=tr
ue
[module.__init+00000000]    <block>
[module.__init+00000001]    %i0 = vm.const.i32 527363  // 0x00080C03
[module.__init+00000008]    %i1 = vm.const.i32 48  // 0x00000030
[module.__init+0000000F]    %i2 = vm.const.i32 1  // 0x00000001
[module.__init+00000016]    %i3 = vm.const.i32 -1  // 0xFFFFFFFF
[module.__init+0000001D]    %i4 = vm.const.i32.zero
[module.__init+00000020]    %i6:7 = vm.const.i64 -1  // 0xFFFFFFFFFFFFFFFF
[module.__init+0000002B]    %i8:9 = vm.const.i64.zero
[module.__init+0000002E]    %i10:11 = vm.const.i64 64  // 0x0000000000000040
[module.__init+00000039]    %r0 = vm.const.ref.zero
[module.__init+0000003C]    %i5 = vm.const.i32 18  // 0x00000012
[module.__init+00000043]    %i12:13 = vm.const.i64 1  // 0x0000000000000001
[module.__init+0000004E]    %r1 = vm.const.ref.zero
[module.__init+00000051]    %i14 = vm.call @hal.devices.count()
[module.__init+0000005C]    %i14:15 = vm.ext.i32.i64.s %i14(1)
[module.__init+00000061]    vm.br ^0000007C(%r1(null)->%r2, %i8(0)->%i16, %i9(0)->%i17, %i8(0)->%i18, %i9(0)->%i19)
[module.__init+0000007D]    %i20 = vm.cmp.nz.ref %r2(null)
[module.__init+00000082]    %i20 = vm.xor.i32 %i20(0), %i2(1)
[module.__init+00000089]    %i21 = vm.cmp.lt.i64.s %i16:17(0), %i14:15(1)
[module.__init+00000090]    %i21 = vm.and.i32 %i20(1), %i21(1)
[module.__init+00000097]    vm.cond_br %i21(1), ^000000A6(), ^00000170()
[module.__init+000000A7]    %i20 = vm.trunc.i64.i32 %i16:17(0)
[module.__init+000000AC]    %r2 = vm.call @hal.devices.get(%i20(0))
[module.__init+000000BA]    %r3 = vm.const.ref.rodata 0  // 0x0x145809a54 13b
[module.__init+000000C1]    %r4 = vm.const.ref.rodata 1  // 0x0x145809a70 5b
[module.__init+000000C8]    %i20, %i22 = vm.call @hal.device.query.i64(%r2(!hal.device/0x0x144e24a70), %r3(!vm.buffer/0x0x144f041d0), %r4(!vm.buffer/0x0x144f041f8))
[module.__init+000000DC]    %i21 = vm.cmp.nz.i64 %i22:23(1)
[module.__init+000000E1]    %i20 = vm.select.i32 %i20(1) ? %i21(1) : %i4(0)
[module.__init+000000EA]    vm.cond_br %i20(1), ^000000FE(), ^00000136(%i4(0)->%i20)
[module.__init+000000FF]    %r3 = vm.const.ref.rodata 2  // 0x0x145809a84 21b
[module.__init+00000106]    %r4 = vm.const.ref.rodata 3  // 0x0x145809aa8 12b
[module.__init+0000010D]    %i20, %i22 = vm.call @hal.device.query.i64(%r2(!hal.device/0x0x144e24a70), %r3(!vm.buffer/0x0x144f04220), %r4(!vm.buffer/0x0x144f04248))
[module.__init+00000120]    %i21 = vm.cmp.nz.i64 %i22:23(1)
[module.__init+00000125]    %i20 = vm.select.i32 %i20(1) ? %i21(1) : %i4(0)
[module.__init+0000012E]    vm.br ^00000136()
[module.__init+00000137]    %i21 = vm.cmp.eq.i64 %i18:19(0), %i8:9(0)
[module.__init+0000013E]    %i22:23 = vm.select.i64 %i20(1) ? %i12:13(1) : %i8:9(0)
[module.__init+00000147]    %i18:19 = vm.add.i64 %i18:19(0), %i22:23(1)
[module.__init+0000014E]    %i20 = vm.and.i32 %i20(1), %i21(1)
[module.__init+00000155]    %r2 = vm.select.ref %i20(1) ? %r2(!hal.device/0x0x144e24a70) : %r1(null) -> !hal.device
[module.__init+00000162]    %i16:17 = vm.add.i64 %i16:17(0), %i12:13(1)
[module.__init+00000169]    vm.br ^0000007C()
[module.__init+0000007D]    %i20 = vm.cmp.nz.ref %r2(!hal.device/0x0x144e24a70)
[module.__init+00000082]    %i20 = vm.xor.i32 %i20(1), %i2(1)
[module.__init+00000089]    %i21 = vm.cmp.lt.i64.s %i16:17(1), %i14:15(1)
[module.__init+00000090]    %i21 = vm.and.i32 %i20(0), %i21(0)
[module.__init+00000097]    vm.cond_br %i21(0), ^000000A6(), ^00000170()
[module.__init+00000171]    vm.cond_br %i20(0), ^00000180(), ^000003B5()
[module.__init+000003B6]    %r1 = vm.const.ref.rodata 4  // 0x0x145809ac0 64b
[module.__init+000003BD]    %r3 = vm.call @hal.device.allocator(%r2(!hal.device/0x0x144e24a70))
[module.__init+000003CA]    %r4 = vm.call @hal.allocator.import(%r3(!hal.allocator/0x0x144e29f80), %i2(1), %i6(4294967295), %i1(48), %i0(527363), %r1(!vm.buffer/0x0x144f04270), %i8(0), %i10(64))
[module.__init+000003E6]    %i5 = vm.cmp.nz.ref %r4(!hal.buffer/0x0x146325af0)
[module.__init+000003EB]    vm.global.store.ref %r2(!hal.device/0x0x144e24a70), .refs[0] : !hal.device
[module.__init+000003F6]    vm.cond_br %i5(1), ^00000478(%r4(!hal.buffer/0x0x146325af0)->%r1), ^0000040A()
[module.__init+00000479]    %i0 = vm.call.varadic @hal.fence.await(%i3(4294967295), %i8(0), %r0(null))
[module.__init+00000492]    vm.cond_br %i0(0), ^000004B2(), ^000004A2()
[module.__init+000004A3]    vm.global.store.ref %r1(!hal.buffer/0x0x146325af0), .refs[1] : !hal.buffer
[module.__init+000004AE]    vm.return 
EXEC @import
[module.import+00000000]    <block>
[module.import+00000001]    vm.return %r0(!hal.buffer_view/0x0x146204320)
result[0]: hal.buffer_view
2x2xf32=[2 2][2 2]
```