### PR TITLE
[TensorExt] Drop space from count_from_slice printer

### DIFF
--- a/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/TensorExt/IR/TensorExtOps.td
@@ -263,7 +263,7 @@ class IREETensorExt_DispatchWorkgroupCountOp<string mnemonic, list<Trait> traits
   let results = (outs Index:$x, Index:$y, Index:$z);
 
   let assemblyFormat = [{
-    attr-dict $operands
+    attr-dict ($operands^)?
   }];
 }
 


### PR DESCRIPTION
By making the assembly format explicitly check the size of the input operands, it cleans up whitespace at the end of the op when it has none.

Printer before:

```
void DispatchWorkgroupCountFromSliceOp::print(::mlir::OpAsmPrinter &_odsPrinter) {
  ::llvm::SmallVector<::llvm::StringRef, 2> elidedAttrs;
  _odsPrinter.printOptionalAttrDict((*this)->getAttrs(), elidedAttrs);
  _odsPrinter << ' ';
  _odsPrinter << getOperands();
}
```

Printer after:

```
void DispatchWorkgroupCountFromSliceOp::print(::mlir::OpAsmPrinter &_odsPrinter) {
  ::llvm::SmallVector<::llvm::StringRef, 2> elidedAttrs;
  _odsPrinter.printOptionalAttrDict((*this)->getAttrs(), elidedAttrs);
  if (!getOperands().empty()) {
    _odsPrinter << ' ';
    _odsPrinter << getOperands();
  }
}
```