### PR TITLE
Speeding up two hotspots in large programs.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/ResourceUsage.cpp
@@ -269,10 +269,8 @@ private:
         })
         .Case([&](IREE::Util::GlobalLoadOpInterface op) {
           removeAssumedBits(NOT_GLOBAL_READ);
-          auto *globalInfo =
-              solver.getExplorer().queryGlobalInfoFrom(op.getGlobalName(), op);
-          auto globalType = llvm::cast<IREE::Stream::ResourceType>(
-              globalInfo->op.getGlobalType());
+          auto globalType = cast<IREE::Stream::ResourceType>(
+              op.getLoadedGlobalValue().getType());
           switch (globalType.getLifetime()) {
           case IREE::Stream::Lifetime::Constant:
             removeAssumedBits(NOT_CONSTANT);
@@ -640,10 +638,8 @@ private:
         })
         .Case([&](IREE::Util::GlobalStoreOpInterface op) {
           removeAssumedBits(NOT_GLOBAL_WRITE);
-          auto *globalInfo =
-              solver.getExplorer().queryGlobalInfoFrom(op.getGlobalName(), op);
-          auto globalType = llvm::cast<IREE::Stream::ResourceType>(
-              globalInfo->op.getGlobalType());
+          auto globalType = cast<IREE::Stream::ResourceType>(
+              op.getStoredGlobalValue().getType());
           switch (globalType.getLifetime()) {
           case IREE::Stream::Lifetime::Constant:
             removeAssumedBits(NOT_CONSTANT);

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/global_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/global_folding.mlir
@@ -1,16 +1,5 @@
 // RUN: iree-opt --split-input-file --canonicalize %s | FileCheck %s
 
-// CHECK: util.global private @v_initialized = dense<4> : tensor<4xi32>
-util.global private @v_initialized : tensor<4xi32>
-// CHECK-NOT: util.initializer
-util.initializer {
-  %0 = arith.constant dense<4> : tensor<4xi32>
-  util.global.store %0, @v_initialized : tensor<4xi32>
-  util.return
-}
-
-// -----
-
 util.global private @v_unused : tensor<4xi32>
 // CHECK-LABEL: @unused_load
 util.func public @unused_load() {

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/FoldGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/FoldGlobals.cpp
@@ -354,8 +354,7 @@ static bool deduplicateConstantGlobals(GlobalTable &globalTable) {
   return true; // did change
 }
 
-class FoldGlobalsPass : public impl::FoldGlobalsPassBase<FoldGlobalsPass> {
-public:
+struct FoldGlobalsPass : public impl::FoldGlobalsPassBase<FoldGlobalsPass> {
   void runOnOperation() override {
     auto *context = &getContext();
     RewritePatternSet patterns(context);


### PR DESCRIPTION
InlineConstantGlobalInitializer was not using a symbol table and is redundant with what FoldGlobalsPass does anyway. The global info queried in resource usage analysis was just used to get the type - instead, the type can be accessed locally on the load/store op.