### PR TITLE
[VectorExt] Vectorize `iree_linalg_ext.gather`

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GenericVectorization.cpp
@@ -126,6 +126,8 @@ void GenericVectorizationPass::runOnOperation() {
     } else if (enableVectorMasking &&
                isa<linalg::PackOp, linalg::UnPackOp>(op)) {
       candidates.push_back(op);
+    } else if (isa<IREE::LinalgExt::GatherOp>(op)) {
+      candidates.push_back(op);
     }
   });
 
@@ -165,6 +167,9 @@ void GenericVectorizationPass::runOnOperation() {
       (void)IREE::VectorExt::vectorizeGatherLikeGenericToTransferGather(
           rewriter, cast<linalg::GenericOp>(op), vectorSizes, scalableVecDims,
           vectorizeGatherAccesses);
+    } else if (auto gatherOp = dyn_cast<IREE::LinalgExt::GatherOp>(op)) {
+      (void)IREE::VectorExt::vectorizeLinalgExtGatherToTransferGather(rewriter,
+                                                                      gatherOp);
     } else {
       (void)linalg::vectorize(rewriter, op, vectorSizes, scalableVecDims,
                               vectorizeGatherAccesses);

--- a/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/generic_vectorization.mlir
@@ -703,3 +703,16 @@ func.func @multi_extract(%storage : !storage, %storage2: !storage, %ind0: !ind0,
 
 // CHECK-GATHER-LABEL: @multi_extract
 // CHECK-GATHER-COUNT-2: transfer_gather
+
+// -----
+
+func.func @linalg_ext_gather(%source : tensor<1024x128xi32>, %indices : tensor<10xi32>) -> (tensor<10x128xi32>) {
+  %empty = tensor.empty() : tensor<10x128xi32>
+  %result = iree_linalg_ext.gather dimension_map = [0]
+                          ins(%source, %indices : tensor<1024x128xi32>, tensor<10xi32>)
+                          outs(%empty: tensor<10x128xi32>) -> tensor<10x128xi32>
+  return %result : tensor<10x128xi32>
+}
+
+// CHECK-LABEL: @linalg_ext_gather
+//       CHECK:   transfer_gather

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/BUILD.bazel
@@ -47,6 +47,7 @@ iree_compiler_cc_library(
     deps = [
         ":PassesIncGen",
         "//compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR:IREEVectorExtDialect",
+        "//compiler/src/iree/compiler/Dialect/LinalgExt/IR",
         "//compiler/src/iree/compiler/Dialect/LinalgExt/Utils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/CMakeLists.txt
@@ -47,6 +47,7 @@ iree_cc_library(
     MLIRVectorTransforms
     MLIRVectorUtils
     iree::compiler::Codegen::Dialect::VectorExt::IR::IREEVectorExtDialect
+    iree::compiler::Dialect::LinalgExt::IR
     iree::compiler::Dialect::LinalgExt::Utils
   PUBLIC
 )

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/Transforms.h
@@ -7,6 +7,7 @@
 #ifndef IREE_COMPILER_CODEGEN_DIALECT_VECTOR_EXT_TRANSFORMS_TRANSFORMS_H_
 #define IREE_COMPILER_CODEGEN_DIALECT_VECTOR_EXT_TRANSFORMS_TRANSFORMS_H_
 
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -17,6 +18,10 @@ LogicalResult vectorizeGatherLikeGenericToTransferGather(
     RewriterBase &rewriter, linalg::GenericOp linalgOp,
     ArrayRef<int64_t> vectorSizes = {}, ArrayRef<bool> scalableVecDims = {},
     bool vectorizeNDExtract = false);
+
+LogicalResult
+vectorizeLinalgExtGatherToTransferGather(RewriterBase &rewriter,
+                                         IREE::LinalgExt::GatherOp gatherOp);
 
 void populateVectorTransferGatherLoweringPatterns(RewritePatternSet &patterns);
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorizeIREEVectorExtOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/VectorizeIREEVectorExtOps.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtDialect.h"
 #include "iree/compiler/Codegen/Dialect/VectorExt/Transforms/Passes.h"
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
@@ -485,6 +486,74 @@ LogicalResult vectorizeGatherLikeGenericToTransferGather(
     return failure();
   }
 
+  return success();
+}
+
+LogicalResult
+vectorizeLinalgExtGatherToTransferGather(RewriterBase &rewriter,
+                                         IREE::LinalgExt::GatherOp gatherOp) {
+
+  // TODO: need to split the innermost dim of `indices` into `indexDepth`
+  // vectors so that each independent index can be passed to the
+  // iree_vector_ext.transfer_gather op.
+  if (gatherOp.getIndexDepth() != 1) {
+    return failure();
+  }
+
+  // TODO: There is no 1-to-1 conversion between `iree_linalg_ext.gather` and
+  // `iree_vector_ext.transfer_gather` if the batch rank is > 1. Maybe support
+  // unrolling the batch dimension in the future.
+  if (gatherOp.getBatchRank() > 1) {
+    return failure();
+  }
+
+  auto loc = gatherOp.getLoc();
+  RewriterBase::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(gatherOp);
+
+  ShapedType indicesTy = gatherOp.getIndicesType();
+  ShapedType gatherTy = gatherOp.getOutputType();
+  ShapedType sourceTy = gatherOp.getSourceType();
+
+  auto gatherVectorTy =
+      VectorType::get(gatherTy.getShape(), gatherTy.getElementType());
+  // Rank-reduced to remove the innermost unit dim.
+  auto indicesVecTy =
+      VectorType::get(indicesTy.getShape().take_front(gatherOp.getBatchRank()),
+                      rewriter.getIndexType());
+
+  // Read `indices` tensor via `vector.transfer_read` into a vector of index
+  // elem type.
+  Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  Value indicesVec = rewriter.create<vector::TransferReadOp>(
+      loc, indicesVecTy, gatherOp.getIndices(),
+      SmallVector<Value>(indicesTy.getRank(), zero));
+
+  // Create transfer_gather op
+  SmallVector<Value> baseIndices(sourceTy.getRank(), zero);
+  SmallVector<bool> indexed(sourceTy.getRank(), false);
+  indexed[0] = true;
+  auto inBounds =
+      rewriter.getBoolArrayAttr(SmallVector<bool>(sourceTy.getRank(), true));
+  auto indexedMaps = rewriter.getAffineMapArrayAttr(SmallVector<AffineMap>(
+      1,
+      rewriter.getMultiDimIdentityMap(sourceTy.getRank()).getMajorSubMap(1)));
+  Value padding = rewriter.create<arith::ConstantOp>(
+      loc, rewriter.getZeroAttr(gatherTy.getElementType()));
+
+  auto transferGatherOp = rewriter.create<IREE::VectorExt::TransferGatherOp>(
+      loc, gatherVectorTy, gatherOp.getSource(), baseIndices,
+      ValueRange{indicesVec}, rewriter.getBoolArrayAttr(indexed), indexedMaps,
+      rewriter.getMultiDimIdentityMap(gatherTy.getRank()), padding,
+      /*mask=*/Value(), inBounds);
+
+  // Write back into tensor.
+  auto emptyOp = rewriter.create<tensor::EmptyOp>(loc, gatherTy.getShape(),
+                                                  gatherTy.getElementType());
+  SmallVector<Value> writeIndices(gatherTy.getRank(), zero);
+  auto writeOp = rewriter.create<vector::TransferWriteOp>(
+      loc, transferGatherOp.getResult(), emptyOp, writeIndices);
+  rewriter.replaceOp(gatherOp, writeOp);
   return success();
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/test/vectorize_vector_ext_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/Transforms/test/vectorize_vector_ext_ops.mlir
@@ -74,3 +74,73 @@ func.func @vectorize_matmul_dyn_parallel(%A: tensor<?x64xf32>,
 
 // CHECK-DAG: %[[OPMASK:.+]]  = vector.create_mask %[[ADIM]], %[[BDIM]], %c64 : vector<64x64x64xi1>
 // CHECK-DAG: vector.mask %[[OPMASK]] { vector.contract {{.*}} %[[A]]
+
+// -----
+
+func.func @linalg_ext_gather(%source : tensor<1024x128xi32>, %indices : tensor<10xi32>) -> (tensor<10x128xi32>) {
+  %empty = tensor.empty() : tensor<10x128xi32>
+  %result = iree_linalg_ext.gather dimension_map = [0]
+    ins(%source, %indices : tensor<1024x128xi32>, tensor<10xi32>)
+    outs(%empty: tensor<10x128xi32>) -> tensor<10x128xi32>
+  return %result : tensor<10x128xi32>
+}
+
+// CHECK-LABEL: @linalg_ext_gather
+//  CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+//  CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
+//       CHECK:   %[[C0:.+]] = arith.constant 0 : index
+//       CHECK:   %[[READ:.+]] = vector.transfer_read %[[ARG1]]
+//  CHECK-SAME:     : tensor<10xi32>, vector<10xindex>
+//       CHECK:   %[[GATHER:.+]] = iree_vector_ext.transfer_gather %[[ARG0]]
+//  CHECK-SAME:     [%[[C0]], %[[C0]]][%[[READ]]: vector<10xindex>, None]
+
+// -----
+
+func.func @linalg_ext_gather_no_vectorize_multi_batch(%source : tensor<1024x128xi32>, %indices : tensor<32x32xi32>) -> (tensor<32x32x128xi32>) {
+  %empty = tensor.empty() : tensor<32x32x128xi32>
+  %result = iree_linalg_ext.gather dimension_map = [0]
+    ins(%source, %indices : tensor<1024x128xi32>, tensor<32x32xi32>)
+    outs(%empty: tensor<32x32x128xi32>)  -> tensor<32x32x128xi32>
+  return %result : tensor<32x32x128xi32>
+}
+// CHECK-LABEL: @linalg_ext_gather_no_vectorize_multi_batch
+//  CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+//  CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
+//       CHECK:   %[[GATHER:.+]] = iree_linalg_ext.gather
+//  CHECK-SAME:     ins(%[[ARG0]], %[[ARG1]]
+//       CHECK:   return %[[GATHER]]
+
+// -----
+
+func.func @linalg_ext_gather_no_vectorize_multi_index(%source : tensor<1024x64x64x128xi32>, %indices : tensor<10x3xi32>) -> (tensor<10x128xi32>) {
+  %empty = tensor.empty() : tensor<10x128xi32>
+  %result = iree_linalg_ext.gather dimension_map = [0, 1, 2]
+    ins(%source, %indices : tensor<1024x64x64x128xi32>, tensor<10x3xi32>)
+    outs(%empty: tensor<10x128xi32>) -> tensor<10x128xi32>
+  return %result : tensor<10x128xi32>
+}
+// CHECK-LABEL: @linalg_ext_gather_no_vectorize_multi_index
+//  CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+//  CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
+//       CHECK:   %[[GATHER:.+]] = iree_linalg_ext.gather
+//  CHECK-SAME:     ins(%[[ARG0]], %[[ARG1]]
+//       CHECK:   return %[[GATHER]]
+
+// -----
+
+func.func @linalg_ext_gather_unit_dim(%source : tensor<1024x128xi32>, %indices : tensor<10x1xi32>) -> (tensor<10x128xi32>) {
+  %empty = tensor.empty() : tensor<10x128xi32>
+  %result = iree_linalg_ext.gather dimension_map = [0]
+    ins(%source, %indices : tensor<1024x128xi32>, tensor<10x1xi32>)
+    outs(%empty: tensor<10x128xi32>) -> tensor<10x128xi32>
+  return %result : tensor<10x128xi32>
+}
+
+// CHECK-LABEL: @linalg_ext_gather_unit_dim
+//  CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+//  CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
+//       CHECK:   %[[C0:.+]] = arith.constant 0 : index
+//       CHECK:   %[[READ:.+]] = vector.transfer_read %[[ARG1]]
+//  CHECK-SAME:     : tensor<10x1xi32>, vector<10xindex>
+//       CHECK:   %[[GATHER:.+]] = iree_vector_ext.transfer_gather %[[ARG0]]
+//  CHECK-SAME:     [%[[C0]], %[[C0]]][%[[READ]]: vector<10xindex>, None]


### PR DESCRIPTION
Adds conversion from `iree_linalg_ext.gather` to `iree_vector_ext.transfer_gather`. This doesn't support cases where batchRank > 1 or indexDepth > 1.