### PR TITLE
[Flow] Dump affinity info in DumpDispatchGraph pass.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DumpDispatchGraph.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DumpDispatchGraph.cpp
@@ -12,7 +12,9 @@
 
 #include <utility>
 
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
+#include "iree/compiler/Dialect/Stream/IR/StreamInterfaces.h"
 #include "iree/compiler/Dialect/TensorExt/IR/TensorExtOps.h"
 #include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
@@ -477,6 +479,13 @@ private:
         }
       } else {
         os << op->getName() << "\n";
+      }
+      if (auto affinityOp = dyn_cast<IREE::Stream::AffinityOpInterface>(op)) {
+        os << affinityOp.getAffinityAttr();
+      } else if (auto transferOp = dyn_cast<IREE::Flow::TensorTransferOp>(op)) {
+        os << transferOp.getTarget() << "\n";
+      } else if (auto barrierOp = dyn_cast<IREE::Flow::TensorBarrierOp>(op)) {
+        os << barrierOp.getTarget() << "\n";
       }
 
       if (printResultTypes) {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DumpDispatchGraph.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DumpDispatchGraph.cpp
@@ -481,7 +481,7 @@ private:
         os << op->getName() << "\n";
       }
       if (auto affinityOp = dyn_cast<IREE::Stream::AffinityOpInterface>(op)) {
-        os << affinityOp.getAffinityAttr();
+        os << affinityOp.getAffinityAttr() << "\n";
       } else if (auto transferOp = dyn_cast<IREE::Flow::TensorTransferOp>(op)) {
         os << transferOp.getTarget() << "\n";
       } else if (auto barrierOp = dyn_cast<IREE::Flow::TensorBarrierOp>(op)) {


### PR DESCRIPTION
No tests are added because they don't exist. It dumps more information, so we can do basic affinity analysis outside the main tree. E.g., people can use the tool from https://github.com/hanhanW/iree-toolbox to verify if the input program has reasonable affinity assignment or not.