### PR TITLE
[Flow] Set known dimensions on concat output

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Patterns.cpp
@@ -9,6 +9,7 @@
 #include "iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Utils.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "llvm/ADT/STLExtras.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Arith/Utils/Utils.h"
@@ -16,6 +17,7 @@
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tensor/Utils/Utils.h"
+#include "mlir/IR/OpDefinition.h"
 
 namespace mlir::iree_compiler::IREE::Flow {
 
@@ -213,6 +215,25 @@ struct ConvertTensorConcatPattern : public OpRewritePattern<tensor::ConcatOp> {
         concatOffsets.push_back(outputShape[0]);
         outputShape[0] = affine::makeComposedFoldedAffineApply(
             rewriter, loc, addExpr, {outputShape[0], inputShape[0]});
+
+        auto isDynamic = [](mlir::OpFoldResult dim) {
+          if (auto cst = mlir::getConstantIntValue(dim)) {
+            return mlir::ShapedType::isDynamic(*cst);
+          }
+          return true;
+        };
+
+        // Any dims outside of concatenation axis (only `0` supported currently)
+        // should be equal. Fill in any dynamic dims in `outputShape` known from
+        // other inputs.
+        // Ex. concat([?,?], [?,12]) -> [?,12]
+        for (auto [dimIdx, outDim] :
+             llvm::drop_begin(llvm::enumerate(outputShape))) {
+          OpFoldResult inDim = inputShape[dimIdx];
+          if (isDynamic(outDim) && !isDynamic(inDim)) {
+            outputShape[dimIdx] = inDim;
+          }
+        }
       }
       inputShapes.emplace_back(std::move(inputShape));
     }

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/concat.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/concat.mlir
@@ -34,3 +34,24 @@ func.func @dont_lower_non_outer_dim_concat(%arg0: tensor<4x?xf32>, %arg1 : tenso
 // CHECK-LABEL: func @dont_lower_non_outer_dim_concat
 //       CHECK:   %[[CONCAT:.+]] = tensor.concat
 //       CHECK:   return %[[CONCAT]]
+// -----
+
+func.func @mixed_concat_static_dim(%arg0: tensor<2x?xf32>, %arg1 : tensor<?x2xf32>) -> tensor<?x2xf32> {
+  %0 = tensor.concat dim(0) %arg0, %arg1 : (tensor<2x?xf32>, tensor<?x2xf32>) -> tensor<?x2xf32>
+  return %0 : tensor<?x2xf32>
+}
+// CHECK-LABEL: func.func @mixed_concat_static_dim
+//  CHECK-SAME:     %[[ARG0:.+]]: tensor<2x?xf32>
+//  CHECK-SAME:     %[[ARG1:.+]]: tensor<?x2xf32>
+//   CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : index
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG:   %[[ARG0_D1:.+]] = tensor.dim %[[ARG0]], %[[C1]] : tensor<2x?xf32>
+//   CHECK-DAG:   %[[ARG1_D0:.+]] = tensor.dim %[[ARG1]], %[[C0]] : tensor<?x2xf32>
+//       CHECK:   %[[RESULT_D0:.+]] = affine.apply affine_map<()[s0] -> (s0 + 2)>()[%[[ARG1_D0]]]
+//       CHECK:   %[[EMPTY:.+]] = tensor.empty(%[[RESULT_D0]]) : tensor<?x2xf32>
+//       CHECK:   %[[UPDATE1:.+]] = flow.tensor.update %[[ARG0]], %[[EMPTY]][%[[C0]], %[[C0]]]
+//  CHECK-SAME:       : tensor<2x?xf32>{%[[ARG0_D1]]} -> %1 as tensor<?x2xf32>{%0}
+//       CHECK:   %[[UPDATE2:.+]] = flow.tensor.update %[[ARG1]], %[[UPDATE1]][%[[C2]], %[[C0]]]
+//  CHECK-SAME:       : tensor<?x2xf32>{%[[ARG1_D0]]} -> %2 as tensor<?x2xf32>{%0}
+//       CHECK:   return %[[UPDATE2]] : tensor<?x2xf32>


### PR DESCRIPTION
Concat requires that shape dimensions outside of concatenation axis are equal for all inputs. This PR ensures that statically known dimensions for non-concatenation-axis shape are used for output even when some inputs are dynamic for said axis.
For example `concat([?,?], [?,12]) -> [?,12]` (not, as previously,  `concat([?,?], [?,12]) -> [?,?]`).

Fixes #20154