### PR TITLE
Integrate llvm-project@d45031ce5281

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -968,7 +968,8 @@ DiagnosedSilenceableFailure transform_dialect::IREEBufferizeOp::apply(
       return addressSpaceAttr;
     };
   }
-  if (failed(runIREEOneShotBufferize(target, options))) {
+  bufferization::BufferizationState bufferizationState;
+  if (failed(runIREEOneShotBufferize(target, options, bufferizationState))) {
     return mlir::emitDefiniteFailure(target, "bufferization failed");
   }
 

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.h
@@ -45,7 +45,8 @@ LogicalResult eliminateEmptyTensors(
 /// Bufferizes the given op with One-Shot Bufferize.
 LogicalResult
 runIREEOneShotBufferize(Operation *op,
-                        const IREEOneShotBufferizationOptions &options);
+                        const IREEOneShotBufferizationOptions &options,
+                        bufferization::BufferizationState &state);
 
 /// For a given operation within a dispatch, tile and distribute the operation
 /// to workgroups as well as tile + fuse its producers. Returns the

--- a/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/UKernelOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/Codegen/IR/UKernelOps.cpp
@@ -235,9 +235,9 @@ template <typename OpTy>
 struct UKernelOpsBufferizationInterface
     : public bufferization::DstBufferizableOpInterfaceExternalModel<
           UKernelOpsBufferizationInterface<OpTy>, OpTy> {
-  LogicalResult
-  bufferize(Operation *op, RewriterBase &rewriter,
-            const bufferization::BufferizationOptions &options) const {
+  LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
+                          const bufferization::BufferizationOptions &options,
+                          bufferization::BufferizationState &state) const {
     // TODO: Handle operations with regions if needed.
     if (op->getNumRegions() != 0) {
       op->emitOpError(

--- a/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/GPU/Transforms/BufferizationInterfaces.cpp
@@ -123,7 +123,8 @@ struct BarrierRegionOpBufferizationInterface
   }
 
   LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
-                          const BufferizationOptions &options) const {
+                          const BufferizationOptions &options,
+                          bufferization::BufferizationState &state) const {
     auto barrierOp = cast<IREE::GPU::BarrierRegionOp>(op);
     auto terminator =
         cast<IREE::GPU::YieldOp>(barrierOp.getBody()->getTerminator());
@@ -205,7 +206,8 @@ struct ValueBarrierOpBufferizationInterface
   }
 
   LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
-                          const BufferizationOptions &options) const {
+                          const BufferizationOptions &options,
+                          bufferization::BufferizationState &state) const {
     auto barrierOp = cast<IREE::GPU::ValueBarrierOp>(op);
     if (!barrierOp.hasTensorSemantics()) {
       return failure();
@@ -261,7 +263,8 @@ struct YieldOpBufferizationInterface
   }
 
   LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
-                          const BufferizationOptions &options) const {
+                          const BufferizationOptions &options,
+                          bufferization::BufferizationState &state) const {
     auto yieldOp = cast<IREE::GPU::YieldOp>(op);
 
     SmallVector<Value> newResults;
@@ -348,7 +351,8 @@ struct BufferResourceCastOpBufferizationInterface
   }
 
   LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
-                          const BufferizationOptions &options) const {
+                          const BufferizationOptions &options,
+                          bufferization::BufferizationState &state) const {
     auto castOp = cast<IREE::GPU::BufferResourceCastOp>(op);
 
     FailureOr<Value> buffer = getBuffer(rewriter, castOp.getInput(), options);

--- a/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
@@ -66,7 +66,8 @@ struct DispatchTensorLoadOpInterface
   }
 
   LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
-                          const BufferizationOptions &options) const {
+                          const BufferizationOptions &options,
+                          bufferization::BufferizationState &state) const {
     auto loadOp = cast<IREE::TensorExt::DispatchTensorLoadOp>(op);
     auto tensorSubspanOp =
         loadOp.getSource()
@@ -118,7 +119,8 @@ struct DispatchTensorStoreOpInterface
   }
 
   LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
-                          const BufferizationOptions &options) const {
+                          const BufferizationOptions &options,
+                          bufferization::BufferizationState &state) const {
     auto storeOp = cast<IREE::TensorExt::DispatchTensorStoreOp>(op);
     auto tensorSubspanOp =
         storeOp.getTarget()
@@ -200,7 +202,8 @@ struct LoadFromBufferOpInterface
   }
 
   LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
-                          const BufferizationOptions &options) const {
+                          const BufferizationOptions &options,
+                          bufferization::BufferizationState &state) const {
     auto loadOp = cast<IREE::Codegen::LoadFromBufferOp>(op);
     replaceOpWithBufferizedValues(rewriter, op, loadOp.getBuffer());
     return success();
@@ -227,7 +230,8 @@ struct StoreToBufferOpInterface
   }
 
   LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
-                          const BufferizationOptions &options) const {
+                          const BufferizationOptions &options,
+                          bufferization::BufferizationState &state) const {
     auto storeOp = cast<IREE::Codegen::StoreToBufferOp>(op);
     FailureOr<Value> maybeBuffer =
         getBuffer(rewriter, storeOp.getTensor(), options);
@@ -332,7 +336,8 @@ struct LinalgExtOpInterface
   }
 
   LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
-                          const BufferizationOptions &options) const {
+                          const BufferizationOptions &options,
+                          bufferization::BufferizationState &state) const {
     return bufferizeLinalgExtOp(
         rewriter, cast<IREE::LinalgExt::LinalgExtOp>(op), options);
   }
@@ -467,7 +472,8 @@ struct PackUnPackOpInterface
   }
 
   LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
-                          const BufferizationOptions &options) const {
+                          const BufferizationOptions &options,
+                          bufferization::BufferizationState &state) const {
     return TypeSwitch<Operation *, LogicalResult>(op)
         .template Case<linalg::PackOp>(
             [&](auto pack) { return bufferizePackOp(rewriter, pack, options); })

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/VectorContractCustomKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/VectorContractCustomKernels.cpp
@@ -872,7 +872,8 @@ private:
     generateAsmCodeAndConstraints(code, constraints);
     LLVM::InlineAsmOp asmOp = rewriter.create<LLVM::InlineAsmOp>(
         loc, returnType, inputs, code, constraints,
-        /*has_side_effects=*/false, /*is_align_stack=*/false, dialectAttr,
+        /*has_side_effects=*/false, /*is_align_stack=*/false,
+        LLVM::TailCallKind::None, dialectAttr,
         /*operand_attrs=*/ArrayAttr());
     // Extract result vectors from the asm op.
     SmallVector<Value> resVec;

--- a/tests/e2e/linalg/BUILD.bazel
+++ b/tests/e2e/linalg/BUILD.bazel
@@ -24,7 +24,6 @@ LLVM_SRCS = enforce_glob(
         "conv2d.mlir",
         "fp_to_subbyte.mlir",
         "narrow_n_matmuls.mlir",
-        "pack.mlir",
         "pack_dynamic_inner_tiles.mlir",
         "pack_i8.mlir",
         "subbyte_to_fp.mlir",
@@ -32,6 +31,9 @@ LLVM_SRCS = enforce_glob(
     ],
     include = ["*.mlir"],
     exclude = [
+        # TODO(#20929): Enable the pack.mlir test after the numerical issue is
+        # fixed.
+        "pack.mlir",
         "large_linalg_matmul.mlir",
         "index.mlir",
     ],
@@ -45,6 +47,38 @@ iree_check_single_backend_test_suite(
     tags = [
         # subbyte support for wasm is not on priorities.
         "nowasm",
+    ],
+    target_backend = "llvm-cpu",
+)
+
+NO_RISCV_SRCS = enforce_glob(
+    # keep sorted
+    [
+        "pack.mlir",
+    ],
+    include = ["*.mlir"],
+    exclude = [
+        "conv2d.mlir",
+        "fp_to_subbyte.mlir",
+        "index.mlir",
+        "large_linalg_matmul.mlir",
+        "narrow_n_matmuls.mlir",
+        "pack_dynamic_inner_tiles.mlir",
+        "pack_i8.mlir",
+        "subbyte_to_fp.mlir",
+        "unpack.mlir",
+    ],
+)
+
+iree_check_single_backend_test_suite(
+    name = "check_llvm-cpu_local-task_noriscv",
+    srcs = NO_RISCV_SRCS,
+    compiler_flags = ["--iree-llvmcpu-target-cpu=generic"],
+    driver = "local-task",
+    tags = [
+        # subbyte support for wasm is not on priorities.
+        "nowasm",
+        "noriscv",
     ],
     target_backend = "llvm-cpu",
 )

--- a/tests/e2e/linalg/CMakeLists.txt
+++ b/tests/e2e/linalg/CMakeLists.txt
@@ -17,7 +17,6 @@ iree_check_single_backend_test_suite(
     "conv2d.mlir"
     "fp_to_subbyte.mlir"
     "narrow_n_matmuls.mlir"
-    "pack.mlir"
     "pack_dynamic_inner_tiles.mlir"
     "pack_i8.mlir"
     "subbyte_to_fp.mlir"
@@ -30,6 +29,22 @@ iree_check_single_backend_test_suite(
     "--iree-llvmcpu-target-cpu=generic"
   LABELS
     "nowasm"
+)
+
+iree_check_single_backend_test_suite(
+  NAME
+    check_llvm-cpu_local-task_noriscv
+  SRCS
+    "pack.mlir"
+  TARGET_BACKEND
+    "llvm-cpu"
+  DRIVER
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-llvmcpu-target-cpu=generic"
+  LABELS
+    "nowasm"
+    "noriscv"
 )
 
 iree_check_single_backend_test_suite(


### PR DESCRIPTION
Dropped reverts, which are fixed by the head:
- https://github.com/iree-org/llvm-project/commit/0357fd9d0583393135ecb651b038acd39d7c9208
- https://github.com/iree-org/llvm-project/commit/20a9a98f1430384fcd602ce560a36f93c6cd1b2d

Carried revert:
- (old) https://github.com/iree-org/llvm-project/commit/13631cf47007968f6790c4cdf39b8c3784d819e9
- (new) https://github.com/iree-org/llvm-project/commit/5f144b5d8134c23f4028d5e7a334d40b6f260252
- (new) https://github.com/iree-org/llvm-project/commit/cddcc131aace5714f819b2189dd22bc0f10427d4
- (new) https://github.com/llvm/llvm-project/commit/989aadf4b112ef55648d801c4003b63f8aad930e

Additional cherry-picks, which can be dropped after we bump ahead of it:
- https://github.com/iree-org/llvm-project/commit/92b96897b0edd124934daddf96f3468d488924d6

The fixes in IREE are for
- https://github.com/llvm/llvm-project/commit/05494f3bad0322f2f0d2128857ba30479d97deb2
- https://github.com/llvm/llvm-project/commit/61d5fdf50c78810972f5984473600fd917ccaff5

The second and the third reverts because they break torch-mlir. I have a fix for IREE side and can fix torch-mlir together in our repo. I prefer fixing them later because we are already ~1 week behind the LLVM head.

The four revert is because of an assertion in convert-to-llvm lowering in ARM SME pipeline tests.

Fixes https://github.com/iree-org/iree/issues/20737