### PR TITLE
[Codegen][NFC] Make namespace usage follow IREE::[Encoding|Codegen].

### DIFF
--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/CPUEncodingExternalModels.cpp
@@ -53,8 +53,8 @@
 
 namespace mlir::iree_compiler::IREE::CPU {
 
-using Codegen::MaterializeEncodingInfo;
-using Codegen::TileMxNxK;
+using IREE::Codegen::MaterializeEncodingInfo;
+using IREE::Codegen::TileMxNxK;
 
 namespace {
 
@@ -606,7 +606,7 @@ struct CPUDeviceEncodingPackedLayoutAttrInterface
       return info;
     }
     info = std::move(maybeEncodingInfo.value());
-    if (Encoding::isNarrowNResult(encoding)) {
+    if (IREE::Encoding::isNarrowNResult(encoding)) {
       transposeInPlace(info);
     }
     return info;
@@ -742,7 +742,7 @@ struct VMVXDeviceEncodingPackedLayoutAttrInterface final
       return info;
     }
     info = std::move(maybeEncodingInfo.value());
-    if (Encoding::isNarrowNResult(encoding)) {
+    if (IREE::Encoding::isNarrowNResult(encoding)) {
       transposeInPlace(info);
     }
     return info;

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -349,7 +349,7 @@ struct GPUDeviceEncodingPackedLayoutAttrInterface
     info = std::move(maybeEncodingInfo.value());
     auto fragment = static_cast<IREE::GPU::MMAFragment>(
         encoding.getOperandIndex().getInt());
-    FailureOr<TileSwizzle> maybeSwizzle =
+    FailureOr<IREE::Codegen::TileSwizzle> maybeSwizzle =
         getEncodingSwizzle(encoding, mma, fragment);
     if (failed(maybeSwizzle)) {
       return info;

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/GPUEncodingExternalModels.cpp
@@ -52,8 +52,8 @@
 
 namespace mlir::iree_compiler::IREE::GPU {
 
-using Codegen::MaterializeEncodingInfo;
-using Codegen::TileMxNxK;
+using IREE::Codegen::MaterializeEncodingInfo;
+using IREE::Codegen::TileMxNxK;
 
 namespace {
 
@@ -82,7 +82,7 @@ static MMAAttr chooseIntrinsicMMAAttr(TypeRange eTypes, TargetWgpAttr wgp) {
 
 static DataTiledMMAAttr
 chooseDataTiledMMAAttr(TypeRange eTypes, TargetAttr target,
-                       Encoding::EncodingAttr encoding) {
+                       IREE::Encoding::EncodingAttr encoding) {
   if (!target) {
     return {};
   }
@@ -349,7 +349,7 @@ struct GPUDeviceEncodingPackedLayoutAttrInterface
     info = std::move(maybeEncodingInfo.value());
     auto fragment = static_cast<IREE::GPU::MMAFragment>(
         encoding.getOperandIndex().getInt());
-    FailureOr<Codegen::TileSwizzle> maybeSwizzle =
+    FailureOr<TileSwizzle> maybeSwizzle =
         getEncodingSwizzle(encoding, mma, fragment);
     if (failed(maybeSwizzle)) {
       return info;
@@ -417,7 +417,7 @@ struct GPUHostEncodingLayoutResolverAttrInterface final
 };
 
 struct GPUPadDeviceEncodingLayoutAttrInterface final
-    : Encoding::LayoutAttrInterface::ExternalModel<
+    : IREE::Encoding::LayoutAttrInterface::ExternalModel<
           GPUPadDeviceEncodingLayoutAttrInterface, GPUPadLayoutAttr> {
   Operation *lowerOp(Attribute attr, OpBuilder &b, Operation *op,
                      TypeRange convertedResTypes,
@@ -427,7 +427,7 @@ struct GPUPadDeviceEncodingLayoutAttrInterface final
 };
 
 struct GPUPadEncodingLayoutResolverAttrInterface final
-    : Encoding::EncodingLayoutResolverAttrInterface::ExternalModel<
+    : IREE::Encoding::EncodingLayoutResolverAttrInterface::ExternalModel<
           GPUPadEncodingLayoutResolverAttrInterface, GPUPadLayoutAttr> {
   Attribute cloneWithSimplifiedConfig(Attribute attr,
                                       DictionaryAttr config) const {
@@ -445,12 +445,12 @@ struct GPUPadEncodingLayoutResolverAttrInterface final
     MLIRContext *ctx = attr.getContext();
     auto padLayoutAttr = cast<GPUPadLayoutAttr>(attr);
     auto contractionEncodingAttr =
-        dyn_cast_or_null<Encoding::ContractionEncodingAttrInterface>(
+        dyn_cast_or_null<IREE::Encoding::ContractionEncodingAttrInterface>(
             type.getEncoding());
 
     const int64_t rank = type.getRank();
     auto noPaddingAttr =
-        Encoding::PadEncodingLayoutAttr::getIdentityAttr(ctx, rank);
+        IREE::Encoding::PadEncodingLayoutAttr::getIdentityAttr(ctx, rank);
     if (!padLayoutAttr.getCacheLineBytes() || !padLayoutAttr.getCacheSets()) {
       return noPaddingAttr;
     }
@@ -540,7 +540,7 @@ struct GPUPadEncodingLayoutResolverAttrInterface final
     const int64_t numPadElements = (padBytes * 8) / elementBits;
     SmallVector<int64_t> padValues(rank, 0);
     padValues[padDimensionIndex] = numPadElements;
-    auto padLayout = Encoding::PadEncodingLayoutAttr::get(ctx, padValues);
+    auto padLayout = IREE::Encoding::PadEncodingLayoutAttr::get(ctx, padValues);
     return padLayout;
   }
 };

--- a/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/ExternalInterfaces/Utils.cpp
@@ -19,7 +19,7 @@
 #include "mlir/IR/MLIRContext.h"
 
 namespace mlir::iree_compiler::IREE {
-using Codegen::MaterializeEncodingInfo;
+using IREE::Codegen::MaterializeEncodingInfo;
 
 Value calculatePackedStorageSizeInBytesImpl(Attribute attr, Location loc,
                                             OpBuilder &builder,


### PR DESCRIPTION
In the core dialect, we prefer fully specify type name. This makes it easier to do large scale replacements, avoids conflicts with mlir upstream types, and makes it easier to port passes between dialects.

The revision also removes the using-directives (e.g., using namespace foo), because we don't want to pollute the codebase.