### PR TITLE
Align iree_hal_sync_device_t allocation to 16 bytes.

### DIFF
--- a/runtime/src/iree/hal/drivers/local_sync/sync_device.c
+++ b/runtime/src/iree/hal/drivers/local_sync/sync_device.c
@@ -6,7 +6,6 @@
 
 #include "iree/hal/drivers/local_sync/sync_device.h"
 
-#include <stdalign.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
@@ -88,7 +87,7 @@ iree_status_t iree_hal_sync_device_create(
       sizeof(*device) + loader_count * sizeof(*device->loaders);
   iree_host_size_t total_size = struct_size + identifier.size;
   iree_status_t status = iree_allocator_malloc_aligned(
-      host_allocator, total_size, alignof(iree_hal_sync_device_t), 0,
+      host_allocator, total_size, iree_alignof(iree_hal_sync_device_t), 0,
       (void**)&device);
   if (iree_status_is_ok(status)) {
     memset(device, 0, total_size);

--- a/runtime/src/iree/hal/drivers/local_sync/sync_device.c
+++ b/runtime/src/iree/hal/drivers/local_sync/sync_device.c
@@ -6,6 +6,7 @@
 
 #include "iree/hal/drivers/local_sync/sync_device.h"
 
+#include <stdalign.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
@@ -86,8 +87,9 @@ iree_status_t iree_hal_sync_device_create(
   iree_host_size_t struct_size =
       sizeof(*device) + loader_count * sizeof(*device->loaders);
   iree_host_size_t total_size = struct_size + identifier.size;
-  iree_status_t status =
-      iree_allocator_malloc(host_allocator, total_size, (void**)&device);
+  iree_status_t status = iree_allocator_malloc_aligned(
+      host_allocator, total_size, alignof(iree_hal_sync_device_t), 0,
+      (void**)&device);
   if (iree_status_is_ok(status)) {
     memset(device, 0, total_size);
     iree_hal_resource_initialize(&iree_hal_sync_device_vtable,
@@ -134,7 +136,7 @@ static void iree_hal_sync_device_destroy(iree_hal_device_t* base_device) {
 
   iree_arena_block_pool_deinitialize(&device->large_block_pool);
 
-  iree_allocator_free(host_allocator, device);
+  iree_allocator_free_aligned(host_allocator, device);
 
   IREE_TRACE_ZONE_END(z0);
 }


### PR DESCRIPTION
This PR fixes an undefined behavior detected by ubsan. The alignment of `iree_hal_sync_device_t` is 16 because of `iree_arena_block_pool_t` and `iree_atomic_arena_block_slist_t` whose alignment is defined by `iree_alignas(iree_max_align_t)`.

`device` is allocated by `new_ptr = calloc(1, byte_length);` whose alignment is [fundamental alignment](https://en.cppreference.com/w/c/language/object#Alignment) according to https://en.cppreference.com/w/c/memory/calloc. In my case, `device` is aligned of 8 byte.

This undefined behavior caused unexpected fault when building iree-runtime in cmake release build type.