### PR TITLE
[Codegen] Support multiple forall ops in ReconcileTranslationInfo

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
@@ -206,7 +206,6 @@ resolveWorkgroupForAll(RewriterBase &rewriter, scf::ForallOp forallOp,
 
   // Scale the process IDs and counts to account for the forall op steps. These
   // are the forall offsets for each process, and the bounds of these offsets.
-  rewriter.setInsertionPoint(forallOp);
   SmallVector<Value> procOffsets, procOffsetBounds;
   for (auto [id, count, step] : llvm::zip_equal(procIds, nProcs, mixedStep)) {
     Value procOffset = getValueOrCreateConstantIndexOp(
@@ -244,6 +243,10 @@ resolveWorkgroupForAll(RewriterBase &rewriter, scf::ForallOp forallOp,
   return success();
 }
 
+/// Resolve the workgroup counts for the function based on the extents of the
+/// `forAllOps`. When there are multiple foralls, the worker counts of the
+/// foralls are linearized, and the maximum count is chosen as the workgroup X
+/// count for the dispatch.
 static LogicalResult
 resolveWorkgroupCounts(RewriterBase &rewriter, mlir::FunctionOpInterface funcOp,
                        ArrayRef<scf::ForallOp> forAllOps,

--- a/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ReconcileTranslationInfo.cpp
@@ -17,6 +17,7 @@
 #include "iree/compiler/Codegen/Common/Passes.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Transforms/Transforms.h"
+#include "iree/compiler/Dialect/LinalgExt/Utils/Utils.h"
 #include "llvm/Support/Casting.h"
 #include "mlir/Analysis/CallGraph.h"
 #include "mlir/Dialect/Affine/Utils.h"
@@ -74,18 +75,15 @@ getMappingPermutation(ArrayRef<IREE::Codegen::WorkgroupMappingAttr> mapping) {
 
 /// Return the procId and nprocs to use for each of the distributed loops,
 /// derived from `hal.interface.workgroup.id/count`s.
-static FailureOr<
-    std::pair<SmallVector<OpFoldResult>, SmallVector<OpFoldResult>>>
+static std::pair<SmallVector<OpFoldResult>, SmallVector<OpFoldResult>>
 getProcIdsAndNprocs(
     scf::ForallOp forallOp, RewriterBase &builder, Location loc,
     SmallVector<IREE::Codegen::WorkgroupMappingAttr> workgroupMappings,
     SmallVector<OpFoldResult> lowerBounds,
     SmallVector<OpFoldResult> upperBounds, SmallVector<OpFoldResult> steps,
     IREE::Codegen::WorkgroupId deLinearizeFrom) {
-  if (workgroupMappings.size() != lowerBounds.size()) {
-    return forallOp.emitOpError(
-        "expected as many workgroup mapping attributes as number of loops");
-  }
+  assert(workgroupMappings.size() == lowerBounds.size() &&
+         "expected as many workgroup mapping attributes as number of loops");
 
   auto permutation = getMappingPermutation(workgroupMappings);
   applyPermutationToVector(workgroupMappings, permutation);
@@ -176,7 +174,8 @@ getProcIdsAndNprocs(
 /// Resolve scf.forall operation by using the workgroup ID and counts.
 static LogicalResult
 resolveWorkgroupForAll(RewriterBase &rewriter, scf::ForallOp forallOp,
-                       IREE::Codegen::WorkgroupId deLinearizeFrom) {
+                       IREE::Codegen::WorkgroupId deLinearizeFrom,
+                       bool generateLoopNest) {
   if (forallOp->getNumResults() != 0) {
     return forallOp.emitOpError(
         "cannot resolve for all ops with return values");
@@ -189,74 +188,119 @@ resolveWorkgroupForAll(RewriterBase &rewriter, scf::ForallOp forallOp,
   if (failed(workgroupMapping)) {
     return failure();
   }
+  if (workgroupMapping->size() != mixedLowerBound.size()) {
+    return forallOp.emitOpError(
+        "expected as many workgroup mapping attributes as number of loops");
+  }
 
   OpBuilder::InsertionGuard g(rewriter);
   rewriter.setInsertionPoint(forallOp);
+  Location loc = forallOp.getLoc();
 
-  SmallVector<OpFoldResult> procId;
+  // Get process IDs and counts by querying hal.interface.workgroup.id/count ops
+  // and delinearizing any dimensions of the forall beyond `deLinearizeFrom`.
+  SmallVector<OpFoldResult> procIds, nProcs;
+  std::tie(procIds, nProcs) = getProcIdsAndNprocs(
+      forallOp, rewriter, loc, workgroupMapping.value(), mixedLowerBound,
+      mixedUpperBound, mixedStep, deLinearizeFrom);
 
-  {
-    FailureOr<std::pair<SmallVector<OpFoldResult>, SmallVector<OpFoldResult>>>
-        procInfo =
-            getProcIdsAndNprocs(forallOp, rewriter, forallOp.getLoc(),
-                                workgroupMapping.value(), mixedLowerBound,
-                                mixedUpperBound, mixedStep, deLinearizeFrom);
-    if (failed(procInfo)) {
-      return failure();
-    }
-    std::swap(procId, procInfo->first);
+  // Scale the process IDs and counts to account for the forall op steps. These
+  // are the forall offsets for each process, and the bounds of these offsets.
+  rewriter.setInsertionPoint(forallOp);
+  SmallVector<Value> procOffsets, procOffsetBounds;
+  for (auto [id, count, step] : llvm::zip_equal(procIds, nProcs, mixedStep)) {
+    Value procOffset = getValueOrCreateConstantIndexOp(
+        rewriter, loc, IREE::LinalgExt::mulOfrs(rewriter, loc, id, step));
+    Value procOffsetBound = getValueOrCreateConstantIndexOp(
+        rewriter, loc, IREE::LinalgExt::mulOfrs(rewriter, loc, count, step));
+    procOffsets.push_back(procOffset);
+    procOffsetBounds.push_back(procOffsetBound);
   }
 
-  /// For now this is assuming that number of workgroups is exactly equal to
-  /// the iterations for each loop dimension. Just inline the forall body into
-  /// the parent.
-  Block *parentBlock = forallOp->getBlock();
-  Block *remainingBlock =
-      rewriter.splitBlock(parentBlock, Block::iterator(forallOp));
-  for (auto [id, step] : llvm::zip_equal(procId, mixedStep)) {
-    rewriter.setInsertionPointToEnd(parentBlock);
-    AffineExpr s0, s1;
-    bindSymbols(rewriter.getContext(), s0, s1);
-    AffineExpr expr = s1 * s0;
-    id = affine::makeComposedFoldedAffineApply(rewriter, forallOp.getLoc(),
-                                               expr, {id, step});
+  // If a loop nest is not necessary, then just inline the body of the forall.
+  if (!generateLoopNest) {
+    rewriter.eraseOp(forallOp.getBody()->getTerminator());
+    rewriter.inlineBlockBefore(forallOp.getBody(), forallOp,
+                               /*argValues=*/procOffsets);
+    rewriter.eraseOp(forallOp);
+    return success();
   }
-  auto argReplacements =
-      getValueOrCreateConstantIndexOp(rewriter, forallOp.getLoc(), procId);
-  Block *loopBody = forallOp.getBody();
-  rewriter.eraseOp(loopBody->getTerminator());
-  rewriter.mergeBlocks(loopBody, parentBlock, argReplacements);
-  rewriter.mergeBlocks(remainingBlock, parentBlock, ValueRange{});
+
+  // The bounds of process offsets may not match the bounds of the forall op, so
+  // form a loop nest iterating from the process offsets to the loop bounds, and
+  // stepping by the process offset bounds. Inline the body of the forall op
+  // into the loop nest.
+  SmallVector<Value> forallUbs =
+      getValueOrCreateConstantIndexOp(rewriter, loc, mixedUpperBound);
+  scf::LoopNest loopNest = scf::buildLoopNest(rewriter, loc, procOffsets,
+                                              forallUbs, procOffsetBounds);
+  SmallVector<Value> loopNestIvs = llvm::map_to_vector(
+      loopNest.loops, [](scf::ForOp loop) { return loop.getInductionVar(); });
+  Block *loopNestBody = loopNest.loops.back().getBody();
+  rewriter.eraseOp(forallOp.getBody()->getTerminator());
+  rewriter.inlineBlockBefore(forallOp.getBody(), loopNestBody->getTerminator(),
+                             /*argValues=*/loopNestIvs);
   rewriter.eraseOp(forallOp);
   return success();
 }
 
 static LogicalResult
-resolveWorkgroupCount(RewriterBase &rewriter, mlir::FunctionOpInterface funcOp,
-                      scf::ForallOp forAllOp,
-                      IREE::Codegen::WorkgroupId deLinearizeFrom) {
+resolveWorkgroupCounts(RewriterBase &rewriter, mlir::FunctionOpInterface funcOp,
+                       ArrayRef<scf::ForallOp> forAllOps,
+                       IREE::Codegen::WorkgroupId deLinearizeFrom) {
   OpBuilder::InsertionGuard g(rewriter);
-  rewriter.setInsertionPoint(forAllOp);
-  SmallVector<OpFoldResult> lowerBounds = forAllOp.getMixedLowerBound();
-  SmallVector<OpFoldResult> upperBounds = forAllOp.getMixedUpperBound();
-  SmallVector<OpFoldResult> steps = forAllOp.getMixedStep();
-  SmallVector<OpFoldResult> workgroupCount(lowerBounds.size());
+  OpFoldResult maxWorkgroupCount;
   AffineExpr s0, s1, s2;
   bindSymbols(rewriter.getContext(), s0, s1, s2);
   AffineExpr countExpr = (s1 - s0).ceilDiv(s2);
-  for (auto [index, lb, ub, step] :
-       llvm::enumerate(lowerBounds, upperBounds, steps)) {
-    workgroupCount[index] = affine::makeComposedFoldedAffineApply(
-        rewriter, forAllOp.getLoc(), countExpr, {lb, ub, step});
+  for (scf::ForallOp forAllOp : forAllOps) {
+    rewriter.setInsertionPoint(forAllOp);
+    SmallVector<OpFoldResult> workgroupCounts;
+    Location loc = forAllOp.getLoc();
+    for (auto [lb, ub, step] : llvm::zip_equal(forAllOp.getMixedLowerBound(),
+                                               forAllOp.getMixedUpperBound(),
+                                               forAllOp.getMixedStep())) {
+      workgroupCounts.push_back(affine::makeComposedFoldedAffineApply(
+          rewriter, loc, countExpr, {lb, ub, step}));
+    }
+    // If there is only a single forall op, then there is no need to linearize
+    // the workgroup counts, since the x, y, and z counts will match the ranges
+    // of the single forall.
+    if (forAllOps.size() == 1) {
+      SmallVector<IREE::Codegen::WorkgroupMappingAttr> mappingAttr =
+          llvm::map_to_vector(forAllOp.getMapping().value(), [](auto a) {
+            return cast<IREE::Codegen::WorkgroupMappingAttr>(a);
+          });
+      auto permutation = getMappingPermutation(mappingAttr);
+      workgroupCounts = applyPermutation(workgroupCounts, permutation);
+      return lowerWorkgroupCountFromSliceOp(rewriter, funcOp, workgroupCounts,
+                                            static_cast<int>(deLinearizeFrom) +
+                                                1);
+    }
+    // If there are multiple foralls, then the workgroup counts will be
+    // linearized, and then the workgroup_count_from_slice op will be lowered
+    // with the maximum workgroup count.
+    OpFoldResult flatWorkgroupCount = rewriter.getIndexAttr(1);
+    for (OpFoldResult count : workgroupCounts) {
+      flatWorkgroupCount =
+          IREE::LinalgExt::mulOfrs(rewriter, loc, flatWorkgroupCount, count);
+    }
+    auto asValue = [&](OpFoldResult ofr) {
+      return getValueOrCreateConstantIndexOp(rewriter, loc, ofr);
+    };
+    maxWorkgroupCount =
+        !maxWorkgroupCount
+            ? flatWorkgroupCount
+            : rewriter
+                  .create<arith::MaxUIOp>(loc, asValue(maxWorkgroupCount),
+                                          asValue(flatWorkgroupCount))
+                  .getResult();
   }
-  auto mappingAttr =
-      llvm::map_to_vector(forAllOp.getMapping().value(), [](auto a) {
-        return cast<IREE::Codegen::WorkgroupMappingAttr>(a);
-      });
-  auto permutation = getMappingPermutation(mappingAttr);
-  workgroupCount = applyPermutation(workgroupCount, permutation);
-  return lowerWorkgroupCountFromSliceOp(rewriter, funcOp, workgroupCount,
-                                        static_cast<int>(deLinearizeFrom) + 1);
+  OpFoldResult one = rewriter.getIndexAttr(1);
+  // The order of dimensions expected by `lowerWorkgroupCountFromSliceOp`
+  // is {z, y, x}.
+  SmallVector<OpFoldResult> workgroupCounts = {one, one, maxWorkgroupCount};
+  return lowerWorkgroupCountFromSliceOp(rewriter, funcOp, workgroupCounts);
 }
 
 static LogicalResult
@@ -291,22 +335,30 @@ resolveWorkgroupForAll(RewriterBase &rewriter, FunctionOpInterface funcOp,
     return lowerWorkgroupCountFromSliceOp(rewriter, funcOp,
                                           ArrayRef<OpFoldResult>{});
   }
-  if (!llvm::hasSingleElement(workgroupForAllOps)) {
-    return funcOp.emitOpError("unhandled resolution of zero/multiple "
-                              "scf.forall ops withing the function");
-  }
 
   if (!llvm::hasSingleElement(body)) {
     return funcOp.emitOpError("unhandled function with multiple blocks");
   }
 
-  scf::ForallOp forallOp = *forAllOps.begin();
-  if (failed(
-          resolveWorkgroupCount(rewriter, funcOp, forallOp, deLinearizeFrom))) {
+  if (failed(resolveWorkgroupCounts(rewriter, funcOp, workgroupForAllOps,
+                                    deLinearizeFrom))) {
     return failure();
   }
-
-  return resolveWorkgroupForAll(rewriter, *forAllOps.begin(), deLinearizeFrom);
+  // If there are multiple forall ops, then the workgroup counts will be
+  // flattened into the workgroup X dim.
+  bool multiForall = workgroupForAllOps.size() > 1;
+  if (multiForall) {
+    deLinearizeFrom = IREE::Codegen::WorkgroupId::IdX;
+  }
+  for (auto [idx, forallOp] : llvm::enumerate(workgroupForAllOps)) {
+    // Generate a loop nest when there are multiple foralls, because the
+    // workgroup counts might not match between foralls.
+    if (failed(resolveWorkgroupForAll(rewriter, forallOp, deLinearizeFrom,
+                                      /*generateLoopNest=*/multiForall))) {
+      return failure();
+    }
+  }
+  return success();
 }
 
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-codegen-reconcile-translation-info, canonicalize)))" %s --verify-diagnostics --allow-unregistered-dialect | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-codegen-reconcile-translation-info, canonicalize, cse)))" %s --verify-diagnostics --allow-unregistered-dialect | FileCheck %s
 
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   #hal.pipeline.binding<storage_buffer>
@@ -263,7 +263,7 @@ hal.executable private @scf_forall_2D_dynamic_tile_size {
   }
 }
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0, s1] -> (s0 ceildiv s1)
-//  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0, s1] -> (s1 * s0)>
+//  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0, s1] -> (s0 * s1)>
 //      CHECK: hal.executable.export public @scf_forall_2D_dynamic_tile_size layout
 // CHECK-SAME:     %[[ARG1:[a-zA-z0-9]+]]: index
 // CHECK-SAME:     %[[ARG2:[a-zA-z0-9]+]]: index
@@ -336,7 +336,7 @@ hal.executable private @scf_forall_4D {
 }
 //  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0, s1, s2] -> ((-s0 + s1) ceildiv s2)>
 //  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0, s1, s2, s3, s4, s5] -> (((-s0 + s1) ceildiv s2) * ((-s3 + s4) ceildiv s5))>
-//  CHECK-DAG: #[[MAP2:.+]] = affine_map<()[s0, s1] -> (s1 * s0)>
+//  CHECK-DAG: #[[MAP2:.+]] = affine_map<()[s0, s1] -> (s0 * s1)>
 //      CHECK: hal.executable.export public @scf_forall_4D layout
 // CHECK-SAME:     %[[ARG1:[a-zA-z0-9]+]]: index
 // CHECK-SAME:     %[[ARG2:[a-zA-z0-9]+]]: index
@@ -543,3 +543,95 @@ hal.executable private @multi_export_scf_forall {
 //  CHECK-DAG:   hal.interface.workgroup.id[0]
 //  CHECK-NOT:   scf.forall
 //      CHECK:   "use1"
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<constants = 4, bindings = [
+    #hal.pipeline.binding<storage_buffer>]>
+hal.executable private @multiple_scf_forall_ops {
+  hal.executable.variant public @multiple_scf_forall_ops target(#hal.executable.target<"", "", {}>) {
+    hal.executable.export public @multiple_scf_forall_ops layout(#pipeline_layout) count(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice %arg1, %arg2, %arg3, %arg4
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @multiple_scf_forall_ops() {
+        %cst0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
+        %cst1 = hal.interface.constant.load layout(#pipeline_layout) ordinal(1) : index
+        %cst2 = hal.interface.constant.load layout(#pipeline_layout) ordinal(2) : index
+        %cst3 = hal.interface.constant.load layout(#pipeline_layout) ordinal(3) : index
+        %0 = iree_tensor_ext.dispatch.workload.ordinal %cst0, 0 : index
+        %1 = iree_tensor_ext.dispatch.workload.ordinal %cst1, 1 : index
+        %2 = iree_tensor_ext.dispatch.workload.ordinal %cst2, 2 : index
+        %3 = iree_tensor_ext.dispatch.workload.ordinal %cst3, 3 : index
+        scf.forall (%arg0, %arg1) = (0, 0) to (%0, %1) step(%2, %3) {
+          "use"(%arg0, %arg1) : (index, index) -> ()
+          scf.forall.in_parallel {}
+        } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
+        scf.forall (%arg0, %arg1) = (0, 0) to (16, 32) step(4, 2) {
+          "use"(%arg0, %arg1) : (index, index) -> ()
+          scf.forall.in_parallel {}
+        } {mapping = [#iree_codegen.workgroup_mapping<x>, #iree_codegen.workgroup_mapping<y>]}
+        return
+      }
+    }
+  }
+}
+//  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0, s1, s2, s3] -> ((s2 ceildiv s3) * (s0 ceildiv s1))>
+//  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0, s1] -> (s0 ceildiv s1)>
+//  CHECK-DAG: #[[MAP2:.+]] = affine_map<()[s0, s1, s2] -> (s0 ceildiv s1, s2)>
+//  CHECK-DAG: #[[MAP3:.+]] = affine_map<()[s0, s1, s2, s3] -> (s0 ceildiv s1, s2 ceildiv s3)>
+//  CHECK-DAG: #[[MAP4:.+]] = affine_map<()[s0, s1] -> (s0 * s1)>
+//  CHECK-DAG: #[[MAP5:.+]] = affine_map<()[s0] -> (4, s0)>
+//  CHECK-DAG: #[[MAP6:.+]] = affine_map<()[s0, s1] -> (16, s0 ceildiv s1)>
+//  CHECK-DAG: #[[MAP7:.+]] = affine_map<()[s0] -> (s0 * 4)>
+//  CHECK-DAG: #[[MAP8:.+]] = affine_map<()[s0] -> (s0 * 2)>
+//      CHECK: hal.executable.export public @multiple_scf_forall_ops layout
+// CHECK-SAME:     %[[ARG1:[a-zA-z0-9]+]]: index
+// CHECK-SAME:     %[[ARG2:[a-zA-z0-9]+]]: index
+// CHECK-SAME:     %[[ARG3:[a-zA-z0-9]+]]: index
+// CHECK-SAME:     %[[ARG4:[a-zA-z0-9]+]]: index
+//  CHECK-DAG:   %[[WG_X0:.+]] = affine.apply #[[MAP0]]()[%[[ARG1]], %[[ARG3]], %[[ARG2]], %[[ARG4]]]
+//  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
+//  CHECK-DAG:   %[[WG_X1:.+]] = arith.constant 64
+//  CHECK-DAG:   %[[WG_X:.+]] = arith.maxui %[[WG_X0]], %[[WG_X1]]
+//      CHECK:   hal.return %[[WG_X]], %[[C1]], %[[C1]]
+//      CHECK: func @multiple_scf_forall_ops()
+//  CHECK-DAG:   %[[C32:.+]] = arith.constant 32
+//  CHECK-DAG:   %[[C16:.+]] = arith.constant 16
+//  CHECK-DAG:   %[[UB0:.+]] = hal.interface.constant.load {{.+}} ordinal(0)
+//  CHECK-DAG:   %[[UB1:.+]] = hal.interface.constant.load {{.+}} ordinal(1)
+//  CHECK-DAG:   %[[STEP0:.+]] = hal.interface.constant.load {{.+}} ordinal(2)
+//  CHECK-DAG:   %[[STEP1:.+]] = hal.interface.constant.load {{.+}} ordinal(3)
+//  CHECK-DAG:   %[[EXTENT0:.+]] = affine.apply #[[MAP1]]()[%[[UB0]], %[[STEP0]]]
+//  CHECK-DAG:   %[[EXTENT1:.+]] = affine.apply #[[MAP1]]()[%[[UB1]], %[[STEP1]]]
+//  CHECK-DAG:   %[[WG_ID_X:.+]] = hal.interface.workgroup.id[0]
+//  CHECK-DAG:   %[[WG_COUNT_X:.+]] = hal.interface.workgroup.count[0]
+
+//  CHECK-DAG:   %[[WG_IDS_1ST:.+]]:2 = affine.delinearize_index %[[WG_ID_X]]
+// CHECK-SAME:     into (%[[EXTENT0]], %[[EXTENT1]])
+//  CHECK-DAG:   %[[NPROCS1_1ST:.+]] = affine.min #[[MAP2]]()[%[[UB1]], %[[STEP1]], %[[WG_COUNT_X]]]
+//  CHECK-DAG:   %[[NPROCS0_1ST:.+]] = affine.min #[[MAP3]]()[%[[UB0]], %[[STEP0]], %[[WG_COUNT_X]], %[[NPROCS1_1ST]]]
+//  CHECK-DAG:   %[[LOOP_START0_1ST:.+]] = affine.apply #[[MAP4]]()[%[[WG_IDS_1ST]]#0, %[[STEP0]]]
+//  CHECK-DAG:   %[[LOOP_START1_1ST:.+]] = affine.apply #[[MAP4]]()[%[[WG_IDS_1ST]]#1, %[[STEP1]]]
+//  CHECK-DAG:   %[[LOOP_STEP0_1ST:.+]] = affine.apply #[[MAP4]]()[%[[NPROCS0_1ST]], %[[STEP0]]]
+//  CHECK-DAG:   %[[LOOP_STEP1_1ST:.+]] = affine.apply #[[MAP4]]()[%[[NPROCS1_1ST]], %[[STEP1]]]
+//  CHECK-NOT:   scf.forall
+//      CHECK:   scf.for %[[I:.+]] = %[[LOOP_START0_1ST]] to %[[UB0]] step %[[LOOP_STEP0_1ST]]
+//      CHECK:     scf.for %[[J:.+]] = %[[LOOP_START1_1ST]] to %[[UB1]] step %[[LOOP_STEP1_1ST]]
+//      CHECK:       "use"(%[[I]], %[[J]])
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+
+//  CHECK-DAG:   %[[WG_IDS_2ND:.+]]:2 = affine.delinearize_index %[[WG_ID_X]] into (16, 4)
+//  CHECK-DAG:   %[[NPROCS1_2ND:.+]] = affine.min #[[MAP5]]()[%[[WG_COUNT_X]]]
+//  CHECK-DAG:   %[[NPROCS0_2ND:.+]] = affine.min #[[MAP6]]()[%[[WG_COUNT_X]], %[[NPROCS1_2ND]]]
+//  CHECK-DAG:   %[[LOOP_START1_2ND:.+]] = affine.apply #[[MAP8]]()[%[[WG_IDS_2ND]]#0]
+//  CHECK-DAG:   %[[LOOP_START0_2ND:.+]] = affine.apply #[[MAP7]]()[%[[WG_IDS_2ND]]#1]
+//  CHECK-DAG:   %[[LOOP_STEP1_2ND:.+]] = affine.apply #[[MAP8]]()[%[[NPROCS0_2ND]]]
+//  CHECK-DAG:   %[[LOOP_STEP0_2ND:.+]] = affine.apply #[[MAP7]]()[%[[NPROCS1_2ND]]]
+//      CHECK:   scf.for %[[I:.+]] = %[[LOOP_START0_2ND]] to %[[C16]] step %[[LOOP_STEP0_2ND]]
+//      CHECK:     scf.for %[[J:.+]] = %[[LOOP_START1_2ND]] to %[[C32]] step %[[LOOP_STEP1_2ND]]
+//      CHECK:       "use"(%[[I]], %[[J]])
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }

--- a/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info.mlir
@@ -635,3 +635,57 @@ hal.executable private @multiple_scf_forall_ops {
 //      CHECK:       "use"(%[[I]], %[[J]])
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<constants = 0, bindings = [
+    #hal.pipeline.binding<storage_buffer>]>
+hal.executable private @different_rank_scf_forall_ops {
+  hal.executable.variant public @different_rank_scf_forall_ops target(#hal.executable.target<"", "", {}>) {
+    hal.executable.export public @different_rank_scf_forall_ops layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+      %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @different_rank_scf_forall_ops() {
+        scf.forall (%arg0, %arg1) = (0, 0) to (2, 42) step(1, 1) {
+          "use"(%arg0, %arg1) : (index, index) -> ()
+          scf.forall.in_parallel {}
+        } {mapping = [#iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
+        scf.forall (%arg0, %arg1, %arg2) = (0, 0, 0) to (4, 2, 8) step(1, 1, 1) {
+          "use"(%arg0, %arg1, %arg2) : (index, index, index) -> ()
+          scf.forall.in_parallel {}
+        } {mapping = [#iree_codegen.workgroup_mapping<z>, #iree_codegen.workgroup_mapping<y>, #iree_codegen.workgroup_mapping<x>]}
+        return
+      }
+    }
+  }
+}
+//      CHECK: hal.executable.export public @different_rank_scf_forall_ops
+//  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
+//  CHECK-DAG:   %[[WG_X:.+]] = arith.constant 84
+//      CHECK:   hal.return %[[WG_X]], %[[C1]], %[[C1]]
+//      CHECK: func @different_rank_scf_forall_ops
+//  CHECK-DAG:   %[[C2:.+]] = arith.constant 2
+//  CHECK-DAG:   %[[C4:.+]] = arith.constant 4
+//  CHECK-DAG:   %[[C8:.+]] = arith.constant 8
+//  CHECK-DAG:   %[[C42:.+]] = arith.constant 42
+//  CHECK-DAG:   %[[WG_ID_X:.+]] = hal.interface.workgroup.id[0]
+//  CHECK-DAG:   %[[WG_COUNT_X:.+]] = hal.interface.workgroup.count[0]
+
+//  CHECK-DAG:   %[[WG_IDS_1ST:.+]]:2 = affine.delinearize_index %[[WG_ID_X]] into (2, 42)
+//  CHECK-NOT:   scf.forall
+//      CHECK:   scf.for %[[I:.+]] = %[[WG_IDS_1ST]]#0 to %[[C2]]
+//      CHECK:     scf.for %[[J:.+]] = %[[WG_IDS_1ST]]#1 to %[[C42]]
+//      CHECK:       "use"(%[[I]], %[[J]])
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+
+//  CHECK-DAG:   %[[WG_IDS_2ND:.+]]:3 = affine.delinearize_index %[[WG_ID_X]] into (4, 2, 8)
+//      CHECK:   scf.for %[[I:.+]] = %[[WG_IDS_2ND]]#0 to %[[C4]]
+//      CHECK:     scf.for %[[J:.+]] = %[[WG_IDS_2ND]]#1 to %[[C2]]
+//      CHECK:       scf.for %[[K:.+]] = %[[WG_IDS_2ND]]#2 to %[[C8]]
+//      CHECK:         "use"(%[[I]], %[[J]], %[[K]])
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }

--- a/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info_linearize.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reconcile_translation_info_linearize.mlir
@@ -69,24 +69,24 @@ hal.executable private @scf_forall_2D_dynamic_tile_size {
 //   DISTRIBUTEX-DAG:     %[[SIZE1:.+]] = affine.apply affine_map<()[s0, s1, s2] -> ((-s0 + s1) ceildiv s2)>()[%[[ARG0]], %[[ARG2]], %[[ARG4]]]
 //   DISTRIBUTEX-DAG:     %[[IDX:.+]] = hal.interface.workgroup.id[0] : index
 //   DISTRIBUTEX-DAG:     %[[DELINEARIZE:.+]]:2 = affine.delinearize_index %[[IDX]] into (%[[SIZE1]], %[[SIZE0]])
-//   DISTRIBUTEX-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0, s1] -> (s1 * s0)>()[%[[DELINEARIZE]]#0, %[[ARG4]]]
-//   DISTRIBUTEX-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0, s1] -> (s1 * s0)>()[%[[DELINEARIZE]]#1, %[[ARG5]]]
+//   DISTRIBUTEX-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%[[DELINEARIZE]]#0, %[[ARG4]]]
+//   DISTRIBUTEX-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%[[DELINEARIZE]]#1, %[[ARG5]]]
 //       DISTRIBUTEX:     "use"(%[[IV0]], %[[IV1]])
 
 //   DISTRIBUTEY-DAG:     %[[ARG4:.+]] = hal.interface.constant.load {{.+}} ordinal(4)
 //   DISTRIBUTEY-DAG:     %[[ARG5:.+]] = hal.interface.constant.load {{.+}} ordinal(5)
 //   DISTRIBUTEY-DAG:     %[[IDX:.+]] = hal.interface.workgroup.id[0] : index
 //   DISTRIBUTEY-DAG:     %[[IDY:.+]] = hal.interface.workgroup.id[1] : index
-//   DISTRIBUTEY-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0, s1] -> (s1 * s0)>()[%[[IDY]], %[[ARG4]]]
-//   DISTRIBUTEY-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0, s1] -> (s1 * s0)>()[%[[IDX]], %[[ARG5]]]
+//   DISTRIBUTEY-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%[[IDY]], %[[ARG4]]]
+//   DISTRIBUTEY-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%[[IDX]], %[[ARG5]]]
 //       DISTRIBUTEY:     "use"(%[[IV0]], %[[IV1]])
 
 //   DISTRIBUTEZ-DAG:     %[[ARG4:.+]] = hal.interface.constant.load {{.+}} ordinal(4)
 //   DISTRIBUTEZ-DAG:     %[[ARG5:.+]] = hal.interface.constant.load {{.+}} ordinal(5)
 //   DISTRIBUTEZ-DAG:     %[[IDX:.+]] = hal.interface.workgroup.id[0] : index
 //   DISTRIBUTEZ-DAG:     %[[IDY:.+]] = hal.interface.workgroup.id[1] : index
-//   DISTRIBUTEZ-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0, s1] -> (s1 * s0)>()[%[[IDY]], %[[ARG4]]]
-//   DISTRIBUTEZ-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0, s1] -> (s1 * s0)>()[%[[IDX]], %[[ARG5]]]
+//   DISTRIBUTEZ-DAG:     %[[IV0:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%[[IDY]], %[[ARG4]]]
+//   DISTRIBUTEZ-DAG:     %[[IV1:.+]] = affine.apply affine_map<()[s0, s1] -> (s0 * s1)>()[%[[IDX]], %[[ARG5]]]
 //       DISTRIBUTEZ:     "use"(%[[IV0]], %[[IV1]])
 
 // // -----


### PR DESCRIPTION
Allow multiple scf.forall ops in dispatch functions, and support resolution of the foralls with a shared workgroup count. When there are multiple foralls, the worker counts of the foralls are linearized, and the maximum count is chosen as the workgroup X count for the dispatch. Then, workgroup IDs are delinearized from the X dim during the resolution of each scf.forall op, and an scf.for is generated around the distributed loops because their iteration spaces might not match the shared workgroup count.