### PR TITLE
[HAL] Do not underflow to smallest normalized value on f32 to f8e8m0fnu conversion

### DIFF
--- a/runtime/src/iree/base/internal/math.h
+++ b/runtime/src/iree/base/internal/math.h
@@ -593,14 +593,19 @@ static inline uint8_t iree_math_f32_to_f8e8m0fnu(float value) {
   if (!isfinite(value)) {
     return 0xFF;
   }
-  if (value <= 0.f) {
+  // drop sign
+  float abs = fabs(value);
+  // under flow zero to minimum to smallest normalized value.
+  if (abs == 0.f) {
     return 0;
   }
+
   int exp = 0;
-  // Normalized is in the interval [0.5, 1.0).
-  float normalized = frexpf(value, &exp);
+  // Normalized is in the interval [0.5, 1.0) for values not equal to 0.
+  float normalized = frexpf(abs, &exp);
   // If the normalized value is closer to 0.5 than to 1.0, decrement the
   // exponent.
+  printf("%f\n", normalized);
   int rounded = exp - (normalized < 0.75f);
   int biased = rounded + 127;
   // The clamping below is to 0xFF, mapping to NaN any value that is larger than

--- a/runtime/src/iree/base/internal/math_test.cc
+++ b/runtime/src/iree/base/internal/math_test.cc
@@ -1027,15 +1027,20 @@ TEST(F8E8M0FNUConversionTest, F32ToF8E8M0FNU) {
   EXPECT_EQ(0xFF, iree_math_f32_to_f8e8m0fnu(NAN));
   for (int exp = -127; exp <= 127; ++exp) {
     EXPECT_EQ(127 + exp, iree_math_f32_to_f8e8m0fnu(ldexpf(1.0f, exp)));
+    EXPECT_EQ(127 + exp, iree_math_f32_to_f8e8m0fnu(ldexpf(-1.0f, exp)));
+
     // 1.5 Should get rounded to the next exponent value or to NaN if that
     // overflows.
     EXPECT_EQ(128 + exp, iree_math_f32_to_f8e8m0fnu(ldexpf(1.5f, exp)));
+    EXPECT_EQ(128 + exp, iree_math_f32_to_f8e8m0fnu(ldexpf(-1.5f, exp)));
   }
   EXPECT_EQ(0xFF, iree_math_f32_to_f8e8m0fnu(NAN));
   EXPECT_EQ(0xFF, iree_math_f32_to_f8e8m0fnu(+INFINITY));
   EXPECT_EQ(0xFF, iree_math_f32_to_f8e8m0fnu(-INFINITY));
-  EXPECT_EQ(0x00, iree_math_f32_to_f8e8m0fnu(-1.0f));
+  EXPECT_EQ(0x7F, iree_math_f32_to_f8e8m0fnu(1.0f));
+  EXPECT_EQ(0x7F, iree_math_f32_to_f8e8m0fnu(-1.0f));
   EXPECT_EQ(0x00, iree_math_f32_to_f8e8m0fnu(0.0f));
+  EXPECT_EQ(0x00, iree_math_f32_to_f8e8m0fnu(-0.0f));
   EXPECT_EQ(0x01, iree_math_f32_to_f8e8m0fnu(FLT_MIN));
   // Overflow to NaN
   EXPECT_EQ(0xFF, iree_math_f32_to_f8e8m0fnu(FLT_MAX));


### PR DESCRIPTION
 Do not underflow to smallest normalized value on f32 tof8e8m0fnu conversion


As discussed here:

> Yeah, given that this meant to be an exponent part for scaling other floats by, I figure fabs() might be a better thing to have there

_Originally posted by @krzysz00 in https://github.com/llvm/llvm-project/issues/140332#issuecomment-2888541697_
            