### PR TITLE
[NFC][Codegen] Rename early bufferization op operands

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BufferizeDispatchTensorLoadStore.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BufferizeDispatchTensorLoadStore.cpp
@@ -81,9 +81,9 @@ bufferizeDispatchTensorStore(RewriterBase &rewriter,
       storeOp.getMixedOffsets(), storeOp.getMixedSizes(),
       storeOp.getMixedStrides());
 
-  Value value = storeOp.getValue();
+  Value tensor = storeOp.getValue();
   rewriter.setInsertionPoint(storeOp);
-  rewriter.replaceOpWithNewOp<IREE::Codegen::StoreToMemrefOp>(storeOp, value,
+  rewriter.replaceOpWithNewOp<IREE::Codegen::StoreToMemrefOp>(storeOp, tensor,
                                                               outputBuffer);
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.cpp
@@ -289,7 +289,7 @@ foldPadIntoMapScatter(RewriterBase &rewriter, tensor::PadOp padOp,
       padOp.getSourceType().getShape(), rewriter.getContext());
 
   // Write the padding values directly into the outputBuffer.
-  Value outputBuffer = storeOp.getTarget();
+  Value outputBuffer = storeOp.getBuffer();
   auto innerLoopBuilder = [&](OpBuilder &b, Location loopLoc, ValueRange ivs) {
     // We need to scatter the padding values according to the existing
     // mapScatterOp transformation, so clone the transformation into the
@@ -427,13 +427,13 @@ insertIdentityMapScatter(RewriterBase &rewriter,
   auto mapScatterDest =
       rewriter
           .create<tensor::EmptyOp>(
-              loc, memref::getMixedSizes(rewriter, loc, storeOp.getTarget()),
-              storeOp.getValue().getType().getElementType())
+              loc, memref::getMixedSizes(rewriter, loc, storeOp.getBuffer()),
+              storeOp.getTensor().getType().getElementType())
           .getResult();
   auto mapScatterOp = MapScatterOp::createIdentityMapScatter(
-      rewriter, loc, storeOp.getValue(), mapScatterDest);
+      rewriter, loc, storeOp.getTensor(), mapScatterDest);
   rewriter.modifyOpInPlace(storeOp, [&]() {
-    storeOp.getValueMutable().assign(mapScatterOp.getResult(0));
+    storeOp.getTensorMutable().assign(mapScatterOp.getResult(0));
   });
   LDBG("Created identity map_scatter:\n" << mapScatterOp);
   return mapScatterOp;

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
@@ -71,12 +71,12 @@ void ExtractStridedMetadataOp::getAsmResultNames(
 //===----------------------------------------------------------------------===//
 
 LogicalResult LoadFromMemrefOp::verify() {
-  RankedTensorType resultType = getResult().getType();
-  MemRefType sourceType = getSource().getType();
-  if (failed(verifyCompatibleShape(resultType.getShape(),
-                                   sourceType.getShape())) ||
-      resultType.getElementType() != sourceType.getElementType()) {
-    return emitOpError("source and result shapes must be compatible and "
+  RankedTensorType tensorType = getTensor().getType();
+  MemRefType memrefType = getBuffer().getType();
+  if (failed(verifyCompatibleShape(tensorType.getShape(),
+                                   memrefType.getShape())) ||
+      tensorType.getElementType() != memrefType.getElementType()) {
+    return emitOpError("buffer and tensor shapes must be compatible and "
                        "element types must match");
   }
   return success();
@@ -85,7 +85,7 @@ LogicalResult LoadFromMemrefOp::verify() {
 void LoadFromMemrefOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
-  effects.emplace_back(MemoryEffects::Read::get(), &getSourceMutable(),
+  effects.emplace_back(MemoryEffects::Read::get(), &getBufferMutable(),
                        SideEffects::DefaultResource::get());
 }
 
@@ -94,13 +94,13 @@ void LoadFromMemrefOp::getEffects(
 //===----------------------------------------------------------------------===//
 
 LogicalResult StoreToMemrefOp::verify() {
-  RankedTensorType valueType = getValue().getType();
-  MemRefType targetType = getTarget().getType();
-  if (failed(
-          verifyCompatibleShape(valueType.getShape(), targetType.getShape())) ||
-      valueType.getElementType() != targetType.getElementType()) {
-    return emitOpError("value and target shapes must be compatible and element "
-                       "types must match");
+  RankedTensorType tensorType = getTensor().getType();
+  MemRefType memrefType = getBuffer().getType();
+  if (failed(verifyCompatibleShape(tensorType.getShape(),
+                                   memrefType.getShape())) ||
+      tensorType.getElementType() != memrefType.getElementType()) {
+    return emitOpError("tensor and buffer shapes must be compatible and "
+                       "element types must match");
   }
   return success();
 }
@@ -108,6 +108,6 @@ LogicalResult StoreToMemrefOp::verify() {
 void StoreToMemrefOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
-  effects.emplace_back(MemoryEffects::Write::get(), &getTargetMutable(),
+  effects.emplace_back(MemoryEffects::Write::get(), &getBufferMutable(),
                        SideEffects::DefaultResource::get());
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
@@ -186,14 +186,14 @@ def IREECodegen_LoadFromMemrefOp : Op<IREECodegen_Dialect, "load_from_memref",
   }];
 
   let arguments = (ins
-    AnyStridedMemRef:$source
+    AnyStridedMemRef:$buffer
   );
   let results = (outs
-    AnyRankedTensor:$result
+    AnyRankedTensor:$tensor
   );
 
   let assemblyFormat = [{
-    $source attr-dict `:` type($source) `->` type($result)
+    $buffer attr-dict `:` type($buffer) `->` type($tensor)
   }];
 
   let hasVerifier = 1;
@@ -208,14 +208,14 @@ def IREECodegen_StoreToMemrefOp : Op<IREECodegen_Dialect, "store_to_memref",
   }];
 
   let arguments = (ins
-    AnyRankedTensor:$value,
-    AnyStridedMemRef:$target
+    AnyRankedTensor:$tensor,
+    AnyStridedMemRef:$buffer
   );
   let results = (outs);
 
   let assemblyFormat = [{
-    $value `,` $target
-    attr-dict `:` type($value) `into` type($target)
+    $tensor `,` $buffer
+    attr-dict `:` type($tensor) `into` type($buffer)
   }];
 
   let hasVerifier = 1;

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/invalid.mlir
@@ -14,7 +14,7 @@ module {
 // -----
 
 func.func @load_from_memref_invalid_shape(%arg0: memref<5xf32>) -> tensor<4xf32> {
-  // expected-error @+1 {{source and result shapes must be compatible and element types must match}}
+  // expected-error @+1 {{buffer and tensor shapes must be compatible and element types must match}}
   %value = iree_codegen.load_from_memref %arg0 : memref<5xf32> -> tensor<4xf32>
   return %value : tensor<4xf32>
 }
@@ -22,7 +22,7 @@ func.func @load_from_memref_invalid_shape(%arg0: memref<5xf32>) -> tensor<4xf32>
 // -----
 
 func.func @load_from_memref_invalid_element_type(%arg0: memref<4xf32>) -> tensor<4xf16> {
-  // expected-error @+1 {{source and result shapes must be compatible and element types must match}}
+  // expected-error @+1 {{buffer and tensor shapes must be compatible and element types must match}}
   %value = iree_codegen.load_from_memref %arg0 : memref<4xf32> -> tensor<4xf16>
   return %value : tensor<4xf16>
 }
@@ -30,7 +30,7 @@ func.func @load_from_memref_invalid_element_type(%arg0: memref<4xf32>) -> tensor
 // -----
 
 func.func @store_to_memref_invalid_shape(%arg0: tensor<4xf32>, %arg1: memref<5xf32>) {
-  // expected-error @+1 {{value and target shapes must be compatible and element types must match}}
+  // expected-error @+1 {{tensor and buffer shapes must be compatible and element types must match}}
   iree_codegen.store_to_memref %arg0, %arg1 : tensor<4xf32> into memref<5xf32>
   return
 }
@@ -38,7 +38,7 @@ func.func @store_to_memref_invalid_shape(%arg0: tensor<4xf32>, %arg1: memref<5xf
 // -----
 
 func.func @store_to_memref_invalid_element_type(%arg0: tensor<4xf16>, %arg1: memref<4xf32>) {
-  // expected-error @+1 {{value and target shapes must be compatible and element types must match}}
+  // expected-error @+1 {{tensor and buffer shapes must be compatible and element types must match}}
   iree_codegen.store_to_memref %arg0, %arg1 : tensor<4xf16> into memref<4xf32>
   return
 }


### PR DESCRIPTION
Rename the operands of the iree_codegen.load_from_memref/store_to_memref ops to make them more aligned with each other. This improves readability, and makes writing templated patterns easier.
 - `iree_codegen.load_from_memref`: rename `source -> buffer`, and `result -> tensor`
 - `iree_codegen.store_to_memref`: rename `target -> buffer`, and `value -> tensor`