### PR TITLE
Sink cast-like flow ops across flow.tensor.transfer/barrier.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
@@ -465,6 +465,39 @@ util.func public @ElideIntermediateTransferFourTransfers(%operand: tensor<1xf16>
 
 // -----
 
+// CHECK-LABEL: @SinkCastLikeOpAcrossTransfer
+//  CHECK-SAME: (%[[ORIGIN:.+]]: tensor<?x4xf16>, %[[DIM:.+]]: index)
+util.func public @SinkCastLikeOpAcrossTransfer(%origin: tensor<?x4xf16>, %dim: index) -> tensor<4x?xf16> {
+  // CHECK-NOT: flow.tensor.reshape
+  %source = flow.tensor.reshape %origin : tensor<?x4xf16>{%dim} -> tensor<4x?xf16>{%dim}
+  // CHECK: %[[TRANSFER:.+]] = flow.tensor.transfer %[[ORIGIN]] : tensor<?x4xf16>{%[[DIM]]}
+  %transfer = flow.tensor.transfer %source : tensor<4x?xf16>{%dim} to "foo"
+  // CHECK: %[[RESHAPE:.+]] = flow.tensor.reshape %[[TRANSFER]] : tensor<?x4xf16>{%[[DIM]]} -> tensor<4x?xf16>{%[[DIM]]}
+  // CHECK: util.return %[[RESHAPE]]
+  util.return %transfer : tensor<4x?xf16>
+}
+
+// -----
+
+// Tests that a sandwich of cast -> transfer -> cast from/to the same type is
+// folded away. This example is a combination of SinkCastLikeOpAcrossTransfer
+// and simple reshape-reshape fold.
+
+// CHECK-LABEL: @SinkCastLikeOpAcrossTransferSandwich
+//  CHECK-SAME: (%[[ORIGIN:.+]]: tensor<?x4xf16>, %[[DIM:.+]]: index)
+util.func public @SinkCastLikeOpAcrossTransferSandwich(%origin: tensor<?x4xf16>, %dim: index) -> tensor<?x4xf16> {
+  // CHECK-NOT: flow.tensor.reshape
+  %source = flow.tensor.reshape %origin : tensor<?x4xf16>{%dim} -> tensor<4x?xf16>{%dim}
+  // CHECK: %[[TARGET:.+]] = flow.tensor.transfer %[[ORIGIN]] : tensor<?x4xf16>{%[[DIM]]}
+  %transfer = flow.tensor.transfer %source : tensor<4x?xf16>{%dim} to "foo"
+  // CHECK-NOT: flow.tensor.reshape
+  %target = flow.tensor.reshape %transfer : tensor<4x?xf16>{%dim} -> tensor<?x4xf16>{%dim}
+  // CHECK: util.return %[[TARGET]]
+  util.return %target : tensor<?x4xf16>
+}
+
+// -----
+
 // CHECK-LABEL: @sliceConst0D
 util.func public @sliceConst0D() -> tensor<i32> {
   %0 = arith.constant dense<0> : tensor<i32>

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/clone_to_consumers.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/clone_to_consumers.mlir
@@ -86,22 +86,24 @@ util.func private @splatLikeDispatchOp() -> (tensor<1xi32>, tensor<1xi32>) {
 
 // Tests that tied ops that do not have affinity of their own are cloned in
 // order to fully flatten out the dependency chain. Here we expect both the
-// splat dispatch and the reshape to be cloned for each target.
+// splat dispatch and the reshape to be cloned for each target. Note that
+// reshapes move past transfers because the pass applies canonicalization
+// patterns.
 
 // CHECK-LABEL: @reshapedDispatchOp
 util.func private @reshapedDispatchOp() -> (tensor<1x4xi32>, tensor<1x4xi32>) {
   %splat_value = arith.constant 123 : i32
   //      CHECK: %[[DISPATCH_A:.+]] = flow.dispatch
+  // CHECK-NEXT: %[[TRANSFER_A:.+]] = flow.tensor.transfer %[[DISPATCH_A]]
+  // CHECK-NEXT: %[[RESHAPE_A:.+]] = flow.tensor.reshape %[[TRANSFER_A]]
   %splat = flow.dispatch @some::@splat_like(%splat_value) : (i32) -> tensor<4x1xi32>
-  // CHECK-NEXT: %[[RESHAPE_A:.+]] = flow.tensor.reshape %[[DISPATCH_A]]
   %reshape = flow.tensor.reshape %splat : tensor<4x1xi32> -> tensor<1x4xi32>
-  // CHECK-NEXT: %[[TRANSFER_A:.+]] = flow.tensor.transfer %[[RESHAPE_A]]
   %transfer_a = flow.tensor.transfer %reshape : tensor<1x4xi32> to #hal.device.promise<@dev_a>
   // CHECK-NEXT: %[[DISPATCH_B:.+]] = flow.dispatch
-  // CHECK-NEXT: %[[RESHAPE_B:.+]] = flow.tensor.reshape %[[DISPATCH_B]]
-  // CHECK-NEXT: %[[TRANSFER_B:.+]] = flow.tensor.transfer %[[RESHAPE_B]]
+  // CHECK-NEXT: %[[TRANSFER_B:.+]] = flow.tensor.transfer %[[DISPATCH_B]]
+  // CHECK-NEXT: %[[RESHAPE_B:.+]] = flow.tensor.reshape %[[TRANSFER_B]]
   %transfer_b = flow.tensor.transfer %reshape : tensor<1x4xi32> to #hal.device.promise<@dev_b>
-  // CHECK-NEXT: util.return %[[TRANSFER_A]], %[[TRANSFER_B]]
+  // CHECK-NEXT: util.return %[[RESHAPE_A]], %[[RESHAPE_B]]
   util.return %transfer_a, %transfer_b : tensor<1x4xi32>, tensor<1x4xi32>
 }
 


### PR DESCRIPTION
Sinking across barriers is safe because by the time the flow cast ops are inserted dispatches should already be formed and the barriers are present for subsequent partitioning by the stream dialect that does not care about the shape information.

This cleans up ~2% of the reshapes in 405b (~70k ops total).

Fixes #18742 (similar idea, but simpler implementation and restricted to only flow ops - tensor dialect folding needs to happen earlier and not in canonicalizers to avoid impacting dispatch creation).