### PR TITLE
[PJRT] Support PJRT_Memory related APIs in IREE PJRT plugin

### DIFF
--- a/.github/workflows/pkgci_test_pjrt.yml
+++ b/.github/workflows/pkgci_test_pjrt.yml
@@ -76,7 +76,7 @@ jobs:
           export CMAKE_CXX_COMPILER_LAUNCHER=ccache
           python -m pip install -v --no-deps -e integrations/pjrt/python_packages/iree_${{ matrix.pjrt_platform }}_plugin
           # install
-          python -m pip install jax==0.4.36
+          python -m pip install jax==0.6.1
       - name: Run tests
         run: |
           source ${VENV_DIR}/bin/activate

--- a/integrations/pjrt/README.md
+++ b/integrations/pjrt/README.md
@@ -16,8 +16,7 @@ most powerful).
 ```shell
 pip install -r requirements.txt
 
-# a higher version of jax is highly recommended, e.g. 0.4.36
-pip install jax==0.4.36
+pip install jax==0.6.1
 ```
 
 Verify that your Jax install is functional like:


### PR DESCRIPTION
It closes #20907.
It closes #20093.

Newly supported APIs:
- PJRT_Client_AddressableMemories 
- PJRT_Device_AddressableMemories 
- PJRT_Device_DefaultMemory
- PJRT_Buffer_Memory
- PJRT_Memory_Id
- PJRT_Memory_Kind
- PJRT_Memory_ToString
- PJRT_Memory_DebugString
- PJRT_Memory_AddressableByDevices

Currently the memory is one-to-one mapped from its device, just for JAX to successfully initialize the PJRT plugin.

After this patch, the PJRT plugin can support JAX from 0.5.1 up to the latest version (0.6.1) (see #20907 for the current status).

ci-exactly: build_packages, test_pjrt