### PR TITLE
[Codegen] Fix dominance issue in collapse shape fusion

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/Transforms.cpp
@@ -362,6 +362,7 @@ static tensor::ParallelInsertSliceOp
 collapseParallelInsertOp(RewriterBase &rewriter,
                          tensor::ParallelInsertSliceOp parallelInsertOp,
                          SmallVector<ReassociationIndices> reassociations) {
+  OpBuilder::InsertionGuard g(rewriter);
   // Compute the collapsed offsets, sizes, and strides.
   auto subsetOp =
       cast<SubsetInsertionOpInterface>(parallelInsertOp.getOperation());

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -1254,7 +1254,16 @@ setInsertionPointAfterLastNeededValue(OpBuilder &builder,
       definingOp =
           &cast<BlockArgument>(val).getOwner()->getOperations().front();
     }
-    if (!definingOp || (lastOp && domInfo.dominates(definingOp, lastOp)))
+    if (!definingOp)
+      continue;
+    if (lastOp && definingOp == lastOp) {
+      // Combine 'setInsertionPointBefore' by ANDing because we only want to set
+      // the insertion point before the last op if all values this operation is
+      // derived from are block arguments.
+      setInsertionPointBefore &= isa<BlockArgument>(val);
+      continue;
+    }
+    if (lastOp && domInfo.dominates(definingOp, lastOp))
       continue;
     lastOp = definingOp;
 


### PR DESCRIPTION
In fusion of consumer `tensor.collapse_shape` operations into `scf.forall`, there is a potential dominance issue if the `tensor.parallel_insert_slice` operation depends on both a BlockArgument and an affine expression on the same BlockArgument (in this order). This lead to the following error for the added test:
```
...
error: operand #1 does not dominate this use
    %2 = affine.apply #map(%arg4)
...
```