### PR TITLE
[Codegen] Add pass for specializing executable variants

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -156,6 +156,7 @@ iree_compiler_cc_library(
         "RemoveSingleIterationLoop.cpp",
         "ReplaceSlowMinMaxOps.cpp",
         "ResolveSwizzleHints.cpp",
+        "SpecializeExports.cpp",
         "SplitFullPartialTransferPass.cpp",
         "StripCompilationInfoPass.cpp",
         "TensorDynamicDimAnalysis.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -145,6 +145,7 @@ iree_cc_library(
     "RemoveSingleIterationLoop.cpp"
     "ReplaceSlowMinMaxOps.cpp"
     "ResolveSwizzleHints.cpp"
+    "SpecializeExports.cpp"
     "SplitFullPartialTransferPass.cpp"
     "StripCompilationInfoPass.cpp"
     "TensorDynamicDimAnalysis.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -658,6 +658,11 @@ def ResolveSwizzleHintsPass :
   ];
 }
 
+def SpecializeExportsPass :
+    Pass<"iree-codegen-specialize-exports", "IREE::HAL::ExecutableVariantOp">{
+   let summary = "Specializes exported functions based on annotated ranges";
+}
+
 def StripCompilationInfoPass :
     Pass<"iree-codegen-strip-compilation-info", "">{
    let summary = "Remove all the the lowering configuration and translation info attributes.";

--- a/compiler/src/iree/compiler/Codegen/Common/SpecializeExports.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/SpecializeExports.cpp
@@ -1,0 +1,463 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cstdint>
+#include <numeric>
+#include "iree/compiler/Codegen/Common/Passes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "iree/compiler/Dialect/TensorExt/IR/TensorExtOps.h"
+#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
+#include "llvm/ADT/SlowDynamicAPInt.h"
+#include "llvm/Support/Casting.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Arith/Utils/Utils.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/IR/Visitors.h"
+
+#define DEBUG_TYPE "iree-codegen-specialize-exports"
+
+using RangeAttrHelper = mlir::iree_compiler::IREE::Codegen::IREECodegenDialect::
+    SpecializationRangesAttrHelper;
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_SPECIALIZEEXPORTSPASS
+#include "iree/compiler/Codegen/Common/Passes.h.inc"
+
+namespace {
+struct AssumedWorkloadSize {
+  int64_t staticSize = ShapedType::kDynamic;
+  int64_t workloadOrdinal;
+  OpResult assumptionOrOrdinal;
+};
+} // namespace
+
+/// Returns a list of sizes, or the tied workload ordinal if dynamic, for the
+/// iteration domain of the target tilable op. This is needed when constructing
+/// the condition region. Also returns the `util.int.assume` for each size if
+/// present so we can simply update the range there instead of constructing a
+/// new one.
+static FailureOr<SmallVector<AssumedWorkloadSize>>
+getIterationDomainAsWorkload(TilingInterface specializationRoot) {
+  OpBuilder b(specializationRoot);
+  SmallVector<mlir::Range> iterationSpace =
+      specializationRoot.getIterationDomain(b);
+
+  SmallVector<AssumedWorkloadSize> workloadAssumptions(iterationSpace.size());
+
+  for (auto [i, range] : llvm::enumerate(iterationSpace)) {
+    // Non-zero offset and non-unit stride unsupported.
+    if (!isZeroIndex(range.offset) || !isConstantIntValue(range.stride, 1)) {
+      LLVM_DEBUG(llvm::dbgs() << "Failed to get zero offset + unit stride.");
+      return failure();
+    }
+
+    std::optional<int64_t> constantSize = getConstantIntValue(range.size);
+    if (constantSize) {
+      workloadAssumptions[i].staticSize = constantSize.value();
+      continue;
+    }
+
+    // Look for the ordinal defining the size. This relies on folders kicking in
+    // to remove the cruft when querying for the iteration domain.
+    auto size = cast<Value>(range.size);
+    if (auto dimOp = size.getDefiningOp<tensor::DimOp>()) {
+      std::optional<int64_t> dim = getConstantIntValue(dimOp.getDimension());
+      if (dim) {
+        // Walk up the SSA chain for the definition of the dynamic dim.
+        size = getValueOrCreateConstantIndexOp(
+            b, specializationRoot.getLoc(),
+            IREE::Util::findDim(dimOp.getSource(), dim.value()));
+      }
+    }
+    auto workloadOrdinal =
+        size.getDefiningOp<IREE::TensorExt::DispatchWorkloadOrdinalOp>();
+    if (!workloadOrdinal) {
+      // If we can't map back to the workload, we can't build the selection
+      // condition.
+      LLVM_DEBUG({
+        llvm::dbgs() << "Could not find workload ordinal for size\n\t";
+        llvm::dbgs() << range.size << "\n";
+      });
+      return failure();
+    }
+
+    workloadAssumptions[i].workloadOrdinal =
+        workloadOrdinal.getOrdinal().getZExtValue();
+
+    if (!workloadOrdinal.getOperand()
+             .getDefiningOp<IREE::Util::AssumeIntOp>()) {
+      LLVM_DEBUG({
+        llvm::dbgs() << "Could not find int.assume for size\n\t";
+        llvm::dbgs() << range.size << "\n";
+      });
+      // If no assume is found, point to the result of the ordinal. Later we
+      // will generate an assume on the input.
+      workloadAssumptions[i].assumptionOrOrdinal =
+          workloadOrdinal->getOpResult(0);
+    } else {
+      workloadAssumptions[i].assumptionOrOrdinal =
+          cast<OpResult>(workloadOrdinal.getOperand());
+    }
+  }
+  return workloadAssumptions;
+}
+
+/// Gets the next value not present in |ordinals| that is >= |ordinal| and
+/// adds it to the set.
+static int64_t
+getAndInsertNextAvailableOrdinal(llvm::SmallDenseSet<int64_t> &ordinals,
+                                 int64_t ordinal) {
+  int64_t newOrdinal = ordinal + 1;
+  while (ordinals.contains(newOrdinal)) {
+    ++newOrdinal;
+  }
+  ordinals.insert(newOrdinal);
+  return newOrdinal;
+}
+
+/// Specializes the function |func| exported by |exportOp| based on
+/// |specializationRoot|. The ranges of the iteration space of the tilable
+/// root to specialize for is specified by |specializationRanges|.
+static void specializeExportedFunction(
+    IREE::HAL::ExecutableExportOp exportOp, func::FuncOp func,
+    TilingInterface specializationRoot,
+    IREE::Util::MultiIntAssumptionArrayAttr specializationRanges,
+    llvm::SmallDenseSet<int64_t> &ordinals) {
+  if (specializationRanges.empty()) {
+    LLVM_DEBUG(llvm::dbgs() << "Empty specialization ranges.");
+    return;
+  }
+
+  // Bail out if the export already has a fallback, or if there is no workgroup
+  // count body.
+  if (!exportOp.getWorkgroupCountBody() || exportOp.getConditionFallback()) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "Missing workgroup count body or already has fallback.");
+    return;
+  }
+
+  FailureOr<SmallVector<AssumedWorkloadSize>> maybeWorkloadMapping =
+      getIterationDomainAsWorkload(specializationRoot);
+  if (failed(maybeWorkloadMapping)) {
+    LLVM_DEBUG(llvm::dbgs() << "Empty specialization ranges.");
+    return;
+  }
+
+  SymbolTable innerModule = SymbolTable::getNearestSymbolTable(func);
+  SymbolTable symbolTable(innerModule);
+
+  IREE::HAL::ExecutableExportOp currentExport = exportOp;
+  func::FuncOp currentFunction = func;
+  OpBuilder builder(exportOp);
+  Location loc = exportOp.getLoc();
+
+  ArrayRef<AssumedWorkloadSize> workloadMapping = maybeWorkloadMapping.value();
+  for (auto specializationRange : specializationRanges) {
+    [[maybe_unused]] bool requiresSpecialization = false;
+    bool neverApplies = false;
+    bool alwaysApplies = true;
+
+    // First determine whether the target specialization range is even capable
+    // of applying, or if it always applies.
+    //
+    // Use zip for implicit truncation behavior to the number of ranges. Note
+    // that this will skip any ranges longer than the workload rank, potentially
+    // creating unexpected successes, however the alternative is to fail.
+    for (auto [range, assumedSize] :
+         llvm::zip(specializationRange, workloadMapping)) {
+      int64_t umin = range.getUmin().value_or(0);
+      int64_t umax = range.getUmax().value_or(INT64_MAX);
+      int64_t udiv = range.getUdiv().value_or(1);
+
+      int64_t valueUmin = 0;
+      int64_t valueUmax = INT64_MAX;
+      int64_t valueUdiv = 1;
+      if (!ShapedType::isDynamic(assumedSize.staticSize)) {
+        valueUmin = assumedSize.staticSize;
+        valueUmax = assumedSize.staticSize;
+        valueUdiv = assumedSize.staticSize;
+      } else {
+        // Specialization is only needed if there is at least one dynamic shape
+        // present.
+        requiresSpecialization = true;
+
+        // Infer the range/divisor of the dim based on the tied assumption.
+        if (auto assumeOp = llvm::dyn_cast<IREE::Util::AssumeIntOp>(
+                assumedSize.assumptionOrOrdinal.getOwner())) {
+          std::pair<std::optional<int64_t>, std::optional<int64_t>>
+              dynamicRange = assumeOp.getUnionedUnsignedRange(
+                  assumedSize.assumptionOrOrdinal.getResultNumber());
+          valueUmin = dynamicRange.first.value_or(0);
+          valueUmax = dynamicRange.second.value_or(INT64_MAX);
+          valueUdiv = assumeOp
+                          .getUnionedUnsignedDivisor(
+                              assumedSize.assumptionOrOrdinal.getResultNumber())
+                          .value_or(1);
+        } else {
+          // If we have no assumption to go off of, use the most pessimistic
+          // range possible.
+          valueUmin = 0;
+          valueUmax = INT64_MAX;
+          valueUdiv = 1;
+        }
+      }
+
+      // The range is unsatisfiable if there is no multiple of the LCM of
+      // the true divisor and the target divisor in the value's range.
+      int64_t divLCM = std::lcm(udiv, valueUdiv);
+      int64_t nearestUminCeil = (divLCM + valueUmin - 1) / divLCM;
+      if (umin > valueUmax || umax < valueUmin || nearestUminCeil > umax) {
+        neverApplies = true;
+        break;
+      }
+
+      // Check if the target range is fully contained within the true range.
+      // If not, the target range may sometimes not apply and we need a
+      // fallback.
+      if (umin > valueUmin || umax < valueUmax || valueUdiv % udiv != 0) {
+        alwaysApplies = false;
+      }
+    }
+
+    // Skip this range if it never applies.
+    if (neverApplies) {
+      LLVM_DEBUG({
+        llvm::dbgs() << "Specialization range never applies:\n\t";
+        llvm::dbgs() << specializationRange << "\n";
+      });
+      continue;
+    }
+
+    // Skip all subsequent ranges if this one always applies. Note that if this
+    // range always applies, the assumptions within the IR is already a strict
+    // subset of the requested ranges, meaning no change is needed to the IR
+    // either.
+    if (alwaysApplies) {
+      LLVM_DEBUG({
+        llvm::dbgs() << "Specialization range always applies:\n\t";
+        llvm::dbgs() << specializationRange << "\n";
+      });
+      return;
+    }
+
+    // Static iteration domains should always be perfectly resolvable.
+    // Assert we have at least one dynamic workload value to specialize on.
+    assert(requiresSpecialization && "unexpected static iteration domain");
+
+    builder.setInsertionPoint(currentFunction);
+    StringAttr currentFunctionName = currentFunction.getSymNameAttr();
+
+    // Use a mapping to track the newly created assumption ops.
+    IRMapping mapping;
+    auto clonedFunction =
+        cast<func::FuncOp>(builder.clone(*currentFunction, mapping));
+    StringAttr newFunctionName = symbolTable.insert(clonedFunction);
+
+    // To avoid invalidating the workload mapping, swap the symbol names so the
+    // original function body stays as |currentFunction| (the last function in
+    // the fallback cascade).
+    symbolTable.setSymbolName(currentFunction, newFunctionName);
+    symbolTable.setSymbolName(clonedFunction, currentFunctionName);
+
+    builder.setInsertionPointAfter(currentExport);
+    auto newExport =
+        cast<IREE::HAL::ExecutableExportOp>(builder.clone(*currentExport));
+    int64_t newOrdinal = getAndInsertNextAvailableOrdinal(
+        ordinals, currentExport.getOrdinalAttr().getInt());
+    newExport.setOrdinalAttr(builder.getIndexAttr(newOrdinal));
+    newExport.setSymNameAttr(newFunctionName);
+
+    currentExport.setConditionFallback(newFunctionName);
+    {
+      SmallVector<Type> argTypes(
+          currentExport.getWorkgroupCountBody()->getArgumentTypes());
+      SmallVector<Location> locs(argTypes.size(), loc);
+      Block *newCondition = builder.createBlock(
+          &currentExport.getCondition(), currentExport.getCondition().begin(),
+          argTypes, locs);
+      builder.setInsertionPointToStart(newCondition);
+
+      Value exportCondition =
+          builder.create<arith::ConstantIntOp>(loc, 1, builder.getI1Type());
+
+      for (auto [range, assumedSize] :
+           llvm::zip(specializationRange, workloadMapping)) {
+        if (!ShapedType::isDynamic(assumedSize.staticSize)) {
+          continue;
+        }
+
+        // +1 for the device.
+        Value workload =
+            newCondition->getArgument(assumedSize.workloadOrdinal + 1);
+        Value zero = builder.create<arith::ConstantIndexOp>(loc, 0);
+
+        if (range.getUmin().has_value()) {
+          Value uminVal = builder.create<arith::ConstantIndexOp>(
+              loc, range.getUmin().value());
+          Value cmp = builder.create<arith::CmpIOp>(
+              loc, arith::CmpIPredicate::ule, uminVal, workload);
+          exportCondition =
+              builder.create<arith::AndIOp>(loc, cmp, exportCondition);
+        }
+        if (range.getUmax().has_value()) {
+          Value umaxVal = builder.create<arith::ConstantIndexOp>(
+              loc, range.getUmax().value());
+          Value cmp = builder.create<arith::CmpIOp>(
+              loc, arith::CmpIPredicate::uge, umaxVal, workload);
+          exportCondition =
+              builder.create<arith::AndIOp>(loc, cmp, exportCondition);
+        }
+        if (range.getUdiv().has_value()) {
+          Value udivVal = builder.create<arith::ConstantIndexOp>(
+              loc, range.getUdiv().value());
+          Value rem = builder.create<arith::RemUIOp>(loc, workload, udivVal);
+          Value cmp = builder.create<arith::CmpIOp>(
+              loc, arith::CmpIPredicate::eq, rem, zero);
+          exportCondition =
+              builder.create<arith::AndIOp>(loc, cmp, exportCondition);
+        }
+
+        if (auto originalAssumeOp = llvm::dyn_cast<IREE::Util::AssumeIntOp>(
+                assumedSize.assumptionOrOrdinal.getOwner())) {
+          auto clonedAssumeOp =
+              cast<IREE::Util::AssumeIntOp>(mapping.lookup(originalAssumeOp));
+          ArrayAttr assumptionsAttr = clonedAssumeOp.getAssumptionsAttr();
+          SmallVector<Attribute> newAssumptionsLists(
+              assumptionsAttr.getAsRange<Attribute>());
+
+          // Replace the list in the assume with the one we're specializing for.
+          // Single-attribute assumption lists are implicitly broadcasted to the
+          // total number of callsites so this is always valid.
+          newAssumptionsLists[assumedSize.assumptionOrOrdinal
+                                  .getResultNumber()] =
+              builder.getArrayAttr({range});
+          clonedAssumeOp.setAssumptionsAttr(
+              builder.getArrayAttr(newAssumptionsLists));
+        } else {
+          // If there is no assume already present, create a new one and replace
+          // the operand of the ordinal with it. Normally all assumptions would
+          // be combined into one, however this is difficult to do at this late
+          // stage because it's hard to make dominance guarantees. The reason
+          // for a single assume it to correlate callsites, which is irrelevant
+          // here anyway so this is fine.
+          OpBuilder::InsertionGuard g(builder);
+          auto ordinalOp = cast<IREE::TensorExt::DispatchWorkloadOrdinalOp>(
+              mapping.lookup(assumedSize.assumptionOrOrdinal.getOwner()));
+          builder.setInsertionPoint(ordinalOp);
+          Value assumedOperand =
+              builder
+                  .create<IREE::Util::AssumeIntOp>(loc, ordinalOp.getOperand(),
+                                                   builder.getArrayAttr(range))
+                  .getResult(0);
+          ordinalOp.setOperand(assumedOperand);
+        }
+      }
+
+      builder.create<IREE::HAL::ReturnOp>(loc, exportCondition);
+    }
+    // Current function is still the original function, just with a new symbol
+    // name.
+    currentExport = newExport;
+  }
+
+  return;
+}
+
+/// Walks the function |func| exported by |exportOp| and looks for a tilable
+/// operation annotated with specialization ranges. The range annotation can
+/// be accesses with |helper|.
+static void specializeExportedFunctionByRangeAttribute(
+    IREE::HAL::ExecutableExportOp exportOp, func::FuncOp func,
+    RangeAttrHelper helper, llvm::SmallDenseSet<int64_t> &ordinals) {
+  TilingInterface specializationRoot;
+  IREE::Util::MultiIntAssumptionArrayAttr specializationRanges;
+
+  // Walk for the first op specifying specialization ranges. Its unclear what
+  // to do with multiple annotations (which one takes precedence etc.) so for
+  // now take the first.
+  func.walk([&](TilingInterface op) {
+    if (auto maybeRanges = helper.getAttr(op)) {
+      specializationRanges = maybeRanges;
+      specializationRoot = op;
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+
+  if (!specializationRoot) {
+    return;
+  }
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "Specialization root:\n\t";
+    llvm::dbgs() << specializationRoot << "\n";
+  });
+
+  // Remove the attribute now before it potentially gets cloned across multiple
+  // function copies.
+  helper.removeAttr(specializationRoot);
+
+  specializeExportedFunction(exportOp, func, specializationRoot,
+                             specializationRanges, ordinals);
+}
+
+namespace {
+struct SpecializeExportsPass final
+    : impl::SpecializeExportsPassBase<SpecializeExportsPass> {
+public:
+  using Base::Base;
+
+  void runOnOperation() override {
+    IREE::HAL::ExecutableVariantOp variant = getOperation();
+
+    auto *codegenDialect =
+        getContext().getLoadedDialect<IREE::Codegen::IREECodegenDialect>();
+    RangeAttrHelper helper =
+        codegenDialect->getSpecializationRangesAttrHelper();
+
+    ModuleOp innerModule = variant.getInnerModule();
+    if (!innerModule) {
+      // Nothing to do if function definitions aren't provided.
+      return;
+    }
+
+    SmallVector<IREE::HAL::ExecutableExportOp, 1> exports(
+        variant.getExportOps());
+
+    // Get the set of exported ordinals. We need to know which ordinals are
+    // available when introducing new exports.
+    llvm::SmallDenseSet<int64_t> ordinalSet;
+    for (auto exportOp : exports) {
+      IntegerAttr ordinalAttr = exportOp.getOrdinalAttr();
+      if (!ordinalAttr) {
+        return;
+      }
+      ordinalSet.insert(ordinalAttr.getInt());
+    }
+
+    for (auto exportOp : exports) {
+      auto exportedFunc = llvm::dyn_cast_if_present<func::FuncOp>(
+          SymbolTable::lookupNearestSymbolFrom(innerModule,
+                                               exportOp.getSymNameAttr()));
+      if (!exportedFunc || exportedFunc.isExternal()) {
+        // Skip external functions.
+        continue;
+      }
+      LLVM_DEBUG({
+        llvm::dbgs() << "Specializing export:\n\t";
+        llvm::dbgs() << exportOp << "\n";
+      });
+      specializeExportedFunctionByRangeAttribute(exportOp, exportedFunc, helper,
+                                                 ordinalSet);
+    }
+  }
+};
+
+} // namespace
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/SpecializeExports.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/SpecializeExports.cpp
@@ -437,17 +437,8 @@ public:
     for (auto exportOp : exports) {
       IntegerAttr ordinalAttr = exportOp.getOrdinalAttr();
       if (!ordinalAttr) {
-        // We can't add new fallback entry points if we don't have ordinals on
-        // the exports. In such cases bail out and drop all specialization
-        // annotations. Failing to specialize is not considered a failure as the
-        // IR is otherwise still valid.
-        variant.walk([&](Operation *op) {
-          // Guard for silly assert around removal of non-present attribute.
-          if (helper.isAttrPresent(op)) {
-            helper.removeAttr(op);
-          }
-        });
-        return;
+        exportOp.emitError("Missing export ordinal for specialization.");
+        return signalPassFailure();
       }
       ordinalSet.insert(ordinalAttr.getInt());
     }

--- a/compiler/src/iree/compiler/Codegen/Common/SpecializeExports.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/SpecializeExports.cpp
@@ -52,7 +52,7 @@ getIterationDomainAsWorkload(TilingInterface specializationRoot) {
 
   for (auto [i, range] : llvm::enumerate(iterationSpace)) {
     // Non-zero offset and non-unit stride unsupported.
-    if (!isZeroIndex(range.offset) || !isConstantIntValue(range.stride, 1)) {
+    if (!isZeroInteger(range.offset) || !isConstantIntValue(range.stride, 1)) {
       LLVM_DEBUG(llvm::dbgs() << "Failed to get zero offset + unit stride.");
       return failure();
     }

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -94,6 +94,7 @@ iree_lit_test_suite(
             "resolve_swizzle_hints.mlir",
             "repeated_matcher_use.mlir",
             "replace_slow_min_max_ops.mlir",
+            "specialize_exports.mlir",
             "strip_compilation_info.mlir",
             "test_partitionable_loops_interface.mlir",
             "tile_and_distribute_to_workgroups.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -90,6 +90,7 @@ iree_lit_test_suite(
     "repeated_matcher_use.mlir"
     "replace_slow_min_max_ops.mlir"
     "resolve_swizzle_hints.mlir"
+    "specialize_exports.mlir"
     "strip_compilation_info.mlir"
     "test_partitionable_loops_interface.mlir"
     "tile_and_distribute_to_workgroups.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/specialize_exports.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/specialize_exports.mlir
@@ -1,42 +1,40 @@
 // RUN: iree-opt %s \
 // RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-codegen-specialize-exports, cse)))" \
-// RUN: --split-input-file | FileCheck %s
+// RUN:   --split-input-file | FileCheck %s
 
 #executable_target_embedded_elf_aarch64 = #hal.executable.target<"llvm-cpu", "embedded-elf-aarch64">
 #pipeline_layout = #hal.pipeline.layout<constants = 1, bindings = [
   #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
   #hal.pipeline.binding<storage_buffer, ReadOnly>,
   #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
-module {
-  hal.executable private @single_specialization_executable {
-    hal.executable.variant public @variant target(#executable_target_embedded_elf_aarch64) {
-      hal.executable.export public @matmul_transpose_b_Dx1024x4096_f16xf16xf32 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index) -> (index, index, index) {
-        %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
-        hal.return %x, %y, %z : index, index, index
-      }
-      builtin.module {
-        func.func @matmul_transpose_b_Dx1024x4096_f16xf16xf32() {
-          %c0 = arith.constant 0 : index
-          %cst = arith.constant 0.000000e+00 : f32
-          %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
-          %1 = arith.index_castui %0 : i32 to index
-          %2 = util.assume.int %1<umin = 256, umax = 1048320, udiv = 256> : index
-          %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x4096xf16>>
-          %4 = iree_tensor_ext.dispatch.workload.ordinal %2, 0 : index
-          %5 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%4}
-          %6 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x1024xf32>>{%4}
-          %7 = iree_tensor_ext.dispatch.tensor.load %5, offsets = [0, 0], sizes = [%4, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%4} -> tensor<?x4096xf16>
-          %8 = iree_tensor_ext.dispatch.tensor.load %3, offsets = [0, 0], sizes = [1024, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x4096xf16>> -> tensor<1024x4096xf16>
-          %9 = tensor.empty(%4) : tensor<?x1024xf32>
-          %10 = linalg.fill ins(%cst : f32) outs(%9 : tensor<?x1024xf32>) -> tensor<?x1024xf32>
-          %11 = linalg.matmul_transpose_b {
-            iree_codegen.specialization_ranges = #util<int.assumption.multi_array[
-              [<umin = 128, umax = 4096, udiv = 128>, <umin = 128, umax = 4096, udiv = 128>, <umin = 64, udiv = 64>],
-              [<umin = 4096, udiv = 256>, <umin = 4096, udiv = 256>, <udiv = 64>]]>}
-            ins(%7, %8 : tensor<?x4096xf16>, tensor<1024x4096xf16>) outs(%10 : tensor<?x1024xf32>) -> tensor<?x1024xf32>
-          iree_tensor_ext.dispatch.tensor.store %11, %6, offsets = [0, 0], sizes = [%4, 1024], strides = [1, 1] : tensor<?x1024xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x1024xf32>>{%4}
-          return
-        }
+hal.executable private @single_specialization_executable {
+  hal.executable.variant public @variant target(#executable_target_embedded_elf_aarch64) {
+    hal.executable.export public @matmul_transpose_b_Dx1024x4096_f16xf16xf32 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matmul_transpose_b_Dx1024x4096_f16xf16xf32() {
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0.000000e+00 : f32
+        %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
+        %1 = arith.index_castui %0 : i32 to index
+        %2 = util.assume.int %1<umin = 256, umax = 1048320, udiv = 256> : index
+        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x4096xf16>>
+        %4 = iree_tensor_ext.dispatch.workload.ordinal %2, 0 : index
+        %5 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%4}
+        %6 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x1024xf32>>{%4}
+        %7 = iree_tensor_ext.dispatch.tensor.load %5, offsets = [0, 0], sizes = [%4, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%4} -> tensor<?x4096xf16>
+        %8 = iree_tensor_ext.dispatch.tensor.load %3, offsets = [0, 0], sizes = [1024, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x4096xf16>> -> tensor<1024x4096xf16>
+        %9 = tensor.empty(%4) : tensor<?x1024xf32>
+        %10 = linalg.fill ins(%cst : f32) outs(%9 : tensor<?x1024xf32>) -> tensor<?x1024xf32>
+        %11 = linalg.matmul_transpose_b {
+          iree_codegen.specialization_ranges = #util<int.assumption.multi_array[
+            [<umin = 128, umax = 4096, udiv = 128>, <umin = 128, umax = 4096, udiv = 128>, <umin = 64, udiv = 64>],
+            [<umin = 4096, udiv = 256>, <umin = 4096, udiv = 256>, <udiv = 64>]]>}
+          ins(%7, %8 : tensor<?x4096xf16>, tensor<1024x4096xf16>) outs(%10 : tensor<?x1024xf32>) -> tensor<?x1024xf32>
+        iree_tensor_ext.dispatch.tensor.store %11, %6, offsets = [0, 0], sizes = [%4, 1024], strides = [1, 1] : tensor<?x1024xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x1024xf32>>{%4}
+        return
       }
     }
   }
@@ -75,37 +73,35 @@ module {
   #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
   #hal.pipeline.binding<storage_buffer, ReadOnly>,
   #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
-module {
-  hal.executable private @multiple_specialization_executable {
-    hal.executable.variant public @variant target(#executable_target_embedded_elf_aarch64) {
-      hal.executable.export public @matmul_transpose_b_Dx1024x4096_f16xf16xf32 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index) -> (index, index, index) {
-        %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
-        hal.return %x, %y, %z : index, index, index
-      }
-      builtin.module {
-        func.func @matmul_transpose_b_Dx1024x4096_f16xf16xf32() {
-          %c0 = arith.constant 0 : index
-          %cst = arith.constant 0.000000e+00 : f32
-          %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
-          %1 = arith.index_castui %0 : i32 to index
-          %2 = util.assume.int %1<umin = 256, umax = 1048320, udiv = 256> : index
-          %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x4096xf16>>
-          %4 = iree_tensor_ext.dispatch.workload.ordinal %2, 0 : index
-          %5 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%4}
-          %6 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x1024xf32>>{%4}
-          %7 = iree_tensor_ext.dispatch.tensor.load %5, offsets = [0, 0], sizes = [%4, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%4} -> tensor<?x4096xf16>
-          %8 = iree_tensor_ext.dispatch.tensor.load %3, offsets = [0, 0], sizes = [1024, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x4096xf16>> -> tensor<1024x4096xf16>
-          %9 = tensor.empty(%4) : tensor<?x1024xf32>
-          %10 = linalg.fill ins(%cst : f32) outs(%9 : tensor<?x1024xf32>) -> tensor<?x1024xf32>
-          %11 = linalg.matmul_transpose_b {
-            iree_codegen.specialization_ranges = #util<int.assumption.multi_array[
-              [<umin = 128, umax = 4096, udiv = 128>, <umin = 128, umax = 4096, udiv = 128>, <umin = 64, udiv = 64>],
-              [<umin = 0, udiv = 512>, <umin = 0, udiv = 512>, <udiv = 64>], [<udiv = 16>, <udiv = 16>, <udiv = 64>],
-              [<umin = 0, udiv = 512>, <umin = 0, udiv = 512>, <udiv = 64>]]>}
-            ins(%7, %8 : tensor<?x4096xf16>, tensor<1024x4096xf16>) outs(%10 : tensor<?x1024xf32>) -> tensor<?x1024xf32>
-          iree_tensor_ext.dispatch.tensor.store %11, %6, offsets = [0, 0], sizes = [%4, 1024], strides = [1, 1] : tensor<?x1024xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x1024xf32>>{%4}
-          return
-        }
+hal.executable private @multiple_specialization_executable {
+  hal.executable.variant public @variant target(#executable_target_embedded_elf_aarch64) {
+    hal.executable.export public @matmul_transpose_b_Dx1024x4096_f16xf16xf32 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matmul_transpose_b_Dx1024x4096_f16xf16xf32() {
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0.000000e+00 : f32
+        %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
+        %1 = arith.index_castui %0 : i32 to index
+        %2 = util.assume.int %1<umin = 256, umax = 1048320, udiv = 256> : index
+        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x4096xf16>>
+        %4 = iree_tensor_ext.dispatch.workload.ordinal %2, 0 : index
+        %5 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%4}
+        %6 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x1024xf32>>{%4}
+        %7 = iree_tensor_ext.dispatch.tensor.load %5, offsets = [0, 0], sizes = [%4, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%4} -> tensor<?x4096xf16>
+        %8 = iree_tensor_ext.dispatch.tensor.load %3, offsets = [0, 0], sizes = [1024, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x4096xf16>> -> tensor<1024x4096xf16>
+        %9 = tensor.empty(%4) : tensor<?x1024xf32>
+        %10 = linalg.fill ins(%cst : f32) outs(%9 : tensor<?x1024xf32>) -> tensor<?x1024xf32>
+        %11 = linalg.matmul_transpose_b {
+          iree_codegen.specialization_ranges = #util<int.assumption.multi_array[
+            [<umin = 128, umax = 4096, udiv = 128>, <umin = 128, umax = 4096, udiv = 128>, <umin = 64, udiv = 64>],
+            [<umin = 0, udiv = 512>, <umin = 0, udiv = 512>, <udiv = 64>], [<udiv = 16>, <udiv = 16>, <udiv = 64>],
+            [<umin = 0, udiv = 512>, <umin = 0, udiv = 512>, <udiv = 64>]]>}
+          ins(%7, %8 : tensor<?x4096xf16>, tensor<1024x4096xf16>) outs(%10 : tensor<?x1024xf32>) -> tensor<?x1024xf32>
+        iree_tensor_ext.dispatch.tensor.store %11, %6, offsets = [0, 0], sizes = [%4, 1024], strides = [1, 1] : tensor<?x1024xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x1024xf32>>{%4}
+        return
       }
     }
   }
@@ -139,42 +135,40 @@ module {
   #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
   #hal.pipeline.binding<storage_buffer, ReadOnly>,
   #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
-module {
-  hal.executable private @multiple_dimension_assume {
-    hal.executable.variant public @variant target(#executable_target_embedded_elf_aarch64) {
-      hal.executable.export public @matmul_transpose_b_Dx1024x4096_f16xf16xf32 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index) -> (index, index, index) {
-        %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
-        hal.return %x, %y, %z : index, index, index
-      }
-      builtin.module {
-        func.func @matmul_transpose_b_Dx1024x4096_f16xf16xf32() {
-          %c0 = arith.constant 0 : index
-          %cst = arith.constant 0.000000e+00 : f32
-          %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
-          %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : i32
-          %2 = arith.index_castui %0 : i32 to index
-          %3 = arith.index_castui %1 : i32 to index
-          %4:2 = util.assume.int
-              %2[<umin = 256, umax = 8192, udiv = 256>, <udiv = 128>],
-              %3<udiv = 512>
-            : index, index
-          %5 = iree_tensor_ext.dispatch.workload.ordinal %4#1, 1 : index
-          %6 = iree_tensor_ext.dispatch.workload.ordinal %4#0, 0 : index
-          %7 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%6}
-          %8 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%5}
-          %9 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x?xf32>>{%6, %5}
-          %10 = iree_tensor_ext.dispatch.tensor.load %7, offsets = [0, 0], sizes = [%6, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%6} -> tensor<?x4096xf16>
-          %11 = iree_tensor_ext.dispatch.tensor.load %8, offsets = [0, 0], sizes = [%5, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%5} -> tensor<?x4096xf16>
-          %12 = tensor.empty(%6, %5) : tensor<?x?xf32>
-          %13 = linalg.fill ins(%cst : f32) outs(%12 : tensor<?x?xf32>) -> tensor<?x?xf32>
-          %14 = linalg.matmul_transpose_b {
-            iree_codegen.specialization_ranges = #util<int.assumption.multi_array[
-              [<umin = 128, umax = 4096, udiv = 128>, <umin = 128, umax = 4096, udiv = 128>, <umin = 64, udiv = 64>],
-              [<umin = 4096, udiv = 256>, <umin = 4096, udiv = 256>, <udiv = 64>]]>}
-            ins(%10, %11 : tensor<?x4096xf16>, tensor<?x4096xf16>) outs(%13 : tensor<?x?xf32>) -> tensor<?x?xf32>
-          iree_tensor_ext.dispatch.tensor.store %14, %9, offsets = [0, 0], sizes = [%6, %5], strides = [1, 1] : tensor<?x?xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x?xf32>>{%6, %5}
-          return
-        }
+hal.executable private @multiple_dimension_assume {
+  hal.executable.variant public @variant target(#executable_target_embedded_elf_aarch64) {
+    hal.executable.export public @matmul_transpose_b_Dx1024x4096_f16xf16xf32 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matmul_transpose_b_Dx1024x4096_f16xf16xf32() {
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0.000000e+00 : f32
+        %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
+        %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : i32
+        %2 = arith.index_castui %0 : i32 to index
+        %3 = arith.index_castui %1 : i32 to index
+        %4:2 = util.assume.int
+            %2[<umin = 256, umax = 8192, udiv = 256>, <udiv = 128>],
+            %3<udiv = 512>
+          : index, index
+        %5 = iree_tensor_ext.dispatch.workload.ordinal %4#1, 1 : index
+        %6 = iree_tensor_ext.dispatch.workload.ordinal %4#0, 0 : index
+        %7 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%6}
+        %8 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%5}
+        %9 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x?xf32>>{%6, %5}
+        %10 = iree_tensor_ext.dispatch.tensor.load %7, offsets = [0, 0], sizes = [%6, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%6} -> tensor<?x4096xf16>
+        %11 = iree_tensor_ext.dispatch.tensor.load %8, offsets = [0, 0], sizes = [%5, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%5} -> tensor<?x4096xf16>
+        %12 = tensor.empty(%6, %5) : tensor<?x?xf32>
+        %13 = linalg.fill ins(%cst : f32) outs(%12 : tensor<?x?xf32>) -> tensor<?x?xf32>
+        %14 = linalg.matmul_transpose_b {
+          iree_codegen.specialization_ranges = #util<int.assumption.multi_array[
+            [<umin = 128, umax = 4096, udiv = 128>, <umin = 128, umax = 4096, udiv = 128>, <umin = 64, udiv = 64>],
+            [<umin = 4096, udiv = 256>, <umin = 4096, udiv = 256>, <udiv = 64>]]>}
+          ins(%10, %11 : tensor<?x4096xf16>, tensor<?x4096xf16>) outs(%13 : tensor<?x?xf32>) -> tensor<?x?xf32>
+        iree_tensor_ext.dispatch.tensor.store %14, %9, offsets = [0, 0], sizes = [%6, %5], strides = [1, 1] : tensor<?x?xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x?xf32>>{%6, %5}
+        return
       }
     }
   }
@@ -246,40 +240,38 @@ module {
   #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
   #hal.pipeline.binding<storage_buffer, ReadOnly>,
   #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
-module {
-  hal.executable private @unrelated_int_assume {
-    hal.executable.variant public @variant target(#executable_target_embedded_elf_aarch64) {
-      hal.executable.export public @matmul_transpose_b_Dx1024x4096_f16xf16xf32 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index) -> (index, index, index) {
-        %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
-        hal.return %x, %y, %z : index, index, index
-      }
-      builtin.module {
-        func.func @matmul_transpose_b_Dx1024x4096_f16xf16xf32() {
-          %c0 = arith.constant 0 : index
-          %cst = arith.constant 0.000000e+00 : f32
-          %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
-          %12 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : i32
-          %1 = arith.index_castui %0 : i32 to index
-          %13 = arith.index_castui %12 : i32 to index
-          %2:2 = util.assume.int
-              %1[<umin = 256, umax = 1048320, udiv = 256>, <udiv = 128>],
-              %13[<umin = 0, umax = 1000, udiv = 2>, <umin = 1, umax = 2000, udiv = 3>]
-            : index, index
-          %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%2#1) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x4096xf16>>
-          %4 = iree_tensor_ext.dispatch.workload.ordinal %2#0, 0 : index
-          %5 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%4}
-          %6 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x1024xf32>>{%4}
-          %7 = iree_tensor_ext.dispatch.tensor.load %5, offsets = [0, 0], sizes = [%4, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%4} -> tensor<?x4096xf16>
-          %8 = iree_tensor_ext.dispatch.tensor.load %3, offsets = [0, 0], sizes = [1024, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x4096xf16>> -> tensor<1024x4096xf16>
-          %9 = tensor.empty(%4) : tensor<?x1024xf32>
-          %10 = linalg.fill ins(%cst : f32) outs(%9 : tensor<?x1024xf32>) -> tensor<?x1024xf32>
-          %11 = linalg.matmul_transpose_b {
-            iree_codegen.specialization_ranges = #util<int.assumption.multi_array[
-              [<umin = 4096, udiv = 256>, <udiv = 256>, <udiv = 64>]]>}
-            ins(%7, %8 : tensor<?x4096xf16>, tensor<1024x4096xf16>) outs(%10 : tensor<?x1024xf32>) -> tensor<?x1024xf32>
-          iree_tensor_ext.dispatch.tensor.store %11, %6, offsets = [0, 0], sizes = [%4, 1024], strides = [1, 1] : tensor<?x1024xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x1024xf32>>{%4}
-          return
-        }
+hal.executable private @unrelated_int_assume {
+  hal.executable.variant public @variant target(#executable_target_embedded_elf_aarch64) {
+    hal.executable.export public @matmul_transpose_b_Dx1024x4096_f16xf16xf32 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matmul_transpose_b_Dx1024x4096_f16xf16xf32() {
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0.000000e+00 : f32
+        %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
+        %12 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : i32
+        %1 = arith.index_castui %0 : i32 to index
+        %13 = arith.index_castui %12 : i32 to index
+        %2:2 = util.assume.int
+            %1[<umin = 256, umax = 1048320, udiv = 256>, <udiv = 128>],
+            %13[<umin = 0, umax = 1000, udiv = 2>, <umin = 1, umax = 2000, udiv = 3>]
+          : index, index
+        %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%2#1) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x4096xf16>>
+        %4 = iree_tensor_ext.dispatch.workload.ordinal %2#0, 0 : index
+        %5 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%4}
+        %6 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x1024xf32>>{%4}
+        %7 = iree_tensor_ext.dispatch.tensor.load %5, offsets = [0, 0], sizes = [%4, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%4} -> tensor<?x4096xf16>
+        %8 = iree_tensor_ext.dispatch.tensor.load %3, offsets = [0, 0], sizes = [1024, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x4096xf16>> -> tensor<1024x4096xf16>
+        %9 = tensor.empty(%4) : tensor<?x1024xf32>
+        %10 = linalg.fill ins(%cst : f32) outs(%9 : tensor<?x1024xf32>) -> tensor<?x1024xf32>
+        %11 = linalg.matmul_transpose_b {
+          iree_codegen.specialization_ranges = #util<int.assumption.multi_array[
+            [<umin = 4096, udiv = 256>, <udiv = 256>, <udiv = 64>]]>}
+          ins(%7, %8 : tensor<?x4096xf16>, tensor<1024x4096xf16>) outs(%10 : tensor<?x1024xf32>) -> tensor<?x1024xf32>
+        iree_tensor_ext.dispatch.tensor.store %11, %6, offsets = [0, 0], sizes = [%4, 1024], strides = [1, 1] : tensor<?x1024xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x1024xf32>>{%4}
+        return
       }
     }
   }
@@ -313,38 +305,36 @@ module {
   #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
   #hal.pipeline.binding<storage_buffer, ReadOnly>,
   #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
-module {
-  hal.executable private @no_assume {
-    hal.executable.variant public @variant target(#executable_target_embedded_elf_aarch64) {
-      hal.executable.export public @matmul_transpose_b_Dx1024x4096_f16xf16xf32 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index) -> (index, index, index) {
-        %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
-        hal.return %x, %y, %z : index, index, index
-      }
-      builtin.module {
-        func.func @matmul_transpose_b_Dx1024x4096_f16xf16xf32() {
-          %c0 = arith.constant 0 : index
-          %cst = arith.constant 0.000000e+00 : f32
-          %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
-          %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : i32
-          %2 = arith.index_castui %0 : i32 to index
-          %3 = arith.index_castui %1 : i32 to index
-          %5 = iree_tensor_ext.dispatch.workload.ordinal %2, 1 : index
-          %6 = iree_tensor_ext.dispatch.workload.ordinal %3, 0 : index
-          %7 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%6}
-          %8 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%5}
-          %9 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x?xf32>>{%6, %5}
-          %10 = iree_tensor_ext.dispatch.tensor.load %7, offsets = [0, 0], sizes = [%6, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%6} -> tensor<?x4096xf16>
-          %11 = iree_tensor_ext.dispatch.tensor.load %8, offsets = [0, 0], sizes = [%5, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%5} -> tensor<?x4096xf16>
-          %12 = tensor.empty(%6, %5) : tensor<?x?xf32>
-          %13 = linalg.fill ins(%cst : f32) outs(%12 : tensor<?x?xf32>) -> tensor<?x?xf32>
-          %14 = linalg.matmul_transpose_b {
-            iree_codegen.specialization_ranges = #util<int.assumption.multi_array[
-              [<umin = 128, umax = 4096, udiv = 128>, <umin = 128, umax = 4096, udiv = 128>, <umin = 64, udiv = 64>],
-              [<umin = 4096, udiv = 256>, <umin = 4096, udiv = 256>, <udiv = 64>]]>}
-            ins(%10, %11 : tensor<?x4096xf16>, tensor<?x4096xf16>) outs(%13 : tensor<?x?xf32>) -> tensor<?x?xf32>
-          iree_tensor_ext.dispatch.tensor.store %14, %9, offsets = [0, 0], sizes = [%6, %5], strides = [1, 1] : tensor<?x?xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x?xf32>>{%6, %5}
-          return
-        }
+hal.executable private @no_assume {
+  hal.executable.variant public @variant target(#executable_target_embedded_elf_aarch64) {
+    hal.executable.export public @matmul_transpose_b_Dx1024x4096_f16xf16xf32 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matmul_transpose_b_Dx1024x4096_f16xf16xf32() {
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0.000000e+00 : f32
+        %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
+        %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : i32
+        %2 = arith.index_castui %0 : i32 to index
+        %3 = arith.index_castui %1 : i32 to index
+        %5 = iree_tensor_ext.dispatch.workload.ordinal %2, 1 : index
+        %6 = iree_tensor_ext.dispatch.workload.ordinal %3, 0 : index
+        %7 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%6}
+        %8 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%5}
+        %9 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x?xf32>>{%6, %5}
+        %10 = iree_tensor_ext.dispatch.tensor.load %7, offsets = [0, 0], sizes = [%6, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%6} -> tensor<?x4096xf16>
+        %11 = iree_tensor_ext.dispatch.tensor.load %8, offsets = [0, 0], sizes = [%5, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%5} -> tensor<?x4096xf16>
+        %12 = tensor.empty(%6, %5) : tensor<?x?xf32>
+        %13 = linalg.fill ins(%cst : f32) outs(%12 : tensor<?x?xf32>) -> tensor<?x?xf32>
+        %14 = linalg.matmul_transpose_b {
+          iree_codegen.specialization_ranges = #util<int.assumption.multi_array[
+            [<umin = 128, umax = 4096, udiv = 128>, <umin = 128, umax = 4096, udiv = 128>, <umin = 64, udiv = 64>],
+            [<umin = 4096, udiv = 256>, <umin = 4096, udiv = 256>, <udiv = 64>]]>}
+          ins(%10, %11 : tensor<?x4096xf16>, tensor<?x4096xf16>) outs(%13 : tensor<?x?xf32>) -> tensor<?x?xf32>
+        iree_tensor_ext.dispatch.tensor.store %14, %9, offsets = [0, 0], sizes = [%6, %5], strides = [1, 1] : tensor<?x?xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x?xf32>>{%6, %5}
+        return
       }
     }
   }
@@ -376,3 +366,38 @@ module {
 //   CHECK-DAG:       util.assume.int %{{.*}}<umin = 4096, udiv = 256>
 //       CHECK:     func.func @matmul_transpose_b_Dx1024x4096_f16xf16xf32_0_1
 //   CHECK-NOT:       util.assume.int
+
+// -----
+
+#executable_target_embedded_elf_aarch64 = #hal.executable.target<"llvm-cpu", "embedded-elf-aarch64">
+#pipeline_layout = #hal.pipeline.layout<constants = 1, bindings = [
+  #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
+hal.executable private @no_ordinal {
+  hal.executable.variant public @variant target(#executable_target_embedded_elf_aarch64) {
+    hal.executable.export public @matmul_transpose_b_Dx1024x4096_f16xf16xf32 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matmul_transpose_b_Dx1024x4096_f16xf16xf32() {
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0.000000e+00 : f32
+        %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
+        %2 = arith.index_castui %0 : i32 to index
+        %3 = iree_tensor_ext.dispatch.workload.ordinal %2, 0 : index
+        %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?xf32>>{%3}
+        %5 = iree_tensor_ext.dispatch.tensor.load %4, offsets = [0], sizes = [%3], strides = [1] : !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?xf32>>{%3} -> tensor<?xf32>
+        %6 = tensor.empty(%3) : tensor<?xf32>
+        %7 = linalg.copy {iree_codegen.specialization_ranges = #util<int.assumption.multi_array[
+            [<umin = 4096, udiv = 256>]]>}
+          ins(%5 : tensor<?xf32>) outs(%6 : tensor<?xf32>) -> tensor<?xf32>
+        iree_tensor_ext.dispatch.tensor.store %7, %4, offsets = [0], sizes = [%3], strides = [1] : tensor<?xf32> -> !iree_tensor_ext.dispatch.tensor<readwrite:tensor<?xf32>>{%3}
+        return
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: hal.executable private @no_ordinal
+
+//   CHECK-NOT: iree_codegen.specialization_ranges

--- a/compiler/src/iree/compiler/Codegen/Common/test/specialize_exports.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/specialize_exports.mlir
@@ -1,0 +1,378 @@
+// RUN: iree-opt %s \
+// RUN:   --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-codegen-specialize-exports, cse)))" \
+// RUN: --split-input-file | FileCheck %s
+
+#executable_target_embedded_elf_aarch64 = #hal.executable.target<"llvm-cpu", "embedded-elf-aarch64">
+#pipeline_layout = #hal.pipeline.layout<constants = 1, bindings = [
+  #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
+module {
+  hal.executable private @single_specialization_executable {
+    hal.executable.variant public @variant target(#executable_target_embedded_elf_aarch64) {
+      hal.executable.export public @matmul_transpose_b_Dx1024x4096_f16xf16xf32 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index) -> (index, index, index) {
+        %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
+        hal.return %x, %y, %z : index, index, index
+      }
+      builtin.module {
+        func.func @matmul_transpose_b_Dx1024x4096_f16xf16xf32() {
+          %c0 = arith.constant 0 : index
+          %cst = arith.constant 0.000000e+00 : f32
+          %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
+          %1 = arith.index_castui %0 : i32 to index
+          %2 = util.assume.int %1<umin = 256, umax = 1048320, udiv = 256> : index
+          %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x4096xf16>>
+          %4 = iree_tensor_ext.dispatch.workload.ordinal %2, 0 : index
+          %5 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%4}
+          %6 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x1024xf32>>{%4}
+          %7 = iree_tensor_ext.dispatch.tensor.load %5, offsets = [0, 0], sizes = [%4, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%4} -> tensor<?x4096xf16>
+          %8 = iree_tensor_ext.dispatch.tensor.load %3, offsets = [0, 0], sizes = [1024, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x4096xf16>> -> tensor<1024x4096xf16>
+          %9 = tensor.empty(%4) : tensor<?x1024xf32>
+          %10 = linalg.fill ins(%cst : f32) outs(%9 : tensor<?x1024xf32>) -> tensor<?x1024xf32>
+          %11 = linalg.matmul_transpose_b {
+            iree_codegen.specialization_ranges = #util<int.assumption.multi_array[
+              [<umin = 128, umax = 4096, udiv = 128>, <umin = 128, umax = 4096, udiv = 128>, <umin = 64, udiv = 64>],
+              [<umin = 4096, udiv = 256>, <umin = 4096, udiv = 256>, <udiv = 64>]]>}
+            ins(%7, %8 : tensor<?x4096xf16>, tensor<1024x4096xf16>) outs(%10 : tensor<?x1024xf32>) -> tensor<?x1024xf32>
+          iree_tensor_ext.dispatch.tensor.store %11, %6, offsets = [0, 0], sizes = [%4, 1024], strides = [1, 1] : tensor<?x1024xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x1024xf32>>{%4}
+          return
+        }
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: hal.executable private @single_specialization_executable
+
+//       CHECK:   hal.executable.export public @matmul_transpose_b_Dx1024x4096_f16xf16xf32 ordinal(0)
+//  CHECK-SAME:     condition(%{{.*}}: !hal.device, %[[W:.+]]: index) -> i1
+//   CHECK-DAG:       %[[TRUE:.+]] = arith.constant true
+//       CHECK:       %[[UMIN:.+]] = arith.cmpi ule, %c128, %[[W]]
+//       CHECK:       %[[CMIN:.+]] = arith.andi %[[UMIN]], %[[TRUE]]
+//       CHECK:       %[[UMAX:.+]] = arith.cmpi uge, %c4096, %[[W]]
+//       CHECK:       %[[CMAX:.+]] = arith.andi %[[UMAX]], %[[CMIN]]
+//       CHECK:       %[[UREM:.+]] = arith.remui %[[W]], %c128
+//       CHECK:       %[[UDIV:.+]] = arith.cmpi eq, %[[UREM]], %c0
+//       CHECK:       %[[CDIV:.+]] = arith.andi %[[UDIV]], %[[CMAX]]
+//       CHECK:       hal.return %[[CDIV]]
+//       CHECK:     fallback(@matmul_transpose_b_Dx1024x4096_f16xf16xf32_0)
+//  CHECK-SAME:     count(%{{[A-Za-z0-9]*}}: !hal.device
+//  CHECK-NEXT:       iree_tensor_ext.dispatch.workgroup_count_from_slice
+
+//       CHECK:   hal.executable.export public @matmul_transpose_b_Dx1024x4096_f16xf16xf32_0 ordinal(1)
+//  CHECK-NEXT:       iree_tensor_ext.dispatch.workgroup_count_from_slice
+
+//       CHECK:   builtin.module
+//       CHECK:     func.func @matmul_transpose_b_Dx1024x4096_f16xf16xf32
+//       CHECK:       util.assume.int %{{.*}}<umin = 128, umax = 4096, udiv = 128>
+//       CHECK:     func.func @matmul_transpose_b_Dx1024x4096_f16xf16xf32_0
+//       CHECK:       util.assume.int %{{.*}}<umin = 256, umax = 1048320, udiv = 256>
+
+// -----
+
+#executable_target_embedded_elf_aarch64 = #hal.executable.target<"llvm-cpu", "embedded-elf-aarch64">
+#pipeline_layout = #hal.pipeline.layout<constants = 1, bindings = [
+  #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
+module {
+  hal.executable private @multiple_specialization_executable {
+    hal.executable.variant public @variant target(#executable_target_embedded_elf_aarch64) {
+      hal.executable.export public @matmul_transpose_b_Dx1024x4096_f16xf16xf32 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index) -> (index, index, index) {
+        %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
+        hal.return %x, %y, %z : index, index, index
+      }
+      builtin.module {
+        func.func @matmul_transpose_b_Dx1024x4096_f16xf16xf32() {
+          %c0 = arith.constant 0 : index
+          %cst = arith.constant 0.000000e+00 : f32
+          %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
+          %1 = arith.index_castui %0 : i32 to index
+          %2 = util.assume.int %1<umin = 256, umax = 1048320, udiv = 256> : index
+          %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x4096xf16>>
+          %4 = iree_tensor_ext.dispatch.workload.ordinal %2, 0 : index
+          %5 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%4}
+          %6 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x1024xf32>>{%4}
+          %7 = iree_tensor_ext.dispatch.tensor.load %5, offsets = [0, 0], sizes = [%4, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%4} -> tensor<?x4096xf16>
+          %8 = iree_tensor_ext.dispatch.tensor.load %3, offsets = [0, 0], sizes = [1024, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x4096xf16>> -> tensor<1024x4096xf16>
+          %9 = tensor.empty(%4) : tensor<?x1024xf32>
+          %10 = linalg.fill ins(%cst : f32) outs(%9 : tensor<?x1024xf32>) -> tensor<?x1024xf32>
+          %11 = linalg.matmul_transpose_b {
+            iree_codegen.specialization_ranges = #util<int.assumption.multi_array[
+              [<umin = 128, umax = 4096, udiv = 128>, <umin = 128, umax = 4096, udiv = 128>, <umin = 64, udiv = 64>],
+              [<umin = 0, udiv = 512>, <umin = 0, udiv = 512>, <udiv = 64>], [<udiv = 16>, <udiv = 16>, <udiv = 64>],
+              [<umin = 0, udiv = 512>, <umin = 0, udiv = 512>, <udiv = 64>]]>}
+            ins(%7, %8 : tensor<?x4096xf16>, tensor<1024x4096xf16>) outs(%10 : tensor<?x1024xf32>) -> tensor<?x1024xf32>
+          iree_tensor_ext.dispatch.tensor.store %11, %6, offsets = [0, 0], sizes = [%4, 1024], strides = [1, 1] : tensor<?x1024xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x1024xf32>>{%4}
+          return
+        }
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: hal.executable private @multiple_specialization_executable
+
+//       CHECK:   hal.executable.export public @matmul_transpose_b_Dx1024x4096_f16xf16xf32 ordinal(0)
+//  CHECK-SAME:     condition(%{{.*}}: !hal.device, %[[W:.+]]: index) -> i1
+//       CHECK:     fallback(@matmul_transpose_b_Dx1024x4096_f16xf16xf32_0)
+
+//       CHECK:   hal.executable.export public @matmul_transpose_b_Dx1024x4096_f16xf16xf32_0 ordinal(1)
+//  CHECK-SAME:     condition(%{{.*}}: !hal.device, %[[W:.+]]: index) -> i1
+//       CHECK:     fallback(@matmul_transpose_b_Dx1024x4096_f16xf16xf32_0_1)
+
+//       CHECK:   hal.executable.export public @matmul_transpose_b_Dx1024x4096_f16xf16xf32_0_1 ordinal(2)
+//  CHECK-NEXT:       iree_tensor_ext.dispatch.workgroup_count_from_slice
+
+//       CHECK:   builtin.module
+//       CHECK:     func.func @matmul_transpose_b_Dx1024x4096_f16xf16xf32
+//       CHECK:       util.assume.int %{{.*}}<umin = 128, umax = 4096, udiv = 128>
+//       CHECK:     func.func @matmul_transpose_b_Dx1024x4096_f16xf16xf32_0
+//       CHECK:       util.assume.int %{{.*}}<umin = 0, udiv = 512>
+//       CHECK:     func.func @matmul_transpose_b_Dx1024x4096_f16xf16xf32_0_1
+//       CHECK:       util.assume.int %{{.*}}<umin = 256, umax = 1048320, udiv = 256>
+
+// -----
+
+#executable_target_embedded_elf_aarch64 = #hal.executable.target<"llvm-cpu", "embedded-elf-aarch64">
+#pipeline_layout = #hal.pipeline.layout<constants = 2, bindings = [
+  #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
+module {
+  hal.executable private @multiple_dimension_assume {
+    hal.executable.variant public @variant target(#executable_target_embedded_elf_aarch64) {
+      hal.executable.export public @matmul_transpose_b_Dx1024x4096_f16xf16xf32 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index) -> (index, index, index) {
+        %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
+        hal.return %x, %y, %z : index, index, index
+      }
+      builtin.module {
+        func.func @matmul_transpose_b_Dx1024x4096_f16xf16xf32() {
+          %c0 = arith.constant 0 : index
+          %cst = arith.constant 0.000000e+00 : f32
+          %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
+          %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : i32
+          %2 = arith.index_castui %0 : i32 to index
+          %3 = arith.index_castui %1 : i32 to index
+          %4:2 = util.assume.int
+              %2[<umin = 256, umax = 8192, udiv = 256>, <udiv = 128>],
+              %3<udiv = 512>
+            : index, index
+          %5 = iree_tensor_ext.dispatch.workload.ordinal %4#1, 1 : index
+          %6 = iree_tensor_ext.dispatch.workload.ordinal %4#0, 0 : index
+          %7 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%6}
+          %8 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%5}
+          %9 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x?xf32>>{%6, %5}
+          %10 = iree_tensor_ext.dispatch.tensor.load %7, offsets = [0, 0], sizes = [%6, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%6} -> tensor<?x4096xf16>
+          %11 = iree_tensor_ext.dispatch.tensor.load %8, offsets = [0, 0], sizes = [%5, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%5} -> tensor<?x4096xf16>
+          %12 = tensor.empty(%6, %5) : tensor<?x?xf32>
+          %13 = linalg.fill ins(%cst : f32) outs(%12 : tensor<?x?xf32>) -> tensor<?x?xf32>
+          %14 = linalg.matmul_transpose_b {
+            iree_codegen.specialization_ranges = #util<int.assumption.multi_array[
+              [<umin = 128, umax = 4096, udiv = 128>, <umin = 128, umax = 4096, udiv = 128>, <umin = 64, udiv = 64>],
+              [<umin = 4096, udiv = 256>, <umin = 4096, udiv = 256>, <udiv = 64>]]>}
+            ins(%10, %11 : tensor<?x4096xf16>, tensor<?x4096xf16>) outs(%13 : tensor<?x?xf32>) -> tensor<?x?xf32>
+          iree_tensor_ext.dispatch.tensor.store %14, %9, offsets = [0, 0], sizes = [%6, %5], strides = [1, 1] : tensor<?x?xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x?xf32>>{%6, %5}
+          return
+        }
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: hal.executable private @multiple_dimension_assume
+
+//       CHECK:   hal.executable.export public @matmul_transpose_b_Dx1024x4096_f16xf16xf32 ordinal(0)
+//  CHECK-SAME:     condition(%{{.*}}: !hal.device, %[[W0:[A-Za-z0-9]+]]: index, %[[W1:[A-Za-z0-9]+]]: index) -> i1
+//       CHECK:       %[[TRUE:.+]] = arith.constant true
+//       CHECK:       %[[UMIN:.+]] = arith.cmpi ule, %c128, %[[W0]]
+//       CHECK:       %[[CMIN:.+]] = arith.andi %[[UMIN]], %[[TRUE]]
+//       CHECK:       %[[UMAX:.+]] = arith.cmpi uge, %c4096, %[[W0]]
+//       CHECK:       %[[CMAX:.+]] = arith.andi %[[UMAX]], %[[CMIN]]
+//       CHECK:       %[[UREM:.+]] = arith.remui %[[W0]], %c128
+//       CHECK:       %[[UDIV:.+]] = arith.cmpi eq, %[[UREM]], %c0
+//       CHECK:       %[[CDIV:.+]] = arith.andi %[[UDIV]], %[[CMAX]]
+//       CHECK:       %[[UMIN1:.+]] = arith.cmpi ule, %c128, %[[W1]]
+//       CHECK:       %[[CMIN1:.+]] = arith.andi %[[UMIN1]], %[[CDIV]]
+//       CHECK:       %[[UMAX1:.+]] = arith.cmpi uge, %c4096, %[[W1]]
+//       CHECK:       %[[CMAX1:.+]] = arith.andi %[[UMAX1]], %[[CMIN1]]
+//       CHECK:       %[[UREM1:.+]] = arith.remui %[[W1]], %c128
+//       CHECK:       %[[UDIV1:.+]] = arith.cmpi eq, %[[UREM1]], %c0
+//       CHECK:       %[[CDIV1:.+]] = arith.andi %[[UDIV1]], %[[CMAX1]]
+//       CHECK:       hal.return %[[CDIV1]]
+//       CHECK:     fallback(@matmul_transpose_b_Dx1024x4096_f16xf16xf32_0)
+//  CHECK-SAME:     count(%{{[A-Za-z0-9]*}}: !hal.device
+//  CHECK-NEXT:       iree_tensor_ext.dispatch.workgroup_count_from_slice
+
+//       CHECK:   hal.executable.export public @matmul_transpose_b_Dx1024x4096_f16xf16xf32_0 ordinal(1)
+//  CHECK-SAME:     condition(%{{.*}}: !hal.device, %[[W0:[A-Za-z0-9]+]]: index, %[[W1:[A-Za-z0-9]+]]: index) -> i1
+//       CHECK:       %[[TRUE:.+]] = arith.constant true
+//       CHECK:       %[[UMIN:.+]] = arith.cmpi ule, %c4096, %[[W0]]
+//       CHECK:       %[[CMIN:.+]] = arith.andi %[[UMIN]], %[[TRUE]]
+//       CHECK:       %[[UREM:.+]] = arith.remui %[[W0]], %c256
+//       CHECK:       %[[UDIV:.+]] = arith.cmpi eq, %[[UREM]], %c0
+//       CHECK:       %[[CDIV:.+]] = arith.andi %[[UDIV]], %[[CMIN]]
+//       CHECK:       %[[UMIN1:.+]] = arith.cmpi ule, %c4096, %[[W1]]
+//       CHECK:       %[[CMIN1:.+]] = arith.andi %[[UMIN1]], %[[CDIV]]
+//       CHECK:       %[[UREM1:.+]] = arith.remui %[[W1]], %c256
+//       CHECK:       %[[UDIV1:.+]] = arith.cmpi eq, %[[UREM1]], %c0
+//       CHECK:       %[[CDIV1:.+]] = arith.andi %[[UDIV1]], %[[CMIN1]]
+//       CHECK:       hal.return %[[CDIV1]]
+//       CHECK:     fallback(@matmul_transpose_b_Dx1024x4096_f16xf16xf32_0_1)
+//  CHECK-SAME:     count(%{{[A-Za-z0-9]*}}: !hal.device
+//  CHECK-NEXT:       iree_tensor_ext.dispatch.workgroup_count_from_slice
+
+//       CHECK:   hal.executable.export public @matmul_transpose_b_Dx1024x4096_f16xf16xf32_0_1 ordinal(2)
+//  CHECK-NEXT:       iree_tensor_ext.dispatch.workgroup_count_from_slice
+
+//       CHECK:   builtin.module
+//       CHECK:     func.func @matmul_transpose_b_Dx1024x4096_f16xf16xf32
+//       CHECK:       util.assume.int
+//  CHECK-NEXT:         <umin = 128, umax = 4096, udiv = 128>
+//  CHECK-NEXT:         <umin = 128, umax = 4096, udiv = 128>
+//       CHECK:     func.func @matmul_transpose_b_Dx1024x4096_f16xf16xf32_0
+//       CHECK:       util.assume.int
+//  CHECK-NEXT:         <umin = 4096, udiv = 256>
+//  CHECK-NEXT:         <umin = 4096, udiv = 256>
+//       CHECK:     func.func @matmul_transpose_b_Dx1024x4096_f16xf16xf32_0_1
+//       CHECK:       util.assume.int
+//  CHECK-NEXT:         [<umin = 256, umax = 8192, udiv = 256>, <udiv = 128>]
+//  CHECK-NEXT:         <udiv = 512>
+
+// -----
+
+#executable_target_embedded_elf_aarch64 = #hal.executable.target<"llvm-cpu", "embedded-elf-aarch64">
+#pipeline_layout = #hal.pipeline.layout<constants = 2, bindings = [
+  #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
+module {
+  hal.executable private @unrelated_int_assume {
+    hal.executable.variant public @variant target(#executable_target_embedded_elf_aarch64) {
+      hal.executable.export public @matmul_transpose_b_Dx1024x4096_f16xf16xf32 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index) -> (index, index, index) {
+        %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
+        hal.return %x, %y, %z : index, index, index
+      }
+      builtin.module {
+        func.func @matmul_transpose_b_Dx1024x4096_f16xf16xf32() {
+          %c0 = arith.constant 0 : index
+          %cst = arith.constant 0.000000e+00 : f32
+          %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
+          %12 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : i32
+          %1 = arith.index_castui %0 : i32 to index
+          %13 = arith.index_castui %12 : i32 to index
+          %2:2 = util.assume.int
+              %1[<umin = 256, umax = 1048320, udiv = 256>, <udiv = 128>],
+              %13[<umin = 0, umax = 1000, udiv = 2>, <umin = 1, umax = 2000, udiv = 3>]
+            : index, index
+          %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%2#1) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x4096xf16>>
+          %4 = iree_tensor_ext.dispatch.workload.ordinal %2#0, 0 : index
+          %5 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%4}
+          %6 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x1024xf32>>{%4}
+          %7 = iree_tensor_ext.dispatch.tensor.load %5, offsets = [0, 0], sizes = [%4, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%4} -> tensor<?x4096xf16>
+          %8 = iree_tensor_ext.dispatch.tensor.load %3, offsets = [0, 0], sizes = [1024, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<1024x4096xf16>> -> tensor<1024x4096xf16>
+          %9 = tensor.empty(%4) : tensor<?x1024xf32>
+          %10 = linalg.fill ins(%cst : f32) outs(%9 : tensor<?x1024xf32>) -> tensor<?x1024xf32>
+          %11 = linalg.matmul_transpose_b {
+            iree_codegen.specialization_ranges = #util<int.assumption.multi_array[
+              [<umin = 4096, udiv = 256>, <udiv = 256>, <udiv = 64>]]>}
+            ins(%7, %8 : tensor<?x4096xf16>, tensor<1024x4096xf16>) outs(%10 : tensor<?x1024xf32>) -> tensor<?x1024xf32>
+          iree_tensor_ext.dispatch.tensor.store %11, %6, offsets = [0, 0], sizes = [%4, 1024], strides = [1, 1] : tensor<?x1024xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x1024xf32>>{%4}
+          return
+        }
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: hal.executable private @unrelated_int_assume
+
+//       CHECK:   hal.executable.export public @matmul_transpose_b_Dx1024x4096_f16xf16xf32 ordinal(0)
+//  CHECK-SAME:     condition(%{{.*}}: !hal.device, %[[W:.+]]: index) -> i1
+//       CHECK:     fallback(@matmul_transpose_b_Dx1024x4096_f16xf16xf32_0)
+//  CHECK-SAME:     count(%{{[A-Za-z0-9]*}}: !hal.device
+//  CHECK-NEXT:       iree_tensor_ext.dispatch.workgroup_count_from_slice
+
+//       CHECK:   hal.executable.export public @matmul_transpose_b_Dx1024x4096_f16xf16xf32_0 ordinal(1)
+//  CHECK-NEXT:       iree_tensor_ext.dispatch.workgroup_count_from_slice
+
+//       CHECK:   builtin.module
+//       CHECK:     func.func @matmul_transpose_b_Dx1024x4096_f16xf16xf32
+//       CHECK:       util.assume.int
+//  CHECK-NEXT:         <umin = 4096, udiv = 256>
+//  CHECK-NEXT:         [<umin = 0, umax = 1000, udiv = 2>, <umin = 1, umax = 2000, udiv = 3>]
+//       CHECK:     func.func @matmul_transpose_b_Dx1024x4096_f16xf16xf32_0
+//       CHECK:       util.assume.int
+//  CHECK-NEXT:         [<umin = 256, umax = 1048320, udiv = 256>, <udiv = 128>]
+//  CHECK-NEXT:         [<umin = 0, umax = 1000, udiv = 2>, <umin = 1, umax = 2000, udiv = 3>]
+
+// -----
+
+#executable_target_embedded_elf_aarch64 = #hal.executable.target<"llvm-cpu", "embedded-elf-aarch64">
+#pipeline_layout = #hal.pipeline.layout<constants = 2, bindings = [
+  #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+  #hal.pipeline.binding<storage_buffer, ReadOnly>,
+  #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
+module {
+  hal.executable private @no_assume {
+    hal.executable.variant public @variant target(#executable_target_embedded_elf_aarch64) {
+      hal.executable.export public @matmul_transpose_b_Dx1024x4096_f16xf16xf32 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2: index) -> (index, index, index) {
+        %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
+        hal.return %x, %y, %z : index, index, index
+      }
+      builtin.module {
+        func.func @matmul_transpose_b_Dx1024x4096_f16xf16xf32() {
+          %c0 = arith.constant 0 : index
+          %cst = arith.constant 0.000000e+00 : f32
+          %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : i32
+          %1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : i32
+          %2 = arith.index_castui %0 : i32 to index
+          %3 = arith.index_castui %1 : i32 to index
+          %5 = iree_tensor_ext.dispatch.workload.ordinal %2, 1 : index
+          %6 = iree_tensor_ext.dispatch.workload.ordinal %3, 0 : index
+          %7 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%6}
+          %8 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%5}
+          %9 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(Indirect) : !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x?xf32>>{%6, %5}
+          %10 = iree_tensor_ext.dispatch.tensor.load %7, offsets = [0, 0], sizes = [%6, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%6} -> tensor<?x4096xf16>
+          %11 = iree_tensor_ext.dispatch.tensor.load %8, offsets = [0, 0], sizes = [%5, 4096], strides = [1, 1] : !iree_tensor_ext.dispatch.tensor<readonly:tensor<?x4096xf16>>{%5} -> tensor<?x4096xf16>
+          %12 = tensor.empty(%6, %5) : tensor<?x?xf32>
+          %13 = linalg.fill ins(%cst : f32) outs(%12 : tensor<?x?xf32>) -> tensor<?x?xf32>
+          %14 = linalg.matmul_transpose_b {
+            iree_codegen.specialization_ranges = #util<int.assumption.multi_array[
+              [<umin = 128, umax = 4096, udiv = 128>, <umin = 128, umax = 4096, udiv = 128>, <umin = 64, udiv = 64>],
+              [<umin = 4096, udiv = 256>, <umin = 4096, udiv = 256>, <udiv = 64>]]>}
+            ins(%10, %11 : tensor<?x4096xf16>, tensor<?x4096xf16>) outs(%13 : tensor<?x?xf32>) -> tensor<?x?xf32>
+          iree_tensor_ext.dispatch.tensor.store %14, %9, offsets = [0, 0], sizes = [%6, %5], strides = [1, 1] : tensor<?x?xf32> -> !iree_tensor_ext.dispatch.tensor<writeonly:tensor<?x?xf32>>{%6, %5}
+          return
+        }
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: hal.executable private @no_assume
+
+//       CHECK:   hal.executable.export public @matmul_transpose_b_Dx1024x4096_f16xf16xf32 ordinal(0)
+//  CHECK-SAME:     condition(%{{.*}}: !hal.device
+//       CHECK:     fallback(@matmul_transpose_b_Dx1024x4096_f16xf16xf32_0)
+//  CHECK-SAME:     count(%{{[A-Za-z0-9]*}}: !hal.device
+//  CHECK-NEXT:       iree_tensor_ext.dispatch.workgroup_count_from_slice
+
+//       CHECK:   hal.executable.export public @matmul_transpose_b_Dx1024x4096_f16xf16xf32_0 ordinal(1)
+//  CHECK-SAME:     condition(%{{.*}}: !hal.device
+//       CHECK:     fallback(@matmul_transpose_b_Dx1024x4096_f16xf16xf32_0_1)
+//  CHECK-SAME:     count(%{{[A-Za-z0-9]*}}: !hal.device
+//  CHECK-NEXT:       iree_tensor_ext.dispatch.workgroup_count_from_slice
+
+//       CHECK:   hal.executable.export public @matmul_transpose_b_Dx1024x4096_f16xf16xf32_0_1 ordinal(2)
+//  CHECK-NEXT:       iree_tensor_ext.dispatch.workgroup_count_from_slice
+
+//       CHECK:   builtin.module
+//       CHECK:     func.func @matmul_transpose_b_Dx1024x4096_f16xf16xf32
+//   CHECK-DAG:       util.assume.int %{{.*}}<umin = 128, umax = 4096, udiv = 128>
+//   CHECK-DAG:       util.assume.int %{{.*}}<umin = 128, umax = 4096, udiv = 128>
+//       CHECK:     func.func @matmul_transpose_b_Dx1024x4096_f16xf16xf32_0
+//   CHECK-DAG:       util.assume.int %{{.*}}<umin = 4096, udiv = 256>
+//   CHECK-DAG:       util.assume.int %{{.*}}<umin = 4096, udiv = 256>
+//       CHECK:     func.func @matmul_transpose_b_Dx1024x4096_f16xf16xf32_0_1
+//   CHECK-NOT:       util.assume.int

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/BUILD.bazel
@@ -90,6 +90,7 @@ iree_compiler_cc_library(
         ":LoweringConfigInterfaceGen",
         ":UKernelOpsGen",
         "//compiler/src/iree/compiler/Codegen/Interfaces:UKernelOpInterface",
+        "//compiler/src/iree/compiler/Dialect/Util/IR",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:ArithDialect",

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/CMakeLists.txt
@@ -69,6 +69,7 @@ iree_cc_library(
     MLIRTransformDialectTransforms
     MLIRViewLikeInterface
     iree::compiler::Codegen::Interfaces::UKernelOpInterface
+    iree::compiler::Dialect::Util::IR
   PUBLIC
 )
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h
@@ -9,6 +9,7 @@
 
 #include <mutex>
 
+#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringMap.h"
 #include "mlir/IR/Dialect.h"

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.td
@@ -33,6 +33,31 @@ def IREECodegen_Dialect : Dialect {
     search to easily override the heuristics that are hard-coded
     within a backend.
   }];
+  let discardableAttrs = (ins
+    /// Discardable attribute for specializing kernels based on iteration
+    /// domain. For example,
+    ///
+    /// ```
+    /// %35 = linalg.matmul ins(%30, %31 : tensor<?x?xf16>, tensor<?x?xf16>) outs(%34 : tensor<?x?xf32>)
+    ///   {iree_codegen.specialization_ranges = #util<int.assumption.multi_array[
+    ///     [<umin = 128, umax = 4096, udiv = 128>, <umin = 128, umax = 4096, udiv = 128>, <umin = 64, udiv = 64>],
+    ///     [<umin = 4096, udiv = 256>, <umin = 4096, udiv = 256>, <udiv = 64>]
+    /// ]>} -> tensor<?x?xf32>
+    /// ```
+    ///
+    /// This matmul will be specialized into up to 3 variants, one default, and
+    /// two for each list of ranges. The lists of ranges are ordered with
+    /// respect to the iteration space of the op. So in this case, for the first
+    /// specialization, the first iteration dim (M) must be 128 <= M <= 4096 and
+    /// divisible by 128. All ranges in a list must be satisfied at the same
+    /// time for a workload to specialize.
+    ///
+    /// The specialization ranges are ordered by priority so the highest
+    /// priority ranges are listed first. Specializations that statically
+    /// never apply won't be generated, and specializations that always apply
+    /// will skip all subsequent specializations.
+    "::mlir::iree_compiler::IREE::Util::MultiIntAssumptionArrayAttr":$specialization_ranges
+  );
   let extraClassDeclaration = [{
     void initializeCodegenAttrs();
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -837,6 +837,7 @@ void buildLLVMCPUCodegenConfigurationPassPipelineImpl(
 
 void buildLLVMCPUCodegenConfigurationPassPipeline(
     OpPassManager &variantPassManager) {
+  variantPassManager.addPass(createSpecializeExportsPass());
   OpPassManager &modulePassManager = variantPassManager.nest<ModuleOp>();
   buildLLVMCPUCodegenConfigurationPassPipelineImpl(modulePassManager);
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -1229,6 +1229,7 @@ static void buildLLVMGPUCodegenConfigurationPassPipelineImpl(
 
 void buildLLVMGPUCodegenConfigurationPassPipeline(
     OpPassManager &variantPassManager) {
+  variantPassManager.addPass(createSpecializeExportsPass());
   buildLLVMGPUCodegenConfigurationPassPipelineImpl(
       variantPassManager.nest<ModuleOp>());
 }
@@ -1307,6 +1308,7 @@ static void buildROCDLCodegenConfigurationPassPipelineImpl(
 
 void buildROCDLCodegenConfigurationPassPipeline(
     OpPassManager &variantPassManager) {
+  variantPassManager.addPass(createSpecializeExportsPass());
   OpPassManager &modulePassManager = variantPassManager.nest<ModuleOp>();
   buildROCDLCodegenConfigurationPassPipelineImpl(modulePassManager);
 }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -633,6 +633,7 @@ static void buildSPIRVCodegenConfigurationPassPipelineImpl(
 
 void buildSPIRVCodegenConfigurationPassPipeline(
     OpPassManager &variantPassManager) {
+  variantPassManager.addPass(createSpecializeExportsPass());
   OpPassManager &modulePassManager = variantPassManager.nest<ModuleOp>();
   buildSPIRVCodegenConfigurationPassPipelineImpl(modulePassManager);
 }

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilAttrs.td
@@ -44,6 +44,18 @@ def Util_MultiValueIntAssumptionAttrList : TypedArrayAttrBase<
     Util_IntAssumptionAttrList,
     "list of int attribute assumptions for multiple values">;
 
+/// Convenience array attribute for assumption lists.
+def Util_IntAssumptionAttrArray : ArrayOfAttr<
+  Util_Dialect, "IntAssumptionArray", "int.assumption.array", "IntAssumptionAttr"> {
+  let cppNamespace = "::mlir::iree_compiler::IREE::Util";
+}
+
+/// Convenience array attribute for nested assumption lists.
+def Util_MultiValueIntAssumptionAttrArray : ArrayOfAttr<
+  Util_Dialect, "MultiIntAssumptionArray", "int.assumption.multi_array", "IntAssumptionArrayAttr"> {
+  let cppNamespace = "::mlir::iree_compiler::IREE::Util";
+}
+
 //===----------------------------------------------------------------------===//
 // #util.byte_pattern
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.h
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.h
@@ -258,6 +258,8 @@ std::optional<ValueRange> findDynamicDims(Value shapedValue);
 // Walks the SSA use-def chain upwards to find the requested dimension of the
 // value if the dimension is dynamic. Returns the static size if the dim is
 // static, and null if the walk fails.
+// NOTE: If querying more than one dimension prefer findDynamicDims instead
+// of calling this multiple times for the same |shapedValue|.
 OpFoldResult findDim(Value shapedValue, int64_t dim);
 
 // Walks the SSA use-def chain to find the dynamic dimensions of the value.

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.h
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.h
@@ -255,6 +255,11 @@ using SetIntDivisibilityFn =
 // value. Returns None if the shape cannot be found.
 std::optional<ValueRange> findDynamicDims(Value shapedValue);
 
+// Walks the SSA use-def chain upwards to find the requested dimension of the
+// value if the dimension is dynamic. Returns the static size if the dim is
+// static, and null if the walk fails.
+OpFoldResult findDim(Value shapedValue, int64_t dim);
+
 // Walks the SSA use-def chain to find the dynamic dimensions of the value.
 // Returns None if the shape cannot be found or if it is defined after
 // {|block|, |insertionPoint|}.


### PR DESCRIPTION
This allows for kernel specialization by way of annotating tilable ops with the preferred iteration ranges and divisibilities to specialize for. For example,

```
%35 = linalg.matmul ins(%30, %31 : tensor<?x?xf16>, tensor<?x?xf16>) outs(%34 : tensor<?x?xf32>)
  {iree_codegen.specialization_ranges = #util<int.assumption.multi_array[
    [<umin = 128, umax = 4096, udiv = 128>, <umin = 128, umax = 4096, udiv = 128>, <umin = 64, udiv = 64>],
    [<umin = 4096, udiv = 256>, <umin = 4096, udiv = 256>, <udiv = 64>]
]>} -> tensor<?x?xf32>
```

This matmul will be specialized into up to 3 variants, one default, and two for each list of ranges. More details can be found in the code documentation.

To specialize a dispatch, the pass queries the iteration domain of the tilable op and looks for a producer `util.int.assume` op. The function is then cloned and the assume is updated to match the requested ranges.

This is just one way to implement kernel specialization, in the future we can implement many more options (e.g. based on estimated TOPs or smallest individual dimension) and that's without considering what device we're targeting. The implementation here supports many common cases of minimum/maximum sizes and alignments. Learnings here will translate to future improvements for other strategies.

This pass runs first thing in the configuration pipelines because it needs to apply to the variant, and should run before passes like BlockDynamicDims which takes advantage of `util.assume.int` information that this pass refines.