### PR TITLE
[ROCm] Set ABI version control variable correctly

### DIFF
--- a/compiler/plugins/target/ROCM/ROCMTargetUtils.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTargetUtils.cpp
@@ -136,7 +136,7 @@ LogicalResult setHIPGlobals(Location loc, llvm::Module *module,
   auto *int32Type = llvm::Type::getInt32Ty(module->getContext());
   overridePlatformGlobal(module, "__oclc_ISA_version", chipCode, int32Type);
 
-  overridePlatformGlobal(module, "__oclc_version", abiVersion, int32Type);
+  overridePlatformGlobal(module, "__oclc_ABI_version", abiVersion, int32Type);
 
   // Link oclc configurations as globals.
   auto *boolType = llvm::Type::getInt8Ty(module->getContext());


### PR DESCRIPTION
Testing of the load to LDS PR discovered that we were setting a non-existing `__oclc_version` global instead of the intened `__oclc_ABI_version` when populating the constants needed for the device libraries.