### PR TITLE
Fix iree-codegen-llvmcpu-configuration-pipeline registration

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -903,7 +903,7 @@ void registerCodegenLLVMCPUPasses() {
       "iree-codegen-llvmcpu-configuration-pipeline",
       "Runs the translation strategy configuration pipeline on Linalg for CPU",
       [](OpPassManager &modulePassManager) {
-        buildLLVMCPUCodegenConfigurationPassPipeline(modulePassManager);
+        buildLLVMCPUCodegenConfigurationPassPipelineImpl(modulePassManager);
       });
 
   static PassPipelineRegistration<> LLVMCPUBufferizationPipeline(


### PR DESCRIPTION
This fixes the registration of the `iree-codegen-llvmcpu-configuration-pipeline` pipeline.

Running `iree-opt --dump-pass-pipeline --pass-pipeline="builtin.module(iree-codegen-llvmcpu-configuration-pipeline)"` resulted in
```
Pass Manager with 1 passes:
builtin.module(builtin.module(func.func(iree-codegen-type-propagation,iree-codegen-bubble-up-ordinal-ops,iree-codegen-bufferize-copy-only-dispatches,iree-codegen-decompose-softmax{use-fusion=true}),iree-codegen-materialize-user-configs,func.func(iree-codegen-rematerialize-parallel-ops,iree-llvmcpu-expand-f16-op-to-f32,iree-codegen-materialize-device-encoding{test-cl-gpu-target=false},iree-codegen-erase-hal-descriptor-type-from-memref),iree-llvmcpu-select-lowering-strategy))
```

With this fix we get
```
Pass Manager with 4 passes:
builtin.module(func.func(iree-codegen-type-propagation,iree-codegen-bubble-up-ordinal-ops,iree-codegen-bufferize-copy-only-dispatches,iree-codegen-decompose-softmax{use-fusion=true}),iree-codegen-materialize-user-configs,func.func(iree-codegen-rematerialize-parallel-ops,iree-llvmcpu-expand-f16-op-to-f32,iree-codegen-materialize-device-encoding{test-cl-gpu-target=false},iree-codegen-erase-hal-descriptor-type-from-memref),iree-llvmcpu-select-lowering-strategy)
```

This seems to be only an issue for the llvm-cpu backend and is correct for the other backends (GPU, ROCDL, etc.).