### PR TITLE
[Codegen][ROCDL] Drop nominal support for dynamic shared mem

### DIFF
--- a/compiler/plugins/target/ROCM/ROCMTarget.cpp
+++ b/compiler/plugins/target/ROCM/ROCMTarget.cpp
@@ -828,12 +828,6 @@ protected:
         blockDims.z = cast<IntegerAttr>(workgroupSize[2]).getInt();
       }
 
-      uint32_t blockSharedMemorySize = 0;
-      if (std::optional<APInt> workgroupLocalMemoryAttr =
-              exportOp.getWorkgroupLocalMemory()) {
-        blockSharedMemorySize = workgroupLocalMemoryAttr->getSExtValue();
-      }
-
       auto layoutAttr = exportOp.getLayoutAttr();
       uint32_t constantCount = static_cast<uint32_t>(layoutAttr.getConstants());
       SmallVector<iree_hal_hip_BindingBits_enum_t> bindingFlags;
@@ -856,8 +850,6 @@ protected:
       iree_hal_hip_ExportDef_module_ordinal_add(builder, 0); // always 0 today
       iree_hal_hip_ExportDef_kernel_name_add(builder, kernelNameRef);
       iree_hal_hip_ExportDef_block_dims_add(builder, &blockDims);
-      iree_hal_hip_ExportDef_block_shared_memory_size_add(
-          builder, blockSharedMemorySize);
       iree_hal_hip_ExportDef_constant_count_add(builder, constantCount);
       iree_hal_hip_ExportDef_binding_flags_add(builder, bindingFlagsRef);
       iree_hal_hip_ExportDef_debug_info_add(builder, exportDebugInfos[ordinal]);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
@@ -32,7 +32,7 @@ namespace mlir::iree_compiler {
 
 void ConvertToDynamicSharedMemory(ModuleOp moduleOp) {
   SymbolTableCollection symbolTableCollection;
-  // Collect all the adressOfOps to static shared memory globals.
+  // Collect all the addressOfOps to static shared memory globals.
   SmallVector<LLVM::AddressOfOp> addressOfOps;
   moduleOp.walk([&](LLVM::AddressOfOp addressOfOp) {
     // Check that the global associated with this addressOfOp has shared memory
@@ -91,6 +91,18 @@ void ConvertToDynamicSharedMemory(ModuleOp moduleOp) {
     for (auto exportOp : variantOp.getExportOps()) {
       exportOp->setAttr(exportOp.getWorkgroupLocalMemoryAttrName(),
                         builder.getIndexAttr(numberOfBytes));
+    }
+  }
+}
+
+void setSharedMemoryAlignment(ModuleOp moduleOp, uint64_t newAlignment) {
+  for (auto global : moduleOp.getOps<LLVM::GlobalOp>()) {
+    if (global.getAddrSpace() == 3) {
+      uint64_t baseAlignment = 0;
+      if (std::optional<uint64_t> alignment = global.getAlignment()) {
+        baseAlignment = alignment.value();
+      }
+      global.setAlignment(std::max<uint64_t>(baseAlignment, newAlignment));
     }
   }
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.h
@@ -29,6 +29,8 @@ void populateConvertSharedMemoryAllocOps(RewritePatternSet &patterns);
 
 void ConvertToDynamicSharedMemory(ModuleOp moduleOp);
 
+void setSharedMemoryAlignment(ModuleOp moduleOp, uint64_t newAlignment);
+
 using MemorySpaceMapping =
     std::function<unsigned(gpu::AddressSpace gpuAddressSpace)>;
 void populateGpuMemorySpaceAttributeConversions(

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -339,9 +339,10 @@ struct ConvertToROCDLPass final
     }
 
     LDBG("After converting to rocdl\n" << m);
-    ConvertToDynamicSharedMemory(m);
 
-    LDBG("After converting to dynamic shared memory\n" << m);
+    setSharedMemoryAlignment(m, 16);
+
+    LDBG("After updating shared memory alignments\n" << m);
   }
 };
 } // namespace mlir::iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -340,6 +340,10 @@ struct ConvertToROCDLPass final
 
     LDBG("After converting to rocdl\n" << m);
 
+    // 16 is the maximum relevant alignment for all AMD GPUs. Unceremoniously
+    // set it to 16 as all of our allocations almost always have much greater
+    // alignment than this.
+    // TODO(qedawkins): Set this much earlier when we introduce the allocations.
     setSharedMemoryAlignment(m, 16);
 
     LDBG("After updating shared memory alignments\n" << m);

--- a/runtime/src/iree/hal/drivers/hip/dynamic_symbol_tables.h
+++ b/runtime/src/iree/hal/drivers/hip/dynamic_symbol_tables.h
@@ -36,6 +36,8 @@ IREE_HAL_HIP_REQUIRED_PFN_DECL(hipEventRecord, hipEvent_t, hipStream_t)
 IREE_HAL_HIP_REQUIRED_PFN_DECL(hipEventSynchronize, hipEvent_t)
 IREE_HAL_HIP_REQUIRED_PFN_DECL(hipFree, void *)
 IREE_HAL_HIP_REQUIRED_PFN_DECL(hipFreeAsync, void *, hipStream_t)
+IREE_HAL_HIP_REQUIRED_PFN_DECL(hipFuncGetAttribute, int *, hipFuncAttribute,
+                               const void *)
 IREE_HAL_HIP_REQUIRED_PFN_DECL(hipFuncSetAttribute, const void *,
                                hipFuncAttribute, int)
 IREE_HAL_HIP_REQUIRED_PFN_DECL(hipGetDeviceCount, int *)

--- a/runtime/src/iree/hal/drivers/hip/graph_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/hip/graph_command_buffer.c
@@ -815,7 +815,6 @@ static iree_status_t iree_hal_hip_graph_command_buffer_dispatch(
       .gridDim.z = workgroup_count[2],
       .func = kernel_params->function,
       .kernelParams = params_ptr,
-      .sharedMemBytes = kernel_params->block_shared_memory_size,
   };
 
   if (command_buffer->graph_node_count >=

--- a/runtime/src/iree/hal/drivers/hip/native_executable.h
+++ b/runtime/src/iree/hal/drivers/hip/native_executable.h
@@ -37,7 +37,6 @@ typedef struct iree_hal_hip_kernel_params_t {
   uint32_t binding_count;
 
   uint32_t block_dims[3];
-  uint32_t block_shared_memory_size;
 
   IREE_TRACE(iree_hal_hip_kernel_debug_info_t debug_info;)
 } iree_hal_hip_kernel_params_t;

--- a/runtime/src/iree/hal/drivers/hip/stream_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/hip/stream_command_buffer.c
@@ -578,8 +578,7 @@ static iree_status_t iree_hal_hip_stream_command_buffer_dispatch(
           kernel_params->function, workgroup_count[0], workgroup_count[1],
           workgroup_count[2], kernel_params->block_dims[0],
           kernel_params->block_dims[1], kernel_params->block_dims[2],
-          kernel_params->block_shared_memory_size, command_buffer->hip_stream,
-          params_ptr, NULL),
+          /*sharedMemBytes=*/0, command_buffer->hip_stream, params_ptr, NULL),
       "hipModuleLaunchKernel");
 
   IREE_HAL_STREAM_TRACE_ZONE_END(command_buffer->tracing_context,

--- a/runtime/src/iree/schemas/hip_executable_def.fbs
+++ b/runtime/src/iree/schemas/hip_executable_def.fbs
@@ -38,7 +38,7 @@ table ExportDef {
   block_dims:BlockDims;
 
   // Size of dynamic shared memory per block.
-  block_shared_memory_size:uint32;
+  block_shared_memory_size:uint32 (deprecated);
 
   // Total number of 32-bit push constants used by the export.
   constant_count:uint32;


### PR DESCRIPTION
This was introduced for CUDA to work around static allocation limits (see #8317) and then subsequently cloned for ROCM. There is no such allocation limit on the AMD side and we don't actually support dynamic shared memory, so we can drop it.

Immediately this fixes issues where multiple exported functions will request the sum of the memory required across all functions because the dynamic symbol obfuscates the actual required amount.

To avoid regressions, this matches the current behavior of forcing all shared memory allocations to be aligned by 16. Runtime
support for dynamic shared is dropped and the `block_shared_memory_size` field in the flatbuffer is marked as deprecated. To
retain load time checking of shared memory resource constraints, we now query exported functions directly using `hipFuncGetAttribute(..., HIP_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES)`.