### PR TITLE
[Dispatch Creation] Clone iree_linalg_ext.gather for attn

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -936,17 +936,6 @@ static bool hasUnfusableUseInDispatch(Value v, Operation *dispatchOp) {
       if (insertSliceUser.getDest() == v)
         return true;
     }
-
-    if (auto attentionOp = dyn_cast<IREE::LinalgExt::AttentionOp>(user)) {
-      // Only clone if used by Query, Mask, or scale.
-      if (!LinalgExt::isBitExtendOp(v.getDefiningOp()) &&
-          !llvm::is_contained<Value>(
-              {attentionOp.getQuery(), attentionOp.getMask(),
-               attentionOp.getScale(), attentionOp.getOutput()},
-              v)) {
-        return true;
-      }
-    }
   }
   return false;
 }

--- a/compiler/src/iree/compiler/DispatchCreation/test/clone_producers_into_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/clone_producers_into_dispatch_regions.mlir
@@ -689,3 +689,105 @@ util.func @clone_gather_elementwise(%source : tensor<2x2x2048xi32>,
 // CHECK-SAME:         ins(%[[GATHER]] :
 //      CHECK:     flow.return %[[GENERIC]]
 //      CHECK:   util.return %[[DISPATCH]]
+
+// -----
+
+util.func public @clone_linalg_ext_gather_attention(
+  %arg0: tensor<?x32x2x32x8x128xf16>, %arg1: tensor<8x4x1x128xf16>,
+  %arg2: tensor<8x4x1x?x32xf16>, %arg3: index,
+  %arg4: tensor<1x?xi64>, %arg5: index) -> tensor<8x4x1x128xf16> {
+  %0 = tensor.empty(%arg5) : tensor<1x?x32x8x128xf16>
+  %extracted_slice = tensor.extract_slice %arg0[0, 31, 1, 0, 0, 0] [%arg3, 1, 1, 32, 8, 128] [1, 1, 1, 1, 1, 1] : tensor<?x32x2x32x8x128xf16> to tensor<?x32x8x128xf16>
+  %extracted_slice_0 = tensor.extract_slice %arg0[0, 31, 0, 0, 0, 0] [%arg3, 1, 1, 32, 8, 128] [1, 1, 1, 1, 1, 1] : tensor<?x32x2x32x8x128xf16> to tensor<?x32x8x128xf16>
+  %1 = iree_linalg_ext.gather dimension_map = [0]
+    ins(%extracted_slice_0, %arg4 : tensor<?x32x8x128xf16>, tensor<1x?xi64>)
+    outs(%0 : tensor<1x?x32x8x128xf16>) -> tensor<1x?x32x8x128xf16>
+  %2 = iree_linalg_ext.gather dimension_map = [0]
+    ins(%extracted_slice, %arg4 : tensor<?x32x8x128xf16>, tensor<1x?xi64>)
+    outs(%0 : tensor<1x?x32x8x128xf16>) -> tensor<1x?x32x8x128xf16>
+
+  %3 = flow.dispatch.region -> (tensor<8x4x1x128xf16>) {
+    %4 = tensor.empty() : tensor<8x4x1x128xf16>
+    %cst = arith.constant 8.837890e-02 : f16
+    %5 = iree_linalg_ext.attention {
+      indexing_maps = [
+        affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d4)>,
+        affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d5, d6, d7, d0, d4)>,
+        affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d5, d6, d7, d0, d3)>,
+        affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> ()>,
+        affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d5, d6, d7)>,
+        affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3)>]}
+      ins(%arg1, %1, %2, %cst, %arg2 : tensor<8x4x1x128xf16>, tensor<1x?x32x8x128xf16>, tensor<1x?x32x8x128xf16>, f16, tensor<8x4x1x?x32xf16>)
+      outs(%4 : tensor<8x4x1x128xf16>) {
+    ^bb0(%arg6: f32):
+      iree_linalg_ext.yield %arg6 : f32
+    } -> tensor<8x4x1x128xf16>
+    flow.return %5 : tensor<8x4x1x128xf16>
+  }
+  util.return %3 : tensor<8x4x1x128xf16>
+}
+// CHECK-LABEL: func public @clone_linalg_ext_gather_attention
+// CHECK-SAME:     %[[ARG0:.+]]: tensor<?x32x2x32x8x128xf16>
+// CHECK-SAME:     %[[ARG1:.+]]: tensor<8x4x1x128xf16>
+//      CHECK:   %[[DISPATCH:.+]] = flow.dispatch.region
+//  CHECK-DAG:     %[[EXTRACTK:.+]] = tensor.extract_slice %[[ARG0]][0, 31, 0, 0, 0, 0]
+//  CHECK-DAG:     %[[EXTRACTV:.+]] = tensor.extract_slice %[[ARG0]][0, 31, 1, 0, 0, 0]
+//  CHECK-DAG:     %[[GATHERK:.+]] = iree_linalg_ext.gather
+// CHECK-SAME:         ins(%[[EXTRACTK]]
+//  CHECK-DAG:     %[[GATHERV:.+]] = iree_linalg_ext.gather
+// CHECK-SAME:         ins(%[[EXTRACTV]]
+//      CHECK:     %[[ATTN:.+]] = iree_linalg_ext.attention
+// CHECK-SAME:       ins(%[[ARG1]], %[[GATHERK]], %[[GATHERV]]
+//      CHECK:     flow.return %[[ATTN]]
+//      CHECK:   util.return %[[DISPATCH]]
+
+// -----
+
+// Don't clone 'gather-like' operations (only `iree_linalg_ext.gather`) is supported.
+util.func public @dont_clone_gather_like(%arg0: tensor<4x1x4xi64>, %arg1: tensor<16384x16x32x128xf16>, %arg2: f16, %arg3: i64, %arg4: tensor<4x4x16x32x128xf16>, %arg5: tensor<4x1x32x1x128xf16>) -> tensor<4x32x1x128xf16> {
+  %0 = tensor.empty() : tensor<4x1x4x16x32x128xf16>
+  %1 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d4, d5)>], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "parallel"]} ins(%arg0 : tensor<4x1x4xi64>) outs(%0 : tensor<4x1x4x16x32x128xf16>) {
+  ^bb0(%in: i64, %out: f16):
+    %5 = arith.index_cast %in : i64 to index
+    %6 = linalg.index 3 : index
+    %7 = linalg.index 4 : index
+    %8 = linalg.index 5 : index
+    %extracted = tensor.extract %arg1[%5, %6, %7, %8] : tensor<16384x16x32x128xf16>
+    linalg.yield %extracted : f16
+  } -> tensor<4x1x4x16x32x128xf16>
+  %2 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d4, d5)>], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "parallel"]} ins(%arg0 : tensor<4x1x4xi64>) outs(%0 : tensor<4x1x4x16x32x128xf16>) {
+  ^bb0(%in: i64, %out: f16):
+    %5 = arith.addi %in, %arg3 : i64
+    %6 = arith.index_cast %5 : i64 to index
+    %7 = linalg.index 3 : index
+    %8 = linalg.index 4 : index
+    %9 = linalg.index 5 : index
+    %extracted = tensor.extract %arg1[%6, %7, %8, %9] : tensor<16384x16x32x128xf16>
+    linalg.yield %extracted : f16
+  } -> tensor<4x1x4x16x32x128xf16>
+  %3 = tensor.empty() : tensor<4x1x32x1x128xf16>
+  %4 = flow.dispatch.region -> (tensor<4x1x32x1x128xf16>) {
+    %5 = iree_linalg_ext.attention {
+      indexing_maps = [
+        affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3, d4)>,
+        affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d5, d6, d2, d4)>,
+        affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d5, d6, d2, d7)>,
+        affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> ()>,
+        affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d1, d2, d3, d7)>]}
+      ins(%arg5, %1, %2, %arg2 : tensor<4x1x32x1x128xf16>, tensor<4x1x4x16x32x128xf16>, tensor<4x1x4x16x32x128xf16>, f16)
+      outs(%3 : tensor<4x1x32x1x128xf16>) {
+      ^bb0(%score: f16):
+        iree_linalg_ext.yield %score: f16
+    } -> tensor<4x1x32x1x128xf16>
+    flow.return %5 : tensor<4x1x32x1x128xf16>
+  }
+  %collapsed = tensor.collapse_shape %4 [[0, 1], [2], [3], [4]] : tensor<4x1x32x1x128xf16> into tensor<4x32x1x128xf16>
+  util.return %collapsed : tensor<4x32x1x128xf16>
+}
+// CHECK-LABEL:  util.func public @dont_clone_gather_like
+//   CHECK-DAG:    %[[DISPATCHK:.+]] = flow.dispatch.region
+//   CHECK-DAG:    %[[DISPATCHV:.+]] = flow.dispatch.region
+//       CHECK:    %[[DISPATCH:.+]] = flow.dispatch.region
+//       CHECK:      %[[ATTENTION:.+]] = iree_linalg_ext.attention
+//       CHECK:        ins({{.*}}, %[[DISPATCHK]], %[[DISPATCHV]]
+//       CHECK:      flow.return %[[ATTENTION]]


### PR DESCRIPTION
The check in `hasUnfusableUseInDispatch` was meant to prevent RoPE from being fused with attention for any operand except query. However, its a bit redundant with the other check added in https://github.com/iree-org/iree/pull/19829. Additionally, it blocks fusing `iree_linalg_ext.gather` in paged attention models.

I added a test to check that `iree_linalg_ext.gather` gets fused and the second checks that "gather-like" `linalg.generic` ops do not get cloned.