### PR TITLE
[Codegen] Enable reshape into buffer folding in BlockDynamicDimensions

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/block_dynamic_dims.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/block_dynamic_dims.mlir
@@ -353,45 +353,34 @@ func.func @fold_reshapes_with_bindings() {
 
 // -----
 
-#pipeline_layout = #hal.pipeline.layout<constants = 4, bindings = [
-    #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
-    #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
-func.func @block_dims_with_early_bufferization_ops() {
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.constant.load layout(#pipeline_layout) ordinal(0) : index
-  %1 = util.assume.int %0<umin = 16, umax = 4080, udiv = 16> : index
-  %2 = iree_tensor_ext.dispatch.workload.ordinal %1, 0 : index
-  %3 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : memref<?xf32, #hal.descriptor_type<storage_buffer>>{%2}
-  memref.assume_alignment %3, 64 : memref<?xf32, #hal.descriptor_type<storage_buffer>>
-  %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags(Indirect) : memref<?xf32, #hal.descriptor_type<storage_buffer>>{%2}
-  memref.assume_alignment %4, 64 : memref<?xf32, #hal.descriptor_type<storage_buffer>>
-  %5 = iree_codegen.load_from_buffer %3 : memref<?xf32, #hal.descriptor_type<storage_buffer>> -> tensor<?xf32>
-  %6 = tensor.empty(%2) : tensor<?xf32>
-  %7 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%5 : tensor<?xf32>) outs(%6 : tensor<?xf32>) {
+func.func @block_dims_with_early_bufferization_ops(%input: memref<?xf32>, %size: index) {
+  %0 = util.assume.int %size<umin = 16, umax = 4080, udiv = 16> : index
+  %1 = memref.alloc(%0) : memref<?xf32>
+  %2 = iree_codegen.load_from_buffer %input : memref<?xf32> -> tensor<?xf32>
+  %3 = tensor.empty(%0) : tensor<?xf32>
+  %4 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>,
+                                        affine_map<(d0) -> (d0)>],
+                       iterator_types = ["parallel"]}
+                       ins(%2 : tensor<?xf32>) outs(%3 : tensor<?xf32>) {
   ^bb0(%in: f32, %out: f32):
     linalg.yield %in : f32
   } -> tensor<?xf32>
-  iree_codegen.store_to_buffer %7, %4 : tensor<?xf32> into memref<?xf32, #hal.descriptor_type<storage_buffer>>
+  iree_codegen.store_to_buffer %4, %1 : tensor<?xf32> into memref<?xf32>
   return
 }
 // Check that the reshapes are able to be folded into load_from_buffer and
 // store_to_buffer ops.
 //
-// CHECK-LABEL: func @block_dims_with_early_bufferization_ops()
-//       CHECK:   %[[INPUT_BINDING:.+]] = hal.interface.binding.subspan
-//  CHECK-SAME:       binding(0)
-//  CHECK-SAME:       memref<?xf32, #hal.descriptor_type<storage_buffer>>{%[[DIM:.+]]}
-//       CHECK:   %[[OUTPUT_BINDING:.+]] = hal.interface.binding.subspan
-//  CHECK-SAME:       binding(1)
-//  CHECK-SAME:       memref<?xf32, #hal.descriptor_type<storage_buffer>>{%[[DIM]]}
-//   CHECK-DAG:   %[[INPUT_EXPAND:.+]] = memref.expand_shape %[[INPUT_BINDING]]
-//   CHECK-DAG:   %[[OUTPUT_EXPAND:.+]] = memref.expand_shape %[[OUTPUT_BINDING]]
-//       CHECK:   %[[INPUT_TENSOR:.+]] = iree_codegen.load_from_buffer %[[INPUT_EXPAND]]
-//  CHECK-SAME:       memref<?x16xf32, #hal.descriptor_type<storage_buffer>> -> tensor<?x16xf32>
+// CHECK-LABEL: func @block_dims_with_early_bufferization_ops(
+//  CHECK-SAME:   %[[INPUT_BUFFER:[a-zA-Z0-9_]+]]
+//   CHECK-DAG:   %[[ALLOC:.+]] = memref.alloc
+//   CHECK-DAG:   %[[ALLOC_EXPAND:.+]] = memref.expand_shape %[[ALLOC]]
+//   CHECK-DAG:   %[[INPUT_EXPAND:.+]] = memref.expand_shape %[[INPUT_BUFFER]]
+//   CHECK-DAG:   %[[INPUT_TENSOR:.+]] = iree_codegen.load_from_buffer %[[INPUT_EXPAND]]
 //       CHECK:   %[[GENERIC:.+]] = linalg.generic
 //  CHECK-SAME:     ins(%[[INPUT_TENSOR]] : tensor<?x16xf32>)
-//       CHECK:   iree_codegen.store_to_buffer %[[GENERIC]], %[[OUTPUT_EXPAND]]
-//  CHECK-SAME:       tensor<?x16xf32> into memref<?x16xf32, #hal.descriptor_type<storage_buffer>>
+//       CHECK:   iree_codegen.store_to_buffer %[[GENERIC]], %[[ALLOC_EXPAND]]
+//  CHECK-SAME:       tensor<?x16xf32> into memref<?x16xf32>
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/Common/test/canonicalize_early_bufferization_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/canonicalize_early_bufferization_ops.mlir
@@ -19,9 +19,9 @@ func.func @fold_reshape_load() {
 //   CHECK-DAG:   %[[SRC_SUBSPAN:.+]] = hal.interface.binding.subspan{{.*}} binding(0){{.*}} memref<3x3x1x96xf32
 //   CHECK-DAG:   %[[COLLAPSE:.+]] = memref.collapse_shape %[[SRC_SUBSPAN]]{{.*}} into memref<864xf32
 //   CHECK-DAG:   %[[EXPAND:.+]] = memref.expand_shape %[[COLLAPSE]]{{.*}} into memref<3x3x96xf32
-//   CHECK-DAG:   %[[DEST_SUBSPAN:.+]] = hal.interface.binding.subspan{{.*}} binding(1)
 //       CHECK:   %[[LOAD:.+]] = iree_codegen.load_from_buffer %[[EXPAND]]
 //  CHECK-SAME:     memref<3x3x96xf32, #hal.descriptor_type<storage_buffer>> -> tensor<3x3x96xf32>
+//       CHECK:   %[[DEST_SUBSPAN:.+]] = hal.interface.binding.subspan{{.*}} binding(1)
 //       CHECK:   %[[BARRIER:.+]] = util.optimization_barrier %[[LOAD]]
 //       CHECK:   iree_codegen.store_to_buffer %[[BARRIER]], %[[DEST_SUBSPAN]]
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.cpp
@@ -89,6 +89,15 @@ void LoadFromBufferOp::getEffects(
                        SideEffects::DefaultResource::get());
 }
 
+LogicalResult LoadFromBufferOp::reifyResultShapes(
+    OpBuilder &b, ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
+  OpBuilder::InsertionGuard g(b);
+  b.setInsertionPointAfterValue(getBuffer());
+  reifiedReturnShapes.resize(1);
+  reifiedReturnShapes[0] = memref::getMixedSizes(b, getLoc(), getBuffer());
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // StoreToBufferOp
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenOps.td
@@ -178,7 +178,8 @@ def IREECodegen_NullPointerOp :
 //===----------------------------------------------------------------------===//
 
 def IREECodegen_LoadFromBufferOp : Op<IREECodegen_Dialect, "load_from_buffer",
-    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+     DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>]> {
   let summary = [{Loads a tensor from a memref.}];
   let description = [{
     Loads a tensor from a memref with a compatible shape and the same element

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -1394,6 +1394,8 @@ struct FoldExpandShapeIntoLoadFromBuffer
     rewriter.modifyOpInPlace(loadOp, [&]() {
       loadOp->getOpResult(0).setType(expandOp.getResultType());
     });
+    DominanceInfo domInfo;
+    moveOpAfterLastOperand(rewriter, domInfo, loadOp);
     rewriter.replaceOp(expandOp, loadOp);
     return success();
   }

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -226,6 +226,11 @@ Operation *
 setInsertionPointAfterLastNeededValue(OpBuilder &builder,
                                       SubsetInsertionOpInterface subsetOp);
 
+/// Moves the op to right after its last (most dominant) operand. If the operand
+/// is a block argument, then the op is moved to the start of the block.
+void moveOpAfterLastOperand(RewriterBase &rewriter, DominanceInfo &domInfo,
+                            Operation *op);
+
 /// Check if the two tensor types (with their respective dynamic dimension
 /// values) have the same shape.
 bool equalTensorShape(RankedTensorType tensorType, ValueRange tensorDynSizes,


### PR DESCRIPTION
Adds the `FoldTensorReshapeIntoBufferPatterns` to the BlockDynamicDimensions pass, and implements the `ReifyRankedShapedTypeOpInterface` on the `iree_codegen.load_from_buffer` operation in order to enable resolution of tensor.dim ops.

An additional step is added to the `BlockDynamicDimensions` that pushes memref reshape operations upwards in the dispatch, because when reshapes are folded into the iree_codegen.store_to_buffer ops, the resulting memref reshapes need to be created near the end of the dispatch to obey dominance, but once tensor.dim ops are resolved, they can be pushed up to where the resolved dims are defined. Pushing the reshape ops up is necessary right now, because empty tensor elimination requires the buffer of the store_to_memref op to be dominating the empty tensor to replace.