### PR TITLE
[Codegen] Add ukernel support for argmax on BF16 and enable optional max value return

### DIFF
--- a/compiler/plugins/target/ROCM/builtins/ukernel/BUILD.bazel
+++ b/compiler/plugins/target/ROCM/builtins/ukernel/BUILD.bazel
@@ -37,6 +37,8 @@ gpu_archs = [
 
 # Element type combinations for the argmax ukernel.
 argmax_types = [
+    "bf16i32",
+    "bf16i64",
     "f16i32",
     "f16i64",
     "f32i32",

--- a/compiler/plugins/target/ROCM/builtins/ukernel/CMakeLists.txt
+++ b/compiler/plugins/target/ROCM/builtins/ukernel/CMakeLists.txt
@@ -16,6 +16,102 @@ endif()
 
 iree_amdgpu_bitcode_library(
   NAME
+    iree_uk_amdgpu_argmax_bf16i32_gfx90a
+  GPU_ARCH
+    gfx90a
+  SRCS
+    "common.h"
+    "iree_uk_amdgpu_argmax_bf16i32.c"
+  OUT
+    "iree_uk_amdgpu_argmax_bf16i32.gfx90a.bc"
+)
+
+iree_amdgpu_bitcode_library(
+  NAME
+    iree_uk_amdgpu_argmax_bf16i32_gfx942
+  GPU_ARCH
+    gfx942
+  SRCS
+    "common.h"
+    "iree_uk_amdgpu_argmax_bf16i32.c"
+  OUT
+    "iree_uk_amdgpu_argmax_bf16i32.gfx942.bc"
+)
+
+iree_amdgpu_bitcode_library(
+  NAME
+    iree_uk_amdgpu_argmax_bf16i32_gfx1030
+  GPU_ARCH
+    gfx1030
+  SRCS
+    "common.h"
+    "iree_uk_amdgpu_argmax_bf16i32.c"
+  OUT
+    "iree_uk_amdgpu_argmax_bf16i32.gfx1030.bc"
+)
+
+iree_amdgpu_bitcode_library(
+  NAME
+    iree_uk_amdgpu_argmax_bf16i32_gfx1100
+  GPU_ARCH
+    gfx1100
+  SRCS
+    "common.h"
+    "iree_uk_amdgpu_argmax_bf16i32.c"
+  OUT
+    "iree_uk_amdgpu_argmax_bf16i32.gfx1100.bc"
+)
+
+iree_amdgpu_bitcode_library(
+  NAME
+    iree_uk_amdgpu_argmax_bf16i64_gfx90a
+  GPU_ARCH
+    gfx90a
+  SRCS
+    "common.h"
+    "iree_uk_amdgpu_argmax_bf16i64.c"
+  OUT
+    "iree_uk_amdgpu_argmax_bf16i64.gfx90a.bc"
+)
+
+iree_amdgpu_bitcode_library(
+  NAME
+    iree_uk_amdgpu_argmax_bf16i64_gfx942
+  GPU_ARCH
+    gfx942
+  SRCS
+    "common.h"
+    "iree_uk_amdgpu_argmax_bf16i64.c"
+  OUT
+    "iree_uk_amdgpu_argmax_bf16i64.gfx942.bc"
+)
+
+iree_amdgpu_bitcode_library(
+  NAME
+    iree_uk_amdgpu_argmax_bf16i64_gfx1030
+  GPU_ARCH
+    gfx1030
+  SRCS
+    "common.h"
+    "iree_uk_amdgpu_argmax_bf16i64.c"
+  OUT
+    "iree_uk_amdgpu_argmax_bf16i64.gfx1030.bc"
+)
+
+iree_amdgpu_bitcode_library(
+  NAME
+    iree_uk_amdgpu_argmax_bf16i64_gfx1100
+  GPU_ARCH
+    gfx1100
+  SRCS
+    "common.h"
+    "iree_uk_amdgpu_argmax_bf16i64.c"
+  OUT
+    "iree_uk_amdgpu_argmax_bf16i64.gfx1100.bc"
+)
+
+iree_amdgpu_bitcode_library(
+  NAME
     iree_uk_amdgpu_argmax_f16i32_gfx90a
   GPU_ARCH
     gfx90a
@@ -222,6 +318,14 @@ iree_c_embed_data(
   NAME
     iree_uk_amdgpu_bitcode
   SRCS
+    "iree_uk_amdgpu_argmax_bf16i32.gfx1030.bc"
+    "iree_uk_amdgpu_argmax_bf16i32.gfx1100.bc"
+    "iree_uk_amdgpu_argmax_bf16i32.gfx90a.bc"
+    "iree_uk_amdgpu_argmax_bf16i32.gfx942.bc"
+    "iree_uk_amdgpu_argmax_bf16i64.gfx1030.bc"
+    "iree_uk_amdgpu_argmax_bf16i64.gfx1100.bc"
+    "iree_uk_amdgpu_argmax_bf16i64.gfx90a.bc"
+    "iree_uk_amdgpu_argmax_bf16i64.gfx942.bc"
     "iree_uk_amdgpu_argmax_f16i32.gfx1030.bc"
     "iree_uk_amdgpu_argmax_f16i32.gfx1100.bc"
     "iree_uk_amdgpu_argmax_f16i32.gfx90a.bc"

--- a/compiler/plugins/target/ROCM/builtins/ukernel/common.h
+++ b/compiler/plugins/target/ROCM/builtins/ukernel/common.h
@@ -122,12 +122,4 @@ static inline uint64_t __ballot(int predicate) {
       predicate, 0, 33 /*ICMP_NE from llvm/include/llvm/IR/InstrTypes.h*/);
 }
 
-//===----------------------------------------------------------------------===//
-// Utility functions for bf16 (Brain Floating Point 16-bit)
-//===----------------------------------------------------------------------===//
-
-__attribute__((used)) static inline float bf16_to_f32(__bf16 x) { return x; }
-
-__attribute__((used)) static inline __bf16 f32_to_bf16(float x) { return x; }
-
 #endif // COMPILER_PLUGINS_TARGET_ROCM_BUILTINS_UKERNEL_COMMON_H_

--- a/compiler/plugins/target/ROCM/builtins/ukernel/common.h
+++ b/compiler/plugins/target/ROCM/builtins/ukernel/common.h
@@ -122,4 +122,37 @@ static inline uint64_t __ballot(int predicate) {
       predicate, 0, 33 /*ICMP_NE from llvm/include/llvm/IR/InstrTypes.h*/);
 }
 
+//===----------------------------------------------------------------------===//
+// Local definition for bf16 (Brain Floating Point 16-bit)
+//===----------------------------------------------------------------------===//
+
+typedef uint16_t _BFloat16;
+
+// from amd_hip_bfloat16.h.
+// round upper 16 bits of IEEE float to convert to bfloat16.
+static inline _BFloat16 f32_to_bf16(float value) {
+  union {
+    float fp32;
+    uint32_t int32;
+  } u = {value};
+
+  if (~u.int32 & 0x7f800000) {
+    u.int32 += 0x7fff + ((u.int32 >> 16) & 1);
+  } else if (u.int32 & 0xffff) {
+    u.int32 |= 0x10000;
+  }
+
+  return (_BFloat16)(u.int32 >> 16);
+}
+
+// from amd_hip_bfloat16.h.
+// zero extend lower 16 bits of bfloat16 to convert to IEEE float.
+static inline float bf16_to_f32(_BFloat16 value) {
+  union {
+    uint32_t int32;
+    float fp32;
+  } u = {(uint32_t)(value) << 16};
+  return u.fp32;
+}
+
 #endif // COMPILER_PLUGINS_TARGET_ROCM_BUILTINS_UKERNEL_COMMON_H_

--- a/compiler/plugins/target/ROCM/builtins/ukernel/common.h
+++ b/compiler/plugins/target/ROCM/builtins/ukernel/common.h
@@ -123,36 +123,11 @@ static inline uint64_t __ballot(int predicate) {
 }
 
 //===----------------------------------------------------------------------===//
-// Local definition for bf16 (Brain Floating Point 16-bit)
+// Utility functions for bf16 (Brain Floating Point 16-bit)
 //===----------------------------------------------------------------------===//
 
-typedef uint16_t _BFloat16;
+__attribute__((used)) static inline float bf16_to_f32(__bf16 x) { return x; }
 
-// from amd_hip_bfloat16.h.
-// round upper 16 bits of IEEE float to convert to bfloat16.
-static inline _BFloat16 f32_to_bf16(float value) {
-  union {
-    float fp32;
-    uint32_t int32;
-  } u = {value};
-
-  if (~u.int32 & 0x7f800000) {
-    u.int32 += 0x7fff + ((u.int32 >> 16) & 1);
-  } else if (u.int32 & 0xffff) {
-    u.int32 |= 0x10000;
-  }
-
-  return (_BFloat16)(u.int32 >> 16);
-}
-
-// from amd_hip_bfloat16.h.
-// zero extend lower 16 bits of bfloat16 to convert to IEEE float.
-static inline float bf16_to_f32(_BFloat16 value) {
-  union {
-    uint32_t int32;
-    float fp32;
-  } u = {(uint32_t)(value) << 16};
-  return u.fp32;
-}
+__attribute__((used)) static inline __bf16 f32_to_bf16(float x) { return x; }
 
 #endif // COMPILER_PLUGINS_TARGET_ROCM_BUILTINS_UKERNEL_COMMON_H_

--- a/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_bf16i32.c
+++ b/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_bf16i32.c
@@ -20,7 +20,7 @@ iree_uk_amdgpu_argmax_bf16i32(const __bf16 *inputBuffer, int64_t input_offset,
   // Set identity value to handle problem non divisible by subgroupSize.
   float laneMax = laneID >= reductionSize
                       ? -FLT_MAX
-                      : bf16_to_f32(inputBuffer[input_offset + laneID]);
+                      : (float)(inputBuffer[input_offset + laneID]);
   int32_t laneResult = laneID;
 
   // NOTE: On F32 kernels with clang, reductionSize/blockDim.x has numerical
@@ -30,7 +30,7 @@ iree_uk_amdgpu_argmax_bf16i32(const __bf16 *inputBuffer, int64_t input_offset,
     int32_t idx = warpSize * i + laneID;
     float newIn = idx >= reductionSize
                       ? -FLT_MAX
-                      : bf16_to_f32(inputBuffer[input_offset + idx]);
+                      : (float)(inputBuffer[input_offset + idx]);
     if (newIn == laneMax)
       continue;
     laneMax = __builtin_fmaxf(newIn, laneMax);

--- a/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_bf16i32.c
+++ b/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_bf16i32.c
@@ -7,9 +7,9 @@
 #include "compiler/plugins/target/ROCM/builtins/ukernel/common.h"
 
 [[clang::always_inline]] void
-iree_uk_amdgpu_argmax_bf16i32(const _BFloat16 *inputBuffer,
-                              int64_t input_offset, int32_t *outputBuffer,
-                              int64_t output_offset, int64_t reductionSize) {
+iree_uk_amdgpu_argmax_bf16i32(const __bf16 *inputBuffer, int64_t input_offset,
+                              int32_t *outputBuffer, int64_t output_offset,
+                              int64_t reductionSize) {
   // NOTE:
   // We convert bf16 inputs to f32 before computation because HIP/OCKL and
   // Clang/LLVM do not currently support native arithmetic or comparisons on

--- a/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_bf16i32.c
+++ b/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_bf16i32.c
@@ -6,10 +6,76 @@
 
 #include "compiler/plugins/target/ROCM/builtins/ukernel/common.h"
 
-[[clang::always_inline]] void
-iree_uk_amdgpu_argmax_bf16i32(const __bf16 *inputBuffer, int64_t input_offset,
-                              int32_t *outputBuffer, int64_t output_offset,
-                              int64_t reductionSize) {
+// [[clang::always_inline]] void iree_uk_amdgpu_argmax_bf16i32(
+//     const __bf16 *inputBuffer, int64_t input_offset, __bf16 *outputBufferVal,
+//     int64_t output_val_offset, int32_t *outputBufferIdx,
+//     int64_t output_idx_offset, int64_t reductionSize, bool writeValue) {
+//   // NOTE:
+//   // We convert bf16 inputs to f32 before computation because HIP/OCKL and
+//   // Clang/LLVM do not currently support native arithmetic or comparisons on
+//   // bf16. In practice, these operations are internally performed by first
+//   // converting bf16 to float.
+//   const int warpSize = __builtin_amdgcn_wavefrontsize();
+//   int32_t laneID = __builtin_amdgcn_workitem_id_x();
+//   // Set identity value to handle problem non divisible by subgroupSize.
+//   float laneMax = laneID >= reductionSize
+//                       ? -FLT_MAX
+//                       : (float)(inputBuffer[input_offset + laneID]);
+//   int32_t laneResult = laneID;
+
+//   // NOTE: On F32 kernels with clang, reductionSize/blockDim.x has numerical
+//   // inaccuracy.
+//   int32_t numBatches = (reductionSize + warpSize - 1) / warpSize;
+//   for (int i = 1; i < numBatches; ++i) {
+//     int32_t idx = warpSize * i + laneID;
+//     float newIn = idx >= reductionSize
+//                       ? -FLT_MAX
+//                       : (float)(inputBuffer[input_offset + idx]);
+//     if (newIn == laneMax)
+//       continue;
+//     laneMax = __builtin_fmaxf(newIn, laneMax);
+//     laneResult = newIn == laneMax ? idx : laneResult;
+//   }
+
+//   // Final reduction with one subgroup
+//   // NOTE: __ockl_wfred_max_f32 has correctness issue on gfx1100 documented
+//   on
+//   // https://github.com/iree-org/iree/issues/16112.
+//   float wgMax = laneMax;
+//   for (int i = 1; i < warpSize; i *= 2) {
+//     wgMax = __builtin_fmaxf(__shfl_xor_f(wgMax, i), wgMax);
+//   }
+//   // Check if there are multiple max value holders.
+//   uint64_t laneHasMaxValmask = __ballot(wgMax == laneMax);
+//   // if there is only one max value holder, write and exit.
+//   if (__builtin_popcountll(laneHasMaxValmask) == 1) {
+//     if (wgMax == laneMax) {
+//       if (writeValue) {
+//         outputBufferVal[output_val_offset] = (__bf16)wgMax;
+//       }
+//       outputBufferIdx[output_idx_offset] = laneResult;
+//     }
+//   } else {
+//     // if there are multiple max value holder, find smallest index (argmax
+//     // semantics).
+//     int32_t indexVal = wgMax == laneMax ? laneResult : __INT32_MAX__;
+//     laneResult = __ockl_wfred_min_i32(indexVal);
+//     if (laneID == 0) {
+//       if (writeValue) {
+//         outputBufferVal[output_val_offset] = (__bf16)wgMax;
+//       }
+//       outputBufferIdx[output_idx_offset] = laneResult;
+//     }
+//   }
+//   // TODO(bjacob): this fence should be on the caller side. Move to
+//   TileAndFuse?
+//   __threadfence_block();
+// }
+
+[[clang::always_inline]] void iree_uk_amdgpu_argmax_bf16i32(
+    const __bf16 *inputBuffer, int64_t input_offset, __bf16 *outputBufferVal,
+    int64_t output_val_offset, int32_t *outputBufferIdx,
+    int64_t output_idx_offset, int64_t reductionSize) {
   // NOTE:
   // We convert bf16 inputs to f32 before computation because HIP/OCKL and
   // Clang/LLVM do not currently support native arithmetic or comparisons on
@@ -49,7 +115,10 @@ iree_uk_amdgpu_argmax_bf16i32(const __bf16 *inputBuffer, int64_t input_offset,
   // if there is only one max value holder, write and exit.
   if (__builtin_popcountll(laneHasMaxValmask) == 1) {
     if (wgMax == laneMax) {
-      outputBuffer[output_offset] = laneResult;
+      if (outputBufferVal != nullptr) {
+        outputBufferVal[output_val_offset] = (__bf16)wgMax;
+      }
+      outputBufferIdx[output_idx_offset] = laneResult;
     }
   } else {
     // if there are multiple max value holder, find smallest index (argmax
@@ -57,7 +126,10 @@ iree_uk_amdgpu_argmax_bf16i32(const __bf16 *inputBuffer, int64_t input_offset,
     int32_t indexVal = wgMax == laneMax ? laneResult : __INT32_MAX__;
     laneResult = __ockl_wfred_min_i32(indexVal);
     if (laneID == 0) {
-      outputBuffer[output_offset] = laneResult;
+      if (outputBufferVal != nullptr) {
+        outputBufferVal[output_val_offset] = (__bf16)wgMax;
+      }
+      outputBufferIdx[output_idx_offset] = laneResult;
     }
   }
   // TODO(bjacob): this fence should be on the caller side. Move to TileAndFuse?

--- a/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_bf16i32.c
+++ b/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_bf16i32.c
@@ -6,76 +6,10 @@
 
 #include "compiler/plugins/target/ROCM/builtins/ukernel/common.h"
 
-// [[clang::always_inline]] void iree_uk_amdgpu_argmax_bf16i32(
-//     const __bf16 *inputBuffer, int64_t input_offset, __bf16 *outputBufferVal,
-//     int64_t output_val_offset, int32_t *outputBufferIdx,
-//     int64_t output_idx_offset, int64_t reductionSize, bool writeValue) {
-//   // NOTE:
-//   // We convert bf16 inputs to f32 before computation because HIP/OCKL and
-//   // Clang/LLVM do not currently support native arithmetic or comparisons on
-//   // bf16. In practice, these operations are internally performed by first
-//   // converting bf16 to float.
-//   const int warpSize = __builtin_amdgcn_wavefrontsize();
-//   int32_t laneID = __builtin_amdgcn_workitem_id_x();
-//   // Set identity value to handle problem non divisible by subgroupSize.
-//   float laneMax = laneID >= reductionSize
-//                       ? -FLT_MAX
-//                       : (float)(inputBuffer[input_offset + laneID]);
-//   int32_t laneResult = laneID;
-
-//   // NOTE: On F32 kernels with clang, reductionSize/blockDim.x has numerical
-//   // inaccuracy.
-//   int32_t numBatches = (reductionSize + warpSize - 1) / warpSize;
-//   for (int i = 1; i < numBatches; ++i) {
-//     int32_t idx = warpSize * i + laneID;
-//     float newIn = idx >= reductionSize
-//                       ? -FLT_MAX
-//                       : (float)(inputBuffer[input_offset + idx]);
-//     if (newIn == laneMax)
-//       continue;
-//     laneMax = __builtin_fmaxf(newIn, laneMax);
-//     laneResult = newIn == laneMax ? idx : laneResult;
-//   }
-
-//   // Final reduction with one subgroup
-//   // NOTE: __ockl_wfred_max_f32 has correctness issue on gfx1100 documented
-//   on
-//   // https://github.com/iree-org/iree/issues/16112.
-//   float wgMax = laneMax;
-//   for (int i = 1; i < warpSize; i *= 2) {
-//     wgMax = __builtin_fmaxf(__shfl_xor_f(wgMax, i), wgMax);
-//   }
-//   // Check if there are multiple max value holders.
-//   uint64_t laneHasMaxValmask = __ballot(wgMax == laneMax);
-//   // if there is only one max value holder, write and exit.
-//   if (__builtin_popcountll(laneHasMaxValmask) == 1) {
-//     if (wgMax == laneMax) {
-//       if (writeValue) {
-//         outputBufferVal[output_val_offset] = (__bf16)wgMax;
-//       }
-//       outputBufferIdx[output_idx_offset] = laneResult;
-//     }
-//   } else {
-//     // if there are multiple max value holder, find smallest index (argmax
-//     // semantics).
-//     int32_t indexVal = wgMax == laneMax ? laneResult : __INT32_MAX__;
-//     laneResult = __ockl_wfred_min_i32(indexVal);
-//     if (laneID == 0) {
-//       if (writeValue) {
-//         outputBufferVal[output_val_offset] = (__bf16)wgMax;
-//       }
-//       outputBufferIdx[output_idx_offset] = laneResult;
-//     }
-//   }
-//   // TODO(bjacob): this fence should be on the caller side. Move to
-//   TileAndFuse?
-//   __threadfence_block();
-// }
-
 [[clang::always_inline]] void iree_uk_amdgpu_argmax_bf16i32(
     const __bf16 *inputBuffer, int64_t input_offset, __bf16 *outputBufferVal,
     int64_t output_val_offset, int32_t *outputBufferIdx,
-    int64_t output_idx_offset, int64_t reductionSize) {
+    int64_t output_idx_offset, int64_t reductionSize, bool writeValue) {
   // NOTE:
   // We convert bf16 inputs to f32 before computation because HIP/OCKL and
   // Clang/LLVM do not currently support native arithmetic or comparisons on
@@ -104,8 +38,8 @@
   }
 
   // Final reduction with one subgroup
-  // NOTE: __ockl_wfred_max_f32 has correctness issue on gfx1100 documented on
-  // https://github.com/iree-org/iree/issues/16112.
+  // NOTE: __ockl_wfred_max_f32 has correctness issue on gfx1100 documented
+  // on https://github.com/iree-org/iree/issues/16112.
   float wgMax = laneMax;
   for (int i = 1; i < warpSize; i *= 2) {
     wgMax = __builtin_fmaxf(__shfl_xor_f(wgMax, i), wgMax);
@@ -115,7 +49,7 @@
   // if there is only one max value holder, write and exit.
   if (__builtin_popcountll(laneHasMaxValmask) == 1) {
     if (wgMax == laneMax) {
-      if (outputBufferVal != nullptr) {
+      if (writeValue) {
         outputBufferVal[output_val_offset] = (__bf16)wgMax;
       }
       outputBufferIdx[output_idx_offset] = laneResult;
@@ -126,7 +60,7 @@
     int32_t indexVal = wgMax == laneMax ? laneResult : __INT32_MAX__;
     laneResult = __ockl_wfred_min_i32(indexVal);
     if (laneID == 0) {
-      if (outputBufferVal != nullptr) {
+      if (writeValue) {
         outputBufferVal[output_val_offset] = (__bf16)wgMax;
       }
       outputBufferIdx[output_idx_offset] = laneResult;

--- a/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_bf16i32.c
+++ b/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_bf16i32.c
@@ -1,0 +1,65 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "compiler/plugins/target/ROCM/builtins/ukernel/common.h"
+
+[[clang::always_inline]] void
+iree_uk_amdgpu_argmax_bf16i32(const _BFloat16 *inputBuffer,
+                              int64_t input_offset, int32_t *outputBuffer,
+                              int64_t output_offset, int64_t reductionSize) {
+  // NOTE:
+  // We convert bf16 inputs to f32 before computation because HIP/OCKL and
+  // Clang/LLVM do not currently support native arithmetic or comparisons on
+  // bf16. In practice, these operations are internally performed by first
+  // converting bf16 to float.
+  const int warpSize = __builtin_amdgcn_wavefrontsize();
+  int32_t laneID = __builtin_amdgcn_workitem_id_x();
+  // Set identity value to handle problem non divisible by subgroupSize.
+  float laneMax = laneID >= reductionSize
+                      ? -FLT_MAX
+                      : bf16_to_f32(inputBuffer[input_offset + laneID]);
+  int32_t laneResult = laneID;
+
+  // NOTE: On F32 kernels with clang, reductionSize/blockDim.x has numerical
+  // inaccuracy.
+  int32_t numBatches = (reductionSize + warpSize - 1) / warpSize;
+  for (int i = 1; i < numBatches; ++i) {
+    int32_t idx = warpSize * i + laneID;
+    float newIn = idx >= reductionSize
+                      ? -FLT_MAX
+                      : bf16_to_f32(inputBuffer[input_offset + idx]);
+    if (newIn == laneMax)
+      continue;
+    laneMax = __builtin_fmaxf(newIn, laneMax);
+    laneResult = newIn == laneMax ? idx : laneResult;
+  }
+
+  // Final reduction with one subgroup
+  // NOTE: __ockl_wfred_max_f32 has correctness issue on gfx1100 documented on
+  // https://github.com/iree-org/iree/issues/16112.
+  float wgMax = laneMax;
+  for (int i = 1; i < warpSize; i *= 2) {
+    wgMax = __builtin_fmaxf(__shfl_xor_f(wgMax, i), wgMax);
+  }
+  // Check if there are multiple max value holders.
+  uint64_t laneHasMaxValmask = __ballot(wgMax == laneMax);
+  // if there is only one max value holder, write and exit.
+  if (__builtin_popcountll(laneHasMaxValmask) == 1) {
+    if (wgMax == laneMax) {
+      outputBuffer[output_offset] = laneResult;
+    }
+  } else {
+    // if there are multiple max value holder, find smallest index (argmax
+    // semantics).
+    int32_t indexVal = wgMax == laneMax ? laneResult : __INT32_MAX__;
+    laneResult = __ockl_wfred_min_i32(indexVal);
+    if (laneID == 0) {
+      outputBuffer[output_offset] = laneResult;
+    }
+  }
+  // TODO(bjacob): this fence should be on the caller side. Move to TileAndFuse?
+  __threadfence_block();
+}

--- a/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_bf16i64.c
+++ b/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_bf16i64.c
@@ -1,0 +1,65 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "compiler/plugins/target/ROCM/builtins/ukernel/common.h"
+
+[[clang::always_inline]] void
+iree_uk_amdgpu_argmax_bf16i64(const _BFloat16 *inputBuffer,
+                              int64_t input_offset, int64_t *outputBuffer,
+                              int64_t output_offset, int64_t reductionSize) {
+  // NOTE:
+  // We convert bf16 inputs to f32 before computation because HIP/OCKL and
+  // Clang/LLVM do not currently support native arithmetic or comparisons on
+  // bf16. In practice, these operations are internally performed by first
+  // converting bf16 to float.
+  const int warpSize = __builtin_amdgcn_wavefrontsize();
+  int32_t laneID = __builtin_amdgcn_workitem_id_x();
+  // Set identity value to handle problem non divisible by subgroupSize.
+  float laneMax = laneID >= reductionSize
+                      ? -FLT_MAX
+                      : bf16_to_f32(inputBuffer[input_offset + laneID]);
+  int64_t laneResult = laneID;
+
+  // NOTE: On F32 kernels with clang, reductionSize/blockDim.x has numerical
+  // inaccuracy.
+  int32_t numBatches = (reductionSize + warpSize - 1) / warpSize;
+  for (int i = 1; i < numBatches; ++i) {
+    int32_t idx = warpSize * i + laneID;
+    float newIn = idx >= reductionSize
+                      ? -FLT_MAX
+                      : bf16_to_f32(inputBuffer[input_offset + idx]);
+    if (newIn == laneMax)
+      continue;
+    laneMax = __builtin_fmaxf(newIn, laneMax);
+    laneResult = newIn == laneMax ? idx : laneResult;
+  }
+
+  // Final reduction with one subgroup
+  // NOTE: __ockl_wfred_max_f32 has correctness issue on gfx1100 documented on
+  // https://github.com/iree-org/iree/issues/16112.
+  float wgMax = laneMax;
+  for (int i = 1; i < warpSize; i *= 2) {
+    wgMax = __builtin_fmaxf(__shfl_xor_f(wgMax, i), wgMax);
+  }
+  // Check if there are multiple max value holders.
+  uint64_t laneHasMaxValmask = __ballot(wgMax == laneMax);
+  // if there is only one max value holder, write and exit.
+  if (__builtin_popcountll(laneHasMaxValmask) == 1) {
+    if (wgMax == laneMax) {
+      outputBuffer[output_offset] = laneResult;
+    }
+  } else {
+    // if there are multiple max value holder, find smallest index (argmax
+    // semantics).
+    int64_t indexVal = wgMax == laneMax ? laneResult : INT64_MAX;
+    laneResult = __ockl_wfred_min_i64(indexVal);
+    if (laneID == 0) {
+      outputBuffer[output_offset] = laneResult;
+    }
+  }
+  // TODO(bjacob): this fence should be on the caller side. Move to TileAndFuse?
+  __threadfence_block();
+}

--- a/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_bf16i64.c
+++ b/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_bf16i64.c
@@ -20,7 +20,7 @@ iree_uk_amdgpu_argmax_bf16i64(const __bf16 *inputBuffer, int64_t input_offset,
   // Set identity value to handle problem non divisible by subgroupSize.
   float laneMax = laneID >= reductionSize
                       ? -FLT_MAX
-                      : bf16_to_f32(inputBuffer[input_offset + laneID]);
+                      : (float)(inputBuffer[input_offset + laneID]);
   int64_t laneResult = laneID;
 
   // NOTE: On F32 kernels with clang, reductionSize/blockDim.x has numerical
@@ -30,7 +30,7 @@ iree_uk_amdgpu_argmax_bf16i64(const __bf16 *inputBuffer, int64_t input_offset,
     int32_t idx = warpSize * i + laneID;
     float newIn = idx >= reductionSize
                       ? -FLT_MAX
-                      : bf16_to_f32(inputBuffer[input_offset + idx]);
+                      : (float)(inputBuffer[input_offset + idx]);
     if (newIn == laneMax)
       continue;
     laneMax = __builtin_fmaxf(newIn, laneMax);

--- a/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_bf16i64.c
+++ b/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_bf16i64.c
@@ -7,9 +7,9 @@
 #include "compiler/plugins/target/ROCM/builtins/ukernel/common.h"
 
 [[clang::always_inline]] void
-iree_uk_amdgpu_argmax_bf16i64(const _BFloat16 *inputBuffer,
-                              int64_t input_offset, int64_t *outputBuffer,
-                              int64_t output_offset, int64_t reductionSize) {
+iree_uk_amdgpu_argmax_bf16i64(const __bf16 *inputBuffer, int64_t input_offset,
+                              int64_t *outputBuffer, int64_t output_offset,
+                              int64_t reductionSize) {
   // NOTE:
   // We convert bf16 inputs to f32 before computation because HIP/OCKL and
   // Clang/LLVM do not currently support native arithmetic or comparisons on

--- a/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_f16i64.c
+++ b/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_f16i64.c
@@ -6,10 +6,11 @@
 
 #include "compiler/plugins/target/ROCM/builtins/ukernel/common.h"
 
-[[clang::always_inline]] void
-iree_uk_amdgpu_argmax_f16i64(const _Float16 *inputBuffer, int64_t input_offset,
-                             int64_t *outputBuffer, int64_t output_offset,
-                             int64_t reductionSize) {
+[[clang::always_inline]] void iree_uk_amdgpu_argmax_f16i64(
+    const _Float16 *inputBuffer, int64_t input_offset,
+    _Float16 *outputBufferVal, int64_t output_val_offset,
+    int64_t *outputBufferIdx, int64_t output_idx_offset, int64_t reductionSize,
+    bool writeValue) {
   const int warpSize = __builtin_amdgcn_wavefrontsize();
   _Float16 NEG_F16_MAX = (_Float16)(-65504.0f);
   int32_t laneID = __builtin_amdgcn_workitem_id_x();
@@ -37,7 +38,10 @@ iree_uk_amdgpu_argmax_f16i64(const _Float16 *inputBuffer, int64_t input_offset,
   // if there is only one max value holder, write and exit.
   if (__builtin_popcountll(laneHasMaxValmask) == 1) {
     if (wgMax == laneMax) {
-      outputBuffer[output_offset] = laneResult;
+      if (writeValue) {
+        outputBufferVal[output_val_offset] = wgMax;
+      }
+      outputBufferIdx[output_idx_offset] = laneResult;
     }
   } else {
     // if there are multiple max value holder, find smallest index (argmax
@@ -45,7 +49,10 @@ iree_uk_amdgpu_argmax_f16i64(const _Float16 *inputBuffer, int64_t input_offset,
     int64_t indexVal = wgMax == laneMax ? laneResult : INT64_MAX;
     laneResult = __ockl_wfred_min_i64(indexVal);
     if (laneID == 0) {
-      outputBuffer[output_offset] = laneResult;
+      if (writeValue) {
+        outputBufferVal[output_val_offset] = wgMax;
+      }
+      outputBufferIdx[output_idx_offset] = laneResult;
     }
   }
   // TODO(bjacob): this fence should be on the caller side. Move to TileAndFuse?

--- a/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_f32i32.c
+++ b/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_f32i32.c
@@ -6,10 +6,10 @@
 
 #include "compiler/plugins/target/ROCM/builtins/ukernel/common.h"
 
-[[clang::always_inline]] void
-iree_uk_amdgpu_argmax_f32i32(const float *inputBuffer, int64_t input_offset,
-                             int32_t *outputBuffer, int64_t output_offset,
-                             int64_t reductionSize) {
+[[clang::always_inline]] void iree_uk_amdgpu_argmax_f32i32(
+    const float *inputBuffer, int64_t input_offset, float *outputBufferVal,
+    int64_t output_val_offset, int32_t *outputBufferIdx,
+    int64_t output_idx_offset, int64_t reductionSize, bool writeValue) {
   const int warpSize = __builtin_amdgcn_wavefrontsize();
   int32_t laneID = __builtin_amdgcn_workitem_id_x();
   // Set identity value to handle problem non divisible by subgroupSize.
@@ -42,7 +42,10 @@ iree_uk_amdgpu_argmax_f32i32(const float *inputBuffer, int64_t input_offset,
   // if there is only one max value holder, write and exit.
   if (__builtin_popcountll(laneHasMaxValmask) == 1) {
     if (wgMax == laneMax) {
-      outputBuffer[output_offset] = laneResult;
+      if (writeValue) {
+        outputBufferVal[output_val_offset] = wgMax;
+      }
+      outputBufferIdx[output_idx_offset] = laneResult;
     }
   } else {
     // if there are multiple max value holder, find smallest index (argmax
@@ -50,7 +53,10 @@ iree_uk_amdgpu_argmax_f32i32(const float *inputBuffer, int64_t input_offset,
     int32_t indexVal = wgMax == laneMax ? laneResult : __INT32_MAX__;
     laneResult = __ockl_wfred_min_i32(indexVal);
     if (laneID == 0) {
-      outputBuffer[output_offset] = laneResult;
+      if (writeValue) {
+        outputBufferVal[output_val_offset] = wgMax;
+      }
+      outputBufferIdx[output_idx_offset] = laneResult;
     }
   }
   // TODO(bjacob): this fence should be on the caller side. Move to TileAndFuse?

--- a/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_f32i64.c
+++ b/compiler/plugins/target/ROCM/builtins/ukernel/iree_uk_amdgpu_argmax_f32i64.c
@@ -6,10 +6,10 @@
 
 #include "compiler/plugins/target/ROCM/builtins/ukernel/common.h"
 
-[[clang::always_inline]] void
-iree_uk_amdgpu_argmax_f32i64(const float *inputBuffer, int64_t input_offset,
-                             int64_t *outputBuffer, int64_t output_offset,
-                             int64_t reductionSize) {
+[[clang::always_inline]] void iree_uk_amdgpu_argmax_f32i64(
+    const float *inputBuffer, int64_t input_offset, float *outputBufferVal,
+    int64_t output_val_offset, int64_t *outputBufferIdx,
+    int64_t output_idx_offset, int64_t reductionSize, bool writeValue) {
   const int warpSize = __builtin_amdgcn_wavefrontsize();
   int32_t laneID = __builtin_amdgcn_workitem_id_x();
   // Set identity value to handle problem non divisible by subgroupSize.
@@ -42,7 +42,10 @@ iree_uk_amdgpu_argmax_f32i64(const float *inputBuffer, int64_t input_offset,
   // if there is only one max value holder, write and exit.
   if (__builtin_popcountll(laneHasMaxValmask) == 1) {
     if (wgMax == laneMax) {
-      outputBuffer[output_offset] = laneResult;
+      if (writeValue) {
+        outputBufferVal[output_val_offset] = wgMax;
+      }
+      outputBufferIdx[output_idx_offset] = laneResult;
     }
   } else {
     // if there are multiple max value holder, find smallest index (argmax
@@ -50,7 +53,10 @@ iree_uk_amdgpu_argmax_f32i64(const float *inputBuffer, int64_t input_offset,
     int64_t indexVal = wgMax == laneMax ? laneResult : INT64_MAX;
     laneResult = __ockl_wfred_min_i64(indexVal);
     if (laneID == 0) {
-      outputBuffer[output_offset] = laneResult;
+      if (writeValue) {
+        outputBufferVal[output_val_offset] = wgMax;
+      }
+      outputBufferIdx[output_idx_offset] = laneResult;
     }
   }
   // TODO(bjacob): this fence should be on the caller side. Move to TileAndFuse?

--- a/compiler/plugins/target/ROCM/builtins/ukernel/test/argmax_linking.mlir
+++ b/compiler/plugins/target/ROCM/builtins/ukernel/test/argmax_linking.mlir
@@ -54,6 +54,144 @@ func.func @argmax_1d_f16i64(%arg0: tensor<1x?xf16>) -> tensor<1x1xi64> {
   return %expanded_1 : tensor<1x1xi64>
 }
 
+// -----
+
+// CHECK: llvm.func @iree_uk_amdgpu_argmax_bf16i32
+// CHECK: llvm.call @iree_uk_amdgpu_argmax_bf16i32
+func.func @argmax_1d_bf16i32(%arg0: tensor<1x?xbf16>) -> tensor<1x1xi32> {
+  %c0_i32 = arith.constant 0 : i32
+  %cst = arith.constant 0xFF80 : bf16  // -inf in bf16
+  %c0 = arith.constant 0 : index
+
+  %init_val = tensor.empty() : tensor<1xbf16>
+  %init_idx = tensor.empty() : tensor<1xi32>
+  %filled_val = linalg.fill ins(%cst : bf16) outs(%init_val : tensor<1xbf16>) -> tensor<1xbf16>
+  %filled_idx = linalg.fill ins(%c0_i32 : i32) outs(%init_idx : tensor<1xi32>) -> tensor<1xi32>
+
+  %result:2 = linalg.generic {
+      indexing_maps = [
+        affine_map<(d0, d1) -> (d0, d1)>,
+        affine_map<(d0, d1) -> (d0)>,
+        affine_map<(d0, d1) -> (d0)>
+      ],
+      iterator_types = ["parallel", "reduction"]
+    } ins(%arg0 : tensor<1x?xbf16>) outs(%filled_val, %filled_idx : tensor<1xbf16>, tensor<1xi32>) {
+    ^bb0(%in: bf16, %cur_val: bf16, %cur_idx: i32):
+      %i = linalg.index 1 : index
+      %i32 = arith.index_cast %i : index to i32
+      %max = arith.maximumf %in, %cur_val : bf16
+      %pred = arith.cmpf ogt, %in, %cur_val : bf16
+      %new_idx = arith.select %pred, %i32, %cur_idx : i32
+      linalg.yield %max, %new_idx : bf16, i32
+  } -> (tensor<1xbf16>, tensor<1xi32>)
+
+  %expanded = tensor.expand_shape %result#1 [[0, 1]] output_shape [1, 1] : tensor<1xi32> into tensor<1x1xi32>
+  return %expanded : tensor<1x1xi32>
+}
+
+// -----
+
+// CHECK: llvm.func @iree_uk_amdgpu_argmax_bf16i64
+// CHECK: llvm.call @iree_uk_amdgpu_argmax_bf16i64
+func.func @argmax_1d_bf16i64(%arg0: tensor<1x?xbf16>) -> tensor<1x1xi64> {
+  %c0_i64 = arith.constant 0 : i64
+  %cst = arith.constant 0xFF80 : bf16  // -inf in bf16
+  %c0 = arith.constant 0 : index
+
+  %init_val = tensor.empty() : tensor<1xbf16>
+  %init_idx = tensor.empty() : tensor<1xi64>
+  %filled_val = linalg.fill ins(%cst : bf16) outs(%init_val : tensor<1xbf16>) -> tensor<1xbf16>
+  %filled_idx = linalg.fill ins(%c0_i64 : i64) outs(%init_idx : tensor<1xi64>) -> tensor<1xi64>
+
+  %result:2 = linalg.generic {
+      indexing_maps = [
+        affine_map<(d0, d1) -> (d0, d1)>,
+        affine_map<(d0, d1) -> (d0)>,
+        affine_map<(d0, d1) -> (d0)>
+      ],
+      iterator_types = ["parallel", "reduction"]
+    } ins(%arg0 : tensor<1x?xbf16>) outs(%filled_val, %filled_idx : tensor<1xbf16>, tensor<1xi64>) {
+    ^bb0(%in: bf16, %cur_val: bf16, %cur_idx: i64):
+      %i = linalg.index 1 : index
+      %i64 = arith.index_cast %i : index to i64
+      %max = arith.maximumf %in, %cur_val : bf16
+      %pred = arith.cmpf ogt, %in, %cur_val : bf16
+      %new_idx = arith.select %pred, %i64, %cur_idx : i64
+      linalg.yield %max, %new_idx : bf16, i64
+  } -> (tensor<1xbf16>, tensor<1xi64>)
+
+  %expanded = tensor.expand_shape %result#1 [[0, 1]] output_shape [1, 1] : tensor<1xi64> into tensor<1x1xi64>
+  return %expanded : tensor<1x1xi64>
+}
+
+// -----
+
+// CHECK: llvm.func @iree_uk_amdgpu_argmax_bf16i32
+// CHECK: llvm.call @iree_uk_amdgpu_argmax_bf16i32
+func.func @argmax_2d_bf16i32(%arg0: tensor<16x?xbf16>) -> tensor<16x1xi32> {
+  %c0_i32 = arith.constant 0 : i32
+  %cst = arith.constant 0xFF80 : bf16  // -inf for bf16
+
+  %init_val = tensor.empty() : tensor<16xbf16>
+  %init_idx = tensor.empty() : tensor<16xi32>
+  %filled_val = linalg.fill ins(%cst : bf16) outs(%init_val : tensor<16xbf16>) -> tensor<16xbf16>
+  %filled_idx = linalg.fill ins(%c0_i32 : i32) outs(%init_idx : tensor<16xi32>) -> tensor<16xi32>
+
+  %result:2 = linalg.generic {
+      indexing_maps = [
+        affine_map<(d0, d1) -> (d0, d1)>,
+        affine_map<(d0, d1) -> (d0)>,
+        affine_map<(d0, d1) -> (d0)>
+      ],
+      iterator_types = ["parallel", "reduction"]
+    } ins(%arg0 : tensor<16x?xbf16>) outs(%filled_val, %filled_idx : tensor<16xbf16>, tensor<16xi32>) {
+    ^bb0(%in: bf16, %cur_val: bf16, %cur_idx: i32):
+      %j = linalg.index 1 : index
+      %j32 = arith.index_cast %j : index to i32
+      %max = arith.maximumf %in, %cur_val : bf16
+      %pred = arith.cmpf ogt, %in, %cur_val : bf16
+      %sel_idx = arith.select %pred, %j32, %cur_idx : i32
+      linalg.yield %max, %sel_idx : bf16, i32
+  } -> (tensor<16xbf16>, tensor<16xi32>)
+
+  %expanded = tensor.expand_shape %result#1 [[0, 1]] output_shape [16, 1] : tensor<16xi32> into tensor<16x1xi32>
+  return %expanded : tensor<16x1xi32>
+}
+
+// -----
+
+// CHECK: llvm.func @iree_uk_amdgpu_argmax_bf16i64
+// CHECK: llvm.call @iree_uk_amdgpu_argmax_bf16i64
+func.func @argmax_2d_bf16i64(%arg0: tensor<16x?xbf16>) -> tensor<16x1xi64> {
+  %c0_i64 = arith.constant 0 : i64
+  %cst = arith.constant 0xFF80 : bf16  // -inf for bf16
+  %c0 = arith.constant 0 : index
+
+  %init_idx = tensor.empty() : tensor<16xi64>
+  %init_val = tensor.empty() : tensor<16xbf16>
+  %filled_idx = linalg.fill ins(%c0_i64 : i64) outs(%init_idx : tensor<16xi64>) -> tensor<16xi64>
+  %filled_val = linalg.fill ins(%cst : bf16) outs(%init_val : tensor<16xbf16>) -> tensor<16xbf16>
+
+  %result:2 = linalg.generic {
+      indexing_maps = [
+        affine_map<(d0, d1) -> (d0, d1)>,
+        affine_map<(d0, d1) -> (d0)>,
+        affine_map<(d0, d1) -> (d0)>
+      ],
+      iterator_types = ["parallel", "reduction"]
+    } ins(%arg0 : tensor<16x?xbf16>) outs(%filled_val, %filled_idx : tensor<16xbf16>, tensor<16xi64>) {
+    ^bb0(%in: bf16, %cur_val: bf16, %cur_idx: i64):
+      %j = linalg.index 1 : index
+      %j64 = arith.index_cast %j : index to i64
+      %max = arith.maximumf %in, %cur_val : bf16
+      %pred = arith.cmpf ogt, %in, %cur_val : bf16
+      %sel_idx = arith.select %pred, %j64, %cur_idx : i64
+      linalg.yield %max, %sel_idx : bf16, i64
+  } -> (tensor<16xbf16>, tensor<16xi64>)
+
+  %expanded = tensor.expand_shape %result#1 [[0, 1]] output_shape [16, 1] : tensor<16xi64> into tensor<16x1xi64>
+  return %expanded : tensor<16x1xi64>
+}
 
 // -----
 
@@ -140,6 +278,90 @@ func.func @argmax_3d_dyn_f32i64(%arg0: tensor<?x?x?xf32>) -> tensor<?x?xf32> {
   } -> (tensor<?x?xf32>, tensor<?x?xi64>)
   %5 = arith.sitofp %4#1 : tensor<?x?xi64> to tensor<?x?xf32>
   return %5 : tensor<?x?xf32>
+}
+
+// -----
+
+// CHECK: llvm.func @iree_uk_amdgpu_argmax_bf16i32
+// CHECK: llvm.call @iree_uk_amdgpu_argmax_bf16i32
+#map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d0, d1)>
+func.func @argmax_3d_dyn_bf16i32(%arg0: tensor<?x?x?xbf16>) -> tensor<?x?xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c0_i32 = arith.constant 0 : i32
+  %cst = arith.constant 0xFF80 : bf16  // -inf for bf16
+
+  %dim0 = tensor.dim %arg0, %c0 : tensor<?x?x?xbf16>
+  %dim1 = tensor.dim %arg0, %c1 : tensor<?x?x?xbf16>
+
+  %init_val = tensor.empty(%dim0, %dim1) : tensor<?x?xbf16>
+  %init_idx = tensor.empty(%dim0, %dim1) : tensor<?x?xi32>
+
+  %filled_val = linalg.fill ins(%cst : bf16) outs(%init_val : tensor<?x?xbf16>) -> tensor<?x?xbf16>
+  %filled_idx = linalg.fill ins(%c0_i32 : i32) outs(%init_idx : tensor<?x?xi32>) -> tensor<?x?xi32>
+
+  %result:2 = linalg.generic {
+      indexing_maps = [
+        affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
+        affine_map<(d0, d1, d2) -> (d0, d1)>,
+        affine_map<(d0, d1, d2) -> (d0, d1)>
+      ],
+      iterator_types = ["parallel", "parallel", "reduction"]
+    } ins(%arg0 : tensor<?x?x?xbf16>) outs(%filled_val, %filled_idx : tensor<?x?xbf16>, tensor<?x?xi32>) {
+    ^bb0(%in: bf16, %cur_val: bf16, %cur_idx: i32):
+      %k = linalg.index 2 : index
+      %k_i32 = arith.index_cast %k : index to i32
+      %max = arith.maximumf %in, %cur_val : bf16
+      %pred = arith.cmpf ogt, %in, %cur_val : bf16
+      %sel_idx = arith.select %pred, %k_i32, %cur_idx : i32
+      linalg.yield %max, %sel_idx : bf16, i32
+  } -> (tensor<?x?xbf16>, tensor<?x?xi32>)
+
+  %result_f32 = arith.sitofp %result#1 : tensor<?x?xi32> to tensor<?x?xf32>
+  return %result_f32 : tensor<?x?xf32>
+}
+
+// -----
+
+// CHECK: llvm.func @iree_uk_amdgpu_argmax_bf16i64
+// CHECK: llvm.call @iree_uk_amdgpu_argmax_bf16i64
+#map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d0, d1)>
+func.func @argmax_3d_dyn_bf16i64(%arg0: tensor<?x?x?xbf16>) -> tensor<?x?xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c0_i64 = arith.constant 0 : i64
+  %cst = arith.constant 0xFF80 : bf16  // -inf for bf16
+
+  %dim0 = tensor.dim %arg0, %c0 : tensor<?x?x?xbf16>
+  %dim1 = tensor.dim %arg0, %c1 : tensor<?x?x?xbf16>
+
+  %init_val = tensor.empty(%dim0, %dim1) : tensor<?x?xbf16>
+  %init_idx = tensor.empty(%dim0, %dim1) : tensor<?x?xi64>
+
+  %filled_val = linalg.fill ins(%cst : bf16) outs(%init_val : tensor<?x?xbf16>) -> tensor<?x?xbf16>
+  %filled_idx = linalg.fill ins(%c0_i64 : i64) outs(%init_idx : tensor<?x?xi64>) -> tensor<?x?xi64>
+
+  %result:2 = linalg.generic {
+      indexing_maps = [
+        affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
+        affine_map<(d0, d1, d2) -> (d0, d1)>,
+        affine_map<(d0, d1, d2) -> (d0, d1)>
+      ],
+      iterator_types = ["parallel", "parallel", "reduction"]
+    } ins(%arg0 : tensor<?x?x?xbf16>) outs(%filled_val, %filled_idx : tensor<?x?xbf16>, tensor<?x?xi64>) {
+    ^bb0(%in: bf16, %cur_val: bf16, %cur_idx: i64):
+      %k = linalg.index 2 : index
+      %k_i64 = arith.index_cast %k : index to i64
+      %max = arith.maximumf %in, %cur_val : bf16
+      %pred = arith.cmpf ogt, %in, %cur_val : bf16
+      %sel_idx = arith.select %pred, %k_i64, %cur_idx : i64
+      linalg.yield %max, %sel_idx : bf16, i64
+  } -> (tensor<?x?xbf16>, tensor<?x?xi64>)
+
+  %result_f32 = arith.sitofp %result#1 : tensor<?x?xi64> to tensor<?x?xf32>
+  return %result_f32 : tensor<?x?xf32>
 }
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_lower_to_ukernels.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_lower_to_ukernels.mlir
@@ -40,6 +40,52 @@ func.func @argmax_f32i64_with_selected_ukernel(%arg0 : tensor<1x?xf32>) -> tenso
 
 // -----
 
+#config = #iree_gpu.lowering_config<{
+  ukernel = #iree_gpu.ukernel_config<name = "some_ukernel", def_attrs = {vm.import.module = "rocm"}>
+}>
+
+func.func @argmax_bf16i64_with_selected_ukernel(%arg0 : tensor<1x?xbf16>) -> tensor<1xi64> {
+  %c0_i64 = arith.constant 0 : i64
+  %cst = arith.constant 0xFF80 : bf16
+  %0 = tensor.empty() : tensor<1xi64>
+  %1 = linalg.fill ins(%c0_i64 : i64) outs(%0 : tensor<1xi64>) -> tensor<1xi64>
+  %2 = tensor.empty() : tensor<1xbf16>
+  %3 = linalg.fill ins(%cst : bf16) outs(%2 : tensor<1xbf16>) -> tensor<1xbf16>
+  %4:2 = linalg.generic {
+        indexing_maps = [
+          affine_map<(d0, d1) -> (d0, d1)>,
+          affine_map<(d0, d1) -> (d0)>,
+          affine_map<(d0, d1) -> (d0)>
+        ],
+        iterator_types = ["parallel", "reduction"]
+      }
+      ins(%arg0 : tensor<1x?xbf16>)
+      outs(%3, %1 : tensor<1xbf16>, tensor<1xi64>)
+      attrs = {lowering_config = #config} {
+  ^bb0(%in: bf16, %out: bf16, %out_0: i64):
+    %5 = linalg.index 1 : index
+    %6 = arith.index_cast %5 : index to i64
+    %7 = arith.maximumf %in, %out : bf16
+    %8 = arith.cmpf ogt, %in, %out : bf16
+    %9 = arith.select %8, %6, %out_0 : i64
+    linalg.yield %7, %9 : bf16, i64
+  } -> (tensor<1xbf16>, tensor<1xi64>)
+  return %4#1 : tensor<1xi64>
+}
+
+//CHECK-LABEL: func @argmax_bf16i64_with_selected_ukernel(
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<1x?xbf16>
+//  CHECK-DAG:   %[[C1_index:.+]] = arith.constant 1 : index
+//  CHECK-DAG:   %[[C0_i64:.+]] = arith.constant 0
+//  CHECK-DAG:   %[[FILL:.+]] = linalg.fill ins(%[[C0_i64]]
+//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic
+//  CHECK-SAME:      "some_ukernel"
+// CHECK-SAME:       ins(%[[ARG0]] :
+// CHECK-SAME:       outs(%[[FILL]] :
+//      CHECK:   return %[[MICRO_KERNEL]]
+
+// -----
+
 func.func @argmax_f32i64_without_selected_ukernel(%arg0 : tensor<1x?xf32>) -> tensor<1xi64> {
   %c0_i64 = arith.constant 0 : i64
   %cst = arith.constant 0xFF800000 : f32

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_lower_to_ukernels.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_lower_to_ukernels.mlir
@@ -31,12 +31,14 @@ func.func @argmax_f32i64_with_selected_ukernel(%arg0 : tensor<1x?xf32>) -> tenso
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<1x?xf32>
 //  CHECK-DAG:   %[[C1_index:.+]] = arith.constant 1 : index
 //  CHECK-DAG:   %[[C0_i64:.+]] = arith.constant 0
-//  CHECK-DAG:   %[[FILL:.+]] = linalg.fill ins(%[[C0_i64]]
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic
-//  CHECK-SAME:      "some_ukernel"
+//  CHECK-DAG:   %[[NEG_INF:.+]] = arith.constant 0xFF800000 : f32
+//  CHECK-DAG:   %[[FILL_IDX:.+]] = linalg.fill ins(%[[C0_i64]]
+//  CHECK-DAG:   %[[FILL_VAL:.+]] = linalg.fill ins(%[[NEG_INF]]
+//      CHECK:   %[[MICRO_KERNEL:.+]]:2 = iree_codegen.ukernel.generic
+// CHECK-SAME:      "some_ukernel"
 // CHECK-SAME:       ins(%[[ARG0]] :
-// CHECK-SAME:       outs(%[[FILL]] :
-//      CHECK:   return %[[MICRO_KERNEL]]
+// CHECK-SAME:       outs(%[[FILL_VAL]], %[[FILL_IDX]] :
+//      CHECK:   return %[[MICRO_KERNEL]]#1
 
 // -----
 
@@ -77,12 +79,14 @@ func.func @argmax_bf16i64_with_selected_ukernel(%arg0 : tensor<1x?xbf16>) -> ten
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<1x?xbf16>
 //  CHECK-DAG:   %[[C1_index:.+]] = arith.constant 1 : index
 //  CHECK-DAG:   %[[C0_i64:.+]] = arith.constant 0
-//  CHECK-DAG:   %[[FILL:.+]] = linalg.fill ins(%[[C0_i64]]
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic
-//  CHECK-SAME:      "some_ukernel"
+//  CHECK-DAG:   %[[NEG_INF:.+]] = arith.constant 0xFF80 : bf16
+//  CHECK-DAG:   %[[FILL_IDX:.+]] = linalg.fill ins(%[[C0_i64]]
+//  CHECK-DAG:   %[[FILL_VAL:.+]] = linalg.fill ins(%[[NEG_INF]]
+//      CHECK:   %[[MICRO_KERNEL:.+]]:2 = iree_codegen.ukernel.generic
+// CHECK-SAME:      "some_ukernel"
 // CHECK-SAME:       ins(%[[ARG0]] :
-// CHECK-SAME:       outs(%[[FILL]] :
-//      CHECK:   return %[[MICRO_KERNEL]]
+// CHECK-SAME:       outs(%[[FILL_VAL]], %[[FILL_IDX]] :
+//      CHECK:   return %[[MICRO_KERNEL]]#1
 
 // -----
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -837,11 +837,6 @@ bool isArgmaxOp(linalg::GenericOp genericOp) {
     return false;
   }
 
-  // If max value is being used, it is not a pure argmax.
-  if (!genericOp.getResults()[0].use_empty()) {
-    return false;
-  }
-
   // Argmax will require 1D reduction.
   if (genericOp.getNumReductionLoops() != 1) {
     return false;


### PR DESCRIPTION
This PR mainly add two changes relevant to ukernel support for argmax op. 

**Change 1: BF16 support**
 this PR adds the uKernels iree_uk_amdgpu_argmax_bf16i64 and iree_uk_amdgpu_argmax_bf16i32. These implementations are adapted from the existing float versions, as low-level bf16 support typically involves converting to float32 for computation.

**Change 2:  Support Returning the Maximum Value**
Previously, the compiler restricted argmax lowering to pure-index-only cases using the following check:
```C++
// If max value is being used, it is not a pure argmax.
if (!genericOp.getResults()[0].use_empty()) {
  return false;
}
```
This check has been removed to enable the microkernel to support both:
- Returning only the index (pure argmax)
- Returning both the maximum value and its index

To support this at the ukernel level, I added a writeValue boolean flag to control whether the value output should be written.

Once this LLVM PR is integrated: https://github.com/llvm/llvm-project/pull/140775, I plan to further simplify the implementation by checking whether outputBufferVal is nullptr instead of relying on an explicit flag.

The PR also includes a corresponding test. In addition, I performed manual correctness checks to validate the behavior, I put my scripts here: https://github.com/bangtianliu/work-scripts/tree/master/argmax.

Issue: #20650