### PR TITLE
[DispatchCreation] Make sure `collapse_shape/expand_shape` are hoisted out properly.

### DIFF
--- a/compiler/src/iree/compiler/Preprocessing/Common/MakeSingleDispatchForFunction.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Common/MakeSingleDispatchForFunction.cpp
@@ -45,9 +45,11 @@ void MakeSingleDispatchForFunctionPass::runOnOperation() {
   Block &block = body.front();
   auto whitelistedOps = [&](Operation *op) {
     auto dialect = op->getDialect();
-    if (isa<IREE::LinalgExt::IREELinalgExtDialect, linalg::LinalgDialect,
-            tensor::TensorDialect>(dialect)) {
+    if (isa<IREE::LinalgExt::IREELinalgExtDialect, linalg::LinalgDialect>(dialect)) {
       return true;
+    }
+    if (isa<tensor::TensorDialect>(dialect)) {
+      return !isa<tensor::EmptyOp>(op);
     }
     if (isa<arith::ArithDialect>(dialect)) {
       return !isa<arith::ConstantOp>(op);


### PR DESCRIPTION
The `CollapseDimensions` pass wants to put the
`collapse_shape`/`expand_shape` out of the dispatch. The collapse does not account for `linalg.fill` operations (for example). The collapsing of these operations is done through use of a cleanup pattern later. The hoisting though needs to be done after the cleanup patterns are run.

Also change a walk, which was modifying a function during the walk that can be tricky.

Towards #20811