### PR TITLE
[Codegen] Make ReconcileTranslationInfo work with multiple exports

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
@@ -17,6 +17,8 @@
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Transforms/Transforms.h"
+#include "llvm/Support/Casting.h"
+#include "mlir/Analysis/CallGraph.h"
 #include "mlir/Dialect/Affine/Utils.h"
 #include "mlir/Dialect/Arith/Utils/Utils.h"
 
@@ -362,77 +364,108 @@ void ReconcileTranslationInfoPass::runOnOperation() {
   auto variantOp = getOperation();
   auto innerModuleOp = variantOp.getInnerModule();
 
+  // Get the symbol table of the inner module to lookup exported functions.
+  SymbolTable symbolTable(innerModuleOp);
+
+  // Construct the call-graph for the inner module. We traverse this when
+  // reconciling translation info.
+  CallGraph callGraph(innerModuleOp);
+
+  IRRewriter rewriter(&getContext());
   auto exportOps = variantOp.getOps<IREE::HAL::ExecutableExportOp>();
 
-  // reconciliation for multiple export ops is unsupported.
-  if (!llvm::hasSingleElement(exportOps)) {
-    return;
-  }
-  auto exportOp = *exportOps.begin();
-  IRRewriter rewriter(&getContext());
+  for (auto exportOp : exportOps) {
+    SmallVector<IREE::Codegen::TranslationInfoAttr> translationInfos;
+    auto rootFuncOp = llvm::dyn_cast_if_present<FunctionOpInterface>(
+        symbolTable.lookup(exportOp.getSymNameAttr()));
+    if (!rootFuncOp || rootFuncOp.isExternal()) {
+      // Skip external functions.
+      continue;
+    }
+    // Resolve workgroup distribution related `scf.forall` ops. Today only a
+    // single loop in the exported function is supported.
+    if (failed(resolveWorkgroupForAll(rewriter, rootFuncOp, distributeAlong))) {
+      variantOp.emitOpError(
+          "failed in iree-codegen-reconcile-translation-info pass");
+      return signalPassFailure();
+    }
 
-  SmallVector<IREE::Codegen::TranslationInfoAttr> translationInfos;
-  auto walkResult =
-      innerModuleOp->walk([&](FunctionOpInterface funcOp) -> WalkResult {
-        // Resolve workgroup distribution related `scf.forall` ops.
-        if (failed(resolveWorkgroupForAll(rewriter, funcOp, distributeAlong))) {
-          return failure();
+    std::queue<FunctionOpInterface> nodeQueue;
+    nodeQueue.push(rootFuncOp);
+
+    llvm::SmallDenseSet<FunctionOpInterface> visitedFunctions;
+
+    while (!nodeQueue.empty()) {
+      FunctionOpInterface funcOp = nodeQueue.front();
+      if (!visitedFunctions.insert(funcOp).second) {
+        rootFuncOp.emitOpError(
+            "recursive function call in translation info reconciliation");
+        return signalPassFailure();
+      }
+
+      if (CallGraphNode *node =
+              callGraph.lookupNode(&funcOp.getFunctionBody())) {
+        for (CallGraphNode::Edge callEdge : *node) {
+          auto calledFunc = callEdge.getTarget()
+                                ->getCallableRegion()
+                                ->getParentOfType<FunctionOpInterface>();
+          nodeQueue.push(calledFunc);
         }
+      }
+      nodeQueue.pop();
 
-        auto translationInfo = getTranslationInfo(funcOp);
-        if (!translationInfo) {
-          return WalkResult::advance();
-        }
+      auto translationInfo = getTranslationInfo(funcOp);
+      if (!translationInfo) {
+        // No translation info means nothing to reconcile.
+        continue;
+      }
+      translationInfos.push_back(translationInfo);
 
-        translationInfos.push_back(translationInfo);
-        // The following is moving the target-func-attrs specification from
-        // translation info into the func-like op. This is not the best
-        // place to do this, but the intent is after this pass all the
-        // lowering configs and translation infos will be deleted.
-        DictionaryAttr targetFuncAttrs = getTargetFuncAttrs(translationInfo);
-        if (targetFuncAttrs) {
-          funcOp->setAttr("llvm_func_attrs", targetFuncAttrs);
-        }
-        return WalkResult::advance();
-      });
-  if (walkResult.wasInterrupted()) {
-    variantOp.emitOpError(
-        "failed in iree-codegen-reconcile-translation-info pass");
-    return signalPassFailure();
-  }
+      // The following is moving the target-func-attrs specification from
+      // translation info into the func-like op. This is not the best
+      // place to do this, but the intent is after this pass all the
+      // lowering configs and translation infos will be deleted.
+      DictionaryAttr targetFuncAttrs = getTargetFuncAttrs(translationInfo);
+      if (targetFuncAttrs) {
+        funcOp->setAttr("llvm_func_attrs", targetFuncAttrs);
+      }
+    }
 
-  // Reconcile workgroup sizes.
-  FailureOr<SmallVector<int64_t>> reconciledWorkgroupSize =
-      reconcileWorkgroupSize(translationInfos);
-  if (failed(reconciledWorkgroupSize)) {
-    exportOp.emitOpError("failed to reconcile workgroup sizes");
-    return signalPassFailure();
-  }
-  if (reconciledWorkgroupSize->size() > 3) {
-    exportOp.emitOpError(
-        "reconciled workgroup size is greater than 3 (illegal)");
-    return signalPassFailure();
-  }
-  std::array<int64_t, 3> workgroupSize = {1, 1, 1};
-  for (auto [index, size] : llvm::enumerate(reconciledWorkgroupSize.value())) {
-    workgroupSize[index] = size;
-  }
-  auto workgroupSizeArrayAttr = rewriter.getIndexArrayAttr(workgroupSize);
-  exportOp.setWorkgroupSizeAttr(workgroupSizeArrayAttr);
+    // Reconcile workgroup sizes.
+    FailureOr<SmallVector<int64_t>> reconciledWorkgroupSize =
+        reconcileWorkgroupSize(translationInfos);
+    if (failed(reconciledWorkgroupSize)) {
+      exportOp.emitOpError("failed to reconcile workgroup sizes");
+      return signalPassFailure();
+    }
+    if (reconciledWorkgroupSize->size() > 3) {
+      exportOp.emitOpError(
+          "reconciled workgroup size is greater than 3 (illegal)");
+      return signalPassFailure();
+    }
+    std::array<int64_t, 3> workgroupSize = {1, 1, 1};
+    for (auto [index, size] :
+         llvm::enumerate(reconciledWorkgroupSize.value())) {
+      workgroupSize[index] = size;
+    }
+    auto workgroupSizeArrayAttr = rewriter.getIndexArrayAttr(workgroupSize);
+    exportOp.setWorkgroupSizeAttr(workgroupSizeArrayAttr);
 
-  // Reconcile subgroup sizes.
-  FailureOr<int64_t> reconciledSubgroupSize =
-      reconcileSubgroupSize(translationInfos);
-  if (failed(reconciledSubgroupSize)) {
-    exportOp.emitOpError("failed to reconcile subgroup size");
-    return signalPassFailure();
-  }
-  if (reconciledSubgroupSize.value() != int64_t()) {
-    exportOp.setSubgroupSizeAttr(
-        rewriter.getIndexAttr(reconciledSubgroupSize.value()));
+    // Reconcile subgroup sizes.
+    FailureOr<int64_t> reconciledSubgroupSize =
+        reconcileSubgroupSize(translationInfos);
+    if (failed(reconciledSubgroupSize)) {
+      exportOp.emitOpError("failed to reconcile subgroup size");
+      return signalPassFailure();
+    }
+    if (reconciledSubgroupSize.value() != int64_t()) {
+      exportOp.setSubgroupSizeAttr(
+          rewriter.getIndexAttr(reconciledSubgroupSize.value()));
+    }
   }
 
-  // Erase all the lowering configs and translation infos.
+  // Erase all the lowering configs and translation infos after we have finished
+  // processing all exported functions.
   innerModuleOp->walk([](Operation *op) {
     if (auto funcOp = dyn_cast<FunctionOpInterface>(op)) {
       eraseTranslationInfo(funcOp);

--- a/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
@@ -406,6 +406,10 @@ void ReconcileTranslationInfoPass::runOnOperation() {
       if (CallGraphNode *node =
               callGraph.lookupNode(&funcOp.getFunctionBody())) {
         for (CallGraphNode::Edge callEdge : *node) {
+          if (callEdge.getTarget()->isExternal()) {
+            // Skip external calls.
+            continue;
+          }
           auto calledFunc = callEdge.getTarget()
                                 ->getCallableRegion()
                                 ->getParentOfType<FunctionOpInterface>();

--- a/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info.mlir
@@ -172,20 +172,19 @@ hal.executable private @llvm_func_attrs {
         func.call @fn2() : () -> ()
         return
       }
-      func.func @fn1() attributes {translation_info = #iree_codegen.translation_info<pipeline = None, {llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>}  {
+      func.func @fn1() attributes {translation_info = #iree_codegen.translation_info<pipeline = None, {llvm_func_attrs = {"some-llvm-attr" = "2"}}>}  {
         return
       }
-      func.func @fn2() attributes {translation_info = #iree_codegen.translation_info<pipeline = None, {llvm_func_attrs = {"amdgpu-waves-per-eu" = "4"}}>} {
+      func.func @fn2() attributes {translation_info = #iree_codegen.translation_info<pipeline = None, {llvm_func_attrs = {"some-llvm-attr" = "4"}}>} {
         return
       }
     }
   }
 }
 
-// TODO: This test makes no sense if fn1 and fn2 are called together.
 // CHECK-LABEL: hal.executable private @llvm_func_attrs
-//       CHECK:   func.func @fn1() attributes {llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}
-//       CHECK:   func.func @fn2() attributes {llvm_func_attrs = {"amdgpu-waves-per-eu" = "4"}}
+//       CHECK:   func.func @fn1() attributes {llvm_func_attrs = {"some-llvm-attr" = "2"}}
+//       CHECK:   func.func @fn2() attributes {llvm_func_attrs = {"some-llvm-attr" = "4"}}
 
 // -----
 
@@ -523,7 +522,7 @@ hal.executable private @multi_export_scf_forall {
 // CHECK-SAME:     %[[ARG3:[a-zA-z0-9]+]]: index
 //  CHECK-DAG:   %[[WG_Y:.+]] = affine.apply #[[MAP0]]()[%[[ARG1]]]
 //  CHECK-DAG:   %[[WG_X:.+]] = affine.apply #[[MAP1]]()[%[[ARG2]]]
-//  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
 //      CHECK:   hal.return %[[WG_X]], %[[WG_Y]], %[[C1]]
 //      CHECK: hal.executable.export public @entry_point1 layout
 // CHECK-SAME:     %[[ARG1_1:[a-zA-z0-9]+]]: index
@@ -531,7 +530,7 @@ hal.executable private @multi_export_scf_forall {
 // CHECK-SAME:     %[[ARG3_1:[a-zA-z0-9]+]]: index
 //  CHECK-DAG:   %[[WG_Y_1:.+]] = affine.apply #[[MAP0]]()[%[[ARG1_1]]]
 //  CHECK-DAG:   %[[WG_X_1:.+]] = affine.apply #[[MAP1]]()[%[[ARG2_1]]]
-//  CHECK-DAG:   %[[C1_1:.+]] = arith.constant 1 : index
+//  CHECK-DAG:   %[[C1_1:.+]] = arith.constant 1
 //      CHECK:   hal.return %[[WG_X_1]], %[[WG_Y_1]], %[[C1_1]]
 
 //      CHECK: func @entry_point0()

--- a/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info.mlir
@@ -7,6 +7,11 @@ hal.executable private @reconcile_workgroup_size {
   hal.executable.variant public @reconcile_workgroup_size target(#hal.executable.target<"", "", {}>) {
     hal.executable.export public @entry_point layout(#pipeline_layout)
     builtin.module {
+      func.func @entry_point() attributes {translation_info = #iree_codegen.translation_info<pipeline = None workgroup_size = [4]>}  {
+        func.call @fn1() : () -> ()
+        func.call @fn2() : () -> ()
+        return
+      }
       func.func @fn1() attributes {translation_info = #iree_codegen.translation_info<pipeline = None workgroup_size = [4]>}  {
         return
       }
@@ -29,6 +34,11 @@ hal.executable private @single_translation_info {
   hal.executable.variant public @single_translation_info target(#hal.executable.target<"", "", {}>) {
     hal.executable.export public @entry_point layout(#pipeline_layout)
     builtin.module {
+      func.func @entry_point()  {
+        func.call @fn1() : () -> ()
+        func.call @fn2() : () -> ()
+        return
+      }
       func.func @fn1() attributes {translation_info = #iree_codegen.translation_info<pipeline = None workgroup_size = [4]>}  {
         return
       }
@@ -52,6 +62,11 @@ hal.executable private @err_mistmatched_workgroup_size {
     // expected-error @+1 {{failed to reconcile workgroup sizes}}
     hal.executable.export public @entry_point layout(#pipeline_layout)
     builtin.module {
+      func.func @entry_point()  {
+        func.call @fn1() : () -> ()
+        func.call @fn2() : () -> ()
+        return
+      }
       func.func @fn1() attributes {translation_info = #iree_codegen.translation_info<pipeline = None workgroup_size = [4]>}  {
         return
       }
@@ -72,6 +87,11 @@ hal.executable private @err_mistmatched_workgroup_size2 {
     // expected-error @+1 {{failed to reconcile workgroup sizes}}
     hal.executable.export public @entry_point layout(#pipeline_layout)
     builtin.module {
+      func.func @entry_point()  {
+        func.call @fn1() : () -> ()
+        func.call @fn2() : () -> ()
+        return
+      }
       func.func @fn1() attributes {translation_info = #iree_codegen.translation_info<pipeline = None workgroup_size = [4]>}  {
         return
       }
@@ -91,6 +111,11 @@ hal.executable private @reconcile_subgroup_size {
   hal.executable.variant public @reconcile_subgroup_size target(#hal.executable.target<"", "", {}>) {
     hal.executable.export public @entry_point layout(#pipeline_layout)
     builtin.module {
+      func.func @entry_point()  {
+        func.call @fn1() : () -> ()
+        func.call @fn2() : () -> ()
+        return
+      }
       func.func @fn1() attributes {translation_info = #iree_codegen.translation_info<pipeline = None subgroup_size = 32>}  {
         return
       }
@@ -111,20 +136,23 @@ hal.executable private @reconcile_subgroup_size {
 ]>
 hal.executable private @err_reconcile_subgroup_size {
   hal.executable.variant public @err_reconcile_subgroup_size target(#hal.executable.target<"", "", {}>) {
+    // expected-error @+1 {{failed to reconcile subgroup size}}
     hal.executable.export public @entry_point layout(#pipeline_layout)
     builtin.module {
+      func.func @entry_point()  {
+        func.call @fn1() : () -> ()
+        func.call @fn2() : () -> ()
+        return
+      }
       func.func @fn1() attributes {translation_info = #iree_codegen.translation_info<pipeline = None subgroup_size = 32>}  {
         return
       }
-      func.func @fn2() attributes {translation_info = #iree_codegen.translation_info<pipeline = None subgroup_size = 32>} {
+      func.func @fn2() attributes {translation_info = #iree_codegen.translation_info<pipeline = None subgroup_size = 64>} {
         return
       }
     }
   }
 }
-// CHECK-LABEL: hal.executable private @err_reconcile_subgroup_size
-//       CHECK: hal.executable.export public @entry_point
-//  CHECK-SAME:     subgroup_size = 32 : index
 
 // -----
 
@@ -133,8 +161,17 @@ hal.executable private @err_reconcile_subgroup_size {
 ]>
 hal.executable private @llvm_func_attrs {
   hal.executable.variant public @llvm_func_attrs target(#hal.executable.target<"", "", {}>) {
-    hal.executable.export public @entry_point layout(#pipeline_layout)
+    hal.executable.export public @entry_point1 layout(#pipeline_layout)
+    hal.executable.export public @entry_point2 layout(#pipeline_layout)
     builtin.module {
+      func.func @entry_point1()  {
+        func.call @fn1() : () -> ()
+        return
+      }
+      func.func @entry_point2()  {
+        func.call @fn2() : () -> ()
+        return
+      }
       func.func @fn1() attributes {translation_info = #iree_codegen.translation_info<pipeline = None, {llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}>}  {
         return
       }
@@ -144,6 +181,8 @@ hal.executable private @llvm_func_attrs {
     }
   }
 }
+
+// TODO: This test makes no sense if fn1 and fn2 are called together.
 // CHECK-LABEL: hal.executable private @llvm_func_attrs
 //       CHECK:   func.func @fn1() attributes {llvm_func_attrs = {"amdgpu-waves-per-eu" = "2"}}
 //       CHECK:   func.func @fn2() attributes {llvm_func_attrs = {"amdgpu-waves-per-eu" = "4"}}
@@ -431,3 +470,77 @@ hal.executable private @no_loop_default_workgroup_count {
 //      CHECK:   hal.return %[[C1]], %[[C1]], %[[C1]]
 //      CHECK: func @no_loop_default_workgroup_count()
 // CHECK-NEXT:   return
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<constants = 3, bindings = [
+    #hal.pipeline.binding<storage_buffer>]>
+hal.executable private @multi_export_scf_forall {
+  hal.executable.variant public @multi_export_scf_forall target(#hal.executable.target<"", "", {}>) {
+    hal.executable.export public @entry_point0 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2, %arg3
+      hal.return %x, %y, %z : index, index, index
+    }
+    hal.executable.export public @entry_point1 layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2, %arg3
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @entry_point0() {
+        %cst0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+        %cst1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
+        %cst2 = hal.interface.constant.load layout(#pipeline_layout) ordinal(2) : index
+        %0 = iree_tensor_ext.dispatch.workload.ordinal %cst0, 0 : index
+        %1 = iree_tensor_ext.dispatch.workload.ordinal %cst1, 1 : index
+        %2 = iree_tensor_ext.dispatch.workload.ordinal %cst2, 2 : index
+        scf.forall (%arg0, %arg1) = (0, 0) to (%0, %1) step(64, 32) {
+          "use0"(%arg0, %arg1) : (index, index) -> ()
+          scf.forall.in_parallel {}
+        } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
+        return
+      }
+      func.func @entry_point1() {
+        %cst0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+        %cst1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
+        %cst2 = hal.interface.constant.load layout(#pipeline_layout) ordinal(2) : index
+        %0 = iree_tensor_ext.dispatch.workload.ordinal %cst0, 0 : index
+        %1 = iree_tensor_ext.dispatch.workload.ordinal %cst1, 1 : index
+        %2 = iree_tensor_ext.dispatch.workload.ordinal %cst2, 2 : index
+        scf.forall (%arg0, %arg1) = (0, 0) to (%0, %1) step(64, 32) {
+          "use1"(%arg0, %arg1) : (index, index) -> ()
+          scf.forall.in_parallel {}
+        } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
+        return
+      }
+    }
+  }
+}
+//  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)
+//  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 32)
+//      CHECK: hal.executable.export public @entry_point0 layout
+// CHECK-SAME:     %[[ARG1:[a-zA-z0-9]+]]: index
+// CHECK-SAME:     %[[ARG2:[a-zA-z0-9]+]]: index
+// CHECK-SAME:     %[[ARG3:[a-zA-z0-9]+]]: index
+//  CHECK-DAG:   %[[WG_Y:.+]] = affine.apply #[[MAP0]]()[%[[ARG1]]]
+//  CHECK-DAG:   %[[WG_X:.+]] = affine.apply #[[MAP1]]()[%[[ARG2]]]
+//  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//      CHECK:   hal.return %[[WG_X]], %[[WG_Y]], %[[C1]]
+//      CHECK: hal.executable.export public @entry_point1 layout
+// CHECK-SAME:     %[[ARG1_1:[a-zA-z0-9]+]]: index
+// CHECK-SAME:     %[[ARG2_1:[a-zA-z0-9]+]]: index
+// CHECK-SAME:     %[[ARG3_1:[a-zA-z0-9]+]]: index
+//  CHECK-DAG:   %[[WG_Y_1:.+]] = affine.apply #[[MAP0]]()[%[[ARG1_1]]]
+//  CHECK-DAG:   %[[WG_X_1:.+]] = affine.apply #[[MAP1]]()[%[[ARG2_1]]]
+//  CHECK-DAG:   %[[C1_1:.+]] = arith.constant 1 : index
+//      CHECK:   hal.return %[[WG_X_1]], %[[WG_Y_1]], %[[C1_1]]
+
+//      CHECK: func @entry_point0()
+//  CHECK-DAG:   hal.interface.workgroup.id[1]
+//  CHECK-DAG:   hal.interface.workgroup.id[0]
+//  CHECK-NOT:   scf.forall
+//      CHECK:   "use0"
+//      CHECK: func @entry_point1()
+//  CHECK-DAG:   hal.interface.workgroup.id[1]
+//  CHECK-DAG:   hal.interface.workgroup.id[0]
+//  CHECK-NOT:   scf.forall
+//      CHECK:   "use1"


### PR DESCRIPTION
Symbol uniqueness guarantees that exports -> functions is injective (and bijective with public functions) so we can greedily reconcile translation info for each export. It is, however, possible for multiple publicly exported functions to transiently call a shared function which needs to resolve with consistent translation info (workgroup/subgroup size).

To support the kind of code we generate today, this works in 2 steps. Foreach export:
  1. Resolve workgroup count from the immediately exported function (guaranteed consistent by bijection). This means we don't support transiently distributed function calls yet.
  2. Walk the callgraph to find all locally annotated global kernel parameters (subgroup/workgroup size) and make sure they are consistent per export.