### PR TITLE
[LinalgExt] Fold unit dims for iree_linalg_ext.gather

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -910,6 +910,7 @@ void addGPUVectorDistributePassPipeline(OpPassManager &funcPassManager,
   if (!usePadToModelSharedMemcpy) {
     LinalgFoldUnitExtentDimsPassOptions options;
     options.useRankReducingSlices = true;
+    funcPassManager.addPass(IREE::LinalgExt::createFoldUnitExtentDimsPass());
     funcPassManager.addPass(
         IREE::VectorExt::createVectorExtFoldUnitExtentDimsPass());
     funcPassManager.addPass(mlir::createLinalgFoldUnitExtentDimsPass(options));

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/BUILD.bazel
@@ -36,6 +36,7 @@ iree_compiler_cc_library(
         "DecomposeAttention.cpp",
         "DecomposeIm2col.cpp",
         "DecomposeWinogradPass.cpp",
+        "FoldUnitExtentDims.cpp",
         "PadContractionToBlockSize.cpp",
         "Passes.cpp",
         "ReshapeFusion.cpp",

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/CMakeLists.txt
@@ -33,6 +33,7 @@ iree_cc_library(
     "DecomposeAttention.cpp"
     "DecomposeIm2col.cpp"
     "DecomposeWinogradPass.cpp"
+    "FoldUnitExtentDims.cpp"
     "PadContractionToBlockSize.cpp"
     "Passes.cpp"
     "ReshapeFusion.cpp"

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/FoldUnitExtentDims.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/FoldUnitExtentDims.cpp
@@ -1,0 +1,38 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
+#include "iree/compiler/Dialect/LinalgExt/Transforms/Transforms.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/WalkPatternRewriteDriver.h"
+
+namespace mlir::iree_compiler::IREE::LinalgExt {
+
+#define GEN_PASS_DEF_FOLDUNITEXTENTDIMSPASS
+#include "iree/compiler/Dialect/LinalgExt/Transforms/Passes.h.inc"
+
+namespace {
+
+struct FoldUnitExtentDimsPass final
+    : impl::FoldUnitExtentDimsPassBase<FoldUnitExtentDimsPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry
+        .insert<IREE::LinalgExt::IREELinalgExtDialect, tensor::TensorDialect>();
+  }
+  void runOnOperation() override;
+};
+
+} // namespace
+
+void FoldUnitExtentDimsPass::runOnOperation() {
+  RewritePatternSet patterns(&getContext());
+  linalg::ControlDropUnitDims options;
+  IREE::LinalgExt::populateFoldUnitExtentDimsPatterns(patterns, options);
+  walkAndApplyPatterns(getOperation(), std::move(patterns));
+}
+
+} // namespace mlir::iree_compiler::IREE::LinalgExt

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Passes.td
@@ -94,4 +94,13 @@ def ConvertAttentionToOnlineAttentionPass :
   let summary = "Converts attention op to online_attention op";
 }
 
+def FoldUnitExtentDimsPass :
+      Pass<"iree-linalg-ext-fold-unit-extent-dims", "">  {
+  let summary = "Folds unit dims for iree_linalg_ext ops";
+  let dependentDialects = [
+    "::mlir::tensor::TensorDialect",
+    "::mlir::iree_compiler::IREE::LinalgExt::IREELinalgExtDialect"
+  ];
+}
+
 #endif  // IREE_DIALECT_LINALGEXT_PASSES

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ReshapeFusion.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ReshapeFusion.cpp
@@ -652,6 +652,93 @@ struct DropScatterUnitIndexDepth final : public OpRewritePattern<ScatterOp> {
   }
 };
 
+struct DropGatherBatchUnitDims final : public OpRewritePattern<GatherOp> {
+  using OpRewritePattern<GatherOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(GatherOp gatherOp,
+                                PatternRewriter &rewriter) const override {
+
+    if (gatherOp.getBatchRank() <= 1) {
+      return rewriter.notifyMatchFailure(
+          gatherOp, "dropping unit dims from batch rank 1 is not supported.");
+    }
+
+    Location loc = gatherOp.getLoc();
+
+    auto rankReduceOperand = [&rewriter,
+                              &loc](int64_t numDims, Value operand,
+                                    ShapedType ty) -> FailureOr<Value> {
+      ArrayRef<int64_t> shape = ty.getShape();
+
+      // Find list of dims to drop and the target shape.
+      SmallVector<bool> unitDims(shape.size(), false);
+      for (auto [isUnitDim, size] : llvm::zip_equal(unitDims, shape)) {
+        if (size == 1) {
+          isUnitDim = true;
+        }
+      }
+
+      // Because gather/scatter like to define special behavior to allow eliding
+      // the coordinate dimension, we have to make sure we don't generate a 0-D
+      // tensor.
+      auto slice = MutableArrayRef(unitDims).take_front(numDims);
+      if (llvm::all_of(slice, [](bool x) { return x; })) {
+        slice.back() = false;
+      }
+
+      SmallVector<int64_t> targetShape;
+      for (int i = 0; i < numDims; ++i) {
+        if (!unitDims[i]) {
+          targetShape.push_back(shape[i]);
+        }
+      }
+
+      ArrayRef<int64_t> remaining = shape.drop_front(numDims);
+      targetShape.append(remaining.begin(), remaining.end());
+
+      // No unit dims dropped.
+      if (targetShape.size() == shape.size()) {
+        return failure();
+      }
+
+      // Drop unit dims using extract_slice.
+      FailureOr<Value> rankReducingExtract =
+          tensor::ExtractSliceOp::rankReduceIfNeeded(rewriter, loc, operand,
+                                                     targetShape);
+      assert(succeeded(rankReducingExtract) && "not a unit-extent collapse");
+      return rankReducingExtract.value();
+    };
+
+    FailureOr<Value> newIndices =
+        rankReduceOperand(gatherOp.getBatchRank(), gatherOp.getIndices(),
+                          gatherOp.getIndicesType());
+    FailureOr<Value> newOutput =
+        rankReduceOperand(gatherOp.getBatchRank(), gatherOp.getOutput(),
+                          gatherOp.getOutputType());
+
+    if (failed(newIndices) || failed(newOutput)) {
+      return failure();
+    }
+
+    // New Gather.
+    auto newGather = rewriter.create<GatherOp>(
+        gatherOp.getLoc(), TypeRange{newOutput->getType()},
+        ValueRange{gatherOp.getSource(), newIndices.value()},
+        ValueRange{newOutput.value()}, gatherOp.getDimensionMap());
+
+    Value dest = gatherOp.getOutput();
+    int64_t rank = gatherOp.getOutputType().getRank();
+    SmallVector<OpFoldResult> offsets(rank, rewriter.getIndexAttr(0));
+    SmallVector<OpFoldResult> sizes =
+        tensor::getMixedSizes(rewriter, loc, dest);
+    SmallVector<OpFoldResult> strides(rank, rewriter.getIndexAttr(1));
+
+    rewriter.replaceOpWithNewOp<tensor::InsertSliceOp>(
+        gatherOp, newGather.getResult(0), dest, offsets, sizes, strides);
+
+    return success();
+  }
+};
+
 struct FoldScatterWithProducerReshapeByExpansion final
     : public OpRewritePattern<ScatterOp> {
   FoldScatterWithProducerReshapeByExpansion(
@@ -947,7 +1034,8 @@ SmallVector<unsigned> defaultControlDropUnitDims(Operation *op) {
 
 void populateFoldUnitExtentDimsPatterns(
     RewritePatternSet &patterns, const linalg::ControlDropUnitDims &options) {
-  patterns.add<DropScatterUnitIndexDepth>(patterns.getContext());
+  patterns.add<DropScatterUnitIndexDepth, DropGatherBatchUnitDims>(
+      patterns.getContext());
 }
 
 } // namespace mlir::iree_compiler::IREE::LinalgExt

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ReshapeFusion.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/ReshapeFusion.cpp
@@ -652,86 +652,77 @@ struct DropScatterUnitIndexDepth final : public OpRewritePattern<ScatterOp> {
   }
 };
 
+FailureOr<Value> rankReduceOperand(RewriterBase &rewriter, Location loc,
+                                   int64_t numDims, Value operand,
+                                   ShapedType ty) {
+  // Find list of dims to drop and the target shape.
+  ArrayRef<int64_t> shape = ty.getShape();
+  SmallVector<bool> unitDims(shape.size(), false);
+  for (auto [isUnitDim, size] : llvm::zip_equal(unitDims, shape)) {
+    if (size == 1) {
+      isUnitDim = true;
+    }
+  }
+  // Because gather/scatter like to define special behavior to allow eliding
+  // the coordinate dimension, we have to make sure we don't generate a 0-D
+  // tensor.
+  auto slice = MutableArrayRef(unitDims).take_front(numDims);
+  if (llvm::all_of(slice, [](bool x) { return x; })) {
+    slice.back() = false;
+  }
+  SmallVector<int64_t> targetShape;
+  for (int i = 0; i < numDims; ++i) {
+    if (!unitDims[i]) {
+      targetShape.push_back(shape[i]);
+    }
+  }
+  ArrayRef<int64_t> remaining = shape.drop_front(numDims);
+  targetShape.append(remaining.begin(), remaining.end());
+  // No unit dims dropped.
+  if (targetShape.size() == shape.size()) {
+    return failure();
+  }
+  // Drop unit dims using extract_slice.
+  FailureOr<Value> rankReducingExtract =
+      tensor::ExtractSliceOp::rankReduceIfNeeded(rewriter, loc, operand,
+                                                 targetShape);
+  assert(succeeded(rankReducingExtract) && "not a unit-extent collapse");
+  return rankReducingExtract.value();
+};
+
 struct DropGatherBatchUnitDims final : public OpRewritePattern<GatherOp> {
   using OpRewritePattern<GatherOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(GatherOp gatherOp,
                                 PatternRewriter &rewriter) const override {
-
+    Location loc = gatherOp.getLoc();
+    if (!gatherOp.hasPureTensorSemantics()) {
+      return rewriter.notifyMatchFailure(
+          gatherOp, "dropping unit dims not implemented for buffer semantics");
+    }
     if (gatherOp.getBatchRank() <= 1) {
       return rewriter.notifyMatchFailure(
           gatherOp, "dropping unit dims from batch rank 1 is not supported.");
     }
 
-    Location loc = gatherOp.getLoc();
-
-    auto rankReduceOperand = [&rewriter,
-                              &loc](int64_t numDims, Value operand,
-                                    ShapedType ty) -> FailureOr<Value> {
-      ArrayRef<int64_t> shape = ty.getShape();
-
-      // Find list of dims to drop and the target shape.
-      SmallVector<bool> unitDims(shape.size(), false);
-      for (auto [isUnitDim, size] : llvm::zip_equal(unitDims, shape)) {
-        if (size == 1) {
-          isUnitDim = true;
-        }
-      }
-
-      // Because gather/scatter like to define special behavior to allow eliding
-      // the coordinate dimension, we have to make sure we don't generate a 0-D
-      // tensor.
-      auto slice = MutableArrayRef(unitDims).take_front(numDims);
-      if (llvm::all_of(slice, [](bool x) { return x; })) {
-        slice.back() = false;
-      }
-
-      SmallVector<int64_t> targetShape;
-      for (int i = 0; i < numDims; ++i) {
-        if (!unitDims[i]) {
-          targetShape.push_back(shape[i]);
-        }
-      }
-
-      ArrayRef<int64_t> remaining = shape.drop_front(numDims);
-      targetShape.append(remaining.begin(), remaining.end());
-
-      // No unit dims dropped.
-      if (targetShape.size() == shape.size()) {
-        return failure();
-      }
-
-      // Drop unit dims using extract_slice.
-      FailureOr<Value> rankReducingExtract =
-          tensor::ExtractSliceOp::rankReduceIfNeeded(rewriter, loc, operand,
-                                                     targetShape);
-      assert(succeeded(rankReducingExtract) && "not a unit-extent collapse");
-      return rankReducingExtract.value();
-    };
-
     FailureOr<Value> newIndices =
-        rankReduceOperand(gatherOp.getBatchRank(), gatherOp.getIndices(),
-                          gatherOp.getIndicesType());
+        rankReduceOperand(rewriter, loc, gatherOp.getBatchRank(),
+                          gatherOp.getIndices(), gatherOp.getIndicesType());
     FailureOr<Value> newOutput =
-        rankReduceOperand(gatherOp.getBatchRank(), gatherOp.getOutput(),
-                          gatherOp.getOutputType());
-
+        rankReduceOperand(rewriter, loc, gatherOp.getBatchRank(),
+                          gatherOp.getOutput(), gatherOp.getOutputType());
     if (failed(newIndices) || failed(newOutput)) {
       return failure();
     }
-
-    // New Gather.
     auto newGather = rewriter.create<GatherOp>(
         gatherOp.getLoc(), TypeRange{newOutput->getType()},
         ValueRange{gatherOp.getSource(), newIndices.value()},
         ValueRange{newOutput.value()}, gatherOp.getDimensionMap());
-
     Value dest = gatherOp.getOutput();
     int64_t rank = gatherOp.getOutputType().getRank();
     SmallVector<OpFoldResult> offsets(rank, rewriter.getIndexAttr(0));
     SmallVector<OpFoldResult> sizes =
         tensor::getMixedSizes(rewriter, loc, dest);
     SmallVector<OpFoldResult> strides(rank, rewriter.getIndexAttr(1));
-
     rewriter.replaceOpWithNewOp<tensor::InsertSliceOp>(
         gatherOp, newGather.getResult(0), dest, offsets, sizes, strides);
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Transforms.h
@@ -31,7 +31,10 @@ void populateBubbleTransposeFromLinalgExtOps(
     RewritePatternSet &patterns,
     const linalg::ControlFusionFn &controlFusionFn);
 
-/// Drop unit extent dims from linalg ext ops
+/// Drop unit extent dims from linalg ext ops. Uses reshapes to fold scatter
+/// and slices to fold gather operations.
+/// TODO: Respect the rank reduction strategy specified in ControlDropUnitDims
+/// options.
 void populateFoldUnitExtentDimsPatterns(
     RewritePatternSet &patterns, const linalg::ControlDropUnitDims &options);
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/BUILD.bazel
@@ -23,6 +23,7 @@ iree_lit_test_suite(
             "decompose_im2col.mlir",
             "decompose_winograd.mlir",
             "distribution.mlir",
+            "fold_unit_dims.mlir",
             "pad_contraction_to_block_size.mlir",
             "split_reduction.mlir",
             "tiling.mlir",

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/CMakeLists.txt
@@ -21,6 +21,7 @@ iree_lit_test_suite(
     "decompose_im2col.mlir"
     "decompose_winograd.mlir"
     "distribution.mlir"
+    "fold_unit_dims.mlir"
     "pad_contraction_to_block_size.mlir"
     "split_reduction.mlir"
     "tiling.mlir"

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/fold_unit_dims.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/test/fold_unit_dims.mlir
@@ -1,0 +1,16 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(iree-linalg-ext-fold-unit-extent-dims)" %s --split-input-file --mlir-print-local-scope | FileCheck %s
+
+util.func public @gather(%source: tensor<4x4x4x4xf16>, %indices: tensor<4x1x2xi64>) -> tensor<4x1x4x4xf16> {
+  %empty = tensor.empty() : tensor<4x1x4x4xf16>
+  %0 = iree_linalg_ext.gather dimension_map = [0, 1]
+          ins(%source, %indices: tensor<4x4x4x4xf16>, tensor<4x1x2xi64>)
+          outs(%empty: tensor<4x1x4x4xf16>) -> tensor<4x1x4x4xf16>
+  util.return %0 : tensor<4x1x4x4xf16>
+}
+
+// CHECK-LABEL: util.func public @gather
+// CHECK: %[[INDICES:.+]] = tensor.extract_slice %{{.*}}[0, 0, 0] [4, 1, 2] [1, 1, 1] : tensor<4x1x2xi64> to tensor<4x2xi64>
+// CHECK: %[[OUTPUT:.+]] = tensor.extract_slice %{{.*}}[0, 0, 0, 0] [4, 1, 4, 4] [1, 1, 1, 1] : tensor<4x1x4x4xf16> to tensor<4x4x4xf16>
+// CHECK: %[[RESULT:.+]] = iree_linalg_ext.gather
+// CHECK-SAME: -> tensor<4x4x4xf16>
+// CHECK: %[[EXPANDED_RESULT:.+]] = tensor.insert_slice %[[RESULT]] into %{{.*}}[0, 0, 0, 0] [4, 1, 4, 4] [1, 1, 1, 1] : tensor<4x4x4xf16> into tensor<4x1x4x4xf16>


### PR DESCRIPTION
For iree_linalg_ext.gather to vectorize, there should only be 1 batch dimension. This patch adds unit dim folding for iree_linalg_ext.gather to get it to at-max 1 batch dimension once outer batch dimensions are tiled to 1.