### PR TITLE
[VectorExt] Fix transfer_gather printer

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/VectorExtOps.cpp
@@ -139,11 +139,11 @@ void TransferGatherOp::print(OpAsmPrinter &p) {
   p << " " << getBase() << "[" << getIndices() << "]";
   printIndexVecs(p, *this, getIndexVecs(), getIndexVecs().getTypes(),
                  getIndexedAttr());
+  p << ", " << getPadding();
   if (getMask())
     p << ", " << getMask();
   printTransferAttrs(p, *this, {"indexed"});
-  p << " : " << getShapedType() << ", "
-    << llvm::interleaved(getIndexVecs().getType()) << ", " << getType();
+  p << " : " << getShapedType() << ", " << getType();
 }
 
 static LogicalResult

--- a/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/VectorExt/IR/test/roundtrip.mlir
@@ -1,4 +1,5 @@
 // RUN: iree-opt --split-input-file %s | FileCheck %s
+// RUN: iree-opt --split-input-file %s | iree-opt --split-input-file | FileCheck %s
 
 func.func @specify_inline_layout(%lhs: memref<32x32xf16>) -> vector<32x32xf16> {
   %cst_0 = arith.constant 0.0 : f16


### PR DESCRIPTION
Print the `padding` operand & removes printing the index vec types at the end of the op. Because this uses a custom printer and parser, I added `iree-opt --split-input-file %s | iree-opt --split-input-file | FileCheck %s` to the roundtrip tests.


Fixes https://github.com/iree-org/iree/issues/20802