### PR TITLE
Fix padding to nop encoding specialization

### DIFF
--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -435,7 +435,7 @@ struct GPUPadEncodingLayoutResolverAttrInterface final
     std::optional<IREE::GPU::L1CacheInfo> cache =
         IREE::GPU::getL1CacheInfo(gpuTarget);
     if (!cache) {
-      return IREE::Codegen::EncodingNopLayoutAttr::get(ctx);
+      return GPUPadLayoutAttr::get(ctx, std::nullopt, std::nullopt);
     }
     return GPUPadLayoutAttr::get(ctx, cache->cacheLineBytes, cache->cacheSets);
   }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/specialize_encodings.mlir
@@ -145,6 +145,23 @@ util.func public @with_pad_encoding(%arg0: index, %arg1: index, %scalar_f32 : f3
 
 // -----
 
+// Creates an nop encoding if no `iree.gpu.target` is provided.
+
+#executable_target_rocm_bytecode_fb = #hal.executable.target<"rocm", "rocm-hsaco-fb", {abi = "hip", iree.encoding.resolver = #iree_gpu.gpu_pad_layout<> }>
+#device_target_local_0_ = #hal.device.target<"local", {ordinal = 0 : index}, [#executable_target_rocm_bytecode_fb]> : !hal.device
+#encoding = #iree_encoding.testing_encoding<>
+
+util.global private @device_a = #device_target_local_0_
+util.func public @create_pad_identity_encoding(%arg0: index, %arg1: index) {
+  %0 = stream.tensor.empty on(#hal.device.affinity<@device_a>) : tensor<?x0xf32, #encoding>{%arg0} in !stream.resource<*>{%arg1}
+  util.return
+}
+// CHECK: #[[$IDENTITY_ENCODING:.+]] = #iree_encoding.testing_encoding<[#iree_encoding.pad_encoding_layout<[0, 0]>]>
+// CHECK-LABEL: @create_pad_identity_encoding
+// CHECK: stream.tensor.empty {{.*}} :  tensor<?x0xf32, #[[$IDENTITY_ENCODING]]>
+
+// -----
+
 //------------------------------------------------------------------------------
 // Stream ops that have TensorPhaseOp trait. This test suite tests that the
 // encoding is updated that carries resolved layouts.


### PR DESCRIPTION
Fixes an issue encountered while enabling the pad based encoding: https://github.com/iree-org/iree/issues/20835#issuecomment-2885721728

When no GPU::L1CacheInfo can be retrieved, the `GPUPadLayoutAttr` is resolved to a `EncodingNopLayoutAttr`, however this results in the following error:
```
LLVM ERROR: can't create Attribute 'mlir::iree_compiler::IREE::Codegen::EncodingNopLayoutAttr' because storage uniquer isn't initialized: the dialect was likely not loaded, or the attribute wasn't added with addAttributes<...>() in the Dialect::initialize() method.
```
While this could be resolved by adding `ctx->getOrLoadDialect<IREE::Codegen::IREECodegenDialect>();` and implementing the SerializableEncodingAttrInterface for `EncodingNopLayoutAttr`, it's chosen to replace the nop encoding attribute resolver with the identity `GPUPadLayoutAttr` resolver.