### PR TITLE
Prefetch shared memory in presence of scf.if

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -544,6 +544,7 @@ void addGPUTileAndFusePassPipeline(OpPassManager &funcPassManager,
   }
   if (pipelineOptions.prefetchSharedMemory) {
     funcPassManager.addPass(createHoistStaticallyBoundAllocationsPass());
+    funcPassManager.addPass(createRemoveSingleIterationLoopPass());
     funcPassManager.addPass(createLLVMGPUPrefetchSharedMemoryPass());
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/PrefetchSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/PrefetchSharedMemoryCopy.cpp
@@ -211,12 +211,15 @@ private:
       getValueDependencies(ifOp, writeDependencies, /*noTransferReads=*/true);
       return;
     }
-    // By default we can mark the if op as read stage.
+    if (hasGlobalRead) {
+      getValueDependencies(ifOp, readDependencies);
+      return;
+    }
+    // If we dont know what kind of read/write the if is doing then we bail-out.
     // TODO (nirvedhmeshram) : Add handling for private memory allocations. e.g
     // write to private memory could go in write stage. But the analysis
     // in `getValueDependencies` also needs to be aware of private memory for
     // this so that needs to be added at the same time.
-    getValueDependencies(ifOp, readDependencies);
   }
 
   // We only support loops whose bodies can be divided into 3 stages (read,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/PrefetchSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/PrefetchSharedMemoryCopy.cpp
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.h"
+#include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
-
 #include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/STLExtras.h"
@@ -176,9 +176,50 @@ private:
     });
   }
 
+  void getValueDependenciesForIf(scf::IfOp ifOp,
+                                 DenseSet<Operation *> &readDependencies,
+                                 DenseSet<Operation *> &writeDependencies) {
+    // scf.if with results should be supported directly through the usual
+    // handling so bail-out here in that case
+    if (ifOp->getNumResults() != 0)
+      return;
+    bool hasGlobalRead = false;
+    bool hasSharedWrite = false;
+    // Else region not yet supported.
+    if (!ifOp.getElseRegion().empty()) {
+      return;
+    }
+    ifOp->walk([&](Operation *op) {
+      if (auto readOp = dyn_cast<vector::TransferReadOp>(op)) {
+        auto sourceType = dyn_cast<MemRefType>(readOp.getBase().getType());
+        if (hasGlobalMemoryAddressSpace(sourceType)) {
+          hasGlobalRead = true;
+        }
+      }
+      if (auto writeOp = dyn_cast<vector::TransferWriteOp>(op)) {
+        auto dstType = dyn_cast<MemRefType>(writeOp.getBase().getType());
+        if (hasSharedMemoryAddressSpace(dstType)) {
+          hasSharedWrite = true;
+        }
+      }
+    });
+    // if op has both read and write stages and hence we cannot do prefetching.
+    if (hasGlobalRead && hasSharedWrite) {
+      return;
+    }
+    if (hasSharedWrite) {
+      getValueDependencies(ifOp, writeDependencies, /*noTransferReads=*/true);
+      return;
+    }
+    // By default we can mark the if op as read stage.
+    getValueDependencies(ifOp, readDependencies);
+  }
+
   // We only support loops whose bodies can be divided into 3 stages (read,
   // write, compute). If there are any remaining ops with side effects (except
-  // for gpu.barrier), the loop is not supported.
+  // for gpu.barrier and certain scf.if ops), the loop is not supported.
+  // For scf.if we only support them if we can analyze the region and
+  // identify which stage the if op should belong to.
   LogicalResult initializeStages() {
     DenseSet<Operation *> readDependencies;
     DenseSet<Operation *> writeDependencies;
@@ -192,6 +233,8 @@ private:
                              /*noTransferReads=*/true);
       } else if (auto compute = dyn_cast<scf::YieldOp>(op)) {
         getValueDependencies(compute, computeDependencies);
+      } else if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+        getValueDependenciesForIf(ifOp, readDependencies, writeDependencies);
       }
     }
     // If `scf.yeild` is the only compute op then there is no value in doing

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/PrefetchSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Utils/PrefetchSharedMemoryCopy.cpp
@@ -212,6 +212,10 @@ private:
       return;
     }
     // By default we can mark the if op as read stage.
+    // TODO (nirvedhmeshram) : Add handling for private memory allocations. e.g
+    // write to private memory could go in write stage. But the analysis
+    // in `getValueDependencies` also needs to be aware of private memory for
+    // this so that needs to be added at the same time.
     getValueDependencies(ifOp, readDependencies);
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/prefetch_shared_memory.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/prefetch_shared_memory.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -pass-pipeline="builtin.module(func.func(iree-llvmgpu-prefetch-shared-memory),cse,canonicalize)" %s | FileCheck %s
+// RUN: iree-opt -pass-pipeline="builtin.module(func.func(iree-llvmgpu-prefetch-shared-memory),cse,canonicalize)" %s --split-input-file | FileCheck %s
 
 // CHECK-LABEL: @prefetch_add
 // CHECK-SAME: (%[[GLOBAL:.*]]: memref<128xf32>)
@@ -39,6 +39,8 @@ func.func @prefetch_add(%arg0: memref<128xf32>) {
   vector.transfer_write %0, %arg0[%c0] {in_bounds = [true]} : vector<1xf32>, memref<128xf32>
   return
 }
+
+// -----
 
 // CHECK-LABEL: @prefetch_multi_scf_return
 // CHECK-SAME: (%[[GLOBAL:.*]]: memref<128xf32>)
@@ -81,6 +83,8 @@ func.func @prefetch_multi_scf_return(%arg0: memref<128xf32>) -> (vector<1xf32>, 
   // CHECK: return %[[EPI_COMPUTE]], %[[EPI_COMPUTE2]]
   return %0#0, %0#1 : vector<1xf32>, vector<1xf32>
 }
+
+// -----
 
 // CHECK-LABEL: @prefetch_add_with_if
 // CHECK-SAME: (%[[GLOBAL:.*]]: memref<128xf32>)
@@ -136,6 +140,7 @@ func.func @prefetch_add_with_if(%arg0: memref<128xf32>) {
 }
 
 // -----
+
 // CHECK-LABEL: @noprefetch_copyback
 func.func @noprefetch_copyback(%arg0: memref<128xf32>, %arg1: memref<128xf32>) {
   %cst = arith.constant dense<0.000000e+00> : vector<1xf32>
@@ -149,4 +154,96 @@ func.func @noprefetch_copyback(%arg0: memref<128xf32>, %arg1: memref<128xf32>) {
   }
   return
 }
+// CHECK-NOT: gpu.barrier
+
+// -----
+
+// CHECK-LABEL: @prefetch_scf_if
+func.func @prefetch_scf_if(%arg0: memref<128xf32>, %cond : i1) {
+  %cst = arith.constant dense<0.000000e+00> : vector<1xf32>
+  %cst_0 = arith.constant 0.000000e+00 : f32
+  %c128 = arith.constant 128 : index
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %alloc = memref.alloc() : memref<1xf32, #gpu.address_space<workgroup>>
+  %alloca = memref.alloca() : memref<1xf32, #gpu.address_space<private>>
+  %0 = scf.for %arg1 = %c0 to %c128 step %c1 iter_args(%arg2 = %cst) -> (vector<1xf32>) {
+    scf.if %cond {
+      %1 = vector.transfer_read %arg0[%arg1], %cst_0 : memref<128xf32>, vector<1xf32>
+      vector.transfer_write %1, %alloca[%c0] : vector<1xf32>, memref<1xf32, #gpu.address_space<private>>
+    }
+    scf.if %cond {
+    %1 = vector.transfer_read %alloca[%c0], %cst_0 : memref<1xf32, #gpu.address_space<private>>, vector<1xf32>
+    vector.transfer_write %1, %alloc[%c0] {in_bounds = [true]} : vector<1xf32>, memref<1xf32, #gpu.address_space<workgroup>>
+    }
+    %2 = vector.transfer_read %alloc[%c0], %cst_0 : memref<1xf32, #gpu.address_space<workgroup>>, vector<1xf32>
+    %3 = arith.addf %2, %arg2 : vector<1xf32>
+    scf.yield %3 : vector<1xf32>
+  }
+  vector.transfer_write %0, %arg0[%c0] {in_bounds = [true]} : vector<1xf32>, memref<128xf32>
+  return
+}
+
+// CHECK-SAME: (%[[GLOBAL:.*]]: memref<128xf32>, %[[COND:.*]]: i1)
+
+// CHECK-DAG: %[[C127:.*]] = arith.constant 127 : index
+// CHECK-DAG: %[[CST:.*]] = arith.constant dense<0.000000e+00> : vector<1xf32>
+// CHECK-DAG: %[[CST_0:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+// CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[WG_ALLOC:.*]] = memref.alloc() : memref<1xf32, #gpu.address_space<workgroup>>
+// CHECK-DAG: %[[PRIV_ALLOC:.*]] = memref.alloca() : memref<1xf32, #gpu.address_space<private>>
+
+// CHECK: scf.if %[[COND]] {
+// CHECK:   %[[IF_READ:.*]] = vector.transfer_read %[[GLOBAL]][%[[C0]]]
+// CHECK:   vector.transfer_write %[[IF_READ]], %[[PRIV_ALLOC]][%[[C0]]]
+// CHECK:   %[[PRIV_READ:.*]] = vector.transfer_read %[[PRIV_ALLOC]][%[[C0]]]
+// CHECK:   vector.transfer_write %[[PRIV_READ]], %[[WG_ALLOC]][%[[C0]]]
+// CHECK: }
+
+// CHECK: %[[OUT:.*]] = scf.for %[[IV:.*]] = %[[C0]] to %[[C127]] step %[[C1]] iter_args(%[[ARG:.*]] = %[[CST]])
+// CHECK:   %[[IVP1:.*]] = arith.addi %[[IV]], %[[C1]]
+// CHECK:   scf.if %[[COND]] {
+// CHECK:     %[[KER_READ:.*]] = vector.transfer_read %[[GLOBAL]][%[[IVP1]]]
+// CHECK:     vector.transfer_write %[[KER_READ]], %[[PRIV_ALLOC]][%[[C0]]]
+// CHECK:   }
+// CHECK:   gpu.barrier
+// CHECK:   %[[COMPUTE_READ:.*]] = vector.transfer_read %[[WG_ALLOC]][%[[C0]]]
+// CHECK:   %[[COMPUTE:.*]] = arith.addf %[[COMPUTE_READ]], %[[ARG]]
+// CHECK:   gpu.barrier
+// CHECK:   scf.if %[[COND]] {
+// CHECK:     %[[COMPUTE_RELOAD:.*]] = vector.transfer_read %[[PRIV_ALLOC]][%[[C0]]]
+// CHECK:     vector.transfer_write %[[COMPUTE_RELOAD]], %[[WG_ALLOC]][%[[C0]]]
+// CHECK:   }
+// CHECK: scf.yield %[[COMPUTE]]
+
+// CHECK: gpu.barrier
+// CHECK: %[[EPI_READ:.*]] = vector.transfer_read %[[WG_ALLOC]][%[[C0]]]
+// CHECK: %[[EPI_COMPUTE:.*]] = arith.addf %[[EPI_READ]], %[[OUT]]
+// CHECK: vector.transfer_write %[[EPI_COMPUTE]], %[[GLOBAL]][%[[C0]]]
+
+// -----
+
+// CHECK-LABEL: @noprefetch_scf_if_readwritetogether
+func.func @noprefetch_scf_if_readwritetogether(%arg0: memref<128xf32>, %cond : i1) {
+  %cst = arith.constant dense<0.000000e+00> : vector<1xf32>
+  %cst_0 = arith.constant 0.000000e+00 : f32
+  %c128 = arith.constant 128 : index
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %alloc = memref.alloc() : memref<1xf32, #gpu.address_space<workgroup>>
+  %alloca = memref.alloca() : memref<1xf32, #gpu.address_space<private>>
+  %0 = scf.for %arg1 = %c0 to %c128 step %c1 iter_args(%arg2 = %cst) -> (vector<1xf32>) {
+    scf.if %cond {
+      %1 = vector.transfer_read %arg0[%arg1], %cst_0 : memref<128xf32>, vector<1xf32>
+      vector.transfer_write %1, %alloc[%c0] {in_bounds = [true]} : vector<1xf32>, memref<1xf32, #gpu.address_space<workgroup>>
+    }
+    %2 = vector.transfer_read %alloc[%c0], %cst_0 : memref<1xf32, #gpu.address_space<workgroup>>, vector<1xf32>
+    %3 = arith.addf %2, %arg2 : vector<1xf32>
+    scf.yield %3 : vector<1xf32>
+  }
+  vector.transfer_write %0, %arg0[%c0] {in_bounds = [true]} : vector<1xf32>, memref<128xf32>
+  return
+}
+
 // CHECK-NOT: gpu.barrier


### PR DESCRIPTION
Currently if the scf.if op is not a part of the use def chain which is often the case for scf.if ops with no results, then the prefetching pass bails out. Such scf.if ops can happen as a result of dynamically zero or unit trip scf.fors that get lowered to scf.if by `RemoveSingleIterationLoopPass` . 
Currently use case of this is in the presence of post workgroup distribution dispatch padding for unaligned to intrinsic shapes for both GEMMs and IGEMMs can result in such dynamic unit trip loops and it is beneficial for performance reasons to be able to prefetch these. 