### PR TITLE
[LinalgExt] Remove region from LinalgExt::GatherOp

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -235,12 +235,7 @@ def IREELinalgExt_GatherOp : IREELinalgExt_Op<"gather",
   let summary = [{Gathers slices from a source based on a tensor of indices.}];
   let description = [{
     Takes two inputs (`source` and `indices`) and outputs value (`output`).
-    The operation returns the value at the slices specified by `indices` by
-    combining the gathered value from `source` with the value in `output`
-    using the computation specified in `region`. The `region` specifies a binary
-    operation of signature `(T, T) -> T`, where `T` is the element-type of
-    `source` & `output`. The first argument is from `source` and the second is
-    from `output`.
+    The operation returns the value at the slices specified by `indices`.
 
     The size of the `dimension_map` attribute is used to determine how many
     indices are used to index into `source`, i.e. `index_depth`. The
@@ -259,12 +254,11 @@ def IREELinalgExt_GatherOp : IREELinalgExt_Op<"gather",
       DenseI64ArrayAttr:$dimension_map
   );
   let results = (outs Variadic<AnyRankedTensor>:$results);
-  let regions = (region AnyRegion:$region);
   let assemblyFormat = [{
     attr-dict `dimension_map` `=` $dimension_map
     (`ins` `(` $inputs^ `:` type($inputs) `)`)?
     `outs` `(` $outputs `:` type($outputs) `)`
-    $region (`->` type($results)^)?
+    (`->` type($results)^)?
   }];
 
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -392,7 +392,6 @@ GatherOp::generateResultTileValue(OpBuilder &builder, unsigned resultNumber,
 LogicalResult GatherOp::generateScalarImplementation(OpBuilder &b, Location loc,
                                                      ValueRange ivs) {
   auto indexDepth = getIndexDepth();
-  Value result = b.create<memref::LoadOp>(loc, getOutput(), ivs);
   SmallVector<Value> loadIndices(ivs.take_front(getBatchRank()));
 
   // Populate with empty values.
@@ -423,19 +422,9 @@ LogicalResult GatherOp::generateScalarImplementation(OpBuilder &b, Location loc,
 
   Value init = b.create<memref::LoadOp>(loc, getSource(), starts);
 
-  IRMapping bvm;
-  Block &block = getRegion().front();
-  bvm.map(block.getArgument(0), init);
-  bvm.map(block.getArgument(1), result);
-  for (auto &blockOp : block.without_terminator()) {
-    b.clone(blockOp, bvm);
-  }
-
   // The last op is linalg_ext.yield op. Store the operand to
   // destination.
-  b.create<memref::StoreOp>(
-      loc, bvm.lookupOrDefault(block.getTerminator()->getOperand(0)),
-      getOutput(), ivs);
+  b.create<memref::StoreOp>(loc, init, getOutput(), ivs);
   return success();
 }
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -438,10 +438,7 @@ func.func @gather_output_too_large(
   %0 = iree_linalg_ext.gather
     dimension_map = [0]
     ins(%source, %idx : tensor<10xf32>, tensor<1xi32>)
-    outs(%output : tensor<2xf32>) {
-    ^bb0(%arg0: f32, %arg1: f32):
-      iree_linalg_ext.yield %arg0 : f32
-  } -> tensor<2xf32>
+    outs(%output : tensor<2xf32>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
 
@@ -454,10 +451,7 @@ func.func @gather_mismatch_output_and_source(
   %0 = iree_linalg_ext.gather
     dimension_map = [0]
     ins(%source, %idx : tensor<10x10xf32>, tensor<2xi32>)
-    outs(%output : tensor<1xf32>) {
-    ^bb0(%arg0: f32, %arg1: f32):
-      iree_linalg_ext.yield %arg0 : f32
-  } -> tensor<1xf32>
+    outs(%output : tensor<1xf32>) -> tensor<1xf32>
   return %0 : tensor<1xf32>
 }
 
@@ -470,10 +464,7 @@ func.func @gather_indices_batch_rank_too_large(
   %0 = iree_linalg_ext.gather
     dimension_map = [0]
     ins(%source, %idx : tensor<10x10xf32>, tensor<1x2xi32>)
-    outs(%output : tensor<10xf32>) {
-    ^bb0(%arg0: f32, %arg1: f32):
-      iree_linalg_ext.yield %arg0 : f32
-  } -> tensor<10xf32>
+    outs(%output : tensor<10xf32>) -> tensor<10xf32>
   return %0 : tensor<10xf32>
 }
 
@@ -486,10 +477,7 @@ func.func @gather_dim_map_mismatch(
   %0 = iree_linalg_ext.gather
     dimension_map = [0, 1]
     ins(%source, %idx : tensor<2xf32>, tensor<1xi32>)
-    outs(%output : tensor<1xf32>) {
-    ^bb0(%arg0: f32, %arg1: f32):
-      iree_linalg_ext.yield %arg0 : f32
-  } -> tensor<1xf32>
+    outs(%output : tensor<1xf32>) -> tensor<1xf32>
   return %0 : tensor<1xf32>
 }
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
@@ -598,10 +598,7 @@ func.func @gather_static(
   %0 = iree_linalg_ext.gather
     dimension_map = [0]
     ins(%source, %idx : tensor<10xf32>, tensor<1xi32>)
-    outs(%result : tensor<1xf32>) {
-    ^bb0(%arg0: f32, %arg1: f32):
-      iree_linalg_ext.yield %arg0 : f32
-  } -> tensor<1xf32>
+    outs(%result : tensor<1xf32>) -> tensor<1xf32>
   return %0 : tensor<1xf32>
 }
 // CHECK-LABEL: func.func @gather_static(
@@ -612,7 +609,6 @@ func.func @gather_static(
 // CHECK-SAME:     dimension_map = [0]
 // CHECK-SAME:     ins(%[[SOURCE]], %[[IDX]]
 // CHECK-SAME:     outs(%[[RESULT]]
-//      CHECK:   iree_linalg_ext.yield %{{.+}} : f32
 //      CHECK:   return %[[VAL]]
 
 // -----
@@ -623,10 +619,7 @@ func.func @gather_static_2D_batch(
   %0 = iree_linalg_ext.gather
     dimension_map = [0, 1]
     ins(%source, %idx : tensor<4x3xf32>, tensor<1x1xi32>)
-    outs(%result : tensor<1xf32>) {
-    ^bb0(%arg0: f32, %arg1: f32):
-      iree_linalg_ext.yield %arg0 : f32
-  } -> tensor<1xf32>
+    outs(%result : tensor<1xf32>) -> tensor<1xf32>
   return %0 : tensor<1xf32>
 }
 // CHECK-LABEL: func.func @gather_static_2D_batch(
@@ -637,7 +630,6 @@ func.func @gather_static_2D_batch(
 // CHECK-SAME:     dimension_map = [0, 1]
 // CHECK-SAME:     ins(%[[SOURCE]], %[[IDX]]
 // CHECK-SAME:     outs(%[[RESULT]]
-//      CHECK:   iree_linalg_ext.yield %{{.+}} : f32
 //      CHECK:   return %[[VAL]]
 
 // -----
@@ -648,10 +640,7 @@ func.func @gather_dynamic(
   %0 = iree_linalg_ext.gather
     dimension_map = [0, 1]
     ins(%source, %idx : tensor<?x?xf32>, tensor<?x1xi32>)
-    outs(%result : tensor<?xf32>) {
-    ^bb0(%arg0: f32, %arg1: f32):
-      iree_linalg_ext.yield %arg0 : f32
-  } -> tensor<?xf32>
+    outs(%result : tensor<?xf32>) -> tensor<?xf32>
   return %0 : tensor<?xf32>
 }
 // CHECK-LABEL: func.func @gather_dynamic(
@@ -662,7 +651,6 @@ func.func @gather_dynamic(
 // CHECK-SAME:     dimension_map = [0, 1]
 // CHECK-SAME:     ins(%[[SOURCE]], %[[IDX]]
 // CHECK-SAME:     outs(%[[RESULT]]
-//      CHECK:   iree_linalg_ext.yield %{{.+}} : f32
 //      CHECK:   return %[[VAL]]
 
 // -----
@@ -673,10 +661,7 @@ func.func @gather_static_memref(
   iree_linalg_ext.gather
     dimension_map = [0]
     ins(%source, %idx : memref<10xf32>, memref<1xi32>)
-    outs(%result : memref<1xf32>) {
-    ^bb0(%arg0: f32, %arg1: f32):
-      iree_linalg_ext.yield %arg0 : f32
-  }
+    outs(%result : memref<1xf32>)
   return
 }
 // CHECK-LABEL: func.func @gather_static_memref(
@@ -687,7 +672,6 @@ func.func @gather_static_memref(
 // CHECK-SAME:     dimension_map = [0]
 // CHECK-SAME:     ins(%[[SOURCE]], %[[IDX]]
 // CHECK-SAME:     outs(%[[RESULT]]
-//      CHECK:       iree_linalg_ext.yield %{{.+}} : f32
 //      CHECK:   return
 
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
@@ -1417,10 +1417,7 @@ func.func @gather_1d_indices(%arg0 : memref<10x10xi32>, %arg1 : memref<1xi32>, %
   iree_linalg_ext.gather
     dimension_map = [0]
     ins(%arg0, %arg1: memref<10x10xi32>, memref<1xi32>)
-    outs(%arg2: memref<1x10xi32>) {
-    ^bb0(%bb0: i32, %bb1: i32):
-      iree_linalg_ext.yield %bb0 : i32
-  }
+    outs(%arg2: memref<1x10xi32>)
   return
 }
 // CHECK-LABEL: func @gather_1d_indices
@@ -1442,10 +1439,7 @@ func.func @gather_2d_indices(%arg0 : memref<2x2xi32>, %arg1 : memref<2x2xi32>, %
   iree_linalg_ext.gather
     dimension_map = [0, 1]
     ins(%arg0, %arg1: memref<2x2xi32>, memref<2x2xi32>)
-    outs(%arg2: memref<2xi32>) {
-    ^bb0(%bb0: i32, %bb1: i32):
-      iree_linalg_ext.yield %bb0 : i32
-  }
+    outs(%arg2: memref<2xi32>)
   return
 }
 // CHECK-LABEL: func @gather_2d_indices
@@ -1469,10 +1463,7 @@ func.func @gather_perm_dim_map(%arg0 : memref<2x2xi32>, %arg1 : memref<2x2xi32>,
   iree_linalg_ext.gather
     dimension_map = [1, 0]
     ins(%arg0, %arg1: memref<2x2xi32>, memref<2x2xi32>)
-    outs(%arg2: memref<2xi32>) {
-    ^bb0(%bb0: i32, %bb1: i32):
-      iree_linalg_ext.yield %bb0 : i32
-  }
+    outs(%arg2: memref<2xi32>)
   return
 }
 // CHECK-LABEL: func @gather_perm_dim_map
@@ -1497,11 +1488,7 @@ func.func @gather_inline_region(%arg0 : memref<2x2xi32>, %arg1 : memref<2x2xi32>
   iree_linalg_ext.gather
     dimension_map = [0, 1]
     ins(%arg0, %arg1: memref<2x2xi32>, memref<2x2xi32>)
-    outs(%arg2: memref<2xi32>) {
-    ^bb0(%bb0: i32, %bb1: i32):
-      %0 = arith.muli %bb0, %cst : i32
-      iree_linalg_ext.yield %0 : i32
-  }
+    outs(%arg2: memref<2xi32>)
   return
 }
 // CHECK-LABEL: func @gather_inline_region
@@ -1510,7 +1497,6 @@ func.func @gather_inline_region(%arg0 : memref<2x2xi32>, %arg1 : memref<2x2xi32>
 // CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]
 // CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
 // CHECK-DAG:     %[[C2:.+]] = arith.constant 2 : index
-// CHECK-DAG:     %[[C3:.+]] = arith.constant 3 : i32
 // CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
 // CHECK:         scf.for %[[I:.+]] = %[[C0]] to %[[C2]] step %[[C1]] {
 // CHECK:           %[[IDX0:.+]] = memref.load %[[ARG1]][%[[I]], %[[C0]]] : memref<2x2xi32>
@@ -1518,8 +1504,7 @@ func.func @gather_inline_region(%arg0 : memref<2x2xi32>, %arg1 : memref<2x2xi32>
 // CHECK:           %[[IDX1:.+]] = memref.load %[[ARG1]][%[[I]], %[[C1]]] : memref<2x2xi32>
 // CHECK:           %[[CAST1:.+]] = arith.index_cast %[[IDX1]] : i32 to index
 // CHECK:           %[[LOAD0:.+]] = memref.load %[[ARG0]][%[[CAST0]], %[[CAST1]]] : memref<2x2xi32>
-// CHECK:           %[[MUL:.+]] = arith.muli %[[LOAD0]], %[[C3]] : i32
-// CHECK:           memref.store %[[MUL]], %[[ARG2]][%[[I]]] : memref<2xi32>
+// CHECK:           memref.store %[[LOAD0]], %[[ARG2]][%[[I]]] : memref<2xi32>
 
 // -----
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
@@ -2599,10 +2599,7 @@ func.func @gather_1d_indices(%arg0 : memref<?x?xi32>, %arg1 : memref<?xi32>, %ar
   iree_linalg_ext.gather
     dimension_map = [0]
     ins(%arg0, %arg1: memref<?x?xi32>, memref<?xi32>)
-    outs(%arg2: memref<?x?xi32>) {
-    ^bb0(%bb0: i32, %bb1: i32):
-      iree_linalg_ext.yield %bb0 : i32
-  }
+    outs(%arg2: memref<?x?xi32>)
   return
 }
 module attributes { transform.with_named_sequence } {
@@ -2642,10 +2639,7 @@ func.func @gather_2d_indices(%arg0 : memref<?x?xi32>, %arg1 : memref<?x2xi32>, %
   iree_linalg_ext.gather
     dimension_map = [0, 1]
     ins(%arg0, %arg1: memref<?x?xi32>, memref<?x2xi32>)
-    outs(%arg2: memref<?xi32>) {
-    ^bb0(%bb0: i32, %bb1: i32):
-      iree_linalg_ext.yield %bb0 : i32
-  }
+    outs(%arg2: memref<?xi32>)
   return
 }
 module attributes { transform.with_named_sequence } {

--- a/tests/e2e/linalg_ext_ops/gather.mlir
+++ b/tests/e2e/linalg_ext_ops/gather.mlir
@@ -4,10 +4,7 @@ func.func @gather_from_splat_tensor() {
   %indices = util.unfoldable_constant dense<0> : tensor<1xi32>
   %result = iree_linalg_ext.gather dimension_map = [0]
                           ins(%source, %indices : tensor<10x10xi32>, tensor<1xi32>)
-                          outs(%empty : tensor<1x10xi32>) {
-                    ^bb0(%arg0: i32, %arg1: i32):
-                      iree_linalg_ext.yield %arg0 : i32
-  } -> tensor<1x10xi32>
+                          outs(%empty : tensor<1x10xi32>) -> tensor<1x10xi32>
 
   check.expect_eq_const(%result, dense<0> : tensor<1x10xi32>)
             : tensor<1x10xi32>
@@ -20,10 +17,7 @@ func.func @gather_2d_index_with_batch() {
   %indices = util.unfoldable_constant dense<[[0, 1], [1, 0]]> : tensor<2x2xi32>
   %result = iree_linalg_ext.gather dimension_map = [0, 1]
                           ins(%source, %indices : tensor<2x2xi32>, tensor<2x2xi32>)
-                          outs(%empty: tensor<2xi32>) {
-                    ^bb0(%arg0: i32, %arg1: i32):
-                      iree_linalg_ext.yield %arg0 : i32
-  } -> tensor<2xi32>
+                          outs(%empty: tensor<2xi32>) -> tensor<2xi32>
   check.expect_eq_const(%result, dense<[1, 2]> : tensor<2xi32>) : tensor<2xi32>
   return
 }
@@ -34,10 +28,7 @@ func.func @gather_2d_index_no_batch() {
   %indices = util.unfoldable_constant dense<[0, 1]> : tensor<2xi32>
   %result = iree_linalg_ext.gather dimension_map = [0, 1]
                           ins(%source, %indices : tensor<2x2x1xi32>, tensor<2xi32>)
-                          outs(%empty: tensor<1xi32>) {
-                    ^bb0(%arg0: i32, %arg1: i32):
-                      iree_linalg_ext.yield %arg0 : i32
-  } -> tensor<1xi32>
+                          outs(%empty: tensor<1xi32>) -> tensor<1xi32>
   check.expect_eq_const(%result, dense<[1]> : tensor<1xi32>) : tensor<1xi32>
   return
 }
@@ -48,10 +39,7 @@ func.func @gather_1d_index_no_batch() {
   %indices = util.unfoldable_constant dense<[1]> : tensor<1xi32>
   %result = iree_linalg_ext.gather dimension_map = [0]
                           ins(%source, %indices : tensor<2x2xi32>, tensor<1xi32>)
-                          outs(%empty: tensor<2xi32>) {
-                    ^bb0(%arg0: i32, %arg1: i32):
-                      iree_linalg_ext.yield %arg0 : i32
-  } -> tensor<2xi32>
+                          outs(%empty: tensor<2xi32>) -> tensor<2xi32>
   check.expect_eq_const(%result, dense<[2, 3]> : tensor<2xi32>) : tensor<2xi32>
   return
 }
@@ -63,11 +51,7 @@ func.func @gather_muli_in_region() {
   %indices = util.unfoldable_constant dense<[1]> : tensor<1xi32>
   %result = iree_linalg_ext.gather dimension_map = [0]
                           ins(%source, %indices : tensor<2x2xi32>, tensor<1xi32>)
-                          outs(%empty: tensor<2xi32>) {
-                    ^bb0(%arg0: i32, %arg1: i32):
-                      %0 = arith.muli %arg0, %cst : i32
-                      iree_linalg_ext.yield %0 : i32
-  } -> tensor<2xi32>
+                          outs(%empty: tensor<2xi32>) -> tensor<2xi32>
   check.expect_eq_const(%result, dense<[4, 6]> : tensor<2xi32>) : tensor<2xi32>
   return
 }
@@ -78,10 +62,7 @@ func.func @gather_perm_map() {
   %indices = util.unfoldable_constant dense<[0, 1]> : tensor<2xi32>
   %result = iree_linalg_ext.gather dimension_map = [1, 0]
                           ins(%source, %indices : tensor<2x2x1xi32>, tensor<2xi32>)
-                          outs(%empty: tensor<1xi32>) {
-                    ^bb0(%arg0: i32, %arg1: i32):
-                      iree_linalg_ext.yield %arg0 : i32
-  } -> tensor<1xi32>
+                          outs(%empty: tensor<1xi32>) -> tensor<1xi32>
   check.expect_eq_const(%result, dense<[2]> : tensor<1xi32>) : tensor<1xi32>
   return
 }

--- a/tests/e2e/linalg_ext_ops/gather.mlir
+++ b/tests/e2e/linalg_ext_ops/gather.mlir
@@ -44,18 +44,6 @@ func.func @gather_1d_index_no_batch() {
   return
 }
 
-func.func @gather_muli_in_region() {
-  %cst = arith.constant 2 : i32
-  %source = util.unfoldable_constant dense<[[0, 1], [2, 3]]> : tensor<2x2xi32>
-  %empty = tensor.empty() : tensor<2xi32>
-  %indices = util.unfoldable_constant dense<[1]> : tensor<1xi32>
-  %result = iree_linalg_ext.gather dimension_map = [0]
-                          ins(%source, %indices : tensor<2x2xi32>, tensor<1xi32>)
-                          outs(%empty: tensor<2xi32>) -> tensor<2xi32>
-  check.expect_eq_const(%result, dense<[4, 6]> : tensor<2xi32>) : tensor<2xi32>
-  return
-}
-
 func.func @gather_perm_map() {
   %source = util.unfoldable_constant dense<[[[0], [1]], [[2], [3]]]> : tensor<2x2x1xi32>
   %empty = tensor.empty() : tensor<1xi32>


### PR DESCRIPTION
The region only makes sense for scatter to do updates. For gather, it doesn't make sense to try to update output values while loading. It should be done in a seperate linalg.generic operation.