### PR TITLE
[Codegen][LLVMGPU] Optionally linearize the number of workgroups specified

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -265,6 +265,20 @@ def ReconcileTranslationInfoPass
       "Reconcile information (like workgroup_size, subgroup_size) across "
       "`TranslationInfo` set on each function in the dispatch and merge them"
       "and set them at the appropriate places in the surrounding HAL ops";
+  let options = [
+    Option<"distributeAlong", "distribute-along",
+           "::mlir::iree_compiler::IREE::Codegen::WorkgroupId",
+           /*default=*/"IREE::Codegen::WorkgroupId::IdZ",
+           "Constrain the workgroup distribution along grid dimensions.",
+           [{
+           ::llvm::cl::values(
+            clEnumValN(IREE::Codegen::WorkgroupId::IdX, "x",
+              "Constrain the workgroup distribution to use only workgroups along x."),
+            clEnumValN(IREE::Codegen::WorkgroupId::IdY, "y",
+              "Constrain the workgroup distribution to use only workgroups along x and y."),
+            clEnumValN(IREE::Codegen::WorkgroupId::IdZ, "z",
+              "Constrain the workgroup distribution to use only workgroups along x, y and z."))}]>
+  ];
 }
 
 def ReplaceSlowMinMaxOpsPass

--- a/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
@@ -31,6 +31,7 @@ class ReconcileTranslationInfoPass final
     : public impl::ReconcileTranslationInfoPassBase<
           ReconcileTranslationInfoPass> {
 public:
+  using Base::Base;
   void runOnOperation() override;
 };
 } // namespace
@@ -77,7 +78,8 @@ getProcIdsAndNprocs(
     scf::ForallOp forallOp, RewriterBase &builder, Location loc,
     SmallVector<IREE::Codegen::WorkgroupMappingAttr> workgroupMappings,
     SmallVector<OpFoldResult> lowerBounds,
-    SmallVector<OpFoldResult> upperBounds, SmallVector<OpFoldResult> steps) {
+    SmallVector<OpFoldResult> upperBounds, SmallVector<OpFoldResult> steps,
+    IREE::Codegen::WorkgroupId deLinearizeFrom) {
   if (workgroupMappings.size() != lowerBounds.size()) {
     return forallOp.emitOpError(
         "expected as many workgroup mapping attributes as number of loops");
@@ -97,53 +99,50 @@ getProcIdsAndNprocs(
   AffineExpr s0, s1, s2;
   bindSymbols(builder.getContext(), s0, s1, s2);
   AffineExpr extentExpr = (s1 - s0).ceilDiv(s2);
-  IREE::Codegen::WorkgroupMappingAttr baseZDim =
-      IREE::Codegen::WorkgroupMappingAttr::get(builder.getContext(),
-                                               IREE::Codegen::WorkgroupId::IdZ);
   SmallVector<OpFoldResult> loopExtents;
-  if (workgroupMappings.size() > baseZDim.getMappingId()) {
-    loopExtents.resize(workgroupMappings.size() - baseZDim.getMappingId());
+  if (workgroupMappings.size() > static_cast<size_t>(deLinearizeFrom)) {
+    loopExtents.resize(workgroupMappings.size() -
+                       static_cast<size_t>(deLinearizeFrom));
   }
   for (int index = workgroupMappings.size() - 1; index >= 0; --index) {
     auto workgroupMapping = workgroupMappings[index];
     auto lowerBound = lowerBounds[index];
     auto upperBound = upperBounds[index];
     auto step = steps[index];
-    switch (workgroupMapping.getId()) {
-    case IREE::Codegen::WorkgroupId::IdX:
+    if (workgroupMapping.getId() < deLinearizeFrom) {
       procId[index] =
-          builder.create<IREE::HAL::InterfaceWorkgroupIDOp>(loc, 0).getResult();
-      nprocs[index] =
-          builder.create<IREE::HAL::InterfaceWorkgroupCountOp>(loc, 0)
+          builder
+              .create<IREE::HAL::InterfaceWorkgroupIDOp>(
+                  loc, static_cast<unsigned>(workgroupMapping.getId()))
               .getResult();
-      break;
-    case IREE::Codegen::WorkgroupId::IdY:
-      procId[index] =
-          builder.create<IREE::HAL::InterfaceWorkgroupIDOp>(loc, 1).getResult();
       nprocs[index] =
-          builder.create<IREE::HAL::InterfaceWorkgroupCountOp>(loc, 1)
+          builder
+              .create<IREE::HAL::InterfaceWorkgroupCountOp>(
+                  loc, static_cast<unsigned>(workgroupMapping.getId()))
               .getResult();
-      break;
-    case IREE::Codegen::WorkgroupId::IdZ: {
-      OpFoldResult extent = affine::makeComposedFoldedAffineApply(
-          builder, loc, extentExpr, {lowerBound, upperBound, step});
-      loopExtents[index] = extent;
-      break;
+      continue;
     }
-    }
+    OpFoldResult extent = affine::makeComposedFoldedAffineApply(
+        builder, loc, extentExpr, {lowerBound, upperBound, step});
+    loopExtents[index] = extent;
   }
 
   // Delinearize the z-dim based on the loop extents.
   if (!loopExtents.empty()) {
-    Value zDimId =
-        builder.create<IREE::HAL::InterfaceWorkgroupIDOp>(loc, 2).getResult();
-    OpFoldResult zNprocs =
-        builder.create<IREE::HAL::InterfaceWorkgroupCountOp>(loc, 2)
+    Value delinearizedDimId =
+        builder
+            .create<IREE::HAL::InterfaceWorkgroupIDOp>(
+                loc, static_cast<unsigned>(deLinearizeFrom))
+            .getResult();
+    OpFoldResult delinearizedNprocs =
+        builder
+            .create<IREE::HAL::InterfaceWorkgroupCountOp>(
+                loc, static_cast<unsigned>(deLinearizeFrom))
             .getResult();
 
     if (loopExtents.size() != 1) {
       auto delinearizeOp = builder.create<affine::AffineDelinearizeIndexOp>(
-          loc, zDimId, loopExtents);
+          loc, delinearizedDimId, loopExtents);
       SmallVector<OpFoldResult> orderedDelinearizedDimIds =
           llvm::map_to_vector(delinearizeOp.getResults(),
                               [](Value v) -> OpFoldResult { return v; });
@@ -154,15 +153,15 @@ getProcIdsAndNprocs(
         auto extent = loopExtents[index];
         procId[index] = delinearizeOp->getResult(index);
         OpFoldResult currNprocs = affine::makeComposedFoldedAffineMin(
-            builder, loc, minMap, {extent, zNprocs});
+            builder, loc, minMap, {extent, delinearizedNprocs});
         nprocs[index] = currNprocs;
-        zNprocs = affine::makeComposedFoldedAffineApply(
-            builder, loc, ceilDivExpr, {zNprocs, currNprocs});
+        delinearizedNprocs = affine::makeComposedFoldedAffineApply(
+            builder, loc, ceilDivExpr, {delinearizedNprocs, currNprocs});
       }
     } else {
       // If there is only one z-dim mapping, just use the ID directly.
-      procId[0] = zDimId;
-      nprocs[0] = zNprocs;
+      procId[0] = delinearizedDimId;
+      nprocs[0] = delinearizedNprocs;
     }
   }
 
@@ -173,8 +172,9 @@ getProcIdsAndNprocs(
 }
 
 /// Resolve scf.forall operation by using the workgroup ID and counts.
-static LogicalResult resolveWorkgroupForAll(RewriterBase &rewriter,
-                                            scf::ForallOp forallOp) {
+static LogicalResult
+resolveWorkgroupForAll(RewriterBase &rewriter, scf::ForallOp forallOp,
+                       IREE::Codegen::WorkgroupId delinearizeFrom) {
   if (forallOp->getNumResults() != 0) {
     return forallOp.emitOpError(
         "cannot resolve for all ops with return values");
@@ -198,7 +198,7 @@ static LogicalResult resolveWorkgroupForAll(RewriterBase &rewriter,
         procInfo =
             getProcIdsAndNprocs(forallOp, rewriter, forallOp.getLoc(),
                                 workgroupMapping.value(), mixedLowerBound,
-                                mixedUpperBound, mixedStep);
+                                mixedUpperBound, mixedStep, delinearizeFrom);
     if (failed(procInfo)) {
       return failure();
     }
@@ -229,9 +229,10 @@ static LogicalResult resolveWorkgroupForAll(RewriterBase &rewriter,
   return success();
 }
 
-static LogicalResult resolveWorkgroupCount(RewriterBase &rewriter,
-                                           mlir::FunctionOpInterface funcOp,
-                                           scf::ForallOp forAllOp) {
+static LogicalResult
+resolveWorkgroupCount(RewriterBase &rewriter, mlir::FunctionOpInterface funcOp,
+                      scf::ForallOp forAllOp,
+                      IREE::Codegen::WorkgroupId delinearizeFrom) {
   OpBuilder::InsertionGuard g(rewriter);
   rewriter.setInsertionPoint(forAllOp);
   SmallVector<OpFoldResult> lowerBounds = forAllOp.getMixedLowerBound();
@@ -252,11 +253,13 @@ static LogicalResult resolveWorkgroupCount(RewriterBase &rewriter,
       });
   auto permutation = getMappingPermutation(mappingAttr);
   workgroupCount = applyPermutation(workgroupCount, permutation);
-  return lowerWorkgroupCountFromSliceOp(rewriter, funcOp, workgroupCount);
+  return lowerWorkgroupCountFromSliceOp(rewriter, funcOp, workgroupCount,
+                                        static_cast<int>(delinearizeFrom) + 1);
 }
 
-static LogicalResult resolveWorkgroupForAll(RewriterBase &rewriter,
-                                            FunctionOpInterface funcOp) {
+static LogicalResult
+resolveWorkgroupForAll(RewriterBase &rewriter, FunctionOpInterface funcOp,
+                       IREE::Codegen::WorkgroupId delinearizeFrom) {
   Region &body = funcOp.getFunctionBody();
 
   if (body.empty()) {
@@ -296,11 +299,12 @@ static LogicalResult resolveWorkgroupForAll(RewriterBase &rewriter,
   }
 
   scf::ForallOp forallOp = *forAllOps.begin();
-  if (failed(resolveWorkgroupCount(rewriter, funcOp, forallOp))) {
+  if (failed(
+          resolveWorkgroupCount(rewriter, funcOp, forallOp, delinearizeFrom))) {
     return failure();
   }
 
-  return resolveWorkgroupForAll(rewriter, *forAllOps.begin());
+  return resolveWorkgroupForAll(rewriter, *forAllOps.begin(), delinearizeFrom);
 }
 
 //===---------------------------------------------------------------------===//
@@ -371,7 +375,7 @@ void ReconcileTranslationInfoPass::runOnOperation() {
   auto walkResult =
       innerModuleOp->walk([&](FunctionOpInterface funcOp) -> WalkResult {
         // Resolve workgroup distribution related `scf.forall` ops.
-        if (failed(resolveWorkgroupForAll(rewriter, funcOp))) {
+        if (failed(resolveWorkgroupForAll(rewriter, funcOp, distributeAlong))) {
           return failure();
         }
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD.bazel
@@ -85,6 +85,7 @@ iree_lit_test_suite(
             "propagate_dispatch_size_bounds.mlir",
             "propagate_reshapes_by_expansion.mlir",
             "reconcile_translation_info.mlir",
+            "reconcile_translation_info_linearize.mlir",
             "reductions.mlir",
             "rematerialize_parallel_ops.mlir",
             "remove_dead_allocs.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -81,6 +81,7 @@ iree_lit_test_suite(
     "propagate_dispatch_size_bounds.mlir"
     "propagate_reshapes_by_expansion.mlir"
     "reconcile_translation_info.mlir"
+    "reconcile_translation_info_linearize.mlir"
     "reductions.mlir"
     "rematerialize_parallel_ops.mlir"
     "remove_dead_allocs.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info_linearize.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info_linearize.mlir
@@ -58,13 +58,13 @@ hal.executable private @scf_forall_2D_dynamic_tile_size {
 //       DISTRIBUTEZ:     hal.return %[[SIZE1]], %[[SIZE0]], %[[C1]]
 
 //         CHECK-ALL:   @scf_forall_2D_dynamic_tile_size()
-//     CHECK-ALL-DAG:     %[[ARG0:.+]] = hal.interface.constant.load {{.+}} ordinal(0)
-//     CHECK-ALL-DAG:     %[[ARG1:.+]] = hal.interface.constant.load {{.+}} ordinal(1)
-//     CHECK-ALL-DAG:     %[[ARG2:.+]] = hal.interface.constant.load {{.+}} ordinal(2)
-//     CHECK-ALL-DAG:     %[[ARG3:.+]] = hal.interface.constant.load {{.+}} ordinal(3)
-//     CHECK-ALL-DAG:     %[[ARG4:.+]] = hal.interface.constant.load {{.+}} ordinal(4)
-//     CHECK-ALL-DAG:     %[[ARG5:.+]] = hal.interface.constant.load {{.+}} ordinal(5)
 
+//   DISTRIBUTEX-DAG:     %[[ARG0:.+]] = hal.interface.constant.load {{.+}} ordinal(0)
+//   DISTRIBUTEX-DAG:     %[[ARG1:.+]] = hal.interface.constant.load {{.+}} ordinal(1)
+//   DISTRIBUTEX-DAG:     %[[ARG2:.+]] = hal.interface.constant.load {{.+}} ordinal(2)
+//   DISTRIBUTEX-DAG:     %[[ARG3:.+]] = hal.interface.constant.load {{.+}} ordinal(3)
+//   DISTRIBUTEX-DAG:     %[[ARG4:.+]] = hal.interface.constant.load {{.+}} ordinal(4)
+//   DISTRIBUTEX-DAG:     %[[ARG5:.+]] = hal.interface.constant.load {{.+}} ordinal(5)
 //   DISTRIBUTEX-DAG:     %[[SIZE0:.+]] = affine.apply affine_map<()[s0, s1, s2] -> ((-s0 + s1) ceildiv s2)>()[%[[ARG1]], %[[ARG3]], %[[ARG5]]]
 //   DISTRIBUTEX-DAG:     %[[SIZE1:.+]] = affine.apply affine_map<()[s0, s1, s2] -> ((-s0 + s1) ceildiv s2)>()[%[[ARG0]], %[[ARG2]], %[[ARG4]]]
 //   DISTRIBUTEX-DAG:     %[[IDX:.+]] = hal.interface.workgroup.id[0] : index
@@ -73,12 +73,16 @@ hal.executable private @scf_forall_2D_dynamic_tile_size {
 //   DISTRIBUTEX-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0, s1] -> (s1 * s0)>()[%[[DELINEARIZE]]#1, %[[ARG5]]]
 //       DISTRIBUTEX:     "use"(%[[IV0]], %[[IV1]])
 
+//   DISTRIBUTEY-DAG:     %[[ARG4:.+]] = hal.interface.constant.load {{.+}} ordinal(4)
+//   DISTRIBUTEY-DAG:     %[[ARG5:.+]] = hal.interface.constant.load {{.+}} ordinal(5)
 //   DISTRIBUTEY-DAG:     %[[IDX:.+]] = hal.interface.workgroup.id[0] : index
 //   DISTRIBUTEY-DAG:     %[[IDY:.+]] = hal.interface.workgroup.id[1] : index
 //   DISTRIBUTEY-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0, s1] -> (s1 * s0)>()[%[[IDY]], %[[ARG4]]]
 //   DISTRIBUTEY-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0, s1] -> (s1 * s0)>()[%[[IDX]], %[[ARG5]]]
 //       DISTRIBUTEY:     "use"(%[[IV0]], %[[IV1]])
 
+//   DISTRIBUTEZ-DAG:     %[[ARG4:.+]] = hal.interface.constant.load {{.+}} ordinal(4)
+//   DISTRIBUTEZ-DAG:     %[[ARG5:.+]] = hal.interface.constant.load {{.+}} ordinal(5)
 //   DISTRIBUTEZ-DAG:     %[[IDX:.+]] = hal.interface.workgroup.id[0] : index
 //   DISTRIBUTEZ-DAG:     %[[IDY:.+]] = hal.interface.workgroup.id[1] : index
 //   DISTRIBUTEZ-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0, s1] -> (s1 * s0)>()[%[[IDY]], %[[ARG4]]]

--- a/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info_linearize.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info_linearize.mlir
@@ -1,0 +1,176 @@
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-codegen-reconcile-translation-info{distribute-along=x}, canonicalize)))" --allow-unregistered-dialect --mlir-print-local-scope %s | FileCheck %s --check-prefix=DISTRIBUTEX
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-codegen-reconcile-translation-info{distribute-along=y}, canonicalize)))" --allow-unregistered-dialect --mlir-print-local-scope %s | FileCheck %s --check-prefix=DISTRIBUTEY
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-codegen-reconcile-translation-info{distribute-along=z}, canonicalize)))" --allow-unregistered-dialect --mlir-print-local-scope %s | FileCheck %s --check-prefix=DISTRIBUTEZ
+
+#pipeline_layout = #hal.pipeline.layout<constants = 6, bindings = [
+    #hal.pipeline.binding<storage_buffer>]>
+hal.executable private @scf_forall_2D_dynamic_tile_size {
+  hal.executable.variant public @scf_forall_2D_dynamic_tile_size target(#hal.executable.target<"", "", {}>) {
+    hal.executable.export public @scf_forall_2D_dynamic_tile_size layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index, %arg5 : index, %arg6 : index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2, %arg3, %arg4, %arg5, %arg6
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @scf_forall_2D_dynamic_tile_size() {
+        %cst0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+        %cst1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
+        %cst2 = hal.interface.constant.load layout(#pipeline_layout) ordinal(2) : index
+        %cst3 = hal.interface.constant.load layout(#pipeline_layout) ordinal(3) : index
+        %cst4 = hal.interface.constant.load layout(#pipeline_layout) ordinal(4) : index
+        %cst5 = hal.interface.constant.load layout(#pipeline_layout) ordinal(5) : index
+        %0 = iree_tensor_ext.dispatch.workload.ordinal %cst0, 0 : index
+        %1 = iree_tensor_ext.dispatch.workload.ordinal %cst1, 1 : index
+        %2 = iree_tensor_ext.dispatch.workload.ordinal %cst2, 2 : index
+        %3 = iree_tensor_ext.dispatch.workload.ordinal %cst3, 3 : index
+        %4 = iree_tensor_ext.dispatch.workload.ordinal %cst4, 4 : index
+        %5 = iree_tensor_ext.dispatch.workload.ordinal %cst5, 5 : index
+        scf.forall (%arg0, %arg1) = (%0, %1) to (%2, %3) step(%4, %5) {
+          "use"(%arg0, %arg1) : (index, index) -> ()
+          scf.forall.in_parallel {}
+        } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
+        return
+      }
+    }
+  }
+}
+//       DISTRIBUTEX:   hal.executable.export
+//  DISTRIBUTEX-SAME:       %[[ARG0:[a-zA-Z0-9]+]]: !hal.device
+//  DISTRIBUTEX-SAME:       %[[ARG1:[a-zA-Z0-9]+]]: index
+//  DISTRIBUTEX-SAME:       %[[ARG2:[a-zA-Z0-9]+]]: index
+//  DISTRIBUTEX-SAME:       %[[ARG3:[a-zA-Z0-9]+]]: index
+//  DISTRIBUTEX-SAME:       %[[ARG4:[a-zA-Z0-9]+]]: index
+//  DISTRIBUTEX-SAME:       %[[ARG5:[a-zA-Z0-9]+]]: index
+//  DISTRIBUTEX-SAME:       %[[ARG6:[a-zA-Z0-9]+]]: index
+//       DISTRIBUTEX:     %[[C1:.+]] = arith.constant 1 : index
+//       DISTRIBUTEX:     %[[SIZE:.+]] = affine.apply affine_map<()[s0, s1, s2, s3, s4, s5] -> (((-s0 + s1) ceildiv s2) * ((-s3 + s4) ceildiv s5))>()
+//  DISTRIBUTEX-SAME:         [%[[ARG2]], %[[ARG4]], %[[ARG6]], %[[ARG1]], %[[ARG3]], %[[ARG5]]]
+//       DISTRIBUTEX:     hal.return %[[SIZE]], %[[C1]], %[[C1]]
+//       DISTRIBUTEX:   @scf_forall_2D_dynamic_tile_size()
+//   DISTRIBUTEX-DAG:     %[[ARG0:.+]] = hal.interface.constant.load {{.+}} ordinal(0)
+//   DISTRIBUTEX-DAG:     %[[ARG1:.+]] = hal.interface.constant.load {{.+}} ordinal(1)
+//   DISTRIBUTEX-DAG:     %[[ARG2:.+]] = hal.interface.constant.load {{.+}} ordinal(2)
+//   DISTRIBUTEX-DAG:     %[[ARG3:.+]] = hal.interface.constant.load {{.+}} ordinal(3)
+//   DISTRIBUTEX-DAG:     %[[ARG4:.+]] = hal.interface.constant.load {{.+}} ordinal(4)
+//   DISTRIBUTEX-DAG:     %[[ARG5:.+]] = hal.interface.constant.load {{.+}} ordinal(5)
+//   DISTRIBUTEX-DAG:     %[[SIZE0:.+]] = affine.apply affine_map<()[s0, s1, s2] -> ((-s0 + s1) ceildiv s2)>()[%[[ARG1]], %[[ARG3]], %[[ARG5]]]
+//   DISTRIBUTEX-DAG:     %[[SIZE1:.+]] = affine.apply affine_map<()[s0, s1, s2] -> ((-s0 + s1) ceildiv s2)>()[%[[ARG0]], %[[ARG2]], %[[ARG4]]]
+//   DISTRIBUTEX-DAG:     %[[IDX:.+]] = hal.interface.workgroup.id[0] : index
+//   DISTRIBUTEX-DAG:     %[[DELINEARIZE:.+]]:2 = affine.delinearize_index %[[IDX]] into (%[[SIZE1]], %[[SIZE0]])
+//   DISTRIBUTEX-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0, s1] -> (s1 * s0)>()[%[[DELINEARIZE]]#0, %[[ARG4]]]
+//   DISTRIBUTEX-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0, s1] -> (s1 * s0)>()[%[[DELINEARIZE]]#1, %[[ARG5]]]
+//       DISTRIBUTEX:     "use"(%[[IV0]], %[[IV1]])
+
+//       DISTRIBUTEY:   hal.executable.export
+//  DISTRIBUTEY-SAME:       %[[ARG0:[a-zA-Z0-9]+]]: !hal.device
+//  DISTRIBUTEY-SAME:       %[[ARG1:[a-zA-Z0-9]+]]: index
+//  DISTRIBUTEY-SAME:       %[[ARG2:[a-zA-Z0-9]+]]: index
+//  DISTRIBUTEY-SAME:       %[[ARG3:[a-zA-Z0-9]+]]: index
+//  DISTRIBUTEY-SAME:       %[[ARG4:[a-zA-Z0-9]+]]: index
+//  DISTRIBUTEY-SAME:       %[[ARG5:[a-zA-Z0-9]+]]: index
+//  DISTRIBUTEY-SAME:       %[[ARG6:[a-zA-Z0-9]+]]: index
+//       DISTRIBUTEY:     %[[C1:.+]] = arith.constant 1 : index
+//   DISTRIBUTEY-DAG:     %[[SIZE0:.+]] = affine.apply affine_map<()[s0, s1, s2] -> ((-s0 + s1) ceildiv s2)>()[%[[ARG1]], %[[ARG3]], %[[ARG5]]]
+//   DISTRIBUTEY-DAG:     %[[SIZE1:.+]] = affine.apply affine_map<()[s0, s1, s2] -> ((-s0 + s1) ceildiv s2)>()[%[[ARG2]], %[[ARG4]], %[[ARG6]]]
+//       DISTRIBUTEY:     hal.return %[[SIZE1]], %[[SIZE0]], %[[C1]]
+//       DISTRIBUTEY:   @scf_forall_2D_dynamic_tile_size()
+//   DISTRIBUTEY-DAG:     %[[ARG4:.+]] = hal.interface.constant.load {{.+}} ordinal(4)
+//   DISTRIBUTEY-DAG:     %[[ARG5:.+]] = hal.interface.constant.load {{.+}} ordinal(5)
+//   DISTRIBUTEY-DAG:     %[[IDX:.+]] = hal.interface.workgroup.id[0] : index
+//   DISTRIBUTEY-DAG:     %[[IDY:.+]] = hal.interface.workgroup.id[1] : index
+//   DISTRIBUTEY-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0, s1] -> (s1 * s0)>()[%[[IDY]], %[[ARG4]]]
+//   DISTRIBUTEY-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0, s1] -> (s1 * s0)>()[%[[IDX]], %[[ARG5]]]
+//       DISTRIBUTEY:     "use"(%[[IV0]], %[[IV1]])
+
+//       DISTRIBUTEZ:   hal.executable.export
+//  DISTRIBUTEZ-SAME:       %[[ARG0:[a-zA-Z0-9]+]]: !hal.device
+//  DISTRIBUTEZ-SAME:       %[[ARG1:[a-zA-Z0-9]+]]: index
+//  DISTRIBUTEZ-SAME:       %[[ARG2:[a-zA-Z0-9]+]]: index
+//  DISTRIBUTEZ-SAME:       %[[ARG3:[a-zA-Z0-9]+]]: index
+//  DISTRIBUTEZ-SAME:       %[[ARG4:[a-zA-Z0-9]+]]: index
+//  DISTRIBUTEZ-SAME:       %[[ARG5:[a-zA-Z0-9]+]]: index
+//  DISTRIBUTEZ-SAME:       %[[ARG6:[a-zA-Z0-9]+]]: index
+//       DISTRIBUTEZ:     %[[C1:.+]] = arith.constant 1 : index
+//   DISTRIBUTEZ-DAG:     %[[SIZE0:.+]] = affine.apply affine_map<()[s0, s1, s2] -> ((-s0 + s1) ceildiv s2)>()[%[[ARG1]], %[[ARG3]], %[[ARG5]]]
+//   DISTRIBUTEZ-DAG:     %[[SIZE1:.+]] = affine.apply affine_map<()[s0, s1, s2] -> ((-s0 + s1) ceildiv s2)>()[%[[ARG2]], %[[ARG4]], %[[ARG6]]]
+//       DISTRIBUTEZ:     hal.return %[[SIZE1]], %[[SIZE0]], %[[C1]]
+//       DISTRIBUTEZ:   @scf_forall_2D_dynamic_tile_size()
+//   DISTRIBUTEZ-DAG:     %[[ARG4:.+]] = hal.interface.constant.load {{.+}} ordinal(4)
+//   DISTRIBUTEZ-DAG:     %[[ARG5:.+]] = hal.interface.constant.load {{.+}} ordinal(5)
+//   DISTRIBUTEZ-DAG:     %[[IDX:.+]] = hal.interface.workgroup.id[0] : index
+//   DISTRIBUTEZ-DAG:     %[[IDY:.+]] = hal.interface.workgroup.id[1] : index
+//   DISTRIBUTEZ-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0, s1] -> (s1 * s0)>()[%[[IDY]], %[[ARG4]]]
+//   DISTRIBUTEZ-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0, s1] -> (s1 * s0)>()[%[[IDX]], %[[ARG5]]]
+//       DISTRIBUTEZ:     "use"(%[[IV0]], %[[IV1]])
+
+// // -----
+
+#pipeline_layout = #hal.pipeline.layout<constants = 0, bindings = [
+    #hal.pipeline.binding<storage_buffer>]>
+hal.executable private @scf_forall_3D_tile_size {
+  hal.executable.variant public @scf_forall_3D_tile_size target(#hal.executable.target<"", "", {}>) {
+    hal.executable.export public @scf_forall_3D_tile_size layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @scf_forall_3D_tile_size() {
+        %c1 = arith.constant 1 : index
+        %c2 = arith.constant 2 : index
+        %c3 = arith.constant 3 : index
+        %c44 = arith.constant 44 : index
+        %c55 = arith.constant 55 : index
+        %c66 = arith.constant 66 : index
+        %c5 = arith.constant 5 : index
+        %c6 = arith.constant 6 : index
+        %c7 = arith.constant 7 : index
+        scf.forall (%arg0, %arg1, %arg2) = (%c1, %c2, %c3) to (%c44, %c55, %c66) step(%c7, %c6, %c5) {
+          "use"(%arg0, %arg1, %arg2) : (index, index, index) -> ()
+          scf.forall.in_parallel {}
+        } {mapping = [#iree_codegen.workgroup_mapping<z>, #iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
+        return
+      }
+    }
+  }
+}
+//       DISTRIBUTEX:   hal.executable.export
+//  DISTRIBUTEX-SAME:       %[[ARG0:[a-zA-Z0-9]+]]: !hal.device
+//   DISTRIBUTEX-DAG:     %[[C1:.+]] = arith.constant 1 : index
+//   DISTRIBUTEX-DAG:     %[[C819:.+]] = arith.constant 819 : index
+//       DISTRIBUTEX:     hal.return %[[C819]], %[[C1]], %[[C1]]
+//       DISTRIBUTEX:   @scf_forall_3D_tile_size()
+//   DISTRIBUTEX-DAG:     %[[IDX:.+]] = hal.interface.workgroup.id[0] : index
+//   DISTRIBUTEX-DAG:     %[[DELINEARIZE:.+]]:3 = affine.delinearize_index %[[IDX]] into (7, 9, 13)
+//   DISTRIBUTEX-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0] -> (s0 * 7)>()[%[[DELINEARIZE]]#0]
+//   DISTRIBUTEX-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0] -> (s0 * 6)>()[%[[DELINEARIZE]]#1]
+//   DISTRIBUTEX-DAG:     %[[IV2:.+]] = affine.apply affine_map<()[s0] -> (s0 * 5)>()[%[[DELINEARIZE]]#2]
+//       DISTRIBUTEX:     "use"(%[[IV0]], %[[IV1]], %[[IV2]])
+
+//       DISTRIBUTEY:   hal.executable.export
+//  DISTRIBUTEY-SAME:       %[[ARG0:[a-zA-Z0-9]+]]: !hal.device
+//   DISTRIBUTEY-DAG:     %[[C1:.+]] = arith.constant 1 : index
+//   DISTRIBUTEY-DAG:     %[[C13:.+]] = arith.constant 13 : index
+//   DISTRIBUTEY-DAG:     %[[C63:.+]] = arith.constant 63 : index
+//       DISTRIBUTEY:     hal.return %[[C13]], %[[C63]], %[[C1]]
+//       DISTRIBUTEY:   @scf_forall_3D_tile_size()
+//   DISTRIBUTEY-DAG:     %[[IDX:.+]] = hal.interface.workgroup.id[0] : index
+//   DISTRIBUTEY-DAG:     %[[IDY:.+]] = hal.interface.workgroup.id[1] : index
+//   DISTRIBUTEY-DAG:     %[[DELINEARIZE:.+]]:2 = affine.delinearize_index %[[IDY]] into (7, 9)
+//   DISTRIBUTEY-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0] -> (s0 * 7)>()[%[[DELINEARIZE]]#0]
+//   DISTRIBUTEY-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0] -> (s0 * 6)>()[%[[DELINEARIZE]]#1]
+//   DISTRIBUTEY-DAG:     %[[IV2:.+]] = affine.apply affine_map<()[s0] -> (s0 * 5)>()[%[[IDX]]]
+//       DISTRIBUTEY:     "use"(%[[IV0]], %[[IV1]], %[[IV2]])
+
+//       DISTRIBUTEZ:   hal.executable.export
+//  DISTRIBUTEZ-SAME:       %[[ARG0:[a-zA-Z0-9]+]]: !hal.device
+//   DISTRIBUTEZ-DAG:     %[[C13:.+]] = arith.constant 13 : index
+//   DISTRIBUTEZ-DAG:     %[[C9:.+]] = arith.constant 9 : index
+//   DISTRIBUTEZ-DAG:     %[[C7:.+]] = arith.constant 7 : index
+//       DISTRIBUTEZ:     hal.return %[[C13]], %[[C9]], %[[C7]]
+//       DISTRIBUTEZ:   @scf_forall_3D_tile_size()
+//   DISTRIBUTEZ-DAG:     %[[IDX:.+]] = hal.interface.workgroup.id[0] : index
+//   DISTRIBUTEZ-DAG:     %[[IDY:.+]] = hal.interface.workgroup.id[1] : index
+//   DISTRIBUTEZ-DAG:     %[[IDZ:.+]] = hal.interface.workgroup.id[2] : index
+//   DISTRIBUTEZ-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0] -> (s0 * 7)>()[%[[IDZ]]]
+//   DISTRIBUTEZ-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0] -> (s0 * 6)>()[%[[IDY]]]
+//   DISTRIBUTEZ-DAG:     %[[IV2:.+]] = affine.apply affine_map<()[s0] -> (s0 * 5)>()[%[[IDX]]]
+//       DISTRIBUTEZ:     "use"(%[[IV0]], %[[IV1]], %[[IV2]])

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -85,7 +85,7 @@ static llvm::cl::opt<IREE::Codegen::WorkgroupId>
     clSetWorkgroupDistributionAlong(
         "iree-llvmgpu-set-workgroup-distribution-along",
         llvm::cl::desc(
-            "Contrain the workgroup distribution along grid dimensions"),
+            "Constrain the workgroup distribution along grid dimensions."),
         llvm::cl::values(clEnumValN(IREE::Codegen::WorkgroupId::IdX, "x",
                                     "Constrain the workgroup distribution to "
                                     "use only workgroups along x."),

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -81,6 +81,24 @@ static llvm::cl::opt<bool> clDistributeToWorkgroupsUsingForall(
     llvm::cl::desc("Use scf.forall for distribution to workgroups"),
     llvm::cl::init(false), llvm::cl::Hidden);
 
+static llvm::cl::opt<IREE::Codegen::WorkgroupId>
+    clSetWorkgroupDistributionAlong(
+        "iree-llvmgpu-set-workgroup-distribution-along",
+        llvm::cl::desc(
+            "Contrain the workgroup distribution along grid dimensions"),
+        llvm::cl::values(clEnumValN(IREE::Codegen::WorkgroupId::IdX, "x",
+                                    "Constrain the workgroup distribution to "
+                                    "use only workgroups along x."),
+                         clEnumValN(IREE::Codegen::WorkgroupId::IdY, "y",
+                                    "Constrain the workgroup distribution to "
+                                    "use only workgroups along x and y."),
+                         clEnumValN(IREE::Codegen::WorkgroupId::IdZ, "z",
+                                    "Constrain the workgroup distribution to "
+                                    "use only workgroups along x, y and z.")),
+        llvm::cl::init(IREE::Codegen::WorkgroupId::IdZ)
+
+    );
+
 //===----------------------------------------------------------------------===//
 // Bufferization Configuration
 //===----------------------------------------------------------------------===//
@@ -1226,7 +1244,11 @@ void buildLLVMGPUCodegenPassPipeline(OpPassManager &variantPassManager,
         .addPass(createLLVMGPULowerExecutableTargetPass)
         .addPass(createVerifyWorkgroupDistributionPass);
   }
-  variantPassManager.addPass(createReconcileTranslationInfoPass());
+  {
+    ReconcileTranslationInfoPassOptions options;
+    options.distributeAlong = clSetWorkgroupDistributionAlong;
+    variantPassManager.addPass(createReconcileTranslationInfoPass(options));
+  }
 
   //===--------------------------------------------------------------------===//
   // Convert Linalg ops to LLVM+NVVM/ROCDL ops.


### PR DESCRIPTION
While IREE generated code itself might have a logical view of grid along x/y/z dimension, the hardware itself does not really care about that. The number of workgroups can just be linearized along (x) or (x, y) dimensions and then the generated code can split out the physical workgroup ID into many different logical workgroup IDs. This avoids hitting some limits of number of workgroups along y/z dimensions (We never really launch workgroups, or should launch, more workgroups than the limit on x dimension).

This logic already exists for handling logical distributions of greater than 3D. Add an option to allow it to constrain physical distribution to 1D/2D.

Fixes #20766 