### PR TITLE
[NFC] Rename load_from/store_to_memref to load_from/store_to_buffer

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BufferizeDispatchTensorLoadStore.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BufferizeDispatchTensorLoadStore.cpp
@@ -56,7 +56,7 @@ bufferizeDispatchTensorLoad(RewriterBase &rewriter,
       rewriter, loadOp.getLoc(), subspanOp, loadOp.getType(),
       loadOp.getMixedOffsets(), loadOp.getMixedSizes(),
       loadOp.getMixedStrides());
-  rewriter.replaceOpWithNewOp<IREE::Codegen::LoadFromMemrefOp>(
+  rewriter.replaceOpWithNewOp<IREE::Codegen::LoadFromBufferOp>(
       loadOp, loadOp.getType(), sourceBuffer);
 }
 
@@ -68,10 +68,10 @@ bufferizeDispatchTensorStore(RewriterBase &rewriter,
   if (!subspanOp) {
     return;
   }
-  // For the store_to_memref op, generate any subviews as early as possible in
-  // the IR. This opens more opportunities for using the store_to_memref op's
+  // For the store_to_buffer op, generate any subviews as early as possible in
+  // the IR. This opens more opportunities for using the store_to_buffer op's
   // SubsetInsertionOpInterface, since equivalent subset extractions can only be
-  // created after the store_to_memref op's output (the subspan or subview) in
+  // created after the store_to_buffer op's output (the subspan or subview) in
   // the IR.
   OpBuilder::InsertionGuard g(rewriter);
   (void)setInsertionPointAfterLastNeededValue(
@@ -83,7 +83,7 @@ bufferizeDispatchTensorStore(RewriterBase &rewriter,
 
   Value tensor = storeOp.getValue();
   rewriter.setInsertionPoint(storeOp);
-  rewriter.replaceOpWithNewOp<IREE::Codegen::StoreToMemrefOp>(storeOp, tensor,
+  rewriter.replaceOpWithNewOp<IREE::Codegen::StoreToBufferOp>(storeOp, tensor,
                                                               outputBuffer);
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.h
+++ b/compiler/src/iree/compiler/Codegen/Common/CombineLayoutTransformation.h
@@ -32,15 +32,15 @@ using PadDistributionConfigFn = function_ref<SmallVector<DistributionConfig>(
     ArrayRef<int64_t> iterationBounds, MLIRContext *)>;
 
 /// Combines any layout/indexing transformation ops at the ends of a dispatch.
-/// Finds `iree_codegen.store_to_memref` ops in the `funcOp`, and combines any
+/// Finds `iree_codegen.store_to_buffer` ops in the `funcOp`, and combines any
 /// layout transformation ops (like expand_shape, transpose, pack, etc.) that
 /// produce the tensor being stored into a single `iree_linalg_ext.map_scatter`
 /// op.
 ///
 /// This transformation will also combine `tensor.pad` ops into the map_scatter
-/// op, by moving the writing of the padding values to after the store_to_memref
+/// op, by moving the writing of the padding values to after the store_to_buffer
 /// op, and writing the padding values directly to the output buffer of the
-/// store_to_memref. The writes of the pad values will be distributed based on
+/// store_to_buffer. The writes of the pad values will be distributed based on
 /// the `DistributionConfig`s returned by `padDistributionConfigFn`, and then
 /// the inner distributed tile will be tiled to a loop nest of memref.store ops.
 LogicalResult

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/Passes.td
@@ -35,12 +35,12 @@ def GPUCombineLayoutTransformationPass :
   let summary =
     "Combines layout transformation operations into a single map_scatter operation.";
   let description = [{
-    Starting from iree_codegen.store_to_memref ops, iteratively combine producer
+    Starting from iree_codegen.store_to_buffer ops, iteratively combine producer
     layout/indexing transformation ops (linalg.transpose, tensor.collapse_shape,
     etc.) into a single iree_linalg_ext.map_scatter operation. For tensor.pad
     ops, the writing of pad values is distributed to workgroups and threads, and
     then the padding values are written directly to the output buffer of the
-    store_to_memref op.
+    store_to_buffer op.
   }];
   let dependentDialects = [
     "iree_compiler::IREE::LinalgExt::IREELinalgExtDialect",

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_combine_layout_transformation.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_combine_layout_transformation.mlir
@@ -6,7 +6,7 @@ func.func @fold_pad_op(%source : tensor<250xf32>, %result : memref<256xf32>) {
   ^bb0(%arg0: index):
     tensor.yield %cst : f32
   } : tensor<250xf32> to tensor<256xf32>
-  iree_codegen.store_to_memref %padded, %result : tensor<256xf32> into memref<256xf32>
+  iree_codegen.store_to_buffer %padded, %result : tensor<256xf32> into memref<256xf32>
   return
 }
 //       CHECK: #[[$MAP:.+]] = affine_map<(d0) -> (256, d0 + 64)>
@@ -25,7 +25,7 @@ func.func @fold_pad_op(%source : tensor<250xf32>, %result : memref<256xf32>) {
 //  CHECK-NEXT:   ^bb0(%[[IDX0:.+]]: index):
 //       CHECK:     iree_linalg_ext.yield %[[IDX0]], %[[TRUE]]
 //       CHECK:   } : tensor<250xf32> into tensor<256xf32> -> tensor<256xf32>
-//       CHECK:   iree_codegen.store_to_memref %[[MAP_SCATTER]], %[[RESULT]] : tensor<256xf32> into memref<256xf32>
+//       CHECK:   iree_codegen.store_to_buffer %[[MAP_SCATTER]], %[[RESULT]] : tensor<256xf32> into memref<256xf32>
 
 //       CHECK:   scf.forall (%[[WG_IV:.+]]) = (0) to (256) step (64) {
 //       CHECK:     %[[WG_TILE_UB:.+]] = affine.min #[[$MAP]](%[[WG_IV]])

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -51,8 +51,8 @@ def BufferizeDispatchTensorLoadStorePass :
       "Bufferize the iree_tensor_ext.dispatch.tensor.load/store ops at dispatch boundaries";
   let description = [{
     Pass to bufferize the edges of dispatch regions, converting
-    iree_tensor_ext.dispatch.tensor.load ops to iree_codegen.load_from_memref, and
-    iree_tensor_ext.dispatch.tensor.store ops to iree_codegen.store_to_memref.
+    iree_tensor_ext.dispatch.tensor.load ops to iree_codegen.load_from_buffer, and
+    iree_tensor_ext.dispatch.tensor.store ops to iree_codegen.store_to_buffer.
   }];
   let dependentDialects = [
     "IREE::Codegen::IREECodegenDialect",
@@ -128,12 +128,12 @@ def CombineLayoutTransformationPass :
   let summary =
     "Combines layout transformation operations into a single map_scatter operation.";
   let description = [{
-    Starting from iree_codegen.store_to_memref ops, iteratively combine producer
+    Starting from iree_codegen.store_to_buffer ops, iteratively combine producer
     layout/indexing transformation ops (linalg.transpose, tensor.collapse_shape,
     etc.) into a single iree_linalg_ext.map_scatter operation. For tensor.pad
     ops, the writing of pad values is distributed to workgroups, and then the
     padding values are written directly to the output buffer of the
-    store_to_memref op.
+    store_to_buffer op.
   }];
   let dependentDialects = [
     "iree_compiler::IREE::LinalgExt::IREELinalgExtDialect",

--- a/compiler/src/iree/compiler/Codegen/Common/test/bufferize_dispatch_tensor_load_store.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/bufferize_dispatch_tensor_load_store.mlir
@@ -19,9 +19,9 @@ func.func @dispatch_tensor_load_and_store() {
 // CHECK-SAME:        binding(0) : memref<16xf32, #hal.descriptor_type<storage_buffer>>
 // CHECK:         %[[OUTPUT:.+]] = hal.interface.binding.subspan
 // CHECK-SAME:        binding(1) : memref<16xf32, #hal.descriptor_type<storage_buffer>>
-// CHECK:         %[[LOAD:.+]] = iree_codegen.load_from_memref %[[INPUT]]
+// CHECK:         %[[LOAD:.+]] = iree_codegen.load_from_buffer %[[INPUT]]
 // CHECK-SAME:        : memref<16xf32, #hal.descriptor_type<storage_buffer>> -> tensor<16xf32>
-// CHECK:         iree_codegen.store_to_memref %[[LOAD]], %[[OUTPUT]]
+// CHECK:         iree_codegen.store_to_buffer %[[LOAD]], %[[OUTPUT]]
 // CHECK-SAME:        : tensor<16xf32> into memref<16xf32, #hal.descriptor_type<storage_buffer>>
 
 // -----
@@ -51,9 +51,9 @@ func.func @dispatch_tensor_load_and_store_slices() {
 // CHECK:         %[[INPUT_SUBVIEW:.+]] = memref.subview %[[INPUT]][2] [12] [1]
 // CHECK-SAME:        : memref<16xf32, #hal.descriptor_type<storage_buffer>> to
 // CHECK-SAME:          memref<12xf32, strided<[1], offset: 2>, #hal.descriptor_type<storage_buffer>>
-// CHECK:         %[[LOAD:.+]] = iree_codegen.load_from_memref %[[INPUT_SUBVIEW]]
+// CHECK:         %[[LOAD:.+]] = iree_codegen.load_from_buffer %[[INPUT_SUBVIEW]]
 // CHECK-SAME:        : memref<12xf32, strided<[1], offset: 2>, #hal.descriptor_type<storage_buffer>> -> tensor<12xf32>
-// CHECK:         iree_codegen.store_to_memref %[[LOAD]], %[[OUTPUT_SUBVIEW]]
+// CHECK:         iree_codegen.store_to_buffer %[[LOAD]], %[[OUTPUT_SUBVIEW]]
 // CHECK-SAME:        : tensor<12xf32> into memref<12xf32, strided<[1], offset: 4>, #hal.descriptor_type<storage_buffer>>
 
 // -----
@@ -81,10 +81,10 @@ func.func @dispatch_tensor_load_and_store_with_compute_op() {
 // CHECK-SAME:        binding(1) : memref<16xf32, #hal.descriptor_type<storage_buffer>>
 // CHECK:         %[[OUTPUT_SUBVIEW:.+]] = memref.subview %[[OUTPUT]][4] [12] [1]
 // CHECK:         %[[INPUT_SUBVIEW:.+]] = memref.subview %[[INPUT]][2] [12] [1]
-// CHECK:         %[[LOAD:.+]] = iree_codegen.load_from_memref %[[INPUT_SUBVIEW]]
+// CHECK:         %[[LOAD:.+]] = iree_codegen.load_from_buffer %[[INPUT_SUBVIEW]]
 // CHECK:         %[[INIT:.+]] = tensor.empty() : tensor<12xf32>
 // CHECK:         %[[COPY:.+]] = linalg.copy ins(%[[LOAD]]{{.*}} outs(%[[INIT]]
-// CHECK:         iree_codegen.store_to_memref %[[COPY]], %[[OUTPUT_SUBVIEW]]
+// CHECK:         iree_codegen.store_to_buffer %[[COPY]], %[[OUTPUT_SUBVIEW]]
 
 // -----
 
@@ -117,9 +117,9 @@ func.func @dynamic_dispatch_tensor_load_and_store(%offset: index, %size: index, 
 // CHECK:         %[[INPUT_SUBVIEW:.+]] = memref.subview %[[INPUT]][%[[OFFSET]]] [%[[SIZE]]] [%[[STRIDE]]]
 // CHECK-SAME:        : memref<?xf32, #hal.descriptor_type<storage_buffer>> to
 // CHECK-SAME:          memref<?xf32, strided<[?], offset: ?>, #hal.descriptor_type<storage_buffer>>
-// CHECK:         %[[LOAD:.+]] = iree_codegen.load_from_memref %[[INPUT_SUBVIEW]]
+// CHECK:         %[[LOAD:.+]] = iree_codegen.load_from_buffer %[[INPUT_SUBVIEW]]
 // CHECK-SAME:        : memref<?xf32, strided<[?], offset: ?>, #hal.descriptor_type<storage_buffer>> -> tensor<?xf32>
-// CHECK:         iree_codegen.store_to_memref %[[LOAD]], %[[OUTPUT_SUBVIEW]]
+// CHECK:         iree_codegen.store_to_buffer %[[LOAD]], %[[OUTPUT_SUBVIEW]]
 // CHECK-SAME:        : tensor<?xf32> into memref<?xf32, strided<[?], offset: ?>, #hal.descriptor_type<storage_buffer>>
 
 // -----
@@ -149,7 +149,7 @@ func.func @rank_reducing_slices() {
 // CHECK:         %[[INPUT_SUBVIEW:.+]] = memref.subview %[[INPUT]][0, 2] [1, 12] [1, 1]
 // CHECK-SAME:        : memref<8x16xf32, #hal.descriptor_type<storage_buffer>> to
 // CHECK-SAME:          memref<12xf32, strided<[1], offset: 2>, #hal.descriptor_type<storage_buffer>>
-// CHECK:         %[[LOAD:.+]] = iree_codegen.load_from_memref %[[INPUT_SUBVIEW]]
+// CHECK:         %[[LOAD:.+]] = iree_codegen.load_from_buffer %[[INPUT_SUBVIEW]]
 // CHECK-SAME:        : memref<12xf32, strided<[1], offset: 2>, #hal.descriptor_type<storage_buffer>> -> tensor<12xf32>
-// CHECK:         iree_codegen.store_to_memref %[[LOAD]], %[[OUTPUT_SUBVIEW]]
+// CHECK:         iree_codegen.store_to_buffer %[[LOAD]], %[[OUTPUT_SUBVIEW]]
 // CHECK-SAME:        : tensor<12xf32> into memref<12xf32, strided<[1], offset: 4>, #hal.descriptor_type<storage_buffer>>

--- a/compiler/src/iree/compiler/Codegen/Common/test/combine_layout_transformation.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/combine_layout_transformation.mlir
@@ -2,7 +2,7 @@
 
 func.func @fold_collapse_shape_op(%source : tensor<2x4x16xf32>, %result : memref<8x16xf32>) {
   %collapse = tensor.collapse_shape %source [[0, 1], [2]] : tensor<2x4x16xf32> into tensor<8x16xf32>
-  iree_codegen.store_to_memref %collapse, %result : tensor<8x16xf32> into memref<8x16xf32>
+  iree_codegen.store_to_buffer %collapse, %result : tensor<8x16xf32> into memref<8x16xf32>
   return
 }
 // CHECK-LABEL: @fold_collapse_shape_op
@@ -17,13 +17,13 @@ func.func @fold_collapse_shape_op(%source : tensor<2x4x16xf32>, %result : memref
 //  CHECK-SAME:       [%[[IDX0]], %[[IDX1]]] by (2, 4)
 //       CHECK:     iree_linalg_ext.yield %[[LINEARIZE]], %[[IDX2]], %[[TRUE]]
 //       CHECK:   } : tensor<2x4x16xf32> into tensor<8x16xf32> -> tensor<8x16xf32>
-//       CHECK:   iree_codegen.store_to_memref %[[MAP_SCATTER]], %[[RESULT]] : tensor<8x16xf32> into memref<8x16xf32>
+//       CHECK:   iree_codegen.store_to_buffer %[[MAP_SCATTER]], %[[RESULT]] : tensor<8x16xf32> into memref<8x16xf32>
 
 // -----
 
 func.func @fold_expand_shape_op(%source : tensor<8x16xf32>, %result : memref<2x4x16xf32>) {
   %expand = tensor.expand_shape %source [[0, 1], [2]] output_shape [2, 4, 16] : tensor<8x16xf32> into tensor<2x4x16xf32>
-  iree_codegen.store_to_memref %expand, %result : tensor<2x4x16xf32> into memref<2x4x16xf32>
+  iree_codegen.store_to_buffer %expand, %result : tensor<2x4x16xf32> into memref<2x4x16xf32>
   return
 }
 // CHECK-LABEL: @fold_expand_shape_op
@@ -37,14 +37,14 @@ func.func @fold_expand_shape_op(%source : tensor<8x16xf32>, %result : memref<2x4
 //       CHECK:     %[[DELINEARIZE:.+]]:2 = affine.delinearize_index %[[IDX0]] into (2, 4)
 //       CHECK:     iree_linalg_ext.yield %[[DELINEARIZE]]#0, %[[DELINEARIZE]]#1, %[[IDX1]], %[[TRUE]]
 //       CHECK:   } : tensor<8x16xf32> into tensor<2x4x16xf32> -> tensor<2x4x16xf32>
-//       CHECK:   iree_codegen.store_to_memref %[[MAP_SCATTER]], %[[RESULT]] : tensor<2x4x16xf32> into memref<2x4x16xf32>
+//       CHECK:   iree_codegen.store_to_buffer %[[MAP_SCATTER]], %[[RESULT]] : tensor<2x4x16xf32> into memref<2x4x16xf32>
 
 // -----
 
 func.func @fold_transpose_op(%source : tensor<2x4x16xf32>, %result : memref<4x16x2xf32>) {
   %init = tensor.empty() : tensor<4x16x2xf32>
   %transposed = linalg.transpose ins(%source : tensor<2x4x16xf32>) outs(%init : tensor<4x16x2xf32>) permutation = [1, 2, 0]
-  iree_codegen.store_to_memref %transposed, %result : tensor<4x16x2xf32> into memref<4x16x2xf32>
+  iree_codegen.store_to_buffer %transposed, %result : tensor<4x16x2xf32> into memref<4x16x2xf32>
   return
 }
 // CHECK-LABEL: @fold_transpose_op
@@ -57,13 +57,13 @@ func.func @fold_transpose_op(%source : tensor<2x4x16xf32>, %result : memref<4x16
 //  CHECK-NEXT:   ^bb0(%[[IDX0:.+]]: index, %[[IDX1:.+]]: index, %[[IDX2:.+]]: index):
 //       CHECK:     iree_linalg_ext.yield %[[IDX1]], %[[IDX2]], %[[IDX0]], %[[TRUE]]
 //       CHECK:   } : tensor<2x4x16xf32> into tensor<4x16x2xf32> -> tensor<4x16x2xf32>
-//       CHECK:   iree_codegen.store_to_memref %[[MAP_SCATTER]], %[[RESULT]] : tensor<4x16x2xf32> into memref<4x16x2xf32>
+//       CHECK:   iree_codegen.store_to_buffer %[[MAP_SCATTER]], %[[RESULT]] : tensor<4x16x2xf32> into memref<4x16x2xf32>
 
 // -----
 
 func.func @fold_extract_slice_op(%source : tensor<64xf32>, %result : memref<63xf32>) {
   %slice = tensor.extract_slice %source[0] [63] [1] : tensor<64xf32> to tensor<63xf32>
-  iree_codegen.store_to_memref %slice, %result : tensor<63xf32> into memref<63xf32>
+  iree_codegen.store_to_buffer %slice, %result : tensor<63xf32> into memref<63xf32>
   return
 }
 // CHECK-LABEL: @fold_extract_slice_op
@@ -77,13 +77,13 @@ func.func @fold_extract_slice_op(%source : tensor<64xf32>, %result : memref<63xf
 //       CHECK:     %[[MASK:.+]] = arith.cmpi ult, %[[IDX0]], %[[C63]]
 //       CHECK:     iree_linalg_ext.yield %[[IDX0]], %[[MASK]]
 //       CHECK:   } : tensor<64xf32> into tensor<63xf32> -> tensor<63xf32>
-//       CHECK:   iree_codegen.store_to_memref %[[MAP_SCATTER]], %[[RESULT]] : tensor<63xf32> into memref<63xf32>
+//       CHECK:   iree_codegen.store_to_buffer %[[MAP_SCATTER]], %[[RESULT]] : tensor<63xf32> into memref<63xf32>
 
 // -----
 
 func.func @no_fold_offset_extract_slice_op(%source : tensor<64xf32>, %result : memref<4xf32>) {
   %slice = tensor.extract_slice %source[42] [4] [1] : tensor<64xf32> to tensor<4xf32>
-  iree_codegen.store_to_memref %slice, %result : tensor<4xf32> into memref<4xf32>
+  iree_codegen.store_to_buffer %slice, %result : tensor<4xf32> into memref<4xf32>
   return
 }
 // CHECK-LABEL: @no_fold_offset_extract_slice_op
@@ -94,7 +94,7 @@ func.func @no_fold_offset_extract_slice_op(%source : tensor<64xf32>, %result : m
 
 func.func @no_fold_strided_extract_slice_op(%source : tensor<64xf32>, %result : memref<16xf32>) {
   %slice = tensor.extract_slice %source[0] [16] [4] : tensor<64xf32> to tensor<16xf32>
-  iree_codegen.store_to_memref %slice, %result : tensor<16xf32> into memref<16xf32>
+  iree_codegen.store_to_buffer %slice, %result : tensor<16xf32> into memref<16xf32>
   return
 }
 // CHECK-LABEL: @no_fold_strided_extract_slice_op
@@ -109,7 +109,7 @@ func.func @fold_pad_op(%source : tensor<250xf32>, %result : memref<256xf32>) {
   ^bb0(%arg0: index):
     tensor.yield %cst : f32
   } : tensor<250xf32> to tensor<256xf32>
-  iree_codegen.store_to_memref %padded, %result : tensor<256xf32> into memref<256xf32>
+  iree_codegen.store_to_buffer %padded, %result : tensor<256xf32> into memref<256xf32>
   return
 }
 //       CHECK: #[[$MAP:.+]] = affine_map<(d0) -> (256, d0 + 64)>
@@ -127,7 +127,7 @@ func.func @fold_pad_op(%source : tensor<250xf32>, %result : memref<256xf32>) {
 //  CHECK-NEXT:   ^bb0(%[[IDX0:.+]]: index):
 //       CHECK:     iree_linalg_ext.yield %[[IDX0]], %[[TRUE]]
 //       CHECK:   } : tensor<250xf32> into tensor<256xf32> -> tensor<256xf32>
-//       CHECK:   iree_codegen.store_to_memref %[[MAP_SCATTER]], %[[RESULT]] : tensor<256xf32> into memref<256xf32>
+//       CHECK:   iree_codegen.store_to_buffer %[[MAP_SCATTER]], %[[RESULT]] : tensor<256xf32> into memref<256xf32>
 
 //       CHECK:   scf.forall (%[[WG_IV:.+]]) = (0) to (256) step (64) {
 //       CHECK:     %[[WG_TILE_UB:.+]] = affine.min #[[$MAP]](%[[WG_IV]])
@@ -152,7 +152,7 @@ func.func @fold_unpack_op(%source : tensor<?x?x128x128xf32>, %result : memref<?x
   %unpack = linalg.unpack %source
       outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [128, 128]
       into %dest : tensor<?x?x128x128xf32> -> tensor<?x?xf32>
-  iree_codegen.store_to_memref %unpack, %result : tensor<?x?xf32> into memref<?x?xf32>
+  iree_codegen.store_to_buffer %unpack, %result : tensor<?x?xf32> into memref<?x?xf32>
   return
 }
 //       CHECK: #[[$MAP:.+]] = affine_map<()[s0] -> (s0 * 128)>
@@ -181,7 +181,7 @@ func.func @fold_unpack_op(%source : tensor<?x?x128x128xf32>, %result : memref<?x
 //       CHECK:     %[[MASK:.+]] = arith.andi %[[BOUND0]], %[[BOUND1]] : i1
 //       CHECK:     iree_linalg_ext.yield %[[DELINEARIZE]]#0, %[[DELINEARIZE]]#1, %[[MASK]]
 //       CHECK:   } : tensor<?x?x128x128xf32> into tensor<?x?xf32> -> tensor<?x?xf32>
-//       CHECK:   iree_codegen.store_to_memref %[[MAP_SCATTER]], %[[RESULT]] : tensor<?x?xf32> into memref<?x?xf32>
+//       CHECK:   iree_codegen.store_to_buffer %[[MAP_SCATTER]], %[[RESULT]] : tensor<?x?xf32> into memref<?x?xf32>
 
 // -----
 
@@ -191,7 +191,7 @@ func.func @fold_pack_op(%source : tensor<250x250xf32>, %result : memref<2x2x128x
   %unpack = linalg.pack %source padding_value(%cst : f32)
       outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [128, 128]
       into %dest : tensor<250x250xf32> -> tensor<2x2x128x128xf32>
-  iree_codegen.store_to_memref %unpack, %result : tensor<2x2x128x128xf32> into memref<2x2x128x128xf32>
+  iree_codegen.store_to_buffer %unpack, %result : tensor<2x2x128x128xf32> into memref<2x2x128x128xf32>
   return
 }
 //       CHECK: #[[$MAP:.+]] = affine_map<(d0) -> (256, d0 + 1)>
@@ -214,7 +214,7 @@ func.func @fold_pack_op(%source : tensor<250x250xf32>, %result : memref<2x2x128x
 //  CHECK-SAME:       into (2, 128)
 //       CHECK:     iree_linalg_ext.yield %[[DELINEARIZE0]]#0, %[[DELINEARIZE1]]#0, %[[DELINEARIZE0]]#1, %[[DELINEARIZE1]]#1, %[[TRUE]]
 //       CHECK:   } : tensor<250x250xf32> into tensor<2x2x128x128xf32> -> tensor<2x2x128x128xf32>
-//       CHECK:   iree_codegen.store_to_memref %[[MAP_SCATTER]], %[[RESULT]] : tensor<2x2x128x128xf32> into memref<2x2x128x128xf32>
+//       CHECK:   iree_codegen.store_to_buffer %[[MAP_SCATTER]], %[[RESULT]] : tensor<2x2x128x128xf32> into memref<2x2x128x128xf32>
 
 //       CHECK:   scf.forall (%[[WG_IV0:.+]], %[[WG_IV1:.+]]) = (0, 0) to (256, 256) step (1, 64) {
 //   CHECK-DAG:     %[[WG_TILE_UB0:.+]] = affine.min #[[$MAP]](%[[WG_IV0]])

--- a/compiler/src/iree/compiler/Codegen/Common/test/eliminate_empty_tensors.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/eliminate_empty_tensors.mlir
@@ -38,21 +38,21 @@ func.func @eliminate_empty_tensors_with_store_op() {
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @eliminate_empty_tensors_with_store_to_memref_op() {
+func.func @eliminate_empty_tensors_with_store_to_buffer_op() {
   %c0 = arith.constant 0 : index
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<128xf32, #hal.descriptor_type<storage_buffer>>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : memref<128xf32, #hal.descriptor_type<storage_buffer>>
-  %2 = iree_codegen.load_from_memref %0 : memref<128xf32, #hal.descriptor_type<storage_buffer>> -> tensor<128xf32>
+  %2 = iree_codegen.load_from_buffer %0 : memref<128xf32, #hal.descriptor_type<storage_buffer>> -> tensor<128xf32>
   %3 = tensor.empty() : tensor<128xf32>
   %copy = linalg.copy ins(%2 : tensor<128xf32>) outs(%3 : tensor<128xf32>) -> tensor<128xf32>
-  iree_codegen.store_to_memref %copy, %1 : tensor<128xf32> into memref<128xf32, #hal.descriptor_type<storage_buffer>>
+  iree_codegen.store_to_buffer %copy, %1 : tensor<128xf32> into memref<128xf32, #hal.descriptor_type<storage_buffer>>
   return
 }
 
-// CHECK-LABEL: @eliminate_empty_tensors_with_store_to_memref_op
+// CHECK-LABEL: @eliminate_empty_tensors_with_store_to_buffer_op
 //     CHECK: %[[INPUT_SPAN:.+]] = hal.interface.binding.subspan{{.*}}binding(0)
 //     CHECK: %[[RESULT_SPAN:.+]] = hal.interface.binding.subspan{{.*}}binding(1)
-// CHECK-DAG: %[[INPUT:.+]] = iree_codegen.load_from_memref %[[INPUT_SPAN]]
-// CHECK-DAG: %[[INIT:.+]] = iree_codegen.load_from_memref %[[RESULT_SPAN]]
+// CHECK-DAG: %[[INPUT:.+]] = iree_codegen.load_from_buffer %[[INPUT_SPAN]]
+// CHECK-DAG: %[[INIT:.+]] = iree_codegen.load_from_buffer %[[RESULT_SPAN]]
 //     CHECK: %[[COPY:.+]] = linalg.copy ins(%[[INPUT]] : tensor<128xf32>) outs(%[[INIT]] : tensor<128xf32>)
-//     CHECK: iree_codegen.store_to_memref %[[COPY]], %[[RESULT_SPAN]]
+//     CHECK: iree_codegen.store_to_buffer %[[COPY]], %[[RESULT_SPAN]]

--- a/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
@@ -2955,16 +2955,16 @@ func.func @check_no_alloc() {
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @load_from_memref_store_to_memref() {
+func.func @load_from_buffer_store_to_buffer() {
   %c0 = arith.constant 0 : index
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<128xf32, #hal.descriptor_type<storage_buffer>>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : memref<128xf32, #hal.descriptor_type<storage_buffer>>
-  %2 = iree_codegen.load_from_memref %0 {read_only} : memref<128xf32, #hal.descriptor_type<storage_buffer>> -> tensor<128xf32>
-  iree_codegen.store_to_memref %2, %1 : tensor<128xf32> into memref<128xf32, #hal.descriptor_type<storage_buffer>>
+  %2 = iree_codegen.load_from_buffer %0 {read_only} : memref<128xf32, #hal.descriptor_type<storage_buffer>> -> tensor<128xf32>
+  iree_codegen.store_to_buffer %2, %1 : tensor<128xf32> into memref<128xf32, #hal.descriptor_type<storage_buffer>>
   return
 }
 
-// CHECK-LABEL: func.func @load_from_memref_store_to_memref()
+// CHECK-LABEL: func.func @load_from_buffer_store_to_buffer()
 //   CHECK-DAG:   %[[INPUT:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)
 //   CHECK-DAG:   %[[OUTPUT:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)
 //       CHECK:   linalg.generic
@@ -2977,12 +2977,12 @@ func.func @load_from_memref_store_to_memref() {
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @load_from_memref_store_to_memref_in_place() {
+func.func @load_from_buffer_store_to_buffer_in_place() {
   %c0 = arith.constant 0 : index
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) : memref<128x384xf32, #hal.descriptor_type<storage_buffer>>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : memref<128x384xf32, #hal.descriptor_type<storage_buffer>>
-  %2 = iree_codegen.load_from_memref %0 : memref<128x384xf32, #hal.descriptor_type<storage_buffer>> -> tensor<128x384xf32>
-  %3 = iree_codegen.load_from_memref %1 : memref<128x384xf32, #hal.descriptor_type<storage_buffer>> -> tensor<128x384xf32>
+  %2 = iree_codegen.load_from_buffer %0 : memref<128x384xf32, #hal.descriptor_type<storage_buffer>> -> tensor<128x384xf32>
+  %3 = iree_codegen.load_from_buffer %1 : memref<128x384xf32, #hal.descriptor_type<storage_buffer>> -> tensor<128x384xf32>
   %forall = scf.forall (%arg0) in (128) shared_outs(%arg1 = %3) -> (tensor<128x384xf32>) {
     %input = tensor.extract_slice %2[%arg0, 0] [1, 384] [1, 1] : tensor<128x384xf32> to tensor<384xf32>
     %init = tensor.extract_slice %arg1[%arg0, 0] [1, 384] [1, 1] : tensor<128x384xf32> to tensor<384xf32>
@@ -2991,11 +2991,11 @@ func.func @load_from_memref_store_to_memref_in_place() {
       tensor.parallel_insert_slice %copy into %arg1[%arg0, 0] [1, 384] [1, 1] : tensor<384xf32> into tensor<128x384xf32>
     }
   } {mapping = [#iree_codegen.workgroup_mapping<x>]}
-  iree_codegen.store_to_memref %forall, %1 : tensor<128x384xf32> into memref<128x384xf32, #hal.descriptor_type<storage_buffer>>
+  iree_codegen.store_to_buffer %forall, %1 : tensor<128x384xf32> into memref<128x384xf32, #hal.descriptor_type<storage_buffer>>
   return
 }
 
-// CHECK-LABEL: func.func @load_from_memref_store_to_memref_in_place()
+// CHECK-LABEL: func.func @load_from_buffer_store_to_buffer_in_place()
 //   CHECK-DAG:   %[[INPUT:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)
 //   CHECK-DAG:   %[[OUTPUT:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)
 //       CHECK:   scf.forall (%[[ARG0:.+]]) in (128)
@@ -3009,18 +3009,18 @@ func.func @load_from_memref_store_to_memref_in_place() {
   #hal.pipeline.binding<storage_buffer>,
   #hal.pipeline.binding<storage_buffer>
 ]>
-func.func @load_from_memref_read_only_copy() {
+func.func @load_from_buffer_read_only_copy() {
   %c0 = arith.constant 0 : index
   %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : memref<2x64xf32, #hal.descriptor_type<storage_buffer>>
   %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) : memref<128xf32, #hal.descriptor_type<storage_buffer>>
   %collapse = memref.collapse_shape %0 [[0, 1]] : memref<2x64xf32, #hal.descriptor_type<storage_buffer>> into memref<128xf32, #hal.descriptor_type<storage_buffer>>
-  %2 = iree_codegen.load_from_memref %collapse : memref<128xf32, #hal.descriptor_type<storage_buffer>> -> tensor<128xf32>
+  %2 = iree_codegen.load_from_buffer %collapse : memref<128xf32, #hal.descriptor_type<storage_buffer>> -> tensor<128xf32>
   %copy = linalg.copy ins(%2 : tensor<128xf32>) outs(%2 : tensor<128xf32>) -> tensor<128xf32>
-  iree_codegen.store_to_memref %copy, %1 : tensor<128xf32> into memref<128xf32, #hal.descriptor_type<storage_buffer>>
+  iree_codegen.store_to_buffer %copy, %1 : tensor<128xf32> into memref<128xf32, #hal.descriptor_type<storage_buffer>>
   return
 }
 
-// CHECK-LABEL: func.func @load_from_memref_read_only_copy()
+// CHECK-LABEL: func.func @load_from_buffer_read_only_copy()
 //   CHECK-DAG:   %[[READ_ONLY_BUFFER:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(0)
 //   CHECK-DAG:   %[[COLLAPSED:.+]] = memref.collapse_shape %[[READ_ONLY_BUFFER]]
 //   CHECK-DAG:   %[[OUTPUT:.+]] = hal.interface.binding.subspan layout({{.+}}) binding(1)

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
@@ -67,10 +67,10 @@ void ExtractStridedMetadataOp::getAsmResultNames(
 }
 
 //===----------------------------------------------------------------------===//
-// LoadFromMemrefOp
+// LoadFromBufferOp
 //===----------------------------------------------------------------------===//
 
-LogicalResult LoadFromMemrefOp::verify() {
+LogicalResult LoadFromBufferOp::verify() {
   RankedTensorType tensorType = getTensor().getType();
   MemRefType memrefType = getBuffer().getType();
   if (failed(verifyCompatibleShape(tensorType.getShape(),
@@ -82,7 +82,7 @@ LogicalResult LoadFromMemrefOp::verify() {
   return success();
 }
 
-void LoadFromMemrefOp::getEffects(
+void LoadFromBufferOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
   effects.emplace_back(MemoryEffects::Read::get(), &getBufferMutable(),
@@ -90,10 +90,10 @@ void LoadFromMemrefOp::getEffects(
 }
 
 //===----------------------------------------------------------------------===//
-// StoreToMemrefOp
+// StoreToBufferOp
 //===----------------------------------------------------------------------===//
 
-LogicalResult StoreToMemrefOp::verify() {
+LogicalResult StoreToBufferOp::verify() {
   RankedTensorType tensorType = getTensor().getType();
   MemRefType memrefType = getBuffer().getType();
   if (failed(verifyCompatibleShape(tensorType.getShape(),
@@ -105,7 +105,7 @@ LogicalResult StoreToMemrefOp::verify() {
   return success();
 }
 
-void StoreToMemrefOp::getEffects(
+void StoreToBufferOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
   effects.emplace_back(MemoryEffects::Write::get(), &getBufferMutable(),

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
@@ -174,10 +174,10 @@ def IREECodegen_NullPointerOp :
 }
 
 //===----------------------------------------------------------------------===//
-// LoadFrom/StoreToMemref Ops
+// LoadFrom/StoreToBuffer Ops
 //===----------------------------------------------------------------------===//
 
-def IREECodegen_LoadFromMemrefOp : Op<IREECodegen_Dialect, "load_from_memref",
+def IREECodegen_LoadFromBufferOp : Op<IREECodegen_Dialect, "load_from_buffer",
     [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = [{Loads a tensor from a memref.}];
   let description = [{
@@ -199,7 +199,7 @@ def IREECodegen_LoadFromMemrefOp : Op<IREECodegen_Dialect, "load_from_memref",
   let hasVerifier = 1;
 }
 
-def IREECodegen_StoreToMemrefOp : Op<IREECodegen_Dialect, "store_to_memref",
+def IREECodegen_StoreToBufferOp : Op<IREECodegen_Dialect, "store_to_buffer",
     [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = [{Stores a tensor into a memref.}];
   let description = [{

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/invalid.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/invalid.mlir
@@ -13,32 +13,32 @@ module {
 
 // -----
 
-func.func @load_from_memref_invalid_shape(%arg0: memref<5xf32>) -> tensor<4xf32> {
+func.func @load_from_buffer_invalid_shape(%arg0: memref<5xf32>) -> tensor<4xf32> {
   // expected-error @+1 {{buffer and tensor shapes must be compatible and element types must match}}
-  %value = iree_codegen.load_from_memref %arg0 : memref<5xf32> -> tensor<4xf32>
+  %value = iree_codegen.load_from_buffer %arg0 : memref<5xf32> -> tensor<4xf32>
   return %value : tensor<4xf32>
 }
 
 // -----
 
-func.func @load_from_memref_invalid_element_type(%arg0: memref<4xf32>) -> tensor<4xf16> {
+func.func @load_from_buffer_invalid_element_type(%arg0: memref<4xf32>) -> tensor<4xf16> {
   // expected-error @+1 {{buffer and tensor shapes must be compatible and element types must match}}
-  %value = iree_codegen.load_from_memref %arg0 : memref<4xf32> -> tensor<4xf16>
+  %value = iree_codegen.load_from_buffer %arg0 : memref<4xf32> -> tensor<4xf16>
   return %value : tensor<4xf16>
 }
 
 // -----
 
-func.func @store_to_memref_invalid_shape(%arg0: tensor<4xf32>, %arg1: memref<5xf32>) {
+func.func @store_to_buffer_invalid_shape(%arg0: tensor<4xf32>, %arg1: memref<5xf32>) {
   // expected-error @+1 {{tensor and buffer shapes must be compatible and element types must match}}
-  iree_codegen.store_to_memref %arg0, %arg1 : tensor<4xf32> into memref<5xf32>
+  iree_codegen.store_to_buffer %arg0, %arg1 : tensor<4xf32> into memref<5xf32>
   return
 }
 
 // -----
 
-func.func @store_to_memref_invalid_element_type(%arg0: tensor<4xf16>, %arg1: memref<4xf32>) {
+func.func @store_to_buffer_invalid_element_type(%arg0: tensor<4xf16>, %arg1: memref<4xf32>) {
   // expected-error @+1 {{tensor and buffer shapes must be compatible and element types must match}}
-  iree_codegen.store_to_memref %arg0, %arg1 : tensor<4xf16> into memref<4xf32>
+  iree_codegen.store_to_buffer %arg0, %arg1 : tensor<4xf16> into memref<4xf32>
   return
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/test/roundtrip.mlir
@@ -1,23 +1,23 @@
 // RUN: iree-opt --split-input-file %s | FileCheck %s
 
-func.func @load_from_memref(%arg0: memref<4xf32>) -> tensor<4xf32> {
-  %value = iree_codegen.load_from_memref %arg0 : memref<4xf32> -> tensor<4xf32>
+func.func @load_from_buffer(%arg0: memref<4xf32>) -> tensor<4xf32> {
+  %value = iree_codegen.load_from_buffer %arg0 : memref<4xf32> -> tensor<4xf32>
   return %value : tensor<4xf32>
 }
-// CHECK-LABEL: func.func @load_from_memref(
+// CHECK-LABEL: func.func @load_from_buffer(
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]
-// CHECK:         iree_codegen.load_from_memref %[[ARG0]]
+// CHECK:         iree_codegen.load_from_buffer %[[ARG0]]
 // CHECK-SAME:      : memref<4xf32> -> tensor<4xf32>
 
 // -----
 
-func.func @load_from_memref_mixed_static_dynamic(%arg0: memref<?x4xf32>) -> tensor<4x?xf32> {
-  %value = iree_codegen.load_from_memref %arg0 : memref<?x4xf32> -> tensor<4x?xf32>
+func.func @load_from_buffer_mixed_static_dynamic(%arg0: memref<?x4xf32>) -> tensor<4x?xf32> {
+  %value = iree_codegen.load_from_buffer %arg0 : memref<?x4xf32> -> tensor<4x?xf32>
   return %value : tensor<4x?xf32>
 }
-// CHECK-LABEL: func.func @load_from_memref_mixed_static_dynamic(
+// CHECK-LABEL: func.func @load_from_buffer_mixed_static_dynamic(
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]
-// CHECK:         iree_codegen.load_from_memref %[[ARG0]]
+// CHECK:         iree_codegen.load_from_buffer %[[ARG0]]
 // CHECK-SAME:      : memref<?x4xf32> -> tensor<4x?xf32>
 
 // -----
@@ -25,37 +25,37 @@ func.func @load_from_memref_mixed_static_dynamic(%arg0: memref<?x4xf32>) -> tens
 func.func @load_from_strided_memref(
     %arg0: memref<?x?xf32, strided<[?, 1], offset: ?>>
 ) -> tensor<?x?xf32> {
-  %value = iree_codegen.load_from_memref %arg0
+  %value = iree_codegen.load_from_buffer %arg0
     : memref<?x?xf32, strided<[?, 1], offset: ?>> -> tensor<?x?xf32>
   return %value : tensor<?x?xf32>
 }
 // CHECK-LABEL: func.func @load_from_strided_memref(
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]:
-// CHECK:         iree_codegen.load_from_memref %[[ARG0]]
+// CHECK:         iree_codegen.load_from_buffer %[[ARG0]]
 // CHECK-SAME:      : memref<?x?xf32, strided<[?, 1], offset: ?>> -> tensor<?x?xf32>
 
 // -----
 
-func.func @store_to_memref(%arg0: tensor<4xf32>, %arg1: memref<4xf32>) {
-  iree_codegen.store_to_memref %arg0, %arg1 : tensor<4xf32> into memref<4xf32>
+func.func @store_to_buffer(%arg0: tensor<4xf32>, %arg1: memref<4xf32>) {
+  iree_codegen.store_to_buffer %arg0, %arg1 : tensor<4xf32> into memref<4xf32>
   return
 }
-// CHECK-LABEL: func.func @store_to_memref(
+// CHECK-LABEL: func.func @store_to_buffer(
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]
 // CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]+]]
-// CHECK:         iree_codegen.store_to_memref %[[ARG0]], %[[ARG1]]
+// CHECK:         iree_codegen.store_to_buffer %[[ARG0]], %[[ARG1]]
 // CHECK-SAME:      : tensor<4xf32> into memref<4xf32>
 
 // -----
 
-func.func @store_to_memref_mixed_static_dynamic(%arg0: tensor<4x?xf32>, %arg1: memref<?x4xf32>) {
-  iree_codegen.store_to_memref %arg0, %arg1 : tensor<4x?xf32> into memref<?x4xf32>
+func.func @store_to_buffer_mixed_static_dynamic(%arg0: tensor<4x?xf32>, %arg1: memref<?x4xf32>) {
+  iree_codegen.store_to_buffer %arg0, %arg1 : tensor<4x?xf32> into memref<?x4xf32>
   return
 }
-// CHECK-LABEL: func.func @store_to_memref_mixed_static_dynamic(
+// CHECK-LABEL: func.func @store_to_buffer_mixed_static_dynamic(
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]
 // CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]+]]
-// CHECK:         iree_codegen.store_to_memref %[[ARG0]], %[[ARG1]]
+// CHECK:         iree_codegen.store_to_buffer %[[ARG0]], %[[ARG1]]
 // CHECK-SAME:      : tensor<4x?xf32> into memref<?x4xf32>
 
 // -----
@@ -63,12 +63,12 @@ func.func @store_to_memref_mixed_static_dynamic(%arg0: tensor<4x?xf32>, %arg1: m
 func.func @store_to_strided_memref(
     %arg0: tensor<?x?xf32>, %arg1: memref<?x?xf32, strided<[?, 1], offset: ?>>
 ) {
-  iree_codegen.store_to_memref %arg0, %arg1
+  iree_codegen.store_to_buffer %arg0, %arg1
     : tensor<?x?xf32> into memref<?x?xf32, strided<[?, 1], offset: ?>>
   return
 }
 // CHECK-LABEL: func.func @store_to_strided_memref(
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]+]]:
 // CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]+]]:
-// CHECK:         iree_codegen.store_to_memref %[[ARG0]], %[[ARG1]]
+// CHECK:         iree_codegen.store_to_buffer %[[ARG0]], %[[ARG1]]
 // CHECK-SAME:      : tensor<?x?xf32> into memref<?x?xf32, strided<[?, 1], offset: ?>>

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -1221,14 +1221,14 @@ void populateReshapeToInterfaceTensorPatterns(RewritePatternSet &patterns) {
 }
 
 //===--------------------------------------------------------------------====//
-// Patterns to fold ops into iree_codegen.store_to/load_from_memref
+// Patterns to fold ops into iree_codegen.store_to/load_from_buffer
 //===--------------------------------------------------------------------====//
 
 namespace {
 
-/// Given an iree_codegen.load_from_memref op or iree_codegen.store_to_memref
+/// Given an iree_codegen.load_from_buffer op or iree_codegen.store_to_buffer
 /// op, and a list of reassociation indices, replace the memref operand of the
-/// load_from_memref or store_to_memref op with a collapsed memref according to
+/// load_from_buffer or store_to_buffer op with a collapsed memref according to
 /// the reassociations. The `tensorToMemrefOp` will be modified in place without
 /// updating users or producers. The caller of this function is responsible for
 /// updating producers and consumers to maintain valid IR.
@@ -1253,9 +1253,9 @@ collapseMemrefOperand(RewriterBase &rewriter, OpTy tensorToMemrefOp,
   return success();
 }
 
-/// Given an iree_codegen.load_from_memref op or iree_codegen.store_to_memref
+/// Given an iree_codegen.load_from_buffer op or iree_codegen.store_to_buffer
 /// op, a list of reassociation indices, and an output shape, replace the memref
-/// operand of the load_from_memref or store_to_memref op with an expanded
+/// operand of the load_from_buffer or store_to_buffer op with an expanded
 /// memref according to the reassociations. The `tensorToMemrefOp` will be
 /// modified in place without updating users or producers. The caller of this
 /// function is responsible for updating producers and consumers to maintain
@@ -1289,14 +1289,14 @@ expandMemrefOperand(RewriterBase &rewriter, OpTy tensorToMemrefOp,
   return success();
 }
 
-/// Fold a tensor.expand_shape into a consumer iree_codegen.store_to_memref op
-/// by collapsing the memref operand of the store_to_memref, and replacing the
+/// Fold a tensor.expand_shape into a consumer iree_codegen.store_to_buffer op
+/// by collapsing the memref operand of the store_to_buffer, and replacing the
 /// tensor operand with the source of the expand_shape.
-struct FoldExpandShapeIntoStoreToMemref
-    : OpRewritePattern<IREE::Codegen::StoreToMemrefOp> {
-  using OpRewritePattern<IREE::Codegen::StoreToMemrefOp>::OpRewritePattern;
+struct FoldExpandShapeIntoStoreToBuffer
+    : OpRewritePattern<IREE::Codegen::StoreToBufferOp> {
+  using OpRewritePattern<IREE::Codegen::StoreToBufferOp>::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(IREE::Codegen::StoreToMemrefOp storeOp,
+  LogicalResult matchAndRewrite(IREE::Codegen::StoreToBufferOp storeOp,
                                 PatternRewriter &rewriter) const override {
     auto expandOp = storeOp.getTensor().getDefiningOp<tensor::ExpandShapeOp>();
     if (!expandOp) {
@@ -1313,14 +1313,14 @@ struct FoldExpandShapeIntoStoreToMemref
   }
 };
 
-/// Fold a tensor.collapse_shape into a consumer iree_codegen.store_to_memref op
-/// by expanding the memref operand of the store_to_memref, and replacing the
+/// Fold a tensor.collapse_shape into a consumer iree_codegen.store_to_buffer op
+/// by expanding the memref operand of the store_to_buffer, and replacing the
 /// tensor operand with the source of the collapse_shape.
-struct FoldCollapseShapeIntoStoreToMemref
-    : OpRewritePattern<IREE::Codegen::StoreToMemrefOp> {
-  using OpRewritePattern<IREE::Codegen::StoreToMemrefOp>::OpRewritePattern;
+struct FoldCollapseShapeIntoStoreToBuffer
+    : OpRewritePattern<IREE::Codegen::StoreToBufferOp> {
+  using OpRewritePattern<IREE::Codegen::StoreToBufferOp>::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(IREE::Codegen::StoreToMemrefOp storeOp,
+  LogicalResult matchAndRewrite(IREE::Codegen::StoreToBufferOp storeOp,
                                 PatternRewriter &rewriter) const override {
     auto collapseOp =
         storeOp.getTensor().getDefiningOp<tensor::CollapseShapeOp>();
@@ -1341,14 +1341,14 @@ struct FoldCollapseShapeIntoStoreToMemref
   }
 };
 
-/// Fold a tensor.collapse_shape into a producer iree_codegen.load_from_memref
-/// op by collapsing the memref operand of the load_from_memref, and replacing
-/// the collapse_shape with the collapsed load_from_memref op.
-struct FoldCollapseShapeIntoLoadFromMemref
-    : OpRewritePattern<IREE::Codegen::LoadFromMemrefOp> {
-  using OpRewritePattern<IREE::Codegen::LoadFromMemrefOp>::OpRewritePattern;
+/// Fold a tensor.collapse_shape into a producer iree_codegen.load_from_buffer
+/// op by collapsing the memref operand of the load_from_buffer, and replacing
+/// the collapse_shape with the collapsed load_from_buffer op.
+struct FoldCollapseShapeIntoLoadFromBuffer
+    : OpRewritePattern<IREE::Codegen::LoadFromBufferOp> {
+  using OpRewritePattern<IREE::Codegen::LoadFromBufferOp>::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(IREE::Codegen::LoadFromMemrefOp loadOp,
+  LogicalResult matchAndRewrite(IREE::Codegen::LoadFromBufferOp loadOp,
                                 PatternRewriter &rewriter) const override {
     if (!loadOp->hasOneUse()) {
       return rewriter.notifyMatchFailure(loadOp, "load op has multiple uses");
@@ -1370,14 +1370,14 @@ struct FoldCollapseShapeIntoLoadFromMemref
   }
 };
 
-/// Fold a tensor.expand_shape into a producer iree_codegen.load_from_memref op
-/// by expanding the memref operand of the load_from_memref, and replacing the
-/// expand_shape with the expanded load_from_memref op.
-struct FoldExpandShapeIntoLoadFromMemref
-    : OpRewritePattern<IREE::Codegen::LoadFromMemrefOp> {
-  using OpRewritePattern<IREE::Codegen::LoadFromMemrefOp>::OpRewritePattern;
+/// Fold a tensor.expand_shape into a producer iree_codegen.load_from_buffer op
+/// by expanding the memref operand of the load_from_buffer, and replacing the
+/// expand_shape with the expanded load_from_buffer op.
+struct FoldExpandShapeIntoLoadFromBuffer
+    : OpRewritePattern<IREE::Codegen::LoadFromBufferOp> {
+  using OpRewritePattern<IREE::Codegen::LoadFromBufferOp>::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(IREE::Codegen::LoadFromMemrefOp loadOp,
+  LogicalResult matchAndRewrite(IREE::Codegen::LoadFromBufferOp loadOp,
                                 PatternRewriter &rewriter) const override {
     if (!loadOp->hasOneUse()) {
       return rewriter.notifyMatchFailure(loadOp, "load op has multiple uses");
@@ -1405,8 +1405,8 @@ struct FoldExpandShapeIntoLoadFromMemref
 
 void populateFoldTensorReshapeIntoBufferPatterns(RewritePatternSet &patterns) {
   patterns.insert<
-      FoldCollapseShapeIntoLoadFromMemref, FoldExpandShapeIntoLoadFromMemref,
-      FoldCollapseShapeIntoStoreToMemref, FoldExpandShapeIntoStoreToMemref>(
+      FoldCollapseShapeIntoLoadFromBuffer, FoldExpandShapeIntoLoadFromBuffer,
+      FoldCollapseShapeIntoStoreToBuffer, FoldExpandShapeIntoStoreToBuffer>(
       patterns.getContext());
 }
 

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.h
@@ -104,7 +104,7 @@ void populateRemoveSingleIterationLoopPattern(RewritePatternSet &patterns);
 void populateReshapeToInterfaceTensorPatterns(RewritePatternSet &patterns);
 
 /// Populate patterns that fold tensor.expand/collapse_shape into the memref
-/// of iree_codegen.load_from_memref or iree_codegen.store_to_memref ops.
+/// of iree_codegen.load_from_buffer or iree_codegen.store_to_buffer ops.
 void populateFoldTensorReshapeIntoBufferPatterns(RewritePatternSet &patterns);
 
 /// Populate patterns that remove dead allocations


### PR DESCRIPTION
Renames `iree_codegen.load_from_memref` to `iree_codegen.load_from_buffer`, and `iree_codegen.store_to_memref` to `iree_codegen.store_to_buffer` for consistency with the op definition.