### PR TITLE
[LinalgExt] Add a canonicalization pattern to drop unused results from sort op

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -451,6 +451,8 @@ def IREELinalgExt_SortOp : IREELinalgExt_Op<"sort",
       return getOutputsMutable();
     }
   }];
+
+  let hasCanonicalizer = 1;
 }
 
 def IREELinalgExt_FftOp : IREELinalgExt_Op<"fft", [

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/canonicalize.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/canonicalize.mlir
@@ -21,7 +21,7 @@ func.func @pack_canonicalize(%arg0 : tensor<?x?xi32>,
 
 // -----
 
-func.func @sort_canonicalize(%arg0 : tensor<?x10xf32>,
+func.func @sort_drop_unused_results(%arg0 : tensor<?x10xf32>,
     %arg1 : tensor<?x10xi64>) -> tensor<?x10xf32> {
   %0:2 = iree_linalg_ext.sort dimension(1) outs(%arg0, %arg1: tensor<?x10xf32>,
       tensor<?x10xi64>) {
@@ -31,7 +31,7 @@ func.func @sort_canonicalize(%arg0 : tensor<?x10xf32>,
   } -> tensor<?x10xf32>, tensor<?x10xi64>
   return %0#0 : tensor<?x10xf32>
 }
-// CHECK-LABEL: func.func @sort_canonicalize
+// CHECK-LABEL: func.func @sort_drop_unused_results
 //  CHECK-SAME:     %[[ARG0:.+]]: tensor<?x10xf32>
 //  CHECK-SAME:     %[[ARG1:.+]]: tensor<?x10xi64>
 //       CHECK:   %[[SORT:.+]] = iree_linalg_ext.sort dimension(1) outs(%[[ARG0]] : tensor<?x10xf32>)

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/canonicalize.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/canonicalize.mlir
@@ -18,3 +18,20 @@ func.func @pack_canonicalize(%arg0 : tensor<?x?xi32>,
 //  CHECK-SAME:       into %[[ARG1]]
 //       CHECK:   %[[CAST:.+]] = tensor.cast %[[PACK]]
 //       CHECK:   return %[[CAST]]
+
+// -----
+
+func.func @sort_canonicalize(%arg0 : tensor<?x10xf32>,
+    %arg1 : tensor<?x10xi64>) -> tensor<?x10xf32> {
+  %0:2 = iree_linalg_ext.sort dimension(1) outs(%arg0, %arg1: tensor<?x10xf32>,
+      tensor<?x10xi64>) {
+  ^bb0(%arg2: f32, %arg3: f32, %arg4: i64, %arg5: i64):
+    %42 = arith.cmpf oge, %arg2, %arg3 : f32
+    iree_linalg_ext.yield %42 : i1
+  } -> tensor<?x10xf32>, tensor<?x10xi64>
+  return %0#0 : tensor<?x10xf32>
+}
+// CHECK-LABEL: func.func @sort_canonicalize
+//  CHECK-SAME:     %[[ARG0:.+]]: tensor<?x10xf32>
+//  CHECK-SAME:     %[[ARG1:.+]]: tensor<?x10xi64>
+//       CHECK:   %[[SORT:.+]] = iree_linalg_ext.sort dimension(1) outs(%[[ARG0]] : tensor<?x10xf32>)


### PR DESCRIPTION
Issue: https://github.com/iree-org/iree/issues/20699

Fixes bufferization failures caused by unused results of DPS ops. Adds a canonicalization pattern to remove unused results.