### PR TITLE
[VectorDistribution] Add pattern to distribute transfer_gather ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -610,7 +610,7 @@ struct DistributeTransferGather final
           StaticTileOffsetRange(vecDistShape, vecTileShape).begin());
     }
 
-    auto indexed =
+    SmallVector<bool> indexed =
         llvm::to_vector(gatherOp.getIndexed().getAsValueRange<BoolAttr>());
 
     for (auto [idx, offsets] :
@@ -631,7 +631,8 @@ struct DistributeTransferGather final
       SmallVector<Value> slicedIndexVecs;
       for (auto [indexVecIdx, disIndexVec, layout] :
            llvm::enumerate(disIndexVecs, indexVecLayouts)) {
-        auto offsets = llvm::to_vector(*(allIndexVecOffsets[indexVecIdx]));
+        SmallVector<int64_t> offsets =
+            llvm::to_vector(*(allIndexVecOffsets[indexVecIdx]));
         ++allIndexVecOffsets[indexVecIdx];
         VectorValue slicedIndexVec = getSlicedIndexVec(
             rewriter, gatherOp.getLoc(), offsets, layout, disIndexVec);

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUNestedLayoutDistributionPatterns.cpp
@@ -228,7 +228,7 @@ static LogicalResult populateWarpAndThreadIndices(
 }
 
 static VectorValue getSlicedPermutedMask(PatternRewriter &rewriter,
-                                         Location loc, AffineMap permMap,
+                                         Location loc,
                                          ArrayRef<int64_t> offsets,
                                          NestedLayoutAttr vectorLayout,
                                          VectorValue mask) {
@@ -238,6 +238,18 @@ static VectorValue getSlicedPermutedMask(PatternRewriter &rewriter,
   VectorValue slicedMask = rewriter.create<vector::ExtractStridedSliceOp>(
       loc, mask, sliceMaskOffsets, vectorLayout.getElementTile(), strides);
   return slicedMask;
+}
+
+static VectorValue getSlicedIndexVec(PatternRewriter &rewriter, Location loc,
+                                     ArrayRef<int64_t> offsets,
+                                     NestedLayoutAttr vectorLayout,
+                                     VectorValue indexVec) {
+  SmallVector<int64_t> sliceMaskOffsets =
+      getDistributedTransferOffsetsFromNestedLayout(offsets, vectorLayout);
+  SmallVector<int64_t> strides(vectorLayout.getElementTile().size(), 1);
+  VectorValue slicedIndexVec = rewriter.create<vector::ExtractStridedSliceOp>(
+      loc, indexVec, sliceMaskOffsets, vectorLayout.getElementTile(), strides);
+  return slicedIndexVec;
 }
 
 /// Project a vector based on a provided projection map.
@@ -361,7 +373,7 @@ struct DistributeTransferRead final
         SmallVector<int64_t> maskTileShape =
             getElementVectorTileShape(maskLayout);
         SmallVector<int64_t> maskOffsets = allMaskOffsets[idx];
-        slicedMask = getSlicedPermutedMask(rewriter, readOp.getLoc(), permMap,
+        slicedMask = getSlicedPermutedMask(rewriter, readOp.getLoc(),
                                            maskOffsets, maskLayout, mask);
       }
 
@@ -480,7 +492,7 @@ struct DistributeTransferWrite final
         SmallVector<int64_t> maskTileShape =
             getElementVectorTileShape(maskLayout);
         SmallVector<int64_t> maskOffsets = allMaskOffsets[idx];
-        slicedMask = getSlicedPermutedMask(rewriter, writeOp.getLoc(), permMap,
+        slicedMask = getSlicedPermutedMask(rewriter, writeOp.getLoc(),
                                            maskOffsets, maskLayout, mask);
       }
 
@@ -491,6 +503,170 @@ struct DistributeTransferWrite final
     }
 
     rewriter.eraseOp(writeOp);
+    return success();
+  }
+
+  Value threadId;
+  int64_t subgroupSize;
+};
+
+/// Pattern to distribute `vector.transfer_gather` ops with nested layouts.
+struct DistributeTransferGather final
+    : OpDistributionPattern<IREE::VectorExt::TransferGatherOp> {
+  using OpDistributionPattern::OpDistributionPattern;
+
+  DistributeTransferGather(MLIRContext *context, Value threadId,
+                           int64_t subgroupSize)
+      : OpDistributionPattern(context), threadId(threadId),
+        subgroupSize(subgroupSize) {}
+
+  LogicalResult matchAndRewrite(IREE::VectorExt::TransferGatherOp gatherOp,
+                                DistributionSignature &signature,
+                                PatternRewriter &rewriter) const override {
+
+    NestedLayoutAttr vectorLayout =
+        dyn_cast<NestedLayoutAttr>(signature[gatherOp.getResult()]);
+    if (!vectorLayout) {
+      return rewriter.notifyMatchFailure(gatherOp,
+                                         "non-nested transfer_gather layout");
+    }
+
+    SmallVector<NestedLayoutAttr> indexVecLayouts;
+    SmallVector<VectorValue> disIndexVecs;
+    for (Value indexVec : gatherOp.getIndexVecs()) {
+      auto vec = cast<VectorValue>(indexVec);
+      NestedLayoutAttr layout = dyn_cast<NestedLayoutAttr>(signature[vec]);
+      if (!layout) {
+        return rewriter.notifyMatchFailure(gatherOp,
+                                           "non-nested index vec layout");
+      }
+      indexVecLayouts.push_back(layout);
+      vec = getDistributed(rewriter, vec, layout);
+      vec = getDeinterleavedUnpackedForm(rewriter, vec, layout);
+      disIndexVecs.push_back(vec);
+    }
+
+    VectorValue mask = gatherOp.getMask();
+    NestedLayoutAttr maskLayout;
+    if (mask) {
+      maskLayout = dyn_cast<NestedLayoutAttr>(signature[mask]);
+      if (!maskLayout) {
+        return rewriter.notifyMatchFailure(gatherOp,
+                                           "non-nested mask vector layout");
+      }
+      mask = getDistributed(rewriter, mask, maskLayout);
+      mask = getDeinterleavedUnpackedForm(rewriter, mask, maskLayout);
+    }
+
+    // Guard on memrefs for distribution. In isolation this pattern is agnostic
+    // to tensors or memrefs.
+    if (!isa<MemRefType>(gatherOp.getBase().getType())) {
+      return rewriter.notifyMatchFailure(gatherOp,
+                                         "distribution expects memrefs");
+    }
+
+    SmallVector<int64_t> distShape = vectorLayout.getDistributedShape();
+    SmallVector<int64_t> tileShape = getElementVectorTileShape(vectorLayout);
+    int64_t rank = vectorLayout.getRank();
+
+    Type elementType = gatherOp.getBase().getType().getElementType();
+    auto vectorType = VectorType::get(distShape, elementType);
+    // The shape of the vector we read is pre-permutation. The permutation is
+    // a transpose on the resulting read vector.
+    auto innerVectorType =
+        VectorType::get(vectorLayout.getElementTile(), elementType);
+
+    // Initialize the full distributed vector for unrolling the batch/outer
+    // vector dimensions.
+    Value zero = rewriter.create<arith::ConstantOp>(
+        gatherOp.getLoc(), vectorType, rewriter.getZeroAttr(vectorType));
+    VectorValue acc = cast<VectorValue>(zero);
+
+    SmallVector<Value> warpIndices, threadIndices;
+    if (failed(populateWarpAndThreadIndices(rewriter, threadId, subgroupSize,
+                                            vectorLayout, warpIndices,
+                                            threadIndices))) {
+      return rewriter.notifyMatchFailure(
+          gatherOp, "warp or thread tiles have overlapping strides");
+    }
+
+    ValueRange indices = gatherOp.getIndices();
+    AffineMap permMap = gatherOp.getPermutationMap();
+    SmallVector<int64_t> strides(rank, 1);
+
+    SmallVector<SmallVector<int64_t>> allMaskOffsets;
+    std::vector<StaticTileOffsetRange::IteratorTy> allIndexVecOffsets;
+    if (mask) {
+      SmallVector<int64_t> maskDistShape = maskLayout.getDistributedShape();
+      SmallVector<int64_t> maskTileShape =
+          getElementVectorTileShape(maskLayout);
+      allMaskOffsets =
+          llvm::to_vector(StaticTileOffsetRange(maskDistShape, maskTileShape));
+    }
+    for (NestedLayoutAttr layout : indexVecLayouts) {
+      SmallVector<int64_t> vecDistShape = layout.getDistributedShape();
+      SmallVector<int64_t> vecTileShape = getElementVectorTileShape(layout);
+      allIndexVecOffsets.push_back(
+          StaticTileOffsetRange(vecDistShape, vecTileShape).begin());
+    }
+
+    auto indexed =
+        llvm::to_vector(gatherOp.getIndexed().getAsValueRange<BoolAttr>());
+
+    for (auto [idx, offsets] :
+         llvm::enumerate(StaticTileOffsetRange(distShape, tileShape))) {
+      SmallVector<Value> slicedIndices = getTransferIndicesFromNestedLayout(
+          rewriter, indices, offsets, vectorLayout, permMap, warpIndices,
+          threadIndices);
+
+      // Only take the sliced indices for the non-indexed values.
+      for (auto [dim, slicedIndex, index] :
+           llvm::enumerate(slicedIndices, indices)) {
+        if (indexed[dim]) {
+          slicedIndex = index;
+        }
+      }
+
+      // Extract offset from index_vecs.
+      SmallVector<Value> slicedIndexVecs;
+      for (auto [indexVecIdx, disIndexVec, layout] :
+           llvm::enumerate(disIndexVecs, indexVecLayouts)) {
+        auto offsets = llvm::to_vector(*(allIndexVecOffsets[indexVecIdx]));
+        ++allIndexVecOffsets[indexVecIdx];
+        VectorValue slicedIndexVec = getSlicedIndexVec(
+            rewriter, gatherOp.getLoc(), offsets, layout, disIndexVec);
+        slicedIndexVecs.push_back(slicedIndexVec);
+      }
+
+      VectorValue slicedMask = nullptr;
+      if (mask) {
+        SmallVector<int64_t> maskDistShape = maskLayout.getDistributedShape();
+        SmallVector<int64_t> maskTileShape =
+            getElementVectorTileShape(maskLayout);
+        SmallVector<int64_t> maskOffsets = allMaskOffsets[idx];
+        slicedMask = getSlicedPermutedMask(rewriter, gatherOp.getLoc(),
+                                           maskOffsets, maskLayout, mask);
+      }
+
+      VectorValue slicedGather =
+          rewriter.create<IREE::VectorExt::TransferGatherOp>(
+              gatherOp.getLoc(), innerVectorType, gatherOp.getBase(),
+              slicedIndices, slicedIndexVecs, gatherOp.getIndexed(),
+              gatherOp.getIndexedMaps(), gatherOp.getPermutationMapAttr(),
+              gatherOp.getPadding(), slicedMask, gatherOp.getInBoundsAttr());
+
+      if (acc.getType().getRank() == 0) {
+        // TODO: This should really be a folding pattern in
+        // insert_strided_slice, but instead insert_strided_slice just doesn't
+        // support 0-d vectors...
+        acc = slicedGather;
+      } else {
+        acc = rewriter.create<vector::InsertStridedSliceOp>(
+            gatherOp.getLoc(), slicedGather, acc, offsets, strides);
+      }
+    }
+
+    replaceOpWithDistributedValues(rewriter, gatherOp, acc);
     return success();
   }
 
@@ -1813,8 +1989,9 @@ void populateGPUDistributeNestedLayoutAttrPatterns(RewritePatternSet &patterns,
                                                    Value threadId,
                                                    int64_t subgroupSize,
                                                    int64_t maxBitsPerShuffle) {
-  patterns.add<DistributeTransferRead, DistributeTransferWrite>(
-      patterns.getContext(), threadId, subgroupSize);
+  patterns.add<DistributeTransferRead, DistributeTransferWrite,
+               DistributeTransferGather>(patterns.getContext(), threadId,
+                                         subgroupSize);
   patterns.add<DistributeBroadcast, DistributeTranspose>(patterns.getContext());
   patterns.add<DistributeMultiReduction>(patterns.getContext(), subgroupSize,
                                          maxBitsPerShuffle);

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
@@ -1248,3 +1248,59 @@ builtin.module attributes { transform.with_named_sequence } {
 // Accumulator addition
 // CHECK:      %[[BROADCASTED:.+]] = vector.broadcast %[[SCALAR]] : f32 to vector<1xf32>
 // CHECK:      arith.addf %{{.*}}, %[[BROADCASTED]]
+
+// -----
+
+#layout_1d = #iree_vector_ext.nested_layout<
+  subgroup_tile = [4],
+  batch_tile = [4],
+  outer_tile = [1],
+  thread_tile = [1],
+  element_tile = [1],
+
+  subgroup_strides = [1],
+  thread_strides = [0]
+>
+
+#layout = #iree_vector_ext.nested_layout<
+  subgroup_tile = [4, 1],
+  batch_tile = [4, 1],
+  outer_tile = [1, 1],
+  thread_tile = [1, 1],
+  element_tile = [1, 8],
+
+  subgroup_strides = [1, 0],
+  thread_strides = [0, 0]
+>
+
+func.func @paged_transfer_gather(%indices: vector<16xindex>,
+  %source: memref<4096x512x8xf16>) -> vector<16x8xf16> {
+
+  %cst0 = arith.constant 0.0 : f16
+  %c0 = arith.constant 0 : index
+  %dim = memref.dim %source, %c0 : memref<4096x512x8xf16>
+
+  %l_indices = iree_vector_ext.to_layout %indices to layout(#layout_1d) : vector<16xindex>
+
+  %out = iree_vector_ext.transfer_gather %source[%c0, %c0, %c0]
+  [None, %l_indices: vector<16xindex>, None], %cst0 { indexed_maps = [
+                                             affine_map<(d0, d1, d2) -> (d1)>],
+    permutation_map = affine_map<(d0, d1, d2) -> (d1, d2)>,
+    in_bounds = [true, true] }
+  : memref<4096x512x8xf16>, vector<16x8xf16>
+
+  %l_out = iree_vector_ext.to_layout %out to layout(#layout) : vector<16x8xf16>
+
+  return %l_out : vector<16x8xf16>
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: @paged_transfer_gather
+// CHECK-COUNT-4: vector.transfer_read

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_nested_layout_vector_distribution.mlir
@@ -1251,17 +1251,6 @@ builtin.module attributes { transform.with_named_sequence } {
 
 // -----
 
-#layout_1d = #iree_vector_ext.nested_layout<
-  subgroup_tile = [4],
-  batch_tile = [4],
-  outer_tile = [1],
-  thread_tile = [1],
-  element_tile = [1],
-
-  subgroup_strides = [1],
-  thread_strides = [0]
->
-
 #layout = #iree_vector_ext.nested_layout<
   subgroup_tile = [4, 1],
   batch_tile = [4, 1],
@@ -1280,10 +1269,8 @@ func.func @paged_transfer_gather(%indices: vector<16xindex>,
   %c0 = arith.constant 0 : index
   %dim = memref.dim %source, %c0 : memref<4096x512x8xf16>
 
-  %l_indices = iree_vector_ext.to_layout %indices to layout(#layout_1d) : vector<16xindex>
-
   %out = iree_vector_ext.transfer_gather %source[%c0, %c0, %c0]
-  [None, %l_indices: vector<16xindex>, None], %cst0 { indexed_maps = [
+  [None, %indices: vector<16xindex>, None], %cst0 { indexed_maps = [
                                              affine_map<(d0, d1, d2) -> (d1)>],
     permutation_map = affine_map<(d0, d1, d2) -> (d1, d2)>,
     in_bounds = [true, true] }
@@ -1303,4 +1290,59 @@ builtin.module attributes { transform.with_named_sequence } {
 }
 
 // CHECK-LABEL: @paged_transfer_gather
-// CHECK-COUNT-4: vector.transfer_read
+// CHECK-SAME: %[[INDICES:.+]]: vector<16xindex>, %[[SOURCE:.+]]: memref<4096x512x8xf16>
+// CHECK: %[[DIS_INDICES:.+]] = iree_vector_ext.to_simt %[[INDICES]] : vector<16xindex> -> vector<4x1x1xindex>
+// CHECK: %[[GATHER0:.+]] = vector.extract %[[DIS_INDICES]][0, 0, 0]
+// CHECK: vector.transfer_read %[[SOURCE]][%c0, %[[GATHER0]], %c0]
+// CHECK: %[[GATHER1:.+]] = vector.extract %[[DIS_INDICES]][1, 0, 0]
+// CHECK: vector.transfer_read %[[SOURCE]][%c0, %[[GATHER1]], %c0]
+// CHECK: %[[GATHER2:.+]] = vector.extract %[[DIS_INDICES]][2, 0, 0]
+// CHECK: vector.transfer_read %[[SOURCE]][%c0, %[[GATHER2]], %c0]
+// CHECK: %[[GATHER3:.+]] = vector.extract %[[DIS_INDICES]][3, 0, 0]
+// CHECK: vector.transfer_read %[[SOURCE]][%c0, %[[GATHER3]], %c0]
+
+// -----
+
+#layout = #iree_vector_ext.nested_layout<
+  subgroup_tile = [4, 1],
+  batch_tile = [4, 1],
+  outer_tile = [1, 1],
+  thread_tile = [1, 1],
+  element_tile = [1, 8],
+
+  subgroup_strides = [1, 0],
+  thread_strides = [0, 0]
+>
+
+func.func @paged_transfer_gather_multi_index(%indices: vector<16xindex>,
+  %indices2: vector<8x16xindex>,
+  %source: memref<4096x512x8xf16>) -> vector<16x8xf16> {
+
+  %cst0 = arith.constant 0.0 : f16
+  %c0 = arith.constant 0 : index
+  %dim = memref.dim %source, %c0 : memref<4096x512x8xf16>
+
+  %out = iree_vector_ext.transfer_gather %source[%c0, %c0, %c0]
+  [None, %indices: vector<16xindex>, %indices2: vector<8x16xindex>], %cst0
+                                           { indexed_maps = [
+                                             affine_map<(d0, d1, d2) -> (d1)>,
+                                             affine_map<(d0, d1, d2) -> (d2, d1)>],
+    permutation_map = affine_map<(d0, d1, d2) -> (d1, d2)>,
+    in_bounds = [true, true] }
+  : memref<4096x512x8xf16>, vector<16x8xf16>
+
+  %l_out = iree_vector_ext.to_layout %out to layout(#layout) : vector<16x8xf16>
+
+  return %l_out : vector<16x8xf16>
+}
+
+builtin.module attributes { transform.with_named_sequence } {
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.readonly}) {
+    %top_level_func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.test_gpu_vector_distribution %top_level_func : !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: @paged_transfer_gather_multi_index
+// CHECK-COUNT-4: vector_ext.transfer_gather


### PR DESCRIPTION
transfer_gather is distributed just like transfer_read on non gathered dimensions and like vector.gather on gathered dimensions.