### PR TITLE
Ignoring single-user ops in CloneToConsumers.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/Affinity.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/Affinity.cpp
@@ -742,6 +742,13 @@ ChangeStatus OpAffinityPVS::updateOperation(Operation *op,
       if (isa<IREE::Stream::AffinityTypeInterface>(operand.getType())) {
         auto valuePVS = solver.getElementFor<ValueProducerAffinityPVS>(
             *this, Position::forValue(operand), DFX::Resolution::REQUIRED);
+        LLVM_DEBUG({
+          llvm::dbgs() << "[OpAffinityPVS] op ";
+          op->getName().print(llvm::dbgs());
+          llvm::dbgs() << " consumes ";
+          valuePVS.print(llvm::dbgs(), solver.getAsmState());
+          llvm::dbgs() << "\n";
+        });
         newState ^= valuePVS;
       }
     }
@@ -750,6 +757,13 @@ ChangeStatus OpAffinityPVS::updateOperation(Operation *op,
       if (isa<IREE::Stream::AffinityTypeInterface>(result.getType())) {
         auto valuePVS = solver.getElementFor<ValueConsumerAffinityPVS>(
             *this, Position::forValue(result), DFX::Resolution::REQUIRED);
+        LLVM_DEBUG({
+          llvm::dbgs() << "[OpAffinityPVS] op ";
+          op->getName().print(llvm::dbgs());
+          llvm::dbgs() << " produces ";
+          valuePVS.print(llvm::dbgs(), solver.getAsmState());
+          llvm::dbgs() << "\n";
+        });
         newState ^= valuePVS;
       }
     }


### PR DESCRIPTION
Previously the pass would always clone an op if analysis resulted in multiple producer affinities. This leads to bad behavior where the pass will keep trying to clone ops in order to fix the situation but do nothing meaningful before the next try (and eventually hit the limit).

This should help situations where CloneToConsumersPass was hitting its iteration limit. It does not fix affinity analysis iteration limits - those are caused by ambiguous IR and will still fail to converge with these changes.