### PR TITLE
[Preprocessing] Add SinkReshapesPass in MakeSingleDispatchPassPipeline

### DIFF
--- a/compiler/src/iree/compiler/Preprocessing/Common/test/attr_based_pipeline.mlir
+++ b/compiler/src/iree/compiler/Preprocessing/Common/test/attr_based_pipeline.mlir
@@ -52,6 +52,37 @@ func.func @single_dispatch_fusion(%lhs : tensor<18x288xf32>, %rhs :  tensor<18x2
 //   CHECK-NOT:     linalg.generic
 
 // -----
+// Verifies the `tensor.expand_shape` op remains positioned after the elementwise op.
+
+func.func @single_dispatch_bubble_and_sink_expand_shape(%arg0 : tensor<16x50x32x2048xbf16>, %arg1 : tensor<16x16x32x2048xbf16>, %arg2 : tensor<2048x3x2048xf32>)
+    -> tensor<2048x3x1x2048xbf16> attributes {
+    preprocessing_pipeline = #util.preprocessing_pipeline<"iree-preprocessing-make-single-dispatch">} {
+  %0 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d1 + d4 * 3, d5, d2)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d4, d5, d0)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%arg0, %arg1 : tensor<16x50x32x2048xbf16>, tensor<16x16x32x2048xbf16>) outs(%arg2 : tensor<2048x3x2048xf32>) {
+  ^bb0(%in: bf16, %in_1: bf16, %out: f32):
+    %10 = arith.extf %in : bf16 to f32
+    %11 = arith.extf %in_1 : bf16 to f32
+    %12 = arith.mulf %10, %11 : f32
+    %13 = arith.addf %out, %12 : f32
+    linalg.yield %13 : f32
+  } -> tensor<2048x3x2048xf32>
+  %1 = tensor.empty() : tensor<2048x3x2048xbf16>
+  %2 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%0 : tensor<2048x3x2048xf32>) outs(%1 : tensor<2048x3x2048xbf16>) {
+  ^bb0(%in: f32, %out: bf16):
+    %10 = arith.truncf %in : f32 to bf16
+    linalg.yield %10 : bf16
+  } -> tensor<2048x3x2048xbf16>
+  %expanded = tensor.expand_shape %2 [[0], [1, 2], [3]] output_shape [2048, 3, 1, 2048] : tensor<2048x3x2048xbf16> into tensor<2048x3x1x2048xbf16>
+  return %expanded : tensor<2048x3x1x2048xbf16>
+}
+
+// CHECK-LABEL: @single_dispatch_bubble_and_sink_expand_shape
+//       CHECK:   %[[DISPATCH:.+]] = flow.dispatch.region
+//       CHECK:     linalg.generic
+//   CHECK-NOT:     tensor.expand_shape
+//       CHECK:     linalg.generic
+//       CHECK:     tensor.expand_shape
+
+// -----
 
 module {
 func.func @function1(%lhs : tensor<10x20xf16>, %rhs : tensor<20x40xf16>,

--- a/compiler/src/iree/compiler/Preprocessing/Passes.cpp
+++ b/compiler/src/iree/compiler/Preprocessing/Passes.cpp
@@ -158,6 +158,9 @@ buildMakeSingleDispatchPassPipeline(OpPassManager &passManager,
   passManager.addPass(DispatchCreation::createElementwiseOpFusionPass(
       DispatchCreation::ElementwiseOpFusionPassOptions{
           /*enableElementWiseFuseMultiReduction=*/true}));
+  // After elementwise operation fusion sink reshapes that block
+  // producer-consumer fusion.
+  passManager.addPass(DispatchCreation::createSinkReshapesPass());
   passManager.addPass(createMakeSingleDispatchForFunctionPass());
 }
 


### PR DESCRIPTION
This PR adds `SinkReshapesPass` after `BubbleUpExpandShapesPass` and `ElementwiseOpFusionPass` to enable producer-consumer fusion that was blocked by the reshape ops. This is similar to https://github.com/iree-org/iree/blob/9789fe675d50fe6163552655177dec7d60557546/compiler/src/iree/compiler/DispatchCreation/Passes.cpp#L156.

For example, the IR before is as
```
util.func public @conv_2d_bfloat16_weight_backward_16x48x32x2048_nhwc_2048x3x1x2048_fhwc_nhwf_3x1s_1x0p_1x1d_1g$async(%arg0: !hal.buffer_view, %arg1: !hal.buffer_view, %arg2: !hal.fence, %arg3: !hal.fence) -> !hal.buffer_view attributes {inlining_policy = #util.inline.never, iree.abi.model = "coarse-fences", iree.abi.stub, preprocessing_pipeline = #util.preprocessing_pipeline<"iree-preprocessing-make-single-dispatch">} {
  %cst = arith.constant 0.000000e+00 : bf16
  %cst_0 = arith.constant 0.000000e+00 : f32
  %0 = hal.tensor.import wait(%arg2) => %arg0 : !hal.buffer_view -> tensor<16x16x32x2048xbf16>
  %1 = hal.tensor.import wait(%arg2) => %arg1 : !hal.buffer_view -> tensor<16x48x32x2048xbf16>
  %padded = tensor.pad %1 low[0, 1, 0, 0] high[0, 1, 0, 0] {
  ^bb0(%arg4: index, %arg5: index, %arg6: index, %arg7: index):
    tensor.yield %cst : bf16
  } : tensor<16x48x32x2048xbf16> to tensor<16x50x32x2048xbf16>
  %2 = tensor.empty() : tensor<2048x3x2048xf32>
  %3 = linalg.fill ins(%cst_0 : f32) outs(%2 : tensor<2048x3x2048xf32>) -> tensor<2048x3x2048xf32>
  %4 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d1 + d4 * 3, d5, d2)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d4, d5, d0)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel", "reduction", "reduction", "reduction"]} ins(%padded, %0 : tensor<16x50x32x2048xbf16>, tensor<16x16x32x2048xbf16>) outs(%3 : tensor<2048x3x2048xf32>) {
  ^bb0(%in: bf16, %in_1: bf16, %out: f32):
    %9 = arith.extf %in : bf16 to f32
    %10 = arith.extf %in_1 : bf16 to f32
    %11 = arith.mulf %9, %10 : f32
    %12 = arith.addf %out, %11 : f32
    linalg.yield %12 : f32
  } -> tensor<2048x3x2048xf32>
  %expanded = tensor.expand_shape %4 [[0], [1, 2], [3]] output_shape [2048, 3, 1, 2048] : tensor<2048x3x2048xf32> into tensor<2048x3x1x2048xf32>
  %5 = tensor.empty() : tensor<2048x3x1x2048xbf16>
  %6 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%expanded : tensor<2048x3x1x2048xf32>) outs(%5 : tensor<2048x3x1x2048xbf16>) {
  ^bb0(%in: f32, %out: bf16):
    %9 = arith.truncf %in : f32 to bf16
    linalg.yield %9 : bf16
  } -> tensor<2048x3x1x2048xbf16>
  %7 = hal.tensor.barrier join(%6 : tensor<2048x3x1x2048xbf16>) => %arg3 : !hal.fence
  %8 = hal.tensor.export %7 : tensor<2048x3x1x2048xbf16> -> !hal.buffer_view
  util.return %8 : !hal.buffer_view
}
```
`tensor.expand_shape` op would block the fusion and result in large allocation on stack.  After adding the pass, it sinks the `tensor.expand_shape` after the elementwise op.