### PR TITLE
[Codegen] split-k on argmax to ensure ukernel support

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_lower_to_ukernels.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_lower_to_ukernels.mlir
@@ -144,7 +144,7 @@ func.func @argmax_invalid_index_without_selected_ukernel(
     ^bb0(%in: f32, %val: f32, %idx: i64):
       %i = linalg.index 0 : index
       %cast = arith.index_cast %i : index to i64
-      // Breaks isArgmaxOp matching
+      // Breaks isArgmaxOp matching.
       %plus = arith.addi %cast, %c0_i64 : i64
       %maxval = arith.maximumf %in, %val : f32
       %cmp = arith.cmpf ogt, %in, %val : f32

--- a/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_lower_to_ukernels.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/GPU/test/gpu_lower_to_ukernels.mlir
@@ -119,6 +119,52 @@ func.func @argmax_f32i64_without_selected_ukernel(%arg0 : tensor<1x?xf32>) -> te
 
 // -----
 
+func.func @argmax_invalid_index_without_selected_ukernel() -> tensor<i64> {
+  %c0_f32 = arith.constant 0.0 : f32
+  %c0_i64 = arith.constant 0 : i64
+  %cst_min = arith.constant 0xFF800000 : f32  // -inf
+
+  %input_empty = tensor.empty() : tensor<131072xf32>
+  %input = linalg.fill ins(%c0_f32 : f32)
+            outs(%input_empty : tensor<131072xf32>) -> tensor<131072xf32>
+
+  %init_val_empty = tensor.empty() : tensor<f32>
+  %init_val = linalg.fill ins(%cst_min : f32)
+              outs(%init_val_empty : tensor<f32>) -> tensor<f32>
+
+  %init_idx_empty = tensor.empty() : tensor<i64>
+  %init_idx = linalg.fill ins(%c0_i64 : i64)
+              outs(%init_idx_empty : tensor<i64>) -> tensor<i64>
+
+  %result:2 = linalg.generic {
+      indexing_maps = [
+        affine_map<(d0) -> (d0)>,
+        affine_map<(d0) -> ()>,
+        affine_map<(d0) -> ()>
+      ],
+      iterator_types = ["reduction"]
+    } ins(%input : tensor<131072xf32>)
+      outs(%init_val, %init_idx : tensor<f32>, tensor<i64>) {
+    ^bb0(%in: f32, %val: f32, %idx: i64):
+      %i = linalg.index 0 : index
+      %cast = arith.index_cast %i : index to i64
+      // intermediate op breaks isArgmaxOp matcher.
+      %plus = arith.addi %cast, %c0_i64 : i64
+      %maxval = arith.maximumf %in, %val : f32
+      %cmp = arith.cmpf ogt, %in, %val : f32
+      %sel = arith.select %cmp, %plus, %idx : i64
+      linalg.yield %maxval, %sel : f32, i64
+  } -> (tensor<f32>, tensor<i64>)
+
+  return %result#1 : tensor<i64>
+}
+
+// CHECK-LABEL: func @argmax_invalid_index_without_selected_ukernel(
+//      CHECK-NOT: iree_codegen.ukernel.generic
+//      CHECK: linalg.generic
+
+// -----
+
 func.func @multi_mma_mfma_i32_16x16x32_i8(%a : tensor<1x2x8x1x1x2x8xi8>, %b : tensor<1x2x1x2x1x1x2x8xi8>, %c : tensor<1x1x1x8x2x1x1x4xi32>) -> tensor<1x1x1x8x2x1x1x4xi32> {
   %d = iree_gpu.multi_mma %a, %b, %c {
     indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>],

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Transforms.h
@@ -132,15 +132,14 @@ FailureOr<std::pair<Value, Value>> rewriteFft(Operation *op, Value operand,
 /// `arith.cmpf`, and `arith.select` ops. It assumes a known structure of the
 /// region and injects index computations to track global indices.
 ///
-/// The transformation proceeds in three steps:
+/// The transformation proceeds in two steps:
 /// 1. Emit a strict argmax op that computes the maximum value and local index
 ///    within each tile (i.e., the inner dimension after splitting the
 ///    reduction).
-/// 2. Remap the local index to a global index using the formula
-///    `gidx = outer × tileSize + local`, where `outer` is the loop index
-///    from the new parallel dimension.
-/// 3. Reduce the value-globalIndex pairs to the final result using the original
-///    combiner structure (`maximumf`, `cmpf`, `select`).
+/// 2. Emit a final argmax-style reduction that directly computes the global
+/// index
+///    on-the-fly as `globalIndex = outer × tileSize + local`, using the
+///    original combiner structure (`maximumf`, `cmpf`, `select`).
 ///
 /// Returns the resulting partial and final linalg.generic ops, or failure
 /// if the pattern does not match or cannot be split.
@@ -165,8 +164,10 @@ FailureOr<std::pair<Value, Value>> rewriteFft(Operation *op, Value operand,
 ///
 /// %expanded = tensor.expand_shape %arg0 [[0], [1, 2]] : tensor<?x512xbf16>
 ///     into tensor<?x4x128xbf16>
+///
 /// %init_val = linalg.fill ... : tensor<?x4xbf16>
 /// %init_idx = linalg.fill ... : tensor<?x4xi64>
+///
 /// %partial:2 = linalg.generic {
 ///   indexing_maps = [...],
 ///   iterator_types = ["parallel", "reduction"]
@@ -175,19 +176,13 @@ FailureOr<std::pair<Value, Value>> rewriteFft(Operation *op, Value operand,
 ///   // strict argmax over local tile
 /// }
 ///
-/// %gidx = linalg.generic {
-///   indexing_maps = [...],
-///   iterator_types = ["parallel", "parallel"]
-/// } ins(%partial#1) outs(%remap_init) {
-///   // compute: outer × 128 + inner
-/// }
-///
 /// %final:2 = linalg.generic {
 ///   indexing_maps = [...],
-///   iterator_types = ["reduction"]
-/// } ins(%partial#0, %gidx)
+///   iterator_types = ["parallel", "reduction"]
+/// } ins(%partial#0, %partial#1)
 ///   outs(%out_val, %out_idx) {
-///   // same argmax combiner
+///   // compute global index = outer × 128 + local inside region
+///   // then apply argmax combiner using (value, global index) pairs
 /// }
 FailureOr<linalg::SplitReductionResult>
 splitArgmaxReduction(RewriterBase &rewriter, linalg::GenericOp genericOp,

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Transforms/Transforms.h
@@ -132,6 +132,16 @@ FailureOr<std::pair<Value, Value>> rewriteFft(Operation *op, Value operand,
 /// `arith.cmpf`, and `arith.select` ops. It assumes a known structure of the
 /// region and injects index computations to track global indices.
 ///
+/// The transformation proceeds in three steps:
+/// 1. Emit a strict argmax op that computes the maximum value and local index
+///    within each tile (i.e., the inner dimension after splitting the
+///    reduction).
+/// 2. Remap the local index to a global index using the formula
+///    `gidx = outer × tileSize + local`, where `outer` is the loop index
+///    from the new parallel dimension.
+/// 3. Reduce the value-globalIndex pairs to the final result using the original
+///    combiner structure (`maximumf`, `cmpf`, `select`).
+///
 /// Returns the resulting partial and final linalg.generic ops, or failure
 /// if the pattern does not match or cannot be split.
 ///
@@ -155,23 +165,29 @@ FailureOr<std::pair<Value, Value>> rewriteFft(Operation *op, Value operand,
 ///
 /// %expanded = tensor.expand_shape %arg0 [[0], [1, 2]] : tensor<?x512xbf16>
 ///     into tensor<?x4x128xbf16>
-/// %init_val = linalg.fill ins(%cst : bf16) outs(%empty : tensor<?x4xbf16>)
-/// %init_idx = linalg.fill ins(%zero : i64) outs(%empty : tensor<?x4xi64>)
+/// %init_val = linalg.fill ... : tensor<?x4xbf16>
+/// %init_idx = linalg.fill ... : tensor<?x4xi64>
 /// %partial:2 = linalg.generic {
 ///   indexing_maps = [...],
 ///   iterator_types = ["parallel", "reduction"]
-/// } ins(%expanded : tensor<?x4x128xbf16>)
-///   outs(%init_val, %init_idx : tensor<?x4xbf16>, tensor<?x4xi64>) {
-///   // compute global index: outer_idx * 128 + inner_idx
-///   ...
+/// } ins(%expanded)
+///   outs(%init_val, %init_idx) {
+///   // strict argmax over local tile
 /// }
+///
+/// %gidx = linalg.generic {
+///   indexing_maps = [...],
+///   iterator_types = ["parallel", "parallel"]
+/// } ins(%partial#1) outs(%remap_init) {
+///   // compute: outer × 128 + inner
+/// }
+///
 /// %final:2 = linalg.generic {
 ///   indexing_maps = [...],
 ///   iterator_types = ["reduction"]
-/// } ins(%partial#0, %partial#1)
-///   outs(%out_val, %out_idx : tensor<?xbf16>, tensor<?xi64>) {
-///   // same combiner: maximumf, cmpf, select
-///   ...
+/// } ins(%partial#0, %gidx)
+///   outs(%out_val, %out_idx) {
+///   // same argmax combiner
 /// }
 FailureOr<linalg::SplitReductionResult>
 splitArgmaxReduction(RewriterBase &rewriter, linalg::GenericOp genericOp,

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -891,6 +891,15 @@ bool isArgmaxOp(linalg::GenericOp genericOp) {
     if (!matchPattern(producer, m_Op<arith::SelectOp>())) {
       return false;
     }
+    auto selectOp = dyn_cast<arith::SelectOp>(producerOutput.getDefiningOp());
+    Value trueVal = selectOp.getTrueValue();
+    if (auto castOp = trueVal.getDefiningOp<arith::IndexCastOp>())
+      trueVal = castOp.getIn();
+
+    // Ensure the true value is directly produced by linalg.index.
+    auto indexOp = trueVal.getDefiningOp<linalg::IndexOp>();
+    if (!indexOp)
+      return false;
   }
 
   // Producer of arith.select op is arith.cmpf

--- a/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/LinalgExt/Utils/Utils.cpp
@@ -891,7 +891,7 @@ bool isArgmaxOp(linalg::GenericOp genericOp) {
     if (!matchPattern(producer, m_Op<arith::SelectOp>())) {
       return false;
     }
-    auto selectOp = dyn_cast<arith::SelectOp>(producerOutput.getDefiningOp());
+    auto selectOp = cast<arith::SelectOp>(producerOutput.getDefiningOp());
     Value trueVal = selectOp.getTrueValue();
     if (auto castOp = trueVal.getDefiningOp<arith::IndexCastOp>())
       trueVal = castOp.getIn();

--- a/compiler/src/iree/compiler/DispatchCreation/test/split_reduction.mlir
+++ b/compiler/src/iree/compiler/DispatchCreation/test/split_reduction.mlir
@@ -59,8 +59,9 @@ util.func public @argmax(%arg0: tensor<?x131072xbf16>, %arg1: index) -> tensor<?
 // CHECK: #[[$MAP2:.+]] = affine_map<(d0, d1) -> (d0, d1)>
 // CHECK: #[[$MAP3:.+]] = affine_map<(d0, d1) -> (d0)>
 
-// CHECK-LABEL:   util.func public @argmax
-// Check identity value preparation
+// CHECK-LABEL: util.func public @argmax
+
+// Identity value preparation
 // CHECK: %[[CST:.+]] = arith.constant 0xFF80 : bf16
 // CHECK: %[[ZERO:.+]] = arith.constant 0 : i64
 // CHECK: %[[FINALVAL_EMPTY:.+]] = tensor.empty(%[[ARG1:.+]]) : tensor<?xbf16>
@@ -68,42 +69,47 @@ util.func public @argmax(%arg0: tensor<?x131072xbf16>, %arg1: index) -> tensor<?
 // CHECK: %[[FINALIDX_EMPTY:.+]] = tensor.empty(%[[ARG1]]) : tensor<?xi64>
 // CHECK: %[[FINALIDX:.+]] = linalg.fill ins(%[[ZERO]] : i64) outs(%[[FINALIDX_EMPTY]] : tensor<?xi64>) -> tensor<?xi64>
 
-// Check partial reduction.
+// Step 1: Strict argmax with local index
 // CHECK: %[[EXPAND:.+]] = tensor.expand_shape %arg0 {{\[}}[0], [1, 2]] output_shape [%{{.+}}, 1024, 128] : tensor<?x131072xbf16> into tensor<?x1024x128xbf16>
 // CHECK: %[[INITVAL:.+]] = tensor.empty(%{{.+}}) : tensor<?x1024xbf16>
 // CHECK: %[[FILLVAL:.+]] = linalg.fill ins(%{{.+}} : bf16) outs(%[[INITVAL]] : tensor<?x1024xbf16>) -> tensor<?x1024xbf16>
 // CHECK: %[[INITIDX:.+]] = tensor.empty(%{{.+}}) : tensor<?x1024xi64>
 // CHECK: %[[FILLIDX:.+]] = linalg.fill ins(%{{.+}} : i64) outs(%[[INITIDX]] : tensor<?x1024xi64>) -> tensor<?x1024xi64>
-
 // CHECK: %[[PARTIAL:.+]]:2 = linalg.generic
 // CHECK-SAME: indexing_maps = [#[[$MAP0]], #[[$MAP1]], #[[$MAP1]]]
 // CHECK-SAME: iterator_types = ["parallel", "parallel", "reduction"]
-// CHECK-SAME: ins(%[[EXPAND]] : tensor<?x1024x128xbf16>)
-// CHECK-SAME: outs(%[[FILLVAL]], %[[FILLIDX]] : tensor<?x1024xbf16>, tensor<?x1024xi64>)
-// CHECK: ^bb0(%[[VAL:.+]]: bf16, %[[ACC:.+]]: bf16, %[[IDX:.+]]: i64)
-// CHECK: %[[OUTER:.+]] = linalg.index 1 : index
-// CHECK: %[[INNER:.+]] = linalg.index 2 : index
-// CHECK: %[[OFFSET:.+]] = arith.muli %[[OUTER]], %{{.+}} : index
-// CHECK: %[[GIDX:.+]] = arith.addi %[[OFFSET]], %[[INNER]] : index
-// CHECK: %[[CAST:.+]] = arith.index_cast %[[GIDX]] : index to i64
-// CHECK: %[[MAX:.+]] = arith.maximumf %[[VAL]], %[[ACC]] : bf16
-// CHECK: %[[CMP:.+]] = arith.cmpf ogt, %[[VAL]], %[[ACC]] : bf16
-// CHECK: %[[SEL:.+]] = arith.select %[[CMP]], %[[CAST]], %[[IDX]] : i64
-// CHECK: linalg.yield %[[MAX]], %[[SEL]] : bf16, i64
+// CHECK: ^bb0(%[[IN:.+]]: bf16, %[[ACC:.+]]: bf16, %[[IDX:.+]]: i64)
+// CHECK: %[[REDIDX:.+]] = linalg.index 2 : index
+// CHECK: %[[CASTIDX:.+]] = arith.index_cast %[[REDIDX]] : index to i64
+// CHECK: %[[MAXVAL:.+]] = arith.maximumf %[[IN]], %[[ACC]] : bf16
+// CHECK: %[[CMP:.+]] = arith.cmpf ogt, %[[IN]], %[[ACC]] : bf16
+// CHECK: %[[SELIDX:.+]] = arith.select %[[CMP]], %[[CASTIDX]], %[[IDX]] : i64
+// CHECK: linalg.yield %[[MAXVAL]], %[[SELIDX]] : bf16, i64
 
-// Check Final reduction.
+// Step 2: Compute global index = outer * tile_size + local
+// CHECK: %[[C128:.+]] = arith.constant 128 : index
+// CHECK: %[[LOCALIDX:.+]] = tensor.empty(%{{.+}}) : tensor<?x1024xi64>
+// CHECK: %[[FILLGIDX:.+]] = linalg.fill ins(%{{.+}} : i64) outs(%[[LOCALIDX]] : tensor<?x1024xi64>) -> tensor<?x1024xi64>
+// CHECK: %[[GLOBALIDX:.+]] = linalg.generic
+// CHECK-SAME: indexing_maps = [#[[$MAP2]], #[[$MAP2]]]
+// CHECK-SAME: iterator_types = ["parallel", "parallel"]
+// CHECK: ^bb0(%[[INIDX:.+]]: i64, %[[GIDX_OUT:.+]]: i64)
+// CHECK: %[[OUTER:.+]] = linalg.index 1 : index
+// CHECK: %[[OFFSET:.+]] = arith.muli %[[OUTER]], %[[C128]] : index
+// CHECK: %[[OFFSET_CAST:.+]] = arith.index_cast %[[OFFSET]] : index to i64
+// CHECK: %[[GLOBALIDXVAL:.+]] = arith.addi %[[OFFSET_CAST]], %[[INIDX]] : i64
+// CHECK: linalg.yield %[[GLOBALIDXVAL]] : i64
+
+// Step 3: Final reduction over the parallel dim
 // CHECK: %[[FINAL:.+]]:2 = linalg.generic
 // CHECK-SAME: indexing_maps = [#[[$MAP2]], #[[$MAP2]], #[[$MAP3]], #[[$MAP3]]]
 // CHECK-SAME: iterator_types = ["parallel", "reduction"]
-// CHECK-SAME: ins(%[[PARTIAL]]#0, %[[PARTIAL]]#1 : tensor<?x1024xbf16>, tensor<?x1024xi64>)
-// CHECK-SAME: outs(%[[FINALVAL]], %[[FINALIDX]] : tensor<?xbf16>, tensor<?xi64>)
 // CHECK: ^bb0(%[[V1:.+]]: bf16, %[[I1:.+]]: i64, %[[V2:.+]]: bf16, %[[I2:.+]]: i64)
 // CHECK: %[[MAX2:.+]] = arith.maximumf %[[V1]], %[[V2]] : bf16
 // CHECK: %[[CMP2:.+]] = arith.cmpf ogt, %[[V1]], %[[V2]] : bf16
 // CHECK: %[[SEL2:.+]] = arith.select %[[CMP2]], %[[I1]], %[[I2]] : i64
 // CHECK: linalg.yield %[[MAX2]], %[[SEL2]] : bf16, i64
 
-// Check final return.
 // CHECK: util.return %[[FINAL]]#1 : tensor<?xi64>
 
 // -----

--- a/tests/e2e/linalg/BUILD.bazel
+++ b/tests/e2e/linalg/BUILD.bazel
@@ -226,6 +226,7 @@ iree_check_single_backend_test_suite(
 ROCM_SRCS = enforce_glob(
     # keep sorted
     [
+        "argmax.mlir",
         "pack_i8.mlir",
         "unpack.mlir",
     ],
@@ -241,7 +242,6 @@ ROCM_SRCS = enforce_glob(
         # See bug #20294
         "pack.mlir",
         "pack_dynamic_inner_tiles.mlir",
-        "argmax.mlir",
     ],
 )
 

--- a/tests/e2e/linalg/BUILD.bazel
+++ b/tests/e2e/linalg/BUILD.bazel
@@ -36,6 +36,7 @@ LLVM_SRCS = enforce_glob(
         "pack.mlir",
         "large_linalg_matmul.mlir",
         "index.mlir",
+        "argmax.mlir",
     ],
 )
 
@@ -67,6 +68,7 @@ NO_RISCV_SRCS = enforce_glob(
         "pack_i8.mlir",
         "subbyte_to_fp.mlir",
         "unpack.mlir",
+        "argmax.mlir",
     ],
 )
 
@@ -99,6 +101,7 @@ VMVX_SRCS = enforce_glob(
         "large_linalg_matmul.mlir",
         "subbyte_to_fp.mlir",
         "index.mlir",
+        "argmax.mlir",
     ],
 )
 
@@ -146,6 +149,7 @@ VULKAN_SRCS = enforce_glob(
         "pack_dynamic_inner_tiles.mlir",
         "pack_i8.mlir",
         "unpack.mlir",
+        "argmax.mlir",
     ],
 )
 
@@ -200,6 +204,7 @@ CUDA_SRCS = enforce_glob(
         # See bug #20294
         "pack.mlir",
         "pack_dynamic_inner_tiles.mlir",
+        "argmax.mlir",
     ],
 )
 
@@ -236,6 +241,7 @@ ROCM_SRCS = enforce_glob(
         # See bug #20294
         "pack.mlir",
         "pack_dynamic_inner_tiles.mlir",
+        "argmax.mlir",
     ],
 )
 
@@ -262,9 +268,22 @@ iree_check_single_backend_test_suite(
     target_backend = "llvm-cpu",
 )
 
+ARGMAX_SRCS = [
+    "argmax.mlir",
+]
+
+iree_check_single_backend_test_suite(
+    name = "check_argmax_llvm-cpu_local-task",
+    srcs = ARGMAX_SRCS,
+    compiler_flags = ["--iree-llvmcpu-target-cpu=generic"],
+    driver = "local-task",
+    target_backend = "llvm-cpu",
+)
+
 test_suite(
     name = "check",
     tests = [
+        ":check_argmax_llvm-cpu_local-task",
         ":check_index_llvm-cpu_local-task",
         ":check_large_linalg_matmul_cuda",
         ":check_llvm-cpu_local-task",

--- a/tests/e2e/linalg/CMakeLists.txt
+++ b/tests/e2e/linalg/CMakeLists.txt
@@ -169,4 +169,17 @@ iree_check_single_backend_test_suite(
     "noriscv"
 )
 
+iree_check_single_backend_test_suite(
+  NAME
+    check_argmax_llvm-cpu_local-task
+  SRCS
+    "argmax.mlir"
+  TARGET_BACKEND
+    "llvm-cpu"
+  DRIVER
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-llvmcpu-target-cpu=generic"
+)
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/tests/e2e/linalg/CMakeLists.txt
+++ b/tests/e2e/linalg/CMakeLists.txt
@@ -146,6 +146,7 @@ iree_check_single_backend_test_suite(
   NAME
     check_rocm_hip
   SRCS
+    "argmax.mlir"
     "pack_i8.mlir"
     "unpack.mlir"
   TARGET_BACKEND

--- a/tests/e2e/linalg/argmax.mlir
+++ b/tests/e2e/linalg/argmax.mlir
@@ -1,0 +1,44 @@
+func.func @argmax_1d() {
+  // Step 1: Fill the tensor with default value 7.0
+  %seven = arith.constant 7.0 : f32
+  %input_init = tensor.empty() : tensor<131072xf32>
+  %input_filled = linalg.fill ins(%seven : f32) outs(%input_init : tensor<131072xf32>) -> tensor<131072xf32>
+
+  // Step 2: Insert a larger value at index 131071
+  %large = arith.constant 53.0 : f32
+  %index = arith.constant 131071 : index
+  %input = tensor.insert %large into %input_filled[%index] : tensor<131072xf32>
+
+  // Step 3: Identity values
+  %neg_inf = arith.constant 0xFF800000 : f32  // -inf
+  %c0_i32 = arith.constant 0 : i32
+  %init_val_buf = tensor.empty() : tensor<f32>
+  %init_idx_buf = tensor.empty() : tensor<i32>
+  %init_val = linalg.fill ins(%neg_inf : f32) outs(%init_val_buf : tensor<f32>) -> tensor<f32>
+  %init_idx = linalg.fill ins(%c0_i32 : i32) outs(%init_idx_buf : tensor<i32>) -> tensor<i32>
+
+  // Step 4: Argmax
+  %result:2 = linalg.generic {
+      indexing_maps = [
+        affine_map<(d0) -> (d0)>,
+        affine_map<(d0) -> ()>,
+        affine_map<(d0) -> ()>
+      ],
+      iterator_types = ["reduction"]
+    } ins(%input : tensor<131072xf32>)
+      outs(%init_val, %init_idx : tensor<f32>, tensor<i32>) {
+    ^bb0(%in: f32, %val: f32, %idx: i32):
+      %i = linalg.index 0 : index
+      %i_cast = arith.index_cast %i : index to i32
+      %maxval = arith.maximumf %in, %val : f32
+      %cmp = arith.cmpf ogt, %in, %val : f32
+      %sel_idx = arith.select %cmp, %i_cast, %idx : i32
+      linalg.yield %maxval, %sel_idx : f32, i32
+  } -> (tensor<f32>, tensor<i32>)
+
+  // Step 5: Verify
+  check.expect_almost_eq_const(%result#0, dense<53.0> : tensor<f32>) : tensor<f32>
+  check.expect_eq_const(%result#1, dense<131071> : tensor<i32>) : tensor<i32>
+
+  return
+}

--- a/tests/e2e/linalg/argmax.mlir
+++ b/tests/e2e/linalg/argmax.mlir
@@ -1,15 +1,12 @@
 func.func @argmax_1d() {
-  // Step 1: Fill the tensor with default value 7.0
   %seven = arith.constant 7.0 : f32
   %input_init = tensor.empty() : tensor<131072xf32>
   %input_filled = linalg.fill ins(%seven : f32) outs(%input_init : tensor<131072xf32>) -> tensor<131072xf32>
 
-  // Step 2: Insert a larger value at index 131071
   %large = arith.constant 53.0 : f32
   %index = arith.constant 131071 : index
   %input = tensor.insert %large into %input_filled[%index] : tensor<131072xf32>
 
-  // Step 3: Identity values
   %neg_inf = arith.constant 0xFF800000 : f32  // -inf
   %c0_i32 = arith.constant 0 : i32
   %init_val_buf = tensor.empty() : tensor<f32>
@@ -17,7 +14,6 @@ func.func @argmax_1d() {
   %init_val = linalg.fill ins(%neg_inf : f32) outs(%init_val_buf : tensor<f32>) -> tensor<f32>
   %init_idx = linalg.fill ins(%c0_i32 : i32) outs(%init_idx_buf : tensor<i32>) -> tensor<i32>
 
-  // Step 4: Argmax
   %result:2 = linalg.generic {
       indexing_maps = [
         affine_map<(d0) -> (d0)>,
@@ -36,7 +32,6 @@ func.func @argmax_1d() {
       linalg.yield %maxval, %sel_idx : f32, i32
   } -> (tensor<f32>, tensor<i32>)
 
-  // Step 5: Verify
   check.expect_almost_eq_const(%result#0, dense<53.0> : tensor<f32>) : tensor<f32>
   check.expect_eq_const(%result#1, dense<131071> : tensor<i32>) : tensor<i32>
 


### PR DESCRIPTION
The current split-k transformation for argmax generates two linalg.generic operations:
```
%8:2 = linalg.generic {indexing_maps = [#map, #map1, #map1], iterator_types = ["parallel", "parallel", "reduction"]} ins(%expanded : tensor<?x1024x128xbf16>) outs(%5, %7 : tensor<?x1024xbf16>, tensor<?x1024xi64>) {
    ^bb0(%in: bf16, %out: bf16, %out_6: i64):
      %10 = linalg.index 1 : index
      %11 = linalg.index 2 : index
      %12 = arith.muli %10, %c128 : index
      %13 = arith.addi %12, %11 : index
      %14 = arith.index_cast %13 : index to i64
      %15 = linalg.index 1 : index
      %16 = arith.index_cast %15 : index to i64
      %17 = arith.maximumf %in, %out : bf16
      %18 = arith.cmpf ogt, %in, %out : bf16
      %19 = arith.select %18, %14, %out_6 : i64
      linalg.yield %17, %19 : bf16, i64
    } -> (tensor<?x1024xbf16>, tensor<?x1024xi64>)
%9:2 = linalg.generic {indexing_maps = [#map2, #map2, #map3, #map3], iterator_types = ["parallel", "reduction"]} ins(%8#0, %8#1 : tensor<?x1024xbf16>, tensor<?x1024xi64>) outs(%1, %3 : tensor<?xbf16>, tensor<?xi64>) {
    ^bb0(%in: bf16, %in_6: i64, %out: bf16, %out_7: i64):
      %10 = arith.maximumf %in, %out : bf16
      %11 = arith.cmpf ogt, %in, %out : bf16
      %12 = arith.select %11, %in_6, %out_7 : i64
      linalg.yield %10, %12 : bf16, i64
    } -> (tensor<?xbf16>, tensor<?xi64>)
util.return %9#1 : tensor<?xi64>
```
However, the first linalg.generic op is not a strict argmax—it performs a reduction on the value and selects a global index. Despite this, the IREE compiler would treat it as an argmax and lower it into a ukernel, ignoring the global index computation. This leads to **incorrect results** when using split-k and ukernel together.

# What this PR does
- Tightens the `isArgmaxOp` function: It now returns false for generic ops like the first one above, which are not structurally strict argmax patterns. One corresponding test is added to `Codegen/Common/GPU/test/gpu_lower_to_ukernels.mlir`.
- Update the split-k transformation to emit two 'linalg.generic' ops:
    1. **Strict argmax** that computes the max value and local index.
    2.  **Final argmax-style reduction**,  which also computes the global index in-place using the formula `gidx = outer × tile + inner` and selects it based on the max value.

Then the resulting IR looks like this
```
    %8:2 = linalg.generic {indexing_maps = [#map, #map1, #map1], iterator_types = ["parallel", "parallel", "reduction"]} ins(%expanded : tensor<?x1024x128xbf16>) outs(%5, %7 : tensor<?x1024xbf16>, tensor<?x1024xi64>) {
    ^bb0(%in: bf16, %out: bf16, %out_6: i64):
      %10 = linalg.index 2 : index
      %11 = arith.index_cast %10 : index to i64
      %12 = arith.maximumf %in, %out : bf16
      %13 = arith.cmpf ogt, %in, %out : bf16
      %14 = arith.select %13, %11, %out_6 : i64
      linalg.yield %12, %14 : bf16, i64
    } -> (tensor<?x1024xbf16>, tensor<?x1024xi64>)
    %c128 = arith.constant 128 : index
    %9:2 = linalg.generic {indexing_maps = [#map2, #map2, #map3, #map3], iterator_types = ["parallel", "reduction"]} ins(%8#0, %8#1 : tensor<?x1024xbf16>, tensor<?x1024xi64>) outs(%1, %3 : tensor<?xbf16>, tensor<?xi64>) {
    ^bb0(%in: bf16, %in_6: i64, %out: bf16, %out_7: i64):
      %10 = linalg.index 1 : index
      %11 = arith.muli %10, %c128 : index
      %12 = arith.index_cast %11 : index to i64
      %13 = arith.addi %12, %in_6 : i64
      %14 = arith.maximumf %in, %out : bf16
      %15 = arith.cmpf ogt, %in, %out : bf16
      %16 = arith.select %15, %13, %out_7 : i64
      linalg.yield %14, %16 : bf16, i64
    } -> (tensor<?xbf16>, tensor<?xi64>)
    util.return %9#1 : tensor<?xi64>
  }
```