### PR TITLE
[NFC][Encoding] Move convertType to LayoutAttrInterface

### DIFF
--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -613,7 +613,7 @@ struct CPUDeviceEncodingPackedLayoutAttrInterface
 };
 
 struct CPUDeviceEncodingLayoutAttrInterface final
-    : public Encoding::LayoutAttrInterface::ExternalModel<
+    : public DeviceEncodingLayoutAttrInterfaceExternalModelBase<
           CPUDeviceEncodingLayoutAttrInterface, CPUEncodingLayoutAttr> {
 
   Operation *lowerOp(Attribute attr, OpBuilder &b, Operation *op,
@@ -653,7 +653,7 @@ struct CPUHostEncodingLayoutResolverAttrInterface final
 };
 
 struct CPUHostSerializableEncodingAttrInterface final
-    : HostSerializableEncodingAttrInterfaceExternalModelBase<
+    : IREE::Encoding::SerializableEncodingAttrInterface::ExternalModel<
           CPUHostSerializableEncodingAttrInterface, CPUEncodingLayoutAttr> {
 
   Value calculateStorageSizeInBytes(Attribute attr, Location loc,
@@ -749,7 +749,7 @@ struct VMVXDeviceEncodingPackedLayoutAttrInterface final
 };
 
 struct VMVXDeviceEncodingLayoutAttrInterface final
-    : Encoding::LayoutAttrInterface::ExternalModel<
+    : DeviceEncodingLayoutAttrInterfaceExternalModelBase<
           VMVXDeviceEncodingLayoutAttrInterface, VMVXEncodingLayoutAttr> {
 
   Operation *lowerOp(Attribute attr, OpBuilder &b, Operation *op,
@@ -788,7 +788,7 @@ struct VMVXHostEncodingLayoutResolverAttrInterface final
 };
 
 struct VMVXHostSerializableEncodingAttrInterface final
-    : HostSerializableEncodingAttrInterfaceExternalModelBase<
+    : IREE::Encoding::SerializableEncodingAttrInterface::ExternalModel<
           VMVXHostSerializableEncodingAttrInterface, VMVXEncodingLayoutAttr> {
   Value calculateStorageSizeInBytes(Attribute attr, Location loc,
                                     OpBuilder &builder, RankedTensorType type,

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -359,7 +359,7 @@ struct GPUDeviceEncodingPackedLayoutAttrInterface
 };
 
 struct GPUDeviceEncodingLayoutAttrInterface
-    : public Encoding::LayoutAttrInterface::ExternalModel<
+    : public DeviceEncodingLayoutAttrInterfaceExternalModelBase<
           GPUDeviceEncodingLayoutAttrInterface, GPUEncodingLayoutAttr> {
   Operation *lowerOp(Attribute attr, OpBuilder &b, Operation *op,
                      TypeRange convertedResTypes,
@@ -380,7 +380,7 @@ struct GPUDeviceEncodingLayoutAttrInterface
 };
 
 struct GPUHostSerializableEncodingAttrInterface final
-    : HostSerializableEncodingAttrInterfaceExternalModelBase<
+    : IREE::Encoding::SerializableEncodingAttrInterface::ExternalModel<
           GPUHostSerializableEncodingAttrInterface, GPUEncodingLayoutAttr> {
 
   Value calculateStorageSizeInBytes(Attribute attr, Location loc,

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.h
@@ -69,11 +69,11 @@ getEncodingInfoFromLayouts(RankedTensorType type) {
   return std::nullopt;
 }
 
-template <typename DeviceSerializableEncodingAttrInterface,
+template <typename DeviceEncodingLayoutAttrInterface,
           typename EncodingLayoutAttr>
-struct HostSerializableEncodingAttrInterfaceExternalModelBase
-    : public IREE::Encoding::SerializableEncodingAttrInterface::ExternalModel<
-          DeviceSerializableEncodingAttrInterface, EncodingLayoutAttr> {
+struct DeviceEncodingLayoutAttrInterfaceExternalModelBase
+    : public IREE::Encoding::LayoutAttrInterface::ExternalModel<
+          DeviceEncodingLayoutAttrInterface, EncodingLayoutAttr> {
 public:
   MaterializeEncodingInfo getEncodingInfo(EncodingLayoutAttr layoutAttr,
                                           RankedTensorType type) const {

--- a/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Encoding/IR/EncodingInterfaces.td
@@ -95,7 +95,6 @@ def IREEEncoding_SerializableEncodingAttrInterface :
     - `isSerialized`: checks if the encoding is serialized or not.
     - `cloneWithLayouts`: creates a serializable encoding with the layouts
       information.
-    - `convertType`: converts a type to materialized form.
     - The rest of methods that interpret the encodings. E.g.,
       `calculateStorageSizeInBytes` is the method to parse layouts and produce
       the storage size in bytes.
@@ -197,22 +196,7 @@ def IREEEncoding_SerializableEncodingAttrInterface :
         assert(false && "unimplemented interface method");
         return {};
       }]
-    >,
-    InterfaceMethod<
-      /*desc=*/[{
-        Returns the materialized form for the provided type.
-      }],
-      /*retTy=*/"::mlir::Type",
-      /*methodName=*/"convertType",
-      /*args=*/(ins
-        "::mlir::Type":$type
-      ),
-      /*methodBody=*/"",
-      /*defaultImplementation=*/[{
-        assert(false && "unimplemented interface method");
-        return type;
-      }]
-    >,
+    >
   ];
 
   let extraClassDeclaration = [{
@@ -228,12 +212,31 @@ def IREEEncoding_LayoutAttrInterface :
   let cppNamespace = "::mlir::iree_compiler::IREE::Encoding";
   let description = [{
     An interface that collects a set of methods for encoding materialization.
+
+    These are the core methods:
+    - `convertType`: converts a type to its materialized form.
+    - `lowerOp`: converts an operation to its materialized form.
   }];
 
   let methods = [
     InterfaceMethod<
       /*desc=*/[{
-        Returns the layout of materialized encoding for a tensor type.
+        Returns the materialized form for the provided type.
+      }],
+      /*retTy=*/"::mlir::Type",
+      /*methodName=*/"convertType",
+      /*args=*/(ins
+        "::mlir::Type":$type
+      ),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        assert(false && "unimplemented interface method");
+        return type;
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns the materialized form for the provided operation.
       }],
       /*retTy=*/"::mlir::Operation *",
       /*methodName=*/"lowerOp",


### PR DESCRIPTION
The `convertType` interface method, which converts a type into its materialized form, belongs in the Encoding's `LayoutAttrInterface` instead of the `SerializableEncodingAttrInterface` as the former is responsible for materializing encodings, while the latter describes properties of serialized encodings, see https://github.com/iree-org/iree/pull/20741#discussion_r2080658419.