### PR TITLE
Adding affinity solver max iterations flag and upping default.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Analysis/Affinity.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Analysis/Affinity.cpp
@@ -15,6 +15,7 @@
 #include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -26,6 +27,12 @@
 #define DEBUG_TYPE "iree-util-dfx"
 
 namespace mlir::iree_compiler::IREE::Stream {
+
+static llvm::cl::opt<int> clSolverMaxIterations(
+    "iree-stream-affinity-solver-max-iterations",
+    llvm::cl::desc("Maximum affinity analysis solver iteration count before it "
+                   "gives up. Roughly equivalent to operation chain depth."),
+    llvm::cl::init(128));
 
 //===----------------------------------------------------------------------===//
 // Utilities
@@ -1114,7 +1121,7 @@ LogicalResult AffinityAnalysis::run() {
     });
   });
 
-  if (failed(solver.run())) {
+  if (failed(solver.run(clSolverMaxIterations))) {
     return failure(); // did not converge
   }
 

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/DFX/Solver.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/DFX/Solver.cpp
@@ -22,7 +22,7 @@ Solver::~Solver() {
   }
 }
 
-LogicalResult Solver::run() {
+LogicalResult Solver::run(int maxIterations) {
   LLVM_DEBUG(llvm::dbgs() << "[Solver] identified and initialized "
                           << depGraph.syntheticRoot.deps.size()
                           << " abstract elements\n");
@@ -30,7 +30,7 @@ LogicalResult Solver::run() {
   // Now that all abstract elements are collected and initialized we start
   // the abstract analysis.
   phase = Phase::UPDATE;
-  auto result = runTillFixpoint();
+  auto result = runTillFixpoint(maxIterations);
   phase = Phase::DONE;
 
   if (failed(result)) {
@@ -40,9 +40,8 @@ LogicalResult Solver::run() {
   return result;
 }
 
-LogicalResult Solver::runTillFixpoint() {
-  unsigned iterationCounter = 1;
-  unsigned maxIterations = maxFixpointIterations.value_or(32);
+LogicalResult Solver::runTillFixpoint(int maxIterations) {
+  int iterationCounter = 1;
 
   SmallVector<AbstractElement *, 32> changedElements;
   SetVector<AbstractElement *> worklist, invalidElements;

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/DFX/Solver.h
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/DFX/Solver.h
@@ -234,7 +234,7 @@ public:
 
   // Runs the solver until either it converges to a fixed point or exceeds the
   // maximum iteration count. Returns success() if it converges in time.
-  LogicalResult run();
+  LogicalResult run(int maxIterations = 32);
 
   // Prints the constraint dependency graph to |os|.
   void print(llvm::raw_ostream &os);
@@ -254,7 +254,7 @@ protected:
   // If the maximum iteration count is reached this method will
   // indicate pessimistic fixpoint on elements that transitively depend on
   // elements that were still scheduled for an update.
-  LogicalResult runTillFixpoint();
+  LogicalResult runTillFixpoint(int maxIterations);
 
   // Runs update on |element| and tracks the dependencies queried while doing
   // so. Also adjusts the state if we know further updates are not necessary.
@@ -263,9 +263,6 @@ protected:
   // Remembers the dependencies on the top of the dependence stack such that
   // they may trigger further updates.
   void rememberDependencies();
-
-  // Maximum number of fixed point iterations or None for default.
-  std::optional<unsigned> maxFixpointIterations;
 
   // A flag that indicates which stage of the process we are in.
   enum class Phase {


### PR DESCRIPTION
`--iree-stream-affinity-solver-max-iterations=N` will allow an easy way to isolate analysis failures to the solver iteration count. Now that CloneToConsumersPass isn't running the solver itself in a loop (much) it's less scary to up the default, though it's still risky in the failure cases as it could lead to _very_ long times to failure.

The proper solution is to reduce the iteration count by somehow dealing with very long tied op chains that pass through multiple affinities.