### PR TITLE
Fix Link error when `IREECompiler.lib` hits 4GiB

### DIFF
--- a/build_tools/cmake/build_all.sh
+++ b/build_tools/cmake/build_all.sh
@@ -51,7 +51,7 @@ declare -a CMAKE_ARGS=(
   "-DIREE_ENABLE_LLD=ON"
 
   # Potential workaround for 4GiB PDB limit
-  "-DIREE_LINK_COMPILER_SHARED_LIBRARY=OFF"
+  "-DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded"
 
   # Enable docs build on the CI. The additional builds are pretty fast and
   # give us early warnings for some types of website publication errors.

--- a/build_tools/cmake/build_all.sh
+++ b/build_tools/cmake/build_all.sh
@@ -50,6 +50,9 @@ declare -a CMAKE_ARGS=(
   # Use `lld` for faster linking.
   "-DIREE_ENABLE_LLD=ON"
 
+  # Potential workaround for 4GiB PDB limit
+  "-DIREE_LINK_COMPILER_SHARED_LIBRARY=OFF"
+
   # Enable docs build on the CI. The additional builds are pretty fast and
   # give us early warnings for some types of website publication errors.
   "-DIREE_BUILD_DOCS=ON"

--- a/build_tools/cmake/build_all.sh
+++ b/build_tools/cmake/build_all.sh
@@ -50,9 +50,6 @@ declare -a CMAKE_ARGS=(
   # Use `lld` for faster linking.
   "-DIREE_ENABLE_LLD=ON"
 
-  # Potential workaround for 4GiB PDB limit
-  "-DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded"
-
   # Enable docs build on the CI. The additional builds are pretty fast and
   # give us early warnings for some types of website publication errors.
   "-DIREE_BUILD_DOCS=ON"

--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -122,10 +122,10 @@ if [[ "${OSTYPE}" =~ ^msys ]]; then
     "iree/tests/e2e/matmul/e2e_matmul_vmvx_dt_uk_i8_small_vmvx_local-task"
     "iree/tests/e2e/matmul/e2e_matmul_vmvx_dt_uk_f32_small_vmvx_local-task"
     # TODO: Regressed when `pack` ukernel gained a uint64_t parameter in #13264.
-    "iree/tests/e2e/tensor_ops/check_vmvx_ukernel_local-task_pack.mlir"
-    "iree/tests/e2e/tensor_ops/check_vmvx_ukernel_local-task_pack_dynamic_inner_tiles.mlir"
+    "iree/tests/e2e/linalg/check_vmvx_ukernel_local-task_pack.mlir"
+    "iree/tests/e2e/linalg/check_vmvx_ukernel_local-task_pack_dynamic_inner_tiles.mlir"
     # TODO: Fix equality mismatch
-    "iree/tests/e2e/tensor_ops/check_vmvx_ukernel_local-task_unpack.mlir"
+    "iree/tests/e2e/linalg/check_vmvx_ukernel_local-task_unpack.mlir"
     # TODO(#11070): Fix argument/result signature mismatch
     "iree/tests/e2e/tosa_ops/check_vmvx_local-sync_microkernels_matmul.mlir"
     # Flaky on CI opening the .safetensors testdata for unknown reasons, skip.

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -417,6 +417,9 @@ iree_select_compiler_opts(IREE_DEFAULT_LINKOPTS
     ${_IREE_LOGGING_LINKOPTS}
   MSVC
     "-natvis:${IREE_ROOT_DIR}/runtime/iree.natvis"
+    
+    # Added to fix "LNK1318" error when "IREECompiler.pdb" exceeds 4GiB per:
+    # https://github.com/iree-org/iree/issues/20763#issuecomment-2902057042
     "-pdbpagesize:32768"
 )
 

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -417,6 +417,7 @@ iree_select_compiler_opts(IREE_DEFAULT_LINKOPTS
     ${_IREE_LOGGING_LINKOPTS}
   MSVC
     "-natvis:${IREE_ROOT_DIR}/runtime/iree.natvis"
+    "/pdbpagesize:32768"
 )
 
 if(EMSCRIPTEN AND IREE_EXTERNAL_WEBGPU_HAL_DRIVER_FOUND)

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -417,7 +417,7 @@ iree_select_compiler_opts(IREE_DEFAULT_LINKOPTS
     ${_IREE_LOGGING_LINKOPTS}
   MSVC
     "-natvis:${IREE_ROOT_DIR}/runtime/iree.natvis"
-    "/pdbpagesize:32768"
+    "-pdbpagesize:32768"
 )
 
 if(EMSCRIPTEN AND IREE_EXTERNAL_WEBGPU_HAL_DRIVER_FOUND)

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -417,7 +417,7 @@ iree_select_compiler_opts(IREE_DEFAULT_LINKOPTS
     ${_IREE_LOGGING_LINKOPTS}
   MSVC
     "-natvis:${IREE_ROOT_DIR}/runtime/iree.natvis"
-    
+
     # Added to fix "LNK1318" error when "IREECompiler.pdb" exceeds 4GiB per:
     # https://github.com/iree-org/iree/issues/20763#issuecomment-2902057042
     "-pdbpagesize:32768"


### PR DESCRIPTION
per https://github.com/iree-org/iree/issues/20763#issuecomment-2902057042
Added `"-pdbpagesize:32768"` to `iree_copts.cmake`

This allows the `IREECompiler.pdb` to bypass the default 4GiB size limit.
The `Building IREE` step successfully completes:
`Building IREE - 17m 10s`
https://github.com/iree-org/iree/actions/runs/15194992529/job/42736750558