### PR TITLE
[LinalgExt] Canonicalize gather to an extract_slice

### DIFF
--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -363,7 +363,7 @@ struct ConvertGatherToExtract
     int64_t sourceRank = gatherOp.getSourceType().getRank();
     offsets.resize(sourceRank, rewriter.getIndexAttr(0));
 
-    // Create the new `tensor.extract_slice`
+    // Create the new `tensor.extract_slice`.
     SmallVector<OpFoldResult> strides(sourceRank, rewriter.getIndexAttr(1));
     SmallVector<int64_t> resultShape(gatherOp.getIndexDepth(), 1);
     SmallVector<OpFoldResult> sizes(gatherOp.getIndexDepth(),
@@ -384,8 +384,7 @@ struct ConvertGatherToExtract
     int64_t gatherRank = gatherOp.getOutputType().getRank();
     if (sliceRank < gatherRank) {
       SmallVector<ReassociationIndices> reassoc(1);
-      llvm::append_range(reassoc[0],
-                         llvm::seq<int64_t>(0, gatherOp.getBatchRank()));
+      llvm::append_range(reassoc[0], llvm::seq(gatherOp.getBatchRank()));
       for (int64_t i = 0; i < sourceRank - 1; i++) {
         reassoc.emplace_back(1, i + gatherOp.getBatchRank());
       }
@@ -394,8 +393,7 @@ struct ConvertGatherToExtract
           gatherOp, gatherOp.getOutputType(), sliceOp.getResult(), reassoc);
     } else if (sliceRank > gatherRank) {
       SmallVector<ReassociationIndices> reassoc(1);
-      llvm::append_range(reassoc[0],
-                         llvm::seq<int64_t>(0, sliceRank - gatherRank + 1));
+      llvm::append_range(reassoc[0], llvm::seq(sliceRank - gatherRank + 1));
       for (int64_t i = sliceRank - gatherRank + 1; i < sliceRank; i++) {
         reassoc.emplace_back(1, i);
       }

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -21,6 +21,7 @@
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/Dialect/Utils/StructuredOpsUtils.h"
 #include "mlir/IR/AffineExpr.h"
@@ -323,6 +324,95 @@ GatherOp::reifyResultShapes(OpBuilder &b,
                             ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
   return cast<LinalgExtOp>(getOperation())
       .reifyResultShapes(b, reifiedReturnShapes);
+}
+
+namespace {
+struct ConvertGatherToExtract
+    : public OpRewritePattern<IREE::LinalgExt::GatherOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(IREE::LinalgExt::GatherOp gatherOp,
+                                PatternRewriter &rewriter) const override {
+    // TODO: support memref case.
+    if (!gatherOp.hasPureTensorSemantics()) {
+      return failure();
+    }
+
+    auto loc = gatherOp.getLoc();
+    ArrayRef<int64_t> indicesShape = gatherOp.getIndicesType().getShape();
+    ArrayRef<int64_t> batchShape =
+        indicesShape.take_front(gatherOp.getBatchRank());
+    if (!llvm::all_of(batchShape, [](int64_t size) { return size == 1; })) {
+      return failure();
+    }
+
+    // Get all `indexDepth` indices as scalars.
+    SmallVector<Value> indices(indicesShape.size(),
+                               rewriter.create<arith::ConstantIndexOp>(loc, 0));
+    SmallVector<OpFoldResult> offsets(gatherOp.getIndexDepth());
+    for (int64_t i = 0; i < gatherOp.getIndexDepth(); i++) {
+      indices.back() = rewriter.create<arith::ConstantIndexOp>(loc, i);
+      Value elem = rewriter.create<tensor::ExtractOp>(
+          loc, gatherOp.getIndices(), indices);
+      offsets[i] =
+          rewriter
+              .create<arith::IndexCastOp>(loc, rewriter.getIndexType(), elem)
+              .getResult();
+    }
+
+    applyPermutationToVector(offsets, gatherOp.getDimensionMap());
+    int64_t sourceRank = gatherOp.getSourceType().getRank();
+    offsets.resize(sourceRank, rewriter.getIndexAttr(0));
+
+    // Create the new `tensor.extract_slice`
+    SmallVector<OpFoldResult> strides(sourceRank, rewriter.getIndexAttr(1));
+    SmallVector<int64_t> resultShape(gatherOp.getIndexDepth(), 1);
+    SmallVector<OpFoldResult> sizes(gatherOp.getIndexDepth(),
+                                    rewriter.getIndexAttr(1));
+    for (int64_t i = gatherOp.getIndexDepth(); i < sourceRank; i++) {
+      sizes.push_back(
+          rewriter.createOrFold<tensor::DimOp>(loc, gatherOp.getSource(), i));
+      resultShape.push_back(gatherOp.getSourceType().getDimSize(i));
+    }
+    auto resultType =
+        cast<RankedTensorType>(gatherOp.getSourceType()).clone(resultShape);
+    auto sliceOp = rewriter.create<tensor::ExtractSliceOp>(
+        loc, resultType, gatherOp.getSource(), offsets, sizes, strides);
+
+    // `sliceOp` may differ from the expected result type by leading unit
+    // dimensions. Reshape so that the types match.
+    int64_t sliceRank = sliceOp.getResultType().getRank();
+    int64_t gatherRank = gatherOp.getOutputType().getRank();
+    if (sliceRank < gatherRank) {
+      SmallVector<ReassociationIndices> reassoc(1);
+      llvm::append_range(reassoc[0],
+                         llvm::seq<int64_t>(0, gatherOp.getBatchRank()));
+      for (int64_t i = 0; i < sourceRank - 1; i++) {
+        reassoc.emplace_back(1, i + gatherOp.getBatchRank());
+      }
+
+      rewriter.replaceOpWithNewOp<tensor::ExpandShapeOp>(
+          gatherOp, gatherOp.getOutputType(), sliceOp.getResult(), reassoc);
+    } else if (sliceRank > gatherRank) {
+      SmallVector<ReassociationIndices> reassoc(1);
+      llvm::append_range(reassoc[0],
+                         llvm::seq<int64_t>(0, sliceRank - gatherRank + 1));
+      for (int64_t i = sliceRank - gatherRank + 1; i < sliceRank; i++) {
+        reassoc.emplace_back(1, i);
+      }
+
+      rewriter.replaceOpWithNewOp<tensor::CollapseShapeOp>(
+          gatherOp, gatherOp.getOutputType(), sliceOp.getResult(), reassoc);
+    } else {
+      rewriter.replaceOp(gatherOp, sliceOp);
+    }
+    return success();
+  }
+};
+} // namespace
+
+void GatherOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                           MLIRContext *ctx) {
+  results.add<ConvertGatherToExtract>(ctx);
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -349,7 +349,7 @@ struct ConvertGatherToExtract
     SmallVector<Value> indices(indicesShape.size(),
                                rewriter.create<arith::ConstantIndexOp>(loc, 0));
     SmallVector<OpFoldResult> offsets(gatherOp.getIndexDepth());
-    for (int64_t i = 0; i < gatherOp.getIndexDepth(); i++) {
+    for (int64_t i = 0; i < gatherOp.getIndexDepth(); ++i) {
       indices.back() = rewriter.create<arith::ConstantIndexOp>(loc, i);
       Value elem = rewriter.create<tensor::ExtractOp>(
           loc, gatherOp.getIndices(), indices);
@@ -368,7 +368,7 @@ struct ConvertGatherToExtract
     SmallVector<int64_t> resultShape(gatherOp.getIndexDepth(), 1);
     SmallVector<OpFoldResult> sizes(gatherOp.getIndexDepth(),
                                     rewriter.getIndexAttr(1));
-    for (int64_t i = gatherOp.getIndexDepth(); i < sourceRank; i++) {
+    for (int64_t i = gatherOp.getIndexDepth(); i < sourceRank; ++i) {
       sizes.push_back(
           rewriter.createOrFold<tensor::DimOp>(loc, gatherOp.getSource(), i));
       resultShape.push_back(gatherOp.getSourceType().getDimSize(i));
@@ -385,7 +385,7 @@ struct ConvertGatherToExtract
     if (sliceRank < gatherRank) {
       SmallVector<ReassociationIndices> reassoc(1);
       llvm::append_range(reassoc[0], llvm::seq(gatherOp.getBatchRank()));
-      for (int64_t i = 0; i < sourceRank - 1; i++) {
+      for (int64_t i = 0; i < sourceRank - 1; ++i) {
         reassoc.emplace_back(1, i + gatherOp.getBatchRank());
       }
 
@@ -394,7 +394,7 @@ struct ConvertGatherToExtract
     } else if (sliceRank > gatherRank) {
       SmallVector<ReassociationIndices> reassoc(1);
       llvm::append_range(reassoc[0], llvm::seq(sliceRank - gatherRank + 1));
-      for (int64_t i = sliceRank - gatherRank + 1; i < sliceRank; i++) {
+      for (int64_t i = sliceRank - gatherRank + 1; i < sliceRank; ++i) {
         reassoc.emplace_back(1, i);
       }
 

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -311,6 +311,8 @@ def IREELinalgExt_GatherOp : IREELinalgExt_Op<"gather",
       return getOutputsMutable();
     }
   }];
+
+  let hasCanonicalizer = 1;
 }
 
 def IREELinalgExt_MapScatterOp : IREELinalgExt_PureOp<"map_scatter",

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/canonicalize.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/canonicalize.mlir
@@ -35,3 +35,122 @@ func.func @sort_drop_unused_results(%arg0 : tensor<?x10xf32>,
 //  CHECK-SAME:     %[[ARG0:.+]]: tensor<?x10xf32>
 //  CHECK-SAME:     %[[ARG1:.+]]: tensor<?x10xi64>
 //       CHECK:   %[[SORT:.+]] = iree_linalg_ext.sort dimension(1) outs(%[[ARG0]] : tensor<?x10xf32>)
+
+// -----
+
+func.func @gather_to_extract_slice_expand(%source : tensor<1024x128xi32>, %indices : tensor<1x1xi32>) -> (tensor<1x1x128xi32>) {
+  %empty = tensor.empty() : tensor<1x1x128xi32>
+  %result = iree_linalg_ext.gather dimension_map = [0]
+    ins(%source, %indices : tensor<1024x128xi32>, tensor<1x1xi32>)
+    outs(%empty: tensor<1x1x128xi32>) -> tensor<1x1x128xi32>
+  return %result : tensor<1x1x128xi32>
+}
+
+// CHECK-LABEL: @gather_to_extract_slice_expand
+//  CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+//  CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
+//       CHECK:   %[[C0:.+]] = arith.constant 0 : index
+//       CHECK:   %[[IDX:.+]] = tensor.extract %[[ARG1]][%[[C0]], %[[C0]]]
+//       CHECK:   %[[CAST:.+]] = arith.index_cast %[[IDX]]
+//       CHECK:   %[[SLICE:.+]] = tensor.extract_slice %[[ARG0]]
+//  CHECK-SAME:     [%[[CAST]], 0] [1, 128] [1, 1]
+//  CHECK-SAME:     tensor<1024x128xi32> to tensor<1x128xi32>
+//       CHECK:   %[[EXPAND:.+]] = tensor.expand_shape %[[SLICE]]
+//       CHECK:   return %[[EXPAND]] : tensor<1x1x128xi32>
+
+// -----
+
+func.func @gather_to_extract_slice_no_reshape(%source : tensor<1024x128xi32>, %indices : tensor<1xi32>) -> (tensor<1x128xi32>) {
+  %empty = tensor.empty() : tensor<1x128xi32>
+  %result = iree_linalg_ext.gather dimension_map = [0]
+    ins(%source, %indices : tensor<1024x128xi32>, tensor<1xi32>)
+    outs(%empty: tensor<1x128xi32>) -> tensor<1x128xi32>
+  return %result : tensor<1x128xi32>
+}
+
+// CHECK-LABEL: @gather_to_extract_slice_no_reshape
+//  CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+//  CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
+//       CHECK:   %[[C0:.+]] = arith.constant 0 : index
+//       CHECK:   %[[IDX:.+]] = tensor.extract %[[ARG1]][%[[C0]]]
+//       CHECK:   %[[CAST:.+]] = arith.index_cast %[[IDX]]
+//       CHECK:   %[[SLICE:.+]] = tensor.extract_slice %[[ARG0]]
+//  CHECK-SAME:     [%[[CAST]], 0] [1, 128] [1, 1]
+//  CHECK-SAME:     tensor<1024x128xi32> to tensor<1x128xi32>
+//       CHECK:   return %[[SLICE]] : tensor<1x128xi32>
+
+// -----
+
+func.func @gather_to_extract_slice_perm(%source : tensor<10x1024x128xi32>, %indices : tensor<1x1x2xi32>) -> (tensor<1x1x128xi32>) {
+  %empty = tensor.empty() : tensor<1x1x128xi32>
+  %result = iree_linalg_ext.gather dimension_map = [1, 0]
+    ins(%source, %indices : tensor<10x1024x128xi32>, tensor<1x1x2xi32>)
+    outs(%empty: tensor<1x1x128xi32>) -> tensor<1x1x128xi32>
+  return %result : tensor<1x1x128xi32>
+}
+
+// CHECK-LABEL: @gather_to_extract_slice_perm
+//  CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+//  CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG:   %[[IDX0:.+]] = tensor.extract %[[ARG1]][%[[C0]], %[[C0]], %[[C0]]]
+//   CHECK-DAG:   %[[IDX1:.+]] = tensor.extract %[[ARG1]][%[[C0]], %[[C0]], %[[C1]]]
+//   CHECK-DAG:   %[[CAST0:.+]] = arith.index_cast %[[IDX0]]
+//   CHECK-DAG:   %[[CAST1:.+]] = arith.index_cast %[[IDX1]]
+//       CHECK:   %[[SLICE:.+]] = tensor.extract_slice %[[ARG0]]
+//  CHECK-SAME:     [%[[CAST1]], %[[CAST0]], 0] [1, 1, 128] [1, 1, 1]
+//  CHECK-SAME:     tensor<10x1024x128xi32> to tensor<1x1x128xi32>
+//       CHECK:   return %[[SLICE]] : tensor<1x1x128xi32>
+
+// -----
+
+func.func @gather_to_extract_slice_full_collapse(%source : tensor<2x2x1xi32>, %indices : tensor<2xi32>) -> (tensor<1xi32>) {
+  %empty = tensor.empty() : tensor<1xi32>
+  %result = iree_linalg_ext.gather dimension_map = [0, 1]
+    ins(%source, %indices : tensor<2x2x1xi32>, tensor<2xi32>)
+    outs(%empty: tensor<1xi32>) -> tensor<1xi32>
+  return %result : tensor<1xi32>
+}
+
+// CHECK-LABEL: @gather_to_extract_slice_full_collapse
+//  CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+//  CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG:   %[[IDX0:.+]] = tensor.extract %[[ARG1]][%[[C0]]]
+//   CHECK-DAG:   %[[IDX1:.+]] = tensor.extract %[[ARG1]][%[[C1]]]
+//   CHECK-DAG:   %[[CAST0:.+]] = arith.index_cast %[[IDX0]]
+//   CHECK-DAG:   %[[CAST1:.+]] = arith.index_cast %[[IDX1]]
+//       CHECK:   %[[SLICE:.+]] = tensor.extract_slice %[[ARG0]]
+//  CHECK-SAME:     [%[[CAST0]], %[[CAST1]], 0] [1, 1, 1] [1, 1, 1]
+//  CHECK-SAME:     tensor<2x2x1xi32> to tensor<1x1x1xi32>
+//       CHECK:   %[[COLLAPSE:.+]] = tensor.collapse_shape %[[SLICE]]
+//  CHECK-SAME:     tensor<1x1x1xi32> into tensor<1xi32>
+//       CHECK:   return %[[COLLAPSE]] : tensor<1xi32>
+
+// -----
+
+func.func @gather_to_extract_slice_partial_collapse(%source : tensor<2x2x100x100xi32>, %indices : tensor<2xi32>) -> (tensor<100x100xi32>) {
+  %empty = tensor.empty() : tensor<100x100xi32>
+  %result = iree_linalg_ext.gather dimension_map = [1, 0]
+    ins(%source, %indices : tensor<2x2x100x100xi32>, tensor<2xi32>)
+    outs(%empty: tensor<100x100xi32>) -> tensor<100x100xi32>
+  return %result : tensor<100x100xi32>
+}
+
+// CHECK-LABEL: @gather_to_extract_slice_partial_collapse
+//  CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+//  CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG:   %[[IDX0:.+]] = tensor.extract %[[ARG1]][%[[C0]]]
+//   CHECK-DAG:   %[[IDX1:.+]] = tensor.extract %[[ARG1]][%[[C1]]]
+//   CHECK-DAG:   %[[CAST0:.+]] = arith.index_cast %[[IDX0]]
+//   CHECK-DAG:   %[[CAST1:.+]] = arith.index_cast %[[IDX1]]
+//       CHECK:   %[[SLICE:.+]] = tensor.extract_slice %[[ARG0]]
+//  CHECK-SAME:     [%[[CAST1]], %[[CAST0]], 0, 0] [1, 1, 100, 100] [1, 1, 1, 1]
+//  CHECK-SAME:     tensor<2x2x100x100xi32> to tensor<1x1x100x100xi32>
+//       CHECK:   %[[COLLAPSE:.+]] = tensor.collapse_shape %[[SLICE]]
+//  CHECK-SAME:     tensor<1x1x100x100xi32> into tensor<100x100xi32>
+//       CHECK:   return %[[COLLAPSE]] : tensor<100x100xi32>

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/canonicalize.mlir
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/IR/test/canonicalize.mlir
@@ -45,7 +45,6 @@ func.func @gather_to_extract_slice_expand(%source : tensor<1024x128xi32>, %indic
     outs(%empty: tensor<1x1x128xi32>) -> tensor<1x1x128xi32>
   return %result : tensor<1x1x128xi32>
 }
-
 // CHECK-LABEL: @gather_to_extract_slice_expand
 //  CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
 //  CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
@@ -56,7 +55,7 @@ func.func @gather_to_extract_slice_expand(%source : tensor<1024x128xi32>, %indic
 //  CHECK-SAME:     [%[[CAST]], 0] [1, 128] [1, 1]
 //  CHECK-SAME:     tensor<1024x128xi32> to tensor<1x128xi32>
 //       CHECK:   %[[EXPAND:.+]] = tensor.expand_shape %[[SLICE]]
-//       CHECK:   return %[[EXPAND]] : tensor<1x1x128xi32>
+//  CHECK-SAME:     tensor<1x128xi32> into tensor<1x1x128xi32>
 
 // -----
 
@@ -67,7 +66,6 @@ func.func @gather_to_extract_slice_no_reshape(%source : tensor<1024x128xi32>, %i
     outs(%empty: tensor<1x128xi32>) -> tensor<1x128xi32>
   return %result : tensor<1x128xi32>
 }
-
 // CHECK-LABEL: @gather_to_extract_slice_no_reshape
 //  CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
 //  CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
@@ -77,7 +75,6 @@ func.func @gather_to_extract_slice_no_reshape(%source : tensor<1024x128xi32>, %i
 //       CHECK:   %[[SLICE:.+]] = tensor.extract_slice %[[ARG0]]
 //  CHECK-SAME:     [%[[CAST]], 0] [1, 128] [1, 1]
 //  CHECK-SAME:     tensor<1024x128xi32> to tensor<1x128xi32>
-//       CHECK:   return %[[SLICE]] : tensor<1x128xi32>
 
 // -----
 
@@ -88,7 +85,6 @@ func.func @gather_to_extract_slice_perm(%source : tensor<10x1024x128xi32>, %indi
     outs(%empty: tensor<1x1x128xi32>) -> tensor<1x1x128xi32>
   return %result : tensor<1x1x128xi32>
 }
-
 // CHECK-LABEL: @gather_to_extract_slice_perm
 //  CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
 //  CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
@@ -101,7 +97,6 @@ func.func @gather_to_extract_slice_perm(%source : tensor<10x1024x128xi32>, %indi
 //       CHECK:   %[[SLICE:.+]] = tensor.extract_slice %[[ARG0]]
 //  CHECK-SAME:     [%[[CAST1]], %[[CAST0]], 0] [1, 1, 128] [1, 1, 1]
 //  CHECK-SAME:     tensor<10x1024x128xi32> to tensor<1x1x128xi32>
-//       CHECK:   return %[[SLICE]] : tensor<1x1x128xi32>
 
 // -----
 
@@ -112,7 +107,6 @@ func.func @gather_to_extract_slice_full_collapse(%source : tensor<2x2x1xi32>, %i
     outs(%empty: tensor<1xi32>) -> tensor<1xi32>
   return %result : tensor<1xi32>
 }
-
 // CHECK-LABEL: @gather_to_extract_slice_full_collapse
 //  CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
 //  CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
@@ -127,7 +121,6 @@ func.func @gather_to_extract_slice_full_collapse(%source : tensor<2x2x1xi32>, %i
 //  CHECK-SAME:     tensor<2x2x1xi32> to tensor<1x1x1xi32>
 //       CHECK:   %[[COLLAPSE:.+]] = tensor.collapse_shape %[[SLICE]]
 //  CHECK-SAME:     tensor<1x1x1xi32> into tensor<1xi32>
-//       CHECK:   return %[[COLLAPSE]] : tensor<1xi32>
 
 // -----
 
@@ -138,7 +131,6 @@ func.func @gather_to_extract_slice_partial_collapse(%source : tensor<2x2x100x100
     outs(%empty: tensor<100x100xi32>) -> tensor<100x100xi32>
   return %result : tensor<100x100xi32>
 }
-
 // CHECK-LABEL: @gather_to_extract_slice_partial_collapse
 //  CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
 //  CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
@@ -153,4 +145,3 @@ func.func @gather_to_extract_slice_partial_collapse(%source : tensor<2x2x100x100
 //  CHECK-SAME:     tensor<2x2x100x100xi32> to tensor<1x1x100x100xi32>
 //       CHECK:   %[[COLLAPSE:.+]] = tensor.collapse_shape %[[SLICE]]
 //  CHECK-SAME:     tensor<1x1x100x100xi32> into tensor<100x100xi32>
-//       CHECK:   return %[[COLLAPSE]] : tensor<100x100xi32>

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -104,26 +104,6 @@ Operation *getSlice(OpBuilder &b, Location loc, Value src,
       });
 }
 
-Operation *getElement(OpBuilder &b, Location loc, Value src,
-                      ArrayRef<OpFoldResult> indices) {
-  SmallVector<Value> valueIndices =
-      llvm::map_to_vector(indices, [&](OpFoldResult ofr) {
-        return getValueOrCreateConstantIndexOp(b, loc, ofr);
-      });
-
-  return TypeSwitch<Type, Operation *>(src.getType())
-      .Case<RankedTensorType>([&](RankedTensorType t) -> Operation * {
-        return b.create<tensor::ExtractOp>(loc, src, valueIndices);
-      })
-      .Case<MemRefType>([&](MemRefType type) -> Operation * {
-        return b.create<memref::LoadOp>(loc, src, valueIndices);
-      })
-      .Default([&](Type t) -> Operation * {
-        assert(false && "invalid type");
-        return nullptr;
-      });
-}
-
 Value castValue(OpBuilder &b, Location loc, Value src, ShapedType type) {
   return TypeSwitch<Type, Value>(src.getType())
       .Case<RankedTensorType>([&](RankedTensorType t) -> Value {

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -104,6 +104,26 @@ Operation *getSlice(OpBuilder &b, Location loc, Value src,
       });
 }
 
+Operation *getElement(OpBuilder &b, Location loc, Value src,
+                      ArrayRef<OpFoldResult> indices) {
+  SmallVector<Value> valueIndices =
+      llvm::map_to_vector(indices, [&](OpFoldResult ofr) {
+        return getValueOrCreateConstantIndexOp(b, loc, ofr);
+      });
+
+  return TypeSwitch<Type, Operation *>(src.getType())
+      .Case<RankedTensorType>([&](RankedTensorType t) -> Operation * {
+        return b.create<tensor::ExtractOp>(loc, src, valueIndices);
+      })
+      .Case<MemRefType>([&](MemRefType type) -> Operation * {
+        return b.create<memref::LoadOp>(loc, src, valueIndices);
+      })
+      .Default([&](Type t) -> Operation * {
+        assert(false && "invalid type");
+        return nullptr;
+      });
+}
+
 Value castValue(OpBuilder &b, Location loc, Value src, ShapedType type) {
   return TypeSwitch<Type, Value>(src.getType())
       .Case<RankedTensorType>([&](RankedTensorType t) -> Value {

--- a/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests.mlir
@@ -325,10 +325,10 @@ util.func public @make_single_dispatch(%arg0: tensor<16x8x32x2048xbf16>, %arg1: 
 
 // -----
 
-util.func public @gather_matmul(%source : tensor<2x2x100x100xi32>, %indices : tensor<2xi32>, %arg2 : tensor<100x100xi32>, %arg3 : tensor<100x100xi32>) -> tensor<100x100xi32> {
+util.func public @gather_matmul(%source : tensor<20x20x100xi32>, %indices : tensor<100x2xi32>, %arg2 : tensor<100x100xi32>, %arg3 : tensor<100x100xi32>) -> tensor<100x100xi32> {
   %empty = tensor.empty() : tensor<100x100xi32>
   %result = iree_linalg_ext.gather dimension_map = [1, 0]
-                          ins(%source, %indices : tensor<2x2x100x100xi32>, tensor<2xi32>)
+                          ins(%source, %indices : tensor<20x20x100xi32>, tensor<100x2xi32>)
                           outs(%empty: tensor<100x100xi32>) -> tensor<100x100xi32>
   %mm = linalg.matmul_transpose_b ins(%result, %arg2 : tensor<100x100xi32>, tensor<100x100xi32>) outs(%arg3 : tensor<100x100xi32>) -> tensor<100x100xi32>
   util.return %mm : tensor<100x100xi32>
@@ -343,10 +343,10 @@ util.func public @gather_matmul(%source : tensor<2x2x100x100xi32>, %indices : te
 
 // -----
 
-util.func public @single_gather(%source : tensor<2x2x100x100xi32>, %indices : tensor<2xi32>, %arg2 : tensor<100x100xi32>, %arg3 : tensor<100x100xi32>) -> tensor<100x100xi32> {
+util.func public @single_gather(%source : tensor<20x20x100xi32>, %indices : tensor<100x2xi32>, %arg2 : tensor<100x100xi32>, %arg3 : tensor<100x100xi32>) -> tensor<100x100xi32> {
   %empty = tensor.empty() : tensor<100x100xi32>
   %result = iree_linalg_ext.gather dimension_map = [1, 0]
-                          ins(%source, %indices : tensor<2x2x100x100xi32>, tensor<2xi32>)
+                          ins(%source, %indices : tensor<20x20x100xi32>, tensor<100x2xi32>)
                           outs(%empty: tensor<100x100xi32>) -> tensor<100x100xi32>
   util.return %result : tensor<100x100xi32>
 }


### PR DESCRIPTION
Adds canonicalizer to `iree_linalg_ext.gather` to convert to a `tensor.extract_slice` when there is only a single contiguous slice gathered by the op (aka a single batch of indices).


Also, I had to fixup `compiler/src/iree/compiler/DispatchCreation/test/pipeline_tests.mlir` so that the gathers didn't get converted.