### PR TITLE
[NFC][Codegen] Move EncodingNop LayoutAttrInterface to external model

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncoding.cpp
@@ -95,7 +95,8 @@ materializeFuncOpEncodings(FunctionOpInterface funcOp,
       }
       LDBG("Select EncodingNopLayoutAttr attribute as the layout "
            "attribute (Encoding resolver unknown or unsupported).");
-      return IREE::Codegen::EncodingNopLayoutAttr::get(ctx);
+      return cast<IREE::Codegen::LayoutAttrInterface>(
+          IREE::Codegen::EncodingNopLayoutAttr::get(ctx));
     };
 
     // The layoutAttr should come in without any target info attached to it,

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoNop.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoNop.cpp
@@ -43,9 +43,10 @@ struct MaterializeEncodingIntoNopPass final
     };
 
     RewritePatternSet materializeEncodingPattern(context);
-    MaterializeEncodingTypeConverter typeConverter(
-        IREE::Codegen::EncodingNopLayoutAttr::get(context),
-        materializeEncodingValueFn);
+    auto layoutAttr = cast<IREE::Codegen::LayoutAttrInterface>(
+        IREE::Codegen::EncodingNopLayoutAttr::get(context));
+    MaterializeEncodingTypeConverter typeConverter(layoutAttr,
+                                                   materializeEncodingValueFn);
     MaterializeEncodingConversionTarget target(*context);
     populateMaterializeEncodingPatterns(materializeEncodingPattern, target,
                                         typeConverter);

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.cpp
@@ -464,21 +464,6 @@ int64_t WorkgroupMappingAttr::getRelativeIndex() const {
 }
 
 //===---------------------------------------------------------------------===//
-// iree_codegen.encoding_nop_layout
-//===---------------------------------------------------------------------===//
-
-MaterializeEncodingInfo
-EncodingNopLayoutAttr::getEncodingInfo(RankedTensorType type) const {
-  return MaterializeEncodingInfo{};
-}
-
-Operation *EncodingNopLayoutAttr::lowerOp(OpBuilder &b, Operation *op,
-                                          TypeRange convertedResTypes,
-                                          ValueRange convertedOperands) const {
-  return clone(b, op, convertedResTypes, convertedOperands);
-}
-
-//===---------------------------------------------------------------------===//
 // iree_codegen.rotate_rows
 //===---------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.td
@@ -419,12 +419,7 @@ def IREECodegen_ExportConfig : AttrDef<IREECodegen_Dialect, "ExportConfig", []> 
 //===---------------------------------------------------------------------===//
 
 def IREECodegen_EncodingNopLayoutAttr  :
-    AttrDef<IREECodegen_Dialect, "EncodingNopLayout", [
-    DeclareAttrInterfaceMethods<IREECodegen_LayoutAttrInterface, [
-        "getEncodingInfo",
-        "lowerOp"
-      ]>
-    ]> {
+    AttrDef<IREECodegen_Dialect, "EncodingNopLayout"> {
   let mnemonic = "encoding_nop_layout";
   let summary = [{An attribute with implementation that treats encoding as nop.}];
   let description = [{

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CodegenExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CodegenExternalModels.cpp
@@ -15,6 +15,21 @@ namespace mlir::iree_compiler::IREE::Codegen {
 
 using IREE::TensorExt::DispatchTensorType;
 
+struct EncodingNopDeviceLayoutAttrInterface final
+    : IREE::Codegen::LayoutAttrInterface::ExternalModel<
+          EncodingNopDeviceLayoutAttrInterface, EncodingNopLayoutAttr> {
+  IREE::Codegen::MaterializeEncodingInfo
+  getEncodingInfo(Attribute attr, RankedTensorType type) const {
+    return IREE::Codegen::MaterializeEncodingInfo{};
+  }
+
+  Operation *lowerOp(Attribute attr, OpBuilder &b, Operation *op,
+                     TypeRange convertedResTypes,
+                     ValueRange convertedOperands) const {
+    return clone(b, op, convertedResTypes, convertedOperands);
+  }
+};
+
 struct EncodingNopHostEncodingLayoutResolverAttrInterface final
     : IREE::Encoding::EncodingLayoutResolverAttrInterface::ExternalModel<
           EncodingNopHostEncodingLayoutResolverAttrInterface,
@@ -58,7 +73,8 @@ void registerCodegenExternalModels(DialectRegistry &registry) {
       +[](MLIRContext *ctx, IREE::Codegen::IREECodegenDialect *dialect) {
         EncodingNopLayoutAttr::attachInterface<
             EncodingNopHostEncodingLayoutResolverAttrInterface,
-            EncodingNopHostSerializableEncodingAttrInterface>(*ctx);
+            EncodingNopHostSerializableEncodingAttrInterface,
+            EncodingNopDeviceLayoutAttrInterface>(*ctx);
       });
 }
 


### PR DESCRIPTION
This PR moves the `LayoutAttrInterface` implementation for `EncodingNopLayoutAttr` to the external model interfaces to facilitate moving `LayoutAttrInterface` itself from Codegen to Encoding, see https://github.com/iree-org/iree/issues/20160#issuecomment-2845435937