### PR TITLE
[AMDGPU] Rewrite some gpu.shuffle xor to ds_swizzle, per upstream

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToROCDL.cpp
@@ -282,6 +282,7 @@ struct ConvertToROCDLPass final
     {
       RewritePatternSet patterns(&getContext());
       populateGpuRewritePatterns(patterns);
+      populateGpuPromoteShuffleToAMDGPUPatterns(patterns);
       if (failed(applyPatternsGreedily(m, std::move(patterns)))) {
         return signalPassFailure();
       }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_warp_reduction.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/ROCDL/pipeline_warp_reduction.mlir
@@ -35,7 +35,7 @@ hal.executable private @warp_reduction {
 }
 
 //   CHECK-LABEL: llvm.func @warp_reduction
-// CHECK-COUNT-8:   rocdl.ds_bpermute
+// CHECK-COUNT-8:   rocdl.ds_{{swizzle|bpermute}}
 
 // -----
 
@@ -76,4 +76,4 @@ hal.executable public @main_dispatch_517 {
 // TODO: we probably need to revisit the configuration heuristics here.
 
 //     CHECK-LABEL: llvm.func @warp_reduction_large_vector
-// CHECK-COUNT-640:   rocdl.ds_bpermute
+// CHECK-COUNT-640:   rocdl.ds_{{swizzle|bpermute}}


### PR DESCRIPTION
This incerporates an @Hardcode84  pattern that got added upstream into our lowering, mirroring changset to LowerGPUOpsToRocdl.cpp .