### PR TITLE
[LinalgExt] Restrict GatherOp to better preserve rank information

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -235,12 +235,7 @@ def IREELinalgExt_GatherOp : IREELinalgExt_Op<"gather",
   let summary = [{Gathers slices from a source based on a tensor of indices.}];
   let description = [{
     Takes two inputs (`source` and `indices`) and outputs value (`output`).
-    The operation returns the value at the slices specified by `indices` by
-    combining the gathered value from `source` with the value in `output`
-    using the computation specified in `region`. The `region` specifies a binary
-    operation of signature `(T, T) -> T`, where `T` is the element-type of
-    `source` & `output`. The first argument is from `source` and the second is
-    from `output`.
+    The operation returns the value at the slices specified by `indices`.
 
     The size of the `dimension_map` attribute is used to determine how many
     indices are used to index into `source`, i.e. `index_depth`. The
@@ -259,12 +254,11 @@ def IREELinalgExt_GatherOp : IREELinalgExt_Op<"gather",
       DenseI64ArrayAttr:$dimension_map
   );
   let results = (outs Variadic<AnyRankedTensor>:$results);
-  let regions = (region AnyRegion:$region);
   let assemblyFormat = [{
     attr-dict `dimension_map` `=` $dimension_map
     (`ins` `(` $inputs^ `:` type($inputs) `)`)?
     `outs` `(` $outputs `:` type($outputs) `)`
-    $region (`->` type($results)^)?
+    (`->` type($results)^)?
   }];
 
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -234,19 +234,15 @@ def IREELinalgExt_GatherOp : IREELinalgExt_Op<"gather",
          "generateResultTileValue"]>]> {
   let summary = [{Gathers slices from a source based on a tensor of indices.}];
   let description = [{
-    Takes two inputs (`source` and `indices`) and outputs value (`output`).
-    The operation returns the value at the slices specified by `indices`.
+    Takes two inputs (`source` and `indices`) and outputs value (`output`). The
+    operation returns a gather along outer dimensions of `source` as specified
+    by `indices`, gathering contigious inner slices.
 
-    The size of the `dimension_map` attribute is used to determine how many
-    indices are used to index into `source`, i.e. `index_depth`. The
-    `dimension_map` attribute describes which index value maps to which dimension
-    in the destination.
-
-    This operation preforms the opposite operation of `iree_linalg_ext.scatter`.
-    Instead of scattering `updates` into `original`, it gathers the values from
-    `source` into `output` using the indices in `indices`. See the documentation
-    on `iree_linalg_ext.scatter` for more details regarding the indexing/shape
-    semantics.
+    The `output` and `source` are N-D shaped tensor/memrefs. `indices` is a
+    K+1 -D shaped tensor/memref. The `dimension_map` is a minor identity of
+    size `K` describing which outer dimensions of `source` are gathered. The
+    last dimension of `indices` is always of size `K`, specifying a list of
+    indices to index the outer dimensions using.
   }];
   let arguments = (ins
       Variadic<AnyRankedTensorOrMemRefType>:$inputs,

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/TilingInterfaceImpl.cpp
@@ -392,7 +392,6 @@ GatherOp::generateResultTileValue(OpBuilder &builder, unsigned resultNumber,
 LogicalResult GatherOp::generateScalarImplementation(OpBuilder &b, Location loc,
                                                      ValueRange ivs) {
   auto indexDepth = getIndexDepth();
-  Value result = b.create<memref::LoadOp>(loc, getOutput(), ivs);
   SmallVector<Value> loadIndices(ivs.take_front(getBatchRank()));
 
   // Populate with empty values.
@@ -423,19 +422,9 @@ LogicalResult GatherOp::generateScalarImplementation(OpBuilder &b, Location loc,
 
   Value init = b.create<memref::LoadOp>(loc, getSource(), starts);
 
-  IRMapping bvm;
-  Block &block = getRegion().front();
-  bvm.map(block.getArgument(0), init);
-  bvm.map(block.getArgument(1), result);
-  for (auto &blockOp : block.without_terminator()) {
-    b.clone(blockOp, bvm);
-  }
-
   // The last op is linalg_ext.yield op. Store the operand to
   // destination.
-  b.create<memref::StoreOp>(
-      loc, bvm.lookupOrDefault(block.getTerminator()->getOperand(0)),
-      getOutput(), ivs);
+  b.create<memref::StoreOp>(loc, init, getOutput(), ivs);
   return success();
 }
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/invalid.mlir
@@ -438,10 +438,7 @@ func.func @gather_output_too_large(
   %0 = iree_linalg_ext.gather
     dimension_map = [0]
     ins(%source, %idx : tensor<10xf32>, tensor<1xi32>)
-    outs(%output : tensor<2xf32>) {
-    ^bb0(%arg0: f32, %arg1: f32):
-      iree_linalg_ext.yield %arg0 : f32
-  } -> tensor<2xf32>
+    outs(%output : tensor<2xf32>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }
 
@@ -454,10 +451,7 @@ func.func @gather_mismatch_output_and_source(
   %0 = iree_linalg_ext.gather
     dimension_map = [0]
     ins(%source, %idx : tensor<10x10xf32>, tensor<2xi32>)
-    outs(%output : tensor<1xf32>) {
-    ^bb0(%arg0: f32, %arg1: f32):
-      iree_linalg_ext.yield %arg0 : f32
-  } -> tensor<1xf32>
+    outs(%output : tensor<1xf32>) -> tensor<1xf32>
   return %0 : tensor<1xf32>
 }
 
@@ -470,10 +464,7 @@ func.func @gather_indices_batch_rank_too_large(
   %0 = iree_linalg_ext.gather
     dimension_map = [0]
     ins(%source, %idx : tensor<10x10xf32>, tensor<1x2xi32>)
-    outs(%output : tensor<10xf32>) {
-    ^bb0(%arg0: f32, %arg1: f32):
-      iree_linalg_ext.yield %arg0 : f32
-  } -> tensor<10xf32>
+    outs(%output : tensor<10xf32>) -> tensor<10xf32>
   return %0 : tensor<10xf32>
 }
 
@@ -486,10 +477,7 @@ func.func @gather_dim_map_mismatch(
   %0 = iree_linalg_ext.gather
     dimension_map = [0, 1]
     ins(%source, %idx : tensor<2xf32>, tensor<1xi32>)
-    outs(%output : tensor<1xf32>) {
-    ^bb0(%arg0: f32, %arg1: f32):
-      iree_linalg_ext.yield %arg0 : f32
-  } -> tensor<1xf32>
+    outs(%output : tensor<1xf32>) -> tensor<1xf32>
   return %0 : tensor<1xf32>
 }
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
@@ -598,10 +598,7 @@ func.func @gather_static(
   %0 = iree_linalg_ext.gather
     dimension_map = [0]
     ins(%source, %idx : tensor<10xf32>, tensor<1xi32>)
-    outs(%result : tensor<1xf32>) {
-    ^bb0(%arg0: f32, %arg1: f32):
-      iree_linalg_ext.yield %arg0 : f32
-  } -> tensor<1xf32>
+    outs(%result : tensor<1xf32>) -> tensor<1xf32>
   return %0 : tensor<1xf32>
 }
 // CHECK-LABEL: func.func @gather_static(
@@ -612,7 +609,6 @@ func.func @gather_static(
 // CHECK-SAME:     dimension_map = [0]
 // CHECK-SAME:     ins(%[[SOURCE]], %[[IDX]]
 // CHECK-SAME:     outs(%[[RESULT]]
-//      CHECK:   iree_linalg_ext.yield %{{.+}} : f32
 //      CHECK:   return %[[VAL]]
 
 // -----
@@ -623,10 +619,7 @@ func.func @gather_static_2D_batch(
   %0 = iree_linalg_ext.gather
     dimension_map = [0, 1]
     ins(%source, %idx : tensor<4x3xf32>, tensor<1x1xi32>)
-    outs(%result : tensor<1xf32>) {
-    ^bb0(%arg0: f32, %arg1: f32):
-      iree_linalg_ext.yield %arg0 : f32
-  } -> tensor<1xf32>
+    outs(%result : tensor<1xf32>) -> tensor<1xf32>
   return %0 : tensor<1xf32>
 }
 // CHECK-LABEL: func.func @gather_static_2D_batch(
@@ -637,7 +630,6 @@ func.func @gather_static_2D_batch(
 // CHECK-SAME:     dimension_map = [0, 1]
 // CHECK-SAME:     ins(%[[SOURCE]], %[[IDX]]
 // CHECK-SAME:     outs(%[[RESULT]]
-//      CHECK:   iree_linalg_ext.yield %{{.+}} : f32
 //      CHECK:   return %[[VAL]]
 
 // -----
@@ -648,10 +640,7 @@ func.func @gather_dynamic(
   %0 = iree_linalg_ext.gather
     dimension_map = [0, 1]
     ins(%source, %idx : tensor<?x?xf32>, tensor<?x1xi32>)
-    outs(%result : tensor<?xf32>) {
-    ^bb0(%arg0: f32, %arg1: f32):
-      iree_linalg_ext.yield %arg0 : f32
-  } -> tensor<?xf32>
+    outs(%result : tensor<?xf32>) -> tensor<?xf32>
   return %0 : tensor<?xf32>
 }
 // CHECK-LABEL: func.func @gather_dynamic(
@@ -662,7 +651,6 @@ func.func @gather_dynamic(
 // CHECK-SAME:     dimension_map = [0, 1]
 // CHECK-SAME:     ins(%[[SOURCE]], %[[IDX]]
 // CHECK-SAME:     outs(%[[RESULT]]
-//      CHECK:   iree_linalg_ext.yield %{{.+}} : f32
 //      CHECK:   return %[[VAL]]
 
 // -----
@@ -673,10 +661,7 @@ func.func @gather_static_memref(
   iree_linalg_ext.gather
     dimension_map = [0]
     ins(%source, %idx : memref<10xf32>, memref<1xi32>)
-    outs(%result : memref<1xf32>) {
-    ^bb0(%arg0: f32, %arg1: f32):
-      iree_linalg_ext.yield %arg0 : f32
-  }
+    outs(%result : memref<1xf32>)
   return
 }
 // CHECK-LABEL: func.func @gather_static_memref(
@@ -687,7 +672,6 @@ func.func @gather_static_memref(
 // CHECK-SAME:     dimension_map = [0]
 // CHECK-SAME:     ins(%[[SOURCE]], %[[IDX]]
 // CHECK-SAME:     outs(%[[RESULT]]
-//      CHECK:       iree_linalg_ext.yield %{{.+}} : f32
 //      CHECK:   return
 
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/roundtrip.mlir
@@ -593,11 +593,11 @@ func.func @scatter_update_slice_2D(
 // -----
 
 func.func @gather_static(
-    %source : tensor<10xf32>, %idx : tensor<1xi32>,
+    %source : tensor<10xf32>, %idx : tensor<1x1xi32>,
     %result : tensor<1xf32>) -> tensor<1xf32> {
   %0 = iree_linalg_ext.gather
     dimension_map = [0]
-    ins(%source, %idx : tensor<10xf32>, tensor<1xi32>)
+    ins(%source, %idx : tensor<10xf32>, tensor<1x1xi32>)
     outs(%result : tensor<1xf32>) -> tensor<1xf32>
   return %0 : tensor<1xf32>
 }
@@ -614,13 +614,13 @@ func.func @gather_static(
 // -----
 
 func.func @gather_static_2D_batch(
-    %source : tensor<4x3xf32>, %idx : tensor<1x1xi32>,
-    %result : tensor<1xf32>) -> tensor<1xf32> {
+    %source : tensor<4x3xf32>, %idx : tensor<1x1x2xi32>,
+    %result : tensor<1x1xf32>) -> tensor<1x1xf32> {
   %0 = iree_linalg_ext.gather
     dimension_map = [0, 1]
-    ins(%source, %idx : tensor<4x3xf32>, tensor<1x1xi32>)
-    outs(%result : tensor<1xf32>) -> tensor<1xf32>
-  return %0 : tensor<1xf32>
+    ins(%source, %idx : tensor<4x3xf32>, tensor<1x1x2xi32>)
+    outs(%result : tensor<1x1xf32>) -> tensor<1x1xf32>
+  return %0 : tensor<1x1xf32>
 }
 // CHECK-LABEL: func.func @gather_static_2D_batch(
 // CHECK-SAME:   %[[SOURCE:[a-zA-Z0-9_]+]]
@@ -635,13 +635,13 @@ func.func @gather_static_2D_batch(
 // -----
 
 func.func @gather_dynamic(
-    %source : tensor<?x?xf32>, %idx : tensor<?x1xi32>,
-    %result : tensor<?xf32>) -> tensor<?xf32> {
+    %source : tensor<?x?xf32>, %idx : tensor<?x?x2xi32>,
+    %result : tensor<?x?xf32>) -> tensor<?x?xf32> {
   %0 = iree_linalg_ext.gather
     dimension_map = [0, 1]
-    ins(%source, %idx : tensor<?x?xf32>, tensor<?x1xi32>)
-    outs(%result : tensor<?xf32>) -> tensor<?xf32>
-  return %0 : tensor<?xf32>
+    ins(%source, %idx : tensor<?x?xf32>, tensor<?x?x2xi32>)
+    outs(%result : tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
 }
 // CHECK-LABEL: func.func @gather_dynamic(
 // CHECK-SAME:   %[[SOURCE:[a-zA-Z0-9_]+]]
@@ -656,11 +656,11 @@ func.func @gather_dynamic(
 // -----
 
 func.func @gather_static_memref(
-    %source : memref<10xf32>, %idx : memref<1xi32>,
+    %source : memref<10xf32>, %idx : memref<1x1xi32>,
     %result : memref<1xf32>) {
   iree_linalg_ext.gather
     dimension_map = [0]
-    ins(%source, %idx : memref<10xf32>, memref<1xi32>)
+    ins(%source, %idx : memref<10xf32>, memref<1x1xi32>)
     outs(%result : memref<1xf32>)
   return
 }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
@@ -1417,10 +1417,7 @@ func.func @gather_1d_indices(%arg0 : memref<10x10xi32>, %arg1 : memref<1xi32>, %
   iree_linalg_ext.gather
     dimension_map = [0]
     ins(%arg0, %arg1: memref<10x10xi32>, memref<1xi32>)
-    outs(%arg2: memref<1x10xi32>) {
-    ^bb0(%bb0: i32, %bb1: i32):
-      iree_linalg_ext.yield %bb0 : i32
-  }
+    outs(%arg2: memref<1x10xi32>)
   return
 }
 // CHECK-LABEL: func @gather_1d_indices
@@ -1442,10 +1439,7 @@ func.func @gather_2d_indices(%arg0 : memref<2x2xi32>, %arg1 : memref<2x2xi32>, %
   iree_linalg_ext.gather
     dimension_map = [0, 1]
     ins(%arg0, %arg1: memref<2x2xi32>, memref<2x2xi32>)
-    outs(%arg2: memref<2xi32>) {
-    ^bb0(%bb0: i32, %bb1: i32):
-      iree_linalg_ext.yield %bb0 : i32
-  }
+    outs(%arg2: memref<2xi32>)
   return
 }
 // CHECK-LABEL: func @gather_2d_indices
@@ -1469,10 +1463,7 @@ func.func @gather_perm_dim_map(%arg0 : memref<2x2xi32>, %arg1 : memref<2x2xi32>,
   iree_linalg_ext.gather
     dimension_map = [1, 0]
     ins(%arg0, %arg1: memref<2x2xi32>, memref<2x2xi32>)
-    outs(%arg2: memref<2xi32>) {
-    ^bb0(%bb0: i32, %bb1: i32):
-      iree_linalg_ext.yield %bb0 : i32
-  }
+    outs(%arg2: memref<2xi32>)
   return
 }
 // CHECK-LABEL: func @gather_perm_dim_map
@@ -1497,11 +1488,7 @@ func.func @gather_inline_region(%arg0 : memref<2x2xi32>, %arg1 : memref<2x2xi32>
   iree_linalg_ext.gather
     dimension_map = [0, 1]
     ins(%arg0, %arg1: memref<2x2xi32>, memref<2x2xi32>)
-    outs(%arg2: memref<2xi32>) {
-    ^bb0(%bb0: i32, %bb1: i32):
-      %0 = arith.muli %bb0, %cst : i32
-      iree_linalg_ext.yield %0 : i32
-  }
+    outs(%arg2: memref<2xi32>)
   return
 }
 // CHECK-LABEL: func @gather_inline_region
@@ -1510,7 +1497,6 @@ func.func @gather_inline_region(%arg0 : memref<2x2xi32>, %arg1 : memref<2x2xi32>
 // CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]
 // CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
 // CHECK-DAG:     %[[C2:.+]] = arith.constant 2 : index
-// CHECK-DAG:     %[[C3:.+]] = arith.constant 3 : i32
 // CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
 // CHECK:         scf.for %[[I:.+]] = %[[C0]] to %[[C2]] step %[[C1]] {
 // CHECK:           %[[IDX0:.+]] = memref.load %[[ARG1]][%[[I]], %[[C0]]] : memref<2x2xi32>
@@ -1518,8 +1504,7 @@ func.func @gather_inline_region(%arg0 : memref<2x2xi32>, %arg1 : memref<2x2xi32>
 // CHECK:           %[[IDX1:.+]] = memref.load %[[ARG1]][%[[I]], %[[C1]]] : memref<2x2xi32>
 // CHECK:           %[[CAST1:.+]] = arith.index_cast %[[IDX1]] : i32 to index
 // CHECK:           %[[LOAD0:.+]] = memref.load %[[ARG0]][%[[CAST0]], %[[CAST1]]] : memref<2x2xi32>
-// CHECK:           %[[MUL:.+]] = arith.muli %[[LOAD0]], %[[C3]] : i32
-// CHECK:           memref.store %[[MUL]], %[[ARG2]][%[[I]]] : memref<2xi32>
+// CHECK:           memref.store %[[LOAD0]], %[[ARG2]][%[[I]]] : memref<2xi32>
 
 // -----
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/convert_to_loops.mlir
@@ -1413,10 +1413,10 @@ func.func @unpack(%arg0: memref<1x4x6x6x2xf32>, %arg1: memref<1x6x6x8xf32>) {
 
 // -----
 
-func.func @gather_1d_indices(%arg0 : memref<10x10xi32>, %arg1 : memref<1xi32>, %arg2 : memref<1x10xi32>) {
+func.func @gather_1d_indices(%arg0 : memref<10x10xi32>, %arg1 : memref<1x1xi32>, %arg2 : memref<1x10xi32>) {
   iree_linalg_ext.gather
     dimension_map = [0]
-    ins(%arg0, %arg1: memref<10x10xi32>, memref<1xi32>)
+    ins(%arg0, %arg1: memref<10x10xi32>, memref<1x1xi32>)
     outs(%arg2: memref<1x10xi32>)
   return
 }
@@ -1429,17 +1429,17 @@ func.func @gather_1d_indices(%arg0 : memref<10x10xi32>, %arg1 : memref<1xi32>, %
 // CHECK-DAG:     %[[C10:.+]] = arith.constant 10 : index
 // CHECK:         scf.for %[[I:.+]] = %[[C0]] to %[[C1]] step %[[C1]] {
 // CHECK:           scf.for %[[J:.+]] = %[[C0]] to %[[C10]] step %[[C1]] {
-// CHECK:             %[[IDX:.+]] = memref.load %[[ARG1]][%[[I]]] : memref<1xi32>
+// CHECK:             %[[IDX:.+]] = memref.load %[[ARG1]][%[[I]], %[[C0]]] : memref<1x1xi32>
 // CHECK:             %[[CAST:.+]] = arith.index_cast %[[IDX]] : i32 to index
 // CHECK:             %[[LOAD:.+]] = memref.load %[[ARG0]][%[[CAST]], %[[J]]] : memref<10x10xi32>
 
 // -----
 
-func.func @gather_2d_indices(%arg0 : memref<2x2xi32>, %arg1 : memref<2x2xi32>, %arg2 : memref<2xi32>) {
+func.func @gather_2d_indices(%arg0 : memref<2x2xi32>, %arg1 : memref<1x2x2xi32>, %arg2 : memref<1x2xi32>) {
   iree_linalg_ext.gather
     dimension_map = [0, 1]
-    ins(%arg0, %arg1: memref<2x2xi32>, memref<2x2xi32>)
-    outs(%arg2: memref<2xi32>)
+    ins(%arg0, %arg1: memref<2x2xi32>, memref<1x2x2xi32>)
+    outs(%arg2: memref<1x2xi32>)
   return
 }
 // CHECK-LABEL: func @gather_2d_indices
@@ -1449,62 +1449,14 @@ func.func @gather_2d_indices(%arg0 : memref<2x2xi32>, %arg1 : memref<2x2xi32>, %
 // CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
 // CHECK-DAG:     %[[C2:.+]] = arith.constant 2 : index
 // CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
-// CHECK:         scf.for %[[I:.+]] = %[[C0]] to %[[C2]] step %[[C1]] {
-// CHECK:           %[[IDX0:.+]] = memref.load %[[ARG1]][%[[I]], %[[C0]]] : memref<2x2xi32>
-// CHECK:           %[[CAST0:.+]] = arith.index_cast %[[IDX0]] : i32 to index
-// CHECK:           %[[IDX1:.+]] = memref.load %[[ARG1]][%[[I]], %[[C1]]] : memref<2x2xi32>
-// CHECK:           %[[CAST1:.+]] = arith.index_cast %[[IDX1]] : i32 to index
-// CHECK:           %[[LOAD0:.+]] = memref.load %[[ARG0]][%[[CAST0]], %[[CAST1]]] : memref<2x2xi32>
-// CHECK:           memref.store %[[LOAD0]], %[[ARG2]][%[[I]]] : memref<2xi32>
-
-// -----
-
-func.func @gather_perm_dim_map(%arg0 : memref<2x2xi32>, %arg1 : memref<2x2xi32>, %arg2 : memref<2xi32>) {
-  iree_linalg_ext.gather
-    dimension_map = [1, 0]
-    ins(%arg0, %arg1: memref<2x2xi32>, memref<2x2xi32>)
-    outs(%arg2: memref<2xi32>)
-  return
-}
-// CHECK-LABEL: func @gather_perm_dim_map
-// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
-// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
-// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]
-// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
-// CHECK-DAG:     %[[C2:.+]] = arith.constant 2 : index
-// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
-// CHECK:         scf.for %[[I:.+]] = %[[C0]] to %[[C2]] step %[[C1]] {
-// CHECK:           %[[IDX0:.+]] = memref.load %[[ARG1]][%[[I]], %[[C0]]] : memref<2x2xi32>
-// CHECK:           %[[CAST0:.+]] = arith.index_cast %[[IDX0]] : i32 to index
-// CHECK:           %[[IDX1:.+]] = memref.load %[[ARG1]][%[[I]], %[[C1]]] : memref<2x2xi32>
-// CHECK:           %[[CAST1:.+]] = arith.index_cast %[[IDX1]] : i32 to index
-// CHECK:           %[[LOAD0:.+]] = memref.load %[[ARG0]][%[[CAST1]], %[[CAST0]]] : memref<2x2xi32>
-// CHECK:           memref.store %[[LOAD0]], %[[ARG2]][%[[I]]] : memref<2xi32>
-
-// -----
-
-func.func @gather_inline_region(%arg0 : memref<2x2xi32>, %arg1 : memref<2x2xi32>, %arg2 : memref<2xi32>) {
-  %cst = arith.constant 3 : i32
-  iree_linalg_ext.gather
-    dimension_map = [0, 1]
-    ins(%arg0, %arg1: memref<2x2xi32>, memref<2x2xi32>)
-    outs(%arg2: memref<2xi32>)
-  return
-}
-// CHECK-LABEL: func @gather_inline_region
-// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
-// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
-// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]
-// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
-// CHECK-DAG:     %[[C2:.+]] = arith.constant 2 : index
-// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
-// CHECK:         scf.for %[[I:.+]] = %[[C0]] to %[[C2]] step %[[C1]] {
-// CHECK:           %[[IDX0:.+]] = memref.load %[[ARG1]][%[[I]], %[[C0]]] : memref<2x2xi32>
-// CHECK:           %[[CAST0:.+]] = arith.index_cast %[[IDX0]] : i32 to index
-// CHECK:           %[[IDX1:.+]] = memref.load %[[ARG1]][%[[I]], %[[C1]]] : memref<2x2xi32>
-// CHECK:           %[[CAST1:.+]] = arith.index_cast %[[IDX1]] : i32 to index
-// CHECK:           %[[LOAD0:.+]] = memref.load %[[ARG0]][%[[CAST0]], %[[CAST1]]] : memref<2x2xi32>
-// CHECK:           memref.store %[[LOAD0]], %[[ARG2]][%[[I]]] : memref<2xi32>
+// CHECK:         scf.for %[[I:.+]] = %[[C0]] to %[[C1]] step %[[C1]] {
+// CHECK:           scf.for %[[I2:.+]] = %[[C0]] to %[[C2]] step %[[C1]] {
+// CHECK:             %[[IDX0:.+]] = memref.load %[[ARG1]][%[[I]], %[[I2]], %[[C0]]] : memref<1x2x2xi32>
+// CHECK:             %[[CAST0:.+]] = arith.index_cast %[[IDX0]] : i32 to index
+// CHECK:             %[[IDX1:.+]] = memref.load %[[ARG1]][%[[I]], %[[I2]], %[[C1]]] : memref<1x2x2xi32>
+// CHECK:             %[[CAST1:.+]] = arith.index_cast %[[IDX1]] : i32 to index
+// CHECK:             %[[LOAD0:.+]] = memref.load %[[ARG0]][%[[CAST0]], %[[CAST1]]] : memref<2x2xi32>
+// CHECK:             memref.store %[[LOAD0]], %[[ARG2]][%[[I]], %[[I2]]] : memref<1x2xi32>
 
 // -----
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
@@ -2599,10 +2599,7 @@ func.func @gather_1d_indices(%arg0 : memref<?x?xi32>, %arg1 : memref<?xi32>, %ar
   iree_linalg_ext.gather
     dimension_map = [0]
     ins(%arg0, %arg1: memref<?x?xi32>, memref<?xi32>)
-    outs(%arg2: memref<?x?xi32>) {
-    ^bb0(%bb0: i32, %bb1: i32):
-      iree_linalg_ext.yield %bb0 : i32
-  }
+    outs(%arg2: memref<?x?xi32>)
   return
 }
 module attributes { transform.with_named_sequence } {
@@ -2642,10 +2639,7 @@ func.func @gather_2d_indices(%arg0 : memref<?x?xi32>, %arg1 : memref<?x2xi32>, %
   iree_linalg_ext.gather
     dimension_map = [0, 1]
     ins(%arg0, %arg1: memref<?x?xi32>, memref<?x2xi32>)
-    outs(%arg2: memref<?xi32>) {
-    ^bb0(%bb0: i32, %bb1: i32):
-      iree_linalg_ext.yield %bb0 : i32
-  }
+    outs(%arg2: memref<?xi32>)
   return
 }
 module attributes { transform.with_named_sequence } {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/tiling.mlir
@@ -2595,10 +2595,10 @@ module attributes { transform.with_named_sequence } {
 
 // -----
 
-func.func @gather_1d_indices(%arg0 : memref<?x?xi32>, %arg1 : memref<?xi32>, %arg2 : memref<?x?xi32>) {
+func.func @gather_1d_indices(%arg0 : memref<?x?xi32>, %arg1 : memref<?x1xi32>, %arg2 : memref<?x?xi32>) {
   iree_linalg_ext.gather
     dimension_map = [0]
-    ins(%arg0, %arg1: memref<?x?xi32>, memref<?xi32>)
+    ins(%arg0, %arg1: memref<?x?xi32>, memref<?x1xi32>)
     outs(%arg2: memref<?x?xi32>)
   return
 }
@@ -2626,7 +2626,7 @@ module attributes { transform.with_named_sequence } {
 //  CHECK-DAG:       %[[MIN0:.+]] = affine.min #[[MAP0]](%[[I]])[%[[D0]]]
 //  CHECK-DAG:       %[[MIN1:.+]] = affine.min #[[MAP1]](%[[J]])[%[[D1]]]
 //  CHECK-DAG:       %[[RESULT:.+]] = memref.subview %[[ARG2]][%[[I]], %[[J]]] [%[[MIN0]], %[[MIN1]]] [1, 1]
-//  CHECK-DAG:       %[[INDEX:.+]] = memref.subview %[[ARG1]][%[[I]]] [%[[MIN0]]] [1]
+//  CHECK-DAG:       %[[INDEX:.+]] = memref.subview %[[ARG1]][%[[I]], 0] [%[[MIN0]], 1] [1, 1]
 //  CHECK-DAG:       %[[D2:.+]] = memref.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:       %[[SOURCE:.+]] = memref.subview %[[ARG0]][0, %[[J]]] [%[[D2]], %[[MIN1]]] [1, 1]
 //      CHECK:       iree_linalg_ext.gather
@@ -2635,11 +2635,11 @@ module attributes { transform.with_named_sequence } {
 
 // -----
 
-func.func @gather_2d_indices(%arg0 : memref<?x?xi32>, %arg1 : memref<?x2xi32>, %arg2 : memref<?xi32>) {
+func.func @gather_2d_indices(%arg0 : memref<?x?xi32>, %arg1 : memref<?x?x2xi32>, %arg2 : memref<?x?xi32>) {
   iree_linalg_ext.gather
     dimension_map = [0, 1]
-    ins(%arg0, %arg1: memref<?x?xi32>, memref<?x2xi32>)
-    outs(%arg2: memref<?xi32>)
+    ins(%arg0, %arg1: memref<?x?xi32>, memref<?x?x2xi32>)
+    outs(%arg2: memref<?x?xi32>)
   return
 }
 module attributes { transform.with_named_sequence } {
@@ -2658,10 +2658,11 @@ module attributes { transform.with_named_sequence } {
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //  CHECK-DAG:   %[[D0:.+]] = memref.dim %[[ARG2]], %[[C0]]
+//  CHECK-DAG:   %[[D1:.+]] = memref.dim %[[ARG2]], %[[C1]]
 //      CHECK:   scf.for %[[I:.+]] = %[[C0]] to %[[D0]] step %[[C13]]
 //  CHECK-DAG:     %[[MIN:.+]] = affine.min #[[MAP0]](%[[I]])[%[[D0]]]
-//  CHECK-DAG:     %[[RESULT:.+]] = memref.subview %[[ARG2]][%[[I]]] [%[[MIN]]] [1]
-//  CHECK-DAG:     %[[INDEX:.+]] = memref.subview %[[ARG1]][%[[I]], 0] [%[[MIN]], 2] [1, 1]
+//  CHECK-DAG:     %[[RESULT:.+]] = memref.subview %[[ARG2]][%[[I]], 0] [%[[MIN]], %[[D1]]] [1, 1]
+//  CHECK-DAG:     %[[INDEX:.+]] = memref.subview %[[ARG1]][%[[I]], 0, 0] [%[[MIN]], %[[D1]], 2] [1, 1, 1]
 //  CHECK-DAG:     %[[D1:.+]] = memref.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:     %[[D2:.+]] = memref.dim %[[ARG0]], %[[C1]]
 //  CHECK-DAG:     %[[SOURCE:.+]] = memref.subview %[[ARG0]][0, 0] [%[[D1]], %[[D2]]] [1, 1]


### PR DESCRIPTION
This PR restricts the GatherOp definition. This disallows:

- Reshapes on the gathered dimensions based on the indices vector. The rank of the source, output must be same now. Any reshapes should be done using expand_shape/collapse_shape and should not be part of the op definition.
- dimension_map doesn't allow permutation. If we want transposes, we should move to a more standard indexing_maps definition, creating a mapping between source, indices and output on the gathered dimensions.

Note that no other implementations need to be changed right now because we are only restricting the input space of the operation.