### PR TITLE
[Codegen][GPU] Support padding in CombineLayoutTransformation

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -210,6 +210,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
         "//compiler/src/iree/compiler/Dialect/LinalgExt/IR",
         "//compiler/src/iree/compiler/Dialect/LinalgExt/Transforms",
+        "//compiler/src/iree/compiler/Dialect/LinalgExt/Utils",
         "//compiler/src/iree/compiler/Dialect/Stream/Analysis",
         "//compiler/src/iree/compiler/Dialect/TensorExt/IR",
         "//compiler/src/iree/compiler/Dialect/TensorExt/Transforms",

--- a/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD.bazel
@@ -178,6 +178,7 @@ iree_compiler_cc_library(
     ],
     hdrs = [
         "BufferizationAnalysis.h",
+        "CombineLayoutTransformation.h",
         "EncodingUtils.h",
         "ExtractAddressComputation.h",
         "PassUtils.h",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -69,6 +69,7 @@ iree_cc_library(
     Common
   HDRS
     "BufferizationAnalysis.h"
+    "CombineLayoutTransformation.h"
     "EncodingUtils.h"
     "ExtractAddressComputation.h"
     "PassUtils.h"

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -240,6 +240,7 @@ iree_cc_library(
     iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::LinalgExt::IR
     iree::compiler::Dialect::LinalgExt::Transforms
+    iree::compiler::Dialect::LinalgExt::Utils
     iree::compiler::Dialect::Stream::Analysis
     iree::compiler::Dialect::TensorExt::IR
     iree::compiler::Dialect::TensorExt::Transforms

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -4,9 +4,11 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree/compiler/Codegen/Common/CombineLayoutTransformation.h"
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.h"
 #include "iree/compiler/Dialect/LinalgExt/Transforms/Transforms.h"
+#include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
@@ -39,8 +41,18 @@ static void simplifyComplexRelayoutOps(RewriterBase &rewriter,
       funcOp.getFunctionBody().getOps<linalg::PackOp>());
   for (auto packOp : packOps) {
     rewriter.setInsertionPoint(packOp);
-    (void)linalg::lowerPack(rewriter, packOp,
-                            /*lowerPadLikeWithInsertSlice=*/false);
+    FailureOr<linalg::LowerPackResult> result = linalg::lowerPack(
+        rewriter, packOp, /*lowerPadLikeWithInsertSlice=*/false);
+    // For aligned pack ops, the pad will be a no-op, and can be folded away.
+    // Fold it here so it does not complicate the index transformation folding
+    // later on.
+    if (failed(result) || !result->padOp) {
+      continue;
+    }
+    if (areAllConstantIntValue(result->padOp.getMixedLowPad(), 0) &&
+        areAllConstantIntValue(result->padOp.getMixedHighPad(), 0)) {
+      rewriter.replaceOp(result->padOp, result->padOp.getSource());
+    }
   }
   SmallVector<linalg::UnPackOp> unPackOps(
       funcOp.getFunctionBody().getOps<linalg::UnPackOp>());
@@ -198,12 +210,159 @@ foldExtractSliceIntoMapScatter(RewriterBase &rewriter,
   return mapScatterOp;
 }
 
+static void buildNestedDistributionLoops(
+    RewriterBase &rewriter, Location loc, int64_t distributionLevel,
+    SmallVector<OpFoldResult> lbs, SmallVector<OpFoldResult> ubs,
+    ArrayRef<DistributionConfig> distConfigs,
+    function_ref<void(OpBuilder &, Location, ValueRange)> innerLoopBuilder) {
+  DistributionConfig distConfig = distConfigs[distributionLevel];
+  SmallVector<OpFoldResult> steps = llvm::map_to_vector(
+      distConfig.tileSizes, [&](int64_t size) -> OpFoldResult {
+        return rewriter.getIndexAttr(size);
+      });
+  rewriter.create<scf::ForallOp>(
+      loc, lbs, ubs, steps, /*outputs=*/ValueRange(),
+      rewriter.getArrayAttr(distConfig.mapping),
+      /*bodyBuilder=*/[&](OpBuilder &b, Location nestedLoc, ValueRange ivs) {
+        SmallVector<OpFoldResult> nestedLbs(ivs);
+        SmallVector<OpFoldResult> nestedUbs;
+        for (auto [start, step, ub] : llvm::zip_equal(nestedLbs, steps, ubs)) {
+          auto tileEnd = IREE::LinalgExt::addOfrs(b, nestedLoc, start, step);
+          auto minMap = AffineMap::get(
+              2, 0, {b.getAffineDimExpr(0), b.getAffineDimExpr(1)},
+              rewriter.getContext());
+          auto min = affine::makeComposedFoldedAffineMin(b, nestedLoc, minMap,
+                                                         {tileEnd, ub});
+          nestedUbs.push_back(min);
+        }
+        // Continue distribution if there are more distribution levels.
+        if (distributionLevel + 1 < distConfigs.size()) {
+          buildNestedDistributionLoops(
+              rewriter, nestedLoc, distributionLevel + 1, nestedLbs, nestedUbs,
+              distConfigs, innerLoopBuilder);
+          b.create<scf::InParallelOp>(nestedLoc);
+          return;
+        }
+        // Otherwise, tile to one, and generate the inner loop body.
+        SmallVector<Value> nestedLbVals =
+            getValueOrCreateConstantIndexOp(b, nestedLoc, nestedLbs);
+        SmallVector<Value> nestedUbVals =
+            getValueOrCreateConstantIndexOp(b, nestedLoc, nestedUbs);
+        Value one = rewriter.create<arith::ConstantIndexOp>(nestedLoc, 1);
+        SmallVector<Value> unitSteps(nestedLbs.size(), one);
+        scf::buildLoopNest(rewriter, nestedLoc, nestedLbVals, nestedUbVals,
+                           unitSteps, innerLoopBuilder);
+        b.create<scf::InParallelOp>(nestedLoc);
+      });
+}
+
+/// Fold a tensor.pad op into a iree_linalg_ext.map_scatter op, and separate
+/// the writing of padding values into a separate operation on the buffer that
+/// the map_scatter op is ultimately written into. The result buffer is taken
+/// from the direct consumer of the `mapScatterOp`, which is expected to be an
+/// `iree_codegen.store_to_memref` op. Return failure if the result buffer is
+/// not found.
+static FailureOr<MapScatterOp>
+foldPadIntoMapScatter(RewriterBase &rewriter, tensor::PadOp padOp,
+                      MapScatterOp mapScatterOp,
+                      DistributionConfigFn distributionConfigFn) {
+  // Find the output buffer that the mapScatterOp is stored into.
+  if (!mapScatterOp->hasOneUse()) {
+    return rewriter.notifyMatchFailure(
+        mapScatterOp, "map_scatter does not have a single user");
+  }
+  auto storeOp = dyn_cast<IREE::Codegen::StoreToMemrefOp>(
+      *mapScatterOp->getUsers().begin());
+  if (!storeOp) {
+    return rewriter.notifyMatchFailure(
+        mapScatterOp,
+        "map_scatter user is not an iree_codegen.store_to_memref op");
+  }
+  Value outputBuffer = storeOp.getTarget();
+
+  // Write the padding values directly into the outputBuffer.
+  rewriter.setInsertionPointAfter(storeOp);
+  Location loc = padOp->getLoc();
+  SmallVector<OpFoldResult> padSrcSizes =
+      tensor::getMixedSizes(rewriter, loc, padOp.getSource());
+  SmallVector<OpFoldResult> ubs =
+      tensor::getMixedSizes(rewriter, loc, padOp.getResult());
+  SmallVector<OpFoldResult> lbs(ubs.size(), rewriter.getIndexAttr(0));
+  SmallVector<DistributionConfig> distConfigs = distributionConfigFn(
+      padOp.getSourceType().getShape(), rewriter.getContext());
+
+  auto innerLoopBuilder = [&](OpBuilder &b, Location loopLoc, ValueRange ivs) {
+    // We need to scatter the padding values according to the existing
+    // mapScatterOp transformation, so clone the transformation into the
+    // loop nest.
+    auto clonedMapScatterOp = cast<MapScatterOp>(b.clone(*mapScatterOp));
+    Block &clonedTransformBody =
+        clonedMapScatterOp.getTransformationRegion().getBlocks().front();
+    // Get a pointer to the YieldOp before inlining the Block.
+    auto yieldOp =
+        cast<IREE::LinalgExt::YieldOp>(clonedTransformBody.getTerminator());
+    rewriter.inlineBlockBefore(&clonedTransformBody, clonedMapScatterOp, ivs);
+    rewriter.eraseOp(clonedMapScatterOp);
+    OpBuilder::InsertionGuard g(b);
+    b.setInsertionPointAfter(yieldOp);
+    // Compute the indices into the outputBuffer, and the if condition to
+    // write the padding values. Padding values must obey the existing mask
+    // of the current mapScatterOp, and also be in the low or high pad
+    // range of the padOp.
+    SmallVector<OpFoldResult> low = padOp.getMixedLowPad();
+    Value writeCond = nullptr;
+    for (auto [l, srcSize, idx] : llvm::zip_equal(low, padSrcSizes, ivs)) {
+      Value lowVal = getValueOrCreateConstantIndexOp(rewriter, loc, l);
+      auto isLowPad = rewriter
+                          .create<arith::CmpIOp>(loc, arith::CmpIPredicate::ult,
+                                                 idx, lowVal)
+                          ->getResult(0);
+      Value highPadStart = getValueOrCreateConstantIndexOp(
+          rewriter, loc, IREE::LinalgExt::addOfrs(b, loopLoc, l, srcSize));
+      auto isHighPad =
+          rewriter
+              .create<arith::CmpIOp>(loc, arith::CmpIPredicate::uge, idx,
+                                     highPadStart)
+              ->getResult(0);
+      Value isPad = rewriter.create<arith::OrIOp>(loc, isLowPad, isHighPad);
+      if (!writeCond) {
+        writeCond = isPad;
+        continue;
+      }
+      writeCond = rewriter.create<arith::OrIOp>(loc, writeCond, isPad);
+    }
+    SmallVector<Value> storeIndices(yieldOp.getOperands());
+    rewriter.eraseOp(yieldOp);
+    Value mask = storeIndices.pop_back_val();
+    writeCond = rewriter.create<arith::AndIOp>(loc, writeCond, mask);
+    // Create the store to the outputBuffer.
+    auto thenBuilder = [&](OpBuilder &nestedBuilder, Location ifLoc) {
+      nestedBuilder.create<memref::StoreOp>(
+          ifLoc, padOp.getConstantPaddingValue(), outputBuffer, storeIndices);
+      nestedBuilder.create<scf::YieldOp>(ifLoc);
+    };
+    b.create<scf::IfOp>(loopLoc, writeCond, thenBuilder);
+  };
+
+  buildNestedDistributionLoops(rewriter, loc, 0, lbs, ubs, distConfigs,
+                               innerLoopBuilder);
+
+  // Now that the padding values are being written to the outputBuffer, the
+  // padOp becomes a no-op with respect to the index transformation on the
+  // non-padded values.
+  rewriter.modifyOpInPlace(mapScatterOp, [&]() {
+    mapScatterOp.getInputMutable().assign(padOp.getSource());
+  });
+  return mapScatterOp;
+}
+
 /// Fold the `op` into the `mapScatterOp`, if possible. The resulting
 /// map_scatter op is returned, if the `op` was folded. Otherwise, return
 /// failure.
-static FailureOr<MapScatterOp> foldIntoMapScatter(RewriterBase &rewriter,
-                                                  Operation *op,
-                                                  MapScatterOp mapScatterOp) {
+static FailureOr<MapScatterOp>
+foldIntoMapScatter(RewriterBase &rewriter, Operation *op,
+                   MapScatterOp mapScatterOp,
+                   DistributionConfigFn distributionConfigFn) {
   return llvm::TypeSwitch<Operation *, FailureOr<MapScatterOp>>(op)
       .Case<linalg::CopyOp>([&](linalg::CopyOp copyOp) {
         return foldIdentityLikeOpIntoMapScatter(rewriter, copyOp, mapScatterOp);
@@ -221,6 +380,10 @@ static FailureOr<MapScatterOp> foldIntoMapScatter(RewriterBase &rewriter,
         return foldExtractSliceIntoMapScatter(rewriter, extractSliceOp,
                                               mapScatterOp);
       })
+      .Case<tensor::PadOp>([&](tensor::PadOp padOp) {
+        return foldPadIntoMapScatter(rewriter, padOp, mapScatterOp,
+                                     distributionConfigFn);
+      })
       .Default([](Operation *) { return failure(); });
 }
 
@@ -229,7 +392,8 @@ static FailureOr<MapScatterOp> foldIntoMapScatter(RewriterBase &rewriter,
 /// is inserted before the root, and then the producers of the map_scatter op
 /// are folded into the map_scatter until an unsupported op is reached.
 static void combineRelayoutOpChain(RewriterBase &rewriter,
-                                   MapScatterOp mapScatterOp) {
+                                   MapScatterOp mapScatterOp,
+                                   DistributionConfigFn distributionConfigFn) {
   Operation *relayoutOp = mapScatterOp.getInput().getDefiningOp();
   if (!relayoutOp) {
     return;
@@ -239,8 +403,8 @@ static void combineRelayoutOpChain(RewriterBase &rewriter,
     LDBG("Attempting to fold " << relayoutOp->getName()
                                << " into map_scatter op:\n"
                                << *relayoutOp);
-    FailureOr<MapScatterOp> maybeCombinedRelayoutOp =
-        foldIntoMapScatter(rewriter, relayoutOp, combinedRelayoutOp);
+    FailureOr<MapScatterOp> maybeCombinedRelayoutOp = foldIntoMapScatter(
+        rewriter, relayoutOp, combinedRelayoutOp, distributionConfigFn);
     if (failed(maybeCombinedRelayoutOp)) {
       LDBG("Failed to fold " << relayoutOp->getName()
                              << " into map_scatter op");
@@ -278,6 +442,58 @@ insertIdentityMapScatter(RewriterBase &rewriter,
   return mapScatterOp;
 }
 
+static SmallVector<DistributionConfig>
+defaultWorkgroupDistributionConfigFn(ArrayRef<int64_t> sizes,
+                                     MLIRContext *ctx) {
+  DistributionConfig workgroupDistributionConfig;
+  workgroupDistributionConfig.tileSizes = SmallVector<int64_t>(sizes.size(), 1);
+  workgroupDistributionConfig.tileSizes.back() = 64;
+  workgroupDistributionConfig.mapping = llvm::map_to_vector(
+      llvm::seq<int64_t>(sizes.size()), [&](int64_t dim) -> Attribute {
+        switch (dim) {
+        case 0:
+        case 1:
+        case 2:
+          return IREE::Codegen::WorkgroupMappingAttr::get(
+              ctx, IREE::Codegen::symbolizeWorkgroupId(dim).value());
+        default:
+          return IREE::Codegen::WorkgroupMappingAttr::get(
+              ctx, IREE::Codegen::WorkgroupId::IdZ, dim - 2);
+        }
+      });
+  std::reverse(workgroupDistributionConfig.mapping.begin(),
+               workgroupDistributionConfig.mapping.end());
+  return {workgroupDistributionConfig};
+}
+
+LogicalResult
+combineLayoutTransformation(MLIRContext *ctx, FunctionOpInterface funcOp,
+                            DistributionConfigFn distributionConfigFn) {
+  // Apply some preprocessing to convert complex layout transformation
+  // ops like pack and unpack into simpler supported ops.
+  IRRewriter rewriter(ctx);
+  simplifyComplexRelayoutOps(rewriter, funcOp);
+
+  // Start from iree_codegen.store_to_memref ops, and combine producer
+  // relayout ops into a single map_scatter.
+  SmallVector<IREE::Codegen::StoreToMemrefOp> dispatchResults(
+      funcOp.getFunctionBody().getOps<IREE::Codegen::StoreToMemrefOp>());
+  for (IREE::Codegen::StoreToMemrefOp dispatchResult : dispatchResults) {
+    MapScatterOp mapScatterOp =
+        insertIdentityMapScatter(rewriter, dispatchResult);
+    combineRelayoutOpChain(rewriter, mapScatterOp, distributionConfigFn);
+  }
+
+  // Cleanup any tensor.dim ops that may be present after relayout
+  // combination.
+  RewritePatternSet cleanupPatterns(ctx);
+  memref::populateResolveRankedShapedTypeResultDimsPatterns(cleanupPatterns);
+  if (failed(applyPatternsGreedily(funcOp, std::move(cleanupPatterns)))) {
+    return failure();
+  }
+  return success();
+}
+
 namespace {
 
 struct CombineLayoutTransformationPass final
@@ -287,28 +503,9 @@ struct CombineLayoutTransformationPass final
       CombineLayoutTransformationPass>::CombineLayoutTransformationPassBase;
 
   void runOnOperation() override {
-    auto funcOp = getOperation();
-
-    // Apply some preprocessing to convert complex layout transformation
-    // ops like pack and unpack into simpler supported ops.
-    IRRewriter rewriter(&getContext());
-    simplifyComplexRelayoutOps(rewriter, funcOp);
-
-    // Start from iree_codegen.store_to_memref ops, and combine producer
-    // relayout ops into a single map_scatter.
-    SmallVector<IREE::Codegen::StoreToMemrefOp> dispatchResults(
-        funcOp.getFunctionBody().getOps<IREE::Codegen::StoreToMemrefOp>());
-    for (IREE::Codegen::StoreToMemrefOp dispatchResult : dispatchResults) {
-      MapScatterOp mapScatterOp =
-          insertIdentityMapScatter(rewriter, dispatchResult);
-      combineRelayoutOpChain(rewriter, mapScatterOp);
-    }
-
-    // Cleanup any tensor.dim ops that may be present after relayout
-    // combination.
-    RewritePatternSet cleanupPatterns(&getContext());
-    memref::populateResolveRankedShapedTypeResultDimsPatterns(cleanupPatterns);
-    if (failed(applyPatternsGreedily(funcOp, std::move(cleanupPatterns)))) {
+    if (failed(combineLayoutTransformation(
+            &getContext(), getOperation(),
+            defaultWorkgroupDistributionConfigFn))) {
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.h
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.h
@@ -15,7 +15,7 @@ namespace mlir::iree_compiler {
 /// space. The rank of `tileSizes` and `mapping` should match the rank of the
 /// iteration space for which the DistributionConfig is described.
 struct DistributionConfig {
-  /// The tileSizes for each worker of the distribution. The strides of the
+  /// The tile sizes for each worker of the distribution. The strides of the
   /// tiles are expected to be 1.
   SmallVector<int64_t> tileSizes;
   /// Distribution mapping for the distributed loops (e.g., the `mapping`

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.h
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.h
@@ -1,0 +1,28 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#ifndef IREE_COMPILER_CODEGEN_COMMON_COMBINELAYOUTTRANSFORMATION_H_
+#define IREE_COMPILER_CODEGEN_COMMON_COMBINELAYOUTTRANSFORMATION_H_
+
+#include "mlir/Interfaces/FunctionInterfaces.h"
+
+using namespace mlir;
+
+namespace mlir::iree_compiler {
+
+struct DistributionConfig {
+  SmallVector<int64_t> tileSizes;
+  SmallVector<Attribute> mapping;
+};
+
+using DistributionConfigFn = function_ref<SmallVector<DistributionConfig>(
+    ArrayRef<int64_t>, MLIRContext *)>;
+
+LogicalResult
+combineLayoutTransformation(MLIRContext *ctx, FunctionOpInterface funcOp,
+                            DistributionConfigFn distributionConfigFn);
+
+} // namespace mlir::iree_compiler
+#endif // IREE_COMPILER_CODEGEN_COMMON_COMBINELAYOUTTRANSFORMATION_H_

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.h
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.h
@@ -1,28 +1,51 @@
-// Copyright 2023 The IREE Authors
+// Copyright 2025 The IREE Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 #ifndef IREE_COMPILER_CODEGEN_COMMON_COMBINELAYOUTTRANSFORMATION_H_
 #define IREE_COMPILER_CODEGEN_COMMON_COMBINELAYOUTTRANSFORMATION_H_
 
 #include "mlir/Interfaces/FunctionInterfaces.h"
 
-using namespace mlir;
-
 namespace mlir::iree_compiler {
 
+/// Describes the configuration for distributing a fully parallel iteration
+/// space. The rank of `tileSizes` and `mapping` should match the rank of the
+/// iteration space for which the DistributionConfig is described.
 struct DistributionConfig {
+  /// The tileSizes for each worker of the distribution. The strides of the
+  /// tiles are expected to be 1.
   SmallVector<int64_t> tileSizes;
+  /// Distribution mapping for the distributed loops (e.g., the `mapping`
+  /// attribute of an scf.forall op).
   SmallVector<Attribute> mapping;
 };
 
-using DistributionConfigFn = function_ref<SmallVector<DistributionConfig>(
-    ArrayRef<int64_t>, MLIRContext *)>;
+/// Type for a callback that determines how to distribute the writing of pad
+/// values to an output buffer. The function takes in the iteration bounds of
+/// the original pad op, and returns a list of `DistributionConfig`s, each of
+/// which describes a level of distribution. The first DistributionConfig in
+/// the list represents the outermost distribution loop set.
+using PadDistributionConfigFn = function_ref<SmallVector<DistributionConfig>(
+    ArrayRef<int64_t> iterationBounds, MLIRContext *)>;
 
+/// Combines any layout/indexing transformation ops at the ends of a dispatch.
+/// Finds `iree_codegen.store_to_memref` ops in the `funcOp`, and combines any
+/// layout transformation ops (like expand_shape, transpose, pack, etc.) that
+/// produce the tensor being stored into a single `iree_linalg_ext.map_scatter`
+/// op.
+///
+/// This transformation will also combine `tensor.pad` ops into the map_scatter
+/// op, by moving the writing of the padding values to after the store_to_memref
+/// op, and writing the padding values directly to the output buffer of the
+/// store_to_memref. The writes of the pad values will be distributed based on
+/// the `DistributionConfig`s returned by `padDistributionConfigFn`, and then
+/// the inner distributed tile will be tiled to a loop nest of memref.store ops.
 LogicalResult
 combineLayoutTransformation(MLIRContext *ctx, FunctionOpInterface funcOp,
-                            DistributionConfigFn distributionConfigFn);
+                            PadDistributionConfigFn padDistributionConfigFn);
 
 } // namespace mlir::iree_compiler
 #endif // IREE_COMPILER_CODEGEN_COMMON_COMBINELAYOUTTRANSFORMATION_H_

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
@@ -61,6 +61,7 @@ iree_compiler_cc_library(
         "GPUApplyTilingLevel.cpp",
         "GPUBubbleResourceCasts.cpp",
         "GPUCheckResourceUsage.cpp",
+        "GPUCombineLayoutTransformation.cpp",
         "GPUCombineValueBarriers.cpp",
         "GPUCreateFastSlowPath.cpp",
         "GPUDistribute.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/BUILD.bazel
@@ -116,6 +116,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Utils",
         "//compiler/src/iree/compiler/Codegen/Utils:VectorOpUtils",
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
+        "//compiler/src/iree/compiler/Dialect/LinalgExt/Transforms",
         "//compiler/src/iree/compiler/Dialect/LinalgExt/Utils",
         "//compiler/src/iree/compiler/Dialect/TensorExt/IR",
         "//compiler/src/iree/compiler/Utils",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
@@ -54,6 +54,7 @@ iree_cc_library(
     "GPUApplyTilingLevel.cpp"
     "GPUBubbleResourceCasts.cpp"
     "GPUCheckResourceUsage.cpp"
+    "GPUCombineLayoutTransformation.cpp"
     "GPUCombineValueBarriers.cpp"
     "GPUCreateFastSlowPath.cpp"
     "GPUDistribute.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/CMakeLists.txt
@@ -145,6 +145,7 @@ iree_cc_library(
     iree::compiler::Codegen::Utils
     iree::compiler::Codegen::Utils::VectorOpUtils
     iree::compiler::Dialect::HAL::IR
+    iree::compiler::Dialect::LinalgExt::Transforms
     iree::compiler::Dialect::LinalgExt::Utils
     iree::compiler::Dialect::TensorExt::IR
     iree::compiler::Utils

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/GPUCombineLayoutTransformation.cpp
@@ -1,0 +1,73 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/CombineLayoutTransformation.h"
+#include "iree/compiler/Codegen/Common/GPU/Passes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Dialect/LinalgExt/Transforms/Transforms.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+
+#define DEBUG_TYPE "iree-codegen-gpu-combine-layout-transformation"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+#define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
+
+namespace mlir::iree_compiler {
+
+#define GEN_PASS_DEF_GPUCOMBINELAYOUTTRANSFORMATIONPASS
+#include "iree/compiler/Codegen/Common/GPU/Passes.h.inc"
+
+static SmallVector<DistributionConfig>
+gpuDistributionConfigFn(ArrayRef<int64_t> sizes, MLIRContext *ctx) {
+  // First level of distribution (workgroup).
+  DistributionConfig workgroupDistributionConfig;
+  workgroupDistributionConfig.tileSizes = SmallVector<int64_t>(sizes.size(), 1);
+  workgroupDistributionConfig.tileSizes.back() = 64;
+  workgroupDistributionConfig.mapping = llvm::map_to_vector(
+      llvm::seq<int64_t>(sizes.size()), [&](int64_t dim) -> Attribute {
+        switch (dim) {
+        case 0:
+        case 1:
+        case 2:
+          return IREE::Codegen::WorkgroupMappingAttr::get(
+              ctx, IREE::Codegen::symbolizeWorkgroupId(dim).value());
+        default:
+          return IREE::Codegen::WorkgroupMappingAttr::get(
+              ctx, IREE::Codegen::WorkgroupId::IdZ, dim - 2);
+        }
+      });
+  // Second level of distribution (thread).
+  DistributionConfig threadDistributionConfig;
+  threadDistributionConfig.tileSizes = SmallVector<int64_t>(sizes.size(), 1);
+  threadDistributionConfig.mapping = llvm::map_to_vector(
+      llvm::reverse(llvm::seq<int64_t>(sizes.size())),
+      [&](int64_t idx) -> Attribute {
+        unsigned mappingId =
+            static_cast<unsigned>(gpu::MappingId::LinearDim0) + idx;
+        return gpu::GPUThreadMappingAttr::get(
+            ctx, static_cast<gpu::MappingId>(mappingId));
+      });
+  return {workgroupDistributionConfig, threadDistributionConfig};
+}
+
+namespace {
+
+struct GPUCombineLayoutTransformationPass final
+    : impl::GPUCombineLayoutTransformationPassBase<
+          GPUCombineLayoutTransformationPass> {
+  using impl::GPUCombineLayoutTransformationPassBase<
+      GPUCombineLayoutTransformationPass>::
+      GPUCombineLayoutTransformationPassBase;
+
+  void runOnOperation() override {
+    if (failed(combineLayoutTransformation(&getContext(), getOperation(),
+                                           gpuDistributionConfigFn))) {
+      return signalPassFailure();
+    }
+  }
+};
+
+} // namespace
+} // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -30,6 +30,18 @@ def GPUCheckResourceUsagePass :
   let constructor = "mlir::iree_compiler::createGPUCheckResourceUsagePass()";
 }
 
+def GPUCombineLayoutTransformationPass :
+    InterfacePass<"iree-codegen-gpu-combine-layout-transformation", "mlir::FunctionOpInterface"> {
+  let summary =
+    "Combines layout transformation operations on the results of a dispatch into a single operation.";
+  let dependentDialects = [
+    "iree_compiler::IREE::LinalgExt::IREELinalgExtDialect",
+    "gpu::GPUDialect",
+    "scf::SCFDialect",
+    "tensor::TensorDialect"
+  ];
+}
+
 def GPUCombineValueBarriersPass :
     Pass<"iree-codegen-gpu-combine-value-barriers", ""> {
   let summary = "Combines `iree_gpu.value_barrier` ops";

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -33,7 +33,15 @@ def GPUCheckResourceUsagePass :
 def GPUCombineLayoutTransformationPass :
     InterfacePass<"iree-codegen-gpu-combine-layout-transformation", "mlir::FunctionOpInterface"> {
   let summary =
-    "Combines layout transformation operations on the results of a dispatch into a single operation.";
+    "Combines layout transformation operations into a single map_scatter operation.";
+  let description = [{
+    Starting from iree_codegen.store_to_memref ops, iteratively combine producer
+    layout/indexing transformation ops (linalg.transpose, tensor.collapse_shape,
+    etc.) into a single iree_linalg_ext.map_scatter operation. For tensor.pad
+    ops, the writing of pad values is distributed to workgroups and threads, and
+    then the padding values are written directly to the output buffer of the
+    store_to_memref op.
+  }];
   let dependentDialects = [
     "iree_compiler::IREE::LinalgExt::IREELinalgExtDialect",
     "gpu::GPUDialect",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/BUILD.bazel
@@ -24,6 +24,7 @@ iree_lit_test_suite(
             "gpu_apply_tiling_level.mlir",
             "gpu_bubble_resource_casts.mlir",
             "gpu_check_resource_usage.mlir",
+            "gpu_combine_layout_transformation.mlir",
             "gpu_create_fast_slow_path.mlir",
             "gpu_distribute.mlir",
             "gpu_distribute_copy_using_forall.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/CMakeLists.txt
@@ -20,6 +20,7 @@ iree_lit_test_suite(
     "gpu_apply_tiling_level.mlir"
     "gpu_bubble_resource_casts.mlir"
     "gpu_check_resource_usage.mlir"
+    "gpu_combine_layout_transformation.mlir"
     "gpu_combine_value_barriers.mlir"
     "gpu_create_fast_slow_path.mlir"
     "gpu_distribute.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_combine_layout_transformation.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_combine_layout_transformation.mlir
@@ -1,0 +1,43 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-codegen-gpu-combine-layout-transformation,canonicalize,cse))" -split-input-file %s | FileCheck %s
+
+func.func @fold_pad_op(%source : tensor<250xf32>, %result : memref<256xf32>) {
+  %cst = arith.constant 0.0 : f32
+  %padded = tensor.pad %source low[2] high[4] {
+  ^bb0(%arg0: index):
+    tensor.yield %cst : f32
+  } : tensor<250xf32> to tensor<256xf32>
+  iree_codegen.store_to_memref %padded, %result : tensor<256xf32> into memref<256xf32>
+  return
+}
+//       CHECK: #[[$MAP:.+]] = affine_map<(d0) -> (256, d0 + 64)>
+//       CHECK: #[[$MAP1:.+]] = affine_map<(d0, d1) -> (256, d1 + 64, d0 + 1)>
+// CHECK-LABEL: @fold_pad_op
+//  CHECK-SAME:   %[[SOURCE:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[RESULT:[a-zA-Z0-9_]+]]
+//   CHECK-DAG:   %[[PAD_VAL:.+]] = arith.constant 0.000000e+00 : f32
+//   CHECK-DAG:   %[[TRUE:.+]] = arith.constant true
+//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : index
+//   CHECK-DAG:   %[[C252:.+]] = arith.constant 252 : index
+//       CHECK:   %[[MAP_SCATTER_DEST:.+]] = tensor.empty() : tensor<256xf32>
+//       CHECK:   %[[MAP_SCATTER:.+]] = iree_linalg_ext.map_scatter
+//  CHECK-SAME:     %[[SOURCE]] into %[[MAP_SCATTER_DEST]] {
+//  CHECK-NEXT:   ^bb0(%[[IDX0:.+]]: index):
+//       CHECK:     iree_linalg_ext.yield %[[IDX0]], %[[TRUE]]
+//       CHECK:   } : tensor<250xf32> into tensor<256xf32> -> tensor<256xf32>
+//       CHECK:   iree_codegen.store_to_memref %[[MAP_SCATTER]], %[[RESULT]] : tensor<256xf32> into memref<256xf32>
+
+//       CHECK:   scf.forall (%[[WG_IV:.+]]) = (0) to (256) step (64) {
+//       CHECK:     %[[WG_TILE_UB:.+]] = affine.min #[[$MAP]](%[[WG_IV]])
+//       CHECK:     scf.forall (%[[THREAD_IV:.+]]) = (%[[WG_IV]]) to (%[[WG_TILE_UB]]) step (1) {
+//       CHECK:       %[[THREAD_TILE_UB:.+]] = affine.min #[[$MAP1]](%[[THREAD_IV]], %[[WG_IV]])
+//       CHECK:       scf.for %[[IDX:.+]] = %[[THREAD_IV]] to %[[THREAD_TILE_UB]] step %[[C1]] {
+//   CHECK-DAG:         %[[IS_LOW_PAD:.+]] = arith.cmpi ult, %[[IDX]], %[[C2]] : index
+//   CHECK-DAG:         %[[IS_HIGH_PAD:.+]] = arith.cmpi uge, %[[IDX]], %[[C252]] : index
+//   CHECK-DAG:         %[[IS_PAD:.+]] = arith.ori %[[IS_LOW_PAD]], %[[IS_HIGH_PAD]] : i1
+//       CHECK:         scf.if %[[IS_PAD]] {
+//  CHECK-NEXT:           memref.store %[[PAD_VAL]], %[[RESULT]][%[[IDX]]] : memref<256xf32>
+//  CHECK-NEXT:         }
+//  CHECK:            }
+//  CHECK:          } {mapping = [#gpu.thread<linear_dim_0>]}
+//  CHECK:        } {mapping = [#iree_codegen.workgroup_mapping<x>]}

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -129,6 +129,7 @@ def CombineLayoutTransformationPass :
     "Combines layout transformation operations on the results of a dispatch into a single operation.";
   let dependentDialects = [
     "iree_compiler::IREE::LinalgExt::IREELinalgExtDialect",
+    "scf::SCFDialect",
     "tensor::TensorDialect"
   ];
 }

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -126,7 +126,15 @@ def ConvertToDestinationPassingStylePass :
 def CombineLayoutTransformationPass :
     InterfacePass<"iree-codegen-combine-layout-transformation", "mlir::FunctionOpInterface"> {
   let summary =
-    "Combines layout transformation operations on the results of a dispatch into a single operation.";
+    "Combines layout transformation operations into a single map_scatter operation.";
+  let description = [{
+    Starting from iree_codegen.store_to_memref ops, iteratively combine producer
+    layout/indexing transformation ops (linalg.transpose, tensor.collapse_shape,
+    etc.) into a single iree_linalg_ext.map_scatter operation. For tensor.pad
+    ops, the writing of pad values is distributed to workgroups, and then the
+    padding values are written directly to the output buffer of the
+    store_to_memref op.
+  }];
   let dependentDialects = [
     "iree_compiler::IREE::LinalgExt::IREELinalgExtDialect",
     "scf::SCFDialect",

--- a/compiler/src/iree/compiler/Codegen/Common/test/combine_layout_transformation.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/combine_layout_transformation.mlir
@@ -104,6 +104,46 @@ func.func @no_fold_strided_extract_slice_op(%source : tensor<64xf32>, %result : 
 
 // -----
 
+func.func @fold_pad_op(%source : tensor<250xf32>, %result : memref<256xf32>) {
+  %cst = arith.constant 0.0 : f32
+  %padded = tensor.pad %source low[2] high[4] {
+  ^bb0(%arg0: index):
+    tensor.yield %cst : f32
+  } : tensor<250xf32> to tensor<256xf32>
+  iree_codegen.store_to_memref %padded, %result : tensor<256xf32> into memref<256xf32>
+  return
+}
+//       CHECK: #[[$MAP:.+]] = affine_map<(d0) -> (256, d0 + 64)>
+// CHECK-LABEL: @fold_pad_op
+//  CHECK-SAME:   %[[SOURCE:[a-zA-Z0-9_]+]]
+//  CHECK-SAME:   %[[RESULT:[a-zA-Z0-9_]+]]
+//   CHECK-DAG:   %[[PAD_VAL:.+]] = arith.constant 0.000000e+00 : f32
+//   CHECK-DAG:   %[[TRUE:.+]] = arith.constant true
+//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : index
+//   CHECK-DAG:   %[[C252:.+]] = arith.constant 252 : index
+//       CHECK:   %[[MAP_SCATTER_DEST:.+]] = tensor.empty() : tensor<256xf32>
+//       CHECK:   %[[MAP_SCATTER:.+]] = iree_linalg_ext.map_scatter
+//  CHECK-SAME:     %[[SOURCE]] into %[[MAP_SCATTER_DEST]] {
+//  CHECK-NEXT:   ^bb0(%[[IDX0:.+]]: index):
+//       CHECK:     iree_linalg_ext.yield %[[IDX0]], %[[TRUE]]
+//       CHECK:   } : tensor<250xf32> into tensor<256xf32> -> tensor<256xf32>
+//       CHECK:   iree_codegen.store_to_memref %[[MAP_SCATTER]], %[[RESULT]] : tensor<256xf32> into memref<256xf32>
+
+//       CHECK:   scf.forall (%[[WG_IV:.+]]) = (0) to (256) step (64) {
+//       CHECK:     %[[WG_TILE_UB:.+]] = affine.min #[[$MAP]](%[[WG_IV]])
+//       CHECK:     scf.for %[[IDX:.+]] = %[[WG_IV]] to %[[WG_TILE_UB]] step %[[C1]] {
+//   CHECK-DAG:       %[[IS_LOW_PAD:.+]] = arith.cmpi ult, %[[IDX]], %[[C2]] : index
+//   CHECK-DAG:       %[[IS_HIGH_PAD:.+]] = arith.cmpi uge, %[[IDX]], %[[C252]] : index
+//   CHECK-DAG:       %[[IS_PAD:.+]] = arith.ori %[[IS_LOW_PAD]], %[[IS_HIGH_PAD]] : i1
+//       CHECK:       scf.if %[[IS_PAD]] {
+//  CHECK-NEXT:         memref.store %[[PAD_VAL]], %[[RESULT]][%[[IDX]]] : memref<256xf32>
+//  CHECK-NEXT:       }
+//  CHECK:          }
+//  CHECK:        } {mapping = [#iree_codegen.workgroup_mapping<x>]}
+
+// -----
+
 func.func @fold_unpack_op(%source : tensor<?x?x128x128xf32>, %result : memref<?x?xf32>) {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
@@ -155,19 +195,47 @@ func.func @fold_pack_op(%source : tensor<250x250xf32>, %result : memref<2x2x128x
   iree_codegen.store_to_memref %unpack, %result : tensor<2x2x128x128xf32> into memref<2x2x128x128xf32>
   return
 }
+//       CHECK: #[[$MAP:.+]] = affine_map<(d0) -> (256, d0 + 1)>
+//       CHECK: #[[$MAP1:.+]] = affine_map<(d0) -> (256, d0 + 64)>
 // CHECK-LABEL: @fold_pack_op
 //  CHECK-SAME:   %[[SOURCE:[a-zA-Z0-9_]+]]
 //  CHECK-SAME:   %[[RESULT:[a-zA-Z0-9_]+]]
 //   CHECK-DAG:   %[[TRUE:.+]] = arith.constant true
-//       CHECK:   %[[PAD:.+]] = tensor.pad %[[SOURCE]] low[0, 0] high[6, 6]
+//   CHECK-DAG:   %[[PAD_VAL:.+]] = arith.constant 0.000000e+00 : f32
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG:   %[[C250:.+]] = arith.constant 250 : index
 //       CHECK:   %[[MAP_SCATTER_DEST:.+]] = tensor.empty() : tensor<2x2x128x128xf32>
 //       CHECK:   %[[MAP_SCATTER:.+]] = iree_linalg_ext.map_scatter
-//  CHECK-SAME:     %[[PAD]] into %[[MAP_SCATTER_DEST]] {
+//  CHECK-SAME:     %[[SOURCE]] into %[[MAP_SCATTER_DEST]] {
 //  CHECK-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index):
 //       CHECK:     %[[DELINEARIZE0:.+]]:2 = affine.delinearize_index %[[IDX0]]
 //  CHECK-SAME:       into (2, 128) : index, index
 //       CHECK:     %[[DELINEARIZE1:.+]]:2 = affine.delinearize_index %[[IDX1]]
 //  CHECK-SAME:       into (2, 128) : index, index
 //       CHECK:     iree_linalg_ext.yield %[[DELINEARIZE0]]#0, %[[DELINEARIZE1]]#0, %[[DELINEARIZE0]]#1, %[[DELINEARIZE1]]#1, %[[TRUE]]
-//       CHECK:   } : tensor<256x256xf32> into tensor<2x2x128x128xf32> -> tensor<2x2x128x128xf32>
+//       CHECK:   } : tensor<250x250xf32> into tensor<2x2x128x128xf32> -> tensor<2x2x128x128xf32>
 //       CHECK:   iree_codegen.store_to_memref %[[MAP_SCATTER]], %[[RESULT]] : tensor<2x2x128x128xf32> into memref<2x2x128x128xf32>
+
+//       CHECK:   scf.forall (%[[WG_IV0:.+]], %[[WG_IV1:.+]]) = (0, 0) to (256, 256) step (1, 64) {
+//   CHECK-DAG:     %[[WG_TILE_UB0:.+]] = affine.min #[[$MAP]](%[[WG_IV0]])
+//   CHECK-DAG:     %[[WG_TILE_UB1:.+]] = affine.min #[[$MAP1]](%[[WG_IV1]])
+//       CHECK:     scf.for %[[IDX0:.+]] = %[[WG_IV0]] to %[[WG_TILE_UB0]] step %[[C1]] {
+//       CHECK:       scf.for %[[IDX1:.+]] = %[[WG_IV1]] to %[[WG_TILE_UB1]] step %[[C1]] {
+//   CHECK-DAG:         %[[EXPANDED_IDX0:.+]]:2 = affine.delinearize_index %[[IDX0]] into (2, 128) : index, index
+//   CHECK-DAG:         %[[EXPANDED_IDX1:.+]]:2 = affine.delinearize_index %[[IDX1]] into (2, 128) : index, index
+//   CHECK-DAG:         %[[IDX0_IS_LOW_PAD:.+]] = arith.cmpi ult, %[[IDX0]], %[[C0]] : index
+//   CHECK-DAG:         %[[IDX0_IS_HIGH_PAD:.+]] = arith.cmpi uge, %[[IDX0]], %[[C250]] : index
+//   CHECK-DAG:         %[[IDX0_IS_PAD:.+]] = arith.ori %[[IDX0_IS_LOW_PAD]], %[[IDX0_IS_HIGH_PAD]] : i1
+//   CHECK-DAG:         %[[IDX1_IS_LOW_PAD:.+]] = arith.cmpi ult, %[[IDX1]], %[[C0]] : index
+//   CHECK-DAG:         %[[IDX1_IS_HIGH_PAD:.+]] = arith.cmpi uge, %[[IDX1]], %[[C250]] : index
+//   CHECK-DAG:         %[[IDX1_IS_PAD:.+]] = arith.ori %[[IDX1_IS_LOW_PAD]], %[[IDX1_IS_HIGH_PAD]] : i1
+//   CHECK-DAG:         %[[IS_PAD:.+]] = arith.ori %[[IDX0_IS_PAD]], %[[IDX1_IS_PAD]] : i1
+//       CHECK:         scf.if %[[IS_PAD]] {
+//  CHECK-NEXT:           memref.store %[[PAD_VAL]], %[[RESULT]]
+//  CHECK-SAME:             [%[[EXPANDED_IDX0]]#0, %[[EXPANDED_IDX1]]#0, %[[EXPANDED_IDX0]]#1, %[[EXPANDED_IDX1]]#1]
+//  CHECK-SAME:             : memref<2x2x128x128xf32>
+//  CHECK-NEXT:         }
+//  CHECK:            }
+//  CHECK:          }
+//  CHECK:        } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}


### PR DESCRIPTION
Adds support to fold tensor.pad ops into map_scatter during CombineLayoutTransformation. This requires moving the writing of padding values directly to the output memref, which needs to be distributed and tiled to a scalar store of the padding value. The distribution of the pad is determined by a callback that returns a list of distribution tile sizes and mappings, so that different pass implementations can decide how to distribute the pad. By default, the padding is only distributed to workgroups.

A new implementation of the pass for GPU backends called `GPUCombineLayoutTransformation` is also added, which does both workgroup and thread distribution on the pad.